### PR TITLE
feat: prove the induced-character formula

### DIFF
--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.StdBasis
+public import Mathlib.LinearAlgebra.Trace
+
+/-!
+# Traces of coordinate-permuting maps
+
+This file computes the trace of an endomorphism of a finite product that permutes the factors
+and applies a linear endomorphism in each output coordinate. Only fixed coordinates contribute
+to the trace.
+
+The result is the linear-algebra input for character formulas of induced representations.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+variable {k : Type u} {ι : Type v} {M : Type w}
+  [Field k] [Fintype ι] [DecidableEq ι]
+  [AddCommGroup M] [Module k M] [FiniteDimensional k M]
+
+/-- The trace of a coordinate-permuting endomorphism of a finite product is the sum of the
+traces on its fixed coordinates. -/
+theorem LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ : ι → ι)
+    (f : ι → M →ₗ[k] M) (hT : ∀ x i, T x i = f i (x (σ i))) :
+    LinearMap.trace k (ι → M) T =
+      ∑ i : ι, if σ i = i then LinearMap.trace k M (f i) else 0 := by
+  let b := Module.Free.chooseBasis k M
+  letI := Fintype.ofFinite (Module.Free.ChooseBasisIndex k M)
+  let B := Pi.basis fun _ : ι => b
+  rw [LinearMap.trace_eq_matrix_trace k B, Matrix.trace]
+  rw [Fintype.sum_sigma]
+  apply Finset.sum_congr rfl
+  intro i _
+  by_cases hi : σ i = i
+  · simp only [hi, ↓reduceIte]
+    rw [LinearMap.trace_eq_matrix_trace k b, Matrix.trace]
+    apply Finset.sum_congr rfl
+    intro j _
+    simp [LinearMap.toMatrix_apply, B, b, hT, hi]
+  · simp only [hi, ↓reduceIte]
+    apply Finset.sum_eq_zero
+    intro j _
+    simp [LinearMap.toMatrix_apply, B, b, hT, hi]
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Trace/Pi.lean
+++ b/TauCeti/LinearAlgebra/Trace/Pi.lean
@@ -8,11 +8,11 @@ public import Mathlib.LinearAlgebra.StdBasis
 public import Mathlib.LinearAlgebra.Trace
 
 /-!
-# Traces of coordinate-permuting maps
+# Traces of coordinate-reindexing maps
 
-This file computes the trace of an endomorphism of a finite product that permutes the factors
-and applies a linear endomorphism in each output coordinate. Only fixed coordinates contribute
-to the trace.
+This file computes the trace of an endomorphism of a finite product that selects an input
+coordinate for each output coordinate and applies a linear endomorphism there. Only fixed
+coordinates contribute to the trace.
 
 The result is the linear-algebra input for character formulas of induced representations.
 -/
@@ -24,10 +24,11 @@ namespace TauCeti
 universe u v w
 
 variable {k : Type u} {ι : Type v} {M : Type w}
-  [Field k] [Fintype ι] [DecidableEq ι]
+  [Field k] [Fintype ι]
   [AddCommGroup M] [Module k M] [FiniteDimensional k M]
 
-/-- The trace of a coordinate-permuting endomorphism of a finite product is the sum of the
+open scoped Classical in
+/-- The trace of a coordinate-reindexing endomorphism of a finite product is the sum of the
 traces on its fixed coordinates. -/
 theorem LinearMap.trace_pi_of_apply_eq (T : (ι → M) →ₗ[k] (ι → M)) (σ : ι → ι)
     (f : ι → M →ₗ[k] M) (hT : ∀ x i, T x i = f i (x (σ i))) :

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.LinearAlgebra.Trace.Pi
 public import TauCeti.RepresentationTheory.Induction.FiniteDimensional
+public import Mathlib.RepresentationTheory.Character
 
 /-!
 # Characters of induced representations
@@ -92,18 +93,24 @@ private theorem trace_ind_eq_sum_rightCosets [S.FiniteIndex] [Fintype (RightCose
         else 0 := by
   let e := indSubtypeEquivPi A
   rw [← LinearMap.trace_conj' ((Rep.ind S.subtype A).ρ g) e]
-  refine LinearMap.trace_pi_of_apply_eq
+  have hT (x : RightCosets S → A) (q : RightCosets S) :
+      e.conj ((Rep.ind S.subtype A).ρ g) x q =
+        A.ρ (rightCosetFactor (S := S) (q.out * g))
+          (x (Quotient.mk'' (q.out * g))) := by
+    have he : indSubtypeEquivPi A (e.symm x) = x := by
+      simpa only [e] using e.apply_symm_apply x
+    rw [LinearEquiv.conj_apply, LinearMap.comp_apply, LinearMap.comp_apply,
+      LinearEquiv.coe_coe]
+    rw [indSubtypeEquivPi_ρ_apply]
+    exact congrArg (A.ρ (rightCosetFactor (S := S) (q.out * g)))
+      (congrFun he (Quotient.mk'' (q.out * g)))
+  rw [LinearMap.trace_pi_of_apply_eq
     (T := e.conj ((Rep.ind S.subtype A).ρ g))
     (σ := fun q => Quotient.mk'' (q.out * g))
-    (f := fun q => A.ρ (rightCosetFactor (S := S) (q.out * g))) ?_
-  intro x q
-  have he : indSubtypeEquivPi A (e.symm x) = x := by
-    simpa only [e] using e.apply_symm_apply x
-  rw [LinearEquiv.conj_apply, LinearMap.comp_apply, LinearMap.comp_apply,
-    LinearEquiv.coe_coe]
-  rw [indSubtypeEquivPi_ρ_apply]
-  exact congrArg (A.ρ (rightCosetFactor (S := S) (q.out * g)))
-    (congrFun he (Quotient.mk'' (q.out * g)))
+    (f := fun q => A.ρ (rightCosetFactor (S := S) (q.out * g))) hT]
+  apply Finset.sum_congr rfl
+  intro q _
+  by_cases hq : Quotient.mk'' (q.out * g) = q <;> simp [hq]
 
 open scoped Classical in
 /-- The trace computation expressed as the standard character summand, still indexed by right
@@ -155,12 +162,23 @@ open scoped Classical in
 /-- The induced character at `g` is the sum of the original character over those left coset
 representatives `t` for which `t⁻¹ g t` belongs to the subgroup. -/
 theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] [Fintype (G ⧸ S)] (A : FDRep k S) (g : G) :
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) (g : G) :
     (indFDRep (k := k) (G := G) A).character g =
+      letI := Fintype.ofFinite (G ⧸ S)
       ∑ t : G ⧸ S,
         if h : (Quotient.out t)⁻¹ * g * Quotient.out t ∈ S then
           A.character ⟨(Quotient.out t)⁻¹ * g * Quotient.out t, h⟩
         else 0 := by
+  have hindCharacter :
+      (indFDRep (k := k) (G := G) A).character g =
+        (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g := by
+    have hforget :
+        (indFDRep (k := k) (G := G) A).character g =
+          ((forget₂ (FDRep k G) (Rep k G)).obj
+            (indFDRep (k := k) (G := G) A)).ρ.character g := rfl
+    exact hforget.trans (congrFun
+      (Representation.char_iso (Representation.equivOfIso (indFDRepForgetIso A))) g)
+  letI := Fintype.ofFinite (G ⧸ S)
   let A' : Rep.{u} k S := (forget₂ (FDRep k S) (Rep k S)).obj A
   letI : FiniteDimensional k A' := by
     -- The forgetful object's carrier is the same vector space, hidden behind category wrappers.
@@ -168,12 +186,23 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
     infer_instance
   letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   letI : Fintype (Rep.RightCosets S) := QuotientGroup.fintypeQuotientRightRel
+  have hforgetCharacter (s : S) : A'.ρ.character s = A.character s := by
+    -- The forgetful functor changes only the categorical wrapper around `A`.
+    rfl
   have hcharacter :
       (indFDRep (k := k) (G := G) A).character g =
         LinearMap.trace k (Rep.ind S.subtype A') ((Rep.ind S.subtype A').ρ g) := by
-    simp only [indFDRep_character_eq, Representation.character, A']
+    rw [hindCharacter, Representation.character]
   rw [hcharacter, Rep.trace_ind_eq_sum_terms A' g]
   let e := QuotientGroup.quotientRightRelEquivQuotientLeftRel S
+  have he_mk (x : G) : e (Quotient.mk'' x) = QuotientGroup.mk x⁻¹ := by
+    change @Quotient.map' G G (QuotientGroup.rightRel S) (QuotientGroup.leftRel S)
+      (fun y => y⁻¹) (fun a b => by
+        rw [QuotientGroup.leftRel_apply, QuotientGroup.rightRel_apply]
+        exact fun h => (congrArg (· ∈ S) (by simp)).mp (S.inv_mem h))
+        (@Quotient.mk'' G (QuotientGroup.rightRel S) x) =
+        @Quotient.mk'' G (QuotientGroup.leftRel S) x⁻¹
+    apply Quotient.map'_mk''
   calc
     (∑ q : Rep.RightCosets S, Rep.inducedCharacterTerm A'.ρ g q.out⁻¹) =
         ∑ t : G ⧸ S, Rep.inducedCharacterTerm A'.ρ g t.out := by
@@ -184,12 +213,14 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
         calc
           e q = e (Quotient.mk'' q.out) :=
             congrArg e (Quotient.out_eq' q).symm
-          _ = QuotientGroup.mk q.out⁻¹ := rfl
+          _ = QuotientGroup.mk q.out⁻¹ := he_mk q.out
       exact heq.symm.trans (Quotient.out_eq' (e q)).symm
     _ = _ := by
       apply Finset.sum_congr rfl
       intro t _
       rw [Rep.inducedCharacterTerm]
-      rfl
+      by_cases hmem : t.out⁻¹ * g * t.out ∈ S
+      · rw [dif_pos hmem, dif_pos hmem, hforgetCharacter]
+      · rw [dif_neg hmem, dif_neg hmem]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -41,6 +41,20 @@ variable {k G : Type u} [Field k] [Group G] {S : Subgroup G}
 
 private abbrev RightCosets (S : Subgroup G) := Quotient (QuotientGroup.rightRel S)
 
+/-- The right-to-left-coset equivalence sends the right coset of `x` to the left coset of
+`x⁻¹`. Mathlib does not currently expose a computation lemma for this equivalence, so keep
+the necessary unfolding of its `Quotient.map'` implementation isolated here. -/
+private theorem quotientRightRelEquivQuotientLeftRel_mk (S : Subgroup G) (x : G) :
+    QuotientGroup.quotientRightRelEquivQuotientLeftRel S (Quotient.mk'' x) =
+      QuotientGroup.mk x⁻¹ := by
+  change @Quotient.map' G G (QuotientGroup.rightRel S) (QuotientGroup.leftRel S)
+    (fun y => y⁻¹) (fun a b => by
+      rw [QuotientGroup.leftRel_apply, QuotientGroup.rightRel_apply]
+      exact fun h => (congrArg (· ∈ S) (by simp)).mp (S.inv_mem h))
+      (@Quotient.mk'' G (QuotientGroup.rightRel S) x) =
+      @Quotient.mk'' G (QuotientGroup.leftRel S) x⁻¹
+  apply Quotient.map'_mk''
+
 open scoped Classical in
 /-- The contribution of a group element to the induced-character sum at a representative `x`. -/
 private noncomputable def inducedCharacterTerm {V : Type u} [AddCommGroup V] [Module k V]
@@ -195,14 +209,6 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
     rw [hindCharacter, Representation.character]
   rw [hcharacter, Rep.trace_ind_eq_sum_terms A' g]
   let e := QuotientGroup.quotientRightRelEquivQuotientLeftRel S
-  have he_mk (x : G) : e (Quotient.mk'' x) = QuotientGroup.mk x⁻¹ := by
-    change @Quotient.map' G G (QuotientGroup.rightRel S) (QuotientGroup.leftRel S)
-      (fun y => y⁻¹) (fun a b => by
-        rw [QuotientGroup.leftRel_apply, QuotientGroup.rightRel_apply]
-        exact fun h => (congrArg (· ∈ S) (by simp)).mp (S.inv_mem h))
-        (@Quotient.mk'' G (QuotientGroup.rightRel S) x) =
-        @Quotient.mk'' G (QuotientGroup.leftRel S) x⁻¹
-    apply Quotient.map'_mk''
   calc
     (∑ q : Rep.RightCosets S, Rep.inducedCharacterTerm A'.ρ g q.out⁻¹) =
         ∑ t : G ⧸ S, Rep.inducedCharacterTerm A'.ρ g t.out := by
@@ -213,7 +219,8 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
         calc
           e q = e (Quotient.mk'' q.out) :=
             congrArg e (Quotient.out_eq' q).symm
-          _ = QuotientGroup.mk q.out⁻¹ := he_mk q.out
+          _ = QuotientGroup.mk q.out⁻¹ :=
+            Rep.quotientRightRelEquivQuotientLeftRel_mk S q.out
       exact heq.symm.trans (Quotient.out_eq' (e q)).symm
     _ = _ := by
       apply Finset.sum_congr rfl

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.Trace.Pi
+public import TauCeti.RepresentationTheory.Induction.FiniteDimensional
+
+/-!
+# Characters of induced representations
+
+This file proves the coset-representative formula for the character of a representation induced
+from a finite-index subgroup. The formula is valid over any field and has no division by the
+subgroup order.
+
+## Main result
+
+* `TauCeti.character_indFDRep_sum_quotient` expresses an induced character as a sum over left
+  cosets.
+
+## References
+
+* [Induction and restriction roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md),
+  Layer 2.
+* J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 7.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u
+
+namespace Rep
+
+variable {k G : Type u} [Field k] [Group G] {S : Subgroup G}
+
+private abbrev RightCosets (S : Subgroup G) := Quotient (QuotientGroup.rightRel S)
+
+open scoped Classical in
+/-- The contribution of a group element to the induced-character sum at a representative `x`. -/
+private noncomputable def inducedCharacterTerm {V : Type u} [AddCommGroup V] [Module k V]
+    (ρ : Representation k S V) (g x : G) : k :=
+  if h : x⁻¹ * g * x ∈ S then ρ.character ⟨x⁻¹ * g * x, h⟩ else 0
+
+/-- The induced-character summand is unchanged on replacing a representative by another
+representative of the same left coset. -/
+private theorem inducedCharacterTerm_mul {V : Type u} [AddCommGroup V] [Module k V]
+    (ρ : Representation k S V) (g x : G) (s : S) :
+    inducedCharacterTerm ρ g (x * s) = inducedCharacterTerm ρ g x := by
+  by_cases hx : x⁻¹ * g * x ∈ S
+  · have hxs : (x * (s : G))⁻¹ * g * (x * s) ∈ S := by
+      simpa [mul_assoc] using S.mul_mem (S.mul_mem (S.inv_mem s.2) hx) s.2
+    rw [inducedCharacterTerm, dif_pos hxs, inducedCharacterTerm, dif_pos hx]
+    have helem :
+        (⟨(x * (s : G))⁻¹ * g * (x * s), hxs⟩ : S) =
+          s⁻¹ * ⟨x⁻¹ * g * x, hx⟩ * s := by
+      apply Subtype.ext
+      simp only [Subgroup.coe_mul, Subgroup.coe_inv]
+      group
+    rw [helem]
+    simpa only [inv_inv] using ρ.char_conj ⟨x⁻¹ * g * x, hx⟩ s⁻¹
+  · have hxs : (x * (s : G))⁻¹ * g * (x * s) ∉ S := by
+      intro h
+      apply hx
+      simpa [mul_assoc] using S.mul_mem (S.mul_mem s.2 h) (S.inv_mem s.2)
+    rw [inducedCharacterTerm, dif_neg hxs, inducedCharacterTerm, dif_neg hx]
+
+/-- The induced-character summand depends only on the left coset of its representative. -/
+private theorem inducedCharacterTerm_eq_of_mk_eq {V : Type u} [AddCommGroup V] [Module k V]
+    (ρ : Representation k S V) (g x y : G)
+    (hxy : (QuotientGroup.mk x : G ⧸ S) = QuotientGroup.mk y) :
+    inducedCharacterTerm ρ g x = inducedCharacterTerm ρ g y := by
+  have hs : x⁻¹ * y ∈ S :=
+    QuotientGroup.leftRel_apply.mp (Quotient.exact' hxy)
+  let s : S := ⟨x⁻¹ * y, hs⟩
+  have hy : x * (s : G) = y := by simp [s]
+  rw [← hy, inducedCharacterTerm_mul]
+
+open scoped Classical in
+/-- The trace of the induced action, computed on the right-coset model. -/
+private theorem trace_ind_eq_sum_rightCosets [S.FiniteIndex] [Fintype (RightCosets S)]
+    (A : Rep.{u} k S)
+    [FiniteDimensional k A] (g : G) :
+    LinearMap.trace k (Rep.ind S.subtype A) ((Rep.ind S.subtype A).ρ g) =
+      ∑ q : RightCosets S,
+        if Quotient.mk'' (q.out * g) = q then
+          LinearMap.trace k A (A.ρ (rightCosetFactor (S := S) (q.out * g)))
+        else 0 := by
+  let e := indSubtypeEquivPi A
+  rw [← LinearMap.trace_conj' ((Rep.ind S.subtype A).ρ g) e]
+  refine LinearMap.trace_pi_of_apply_eq
+    (T := e.conj ((Rep.ind S.subtype A).ρ g))
+    (σ := fun q => Quotient.mk'' (q.out * g))
+    (f := fun q => A.ρ (rightCosetFactor (S := S) (q.out * g))) ?_
+  intro x q
+  have he : indSubtypeEquivPi A (e.symm x) = x := by
+    simpa only [e] using e.apply_symm_apply x
+  rw [LinearEquiv.conj_apply, LinearMap.comp_apply, LinearMap.comp_apply,
+    LinearEquiv.coe_coe]
+  rw [indSubtypeEquivPi_ρ_apply]
+  exact congrArg (A.ρ (rightCosetFactor (S := S) (q.out * g)))
+    (congrFun he (Quotient.mk'' (q.out * g)))
+
+open scoped Classical in
+/-- The trace computation expressed as the standard character summand, still indexed by right
+cosets. -/
+private theorem trace_ind_eq_sum_terms [S.FiniteIndex] [Fintype (RightCosets S)]
+    (A : Rep.{u} k S) [FiniteDimensional k A] (g : G) :
+    LinearMap.trace k (Rep.ind S.subtype A) ((Rep.ind S.subtype A).ρ g) =
+      ∑ q : RightCosets S, inducedCharacterTerm A.ρ g q.out⁻¹ := by
+  rw [trace_ind_eq_sum_rightCosets A g]
+  apply Finset.sum_congr rfl
+  intro q _
+  by_cases hq : Quotient.mk'' (q.out * g) = q
+  · have hmem : q.out * g * q.out⁻¹ ∈ S := by
+      have hq' :
+          Quotient.mk'' (q.out * g) = (Quotient.mk'' q.out : RightCosets S) :=
+        hq.trans (Quotient.out_eq' q).symm
+      have hinv : q.out * g⁻¹ * q.out⁻¹ ∈ S := by
+        simpa [mul_assoc] using
+          (QuotientGroup.rightRel_apply.mp (Quotient.exact' hq'))
+      simpa [mul_assoc] using S.inv_mem hinv
+    rw [if_pos hq, inducedCharacterTerm, dif_pos (by simpa [mul_assoc] using hmem)]
+    have hfactor :
+        rightCosetFactor (S := S) (q.out * g) =
+          ⟨q.out * g * q.out⁻¹, hmem⟩ := by
+      apply Subtype.ext
+      have hout :
+          Quotient.out (Quotient.mk'' (q.out * g) : RightCosets S) = q.out :=
+        congrArg Quotient.out hq
+      calc
+        (rightCosetFactor (S := S) (q.out * g) : G) =
+            (rightCosetFactor (S := S) (q.out * g) : G) *
+              Quotient.out (Quotient.mk'' (q.out * g) : RightCosets S) * q.out⁻¹ := by
+                rw [hout]
+                simp
+        _ = q.out * g * q.out⁻¹ := by rw [rightCosetFactor_mul_out]
+    rw [hfactor]
+    simp only [Representation.character, inv_inv]
+  · have hmem : q.out * g * q.out⁻¹ ∉ S := by
+      intro h
+      apply hq
+      refine (Quotient.sound' ?_).trans (Quotient.out_eq' q)
+      rw [QuotientGroup.rightRel_apply]
+      simpa [mul_assoc] using S.inv_mem h
+    rw [if_neg hq, inducedCharacterTerm, dif_neg (by simpa [mul_assoc] using hmem)]
+
+end Rep
+
+open scoped Classical in
+/-- The induced character at `g` is the sum of the original character over those left coset
+representatives `t` for which `t⁻¹ g t` belongs to the subgroup. -/
+theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] [Fintype (G ⧸ S)] (A : FDRep k S) (g : G) :
+    (indFDRep (k := k) (G := G) A).character g =
+      ∑ t : G ⧸ S,
+        if h : (Quotient.out t)⁻¹ * g * Quotient.out t ∈ S then
+          A.character ⟨(Quotient.out t)⁻¹ * g * Quotient.out t, h⟩
+        else 0 := by
+  let A' : Rep.{u} k S := (forget₂ (FDRep k S) (Rep k S)).obj A
+  letI : FiniteDimensional k A' := by
+    -- The forgetful object's carrier is the same vector space, hidden behind category wrappers.
+    change FiniteDimensional k A
+    infer_instance
+  letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
+  letI : Fintype (Rep.RightCosets S) := QuotientGroup.fintypeQuotientRightRel
+  have hcharacter :
+      (indFDRep (k := k) (G := G) A).character g =
+        LinearMap.trace k (Rep.ind S.subtype A') ((Rep.ind S.subtype A').ρ g) := by
+    simp only [indFDRep_character_eq, Representation.character, A']
+  rw [hcharacter, Rep.trace_ind_eq_sum_terms A' g]
+  let e := QuotientGroup.quotientRightRelEquivQuotientLeftRel S
+  calc
+    (∑ q : Rep.RightCosets S, Rep.inducedCharacterTerm A'.ρ g q.out⁻¹) =
+        ∑ t : G ⧸ S, Rep.inducedCharacterTerm A'.ρ g t.out := by
+      apply Fintype.sum_equiv e
+      intro q
+      apply Rep.inducedCharacterTerm_eq_of_mk_eq
+      have heq : e q = QuotientGroup.mk q.out⁻¹ := by
+        calc
+          e q = e (Quotient.mk'' q.out) :=
+            congrArg e (Quotient.out_eq' q).symm
+          _ = QuotientGroup.mk q.out⁻¹ := rfl
+      exact heq.symm.trans (Quotient.out_eq' (e q)).symm
+    _ = _ := by
+      apply Finset.sum_congr rfl
+      intro t _
+      rw [Rep.inducedCharacterTerm]
+      rfl
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RepresentationTheory.FDRep
 public import Mathlib.RepresentationTheory.FiniteIndex
 
@@ -273,6 +274,15 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
     (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A) ≅
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Iso.refl _
+
+/-- The character of `indFDRep A` is the character of Mathlib's underlying induced
+representation. -/
+@[simp]
+theorem indFDRep_character_eq {k G : Type u} [Field k] [Group G]
+    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) (g : G) :
+    (indFDRep A).character g =
+      (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g :=
+  (rfl)
 
 /-- Induction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.indFunctor`
 on the underlying intertwiner, conjugated by `indFDRepForgetIso` and transported back along the

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.Dimension.Constructions
-public import Mathlib.RepresentationTheory.Character
 public import Mathlib.RepresentationTheory.FDRep
 public import Mathlib.RepresentationTheory.FiniteIndex
 
@@ -274,15 +273,6 @@ noncomputable def indFDRepForgetIso {k G : Type u} [Field k] [Group G]
     (forget₂ (FDRep k G) (Rep k G)).obj (indFDRep A) ≅
       Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A) :=
   Iso.refl _
-
-/-- The character of `indFDRep A` is the character of Mathlib's underlying induced
-representation. -/
-@[simp]
-theorem indFDRep_character_eq {k G : Type u} [Field k] [Group G]
-    {S : Subgroup G} [S.FiniteIndex] (A : FDRep k S) (g : G) :
-    (indFDRep A).character g =
-      (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g :=
-  (rfl)
 
 /-- Induction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.indFunctor`
 on the underlying intertwiner, conjugated by `indFDRepForgetIso` and transported back along the


### PR DESCRIPTION
This PR proves the coset-representative formula for the character of a finite-index induced representation over an arbitrary field, with no division by the subgroup order.

It advances `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, Layer 2, item “The induced-character formula (primary form: coset-representative sum, no division),” and supplies the declaration `character_indFDRep_sum_quotient` pinned in `Suggested.lean`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"character-indfdrep-sum-quotient"}-->

It adds a reusable trace lemma for coordinate-permuting endomorphisms, computes the trace of Mathlib's induced action on Tau Ceti's existing right-coset model, proves the representative-independence and left/right-coset orientation steps, and exposes the result for `FDRep.character`. It also adds the small definitional character bridge needed to move between `indFDRep` and its underlying `Rep.ind`.

The implementation reuses, without copying, Mathlib's `Pi.basis`, `LinearMap.trace_eq_matrix_trace`, and `QuotientGroup.quotientRightRelEquivQuotientLeftRel`, together with Tau Ceti's existing `indSubtypeEquivPi`, `indSubtypeEquivPi_ρ_apply`, and `rightCosetFactor` API. No content was migrated from the supplementary source snapshot. The mathematical reference is J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 7, as recorded in the module documentation.

`lake exe cache get`: `No files to download`; `Already decompressed 8641 file(s)`.

`lake build`: `Build completed successfully (5800 jobs).`

`lake exe axioms`: `axioms: audited 14793 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

`lake exe module-system`: `module-system: all 835 TauCeti module(s) opt into the module system.`

🤖 Prepared with Codex
