### PR TITLE
feat: chart human participation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Infrastructure policy unit tests
         run: |
           PYTHONPATH=scripts python3 scripts/test_check_bot_lakefile.py
+          PYTHONPATH=scripts python3 scripts/test_participant_graph.py
           python3 scripts/pr_status/test_stuck_alerts.py
           python3 scripts/test_roadmap_label.py
           python3 scripts/pr_status/test_pr_labels.py

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -23,7 +23,9 @@ name: Pages
 # state. The per-roadmap chart (scripts/loc_roadmap_graph.py) is regenerated the same
 # way, but from the PR labels rather than git, since roadmap attribution lives in the
 # `roadmap/<Area>` labels; it reads them via gh (hence pull-requests: read below). The
-# daily `schedule` below redeploys the site so the charts track the project as it grows.
+# participation snapshot likewise reads GitHub through gh, but deduplicates the current
+# human actors instead of reconstructing a historical series. The daily `schedule` below
+# redeploys the site so the charts track the project as it grows.
 # (This replaces the old loc-graph workflow, which committed the SVGs to main on a
 # schedule; main now sits behind a merge queue that refuses direct pushes, so generating
 # the charts in this build is the only way they refresh.)
@@ -36,16 +38,20 @@ on:
       - 'docbuild/**'
       - 'scripts/loc_graph.py'
       - 'scripts/loc_roadmap_graph.py'
+      - 'scripts/participant_graph.py'
       - '.github/workflows/pages.yml'
   schedule:
     - cron: "0 6 * * *"   # Daily 06:00 UTC: refresh the lines-of-code charts and the API docs
   workflow_dispatch:
 
 permissions:
+  # These scopes govern this repository. Reads from the other three repositories
+  # rely on their public visibility.
   contents: read
   pages: write
   id-token: write
-  pull-requests: read   # the per-roadmap chart reads PR labels via gh (scripts/loc_roadmap_graph.py)
+  issues: read      # issue participants in this repository
+  pull-requests: read # roadmap labels and PR participants
 
 concurrency:
   group: pages
@@ -107,6 +113,18 @@ jobs:
             --title "Tau Ceti — lines of Lean per roadmap" \
             --out web/static_files/loc-per-roadmap.svg \
           || echo "::warning::per-roadmap chart generation failed; keeping the committed fallback SVG"
+
+      # A current snapshot rather than a historical series: participants are deduplicated
+      # across PRs, issues, comments/reviews, and default-branch commits in all four repos.
+      # This API scan runs only in the daily/deploy build, never at request time.
+      - name: Regenerate the participation snapshot into static_files
+        working-directory: ${{ github.workspace }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          python3 scripts/participant_graph.py \
+            --out web/static_files/participation.svg \
+          || echo "::warning::participation graph generation failed; keeping the committed fallback SVG"
 
       - name: Install elan
         run: |

--- a/scripts/participant_graph.py
+++ b/scripts/participant_graph.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Generate a compact SVG snapshot of human participation across Tau Ceti.
+
+A participant is a human GitHub account that has opened a pull request or issue,
+participated in one of those conversations (including reviews), or authored a
+default-branch commit in any of the four project repositories.
+
+The PR/issue participant connections avoid downloading every individual comment.
+The largest repository still takes about a minute to scan, so this is intended for
+the daily Pages build, not for a request-time web endpoint. Pure stdlib; `gh` supplies
+authenticated GitHub access. Cross-repository queries rely on all four repositories
+remaining public.
+"""
+
+import argparse
+import datetime as dt
+import html
+import json
+import subprocess
+import sys
+import time
+
+
+BG = "#101936"
+PANEL = "#1b2547"
+BAR_BG = "#27335a"
+TEXT = "#eef2fb"
+MUTED = "#9aa6c9"
+
+REPOSITORIES = [
+    ("TauCetiProject/TauCeti", "TauCeti", "#ff9d4d"),
+    ("TauCetiProject/TauCetiRoadmap", "TauCetiRoadmap", "#5eead4"),
+    ("kim-em/TauCetiWorker", "TauCetiWorker", "#60a5fa"),
+    ("TauCetiProject/TauCetiReview", "TauCetiReview", "#c084fc"),
+]
+
+# Some GitHub Apps surface through GraphQL as User nodes or without their REST
+# `[bot]` suffix. Keep the project-specific aliases explicit; the generic suffix
+# check below handles conventional bot accounts.
+AUTOMATION_LOGINS = {
+    "claude",
+    "copilot",
+    "copilot-pull-request-reviewer",
+    "dependabot",
+    "github-actions",
+    "tau-ceti-claim-bot",
+    "tau-ceti-roadmap-sync",
+    "tauceti-review-bot",
+    "web-flow",
+}
+
+
+def canonical_human(login: str | None) -> str | None:
+    """Return a case-insensitive identity, or None for known automation."""
+    if not login:
+        return None
+    actor = login.casefold()
+    unsuffixed = actor.removesuffix("[bot]")
+    if actor.endswith("[bot]") or unsuffixed in AUTOMATION_LOGINS:
+        return None
+    return actor
+
+
+def gh_json(*args: str):
+    """Run one read-only gh query, retrying transient API/transport failures."""
+    for attempt in range(3):
+        try:
+            out = subprocess.run(
+                ["gh", *args],
+                check=True,
+                text=True,
+                stdout=subprocess.PIPE,
+                timeout=120,
+            ).stdout
+            return json.loads(out)
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired):
+            if attempt == 2:
+                raise
+            delay = 2 ** attempt
+            print(f"GitHub query failed; retrying in {delay}s", file=sys.stderr)
+            time.sleep(delay)
+
+
+def connection_query(field: str) -> str:
+    if field == "pullRequests":
+        states = "[OPEN, CLOSED, MERGED]"
+    elif field == "issues":
+        states = "[OPEN, CLOSED]"
+    else:
+        raise ValueError(f"unsupported connection: {field}")
+    return f"""
+query($owner: String!, $name: String!, $cursor: String) {{
+  repository(owner: $owner, name: $name) {{
+    {field}(
+      first: 100,
+      after: $cursor,
+      states: {states},
+      orderBy: {{field: CREATED_AT, direction: ASC}}
+    ) {{
+      nodes {{
+        number
+        author {{ login }}
+        participants(first: 100) {{
+          nodes {{ login }}
+          pageInfo {{ hasNextPage }}
+        }}
+      }}
+      pageInfo {{ hasNextPage endCursor }}
+    }}
+  }}
+}}
+"""
+
+
+def actors_from_page(page: dict, field: str, repo: str) -> tuple[set[str], bool, str | None]:
+    """Extract human actors and outer pagination state from one GraphQL page."""
+    connection = page["data"]["repository"][field]
+    people: set[str] = set()
+    for item in connection["nodes"]:
+        participants = item["participants"]
+        if participants["pageInfo"]["hasNextPage"]:
+            raise RuntimeError(
+                f"{repo} {field} #{item['number']} has more than 100 participants; "
+                "refusing to undercount"
+            )
+        logins = [item.get("author", {}).get("login") if item.get("author") else None]
+        logins.extend(actor.get("login") for actor in participants["nodes"])
+        people.update(actor for login in logins if (actor := canonical_human(login)))
+    info = connection["pageInfo"]
+    return people, info["hasNextPage"], info.get("endCursor")
+
+
+def fetch_connection(repo: str, field: str) -> set[str]:
+    owner, name = repo.split("/", 1)
+    query = connection_query(field)
+    people: set[str] = set()
+    cursor = None
+    while True:
+        args = [
+            "api", "graphql",
+            "-f", f"query={query}",
+            "-f", f"owner={owner}",
+            "-f", f"name={name}",
+        ]
+        if cursor is not None:
+            args.extend(["-f", f"cursor={cursor}"])
+        page = gh_json(*args)
+        found, has_next, cursor = actors_from_page(page, field, repo)
+        people.update(found)
+        if not has_next:
+            return people
+        if not cursor:
+            raise RuntimeError(f"{repo} {field} pagination had no end cursor")
+
+
+def fetch_contributors(repo: str) -> set[str]:
+    """Fetch linked default-branch commit authors.
+
+    Anonymous email identities cannot be deduplicated against linked accounts or
+    across repositories, so counting them would make the headline less accurate.
+    """
+    pages = gh_json(
+        "api", "--paginate", "--slurp",
+        f"repos/{repo}/contributors?per_page=100",
+    )
+    people: set[str] = set()
+    for page in pages:
+        for contributor in page:
+            actor = canonical_human(contributor.get("login"))
+            if actor is not None:
+                people.add(actor)
+    return people
+
+
+def fetch_all() -> dict[str, set[str]]:
+    result = {}
+    for repo, _, _ in REPOSITORIES:
+        result[repo] = (
+            fetch_connection(repo, "pullRequests")
+            | fetch_connection(repo, "issues")
+            | fetch_contributors(repo)
+        )
+    return result
+
+
+def load_data(path: str) -> tuple[dict[str, set[str]], str | None]:
+    with open(path, encoding="utf-8") as data_file:
+        raw = json.load(data_file)
+    if "repositories" in raw:
+        generated = raw.get("generatedAt")
+        raw = raw["repositories"]
+    else:
+        generated = None
+    expected = {repo for repo, _, _ in REPOSITORIES}
+    if set(raw) != expected:
+        raise ValueError(f"data repositories must be exactly: {', '.join(sorted(expected))}")
+    return {
+        repo: {actor for login in logins if (actor := canonical_human(login))}
+        for repo, logins in raw.items()
+    }, generated
+
+
+def dump_data(path: str, people: dict[str, set[str]], generated: str) -> None:
+    with open(path, "w", encoding="utf-8") as out:
+        json.dump({
+            "generatedAt": generated,
+            "repositories": {
+                repo: sorted(people[repo])
+                for repo, _, _ in REPOSITORIES
+            },
+        }, out, indent=2)
+        out.write("\n")
+
+
+def render(people: dict[str, set[str]], title: str, out: str, as_of: str) -> int:
+    total_people = set().union(*people.values())
+    total = len(total_people)
+    counts = {repo: len(people[repo]) for repo, _, _ in REPOSITORIES}
+    scale = max(total, 1)
+
+    W, H = 980, 430
+    L, R, T = 245, 70, 132
+    pw = W - L - R
+    bar_h, gap = 42, 18
+
+    bars = []
+    for i, (repo, label, color) in enumerate(REPOSITORIES):
+        count = counts[repo]
+        y = T + i * (bar_h + gap)
+        width = pw * count / scale
+        bars.extend([
+            f'<text class="label" x="{L-18}" y="{y+27}">{html.escape(label)}</text>',
+            f'<rect x="{L}" y="{y}" width="{pw}" height="{bar_h}" rx="8" fill="{BAR_BG}"/>',
+            f'<rect x="{L}" y="{y}" width="{width:.1f}" height="{bar_h}" rx="8" fill="{color}"/>',
+            f'<text class="count" x="{L+width+12:.1f}" y="{y+27}">{count}</text>',
+        ])
+
+    safe_as_of = html.escape(as_of)
+    subtitle = f"{total} people across {len(REPOSITORIES)} repositories as of {as_of}"
+    breakdown = ", ".join(
+        f"{label}: {counts[repo]}"
+        for repo, label, _ in REPOSITORIES
+    )
+    svg = f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {W} {H}"
+     font-family="ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif"
+     role="img" aria-labelledby="participation-title participation-description">
+  <title id="participation-title">{html.escape(title)}: {html.escape(subtitle)}</title>
+  <desc id="participation-description">{html.escape(breakdown)}. People active in several repositories are counted in each bar.</desc>
+  <style>
+    .title{{fill:{TEXT};font-size:19px;font-weight:600}}
+    .total{{fill:{TEXT};font-size:42px;font-weight:700}}
+    .sub{{fill:{MUTED};font-size:13px}}
+    .label{{fill:{TEXT};font-size:15px;text-anchor:end}}
+    .count{{fill:{TEXT};font-size:16px;font-weight:650}}
+    .note{{fill:{MUTED};font-size:12.5px}}
+  </style>
+  <rect x="0.5" y="0.5" width="{W-1}" height="{H-1}" rx="12" fill="{BG}" stroke="{PANEL}"/>
+  <text class="title" x="50" y="36">{html.escape(title)}</text>
+  <text class="total" x="50" y="91">{total}</text>
+  <text class="sub" x="112" y="86">unique people · {safe_as_of}</text>
+  {''.join(bars)}
+  <text class="note" x="50" y="{H-30}">
+    Opened a PR/issue, commented or reviewed, or authored a default-branch commit. Multi-repo participants appear in each bar.
+  </text>
+</svg>
+'''
+    with open(out, "w", encoding="utf-8") as svg_file:
+        svg_file.write(svg)
+    return total
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--data", help="offline JSON snapshot; otherwise query GitHub with gh")
+    ap.add_argument("--dump-data", help="write the fetched, filtered actor snapshot as JSON")
+    ap.add_argument("--title", default="Tau Ceti — human participation")
+    ap.add_argument("--out", required=True)
+    args = ap.parse_args()
+
+    today = dt.datetime.now(dt.timezone.utc).date().isoformat()
+    try:
+        if args.data:
+            people, generated = load_data(args.data)
+            as_of = generated or today
+        else:
+            people = fetch_all()
+            as_of = today
+        if args.dump_data:
+            dump_data(args.dump_data, people, as_of)
+        total = render(people, args.title, args.out, as_of)
+    except (RuntimeError, subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        sys.exit(f"participant graph generation failed: {exc}")
+
+    detail = ", ".join(
+        f"{label}={len(people[repo])}"
+        for repo, label, _ in REPOSITORIES
+    )
+    print(f"wrote {args.out}: {total} unique people ({detail})")

--- a/scripts/test_participant_graph.py
+++ b/scripts/test_participant_graph.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Tests for the participation snapshot graph.
+
+Run with:
+
+    PYTHONPATH=scripts python3 scripts/test_participant_graph.py
+"""
+
+import json
+import pathlib
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+from unittest import mock
+
+import participant_graph as pg
+
+
+class ParticipantGraphTest(unittest.TestCase):
+    def test_filters_bot_suffixes_and_app_aliases(self):
+        self.assertIsNone(pg.canonical_human("github-actions[bot]"))
+        self.assertIsNone(pg.canonical_human("tauceti-review-bot"))
+        self.assertIsNone(pg.canonical_human("Copilot"))
+        self.assertIsNone(pg.canonical_human("claude"))
+        self.assertEqual(pg.canonical_human("CBirkbeck"), "cbirkbeck")
+
+    def test_extracts_authors_and_participants(self):
+        page = {
+            "data": {"repository": {"pullRequests": {
+                "nodes": [{
+                    "number": 7,
+                    "author": {"login": "HumanAuthor"},
+                    "participants": {
+                        "nodes": [
+                            {"login": "HumanReviewer"},
+                            {"login": "github-actions[bot]"},
+                        ],
+                        "pageInfo": {"hasNextPage": False},
+                    },
+                }],
+                "pageInfo": {"hasNextPage": True, "endCursor": "next"},
+            }}},
+        }
+
+        people, has_next, cursor = pg.actors_from_page(
+            page, "pullRequests", "owner/repo"
+        )
+
+        self.assertEqual(people, {"humanauthor", "humanreviewer"})
+        self.assertTrue(has_next)
+        self.assertEqual(cursor, "next")
+
+    def test_refuses_to_undercount_large_conversations(self):
+        page = {
+            "data": {"repository": {"issues": {
+                "nodes": [{
+                    "number": 9,
+                    "author": {"login": "person"},
+                    "participants": {
+                        "nodes": [],
+                        "pageInfo": {"hasNextPage": True},
+                    },
+                }],
+                "pageInfo": {"hasNextPage": False, "endCursor": None},
+            }}},
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "more than 100 participants"):
+            pg.actors_from_page(page, "issues", "owner/repo")
+
+    def test_connection_paginates_with_raw_cursor(self):
+        def page(login, has_next, cursor):
+            return {
+                "data": {"repository": {"issues": {
+                    "nodes": [{
+                        "number": 1,
+                        "author": {"login": login},
+                        "participants": {
+                            "nodes": [],
+                            "pageInfo": {"hasNextPage": False},
+                        },
+                    }],
+                    "pageInfo": {
+                        "hasNextPage": has_next,
+                        "endCursor": cursor,
+                    },
+                }}},
+            }
+
+        with mock.patch.object(
+            pg, "gh_json",
+            side_effect=[page("First", True, "opaque-cursor"), page("Second", False, None)],
+        ) as query:
+            people = pg.fetch_connection("owner/repo", "issues")
+
+        self.assertEqual(people, {"first", "second"})
+        second_args = query.call_args_list[1].args
+        self.assertIn("cursor=opaque-cursor", second_args)
+        self.assertEqual(second_args[second_args.index("cursor=opaque-cursor") - 1], "-f")
+
+    def test_contributors_keep_linked_humans_only(self):
+        payload = [[
+            {"login": "Human", "type": "User"},
+            {"login": "github-actions[bot]", "type": "Bot"},
+            {"name": "Unlinked Human", "email": "human@example.com", "type": "Anonymous"},
+        ]]
+        with mock.patch.object(pg, "gh_json", return_value=payload):
+            people = pg.fetch_contributors("owner/repo")
+
+        self.assertEqual(people, {"human"})
+
+    def test_loads_filters_and_renders_snapshot(self):
+        repositories = {
+            repo: ["SharedHuman", f"{label}Human", "Copilot"]
+            for repo, label, _ in pg.REPOSITORIES
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            data = tmp_path / "people.json"
+            out = tmp_path / "people.svg"
+            data.write_text(json.dumps({
+                "generatedAt": "2026-07-29",
+                "repositories": repositories,
+            }))
+
+            people, generated = pg.load_data(str(data))
+            total = pg.render(people, "Participation", str(out), generated)
+            svg = out.read_text()
+            ET.fromstring(svg)
+
+        self.assertEqual(total, 5)
+        self.assertIn('class="total" x="50" y="91">5</text>', svg)
+        self.assertIn("TauCetiRoadmap", svg)
+        self.assertIn("2026-07-29", svg)
+        self.assertIn("Multi-repo participants appear in each bar", svg)
+        self.assertIn("<desc ", svg)
+
+    def test_dump_and_load_round_trip(self):
+        people = {
+            repo: {"shared", label.casefold()}
+            for repo, label, _ in pg.REPOSITORIES
+        }
+        with tempfile.TemporaryDirectory() as tmp:
+            data = pathlib.Path(tmp) / "people.json"
+            pg.dump_data(str(data), people, "2026-07-29")
+            loaded, generated = pg.load_data(str(data))
+
+        self.assertEqual(loaded, people)
+        self.assertEqual(generated, "2026-07-29")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -73,9 +73,12 @@ Infrastructure and refactor PRs, which advance no roadmap, are left out.
 Who has taken part? The snapshot below counts GitHub accounts that have
 opened a pull request or issue, participated in those conversations (including
 reviews), or authored a commit on the default branch of TauCeti, TauCetiRoadmap,
-TauCetiWorker, or TauCetiReview. Automation accounts are excluded. The headline
-deduplicates people across all four repositories; the repository bars deliberately
-overlap.
+TauCetiWorker, or TauCetiReview. Accounts recognised as automation are dropped:
+logins carrying GitHub's `[bot]` suffix, together with the project's own automation
+aliases. Nothing verifies that the accounts left over belong to people, so any
+automation the filter does not recognise is still counted. The headline
+deduplicates accounts across all four repositories; the repository bars
+deliberately overlap.
 
 :::blob participationGraph
 :::

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -36,7 +36,7 @@ def roadmapGraph : Html := {{
 /-- A current snapshot of human participation across the four project repositories.
 Regenerated daily by the `pages` workflow (`scripts/participant_graph.py`) from
 GitHub PR/issue participant connections and default-branch commit contributors. -/
-def participationGraph : Html := {{
+private def participationGraph : Html := {{
   <figure class="loc-figure loc-figure-wide">
     <img class="loc-graph" src="static/participation.svg"
          alt="Human participation across the four Tau Ceti repositories"/>

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -33,14 +33,16 @@ def roadmapGraph : Html := {{
   </figure>
 }}
 
-/-- A current snapshot of human participation across the four project repositories.
-Regenerated daily by the `pages` workflow (`scripts/participant_graph.py`) from
-GitHub PR/issue participant connections and default-branch commit contributors. -/
+/-- A current snapshot of participation across the four project repositories: the GitHub
+accounts that remain once recognised automation is excluded, which is not the same as a
+verified count of people. Regenerated daily by the `pages` workflow
+(`scripts/participant_graph.py`) from GitHub PR/issue participant connections and
+default-branch commit contributors. -/
 private def participationGraph : Html := {{
   <figure class="loc-figure loc-figure-wide">
     <img class="loc-graph" src="static/participation.svg"
-         alt="Human participation across the four Tau Ceti repositories"/>
-    <figcaption>"Unique human participants by repository; people active in several repositories appear in several bars."</figcaption>
+         alt="Participation across the four Tau Ceti repositories, by repository"/>
+    <figcaption>"Participating accounts by repository, once recognised automation is excluded; an account active in several repositories appears in several bars."</figcaption>
   </figure>
 }}
 

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -33,6 +33,17 @@ def roadmapGraph : Html := {{
   </figure>
 }}
 
+/-- A current snapshot of human participation across the four project repositories.
+Regenerated daily by the `pages` workflow (`scripts/participant_graph.py`) from
+GitHub PR/issue participant connections and default-branch commit contributors. -/
+def participationGraph : Html := {{
+  <figure class="loc-figure loc-figure-wide">
+    <img class="loc-graph" src="static/participation.svg"
+         alt="Human participation across the four Tau Ceti repositories"/>
+    <figcaption>"Unique human participants by repository; people active in several repositories appear in several bars."</figcaption>
+  </figure>
+}}
+
 #doc (Page) "Statistics" =>
 
 How much mathematics has Tau Ceti formalized, and how fast is the roadmap that
@@ -57,4 +68,14 @@ both PRs, so this measures work landed per roadmap, not a snapshot line count.
 Infrastructure and refactor PRs, which advance no roadmap, are left out.
 
 :::blob roadmapGraph
+:::
+
+Who has taken part? The snapshot below counts GitHub accounts that have
+opened a pull request or issue, participated in those conversations (including
+reviews), or authored a commit on the default branch of TauCeti, TauCetiRoadmap,
+TauCetiWorker, or TauCetiReview. Automation accounts are excluded. The headline
+deduplicates people across all four repositories; the repository bars deliberately
+overlap.
+
+:::blob participationGraph
 :::

--- a/web/static_files/participation.svg
+++ b/web/static_files/participation.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 430"
+     font-family="ui-sans-serif,system-ui,-apple-system,'Segoe UI',Roboto,sans-serif"
+     role="img" aria-labelledby="participation-title participation-description">
+  <title id="participation-title">Tau Ceti — human participation: 27 people across 4 repositories as of 2026-07-29</title>
+  <desc id="participation-description">TauCeti: 17, TauCetiRoadmap: 15, TauCetiWorker: 3, TauCetiReview: 2. People active in several repositories are counted in each bar.</desc>
+  <style>
+    .title{fill:#eef2fb;font-size:19px;font-weight:600}
+    .total{fill:#eef2fb;font-size:42px;font-weight:700}
+    .sub{fill:#9aa6c9;font-size:13px}
+    .label{fill:#eef2fb;font-size:15px;text-anchor:end}
+    .count{fill:#eef2fb;font-size:16px;font-weight:650}
+    .note{fill:#9aa6c9;font-size:12.5px}
+  </style>
+  <rect x="0.5" y="0.5" width="979" height="429" rx="12" fill="#101936" stroke="#1b2547"/>
+  <text class="title" x="50" y="36">Tau Ceti — human participation</text>
+  <text class="total" x="50" y="91">27</text>
+  <text class="sub" x="112" y="86">unique people · 2026-07-29</text>
+  <text class="label" x="227" y="159">TauCeti</text><rect x="245" y="132" width="665" height="42" rx="8" fill="#27335a"/><rect x="245" y="132" width="418.7" height="42" rx="8" fill="#ff9d4d"/><text class="count" x="675.7" y="159">17</text><text class="label" x="227" y="219">TauCetiRoadmap</text><rect x="245" y="192" width="665" height="42" rx="8" fill="#27335a"/><rect x="245" y="192" width="369.4" height="42" rx="8" fill="#5eead4"/><text class="count" x="626.4" y="219">15</text><text class="label" x="227" y="279">TauCetiWorker</text><rect x="245" y="252" width="665" height="42" rx="8" fill="#27335a"/><rect x="245" y="252" width="73.9" height="42" rx="8" fill="#60a5fa"/><text class="count" x="330.9" y="279">3</text><text class="label" x="227" y="339">TauCetiReview</text><rect x="245" y="312" width="665" height="42" rx="8" fill="#27335a"/><rect x="245" y="312" width="49.3" height="42" rx="8" fill="#c084fc"/><text class="count" x="306.3" y="339">2</text>
+  <text class="note" x="50" y="400">
+    Opened a PR/issue, commented or reviewed, or authored a default-branch commit. Multi-repo participants appear in each bar.
+  </text>
+</svg>


### PR DESCRIPTION
## Summary

- add a daily participation snapshot covering TauCeti, TauCetiRoadmap, TauCetiWorker, and TauCetiReview
- count linked human GitHub accounts that opened PRs/issues, participated in their conversations or reviews, or authored default-branch commits
- deduplicate across repositories and exclude conventional bots plus the project automation aliases GitHub exposes as users
- render the exact union as a headline and overlapping per-repository bars on the Statistics page
- retain a dated committed SVG if a retried GitHub query fails, rather than publishing a partial total

The current live result is **27 unique people**: TauCeti 17, TauCetiRoadmap 15, TauCetiWorker 3, and TauCetiReview 2. The full four-repository scan takes about 67 seconds and runs only in the existing daily/deploy Pages job.

## Validation

- `PYTHONPATH=scripts python3 scripts/test_participant_graph.py` (7 tests)
- full lightweight infrastructure policy test suite
- live four-repository query and SVG generation: 27 people
- generated SVG XML parse and accessible title/description check
- `cd web && lake build Site.Stats`
- workflow YAML parse
- `git diff --check`

An independent second opinion confirmed the participant-connection semantics. Its validated recommendations were incorporated: linked contributors only, API retries, raw cursor handling, UTF-8 I/O, total-scaled bars, accessible SVG metadata, and expanded pagination/contributor/round-trip tests.

This intentionally changes human-owned `scripts/`, `.github/`, and website files and therefore requires human review.