### PR TITLE
feat: add conditional de Finetti equivalences

### DIFF
--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -13,14 +13,22 @@ import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Map
 
 /-!
-# The de Finetti–Ryll-Nardzewski summit and equivalences
+# The de Finetti–Ryll-Nardzewski theorem and equivalences
 
-The de Finetti summit in its **conditional** form, and the equivalences in their **mixture** form.
+The de Finetti summit in its **conditional** form, together with its conditional and mixture
+equivalences.
 
 `conditionallyIID_of_contractable` is the sharp statement: a contractable process valued in a
 nonempty standard Borel space is conditionally i.i.d., a joint-law disintegration given a directing
-measure. The mixture equivalences below are the integrated-out forms, and for a process with
-measurable coordinates, valued in a nonempty standard Borel space, under a finite measure, they read
+measure. Since exchangeability implies contractability, `conditionallyIID_of_exchangeable` is de
+Finetti's theorem in the same sharp form. For a process with measurable coordinates, valued in a
+nonempty standard Borel space, under a finite measure, the conditional equivalences read
+
+* exchangeable **iff** conditionally i.i.d. (`deFinetti_equivalence`), and
+* contractable **iff** exchangeable and conditionally i.i.d.
+  (`deFinetti_RyllNardzewski_equivalence`).
+
+Their integrated-out mixture forms read
 
 * exchangeable **iff** mixed i.i.d. (`exchangeable_iff_mixedIID`),
 * contractable **iff** mixed i.i.d. (`contractable_iff_mixedIID`, the two-way form), and
@@ -34,17 +42,12 @@ hard direction is the merged reverse-martingale de Finetti chain
 (`MixedIID.exchangeable`, `MixedIID.contractable`).
 
 The roadmap directs that "summit theorems conclude `ConditionallyIID`, never merely `MixedIID`"
-(`TauCetiRoadmap/Exchangeability/README.md`, Layers 6–7), which
-`conditionallyIID_of_contractable` now does. Its witness is reachable explicitly:
+(`TauCetiRoadmap/Exchangeability/README.md`, Layers 6–7). Both conditional implications do so. The
+contractable theorem's witness is reachable explicitly:
 `conditionallyIIDWith_of_contractable_pathSpace` names the tail conditional law on path space and
 `ConditionallyIIDWith.of_pathLaw` transports it.
 
-Still absent are the *equivalence* handles the roadmap reserves — `deFinetti`,
-`deFinetti_equivalence`, `deFinetti_RyllNardzewski_equivalence` — since those also need
-`conditionallyIID_of_exchangeable`, which is open. The equivalences below therefore remain the
-mixture forms, named as such.
-
-Both equivalences hold on an arbitrary measurable sample space `Ω` under `[IsFiniteMeasure μ]`;
+All theorems hold on an arbitrary measurable sample space `Ω` under `[IsFiniteMeasure μ]`;
 the standard-Borel hypothesis sits only on the state space `α`, each value of the mixing
 representative being a probability measure on `α`. (The *mixing law* itself — the law of `ν` — is a
 measure on `ProbabilityMeasure α`, not on `α`.)
@@ -60,6 +63,9 @@ a strictly weaker statement.
 
 * `conditionallyIID_of_contractable` — the conditional summit: contractable implies conditionally
   i.i.d., strengthening the forward direction of `contractable_iff_mixedIID`.
+* `conditionallyIID_of_exchangeable`, `deFinetti` — de Finetti's theorem in conditional form.
+* `deFinetti_equivalence` — exchangeable iff conditionally i.i.d.
+* `deFinetti_RyllNardzewski_equivalence` — contractable iff exchangeable and conditionally i.i.d.
 * `exchangeable_iff_mixedIID` — de Finetti's theorem as an equivalence, mixture form.
 * `contractable_iff_mixedIID` — the two-way Ryll-Nardzewski equivalence, mixture form.
 * `contractable_iff_exchangeable_and_mixedIID` — the roadmap's conjunction form.
@@ -125,6 +131,46 @@ theorem conditionallyIID_of_contractable [StandardBorelSpace α] [Nonempty α] {
   exact ConditionallyIID.of_directing
     ((conditionallyIIDWith_of_contractable_pathSpace
       (Contractable.coordinate_pathLaw hX fun i => (hX_meas i).aemeasurable)).of_pathLaw hX_meas)
+
+/-- **De Finetti's theorem, conditional form.** An exchangeable process valued in a nonempty
+standard Borel space is conditionally i.i.d. No standard-Borel hypothesis is imposed on the sample
+space. -/
+theorem conditionallyIID_of_exchangeable [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX : Exchangeable μ X)
+    (hX_meas : ∀ n, Measurable (X n)) :
+    ConditionallyIID μ X :=
+  conditionallyIID_of_contractable
+    (hX.contractable fun n => (hX_meas n).aemeasurable) hX_meas
+
+/-- **De Finetti's theorem.** An exchangeable process valued in a nonempty standard Borel space is
+conditionally i.i.d. This is the conventional theorem-name handle for
+`conditionallyIID_of_exchangeable`. -/
+theorem deFinetti [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n))
+    (hX : Exchangeable μ X) :
+    ConditionallyIID μ X :=
+  conditionallyIID_of_exchangeable hX hX_meas
+
+/-- **De Finetti's theorem as an equivalence.** A process with measurable coordinates, valued in a
+nonempty standard Borel space, is exchangeable iff it is conditionally i.i.d. -/
+theorem deFinetti_equivalence [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
+    Exchangeable μ X ↔ ConditionallyIID μ X :=
+  ⟨fun hX => conditionallyIID_of_exchangeable hX hX_meas,
+    fun hX => (mixedIID_of_conditionallyIID hX).exchangeable⟩
+
+/-- **The de Finetti–Ryll-Nardzewski equivalence.** A process with measurable coordinates, valued
+in a nonempty standard Borel space, is contractable iff it is both exchangeable and conditionally
+i.i.d. -/
+theorem deFinetti_RyllNardzewski_equivalence [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX_meas : ∀ n, Measurable (X n)) :
+    Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X := by
+  constructor
+  · intro hX
+    have hX_cond := conditionallyIID_of_contractable hX hX_meas
+    exact ⟨(mixedIID_of_conditionallyIID hX_cond).exchangeable, hX_cond⟩
+  · exact fun hX => (mixedIID_of_conditionallyIID hX.2).contractable
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -43,10 +43,10 @@ projection it pins alongside — which consumes the already-landed Layer 1 joint
 `measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure`.
 
 The Layer 1 joint-rectangle common ending `conditionallyIID_of_jointRectangles` lives in
-`TauCeti.Probability.DeFinetti.ConditionalCommonEnding`. Still open here are the Layer 6 summit
-theorems that *conclude* this predicate, `conditionallyIID_of_contractable` and
-`conditionallyIID_of_exchangeable`, together with the `deFinetti*` handles that return with them.
-A.e. uniqueness of the directing measure (`conditionallyIID_ae_unique`) lives in
+`TauCeti.Probability.DeFinetti.ConditionalCommonEnding`. The Layer 6 summit theorems that conclude
+this predicate, together with the `deFinetti*` equivalence handles, live in
+`TauCeti.Probability.DeFinetti.Theorem`. A.e. uniqueness of the directing measure
+(`conditionallyIID_ae_unique`) lives in
 `TauCeti.Probability.Exchangeability.ConditionallyIID.Unique`.
 -/
 


### PR DESCRIPTION
This PR completes the conditional summit API from `TauCetiRoadmap/Exchangeability/README.md`, Layer 6 (“directing measures and de Finetti representation”), specifically the named milestones `conditionallyIID_of_exchangeable`, `deFinetti`, `deFinetti_equivalence`, and `deFinetti_RyllNardzewski_equivalence`. State de Finetti in its sharp conditional form and assemble the roadmap’s equivalence `Contractable μ X ↔ Exchangeable μ X ∧ ConditionallyIID μ X`.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"definetti-ryllnardzewski-equivalence"}-->

This is the lowest-hanging distinct Exchangeability target because the hard conditional theorem `conditionallyIID_of_contractable` landed in #1395, while the Layer 0 bridges from exchangeability to contractability and from conditional i.i.d. to mixed i.i.d. are already on `main`; no open PR covers the remaining wrappers. Preserve the stronger landed `[IsFiniteMeasure μ]` generality, so probability measures specialize directly, and keep the standard-Borel hypothesis only on the state space.

Update the module overview and the defining predicate’s documentation so they no longer describe these Layer 6 theorems as open. The implementation changes two existing files under `TauCeti/` with 62 insertions and 16 deletions; the canonical theorem module is 177 lines after the change.

Follow Kallenberg, *Probabilistic Symmetries and Invariance Principles* (2005), Theorem 1.1, as already cited in the theorem module and Exchangeability roadmap. Reuse Tau Ceti’s `conditionallyIID_of_contractable`, `Exchangeable.contractable`, `mixedIID_of_conditionallyIID`, `MixedIID.exchangeable`, and `MixedIID.contractable`. Vendor no Mathlib infrastructure and adapt no external formalization.

`lake build` completes successfully across 5,828 jobs. `tauceti-axioms --changed-from origin/main` audits 21 declarations in two changed modules using only `propext`, `Classical.choice`, and `Quot.sound`. `tauceti-lint-env --changed-from origin/main` passes with zero violations.

🤖 Prepared with Codex
