### PR TITLE
feat(OrthogonalL2Bases): the Hermite functions are a Hilbert basis of L²(ℝ)

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
@@ -1,0 +1,178 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
+public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Orthonormal
+
+/-!
+# The Hermite functions as a Hilbert basis of `L²(ℝ)`
+
+This file instantiates the weighted-measure machinery at the Gaussian weight `w(x) = e^{-x²}` and
+the dilated Hermite polynomials `Hₙ(x√2)`, whose `√w`-envelope is exactly the Hermite function
+`ψₙ` of `TauCeti.hermiteFunction`.
+
+## Main statements
+
+* `TauCeti.integrable_exp_mul_abs_gaussianWeight` — the Gaussian weight has every exponential
+  moment finite, the hypothesis the completeness theorem
+  `TauCeti.orthogonal_span_range_bareNormalizedLp_eq_bot` needs.
+* `TauCeti.degree_hermiteDilated` — `Hₙ(x√2)` has degree exactly `n`.
+* `TauCeti.integral_hermiteDilated_mul_hermiteDilated_mul_gaussianWeight` — the orthogonality
+  relation with normalization `cₙ = n!√π`, obtained from the Hermite function orthonormality
+  (milestone A2).
+* `TauCeti.hermiteHilbertBasis` — **milestone A3**: the Hermite functions as a `HilbertBasis` of
+  `L²(ℝ)`, the principal result of this file.
+* `TauCeti.coe_hermiteHilbertBasis` — its normal form: the `n`-th basis vector really is `ψₙ`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial Real
+
+/-- The dilation preserves degrees: `Hₙ(√2 · X)` has degree exactly `n`.
+
+`TauCeti.hermiteDilated` itself lives in the `MemLp` layer, where the membership results are
+already stated about it; only this degree fact is new here, and only the basis construction
+needs it. -/
+theorem degree_hermiteDilated (n : ℕ) : (hermiteDilated n).degree = (n : WithBot ℕ) := by
+  have h2 : Real.sqrt 2 ≠ 0 := by positivity
+  have hq : (Polynomial.C (Real.sqrt 2) * Polynomial.X).degree = 1 :=
+    Polynomial.degree_C_mul_X h2
+  have hmap : ((hermite n).map (Int.castRingHom ℝ)).degree = (n : WithBot ℕ) := by
+    rw [Polynomial.degree_map_eq_of_injective Int.cast_injective, Polynomial.degree_hermite]
+  rw [hermiteDilated_def, Polynomial.degree_comp (by rw [hq]; norm_num), hq, hmap, mul_one]
+
+/-- **Finite exponential moments of the Gaussian weight.** For every rate `a`, `e^{a|x|}` is
+integrable against `e^{-x²}·dx`, because `a|x| ≤ (a² + x²)/2` gives the domination
+`e^{a|x|}e^{-x²} ≤ e^{a²/2}·e^{-x²/2}`. -/
+theorem integrable_exp_mul_abs_gaussianWeight (a : ℝ) :
+    Integrable (fun x : ℝ => Real.exp (a * |x|))
+      (volume.withDensity fun x => ENNReal.ofReal (Real.exp (-x ^ 2))) := by
+  have hgauss : Integrable (fun x : ℝ => Real.exp (a ^ 2 / 2) * Real.exp (-(1 / 2) * x ^ 2)) :=
+    (integrable_exp_neg_mul_sq (by norm_num : (0:ℝ) < 1 / 2)).const_mul _
+  have hcore : Integrable (fun x : ℝ => Real.exp (a * |x|) * Real.exp (-x ^ 2)) := by
+    refine hgauss.mono' (by fun_prop) (Filter.Eventually.of_forall fun x => ?_)
+    rw [← Real.exp_add, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _), ← Real.exp_add]
+    refine Real.exp_le_exp.2 ?_
+    nlinarith [sq_nonneg (|x| - a), sq_abs x, abs_nonneg x]
+  rw [integrable_withDensity_iff_integrable_smul₀' (by fun_prop)
+    (Filter.Eventually.of_forall fun _ => ENNReal.ofReal_lt_top)]
+  have hfun : (fun x : ℝ => (ENNReal.ofReal (Real.exp (-x ^ 2))).toReal • Real.exp (a * |x|))
+      = fun x : ℝ => Real.exp (a * |x|) * Real.exp (-x ^ 2) := by
+    funext x
+    rw [smul_eq_mul, ENNReal.toReal_ofReal (Real.exp_pos _).le, mul_comm]
+  rw [hfun]
+  exact hcore
+
+/-- The Hermite normalization `cₙ = n!·√π` is positive. -/
+theorem hermiteNormalization_pos (n : ℕ) : (0 : ℝ) < (n.factorial : ℝ) * Real.sqrt Real.pi := by
+  have hfac : (0 : ℝ) < (n.factorial : ℝ) := by exact_mod_cast Nat.factorial_pos n
+  have hpi : (0 : ℝ) < Real.sqrt Real.pi := Real.sqrt_pos.mpr Real.pi_pos
+  positivity
+
+/-- **Orthogonality against the Gaussian weight.** `∫ Hₘ(x√2)Hₙ(x√2)e^{-x²} = δₘₙ·n!√π`. This is
+the Hermite function orthonormality (milestone A2) with the normalizations put back. -/
+theorem integral_hermiteDilated_mul_hermiteDilated_mul_gaussianWeight (m n : ℕ) :
+    (∫ x : ℝ, (hermiteDilated m).eval x * (hermiteDilated n).eval x * Real.exp (-x ^ 2))
+      = if m = n then (n.factorial : ℝ) * Real.sqrt Real.pi else 0 := by
+  have hpt : ∀ x : ℝ, (hermiteDilated m).eval x * (hermiteDilated n).eval x * Real.exp (-x ^ 2)
+      = (Real.sqrt ((m.factorial : ℝ) * Real.sqrt Real.pi)
+          * Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi))
+        * (hermiteFunction m x * hermiteFunction n x) := by
+    intro x
+    have he : Real.exp (-(x ^ 2 / 2)) * Real.exp (-(x ^ 2 / 2)) = Real.exp (-x ^ 2) := by
+      rw [← Real.exp_add]
+      ring_nf
+    have hm : Real.sqrt ((m.factorial : ℝ) * Real.sqrt Real.pi) ≠ 0 :=
+      ne_of_gt (Real.sqrt_pos.mpr (hermiteNormalization_pos m))
+    have hn : Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) ≠ 0 :=
+      ne_of_gt (Real.sqrt_pos.mpr (hermiteNormalization_pos n))
+    rw [eval_hermiteDilated, eval_hermiteDilated, hermiteFunction_def, hermiteFunction_def, ← he]
+    field_simp
+  simp_rw [hpt]
+  rw [integral_const_mul, integral_hermiteFunction_mul_hermiteFunction]
+  by_cases hmn : m = n
+  · subst hmn
+    rw [if_pos rfl, if_pos rfl, mul_one,
+      Real.mul_self_sqrt (hermiteNormalization_pos m).le]
+  · rw [if_neg hmn, if_neg hmn, mul_zero]
+
+section Basis
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+
+/-- The `MemLp` obligation for the dilated Hermite family against the Gaussian weight. This is the
+generic `TauCeti.memLp_two_bareNormalized` at `p = hermiteDilated`, `c n = n!√π`; the only content
+specific to this family is the exponential moment of `e^{-x²}`. -/
+private theorem memLp_hermiteDilated_normalized (n : ℕ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜)
+        ((hermiteDilated n).eval x / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi))) 2
+      (volume.withDensity fun x => ENNReal.ofReal (Real.exp (-x ^ 2))) :=
+  memLp_two_bareNormalized (𝕜 := 𝕜) ⟨1, one_pos, integrable_exp_mul_abs_gaussianWeight 1⟩
+    hermiteDilated (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi) n
+
+/-- **Roadmap A3: the Hermite functions are a Hilbert basis of `L²(ℝ)`.** Orthonormality comes from
+the weighted-measure machinery and completeness from moment determinacy
+(`TauCeti.orthogonal_span_range_bareNormalizedLp_eq_bot`), applied to the exact-degree family
+`Hₙ(x√2)` against the Gaussian weight `e^{-x²}`. -/
+noncomputable def hermiteHilbertBasis : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (volume : Measure ℝ)) :=
+  hilbertBasisOfOrthogonalSystem (𝕜 := 𝕜) (fun n x => (hermiteDilated n).eval x)
+    (fun x => Real.exp (-x ^ 2)) (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi)
+    (Filter.Eventually.of_forall fun x => Real.exp_pos _) (by fun_prop)
+    hermiteNormalization_pos
+    (fun m n => by
+      simpa using integral_hermiteDilated_mul_hermiteDilated_mul_gaussianWeight m n)
+    (memLp_hermiteDilated_normalized 𝕜)
+    (orthogonal_span_range_bareNormalizedLp_eq_bot (𝕜 := 𝕜) hermiteDilated
+      (fun x => Real.exp (-x ^ 2))
+      (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi) degree_hermiteDilated
+      hermiteNormalization_pos ⟨1, one_pos, integrable_exp_mul_abs_gaussianWeight 1⟩
+      (memLp_hermiteDilated_normalized 𝕜))
+
+/-- **The basis vectors are the Hermite functions.** Without this the construction would only
+exhibit *some* Hilbert basis; here the `√w`-envelope of `Hₙ(x√2)/√cₙ` is identified with `ψₙ`. -/
+@[simp]
+theorem coe_hermiteHilbertBasis : ⇑(hermiteHilbertBasis 𝕜) = hermiteFunctionLp 𝕜 := by
+  funext n
+  have hwpos : ∀ᵐ x ∂(volume : Measure ℝ), 0 < Real.exp (-x ^ 2) :=
+    Filter.Eventually.of_forall fun x => Real.exp_pos _
+  have hwm : AEMeasurable (fun x : ℝ => Real.exp (-x ^ 2)) volume := by fun_prop
+  -- `w > 0` makes `μ` absolutely continuous with respect to `w·μ`, so the `w·μ`-a.e.
+  -- representative of the normalized family is also a `volume`-a.e. one.
+  have hac : (volume : Measure ℝ)
+      ≪ volume.withDensity fun x => ENNReal.ofReal (Real.exp (-x ^ 2)) :=
+    withDensity_absolutelyContinuous' hwm.ennreal_ofReal
+      (Filter.Eventually.of_forall fun x => by
+        simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
+        exact Real.exp_pos _)
+  rw [hermiteHilbertBasis, coe_hilbertBasisOfOrthogonalSystem]
+  refine Lp.ext ?_
+  filter_upwards [weightL2Isometry_apply (𝕜 := 𝕜) volume (fun x => Real.exp (-x ^ 2)) hwpos hwm
+      (bareNormalizedLp (𝕜 := 𝕜) (fun n x => (hermiteDilated n).eval x)
+        (fun x => Real.exp (-x ^ 2)) (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi)
+        (memLp_hermiteDilated_normalized 𝕜) n),
+    (coeFn_bareNormalizedLp (𝕜 := 𝕜) (fun n x => (hermiteDilated n).eval x)
+      (fun x => Real.exp (-x ^ 2)) (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi)
+      (memLp_hermiteDilated_normalized 𝕜) n).filter_mono hac.ae_le,
+    coeFn_hermiteFunctionLp (𝕜 := 𝕜) n] with x h1 h2 h3
+  -- `√w` is the Hermite envelope: `√(e^{-x²}) = e^{-x²/2}`. `Real.sqrt_mul_self` wants the
+  -- radicand presented as a literal product, so the exponent is split first and `Real.exp_add`
+  -- turns the sum into that product; the split is stated as its own equality rather than being
+  -- reshaped inline.
+  have hsplit : (-x ^ 2 : ℝ) = -(x ^ 2 / 2) + -(x ^ 2 / 2) := by ring
+  have hs : Real.sqrt (Real.exp (-x ^ 2)) = Real.exp (-(x ^ 2 / 2)) := by
+    rw [hsplit, Real.exp_add]
+    exact Real.sqrt_mul_self (Real.exp_pos _).le
+  rw [h1, h2, h3, hermiteFunction_def, eval_hermiteDilated, Algebra.smul_def, ← map_mul, hs]
+  congr 1
+  ring
+
+end Basis
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
@@ -48,18 +48,33 @@ open scoped NNReal ENNReal
 
 /-! ## `L¹` and `L²` membership of the Hermite functions -/
 
-/-- The polynomial `Hₙ(·√2)`, real-evaluated, as a composition whose `eval` is `aeval (·√2)`. -/
-private lemma eval_hermiteComp (n : ℕ) (x : ℝ) :
-    (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))).eval x
-      = aeval (x * Real.sqrt 2) (hermite n) := by
-  rw [eval_comp, eval_mul, eval_X, eval_C, aeval_def, algebraMap_int_eq, ← eval_map]
+/-- The dilated Hermite polynomial `Hₙ(√2 · X)`, the polynomial whose Gaussian envelope is the
+Hermite function `ψₙ`.
+
+It is defined at this layer rather than at the basis layer because every `MemLp` result below is
+already about it: `ψₙ` *is* this polynomial times `exp(-x²/2)`, up to normalization. -/
+noncomputable def hermiteDilated (n : ℕ) : Polynomial ℝ :=
+  ((hermite n).map (Int.castRingHom ℝ)).comp (Polynomial.C (Real.sqrt 2) * X)
+
+/-- The defining equation of `TauCeti.hermiteDilated`, exported so that consumers in other modules
+can rewrite with it. -/
+theorem hermiteDilated_def (n : ℕ) :
+    hermiteDilated n
+      = ((hermite n).map (Int.castRingHom ℝ)).comp (Polynomial.C (Real.sqrt 2) * Polynomial.X) := by
+  rw [hermiteDilated]
+
+/-- Evaluating the dilated Hermite polynomial is `aeval (·√2)`. -/
+theorem eval_hermiteDilated (n : ℕ) (x : ℝ) :
+    (hermiteDilated n).eval x = aeval (x * Real.sqrt 2) (hermite n) := by
+  rw [hermiteDilated_def, eval_comp, eval_mul, eval_X, eval_C, aeval_def, algebraMap_int_eq,
+    ← eval_map, mul_comm]
 
 /-- **Target A2 (`L¹`).** Each Hermite function is integrable against Lebesgue measure: it is a
 polynomial in `x` times the Gaussian envelope `exp(-x²/2)`, the `v = 1` case of
 `integrable_eval_mul_gaussianEnvelope`. -/
 theorem integrable_hermiteFunction (n : ℕ) : Integrable (hermiteFunction n) volume := by
   have h := integrable_eval_mul_gaussianEnvelope 0
-    (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))) (w := 1)
+    (hermiteDilated n) (w := 1)
     one_ne_zero
   have exponent_one :
       ∀ x : ℝ, (-(x ^ 2 / 2) : ℝ) = -(x - 0) ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)) := by
@@ -67,11 +82,11 @@ theorem integrable_hermiteFunction (n : ℕ) : Integrable (hermiteFunction n) vo
     push_cast
     ring
   have hfun : hermiteFunction n = fun x =>
-      (((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))).eval x
+      (hermiteDilated n).eval x
         * Real.exp (-(x - 0) ^ 2 / (2 * ((1 : ℝ≥0) : ℝ)))
         / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) := by
     funext x
-    rw [hermiteFunction_def, ← eval_hermiteComp, exponent_one x]
+    rw [hermiteFunction_def, ← eval_hermiteDilated, exponent_one x]
   rw [hfun]
   exact h.div_const _
 
@@ -82,13 +97,13 @@ membership `hermiteFunctionLp` needs to realize `ψₙ` as an element of `Lp ℝ
 theorem memLp_two_hermiteFunction (n : ℕ) : MemLp (hermiteFunction n) 2 volume := by
   rw [memLp_two_iff_integrable_sq (continuous_hermiteFunction n).aestronglyMeasurable]
   have hfun : (fun x => hermiteFunction n x ^ 2) = fun x =>
-      ((((hermite n).map (Int.castRingHom ℝ)).comp (X * Polynomial.C (Real.sqrt 2))) ^ 2).eval x
+      ((hermiteDilated n) ^ 2).eval x
         * Real.exp (-x ^ 2)
         / Real.sqrt ((n.factorial : ℝ) * Real.sqrt Real.pi) ^ 2 := by
     funext x
     have henv : Real.exp (-(x ^ 2 / 2)) ^ 2 = Real.exp (-x ^ 2) := by
       rw [pow_two, ← Real.exp_add]; congr 1; ring
-    rw [hermiteFunction_def, div_pow, mul_pow, henv, eval_pow, eval_hermiteComp]
+    rw [hermiteFunction_def, div_pow, mul_pow, henv, eval_pow, eval_hermiteDilated]
   rw [hfun]
   exact (integrable_eval_mul_exp_neg_sq _).div_const _
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/PiBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/PiBasis.lean
@@ -1,0 +1,69 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import TauCeti.Analysis.InnerProductSpace.L2.Pi
+public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.HilbertBasis
+
+/-!
+# The multi-index Hermite-function basis of `L²(ℝ^ι)`
+
+The `Fintype`-indexed product of the one-dimensional Hermite-function basis: the multi-index family
+`Ψ_a(x) = ∏ᵢ ψ_{aᵢ}(xᵢ)` is a Hilbert basis of `L²(volume^ι)`, the standard eigenbasis of the
+`ℝ^ι` harmonic oscillator.
+
+This is the Lebesgue-product-measure sibling of `TauCeti.gaussianHermitePiBasis` (which carries the
+Gaussian in the measure). Both are `TauCeti.piHilbertBasis` over their respective one-dimensional
+factor — here `TauCeti.hermiteHilbertBasis` — so this file only performs the assembly.
+
+## Main statements
+
+* `TauCeti.hermiteFunctionPiBasis` — the multi-index basis.
+* `TauCeti.coeFn_hermiteFunctionPiBasis` — the anti-vacuity pin: the `a`-th vector really is the
+  product `∏ᵢ ψ_{aᵢ}(xᵢ)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable (𝕜 : Type*) [RCLike 𝕜] (ι : Type*) [Fintype ι]
+
+/-- **The multidimensional Hermite-function basis.** `piHilbertBasis` over the one-dimensional
+Hermite-function basis in every coordinate — the eigenbasis of the `ℝ^ι` harmonic oscillator. -/
+noncomputable def hermiteFunctionPiBasis :
+    HilbertBasis (ι → ℕ) 𝕜 (Lp 𝕜 2 (Measure.pi fun _ : ι => (volume : Measure ℝ))) :=
+  piHilbertBasis fun _ => hermiteHilbertBasis 𝕜
+
+/-- **The basis vectors are the multi-index Hermite-function products.** Without this the
+construction would only exhibit *some* Hilbert basis of `L²(volume^ι)`. The coordinatewise
+identification `⇑(hermiteHilbertBasis 𝕜) = hermiteFunctionLp 𝕜` transfers to the product measure
+because each evaluation map pushes the product's a.e. filter into the factor's
+(`MeasureTheory.Measure.tendsto_eval_ae_ae`). -/
+theorem coeFn_hermiteFunctionPiBasis (a : ι → ℕ) :
+    ⇑(hermiteFunctionPiBasis 𝕜 ι a)
+      =ᵐ[Measure.pi fun _ : ι => (volume : Measure ℝ)]
+        fun x => ∏ i, (algebraMap ℝ 𝕜) (hermiteFunction (a i) (x i)) := by
+  have hcoord : ∀ i : ι,
+      ∀ᵐ x : ι → ℝ ∂(Measure.pi fun _ : ι => (volume : Measure ℝ)),
+        hermiteHilbertBasis 𝕜 (a i) (x i)
+          = (algebraMap ℝ 𝕜) (hermiteFunction (a i) (x i)) := by
+    intro i
+    have h1 : ⇑(hermiteHilbertBasis 𝕜 (a i)) =ᵐ[volume]
+        fun x => (algebraMap ℝ 𝕜) (hermiteFunction (a i) x) := by
+      rw [coe_hermiteHilbertBasis]
+      exact coeFn_hermiteFunctionLp (𝕜 := 𝕜) (a i)
+    exact (Measure.tendsto_eval_ae_ae
+      (μ := fun _ : ι => (volume : Measure ℝ)) (i := i)).eventually h1
+  rw [hermiteFunctionPiBasis]
+  filter_upwards [coeFn_piHilbertBasis (fun _ : ι => hermiteHilbertBasis 𝕜) a,
+    ae_all_iff.2 hcoord] with x hx hall
+  rw [hx]
+  exact Finset.prod_congr rfl fun i _ => hall i
+
+end TauCeti


### PR DESCRIPTION
This PR lands the headline milestone **A3** of `TauCetiRoadmap/OrthogonalL2Bases/README.md` — `hermiteHilbertBasis 𝕜 : HilbertBasis ℕ 𝕜 (Lp 𝕜 2 volume)`, the Hermite functions as a Hilbert basis of `L²(ℝ)`, with its element-level export `coe_hermiteHilbertBasis` — and the Lebesgue half of **Part D**, the multi-index basis `hermiteFunctionPiBasis` of `L²(ℝ^ι)`. Orthonormality (A2) was already shipped as `TauCeti.orthonormal_hermiteFunctionLp`; the missing half was completeness, and this obtains it by instantiating the general criterion of #1283 at the Gaussian weight `w(x) = e^{-x²}` and the dilated Hermite polynomials `Hₙ(x√2)`, whose `√w`-envelope is exactly `ψₙ`.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"hermite-function-hilbert-basis"}-->

Split out of #1283 at the reviewer's request. The `scope` thread there asked to "split the general completeness prerequisite from its applications, and submit the Chebyshev and Hermite/Gaussian basis chains as separate PRs". This is the Hermite-function chain: two new files and one edit to the existing `MemLp` layer, 272 added lines. It **depends on #1283** — `Hermite/Function/HilbertBasis.lean` imports `TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness` and consumes `orthogonal_span_range_bareNormalizedLp_eq_bot` and `memLp_two_bareNormalized` from it — so it is not mergeable before that one. It is independent of the Gaussian-measure chain, which shares no declaration with it.

The completeness input the criterion asks for is one finite exponential moment of the weight, supplied by `integrable_exp_mul_abs_gaussianWeight` via the domination `a|x| ≤ (a² + x²)/2`, so `e^{a|x|}e^{-x²} ≤ e^{a²/2}e^{-x²/2}` leaves a spare Gaussian. The spanning input is `degree_hermiteDilated`: the dilation by `√2` is a unit multiple of `X`, so degrees are preserved exactly, and `degree` rather than `natDegree` is what keeps `p 0 = 0` out. The orthogonality relation `∫ Hₘ(x√2) Hₙ(x√2) e^{-x²} = δₘₙ · n!√π` is derived from the already-merged Hermite-function orthonormality rather than re-proved, and the normalization constant `cₙ = n!√π` is what makes `bareNormalizedLp` reduce to `hermiteFunctionLp` on the nose.

`Hermite/Function/MemLp.lean` gains 25 net lines: the polynomial `Hₙ(√2 · X)` was previously spelled out inline three times in that file as `((hermite n).map (Int.castRingHom ℝ)).comp (X * C (√2))`, and is now the named `hermiteDilated` with its defining equation `hermiteDilated_def` and evaluation `eval_hermiteDilated`. It is defined at the `MemLp` layer rather than at the basis layer because every membership result already in that file is about it — `ψₙ` *is* this polynomial times `exp(-x²/2)`, up to normalization — so the basis layer only adds the degree fact it alone needs.

`coe_hermiteHilbertBasis` is the anti-vacuity pin the roadmap names as a separate deliverable: without it the construction exhibits only *some* Hilbert basis of `L²(ℝ)`, which is a separability fact rather than a statement about the Hermite functions. The `coe_` rather than `coeFn_` spelling matches the adjacent `TauCeti.coe_hilbertBasisOfWeightedMeasure` and the Mathlib lemma that proves it, `HilbertBasis.coe_mkOfOrthogonalEqBot`. In the product file the `coeFn_` spelling is used instead, because there the statement is an a.e. equality of a coerced `L²` element; the coordinatewise identification transfers to the product measure through `MeasureTheory.Measure.tendsto_eval_ae_ae`.

`hermiteFunctionPiBasis` is `TauCeti.piHilbertBasis` (merged in #1202) over `ι` copies of this basis, so that file performs assembly only; both `𝕜 = ℝ` and `𝕜 = ℂ` instantiate, the complex case through the `algebraMap ℝ 𝕜` lift already carried by `hermiteFunctionLp`.

No Mathlib infrastructure was vendored. Verified with `lake exe cache get` and `lake build TauCeti.Analysis.SpecialFunctions.Hermite.Function.PiBasis`: `Build completed successfully (3119 jobs)`. `#print axioms` on `hermiteHilbertBasis`, `coe_hermiteHilbertBasis`, `hermiteFunctionPiBasis` and `coeFn_hermiteFunctionPiBasis` reports `[propext, Classical.choice, Quot.sound]` for each.

🤖 Prepared with Claude
