### PR TITLE
feat: add the mean ergodic projection

### DIFF
--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -95,7 +95,9 @@ private theorem compMeasurePreservingₗᵢ_toLinearMap_apply
       congrFun (LinearIsometry.coe_toLinearMap _) g
     _ = Lp.compMeasurePreserving T hT g := compMeasurePreservingₗ_apply T hT g
 
-private theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+/-- The fixed space is the equalizer of the continuous `Lᵖ` composition operator and the
+identity. -/
+theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     fixedSpace (𝕜 := 𝕜) (E := E) (p := p) T hT =
       (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by

--- a/TauCeti/Probability/Ergodic/MeanErgodic.lean
+++ b/TauCeti/Probability/Ergodic/MeanErgodic.lean
@@ -43,18 +43,11 @@ def metProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Lp E 2 μ →L[𝕜] Lp E 2 μ :=
   (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection
 
-/-- The mean-ergodic projection is the orthogonal projection onto the fixed space. -/
-theorem metProjection_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
-    (g : Lp E 2 μ) :
-    metProjection (𝕜 := 𝕜) T hT g =
-      (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection g :=
-  (rfl)
-
 /-- The mean-ergodic projection takes values in the fixed space. -/
 theorem metProjection_mem_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp E 2 μ) :
     metProjection (𝕜 := 𝕜) T hT g ∈ fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
-  rw [metProjection_apply]
+  rw [metProjection]
   exact Submodule.starProjection_apply_mem _ _
 
 /-- The mean-ergodic projection fixes exactly the invariant `L²` observables. -/
@@ -63,7 +56,7 @@ theorem metProjection_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ �
     (g : Lp E 2 μ) :
     metProjection (𝕜 := 𝕜) T hT g = g ↔
       g ∈ fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
-  rw [metProjection_apply]
+  rw [metProjection]
   exact Submodule.starProjection_eq_self_iff
 
 /-- The range of the mean-ergodic projection is the fixed space. -/
@@ -80,7 +73,7 @@ theorem sub_metProjection_mem_orthogonal (T : Ω → Ω) (hT : MeasurePreserving
     (g : Lp E 2 μ) :
     g - metProjection (𝕜 := 𝕜) T hT g ∈
       (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT)ᗮ := by
-  rw [metProjection_apply]
+  rw [metProjection]
   exact Submodule.sub_starProjection_mem_orthogonal _
 
 /-- The mean-ergodic projection for the identity transformation is the identity operator. -/
@@ -90,6 +83,7 @@ theorem metProjection_id :
       ContinuousLinearMap.id 𝕜 (Lp E 2 μ) := by
   apply ContinuousLinearMap.ext
   intro g
+  rw [metProjection]
   exact Submodule.starProjection_eq_self_iff.mpr
     ((mem_fixedSpace_iff (𝕜 := 𝕜) (E := E) (p := 2) (MeasurePreserving.id μ) g).2
       (Lp.compMeasurePreserving_id_apply g))

--- a/TauCeti/Probability/Ergodic/MeanErgodic.lean
+++ b/TauCeti/Probability/Ergodic/MeanErgodic.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Ergodic.FixedSpace
+public import Mathlib.Dynamics.BirkhoffSum.NormedSpace
+public import Mathlib.MeasureTheory.Function.L2Space
+import Mathlib.Analysis.InnerProductSpace.MeanErgodic
+
+/-!
+# Mean ergodic projection for measure-preserving maps
+
+This file defines the orthogonal projection from vector-valued `L²` onto the fixed space of the
+composition operator associated to a measure-preserving endomorphism. It characterizes the
+projection by membership, fixed points, its range, and the orthogonal error.
+
+The main theorem, `birkhoffAverage_tendsto_metProjection`, says that the Birkhoff averages of the
+composition operator converge in `L²` to this projection. It specializes Mathlib's von Neumann
+mean ergodic theorem
+`ContinuousLinearMap.tendsto_birkhoffAverage_orthogonalProjection` to the `L²` composition
+isometry.
+-/
+
+public section
+
+noncomputable section
+
+open Function MeasureTheory Filter
+open scoped ENNReal Topology
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [RCLike 𝕜]
+  [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
+  {μ : Measure Ω}
+
+/-- The mean-ergodic projection onto the `L²` observables fixed by composition with `T`. -/
+def metProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    Lp E 2 μ →L[𝕜] Lp E 2 μ :=
+  (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection
+
+/-- The mean-ergodic projection is the orthogonal projection onto the fixed space. -/
+theorem metProjection_apply (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E 2 μ) :
+    metProjection (𝕜 := 𝕜) T hT g =
+      (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection g :=
+  (rfl)
+
+/-- The mean-ergodic projection takes values in the fixed space. -/
+theorem metProjection_mem_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E 2 μ) :
+    metProjection (𝕜 := 𝕜) T hT g ∈ fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
+  rw [metProjection_apply]
+  exact Submodule.starProjection_apply_mem _ _
+
+/-- The mean-ergodic projection fixes exactly the invariant `L²` observables. -/
+@[simp]
+theorem metProjection_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E 2 μ) :
+    metProjection (𝕜 := 𝕜) T hT g = g ↔
+      g ∈ fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
+  rw [metProjection_apply]
+  exact Submodule.starProjection_eq_self_iff
+
+/-- The range of the mean-ergodic projection is the fixed space. -/
+@[simp]
+theorem range_metProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    (metProjection (𝕜 := 𝕜) (E := E) T hT).range =
+      fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
+  rw [metProjection]
+  exact Submodule.range_starProjection _
+
+/-- The error after mean-ergodic projection is orthogonal to the fixed space. -/
+@[simp]
+theorem sub_metProjection_mem_orthogonal (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp E 2 μ) :
+    g - metProjection (𝕜 := 𝕜) T hT g ∈
+      (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT)ᗮ := by
+  rw [metProjection_apply]
+  exact Submodule.sub_starProjection_mem_orthogonal _
+
+/-- The mean-ergodic projection for the identity transformation is the identity operator. -/
+@[simp]
+theorem metProjection_id :
+    metProjection (μ := μ) (𝕜 := 𝕜) (E := E) id (MeasurePreserving.id μ) =
+      ContinuousLinearMap.id 𝕜 (Lp E 2 μ) := by
+  apply ContinuousLinearMap.ext
+  intro g
+  exact Submodule.starProjection_eq_self_iff.mpr
+    ((mem_fixedSpace_iff (𝕜 := 𝕜) (E := E) (p := 2) (MeasurePreserving.id μ) g).2
+      (Lp.compMeasurePreserving_id_apply g))
+
+/-- The Birkhoff averages of the `L²` composition operator converge to the mean-ergodic
+projection onto its fixed space. -/
+theorem birkhoffAverage_tendsto_metProjection (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) (g : Lp E 2 μ) :
+    Tendsto
+      (birkhoffAverage 𝕜
+        (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap id · g)
+      atTop (𝓝 (metProjection (𝕜 := 𝕜) T hT g)) := by
+  let Uᵢ : Lp E 2 μ →ₗᵢ[𝕜] Lp E 2 μ := Lp.compMeasurePreservingₗᵢ 𝕜 T hT
+  let U : Lp E 2 μ →L[𝕜] Lp E 2 μ := Uᵢ.toContinuousLinearMap
+  have hU_norm : ‖U‖ ≤ 1 := Uᵢ.norm_toContinuousLinearMap_le
+  have hU := U.tendsto_birkhoffAverage_orthogonalProjection hU_norm g
+  have hspace :
+      U.eqLocus (1 : Lp E 2 μ →L[𝕜] Lp E 2 μ) =
+        fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT := by
+    simpa only [U, Uᵢ] using
+      (fixedSpace_eq_eqLocus (𝕜 := 𝕜) (E := E) (p := 2) T hT).symm
+  simpa only [U, Uᵢ, metProjection, hspace,
+    Submodule.coe_orthogonalProjectionOnto_apply] using hU
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR adds the mean-ergodic projection for a measure-preserving endomorphism: define the orthogonal projection from vector-valued `L²` onto the fixed space of its composition operator, characterize its range, fixed points, and orthogonal error, and prove that the operator's Birkhoff averages converge in `L²` to that projection.

This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 5, specifically the named generic operator-theoretic milestones `metProjection` and `birkhoffAverage_tendsto_metProjection`. It is the lowest-hanging unfinished dependency-order target because the required `fixedSpace` has landed, Mathlib already supplies the `L²` composition isometry and abstract von Neumann mean ergodic theorem, and no open PR covers the specialization.

Add `TauCeti/Probability/Ergodic/MeanErgodic.lean` (119 lines), and expose the existing `fixedSpace_eq_eqLocus` bridge in `FixedSpace.lean` with a public docstring so the specialization can identify Mathlib's equalizer projection without reproving it. Reuse Mathlib's `Lp.compMeasurePreservingₗᵢ`, `LinearIsometry.norm_toContinuousLinearMap_le`, and `ContinuousLinearMap.tendsto_birkhoffAverage_orthogonalProjection`; no Mathlib infrastructure or external formalization is vendored or adapted.

`lake build --iofail` reports `Build completed successfully (5653 jobs).` `tauceti-local-checks --base origin/main` reports `LOCAL-AXIOMS: PASS — audited 31 declaration(s) defined in 2 changed module(s).`, `LOCAL-MODULE-SYSTEM: PASS — checked 2 changed module(s).`, and `LOCAL-LINT: PASS — checked 31 declaration(s), 2 docstring candidate(s), and changed-module @[nolint] entries.`

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"birkhoffaverage-tendsto-metprojection"}-->

🤖 Prepared with Codex
