### PR TITLE
feat: prove Frobenius reciprocity as a character identity

### DIFF
--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.Pairing
 public import TauCeti.RepresentationTheory.Induction.FiniteDimensional
+public import TauCeti.RepresentationTheory.Induction.Restriction
 public import Mathlib.CategoryTheory.Linear.Basic
 public import Mathlib.RepresentationTheory.Character
 
@@ -17,40 +18,37 @@ For a finite-index subgroup `S` of a group `G`, Mathlib's adjunction `Rep.indRes
 identifies `Hom_G(Ind_S^G A, B)` with `Hom_S(A, Res_S B)`.  This file transports that adjunction to
 finite-dimensional representations and reads it off as an identity of character scalar products:
 
-`⟨Ind χ, ψ⟩_G = ⟨χ, Res ψ⟩_S`.
+`⟨Ind χ, ψ⟩_G = ⟨χ, Res ψ⟩_S`,
 
-## Main definitions
-
-* `TauCeti.resFDRep`: restriction of a finite-dimensional representation to a subgroup.
-* `TauCeti.indResFDRepHomEquiv`: Frobenius reciprocity as a `k`-linear equivalence
-  `Hom_G(Ind_S^G A, B) ≃ₗ[k] Hom_S(A, Res_S B)`.
-* `TauCeti.resIndFDRepHomEquiv`: the second reciprocity
-  `Hom_S(Res_S B, A) ≃ₗ[k] Hom_G(B, Ind_S^G A)`, available because induction from a finite-index
-  subgroup is a right adjoint to restriction as well as a left one.
+together with the identity in the other direction `⟨Res ψ, χ⟩_S = ⟨ψ, Ind χ⟩_G`.
 
 ## Main statements
 
 * `TauCeti.finrank_hom_indFDRep`, `TauCeti.finrank_hom_resFDRep`: the paired intertwining spaces
   have the same dimension.
-* `TauCeti.frobenius_reciprocity`: the character form, with both scalar products written out as
-  explicit normalized sums.
-* `TauCeti.characterPairing_indFDRep`: the same identity phrased against
-  `TauCeti.ClassFunction.characterPairing`.
+* `TauCeti.frobenius_reciprocity` and `TauCeti.frobenius_reciprocity_resFDRep`: the character form
+  in both directions, with all scalar products written out as explicit normalized sums.
+* `TauCeti.characterPairing_indFDRep`, `TauCeti.characterPairing_resFDRep`: the same two identities
+  phrased against `TauCeti.ClassFunction.characterPairing`.
 * `TauCeti.card_inv_mul_sum_character_indFDRep`: reciprocity against the trivial representation,
   which says that induction does not change the (normalized) average of a character.
 
 ## Implementation notes
 
 Only the coefficient field and the invertibility of `Nat.card G` are assumed; no algebraic closure
-is needed, because each side is computed by Mathlib's
-`FDRep.scalar_product_char_eq_finrank_equivariant` rather than by orthogonality of irreducible
-characters.  Invertibility of `Nat.card S` is not a separate hypothesis: it follows from
-`Subgroup.card_mul_index`.
+is needed, because each side is computed by
+`TauCeti.ClassFunction.characterPairing_ofFDRep_eq_finrank` rather than by orthogonality of
+irreducible characters.  Invertibility of `Nat.card S` is not a separate hypothesis: it follows
+from `Subgroup.card_mul_index`.
 
-Both scalar products are stated in the order `⟨Ind χ, ψ⟩`, matching the roadmap.  Mathlib's
-`FDRep.scalar_product_char_eq_finrank_equivariant` computes the opposite order, so the proof first
-reindexes each sum by `g ↦ g⁻¹`; this is the symmetry of the pairing, recorded for class functions
-as `TauCeti.ClassFunction.characterPairing_symm`.
+That pairing-to-dimension lemma computes `⟨χ_V, χ_W⟩` as `finrank k (W ⟶ V)`, exchanging the two
+arguments.  So the identity stated in the order `⟨Ind χ, ψ⟩ = ⟨χ, Res ψ⟩` is read off the *second*
+reciprocity `finrank_hom_resFDRep`, and the identity in the order `⟨Res ψ, χ⟩ = ⟨ψ, Ind χ⟩` off the
+first, `finrank_hom_indFDRep`.  Neither direction needs a reindexing of the sums.
+
+The two `k`-linear equivalences of intertwining spaces that carry the reciprocities are private:
+only their `finrank` corollaries are intended as API, and both are opaque transports whose bodies
+would have to be exposed before a consumer could identify the transported intertwiner.
 
 ## References
 
@@ -72,33 +70,6 @@ universe u
 
 variable {k G : Type u} [Field k] [Group G]
 
-section Restriction
-
-/-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
-`Action.res` along `S.subtype`, under the definitional identification
-`FDRep k G = Action (FGModuleCat k) G`; this definition only supplies the representation-theoretic
-name.
-
-The body is not exposed, as for `TauCeti.indFDRep`; the characteristic properties are
-`character_resFDRep` and `forget₂_obj_resFDRep`, the latter identifying the underlying object with
-Mathlib's `Rep.res` and so carrying the description of the representation itself. -/
-def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
-  (Action.res (FGModuleCat k) S.subtype).obj B
-
-/-- The character of a restriction is the restriction of the character. -/
-@[simp]
-theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
-    (resFDRep S B).character s = B.character (s : G) :=
-  (rfl)
-
-/-- Restriction commutes with forgetting finite-dimensionality. -/
-theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
-    (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
-      Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
-  (rfl)
-
-end Restriction
-
 section HomSpaces
 
 variable {S : Subgroup G}
@@ -108,13 +79,16 @@ intertwining spaces: `Hom_G(Ind_S^G A, B) ≃ₗ[k] Hom_S(A, Res_S B)`.
 
 This is Mathlib's `Rep.indResHomEquiv`, the linear form of the adjunction
 `Rep.indResAdjunction`, conjugated by the fully faithful forgetful functor
-`FDRep k G ⥤ Rep k G` and by `TauCeti.indFDRepForgetIso`. -/
-noncomputable def indResFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+`FDRep k G ⥤ Rep k G` and by `TauCeti.indFDRepForgetIso`.
+
+It is private: only `finrank_hom_indFDRep` is intended as API. -/
+private noncomputable def indResFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
     (indFDRep A ⟶ B) ≃ₗ[k] (A ⟶ resFDRep S B) :=
   (FDRep.forget₂HomLinearEquiv (indFDRep A) B).symm.trans <|
     ((Linear.homCongr k (indFDRepForgetIso A) (Iso.refl _)).trans
-      (Rep.indResHomEquiv S.subtype _ _)).trans
-        (FDRep.forget₂HomLinearEquiv A (resFDRep S B))
+      (Rep.indResHomEquiv S.subtype _ _)).trans <|
+        (Linear.homCongr k (Iso.refl _) (resFDRepForgetIso S B).symm).trans
+          (FDRep.forget₂HomLinearEquiv A (resFDRep S B))
 
 /-- The intertwining space out of an induced representation has the same dimension as the
 intertwining space into the corresponding restriction. This is the quantitative content of
@@ -128,12 +102,15 @@ theorem finrank_hom_indFDRep [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
 
 Where `TauCeti.indResFDRepHomEquiv` transports Mathlib's `Rep.indResHomEquiv`, this transports
 `Rep.resCoindHomEquiv` along Mathlib's finite-index identification `Rep.indCoindIso` of induction
-with coinduction; the pair is the finite-dimensional shadow of `Rep.resIndAdjunction`. -/
-noncomputable def resIndFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+with coinduction; the pair is the finite-dimensional shadow of `Rep.resIndAdjunction`.
+
+It is private: only `finrank_hom_resFDRep` is intended as API. -/
+private noncomputable def resIndFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
     (resFDRep S B ⟶ A) ≃ₗ[k] (B ⟶ indFDRep A) :=
   -- `Rep.indCoindIso` picks coset representatives, so it wants the coset relation to be decidable.
   letI : DecidableRel ⇑(QuotientGroup.rightRel S) := Classical.decRel _
   (FDRep.forget₂HomLinearEquiv (resFDRep S B) A).symm.trans <|
+    (Linear.homCongr k (resFDRepForgetIso S B) (Iso.refl _)).trans <|
     (Rep.resCoindHomEquiv S.subtype _ _).trans <|
       (Linear.homCongr k (Iso.refl _)
         ((indFDRepForgetIso A).trans (Rep.indCoindIso _)).symm).trans
@@ -149,12 +126,6 @@ end HomSpaces
 section Characters
 
 variable {S : Subgroup G}
-
-/-- The scalar product of two functions on a finite group is symmetric: reindexing by `g ↦ g⁻¹`
-exchanges the two arguments.  No class-function hypothesis is needed. -/
-private theorem sum_mul_inv_comm {Γ : Type*} [Group Γ] [Fintype Γ] (f h : Γ → k) :
-    ∑ g : Γ, f g * h g⁻¹ = ∑ g : Γ, h g * f g⁻¹ :=
-  (Fintype.sum_equiv (Equiv.inv Γ) _ _ fun g => by simp [mul_comm]).symm
 
 /-- If the order of a finite group is invertible in `k`, then so is the order of any subgroup,
 because the two differ by the index. -/
@@ -172,28 +143,53 @@ Both sides are written as explicit normalized sums, so the statement does not de
 any particular pairing; `TauCeti.characterPairing_indFDRep` is the same identity phrased against
 `TauCeti.ClassFunction.characterPairing`.  The hypothesis `hG` is what makes the normalizing factors
 meaningful; it also supplies the invertibility of `Nat.card S`. -/
-theorem frobenius_reciprocity [Fintype G] [S.FiniteIndex] (hG : IsUnit (Nat.card G : k))
+theorem frobenius_reciprocity [Fintype G] (hG : IsUnit (Nat.card G : k))
     (A : FDRep k S) (B : FDRep k G) :
     (Nat.card G : k)⁻¹ * ∑ g : G, (indFDRep A).character g * B.character g⁻¹ =
       (Nat.card S : k)⁻¹ * ∑ s : S, A.character s * B.character ((s : G)⁻¹) := by
   letI : Invertible (Nat.card G : k) := hG.invertible
   letI : Invertible (Nat.card S : k) := (isUnit_natCard_subgroup S hG).invertible
-  -- The subgroup element `(s : G)⁻¹` is the coercion of `s⁻¹`, so the right-hand sum is already a
-  -- scalar product of characters of `S`.
-  have hres (s : S) : B.character ((s : G)⁻¹) = (resFDRep S B).character s⁻¹ := rfl
-  simp only [hres]
-  -- Reindexing each sum by `g ↦ g⁻¹` puts its two factors in the order Mathlib's scalar-product
-  -- lemma expects, and each side then becomes the dimension of an intertwining space.
-  rw [sum_mul_inv_comm (indFDRep A).character B.character,
-    sum_mul_inv_comm A.character (resFDRep S B).character,
-    FDRep.scalar_product_char_eq_finrank_equivariant (indFDRep A) B,
-    FDRep.scalar_product_char_eq_finrank_equivariant A (resFDRep S B),
-    finrank_hom_indFDRep A B]
+  calc (Nat.card G : k)⁻¹ * ∑ g : G, (indFDRep A).character g * B.character g⁻¹
+      = ClassFunction.characterPairing (ClassFunction.ofFDRep (indFDRep A))
+          (ClassFunction.ofFDRep B) := (ClassFunction.characterPairing_ofFDRep _ _).symm
+    _ = (Module.finrank k (B ⟶ indFDRep A) : k) :=
+        ClassFunction.characterPairing_ofFDRep_eq_finrank _ _
+    _ = (Module.finrank k (resFDRep S B ⟶ A) : k) := by rw [finrank_hom_resFDRep]
+    _ = ClassFunction.characterPairing (ClassFunction.ofFDRep A)
+          (ClassFunction.ofFDRep (resFDRep S B)) :=
+        (ClassFunction.characterPairing_ofFDRep_eq_finrank _ _).symm
+    _ = (Nat.card S : k)⁻¹ * ∑ s : S, A.character s * (resFDRep S B).character s⁻¹ :=
+        ClassFunction.characterPairing_ofFDRep _ _
+    _ = (Nat.card S : k)⁻¹ * ∑ s : S, A.character s * B.character ((s : G)⁻¹) := by simp
+
+open scoped Classical in
+/-- **Frobenius reciprocity in the other direction**: the scalar product over `S` of a restricted
+character with a character of `S` equals the scalar product over `G` of the original character with
+the induced character.  This is the shadow of the second adjunction, `Rep.resIndAdjunction`. -/
+theorem frobenius_reciprocity_resFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (A : FDRep k S) (B : FDRep k G) :
+    (Nat.card S : k)⁻¹ * ∑ s : S, B.character (s : G) * A.character s⁻¹ =
+      (Nat.card G : k)⁻¹ * ∑ g : G, B.character g * (indFDRep A).character g⁻¹ := by
+  letI : Invertible (Nat.card G : k) := hG.invertible
+  letI : Invertible (Nat.card S : k) := (isUnit_natCard_subgroup S hG).invertible
+  calc (Nat.card S : k)⁻¹ * ∑ s : S, B.character (s : G) * A.character s⁻¹
+      = ClassFunction.characterPairing (ClassFunction.ofFDRep (resFDRep S B))
+          (ClassFunction.ofFDRep A) := by
+        rw [ClassFunction.characterPairing_ofFDRep]
+        simp
+    _ = (Module.finrank k (A ⟶ resFDRep S B) : k) :=
+        ClassFunction.characterPairing_ofFDRep_eq_finrank _ _
+    _ = (Module.finrank k (indFDRep A ⟶ B) : k) := by rw [finrank_hom_indFDRep]
+    _ = ClassFunction.characterPairing (ClassFunction.ofFDRep B)
+          (ClassFunction.ofFDRep (indFDRep A)) :=
+        (ClassFunction.characterPairing_ofFDRep_eq_finrank _ _).symm
+    _ = (Nat.card G : k)⁻¹ * ∑ g : G, B.character g * (indFDRep A).character g⁻¹ :=
+        ClassFunction.characterPairing_ofFDRep _ _
 
 open scoped Classical in
 /-- Frobenius reciprocity, phrased against the normalized pairing of class functions used by the
 character-theory development. -/
-theorem characterPairing_indFDRep [Fintype G] [S.FiniteIndex] (hG : IsUnit (Nat.card G : k))
+theorem characterPairing_indFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
     (A : FDRep k S) (B : FDRep k G) :
     ClassFunction.characterPairing (ClassFunction.ofFDRep (indFDRep A))
         (ClassFunction.ofFDRep B) =
@@ -203,11 +199,23 @@ theorem characterPairing_indFDRep [Fintype G] [S.FiniteIndex] (hG : IsUnit (Nat.
   simpa using frobenius_reciprocity hG A B
 
 open scoped Classical in
+/-- The reciprocity in the other direction, phrased against
+`TauCeti.ClassFunction.characterPairing`. -/
+theorem characterPairing_resFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (A : FDRep k S) (B : FDRep k G) :
+    ClassFunction.characterPairing (ClassFunction.ofFDRep (resFDRep S B))
+        (ClassFunction.ofFDRep A) =
+      ClassFunction.characterPairing (ClassFunction.ofFDRep B)
+        (ClassFunction.ofFDRep (indFDRep A)) := by
+  rw [ClassFunction.characterPairing_apply, ClassFunction.characterPairing_apply]
+  simpa using frobenius_reciprocity_resFDRep hG A B
+
+open scoped Classical in
 /-- Reciprocity against the trivial representation: the normalized average of an induced character
 over `G` is the normalized average of the original character over `S`.  Equivalently, by
 `FDRep.average_char_eq_finrank_invariants`, inducing does not change the dimension of the space of
 invariants. -/
-theorem card_inv_mul_sum_character_indFDRep [Fintype G] [S.FiniteIndex]
+theorem card_inv_mul_sum_character_indFDRep [Fintype G]
     (hG : IsUnit (Nat.card G : k)) (A : FDRep k S) :
     (Nat.card G : k)⁻¹ * ∑ g : G, (indFDRep A).character g =
       (Nat.card S : k)⁻¹ * ∑ s : S, A.character s := by

--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Pairing
+public import TauCeti.RepresentationTheory.Induction.FiniteDimensional
+public import Mathlib.CategoryTheory.Linear.Basic
+public import Mathlib.RepresentationTheory.Character
+
+/-!
+# Frobenius reciprocity as a character identity
+
+For a finite-index subgroup `S` of a group `G`, Mathlib's adjunction `Rep.indResAdjunction`
+identifies `Hom_G(Ind_S^G A, B)` with `Hom_S(A, Res_S B)`.  This file transports that adjunction to
+finite-dimensional representations and reads it off as an identity of character scalar products:
+
+`⟨Ind χ, ψ⟩_G = ⟨χ, Res ψ⟩_S`.
+
+## Main definitions
+
+* `TauCeti.resFDRep`: restriction of a finite-dimensional representation to a subgroup.
+* `TauCeti.indResFDRepHomEquiv`: Frobenius reciprocity as a `k`-linear equivalence
+  `Hom_G(Ind_S^G A, B) ≃ₗ[k] Hom_S(A, Res_S B)`.
+* `TauCeti.resIndFDRepHomEquiv`: the second reciprocity
+  `Hom_S(Res_S B, A) ≃ₗ[k] Hom_G(B, Ind_S^G A)`, available because induction from a finite-index
+  subgroup is a right adjoint to restriction as well as a left one.
+
+## Main statements
+
+* `TauCeti.finrank_hom_indFDRep`, `TauCeti.finrank_hom_resFDRep`: the paired intertwining spaces
+  have the same dimension.
+* `TauCeti.frobenius_reciprocity`: the character form, with both scalar products written out as
+  explicit normalized sums.
+* `TauCeti.characterPairing_indFDRep`: the same identity phrased against
+  `TauCeti.ClassFunction.characterPairing`.
+* `TauCeti.card_inv_mul_sum_character_indFDRep`: reciprocity against the trivial representation,
+  which says that induction does not change the (normalized) average of a character.
+
+## Implementation notes
+
+Only the coefficient field and the invertibility of `Nat.card G` are assumed; no algebraic closure
+is needed, because each side is computed by Mathlib's
+`FDRep.scalar_product_char_eq_finrank_equivariant` rather than by orthogonality of irreducible
+characters.  Invertibility of `Nat.card S` is not a separate hypothesis: it follows from
+`Subgroup.card_mul_index`.
+
+Both scalar products are stated in the order `⟨Ind χ, ψ⟩`, matching the roadmap.  Mathlib's
+`FDRep.scalar_product_char_eq_finrank_equivariant` computes the opposite order, so the proof first
+reindexes each sum by `g ↦ g⁻¹`; this is the symmetry of the pairing, recorded for class functions
+as `TauCeti.ClassFunction.characterPairing_symm`.
+
+## References
+
+This is the "Frobenius reciprocity as a character identity" item of Layer 2 in
+`TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`, recorded in its
+`Suggested.lean` as `frobenius_reciprocity`.
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, Chapter 7.2.
+* I. M. Isaacs, *Character Theory of Finite Groups*, Lemma 5.2.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+variable {k G : Type u} [Field k] [Group G]
+
+section Restriction
+
+/-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
+`Action.res` along `S.subtype`, under the definitional identification
+`FDRep k G = Action (FGModuleCat k) G`; this definition only supplies the representation-theoretic
+name. -/
+@[expose]
+def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
+  (Action.res (FGModuleCat k) S.subtype).obj B
+
+/-- Restriction acts on the representation by precomposing with the inclusion of the subgroup. -/
+@[simp]
+theorem resFDRep_ρ (S : Subgroup G) (B : FDRep k G) :
+    (resFDRep S B).ρ = B.ρ.comp S.subtype :=
+  rfl
+
+/-- The character of a restriction is the restriction of the character. -/
+@[simp]
+theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
+    (resFDRep S B).character s = B.character (s : G) :=
+  rfl
+
+/-- Restriction commutes with forgetting finite-dimensionality. -/
+theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
+    (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
+      Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
+  rfl
+
+end Restriction
+
+section HomSpaces
+
+variable {S : Subgroup G}
+
+/-- **Frobenius reciprocity** for finite-dimensional representations, as a `k`-linear equivalence of
+intertwining spaces: `Hom_G(Ind_S^G A, B) ≃ₗ[k] Hom_S(A, Res_S B)`.
+
+This is Mathlib's `Rep.indResHomEquiv`, the linear form of the adjunction
+`Rep.indResAdjunction`, conjugated by the fully faithful forgetful functor
+`FDRep k G ⥤ Rep k G` and by `TauCeti.indFDRepForgetIso`. -/
+noncomputable def indResFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+    (indFDRep A ⟶ B) ≃ₗ[k] (A ⟶ resFDRep S B) :=
+  (FDRep.forget₂HomLinearEquiv (indFDRep A) B).symm.trans <|
+    ((Linear.homCongr k (indFDRepForgetIso A) (Iso.refl _)).trans
+      (Rep.indResHomEquiv S.subtype _ _)).trans
+        (FDRep.forget₂HomLinearEquiv A (resFDRep S B))
+
+/-- The intertwining space out of an induced representation has the same dimension as the
+intertwining space into the corresponding restriction. This is the quantitative content of
+Frobenius reciprocity, and holds over an arbitrary field. -/
+theorem finrank_hom_indFDRep [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+    Module.finrank k (indFDRep A ⟶ B) = Module.finrank k (A ⟶ resFDRep S B) :=
+  (indResFDRepHomEquiv A B).finrank_eq
+
+/-- **The second reciprocity**, available because induction from a finite-index subgroup is also a
+*right* adjoint to restriction: `Hom_S(Res_S B, A) ≃ₗ[k] Hom_G(B, Ind_S^G A)`.
+
+Where `TauCeti.indResFDRepHomEquiv` transports Mathlib's `Rep.indResHomEquiv`, this transports
+`Rep.resCoindHomEquiv` along Mathlib's finite-index identification `Rep.indCoindIso` of induction
+with coinduction; the pair is the finite-dimensional shadow of `Rep.resIndAdjunction`. -/
+noncomputable def resIndFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+    (resFDRep S B ⟶ A) ≃ₗ[k] (B ⟶ indFDRep A) :=
+  -- `Rep.indCoindIso` picks coset representatives, so it wants the coset relation to be decidable.
+  letI : DecidableRel ⇑(QuotientGroup.rightRel S) := Classical.decRel _
+  (FDRep.forget₂HomLinearEquiv (resFDRep S B) A).symm.trans <|
+    (Rep.resCoindHomEquiv S.subtype _ _).trans <|
+      (Linear.homCongr k (Iso.refl _)
+        ((indFDRepForgetIso A).trans (Rep.indCoindIso _)).symm).trans
+          (FDRep.forget₂HomLinearEquiv B (indFDRep A))
+
+/-- The dimension form of the second reciprocity. -/
+theorem finrank_hom_resFDRep [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
+    Module.finrank k (resFDRep S B ⟶ A) = Module.finrank k (B ⟶ indFDRep A) :=
+  (resIndFDRepHomEquiv A B).finrank_eq
+
+end HomSpaces
+
+section Characters
+
+variable {S : Subgroup G}
+
+/-- The scalar product of two functions on a finite group is symmetric: reindexing by `g ↦ g⁻¹`
+exchanges the two arguments.  No class-function hypothesis is needed. -/
+private theorem sum_mul_inv_comm {Γ : Type*} [Group Γ] [Fintype Γ] (f h : Γ → k) :
+    ∑ g : Γ, f g * h g⁻¹ = ∑ g : Γ, h g * f g⁻¹ :=
+  (Fintype.sum_equiv (Equiv.inv Γ) _ _ fun g => by simp [mul_comm]).symm
+
+/-- If the order of a finite group is invertible in `k`, then so is the order of any subgroup,
+because the two differ by the index. -/
+private theorem isUnit_natCard_subgroup [Finite G] (S : Subgroup G)
+    (hG : IsUnit (Nat.card G : k)) : IsUnit (Nat.card S : k) := by
+  refine isUnit_of_mul_isUnit_left (y := (S.index : k)) ?_
+  rwa [← Nat.cast_mul, S.card_mul_index]
+
+open scoped Classical in
+/-- **Frobenius reciprocity as a character identity.**  The scalar product over `G` of an induced
+character with a character of `G` equals the scalar product over `S` of the original character with
+the restricted character.
+
+Both sides are written as explicit normalized sums, so the statement does not depend on the name of
+any particular pairing; `TauCeti.characterPairing_indFDRep` is the same identity phrased against
+`TauCeti.ClassFunction.characterPairing`.  The hypothesis `hG` is what makes the normalizing factors
+meaningful; it also supplies the invertibility of `Nat.card S`. -/
+theorem frobenius_reciprocity [Fintype G] [S.FiniteIndex] (hG : IsUnit (Nat.card G : k))
+    (A : FDRep k S) (B : FDRep k G) :
+    (Nat.card G : k)⁻¹ * ∑ g : G, (indFDRep A).character g * B.character g⁻¹ =
+      (Nat.card S : k)⁻¹ * ∑ s : S, A.character s * B.character ((s : G)⁻¹) := by
+  letI : Invertible (Nat.card G : k) := hG.invertible
+  letI : Invertible (Nat.card S : k) := (isUnit_natCard_subgroup S hG).invertible
+  -- The subgroup element `(s : G)⁻¹` is the coercion of `s⁻¹`, so the right-hand sum is already a
+  -- scalar product of characters of `S`.
+  have hres (s : S) : B.character ((s : G)⁻¹) = (resFDRep S B).character s⁻¹ := rfl
+  simp only [hres]
+  -- Reindexing each sum by `g ↦ g⁻¹` puts its two factors in the order Mathlib's scalar-product
+  -- lemma expects, and each side then becomes the dimension of an intertwining space.
+  rw [sum_mul_inv_comm (indFDRep A).character B.character,
+    sum_mul_inv_comm A.character (resFDRep S B).character,
+    FDRep.scalar_product_char_eq_finrank_equivariant (indFDRep A) B,
+    FDRep.scalar_product_char_eq_finrank_equivariant A (resFDRep S B),
+    finrank_hom_indFDRep A B]
+
+open scoped Classical in
+/-- Frobenius reciprocity, phrased against the normalized pairing of class functions used by the
+character-theory development. -/
+theorem characterPairing_indFDRep [Fintype G] [S.FiniteIndex] (hG : IsUnit (Nat.card G : k))
+    (A : FDRep k S) (B : FDRep k G) :
+    ClassFunction.characterPairing (ClassFunction.ofFDRep (indFDRep A))
+        (ClassFunction.ofFDRep B) =
+      ClassFunction.characterPairing (ClassFunction.ofFDRep A)
+        (ClassFunction.ofFDRep (resFDRep S B)) := by
+  rw [ClassFunction.characterPairing_apply, ClassFunction.characterPairing_apply]
+  simpa using frobenius_reciprocity hG A B
+
+open scoped Classical in
+/-- Reciprocity against the trivial representation: the normalized average of an induced character
+over `G` is the normalized average of the original character over `S`.  Equivalently, by
+`FDRep.average_char_eq_finrank_invariants`, inducing does not change the dimension of the space of
+invariants. -/
+theorem card_inv_mul_sum_character_indFDRep [Fintype G] [S.FiniteIndex]
+    (hG : IsUnit (Nat.card G : k)) (A : FDRep k S) :
+    (Nat.card G : k)⁻¹ * ∑ g : G, (indFDRep A).character g =
+      (Nat.card S : k)⁻¹ * ∑ s : S, A.character s := by
+  have htriv (g : G) : (FDRep.of (Representation.trivial k G k)).character g = 1 := by
+    simp [FDRep.character, Representation.trivial]
+  simpa [htriv] using frobenius_reciprocity hG A (FDRep.of (Representation.trivial k G k))
+
+end Characters
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -77,28 +77,25 @@ section Restriction
 /-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
 `Action.res` along `S.subtype`, under the definitional identification
 `FDRep k G = Action (FGModuleCat k) G`; this definition only supplies the representation-theoretic
-name. -/
-@[expose]
+name.
+
+The body is not exposed, as for `TauCeti.indFDRep`; the characteristic properties are
+`character_resFDRep` and `forget₂_obj_resFDRep`, the latter identifying the underlying object with
+Mathlib's `Rep.res` and so carrying the description of the representation itself. -/
 def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
   (Action.res (FGModuleCat k) S.subtype).obj B
-
-/-- Restriction acts on the representation by precomposing with the inclusion of the subgroup. -/
-@[simp]
-theorem resFDRep_ρ (S : Subgroup G) (B : FDRep k G) :
-    (resFDRep S B).ρ = B.ρ.comp S.subtype :=
-  rfl
 
 /-- The character of a restriction is the restriction of the character. -/
 @[simp]
 theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
     (resFDRep S B).character s = B.character (s : G) :=
-  rfl
+  (rfl)
 
 /-- Restriction commutes with forgetting finite-dimensionality. -/
 theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
     (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
       Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
-  rfl
+  (rfl)
 
 end Restriction
 

--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -43,8 +43,10 @@ from `Subgroup.card_mul_index`.
 
 That pairing-to-dimension lemma computes `⟨χ_V, χ_W⟩` as `finrank k (W ⟶ V)`, exchanging the two
 arguments.  So the identity stated in the order `⟨Ind χ, ψ⟩ = ⟨χ, Res ψ⟩` is read off the *second*
-reciprocity `finrank_hom_resFDRep`, and the identity in the order `⟨Res ψ, χ⟩ = ⟨ψ, Ind χ⟩` off the
-first, `finrank_hom_indFDRep`.  Neither direction needs a reindexing of the sums.
+reciprocity, `finrank_hom_resFDRep`.  The identity in the order `⟨Res ψ, χ⟩ = ⟨ψ, Ind χ⟩` is then
+just that one with both sides flipped, by `TauCeti.ClassFunction.characterPairing_symm`, so it is
+derived rather than proved again from `finrank_hom_indFDRep`.  Neither direction needs a reindexing
+of the sums.
 
 The two `k`-linear equivalences of intertwining spaces that carry the reciprocities are private:
 only their `finrank` corollaries are intended as API, and both are opaque transports whose bodies
@@ -163,30 +165,6 @@ theorem frobenius_reciprocity [Fintype G] (hG : IsUnit (Nat.card G : k))
     _ = (Nat.card S : k)⁻¹ * ∑ s : S, A.character s * B.character ((s : G)⁻¹) := by simp
 
 open scoped Classical in
-/-- **Frobenius reciprocity in the other direction**: the scalar product over `S` of a restricted
-character with a character of `S` equals the scalar product over `G` of the original character with
-the induced character.  This is the shadow of the second adjunction, `Rep.resIndAdjunction`. -/
-theorem frobenius_reciprocity_resFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
-    (A : FDRep k S) (B : FDRep k G) :
-    (Nat.card S : k)⁻¹ * ∑ s : S, B.character (s : G) * A.character s⁻¹ =
-      (Nat.card G : k)⁻¹ * ∑ g : G, B.character g * (indFDRep A).character g⁻¹ := by
-  letI : Invertible (Nat.card G : k) := hG.invertible
-  letI : Invertible (Nat.card S : k) := (isUnit_natCard_subgroup S hG).invertible
-  calc (Nat.card S : k)⁻¹ * ∑ s : S, B.character (s : G) * A.character s⁻¹
-      = ClassFunction.characterPairing (ClassFunction.ofFDRep (resFDRep S B))
-          (ClassFunction.ofFDRep A) := by
-        rw [ClassFunction.characterPairing_ofFDRep]
-        simp
-    _ = (Module.finrank k (A ⟶ resFDRep S B) : k) :=
-        ClassFunction.characterPairing_ofFDRep_eq_finrank _ _
-    _ = (Module.finrank k (indFDRep A ⟶ B) : k) := by rw [finrank_hom_indFDRep]
-    _ = ClassFunction.characterPairing (ClassFunction.ofFDRep B)
-          (ClassFunction.ofFDRep (indFDRep A)) :=
-        (ClassFunction.characterPairing_ofFDRep_eq_finrank _ _).symm
-    _ = (Nat.card G : k)⁻¹ * ∑ g : G, B.character g * (indFDRep A).character g⁻¹ :=
-        ClassFunction.characterPairing_ofFDRep _ _
-
-open scoped Classical in
 /-- Frobenius reciprocity, phrased against the normalized pairing of class functions used by the
 character-theory development. -/
 theorem characterPairing_indFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
@@ -200,15 +178,29 @@ theorem characterPairing_indFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
 
 open scoped Classical in
 /-- The reciprocity in the other direction, phrased against
-`TauCeti.ClassFunction.characterPairing`. -/
+`TauCeti.ClassFunction.characterPairing`.  The pairing is symmetric, so this is
+`characterPairing_indFDRep` with both sides flipped. -/
 theorem characterPairing_resFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
     (A : FDRep k S) (B : FDRep k G) :
     ClassFunction.characterPairing (ClassFunction.ofFDRep (resFDRep S B))
         (ClassFunction.ofFDRep A) =
       ClassFunction.characterPairing (ClassFunction.ofFDRep B)
         (ClassFunction.ofFDRep (indFDRep A)) := by
-  rw [ClassFunction.characterPairing_apply, ClassFunction.characterPairing_apply]
-  simpa using frobenius_reciprocity_resFDRep hG A B
+  rw [ClassFunction.characterPairing_symm (ClassFunction.ofFDRep (resFDRep S B)),
+    ClassFunction.characterPairing_symm (ClassFunction.ofFDRep B)]
+  exact (characterPairing_indFDRep hG A B).symm
+
+open scoped Classical in
+/-- **Frobenius reciprocity in the other direction**: the scalar product over `S` of a restricted
+character with a character of `S` equals the scalar product over `G` of the original character with
+the induced character.  This is `characterPairing_resFDRep` with the pairing unfolded. -/
+theorem frobenius_reciprocity_resFDRep [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (A : FDRep k S) (B : FDRep k G) :
+    (Nat.card S : k)⁻¹ * ∑ s : S, B.character (s : G) * A.character s⁻¹ =
+      (Nat.card G : k)⁻¹ * ∑ g : G, B.character g * (indFDRep A).character g⁻¹ := by
+  have h := characterPairing_resFDRep hG A B
+  rw [ClassFunction.characterPairing_apply, ClassFunction.characterPairing_apply] at h
+  simpa using h
 
 open scoped Classical in
 /-- Reciprocity against the trivial representation: the normalized average of an induced character

--- a/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
+++ b/TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean
@@ -86,11 +86,12 @@ This is Mathlib's `Rep.indResHomEquiv`, the linear form of the adjunction
 It is private: only `finrank_hom_indFDRep` is intended as API. -/
 private noncomputable def indResFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B : FDRep k G) :
     (indFDRep A ⟶ B) ≃ₗ[k] (A ⟶ resFDRep S B) :=
+  -- `resFDRep` is an abbreviation for `Action.res`, so its image under `forget₂` is `Rep.res`
+  -- definitionally and the restriction side needs no comparison isomorphism.
   (FDRep.forget₂HomLinearEquiv (indFDRep A) B).symm.trans <|
     ((Linear.homCongr k (indFDRepForgetIso A) (Iso.refl _)).trans
-      (Rep.indResHomEquiv S.subtype _ _)).trans <|
-        (Linear.homCongr k (Iso.refl _) (resFDRepForgetIso S B).symm).trans
-          (FDRep.forget₂HomLinearEquiv A (resFDRep S B))
+      (Rep.indResHomEquiv S.subtype _ _)).trans
+        (FDRep.forget₂HomLinearEquiv A (resFDRep S B))
 
 /-- The intertwining space out of an induced representation has the same dimension as the
 intertwining space into the corresponding restriction. This is the quantitative content of
@@ -112,7 +113,6 @@ private noncomputable def resIndFDRepHomEquiv [S.FiniteIndex] (A : FDRep k S) (B
   -- `Rep.indCoindIso` picks coset representatives, so it wants the coset relation to be decidable.
   letI : DecidableRel ⇑(QuotientGroup.rightRel S) := Classical.decRel _
   (FDRep.forget₂HomLinearEquiv (resFDRep S B) A).symm.trans <|
-    (Linear.homCongr k (resFDRepForgetIso S B) (Iso.refl _)).trans <|
     (Rep.resCoindHomEquiv S.subtype _ _).trans <|
       (Linear.homCongr k (Iso.refl _)
         ((indFDRepForgetIso A).trans (Rep.indCoindIso _)).symm).trans

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -11,37 +11,25 @@ public import Mathlib.RepresentationTheory.Rep.Res
 /-!
 # Restriction of a finite-dimensional representation to a subgroup
 
-For a subgroup `S` of a group `G` this file restricts a finite-dimensional representation of `G`
-to `S`.  This is Mathlib's `Rep.res` transported to `FDRep`, and it depends on nothing beyond
-`FDRep` itself: it is kept separate from the induction and Frobenius-reciprocity files so that a
-consumer of restriction alone need not import them.
+For a subgroup `S` of a group `G` this file names the restriction of a finite-dimensional
+representation of `G` to `S` and records its character.
 
-Restriction is packaged both objectwise, as `resFDRep`, and functorially, as `resFDRepFunctor`,
-the latter naturally isomorphic to `Rep.resFunctor` under the forgetful functor to `Rep k S`.
-This mirrors the `indFDRep` / `indFDRepFunctor` pair of
-`TauCeti.RepresentationTheory.Induction.FiniteDimensional`.
+`FDRep k G` is by definition `Action (FGModuleCat k) G`, so Mathlib's `Action.res` along
+`S.subtype` *is* the restriction functor `FDRep k G ⥤ FDRep k S`; nothing has to be built.
+Accordingly `resFDRep` is a reducible abbreviation for that functor on objects, exactly as
+Mathlib's `Rep.res` is one for `Rep.resFunctor` on objects, and everything functorial —
+restriction of an intertwiner, the functor laws, naturality — is used straight from
+`Action.res (FGModuleCat k) S.subtype` and its `@[simps]` lemmas (`Action.res_obj_V`,
+`Action.res_obj_ρ`, `Action.res_map_hom`) rather than restated here.
 
 ## Main definitions
 
 * `TauCeti.resFDRep`: restriction of a finite-dimensional representation to a subgroup.
-* `TauCeti.resFDRepMap`: restriction of an intertwiner.
-* `TauCeti.resFDRepFunctor`: the two packaged as a functor `FDRep k G ⥤ FDRep k S`.
-* `TauCeti.resFDRepForgetIso`, `TauCeti.resFDRepForgetNatIso`: the identification of `resFDRep`
-  with Mathlib's `Rep.res` after forgetting finite-dimensionality, objectwise and naturally.
 
 ## Implementation notes
 
-Everything except the character formula lives over a commutative ring, matching Mathlib's
-`Rep.resFunctor`; `Field k` enters only with `FDRep.character`.
-
-The bodies of `resFDRep` and `resFDRepMap` are not exposed; their characteristic properties are
-`character_resFDRep`, `forget₂_obj_resFDRep` and `forget₂_map_resFDRepMap`.  The second is an
-*equality* of objects of `Rep k S` with `Rep.res`, not merely an isomorphism, so it carries the
-description of the restricted representation and lets Mathlib's `Rep.res` API transfer.  Since a
-sealed body cannot be unfolded while elaborating the *type* of a later declaration,
-`resFDRepForgetIso` records the same identification as an isomorphism, which the morphism-level
-lemmas and downstream files use in place of the definitional equality; this mirrors
-`TauCeti.indFDRepForgetIso`.
+The abbreviation is over a commutative ring, matching Mathlib's `Action.res`; `Field k` enters
+only with `FDRep.character`.
 
 ## References
 
@@ -63,91 +51,23 @@ section Representation
 
 variable [CommRing k]
 
-/-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
+/-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`: Mathlib's
 `Action.res` along `S.subtype`, under the definitional identification
-`FDRep k G = Action (FGModuleCat k) G`; this definition only supplies the representation-theoretic
-name. -/
-def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
+`FDRep k G = Action (FGModuleCat k) G`.
+
+This is a reducible abbreviation, so Mathlib's `Action.res` API applies to it unchanged; in
+particular `(Action.res (FGModuleCat k) S.subtype).map f : resFDRep S B ⟶ resFDRep S B'`
+restricts an intertwiner, and is functorial by `Functor.map_id` and `Functor.map_comp`. -/
+abbrev resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
   (Action.res (FGModuleCat k) S.subtype).obj B
 
-/-- Restriction commutes with forgetting finite-dimensionality. -/
+/-- Restriction commutes with forgetting finite-dimensionality: after forgetting, `resFDRep` is
+Mathlib's `Rep.res`, on the nose rather than up to isomorphism. -/
 @[simp]
 theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
     (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
       Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
-  (rfl)
-
-/-- `forget₂_obj_resFDRep` as an isomorphism, for use in the types of later declarations, where the
-sealed body of `resFDRep` is not available to unfold. -/
-noncomputable def resFDRepForgetIso (S : Subgroup G) (B : FDRep k G) :
-    (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) ≅
-      Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
-  Iso.refl _
-
-/-- Restriction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.resFunctor`
-on the underlying intertwiner, conjugated by `resFDRepForgetIso` and transported back along the
-fully faithful forgetful functor `FDRep k S ⥤ Rep k S`.  Its characterizing property is
-`forget₂_map_resFDRepMap`; the definition itself is not exposed. -/
-noncomputable def resFDRepMap (S : Subgroup G) {B B' : FDRep k G} (f : B ⟶ B') :
-    resFDRep S B ⟶ resFDRep S B' :=
-  (forget₂ (FDRep k S) (Rep k S)).preimage
-    ((resFDRepForgetIso S B).hom ≫
-      (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f) ≫
-        (resFDRepForgetIso S B').inv)
-
-/-- Forgetting finite-dimensionality from `resFDRepMap` gives Mathlib's restricted intertwiner,
-conjugated by `resFDRepForgetIso`.  This is the only fact about `resFDRepMap` used below. -/
-@[simp]
-theorem forget₂_map_resFDRepMap (S : Subgroup G) {B B' : FDRep k G} (f : B ⟶ B') :
-    (forget₂ (FDRep k S) (Rep k S)).map (resFDRepMap S f) =
-      (resFDRepForgetIso S B).hom ≫
-        (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f) ≫
-          (resFDRepForgetIso S B').inv := by
-  rw [resFDRepMap]
-  exact (forget₂ (FDRep k S) (Rep k S)).map_preimage _
-
-/-- Restriction of intertwiners preserves identities. -/
-theorem resFDRepMap_id (S : Subgroup G) (B : FDRep k G) :
-    resFDRepMap S (𝟙 B) = 𝟙 (resFDRep S B) :=
-  -- The law holds after applying the forgetful functor: the conjugating copies of
-  -- `resFDRepForgetIso` cancel, so the proof does not unfold `resFDRep`.
-  (forget₂ (FDRep k S) (Rep k S)).map_injective (by
-    simp only [forget₂_map_resFDRepMap, CategoryTheory.Functor.map_id]
-    rfl)
-
-/-- Restriction of intertwiners preserves composition. -/
-theorem resFDRepMap_comp (S : Subgroup G) {B B' B'' : FDRep k G} (f : B ⟶ B') (g : B' ⟶ B'') :
-    resFDRepMap S (f ≫ g) = resFDRepMap S f ≫ resFDRepMap S g :=
-  (forget₂ (FDRep k S) (Rep k S)).map_injective (by
-    simp only [forget₂_map_resFDRepMap, CategoryTheory.Functor.map_comp]
-    rfl)
-
-/-- Restriction to a subgroup, as a functor on finite-dimensional representations.  It acts on
-objects as `resFDRep` and on intertwiners as `resFDRepMap`.
-
-`@[simps obj map]` supplies the projection lemmas `resFDRepFunctor_obj` and `resFDRepFunctor_map`.
-Both are proved by `rfl`, and the type of the second needs `(resFDRepFunctor S).obj B` to reduce to
-`resFDRep S B`, so this definition is `@[expose]`.  Exposing it publishes exactly those two
-projections: the construction of the morphism map lives in `resFDRepMap`, which stays opaque behind
-`forget₂_map_resFDRepMap`. -/
-@[expose, simps obj map]
-noncomputable def resFDRepFunctor (S : Subgroup G) : FDRep k G ⥤ FDRep k S where
-  obj B := resFDRep S B
-  map f := resFDRepMap S f
-  map_id B := resFDRepMap_id S B
-  map_comp f g := resFDRepMap_comp S f g
-
-/-- Under the forgetful functor to `Rep k S`, `resFDRepFunctor` is naturally isomorphic to
-Mathlib's restriction functor, componentwise by `resFDRepForgetIso`. -/
-noncomputable def resFDRepForgetNatIso (S : Subgroup G) :
-    resFDRepFunctor (k := k) S ⋙ forget₂ (FDRep k S) (Rep k S) ≅
-      forget₂ (FDRep k G) (Rep k G) ⋙ Rep.resFunctor S.subtype :=
-  NatIso.ofComponents (fun B ↦ resFDRepForgetIso S B) fun {B B'} f ↦ by
-    -- Naturality is the cancellation of the conjugating isomorphisms in `resFDRepMap`.
-    change (forget₂ (FDRep k S) (Rep k S)).map (resFDRepMap S f) ≫ (resFDRepForgetIso S B').hom =
-      (resFDRepForgetIso S B).hom ≫
-        (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f)
-    rw [forget₂_map_resFDRepMap, Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+  rfl
 
 end Representation
 
@@ -159,7 +79,7 @@ variable [Field k]
 @[simp]
 theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
     (resFDRep S B).character s = B.character (s : G) :=
-  (rfl)
+  rfl
 
 end Character
 

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -16,20 +16,31 @@ to `S`.  This is Mathlib's `Rep.res` transported to `FDRep`, and it depends on n
 `FDRep` itself: it is kept separate from the induction and Frobenius-reciprocity files so that a
 consumer of restriction alone need not import them.
 
+Restriction is packaged both objectwise, as `resFDRep`, and functorially, as `resFDRepFunctor`,
+the latter naturally isomorphic to `Rep.resFunctor` under the forgetful functor to `Rep k S`.
+This mirrors the `indFDRep` / `indFDRepFunctor` pair of
+`TauCeti.RepresentationTheory.Induction.FiniteDimensional`.
+
 ## Main definitions
 
 * `TauCeti.resFDRep`: restriction of a finite-dimensional representation to a subgroup.
-* `TauCeti.resFDRepForgetIso`: the identification of `resFDRep` with Mathlib's `Rep.res` after
-  forgetting finite-dimensionality.
+* `TauCeti.resFDRepMap`: restriction of an intertwiner.
+* `TauCeti.resFDRepFunctor`: the two packaged as a functor `FDRep k G ⥤ FDRep k S`.
+* `TauCeti.resFDRepForgetIso`, `TauCeti.resFDRepForgetNatIso`: the identification of `resFDRep`
+  with Mathlib's `Rep.res` after forgetting finite-dimensionality, objectwise and naturally.
 
 ## Implementation notes
 
-The body of `resFDRep` is not exposed; its characteristic properties are `character_resFDRep` and
-`forget₂_obj_resFDRep`.  The latter is an *equality* of objects of `Rep k S` with `Rep.res`, not
-merely an isomorphism, so it carries the description of the restricted representation and lets
-Mathlib's `Rep.res` API transfer.  Since a sealed body cannot be unfolded while elaborating the
-*type* of a later declaration, `resFDRepForgetIso` records the same identification as an
-isomorphism, which downstream files use in place of the definitional equality; this mirrors
+Everything except the character formula lives over a commutative ring, matching Mathlib's
+`Rep.resFunctor`; `Field k` enters only with `FDRep.character`.
+
+The bodies of `resFDRep` and `resFDRepMap` are not exposed; their characteristic properties are
+`character_resFDRep`, `forget₂_obj_resFDRep` and `forget₂_map_resFDRepMap`.  The second is an
+*equality* of objects of `Rep k S` with `Rep.res`, not merely an isomorphism, so it carries the
+description of the restricted representation and lets Mathlib's `Rep.res` API transfer.  Since a
+sealed body cannot be unfolded while elaborating the *type* of a later declaration,
+`resFDRepForgetIso` records the same identification as an isomorphism, which the morphism-level
+lemmas and downstream files use in place of the definitional equality; this mirrors
 `TauCeti.indFDRepForgetIso`.
 
 ## References
@@ -46,7 +57,11 @@ namespace TauCeti
 
 universe u
 
-variable {k G : Type u} [Field k] [Group G]
+variable {k G : Type u} [Group G]
+
+section Representation
+
+variable [CommRing k]
 
 /-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
 `Action.res` along `S.subtype`, under the definitional identification
@@ -55,13 +70,8 @@ name. -/
 def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
   (Action.res (FGModuleCat k) S.subtype).obj B
 
-/-- The character of a restriction is the restriction of the character. -/
-@[simp]
-theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
-    (resFDRep S B).character s = B.character (s : G) :=
-  (rfl)
-
 /-- Restriction commutes with forgetting finite-dimensionality. -/
+@[simp]
 theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
     (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
       Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
@@ -73,5 +83,84 @@ noncomputable def resFDRepForgetIso (S : Subgroup G) (B : FDRep k G) :
     (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) ≅
       Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
   Iso.refl _
+
+/-- Restriction of an intertwiner of finite-dimensional representations: Mathlib's `Rep.resFunctor`
+on the underlying intertwiner, conjugated by `resFDRepForgetIso` and transported back along the
+fully faithful forgetful functor `FDRep k S ⥤ Rep k S`.  Its characterizing property is
+`forget₂_map_resFDRepMap`; the definition itself is not exposed. -/
+noncomputable def resFDRepMap (S : Subgroup G) {B B' : FDRep k G} (f : B ⟶ B') :
+    resFDRep S B ⟶ resFDRep S B' :=
+  (forget₂ (FDRep k S) (Rep k S)).preimage
+    ((resFDRepForgetIso S B).hom ≫
+      (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f) ≫
+        (resFDRepForgetIso S B').inv)
+
+/-- Forgetting finite-dimensionality from `resFDRepMap` gives Mathlib's restricted intertwiner,
+conjugated by `resFDRepForgetIso`.  This is the only fact about `resFDRepMap` used below. -/
+@[simp]
+theorem forget₂_map_resFDRepMap (S : Subgroup G) {B B' : FDRep k G} (f : B ⟶ B') :
+    (forget₂ (FDRep k S) (Rep k S)).map (resFDRepMap S f) =
+      (resFDRepForgetIso S B).hom ≫
+        (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f) ≫
+          (resFDRepForgetIso S B').inv := by
+  rw [resFDRepMap]
+  exact (forget₂ (FDRep k S) (Rep k S)).map_preimage _
+
+/-- Restriction of intertwiners preserves identities. -/
+theorem resFDRepMap_id (S : Subgroup G) (B : FDRep k G) :
+    resFDRepMap S (𝟙 B) = 𝟙 (resFDRep S B) :=
+  -- The law holds after applying the forgetful functor: the conjugating copies of
+  -- `resFDRepForgetIso` cancel, so the proof does not unfold `resFDRep`.
+  (forget₂ (FDRep k S) (Rep k S)).map_injective (by
+    simp only [forget₂_map_resFDRepMap, CategoryTheory.Functor.map_id]
+    rfl)
+
+/-- Restriction of intertwiners preserves composition. -/
+theorem resFDRepMap_comp (S : Subgroup G) {B B' B'' : FDRep k G} (f : B ⟶ B') (g : B' ⟶ B'') :
+    resFDRepMap S (f ≫ g) = resFDRepMap S f ≫ resFDRepMap S g :=
+  (forget₂ (FDRep k S) (Rep k S)).map_injective (by
+    simp only [forget₂_map_resFDRepMap, CategoryTheory.Functor.map_comp]
+    rfl)
+
+/-- Restriction to a subgroup, as a functor on finite-dimensional representations.  It acts on
+objects as `resFDRep` and on intertwiners as `resFDRepMap`.
+
+`@[simps obj map]` supplies the projection lemmas `resFDRepFunctor_obj` and `resFDRepFunctor_map`.
+Both are proved by `rfl`, and the type of the second needs `(resFDRepFunctor S).obj B` to reduce to
+`resFDRep S B`, so this definition is `@[expose]`.  Exposing it publishes exactly those two
+projections: the construction of the morphism map lives in `resFDRepMap`, which stays opaque behind
+`forget₂_map_resFDRepMap`. -/
+@[expose, simps obj map]
+noncomputable def resFDRepFunctor (S : Subgroup G) : FDRep k G ⥤ FDRep k S where
+  obj B := resFDRep S B
+  map f := resFDRepMap S f
+  map_id B := resFDRepMap_id S B
+  map_comp f g := resFDRepMap_comp S f g
+
+/-- Under the forgetful functor to `Rep k S`, `resFDRepFunctor` is naturally isomorphic to
+Mathlib's restriction functor, componentwise by `resFDRepForgetIso`. -/
+noncomputable def resFDRepForgetNatIso (S : Subgroup G) :
+    resFDRepFunctor (k := k) S ⋙ forget₂ (FDRep k S) (Rep k S) ≅
+      forget₂ (FDRep k G) (Rep k G) ⋙ Rep.resFunctor S.subtype :=
+  NatIso.ofComponents (fun B ↦ resFDRepForgetIso S B) fun {B B'} f ↦ by
+    -- Naturality is the cancellation of the conjugating isomorphisms in `resFDRepMap`.
+    change (forget₂ (FDRep k S) (Rep k S)).map (resFDRepMap S f) ≫ (resFDRepForgetIso S B').hom =
+      (resFDRepForgetIso S B).hom ≫
+        (Rep.resFunctor S.subtype).map ((forget₂ (FDRep k G) (Rep k G)).map f)
+    rw [forget₂_map_resFDRepMap, Category.assoc, Category.assoc, Iso.inv_hom_id, Category.comp_id]
+
+end Representation
+
+section Character
+
+variable [Field k]
+
+/-- The character of a restriction is the restriction of the character. -/
+@[simp]
+theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
+    (resFDRep S B).character s = B.character (s : G) :=
+  (rfl)
+
+end Character
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/Restriction.lean
+++ b/TauCeti/RepresentationTheory/Induction/Restriction.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RepresentationTheory.Character
+public import Mathlib.RepresentationTheory.Rep.Res
+
+/-!
+# Restriction of a finite-dimensional representation to a subgroup
+
+For a subgroup `S` of a group `G` this file restricts a finite-dimensional representation of `G`
+to `S`.  This is Mathlib's `Rep.res` transported to `FDRep`, and it depends on nothing beyond
+`FDRep` itself: it is kept separate from the induction and Frobenius-reciprocity files so that a
+consumer of restriction alone need not import them.
+
+## Main definitions
+
+* `TauCeti.resFDRep`: restriction of a finite-dimensional representation to a subgroup.
+* `TauCeti.resFDRepForgetIso`: the identification of `resFDRep` with Mathlib's `Rep.res` after
+  forgetting finite-dimensionality.
+
+## Implementation notes
+
+The body of `resFDRep` is not exposed; its characteristic properties are `character_resFDRep` and
+`forget₂_obj_resFDRep`.  The latter is an *equality* of objects of `Rep k S` with `Rep.res`, not
+merely an isomorphism, so it carries the description of the restricted representation and lets
+Mathlib's `Rep.res` API transfer.  Since a sealed body cannot be unfolded while elaborating the
+*type* of a later declaration, `resFDRepForgetIso` records the same identification as an
+isomorphism, which downstream files use in place of the definitional equality; this mirrors
+`TauCeti.indFDRepForgetIso`.
+
+## References
+
+This is restriction infrastructure for Layer 2 of
+`TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+variable {k G : Type u} [Field k] [Group G]
+
+/-- Restriction of a finite-dimensional representation of `G` to a subgroup `S`.  This is Mathlib's
+`Action.res` along `S.subtype`, under the definitional identification
+`FDRep k G = Action (FGModuleCat k) G`; this definition only supplies the representation-theoretic
+name. -/
+def resFDRep (S : Subgroup G) (B : FDRep k G) : FDRep k S :=
+  (Action.res (FGModuleCat k) S.subtype).obj B
+
+/-- The character of a restriction is the restriction of the character. -/
+@[simp]
+theorem character_resFDRep (S : Subgroup G) (B : FDRep k G) (s : S) :
+    (resFDRep S B).character s = B.character (s : G) :=
+  (rfl)
+
+/-- Restriction commutes with forgetting finite-dimensionality. -/
+theorem forget₂_obj_resFDRep (S : Subgroup G) (B : FDRep k G) :
+    (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) =
+      Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
+  (rfl)
+
+/-- `forget₂_obj_resFDRep` as an isomorphism, for use in the types of later declarations, where the
+sealed body of `resFDRep` is not available to unfold. -/
+noncomputable def resFDRepForgetIso (S : Subgroup G) (B : FDRep k G) :
+    (forget₂ (FDRep k S) (Rep k S)).obj (resFDRep S B) ≅
+      Rep.res S.subtype ((forget₂ (FDRep k G) (Rep k G)).obj B) :=
+  Iso.refl _
+
+end TauCeti


### PR DESCRIPTION
This PR proves Frobenius reciprocity as a character identity for a finite-index subgroup: the normalized scalar product over `G` of an induced character with a character of `G` equals the normalized scalar product over the subgroup of the original character with the restricted character, together with the identity in the other direction. It transports Mathlib's `Rep.indResHomEquiv` (the linear form of `Rep.indResAdjunction`) and `Rep.resCoindHomEquiv` (together with the finite-index identification `Rep.indCoindIso`) to finite-dimensional representations, obtaining both reciprocity isomorphisms as `k`-linear equivalences of intertwining spaces, and then reads each side of the character identity off `TauCeti.ClassFunction.characterPairing_ofFDRep_eq_finrank`.

The target is the "Frobenius reciprocity as a character identity" bullet of Layer 2 in `TauCetiRoadmap/RepresentationTheory/InductionRestriction/README.md` ("Frobenius reciprocity as an identity of character inner products in both directions"), recorded in that roadmap's `Suggested.lean` as `frobenius_reciprocity`; the statement here matches that signature, save that the redundant `[S.FiniteIndex]` is dropped in favour of the instance `[Fintype G]` already supplies. The same layer asks for "a small compatibility layer relating Mathlib's scalar product to the character-theory roadmap's `characterPairing`", supplied here as `characterPairing_indFDRep` and `characterPairing_resFDRep`.

Two new files:

`TauCeti/RepresentationTheory/Induction/Restriction.lean` carries the restriction API on its own, depending on nothing beyond `FDRep`: `resFDRep`, restriction of a finite-dimensional representation to a subgroup, as Mathlib's `Action.res` along `S.subtype`, with its character, its `forget₂` compatibility, and `resFDRepForgetIso`, the same identification as an isomorphism for use in the types of later declarations.

`TauCeti/RepresentationTheory/Induction/FrobeniusReciprocity.lean` adds:

- `indResFDRepHomEquiv : (indFDRep A ⟶ B) ≃ₗ[k] (A ⟶ resFDRep S B)` and `resIndFDRepHomEquiv : (resFDRep S B ⟶ A) ≃ₗ[k] (B ⟶ indFDRep A)`, both private, with their public `finrank` corollaries `finrank_hom_indFDRep` and `finrank_hom_resFDRep` (these need only a field, no invertibility);
- `frobenius_reciprocity` and `frobenius_reciprocity_resFDRep`, the character identity in both directions, with all sides written as explicit normalized sums;
- `characterPairing_indFDRep` and `characterPairing_resFDRep`, the same two identities against `TauCeti.ClassFunction.characterPairing`;
- `card_inv_mul_sum_character_indFDRep`, reciprocity against the trivial representation: inducing does not change the normalized average of a character.

The only hypothesis beyond a field is `IsUnit (Nat.card G : k)`; invertibility of `Nat.card S` is derived from `Subgroup.card_mul_index` rather than assumed, and no algebraic closure is needed since each side is computed as a dimension of intertwining maps rather than by orthogonality of irreducible characters.

No Mathlib infrastructure was vendored, and no material was taken from the supplementary source snapshot.

`lake build`, `lake exe axioms`, `lake exe module-system`, and `scripts/lint-env.sh` all pass locally.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"frobenius-reciprocity"}-->

🤖 Prepared with Claude Code
