### PR TITLE
refactor(Contour): use Mathlib's finite-family bound for the window radius

### DIFF
--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -112,22 +112,6 @@ private theorem exists_radius_perWindow_tendsto {γ : ℝ → ℂ} {a b t₀ : �
       (fun b' h1 h2 => hc_L (t₀ - ρ) b' (by linarith) h1 h2)
       (hc_plus ρ hρ_pos hρ_le) (hc_minus ρ hρ_pos hρ_le)⟩⟩
 
-/-- **A single radius below a finite family of positive radii and a given bound.** Given positive
-radii `R` on a finite `T` and a bound `r₀ > 0`, there is a `ρ` with `0 < ρ < r₀` and `ρ ≤ R t` for
-every `t ∈ T`. The index type is arbitrary and `T` may be empty, where the constraint is vacuous. -/
-private theorem exists_uniform_window_radius {ι : Type*} {T : Finset ι} {R : ι → ℝ}
-    (hR_pos : ∀ t ∈ T, 0 < R t) {r₀ : ℝ} (hr₀ : 0 < r₀) :
-    ∃ ρ, 0 < ρ ∧ ρ < r₀ ∧ ∀ t ∈ T, ρ ≤ R t := by
-  obtain ⟨ρ, hρ, hlt⟩ := Pi.exists_forall_pos_add_lt (ι := Option {t // t ∈ T})
-    (x := fun _ => (0 : ℝ)) (y := fun i => i.elim r₀ fun t => R t.1)
-    (fun i => by
-      cases i with
-      | none => simpa using hr₀
-      | some t => simpa using hR_pos t.1 t.2)
-  refine ⟨ρ, hρ, ?_, fun t ht => ?_⟩
-  · simpa using hlt none
-  · exact le_of_lt (by simpa using hlt (some ⟨t, ht⟩))
-
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal
 value of `t ↦ (γ t - s)⁻¹ * deriv γ t` at `s` exists on `[a, b]`. Endpoint crossings are
@@ -161,7 +145,16 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       exists_radius_perWindow_tendsto h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
     obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
       hT_ne h_Ioo fun t _ => Finset.notMem_empty t
-    obtain ⟨ρ, hρ_pos, hρ_lt, hρ_le_R⟩ := exists_uniform_window_radius hR_pos hr₀_pos
+    -- one radius below both the endpoint bound `r₀` and every per-crossing radius `R t`
+    obtain ⟨ρ, hρ_pos, hρ_all⟩ := Pi.exists_forall_pos_add_lt (ι := Option {t // t ∈ T})
+      (x := fun _ => (0 : ℝ)) (y := fun i => i.elim r₀ fun t => R t.1)
+      (fun i => by
+        cases i with
+        | none => simpa using hr₀_pos
+        | some t => simpa using hR_pos t.1 t.2)
+    have hρ_lt : ρ < r₀ := by simpa using hρ_all none
+    have hρ_le_R : ∀ t ∈ T, ρ ≤ R t := fun t ht =>
+      le_of_lt (by simpa using hρ_all (some ⟨t, ht⟩))
     refine cauchyPVExistsAt_of_perWindow_tendsto hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -111,6 +111,19 @@ private theorem exists_radius_perWindow_tendsto {γ : ℝ → ℂ} {a b t₀ : �
       (fun b' h1 h2 => hc_L (t₀ - ρ) b' (by linarith) h1 h2)
       (hc_plus ρ hρ_pos hρ_le) (hc_minus ρ hρ_pos hρ_le)⟩⟩
 
+/-- **A single radius below a finite family of positive radii and a given bound.** For a nonempty
+finite `T`, positive radii `R` on `T`, and `r₀ > 0`, there is a `ρ` with `0 < ρ < r₀` and
+`ρ ≤ R t` for every `t ∈ T`. -/
+private theorem exists_uniform_window_radius {T : Finset ℝ} (hT : T.Nonempty) {R : ℝ → ℝ}
+    (hR_pos : ∀ t ∈ T, 0 < R t) {r₀ : ℝ} (hr₀ : 0 < r₀) :
+    ∃ ρ, 0 < ρ ∧ ρ < r₀ ∧ ∀ t ∈ T, ρ ≤ R t := by
+  have hinf_pos : 0 < T.inf' hT R := (Finset.lt_inf'_iff hT).mpr hR_pos
+  refine ⟨min r₀ (T.inf' hT R) / 2, half_pos (lt_min hr₀ hinf_pos), ?_, fun t ht => ?_⟩
+  · have := min_le_left r₀ (T.inf' hT R); linarith
+  · have h1 := Finset.inf'_le R ht
+    have h2 := min_le_right r₀ (T.inf' hT R)
+    linarith
+
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal
 value of `t ↦ (γ t - s)⁻¹ * deriv γ t` at `s` exists on `[a, b]`. Endpoint crossings are
@@ -144,16 +157,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       exists_radius_perWindow_tendsto h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
     obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
       hT_ne h_Ioo fun t _ => Finset.notMem_empty t
-    set ρ : ℝ := min r₀ (T.inf' hT_ne R) / 2 with hρ_def
-    have hRmin_pos : 0 < T.inf' hT_ne R := (Finset.lt_inf'_iff hT_ne).mpr hR_pos
-    have hρ_pos : 0 < ρ := half_pos (lt_min hr₀_pos hRmin_pos)
-    have hρ_lt : ρ < r₀ := by
-      have := min_le_left r₀ (T.inf' hT_ne R)
-      rw [hρ_def]; linarith
-    have hρ_le_R : ∀ t ∈ T, ρ ≤ R t := fun t ht => by
-      have h1 := Finset.inf'_le R ht
-      have h2 := min_le_right r₀ (T.inf' hT_ne R)
-      rw [hρ_def]; linarith
+    obtain ⟨ρ, hρ_pos, hρ_lt, hρ_le_R⟩ := exists_uniform_window_radius hT_ne hR_pos hr₀_pos
     refine cauchyPVExistsAt_of_perWindow_tendsto hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -111,18 +111,20 @@ private theorem exists_radius_perWindow_tendsto {γ : ℝ → ℂ} {a b t₀ : �
       (fun b' h1 h2 => hc_L (t₀ - ρ) b' (by linarith) h1 h2)
       (hc_plus ρ hρ_pos hρ_le) (hc_minus ρ hρ_pos hρ_le)⟩⟩
 
-/-- **A single radius below a finite family of positive radii and a given bound.** For a nonempty
-finite `T`, positive radii `R` on `T`, and `r₀ > 0`, there is a `ρ` with `0 < ρ < r₀` and
-`ρ ≤ R t` for every `t ∈ T`. -/
-private theorem exists_uniform_window_radius {T : Finset ℝ} (hT : T.Nonempty) {R : ℝ → ℝ}
+/-- **A single radius below a finite family of positive radii and a given bound.** Given positive
+radii `R` on a finite `T` and a bound `r₀ > 0`, there is a `ρ` with `0 < ρ < r₀` and `ρ ≤ R t` for
+every `t ∈ T`. The index type is arbitrary and `T` may be empty, where the constraint is vacuous. -/
+private theorem exists_uniform_window_radius {ι : Type*} {T : Finset ι} {R : ι → ℝ}
     (hR_pos : ∀ t ∈ T, 0 < R t) {r₀ : ℝ} (hr₀ : 0 < r₀) :
     ∃ ρ, 0 < ρ ∧ ρ < r₀ ∧ ∀ t ∈ T, ρ ≤ R t := by
-  have hinf_pos : 0 < T.inf' hT R := (Finset.lt_inf'_iff hT).mpr hR_pos
-  refine ⟨min r₀ (T.inf' hT R) / 2, half_pos (lt_min hr₀ hinf_pos), ?_, fun t ht => ?_⟩
-  · have := min_le_left r₀ (T.inf' hT R); linarith
-  · have h1 := Finset.inf'_le R ht
-    have h2 := min_le_right r₀ (T.inf' hT R)
-    linarith
+  rcases T.eq_empty_or_nonempty with rfl | hT
+  · exact ⟨r₀ / 2, half_pos hr₀, by linarith, by simp⟩
+  · have hinf_pos : 0 < T.inf' hT R := (Finset.lt_inf'_iff hT).mpr hR_pos
+    refine ⟨min r₀ (T.inf' hT R) / 2, half_pos (lt_min hr₀ hinf_pos), ?_, fun t ht => ?_⟩
+    · have := min_le_left r₀ (T.inf' hT R); linarith
+    · have h1 := Finset.inf'_le R ht
+      have h2 := min_le_right r₀ (T.inf' hT R)
+      linarith
 
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal
@@ -157,7 +159,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       exists_radius_perWindow_tendsto h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
     obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
       hT_ne h_Ioo fun t _ => Finset.notMem_empty t
-    obtain ⟨ρ, hρ_pos, hρ_lt, hρ_le_R⟩ := exists_uniform_window_radius hT_ne hR_pos hr₀_pos
+    obtain ⟨ρ, hρ_pos, hρ_lt, hρ_le_R⟩ := exists_uniform_window_radius hR_pos hr₀_pos
     refine cauchyPVExistsAt_of_perWindow_tendsto hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -16,6 +16,7 @@ import TauCeti.Analysis.Contour.Crossing.PVAggregation
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.PerWindow.CPV
 import TauCeti.Analysis.Contour.PiecewiseC1On
+import Mathlib.Algebra.Order.Field.Pi
 
 /-!
 # Existence of the Cauchy-kernel principal value along an immersed curve
@@ -117,14 +118,15 @@ every `t ∈ T`. The index type is arbitrary and `T` may be empty, where the con
 private theorem exists_uniform_window_radius {ι : Type*} {T : Finset ι} {R : ι → ℝ}
     (hR_pos : ∀ t ∈ T, 0 < R t) {r₀ : ℝ} (hr₀ : 0 < r₀) :
     ∃ ρ, 0 < ρ ∧ ρ < r₀ ∧ ∀ t ∈ T, ρ ≤ R t := by
-  rcases T.eq_empty_or_nonempty with rfl | hT
-  · exact ⟨r₀ / 2, half_pos hr₀, by linarith, by simp⟩
-  · have hinf_pos : 0 < T.inf' hT R := (Finset.lt_inf'_iff hT).mpr hR_pos
-    refine ⟨min r₀ (T.inf' hT R) / 2, half_pos (lt_min hr₀ hinf_pos), ?_, fun t ht => ?_⟩
-    · have := min_le_left r₀ (T.inf' hT R); linarith
-    · have h1 := Finset.inf'_le R ht
-      have h2 := min_le_right r₀ (T.inf' hT R)
-      linarith
+  obtain ⟨ρ, hρ, hlt⟩ := Pi.exists_forall_pos_add_lt (ι := Option {t // t ∈ T})
+    (x := fun _ => (0 : ℝ)) (y := fun i => i.elim r₀ fun t => R t.1)
+    (fun i => by
+      cases i with
+      | none => simpa using hr₀
+      | some t => simpa using hR_pos t.1 t.2)
+  refine ⟨ρ, hρ, ?_, fun t ht => ?_⟩
+  · simpa using hlt none
+  · exact le_of_lt (by simpa using hlt (some ⟨t, ht⟩))
 
 /-- **Existence of the Cauchy-kernel principal value along a piecewise-`C¹` immersion**: if
 every parameter of `[a, b]` where `γ` meets `s` is interior, the single-point Cauchy principal


### PR DESCRIPTION
The non-empty branch of `IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub` built a single window radius below both a common endpoint bound `r₀` and the per-crossing radii `R`, using `min`, `Finset.inf'` and three `linarith` steps.

Mathlib already has that construction. `Pi.exists_forall_pos_add_lt` (`Algebra/Order/Field/Pi.lean:25`) produces, for a finite family with `x i < y i`, a single `ε > 0` with `x i + ε < y i` for every `i`. Applying it over `Option {t // t ∈ T}` — `none` carrying `r₀`, `some t` carrying `R t` — yields `ρ < r₀` and `ρ ≤ R t` directly from its strict conclusion.

**What this PR does, corrected.** It opened as an extraction that shortened the parent from 49 lines to 40. Review moved it somewhere better: `generality` widened the extracted helper to an arbitrary index type and a possibly-empty finset, which is exactly what made the Mathlib lemma applicable; `reuse` then had it call that lemma; and once it did, the helper was a thin wrapper that only weakened the lemma’s strict bounds, so `reuse` had it inlined and removed.

So **the parent body is 49 lines either way** — this no longer shortens anything. What it removes is the hand-rolled infimum construction and the `Finset.Nonempty` case split, in favour of the Mathlib theorem that does the same work. I have relabelled the PR accordingly rather than leave the original line-count claim standing.

Gates: `lake build` (zero diagnostics), `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` all green. Rebased onto current main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)