### PR TITLE
feat: add the unique de Finetti mixture representation

### DIFF
--- a/TauCeti/Probability/DeFinetti/Mixture.lean
+++ b/TauCeti/Probability/DeFinetti/Mixture.lean
@@ -38,14 +38,14 @@ No theorem here assumes `[StandardBorelSpace Ω]`. That hypothesis is what *supp
 witness costs — `mixedIIDWith_of_contractable` carries it — so the specialization below takes the
 witness as an explicit hypothesis instead of deriving it.
 
-## What is not here
+## Final representation
 
 The Layer 6 bullet in `TauCetiRoadmap/Exchangeability/README.md` asks for the mixture form with `π`
 the **unique** law of `ν`. That uniqueness is `mixedIID_mixingLaw_unique`, proved alongside the
 generic representation in `Exchangeability/MixedIID/Mixture.lean`; it is stated for `MixedIIDWith`
-witnesses and so does not mention `deFinettiMeasure`. The roadmap name `deFinetti_mixture` stays
-reserved for the theorem that *derives* a canonical witness rather than assuming one, which is
-still open.
+witnesses and so does not mention `deFinettiMeasure`. The theorem `deFinetti_mixture` in
+`TauCeti.Probability.DeFinetti.Representation` derives the unique mixing-law representation from
+exchangeability without assuming a witness.
 -/
 
 public section

--- a/TauCeti/Probability/DeFinetti/Representation.lean
+++ b/TauCeti/Probability/DeFinetti/Representation.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.Mixture
+public import TauCeti.Probability.DeFinetti.Theorem
+
+/-!
+# The unique de Finetti mixture representation
+
+De Finetti's theorem identifies an exchangeable sequence with a unique mixture of i.i.d. sequence
+laws. In path-law form, there is a unique probability measure `π` on `ProbabilityMeasure α` such
+that
+
+```text
+pathLaw μ X = ∫ P^{⊗ℕ} dπ(P).
+```
+
+The conditional theorem `conditionallyIID_of_exchangeable` supplies a directing measure, hence a
+mixed-i.i.d. witness after integrating out the directing coordinate.
+`MixedIID.existsUnique_mixingLaw` then packages the witness's law intrinsically: the injectivity of
+the infinite-product mixture makes `π` independent of the chosen directing measure.
+
+This is the `deFinetti_mixture` target from
+`TauCetiRoadmap/Exchangeability/README.md`, Layer 6, “directing measures and de Finetti
+representation.” It is the mixture-of-product-measures form with the unique law of the directing
+measure. Unlike the sample-space-specific `deFinettiMeasure`, the statement needs a standard Borel
+structure only on the state space `α`; the sample space `Ω` remains an arbitrary measurable space.
+
+The mathematical statement follows Kallenberg, *Probabilistic Symmetries and Invariance
+Principles* (2005), Theorem 1.1. The proof is an assembly of Tau Ceti's conditional de Finetti
+theorem, infinite-product mixture representation, and mixing-law injectivity; no formalization is
+ported or adapted here.
+
+## Main result
+
+* `deFinetti_mixture` — an exchangeable sequence has a unique mixing law in its infinite-product
+  representation.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **De Finetti's theorem, unique mixture form.** An exchangeable process under a probability law,
+with measurable coordinates in a nonempty standard Borel state space, has a unique probability
+mixing law `π` for which its path law is the `π`-mixture of the i.i.d. infinite product laws. -/
+theorem deFinetti_mixture [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω}
+    [IsProbabilityMeasure μ] {X : ℕ → Ω → α} (hX : Exchangeable μ X)
+    (hX_meas : ∀ n, Measurable (X n)) :
+    ∃! π : ProbabilityMeasure (ProbabilityMeasure α),
+      pathLaw μ X = (π : Measure (ProbabilityMeasure α)).bind
+        fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
+  (mixedIID_of_conditionallyIID (conditionallyIID_of_exchangeable hX hX_meas))
+    |>.existsUnique_mixingLaw fun n => (hX_meas n).aemeasurable
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Mixture.lean
@@ -27,10 +27,14 @@ written in the `Measure.bind` idiom.
 * `pathLaw_eq_bind_infinitePi_of_mixedIIDWith` — the representation, for an arbitrary mixing
   representative.
 * `mixedIID_mixingLaw_unique` — the mixing law `μ.map ν` is determined by the process.
+* `MixedIID.existsUnique_mixingLaw` — a mixed i.i.d. process under a probability law has a unique
+  probability mixing law in the infinite-product representation.
 
-It needs only `[IsFiniteMeasure μ]`, a.e.-measurable coordinates, and the witness. In particular no
-standard-Borel hypothesis appears: that is the cost of *supplying* a canonical witness, not of using
-one, so this statement is about `MixedIIDWith` alone and carries no de Finetti dependency.
+The witness-level representation and uniqueness results need only `[IsFiniteMeasure μ]`,
+a.e.-measurable coordinates, and the witness. `MixedIID.existsUnique_mixingLaw` assumes
+`[IsProbabilityMeasure μ]` only so that the unique mixing law can be bundled as a
+`ProbabilityMeasure`. No standard-Borel hypothesis appears: that is the cost of *supplying* a
+canonical witness, not of using one, so this file carries no de Finetti dependency.
 
 ## Implementation
 
@@ -46,8 +50,8 @@ asking for the mixture-of-product-measures form. That bullet also asks for `π` 
 law of `ν`, which `mixedIID_mixingLaw_unique` now supplies: the mixture representation turns two
 witnesses into the same `Measure.bind`, and injectivity of `π ↦ π.bind (P ↦ P^{⊗ℕ})`
 (`Measure.ext_of_bind_infinitePi_eq`) identifies the mixing laws. The roadmap name
-`deFinetti_mixture` stays reserved for the theorem that derives a canonical witness rather than
-assuming one.
+`deFinetti_mixture`, which derives the unique representation from exchangeability rather than
+assuming a witness, lives in `TauCeti.Probability.DeFinetti.Representation`.
 -/
 
 public section
@@ -120,6 +124,30 @@ theorem mixedIID_mixingLaw_unique {μ : Measure Ω} [IsFiniteMeasure μ] {X : �
   refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
   rw [← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h,
     ← pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX h']
+
+/-- **Existence and uniqueness of the mixing law.** A mixed i.i.d. process under a probability
+law has a unique probability measure `π` on `ProbabilityMeasure α` such that its path law is
+the `π`-mixture of the infinite product measures `P^{⊗ℕ}`.
+
+This identifies the mixing law intrinsically from the path law, rather than merely comparing the
+pushforwards of two supplied mixing representatives as `mixedIID_mixingLaw_unique` does. -/
+theorem MixedIID.existsUnique_mixingLaw {μ : Measure Ω} [IsProbabilityMeasure μ]
+    {X : ℕ → Ω → α} (h : MixedIID μ X) (hX : ∀ n, AEMeasurable (X n) μ) :
+    ∃! π : ProbabilityMeasure (ProbabilityMeasure α),
+      pathLaw μ X = (π : Measure (ProbabilityMeasure α)).bind
+        fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) := by
+  obtain ⟨ν, hν⟩ := h.exists_mixingRepresentative
+  let π : ProbabilityMeasure (ProbabilityMeasure α) :=
+    ProbabilityMeasure.map (⟨μ, inferInstance⟩ : ProbabilityMeasure Ω)
+      hν.measurable_mixingRepresentative.aemeasurable
+  refine ⟨π, ?_, ?_⟩
+  · simpa only [π, ProbabilityMeasure.toMeasure_map, ProbabilityMeasure.coe_mk] using
+      pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX hν
+  · intro π' hπ'
+    apply ProbabilityMeasure.toMeasure_injective
+    refine TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_
+    simpa only [π, ProbabilityMeasure.toMeasure_map, ProbabilityMeasure.coe_mk] using
+      hπ'.symm.trans (pathLaw_eq_bind_infinitePi_of_mixedIIDWith hX hν)
 
 end Probability
 


### PR DESCRIPTION
This PR adds the unique mixture-of-product-measures form of de Finetti’s theorem: an exchangeable sequence on a nonempty standard Borel state space has a unique probability law `π` on `ProbabilityMeasure α` such that its path law is `π.bind (P ↦ P^{⊗ℕ})`.

It advances `TauCetiRoadmap/Exchangeability/README.md`, Layer 6, specifically the directing-measure API item “the mixture-of-product-measures form: `pathLaw X = ∫ p^{⊗ℕ} dπ(p)` with `π` the unique law of `ν` on `P(α)`,” exposed in Layer 7 as `deFinetti_mixture`. This is the lowest-hanging unfinished Exchangeability target because the conditional summit, the arbitrary-witness infinite-product representation, and injectivity of the mixing operation are already on `main`; the remaining empirical-measure, extreme-point, route-specific, and generalized-exchangeability targets require substantial new infrastructure. The open countable-index PR covers a distinct Layer 8 target.

Add `MixedIID.existsUnique_mixingLaw`, which bundles the pushforward law of any mixing representative and proves it is the unique probability mixing law inducing the process path law. Add `TauCeti/Probability/DeFinetti/Representation.lean` (69 lines), where `deFinetti_mixture` first obtains a genuine directing measure from the sharp conditional theorem and then applies that intrinsic uniqueness result. Update the two predecessor module docstrings to point to the completed representation theorem. The sample space remains an arbitrary measurable space; only the state space is standard Borel.

Follow Kallenberg, *Probabilistic Symmetries and Invariance Principles* (2005), Theorem 1.1, with attribution in the new module. Reuse Tau Ceti’s `conditionallyIID_of_exchangeable`, `mixedIID_of_conditionallyIID`, `pathLaw_eq_bind_infinitePi_of_mixedIIDWith`, and `Measure.ext_of_bind_infinitePi_eq`, together with Mathlib’s `ProbabilityMeasure.map` and `ProbabilityMeasure.toMeasure_injective`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake build` completes successfully across 5,837 jobs. `tauceti-axioms --changed-from origin/main` audits 13 declarations in three changed modules, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` passes with zero violations.

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"definetti-mixture"}-->

🤖 Prepared with Codex
