### PR TITLE
refactor(Probability): extract the i.i.d. block-selection identity

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -7,7 +7,8 @@ module
 public import Mathlib.MeasureTheory.Measure.FiniteMeasurePi
 -- Public: `Measure.infinitePi` appears in the infinite-product statement.
 public import Mathlib.Probability.ProductMeasure
--- Non-public: `map_infinitePi_infinitePi_of_inj` is used only inside the prefix-marginal proof.
+-- Non-public: `map_infinitePi_infinitePi_of_inj` is used inside the prefix-marginal and
+-- block-selection proofs.
 import Mathlib.Probability.Independence.InfinitePi
 -- Non-public: `map_bind` is used only inside the mixture prefix-rectangle proof.
 import TauCeti.MeasureTheory.Measure.GiryMonad

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -51,6 +51,11 @@ Measurability:
   coordinates being the corresponding finite product, with `map_prefixProj_infinitePi_const` the
   constant-family form. Mathlib's `Measure.infinitePi_map_restrict` gives the marginal indexed by a
   coerced `Finset`; this is the `Fin n`-prefix form that prefix-marginal arguments on `ℕ → α` use.
+* `map_infinitePi_pair_block` — an **arbitrary injective block** of coordinates read off a constant
+  countable power, and tagged with the law it came from: `Q^{⊗ℕ}` pushed along
+  `x ↦ (Q, x ∘ k)` is `δ_Q ⊗ Q^{⊗ Fin m}`. This generalizes the prefix marginal above from `Fin.val`
+  to any injective `k`, and pairs it with the Dirac factor, which is the form a disintegration
+  against a directing measure consumes.
 
 Bind-evaluation of the mixture `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure`:
 * `bind_probabilityMeasure_pi_apply` — evaluation on a measurable set as the integral of the product

--- a/TauCeti/MeasureTheory/Measure/ProductKernel.lean
+++ b/TauCeti/MeasureTheory/Measure/ProductKernel.lean
@@ -245,6 +245,29 @@ theorem map_prefixProj_infinitePi_const {α : Type*} [MeasurableSpace α] (p : P
       = Measure.pi (fun _ : Fin n => (p : Measure α)) :=
   map_prefixProj_infinitePi (fun _ => p) n
 
+/-- **Selecting a block from an i.i.d. power, tagged with its own law.** Reading an injective block
+`k : Fin m → ℕ` of coordinates off the countable power `Q^{⊗ℕ}` and recording `Q` alongside the
+result gives `δ_Q ⊗ Q^{⊗ Fin m}`; injectivity is what makes the selected coordinates independent.
+
+This is `map_prefixProj_infinitePi_const` for an arbitrary injective block rather than a prefix,
+paired with the law, which is the form a disintegration against a directing measure consumes. -/
+theorem map_infinitePi_pair_block {α : Type*} [MeasurableSpace α] (Q : ProbabilityMeasure α)
+    {m : ℕ} {k : Fin m → ℕ} (hk : Function.Injective k) :
+    (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
+      = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
+  have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
+    measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
+  calc (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
+      = ((Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+          fun x : ℕ → α => fun i : Fin m => x (k i)).map (Prod.mk Q) :=
+        (Measure.map_map measurable_prodMk_left hblk).symm
+    _ = (Measure.pi fun _ : Fin m => (Q : Measure α)).map (Prod.mk Q) := by
+        rw [Measure.map_infinitePi_infinitePi_of_inj hk, Measure.infinitePi_eq_pi]
+    _ = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
+        rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
+
 /-- **Bind-evaluation.** Evaluating the mixture
 `μ.bind fun ω => (ProbabilityMeasure.pi fun i => ν i ω).toMeasure` on a measurable set `s` gives
 `∫⁻ ω, … s ∂μ`, requiring only a.e.-measurability of each coordinate kernel `ν i`. -/

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -124,27 +124,6 @@ theorem iidMixtureLaw_map_directing (hP : Measurable P) :
   have hcomp : (fun ω : T × (ℕ → α) => P ω.1) = P ∘ Prod.fst := rfl
   rw [hcomp, ← Measure.map_map hP measurable_fst, iidMixtureLaw_map_fst hP]
 
-/-- **Selecting a block from an i.i.d. power, tagged with its own law.** Reading an injective block
-`k : Fin m → ℕ` of coordinates off the countable power `Q^{⊗ℕ}` and recording `Q` alongside it
-gives `δ_Q ⊗ Q^{⊗ Fin m}`. Injectivity of `k` is what makes the selected coordinates independent,
-so it is exactly the hypothesis of `Measure.map_infinitePi_infinitePi_of_inj`. -/
-private theorem map_infinitePi_pair_block (Q : ProbabilityMeasure α) {m : ℕ} {k : Fin m → ℕ}
-    (hk : Function.Injective k) :
-    (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
-        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
-      = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
-  have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
-    measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
-  calc (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
-        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
-      = ((Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
-          fun x : ℕ → α => fun i : Fin m => x (k i)).map (Prod.mk Q) :=
-        (Measure.map_map measurable_prodMk_left hblk).symm
-    _ = (Measure.pi fun _ : Fin m => (Q : Measure α)).map (Prod.mk Q) := by
-        rw [Measure.map_infinitePi_infinitePi_of_inj hk, Measure.infinitePi_eq_pi]
-    _ = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
-        rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
-
 /-- **The canonical process is conditionally i.i.d.** For a measurable family `P`, the coordinate
 process of `iidMixtureLaw π P` is conditionally i.i.d. with directing measure `ω ↦ P ω.1`: along
 every finite selection of distinct coordinates, the joint law of the directing measure and the
@@ -175,7 +154,7 @@ theorem conditionallyIIDWith_iidMixtureLaw (hP : Measurable P) :
         (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) = g (P t) := by
     intro t
     rw [Measure.dirac_prod, Measure.map_map hsel measurable_prodMk_left]
-    exact map_infinitePi_pair_block (P t) hk
+    exact TauCeti.MeasureTheory.map_infinitePi_pair_block (P t) hk
   -- the left-hand side: naturality of `bind` pushes the selection through the mixture, fibre by
   -- fibre
   have hleft : (iidMixtureLaw π P).map (fun ω => (P ω.1, fun i : Fin m => ω.2 (k i)))

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -124,6 +124,27 @@ theorem iidMixtureLaw_map_directing (hP : Measurable P) :
   have hcomp : (fun ω : T × (ℕ → α) => P ω.1) = P ∘ Prod.fst := rfl
   rw [hcomp, ← Measure.map_map hP measurable_fst, iidMixtureLaw_map_fst hP]
 
+/-- **Selecting a block from an i.i.d. power, tagged with its own law.** Reading an injective block
+`k : Fin m → ℕ` of coordinates off the countable power `Q^{⊗ℕ}` and recording `Q` alongside it
+gives `δ_Q ⊗ Q^{⊗ Fin m}`. Injectivity of `k` is what makes the selected coordinates independent,
+so it is exactly the hypothesis of `Measure.map_infinitePi_infinitePi_of_inj`. -/
+private theorem map_infinitePi_pair_block (Q : ProbabilityMeasure α) {m : ℕ} {k : Fin m → ℕ}
+    (hk : Function.Injective k) :
+    (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
+      = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
+  have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
+    measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
+  calc (Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+        (fun x : ℕ → α => (Q, fun i : Fin m => x (k i)))
+      = ((Measure.infinitePi fun _ : ℕ => (Q : Measure α)).map
+          fun x : ℕ → α => fun i : Fin m => x (k i)).map (Prod.mk Q) :=
+        (Measure.map_map measurable_prodMk_left hblk).symm
+    _ = (Measure.pi fun _ : Fin m => (Q : Measure α)).map (Prod.mk Q) := by
+        rw [Measure.map_infinitePi_infinitePi_of_inj hk, Measure.infinitePi_eq_pi]
+    _ = (Measure.dirac Q).prod (ProbabilityMeasure.pi fun _ : Fin m => Q).toMeasure := by
+        rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
+
 /-- **The canonical process is conditionally i.i.d.** For a measurable family `P`, the coordinate
 process of `iidMixtureLaw π P` is conditionally i.i.d. with directing measure `ω ↦ P ω.1`: along
 every finite selection of distinct coordinates, the joint law of the directing measure and the
@@ -148,33 +169,13 @@ theorem conditionallyIIDWith_iidMixtureLaw (hP : Measurable P) :
     (hP.comp measurable_fst).prodMk
       (measurable_pi_lambda _ fun i => (measurable_pi_apply (k i)).comp measurable_snd)
   -- Each fibre of the mixture selects its block out of a countable power: `Measure.dirac_prod`
-  -- turns the fibre into a pushforward of `(P t)^{⊗ℕ}`, and
-  -- `Measure.map_infinitePi_infinitePi_of_inj` — this is where injectivity of `k` enters — reads
-  -- the block off as `(P t)^{⊗ Fin m}`.
-  have hblk : Measurable fun x : ℕ → α => fun i : Fin m => x (k i) :=
-    measurable_pi_lambda _ fun i => measurable_pi_apply (k i)
+  -- turns the fibre into a pushforward of `(P t)^{⊗ℕ}`, on which the block-selection lemma applies.
   have hfib : ∀ t : T,
       ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map
         (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) = g (P t) := by
     intro t
-    have hcomp : (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) ∘ Prod.mk t
-        = Prod.mk (P t) ∘ fun x : ℕ → α => fun i : Fin m => x (k i) := rfl
-    calc ((Measure.dirac t).prod (Measure.infinitePi fun _ : ℕ => (P t : Measure α))).map
-          (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i)))
-        = ((Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map (Prod.mk t)).map
-            (fun ω : T × (ℕ → α) => (P ω.1, fun i : Fin m => ω.2 (k i))) := by
-          rw [Measure.dirac_prod]
-      _ = (Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map
-            (Prod.mk (P t) ∘ fun x : ℕ → α => fun i : Fin m => x (k i)) := by
-          rw [Measure.map_map hsel measurable_prodMk_left, hcomp]
-      _ = ((Measure.infinitePi fun _ : ℕ => (P t : Measure α)).map
-            fun x : ℕ → α => fun i : Fin m => x (k i)).map (Prod.mk (P t)) :=
-          (Measure.map_map measurable_prodMk_left hblk).symm
-      _ = (Measure.pi fun _ : Fin m => (P t : Measure α)).map (Prod.mk (P t)) := by
-          rw [Measure.map_infinitePi_infinitePi_of_inj hk, Measure.infinitePi_eq_pi]
-      _ = g (P t) := by
-          simp only [hg]
-          rw [ProbabilityMeasure.toMeasure_pi, Measure.dirac_prod]
+    rw [Measure.dirac_prod, Measure.map_map hsel measurable_prodMk_left]
+    exact map_infinitePi_pair_block (P t) hk
   -- the left-hand side: naturality of `bind` pushes the selection through the mixture, fibre by
   -- fibre
   have hleft : (iidMixtureLaw π P).map (fun ω => (P ω.1, fun i : Fin m => ω.2 (k i)))

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Construct.lean
@@ -14,8 +14,6 @@ import TauCeti.Probability.Exchangeability.MixedIID.Mixture
 import TauCeti.Probability.Exchangeability.Contractability
 import TauCeti.Probability.Exchangeability.IID
 import TauCeti.MeasureTheory.Measure.GiryMonad
--- Non-public: `Measure.map_infinitePi_infinitePi_of_inj` selects a block out of a countable power.
-import Mathlib.Probability.Independence.InfinitePi
 
 /-!
 # The canonical conditionally i.i.d. process


### PR DESCRIPTION
The bulk of `conditionallyIIDWith_iidMixtureLaw`'s 60-line proof body was a 22-line `hfib` establishing the fibrewise identity — and most of it was really a statement about countable powers, with no reference to the parameter space at all.

This extracts it as `map_infinitePi_pair_block`: reading an injective block `k : Fin m → ℕ` off the countable power `Q^{⊗ℕ}` and recording `Q` alongside it gives `δ_Q ⊗ Q^{⊗ Fin m}`.

Its hypotheses were re-derived rather than inherited. Stated for a bare `Q : ProbabilityMeasure α`, it drops `T`, `t`, `P`, `hP`, and the selection-map measurability (`hsel`) that the inline version had in scope; the block measurability `hblk` moves inside, since only this lemma uses it. What remains is `hk`, which is exactly the hypothesis of `Measure.map_infinitePi_infinitePi_of_inj` — the one step where injectivity is what makes the selected coordinates independent.

The parent's `hfib` becomes `Measure.dirac_prod`, one `Measure.map_map`, and the lemma: **60 → 40** lines of proof body. No statement changes.

At `m = 0` the identity is still meaningful rather than vacuous: `k` is trivially injective and both sides are `δ_(Q, ())`.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`.