### PR TITLE
feat: move every weight into the dominant chamber

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -1,0 +1,225 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.Positive
+public import TauCeti.LinearAlgebra.RootSystem.WeylGroup
+
+public section
+
+/-!
+# The dominant chamber of a base
+
+Over a linearly ordered coefficient ring the simple coroots of a base cut the weight space into
+sign-pattern cones, the Weyl chambers. This file introduces the dominant one, both closed and
+open, and proves that it meets every Weyl orbit: every weight can be moved into the closed
+dominant chamber by some element of the Weyl group. Equivalently, the Weyl translates of the
+closed dominant chamber cover the whole weight space.
+
+The proof is the classical averaging argument. The Weyl group of a finite root system is finite,
+so the sum of the simple-coroot functionals over the positive roots, evaluated along an orbit,
+attains a maximum. A simple reflection `sᵢ` permutes the positive roots other than `αᵢ` and sends
+`αᵢ` to `-αᵢ`, so applying `sᵢ` changes that sum by `-2⟨αᵢ^∨, x⟩`; maximality therefore forces
+`⟨αᵢ^∨, x⟩ ≥ 0` for every simple root, which is dominance.
+
+## Main definitions
+
+* `TauCeti.dominantChamber` is the closed dominant chamber of a base.
+* `TauCeti.openDominantChamber` is its open counterpart.
+
+## Main results
+
+* `TauCeti.exists_mem_dominantChamber`: every weight is Weyl-conjugate into the closed dominant
+  chamber.
+* `TauCeti.iUnion_smul_dominantChamber_eq_univ`: the Weyl translates of the closed dominant
+  chamber cover the weight space.
+* `TauCeti.ofIdx_smul_notMem_dominantChamber` and
+  `TauCeti.ofIdx_smul_ne_of_mem_openDominantChamber`: a simple reflection moves every point of the
+  open dominant chamber, and moves it out of the closed chamber.
+
+## Implementation notes
+
+The roadmap states this layer over `ℝ`. Nothing in the argument uses completeness, division, or
+the archimedean property, so the statements here are made over an arbitrary linearly ordered
+commutative ring; `ℝ` and `ℚ` are the intended instances.
+
+## References
+
+This file implements the chamber definitions of Layer 4 ("Weyl chambers as cones") and the
+existence half of its fundamental-domain item (`exists_mem_dominantChamber`) in
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, following the target signatures in
+that roadmap's `Suggested.lean`. Uniqueness of the dominant representative is not proved here.
+
+The argument is the one in J. E. Humphreys, *Introduction to Lie Algebras and Representation
+Theory*, GTM 9, Ch. III, §10.3.
+-/
+
+namespace TauCeti
+
+open Pointwise Set
+
+universe u v w x
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N)
+
+namespace RootPairing
+
+/-- Reflecting a root in itself negates its coroot functional. -/
+lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
+  rw [_root_.RootPairing.coroot', P.coroot_reflectionPerm, P.coreflection_apply_self]
+  simp
+
+/-- A reflection reverses the sign of its own coroot functional. This is the sign change that
+drives the chamber geometry below. -/
+lemma coroot'_reflection_self (i : ι) (x : M) :
+    P.coroot' i (P.reflection i x) = -P.coroot' i x := by
+  rw [P.coroot'_reflection, coroot'_reflectionPerm_self]
+  simp
+
+/-- A simple reflection reverses the sign of its own coroot functional. -/
+lemma coroot'_ofIdx_smul_self (i : ι) (x : M) :
+    P.coroot' i (_root_.RootPairing.weylGroup.ofIdx P i • x) = -P.coroot' i x :=
+  coroot'_reflection_self P i x
+
+end RootPairing
+
+variable [LinearOrder R] (b : P.Base)
+
+/-- The closed dominant chamber of a base: the weights on which every simple coroot is
+nonnegative. -/
+def dominantChamber : Set M := {x | ∀ i ∈ b.support, 0 ≤ P.coroot' i x}
+
+/-- The open dominant chamber of a base: the weights on which every simple coroot is positive. -/
+def openDominantChamber : Set M := {x | ∀ i ∈ b.support, 0 < P.coroot' i x}
+
+/-- Membership in the closed dominant chamber. -/
+@[simp]
+lemma mem_dominantChamber (x : M) :
+    x ∈ dominantChamber P b ↔ ∀ i ∈ b.support, 0 ≤ P.coroot' i x := Iff.rfl
+
+/-- Membership in the open dominant chamber. -/
+@[simp]
+lemma mem_openDominantChamber (x : M) :
+    x ∈ openDominantChamber P b ↔ ∀ i ∈ b.support, 0 < P.coroot' i x := Iff.rfl
+
+/-- The open dominant chamber is contained in the closed one. -/
+lemma openDominantChamber_subset_dominantChamber :
+    openDominantChamber P b ⊆ dominantChamber P b :=
+  fun _ hx i hi ↦ (hx i hi).le
+
+/-- The origin is dominant. -/
+lemma zero_mem_dominantChamber : (0 : M) ∈ dominantChamber P b := by
+  simp
+
+variable [IsStrictOrderedRing R]
+
+/-- The closed dominant chamber is closed under addition. -/
+lemma add_mem_dominantChamber {x y : M} (hx : x ∈ dominantChamber P b)
+    (hy : y ∈ dominantChamber P b) : x + y ∈ dominantChamber P b :=
+  fun i hi ↦ by simpa using add_nonneg (hx i hi) (hy i hi)
+
+/-- The closed dominant chamber is closed under nonnegative scaling. -/
+lemma smul_mem_dominantChamber {t : R} (ht : 0 ≤ t) {x : M} (hx : x ∈ dominantChamber P b) :
+    t • x ∈ dominantChamber P b :=
+  fun i hi ↦ by simpa using mul_nonneg ht (hx i hi)
+
+/-- A simple reflection carries every point of the open dominant chamber out of the closed
+dominant chamber, since it reverses the sign of the corresponding simple coroot. -/
+theorem ofIdx_smul_notMem_dominantChamber {i : ι} (hi : i ∈ b.support) {x : M}
+    (hx : x ∈ openDominantChamber P b) :
+    RootPairing.weylGroup.ofIdx P i • x ∉ dominantChamber P b := by
+  intro hmem
+  have h := hmem i hi
+  rw [RootPairing.coroot'_ofIdx_smul_self] at h
+  have := hx i hi
+  linarith
+
+/-- No simple reflection fixes a point of the open dominant chamber. -/
+theorem ofIdx_smul_ne_of_mem_openDominantChamber {i : ι} (hi : i ∈ b.support) {x : M}
+    (hx : x ∈ openDominantChamber P b) :
+    RootPairing.weylGroup.ofIdx P i • x ≠ x := by
+  intro hfix
+  have h := congrArg (P.coroot' i) hfix
+  rw [RootPairing.coroot'_ofIdx_smul_self] at h
+  have := hx i hi
+  linarith
+
+section Finite
+
+variable [Finite ι]
+
+/-- The sum of the simple-coroot functionals over the positive roots, evaluated at `x`. Up to the
+factor two this is the pairing of `x` with the Weyl vector on the coroot side; all that is used
+below is how it transforms under a simple reflection. -/
+private noncomputable def posCorootSum (x : M) : R :=
+  ∑ i ∈ (posRoots_finite P b).toFinset, P.coroot' i x
+
+variable [P.IsCrystallographic] [P.IsReduced]
+
+/-- A simple reflection changes `posCorootSum` by twice the value of its own simple coroot. The
+reflection permutes the positive roots other than its own simple root, and negates that one. -/
+private lemma posCorootSum_reflection {i : ι} (hi : i ∈ b.support) (x : M) :
+    posCorootSum P b (P.reflection i x) = posCorootSum P b x - 2 * P.coroot' i x := by
+  classical
+  set s := (posRoots_finite P b).toFinset with hs
+  have hmem : ∀ j : ι, j ∈ s ↔ j ∈ posRoots P b := by
+    intro j; rw [hs, Set.Finite.mem_toFinset]
+  have his : i ∈ s := (hmem i).mpr (support_subset_posRoots P b hi)
+  -- Reflecting the argument reindexes the summand along `P.reflectionPerm i`.
+  have hreindex : posCorootSum P b (P.reflection i x) =
+      ∑ j ∈ s, P.coroot' (P.reflectionPerm i j) x :=
+    Finset.sum_congr rfl fun _ _ ↦ P.coroot'_reflection x
+  -- The reflected simple coroot is the negative of the original.
+  have hself : P.coroot' (P.reflectionPerm i i) x = -P.coroot' i x := by
+    rw [RootPairing.coroot'_reflectionPerm_self]
+    simp
+  -- Away from `i` the reflection is a bijection of the punctured positive roots.
+  have hpunctured : ∑ j ∈ s.erase i, P.coroot' (P.reflectionPerm i j) x =
+      ∑ j ∈ s.erase i, P.coroot' j x := by
+    refine Finset.sum_equiv (P.reflectionPerm i) (fun j ↦ ?_) (fun _ _ ↦ rfl)
+    have h := reflectionPerm_mem_posRoots_diff_singleton_iff P b hi j
+    simp only [Set.mem_sdiff, Set.mem_singleton_iff] at h
+    simp only [Finset.mem_erase, hmem]
+    tauto
+  have hexpand : posCorootSum P b x = P.coroot' i x + ∑ j ∈ s.erase i, P.coroot' j x :=
+    (Finset.add_sum_erase _ _ his).symm
+  rw [hreindex, ← Finset.add_sum_erase _ _ his, hpunctured, hself, hexpand]
+  ring
+
+variable [P.IsRootSystem]
+
+/-- **Every weight is Weyl-conjugate into the closed dominant chamber.** Together with the
+uniqueness of that representative this says the closed dominant chamber is a fundamental domain
+for the Weyl group. -/
+theorem exists_mem_dominantChamber (x : M) :
+    ∃ w : P.weylGroup, w • x ∈ dominantChamber P b := by
+  have : Finite P.weylGroup := RootPairing.finite_weylGroup P
+  obtain ⟨w, hw⟩ := Finite.exists_max fun w : P.weylGroup ↦ posCorootSum P b (w • x)
+  refine ⟨w, fun i hi ↦ ?_⟩
+  have hsmul : (RootPairing.weylGroup.ofIdx P i * w) • x = P.reflection i (w • x) := by
+    simp [mul_smul]
+  have hle := hw (RootPairing.weylGroup.ofIdx P i * w)
+  rw [hsmul, posCorootSum_reflection P b hi] at hle
+  linarith
+
+/-- Every Weyl orbit meets the closed dominant chamber. -/
+theorem orbit_inter_dominantChamber_nonempty (x : M) :
+    (MulAction.orbit P.weylGroup x ∩ dominantChamber P b).Nonempty := by
+  obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b x
+  exact ⟨w • x, ⟨w, rfl⟩, hw⟩
+
+/-- **The Weyl translates of the closed dominant chamber cover the weight space.** -/
+theorem iUnion_smul_dominantChamber_eq_univ :
+    ⋃ w : P.weylGroup, w • dominantChamber P b = (univ : Set M) := by
+  refine Set.eq_univ_of_forall fun x ↦ ?_
+  obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b x
+  refine Set.mem_iUnion.mpr ⟨w⁻¹, ?_⟩
+  exact ⟨w • x, hw, inv_smul_smul w x⟩
+
+end Finite
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -46,10 +46,11 @@ The roadmap states this layer over `ℝ`. Nothing in the argument uses completen
 the archimedean property, so the statements here are made over an arbitrary linearly ordered
 commutative ring; `ℝ` and `ℚ` are the intended instances.
 
-The maximization argument needs nothing of the ambient pairing beyond finiteness of the Weyl group,
-so it is proved as `exists_mem_dominantChamber_of_finite_weylGroup`; the roadmap-signature
-`exists_mem_dominantChamber` is the root-system case, obtained from
-`TauCeti.RootPairing.finite_weylGroup`.
+The maximization argument is proved as `exists_mem_dominantChamber_of_finite_weylGroup`, which
+asks for no root-system assumption: on top of the standing `Finite ι`, `P.IsCrystallographic` and
+`P.IsReduced` hypotheses that the positive-root permutation step needs, it assumes only
+`Finite P.weylGroup`. The roadmap-signature `exists_mem_dominantChamber` is the root-system case,
+where that finiteness comes from `TauCeti.RootPairing.finite_weylGroup`.
 
 ## References
 
@@ -192,8 +193,9 @@ section FiniteWeylGroup
 
 variable [Finite P.weylGroup]
 
-/-- **Every weight is Weyl-conjugate into the closed dominant chamber**, whenever the Weyl group is
-finite. Maximizing `posCorootSum` along the orbit produces the dominant representative. -/
+/-- **Every weight is Weyl-conjugate into the closed dominant chamber**, for a crystallographic
+reduced pairing with finitely many roots whose Weyl group is finite. Maximizing `posCorootSum`
+along the orbit produces the dominant representative. -/
 theorem exists_mem_dominantChamber_of_finite_weylGroup (x : M) :
     ∃ w : P.weylGroup, w • x ∈ dominantChamber P b := by
   obtain ⟨w, hw⟩ := Finite.exists_max fun w : P.weylGroup ↦ posCorootSum P b (w • x)

--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -19,7 +19,7 @@ dominant chamber by some element of the Weyl group. Equivalently, the Weyl trans
 closed dominant chamber cover the whole weight space.
 
 The proof is the classical averaging argument. The Weyl group of a finite root system is finite,
-so the sum of the simple-coroot functionals over the positive roots, evaluated along an orbit,
+so the sum of the coroot functionals indexed by the positive roots, evaluated along an orbit,
 attains a maximum. A simple reflection `sᵢ` permutes the positive roots other than `αᵢ` and sends
 `αᵢ` to `-αᵢ`, so applying `sᵢ` changes that sum by `-2⟨αᵢ^∨, x⟩`; maximality therefore forces
 `⟨αᵢ^∨, x⟩ ≥ 0` for every simple root, which is dominance.
@@ -31,7 +31,8 @@ attains a maximum. A simple reflection `sᵢ` permutes the positive roots other 
 
 ## Main results
 
-* `TauCeti.exists_mem_dominantChamber`: every weight is Weyl-conjugate into the closed dominant
+* `TauCeti.exists_mem_dominantChamber_of_finite_weylGroup` and
+  `TauCeti.exists_mem_dominantChamber`: every weight is Weyl-conjugate into the closed dominant
   chamber.
 * `TauCeti.iUnion_smul_dominantChamber_eq_univ`: the Weyl translates of the closed dominant
   chamber cover the weight space.
@@ -44,6 +45,11 @@ attains a maximum. A simple reflection `sᵢ` permutes the positive roots other 
 The roadmap states this layer over `ℝ`. Nothing in the argument uses completeness, division, or
 the archimedean property, so the statements here are made over an arbitrary linearly ordered
 commutative ring; `ℝ` and `ℚ` are the intended instances.
+
+The averaging argument needs nothing of the ambient pairing beyond finiteness of the Weyl group,
+so it is proved as `exists_mem_dominantChamber_of_finite_weylGroup`; the roadmap-signature
+`exists_mem_dominantChamber` is the root-system case, obtained from
+`TauCeti.RootPairing.finite_weylGroup`.
 
 ## References
 
@@ -65,27 +71,6 @@ universe u v w x
 variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : RootPairing ι R M N)
-
-namespace RootPairing
-
-/-- Reflecting a root in itself negates its coroot functional. -/
-lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
-  rw [_root_.RootPairing.coroot', P.coroot_reflectionPerm, P.coreflection_apply_self]
-  simp
-
-/-- A reflection reverses the sign of its own coroot functional. This is the sign change that
-drives the chamber geometry below. -/
-lemma coroot'_reflection_self (i : ι) (x : M) :
-    P.coroot' i (P.reflection i x) = -P.coroot' i x := by
-  rw [P.coroot'_reflection, coroot'_reflectionPerm_self]
-  simp
-
-/-- A simple reflection reverses the sign of its own coroot functional. -/
-lemma coroot'_ofIdx_smul_self (i : ι) (x : M) :
-    P.coroot' i (_root_.RootPairing.weylGroup.ofIdx P i • x) = -P.coroot' i x :=
-  coroot'_reflection_self P i x
-
-end RootPairing
 
 variable [LinearOrder R] (b : P.Base)
 
@@ -127,6 +112,16 @@ lemma smul_mem_dominantChamber {t : R} (ht : 0 ≤ t) {x : M} (hx : x ∈ domina
     t • x ∈ dominantChamber P b :=
   fun i hi ↦ by simpa using mul_nonneg ht (hx i hi)
 
+/-- The open dominant chamber is closed under addition. -/
+lemma add_mem_openDominantChamber {x y : M} (hx : x ∈ openDominantChamber P b)
+    (hy : y ∈ openDominantChamber P b) : x + y ∈ openDominantChamber P b :=
+  fun i hi ↦ by simpa using add_pos (hx i hi) (hy i hi)
+
+/-- The open dominant chamber is closed under positive scaling. -/
+lemma smul_mem_openDominantChamber {t : R} (ht : 0 < t) {x : M}
+    (hx : x ∈ openDominantChamber P b) : t • x ∈ openDominantChamber P b :=
+  fun i hi ↦ by simpa using mul_pos ht (hx i hi)
+
 /-- A simple reflection carries every point of the open dominant chamber out of the closed
 dominant chamber, since it reverses the sign of the corresponding simple coroot. -/
 theorem ofIdx_smul_notMem_dominantChamber {i : ι} (hi : i ∈ b.support) {x : M}
@@ -134,25 +129,26 @@ theorem ofIdx_smul_notMem_dominantChamber {i : ι} (hi : i ∈ b.support) {x : M
     RootPairing.weylGroup.ofIdx P i • x ∉ dominantChamber P b := by
   intro hmem
   have h := hmem i hi
-  rw [RootPairing.coroot'_ofIdx_smul_self] at h
+  rw [_root_.RootPairing.weylGroup.ofIdx_smul, _root_.RootPairing.Equiv.reflection_smul,
+    RootPairing.coroot'_reflection_self] at h
   have := hx i hi
   linarith
 
-/-- No simple reflection fixes a point of the open dominant chamber. -/
+/-- No simple reflection fixes a point of the open dominant chamber: it would otherwise stay in
+the closed dominant chamber. -/
 theorem ofIdx_smul_ne_of_mem_openDominantChamber {i : ι} (hi : i ∈ b.support) {x : M}
     (hx : x ∈ openDominantChamber P b) :
     RootPairing.weylGroup.ofIdx P i • x ≠ x := by
   intro hfix
-  have h := congrArg (P.coroot' i) hfix
-  rw [RootPairing.coroot'_ofIdx_smul_self] at h
-  have := hx i hi
-  linarith
+  refine ofIdx_smul_notMem_dominantChamber P b hi hx ?_
+  rw [hfix]
+  exact openDominantChamber_subset_dominantChamber P b hx
 
 section Finite
 
 variable [Finite ι]
 
-/-- The sum of the simple-coroot functionals over the positive roots, evaluated at `x`. Up to the
+/-- The sum of the coroot functionals indexed by the positive roots, evaluated at `x`. Up to the
 factor two this is the pairing of `x` with the Weyl vector on the coroot side; all that is used
 below is how it transforms under a simple reflection. -/
 private noncomputable def posCorootSum (x : M) : R :=
@@ -165,12 +161,14 @@ reflection permutes the positive roots other than its own simple root, and negat
 private lemma posCorootSum_reflection {i : ι} (hi : i ∈ b.support) (x : M) :
     posCorootSum P b (P.reflection i x) = posCorootSum P b x - 2 * P.coroot' i x := by
   classical
+  -- Work with the underlying sums rather than leaning on `posCorootSum` unfolding silently.
+  unfold posCorootSum
   set s := (posRoots_finite P b).toFinset with hs
   have hmem : ∀ j : ι, j ∈ s ↔ j ∈ posRoots P b := by
     intro j; rw [hs, Set.Finite.mem_toFinset]
   have his : i ∈ s := (hmem i).mpr (support_subset_posRoots P b hi)
   -- Reflecting the argument reindexes the summand along `P.reflectionPerm i`.
-  have hreindex : posCorootSum P b (P.reflection i x) =
+  have hreindex : ∑ j ∈ s, P.coroot' j (P.reflection i x) =
       ∑ j ∈ s, P.coroot' (P.reflectionPerm i j) x :=
     Finset.sum_congr rfl fun _ _ ↦ P.coroot'_reflection x
   -- The reflected simple coroot is the negative of the original.
@@ -185,19 +183,19 @@ private lemma posCorootSum_reflection {i : ι} (hi : i ∈ b.support) (x : M) :
     simp only [Set.mem_sdiff, Set.mem_singleton_iff] at h
     simp only [Finset.mem_erase, hmem]
     tauto
-  have hexpand : posCorootSum P b x = P.coroot' i x + ∑ j ∈ s.erase i, P.coroot' j x :=
+  have hexpand : ∑ j ∈ s, P.coroot' j x = P.coroot' i x + ∑ j ∈ s.erase i, P.coroot' j x :=
     (Finset.add_sum_erase _ _ his).symm
   rw [hreindex, ← Finset.add_sum_erase _ _ his, hpunctured, hself, hexpand]
   ring
 
-variable [P.IsRootSystem]
+section FiniteWeylGroup
 
-/-- **Every weight is Weyl-conjugate into the closed dominant chamber.** Together with the
-uniqueness of that representative this says the closed dominant chamber is a fundamental domain
-for the Weyl group. -/
-theorem exists_mem_dominantChamber (x : M) :
+variable [Finite P.weylGroup]
+
+/-- **Every weight is Weyl-conjugate into the closed dominant chamber**, whenever the Weyl group is
+finite. Maximising `posCorootSum` along the orbit produces the dominant representative. -/
+theorem exists_mem_dominantChamber_of_finite_weylGroup (x : M) :
     ∃ w : P.weylGroup, w • x ∈ dominantChamber P b := by
-  have : Finite P.weylGroup := RootPairing.finite_weylGroup P
   obtain ⟨w, hw⟩ := Finite.exists_max fun w : P.weylGroup ↦ posCorootSum P b (w • x)
   refine ⟨w, fun i hi ↦ ?_⟩
   have hsmul : (RootPairing.weylGroup.ofIdx P i * w) • x = P.reflection i (w • x) := by
@@ -209,16 +207,26 @@ theorem exists_mem_dominantChamber (x : M) :
 /-- Every Weyl orbit meets the closed dominant chamber. -/
 theorem orbit_inter_dominantChamber_nonempty (x : M) :
     (MulAction.orbit P.weylGroup x ∩ dominantChamber P b).Nonempty := by
-  obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b x
+  obtain ⟨w, hw⟩ := exists_mem_dominantChamber_of_finite_weylGroup P b x
   exact ⟨w • x, ⟨w, rfl⟩, hw⟩
 
 /-- **The Weyl translates of the closed dominant chamber cover the weight space.** -/
 theorem iUnion_smul_dominantChamber_eq_univ :
     ⋃ w : P.weylGroup, w • dominantChamber P b = (univ : Set M) := by
   refine Set.eq_univ_of_forall fun x ↦ ?_
-  obtain ⟨w, hw⟩ := exists_mem_dominantChamber P b x
+  obtain ⟨w, hw⟩ := exists_mem_dominantChamber_of_finite_weylGroup P b x
   refine Set.mem_iUnion.mpr ⟨w⁻¹, ?_⟩
   exact ⟨w • x, hw, inv_smul_smul w x⟩
+
+end FiniteWeylGroup
+
+/-- **Every weight is Weyl-conjugate into the closed dominant chamber.** Together with the
+uniqueness of that representative this says the closed dominant chamber is a fundamental domain
+for the Weyl group. -/
+theorem exists_mem_dominantChamber [P.IsRootSystem] (x : M) :
+    ∃ w : P.weylGroup, w • x ∈ dominantChamber P b :=
+  letI := RootPairing.finite_weylGroup P
+  exists_mem_dominantChamber_of_finite_weylGroup P b x
 
 end Finite
 

--- a/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Chamber.lean
@@ -18,11 +18,11 @@ open, and proves that it meets every Weyl orbit: every weight can be moved into 
 dominant chamber by some element of the Weyl group. Equivalently, the Weyl translates of the
 closed dominant chamber cover the whole weight space.
 
-The proof is the classical averaging argument. The Weyl group of a finite root system is finite,
-so the sum of the coroot functionals indexed by the positive roots, evaluated along an orbit,
-attains a maximum. A simple reflection `sᵢ` permutes the positive roots other than `αᵢ` and sends
-`αᵢ` to `-αᵢ`, so applying `sᵢ` changes that sum by `-2⟨αᵢ^∨, x⟩`; maximality therefore forces
-`⟨αᵢ^∨, x⟩ ≥ 0` for every simple root, which is dominance.
+The proof is the classical maximization argument. The Weyl group of a finite root system is
+finite, so the sum of the coroot functionals indexed by the positive roots, evaluated along an
+orbit, attains a maximum. A simple reflection `sᵢ` permutes the positive roots other than `αᵢ`
+and sends `αᵢ` to `-αᵢ`, so applying `sᵢ` changes that sum by `-2⟨αᵢ^∨, x⟩`; maximality
+therefore forces `⟨αᵢ^∨, x⟩ ≥ 0` for every simple root, which is dominance.
 
 ## Main definitions
 
@@ -46,7 +46,7 @@ The roadmap states this layer over `ℝ`. Nothing in the argument uses completen
 the archimedean property, so the statements here are made over an arbitrary linearly ordered
 commutative ring; `ℝ` and `ℚ` are the intended instances.
 
-The averaging argument needs nothing of the ambient pairing beyond finiteness of the Weyl group,
+The maximization argument needs nothing of the ambient pairing beyond finiteness of the Weyl group,
 so it is proved as `exists_mem_dominantChamber_of_finite_weylGroup`; the roadmap-signature
 `exists_mem_dominantChamber` is the root-system case, obtained from
 `TauCeti.RootPairing.finite_weylGroup`.
@@ -193,7 +193,7 @@ section FiniteWeylGroup
 variable [Finite P.weylGroup]
 
 /-- **Every weight is Weyl-conjugate into the closed dominant chamber**, whenever the Weyl group is
-finite. Maximising `posCorootSum` along the orbit produces the dominant representative. -/
+finite. Maximizing `posCorootSum` along the orbit produces the dominant representative. -/
 theorem exists_mem_dominantChamber_of_finite_weylGroup (x : M) :
     ∃ w : P.weylGroup, w • x ∈ dominantChamber P b := by
   obtain ⟨w, hw⟩ := Finite.exists_max fun w : P.weylGroup ↦ posCorootSum P b (w • x)

--- a/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Inversions/Exchange.lean
@@ -41,20 +41,6 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
 
 variable [CharZero R] (b : P.Base)
 
-private lemma reflectionPerm_ne_of_isPos {i j : ι} (hi : i ∈ b.support)
-    (hj : b.IsPos j) :
-    P.reflectionPerm i j ≠ i := by
-  intro h
-  have hji : j = P.reflectionPerm i i := by
-    calc
-      j = P.reflectionPerm i (P.reflectionPerm i j) :=
-        (P.reflectionPerm_self i j).symm
-      _ = P.reflectionPerm i i := congrArg (P.reflectionPerm i) h
-  have hneg : ¬ b.IsPos (P.reflectionPerm i i) := by
-    rw [isPos_reflectionPerm_self_iff_mem_negRoots, mem_negRoots]
-    exact not_not_intro (b.isPos_of_mem_support hi)
-  exact hneg (hji ▸ hj)
-
 variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
 
 /-- Membership criterion for the punctured inversion sets: a positive root other than the
@@ -64,7 +50,7 @@ private lemma reflectionPerm_mem_inversions_sdiff (v : P.weylGroup) {i j : ι}
     (hneg : ¬ b.IsPos (P.weylGroupToPerm v (P.reflectionPerm i j))) :
     P.reflectionPerm i j ∈ inversions P b v \ {i} :=
   ⟨(mem_inversions P b _ _).mpr ⟨hj.reflectionPerm hi hji, hneg⟩, by
-    simpa using reflectionPerm_ne_of_isPos P b hi hj⟩
+    simpa using reflectionPerm_ne_of_mem_posRoots P b hi ((mem_posRoots P b j).mpr hj)⟩
 
 /-- Away from the distinguished simple root, reflection bijects the inversion sets before and
 after right multiplication by that simple reflection. -/

--- a/TauCeti/LinearAlgebra/RootSystem/Positive.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/Positive.lean
@@ -12,12 +12,19 @@ public section
 # Positive and negative roots
 
 This file packages Mathlib's positivity predicate for a root-pairing base as the sets of positive
-and negative root indices. It records their partition and their exchange under root negation.
+and negative root indices. It records their partition, their exchange under root negation, and the
+fact that a simple reflection permutes the positive roots other than its own simple root.
 
 ## Main definitions
 
 * `TauCeti.posRoots` is the set of positive roots relative to a base.
 * `TauCeti.negRoots` is its complementary set of negative roots.
+
+## Main results
+
+* `TauCeti.image_reflectionPerm_self_posRoots` says root negation exchanges the two sets.
+* `TauCeti.bijOn_reflectionPerm_posRoots_diff_singleton` says a simple reflection permutes the
+  positive roots other than its own simple root.
 
 ## References
 
@@ -171,5 +178,43 @@ theorem image_reflectionPerm_self_negRoots :
       ext i
       simp only [Set.mem_compl_iff, mem_negRoots, mem_posRoots]
       tauto
+
+/-- Reflecting a positive root in a simple root never produces that simple root: the only root
+sent to a simple root `αᵢ` by `sᵢ` is `-αᵢ`, which is negative. -/
+lemma reflectionPerm_ne_of_mem_posRoots {i j : ι} (hi : i ∈ b.support)
+    (hj : j ∈ posRoots P b) :
+    P.reflectionPerm i j ≠ i := by
+  intro h
+  have hji : j = P.reflectionPerm i i := by
+    rw [← P.reflectionPerm_self i j, h]
+  rw [mem_posRoots, hji, isPos_reflectionPerm_self_iff_mem_negRoots, mem_negRoots] at hj
+  exact hj (b.isPos_of_mem_support hi)
+
+variable [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
+
+/-- A simple reflection preserves the set of positive roots other than its own simple root. Both
+directions follow from the forward implication because `P.reflectionPerm i` is an involution. -/
+lemma reflectionPerm_mem_posRoots_diff_singleton_iff {i : ι} (hi : i ∈ b.support) (j : ι) :
+    P.reflectionPerm i j ∈ posRoots P b \ {i} ↔ j ∈ posRoots P b \ {i} := by
+  have key : ∀ k : ι, k ∈ posRoots P b \ {i} → P.reflectionPerm i k ∈ posRoots P b \ {i} := by
+    rintro k ⟨hkpos, hkne⟩
+    have hkne' : k ≠ i := by simpa using hkne
+    exact ⟨(mem_posRoots P b _).mpr (((mem_posRoots P b k).mp hkpos).reflectionPerm hi hkne'),
+      by simpa using reflectionPerm_ne_of_mem_posRoots P b hi hkpos⟩
+  refine ⟨fun h ↦ ?_, key j⟩
+  simpa only [P.reflectionPerm_self i j] using key _ h
+
+/-- A simple reflection permutes the positive roots other than its own simple root. -/
+theorem bijOn_reflectionPerm_posRoots_diff_singleton {i : ι} (hi : i ∈ b.support) :
+    Set.BijOn (P.reflectionPerm i) (posRoots P b \ {i}) (posRoots P b \ {i}) :=
+  Set.InvOn.bijOn ⟨fun j _ ↦ P.reflectionPerm_self i j, fun j _ ↦ P.reflectionPerm_self i j⟩
+    (fun _ hj ↦ (reflectionPerm_mem_posRoots_diff_singleton_iff P b hi _).mpr hj)
+    (fun _ hj ↦ (reflectionPerm_mem_posRoots_diff_singleton_iff P b hi _).mpr hj)
+
+/-- The image form of `bijOn_reflectionPerm_posRoots_diff_singleton`: a simple reflection maps the
+positive roots other than its own simple root onto themselves. -/
+theorem image_reflectionPerm_posRoots_diff_singleton {i : ι} (hi : i ∈ b.support) :
+    P.reflectionPerm i '' (posRoots P b \ {i}) = posRoots P b \ {i} :=
+  (bijOn_reflectionPerm_posRoots_diff_singleton P b hi).image_eq
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -80,6 +80,7 @@ lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = 
   simp
 
 /-- A reflection reverses the sign of its own coroot functional. -/
+@[grind =]
 lemma coroot'_reflection_self (i : ι) (x : M) :
     P.coroot' i (P.reflection i x) = -P.coroot' i x := by
   rw [P.coroot'_reflection, coroot'_reflectionPerm_self]

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -74,6 +74,7 @@ end RootPairing.Equiv
 namespace RootPairing
 
 /-- Reflecting a root in itself negates its coroot functional. -/
+@[simp]
 lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
   rw [_root_.RootPairing.coroot', P.coroot_reflectionPerm, P.coreflection_apply_self]
   simp

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -14,12 +14,15 @@ public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
 This file proves that the action of the automorphism group of a root system on its root indices is
 faithful.  Consequently, every subgroup of that automorphism group, and in particular the Weyl
 group, is finite when the root index type is finite.  It also records how that action evaluates on
-simple reflections and how it interacts with root negation.
+simple reflections, how it interacts with root negation, and the sign change a reflection induces
+on its own coroot functional.
 
 ## Main results
 
 * `TauCeti.RootPairing.Equiv.indexHom_injective` says that an automorphism of a root system is
   determined by its permutation of the roots.
+* `TauCeti.RootPairing.coroot'_reflection_self` says a reflection reverses the sign of its own
+  coroot functional.
 * `TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
 * `TauCeti.RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
 * `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
@@ -69,6 +72,17 @@ theorem indexHom_injective [P.IsRootSystem] :
 end RootPairing.Equiv
 
 namespace RootPairing
+
+/-- Reflecting a root in itself negates its coroot functional. -/
+lemma coroot'_reflectionPerm_self (i : ι) : P.coroot' (P.reflectionPerm i i) = -P.coroot' i := by
+  rw [_root_.RootPairing.coroot', P.coroot_reflectionPerm, P.coreflection_apply_self]
+  simp
+
+/-- A reflection reverses the sign of its own coroot functional. -/
+lemma coroot'_reflection_self (i : ι) (x : M) :
+    P.coroot' i (P.reflection i x) = -P.coroot' i x := by
+  rw [P.coroot'_reflection, coroot'_reflectionPerm_self]
+  simp
 
 /-- If the roots span, the action of the Weyl group on root indices is faithful. -/
 theorem weylGroupToPerm_injective_of_span_eq_top


### PR DESCRIPTION
This PR introduces the closed and open dominant chambers of a base of a root pairing and proves that the closed dominant chamber meets every Weyl orbit: for every weight `x` there is `w` in the Weyl group with `w • x` dominant. Equivalently, the Weyl translates of the closed dominant chamber cover the weight space.

The proof is the classical maximization argument. The Weyl group of a finite root system is finite (already on `main`, `TauCeti.RootPairing.finite_weylGroup`), so the sum of the coroot functionals indexed by the positive roots, evaluated along an orbit, attains a maximum. A simple reflection `sᵢ` permutes the positive roots other than `αᵢ` and negates `αᵢ`, so applying `sᵢ` changes that sum by `-2⟨αᵢ^∨, x⟩`; maximality then forces `⟨αᵢ^∨, x⟩ ≥ 0` at every simple root, which is dominance. Alongside this the file records that the closed chamber is a convex cone, and two first steps towards the uniqueness half: a simple reflection carries every point of the open dominant chamber out of the closed one, and fixes no point of the open chamber.

The permutation fact the argument runs on — a simple reflection permutes the positive roots other than its own simple root — is Layer 1 material, so it goes into the existing `TauCeti/LinearAlgebra/RootSystem/Positive.lean` rather than the new file, as `reflectionPerm_mem_posRoots_diff_singleton_iff` with `Set.BijOn` and image corollaries. Its ingredient `reflectionPerm_ne_of_mem_posRoots` was previously a private lemma in `Inversions/Exchange.lean`; that copy is deleted and the one call site now uses the public version, so the fact is stated once.

The roadmap pins this layer over `ℝ`. Nothing in the argument uses completeness, division, or the archimedean property, so the statements are made over an arbitrary linearly ordered commutative ring, with `ℝ` and `ℚ` the intended instances; the pinned `ℝ` signature is the special case.

Roadmap target: `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 4 ("Weyl chambers, the fundamental domain, and the longest element"), first bullet ("Weyl chambers as cones": `dominantChamber` and its interior) and the existence half of the second bullet ("The fundamental domain": `exists_mem_dominantChamber`), both pinned in that roadmap's `Suggested.lean`. Uniqueness of the dominant representative (`eq_of_mem_dominantChamber_interior`, `eq_one_of_smul_eq_self_of_interior`) is not attempted here. The Layer 1 prerequisites this consumes — positive roots, the faithful permutation action, and finiteness of the Weyl group — are already on `main`.

No Mathlib infrastructure was vendored, and no material was taken from the supplementary source snapshot.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-mem-dominantchamber"}-->

🤖 Prepared with Claude Code


