### PR TITLE
feat: add standard Young tableaux

### DIFF
--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -207,7 +207,7 @@ noncomputable def standardCount (μ : YoungDiagram) : ℕ :=
 /-- The number of standard Young tableaux is the cardinality of their finite type. -/
 theorem standardCount_def (μ : YoungDiagram) :
     standardCount μ = Fintype.card (StandardYoungTableau μ) :=
-  standardCount.eq_1 μ
+  by simp only [standardCount]
 
 /-- Transposing a Young diagram does not change its number of standard Young tableaux. -/
 @[simp]

--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -112,10 +112,6 @@ private def transposeCellEquiv (μ : YoungDiagram) : ↥μ.transpose.cells ≃ �
     apply Subtype.ext
     exact Prod.swap_swap c.1
 
-private theorem finCongr_apply_val {m n : ℕ} (h : m = n) (a : Fin m) :
-    (finCongr h a).val = a.val :=
-  rfl
-
 /-- Transpose a standard Young tableau by swapping its rows and columns while preserving its
 labels. -/
 def transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
@@ -143,7 +139,7 @@ theorem transpose_apply_val {μ : YoungDiagram} (T : StandardYoungTableau μ)
       congrArg Fin.val (toEquiv_apply T.transpose c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val := by
       simp only [transpose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk,
-        finCongr_apply_val, toEquiv_apply]
+        finCongr, Fin.val_cast, toEquiv_apply]
 
 private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpose) :
     StandardYoungTableau μ where
@@ -168,7 +164,7 @@ private theorem untranspose_apply_val {μ : YoungDiagram}
       congrArg Fin.val (toEquiv_apply (untranspose T) c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val := by
       simp only [untranspose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
-        finCongr_apply_val, toEquiv_apply]
+        Equiv.coe_fn_mk, finCongr, Fin.val_cast, toEquiv_apply]
 
 /-- Transposition is an equivalence between standard Young tableaux of conjugate shapes. -/
 def transposeEquiv (μ : YoungDiagram) :

--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -205,7 +205,6 @@ noncomputable def standardCount (μ : YoungDiagram) : ℕ :=
   Fintype.card (StandardYoungTableau μ)
 
 /-- The number of standard Young tableaux is the cardinality of their finite type. -/
-@[simp]
 theorem standardCount_def (μ : YoungDiagram) :
     standardCount μ = Fintype.card (StandardYoungTableau μ) :=
   standardCount.eq_1 μ

--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 Tau Ceti. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Codex
+-/
+module
+
+public import Mathlib.Data.FunLike.Fintype
+public import TauCeti.Combinatorics.Young.YoungDiagram
+
+/-!
+# Standard Young tableaux
+
+A standard Young tableau of shape `μ` is a bijective labeling of the cells of `μ` by
+`Fin μ.card` that increases strictly from left to right and from top to bottom. This file
+defines standard Young tableaux, their finite cardinality `standardCount`, and transposition.
+
+The labels start at zero, following the `Fin μ.card` convention in the Schur--Weyl roadmap.
+
+## References
+
+* [W. Fulton, *Young Tableaux*][fulton1997], Section 1.1.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 0.
+* Mathlib's `Mathlib.Combinatorics.Young.YoungDiagram`, for Young diagrams and their
+  transposition.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A standard Young tableau of shape `μ` is a bijective labeling of its cells by
+`Fin μ.card`, strictly increasing along rows and columns. -/
+structure StandardYoungTableau (μ : YoungDiagram) where
+  /-- The bijection from cells of the diagram to their labels. -/
+  toEquiv : ↥μ.cells ≃ Fin μ.card
+  /-- Labels increase strictly from left to right. -/
+  row_strict' : ∀ {i j₁ j₂ : ℕ} (h : j₁ < j₂) (hcell : (i, j₂) ∈ μ),
+    toEquiv ⟨(i, j₁), μ.up_left_mem (by rfl) h.le hcell⟩ < toEquiv ⟨(i, j₂), hcell⟩
+  /-- Labels increase strictly from top to bottom. -/
+  col_strict' : ∀ {i₁ i₂ j : ℕ} (h : i₁ < i₂) (hcell : (i₂, j) ∈ μ),
+    toEquiv ⟨(i₁, j), μ.up_left_mem h.le (by rfl) hcell⟩ < toEquiv ⟨(i₂, j), hcell⟩
+
+namespace StandardYoungTableau
+
+instance instFunLike {μ : YoungDiagram} :
+    FunLike (StandardYoungTableau μ) ↥μ.cells (Fin μ.card) where
+  coe T := T.toEquiv
+  coe_injective T U h := by
+    cases T with
+    | mk e _ _ =>
+      cases U with
+      | mk e' _ _ =>
+        congr
+        exact Equiv.ext fun c => congrFun h c
+
+/-- The underlying function of a standard Young tableau is its labeling equivalence. -/
+@[simp]
+theorem coe_toEquiv {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    ⇑T.toEquiv = T :=
+  rfl
+
+/-- Evaluating the labeling equivalence agrees with evaluating the tableau. -/
+@[simp]
+theorem toEquiv_apply {μ : YoungDiagram} (T : StandardYoungTableau μ) (c : ↥μ.cells) :
+    T.toEquiv c = T c :=
+  rfl
+
+/-- Two standard Young tableaux are equal when all of their entries agree. -/
+@[ext]
+theorem ext {μ : YoungDiagram} {T U : StandardYoungTableau μ}
+    (h : ∀ c, T c = U c) : T = U :=
+  DFunLike.ext T U h
+
+/-- The entries of a standard Young tableau form a bijection. -/
+theorem bijective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    Function.Bijective T :=
+  T.toEquiv.bijective
+
+/-- The entries of a standard Young tableau are injective. -/
+theorem injective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    Function.Injective T :=
+  T.toEquiv.injective
+
+/-- Every label occurs in a standard Young tableau. -/
+theorem surjective {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    Function.Surjective T :=
+  T.toEquiv.surjective
+
+/-- Entries of a standard Young tableau increase strictly from left to right. -/
+theorem row_strict {μ : YoungDiagram} (T : StandardYoungTableau μ)
+    {i j₁ j₂ : ℕ} (h : j₁ < j₂) (hcell : (i, j₂) ∈ μ) :
+    T ⟨(i, j₁), μ.up_left_mem (by rfl) h.le hcell⟩ < T ⟨(i, j₂), hcell⟩ :=
+  T.row_strict' h hcell
+
+/-- Entries of a standard Young tableau increase strictly from top to bottom. -/
+theorem col_strict {μ : YoungDiagram} (T : StandardYoungTableau μ)
+    {i₁ i₂ j : ℕ} (h : i₁ < i₂) (hcell : (i₂, j) ∈ μ) :
+    T ⟨(i₁, j), μ.up_left_mem h.le (by rfl) hcell⟩ < T ⟨(i₂, j), hcell⟩ :=
+  T.col_strict' h hcell
+
+private def transposeCellEquiv (μ : YoungDiagram) : ↥μ.transpose.cells ≃ ↥μ.cells where
+  toFun c := ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩
+  invFun c :=
+    ⟨c.1.swap, YoungDiagram.mem_transpose.mpr
+      (by simpa only [Prod.swap_swap, YoungDiagram.mem_cells] using c.2)⟩
+  left_inv c := by
+    apply Subtype.ext
+    exact Prod.swap_swap c.1
+  right_inv c := by
+    apply Subtype.ext
+    exact Prod.swap_swap c.1
+
+private theorem finCongr_lt_finCongr {m n : ℕ} (h : m = n) {a b : Fin m} :
+    finCongr h a < finCongr h b ↔ a < b :=
+  Fin.cast_lt_cast h
+
+private theorem finCongr_apply_val {m n : ℕ} (h : m = n) (a : Fin m) :
+    (finCongr h a).val = a.val :=
+  rfl
+
+/-- Transpose a standard Young tableau by swapping its rows and columns while preserving its
+labels. -/
+def transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    StandardYoungTableau μ.transpose where
+  toEquiv :=
+    (transposeCellEquiv μ).trans
+      (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ).symm))
+  row_strict' h hcell := by
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
+      finCongr_lt_finCongr, toEquiv_apply] using
+      T.col_strict h (YoungDiagram.mem_transpose.mp hcell)
+  col_strict' h hcell := by
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
+      finCongr_lt_finCongr, toEquiv_apply] using
+      T.row_strict h (YoungDiagram.mem_transpose.mp hcell)
+
+/-- Transposition preserves the numeric label of each cell. -/
+@[simp]
+theorem transpose_apply_val {μ : YoungDiagram} (T : StandardYoungTableau μ)
+    (c : ↥μ.transpose.cells) :
+    (T.transpose c).val =
+      (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val :=
+  calc
+    (T.transpose c).val = (T.transpose.toEquiv c).val :=
+      congrArg Fin.val (toEquiv_apply T.transpose c).symm
+    _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val := by
+      simp only [transpose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk,
+        finCongr_apply_val, toEquiv_apply]
+
+private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpose) :
+    StandardYoungTableau μ where
+  toEquiv :=
+    (transposeCellEquiv μ).symm.trans
+      (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ)))
+  row_strict' h hcell := by
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk, Prod.swap,
+      finCongr_lt_finCongr, toEquiv_apply] using
+      T.col_strict h (YoungDiagram.mem_transpose.mpr hcell)
+  col_strict' h hcell := by
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk, Prod.swap,
+      finCongr_lt_finCongr, toEquiv_apply] using
+      T.row_strict h (YoungDiagram.mem_transpose.mpr hcell)
+
+/-- Transposition is an equivalence between standard Young tableaux of conjugate shapes. -/
+def transposeEquiv (μ : YoungDiagram) :
+    StandardYoungTableau μ ≃ StandardYoungTableau μ.transpose where
+  toFun := transpose
+  invFun := untranspose
+  left_inv T := by
+    ext c
+    rfl
+  right_inv T := by
+    ext c
+    rfl
+
+/-- The forward map of `transposeEquiv` is tableau transposition. -/
+@[simp]
+theorem transposeEquiv_apply {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    transposeEquiv μ T = T.transpose :=
+  by simp [transposeEquiv]
+
+/-- Standard Young tableaux of a fixed shape form a finite type. -/
+noncomputable instance instFintype (μ : YoungDiagram) :
+    Fintype (StandardYoungTableau μ) :=
+  FunLike.fintype (StandardYoungTableau μ)
+
+end StandardYoungTableau
+
+/-- The number of standard Young tableaux of shape `μ`. -/
+noncomputable def standardCount (μ : YoungDiagram) : ℕ :=
+  Fintype.card (StandardYoungTableau μ)
+
+/-- Transposing a Young diagram does not change its number of standard Young tableaux. -/
+@[simp]
+theorem standardCount_transpose (μ : YoungDiagram) :
+    standardCount μ.transpose = standardCount μ :=
+  Fintype.card_congr (StandardYoungTableau.transposeEquiv μ).symm
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -112,10 +112,6 @@ private def transposeCellEquiv (μ : YoungDiagram) : ↥μ.transpose.cells ≃ �
     apply Subtype.ext
     exact Prod.swap_swap c.1
 
-private theorem finCongr_lt_finCongr {m n : ℕ} (h : m = n) {a b : Fin m} :
-    finCongr h a < finCongr h b ↔ a < b :=
-  Fin.cast_lt_cast h
-
 private theorem finCongr_apply_val {m n : ℕ} (h : m = n) (a : Fin m) :
     (finCongr h a).val = a.val :=
   rfl
@@ -129,11 +125,11 @@ def transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
       (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ).symm))
   row_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
-      finCongr_lt_finCongr, toEquiv_apply] using
+      finCongr, Fin.cast_lt_cast, toEquiv_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mp hcell)
   col_strict' h hcell := by
     simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
-      finCongr_lt_finCongr, toEquiv_apply] using
+      finCongr, Fin.cast_lt_cast, toEquiv_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mp hcell)
 
 /-- Transposition preserves the numeric label of each cell. -/
@@ -155,13 +151,24 @@ private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpo
     (transposeCellEquiv μ).symm.trans
       (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ)))
   row_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk, Prod.swap,
-      finCongr_lt_finCongr, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
+      Equiv.coe_fn_mk, Prod.swap, finCongr, Fin.cast_lt_cast, toEquiv_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mpr hcell)
   col_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk, Prod.swap,
-      finCongr_lt_finCongr, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
+      Equiv.coe_fn_mk, Prod.swap, finCongr, Fin.cast_lt_cast, toEquiv_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mpr hcell)
+
+private theorem untranspose_apply_val {μ : YoungDiagram}
+    (T : StandardYoungTableau μ.transpose) (c : ↥μ.cells) :
+    (untranspose T c).val =
+      (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val :=
+  calc
+    (untranspose T c).val = ((untranspose T).toEquiv c).val :=
+      congrArg Fin.val (toEquiv_apply (untranspose T) c).symm
+    _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val := by
+      simp only [untranspose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
+        finCongr_apply_val, toEquiv_apply]
 
 /-- Transposition is an equivalence between standard Young tableaux of conjugate shapes. -/
 def transposeEquiv (μ : YoungDiagram) :
@@ -169,17 +176,35 @@ def transposeEquiv (μ : YoungDiagram) :
   toFun := transpose
   invFun := untranspose
   left_inv T := by
-    ext c
-    rfl
+    apply DFunLike.ext
+    intro c
+    apply Fin.ext
+    simp only [untranspose_apply_val, transpose_apply_val, Prod.swap_swap]
   right_inv T := by
-    ext c
-    rfl
+    apply DFunLike.ext
+    intro c
+    apply Fin.ext
+    simp only [transpose_apply_val, untranspose_apply_val, Prod.swap_swap]
 
 /-- The forward map of `transposeEquiv` is tableau transposition. -/
 @[simp]
 theorem transposeEquiv_apply {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     transposeEquiv μ T = T.transpose :=
   by simp [transposeEquiv]
+
+/-- The inverse transpose equivalence swaps cells while preserving their numeric labels. -/
+@[simp]
+theorem transposeEquiv_symm_apply_val {μ : YoungDiagram}
+    (T : StandardYoungTableau μ.transpose) (c : ↥μ.cells) :
+    (((transposeEquiv μ).symm T) c).val =
+      (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val :=
+  untranspose_apply_val T c
+
+/-- Applying inverse transposition after transposition returns the original tableau. -/
+@[simp]
+theorem transposeEquiv_symm_transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
+    (transposeEquiv μ).symm T.transpose = T :=
+  (transposeEquiv μ).left_inv T
 
 /-- Standard Young tableaux of a fixed shape form a finite type. -/
 noncomputable instance instFintype (μ : YoungDiagram) :

--- a/TauCeti/Combinatorics/Young/StandardTableau.lean
+++ b/TauCeti/Combinatorics/Young/StandardTableau.lean
@@ -100,17 +100,8 @@ theorem col_strict {μ : YoungDiagram} (T : StandardYoungTableau μ)
     T ⟨(i₁, j), μ.up_left_mem h.le (by rfl) hcell⟩ < T ⟨(i₂, j), hcell⟩ :=
   T.col_strict' h hcell
 
-private def transposeCellEquiv (μ : YoungDiagram) : ↥μ.transpose.cells ≃ ↥μ.cells where
-  toFun c := ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩
-  invFun c :=
-    ⟨c.1.swap, YoungDiagram.mem_transpose.mpr
-      (by simpa only [Prod.swap_swap, YoungDiagram.mem_cells] using c.2)⟩
-  left_inv c := by
-    apply Subtype.ext
-    exact Prod.swap_swap c.1
-  right_inv c := by
-    apply Subtype.ext
-    exact Prod.swap_swap c.1
+private def transposeCellEquiv (μ : YoungDiagram) : ↥μ.transpose.cells ≃ ↥μ.cells :=
+  (Equiv.prodComm ℕ ℕ).subtypeEquiv fun _ => YoungDiagram.mem_transpose
 
 /-- Transpose a standard Young tableau by swapping its rows and columns while preserving its
 labels. -/
@@ -120,12 +111,14 @@ def transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
     (transposeCellEquiv μ).trans
       (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ).symm))
   row_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
-      finCongr, Fin.cast_lt_cast, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.subtypeEquiv_apply,
+      Equiv.prodComm_apply, Prod.swap, finCongr, Equiv.coe_fn_mk, Fin.cast_lt_cast,
+      toEquiv_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mp hcell)
   col_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk, Prod.swap,
-      finCongr, Fin.cast_lt_cast, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.subtypeEquiv_apply,
+      Equiv.prodComm_apply, Prod.swap, finCongr, Equiv.coe_fn_mk, Fin.cast_lt_cast,
+      toEquiv_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mp hcell)
 
 /-- Transposition preserves the numeric label of each cell. -/
@@ -138,8 +131,9 @@ theorem transpose_apply_val {μ : YoungDiagram} (T : StandardYoungTableau μ)
     (T.transpose c).val = (T.transpose.toEquiv c).val :=
       congrArg Fin.val (toEquiv_apply T.transpose c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mp c.2⟩).val := by
-      simp only [transpose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_mk,
-        finCongr, Fin.val_cast, toEquiv_apply]
+      simp only [transpose, Equiv.trans_apply, transposeCellEquiv,
+        Equiv.subtypeEquiv_apply, Equiv.prodComm_apply, finCongr, Equiv.coe_fn_mk,
+        Fin.val_cast, toEquiv_apply]
 
 private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpose) :
     StandardYoungTableau μ where
@@ -147,12 +141,14 @@ private def untranspose {μ : YoungDiagram} (T : StandardYoungTableau μ.transpo
     (transposeCellEquiv μ).symm.trans
       (T.toEquiv.trans (finCongr (YoungDiagram.card_transpose μ)))
   row_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
-      Equiv.coe_fn_mk, Prod.swap, finCongr, Fin.cast_lt_cast, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.subtypeEquiv_symm,
+      Equiv.prodComm_symm, Equiv.subtypeEquiv_apply, Equiv.prodComm_apply, Prod.swap,
+      finCongr, Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
       T.col_strict h (YoungDiagram.mem_transpose.mpr hcell)
   col_strict' h hcell := by
-    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
-      Equiv.coe_fn_mk, Prod.swap, finCongr, Fin.cast_lt_cast, toEquiv_apply] using
+    simpa only [Equiv.trans_apply, transposeCellEquiv, Equiv.subtypeEquiv_symm,
+      Equiv.prodComm_symm, Equiv.subtypeEquiv_apply, Equiv.prodComm_apply, Prod.swap,
+      finCongr, Equiv.coe_fn_mk, Fin.cast_lt_cast, toEquiv_apply] using
       T.row_strict h (YoungDiagram.mem_transpose.mpr hcell)
 
 private theorem untranspose_apply_val {μ : YoungDiagram}
@@ -163,8 +159,9 @@ private theorem untranspose_apply_val {μ : YoungDiagram}
     (untranspose T c).val = ((untranspose T).toEquiv c).val :=
       congrArg Fin.val (toEquiv_apply (untranspose T) c).symm
     _ = (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val := by
-      simp only [untranspose, Equiv.trans_apply, transposeCellEquiv, Equiv.coe_fn_symm_mk,
-        Equiv.coe_fn_mk, finCongr, Fin.val_cast, toEquiv_apply]
+      simp only [untranspose, Equiv.trans_apply, transposeCellEquiv,
+        Equiv.subtypeEquiv_symm, Equiv.prodComm_symm, Equiv.subtypeEquiv_apply,
+        Equiv.prodComm_apply, finCongr, Equiv.coe_fn_mk, Fin.val_cast, toEquiv_apply]
 
 /-- Transposition is an equivalence between standard Young tableaux of conjugate shapes. -/
 def transposeEquiv (μ : YoungDiagram) :
@@ -196,12 +193,6 @@ theorem transposeEquiv_symm_apply_val {μ : YoungDiagram}
       (T ⟨c.1.swap, YoungDiagram.mem_transpose.mpr c.2⟩).val :=
   untranspose_apply_val T c
 
-/-- Applying inverse transposition after transposition returns the original tableau. -/
-@[simp]
-theorem transposeEquiv_symm_transpose {μ : YoungDiagram} (T : StandardYoungTableau μ) :
-    (transposeEquiv μ).symm T.transpose = T :=
-  (transposeEquiv μ).left_inv T
-
 /-- Standard Young tableaux of a fixed shape form a finite type. -/
 noncomputable instance instFintype (μ : YoungDiagram) :
     Fintype (StandardYoungTableau μ) :=
@@ -212,6 +203,12 @@ end StandardYoungTableau
 /-- The number of standard Young tableaux of shape `μ`. -/
 noncomputable def standardCount (μ : YoungDiagram) : ℕ :=
   Fintype.card (StandardYoungTableau μ)
+
+/-- The number of standard Young tableaux is the cardinality of their finite type. -/
+@[simp]
+theorem standardCount_def (μ : YoungDiagram) :
+    standardCount μ = Fintype.card (StandardYoungTableau μ) :=
+  standardCount.eq_1 μ
 
 /-- Transposing a Young diagram does not change its number of standard Young tableaux. -/
 @[simp]


### PR DESCRIPTION
This PR adds standard Young tableaux as the next combinatorial foundation for symmetric-group representation theory. It advances `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 0, the specific item “Standard Young tableaux”: define `StandardYoungTableau μ`, give its `Fintype` instance and count `standardCount μ`, and provide tableau transposition.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"standard-young-tableaux"}-->

This is the lowest-hanging distinct RepresentationTheory target because the preceding Layer 0 partition/diagram dictionary, dominance order, and conjugation-reverses-dominance targets have merged, while no open PR covers standard tableaux. The target is independent of the later Young-subgroup and Specht-module constructions and supplies the finite index type required by the roadmap’s standard polytabloid basis, hook-length formula, and RSK correspondence.

Add `TauCeti/Combinatorics/Young/StandardTableau.lean` (201 lines). Model a tableau by an equivalence from Mathlib’s finite cell subtype `↥μ.cells` to `Fin μ.card`, together with strict row and column monotonicity. Expose evaluation, extensionality, bijectivity, and row/column elimination lemmas. Package transposition as `StandardYoungTableau.transposeEquiv`, prove that it preserves numeric labels while exchanging the row and column conditions, and derive `standardCount μ.transpose = standardCount μ`.

Follow Fulton, *Young Tableaux*, Section 1.1, as recorded in the module documentation. Reuse Mathlib’s `YoungDiagram.up_left_mem`, `YoungDiagram.mem_transpose`, `FunLike.fintype`, and `Fin.cast_lt_cast`, together with Tau Ceti’s `YoungDiagram.card_transpose`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake build` reports `Build completed successfully (5636 jobs).` `lake exe axioms` reports `axioms: audited 13379 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
