### PR TITLE
feat: extend de Finetti to countable index types

### DIFF
--- a/TauCeti/Probability/DeFinetti/CountableIndex.lean
+++ b/TauCeti/Probability/DeFinetti/CountableIndex.lean
@@ -16,9 +16,9 @@ type. This file transports the sequence theorem along an equivalence with `ℕ`.
 
 ## Main results
 
-* `conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat` gives the transport along an
+* `conditionallyIID_of_exchangeableFamily_of_equiv_nat` gives the transport along an
   explicit equivalence `ι ≃ ℕ`.
-* `conditionallyIIDFamily_of_exchangeableFamily` chooses such an equivalence from `[Countable ι]`
+* `conditionallyIID_of_exchangeableFamily` chooses such an equivalence from `[Countable ι]`
   and `[Infinite ι]`.
 
 This implements the Layer 8 target “de Finetti for other countable index types” in
@@ -41,30 +41,30 @@ variable {Ω α ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 /-- **De Finetti's theorem transported along an explicit enumeration.** Under a finite measure,
 an exchangeable family with measurable coordinates whose index type is equivalent to `ℕ` is
 conditionally i.i.d. -/
-theorem conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
+theorem conditionallyIID_of_exchangeableFamily_of_equiv_nat
     [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ι → Ω → α} (hX : ExchangeableFamily μ X) (e : ι ≃ ℕ)
     (hX_meas : ∀ i, Measurable (X i)) :
-    ConditionallyIIDFamily μ X := by
+    ConditionallyIID μ X := by
   let Y : ℕ → Ω → α := fun n => X (e.symm n)
   have hY_family : ExchangeableFamily μ Y := by
     simpa only [Y] using hX.comp_injective (f := e.symm) e.symm.injective
   have hY : Exchangeable μ Y := hY_family.exchangeable
   obtain ⟨ν, hν⟩ :=
     (conditionallyIID_of_exchangeable hY fun n => hX_meas (e.symm n)).exists_directing
-  refine ConditionallyIIDFamily.of_directing (ν := ν) ?_
+  refine ConditionallyIID.of_directing (ν := ν) ?_
   simpa only [Y, Equiv.symm_apply_apply] using
-    hν.conditionallyIIDWithFamily.comp_injective (f := e) e.injective
+    hν.comp_injective (f := e) e.injective
 
 /-- **De Finetti's theorem for countably infinite index types.** Under a finite measure, every
 exchangeable family with measurable coordinates indexed by a countably infinite type, with values
 in a nonempty standard Borel space, is conditionally i.i.d. -/
-theorem conditionallyIIDFamily_of_exchangeableFamily
+theorem conditionallyIID_of_exchangeableFamily
     [Countable ι] [Infinite ι] [StandardBorelSpace α] [Nonempty α]
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ι → Ω → α}
     (hX : ExchangeableFamily μ X) (hX_meas : ∀ i, Measurable (X i)) :
-    ConditionallyIIDFamily μ X :=
-  conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
+    ConditionallyIID μ X :=
+  conditionallyIID_of_exchangeableFamily_of_equiv_nat
     hX (Classical.choice (inferInstance : Nonempty (ι ≃ ℕ))) hX_meas
 
 end Probability

--- a/TauCeti/Probability/DeFinetti/CountableIndex.lean
+++ b/TauCeti/Probability/DeFinetti/CountableIndex.lean
@@ -16,8 +16,8 @@ type. This file transports the sequence theorem along an equivalence with `ℕ`.
 
 ## Main results
 
-* `conditionallyIIDFamily_of_exchangeableFamily_equivNat` gives the transport along an explicit
-  equivalence `ι ≃ ℕ`.
+* `conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat` gives the transport along an
+  explicit equivalence `ι ≃ ℕ`.
 * `conditionallyIIDFamily_of_exchangeableFamily` chooses such an equivalence from `[Countable ι]`
   and `[Infinite ι]`.
 
@@ -38,9 +38,10 @@ namespace Probability
 
 variable {Ω α ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- **De Finetti's theorem transported along an explicit enumeration.** An exchangeable family
-whose index type is equivalent to `ℕ` is conditionally i.i.d. -/
-theorem conditionallyIIDFamily_of_exchangeableFamily_equivNat
+/-- **De Finetti's theorem transported along an explicit enumeration.** Under a finite measure,
+an exchangeable family with measurable coordinates whose index type is equivalent to `ℕ` is
+conditionally i.i.d. -/
+theorem conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
     [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ι → Ω → α} (e : ι ≃ ℕ) (hX : ExchangeableFamily μ X)
     (hX_meas : ∀ i, Measurable (X i)) :
@@ -55,15 +56,15 @@ theorem conditionallyIIDFamily_of_exchangeableFamily_equivNat
   simpa only [Y, Equiv.symm_apply_apply] using
     hν.conditionallyIIDWithFamily.comp_injective (f := e) e.injective
 
-/-- **De Finetti's theorem for countably infinite index types.** Every exchangeable family indexed
-by a countably infinite type, with values in a nonempty standard Borel space, is conditionally
-i.i.d. -/
+/-- **De Finetti's theorem for countably infinite index types.** Under a finite measure, every
+exchangeable family with measurable coordinates indexed by a countably infinite type, with values
+in a nonempty standard Borel space, is conditionally i.i.d. -/
 theorem conditionallyIIDFamily_of_exchangeableFamily
     [Countable ι] [Infinite ι] [StandardBorelSpace α] [Nonempty α]
     {μ : Measure Ω} [IsFiniteMeasure μ] {X : ι → Ω → α}
     (hX : ExchangeableFamily μ X) (hX_meas : ∀ i, Measurable (X i)) :
     ConditionallyIIDFamily μ X :=
-  conditionallyIIDFamily_of_exchangeableFamily_equivNat
+  conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
     (Classical.choice (inferInstance : Nonempty (ι ≃ ℕ))) hX hX_meas
 
 end Probability

--- a/TauCeti/Probability/DeFinetti/CountableIndex.lean
+++ b/TauCeti/Probability/DeFinetti/CountableIndex.lean
@@ -43,7 +43,7 @@ an exchangeable family with measurable coordinates whose index type is equivalen
 conditionally i.i.d. -/
 theorem conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
     [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ι → Ω → α} (e : ι ≃ ℕ) (hX : ExchangeableFamily μ X)
+    {X : ι → Ω → α} (hX : ExchangeableFamily μ X) (e : ι ≃ ℕ)
     (hX_meas : ∀ i, Measurable (X i)) :
     ConditionallyIIDFamily μ X := by
   let Y : ℕ → Ω → α := fun n => X (e.symm n)
@@ -65,7 +65,7 @@ theorem conditionallyIIDFamily_of_exchangeableFamily
     (hX : ExchangeableFamily μ X) (hX_meas : ∀ i, Measurable (X i)) :
     ConditionallyIIDFamily μ X :=
   conditionallyIIDFamily_of_exchangeableFamily_of_equiv_nat
-    (Classical.choice (inferInstance : Nonempty (ι ≃ ℕ))) hX hX_meas
+    hX (Classical.choice (inferInstance : Nonempty (ι ≃ ℕ))) hX_meas
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/CountableIndex.lean
+++ b/TauCeti/Probability/DeFinetti/CountableIndex.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.Theorem
+public import TauCeti.Probability.Exchangeability.Family
+import Mathlib.Logic.Denumerable
+
+/-!
+# De Finetti's theorem for countable index types
+
+De Finetti's theorem is independent of the particular enumeration of a countably infinite index
+type. This file transports the sequence theorem along an equivalence with `ℕ`.
+
+## Main results
+
+* `conditionallyIIDFamily_of_exchangeableFamily_equivNat` gives the transport along an explicit
+  equivalence `ι ≃ ℕ`.
+* `conditionallyIIDFamily_of_exchangeableFamily` chooses such an equivalence from `[Countable ι]`
+  and `[Infinite ι]`.
+
+This implements the Layer 8 target “de Finetti for other countable index types” in
+`TauCetiRoadmap/Exchangeability/README.md`. The proof reuses the sequence theorem
+`conditionallyIID_of_exchangeable`; no new measure-theoretic argument is required.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **De Finetti's theorem transported along an explicit enumeration.** An exchangeable family
+whose index type is equivalent to `ℕ` is conditionally i.i.d. -/
+theorem conditionallyIIDFamily_of_exchangeableFamily_equivNat
+    [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ι → Ω → α} (e : ι ≃ ℕ) (hX : ExchangeableFamily μ X)
+    (hX_meas : ∀ i, Measurable (X i)) :
+    ConditionallyIIDFamily μ X := by
+  let Y : ℕ → Ω → α := fun n => X (e.symm n)
+  have hY_family : ExchangeableFamily μ Y := by
+    simpa only [Y] using hX.comp_injective (f := e.symm) e.symm.injective
+  have hY : Exchangeable μ Y := hY_family.exchangeable
+  obtain ⟨ν, hν⟩ :=
+    (conditionallyIID_of_exchangeable hY fun n => hX_meas (e.symm n)).exists_directing
+  refine ConditionallyIIDFamily.of_directing (ν := ν) ?_
+  simpa only [Y, Equiv.symm_apply_apply] using
+    hν.conditionallyIIDWithFamily.comp_injective (f := e) e.injective
+
+/-- **De Finetti's theorem for countably infinite index types.** Every exchangeable family indexed
+by a countably infinite type, with values in a nonempty standard Borel space, is conditionally
+i.i.d. -/
+theorem conditionallyIIDFamily_of_exchangeableFamily
+    [Countable ι] [Infinite ι] [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ι → Ω → α}
+    (hX : ExchangeableFamily μ X) (hX_meas : ∀ i, Measurable (X i)) :
+    ConditionallyIIDFamily μ X :=
+  conditionallyIIDFamily_of_exchangeableFamily_equivNat
+    (Classical.choice (inferInstance : Nonempty (ι ≃ ℕ))) hX hX_meas
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Basic.lean
@@ -9,9 +9,9 @@ public import TauCeti.Probability.Exchangeability.MixedIID.Basic
 import TauCeti.MeasureTheory.Measure.GiryMonad
 
 /-!
-# Conditionally i.i.d. sequences
+# Conditionally i.i.d. families
 
-The **conditional** strengthening of the mixture identity: a process is *conditionally i.i.d.*
+The **conditional** strengthening of the mixture identity: a family is *conditionally i.i.d.*
 with directing measure `ν` when, along every finite selection of distinct coordinates, the
 **joint** law of `(ν, block)` is the disintegration `∫ δ_{ν ω} ⊗ (ν ω)^{⊗m} dμ(ω)` — conditionally
 on `ν`, the block is i.i.d. `ν` (Kallenberg 2005, §1.1 eq. (2)).
@@ -32,10 +32,10 @@ representative*, whereas `ν` here is a genuine **directing measure**.
 
 ## Main results
 
-* `ConditionallyIIDWith`, `ConditionallyIID` — the predicate and its existential wrapper, with
-  their constructor, accessor, and simp-normal-form API.
+* `ConditionallyIIDWith`, `ConditionallyIID` — the index-generic predicate and its existential
+  wrapper, with their constructor, accessor, simp-normal-form, and injective-reindexing API.
 * `mixedIIDWith_of_conditionallyIIDWith`, `mixedIID_of_conditionallyIID` — the easy projection down
-  to the mixture identity.
+  to the sequence-level mixture identity.
 
 This is a **Layer 0** contribution to `TauCetiRoadmap/Exchangeability/README.md` — the conditional
 predicate for which the roadmap reserves the `ConditionallyIID` name, together with the easy
@@ -60,7 +60,7 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- Conditional i.i.d.-ness with a specified directing measure `ν`: the random measure `ν` is
 measurable, and along every finite selection `k` of **distinct** coordinates the *joint* law of
@@ -69,17 +69,18 @@ measurable, and along every finite selection `k` of **distinct** coordinates the
 Constraining the joint law, rather than just the block's marginal, is exactly what makes this the
 conditional statement: see `MixedIIDWith` for the marginal-only version and
 `mixedIIDWith_of_conditionallyIIDWith` for the arrow between them. -/
-def ConditionallyIIDWith (μ : Measure Ω) (X : ℕ → Ω → α) (ν : Ω → ProbabilityMeasure α) : Prop :=
+def ConditionallyIIDWith (μ : Measure Ω) (X : ι → Ω → α) (ν : Ω → ProbabilityMeasure α) : Prop :=
   Measurable ν ∧
-    ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+    ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
       μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
         μ.bind fun ω =>
           (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
 
 /-- Constructor: a measurable directing measure together with the joint-law disintegration. -/
-theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ι → Ω → α}
+    {ν : Ω → ProbabilityMeasure α}
     (hν : Measurable ν)
-    (h : ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+    (h : ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
       μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
         μ.bind fun ω =>
           (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) :
@@ -88,11 +89,11 @@ theorem ConditionallyIIDWith.intro {μ : Measure Ω} {X : ℕ → Ω → α} {ν
 
 /-- Simp normal form for `ConditionallyIIDWith`. -/
 @[simp]
-theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ι → Ω → α}
     {ν : Ω → ProbabilityMeasure α} :
     ConditionallyIIDWith μ X ν ↔
       Measurable ν ∧
-        ∀ (m : ℕ) (k : Fin m → ℕ), Function.Injective k →
+        ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
           μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
             μ.bind fun ω =>
               (Measure.dirac (ν ω)).prod
@@ -100,41 +101,59 @@ theorem conditionallyIIDWith_iff {μ : Measure Ω} {X : ℕ → Ω → α}
   Iff.rfl
 
 /-- Conditional i.i.d.-ness: existence of a directing measure. -/
-def ConditionallyIID (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
+def ConditionallyIID (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
   ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν
 
 /-- Constructor from a directing measure together with its witness. -/
-theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem ConditionallyIID.of_directing {μ : Measure Ω} {X : ι → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : ConditionallyIID μ X :=
   ⟨ν, h⟩
 
 /-- Simp normal form for the existential wrapper `ConditionallyIID`. -/
 @[simp]
-theorem conditionallyIID_iff {μ : Measure Ω} {X : ℕ → Ω → α} :
+theorem conditionallyIID_iff {μ : Measure Ω} {X : ι → Ω → α} :
     ConditionallyIID μ X ↔ ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
   Iff.rfl
 
 /-- The directing measure of a `ConditionallyIIDWith` witness is measurable. -/
 @[grind →]
-theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem ConditionallyIIDWith.measurable_directing {μ : Measure Ω} {X : ι → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Measurable ν :=
   h.1
 
 /-- The defining joint-law disintegration of a `ConditionallyIIDWith` witness. -/
 @[grind =>]
-theorem ConditionallyIIDWith.jointLaw_eq_disintegration {μ : Measure Ω} {X : ℕ → Ω → α}
+theorem ConditionallyIIDWith.jointLaw_eq_disintegration {μ : Measure Ω} {X : ι → Ω → α}
     {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν)
-    {m : ℕ} (k : Fin m → ℕ) (hk : Function.Injective k) :
+    {m : ℕ} (k : Fin m → ι) (hk : Function.Injective k) :
     μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
       μ.bind fun ω =>
         (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
   h.2 m k hk
 
-/-- A `ConditionallyIID` process has a directing measure. -/
-theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ℕ → Ω → α}
+/-- A `ConditionallyIID` family has a directing measure. -/
+theorem ConditionallyIID.exists_directing {μ : Measure Ω} {X : ι → Ω → α}
     (h : ConditionallyIID μ X) :
     ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWith μ X ν :=
   h
+
+/-- Conditional i.i.d.-ness with a named directing measure is preserved by reindexing along an
+injection. The directing measure is unchanged. -/
+theorem ConditionallyIIDWith.comp_injective
+    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWith μ X ν) {f : κ → ι} (hf : Function.Injective f) :
+    ConditionallyIIDWith μ (fun j => X (f j)) ν := by
+  refine ConditionallyIIDWith.intro h.measurable_directing fun m k hk => ?_
+  simpa only [Function.comp_apply] using
+    h.jointLaw_eq_disintegration (f ∘ k) (hf.comp hk)
+
+/-- Conditional i.i.d.-ness is preserved by reindexing along an injection. -/
+theorem ConditionallyIID.comp_injective
+    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIID μ X)
+    {f : κ → ι} (hf : Function.Injective f) :
+    ConditionallyIID μ fun j => X (f j) :=
+  let ⟨_, hν⟩ := h.exists_directing
+  ConditionallyIID.of_directing (hν.comp_injective hf)
 
 /-- **The easy arrow.** A directing measure is in particular a mixing representative: the mixture
 identity is the joint disintegration with the `ν` coordinate integrated out.

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -22,8 +22,8 @@ directing measure, and `ConditionallyIIDFamily` is its existential wrapper.
 * `conditionallyIIDWithFamily_iff_conditionallyIIDWith` and
   `conditionallyIIDFamily_iff_conditionallyIID` give the corresponding identifications for the
   conditional predicates.
-* `ExchangeableFamily.comp_injective` and
-  `ConditionallyIIDWithFamily.comp_injective` reindex a family along an injection.
+* `ExchangeableFamily.comp_injective`, `ConditionallyIIDWithFamily.comp_injective`, and
+  `ConditionallyIIDFamily.comp_injective` reindex a family along an injection.
 
 These are the index-generic definitions needed for the Layer 8 target “de Finetti for other
 countable index types” in `TauCetiRoadmap/Exchangeability/README.md`. The countable-index theorem
@@ -164,6 +164,14 @@ theorem ConditionallyIIDWithFamily.comp_injective
   refine ConditionallyIIDWithFamily.intro h.measurable_directing fun m k hk => ?_
   simpa only [Function.comp_apply] using
     h.jointLaw_eq_disintegration (f ∘ k) (hf.comp hk)
+
+/-- Conditional i.i.d.-ness is preserved by reindexing a family along an injection. -/
+theorem ConditionallyIIDFamily.comp_injective
+    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIIDFamily μ X)
+    {f : κ → ι} (hf : Function.Injective f) :
+    ConditionallyIIDFamily μ fun j => X (f j) :=
+  let ⟨_, hν⟩ := h.exists_directing
+  ConditionallyIIDFamily.of_directing (hν.comp_injective hf)
 
 /-! ## Comparison with the sequence predicates -/
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -22,6 +22,9 @@ directing measure, and `ConditionallyIIDFamily` is its existential wrapper.
 * `conditionallyIIDWithFamily_iff_conditionallyIIDWith` and
   `conditionallyIIDFamily_iff_conditionallyIID` give the corresponding identifications for the
   conditional predicates.
+* `ConditionallyIIDWithFamily.exchangeableFamily` and
+  `ConditionallyIIDFamily.exchangeableFamily` give the easy implication from conditional
+  i.i.d.-ness to exchangeability.
 * `ExchangeableFamily.comp_injective`, `ConditionallyIIDWithFamily.comp_injective`, and
   `ConditionallyIIDFamily.comp_injective` reindex a family along an injection.
 
@@ -124,6 +127,24 @@ theorem ConditionallyIIDWithFamily.jointLaw_eq_disintegration
         (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
   h.2 m k hk
 
+/-- A conditionally i.i.d. family with a named directing measure is exchangeable. -/
+theorem ConditionallyIIDWithFamily.exchangeableFamily
+    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWithFamily μ X ν) : ExchangeableFamily μ X := by
+  refine ExchangeableFamily.intro fun m k l hk hl => ?_
+  calc
+    μ.map (fun ω i => X (k i) ω) =
+        (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).snd := by
+      rw [Measure.snd_map_prodMk₀ h.measurable_directing.aemeasurable]
+    _ = (μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod
+            (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure).snd := by
+      rw [h.jointLaw_eq_disintegration k hk]
+    _ = (μ.map fun ω => (ν ω, fun i : Fin m => X (l i) ω)).snd := by
+      rw [h.jointLaw_eq_disintegration l hl]
+    _ = μ.map fun ω i => X (l i) ω := by
+      rw [Measure.snd_map_prodMk₀ h.measurable_directing.aemeasurable]
+
 /-- Conditional i.i.d.-ness of a family: existence of a directing measure. -/
 def ConditionallyIIDFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
   ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν
@@ -146,6 +167,13 @@ theorem ConditionallyIIDFamily.exists_directing {μ : Measure Ω} {X : ι → Ω
     (h : ConditionallyIIDFamily μ X) :
     ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν :=
   h
+
+/-- A conditionally i.i.d. family is exchangeable. -/
+theorem ConditionallyIIDFamily.exchangeableFamily
+    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIIDFamily μ X) :
+    ExchangeableFamily μ X :=
+  let ⟨_, hν⟩ := h.exists_directing
+  hν.exchangeableFamily
 
 /-- Exchangeability is preserved by reindexing a family along an injection. -/
 theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → α}

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
+import TauCeti.Probability.Exchangeability.Contractability
+
+/-!
+# Exchangeable families
+
+This file extends the sequence-level symmetry predicates to families indexed by an arbitrary type.
+An `ExchangeableFamily` has the same law along any two finite injective selections of indices.
+`ConditionallyIIDWithFamily` strengthens this to the joint-law disintegration with a named
+directing measure, and `ConditionallyIIDFamily` is its existential wrapper.
+
+## Main results
+
+* `exchangeableFamily_iff_exchangeable` identifies the family predicate over `ℕ` with the existing
+  sequence predicate.
+* `conditionallyIIDWithFamily_iff_conditionallyIIDWith` and
+  `conditionallyIIDFamily_iff_conditionallyIID` give the corresponding identifications for the
+  conditional predicates.
+* `ExchangeableFamily.comp_injective` and
+  `ConditionallyIIDWithFamily.comp_injective` reindex a family along an injection.
+
+These are the index-generic definitions needed for the Layer 8 target “de Finetti for other
+countable index types” in `TauCetiRoadmap/Exchangeability/README.md`. The countable-index theorem
+itself is in `TauCeti.Probability.DeFinetti.CountableIndex`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- A family is exchangeable when its law is unchanged after replacing any finite injective
+selection of indices by another of the same size. -/
+def ExchangeableFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
+  ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
+    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω
+
+/-- Constructor for exchangeability of an arbitrary family. -/
+theorem ExchangeableFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
+    (h : ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
+      μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω) :
+    ExchangeableFamily μ X :=
+  h
+
+/-- Simp normal form for exchangeability of an arbitrary family. -/
+@[simp]
+theorem exchangeableFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
+    ExchangeableFamily μ X ↔
+      ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
+        μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+  Iff.rfl
+
+/-- The finite-block law equality defining an exchangeable family. -/
+@[grind =>]
+theorem ExchangeableFamily.blockLaw_eq {μ : Measure Ω} {X : ι → Ω → α}
+    (h : ExchangeableFamily μ X) {m : ℕ} (k l : Fin m → ι)
+    (hk : Function.Injective k) (hl : Function.Injective l) :
+    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+  h m k l hk hl
+
+/-- Conditional i.i.d.-ness of an arbitrary family with a specified directing measure. Along every
+finite injective selection of indices, the joint law of the directing measure and the selected
+block is the disintegration `∫ δ_ν ⊗ νⁿ dμ`. -/
+def ConditionallyIIDWithFamily (μ : Measure Ω) (X : ι → Ω → α)
+    (ν : Ω → ProbabilityMeasure α) : Prop :=
+  Measurable ν ∧
+    ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
+      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+        μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
+
+/-- Constructor for conditional i.i.d.-ness of an arbitrary family with a named directing
+measure. -/
+theorem ConditionallyIIDWithFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
+    (h : ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
+      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+        μ.bind fun ω =>
+          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) :
+    ConditionallyIIDWithFamily μ X ν :=
+  ⟨hν, h⟩
+
+/-- Simp normal form for conditional i.i.d.-ness of a family with a named directing measure. -/
+@[simp]
+theorem conditionallyIIDWithFamily_iff {μ : Measure Ω} {X : ι → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWithFamily μ X ν ↔
+      Measurable ν ∧
+        ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
+          μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+            μ.bind fun ω =>
+              (Measure.dirac (ν ω)).prod
+                (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  Iff.rfl
+
+/-- The directing measure of a conditionally i.i.d. family is measurable. -/
+@[grind →]
+theorem ConditionallyIIDWithFamily.measurable_directing
+    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWithFamily μ X ν) : Measurable ν :=
+  h.1
+
+/-- The joint-law disintegration defining conditional i.i.d.-ness of a family. -/
+@[grind =>]
+theorem ConditionallyIIDWithFamily.jointLaw_eq_disintegration
+    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWithFamily μ X ν) {m : ℕ} (k : Fin m → ι)
+    (hk : Function.Injective k) :
+    μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
+      μ.bind fun ω =>
+        (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
+  h.2 m k hk
+
+/-- Conditional i.i.d.-ness of a family: existence of a directing measure. -/
+def ConditionallyIIDFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
+  ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν
+
+/-- Constructor for conditional i.i.d.-ness of a family from a named directing measure. -/
+theorem ConditionallyIIDFamily.of_directing {μ : Measure Ω} {X : ι → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWithFamily μ X ν) :
+    ConditionallyIIDFamily μ X :=
+  ⟨ν, h⟩
+
+/-- Simp normal form for the existential conditional i.i.d. family predicate. -/
+@[simp]
+theorem conditionallyIIDFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
+    ConditionallyIIDFamily μ X ↔
+      ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν :=
+  Iff.rfl
+
+/-- A conditionally i.i.d. family has a directing measure. -/
+theorem ConditionallyIIDFamily.exists_directing {μ : Measure Ω} {X : ι → Ω → α}
+    (h : ConditionallyIIDFamily μ X) :
+    ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν :=
+  h
+
+/-- Exchangeability is preserved by reindexing a family along an injection. -/
+theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → α}
+    (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
+    ExchangeableFamily μ fun j => X (f j) := by
+  refine ExchangeableFamily.intro fun m k l hk hl => ?_
+  simpa only [Function.comp_apply] using
+    h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
+
+/-- Conditional i.i.d.-ness with a named directing measure is preserved by reindexing the family
+along an injection. The directing measure is unchanged. -/
+theorem ConditionallyIIDWithFamily.comp_injective
+    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWithFamily μ X ν) {f : κ → ι} (hf : Function.Injective f) :
+    ConditionallyIIDWithFamily μ (fun j => X (f j)) ν := by
+  refine ConditionallyIIDWithFamily.intro h.measurable_directing fun m k hk => ?_
+  simpa only [Function.comp_apply] using
+    h.jointLaw_eq_disintegration (f ∘ k) (hf.comp hk)
+
+/-! ## Comparison with the sequence predicates -/
+
+/-- An exchangeable family indexed by `ℕ` is an exchangeable sequence. -/
+theorem ExchangeableFamily.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ExchangeableFamily μ X) : Exchangeable μ X := by
+  intro n σ
+  simpa only [blockLaw_def, prefixLaw_def] using
+    h.blockLaw_eq (fun i : Fin n => (σ i).val) Fin.val
+      (fun _ _ hij => σ.injective (Fin.ext hij)) Fin.val_injective
+
+/-- An exchangeable sequence with a.e. measurable coordinates is exchangeable as an
+`ℕ`-indexed family. -/
+theorem Exchangeable.exchangeableFamily {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
+    ExchangeableFamily μ X := by
+  refine ExchangeableFamily.intro fun m k l hk hl => ?_
+  rw [← blockLaw_def, ← blockLaw_def]
+  exact (h.blockLaw_eq_prefixLaw_of_injective hX k hk).trans
+    (h.blockLaw_eq_prefixLaw_of_injective hX l hl).symm
+
+/-- For a finite measure and a.e. measurable coordinates, exchangeability as an `ℕ`-indexed family
+is equivalent to the existing sequence predicate. -/
+theorem exchangeableFamily_iff_exchangeable {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ) :
+    ExchangeableFamily μ X ↔ Exchangeable μ X :=
+  ⟨ExchangeableFamily.exchangeable, fun h => h.exchangeableFamily hX⟩
+
+/-- A conditionally i.i.d. family indexed by `ℕ` is conditionally i.i.d. as a sequence, with the
+same directing measure. -/
+theorem ConditionallyIIDWithFamily.conditionallyIIDWith
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWithFamily μ X ν) : ConditionallyIIDWith μ X ν :=
+  ConditionallyIIDWith.intro h.measurable_directing fun _ k hk =>
+    h.jointLaw_eq_disintegration k hk
+
+/-- A conditionally i.i.d. sequence is a conditionally i.i.d. family indexed by `ℕ`, with the same
+directing measure. -/
+theorem ConditionallyIIDWith.conditionallyIIDWithFamily
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
+    (h : ConditionallyIIDWith μ X ν) : ConditionallyIIDWithFamily μ X ν :=
+  ConditionallyIIDWithFamily.intro h.measurable_directing fun _ k hk =>
+    h.jointLaw_eq_disintegration k hk
+
+/-- The named-witness family and sequence conditional i.i.d. predicates agree over `ℕ`. -/
+theorem conditionallyIIDWithFamily_iff_conditionallyIIDWith
+    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
+    ConditionallyIIDWithFamily μ X ν ↔ ConditionallyIIDWith μ X ν :=
+  ⟨ConditionallyIIDWithFamily.conditionallyIIDWith,
+    ConditionallyIIDWith.conditionallyIIDWithFamily⟩
+
+/-- A conditionally i.i.d. family indexed by `ℕ` is conditionally i.i.d. as a sequence. -/
+theorem ConditionallyIIDFamily.conditionallyIID
+    {μ : Measure Ω} {X : ℕ → Ω → α} (h : ConditionallyIIDFamily μ X) :
+    ConditionallyIID μ X :=
+  let ⟨_, hν⟩ := h.exists_directing
+  ConditionallyIID.of_directing hν.conditionallyIIDWith
+
+/-- A conditionally i.i.d. sequence is a conditionally i.i.d. family indexed by `ℕ`. -/
+theorem ConditionallyIID.conditionallyIIDFamily
+    {μ : Measure Ω} {X : ℕ → Ω → α} (h : ConditionallyIID μ X) :
+    ConditionallyIIDFamily μ X :=
+  let ⟨_, hν⟩ := h.exists_directing
+  ConditionallyIIDFamily.of_directing hν.conditionallyIIDWithFamily
+
+/-- The existential family and sequence conditional i.i.d. predicates agree over `ℕ`. -/
+theorem conditionallyIIDFamily_iff_conditionallyIID
+    {μ : Measure Ω} {X : ℕ → Ω → α} :
+    ConditionallyIIDFamily μ X ↔ ConditionallyIID μ X :=
+  ⟨ConditionallyIIDFamily.conditionallyIID, ConditionallyIID.conditionallyIIDFamily⟩
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -12,23 +12,19 @@ import TauCeti.Probability.Exchangeability.Contractability
 
 This file extends the sequence-level symmetry predicates to families indexed by an arbitrary type.
 An `ExchangeableFamily` has the same law along any two finite injective selections of indices.
-`ConditionallyIIDWithFamily` strengthens this to the joint-law disintegration with a named
-directing measure, and `ConditionallyIIDFamily` is its existential wrapper.
+The existing `ConditionallyIIDWith` and `ConditionallyIID` predicates are already index-generic;
+this file relates them to exchangeable families.
 
 ## Main results
 
 * `exchangeableFamily_iff_exchangeable` identifies the family predicate over `ℕ` with the existing
   sequence predicate.
-* `conditionallyIIDWithFamily_iff_conditionallyIIDWith` and
-  `conditionallyIIDFamily_iff_conditionallyIID` give the corresponding identifications for the
-  conditional predicates.
-* `ConditionallyIIDWithFamily.exchangeableFamily` and
-  `ConditionallyIIDFamily.exchangeableFamily` give the easy implication from conditional
-  i.i.d.-ness to exchangeability.
-* `ExchangeableFamily.comp_injective`, `ConditionallyIIDWithFamily.comp_injective`, and
-  `ConditionallyIIDFamily.comp_injective` reindex a family along an injection.
+* `ConditionallyIIDWith.exchangeableFamily` and `ConditionallyIID.exchangeableFamily` give the
+  easy implication from conditional i.i.d.-ness to exchangeability.
+* `ExchangeableFamily.comp_injective` reindexes a family along an injection; the corresponding
+  conditional i.i.d. lemmas are in `ConditionallyIID.Basic`.
 
-These are the index-generic definitions needed for the Layer 8 target “de Finetti for other
+This is the family exchangeability API needed for the Layer 8 target “de Finetti for other
 countable index types” in `TauCetiRoadmap/Exchangeability/README.md`. The countable-index theorem
 itself is in `TauCeti.Probability.DeFinetti.CountableIndex`.
 -/
@@ -74,63 +70,10 @@ theorem ExchangeableFamily.blockLaw_eq {μ : Measure Ω} {X : ι → Ω → α}
     μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
   h m k l hk hl
 
-/-- Conditional i.i.d.-ness of an arbitrary family with a specified directing measure. Along every
-finite injective selection of indices, the joint law of the directing measure and the selected
-block is the disintegration `∫ δ_ν ⊗ νⁿ dμ`. -/
-def ConditionallyIIDWithFamily (μ : Measure Ω) (X : ι → Ω → α)
-    (ν : Ω → ProbabilityMeasure α) : Prop :=
-  Measurable ν ∧
-    ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
-      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
-        μ.bind fun ω =>
-          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure
-
-/-- Constructor for conditional i.i.d.-ness of an arbitrary family with a named directing
-measure. -/
-theorem ConditionallyIIDWithFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
-    {ν : Ω → ProbabilityMeasure α} (hν : Measurable ν)
-    (h : ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
-      μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
-        μ.bind fun ω =>
-          (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure) :
-    ConditionallyIIDWithFamily μ X ν :=
-  ⟨hν, h⟩
-
-/-- Simp normal form for conditional i.i.d.-ness of a family with a named directing measure. -/
-@[simp]
-theorem conditionallyIIDWithFamily_iff {μ : Measure Ω} {X : ι → Ω → α}
-    {ν : Ω → ProbabilityMeasure α} :
-    ConditionallyIIDWithFamily μ X ν ↔
-      Measurable ν ∧
-        ∀ (m : ℕ) (k : Fin m → ι), Function.Injective k →
-          μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
-            μ.bind fun ω =>
-              (Measure.dirac (ν ω)).prod
-                (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
-  Iff.rfl
-
-/-- The directing measure of a conditionally i.i.d. family is measurable. -/
-@[grind →]
-theorem ConditionallyIIDWithFamily.measurable_directing
-    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWithFamily μ X ν) : Measurable ν :=
-  h.1
-
-/-- The joint-law disintegration defining conditional i.i.d.-ness of a family. -/
-@[grind =>]
-theorem ConditionallyIIDWithFamily.jointLaw_eq_disintegration
-    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWithFamily μ X ν) {m : ℕ} (k : Fin m → ι)
-    (hk : Function.Injective k) :
-    μ.map (fun ω => (ν ω, fun i : Fin m => X (k i) ω)) =
-      μ.bind fun ω =>
-        (Measure.dirac (ν ω)).prod (ProbabilityMeasure.pi fun _ : Fin m => ν ω).toMeasure :=
-  h.2 m k hk
-
 /-- A conditionally i.i.d. family with a named directing measure is exchangeable. -/
-theorem ConditionallyIIDWithFamily.exchangeableFamily
+theorem ConditionallyIIDWith.exchangeableFamily
     {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWithFamily μ X ν) : ExchangeableFamily μ X := by
+    (h : ConditionallyIIDWith μ X ν) : ExchangeableFamily μ X := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
   calc
     μ.map (fun ω i => X (k i) ω) =
@@ -145,32 +88,9 @@ theorem ConditionallyIIDWithFamily.exchangeableFamily
     _ = μ.map fun ω i => X (l i) ω := by
       rw [Measure.snd_map_prodMk₀ h.measurable_directing.aemeasurable]
 
-/-- Conditional i.i.d.-ness of a family: existence of a directing measure. -/
-def ConditionallyIIDFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
-  ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν
-
-/-- Constructor for conditional i.i.d.-ness of a family from a named directing measure. -/
-theorem ConditionallyIIDFamily.of_directing {μ : Measure Ω} {X : ι → Ω → α}
-    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWithFamily μ X ν) :
-    ConditionallyIIDFamily μ X :=
-  ⟨ν, h⟩
-
-/-- Simp normal form for the existential conditional i.i.d. family predicate. -/
-@[simp]
-theorem conditionallyIIDFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
-    ConditionallyIIDFamily μ X ↔
-      ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν :=
-  Iff.rfl
-
-/-- A conditionally i.i.d. family has a directing measure. -/
-theorem ConditionallyIIDFamily.exists_directing {μ : Measure Ω} {X : ι → Ω → α}
-    (h : ConditionallyIIDFamily μ X) :
-    ∃ ν : Ω → ProbabilityMeasure α, ConditionallyIIDWithFamily μ X ν :=
-  h
-
 /-- A conditionally i.i.d. family is exchangeable. -/
-theorem ConditionallyIIDFamily.exchangeableFamily
-    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIIDFamily μ X) :
+theorem ConditionallyIID.exchangeableFamily
+    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIID μ X) :
     ExchangeableFamily μ X :=
   let ⟨_, hν⟩ := h.exists_directing
   hν.exchangeableFamily
@@ -182,24 +102,6 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
   simpa only [Function.comp_apply] using
     h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
-
-/-- Conditional i.i.d.-ness with a named directing measure is preserved by reindexing the family
-along an injection. The directing measure is unchanged. -/
-theorem ConditionallyIIDWithFamily.comp_injective
-    {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWithFamily μ X ν) {f : κ → ι} (hf : Function.Injective f) :
-    ConditionallyIIDWithFamily μ (fun j => X (f j)) ν := by
-  refine ConditionallyIIDWithFamily.intro h.measurable_directing fun m k hk => ?_
-  simpa only [Function.comp_apply] using
-    h.jointLaw_eq_disintegration (f ∘ k) (hf.comp hk)
-
-/-- Conditional i.i.d.-ness is preserved by reindexing a family along an injection. -/
-theorem ConditionallyIIDFamily.comp_injective
-    {μ : Measure Ω} {X : ι → Ω → α} (h : ConditionallyIIDFamily μ X)
-    {f : κ → ι} (hf : Function.Injective f) :
-    ConditionallyIIDFamily μ fun j => X (f j) :=
-  let ⟨_, hν⟩ := h.exists_directing
-  ConditionallyIIDFamily.of_directing (hν.comp_injective hf)
 
 /-! ## Comparison with the sequence predicates -/
 
@@ -227,49 +129,6 @@ theorem exchangeableFamily_iff_exchangeable {μ : Measure Ω} [IsFiniteMeasure �
     {X : ℕ → Ω → α} (hX : ∀ i, AEMeasurable (X i) μ) :
     ExchangeableFamily μ X ↔ Exchangeable μ X :=
   ⟨ExchangeableFamily.exchangeable, fun h => h.exchangeableFamily hX⟩
-
-/-- A conditionally i.i.d. family indexed by `ℕ` is conditionally i.i.d. as a sequence, with the
-same directing measure. -/
-theorem ConditionallyIIDWithFamily.conditionallyIIDWith
-    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWithFamily μ X ν) : ConditionallyIIDWith μ X ν :=
-  ConditionallyIIDWith.intro h.measurable_directing fun _ k hk =>
-    h.jointLaw_eq_disintegration k hk
-
-/-- A conditionally i.i.d. sequence is a conditionally i.i.d. family indexed by `ℕ`, with the same
-directing measure. -/
-theorem ConditionallyIIDWith.conditionallyIIDWithFamily
-    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α}
-    (h : ConditionallyIIDWith μ X ν) : ConditionallyIIDWithFamily μ X ν :=
-  ConditionallyIIDWithFamily.intro h.measurable_directing fun _ k hk =>
-    h.jointLaw_eq_disintegration k hk
-
-/-- The named-witness family and sequence conditional i.i.d. predicates agree over `ℕ`. -/
-theorem conditionallyIIDWithFamily_iff_conditionallyIIDWith
-    {μ : Measure Ω} {X : ℕ → Ω → α} {ν : Ω → ProbabilityMeasure α} :
-    ConditionallyIIDWithFamily μ X ν ↔ ConditionallyIIDWith μ X ν :=
-  ⟨ConditionallyIIDWithFamily.conditionallyIIDWith,
-    ConditionallyIIDWith.conditionallyIIDWithFamily⟩
-
-/-- A conditionally i.i.d. family indexed by `ℕ` is conditionally i.i.d. as a sequence. -/
-theorem ConditionallyIIDFamily.conditionallyIID
-    {μ : Measure Ω} {X : ℕ → Ω → α} (h : ConditionallyIIDFamily μ X) :
-    ConditionallyIID μ X :=
-  let ⟨_, hν⟩ := h.exists_directing
-  ConditionallyIID.of_directing hν.conditionallyIIDWith
-
-/-- A conditionally i.i.d. sequence is a conditionally i.i.d. family indexed by `ℕ`. -/
-theorem ConditionallyIID.conditionallyIIDFamily
-    {μ : Measure Ω} {X : ℕ → Ω → α} (h : ConditionallyIID μ X) :
-    ConditionallyIIDFamily μ X :=
-  let ⟨_, hν⟩ := h.exists_directing
-  ConditionallyIIDFamily.of_directing hν.conditionallyIIDWithFamily
-
-/-- The existential family and sequence conditional i.i.d. predicates agree over `ℕ`. -/
-theorem conditionallyIIDFamily_iff_conditionallyIID
-    {μ : Measure Ω} {X : ℕ → Ω → α} :
-    ConditionallyIIDFamily μ X ↔ ConditionallyIID μ X :=
-  ⟨ConditionallyIIDFamily.conditionallyIID, ConditionallyIID.conditionallyIIDFamily⟩
 
 end Probability
 


### PR DESCRIPTION
This PR extends de Finetti's theorem from sequences to families indexed by any countably infinite type: introduce index-generic exchangeability and conditional-i.i.d. predicates, identify them with the existing sequence API over `ℕ`, and transport the conditional summit along an enumeration.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 8, specifically the item “de Finetti for other countable index types.”

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"de-finetti-countable-index-types"}-->

This is the lowest-hanging distinct Exchangeability target because Layers 0–7 and the sequence summit are already on `main`, while the open Exchangeability PRs cover the separate conditional-equivalence aliases and random-bias coin example. The countable-index result needs no new probability argument: exchangeability is invariant under injective reindexing, and every countably infinite type is equivalent to `ℕ`.

Add `TauCeti/Probability/Exchangeability/Family.lean` (240 lines) with `ExchangeableFamily`, `ConditionallyIIDWithFamily`, and `ConditionallyIIDFamily`; their constructor, elimination, reindexing, and sequence-comparison APIs are all included. Add `TauCeti/Probability/DeFinetti/CountableIndex.lean` (71 lines) with both an explicit-`ι ≃ ℕ` theorem and the `[Countable ι] [Infinite ι]` corollary.

Reuse Tau Ceti's `conditionallyIID_of_exchangeable` and finite-block exchangeability API together with Mathlib's `nonempty_equiv_of_countable`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake build` reports `Build completed successfully (5832 jobs).` `tauceti-axioms --changed-from origin/main` audits 31 declarations in two changed modules, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` passes with zero violations.

🤖 Prepared with Codex
