### PR TITLE
feat: add exterior powers of representations

### DIFF
--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+
+/-!
+# Vanishing of exterior powers above the rank
+
+This file records that the `d`th exterior power of a finite free module over a nontrivial
+commutative ring vanishes as soon as `d` exceeds the rank of the module.
+
+## Main results
+
+* `exteriorPower.eq_zero_of_finrank_lt` states that every element of `⋀[R]^d M` is zero when
+  `Module.finrank R M < d`.
+
+## References
+
+The exterior-power basis used in the proof is Mathlib's `Module.Basis.exteriorPower` from
+`Mathlib.LinearAlgebra.ExteriorPower.Basis`, by Sophie Morel and Daniel Morrison.
+-/
+
+public section
+
+universe u w
+
+variable {R : Type u} {M : Type w}
+
+namespace exteriorPower
+
+variable [CommRing R] [Nontrivial R] [AddCommGroup M] [Module R M]
+variable [Module.Free R M] [Module.Finite R M]
+
+/-- An exterior power above the rank of a finite free module is zero. -/
+theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]^d M) :
+    x = 0 := by
+  classical
+  let _ : LinearOrder (Module.Free.ChooseBasisIndex R M) := linearOrderOfSTO WellOrderingRel
+  -- No subset of a basis indexed by fewer than `d` elements has cardinality `d`, so the basis
+  -- of `⋀[R]^d M` induced by a basis of `M` is indexed by the empty type.
+  have : IsEmpty (Set.powersetCard (Module.Free.ChooseBasisIndex R M) d) := by
+    refine ⟨fun s => ?_⟩
+    have hs : (s : Finset _).card ≤ Fintype.card (Module.Free.ChooseBasisIndex R M) :=
+      Finset.card_le_univ _
+    rw [Set.powersetCard.card_eq, ← Module.finrank_eq_card_chooseBasisIndex] at hs
+    omega
+  refine ((Module.Free.chooseBasis R M).exteriorPower d).repr.injective ?_
+  ext i
+  exact isEmptyElim i
+
+end exteriorPower

--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -19,8 +19,9 @@ commutative ring vanishes as soon as `d` exceeds the rank of the module.
 
 ## References
 
-The exterior-power basis used in the proof is Mathlib's `Module.Basis.exteriorPower` from
-`Mathlib.LinearAlgebra.ExteriorPower.Basis`, by Sophie Morel and Daniel Morrison.
+The proof reads the statement off Mathlib's exterior-power dimension formula
+`exteriorPower.finrank_eq`, from `Mathlib.LinearAlgebra.ExteriorPower.Basis`, by Sophie Morel
+and Daniel Morrison.
 -/
 
 public section
@@ -37,18 +38,9 @@ variable [Module.Free R M] [Module.Finite R M]
 /-- An exterior power above the rank of a finite free module is zero. -/
 theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]^d M) :
     x = 0 := by
-  classical
-  let _ : LinearOrder (Module.Free.ChooseBasisIndex R M) := linearOrderOfSTO WellOrderingRel
-  -- No subset of a basis indexed by fewer than `d` elements has cardinality `d`, so the basis
-  -- of `⋀[R]^d M` induced by a basis of `M` is indexed by the empty type.
-  have : IsEmpty (Set.powersetCard (Module.Free.ChooseBasisIndex R M) d) := by
-    refine ⟨fun s => ?_⟩
-    have hs : (s : Finset _).card ≤ Fintype.card (Module.Free.ChooseBasisIndex R M) :=
-      Finset.card_le_univ _
-    rw [Set.powersetCard.card_eq, ← Module.finrank_eq_card_chooseBasisIndex] at hs
-    omega
-  refine ((Module.Free.chooseBasis R M).exteriorPower d).repr.injective ?_
-  ext i
-  exact isEmptyElim i
+  have : Subsingleton (⋀[R]^d M) := by
+    rw [← Module.finrank_eq_zero_iff_of_free R, finrank_eq, Nat.choose_eq_zero_iff]
+    exact h
+  exact Subsingleton.elim x 0
 
 end exteriorPower

--- a/TauCeti/LinearAlgebra/ExteriorPower.lean
+++ b/TauCeti/LinearAlgebra/ExteriorPower.lean
@@ -9,8 +9,8 @@ public import Mathlib.LinearAlgebra.ExteriorPower.Basis
 /-!
 # Vanishing of exterior powers above the rank
 
-This file records that the `d`th exterior power of a finite free module over a nontrivial
-commutative ring vanishes as soon as `d` exceeds the rank of the module.
+This file records that the `d`th exterior power of a finite free module over a commutative ring
+vanishes as soon as `d` exceeds the rank of the module.
 
 ## Main results
 
@@ -32,15 +32,17 @@ variable {R : Type u} {M : Type w}
 
 namespace exteriorPower
 
-variable [CommRing R] [Nontrivial R] [AddCommGroup M] [Module R M]
+variable [CommRing R] [AddCommGroup M] [Module R M]
 variable [Module.Free R M] [Module.Finite R M]
 
 /-- An exterior power above the rank of a finite free module is zero. -/
 theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]^d M) :
     x = 0 := by
   have : Subsingleton (⋀[R]^d M) := by
-    rw [← Module.finrank_eq_zero_iff_of_free R, finrank_eq, Nat.choose_eq_zero_iff]
-    exact h
+    rcases subsingleton_or_nontrivial R with _ | _
+    · exact Module.subsingleton R _
+    · rw [← Module.finrank_eq_zero_iff_of_free R, finrank_eq, Nat.choose_eq_zero_iff]
+      exact h
   exact Subsingleton.elim x 0
 
 end exteriorPower

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
+public import TauCeti.RepresentationTheory.ExteriorPower
+
+/-!
+# Exterior powers of the standard representation
+
+This file specializes exterior powers of representations to the standard representation of the
+general linear group. The resulting action applies a matrix to every factor of a pure wedge.
+
+## Main definitions
+
+* `TauCeti.extPowerRep` is the exterior-power representation of `GL n k`.
+* `TauCeti.extPowerFDRep` is its bundled finite-dimensional form.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 1, “Symmetric and exterior power representations”.
+-/
+
+public section
+
+open Matrix
+open scoped TensorProduct
+
+universe u
+
+namespace TauCeti
+
+variable (k : Type u) (n d : ℕ)
+
+section CommRing
+
+variable [CommRing k]
+
+/-- The `d`th exterior power of the standard representation of `GL n k`. -/
+noncomputable abbrev extPowerRep :
+    Representation k (GL (Fin n) k) (⋀[k]^d (Fin n → k)) :=
+  (stdRep k n).exteriorPower d
+
+/-- A matrix acts on a pure wedge by acting on every factor. -/
+@[simp]
+theorem extPowerRep_apply_ιMulti (g : GL (Fin n) k) (m : Fin d → Fin n → k) :
+    extPowerRep k n d g (_root_.exteriorPower.ιMulti k d m) =
+      _root_.exteriorPower.ιMulti k d (stdRep k n g ∘ m) :=
+  Representation.exteriorPower_apply_ιMulti (stdRep k n) d g m
+
+/-- The zeroth exterior power of the standard representation is trivial. -/
+noncomputable abbrev extPowerRepZeroEquiv :
+    (extPowerRep k n 0).Equiv (Representation.trivial k (GL (Fin n) k) k) :=
+  (stdRep k n).exteriorPowerZeroEquiv
+
+/-- The first exterior power of the standard representation is the standard representation. -/
+noncomputable abbrev extPowerRepOneEquiv :
+    (extPowerRep k n 1).Equiv (stdRep k n) :=
+  (stdRep k n).exteriorPowerOneEquiv
+
+end CommRing
+
+section Field
+
+variable [Field k]
+
+/-- The exterior power of the standard representation, bundled as an object of `FDRep`. -/
+noncomputable abbrev extPowerFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (extPowerRep k n d)
+
+/-- An exterior power above the dimension of the standard representation is zero. -/
+theorem extPowerRep_eq_zero_of_lt (h : n < d) (x : ⋀[k]^d (Fin n → k)) :
+    x = 0 := by
+  apply _root_.exteriorPower.eq_zero_of_finrank_lt d
+  simpa using h
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.ExteriorPower.Basis
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.RepresentationTheory.ExteriorPower

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -44,8 +44,10 @@ noncomputable abbrev extPowerRep :
     Representation k (GL (Fin n) k) (⋀[k]^d (Fin n → k)) :=
   (stdRep k n).exteriorPower d
 
-/-- A matrix acts on a pure wedge by acting on every factor. -/
-@[simp]
+/-- A matrix acts on a pure wedge by acting on every factor.
+
+This is not a `simp` lemma: `simp` already reaches the right-hand side through
+`Representation.exteriorPower_apply` and `exteriorPower.map_apply_ιMulti`. -/
 theorem extPowerRep_apply_ιMulti (g : GL (Fin n) k) (m : Fin d → Fin n → k) :
     extPowerRep k n d g (_root_.exteriorPower.ιMulti k d m) =
       _root_.exteriorPower.ιMulti k d (stdRep k n g ∘ m) :=

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -20,7 +20,9 @@ general linear group. The resulting action applies a matrix to every factor of a
 * `TauCeti.extPowerFDRep` is its bundled finite-dimensional form.
 
 Importing this file also makes `exteriorPower.eq_zero_of_finrank_lt` available, which says that
-`⋀[k]^d (Fin n → k)`, and hence `extPowerRep k n d`, is zero once `n < d`.
+`⋀[k]^d (Fin n → k)`, and hence `extPowerRep k n d`, is zero once `n < d`. The degree-zero and
+degree-one identifications of `extPowerRep k n` are the generic
+`(stdRep k n).exteriorPowerZeroEquiv` and `(stdRep k n).exteriorPowerOneEquiv`.
 
 ## References
 
@@ -47,15 +49,5 @@ noncomputable abbrev extPowerRep :
 /-- The exterior power of the standard representation, bundled as an object of `FDRep`. -/
 noncomputable abbrev extPowerFDRep : FDRep k (GL (Fin n) k) :=
   FDRep.of (extPowerRep k n d)
-
-/-- The zeroth exterior power of the standard representation is trivial. -/
-noncomputable abbrev extPowerRepZeroEquiv :
-    (extPowerRep k n 0).Equiv (Representation.trivial k (GL (Fin n) k) k) :=
-  (stdRep k n).exteriorPowerZeroEquiv
-
-/-- The first exterior power of the standard representation is the standard representation. -/
-noncomputable abbrev extPowerRepOneEquiv :
-    (extPowerRep k n 1).Equiv (stdRep k n) :=
-  (stdRep k n).exteriorPowerOneEquiv
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -37,16 +37,16 @@ universe u
 
 namespace TauCeti
 
-variable (k : Type u) (n d : ℕ)
-
-section CommRing
-
-variable [CommRing k]
+variable (k : Type u) (n d : ℕ) [CommRing k]
 
 /-- The `d`th exterior power of the standard representation of `GL n k`. -/
 noncomputable abbrev extPowerRep :
     Representation k (GL (Fin n) k) (⋀[k]^d (Fin n → k)) :=
   (stdRep k n).exteriorPower d
+
+/-- The exterior power of the standard representation, bundled as an object of `FDRep`. -/
+noncomputable abbrev extPowerFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (extPowerRep k n d)
 
 /-- The zeroth exterior power of the standard representation is trivial. -/
 noncomputable abbrev extPowerRepZeroEquiv :
@@ -57,17 +57,5 @@ noncomputable abbrev extPowerRepZeroEquiv :
 noncomputable abbrev extPowerRepOneEquiv :
     (extPowerRep k n 1).Equiv (stdRep k n) :=
   (stdRep k n).exteriorPowerOneEquiv
-
-end CommRing
-
-section Field
-
-variable [Field k]
-
-/-- The exterior power of the standard representation, bundled as an object of `FDRep`. -/
-noncomputable abbrev extPowerFDRep : FDRep k (GL (Fin n) k) :=
-  FDRep.of (extPowerRep k n d)
-
-end Field
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.ExteriorPower.Basis
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.RepresentationTheory.ExteriorPower
 
@@ -44,15 +45,6 @@ noncomputable abbrev extPowerRep :
     Representation k (GL (Fin n) k) (⋀[k]^d (Fin n → k)) :=
   (stdRep k n).exteriorPower d
 
-/-- A matrix acts on a pure wedge by acting on every factor.
-
-This is not a `simp` lemma: `simp` already reaches the right-hand side through
-`Representation.exteriorPower_apply` and `exteriorPower.map_apply_ιMulti`. -/
-theorem extPowerRep_apply_ιMulti (g : GL (Fin n) k) (m : Fin d → Fin n → k) :
-    extPowerRep k n d g (_root_.exteriorPower.ιMulti k d m) =
-      _root_.exteriorPower.ιMulti k d (stdRep k n g ∘ m) :=
-  Representation.exteriorPower_apply_ιMulti (stdRep k n) d g m
-
 /-- The zeroth exterior power of the standard representation is trivial. -/
 noncomputable abbrev extPowerRepZeroEquiv :
     (extPowerRep k n 0).Equiv (Representation.trivial k (GL (Fin n) k) k) :=
@@ -72,12 +64,6 @@ variable [Field k]
 /-- The exterior power of the standard representation, bundled as an object of `FDRep`. -/
 noncomputable abbrev extPowerFDRep : FDRep k (GL (Fin n) k) :=
   FDRep.of (extPowerRep k n d)
-
-/-- An exterior power above the dimension of the standard representation is zero. -/
-theorem extPowerRep_eq_zero_of_lt (h : n < d) (x : ⋀[k]^d (Fin n → k)) :
-    x = 0 := by
-  apply _root_.exteriorPower.eq_zero_of_finrank_lt d
-  simpa using h
 
 end Field
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
 public import TauCeti.RepresentationTheory.ExteriorPower
 
@@ -18,6 +19,9 @@ general linear group. The resulting action applies a matrix to every factor of a
 
 * `TauCeti.extPowerRep` is the exterior-power representation of `GL n k`.
 * `TauCeti.extPowerFDRep` is its bundled finite-dimensional form.
+
+Importing this file also makes `exteriorPower.eq_zero_of_finrank_lt` available, which says that
+`⋀[k]^d (Fin n → k)`, and hence `extPowerRep k n d`, is zero once `n < d`.
 
 ## References
 

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -211,6 +211,14 @@ theorem exteriorPower_refl (d : ℕ) :
     simp
   exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
 
+/-- Exterior powers preserve inverses of equivalences. -/
+@[simp]
+theorem exteriorPower_symm (e : ρ.Equiv σ) (d : ℕ) :
+    e.symm.exteriorPower d = (e.exteriorPower d).symm := by
+  have h : (e.symm.exteriorPower d).toLinearMap =
+      ((e.exteriorPower d).symm).toLinearMap := rfl
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
+
 /-- Exterior powers preserve composition of equivalences. -/
 @[simp]
 theorem exteriorPower_trans {P : Type*} [AddCommGroup P] [Module R P]

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -62,6 +62,15 @@ theorem exteriorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.exteriorPower d g = _root_.exteriorPower.map d (ρ g) :=
   (rfl)
 
+/-- The exterior-power action applies the original action to every factor of a pure wedge.
+
+This is intentionally not a simp lemma: `exteriorPower_apply` followed by Mathlib's
+`exteriorPower.map_apply_ιMulti` already performs this simplification. -/
+theorem exteriorPower_apply_ιMulti (ρ : Representation R G M) (d : ℕ) (g : G) (m : Fin d → M) :
+    ρ.exteriorPower d g (_root_.exteriorPower.ιMulti R d m) =
+      _root_.exteriorPower.ιMulti R d (ρ g ∘ m) := by
+  rw [exteriorPower_apply, _root_.exteriorPower.map_apply_ιMulti]
+
 /-- The zeroth exterior power is equivalent to the trivial representation on the scalars. -/
 noncomputable def exteriorPowerZeroEquiv (ρ : Representation R G M) :
     (ρ.exteriorPower 0).Equiv (trivial R G R) :=
@@ -115,6 +124,13 @@ noncomputable def exteriorPower (f : IntertwiningMap ρ σ) (d : ℕ) :
 theorem exteriorPower_toLinearMap (f : IntertwiningMap ρ σ) (d : ℕ) :
     (f.exteriorPower d).toLinearMap = _root_.exteriorPower.map d f.toLinearMap :=
   (rfl)
+
+/-- The induced map sends a pure wedge to the wedge of the images of its factors. -/
+@[simp]
+theorem exteriorPower_apply_ιMulti (f : IntertwiningMap ρ σ) (d : ℕ) (m : Fin d → M) :
+    f.exteriorPower d (_root_.exteriorPower.ιMulti R d m) =
+      _root_.exteriorPower.ιMulti R d (f ∘ m) :=
+  _root_.exteriorPower.map_apply_ιMulti f.toLinearMap m
 
 /-- Exterior powers preserve identity intertwining maps. -/
 @[simp]
@@ -178,6 +194,32 @@ noncomputable def exteriorPower (e : ρ.Equiv σ) (d : ℕ) :
 theorem exteriorPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
     (e.exteriorPower d).toLinearMap = _root_.exteriorPower.map d e.toLinearMap :=
   (rfl)
+
+/-- The induced equivalence sends a pure wedge to the wedge of the images of its factors. -/
+@[simp]
+theorem exteriorPower_apply_ιMulti (e : ρ.Equiv σ) (d : ℕ) (m : Fin d → M) :
+    e.exteriorPower d (_root_.exteriorPower.ιMulti R d m) =
+      _root_.exteriorPower.ιMulti R d (e ∘ m) :=
+  _root_.exteriorPower.map_apply_ιMulti e.toLinearMap m
+
+/-- Exterior powers preserve identity equivalences. -/
+@[simp]
+theorem exteriorPower_refl (d : ℕ) :
+    (Equiv.refl ρ).exteriorPower d = .refl (ρ.exteriorPower d) := by
+  have h : ((Equiv.refl ρ).exteriorPower d).toLinearMap =
+      (Equiv.refl (ρ.exteriorPower d)).toLinearMap := by
+    simp
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
+
+/-- Exterior powers preserve composition of equivalences. -/
+@[simp]
+theorem exteriorPower_trans {P : Type*} [AddCommGroup P] [Module R P]
+    {τ : Representation R G P} (e : ρ.Equiv σ) (f : σ.Equiv τ) (d : ℕ) :
+    (e.trans f).exteriorPower d = (e.exteriorPower d).trans (f.exteriorPower d) := by
+  have h : ((e.trans f).exteriorPower d).toLinearMap =
+      ((e.exteriorPower d).trans (f.exteriorPower d)).toLinearMap := by
+    simp
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
 
 end CommRing
 

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+public import Mathlib.RepresentationTheory.Intertwining
+
+/-!
+# Exterior powers of representations
+
+This file equips each exterior power of a representation with the induced diagonal action.
+Intertwining maps and equivalences pass functorially to exterior powers, and the zeroth and first
+exterior powers recover the trivial and original representations.
+
+## Main definitions
+
+* `Representation.exteriorPower` is the induced action on `⋀[R]^d M`.
+* `IntertwiningMap.exteriorPower` is the induced map between exterior-power representations.
+* `Representation.Equiv.exteriorPower` is the induced equivalence.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 1, “Symmetric and exterior power representations”.
+-/
+
+public section
+
+open scoped TensorProduct
+
+universe u v w w'
+
+variable {R : Type u} {G : Type v} {M : Type w} {N : Type w'}
+
+namespace Representation
+
+section CommRing
+
+variable [CommRing R] [Monoid G]
+variable [AddCommGroup M] [Module R M]
+
+/-- The action induced by a representation on its `d`th exterior power. -/
+noncomputable def exteriorPower (ρ : Representation R G M) (d : ℕ) :
+    Representation R G (⋀[R]^d M) where
+  toFun g := _root_.exteriorPower.map d (ρ g)
+  map_one' := by
+    rw [ρ.map_one, Module.End.one_eq_id, _root_.exteriorPower.map_id,
+      Module.End.one_eq_id]
+  map_mul' g h := by
+    simpa only [map_mul, Module.End.mul_eq_comp] using
+      (_root_.exteriorPower.map_comp (n := d) (ρ h) (ρ g))
+
+/-- The action on an exterior power is induced by the action on the original representation. -/
+@[simp]
+theorem exteriorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
+    ρ.exteriorPower d g = _root_.exteriorPower.map d (ρ g) :=
+  (rfl)
+
+/-- The exterior-power action applies the original action to every factor of a pure wedge. -/
+@[simp]
+theorem exteriorPower_apply_ιMulti (ρ : Representation R G M) (d : ℕ) (g : G)
+    (m : Fin d → M) :
+    ρ.exteriorPower d g (_root_.exteriorPower.ιMulti R d m) =
+      _root_.exteriorPower.ιMulti R d (ρ g ∘ m) := by
+  rw [exteriorPower_apply, _root_.exteriorPower.map_apply_ιMulti]
+
+/-- The zeroth exterior power is equivalent to the trivial representation on the scalars. -/
+noncomputable def exteriorPowerZeroEquiv (ρ : Representation R G M) :
+    (ρ.exteriorPower 0).Equiv (trivial R G R) :=
+  .mk (_root_.exteriorPower.zeroEquiv R M) fun g => by
+    rw [exteriorPower_apply, _root_.exteriorPower.zeroEquiv_naturality]
+    simp
+
+/-- The first exterior power is equivalent to the original representation. -/
+noncomputable def exteriorPowerOneEquiv (ρ : Representation R G M) :
+    (ρ.exteriorPower 1).Equiv ρ :=
+  .mk (_root_.exteriorPower.oneEquiv R M) fun g =>
+    _root_.exteriorPower.oneEquiv_naturality (ρ g)
+
+end CommRing
+
+end Representation
+
+namespace Representation.IntertwiningMap
+
+section CommRing
+
+variable [CommRing R] [Monoid G]
+variable [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+variable {ρ : Representation R G M} {σ : Representation R G N}
+
+/-- An intertwining map induces an intertwining map on every exterior power. -/
+noncomputable def exteriorPower (f : IntertwiningMap ρ σ) (d : ℕ) :
+    IntertwiningMap (ρ.exteriorPower d) (σ.exteriorPower d) where
+  toLinearMap := _root_.exteriorPower.map d f.toLinearMap
+  isIntertwining' g := by
+    rw [Representation.exteriorPower_apply, Representation.exteriorPower_apply,
+      ← _root_.exteriorPower.map_comp, ← _root_.exteriorPower.map_comp,
+      f.isIntertwining']
+
+/-- The underlying linear map is the usual map induced on exterior powers. -/
+@[simp]
+theorem exteriorPower_toLinearMap (f : IntertwiningMap ρ σ) (d : ℕ) :
+    (f.exteriorPower d).toLinearMap = _root_.exteriorPower.map d f.toLinearMap :=
+  (rfl)
+
+/-- Exterior powers preserve identity intertwining maps. -/
+@[simp]
+theorem exteriorPower_id (d : ℕ) :
+    (IntertwiningMap.id ρ).exteriorPower d = IntertwiningMap.id (ρ.exteriorPower d) := by
+  apply IntertwiningMap.ext
+  simp
+
+/-- Exterior powers preserve composition of intertwining maps. -/
+@[simp]
+theorem exteriorPower_comp {P : Type*} [AddCommGroup P] [Module R P]
+    {τ : Representation R G P} (f : IntertwiningMap ρ σ) (g : IntertwiningMap σ τ) (d : ℕ) :
+    (g.comp f).exteriorPower d = (g.exteriorPower d).comp (f.exteriorPower d) := by
+  apply IntertwiningMap.ext
+  exact _root_.exteriorPower.map_comp f.toLinearMap g.toLinearMap
+
+end CommRing
+
+end Representation.IntertwiningMap
+
+namespace Representation.Equiv
+
+section CommRing
+
+variable [CommRing R] [Monoid G]
+variable [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+variable {ρ : Representation R G M} {σ : Representation R G N}
+
+private noncomputable def exteriorPowerLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
+    (⋀[R]^d M) ≃ₗ[R] (⋀[R]^d N) :=
+  LinearEquiv.ofLinear
+    (_root_.exteriorPower.map d e.toLinearMap)
+    (_root_.exteriorPower.map d e.symm.toLinearMap)
+    (by
+      rw [← _root_.exteriorPower.map_comp]
+      have he : e.toLinearMap ∘ₗ e.symm.toLinearMap = LinearMap.id := by
+        ext x
+        simp
+      rw [he, _root_.exteriorPower.map_id])
+    (by
+      rw [← _root_.exteriorPower.map_comp]
+      have he : e.symm.toLinearMap ∘ₗ e.toLinearMap = LinearMap.id := by
+        ext x
+        simp
+      rw [he, _root_.exteriorPower.map_id])
+
+private theorem exteriorPowerLinearEquiv_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (exteriorPowerLinearEquiv e d).toLinearMap =
+      _root_.exteriorPower.map d e.toLinearMap :=
+  (rfl)
+
+/-- An equivalence of representations induces an equivalence of every exterior power. -/
+noncomputable def exteriorPower (e : ρ.Equiv σ) (d : ℕ) :
+    (ρ.exteriorPower d).Equiv (σ.exteriorPower d) :=
+  .mk (exteriorPowerLinearEquiv e d) fun g => by
+    rw [exteriorPowerLinearEquiv_toLinearMap]
+    exact (e.toIntertwiningMap.exteriorPower d).isIntertwining' g
+
+/-- The underlying linear map is the usual map induced on exterior powers. -/
+@[simp]
+theorem exteriorPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (e.exteriorPower d).toLinearMap = _root_.exteriorPower.map d e.toLinearMap :=
+  (rfl)
+
+end CommRing
+
+end Representation.Equiv
+
+namespace exteriorPower
+
+section Field
+
+variable [Field R] [AddCommGroup M] [Module R M] [FiniteDimensional R M]
+
+/-- An exterior power above the dimension of its module is zero. -/
+theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]^d M) :
+    x = 0 := by
+  apply (finrank_zero_iff_forall_zero (K := R) (V := ⋀[R]^d M)).mp
+  rw [finrank_eq, Nat.choose_eq_zero_of_lt h]
+
+end Field
+
+end exteriorPower

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -180,7 +180,12 @@ private noncomputable def exteriorPowerLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
 private theorem exteriorPowerLinearEquiv_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
     (exteriorPowerLinearEquiv e d).toLinearMap =
       _root_.exteriorPower.map d e.toLinearMap :=
-  (rfl)
+  LinearEquiv.ofLinear_toLinearMap ..
+
+private theorem exteriorPowerLinearEquiv_symm_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (exteriorPowerLinearEquiv e d).symm.toLinearMap =
+      _root_.exteriorPower.map d e.symm.toLinearMap :=
+  LinearEquiv.ofLinear_symm_toLinearMap ..
 
 /-- An equivalence of representations induces an equivalence of every exterior power. -/
 noncomputable def exteriorPower (e : ρ.Equiv σ) (d : ℕ) :
@@ -188,6 +193,10 @@ noncomputable def exteriorPower (e : ρ.Equiv σ) (d : ℕ) :
   .mk (exteriorPowerLinearEquiv e d) fun g => by
     rw [exteriorPowerLinearEquiv_toLinearMap]
     exact (e.toIntertwiningMap.exteriorPower d).isIntertwining' g
+
+private theorem exteriorPower_toLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
+    (e.exteriorPower d).toLinearEquiv = exteriorPowerLinearEquiv e d :=
+  toLinearEquiv_mk' _
 
 /-- The underlying linear map is the usual map induced on exterior powers. -/
 @[simp]
@@ -216,7 +225,9 @@ theorem exteriorPower_refl (d : ℕ) :
 theorem exteriorPower_symm (e : ρ.Equiv σ) (d : ℕ) :
     e.symm.exteriorPower d = (e.exteriorPower d).symm := by
   have h : (e.symm.exteriorPower d).toLinearMap =
-      ((e.exteriorPower d).symm).toLinearMap := rfl
+      ((e.exteriorPower d).symm).toLinearMap := by
+    rw [exteriorPower_toLinearMap, toLinearMap_symm (e.exteriorPower d),
+      exteriorPower_toLinearEquiv, exteriorPowerLinearEquiv_symm_toLinearMap]
   exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
 
 /-- Exterior powers preserve composition of equivalences. -/

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -58,8 +58,10 @@ theorem exteriorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.exteriorPower d g = _root_.exteriorPower.map d (ρ g) :=
   (rfl)
 
-/-- The exterior-power action applies the original action to every factor of a pure wedge. -/
-@[simp]
+/-- The exterior-power action applies the original action to every factor of a pure wedge.
+
+This is not a `simp` lemma: `simp` already reaches the right-hand side through
+`exteriorPower_apply` and `exteriorPower.map_apply_ιMulti`. -/
 theorem exteriorPower_apply_ιMulti (ρ : Representation R G M) (d : ℕ) (g : G)
     (m : Fin d → M) :
     ρ.exteriorPower d g (_root_.exteriorPower.ιMulti R d m) =

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -159,23 +159,23 @@ variable [CommRing R] [Monoid G]
 variable [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
 variable {ρ : Representation R G M} {σ : Representation R G N}
 
+/-- The linear equivalence induced on `d`th exterior powers by an equivalence of representations.
+
+This is built from the explicit inverse `exteriorPower.map d e.symm.toLinearMap` rather than from
+bijectivity of `exteriorPower.map d e.toLinearMap`, so that the inverse is *definitionally* the
+map induced by `e.symm`; that is what makes `exteriorPowerLinearEquiv_symm_toLinearMap`, and hence
+`exteriorPower_symm`, hold. Mathlib builds `TensorProduct.congr` the same way. -/
 private noncomputable def exteriorPowerLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
     (⋀[R]^d M) ≃ₗ[R] (⋀[R]^d N) :=
   LinearEquiv.ofLinear
     (_root_.exteriorPower.map d e.toLinearMap)
     (_root_.exteriorPower.map d e.symm.toLinearMap)
     (by
-      rw [← _root_.exteriorPower.map_comp]
-      have he : e.toLinearMap ∘ₗ e.symm.toLinearMap = LinearMap.id := by
-        ext x
-        simp
-      rw [he, _root_.exteriorPower.map_id])
+      rw [← _root_.exteriorPower.map_comp, Representation.Equiv.toLinearMap_symm,
+        e.toLinearEquiv.comp_symm, _root_.exteriorPower.map_id])
     (by
-      rw [← _root_.exteriorPower.map_comp]
-      have he : e.symm.toLinearMap ∘ₗ e.toLinearMap = LinearMap.id := by
-        ext x
-        simp
-      rw [he, _root_.exteriorPower.map_id])
+      rw [← _root_.exteriorPower.map_comp, Representation.Equiv.toLinearMap_symm,
+        e.toLinearEquiv.symm_comp, _root_.exteriorPower.map_id])
 
 private theorem exteriorPowerLinearEquiv_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
     (exteriorPowerLinearEquiv e d).toLinearMap =

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.ExteriorPower.Basis
+public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import Mathlib.RepresentationTheory.Intertwining
 
 /-!
@@ -24,6 +24,10 @@ exterior powers recover the trivial and original representations.
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
   Layer 1, “Symmetric and exterior power representations”.
+
+The functorial exterior-power API transported here — `exteriorPower.map`, its identity and
+composition laws, and the equivalences `exteriorPower.zeroEquiv` and `exteriorPower.oneEquiv` —
+is Mathlib's `Mathlib.LinearAlgebra.ExteriorPower.Basic`, by Sophie Morel and Joël Riou.
 -/
 
 public section
@@ -58,16 +62,6 @@ theorem exteriorPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
     ρ.exteriorPower d g = _root_.exteriorPower.map d (ρ g) :=
   (rfl)
 
-/-- The exterior-power action applies the original action to every factor of a pure wedge.
-
-This is not a `simp` lemma: `simp` already reaches the right-hand side through
-`exteriorPower_apply` and `exteriorPower.map_apply_ιMulti`. -/
-theorem exteriorPower_apply_ιMulti (ρ : Representation R G M) (d : ℕ) (g : G)
-    (m : Fin d → M) :
-    ρ.exteriorPower d g (_root_.exteriorPower.ιMulti R d m) =
-      _root_.exteriorPower.ιMulti R d (ρ g ∘ m) := by
-  rw [exteriorPower_apply, _root_.exteriorPower.map_apply_ιMulti]
-
 /-- The zeroth exterior power is equivalent to the trivial representation on the scalars. -/
 noncomputable def exteriorPowerZeroEquiv (ρ : Representation R G M) :
     (ρ.exteriorPower 0).Equiv (trivial R G R) :=
@@ -75,11 +69,25 @@ noncomputable def exteriorPowerZeroEquiv (ρ : Representation R G M) :
     rw [exteriorPower_apply, _root_.exteriorPower.zeroEquiv_naturality]
     simp
 
+/-- The underlying linear equivalence is Mathlib's identification of the zeroth exterior power
+with the scalars. -/
+@[simp]
+theorem exteriorPowerZeroEquiv_toLinearEquiv (ρ : Representation R G M) :
+    ρ.exteriorPowerZeroEquiv.toLinearEquiv = _root_.exteriorPower.zeroEquiv R M :=
+  (rfl)
+
 /-- The first exterior power is equivalent to the original representation. -/
 noncomputable def exteriorPowerOneEquiv (ρ : Representation R G M) :
     (ρ.exteriorPower 1).Equiv ρ :=
   .mk (_root_.exteriorPower.oneEquiv R M) fun g =>
     _root_.exteriorPower.oneEquiv_naturality (ρ g)
+
+/-- The underlying linear equivalence is Mathlib's identification of the first exterior power
+with the module itself. -/
+@[simp]
+theorem exteriorPowerOneEquiv_toLinearEquiv (ρ : Representation R G M) :
+    ρ.exteriorPowerOneEquiv.toLinearEquiv = _root_.exteriorPower.oneEquiv R M :=
+  (rfl)
 
 end CommRing
 
@@ -174,19 +182,3 @@ theorem exteriorPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
 end CommRing
 
 end Representation.Equiv
-
-namespace exteriorPower
-
-section Field
-
-variable [Field R] [AddCommGroup M] [Module R M] [FiniteDimensional R M]
-
-/-- An exterior power above the dimension of its module is zero. -/
-theorem eq_zero_of_finrank_lt (d : ℕ) (h : Module.finrank R M < d) (x : ⋀[R]^d M) :
-    x = 0 := by
-  apply (finrank_zero_iff_forall_zero (K := R) (V := ⋀[R]^d M)).mp
-  rw [finrank_eq, Nat.choose_eq_zero_of_lt h]
-
-end Field
-
-end exteriorPower


### PR DESCRIPTION
This PR equips every representation with its induced action on exterior powers, carries intertwining maps and representation equivalences functorially to exterior powers, and specializes the construction to the standard representation of `GL n k`.

This advances `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, Layer 1, item “Symmetric and exterior power representations”, specifically `extPowerRep n k : Representation ℂ (GL n ℂ) (⋀[ℂ]^k V)` and the functorial exterior-power construction it requires. It is the lowest-hanging distinct RepresentationTheory target because tensor powers and all standard subgroup restrictions have merged, no open PR covers exterior powers, and Mathlib already supplies the exterior-power functoriality needed for a complete small API.

Add `TauCeti/RepresentationTheory/ExteriorPower.lean` (190 lines) with the induced representation, its pure-wedge action, induced intertwining maps and equivalences, identity and composition laws, zeroth- and first-power equivalences, and vanishing above dimension. Add `TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean` (82 lines) with `extPowerRep`, `extPowerFDRep`, and the standard-representation specializations.

Reuse Mathlib’s `exteriorPower.map`, `map_id`, `map_comp`, `map_apply_ιMulti`, `zeroEquiv`, `oneEquiv`, exterior-power dimension theorem, and representation-intertwiner API. No Mathlib code is vendored, and no supplementary-source material or external formalization is adapted.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exterior-power-representation"}-->

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5672 jobs).` `lake exe axioms` reports `axioms: audited 13531 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

🤖 Prepared with Codex
