### PR TITLE
feat: construct exchangeable coin flips with a random bias

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -36,10 +36,10 @@ Measurability:
   `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}`, pairing the block kernel with a Dirac mass at the mixing
   measure. This is the joint-space input a conditional (joint-law) reading of the mixture
   identity needs, as opposed to the block kernel alone.
-* `measurable_dirac_prod_infinitePi_const` — the parameter-tagged countable-product kernel
-  `t ↦ δ_t ⊗ (P t)^{⊗ℕ}`, for a measurable family `P` of probability measures. Here the Dirac
-  factor sits on the parameter rather than on the measure it selects, which is what a mixture
-  retaining its parameter as a coordinate needs.
+* `measurable_dirac_prod_infinitePi_const` — the parameter-tagged product kernel
+  `t ↦ δ_t ⊗ (P t)^{⊗ι}` over an **arbitrary** index type, for a measurable family `P` of
+  probability measures. Here the Dirac factor sits on the parameter rather than on the measure it
+  selects, which is what a mixture retaining its parameter as a coordinate needs.
 * `measurable_infinitePi` — the product `p ↦ ⊗ᵢ p i` over an **arbitrary** index type, of a
   dependent family of probability measures, is measurable in the measure argument;
   `measurable_infinitePi_const` is the `ℕ`-constant-power specialization `p ↦ p^{⊗ℕ}`. Mathlib
@@ -203,25 +203,25 @@ theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
       Measure.infinitePi (fun _ : ℕ => (p : Measure α)) :=
   measurable_infinitePi.comp (measurable_pi_lambda _ fun _ => measurable_id)
 
-/-- **Parameter-tagged countable-product kernel.** For a measurable family of probability measures
-`P : T → ProbabilityMeasure α`, the random measure `t ↦ δ_t ⊗ (P t)^{⊗ℕ}` on `T × (ℕ → α)` is
-measurable.
+/-- **Parameter-tagged product kernel.** For a measurable family of probability measures
+`P : T → ProbabilityMeasure α`, the random measure `t ↦ δ_t ⊗ (P t)^{⊗ι}` on `T × (ι → α)` is
+measurable, over an arbitrary index type `ι`.
 
-This is the countable-power companion of
+This is the arbitrary-power companion of
 `measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure`, with the Dirac factor sitting on the
 *parameter* rather than on the measure it selects. It is what a mixture that retains its parameter
 as a coordinate needs for `Measure.bind_apply`. -/
 @[fun_prop]
-theorem measurable_dirac_prod_infinitePi_const {T α : Type*} [MeasurableSpace T]
+theorem measurable_dirac_prod_infinitePi_const {T α ι' : Type*} [MeasurableSpace T]
     [MeasurableSpace α] (P : T → ProbabilityMeasure α) (hP : Measurable P) :
     Measurable fun t =>
-      (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α)) := by
+      (Measure.dirac t).prod (Measure.infinitePi fun _ : ι' => (P t : Measure α)) := by
   have hdirac : Measurable fun t => (⟨Measure.dirac t, inferInstance⟩ : ProbabilityMeasure T) :=
     Measure.measurable_dirac.subtype_mk
   have hpow : Measurable fun t =>
-      (⟨Measure.infinitePi fun _ : ℕ => (P t : Measure α), inferInstance⟩ :
-        ProbabilityMeasure (ℕ → α)) :=
-    (measurable_infinitePi_const.comp hP).subtype_mk
+      (⟨Measure.infinitePi fun _ : ι' => (P t : Measure α), inferInstance⟩ :
+        ProbabilityMeasure (ι' → α)) :=
+    (measurable_infinitePi.comp (measurable_pi_lambda _ fun _ => hP)).subtype_mk
   exact ProbabilityMeasure.measurable_fun_prod.comp (hdirac.prodMk hpow)
 
 /-- **Finite-prefix marginal of a countable product.** Restricting `⊗ⱼ p j` to its first `n`

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -36,6 +36,10 @@ Measurability:
   `ω ↦ δ_{ν ω} ⊗ (ν ω)^{⊗ Fin m}`, pairing the block kernel with a Dirac mass at the mixing
   measure. This is the joint-space input a conditional (joint-law) reading of the mixture
   identity needs, as opposed to the block kernel alone.
+* `measurable_dirac_prod_infinitePi_const` — the parameter-tagged countable-product kernel
+  `t ↦ δ_t ⊗ (P t)^{⊗ℕ}`, for a measurable family `P` of probability measures. Here the Dirac
+  factor sits on the parameter rather than on the measure it selects, which is what a mixture
+  retaining its parameter as a coordinate needs.
 * `measurable_infinitePi` — the product `p ↦ ⊗ᵢ p i` over an **arbitrary** index type, of a
   dependent family of probability measures, is measurable in the measure argument;
   `measurable_infinitePi_const` is the `ℕ`-constant-power specialization `p ↦ p^{⊗ℕ}`. Mathlib
@@ -198,6 +202,27 @@ theorem measurable_infinitePi_const {α : Type*} [MeasurableSpace α] :
     Measurable fun p : ProbabilityMeasure α =>
       Measure.infinitePi (fun _ : ℕ => (p : Measure α)) :=
   measurable_infinitePi.comp (measurable_pi_lambda _ fun _ => measurable_id)
+
+/-- **Parameter-tagged countable-product kernel.** For a measurable family of probability measures
+`P : T → ProbabilityMeasure α`, the random measure `t ↦ δ_t ⊗ (P t)^{⊗ℕ}` on `T × (ℕ → α)` is
+measurable.
+
+This is the countable-power companion of
+`measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure`, with the Dirac factor sitting on the
+*parameter* rather than on the measure it selects. It is what a mixture that retains its parameter
+as a coordinate needs for `Measure.bind_apply`. -/
+@[fun_prop]
+theorem measurable_dirac_prod_infinitePi_const {T α : Type*} [MeasurableSpace T]
+    [MeasurableSpace α] (P : T → ProbabilityMeasure α) (hP : Measurable P) :
+    Measurable fun t =>
+      (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α)) := by
+  have hdirac : Measurable fun t => (⟨Measure.dirac t, inferInstance⟩ : ProbabilityMeasure T) :=
+    Measure.measurable_dirac.subtype_mk
+  have hpow : Measurable fun t =>
+      (⟨Measure.infinitePi fun _ : ℕ => (P t : Measure α), inferInstance⟩ :
+        ProbabilityMeasure (ℕ → α)) :=
+    (measurable_infinitePi_const.comp hP).subtype_mk
+  exact ProbabilityMeasure.measurable_fun_prod.comp (hdirac.prodMk hpow)
 
 /-- **Finite-prefix marginal of a countable product.** Restricting `⊗ⱼ p j` to its first `n`
 coordinates gives the finite product `⊗_{i : Fin n} p i`.

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
@@ -59,14 +59,20 @@ comes up `true` with probability `p`.
 Phrasing the example through this kernel — rather than through a `Bernoulli` random variable —
 keeps it independent of any particular parametrized-distribution API: all it needs is that the
 family is measurable in the bias. -/
+-- `@[expose]` is forced by the exported `rfl`-unfold `coinKernel_toMeasure` below: a public theorem
+-- proved by unfolding the body requires the body to be exposed.
 @[expose]
 def coinKernel (p : I) : ProbabilityMeasure Bool :=
   ⟨bernoulliMeasure true false p, inferInstance⟩
 
+/-- The measure underlying `coinKernel p` is Mathlib's Bernoulli measure on `Bool`. -/
+@[simp]
 theorem coinKernel_toMeasure (p : I) :
     (coinKernel p : Measure Bool) = bernoulliMeasure true false p :=
   rfl
 
+-- Not `@[simp]`: with `coinKernel_toMeasure` in the simp set this left-hand side is not
+-- simp-normal, and `simp` closes the statement outright — the `simpNF` linter rejects the tag.
 /-- The bias is read back off the coin: `coinKernel p` gives mass `p` to `{true}`. -/
 theorem coinKernel_apply_true (p : I) :
     (coinKernel p : Measure Bool) {true} = (toNNReal p : ℝ≥0∞) := by
@@ -84,7 +90,7 @@ theorem measurable_coinKernel : Measurable coinKernel := by
     Pi.smul_apply]
   exact (hp.mul_const _).add (hσ.mul_const _)
 
-variable (π : Measure I) [IsProbabilityMeasure π]
+variable (π : Measure I)
 
 /-- **The worked example.** Draw a bias from `π`, then flip i.i.d. coins with that bias: the
 resulting `Bool`-valued sequence is conditionally i.i.d. with directing measure
@@ -112,14 +118,15 @@ theorem contractable_coinFlips :
     Contractable (iidMixtureLaw π coinKernel) fun n ω => ω.2 n :=
   contractable_iidMixtureLaw measurable_coinKernel
 
-/-- Independent flips force a deterministic bias: reading the bias back off the directing measure
-turns the degeneracy of the mixing law (`exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw`) into
-degeneracy of the bias law itself. -/
-theorem exists_map_toNNReal_eq_dirac_of_iIndepFun_coinFlips
+/-- **Independent flips force a deterministic bias.** If the coordinates of the coin-flip sequence
+are independent, then the law of the bias — pushed forward along `toNNReal` — is a Dirac
+measure. -/
+theorem exists_map_toNNReal_eq_dirac_of_iIndepFun_coinFlips [IsProbabilityMeasure π]
     (h : iIndepFun (fun n (ω : I × (ℕ → Bool)) => ω.2 n) (iidMixtureLaw π coinKernel)) :
     ∃ c : ℝ≥0∞, π.map (fun p : I => (toNNReal p : ℝ≥0∞)) = Measure.dirac c := by
   have hev : Measurable fun Q : ProbabilityMeasure Bool => (Q : Measure Bool) {true} :=
     (Measure.measurable_coe (measurableSet_singleton true)).comp measurable_subtype_coe
+  -- degeneracy of the mixing law, transported along the bias readout `Q ↦ Q {true}`
   obtain ⟨Q, hQ⟩ := exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw measurable_coinKernel h
   refine ⟨(Q : Measure Bool) {true}, ?_⟩
   have hcomp : (fun p : I => (toNNReal p : ℝ≥0∞))

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean
@@ -1,0 +1,170 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
+public import Mathlib.Probability.Distributions.Bernoulli
+
+/-!
+# Exchangeable coin flips: the worked example of a random bias
+
+This file discharges the second worked example of the Exchangeability roadmap
+(`TauCetiRoadmap/Exchangeability/README.md`, "Worked examples"):
+
+> A `Bool`-valued sequence generated conditionally i.i.d. given a random `θ` (draw `θ`, then flip
+> i.i.d. `κ (θ ω)`-coins) is exchangeable, with `ω ↦ κ (θ ω)` (`κ` a two-point kernel) as the
+> directing measure — genuinely: the generating construction makes it a witness of
+> `ConditionallyIIDWith`, not merely a mixing representative.
+
+The two-point kernel is `coinKernel p = Ber(true, false, p)`, Mathlib's `bernoulliMeasure` bundled
+as a `ProbabilityMeasure Bool`; the parameter `θ` is the first coordinate of the canonical space
+`I × (ℕ → Bool)` and the bias measure `π` is arbitrary. As the roadmap insists, the directing
+measure is the *random probability measure* `ω ↦ coinKernel ω.1`, not the bias `ω ↦ ω.1` itself.
+
+The example carries weight because the sequence is exchangeable without being independent:
+`not_iIndepFun_coinFlips` exhibits a two-point bias law for which the coordinates are dependent, so
+`ConditionallyIID` really is a wider class than i.i.d. and the constructed directing measure is not
+a disguised constant.
+
+## Main results
+
+* `coinKernel` — the two-point kernel `p ↦ Ber(true, false, p)`, with `measurable_coinKernel` and
+  the bias readout `coinKernel_apply_true`.
+* `conditionallyIIDWith_coinFlips` — the coin-flip sequence is conditionally i.i.d. with directing
+  measure `ω ↦ coinKernel ω.1`, hence `exchangeable_coinFlips` and `contractable_coinFlips`.
+* `not_iIndepFun_coinFlips` — for a bias that is genuinely random the flips are *not* independent.
+
+The construction it instantiates is `iidMixtureLaw` in
+`TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean`. Nothing here is adapted from
+`cameronfreer/exchangeability`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory unitInterval
+
+open scoped ENNReal NNReal
+
+namespace TauCeti
+
+namespace Probability
+
+/-- **The two-point kernel.** `coinKernel p` is the law of one `Bool`-valued flip of a coin that
+comes up `true` with probability `p`.
+
+Phrasing the example through this kernel — rather than through a `Bernoulli` random variable —
+keeps it independent of any particular parametrized-distribution API: all it needs is that the
+family is measurable in the bias. -/
+@[expose]
+def coinKernel (p : I) : ProbabilityMeasure Bool :=
+  ⟨bernoulliMeasure true false p, inferInstance⟩
+
+theorem coinKernel_toMeasure (p : I) :
+    (coinKernel p : Measure Bool) = bernoulliMeasure true false p :=
+  rfl
+
+/-- The bias is read back off the coin: `coinKernel p` gives mass `p` to `{true}`. -/
+theorem coinKernel_apply_true (p : I) :
+    (coinKernel p : Measure Bool) {true} = (toNNReal p : ℝ≥0∞) := by
+  rw [coinKernel_toMeasure]
+  exact bernoulliMeasure_apply_of_mem_of_notMem p (measurableSet_singleton _) rfl (by simp)
+
+/-- The two-point kernel is measurable in the bias, so it can direct a mixture. -/
+theorem measurable_coinKernel : Measurable coinKernel := by
+  have hp : Measurable fun p : I => (toNNReal p : ℝ≥0∞) :=
+    measurable_coe_nnreal_ennreal.comp toNNReal_continuous.measurable
+  have hσ : Measurable fun p : I => (toNNReal (σ p) : ℝ≥0∞) :=
+    measurable_coe_nnreal_ennreal.comp (toNNReal_continuous.comp continuous_symm).measurable
+  refine (Measure.measurable_of_measurable_coe _ fun s _ => ?_).subtype_mk
+  simp only [bernoulliMeasure_def, Measure.coe_add, Measure.coe_smul, Pi.add_apply,
+    Pi.smul_apply]
+  exact (hp.mul_const _).add (hσ.mul_const _)
+
+variable (π : Measure I) [IsProbabilityMeasure π]
+
+/-- **The worked example.** Draw a bias from `π`, then flip i.i.d. coins with that bias: the
+resulting `Bool`-valued sequence is conditionally i.i.d. with directing measure
+`ω ↦ coinKernel ω.1`.
+
+This is the sharp conditional statement, not just the mixture identity: the generating construction
+puts the sequence and its directing measure on one space and pins their joint law. -/
+theorem conditionallyIIDWith_coinFlips :
+    ConditionallyIIDWith (iidMixtureLaw π coinKernel) (fun n ω => ω.2 n)
+      fun ω => coinKernel ω.1 :=
+  conditionallyIIDWith_iidMixtureLaw measurable_coinKernel
+
+/-- The coin-flip sequence is conditionally i.i.d. (existential form). -/
+theorem conditionallyIID_coinFlips :
+    ConditionallyIID (iidMixtureLaw π coinKernel) fun n ω => ω.2 n :=
+  conditionallyIID_iidMixtureLaw measurable_coinKernel
+
+/-- The coin-flip sequence is exchangeable. -/
+theorem exchangeable_coinFlips :
+    Exchangeable (iidMixtureLaw π coinKernel) fun n ω => ω.2 n :=
+  exchangeable_iidMixtureLaw measurable_coinKernel
+
+/-- The coin-flip sequence is contractable. -/
+theorem contractable_coinFlips :
+    Contractable (iidMixtureLaw π coinKernel) fun n ω => ω.2 n :=
+  contractable_iidMixtureLaw measurable_coinKernel
+
+/-- Independent flips force a deterministic bias: reading the bias back off the directing measure
+turns the degeneracy of the mixing law (`exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw`) into
+degeneracy of the bias law itself. -/
+theorem exists_map_toNNReal_eq_dirac_of_iIndepFun_coinFlips
+    (h : iIndepFun (fun n (ω : I × (ℕ → Bool)) => ω.2 n) (iidMixtureLaw π coinKernel)) :
+    ∃ c : ℝ≥0∞, π.map (fun p : I => (toNNReal p : ℝ≥0∞)) = Measure.dirac c := by
+  have hev : Measurable fun Q : ProbabilityMeasure Bool => (Q : Measure Bool) {true} :=
+    (Measure.measurable_coe (measurableSet_singleton true)).comp measurable_subtype_coe
+  obtain ⟨Q, hQ⟩ := exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw measurable_coinKernel h
+  refine ⟨(Q : Measure Bool) {true}, ?_⟩
+  have hcomp : (fun p : I => (toNNReal p : ℝ≥0∞))
+      = (fun Q : ProbabilityMeasure Bool => (Q : Measure Bool) {true}) ∘ coinKernel :=
+    funext fun p => (coinKernel_apply_true p).symm
+  rw [hcomp, ← Measure.map_map hev measurable_coinKernel, hQ]
+  exact Measure.map_dirac' hev Q
+
+/-- The bias-to-mass map `I → ℝ≥0∞` is injective, so a degenerate image law means a degenerate
+bias law. -/
+private theorem toNNReal_ennreal_injective :
+    Function.Injective fun p : I => (toNNReal p : ℝ≥0∞) := by
+  intro x y hxy
+  exact Subtype.ext (by simpa using congrArg ENNReal.toReal hxy)
+
+/-- **Exchangeable but not independent.** With the bias itself drawn from a nondegenerate two-point
+law `Ber(a, b, r)` — two distinct biases `a ≠ b`, each of positive probability — the coin flips are
+exchangeable (`exchangeable_coinFlips`) yet dependent.
+
+So `ConditionallyIID` is strictly wider than i.i.d., and the directing measure the construction
+supplies is genuinely random rather than an a.e. constant. -/
+theorem not_iIndepFun_coinFlips {a b r : I} (hab : a ≠ b) (hr₀ : r ≠ 0) (hr₁ : r ≠ 1) :
+    ¬ iIndepFun (fun n (ω : I × (ℕ → Bool)) => ω.2 n)
+      (iidMixtureLaw (bernoulliMeasure a b r) coinKernel) := by
+  intro h
+  have hmeas : Measurable fun p : I => (toNNReal p : ℝ≥0∞) :=
+    measurable_coe_nnreal_ennreal.comp toNNReal_continuous.measurable
+  obtain ⟨c, hc⟩ := exists_map_toNNReal_eq_dirac_of_iIndepFun_coinFlips _ h
+  rw [map_bernoulliMeasure' a b hmeas r] at hc
+  -- evaluating both sides at the singleton `{a's mass}` gives `r` on the left and `0` or `1`
+  -- on the right
+  have hne : (toNNReal b : ℝ≥0∞) ≠ (toNNReal a : ℝ≥0∞) := fun hcon =>
+    hab (toNNReal_ennreal_injective hcon).symm
+  have hval := congrArg (fun m : Measure ℝ≥0∞ => m {(toNNReal a : ℝ≥0∞)}) hc
+  rw [bernoulliMeasure_apply_of_mem_of_notMem r (measurableSet_singleton _) rfl hne,
+    Measure.dirac_apply' _ (measurableSet_singleton _)] at hval
+  -- `r` is neither `0` nor `1`, but the indicator on the right is one of the two
+  have hr₀' : (toNNReal r : ℝ≥0∞) ≠ 0 := fun hcon =>
+    hr₀ (toNNReal_ennreal_injective (by simpa using hcon))
+  have hr₁' : (toNNReal r : ℝ≥0∞) ≠ 1 := fun hcon =>
+    hr₁ (toNNReal_ennreal_injective (by simpa using hcon))
+  by_cases hmem : c ∈ ({(toNNReal a : ℝ≥0∞)} : Set ℝ≥0∞)
+  · exact hr₁' (by simpa [hmem] using hval)
+  · exact hr₀' (by simpa [hmem] using hval)
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -83,10 +83,14 @@ coordinates i.i.d. from `P t`, keeping `t` as the first coordinate of the sample
 Retaining the parameter is what makes this a *conditional* construction rather than only a mixture
 of i.i.d. laws: the sequence and its directing measure live on the same space, so the joint law of
 the two can be compared with the disintegration `ConditionallyIIDWith` demands. -/
+-- `@[expose]` is forced by the exported `rfl`-unfold `iidMixtureLaw_def` below: a public theorem
+-- proved by unfolding the body requires the body to be exposed.
 @[expose]
 def iidMixtureLaw (π : Measure T) (P : T → ProbabilityMeasure α) : Measure (T × (ℕ → α)) :=
   π.bind fun t => (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))
 
+/-- The canonical law unfolded as the `π`-mixture of the parameter-tagged countable powers. -/
+@[simp]
 theorem iidMixtureLaw_def (π : Measure T) (P : T → ProbabilityMeasure α) :
     iidMixtureLaw π P =
       π.bind fun t => (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α)) :=
@@ -103,7 +107,7 @@ theorem isProbabilityMeasure_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measu
     (.of_forall fun _ => inferInstance)
 
 /-- The parameter coordinate of the canonical law is distributed as `π`. -/
-theorem iidMixtureLaw_map_fst [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem iidMixtureLaw_map_fst (hP : Measurable P) :
     (iidMixtureLaw π P).map Prod.fst = π := by
   have hfst : ∀ t : T,
       ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map Prod.fst
@@ -115,23 +119,24 @@ theorem iidMixtureLaw_map_fst [IsProbabilityMeasure π] (hP : Measurable P) :
   exact Measure.bind_dirac
 
 /-- The directing measure of the canonical law has the prescribed mixing law `π.map P`. -/
-theorem iidMixtureLaw_map_directing [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem iidMixtureLaw_map_directing (hP : Measurable P) :
     (iidMixtureLaw π P).map (fun ω => P ω.1) = π.map P := by
   have hcomp : (fun ω : T × (ℕ → α) => P ω.1) = P ∘ Prod.fst := rfl
   rw [hcomp, ← Measure.map_map hP measurable_fst, iidMixtureLaw_map_fst hP]
 
-/-- **The canonical process is conditionally i.i.d.** with the prescribed directing measure.
+/-- **The canonical process is conditionally i.i.d.** For a measurable family `P`, the coordinate
+process of `iidMixtureLaw π P` is conditionally i.i.d. with directing measure `ω ↦ P ω.1`: along
+every finite selection of distinct coordinates, the joint law of the directing measure and the
+selected block is the disintegration `∫ δ_{P ω.1} ⊗ (P ω.1)^{⊗ Fin m}`.
 
-Both sides of the joint-law disintegration collapse to the same `π`-mixture of
-`δ_{P t} ⊗ (P t)^{⊗ Fin m}`. On the left, naturality of `bind` pushes the selection
-`ω ↦ (P ω.1, (ω.2 ∘ k))` inside the mixture, where `Measure.dirac_prod` turns each fibre into a
-pushforward of `(P t)^{⊗ℕ}` and `Measure.map_infinitePi_infinitePi_of_inj` — this is where
-injectivity of `k` enters — reads off the block as `(P t)^{⊗ Fin m}`. On the right, the mixing
-kernel factors through the parameter, so `bind_map` reindexes the mixture over `π`. -/
-theorem conditionallyIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+This is the sharp conditional conclusion — the directing measure is pinned to the process, not
+merely to the block laws — which is what makes `iidMixtureLaw` a realization of `P` as a directing
+measure rather than only as a mixing representative. -/
+theorem conditionallyIIDWith_iidMixtureLaw (hP : Measurable P) :
     ConditionallyIIDWith (iidMixtureLaw π P) (fun n ω => ω.2 n) (fun ω => P ω.1) := by
-  haveI := isProbabilityMeasure_iidMixtureLaw (π := π) hP
-  have hker := TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const P hP
+  -- Both sides of the disintegration collapse to the same `π`-mixture of
+  -- `δ_{P t} ⊗ (P t)^{⊗ Fin m}`.
+  have hker := TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const (ι' := ℕ) P hP
   refine ConditionallyIIDWith.intro (hP.comp measurable_fst) fun m k hk => ?_
   -- the joint kernel `Q ↦ δ_Q ⊗ Q^{⊗ Fin m}`, through which both sides factor
   set g : ProbabilityMeasure α → Measure (ProbabilityMeasure α × (Fin m → α)) := fun Q =>
@@ -142,7 +147,10 @@ theorem conditionallyIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measu
   have hsel : Measurable fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i)) :=
     (hP.comp measurable_fst).prodMk
       (measurable_pi_lambda _ fun i => (measurable_pi_apply (k i)).comp measurable_snd)
-  -- each fibre of the mixture selects its block out of a countable power
+  -- Each fibre of the mixture selects its block out of a countable power: `Measure.dirac_prod`
+  -- turns the fibre into a pushforward of `(P t)^{⊗ℕ}`, and
+  -- `Measure.map_infinitePi_infinitePi_of_inj` — this is where injectivity of `k` enters — reads
+  -- the block off as `(P t)^{⊗ Fin m}`.
   have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
     measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
   have hfib : ∀ t : T,
@@ -167,12 +175,14 @@ theorem conditionallyIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measu
       _ = g (P t) := by
           simp only [hg]
           rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
-  -- the left-hand side: push the selection through the mixture, fibre by fibre
+  -- the left-hand side: naturality of `bind` pushes the selection through the mixture, fibre by
+  -- fibre
   have hleft : (iidMixtureLaw π P).map (fun ω => (P ω.1, fun i : Fin m => ω.2 (k i)))
       = π.bind fun t => g (P t) := by
     rw [iidMixtureLaw_def, TauCeti.MeasureTheory.map_bind hker.aemeasurable hsel]
     simp_rw [hfib]
-  -- the right-hand side: the mixing kernel factors through the parameter
+  -- the right-hand side: the mixing kernel factors through the parameter, so `bind_map` reindexes
+  -- the mixture over `π`
   have hright : ((iidMixtureLaw π P).bind fun ω =>
       (Measure.dirac (P ω.1)).prod (ProbabilityMeasure.pi fun _ : Fin m => P ω.1).toMeasure)
       = π.bind fun t => g (P t) :=
@@ -186,22 +196,22 @@ theorem conditionallyIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measu
   rw [hleft, hright]
 
 /-- The canonical process is conditionally i.i.d. (existential form). -/
-theorem conditionallyIID_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem conditionallyIID_iidMixtureLaw (hP : Measurable P) :
     ConditionallyIID (iidMixtureLaw π P) fun n ω => ω.2 n :=
   .of_directing (conditionallyIIDWith_iidMixtureLaw hP)
 
 /-- The prescribed family is in particular a mixing representative of the canonical process. -/
-theorem mixedIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem mixedIIDWith_iidMixtureLaw (hP : Measurable P) :
     MixedIIDWith (iidMixtureLaw π P) (fun n ω => ω.2 n) fun ω => P ω.1 :=
   mixedIIDWith_of_conditionallyIIDWith (conditionallyIIDWith_iidMixtureLaw hP)
 
 /-- The canonical process is exchangeable. -/
-theorem exchangeable_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem exchangeable_iidMixtureLaw (hP : Measurable P) :
     Exchangeable (iidMixtureLaw π P) fun n ω => ω.2 n :=
   (mixedIIDWith_iidMixtureLaw hP).exchangeable
 
 /-- The canonical process is contractable. -/
-theorem contractable_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+theorem contractable_iidMixtureLaw (hP : Measurable P) :
     Contractable (iidMixtureLaw π P) fun n ω => ω.2 n :=
   (mixedIIDWith_iidMixtureLaw hP).contractable
 
@@ -218,22 +228,22 @@ theorem pathLaw_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
 
 /-- **The construction is genuinely richer than i.i.d.** If the canonical process happens to have
 independent coordinates, then its mixing law `π.map P` is a point mass — so a nondegenerate `π.map
-P` produces an exchangeable sequence that is *not* independent.
-
-The coordinates are automatically identically distributed (the process is contractable), so
-independence would exhibit a constant mixing representative; uniqueness of the mixing law
-(`mixedIID_mixingLaw_unique`) then identifies `π.map P` with that constant's law. -/
+P` produces an exchangeable sequence that is *not* independent, and the directing measure the
+construction supplies is genuinely random rather than an a.e. constant. -/
 theorem exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw [IsProbabilityMeasure π]
     (hP : Measurable P) (h : iIndepFun (fun n (ω : T × (ℕ → α)) => ω.2 n) (iidMixtureLaw π P)) :
     ∃ Q : ProbabilityMeasure α, π.map P = Measure.dirac Q := by
   haveI := isProbabilityMeasure_iidMixtureLaw (π := π) hP
   have hX : ∀ n, AEMeasurable (fun ω : T × (ℕ → α) => ω.2 n) (iidMixtureLaw π P) :=
     fun n => ((measurable_pi_apply n).comp measurable_snd).aemeasurable
+  -- the coordinates are automatically identically distributed, the process being contractable, so
+  -- independence exhibits a constant mixing representative
   have hident : ∀ i, IdentDistrib (fun ω : T × (ℕ → α) => ω.2 i)
       (fun ω : T × (ℕ → α) => ω.2 0) (iidMixtureLaw π P) (iidMixtureLaw π P) :=
     fun i => (contractable_iidMixtureLaw hP).identDistrib_coord (hX i) (hX 0)
   refine ⟨⟨(iidMixtureLaw π P).map fun ω => ω.2 0,
     Measure.isProbabilityMeasure_map (hX 0)⟩, ?_⟩
+  -- uniqueness of the mixing law then identifies `π.map P` with that constant's law
   rw [← iidMixtureLaw_map_directing hP,
     mixedIID_mixingLaw_unique hX (mixedIIDWith_iidMixtureLaw hP)
       (MixedIIDWith.of_iIndepFun_identDistrib h hident),

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
+public import TauCeti.MeasureTheory.Measure.ProductKernel
+-- Public: `iIndepFun` appears in the hypothesis of the degeneracy theorem.
+public import Mathlib.Probability.Independence.Basic
+-- Non-public: the mixture representation and its uniqueness are used only inside the
+-- degeneracy proof, and the Layer 0 implications only inside the corollaries.
+import TauCeti.Probability.Exchangeability.MixedIID.Mixture
+import TauCeti.Probability.Exchangeability.Contractability
+import TauCeti.Probability.Exchangeability.IID
+import TauCeti.MeasureTheory.Measure.GiryMonad
+-- Non-public: `Measure.map_infinitePi_infinitePi_of_inj` selects a block out of a countable power.
+import Mathlib.Probability.Independence.InfinitePi
+
+/-!
+# The canonical conditionally i.i.d. process
+
+Every measurable family of probability measures is *realized* as a directing measure. Given a
+probability measure `π` on a parameter space `T` and a measurable family
+`P : T → ProbabilityMeasure α`, the law
+
+```text
+iidMixtureLaw π P = ∫ δ_t ⊗ (P t)^{⊗ℕ} dπ(t)
+```
+
+on `T × (ℕ → α)` is the two-stage experiment "draw the parameter `t` from `π`, then sample the
+coordinates i.i.d. from `P t`", with the parameter retained as the first coordinate. Its
+coordinate process `X n ω = ω.2 n` is **conditionally i.i.d.** with directing measure
+`ω ↦ P ω.1`, and the law of that directing measure is the prescribed `π.map P`.
+
+This is the converse direction of the Layer 6 uniqueness statements: `mixedIID_mixingLaw_unique`
+and `conditionallyIID_ae_unique` say a directing measure is pinned down by the process, and the
+theorems here say every law on `ProbabilityMeasure α` of the form `π.map P` does arise. Before
+this file the only `ConditionallyIIDWith` witnesses available were the constant one
+(`ConditionallyIIDWith.of_iIndepFun_identDistrib`, i.e. plain i.i.d.) and the one the hard
+de Finetti theorem extracts from contractability; nothing produced a *prescribed* nondegenerate
+directing measure.
+
+Note that the conclusion is the sharp conditional predicate, not merely the mixture identity: the
+generating construction ties the process to `ν` and not just to its law, which is exactly the
+difference the roadmap insists on
+(`TauCetiRoadmap/Exchangeability/README.md`, "Standing hypotheses").
+
+## Main results
+
+* `iidMixtureLaw` — the canonical two-stage law, with `isProbabilityMeasure_iidMixtureLaw` and the
+  marginal `iidMixtureLaw_map_fst`.
+* `conditionallyIIDWith_iidMixtureLaw` — the coordinate process is conditionally i.i.d. with
+  directing measure `ω ↦ P ω.1`, and the corollaries `mixedIIDWith_iidMixtureLaw`,
+  `exchangeable_iidMixtureLaw`, `contractable_iidMixtureLaw`.
+* `iidMixtureLaw_map_directing` — the directing measure has the prescribed law `π.map P`, and
+  `pathLaw_iidMixtureLaw` reads the path law as the `π.map P`-mixture of infinite powers.
+* `exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw` — the construction is genuinely richer than
+  i.i.d.: independent coordinates force the mixing law `π.map P` to be a point mass.
+
+This advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 6 (directing measures), and
+supplies the construction the roadmap's coin-flipping worked example instantiates
+(`TauCeti/Probability/Exchangeability/ConditionallyIID/CoinFlips.lean`). It needs no material from
+`cameronfreer/exchangeability`, whose `ConditionallyIID` names the weaker mixture identity.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {T α : Type*} [MeasurableSpace T] [MeasurableSpace α]
+
+/-- **The canonical conditionally i.i.d. law.** Draw a parameter `t` from `π`, then sample the
+coordinates i.i.d. from `P t`, keeping `t` as the first coordinate of the sample space
+`T × (ℕ → α)`.
+
+Retaining the parameter is what makes this a *conditional* construction rather than only a mixture
+of i.i.d. laws: the sequence and its directing measure live on the same space, so the joint law of
+the two can be compared with the disintegration `ConditionallyIIDWith` demands. -/
+@[expose]
+def iidMixtureLaw (π : Measure T) (P : T → ProbabilityMeasure α) : Measure (T × (ℕ → α)) :=
+  π.bind fun t => (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))
+
+theorem iidMixtureLaw_def (π : Measure T) (P : T → ProbabilityMeasure α) :
+    iidMixtureLaw π P =
+      π.bind fun t => (Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α)) :=
+  rfl
+
+variable {π : Measure T} {P : T → ProbabilityMeasure α}
+
+/-- The canonical law is a probability measure. Measurability of `P` is needed, not decorative:
+`Measure.bind` against a non-measurable kernel is the zero measure. -/
+theorem isProbabilityMeasure_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    IsProbabilityMeasure (iidMixtureLaw π P) :=
+  MeasureTheory.isProbabilityMeasure_bind
+    (TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const P hP).aemeasurable
+    (.of_forall fun _ => inferInstance)
+
+/-- The parameter coordinate of the canonical law is distributed as `π`. -/
+theorem iidMixtureLaw_map_fst [IsProbabilityMeasure π] (hP : Measurable P) :
+    (iidMixtureLaw π P).map Prod.fst = π := by
+  have hfst : ∀ t : T,
+      ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map Prod.fst
+        = Measure.dirac t := fun _ => Measure.fst_prod
+  rw [iidMixtureLaw_def, TauCeti.MeasureTheory.map_bind
+    (TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const P hP).aemeasurable
+    measurable_fst]
+  simp_rw [hfst]
+  exact Measure.bind_dirac
+
+/-- The directing measure of the canonical law has the prescribed mixing law `π.map P`. -/
+theorem iidMixtureLaw_map_directing [IsProbabilityMeasure π] (hP : Measurable P) :
+    (iidMixtureLaw π P).map (fun ω => P ω.1) = π.map P := by
+  have hcomp : (fun ω : T × (ℕ → α) => P ω.1) = P ∘ Prod.fst := rfl
+  rw [hcomp, ← Measure.map_map hP measurable_fst, iidMixtureLaw_map_fst hP]
+
+/-- **The canonical process is conditionally i.i.d.** with the prescribed directing measure.
+
+Both sides of the joint-law disintegration collapse to the same `π`-mixture of
+`δ_{P t} ⊗ (P t)^{⊗ Fin m}`. On the left, naturality of `bind` pushes the selection
+`ω ↦ (P ω.1, (ω.2 ∘ k))` inside the mixture, where `Measure.dirac_prod` turns each fibre into a
+pushforward of `(P t)^{⊗ℕ}` and `Measure.map_infinitePi_infinitePi_of_inj` — this is where
+injectivity of `k` enters — reads off the block as `(P t)^{⊗ Fin m}`. On the right, the mixing
+kernel factors through the parameter, so `bind_map` reindexes the mixture over `π`. -/
+theorem conditionallyIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    ConditionallyIIDWith (iidMixtureLaw π P) (fun n ω => ω.2 n) (fun ω => P ω.1) := by
+  haveI := isProbabilityMeasure_iidMixtureLaw (π := π) hP
+  have hker := TauCeti.MeasureTheory.measurable_dirac_prod_infinitePi_const P hP
+  refine ConditionallyIIDWith.intro (hP.comp measurable_fst) fun m k hk => ?_
+  -- the joint kernel `Q ↦ δ_Q ⊗ Q^{⊗ Fin m}`, through which both sides factor
+  set g : ProbabilityMeasure α → Measure (ProbabilityMeasure α × (Fin m → α)) := fun Q =>
+    (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure with hg
+  have hgmeas : Measurable g :=
+    TauCeti.MeasureTheory.measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure
+      (fun Q : ProbabilityMeasure α => Q) measurable_id
+  have hsel : Measurable fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i)) :=
+    (hP.comp measurable_fst).prodMk
+      (measurable_pi_lambda _ fun i => (measurable_pi_apply (k i)).comp measurable_snd)
+  -- each fibre of the mixture selects its block out of a countable power
+  have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
+    measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
+  have hfib : ∀ t : T,
+      ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map
+        (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) = g (P t) := by
+    intro t
+    have hcomp : (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) ∘ Prod.mk t
+        = Prod.mk (P t) ∘ fun x : ℕ → α => fun i : Fin m => x (k i) := rfl
+    calc ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map
+          (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i)))
+        = ((Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map (Prod.mk t)).map
+            (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) := by
+          rw [Measure.dirac_prod]
+      _ = (Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map
+            (Prod.mk (P t) ∘ fun x : ℕ → α => fun i : Fin m => x (k i)) := by
+          rw [Measure.map_map hsel measurable_prodMk_left, hcomp]
+      _ = ((Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map
+            fun x : ℕ → α => fun i : Fin m => x (k i)).map (Prod.mk (P t)) :=
+          (Measure.map_map measurable_prodMk_left hblk).symm
+      _ = (Measure.pi fun _ : Fin m => (P t : Measure α)).map (Prod.mk (P t)) := by
+          rw [Measure.map_infinitePi_infinitePi_of_inj hk, Measure.infinitePi_eq_pi]
+      _ = g (P t) := by
+          simp only [hg]
+          rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
+  -- the left-hand side: push the selection through the mixture, fibre by fibre
+  have hleft : (iidMixtureLaw π P).map (fun ω => (P ω.1, fun i : Fin m => ω.2 (k i)))
+      = π.bind fun t => g (P t) := by
+    rw [iidMixtureLaw_def, TauCeti.MeasureTheory.map_bind hker.aemeasurable hsel]
+    simp_rw [hfib]
+  -- the right-hand side: the mixing kernel factors through the parameter
+  have hright : ((iidMixtureLaw π P).bind fun ω =>
+      (Measure.dirac (P ω.1)).prod (ProbabilityMeasure.pi fun _ : Fin m => P ω.1).toMeasure)
+      = π.bind fun t => g (P t) :=
+    calc (iidMixtureLaw π P).bind (fun ω => g (P ω.1))
+        = ((iidMixtureLaw π P).map fun ω => P ω.1).bind g :=
+          (TauCeti.MeasureTheory.bind_map (hP.comp measurable_fst).aemeasurable
+            hgmeas.aemeasurable).symm
+      _ = (π.map P).bind g := by rw [iidMixtureLaw_map_directing hP]
+      _ = π.bind fun t => g (P t) :=
+          TauCeti.MeasureTheory.bind_map hP.aemeasurable hgmeas.aemeasurable
+  rw [hleft, hright]
+
+/-- The canonical process is conditionally i.i.d. (existential form). -/
+theorem conditionallyIID_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    ConditionallyIID (iidMixtureLaw π P) fun n ω => ω.2 n :=
+  .of_directing (conditionallyIIDWith_iidMixtureLaw hP)
+
+/-- The prescribed family is in particular a mixing representative of the canonical process. -/
+theorem mixedIIDWith_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    MixedIIDWith (iidMixtureLaw π P) (fun n ω => ω.2 n) fun ω => P ω.1 :=
+  mixedIIDWith_of_conditionallyIIDWith (conditionallyIIDWith_iidMixtureLaw hP)
+
+/-- The canonical process is exchangeable. -/
+theorem exchangeable_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    Exchangeable (iidMixtureLaw π P) fun n ω => ω.2 n :=
+  (mixedIIDWith_iidMixtureLaw hP).exchangeable
+
+/-- The canonical process is contractable. -/
+theorem contractable_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    Contractable (iidMixtureLaw π P) fun n ω => ω.2 n :=
+  (mixedIIDWith_iidMixtureLaw hP).contractable
+
+/-- The path law of the canonical process is the `π.map P`-mixture of infinite product measures —
+the de Finetti mixture representation, here with the mixing law prescribed in advance. -/
+theorem pathLaw_iidMixtureLaw [IsProbabilityMeasure π] (hP : Measurable P) :
+    pathLaw (iidMixtureLaw π P) (fun n ω => ω.2 n)
+      = (π.map P).bind fun Q => Measure.infinitePi fun _ : ℕ => (Q : Measure α) := by
+  haveI := isProbabilityMeasure_iidMixtureLaw (π := π) hP
+  rw [← iidMixtureLaw_map_directing hP]
+  exact pathLaw_eq_bind_infinitePi_of_mixedIIDWith
+    (fun n => ((measurable_pi_apply n).comp measurable_snd).aemeasurable)
+    (mixedIIDWith_iidMixtureLaw hP)
+
+/-- **The construction is genuinely richer than i.i.d.** If the canonical process happens to have
+independent coordinates, then its mixing law `π.map P` is a point mass — so a nondegenerate `π.map
+P` produces an exchangeable sequence that is *not* independent.
+
+The coordinates are automatically identically distributed (the process is contractable), so
+independence would exhibit a constant mixing representative; uniqueness of the mixing law
+(`mixedIID_mixingLaw_unique`) then identifies `π.map P` with that constant's law. -/
+theorem exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw [IsProbabilityMeasure π]
+    (hP : Measurable P) (h : iIndepFun (fun n (ω : T × (ℕ → α)) => ω.2 n) (iidMixtureLaw π P)) :
+    ∃ Q : ProbabilityMeasure α, π.map P = Measure.dirac Q := by
+  haveI := isProbabilityMeasure_iidMixtureLaw (π := π) hP
+  have hX : ∀ n, AEMeasurable (fun ω : T × (ℕ → α) => ω.2 n) (iidMixtureLaw π P) :=
+    fun n => ((measurable_pi_apply n).comp measurable_snd).aemeasurable
+  have hident : ∀ i, IdentDistrib (fun ω : T × (ℕ → α) => ω.2 i)
+      (fun ω : T × (ℕ → α) => ω.2 0) (iidMixtureLaw π P) (iidMixtureLaw π P) :=
+    fun i => (contractable_iidMixtureLaw hP).identDistrib_coord (hX i) (hX 0)
+  refine ⟨⟨(iidMixtureLaw π P).map fun ω => ω.2 0,
+    Measure.isProbabilityMeasure_map (hX 0)⟩, ?_⟩
+  rw [← iidMixtureLaw_map_directing hP,
+    mixedIID_mixingLaw_unique hX (mixedIIDWith_iidMixtureLaw hP)
+      (MixedIIDWith.of_iIndepFun_identDistrib h hident),
+    Measure.map_const, measure_univ, one_smul]
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
This PR discharges the roadmap's coin-flipping worked example — "A `Bool`-valued sequence generated conditionally i.i.d. given a random `θ` (draw `θ`, then flip i.i.d. `κ (θ ω)`-coins) is exchangeable, with `ω ↦ κ (θ ω)` (`κ` a two-point kernel) as the directing measure — genuinely: the generating construction makes it a witness of `ConditionallyIIDWith`, not merely a mixing representative" (`TauCetiRoadmap/Exchangeability/README.md`, "Worked examples") — together with the general construction it needs, which is the Layer 6 directing-measure existence statement.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"bool-valued-sequence-conditionally-iid-given-random-theta"}-->

Introduce `iidMixtureLaw π P = ∫ δ_t ⊗ (P t)^{⊗ℕ} dπ(t)` on `T × (ℕ → α)`: draw a parameter from `π`, then sample the coordinates i.i.d. from `P t`, keeping the parameter as the first coordinate so that the sequence and its directing measure live on one space. Prove `conditionallyIIDWith_iidMixtureLaw`: the coordinate process is conditionally i.i.d. with directing measure `ω ↦ P ω.1`, in the sharp joint-law form rather than only the mixture identity. Record the prescribed mixing law `iidMixtureLaw_map_directing : (iidMixtureLaw π P).map (fun ω => P ω.1) = π.map P`, the parameter marginal, the mixture representation of the path law, and the Layer 0 consequences (`mixedIIDWith_`, `exchangeable_`, `contractable_iidMixtureLaw`). This is the converse of the landed uniqueness theorems: `mixedIID_mixingLaw_unique` and `conditionallyIID_ae_unique` say a directing measure is pinned down by the process, and this says every law of the form `π.map P` is realized. Before this file the only `ConditionallyIIDWith` witnesses on `main` were the constant one (plain i.i.d.) and the one extracted from contractability by the hard de Finetti theorem; nothing produced a prescribed nondegenerate directing measure.

Then instantiate at the two-point kernel `coinKernel p = Ber(true, false, p)` to obtain `conditionallyIIDWith_coinFlips`, `exchangeable_coinFlips`, and `contractable_coinFlips`. Keep the example honest about what it is showing: `exists_map_eq_dirac_of_iIndepFun_iidMixtureLaw` proves that independent coordinates force the mixing law to be a point mass, and `not_iIndepFun_coinFlips` specializes that to a bias drawn from a nondegenerate two-point law, so the constructed sequence is exchangeable without being i.i.d. and its directing measure is genuinely random rather than an a.e. constant. As the roadmap asks, the directing measure is the random probability measure `ω ↦ coinKernel ω.1`, not the bias `ω ↦ ω.1`.

Vendor no Mathlib infrastructure. Consume Mathlib directly: `Measure.infinitePi` with `Measure.map_infinitePi_infinitePi_of_inj` (which is what makes injectivity of the block selection the only hypothesis the block computation needs) and `Measure.infinitePi_eq_pi`, `Measure.dirac_prod`, `Measure.fst_prod`, `MeasureTheory.isProbabilityMeasure_bind`, `ProbabilityMeasure.measurable_fun_prod`, and `ProbabilityTheory.bernoulliMeasure` with `map_bernoulliMeasure'` for the two-point kernel — using Mathlib's Bernoulli measure keeps the example free of any parametrized-distribution API of its own, which is the independence the roadmap asks for. Reuse Tau Ceti's `measurable_infinitePi_const`, `measurable_dirac_prod_probabilityMeasure_pi_const_toMeasure`, `map_bind`/`bind_map`, `mixedIIDWith_of_conditionallyIIDWith`, `MixedIIDWith.of_iIndepFun_identDistrib`, `Contractable.identDistrib_coord`, `pathLaw_eq_bind_infinitePi_of_mixedIIDWith`, and `mixedIID_mixingLaw_unique`. Nothing is adapted from `cameronfreer/exchangeability`, whose `ConditionallyIID` names the weaker mixture identity. Kallenberg, *Probabilistic Symmetries and Invariance Principles* (2005), §1.1 eq. (2) is the reference for the disintegration being witnessed.

The one change to an existing file is `measurable_dirac_prod_infinitePi_const` in `TauCeti/MeasureTheory/Measure/ProductKernel.lean` (25 lines, with its module-overview bullet), the countable-power companion of the finite joint-kernel measurability already there, with the Dirac factor on the parameter rather than on the measure it selects; that is the Layer 1 product-kernel home for it. The two new modules are 244 and 170 lines.

`lake build` completes successfully across 5,832 jobs. `lake exe axioms` audits 15,355 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`. `lake exe module-system` reports all 862 modules opted in, and `scripts/lint-env.sh --changed-from origin/main` passes with no new violations.

🤖 Prepared with Claude Code
