### PR TITLE
feat: add K(G, 1) spaces

### DIFF
--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -81,7 +81,7 @@ protected theorem pathConnectedSpace (h : IsAspherical X x) : PathConnectedSpace
   h.1
 
 /-- Every homotopy group of an aspherical space in dimension at least two is trivial. -/
-protected theorem subsingleton_homotopyGroupPi (h : IsAspherical X x) (n : ℕ) :
+protected theorem subsingleton_homotopyGroup (h : IsAspherical X x) (n : ℕ) :
     Subsingleton (π_ (n + 2) X x) :=
   h.2 n
 
@@ -90,7 +90,7 @@ theorem of_homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
     IsAspherical Y y := by
   letI : PathConnectedSpace X := hX.pathConnectedSpace
   refine ⟨e.surjective.pathConnectedSpace e.continuous, fun n ↦ ?_⟩
-  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroupPi n
+  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroup n
   exact
     (HomotopyGroup.homeomorphMulEquivOfEq (N := Fin (n + 2)) e he).toEquiv
       |>.subsingleton_congr.mp inferInstance
@@ -101,8 +101,8 @@ theorem prod (hX : IsAspherical X x) (hY : IsAspherical Y y) :
   letI : PathConnectedSpace X := hX.pathConnectedSpace
   letI : PathConnectedSpace Y := hY.pathConnectedSpace
   refine ⟨inferInstance, fun n ↦ ?_⟩
-  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroupPi n
-  letI : Subsingleton (π_ (n + 2) Y y) := hY.subsingleton_homotopyGroupPi n
+  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroup n
+  letI : Subsingleton (π_ (n + 2) Y y) := hY.subsingleton_homotopyGroup n
   exact
     (HomotopyGroup.prodEquiv (N := Fin (n + 2)) x y).subsingleton_congr.mpr inferInstance
 
@@ -114,7 +114,7 @@ theorem pi (h : ∀ i, IsAspherical (Z i) (z i)) :
   letI : ∀ i, PathConnectedSpace (Z i) := fun i ↦ (h i).pathConnectedSpace
   refine ⟨inferInstance, fun n ↦ ?_⟩
   letI : ∀ i, Subsingleton (π_ (n + 2) (Z i) (z i)) :=
-    fun i ↦ (h i).subsingleton_homotopyGroupPi n
+    fun i ↦ (h i).subsingleton_homotopyGroup n
   exact inferInstance
 
 end IsAspherical

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -25,7 +25,8 @@ The product results reuse the existing product isomorphisms for fundamental and 
 homotopy groups.
 
 This implements the general API for `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4,
-item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are in
+item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are respectively in
+`TauCeti.AlgebraicTopology.UniversalCover.Circle.EilenbergMacLane` and
 `TauCeti.AlgebraicTopology.UniversalCover.Torus.EilenbergMacLane`.
 
 ## Main declarations
@@ -34,7 +35,8 @@ item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are in
   dimensions at least two.
 * `TauCeti.IsEilenbergMacLaneSpaceOne`: the property of being an Eilenberg--Mac Lane space
   of type `K(G, 1)`.
-* `TauCeti.IsAspherical.homeomorph`, `TauCeti.IsEilenbergMacLaneSpaceOne.homeomorph`:
+* `TauCeti.IsAspherical.of_homeomorph`,
+  `TauCeti.IsEilenbergMacLaneSpaceOne.of_homeomorph`:
   invariance under pointed homeomorphisms.
 * `TauCeti.IsAspherical.prod`, `TauCeti.IsAspherical.pi`,
   `TauCeti.IsEilenbergMacLaneSpaceOne.prod`, `TauCeti.IsEilenbergMacLaneSpaceOne.pi`:
@@ -57,6 +59,7 @@ def IsAspherical (X : Type u) [TopologicalSpace X] (x : X) : Prop :=
   PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x)
 
 /-- Characteristic restatement of asphericity. -/
+@[simp]
 theorem isAspherical_iff {X : Type u} [TopologicalSpace X] {x : X} :
     IsAspherical X x ↔
       PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x) :=
@@ -66,6 +69,12 @@ namespace IsAspherical
 
 variable {X : Type u} {Y : Type v} [TopologicalSpace X] [TopologicalSpace Y]
   {x : X} {y : Y}
+
+/-- Construct asphericity from path-connectedness and the vanishing of all homotopy groups
+in dimensions at least two. -/
+protected theorem mk (hX : PathConnectedSpace X)
+    (hπ : ∀ n : ℕ, Subsingleton (π_ (n + 2) X x)) : IsAspherical X x :=
+  ⟨hX, hπ⟩
 
 /-- An aspherical space is path-connected. -/
 protected theorem pathConnectedSpace (h : IsAspherical X x) : PathConnectedSpace X :=
@@ -77,7 +86,7 @@ protected theorem subsingleton_homotopyGroupPi (h : IsAspherical X x) (n : ℕ) 
   h.2 n
 
 /-- Asphericity is preserved by a pointed homeomorphism. -/
-theorem homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
+theorem of_homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
     IsAspherical Y y := by
   letI : PathConnectedSpace X := hX.pathConnectedSpace
   refine ⟨e.surjective.pathConnectedSpace e.continuous, fun n ↦ ?_⟩
@@ -117,6 +126,7 @@ def IsEilenbergMacLaneSpaceOne (G : Type u) [Group G]
   IsAspherical X x ∧ Nonempty (FundamentalGroup X x ≃* G)
 
 /-- Characteristic restatement of the `K(G, 1)` property. -/
+@[simp]
 theorem isEilenbergMacLaneSpaceOne_iff {G : Type u} [Group G]
     {X : Type v} [TopologicalSpace X] {x : X} :
     IsEilenbergMacLaneSpaceOne G X x ↔
@@ -128,6 +138,13 @@ namespace IsEilenbergMacLaneSpaceOne
 variable {G : Type u} {H : Type v} [Group G] [Group H]
   {X : Type v} {Y : Type w} [TopologicalSpace X] [TopologicalSpace Y]
   {x : X} {y : Y}
+
+/-- Construct the `K(G, 1)` property from asphericity and an isomorphism between the
+fundamental group and `G`. -/
+protected theorem mk (hX : IsAspherical X x)
+    (hπ : Nonempty (FundamentalGroup X x ≃* G)) :
+    IsEilenbergMacLaneSpaceOne G X x :=
+  ⟨hX, hπ⟩
 
 /-- A `K(G, 1)` space is aspherical. -/
 protected theorem isAspherical (h : IsEilenbergMacLaneSpaceOne G X x) :
@@ -141,15 +158,15 @@ protected theorem nonempty_fundamentalGroupMulEquiv
   h.2
 
 /-- Transporting the target group along an isomorphism preserves the `K(G, 1)` property. -/
-theorem mulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : G ≃* H) :
+theorem of_mulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : G ≃* H) :
     IsEilenbergMacLaneSpaceOne H X x :=
   ⟨h.isAspherical, h.nonempty_fundamentalGroupMulEquiv.map fun f ↦ f.trans e⟩
 
 /-- The `K(G, 1)` property is preserved by a pointed homeomorphism. -/
-theorem homeomorph (h : IsEilenbergMacLaneSpaceOne G X x)
+theorem of_homeomorph (h : IsEilenbergMacLaneSpaceOne G X x)
     (e : X ≃ₜ Y) (he : e x = y) :
     IsEilenbergMacLaneSpaceOne G Y y :=
-  ⟨h.isAspherical.homeomorph e he,
+  ⟨h.isAspherical.of_homeomorph e he,
     h.nonempty_fundamentalGroupMulEquiv.map fun f ↦
       (FundamentalGroup.homeomorphMulEquivOfEq e he).symm.trans f⟩
 

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -115,7 +115,7 @@ theorem pi (h : ∀ i, IsAspherical (Z i) (z i)) :
   refine ⟨inferInstance, fun n ↦ ?_⟩
   letI : ∀ i, Subsingleton (π_ (n + 2) (Z i) (z i)) :=
     fun i ↦ (h i).subsingleton_homotopyGroupPi n
-  exact (HomotopyGroup.piEquiv (N := Fin (n + 2)) z).subsingleton_congr.mpr inferInstance
+  exact inferInstance
 
 end IsAspherical
 

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -51,7 +51,7 @@ open scoped Topology Topology.Homotopy
 
 noncomputable section
 
-universe u v w
+universe u v w w'
 
 /-- A based space is aspherical when it is path-connected and every homotopy group in
 dimension at least two is trivial. -/
@@ -59,7 +59,6 @@ def IsAspherical (X : Type u) [TopologicalSpace X] (x : X) : Prop :=
   PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x)
 
 /-- Characteristic restatement of asphericity. -/
-@[simp]
 theorem isAspherical_iff {X : Type u} [TopologicalSpace X] {x : X} :
     IsAspherical X x ↔
       PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x) :=
@@ -126,7 +125,6 @@ def IsEilenbergMacLaneSpaceOne (G : Type u) [Group G]
   IsAspherical X x ∧ Nonempty (FundamentalGroup X x ≃* G)
 
 /-- Characteristic restatement of the `K(G, 1)` property. -/
-@[simp]
 theorem isEilenbergMacLaneSpaceOne_iff {G : Type u} [Group G]
     {X : Type v} [TopologicalSpace X] {x : X} :
     IsEilenbergMacLaneSpaceOne G X x ↔
@@ -136,7 +134,7 @@ theorem isEilenbergMacLaneSpaceOne_iff {G : Type u} [Group G]
 namespace IsEilenbergMacLaneSpaceOne
 
 variable {G : Type u} {H : Type v} [Group G] [Group H]
-  {X : Type v} {Y : Type w} [TopologicalSpace X] [TopologicalSpace Y]
+  {X : Type w} {Y : Type w'} [TopologicalSpace X] [TopologicalSpace Y]
   {x : X} {y : Y}
 
 /-- Construct the `K(G, 1)` property from asphericity and an isomorphism between the
@@ -171,7 +169,7 @@ theorem of_homeomorph (h : IsEilenbergMacLaneSpaceOne G X x)
       (FundamentalGroup.homeomorphMulEquivOfEq e he).symm.trans f⟩
 
 variable {G₁ : Type u} {G₂ : Type v} [Group G₁] [Group G₂]
-  {X₁ : Type v} {X₂ : Type w} [TopologicalSpace X₁] [TopologicalSpace X₂]
+  {X₁ : Type w} {X₂ : Type w'} [TopologicalSpace X₁] [TopologicalSpace X₂]
   {x₁ : X₁} {x₂ : X₂}
 
 /-- The product of a `K(G₁, 1)` space and a `K(G₂, 1)` space is a

--- a/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
+++ b/TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.FundamentalGroup.Homeomorph
+public import TauCeti.AlgebraicTopology.FundamentalGroup.Product
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Homeomorph
+public import TauCeti.Topology.Homotopy.HomotopyGroup.Product
+
+/-!
+# Aspherical spaces and Eilenberg--Mac Lane spaces of type `K(G, 1)`
+
+A based space is aspherical when it is path-connected and all of its homotopy groups in
+dimensions at least two are trivial. An Eilenberg--Mac Lane space of type `K(G, 1)` is an
+aspherical space whose fundamental group is isomorphic to `G`.
+
+The definitions are properties rather than structures carrying chosen isomorphisms. Thus they
+are invariant under changing an exhibited fundamental-group isomorphism, and do not retain
+noncanonical data. This file records invariance under homeomorphism and under isomorphism of
+the target group, as well as closure under binary and indexed products.
+
+The product results reuse the existing product isomorphisms for fundamental and higher
+homotopy groups.
+
+This implements the general API for `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4,
+item 13, "`K(G, 1)` spaces". Concrete circle and torus examples are in
+`TauCeti.AlgebraicTopology.UniversalCover.Torus.EilenbergMacLane`.
+
+## Main declarations
+
+* `TauCeti.IsAspherical`: path-connectedness together with vanishing homotopy groups in
+  dimensions at least two.
+* `TauCeti.IsEilenbergMacLaneSpaceOne`: the property of being an Eilenberg--Mac Lane space
+  of type `K(G, 1)`.
+* `TauCeti.IsAspherical.homeomorph`, `TauCeti.IsEilenbergMacLaneSpaceOne.homeomorph`:
+  invariance under pointed homeomorphisms.
+* `TauCeti.IsAspherical.prod`, `TauCeti.IsAspherical.pi`,
+  `TauCeti.IsEilenbergMacLaneSpaceOne.prod`, `TauCeti.IsEilenbergMacLaneSpaceOne.pi`:
+  closure under products.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Topology Topology.Homotopy
+
+noncomputable section
+
+universe u v w
+
+/-- A based space is aspherical when it is path-connected and every homotopy group in
+dimension at least two is trivial. -/
+def IsAspherical (X : Type u) [TopologicalSpace X] (x : X) : Prop :=
+  PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x)
+
+/-- Characteristic restatement of asphericity. -/
+theorem isAspherical_iff {X : Type u} [TopologicalSpace X] {x : X} :
+    IsAspherical X x ↔
+      PathConnectedSpace X ∧ ∀ n : ℕ, Subsingleton (π_ (n + 2) X x) :=
+  Iff.rfl
+
+namespace IsAspherical
+
+variable {X : Type u} {Y : Type v} [TopologicalSpace X] [TopologicalSpace Y]
+  {x : X} {y : Y}
+
+/-- An aspherical space is path-connected. -/
+protected theorem pathConnectedSpace (h : IsAspherical X x) : PathConnectedSpace X :=
+  h.1
+
+/-- Every homotopy group of an aspherical space in dimension at least two is trivial. -/
+protected theorem subsingleton_homotopyGroupPi (h : IsAspherical X x) (n : ℕ) :
+    Subsingleton (π_ (n + 2) X x) :=
+  h.2 n
+
+/-- Asphericity is preserved by a pointed homeomorphism. -/
+theorem homeomorph (hX : IsAspherical X x) (e : X ≃ₜ Y) (he : e x = y) :
+    IsAspherical Y y := by
+  letI : PathConnectedSpace X := hX.pathConnectedSpace
+  refine ⟨e.surjective.pathConnectedSpace e.continuous, fun n ↦ ?_⟩
+  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroupPi n
+  exact
+    (HomotopyGroup.homeomorphMulEquivOfEq (N := Fin (n + 2)) e he).toEquiv
+      |>.subsingleton_congr.mp inferInstance
+
+/-- The product of two aspherical spaces is aspherical. -/
+theorem prod (hX : IsAspherical X x) (hY : IsAspherical Y y) :
+    IsAspherical (X × Y) (x, y) := by
+  letI : PathConnectedSpace X := hX.pathConnectedSpace
+  letI : PathConnectedSpace Y := hY.pathConnectedSpace
+  refine ⟨inferInstance, fun n ↦ ?_⟩
+  letI : Subsingleton (π_ (n + 2) X x) := hX.subsingleton_homotopyGroupPi n
+  letI : Subsingleton (π_ (n + 2) Y y) := hY.subsingleton_homotopyGroupPi n
+  exact
+    (HomotopyGroup.prodEquiv (N := Fin (n + 2)) x y).subsingleton_congr.mpr inferInstance
+
+variable {ι : Type w} {Z : ι → Type u} [∀ i, TopologicalSpace (Z i)] {z : ∀ i, Z i}
+
+/-- An indexed product of aspherical spaces is aspherical. -/
+theorem pi (h : ∀ i, IsAspherical (Z i) (z i)) :
+    IsAspherical (∀ i, Z i) z := by
+  letI : ∀ i, PathConnectedSpace (Z i) := fun i ↦ (h i).pathConnectedSpace
+  refine ⟨inferInstance, fun n ↦ ?_⟩
+  letI : ∀ i, Subsingleton (π_ (n + 2) (Z i) (z i)) :=
+    fun i ↦ (h i).subsingleton_homotopyGroupPi n
+  exact (HomotopyGroup.piEquiv (N := Fin (n + 2)) z).subsingleton_congr.mpr inferInstance
+
+end IsAspherical
+
+/-- A based space is an Eilenberg--Mac Lane space of type `K(G, 1)` when it is aspherical
+and its fundamental group is isomorphic to `G`. -/
+def IsEilenbergMacLaneSpaceOne (G : Type u) [Group G]
+    (X : Type v) [TopologicalSpace X] (x : X) : Prop :=
+  IsAspherical X x ∧ Nonempty (FundamentalGroup X x ≃* G)
+
+/-- Characteristic restatement of the `K(G, 1)` property. -/
+theorem isEilenbergMacLaneSpaceOne_iff {G : Type u} [Group G]
+    {X : Type v} [TopologicalSpace X] {x : X} :
+    IsEilenbergMacLaneSpaceOne G X x ↔
+      IsAspherical X x ∧ Nonempty (FundamentalGroup X x ≃* G) :=
+  Iff.rfl
+
+namespace IsEilenbergMacLaneSpaceOne
+
+variable {G : Type u} {H : Type v} [Group G] [Group H]
+  {X : Type v} {Y : Type w} [TopologicalSpace X] [TopologicalSpace Y]
+  {x : X} {y : Y}
+
+/-- A `K(G, 1)` space is aspherical. -/
+protected theorem isAspherical (h : IsEilenbergMacLaneSpaceOne G X x) :
+    IsAspherical X x :=
+  h.1
+
+/-- The fundamental group of a `K(G, 1)` space is isomorphic to `G`. -/
+protected theorem nonempty_fundamentalGroupMulEquiv
+    (h : IsEilenbergMacLaneSpaceOne G X x) :
+    Nonempty (FundamentalGroup X x ≃* G) :=
+  h.2
+
+/-- Transporting the target group along an isomorphism preserves the `K(G, 1)` property. -/
+theorem mulEquiv (h : IsEilenbergMacLaneSpaceOne G X x) (e : G ≃* H) :
+    IsEilenbergMacLaneSpaceOne H X x :=
+  ⟨h.isAspherical, h.nonempty_fundamentalGroupMulEquiv.map fun f ↦ f.trans e⟩
+
+/-- The `K(G, 1)` property is preserved by a pointed homeomorphism. -/
+theorem homeomorph (h : IsEilenbergMacLaneSpaceOne G X x)
+    (e : X ≃ₜ Y) (he : e x = y) :
+    IsEilenbergMacLaneSpaceOne G Y y :=
+  ⟨h.isAspherical.homeomorph e he,
+    h.nonempty_fundamentalGroupMulEquiv.map fun f ↦
+      (FundamentalGroup.homeomorphMulEquivOfEq e he).symm.trans f⟩
+
+variable {G₁ : Type u} {G₂ : Type v} [Group G₁] [Group G₂]
+  {X₁ : Type v} {X₂ : Type w} [TopologicalSpace X₁] [TopologicalSpace X₂]
+  {x₁ : X₁} {x₂ : X₂}
+
+/-- The product of a `K(G₁, 1)` space and a `K(G₂, 1)` space is a
+`K(G₁ × G₂, 1)` space. -/
+theorem prod (h₁ : IsEilenbergMacLaneSpaceOne G₁ X₁ x₁)
+    (h₂ : IsEilenbergMacLaneSpaceOne G₂ X₂ x₂) :
+    IsEilenbergMacLaneSpaceOne (G₁ × G₂) (X₁ × X₂) (x₁, x₂) := by
+  refine ⟨h₁.isAspherical.prod h₂.isAspherical, ?_⟩
+  obtain ⟨e₁⟩ := h₁.nonempty_fundamentalGroupMulEquiv
+  obtain ⟨e₂⟩ := h₂.nonempty_fundamentalGroupMulEquiv
+  exact ⟨(FundamentalGroup.prodMulEquiv x₁ x₂).trans (e₁.prodCongr e₂)⟩
+
+variable {ι : Type w} {G' : ι → Type u} {Z : ι → Type v}
+  [∀ i, Group (G' i)] [∀ i, TopologicalSpace (Z i)] {z : ∀ i, Z i}
+
+/-- An indexed product of `K(Gᵢ, 1)` spaces is a `K(Π i, Gᵢ, 1)` space. -/
+theorem pi (h : ∀ i, IsEilenbergMacLaneSpaceOne (G' i) (Z i) (z i)) :
+    IsEilenbergMacLaneSpaceOne (∀ i, G' i) (∀ i, Z i) z := by
+  refine ⟨IsAspherical.pi fun i ↦ (h i).isAspherical, ?_⟩
+  exact ⟨(FundamentalGroup.piMulEquiv z).trans
+    (MulEquiv.piCongrRight fun i ↦ Classical.choice (h i).nonempty_fundamentalGroupMulEquiv)⟩
+
+end IsEilenbergMacLaneSpaceOne
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/EilenbergMacLane.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.Circle.FundamentalGroup
+public import TauCeti.AlgebraicTopology.UniversalCover.Circle.HigherHomotopy
+
+/-!
+# Circles as Eilenberg--Mac Lane spaces
+
+A real additive circle of nonzero period is a `K(ℤ, 1)`: it is path-connected, its
+fundamental group is infinite cyclic, and all its higher homotopy groups vanish.
+
+These results package the existing circle calculations into the Eilenberg--Mac Lane API. The
+fundamental-group witness is `TauCeti.AddCircle.fundamentalGroupMulEquiv`, and higher homotopy
+vanishing is supplied by `TauCeti.AddCircle.subsingleton_homotopyGroup`.
+
+This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
+"`K(G, 1)` spaces", for circles.
+
+## Main declarations
+
+* `TauCeti.AddCircle.isAspherical`: every real additive circle is aspherical.
+* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
+  `K(ℤ, 1)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Topology Topology.Homotopy
+
+noncomputable section
+
+namespace AddCircle
+
+/-- Every real additive circle is aspherical. The nonzero-period hypothesis is needed only
+for the later identification of its fundamental group with `ℤ`. -/
+theorem isAspherical (p : ℝ) (x : AddCircle p) :
+    TauCeti.IsAspherical (AddCircle p) x :=
+  TauCeti.IsAspherical.mk inferInstance fun _ ↦ inferInstance
+
+/-- A real additive circle with nonzero period is an Eilenberg--Mac Lane space of type
+`K(ℤ, 1)`, with `ℤ` written multiplicatively to match the fundamental group. -/
+theorem isEilenbergMacLaneSpaceOne (p : ℝ) (hp : p ≠ 0) (x : AddCircle p) :
+    TauCeti.IsEilenbergMacLaneSpaceOne (Multiplicative ℤ) (AddCircle p) x := by
+  obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
+  exact TauCeti.IsEilenbergMacLaneSpaceOne.mk
+    (isAspherical p _) ⟨fundamentalGroupMulEquiv p hp ⟨e, rfl⟩⟩
+
+end AddCircle
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.EilenbergMacLane.Basic
+public import TauCeti.AlgebraicTopology.UniversalCover.Torus.FundamentalGroup
+public import TauCeti.AlgebraicTopology.UniversalCover.Torus.HigherHomotopy
+
+/-!
+# Circles and tori as Eilenberg--Mac Lane spaces
+
+A real additive circle of nonzero period is a `K(ℤ, 1)`: it is path-connected, its
+fundamental group is infinite cyclic, and all its higher homotopy groups vanish. More
+generally, an arbitrary indexed product of such circles is a `K(Π i, ℤ, 1)`.
+
+These results package the existing circle and torus calculations into the Eilenberg--Mac Lane
+API. The fundamental-group witnesses are
+`TauCeti.AddCircle.fundamentalGroupMulEquiv` and
+`TauCeti.AddCircle.piFundamentalGroupMulEquiv`; higher homotopy vanishing is supplied by
+`TauCeti.AddCircle.subsingleton_homotopyGroup` and
+`TauCeti.AddCircle.subsingleton_homotopyGroup_pi`.
+
+This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
+"`K(G, 1)` spaces", for circles and arbitrary products of circles.
+
+## Main declarations
+
+* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
+  `K(ℤ, 1)`.
+* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate
+  real circles is a `K(Π i, ℤ, 1)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Topology Topology.Homotopy
+
+noncomputable section
+
+namespace AddCircle
+
+/-- Every real additive circle is aspherical. The nonzero-period hypothesis is needed only
+for the later identification of its fundamental group with `ℤ`. -/
+theorem isAspherical (p : ℝ) (x : AddCircle p) :
+    TauCeti.IsAspherical (AddCircle p) x :=
+  isAspherical_iff.mpr ⟨inferInstance, fun _ ↦ inferInstance⟩
+
+/-- A real additive circle with nonzero period is an Eilenberg--Mac Lane space of type
+`K(ℤ, 1)`, with `ℤ` written multiplicatively to match the fundamental group. -/
+theorem isEilenbergMacLaneSpaceOne (p : ℝ) (hp : p ≠ 0) (x : AddCircle p) :
+    TauCeti.IsEilenbergMacLaneSpaceOne (Multiplicative ℤ) (AddCircle p) x := by
+  obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
+  exact isEilenbergMacLaneSpaceOne_iff.mpr
+    ⟨isAspherical p _, ⟨fundamentalGroupMulEquiv p hp ⟨e, rfl⟩⟩⟩
+
+variable {ι : Type*}
+
+/-- Every indexed product of real additive circles is aspherical. -/
+theorem isAspherical_pi (p : ι → ℝ) (x : ∀ i, AddCircle (p i)) :
+    TauCeti.IsAspherical (∀ i, AddCircle (p i)) x :=
+  isAspherical_iff.mpr ⟨inferInstance, fun _ ↦ inferInstance⟩
+
+/-- An indexed product of real additive circles with nonzero periods is an Eilenberg--Mac
+Lane space of type `K(Π i, ℤ, 1)`. No finiteness assumption on the index type is needed. -/
+theorem isEilenbergMacLaneSpaceOne_pi (p : ι → ℝ) (hp : ∀ i, p i ≠ 0)
+    (x : ∀ i, AddCircle (p i)) :
+    TauCeti.IsEilenbergMacLaneSpaceOne (∀ _ : ι, Multiplicative ℤ)
+      (∀ i, AddCircle (p i)) x := by
+  choose e he using fun i ↦ QuotientAddGroup.mk_surjective (x i)
+  let lift : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i} :=
+    fun i ↦ ⟨e i, by simpa using he i⟩
+  exact isEilenbergMacLaneSpaceOne_iff.mpr
+    ⟨isAspherical_pi p x, ⟨piFundamentalGroupMulEquiv hp lift⟩⟩
+
+end AddCircle
+
+end
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -4,31 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.AlgebraicTopology.EilenbergMacLane.Basic
-public import TauCeti.AlgebraicTopology.UniversalCover.Torus.FundamentalGroup
-public import TauCeti.AlgebraicTopology.UniversalCover.Torus.HigherHomotopy
+public import TauCeti.AlgebraicTopology.UniversalCover.Circle.EilenbergMacLane
 
 /-!
-# Circles and tori as Eilenberg--Mac Lane spaces
+# Tori as Eilenberg--Mac Lane spaces
 
-A real additive circle of nonzero period is a `K(ℤ, 1)`: it is path-connected, its
-fundamental group is infinite cyclic, and all its higher homotopy groups vanish. More
-generally, an arbitrary indexed product of such circles is a `K(Π i, ℤ, 1)`.
+An arbitrary indexed product of real additive circles with nonzero periods is a
+`K(Π i, ℤ, 1)`.
 
-These results package the existing circle and torus calculations into the Eilenberg--Mac Lane
-API. The fundamental-group witnesses are
-`TauCeti.AddCircle.fundamentalGroupMulEquiv` and
-`TauCeti.AddCircle.piFundamentalGroupMulEquiv`; higher homotopy vanishing is supplied by
-`TauCeti.AddCircle.subsingleton_homotopyGroup` and
-`TauCeti.AddCircle.subsingleton_homotopyGroup_pi`.
+These results derive directly from the Eilenberg--Mac Lane product API and the circle
+calculation in `TauCeti.AlgebraicTopology.UniversalCover.Circle.EilenbergMacLane`.
 
 This realizes `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13,
-"`K(G, 1)` spaces", for circles and arbitrary products of circles.
+"`K(G, 1)` spaces", for arbitrary products of circles.
 
 ## Main declarations
 
-* `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne`: a nondegenerate real circle is a
-  `K(ℤ, 1)`.
+* `TauCeti.AddCircle.isAspherical_pi`: an indexed product of real circles is aspherical.
 * `TauCeti.AddCircle.isEilenbergMacLaneSpaceOne_pi`: an indexed product of nondegenerate
   real circles is a `K(Π i, ℤ, 1)`.
 -/
@@ -43,38 +35,21 @@ noncomputable section
 
 namespace AddCircle
 
-/-- Every real additive circle is aspherical. The nonzero-period hypothesis is needed only
-for the later identification of its fundamental group with `ℤ`. -/
-theorem isAspherical (p : ℝ) (x : AddCircle p) :
-    TauCeti.IsAspherical (AddCircle p) x :=
-  isAspherical_iff.mpr ⟨inferInstance, fun _ ↦ inferInstance⟩
-
-/-- A real additive circle with nonzero period is an Eilenberg--Mac Lane space of type
-`K(ℤ, 1)`, with `ℤ` written multiplicatively to match the fundamental group. -/
-theorem isEilenbergMacLaneSpaceOne (p : ℝ) (hp : p ≠ 0) (x : AddCircle p) :
-    TauCeti.IsEilenbergMacLaneSpaceOne (Multiplicative ℤ) (AddCircle p) x := by
-  obtain ⟨e, rfl⟩ := QuotientAddGroup.mk_surjective x
-  exact isEilenbergMacLaneSpaceOne_iff.mpr
-    ⟨isAspherical p _, ⟨fundamentalGroupMulEquiv p hp ⟨e, rfl⟩⟩⟩
-
 variable {ι : Type*}
 
 /-- Every indexed product of real additive circles is aspherical. -/
 theorem isAspherical_pi (p : ι → ℝ) (x : ∀ i, AddCircle (p i)) :
     TauCeti.IsAspherical (∀ i, AddCircle (p i)) x :=
-  isAspherical_iff.mpr ⟨inferInstance, fun _ ↦ inferInstance⟩
+  TauCeti.IsAspherical.pi fun i ↦ isAspherical (p i) (x i)
 
 /-- An indexed product of real additive circles with nonzero periods is an Eilenberg--Mac
 Lane space of type `K(Π i, ℤ, 1)`. No finiteness assumption on the index type is needed. -/
 theorem isEilenbergMacLaneSpaceOne_pi (p : ι → ℝ) (hp : ∀ i, p i ≠ 0)
     (x : ∀ i, AddCircle (p i)) :
     TauCeti.IsEilenbergMacLaneSpaceOne (∀ _ : ι, Multiplicative ℤ)
-      (∀ i, AddCircle (p i)) x := by
-  choose e he using fun i ↦ QuotientAddGroup.mk_surjective (x i)
-  let lift : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i} :=
-    fun i ↦ ⟨e i, by simpa using he i⟩
-  exact isEilenbergMacLaneSpaceOne_iff.mpr
-    ⟨isAspherical_pi p x, ⟨piFundamentalGroupMulEquiv hp lift⟩⟩
+      (∀ i, AddCircle (p i)) x :=
+  TauCeti.IsEilenbergMacLaneSpaceOne.pi fun i ↦
+    isEilenbergMacLaneSpaceOne (p i) (hp i) (x i)
 
 end AddCircle
 


### PR DESCRIPTION
This PR defines aspherical based spaces and Eilenberg--Mac Lane spaces of type `K(G, 1)`, proves invariance under pointed homeomorphisms and group isomorphisms, proves closure under binary and indexed products, and packages every nondegenerate real additive circle and arbitrary product of such circles as concrete `K(G, 1)` spaces.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, exactly the application target “`K(G, 1)` spaces.” This is the lowest-hanging unfinished direct target because the necessary circle and torus calculations have now landed: `π₁(AddCircle p) ≃* Multiplicative ℤ`, the indexed-product formula for fundamental groups, and triviality of every higher homotopy group of circles and tori. No open PR covers this packaging or a general asphericity/Eilenberg--Mac Lane predicate, and neither Mathlib nor Tau Ceti already contains one.

Add `TauCeti/AlgebraicTopology/EilenbergMacLane/Basic.lean` (184 lines) with `IsAspherical`, `IsEilenbergMacLaneSpaceOne`, their characteristic elimination API, pointed-homeomorphism invariance, target-group transport, and binary/indexed product theorems. Add `TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean` (83 lines) with the circle `K(ℤ, 1)` theorem and the arbitrary-product `K(Π i, ℤ, 1)` theorem at any basepoint.

No Mathlib infrastructure is vendored and no external formalization is copied or adapted. The proofs reuse Tau Ceti’s existing `FundamentalGroup.prodMulEquiv`, `FundamentalGroup.piMulEquiv`, `HomotopyGroup.prodEquiv`, `HomotopyGroup.piEquiv`, circle and torus fundamental-group equivalences, and higher-homotopy subsingleton instances, together with Mathlib’s path-connected product instances.

`lake build` reports `Build completed successfully (5845 jobs).` `tauceti-axioms --changed-from origin/main` and `tauceti-lint-env --changed-from origin/main` both complete successfully.

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"k-g-1-spaces"}-->

🤖 Prepared with Codex
