### PR TITLE
refactor(Analysis/Complex/Conformal): name the differentiability hypothesis, reuse the open-mapping lemma

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -6,8 +6,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
 public import TauCeti.Analysis.Complex.BranchLogRoot
+import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 import TauCeti.Analysis.Complex.Conformal.Moebius
-import Mathlib.Analysis.Complex.OpenMapping
 import Mathlib.Analysis.Convex.Contractible
 
 /-!
@@ -125,17 +125,9 @@ theorem exists_differentiableOn_injOn_mapsTo_unitBall {U : Set ℂ} (hUc : IsSim
   -- itself nonvanishing.
   obtain ⟨h, hhd, hsq, hsq_inj, hne⟩ := exists_sq_eq_sub_injOn_ne_zero hUc hUo ha
   have hinj : InjOn h U := fun z₁ hz₁ z₂ hz₂ he => hsq_inj hz₁ hz₂ (by simp only; rw [he])
-  -- `h '' U` is open: `h` is injective, hence nonconstant, on the connected `U`.
-  have hconn : IsPreconnected U := hUc.isPathConnected.isConnected.isPreconnected
-  have hanal : AnalyticOnNhd ℂ h U := hhd.analyticOnNhd hUo
+  -- `h '' U` is open, `h` being injective and holomorphic on the open `U`.
   obtain ⟨z₀, hz₀⟩ := hUc.nonempty
-  have hopen : IsOpen (h '' U) := by
-    rcases hanal.is_constant_or_isOpen hconn with hconst | hopenmap
-    · obtain ⟨w, hw⟩ := hconst
-      obtain ⟨z₁, hz₁, hz₁ne⟩ :=
-        (infinite_of_mem_nhds z₀ (hUo.mem_nhds hz₀)).nontrivial.exists_ne z₀
-      exact absurd (hinj hz₁ hz₀ (by rw [hw _ hz₁, hw _ hz₀])) hz₁ne
-    · exact hopenmap U (subset_refl U) hUo
+  have hopen : IsOpen (h '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hhd hinj
   -- The image contains a ball around `h z₀`, and `-h` avoids it.
   obtain ⟨r, hr, hball⟩ := Metric.isOpen_iff.mp hopen (h z₀) ⟨z₀, hz₀, rfl⟩
   set w₀ : ℂ := h z₀ with hw₀

--- a/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
@@ -113,4 +113,12 @@ theorem isSimplyConnected_image_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
   have : SimplyConnectedSpace ↥Ω := hΩc
   exact (Homeomorph.Set.univ ↥Ω).toHomotopyEquiv.simplyConnectedSpace
 
+/-- Deprecated compatibility alias for the old name, which named only the injectivity hypothesis. -/
+@[deprecated isOpen_image_of_differentiableOn_of_injOn (since := "2026-07-29")]
+alias isOpen_image_of_injOn := isOpen_image_of_differentiableOn_of_injOn
+
+/-- Deprecated compatibility alias for the old name, which named only the injectivity hypothesis. -/
+@[deprecated isSimplyConnected_image_of_differentiableOn_of_injOn (since := "2026-07-29")]
+alias isSimplyConnected_image_of_injOn := isSimplyConnected_image_of_differentiableOn_of_injOn
+
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
@@ -32,9 +32,9 @@ homotopy argument here.
 
 ## Main statements
 
-* `TauCeti.isOpen_image_of_injOn` — the image of an open set is open.
-* `TauCeti.isSimplyConnected_image_of_injOn` — the image of an open simply connected set is simply
-  connected.
+* `TauCeti.isOpen_image_of_differentiableOn_of_injOn` — the image of an open set is open.
+* `TauCeti.isSimplyConnected_image_of_differentiableOn_of_injOn` — the image of an open simply
+  connected set is simply connected.
 
 ## Coordination with upstream Mathlib
 
@@ -60,8 +60,8 @@ variable {Ω : Set ℂ} {g : ℂ → ℂ}
 /-- **The image of an open set under an injective holomorphic map is open.** No connectivity
 hypothesis is needed: openness is local, and on a small ball around any point of `Ω` the map is
 analytic and nonconstant, so the open mapping theorem applies there. -/
-theorem isOpen_image_of_injOn (hΩo : IsOpen Ω) (hgd : DifferentiableOn ℂ g Ω) (hgi : InjOn g Ω) :
-    IsOpen (g '' Ω) := by
+theorem isOpen_image_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
+    (hgd : DifferentiableOn ℂ g Ω) (hgi : InjOn g Ω) : IsOpen (g '' Ω) := by
   rw [isOpen_iff_forall_mem_open]
   rintro _ ⟨z, hz, rfl⟩
   obtain ⟨ε, hε, hball⟩ := Metric.isOpen_iff.mp hΩo z hz
@@ -84,13 +84,13 @@ theorem isOpen_image_of_injOn (hΩo : IsOpen Ω) (hgd : DifferentiableOn ℂ g �
 
 /-- Restricted to its open domain, an injective holomorphic map is an open map into `ℂ`: an open
 subset of the subtype `↥Ω` is `Ω` met with an open set, and the image of that is open by
-`TauCeti.isOpen_image_of_injOn`. -/
+`TauCeti.isOpen_image_of_differentiableOn_of_injOn`. -/
 private theorem isOpenMap_restrict (hΩo : IsOpen Ω) (hgd : DifferentiableOn ℂ g Ω)
     (hgi : InjOn g Ω) : IsOpenMap (Ω.restrict g) := by
   intro V hV
   obtain ⟨W, hW, rfl⟩ := isOpen_induced_iff.mp hV
   rw [Set.image_restrict]
-  exact isOpen_image_of_injOn (hW.inter hΩo) (hgd.mono inter_subset_right)
+  exact isOpen_image_of_differentiableOn_of_injOn (hW.inter hΩo) (hgd.mono inter_subset_right)
     (hgi.mono inter_subset_right)
 
 /-- **Injective holomorphic maps preserve simple connectivity.** The image of an open simply
@@ -99,8 +99,9 @@ connected set under a holomorphic map injective on it is again simply connected.
 The mathematical content beyond openness is Mathlib's
 `Topology.IsEmbedding.isSimplyConnected_image`: the restriction of `g` to `Ω` is a topological
 embedding, because it is continuous, injective, and open. -/
-theorem isSimplyConnected_image_of_injOn (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω)
-    (hgd : DifferentiableOn ℂ g Ω) (hgi : InjOn g Ω) : IsSimplyConnected (g '' Ω) := by
+theorem isSimplyConnected_image_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
+    (hΩc : IsSimplyConnected Ω) (hgd : DifferentiableOn ℂ g Ω) (hgi : InjOn g Ω) :
+    IsSimplyConnected (g '' Ω) := by
   have hemb : IsEmbedding (Ω.restrict g) :=
     (IsOpenEmbedding.of_continuous_injective_isOpenMap
       (continuousOn_iff_continuous_restrict.mp hgd.continuousOn)

--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -228,9 +228,10 @@ theorem surjOn_ball_of_isMaxOn {Ω : Set ℂ} (hΩo : IsOpen Ω) (hΩc : IsSimpl
   by_cases hUeq : g '' Ω = ball (0 : ℂ) 1
   · exact hUeq.ge
   exfalso
-  have hUo : IsOpen (g '' Ω) := isOpen_image_of_injOn hΩo hg.differentiableOn hg.injOn
+  have hUo : IsOpen (g '' Ω) :=
+    isOpen_image_of_differentiableOn_of_injOn hΩo hg.differentiableOn hg.injOn
   have hUc : IsSimplyConnected (g '' Ω) :=
-    isSimplyConnected_image_of_injOn hΩo hΩc hg.differentiableOn hg.injOn
+    isSimplyConnected_image_of_differentiableOn_of_injOn hΩo hΩc hg.differentiableOn hg.injOn
   have hU₀ : (0 : ℂ) ∈ g '' Ω := ⟨z₀, hz₀, hg.map_base⟩
   obtain ⟨f, hf, hfd1⟩ := exists_isPointedDiscInjectionOn_one_lt_norm_deriv hUo hUc hU₀
     hg.mapsTo.image_subset hUeq


### PR DESCRIPTION
Applies two review findings that arrived on #1339 *after* it had already merged, so they could not
be pushed to that branch. Both concern already-merged material, which
[`CLAUDE.md`](https://github.com/TauCetiProject/TauCeti/blob/main/.claude/CLAUDE.md) puts in scope
without a roadmap entry ("refactoring, simplifying proofs, … adopting a cleaner idiom"). Related
roadmap: [`TauCetiRoadmap/ConformalMapping/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/ConformalMapping/README.md).

## naming — the omitted hypothesis

Both public theorems of `ImageSimplyConnected.lean` advertised only `InjOn` after `_of`, though each
also requires `DifferentiableOn`:

* `isOpen_image_of_injOn` → **`isOpen_image_of_differentiableOn_of_injOn`**
* `isSimplyConnected_image_of_injOn` → **`isSimplyConnected_image_of_differentiableOn_of_injOn`**

The hypotheses now appear after `_of` in argument order. The two call sites in `Koebe.lean` are
updated.

## reuse — a duplicated open-mapping argument

`DiscInjection.lean` still hand-rolled the local open-mapping argument that
`isOpen_image_of_differentiableOn_of_injOn` packages: derive preconnectedness, upgrade to
`AnalyticOnNhd`, split on `is_constant_or_isOpen`, and rule out the constant branch by producing two
distinct points of a neighbourhood. Ten lines collapse to one call.

`hconn` and `hanal` were used nowhere else in that proof, and with the block gone
`Mathlib.Analysis.Complex.OpenMapping` is no longer needed there either, so the import is dropped.
`obtain ⟨z₀, hz₀⟩ := hUc.nonempty` stays — the base point is still needed for the image ball.

Note the direction of the dependency: `DiscInjection.lean` now imports `ImageSimplyConnected.lean`,
which imports nothing from TauCeti, so no cycle is introduced.

## Verification

`lake build` (5646 jobs), `lake exe axioms` (13440 declarations, all within
`[propext, Classical.choice, Quot.sound]`), and `scripts/lint-env.sh` all pass. No proof was
weakened: the deleted argument is the same one the lemma proves, and the renames are mechanical.

Roadmap: ConformalMapping