### PR TITLE
refactor(Exchangeability): make blockLaw index-generic and use it in ExchangeableFamily

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -12,10 +12,14 @@ public import Mathlib.Tactic.Measurability
 /-!
 # Basic exchangeability definitions
 
-This file starts the Layer 0 exchangeability API: indexed block laws of a process,
+This file starts the Layer 0 exchangeability API: indexed block laws of a family,
 prefix laws, path laws, finite exchangeability, full exchangeability, and
 contractability. The definitions are intentionally hypothesis-light; measurability
 hypotheses enter only in lemmas that compose `Measure.map`s.
+
+`blockLaw` and its characteristic lemmas are stated for an arbitrary index type; the remaining
+definitions here are about the order structure of `ℕ` (prefixes, shifts, strictly increasing
+selections) and stay sequence-level.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
@@ -34,11 +38,15 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The finite-dimensional law of a process along a coordinate selection `k`. -/
+/-- The finite-dimensional law of a family along a coordinate selection `k`.
+
+The index type is arbitrary: nothing about a finite selection needs the indices to be natural
+numbers, and `ExchangeableFamily` selects from an arbitrary type. Sequence-level users get the
+`ι = ℕ` case by unification. -/
 @[expose]
-def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+def blockLaw (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     Measure (Fin m → α) :=
   μ.map fun ω i => X (k i) ω
 
@@ -90,7 +98,7 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → blockLaw μ X k = prefixLaw μ X m
 
 @[simp]
-theorem blockLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   rfl
 
@@ -101,7 +109,7 @@ theorem blockLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fi
 coordinate-wise preimage. This is the characteristic evaluation of `blockLaw` as a pushforward;
 `blockLaw_apply_rectangle` is the rectangle specialization. -/
 @[grind =>]
-theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) {S : Set (Fin m → α)} (hS : MeasurableSet S) :
     blockLaw μ X k S = μ ((fun ω i => X (k i) ω) ⁻¹' S) := by
   rw [blockLaw_def, Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ hXk) hS]
@@ -110,7 +118,7 @@ theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {
 measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}` — the rectangle specialization
 of `blockLaw_apply_of_measurable`. -/
 @[grind =>]
-theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
     blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
   rw [blockLaw_apply_of_measurable μ X k hXk (MeasurableSet.univ_pi hB)]
@@ -173,7 +181,7 @@ theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
   rfl
 
 /-- A coordinatewise measurable map sends block laws to block laws. -/
-theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} {m : ℕ} (k : Fin m → ℕ)
+theorem map_blockLaw (μ : Measure Ω) {X : ι → Ω → α} {m : ℕ} (k : Fin m → ι)
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
     (hXk : ∀ i : Fin m, AEMeasurable (X (k i)) μ) :
     (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) =
@@ -208,8 +216,8 @@ theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
 
 /-- Push a block law forward along a coordinate reindexing: selecting the coordinates of
 `blockLaw μ X k` through `g : Fin p → Fin n` yields the block law along `k ∘ g`. -/
-theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : ℕ}
-    (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
+theorem map_blockLaw_reindex (μ : Measure Ω) {X : ι → Ω → α} {n p : ℕ}
+    (k : Fin n → ι) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
     (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
       blockLaw μ X (k ∘ g) := by
   rw [blockLaw_def, blockLaw_def,

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -101,17 +101,6 @@ theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
   (rfl)
 
-/-- Reindexing the family before selecting is the same as composing the selection: the
-characteristic lemma for `blockLaw` under precomposition, so callers need not unfold the
-definition.
-
-Not a `simp` lemma: `simp` already derives this from `blockLaw_def` and `Function.comp_apply`, so
-tagging it would be a redundant rewrite. It exists to be cited explicitly, which is what keeps
-downstream proofs off `blockLaw`'s body. -/
-theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (g : κ → ι) (k : Fin m → κ) :
-    blockLaw μ (fun j => X (g j)) k = blockLaw μ X (g ∘ k) :=
-  (rfl)
-
 -- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes
 -- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form
 -- needs the a.e.-measurability side condition `hXk`, which `simp` cannot discharge.

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -38,7 +38,7 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α β ι : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α β ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
 /-- The finite-dimensional law of a family along a coordinate selection `k`.
 
@@ -100,6 +100,14 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
 @[simp]
 theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
+  rfl
+
+/-- Reindexing the family before selecting is the same as composing the selection: the
+characteristic lemma for `blockLaw` under precomposition, so callers need not unfold the
+definition. -/
+@[simp]
+theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (g : κ → ι) (k : Fin m → κ) :
+    blockLaw μ (fun j => X (g j)) k = blockLaw μ X (g ∘ k) :=
   rfl
 
 -- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -45,7 +45,6 @@ variable {Ω α β ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 The index type is arbitrary: nothing about a finite selection needs the indices to be natural
 numbers, and `ExchangeableFamily` selects from an arbitrary type. Sequence-level users get the
 `ι = ℕ` case by unification. -/
-@[expose]
 def blockLaw (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     Measure (Fin m → α) :=
   μ.map fun ω i => X (k i) ω
@@ -100,7 +99,7 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
 @[simp]
 theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
-  rfl
+  (rfl)
 
 /-- Reindexing the family before selecting is the same as composing the selection: the
 characteristic lemma for `blockLaw` under precomposition, so callers need not unfold the
@@ -108,7 +107,7 @@ definition. -/
 @[simp]
 theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (g : κ → ι) (k : Fin m → κ) :
     blockLaw μ (fun j => X (g j)) k = blockLaw μ X (g ∘ k) :=
-  rfl
+  (rfl)
 
 -- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes
 -- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form

--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -103,8 +103,11 @@ theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin
 
 /-- Reindexing the family before selecting is the same as composing the selection: the
 characteristic lemma for `blockLaw` under precomposition, so callers need not unfold the
-definition. -/
-@[simp]
+definition.
+
+Not a `simp` lemma: `simp` already derives this from `blockLaw_def` and `Function.comp_apply`, so
+tagging it would be a redundant rewrite. It exists to be cited explicitly, which is what keeps
+downstream proofs off `blockLaw`'s body. -/
 theorem blockLaw_comp (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (g : κ → ι) (k : Fin m → κ) :
     blockLaw μ (fun j => X (g j)) k = blockLaw μ X (g ∘ k) :=
   (rfl)

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -120,11 +120,12 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
   intro m k hk
   calc
     blockLaw μ (fun n ω => X (φ n) ω) k =
-        blockLaw μ X (φ ∘ k) := rfl
+        blockLaw μ X (φ ∘ k) := blockLaw_comp μ X φ k
     _ = prefixLaw μ X m := h.map (hφ.comp hk)
-    _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
-      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
-    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+    _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) :=
+      ((h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm).trans
+        (blockLaw_comp μ X φ (fun i : Fin m => i.val)).symm
+    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := (prefixLaw_def _ _ _).symm
 
 /-- **An exchangeable sequence has the prefix law along any injective finite selection:**
 `blockLaw μ X k = prefixLaw μ X n` for injective `k : Fin n → ℕ`. -/

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -120,12 +120,14 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
   intro m k hk
   calc
     blockLaw μ (fun n ω => X (φ n) ω) k =
-        blockLaw μ X (φ ∘ k) := blockLaw_comp μ X φ k
+        blockLaw μ X (φ ∘ k) := by
+      simp only [blockLaw_def, Function.comp_apply]
     _ = prefixLaw μ X m := h.map (hφ.comp hk)
-    _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) :=
-      ((h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm).trans
-        (blockLaw_comp μ X φ (fun i : Fin m => i.val)).symm
-    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := (prefixLaw_def _ _ _).symm
+    _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
+      have := (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
+      simpa only [blockLaw_def, Function.comp_apply] using this
+    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := by
+      simp only [prefixLaw_def]
 
 /-- **An exchangeable sequence has the prefix law along any injective finite selection:**
 `blockLaw μ X k = prefixLaw μ X n` for injective `k : Fin n → ℕ`. -/

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -45,12 +45,12 @@ variable {Ω α ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 selection of indices by another of the same size. -/
 def ExchangeableFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
   ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω
+    blockLaw μ X k = blockLaw μ X l
 
 /-- Constructor for exchangeability of an arbitrary family. -/
 theorem ExchangeableFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
     (h : ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-      μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω) :
+      blockLaw μ X k = blockLaw μ X l) :
     ExchangeableFamily μ X :=
   h
 
@@ -59,7 +59,7 @@ theorem ExchangeableFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
 theorem exchangeableFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
     ExchangeableFamily μ X ↔
       ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-        μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+        blockLaw μ X k = blockLaw μ X l :=
   Iff.rfl
 
 /-- The finite-block law equality defining an exchangeable family. -/
@@ -67,7 +67,7 @@ theorem exchangeableFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
 theorem ExchangeableFamily.blockLaw_eq {μ : Measure Ω} {X : ι → Ω → α}
     (h : ExchangeableFamily μ X) {m : ℕ} (k l : Fin m → ι)
     (hk : Function.Injective k) (hl : Function.Injective l) :
-    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+    blockLaw μ X k = blockLaw μ X l :=
   h m k l hk hl
 
 /-- A conditionally i.i.d. family with a named directing measure is exchangeable. -/
@@ -100,7 +100,7 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  simpa only [Function.comp_apply] using
+  simpa only [blockLaw_def, Function.comp_apply] using
     h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
 
 /-! ## Comparison with the sequence predicates -/
@@ -119,7 +119,6 @@ theorem Exchangeable.exchangeableFamily {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     ExchangeableFamily μ X := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  rw [← blockLaw_def, ← blockLaw_def]
   exact (h.blockLaw_eq_prefixLaw_of_injective hX k hk).trans
     (h.blockLaw_eq_prefixLaw_of_injective hX l hl).symm
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -75,6 +75,7 @@ theorem ConditionallyIIDWith.exchangeableFamily
     {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
     (h : ConditionallyIIDWith μ X ν) : ExchangeableFamily μ X := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
+  rw [blockLaw_def, blockLaw_def]
   calc
     μ.map (fun ω i => X (k i) ω) =
         (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).snd := by
@@ -100,8 +101,9 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  rw [blockLaw_comp, blockLaw_comp]
-  exact h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
+  exact (blockLaw_comp μ X f k).trans
+    ((h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)).trans
+      (blockLaw_comp μ X f l).symm)
 
 /-! ## Comparison with the sequence predicates -/
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -101,9 +101,8 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  exact (blockLaw_comp μ X f k).trans
-    ((h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)).trans
-      (blockLaw_comp μ X f l).symm)
+  simpa only [blockLaw_def, Function.comp_apply] using
+    h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
 
 /-! ## Comparison with the sequence predicates -/
 

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -100,8 +100,8 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  simpa only [blockLaw_def, Function.comp_apply] using
-    h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
+  rw [blockLaw_comp, blockLaw_comp]
+  exact h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
 
 /-! ## Comparison with the sequence predicates -/
 


### PR DESCRIPTION
## The defect

`blockLaw μ X k` is by definition `μ.map fun ω i => X (k i) ω` — the law of a finite selection of
coordinates. Nothing about a finite selection requires the indices to be natural numbers, but the
declaration pinned them:

```lean
def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) : Measure (Fin m → α)
```

That became load-bearing when #1451 added families over an arbitrary index type. `ExchangeableFamily`
could not use `blockLaw`, so it wrote the pushforward out longhand in **four** places — the
definition, `ExchangeableFamily.intro`, `exchangeableFamily_iff`, and a lemma named
`ExchangeableFamily.blockLaw_eq` that could not mention `blockLaw`. All four now read
`blockLaw μ X k = blockLaw μ X l`.

## What changes

Generalize the index type on `blockLaw` and on the five lemmas that are equally index-agnostic:
`blockLaw_def`, `blockLaw_apply_of_measurable`, `blockLaw_apply_rectangle`, `map_blockLaw`, and
`map_blockLaw_reindex`.

**No call site changes.** `ι` unifies with `ℕ`, so the 185 existing uses across 20 files compile
untouched. Two proofs in `Family.lean` get *shorter*, because their goals now arrive already in
`blockLaw` form instead of needing `← blockLaw_def` to get there.

## What deliberately stays sequence-level

`prefixLaw`, `pathLaw`, `shift`, `permReindex`, `ExchangeableAt`, `Exchangeable`, and `Contractable`
are about the **order structure** of `ℕ` — prefixes, shifts, strictly increasing selections — not
merely about being indexed. Generalizing them would be a different (and mostly meaningless) change,
so the module docstring now says which half is which.

## Follow-up, not in this PR

`MixedIIDWith` is defined through `blockLaw`, so it stayed `ℕ`-only while `ConditionallyIIDWith`
became index-generic in #1451. The consequence is that the projection
`mixedIIDWith_of_conditionallyIIDWith` exists only at `ι = ℕ` even though its source predicate is
general. This PR is the prerequisite for fixing that; the fix itself is a separate PR, per the
one-topic rule.

## Verification

Full `lake build` green (5894 jobs).

Refactor of already-landed code, so no roadmap intention — `AGENTS.md` puts this in scope without
one.
