### PR TITLE
feat: add characteristic-two lattice homology

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -300,6 +300,7 @@ theorem latticeDifferential_comp_self
 
 /-- The lattice differential vanishes when the plumbing graph has no vertices. Every cube then
 has an empty direction set, so the weighted face sum on every generator is empty. -/
+@[simp]
 theorem latticeDifferential_eq_zero_of_isEmpty [IsEmpty V]
     (P : PlumbingGraph V) (k : P.characteristicVectors) :
     P.latticeDifferential k = 0 := by

--- a/TauCeti/LowDimTopology/Plumbing/Differential.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Differential.lean
@@ -38,6 +38,8 @@ oriented cubical differential.
 * `TauCeti.PlumbingGraph.latticeDifferential_single`: the differential on a basis cube.
 * `TauCeti.PlumbingGraph.latticeDifferential_comp_self`: the lattice differential squares to
   zero.
+* `TauCeti.PlumbingGraph.latticeDifferential_eq_zero_of_isEmpty`: the zero-vertex
+  plumbing has zero differential.
 
 ## References
 
@@ -295,6 +297,19 @@ theorem latticeDifferential_comp_self
     (P.latticeDifferential k).comp (P.latticeDifferential k) = 0 := by
   refine Finsupp.lhom_ext' fun C => LinearMap.ext_ring ?_
   simp [LinearMap.comp_apply]
+
+/-- The lattice differential vanishes when the plumbing graph has no vertices. Every cube then
+has an empty direction set, so the weighted face sum on every generator is empty. -/
+theorem latticeDifferential_eq_zero_of_isEmpty [IsEmpty V]
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeDifferential k = 0 := by
+  refine Finsupp.lhom_ext' fun C => LinearMap.ext_ring ?_
+  simp only [LinearMap.comp_apply, Finsupp.lsingle_apply, LinearMap.zero_apply]
+  rw [latticeDifferential_single, latticeDifferentialOnGenerator_def]
+  have hattach : C.directions.attach = ∅ :=
+    Finset.eq_empty_iff_forall_notMem.mpr fun v _ => isEmptyElim v.1
+  rw [hattach]
+  simp
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -88,18 +88,6 @@ theorem latticeShortComplex_X₃ (P : PlumbingGraph V) (k : P.characteristicVect
     (P.latticeShortComplex k).X₃ =
       ModuleCat.of PlumbingCoefficient (PlumbingChain V) := (rfl)
 
-/-- The first map of the lattice short complex is the lattice differential. -/
-@[simp]
-theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    HEq (P.latticeShortComplex k).f
-      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
-
-/-- The second map of the lattice short complex is the lattice differential. -/
-@[simp]
-theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    HEq (P.latticeShortComplex k).g
-      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
-
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.
 
@@ -122,13 +110,13 @@ noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
     P.latticeHomology k ≅ ModuleCat.of PlumbingCoefficient (PlumbingChain V) := by
   let S := P.latticeShortComplex k
   have hf : S.f = 0 := by
-    have h := P.latticeShortComplex_f k
-    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
-    exact eq_of_heq h
+    change ModuleCat.ofHom (P.latticeDifferential k) = 0
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k]
+    rfl
   have hg : S.g = 0 := by
-    have h := P.latticeShortComplex_g k
-    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
-    exact eq_of_heq h
+    change ModuleCat.ofHom (P.latticeDifferential k) = 0
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k]
+    rfl
   exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is a universe-lifted copy

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -88,6 +88,18 @@ theorem latticeShortComplex_X₃ (P : PlumbingGraph V) (k : P.characteristicVect
     (P.latticeShortComplex k).X₃ =
       ModuleCat.of PlumbingCoefficient (PlumbingChain V) := (rfl)
 
+/-- The left map of the lattice short complex is the lattice differential. -/
+@[simp]
+theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    HEq (P.latticeShortComplex k).f
+      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
+
+/-- The right map of the lattice short complex is the lattice differential. -/
+@[simp]
+theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    HEq (P.latticeShortComplex k).g
+      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
+
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.
 
@@ -111,13 +123,13 @@ noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
     P.latticeHomology k ≅ ModuleCat.of PlumbingCoefficient (PlumbingChain V) := by
   let S := P.latticeShortComplex k
   have hf : S.f = 0 := by
-    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_f,
-      P.latticeDifferential_eq_zero_of_isEmpty k]
-    rfl
+    have h := P.latticeShortComplex_f k
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
+    exact eq_of_heq h
   have hg : S.g = 0 := by
-    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_g,
-      P.latticeDifferential_eq_zero_of_isEmpty k]
-    rfl
+    have h := P.latticeShortComplex_g k
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
+    exact eq_of_heq h
   exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is a universe-lifted copy

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+public import TauCeti.LowDimTopology.Plumbing.Differential
+import Mathlib.Algebra.Module.ULift
+import Mathlib.LinearAlgebra.Finsupp.Pi
+
+/-!
+# Lattice homology over `𝔽₂[U]`
+
+This file packages the characteristic-two plumbing-lattice differential as a short complex and
+defines its homology. For a plumbing graph `P` and characteristic covector `k`, the same weighted
+differential occurs on both sides of the short complex
+
+`PlumbingChain V → PlumbingChain V → PlumbingChain V`.
+
+The relation `∂² = 0` proved in `Differential.lean` makes this a short complex. Its homology is
+therefore the kernel of the differential modulo its range, with coefficients in `𝔽₂[U]`.
+
+The construction deliberately uses Mathlib's `ShortComplex` homology API. Thus its existing
+`cycles`, `homologyπ`, and homology-map interfaces apply directly, without a parallel
+plumbing-specific quotient API.
+
+This is the ungraded total module obtained from all cubical dimensions. The cubical and weight
+gradings, integral signs, the `ℍ⁰` variant, and invariance under Neumann moves are separate later
+stages. As a first computation, the zero-vertex plumbing has zero differential, so its homology is
+canonically isomorphic to its whole chain module.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.latticeShortComplex`: the short complex with the lattice differential
+  in both positions.
+* `TauCeti.PlumbingGraph.latticeHomology`: its canonical `𝔽₂[U]`-module homology.
+* `TauCeti.PlumbingGraph.latticeHomologyIsoChainOfIsEmpty`: the homology of a zero-vertex
+  plumbing is its full chain module.
+* `TauCeti.PlumbingGraph.latticeHomologyIsoCoefficientOfIsEmpty`: that chain module has one
+  generator, so the homology is a universe-lifted copy of `𝔽₂[U]`.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, which asks for
+Némethi's lattice homology `ℍ⁻` as a polynomial module built from lattice points and weight
+functions. The characteristic-two coefficient stage and the weighted cubical differential follow
+A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+namespace PlumbingGraph
+
+universe u
+
+variable {V : Type u} [DecidableEq V] [Fintype V]
+
+/-- The short complex whose two maps are the characteristic-two lattice differential.
+
+The three objects are the total plumbing-chain module on all cubical dimensions. The short-complex
+condition is exactly `latticeDifferential_comp_self`. -/
+noncomputable abbrev latticeShortComplex
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    ShortComplex (ModuleCat PlumbingCoefficient) :=
+  ShortComplex.moduleCatMk (P.latticeDifferential k) (P.latticeDifferential k)
+    (P.latticeDifferential_comp_self k)
+
+/-- The characteristic-two lattice homology module: the homology of the weighted
+plumbing-lattice short complex.
+
+Because this is an abbreviation for Mathlib's canonical homology object, the generic
+`ShortComplex.cycles`, `ShortComplex.homologyπ`, and homology-map API can be used directly. -/
+noncomputable abbrev latticeHomology
+    (P : PlumbingGraph V) (k : P.characteristicVectors) : ModuleCat PlumbingCoefficient :=
+  (P.latticeShortComplex k).homology
+
+/-- The characteristic-two lattice homology of a zero-vertex plumbing is canonically isomorphic
+to its whole plumbing-chain module. -/
+noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeHomology k ≅ ModuleCat.of PlumbingCoefficient (PlumbingChain V) := by
+  let S := P.latticeShortComplex k
+  have hf : S.f = 0 := by
+    apply ModuleCat.hom_ext
+    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_f,
+      P.latticeDifferential_eq_zero_of_isEmpty k, ModuleCat.hom_zero]
+    rfl
+  have hg : S.g = 0 := by
+    apply ModuleCat.hom_ext
+    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_g,
+      P.latticeDifferential_eq_zero_of_isEmpty k, ModuleCat.hom_zero]
+    rfl
+  exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
+
+/-- The characteristic-two lattice homology of a zero-vertex plumbing is a universe-lifted copy
+of the coefficient module `𝔽₂[U]`. -/
+noncomputable def latticeHomologyIsoCoefficientOfIsEmpty [IsEmpty V]
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeHomology k ≅
+      ModuleCat.of PlumbingCoefficient (ULift.{u} PlumbingCoefficient) := by
+  let C : PlumbingCube V := { base := isEmptyElim, directions := ∅ }
+  letI : Subsingleton (PlumbingCube V) :=
+    ⟨fun A B => PlumbingCube.ext (Subsingleton.elim A.base B.base)
+      (Subsingleton.elim A.directions B.directions)⟩
+  exact P.latticeHomologyIsoChainOfIsEmpty k ≪≫
+    ((Finsupp.uniqueLinearEquiv PlumbingCoefficient PlumbingCoefficient C).trans
+      ULift.moduleEquiv.symm).toModuleIso
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -98,6 +98,7 @@ noncomputable def latticeHomology
   (P.latticeShortComplex k).homology
 
 /-- Lattice homology is the canonical homology object of the lattice short complex. -/
+@[simp]
 theorem latticeHomology_def (P : PlumbingGraph V) (k : P.characteristicVectors) :
     P.latticeHomology k = (P.latticeShortComplex k).homology := by
   unfold latticeHomology
@@ -110,12 +111,12 @@ noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
     P.latticeHomology k ≅ ModuleCat.of PlumbingCoefficient (PlumbingChain V) := by
   let S := P.latticeShortComplex k
   have hf : S.f = 0 := by
-    change ModuleCat.ofHom (P.latticeDifferential k) = 0
-    rw [P.latticeDifferential_eq_zero_of_isEmpty k]
+    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_f,
+      P.latticeDifferential_eq_zero_of_isEmpty k]
     rfl
   have hg : S.g = 0 := by
-    change ModuleCat.ofHom (P.latticeDifferential k) = 0
-    rw [P.latticeDifferential_eq_zero_of_isEmpty k]
+    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_g,
+      P.latticeDifferential_eq_zero_of_isEmpty k]
     rfl
   exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
 

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -64,20 +64,56 @@ variable {V : Type u} [DecidableEq V] [Fintype V]
 
 The three objects are the total plumbing-chain module on all cubical dimensions. The short-complex
 condition is exactly `latticeDifferential_comp_self`. -/
-noncomputable abbrev latticeShortComplex
+@[expose] noncomputable def latticeShortComplex
     (P : PlumbingGraph V) (k : P.characteristicVectors) :
     ShortComplex (ModuleCat PlumbingCoefficient) :=
   ShortComplex.moduleCatMk (P.latticeDifferential k) (P.latticeDifferential k)
     (P.latticeDifferential_comp_self k)
 
+/-- The left object of the lattice short complex is the plumbing-chain module. -/
+@[simp]
+theorem latticeShortComplex_X₁ (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).X₁ =
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+
+/-- The middle object of the lattice short complex is the plumbing-chain module. -/
+@[simp]
+theorem latticeShortComplex_X₂ (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).X₂ =
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+
+/-- The right object of the lattice short complex is the plumbing-chain module. -/
+@[simp]
+theorem latticeShortComplex_X₃ (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).X₃ =
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+
+/-- The first map of the lattice short complex is the lattice differential. -/
+@[simp]
+theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).f = ModuleCat.ofHom (P.latticeDifferential k) := by
+  simp [latticeShortComplex]
+
+/-- The second map of the lattice short complex is the lattice differential. -/
+@[simp]
+theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    (P.latticeShortComplex k).g = ModuleCat.ofHom (P.latticeDifferential k) := by
+  simp [latticeShortComplex]
+
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.
 
-Because this is an abbreviation for Mathlib's canonical homology object, the generic
-`ShortComplex.cycles`, `ShortComplex.homologyπ`, and homology-map API can be used directly. -/
-noncomputable abbrev latticeHomology
+This is Mathlib's canonical homology object, so the generic `ShortComplex.cycles`,
+`ShortComplex.homologyπ`, and homology-map API can be used directly via `latticeHomology_def`. -/
+noncomputable def latticeHomology
     (P : PlumbingGraph V) (k : P.characteristicVectors) : ModuleCat PlumbingCoefficient :=
   (P.latticeShortComplex k).homology
+
+/-- Lattice homology is the canonical homology object of the lattice short complex. -/
+theorem latticeHomology_def (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeHomology k = (P.latticeShortComplex k).homology := by
+  unfold latticeHomology
+  rfl
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is canonically isomorphic
 to its whole plumbing-chain module. -/
@@ -87,13 +123,13 @@ noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
   let S := P.latticeShortComplex k
   have hf : S.f = 0 := by
     apply ModuleCat.hom_ext
-    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_f,
-      P.latticeDifferential_eq_zero_of_isEmpty k, ModuleCat.hom_zero]
+    simp only [S, latticeShortComplex_f, P.latticeDifferential_eq_zero_of_isEmpty k,
+      ModuleCat.hom_zero]
     rfl
   have hg : S.g = 0 := by
     apply ModuleCat.hom_ext
-    simp only [S, latticeShortComplex, ShortComplex.moduleCatMk_g,
-      P.latticeDifferential_eq_zero_of_isEmpty k, ModuleCat.hom_zero]
+    simp only [S, latticeShortComplex_g, P.latticeDifferential_eq_zero_of_isEmpty k,
+      ModuleCat.hom_zero]
     rfl
   exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
 

--- a/TauCeti/LowDimTopology/Plumbing/Homology.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Homology.lean
@@ -64,7 +64,7 @@ variable {V : Type u} [DecidableEq V] [Fintype V]
 
 The three objects are the total plumbing-chain module on all cubical dimensions. The short-complex
 condition is exactly `latticeDifferential_comp_self`. -/
-@[expose] noncomputable def latticeShortComplex
+noncomputable def latticeShortComplex
     (P : PlumbingGraph V) (k : P.characteristicVectors) :
     ShortComplex (ModuleCat PlumbingCoefficient) :=
   ShortComplex.moduleCatMk (P.latticeDifferential k) (P.latticeDifferential k)
@@ -74,31 +74,31 @@ condition is exactly `latticeDifferential_comp_self`. -/
 @[simp]
 theorem latticeShortComplex_X₁ (P : PlumbingGraph V) (k : P.characteristicVectors) :
     (P.latticeShortComplex k).X₁ =
-      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := (rfl)
 
 /-- The middle object of the lattice short complex is the plumbing-chain module. -/
 @[simp]
 theorem latticeShortComplex_X₂ (P : PlumbingGraph V) (k : P.characteristicVectors) :
     (P.latticeShortComplex k).X₂ =
-      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := (rfl)
 
 /-- The right object of the lattice short complex is the plumbing-chain module. -/
 @[simp]
 theorem latticeShortComplex_X₃ (P : PlumbingGraph V) (k : P.characteristicVectors) :
     (P.latticeShortComplex k).X₃ =
-      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := rfl
+      ModuleCat.of PlumbingCoefficient (PlumbingChain V) := (rfl)
 
 /-- The first map of the lattice short complex is the lattice differential. -/
 @[simp]
 theorem latticeShortComplex_f (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    (P.latticeShortComplex k).f = ModuleCat.ofHom (P.latticeDifferential k) := by
-  simp [latticeShortComplex]
+    HEq (P.latticeShortComplex k).f
+      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
 
 /-- The second map of the lattice short complex is the lattice differential. -/
 @[simp]
 theorem latticeShortComplex_g (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    (P.latticeShortComplex k).g = ModuleCat.ofHom (P.latticeDifferential k) := by
-  simp [latticeShortComplex]
+    HEq (P.latticeShortComplex k).g
+      (ModuleCat.ofHom (P.latticeDifferential k)) := (HEq.rfl)
 
 /-- The characteristic-two lattice homology module: the homology of the weighted
 plumbing-lattice short complex.
@@ -122,15 +122,13 @@ noncomputable def latticeHomologyIsoChainOfIsEmpty [IsEmpty V]
     P.latticeHomology k ≅ ModuleCat.of PlumbingCoefficient (PlumbingChain V) := by
   let S := P.latticeShortComplex k
   have hf : S.f = 0 := by
-    apply ModuleCat.hom_ext
-    simp only [S, latticeShortComplex_f, P.latticeDifferential_eq_zero_of_isEmpty k,
-      ModuleCat.hom_zero]
-    rfl
+    have h := P.latticeShortComplex_f k
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
+    exact eq_of_heq h
   have hg : S.g = 0 := by
-    apply ModuleCat.hom_ext
-    simp only [S, latticeShortComplex_g, P.latticeDifferential_eq_zero_of_isEmpty k,
-      ModuleCat.hom_zero]
-    rfl
+    have h := P.latticeShortComplex_g k
+    rw [P.latticeDifferential_eq_zero_of_isEmpty k] at h
+    exact eq_of_heq h
   exact (S.asIsoHomologyπ hf).symm ≪≫ S.cyclesIsoX₂ hg
 
 /-- The characteristic-two lattice homology of a zero-vertex plumbing is a universe-lifted copy


### PR DESCRIPTION
This PR packages the characteristic-two weighted plumbing differential as a Mathlib short complex, defines its canonical `𝔽₂[U]`-module homology, and computes the zero-vertex case as one universe-lifted copy of the coefficient module.

It advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, specifically “Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions,” at the roadmap's required `𝔽₂`-first stage. This is the lowest-hanging direct Lane L target because the weighted differential and its square-zero theorem are already on `main`, while the homology object itself was not yet defined.

The zero-vertex computation proves the differential vanishes, identifies homology with the whole chain module, and then uses the unique plumbing cube to identify that module with `𝔽₂[U]`. The construction follows A. Némethi, arXiv:0709.0841, Section 3, as cited in both module docstrings.

Reuse Mathlib's `ShortComplex.moduleCatMk`, canonical `ShortComplex.homology`, `asIsoHomologyπ`, `cyclesIsoX₂`, `Finsupp.uniqueLinearEquiv`, and `ULift.moduleEquiv`. No Mathlib infrastructure or external formalization is vendored, copied, or adapted.

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-homology-f2u"}-->

Validation passes with `lake build` (5,710 jobs), `tauceti-axioms --changed-from origin/main` (66 declarations, allowlist only), and `tauceti-lint-env --changed-from origin/main` (zero violations; all eight scanned declarations documented).

🤖 Prepared with Codex
