### PR TITLE
refactor(Conformal): extract the nonvanishing-derivative step of not_injOn_of_deriv_eq_zero

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -254,30 +254,21 @@ private lemma not_injOn_ball_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ} {r 
 
 /-- **A non-locally-constant analytic function has eventually nonvanishing derivative.** If `f` is
 analytic at `z₀` and takes a value different from `f z₀` at every point of some punctured
-neighbourhood, then `deriv f` is nonzero on a punctured neighbourhood of `z₀`.
-
-Analyticity gives the dichotomy that `deriv f` either vanishes on a whole punctured neighbourhood
-of `z₀` or is nonvanishing on one. The first alternative makes `fderiv ℂ f` vanish on a ball, hence
-`f` constant there, which contradicts `hne`. -/
+neighbourhood, then `deriv f` is nonzero on a punctured neighbourhood of `z₀`. -/
 private theorem eventually_deriv_ne_zero_of_eventually_ne {f : ℂ → ℂ} {z₀ : ℂ}
     (hf : AnalyticAt ℂ f z₀) (hne : ∀ᶠ z in 𝓝[≠] z₀, f z ≠ f z₀) :
     ∀ᶠ z in 𝓝[≠] z₀, deriv f z ≠ 0 := by
   rcases hf.deriv.eventually_eq_zero_or_eventually_ne_zero with hz | hz
   · exfalso
     obtain ⟨ε, hε, hball⟩ := Metric.eventually_nhds_iff.mp (hz.and hf.eventually_analyticAt)
-    have hfd : Set.EqOn (fderiv ℂ f) 0 (ball z₀ ε) := by
-      intro x hx
-      have hdx : deriv f x = 0 := (hball (mem_ball.mp hx)).1
-      refine ContinuousLinearMap.ext fun y => ?_
-      rw [fderiv_eq_smul_deriv, hdx]
-      simp
+    have hfd : Set.EqOn (deriv f) 0 (ball z₀ ε) := fun x hx => (hball (mem_ball.mp hx)).1
     have hdiff : DifferentiableOn ℂ f (ball z₀ ε) := fun x hx =>
       ((hball (mem_ball.mp hx)).2.differentiableAt).differentiableWithinAt
     have hpunct : ∀ᶠ z in 𝓝[≠] z₀, z ∈ ball z₀ ε ∧ f z ≠ f z₀ := by
       filter_upwards [nhdsWithin_le_nhds (Metric.ball_mem_nhds z₀ hε), hne] with z h1 h2
       exact ⟨h1, h2⟩
     obtain ⟨b, hbball, hbne⟩ := hpunct.exists
-    exact hbne (isOpen_ball.is_const_of_fderiv_eq_zero
+    exact hbne (isOpen_ball.is_const_of_deriv_eq_zero
       (convex_ball z₀ ε).isPreconnected hdiff hfd hbball (mem_ball_self hε))
   · exact hz
 

--- a/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocalDegree.lean
@@ -252,6 +252,35 @@ private lemma not_injOn_ball_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ} {r 
   obtain ⟨a, ha, b, hb, hab⟩ := hnontriv
   exact fun hinj => hab (hinj ha.1 hb.1 (ha.2.trans hb.2.symm))
 
+/-- **A non-locally-constant analytic function has eventually nonvanishing derivative.** If `f` is
+analytic at `z₀` and takes a value different from `f z₀` at every point of some punctured
+neighbourhood, then `deriv f` is nonzero on a punctured neighbourhood of `z₀`.
+
+Analyticity gives the dichotomy that `deriv f` either vanishes on a whole punctured neighbourhood
+of `z₀` or is nonvanishing on one. The first alternative makes `fderiv ℂ f` vanish on a ball, hence
+`f` constant there, which contradicts `hne`. -/
+private theorem eventually_deriv_ne_zero_of_eventually_ne {f : ℂ → ℂ} {z₀ : ℂ}
+    (hf : AnalyticAt ℂ f z₀) (hne : ∀ᶠ z in 𝓝[≠] z₀, f z ≠ f z₀) :
+    ∀ᶠ z in 𝓝[≠] z₀, deriv f z ≠ 0 := by
+  rcases hf.deriv.eventually_eq_zero_or_eventually_ne_zero with hz | hz
+  · exfalso
+    obtain ⟨ε, hε, hball⟩ := Metric.eventually_nhds_iff.mp (hz.and hf.eventually_analyticAt)
+    have hfd : Set.EqOn (fderiv ℂ f) 0 (ball z₀ ε) := by
+      intro x hx
+      have hdx : deriv f x = 0 := (hball (mem_ball.mp hx)).1
+      refine ContinuousLinearMap.ext fun y => ?_
+      rw [fderiv_eq_smul_deriv, hdx]
+      simp
+    have hdiff : DifferentiableOn ℂ f (ball z₀ ε) := fun x hx =>
+      ((hball (mem_ball.mp hx)).2.differentiableAt).differentiableWithinAt
+    have hpunct : ∀ᶠ z in 𝓝[≠] z₀, z ∈ ball z₀ ε ∧ f z ≠ f z₀ := by
+      filter_upwards [nhdsWithin_le_nhds (Metric.ball_mem_nhds z₀ hε), hne] with z h1 h2
+      exact ⟨h1, h2⟩
+    obtain ⟨b, hbball, hbne⟩ := hpunct.exists
+    exact hbne (isOpen_ball.is_const_of_fderiv_eq_zero
+      (convex_ball z₀ ε).isPreconnected hdiff hfd hbball (mem_ball_self hε))
+  · exact hz
+
 /-- **Local injectivity fails at a critical point.** An analytic function whose derivative vanishes
 at `z₀` is not injective on *any* neighbourhood of `z₀`.
 
@@ -273,25 +302,8 @@ theorem not_injOn_of_deriv_eq_zero {f : ℂ → ℂ} {z₀ : ℂ}
     obtain ⟨a, haV, hane, haeq⟩ := hpunct.exists
     exact hane (hinj haV hz₀V haeq)
   · -- `f` is non-constant near `z₀`; find a disc where the degree argument applies
-    have hderiv : ∀ᶠ z in 𝓝[≠] z₀, deriv f z ≠ 0 := by
-      rcases hf.deriv.eventually_eq_zero_or_eventually_ne_zero with hz | hz
-      · exfalso
-        obtain ⟨ε, hε, hball⟩ := Metric.eventually_nhds_iff.mp (hz.and hf.eventually_analyticAt)
-        have hfd : Set.EqOn (fderiv ℂ f) 0 (ball z₀ ε) := by
-          intro x hx
-          have hdx : deriv f x = 0 := (hball (mem_ball.mp hx)).1
-          refine ContinuousLinearMap.ext fun y => ?_
-          rw [fderiv_eq_smul_deriv, hdx]
-          simp
-        have hdiff : DifferentiableOn ℂ f (ball z₀ ε) := fun x hx =>
-          ((hball (mem_ball.mp hx)).2.differentiableAt).differentiableWithinAt
-        have hpunct : ∀ᶠ z in 𝓝[≠] z₀, z ∈ ball z₀ ε ∧ f z ≠ f z₀ := by
-          filter_upwards [nhdsWithin_le_nhds (Metric.ball_mem_nhds z₀ hε), hisol] with z h1 h2
-          exact ⟨h1, sub_ne_zero.mp h2⟩
-        obtain ⟨b, hbball, hbne⟩ := hpunct.exists
-        exact hbne (isOpen_ball.is_const_of_fderiv_eq_zero
-          (convex_ball z₀ ε).isPreconnected hdiff hfd hbball (mem_ball_self hε))
-      · exact hz
+    have hderiv : ∀ᶠ z in 𝓝[≠] z₀, deriv f z ≠ 0 :=
+      eventually_deriv_ne_zero_of_eventually_ne hf (hisol.mono fun _ h => sub_ne_zero.mp h)
     -- one neighbourhood on which every requirement holds at once
     have hall : ∀ᶠ z in 𝓝 z₀, AnalyticAt ℂ f z ∧ z ∈ V ∧
         (z ≠ z₀ → f z ≠ f z₀) ∧ (z ≠ z₀ → deriv f z ≠ 0) := by


### PR DESCRIPTION
The non-constant branch of `not_injOn_of_deriv_eq_zero` opened with a 19-line argument that has nothing to do with injectivity: from the fact that `f` differs from `f z₀` throughout a punctured neighbourhood, deduce that `deriv f` is nonvanishing on one. That is a standalone fact about analytic functions, so it is extracted:

```lean
private theorem eventually_deriv_ne_zero_of_eventually_ne {f : ℂ → ℂ} {z₀ : ℂ}
    (hf : AnalyticAt ℂ f z₀) (hne : ∀ᶠ z in 𝓝[≠] z₀, f z ≠ f z₀) :
    ∀ᶠ z in 𝓝[≠] z₀, deriv f z ≠ 0
```

**Hypotheses were re-derived at extraction, not inherited.** The parent had `deriv f z₀ = 0`, the neighbourhood `V`, and the injectivity hypothesis all in scope; the helper uses none of them. The parent carries the fact in the form `f z - f z₀ ≠ 0`, which is converted at the call site with `sub_ne_zero.mp` rather than being baked into the helper.

**Proof bodies:** `not_injOn_of_deriv_eq_zero` 46 → 29; new helper 19. Both under the 50-line limit, and the parent now reads as its two cases (locally constant / not) rather than burying an unrelated sub-argument in one of them.

No public surface changes — the helper is `private`, and the parent’s signature and statement are untouched.

Gates: `lake build` (zero diagnostics), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)