### PR TITLE
chore: put the copyright header before `module`, and add the one missing header

### DIFF
--- a/TauCeti/Analysis/Complex/BranchLogRoot.lean
+++ b/TauCeti/Analysis/Complex/BranchLogRoot.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.Complex.BranchLogRoot
 public import Mathlib.Analysis.Calculus.FDeriv.Defs
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv

--- a/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
+++ b/TauCeti/Analysis/Complex/Conformal/DiscInjection.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.Complex.BranchLogRoot
 import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 import TauCeti.Analysis.Complex.Conformal.Moebius

--- a/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ExtremalFamily.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.Complex.Conformal.DiscInjection
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 import TauCeti.Analysis.Complex.Conformal.Hurwitz

--- a/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ImageSimplyConnected.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.Complex.OpenMapping
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
 import Mathlib.Topology.Homeomorph.Lemmas

--- a/TauCeti/Analysis/Complex/Conformal/Koebe.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Koebe.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.Complex.Conformal.ExtremalFamily
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 import TauCeti.Analysis.Complex.BranchLogRoot

--- a/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
+++ b/TauCeti/Analysis/Complex/Conformal/RiemannMapping/Existence.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.Complex.Conformal.Koebe
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 import TauCeti.Analysis.Complex.Conformal.InverseFunction

--- a/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Schwarz.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.Complex.Schwarz
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 
 /-!

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 public import Mathlib.MeasureTheory.Function.L2Space

--- a/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.AEEqOfIntegral
 public import Mathlib.MeasureTheory.Function.L2Space

--- a/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
+++ b/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.InnerProductSpace.WeightedOrthogonalBasis
 public import TauCeti.Probability.Moments.VanishingMoments
 public import Mathlib.Algebra.Polynomial.Sequence

--- a/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
+++ b/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Basic.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.Analysis.Calculus.ContDiff.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv
 public import Mathlib.Analysis.SpecialFunctions.Sqrt

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.Analysis.Fourier.FourierTransformDeriv
 public import Mathlib.Analysis.SpecialFunctions.Gaussian.FourierTransform
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Ladder

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Orthonormal
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Ladder.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Ladder.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.MemLp
 
 /-!

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/MemLp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Basic
 public import TauCeti.Probability.Distributions.Gaussian.PolynomialMemLp
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.Orthonormal
 public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Lp

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Oscillator.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Oscillator.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Ladder
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/PiBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/PiBasis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.InnerProductSpace.L2.Pi
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.HilbertBasis
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Orthogonality.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Orthogonality.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.Calculus.Deriv.Pow
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/HilbertBasis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.InnerProductSpace.l2Space
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Span
 public import TauCeti.Probability.Moments.VanishingMoments

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Moments.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Orthogonality
 import TauCeti.MeasureTheory.Function.PolynomialMemLp
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Moments
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
 import TauCeti.RingTheory.Polynomial.Chebyshev.Basis

--- a/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedMemLp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 
 /-!

--- a/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
+++ b/TauCeti/MeasureTheory/Function/BoundedSupportExponential.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.Analysis.RCLike.Basic
 public import Mathlib.Analysis.SpecialFunctions.Exp
 public import Mathlib.MeasureTheory.Function.L1Space.Integrable

--- a/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
+++ b/TauCeti/MeasureTheory/Function/PolynomialMemLp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.Topology.Algebra.Polynomial
 

--- a/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
+++ b/TauCeti/MeasureTheory/Function/WeightL2Isometry.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Function.L2Space
 public import Mathlib.MeasureTheory.Measure.WithDensity
 import Mathlib.MeasureTheory.Function.SpecialFunctions.Basic

--- a/TauCeti/MeasureTheory/Integral/PiSystem.lean
+++ b/TauCeti/MeasureTheory/Integral/PiSystem.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Integral.Bochner.Set
 public import Mathlib.MeasureTheory.PiSystem
 

--- a/TauCeti/MeasureTheory/Integral/Prod.lean
+++ b/TauCeti/MeasureTheory/Integral/Prod.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Integral.Prod
 public import TauCeti.MeasureTheory.Integral.PiSystem
 

--- a/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/HermiteMemLp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
 public import Mathlib.Analysis.RCLike.Basic
 public import TauCeti.Probability.Distributions.Gaussian.PolynomialMemLp

--- a/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/PolynomialMemLp.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Probability.Distributions.Gaussian.Real
 public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 

--- a/TauCeti/Probability/Moments/CompactDeterminacy.lean
+++ b/TauCeti/Probability/Moments/CompactDeterminacy.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 import Mathlib.Algebra.Group.Submonoid.Finsupp
 import Mathlib.MeasureTheory.Measure.FiniteMeasureExt

--- a/TauCeti/Probability/Moments/Determinacy.lean
+++ b/TauCeti/Probability/Moments/Determinacy.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Probability.Moments.ComplexMGF
 public import Mathlib.MeasureTheory.Measure.CharacteristicFunction.Basic
 public import Mathlib.Analysis.Analytic.Order

--- a/TauCeti/Probability/Moments/VanishingMoments.lean
+++ b/TauCeti/Probability/Moments/VanishingMoments.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 public import TauCeti.Probability.Moments.Determinacy
 public import Mathlib.Analysis.RCLike.Basic

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -1,3 +1,7 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
 module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassSum.Basis

--- a/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
+++ b/TauCeti/RingTheory/Polynomial/Chebyshev/Basis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Codex
 -/
+module
+
 public import Mathlib.RingTheory.Polynomial.Chebyshev
 
 /-!

--- a/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/Derivative.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Algebra.Polynomial.AlgebraMap
 public import Mathlib.RingTheory.Polynomial.Hermite.Basic
 

--- a/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
+++ b/TauCeti/RingTheory/Polynomial/Hermite/GeneratingFunction.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Analysis.Complex.TaylorSeries
 public import Mathlib.Analysis.Calculus.Deriv.Polynomial
 public import Mathlib.Analysis.SpecialFunctions.ExpDeriv


### PR DESCRIPTION
## Why

`scripts/ModuleSystem.lean` states the convention its own check describes: `module` belongs on
"the first line of each (after the copyright header)". 306 files in `TauCeti/` follow it, and so
does Mathlib for every file carrying a copyright block —
`Mathlib/Order/Basic.lean`, `Mathlib/Topology/Basic.lean`, and
`Mathlib/MeasureTheory/Measure/ProbabilityMeasure.lean` all open with the header and put `module`
directly after it.

39 files had the two inverted: they opened with `module` and pushed the copyright block below it.

## What

**Reorder 39 headers.** Purely positional — no header text is altered, and `module` still precedes
every import in each file. Verified mechanically: no file in `TauCeti/` now begins with `module`.

**Add the one missing copyright block.**
`RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean` presented the same shape for
a different reason — it had no copyright block at all, the only such file in `TauCeti/`. It now
carries one matching its five siblings in that directory verbatim, including their omission of an
`Authors:` line.

## Risk

None to compilation: a block comment is not a command, so `module` remains the file's first command
either way — which is why Mathlib can order it this way. Full `lake build` green locally (5830 jobs).

Housekeeping only, so no roadmap intention; `CLAUDE.md` puts adopting a cleaner idiom in scope
without one.