### PR TITLE
feat: package conformal Riemann maps

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.Conformal
+public import Mathlib.Topology.OpenPartialHomeomorph.Basic
+import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
+import TauCeti.Analysis.Complex.Conformal.InverseFunction
+
+/-!
+# Injective holomorphic maps as partial homeomorphisms
+
+An injective holomorphic map on an open subset of `ℂ` is a biholomorphism onto its image. This
+file packages that fact as an `OpenPartialHomeomorph ℂ ℂ`, so conformal-mapping results can carry
+their source, target, inverse, and topological equivalence in one existing Mathlib object.
+
+The forward map of `DifferentiableOn.toOpenPartialHomeomorph` is the original function, its source
+is the given open set, its target is the image, and its inverse is `Function.invFunOn`. The inverse
+is holomorphic by `TauCeti.DifferentiableOn.invFunOn`. Both directions are conformal: injectivity
+on an open neighbourhood forces the complex derivative to be nonzero, so Mathlib's
+`DifferentiableAt.conformalAt` applies.
+
+This is the packaging prerequisite for the conformal companion to the Riemann mapping theorem.
+It advances the `ConformalMapping/README.md` generality-bar requirement to derive packaged
+equivalence and `ConformalAt` API from a holomorphic bijection.
+
+## Main declarations
+
+* `TauCeti.DifferentiableOn.toOpenPartialHomeomorph` packages an injective holomorphic map.
+* `TauCeti.DifferentiableOn.toHomeomorphOfBijOn` packages a holomorphic bijection between open
+  sets as a homeomorphism of their subtypes.
+* `TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn` proves its pointwise conformality.
+* `TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm` proves conformality of the
+  inverse.
+
+## Coordination with upstream Mathlib
+
+This L0--L3 infrastructure overlaps the Riemann-mapping development in
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505). It is a temporary
+shim: replace it with public human-curated Mathlib API, and refactor its consumers, if that
+development exports the same packaging.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Set
+
+variable {U : Set ℂ} {f : ℂ → ℂ}
+
+/-- Package an injective holomorphic map on an open set as an open partial homeomorphism onto its
+image.
+
+On the image, `Function.invFunOn f U` selects the unique preimage in `U`; no injectivity of `f`
+outside `U` is required. -/
+noncomputable def DifferentiableOn.toOpenPartialHomeomorph
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    OpenPartialHomeomorph ℂ ℂ where
+  toPartialEquiv := hinj.toPartialEquiv f U
+  open_source := hU
+  open_target := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
+  continuousOn_toFun := hf.continuousOn
+  continuousOn_invFun := (TauCeti.DifferentiableOn.invFunOn hf hU hinj).continuousOn
+
+/-- The source of the partial homeomorphism associated to an injective holomorphic map is its
+given domain. -/
+@[simp]
+theorem DifferentiableOn.toOpenPartialHomeomorph_source
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).source = U :=
+  (rfl)
+
+/-- The target of the partial homeomorphism associated to an injective holomorphic map is its
+image. -/
+@[simp]
+theorem DifferentiableOn.toOpenPartialHomeomorph_target
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).target = f '' U :=
+  (rfl)
+
+/-- The partial homeomorphism associated to an injective holomorphic map applies as the original
+map. -/
+@[simp]
+theorem DifferentiableOn.toOpenPartialHomeomorph_apply
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) (z : ℂ) :
+    TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj z = f z :=
+  (rfl)
+
+/-- The underlying function of the partial homeomorphism associated to an injective holomorphic
+map is the original map. -/
+theorem DifferentiableOn.toOpenPartialHomeomorph_coe
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj : ℂ → ℂ) = f :=
+  funext (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hinj)
+
+/-- The inverse of the partial homeomorphism associated to an injective holomorphic map is
+`Function.invFunOn` for the specified domain. -/
+@[simp]
+theorem DifferentiableOn.toOpenPartialHomeomorph_symm_apply
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) (w : ℂ) :
+    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w =
+      Function.invFunOn f U w :=
+  (rfl)
+
+/-- The underlying inverse function of the partial homeomorphism associated to an injective
+holomorphic map is `Function.invFunOn` for the specified domain. -/
+theorem DifferentiableOn.toOpenPartialHomeomorph_coe_symm
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    ((TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm : ℂ → ℂ) =
+      Function.invFunOn f U :=
+  funext (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_symm_apply hf hU hinj)
+
+/-- Package a holomorphic bijection from an open set `U` onto a set `V` as a homeomorphism between
+the corresponding subtypes.
+
+This is the subtype equivalence carried by
+`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`, with its target identified using the supplied
+`BijOn` hypothesis. -/
+noncomputable def DifferentiableOn.toHomeomorphOfBijOn {V : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) : U ≃ₜ V :=
+  (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hbij.injOn)
+    |>.homeomorphOfImageSubsetSource
+      (by
+        rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source hf hU hbij.injOn])
+      (by
+        simpa only [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_apply hf hU hbij.injOn]
+          using hbij.image_eq)
+
+/-- The homeomorphism induced by a holomorphic bijection applies as the original map. -/
+@[simp]
+theorem DifferentiableOn.toHomeomorphOfBijOn_apply {V : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) (z : U) :
+    ((TauCeti.DifferentiableOn.toHomeomorphOfBijOn hf hU hbij z : V) : ℂ) = f z :=
+  (rfl)
+
+/-- The inverse homeomorphism induced by a holomorphic bijection applies as
+`Function.invFunOn`. -/
+@[simp]
+theorem DifferentiableOn.toHomeomorphOfBijOn_symm_apply {V : Set ℂ}
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hbij : BijOn f U V) (w : V) :
+    (((TauCeti.DifferentiableOn.toHomeomorphOfBijOn hf hU hbij).symm w : U) : ℂ) =
+      Function.invFunOn f U w :=
+  (rfl)
+
+/-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
+holomorphic on its target. -/
+theorem DifferentiableOn.toOpenPartialHomeomorph_differentiableOn_symm
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
+    DifferentiableOn ℂ
+      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm (f '' U) := by
+  rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe_symm hf hU hinj]
+  exact TauCeti.DifferentiableOn.invFunOn hf hU hinj
+
+/-- An injective holomorphic map on an open set is conformal at every point of that set. -/
+theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
+    {z : ℂ} (hz : z ∈ U) : ConformalAt f z := by
+  have hfz : AnalyticAt ℂ f z := hf.analyticAt (hU.mem_nhds hz)
+  have hderiv : deriv f z ≠ 0 :=
+    (exists_injOn_nhds_iff_deriv_ne_zero hfz).mp ⟨U, hU.mem_nhds hz, hinj⟩
+  exact hfz.differentiableAt.conformalAt hderiv
+
+/-- The open partial homeomorphism associated to an injective holomorphic map is conformal on its
+source. -/
+theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
+    {z : ℂ} (hz : z ∈ U) :
+    ConformalAt (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj) z := by
+  rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe hf hU hinj]
+  exact TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn hf hU hinj hz
+
+/-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
+conformal on its target. -/
+theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm
+    (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
+    {w : ℂ} (hw : w ∈ f '' U) :
+    ConformalAt
+      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm w := by
+  let e := TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj
+  have hinv : InjOn e.symm (f '' U) := by
+    simpa only [e, OpenPartialHomeomorph.symm_source,
+      TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target] using e.symm.injOn
+  exact TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn
+    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_differentiableOn_symm hf hU hinj)
+    (isOpen_image_of_differentiableOn_of_injOn hU hf hinj) hinv hw
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Biholomorph.lean
@@ -32,7 +32,7 @@ equivalence and `ConformalAt` API from a holomorphic bijection.
 * `TauCeti.DifferentiableOn.toHomeomorphOfBijOn` packages a holomorphic bijection between open
   sets as a homeomorphism of their subtypes.
 * `TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn` proves its pointwise conformality.
-* `TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm` proves conformality of the
+* `TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm` proves conformality of the
   inverse.
 
 ## Coordination with upstream Mathlib
@@ -58,12 +58,9 @@ On the image, `Function.invFunOn f U` selects the unique preimage in `U`; no inj
 outside `U` is required. -/
 noncomputable def DifferentiableOn.toOpenPartialHomeomorph
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
-    OpenPartialHomeomorph ℂ ℂ where
-  toPartialEquiv := hinj.toPartialEquiv f U
-  open_source := hU
-  open_target := isOpen_image_of_differentiableOn_of_injOn hU hf hinj
-  continuousOn_toFun := hf.continuousOn
-  continuousOn_invFun := (TauCeti.DifferentiableOn.invFunOn hf hU hinj).continuousOn
+    OpenPartialHomeomorph ℂ ℂ :=
+  OpenPartialHomeomorph.ofContinuousOpenRestrict (hinj.toPartialEquiv f U) hf.continuousOn
+    (isOpenMap_restrict_of_differentiableOn_of_injOn hU hf hinj) hU
 
 /-- The source of the partial homeomorphism associated to an injective holomorphic map is its
 given domain. -/
@@ -91,6 +88,7 @@ theorem DifferentiableOn.toOpenPartialHomeomorph_apply
 
 /-- The underlying function of the partial homeomorphism associated to an injective holomorphic
 map is the original map. -/
+@[simp]
 theorem DifferentiableOn.toOpenPartialHomeomorph_coe
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
     (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj : ℂ → ℂ) = f :=
@@ -107,6 +105,7 @@ theorem DifferentiableOn.toOpenPartialHomeomorph_symm_apply
 
 /-- The underlying inverse function of the partial homeomorphism associated to an injective
 holomorphic map is `Function.invFunOn` for the specified domain. -/
+@[simp]
 theorem DifferentiableOn.toOpenPartialHomeomorph_coe_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
     ((TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm : ℂ → ℂ) =
@@ -147,7 +146,7 @@ theorem DifferentiableOn.toHomeomorphOfBijOn_symm_apply {V : Set ℂ}
 
 /-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
 holomorphic on its target. -/
-theorem DifferentiableOn.toOpenPartialHomeomorph_differentiableOn_symm
+theorem DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U) :
     DifferentiableOn ℂ
       (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj).symm (f '' U) := by
@@ -165,7 +164,7 @@ theorem DifferentiableOn.conformalAt_of_isOpen_of_injOn
 
 /-- The open partial homeomorphism associated to an injective holomorphic map is conformal on its
 source. -/
-theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt
+theorem DifferentiableOn.conformalAt_toOpenPartialHomeomorph
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {z : ℂ} (hz : z ∈ U) :
     ConformalAt (TauCeti.DifferentiableOn.toOpenPartialHomeomorph hf hU hinj) z := by
@@ -174,7 +173,7 @@ theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt
 
 /-- The inverse of the open partial homeomorphism associated to an injective holomorphic map is
 conformal on its target. -/
-theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm
+theorem DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm
     (hf : DifferentiableOn ℂ f U) (hU : IsOpen U) (hinj : InjOn f U)
     {w : ℂ} (hw : w ∈ f '' U) :
     ConformalAt
@@ -184,7 +183,7 @@ theorem DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm
     simpa only [e, OpenPartialHomeomorph.symm_source,
       TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target] using e.symm.injOn
   exact TauCeti.DifferentiableOn.conformalAt_of_isOpen_of_injOn
-    (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_differentiableOn_symm hf hU hinj)
+    (TauCeti.DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hf hU hinj)
     (isOpen_image_of_differentiableOn_of_injOn hU hf hinj) hinv hw
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
@@ -85,8 +85,8 @@ theorem isOpen_image_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
 /-- Restricted to its open domain, an injective holomorphic map is an open map into `ℂ`: an open
 subset of the subtype `↥Ω` is `Ω` met with an open set, and the image of that is open by
 `TauCeti.isOpen_image_of_differentiableOn_of_injOn`. -/
-private theorem isOpenMap_restrict (hΩo : IsOpen Ω) (hgd : DifferentiableOn ℂ g Ω)
-    (hgi : InjOn g Ω) : IsOpenMap (Ω.restrict g) := by
+theorem isOpenMap_restrict_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
+    (hgd : DifferentiableOn ℂ g Ω) (hgi : InjOn g Ω) : IsOpenMap (Ω.restrict g) := by
   intro V hV
   obtain ⟨W, hW, rfl⟩ := isOpen_induced_iff.mp hV
   rw [Set.image_restrict]
@@ -105,7 +105,8 @@ theorem isSimplyConnected_image_of_differentiableOn_of_injOn (hΩo : IsOpen Ω)
   have hemb : IsEmbedding (Ω.restrict g) :=
     (IsOpenEmbedding.of_continuous_injective_isOpenMap
       (continuousOn_iff_continuous_restrict.mp hgd.continuousOn)
-      (Set.injOn_iff_injective.mp hgi) (isOpenMap_restrict hΩo hgd hgi)).isEmbedding
+      (Set.injOn_iff_injective.mp hgi)
+      (isOpenMap_restrict_of_differentiableOn_of_injOn hΩo hgd hgi)).isEmbedding
   have himg := hemb.isSimplyConnected_image (s := (univ : Set ↥Ω))
   rw [image_univ, Set.range_restrict] at himg
   refine himg.mpr ?_

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
@@ -71,8 +71,7 @@ theorem riemannMapping_openPartialHomeomorph {Ω : Set ℂ}
       DifferentiableOn ℂ e.symm (ball (0 : ℂ) 1) ∧
       (∀ z ∈ Ω, ConformalAt e z) ∧
       ∀ w ∈ ball (0 : ℂ) 1, ConformalAt e.symm w := by
-  obtain ⟨f, hbij, hfd, hinvd, -, -⟩ :=
-    exists_bijOn_ball_differentiableOn_invFunOn hΩo hΩc hΩ
+  obtain ⟨f, hbij, hfd, -⟩ := riemannMapping hΩo hΩc hΩ
   refine ⟨TauCeti.DifferentiableOn.toOpenPartialHomeomorph hfd hΩo hbij.injOn,
     ?_, ?_, ?_, ?_, ?_, ?_⟩
   · exact TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source hfd hΩo hbij.injOn
@@ -81,12 +80,13 @@ theorem riemannMapping_openPartialHomeomorph {Ω : Set ℂ}
         hbij.image_eq
   · rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe hfd hΩo hbij.injOn]
     exact hfd
-  · rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe_symm hfd hΩo hbij.injOn]
-    exact hinvd
+  · have hinv :=
+      TauCeti.DifferentiableOn.differentiableOn_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
+    simpa only [hbij.image_eq] using hinv
   · exact fun z hz =>
-      TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt hfd hΩo hbij.injOn hz
+      TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph hfd hΩo hbij.injOn hz
   · intro w hw
-    exact TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm hfd hΩo hbij.injOn
+    exact TauCeti.DifferentiableOn.conformalAt_toOpenPartialHomeomorph_symm hfd hΩo hbij.injOn
       (hbij.image_eq ▸ hw)
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean
@@ -1,0 +1,92 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Biholomorph
+public import TauCeti.Analysis.Complex.Conformal.RiemannMapping.Existence
+
+/-!
+# The Riemann map as a conformal partial homeomorphism
+
+The Riemann mapping theorem in `RiemannMapping/Existence.lean` produces a holomorphic bijection
+between a simply connected proper domain and the open unit disc, together with a holomorphic
+inverse. This file packages the same result as an `OpenPartialHomeomorph ℂ ℂ`. Its source and
+target are exactly the domain and the disc, and both it and its inverse are holomorphic and
+conformal on those sets.
+
+This is the packaged-equivalence and `ConformalAt` companion required by the generality bar in
+`TauCetiRoadmap/ConformalMapping/README.md`: the roadmap asks that the unbundled Riemann-map
+statement be accompanied by the natural equivalence and conformality API.
+
+## Main result
+
+* `TauCeti.riemannMapping_openPartialHomeomorph` — a Riemann map packaged with its inverse,
+  source, target, holomorphy, and conformality.
+* `TauCeti.riemannMapping_homeomorph` — the resulting homeomorphism
+  `Ω ≃ₜ Complex.UnitDisc`.
+
+## Coordination with upstream Mathlib
+
+The Riemann mapping theorem is being formalized upstream in
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505). This L3 theorem is
+an explicitly temporary shim: delete it and refactor consumers to the public human-curated
+Mathlib theorem and packaging once those land.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 6 §1.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Metric Set
+
+/-- **The Riemann mapping theorem as a homeomorphism.** A simply connected open proper subset of
+`ℂ`, regarded as a subtype, is homeomorphic to `Complex.UnitDisc`.
+
+The homeomorphism is induced by the holomorphic bijection supplied by `TauCeti.riemannMapping`;
+its forward and inverse formulas are
+`DifferentiableOn.toHomeomorphOfBijOn_apply` and
+`DifferentiableOn.toHomeomorphOfBijOn_symm_apply`. -/
+theorem riemannMapping_homeomorph {Ω : Set ℂ}
+    (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) (hΩ : Ω ≠ univ) :
+    Nonempty (Ω ≃ₜ Complex.UnitDisc) := by
+  obtain ⟨f, hbij, hfd, -⟩ := riemannMapping hΩo hΩc hΩ
+  exact ⟨TauCeti.DifferentiableOn.toHomeomorphOfBijOn hfd hΩo hbij⟩
+
+/-- **The Riemann mapping theorem as a conformal open partial homeomorphism.** A simply connected
+open proper subset `Ω` of `ℂ` is the source of an open partial homeomorphism whose target is the
+open unit disc. The map and its inverse are holomorphic and conformal throughout their respective
+domains. -/
+theorem riemannMapping_openPartialHomeomorph {Ω : Set ℂ}
+    (hΩo : IsOpen Ω) (hΩc : IsSimplyConnected Ω) (hΩ : Ω ≠ univ) :
+    ∃ e : OpenPartialHomeomorph ℂ ℂ,
+      e.source = Ω ∧
+      e.target = ball (0 : ℂ) 1 ∧
+      DifferentiableOn ℂ e Ω ∧
+      DifferentiableOn ℂ e.symm (ball (0 : ℂ) 1) ∧
+      (∀ z ∈ Ω, ConformalAt e z) ∧
+      ∀ w ∈ ball (0 : ℂ) 1, ConformalAt e.symm w := by
+  obtain ⟨f, hbij, hfd, hinvd, -, -⟩ :=
+    exists_bijOn_ball_differentiableOn_invFunOn hΩo hΩc hΩ
+  refine ⟨TauCeti.DifferentiableOn.toOpenPartialHomeomorph hfd hΩo hbij.injOn,
+    ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · exact TauCeti.DifferentiableOn.toOpenPartialHomeomorph_source hfd hΩo hbij.injOn
+  · exact
+      (TauCeti.DifferentiableOn.toOpenPartialHomeomorph_target hfd hΩo hbij.injOn).trans
+        hbij.image_eq
+  · rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe hfd hΩo hbij.injOn]
+    exact hfd
+  · rw [TauCeti.DifferentiableOn.toOpenPartialHomeomorph_coe_symm hfd hΩo hbij.injOn]
+    exact hinvd
+  · exact fun z hz =>
+      TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt hfd hΩo hbij.injOn hz
+  · intro w hw
+    exact TauCeti.DifferentiableOn.toOpenPartialHomeomorph_conformalAt_symm hfd hΩo hbij.injOn
+      (hbij.image_eq ▸ hw)
+
+end TauCeti


### PR DESCRIPTION
This PR packages an injective holomorphic map on an open subset of `ℂ` as Mathlib's existing `OpenPartialHomeomorph`, identifies its inverse with `Function.invFunOn`, and proves that both directions are holomorphic and conformal. It also packages a holomorphic `BijOn` as a subtype homeomorphism and specializes both constructions to the existing Riemann mapping theorem.

This advances `TauCetiRoadmap/ConformalMapping/README.md`, the Generality bar item “Conformal isomorphism = holomorphic bijection,” specifically its instruction to “derive the packaged `≃` / `ConformalAt` API as companions.” It is the lowest-hanging distinct ConformalMapping target because the core L0–L3 analytic theorems and real/line/circle reflection are already on `main`, while Mathlib already supplies the apparent remaining easy L0 target Morera through `Complex.isConservativeOn_and_continuousOn_iff_isDifferentiableOn`; no open PR covers the missing packaged Riemann-map API.

Add `TauCeti/Analysis/Complex/Conformal/Biholomorph.lean` (190 lines) with the generic packaging, its characteristic source/target/forward/inverse formulas, the subtype homeomorphism, and conformality in both directions. Add `TauCeti/Analysis/Complex/Conformal/RiemannMapping/Conformal.lean` (92 lines) with `riemannMapping_homeomorph` and `riemannMapping_openPartialHomeomorph`.

Reuse Mathlib's `Set.InjOn.toPartialEquiv`, `OpenPartialHomeomorph`, and `DifferentiableAt.conformalAt`, together with Tau Ceti's existing open-image and holomorphic-inverse theorems. Vendor no Mathlib infrastructure and copy or adapt no external formalization. Per the roadmap's L0–L3 coordination clause, treat this API as a temporary shim for the human-curated Riemann-mapping work in `Mathlib.Analysis.Complex.RiemannMapping` and [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), replacing it if matching public upstream packaging lands.

`lake build --iofail` reports `Build completed successfully (5656 jobs).` `tauceti-local-checks --base origin/main` reports `LOCAL-AXIOMS: PASS — audited 21 declaration(s) defined in 2 changed module(s).`, `LOCAL-MODULE-SYSTEM: PASS — checked 2 changed module(s).`, and `LOCAL-LINT: PASS — checked 21 declaration(s), 2 docstring candidate(s), and changed-module @[nolint] entries.`

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"riemann-mapping-conformalat-api"}-->

🤖 Prepared with Codex
