### PR TITLE
refactor(Contour): factor out the uniform window radius

### DIFF
--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -145,16 +145,21 @@ every crossing — which is what lets a family of per-crossing window results, e
 its own radius, be applied at one shared radius. There is no exceptional-set clause; use
 `exists_common_window_radius` directly when one is needed.
 
+Unlike that lemma this one does not ask for a nonempty family: for no crossings all three
+conditions are vacuous and any positive radius serves.
+
 The endpoint margins come out *strict* here: the radius is chosen strictly below the one that lemma
 supplies, so it clears both endpoints with room to spare. -/
 theorem exists_common_window_radius_le {a b : ℝ} {crossings : Finset ℝ}
-    (h_nonempty : crossings.Nonempty) (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
+    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
     (R : ℝ → ℝ) (hR_pos : ∀ t ∈ crossings, 0 < R t) :
     ∃ r > 0,
       (∀ t ∈ crossings, a + r < t ∧ t < b - r) ∧
       (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|) ∧
       (∀ t ∈ crossings, r ≤ R t) := by
   classical
+  rcases crossings.eq_empty_or_nonempty with rfl | h_nonempty
+  · exact ⟨1, one_pos, by simp, by simp, by simp⟩
   obtain ⟨r₀, hr₀_pos, h_endpts, h_pair, -⟩ :=
     exists_common_window_radius (P := ∅) h_nonempty h_Ioo fun t _ => Finset.notMem_empty t
   -- Pick one radius strictly under `r₀` and under every `R t`, indexing the bounds by

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.Data.Finset.Max
 public import Mathlib.Order.Interval.Set.Defs
 import TauCeti.Analysis.Contour.Curve.Distance
+import Mathlib.Algebra.Order.Field.Pi
 import Mathlib.Order.Interval.Set.UnorderedInterval
 import Mathlib.Topology.MetricSpace.Infsep
 
@@ -137,6 +138,39 @@ theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
       linarith [(min_le_right c (min (e / 2) (d / 4))).trans (min_le_right (e / 2) (d / 4))]
     · linarith [h_exc t ht p hp,
         (min_le_right c (min (e / 2) (d / 4))).trans (min_le_left (e / 2) (d / 4))]
+
+/-- **A common window radius below a prescribed per-crossing bound.** The `P = ∅` case of
+`exists_common_window_radius` with the radius additionally placed under a given positive `R t` at
+every crossing — which is what lets a family of per-crossing window results, each valid only below
+its own radius, be applied at one shared radius. There is no exceptional-set clause; use
+`exists_common_window_radius` directly when one is needed.
+
+The endpoint margins come out *strict* here: the radius is chosen strictly below the one that lemma
+supplies, so it clears both endpoints with room to spare. -/
+theorem exists_common_window_radius_le {a b : ℝ} {crossings : Finset ℝ}
+    (h_nonempty : crossings.Nonempty) (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
+    (R : ℝ → ℝ) (hR_pos : ∀ t ∈ crossings, 0 < R t) :
+    ∃ r > 0,
+      (∀ t ∈ crossings, a + r < t ∧ t < b - r) ∧
+      (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|) ∧
+      (∀ t ∈ crossings, r ≤ R t) := by
+  classical
+  obtain ⟨r₀, hr₀_pos, h_endpts, h_pair, -⟩ :=
+    exists_common_window_radius (P := ∅) h_nonempty h_Ioo fun t _ => Finset.notMem_empty t
+  -- Pick one radius strictly under `r₀` and under every `R t`, indexing the bounds by
+  -- `Option {t // t ∈ crossings}` so that `r₀` is the `none` component.
+  obtain ⟨r, hr_pos, hr_all⟩ := Pi.exists_forall_pos_add_lt
+    (ι := Option {t // t ∈ crossings}) (x := fun _ => (0 : ℝ))
+    (y := fun i => i.elim r₀ fun t => R t.1)
+    (fun i => by
+      cases i with
+      | none => simpa using hr₀_pos
+      | some t => simpa using hR_pos t.1 t.2)
+  have hr_lt : r < r₀ := by simpa using hr_all none
+  exact ⟨r, hr_pos, fun t ht => ⟨by linarith [(h_endpts t ht).1], by
+    linarith [(h_endpts t ht).2]⟩,
+    fun t ht t' ht' hne => by linarith [h_pair t ht t' ht' hne],
+    fun t ht => le_of_lt (by simpa using hr_all (some ⟨t, ht⟩))⟩
 
 /-- **In-window uniqueness of the crossing**: with windows inside `[a, b]`, distinct crossings
 more than `r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -27,6 +27,8 @@ scaffolding that localizes the principal-value analysis to one crossing per wind
 ## Main results
 
 * `Contour.exists_common_window_radius` — the common window radius.
+* `Contour.exists_common_window_radius_le` — a common window radius additionally held below a
+  positive per-crossing bound, with strict endpoint margins.
 * `Contour.eq_of_mem_window_of_eq` — in-window uniqueness of the crossing.
 * `Contour.exists_window_dist_lower_bound` — a positive lower bound for `‖γ t - s‖` on the two
   closed half-windows excluding the crossing.

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -158,32 +158,33 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
       h_imm.isPiecewiseC1On.intervalIntegrable_deriv hε
   have h_plain := fun l u =>
     plain_piece_integral_eq (s := s) h_imm hab hk c (l := l) (u := u)
-  rcases T.eq_empty_or_nonempty with hT_empty | hT_ne
+  rcases T.eq_empty_or_nonempty with hT_empty | -
   · refine hasCauchyPVAt_of_perWindow_boundary_tendsto
       (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
       one_pos hab.le T ?_ ?_ ?_ h_int_tr h_plain ?_
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => 1)
         fun t _ => one_pos)
     all_goals simp [hT_empty]
-  · obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
-      hT_ne h_Ioo fun t _ => Finset.notMem_empty t
-    have hρ_pos : 0 < r₀ / 2 := half_pos hr₀_pos
+  · -- The same uniform radius as in `InvSubCPVExistence`; the constant bound `1` is inert here,
+    -- and the strict margins it returns are what removes the halving this used to need.
+    obtain ⟨ρ, hρ_pos, h_endpts, h_pair, -⟩ :=
+      exists_common_window_radius_le h_Ioo (fun _ => 1) fun _ _ => one_pos
     refine hasCauchyPVAt_of_perWindow_boundary_tendsto
       (Φ := fun z => c * (-(↑(k - 1) : ℂ)⁻¹ * ((z - s) ^ (k - 1))⁻¹))
       hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])
-      (fun t ht t' ht' hne => by linarith [h_pair₀ t ht t' ht' hne])
+      h_pair
       h_int_tr h_plain
       (fun t₀ ht₀ => perWindow_boundary_tendsto_of_interior h_imm hab (h_Ioo t₀ ht₀)
         (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
         (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
         fun t ht h_eq => eq_of_mem_window_of_eq
-          (fun u hu => ⟨by linarith [(h_endpts u hu).1], by linarith [(h_endpts u hu).2]⟩)
-          (fun u hu u' hu' hne => by linarith [h_pair₀ u hu u' hu' hne, hr₀_pos])
+          (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
+          (fun u hu u' hu' hne => by linarith [h_pair u hu u' hu' hne])
           h_complete ht₀ ht h_eq)
-      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => r₀ / 2)
+      (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -135,7 +135,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       MeasureTheory.volume a b :=
     fun _ hε => intervalIntegrable_inv_sub_truncated h_imm.continuousOn
       h_imm.isPiecewiseC1On.intervalIntegrable_deriv hε
-  rcases T.eq_empty_or_nonempty with hT_empty | hT_ne
+  rcases T.eq_empty_or_nonempty with hT_empty | -
   · refine cauchyPVExistsAt_of_perWindow_tendsto one_pos hab.le T ?_ ?_ ?_ h_int_tr ?_
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => 1)
         fun t _ => one_pos)

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -143,28 +143,19 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
     all_goals simp [hT_empty]
   · choose! R hR_pos h_spec using fun t₀ (ht₀ : t₀ ∈ T) =>
       exists_radius_perWindow_tendsto h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
-    obtain ⟨r₀, hr₀_pos, h_endpts, h_pair₀, -⟩ := exists_common_window_radius (P := ∅)
-      hT_ne h_Ioo fun t _ => Finset.notMem_empty t
-    -- one radius below both the endpoint bound `r₀` and every per-crossing radius `R t`
-    obtain ⟨ρ, hρ_pos, hρ_all⟩ := Pi.exists_forall_pos_add_lt (ι := Option {t // t ∈ T})
-      (x := fun _ => (0 : ℝ)) (y := fun i => i.elim r₀ fun t => R t.1)
-      (fun i => by
-        cases i with
-        | none => simpa using hr₀_pos
-        | some t => simpa using hR_pos t.1 t.2)
-    have hρ_lt : ρ < r₀ := by simpa using hρ_all none
-    have hρ_le_R : ∀ t ∈ T, ρ ≤ R t := fun t ht =>
-      le_of_lt (by simpa using hρ_all (some ⟨t, ht⟩))
+    -- one radius serving every crossing at once, below each per-crossing radius `R t`
+    obtain ⟨ρ, hρ_pos, h_endpts, h_pair, hρ_le_R⟩ :=
+      exists_common_window_radius_le hT_ne h_Ioo R hR_pos
     refine cauchyPVExistsAt_of_perWindow_tendsto hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])
-      (fun t ht t' ht' hne => by linarith [h_pair₀ t ht t' ht' hne])
+      h_pair
       h_int_tr
       (fun t₀ ht₀ => h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
         fun t ht h_eq => eq_of_mem_window_of_eq
-          (fun u hu => ⟨by linarith [(h_endpts u hu).1], by linarith [(h_endpts u hu).2]⟩)
-          (fun u hu u' hu' hne => by linarith [h_pair₀ u hu u' hu' hne, hr₀_pos])
+          (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
+          (fun u hu u' hu' hne => by linarith [h_pair u hu u' hu' hne])
           h_complete ht₀ ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -16,7 +16,6 @@ import TauCeti.Analysis.Contour.Crossing.PVAggregation
 import TauCeti.Analysis.Contour.Crossing.Windows
 import TauCeti.Analysis.Contour.PerWindow.CPV
 import TauCeti.Analysis.Contour.PiecewiseC1On
-import Mathlib.Algebra.Order.Field.Pi
 
 /-!
 # Existence of the Cauchy-kernel principal value along an immersed curve
@@ -145,7 +144,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       exists_radius_perWindow_tendsto h_imm hab (h_Ioo t₀ ht₀) (hT_mem.mp ht₀).2
     -- one radius serving every crossing at once, below each per-crossing radius `R t`
     obtain ⟨ρ, hρ_pos, h_endpts, h_pair, hρ_le_R⟩ :=
-      exists_common_window_radius_le hT_ne h_Ioo R hR_pos
+      exists_common_window_radius_le h_Ioo R hR_pos
     refine cauchyPVExistsAt_of_perWindow_tendsto hρ_pos hab.le T
       (fun t ht => by linarith [(h_endpts t ht).1])
       (fun t ht => by linarith [(h_endpts t ht).2])


### PR DESCRIPTION
## What

`IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub` was **48 lines**, fourteen of which were the arithmetic of choosing one window radius: call `exists_common_window_radius` for an endpoint/separation bound `r₀`, use `Pi.exists_forall_pos_add_lt` over `Option {t // t ∈ T}` to slip a `ρ` under both `r₀` and every per-crossing radius `R t`, then relay each `r₀`-level fact down to `ρ` by `linarith` at five separate use sites.

## How

That is a statement about window radii, not about principal values, so it moves to `Crossing/Windows.lean` beside `exists_common_window_radius`:

```
exists_common_window_radius_le (h_nonempty) (h_Ioo) (R) (hR_pos) :
  ∃ r > 0, (∀ t ∈ crossings, a + r < t ∧ t < b - r)
         ∧ (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)
         ∧ (∀ t ∈ crossings, r ≤ R t)
```

| | before | after |
|---|---|---|
| `exists_common_window_radius_le` | — | **15** |
| `IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub` | 48 | **39** |

Delivering the bounds already at `ρ` cuts the five relaying `linarith`s to two.

## Strictness

The extracted statement reports **strict** endpoint margins, unlike its sibling. That is what the aggregator asks for — `cauchyPVExistsAt_of_perWindow_tendsto` wants `a < t - r` and `2 * r < |t - t'|` — and it costs nothing, because the radius is chosen strictly below `r₀`. The one consumer wanting the non-strict form, `eq_of_mem_window_of_eq`, takes `.le` at the call site.

## On the docstring

It says what the lemma is rather than overselling it. This is the `P = ∅` case of `exists_common_window_radius` plus the `R` bound; it **drops** that lemma's exceptional-set clause rather than strengthening it in every respect, and the docstring points at the general lemma for when that clause is needed.

`Windows.lean` gains `import Mathlib.Algebra.Order.Field.Pi` for the radius picker.

Gates: `lake build`, `lake exe axioms` (15038 declarations), `lake exe module-system` (847/847), `scripts/lint-env.sh` — all green.