### PR TITLE
feat: add finite mixtures of exponential extreme rays

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Basic.lean
@@ -46,8 +46,9 @@ point `0`); on the open half-line it agrees with the ordinary iterated derivativ
   nonnegativity and monotonicity on `[0, ∞)`.
 * `TauCeti.IsCompletelyMonotone.neg_one_pow_mul_iteratedDeriv_nonneg`: on the open half-line,
   the sign condition also holds for ordinary iterated derivatives.
-* `TauCeti.IsCompletelyMonotone.add`, `TauCeti.IsCompletelyMonotone.smul`: closure under
-  sums and nonnegative scalar multiples.
+* `TauCeti.IsCompletelyMonotone.add`, `TauCeti.IsCompletelyMonotone.sum`,
+  `TauCeti.IsCompletelyMonotone.smul`: closure under addition, finite sums, and nonnegative
+  scalar multiples.
 * `TauCeti.IsCompletelyMonotoneOnIoi`: the open-half-line analogue, using ordinary iterated
   derivatives on `(0, ∞)`.
 * `TauCeti.isCompletelyMonotone_const`: a nonnegative constant is completely monotone.
@@ -248,6 +249,20 @@ lemma isCompletelyMonotone_const {c : ℝ} (hc : 0 ≤ c) :
   rcases n with _ | n
   · simpa [iteratedDerivWithin_const] using hc
   · simp [iteratedDerivWithin_const]
+
+/-- Completely monotone functions are closed under finite sums. -/
+theorem IsCompletelyMonotone.sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
+    (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
+    IsCompletelyMonotone (fun t => ∑ i ∈ s, f i t) := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+      simpa using isCompletelyMonotone_const (c := 0) le_rfl
+  | @insert i s hi ih =>
+      have hsum := (hf i (Finset.mem_insert_self i s)).add
+        (ih fun j hj => hf j (Finset.mem_insert_of_mem hj))
+      exact hsum.congr fun t _ => by
+        simp [hi, Pi.add_apply]
 
 /-- The prototype completely monotone function `t ↦ e^{-x t}` for `x ≥ 0`. Its `n`-th
 derivative is `(-x)ⁿ e^{-x t}`, so `(-1)ⁿ` times it is `xⁿ e^{-x t} ≥ 0`. -/

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
@@ -21,7 +21,6 @@ acceptance examples in the one-parameter-semigroups roadmap.
 
 ## Main declarations
 
-* `TauCeti.IsCompletelyMonotone.sum`: completely monotone functions are closed under finite sums.
 * `TauCeti.finiteExponentialMixture`: a finite positive mixture of exponential extreme rays.
 * `TauCeti.finiteExponentialMixtureMeasure`: the corresponding finite sum of weighted Dirac
   measures on `ℝ≥0`.
@@ -45,24 +44,6 @@ open scoped ENNReal NNReal
 
 namespace TauCeti
 
-namespace IsCompletelyMonotone
-
-/-- Completely monotone functions are closed under finite sums. -/
-theorem sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
-    (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
-    IsCompletelyMonotone (fun t => ∑ i ∈ s, f i t) := by
-  classical
-  induction s using Finset.induction_on with
-  | empty =>
-      simpa using isCompletelyMonotone_const (c := 0) le_rfl
-  | @insert i s hi ih =>
-      have hsum := (hf i (Finset.mem_insert_self i s)).add
-        (ih fun j hj => hf j (Finset.mem_insert_of_mem hj))
-      exact hsum.congr fun t _ => by
-        simp [hi, Pi.add_apply]
-
-end IsCompletelyMonotone
-
 /-- A finite positive mixture of the exponential extreme rays `t ↦ exp (-p * t)`.
 
 The weights and rates are indexed by a finset. Both take values in `ℝ≥0`, making their
@@ -71,26 +52,19 @@ noncomputable def finiteExponentialMixture {ι : Type*} (s : Finset ι)
     (w p : ι → ℝ≥0) (t : ℝ) : ℝ :=
   ∑ i ∈ s, (w i : ℝ) * Real.exp (-(p i : ℝ) * t)
 
-/-- Evaluation of a finite exponential mixture as its defining finite sum. -/
-theorem finiteExponentialMixture_apply {ι : Type*} (s : Finset ι)
-    (w p : ι → ℝ≥0) (t : ℝ) :
-    finiteExponentialMixture s w p t =
-      ∑ i ∈ s, (w i : ℝ) * Real.exp (-(p i : ℝ) * t) := by
-  rw [finiteExponentialMixture]
-
 /-- The empty exponential mixture is the zero function. -/
 @[simp]
 theorem finiteExponentialMixture_empty {ι : Type*} (w p : ι → ℝ≥0) :
     finiteExponentialMixture ∅ w p = 0 := by
   ext t
-  simp [finiteExponentialMixture_apply]
+  simp [finiteExponentialMixture]
 
 /-- A singleton exponential mixture is one weighted exponential extreme ray. -/
 @[simp]
 theorem finiteExponentialMixture_singleton {ι : Type*} (i : ι) (w p : ι → ℝ≥0) (t : ℝ) :
     finiteExponentialMixture {i} w p t =
       (w i : ℝ) * Real.exp (-(p i : ℝ) * t) := by
-  simp [finiteExponentialMixture_apply]
+  simp [finiteExponentialMixture]
 
 /-- Every finite positive mixture of exponential extreme rays is completely monotone. -/
 theorem isCompletelyMonotone_finiteExponentialMixture {ι : Type*} (s : Finset ι)
@@ -110,6 +84,17 @@ Repeated rates are intentionally allowed: measure addition combines their weight
 noncomputable def finiteExponentialMixtureMeasure {ι : Type*} (s : Finset ι)
     (w p : ι → ℝ≥0) : Measure ℝ≥0 :=
   ∑ i ∈ s, (w i : ℝ≥0∞) • Measure.dirac (p i)
+
+/-- The representing measure of a measurable set is the sum of the weights at rates in the set. -/
+@[simp]
+theorem finiteExponentialMixtureMeasure_apply {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) {A : Set ℝ≥0} (hA : MeasurableSet A) :
+    finiteExponentialMixtureMeasure s w p A =
+      ∑ i ∈ s, A.indicator (fun _ => (w i : ℝ≥0∞)) (p i) := by
+  simp only [finiteExponentialMixtureMeasure, Measure.finsetSum_apply, hA,
+    Measure.smul_apply, Measure.dirac_apply']
+  refine Finset.sum_congr rfl fun i _ => ?_
+  by_cases hi : p i ∈ A <;> simp [hi, smul_eq_mul]
 
 /-- The empty exponential mixture has the zero representing measure. -/
 @[simp]
@@ -131,7 +116,7 @@ theorem finiteExponentialMixture_eq_integral {ι : Type*} (s : Finset ι)
     finiteExponentialMixture s w p t =
       ∫ q : ℝ≥0, Real.exp (-t * (q : ℝ)) ∂finiteExponentialMixtureMeasure s w p := by
   rw [finiteExponentialMixtureMeasure, integral_finsetSum_measure]
-  · rw [finiteExponentialMixture_apply]
+  · rw [finiteExponentialMixture]
     refine Finset.sum_congr rfl fun i _ => ?_
     rw [integral_smul_measure, integral_dirac]
     simp [mul_comm]
@@ -149,6 +134,6 @@ theorem integral_exp_neg_mul_dirac_one (t : ℝ) :
 theorem finiteExponentialMixture_singleton_one (t : ℝ) :
     finiteExponentialMixture ({()} : Finset Unit) (fun _ => 1) (fun _ => 1) t =
       Real.exp (-t) := by
-  simp [finiteExponentialMixture_apply]
+  simp [finiteExponentialMixture]
 
 end TauCeti

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Basic
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
+
+/-!
+# Finite mixtures of completely monotone exponential functions
+
+The extreme rays of the cone of completely monotone functions are the exponential functions
+`t ↦ exp (-p * t)` with `p ≥ 0`. This file develops their finite positive mixtures. It packages
+a finite mixture both as an explicit sum and as the Laplace transform of the corresponding
+finite sum of weighted Dirac measures.
+
+This is the finite-support case of the measure representation in Bernstein's theorem. In
+particular, a single atom of unit weight at `p = 1` represents `t ↦ exp (-t)`, one of the
+acceptance examples in the one-parameter-semigroups roadmap.
+
+## Main declarations
+
+* `TauCeti.IsCompletelyMonotone.sum`: completely monotone functions are closed under finite sums.
+* `TauCeti.finiteExponentialMixture`: a finite positive mixture of exponential extreme rays.
+* `TauCeti.finiteExponentialMixtureMeasure`: the corresponding finite sum of weighted Dirac
+  measures on `ℝ≥0`.
+* `TauCeti.isCompletelyMonotone_finiteExponentialMixture`: every finite exponential mixture is
+  completely monotone.
+* `TauCeti.finiteExponentialMixture_eq_integral`: the explicit sum is the Laplace transform of
+  its discrete representing measure.
+* `TauCeti.integral_exp_neg_mul_dirac_one`: the acceptance example
+  `exp (-t) ↔ δ₁`.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Chapter 1.
+-/
+
+public section
+
+open MeasureTheory Set
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+namespace IsCompletelyMonotone
+
+/-- Completely monotone functions are closed under finite sums. -/
+theorem sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
+    (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
+    IsCompletelyMonotone (fun t => ∑ i ∈ s, f i t) := by
+  classical
+  induction s using Finset.induction_on with
+  | empty =>
+      simpa using isCompletelyMonotone_const (c := 0) le_rfl
+  | @insert i s hi ih =>
+      have hsum := (hf i (Finset.mem_insert_self i s)).add
+        (ih fun j hj => hf j (Finset.mem_insert_of_mem hj))
+      exact hsum.congr fun t _ => by
+        simp [hi, Pi.add_apply]
+
+end IsCompletelyMonotone
+
+/-- A finite positive mixture of the exponential extreme rays `t ↦ exp (-p * t)`.
+
+The weights and rates are indexed by a finset. Both take values in `ℝ≥0`, making their
+nonnegativity intrinsic to the data. -/
+noncomputable def finiteExponentialMixture {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) (t : ℝ) : ℝ :=
+  ∑ i ∈ s, (w i : ℝ) * Real.exp (-(p i : ℝ) * t)
+
+/-- Evaluation of a finite exponential mixture as its defining finite sum. -/
+theorem finiteExponentialMixture_apply {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) (t : ℝ) :
+    finiteExponentialMixture s w p t =
+      ∑ i ∈ s, (w i : ℝ) * Real.exp (-(p i : ℝ) * t) := by
+  rw [finiteExponentialMixture]
+
+/-- The empty exponential mixture is the zero function. -/
+@[simp]
+theorem finiteExponentialMixture_empty {ι : Type*} (w p : ι → ℝ≥0) :
+    finiteExponentialMixture ∅ w p = 0 := by
+  ext t
+  simp [finiteExponentialMixture_apply]
+
+/-- A singleton exponential mixture is one weighted exponential extreme ray. -/
+@[simp]
+theorem finiteExponentialMixture_singleton {ι : Type*} (i : ι) (w p : ι → ℝ≥0) (t : ℝ) :
+    finiteExponentialMixture {i} w p t =
+      (w i : ℝ) * Real.exp (-(p i : ℝ) * t) := by
+  simp [finiteExponentialMixture_apply]
+
+/-- Every finite positive mixture of exponential extreme rays is completely monotone. -/
+theorem isCompletelyMonotone_finiteExponentialMixture {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) :
+    IsCompletelyMonotone (finiteExponentialMixture s w p) := by
+  apply IsCompletelyMonotone.sum
+  intro i hi
+  have hexp : IsCompletelyMonotone (fun t : ℝ => Real.exp (-(p i : ℝ) * t)) :=
+    isCompletelyMonotone_exp_neg_mul (p i).coe_nonneg
+  have hweighted := hexp.smul (w i).coe_nonneg
+  exact hweighted.congr fun t _ => by
+    simp [Pi.smul_apply, smul_eq_mul]
+
+/-- The finite positive measure that places weight `w i` at each rate `p i`.
+
+Repeated rates are intentionally allowed: measure addition combines their weights. -/
+noncomputable def finiteExponentialMixtureMeasure {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) : Measure ℝ≥0 :=
+  ∑ i ∈ s, (w i : ℝ≥0∞) • Measure.dirac (p i)
+
+/-- The empty exponential mixture has the zero representing measure. -/
+@[simp]
+theorem finiteExponentialMixtureMeasure_empty {ι : Type*} (w p : ι → ℝ≥0) :
+    finiteExponentialMixtureMeasure ∅ w p = 0 := by
+  simp [finiteExponentialMixtureMeasure]
+
+/-- A singleton mixture has the corresponding weighted Dirac representing measure. -/
+@[simp]
+theorem finiteExponentialMixtureMeasure_singleton {ι : Type*} (i : ι)
+    (w p : ι → ℝ≥0) :
+    finiteExponentialMixtureMeasure {i} w p =
+      (w i : ℝ≥0∞) • Measure.dirac (p i) := by
+  simp [finiteExponentialMixtureMeasure]
+
+/-- A finite exponential mixture is the Laplace transform of its discrete representing measure. -/
+theorem finiteExponentialMixture_eq_integral {ι : Type*} (s : Finset ι)
+    (w p : ι → ℝ≥0) (t : ℝ) :
+    finiteExponentialMixture s w p t =
+      ∫ q : ℝ≥0, Real.exp (-t * (q : ℝ)) ∂finiteExponentialMixtureMeasure s w p := by
+  rw [finiteExponentialMixtureMeasure, integral_finsetSum_measure]
+  · rw [finiteExponentialMixture_apply]
+    refine Finset.sum_congr rfl fun i _ => ?_
+    rw [integral_smul_measure, integral_dirac]
+    simp [mul_comm]
+  · intro i hi
+    exact (integrable_dirac (by simp)).smul_measure (by simp)
+
+/-- The Laplace transform of the unit Dirac mass at `1` is `t ↦ exp (-t)`.
+
+This is the discrete representing-measure acceptance example for Bernstein's theorem. -/
+theorem integral_exp_neg_mul_dirac_one (t : ℝ) :
+    (∫ q : ℝ≥0, Real.exp (-t * (q : ℝ)) ∂Measure.dirac 1) = Real.exp (-t) := by
+  simp
+
+/-- The exponential `t ↦ exp (-t)` is the unit-weight, unit-rate finite exponential mixture. -/
+theorem finiteExponentialMixture_singleton_one (t : ℝ) :
+    finiteExponentialMixture ({()} : Finset Unit) (fun _ => 1) (fun _ => 1) t =
+      Real.exp (-t) := by
+  simp [finiteExponentialMixture_apply]
+
+end TauCeti


### PR DESCRIPTION
This PR adds finite positive mixtures of the exponential extreme rays of the completely monotone cone, packages their weighted-Dirac representing measures, and proves the exact Laplace-transform identity. It also records the roadmap acceptance example that the unit Dirac mass at `1` represents `t ↦ exp (-t)`.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B, specifically the API item “The extreme rays: the functions `t ↦ e^{−tx}` (`x ≥ 0`) are the building blocks, and the representation below realizes a general completely monotone function as a mixture of them,” together with the acceptance example “`e^{−t} → δ₁`.” It is the lowest-hanging distinct target because the individual exponential rays and binary additive closure are already on `main`, while the open PR #1317 covers the separate Prokhorov-tightness step; the missing finite-mixture layer follows directly from those landed rays and supplies the exact finite-support case of Bernstein representation without overlapping measure extraction.

Add `TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean` (154 lines). Provide finite-sum closure for `IsCompletelyMonotone`, define `finiteExponentialMixture` and `finiteExponentialMixtureMeasure`, characterize empty and singleton mixtures, prove every mixture completely monotone, and identify it pointwise with the Laplace transform of its discrete measure.

Follow Schilling–Song–Vondraček, *Bernstein Functions: Theory and Applications*, Chapter 1, as cited in the module documentation. Reuse Tau Ceti’s `isCompletelyMonotone_exp_neg_mul`, additive and nonnegative-scalar closure, and Mathlib’s finite-sum measure, scalar-measure integral, and Dirac integral API. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5618 jobs).` `lake exe axioms` reports `axioms: audited 13045 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"finite-mixtures-extreme-rays"}-->

🤖 Prepared with Codex
