### PR TITLE
feat: pull back chosen sections

### DIFF
--- a/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
+++ b/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
@@ -54,7 +54,7 @@ noncomputable def pullback (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f
   id := Limits.pullback.lift_snd _ _ _
 
 /-- The section underlying `SplitEpi.pullback` is the canonical pullback lift. -/
-lemma pullback_section (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
+lemma pullback_section_def (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
     (h.pullback g).section_ =
       Limits.pullback.lift (g ≫ h.section_) (𝟙 T) (by simp) :=
   (rfl)
@@ -64,7 +64,7 @@ the base-change morphism. -/
 @[reassoc (attr := simp)]
 lemma pullback_section_fst (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
     (h.pullback g).section_ ≫ Limits.pullback.fst f g = g ≫ h.section_ := by
-  simp only [pullback_section, Limits.pullback.lift_fst]
+  simp only [pullback_section_def, Limits.pullback.lift_fst]
 
 /-- The two projection formulas uniquely determine the pulled-back section. -/
 lemma eq_pullback_section (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g]
@@ -89,11 +89,8 @@ lemma pullback_section_naturality {Y : C} {f' : Y ⟶ S} (h : SplitEpi f)
         Limits.pullback.map f g f' g i (𝟙 T) (𝟙 S) (by simp [hi]) (by simp) =
       (h'.pullback g).section_ := by
   apply Limits.pullback.hom_ext
-  · rw [Category.assoc, Limits.pullback.lift_fst]
-    rw [← Category.assoc, h.pullback_section_fst, Category.assoc, hsection]
-    exact (h'.pullback_section_fst g).symm
-  · rw [Category.assoc, Limits.pullback.lift_snd]
-    rw [Category.comp_id, (h.pullback g).id, (h'.pullback g).id]
+  · simp [Limits.pullback.map, Limits.pullback.lift_fst, Category.assoc, hsection]
+  · simp [Limits.pullback.map, Limits.pullback.lift_snd, Category.assoc]
 
 /-- Pullback of a chosen section is natural in the base-change morphism.
 
@@ -106,14 +103,8 @@ lemma pullback_section_map (h : SplitEpi f) {T T' : C} (g : T ⟶ S) (k : T' ⟶
         Limits.pullback.map f (k ≫ g) f g (𝟙 X) k (𝟙 S) (by simp) (by simp) =
       k ≫ (h.pullback g).section_ := by
   apply Limits.pullback.hom_ext
-  · rw [Category.assoc, Limits.pullback.lift_fst, Category.comp_id]
-    rw [h.pullback_section_fst (k ≫ g)]
-    rw [Category.assoc k (h.pullback g).section_ (Limits.pullback.fst f g),
-      h.pullback_section_fst]
-    rw [Category.assoc]
-  · rw [Category.assoc, Limits.pullback.lift_snd]
-    rw [← Category.assoc, (h.pullback (k ≫ g)).id, Category.id_comp]
-    rw [Category.assoc, (h.pullback g).id, Category.comp_id]
+  · simp [Limits.pullback.map, Limits.pullback.lift_fst, Category.assoc]
+  · simp [Limits.pullback.map, Limits.pullback.lift_snd, Category.assoc]
 
 end SplitEpi
 

--- a/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
+++ b/TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean
@@ -1,0 +1,130 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.EpiMono
+public import Mathlib.CategoryTheory.Limits.Shapes.Pullback.HasPullback
+
+/-!
+# Pullbacks of split epimorphisms
+
+This file proves that a chosen section pulls back along an arbitrary morphism. If
+`s : S ⟶ X` is a section of `f : X ⟶ S` and `g : T ⟶ S`, its base change is the
+canonical morphism
+
+```
+T ⟶ X ×[S] T
+```
+
+whose projections are `g ≫ s` and `𝟙 T`. The construction is packaged as
+`CategoryTheory.SplitEpi.pullback`; its projection formulas characterize it uniquely.
+The file also records naturality in both the split epimorphism and the base-change
+morphism, and supplies the corresponding low-priority `IsSplitEpi` instance.
+
+For a scheme over a field, a rational point is precisely such a chosen section of the
+structure morphism. Thus this construction supplies base change of rational points, as
+required by the displayed `x₀.baseChange K` and base-change compatibility target in
+`TauCetiRoadmap/JacobianChallenge/README.md`. No formalization is vendored; the
+construction is the universal property of Mathlib's `pullback`.
+-/
+
+public section
+
+open CategoryTheory.Limits
+
+namespace CategoryTheory
+
+universe v u
+
+variable {C : Type u} [Category.{v} C]
+
+namespace SplitEpi
+
+variable {X S : C} {f : X ⟶ S}
+
+/-- Pull a chosen section of `f : X ⟶ S` back along `g : T ⟶ S`.
+
+The resulting section of `pullback.snd f g` has first projection `g ≫ h.section_`
+and second projection the identity of `T`. -/
+noncomputable def pullback (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
+    SplitEpi (Limits.pullback.snd f g) where
+  section_ := Limits.pullback.lift (g ≫ h.section_) (𝟙 T) (by simp)
+  id := Limits.pullback.lift_snd _ _ _
+
+/-- The section underlying `SplitEpi.pullback` is the canonical pullback lift. -/
+lemma pullback_section (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
+    (h.pullback g).section_ =
+      Limits.pullback.lift (g ≫ h.section_) (𝟙 T) (by simp) :=
+  (rfl)
+
+/-- The first projection of a pulled-back section is the original section after
+the base-change morphism. -/
+@[reassoc (attr := simp)]
+lemma pullback_section_fst (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g] :
+    (h.pullback g).section_ ≫ Limits.pullback.fst f g = g ≫ h.section_ := by
+  simp only [pullback_section, Limits.pullback.lift_fst]
+
+/-- The two projection formulas uniquely determine the pulled-back section. -/
+lemma eq_pullback_section (h : SplitEpi f) {T : C} (g : T ⟶ S) [HasPullback f g]
+    (t : T ⟶ Limits.pullback f g)
+    (hfst : t ≫ Limits.pullback.fst f g = g ≫ h.section_)
+    (hsnd : t ≫ Limits.pullback.snd f g = 𝟙 T) :
+    t = (h.pullback g).section_ := by
+  apply Limits.pullback.hom_ext
+  · rw [hfst, pullback_section_fst]
+  · rw [hsnd, (h.pullback g).id]
+
+/-- Pullback of chosen sections is natural in morphisms of split epimorphisms.
+
+Here `i : X ⟶ Y` lies over `S`, and `h.section_ ≫ i = h'.section_` says that it
+preserves the chosen sections. The induced map of pullbacks then preserves their
+pulled-back sections. -/
+lemma pullback_section_naturality {Y : C} {f' : Y ⟶ S} (h : SplitEpi f)
+    (h' : SplitEpi f') (i : X ⟶ Y) (hi : f = i ≫ f')
+    (hsection : h.section_ ≫ i = h'.section_) {T : C} (g : T ⟶ S)
+    [HasPullback f g] [HasPullback f' g] :
+    (h.pullback g).section_ ≫
+        Limits.pullback.map f g f' g i (𝟙 T) (𝟙 S) (by simp [hi]) (by simp) =
+      (h'.pullback g).section_ := by
+  apply Limits.pullback.hom_ext
+  · rw [Category.assoc, Limits.pullback.lift_fst]
+    rw [← Category.assoc, h.pullback_section_fst, Category.assoc, hsection]
+    exact (h'.pullback_section_fst g).symm
+  · rw [Category.assoc, Limits.pullback.lift_snd]
+    rw [Category.comp_id, (h.pullback g).id, (h'.pullback g).id]
+
+/-- Pullback of a chosen section is natural in the base-change morphism.
+
+For `k : T' ⟶ T`, the canonical map from the pullback along `k ≫ g` to the
+pullback along `g` carries the section over `T'` to the section over `T`
+precomposed with `k`. -/
+lemma pullback_section_map (h : SplitEpi f) {T T' : C} (g : T ⟶ S) (k : T' ⟶ T)
+    [HasPullback f g] [HasPullback f (k ≫ g)] :
+    (h.pullback (k ≫ g)).section_ ≫
+        Limits.pullback.map f (k ≫ g) f g (𝟙 X) k (𝟙 S) (by simp) (by simp) =
+      k ≫ (h.pullback g).section_ := by
+  apply Limits.pullback.hom_ext
+  · rw [Category.assoc, Limits.pullback.lift_fst, Category.comp_id]
+    rw [h.pullback_section_fst (k ≫ g)]
+    rw [Category.assoc k (h.pullback g).section_ (Limits.pullback.fst f g),
+      h.pullback_section_fst]
+    rw [Category.assoc]
+  · rw [Category.assoc, Limits.pullback.lift_snd]
+    rw [← Category.assoc, (h.pullback (k ≫ g)).id, Category.id_comp]
+    rw [Category.assoc, (h.pullback g).id, Category.comp_id]
+
+end SplitEpi
+
+/-- A pullback of a split epimorphism is a split epimorphism.
+
+The low priority leaves more specialized instances, such as the diagonal pullback,
+in control when they apply. Use `SplitEpi.pullback` when the particular chosen
+section matters. -/
+noncomputable instance (priority := 100) Limits.pullback.snd_isSplitEpi
+    {X S T : C} (f : X ⟶ S) (g : T ⟶ S) [HasPullback f g] [IsSplitEpi f] :
+    IsSplitEpi (Limits.pullback.snd f g) :=
+  IsSplitEpi.mk' (IsSplitEpi.exists_splitEpi.some.pullback g)
+
+end CategoryTheory


### PR DESCRIPTION
This PR adds base change of a chosen section: for `s : S ⟶ X` splitting `f : X ⟶ S` and `g : T ⟶ S`, construct the canonical section `T ⟶ X ×[S] T` with projections `g ≫ s` and `𝟙 T`. Package it as `CategoryTheory.SplitEpi.pullback`, prove its characteristic projection and uniqueness API, prove naturality in both pointed morphisms and further base changes, and register a low-priority `IsSplitEpi` instance.

This is a direct prerequisite for `TauCetiRoadmap/JacobianChallenge/README.md`, “The end goal (v1)”, specifically the displayed base-changed rational point `x₀.baseChange K` in `jacobian_baseChange`, together with Layer F’s item “Base-change compatibility along `k → K`”. A rational point of a scheme over `k` is a chosen section of its structure morphism; the newly merged `TauCeti.AlgebraicGeometry.RationalPoint.Basic` explicitly leaves base change of rational points to a subsequent categorical file, which this PR supplies.

Place the result in `TauCeti/CategoryTheory/Limits/Shapes/Pullback/SplitEpi.lean` because the construction is valid in every category with the relevant pullback, while its first consumer is the Jacobian roadmap’s rational-point base change. The file is 130 lines and introduces no roadmap-specific wrapper around the generic fact.

No Mathlib infrastructure is vendored or adapted. The construction consumes Mathlib’s `SplitEpi`, `pullback.lift`, `pullback.map`, and `pullback.hom_ext` APIs directly.

`lake build` completes successfully across 5,895 jobs. `tauceti-axioms --changed-from origin/main` audits 15 declarations in the changed module, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` reports zero violations.

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"base-change-of-rational-points"}-->

🤖 Prepared with Codex
