### PR TITLE
feat: add the algebra of matrix coefficients

### DIFF
--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -187,11 +187,13 @@ theorem matrixCoeff_trivial (v w : V) :
 
 /-- A matrix coefficient of an invariant submodule is the matrix coefficient of the ambient
 representation at the underlying vectors, so passing to a subrepresentation creates no new
-matrix coefficients. -/
+matrix coefficients; `continuous_subrepresentation hπ` is the continuity witness of the restricted
+action. -/
 @[simp]
 theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v ∈ W, π g v ∈ W)
-    (hsub : Continuous (subrepresentation π W hW)) (v w : W) :
-    matrixCoeff (subrepresentation π W hW) hsub v w = matrixCoeff π hπ (v : V) (w : V) := by
+    (v w : W) :
+    matrixCoeff (subrepresentation π W hW) (continuous_subrepresentation hπ) v w =
+      matrixCoeff π hπ (v : V) (w : V) := by
   ext g
   simp [Submodule.coe_inner]
 

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -188,6 +188,7 @@ theorem matrixCoeff_trivial (v w : V) :
 /-- A matrix coefficient of an invariant submodule is the matrix coefficient of the ambient
 representation at the underlying vectors, so passing to a subrepresentation creates no new
 matrix coefficients. -/
+@[simp]
 theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v ∈ W, π g v ∈ W)
     (hsub : Continuous (subrepresentation π W hW)) (v w : W) :
     matrixCoeff (subrepresentation π W hW) hsub v w = matrixCoeff π hπ (v : V) (w : V) := by
@@ -196,6 +197,7 @@ theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v 
 
 /-- Restricting a representation along a continuous homomorphism precomposes its matrix
 coefficients; the restricted action is `π ∘ φ`, so `hπ.comp hφ` is its continuity witness. -/
+@[simp]
 theorem matrixCoeff_restrict {H : Type*} [Monoid H] [TopologicalSpace H] (φ : H →* G)
     (hφ : Continuous φ) (v w : V) :
     matrixCoeff (π.restrict φ) (hπ.comp hφ) v w = (matrixCoeff π hπ v w).comp ⟨φ, hφ⟩ := by

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -7,7 +7,6 @@ module
 public import TauCeti.RepresentationTheory.Continuous.Unitary
 public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.Topology.ContinuousMap.Compact
-public import Mathlib.Topology.ContinuousMap.Star
 import Mathlib.Analysis.InnerProductSpace.Continuous
 
 /-!

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -175,12 +175,12 @@ theorem matrixCoeff_apply_mul_eq_sum {ι : Type*} [Fintype ι] (e : OrthonormalB
 /-! ### The trivial representation, and restriction along a homomorphism -/
 
 /-- A matrix coefficient of the trivial representation is the constant function at the inner
-product of its defining vectors; `continuous_const` is the continuity witness to feed in. Which
-constants arise depends on `V`: they are the values of the inner product, so all of `𝕜` when some
-`⟪v, w⟫ ≠ 0`, and only `0` when `V` is trivial. -/
+product of its defining vectors; the trivial action is constant, so `continuous_const` is its
+continuity witness. Which constants arise depends on `V`: they are the values of the inner product,
+so all of `𝕜` when some `⟪v, w⟫ ≠ 0`, and only `0` when `V` is trivial. -/
 @[simp]
-theorem matrixCoeff_trivial (htriv : Continuous (ContRepresentation.trivial 𝕜 G V)) (v w : V) :
-    matrixCoeff (ContRepresentation.trivial 𝕜 G V) htriv v w =
+theorem matrixCoeff_trivial (v w : V) :
+    matrixCoeff (ContRepresentation.trivial 𝕜 G V) continuous_const v w =
       ContinuousMap.const G ⟪v, w⟫_𝕜 := by
   ext g
   simp
@@ -195,10 +195,10 @@ theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v 
   simp [Submodule.coe_inner]
 
 /-- Restricting a representation along a continuous homomorphism precomposes its matrix
-coefficients. -/
+coefficients; the restricted action is `π ∘ φ`, so `hπ.comp hφ` is its continuity witness. -/
 theorem matrixCoeff_restrict {H : Type*} [Monoid H] [TopologicalSpace H] (φ : H →* G)
-    (hφ : Continuous φ) (hres : Continuous (π.restrict φ)) (v w : V) :
-    matrixCoeff (π.restrict φ) hres v w = (matrixCoeff π hπ v w).comp ⟨φ, hφ⟩ := by
+    (hφ : Continuous φ) (v w : V) :
+    matrixCoeff (π.restrict φ) (hπ.comp hφ) v w = (matrixCoeff π hπ v w).comp ⟨φ, hφ⟩ := by
   ext h
   simp
 

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -42,15 +42,17 @@ matrix coefficients built from different continuity proofs are equal by proof ir
 * `TauCeti.ContRepresentation.star_matrixCoeff`: the conjugate of a matrix coefficient of a
   unitary representation is a matrix coefficient composed with inversion.
 * `TauCeti.ContRepresentation.matrixCoeff_trivial`: the matrix coefficients of the trivial
-  representation are the constants.
+  representation are constant.
 * `TauCeti.ContRepresentation.norm_matrixCoeff_le`: the uniform bound `‖v‖ * ‖w‖` for a unitary
   representation.
 
 The algebra of matrix coefficients is the Layer 3 milestone of the
 [compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap); it is what makes the
-span of the matrix coefficients a translation-stable, conjugation-stable subspace of `C(G)`, and it
-feeds the Schur orthogonality relations of Layer 4. The mathematical development follows
-Daniel Bump, *Lie Groups*, second edition, Chapters 2–4.
+span of the matrix coefficients of a fixed representation a translation-stable subspace of `C(G)`,
+stable under conjugation followed by inversion of the argument, and it feeds the Schur
+orthogonality relations of Layer 4. Conjugation alone leaves that span in general: it produces a
+matrix coefficient of the contragredient representation, which is not built here. The mathematical
+development follows Daniel Bump, *Lie Groups*, second edition, Chapters 2–4.
 -/
 
 public section
@@ -178,8 +180,9 @@ theorem continuous_trivial :
     Continuous (ContRepresentation.trivial 𝕜 G V) :=
   continuous_const
 
-/-- The matrix coefficients of the trivial representation are the constant functions. With
-sesquilinearity this puts every constant in the span of the matrix coefficients. -/
+/-- A matrix coefficient of the trivial representation is the constant function at the inner
+product of its defining vectors. Which constants arise depends on `V`: they are the values of the
+inner product, so all of `𝕜` when some `⟪v, w⟫ ≠ 0`, and only `0` when `V` is trivial. -/
 @[simp]
 theorem matrixCoeff_trivial (htriv : Continuous (ContRepresentation.trivial 𝕜 G V)) (v w : V) :
     matrixCoeff (ContRepresentation.trivial 𝕜 G V) htriv v w =

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -5,23 +5,52 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RepresentationTheory.Continuous.Unitary
+public import Mathlib.Analysis.InnerProductSpace.PiL2
 public import Mathlib.Topology.ContinuousMap.Compact
+public import Mathlib.Topology.ContinuousMap.Star
 import Mathlib.Analysis.InnerProductSpace.Continuous
 
 /-!
 # Matrix coefficients of continuous representations
 
 This file defines the matrix coefficient
-`g ↦ ⟪π g v, w⟫` of a representation whose operator-valued action is continuous, and proves the
-uniform bound for unitary representations.
+`g ↦ ⟪π g v, w⟫` of a representation whose operator-valued action is continuous, and develops its
+algebra: sesquilinearity in the defining vectors, the matrix-multiplication identity at a product
+of group elements, the behaviour under left and right translation of the group argument, the
+involution coming from inversion, and the uniform bound for unitary representations.
 
 Mathlib's `ContRepresentation` bundles continuous linear action operators but does not require
 continuity of the map from the acting topological monoid to those operators. The continuity
-hypothesis is therefore explicit in `matrixCoeff` and its API.
+hypothesis is therefore explicit in `matrixCoeff` and its API; since it is a `Prop` argument, two
+matrix coefficients built from different continuity proofs are equal by proof irrelevance.
 
-The uniform bound is part of the Layer 1 unitarity-predicate milestone in the
-[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap). The mathematical
-development follows Daniel Bump, *Lie Groups*, second edition, Chapters 2–4.
+## Main definitions
+
+* `TauCeti.ContRepresentation.matrixCoeff`: the matrix coefficient `g ↦ ⟪π g v, w⟫` as an element
+  of `C(G, 𝕜)`.
+* `TauCeti.ContRepresentation.matrixCoeffₛₗ`: the matrix coefficients of a fixed representation
+  bundled as a sesquilinear map `V →ₗ⋆[𝕜] V →ₗ[𝕜] C(G, 𝕜)`, in Mathlib's `innerₛₗ` convention.
+
+## Main statements
+
+* `TauCeti.ContRepresentation.matrixCoeff_apply_mul_eq_sum`: in an orthonormal basis, matrix
+  coefficients multiply like matrices, `π_{ik}(g * h) = ∑ j, π_{ij}(g) · π_{jk}(h)`.
+* `TauCeti.ContRepresentation.matrixCoeff_comp_mulRight` and
+  `TauCeti.ContRepresentation.matrixCoeff_comp_mulLeft`: right and left translates of a matrix
+  coefficient of `π` are again matrix coefficients of `π`. This is the `G × G`-action that
+  structures the span of the matrix coefficients.
+* `TauCeti.ContRepresentation.star_matrixCoeff`: the conjugate of a matrix coefficient of a
+  unitary representation is a matrix coefficient composed with inversion.
+* `TauCeti.ContRepresentation.matrixCoeff_trivial`: the matrix coefficients of the trivial
+  representation are the constants.
+* `TauCeti.ContRepresentation.norm_matrixCoeff_le`: the uniform bound `‖v‖ * ‖w‖` for a unitary
+  representation.
+
+The algebra of matrix coefficients is the Layer 3 milestone of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap); it is what makes the
+span of the matrix coefficients a translation-stable, conjugation-stable subspace of `C(G)`, and it
+feeds the Schur orthogonality relations of Layer 4. The mathematical development follows
+Daniel Bump, *Lie Groups*, second edition, Chapters 2–4.
 -/
 
 public section
@@ -57,7 +86,179 @@ theorem matrixCoeff_apply_one (π : ContRepresentation 𝕜 G V) (hπ : Continuo
     matrixCoeff π hπ v w 1 = ⟪v, w⟫_𝕜 := by
   simp
 
+variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+
+/-! ### Sesquilinearity in the defining vectors
+
+Following Mathlib's inner-product convention, a matrix coefficient is conjugate-linear in its first
+vector and linear in its second. -/
+
+@[simp]
+theorem matrixCoeff_zero_left (w : V) : matrixCoeff π hπ 0 w = 0 := by
+  ext g
+  simp
+
+@[simp]
+theorem matrixCoeff_zero_right (v : V) : matrixCoeff π hπ v 0 = 0 := by
+  ext g
+  simp
+
+@[simp]
+theorem matrixCoeff_add_left (v₁ v₂ w : V) :
+    matrixCoeff π hπ (v₁ + v₂) w = matrixCoeff π hπ v₁ w + matrixCoeff π hπ v₂ w := by
+  ext g
+  simp [inner_add_left]
+
+@[simp]
+theorem matrixCoeff_add_right (v w₁ w₂ : V) :
+    matrixCoeff π hπ v (w₁ + w₂) = matrixCoeff π hπ v w₁ + matrixCoeff π hπ v w₂ := by
+  ext g
+  simp [inner_add_right]
+
+@[simp]
+theorem matrixCoeff_smul_left (c : 𝕜) (v w : V) :
+    matrixCoeff π hπ (c • v) w = (starRingEnd 𝕜) c • matrixCoeff π hπ v w := by
+  ext g
+  simp [inner_smul_left]
+
+@[simp]
+theorem matrixCoeff_smul_right (v : V) (c : 𝕜) (w : V) :
+    matrixCoeff π hπ v (c • w) = c • matrixCoeff π hπ v w := by
+  ext g
+  simp [inner_smul_right]
+
+/-- The matrix coefficients of a fixed representation, bundled as a sesquilinear map: conjugate
+linear in the first vector, linear in the second, exactly as Mathlib's `innerₛₗ`.
+
+Bundling records the sesquilinearity in the form the span of the matrix coefficients is built from,
+and supplies the remaining additive identities (`map_neg`, `map_sub`, `map_sum`) through the
+`LinearMap` API. -/
+noncomputable def matrixCoeffₛₗ : V →ₗ⋆[𝕜] V →ₗ[𝕜] C(G, 𝕜) where
+  toFun v :=
+    { toFun := matrixCoeff π hπ v
+      map_add' := matrixCoeff_add_right π hπ v
+      map_smul' := matrixCoeff_smul_right π hπ v }
+  map_add' v₁ v₂ := LinearMap.ext fun w ↦ matrixCoeff_add_left π hπ v₁ v₂ w
+  map_smul' c v := LinearMap.ext fun w ↦ matrixCoeff_smul_left π hπ c v w
+
+@[simp]
+theorem matrixCoeffₛₗ_apply_apply (v w : V) :
+    matrixCoeffₛₗ π hπ v w = matrixCoeff π hπ v w :=
+  (rfl)
+
+/-! ### Translating the group argument -/
+
+/-- Translating the argument of a matrix coefficient on the right moves the action onto the first
+vector. The pointwise statement needs no continuity of the multiplication of `G`. -/
+theorem matrixCoeff_apply_mul_right (v w : V) (g g₀ : G) :
+    matrixCoeff π hπ v w (g * g₀) = matrixCoeff π hπ (π g₀ v) w g := by
+  simp [map_mul]
+
+/-- Matrix coefficients multiply like matrices: expanding the intermediate vector `π h v` in an
+orthonormal basis writes the coefficient at a product as a sum of products of coefficients. In the
+basis notation `π_{ij}(g) = ⟪π g eⱼ, eᵢ⟫` this is `π_{ik}(g * h) = ∑ j, π_{ij}(g) · π_{jk}(h)`. -/
+theorem matrixCoeff_apply_mul_eq_sum {ι : Type*} [Fintype ι] (e : OrthonormalBasis ι 𝕜 V)
+    (v w : V) (g h : G) :
+    matrixCoeff π hπ v w (g * h) =
+      ∑ i, matrixCoeff π hπ (e i) w g * matrixCoeff π hπ v (e i) h := by
+  have hmul : π (g * h) v = π g (π h v) := by simp [map_mul]
+  calc
+    matrixCoeff π hπ v w (g * h) = ⟪π g (∑ i, ⟪e i, π h v⟫_𝕜 • e i), w⟫_𝕜 := by
+      rw [matrixCoeff_apply, hmul, e.sum_repr']
+    _ = ∑ i, (starRingEnd 𝕜) ⟪e i, π h v⟫_𝕜 * ⟪π g (e i), w⟫_𝕜 := by
+      simp [map_sum, sum_inner, inner_smul_left]
+    _ = ∑ i, matrixCoeff π hπ (e i) w g * matrixCoeff π hπ v (e i) h := by
+      simp [inner_conj_symm, mul_comm]
+
+/-! ### The trivial representation, and restriction along a homomorphism -/
+
+/-- The action map of the trivial representation is constant, hence continuous. This is the
+continuity witness to feed to `matrixCoeff` for the trivial representation. -/
+theorem continuous_trivial :
+    Continuous (ContRepresentation.trivial 𝕜 G V) :=
+  continuous_const
+
+/-- The matrix coefficients of the trivial representation are the constant functions. With
+sesquilinearity this puts every constant in the span of the matrix coefficients. -/
+@[simp]
+theorem matrixCoeff_trivial (htriv : Continuous (ContRepresentation.trivial 𝕜 G V)) (v w : V) :
+    matrixCoeff (ContRepresentation.trivial 𝕜 G V) htriv v w =
+      ContinuousMap.const G ⟪v, w⟫_𝕜 := by
+  ext g
+  simp
+
+/-- A matrix coefficient of an invariant submodule is the matrix coefficient of the ambient
+representation at the underlying vectors, so passing to a subrepresentation creates no new
+matrix coefficients. -/
+theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v ∈ W, π g v ∈ W)
+    (hsub : Continuous (subrepresentation π W hW)) (v w : W) :
+    matrixCoeff (subrepresentation π W hW) hsub v w = matrixCoeff π hπ (v : V) (w : V) := by
+  ext g
+  simp [Submodule.coe_inner]
+
+/-- Restricting a representation along a continuous homomorphism precomposes its matrix
+coefficients. -/
+theorem matrixCoeff_restrict {H : Type*} [Monoid H] [TopologicalSpace H] (φ : H →* G)
+    (hφ : Continuous φ) (hres : Continuous (π.restrict φ)) (v w : V) :
+    matrixCoeff (π.restrict φ) hres v w = (matrixCoeff π hπ v w).comp ⟨φ, hφ⟩ := by
+  ext h
+  simp
+
 end Coefficients
+
+section TranslationRight
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Monoid G] [TopologicalSpace G] [SeparatelyContinuousMul G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+
+/-- The right translate of a matrix coefficient of `π` is again a matrix coefficient of `π`: the
+translation is absorbed into the first vector. -/
+theorem matrixCoeff_comp_mulRight (v w : V) (g₀ : G) :
+    (matrixCoeff π hπ v w).comp (ContinuousMap.mulRight g₀) = matrixCoeff π hπ (π g₀ v) w :=
+  ContinuousMap.ext fun g ↦ matrixCoeff_apply_mul_right π hπ v w g g₀
+
+end TranslationRight
+
+section Group
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+variable {π : ContRepresentation 𝕜 G V}
+
+/-- Translating the argument of a matrix coefficient of a unitary representation on the left moves
+the action of the inverse onto the second vector. -/
+theorem matrixCoeff_apply_mul_left (hπ : Continuous π) (hunitary : IsUnitary π) (v w : V)
+    (g₀ g : G) :
+    matrixCoeff π hπ v w (g₀ * g) = matrixCoeff π hπ v (π g₀⁻¹ w) g := by
+  have hmul : π (g₀ * g) v = π g₀ (π g v) := by simp [map_mul]
+  rw [matrixCoeff_apply, matrixCoeff_apply, hmul, hunitary.inner_map_left]
+
+/-- Evaluating a matrix coefficient of a unitary representation at an inverse conjugates it and
+swaps its defining vectors. This is the involution that the span of the matrix coefficients carries;
+see `star_matrixCoeff` for the packaged form. -/
+theorem matrixCoeff_apply_inv (hπ : Continuous π) (hunitary : IsUnitary π) (v w : V) (g : G) :
+    matrixCoeff π hπ v w g⁻¹ = (starRingEnd 𝕜) (matrixCoeff π hπ w v g) := by
+  rw [matrixCoeff_apply, matrixCoeff_apply, hunitary.inner_map_left, inv_inv, inner_conj_symm]
+
+/-- The left translate of a matrix coefficient of a unitary representation is again a matrix
+coefficient: the translation is absorbed into the second vector. -/
+theorem matrixCoeff_comp_mulLeft [SeparatelyContinuousMul G] (hπ : Continuous π)
+    (hunitary : IsUnitary π) (v w : V) (g₀ : G) :
+    (matrixCoeff π hπ v w).comp (ContinuousMap.mulLeft g₀) = matrixCoeff π hπ v (π g₀⁻¹ w) :=
+  ContinuousMap.ext fun g ↦ matrixCoeff_apply_mul_left hπ hunitary v w g₀ g
+
+/-- The conjugate of a matrix coefficient of a unitary representation is the matrix coefficient
+with its vectors swapped, precomposed with inversion. So the span of the matrix coefficients of a
+unitary representation is stable under the star operation of `C(G, 𝕜)` followed by inversion of the
+argument. -/
+theorem star_matrixCoeff [ContinuousInv G] (hπ : Continuous π) (hunitary : IsUnitary π)
+    (v w : V) :
+    star (matrixCoeff π hπ v w) =
+      (matrixCoeff π hπ w v).comp ⟨Inv.inv, continuous_inv⟩ :=
+  ContinuousMap.ext fun g ↦ (matrixCoeff_apply_inv hπ hunitary w v g).symm
+
+end Group
 
 section CompactDomain
 

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -174,15 +174,10 @@ theorem matrixCoeff_apply_mul_eq_sum {ι : Type*} [Fintype ι] (e : OrthonormalB
 
 /-! ### The trivial representation, and restriction along a homomorphism -/
 
-/-- The action map of the trivial representation is constant, hence continuous. This is the
-continuity witness to feed to `matrixCoeff` for the trivial representation. -/
-theorem continuous_trivial :
-    Continuous (ContRepresentation.trivial 𝕜 G V) :=
-  continuous_const
-
 /-- A matrix coefficient of the trivial representation is the constant function at the inner
-product of its defining vectors. Which constants arise depends on `V`: they are the values of the
-inner product, so all of `𝕜` when some `⟪v, w⟫ ≠ 0`, and only `0` when `V` is trivial. -/
+product of its defining vectors; `continuous_const` is the continuity witness to feed in. Which
+constants arise depends on `V`: they are the values of the inner product, so all of `𝕜` when some
+`⟪v, w⟫ ≠ 0`, and only `0` when `V` is trivial. -/
 @[simp]
 theorem matrixCoeff_trivial (htriv : Continuous (ContRepresentation.trivial 𝕜 G V)) (v w : V) :
     matrixCoeff (ContRepresentation.trivial 𝕜 G V) htriv v w =

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -214,6 +214,7 @@ variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
 
 /-- The right translate of a matrix coefficient of `π` is again a matrix coefficient of `π`: the
 translation is absorbed into the first vector. -/
+@[simp]
 theorem matrixCoeff_comp_mulRight (v w : V) (g₀ : G) :
     (matrixCoeff π hπ v w).comp (ContinuousMap.mulRight g₀) = matrixCoeff π hπ (π g₀ v) w :=
   ContinuousMap.ext fun g ↦ matrixCoeff_apply_mul_right π hπ v w g g₀
@@ -243,6 +244,7 @@ theorem matrixCoeff_apply_inv (hπ : Continuous π) (hunitary : IsUnitary π) (v
 
 /-- The left translate of a matrix coefficient of a unitary representation is again a matrix
 coefficient: the translation is absorbed into the second vector. -/
+@[simp]
 theorem matrixCoeff_comp_mulLeft [SeparatelyContinuousMul G] (hπ : Continuous π)
     (hunitary : IsUnitary π) (v w : V) (g₀ : G) :
     (matrixCoeff π hπ v w).comp (ContinuousMap.mulLeft g₀) = matrixCoeff π hπ v (π g₀⁻¹ w) :=
@@ -252,6 +254,7 @@ theorem matrixCoeff_comp_mulLeft [SeparatelyContinuousMul G] (hπ : Continuous �
 with its vectors swapped, precomposed with inversion. So the span of the matrix coefficients of a
 unitary representation is stable under the star operation of `C(G, 𝕜)` followed by inversion of the
 argument. -/
+@[simp]
 theorem star_matrixCoeff [ContinuousInv G] (hπ : Continuous π) (hunitary : IsUnitary π)
     (v w : V) :
     star (matrixCoeff π hπ v w) =

--- a/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RepresentationTheory.Continuous.Basic
+public import Mathlib.Topology.Algebra.Module.Spaces.ContinuousLinearMap
 
 /-!
 # Restricting a continuous representation to an invariant submodule
@@ -21,6 +22,8 @@ action operator, the continuous counterpart of Mathlib's `Representation.subrepr
 
 * `TauCeti.ContRepresentation.toRepresentation_subrepresentation`: the underlying representation of
   a restricted continuous representation is the restriction of the underlying representation.
+* `TauCeti.ContRepresentation.continuous_subrepresentation`: the restriction of a continuous
+  representation to an invariant submodule is again continuous.
 -/
 
 public section
@@ -28,6 +31,8 @@ public section
 namespace TauCeti
 
 namespace ContRepresentation
+
+section Restriction
 
 variable {R G V : Type*} [Ring R] [Monoid G] [AddCommGroup V] [TopologicalSpace V]
   [IsTopologicalAddGroup V] [Module R V]
@@ -57,6 +62,25 @@ theorem toRepresentation_subrepresentation :
       = π.toRepresentation.subrepresentation W fun g _ hv => hW g _ hv := by
   ext g v
   simp [_root_.ContRepresentation.toMonoidHom_apply]
+
+end Restriction
+
+section Continuity
+
+variable {𝕜 G V : Type*} [NormedField 𝕜] [Monoid G] [TopologicalSpace G] [AddCommGroup V]
+  [TopologicalSpace V] [IsTopologicalAddGroup V] [Module 𝕜 V] [ContinuousConstSMul 𝕜 V]
+  {π : ContRepresentation 𝕜 G V} {W : Submodule 𝕜 V} {hW : ∀ g, ∀ v ∈ W, π g v ∈ W}
+
+/-- Restricting a continuous representation to an invariant submodule preserves continuity. The
+inclusion of `W` is inducing, so this reduces to the continuity of `g ↦ π g ∘L W.subtypeL`, which
+is precomposition by a fixed continuous linear map applied to `π`. -/
+theorem continuous_subrepresentation (hπ : Continuous π) :
+    Continuous (subrepresentation π W hW) := by
+  rw [(ContinuousLinearMap.isInducing_postcomp W.subtypeL
+    Topology.IsInducing.subtypeVal).continuous_iff]
+  exact (ContinuousLinearMap.precomp V W.subtypeL).continuous.comp hπ
+
+end Continuity
 
 end ContRepresentation
 

--- a/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
@@ -71,9 +71,11 @@ variable {𝕜 G V : Type*} [NormedField 𝕜] [Monoid G] [TopologicalSpace G] [
   [TopologicalSpace V] [IsTopologicalAddGroup V] [Module 𝕜 V] [ContinuousConstSMul 𝕜 V]
   {π : ContRepresentation 𝕜 G V} {W : Submodule 𝕜 V} {hW : ∀ g, ∀ v ∈ W, π g v ∈ W}
 
-/-- Restricting a continuous representation to an invariant submodule preserves continuity. The
-inclusion of `W` is inducing, so this reduces to the continuity of `g ↦ π g ∘L W.subtypeL`, which
-is precomposition by a fixed continuous linear map applied to `π`. -/
+/-- Restricting a continuous representation to an invariant submodule preserves continuity: from
+continuity of `g ↦ π g` as a map into the continuous linear endomorphisms of `V`, the restricted
+action `g ↦ subrepresentation π W hW g` is continuous into those of `W`. This supplies the
+continuity argument that `matrixCoeff` and the rest of the continuous-representation API take
+explicitly, so a subrepresentation can be used wherever a continuous representation is expected. -/
 theorem continuous_subrepresentation (hπ : Continuous π) :
     Continuous (subrepresentation π W hW) := by
   rw [(ContinuousLinearMap.isInducing_postcomp W.subtypeL


### PR DESCRIPTION
This PR develops the algebra of matrix coefficients of a continuous representation, the second bullet of Layer 3 ("matrix coefficients") in `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`: "Sesquilinearity in `(v, w)`; behaviour under left and right translation ...; the involution `conj (matrixCoeff π v w) = matrixCoeff π̄ w v` under the contragredient/unitarity". It builds directly on the existing `TauCeti.ContRepresentation.matrixCoeff` and its uniform bound, and supplies the identities that Layer 4's Schur orthogonality computation runs on.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"algebra-of-matrix-coefficients"}-->

Everything lands in the existing module `TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean`, where `matrixCoeff` already lives. The new content is: sesquilinearity in the defining vectors — conjugate-linear in the first, linear in the second, matching Mathlib's inner-product convention — with the pointwise lemmas bundled into `matrixCoeffₛₗ : V →ₗ⋆[𝕜] V →ₗ[𝕜] C(G, 𝕜)`, mirroring `innerₛₗ`, so the remaining additive identities come from the `LinearMap` API; the matrix-multiplication identity `matrixCoeff_apply_mul_eq_sum`, which expands the intermediate vector `π h v` in an orthonormal basis to give `π_{ik}(g * h) = ∑ j, π_{ij}(g) · π_{jk}(h)`; the right-translation formula `matrixCoeff_apply_mul_right` and its packaged form `matrixCoeff_comp_mulRight`, absorbing the translation into the first vector with no unitarity needed; the left-translation formulas `matrixCoeff_apply_mul_left` and `matrixCoeff_comp_mulLeft` for a unitary representation on a group, absorbing the translation into the second vector; the involution `matrixCoeff_apply_inv` and its packaged form `star_matrixCoeff`, saying that conjugating a matrix coefficient of a unitary representation swaps its vectors and inverts the argument; and the identification of the matrix coefficients of the trivial representation with the constants (`continuous_trivial`, `matrixCoeff_trivial`), of a subrepresentation with those of the ambient representation (`matrixCoeff_subrepresentation`, reusing `TauCeti.ContRepresentation.subrepresentation`), and of a restriction along a continuous homomorphism with a precomposition (`matrixCoeff_restrict`, reusing Mathlib's `ContRepresentation.restrict`). Together these are what make the span of the matrix coefficients a translation-stable, conjugation-stable subspace of `C(G)` — the structure the representative subalgebra and the `G × G`-action on `L²(G)` are built from.

Hypotheses are kept as weak as each statement allows: the pointwise translation identity needs no continuity of multiplication at all, the packaged translates need only `SeparatelyContinuousMul G`, and the involution needs only `ContinuousInv G`, rather than a blanket topological-group assumption. Unitarity is used exactly where it is needed, through the existing `TauCeti.ContRepresentation.IsUnitary.inner_map_left`. The products-of-matrix-coefficients half of the roadmap bullet (matrix coefficients of `π ⊗ ρ`) is not included: it needs an inner product on the tensor product of representation spaces, which is a separate prerequisite.

No Mathlib infrastructure was vendored; the proofs consume `OrthonormalBasis.sum_repr'`, `Submodule.coe_inner`, `ContinuousMap.mulLeft`/`mulRight`, and the `StarRing C(α, β)` instance from the pinned Mathlib. The mathematical development follows Daniel Bump, *Lie Groups*, second edition, Chapters 2–4.

`lake build`, `lake exe axioms`, `lake exe module-system`, and `scripts/lint-env.sh` are all green locally.

🤖 Prepared with Claude Code
