### PR TITLE
feat: add the class-multiplication matrices of a finite group

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -93,6 +93,15 @@ theorem classSum_commutes {k : Type*} [Semiring k] (C : ConjClasses G) (g : G) :
 
 end
 
+/-- The class sum of the conjugacy class of `1` is the unit of the group algebra: that class is the
+singleton `{1}`. -/
+@[simp]
+theorem classSum_mk_one (k : Type*) [Semiring k] :
+    classSum k (ConjClasses.mk (1 : G)) = 1 := by
+  ext g
+  rw [classSum_coeff, MonoidAlgebra.one_def, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+  simp [ConjClasses.mk_eq_mk_iff_isConj, eq_comm]
+
 /-- Every class sum lies in the center of the group algebra. -/
 theorem classSum_mem_center (k : Type*) [CommSemiring k] (C : ConjClasses G) :
     classSum k C ∈ Subalgebra.center k (MonoidAlgebra k G) := by

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -99,8 +99,8 @@ singleton `{1}`. -/
 theorem classSum_mk_one (k : Type*) [Semiring k] :
     classSum k (ConjClasses.mk (1 : G)) = 1 := by
   ext g
-  rw [classSum_coeff, MonoidAlgebra.one_def, MonoidAlgebra.coeff_single, Finsupp.single_apply]
-  simp [ConjClasses.mk_eq_mk_iff_isConj, eq_comm]
+  simp [MonoidAlgebra.one_def, MonoidAlgebra.coeff_single, Finsupp.single_apply,
+    ConjClasses.mk_eq_mk_iff_isConj, eq_comm]
 
 /-- Every class sum lies in the center of the group algebra. -/
 theorem classSum_mem_center (k : Type*) [CommSemiring k] (C : ConjClasses G) :

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
@@ -87,6 +87,12 @@ theorem classSumCenter_coe (C : ConjClasses G) :
     (classSumCenter (k := k) C : MonoidAlgebra k G) = classSum k C :=
   (rfl)
 
+/-- The class sum of the conjugacy class of `1`, as an element of the center, is `1`. -/
+@[simp]
+theorem classSumCenter_mk_one : classSumCenter (k := k) (ConjClasses.mk (1 : G)) = 1 := by
+  apply Subtype.ext
+  simp
+
 /-- Convert a function on conjugacy classes to the corresponding linear combination of class
 sums. -/
 noncomputable def ofConjClassesCenter (f : ConjClasses G → k) :

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
@@ -81,13 +81,15 @@ matrix with `(Cⱼ, Cₖ)` entry the structure constant `aᵢₖⱼ`.
 The transposed index order is fixed so that `classMultMatrix Cᵢ` is the matrix of left
 multiplication by the class sum `K_{Cᵢ}` on the centre of the group algebra, taken in the class-sum
 basis (`TauCeti.classMultMatrix_map_intCast`). -/
-@[expose] def classMultMatrix (Cᵢ : ConjClasses G) : Matrix (ConjClasses G) (ConjClasses G) ℤ :=
+def classMultMatrix (Cᵢ : ConjClasses G) : Matrix (ConjClasses G) (ConjClasses G) ℤ :=
   Matrix.of fun Cⱼ Cₖ => (structureConstant Cᵢ Cₖ Cⱼ : ℤ)
 
 @[simp]
 theorem classMultMatrix_apply (Cᵢ Cⱼ Cₖ : ConjClasses G) :
     classMultMatrix Cᵢ Cⱼ Cₖ = (structureConstant Cᵢ Cₖ Cⱼ : ℤ) :=
-  rfl
+  -- `(rfl)` rather than `rfl`: the parenthesized form does not export the equation as a
+  -- definitional unfolding, so the body of `classMultMatrix` stays unexposed.
+  (rfl)
 
 /-- **The class-multiplication matrix is the matrix of multiplication by the class sum**: pushing
 `classMultMatrix Cᵢ` into any commutative ring `k` gives the matrix of left multiplication by

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
@@ -29,8 +29,15 @@ of the file, and everything else follows from it:
 
 Since `TauCeti.structureConstant` is a genuine `def` on `[Fintype G] [DecidableEq G]` data, so is
 `classMultMatrix`; these integers and matrices are the whole input to the Burnside--Dixon--Schneider
-character-table algorithm, where the values of a central character on the class sums appear as a
-common eigenvector of the family `{Mᵢ}`.
+character-table algorithm. The eigenvector orientation there is pinned, and the index order above is
+what pins it: writing `vⱼ = ω(K_{Cⱼ})` for the values of a central character on the class sums, the
+row vector `v` is a common **left** eigenvector of the family `{Mᵢ}`, acting from the left via
+`Matrix.vecMul` (`ᵥ*`), with `v ᵥ* Mᵢ = ω(K_{Cᵢ}) • v`. It is *not* a column eigenvector under
+`Matrix.mulVec` (`*ᵥ`): that convention would require the transposed matrix `aᵢⱼₖ` instead. The `*ᵥ`
+action recorded below in `TauCeti.classMultMatrix_mulVec` is a different statement — that `Mᵢ`
+carries class-sum coordinates to the coordinates of the product, which is exactly what makes `Mᵢ` a
+matrix of left multiplication — and not an eigenvector relation. The eigenvector theorem itself
+needs central characters, so it is deferred to the layer that constructs them.
 
 ## References
 
@@ -53,12 +60,6 @@ section Center
 
 variable (k : Type*) [CommSemiring k]
 
-/-- The class sum of the conjugacy class of `1`, as an element of the centre, is `1`. -/
-@[simp]
-theorem classSumCenter_mk_one : classSumCenter (k := k) (ConjClasses.mk (1 : G)) = 1 := by
-  apply Subtype.ext
-  simp
-
 /-- **The structure constants are the matrix of multiplication by a class sum**, entrywise: the
 matrix of left multiplication by `K_{Cᵢ}` on the centre of `k[G]`, in the class-sum basis, has
 `(Cⱼ, Cₖ)` entry `aᵢₖⱼ`. -/
@@ -66,9 +67,9 @@ theorem leftMulMatrix_classSumCenter_apply (Cᵢ Cⱼ Cₖ : ConjClasses G) :
     Algebra.leftMulMatrix (classSumBasis (k := k)) (classSumCenter Cᵢ) Cⱼ Cₖ =
       (structureConstant Cᵢ Cₖ Cⱼ : k) := by
   obtain ⟨g, rfl⟩ := ConjClasses.exists_rep Cⱼ
-  rw [Algebra.leftMulMatrix_eq_repr_mul, classSumBasis_apply, classSumBasis_repr_apply,
-    centerToConjClasses_mk, MulMemClass.coe_mul, classSumCenter_coe, classSumCenter_coe]
-  exact coeff_classSum_mul k Cᵢ Cₖ g
+  simpa only [Algebra.leftMulMatrix_eq_repr_mul, classSumBasis_apply, classSumBasis_repr_apply,
+    centerToConjClasses_mk, MulMemClass.coe_mul, classSumCenter_coe] using
+    coeff_classSum_mul k Cᵢ Cₖ g
 
 end Center
 
@@ -95,7 +96,7 @@ theorem classMultMatrix_map_intCast (k : Type*) [CommRing k] (Cᵢ : ConjClasses
     (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) =
       Algebra.leftMulMatrix (classSumBasis (k := k)) (classSumCenter Cᵢ) := by
   ext Cⱼ Cₖ
-  rw [Matrix.map_apply, classMultMatrix_apply, leftMulMatrix_classSumCenter_apply,
+  simp only [Matrix.map_apply, classMultMatrix_apply, leftMulMatrix_classSumCenter_apply,
     Int.cast_natCast]
 
 /-- The class-multiplication matrix over `ℤ` is itself a matrix of multiplication by a class sum,
@@ -131,7 +132,10 @@ theorem classMultMatrix_mk_one : classMultMatrix (ConjClasses.mk (1 : G)) = 1 :=
   rw [classMultMatrix_eq_leftMulMatrix, classSumCenter_mk_one, map_one]
 
 /-- **The class-multiplication matrix acts by multiplication by the class sum**: it sends the vector
-of class-sum coordinates of a central element `z` to the coordinates of `K_{Cᵢ} * z`. -/
+of class-sum coordinates of a central element `z` to the coordinates of `K_{Cᵢ} * z`.
+
+This `*ᵥ` action is the defining property of a matrix of left multiplication; it is not the pinned
+eigenvector relation, which is a `ᵥ*` action on the central-character row vectors. -/
 theorem classMultMatrix_mulVec (k : Type*) [CommRing k] (Cᵢ : ConjClasses G)
     (z : Subalgebra.center k (MonoidAlgebra k G)) :
     (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) *ᵥ centerToConjClasses z =

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.StructureConstants
+public import Mathlib.LinearAlgebra.Matrix.ToLin
+
+/-!
+# The class-multiplication matrices of a finite group
+
+The centre of the group algebra `k[G]` of a finite group has the class sums `K_C` as a `k`-basis
+(`TauCeti.classSumBasis`), and multiplication in that basis is described by the structure constants
+`aᵢⱼₖ` (`TauCeti.structureConstant`). This file records the matrices of that multiplication.
+
+The **class-multiplication matrix** `classMultMatrix Cᵢ` is the integer matrix with entries
+`(Mᵢ)ⱼₖ = aᵢₖⱼ`. The index order is not an accident: it makes `Mᵢ` exactly the matrix of left
+multiplication by `K_{Cᵢ}` on the centre, taken in the class-sum basis, which is Mathlib's
+`Algebra.leftMulMatrix`. That identification (`TauCeti.classMultMatrix_map_intCast`) is the content
+of the file, and everything else follows from it:
+
+* `TauCeti.classMultMatrix_commute`: the matrices `Mᵢ` commute pairwise, because the centre is a
+  commutative ring and `Algebra.leftMulMatrix` is an algebra homomorphism;
+* `TauCeti.classMultMatrix_injective`: distinct classes give distinct matrices;
+* `TauCeti.classMultMatrix_mk_one`: the matrix at the class of `1` is the identity matrix;
+* `TauCeti.classMultMatrix_mulVec`: `Mᵢ` acts on the coordinate vector of a central element by
+  multiplication by `K_{Cᵢ}`.
+
+Since `TauCeti.structureConstant` is a genuine `def` on `[Fintype G] [DecidableEq G]` data, so is
+`classMultMatrix`; these integers and matrices are the whole input to the Burnside--Dixon--Schneider
+character-table algorithm, where the values of a central character on the class sums appear as a
+common eigenvector of the family `{Mᵢ}`.
+
+## References
+
+This implements the object `classMultMatrix` and the milestone `classMultMatrix_commute` of Layer 5
+of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md)
+and its
+[suggested declarations](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/Suggested.lean).
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Matrix
+
+variable {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+
+section Center
+
+variable (k : Type*) [CommSemiring k]
+
+/-- The class sum of the conjugacy class of `1`, as an element of the centre, is `1`. -/
+@[simp]
+theorem classSumCenter_mk_one : classSumCenter (k := k) (ConjClasses.mk (1 : G)) = 1 := by
+  apply Subtype.ext
+  simp
+
+/-- **The structure constants are the matrix of multiplication by a class sum**, entrywise: the
+matrix of left multiplication by `K_{Cᵢ}` on the centre of `k[G]`, in the class-sum basis, has
+`(Cⱼ, Cₖ)` entry `aᵢₖⱼ`. -/
+theorem leftMulMatrix_classSumCenter_apply (Cᵢ Cⱼ Cₖ : ConjClasses G) :
+    Algebra.leftMulMatrix (classSumBasis (k := k)) (classSumCenter Cᵢ) Cⱼ Cₖ =
+      (structureConstant Cᵢ Cₖ Cⱼ : k) := by
+  obtain ⟨g, rfl⟩ := ConjClasses.exists_rep Cⱼ
+  rw [Algebra.leftMulMatrix_eq_repr_mul, classSumBasis_apply, classSumBasis_repr_apply,
+    centerToConjClasses_mk, MulMemClass.coe_mul, classSumCenter_coe, classSumCenter_coe]
+  exact coeff_classSum_mul k Cᵢ Cₖ g
+
+end Center
+
+section MultMatrix
+
+/-- **The class-multiplication matrix** of a conjugacy class `Cᵢ` of a finite group: the integer
+matrix with `(Cⱼ, Cₖ)` entry the structure constant `aᵢₖⱼ`.
+
+The transposed index order is fixed so that `classMultMatrix Cᵢ` is the matrix of left
+multiplication by the class sum `K_{Cᵢ}` on the centre of the group algebra, taken in the class-sum
+basis (`TauCeti.classMultMatrix_map_intCast`). -/
+@[expose] def classMultMatrix (Cᵢ : ConjClasses G) : Matrix (ConjClasses G) (ConjClasses G) ℤ :=
+  Matrix.of fun Cⱼ Cₖ => (structureConstant Cᵢ Cₖ Cⱼ : ℤ)
+
+@[simp]
+theorem classMultMatrix_apply (Cᵢ Cⱼ Cₖ : ConjClasses G) :
+    classMultMatrix Cᵢ Cⱼ Cₖ = (structureConstant Cᵢ Cₖ Cⱼ : ℤ) :=
+  rfl
+
+/-- **The class-multiplication matrix is the matrix of multiplication by the class sum**: pushing
+`classMultMatrix Cᵢ` into any commutative ring `k` gives the matrix of left multiplication by
+`K_{Cᵢ}` on the centre of `k[G]`, taken in the class-sum basis. -/
+theorem classMultMatrix_map_intCast (k : Type*) [CommRing k] (Cᵢ : ConjClasses G) :
+    (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) =
+      Algebra.leftMulMatrix (classSumBasis (k := k)) (classSumCenter Cᵢ) := by
+  ext Cⱼ Cₖ
+  rw [Matrix.map_apply, classMultMatrix_apply, leftMulMatrix_classSumCenter_apply,
+    Int.cast_natCast]
+
+/-- The class-multiplication matrix over `ℤ` is itself a matrix of multiplication by a class sum,
+namely in the centre of the integral group algebra `ℤ[G]`. -/
+theorem classMultMatrix_eq_leftMulMatrix (Cᵢ : ConjClasses G) :
+    classMultMatrix Cᵢ = Algebra.leftMulMatrix (classSumBasis (k := ℤ)) (classSumCenter Cᵢ) := by
+  rw [← classMultMatrix_map_intCast ℤ Cᵢ]
+  ext Cⱼ Cₖ
+  simp
+
+/-- **The class-multiplication matrices commute pairwise.** They are the images of the class sums
+under an algebra homomorphism out of the centre of `ℤ[G]`, which is commutative. -/
+theorem classMultMatrix_commute (Cᵢ Cⱼ : ConjClasses G) :
+    Commute (classMultMatrix Cᵢ) (classMultMatrix (G := G) Cⱼ) := by
+  rw [classMultMatrix_eq_leftMulMatrix, classMultMatrix_eq_leftMulMatrix]
+  exact (Commute.all _ _).map _
+
+/-- **Distinct conjugacy classes have distinct class-multiplication matrices**: multiplication by a
+class sum determines it, and the class sums are a basis of the centre. -/
+theorem classMultMatrix_injective :
+    Function.Injective (classMultMatrix (G := G)) := by
+  intro Cᵢ Cⱼ h
+  rw [classMultMatrix_eq_leftMulMatrix, classMultMatrix_eq_leftMulMatrix] at h
+  have hb : (classSumBasis (k := ℤ)) Cᵢ = (classSumBasis (k := ℤ)) Cⱼ := by
+    rw [classSumBasis_apply, classSumBasis_apply]
+    exact Algebra.leftMulMatrix_injective (classSumBasis (k := ℤ)) h
+  exact (classSumBasis (k := ℤ)).injective hb
+
+/-- The class-multiplication matrix at the conjugacy class of `1` is the identity matrix: the class
+sum of `{1}` is the unit of the group algebra. -/
+@[simp]
+theorem classMultMatrix_mk_one : classMultMatrix (ConjClasses.mk (1 : G)) = 1 := by
+  rw [classMultMatrix_eq_leftMulMatrix, classSumCenter_mk_one, map_one]
+
+/-- **The class-multiplication matrix acts by multiplication by the class sum**: it sends the vector
+of class-sum coordinates of a central element `z` to the coordinates of `K_{Cᵢ} * z`. -/
+theorem classMultMatrix_mulVec (k : Type*) [CommRing k] (Cᵢ : ConjClasses G)
+    (z : Subalgebra.center k (MonoidAlgebra k G)) :
+    (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) *ᵥ centerToConjClasses z =
+      centerToConjClasses (classSumCenter Cᵢ * z) := by
+  have hrepr : ∀ w : Subalgebra.center k (MonoidAlgebra k G),
+      ((classSumBasis (k := k)).repr w : ConjClasses G → k) = centerToConjClasses w :=
+    fun w => funext fun C => classSumBasis_repr_apply w C
+  rw [classMultMatrix_map_intCast, ← hrepr z, ← hrepr (classSumCenter Cᵢ * z)]
+  exact Algebra.leftMulMatrix_mulVec_repr _ _ _
+
+end MultMatrix
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -99,4 +99,47 @@ theorem classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) :
     rw [if_neg hCₖ.symm, mul_zero]
   · simp
 
+/-- The coefficient of `g` in a product of two class sums is the structure constant at the
+conjugacy class of `g`. This is the pointwise form of `TauCeti.classSum_mul`. -/
+theorem coeff_classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) (g : G) :
+    (classSum k Cᵢ * classSum k Cⱼ).coeff g =
+      (structureConstant Cᵢ Cⱼ (ConjClasses.mk g) : k) := by
+  rw [classSum_mul]
+  simp only [MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply, MonoidAlgebra.coeff_smul_apply,
+    smul_eq_mul, classSum_coeff]
+  rw [Finset.sum_eq_single (ConjClasses.mk g)]
+  · rw [if_pos rfl, mul_one]
+  · intro Cₖ _ hCₖ
+    rw [if_neg hCₖ.symm, mul_zero]
+  · simp
+
+/-- **Counting all the factorizations at once**: weighting the structure constants by the class
+sizes gives the product of the sizes of the two classes, since every product `x * y` with `x ∈ Cᵢ`
+and `y ∈ Cⱼ` is counted exactly once on the left. -/
+theorem sum_structureConstant_mul_card_carrier (Cᵢ Cⱼ : ConjClasses G) :
+    ∑ Cₖ : ConjClasses G, structureConstant Cᵢ Cⱼ Cₖ * Nat.card Cₖ.carrier =
+      Nat.card Cᵢ.carrier * Nat.card Cⱼ.carrier := by
+  -- Apply the augmentation `ℤ[G] → ℤ`, which sends a class sum to the size of its class.
+  set φ := MonoidAlgebra.lift ℤ ℤ G 1 with hφ
+  have hclass : ∀ C : ConjClasses G, φ (classSum ℤ C) = (Nat.card C.carrier : ℤ) := by
+    intro C
+    rw [classSum_eq_sum, map_sum]
+    simp [hφ, Nat.card_eq_fintype_card]
+  have key := (map_mul φ (classSum ℤ Cᵢ) (classSum ℤ Cⱼ)).symm.trans
+    (congrArg φ (classSum_mul ℤ Cᵢ Cⱼ))
+  rw [hclass, hclass, map_sum] at key
+  simp only [map_smul, hclass, smul_eq_mul] at key
+  exact_mod_cast key.symm
+
+/-- **The structure constants are symmetric in their two class arguments**, because the two class
+sums commute in the group algebra. -/
+theorem structureConstant_comm (Cᵢ Cⱼ Cₖ : ConjClasses G) :
+    structureConstant Cᵢ Cⱼ Cₖ = structureConstant Cⱼ Cᵢ Cₖ := by
+  obtain ⟨g, rfl⟩ := ConjClasses.exists_rep Cₖ
+  have hcomm : classSum ℤ Cᵢ * classSum ℤ Cⱼ = classSum ℤ Cⱼ * classSum ℤ Cᵢ :=
+    Subalgebra.mem_center_iff.mp (classSum_mem_center ℤ Cⱼ) _
+  have h := congrArg (fun a : MonoidAlgebra ℤ G => a.coeff g) hcomm
+  simp only [coeff_classSum_mul] at h
+  exact_mod_cast h
+
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -113,24 +113,6 @@ theorem coeff_classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) 
     rw [if_neg hCₖ.symm, mul_zero]
   · simp
 
-/-- **Counting all the factorizations at once**: weighting the structure constants by the class
-sizes gives the product of the sizes of the two classes, since every product `x * y` with `x ∈ Cᵢ`
-and `y ∈ Cⱼ` is counted exactly once on the left. -/
-theorem sum_structureConstant_mul_card_carrier (Cᵢ Cⱼ : ConjClasses G) :
-    ∑ Cₖ : ConjClasses G, structureConstant Cᵢ Cⱼ Cₖ * Nat.card Cₖ.carrier =
-      Nat.card Cᵢ.carrier * Nat.card Cⱼ.carrier := by
-  -- Apply the augmentation `ℤ[G] → ℤ`, which sends a class sum to the size of its class.
-  set φ := MonoidAlgebra.lift ℤ ℤ G 1 with hφ
-  have hclass : ∀ C : ConjClasses G, φ (classSum ℤ C) = (Nat.card C.carrier : ℤ) := by
-    intro C
-    rw [classSum_eq_sum, map_sum]
-    simp [hφ, Nat.card_eq_fintype_card]
-  have key := (map_mul φ (classSum ℤ Cᵢ) (classSum ℤ Cⱼ)).symm.trans
-    (congrArg φ (classSum_mul ℤ Cᵢ Cⱼ))
-  rw [hclass, hclass, map_sum] at key
-  simp only [map_smul, hclass, smul_eq_mul] at key
-  exact_mod_cast key.symm
-
 /-- **The structure constants are symmetric in their two class arguments**, because the two class
 sums commute in the group algebra. -/
 theorem structureConstant_comm (Cᵢ Cⱼ Cₖ : ConjClasses G) :


### PR DESCRIPTION
This PR adds the class-multiplication matrices of a finite group, the first pinned object of Layer 5 of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md` ("Class-multiplication matrices, with a pinned convention": `classMultMatrix i`, `(Mᵢ)ⱼₖ = aᵢₖⱼ`, and the milestone that the `{Mᵢ}` commute), matching the `classMultMatrix` and `classMultMatrix_commute` signatures in that roadmap's `Suggested.lean`. It builds directly on the class-sum basis of the centre and the structure constants that already landed under `TauCeti/RepresentationTheory/CharacterTable/ClassSum/`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"classmultmatrix"}-->

The new module `TauCeti/RepresentationTheory/CharacterTable/ClassSum/MultiplicationMatrix.lean` defines `classMultMatrix Cᵢ : Matrix (ConjClasses G) (ConjClasses G) ℤ` as `Matrix.of fun Cⱼ Cₖ => (structureConstant Cᵢ Cₖ Cⱼ : ℤ)` — a genuine `def` on `[Fintype G] [DecidableEq G]` data, since `structureConstant` is. The mathematical content is that the roadmap's transposed index convention is exactly the standard matrix-of-a-linear-map convention: `classMultMatrix_map_intCast` shows that pushing `classMultMatrix Cᵢ` into any commutative ring `k` gives `Algebra.leftMulMatrix (classSumBasis (k := k)) (classSumCenter Cᵢ)`, the matrix of left multiplication by the class sum `K_{Cᵢ}` on `Z(k[G])` in the class-sum basis. Everything else is read off that identification rather than recomputed from the combinatorics: `classMultMatrix_commute` (the family commutes pairwise, because the centre is a commutative ring and `Algebra.leftMulMatrix` is an algebra homomorphism), `classMultMatrix_injective` (distinct classes give distinct matrices, from `Algebra.leftMulMatrix_injective` and the basis), `classMultMatrix_mk_one` (the matrix at the class of `1` is `1`), and `classMultMatrix_mulVec` (the matrix carries the class-sum coordinate vector of a central element `z` to that of `K_{Cᵢ} * z`).

Three prerequisite lemmas go into the existing files where they belong rather than into the new module. `TauCeti.classSum_mk_one` (the class sum of the class of `1` is the unit of the group algebra) joins `ClassSum/Basic.lean`, and `classSumCenter_mk_one`, its counterpart inside the centre, joins `ClassSum/Basis.lean` beside `classSumCenter_coe`. `ClassSum/StructureConstants.lean` gains `coeff_classSum_mul`, the pointwise form of the already-present `classSum_mul`, and `structureConstant_comm`, the symmetry `aᵢⱼₖ = aⱼᵢₖ`, proved from the fact that two class sums commute.

No Mathlib source is vendored. The reused Mathlib infrastructure is `Algebra.leftMulMatrix` together with `leftMulMatrix_eq_repr_mul`, `leftMulMatrix_mulVec_repr` and `leftMulMatrix_injective` from `Mathlib/LinearAlgebra/Matrix/ToLin.lean`; the regular representation of the class algebra in the class-sum basis is therefore Mathlib's algebra homomorphism, not a new one. Verified locally: `lake build` completes successfully (5773 jobs), `lake exe axioms` reports all 14105 TauCeti declarations within the allowlist `[propext, Classical.choice, Quot.sound]`, `lake exe module-system` passes, and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Claude Code

