### PR TITLE
feat: preserve link components under grid commutation

### DIFF
--- a/TauCeti/KnotTheory/Grid/Commutation/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Components.lean
@@ -48,8 +48,7 @@ namespace GridDiagram
 
 variable {n : ℕ} {G G' : GridDiagram n}
 
-/-- A row commutation leaves the component traversal permutation unchanged. Both marking
-permutations are postcomposed by the same row transposition, which cancels in `X⁻¹ * O`. -/
+/-- A row commutation leaves the component traversal permutation unchanged. -/
 theorem IsRowCommutation.componentPerm_eq (h : IsRowCommutation G G') :
     G'.componentPerm = G.componentPerm := by
   rw [isRowCommutation_iff] at h
@@ -86,35 +85,35 @@ theorem IsCommutation.componentCycleType_eq (h : IsCommutation G G') :
   exact h.elim IsRowCommutation.componentCycleType_eq
     IsColumnCommutation.componentCycleType_eq
 
-/-- A row commutation preserves the number of represented link components. -/
-theorem IsRowCommutation.componentCount_eq (h : IsRowCommutation G G') :
-    G'.componentCount = G.componentCount := by
-  rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
-
-/-- A column commutation preserves the number of represented link components. -/
-theorem IsColumnCommutation.componentCount_eq (h : IsColumnCommutation G G') :
-    G'.componentCount = G.componentCount := by
-  rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
-
 /-- Every elementary commutation preserves the number of represented link components. -/
 theorem IsCommutation.componentCount_eq (h : IsCommutation G G') :
     G'.componentCount = G.componentCount := by
   rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
 
-/-- A row commutation preserves whether a grid diagram represents a knot. -/
-theorem IsRowCommutation.isKnot_iff (h : IsRowCommutation G G') :
-    G'.IsKnot ↔ G.IsKnot := by
-  rw [isKnot_def, h.componentCount_eq, isKnot_def]
+/-- A row commutation preserves the number of represented link components. -/
+theorem IsRowCommutation.componentCount_eq (h : IsRowCommutation G G') :
+    G'.componentCount = G.componentCount :=
+  (isCommutation_iff G G').mpr (Or.inl h) |>.componentCount_eq
 
-/-- A column commutation preserves whether a grid diagram represents a knot. -/
-theorem IsColumnCommutation.isKnot_iff (h : IsColumnCommutation G G') :
-    G'.IsKnot ↔ G.IsKnot := by
-  rw [isKnot_def, h.componentCount_eq, isKnot_def]
+/-- A column commutation preserves the number of represented link components. -/
+theorem IsColumnCommutation.componentCount_eq (h : IsColumnCommutation G G') :
+    G'.componentCount = G.componentCount :=
+  (isCommutation_iff G G').mpr (Or.inr h) |>.componentCount_eq
 
 /-- Every elementary commutation preserves whether a grid diagram represents a knot. -/
 theorem IsCommutation.isKnot_iff (h : IsCommutation G G') :
     G'.IsKnot ↔ G.IsKnot := by
   rw [isKnot_def, h.componentCount_eq, isKnot_def]
+
+/-- A row commutation preserves whether a grid diagram represents a knot. -/
+theorem IsRowCommutation.isKnot_iff (h : IsRowCommutation G G') :
+    G'.IsKnot ↔ G.IsKnot :=
+  (isCommutation_iff G G').mpr (Or.inl h) |>.isKnot_iff
+
+/-- A column commutation preserves whether a grid diagram represents a knot. -/
+theorem IsColumnCommutation.isKnot_iff (h : IsColumnCommutation G G') :
+    G'.IsKnot ↔ G.IsKnot :=
+  (isCommutation_iff G G').mpr (Or.inr h) |>.isKnot_iff
 
 end GridDiagram
 

--- a/TauCeti/KnotTheory/Grid/Commutation/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Components.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.KnotTheory.Grid.Commutation.Move
+public import TauCeti.KnotTheory.Grid.Diagram.Components
+
+/-!
+# Link components under grid commutation
+
+An elementary grid commutation exchanges two adjacent, non-interleaving rows or columns. It
+does not change the represented link, and the first combinatorial shadow of this fact is that it
+preserves the component traversal. A row commutation leaves the component permutation unchanged.
+A column commutation conjugates it by the transposition of the exchanged columns. Consequently
+both moves preserve the multiset of component sizes, the number of components, and whether the
+diagram represents a knot.
+
+These results deliberately concern only component combinatorics. The later invariance proof for
+grid homology attaches pentagon-counting chain maps to the same elementary commutations.
+
+## Main results
+
+* `TauCeti.GridDiagram.IsRowCommutation.componentPerm_eq`: row commutation leaves the component
+  permutation unchanged.
+* `TauCeti.GridDiagram.IsColumnCommutation.componentPerm_eq_conj`: column commutation conjugates
+  the component permutation.
+* `TauCeti.GridDiagram.IsCommutation.componentCycleType_eq`: every commutation preserves the
+  multiset of component sizes.
+* `TauCeti.GridDiagram.IsCommutation.componentCount_eq` and
+  `TauCeti.GridDiagram.IsCommutation.isKnot_iff`: every commutation preserves component count and
+  the knot predicate.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.5, "Invariance over
+𝔽₂. Grid moves = commutation + (de)stabilization", by establishing that the already-defined
+elementary commutations preserve the link-component data from Lane G.1. The grid-move convention
+follows Ozsváth--Stipsicz--Szabó, *Grid Homology for Knots and Links*, Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace GridDiagram
+
+variable {n : ℕ} {G G' : GridDiagram n}
+
+/-- A row commutation leaves the component traversal permutation unchanged. Both marking
+permutations are postcomposed by the same row transposition, which cancels in `X⁻¹ * O`. -/
+theorem IsRowCommutation.componentPerm_eq (h : IsRowCommutation G G') :
+    G'.componentPerm = G.componentPerm := by
+  rw [isRowCommutation_iff] at h
+  rcases h with ⟨a, _, _, rfl⟩
+  simp [GridDiagram.swapRows]
+
+/-- A column commutation conjugates the component traversal permutation by the transposition
+of the exchanged columns. -/
+theorem IsColumnCommutation.componentPerm_eq_conj (h : IsColumnCommutation G G') :
+    ∃ a : Fin n, G'.componentPerm =
+      Equiv.swap a (finRotate n a) * G.componentPerm *
+        (Equiv.swap a (finRotate n a))⁻¹ := by
+  rw [isColumnCommutation_iff] at h
+  rcases h with ⟨a, _, _, rfl⟩
+  exact ⟨a, by
+    simpa [GridDiagram.swapColumns] using
+      componentPerm_relabelColumns G (Equiv.swap a (finRotate n a))⟩
+
+/-- A row commutation preserves the multiset of component sizes. -/
+theorem IsRowCommutation.componentCycleType_eq (h : IsRowCommutation G G') :
+    G'.componentCycleType = G.componentCycleType := by
+  rw [componentCycleType_def, h.componentPerm_eq, componentCycleType_def]
+
+/-- A column commutation preserves the multiset of component sizes. -/
+theorem IsColumnCommutation.componentCycleType_eq (h : IsColumnCommutation G G') :
+    G'.componentCycleType = G.componentCycleType := by
+  obtain ⟨a, ha⟩ := h.componentPerm_eq_conj
+  rw [componentCycleType_def, ha, Equiv.Perm.cycleType_conj, componentCycleType_def]
+
+/-- Every elementary commutation preserves the multiset of component sizes. -/
+theorem IsCommutation.componentCycleType_eq (h : IsCommutation G G') :
+    G'.componentCycleType = G.componentCycleType := by
+  rw [isCommutation_iff] at h
+  exact h.elim IsRowCommutation.componentCycleType_eq
+    IsColumnCommutation.componentCycleType_eq
+
+/-- A row commutation preserves the number of represented link components. -/
+theorem IsRowCommutation.componentCount_eq (h : IsRowCommutation G G') :
+    G'.componentCount = G.componentCount := by
+  rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
+
+/-- A column commutation preserves the number of represented link components. -/
+theorem IsColumnCommutation.componentCount_eq (h : IsColumnCommutation G G') :
+    G'.componentCount = G.componentCount := by
+  rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
+
+/-- Every elementary commutation preserves the number of represented link components. -/
+theorem IsCommutation.componentCount_eq (h : IsCommutation G G') :
+    G'.componentCount = G.componentCount := by
+  rw [componentCount_def, h.componentCycleType_eq, componentCount_def]
+
+/-- A row commutation preserves whether a grid diagram represents a knot. -/
+theorem IsRowCommutation.isKnot_iff (h : IsRowCommutation G G') :
+    G'.IsKnot ↔ G.IsKnot := by
+  rw [isKnot_def, h.componentCount_eq, isKnot_def]
+
+/-- A column commutation preserves whether a grid diagram represents a knot. -/
+theorem IsColumnCommutation.isKnot_iff (h : IsColumnCommutation G G') :
+    G'.IsKnot ↔ G.IsKnot := by
+  rw [isKnot_def, h.componentCount_eq, isKnot_def]
+
+/-- Every elementary commutation preserves whether a grid diagram represents a knot. -/
+theorem IsCommutation.isKnot_iff (h : IsCommutation G G') :
+    G'.IsKnot ↔ G.IsKnot := by
+  rw [isKnot_def, h.componentCount_eq, isKnot_def]
+
+end GridDiagram
+
+end TauCeti

--- a/TauCeti/KnotTheory/Grid/Commutation/Move.lean
+++ b/TauCeti/KnotTheory/Grid/Commutation/Move.lean
@@ -60,6 +60,14 @@ def IsColumnCommutation (G G' : GridDiagram n) : Prop :=
     ColumnsNoninterleaving G a (finRotate n a) ∧
       G' = G.swapColumns a (finRotate n a)
 
+/-- Characterization of an elementary column commutation by its exchanged columns. -/
+theorem isColumnCommutation_iff (G G' : GridDiagram n) :
+    IsColumnCommutation G G' ↔
+      ∃ a : Fin n, a ≠ finRotate n a ∧
+        ColumnsNoninterleaving G a (finRotate n a) ∧
+          G' = G.swapColumns a (finRotate n a) :=
+  Iff.rfl
+
 /-- Swapping a cyclically adjacent non-interleaving pair of columns is a column commutation. -/
 theorem isColumnCommutation_swapColumns (G : GridDiagram n) (a : Fin n)
     (ha : a ≠ finRotate n a) (hG : ColumnsNoninterleaving G a (finRotate n a)) :
@@ -85,6 +93,14 @@ def IsRowCommutation (G G' : GridDiagram n) : Prop :=
   ∃ a : Fin n, a ≠ finRotate n a ∧
     RowsNoninterleaving G a (finRotate n a) ∧
       G' = G.swapRows a (finRotate n a)
+
+/-- Characterization of an elementary row commutation by its exchanged rows. -/
+theorem isRowCommutation_iff (G G' : GridDiagram n) :
+    IsRowCommutation G G' ↔
+      ∃ a : Fin n, a ≠ finRotate n a ∧
+        RowsNoninterleaving G a (finRotate n a) ∧
+          G' = G.swapRows a (finRotate n a) :=
+  Iff.rfl
 
 /-- Swapping a cyclically adjacent non-interleaving pair of rows is a row commutation. -/
 theorem isRowCommutation_swapRows (G : GridDiagram n) (a : Fin n)
@@ -136,6 +152,12 @@ theorem isColumnCommutation_transpose (G G' : GridDiagram n) :
 /-- One elementary grid commutation, either of rows or of columns. -/
 def IsCommutation (G G' : GridDiagram n) : Prop :=
   IsRowCommutation G G' ∨ IsColumnCommutation G G'
+
+/-- A commutation is either an elementary row commutation or an elementary column
+commutation. -/
+theorem isCommutation_iff (G G' : GridDiagram n) :
+    IsCommutation G G' ↔ IsRowCommutation G G' ∨ IsColumnCommutation G G' :=
+  Iff.rfl
 
 /-- The elementary grid commutation relation is symmetric. -/
 theorem isCommutation_comm {G G' : GridDiagram n} :

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -98,9 +98,19 @@ theorem mem_componentCycles_iff (c : Equiv.Perm (Fin n)) :
 def componentCycleType : Multiset ℕ :=
   G.componentPerm.cycleType
 
+/-- The component-size multiset is the cycle type of the component permutation. -/
+theorem componentCycleType_def :
+    G.componentCycleType = G.componentPerm.cycleType :=
+  (rfl)
+
 /-- The number of components of the link represented by a grid diagram. -/
 def componentCount : ℕ :=
   G.componentCycleType.card
+
+/-- The component count is the cardinality of the component-size multiset. -/
+theorem componentCount_def :
+    G.componentCount = G.componentCycleType.card :=
+  (rfl)
 
 /-- The number of component cycles agrees with `componentCount`. -/
 @[simp]
@@ -116,6 +126,10 @@ theorem sum_componentCycleType : G.componentCycleType.sum = n := by
 /-- A grid diagram represents a knot when its component permutation has exactly one cycle. -/
 def IsKnot : Prop :=
   G.componentCount = 1
+
+/-- A grid diagram is a knot diagram exactly when its component count is one. -/
+theorem isKnot_def : G.IsKnot ↔ G.componentCount = 1 :=
+  Iff.rfl
 
 /-- A grid diagram represents a knot exactly when its component permutation is a single
 nontrivial cycle. -/


### PR DESCRIPTION
This PR proves that elementary grid commutations preserve link-component data: a row commutation leaves the component traversal permutation unchanged, while a column commutation conjugates it by the exchanged-column transposition. Deduce invariance of the component-size multiset, component count, and knot predicate for row, column, and combined commutations.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane G.5, specifically “Invariance over 𝔽₂. Grid moves = commutation + (de)stabilization,” by connecting the landed elementary commutation relation to the landed Lane G.1 link-component API. It is the lowest-hanging distinct target because both inputs are already on `main`, while open PRs cover the separate lattice differential, E₈ plumbing, and fully blocked homology symmetries; this missing compatibility is an immediate prerequisite for stating commutation invariance as invariance of the same knot or link.

Add `TauCeti/KnotTheory/Grid/Commutation/Components.lean` (121 lines) and add characteristic lemmas for the existing opaque commutation, component-cycle-type, component-count, and knot definitions (36 lines). Follow Ozsváth–Stipsicz–Szabó, *Grid Homology for Knots and Links*, Chapter 3, as cited in the module documentation. Reuse Tau Ceti’s relabeling naturality and Mathlib’s permutation conjugacy invariance of cycle type; vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5618 jobs).` `lake exe axioms` reports `axioms: audited 13049 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"commutation-preserves-components"}-->

🤖 Prepared with Codex
