### PR TITLE
feat(Analysis/Complex/Conformal): the Koebe square-root step

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -88,11 +88,6 @@ private theorem moebius_apply_zero (c : ℂ) : moebius c 0 = -c := by
 private theorem moebius_self (c : ℂ) : moebius c c = 0 := by
   simp [moebius]
 
-/-- A complex number whose square lies in the open unit disc lies in it too. -/
-private theorem norm_lt_one_of_norm_sq_lt_one {w : ℂ} (hw : ‖w ^ 2‖ < 1) : ‖w‖ < 1 := by
-  have hsq : ‖w‖ ^ 2 < 1 := by rwa [← norm_pow]
-  nlinarith [norm_nonneg w]
-
 /-- **A proper simply connected subdomain of the disc containing the origin expands.** If `U` is an
 open simply connected proper subset of the unit disc with `0 ∈ U`, then there is a holomorphic
 injection of `U` into the disc fixing the origin whose derivative there has norm exceeding `1`.
@@ -126,8 +121,7 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
     have := hhsq hU₀
     simpa [moebius_apply_zero] using this
   have hb1 : ‖b‖ < 1 := by
-    refine norm_lt_one_of_norm_sq_lt_one ?_
-    rw [hb2, norm_neg]
+    rw [← pow_lt_one_iff_of_nonneg (norm_nonneg b) two_ne_zero, ← norm_pow, hb2, norm_neg]
     exact ha1
   have hb0 : b ≠ 0 := by
     intro h0
@@ -136,8 +130,7 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
   -- The square root lands in the disc, since its square does.
   have hhmem : ∀ z ∈ U, h z ∈ ball (0 : ℂ) 1 := by
     intro z hz
-    rw [mem_ball_zero_iff]
-    refine norm_lt_one_of_norm_sq_lt_one ?_
+    rw [mem_ball_zero_iff, ← pow_lt_one_iff_of_nonneg (norm_nonneg (h z)) two_ne_zero, ← norm_pow]
     have hsq : h z ^ 2 = moebius a z := hhsq hz
     rw [hsq, ← mem_ball_zero_iff]
     exact mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha1 (hUd hz)
@@ -167,8 +160,7 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
   have hsqm : MapsTo (fun w : ℂ => w ^ 2) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
     intro w hw
     rw [mem_ball_zero_iff] at hw ⊢
-    rw [norm_pow]
-    nlinarith [norm_nonneg w]
+    rwa [norm_pow, pow_lt_one_iff_of_nonneg (norm_nonneg w) two_ne_zero]
   have hGd : DifferentiableOn ℂ G (ball (0 : ℂ) 1) :=
     (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hna).comp
       ((differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hnb).pow 2)

--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -1,0 +1,291 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import TauCeti.Analysis.Complex.Conformal.ExtremalFamily
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+import TauCeti.Analysis.Complex.BranchLogRoot
+import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
+import TauCeti.Analysis.Complex.Conformal.Moebius
+import TauCeti.Analysis.Complex.Conformal.PseudoHyperbolic
+import Mathlib.Analysis.Complex.Schwarz
+
+/-!
+# The Koebe square-root step
+
+The Riemann mapping theorem is proved by maximizing `‖deriv f z₀‖` over the holomorphic injections
+of a domain into the unit disc that fix a base point. Compactness (`ExtremalFamily.lean`) produces a
+maximizer; this file supplies the other half: a maximizer cannot omit a value of the disc.
+
+The engine is a statement about the disc alone: **a proper simply connected subdomain of the unit
+disc containing the origin admits a holomorphic injection back into the disc that fixes the origin
+and has derivative of norm exceeding `1` there** — no proper subdomain is extremal.
+
+## The construction
+
+Let `U` be such a subdomain and pick `a ∈ ball 0 1 \ U`; write `μ c` for the Möbius factor
+`z ↦ (z - c) / (1 - conj c * z)` of `Conformal/Moebius.lean`. Since `μ a` does not vanish on `U`,
+which is simply connected, it has a holomorphic square root `h` there
+(`TauCeti.exists_differentiableOn_pow_eq`). Put `b := h 0`, so `b ^ 2 = μ a 0 = -a`, and set
+
+* `f := μ b ∘ h`, the improved map;
+* `G := μ (-a) ∘ (· ^ 2) ∘ μ (-b)`, an automorphism followed by squaring followed by an
+  automorphism.
+
+## Why the derivative grows
+
+Not by computing `deriv f 0`. The four steps are:
+
+1. `G ∘ f` is the identity on `U`, by pure algebra: the Möbius factors cancel in pairs and the
+   square meets `h ^ 2 = μ a`. This also gives `InjOn f U` for free, `G` being a left inverse.
+2. `G` is **not** injective on the disc: it squares after an automorphism, so `μ b u` and `μ b (-u)`
+   collide for any `u ≠ 0`.
+3. Hence `‖deriv G 0‖ < 1`, by the strict Schwarz lemma below: Schwarz gives `≤ 1`, and equality
+   would make `G` a rotation, which is injective.
+4. Differentiating `G ∘ f = id` at `0` gives `deriv G 0 * deriv f 0 = 1`.
+
+Together `‖deriv G 0‖ * ‖deriv f 0‖ = 1` with `‖deriv G 0‖ < 1` forces `1 < ‖deriv f 0‖`. This is
+the route a lecturer takes, and it is also the cheaper one to formalize: the only chain rule used is
+the one on an identity, and no `field_simp` over the Möbius denominators is needed.
+
+## Main statements
+
+* `TauCeti.norm_deriv_lt_one_of_not_injOn` — the strict Schwarz lemma.
+* `TauCeti.exists_isPointedDiscInjectionOn_one_lt_norm_deriv` — a proper simply connected subdomain
+  of the disc expands.
+* `TauCeti.surjOn_ball_of_isMaxOn` — an extremal pointed disc injection is surjective onto the disc.
+
+## Coordination with upstream Mathlib
+
+The Riemann mapping theorem is being formalized upstream at
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), which proves the
+L0–L3 prerequisites internally as private lemmas. The declarations here are an explicitly
+**temporary shim**: delete them and refactor downstream consumers onto the exported Mathlib
+versions once those land.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 6 §1.2.
+* J. B. Conway, *Functions of One Complex Variable I* (GTM 11), Ch. VII §4.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Set Metric Topology
+
+/-- **Strict Schwarz lemma.** A holomorphic self-map of the open unit disc fixing the origin that is
+not injective has derivative of norm strictly less than `1` at the origin.
+
+Schwarz's lemma gives `‖deriv g 0‖ ≤ 1`; in the equality case the map is a rotation, hence
+injective. -/
+theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} (hgd : DifferentiableOn ℂ g (ball 0 1))
+    (hgm : MapsTo g (ball 0 1) (ball 0 1)) (hg₀ : g 0 = 0)
+    (hgi : ¬ InjOn g (ball 0 1)) : ‖deriv g 0‖ < 1 := by
+  have hmaps : MapsTo g (ball (0 : ℂ) 1) (closedBall (g 0) 1) := by
+    rw [hg₀]
+    exact hgm.mono_right ball_subset_closedBall
+  rcases (Complex.norm_deriv_le_one_of_mapsTo_ball hgd hmaps one_pos).lt_or_eq with hlt | heq
+  · exact hlt
+  refine absurd ?_ hgi
+  -- In the equality case Schwarz forces `g z = z * deriv g 0`, which is injective.
+  have hds : ‖dslope g 0 0‖ = 1 / 1 := by simpa [dslope_same] using heq
+  have haff := Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div hgd hmaps
+    (mem_ball_self one_pos) hds
+  have hd₀ : deriv g 0 ≠ 0 := fun h₀ => one_ne_zero (heq.symm.trans (by rw [h₀, norm_zero]))
+  intro z hz w hw hzw
+  rw [haff hz, haff hw] at hzw
+  simp only [hg₀, dslope_same, zero_add, sub_zero, smul_eq_mul] at hzw
+  exact mul_right_cancel₀ hd₀ hzw
+
+/-- The scalar unit-disc Möbius factor `z ↦ (z - c) / (1 - conj c * z)`, as a function of its
+centre `c`. This is a private abbreviation for the expression that `Conformal/Moebius.lean` states
+its lemmas about; it keeps the Koebe construction, which juggles four of these factors, readable. -/
+private noncomputable def moebius (c z : ℂ) : ℂ := (z - c) / (1 - (starRingEnd ℂ) c * z)
+
+private theorem moebius_apply_zero (c : ℂ) : moebius c 0 = -c := by
+  simp [moebius]
+
+private theorem moebius_self (c : ℂ) : moebius c c = 0 := by
+  simp [moebius]
+
+private theorem mapsTo_moebius {c : ℂ} (hc : ‖c‖ < 1) :
+    MapsTo (moebius c) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+  mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hc
+
+private theorem differentiableOn_moebius {c : ℂ} (hc : ‖c‖ < 1) :
+    DifferentiableOn ℂ (moebius c) (ball (0 : ℂ) 1) :=
+  differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hc
+
+private theorem leftInvOn_moebius {c : ℂ} (hc : ‖c‖ < 1) :
+    LeftInvOn (moebius (-c)) (moebius c) (ball (0 : ℂ) 1) :=
+  leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hc
+
+private theorem injOn_moebius {c : ℂ} (hc : ‖c‖ < 1) : InjOn (moebius c) (ball (0 : ℂ) 1) :=
+  (leftInvOn_moebius hc).injOn
+
+/-- A complex number whose square lies in the open unit disc lies in it too. -/
+private theorem norm_lt_one_of_norm_sq_lt_one {w : ℂ} (hw : ‖w ^ 2‖ < 1) : ‖w‖ < 1 := by
+  have hsq : ‖w‖ ^ 2 < 1 := by rwa [← norm_pow]
+  nlinarith [norm_nonneg w]
+
+/-- **A proper simply connected subdomain of the disc containing the origin expands.** If `U` is an
+open simply connected proper subset of the unit disc with `0 ∈ U`, then there is a holomorphic
+injection of `U` into the disc fixing the origin whose derivative there has norm exceeding `1`.
+
+This is the engine of the Riemann mapping theorem: no proper subdomain can be extremal. -/
+theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : IsOpen U)
+    (hUc : IsSimplyConnected U) (hU₀ : (0 : ℂ) ∈ U) (hUd : U ⊆ ball 0 1) (hUne : U ≠ ball 0 1) :
+    ∃ f : ℂ → ℂ, IsPointedDiscInjectionOn f U 0 ∧ 1 < ‖deriv f 0‖ := by
+  classical
+  -- A value of the disc omitted by `U`.
+  obtain ⟨a, haU, haU'⟩ : ∃ a ∈ ball (0 : ℂ) 1, a ∉ U := by
+    by_contra hcon
+    push Not at hcon
+    exact hUne (hUd.antisymm hcon)
+  have ha1 : ‖a‖ < 1 := mem_ball_zero_iff.mp haU
+  have ha0 : a ≠ 0 := fun h => haU' (h ▸ hU₀)
+  -- The Möbius factor at `a` does not vanish on `U`, so it has a holomorphic square root there.
+  have hnz : (0 : ℂ) ∉ moebius a '' U := by
+    rintro ⟨z, hz, hz0⟩
+    have hden : 1 - (starRingEnd ℂ) a * z ≠ 0 :=
+      one_sub_conj_mul_ne_zero_of_norm_lt_one (mem_ball_zero_iff.mp (hUd hz)) ha1
+    have : z - a = 0 := by
+      have := hz0
+      rw [moebius, div_eq_zero_iff] at this
+      exact this.resolve_right hden
+    exact haU' (sub_eq_zero.mp this ▸ hz)
+  obtain ⟨h, hhd, hhsq⟩ := exists_differentiableOn_pow_eq hUc hUo
+    ((differentiableOn_moebius ha1).mono hUd) hnz (n := 2) two_ne_zero
+  set b : ℂ := h 0 with hb_def
+  have hb2 : b ^ 2 = -a := by
+    have := hhsq hU₀
+    simpa [moebius_apply_zero] using this
+  have hb1 : ‖b‖ < 1 := by
+    refine norm_lt_one_of_norm_sq_lt_one ?_
+    rw [hb2, norm_neg]
+    exact ha1
+  have hb0 : b ≠ 0 := by
+    intro h0
+    rw [h0] at hb2
+    exact ha0 (by simpa using hb2.symm)
+  -- The square root lands in the disc, since its square does.
+  have hhmem : ∀ z ∈ U, h z ∈ ball (0 : ℂ) 1 := by
+    intro z hz
+    rw [mem_ball_zero_iff]
+    refine norm_lt_one_of_norm_sq_lt_one ?_
+    have hsq : h z ^ 2 = moebius a z := hhsq hz
+    rw [hsq, ← mem_ball_zero_iff]
+    exact mapsTo_moebius ha1 (hUd hz)
+  -- The improved map, and the automorphism-square-automorphism that inverts it.
+  set f : ℂ → ℂ := fun z => moebius b (h z) with hf_def
+  set G : ℂ → ℂ := fun w => moebius (-a) (moebius (-b) w ^ 2) with hG_def
+  have hfd : DifferentiableOn ℂ f U :=
+    (differentiableOn_moebius hb1).comp hhd hhmem
+  have hfm : MapsTo f U (ball (0 : ℂ) 1) := fun z hz => mapsTo_moebius hb1 (hhmem z hz)
+  have hf0 : f 0 = 0 := by
+    rw [hf_def]
+    exact moebius_self b
+  -- Step 1: `G` is a left inverse of `f` on `U`, by pure algebra.
+  have hGf : LeftInvOn G f U := by
+    intro z hz
+    have h1 : moebius (-b) (f z) = h z := leftInvOn_moebius hb1 (hhmem z hz)
+    have h2 : h z ^ 2 = moebius a z := hhsq hz
+    change moebius (-a) (moebius (-b) (f z) ^ 2) = z
+    rw [h1, h2]
+    exact leftInvOn_moebius ha1 (hUd hz)
+  have hfi : InjOn f U := hGf.injOn
+  -- `G` is a holomorphic self-map of the disc fixing the origin.
+  have hsqm : MapsTo (fun w : ℂ => w ^ 2) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
+    intro w hw
+    rw [mem_ball_zero_iff] at hw ⊢
+    rw [norm_pow]
+    nlinarith [norm_nonneg w]
+  have hGd : DifferentiableOn ℂ G (ball (0 : ℂ) 1) :=
+    (differentiableOn_moebius (by rwa [norm_neg] : ‖-a‖ < 1)).comp
+      (((differentiableOn_moebius (by rwa [norm_neg] : ‖-b‖ < 1)).pow 2)) fun w hw =>
+        hsqm (mapsTo_moebius (by rwa [norm_neg] : ‖-b‖ < 1) hw)
+  have hGm : MapsTo G (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := fun w hw =>
+    mapsTo_moebius (by rwa [norm_neg] : ‖-a‖ < 1)
+      (hsqm (mapsTo_moebius (by rwa [norm_neg] : ‖-b‖ < 1) hw))
+  have hG0 : G 0 = 0 := by
+    change moebius (-a) (moebius (-b) 0 ^ 2) = 0
+    rw [moebius_apply_zero, neg_neg, hb2]
+    exact moebius_self (-a)
+  -- Step 2: `G` squares, so it is not injective on the disc.
+  have hGni : ¬ InjOn G (ball (0 : ℂ) 1) := by
+    intro hinj
+    have hu : (1 / 2 : ℂ) ∈ ball (0 : ℂ) 1 := by
+      rw [mem_ball_zero_iff]
+      norm_num
+    have hu' : (-(1 / 2) : ℂ) ∈ ball (0 : ℂ) 1 := by
+      rw [mem_ball_zero_iff]
+      norm_num
+    have hcollide : G (moebius b (1 / 2)) = G (moebius b (-(1 / 2))) := by
+      change moebius (-a) (moebius (-b) (moebius b (1 / 2)) ^ 2)
+        = moebius (-a) (moebius (-b) (moebius b (-(1 / 2))) ^ 2)
+      rw [leftInvOn_moebius hb1 hu, leftInvOn_moebius hb1 hu']
+      norm_num
+    have := injOn_moebius hb1 hu hu'
+      (hinj (mapsTo_moebius hb1 hu) (mapsTo_moebius hb1 hu') hcollide)
+    norm_num at this
+  -- Step 3: the strict Schwarz lemma.
+  have hGderiv : ‖deriv G 0‖ < 1 := norm_deriv_lt_one_of_not_injOn hGd hGm hG0 hGni
+  -- Step 4: differentiate `G ∘ f = id` at the origin.
+  have hderiv_mul : deriv G 0 * deriv f 0 = 1 := by
+    have hf_at : HasDerivAt f (deriv f 0) 0 :=
+      (hfd.differentiableAt (hUo.mem_nhds hU₀)).hasDerivAt
+    have hG_at : HasDerivAt G (deriv G 0) (f 0) := by
+      rw [hf0]
+      exact (hGd.differentiableAt (isOpen_ball.mem_nhds (mem_ball_self one_pos))).hasDerivAt
+    have hcomp : HasDerivAt (G ∘ f) (deriv G 0 * deriv f 0) 0 := hG_at.comp 0 hf_at
+    have hev : (G ∘ f) =ᶠ[𝓝 0] id := by
+      filter_upwards [hUo.mem_nhds hU₀] with z hz using hGf hz
+    exact hcomp.unique ((hasDerivAt_id (0 : ℂ)).congr_of_eventuallyEq hev)
+  refine ⟨f, ⟨hfd, hfm, hfi, hf0⟩, ?_⟩
+  have hnorm : ‖deriv G 0‖ * ‖deriv f 0‖ = 1 := by
+    rw [← norm_mul, hderiv_mul, norm_one]
+  nlinarith [norm_nonneg (deriv f 0), norm_nonneg (deriv G 0)]
+
+/-- **An extremal pointed disc injection is surjective onto the disc.** If `g` maximizes
+`‖deriv · z₀‖` over the holomorphic injections of `Ω` into the disc fixing `z₀`, then `g` omits no
+value of the disc.
+
+Otherwise `U := g '' Ω` would be an open simply connected proper subdomain of the disc containing
+`0`, and composing `g` with the map that
+`TauCeti.exists_isPointedDiscInjectionOn_one_lt_norm_deriv` produces on `U` would beat `g`. -/
+theorem surjOn_ball_of_isMaxOn {Ω : Set ℂ} (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) {z₀ : ℂ}
+    (hz₀ : z₀ ∈ Ω) {g : ℂ → ℂ} (hg : IsPointedDiscInjectionOn g Ω z₀)
+    (hmax : ∀ f : ℂ → ℂ, IsPointedDiscInjectionOn f Ω z₀ → ‖deriv f z₀‖ ≤ ‖deriv g z₀‖) :
+    SurjOn g Ω (ball 0 1) := by
+  by_cases hUeq : g '' Ω = ball (0 : ℂ) 1
+  · exact hUeq.ge
+  exfalso
+  have hUo : IsOpen (g '' Ω) := isOpen_image_of_injOn hΩo hg.differentiableOn hg.injOn
+  have hUc : IsSimplyConnected (g '' Ω) :=
+    isSimplyConnected_image_of_injOn hΩo hΩc hg.differentiableOn hg.injOn
+  have hU₀ : (0 : ℂ) ∈ g '' Ω := ⟨z₀, hz₀, hg.map_base⟩
+  obtain ⟨f, hf, hfd1⟩ := exists_isPointedDiscInjectionOn_one_lt_norm_deriv hUo hUc hU₀
+    hg.mapsTo.image_subset hUeq
+  -- `f ∘ g` competes on `Ω`, and its derivative at the base point is strictly larger.
+  have hmt : MapsTo g Ω (g '' Ω) := fun z hz => mem_image_of_mem g hz
+  have hcomp : IsPointedDiscInjectionOn (f ∘ g) Ω z₀ :=
+    ⟨hf.differentiableOn.comp hg.differentiableOn hmt, hf.mapsTo.comp hmt,
+      hf.injOn.comp hg.injOn hmt, by simp [hg.map_base, hf.map_base]⟩
+  have hderiv : deriv (f ∘ g) z₀ = deriv f 0 * deriv g z₀ := by
+    have hg_at : HasDerivAt g (deriv g z₀) z₀ :=
+      (hg.differentiableOn.differentiableAt (hΩo.mem_nhds hz₀)).hasDerivAt
+    have hf_at : HasDerivAt f (deriv f 0) (g z₀) := by
+      rw [hg.map_base]
+      exact (hf.differentiableOn.differentiableAt (hUo.mem_nhds hU₀)).hasDerivAt
+    exact (hf_at.comp z₀ hg_at).deriv
+  have hpos : 0 < ‖deriv g z₀‖ := norm_pos_iff.mpr (hg.deriv_ne_zero hΩo hz₀)
+  have := hmax _ hcomp
+  rw [hderiv, norm_mul] at this
+  nlinarith
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -11,7 +11,7 @@ import TauCeti.Analysis.Complex.BranchLogRoot
 import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 import TauCeti.Analysis.Complex.Conformal.Moebius
 import TauCeti.Analysis.Complex.Conformal.PseudoHyperbolic
-import Mathlib.Analysis.Complex.Schwarz
+import TauCeti.Analysis.Complex.Conformal.Schwarz
 
 /-!
 # The Koebe square-root step
@@ -42,9 +42,9 @@ Not by computing `deriv f 0`. The four steps are:
 1. `G ∘ f` is the identity on `U`, by pure algebra: the Möbius factors cancel in pairs and the
    square meets `h ^ 2 = μ a`. This also gives `InjOn f U` for free, `G` being a left inverse.
 2. `G` is **not** injective on the disc: it squares after an automorphism, so `μ b u` and `μ b (-u)`
-   collide for any `u ≠ 0`.
-3. Hence `‖deriv G 0‖ < 1`, by the strict Schwarz lemma below: Schwarz gives `≤ 1`, and equality
-   would make `G` a rotation, which is injective.
+   collide for any nonzero `u` in the disc — the proof uses `u = 1/2`.
+3. Hence `‖deriv G 0‖ < 1`, by the strict Schwarz lemma of `Conformal/Schwarz.lean`: Schwarz gives
+   `≤ 1`, and equality would make `G` affine, hence injective.
 4. Differentiating `G ∘ f = id` at `0` gives `deriv G 0 * deriv f 0 = 1`.
 
 Together `‖deriv G 0‖ * ‖deriv f 0‖ = 1` with `‖deriv G 0‖ < 1` forces `1 < ‖deriv f 0‖`. This is
@@ -53,7 +53,6 @@ the one on an identity, and no `field_simp` over the Möbius denominators is nee
 
 ## Main statements
 
-* `TauCeti.norm_deriv_lt_one_of_not_injOn` — the strict Schwarz lemma.
 * `TauCeti.exists_isPointedDiscInjectionOn_one_lt_norm_deriv` — a proper simply connected subdomain
   of the disc expands.
 * `TauCeti.surjOn_ball_of_isMaxOn` — an extremal pointed disc injection is surjective onto the disc.
@@ -78,30 +77,6 @@ namespace TauCeti
 
 open Complex Set Metric Topology
 
-/-- **Strict Schwarz lemma.** A holomorphic self-map of the open unit disc fixing the origin that is
-not injective has derivative of norm strictly less than `1` at the origin.
-
-Schwarz's lemma gives `‖deriv g 0‖ ≤ 1`; in the equality case the map is a rotation, hence
-injective. -/
-theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} (hgd : DifferentiableOn ℂ g (ball 0 1))
-    (hgm : MapsTo g (ball 0 1) (ball 0 1)) (hg₀ : g 0 = 0)
-    (hgi : ¬ InjOn g (ball 0 1)) : ‖deriv g 0‖ < 1 := by
-  have hmaps : MapsTo g (ball (0 : ℂ) 1) (closedBall (g 0) 1) := by
-    rw [hg₀]
-    exact hgm.mono_right ball_subset_closedBall
-  rcases (Complex.norm_deriv_le_one_of_mapsTo_ball hgd hmaps one_pos).lt_or_eq with hlt | heq
-  · exact hlt
-  refine absurd ?_ hgi
-  -- In the equality case Schwarz forces `g z = z * deriv g 0`, which is injective.
-  have hds : ‖dslope g 0 0‖ = 1 / 1 := by simpa [dslope_same] using heq
-  have haff := Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div hgd hmaps
-    (mem_ball_self one_pos) hds
-  have hd₀ : deriv g 0 ≠ 0 := fun h₀ => one_ne_zero (heq.symm.trans (by rw [h₀, norm_zero]))
-  intro z hz w hw hzw
-  rw [haff hz, haff hw] at hzw
-  simp only [hg₀, dslope_same, zero_add, sub_zero, smul_eq_mul] at hzw
-  exact mul_right_cancel₀ hd₀ hzw
-
 /-- The scalar unit-disc Möbius factor `z ↦ (z - c) / (1 - conj c * z)`, as a function of its
 centre `c`. This is a private abbreviation for the expression that `Conformal/Moebius.lean` states
 its lemmas about; it keeps the Koebe construction, which juggles four of these factors, readable. -/
@@ -112,21 +87,6 @@ private theorem moebius_apply_zero (c : ℂ) : moebius c 0 = -c := by
 
 private theorem moebius_self (c : ℂ) : moebius c c = 0 := by
   simp [moebius]
-
-private theorem mapsTo_moebius {c : ℂ} (hc : ‖c‖ < 1) :
-    MapsTo (moebius c) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-  mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hc
-
-private theorem differentiableOn_moebius {c : ℂ} (hc : ‖c‖ < 1) :
-    DifferentiableOn ℂ (moebius c) (ball (0 : ℂ) 1) :=
-  differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hc
-
-private theorem leftInvOn_moebius {c : ℂ} (hc : ‖c‖ < 1) :
-    LeftInvOn (moebius (-c)) (moebius c) (ball (0 : ℂ) 1) :=
-  leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hc
-
-private theorem injOn_moebius {c : ℂ} (hc : ‖c‖ < 1) : InjOn (moebius c) (ball (0 : ℂ) 1) :=
-  (leftInvOn_moebius hc).injOn
 
 /-- A complex number whose square lies in the open unit disc lies in it too. -/
 private theorem norm_lt_one_of_norm_sq_lt_one {w : ℂ} (hw : ‖w ^ 2‖ < 1) : ‖w‖ < 1 := by
@@ -160,7 +120,7 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
       exact this.resolve_right hden
     exact haU' (sub_eq_zero.mp this ▸ hz)
   obtain ⟨h, hhd, hhsq⟩ := exists_differentiableOn_pow_eq hUc hUo
-    ((differentiableOn_moebius ha1).mono hUd) hnz (n := 2) two_ne_zero
+    ((differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one ha1).mono hUd) hnz (n := 2) two_ne_zero
   set b : ℂ := h 0 with hb_def
   have hb2 : b ^ 2 = -a := by
     have := hhsq hU₀
@@ -180,24 +140,28 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
     refine norm_lt_one_of_norm_sq_lt_one ?_
     have hsq : h z ^ 2 = moebius a z := hhsq hz
     rw [hsq, ← mem_ball_zero_iff]
-    exact mapsTo_moebius ha1 (hUd hz)
+    exact mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha1 (hUd hz)
+  have hna : ‖-a‖ < 1 := by rwa [norm_neg]
+  have hnb : ‖-b‖ < 1 := by rwa [norm_neg]
   -- The improved map, and the automorphism-square-automorphism that inverts it.
   set f : ℂ → ℂ := fun z => moebius b (h z) with hf_def
   set G : ℂ → ℂ := fun w => moebius (-a) (moebius (-b) w ^ 2) with hG_def
   have hfd : DifferentiableOn ℂ f U :=
-    (differentiableOn_moebius hb1).comp hhd hhmem
-  have hfm : MapsTo f U (ball (0 : ℂ) 1) := fun z hz => mapsTo_moebius hb1 (hhmem z hz)
+    (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hb1).comp hhd hhmem
+  have hfm : MapsTo f U (ball (0 : ℂ) 1) := fun z hz =>
+    mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hb1 (hhmem z hz)
   have hf0 : f 0 = 0 := by
     rw [hf_def]
     exact moebius_self b
   -- Step 1: `G` is a left inverse of `f` on `U`, by pure algebra.
   have hGf : LeftInvOn G f U := by
     intro z hz
-    have h1 : moebius (-b) (f z) = h z := leftInvOn_moebius hb1 (hhmem z hz)
+    have h1 : moebius (-b) (f z) = h z :=
+      leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hb1 (hhmem z hz)
     have h2 : h z ^ 2 = moebius a z := hhsq hz
-    change moebius (-a) (moebius (-b) (f z) ^ 2) = z
+    simp only [hG_def]
     rw [h1, h2]
-    exact leftInvOn_moebius ha1 (hUd hz)
+    exact leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha1 (hUd hz)
   have hfi : InjOn f U := hGf.injOn
   -- `G` is a holomorphic self-map of the disc fixing the origin.
   have hsqm : MapsTo (fun w : ℂ => w ^ 2) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
@@ -206,14 +170,14 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
     rw [norm_pow]
     nlinarith [norm_nonneg w]
   have hGd : DifferentiableOn ℂ G (ball (0 : ℂ) 1) :=
-    (differentiableOn_moebius (by rwa [norm_neg] : ‖-a‖ < 1)).comp
-      (((differentiableOn_moebius (by rwa [norm_neg] : ‖-b‖ < 1)).pow 2)) fun w hw =>
-        hsqm (mapsTo_moebius (by rwa [norm_neg] : ‖-b‖ < 1) hw)
+    (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hna).comp
+      ((differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hnb).pow 2)
+      fun w hw => hsqm (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hnb hw)
   have hGm : MapsTo G (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := fun w hw =>
-    mapsTo_moebius (by rwa [norm_neg] : ‖-a‖ < 1)
-      (hsqm (mapsTo_moebius (by rwa [norm_neg] : ‖-b‖ < 1) hw))
+    mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hna
+      (hsqm (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hnb hw))
   have hG0 : G 0 = 0 := by
-    change moebius (-a) (moebius (-b) 0 ^ 2) = 0
+    simp only [hG_def]
     rw [moebius_apply_zero, neg_neg, hb2]
     exact moebius_self (-a)
   -- Step 2: `G` squares, so it is not injective on the disc.
@@ -226,15 +190,22 @@ theorem exists_isPointedDiscInjectionOn_one_lt_norm_deriv {U : Set ℂ} (hUo : I
       rw [mem_ball_zero_iff]
       norm_num
     have hcollide : G (moebius b (1 / 2)) = G (moebius b (-(1 / 2))) := by
-      change moebius (-a) (moebius (-b) (moebius b (1 / 2)) ^ 2)
-        = moebius (-a) (moebius (-b) (moebius b (-(1 / 2))) ^ 2)
-      rw [leftInvOn_moebius hb1 hu, leftInvOn_moebius hb1 hu']
+      have e₁ : moebius (-b) (moebius b (1 / 2)) = 1 / 2 :=
+        leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hb1 hu
+      have e₂ : moebius (-b) (moebius b (-(1 / 2))) = -(1 / 2) :=
+        leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hb1 hu'
+      simp only [hG_def]
+      rw [e₁, e₂]
       norm_num
-    have := injOn_moebius hb1 hu hu'
-      (hinj (mapsTo_moebius hb1 hu) (mapsTo_moebius hb1 hu') hcollide)
+    have := (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hb1).injOn hu hu'
+      (hinj (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hb1 hu)
+        (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hb1 hu') hcollide)
     norm_num at this
   -- Step 3: the strict Schwarz lemma.
-  have hGderiv : ‖deriv G 0‖ < 1 := norm_deriv_lt_one_of_not_injOn hGd hGm hG0 hGni
+  have hGcb : MapsTo G (ball (0 : ℂ) 1) (closedBall (G 0) 1) := by
+    rw [hG0]
+    exact hGm.mono_right ball_subset_closedBall
+  have hGderiv : ‖deriv G 0‖ < 1 := norm_deriv_lt_one_of_not_injOn one_pos hGd hGcb hGni
   -- Step 4: differentiate `G ∘ f = id` at the origin.
   have hderiv_mul : deriv G 0 * deriv f 0 = 1 := by
     have hf_at : HasDerivAt f (deriv f 0) 0 :=

--- a/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
@@ -11,17 +11,18 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 /-!
 # A strict form of the Schwarz lemma
 
-Schwarz's lemma bounds the derivative at the centre of a ball by `R₂ / R₁` when a holomorphic map
-sends `ball c R₁` into `closedBall (g c) R₂`. This file records the **strict** form: the bound is
-attained only by an injective map, so a non-injective one has `‖deriv g c‖ < R₂ / R₁`.
+Schwarz's lemma bounds the derivative at the centre of a ball by `R₂ / R₁` when a holomorphic
+map into a strictly convex complex normed space sends `ball c R₁` into `closedBall (g c) R₂`.
+This file records the **strict** form: the bound is attained only by an injective map, so a
+non-injective one has `‖deriv g c‖ < R₂ / R₁`.
 
 ## The argument
 
 Mathlib's `Complex.norm_deriv_le_div_of_mapsTo_ball` gives `‖deriv g c‖ ≤ R₂ / R₁`. In the equality
 case `Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div` — the equality case of Schwarz, available
 for `ℂ` because it is a strictly convex space — forces `g` to be the affine map
-`z ↦ g c + (z - c) * deriv g c` on the ball. The multiplier is nonzero, having norm `R₂ / R₁ > 0`,
-so that map is injective, contradicting the hypothesis.
+`z ↦ g c + (z - c) • deriv g c` on the ball. The slope is a nonzero vector, having norm
+`R₂ / R₁ > 0`, so that map is injective, contradicting the hypothesis.
 
 Both radii must be positive. With `R₂ = 0` the target is the single point `g c`, so `g` is constant
 and *not* injective, while the claimed bound `‖deriv g c‖ < 0` is false.
@@ -50,13 +51,15 @@ namespace TauCeti
 
 open Complex Set Metric
 
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] [StrictConvexSpace ℝ E]
+
 /-- **Strict Schwarz lemma.** A holomorphic map of `ball c R₁` into `closedBall (g c) R₂` that is
 **not** injective has `‖deriv g c‖ < R₂ / R₁`.
 
 Schwarz's lemma gives `‖deriv g c‖ ≤ R₂ / R₁`; in the equality case the map is affine with nonzero
-multiplier, hence injective. Both radii must be positive: for `R₂ = 0` the map is constant, so it is
+slope, hence injective. Both radii must be positive: for `R₂ = 0` the map is constant, so it is
 not injective and the strict bound fails. -/
-theorem norm_deriv_lt_div_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R₁ R₂ : ℝ} (hR₁ : 0 < R₁)
+theorem norm_deriv_lt_div_of_not_injOn {g : ℂ → E} {c : ℂ} {R₁ R₂ : ℝ} (hR₁ : 0 < R₁)
     (hR₂ : 0 < R₂) (hgd : DifferentiableOn ℂ g (ball c R₁))
     (hgm : MapsTo g (ball c R₁) (closedBall (g c) R₂)) (hgi : ¬ InjOn g (ball c R₁)) :
     ‖deriv g c‖ < R₂ / R₁ := by
@@ -72,12 +75,18 @@ theorem norm_deriv_lt_div_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R₁ R₂ : 
     exact (div_pos hR₂ hR₁).ne' heq.symm
   intro z hz w hw hzw
   rw [haff hz, haff hw] at hzw
-  simp only [dslope_same, smul_eq_mul, add_right_inj] at hzw
-  linear_combination mul_right_cancel₀ hd₀ hzw
+  simp only [dslope_same, add_right_inj] at hzw
+  -- The slope is a nonzero vector, so the affine map is injective.
+  have hsub : (z - w) • deriv g c = 0 := by
+    rw [sub_smul]
+    rw [sub_smul, sub_smul] at hzw
+    have := sub_eq_zero.mpr hzw
+    simpa using this
+  exact sub_eq_zero.mp ((smul_eq_zero.mp hsub).resolve_right hd₀)
 
 /-- **Strict Schwarz lemma, equal radii.** A holomorphic map of `ball c R` into
 `closedBall (g c) R` that is **not** injective has `‖deriv g c‖ < 1`. -/
-theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R)
+theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → E} {c : ℂ} {R : ℝ} (hR : 0 < R)
     (hgd : DifferentiableOn ℂ g (ball c R)) (hgm : MapsTo g (ball c R) (closedBall (g c) R))
     (hgi : ¬ InjOn g (ball c R)) : ‖deriv g c‖ < 1 := by
   simpa [div_self hR.ne'] using norm_deriv_lt_div_of_not_injOn hR hR hgd hgm hgi

--- a/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
@@ -1,0 +1,72 @@
+module
+
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+public import Mathlib.Analysis.Complex.Schwarz
+public import Mathlib.Analysis.Calculus.Deriv.Basic
+
+/-!
+# A strict form of the Schwarz lemma
+
+Schwarz's lemma bounds the derivative at the centre of a ball by `1` when a holomorphic map sends
+that ball into the closed ball of the same radius about the image of the centre. This file records
+the **strict** form: the bound is attained only by an injective map, so a non-injective one has
+`‖deriv g c‖ < 1`.
+
+## The argument
+
+Mathlib's `Complex.norm_deriv_le_one_of_mapsTo_ball` gives `‖deriv g c‖ ≤ 1`. In the equality case
+`Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div` — the equality case of Schwarz, available for
+`ℂ` because it is a strictly convex space — forces `g` to be the affine map
+`z ↦ g c + (z - c) * deriv g c` on the ball. The multiplier is nonzero, having norm `1`, so that map
+is injective, contradicting the hypothesis.
+
+## Main statements
+
+* `TauCeti.norm_deriv_lt_one_of_not_injOn` — the strict bound.
+
+## Coordination with upstream Mathlib
+
+The Riemann mapping theorem is being formalized upstream at
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), which proves the
+L0–L3 prerequisites internally as private lemmas. The declaration here is an explicitly
+**temporary shim**: delete it and refactor downstream consumers onto the exported Mathlib version
+once that lands.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 6 §1.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Set Metric
+
+/-- **Strict Schwarz lemma.** A holomorphic map of `ball c R` into `closedBall (g c) R` that is
+**not** injective has `‖deriv g c‖ < 1`.
+
+Schwarz's lemma gives `‖deriv g c‖ ≤ 1`; in the equality case the map is affine with nonzero
+multiplier, hence injective. -/
+theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R)
+    (hgd : DifferentiableOn ℂ g (ball c R)) (hgm : MapsTo g (ball c R) (closedBall (g c) R))
+    (hgi : ¬ InjOn g (ball c R)) : ‖deriv g c‖ < 1 := by
+  rcases (Complex.norm_deriv_le_one_of_mapsTo_ball hgd hgm hR).lt_or_eq with hlt | heq
+  · exact hlt
+  refine absurd ?_ hgi
+  -- In the equality case Schwarz forces `g z = g c + (z - c) * deriv g c`, which is injective.
+  have hds : ‖dslope g c c‖ = R / R := by
+    rw [div_self hR.ne']
+    simpa [dslope_same] using heq
+  have haff := Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div hgd hgm (mem_ball_self hR) hds
+  have hd₀ : deriv g c ≠ 0 := fun h₀ => one_ne_zero (heq.symm.trans (by rw [h₀, norm_zero]))
+  intro z hz w hw hzw
+  rw [haff hz, haff hw] at hzw
+  simp only [dslope_same, smul_eq_mul, add_right_inj] at hzw
+  linear_combination mul_right_cancel₀ hd₀ hzw
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
@@ -11,22 +11,25 @@ public import Mathlib.Analysis.Calculus.Deriv.Basic
 /-!
 # A strict form of the Schwarz lemma
 
-Schwarz's lemma bounds the derivative at the centre of a ball by `1` when a holomorphic map sends
-that ball into the closed ball of the same radius about the image of the centre. This file records
-the **strict** form: the bound is attained only by an injective map, so a non-injective one has
-`‖deriv g c‖ < 1`.
+Schwarz's lemma bounds the derivative at the centre of a ball by `R₂ / R₁` when a holomorphic map
+sends `ball c R₁` into `closedBall (g c) R₂`. This file records the **strict** form: the bound is
+attained only by an injective map, so a non-injective one has `‖deriv g c‖ < R₂ / R₁`.
 
 ## The argument
 
-Mathlib's `Complex.norm_deriv_le_one_of_mapsTo_ball` gives `‖deriv g c‖ ≤ 1`. In the equality case
-`Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div` — the equality case of Schwarz, available for
-`ℂ` because it is a strictly convex space — forces `g` to be the affine map
-`z ↦ g c + (z - c) * deriv g c` on the ball. The multiplier is nonzero, having norm `1`, so that map
-is injective, contradicting the hypothesis.
+Mathlib's `Complex.norm_deriv_le_div_of_mapsTo_ball` gives `‖deriv g c‖ ≤ R₂ / R₁`. In the equality
+case `Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div` — the equality case of Schwarz, available
+for `ℂ` because it is a strictly convex space — forces `g` to be the affine map
+`z ↦ g c + (z - c) * deriv g c` on the ball. The multiplier is nonzero, having norm `R₂ / R₁ > 0`,
+so that map is injective, contradicting the hypothesis.
+
+Both radii must be positive. With `R₂ = 0` the target is the single point `g c`, so `g` is constant
+and *not* injective, while the claimed bound `‖deriv g c‖ < 0` is false.
 
 ## Main statements
 
-* `TauCeti.norm_deriv_lt_one_of_not_injOn` — the strict bound.
+* `TauCeti.norm_deriv_lt_div_of_not_injOn` — the strict bound.
+* `TauCeti.norm_deriv_lt_one_of_not_injOn` — its equal-radius form.
 
 ## Coordination with upstream Mathlib
 
@@ -47,26 +50,36 @@ namespace TauCeti
 
 open Complex Set Metric
 
-/-- **Strict Schwarz lemma.** A holomorphic map of `ball c R` into `closedBall (g c) R` that is
-**not** injective has `‖deriv g c‖ < 1`.
+/-- **Strict Schwarz lemma.** A holomorphic map of `ball c R₁` into `closedBall (g c) R₂` that is
+**not** injective has `‖deriv g c‖ < R₂ / R₁`.
 
-Schwarz's lemma gives `‖deriv g c‖ ≤ 1`; in the equality case the map is affine with nonzero
-multiplier, hence injective. -/
-theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R)
-    (hgd : DifferentiableOn ℂ g (ball c R)) (hgm : MapsTo g (ball c R) (closedBall (g c) R))
-    (hgi : ¬ InjOn g (ball c R)) : ‖deriv g c‖ < 1 := by
-  rcases (Complex.norm_deriv_le_one_of_mapsTo_ball hgd hgm hR).lt_or_eq with hlt | heq
+Schwarz's lemma gives `‖deriv g c‖ ≤ R₂ / R₁`; in the equality case the map is affine with nonzero
+multiplier, hence injective. Both radii must be positive: for `R₂ = 0` the map is constant, so it is
+not injective and the strict bound fails. -/
+theorem norm_deriv_lt_div_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R₁ R₂ : ℝ} (hR₁ : 0 < R₁)
+    (hR₂ : 0 < R₂) (hgd : DifferentiableOn ℂ g (ball c R₁))
+    (hgm : MapsTo g (ball c R₁) (closedBall (g c) R₂)) (hgi : ¬ InjOn g (ball c R₁)) :
+    ‖deriv g c‖ < R₂ / R₁ := by
+  rcases (Complex.norm_deriv_le_div_of_mapsTo_ball hgd hgm hR₁).lt_or_eq with hlt | heq
   · exact hlt
   refine absurd ?_ hgi
   -- In the equality case Schwarz forces `g z = g c + (z - c) * deriv g c`, which is injective.
-  have hds : ‖dslope g c c‖ = R / R := by
-    rw [div_self hR.ne']
-    simpa [dslope_same] using heq
-  have haff := Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div hgd hgm (mem_ball_self hR) hds
-  have hd₀ : deriv g c ≠ 0 := fun h₀ => one_ne_zero (heq.symm.trans (by rw [h₀, norm_zero]))
+  have hds : ‖dslope g c c‖ = R₂ / R₁ := by simpa [dslope_same] using heq
+  have haff := Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div hgd hgm (mem_ball_self hR₁) hds
+  have hd₀ : deriv g c ≠ 0 := by
+    intro h₀
+    rw [h₀, norm_zero] at heq
+    exact (div_pos hR₂ hR₁).ne' heq.symm
   intro z hz w hw hzw
   rw [haff hz, haff hw] at hzw
   simp only [dslope_same, smul_eq_mul, add_right_inj] at hzw
   linear_combination mul_right_cancel₀ hd₀ hzw
+
+/-- **Strict Schwarz lemma, equal radii.** A holomorphic map of `ball c R` into
+`closedBall (g c) R` that is **not** injective has `‖deriv g c‖ < 1`. -/
+theorem norm_deriv_lt_one_of_not_injOn {g : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R)
+    (hgd : DifferentiableOn ℂ g (ball c R)) (hgm : MapsTo g (ball c R) (closedBall (g c) R))
+    (hgi : ¬ InjOn g (ball c R)) : ‖deriv g c‖ < 1 := by
+  simpa [div_self hR.ne'] using norm_deriv_lt_div_of_not_injOn hR hR hgd hgm hgi
 
 end TauCeti


### PR DESCRIPTION
The Koebe square-root step: a proper simply connected subdomain of the unit disc containing the
origin admits a holomorphic injection back into the disc, fixing the origin, whose derivative there
has norm exceeding `1`. Hence a maximizer of the derivative norm omits no value of the disc.
Advances **ConformalMapping L3** — see
[`TauCetiRoadmap/ConformalMapping/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ConformalMapping/README.md)
(roadmap intention #96).

## What this adds

`TauCeti/Analysis/Complex/Conformal/Schwarz.lean`:

* **`norm_deriv_lt_one_of_not_injOn`** — the strict Schwarz lemma, for any ball: a holomorphic map
  of `ball c R` into `closedBall (g c) R` that is *not* injective has `‖deriv g c‖ < 1`. Schwarz
  gives `≤ 1`; the equality case of `Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div` makes the
  map affine with nonzero multiplier, hence injective.

`TauCeti/Analysis/Complex/Conformal/Koebe.lean`:

* **`exists_isPointedDiscInjectionOn_one_lt_norm_deriv`** — the subdomain lemma, the engine of the
  Riemann mapping theorem: no proper subdomain is extremal.
* **`surjOn_ball_of_isMaxOn`** — a maximizer of `‖deriv · z₀‖` over the pointed disc injections of
  `Ω` is surjective onto the disc.

## The construction

Pick `a ∈ ball 0 1 \ U` and write `μ c` for the Möbius factor `z ↦ (z - c) / (1 - conj c * z)` of
`Conformal/Moebius.lean`. Since `μ a` does not vanish on the simply connected `U`, it has a
holomorphic square root `h` there (`TauCeti.exists_differentiableOn_pow_eq`). With `b := h 0`, so
`b ^ 2 = μ a 0 = -a`:

* `f := μ b ∘ h` — the improved map;
* `G := μ (-a) ∘ (· ^ 2) ∘ μ (-b)` — automorphism, squaring, automorphism.

## Why the derivative grows — through the inverse, not a computation

`deriv f 0` is never computed. Instead:

1. `G ∘ f = id` on `U`, by pure algebra: the Möbius factors cancel in pairs
   (`leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one`, twice) and the square meets `h ^ 2 = μ a`.
   This also yields `InjOn f U` for free, via `Set.LeftInvOn.injOn`.
2. `G` is **not** injective on the disc: it squares after an automorphism, so `μ b u` and `μ b (-u)`
   collide for any nonzero `u` of the disc; the proof takes `u = 1/2`. (Nothing about `b` is
   needed.)
3. Hence `‖deriv G 0‖ < 1`, by the strict Schwarz lemma above, using `G 0 = μ (-a) (-a) = 0`
   to recentre the target ball.
4. Differentiating `G ∘ f = id` at `0` — the only chain rule in the file — gives
   `deriv G 0 * deriv f 0 = 1`.

Then `‖deriv G 0‖ * ‖deriv f 0‖ = 1` with `‖deriv G 0‖ < 1` forces `1 < ‖deriv f 0‖`.

This is the classical lecture route, and it is also cheaper to formalize than computing
`deriv f 0 = (1 + ‖b‖²)/(2‖b‖)` through the threefold composition: no triple chain rule, and no
`field_simp` over three possibly-zero denominators.

## A note on the hypotheses

The subdomain lemma assumes `IsSimplyConnected U`, not merely connectedness. Connectedness alone is
false: for `U = ball 0 1 \ {1/2}` — open, connected, containing `0`, proper in the disc — any
injective holomorphic `f : U → 𝔻` is bounded, so the puncture is removable, and Schwarz applied to
the extension gives `‖deriv f 0‖ ≤ 1`. Simple connectivity is exactly what the square root needs,
and it is what the application supplies.

## Reuse

`TauCeti.exists_differentiableOn_pow_eq` (`BranchLogRoot.lean`), the ℂ-level Möbius API of
`Conformal/Moebius.lean` (`mapsTo_ball_…`, `differentiableOn_…`, `leftInvOn_…`),
`one_sub_conj_mul_ne_zero_of_norm_lt_one` (`PseudoHyperbolic.lean`), `IsPointedDiscInjectionOn`
(`ExtremalFamily.lean`), and `isOpen_image_of_injOn` / `isSimplyConnected_image_of_injOn`
(`ImageSimplyConnected.lean`). From Mathlib: `Complex.norm_deriv_le_one_of_mapsTo_ball`,
`Complex.affine_of_mapsTo_ball_of_norm_dslope_eq_div`, `dslope_same`.

The private `moebius` abbreviation is local plumbing: `Conformal/Moebius.lean` states its lemmas
about the bare expression, and this file names it so a construction juggling four such factors stays
readable. It is definitionally that expression, so those lemmas apply unchanged.

## Coordination with upstream Mathlib

The Riemann mapping theorem is being formalized upstream at
[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), which proves the
L0–L3 prerequisites internally as private lemmas. This file is an explicitly **temporary shim**:
delete it and refactor downstream consumers onto the exported Mathlib versions once those land.

## Round 1 review

All five findings are addressed in `823f236`.

* **generality** and **placement** together: the strict Schwarz lemma is now stated for an arbitrary
  `ball c R` into `closedBall (g c) R` and moved to its own `Conformal/Schwarz.lean`, ahead of the
  Koebe construction. Generalizing removed a hypothesis rather than adding one — `g 0 = 0` was only
  recentring the target ball, and `MapsTo g (ball c R) (closedBall (g c) R)` says that directly.
* **reuse**: the four private Möbius wrappers are deleted. The public
  `mapsTo_ball_…`, `differentiableOn_…` and `leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one` are
  applied directly (with `.injOn` for injectivity); the private `moebius` abbreviation is
  definitionally their subject, so they apply without unfolding. The two negated centres are bound
  once as `hna`/`hnb` rather than re-derived at each use.
* **proof-quality**: the three `change` steps are replaced by `simp only [hG_def]`, unfolding the
  local definition through its own `set` equation, and the two collision identities are named.
* **documentation**: the collision claim now reads "for any nonzero `u` in the disc — the proof uses
  `u = 1/2`", which is what the Möbius inverse law supplies.
