### PR TITLE
feat: identify class-algebra homomorphisms with eigenrows

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -21,9 +21,9 @@ the class of `1` — in the row/`ᵥ*` convention pinned by `TauCeti.classMultMa
 Everything rests on the **coordinate identity** `K_{Cᵢ} K_{Cⱼ} = ∑ₖ aᵢⱼₖ K_{Cₖ}` inside the centre,
 which is `TauCeti.classSumCenter_mul`.
 
-* `TauCeti.IsClassEigenrow v` says `v ᵥ* Mᵢ = v Cᵢ • v` for every class `Cᵢ`, and
-  `TauCeti.isClassEigenrow_iff` unwinds it to the scalar identity
-  `∑ₖ aᵢⱼₖ v Cₖ = v Cᵢ * v Cⱼ`.
+* `TauCeti.IsClassEigenrow v` says `v ᵥ* Mᵢ = v Cᵢ • v` for every class `Cᵢ`
+  (`TauCeti.isClassEigenrow_def`), and `TauCeti.isClassEigenrow_iff` unwinds it to the scalar
+  identity `∑ₖ aᵢⱼₖ v Cₖ = v Cᵢ * v Cⱼ`.
 * `TauCeti.isClassEigenrow_of_forall_exists_smul`: for a normalized `v` the eigenvalues need not be
   guessed — being a common left eigenvector at all forces them to be the values of `v`.
 * `TauCeti.isClassEigenrow_classSumRow`: the values of an algebra homomorphism
@@ -98,6 +98,13 @@ be needed for the column/`*ᵥ` convention. -/
 def IsClassEigenrow (v : ConjClasses G → k) : Prop :=
   ∀ Cᵢ : ConjClasses G,
     v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = v Cᵢ • v
+
+/-- `TauCeti.IsClassEigenrow` restated in its defining vector form, for consumers that want the
+literal eigenvector equation without unfolding the definition. -/
+theorem isClassEigenrow_def (v : ConjClasses G → k) :
+    IsClassEigenrow v ↔ ∀ Cᵢ : ConjClasses G,
+      v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = v Cᵢ • v :=
+  Iff.rfl
 
 /-- Acting with a class-multiplication matrix on a row vector from the left contracts the row
 against the structure constants. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.MultiplicationMatrix
-public import Mathlib.Algebra.Algebra.Bilinear
-public import Mathlib.LinearAlgebra.Basis.Bilinear
+import Mathlib.Algebra.Algebra.Bilinear
+import Mathlib.LinearAlgebra.Basis.Bilinear
 
 /-!
 # Common eigenrows of the class-multiplication matrices
@@ -14,8 +14,9 @@ public import Mathlib.LinearAlgebra.Basis.Bilinear
 For a finite group `G` the class sums `K_C` are a `k`-basis of the centre `Z(k[G])`
 (`TauCeti.classSumBasis`), and the class-multiplication matrices `Mᵢ`
 (`TauCeti.classMultMatrix`) record multiplication by `K_{Cᵢ}` in that basis. This file identifies
-the common **left** eigenvectors of the family `{Mᵢ}`, in the row/`ᵥ*` convention pinned by
-`TauCeti.classMultMatrix`, with the `k`-algebra homomorphisms out of the centre.
+the **normalized** common **left** eigenvectors of the family `{Mᵢ}` — those taking the value `1` at
+the class of `1` — in the row/`ᵥ*` convention pinned by `TauCeti.classMultMatrix`, with the
+`k`-algebra homomorphisms out of the centre.
 
 Everything rests on the **coordinate identity** `K_{Cᵢ} K_{Cⱼ} = ∑ₖ aᵢⱼₖ K_{Cₖ}` inside the centre,
 which is `TauCeti.classSumCenter_mul`.
@@ -32,9 +33,11 @@ which is `TauCeti.classSumCenter_mul`.
 * `TauCeti.isClassEigenrow_iff_exists_algHom` and `TauCeti.algHomEquivEigenrow` package the two
   directions as an equivalence between `Z(k[G]) →ₐ[k] k` and the normalized common left eigenrows.
 
-The normalization is exactly the exclusion of the zero row: `TauCeti.isClassEigenrow_zero` shows
-`0` is an eigenrow, and `TauCeti.IsClassEigenrow.mk_one_eq_one` shows that over a ring without zero
-divisors every *nonzero* eigenrow already satisfies `v (ConjClasses.mk 1) = 1`.
+The normalization cannot be dropped: `TauCeti.isClassEigenrow_zero` shows `0` is an eigenrow, while
+`TauCeti.classSumRow_mk_one` shows every row of an algebra homomorphism is normalized. Over a ring
+without zero divisors the normalization is exactly the exclusion of that zero row:
+`TauCeti.IsClassEigenrow.mk_one_eq_one` shows that under `NoZeroDivisors k` every *nonzero* eigenrow
+already satisfies `v (ConjClasses.mk 1) = 1`.
 
 Nothing here uses representation theory: the statement is about the class algebra alone, so it holds
 over any commutative ring `k`. In the Burnside--Dixon--Schneider algorithm it is the step that turns

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -1,0 +1,263 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.MultiplicationMatrix
+public import Mathlib.Algebra.Algebra.Bilinear
+
+/-!
+# Common eigenrows of the class-multiplication matrices
+
+For a finite group `G` the class sums `K_C` are a `k`-basis of the centre `Z(k[G])`
+(`TauCeti.classSumBasis`), and the class-multiplication matrices `Mᵢ`
+(`TauCeti.classMultMatrix`) record multiplication by `K_{Cᵢ}` in that basis. This file identifies
+the common **left** eigenvectors of the family `{Mᵢ}`, in the row/`ᵥ*` convention pinned by
+`TauCeti.classMultMatrix`, with the `k`-algebra homomorphisms out of the centre.
+
+Everything rests on the **coordinate identity** `K_{Cᵢ} K_{Cⱼ} = ∑ₖ aᵢⱼₖ K_{Cₖ}` inside the centre,
+which is `TauCeti.classSumCenter_mul`.
+
+* `TauCeti.IsClassEigenrow v` says `v ᵥ* Mᵢ = v Cᵢ • v` for every class `Cᵢ`, and
+  `TauCeti.isClassEigenrow_iff` unwinds it to the scalar identity
+  `∑ₖ aᵢⱼₖ v Cₖ = v Cᵢ * v Cⱼ`.
+* `TauCeti.isClassEigenrow_of_forall_exists_smul`: for a normalized `v` the eigenvalues need not be
+  guessed — being a common left eigenvector at all forces them to be the values of `v`.
+* `TauCeti.isClassEigenrow_classSumRow`: the values of an algebra homomorphism
+  `φ : Z(k[G]) →ₐ[k] k` on the class sums form such an eigenrow.
+* `TauCeti.eigenrowAlgHom`: conversely, a common left eigenrow `v` normalized by
+  `v (ConjClasses.mk 1) = 1` extends from the class-sum basis to an algebra homomorphism.
+* `TauCeti.isClassEigenrow_iff_exists_algHom` and `TauCeti.algHomEquivEigenrow` package the two
+  directions as an equivalence between `Z(k[G]) →ₐ[k] k` and the normalized common left eigenrows.
+
+The normalization is exactly the exclusion of the zero row: `TauCeti.isClassEigenrow_zero` shows
+`0` is an eigenrow, and `TauCeti.IsClassEigenrow.mk_one_eq_one` shows that over a ring without zero
+divisors every *nonzero* eigenrow already satisfies `v (ConjClasses.mk 1) = 1`.
+
+Nothing here uses representation theory: the statement is about the class algebra alone, so it holds
+over any commutative ring `k`. In the Burnside--Dixon--Schneider algorithm it is the step that turns
+a computed common eigenrow of the (integer, hence reducible mod `p`) matrices `Mᵢ` back into a
+central character; that identification of the algebra homomorphisms with the central characters of
+the irreducible representations is a separate statement, belonging to the layer that constructs
+central characters.
+
+## References
+
+This is the milestone `normalized_eigenrow_iff_algHom` of Layer 5 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md)
+and its
+[suggested declarations](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/Suggested.lean),
+stated over a general commutative ring and with the algebra homomorphism produced as a `def`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Matrix
+
+variable {G : Type*} [Group G] [Fintype G] [DecidableEq G]
+
+variable {k : Type*} [CommRing k]
+
+/-- The row of values of an algebra homomorphism out of the centre of `k[G]` on the class sums. -/
+noncomputable def classSumRow (φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) :
+    ConjClasses G → k :=
+  fun C => φ (classSumCenter C)
+
+@[simp]
+theorem classSumRow_apply (φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k)
+    (C : ConjClasses G) : classSumRow φ C = φ (classSumCenter C) :=
+  (rfl)
+
+/-- The class sum of the class of `1` is the unit of the centre, so every algebra homomorphism
+takes the value `1` there: the row of an algebra homomorphism is normalized. -/
+theorem classSumRow_mk_one (φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) :
+    classSumRow φ (ConjClasses.mk (1 : G)) = 1 := by
+  simp [classSumRow]
+
+/-- An algebra homomorphism out of the centre of `k[G]` is determined by its values on the class
+sums, because those are a basis. -/
+theorem classSumRow_injective :
+    Function.Injective (classSumRow (G := G) (k := k)) := by
+  intro φ ψ h
+  refine AlgHom.toLinearMap_injective (Module.Basis.ext classSumBasis fun C => ?_)
+  simpa only [classSumRow_apply, classSumBasis_apply, AlgHom.toLinearMap_apply] using congrFun h C
+
+/-- A function on the conjugacy classes of `G` is a **common left eigenrow** of the
+class-multiplication matrices when, for every class `Cᵢ`, it is a left eigenvector of
+`classMultMatrix Cᵢ` with eigenvalue its own value at `Cᵢ`.
+
+The row/`ᵥ*` orientation is the one pinned by `TauCeti.classMultMatrix`; the transposed matrix would
+be needed for the column/`*ᵥ` convention. -/
+def IsClassEigenrow (v : ConjClasses G → k) : Prop :=
+  ∀ Cᵢ : ConjClasses G,
+    v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = v Cᵢ • v
+
+/-- Acting with a class-multiplication matrix on a row vector from the left contracts the row
+against the structure constants. -/
+theorem vecMul_classMultMatrix_apply (v : ConjClasses G → k) (Cᵢ Cⱼ : ConjClasses G) :
+    (v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k)) Cⱼ =
+      ∑ Cₖ : ConjClasses G, (structureConstant Cᵢ Cⱼ Cₖ : k) * v Cₖ := by
+  rw [Matrix.vecMul_apply_eq_sum]
+  refine Finset.sum_congr rfl fun Cₖ _ => ?_
+  simp only [Matrix.map_apply, classMultMatrix_apply, Int.cast_natCast]
+  ring
+
+/-- The eigenrow condition, unwound into the scalar identity
+`∑ₖ aᵢⱼₖ v Cₖ = v Cᵢ * v Cⱼ` on the structure constants. -/
+theorem isClassEigenrow_iff (v : ConjClasses G → k) :
+    IsClassEigenrow v ↔ ∀ Cᵢ Cⱼ : ConjClasses G,
+      ∑ Cₖ : ConjClasses G, (structureConstant Cᵢ Cⱼ Cₖ : k) * v Cₖ = v Cᵢ * v Cⱼ := by
+  refine forall_congr' fun Cᵢ => ?_
+  rw [funext_iff]
+  exact forall_congr' fun Cⱼ => by
+    simp only [vecMul_classMultMatrix_apply, Pi.smul_apply, smul_eq_mul]
+
+/-- The zero row is a common left eigenrow. This is why the correspondence with algebra
+homomorphisms needs the normalization `v (ConjClasses.mk 1) = 1`. -/
+theorem isClassEigenrow_zero : IsClassEigenrow (0 : ConjClasses G → k) := by
+  intro Cᵢ
+  simp
+
+/-- The value of a common left eigenrow at the class of `1` acts as an identity on the row: the
+class-multiplication matrix at the class of `1` is the identity matrix. -/
+theorem IsClassEigenrow.mk_one_smul {v : ConjClasses G → k} (hv : IsClassEigenrow v) :
+    v (ConjClasses.mk (1 : G)) • v = v := by
+  have h := hv (ConjClasses.mk (1 : G))
+  rw [classMultMatrix_mk_one] at h
+  simpa using h.symm
+
+/-- Over a ring without zero divisors, a **nonzero** common left eigenrow is automatically
+normalized: its value at the class of `1` is `1`. -/
+theorem IsClassEigenrow.mk_one_eq_one [NoZeroDivisors k] {v : ConjClasses G → k}
+    (hv : IsClassEigenrow v) (hv₀ : v ≠ 0) : v (ConjClasses.mk (1 : G)) = 1 := by
+  obtain ⟨C, hC⟩ : ∃ C, v C ≠ 0 := by
+    by_contra h
+    exact hv₀ (funext fun C => not_not.mp fun hC => h ⟨C, hC⟩)
+  have h := congrFun hv.mk_one_smul C
+  simp only [Pi.smul_apply, smul_eq_mul] at h
+  exact mul_right_cancel₀ hC (by rw [h, one_mul])
+
+/-- **The eigenvalue of a normalized common left eigenvector is forced.** If `v` takes the value `1`
+at the class of `1` and `v ᵥ* Mᵢ = c • v` for some scalar `c`, then `c = v Cᵢ`: evaluating at the
+class of `1` reads the eigenvalue off the row. -/
+theorem eq_of_vecMul_classMultMatrix_eq_smul {v : ConjClasses G → k}
+    (hv₁ : v (ConjClasses.mk (1 : G)) = 1) {Cᵢ : ConjClasses G} {c : k}
+    (h : v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = c • v) : c = v Cᵢ := by
+  have h₁ := congrFun h (ConjClasses.mk (1 : G))
+  rw [vecMul_classMultMatrix_apply] at h₁
+  simp only [structureConstant_mk_one_middle, Nat.cast_ite, Nat.cast_one, Nat.cast_zero,
+    ite_mul, one_mul, zero_mul, Finset.sum_ite_eq' Finset.univ Cᵢ v, Finset.mem_univ, if_true,
+    Pi.smul_apply, smul_eq_mul, hv₁, mul_one] at h₁
+  exact h₁.symm
+
+/-- **A normalized common left eigenvector of the class-multiplication matrices is an eigenrow.**
+Only the existence of *some* eigenvalue for each matrix has to be checked; the normalization forces
+it to be the row's own value. -/
+theorem isClassEigenrow_of_forall_exists_smul {v : ConjClasses G → k}
+    (hv₁ : v (ConjClasses.mk (1 : G)) = 1)
+    (h : ∀ Cᵢ : ConjClasses G,
+      ∃ c : k, v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = c • v) :
+    IsClassEigenrow v := fun Cᵢ => by
+  obtain ⟨c, hc⟩ := h Cᵢ
+  rwa [eq_of_vecMul_classMultMatrix_eq_smul hv₁ hc] at hc
+
+/-- **The values of an algebra homomorphism on the class sums form a common left eigenrow.** This
+is the coordinate identity `TauCeti.classSumCenter_mul` pushed through `φ`. -/
+theorem isClassEigenrow_classSumRow (φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) :
+    IsClassEigenrow (classSumRow φ) := by
+  refine (isClassEigenrow_iff _).mpr fun Cᵢ Cⱼ => ?_
+  have h := congrArg φ (classSumCenter_mul k Cᵢ Cⱼ)
+  simp only [map_mul, map_sum, map_smul, smul_eq_mul] at h
+  simpa only [classSumRow_apply] using h.symm
+
+/-- The linear extension of a row of scalars along the class-sum basis is multiplicative as soon as
+it is multiplicative on the basis itself. -/
+private theorem map_mul_of_basis
+    {f : Subalgebra.center k (MonoidAlgebra k G) →ₗ[k] k}
+    (hf : ∀ Cᵢ Cⱼ : ConjClasses G,
+      f (classSumCenter Cᵢ * classSumCenter Cⱼ) = f (classSumCenter Cᵢ) * f (classSumCenter Cⱼ))
+    (x y : Subalgebra.center k (MonoidAlgebra k G)) : f (x * y) = f x * f y := by
+  have hleft : ∀ (Cᵢ : ConjClasses G) (z : Subalgebra.center k (MonoidAlgebra k G)),
+      f (classSumCenter Cᵢ * z) = f (classSumCenter Cᵢ) * f z := by
+    intro Cᵢ
+    have hmap : f ∘ₗ LinearMap.mulLeft k (classSumCenter (k := k) Cᵢ)
+        = f (classSumCenter Cᵢ) • f :=
+      Module.Basis.ext classSumBasis fun Cⱼ => by
+        simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulLeft_apply,
+          classSumBasis_apply, LinearMap.smul_apply, smul_eq_mul] using hf Cᵢ Cⱼ
+    intro z
+    simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulLeft_apply,
+      LinearMap.smul_apply, smul_eq_mul] using congrArg (fun L => L z) hmap
+  have hmap : f ∘ₗ LinearMap.mulRight k y = f y • f :=
+    Module.Basis.ext classSumBasis fun Cᵢ => by
+      simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulRight_apply,
+        classSumBasis_apply, LinearMap.smul_apply, smul_eq_mul, mul_comm] using hleft Cᵢ y
+  simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulRight_apply,
+    LinearMap.smul_apply, smul_eq_mul, mul_comm] using congrArg (fun L => L x) hmap
+
+variable {v : ConjClasses G → k}
+
+/-- **The algebra homomorphism attached to a normalized common left eigenrow**: the linear extension
+of `v` along the class-sum basis. Multiplicativity is the eigenrow condition read through the
+coordinate identity, and it is unital because the class sum at the class of `1` is `1`. -/
+noncomputable def eigenrowAlgHom (hv₁ : v (ConjClasses.mk (1 : G)) = 1)
+    (hv : IsClassEigenrow v) : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k :=
+  AlgHom.ofLinearMap (Module.Basis.constr classSumBasis k v)
+    (by
+      rw [← classSumCenter_mk_one, ← classSumBasis_apply, Module.Basis.constr_basis]
+      exact hv₁)
+    (map_mul_of_basis fun Cᵢ Cⱼ => by
+      rw [classSumCenter_mul]
+      simp only [map_sum, map_smul, smul_eq_mul, ← classSumBasis_apply,
+        Module.Basis.constr_basis]
+      exact (isClassEigenrow_iff v).mp hv Cᵢ Cⱼ)
+
+@[simp]
+theorem eigenrowAlgHom_classSumCenter (hv₁ : v (ConjClasses.mk (1 : G)) = 1)
+    (hv : IsClassEigenrow v) (C : ConjClasses G) :
+    eigenrowAlgHom hv₁ hv (classSumCenter C) = v C := by
+  rw [eigenrowAlgHom, AlgHom.ofLinearMap_apply, ← classSumBasis_apply,
+    Module.Basis.constr_basis]
+
+@[simp]
+theorem classSumRow_eigenrowAlgHom (hv₁ : v (ConjClasses.mk (1 : G)) = 1)
+    (hv : IsClassEigenrow v) : classSumRow (eigenrowAlgHom hv₁ hv) = v :=
+  funext fun C => eigenrowAlgHom_classSumCenter hv₁ hv C
+
+/-- **Normalized common left eigenrows are exactly the class-algebra homomorphisms.** A function `v`
+on the conjugacy classes with `v (ConjClasses.mk 1) = 1` is a common left eigenvector of every
+class-multiplication matrix, with eigenvalue `v Cᵢ` at `Cᵢ`, if and only if it is the row of values
+of a `k`-algebra homomorphism `Z(k[G]) →ₐ[k] k` on the class sums. -/
+theorem isClassEigenrow_iff_exists_algHom (hv₁ : v (ConjClasses.mk (1 : G)) = 1) :
+    IsClassEigenrow v ↔
+      ∃ φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k, classSumRow φ = v :=
+  ⟨fun hv => ⟨eigenrowAlgHom hv₁ hv, classSumRow_eigenrowAlgHom hv₁ hv⟩,
+    fun ⟨φ, hφ⟩ => hφ ▸ isClassEigenrow_classSumRow φ⟩
+
+/-- **The algebra homomorphisms out of the centre of `k[G]` are the normalized common left
+eigenrows of the class-multiplication matrices**, bundled as an equivalence: a homomorphism goes to
+its row of values on the class sums, and a row extends linearly along the class-sum basis. -/
+noncomputable def algHomEquivEigenrow :
+    (Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) ≃
+      {v : ConjClasses G → k // v (ConjClasses.mk (1 : G)) = 1 ∧ IsClassEigenrow v} where
+  toFun φ := ⟨classSumRow φ, classSumRow_mk_one φ, isClassEigenrow_classSumRow φ⟩
+  invFun v := eigenrowAlgHom v.2.1 v.2.2
+  left_inv _ := classSumRow_injective (classSumRow_eigenrowAlgHom _ _)
+  right_inv v := Subtype.ext (classSumRow_eigenrowAlgHom v.2.1 v.2.2)
+
+@[simp]
+theorem algHomEquivEigenrow_apply_coe (φ : Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) :
+    (algHomEquivEigenrow φ : ConjClasses G → k) = classSumRow φ :=
+  (rfl)
+
+@[simp]
+theorem algHomEquivEigenrow_symm_apply_classSumCenter
+    (v : {v : ConjClasses G → k // v (ConjClasses.mk (1 : G)) = 1 ∧ IsClassEigenrow v})
+    (C : ConjClasses G) :
+    algHomEquivEigenrow.symm v (classSumCenter C) = (v : ConjClasses G → k) C :=
+  eigenrowAlgHom_classSumCenter v.2.1 v.2.2 C
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.MultiplicationMatrix
 public import Mathlib.Algebra.Algebra.Bilinear
+public import Mathlib.LinearAlgebra.Basis.Bilinear
 
 /-!
 # Common eigenrows of the class-multiplication matrices
@@ -148,7 +149,7 @@ theorem eq_of_vecMul_classMultMatrix_eq_smul {v : ConjClasses G → k}
     (h : v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = c • v) : c = v Cᵢ := by
   have h₁ := congrFun h (ConjClasses.mk (1 : G))
   rw [vecMul_classMultMatrix_apply] at h₁
-  simp only [structureConstant_mk_one_middle, Nat.cast_ite, Nat.cast_one, Nat.cast_zero,
+  simp only [structureConstant_mk_one_right, Nat.cast_ite, Nat.cast_one, Nat.cast_zero,
     ite_mul, one_mul, zero_mul, Finset.sum_ite_eq' Finset.univ Cᵢ v, Finset.mem_univ, if_true,
     Pi.smul_apply, smul_eq_mul, hv₁, mul_one] at h₁
   exact h₁.symm
@@ -179,24 +180,11 @@ private theorem map_mul_of_basis
     {f : Subalgebra.center k (MonoidAlgebra k G) →ₗ[k] k}
     (hf : ∀ Cᵢ Cⱼ : ConjClasses G,
       f (classSumCenter Cᵢ * classSumCenter Cⱼ) = f (classSumCenter Cᵢ) * f (classSumCenter Cⱼ))
-    (x y : Subalgebra.center k (MonoidAlgebra k G)) : f (x * y) = f x * f y := by
-  have hleft : ∀ (Cᵢ : ConjClasses G) (z : Subalgebra.center k (MonoidAlgebra k G)),
-      f (classSumCenter Cᵢ * z) = f (classSumCenter Cᵢ) * f z := by
-    intro Cᵢ
-    have hmap : f ∘ₗ LinearMap.mulLeft k (classSumCenter (k := k) Cᵢ)
-        = f (classSumCenter Cᵢ) • f :=
-      Module.Basis.ext classSumBasis fun Cⱼ => by
-        simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulLeft_apply,
-          classSumBasis_apply, LinearMap.smul_apply, smul_eq_mul] using hf Cᵢ Cⱼ
-    intro z
-    simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulLeft_apply,
-      LinearMap.smul_apply, smul_eq_mul] using congrArg (fun L => L z) hmap
-  have hmap : f ∘ₗ LinearMap.mulRight k y = f y • f :=
-    Module.Basis.ext classSumBasis fun Cᵢ => by
-      simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulRight_apply,
-        classSumBasis_apply, LinearMap.smul_apply, smul_eq_mul, mul_comm] using hleft Cᵢ y
-  simpa only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mulRight_apply,
-    LinearMap.smul_apply, smul_eq_mul, mul_comm] using congrArg (fun L => L x) hmap
+    (x y : Subalgebra.center k (MonoidAlgebra k G)) : f (x * y) = f x * f y :=
+  (LinearMap.map_mul_iff f).mpr
+    (LinearMap.ext_basis classSumBasis classSumBasis fun Cᵢ Cⱼ => by
+      simpa only [LinearMap.compr₂_apply, LinearMap.mul_apply', LinearMap.compl₂_apply,
+        LinearMap.coe_comp, Function.comp_apply, classSumBasis_apply] using hf Cᵢ Cⱼ) x y
 
 variable {v : ConjClasses G → k}
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -35,7 +35,7 @@ which is `TauCeti.classSumCenter_mul`.
 
 The normalization cannot be dropped: `TauCeti.isClassEigenrow_zero` shows `0` is an eigenrow, while
 `TauCeti.classSumRow_mk_one` shows every row of an algebra homomorphism is normalized. Over a ring
-without zero divisors the normalization is exactly the exclusion of that zero row:
+without zero divisors it never has to be checked for a row that is not identically zero:
 `TauCeti.IsClassEigenrow.mk_one_eq_one` shows that under `NoZeroDivisors k` every *nonzero* eigenrow
 already satisfies `v (ConjClasses.mk 1) = 1`.
 
@@ -128,6 +128,7 @@ theorem isClassEigenrow_iff (v : ConjClasses G → k) :
 
 /-- The zero row is a common left eigenrow. This is why the correspondence with algebra
 homomorphisms needs the normalization `v (ConjClasses.mk 1) = 1`. -/
+@[simp]
 theorem isClassEigenrow_zero : IsClassEigenrow (0 : ConjClasses G → k) := by
   intro Cᵢ
   simp

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -13,7 +13,7 @@ of the representative.
 These natural numbers are the coefficients for multiplication in the class-sum basis of the center
 of the group algebra. They are the integral input to the Dixon--Schneider character-table
 algorithm. The class of `1` is a unit for them
-(`TauCeti.structureConstant_mk_one_middle`), since its class sum is the unit of the group algebra.
+(`TauCeti.structureConstant_mk_one_right`), since its class sum is the unit of the group algebra.
 -/
 
 public section
@@ -138,17 +138,17 @@ theorem structureConstant_comm (Cᵢ Cⱼ Cₖ : ConjClasses G) :
 /-- **The class of `1` is a unit for the structure constants**: because `K_{Cᵢ} · K_{[1]} = K_{Cᵢ}`,
 the constant `aᵢ,[1],ₖ` is `1` when `Cₖ = Cᵢ` and `0` otherwise. -/
 @[simp]
-theorem structureConstant_mk_one_middle (Cᵢ Cₖ : ConjClasses G) :
+theorem structureConstant_mk_one_right (Cᵢ Cₖ : ConjClasses G) :
     structureConstant Cᵢ (ConjClasses.mk (1 : G)) Cₖ = if Cₖ = Cᵢ then 1 else 0 := by
   obtain ⟨g, rfl⟩ := ConjClasses.exists_rep Cₖ
   have h := coeff_classSum_mul ℕ Cᵢ (ConjClasses.mk (1 : G)) g
   rw [classSum_mk_one, mul_one, classSum_coeff] at h
   simpa using h.symm
 
-/-- The symmetric companion of `TauCeti.structureConstant_mk_one_middle`. -/
+/-- The symmetric companion of `TauCeti.structureConstant_mk_one_right`. -/
 @[simp]
 theorem structureConstant_mk_one_left (Cⱼ Cₖ : ConjClasses G) :
     structureConstant (ConjClasses.mk (1 : G)) Cⱼ Cₖ = if Cₖ = Cⱼ then 1 else 0 := by
-  rw [structureConstant_comm, structureConstant_mk_one_middle]
+  rw [structureConstant_comm, structureConstant_mk_one_right]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -12,7 +12,8 @@ of the representative.
 
 These natural numbers are the coefficients for multiplication in the class-sum basis of the center
 of the group algebra. They are the integral input to the Dixon--Schneider character-table
-algorithm.
+algorithm. The class of `1` is a unit for them
+(`TauCeti.structureConstant_mk_one_middle`), since its class sum is the unit of the group algebra.
 -/
 
 public section
@@ -99,6 +100,16 @@ theorem classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) :
     rw [if_neg hCₖ.symm, mul_zero]
   · simp
 
+/-- **The coordinate identity**: multiplication of class sums inside the centre of the group
+algebra expands in the class-sum basis with the structure constants as coefficients. This is
+`TauCeti.classSum_mul` read in the centre, where the class sums are a basis. -/
+theorem classSumCenter_mul (k : Type*) [CommSemiring k] (Cᵢ Cⱼ : ConjClasses G) :
+    classSumCenter (k := k) Cᵢ * classSumCenter Cⱼ =
+      ∑ Cₖ : ConjClasses G, (structureConstant Cᵢ Cⱼ Cₖ : k) • classSumCenter Cₖ := by
+  refine Subtype.ext ?_
+  push_cast [classSumCenter_coe]
+  exact classSum_mul k Cᵢ Cⱼ
+
 /-- The coefficient of `g` in a product of two class sums is the structure constant at the
 conjugacy class of `g`. This is the pointwise form of `TauCeti.classSum_mul`. -/
 theorem coeff_classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) (g : G) :
@@ -123,5 +134,21 @@ theorem structureConstant_comm (Cᵢ Cⱼ Cₖ : ConjClasses G) :
   have h := congrArg (fun a : MonoidAlgebra ℤ G => a.coeff g) hcomm
   simp only [coeff_classSum_mul] at h
   exact_mod_cast h
+
+/-- **The class of `1` is a unit for the structure constants**: because `K_{Cᵢ} · K_{[1]} = K_{Cᵢ}`,
+the constant `aᵢ,[1],ₖ` is `1` when `Cₖ = Cᵢ` and `0` otherwise. -/
+@[simp]
+theorem structureConstant_mk_one_middle (Cᵢ Cₖ : ConjClasses G) :
+    structureConstant Cᵢ (ConjClasses.mk (1 : G)) Cₖ = if Cₖ = Cᵢ then 1 else 0 := by
+  obtain ⟨g, rfl⟩ := ConjClasses.exists_rep Cₖ
+  have h := coeff_classSum_mul ℕ Cᵢ (ConjClasses.mk (1 : G)) g
+  rw [classSum_mk_one, mul_one, classSum_coeff] at h
+  simpa using h.symm
+
+/-- The symmetric companion of `TauCeti.structureConstant_mk_one_middle`. -/
+@[simp]
+theorem structureConstant_mk_one_left (Cⱼ Cₖ : ConjClasses G) :
+    structureConstant (ConjClasses.mk (1 : G)) Cⱼ Cₖ = if Cₖ = Cⱼ then 1 else 0 := by
+  rw [structureConstant_comm, structureConstant_mk_one_middle]
 
 end TauCeti


### PR DESCRIPTION
This PR identifies the common **left** eigenvectors of the class-multiplication matrices of a finite group with the `k`-algebra homomorphisms out of the centre of the group algebra, in the row/`ᵥ*` convention already pinned by `TauCeti.classMultMatrix`. For a normalized row `v : ConjClasses G → k` with `v [1] = 1`, `TauCeti.isClassEigenrow_iff_exists_algHom` says `v ᵥ* Mᵢ = v Cᵢ • v` for every class `Cᵢ` exactly when `v` is the row of values of some `φ : Z(k[G]) →ₐ[k] k` on the class sums, and `TauCeti.algHomEquivEigenrow` bundles the two directions as an equivalence. The forward direction pushes the coordinate identity `K_{Cᵢ} K_{Cⱼ} = ∑ₖ aᵢⱼₖ K_{Cₖ}` through `φ`; the converse extends `v` linearly along the class-sum basis and checks unitality and multiplicativity on that basis. Two sharpenings come with it: the normalization never has to be checked for a row that is not identically zero (`TauCeti.IsClassEigenrow.mk_one_eq_one` derives `v [1] = 1` for any nonzero eigenrow over a ring without zero divisors), and the eigenvalues never have to be supplied (`TauCeti.isClassEigenrow_of_forall_exists_smul`: a normalized common left eigenvector has its eigenvalues forced to be its own values, read off at the class of `1`). Nothing here uses representation theory, so it is stated over an arbitrary commutative ring rather than over `ℂ`.

This is the Layer 5 milestone `normalized_eigenrow_iff_algHom` of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md` ("Class-multiplication matrices, with a pinned convention": *"Conversely the common left eigenvectors of `{Mᵢ}` are exactly the `{vᵪ}` up to scale (`normalized_eigenrow_iff_algHom`)"*), together with the layer's first bullet, the coordinate identity. It is the step that turns a computed common eigenrow of the integer matrices `Mᵢ` back into a central character in the Burnside-Dixon-Schneider algorithm; identifying these algebra homomorphisms with the central characters of the irreducible representations is a separate statement, left to the layer that constructs central characters, and the file says so.

`TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean` gains the two prerequisites, both stated where the structure constants live: `classSumCenter_mul`, the coordinate identity read inside the centre, and `structureConstant_mk_one_middle`/`_left`, saying the class of `1` is a unit for the structure constants.

The main theorem is named by Mathlib's conventions (`isClassEigenrow_iff_exists_algHom`) rather than by the roadmap's `normalized_eigenrow_iff_algHom`; the module docstring records the correspondence.

No Mathlib infrastructure was vendored, and no content was taken from the supplementary source snapshot.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"normalized-eigenrow-iff-alghom"}-->

🤖 Prepared with Claude Code

