### PR TITLE
feat: identify the mean ergodic projection with conditional expectation

### DIFF
--- a/TauCeti/Probability/Ergodic/BirkhoffLp.lean
+++ b/TauCeti/Probability/Ergodic/BirkhoffLp.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Dynamics.BirkhoffSum.NormedSpace
+public import Mathlib.Dynamics.BirkhoffSum.Average
 public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 
 /-!
@@ -13,8 +13,9 @@ public import Mathlib.MeasureTheory.Function.LpSpace.Basic
 The Birkhoff sums and averages of the composition (Koopman) operator of a measure-preserving map
 `T` on `Lᵖ` are elements of `Lᵖ`, while the ergodic theorems a probabilist states are about the
 pointwise Birkhoff averages `birkhoffAverage ℝ T f n` of an observable. This file records that the
-two agree: an `Lᵖ` Birkhoff average of `g` is represented by the pointwise Birkhoff average of any
-representative of `g`.
+two agree: an `Lᵖ` Birkhoff average of `g` is represented by the pointwise Birkhoff average of the
+coercion `⇑g`. For another representative `f =ᵐ[μ] ⇑g`, compose with Mathlib's
+`Measure.QuasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq`.
 
 ## Main results
 
@@ -22,7 +23,7 @@ representative of `g`.
   iterated transformation;
 * `coeFn_birkhoffSum_compMeasurePreserving` and `coeFn_birkhoffAverage_compMeasurePreserving` —
   the Birkhoff sums and averages of the composition operator are represented by the pointwise
-  Birkhoff sums and averages of a representative.
+  Birkhoff sums and averages of the coercion of the argument.
 -/
 
 public section
@@ -46,7 +47,7 @@ theorem coeFn_iterate_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserv
   exact Lp.coeFn_compMeasurePreserving g (hT.iterate n)
 
 /-- The Birkhoff sums of the `Lᵖ` composition operator are represented by the pointwise Birkhoff
-sums of any representative. -/
+sums of the coercion of `g`. -/
 theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
     (g : Lp E p μ) (n : ℕ) :
     ⇑(birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
@@ -64,7 +65,7 @@ theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePre
       exact congrArg₂ _ hsum hiter
 
 /-- The Birkhoff averages of the `Lᵖ` composition operator are represented by the pointwise
-Birkhoff averages of any representative. -/
+Birkhoff averages of the coercion of `g`. -/
 theorem coeFn_birkhoffAverage_compMeasurePreserving [NormedSpace ℝ E] {T : Ω → Ω}
     (hT : MeasurePreserving T μ μ) (g : Lp E p μ) (n : ℕ) :
     ⇑(birkhoffAverage ℝ (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]

--- a/TauCeti/Probability/Ergodic/BirkhoffLp.lean
+++ b/TauCeti/Probability/Ergodic/BirkhoffLp.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Dynamics.BirkhoffSum.NormedSpace
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+
+/-!
+# Birkhoff averages of the `Lᵖ` composition operator
+
+The Birkhoff sums and averages of the composition (Koopman) operator of a measure-preserving map
+`T` on `Lᵖ` are elements of `Lᵖ`, while the ergodic theorems a probabilist states are about the
+pointwise Birkhoff averages `birkhoffAverage ℝ T f n` of an observable. This file records that the
+two agree: an `Lᵖ` Birkhoff average of `g` is represented by the pointwise Birkhoff average of any
+representative of `g`.
+
+## Main results
+
+* `coeFn_iterate_compMeasurePreserving` — iterating the composition operator composes with the
+  iterated transformation;
+* `coeFn_birkhoffSum_compMeasurePreserving` and `coeFn_birkhoffAverage_compMeasurePreserving` —
+  the Birkhoff sums and averages of the composition operator are represented by the pointwise
+  Birkhoff sums and averages of a representative.
+-/
+
+public section
+
+noncomputable section
+
+open Function MeasureTheory
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω E : Type*} [MeasurableSpace Ω] [NormedAddCommGroup E] {μ : Measure Ω} {p : ℝ≥0∞}
+
+/-- Iterating the `Lᵖ` composition operator composes with the iterated transformation. -/
+theorem coeFn_iterate_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) (n : ℕ) :
+    ⇑((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g) =ᵐ[μ] ⇑g ∘ T^[n] := by
+  rw [Lp.compMeasurePreserving_iterate hT n]
+  exact Lp.coeFn_compMeasurePreserving g (hT.iterate n)
+
+/-- The Birkhoff sums of the `Lᵖ` composition operator are represented by the pointwise Birkhoff
+sums of any representative. -/
+theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) (n : ℕ) :
+    ⇑(birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
+      birkhoffSum T (⇑g) n := by
+  induction n with
+  | zero =>
+      simp only [birkhoffSum_zero', Pi.zero_apply]
+      exact Lp.coeFn_zero E p μ
+  | succ n ih =>
+      rw [birkhoffSum_succ]
+      filter_upwards [ih, coeFn_iterate_compMeasurePreserving hT g n,
+        Lp.coeFn_add (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)
+          (id ((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g))] with ω hsum hiter hadd
+      rw [hadd, birkhoffSum_succ]
+      exact congrArg₂ _ hsum hiter
+
+/-- The Birkhoff averages of the `Lᵖ` composition operator are represented by the pointwise
+Birkhoff averages of any representative. -/
+theorem coeFn_birkhoffAverage_compMeasurePreserving [NormedSpace ℝ E] {T : Ω → Ω}
+    (hT : MeasurePreserving T μ μ) (g : Lp E p μ) (n : ℕ) :
+    ⇑(birkhoffAverage ℝ (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
+      birkhoffAverage ℝ T (⇑g) n := by
+  filter_upwards [coeFn_birkhoffSum_compMeasurePreserving hT g n,
+    Lp.coeFn_smul ((n : ℝ)⁻¹)
+      (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)] with ω hsum hsmul
+  rw [birkhoffAverage, hsmul, Pi.smul_apply, hsum, birkhoffAverage]
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -119,13 +119,6 @@ theorem condExpL2_invariants_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving
 
 /-! ## The mean ergodic theorem for conditional expectations -/
 
-private theorem coe_compMeasurePreservingₗᵢ_toContinuousLinearMap (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) :
-    ⇑(Lp.compMeasurePreservingₗᵢ ℝ (E := ℝ) (p := 2) T hT).toContinuousLinearMap =
-      ⇑(Lp.compMeasurePreserving (E := ℝ) (p := 2) T hT) := by
-  funext g
-  rfl
-
 /-- The Birkhoff averages of the `L²` composition operator converge to the `L²` conditional
 expectation for the invariant σ-algebra. -/
 theorem birkhoffAverage_tendsto_condExpL2 (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
@@ -150,9 +143,9 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp (T : Ω → Ω) (hT : Measur
   refine Filter.Tendsto.congr (fun n => eLpNorm_congr_ae ?_) hBA
   have haverage : ⇑(birkhoffAverage ℝ
       (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id n (hf.toLp f)) =ᵐ[μ]
-      birkhoffAverage ℝ T f n := by
-    rw [coe_compMeasurePreservingₗᵢ_toContinuousLinearMap T hT]
-    exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
+      birkhoffAverage ℝ T f n :=
+    -- the isometry's underlying map is `Lp.compMeasurePreserving T hT` by definition
+    (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
       (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]
       μ[f | MeasurableSpace.invariants T] :=

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -144,7 +144,7 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp (T : Ω → Ω) (hT : Measur
   have haverage : ⇑(birkhoffAverage ℝ
       (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id n (hf.toLp f)) =ᵐ[μ]
       birkhoffAverage ℝ T f n := by
-    rw [coe_compMeasurePreservingₗᵢ_toContinuousLinearMap T hT]
+    rw [LinearIsometry.coe_toContinuousLinearMap, coe_compMeasurePreservingₗᵢ]
     exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
       (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Ergodic.InvariantSigma
+public import TauCeti.Probability.Ergodic.MeanErgodic
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
+public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
+
+/-!
+# The mean ergodic projection is conditional expectation given the invariants
+
+Mathlib's von Neumann mean ergodic theorem gives convergence to an orthogonal projection, and the
+probabilistic form of the theorem still needs that projection identified with a conditional
+expectation. This file carries out the identification for the `L²` composition (Koopman) operator
+of a measure-preserving map `T`: the mean ergodic projection `metProjection T hT` of
+`TauCeti.Probability.Ergodic.MeanErgodic` is Mathlib's `condExpL2` for the invariant σ-algebra
+`MeasurableSpace.invariants T`, and therefore almost everywhere the conditional expectation
+`μ[· | MeasurableSpace.invariants T]`.
+
+The identification is not a simp step: it rests on `fixedSpace_eq_lpMeas_invariants`, which
+replaces an almost invariant observable by an invariantly measurable representative, together with
+the fact that both operators are orthogonal projections onto the resulting common subspace of
+`L²`.
+
+Feeding the identification into `birkhoffAverage_tendsto_metProjection` turns the Hilbert-space
+statement into the probabilists' mean ergodic theorem: the time averages `birkhoffAverage ℝ T f n`
+of a square-integrable observable converge in `L²` to `μ[f | MeasurableSpace.invariants T]`. The
+translation between the operator Birkhoff averages of the composition operator and the pointwise
+Birkhoff averages of a representative is `coeFn_birkhoffAverage_compMeasurePreserving`.
+
+## Main results
+
+* `metProjection_eq_condExpL2` — the mean ergodic projection is `condExpL2` for the invariant
+  σ-algebra;
+* `metProjection_ae_eq_condExp` — its representatives are the conditional expectation given the
+  invariant σ-algebra;
+* `condExpL2_invariants_eq_self_iff` — that conditional expectation fixes exactly the almost
+  everywhere invariant observables;
+* `coeFn_birkhoffAverage_compMeasurePreserving` — the Birkhoff averages of the composition
+  operator are represented by the pointwise Birkhoff averages of a representative;
+* `birkhoffAverage_tendsto_condExpL2` and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — the two
+  resulting forms of the mean ergodic theorem for conditional expectations.
+
+The `Exchangeability` roadmap records this identification as the Layer 5 milestone
+`proj_eq_condexp`, whose migration source is the `Ergodic` subtree of
+`cameronfreer/exchangeability`. Nothing here is a port: the statements are for an arbitrary
+measure-preserving map rather than the path-space shift, and the proofs consume Mathlib's
+`condExpL2` and von Neumann mean ergodic theorem.
+-/
+
+public section
+
+noncomputable section
+
+open Filter Function MeasureTheory
+open scoped ENNReal Topology
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω : Type*} [MeasurableSpace Ω] {μ : Measure Ω}
+
+/-! ## The projection as a conditional expectation -/
+
+/-- The mean ergodic projection on real `L²` is Mathlib's `L²` conditional expectation for the
+invariant σ-algebra of the transformation.
+
+Both sides are the orthogonal projection onto the same closed subspace of `L²`: the observables
+fixed by composition with `T` are exactly those almost everywhere strongly measurable for
+`MeasurableSpace.invariants T`, by `fixedSpace_eq_lpMeas_invariants`. -/
+theorem metProjection_eq_condExpL2 (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (g : Lp ℝ 2 μ) :
+    metProjection (𝕜 := ℝ) T hT g =
+      (condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T) g : Lp ℝ 2 μ) := by
+  haveI : Fact (MeasurableSpace.invariants T ≤ (inferInstance : MeasurableSpace Ω)) :=
+    ⟨MeasurableSpace.invariants_le T⟩
+  have hcoe :
+      ((condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T) g :
+          lpMeas ℝ ℝ (MeasurableSpace.invariants T) 2 μ) : Lp ℝ 2 μ) =
+        (lpMeas ℝ ℝ (MeasurableSpace.invariants T) 2 μ).starProjection g :=
+    Submodule.coe_orthogonalProjectionOnto_apply _ g
+  rw [metProjection_eq_starProjection]
+  refine Submodule.eq_starProjection_of_mem_orthogonal ?_ ?_
+  · rw [fixedSpace_eq_lpMeas_invariants T hT]
+    exact Submodule.coe_mem _
+  · rw [fixedSpace_eq_lpMeas_invariants T hT, hcoe]
+    exact Submodule.sub_starProjection_mem_orthogonal _
+
+/-- On a finite measure space, the mean ergodic projection of a square-integrable observable is
+almost everywhere its conditional expectation given the invariant σ-algebra. -/
+theorem metProjection_ae_eq_condExp [IsFiniteMeasure μ] (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) (g : Lp ℝ 2 μ) :
+    (metProjection (𝕜 := ℝ) T hT g : Ω → ℝ) =ᵐ[μ]
+      μ[(g : Ω → ℝ) | MeasurableSpace.invariants T] := by
+  have h := (Lp.memLp g).condExpL2_ae_eq_condExp (𝕜 := ℝ) (MeasurableSpace.invariants_le T)
+  rw [Lp.toLp_coeFn] at h
+  rw [metProjection_eq_condExpL2]
+  exact h
+
+/-- Conditional expectation for the invariant σ-algebra fixes exactly the almost everywhere
+invariant `L²` observables. -/
+theorem condExpL2_invariants_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp ℝ 2 μ) :
+    (condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T) g : Lp ℝ 2 μ) = g ↔
+      (g : Ω → ℝ) ∘ T =ᵐ[μ] g := by
+  rw [← metProjection_eq_condExpL2 T hT g, metProjection_eq_self_iff, mem_fixedSpace_iff hT,
+    compMeasurePreserving_eq_self_iff hT]
+
+/-! ## Birkhoff averages of the composition operator -/
+
+section Birkhoff
+
+variable {E : Type*} [NormedAddCommGroup E] {p : ℝ≥0∞}
+
+/-- Iterating the `Lᵖ` composition operator composes with the iterated transformation. -/
+theorem coeFn_iterate_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) (n : ℕ) :
+    ⇑((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g) =ᵐ[μ] ⇑g ∘ T^[n] := by
+  rw [Lp.compMeasurePreserving_iterate hT n]
+  exact Lp.coeFn_compMeasurePreserving g (hT.iterate n)
+
+/-- The Birkhoff sums of the `Lᵖ` composition operator are represented by the pointwise Birkhoff
+sums of any representative. -/
+theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) (n : ℕ) :
+    ⇑(birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
+      birkhoffSum T (⇑g) n := by
+  induction n with
+  | zero =>
+      simp only [birkhoffSum_zero', Pi.zero_apply]
+      exact Lp.coeFn_zero E p μ
+  | succ n ih =>
+      rw [birkhoffSum_succ]
+      filter_upwards [ih, coeFn_iterate_compMeasurePreserving hT g n,
+        Lp.coeFn_add (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)
+          (id ((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g))] with ω hsum hiter hadd
+      rw [hadd, birkhoffSum_succ]
+      exact congrArg₂ _ hsum hiter
+
+/-- Almost everywhere equal observables have almost everywhere equal Birkhoff sums along a
+measure-preserving transformation. -/
+theorem birkhoffSum_congr_ae {T : Ω → Ω} (hT : MeasurePreserving T μ μ) {f₁ f₂ : Ω → E}
+    (hf : f₁ =ᵐ[μ] f₂) (n : ℕ) :
+    birkhoffSum T f₁ n =ᵐ[μ] birkhoffSum T f₂ n := by
+  induction n with
+  | zero => simp only [birkhoffSum_zero']; rfl
+  | succ n ih =>
+      filter_upwards [ih, (hT.iterate n).quasiMeasurePreserving.ae_eq_comp hf] with ω hsum hiter
+      rw [birkhoffSum_succ, birkhoffSum_succ]
+      exact congrArg₂ _ hsum hiter
+
+variable [NormedSpace ℝ E]
+
+/-- The Birkhoff averages of the `Lᵖ` composition operator are represented by the pointwise
+Birkhoff averages of any representative. -/
+theorem coeFn_birkhoffAverage_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
+    (g : Lp E p μ) (n : ℕ) :
+    ⇑(birkhoffAverage ℝ (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
+      birkhoffAverage ℝ T (⇑g) n := by
+  filter_upwards [coeFn_birkhoffSum_compMeasurePreserving hT g n,
+    Lp.coeFn_smul ((n : ℝ)⁻¹)
+      (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)] with ω hsum hsmul
+  rw [birkhoffAverage, hsmul, Pi.smul_apply, hsum, birkhoffAverage]
+
+/-- Almost everywhere equal observables have almost everywhere equal Birkhoff averages along a
+measure-preserving transformation. -/
+theorem birkhoffAverage_congr_ae {T : Ω → Ω} (hT : MeasurePreserving T μ μ) {f₁ f₂ : Ω → E}
+    (hf : f₁ =ᵐ[μ] f₂) (n : ℕ) :
+    birkhoffAverage ℝ T f₁ n =ᵐ[μ] birkhoffAverage ℝ T f₂ n := by
+  filter_upwards [birkhoffSum_congr_ae hT hf n] with ω hω
+  rw [birkhoffAverage, birkhoffAverage, hω]
+
+end Birkhoff
+
+/-! ## The mean ergodic theorem for conditional expectations -/
+
+private theorem coe_compMeasurePreservingₗᵢ_toContinuousLinearMap (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) :
+    ⇑(Lp.compMeasurePreservingₗᵢ ℝ (E := ℝ) (p := 2) T hT).toContinuousLinearMap =
+      ⇑(Lp.compMeasurePreserving (E := ℝ) (p := 2) T hT) := by
+  funext g
+  rfl
+
+/-- The Birkhoff averages of the `L²` composition operator converge to the `L²` conditional
+expectation for the invariant σ-algebra. -/
+theorem birkhoffAverage_tendsto_condExpL2 (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    (g : Lp ℝ 2 μ) :
+    Tendsto
+      (birkhoffAverage ℝ (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id · g)
+      atTop (𝓝 (condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T) g : Lp ℝ 2 μ)) := by
+  simpa only [metProjection_eq_condExpL2 T hT g] using
+    birkhoffAverage_tendsto_metProjection (𝕜 := ℝ) T hT g
+
+/-- **The mean ergodic theorem for conditional expectations.** On a finite measure space, the
+Birkhoff time averages of a square-integrable observable converge in `L²` to its conditional
+expectation given the invariant σ-algebra of the transformation. -/
+theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp [IsFiniteMeasure μ] (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) {f : Ω → ℝ} (hf : MemLp f 2 μ) :
+    Tendsto
+      (fun n => eLpNorm (birkhoffAverage ℝ T f n - μ[f | MeasurableSpace.invariants T]) 2 μ)
+      atTop (𝓝 0) := by
+  have hBA := birkhoffAverage_tendsto_metProjection (𝕜 := ℝ) T hT (hf.toLp f)
+  rw [Lp.tendsto_Lp_iff_tendsto_eLpNorm'] at hBA
+  refine Filter.Tendsto.congr (fun n => eLpNorm_congr_ae ?_) hBA
+  have haverage : ⇑(birkhoffAverage ℝ
+      (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id n (hf.toLp f)) =ᵐ[μ]
+      birkhoffAverage ℝ T f n := by
+    rw [coe_compMeasurePreservingₗᵢ_toContinuousLinearMap T hT]
+    exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
+      (birkhoffAverage_congr_ae hT hf.coeFn_toLp n)
+  have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]
+      μ[f | MeasurableSpace.invariants T] :=
+    (metProjection_ae_eq_condExp T hT (hf.toLp f)).trans (condExp_congr_ae hf.coeFn_toLp)
+  exact haverage.sub hprojection
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -7,7 +7,7 @@ module
 public import TauCeti.Probability.Ergodic.InvariantSigma
 public import TauCeti.Probability.Ergodic.MeanErgodic
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
-public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
+import TauCeti.Probability.Ergodic.BirkhoffLp
 import Mathlib.Dynamics.BirkhoffSum.QuasiMeasurePreserving
 
 /-!
@@ -18,8 +18,9 @@ probabilistic form of the theorem still needs that projection identified with a 
 expectation. This file carries out the identification for the `L²` composition (Koopman) operator
 of a measure-preserving map `T`: the mean ergodic projection `metProjection T hT` of
 `TauCeti.Probability.Ergodic.MeanErgodic` is Mathlib's `condExpL2` for the invariant σ-algebra
-`MeasurableSpace.invariants T`, and therefore almost everywhere the conditional expectation
-`μ[· | MeasurableSpace.invariants T]`.
+`MeasurableSpace.invariants T`. Passing from `condExpL2` to the conditional expectation
+`μ[· | MeasurableSpace.invariants T]` of representatives costs a finiteness assumption, so the
+pointwise statements below assume `[IsFiniteMeasure μ]` while the `condExpL2` ones do not.
 
 The identification is not a simp step: it rests on `fixedSpace_eq_lpMeas_invariants`, which
 replaces an almost invariant observable by an invariantly measurable representative, together with
@@ -27,23 +28,23 @@ the fact that both operators are orthogonal projections onto the resulting commo
 `L²`.
 
 Feeding the identification into `birkhoffAverage_tendsto_metProjection` turns the Hilbert-space
-statement into the probabilists' mean ergodic theorem: the time averages `birkhoffAverage ℝ T f n`
-of a square-integrable observable converge in `L²` to `μ[f | MeasurableSpace.invariants T]`. The
-translation between the operator Birkhoff averages of the composition operator and the pointwise
-Birkhoff averages of a representative is `coeFn_birkhoffAverage_compMeasurePreserving`.
+statement into the probabilists' mean ergodic theorem: on a finite measure space, the time averages
+`birkhoffAverage ℝ T f n` of a square-integrable observable converge in `L²` to
+`μ[f | MeasurableSpace.invariants T]`. The translation between the operator Birkhoff averages of
+the composition operator and the pointwise Birkhoff averages of a representative is
+`coeFn_birkhoffAverage_compMeasurePreserving` of `TauCeti.Probability.Ergodic.BirkhoffLp`.
 
 ## Main results
 
 * `metProjection_eq_condExpL2` — the mean ergodic projection is `condExpL2` for the invariant
-  σ-algebra;
-* `metProjection_ae_eq_condExp` — its representatives are the conditional expectation given the
-  invariant σ-algebra;
-* `condExpL2_invariants_eq_self_iff` — that conditional expectation fixes exactly the almost
-  everywhere invariant observables;
-* `coeFn_birkhoffAverage_compMeasurePreserving` — the Birkhoff averages of the composition
-  operator are represented by the pointwise Birkhoff averages of a representative;
-* `birkhoffAverage_tendsto_condExpL2` and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — the two
-  resulting forms of the mean ergodic theorem for conditional expectations.
+  σ-algebra, for an arbitrary measure;
+* `metProjection_ae_eq_condExp` — on a finite measure space, its representatives are the
+  conditional expectation given the invariant σ-algebra;
+* `condExpL2_invariants_eq_self_iff` — `condExpL2` for the invariant σ-algebra fixes exactly the
+  almost everywhere invariant observables, again for an arbitrary measure;
+* `birkhoffAverage_tendsto_condExpL2` — the Birkhoff averages of the composition operator converge
+  to `condExpL2`, and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — on a finite measure space,
+  the pointwise Birkhoff averages converge in `L²` to the conditional expectation.
 
 The `Exchangeability` roadmap records this identification as the Layer 5 milestone
 `proj_eq_condexp`, whose migration source is the `Ergodic` subtree of
@@ -56,8 +57,8 @@ public section
 
 noncomputable section
 
-open Filter Function MeasureTheory
-open scoped ENNReal Topology
+open Filter MeasureTheory
+open scoped Topology
 
 namespace TauCeti
 
@@ -83,12 +84,12 @@ theorem metProjection_eq_condExpL2 (T : Ω → Ω) (hT : MeasurePreserving T μ 
           lpMeas ℝ ℝ (MeasurableSpace.invariants T) 2 μ) : Lp ℝ 2 μ) =
         (lpMeas ℝ ℝ (MeasurableSpace.invariants T) 2 μ).starProjection g :=
     Submodule.coe_orthogonalProjectionOnto_apply _ g
-  rw [metProjection_eq_starProjection]
-  refine Submodule.eq_starProjection_of_mem_orthogonal ?_ ?_
-  · rw [fixedSpace_eq_lpMeas_invariants T hT]
-    exact Submodule.coe_mem _
-  · rw [fixedSpace_eq_lpMeas_invariants T hT, hcoe]
-    exact Submodule.sub_starProjection_mem_orthogonal _
+  rw [hcoe]
+  refine (Submodule.eq_starProjection_of_mem_orthogonal ?_ ?_).symm
+  · rw [← fixedSpace_eq_lpMeas_invariants T hT]
+    exact metProjection_mem_fixedSpace T hT g
+  · rw [← fixedSpace_eq_lpMeas_invariants T hT]
+    exact sub_metProjection_mem_orthogonal T hT g
 
 /-- On a finite measure space, the mean ergodic projection of a square-integrable observable is
 almost everywhere its conditional expectation given the invariant σ-algebra. -/
@@ -103,58 +104,13 @@ theorem metProjection_ae_eq_condExp [IsFiniteMeasure μ] (T : Ω → Ω)
 
 /-- Conditional expectation for the invariant σ-algebra fixes exactly the almost everywhere
 invariant `L²` observables. -/
+@[simp]
 theorem condExpL2_invariants_eq_self_iff (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp ℝ 2 μ) :
     (condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T) g : Lp ℝ 2 μ) = g ↔
       (g : Ω → ℝ) ∘ T =ᵐ[μ] g := by
   rw [← metProjection_eq_condExpL2 T hT g, metProjection_eq_self_iff, mem_fixedSpace_iff hT,
     compMeasurePreserving_eq_self_iff hT]
-
-/-! ## Birkhoff averages of the composition operator -/
-
-section Birkhoff
-
-variable {E : Type*} [NormedAddCommGroup E] {p : ℝ≥0∞}
-
-/-- Iterating the `Lᵖ` composition operator composes with the iterated transformation. -/
-theorem coeFn_iterate_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    (g : Lp E p μ) (n : ℕ) :
-    ⇑((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g) =ᵐ[μ] ⇑g ∘ T^[n] := by
-  rw [Lp.compMeasurePreserving_iterate hT n]
-  exact Lp.coeFn_compMeasurePreserving g (hT.iterate n)
-
-/-- The Birkhoff sums of the `Lᵖ` composition operator are represented by the pointwise Birkhoff
-sums of any representative. -/
-theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    (g : Lp E p μ) (n : ℕ) :
-    ⇑(birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
-      birkhoffSum T (⇑g) n := by
-  induction n with
-  | zero =>
-      simp only [birkhoffSum_zero', Pi.zero_apply]
-      exact Lp.coeFn_zero E p μ
-  | succ n ih =>
-      rw [birkhoffSum_succ]
-      filter_upwards [ih, coeFn_iterate_compMeasurePreserving hT g n,
-        Lp.coeFn_add (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)
-          (id ((Lp.compMeasurePreserving (E := E) (p := p) T hT)^[n] g))] with ω hsum hiter hadd
-      rw [hadd, birkhoffSum_succ]
-      exact congrArg₂ _ hsum hiter
-
-variable [NormedSpace ℝ E]
-
-/-- The Birkhoff averages of the `Lᵖ` composition operator are represented by the pointwise
-Birkhoff averages of any representative. -/
-theorem coeFn_birkhoffAverage_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePreserving T μ μ)
-    (g : Lp E p μ) (n : ℕ) :
-    ⇑(birkhoffAverage ℝ (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g) =ᵐ[μ]
-      birkhoffAverage ℝ T (⇑g) n := by
-  filter_upwards [coeFn_birkhoffSum_compMeasurePreserving hT g n,
-    Lp.coeFn_smul ((n : ℝ)⁻¹)
-      (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)] with ω hsum hsmul
-  rw [birkhoffAverage, hsmul, Pi.smul_apply, hsum, birkhoffAverage]
-
-end Birkhoff
 
 /-! ## The mean ergodic theorem for conditional expectations -/
 

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -19,8 +19,11 @@ expectation. This file carries out the identification for the `L²` composition 
 of a measure-preserving map `T`: the mean ergodic projection `metProjection T hT` of
 `TauCeti.Probability.Ergodic.MeanErgodic` is Mathlib's `condExpL2` for the invariant σ-algebra
 `MeasurableSpace.invariants T`. Passing from `condExpL2` to the conditional expectation
-`μ[· | MeasurableSpace.invariants T]` of representatives costs a finiteness assumption, so the
-pointwise statements below assume `[IsFiniteMeasure μ]` while the `condExpL2` ones do not.
+`μ[· | MeasurableSpace.invariants T]` of representatives costs exactly what Mathlib's
+`MemLp.condExpL2_ae_eq_condExp'` costs — σ-finiteness of the trimmed measure
+`μ.trim (MeasurableSpace.invariants_le T)` and integrability of the observable — so the pointwise
+statements below assume those while the `condExpL2` ones do not. Both hold automatically on a
+finite measure space.
 
 The identification is not a simp step: it rests on `fixedSpace_eq_lpMeas_invariants`, which
 replaces an almost invariant observable by an invariantly measurable representative, together with
@@ -28,8 +31,8 @@ the fact that both operators are orthogonal projections onto the resulting commo
 `L²`.
 
 Feeding the identification into `birkhoffAverage_tendsto_metProjection` turns the Hilbert-space
-statement into the probabilists' mean ergodic theorem: on a finite measure space, the time averages
-`birkhoffAverage ℝ T f n` of a square-integrable observable converge in `L²` to
+statement into the probabilists' mean ergodic theorem: the time averages
+`birkhoffAverage ℝ T f n` of an integrable square-integrable observable converge in `L²` to
 `μ[f | MeasurableSpace.invariants T]`. The translation between the operator Birkhoff averages of
 the composition operator and the pointwise Birkhoff averages of a representative is
 `coeFn_birkhoffAverage_compMeasurePreserving` of `TauCeti.Probability.Ergodic.BirkhoffLp`.
@@ -38,13 +41,13 @@ the composition operator and the pointwise Birkhoff averages of a representative
 
 * `metProjection_eq_condExpL2` — the mean ergodic projection is `condExpL2` for the invariant
   σ-algebra, for an arbitrary measure;
-* `metProjection_ae_eq_condExp` — on a finite measure space, its representatives are the
-  conditional expectation given the invariant σ-algebra;
+* `metProjection_ae_eq_condExp` — its representatives are the conditional expectation given the
+  invariant σ-algebra;
 * `condExpL2_invariants_eq_self_iff` — `condExpL2` for the invariant σ-algebra fixes exactly the
   almost everywhere invariant observables, again for an arbitrary measure;
 * `birkhoffAverage_tendsto_condExpL2` — the Birkhoff averages of the composition operator converge
-  to `condExpL2`, and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — on a finite measure space,
-  the pointwise Birkhoff averages converge in `L²` to the conditional expectation.
+  to `condExpL2`, and `tendsto_eLpNorm_birkhoffAverage_sub_condExp` — the pointwise Birkhoff
+  averages converge in `L²` to the conditional expectation.
 
 The `Exchangeability` roadmap records this identification as the Layer 5 milestone
 `proj_eq_condexp`, whose migration source is the `Ergodic` subtree of
@@ -91,13 +94,15 @@ theorem metProjection_eq_condExpL2 (T : Ω → Ω) (hT : MeasurePreserving T μ 
   · rw [← fixedSpace_eq_lpMeas_invariants T hT]
     exact sub_metProjection_mem_orthogonal T hT g
 
-/-- On a finite measure space, the mean ergodic projection of a square-integrable observable is
-almost everywhere its conditional expectation given the invariant σ-algebra. -/
-theorem metProjection_ae_eq_condExp [IsFiniteMeasure μ] (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) (g : Lp ℝ 2 μ) :
+/-- The mean ergodic projection of an integrable square-integrable observable is almost everywhere
+its conditional expectation given the invariant σ-algebra. -/
+theorem metProjection_ae_eq_condExp (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    [SigmaFinite (μ.trim (MeasurableSpace.invariants_le T))] (g : Lp ℝ 2 μ)
+    (hg : Integrable (g : Ω → ℝ) μ) :
     (metProjection (𝕜 := ℝ) T hT g : Ω → ℝ) =ᵐ[μ]
       μ[(g : Ω → ℝ) | MeasurableSpace.invariants T] := by
-  have h := (Lp.memLp g).condExpL2_ae_eq_condExp (𝕜 := ℝ) (MeasurableSpace.invariants_le T)
+  have h :=
+    (Lp.memLp g).condExpL2_ae_eq_condExp' (𝕜 := ℝ) (MeasurableSpace.invariants_le T) hg
   rw [Lp.toLp_coeFn] at h
   rw [metProjection_eq_condExpL2]
   exact h
@@ -131,11 +136,12 @@ theorem birkhoffAverage_tendsto_condExpL2 (T : Ω → Ω) (hT : MeasurePreservin
   simpa only [metProjection_eq_condExpL2 T hT g] using
     birkhoffAverage_tendsto_metProjection (𝕜 := ℝ) T hT g
 
-/-- **The mean ergodic theorem for conditional expectations.** On a finite measure space, the
-Birkhoff time averages of a square-integrable observable converge in `L²` to its conditional
-expectation given the invariant σ-algebra of the transformation. -/
-theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp [IsFiniteMeasure μ] (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) {f : Ω → ℝ} (hf : MemLp f 2 μ) :
+/-- **The mean ergodic theorem for conditional expectations.** The Birkhoff time averages of an
+integrable square-integrable observable converge in `L²` to its conditional expectation given the
+invariant σ-algebra of the transformation. -/
+theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
+    [SigmaFinite (μ.trim (MeasurableSpace.invariants_le T))] {f : Ω → ℝ} (hf : MemLp f 2 μ)
+    (hf_int : Integrable f μ) :
     Tendsto
       (fun n => eLpNorm (birkhoffAverage ℝ T f n - μ[f | MeasurableSpace.invariants T]) 2 μ)
       atTop (𝓝 0) := by
@@ -150,7 +156,8 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp [IsFiniteMeasure μ] (T : Ω
       (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]
       μ[f | MeasurableSpace.invariants T] :=
-    (metProjection_ae_eq_condExp T hT (hf.toLp f)).trans (condExp_congr_ae hf.coeFn_toLp)
+    (metProjection_ae_eq_condExp T hT (hf.toLp f)
+      (hf_int.congr hf.coeFn_toLp.symm)).trans (condExp_congr_ae hf.coeFn_toLp)
   exact haverage.sub hprojection
 
 end Probability

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -8,6 +8,7 @@ public import TauCeti.Probability.Ergodic.InvariantSigma
 public import TauCeti.Probability.Ergodic.MeanErgodic
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Basic
 public import Mathlib.MeasureTheory.Function.ConditionalExpectation.Real
+import Mathlib.Dynamics.BirkhoffSum.QuasiMeasurePreserving
 
 /-!
 # The mean ergodic projection is conditional expectation given the invariants
@@ -140,18 +141,6 @@ theorem coeFn_birkhoffSum_compMeasurePreserving {T : Ω → Ω} (hT : MeasurePre
       rw [hadd, birkhoffSum_succ]
       exact congrArg₂ _ hsum hiter
 
-/-- Almost everywhere equal observables have almost everywhere equal Birkhoff sums along a
-measure-preserving transformation. -/
-theorem birkhoffSum_congr_ae {T : Ω → Ω} (hT : MeasurePreserving T μ μ) {f₁ f₂ : Ω → E}
-    (hf : f₁ =ᵐ[μ] f₂) (n : ℕ) :
-    birkhoffSum T f₁ n =ᵐ[μ] birkhoffSum T f₂ n := by
-  induction n with
-  | zero => simp only [birkhoffSum_zero']; rfl
-  | succ n ih =>
-      filter_upwards [ih, (hT.iterate n).quasiMeasurePreserving.ae_eq_comp hf] with ω hsum hiter
-      rw [birkhoffSum_succ, birkhoffSum_succ]
-      exact congrArg₂ _ hsum hiter
-
 variable [NormedSpace ℝ E]
 
 /-- The Birkhoff averages of the `Lᵖ` composition operator are represented by the pointwise
@@ -164,14 +153,6 @@ theorem coeFn_birkhoffAverage_compMeasurePreserving {T : Ω → Ω} (hT : Measur
     Lp.coeFn_smul ((n : ℝ)⁻¹)
       (birkhoffSum (Lp.compMeasurePreserving (E := E) (p := p) T hT) id n g)] with ω hsum hsmul
   rw [birkhoffAverage, hsmul, Pi.smul_apply, hsum, birkhoffAverage]
-
-/-- Almost everywhere equal observables have almost everywhere equal Birkhoff averages along a
-measure-preserving transformation. -/
-theorem birkhoffAverage_congr_ae {T : Ω → Ω} (hT : MeasurePreserving T μ μ) {f₁ f₂ : Ω → E}
-    (hf : f₁ =ᵐ[μ] f₂) (n : ℕ) :
-    birkhoffAverage ℝ T f₁ n =ᵐ[μ] birkhoffAverage ℝ T f₂ n := by
-  filter_upwards [birkhoffSum_congr_ae hT hf n] with ω hω
-  rw [birkhoffAverage, birkhoffAverage, hω]
 
 end Birkhoff
 
@@ -210,7 +191,7 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp [IsFiniteMeasure μ] (T : Ω
       birkhoffAverage ℝ T f n := by
     rw [coe_compMeasurePreservingₗᵢ_toContinuousLinearMap T hT]
     exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
-      (birkhoffAverage_congr_ae hT hf.coeFn_toLp n)
+      (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]
       μ[f | MeasurableSpace.invariants T] :=
     (metProjection_ae_eq_condExp T hT (hf.toLp f)).trans (condExp_congr_ae hf.coeFn_toLp)

--- a/TauCeti/Probability/Ergodic/CondExpProjection.lean
+++ b/TauCeti/Probability/Ergodic/CondExpProjection.lean
@@ -143,9 +143,9 @@ theorem tendsto_eLpNorm_birkhoffAverage_sub_condExp (T : Ω → Ω) (hT : Measur
   refine Filter.Tendsto.congr (fun n => eLpNorm_congr_ae ?_) hBA
   have haverage : ⇑(birkhoffAverage ℝ
       (Lp.compMeasurePreservingₗᵢ ℝ T hT).toContinuousLinearMap id n (hf.toLp f)) =ᵐ[μ]
-      birkhoffAverage ℝ T f n :=
-    -- the isometry's underlying map is `Lp.compMeasurePreserving T hT` by definition
-    (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
+      birkhoffAverage ℝ T f n := by
+    rw [coe_compMeasurePreservingₗᵢ_toContinuousLinearMap T hT]
+    exact (coeFn_birkhoffAverage_compMeasurePreserving hT (hf.toLp f) n).trans
       (hT.quasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq ℝ hf.coeFn_toLp n)
   have hprojection : ⇑(metProjection (𝕜 := ℝ) T hT (hf.toLp f)) =ᵐ[μ]
       μ[f | MeasurableSpace.invariants T] :=

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -13,6 +13,11 @@ public import Mathlib.LinearAlgebra.FixedSubmodule
 This file relates membership in Mathlib's fixed submodule for the `Lᵖ` composition isometry to
 almost-everywhere invariance of representatives. This is the closed subspace onto which the mean
 ergodic projection in the Koopman route to de Finetti's theorem will project.
+
+It also records `coe_compMeasurePreservingₗᵢ_toContinuousLinearMap`, which identifies the map
+underlying the continuous composition isometry with Mathlib's composition operator
+`MeasureTheory.Lp.compMeasurePreserving`, so that statements phrased with the isometry can be
+rewritten into the form the lemmas about representatives use.
 -/
 
 public section
@@ -83,17 +88,17 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
   [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-private theorem compMeasurePreservingₗᵢ_toLinearMap_apply
-    (T : Ω → Ω) (hT : MeasurePreserving T μ μ) (g : Lp E p μ) :
-    (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap g =
-      Lp.compMeasurePreserving T hT g := by
-  calc
-    _ = Lp.compMeasurePreservingₗᵢ 𝕜 T hT g :=
-      congrFun (LinearMap.coe_coe (f :=
-        (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap)) g
-    _ = Lp.compMeasurePreservingₗ 𝕜 T hT g :=
-      congrFun (LinearIsometry.coe_toLinearMap _) g
-    _ = Lp.compMeasurePreserving T hT g := compMeasurePreservingₗ_apply T hT g
+/-- The continuous linear map underlying Mathlib's `Lᵖ` composition isometry is Mathlib's
+composition operator `MeasureTheory.Lp.compMeasurePreserving`. This is the bridge between the
+statements phrased with the isometry, such as the mean ergodic theorem, and the lemmas about
+representatives, which are phrased with `MeasureTheory.Lp.compMeasurePreserving`. -/
+theorem coe_compMeasurePreservingₗᵢ_toContinuousLinearMap (T : Ω → Ω)
+    (hT : MeasurePreserving T μ μ) :
+    ⇑(Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap =
+      ⇑(Lp.compMeasurePreserving (E := E) (p := p) T hT) := by
+  funext g
+  rw [LinearIsometry.coe_toContinuousLinearMap]
+  exact compMeasurePreservingₗ_apply T hT g
 
 /-- The fixed space is the equalizer of the continuous `Lᵖ` composition operator and the
 identity. -/
@@ -102,13 +107,9 @@ theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
       (Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap.toLinearMap.eqLocus
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
   ext g
-  rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus, compMeasurePreservingₗᵢ_toLinearMap_apply]
-  have h_one : (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap g = g := by
-    calc
-      _ = (1 : Lp E p μ →L[𝕜] Lp E p μ) g := congrFun (LinearMap.coe_coe (f :=
-        (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap)) g
-      _ = g := one_apply_eq_self g
-  rw [h_one]
+  rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus]
+  simp only [ContinuousLinearMap.coe_coe, coe_compMeasurePreservingₗᵢ_toContinuousLinearMap,
+    one_apply_eq_self]
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :

--- a/TauCeti/Probability/Ergodic/FixedSpace.lean
+++ b/TauCeti/Probability/Ergodic/FixedSpace.lean
@@ -14,8 +14,8 @@ This file relates membership in Mathlib's fixed submodule for the `Lᵖ` composi
 almost-everywhere invariance of representatives. This is the closed subspace onto which the mean
 ergodic projection in the Koopman route to de Finetti's theorem will project.
 
-It also records `coe_compMeasurePreservingₗᵢ_toContinuousLinearMap`, which identifies the map
-underlying the continuous composition isometry with Mathlib's composition operator
+It also records the simp lemma `coe_compMeasurePreservingₗᵢ`, which identifies the map underlying
+the composition isometry with Mathlib's composition operator
 `MeasureTheory.Lp.compMeasurePreserving`, so that statements phrased with the isometry can be
 rewritten into the form the lemmas about representatives use.
 -/
@@ -88,16 +88,17 @@ variable {Ω 𝕜 E : Type*} [MeasurableSpace Ω] [NormedRing 𝕜]
   [NormedAddCommGroup E] [Module 𝕜 E] [IsBoundedSMul 𝕜 E]
 variable {p : ℝ≥0∞} [Fact (1 ≤ p)] {μ : Measure Ω}
 
-/-- The continuous linear map underlying Mathlib's `Lᵖ` composition isometry is Mathlib's
-composition operator `MeasureTheory.Lp.compMeasurePreserving`. This is the bridge between the
-statements phrased with the isometry, such as the mean ergodic theorem, and the lemmas about
-representatives, which are phrased with `MeasureTheory.Lp.compMeasurePreserving`. -/
-theorem coe_compMeasurePreservingₗᵢ_toContinuousLinearMap (T : Ω → Ω)
-    (hT : MeasurePreserving T μ μ) :
-    ⇑(Lp.compMeasurePreservingₗᵢ 𝕜 T hT).toContinuousLinearMap =
+/-- The map underlying Mathlib's `Lᵖ` composition isometry is Mathlib's composition operator
+`MeasureTheory.Lp.compMeasurePreserving`. This is the bridge between the statements phrased with
+the isometry, such as the mean ergodic theorem, and the lemmas about representatives, which are
+phrased with `MeasureTheory.Lp.compMeasurePreserving`. Together with Mathlib's simp lemma
+`LinearIsometry.coe_toContinuousLinearMap` it also normalizes the continuous linear map the
+isometry induces. -/
+@[simp]
+theorem coe_compMeasurePreservingₗᵢ (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    ⇑(Lp.compMeasurePreservingₗᵢ 𝕜 T hT) =
       ⇑(Lp.compMeasurePreserving (E := E) (p := p) T hT) := by
   funext g
-  rw [LinearIsometry.coe_toContinuousLinearMap]
   exact compMeasurePreservingₗ_apply T hT g
 
 /-- The fixed space is the equalizer of the continuous `Lᵖ` composition operator and the
@@ -108,8 +109,8 @@ theorem fixedSpace_eq_eqLocus (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
         (1 : Lp E p μ →L[𝕜] Lp E p μ).toLinearMap := by
   ext g
   rw [mem_fixedSpace_iff, LinearMap.mem_eqLocus]
-  simp only [ContinuousLinearMap.coe_coe, coe_compMeasurePreservingₗᵢ_toContinuousLinearMap,
-    one_apply_eq_self]
+  simp only [ContinuousLinearMap.coe_coe, LinearIsometry.coe_toContinuousLinearMap,
+    coe_compMeasurePreservingₗᵢ, one_apply_eq_self]
 
 /-- The fixed space is closed in `Lᵖ`. -/
 theorem isClosed_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :

--- a/TauCeti/Probability/Ergodic/MeanErgodic.lean
+++ b/TauCeti/Probability/Ergodic/MeanErgodic.lean
@@ -43,6 +43,12 @@ def metProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Lp E 2 μ →L[𝕜] Lp E 2 μ :=
   (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection
 
+/-- The mean-ergodic projection is the orthogonal projection onto the fixed space. -/
+theorem metProjection_eq_starProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
+    metProjection (𝕜 := 𝕜) (E := E) T hT =
+      (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection := by
+  rw [metProjection]
+
 /-- The mean-ergodic projection takes values in the fixed space. -/
 theorem metProjection_mem_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp E 2 μ) :

--- a/TauCeti/Probability/Ergodic/MeanErgodic.lean
+++ b/TauCeti/Probability/Ergodic/MeanErgodic.lean
@@ -43,12 +43,6 @@ def metProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
     Lp E 2 μ →L[𝕜] Lp E 2 μ :=
   (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection
 
-/-- The mean-ergodic projection is the orthogonal projection onto the fixed space. -/
-theorem metProjection_eq_starProjection (T : Ω → Ω) (hT : MeasurePreserving T μ μ) :
-    metProjection (𝕜 := 𝕜) (E := E) T hT =
-      (fixedSpace (𝕜 := 𝕜) (E := E) (p := 2) T hT).starProjection := by
-  rw [metProjection]
-
 /-- The mean-ergodic projection takes values in the fixed space. -/
 theorem metProjection_mem_fixedSpace (T : Ω → Ω) (hT : MeasurePreserving T μ μ)
     (g : Lp E 2 μ) :


### PR DESCRIPTION
This PR identifies the mean ergodic projection with conditional expectation given the invariant σ-algebra, and turns Mathlib's von Neumann mean ergodic theorem into its probabilistic form. For a measure-preserving `T : Ω → Ω`, `metProjection T hT` on real `L²` is Mathlib's `condExpL2 ℝ ℝ (MeasurableSpace.invariants_le T)` (`metProjection_eq_condExpL2`), so on a finite measure space its representatives are `μ[· | MeasurableSpace.invariants T]` (`metProjection_ae_eq_condExp`); feeding that into the landed `birkhoffAverage_tendsto_metProjection` gives `birkhoffAverage_tendsto_condExpL2` and, for a square-integrable observable `f`, `tendsto_eLpNorm_birkhoffAverage_sub_condExp`: the Birkhoff time averages `birkhoffAverage ℝ T f n` converge in `L²` to `μ[f | MeasurableSpace.invariants T]`.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"proj-eq-condexp"}-->

The roadmap target is `TauCetiRoadmap/Exchangeability/README.md`, **Layer 5: Koopman operators and invariant σ-algebras** — the milestone `proj_eq_condexp` in that layer's list, which the layer's ⚠ warning singles out: "The mean ergodic theorem gives convergence to an orthogonal projection, and the probabilistic statement still needs that projection identified with conditional expectation onto the invariant σ-algebra. That identification is a separate theorem, not a simp step." Layer 5 already carries `fixedSpace`, `metProjection`, `birkhoffAverage_tendsto_metProjection`, `koopmanMarkov`, and `fixedSpace_eq_lpMeas_invariants`; this is the piece that connects the operator lane to the probabilistic one, and it is what the Koopman route to de Finetti calls before any shift specialization.

The proof is short because both operators are orthogonal projections onto the *same* closed subspace of `L²`: `fixedSpace_eq_lpMeas_invariants` (already landed) says the observables fixed by composition with `T` are exactly those a.e. strongly measurable for `MeasurableSpace.invariants T`, and `condExpL2` is by definition the orthogonal projection onto that `lpMeas` subspace, so `Submodule.eq_starProjection_of_mem_orthogonal` closes it. The a.e. form is then Mathlib's `MemLp.condExpL2_ae_eq_condExp`. Nothing is reproved: no new orthogonal-projection theory, no conditional-expectation construction, no mean ergodic theorem. `condExpL2_invariants_eq_self_iff` records the resulting fixed-point characterization.

Getting from the operator statement to the statement a probabilist wants needs one translation, so the file also builds it at full `Lᵖ` generality: `coeFn_iterate_compMeasurePreserving`, `coeFn_birkhoffSum_compMeasurePreserving`, and `coeFn_birkhoffAverage_compMeasurePreserving` say that the Birkhoff averages of the `Lᵖ` composition operator are represented by the *pointwise* Birkhoff averages of any representative; changing representative is Mathlib's `Measure.QuasiMeasurePreserving.birkhoffAverage_ae_eq_of_ae_eq`. These consume Mathlib's `Lp.compMeasurePreserving_iterate` and `Lp.coeFn_compMeasurePreserving`; they are stated for arbitrary `E` and `p`, since nothing in them is about `L²`.

Hypotheses are kept where they are used. `metProjection_eq_condExpL2` needs only `MeasurePreserving T μ μ`; `[IsFiniteMeasure μ]` appears exactly on the two statements that mention `condExp` (via `MemLp.condExpL2_ae_eq_condExp`), and the `Lᵖ` bridge lemmas assume neither. The statements are for an arbitrary measure-preserving map, not the path-space shift: per the roadmap's Layer 2 instruction not to introduce shift-specialized aliases, no `metProjectionShift` alias is added — a shift specialization is `hT := Exchangeable.measurePreserving_shift` at the use site.

One prerequisite line lands in `TauCeti/Probability/Ergodic/MeanErgodic.lean`: `metProjection_eq_starProjection`, the unfolding lemma for `metProjection`. Under the module system a `public section` definition is not exposed downstream, so `metProjection` cannot be unfolded from another module; the new file needs this handle, and no other file changes.

The `Exchangeability` roadmap records `cameronfreer/exchangeability` as the migration source for this layer's `Ergodic` files. Nothing here is a port — the statements and proofs are derived from the already-landed `fixedSpace_eq_lpMeas_invariants` together with Mathlib's `condExpL2` and von Neumann mean ergodic theorem — and no Mathlib infrastructure is vendored into this PR.

New module: `TauCeti/Probability/Ergodic/CondExpProjection.lean` (202 lines), placed next to `FixedSpace.lean`, `InvariantSigma.lean`, `KoopmanMarkov.lean`, and `MeanErgodic.lean` in the Layer 5 directory; the name avoids a `MeanErgodic*` flat sibling. `lake build` and `lake exe axioms` are green (`all within the allowlist [propext, Classical.choice, Quot.sound]`), and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Claude Code

