### PR TITLE
feat: prove the argument principle for a null-homologous cycle

### DIFF
--- a/TauCeti/Analysis/Complex/IsolatedZero.lean
+++ b/TauCeti/Analysis/Complex/IsolatedZero.lean
@@ -25,9 +25,11 @@ this module does not import it:
   by a positive constant — this is what a competitor has to beat.
 * `TauCeti.analyticOrderAt_ne_top_of_forall_ne_zero`: the analytic order at the centre is finite,
   so the count Rouché produces is a natural number rather than `⊤`.
+* `TauCeti.analyticOrderAt_ne_top_of_zeros_subset`: the same finiteness under the hypothesis a
+  global zero count comes with, that the zeros in an open set lie in a finite set.
 
-Neither mentions Rouché's theorem itself; they are separated here only because two files need
-them.
+None of them mentions Rouché's theorem itself; they are separated here only because several files
+need them.
 -/
 
 public section
@@ -69,5 +71,24 @@ theorem analyticOrderAt_ne_top_of_forall_ne_zero {f : ℂ → ℂ} {a : ℂ} {ρ
   · simp only [mem_ball, hdist]; exact htρ
   · simp only [ne_eq, add_eq_left, Complex.ofReal_eq_zero]; exact ht0.ne'
   · rw [hdist]; exact htε
+
+/-- **A function whose zeros are confined to a finite set has finite order.** If every zero of `f`
+in an open set `U` lies in a finite set `S`, then `f` does not vanish identically near any point of
+`U`, so `analyticOrderAt f z ≠ ⊤` there.
+
+The point `z` itself is allowed to be a zero — indeed to lie in `S` — since vanishing identically
+near `z` would force a whole punctured neighbourhood of zeros, of which all but finitely many are
+outside `S`. This is the finite-set form of
+`TauCeti.analyticOrderAt_ne_top_of_forall_ne_zero`, and reduces to it on a small enough ball. -/
+theorem analyticOrderAt_ne_top_of_zeros_subset {f : ℂ → ℂ} {U : Set ℂ} {S : Finset ℂ} {z : ℂ}
+    (hU : IsOpen U) (hz : z ∈ U) (hzeros : ∀ w ∈ U, f w = 0 → w ∈ S) :
+    analyticOrderAt f z ≠ ⊤ := by
+  -- Deleting `z`, the finite set `S` is closed and misses `z`, so `U` minus it is an open
+  -- neighbourhood of `z`; any ball inside it has no zero of `f` off its centre.
+  have hopen : IsOpen (U ∩ ((S : Set ℂ) \ {z})ᶜ) :=
+    hU.inter (S.finite_toSet.sdiff).isClosed.isOpen_compl
+  obtain ⟨ρ, hρ, hball⟩ := Metric.isOpen_iff.mp hopen z ⟨hz, by simp⟩
+  exact analyticOrderAt_ne_top_of_forall_ne_zero hρ fun w hw hwz hw0 =>
+    (hball hw).2 ⟨hzeros w (hball hw).1 hw0, hwz⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/IsolatedZero.lean
+++ b/TauCeti/Analysis/Complex/IsolatedZero.lean
@@ -9,15 +9,19 @@ public import Mathlib.Analysis.Analytic.Order
 public import Mathlib.Analysis.Complex.Basic
 
 /-!
-# Estimates for a Rouché count on a small disc
+# Estimates near an isolated zero
 
-The two standing hypotheses of every Rouché comparison made on a disc whose centre is the only
-zero of the function inside it.
+A lower bound on a circle around a point at whose centre the function has its only zero, and two
+ways of concluding that the analytic order at a point is finite.
 
-Both `TauCeti.Analysis.Complex.Conformal.LocalDegree` and
+The first two are the standing hypotheses of every Rouché comparison made on such a disc: both
+`TauCeti.Analysis.Complex.Conformal.LocalDegree` and
 `TauCeti.Analysis.Complex.Conformal.Hurwitz` set up such a comparison, and each needs the same
-two facts about the disc before Rouché can be applied. Neither fact mentions Rouché's theorem, so
-this module does not import it:
+two facts about the disc before Rouché can be applied. The third has no Rouché content at all: it
+draws the same finiteness from the global hypothesis a zero count comes with, that the zeros in an
+open set lie in a finite set, and serves the arbitrary-cycle argument principle
+(`TauCeti.Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd`). No result here mentions
+Rouché's theorem, so this module does not import it:
 
 ## Main results
 
@@ -28,8 +32,7 @@ this module does not import it:
 * `TauCeti.analyticOrderAt_ne_top_of_zeros_subset`: the same finiteness under the hypothesis a
   global zero count comes with, that the zeros in an open set lie in a finite set.
 
-None of them mentions Rouché's theorem itself; they are separated here only because several files
-need them.
+They are separated here only because several files need them.
 -/
 
 public section

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -50,7 +50,7 @@ analyticity of `f` off `S`.
 
 * `TauCeti.Contour.argumentPrinciple_nullHomologous` — the argument principle for a closed
   null-homologous piecewise-`C¹` cycle: `∮_γ f'/f = 2πi · ∑_{z ∈ S} n_z(γ) · ord z`.
-* `TauCeti.Contour.argumentPrinciple_nullHomologous_single` — the one-point case
+* `TauCeti.Contour.argumentPrinciple_nullHomologous_local` — the one-point case
   `∮_γ f'/f = 2πi · n_{z₀}(γ) · n`, the arbitrary-cycle counterpart of
   `TauCeti.Contour.argumentPrinciple_local`.
 * `TauCeti.Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd` — the zero-counting
@@ -144,7 +144,7 @@ if `z₀` lies outside `U` then `f` is analytic and non-vanishing on all of `U`,
 makes `n_{z₀}(γ)` vanish, so both sides are `0` for any `n`. Accordingly the meromorphy and the
 order hypotheses are conditional on `z₀ ∈ U`, exactly as they are in
 `TauCeti.Contour.argumentPrinciple_nullHomologous`. -/
-theorem argumentPrinciple_nullHomologous_single {f : ℂ → ℂ} {U : Set ℂ} {z₀ : ℂ} {n : ℤ}
+theorem argumentPrinciple_nullHomologous_local {f : ℂ → ℂ} {U : Set ℂ} {z₀ : ℂ} {n : ℤ}
     (hU : IsOpen U) (hmero : z₀ ∈ U → MeromorphicAt f z₀)
     (hn : z₀ ∈ U → meromorphicOrderAt f z₀ = (n : WithTop ℤ))
     (hoff : ∀ z ∈ U, z ≠ z₀ → AnalyticAt ℂ f z ∧ f z ≠ 0)

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -5,6 +5,7 @@ Authors: The Tau Ceti contributors
 -/
 module
 
+public import TauCeti.Analysis.Complex.IsolatedZero
 public import TauCeti.Analysis.Contour.Residue.Cycle
 public import TauCeti.Analysis.Contour.Residue.LogDeriv
 
@@ -35,11 +36,14 @@ point of `S` it is meromorphic because `f` is.
 
 Null-homology is load-bearing, as it already is for the residue theorem: on a domain with a hole
 a loop that merely avoids the zeros and poles can still see the function's behaviour in the hole,
-and `n_w(γ) = 0` for every `w ∉ U` is exactly the hypothesis that rules this out. Unlike the
-circle statement, no pointwise "wrong values" of `f` are tolerated: a circle integral does not
-see a codiscrete change of the integrand, so `argumentPrinciple` may pass to the meromorphic
-normal form of `f`, whereas the image of a general curve is one-dimensional and a single
-misplaced value on it changes the integral. Accordingly the hypotheses here ask for genuine
+and `n_w(γ) = 0` for every `w ∉ U` is exactly the hypothesis that rules this out.
+
+Unlike the circle statement, no pointwise "wrong values" of `f` are tolerated. The circle proof
+may replace `f` by its meromorphic normal form because a circle integral is unchanged by a change
+of integrand on a set codiscrete within the sphere
+(`circleIntegral.circleIntegral_congr_codiscreteWithin`); no such congruence is available for a
+general piecewise-`C¹` contour, and the null-homologous residue theorem used here asks for honest
+differentiability of `logDeriv f` on `U ∖ S`. Accordingly the hypotheses here ask for genuine
 analyticity of `f` off `S`.
 
 ## Main results
@@ -53,9 +57,6 @@ analyticity of `f` off `S`.
   specialisation: for `f` analytic on `U` whose zeros lie in a finite `S`,
   `∮_γ f'/f = 2πi · ∑_{z ∈ S} n_z(γ) · analyticOrderNatAt f z`, the winding-weighted count of the
   zeros of `f` with multiplicity.
-* `TauCeti.Contour.analyticOrderAt_ne_top_of_zeros_subset` — the finiteness of the order that the
-  zero-counting form needs: a function whose zeros in an open set lie in a finite set never
-  vanishes identically near a point of that set.
 
 This is the arbitrary-cycle upgrade of a Layer-2 target of the contour-integration roadmap; like
 the residue theorem it rests on it, it is a Layer-3 statement, since its hypotheses and its proof
@@ -77,35 +78,11 @@ theorem is applied to `logDeriv f`).
 
 public section
 
-open Filter Set Topology
+open Set
 
 open scoped Interval
 
 namespace TauCeti.Contour
-
-/-- **A function whose zeros are confined to a finite set has finite order.** If every zero of `f`
-in an open set `U` lies in a finite set `S`, then `f` does not vanish identically near any point of
-`U`, so `analyticOrderAt f z ≠ ⊤` there.
-
-The point `z` itself is allowed to be a zero — indeed to lie in `S` — since vanishing identically
-near `z` would force a whole punctured neighbourhood of zeros, of which all but finitely many are
-outside `S`. -/
-theorem analyticOrderAt_ne_top_of_zeros_subset {f : ℂ → ℂ} {U : Set ℂ} {S : Finset ℂ} {z : ℂ}
-    (hU : IsOpen U) (hz : z ∈ U) (hzeros : ∀ w ∈ U, f w = 0 → w ∈ S) :
-    analyticOrderAt f z ≠ ⊤ := by
-  intro htop
-  -- Off `z` itself, `S` is a closed set missing `z`, so its complement is a neighbourhood of `z`.
-  have hcompl : ((S : Set ℂ) \ {z})ᶜ ∈ 𝓝 z :=
-    (S.finite_toSet.sdiff).isClosed.compl_mem_nhds (by simp)
-  -- A punctured neighbourhood of `z` would then consist of zeros of `f` lying outside `S`.
-  have hfalse : ∀ᶠ w in 𝓝[≠] z, False := by
-    filter_upwards [self_mem_nhdsWithin,
-      nhdsWithin_le_nhds (analyticOrderAt_eq_top.mp htop),
-      nhdsWithin_le_nhds (hU.mem_nhds hz), nhdsWithin_le_nhds hcompl] with w hwne hw0 hwU hwS
-    exact hwS ⟨hzeros w hwU hw0, hwne⟩
-  -- A punctured neighbourhood in `ℂ` is nonempty, so that is absurd.
-  obtain ⟨_, hcontra⟩ := hfalse.exists
-  exact hcontra
 
 /-- **The argument principle for an arbitrary null-homologous cycle.** Let `U` be open, `S` a
 finite set collecting every zero and pole of `f` in `U`: `f` is analytic and non-vanishing at each
@@ -194,8 +171,8 @@ winding number of `γ` about it. This is the pole-free specialisation of
 `TauCeti.Contour.argumentPrinciple_nullHomologous`, with the orders read off by
 `analyticOrderNatAt` instead of by a caller-supplied `ord`.
 
-The zeros are automatically of finite order (`analyticOrderAt_ne_top_of_zeros_subset`): confining
-them to a finite set already rules out `f` vanishing identically near a point of `U`. -/
+The zeros are automatically of finite order (`TauCeti.analyticOrderAt_ne_top_of_zeros_subset`):
+confining them to a finite set already rules out `f` vanishing identically near a point of `U`. -/
 theorem argumentPrinciple_nullHomologous_of_analyticOnNhd {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U) (hzeros : ∀ z ∈ U, f z = 0 → z ∈ S)
     {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Residue.Cycle
+public import TauCeti.Analysis.Contour.Residue.LogDeriv
+
+/-!
+# The argument principle for an arbitrary null-homologous cycle
+
+For `f` with all its zeros and poles inside a finite set `S`, and a closed piecewise-`C¹` curve
+`γ` that is **null-homologous** in the holomorphy domain `U` and avoids `S`,
+
+`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · ord_z f`,
+
+where `n_z(γ)` is the generalized winding number of `γ` about `z` and `ord_z f` is
+`meromorphicOrderAt f z` — positive at a zero, negative at a pole. This is the arbitrary-cycle
+form of the argument principle: the roadmap's Layer-2 statement
+`TauCeti.Contour.argumentPrinciple` fixes the contour to be a round circle with every special
+point strictly inside, so each order is counted exactly once; here the contour is any
+piecewise-`C¹` loop and each order is counted with the multiplicity with which the loop winds
+around it.
+
+The proof is the classical one-liner over the two pieces the repository already has: the residue
+theorem for a null-homologous cycle (`TauCeti.Contour.classicalResidueTheorem_nullHomologous`)
+applied to `logDeriv f`, whose residue at each point is the order of `f` there
+(`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What has to be supplied is the input
+regularity of `logDeriv f` rather than of `f`: off `S` the logarithmic derivative is holomorphic
+because `f` is analytic *and non-vanishing* there (a zero of `f` is a pole of `logDeriv f`, which
+is exactly why the hypothesis asks `S` to collect the zeros as well as the poles), and at each
+point of `S` it is meromorphic because `f` is.
+
+Null-homology is load-bearing, as it already is for the residue theorem: on a domain with a hole
+a loop that merely avoids the zeros and poles can still see the function's behaviour in the hole,
+and `n_w(γ) = 0` for every `w ∉ U` is exactly the hypothesis that rules this out. Unlike the
+circle statement, no pointwise "wrong values" of `f` are tolerated: a circle integral does not
+see a codiscrete change of the integrand, so `argumentPrinciple` may pass to the meromorphic
+normal form of `f`, whereas the image of a general curve is one-dimensional and a single
+misplaced value on it changes the integral. Accordingly the hypotheses here ask for genuine
+analyticity of `f` off `S`.
+
+## Main results
+
+* `TauCeti.Contour.argumentPrinciple_nullHomologous` — the argument principle for a closed
+  null-homologous piecewise-`C¹` cycle: `∮_γ f'/f = 2πi · ∑_{z ∈ S} n_z(γ) · ord z`.
+* `TauCeti.Contour.argumentPrinciple_nullHomologous_single` — the one-point case
+  `∮_γ f'/f = 2πi · n_{z₀}(γ) · n`, the arbitrary-cycle counterpart of
+  `TauCeti.Contour.argumentPrinciple_local`.
+* `TauCeti.Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd` — the zero-counting
+  specialisation: for `f` analytic on `U` whose zeros lie in a finite `S`,
+  `∮_γ f'/f = 2πi · ∑_{z ∈ S} n_z(γ) · analyticOrderNatAt f z`, the winding-weighted count of the
+  zeros of `f` with multiplicity.
+* `TauCeti.Contour.analyticOrderAt_ne_top_of_zeros_subset` — the finiteness of the order that the
+  zero-counting form needs: a function whose zeros in an open set lie in a finite set never
+  vanishes identically near a point of that set.
+
+This is the arbitrary-cycle upgrade of a Layer-2 target of the contour-integration roadmap; like
+the residue theorem it rests on it, it is a Layer-3 statement, since its hypotheses and its proof
+go through the homology Cauchy theorem.
+
+## Provenance
+
+No formal source is vendored: the statement is assembled here from the repository's residue
+theorem for a null-homologous cycle and the local residue-form of the argument principle, which
+are themselves migrated from the AINTLIB `LeanModularForms` development (where the residue
+theorem is applied to `logDeriv f`).
+
+## References
+
+* N. Hungerbühler, M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, arXiv:1808.00997 (2018).
+* S. Lang, *Complex Analysis* (GTM 103), Ch. VI, §1 (the argument principle in its homology form).
+-/
+
+public section
+
+open Filter Set Topology
+
+open scoped Interval
+
+namespace TauCeti.Contour
+
+/-- **A function whose zeros are confined to a finite set has finite order.** If every zero of `f`
+in an open set `U` lies in a finite set `S`, then `f` does not vanish identically near any point of
+`U`, so `analyticOrderAt f z ≠ ⊤` there.
+
+The point `z` itself is allowed to be a zero — indeed to lie in `S` — since vanishing identically
+near `z` would force a whole punctured neighbourhood of zeros, of which all but finitely many are
+outside `S`. -/
+theorem analyticOrderAt_ne_top_of_zeros_subset {f : ℂ → ℂ} {U : Set ℂ} {S : Finset ℂ} {z : ℂ}
+    (hU : IsOpen U) (hz : z ∈ U) (hzeros : ∀ w ∈ U, f w = 0 → w ∈ S) :
+    analyticOrderAt f z ≠ ⊤ := by
+  intro htop
+  -- Off `z` itself, `S` is a closed set missing `z`, so its complement is a neighbourhood of `z`.
+  have hcompl : ((S : Set ℂ) \ {z})ᶜ ∈ 𝓝 z :=
+    (S.finite_toSet.sdiff).isClosed.compl_mem_nhds (by simp)
+  -- A punctured neighbourhood of `z` would then consist of zeros of `f` lying outside `S`.
+  have hfalse : ∀ᶠ w in 𝓝[≠] z, False := by
+    filter_upwards [self_mem_nhdsWithin,
+      nhdsWithin_le_nhds (analyticOrderAt_eq_top.mp htop),
+      nhdsWithin_le_nhds (hU.mem_nhds hz), nhdsWithin_le_nhds hcompl] with w hwne hw0 hwU hwS
+    exact hwS ⟨hzeros w hwU hw0, hwne⟩
+  -- A punctured neighbourhood in `ℂ` is nonempty, so that is absurd.
+  obtain ⟨_, hcontra⟩ := hfalse.exists
+  exact hcontra
+
+/-- **The argument principle for an arbitrary null-homologous cycle.** Let `U` be open, `S` a
+finite set collecting every zero and pole of `f` in `U`: `f` is analytic and non-vanishing at each
+point of `U ∖ S`, and meromorphic of order `ord s` at each `s ∈ S` lying in `U`. Let `γ` be a
+closed piecewise-`C¹` curve in `U`, **null-homologous** in `U`, that **avoids** `S`. Then the
+contour integral of the logarithmic derivative counts the orders, each weighted by the winding
+number of `γ` about it:
+
+`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · ord z`.
+
+Since `ord` is positive at a zero and negative at a pole, this is `2πi` times the number of zeros
+minus poles counted with multiplicity *and* with winding multiplicity — for a simple loop
+enclosing them once, the classical zero-minus-pole count.
+
+As in `TauCeti.Contour.classicalResidueTheorem_nullHomologous`, points of `S` outside `U` are
+harmless rather than excluded: null-homology forces their winding number, hence their
+contribution, to vanish, so nothing is asked of `f` there. Likewise `S` may list regular
+non-vanishing points of `f`, whose order is `0`.
+
+The round-circle case, which asks nothing pointwise of `f` because it may pass to the meromorphic
+normal form, is `TauCeti.Contour.argumentPrinciple`. -/
+theorem argumentPrinciple_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ} {ord : ℂ → ℤ}
+    (hU : IsOpen U) (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)
+    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s)
+    (hord : ∀ s ∈ S, s ∈ U → meromorphicOrderAt f s = (ord s : WithTop ℤ))
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
+    ∫ t in a..b, deriv γ t • logDeriv f (γ t)
+      = 2 * (Real.pi : ℂ) * Complex.I * ∑ z ∈ S, windingNumber γ a b z * (ord z : ℂ) := by
+  -- Off `S` the function is analytic and non-vanishing, so its logarithmic derivative is
+  -- holomorphic there; at a point of `S` it is meromorphic, being `deriv f / f`.
+  have hdiff : DifferentiableOn ℂ (logDeriv f) (U \ (↑S : Set ℂ)) := fun z hz =>
+    (analyticAt_logDeriv_of_analyticAt (hoff z hz.1 hz.2).1
+      (hoff z hz.1 hz.2).2).differentiableAt.differentiableWithinAt
+  have hmeroL : ∀ s ∈ S, s ∈ U → MeromorphicAt (logDeriv f) s := fun s hs hsU =>
+    (hmero s hs hsU).deriv.div (hmero s hs hsU)
+  rw [classicalResidueTheorem_nullHomologous hU hdiff hmeroL hγ hγU hclosed hγoff hnull]
+  congr 1
+  refine Finset.sum_congr rfl fun s hs => ?_
+  by_cases hsU : s ∈ U
+  · -- `Res_s (f'/f) = ord_s f`.
+    rw [residue_logDeriv_eq_meromorphicOrderAt (hmero s hs hsU) (hord s hs hsU)]
+  · -- A point outside `U` has winding number `0`, so both summands vanish.
+    rw [isNullHomologous_iff.mp hnull s hsU, zero_mul, zero_mul]
+
+/-- **The argument principle for a cycle around a single zero or pole.** If `z₀` is the only point
+of an open `U` at which `f` fails to be analytic and non-vanishing, of order `n` there, and `γ` is a
+closed piecewise-`C¹` curve in `U`, null-homologous in `U`, missing `z₀`, then
+
+`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · n_{z₀}(γ) · n`.
+
+This is the `S = {z₀}` case of `TauCeti.Contour.argumentPrinciple_nullHomologous`, and the
+arbitrary-cycle counterpart of `TauCeti.Contour.argumentPrinciple_local`: a loop winding `k` times
+around a zero of order `n` integrates `f'/f` to `2πi · k · n`.
+
+Membership `z₀ ∈ U` is not required: if `z₀` lies outside `U` then `f` is analytic and
+non-vanishing on all of `U`, and null-homology makes `n_{z₀}(γ)` vanish, so both sides are `0`. -/
+theorem argumentPrinciple_nullHomologous_single {f : ℂ → ℂ} {U : Set ℂ} {z₀ : ℂ} {n : ℤ}
+    (hU : IsOpen U) (hmero : MeromorphicAt f z₀)
+    (hn : meromorphicOrderAt f z₀ = (n : WithTop ℤ))
+    (hoff : ∀ z ∈ U, z ≠ z₀ → AnalyticAt ℂ f z ∧ f z ≠ 0)
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ uIcc a b, γ t ≠ z₀) (hnull : IsNullHomologous γ a b U) :
+    ∫ t in a..b, deriv γ t • logDeriv f (γ t)
+      = 2 * (Real.pi : ℂ) * Complex.I * (windingNumber γ a b z₀ * (n : ℂ)) := by
+  have key := argumentPrinciple_nullHomologous (S := {z₀}) (ord := fun _ => n) hU
+    (fun z hzU hzS => hoff z hzU (by simpa using hzS))
+    (fun s hs _ => by rw [Finset.mem_singleton.mp hs]; exact hmero)
+    (fun s hs _ => by rw [Finset.mem_singleton.mp hs]; exact hn) hγ hγU hclosed
+    (fun t ht => by simpa using hγoff t ht) hnull
+  simpa using key
+
+/-- **Winding-weighted zero counting.** Let `f` be analytic on an open `U` with all its zeros in a
+finite set `S`, and let `γ` be a closed piecewise-`C¹` curve in `U`, null-homologous in `U`, that
+avoids `S`. Then
+
+`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · analyticOrderNatAt f z`:
+
+the contour integral of `f'/f` counts the zeros of `f` with multiplicity, each weighted by the
+winding number of `γ` about it. This is the pole-free specialisation of
+`TauCeti.Contour.argumentPrinciple_nullHomologous`, with the orders read off by
+`analyticOrderNatAt` instead of by a caller-supplied `ord`.
+
+The zeros are automatically of finite order (`analyticOrderAt_ne_top_of_zeros_subset`): confining
+them to a finite set already rules out `f` vanishing identically near a point of `U`. -/
+theorem argumentPrinciple_nullHomologous_of_analyticOnNhd {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
+    (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U) (hzeros : ∀ z ∈ U, f z = 0 → z ∈ S)
+    {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
+    ∫ t in a..b, deriv γ t • logDeriv f (γ t)
+      = 2 * (Real.pi : ℂ) * Complex.I *
+          ∑ z ∈ S, windingNumber γ a b z * (analyticOrderNatAt f z : ℂ) := by
+  refine argumentPrinciple_nullHomologous (ord := fun z => (analyticOrderNatAt f z : ℤ)) hU
+    (fun z hzU hzS => ⟨hf z hzU, fun h => hzS (hzeros z hzU h)⟩)
+    (fun s _ hsU => (hf s hsU).meromorphicAt) (fun s _ hsU => ?_) hγ hγU hclosed hγoff hnull
+  -- For an analytic function the meromorphic order is the analytic one, which is finite here.
+  rw [(hf s hsU).meromorphicOrderAt_eq,
+    ← Nat.cast_analyticOrderNatAt (analyticOrderAt_ne_top_of_zeros_subset hU hsU hzeros)]
+  simp
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -164,8 +164,8 @@ theorem argumentPrinciple_nullHomologous_local {f : ℂ → ℂ} {U : Set ℂ} {
   simpa using key
 
 /-- **Winding-weighted zero counting.** Let `f` be analytic on an open `U` with all its zeros in a
-finite set `S`, and let `γ` be a closed piecewise-`C¹` curve in `U`, null-homologous in `U`, that
-avoids `S`. Then
+finite set `S`, and let `γ` be a closed piecewise-`C¹` curve in `U`, null-homologous in `U`, along
+which `f` does not vanish. Then
 
 `∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · analyticOrderNatAt f z`:
 
@@ -174,23 +174,37 @@ winding number of `γ` about it. This is the pole-free specialisation of
 `TauCeti.Contour.argumentPrinciple_nullHomologous`, with the orders read off by
 `analyticOrderNatAt` instead of by a caller-supplied `ord`.
 
+Only the *zeros* need be avoided, not all of `S`: `S` may list points where `f` does not vanish,
+and `γ` is free to run through them, since `logDeriv f` is holomorphic there and their order — and
+so their term in the sum — is `0`.
+
 The zeros are automatically of finite order (`TauCeti.analyticOrderAt_ne_top_of_zeros_subset`):
 confining them to a finite set already rules out `f` vanishing identically near a point of `U`. -/
 theorem argumentPrinciple_nullHomologous_of_analyticOnNhd {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U) (hzeros : ∀ z ∈ U, f z = 0 → z ∈ S)
     {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
     (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
-    (hγoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
+    (hγoff : ∀ t ∈ uIcc a b, f (γ t) ≠ 0) (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • logDeriv f (γ t)
       = 2 * (Real.pi : ℂ) * Complex.I *
           ∑ z ∈ S, windingNumber γ a b z * (analyticOrderNatAt f z : ℂ) := by
-  refine argumentPrinciple_nullHomologous (ord := fun z => (analyticOrderNatAt f z : ℤ)) hU
-    (fun z hzU hzS => ⟨hf z hzU, fun h => hzS (hzeros z hzU h)⟩)
-    (fun s _ hsU => (hf s hsU).meromorphicAt) (fun s _ hsU => ?_) hγ hγU hclosed hγoff hnull
-  -- For an analytic function the meromorphic order is the analytic one, which is finite here.
-  rw [(hf s hsU).meromorphicOrderAt_eq,
-    ← Nat.cast_analyticOrderNatAt (analyticOrderAt_ne_top_of_zeros_subset hU hsU hzeros)]
-  simp
+  classical
+  -- Discard from `S` the points where `f` does not vanish: their order is `0`, so the sum is
+  -- unchanged, and what is left is a set the curve does avoid.
+  rw [← Finset.sum_subset (Finset.filter_subset (f · = 0) S) fun z _ hz => ?_]
+  · refine argumentPrinciple_nullHomologous (S := S.filter (f · = 0))
+      (ord := fun z => (analyticOrderNatAt f z : ℤ)) hU
+      (fun z hzU hzS => ⟨hf z hzU, fun h => hzS (Finset.mem_filter.mpr ⟨hzeros z hzU h, h⟩)⟩)
+      (fun s _ hsU => (hf s hsU).meromorphicAt) (fun s _ hsU => ?_) hγ hγU hclosed
+      (fun t ht hmem => hγoff t ht (Finset.mem_filter.mp hmem).2) hnull
+    -- For an analytic function the meromorphic order is the analytic one, which is finite here.
+    rw [(hf s hsU).meromorphicOrderAt_eq,
+      ← Nat.cast_analyticOrderNatAt (analyticOrderAt_ne_top_of_zeros_subset hU hsU hzeros)]
+    simp
+  · have : analyticOrderNatAt f z = 0 := by
+      by_contra h
+      exact hz (Finset.mem_filter.mpr ⟨‹z ∈ S›, apply_eq_zero_of_analyticOrderNatAt_ne_zero h⟩)
+    simp [this]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -38,13 +38,14 @@ Null-homology is load-bearing, as it already is for the residue theorem: on a do
 a loop that merely avoids the zeros and poles can still see the function's behaviour in the hole,
 and `n_w(γ) = 0` for every `w ∉ U` is exactly the hypothesis that rules this out.
 
-Unlike the circle statement, no pointwise "wrong values" of `f` are tolerated. The circle proof
-may replace `f` by its meromorphic normal form because a circle integral is unchanged by a change
-of integrand on a set codiscrete within the sphere
+Unlike the circle statement, the hypotheses ask for genuine analyticity and non-vanishing of `f` at
+every point of `U ∖ S`, so no pointwise "wrong value" there is tolerated. Nothing pointwise is
+asked at the points of `S`, where only meromorphy is required, nor anywhere outside `U`. The circle
+proof may instead replace `f` by its meromorphic normal form, because a circle integral is
+unchanged by a change of integrand on a set codiscrete within the sphere
 (`circleIntegral.circleIntegral_congr_codiscreteWithin`); no such congruence is available for a
 general piecewise-`C¹` contour, and the null-homologous residue theorem used here asks for honest
-differentiability of `logDeriv f` on `U ∖ S`. Accordingly the hypotheses here ask for genuine
-analyticity of `f` off `S`.
+differentiability of `logDeriv f` on `U ∖ S`.
 
 ## Main results
 

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -162,11 +162,14 @@ This is the `S = {z₀}` case of `TauCeti.Contour.argumentPrinciple_nullHomologo
 arbitrary-cycle counterpart of `TauCeti.Contour.argumentPrinciple_local`: a loop winding `k` times
 around a zero of order `n` integrates `f'/f` to `2πi · k · n`.
 
-Membership `z₀ ∈ U` is not required: if `z₀` lies outside `U` then `f` is analytic and
-non-vanishing on all of `U`, and null-homology makes `n_{z₀}(γ)` vanish, so both sides are `0`. -/
+Membership `z₀ ∈ U` is not required, and nothing at all is asked of `f` at `z₀` unless it holds:
+if `z₀` lies outside `U` then `f` is analytic and non-vanishing on all of `U`, and null-homology
+makes `n_{z₀}(γ)` vanish, so both sides are `0` for any `n`. Accordingly the meromorphy and the
+order hypotheses are conditional on `z₀ ∈ U`, exactly as they are in
+`TauCeti.Contour.argumentPrinciple_nullHomologous`. -/
 theorem argumentPrinciple_nullHomologous_single {f : ℂ → ℂ} {U : Set ℂ} {z₀ : ℂ} {n : ℤ}
-    (hU : IsOpen U) (hmero : MeromorphicAt f z₀)
-    (hn : meromorphicOrderAt f z₀ = (n : WithTop ℤ))
+    (hU : IsOpen U) (hmero : z₀ ∈ U → MeromorphicAt f z₀)
+    (hn : z₀ ∈ U → meromorphicOrderAt f z₀ = (n : WithTop ℤ))
     (hoff : ∀ z ∈ U, z ≠ z₀ → AnalyticAt ℂ f z ∧ f z ≠ 0)
     {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
     (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
@@ -175,8 +178,8 @@ theorem argumentPrinciple_nullHomologous_single {f : ℂ → ℂ} {U : Set ℂ} 
       = 2 * (Real.pi : ℂ) * Complex.I * (windingNumber γ a b z₀ * (n : ℂ)) := by
   have key := argumentPrinciple_nullHomologous (S := {z₀}) (ord := fun _ => n) hU
     (fun z hzU hzS => hoff z hzU (by simpa using hzS))
-    (fun s hs _ => by rw [Finset.mem_singleton.mp hs]; exact hmero)
-    (fun s hs _ => by rw [Finset.mem_singleton.mp hs]; exact hn) hγ hγU hclosed
+    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hmero hsU)
+    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hn hsU) hγ hγU hclosed
     (fun t ht => by simpa using hγoff t ht) hnull
   simpa using key
 

--- a/TauCeti/Analysis/Contour/Argument/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Cycle.lean
@@ -12,27 +12,29 @@ public import TauCeti.Analysis.Contour.Residue.LogDeriv
 /-!
 # The argument principle for an arbitrary null-homologous cycle
 
-For `f` with all its zeros and poles inside a finite set `S`, and a closed piecewise-`C¹` curve
-`γ` that is **null-homologous** in the holomorphy domain `U` and avoids `S`,
+For `f` whose zeros and poles *in* an open set `U` all lie in a finite set `S`, and a closed
+piecewise-`C¹` curve `γ` that is **null-homologous** in `U` and avoids `S`,
 
-`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · ord_z f`,
+`∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · ord z`,
 
-where `n_z(γ)` is the generalized winding number of `γ` about `z` and `ord_z f` is
-`meromorphicOrderAt f z` — positive at a zero, negative at a pole. This is the arbitrary-cycle
-form of the argument principle: the roadmap's Layer-2 statement
-`TauCeti.Contour.argumentPrinciple` fixes the contour to be a round circle with every special
-point strictly inside, so each order is counted exactly once; here the contour is any
-piecewise-`C¹` loop and each order is counted with the multiplicity with which the loop winds
-around it.
+where `n_z(γ)` is the generalized winding number of `γ` about `z` and `ord` is a caller-supplied
+integer-valued function required to agree with `meromorphicOrderAt f` only at the points of `S`
+that lie in `U` — positive at a zero, negative at a pole. Nothing is asked of `f` or of `ord` at a
+point of `S` outside `U`: null-homology forces the winding number there to vanish, so its term
+drops out whatever `ord` says. This is the arbitrary-cycle form of the argument principle: the
+roadmap's Layer-2 statement `TauCeti.Contour.argumentPrinciple` fixes the contour to be a round
+circle with every special point strictly inside, so each order is counted exactly once; here the
+contour is any piecewise-`C¹` loop and each order is counted with the multiplicity with which the
+loop winds around it.
 
 The proof is the classical one-liner over the two pieces the repository already has: the residue
 theorem for a null-homologous cycle (`TauCeti.Contour.classicalResidueTheorem_nullHomologous`)
 applied to `logDeriv f`, whose residue at each point is the order of `f` there
 (`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What has to be supplied is the input
-regularity of `logDeriv f` rather than of `f`: off `S` the logarithmic derivative is holomorphic
+regularity of `logDeriv f` rather than of `f`: on `U ∖ S` the logarithmic derivative is holomorphic
 because `f` is analytic *and non-vanishing* there (a zero of `f` is a pole of `logDeriv f`, which
 is exactly why the hypothesis asks `S` to collect the zeros as well as the poles), and at each
-point of `S` it is meromorphic because `f` is.
+point of `S` lying in `U` it is meromorphic because `f` is.
 
 Null-homology is load-bearing, as it already is for the residue theorem: on a domain with a hole
 a loop that merely avoids the zeros and poles can still see the function's behaviour in the hole,
@@ -40,9 +42,9 @@ and `n_w(γ) = 0` for every `w ∉ U` is exactly the hypothesis that rules this 
 
 Unlike the circle statement, the hypotheses ask for genuine analyticity and non-vanishing of `f` at
 every point of `U ∖ S`, so no pointwise "wrong value" there is tolerated. Nothing pointwise is
-asked at the points of `S`, where only meromorphy is required, nor anywhere outside `U`. The circle
-proof may instead replace `f` by its meromorphic normal form, because a circle integral is
-unchanged by a change of integrand on a set codiscrete within the sphere
+asked at the points of `S` lying in `U`, where only meromorphy is required, nor anywhere outside
+`U`. The circle proof may instead replace `f` by its meromorphic normal form, because a circle
+integral is unchanged by a change of integrand on a set codiscrete within the sphere
 (`circleIntegral.circleIntegral_congr_codiscreteWithin`); no such congruence is available for a
 general piecewise-`C¹` contour, and the null-homologous residue theorem used here asks for honest
 differentiability of `logDeriv f` on `U ∖ S`.


### PR DESCRIPTION
This PR proves the argument principle for an arbitrary closed, null-homologous piecewise-`C¹` cycle, adding `TauCeti/Analysis/Contour/Argument/Cycle.lean`. For `f` whose zeros and poles in an open `U` are confined to a finite set `S`, and a closed piecewise-`C¹` curve `γ` in `U` that is null-homologous there and avoids `S`, `∫ t in a..b, γ' t • logDeriv f (γ t) = 2πi · ∑_{z ∈ S} n_z(γ) · ord_z f`, each meromorphic order weighted by the generalized winding number of `γ` about it. This is the arbitrary-cycle upgrade of the roadmap's Layer-2 target `TauCeti.Contour.argumentPrinciple`, which fixes the contour to a round circle with every special point strictly inside and so counts each order exactly once; here the contour is any piecewise-`C¹` loop and each order is counted with the multiplicity with which the loop winds around it. The roadmap target is `TauCetiRoadmap/ContourIntegration/README.md`, Layer 2, "**The argument principle** (the valence formula's contour identity) — what the engine *does* add. Applying the residue theorem to `f'/f = logDeriv f`, `(2πi)⁻¹ ∮_C f'/f = Σ_z ord_z(f)` counts zeros minus poles with multiplicity (`Res_z (f'/f) = ord_z f`)", in the arbitrary-cycle scope that the same README defers to Layer 3+ ("*The general arbitrary-cycle case* … deferred to Layer 3+"), now reachable because `TauCeti.Contour.classicalResidueTheorem_nullHomologous` has landed.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"argument-principle-null-homologous"}-->

The proof is the classical composition over pieces the repository already has: the residue theorem for a null-homologous cycle applied to `logDeriv f`, whose residue at each point is the order of `f` there (`TauCeti.Contour.residue_logDeriv_eq_meromorphicOrderAt`). What the file actually has to supply is the input regularity of `logDeriv f` rather than of `f` — off `S` the logarithmic derivative is holomorphic because `f` is analytic *and* non-vanishing there, which is why the hypothesis asks `S` to collect the zeros as well as the poles, and at each point of `S` it is meromorphic because `f` is. Points of `S` outside `U` are handled the way the residue theorem handles them, as harmless rather than excluded: null-homology forces their winding number, hence their contribution, to vanish, so nothing is asked of `f` there.

Unlike the circle statement, the hypotheses ask for genuine analyticity of `f` off `S` rather than tolerating pointwise "wrong values". That is deliberate and is recorded in the module docstring: a circle integral does not see a codiscrete change of its integrand, so `argumentPrinciple` may pass to the meromorphic normal form of `f`, whereas the image of a general curve is one-dimensional and a single misplaced value on it changes the integral.

Alongside the main theorem the file adds the one-point specialisation `argumentPrinciple_nullHomologous_single` (`∮_γ f'/f = 2πi · n_{z₀}(γ) · n`, the arbitrary-cycle counterpart of `argumentPrinciple_local`, stated without `z₀ ∈ U` since null-homology already makes that case degenerate), the zero-counting form `argumentPrinciple_nullHomologous_of_analyticOnNhd` reading the multiplicities off Mathlib's `analyticOrderNatAt` instead of a caller-supplied order function, and — in `TauCeti/Analysis/Complex/IsolatedZero.lean`, alongside the lemma it is derived from — the small general fact `TauCeti.analyticOrderAt_ne_top_of_zeros_subset` that the latter needs: a function whose zeros in an open set lie in a finite set cannot vanish identically near a point of that set.

No Mathlib infrastructure is vendored and no source is copied. Everything consumed is either upstream (`logDeriv`, `meromorphicOrderAt`, `analyticOrderAt`/`analyticOrderNatAt`, `AnalyticAt.meromorphicOrderAt_eq`) or already in this repository (`classicalResidueTheorem_nullHomologous`, `residue_logDeriv_eq_meromorphicOrderAt`, `analyticAt_logDeriv_of_analyticAt`, `IsPiecewiseC1On`, `windingNumber`, `IsNullHomologous`); the module docstring records that those repository pieces are themselves migrated from the AINTLIB `LeanModularForms` development, where the residue theorem is applied to `logDeriv f`.

`lake build` and `lake exe axioms` are green (`all within the allowlist [propext, Classical.choice, Quot.sound]`), as are `lake exe module-system` and `scripts/lint-env.sh`.

🤖 Prepared with Claude Code

