### PR TITLE
feat: prove class sums are integral

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
@@ -163,7 +163,16 @@ end TauCeti
 
 namespace TauCeti
 
-variable (k G : Type*) [CommSemiring k] [StrongRankCondition k] [Group G] [Finite G]
+variable (k G : Type*) [CommSemiring k] [Group G] [Finite G]
+
+/-- The center of a finite group algebra is finite as a module, with its class-sum basis. -/
+noncomputable instance instModuleFiniteCenterMonoidAlgebra :
+    Module.Finite k (Subalgebra.center k (MonoidAlgebra k G)) := by
+  letI := Fintype.ofFinite G
+  letI := Classical.decEq G
+  exact Module.Finite.of_basis classSumBasis
+
+variable [StrongRankCondition k]
 
 /-- The dimension of the center of a finite group algebra is the number of conjugacy classes. -/
 theorem finrank_center_monoidAlgebra :

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
@@ -29,21 +29,10 @@ public section
 
 namespace TauCeti
 
-/-- The center of `ℤ[G]` is finite as a `ℤ`-module, with its class-sum basis. -/
-noncomputable instance instModuleFiniteCenterIntMonoidAlgebra
-    {G : Type*} [Group G] [Finite G] :
-    Module.Finite ℤ (Subalgebra.center ℤ (MonoidAlgebra ℤ G)) :=
-  by
-    letI := Fintype.ofFinite G
-    letI := Classical.decEq G
-    exact Module.Finite.of_basis classSumBasis
-
 /-- A class sum is integral over `ℤ` as an element of the center of `ℤ[G]`. -/
 theorem isIntegral_classSum {G : Type*} [Group G] [Fintype G] [DecidableEq G]
     (C : ConjClasses G) :
-    IsIntegral ℤ
-      (⟨classSum ℤ C, classSum_mem_center ℤ C⟩ :
-        Subalgebra.center ℤ (MonoidAlgebra ℤ G)) :=
+    IsIntegral ℤ (classSumCenter (k := ℤ) C) :=
   Algebra.IsIntegral.isIntegral _
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis
+public import Mathlib.RingTheory.IntegralClosure.Algebra.Basic
+
+/-!
+# Integrality of class sums
+
+For a finite group `G`, the class sums form a finite basis of the center of the integral
+group algebra `ℤ[G]`. Consequently every element of this center, and in particular every
+class sum, is integral over `ℤ`.
+
+The point is to establish integrality inside `Z(ℤ[G])`. Integrality of a class sum merely as
+an element of `ℤ[G]` would not retain the central algebra through which central characters
+factor.
+
+## References
+
+* [Character Theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 1, “The integral class center”.
+* C. W. Curtis and I. Reiner, *Methods of Representation Theory*, Volume I, Chapters 1–3.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- The center of `ℤ[G]` is finite as a `ℤ`-module, with its class-sum basis. -/
+noncomputable instance instModuleFiniteCenterIntMonoidAlgebra
+    {G : Type*} [Group G] [Finite G] :
+    Module.Finite ℤ (Subalgebra.center ℤ (MonoidAlgebra ℤ G)) :=
+  by
+    letI := Fintype.ofFinite G
+    letI := Classical.decEq G
+    exact Module.Finite.of_basis classSumBasis
+
+/-- A class sum is integral over `ℤ` as an element of the center of `ℤ[G]`. -/
+theorem isIntegral_classSum {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+    (C : ConjClasses G) :
+    IsIntegral ℤ
+      (⟨classSum ℤ C, classSum_mem_center ℤ C⟩ :
+        Subalgebra.center ℤ (MonoidAlgebra ℤ G)) :=
+  Algebra.IsIntegral.isIntegral _
+
+end TauCeti


### PR DESCRIPTION
This PR proves that every class sum is integral over `ℤ` inside the center `Z(ℤ[G])` of the integral group algebra. Derive the result from the already-landed class-sum basis: that finite basis makes the center module-finite over `ℤ`, and Mathlib’s general module-finite integrality theorem then applies.

This advances `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, Layer 1, item “The integral class center,” specifically the pinned `isIntegral_classSum` target in `TauCetiRoadmap/RepresentationTheory/CharacterTheory/Suggested.lean`. It is the lowest-hanging distinct RepresentationTheory target because the class sums, their basis of the center, and their integer structure constants are already on `main`, while neither Mathlib nor Tau Ceti has the center-finiteness instance or the required center-valued integrality theorem; the open RepresentationTheory PRs concern tableau subgroup conjugacy, tensor squares, matrix coefficients, Young symmetrizers, and conjugate-representation irreducibility.

Add `TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean` (49 lines). The module provides `instModuleFiniteCenterIntMonoidAlgebra` for every finite group and the exact theorem `isIntegral_classSum`. The conclusion is deliberately stated in `Subalgebra.center ℤ (MonoidAlgebra ℤ G)`: stating it only in `ℤ[G]` would lose the central algebra through which the later central-character argument factors.

Follow C. W. Curtis and I. Reiner, *Methods of Representation Theory*, Volume I, Chapters 1–3, as cited in the module. Reuse Tau Ceti’s `classSumBasis` together with Mathlib’s `Module.Finite.of_basis` and `Algebra.IsIntegral.of_finite`. Vendor no Mathlib infrastructure and copy or adapt no supplementary-source formalization.

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5799 jobs).` `lake exe axioms` reports `axioms: audited 14775 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"is-integral-class-sum"}-->

🤖 Prepared with Codex
