### PR TITLE
refactor(RepresentationTheory): collapse the off-diagonal step in the trace proof

### DIFF
--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -148,16 +148,16 @@ private theorem toTensorPower_injective {R : Type} {M : Type*}
     pairingDual_ιMulti_apply, h]
 
 /-- **A strictly off-diagonal block has zero trace.** The endomorphism of `A × C` carrying
-`(a, c)` to `(u c, 0)` traces to `0`: composed the other way round it is the zero map, so
-`trace_comp_comm'` sends its trace to that of `0`.
+`(a, c)` to `(u c, 0)` traces to `0`.
 
-This is the reason a block *triangular* map traces like its diagonal, and it needs nothing about
-the diagonal blocks — only the two factors' finite-dimensionality. -/
-private theorem trace_inl_comp_comp_snd {K A C : Type*} [Field K]
-    [AddCommGroup A] [Module K A] [FiniteDimensional K A]
-    [AddCommGroup C] [Module K C] [FiniteDimensional K C] (u : C →ₗ[K] A) :
+This is why a block *triangular* map traces like its diagonal: the statement says nothing about
+the diagonal blocks, and holds for finite free modules over any commutative ring. -/
+private theorem trace_inl_comp_comp_snd {K A C : Type*} [CommRing K]
+    [AddCommGroup A] [Module K A] [Module.Free K A] [Module.Finite K A]
+    [AddCommGroup C] [Module K C] [Module.Free K C] [Module.Finite K C] (u : C →ₗ[K] A) :
     LinearMap.trace K (A × C)
       ((LinearMap.inl K A C).comp (u.comp (LinearMap.snd K A C))) = 0 := by
+  -- Composed the other way round the block is the zero map, so `trace_comp_comm'` applies.
   rw [LinearMap.trace_comp_comm']
   have hz : (u.comp (LinearMap.snd K A C)).comp (LinearMap.inl K A C) = 0 := by
     ext a

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -147,23 +147,6 @@ private theorem toTensorPower_injective {R : Type} {M : Type*}
   simp only [exteriorPower.ιMultiDual, exteriorPower.ιMulti_family,
     pairingDual_ιMulti_apply, h]
 
-/-- **A strictly off-diagonal block has zero trace.** The endomorphism of `A × C` carrying
-`(a, c)` to `(u c, 0)` traces to `0`.
-
-This is why a block *triangular* map traces like its diagonal: the statement says nothing about
-the diagonal blocks, and holds for finite free modules over any commutative ring. -/
-private theorem trace_inl_comp_comp_snd {K A C : Type*} [CommRing K]
-    [AddCommGroup A] [Module K A] [Module.Free K A] [Module.Finite K A]
-    [AddCommGroup C] [Module K C] [Module.Free K C] [Module.Finite K C] (u : C →ₗ[K] A) :
-    LinearMap.trace K (A × C)
-      ((LinearMap.inl K A C).comp (u.comp (LinearMap.snd K A C))) = 0 := by
-  -- Composed the other way round the block is the zero map, so `trace_comp_comm'` applies.
-  rw [LinearMap.trace_comp_comm']
-  have hz : (u.comp (LinearMap.snd K A C)).comp (LinearMap.inl K A C) = 0 := by
-    ext a
-    simp
-  rw [hz, map_zero]
-
 -- Split an exact sequence as vector spaces. In that splitting the middle action is block
 -- triangular, so its trace is the sum of the traces on the subspace and the quotient.
 private theorem trace_eq_add_of_exact
@@ -219,8 +202,13 @@ private theorem trace_eq_add_of_exact
     · simpa only [LinearMap.add_apply, LinearMap.prodMap_apply, LinearMap.comp_apply,
         LinearMap.inl_apply, LinearMap.snd_apply, Prod.snd_add, add_zero] using
           LinearMap.congr_fun hsndF (a, c)
-  rw [← LinearMap.trace_conj' fB e, ← hF_def, hF, map_add, LinearMap.trace_prodMap',
-    trace_inl_comp_comp_snd u, add_zero]
+  have hoff : LinearMap.trace K (A × C)
+      ((LinearMap.inl K A C).comp (u.comp (LinearMap.snd K A C))) = 0 := by
+    rw [LinearMap.trace_comp_comm']
+    have hz : (u.comp (LinearMap.snd K A C)).comp (LinearMap.inl K A C) = 0 := by ext a; simp
+    rw [hz, map_zero]
+  rw [← LinearMap.trace_conj' fB e, ← hF_def, hF, map_add, LinearMap.trace_prodMap', hoff,
+    add_zero]
 
 end TauCeti.TensorSquare
 

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -147,6 +147,23 @@ private theorem toTensorPower_injective {R : Type} {M : Type*}
   simp only [exteriorPower.ιMultiDual, exteriorPower.ιMulti_family,
     pairingDual_ιMulti_apply, h]
 
+/-- **A strictly off-diagonal block has zero trace.** The endomorphism of `A × C` carrying
+`(a, c)` to `(u c, 0)` traces to `0`: composed the other way round it is the zero map, so
+`trace_comp_comm'` sends its trace to that of `0`.
+
+This is the reason a block *triangular* map traces like its diagonal, and it needs nothing about
+the diagonal blocks — only the two factors' finite-dimensionality. -/
+private theorem trace_inl_comp_comp_snd {K A C : Type*} [Field K]
+    [AddCommGroup A] [Module K A] [FiniteDimensional K A]
+    [AddCommGroup C] [Module K C] [FiniteDimensional K C] (u : C →ₗ[K] A) :
+    LinearMap.trace K (A × C)
+      ((LinearMap.inl K A C).comp (u.comp (LinearMap.snd K A C))) = 0 := by
+  rw [LinearMap.trace_comp_comm']
+  have hz : (u.comp (LinearMap.snd K A C)).comp (LinearMap.inl K A C) = 0 := by
+    ext a
+    simp
+  rw [hz, map_zero]
+
 -- Split an exact sequence as vector spaces. In that splitting the middle action is block
 -- triangular, so its trace is the sum of the traces on the subspace and the quotient.
 private theorem trace_eq_add_of_exact
@@ -202,16 +219,8 @@ private theorem trace_eq_add_of_exact
     · simpa only [LinearMap.add_apply, LinearMap.prodMap_apply, LinearMap.comp_apply,
         LinearMap.inl_apply, LinearMap.snd_apply, Prod.snd_add, add_zero] using
           LinearMap.congr_fun hsndF (a, c)
-  have hoff : LinearMap.trace K (A × C)
-      ((LinearMap.inl K A C).comp (u.comp (LinearMap.snd K A C))) = 0 := by
-    rw [LinearMap.trace_comp_comm']
-    have hz : (u.comp (LinearMap.snd K A C)).comp (LinearMap.inl K A C) = 0 := by
-      apply LinearMap.ext
-      intro a
-      simp
-    rw [hz, map_zero]
-  rw [← LinearMap.trace_conj' fB e, ← hF_def, hF, map_add, LinearMap.trace_prodMap', hoff,
-    add_zero]
+  rw [← LinearMap.trace_conj' fB e, ← hF_def, hF, map_add, LinearMap.trace_prodMap',
+    trace_inl_comp_comp_snd u, add_zero]
 
 end TauCeti.TensorSquare
 


### PR DESCRIPTION
## What

`trace_eq_add_of_exact` came out of #1438 at **51 lines** — one over the limit. (That PR's body said 49; I measured before its last two edits.) This brings it to **48 with no new declarations**, on a five-line diff.

The reduction is in the step showing the off-diagonal block contributes nothing: the reversed composite is now `by ext a; simp` on one line instead of a three-line `apply LinearMap.ext; intro a; simp`.

## How this PR got here

It originally extracted that step as a private `trace_inl_comp_comp_snd`. Two rubrics then spoke:

- `generality` asked for the extracted lemma to be restated over a commutative ring with `Module.Free`/`Module.Finite` — done in the second revision.
- `reuse` then **blocked** it as "a one-use thin wrapper around `LinearMap.trace_comp_comm'`", asking for the calculation to stay local.

Inlining satisfies both: with no lemma there is nothing to over-constrain, and the parent keeps `[Field K]` and `FiniteDimensional`, which it genuinely needs for the splitting.

For the record, `reuse` **approved** that lemma at `0f4333a5` and blocked it at `e4639715` — the only change between those heads being the generalisation `generality` had asked for. I am complying rather than contesting: the substantive point matches how `reuse` has consistently judged small single-use helpers, and complying resolves both threads instead of trading one for the other.

Gates: `lake build`, `lake exe axioms` (15329 declarations), `lake exe module-system` (860/860), `scripts/lint-env.sh` — all green.