### PR TITLE
feat: prove the residue theorem for a null-homologous cycle

### DIFF
--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.Analysis.Contour.PiecewiseC1On
 public import TauCeti.Analysis.Contour.RegularityConditions
 import TauCeti.Analysis.Contour.Cauchy.PrincipalValue.Basic
 import TauCeti.Analysis.Calculus.OneSidedDerivLimit
@@ -32,12 +33,20 @@ each side integral evaluates by the fundamental theorem of calculus to a boundar
 cancellation (`antiderivative_diff_across_crossing_tendsto_zero`) — the mechanism of
 Hungerbühler–Wasem condition (B) at a higher-order pole.
 
+The fundamental theorem of calculus the window integral is built on
+(`Contour.integral_pow_inv_mul_deriv_eq_sub`) is stated here for its own sake, together with its
+closed-curve corollary: around a loop missing the pole the boundary difference cancels, so an
+order-`k ≥ 2` term contributes nothing at all — the fact that leaves only the simple-pole
+coefficient in a residue theorem.
+
 ## Main results
 
 * `Contour.perWindow_higherOrder_truncated_integral_tendsto` — the truncated window integral
   of the order-`k` polar term converges, with the explicit boundary-difference value.
 * `Contour.integral_pow_inv_mul_deriv_eq_sub` — the fundamental theorem of calculus for the
   order-`k` polar term along the curve, on an interval avoiding the pole.
+* `Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed` — the same term integrates to zero
+  around a *closed* piecewise-`C¹` curve missing the pole, the endpoint difference cancelling.
 * `Contour.intervalIntegrable_pow_inv_mul_deriv_truncated` — the truncated order-`k` polar
   integrand is interval-integrable at every truncation level `ε > 0`.
 
@@ -139,6 +148,36 @@ theorem integral_pow_inv_mul_deriv_eq_sub {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
       c).comp_continuousWithinAt (hγ_cont t ht)
   exact MeasureTheory.integral_eq_of_hasDerivAt_off_countable_of_le _ _ hlu hP h_G_cont
     h_G_deriv (intervalIntegrable_pow_inv_mul_deriv c k hlu hγ_cont h_ne hderiv_int)
+
+/-- The oriented case of `Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed`. -/
+private theorem integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
+    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hab : a ≤ b) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (h_ne : ∀ t ∈ Icc a b, γ t ≠ s) :
+    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
+  obtain ⟨P, hP, hdiff⟩ := hγ.exists_countable_differentiableAt
+  rw [min_eq_left hab, max_eq_right hab] at hdiff
+  have hcont : ContinuousOn γ (Icc a b) := by
+    rw [← Set.uIcc_of_le hab]; exact hγ.continuousOn
+  rw [integral_pow_inv_mul_deriv_eq_sub hk c hab hP h_ne hdiff hcont
+    hγ.intervalIntegrable_deriv, hclosed, sub_self]
+
+/-- **A Laurent term of order at least two integrates to zero around a closed curve.** On a
+piecewise-`C¹` curve `γ` with `γ a = γ b` that never meets `s`, the integrand
+`c/(z − s)^k · γ'` with `k ≥ 2` is the derivative of `c · (−(k−1)⁻¹ (γ · − s)^{−(k−1)})`, so
+`Contour.integral_pow_inv_mul_deriv_eq_sub` returns the endpoint difference, which the closedness
+kills. This is why only the simple-pole coefficient of a Laurent tail survives in the residue
+theorem. -/
+theorem integral_pow_inv_mul_deriv_eq_zero_of_closed {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
+    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (h_ne : ∀ t ∈ uIcc a b, γ t ≠ s) :
+    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
+  rcases le_total a b with hab | hba
+  · exact integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hab hγ hclosed
+      fun t ht => h_ne t (by rwa [Set.uIcc_of_le hab])
+  · rw [intervalIntegral.integral_symm b a,
+      integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hba hγ.symm hclosed.symm
+        (fun t ht => h_ne t (by rw [Set.uIcc_comm, Set.uIcc_of_le hba]; exact ht)),
+      neg_zero]
 
 /-- **Antiderivative evaluation on a subinterval missing the crossing.** On a subinterval
 `[l, u]` of the window `[t_i - r, t_i + r]`, where the curve meets `s` only at `t_i` and

--- a/TauCeti/Analysis/Contour/PolarPart/CPV.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/CPV.lean
@@ -113,24 +113,9 @@ theorem hasCauchyPVAt_polarPart (decomp : PolarPartDecomposition f S U) (s : S)
   have h_val : (∑ k : Fin (decomp.order s), if k.val = 0 then
         decomp.coeff s k * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ) else 0)
       = 2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s * residue f s := by
-    rcases Nat.eq_zero_or_pos (decomp.order s) with h0 | h_pos
-    · rw [Finset.sum_eq_zero fun k _ => absurd k.isLt (by omega),
-        decomp.residue_eq s, dif_neg (by omega)]
-      ring
-    · have h_pick : ∀ k : Fin (decomp.order s),
-          (if k.val = 0 then
-            decomp.coeff s k * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ) else 0)
-          = if k = ⟨0, h_pos⟩ then
-            decomp.coeff s ⟨0, h_pos⟩ * cauchyPVAt γ a b (fun z => (z - (s : ℂ))⁻¹) (s : ℂ)
-          else 0 := fun k => by
-        rcases eq_or_ne k ⟨0, h_pos⟩ with rfl | hk
-        · simp
-        · rw [if_neg fun h => hk (Fin.ext h), if_neg hk]
-      rw [Finset.sum_congr rfl fun k _ => h_pick k, Finset.sum_ite_eq' Finset.univ,
-        if_pos (Finset.mem_univ _), decomp.residue_eq s, dif_pos h_pos,
-        windingNumber_eq_cauchyPVAt, ← mul_assoc,
-        mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
-      ring
+    rw [decomp.sum_ite_coeff_eq_residue_mul s, windingNumber_eq_cauchyPVAt, ← mul_assoc,
+      mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
+    ring
   rw [← h_val]
   exact h_pv
 

--- a/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
@@ -32,6 +32,9 @@ parts.
 
 ## Main results
 
+* `Contour.PolarPartDecomposition.sum_ite_coeff_eq_residue_mul` — a weight carried by the
+  simple-pole coefficient alone sums to `Res_s f` times that weight; the last step of every
+  term-by-term evaluation of a polar part.
 * `Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_analyticRemainder_eq_zero` — the
   contour integral of the analytic remainder along a closed null-homologous piecewise-`C¹` curve
   in `U` vanishes, by the homology Cauchy theorem.
@@ -95,6 +98,27 @@ structure PolarPartDecomposition (f : ℂ → ℂ) (S : Finset ℂ) (U : Set ℂ
 namespace PolarPartDecomposition
 
 variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+
+/-- **Only the simple-pole coefficient survives.** Summing the Laurent coefficients at `s` against
+a weight `c` carried by the simple-pole term alone leaves `Res_s f · c`, the empty polar part
+included (both sides are then `0`). Every evaluation of a polar part term by term — as a contour
+integral or as a principal value — bottoms out here, the higher-order terms having already been
+shown to contribute nothing. -/
+theorem sum_ite_coeff_eq_residue_mul (decomp : PolarPartDecomposition f S U) (s : S) (c : ℂ) :
+    (∑ k : Fin (decomp.order s), if k.val = 0 then decomp.coeff s k * c else 0)
+      = residue f s * c := by
+  classical
+  rcases Nat.eq_zero_or_pos (decomp.order s) with h0 | h_pos
+  · rw [Finset.sum_eq_zero fun k _ => absurd k.isLt (by omega), decomp.residue_eq s,
+      dif_neg (by omega), zero_mul]
+  · have h_pick : ∀ k : Fin (decomp.order s),
+        (if k.val = 0 then decomp.coeff s k * c else 0)
+        = if k = ⟨0, h_pos⟩ then decomp.coeff s ⟨0, h_pos⟩ * c else 0 := fun k => by
+      rcases eq_or_ne k ⟨0, h_pos⟩ with rfl | hk
+      · simp
+      · rw [if_neg fun h => hk (Fin.ext h), if_neg hk]
+    rw [Finset.sum_congr rfl fun k _ => h_pick k, Finset.sum_ite_eq' Finset.univ,
+      if_pos (Finset.mem_univ _), decomp.residue_eq s, dif_pos h_pos]
 
 /-- **The analytic remainder integrates to zero** along any closed null-homologous
 piecewise-`C¹` curve in `U` — even one passing through the poles of `f`, since the remainder

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -11,14 +11,14 @@ import TauCeti.Analysis.Contour.PerWindow.HigherOrder
 /-!
 # The classical residue theorem for an arbitrary null-homologous cycle
 
-For `f` differentiable on `U ∖ S` and meromorphic at each point of the finite set `S`, and a
-**closed, null-homologous** piecewise-`C¹` curve `γ` in `U` that **avoids** `S`,
+For `f` differentiable on `U ∖ S` and meromorphic at each point of the finite set `S` lying in
+`U`, and a **closed, null-homologous** piecewise-`C¹` curve `γ` in `U` that **avoids** `S`,
 
 `∫ t in a..b, γ' t • f (γ t) = 2πi · ∑_{s ∈ S} n_s(γ) · Res_s f`,
 
 where `n_s(γ)` is the generalized winding number of `γ` about `s`. This is the general
-arbitrary-cycle form of the classical residue theorem, the case the circle theorem
-(`Contour.classicalResidueTheorem_circle`) generalizes: the contour is an arbitrary
+arbitrary-cycle form of the classical residue theorem, and it generalizes the circle theorem
+(`Contour.classicalResidueTheorem_circle`): the contour is an arbitrary
 piecewise-`C¹` loop rather than a round circle, and each pole is weighted by its winding number
 rather than by `1`. Null-homology is not decoration — on a general holomorphy domain `Ω`, a loop
 that merely avoids the poles need not integrate to the residue sum (a loop around a hole of `Ω`
@@ -182,8 +182,9 @@ be a closed piecewise-`C¹` curve in `U`, **null-homologous** in `U`, that **avo
 each pole weighted by the generalized winding number of `γ` about it.
 
 Points of `S` outside `U` are harmless rather than excluded: null-homology forces their winding
-number, hence their contribution, to vanish. Likewise `S` may list regular points of `f`, whose
-residues are `0`.
+number, hence their contribution, to vanish, so nothing at all is asked of `f` there —
+meromorphicity is required only at the points of `S` that lie in `U`. Likewise `S` may list
+regular points of `f`, whose residues are `0`.
 
 Its `S = ∅` case is the homology Cauchy theorem (`Contour.homologyCauchyTheorem`), so this is
 genuinely a Layer 3 statement; the round-circle case with the poles inside is
@@ -191,19 +192,35 @@ genuinely a Layer 3 statement; the round-circle case with the poles inside is
 Hungerbühler–Wasem theorem `Contour.hungerbuhlerWasem_residueTheorem`. -/
 theorem classicalResidueTheorem_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     (hU : IsOpen U) (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ)))
-    (hmero : ∀ s ∈ S, MeromorphicAt f s) {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
+    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s) {γ : ℝ → ℂ} {a b : ℝ}
+    (hγ : IsPiecewiseC1On γ a b)
     (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
     (hoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • f (γ t)
       = 2 * (Real.pi : ℂ) * Complex.I * ∑ s ∈ S, windingNumber γ a b s * residue f s := by
   classical
-  obtain ⟨decomp⟩ : Nonempty (PolarPartDecomposition f S U) :=
-    ⟨.ofMeromorphic hU hf hmero⟩
+  -- Replace `S` by the part `T` of it lying in `U`, where `f` is meromorphic: a point outside `U`
+  -- has winding number `0` by null-homology, so it drops out of the sum for free.
+  obtain ⟨T, hTS, hfT, hmeroT, hsum⟩ : ∃ T : Finset ℂ, (∀ s ∈ T, s ∈ S) ∧
+      DifferentiableOn ℂ f (U \ (↑T : Set ℂ)) ∧ (∀ s ∈ T, MeromorphicAt f s) ∧
+      (∑ s ∈ S, windingNumber γ a b s * residue f s)
+        = ∑ s ∈ T, windingNumber γ a b s * residue f s :=
+    ⟨S.filter (· ∈ U), fun _ hs => (Finset.mem_filter.mp hs).1,
+      hf.mono fun z hz => ⟨hz.1, fun hzS =>
+        hz.2 (Finset.mem_coe.mpr (Finset.mem_filter.mpr ⟨hzS, hz.1⟩))⟩,
+      fun s hs => hmero s (Finset.mem_filter.mp hs).1 (Finset.mem_filter.mp hs).2,
+      (Finset.sum_filter_of_ne fun s _ hs => not_not.mp fun hsU =>
+        hs (by rw [isNullHomologous_iff.mp hnull s hsU, zero_mul])).symm⟩
+  rw [hsum]
+  obtain ⟨decomp⟩ : Nonempty (PolarPartDecomposition f T U) :=
+    ⟨.ofMeromorphic hU hfT hmeroT⟩
   have hcont : ContinuousOn γ (uIcc a b) := hγ.continuousOn
   have hderiv : IntervalIntegrable (fun t => deriv γ t) volume a b := hγ.intervalIntegrable_deriv
-  have hne : ∀ s : S, ∀ t ∈ uIcc a b, γ t ≠ (s : ℂ) := fun s t ht h_eq =>
-    hoff t ht (h_eq ▸ Finset.mem_coe.mpr s.2)
-  have hpol_cont : ∀ s : S, ContinuousOn (fun t => decomp.polarPart s (γ t)) (uIcc a b) :=
+  have hoffT : ∀ t ∈ uIcc a b, γ t ∉ (↑T : Set ℂ) := fun t ht h =>
+    hoff t ht (Finset.mem_coe.mpr (hTS _ (Finset.mem_coe.mp h)))
+  have hne : ∀ s : T, ∀ t ∈ uIcc a b, γ t ≠ (s : ℂ) := fun s t ht h_eq =>
+    hoffT t ht (h_eq ▸ Finset.mem_coe.mpr s.2)
+  have hpol_cont : ∀ s : T, ContinuousOn (fun t => decomp.polarPart s (γ t)) (uIcc a b) :=
     fun s => ContinuousOn.congr
       (continuousOn_finsetSum Finset.univ fun k _ => continuousOn_const.div
         ((hcont.sub continuousOn_const).pow (k.val + 1))
@@ -213,26 +230,24 @@ theorem classicalResidueTheorem_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ
       (fun t => deriv γ t • decomp.analyticRemainder (γ t)) volume a b :=
     hderiv.smul_continuousOn
       (decomp.analyticRemainder_differentiableOn.continuousOn.comp hcont hγU)
-  have hpol_int : ∀ s ∈ S.attach, IntervalIntegrable
+  have hpol_int : ∀ s ∈ T.attach, IntervalIntegrable
       (fun t => deriv γ t • decomp.polarPart s (γ t)) volume a b :=
     fun s _ => hderiv.smul_continuousOn (hpol_cont s)
   have hsum_int : IntervalIntegrable
-      (fun t => ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t)) volume a b := by
-    have h := IntervalIntegrable.sum S.attach hpol_int
-    rwa [show (∑ s ∈ S.attach, fun t => deriv γ t • decomp.polarPart s (γ t))
-      = fun t => ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t) from
-      funext fun t => Finset.sum_apply _ _ _] at h
+      (fun t => ∑ s ∈ T.attach, deriv γ t • decomp.polarPart s (γ t)) volume a b := by
+    have h := IntervalIntegrable.sum T.attach hpol_int
+    rwa [Finset.sum_fn] at h
   have hf_eq : EqOn (fun t => deriv γ t • f (γ t))
       (fun t => deriv γ t • decomp.analyticRemainder (γ t)
-        + ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t)) (uIcc a b) := fun t ht => by
+        + ∑ s ∈ T.attach, deriv γ t • decomp.polarPart s (γ t)) (uIcc a b) := fun t ht => by
     simp only
-    rw [decomp.f_eq (γ t) ⟨hγU t ht, hoff t ht⟩, smul_add, Finset.smul_sum]
+    rw [decomp.f_eq (γ t) ⟨hγU t ht, hoffT t ht⟩, smul_add, Finset.smul_sum]
   rw [intervalIntegral.integral_congr hf_eq, intervalIntegral.integral_add hrem_int hsum_int,
     intervalIntegral.integral_finsetSum hpol_int,
     decomp.intervalIntegral_deriv_smul_analyticRemainder_eq_zero hU hγ hγU hclosed hnull,
     zero_add, Finset.sum_congr rfl fun s _ =>
       decomp.intervalIntegral_deriv_smul_polarPart s hγ hclosed (hne s),
-    Finset.mul_sum, ← Finset.sum_attach S
+    Finset.mul_sum, ← Finset.sum_attach T
       fun s => 2 * (Real.pi : ℂ) * Complex.I * (windingNumber γ a b s * residue f s)]
   exact Finset.sum_congr rfl fun s _ => by ring
 

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -34,7 +34,8 @@ Laurent tail at `s`. The remainder `g` integrates to zero by the homology Cauchy
 Laurent tail the simple-pole coefficient integrates to `2πi · n_s(γ) · Res_s f`, by the very
 definition of the winding number (the principal value collapses to an ordinary integral because
 `γ` misses `s`), while every coefficient of order `≥ 2` integrates to zero around the closed
-curve, having the primitive `−(k−1)⁻¹(z − s)^{−(k−1)}`.
+curve, having the primitive `−(k−1)⁻¹(z − s)^{−(k−1)}`
+(`Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed`).
 
 Unlike the Hungerbühler–Wasem generalized residue theorem
 (`Contour.hungerbuhlerWasem_residueTheorem`), whose singularities may lie *on* the curve, nothing
@@ -46,8 +47,6 @@ here and not there.
 
 ## Main results
 
-* `TauCeti.Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed` — a Laurent term of order `≥ 2`
-  integrates to zero around a closed piecewise-`C¹` curve missing the pole.
 * `TauCeti.Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_polarPart` — the contour
   integral of a polar part around such a curve is `2πi · n_s(γ) · Res_s f`.
 * `TauCeti.Contour.classicalResidueTheorem_nullHomologous` — the residue theorem for an arbitrary
@@ -75,36 +74,6 @@ open MeasureTheory Set
 open scoped Interval
 
 namespace TauCeti.Contour
-
-/-- The oriented case of `Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed`. -/
-private theorem integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
-    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hab : a ≤ b) (hγ : IsPiecewiseC1On γ a b)
-    (hclosed : γ a = γ b) (h_ne : ∀ t ∈ Icc a b, γ t ≠ s) :
-    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
-  obtain ⟨P, hP, hdiff⟩ := hγ.exists_countable_differentiableAt
-  rw [min_eq_left hab, max_eq_right hab] at hdiff
-  have hcont : ContinuousOn γ (Icc a b) := by
-    rw [← Set.uIcc_of_le hab]; exact hγ.continuousOn
-  rw [integral_pow_inv_mul_deriv_eq_sub hk c hab hP h_ne hdiff hcont
-    hγ.intervalIntegrable_deriv, hclosed, sub_self]
-
-/-- **A Laurent term of order at least two integrates to zero around a closed curve.** On a
-piecewise-`C¹` curve `γ` with `γ a = γ b` that never meets `s`, the integrand
-`c/(z − s)^k · γ'` with `k ≥ 2` is the derivative of `c · (−(k−1)⁻¹ (γ · − s)^{−(k−1)})`, so the
-fundamental theorem of calculus along the contour returns the endpoint difference, which the
-closedness kills. This is why only the simple-pole coefficient of a Laurent tail survives in the
-residue theorem. -/
-theorem integral_pow_inv_mul_deriv_eq_zero_of_closed {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
-    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
-    (h_ne : ∀ t ∈ uIcc a b, γ t ≠ s) :
-    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
-  rcases le_total a b with hab | hba
-  · exact integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hab hγ hclosed
-      fun t ht => h_ne t (by rwa [Set.uIcc_of_le hab])
-  · rw [intervalIntegral.integral_symm b a,
-      integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hba hγ.symm hclosed.symm
-        (fun t ht => h_ne t (by rw [Set.uIcc_comm, Set.uIcc_of_le hba]; exact ht)),
-      neg_zero]
 
 namespace PolarPartDecomposition
 
@@ -153,29 +122,15 @@ theorem intervalIntegral_deriv_smul_polarPart (decomp : PolarPartDecomposition f
       ring
     · rw [if_neg (Nat.pos_iff_ne_zero.mp hk_pos)]
       exact integral_pow_inv_mul_deriv_eq_zero_of_closed (by omega) _ hγ hclosed h_ne
-  rw [hsplit, Finset.sum_congr rfl fun k _ => hval k]
-  rcases Nat.eq_zero_or_pos (decomp.order s) with h0 | h_pos
-  · rw [Finset.sum_eq_zero fun k _ => absurd k.isLt (by omega), decomp.residue_eq s,
-      dif_neg (by omega)]
-    ring
-  · have h_pick : ∀ k : Fin (decomp.order s),
-        (if k.val = 0 then
-          decomp.coeff s k * (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s) else 0)
-        = if k = ⟨0, h_pos⟩ then
-          decomp.coeff s ⟨0, h_pos⟩ *
-            (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s) else 0 := fun k => by
-      rcases eq_or_ne k ⟨0, h_pos⟩ with rfl | hk
-      · simp
-      · rw [if_neg fun h => hk (Fin.ext h), if_neg hk]
-    rw [Finset.sum_congr rfl fun k _ => h_pick k, Finset.sum_ite_eq' Finset.univ,
-      if_pos (Finset.mem_univ _), decomp.residue_eq s, dif_pos h_pos]
-    ring
+  rw [hsplit, Finset.sum_congr rfl fun k _ => hval k, decomp.sum_ite_coeff_eq_residue_mul s]
+  ring
 
 end PolarPartDecomposition
 
 /-- **The classical residue theorem for an arbitrary null-homologous cycle.** Let `U` be open,
-`S` a finite set, `f` differentiable on `U ∖ S` and meromorphic at each point of `S`, and let `γ`
-be a closed piecewise-`C¹` curve in `U`, **null-homologous** in `U`, that **avoids** `S`. Then
+`S` a finite set, `f` differentiable on `U ∖ S` and meromorphic at each point of `S` lying in `U`,
+and let `γ` be a closed piecewise-`C¹` curve in `U`, **null-homologous** in `U`, that **avoids**
+`S`. Then
 
 `∫ t in a..b, γ' t • f (γ t) = 2πi · ∑_{s ∈ S} n_s(γ) · Res_s f`,
 

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.PolarPart.Decomposition
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
+import TauCeti.Analysis.Contour.PerWindow.HigherOrder
+
+/-!
+# The classical residue theorem for an arbitrary null-homologous cycle
+
+For `f` differentiable on `U ∖ S` and meromorphic at each point of the finite set `S`, and a
+**closed, null-homologous** piecewise-`C¹` curve `γ` in `U` that **avoids** `S`,
+
+`∫ t in a..b, γ' t • f (γ t) = 2πi · ∑_{s ∈ S} n_s(γ) · Res_s f`,
+
+where `n_s(γ)` is the generalized winding number of `γ` about `s`. This is the general
+arbitrary-cycle form of the classical residue theorem, the case the circle theorem
+(`Contour.classicalResidueTheorem_circle`) generalizes: the contour is an arbitrary
+piecewise-`C¹` loop rather than a round circle, and each pole is weighted by its winding number
+rather than by `1`. Null-homology is not decoration — on a general holomorphy domain `Ω`, a loop
+that merely avoids the poles need not integrate to the residue sum (a loop around a hole of `Ω`
+sees the function's behaviour there), so `n_w(γ) = 0` for every `w ∉ Ω` is exactly the hypothesis
+that rules this out. Its `S = ∅` case is the homology Cauchy theorem, which is why the roadmap
+defers this statement past Layer 2.
+
+The proof is the classical three-line argument, over the pieces the repository already has. The
+polar-part decomposition (`Contour.PolarPartDecomposition.ofMeromorphic`) writes
+`f = g + ∑_{s ∈ S} P_s` on `U ∖ S`, with `g` differentiable on all of `U` and `P_s` the finite
+Laurent tail at `s`. The remainder `g` integrates to zero by the homology Cauchy theorem
+(`Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_analyticRemainder_eq_zero`). In each
+Laurent tail the simple-pole coefficient integrates to `2πi · n_s(γ) · Res_s f`, by the very
+definition of the winding number (the principal value collapses to an ordinary integral because
+`γ` misses `s`), while every coefficient of order `≥ 2` integrates to zero around the closed
+curve, having the primitive `−(k−1)⁻¹(z − s)^{−(k−1)}`.
+
+Unlike the Hungerbühler–Wasem generalized residue theorem
+(`Contour.hungerbuhlerWasem_residueTheorem`), whose singularities may lie *on* the curve, nothing
+here needs an immersion, a principal value, or the conditions (A′)/(B): with the poles off the
+contour every integral in sight is an ordinary interval integral. Conversely this statement is
+*not* a specialization of the HW theorem, which asks for the strictly stronger
+`Contour.IsPwC1ImmersionOn` regularity, so a piecewise-`C¹` loop with a zero-speed seam is covered
+here and not there.
+
+## Main results
+
+* `TauCeti.Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed` — a Laurent term of order `≥ 2`
+  integrates to zero around a closed piecewise-`C¹` curve missing the pole.
+* `TauCeti.Contour.PolarPartDecomposition.intervalIntegral_deriv_smul_polarPart` — the contour
+  integral of a polar part around such a curve is `2πi · n_s(γ) · Res_s f`.
+* `TauCeti.Contour.classicalResidueTheorem_nullHomologous` — the residue theorem for an arbitrary
+  null-homologous cycle avoiding the poles.
+
+This is the Layer 2/3 "general arbitrary-cycle case" of the contour-integration roadmap.
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 (2018), §3.
+* S. Lang, *Complex Analysis* (GTM 103), Ch. VI (the homology form of the residue theorem).
+
+## Provenance
+
+No formal source is vendored: the statement is assembled here from the repository's polar-part
+decomposition, homology Cauchy theorem, and antiderivative lemma for higher-order Laurent terms,
+which are themselves migrated from the AINTLIB `LeanModularForms` development.
+-/
+
+public section
+
+open MeasureTheory Set
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+/-- The oriented case of `Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed`. -/
+private theorem integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
+    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hab : a ≤ b) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (h_ne : ∀ t ∈ Icc a b, γ t ≠ s) :
+    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
+  obtain ⟨P, hP, hdiff⟩ := hγ.exists_countable_differentiableAt
+  rw [min_eq_left hab, max_eq_right hab] at hdiff
+  have hcont : ContinuousOn γ (Icc a b) := by
+    rw [← Set.uIcc_of_le hab]; exact hγ.continuousOn
+  rw [integral_pow_inv_mul_deriv_eq_sub hk c hab hP h_ne hdiff hcont
+    hγ.intervalIntegrable_deriv, hclosed, sub_self]
+
+/-- **A Laurent term of order at least two integrates to zero around a closed curve.** On a
+piecewise-`C¹` curve `γ` with `γ a = γ b` that never meets `s`, the integrand
+`c/(z − s)^k · γ'` with `k ≥ 2` is the derivative of `c · (−(k−1)⁻¹ (γ · − s)^{−(k−1)})`, so the
+fundamental theorem of calculus along the contour returns the endpoint difference, which the
+closedness kills. This is why only the simple-pole coefficient of a Laurent tail survives in the
+residue theorem. -/
+theorem integral_pow_inv_mul_deriv_eq_zero_of_closed {γ : ℝ → ℂ} {s : ℂ} {k : ℕ}
+    (hk : 2 ≤ k) (c : ℂ) {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (h_ne : ∀ t ∈ uIcc a b, γ t ≠ s) :
+    ∫ t in a..b, c / (γ t - s) ^ k * deriv γ t = 0 := by
+  rcases le_total a b with hab | hba
+  · exact integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hab hγ hclosed
+      fun t ht => h_ne t (by rwa [Set.uIcc_of_le hab])
+  · rw [intervalIntegral.integral_symm b a,
+      integral_pow_inv_mul_deriv_eq_zero_of_closed_of_le hk c hba hγ.symm hclosed.symm
+        (fun t ht => h_ne t (by rw [Set.uIcc_comm, Set.uIcc_of_le hba]; exact ht)),
+      neg_zero]
+
+namespace PolarPartDecomposition
+
+variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+
+/-- **The contour integral of a polar part is the winding-weighted residue.** Around a closed
+piecewise-`C¹` curve missing the pole `s`, the finite Laurent tail of `f` at `s` integrates to
+`2πi · n_s(γ) · Res_s f`: the simple-pole coefficient contributes the index integral, which is
+`2πi` times the generalized winding number since the principal value collapses to an ordinary
+integral off the curve, and every higher-order coefficient contributes zero
+(`Contour.integral_pow_inv_mul_deriv_eq_zero_of_closed`). -/
+theorem intervalIntegral_deriv_smul_polarPart (decomp : PolarPartDecomposition f S U) (s : S)
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (h_ne : ∀ t ∈ uIcc a b, γ t ≠ (s : ℂ)) :
+    ∫ t in a..b, deriv γ t • decomp.polarPart s (γ t)
+      = 2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s * residue f s := by
+  classical
+  have hcont : ContinuousOn γ (uIcc a b) := hγ.continuousOn
+  have hderiv : IntervalIntegrable (fun t => deriv γ t) volume a b := hγ.intervalIntegrable_deriv
+  have hne' : ∀ t ∈ uIcc a b, γ t - (s : ℂ) ≠ 0 := fun t ht => sub_ne_zero.mpr (h_ne t ht)
+  have hindex : ∫ t in a..b, (γ t - (s : ℂ))⁻¹ * deriv γ t
+      = 2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s := by
+    rw [windingNumber_eq_integral_of_avoidance hcont h_ne
+        (intervalIntegrable_inv_sub_mul_deriv hcont h_ne hderiv), ← mul_assoc,
+      mul_inv_cancel₀ Complex.two_pi_I_ne_zero, one_mul]
+  have hterm : ∀ k : Fin (decomp.order s), IntervalIntegrable
+      (fun t => decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) * deriv γ t) volume a b :=
+    fun k => hderiv.continuousOn_mul (continuousOn_const.div
+      ((hcont.sub continuousOn_const).pow _) fun t ht => pow_ne_zero _ (hne' t ht))
+  have hsplit : ∫ t in a..b, deriv γ t • decomp.polarPart s (γ t)
+      = ∑ k : Fin (decomp.order s),
+          ∫ t in a..b, decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) * deriv γ t := by
+    rw [← intervalIntegral.integral_finsetSum fun k _ => hterm k]
+    refine intervalIntegral.integral_congr fun t _ => ?_
+    rw [smul_eq_mul, mul_comm, decomp.polarPart_eq s (γ t), Finset.sum_mul]
+  have hval : ∀ k : Fin (decomp.order s),
+      (∫ t in a..b, decomp.coeff s k / (γ t - (s : ℂ)) ^ (k.val + 1) * deriv γ t)
+        = if k.val = 0 then
+            decomp.coeff s k * (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s)
+          else 0 := by
+    intro k
+    rcases Nat.eq_zero_or_pos k.val with hk0 | hk_pos
+    · rw [if_pos hk0, ← hindex, ← intervalIntegral.integral_const_mul]
+      refine intervalIntegral.integral_congr fun t _ => ?_
+      rw [hk0]
+      ring
+    · rw [if_neg (Nat.pos_iff_ne_zero.mp hk_pos)]
+      exact integral_pow_inv_mul_deriv_eq_zero_of_closed (by omega) _ hγ hclosed h_ne
+  rw [hsplit, Finset.sum_congr rfl fun k _ => hval k]
+  rcases Nat.eq_zero_or_pos (decomp.order s) with h0 | h_pos
+  · rw [Finset.sum_eq_zero fun k _ => absurd k.isLt (by omega), decomp.residue_eq s,
+      dif_neg (by omega)]
+    ring
+  · have h_pick : ∀ k : Fin (decomp.order s),
+        (if k.val = 0 then
+          decomp.coeff s k * (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s) else 0)
+        = if k = ⟨0, h_pos⟩ then
+          decomp.coeff s ⟨0, h_pos⟩ *
+            (2 * (Real.pi : ℂ) * Complex.I * windingNumber γ a b s) else 0 := fun k => by
+      rcases eq_or_ne k ⟨0, h_pos⟩ with rfl | hk
+      · simp
+      · rw [if_neg fun h => hk (Fin.ext h), if_neg hk]
+    rw [Finset.sum_congr rfl fun k _ => h_pick k, Finset.sum_ite_eq' Finset.univ,
+      if_pos (Finset.mem_univ _), decomp.residue_eq s, dif_pos h_pos]
+    ring
+
+end PolarPartDecomposition
+
+/-- **The classical residue theorem for an arbitrary null-homologous cycle.** Let `U` be open,
+`S` a finite set, `f` differentiable on `U ∖ S` and meromorphic at each point of `S`, and let `γ`
+be a closed piecewise-`C¹` curve in `U`, **null-homologous** in `U`, that **avoids** `S`. Then
+
+`∫ t in a..b, γ' t • f (γ t) = 2πi · ∑_{s ∈ S} n_s(γ) · Res_s f`,
+
+each pole weighted by the generalized winding number of `γ` about it.
+
+Points of `S` outside `U` are harmless rather than excluded: null-homology forces their winding
+number, hence their contribution, to vanish. Likewise `S` may list regular points of `f`, whose
+residues are `0`.
+
+Its `S = ∅` case is the homology Cauchy theorem (`Contour.homologyCauchyTheorem`), so this is
+genuinely a Layer 3 statement; the round-circle case with the poles inside is
+`Contour.classicalResidueTheorem_circle`, and the version admitting poles *on* the curve is the
+Hungerbühler–Wasem theorem `Contour.hungerbuhlerWasem_residueTheorem`. -/
+theorem classicalResidueTheorem_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+    (hU : IsOpen U) (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ)))
+    (hmero : ∀ s ∈ S, MeromorphicAt f s) {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
+    (hoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
+    ∫ t in a..b, deriv γ t • f (γ t)
+      = 2 * (Real.pi : ℂ) * Complex.I * ∑ s ∈ S, windingNumber γ a b s * residue f s := by
+  classical
+  obtain ⟨decomp⟩ : Nonempty (PolarPartDecomposition f S U) :=
+    ⟨.ofMeromorphic hU hf hmero⟩
+  have hcont : ContinuousOn γ (uIcc a b) := hγ.continuousOn
+  have hderiv : IntervalIntegrable (fun t => deriv γ t) volume a b := hγ.intervalIntegrable_deriv
+  have hne : ∀ s : S, ∀ t ∈ uIcc a b, γ t ≠ (s : ℂ) := fun s t ht h_eq =>
+    hoff t ht (h_eq ▸ Finset.mem_coe.mpr s.2)
+  have hpol_cont : ∀ s : S, ContinuousOn (fun t => decomp.polarPart s (γ t)) (uIcc a b) :=
+    fun s => ContinuousOn.congr
+      (continuousOn_finsetSum Finset.univ fun k _ => continuousOn_const.div
+        ((hcont.sub continuousOn_const).pow (k.val + 1))
+        fun t ht => pow_ne_zero _ (sub_ne_zero.mpr (hne s t ht)))
+      fun t _ => decomp.polarPart_eq s (γ t)
+  have hrem_int : IntervalIntegrable
+      (fun t => deriv γ t • decomp.analyticRemainder (γ t)) volume a b :=
+    hderiv.smul_continuousOn
+      (decomp.analyticRemainder_differentiableOn.continuousOn.comp hcont hγU)
+  have hpol_int : ∀ s ∈ S.attach, IntervalIntegrable
+      (fun t => deriv γ t • decomp.polarPart s (γ t)) volume a b :=
+    fun s _ => hderiv.smul_continuousOn (hpol_cont s)
+  have hsum_int : IntervalIntegrable
+      (fun t => ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t)) volume a b := by
+    have h := IntervalIntegrable.sum S.attach hpol_int
+    rwa [show (∑ s ∈ S.attach, fun t => deriv γ t • decomp.polarPart s (γ t))
+      = fun t => ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t) from
+      funext fun t => Finset.sum_apply _ _ _] at h
+  have hf_eq : EqOn (fun t => deriv γ t • f (γ t))
+      (fun t => deriv γ t • decomp.analyticRemainder (γ t)
+        + ∑ s ∈ S.attach, deriv γ t • decomp.polarPart s (γ t)) (uIcc a b) := fun t ht => by
+    simp only
+    rw [decomp.f_eq (γ t) ⟨hγU t ht, hoff t ht⟩, smul_add, Finset.smul_sum]
+  rw [intervalIntegral.integral_congr hf_eq, intervalIntegral.integral_add hrem_int hsum_int,
+    intervalIntegral.integral_finsetSum hpol_int,
+    decomp.intervalIntegral_deriv_smul_analyticRemainder_eq_zero hU hγ hγU hclosed hnull,
+    zero_add, Finset.sum_congr rfl fun s _ =>
+      decomp.intervalIntegral_deriv_smul_polarPart s hγ hclosed (hne s),
+    Finset.mul_sum, ← Finset.sum_attach S
+      fun s => 2 * (Real.pi : ℂ) * Complex.I * (windingNumber γ a b s * residue f s)]
+  exact Finset.sum_congr rfl fun s _ => by ring
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -52,7 +52,8 @@ here and not there.
 * `TauCeti.Contour.classicalResidueTheorem_nullHomologous` — the residue theorem for an arbitrary
   null-homologous cycle avoiding the poles.
 
-This is the Layer 2/3 "general arbitrary-cycle case" of the contour-integration roadmap.
+This is the "general arbitrary-cycle case" of the contour-integration roadmap, which that roadmap
+defers to Layer 3+.
 
 ## References
 


### PR DESCRIPTION
This PR proves the general arbitrary-cycle form of the classical residue theorem, the target named in `TauCetiRoadmap/ContourIntegration/README.md` under Layer 2 as "*The general arbitrary-cycle case* `∮_C f = 2πi · Σ_s n_s(C)·Res_s f` for a closed piecewise-`C¹` cycle `C` avoiding `S`", which the roadmap explicitly defers past Layer 2 because its `S = ∅` case is the homology Cauchy theorem. For `f` differentiable on `U ∖ S` and meromorphic at each point of the finite `S`, and a closed, **null-homologous** piecewise-`C¹` curve `γ` in `U` that **avoids** `S`, the new `TauCeti.Contour.classicalResidueTheorem_nullHomologous` gives `∫ t in a..b, γ' t • f (γ t) = 2πi · Σ_{s ∈ S} n_s(γ) · Res_s f`, with each pole weighted by its generalized winding number. This is what the existing round-circle theorem `classicalResidueTheorem_circle` does not reach: the contour is an arbitrary piecewise-`C¹` loop and the weights are winding numbers rather than `1`. It is also not a specialization of the summit `hungerbuhlerWasem_residueTheorem`, which asks for the strictly stronger `IsPwC1ImmersionOn` regularity together with conditions (A′)/(B) and concludes about a principal value; with the poles off the contour nothing here needs an immersion, a principal value, or those conditions, so a loop with a zero-speed seam is covered here and not there.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"classical-residue-theorem-null-homologous-cycle"}-->

The proof is the classical three-line argument assembled over pieces the repository already has, so no new analytic machinery is introduced. `PolarPartDecomposition.ofMeromorphic` writes `f = g + Σ_{s ∈ S} P_s` on `U ∖ S` with `g` differentiable on all of `U`; the remainder integrates to zero by `intervalIntegral_deriv_smul_analyticRemainder_eq_zero`, i.e. by the homology Cauchy theorem; the simple-pole coefficient of each Laurent tail integrates to the index integral, which is `2πi` times the winding number because `windingNumber_eq_integral_of_avoidance` collapses the principal value off the curve; and every coefficient of order `≥ 2` integrates to zero around the loop against the primitive `−(k−1)⁻¹(z − s)^{−(k−1)}`, via the existing `integral_pow_inv_mul_deriv_eq_sub`. Two reusable intermediate results come out of this: `integral_pow_inv_mul_deriv_eq_zero_of_closed` (a Laurent term of order `≥ 2` integrates to zero around a closed curve missing the pole, in either parametrization orientation) and `PolarPartDecomposition.intervalIntegral_deriv_smul_polarPart` (the contour integral of a polar part is `2πi · n_s(γ) · Res_s f`).

Two hypotheses that a reader might expect are deliberately absent. `S ⊆ U` is not required: a point of `S` outside `U` has winding number `0` by null-homology, so it contributes nothing. Nor need `S` consist only of poles — residues at regular points vanish, matching the convention of `classicalResidueTheorem_circle`.

New file: `TauCeti/Analysis/Contour/Residue/Cycle.lean` (241 lines), placed alongside the circle case in `TauCeti/Analysis/Contour/Residue/`. No Mathlib infrastructure is vendored, and no formal source is copied; the module docstring records that the ingredients it consumes are themselves migrations from the AINTLIB `LeanModularForms` development, and cites Hungerbühler–Wasem (arXiv:1808.00997, §3) and Lang, *Complex Analysis* Ch. VI. `lake build` and `lake exe axioms` are green (`all within the allowlist [propext, Classical.choice, Quot.sound]`), and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Claude Code
