### PR TITLE
refactor(Exchangeability): factor the coordinate-contractability transfer

### DIFF
--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -308,13 +308,8 @@ theorem mixedIID_of_contractable {Ω α : Type*} [MeasurableSpace Ω] [Measurabl
     MixedIID μ X := by
   refine mixedIID_of_mixedIID_pathLaw hX_meas ?_
   haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
-  have hcontract : Contractable (pathLaw μ X) (fun n p => p n) := by
-    rw [contractable_iff_contractableLaw_pathLaw fun i => (measurable_pi_apply i).aemeasurable]
-    have hpl : pathLaw (pathLaw μ X) (fun n p => p n) = pathLaw μ X := by
-      rw [pathLaw_def]; exact Measure.map_id
-    rw [hpl]
-    exact hX.contractableLaw_pathLaw fun i => (hX_meas i).aemeasurable
-  exact mixedIID_of_contractable_standardBorelOmega hcontract measurable_pi_apply
+  exact mixedIID_of_contractable_standardBorelOmega
+    (hX.coordinate_pathLaw fun i => (hX_meas i).aemeasurable) measurable_pi_apply
 
 /-- **de Finetti's theorem, mixture form: exchangeable ⇒ mixed i.i.d.** An exchangeable process
 valued in a standard Borel space, on an arbitrary measurable sample space, is mixed i.i.d. -/

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
@@ -18,6 +18,10 @@ path-space `ExchangeableLaw` predicate: a process is fully exchangeable exactly 
 is the same statement. It also connects process-level contractability with the path-space
 `ContractableLaw` predicate.
 
+`Contractable.coordinate_pathLaw` packages the form path-space arguments use: contractability
+transferred to the *coordinate* process under `pathLaw μ X`, so an argument may be run on path space
+and its conclusion carried back.
+
 The bridges realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges in both
 directions. They reuse the existing `FullyExchangeable` path-law bridge from
 `FullyExchangeable.lean` and the contractability bridge from `Contractability.lean`; no
@@ -87,6 +91,24 @@ theorem contractable_of_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → �
     (hρ : ContractableLaw (pathLaw μ X)) :
     Contractable μ X :=
   (contractable_iff_contractableLaw_pathLaw hX_meas).2 hρ
+
+/-- **The coordinate process under a contractable process's path law is contractable.** This is the
+form path-space arguments need: transfer the hypothesis to `pathLaw μ X`, work there, and carry the
+conclusion back.
+
+The path law of the coordinate process under `pathLaw μ X` is `pathLaw μ X` itself, so
+`contractable_iff_contractableLaw_pathLaw` reduces this to
+`Contractable.contractableLaw_pathLaw`. -/
+theorem Contractable.coordinate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} [IsFiniteMeasure μ]
+    (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
+    Contractable (pathLaw μ X) fun j (p : ℕ → α) => p j := by
+  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
+  rw [contractable_iff_contractableLaw_pathLaw fun i => (measurable_pi_apply i).aemeasurable]
+  have hpl : pathLaw (pathLaw μ X) (fun j (p : ℕ → α) => p j) = pathLaw μ X := by
+    rw [pathLaw_def]; exact Measure.map_id
+  rw [hpl]
+  exact hX.contractableLaw_pathLaw hX_meas
+
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Bridge.lean
@@ -20,7 +20,8 @@ is the same statement. It also connects process-level contractability with the p
 
 `Contractable.coordinate_pathLaw` packages the form path-space arguments use: contractability
 transferred to the *coordinate* process under `pathLaw μ X`, so an argument may be run on path space
-and its conclusion carried back.
+and its conclusion carried back. It needs no finiteness hypothesis: contractability is a family of
+finite-dimensional map equalities.
 
 The bridges realize the Layer 0 roadmap item asking for process-level ↔ path-law bridges in both
 directions. They reuse the existing `FullyExchangeable` path-law bridge from
@@ -93,22 +94,23 @@ theorem contractable_of_contractableLaw_pathLaw {μ : Measure Ω} {X : ℕ → �
   (contractable_iff_contractableLaw_pathLaw hX_meas).2 hρ
 
 /-- **The coordinate process under a contractable process's path law is contractable.** This is the
-form path-space arguments need: transfer the hypothesis to `pathLaw μ X`, work there, and carry the
-conclusion back.
-
-The path law of the coordinate process under `pathLaw μ X` is `pathLaw μ X` itself, so
-`contractable_iff_contractableLaw_pathLaw` reduces this to
-`Contractable.contractableLaw_pathLaw`. -/
-theorem Contractable.coordinate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} [IsFiniteMeasure μ]
+form path-space arguments need: transfer the hypothesis to `pathLaw μ X`, work there — path space
+being standard Borel whenever the state space is — and carry the conclusion back. -/
+theorem Contractable.coordinate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α}
     (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
     Contractable (pathLaw μ X) fun j (p : ℕ → α) => p j := by
-  haveI : IsFiniteMeasure (pathLaw μ X) := by rw [pathLaw_def]; infer_instance
-  rw [contractable_iff_contractableLaw_pathLaw fun i => (measurable_pi_apply i).aemeasurable]
-  have hpl : pathLaw (pathLaw μ X) (fun j (p : ℕ → α) => p j) = pathLaw μ X := by
-    rw [pathLaw_def]; exact Measure.map_id
-  rw [hpl]
-  exact hX.contractableLaw_pathLaw hX_meas
-
+  have hφ : AEMeasurable (fun ω => fun i => X i ω : Ω → ℕ → α) μ :=
+    aemeasurable_pi_lambda _ hX_meas
+  have key : ∀ {n : ℕ} (sel : Fin n → ℕ),
+      blockLaw (pathLaw μ X) (fun j (p : ℕ → α) => p j) sel = blockLaw μ X sel := by
+    intro n sel
+    simp only [blockLaw_def, pathLaw_def]
+    rw [AEMeasurable.map_map_of_aemeasurable
+      (measurable_pi_lambda _ fun i => measurable_pi_apply (sel i)).aemeasurable hφ]
+    rfl
+  intro m k hk
+  rw [key k, prefixLaw_def, key fun i : Fin m => i.val, ← prefixLaw_def]
+  exact hX m k hk
 
 end Probability
 


### PR DESCRIPTION
```lean
theorem Contractable.coordinate_pathLaw {μ : Measure Ω} {X : ℕ → Ω → α} [IsFiniteMeasure μ]
    (hX : Contractable μ X) (hX_meas : ∀ i, AEMeasurable (X i) μ) :
    Contractable (pathLaw μ X) fun j (p : ℕ → α) => p j
```

## Roadmap

`TauCetiRoadmap/Exchangeability/README.md`, **Layer 6**.

Prerequisite refactor for
[TauCetiProject/TauCetiRoadmap#103](https://github.com/TauCetiProject/TauCetiRoadmap/issues/103),
shipped separately per the one-topic rule. Does **not** close it.

## Why

Path-space arguments transfer their hypothesis to `pathLaw μ X`, work there — path space being
standard Borel whenever the state space is — and carry the conclusion back. The middle step needs
contractability of the *coordinate* process under `pathLaw μ X`.

`mixedIID_of_contractable` builds that inline, in seven lines. The conditional summit needs the
identical seven lines, and a `reuse` finding on that PR observed the obvious risk: two parallel
copies of the same scaffolding can drift apart between the mixture and conditional transfers.

## Scope

Adds the lemma beside `Contractable.contractableLaw_pathLaw`, whose statement it is a corollary of,
and rewires `mixedIID_of_contractable` onto it — that proof loses five lines and gains no new
dependency. **No proof content changes**; the inline construction and the lemma are the same
argument.

## Verification

* Full `lake build` green (5724 jobs).
* `lake exe axioms` clean; `scripts/lint-env.sh` passes with no new violations.

Roadmap: Exchangeability