### PR TITLE
refactor(Contour): promote the far-from-pole principal value to the PV API

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -176,6 +176,24 @@ theorem HasCauchyPVAt.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z�
     HasCauchyPVAt γ a b f z₀ L :=
   ⟨hint, htendsto⟩
 
+/-- **Away from the pole the principal value is the ordinary integral.** On an interval where the
+curve keeps distance `≥ m > 0` from `z₀`, every small enough truncation leaves the integrand
+untouched, so the principal value at `z₀` is the plain integral. Continuity of the curve is not
+needed — the distance bound and the eventual integrability carry both clauses. The endpoints
+are not assumed ordered; the bound is stated on `uIcc a b`. -/
+theorem hasCauchyPVAt_of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ}
+    {a b m : ℝ} (hm_pos : 0 < m)
+    (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
+    (h_int_tr : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+      (fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b) :
+    HasCauchyPVAt γ a b f z₀ (∫ t in a..b, f (γ t) * deriv γ t) := by
+  have h_ev : (fun ε : ℝ => ∫ t in a..b, if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0)
+      =ᶠ[𝓝[>] (0 : ℝ)] fun _ => ∫ t in a..b, f (γ t) * deriv γ t := by
+    filter_upwards [Ioo_mem_nhdsGT hm_pos] with ε hε
+    refine intervalIntegral.integral_congr fun t ht => ?_
+    rw [if_pos (lt_of_lt_of_le hε.2 (h_far t ht))]
+  exact HasCauchyPVAt.intro h_int_tr (Tendsto.congr' h_ev.symm tendsto_const_nhds)
+
 /-- The convergence clause of `HasCauchyPVAt`: the excised integrals tend to the value. -/
 theorem HasCauchyPVAt.tendsto {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ} {L : ℂ}
     (h : HasCauchyPVAt γ a b f z₀ L) :

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -64,6 +64,9 @@ versus `MeromorphicOn` (on a set).
   `HasCauchyPVAt.zero`, `HasCauchyPVAt.const_mul`, `HasCauchyPVAt.add`, `HasCauchyPVAt.sum` (and the
   `CauchyPVExistsAt` forms) — the principal value is `ℂ`-linear in the integrand, including over
   finite sums.
+* `HasCauchyPVAt.of_dist_lower_bound` — if `γ` stays a positive distance from `z₀` on `[a, b]`,
+  the principal value is the ordinary integral (`cauchyPVExistsAt_of_dist_lower_bound` is the
+  existence form).
 * `HasCauchyPVAt.of_avoidance` — if `γ` avoids `z₀` on `[a, b]` and the integrand is integrable
   there, the principal value is the ordinary integral (`cauchyPVExistsAt_of_avoidance` is the
   existence form).
@@ -181,7 +184,7 @@ curve keeps distance `≥ m > 0` from `z₀`, every small enough truncation leav
 untouched, so the principal value at `z₀` is the plain integral. Continuity of the curve is not
 needed — the distance bound and the eventual integrability carry both clauses. The endpoints
 are not assumed ordered; the bound is stated on `uIcc a b`. -/
-theorem hasCauchyPVAt_of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ}
+theorem HasCauchyPVAt.of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ}
     {a b m : ℝ} (hm_pos : 0 < m)
     (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
     (h_int_tr : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
@@ -484,6 +487,14 @@ theorem HasCauchyPVAt.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} 
   · refine Filter.Tendsto.congr' ?_ (h_ab.2.add h_bc.2)
     filter_upwards [h_ab.1, h_bc.1] with ε hab_int hbc_int
     exact intervalIntegral.integral_add_adjacent_intervals hab_int hbc_int
+
+/-- Existence form of `HasCauchyPVAt.of_dist_lower_bound`. -/
+theorem cauchyPVExistsAt_of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ} {a b m : ℝ}
+    (hm_pos : 0 < m) (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
+    (h_int_tr : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
+      (fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b) :
+    CauchyPVExistsAt γ a b f z₀ :=
+  ⟨_, HasCauchyPVAt.of_dist_lower_bound hm_pos h_far h_int_tr⟩
 
 /-- Existence form of `HasCauchyPVAt.of_avoidance`. -/
 theorem cauchyPVExistsAt_of_avoidance {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}

--- a/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
+++ b/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
@@ -52,26 +52,6 @@ namespace TauCeti.Contour
 
 open Filter MeasureTheory Set Topology
 
-/-- On an interval where the curve keeps distance `≥ m > 0` from `s`, the principal value at
-`s` is the plain integral: the truncation is eventually inactive. Continuity of the curve is
-not needed — the distance bound and the truncated integrability carry the clauses. -/
-private theorem hasCauchyPVAt_of_dist_lower_bound {γ : ℝ → ℂ} {s : ℂ} {g : ℂ → ℂ}
-    {l u m : ℝ} (hlu : l ≤ u) (hm_pos : 0 < m)
-    (h_far : ∀ t ∈ Icc l u, m ≤ ‖γ t - s‖)
-    (h_int_tr : ∀ ε : ℝ, 0 < ε →
-      IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
-        MeasureTheory.volume l u) :
-    HasCauchyPVAt γ l u g s (∫ t in l..u, g (γ t) * deriv γ t) := by
-  have h_ev : (fun ε : ℝ => ∫ t in l..u, if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
-      =ᶠ[𝓝[>] (0 : ℝ)] fun _ => ∫ t in l..u, g (γ t) * deriv γ t := by
-    filter_upwards [Ioo_mem_nhdsGT hm_pos] with ε hε
-    refine intervalIntegral.integral_congr fun t ht => ?_
-    rw [uIcc_of_le hlu] at ht
-    rw [if_pos (lt_of_lt_of_le hε.2 (h_far t ht))]
-  refine hasCauchyPVAt_iff.mpr ⟨?_, Tendsto.congr' h_ev.symm tendsto_const_nhds⟩
-  filter_upwards [self_mem_nhdsWithin] with ε hε
-  exact h_int_tr ε hε
-
 /-- The truncated integrand is eventually interval-integrable on a crossing window interior to
 `[a, b]`, by restriction. -/
 private theorem eventually_intervalIntegrable_truncated_window {γ : ℝ → ℂ} {s : ℂ}
@@ -99,10 +79,11 @@ private theorem hasCauchyPVAt_plain_piece {γ : ℝ → ℂ} {s : ℂ} {g : ℂ 
     {l u : ℝ} (hA : a ≤ l) (hlu : l ≤ u) (hu : u ≤ b)
     (h_far : ∀ t ∈ Icc l u, m ≤ ‖γ t - s‖) :
     HasCauchyPVAt γ l u g s (∫ t in l..u, g (γ t) * deriv γ t) :=
-  hasCauchyPVAt_of_dist_lower_bound hlu hm_pos h_far
-    (fun ε hε => (h_int_tr ε hε).mono_set (by
+  hasCauchyPVAt_of_dist_lower_bound hm_pos (by rwa [uIcc_of_le hlu]) <| by
+    filter_upwards [self_mem_nhdsWithin] with ε hε
+    exact (h_int_tr ε hε).mono_set (by
       rw [uIcc_of_le hlu, uIcc_of_le hab]
-      exact Icc_subset_Icc hA hu))
+      exact Icc_subset_Icc hA hu)
 
 /-- The aggregated value along a sorted crossing list: between-piece values `p` alternating
 with window values `w`. -/

--- a/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
+++ b/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
@@ -79,7 +79,7 @@ private theorem hasCauchyPVAt_plain_piece {γ : ℝ → ℂ} {s : ℂ} {g : ℂ 
     {l u : ℝ} (hA : a ≤ l) (hlu : l ≤ u) (hu : u ≤ b)
     (h_far : ∀ t ∈ Icc l u, m ≤ ‖γ t - s‖) :
     HasCauchyPVAt γ l u g s (∫ t in l..u, g (γ t) * deriv γ t) :=
-  hasCauchyPVAt_of_dist_lower_bound hm_pos (by rwa [uIcc_of_le hlu]) <| by
+  HasCauchyPVAt.of_dist_lower_bound hm_pos (by rwa [uIcc_of_le hlu]) <| by
     filter_upwards [self_mem_nhdsWithin] with ε hε
     exact (h_int_tr ε hε).mono_set (by
       rw [uIcc_of_le hlu, uIcc_of_le hab]


### PR DESCRIPTION
`hasCauchyPVAt_of_dist_lower_bound` — *away from the pole, the principal value is the ordinary integral* — was a `private` helper inside `Crossing/PVAggregation.lean`, although its statement mentions no crossing, window, or aggregation. It belongs with the rest of the `HasCauchyPVAt` introduction API in `Cauchy/PrincipalValue/Basic.lean`, and this moves it there as a public declaration.

## The relocation also weakens it, twice

Neither strengthening was used by the proof:

* **Orientation.** The hypothesis `l ≤ u` is dropped; the statement is now over `Set.uIcc a b`, so it holds for either orientation of the interval.
* **Truncated integrability.** Required only *eventually* along `𝓝[>] 0` (`∀ᶠ ε in 𝓝[>] 0, …`) rather than at every `ε > 0`. The principal value is a limit as `ε ↘ 0`, so integrability at large `ε` never enters.

The sole call site, `hasCauchyPVAt_plain_piece`, adapts to both — it supplies the `uIcc` form by `rwa [uIcc_of_le hlu]` and the eventual form by `filter_upwards [self_mem_nhdsWithin]`.

## Relationship to #1313

This is the half of #1313 that stands on its own. That PR bundles this relocation with making `windowPieceSum` public and adding `hasCauchyPVAt_of_perWindow`, and its `reuse` rubric has asked six rounds running for `windowPieceSum` to be rebuilt on `Finset.intervalGapsWithin` — a substantial piece of `Fin`/`orderEmbOfFin` bookkeeping. Splitting lets the relocation land now and leaves #1313 genuinely single-topic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)