### PR TITLE
refactor(Hermite): separate the raising step from the eigenvalue computation

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
@@ -375,33 +375,20 @@ private theorem fourier_deriv_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : �
   rw [deriv_twoPiHermiteFunction_complex, hfourier] at hd
   simpa only [Pi.smul_apply, smul_eq_mul, mul_assoc] using hd
 
-private theorem fourier_twoPiHermiteFunction_succ (n : ℕ) (eigen : ℂ)
-    (hfourier :
-      𝓕 (fun x : ℝ => (twoPiHermiteFunction n x : ℂ)) =
-        fun x => eigen * twoPiHermiteFunction n x) :
-    𝓕 (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) =
-      fun x => (-Complex.I * eigen) * twoPiHermiteFunction (n + 1) x := by
-  -- Abbreviate the scale, creation-operator terms, and successor function.
+/-- The Fourier transform of the successor, in terms of the transforms of `x ↦ x · hₙ x` and of
+`hₙ'`: the raising relation `twoPiHermiteFunction_succ_complex` pushed through linearity of the
+transform. No eigenfunction hypothesis is involved, so this holds for every `n`. -/
+private theorem fourier_twoPiHermiteFunction_succ_eq (n : ℕ) (w : ℝ) :
+    𝓕 (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) w =
+      (Real.sqrt (2 * ((n : ℝ) + 1)) : ℂ)⁻¹ *
+        ((Real.sqrt (2 * Real.pi) : ℂ) *
+            𝓕 (fun x : ℝ => x • (twoPiHermiteFunction n x : ℂ)) w
+          + (-(Real.sqrt (2 * Real.pi) : ℂ)⁻¹) *
+            𝓕 (fun x : ℝ => ((deriv (twoPiHermiteFunction n) x : ℝ) : ℂ)) w) := by
   let s : ℂ := Real.sqrt (2 * Real.pi)
-  let a : ℂ := Real.sqrt (2 * ((n : ℝ) + 1))
   let xf : ℝ → ℂ := fun x => x • (twoPiHermiteFunction n x : ℂ)
   let df : ℝ → ℂ := fun x => ((deriv (twoPiHermiteFunction n) x : ℝ) : ℂ)
-  let fnext : ℝ → ℂ := fun x => (twoPiHermiteFunction (n + 1) x : ℂ)
-  -- Record the nonvanishing and normalization identities needed by the final scalar calculation.
-  have hs : s ≠ 0 := by
-    dsimp only [s]
-    exact Complex.ofReal_ne_zero.mpr hermiteFourierScale_ne_zero
-  have ha : a ≠ 0 := by
-    dsimp only [a]
-    exact Complex.ofReal_ne_zero.mpr (by positivity)
-  have hs_sq : s ^ 2 = 2 * Real.pi := by
-    dsimp only [s]
-    rw [← Complex.ofReal_pow, hermiteFourierScale_sq]
-    norm_num
-  -- Express the successor by the rescaled creation operator and establish integrability of its
-  -- two summands.
-  have hraise : fnext = a⁻¹ • (s • xf + (-s⁻¹) • df) :=
-    twoPiHermiteFunction_succ_complex n
+  -- Each summand of the raising relation is integrable, which is what linearity needs.
   have hsxf : Integrable (s • xf) volume := by
     apply ((integrable_mul_twoPiHermiteFunction_complex n).const_mul s).congr
     exact Filter.Eventually.of_forall fun x => by rw [Pi.smul_apply, smul_eq_mul]
@@ -409,33 +396,37 @@ private theorem fourier_twoPiHermiteFunction_succ (n : ℕ) (eigen : ℂ)
     dsimp only [df]
     apply ((integrable_deriv_twoPiHermiteFunction n).ofReal.const_mul (-s⁻¹)).congr
     exact Filter.Eventually.of_forall fun _ => rfl
-  funext w
-  -- Apply Fourier linearity, then substitute the transform identities for multiplication and
-  -- differentiation under the eigenfunction hypothesis.
-  have hadd :
-      𝓕 (s • xf + (-s⁻¹) • df) w = (𝓕 (s • xf) + 𝓕 ((-s⁻¹) • df)) w :=
+  have hadd : 𝓕 (s • xf + (-s⁻¹) • df) w = (𝓕 (s • xf) + 𝓕 ((-s⁻¹) • df)) w :=
     congrFun (VectorFourier.fourierIntegral_add
       (e := 𝐞) (L := innerₗ ℝ) (by fun_prop) (by fun_prop) hsxf hinvdf) w
-  have houter := congrFun (fourier_const_smul a⁻¹ (s • xf + (-s⁻¹) • df)) w
-  have hleftRaise := congrArg (fun g : ℝ → ℂ => 𝓕 g w) hraise
-  have hnext :
-      (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) = fnext := rfl
-  have hnextValue : (twoPiHermiteFunction (n + 1) w : ℂ) = fnext w :=
-    congrFun hnext w
-  have hraiseValue :
-      fnext w = a⁻¹ * (s * xf w + (-s⁻¹) * df w) := by
-    simpa only [Pi.add_apply, Pi.smul_apply, smul_eq_mul] using congrFun hraise w
-  rw [hnext, hnextValue]
-  rw [hleftRaise, houter, Pi.smul_apply, smul_eq_mul, hadd]
-  rw [fourier_const_smul, fourier_const_smul, Pi.add_apply,
-    Pi.smul_apply, Pi.smul_apply, smul_eq_mul,
+  rw [congrArg (fun g : ℝ → ℂ => 𝓕 g w) (twoPiHermiteFunction_succ_complex n),
+    congrFun (fourier_const_smul _ (s • xf + (-s⁻¹) • df)) w, Pi.smul_apply, smul_eq_mul,
+    hadd, Pi.add_apply, fourier_const_smul, fourier_const_smul, Pi.smul_apply, Pi.smul_apply,
+    smul_eq_mul, smul_eq_mul]
+
+private theorem fourier_twoPiHermiteFunction_succ (n : ℕ) (eigen : ℂ)
+    (hfourier :
+      𝓕 (fun x : ℝ => (twoPiHermiteFunction n x : ℂ)) =
+        fun x => eigen * twoPiHermiteFunction n x) :
+    𝓕 (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) =
+      fun x => (-Complex.I * eigen) * twoPiHermiteFunction (n + 1) x := by
+  have hs : (Real.sqrt (2 * Real.pi) : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr hermiteFourierScale_ne_zero
+  have ha : (Real.sqrt (2 * ((n : ℝ) + 1)) : ℂ) ≠ 0 :=
+    Complex.ofReal_ne_zero.mpr (by positivity)
+  have hs_sq : (Real.sqrt (2 * Real.pi) : ℂ) ^ 2 = 2 * Real.pi := by
+    rw [← Complex.ofReal_pow, hermiteFourierScale_sq]
+    norm_num
+  funext w
+  -- Expand both sides by the raising relation, then substitute the transforms of the two
+  -- creation-operator terms, which the eigenfunction hypothesis pins down.
+  rw [fourier_twoPiHermiteFunction_succ_eq n w,
     fourier_mul_twoPiHermiteFunction_of_eigen n eigen hfourier,
-    fourier_deriv_twoPiHermiteFunction_of_eigen n eigen hfourier]
-  rw [hraiseValue]
-  -- The remaining goal is the scalar normalization `s² = 2π`.
+    fourier_deriv_twoPiHermiteFunction_of_eigen n eigen hfourier,
+    congrFun (twoPiHermiteFunction_succ_complex n) w]
+  -- What is left is scalar, and turns on the normalization `√(2π)² = 2π`.
   rw [← hs_sq]
-  dsimp only [xf, df]
-  simp only [Complex.real_smul, smul_eq_mul]
+  simp only [Pi.add_apply, Pi.smul_apply, Complex.real_smul, smul_eq_mul]
   field_simp [ha, hs]
   ring_nf
 


### PR DESCRIPTION
## What

`fourier_twoPiHermiteFunction_succ` was **57 lines** — the only proof body over 50 left in the repository. It interleaved two unrelated arguments:

1. pushing the creation-operator relation through linearity of the Fourier transform, and
2. the scalar computation turning the two transform identities into the eigenvalue `-i · eigen`.

## How

| | before | after |
|---|---|---|
| `fourier_twoPiHermiteFunction_succ_eq` | — | **18** |
| `fourier_twoPiHermiteFunction_succ` | 57 | **19** |

`fourier_twoPiHermiteFunction_succ_eq` expresses `𝓕 hₙ₊₁ w` in terms of `𝓕 (x · hₙ) w` and `𝓕 hₙ' w`. It takes **no eigenfunction hypothesis** — that is a property of the raising relation, not of any particular `n` — which is what lets the parent drop to 19 lines whose remaining content is genuinely just the normalization `√(2π)² = 2π`.

This also matches how the rest of the file is organised: one private lemma per Fourier identity, so the new helper sits beside `fourier_mul_twoPiHermiteFunction_of_eigen` and `fourier_deriv_twoPiHermiteFunction_of_eigen`.

## Two mechanics notes

Both of these cost an iteration and are worth recording:

- `set s : ℂ := Real.sqrt (2 * Real.pi)` does **not** elaborate — `set` requires the coercion written out, unlike `let`, which inserts it.
- The `VectorFourier.fourierIntegral_add` rewrite only fires when the `have` states its type using the `𝓕` notation. Written against the unfolded `VectorFourier.fourierIntegral 𝐞 volume (innerₗ ℝ)` form, `rw` reports the pattern as not found even though the goal displays identically.

## Scope

No statement changes: `fourier_twoPiHermiteFunction_succ` keeps its signature, and the new helper is private.

**With this, no proof body in the repository exceeds 48 lines.**

Gates: `lake build`, `lake exe axioms` (14842 declarations), `lake exe module-system` (838/838), `scripts/lint-env.sh` — all green.