### PR TITLE
feat: refine Wedderburn-Artin to a central division algebra

### DIFF
--- a/TauCeti/Algebra/Central/Matrix.lean
+++ b/TauCeti/Algebra/Central/Matrix.lean
@@ -1,0 +1,59 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Central.Basic
+public import Mathlib.Algebra.Central.Matrix
+
+/-!
+# Centrality descends from a matrix algebra to its coefficients
+
+Mathlib proves that a matrix algebra over a central algebra is central
+(`Algebra.IsCentral.matrix`). This file supplies the converse over a nonempty finite index type:
+the centre of `Matrix ι ι D` is the image of the centre of `D` under the scalar embedding
+`Matrix.scalarAlgHom`, which is injective as soon as `ι` is nonempty, so the centre of `D` is `⊥`
+whenever the centre of `Matrix ι ι D` is.
+
+* `TauCeti.isCentral_of_isCentral_matrix`: if `Matrix ι ι D` is central over `K`, then so is `D`;
+* `TauCeti.isCentral_matrix_iff` packages this with Mathlib's converse.
+
+## Implementation notes
+
+`TauCeti.isCentral_of_isCentral_matrix` is deliberately *not* an instance: its hypothesis mentions
+`Matrix ι ι D` while its conclusion mentions only `D`, so instance search could not run it
+backwards, and the index type `ι` is unconstrained by the goal.
+-/
+
+public section
+
+namespace TauCeti
+
+variable (K D : Type*) [CommSemiring K] [Semiring D] [Algebra K D]
+  (ι : Type*) [Fintype ι] [DecidableEq ι] [Nonempty ι]
+
+/-- If a matrix algebra `Matrix ι ι D` over a nonempty finite index type is central over `K`, then
+its coefficient algebra `D` is central over `K`.
+
+The centre of `Matrix ι ι D` is the image of the centre of `D` under the scalar embedding
+`Matrix.scalarAlgHom`, which is injective because `ι` is nonempty; so the centre of `D` is `⊥` as
+soon as the centre of the matrix algebra is. This is the converse of `Algebra.IsCentral.matrix`. -/
+theorem isCentral_of_isCentral_matrix [Algebra.IsCentral K (Matrix ι ι D)] :
+    Algebra.IsCentral K D := by
+  have hinj : Function.Injective (Matrix.scalarAlgHom ι K : D →ₐ[K] Matrix ι ι D) := fun _ _ h ↦
+    Matrix.scalar_inj.mp (by simpa only [Matrix.scalarAlgHom_apply] using h)
+  have h : (Subalgebra.center K D).map (Matrix.scalarAlgHom ι K) =
+      (⊥ : Subalgebra K D).map (Matrix.scalarAlgHom ι K) := by
+    rw [Algebra.map_bot, ← Matrix.subalgebraCenter_eq_scalarAlgHom_map,
+      Algebra.IsCentral.center_eq_bot]
+  exact ⟨(Subalgebra.map_injective hinj h).le⟩
+
+/-- A matrix algebra over a nonempty finite index type is central exactly when its coefficient
+algebra is. -/
+@[simp]
+theorem isCentral_matrix_iff :
+    Algebra.IsCentral K (Matrix ι ι D) ↔ Algebra.IsCentral K D :=
+  ⟨fun _ ↦ isCentral_of_isCentral_matrix K D ι, fun _ ↦ Algebra.IsCentral.matrix K D ι⟩
+
+end TauCeti

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -1,0 +1,240 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Central.Basic
+public import Mathlib.Algebra.Central.Matrix
+public import Mathlib.LinearAlgebra.Dimension.Constructions
+public import Mathlib.RingTheory.LittleWedderburn
+public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
+
+/-!
+# Wedderburn-Artin for central simple algebras
+
+Mathlib's `IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite` writes a finite-dimensional
+simple `K`-algebra `A` as a matrix algebra `Matrix (Fin n) (Fin n) D` over a division algebra `D`,
+but it says nothing about the centre of `D`: the theorem is about simplicity alone. For the theory
+of central simple algebras one needs the refinement in which `D` is again **central** over `K`,
+because that is the hypothesis every later structure theorem (the degree, Skolem-Noether, the Brauer
+group) carries.
+
+This file supplies the missing step. Mathlib proves that a matrix algebra over a central algebra is
+central (`Algebra.IsCentral.matrix`); the converse is `TauCeti.isCentral_of_isCentral_matrix`, which
+reads off the centre of `D` from the centre of `Matrix ι ι D` using
+`Matrix.subalgebraCenter_eq_scalarAlgHom_map` and injectivity of `Matrix.scalarAlgHom`. Feeding it
+Mathlib's Wedderburn-Artin theorem gives `A ≃ₐ[K] Matrix (Fin n) (Fin n) D` with `D` a central
+division algebra, together with the dimension count `finrank K A = n ^ 2 * finrank K D`.
+
+The same file settles the finite base field. A finite division ring is a field (little Wedderburn),
+and a *commutative* algebra is central exactly when its structure map is onto, so a central division
+algebra over a finite field is the field itself and every central simple algebra over a finite field
+is a full matrix algebra `Matrix (Fin n) (Fin n) K`. In particular its dimension is the square
+`n ^ 2`. Centrality is what makes this work: `𝔽_{q^m}` is a finite division algebra over `𝔽_q`
+which is *not* the base field, and `TauCeti.isCentral_iff_surjective_algebraMap` locates the
+failure precisely in the surjectivity of the structure map.
+
+## Main results
+
+* `TauCeti.isCentral_of_isCentral_matrix`: if `Matrix ι ι D` is central over `K` for a nonempty
+  finite `ι`, then so is `D`; `TauCeti.isCentral_matrix_iff` packages this with Mathlib's converse.
+* `TauCeti.exists_algEquiv_matrix_centralDivisionRing`: **Wedderburn-Artin for central simple
+  algebras**. A finite-dimensional central simple `K`-algebra `A` is `Matrix (Fin n) (Fin n) D` for
+  a finite-dimensional **central** division `K`-algebra `D`, and
+  `finrank K A = n ^ 2 * finrank K D`.
+* `TauCeti.surjective_algebraMap_of_mul_comm`, `TauCeti.isCentral_iff_surjective_algebraMap`: a
+  commutative `K`-algebra is central iff its structure map is surjective.
+* `TauCeti.algebraMap_bijective_of_finite`, `TauCeti.baseFieldAlgEquivOfFinite`: a finite central
+  division algebra over a field is the base field.
+* `TauCeti.exists_algEquiv_matrix_of_finite`: a central simple algebra over a **finite** field is a
+  full matrix algebra over that field, and `TauCeti.isSquare_finrank_of_finite`: its dimension is a
+  perfect square.
+
+## Implementation notes
+
+`TauCeti.isCentral_of_isCentral_matrix` is deliberately *not* an instance: its hypothesis mentions
+`Matrix ι ι D` while its conclusion mentions only `D`, so instance search could not run it
+backwards, and the index type `ι` is unconstrained by the goal.
+
+`TauCeti.algebraMap_bijective_of_finite` assumes `Finite D`, the single hypothesis little Wedderburn
+needs, rather than the pair `Finite K` and `FiniteDimensional K D`; the two are equivalent, because
+`K` embeds in `D`. The central-simple corollary does take the pair `Finite K` and
+`FiniteDimensional K A`, which is how a finite base field is met in practice.
+
+Uniqueness of the pair `(n, D)` is *not* proved here; it needs the invariance of the Wedderburn
+data, which is a separate development.
+
+## References
+
+This implements the second bullet of Layer 4 of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md)
+(`A ≅ Mₙ(D)` for a central division algebra `D`, with `finrank K A = n² · finrank K D`) together
+with its finite-field worked example. See R. S. Pierce, *Associative Algebras*, GTM 88, Chapter 12,
+and P. Gille, T. Szamuely, *Central Simple Algebras and Galois Cohomology*, Chapter 2.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+/-! ### Centrality descends from a matrix algebra to its coefficients -/
+
+section Descent
+
+variable (K D : Type*) [CommSemiring K] [Semiring D] [Algebra K D]
+  (ι : Type*) [Fintype ι] [DecidableEq ι] [Nonempty ι]
+
+/-- If a matrix algebra `Matrix ι ι D` over a nonempty finite index type is central over `K`, then
+its coefficient algebra `D` is central over `K`.
+
+The centre of `Matrix ι ι D` is the image of the centre of `D` under the scalar embedding
+`Matrix.scalarAlgHom`, which is injective because `ι` is nonempty; so the centre of `D` is `⊥` as
+soon as the centre of the matrix algebra is. This is the converse of `Algebra.IsCentral.matrix`. -/
+theorem isCentral_of_isCentral_matrix [Algebra.IsCentral K (Matrix ι ι D)] :
+    Algebra.IsCentral K D := by
+  have hinj : Function.Injective (Matrix.scalarAlgHom ι K : D →ₐ[K] Matrix ι ι D) :=
+    fun _ _ h ↦ by simpa using h
+  have h : (Subalgebra.center K D).map (Matrix.scalarAlgHom ι K) =
+      (⊥ : Subalgebra K D).map (Matrix.scalarAlgHom ι K) := by
+    rw [Algebra.map_bot, ← Matrix.subalgebraCenter_eq_scalarAlgHom_map,
+      Algebra.IsCentral.center_eq_bot]
+  exact ⟨(Subalgebra.map_injective hinj h).le⟩
+
+/-- A matrix algebra over a nonempty finite index type is central exactly when its coefficient
+algebra is. -/
+theorem isCentral_matrix_iff :
+    Algebra.IsCentral K (Matrix ι ι D) ↔ Algebra.IsCentral K D :=
+  ⟨fun _ ↦ isCentral_of_isCentral_matrix K D ι, fun _ ↦ Algebra.IsCentral.matrix K D ι⟩
+
+end Descent
+
+/-! ### Wedderburn-Artin for central simple algebras -/
+
+section CentralSimple
+
+variable (K : Type*) [Field K] (A : Type u) [Ring A] [Algebra K A]
+
+/-- Transporting a dimension count along a matrix presentation: an algebra isomorphic to
+`n × n` matrices over `D` has dimension `n ^ 2 * finrank K D`. -/
+theorem finrank_eq_sq_mul_finrank {n : ℕ} {D : Type*} [Ring D] [Algebra K D]
+    (e : A ≃ₐ[K] Matrix (Fin n) (Fin n) D) :
+    Module.finrank K A = n ^ 2 * Module.finrank K D := by
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_matrix, Fintype.card_fin]
+  ring
+
+/-- **Wedderburn-Artin for central simple algebras.** A finite-dimensional central simple
+`K`-algebra `A` is isomorphic to a matrix algebra over a finite-dimensional **central** division
+`K`-algebra `D`, and then `finrank K A = n ^ 2 * finrank K D`.
+
+Mathlib's `IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite` supplies everything except the
+centrality of `D`, which comes from `TauCeti.isCentral_of_isCentral_matrix`. -/
+theorem exists_algEquiv_matrix_centralDivisionRing [Algebra.IsCentral K A] [IsSimpleRing A]
+    [FiniteDimensional K A] :
+    ∃ (n : ℕ) (_ : NeZero n) (D : Type u) (_ : DivisionRing D) (_ : Algebra K D)
+      (_ : Algebra.IsCentral K D) (_ : FiniteDimensional K D),
+      Module.finrank K A = n ^ 2 * Module.finrank K D ∧
+        Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) D) := by
+  have := IsArtinianRing.of_finite K A
+  obtain ⟨n, hn, D, hD, hDalg, hDfin, ⟨e⟩⟩ :=
+    IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite K A
+  have : Nonempty (Fin n) := ⟨0⟩
+  have : Algebra.IsCentral K (Matrix (Fin n) (Fin n) D) :=
+    Algebra.IsCentral.of_algEquiv K A _ e
+  exact ⟨n, hn, D, hD, hDalg, isCentral_of_isCentral_matrix K D (Fin n), hDfin,
+    finrank_eq_sq_mul_finrank K A e, ⟨e⟩⟩
+
+end CentralSimple
+
+/-! ### Central algebras that happen to be commutative -/
+
+/-- If a central `K`-algebra has commutative multiplication then its structure map is surjective:
+every element lies in the centre, hence in the image of `K`.
+
+Commutativity is taken as a hypothesis rather than as a `CommSemiring` instance so that the lemma
+applies to a `DivisionRing` that little Wedderburn has shown to be commutative, without introducing
+a second multiplicative structure on it. -/
+theorem surjective_algebraMap_of_mul_comm (K D : Type*) [CommSemiring K] [Semiring D] [Algebra K D]
+    [Algebra.IsCentral K D] (h : ∀ x y : D, x * y = y * x) :
+    Function.Surjective (algebraMap K D) := fun x ↦ by
+  obtain ⟨a, ha⟩ :=
+    (Algebra.IsCentral.mem_center_iff K).mp (Subalgebra.mem_center_iff.mpr fun b ↦ h b x)
+  exact ⟨a, ha.symm⟩
+
+/-- A commutative `K`-algebra is central over `K` exactly when its structure map is surjective: the
+centre of a commutative algebra is all of it, so demanding that the centre be the image of `K`
+demands that everything be in the image of `K`.
+
+This is the precise sense in which centrality is a strong condition on a field extension: `L / K` is
+central only when `L = K`. It is also what makes the finite-field results below work, once little
+Wedderburn has made a finite division algebra commutative. -/
+theorem isCentral_iff_surjective_algebraMap (K D : Type*) [CommSemiring K] [CommSemiring D]
+    [Algebra K D] : Algebra.IsCentral K D ↔ Function.Surjective (algebraMap K D) := by
+  refine ⟨fun _ ↦ surjective_algebraMap_of_mul_comm K D fun x y ↦ mul_comm x y,
+    fun h ↦ ⟨fun x _ ↦ ?_⟩⟩
+  obtain ⟨a, rfl⟩ := h x
+  exact Algebra.mem_bot.mpr ⟨a, rfl⟩
+
+/-! ### Finite central division algebras and finite base fields -/
+
+section Finite
+
+variable (K : Type*) [Field K] (D : Type*) [DivisionRing D] [Algebra K D]
+  [Algebra.IsCentral K D] [Finite D]
+
+/-- A **finite central division algebra over a field is the base field**: its structure map is
+bijective.
+
+A finite division ring is commutative by little Wedderburn, and a commutative central algebra has
+surjective structure map; injectivity is automatic over a field. Centrality is essential: `𝔽_{q^m}`
+is a finite division algebra over `𝔽_q` whose structure map is not surjective for `m > 1`. -/
+theorem algebraMap_bijective_of_finite : Function.Bijective (algebraMap K D) :=
+  ⟨(algebraMap K D).injective,
+    surjective_algebraMap_of_mul_comm K D (Finite.isDomain_to_isField D).mul_comm⟩
+
+/-- The identification of a finite central division algebra with its base field, as an isomorphism
+of `K`-algebras. -/
+noncomputable def baseFieldAlgEquivOfFinite : D ≃ₐ[K] K :=
+  (AlgEquiv.ofBijective (Algebra.ofId K D) (algebraMap_bijective_of_finite K D)).symm
+
+@[simp]
+theorem baseFieldAlgEquivOfFinite_symm_apply (a : K) :
+    (baseFieldAlgEquivOfFinite K D).symm a = algebraMap K D a := by
+  simp [baseFieldAlgEquivOfFinite]
+
+/-- A finite central division algebra over a field is one-dimensional over it. -/
+theorem finrank_eq_one_of_finite : Module.finrank K D = 1 := by
+  rw [(baseFieldAlgEquivOfFinite K D).toLinearEquiv.finrank_eq, Module.finrank_self]
+
+end Finite
+
+section FiniteField
+
+variable (K : Type*) [Field K] [Finite K] (A : Type u) [Ring A] [Algebra K A]
+  [Algebra.IsCentral K A] [IsSimpleRing A] [FiniteDimensional K A]
+
+/-- **A central simple algebra over a finite field is a full matrix algebra.** Over a finite field
+the only finite-dimensional central division algebra is the field itself, so the division algebra in
+the Wedderburn presentation collapses and `finrank K A = n ^ 2`.
+
+This is the finite-field analogue of Mathlib's
+`IsSimpleRing.exists_algEquiv_matrix_of_isAlgClosed`; note that `IsSimpleRing A` alone would not
+suffice, since `A` could be a proper field extension of `K`. -/
+theorem exists_algEquiv_matrix_of_finite :
+    ∃ (n : ℕ) (_ : NeZero n), Module.finrank K A = n ^ 2 ∧
+      Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) K) := by
+  obtain ⟨n, hn, D, _, _, _, _, hrank, ⟨e⟩⟩ := exists_algEquiv_matrix_centralDivisionRing K A
+  have : Finite D := Module.finite_of_finite K
+  refine ⟨n, hn, ?_, ⟨e.trans (AlgEquiv.mapMatrix (baseFieldAlgEquivOfFinite K D))⟩⟩
+  rw [hrank, finrank_eq_one_of_finite K D, mul_one]
+
+/-- The dimension of a central simple algebra over a finite field is a perfect square. -/
+theorem isSquare_finrank_of_finite : IsSquare (Module.finrank K A) := by
+  obtain ⟨n, _, hrank, -⟩ := exists_algEquiv_matrix_of_finite K A
+  exact ⟨n, by rw [hrank, sq]⟩
+
+end FiniteField
+
+end TauCeti

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -122,6 +122,7 @@ theorem baseFieldAlgEquivOfFinite_symm_apply (a : K) :
   simp [baseFieldAlgEquivOfFinite]
 
 /-- A finite central division algebra over a field is one-dimensional over it. -/
+@[simp]
 theorem finrank_eq_one_of_finite : Module.finrank K D = 1 := by
   rw [(baseFieldAlgEquivOfFinite K D).toLinearEquiv.finrank_eq, Module.finrank_self]
 

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -121,6 +121,11 @@ theorem baseFieldAlgEquivOfFinite_symm_apply (a : K) :
     (baseFieldAlgEquivOfFinite K D).symm a = algebraMap K D a := by
   simp [baseFieldAlgEquivOfFinite]
 
+@[simp]
+theorem algebraMap_baseFieldAlgEquivOfFinite (x : D) :
+    algebraMap K D (baseFieldAlgEquivOfFinite K D x) = x := by
+  rw [← baseFieldAlgEquivOfFinite_symm_apply, AlgEquiv.symm_apply_apply]
+
 /-- A finite central division algebra over a field is one-dimensional over it. -/
 @[simp]
 theorem finrank_eq_one_of_finite : Module.finrank K D = 1 := by

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -28,12 +28,12 @@ Mathlib's Wedderburn-Artin theorem gives `A ≃ₐ[K] Matrix (Fin n) (Fin n) D` 
 division algebra, together with the dimension count `finrank K A = n ^ 2 * finrank K D`.
 
 The same file settles the finite base field. A finite division ring is a field (little Wedderburn),
-and a *commutative* algebra is central exactly when its structure map is onto, so a central division
-algebra over a finite field is the field itself and every central simple algebra over a finite field
-is a full matrix algebra `Matrix (Fin n) (Fin n) K`. In particular its dimension is the square
-`n ^ 2`. Centrality is what makes this work: `𝔽_{q^m}` is a finite division algebra over `𝔽_q`
-which is *not* the base field, and `TauCeti.isCentral_iff_surjective_algebraMap` locates the
-failure precisely in the surjectivity of the structure map.
+so `Algebra.IsCentral.baseField_essentially_unique` collapses a finite central division algebra to
+its base field, and every central simple algebra over a finite field is a full matrix algebra
+`Matrix (Fin n) (Fin n) K`. In particular its dimension is the square `n ^ 2`. Centrality is what
+makes this work: `𝔽_{q^m}` is a finite division algebra over `𝔽_q` which is *not* the base field,
+and `TauCeti.isCentral_iff_surjective_algebraMap` locates the failure precisely in the surjectivity
+of the structure map.
 
 ## Main results
 
@@ -43,10 +43,10 @@ failure precisely in the surjectivity of the structure map.
   algebras**. A finite-dimensional central simple `K`-algebra `A` is `Matrix (Fin n) (Fin n) D` for
   a finite-dimensional **central** division `K`-algebra `D`, and
   `finrank K A = n ^ 2 * finrank K D`.
-* `TauCeti.surjective_algebraMap_of_mul_comm`, `TauCeti.isCentral_iff_surjective_algebraMap`: a
-  commutative `K`-algebra is central iff its structure map is surjective.
-* `TauCeti.algebraMap_bijective_of_finite`, `TauCeti.baseFieldAlgEquivOfFinite`: a finite central
-  division algebra over a field is the base field.
+* `TauCeti.isCentral_iff_surjective_algebraMap`: a commutative `K`-algebra is central iff its
+  structure map is surjective.
+* `TauCeti.baseFieldAlgEquivOfFinite`: a finite central division algebra over a field is the base
+  field.
 * `TauCeti.exists_algEquiv_matrix_of_finite`: a central simple algebra over a **finite** field is a
   full matrix algebra over that field, and `TauCeti.isSquare_finrank_of_finite`: its dimension is a
   perfect square.
@@ -57,7 +57,7 @@ failure precisely in the surjectivity of the structure map.
 `Matrix ι ι D` while its conclusion mentions only `D`, so instance search could not run it
 backwards, and the index type `ι` is unconstrained by the goal.
 
-`TauCeti.algebraMap_bijective_of_finite` assumes `Finite D`, the single hypothesis little Wedderburn
+`TauCeti.baseFieldAlgEquivOfFinite` assumes `Finite D`, the single hypothesis little Wedderburn
 needs, rather than the pair `Finite K` and `FiniteDimensional K D`; the two are equivalent, because
 `K` embeds in `D`. The central-simple corollary does take the pair `Finite K` and
 `FiniteDimensional K A`, which is how a finite base field is met in practice.
@@ -150,32 +150,21 @@ end CentralSimple
 
 /-! ### Central algebras that happen to be commutative -/
 
-/-- If a central `K`-algebra has commutative multiplication then its structure map is surjective:
-every element lies in the centre, hence in the image of `K`.
-
-Commutativity is taken as a hypothesis rather than as a `CommSemiring` instance so that the lemma
-applies to a `DivisionRing` that little Wedderburn has shown to be commutative, without introducing
-a second multiplicative structure on it. -/
-theorem surjective_algebraMap_of_mul_comm (K D : Type*) [CommSemiring K] [Semiring D] [Algebra K D]
-    [Algebra.IsCentral K D] (h : ∀ x y : D, x * y = y * x) :
-    Function.Surjective (algebraMap K D) := fun x ↦ by
-  obtain ⟨a, ha⟩ :=
-    (Algebra.IsCentral.mem_center_iff K).mp (Subalgebra.mem_center_iff.mpr fun b ↦ h b x)
-  exact ⟨a, ha.symm⟩
-
 /-- A commutative `K`-algebra is central over `K` exactly when its structure map is surjective: the
 centre of a commutative algebra is all of it, so demanding that the centre be the image of `K`
 demands that everything be in the image of `K`.
 
 This is the precise sense in which centrality is a strong condition on a field extension: `L / K` is
-central only when `L = K`. It is also what makes the finite-field results below work, once little
-Wedderburn has made a finite division algebra commutative. -/
+central only when `L = K`, which is why the finite-field results below collapse the division algebra
+to its base field once little Wedderburn has made it commutative. -/
 theorem isCentral_iff_surjective_algebraMap (K D : Type*) [CommSemiring K] [CommSemiring D]
     [Algebra K D] : Algebra.IsCentral K D ↔ Function.Surjective (algebraMap K D) := by
-  refine ⟨fun _ ↦ surjective_algebraMap_of_mul_comm K D fun x y ↦ mul_comm x y,
-    fun h ↦ ⟨fun x _ ↦ ?_⟩⟩
-  obtain ⟨a, rfl⟩ := h x
-  exact Algebra.mem_bot.mpr ⟨a, rfl⟩
+  refine ⟨fun _ x ↦ ?_, fun h ↦ ⟨fun x _ ↦ ?_⟩⟩
+  · obtain ⟨a, ha⟩ := (Algebra.IsCentral.mem_center_iff K).mp
+      (Subalgebra.mem_center_iff.mpr fun b ↦ mul_comm b x)
+    exact ⟨a, ha.symm⟩
+  · obtain ⟨a, rfl⟩ := h x
+    exact Algebra.mem_bot.mpr ⟨a, rfl⟩
 
 /-! ### Finite central division algebras and finite base fields -/
 
@@ -184,20 +173,16 @@ section Finite
 variable (K : Type*) [Field K] (D : Type*) [DivisionRing D] [Algebra K D]
   [Algebra.IsCentral K D] [Finite D]
 
-/-- A **finite central division algebra over a field is the base field**: its structure map is
-bijective.
+/-- A **finite central division algebra over a field is the base field**, as an isomorphism of
+`K`-algebras.
 
-A finite division ring is commutative by little Wedderburn, and a commutative central algebra has
-surjective structure map; injectivity is automatic over a field. Centrality is essential: `𝔽_{q^m}`
-is a finite division algebra over `𝔽_q` whose structure map is not surjective for `m > 1`. -/
-theorem algebraMap_bijective_of_finite : Function.Bijective (algebraMap K D) :=
-  ⟨(algebraMap K D).injective,
-    surjective_algebraMap_of_mul_comm K D (Finite.isDomain_to_isField D).mul_comm⟩
-
-/-- The identification of a finite central division algebra with its base field, as an isomorphism
-of `K`-algebras. -/
+A finite division ring is a field by little Wedderburn (the instance `littleWedderburn`), so `K → D`
+is a central extension of fields and `Algebra.IsCentral.baseField_essentially_unique` applied to the
+tower `D / D / K` makes it bijective. Centrality is essential: `𝔽_{q^m}` is a finite division
+algebra over `𝔽_q` whose structure map is not surjective for `m > 1`. -/
 noncomputable def baseFieldAlgEquivOfFinite : D ≃ₐ[K] K :=
-  (AlgEquiv.ofBijective (Algebra.ofId K D) (algebraMap_bijective_of_finite K D)).symm
+  (AlgEquiv.ofBijective (Algebra.ofId K D)
+    (Algebra.IsCentral.baseField_essentially_unique K D D)).symm
 
 @[simp]
 theorem baseFieldAlgEquivOfFinite_symm_apply (a : K) :

--- a/TauCeti/Algebra/CentralSimple/Wedderburn.lean
+++ b/TauCeti/Algebra/CentralSimple/Wedderburn.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.Central.Matrix
 public import Mathlib.Algebra.Central.Basic
-public import Mathlib.Algebra.Central.Matrix
 public import Mathlib.LinearAlgebra.Dimension.Constructions
 public import Mathlib.RingTheory.LittleWedderburn
 public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
@@ -20,42 +20,30 @@ of central simple algebras one needs the refinement in which `D` is again **cent
 because that is the hypothesis every later structure theorem (the degree, Skolem-Noether, the Brauer
 group) carries.
 
-This file supplies the missing step. Mathlib proves that a matrix algebra over a central algebra is
-central (`Algebra.IsCentral.matrix`); the converse is `TauCeti.isCentral_of_isCentral_matrix`, which
-reads off the centre of `D` from the centre of `Matrix ι ι D` using
-`Matrix.subalgebraCenter_eq_scalarAlgHom_map` and injectivity of `Matrix.scalarAlgHom`. Feeding it
-Mathlib's Wedderburn-Artin theorem gives `A ≃ₐ[K] Matrix (Fin n) (Fin n) D` with `D` a central
-division algebra, together with the dimension count `finrank K A = n ^ 2 * finrank K D`.
+This file supplies the missing step. Feeding Mathlib's Wedderburn-Artin theorem the centrality
+descent `TauCeti.isCentral_of_isCentral_matrix` gives `A ≃ₐ[K] Matrix (Fin n) (Fin n) D` with `D` a
+central division algebra, together with the dimension count `finrank K A = n ^ 2 * finrank K D`.
 
 The same file settles the finite base field. A finite division ring is a field (little Wedderburn),
 so `Algebra.IsCentral.baseField_essentially_unique` collapses a finite central division algebra to
 its base field, and every central simple algebra over a finite field is a full matrix algebra
 `Matrix (Fin n) (Fin n) K`. In particular its dimension is the square `n ^ 2`. Centrality is what
 makes this work: `𝔽_{q^m}` is a finite division algebra over `𝔽_q` which is *not* the base field,
-and `TauCeti.isCentral_iff_surjective_algebraMap` locates the failure precisely in the surjectivity
-of the structure map.
+the failure being exactly that its structure map is not surjective.
 
 ## Main results
 
-* `TauCeti.isCentral_of_isCentral_matrix`: if `Matrix ι ι D` is central over `K` for a nonempty
-  finite `ι`, then so is `D`; `TauCeti.isCentral_matrix_iff` packages this with Mathlib's converse.
-* `TauCeti.exists_algEquiv_matrix_centralDivisionRing`: **Wedderburn-Artin for central simple
-  algebras**. A finite-dimensional central simple `K`-algebra `A` is `Matrix (Fin n) (Fin n) D` for
-  a finite-dimensional **central** division `K`-algebra `D`, and
+* `TauCeti.IsSimpleRing.exists_algEquiv_matrix_centralDivisionRing`: **Wedderburn-Artin for central
+  simple algebras**. A finite-dimensional central simple `K`-algebra `A` is
+  `Matrix (Fin n) (Fin n) D` for a finite-dimensional **central** division `K`-algebra `D`, and
   `finrank K A = n ^ 2 * finrank K D`.
-* `TauCeti.isCentral_iff_surjective_algebraMap`: a commutative `K`-algebra is central iff its
-  structure map is surjective.
 * `TauCeti.baseFieldAlgEquivOfFinite`: a finite central division algebra over a field is the base
   field.
-* `TauCeti.exists_algEquiv_matrix_of_finite`: a central simple algebra over a **finite** field is a
-  full matrix algebra over that field, and `TauCeti.isSquare_finrank_of_finite`: its dimension is a
-  perfect square.
+* `TauCeti.IsSimpleRing.exists_algEquiv_matrix_of_finite`: a central simple algebra over a
+  **finite** field is a full matrix algebra over that field, and
+  `TauCeti.IsSimpleRing.isSquare_finrank_of_finite`: its dimension is a perfect square.
 
 ## Implementation notes
-
-`TauCeti.isCentral_of_isCentral_matrix` is deliberately *not* an instance: its hypothesis mentions
-`Matrix ι ι D` while its conclusion mentions only `D`, so instance search could not run it
-backwards, and the index type `ι` is unconstrained by the goal.
 
 `TauCeti.baseFieldAlgEquivOfFinite` assumes `Finite D`, the single hypothesis little Wedderburn
 needs, rather than the pair `Finite K` and `FiniteDimensional K D`; the two are equivalent, because
@@ -80,50 +68,11 @@ namespace TauCeti
 
 universe u
 
-/-! ### Centrality descends from a matrix algebra to its coefficients -/
-
-section Descent
-
-variable (K D : Type*) [CommSemiring K] [Semiring D] [Algebra K D]
-  (ι : Type*) [Fintype ι] [DecidableEq ι] [Nonempty ι]
-
-/-- If a matrix algebra `Matrix ι ι D` over a nonempty finite index type is central over `K`, then
-its coefficient algebra `D` is central over `K`.
-
-The centre of `Matrix ι ι D` is the image of the centre of `D` under the scalar embedding
-`Matrix.scalarAlgHom`, which is injective because `ι` is nonempty; so the centre of `D` is `⊥` as
-soon as the centre of the matrix algebra is. This is the converse of `Algebra.IsCentral.matrix`. -/
-theorem isCentral_of_isCentral_matrix [Algebra.IsCentral K (Matrix ι ι D)] :
-    Algebra.IsCentral K D := by
-  have hinj : Function.Injective (Matrix.scalarAlgHom ι K : D →ₐ[K] Matrix ι ι D) :=
-    fun _ _ h ↦ by simpa using h
-  have h : (Subalgebra.center K D).map (Matrix.scalarAlgHom ι K) =
-      (⊥ : Subalgebra K D).map (Matrix.scalarAlgHom ι K) := by
-    rw [Algebra.map_bot, ← Matrix.subalgebraCenter_eq_scalarAlgHom_map,
-      Algebra.IsCentral.center_eq_bot]
-  exact ⟨(Subalgebra.map_injective hinj h).le⟩
-
-/-- A matrix algebra over a nonempty finite index type is central exactly when its coefficient
-algebra is. -/
-theorem isCentral_matrix_iff :
-    Algebra.IsCentral K (Matrix ι ι D) ↔ Algebra.IsCentral K D :=
-  ⟨fun _ ↦ isCentral_of_isCentral_matrix K D ι, fun _ ↦ Algebra.IsCentral.matrix K D ι⟩
-
-end Descent
-
 /-! ### Wedderburn-Artin for central simple algebras -/
 
-section CentralSimple
+namespace IsSimpleRing
 
 variable (K : Type*) [Field K] (A : Type u) [Ring A] [Algebra K A]
-
-/-- Transporting a dimension count along a matrix presentation: an algebra isomorphic to
-`n × n` matrices over `D` has dimension `n ^ 2 * finrank K D`. -/
-theorem finrank_eq_sq_mul_finrank {n : ℕ} {D : Type*} [Ring D] [Algebra K D]
-    (e : A ≃ₐ[K] Matrix (Fin n) (Fin n) D) :
-    Module.finrank K A = n ^ 2 * Module.finrank K D := by
-  rw [e.toLinearEquiv.finrank_eq, Module.finrank_matrix, Fintype.card_fin]
-  ring
 
 /-- **Wedderburn-Artin for central simple algebras.** A finite-dimensional central simple
 `K`-algebra `A` is isomorphic to a matrix algebra over a finite-dimensional **central** division
@@ -139,32 +88,15 @@ theorem exists_algEquiv_matrix_centralDivisionRing [Algebra.IsCentral K A] [IsSi
         Nonempty (A ≃ₐ[K] Matrix (Fin n) (Fin n) D) := by
   have := IsArtinianRing.of_finite K A
   obtain ⟨n, hn, D, hD, hDalg, hDfin, ⟨e⟩⟩ :=
-    IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite K A
+    _root_.IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite K A
   have : Nonempty (Fin n) := ⟨0⟩
   have : Algebra.IsCentral K (Matrix (Fin n) (Fin n) D) :=
     Algebra.IsCentral.of_algEquiv K A _ e
-  exact ⟨n, hn, D, hD, hDalg, isCentral_of_isCentral_matrix K D (Fin n), hDfin,
-    finrank_eq_sq_mul_finrank K A e, ⟨e⟩⟩
+  refine ⟨n, hn, D, hD, hDalg, isCentral_of_isCentral_matrix K D (Fin n), hDfin, ?_, ⟨e⟩⟩
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_matrix, Fintype.card_fin]
+  ring
 
-end CentralSimple
-
-/-! ### Central algebras that happen to be commutative -/
-
-/-- A commutative `K`-algebra is central over `K` exactly when its structure map is surjective: the
-centre of a commutative algebra is all of it, so demanding that the centre be the image of `K`
-demands that everything be in the image of `K`.
-
-This is the precise sense in which centrality is a strong condition on a field extension: `L / K` is
-central only when `L = K`, which is why the finite-field results below collapse the division algebra
-to its base field once little Wedderburn has made it commutative. -/
-theorem isCentral_iff_surjective_algebraMap (K D : Type*) [CommSemiring K] [CommSemiring D]
-    [Algebra K D] : Algebra.IsCentral K D ↔ Function.Surjective (algebraMap K D) := by
-  refine ⟨fun _ x ↦ ?_, fun h ↦ ⟨fun x _ ↦ ?_⟩⟩
-  · obtain ⟨a, ha⟩ := (Algebra.IsCentral.mem_center_iff K).mp
-      (Subalgebra.mem_center_iff.mpr fun b ↦ mul_comm b x)
-    exact ⟨a, ha.symm⟩
-  · obtain ⟨a, rfl⟩ := h x
-    exact Algebra.mem_bot.mpr ⟨a, rfl⟩
+end IsSimpleRing
 
 /-! ### Finite central division algebras and finite base fields -/
 
@@ -195,7 +127,7 @@ theorem finrank_eq_one_of_finite : Module.finrank K D = 1 := by
 
 end Finite
 
-section FiniteField
+namespace IsSimpleRing
 
 variable (K : Type*) [Field K] [Finite K] (A : Type u) [Ring A] [Algebra K A]
   [Algebra.IsCentral K A] [IsSimpleRing A] [FiniteDimensional K A]
@@ -220,6 +152,6 @@ theorem isSquare_finrank_of_finite : IsSquare (Module.finrank K A) := by
   obtain ⟨n, _, hrank, -⟩ := exists_algEquiv_matrix_of_finite K A
   exact ⟨n, by rw [hrank, sq]⟩
 
-end FiniteField
+end IsSimpleRing
 
 end TauCeti

--- a/TauCeti/Algebra/Subalgebra/Center.lean
+++ b/TauCeti/Algebra/Subalgebra/Center.lean
@@ -12,9 +12,9 @@ public import Mathlib.LinearAlgebra.Dimension.Finrank
 /-!
 # Transporting and decomposing the center of an algebra
 
-Three constructions on `Subalgebra.center` that Mathlib states only for `Subring.center`, or only
+Constructions on `Subalgebra.center` that Mathlib states only for `Subring.center`, or only
 as an equality of subalgebras, and that are needed whenever a structure theorem presents an algebra
-up to an algebra equivalence.
+up to an algebra equivalence, together with the criterion for a commutative algebra to be central.
 
 * `TauCeti.centerCongr` transports the center along an algebra equivalence. It is the
   `Subalgebra` counterpart of Mathlib's `Subring.centerCongr`, which sees only the ring
@@ -24,6 +24,9 @@ up to an algebra equivalence.
   `Π i, S i` to an algebra equivalence with `Π i, Subalgebra.center R (S i)`.
 * `TauCeti.centerAlgEquivOfIsCentral` identifies the center of a central algebra with the base
   field, so that its dimension is one (`TauCeti.finrank_center_of_isCentral`).
+* `TauCeti.isCentral_iff_surjective_algebraMap` records that a commutative algebra is central
+  exactly when its structure map is surjective, the precise sense in which centrality is a strong
+  condition on a field extension.
 -/
 
 public section
@@ -127,5 +130,20 @@ theorem finrank_center_of_isCentral : Module.finrank K (Subalgebra.center K D) =
   ((centerAlgEquivOfIsCentral K D).toLinearEquiv.finrank_eq).trans (CommSemiring.finrank_self K)
 
 end IsCentral
+
+/-- A commutative `K`-algebra is central over `K` exactly when its structure map is surjective: the
+center of a commutative algebra is all of it, so demanding that the center be the image of `K`
+demands that everything be in the image of `K`.
+
+This is the precise sense in which centrality is a strong condition on a field extension: `L / K` is
+central only when `L = K`. -/
+theorem isCentral_iff_surjective_algebraMap (K D : Type*) [CommSemiring K] [CommSemiring D]
+    [Algebra K D] : Algebra.IsCentral K D ↔ Function.Surjective (algebraMap K D) := by
+  refine ⟨fun _ x ↦ ?_, fun h ↦ ⟨fun x _ ↦ ?_⟩⟩
+  · obtain ⟨a, ha⟩ := (Algebra.IsCentral.mem_center_iff K).mp
+      (Subalgebra.mem_center_iff.mpr fun b ↦ mul_comm b x)
+    exact ⟨a, ha.symm⟩
+  · obtain ⟨a, rfl⟩ := h x
+    exact Algebra.mem_bot.mpr ⟨a, rfl⟩
 
 end TauCeti


### PR DESCRIPTION
This PR refines Mathlib's Wedderburn-Artin theorem for a central simple algebra so that the division algebra it produces is again central, and settles the finite base field. Mathlib's `IsSimpleRing.exists_algEquiv_matrix_divisionRing_finite` writes a finite-dimensional simple `K`-algebra `A` as `Matrix (Fin n) (Fin n) D` over a division algebra `D`, but says nothing about the centre of `D`, and centrality of `D` is the hypothesis every later structure theorem (the degree, Skolem-Noether, the Brauer group) carries. The missing step is a descent: Mathlib proves that a matrix algebra over a central algebra is central (`Algebra.IsCentral.matrix`), and `TauCeti.isCentral_of_isCentral_matrix` supplies the converse, reading the centre of `D` off the centre of `Matrix ι ι D` through `Matrix.subalgebraCenter_eq_scalarAlgHom_map` and injectivity of `Matrix.scalarAlgHom`. Composing it with Mathlib's theorem gives `TauCeti.exists_algEquiv_matrix_centralDivisionRing`, together with the dimension count `finrank K A = n ^ 2 * finrank K D`. Over a finite field the division algebra collapses: a finite division ring is commutative by little Wedderburn, and a commutative algebra is central exactly when its structure map is onto (`TauCeti.isCentral_iff_surjective_algebraMap`), so a finite central division algebra is its base field and every central simple algebra over a finite field is a full matrix algebra `Matrix (Fin n) (Fin n) K` of square dimension `n ^ 2`. Centrality is what makes that work, and the surjectivity criterion locates the obstruction exactly: `𝔽_{q^m}` is a finite division algebra over `𝔽_q` that is not the base field.

This implements the second bullet of Layer 4 of `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md` ("A central simple `K`-algebra is `Mₙ(D)` for a **central division** `K`-algebra `D` ... with `finrank K A = n² · finrank K D`. This `A ≅ Mₙ(D)` step comes **first**") together with that roadmap's finite-field worked example ("Every finite-dimensional **central** division algebra over a finite field `𝔽_q` is `𝔽_q` itself ... So every central simple `𝔽_q`-algebra is `Mₙ(𝔽_q)`", including its parenthetical warning that dropping centrality only gives a field extension). It builds on https://github.com/TauCetiProject/TauCeti/pull/1435 (feat: prove the double centralizer theorem), which closed Layer 3, and it is a prerequisite for the degree and the index: the perfect-square dimension is proved here only over a finite field, since the general case needs base change to the algebraic closure.

Uniqueness of the pair `(n, D)` is deliberately not proved: that needs the invariance of the Wedderburn data, a separate Layer 2 development, and the module docstring says so.

No content is derived from the supplementary source snapshot; the file is written against the pinned Mathlib, and every Mathlib result it consumes is named in the module docstring rather than vendored. New module: `TauCeti/Algebra/CentralSimple/Wedderburn.lean`. `lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` are all green locally.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-algequiv-matrix-centraldivisionring"}-->

🤖 Prepared with Claude Code
