### PR TITLE
refactor(Probability): extract the L² rate between two directing measures

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -33,9 +33,6 @@ representative but not another directing measure.
 * `ConditionallyIIDWith.integral_empiricalFrequency_sub_sq` — the `L²` rate: the empirical
   frequency of a measurable set `B` along the first `n` coordinates approximates `(ν ·) B` with
   mean square error exactly `(∫ (ν ·) B - ∫ ((ν ·) B) ^ 2) / n`.
-* `ConditionallyIIDWith.integral_directing_sub_sq_le_four_div` — the finite-sample form of
-  uniqueness: two directing measures of the same process are within `4 / n` of each other in mean
-  square on each fixed measurable set, for every `n ≥ 1`.
 * `conditionallyIID_ae_unique` — two directing measures of the same process are a.e. equal.
 
 ## Implementation
@@ -491,8 +488,11 @@ private theorem integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_
 
 /-- **The `L²` rate between two directing measures.** Two directing measures of the same process
 are within `4 / n` of each other in mean square, for every `n ≥ 1`, on each fixed measurable set.
-This is the quantitative form of `ae_measure_apply_eq`, which is its `n → ∞` limit. -/
-theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsProbabilityMeasure μ]
+This is the scaffolding for `ae_measure_apply_eq`, which is its `n → ∞` limit. It stays private:
+that theorem has the same hypotheses and makes the integrand a.e. zero, so once it is available
+this bound is a trivial consequence and carries no independent content. -/
+private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div
+    [IsProbabilityMeasure μ]
     (hX : ∀ i, AEMeasurable (X i) μ) (h : ConditionallyIIDWith μ X ν)
     (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B) {n : ℕ} (hn : n ≠ 0) :
     ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ ≤ 4 / n := by

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -6,6 +6,9 @@ Authors: Claude
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
+-- Non-public: `measurable_probabilityMeasure_apply_real` evaluates a random measure at a fixed
+-- measurable set.
+import TauCeti.MeasureTheory.Measure.ProbabilityMeasureExt
 -- Non-public: the countable set algebra that compares two random measures set by set.
 import Mathlib.MeasureTheory.SetAlgebra
 -- Non-public: `tendsto_const_div_atTop_nhds_zero_nat` closes the `O(1/n)` squeeze.
@@ -485,21 +488,14 @@ private theorem integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_
 
 /-- **The `L²` rate between two directing measures.** Two directing measures of the same process
 are within `4 / n` of each other in mean square, for every `n ≥ 1`, on each fixed measurable set.
-This is the quantitative form of `ae_measure_apply_eq`, which is its `n → ∞` limit.
-
-Integrability of the squared difference is a hypothesis rather than a consequence: the rate bounds
-available for the two measures separately constrain only the squares of the individual errors,
-which does not make their difference measurable. -/
+This is the quantitative form of `ae_measure_apply_eq`, which is its `n → ∞` limit. -/
 private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsProbabilityMeasure μ]
     (hX : ∀ i, AEMeasurable (X i) μ) (h : ConditionallyIIDWith μ X ν)
-    (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B)
-    (hdint : Integrable (fun ω =>
-      (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2) μ)
-    {n : ℕ} (hn : n ≠ 0) :
+    (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B) {n : ℕ} (hn : n ≠ 0) :
     ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ ≤ 4 / n := by
   have hqm : ∀ ρ : Ω → ProbabilityMeasure α, Measurable ρ →
-      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun ρ hρ =>
-    ((Measure.measurable_coe hB).comp (measurable_subtype_coe.comp hρ)).ennreal_toReal
+      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun _ hρ =>
+    (TauCeti.MeasureTheory.measurable_probabilityMeasure_apply_real hB).comp hρ
   have habs : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω),
       |((ρ ω : Measure α) B).toReal| ≤ 1 := fun ρ ω => by
     rw [abs_of_nonneg ENNReal.toReal_nonneg]
@@ -512,6 +508,11 @@ private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsPr
   have heb : ∀ (m : ℕ) (ω : Ω),
       |(m : ℝ)⁻¹ * ∑ i ∈ Finset.range m, (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω| ≤ 1 :=
     fun m ω => abs_average_indicator_le_one (fun i => X i ⁻¹' B) m ω
+  have hdint : Integrable (fun ω =>
+      (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2) μ :=
+    integrable_sub_sq_of_abs_le_one (hqm ν h.measurable_directing).aemeasurable
+      (hqm ν' h'.measurable_directing).aemeasurable
+      (ae_of_all _ (habs ν)) (ae_of_all _ (habs ν'))
   -- Both errors are bounded by `1 / n`, so the general `2c₁ + 2c₂` bound specializes to `4 / n`.
   have hb : ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ
       ≤ 2 * (n : ℝ)⁻¹ + 2 * (n : ℝ)⁻¹ :=
@@ -535,8 +536,8 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
     (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B) :
     (fun ω => (ν ω : Measure α) B) =ᵐ[μ] fun ω => (ν' ω : Measure α) B := by
   have hqm : ∀ ρ : Ω → ProbabilityMeasure α, Measurable ρ →
-      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun ρ hρ =>
-    ((Measure.measurable_coe hB).comp (measurable_subtype_coe.comp hρ)).ennreal_toReal
+      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun _ hρ =>
+    (TauCeti.MeasureTheory.measurable_probabilityMeasure_apply_real hB).comp hρ
   have hq0 : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω), 0 ≤ ((ρ ω : Measure α) B).toReal :=
     fun _ _ => ENNReal.toReal_nonneg
   have hq1 : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω), ((ρ ω : Measure α) B).toReal ≤ 1 := by
@@ -551,8 +552,9 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
       (ae_of_all _ fun ω => ?_)
     rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
     nlinarith [hq0 ν ω, hq1 ν ω, hq0 ν' ω, hq1 ν' ω]
-  have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := fun n hn =>
-    h.integral_directing_sub_sq_le_four_div hX h' hB hdint (by omega)
+  -- `hd_def` turns the `set` wrapper `d` into the explicit difference the rate lemma is stated for.
+  have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := fun n hn => by
+    simpa only [hd_def] using h.integral_directing_sub_sq_le_four_div hX h' hB (n := n) (by omega)
   have hle : ∫ ω, d ω ^ 2 ∂μ ≤ 0 :=
     ge_of_tendsto (tendsto_const_div_atTop_nhds_zero_nat (4 : ℝ))
       (eventually_atTop.2 ⟨1, fun n hn => hbound n hn⟩)

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -486,6 +486,24 @@ private theorem integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_
           integral_const_mul]
     _ ≤ 2 * c₁ + 2 * c₂ := by linarith
 
+/-- **The squared difference of two directing masses is integrable.** Each evaluation
+`ω ↦ ((ρ ω) B).toReal` is measurable and takes values in `[0, 1]`, so the square of the difference
+is bounded, hence integrable on a finite measure space. -/
+private theorem integrable_toReal_directing_sub_sq [IsFiniteMeasure μ]
+    {ρ ρ' : Ω → ProbabilityMeasure α} (hρ : Measurable ρ) (hρ' : Measurable ρ')
+    (hB : MeasurableSet B) :
+    Integrable (fun ω =>
+      (((ρ ω : Measure α) B).toReal - ((ρ' ω : Measure α) B).toReal) ^ 2) μ := by
+  have habs : ∀ (σ : Ω → ProbabilityMeasure α) (ω : Ω),
+      |((σ ω : Measure α) B).toReal| ≤ 1 := fun σ ω => by
+    rw [abs_of_nonneg ENNReal.toReal_nonneg]
+    simpa using
+      ENNReal.toReal_mono ENNReal.one_ne_top (prob_le_one (μ := (σ ω : Measure α)) (s := B))
+  exact integrable_sub_sq_of_abs_le_one
+    ((TauCeti.MeasureTheory.measurable_probabilityMeasure_apply_real hB).comp hρ).aemeasurable
+    ((TauCeti.MeasureTheory.measurable_probabilityMeasure_apply_real hB).comp hρ').aemeasurable
+    (ae_of_all _ (habs ρ)) (ae_of_all _ (habs ρ'))
+
 /-- **The `L²` rate between two directing measures.** Two directing measures of the same process
 are within `4 / n` of each other in mean square, for every `n ≥ 1`, on each fixed measurable set.
 This is the scaffolding for `ae_measure_apply_eq`, which is its `n → ∞` limit. It stays private:
@@ -513,9 +531,7 @@ private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div
     fun m ω => abs_average_indicator_le_one (fun i => X i ⁻¹' B) m ω
   have hdint : Integrable (fun ω =>
       (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2) μ :=
-    integrable_sub_sq_of_abs_le_one (hqm ν h.measurable_directing).aemeasurable
-      (hqm ν' h'.measurable_directing).aemeasurable
-      (ae_of_all _ (habs ν)) (ae_of_all _ (habs ν'))
+    integrable_toReal_directing_sub_sq h.measurable_directing h'.measurable_directing hB
   -- Both errors are bounded by `1 / n`, so the general `2c₁ + 2c₂` bound specializes to `4 / n`.
   have hb : ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ
       ≤ 2 * (n : ℝ)⁻¹ + 2 * (n : ℝ)⁻¹ :=
@@ -538,24 +554,11 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
     (hX : ∀ i, AEMeasurable (X i) μ) (h : ConditionallyIIDWith μ X ν)
     (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B) :
     (fun ω => (ν ω : Measure α) B) =ᵐ[μ] fun ω => (ν' ω : Measure α) B := by
-  have hqm : ∀ ρ : Ω → ProbabilityMeasure α, Measurable ρ →
-      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun _ hρ =>
-    (TauCeti.MeasureTheory.measurable_probabilityMeasure_apply_real hB).comp hρ
-  have hq0 : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω), 0 ≤ ((ρ ω : Measure α) B).toReal :=
-    fun _ _ => ENNReal.toReal_nonneg
-  have hq1 : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω), ((ρ ω : Measure α) B).toReal ≤ 1 := by
-    intro ρ ω
-    simpa using
-      ENNReal.toReal_mono ENNReal.one_ne_top (prob_le_one (μ := (ρ ω : Measure α)) (s := B))
   set d : Ω → ℝ := fun ω =>
     ((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal with hd_def
-  have habs : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω),
-      |((ρ ω : Measure α) B).toReal| ≤ 1 := fun ρ ω => by
-    rw [abs_of_nonneg (hq0 ρ ω)]; exact hq1 ρ ω
-  have hdint : Integrable (fun ω => d ω ^ 2) μ :=
-    integrable_sub_sq_of_abs_le_one (hqm ν h.measurable_directing).aemeasurable
-      (hqm ν' h'.measurable_directing).aemeasurable
-      (ae_of_all _ (habs ν)) (ae_of_all _ (habs ν'))
+  have hdint : Integrable (fun ω => d ω ^ 2) μ := by
+    simpa only [hd_def] using
+      integrable_toReal_directing_sub_sq h.measurable_directing h'.measurable_directing hB
   -- `hd_def` turns the `set` wrapper `d` into the explicit difference the rate lemma is stated for.
   have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := fun n hn => by
     simpa only [hd_def] using h.integral_directing_sub_sq_le_four_div hX h' hB (n := n) (by omega)

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -33,6 +33,9 @@ representative but not another directing measure.
 * `ConditionallyIIDWith.integral_empiricalFrequency_sub_sq` — the `L²` rate: the empirical
   frequency of a measurable set `B` along the first `n` coordinates approximates `(ν ·) B` with
   mean square error exactly `(∫ (ν ·) B - ∫ ((ν ·) B) ^ 2) / n`.
+* `ConditionallyIIDWith.integral_directing_sub_sq_le_four_div` — the finite-sample form of
+  uniqueness: two directing measures of the same process are within `4 / n` of each other in mean
+  square on each fixed measurable set, for every `n ≥ 1`.
 * `conditionallyIID_ae_unique` — two directing measures of the same process are a.e. equal.
 
 ## Implementation
@@ -489,7 +492,7 @@ private theorem integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_
 /-- **The `L²` rate between two directing measures.** Two directing measures of the same process
 are within `4 / n` of each other in mean square, for every `n ≥ 1`, on each fixed measurable set.
 This is the quantitative form of `ae_measure_apply_eq`, which is its `n → ∞` limit. -/
-private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsProbabilityMeasure μ]
+theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsProbabilityMeasure μ]
     (hX : ∀ i, AEMeasurable (X i) μ) (h : ConditionallyIIDWith μ X ν)
     (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B) {n : ℕ} (hn : n ≠ 0) :
     ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ ≤ 4 / n := by
@@ -546,12 +549,13 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
       ENNReal.toReal_mono ENNReal.one_ne_top (prob_le_one (μ := (ρ ω : Measure α)) (s := B))
   set d : Ω → ℝ := fun ω =>
     ((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal with hd_def
-  have hdm : Measurable d := (hqm ν h.measurable_directing).sub (hqm ν' h'.measurable_directing)
-  have hdint : Integrable (fun ω => d ω ^ 2) μ := by
-    refine Integrable.of_bound (hdm.pow_const 2).aestronglyMeasurable 1
-      (ae_of_all _ fun ω => ?_)
-    rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
-    nlinarith [hq0 ν ω, hq1 ν ω, hq0 ν' ω, hq1 ν' ω]
+  have habs : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω),
+      |((ρ ω : Measure α) B).toReal| ≤ 1 := fun ρ ω => by
+    rw [abs_of_nonneg (hq0 ρ ω)]; exact hq1 ρ ω
+  have hdint : Integrable (fun ω => d ω ^ 2) μ :=
+    integrable_sub_sq_of_abs_le_one (hqm ν h.measurable_directing).aemeasurable
+      (hqm ν' h'.measurable_directing).aemeasurable
+      (ae_of_all _ (habs ν)) (ae_of_all _ (habs ν'))
   -- `hd_def` turns the `set` wrapper `d` into the explicit difference the rate lemma is stated for.
   have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := fun n hn => by
     simpa only [hd_def] using h.integral_directing_sub_sq_le_four_div hX h' hB (n := n) (by omega)

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Unique.lean
@@ -483,6 +483,48 @@ private theorem integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_
           integral_const_mul]
     _ ≤ 2 * c₁ + 2 * c₂ := by linarith
 
+/-- **The `L²` rate between two directing measures.** Two directing measures of the same process
+are within `4 / n` of each other in mean square, for every `n ≥ 1`, on each fixed measurable set.
+This is the quantitative form of `ae_measure_apply_eq`, which is its `n → ∞` limit.
+
+Integrability of the squared difference is a hypothesis rather than a consequence: the rate bounds
+available for the two measures separately constrain only the squares of the individual errors,
+which does not make their difference measurable. -/
+private theorem ConditionallyIIDWith.integral_directing_sub_sq_le_four_div [IsProbabilityMeasure μ]
+    (hX : ∀ i, AEMeasurable (X i) μ) (h : ConditionallyIIDWith μ X ν)
+    (h' : ConditionallyIIDWith μ X ν') (hB : MeasurableSet B)
+    (hdint : Integrable (fun ω =>
+      (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2) μ)
+    {n : ℕ} (hn : n ≠ 0) :
+    ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ ≤ 4 / n := by
+  have hqm : ∀ ρ : Ω → ProbabilityMeasure α, Measurable ρ →
+      Measurable fun ω => ((ρ ω : Measure α) B).toReal := fun ρ hρ =>
+    ((Measure.measurable_coe hB).comp (measurable_subtype_coe.comp hρ)).ennreal_toReal
+  have habs : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω),
+      |((ρ ω : Measure α) B).toReal| ≤ 1 := fun ρ ω => by
+    rw [abs_of_nonneg ENNReal.toReal_nonneg]
+    simpa using
+      ENNReal.toReal_mono ENNReal.one_ne_top (prob_le_one (μ := (ρ ω : Measure α)) (s := B))
+  have hem : ∀ m : ℕ, AEMeasurable (fun ω =>
+      (m : ℝ)⁻¹ * ∑ i ∈ Finset.range m, (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω) μ := fun m =>
+    aemeasurable_const.mul (Finset.aemeasurable_fun_sum _ fun i _ =>
+      measurable_one.aemeasurable.indicator₀ ((hX i).nullMeasurableSet_preimage hB))
+  have heb : ∀ (m : ℕ) (ω : Ω),
+      |(m : ℝ)⁻¹ * ∑ i ∈ Finset.range m, (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω| ≤ 1 :=
+    fun m ω => abs_average_indicator_le_one (fun i => X i ⁻¹' B) m ω
+  -- Both errors are bounded by `1 / n`, so the general `2c₁ + 2c₂` bound specializes to `4 / n`.
+  have hb : ∫ ω, (((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal) ^ 2 ∂μ
+      ≤ 2 * (n : ℝ)⁻¹ + 2 * (n : ℝ)⁻¹ :=
+    integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_integral_sub_sq_le hdint
+      (integrable_sub_sq_of_abs_le_one (hem n) (hqm ν h.measurable_directing).aemeasurable
+        (ae_of_all _ (heb n)) (ae_of_all _ (habs ν)))
+      (integrable_sub_sq_of_abs_le_one (hem n) (hqm ν' h'.measurable_directing).aemeasurable
+        (ae_of_all _ (heb n)) (ae_of_all _ (habs ν')))
+      (h.integral_empiricalFrequency_sub_sq_le hX hB hn)
+      (h'.integral_empiricalFrequency_sub_sq_le hX hB hn)
+  rw [div_eq_mul_inv]
+  linarith
+
 /-- Two directing measures of the same process assign the same mass to each fixed measurable set,
 almost everywhere.
 
@@ -501,16 +543,6 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
     intro ρ ω
     simpa using
       ENNReal.toReal_mono ENNReal.one_ne_top (prob_le_one (μ := (ρ ω : Measure α)) (s := B))
-  have hXB : ∀ i, NullMeasurableSet (X i ⁻¹' B) μ := fun i =>
-    (hX i).nullMeasurableSet_preimage hB
-  have hem : ∀ n : ℕ, AEMeasurable (fun ω =>
-      (n : ℝ)⁻¹ * ∑ i ∈ Finset.range n, (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω) μ := by
-    intro n
-    exact aemeasurable_const.mul
-      (Finset.aemeasurable_fun_sum _ fun i _ => measurable_one.aemeasurable.indicator₀ (hXB i))
-  have heb : ∀ (n : ℕ) (ω : Ω),
-      |(n : ℝ)⁻¹ * ∑ i ∈ Finset.range n, (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω| ≤ 1 :=
-    fun n ω => abs_average_indicator_le_one (fun i => X i ⁻¹' B) n ω
   set d : Ω → ℝ := fun ω =>
     ((ν ω : Measure α) B).toReal - ((ν' ω : Measure α) B).toReal with hd_def
   have hdm : Measurable d := (hqm ν h.measurable_directing).sub (hqm ν' h'.measurable_directing)
@@ -519,27 +551,8 @@ theorem ConditionallyIIDWith.ae_measure_apply_eq [IsProbabilityMeasure μ]
       (ae_of_all _ fun ω => ?_)
     rw [Real.norm_eq_abs, abs_of_nonneg (by positivity)]
     nlinarith [hq0 ν ω, hq1 ν ω, hq0 ν' ω, hq1 ν' ω]
-  have habs : ∀ (ρ : Ω → ProbabilityMeasure α) (ω : Ω),
-      |((ρ ω : Measure α) B).toReal| ≤ 1 := fun ρ ω => by
-    rw [abs_of_nonneg (hq0 ρ ω)]; exact hq1 ρ ω
-  have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := by
-    intro n hn
-    have hn0 : n ≠ 0 := by omega
-    -- Both errors are bounded by `1 / n`, so the general `2c₁ + 2c₂` bound specializes to `4 / n`.
-    -- `hd_def` turns the `set` wrapper `d` into the explicit difference the helper is stated for.
-    have hb : ∫ ω, d ω ^ 2 ∂μ ≤ 2 * (n : ℝ)⁻¹ + 2 * (n : ℝ)⁻¹ := by
-      simpa only [hd_def] using
-        integral_sub_sq_le_two_mul_add_two_mul_of_integral_sub_sq_le_of_integral_sub_sq_le hdint
-          (integrable_sub_sq_of_abs_le_one (hem n)
-            (hqm ν h.measurable_directing).aemeasurable
-            (ae_of_all _ (heb n)) (ae_of_all _ (habs ν)))
-          (integrable_sub_sq_of_abs_le_one (hem n)
-            (hqm ν' h'.measurable_directing).aemeasurable
-            (ae_of_all _ (heb n)) (ae_of_all _ (habs ν')))
-          (h.integral_empiricalFrequency_sub_sq_le hX hB hn0)
-          (h'.integral_empiricalFrequency_sub_sq_le hX hB hn0)
-    rw [div_eq_mul_inv]
-    linarith
+  have hbound : ∀ n : ℕ, 1 ≤ n → ∫ ω, d ω ^ 2 ∂μ ≤ 4 / n := fun n hn =>
+    h.integral_directing_sub_sq_le_four_div hX h' hB hdint (by omega)
   have hle : ∫ ω, d ω ^ 2 ∂μ ≤ 0 :=
     ge_of_tendsto (tendsto_const_div_atTop_nhds_zero_nat (4 : ℝ))
       (eventually_atTop.2 ⟨1, fun n hn => hbound n hn⟩)


### PR DESCRIPTION
`ConditionallyIIDWith.ae_measure_apply_eq` (59-line body) derived its `4 / n` mean-square bound inline — along with the measurability and `[0, 1]` bounds that bound needs — before squeezing `n → ∞`.

The quantitative statement is extracted as `ConditionallyIIDWith.integral_directing_sub_sq_le_four_div`: two directing measures of the same process are within `4 / n` of each other in mean square on each fixed measurable set. `ae_measure_apply_eq` is then its `n → ∞` limit, and consists of the squeeze alone: **59 → 30** lines of proof body.

Integrability of the squared difference is a hypothesis rather than something the helper derives. That is not threading what happened to be in scope: the rate bounds available for the two measures separately constrain only the squares of the *individual* errors, which does not make their difference measurable — the same point that settled the corresponding question for the triangle bound this lemma calls (#1448).

At `n = 1` the bound reads `∫ (q - q')² ≤ 4`, which is consistent: both masses lie in `[0, 1]`.

With this and #1466, no proof body in `TauCeti/` exceeds 50 lines.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`.