### PR TITLE
feat: add étalé-space local charts

### DIFF
--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -38,7 +38,6 @@ variable {X : TopCat.{v}} {C : Type u} [Category.{v} C] {CC : C → Type v}
 variable {F : X.Presheaf C}
 
 /-- A section of a presheaf, viewed as a section of the étalé projection. -/
-@[expose]
 noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
     (s : ToType (F.obj (Opposite.op U))) :
     U → F.EtaleSpace :=
@@ -51,7 +50,8 @@ theorem base_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x :
 
 @[simp]
 theorem germ_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
-    (germSection F U s x).germ = F.germ U x x.2 s :=
+    cast (congrArg (fun y : X ↦ ToType (F.stalk y)) (base_germSection U s x))
+      (germSection F U s x).germ = F.germ U x x.2 s :=
   (rfl)
 
 /-- The open set in the étalé space swept out by the germs of a section. -/
@@ -109,6 +109,19 @@ theorem continuous_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))
   · exact W.isOpen.preimage continuous_subtype_val
   · exact hxW
 
+/-- A germ section is an open embedding of its domain into the étalé space. -/
+theorem isOpenEmbedding_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    Topology.IsOpenEmbedding (germSection F U s) := by
+  refine ⟨?_, isOpen_sectionRange U s⟩
+  apply Topology.IsEmbedding.of_comp (continuous_germSection U s)
+    (TopCat.Presheaf.EtaleSpace.continuous_base F)
+  have hcomp :
+      TopCat.Presheaf.EtaleSpace.base ∘ germSection F U s = (Subtype.val : U → X) := by
+    funext x
+    exact base_germSection U s x
+  rw [hcomp]
+  exact U.isOpen.isOpenEmbedding_subtypeVal.isEmbedding
+
 /-- The local chart on the étalé space determined by a section of a presheaf.
 
 On `sectionRange F U s`, the chart is the étalé projection to `U`; its inverse sends a point
@@ -117,43 +130,10 @@ private noncomputable def sectionOpenPartialHomeomorph (F : X.Presheaf C) (U : O
     (s : ToType (F.obj (Opposite.op U))) (x₀ : U) :
     OpenPartialHomeomorph F.EtaleSpace X := by
   classical
+  letI : Nonempty U := ⟨x₀⟩
   exact
-    { toFun := TopCat.Presheaf.EtaleSpace.base
-      invFun x := if hx : x ∈ U then germSection F U s ⟨x, hx⟩ else germSection F U s x₀
-      source := sectionRange F U s
-      target := U
-      map_source' := by
-        rintro g ⟨x, rfl⟩
-        exact x.2
-      map_target' := by
-        intro x hx
-        split
-        · exact ⟨⟨x, hx⟩, rfl⟩
-        · contradiction
-      left_inv' := by
-        rintro g ⟨x, rfl⟩
-        split
-        · rename_i h
-          congr
-        · rename_i h
-          exact (h x.2).elim
-      right_inv' := by
-        intro x hx
-        split
-        · rfl
-        · contradiction
-      open_source := isOpen_sectionRange U s
-      open_target := U.isOpen
-      continuousOn_toFun := (TopCat.Presheaf.EtaleSpace.continuous_base F).continuousOn
-      continuousOn_invFun := by
-        rw [continuousOn_iff_continuous_restrict]
-        apply (continuous_germSection U s).congr
-        intro x
-        dsimp only [Set.restrict]
-        split
-        · congr
-        · rename_i h
-          exact (h x.2).elim }
+    ((isOpenEmbedding_germSection U s).toOpenPartialHomeomorph (germSection F U s)).symm.trans
+      (U.openPartialHomeomorphSubtypeCoe inferInstance)
 
 /-- The projection from the étalé space of a presheaf to the base is a local homeomorphism. -/
 theorem isLocalHomeomorph_base (F : X.Presheaf C) :
@@ -161,24 +141,23 @@ theorem isLocalHomeomorph_base (F : X.Presheaf C) :
   apply IsLocalHomeomorph.mk
   intro g
   obtain ⟨U, hgU, s, hs⟩ := F.exists_germ_eq g.germ
+  letI : Nonempty U := ⟨⟨g.base, hgU⟩⟩
   let e := sectionOpenPartialHomeomorph F U s ⟨g.base, hgU⟩
-  refine ⟨e, ?_, fun _ _ ↦ rfl⟩
-  -- Unfold the private chart only to expose its source as the range of the chosen germ section.
-  change g ∈ sectionRange F U s
-  rw [mem_sectionRange_iff]
-  exact ⟨hgU, hs.symm⟩
-
-/-- A germ section is an open embedding of its domain into the étalé space. -/
-theorem isOpenEmbedding_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
-    Topology.IsOpenEmbedding (germSection F U s) := by
-  apply (isLocalHomeomorph_base F).isOpenEmbedding_of_comp
-  · have hcomp :
-        TopCat.Presheaf.EtaleSpace.base ∘ germSection F U s = (Subtype.val : U → X) := by
-      funext x
-      exact base_germSection U s x
-    rw [hcomp]
-    exact U.isOpen.isOpenEmbedding_subtypeVal
-  · exact continuous_germSection U s
+  have he_source : e.source = sectionRange F U s := by
+    simp [e, sectionOpenPartialHomeomorph, sectionRange]
+  refine ⟨e, ?_, ?_⟩
+  · rw [he_source, mem_sectionRange_iff]
+    exact ⟨hgU, hs.symm⟩
+  · intro g hg
+    rw [he_source] at hg
+    change
+      g.base =
+        ((isOpenEmbedding_germSection U s).toOpenPartialHomeomorph
+          (germSection F U s)).symm g
+    symm
+    simpa only [base_germSection] using congr_arg TopCat.Presheaf.EtaleSpace.base
+      (Topology.IsOpenEmbedding.toOpenPartialHomeomorph_right_inv
+        (f := germSection F U s) (h := isOpenEmbedding_germSection U s) hg)
 
 end TopCat.Presheaf.EtaleSpace
 

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Sheaves.EtaleSpace
+
+/-!
+# Local charts on the étalé space of a presheaf
+
+This file supplies the local-homeomorphism API for the étalé space of a presheaf.  A section
+over an open set determines a continuous section of the étalé projection, whose range consists
+of its germs.  This range is open and gives a local chart.  Consequently, the projection from
+the étalé space to its base is a local homeomorphism.
+
+The construction extends the étalé-space topology and germ API in
+`Mathlib.Topology.Sheaves.EtaleSpace`.  It is the topological prerequisite for applying
+Mathlib's abstract `IsLocalHomeomorph.monodromy_theorem` to analytic continuation: the remaining
+analytic input is separatedness of the projection, supplied by the identity theorem for
+holomorphic functions.
+-/
+
+public section
+
+open CategoryTheory Function Set TopologicalSpace
+
+namespace TauCeti
+
+namespace TopCat.Presheaf.EtaleSpace
+
+universe v u w
+
+variable {X : TopCat.{v}} {C : Type u} [Category.{v} C] {CC : C → Type v}
+  {FC : C → C → Type w} [∀ A B, FunLike (FC A B) (CC A) (CC B)]
+  [ConcreteCategory C FC] [Limits.HasColimits.{v} C]
+
+variable {F : X.Presheaf C}
+
+/-- A section of a presheaf, viewed as a section of the étalé projection. -/
+@[expose]
+noncomputable def germSection (F : X.Presheaf C) (U : Opens X)
+    (s : ToType (F.obj (Opposite.op U))) :
+    U → F.EtaleSpace :=
+  fun x ↦ ⟨x, F.germ U x x.2 s⟩
+
+@[simp]
+theorem base_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
+    (germSection F U s x).base = x :=
+  (rfl)
+
+@[simp]
+theorem germ_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) (x : U) :
+    (germSection F U s x).germ = F.germ U x x.2 s :=
+  (rfl)
+
+/-- The open set in the étalé space swept out by the germs of a section. -/
+def sectionRange (F : X.Presheaf C) (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    Set F.EtaleSpace :=
+  Set.range (germSection F U s)
+
+/-- Membership in the range of a germ section means being the germ of that section at the
+underlying base point. -/
+@[simp]
+theorem mem_sectionRange_iff {U : Opens X} {s : ToType (F.obj (Opposite.op U))}
+    {g : F.EtaleSpace} :
+    g ∈ sectionRange F U s ↔ ∃ h : g.base ∈ U, g.germ = F.germ U g.base h s := by
+  constructor
+  · rintro ⟨x, rfl⟩
+    exact ⟨x.2, rfl⟩
+  · rintro ⟨h, hg⟩
+    refine ⟨⟨g.base, h⟩, ?_⟩
+    cases g
+    simp only [germSection, TopCat.Presheaf.EtaleSpace.mk.injEq]
+    exact ⟨trivial, heq_of_eq hg.symm⟩
+
+/-- The germs of a section form an open subset of the étalé space. -/
+theorem isOpen_sectionRange (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    IsOpen (sectionRange F U s) := by
+  apply TopologicalSpace.isOpen_generateFrom_of_mem
+  exact ⟨U, s, Set.ext fun g ↦ mem_sectionRange_iff.symm⟩
+
+/-- A germ section is injective because the étalé projection recovers its argument. -/
+theorem germSection_injective (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    Function.Injective (germSection F U s) :=
+  fun _ _ h ↦ Subtype.ext <| congr_arg TopCat.Presheaf.EtaleSpace.base h
+
+variable [Limits.PreservesFilteredColimits (forget C)]
+
+/-- The map taking a point to the germ of a fixed section there is continuous. -/
+theorem continuous_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    Continuous (germSection F U s) := by
+  rw [continuous_generateFrom_iff]
+  rintro _ ⟨V, t, rfl⟩
+  apply isOpen_iff_forall_mem_open.mpr
+  rintro x ⟨hxV, hst⟩
+  -- Expose the dependent stalk index so that `Presheaf.germ_eq` applies at the base point `x`.
+  change F.germ U (x : X) x.2 s = F.germ V (x : X) hxV t at hst
+  obtain ⟨W, hxW, iWU, iWV, heq⟩ :=
+    F.germ_eq x x.2 hxV s t hst
+  let WU : Set U := Subtype.val ⁻¹' W
+  refine ⟨WU, ?_, ?_, ?_⟩
+  · rintro y hy
+    have hyW : (y : X) ∈ W := hy
+    refine ⟨iWV.le hyW, ?_⟩
+    -- As above, the target topology presents this equality with an implicit dependent index.
+    change F.germ U (y : X) y.2 s = F.germ V (y : X) _ t
+    exact F.germ_ext W hyW iWU iWV heq
+  · exact W.isOpen.preimage continuous_subtype_val
+  · exact hxW
+
+/-- The local chart on the étalé space determined by a section of a presheaf.
+
+On `sectionRange F U s`, the chart is the étalé projection to `U`; its inverse sends a point
+to the germ of `s` at that point. -/
+private noncomputable def sectionOpenPartialHomeomorph (F : X.Presheaf C) (U : Opens X)
+    (s : ToType (F.obj (Opposite.op U))) (x₀ : U) :
+    OpenPartialHomeomorph F.EtaleSpace X := by
+  classical
+  exact
+    { toFun := TopCat.Presheaf.EtaleSpace.base
+      invFun x := if hx : x ∈ U then germSection F U s ⟨x, hx⟩ else germSection F U s x₀
+      source := sectionRange F U s
+      target := U
+      map_source' := by
+        rintro g ⟨x, rfl⟩
+        exact x.2
+      map_target' := by
+        intro x hx
+        split
+        · exact ⟨⟨x, hx⟩, rfl⟩
+        · contradiction
+      left_inv' := by
+        rintro g ⟨x, rfl⟩
+        split
+        · rename_i h
+          congr
+        · rename_i h
+          exact (h x.2).elim
+      right_inv' := by
+        intro x hx
+        split
+        · rfl
+        · contradiction
+      open_source := isOpen_sectionRange U s
+      open_target := U.isOpen
+      continuousOn_toFun := (TopCat.Presheaf.EtaleSpace.continuous_base F).continuousOn
+      continuousOn_invFun := by
+        rw [continuousOn_iff_continuous_restrict]
+        apply (continuous_germSection U s).congr
+        intro x
+        dsimp only [Set.restrict]
+        split
+        · congr
+        · rename_i h
+          exact (h x.2).elim }
+
+/-- The projection from the étalé space of a presheaf to the base is a local homeomorphism. -/
+theorem isLocalHomeomorph_base (F : X.Presheaf C) :
+    IsLocalHomeomorph (TopCat.Presheaf.EtaleSpace.base (F := F)) := by
+  apply IsLocalHomeomorph.mk
+  intro g
+  obtain ⟨U, hgU, s, hs⟩ := F.exists_germ_eq g.germ
+  let e := sectionOpenPartialHomeomorph F U s ⟨g.base, hgU⟩
+  refine ⟨e, ?_, fun _ _ ↦ rfl⟩
+  -- Unfold the private chart only to expose its source as the range of the chosen germ section.
+  change g ∈ sectionRange F U s
+  rw [mem_sectionRange_iff]
+  exact ⟨hgU, hs.symm⟩
+
+/-- A germ section is an open embedding of its domain into the étalé space. -/
+theorem isOpenEmbedding_germSection (U : Opens X) (s : ToType (F.obj (Opposite.op U))) :
+    Topology.IsOpenEmbedding (germSection F U s) := by
+  apply (isLocalHomeomorph_base F).isOpenEmbedding_of_comp
+  · have hcomp :
+        TopCat.Presheaf.EtaleSpace.base ∘ germSection F U s = (Subtype.val : U → X) := by
+      funext x
+      exact base_germSection U s x
+    rw [hcomp]
+    exact U.isOpen.isOpenEmbedding_subtypeVal
+  · exact continuous_germSection U s
+
+end TopCat.Presheaf.EtaleSpace
+
+end TauCeti

--- a/TauCeti/Topology/Sheaves/EtaleSpace.lean
+++ b/TauCeti/Topology/Sheaves/EtaleSpace.lean
@@ -135,6 +135,19 @@ private noncomputable def sectionOpenPartialHomeomorph (F : X.Presheaf C) (U : O
     ((isOpenEmbedding_germSection U s).toOpenPartialHomeomorph (germSection F U s)).symm.trans
       (U.openPartialHomeomorphSubtypeCoe inferInstance)
 
+/-- On its source, the chart determined by a section agrees with the étalé projection. -/
+private theorem sectionOpenPartialHomeomorph_apply (F : X.Presheaf C) (U : Opens X)
+    (s : ToType (F.obj (Opposite.op U))) (x₀ : U) {g : F.EtaleSpace}
+    (hg : g ∈ sectionRange F U s) :
+    sectionOpenPartialHomeomorph F U s x₀ g = g.base := by
+  classical
+  letI : Nonempty U := ⟨x₀⟩
+  rw [sectionOpenPartialHomeomorph, OpenPartialHomeomorph.trans_apply,
+    U.openPartialHomeomorphSubtypeCoe_coe inferInstance]
+  simpa only [base_germSection] using congr_arg TopCat.Presheaf.EtaleSpace.base
+    (Topology.IsOpenEmbedding.toOpenPartialHomeomorph_right_inv
+      (f := germSection F U s) (h := isOpenEmbedding_germSection U s) hg)
+
 /-- The projection from the étalé space of a presheaf to the base is a local homeomorphism. -/
 theorem isLocalHomeomorph_base (F : X.Presheaf C) :
     IsLocalHomeomorph (TopCat.Presheaf.EtaleSpace.base (F := F)) := by
@@ -148,16 +161,9 @@ theorem isLocalHomeomorph_base (F : X.Presheaf C) :
   refine ⟨e, ?_, ?_⟩
   · rw [he_source, mem_sectionRange_iff]
     exact ⟨hgU, hs.symm⟩
-  · intro g hg
+  · intro g' hg
     rw [he_source] at hg
-    change
-      g.base =
-        ((isOpenEmbedding_germSection U s).toOpenPartialHomeomorph
-          (germSection F U s)).symm g
-    symm
-    simpa only [base_germSection] using congr_arg TopCat.Presheaf.EtaleSpace.base
-      (Topology.IsOpenEmbedding.toOpenPartialHomeomorph_right_inv
-        (f := germSection F U s) (h := isOpenEmbedding_germSection U s) hg)
+    exact (sectionOpenPartialHomeomorph_apply F U s ⟨g.base, hgU⟩ (g := g') hg).symm
 
 end TopCat.Presheaf.EtaleSpace
 


### PR DESCRIPTION
This PR proves the first topological prerequisite for the remaining analytic-continuation work in `TauCetiRoadmap/ConformalMapping/README.md`, layer **L4 — analytic continuation & the reflection principle**, specifically “the monodromy theorem (continuations along homotopic paths agree).” It establishes that the projection from the étalé space of a presheaf to its base is a local homeomorphism, so Mathlib’s abstract monodromy theorem can later be applied to the étalé space of holomorphic germs once the identity theorem supplies separatedness.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"etale-space-local-homeomorphism"}-->

This is the lowest-hanging uncovered ConformalMapping target prerequisite because L0–L3, reflection across the real axis, lines, circles, and analytic arcs, and Painlevé removability across analytic arcs are already on `main`, while no open PR covers analytic continuation or monodromy. Mathlib already proves the abstract lifting theorem `IsLocalHomeomorph.monodromy_theorem` and explicitly identifies analytic-germ étalé spaces as its intended application, but `Mathlib.Topology.Sheaves.EtaleSpace` did not establish the needed local-homeomorphism property of its projection.

Add `TauCeti/Topology/Sheaves/EtaleSpace.lean` (185 lines). Define the germ section associated to a presheaf section and its open range; characterize membership; prove the germ section continuous, injective, and an open embedding; construct local charts privately; and conclude `TauCeti.TopCat.Presheaf.EtaleSpace.isLocalHomeomorph_base`. State the result for every presheaf valued in a concrete category whose forgetful functor preserves filtered colimits, rather than specializing prematurely to complex-valued holomorphic germs.

Build directly on Mathlib’s `TopCat.Presheaf.EtaleSpace`, `Presheaf.exists_germ_eq`, `Presheaf.germ_eq`, and `IsLocalHomeomorph` APIs. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake build` completes successfully across 5,831 jobs. `tauceti-axioms --changed-from origin/main` audits 21 declarations in the changed module using only `propext`, `Classical.choice`, and `Quot.sound`. `tauceti-lint-env --changed-from origin/main` passes with zero violations.

🤖 Prepared with Codex
