### PR TITLE
feat: add symmetric-power representations

### DIFF
--- a/TauCeti/LinearAlgebra/SymmetricPower.lean
+++ b/TauCeti/LinearAlgebra/SymmetricPower.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.PiTensorProduct.Finite
+public import Mathlib.LinearAlgebra.TensorPower.Symmetric
+
+/-!
+# Functoriality of symmetric tensor powers
+
+This file equips Mathlib's symmetric tensor power with the linear map induced by a linear map of
+the underlying modules. It proves the expected action on pure tensors, identity law, and composition
+law. It also records that a symmetric power indexed by a finite type is finitely generated when its
+underlying module is.
+
+## Main definitions
+
+* `SymmetricPower.map` is the map induced on a symmetric tensor power.
+
+## References
+
+The quotient construction of `SymmetricPower`, including `SymmetricPower.mk` and
+`SymmetricPower.tprod`, is from Kenny Lau's
+`Mathlib.LinearAlgebra.TensorPower.Symmetric`.
+-/
+
+public section
+
+open scoped TensorProduct
+
+universe u v
+
+variable {R ι : Type u} {M : Type v}
+
+namespace SymmetricPower
+
+section CommSemiring
+
+variable [CommSemiring R]
+variable [AddCommMonoid M] [Module R M]
+
+private theorem map_rel {N : Type*} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N) :
+    addConGen (Rel R ι M) ≤
+      AddCon.ker ((mk R ι N).toAddMonoidHom.comp
+        (PiTensorProduct.map fun _ : ι => f).toAddMonoidHom) := by
+  apply AddCon.addConGen_le.2
+  intro x y h
+  cases h with
+  | perm e m =>
+      apply (AddCon.ker_rel _).2
+      simpa only [AddMonoidHom.comp_apply, LinearMap.toAddMonoidHom_coe,
+        PiTensorProduct.map_tprod, tprod, LinearMap.compMultilinearMap_apply,
+        Function.comp_apply] using (tprod_equiv (R := R) e (f ∘ m)).symm
+
+/-- A linear map induces a linear map on every symmetric tensor power. -/
+noncomputable def map {N : Type*} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N) :
+    Sym[R] ι M →ₗ[R] Sym[R] ι N where
+  toFun :=
+    (addConGen (Rel R ι M)).lift
+      ((mk R ι N).toAddMonoidHom.comp
+        (PiTensorProduct.map fun _ : ι => f).toAddMonoidHom)
+      (map_rel f)
+  map_add' := map_add _
+  map_smul' r x := AddCon.induction_on x fun x => by
+    exact congrArg (mk R ι N) ((PiTensorProduct.map fun _ : ι => f).map_smul r x)
+
+/-- The map on symmetric powers commutes with the quotient map from the tensor power. -/
+@[simp]
+theorem map_mk {N : Type*} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N)
+    (x : ⨂[R] (_ : ι), M) :
+    map f (mk R ι M x) = mk R ι N (PiTensorProduct.map (fun _ : ι => f) x) :=
+  by
+    simpa only [map, mk, LinearMap.coe_mk, AddHom.coe_mk, AddMonoidHom.toFun_eq_coe,
+      AddMonoidHom.comp_apply, LinearMap.toAddMonoidHom_coe] using
+        AddCon.lift_mk' (map_rel f) x
+
+/-- The map induced on symmetric powers sends a pure tensor to the tensor of the images. -/
+@[simp]
+theorem map_tprod {N : Type*} [AddCommMonoid N] [Module R N] (f : M →ₗ[R] N) (m : ι → M) :
+    map f (⨂ₛ[R] i, m i) = ⨂ₛ[R] i, f (m i) := by
+  simp only [tprod, LinearMap.compMultilinearMap_apply, map_mk,
+    PiTensorProduct.map_tprod]
+
+/-- The map induced by the identity is the identity on the symmetric power. -/
+@[simp]
+theorem map_id :
+    map (ι := ι) (LinearMap.id (R := R) (M := M)) = LinearMap.id := by
+  apply LinearMap.ext_on (span_tprod_eq_top (R := R) (ι := ι) (M := M))
+  rintro _ ⟨m, rfl⟩
+  simp
+
+/-- Symmetric powers preserve composition of linear maps. -/
+@[simp]
+theorem map_comp {N : Type*} {P : Type*}
+    [AddCommMonoid N] [Module R N] [AddCommMonoid P] [Module R P]
+    (f : M →ₗ[R] N) (g : N →ₗ[R] P) :
+    map (ι := ι) (g.comp f) = (map (ι := ι) g).comp (map (ι := ι) f) := by
+  apply LinearMap.ext_on (span_tprod_eq_top (R := R) (ι := ι) (M := M))
+  rintro _ ⟨m, rfl⟩
+  simp
+
+end CommSemiring
+
+section CommRing
+
+variable [CommRing R]
+variable [AddCommGroup M] [Module R M]
+variable [Finite ι] [Module.Finite R M]
+
+/-- A symmetric power indexed by a finite type is finitely generated when the underlying module
+is finitely generated. -/
+noncomputable instance finite : Module.Finite R (Sym[R] ι M) :=
+  Module.Finite.of_surjective (mk R ι M)
+    (LinearMap.range_eq_top.mp (range_mk R ι M))
+
+end CommRing
+
+end SymmetricPower

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -23,6 +23,8 @@ tensor.
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
   Layer 1, “Symmetric and exterior power representations”.
+* The standard-representation specialization is adapted from the formal template in
+  `TauCeti.RepresentationTheory.ClassicalGroups.ExteriorPower`.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean
@@ -1,0 +1,46 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.ClassicalGroups.Standard
+public import TauCeti.RepresentationTheory.SymmetricPower
+
+/-!
+# Symmetric powers of the standard representation
+
+This file specializes symmetric powers of representations to the standard representation of the
+general linear group. The resulting action applies a matrix to every factor of a pure symmetric
+tensor.
+
+## Main definitions
+
+* `TauCeti.symPowerRep` is the symmetric-power representation of `GL n k`.
+* `TauCeti.symPowerFDRep` is its bundled finite-dimensional form.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 1, “Symmetric and exterior power representations”.
+-/
+
+public section
+
+open Matrix
+open scoped TensorProduct
+
+namespace TauCeti
+
+variable (k : Type) (n d : ℕ) [CommRing k]
+
+/-- The `d`th symmetric power of the standard representation of `GL n k`. -/
+noncomputable abbrev symPowerRep :
+    Representation k (GL (Fin n) k) (Sym[k]^d (Fin n → k)) :=
+  (stdRep k n).symmetricPower d
+
+/-- The symmetric power of the standard representation, bundled as an object of `FDRep`. -/
+noncomputable abbrev symPowerFDRep : FDRep k (GL (Fin n) k) :=
+  FDRep.of (symPowerRep k n d)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SymmetricPower.lean
@@ -23,6 +23,8 @@ Intertwining maps and equivalences pass functorially to symmetric powers.
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
   Layer 1, “Symmetric and exterior power representations”.
+* The representation and equivariance constructions are adapted from the formal template in
+  `TauCeti.RepresentationTheory.ExteriorPower`.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SymmetricPower.lean
@@ -1,0 +1,211 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.Intertwining
+public import TauCeti.LinearAlgebra.SymmetricPower
+
+/-!
+# Symmetric powers of representations
+
+This file equips each symmetric power of a representation with the induced diagonal action.
+Intertwining maps and equivalences pass functorially to symmetric powers.
+
+## Main definitions
+
+* `Representation.symmetricPower` is the induced action on `Sym[R]^d M`.
+* `IntertwiningMap.symmetricPower` is the induced map between symmetric-power representations.
+* `Representation.Equiv.symmetricPower` is the induced equivalence.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 1, “Symmetric and exterior power representations”.
+-/
+
+public section
+
+open scoped TensorProduct
+
+universe v w w'
+
+variable {R : Type} {G : Type v} {M : Type w} {N : Type w'}
+
+namespace Representation
+
+section CommSemiring
+
+variable [CommSemiring R] [Monoid G]
+variable [AddCommMonoid M] [Module R M]
+
+/-- The action induced by a representation on its `d`th symmetric power. -/
+noncomputable def symmetricPower (ρ : Representation R G M) (d : ℕ) :
+    Representation R G (Sym[R]^d M) where
+  toFun g := SymmetricPower.map (ι := Fin d) (ρ g)
+  map_one' := by
+    rw [ρ.map_one, Module.End.one_eq_id, SymmetricPower.map_id,
+      Module.End.one_eq_id]
+  map_mul' g h := by
+    simpa only [map_mul, Module.End.mul_eq_comp] using
+      (SymmetricPower.map_comp (ι := Fin d) (ρ h) (ρ g))
+
+/-- The action on a symmetric power is induced by the action on the original representation. -/
+@[simp]
+theorem symmetricPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
+    ρ.symmetricPower d g = SymmetricPower.map (ι := Fin d) (ρ g) :=
+  (rfl)
+
+/-- The symmetric-power action applies the original action to every factor of a pure tensor.
+
+This is intentionally not a simp lemma: `symmetricPower_apply` followed by
+`SymmetricPower.map_tprod` already performs this simplification. -/
+theorem symmetricPower_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G)
+    (m : Fin d → M) :
+    ρ.symmetricPower d g (⨂ₛ[R] i, m i) = ⨂ₛ[R] i, ρ g (m i) := by
+  rw [symmetricPower_apply, SymmetricPower.map_tprod]
+
+end CommSemiring
+
+end Representation
+
+namespace Representation.IntertwiningMap
+
+section CommSemiring
+
+variable [CommSemiring R] [Monoid G]
+variable [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
+variable {ρ : Representation R G M} {σ : Representation R G N}
+
+/-- An intertwining map induces an intertwining map on every symmetric power. -/
+noncomputable def symmetricPower (f : IntertwiningMap ρ σ) (d : ℕ) :
+    IntertwiningMap (ρ.symmetricPower d) (σ.symmetricPower d) where
+  toLinearMap := SymmetricPower.map (ι := Fin d) f.toLinearMap
+  isIntertwining' g := by
+    rw [Representation.symmetricPower_apply, Representation.symmetricPower_apply,
+      ← SymmetricPower.map_comp, ← SymmetricPower.map_comp, f.isIntertwining']
+
+/-- The underlying linear map is the usual map induced on symmetric powers. -/
+@[simp]
+theorem symmetricPower_toLinearMap (f : IntertwiningMap ρ σ) (d : ℕ) :
+    (f.symmetricPower d).toLinearMap =
+      SymmetricPower.map (ι := Fin d) f.toLinearMap :=
+  (rfl)
+
+/-- The induced map sends a pure symmetric tensor to the tensor of the images. -/
+@[simp]
+theorem symmetricPower_apply_tprod (f : IntertwiningMap ρ σ) (d : ℕ) (m : Fin d → M) :
+    f.symmetricPower d (⨂ₛ[R] i, m i) = ⨂ₛ[R] i, f (m i) :=
+  SymmetricPower.map_tprod f.toLinearMap m
+
+/-- Symmetric powers preserve identity intertwining maps. -/
+@[simp]
+theorem symmetricPower_id (d : ℕ) :
+    (IntertwiningMap.id ρ).symmetricPower d =
+      IntertwiningMap.id (ρ.symmetricPower d) := by
+  apply IntertwiningMap.ext
+  simp
+
+/-- Symmetric powers preserve composition of intertwining maps. -/
+@[simp]
+theorem symmetricPower_comp {P : Type*} [AddCommMonoid P] [Module R P]
+    {τ : Representation R G P} (f : IntertwiningMap ρ σ) (g : IntertwiningMap σ τ) (d : ℕ) :
+    (g.comp f).symmetricPower d =
+      (g.symmetricPower d).comp (f.symmetricPower d) := by
+  apply IntertwiningMap.ext
+  exact SymmetricPower.map_comp f.toLinearMap g.toLinearMap
+
+end CommSemiring
+
+end Representation.IntertwiningMap
+
+namespace Representation.Equiv
+
+section CommSemiring
+
+variable [CommSemiring R] [Monoid G]
+variable [AddCommMonoid M] [Module R M] [AddCommMonoid N] [Module R N]
+variable {ρ : Representation R G M} {σ : Representation R G N}
+
+/-- The linear equivalence induced on `d`th symmetric powers by an equivalence of
+representations. -/
+private noncomputable def symmetricPowerLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
+    (Sym[R]^d M) ≃ₗ[R] (Sym[R]^d N) :=
+  LinearEquiv.ofLinear
+    (SymmetricPower.map (ι := Fin d) e.toLinearMap)
+    (SymmetricPower.map (ι := Fin d) e.symm.toLinearMap)
+    (by
+      rw [← SymmetricPower.map_comp, Representation.Equiv.toLinearMap_symm,
+        e.toLinearEquiv.comp_symm, SymmetricPower.map_id])
+    (by
+      rw [← SymmetricPower.map_comp, Representation.Equiv.toLinearMap_symm,
+        e.toLinearEquiv.symm_comp, SymmetricPower.map_id])
+
+private theorem symmetricPowerLinearEquiv_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (symmetricPowerLinearEquiv e d).toLinearMap =
+      SymmetricPower.map (ι := Fin d) e.toLinearMap :=
+  LinearEquiv.ofLinear_toLinearMap ..
+
+private theorem symmetricPowerLinearEquiv_symm_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (symmetricPowerLinearEquiv e d).symm.toLinearMap =
+      SymmetricPower.map (ι := Fin d) e.symm.toLinearMap :=
+  LinearEquiv.ofLinear_symm_toLinearMap ..
+
+/-- An equivalence of representations induces an equivalence of every symmetric power. -/
+noncomputable def symmetricPower (e : ρ.Equiv σ) (d : ℕ) :
+    (ρ.symmetricPower d).Equiv (σ.symmetricPower d) :=
+  .mk (symmetricPowerLinearEquiv e d) fun g => by
+    rw [symmetricPowerLinearEquiv_toLinearMap]
+    exact (e.toIntertwiningMap.symmetricPower d).isIntertwining' g
+
+private theorem symmetricPower_toLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
+    (e.symmetricPower d).toLinearEquiv = symmetricPowerLinearEquiv e d :=
+  toLinearEquiv_mk' _
+
+/-- The underlying linear map is the usual map induced on symmetric powers. -/
+@[simp]
+theorem symmetricPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
+    (e.symmetricPower d).toLinearMap =
+      SymmetricPower.map (ι := Fin d) e.toLinearMap :=
+  (rfl)
+
+/-- The induced equivalence sends a pure symmetric tensor to the tensor of the images. -/
+@[simp]
+theorem symmetricPower_apply_tprod (e : ρ.Equiv σ) (d : ℕ) (m : Fin d → M) :
+    e.symmetricPower d (⨂ₛ[R] i, m i) = ⨂ₛ[R] i, e (m i) :=
+  SymmetricPower.map_tprod e.toLinearMap m
+
+/-- Symmetric powers preserve identity equivalences. -/
+@[simp]
+theorem symmetricPower_refl (d : ℕ) :
+    (Equiv.refl ρ).symmetricPower d = .refl (ρ.symmetricPower d) := by
+  have h : ((Equiv.refl ρ).symmetricPower d).toLinearMap =
+      (Equiv.refl (ρ.symmetricPower d)).toLinearMap := by
+    simp
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
+
+/-- Symmetric powers preserve inverses of equivalences. -/
+@[simp]
+theorem symmetricPower_symm (e : ρ.Equiv σ) (d : ℕ) :
+    e.symm.symmetricPower d = (e.symmetricPower d).symm := by
+  have h : (e.symm.symmetricPower d).toLinearMap =
+      ((e.symmetricPower d).symm).toLinearMap := by
+    rw [symmetricPower_toLinearMap, toLinearMap_symm (e.symmetricPower d),
+      symmetricPower_toLinearEquiv, symmetricPowerLinearEquiv_symm_toLinearMap]
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
+
+/-- Symmetric powers preserve composition of equivalences. -/
+@[simp]
+theorem symmetricPower_trans {P : Type*} [AddCommMonoid P] [Module R P]
+    {τ : Representation R G P} (e : ρ.Equiv σ) (f : σ.Equiv τ) (d : ℕ) :
+    (e.trans f).symmetricPower d =
+      (e.symmetricPower d).trans (f.symmetricPower d) := by
+  have h : ((e.trans f).symmetricPower d).toLinearMap =
+      ((e.symmetricPower d).trans (f.symmetricPower d)).toLinearMap := by
+    simp
+  exact Equiv.ext (funext fun x => LinearMap.congr_fun h x)
+
+end CommSemiring
+
+end Representation.Equiv


### PR DESCRIPTION
This PR adds functorial symmetric tensor powers, lifts them to representations, intertwining maps, and equivalences, and specializes the construction to the standard representation of `GL n k`. It advances `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, Layer 1, item “Symmetric and exterior power representations,” specifically the requested `symPowerRep n k : Representation ℂ (GL n ℂ) (Sym[ℂ]^k V)` and the functorial symmetric-power construction it requires.

This is the lowest-hanging distinct RepresentationTheory target because tensor powers, exterior powers, the standard representation, and its subgroup restrictions are already on `main`, while no open PR covers symmetric powers. The pinned Mathlib defines `SymmetricPower`, its quotient map, and pure tensors, but does not provide the induced map of symmetric powers; supplying that map directly unlocks the named representation without depending on later character or Schur-Weyl layers.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"symmetric-power-representation"}-->

Add `TauCeti/LinearAlgebra/SymmetricPower.lean` (120 lines) with `SymmetricPower.map`, its quotient and pure-tensor formulas, identity and composition laws, and finite generation for finite index types. Add `TauCeti/RepresentationTheory/SymmetricPower.lean` (211 lines) with the induced action and functorial APIs for intertwining maps and representation equivalences. Add `TauCeti/RepresentationTheory/ClassicalGroups/SymmetricPower.lean` (46 lines) with `symPowerRep` and `symPowerFDRep`, for 377 lines total.

No Mathlib infrastructure is vendored and no external formalization is copied or adapted. Reuse Mathlib’s symmetric-power quotient construction by Kenny Lau from `Mathlib.LinearAlgebra.TensorPower.Symmetric`, together with `PiTensorProduct.map`, `AddCon.lift`, `SymmetricPower.span_tprod_eq_top`, and `Module.Finite.of_surjective`.

`lake build` completes successfully with 5,781 jobs. `tauceti-axioms --changed-from origin/main` audits 40 declarations in three changed modules, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` reports zero violations.

🤖 Prepared with Codex
