### PR TITLE
feat: count the Wedderburn blocks of a finite group algebra

### DIFF
--- a/TauCeti/Algebra/Matrix/Pi.lean
+++ b/TauCeti/Algebra/Matrix/Pi.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Subalgebra.Center
+public import Mathlib.Algebra.Central.Matrix
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+
+/-!
+# Finite products of matrix algebras
+
+The dimension and the center of a product `Π i, Matₙᵢ(k)` of matrix algebras over a field, both
+read off the sizes `nᵢ` alone. Such a product is what a structure theorem of Artin--Wedderburn type
+presents an algebra as, and these are the invariants such a presentation transports.
+
+* `TauCeti.finrank_pi_matrix`: the dimension of the product is `∑ᵢ nᵢ²`;
+* `TauCeti.centerPiMatrixAlgEquiv`: when every size is nonzero the center consists of the tuples of
+  scalar matrices, so it is the algebra `ι → k` of functions on the index, whose dimension is the
+  number of factors (`TauCeti.finrank_center_pi_matrix`).
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+variable (k : Type*) [Field k] {ι : Type*} (d : ι → ℕ)
+
+/-- The center of a product of nonzero matrix algebras over a field consists of the tuples of
+scalar matrices, so it is the algebra of functions on the index. -/
+noncomputable def centerPiMatrixAlgEquiv [∀ i, NeZero (d i)] :
+    Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) ≃ₐ[k] (ι → k) :=
+  centerPiAlgEquiv.trans (AlgEquiv.piCongrRight fun i =>
+    haveI : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
+    centerAlgEquivOfIsCentral k _)
+
+/-- `centerPiMatrixAlgEquiv` reads off the scalar of each component: the `i`-th component of a
+central tuple is the scalar matrix on the `i`-th value of the corresponding function. -/
+@[simp]
+theorem algebraMap_centerPiMatrixAlgEquiv_apply [∀ i, NeZero (d i)]
+    (x : Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) (i : ι) :
+    algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (centerPiMatrixAlgEquiv k d x i) =
+      (x : Π i, Matrix (Fin (d i)) (Fin (d i)) k) i := by
+  simp [centerPiMatrixAlgEquiv, AlgEquiv.piCongrRight]
+
+/-- The inverse of `centerPiMatrixAlgEquiv` assembles a function on the index into the tuple of the
+corresponding scalar matrices. -/
+@[simp]
+theorem centerPiMatrixAlgEquiv_symm_apply_coe [∀ i, NeZero (d i)] (f : ι → k) (i : ι) :
+    ((centerPiMatrixAlgEquiv k d).symm f : Π i, Matrix (Fin (d i)) (Fin (d i)) k) i =
+      algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (f i) := by
+  simp [centerPiMatrixAlgEquiv, AlgEquiv.piCongrRight]
+
+variable [Fintype ι]
+
+/-- The dimension of a finite product of matrix algebras is the sum of the squares of the sizes. -/
+theorem finrank_pi_matrix :
+    Module.finrank k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) = ∑ i, d i ^ 2 := by
+  rw [Module.finrank_pi_fintype]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Module.finrank_matrix]
+  simp [sq]
+
+/-- The center of a finite product of nonzero matrix algebras over a field has dimension the number
+of factors. -/
+theorem finrank_center_pi_matrix [∀ i, NeZero (d i)] :
+    Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) =
+      Fintype.card ι := by
+  rw [(centerPiMatrixAlgEquiv k d).toLinearEquiv.finrank_eq, Module.finrank_pi]
+
+end TauCeti

--- a/TauCeti/Algebra/Subalgebra/Center.lean
+++ b/TauCeti/Algebra/Subalgebra/Center.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Algebra.Pi
+public import Mathlib.Algebra.Algebra.Subalgebra.Pi
+public import Mathlib.Algebra.Central.Basic
+public import Mathlib.LinearAlgebra.Dimension.Finrank
+
+/-!
+# Transporting and decomposing the center of an algebra
+
+Three constructions on `Subalgebra.center` that Mathlib states only for `Subring.center`, or only
+as an equality of subalgebras, and that are needed whenever a structure theorem presents an algebra
+up to an algebra equivalence.
+
+* `TauCeti.centerCongr` transports the center along an algebra equivalence. It is the
+  `Subalgebra` counterpart of Mathlib's `Subring.centerCongr`, which sees only the ring
+  structure and therefore cannot record `R`-linearity.
+* `TauCeti.centerPiAlgEquiv` splits the center of a product of algebras as the product of the
+  centers, upgrading Mathlib's `Subalgebra.center_pi` from an equality of subalgebras of
+  `Π i, S i` to an algebra equivalence with `Π i, Subalgebra.center R (S i)`.
+* `TauCeti.centerAlgEquivOfIsCentral` identifies the center of a central algebra with the base
+  field, so that its dimension is one (`TauCeti.finrank_center_of_isCentral`).
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Semiring B] [Algebra R A] [Algebra R B]
+
+/-- An algebra equivalence carries the center onto the center. -/
+theorem map_center_eq_center (e : A ≃ₐ[R] B) :
+    (Subalgebra.center R A).map (e : A →ₐ[R] B) = Subalgebra.center R B := by
+  refine le_antisymm ?_ ?_
+  · rintro _ hx
+    obtain ⟨a, ha, rfl⟩ := Subalgebra.mem_map.mp hx
+    rw [Subalgebra.mem_center_iff] at ha ⊢
+    intro b'
+    obtain ⟨a', rfl⟩ := e.surjective b'
+    change e a' * e a = e a * e a'
+    rw [← map_mul, ← map_mul, ha a']
+  · intro b hb
+    rw [Subalgebra.mem_center_iff] at hb
+    refine Subalgebra.mem_map.mpr ⟨e.symm b, ?_, e.apply_symm_apply b⟩
+    rw [Subalgebra.mem_center_iff]
+    intro a
+    apply e.injective
+    rw [map_mul, map_mul, e.apply_symm_apply]
+    exact hb (e a)
+
+/-- The center of an algebra, transported along an algebra equivalence. -/
+@[expose] def centerCongr (e : A ≃ₐ[R] B) :
+    Subalgebra.center R A ≃ₐ[R] Subalgebra.center R B :=
+  (e.subalgebraMap _).trans (Subalgebra.equivOfEq _ _ (map_center_eq_center e))
+
+@[simp]
+theorem centerCongr_apply_coe (e : A ≃ₐ[R] B) (x : Subalgebra.center R A) :
+    (centerCongr e x : B) = e (x : A) :=
+  rfl
+
+section Pi
+
+variable {ι : Type*} {S : ι → Type*} [∀ i, Semiring (S i)] [∀ i, Algebra R (S i)]
+
+/-- An element of a product of algebras is central exactly when each of its components is. -/
+theorem mem_center_pi_iff {x : Π i, S i} :
+    x ∈ Subalgebra.center R (Π i, S i) ↔ ∀ i, x i ∈ Subalgebra.center R (S i) := by
+  rw [Subalgebra.center_pi]
+  simp
+
+/-- The center of a product of algebras is the product of their centers. -/
+@[expose] def centerPiAlgEquiv :
+    Subalgebra.center R (Π i, S i) ≃ₐ[R] Π i, Subalgebra.center R (S i) where
+  toFun x i := ⟨x.1 i, mem_center_pi_iff.mp x.2 i⟩
+  invFun y := ⟨fun i => (y i).1, mem_center_pi_iff.mpr fun i => (y i).2⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+  map_mul' _ _ := rfl
+  map_add' _ _ := rfl
+  commutes' _ := rfl
+
+@[simp]
+theorem centerPiAlgEquiv_apply_coe (x : Subalgebra.center R (Π i, S i)) (i : ι) :
+    (centerPiAlgEquiv x i : S i) = (x : Π i, S i) i :=
+  rfl
+
+end Pi
+
+section IsCentral
+
+variable (K D : Type*) [Field K] [Semiring D] [Nontrivial D] [Algebra K D]
+  [Algebra.IsCentral K D]
+
+/-- The center of a central algebra is the base field. -/
+noncomputable def centerAlgEquivOfIsCentral : Subalgebra.center K D ≃ₐ[K] K :=
+  (Subalgebra.equivOfEq _ _ (Algebra.IsCentral.center_eq_bot K D)).trans (Algebra.botEquiv K D)
+
+/-- A central algebra has a one-dimensional center. -/
+@[simp]
+theorem finrank_center_of_isCentral : Module.finrank K (Subalgebra.center K D) = 1 :=
+  ((centerAlgEquivOfIsCentral K D).toLinearEquiv.finrank_eq).trans (CommSemiring.finrank_self K)
+
+end IsCentral
+
+end TauCeti

--- a/TauCeti/Algebra/Subalgebra/Center.lean
+++ b/TauCeti/Algebra/Subalgebra/Center.lean
@@ -41,7 +41,7 @@ theorem map_center_eq_center (e : A ≃ₐ[R] B) :
     rw [Subalgebra.mem_center_iff] at ha ⊢
     intro b'
     obtain ⟨a', rfl⟩ := e.surjective b'
-    change e a' * e a = e a * e a'
+    simp only [AlgEquiv.coe_toAlgHom]
     rw [← map_mul, ← map_mul, ha a']
   · intro b hb
     rw [Subalgebra.mem_center_iff] at hb
@@ -53,14 +53,14 @@ theorem map_center_eq_center (e : A ≃ₐ[R] B) :
     exact hb (e a)
 
 /-- The center of an algebra, transported along an algebra equivalence. -/
-@[expose] def centerCongr (e : A ≃ₐ[R] B) :
+def centerCongr (e : A ≃ₐ[R] B) :
     Subalgebra.center R A ≃ₐ[R] Subalgebra.center R B :=
   (e.subalgebraMap _).trans (Subalgebra.equivOfEq _ _ (map_center_eq_center e))
 
 @[simp]
 theorem centerCongr_apply_coe (e : A ≃ₐ[R] B) (x : Subalgebra.center R A) :
-    (centerCongr e x : B) = e (x : A) :=
-  rfl
+    (centerCongr e x : B) = e (x : A) := by
+  simp [centerCongr]
 
 section Pi
 
@@ -73,7 +73,7 @@ theorem mem_center_pi_iff {x : Π i, S i} :
   simp
 
 /-- The center of a product of algebras is the product of their centers. -/
-@[expose] def centerPiAlgEquiv :
+def centerPiAlgEquiv :
     Subalgebra.center R (Π i, S i) ≃ₐ[R] Π i, Subalgebra.center R (S i) where
   toFun x i := ⟨x.1 i, mem_center_pi_iff.mp x.2 i⟩
   invFun y := ⟨fun i => (y i).1, mem_center_pi_iff.mpr fun i => (y i).2⟩
@@ -85,8 +85,8 @@ theorem mem_center_pi_iff {x : Π i, S i} :
 
 @[simp]
 theorem centerPiAlgEquiv_apply_coe (x : Subalgebra.center R (Π i, S i)) (i : ι) :
-    (centerPiAlgEquiv x i : S i) = (x : Π i, S i) i :=
-  rfl
+    (centerPiAlgEquiv x i : S i) = (x : Π i, S i) i := by
+  simp [centerPiAlgEquiv]
 
 end Pi
 
@@ -98,6 +98,18 @@ variable (K D : Type*) [Field K] [Semiring D] [Nontrivial D] [Algebra K D]
 /-- The center of a central algebra is the base field. -/
 noncomputable def centerAlgEquivOfIsCentral : Subalgebra.center K D ≃ₐ[K] K :=
   (Subalgebra.equivOfEq _ _ (Algebra.IsCentral.center_eq_bot K D)).trans (Algebra.botEquiv K D)
+
+/-- The inverse of `centerAlgEquivOfIsCentral` is the structure map of the algebra. -/
+@[simp]
+theorem coe_centerAlgEquivOfIsCentral_symm (r : K) :
+    ((centerAlgEquivOfIsCentral K D).symm r : D) = algebraMap K D r := by
+  simp [centerAlgEquivOfIsCentral]
+
+/-- `centerAlgEquivOfIsCentral` sends a central element to the scalar it is the image of. -/
+@[simp]
+theorem algebraMap_centerAlgEquivOfIsCentral (x : Subalgebra.center K D) :
+    algebraMap K D (centerAlgEquivOfIsCentral K D x) = (x : D) := by
+  rw [← coe_centerAlgEquivOfIsCentral_symm, AlgEquiv.symm_apply_apply]
 
 /-- A central algebra has a one-dimensional center. -/
 @[simp]

--- a/TauCeti/Algebra/Subalgebra/Center.lean
+++ b/TauCeti/Algebra/Subalgebra/Center.lean
@@ -62,30 +62,40 @@ theorem centerCongr_apply_coe (e : A ≃ₐ[R] B) (x : Subalgebra.center R A) :
     (centerCongr e x : B) = e (x : A) := by
   simp [centerCongr]
 
+/-- The inverse of `centerCongr e` transports the center back along `e.symm`. -/
+@[simp]
+theorem centerCongr_symm_apply_coe (e : A ≃ₐ[R] B) (y : Subalgebra.center R B) :
+    ((centerCongr e).symm y : A) = e.symm (y : B) := by
+  apply e.injective
+  rw [e.apply_symm_apply, ← centerCongr_apply_coe e, (centerCongr e).apply_symm_apply]
+
 section Pi
 
 variable {ι : Type*} {S : ι → Type*} [∀ i, Semiring (S i)] [∀ i, Algebra R (S i)]
 
-/-- An element of a product of algebras is central exactly when each of its components is. -/
-theorem mem_center_pi_iff {x : Π i, S i} :
-    x ∈ Subalgebra.center R (Π i, S i) ↔ ∀ i, x i ∈ Subalgebra.center R (S i) := by
-  rw [Subalgebra.center_pi]
-  simp
-
 /-- The center of a product of algebras is the product of their centers. -/
 def centerPiAlgEquiv :
-    Subalgebra.center R (Π i, S i) ≃ₐ[R] Π i, Subalgebra.center R (S i) where
-  toFun x i := ⟨x.1 i, mem_center_pi_iff.mp x.2 i⟩
-  invFun y := ⟨fun i => (y i).1, mem_center_pi_iff.mpr fun i => (y i).2⟩
-  left_inv _ := rfl
-  right_inv _ := rfl
-  map_mul' _ _ := rfl
-  map_add' _ _ := rfl
-  commutes' _ := rfl
+    Subalgebra.center R (Π i, S i) ≃ₐ[R] Π i, Subalgebra.center R (S i) :=
+  have mem_iff : ∀ x : Π i, S i,
+      x ∈ Subalgebra.center R (Π i, S i) ↔ ∀ i, x i ∈ Subalgebra.center R (S i) := fun _ => by
+    rw [Subalgebra.center_pi]; simp
+  { toFun := fun x i => ⟨x.1 i, (mem_iff _).mp x.2 i⟩
+    invFun := fun y => ⟨fun i => (y i).1, (mem_iff _).mpr fun i => (y i).2⟩
+    left_inv := fun _ => rfl
+    right_inv := fun _ => rfl
+    map_mul' := fun _ _ => rfl
+    map_add' := fun _ _ => rfl
+    commutes' := fun _ => rfl }
 
 @[simp]
 theorem centerPiAlgEquiv_apply_coe (x : Subalgebra.center R (Π i, S i)) (i : ι) :
     (centerPiAlgEquiv x i : S i) = (x : Π i, S i) i := by
+  simp [centerPiAlgEquiv]
+
+/-- The inverse of `centerPiAlgEquiv` assembles a tuple of central elements componentwise. -/
+@[simp]
+theorem centerPiAlgEquiv_symm_apply_coe (y : Π i, Subalgebra.center R (S i)) (i : ι) :
+    (centerPiAlgEquiv.symm y : Π i, S i) i = (y i : S i) := by
   simp [centerPiAlgEquiv]
 
 end Pi

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -75,6 +75,15 @@ noncomputable def centerPiMatrixAlgEquiv [∀ i, NeZero (d i)] :
     haveI : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
     centerAlgEquivOfIsCentral k _)
 
+/-- `centerPiMatrixAlgEquiv` reads off the scalar of each component: the `i`-th component of a
+central tuple is the scalar matrix on the `i`-th value of the corresponding function. -/
+@[simp]
+theorem algebraMap_centerPiMatrixAlgEquiv_apply [∀ i, NeZero (d i)]
+    (x : Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) (i : Fin n) :
+    algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (centerPiMatrixAlgEquiv k d x i) =
+      (x : Π i, Matrix (Fin (d i)) (Fin (d i)) k) i := by
+  simp [centerPiMatrixAlgEquiv, AlgEquiv.piCongrRight]
+
 /-- The center of a finite product of nonzero matrix algebras over a field has dimension the number
 of factors. -/
 theorem finrank_center_pi_matrix [∀ i, NeZero (d i)] :
@@ -87,14 +96,15 @@ end PiMatrix
 
 section GroupAlgebra
 
-variable (k G : Type*) [Field k] [Finite G]
+variable (k G : Type*)
 
 /-- The group algebra of a finite group has dimension the order of the group. -/
-theorem finrank_monoidAlgebra : Module.finrank k (MonoidAlgebra k G) = Nat.card G := by
+theorem finrank_monoidAlgebra [CommSemiring k] [StrongRankCondition k] [Finite G] :
+    Module.finrank k (MonoidAlgebra k G) = Nat.card G := by
   letI := Fintype.ofFinite G
   rw [Module.finrank_eq_card_basis (MonoidAlgebra.basis G k), Fintype.card_eq_nat_card]
 
-variable [Group G]
+variable [Field k] [Finite G] [Group G]
 variable {k G}
 
 /-- **The sum of the squares of the block degrees is the order of the group**: both sides compute
@@ -113,6 +123,17 @@ noncomputable def centerMonoidAlgebraAlgEquivPi {n : ℕ} {d : Fin n → ℕ} [�
     (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
     Subalgebra.center k (MonoidAlgebra k G) ≃ₐ[k] (Fin n → k) :=
   (centerCongr e).trans (centerPiMatrixAlgEquiv k d)
+
+omit [Finite G] in
+/-- `centerMonoidAlgebraAlgEquivPi e` records, block by block, the scalar that a central element of
+`k[G]` acts by: the `i`-th component of the image of `e` is that scalar matrix. -/
+@[simp]
+theorem algebraMap_centerMonoidAlgebraAlgEquivPi_apply {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k)
+    (z : Subalgebra.center k (MonoidAlgebra k G)) (i : Fin n) :
+    algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (centerMonoidAlgebraAlgEquivPi e z i) =
+      e (z : MonoidAlgebra k G) i := by
+  simp [centerMonoidAlgebraAlgEquivPi]
 
 /-- **The number of Wedderburn blocks of `k[G]` is the number of conjugacy classes of `G`**: both
 sides compute the dimension of `Z(k[G])`.

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Subalgebra.Center
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
+public import Mathlib.Algebra.Central.Matrix
+public import Mathlib.Algebra.MonoidAlgebra.Module
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import Mathlib.RepresentationTheory.Maschke
+public import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+
+/-!
+# The Wedderburn blocks of a finite group algebra
+
+Over an algebraically closed field `k` whose characteristic does not divide the order of a finite
+group `G`, Maschke's theorem makes `k[G]` semisimple and Artin--Wedderburn presents it as a finite
+product of matrix algebras `∏ᵢ Matₙᵢ(k)`. This file reads the two classical numerical invariants
+off such a presentation:
+
+* `TauCeti.sum_sq_eq_card_of_algEquiv_pi_matrix`: the degrees satisfy `∑ᵢ nᵢ² = |G|`, because both
+  sides compute `dimₖ k[G]`;
+* `TauCeti.card_eq_card_conjClasses_of_algEquiv_pi_matrix`: the **number of blocks is the number of
+  conjugacy classes** of `G`, because both sides compute `dimₖ Z(k[G])` — on one side through the
+  class-sum basis (`TauCeti.finrank_center_monoidAlgebra`), on the other because the center of a
+  product of matrix algebras over `k` is the product of their (one-dimensional) centers.
+
+`TauCeti.exists_algEquiv_pi_matrix` assembles Maschke and Artin--Wedderburn into the existence of a
+presentation, and `TauCeti.exists_algEquiv_pi_matrix_conjClasses` packages the three results: there
+is a presentation of `k[G]` indexed by the conjugacy classes of `G` whose degrees have squares
+summing to `|G|`.
+
+Two further statements about a Wedderburn presentation are deliberately not proved here, and are
+needed before the block count can be *called* the count of irreducible representations: that the
+blocks are in bijection with the isomorphism classes of simple `k[G]`-modules, and that the multiset
+of degrees does not depend on the chosen presentation. What this file supplies is the numerical
+half, which is what the dimension arguments can see.
+
+## References
+
+This implements the Layer 2 targets `exists_algEquiv_pi_matrix`, `sum_sq_dim_eq_card`,
+`center_algEquiv_pi`, and `card_irreps_eq_card_conjClasses` of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md)
+and its
+[suggested declarations](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/Suggested.lean).
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+/-! ### Products of matrix algebras -/
+
+section PiMatrix
+
+variable (k : Type*) [Field k] {n : ℕ} (d : Fin n → ℕ)
+
+/-- The dimension of a finite product of matrix algebras is the sum of the squares of the sizes. -/
+theorem finrank_pi_matrix :
+    Module.finrank k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) = ∑ i, d i ^ 2 := by
+  rw [Module.finrank_pi_fintype]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Module.finrank_matrix]
+  simp [sq]
+
+/-- The center of a finite product of nonzero matrix algebras over a field consists of the tuples of
+scalar matrices, so it is the algebra of functions on the index. -/
+noncomputable def centerPiMatrixAlgEquiv [∀ i, NeZero (d i)] :
+    Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) ≃ₐ[k] (Fin n → k) :=
+  centerPiAlgEquiv.trans (AlgEquiv.piCongrRight fun i =>
+    haveI : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
+    centerAlgEquivOfIsCentral k _)
+
+/-- The center of a finite product of nonzero matrix algebras over a field has dimension the number
+of factors. -/
+theorem finrank_center_pi_matrix [∀ i, NeZero (d i)] :
+    Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) = n := by
+  rw [(centerPiMatrixAlgEquiv k d).toLinearEquiv.finrank_eq, Module.finrank_pi, Fintype.card_fin]
+
+end PiMatrix
+
+/-! ### The group algebra -/
+
+section GroupAlgebra
+
+variable (k G : Type*) [Field k] [Finite G]
+
+/-- The group algebra of a finite group has dimension the order of the group. -/
+theorem finrank_monoidAlgebra : Module.finrank k (MonoidAlgebra k G) = Nat.card G := by
+  letI := Fintype.ofFinite G
+  rw [Module.finrank_eq_card_basis (MonoidAlgebra.basis G k), Fintype.card_eq_nat_card]
+
+variable [Group G]
+variable {k G}
+
+/-- **The sum of the squares of the block degrees is the order of the group**: both sides compute
+the dimension of `k[G]`. -/
+theorem sum_sq_eq_card_of_algEquiv_pi_matrix {n : ℕ} {d : Fin n → ℕ}
+    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
+    ∑ i, d i ^ 2 = Nat.card G :=
+  calc ∑ i, d i ^ 2
+      = Module.finrank k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) := (finrank_pi_matrix k d).symm
+    _ = Module.finrank k (MonoidAlgebra k G) := e.toLinearEquiv.finrank_eq.symm
+    _ = Nat.card G := finrank_monoidAlgebra k G
+
+/-- **The center of the group algebra splits**: a Wedderburn presentation of `k[G]` with `n` blocks
+identifies `Z(k[G])` with `k ^ n`. -/
+noncomputable def centerMonoidAlgebraAlgEquivPi {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
+    Subalgebra.center k (MonoidAlgebra k G) ≃ₐ[k] (Fin n → k) :=
+  (centerCongr e).trans (centerPiMatrixAlgEquiv k d)
+
+/-- **The number of Wedderburn blocks of `k[G]` is the number of conjugacy classes of `G`**: both
+sides compute the dimension of `Z(k[G])`.
+
+This is the numerical half of the count `#irreducibles = #conjugacy classes`; identifying the blocks
+with the isomorphism classes of simple `k[G]`-modules is a separate statement. -/
+theorem card_eq_card_conjClasses_of_algEquiv_pi_matrix {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
+    n = Nat.card (ConjClasses G) :=
+  calc n = Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) :=
+        (finrank_center_pi_matrix k d).symm
+    _ = Module.finrank k (Subalgebra.center k (MonoidAlgebra k G)) :=
+        (centerCongr e).toLinearEquiv.finrank_eq.symm
+    _ = Nat.card (ConjClasses G) := finrank_center_monoidAlgebra k G
+
+variable (k G) [NeZero (Nat.card G : k)] [IsAlgClosed k]
+
+/-- **Maschke and Artin--Wedderburn for a finite group algebra**: over an algebraically closed field
+whose characteristic does not divide `|G|`, the group algebra is a finite product of matrix algebras
+of positive size. -/
+theorem exists_algEquiv_pi_matrix :
+    ∃ (n : ℕ) (d : Fin n → ℕ), (∀ i, NeZero (d i)) ∧
+      Nonempty (MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :=
+  IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed k (MonoidAlgebra k G)
+
+/-- The Wedderburn decomposition of `k[G]`, indexed by the conjugacy classes of `G`, with the
+degrees squaring to a sum of `|G|`. -/
+theorem exists_algEquiv_pi_matrix_conjClasses :
+    ∃ d : Fin (Nat.card (ConjClasses G)) → ℕ, (∀ i, NeZero (d i)) ∧ ∑ i, d i ^ 2 = Nat.card G ∧
+      Nonempty (MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) := by
+  obtain ⟨n, d, hd, ⟨e⟩⟩ := exists_algEquiv_pi_matrix k G
+  haveI := hd
+  obtain rfl : n = Nat.card (ConjClasses G) := card_eq_card_conjClasses_of_algEquiv_pi_matrix e
+  exact ⟨d, hd, sum_sq_eq_card_of_algEquiv_pi_matrix e, ⟨e⟩⟩
+
+end GroupAlgebra
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -4,11 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.Matrix.Pi
 public import TauCeti.Algebra.Subalgebra.Center
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
-public import Mathlib.Algebra.Central.Matrix
 public import Mathlib.Algebra.MonoidAlgebra.Module
-public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.RepresentationTheory.Maschke
 public import Mathlib.RingTheory.SimpleModule.IsAlgClosed
 
@@ -20,8 +19,8 @@ group `G`, Maschke's theorem makes `k[G]` semisimple and Artin--Wedderburn prese
 product of matrix algebras `∏ᵢ Matₙᵢ(k)`. This file reads the two classical numerical invariants
 off such a presentation:
 
-* `TauCeti.sum_sq_eq_card_of_algEquiv_pi_matrix`: the degrees satisfy `∑ᵢ nᵢ² = |G|`, because both
-  sides compute `dimₖ k[G]`;
+* `TauCeti.sum_sq_eq_card_of_algEquiv_pi_matrix`: the matrix sizes satisfy `∑ᵢ nᵢ² = |G|`, because
+  both sides compute `dimₖ k[G]`;
 * `TauCeti.card_eq_card_conjClasses_of_algEquiv_pi_matrix`: the **number of blocks is the number of
   conjugacy classes** of `G`, because both sides compute `dimₖ Z(k[G])` — on one side through the
   class-sum basis (`TauCeti.finrank_center_monoidAlgebra`), on the other because the center of a
@@ -53,86 +52,46 @@ namespace TauCeti
 
 open scoped BigOperators
 
-/-! ### Products of matrix algebras -/
+section Presentation
 
-section PiMatrix
+variable {k G : Type*} [Field k] {ι : Type*} {d : ι → ℕ}
 
-variable (k : Type*) [Field k] {n : ℕ} (d : Fin n → ℕ)
-
-/-- The dimension of a finite product of matrix algebras is the sum of the squares of the sizes. -/
-theorem finrank_pi_matrix :
-    Module.finrank k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) = ∑ i, d i ^ 2 := by
-  rw [Module.finrank_pi_fintype]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  rw [Module.finrank_matrix]
-  simp [sq]
-
-/-- The center of a finite product of nonzero matrix algebras over a field consists of the tuples of
-scalar matrices, so it is the algebra of functions on the index. -/
-noncomputable def centerPiMatrixAlgEquiv [∀ i, NeZero (d i)] :
-    Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) ≃ₐ[k] (Fin n → k) :=
-  centerPiAlgEquiv.trans (AlgEquiv.piCongrRight fun i =>
-    haveI : Nonempty (Fin (d i)) := Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
-    centerAlgEquivOfIsCentral k _)
-
-/-- `centerPiMatrixAlgEquiv` reads off the scalar of each component: the `i`-th component of a
-central tuple is the scalar matrix on the `i`-th value of the corresponding function. -/
-@[simp]
-theorem algebraMap_centerPiMatrixAlgEquiv_apply [∀ i, NeZero (d i)]
-    (x : Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) (i : Fin n) :
-    algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (centerPiMatrixAlgEquiv k d x i) =
-      (x : Π i, Matrix (Fin (d i)) (Fin (d i)) k) i := by
-  simp [centerPiMatrixAlgEquiv, AlgEquiv.piCongrRight]
-
-/-- The center of a finite product of nonzero matrix algebras over a field has dimension the number
-of factors. -/
-theorem finrank_center_pi_matrix [∀ i, NeZero (d i)] :
-    Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) = n := by
-  rw [(centerPiMatrixAlgEquiv k d).toLinearEquiv.finrank_eq, Module.finrank_pi, Fintype.card_fin]
-
-end PiMatrix
-
-/-! ### The group algebra -/
-
-section GroupAlgebra
-
-variable (k G : Type*)
-
-/-- The group algebra of a finite group has dimension the order of the group. -/
-theorem finrank_monoidAlgebra [CommSemiring k] [StrongRankCondition k] [Finite G] :
-    Module.finrank k (MonoidAlgebra k G) = Nat.card G := by
-  letI := Fintype.ofFinite G
-  rw [Module.finrank_eq_card_basis (MonoidAlgebra.basis G k), Fintype.card_eq_nat_card]
-
-variable [Field k] [Finite G] [Group G]
-variable {k G}
-
-/-- **The sum of the squares of the block degrees is the order of the group**: both sides compute
+/-- **The sum of the squares of the matrix sizes is the order of the group**: both sides compute
 the dimension of `k[G]`. -/
-theorem sum_sq_eq_card_of_algEquiv_pi_matrix {n : ℕ} {d : Fin n → ℕ}
+theorem sum_sq_eq_card_of_algEquiv_pi_matrix [Monoid G] [Finite G] [Fintype ι]
     (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
     ∑ i, d i ^ 2 = Nat.card G :=
   calc ∑ i, d i ^ 2
       = Module.finrank k (Π i, Matrix (Fin (d i)) (Fin (d i)) k) := (finrank_pi_matrix k d).symm
     _ = Module.finrank k (MonoidAlgebra k G) := e.toLinearEquiv.finrank_eq.symm
-    _ = Nat.card G := finrank_monoidAlgebra k G
+    _ = Nat.card G := by
+        letI := Fintype.ofFinite G
+        rw [Module.finrank_eq_card_basis (MonoidAlgebra.basis G k), Fintype.card_eq_nat_card]
 
-/-- **The center of the group algebra splits**: a Wedderburn presentation of `k[G]` with `n` blocks
-identifies `Z(k[G])` with `k ^ n`. -/
-noncomputable def centerMonoidAlgebraAlgEquivPi {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+/-- **The center of the group algebra splits**: a Wedderburn presentation of `k[G]` with blocks
+indexed by `ι` identifies `Z(k[G])` with the algebra `ι → k` of functions on the blocks. -/
+noncomputable def centerMonoidAlgebraAlgEquivPi [Monoid G] [∀ i, NeZero (d i)]
     (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
-    Subalgebra.center k (MonoidAlgebra k G) ≃ₐ[k] (Fin n → k) :=
+    Subalgebra.center k (MonoidAlgebra k G) ≃ₐ[k] (ι → k) :=
   (centerCongr e).trans (centerPiMatrixAlgEquiv k d)
 
-omit [Finite G] in
 /-- `centerMonoidAlgebraAlgEquivPi e` records, block by block, the scalar that a central element of
 `k[G]` acts by: the `i`-th component of the image of `e` is that scalar matrix. -/
 @[simp]
-theorem algebraMap_centerMonoidAlgebraAlgEquivPi_apply {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
+theorem algebraMap_centerMonoidAlgebraAlgEquivPi_apply [Monoid G] [∀ i, NeZero (d i)]
     (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k)
-    (z : Subalgebra.center k (MonoidAlgebra k G)) (i : Fin n) :
+    (z : Subalgebra.center k (MonoidAlgebra k G)) (i : ι) :
     algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (centerMonoidAlgebraAlgEquivPi e z i) =
       e (z : MonoidAlgebra k G) i := by
+  simp [centerMonoidAlgebraAlgEquivPi]
+
+/-- The inverse of `centerMonoidAlgebraAlgEquivPi e` builds the central element acting on each
+block by the prescribed scalar. -/
+@[simp]
+theorem centerMonoidAlgebraAlgEquivPi_symm_apply [Monoid G] [∀ i, NeZero (d i)]
+    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) (f : ι → k) (i : ι) :
+    e ((centerMonoidAlgebraAlgEquivPi e).symm f : MonoidAlgebra k G) i =
+      algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (f i) := by
   simp [centerMonoidAlgebraAlgEquivPi]
 
 /-- **The number of Wedderburn blocks of `k[G]` is the number of conjugacy classes of `G`**: both
@@ -140,16 +99,21 @@ sides compute the dimension of `Z(k[G])`.
 
 This is the numerical half of the count `#irreducibles = #conjugacy classes`; identifying the blocks
 with the isomorphism classes of simple `k[G]`-modules is a separate statement. -/
-theorem card_eq_card_conjClasses_of_algEquiv_pi_matrix {n : ℕ} {d : Fin n → ℕ} [∀ i, NeZero (d i)]
-    (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
-    n = Nat.card (ConjClasses G) :=
-  calc n = Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) :=
+theorem card_eq_card_conjClasses_of_algEquiv_pi_matrix [Group G] [Finite G] [Fintype ι]
+    [∀ i, NeZero (d i)] (e : MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
+    Fintype.card ι = Nat.card (ConjClasses G) :=
+  calc Fintype.card ι
+      = Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) :=
         (finrank_center_pi_matrix k d).symm
     _ = Module.finrank k (Subalgebra.center k (MonoidAlgebra k G)) :=
         (centerCongr e).toLinearEquiv.finrank_eq.symm
     _ = Nat.card (ConjClasses G) := finrank_center_monoidAlgebra k G
 
-variable (k G) [NeZero (Nat.card G : k)] [IsAlgClosed k]
+end Presentation
+
+section Existence
+
+variable (k G : Type*) [Field k] [Group G] [Finite G] [NeZero (Nat.card G : k)] [IsAlgClosed k]
 
 /-- **Maschke and Artin--Wedderburn for a finite group algebra**: over an algebraically closed field
 whose characteristic does not divide `|G|`, the group algebra is a finite product of matrix algebras
@@ -169,13 +133,14 @@ theorem exists_algEquiv_pi_matrix_conjClasses :
       Nonempty (MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) := by
   obtain ⟨n, d, hd, ⟨e⟩⟩ := exists_algEquiv_pi_matrix k G
   haveI := hd
-  obtain rfl : n = Nat.card (ConjClasses G) := card_eq_card_conjClasses_of_algEquiv_pi_matrix e
+  obtain rfl : n = Nat.card (ConjClasses G) := by
+    simpa using card_eq_card_conjClasses_of_algEquiv_pi_matrix e
   set σ := Finite.equivFin (ConjClasses G)
   refine ⟨fun c => d (σ c), fun c => hd _, ?_,
     ⟨e.trans (AlgEquiv.piCongrLeft k (fun i => Matrix (Fin (d i)) (Fin (d i)) k) σ).symm⟩⟩
   rw [finsum_comp_equiv σ (f := fun i => d i ^ 2), finsum_eq_sum_of_fintype]
   exact sum_sq_eq_card_of_algEquiv_pi_matrix e
 
-end GroupAlgebra
+end Existence
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -138,15 +138,22 @@ theorem exists_algEquiv_pi_matrix :
       Nonempty (MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :=
   IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed k (MonoidAlgebra k G)
 
-/-- The Wedderburn decomposition of `k[G]`, indexed by the conjugacy classes of `G`, with the
-degrees squaring to a sum of `|G|`. -/
+/-- The Wedderburn decomposition of `k[G]`, with its blocks indexed by the conjugacy classes of `G`
+themselves, and with the degrees squaring to a sum of `|G|`.
+
+The indexing is by an arbitrary bijection between the blocks and the conjugacy classes: the
+statement asserts nothing about *which* class labels a given block. -/
 theorem exists_algEquiv_pi_matrix_conjClasses :
-    ∃ d : Fin (Nat.card (ConjClasses G)) → ℕ, (∀ i, NeZero (d i)) ∧ ∑ i, d i ^ 2 = Nat.card G ∧
+    ∃ d : ConjClasses G → ℕ, (∀ i, NeZero (d i)) ∧ ∑ᶠ i, d i ^ 2 = Nat.card G ∧
       Nonempty (MonoidAlgebra k G ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) := by
   obtain ⟨n, d, hd, ⟨e⟩⟩ := exists_algEquiv_pi_matrix k G
   haveI := hd
   obtain rfl : n = Nat.card (ConjClasses G) := card_eq_card_conjClasses_of_algEquiv_pi_matrix e
-  exact ⟨d, hd, sum_sq_eq_card_of_algEquiv_pi_matrix e, ⟨e⟩⟩
+  set σ := Finite.equivFin (ConjClasses G)
+  refine ⟨fun c => d (σ c), fun c => hd _, ?_,
+    ⟨e.trans (AlgEquiv.piCongrLeft k (fun i => Matrix (Fin (d i)) (Fin (d i)) k) σ).symm⟩⟩
+  rw [finsum_comp_equiv σ (f := fun i => d i ^ 2), finsum_eq_sum_of_fintype]
+  exact sum_sq_eq_card_of_algEquiv_pi_matrix e
 
 end GroupAlgebra
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.Matrix.Pi
-public import TauCeti.Algebra.Subalgebra.Center
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
 public import Mathlib.Algebra.MonoidAlgebra.Module
 public import Mathlib.RepresentationTheory.Maschke


### PR DESCRIPTION
This PR reads the two classical numerical invariants off an Artin-Wedderburn presentation of a finite group algebra: for `k` algebraically closed with `char k ∤ |G|`, Maschke and Wedderburn give `k[G] ≃ₐ[k] ∏ᵢ Matₙᵢ(k)`, and then `∑ᵢ nᵢ² = |G|` (both sides compute `dimₖ k[G]`) and the number of blocks is `#(ConjClasses G)` (both sides compute `dimₖ Z(k[G])`). The second computation runs through the class-sum basis of the center already in the repo (`TauCeti.finrank_center_monoidAlgebra`) on one side, and through the fact that the center of a product of matrix algebras over `k` is the product of their one-dimensional centers on the other. `TauCeti.exists_algEquiv_pi_matrix_conjClasses` packages the result as a presentation indexed by the conjugacy classes.

This is the Layer 2 group of targets `exists_algEquiv_pi_matrix`, `sum_sq_dim_eq_card`, `center_algEquiv_pi`, and `card_irreps_eq_card_conjClasses` of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md` ("Layer 2: Wedderburn, irreducible indexing, and the count"), pinned in that roadmap's `Suggested.lean`.

Two statements the roadmap groups with these are deliberately *not* claimed here, and the module docstring says so: that the blocks biject with the isomorphism classes of simple `k[G]`-modules, and that the multiset of degrees is independent of the chosen presentation. What lands is the numerical half, which is what the dimension arguments can see; calling the block count the count of irreducibles needs the block/simple-module dictionary, which is separate work.

Two general-algebra files supply the prerequisites, stated at that level rather than for a group algebra because nothing about them is representation-theoretic. `TauCeti/Algebra/Matrix/Pi.lean` records the dimension and the center of a finite product of matrix algebras, and `TauCeti/Algebra/Subalgebra/Center.lean` the center constructions it rests on: transport of the center along an algebra equivalence (`centerCongr`, the `Subalgebra` counterpart of Mathlib's `Subring.centerCongr`, which sees only the ring structure), the splitting of the center of a product (`centerPiAlgEquiv`, upgrading Mathlib's `Subalgebra.center_pi` from an equality of subalgebras to an algebra equivalence), and the identification of the center of a central algebra with the base field.

No material was taken from the supplementary source snapshot; everything here is built on the pinned Mathlib (Maschke, `IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`, `Algebra.IsCentral.matrix`, `Subalgebra.center_pi`) and on the existing `TauCeti/RepresentationTheory/CharacterTable/ClassSum/` files.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"card-irreps-eq-card-conjclasses"}-->

🤖 Prepared with Claude Code

