### PR TITLE
refactor(Comodule): name the monoidal coherence isomorphisms

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
@@ -29,6 +29,8 @@ reconstruction should be built on this full subcategory rather than on all comod
 * `TauCeti.FGComoduleCat.of`: build a finitely generated bundled comodule from unbundled data.
 * `TauCeti.FGComoduleCat.ofHom`: lift an unbundled comodule morphism between finitely generated
   comodules.
+* `TauCeti.FGComoduleCat.isoOfLinearEquiv`: build an isomorphism from a coaction-compatible
+  linear equivalence.
 * `TauCeti.FGComoduleCat.isZero_zero`: `FGComoduleCat.zero` is a zero object.
 * `HasZeroObject (FGComoduleCat R C)`.
 
@@ -197,6 +199,38 @@ theorem ofHom_apply {M N : Type w} [AddCommMonoid M] [Module R M] [Comodule R C 
     [Module.Finite R M] [AddCommMonoid N] [Module R N] [Comodule R C N]
     [Module.Finite R N] (f : Comodule.Hom R C M N) (m : M) :
     ofHom (R := R) (C := C) f m = f m :=
+  rfl
+
+/-- Build an isomorphism of finitely generated comodules from a linear equivalence of the
+underlying modules whose *forward* map respects the coactions.
+
+Compatibility of the inverse is automatic, and is supplied by
+`TauCeti.ComoduleCat.isoOfLinearEquiv`; being a full subcategory, `FGComoduleCat` then inherits
+the isomorphism from `ComoduleCat`. -/
+def isoOfLinearEquiv {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+    (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
+        Comodule.coact (R := R) (C := C) (M := M) =
+      Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap) :
+    M ≅ N :=
+  (ComoduleCat.isFG (R := R) (C := C)).isoMk
+    (ComoduleCat.isoOfLinearEquiv (R := R) (C := C) e h)
+
+/-- The forward map of `FGComoduleCat.isoOfLinearEquiv` is the given linear equivalence. -/
+@[simp]
+theorem isoOfLinearEquiv_hom_apply {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+    (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
+        Comodule.coact (R := R) (C := C) (M := M) =
+      Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap) (m : M) :
+    (isoOfLinearEquiv e h).hom m = e m :=
+  rfl
+
+/-- The inverse map of `FGComoduleCat.isoOfLinearEquiv` is the inverse linear equivalence. -/
+@[simp]
+theorem isoOfLinearEquiv_inv_apply {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+    (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
+        Comodule.coact (R := R) (C := C) (M := M) =
+      Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap) (n : N) :
+    (isoOfLinearEquiv e h).inv n = e.symm n :=
   rfl
 
 variable (R C)

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Basic.lean
@@ -215,6 +215,26 @@ def isoOfLinearEquiv {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
   (ComoduleCat.isFG (R := R) (C := C)).isoMk
     (ComoduleCat.isoOfLinearEquiv (R := R) (C := C) e h)
 
+/-- The forward morphism of `FGComoduleCat.isoOfLinearEquiv` has the original linear equivalence
+underneath. -/
+@[simp]
+theorem isoOfLinearEquiv_hom_toLinearMap {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+    (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
+        Comodule.coact (R := R) (C := C) (M := M) =
+      Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap) :
+    (isoOfLinearEquiv e h).hom.hom.toLinearMap = e.toLinearMap :=
+  rfl
+
+/-- The inverse morphism of `FGComoduleCat.isoOfLinearEquiv` has the inverse linear equivalence
+underneath. -/
+@[simp]
+theorem isoOfLinearEquiv_inv_toLinearMap {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)
+    (h : TensorProduct.map e.toLinearMap LinearMap.id ∘ₗ
+        Comodule.coact (R := R) (C := C) (M := M) =
+      Comodule.coact (R := R) (C := C) (M := N) ∘ₗ e.toLinearMap) :
+    (isoOfLinearEquiv e h).inv.hom.toLinearMap = e.symm.toLinearMap :=
+  rfl
+
 /-- The forward map of `FGComoduleCat.isoOfLinearEquiv` is the given linear equivalence. -/
 @[simp]
 theorem isoOfLinearEquiv_hom_apply {M N : FGComoduleCat.{u, v, w} R C} (e : M ≃ₗ[R] N)

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
@@ -25,8 +25,9 @@ inherited from `SemimoduleCat` along the faithful forgetful functor.
 ## Main declarations
 
 * `TauCeti.FGComoduleCat.tensorUnit`: the finitely generated trivial comodule on the base.
-* `TauCeti.FGComoduleCat.associator`, `TauCeti.FGComoduleCat.leftUnitor`, and
-  `TauCeti.FGComoduleCat.rightUnitor`: the coherence isomorphisms.
+* `TauCeti.FGComoduleCat.tensorAssociator`, `TauCeti.FGComoduleCat.tensorLeftUnitor`, and
+  `TauCeti.FGComoduleCat.tensorRightUnitor`: the coherence isomorphisms, together with the
+  `tensorAssociator_eq` family identifying them with `α_`, `λ_`, and `ρ_`.
 * `MonoidalCategory (TauCeti.FGComoduleCat R C)`: the standard monoidal category structure.
 * `TauCeti.FGComoduleCat.tensorHom_tmul`: tensor products of morphisms on pure tensors.
 * `TauCeti.FGComoduleCat.leftUnitor_hom_apply`,
@@ -65,16 +66,19 @@ noncomputable abbrev tensorUnit : FGComoduleCat.{u, v, u} R C :=
   letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
   of (R := R) (C := C) R
 
-/-- The associator on finitely generated comodules: the associativity equivalence of tensor
-products, which intertwines the diagonal coactions because the coefficient multiplication is
-associative. -/
-noncomputable def associator (M N P : FGComoduleCat.{u, v, u} R C) :
+/-- The associator on finitely generated comodules: the associativity
+equivalence of tensor products, which intertwines the diagonal coactions because the coefficient
+multiplication is associative. The user-facing form is `α_`, characterized by
+`associator_hom_apply` below. -/
+noncomputable def tensorAssociator (M N P : FGComoduleCat.{u, v, u} R C) :
     tensor R C (tensor R C M N) P ≅ tensor R C M (tensor R C N P) :=
   isoOfLinearEquiv (TensorProduct.assoc R M N P) <| by
-    -- The goal names the coactions of the bundled objects `tensor R C _ _`, but the coaction
-    -- lemmas below are stated for the underlying modules. The two agree definitionally, so
-    -- proving the unbundled form and closing with `exact` is what lets `simp` see through to
-    -- `Comodule.tensorCoact`, whose body the module system does not expose here.
+    -- The goal names the coactions of the bundled objects `tensor R C _ _`; the coaction lemmas
+    -- below are stated for the underlying modules. `FGComoduleCat.tensor_coact` and
+    -- `FGComoduleCat.of_coact` say the two agree, and both are `rfl` — but rewriting with them
+    -- is not enough, because what remains needs `Comodule.tensorCoact` and
+    -- `Comodule.tensorCombine` unfolded, and the module system does not expose either body
+    -- here. So the crossing is a single `exact` per coherence map, isolated at the end.
     have h : TensorProduct.map (TensorProduct.assoc R M N P).toLinearMap
           (LinearMap.id : C →ₗ[R] C) ∘ₗ
           Comodule.coact (R := R) (C := C) (M := (M ⊗[R] N) ⊗[R] P) =
@@ -90,14 +94,15 @@ noncomputable def associator (M N P : FGComoduleCat.{u, v, u} R C) :
         (Comodule.coact (R := R) (C := C) (M := P) p)
     exact h
 
-/-- The left unitor on finitely generated comodules: the equivalence `R ⊗ M ≃ M`, which
-intertwines the diagonal coactions because `1` is a left unit for the coefficient
-multiplication. -/
-noncomputable def leftUnitor (M : FGComoduleCat.{u, v, u} R C) :
+/-- The left unitor on finitely generated comodules: the equivalence
+`R ⊗ M ≃ M`, which intertwines the diagonal coactions because `1` is a left unit for the
+coefficient multiplication. The user-facing form is `λ_`, characterized by
+`leftUnitor_hom_apply` below. -/
+noncomputable def tensorLeftUnitor (M : FGComoduleCat.{u, v, u} R C) :
     tensor R C (tensorUnit R C) M ≅ M :=
   letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
   isoOfLinearEquiv (TensorProduct.lid R M) <| by
-    -- Unbundled restatement, as in `associator`.
+    -- Unbundled restatement, as in `tensorAssociator`.
     have h : TensorProduct.map (TensorProduct.lid R M).toLinearMap
           (LinearMap.id : C →ₗ[R] C) ∘ₗ Comodule.coact (R := R) (C := C) (M := R ⊗[R] M) =
         Comodule.coact (R := R) (C := C) (M := M) ∘ₗ (TensorProduct.lid R M).toLinearMap := by
@@ -111,14 +116,15 @@ noncomputable def leftUnitor (M : FGComoduleCat.{u, v, u} R C) :
         (Comodule.coact (R := R) (C := C) (M := M) m)
     exact h
 
-/-- The right unitor on finitely generated comodules: the equivalence `M ⊗ R ≃ M`, which
-intertwines the diagonal coactions because `1` is a right unit for the coefficient
-multiplication. -/
-noncomputable def rightUnitor (M : FGComoduleCat.{u, v, u} R C) :
+/-- The right unitor on finitely generated comodules: the equivalence
+`M ⊗ R ≃ M`, which intertwines the diagonal coactions because `1` is a right unit for the
+coefficient multiplication. The user-facing form is `ρ_`, characterized by
+`rightUnitor_hom_apply` below. -/
+noncomputable def tensorRightUnitor (M : FGComoduleCat.{u, v, u} R C) :
     tensor R C M (tensorUnit R C) ≅ M :=
   letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
   isoOfLinearEquiv (TensorProduct.rid R M) <| by
-    -- Unbundled restatement, as in `associator`.
+    -- Unbundled restatement, as in `tensorAssociator`.
     have h : TensorProduct.map (TensorProduct.rid R M).toLinearMap
           (LinearMap.id : C →ₗ[R] C) ∘ₗ Comodule.coact (R := R) (C := C) (M := M ⊗[R] R) =
         Comodule.coact (R := R) (C := C) (M := M) ∘ₗ (TensorProduct.rid R M).toLinearMap := by
@@ -141,9 +147,9 @@ noncomputable instance instMonoidalCategoryStruct :
   whiskerRight f M := tensorMap f (𝟙 M)
   tensorHom := tensorMap
   tensorUnit := tensorUnit R C
-  associator := associator R C
-  leftUnitor := leftUnitor R C
-  rightUnitor := rightUnitor R C
+  associator := tensorAssociator R C
+  leftUnitor := tensorLeftUnitor R C
+  rightUnitor := tensorRightUnitor R C
 
 /-- Finitely generated right comodules over a bialgebra form a monoidal category under the
 diagonal tensor product. Over a field, these are precisely finite-dimensional comodules. -/
@@ -167,6 +173,23 @@ noncomputable instance instMonoidalCategory :
 
 variable {R C}
 variable {M M' N N' P : FGComoduleCat.{u, v, u} R C}
+
+/-- The monoidal associator is the named one. Rewriting in this direction sends the
+implementation name to the notation, where `associator_hom_apply` and `associator_inv_apply`
+take over. -/
+@[simp]
+theorem tensorAssociator_eq : tensorAssociator R C M N P = α_ M N P :=
+  rfl
+
+/-- The monoidal left unitor is the named one; see `tensorAssociator_eq`. -/
+@[simp]
+theorem tensorLeftUnitor_eq : tensorLeftUnitor R C M = λ_ M :=
+  rfl
+
+/-- The monoidal right unitor is the named one; see `tensorAssociator_eq`. -/
+@[simp]
+theorem tensorRightUnitor_eq : tensorRightUnitor R C M = ρ_ M :=
+  rfl
 
 /-- The monoidal tensor product of two finite-comodule morphisms is their ordinary tensor
 product on underlying linear maps. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
@@ -18,12 +18,15 @@ semiring with its trivial coaction.
 
 The associator and unitors are the usual tensor-product linear equivalences. Their
 compatibility with the diagonal coaction reduces on pure coaction tensors to associativity
-and the unit laws in the coefficient bialgebra. The coherence laws are then inherited from
-`SemimoduleCat` along the faithful forgetful functor.
+and the unit laws in the coefficient bialgebra; compatibility of the *inverse* maps is then
+automatic, and is supplied by `TauCeti.FGComoduleCat.isoOfLinearEquiv`. The coherence laws are
+inherited from `SemimoduleCat` along the faithful forgetful functor.
 
 ## Main declarations
 
 * `TauCeti.FGComoduleCat.tensorUnit`: the finitely generated trivial comodule on the base.
+* `TauCeti.FGComoduleCat.associator`, `TauCeti.FGComoduleCat.leftUnitor`, and
+  `TauCeti.FGComoduleCat.rightUnitor`: the coherence isomorphisms.
 * `MonoidalCategory (TauCeti.FGComoduleCat R C)`: the standard monoidal category structure.
 * `TauCeti.FGComoduleCat.tensorHom_tmul`: tensor products of morphisms on pure tensors.
 * `TauCeti.FGComoduleCat.leftUnitor_hom_apply`,
@@ -62,6 +65,73 @@ noncomputable abbrev tensorUnit : FGComoduleCat.{u, v, u} R C :=
   letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
   of (R := R) (C := C) R
 
+/-- The associator on finitely generated comodules: the associativity equivalence of tensor
+products, which intertwines the diagonal coactions because the coefficient multiplication is
+associative. -/
+noncomputable def associator (M N P : FGComoduleCat.{u, v, u} R C) :
+    tensor R C (tensor R C M N) P ≅ tensor R C M (tensor R C N P) :=
+  isoOfLinearEquiv (TensorProduct.assoc R M N P) <| by
+    -- The goal names the coactions of the bundled objects `tensor R C _ _`, but the coaction
+    -- lemmas below are stated for the underlying modules. The two agree definitionally, so
+    -- proving the unbundled form and closing with `exact` is what lets `simp` see through to
+    -- `Comodule.tensorCoact`, whose body the module system does not expose here.
+    have h : TensorProduct.map (TensorProduct.assoc R M N P).toLinearMap
+          (LinearMap.id : C →ₗ[R] C) ∘ₗ
+          Comodule.coact (R := R) (C := C) (M := (M ⊗[R] N) ⊗[R] P) =
+        Comodule.coact (R := R) (C := C) (M := M ⊗[R] (N ⊗[R] P)) ∘ₗ
+          (TensorProduct.assoc R M N P).toLinearMap := by
+      apply TensorProduct.ext_threefold
+      intro m n p
+      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+        TensorProduct.assoc_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul]
+      exact Comodule.tensorCombine_assoc (R := R) (C := C)
+        (Comodule.coact (R := R) (C := C) (M := M) m)
+        (Comodule.coact (R := R) (C := C) (M := N) n)
+        (Comodule.coact (R := R) (C := C) (M := P) p)
+    exact h
+
+/-- The left unitor on finitely generated comodules: the equivalence `R ⊗ M ≃ M`, which
+intertwines the diagonal coactions because `1` is a left unit for the coefficient
+multiplication. -/
+noncomputable def leftUnitor (M : FGComoduleCat.{u, v, u} R C) :
+    tensor R C (tensorUnit R C) M ≅ M :=
+  letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
+  isoOfLinearEquiv (TensorProduct.lid R M) <| by
+    -- Unbundled restatement, as in `associator`.
+    have h : TensorProduct.map (TensorProduct.lid R M).toLinearMap
+          (LinearMap.id : C →ₗ[R] C) ∘ₗ Comodule.coact (R := R) (C := C) (M := R ⊗[R] M) =
+        Comodule.coact (R := R) (C := C) (M := M) ∘ₗ (TensorProduct.lid R M).toLinearMap := by
+      apply TensorProduct.ext'
+      intro r m
+      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+        TensorProduct.lid_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
+        Comodule.trivial_coact_apply]
+      rw [map_smul]
+      exact Comodule.tensorCombine_lid (R := R) (C := C) r
+        (Comodule.coact (R := R) (C := C) (M := M) m)
+    exact h
+
+/-- The right unitor on finitely generated comodules: the equivalence `M ⊗ R ≃ M`, which
+intertwines the diagonal coactions because `1` is a right unit for the coefficient
+multiplication. -/
+noncomputable def rightUnitor (M : FGComoduleCat.{u, v, u} R C) :
+    tensor R C M (tensorUnit R C) ≅ M :=
+  letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
+  isoOfLinearEquiv (TensorProduct.rid R M) <| by
+    -- Unbundled restatement, as in `associator`.
+    have h : TensorProduct.map (TensorProduct.rid R M).toLinearMap
+          (LinearMap.id : C →ₗ[R] C) ∘ₗ Comodule.coact (R := R) (C := C) (M := M ⊗[R] R) =
+        Comodule.coact (R := R) (C := C) (M := M) ∘ₗ (TensorProduct.rid R M).toLinearMap := by
+      apply TensorProduct.ext'
+      intro m r
+      simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
+        TensorProduct.rid_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
+        Comodule.trivial_coact_apply]
+      rw [map_smul]
+      exact Comodule.tensorCombine_rid (R := R) (C := C)
+        (Comodule.coact (R := R) (C := C) (M := M) m) r
+    exact h
+
 /-- The tensor product, trivial unit, associator, and unitors on finitely generated right
 comodules over a bialgebra. -/
 noncomputable instance instMonoidalCategoryStruct :
@@ -71,118 +141,9 @@ noncomputable instance instMonoidalCategoryStruct :
   whiskerRight f M := tensorMap f (𝟙 M)
   tensorHom := tensorMap
   tensorUnit := tensorUnit R C
-  associator M N P := {
-    hom :=
-      ofHom
-        { toLinearMap := (TensorProduct.assoc R M N P).toLinearMap
-          map_coact := by
-            apply TensorProduct.ext_threefold
-            intro m n p
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.assoc_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul]
-            rw [Comodule.tensor_coact (R := R) (C := C) (M := M) (N := N),
-              Comodule.tensorCoact_tmul,
-              Comodule.tensor_coact (R := R) (C := C) (M := N) (N := P),
-              Comodule.tensorCoact_tmul]
-            exact Comodule.tensorCombine_assoc (R := R) (C := C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)
-              (Comodule.coact (R := R) (C := C) (M := N) n)
-              (Comodule.coact (R := R) (C := C) (M := P) p) }
-    inv :=
-      ofHom
-        { toLinearMap := (TensorProduct.assoc R M N P).symm.toLinearMap
-          map_coact := by
-            apply TensorProduct.ext_threefold'
-            intro m n p
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.assoc_symm_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul]
-            rw [Comodule.tensor_coact (R := R) (C := C) (M := N) (N := P),
-              Comodule.tensorCoact_tmul,
-              Comodule.tensor_coact (R := R) (C := C) (M := M) (N := N),
-              Comodule.tensorCoact_tmul]
-            exact Comodule.tensorCombine_assoc_symm (R := R) (C := C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)
-              (Comodule.coact (R := R) (C := C) (M := N) n)
-              (Comodule.coact (R := R) (C := C) (M := P) p) }
-    hom_inv_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.assoc R M N P).symm_apply_apply
-    inv_hom_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.assoc R M N P).apply_symm_apply
-    }
-
-  leftUnitor M :=
-    letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
-    {
-    hom :=
-      ofHom
-        { toLinearMap := (TensorProduct.lid R M).toLinearMap
-          map_coact := by
-            apply TensorProduct.ext'
-            intro r m
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.lid_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
-              Comodule.trivial_coact_apply]
-            rw [map_smul]
-            exact Comodule.tensorCombine_lid (R := R) (C := C) r
-              (Comodule.coact (R := R) (C := C) (M := M) m) }
-    inv :=
-      ofHom
-        { toLinearMap := (TensorProduct.lid R M).symm.toLinearMap
-          map_coact := by
-            ext m
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.lid_symm_apply, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
-              Comodule.trivial_coact_apply]
-            exact (Comodule.tensorCombine_lid_symm (R := R) (C := C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)).symm }
-    hom_inv_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.lid R M).symm_apply_apply
-    inv_hom_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.lid R M).apply_symm_apply
-    }
-
-  rightUnitor M :=
-    letI : Comodule R C R := Comodule.trivial (R := R) (C := C) (M := R)
-    {
-    hom :=
-      ofHom
-        { toLinearMap := (TensorProduct.rid R M).toLinearMap
-          map_coact := by
-            apply TensorProduct.ext'
-            intro m r
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.rid_tmul, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
-              Comodule.trivial_coact_apply]
-            rw [map_smul]
-            exact Comodule.tensorCombine_rid (R := R) (C := C)
-              (Comodule.coact (R := R) (C := C) (M := M) m) r }
-    inv :=
-      ofHom
-        { toLinearMap := (TensorProduct.rid R M).symm.toLinearMap
-          map_coact := by
-            ext m
-            simp only [LinearMap.comp_apply, LinearEquiv.coe_coe,
-              TensorProduct.rid_symm_apply, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
-              Comodule.trivial_coact_apply]
-            exact (Comodule.tensorCombine_rid_symm (R := R) (C := C)
-              (Comodule.coact (R := R) (C := C) (M := M) m)).symm }
-    hom_inv_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.rid R M).symm_apply_apply
-    inv_hom_id := by
-      apply ObjectProperty.hom_ext
-      apply ComoduleCat.hom_ext
-      exact (TensorProduct.rid R M).apply_symm_apply
-    }
+  associator := associator R C
+  leftUnitor := leftUnitor R C
+  rightUnitor := rightUnitor R C
 
 /-- Finitely generated right comodules over a bialgebra form a monoidal category under the
 diagonal tensor product. Over a field, these are precisely finite-dimensional comodules. -/


### PR DESCRIPTION
## What

`FGComoduleCat.instMonoidalCategoryStruct` carried the associator and both unitors as **107 lines of inline isomorphism literals** — the longest proof body in the repository. Each spelled out a `hom`, an `inv`, and both triangle identities by hand, so the coaction compatibility of every *inverse* map was proved a second time from scratch.

## How

Two pieces already existed and do the work:

* `ComoduleCat.isoOfLinearEquiv` derives the inverse's coaction compatibility from the forward map's.
* Mathlib's `ObjectProperty.isoMk` lifts an isomorphism along a full subcategory.

Wrapping the pair as `FGComoduleCat.isoOfLinearEquiv` (in `Finite/Basic.lean`, beside `ofHom`) cuts the six coaction obligations to three and the four triangle identities to none. The coherence maps then become named definitions — `tensorAssociator`, `tensorLeftUnitor`, `tensorRightUnitor` — mirroring the layout Mathlib's `ModuleCat.MonoidalCategory` uses.

| | before | after |
|---|---|---|
| `instMonoidalCategoryStruct` | 107 | **7** |
| `tensorAssociator` | — | 15 |
| `tensorLeftUnitor` | — | 14 |
| `tensorRightUnitor` | — | 14 |
| `Monoidal.lean` | 265 lines | 244 lines |

## Scope

No statement changes anywhere. Every pre-existing `@[simp]` lemma (`associator_hom_apply`, `leftUnitor_inv_apply`, …) still holds by the same proof term it had before, which is the check that the repackaged isomorphisms are the same maps.

Gates: `lake build`, `lake exe axioms` (14428 declarations), `lake exe module-system` (824/824), `scripts/lint-env.sh` — all green.

## Note for `proof-quality`: the one `exact` per coherence map is irreducible

Each coherence proof states its obligation for the **underlying modules** and closes with a single `exact`. This is not incidental reliance on wrapper reducibility, and the natural fix does not work. Recording the evidence here so it need not be rediscovered:

* The bridge lemma one would reach for **already exists**: `FGComoduleCat.tensor_coact` (`Finite/TensorProduct.lean:81`, `@[simp]`, `rfl`), which is exactly "the bundled `tensor` coaction equals `Comodule.tensorCoact`".
* Rewriting with it does **not** discharge the goal. Replacing the `exact` with `rw [tensor_coact, tensor_coact]` leaves

  ```
  (map (assoc) id) (Comodule.tensorCoact (m ⊗ₜ n ⊗ₜ p)) = Comodule.tensorCoact ((assoc) (m ⊗ₜ n ⊗ₜ p))
  ```

  on which `Comodule.tensorCoact_tmul` cannot fire — the compiler reports it as an *unused* simp argument, and explains why:

  ```
  Note: The following definitions were not unfolded because their definition is not exposed:
    Comodule.tensorCombine ↦ 25
    Comodule.tensorCoact ↦ 25
  ```

* The residue is a *carrier* identification — `↑(tensor R C M N)` versus `↑M ⊗[R] ↑N` — which is a definitional equality between types and so cannot be performed by any propositional rewrite.

So the crossing happens exactly once per coherence map, at the end, and a comment at `tensorAssociator` names the two `rfl` lemmas that license it. Happy to restructure if there is an approach I have missed.