### PR TITLE
refactor(Exchangeability): decompose weighted_sums_converge_L1

### DIFF
--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -148,6 +148,132 @@ private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}
         ((memLp_blockAverage k₀ fun i => hY_L2 (k₀ i)).toLp (blockAverage Y k₀))]
       exact add_le_add hk_bound hk'_bound
 
+/-- A constant over `n + 1` tends to zero along the naturals. -/
+private theorem tendsto_const_div_natCast_add_one (c : ℝ) :
+    Tendsto (fun n : ℕ => c / ((n : ℝ) + 1)) atTop (𝓝 0) := by
+  simpa only [div_eq_mul_inv, one_mul, mul_zero] using
+    (tendsto_const_nhds.mul
+      (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)) :
+      Tendsto (fun n : ℕ => c * (1 / (↑n + 1))) atTop (𝓝 (c * 0)))
+
+/-- For a contractable `L²` sequence the lag-one covariance never exceeds the variance: the
+two-window identity makes the gap a nonnegative multiple of a variance. -/
+private theorem zero_le_variance_sub_cov_of_contractable {μ : Measure Ω} [IsFiniteMeasure μ]
+    {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
+    0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ] := by
+  have hvar := hY.variance_blockAverage_sub_of_disjoint hY_L2
+    (n := 1) (m := 1) (k := fun _ : Fin 1 => 0) (k' := fun _ : Fin 1 => 1)
+    (by omega) (by omega) (fun _ _ _ => Subsingleton.elim _ _)
+    (fun _ _ _ => Subsingleton.elim _ _) (by omega)
+  have hnonneg := variance_nonneg
+    (blockAverage Y (fun _ : Fin 1 => 0) - blockAverage Y (fun _ : Fin 1 => 1)) μ
+  rw [hvar] at hnonneg
+  norm_num at hnonneg
+  linarith
+
+/-- The prefix block averages of a contractable `L²` sequence are Cauchy in `L²`: any two are
+compared through a fresh block lying beyond both. -/
+private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
+    (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) :
+    CauchySeq fun m : ℕ =>
+      (memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
+        (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) := by
+  rw [Metric.cauchySeq_iff]
+  intro ε hε
+  obtain ⟨N, hN⟩ := eventually_atTop.1
+    (tendsto_const_div_natCast_add_one (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]))
+      (Iio_mem_nhds (sq_pos_of_pos (half_pos hε))))
+  refine ⟨N, fun n hn m hm => ?_⟩
+  let l := n + m + 2
+  let k : Fin l → ℕ := fun i => l + i
+  have hl : 0 < l := by omega
+  have hk : Function.Injective k := by
+    intro i j hij
+    exact Fin.ext (Nat.add_left_cancel hij)
+  have hn_disjoint : ∀ i : Fin (n + 1), ∀ j : Fin l, (i : ℕ) ≠ k j := by
+    intro i j
+    dsimp only [k, l]
+    omega
+  have hm_disjoint : ∀ i : Fin (m + 1), ∀ j : Fin l, (i : ℕ) ≠ k j := by
+    intro i j
+    dsimp only [k, l]
+    omega
+  have hdist :=
+    dist_blockAverages_toLp_le_via_disjoint hY hY_L2 hD
+      (Nat.succ_pos n) (Nat.succ_pos m) hl Fin.val_injective Fin.val_injective hk
+      hn_disjoint hm_disjoint (by omega) (by omega)
+  have hlt : ∀ j : ℕ, N ≤ j →
+      Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((j : ℝ) + 1)) < ε / 2 :=
+    fun j hj => (Real.sqrt_lt' (half_pos hε)).mpr (hN j hj)
+  have hn_dist := hlt n hn
+  have hm_dist := hlt m hm
+  simp only [Nat.cast_succ] at hdist
+  linarith
+
+/-- Every fixed-start window approaches the prefix of the same length in `L²`, by comparing both
+through a block lying beyond them. -/
+private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
+    [IsProbabilityMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
+    (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
+    (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) (r : ℕ) :
+    Tendsto (fun m : ℕ =>
+        dist ((memLp_blockAverage (fun j : Fin (m + 1) => r + j) fun j => hY_L2 (r + j)).toLp
+            (blockAverage Y fun j : Fin (m + 1) => r + j))
+          ((memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
+            (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))))
+      atTop (𝓝 0) := by
+  have hsqrt :
+      Tendsto (fun m : ℕ =>
+          2 * Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((m : ℝ) + 1))) atTop (𝓝 0) := by
+    simpa using
+      (Real.continuous_sqrt.continuousAt.tendsto.comp
+        (tendsto_const_div_natCast_add_one
+          (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ])))).const_mul 2
+  refine squeeze_zero' (Eventually.of_forall fun m => dist_nonneg) ?_ hsqrt
+  filter_upwards with m
+  let l := r + m + 1
+  let k : Fin (m + 1) → ℕ := fun i => l + i
+  have hk : Function.Injective k := by
+    intro i j hij
+    exact Fin.ext (Nat.add_left_cancel hij)
+  have hprefix_disjoint : ∀ i : Fin (m + 1), ∀ j : Fin (m + 1), (i : ℕ) ≠ k j := by
+    intro i j
+    dsimp only [k, l]
+    omega
+  have hwindow_disjoint : ∀ i : Fin (m + 1), ∀ j : Fin (m + 1), r + (i : ℕ) ≠ k j := by
+    intro i j
+    dsimp only [k, l]
+    omega
+  have hdist :=
+    dist_blockAverages_toLp_le_via_disjoint hY hY_L2 hD
+      (Nat.succ_pos m) (Nat.succ_pos m) (Nat.succ_pos m)
+      (fun _ _ hij => Fin.ext (Nat.add_left_cancel hij)) Fin.val_injective hk
+      hwindow_disjoint hprefix_disjoint le_rfl le_rfl
+  simp only [Nat.cast_succ] at hdist
+  linarith
+
+/-- On a probability space, `L²` convergence to a limit gives `L¹` convergence of the integrated
+absolute difference. -/
+private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω}
+    [IsProbabilityMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
+    (hW_L2 : ∀ m, MemLp (W m) 2 μ) (ha_L2 : MemLp a 2 μ)
+    (h : Tendsto (fun m => eLpNorm (W m - a) 2 μ) atTop (𝓝 0)) :
+    Tendsto (fun m => ∫ ω, |W m ω - a ω| ∂μ) atTop (𝓝 0) := by
+  have hW_L1 : Tendsto (fun m => eLpNorm (W m - a) 1 μ) atTop (𝓝 0) := by
+    refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h
+      (Eventually.of_forall fun _ => bot_le) ?_
+    filter_upwards with m
+    exact eLpNorm_le_eLpNorm_of_exponent_le one_le_two
+      ((hW_L2 m).sub ha_L2).aestronglyMeasurable
+  have hreal : Tendsto (fun m => (eLpNorm (W m - a) 1 μ).toReal) atTop (𝓝 0) := by
+    simpa only [Function.comp_def, ENNReal.toReal_zero] using
+      (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp hW_L1
+  convert hreal using 1
+  ext m
+  simpa only [Pi.sub_apply, Real.norm_eq_abs, eLpNorm_one_eq_lintegral_enorm] using
+    (integral_norm_eq_lintegral_enorm ((hW_L2 m).sub ha_L2).aestronglyMeasurable)
+
 /-- A bounded measurable observable of a contractable process has fixed-start Cesàro averages
 converging in `L¹` to one common measurable limit.
 
@@ -171,155 +297,37 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
     apply MemLp.of_bound (hY_meas i).aestronglyMeasurable C
     filter_upwards with ω
     exact hC (X i ω)
-  let D : ℝ := Var[Y 0; μ] - cov[Y 0, Y 1; μ]
-  have hD : 0 ≤ D := by
-    have hvar := hY.variance_blockAverage_sub_of_disjoint hY_L2
-      (n := 1) (m := 1) (k := fun _ : Fin 1 => 0) (k' := fun _ : Fin 1 => 1)
-      (by omega) (by omega) (fun _ _ _ => Subsingleton.elim _ _)
-      (fun _ _ _ => Subsingleton.elim _ _) (by omega)
-    have hnonneg := variance_nonneg
-      (blockAverage Y (fun _ : Fin 1 => 0) - blockAverage Y (fun _ : Fin 1 => 1)) μ
-    rw [hvar] at hnonneg
-    norm_num at hnonneg
-    dsimp only [D]
-    linarith
-  let A : ℕ → Ω → ℝ :=
-    fun m => blockAverage Y (Fin.val : Fin (m + 1) → ℕ)
-  have hA_L2 : ∀ m, MemLp (A m) 2 μ := fun m =>
+  have hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ] :=
+    zero_le_variance_sub_cov_of_contractable hY hY_L2
+  have hA_L2 : ∀ m : ℕ, MemLp (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) 2 μ := fun m =>
     memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i
-  let A₂ : ℕ → Lp ℝ 2 μ := fun m => (hA_L2 m).toLp (A m)
-  -- Compare any two prefixes through a fresh block beyond both to obtain an `L²` Cauchy sequence.
-  have hA₂_cauchy : CauchySeq A₂ := by
-    rw [Metric.cauchySeq_iff]
-    intro ε hε
-    have hbound_tendsto :
-        Tendsto (fun n : ℕ => 2 * D / ((n : ℝ) + 1)) atTop (𝓝 0) := by
-      simpa only [div_eq_mul_inv, one_mul, mul_zero] using
-        (tendsto_const_nhds.mul
-          (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)) :
-          Tendsto (fun n : ℕ => (2 * D) * (1 / (↑n + 1))) atTop (𝓝 ((2 * D) * 0)))
-    have heventually :
-        ∀ᶠ n : ℕ in atTop, 2 * D / ((n : ℝ) + 1) < (ε / 2) ^ 2 :=
-      hbound_tendsto (Iio_mem_nhds (sq_pos_of_pos (half_pos hε)))
-    obtain ⟨N, hN⟩ := eventually_atTop.1 heventually
-    refine ⟨N, fun n hn m hm => ?_⟩
-    let l := n + m + 2
-    let k : Fin l → ℕ := fun i => l + i
-    have hl : 0 < l := by omega
-    have hk : Function.Injective k := by
-      intro i j hij
-      exact Fin.ext (Nat.add_left_cancel hij)
-    have hn_disjoint : ∀ i : Fin (n + 1), ∀ j : Fin l, (i : ℕ) ≠ k j := by
-      intro i j
-      dsimp only [k, l]
-      omega
-    have hm_disjoint : ∀ i : Fin (m + 1), ∀ j : Fin l, (i : ℕ) ≠ k j := by
-      intro i j
-      dsimp only [k, l]
-      omega
-    have hdist :
-        dist (A₂ n) (A₂ m) ≤
-          Real.sqrt (2 * D / ((n : ℝ) + 1)) +
-            Real.sqrt (2 * D / ((m : ℝ) + 1)) := by
-      simpa only [A₂, A, D, Nat.cast_succ] using
-        dist_blockAverages_toLp_le_via_disjoint hY hY_L2 hD
-          (Nat.succ_pos n) (Nat.succ_pos m) hl Fin.val_injective Fin.val_injective hk
-          hn_disjoint hm_disjoint (by omega) (by omega)
-    have hn_dist : Real.sqrt (2 * D / ((n : ℝ) + 1)) < ε / 2 := by
-      have hn_bound := hN n hn
-      have hn_nonneg : 0 ≤ 2 * D / ((n : ℝ) + 1) := by positivity
-      nlinarith [Real.sqrt_nonneg (2 * D / ((n : ℝ) + 1)), Real.sq_sqrt hn_nonneg]
-    have hm_dist : Real.sqrt (2 * D / ((m : ℝ) + 1)) < ε / 2 := by
-      have hm_bound := hN m hm
-      have hm_nonneg : 0 ≤ 2 * D / ((m : ℝ) + 1) := by positivity
-      nlinarith [Real.sqrt_nonneg (2 * D / ((m : ℝ) + 1)), Real.sq_sqrt hm_nonneg]
-    linarith
-  -- Completeness of `L²` supplies the common prefix limit and a measurable representative.
-  obtain ⟨a₂, ha₂⟩ :
-      ∃ a₂ : Lp ℝ 2 μ, Tendsto A₂ atTop (𝓝 a₂) :=
-    cauchySeq_tendsto_of_complete hA₂_cauchy
+  let A₂ : ℕ → Lp ℝ 2 μ := fun m =>
+    (hA_L2 m).toLp (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))
+  -- Completeness of `L²` turns the Cauchy prefixes into a limit with a measurable representative.
+  obtain ⟨a₂, ha₂⟩ : ∃ a₂ : Lp ℝ 2 μ, Tendsto A₂ atTop (𝓝 a₂) :=
+    cauchySeq_tendsto_of_complete (cauchySeq_blockAverage_prefix_toLp hY hY_L2 hD)
   let a : Ω → ℝ := (Lp.aestronglyMeasurable a₂).mk a₂
   have ha₂_ae : a₂ =ᵐ[μ] a := (Lp.aestronglyMeasurable a₂).ae_eq_mk
   have ha_meas : Measurable a := (Lp.aestronglyMeasurable a₂).measurable_mk
-  have ha_L2 : MemLp a 2 μ :=
-    (memLp_congr_ae ha₂_ae).mp (Lp.memLp a₂)
-  have ha_L1 : MemLp a 1 μ := ha_L2.mono_exponent one_le_two
-  have ha_toLp : ha_L2.toLp a = a₂ := by
-    apply Lp.ext
-    exact ha_L2.coeFn_toLp.trans ha₂_ae.symm
-  refine ⟨a, ha_meas, ha_L1, fun r => ?_⟩
-  let W : ℕ → Ω → ℝ :=
-    fun m => blockAverage Y fun j : Fin (m + 1) => r + j
-  have hW_L2 : ∀ m, MemLp (W m) 2 μ := fun m =>
+  have ha_L2 : MemLp a 2 μ := (memLp_congr_ae ha₂_ae).mp (Lp.memLp a₂)
+  have ha_toLp : ha_L2.toLp a = a₂ :=
+    Lp.ext (ha_L2.coeFn_toLp.trans ha₂_ae.symm)
+  refine ⟨a, ha_meas, ha_L2.mono_exponent one_le_two, fun r => ?_⟩
+  have hW_L2 : ∀ m : ℕ, MemLp (blockAverage Y fun j : Fin (m + 1) => r + j) 2 μ := fun m =>
     memLp_blockAverage (fun j : Fin (m + 1) => r + j) fun j => hY_L2 (r + j)
-  let W₂ : ℕ → Lp ℝ 2 μ := fun m => (hW_L2 m).toLp (W m)
-  -- A fresh disjoint block makes each fixed-start window close to the same-length prefix.
-  have hWA_dist :
-      Tendsto (fun m => dist (W₂ m) (A₂ m)) atTop (𝓝 0) := by
-    have hq :
-        Tendsto (fun m : ℕ => 2 * D / ((m : ℝ) + 1)) atTop (𝓝 0) := by
-      simpa only [div_eq_mul_inv, one_mul, mul_zero] using
-        (tendsto_const_nhds.mul
-          (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)) :
-          Tendsto (fun m : ℕ => (2 * D) * (1 / (↑m + 1))) atTop (𝓝 ((2 * D) * 0)))
-    have hsqrt :
-        Tendsto (fun m : ℕ => 2 * Real.sqrt (2 * D / ((m : ℝ) + 1))) atTop (𝓝 0) := by
-      simpa using (Real.continuous_sqrt.continuousAt.tendsto.comp hq).const_mul 2
-    refine squeeze_zero' (Eventually.of_forall fun m => dist_nonneg) ?_ hsqrt
-    filter_upwards with m
-    let l := r + m + 1
-    let k : Fin (m + 1) → ℕ := fun i => l + i
-    have hk : Function.Injective k := by
-      intro i j hij
-      exact Fin.ext (Nat.add_left_cancel hij)
-    have hprefix_disjoint :
-        ∀ i : Fin (m + 1), ∀ j : Fin (m + 1), (i : ℕ) ≠ k j := by
-      intro i j
-      dsimp only [k, l]
-      omega
-    have hwindow_disjoint :
-        ∀ i : Fin (m + 1), ∀ j : Fin (m + 1), r + (i : ℕ) ≠ k j := by
-      intro i j
-      dsimp only [k, l]
-      omega
-    calc
-      dist (W₂ m) (A₂ m)
-          ≤ Real.sqrt (2 * D / ((m : ℝ) + 1)) +
-              Real.sqrt (2 * D / ((m : ℝ) + 1)) := by
-        simpa only [W₂, A₂, hW_L2, hA_L2, W, A, D, Nat.cast_succ] using
-          dist_blockAverages_toLp_le_via_disjoint hY hY_L2 hD
-            (Nat.succ_pos m) (Nat.succ_pos m) (Nat.succ_pos m)
-            (fun _ _ hij => Fin.ext (Nat.add_left_cancel hij)) Fin.val_injective hk
-            hwindow_disjoint hprefix_disjoint le_rfl le_rfl
-      _ = 2 * Real.sqrt (2 * D / ((m : ℝ) + 1)) := by ring
+  let W₂ : ℕ → Lp ℝ 2 μ := fun m =>
+    (hW_L2 m).toLp (blockAverage Y fun j : Fin (m + 1) => r + j)
+  -- Each fixed-start window tracks the same-length prefix, so it shares the prefix limit.
   have hW₂_tendsto : Tendsto W₂ atTop (𝓝 a₂) := by
-    apply tendsto_iff_dist_tendsto_zero.2
-    have hupper :
-        Tendsto (fun m => dist (W₂ m) (A₂ m) + dist (A₂ m) a₂) atTop (𝓝 0) := by
-      simpa only [zero_add] using hWA_dist.add (tendsto_iff_dist_tendsto_zero.mp ha₂)
-    refine squeeze_zero' (Eventually.of_forall fun _ => dist_nonneg) ?_ hupper
-    filter_upwards with m
-    exact dist_triangle _ (A₂ m) _
-  have hW_L2_tendsto :
-      Tendsto (fun m => eLpNorm (W m - a) 2 μ) atTop (𝓝 0) := by
-    rw [← Lp.tendsto_Lp_iff_tendsto_eLpNorm'' W hW_L2 a ha_L2]
-    simpa only [ha_toLp] using hW₂_tendsto
-  -- Probability-space norm monotonicity descends convergence from `L²` to `L¹`.
-  have hW_L1_tendsto :
-      Tendsto (fun m => eLpNorm (W m - a) 1 μ) atTop (𝓝 0) := by
-    refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds hW_L2_tendsto
-      (Eventually.of_forall fun _ => bot_le) ?_
-    filter_upwards with m
-    exact eLpNorm_le_eLpNorm_of_exponent_le one_le_two
-      ((hW_L2 m).sub ha_L2).aestronglyMeasurable
-  have hW_L1_real :
-      Tendsto (fun m => (eLpNorm (W m - a) 1 μ).toReal) atTop (𝓝 0) := by
-    simpa only [Function.comp_def, ENNReal.toReal_zero] using
-      (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp hW_L1_tendsto
-  convert hW_L1_real using 1
-  ext m
-  simpa only [Pi.sub_apply, Real.norm_eq_abs, eLpNorm_one_eq_lintegral_enorm] using
-    (integral_norm_eq_lintegral_enorm ((hW_L2 m).sub ha_L2).aestronglyMeasurable)
+    refine tendsto_iff_dist_tendsto_zero.2 (squeeze_zero'
+      (Eventually.of_forall fun _ => dist_nonneg) (Eventually.of_forall fun m =>
+        dist_triangle _ (A₂ m) _) ?_)
+    simpa only [zero_add] using
+      (tendsto_dist_blockAverage_window_prefix_toLp hY hY_L2 hD r).add
+        (tendsto_iff_dist_tendsto_zero.mp ha₂)
+  refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two hW_L2 ha_L2 ?_
+  rw [← Lp.tendsto_Lp_iff_tendsto_eLpNorm'' _ hW_L2 a ha_L2]
+  simpa only [ha_toLp] using hW₂_tendsto
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -63,7 +63,7 @@ private theorem dist_toLp_sq_eq_integral_sq {μ : Measure Ω} {g h : Ω → ℝ}
 
 /-- Bound the `L²` distance from a block average to a longer disjoint block average. -/
 private theorem dist_blockAverage_toLp_le_of_disjoint {μ : Measure Ω}
-    [IsProbabilityMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
+    [IsFiniteMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
     (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
     (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) {n l : ℕ}
     (hn : 0 < n) (hl : 0 < l) {k : Fin n → ℕ} {k₀ : Fin l → ℕ}
@@ -115,7 +115,7 @@ private theorem dist_blockAverage_toLp_le_of_disjoint {μ : Measure Ω}
 
 /-- Compare two block averages in `L²` through a longer block disjoint from both. -/
 private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}
-    [IsProbabilityMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
+    [IsFiniteMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
     (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
     (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) {n m l : ℕ}
     (hn : 0 < n) (hm : 0 < m) (hl : 0 < l)
@@ -165,7 +165,7 @@ private theorem zero_le_variance_sub_covariance_of_contractable {μ : Measure Ω
 
 /-- The prefix block averages of a contractable `L²` sequence are Cauchy in `L²`: any two are
 compared through a fresh block lying beyond both. -/
-private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabilityMeasure μ]
+private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsFiniteMeasure μ]
     {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
     CauchySeq fun m : ℕ =>
       (memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
@@ -208,7 +208,7 @@ private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabil
 /-- Every fixed-start window approaches the prefix of the same length in `L²`, by comparing both
 through a block lying beyond them. -/
 private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
-    [IsProbabilityMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
+    [IsFiniteMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
     (hY_L2 : ∀ i, MemLp (Y i) 2 μ) (r : ℕ) :
     Tendsto (fun m : ℕ =>
         dist ((memLp_blockAverage (fun j : Fin (m + 1) => r + j) fun j => hY_L2 (r + j)).toLp

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -26,8 +26,8 @@ The proof first applies the two-window identity
 `Contractable.integral_sq_blockAverage_sub_of_disjoint` to compare two prefix averages through a
 third block disjoint from both. This makes the prefixes Cauchy in Mathlib's complete `L²` space.
 The same disjoint-block comparison shows that every fixed-start window converges to the prefix
-limit. Finally, `eLpNorm_le_eLpNorm_of_exponent_le` turns the `L²` convergence into `L¹`
-convergence.
+limit. Finally, `eLpNorm_le_eLpNorm_mul_rpow_measure_univ` turns the `L²` convergence into `L¹`
+convergence, at the cost of the fixed factor `μ univ ^ (1 - 1/2)`.
 
 The mathematical argument follows the elementary `L²` route around Theorem 1.1 in Kallenberg,
 *Probabilistic Symmetries and Invariance Principles* (2005). The theorem statement is adapted
@@ -174,11 +174,11 @@ private theorem zero_le_variance_sub_cov_of_contractable {μ : Measure Ω} [IsFi
 /-- The prefix block averages of a contractable `L²` sequence are Cauchy in `L²`: any two are
 compared through a fresh block lying beyond both. -/
 private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabilityMeasure μ]
-    {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
-    (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) :
+    {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
     CauchySeq fun m : ℕ =>
       (memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
         (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) := by
+  have hD := zero_le_variance_sub_cov_of_contractable hY hY_L2
   rw [Metric.cauchySeq_iff]
   intro ε hε
   obtain ⟨N, hN⟩ := eventually_atTop.1
@@ -215,14 +215,14 @@ private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabil
 through a block lying beyond them. -/
 private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
     [IsProbabilityMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
-    (hY_L2 : ∀ i, MemLp (Y i) 2 μ)
-    (hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ]) (r : ℕ) :
+    (hY_L2 : ∀ i, MemLp (Y i) 2 μ) (r : ℕ) :
     Tendsto (fun m : ℕ =>
         dist ((memLp_blockAverage (fun j : Fin (m + 1) => r + j) fun j => hY_L2 (r + j)).toLp
             (blockAverage Y fun j : Fin (m + 1) => r + j))
           ((memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
             (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))))
       atTop (𝓝 0) := by
+  have hD := zero_le_variance_sub_cov_of_contractable hY hY_L2
   have hsqrt :
       Tendsto (fun m : ℕ =>
           2 * Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((m : ℝ) + 1))) atTop (𝓝 0) := by
@@ -253,19 +253,21 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
   simp only [Nat.cast_succ] at hdist
   linarith
 
-/-- On a probability space, `L²` convergence to a limit gives `L¹` convergence of the integrated
-absolute difference. -/
+/-- On a finite measure space, `L²` convergence to a limit gives `L¹` convergence of the integrated
+absolute difference: the exponent comparison costs only the fixed factor `μ univ ^ (1 - 1/2)`. -/
 private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω}
-    [IsProbabilityMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
+    [IsFiniteMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
     (hW_L2 : ∀ m, MemLp (W m) 2 μ) (ha_L2 : MemLp a 2 μ)
     (h : Tendsto (fun m => eLpNorm (W m - a) 2 μ) atTop (𝓝 0)) :
     Tendsto (fun m => ∫ ω, |W m ω - a ω| ∂μ) atTop (𝓝 0) := by
   have hW_L1 : Tendsto (fun m => eLpNorm (W m - a) 1 μ) atTop (𝓝 0) := by
-    refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds h
-      (Eventually.of_forall fun _ => bot_le) ?_
-    filter_upwards with m
-    exact eLpNorm_le_eLpNorm_of_exponent_le one_le_two
-      ((hW_L2 m).sub ha_L2).aestronglyMeasurable
+    -- The exponent comparison costs a fixed finite factor, which the limit absorbs.
+    have hbound := fun m => eLpNorm_le_eLpNorm_mul_rpow_measure_univ (p := 1) (q := 2)
+      one_le_two ((hW_L2 m).sub ha_L2).aestronglyMeasurable
+    refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds ?_
+      (Eventually.of_forall fun _ => bot_le) (Eventually.of_forall hbound)
+    simpa using ENNReal.Tendsto.mul_const h
+      (Or.inr (ENNReal.rpow_ne_top_of_nonneg (by norm_num) (measure_ne_top μ Set.univ)))
   have hreal : Tendsto (fun m => (eLpNorm (W m - a) 1 μ).toReal) atTop (𝓝 0) := by
     simpa only [Function.comp_def, ENNReal.toReal_zero] using
       (ENNReal.tendsto_toReal ENNReal.zero_ne_top).comp hW_L1
@@ -305,7 +307,7 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
     (hA_L2 m).toLp (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))
   -- Completeness of `L²` turns the Cauchy prefixes into a limit with a measurable representative.
   obtain ⟨a₂, ha₂⟩ : ∃ a₂ : Lp ℝ 2 μ, Tendsto A₂ atTop (𝓝 a₂) :=
-    cauchySeq_tendsto_of_complete (cauchySeq_blockAverage_prefix_toLp hY hY_L2 hD)
+    cauchySeq_tendsto_of_complete (cauchySeq_blockAverage_prefix_toLp hY hY_L2)
   let a : Ω → ℝ := (Lp.aestronglyMeasurable a₂).mk a₂
   have ha₂_ae : a₂ =ᵐ[μ] a := (Lp.aestronglyMeasurable a₂).ae_eq_mk
   have ha_meas : Measurable a := (Lp.aestronglyMeasurable a₂).measurable_mk
@@ -323,7 +325,7 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
       (Eventually.of_forall fun _ => dist_nonneg) (Eventually.of_forall fun m =>
         dist_triangle _ (A₂ m) _) ?_)
     simpa only [zero_add] using
-      (tendsto_dist_blockAverage_window_prefix_toLp hY hY_L2 hD r).add
+      (tendsto_dist_blockAverage_window_prefix_toLp hY hY_L2 r).add
         (tendsto_iff_dist_tendsto_zero.mp ha₂)
   refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two hW_L2 ha_L2 ?_
   rw [← Lp.tendsto_Lp_iff_tendsto_eLpNorm'' _ hW_L2 a ha_L2]

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -150,7 +150,7 @@ private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}
 
 /-- For a contractable `L²` sequence the lag-one covariance never exceeds the variance: the
 two-window identity makes the gap a nonnegative multiple of a variance. -/
-private theorem zero_le_variance_sub_cov_of_contractable {μ : Measure Ω} [IsFiniteMeasure μ]
+private theorem zero_le_variance_sub_covariance_of_contractable {μ : Measure Ω} [IsFiniteMeasure μ]
     {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
     0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ] := by
   have hvar := hY.variance_blockAverage_sub_of_disjoint hY_L2
@@ -170,7 +170,7 @@ private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabil
     CauchySeq fun m : ℕ =>
       (memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
         (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) := by
-  have hD := zero_le_variance_sub_cov_of_contractable hY hY_L2
+  have hD := zero_le_variance_sub_covariance_of_contractable hY hY_L2
   rw [Metric.cauchySeq_iff]
   intro ε hε
   have hquot : Tendsto (fun n : ℕ => 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((n : ℝ) + 1))
@@ -216,7 +216,7 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
           ((memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
             (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))))
       atTop (𝓝 0) := by
-  have hD := zero_le_variance_sub_cov_of_contractable hY hY_L2
+  have hD := zero_le_variance_sub_covariance_of_contractable hY hY_L2
   have hsqrt :
       Tendsto (fun m : ℕ =>
           2 * Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((m : ℝ) + 1))) atTop (𝓝 0) := by

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -148,11 +148,11 @@ private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}
         ((memLp_blockAverage k₀ fun i => hY_L2 (k₀ i)).toLp (blockAverage Y k₀))]
       exact add_le_add hk_bound hk'_bound
 
-/-- For a contractable `L²` sequence the lag-one covariance never exceeds the variance: the
-two-window identity makes the gap a nonnegative multiple of a variance. -/
+/-- For a contractable `L²` sequence the lag-one covariance never exceeds the variance. -/
 private theorem zero_le_variance_sub_covariance_of_contractable {μ : Measure Ω} [IsFiniteMeasure μ]
     {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
     0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ] := by
+  -- The two-window identity exhibits the gap as a nonnegative multiple of a variance.
   have hvar := hY.variance_blockAverage_sub_of_disjoint hY_L2
     (n := 1) (m := 1) (k := fun _ : Fin 1 => 0) (k' := fun _ : Fin 1 => 1)
     (by omega) (by omega) (fun _ _ _ => Subsingleton.elim _ _)
@@ -163,13 +163,13 @@ private theorem zero_le_variance_sub_covariance_of_contractable {μ : Measure Ω
   norm_num at hnonneg
   linarith
 
-/-- The prefix block averages of a contractable `L²` sequence are Cauchy in `L²`: any two are
-compared through a fresh block lying beyond both. -/
+/-- The prefix block averages of a contractable `L²` sequence are Cauchy in `L²`. -/
 private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsFiniteMeasure μ]
     {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y) (hY_L2 : ∀ i, MemLp (Y i) 2 μ) :
     CauchySeq fun m : ℕ =>
       (memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
         (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) := by
+  -- Compare any two prefixes through a fresh block lying beyond both.
   have hD := zero_le_variance_sub_covariance_of_contractable hY hY_L2
   rw [Metric.cauchySeq_iff]
   intro ε hε
@@ -205,8 +205,7 @@ private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsFiniteMe
   simp only [Nat.cast_succ] at hdist
   linarith
 
-/-- Every fixed-start window approaches the prefix of the same length in `L²`, by comparing both
-through a block lying beyond them. -/
+/-- Every fixed-start window approaches the prefix of the same length in `L²`. -/
 private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
     [IsFiniteMeasure μ] {Y : ℕ → Ω → ℝ} (hY : Contractable μ Y)
     (hY_L2 : ∀ i, MemLp (Y i) 2 μ) (r : ℕ) :
@@ -216,6 +215,7 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
           ((memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i).toLp
             (blockAverage Y fun i : Fin (m + 1) => (i : ℕ))))
       atTop (𝓝 0) := by
+  -- Compare window and prefix through a block lying beyond them both.
   have hD := zero_le_variance_sub_covariance_of_contractable hY hY_L2
   have hsqrt :
       Tendsto (fun m : ℕ =>
@@ -249,8 +249,8 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
   simp only [Nat.cast_succ] at hdist
   linarith
 
-/-- On a finite measure space, `L²` convergence to a limit gives `L¹` convergence of the integrated
-absolute difference: the exponent comparison costs only the fixed factor `μ univ ^ (1 - 1/2)`. -/
+/-- On a finite measure space, `L²` convergence to a limit gives `L¹` convergence of the
+integrated absolute difference. -/
 private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω}
     [IsFiniteMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
     (hWa_meas : ∀ m, AEStronglyMeasurable (W m - a) μ)

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -148,14 +148,6 @@ private theorem dist_blockAverages_toLp_le_via_disjoint {μ : Measure Ω}
         ((memLp_blockAverage k₀ fun i => hY_L2 (k₀ i)).toLp (blockAverage Y k₀))]
       exact add_le_add hk_bound hk'_bound
 
-/-- A constant over `n + 1` tends to zero along the naturals. -/
-private theorem tendsto_const_div_natCast_add_one (c : ℝ) :
-    Tendsto (fun n : ℕ => c / ((n : ℝ) + 1)) atTop (𝓝 0) := by
-  simpa only [div_eq_mul_inv, one_mul, mul_zero] using
-    (tendsto_const_nhds.mul
-      (tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := ℝ)) :
-      Tendsto (fun n : ℕ => c * (1 / (↑n + 1))) atTop (𝓝 (c * 0)))
-
 /-- For a contractable `L²` sequence the lag-one covariance never exceeds the variance: the
 two-window identity makes the gap a nonnegative multiple of a variance. -/
 private theorem zero_le_variance_sub_cov_of_contractable {μ : Measure Ω} [IsFiniteMeasure μ]
@@ -181,9 +173,11 @@ private theorem cauchySeq_blockAverage_prefix_toLp {μ : Measure Ω} [IsProbabil
   have hD := zero_le_variance_sub_cov_of_contractable hY hY_L2
   rw [Metric.cauchySeq_iff]
   intro ε hε
-  obtain ⟨N, hN⟩ := eventually_atTop.1
-    (tendsto_const_div_natCast_add_one (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]))
-      (Iio_mem_nhds (sq_pos_of_pos (half_pos hε))))
+  have hquot : Tendsto (fun n : ℕ => 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((n : ℝ) + 1))
+      atTop (𝓝 0) := by
+    simpa [Function.comp_def] using (tendsto_const_div_atTop_nhds_zero_nat
+      (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]))).comp (Filter.tendsto_add_atTop_nat 1)
+  obtain ⟨N, hN⟩ := eventually_atTop.1 (hquot (Iio_mem_nhds (sq_pos_of_pos (half_pos hε))))
   refine ⟨N, fun n hn m hm => ?_⟩
   let l := n + m + 2
   let k : Fin l → ℕ := fun i => l + i
@@ -226,10 +220,12 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
   have hsqrt :
       Tendsto (fun m : ℕ =>
           2 * Real.sqrt (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((m : ℝ) + 1))) atTop (𝓝 0) := by
+    have hquot : Tendsto (fun n : ℕ => 2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]) / ((n : ℝ) + 1))
+        atTop (𝓝 0) := by
+      simpa [Function.comp_def] using (tendsto_const_div_atTop_nhds_zero_nat
+        (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ]))).comp (Filter.tendsto_add_atTop_nat 1)
     simpa using
-      (Real.continuous_sqrt.continuousAt.tendsto.comp
-        (tendsto_const_div_natCast_add_one
-          (2 * (Var[Y 0; μ] - cov[Y 0, Y 1; μ])))).const_mul 2
+      (Real.continuous_sqrt.continuousAt.tendsto.comp hquot).const_mul 2
   refine squeeze_zero' (Eventually.of_forall fun m => dist_nonneg) ?_ hsqrt
   filter_upwards with m
   let l := r + m + 1
@@ -257,13 +253,13 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
 absolute difference: the exponent comparison costs only the fixed factor `μ univ ^ (1 - 1/2)`. -/
 private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω}
     [IsFiniteMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
-    (hW_L2 : ∀ m, MemLp (W m) 2 μ) (ha_L2 : MemLp a 2 μ)
+    (hWa_L2 : ∀ m, MemLp (W m - a) 2 μ)
     (h : Tendsto (fun m => eLpNorm (W m - a) 2 μ) atTop (𝓝 0)) :
     Tendsto (fun m => ∫ ω, |W m ω - a ω| ∂μ) atTop (𝓝 0) := by
   have hW_L1 : Tendsto (fun m => eLpNorm (W m - a) 1 μ) atTop (𝓝 0) := by
     -- The exponent comparison costs a fixed finite factor, which the limit absorbs.
     have hbound := fun m => eLpNorm_le_eLpNorm_mul_rpow_measure_univ (p := 1) (q := 2)
-      one_le_two ((hW_L2 m).sub ha_L2).aestronglyMeasurable
+      one_le_two (hWa_L2 m).aestronglyMeasurable
     refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds ?_
       (Eventually.of_forall fun _ => bot_le) (Eventually.of_forall hbound)
     simpa using ENNReal.Tendsto.mul_const h
@@ -274,7 +270,7 @@ private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω
   convert hreal using 1
   ext m
   simpa only [Pi.sub_apply, Real.norm_eq_abs, eLpNorm_one_eq_lintegral_enorm] using
-    (integral_norm_eq_lintegral_enorm ((hW_L2 m).sub ha_L2).aestronglyMeasurable)
+    (integral_norm_eq_lintegral_enorm (hWa_L2 m).aestronglyMeasurable)
 
 /-- A bounded measurable observable of a contractable process has fixed-start Cesàro averages
 converging in `L¹` to one common measurable limit.
@@ -325,7 +321,7 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
     simpa only [zero_add] using
       (tendsto_dist_blockAverage_window_prefix_toLp hY hY_L2 r).add
         (tendsto_iff_dist_tendsto_zero.mp ha₂)
-  refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two hW_L2 ha_L2 ?_
+  refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two (fun m => (hW_L2 m).sub ha_L2) ?_
   rw [← Lp.tendsto_Lp_iff_tendsto_eLpNorm'' _ hW_L2 a ha_L2]
   simpa only [ha_toLp] using hW₂_tendsto
 

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -253,13 +253,13 @@ private theorem tendsto_dist_blockAverage_window_prefix_toLp {μ : Measure Ω}
 absolute difference: the exponent comparison costs only the fixed factor `μ univ ^ (1 - 1/2)`. -/
 private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω}
     [IsFiniteMeasure μ] {W : ℕ → Ω → ℝ} {a : Ω → ℝ}
-    (hWa_L2 : ∀ m, MemLp (W m - a) 2 μ)
+    (hWa_meas : ∀ m, AEStronglyMeasurable (W m - a) μ)
     (h : Tendsto (fun m => eLpNorm (W m - a) 2 μ) atTop (𝓝 0)) :
     Tendsto (fun m => ∫ ω, |W m ω - a ω| ∂μ) atTop (𝓝 0) := by
   have hW_L1 : Tendsto (fun m => eLpNorm (W m - a) 1 μ) atTop (𝓝 0) := by
     -- The exponent comparison costs a fixed finite factor, which the limit absorbs.
     have hbound := fun m => eLpNorm_le_eLpNorm_mul_rpow_measure_univ (p := 1) (q := 2)
-      one_le_two (hWa_L2 m).aestronglyMeasurable
+      one_le_two (hWa_meas m)
     refine tendsto_of_tendsto_of_tendsto_of_le_of_le' tendsto_const_nhds ?_
       (Eventually.of_forall fun _ => bot_le) (Eventually.of_forall hbound)
     simpa using ENNReal.Tendsto.mul_const h
@@ -270,7 +270,7 @@ private theorem tendsto_integral_abs_sub_of_tendsto_eLpNorm_two {μ : Measure Ω
   convert hreal using 1
   ext m
   simpa only [Pi.sub_apply, Real.norm_eq_abs, eLpNorm_one_eq_lintegral_enorm] using
-    (integral_norm_eq_lintegral_enorm (hWa_L2 m).aestronglyMeasurable)
+    (integral_norm_eq_lintegral_enorm (hWa_meas m))
 
 /-- A bounded measurable observable of a contractable process has fixed-start Cesàro averages
 converging in `L¹` to one common measurable limit.
@@ -321,7 +321,8 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
     simpa only [zero_add] using
       (tendsto_dist_blockAverage_window_prefix_toLp hY hY_L2 r).add
         (tendsto_iff_dist_tendsto_zero.mp ha₂)
-  refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two (fun m => (hW_L2 m).sub ha_L2) ?_
+  refine tendsto_integral_abs_sub_of_tendsto_eLpNorm_two
+    (fun m => ((hW_L2 m).sub ha_L2).aestronglyMeasurable) ?_
   rw [← Lp.tendsto_Lp_iff_tendsto_eLpNorm'' _ hW_L2 a ha_L2]
   simpa only [ha_toLp] using hW₂_tendsto
 

--- a/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
+++ b/TauCeti/Probability/Exchangeability/L2/CesaroConvergence.lean
@@ -299,8 +299,6 @@ theorem weighted_sums_converge_L1 {μ : Measure Ω} [IsProbabilityMeasure μ]
     apply MemLp.of_bound (hY_meas i).aestronglyMeasurable C
     filter_upwards with ω
     exact hC (X i ω)
-  have hD : 0 ≤ Var[Y 0; μ] - cov[Y 0, Y 1; μ] :=
-    zero_le_variance_sub_cov_of_contractable hY hY_L2
   have hA_L2 : ∀ m : ℕ, MemLp (blockAverage Y fun i : Fin (m + 1) => (i : ℕ)) 2 μ := fun m =>
     memLp_blockAverage (fun i : Fin (m + 1) => (i : ℕ)) fun i => hY_L2 i
   let A₂ : ℕ → Lp ℝ 2 μ := fun m =>


### PR DESCRIPTION
`weighted_sums_converge_L1` had a **159-line proof body** — the longest in the repo. This extracts four private helpers, leaving a **39-line** main proof that reads as the argument's outline: bound the variance gap, make the prefixes Cauchy, take the `L²` limit, track it with each fixed-start window, descend to `L¹`.

No statement changes — `weighted_sums_converge_L1` keeps its signature, and every helper is `private` and in-file.

## Helpers

| Helper | Body | What it proves |
|---|---|---|
| `zero_le_variance_sub_cov_of_contractable` | 10 | `0 ≤ Var[Y 0] − cov[Y 0, Y 1]` |
| `cauchySeq_blockAverage_prefix_toLp` | 35 | the prefix averages are `L²`-Cauchy |
| `tendsto_dist_blockAverage_window_prefix_toLp` | 33 | each fixed-start window approaches the same-length prefix |
| `tendsto_integral_abs_sub_of_tendsto_eLpNorm_two` | 16 | `L²` convergence ⟹ `L¹` convergence of `∫ \|W − a\|` |

Every proof in the file is now under 50 lines (previously: 159).

## Reuse

* A `Tendsto (fun n => 2 * D / (n + 1)) atTop (𝓝 0)` block appeared **twice, character for character** — once inside the Cauchy argument, once inside the window argument. Both are now Mathlib's `tendsto_const_div_atTop_nhds_zero_nat` composed with `Filter.tendsto_add_atTop_nat 1`, with `simpa [Function.comp_def]` discharging the cast on the successor. No local restatement of it survives.
* The two `nlinarith [Real.sqrt_nonneg _, Real.sq_sqrt _]` square-root comparisons are replaced by `Real.sqrt_lt' : 0 < y → (√x < y ↔ x < y ^ 2)`, which is exactly that statement.
* The `L¹` descent uses `eLpNorm_le_eLpNorm_mul_rpow_measure_univ` rather than a probability-measure-only comparison.

## Generality

Each helper takes only what its own conclusion needs:

* `zero_le_variance_sub_cov_of_contractable` — `[IsFiniteMeasure μ]`, not the ambient `[IsProbabilityMeasure μ]`.
* `tendsto_integral_abs_sub_of_tendsto_eLpNorm_two` — `[IsFiniteMeasure μ]`, and it takes `hWa_meas : ∀ m, AEStronglyMeasurable (W m - a) μ` rather than `MemLp (W m) 2 μ` and `MemLp a 2 μ` separately — only the difference appears, and only its measurability is used. `L²` convergence gives `L¹` convergence on any finite measure space: the exponent comparison costs the fixed factor `μ univ ^ (1 − 1/2)`, which the limit absorbs.
* `cauchySeq_blockAverage_prefix_toLp` and `tendsto_dist_blockAverage_window_prefix_toLp` do **not** take `hD` — they already take `hY` and `hY_L2`, from which `zero_le_variance_sub_cov_of_contractable` derives it internally. Both are stated for `[IsFiniteMeasure μ]`, as are the two pre-existing helpers they call: the chain bottoms out at `Contractable.variance_blockAverage_sub_of_disjoint`, which is itself stated for a finite measure. Only `weighted_sums_converge_L1` keeps `[IsProbabilityMeasure μ]`, since that is its roadmap signature.

The module docstring is updated accordingly — it cited `eLpNorm_le_eLpNorm_of_exponent_le`, which the proof no longer uses.

## Note on the decompose queue

The standing queue listed 11 bodies over 50 lines. Re-measuring the proof body (lines after `:= by` up to the next top-level keyword) across all of `TauCeti/` finds **2**: this one and `orthogonal_span_range_bareNormalizedLp_eq_bot_of_span_eq_top` (71, #1342). With both applied, **0 of 7,592 proof bodies exceed 50 lines**. The named targets `chafaiDensity_ibp_identity`, `condExp_indicator_eq_of_law_eq_of_comap_le`, and `map_ne_neg_of_legendreSym_eq_one` now measure 49, 40, and 39 — already decomposed in earlier rounds. `perWindow_higherOrder_truncated_integral_tendsto` measures 47, not 63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

