### PR TITLE
feat: add averaged induced-character formula

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -174,6 +174,26 @@ private theorem trace_ind_eq_sum_terms [S.FiniteIndex] [Fintype (RightCosets S)]
 
 end Rep
 
+section Forget
+
+variable {k G : Type u} [Field k] [Group G] (A : FDRep k G)
+
+/-- Forgetting finite-dimensionality keeps the same underlying module, so it keeps the
+`FiniteDimensional` instance. -/
+private instance : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
+  inferInstanceAs (FiniteDimensional k A)
+
+/-- The forgetful functor `FDRep k G ⥤ Rep k G` preserves characters. Mathlib's
+`FDRep.forget₂_ρ` supplies the equality of the two representations; the closing `rfl` only
+identifies the two names of the single underlying module, the same definitional identification
+that lets `FDRep.forget₂_ρ` be stated at all. Keep that unfolding isolated here. -/
+private theorem character_forget₂ (g : G) :
+    ((forget₂ (FDRep k G) (Rep k G)).obj A).ρ.character g = A.character g := by
+  rw [FDRep.character, Representation.character, FDRep.forget₂_ρ]
+  rfl
+
+end Forget
+
 open scoped Classical in
 /-- The induced character at `g` is the sum of the original character over those left coset
 representatives `t` for which `t⁻¹ g t` belongs to the subgroup. -/
@@ -187,24 +207,14 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
         else 0 := by
   have hindCharacter :
       (indFDRep (k := k) (G := G) A).character g =
-        (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g := by
-    have hforget :
-        (indFDRep (k := k) (G := G) A).character g =
-          ((forget₂ (FDRep k G) (Rep k G)).obj
-            (indFDRep (k := k) (G := G) A)).ρ.character g := rfl
-    exact hforget.trans (congrFun
+        (Rep.ind S.subtype ((forget₂ (FDRep k S) (Rep k S)).obj A)).ρ.character g :=
+    (character_forget₂ (indFDRep (k := k) (G := G) A) g).symm.trans (congrFun
       (Representation.char_iso (Representation.equivOfIso (indFDRepForgetIso A))) g)
   letI := Fintype.ofFinite (G ⧸ S)
   let A' : Rep.{u} k S := (forget₂ (FDRep k S) (Rep k S)).obj A
-  letI : FiniteDimensional k A' := by
-    -- The forgetful object's carrier is the same vector space, hidden behind category wrappers.
-    change FiniteDimensional k A
-    infer_instance
   letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
   letI : Fintype (Rep.RightCosets S) := QuotientGroup.fintypeQuotientRightRel
-  have hforgetCharacter (s : S) : A'.ρ.character s = A.character s := by
-    -- The forgetful functor changes only the categorical wrapper around `A`.
-    rfl
+  have hforgetCharacter (s : S) : A'.ρ.character s = A.character s := character_forget₂ A s
   have hcharacter :
       (indFDRep (k := k) (G := G) A).character g =
         LinearMap.trace k (Rep.ind S.subtype A') ((Rep.ind S.subtype A').ρ g) := by
@@ -236,7 +246,7 @@ open scoped Classical in
 /-- The induced character at `g`, written as an average over the whole group. The subgroup
 order must be invertible in the coefficient field; without this hypothesis,
 `character_indFDRep_sum_quotient` is the division-free formula to use. -/
-theorem character_ind {k G : Type u} [Field k] [Group G] {S : Subgroup G} [S.FiniteIndex]
+theorem character_ind {k G : Type u} [Field k] [Group G] {S : Subgroup G}
     [Fintype G] (hS : IsUnit (Nat.card S : k)) (A : FDRep k S) (g : G) :
     (indFDRep (k := k) (G := G) A).character g =
       (Nat.card S : k)⁻¹ * ∑ x : G,
@@ -268,7 +278,7 @@ theorem character_ind {k G : Type u} [Field k] [Group G] {S : Subgroup G} [S.Fin
   have haverage :
       (∑ q : G ⧸ S, term q.out) = (Nat.card S : k)⁻¹ * ∑ x : G, term x := by
     rw [hsum, ← mul_assoc, inv_mul_cancel₀ hS.ne_zero, one_mul]
-  have hcharacter (s : S) : A'.ρ.character s = A.character s := rfl
+  have hcharacter (s : S) : A'.ρ.character s = A.character s := character_forget₂ A s
   rw [character_indFDRep_sum_quotient]
   simpa only [term, Rep.inducedCharacterTerm, hcharacter] using haverage
 

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -183,13 +183,13 @@ variable {k G : Type u} [Field k] [Group G] (A : FDRep k G)
 private instance : FiniteDimensional k ((forget₂ (FDRep k G) (Rep k G)).obj A) :=
   inferInstanceAs (FiniteDimensional k A)
 
-/-- The forgetful functor `FDRep k G ⥤ Rep k G` preserves characters. Mathlib's
-`FDRep.forget₂_ρ` supplies the equality of the two representations; the closing `rfl` only
-identifies the two names of the single underlying module, the same definitional identification
-that lets `FDRep.forget₂_ρ` be stated at all. Keep that unfolding isolated here. -/
+/-- The forgetful functor `FDRep k G ⥤ Rep k G` preserves characters. -/
 private theorem character_forget₂ (g : G) :
     ((forget₂ (FDRep k G) (Rep k G)).obj A).ρ.character g = A.character g := by
   rw [FDRep.character, Representation.character, FDRep.forget₂_ρ]
+  -- The remaining `rfl` only identifies the two names of the single underlying module, the same
+  -- definitional identification that lets `FDRep.forget₂_ρ` be stated at all. Keeping it here
+  -- means no other proof in this file needs to unfold `forget₂`.
   rfl
 
 end Forget

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -19,6 +19,8 @@ subgroup order.
 
 * `TauCeti.character_indFDRep_sum_quotient` expresses an induced character as a sum over left
   cosets.
+* `TauCeti.character_ind` rewrites the coset sum as an average over the whole group when the
+  subgroup order is invertible in the coefficient field.
 
 ## References
 
@@ -229,5 +231,45 @@ theorem character_indFDRep_sum_quotient {k G : Type u} [Field k] [Group G]
       by_cases hmem : t.out⁻¹ * g * t.out ∈ S
       · rw [dif_pos hmem, dif_pos hmem, hforgetCharacter]
       · rw [dif_neg hmem, dif_neg hmem]
+
+open scoped Classical in
+/-- The induced character at `g`, written as an average over the whole group. The subgroup
+order must be invertible in the coefficient field; without this hypothesis,
+`character_indFDRep_sum_quotient` is the division-free formula to use. -/
+theorem character_ind {k G : Type u} [Field k] [Group G] {S : Subgroup G} [S.FiniteIndex]
+    [Fintype G] (hS : IsUnit (Nat.card S : k)) (A : FDRep k S) (g : G) :
+    (indFDRep (k := k) (G := G) A).character g =
+      (Nat.card S : k)⁻¹ * ∑ x : G,
+        if h : x⁻¹ * g * x ∈ S then A.character ⟨x⁻¹ * g * x, h⟩ else 0 := by
+  letI : Fintype (G ⧸ S) := Fintype.ofFinite _
+  let e : G ≃ (G ⧸ S) × S := Subgroup.groupEquivQuotientProdSubgroup
+  let A' : Rep k S := (forget₂ (FDRep k S) (Rep k S)).obj A
+  let term : G → k := fun x ↦ Rep.inducedCharacterTerm A'.ρ g x
+  have he_mk (q : G ⧸ S) (s : S) :
+      QuotientGroup.mk (e.symm (q, s)) = q := by
+    exact congrArg Prod.fst (e.apply_symm_apply (q, s))
+  have hterm (q : G ⧸ S) (s : S) :
+      term (e.symm (q, s)) = term q.out := by
+    apply Rep.inducedCharacterTerm_eq_of_mk_eq
+    exact (he_mk q s).trans (Quotient.out_eq' q).symm
+  have hsum :
+      (∑ x : G, term x) = (Nat.card S : k) * ∑ q : G ⧸ S, term q.out := by
+    rw [← e.symm.sum_comp term, Fintype.sum_prod_type]
+    calc
+      (∑ q : G ⧸ S, ∑ s : S, term (e.symm (q, s))) =
+          ∑ q : G ⧸ S, ∑ _s : S, term q.out := by
+            apply Finset.sum_congr rfl
+            intro q _
+            apply Finset.sum_congr rfl
+            intro s _
+            exact hterm q s
+      _ = (Nat.card S : k) * ∑ q : G ⧸ S, term q.out := by
+        simp [Finset.mul_sum]
+  have haverage :
+      (∑ q : G ⧸ S, term q.out) = (Nat.card S : k)⁻¹ * ∑ x : G, term x := by
+    rw [hsum, ← mul_assoc, inv_mul_cancel₀ hS.ne_zero, one_mul]
+  have hcharacter (s : S) : A'.ρ.character s = A.character s := rfl
+  rw [character_indFDRep_sum_quotient]
+  simpa only [term, Rep.inducedCharacterTerm, hcharacter] using haverage
 
 end TauCeti


### PR DESCRIPTION
This PR proves the averaged group-sum formula for the character of a finite-index induced representation: when the subgroup order is invertible in the coefficient field, the character is the subgroup-order-normalized sum over all conjugates in the ambient group.

It advances `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, Layer 2, the specific item “The averaged group-sum form (corollary),” and supplies the declaration `character_ind` pinned in `TauCetiRoadmap/RepresentationTheory/InductionRestriction/Suggested.lean`. This is the lowest-hanging distinct RepresentationTheory target because the division-free coset-representative formula `character_indFDRep_sum_quotient` has just landed on `main`, so the roadmap’s classical averaged form is now an immediate self-contained target; the open RepresentationTheory PRs cover separate tensor-action, tensor-square, exterior-character, Specht-ideal, and conjugation-irreducibility targets.

Extend `TauCeti/RepresentationTheory/Induction/Character.lean` by 42 lines (275 lines total). Partition the ambient group with Mathlib’s `Subgroup.groupEquivQuotientProdSubgroup`, reuse Tau Ceti’s representative-independence lemma for the induced-character summand, identify every subgroup-sized fiber with a constant sum, and cancel the subgroup cardinal only through the explicit `IsUnit (Nat.card S : k)` hypothesis. The existing module documentation already cites J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 7, for the induced-character formula.

Reuse Mathlib’s `Subgroup.groupEquivQuotientProdSubgroup`, `Equiv.sum_comp`, and `Fintype.sum_prod_type`; vendor no Mathlib infrastructure and copy or adapt no material from the supplementary source snapshot or another formalization.

`lake exe cache get` reports `No files to download` and `Already decompressed 8641 file(s)`. `lake build` reports `Build completed successfully (5806 jobs).` `lake exe axioms` reports `axioms: audited 14889 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The module-system audit passes all 841 modules, and the environment linter reports no new violations.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"character-ind"}-->

🤖 Prepared with Codex
