### PR TITLE
feat: conjugate tableau row groups

### DIFF
--- a/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
+++ b/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
@@ -12,8 +12,8 @@ public import Mathlib.GroupTheory.Perm.DomMulAct
 
 Given `f : α → ι`, the permutations `σ` of `α` with `f (σ a) = f a` for every `a` form a subgroup
 of `Equiv.Perm α`, here called `TauCeti.fiberSubgroup f`.  This file records that subgroup, the
-behaviour of the construction under pairing two maps, the criterion for it to be trivial, and the
-isomorphism restricting a fiber-preserving permutation to each fiber,
+behaviour of the construction under conjugation and pairing two maps, the criterion for it to be
+trivial, and the isomorphism restricting a fiber-preserving permutation to each fiber,
 
 `fiberSubgroup f ≃* ∀ i, Equiv.Perm {a // f a = i}`,
 

--- a/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
+++ b/TauCeti/GroupTheory/Perm/FiberSubgroup.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Group.Subgroup.Lattice
+public import Mathlib.Algebra.Group.Subgroup.Map
 public import Mathlib.GroupTheory.Perm.DomMulAct
 
 /-!
@@ -50,6 +50,26 @@ def fiberSubgroup (f : α → ι) : Subgroup (Equiv.Perm α) where
 theorem mem_fiberSubgroup {f : α → ι} {σ : Equiv.Perm α} :
     σ ∈ fiberSubgroup f ↔ ∀ a, f (σ a) = f a :=
   Iff.rfl
+
+/-- Conjugation by `e` transports the subgroup preserving the fibers of `f` to the subgroup
+preserving the fibers of `g` when `e` identifies their fiber equivalence relations. -/
+theorem fiberSubgroup_map_conj {f : α → ι} {g : α → κ} (e : Equiv.Perm α)
+    (h : ∀ a b, f a = f b ↔ g (e a) = g (e b)) :
+    (fiberSubgroup f).map (MulAut.conj e).toMonoidHom = fiberSubgroup g := by
+  ext σ
+  rw [Subgroup.mem_map_equiv, mem_fiberSubgroup, mem_fiberSubgroup]
+  constructor
+  · intro hσ a
+    have hfa : f (e.symm (σ a)) = f (e.symm a) := by
+      simpa only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
+        Equiv.Perm.coe_inv, Equiv.apply_symm_apply] using hσ (e.symm a)
+    have ha := (h (e.symm (σ a)) (e.symm a)).mp hfa
+    simpa only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
+      Equiv.Perm.coe_inv, Equiv.apply_symm_apply] using ha
+  · intro hσ a
+    apply (h _ _).mpr
+    simpa only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
+      Equiv.Perm.coe_inv, Equiv.apply_symm_apply] using hσ (e a)
 
 /-- Preserving the fibers of two maps at once is preserving the fibers of the paired map. -/
 theorem fiberSubgroup_inf (f : α → ι) (g : α → κ) :

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Combinatorics.Young.Partitions
+public import TauCeti.RepresentationTheory.Symmetric.RowColumnSubgroup
+public import TauCeti.RepresentationTheory.Symmetric.YoungSubgroup
+
+/-!
+# Tableau row groups and Young subgroups
+
+The row group of a tableau depends on its labeling, whereas the Young subgroup attached to its
+shape uses consecutive blocks. This file constructs the permutation sending the consecutive-block
+labeling to a given tableau and proves that it conjugates the corresponding Young subgroup onto
+the tableau's row group.
+
+## References
+
+* [G. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 3.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 1.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace YoungTableau
+
+private noncomputable abbrev shapePartition (μ : YoungDiagram) : μ.card.Partition :=
+  (partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩
+
+private theorem shapePartition_sortedParts (μ : YoungDiagram) :
+    (shapePartition μ).parts.sort (· ≥ ·) = μ.rowLens := by
+  have h := partitionEquivYoungDiagram_apply_rowLens μ.card (shapePartition μ)
+  simpa only [shapePartition, Equiv.apply_symm_apply] using h.symm
+
+private abbrev rowBlocks (l : List ℕ) : Type :=
+  Σ i : Fin l.length, Fin (l.get i)
+
+private noncomputable def rowCellsEquiv (μ : YoungDiagram) :
+    rowBlocks μ.rowLens ≃ ↥μ.cells where
+  toFun x := ⟨(x.1, x.2), by
+    rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen]
+    rw [← YoungDiagram.get_rowLens]
+    exact x.2.2⟩
+  invFun c :=
+    ⟨⟨c.1.1, by
+      rw [YoungDiagram.length_rowLens]
+      exact (_root_.YoungDiagram.mem_iff_lt_colLen.mp c.2).trans_le
+        (μ.colLen_anti 0 c.1.2 c.1.2.zero_le)⟩,
+      ⟨c.1.2, by
+        have hj := _root_.YoungDiagram.mem_iff_lt_rowLen.mp c.2
+        rw [← YoungDiagram.get_rowLens] at hj
+        exact hj⟩⟩
+  left_inv _ := rfl
+  right_inv _ := rfl
+
+private noncomputable def sortedBlocksEquivRows (μ : YoungDiagram) :
+    rowBlocks ((shapePartition μ).parts.sort (· ≥ ·)) ≃ rowBlocks μ.rowLens :=
+  Equiv.cast (congrArg rowBlocks (shapePartition_sortedParts μ))
+
+private theorem cast_rowBlocks_fst {l₁ l₂ : List ℕ} (h : l₁ = l₂)
+    (x : rowBlocks l₁) :
+    ((Equiv.cast (congrArg rowBlocks h) x).1 : ℕ) = x.1 := by
+  subst l₂
+  rfl
+
+private theorem sortedBlocksEquivRows_fst (μ : YoungDiagram)
+    (x : rowBlocks ((shapePartition μ).parts.sort (· ≥ ·))) :
+    ((sortedBlocksEquivRows μ x).1 : ℕ) = x.1 :=
+  cast_rowBlocks_fst (shapePartition_sortedParts μ) x
+
+/-- The permutation carrying the consecutive-block labeling of a Young diagram to the labeling
+of `t`. It sends each block of the shape partition to the correspondingly numbered row of `t`. -/
+noncomputable def rowYoungConjugator {μ : YoungDiagram} (t : YoungTableau μ) :
+    Equiv.Perm (Fin μ.card) :=
+  (youngBlocksEquiv (shapePartition μ)).symm |>.trans <|
+    (sortedBlocksEquivRows μ).trans ((rowCellsEquiv μ).trans t)
+
+/-- The row of a label after applying `rowYoungConjugator t` is its consecutive-block number. -/
+@[simp]
+theorem rowIndex_rowYoungConjugator {μ : YoungDiagram} (t : YoungTableau μ)
+    (k : Fin μ.card) :
+    rowIndex t (rowYoungConjugator t k) =
+      youngBlock ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩) k := by
+  let x := (youngBlocksEquiv (shapePartition μ)).symm k
+  have hk : youngBlocksEquiv (shapePartition μ) x = k :=
+    Equiv.apply_symm_apply _ k
+  rw [← hk, youngBlock_youngBlocksEquiv]
+  simp only [rowYoungConjugator, Equiv.trans_apply, rowIndex_apply, rowCellsEquiv,
+    Equiv.symm_apply_apply, x]
+  exact sortedBlocksEquivRows_fst μ x
+
+/-- Conjugation by `rowYoungConjugator t` carries the Young subgroup of the shape partition
+onto the row group of `t`. -/
+theorem map_youngSubgroup_conj_eq_rowSubgroup {μ : YoungDiagram} (t : YoungTableau μ) :
+    (youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)).map
+        (MulAut.conj (rowYoungConjugator t)).toMonoidHom = rowSubgroup t := by
+  ext σ
+  rw [Subgroup.mem_map_equiv, mem_rowSubgroup, mem_youngSubgroup_iff]
+  constructor
+  · intro h k
+    have hleft :=
+      rowIndex_rowYoungConjugator t ((rowYoungConjugator t).symm (σ k))
+    rw [Equiv.apply_symm_apply] at hleft
+    have hright :=
+      rowIndex_rowYoungConjugator t ((rowYoungConjugator t).symm k)
+    rw [Equiv.apply_symm_apply] at hright
+    have hmiddle := congrArg Fin.val (congrFun h ((rowYoungConjugator t).symm k))
+    simp only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
+      Equiv.Perm.coe_inv, Equiv.apply_symm_apply] at hmiddle
+    exact hleft.trans (hmiddle.trans hright.symm)
+  · intro h
+    funext k
+    apply Fin.ext
+    calc
+      (youngBlock ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)
+          (((MulAut.conj (rowYoungConjugator t)).symm σ) k) : ℕ) =
+          rowIndex t (rowYoungConjugator t
+            (((MulAut.conj (rowYoungConjugator t)).symm σ) k)) :=
+        (rowIndex_rowYoungConjugator t _).symm
+      _ = rowIndex t (σ (rowYoungConjugator t k)) := by
+        simp only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
+          Equiv.Perm.coe_inv, Equiv.apply_symm_apply]
+      _ = rowIndex t (rowYoungConjugator t k) := h _
+      _ = (youngBlock ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩) k : ℕ) :=
+        rowIndex_rowYoungConjugator t k
+
+/-- Conjugation by `rowYoungConjugator t` as a multiplicative equivalence from the Young
+subgroup of the shape partition to the row group of `t`. -/
+noncomputable def youngSubgroupConjMulEquiv {μ : YoungDiagram} (t : YoungTableau μ) :
+    youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩) ≃*
+      rowSubgroup t :=
+  ((MulAut.conj (rowYoungConjugator t)).subgroupMap
+      (youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩))).trans
+    (MulEquiv.subgroupCongr (map_youngSubgroup_conj_eq_rowSubgroup t))
+
+/-- The subgroup equivalence acts by conjugation with `rowYoungConjugator t`. -/
+@[simp]
+theorem youngSubgroupConjMulEquiv_coe_apply {μ : YoungDiagram} (t : YoungTableau μ)
+    (σ : youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)) :
+    ((youngSubgroupConjMulEquiv t σ : rowSubgroup t) : Equiv.Perm (Fin μ.card)) =
+      rowYoungConjugator t * σ * (rowYoungConjugator t)⁻¹ :=
+  by simp [youngSubgroupConjMulEquiv, MulAut.conj_apply]
+
+end YoungTableau
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -68,10 +68,21 @@ private theorem cast_rowBlocks_fst {l₁ l₂ : List ℕ} (h : l₁ = l₂)
   subst l₂
   rfl
 
+private theorem cast_rowBlocks_snd {l₁ l₂ : List ℕ} (h : l₁ = l₂)
+    (x : rowBlocks l₁) :
+    ((Equiv.cast (congrArg rowBlocks h) x).2 : ℕ) = x.2 := by
+  subst l₂
+  rfl
+
 private theorem sortedBlocksEquivRows_fst (μ : YoungDiagram)
     (x : rowBlocks ((shapePartition μ).parts.sort (· ≥ ·))) :
     ((sortedBlocksEquivRows μ x).1 : ℕ) = x.1 :=
   cast_rowBlocks_fst (shapePartition_sortedParts μ) x
+
+private theorem sortedBlocksEquivRows_snd (μ : YoungDiagram)
+    (x : rowBlocks ((shapePartition μ).parts.sort (· ≥ ·))) :
+    ((sortedBlocksEquivRows μ x).2 : ℕ) = x.2 :=
+  cast_rowBlocks_snd (shapePartition_sortedParts μ) x
 
 /-- The permutation carrying the consecutive-block labeling of a Young diagram to the labeling
 of `t`. It sends each block of the shape partition to the correspondingly numbered row of `t`. -/
@@ -94,40 +105,40 @@ theorem rowIndex_rowYoungConjugator {μ : YoungDiagram} (t : YoungTableau μ)
     Equiv.symm_apply_apply, x]
   exact sortedBlocksEquivRows_fst μ x
 
+/-- On consecutive-block coordinates, `rowYoungConjugator t` sends position `j` in block `i`
+to the label in position `j` of row `i` of `t`. -/
+@[simp]
+theorem rowYoungConjugator_youngBlocksEquiv {μ : YoungDiagram} (t : YoungTableau μ)
+    (x : Σ i : Fin
+        (((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩).parts.sort (· ≥ ·)).length,
+      Fin ((((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩).parts.sort (· ≥ ·)).get i)) :
+    rowYoungConjugator t
+        (youngBlocksEquiv ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩) x) =
+      t ⟨(x.1, x.2), by
+        rw [YoungDiagram.mem_cells, YoungDiagram.mem_iff_lt_rowLen]
+        let y := sortedBlocksEquivRows μ x
+        calc
+          (x.2 : ℕ) = y.2 := (sortedBlocksEquivRows_snd μ x).symm
+          _ < μ.rowLens.get y.1 := y.2.2
+          _ = μ.rowLen y.1 := YoungDiagram.get_rowLens
+          _ = μ.rowLen x.1 := congrArg μ.rowLen (sortedBlocksEquivRows_fst μ x)⟩ := by
+  simp only [rowYoungConjugator, Equiv.trans_apply, Equiv.symm_apply_apply]
+  apply congrArg t
+  apply Subtype.ext
+  apply Prod.ext
+  · exact sortedBlocksEquivRows_fst μ x
+  · exact sortedBlocksEquivRows_snd μ x
+
 /-- Conjugation by `rowYoungConjugator t` carries the Young subgroup of the shape partition
 onto the row group of `t`. -/
-theorem map_youngSubgroup_conj_eq_rowSubgroup {μ : YoungDiagram} (t : YoungTableau μ) :
+theorem youngSubgroup_map_conj_eq_rowSubgroup {μ : YoungDiagram} (t : YoungTableau μ) :
     (youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)).map
         (MulAut.conj (rowYoungConjugator t)).toMonoidHom = rowSubgroup t := by
-  ext σ
-  rw [Subgroup.mem_map_equiv, mem_rowSubgroup, mem_youngSubgroup_iff]
-  constructor
-  · intro h k
-    have hleft :=
-      rowIndex_rowYoungConjugator t ((rowYoungConjugator t).symm (σ k))
-    rw [Equiv.apply_symm_apply] at hleft
-    have hright :=
-      rowIndex_rowYoungConjugator t ((rowYoungConjugator t).symm k)
-    rw [Equiv.apply_symm_apply] at hright
-    have hmiddle := congrArg Fin.val (congrFun h ((rowYoungConjugator t).symm k))
-    simp only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
-      Equiv.Perm.coe_inv, Equiv.apply_symm_apply] at hmiddle
-    exact hleft.trans (hmiddle.trans hright.symm)
-  · intro h
-    funext k
-    apply Fin.ext
-    calc
-      (youngBlock ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)
-          (((MulAut.conj (rowYoungConjugator t)).symm σ) k) : ℕ) =
-          rowIndex t (rowYoungConjugator t
-            (((MulAut.conj (rowYoungConjugator t)).symm σ) k)) :=
-        (rowIndex_rowYoungConjugator t _).symm
-      _ = rowIndex t (σ (rowYoungConjugator t k)) := by
-        simp only [MulAut.conj_symm_apply, Equiv.Perm.coe_mul, Function.comp_apply,
-          Equiv.Perm.coe_inv, Equiv.apply_symm_apply]
-      _ = rowIndex t (rowYoungConjugator t k) := h _
-      _ = (youngBlock ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩) k : ℕ) :=
-        rowIndex_rowYoungConjugator t k
+  rw [youngSubgroup_eq_fiberSubgroup, rowSubgroup_def]
+  apply fiberSubgroup_map_conj
+  intro a b
+  simp only [rowIndex_rowYoungConjugator]
+  exact Fin.ext_iff
 
 /-- Conjugation by `rowYoungConjugator t` as a multiplicative equivalence from the Young
 subgroup of the shape partition to the row group of `t`. -/
@@ -136,7 +147,7 @@ noncomputable def youngSubgroupConjMulEquiv {μ : YoungDiagram} (t : YoungTablea
       rowSubgroup t :=
   ((MulAut.conj (rowYoungConjugator t)).subgroupMap
       (youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩))).trans
-    (MulEquiv.subgroupCongr (map_youngSubgroup_conj_eq_rowSubgroup t))
+    (MulEquiv.subgroupCongr (youngSubgroup_map_conj_eq_rowSubgroup t))
 
 /-- The subgroup equivalence acts by conjugation with `rowYoungConjugator t`. -/
 @[simp]

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -151,7 +151,7 @@ noncomputable def youngSubgroupConjMulEquiv {μ : YoungDiagram} (t : YoungTablea
 
 /-- The subgroup equivalence acts by conjugation with `rowYoungConjugator t`. -/
 @[simp]
-theorem youngSubgroupConjMulEquiv_coe_apply {μ : YoungDiagram} (t : YoungTableau μ)
+theorem youngSubgroupConjMulEquiv_apply_coe {μ : YoungDiagram} (t : YoungTableau μ)
     (σ : youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)) :
     ((youngSubgroupConjMulEquiv t σ : rowSubgroup t) : Equiv.Perm (Fin μ.card)) =
       rowYoungConjugator t * σ * (rowYoungConjugator t)⁻¹ :=

--- a/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean
@@ -157,6 +157,17 @@ theorem youngSubgroupConjMulEquiv_coe_apply {μ : YoungDiagram} (t : YoungTablea
       rowYoungConjugator t * σ * (rowYoungConjugator t)⁻¹ :=
   by simp [youngSubgroupConjMulEquiv, MulAut.conj_apply]
 
+/-- The inverse subgroup equivalence acts by conjugation with the inverse of
+`rowYoungConjugator t`. -/
+@[simp]
+theorem youngSubgroupConjMulEquiv_symm_apply_coe {μ : YoungDiagram} (t : YoungTableau μ)
+    (τ : rowSubgroup t) :
+    (((youngSubgroupConjMulEquiv t).symm τ :
+        youngSubgroup ((partitionEquivYoungDiagram μ.card).symm ⟨μ, rfl⟩)) :
+      Equiv.Perm (Fin μ.card)) =
+      (rowYoungConjugator t)⁻¹ * τ * rowYoungConjugator t := by
+  simp [youngSubgroupConjMulEquiv]
+
 end YoungTableau
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
@@ -9,6 +9,7 @@ public import TauCeti.Combinatorics.Enumerative.Partition.Basic
 public import Mathlib.Data.Finite.Perm
 public import Mathlib.GroupTheory.Index
 public import Mathlib.GroupTheory.Perm.DomMulAct
+public import TauCeti.GroupTheory.Perm.FiberSubgroup
 
 /-!
 # Young subgroups of symmetric groups
@@ -202,6 +203,13 @@ theorem mem_youngSubgroup_iff {n : ℕ} (μ : n.Partition) (σ : Equiv.Perm (Fin
     σ ∈ youngSubgroup μ ↔ youngBlock μ ∘ σ = youngBlock μ := by
   rw [mem_youngSubgroup_stabilizer_iff]
   exact DomMulAct.mem_stabilizer_iff
+
+/-- The Young subgroup is the subgroup preserving the fibers of its consecutive-block map. -/
+theorem youngSubgroup_eq_fiberSubgroup {n : ℕ} (μ : n.Partition) :
+    youngSubgroup μ = fiberSubgroup (youngBlock μ) := by
+  ext σ
+  rw [mem_youngSubgroup_iff, mem_fiberSubgroup]
+  simp only [funext_iff, Function.comp_apply]
 
 /-- The index of a Young subgroup times its order is `n!`. -/
 theorem youngSubgroup_index_mul {n : ℕ} (μ : n.Partition) :

--- a/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/YoungSubgroup.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.Combinatorics.Enumerative.Partition.Basic
 public import Mathlib.Data.Finite.Perm
 public import Mathlib.GroupTheory.Index
-public import Mathlib.GroupTheory.Perm.DomMulAct
 public import TauCeti.GroupTheory.Perm.FiberSubgroup
 
 /-!


### PR DESCRIPTION
This PR identifies every tableau row group with the Young subgroup of its shape by explicit conjugation. Construct `YoungTableau.rowYoungConjugator` from the consecutive-block enumeration of the shape and the tableau labeling, characterize its action on row indices, prove that conjugation maps the Young subgroup exactly onto `rowSubgroup t`, and package that map as `YoungTableau.youngSubgroupConjMulEquiv`.

It advances `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 1, item “Young subgroups,” specifically the exact target “Any row group `rowSubgroup t` is conjugate to `youngSubgroup μ`.” This is the lowest-hanging distinct RepresentationTheory target because the partition/diagram dictionary, tableau row groups, and consecutive-block Young subgroups are already on `main`, while this stated bridge between them is absent; the open Young-symmetrizer, tensor-square, and matrix-coefficient PRs cover separate targets.

Follow G. D. James, *The Representation Theory of the Symmetric Groups*, Chapter 3, as cited in the module documentation. Reuse Tau Ceti’s `partitionEquivYoungDiagram`, `youngBlocksEquiv`, and row-group API together with Mathlib’s `MulAut.conj.subgroupMap` and `MulEquiv.subgroupCongr`. Vendor no Mathlib infrastructure and copy or adapt no supplementary-source formalization.

Add `TauCeti/RepresentationTheory/Symmetric/TableauSubgroupConjugacy.lean` (151 lines). `lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5798 jobs).` `lake exe axioms` reports `axioms: audited 14741 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The module-system check passes for all 833 TauCeti modules.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"row-subgroup-conjugate-young-subgroup"}-->

🤖 Prepared with Codex
