### PR TITLE
feat: derive Cauchy's theorem for null-homotopic contours

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.Contour.NullHomologous
 public import TauCeti.Analysis.Contour.Winding.Number.Homotopy
 import TauCeti.Analysis.Contour.HomologyCauchy
 
@@ -21,7 +22,6 @@ path, matching the raw-curve interface expected by `homologyCauchyTheorem`.
 
 ## Main results
 
-* `windingNumber_const` — a constant curve has winding number zero on every parameter interval.
 * `windingNumber_eq_zero_of_pathHomotopy_refl` — a loop smoothly homotopic to its constant path
   through a point-avoiding homotopy has winding number zero about that point.
 * `isNullHomologous_of_pathHomotopy_refl` — a loop smoothly contracted inside `Ω` is
@@ -45,30 +45,6 @@ open scoped unitInterval
 open Set
 
 namespace TauCeti.Contour
-
-/-- The generalized winding number of a constant curve is zero on every parameter interval. -/
-@[simp]
-theorem windingNumber_const (x : ℂ) (a b : ℝ) (z : ℂ) :
-    windingNumber (fun _ : ℝ => x) a b z = 0 := by
-  have hpv :
-      HasCauchyPVAt (fun _ : ℝ => x) a b (fun w => (w - z)⁻¹) z 0 := by
-    refine HasCauchyPVAt.intro ?_ ?_
-    · filter_upwards with ε
-      simp only [deriv_const, mul_zero, ite_self]
-      exact IntervalIntegrable.zero
-    · simpa only [deriv_const, mul_zero, ite_self, intervalIntegral.integral_zero] using
-        (tendsto_const_nhds :
-          Filter.Tendsto (fun _ : ℝ => (0 : ℂ)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0))
-  rw [windingNumber_eq_of_hasCauchyPVAt hpv]
-  simp
-
-/-- A constant curve is null-homologous in every ambient set and on every parameter interval. -/
-@[simp]
-theorem isNullHomologous_const (x : ℂ) (a b : ℝ) (Ω : Set ℂ) :
-    IsNullHomologous (fun _ : ℝ => x) a b Ω := by
-  rw [isNullHomologous_iff]
-  intro w _hw
-  exact windingNumber_const x a b w
 
 /-- A loop smoothly homotopic to its constant path through points avoiding `w` has winding number
 zero about `w`. -/

--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.Number.Homotopy
+import TauCeti.Analysis.Contour.HomologyCauchy
+
+/-!
+# Cauchy's theorem for null-homotopic contours
+
+A closed path that is smoothly homotopic to its constant path inside an open set is
+null-homologous there. Consequently, the homology form of Cauchy's theorem makes the contour
+integral of every holomorphic function vanish along such a path. This supplies the
+null-homotopic special case explicitly requested in Layer 3 of the Contour Integration roadmap.
+
+The homotopy is represented by Mathlib's `Path.Homotopy`, and the same `C²` regularity used by
+`windingNumber_eq_of_pathHomotopy` is retained. That regularity supplies a piecewise-`C¹` source
+path, matching the raw-curve interface expected by `homologyCauchyTheorem`.
+
+## Main results
+
+* `windingNumber_const` — a constant curve has winding number zero on every parameter interval.
+* `windingNumber_eq_zero_of_pathHomotopy_refl` — a loop smoothly homotopic to its constant path
+  through a point-avoiding homotopy has winding number zero about that point.
+* `isNullHomologous_of_pathHomotopy_refl` — a loop smoothly contracted inside `Ω` is
+  null-homologous in `Ω`.
+* `cauchyTheorem_of_pathHomotopy_refl` — Cauchy's theorem for such a contractible contour.
+
+## Provenance
+
+No formalization is vendored. The proof combines Tau Ceti's homotopy invariance of the winding
+number with its homology Cauchy theorem. The implication “null-homotopic implies
+null-homologous” and the resulting Cauchy theorem are standard; see S. Lang, *Complex Analysis*,
+Chapter VI, and L. Ahlfors, *Complex Analysis*, Chapter 4, as cited by the Contour Integration
+roadmap.
+-/
+
+public section
+
+noncomputable section
+
+open scoped unitInterval
+open Set
+
+namespace TauCeti.Contour
+
+/-- The generalized winding number of a constant curve is zero on every parameter interval. -/
+@[simp]
+theorem windingNumber_const (x : ℂ) (a b : ℝ) (z : ℂ) :
+    windingNumber (fun _ : ℝ => x) a b z = 0 := by
+  have hpv :
+      HasCauchyPVAt (fun _ : ℝ => x) a b (fun w => (w - z)⁻¹) z 0 := by
+    refine HasCauchyPVAt.intro ?_ ?_
+    · filter_upwards with ε
+      simp only [deriv_const, mul_zero, ite_self]
+      exact IntervalIntegrable.zero
+    · simpa only [deriv_const, mul_zero, ite_self, intervalIntegral.integral_zero] using
+        (tendsto_const_nhds :
+          Filter.Tendsto (fun _ : ℝ => (0 : ℂ)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0))
+  rw [windingNumber_eq_of_hasCauchyPVAt hpv]
+  simp
+
+/-- A constant curve is null-homologous in every ambient set and on every parameter interval. -/
+@[simp]
+theorem isNullHomologous_const (x : ℂ) (a b : ℝ) (Ω : Set ℂ) :
+    IsNullHomologous (fun _ : ℝ => x) a b Ω := by
+  rw [isNullHomologous_iff]
+  intro w _hw
+  exact windingNumber_const x a b w
+
+/-- A loop smoothly homotopic to its constant path through points avoiding `w` has winding number
+zero about `w`. -/
+theorem windingNumber_eq_zero_of_pathHomotopy_refl {x w : ℂ} {p : Path x x}
+    (φ : p.Homotopy (Path.refl x))
+    (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
+      (Set.Icc 0 1))
+    (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
+    windingNumber p.extend 0 1 w = 0 := by
+  rw [windingNumber_eq_of_pathHomotopy φ hφsmooth havoid]
+  rw [Path.refl_extend]
+  exact windingNumber_const x 0 1 w
+
+/-- **Null-homotopic implies null-homologous.** If a loop admits a `C²` path homotopy to its
+constant path whose image lies in `Ω`, then its generalized winding number vanishes at every point
+outside `Ω`. Thus the loop is null-homologous in `Ω`.
+
+This is one direction only: a null-homologous loop need not be null-homotopic. -/
+theorem isNullHomologous_of_pathHomotopy_refl {x : ℂ} {p : Path x x} {Ω : Set ℂ}
+    (φ : p.Homotopy (Path.refl x))
+    (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
+      (Set.Icc 0 1))
+    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :
+    IsNullHomologous p.extend 0 1 Ω :=
+  (isNullHomologous_iff_of_pathHomotopy φ hφsmooth hφΩ).2
+    (by
+      rw [Path.refl_extend]
+      exact isNullHomologous_const x 0 1 Ω)
+
+/-- **Cauchy's theorem for a null-homotopic contour.** Let `p` be a piecewise-`C¹` loop admitting
+a `C²` path homotopy to its constant path inside an open set `Ω`. If `f` is holomorphic on `Ω`,
+then the contour integral of `f` along `p` vanishes.
+
+The smooth homotopy supplies the piecewise-`C¹` regularity expected by
+`homologyCauchyTheorem`, as well as containment of the source path in `Ω` and its null-homology
+there. -/
+theorem cauchyTheorem_of_pathHomotopy_refl {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω)
+    {x : ℂ} (p : Path x x)
+    (φ : p.Homotopy (Path.refl x))
+    (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
+      (Set.Icc 0 1))
+    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω)
+    (hf : DifferentiableOn ℂ f Ω) :
+    ∫ t in (0 : ℝ)..1, deriv p.extend t • f (p.extend t) = 0 := by
+  have hp : IsPiecewiseC1On p.extend 0 1 := by
+    simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (0 : I)
+  apply homologyCauchyTheorem hΩ p.extend 0 1 hp
+  · intro t ht
+    rw [uIcc_of_le zero_le_one] at ht
+    rw [Path.extend_apply p ht]
+    simpa using hφΩ ((0 : Set.Icc (0 : ℝ) 1), ⟨t, ht⟩)
+  · simp only [Path.extend_zero, Path.extend_one]
+  · exact hf
+  · exact isNullHomologous_of_pathHomotopy_refl φ hφsmooth hφΩ
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/NullHomologous.lean
+++ b/TauCeti/Analysis/Contour/NullHomologous.lean
@@ -27,7 +27,8 @@ domains and the proof only needs the vanishing of the winding number on the comp
   hypotheses by intersecting domains.
 * `Contour.IsNullHomologous.union_left`, `Contour.IsNullHomologous.union_right` — a null-homologous
   curve remains null-homologous after adjoining an extra part of the domain.
-* `Contour.isNullHomologous_empty_iff`, `Contour.isNullHomologous_univ` — the two boundary cases.
+* `Contour.isNullHomologous_const`, `Contour.isNullHomologous_empty_iff`,
+  `Contour.isNullHomologous_univ` — constant curves and the two boundary cases.
 * `Contour.IsNullHomologous.refl`, `Contour.IsNullHomologous.of_eq` — a zero-length parameter
   interval is null-homologous in every ambient set.
 * `Contour.IsNullHomologous.congr_windingNumber` — replace a curve by another with the same winding
@@ -56,6 +57,14 @@ theorem isNullHomologous_univ (γ : ℝ → ℂ) (a b : ℝ) :
   rw [isNullHomologous_iff]
   intro w hw
   simp at hw
+
+/-- A constant curve is null-homologous in every ambient set and on every parameter interval. -/
+@[simp]
+theorem isNullHomologous_const (x : ℂ) (a b : ℝ) (Ω : Set ℂ) :
+    IsNullHomologous (fun _ : ℝ => x) a b Ω := by
+  rw [isNullHomologous_iff]
+  intro w _hw
+  exact windingNumber_const x a b w
 
 /-- Null-homology in the empty set is exactly vanishing of the winding number about every point. -/
 @[simp]

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -28,6 +28,8 @@ value does not exist.
   `cauchyPVAt` defining value.
 * `TauCeti.Contour.windingNumber_eq_of_hasCauchyPVAt` — evaluate `windingNumber` from a Cauchy
   principal-value witness, without unfolding the definition.
+* `TauCeti.Contour.windingNumber_const` — a constant curve has winding number zero on every
+  parameter interval.
 * `TauCeti.Contour.windingNumber_congr_curve_ae` — the winding number is unchanged when the curves
   agree almost everywhere on the integration interval and their derivatives agree almost everywhere
   where the curve misses `z₀`;
@@ -93,6 +95,22 @@ theorem windingNumber_same (γ : ℝ → ℂ) (a : ℝ) (z₀ : ℂ) :
   rw [windingNumber_eq_of_hasCauchyPVAt
     (HasCauchyPVAt.refl γ a (fun z : ℂ => (z - z₀)⁻¹) z₀)]
   ring
+
+/-- The generalized winding number of a constant curve is zero on every parameter interval. -/
+@[simp]
+theorem windingNumber_const (x : ℂ) (a b : ℝ) (z : ℂ) :
+    windingNumber (fun _ : ℝ => x) a b z = 0 := by
+  have hpv :
+      HasCauchyPVAt (fun _ : ℝ => x) a b (fun w => (w - z)⁻¹) z 0 := by
+    refine HasCauchyPVAt.intro ?_ ?_
+    · filter_upwards with ε
+      simp only [deriv_const, mul_zero, ite_self]
+      exact IntervalIntegrable.zero
+    · simpa only [deriv_const, mul_zero, ite_self, intervalIntegral.integral_zero] using
+        (tendsto_const_nhds :
+          Filter.Tendsto (fun _ : ℝ => (0 : ℂ)) (nhdsWithin 0 (Set.Ioi 0)) (nhds 0))
+  rw [windingNumber_eq_of_hasCauchyPVAt hpv]
+  simp
 
 /-- **The generalized winding number is unchanged when the curves agree almost everywhere and
 their derivatives agree almost everywhere off `z₀`.** Derivative agreement is only needed where

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -92,7 +92,7 @@ theorem windingNumber_eq_two_pi_I_inv_mul_curveIntegral {x y w : ℂ} {p : Path 
 
 /-- If the extension of a path homotopy is `C²` on the unit square, then every intermediate
 path, extended constantly from the unit interval to `ℝ`, is piecewise `C¹` on `[0, 1]`. -/
-theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x : ℂ} {p q : Path x x}
+theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y}
     (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -24,6 +24,8 @@ integrals on the compact image of the homotopy.
 
 * `windingNumber_eq_two_pi_I_inv_mul_curveIntegral` identifies Tau Ceti's raw-function winding
   number of a piecewise-`C¹` path with Mathlib's curve integral of the Cauchy-kernel `1`-form.
+* `isPiecewiseC1On_eval_of_smoothPathHomotopy` supplies piecewise-`C¹` regularity for every path
+  in a smooth homotopy.
 * `windingNumber_eq_of_pathHomotopy` proves the Layer 0 homotopy invariance result.
 * `isNullHomologous_iff_of_pathHomotopy` transfers null-homology across a homotopy in the ambient
   set.
@@ -88,8 +90,9 @@ theorem windingNumber_eq_two_pi_I_inv_mul_curveIntegral {x y w : ℂ} {p : Path 
     curveIntegral_eq_intervalIntegral_deriv]
   simp only [smul_apply, ContinuousLinearMap.id_apply, smul_eq_mul]
 
-/-- Every intermediate path of a smooth path homotopy is piecewise `C¹`. -/
-private theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x : ℂ} {p q : Path x x}
+/-- If the extension of a path homotopy is `C²` on the unit square, then every intermediate
+path, extended constantly from the unit interval to `ℝ`, is piecewise `C¹` on `[0, 1]`. -/
+theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x : ℂ} {p q : Path x x}
     (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
       (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)


### PR DESCRIPTION
This PR derives null-homology from a smooth contraction of a closed path and then obtains Cauchy's theorem for that null-homotopic contour from the homology Cauchy theorem. Keep the bridge honest at the generalized winding-number level: constant curves have zero principal-value winding number on every parameter interval, homotopy invariance transports that value to the contracted loop, and the homotopy image supplies containment in the ambient open set.

It advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 3, the specific statement “Subsumes the null-homotopic case (null-homotopic ⟹ null-homologous, not conversely),” together with Layer 2's requested “Cauchy's theorem for a contractible contour as a corollary.” This is the lowest-hanging distinct target because the `C²` winding-number homotopy invariance and the homology Cauchy theorem are already on `main`, while no open or recently merged PR supplies their null-homotopic bridge.

Add `TauCeti/Analysis/Contour/Cauchy/Homotopy.lean` (132 lines) with the constant-curve winding and null-homology API, the null-homotopy-to-null-homology theorem, and the contractible-contour Cauchy theorem. Promote the existing intermediate-path regularity lemma in `TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean` so the final theorem derives piecewise-`C¹` regularity from the smooth homotopy instead of requiring a redundant hypothesis.

Reuse Mathlib's `Path.Homotopy`, `Path.refl_extend`, and interval-integral API, together with Tau Ceti's `windingNumber_eq_of_pathHomotopy`, `isNullHomologous_iff_of_pathHomotopy`, and `homologyCauchyTheorem`. Vendor no Mathlib infrastructure and copy or adapt no external formalization. Follow the standard null-homotopy/null-homology implication as presented in the Lang and Ahlfors references cited by the roadmap.

`lake build` completes successfully with 5,806 jobs. `tauceti-axioms --changed-from origin/main` audits 31 declarations in two changed modules, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` reports zero new violations.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"null-homotopic-implies-null-homologous"}-->

🤖 Prepared with Codex
