### PR TITLE
feat: add products of abelian varieties

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
@@ -110,6 +110,10 @@ lemma prod_inv (A B : AbelianVariety K) :
 
 namespace prod
 
+private lemma toOverHom_injective {A B : AbelianVariety K} {f g : A ⟶ B}
+    (h : Hom.toOverHom f = Hom.toOverHom g) : f = g :=
+  (Hom.toOverFunctor (K := K)).map_injective h
+
 /-- The first projection from a product of abelian varieties. -/
 def fst (A B : AbelianVariety K) : prod A B ⟶ A := by
   refine Hom.mk'
@@ -163,8 +167,7 @@ lemma toOverHom_lift {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
 @[simp]
 lemma lift_fst {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
     lift f g ≫ fst A B = f := by
-  apply (Hom.toOverFunctor (K := K)).map_injective
-  change Hom.toOverHom (lift f g ≫ fst A B) = Hom.toOverHom f
+  apply toOverHom_injective
   rw [Hom.toOverHom_comp, toOverHom_lift, toOverHom_fst]
   simp only [← Category.assoc]
   simp
@@ -173,8 +176,7 @@ lemma lift_fst {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
 @[simp]
 lemma lift_snd {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
     lift f g ≫ snd A B = g := by
-  apply (Hom.toOverFunctor (K := K)).map_injective
-  change Hom.toOverHom (lift f g ≫ snd A B) = Hom.toOverHom g
+  apply toOverHom_injective
   rw [Hom.toOverHom_comp, toOverHom_lift, toOverHom_snd]
   simp only [← Category.assoc]
   simp
@@ -184,15 +186,12 @@ lemma lift_snd {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
 lemma hom_ext {A B C : AbelianVariety K} {f g : C ⟶ prod A B}
     (hfst : f ≫ fst A B = g ≫ fst A B)
     (hsnd : f ≫ snd A B = g ≫ snd A B) : f = g := by
-  apply (Hom.toOverFunctor (K := K)).map_injective
-  change Hom.toOverHom f = Hom.toOverHom g
+  apply toOverHom_injective
   rw [← cancel_mono (eqToHom (prod_toOver A B))]
   apply CartesianMonoidalCategory.hom_ext
-  · have h := congrArg (Hom.toOverFunctor (K := K)).map hfst
-    change Hom.toOverHom (f ≫ fst A B) = Hom.toOverHom (g ≫ fst A B) at h
+  · have h := congrArg Hom.toOverHom hfst
     simpa only [Hom.toOverHom_comp, toOverHom_fst, ← Category.assoc] using h
-  · have h := congrArg (Hom.toOverFunctor (K := K)).map hsnd
-    change Hom.toOverHom (f ≫ snd A B) = Hom.toOverHom (g ≫ snd A B) at h
+  · have h := congrArg Hom.toOverHom hsnd
     simpa only [Hom.toOverHom_comp, toOverHom_snd, ← Category.assoc] using h
 
 /-- Precomposing a pairing composes each of its components. -/

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AbelianVariety.Trivial
+
+/-!
+# Products of abelian varieties
+
+This file constructs the product of two abelian varieties over a field. Its underlying scheme is
+the fibre product over the base field, equipped with the componentwise group law. The projections
+and pairing operation exhibit this construction as the categorical binary product in
+`AbelianVariety K`.
+
+Finite products are part of the basic abelian-variety API required in Layer E of
+`TauCetiRoadmap/JacobianChallenge/README.md`. In particular, the theorem of the cube and the
+duality and polarization theory in that layer use powers of an abelian variety. No external
+formalization is vendored; the construction reuses Mathlib's cartesian monoidal structures on
+`Over (Spec K)` and on internal commutative groups.
+-/
+
+public section
+
+open CategoryTheory Limits MonoidalCategory CartesianMonoidalCategory AlgebraicGeometry MonObj
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace AbelianVariety
+
+variable {K : Type u} [Field K]
+
+noncomputable section
+
+private lemma isProper_tensor (A B : AbelianVariety K) :
+    IsProper (A.toOver ⊗ B.toOver).hom := by
+  rw [Over.tensorObj_hom]
+  exact MorphismProperty.comp_mem @IsProper _ _
+    (inferInstanceAs (IsProper (pullback.fst A.toOver.hom B.toOver.hom)))
+    (inferInstanceAs (IsProper A.toOver.hom))
+
+private lemma geometricallyIntegral_tensor (A B : AbelianVariety K) :
+    GeometricallyIntegral (A.toOver ⊗ B.toOver).hom := by
+  rw [geometricallyIntegral_iff]
+  intro L _ x Z fst snd h
+  rw [Over.tensorObj_hom] at h
+  let e :=
+    ((h.isoIsPullback _ _ (.of_hasPullback _ _)) ≪≫
+      (pullbackRightPullbackFstIso A.toOver.hom x
+        (pullback.fst A.toOver.hom B.toOver.hom)).symm).symm
+  exact IsIntegral.of_isIso e.hom
+
+/-- The product of two abelian varieties over `K`. Its underlying scheme is their fibre product
+over `Spec K`, and its group law is componentwise. -/
+def prod (A B : AbelianVariety K) : AbelianVariety K :=
+  letI := isProper_tensor A B
+  letI := geometricallyIntegral_tensor A B
+  ofGeometricallyIntegral (A.toOver ⊗ B.toOver)
+
+/-- The group scheme underlying a product is the fibre product group scheme. -/
+@[simp]
+lemma prod_toOver (A B : AbelianVariety K) :
+    (prod A B).toOver = A.toOver ⊗ B.toOver := by
+  letI := isProper_tensor A B
+  letI := geometricallyIntegral_tensor A B
+  exact ofGeometricallyIntegral_toOver _
+
+/-- The scheme underlying a product is the fibre product of the two underlying schemes over
+`Spec K`. -/
+@[simp]
+lemma prod_toScheme (A B : AbelianVariety K) :
+    (prod A B).toScheme = pullback A.toOver.hom B.toOver.hom := by
+  rw [toScheme, prod_toOver, Over.tensorObj_left]
+
+/-- The unit section of a product is the componentwise unit section. -/
+@[simp]
+lemma prod_one (A B : AbelianVariety K) :
+    η[(prod A B).toOver] ≫ eqToHom (prod_toOver A B) =
+      η[A.toOver ⊗ B.toOver] := by
+  letI := isProper_tensor A B
+  letI := geometricallyIntegral_tensor A B
+  unfold prod
+  exact ofGeometricallyIntegral_one _
+
+/-- The multiplication on a product is componentwise multiplication. -/
+@[simp]
+lemma prod_mul (A B : AbelianVariety K) :
+    μ[(prod A B).toOver] ≫ eqToHom (prod_toOver A B) =
+      (eqToHom (prod_toOver A B) ⊗ₘ eqToHom (prod_toOver A B)) ≫
+        μ[A.toOver ⊗ B.toOver] := by
+  letI := isProper_tensor A B
+  letI := geometricallyIntegral_tensor A B
+  unfold prod
+  exact ofGeometricallyIntegral_mul _
+
+/-- Inversion on a product is componentwise inversion. -/
+@[simp]
+lemma prod_inv (A B : AbelianVariety K) :
+    ι[(prod A B).toOver] ≫ eqToHom (prod_toOver A B) =
+      eqToHom (prod_toOver A B) ≫ ι[A.toOver ⊗ B.toOver] := by
+  letI := isProper_tensor A B
+  letI := geometricallyIntegral_tensor A B
+  unfold prod
+  exact ofGeometricallyIntegral_inv _
+
+namespace prod
+
+/-- The first projection from a product of abelian varieties. -/
+def fst (A B : AbelianVariety K) : prod A B ⟶ A := by
+  refine Hom.mk'
+    (eqToHom (prod_toOver A B) ≫ CartesianMonoidalCategory.fst A.toOver B.toOver) ?_ ?_
+  · rw [← Category.assoc, prod_one]
+    simp
+  · rw [← Category.assoc, prod_mul]
+    simp
+
+/-- The second projection from a product of abelian varieties. -/
+def snd (A B : AbelianVariety K) : prod A B ⟶ B := by
+  refine Hom.mk'
+    (eqToHom (prod_toOver A B) ≫ CartesianMonoidalCategory.snd A.toOver B.toOver) ?_ ?_
+  · rw [← Category.assoc, prod_one]
+    simp
+  · rw [← Category.assoc, prod_mul]
+    simp
+
+/-- Pair two homomorphisms with a common source to obtain a homomorphism into a product. -/
+def lift {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
+    C ⟶ prod A B := by
+  refine Hom.mk'
+    (CartesianMonoidalCategory.lift (Hom.toOverHom f) (Hom.toOverHom g) ≫
+      eqToHom (prod_toOver A B).symm) ?_ ?_
+  · simp [← cancel_mono (eqToHom (prod_toOver A B))]
+  · simp [← cancel_mono (eqToHom (prod_toOver A B))]
+
+/-- The morphism over `Spec K` underlying the first projection is the pullback projection. -/
+@[simp]
+lemma toOverHom_fst (A B : AbelianVariety K) :
+    Hom.toOverHom (fst A B) =
+      eqToHom (prod_toOver A B) ≫ CartesianMonoidalCategory.fst A.toOver B.toOver :=
+  by simp [fst]
+
+/-- The morphism over `Spec K` underlying the second projection is the pullback projection. -/
+@[simp]
+lemma toOverHom_snd (A B : AbelianVariety K) :
+    Hom.toOverHom (snd A B) =
+      eqToHom (prod_toOver A B) ≫ CartesianMonoidalCategory.snd A.toOver B.toOver :=
+  by simp [snd]
+
+/-- The morphism over `Spec K` underlying a pairing is the corresponding pullback lift. -/
+@[simp]
+lemma toOverHom_lift {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
+    Hom.toOverHom (lift f g) =
+      CartesianMonoidalCategory.lift (Hom.toOverHom f) (Hom.toOverHom g) ≫
+        eqToHom (prod_toOver A B).symm :=
+  by simp [lift]
+
+/-- The first projection of a pairing is its first component. -/
+@[simp]
+lemma lift_fst {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
+    lift f g ≫ fst A B = f := by
+  apply (Hom.toOverFunctor (K := K)).map_injective
+  change Hom.toOverHom (lift f g ≫ fst A B) = Hom.toOverHom f
+  rw [Hom.toOverHom_comp, toOverHom_lift, toOverHom_fst]
+  simp only [← Category.assoc]
+  simp
+
+/-- The second projection of a pairing is its second component. -/
+@[simp]
+lemma lift_snd {A B C : AbelianVariety K} (f : C ⟶ A) (g : C ⟶ B) :
+    lift f g ≫ snd A B = g := by
+  apply (Hom.toOverFunctor (K := K)).map_injective
+  change Hom.toOverHom (lift f g ≫ snd A B) = Hom.toOverHom g
+  rw [Hom.toOverHom_comp, toOverHom_lift, toOverHom_snd]
+  simp only [← Category.assoc]
+  simp
+
+/-- Homomorphisms into a product are determined by their two projections. -/
+@[ext]
+lemma hom_ext {A B C : AbelianVariety K} {f g : C ⟶ prod A B}
+    (hfst : f ≫ fst A B = g ≫ fst A B)
+    (hsnd : f ≫ snd A B = g ≫ snd A B) : f = g := by
+  apply (Hom.toOverFunctor (K := K)).map_injective
+  change Hom.toOverHom f = Hom.toOverHom g
+  rw [← cancel_mono (eqToHom (prod_toOver A B))]
+  apply CartesianMonoidalCategory.hom_ext
+  · have h := congrArg (Hom.toOverFunctor (K := K)).map hfst
+    change Hom.toOverHom (f ≫ fst A B) = Hom.toOverHom (g ≫ fst A B) at h
+    simpa only [Hom.toOverHom_comp, toOverHom_fst, ← Category.assoc] using h
+  · have h := congrArg (Hom.toOverFunctor (K := K)).map hsnd
+    change Hom.toOverHom (f ≫ snd A B) = Hom.toOverHom (g ≫ snd A B) at h
+    simpa only [Hom.toOverHom_comp, toOverHom_snd, ← Category.assoc] using h
+
+/-- Precomposing a pairing composes each of its components. -/
+@[reassoc, simp]
+lemma comp_lift {A B C D : AbelianVariety K} (h : D ⟶ C) (f : C ⟶ A) (g : C ⟶ B) :
+    h ≫ lift f g = lift (h ≫ f) (h ≫ g) := by
+  apply hom_ext <;> simp
+
+/-- Pairing the two projections of a homomorphism into a product recovers that homomorphism. -/
+@[simp]
+lemma lift_comp_fst_snd {A B C : AbelianVariety K} (f : C ⟶ prod A B) :
+    lift (f ≫ fst A B) (f ≫ snd A B) = f := by
+  apply hom_ext <;> simp
+
+private def binaryFan (A B : AbelianVariety K) : BinaryFan A B :=
+  BinaryFan.mk (fst A B) (snd A B)
+
+private def binaryFanIsLimit (A B : AbelianVariety K) :
+    IsLimit (binaryFan A B) :=
+  BinaryFan.IsLimit.mk _
+    (fun f g ↦ lift f g)
+    (fun f g ↦ lift_fst f g)
+    (fun f g ↦ lift_snd f g)
+    (fun f g _ hfst hsnd ↦
+      hom_ext
+        (hfst.trans (lift_fst f g).symm)
+        (hsnd.trans (lift_snd f g).symm))
+
+end prod
+
+/-- The concrete product supplies the categorical binary product of abelian varieties. -/
+instance hasBinaryProduct (A B : AbelianVariety K) : HasBinaryProduct A B :=
+  HasLimit.mk ⟨prod.binaryFan A B, prod.binaryFanIsLimit A B⟩
+
+/-- Abelian varieties over a field have categorical binary products. -/
+instance hasBinaryProducts : HasBinaryProducts (AbelianVariety K) :=
+  hasBinaryProducts_of_hasLimit_pair (AbelianVariety K)
+
+/-- Abelian varieties over a field have all finite products. -/
+instance hasFiniteProducts : HasFiniteProducts (AbelianVariety K) :=
+  CategoryTheory.hasFiniteProducts_of_has_binary_and_terminal
+
+end
+
+end AbelianVariety
+
+end AlgebraicGeometry
+
+end TauCeti


### PR DESCRIPTION
This PR adds finite products to the abelian-variety API: define `AbelianVariety.prod A B` on the fibre product over `Spec K`, prove that its componentwise group scheme is again proper and geometrically integral, and expose projections and pairing with the categorical product universal property.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, the specific item “Abelian variety = smooth, proper, geometrically connected group scheme over `k`; basic API.” It is the lowest-hanging distinct continuation of the landed abelian-variety construction because the category, homomorphisms, trivial object, and endomorphism ring are already on `main`, while no open PR or existing Mathlib/Tau Ceti declaration supplies products. Finite products are a direct prerequisite for the same layer’s theorem of the cube/square and duality/polarization theory, which use powers such as `A × A × A`.

Add `TauCeti/AlgebraicGeometry/AbelianVariety/Product.lean` (244 lines). The product’s underlying scheme is identified with `pullback A.toOver.hom B.toOver.hom`; `prod_one`, `prod_mul`, and `prod_inv` characterize its componentwise group operations; `prod.fst`, `prod.snd`, and `prod.lift` provide the projection/pairing API and its beta, eta, naturality, and extensionality laws; and `HasBinaryProducts` plus `HasFiniteProducts` instances connect the concrete construction to Mathlib’s limits API.

The geometric-integrality proof checks arbitrary field base change, uses `pullbackRightPullbackFstIso` to identify it with an iterated pullback, and then applies Mathlib’s existing integral-pullback instances. The construction also reuses the cartesian monoidal structure on `Over (Spec K)`, internal group objects, and the existing `AbelianVariety.ofGeometricallyIntegral` constructor. No Mathlib infrastructure is vendored and no external formalization is copied or adapted.

`lake build` completes successfully (5812 jobs). `tauceti-axioms --changed-from origin/main` audits 44 declarations in the changed module, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` reports zero violations and all documentation candidates covered.

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abelian-variety-products"}-->

🤖 Prepared with Codex
