### PR TITLE
feat(Algebra): a pair of embeddings is realized by a finitely supported permutation

### DIFF
--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -88,4 +88,14 @@ theorem exists_compl_fixedBy_subset_apply_eq {ι β : Type*} [Finite ι] (f g : 
           Equiv.Perm.viaFintypeEmbedding_apply_image σ _ (f.codRestrict T hfT i)
       _ = g i := congrArg Subtype.val (hσ i)
 
+/-- Finite-support form of `Equiv.Perm.exists_compl_fixedBy_subset_apply_eq`: for `f g : ι ↪ β`
+with `ι` finite there is a permutation of `β` carrying each `f i` to `g i` whose support is finite.
+
+This is the shape consumers of finitely supported reindexing want, `(MulAction.fixedBy β σ)ᶜ.Finite`
+being Mathlib's finite-support predicate. -/
+theorem exists_finite_compl_fixedBy_apply_eq {ι β : Type*} [Finite ι] (f g : ι ↪ β) :
+    ∃ σ : Equiv.Perm β, (MulAction.fixedBy β σ)ᶜ.Finite ∧ ∀ i, σ (f i) = g i := by
+  obtain ⟨σ, hsub, hval⟩ := exists_compl_fixedBy_subset_apply_eq f g
+  exact ⟨σ, ((Set.finite_range f).union (Set.finite_range g)).subset hsub, hval⟩
+
 end Equiv.Perm

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -9,6 +9,7 @@ public import Mathlib.Algebra.Group.Action.End
 public import Mathlib.Data.Set.Finite.Lattice
 public import Mathlib.Order.Interval.Finset.Nat
 public import Mathlib.Logic.Equiv.Fintype
+public import Mathlib.Logic.Embedding.Set
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 
 /-!
@@ -54,38 +55,37 @@ theorem finite_compl_fixedBy_conj {G α : Type*} [Group G] [MulAction G α] {g h
     (MulAction.fixedBy α (g⁻¹ * h * g))ᶜ.Finite := by
   simpa [Set.smul_set_compl, MulAction.smul_fixedBy] using hh.smul_set (a := g⁻¹)
 
-/-- **A pair of embeddings from a finite type is realised by a finitely supported permutation.**
-For `f g : ι ↪ β` with `ι` finite there is a permutation of `β` carrying each `f i` to `g i` and
-fixing everything outside the finite set `range f ∪ range g`.
+end TauCeti
 
-Mathlib's `Equiv.Perm.exists_extending_pair` already supplies a permutation with the right values,
-but it matches the complements of the ranges by an arbitrary bijection, so it need not be finitely
-supported. Applying it inside the finite subtype `range f ∪ range g` and pushing the result out with
-`Equiv.Perm.viaFintypeEmbedding` keeps it the identity off that set. -/
-theorem exists_finiteSupport_perm_apply_eq {ι β : Type*} [Finite ι] (f g : ι ↪ β) :
-    ∃ σ : Equiv.Perm β, (MulAction.fixedBy β σ)ᶜ.Finite ∧ ∀ i, σ (f i) = g i := by
+namespace Equiv.Perm
+
+/-- **A pair of embeddings from a finite type is realised by a permutation supported on their
+ranges.** For `f g : ι ↪ β` with `ι` finite there is a permutation of `β` carrying each `f i` to
+`g i` and fixing every point outside `Set.range f ∪ Set.range g`.
+
+That union is finite, so `Set.Finite.subset` turns the containment into finite support in the sense
+of `(MulAction.fixedBy β σ)ᶜ.Finite`. -/
+theorem exists_compl_fixedBy_subset_apply_eq {ι β : Type*} [Finite ι] (f g : ι ↪ β) :
+    ∃ σ : Equiv.Perm β,
+      (MulAction.fixedBy β σ)ᶜ ⊆ Set.range f ∪ Set.range g ∧ ∀ i, σ (f i) = g i := by
   classical
   set T : Set β := Set.range f ∪ Set.range g with hT
-  have hTfin : T.Finite := (Set.finite_range f).union (Set.finite_range g)
-  haveI : Fintype ↥T := hTfin.fintype
+  haveI : Fintype ↥T := ((Set.finite_range f).union (Set.finite_range g)).fintype
   have hfT : ∀ i, f i ∈ T := fun i => Or.inl ⟨i, rfl⟩
   have hgT : ∀ i, g i ∈ T := fun i => Or.inr ⟨i, rfl⟩
-  have hf' : Function.Injective (fun i => (⟨f i, hfT i⟩ : ↥T)) := fun a b h =>
-    f.injective (congrArg Subtype.val h)
-  have hg' : Function.Injective (fun i => (⟨g i, hgT i⟩ : ↥T)) := fun a b h =>
-    g.injective (congrArg Subtype.val h)
-  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hf' hg'
-  set emb : ↥T ↪ β := ⟨Subtype.val, Subtype.val_injective⟩ with hemb
-  refine ⟨Equiv.Perm.viaFintypeEmbedding σ emb, hTfin.subset fun b hb => ?_, fun i => ?_⟩
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair (f.codRestrict T hfT) (g.codRestrict T hgT)
+    (f.codRestrict T hfT).injective (g.codRestrict T hgT).injective
+  refine ⟨Equiv.Perm.viaFintypeEmbedding σ (Function.Embedding.subtype _), fun b hb => ?_,
+    fun i => ?_⟩
   · by_contra hbT
     refine hb ?_
     simp only [MulAction.mem_fixedBy, Equiv.Perm.smul_def]
-    refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range σ emb ?_
+    refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range σ _ ?_
     rintro ⟨x, rfl⟩
     exact hbT x.2
-  · calc (Equiv.Perm.viaFintypeEmbedding σ emb) (f i)
-        = ((σ ⟨f i, hfT i⟩ : ↥T) : β) :=
-          Equiv.Perm.viaFintypeEmbedding_apply_image σ emb ⟨f i, hfT i⟩
+  · calc (Equiv.Perm.viaFintypeEmbedding σ (Function.Embedding.subtype _)) (f i)
+        = ((σ (f.codRestrict T hfT i) : ↥T) : β) :=
+          Equiv.Perm.viaFintypeEmbedding_apply_image σ _ (f.codRestrict T hfT i)
       _ = g i := congrArg Subtype.val (hσ i)
 
-end TauCeti
+end Equiv.Perm

--- a/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
+++ b/TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean
@@ -8,6 +8,7 @@ public import Mathlib.GroupTheory.GroupAction.FixedPoints
 public import Mathlib.Algebra.Group.Action.End
 public import Mathlib.Data.Set.Finite.Lattice
 public import Mathlib.Order.Interval.Finset.Nat
+public import Mathlib.Logic.Equiv.Fintype
 import Mathlib.Algebra.Group.Pointwise.Set.Finite
 
 /-!
@@ -52,5 +53,39 @@ theorem finite_compl_fixedBy_conj {G α : Type*} [Group G] [MulAction G α] {g h
     (hh : (MulAction.fixedBy α h)ᶜ.Finite) :
     (MulAction.fixedBy α (g⁻¹ * h * g))ᶜ.Finite := by
   simpa [Set.smul_set_compl, MulAction.smul_fixedBy] using hh.smul_set (a := g⁻¹)
+
+/-- **A pair of embeddings from a finite type is realised by a finitely supported permutation.**
+For `f g : ι ↪ β` with `ι` finite there is a permutation of `β` carrying each `f i` to `g i` and
+fixing everything outside the finite set `range f ∪ range g`.
+
+Mathlib's `Equiv.Perm.exists_extending_pair` already supplies a permutation with the right values,
+but it matches the complements of the ranges by an arbitrary bijection, so it need not be finitely
+supported. Applying it inside the finite subtype `range f ∪ range g` and pushing the result out with
+`Equiv.Perm.viaFintypeEmbedding` keeps it the identity off that set. -/
+theorem exists_finiteSupport_perm_apply_eq {ι β : Type*} [Finite ι] (f g : ι ↪ β) :
+    ∃ σ : Equiv.Perm β, (MulAction.fixedBy β σ)ᶜ.Finite ∧ ∀ i, σ (f i) = g i := by
+  classical
+  set T : Set β := Set.range f ∪ Set.range g with hT
+  have hTfin : T.Finite := (Set.finite_range f).union (Set.finite_range g)
+  haveI : Fintype ↥T := hTfin.fintype
+  have hfT : ∀ i, f i ∈ T := fun i => Or.inl ⟨i, rfl⟩
+  have hgT : ∀ i, g i ∈ T := fun i => Or.inr ⟨i, rfl⟩
+  have hf' : Function.Injective (fun i => (⟨f i, hfT i⟩ : ↥T)) := fun a b h =>
+    f.injective (congrArg Subtype.val h)
+  have hg' : Function.Injective (fun i => (⟨g i, hgT i⟩ : ↥T)) := fun a b h =>
+    g.injective (congrArg Subtype.val h)
+  obtain ⟨σ, hσ⟩ := Equiv.Perm.exists_extending_pair _ _ hf' hg'
+  set emb : ↥T ↪ β := ⟨Subtype.val, Subtype.val_injective⟩ with hemb
+  refine ⟨Equiv.Perm.viaFintypeEmbedding σ emb, hTfin.subset fun b hb => ?_, fun i => ?_⟩
+  · by_contra hbT
+    refine hb ?_
+    simp only [MulAction.mem_fixedBy, Equiv.Perm.smul_def]
+    refine Equiv.Perm.viaFintypeEmbedding_apply_notMem_range σ emb ?_
+    rintro ⟨x, rfl⟩
+    exact hbT x.2
+  · calc (Equiv.Perm.viaFintypeEmbedding σ emb) (f i)
+        = ((σ ⟨f i, hfT i⟩ : ↥T) : β) :=
+          Equiv.Perm.viaFintypeEmbedding_apply_image σ emb ⟨f i, hfT i⟩
+      _ = g i := congrArg Subtype.val (hσ i)
 
 end TauCeti


### PR DESCRIPTION
```lean
theorem exists_finiteSupport_perm_apply_eq {ι β : Type*} [Finite ι] (f g : ι ↪ β) :
    ∃ σ : Equiv.Perm β, (MulAction.fixedBy β σ)ᶜ.Finite ∧ ∀ i, σ (f i) = g i
```

## Roadmap

`TauCetiRoadmap/Exchangeability/README.md`, **Layer 6**.

Prerequisite for
[TauCetiProject/TauCetiRoadmap#103](https://github.com/TauCetiProject/TauCetiRoadmap/issues/103)
(`conditionallyIID_of_contractable`), shipped separately per the one-topic rule. Does **not** close
it.

**The concrete need.** The joint-rectangle factorization must transport a block identity from the
prefix `i ↦ i` to an arbitrary injective selection `k`, *keeping* the directing-measure event
`ν ⁻¹' S`. Since `ν` is tail-measurable and `pathTail ≤ exchangeableSigma`, it is fixed by every
**finitely supported** reindexing — so the transport needs a permutation that both realises `k` on
the initial segment and has finite support.

## Why Mathlib's version is not enough on its own

`Equiv.Perm.exists_extending_pair` supplies a permutation with the right values, but it matches the
complements of the two ranges by an arbitrary bijection, so it carries no support guarantee. The fix
is to apply it inside the **finite subtype** `range f ∪ range g` and push the result out with
`Equiv.Perm.viaFintypeEmbedding`, which is the identity off that set
(`viaFintypeEmbedding_apply_notMem_range`). Support is then contained in a finite set by
construction.

## Generality and placement

Stated for arbitrary embeddings from a finite type, not for `Fin m → ℕ`, since nothing in the
argument uses more. The de Finetti use case is a direct instantiation:

```lean
exists_finiteSupport_perm_apply_eq ⟨Fin.val, Fin.val_injective⟩ ⟨k, hk⟩
```

Placed in the existing `TauCeti/Algebra/GroupAction/FiniteSupportPerm.lean`, which already collects
bridges for `(MulAction.fixedBy ι π)ᶜ.Finite`.

**Not done here:** `HewittSavage.lean`'s private `blockSwap` is a candidate consumer, but it carries
concrete index bounds (`blockSwap_apply_of_lt` and friends) beyond mere existence, so refactoring it
onto this theorem is a separate question and not attempted in this PR.

## Verification

* Full `lake build` green (5724 jobs).
* `lake exe axioms`: `propext`, `Classical.choice`, `Quot.sound` only.
* `scripts/lint-env.sh` passes with no new violations.
* Smoke-tested standalone, including the `Fin m → ℕ` instantiation above.
