### PR TITLE
fix: walk --first-parent so a feature branch is not a transient spike

### DIFF
--- a/scripts/loc_graph.py
+++ b/scripts/loc_graph.py
@@ -45,8 +45,14 @@ def series(repo, pathspecs, ref):
     # so the "as of" label reflects the current repo. The sort is insurance
     # against history rewrites that leave commit dates out of order; dates are
     # ISO YYYY-MM-DD, so lexicographic order is chronological.
+    #
+    # --first-parent walks the mainline only, so the chart tracks the size of
+    # the branch itself. Without it, a commit on a feature branch is sampled on
+    # its own (earlier) date, and count_lines there sees the whole branch tree,
+    # so a large branch shows up as a spike on the day it was written that
+    # vanishes the next day and only truly lands when the branch merges.
     day_commit = {}
-    for line in git(repo, "log", "--reverse", "--date=short",
+    for line in git(repo, "log", "--first-parent", "--reverse", "--date=short",
                     "--format=%cd %H", ref, "--", *pathspecs).splitlines():
         date, commit = line.split()
         day_commit[date] = commit


### PR DESCRIPTION
This PR makes the lines-of-code charts track the mainline's own size by walking `git log --first-parent` in `series()`. Previously the function sampled every commit reachable from HEAD, so a commit written on a long-lived branch was charted on its own earlier date, and `count_lines` at that commit saw the whole branch tree. A large branch therefore appeared as a spike on the day it was drafted, vanished the next day when a mainline commit was that day's representative, and only truly landed when the branch merged. The roadmap chart's ~10k-line jump on 2026-07-06 (the RepresentationTheory roadmaps, PR #62, merged only on 07-26) was exactly this artifact, along with a smaller blip around 07-22. Walking `--first-parent` attributes each PR's lines to its merge, so the size only moves when work actually lands on the branch; for a squash-merged repository like TauCeti's own chart it changes nothing.

🤖 Prepared with Claude Code