### PR TITLE
feat: add Young symmetrizers

### DIFF
--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -136,8 +136,10 @@ theorem columnAntisymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin 
 /-- Left multiplication by a member of the row group fixes the row symmetrizer. -/
 @[simp]
 theorem mul_rowSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
-    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * rowSymmetrizer t =
+    MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 * rowSymmetrizer t =
       rowSymmetrizer t := by
+  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * rowSymmetrizer t =
+    rowSymmetrizer t
   rw [rowSymmetrizer_def, Finset.mul_sum]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulLeft p)
@@ -147,8 +149,10 @@ theorem mul_rowSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
 /-- Right multiplication by a member of the row group fixes the row symmetrizer. -/
 @[simp]
 theorem mul_rowSymmetrizer_right (t : YoungTableau μ) (p : rowSubgroup t) :
-    rowSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p =
+    rowSymmetrizer t * MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 =
       rowSymmetrizer t := by
+  change rowSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p =
+    rowSymmetrizer t
   rw [rowSymmetrizer_def, Finset.sum_mul]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulRight p)
@@ -159,9 +163,12 @@ theorem mul_rowSymmetrizer_right (t : YoungTableau μ) (p : rowSubgroup t) :
 the sign of that member. -/
 @[simp]
 theorem mul_columnAntisymmetrizer_left (t : YoungTableau μ) (q : colSubgroup t) :
-    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q * columnAntisymmetrizer t =
+    MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 * columnAntisymmetrizer t =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
+  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q * columnAntisymmetrizer t =
+    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+      columnAntisymmetrizer t
   rw [columnAntisymmetrizer_def, Finset.mul_sum, Finset.smul_sum]
   simp_rw [mul_smul_comm,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
@@ -175,9 +182,12 @@ theorem mul_columnAntisymmetrizer_left (t : YoungTableau μ) (q : colSubgroup t)
 the sign of that member. -/
 @[simp]
 theorem mul_columnAntisymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t) :
-    columnAntisymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+    columnAntisymmetrizer t * MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
+  change columnAntisymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+      columnAntisymmetrizer t
   rw [columnAntisymmetrizer_def, Finset.sum_mul, Finset.smul_sum]
   simp_rw [smul_mul_assoc,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
@@ -194,7 +204,7 @@ theorem rowSymmetrizer_sq (t : YoungTableau μ) :
       Nat.card (rowSubgroup t) • rowSymmetrizer t := by
   nth_rewrite 1 [rowSymmetrizer_def]
   rw [Finset.sum_mul]
-  simp_rw [mul_rowSymmetrizer_left]
+  simp_rw [MonoidAlgebra.of_apply, mul_rowSymmetrizer_left]
   rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
 
 /-- The column antisymmetrizer squares to the order of the column group times itself. -/
@@ -204,24 +214,30 @@ theorem columnAntisymmetrizer_sq (t : YoungTableau μ) :
       Nat.card (colSubgroup t) • columnAntisymmetrizer t := by
   nth_rewrite 1 [columnAntisymmetrizer_def]
   rw [Finset.sum_mul]
-  simp_rw [smul_mul_assoc, mul_columnAntisymmetrizer_left, smul_smul,
+  simp_rw [smul_mul_assoc, MonoidAlgebra.of_apply, mul_columnAntisymmetrizer_left, smul_smul,
     permSign_cast_mul_self, one_smul]
   rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
 
 /-- The row group fixes the Young symmetrizer on the left. -/
 @[simp]
 theorem mul_youngSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
-    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * youngSymmetrizer t =
+    MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 * youngSymmetrizer t =
       youngSymmetrizer t := by
-  rw [youngSymmetrizer_def, ← mul_assoc, mul_rowSymmetrizer_left]
+  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * youngSymmetrizer t =
+    youngSymmetrizer t
+  rw [youngSymmetrizer_def, ← mul_assoc, MonoidAlgebra.of_apply, mul_rowSymmetrizer_left]
 
 /-- The column group acts on the Young symmetrizer on the right through its sign character. -/
 @[simp]
 theorem mul_youngSymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t) :
-    youngSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+    youngSymmetrizer t * MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         youngSymmetrizer t := by
-  rw [youngSymmetrizer_def, mul_assoc, mul_columnAntisymmetrizer_right, mul_smul_comm]
+  change youngSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+      youngSymmetrizer t
+  rw [youngSymmetrizer_def, mul_assoc, MonoidAlgebra.of_apply,
+    mul_columnAntisymmetrizer_right, mul_smul_comm]
 
 end
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -75,14 +75,14 @@ noncomputable def youngSymmetrizer (t : YoungTableau μ) :
   rowSymmetrizer t * columnAntisymmetrizer t
 
 /-- The row symmetrizer is the sum of the basis elements indexed by the row group. -/
-theorem rowSymmetrizer_eq_sum (t : YoungTableau μ) :
+theorem rowSymmetrizer_def (t : YoungTableau μ) :
     rowSymmetrizer t =
       ∑ p : rowSubgroup t, MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p :=
   (rfl)
 
 /-- The column antisymmetrizer is the sign-weighted sum of the basis elements indexed by the
 column group. -/
-theorem columnAntisymmetrizer_eq_sum (t : YoungTableau μ) :
+theorem columnAntisymmetrizer_def (t : YoungTableau μ) :
     columnAntisymmetrizer t =
       ∑ q : colSubgroup t,
         ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
@@ -99,7 +99,7 @@ theorem youngSymmetrizer_def (t : YoungTableau μ) :
 theorem rowSymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
     (rowSymmetrizer t).coeff σ = if σ ∈ rowSubgroup t then 1 else 0 := by
   classical
-  rw [rowSymmetrizer_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  rw [rowSymmetrizer_def, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
   simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
   by_cases hσ : σ ∈ rowSubgroup t
   · rw [if_pos hσ,
@@ -118,7 +118,7 @@ theorem columnAntisymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin 
     (columnAntisymmetrizer t).coeff σ =
       if σ ∈ colSubgroup t then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
   classical
-  rw [columnAntisymmetrizer_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  rw [columnAntisymmetrizer_def, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
   simp only [MonoidAlgebra.coeff_smul_apply, MonoidAlgebra.of_apply,
     MonoidAlgebra.coeff_single, Finsupp.single_apply, smul_eq_mul]
   by_cases hσ : σ ∈ colSubgroup t
@@ -134,20 +134,22 @@ theorem columnAntisymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin 
         mul_zero]
 
 /-- Left multiplication by a member of the row group fixes the row symmetrizer. -/
-theorem of_mul_rowSymmetrizer (t : YoungTableau μ) (p : rowSubgroup t) :
+@[simp]
+theorem mul_rowSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
     MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * rowSymmetrizer t =
       rowSymmetrizer t := by
-  rw [rowSymmetrizer_eq_sum, Finset.mul_sum]
+  rw [rowSymmetrizer_def, Finset.mul_sum]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulLeft p)
   intro q
   rfl
 
 /-- Right multiplication by a member of the row group fixes the row symmetrizer. -/
-theorem rowSymmetrizer_mul_of (t : YoungTableau μ) (p : rowSubgroup t) :
+@[simp]
+theorem mul_rowSymmetrizer_right (t : YoungTableau μ) (p : rowSubgroup t) :
     rowSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p =
       rowSymmetrizer t := by
-  rw [rowSymmetrizer_eq_sum, Finset.sum_mul]
+  rw [rowSymmetrizer_def, Finset.sum_mul]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulRight p)
   intro q
@@ -155,11 +157,12 @@ theorem rowSymmetrizer_mul_of (t : YoungTableau μ) (p : rowSubgroup t) :
 
 /-- Left multiplication by a member of the column group scales the column antisymmetrizer by
 the sign of that member. -/
-theorem of_mul_columnAntisymmetrizer (t : YoungTableau μ) (q : colSubgroup t) :
+@[simp]
+theorem mul_columnAntisymmetrizer_left (t : YoungTableau μ) (q : colSubgroup t) :
     MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q * columnAntisymmetrizer t =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
-  rw [columnAntisymmetrizer_eq_sum, Finset.mul_sum, Finset.smul_sum]
+  rw [columnAntisymmetrizer_def, Finset.mul_sum, Finset.smul_sum]
   simp_rw [mul_smul_comm,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulLeft q)
@@ -170,11 +173,12 @@ theorem of_mul_columnAntisymmetrizer (t : YoungTableau μ) (q : colSubgroup t) :
 
 /-- Right multiplication by a member of the column group scales the column antisymmetrizer by
 the sign of that member. -/
-theorem columnAntisymmetrizer_mul_of (t : YoungTableau μ) (q : colSubgroup t) :
+@[simp]
+theorem mul_columnAntisymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t) :
     columnAntisymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
-  rw [columnAntisymmetrizer_eq_sum, Finset.sum_mul, Finset.smul_sum]
+  rw [columnAntisymmetrizer_def, Finset.sum_mul, Finset.smul_sum]
   simp_rw [smul_mul_assoc,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulRight q)
@@ -184,36 +188,40 @@ theorem columnAntisymmetrizer_mul_of (t : YoungTableau μ) (q : colSubgroup t) :
   rw [mul_left_comm, permSign_cast_mul_self, mul_one]
 
 /-- The row symmetrizer squares to the order of the row group times itself. -/
+@[simp]
 theorem rowSymmetrizer_sq (t : YoungTableau μ) :
     rowSymmetrizer t * rowSymmetrizer t =
       Nat.card (rowSubgroup t) • rowSymmetrizer t := by
-  nth_rewrite 1 [rowSymmetrizer_eq_sum]
+  nth_rewrite 1 [rowSymmetrizer_def]
   rw [Finset.sum_mul]
-  simp_rw [of_mul_rowSymmetrizer]
+  simp_rw [mul_rowSymmetrizer_left]
   rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
 
 /-- The column antisymmetrizer squares to the order of the column group times itself. -/
+@[simp]
 theorem columnAntisymmetrizer_sq (t : YoungTableau μ) :
     columnAntisymmetrizer t * columnAntisymmetrizer t =
       Nat.card (colSubgroup t) • columnAntisymmetrizer t := by
-  nth_rewrite 1 [columnAntisymmetrizer_eq_sum]
+  nth_rewrite 1 [columnAntisymmetrizer_def]
   rw [Finset.sum_mul]
-  simp_rw [smul_mul_assoc, of_mul_columnAntisymmetrizer, smul_smul,
+  simp_rw [smul_mul_assoc, mul_columnAntisymmetrizer_left, smul_smul,
     permSign_cast_mul_self, one_smul]
   rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
 
 /-- The row group fixes the Young symmetrizer on the left. -/
-theorem of_mul_youngSymmetrizer (t : YoungTableau μ) (p : rowSubgroup t) :
+@[simp]
+theorem mul_youngSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
     MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * youngSymmetrizer t =
       youngSymmetrizer t := by
-  rw [youngSymmetrizer_def, ← mul_assoc, of_mul_rowSymmetrizer]
+  rw [youngSymmetrizer_def, ← mul_assoc, mul_rowSymmetrizer_left]
 
 /-- The column group acts on the Young symmetrizer on the right through its sign character. -/
-theorem youngSymmetrizer_mul_of (t : YoungTableau μ) (q : colSubgroup t) :
+@[simp]
+theorem mul_youngSymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t) :
     youngSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         youngSymmetrizer t := by
-  rw [youngSymmetrizer_def, mul_assoc, columnAntisymmetrizer_mul_of, mul_smul_comm]
+  rw [youngSymmetrizer_def, mul_assoc, mul_columnAntisymmetrizer_right, mul_smul_comm]
 
 end
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -1,0 +1,222 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.MonoidAlgebra.Basic
+public import Mathlib.Algebra.Group.Subgroup.Finite
+public import Mathlib.GroupTheory.Perm.Sign
+public import TauCeti.RepresentationTheory.Symmetric.RowColumnSubgroup
+
+/-!
+# Young symmetrizers
+
+For a Young tableau `t`, this file defines the row symmetrizer `a_t`, the column
+antisymmetrizer `b_t`, and the Young symmetrizer `c_t = a_t b_t` in the rational group
+algebra of the symmetric group on the entries of `t`.
+
+The defining coefficient formulas are accompanied by the translation laws that characterize
+the two factors: the row group fixes `a_t`, while the column group acts on `b_t` through the
+sign character.  In particular, each factor squares to its subgroup order times itself.
+These are the elementary inputs to the essential-idempotence theorem for `c_t` and the
+construction of Specht modules.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 2.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+noncomputable section
+
+/-- Classical decidability of membership in the row group, used to form its finite sum. -/
+local instance (t : YoungTableau μ) : DecidablePred (· ∈ rowSubgroup t) :=
+  Classical.decPred _
+
+/-- Classical decidability of membership in the column group, used to form its finite sum. -/
+local instance (t : YoungTableau μ) : DecidablePred (· ∈ colSubgroup t) :=
+  Classical.decPred _
+
+@[simp]
+private theorem permSign_cast_mul_self (σ : Equiv.Perm (Fin μ.card)) :
+    ((Equiv.Perm.sign σ : ℤ) : ℚ) * ((Equiv.Perm.sign σ : ℤ) : ℚ) = 1 := by
+  rw [← Int.cast_mul, ← Units.val_mul, Int.units_mul_self]
+  simp
+
+/-- The **row symmetrizer** `a_t`, the sum of the permutations preserving the rows of `t`. -/
+noncomputable def rowSymmetrizer (t : YoungTableau μ) :
+    MonoidAlgebra ℚ (Equiv.Perm (Fin μ.card)) :=
+  ∑ p : rowSubgroup t, MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p
+
+/-- The **column antisymmetrizer** `b_t`, the signed sum of the permutations preserving the
+columns of `t`. -/
+noncomputable def columnAntisymmetrizer (t : YoungTableau μ) :
+    MonoidAlgebra ℚ (Equiv.Perm (Fin μ.card)) :=
+  ∑ q : colSubgroup t,
+    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+      MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q
+
+/-- The **Young symmetrizer** of `t`, with the convention `c_t = a_t b_t`: first
+row-symmetrize, then column-antisymmetrize. -/
+noncomputable def youngSymmetrizer (t : YoungTableau μ) :
+    MonoidAlgebra ℚ (Equiv.Perm (Fin μ.card)) :=
+  rowSymmetrizer t * columnAntisymmetrizer t
+
+/-- The row symmetrizer is the sum of the basis elements indexed by the row group. -/
+theorem rowSymmetrizer_eq_sum (t : YoungTableau μ) :
+    rowSymmetrizer t =
+      ∑ p : rowSubgroup t, MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p :=
+  (rfl)
+
+/-- The column antisymmetrizer is the sign-weighted sum of the basis elements indexed by the
+column group. -/
+theorem columnAntisymmetrizer_eq_sum (t : YoungTableau μ) :
+    columnAntisymmetrizer t =
+      ∑ q : colSubgroup t,
+        ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+          MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q :=
+  (rfl)
+
+/-- The Young symmetrizer uses the row-then-column convention `c_t = a_t b_t`. -/
+theorem youngSymmetrizer_def (t : YoungTableau μ) :
+    youngSymmetrizer t = rowSymmetrizer t * columnAntisymmetrizer t :=
+  (rfl)
+
+/-- The coefficient of a permutation in the row symmetrizer is its row-group indicator. -/
+@[simp]
+theorem rowSymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
+    (rowSymmetrizer t).coeff σ = if σ ∈ rowSubgroup t then 1 else 0 := by
+  classical
+  rw [rowSymmetrizer_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  simp only [MonoidAlgebra.of_apply, MonoidAlgebra.coeff_single, Finsupp.single_apply]
+  by_cases hσ : σ ∈ rowSubgroup t
+  · rw [if_pos hσ,
+      Finset.sum_eq_single (⟨σ, hσ⟩ : rowSubgroup t)]
+    · simp
+    · exact fun p _ hp => if_neg fun h => hp (Subtype.ext h)
+    · simp
+  · rw [if_neg hσ]
+    exact Finset.sum_eq_zero fun p _ =>
+      if_neg fun h : (p : Equiv.Perm (Fin μ.card)) = σ => hσ (h ▸ p.property)
+
+/-- The coefficient of a permutation in the column antisymmetrizer is its sign on the column
+group and zero off that group. -/
+@[simp]
+theorem columnAntisymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
+    (columnAntisymmetrizer t).coeff σ =
+      if σ ∈ colSubgroup t then ((Equiv.Perm.sign σ : ℤ) : ℚ) else 0 := by
+  classical
+  rw [columnAntisymmetrizer_eq_sum, MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply]
+  simp only [MonoidAlgebra.coeff_smul_apply, MonoidAlgebra.of_apply,
+    MonoidAlgebra.coeff_single, Finsupp.single_apply, smul_eq_mul]
+  by_cases hσ : σ ∈ colSubgroup t
+  · rw [if_pos hσ,
+      Finset.sum_eq_single (⟨σ, hσ⟩ : colSubgroup t)]
+    · simp
+    · exact fun q _ hq => by
+        rw [if_neg fun h => hq (Subtype.ext h), mul_zero]
+    · simp
+  · rw [if_neg hσ]
+    exact Finset.sum_eq_zero fun q _ => by
+      rw [if_neg fun h : (q : Equiv.Perm (Fin μ.card)) = σ => hσ (h ▸ q.property),
+        mul_zero]
+
+/-- Left multiplication by a member of the row group fixes the row symmetrizer. -/
+theorem of_mul_rowSymmetrizer (t : YoungTableau μ) (p : rowSubgroup t) :
+    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * rowSymmetrizer t =
+      rowSymmetrizer t := by
+  rw [rowSymmetrizer_eq_sum, Finset.mul_sum]
+  simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
+  apply Fintype.sum_equiv (Equiv.mulLeft p)
+  intro q
+  rfl
+
+/-- Right multiplication by a member of the row group fixes the row symmetrizer. -/
+theorem rowSymmetrizer_mul_of (t : YoungTableau μ) (p : rowSubgroup t) :
+    rowSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p =
+      rowSymmetrizer t := by
+  rw [rowSymmetrizer_eq_sum, Finset.sum_mul]
+  simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
+  apply Fintype.sum_equiv (Equiv.mulRight p)
+  intro q
+  rfl
+
+/-- Left multiplication by a member of the column group scales the column antisymmetrizer by
+the sign of that member. -/
+theorem of_mul_columnAntisymmetrizer (t : YoungTableau μ) (q : colSubgroup t) :
+    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q * columnAntisymmetrizer t =
+      ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+        columnAntisymmetrizer t := by
+  rw [columnAntisymmetrizer_eq_sum, Finset.mul_sum, Finset.smul_sum]
+  simp_rw [mul_smul_comm,
+    ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
+  apply Fintype.sum_equiv (Equiv.mulLeft q)
+  intro p
+  simp only [Equiv.coe_mulLeft, Subgroup.coe_mul, Equiv.Perm.sign_mul, Units.val_mul,
+    Int.cast_mul, smul_smul]
+  rw [← mul_assoc, permSign_cast_mul_self, one_mul]
+
+/-- Right multiplication by a member of the column group scales the column antisymmetrizer by
+the sign of that member. -/
+theorem columnAntisymmetrizer_mul_of (t : YoungTableau μ) (q : colSubgroup t) :
+    columnAntisymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+      ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+        columnAntisymmetrizer t := by
+  rw [columnAntisymmetrizer_eq_sum, Finset.sum_mul, Finset.smul_sum]
+  simp_rw [smul_mul_assoc,
+    ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
+  apply Fintype.sum_equiv (Equiv.mulRight q)
+  intro p
+  simp only [Equiv.coe_mulRight, Subgroup.coe_mul, Equiv.Perm.sign_mul, Units.val_mul,
+    Int.cast_mul, smul_smul]
+  rw [mul_left_comm, permSign_cast_mul_self, mul_one]
+
+/-- The row symmetrizer squares to the order of the row group times itself. -/
+theorem rowSymmetrizer_sq (t : YoungTableau μ) :
+    rowSymmetrizer t * rowSymmetrizer t =
+      Nat.card (rowSubgroup t) • rowSymmetrizer t := by
+  nth_rewrite 1 [rowSymmetrizer_eq_sum]
+  rw [Finset.sum_mul]
+  simp_rw [of_mul_rowSymmetrizer]
+  rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
+
+/-- The column antisymmetrizer squares to the order of the column group times itself. -/
+theorem columnAntisymmetrizer_sq (t : YoungTableau μ) :
+    columnAntisymmetrizer t * columnAntisymmetrizer t =
+      Nat.card (colSubgroup t) • columnAntisymmetrizer t := by
+  nth_rewrite 1 [columnAntisymmetrizer_eq_sum]
+  rw [Finset.sum_mul]
+  simp_rw [smul_mul_assoc, of_mul_columnAntisymmetrizer, smul_smul,
+    permSign_cast_mul_self, one_smul]
+  rw [Finset.sum_const, Finset.card_univ, Nat.card_eq_fintype_card]
+
+/-- The row group fixes the Young symmetrizer on the left. -/
+theorem of_mul_youngSymmetrizer (t : YoungTableau μ) (p : rowSubgroup t) :
+    MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * youngSymmetrizer t =
+      youngSymmetrizer t := by
+  rw [youngSymmetrizer_def, ← mul_assoc, of_mul_rowSymmetrizer]
+
+/-- The column group acts on the Young symmetrizer on the right through its sign character. -/
+theorem youngSymmetrizer_mul_of (t : YoungTableau μ) (q : colSubgroup t) :
+    youngSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
+      ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
+        youngSymmetrizer t := by
+  rw [youngSymmetrizer_def, mul_assoc, columnAntisymmetrizer_mul_of, mul_smul_comm]
+
+end
+
+end YoungTableau
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -138,9 +138,7 @@ theorem columnAntisymmetrizer_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin 
 theorem mul_rowSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
     MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 * rowSymmetrizer t =
       rowSymmetrizer t := by
-  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * rowSymmetrizer t =
-    rowSymmetrizer t
-  rw [rowSymmetrizer_def, Finset.mul_sum]
+  rw [← MonoidAlgebra.of_apply, rowSymmetrizer_def, Finset.mul_sum]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulLeft p)
   intro q
@@ -151,9 +149,7 @@ theorem mul_rowSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
 theorem mul_rowSymmetrizer_right (t : YoungTableau μ) (p : rowSubgroup t) :
     rowSymmetrizer t * MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 =
       rowSymmetrizer t := by
-  change rowSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p =
-    rowSymmetrizer t
-  rw [rowSymmetrizer_def, Finset.sum_mul]
+  rw [← MonoidAlgebra.of_apply, rowSymmetrizer_def, Finset.sum_mul]
   simp_rw [← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulRight p)
   intro q
@@ -166,10 +162,7 @@ theorem mul_columnAntisymmetrizer_left (t : YoungTableau μ) (q : colSubgroup t)
     MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 * columnAntisymmetrizer t =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
-  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q * columnAntisymmetrizer t =
-    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
-      columnAntisymmetrizer t
-  rw [columnAntisymmetrizer_def, Finset.mul_sum, Finset.smul_sum]
+  rw [← MonoidAlgebra.of_apply, columnAntisymmetrizer_def, Finset.mul_sum, Finset.smul_sum]
   simp_rw [mul_smul_comm,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulLeft q)
@@ -185,10 +178,7 @@ theorem mul_columnAntisymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t
     columnAntisymmetrizer t * MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         columnAntisymmetrizer t := by
-  change columnAntisymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
-    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
-      columnAntisymmetrizer t
-  rw [columnAntisymmetrizer_def, Finset.sum_mul, Finset.smul_sum]
+  rw [← MonoidAlgebra.of_apply, columnAntisymmetrizer_def, Finset.sum_mul, Finset.smul_sum]
   simp_rw [smul_mul_assoc,
     ← (MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card))).map_mul]
   apply Fintype.sum_equiv (Equiv.mulRight q)
@@ -223,9 +213,7 @@ theorem columnAntisymmetrizer_sq (t : YoungTableau μ) :
 theorem mul_youngSymmetrizer_left (t : YoungTableau μ) (p : rowSubgroup t) :
     MonoidAlgebra.single (p : Equiv.Perm (Fin μ.card)) 1 * youngSymmetrizer t =
       youngSymmetrizer t := by
-  change MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) p * youngSymmetrizer t =
-    youngSymmetrizer t
-  rw [youngSymmetrizer_def, ← mul_assoc, MonoidAlgebra.of_apply, mul_rowSymmetrizer_left]
+  rw [youngSymmetrizer_def, ← mul_assoc, mul_rowSymmetrizer_left]
 
 /-- The column group acts on the Young symmetrizer on the right through its sign character. -/
 @[simp]
@@ -233,11 +221,7 @@ theorem mul_youngSymmetrizer_right (t : YoungTableau μ) (q : colSubgroup t) :
     youngSymmetrizer t * MonoidAlgebra.single (q : Equiv.Perm (Fin μ.card)) 1 =
       ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
         youngSymmetrizer t := by
-  change youngSymmetrizer t * MonoidAlgebra.of ℚ (Equiv.Perm (Fin μ.card)) q =
-    ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) •
-      youngSymmetrizer t
-  rw [youngSymmetrizer_def, mul_assoc, MonoidAlgebra.of_apply,
-    mul_columnAntisymmetrizer_right, mul_smul_comm]
+  rw [youngSymmetrizer_def, mul_assoc, mul_columnAntisymmetrizer_right, mul_smul_comm]
 
 end
 


### PR DESCRIPTION
This PR adds the row symmetrizer, column antisymmetrizer, and Young symmetrizer of a Young tableau in the rational group algebra, together with their defining coefficient formulas, left and right translation laws, and elementary square relations. It advances `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 2, item “Row, column, and Young symmetrizers,” specifically the convention `youngSymmetrizer t = a_t * b_t` and the adjacent idempotent-theory requirements that the row and column factors satisfy absorption and are idempotent up to their subgroup orders. This is the lowest-hanging distinct RepresentationTheory target because the tableau row and column groups are already on `main`, the permutation-module layer is already in flight, and these finite group-algebra sums are the next independent prerequisite for the Specht-module construction.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"youngsymmetrizer"}-->

The new module `TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean` is 222 lines. It defines `YoungTableau.rowSymmetrizer`, `YoungTableau.columnAntisymmetrizer`, and `YoungTableau.youngSymmetrizer`; characterizes the coefficients of the first two; proves invariance under row-group translation and sign covariance under column-group translation on both sides; proves `a_t² = |R_t| • a_t` and `b_t² = |C_t| • b_t`; and transfers the relevant left and right actions to `c_t`.

The mathematics follows G. D. James, *The Representation Theory of the Symmetric Groups*, Chapter 2, as cited in the module documentation. No supplementary-source material is copied or adapted, and no Mathlib infrastructure is vendored. The implementation reuses Mathlib’s `MonoidAlgebra.of`, `Equiv.Perm.sign`, subgroup finite-type support, and `Fintype.sum_equiv` for translation reindexing.

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5788 jobs).` `lake exe axioms` reports `axioms: audited 14383 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The module-system check passes for all 823 modules, and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Codex
