### PR TITLE
feat: add the Coxeter matrix of a base

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -52,8 +52,8 @@ roots, and there the two simple reflections commute
   roots lies in `{0, 1, 2, 3}`, so `TauCeti.coxeterOrder` reads a genuine Coxeter order off it.
 * `TauCeti.coxeterMatrixOfBase_eq_two_iff`: an entry is `2` exactly for orthogonal simple roots.
   In particular the diagonal entries are not `2`, since no root is orthogonal to itself.
-* `TauCeti.forall_coxeterMatrixOfBase_le_three_iff`: all entries are at most `3` exactly when the
-  Cartan matrix is simply laced.
+* `TauCeti.isSimplyLaced_iff_forall_coxeterMatrixOfBase_le_three`: the Cartan matrix is simply laced
+  exactly when all entries are at most `3`.
 * `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`:
   where the matrix entry is `2`, the product of the two simple reflections does have order `2`.
 
@@ -270,22 +270,23 @@ theorem coxeterMatrixOfBase_eq_two_iff (i j : b.support) :
       coxeterOrder_eq_two_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij),
       cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal]
 
-/-- **The Coxeter matrix of a base has all entries at most `3` exactly when its Cartan matrix is
-simply laced**, that is, exactly when no two simple roots are joined by a multiple edge. -/
-theorem forall_coxeterMatrixOfBase_le_three_iff :
-    (∀ i j, coxeterMatrixOfBase P b i j ≤ 3) ↔ b.cartanMatrix.IsSimplyLaced := by
+/-- **The Cartan matrix of a base is simply laced exactly when the Coxeter matrix of that base has
+all entries at most `3`**, that is, exactly when no two simple roots are joined by a multiple
+edge. -/
+theorem isSimplyLaced_iff_forall_coxeterMatrixOfBase_le_three :
+    b.cartanMatrix.IsSimplyLaced ↔ ∀ i j, coxeterMatrixOfBase P b i j ≤ 3 := by
   constructor
-  · intro h i j hij
-    rcases (coxeterOrder_le_three_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)).mp
-      (by simpa using h i j) with h₀ | h₁
-    · exact Or.inl ((cartanMatrix_mul_cartanMatrix_eq_zero_iff P b i j).mp h₀)
-    · exact Or.inr ((cartanMatrix_mul_cartanMatrix_eq_one_iff P b hij).mp h₁).1
   · intro h i j
     rcases eq_or_ne i j with rfl | hij
     · simp
     · rw [coxeterMatrixOfBase_apply,
         coxeterOrder_le_three_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)]
       rcases h hij with h₁ | h₁ <;> rcases h hij.symm with h₂ | h₂ <;> rw [h₁, h₂] <;> norm_num
+  · intro h i j hij
+    rcases (coxeterOrder_le_three_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)).mp
+      (by simpa using h i j) with h₀ | h₁
+    · exact Or.inl ((cartanMatrix_mul_cartanMatrix_eq_zero_iff P b i j).mp h₀)
+    · exact Or.inr ((cartanMatrix_mul_cartanMatrix_eq_one_iff P b hij).mp h₁).1
 
 end CoxeterMatrixOfBase
 

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -1,0 +1,334 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.GroupTheory.Coxeter.Matrix
+public import Mathlib.LinearAlgebra.Matrix.Cartan
+public import Mathlib.LinearAlgebra.RootSystem.CartanMatrix
+public import Mathlib.LinearAlgebra.RootSystem.Finite.Lemmas
+public import TauCeti.LinearAlgebra.RootSystem.WeylGroup
+
+public section
+
+/-!
+# The Coxeter matrix of a base
+
+A base of a finite crystallographic root pairing has a Cartan matrix, and the Cartan matrix
+determines a Coxeter matrix: the entry attached to a pair of distinct simple roots is read off
+their Cartan product `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩` by `0 ↦ 2`, `1 ↦ 3`, `2 ↦ 4`, `3 ↦ 6`. This file
+proves that the Cartan product of two distinct simple roots really does lie in `{0, 1, 2, 3}`, and
+packages the resulting assignment as a genuine `CoxeterMatrix` indexed by the simple roots.
+
+The numerical content is the exclusion of the value `4`. Mathlib bounds the Coxeter weight of a
+finite crystallographic pairing by `4` and pins it to `{0, 1, 2, 3, 4}`
+(`RootPairing.coxeterWeightIn_mem_set_of_isCrystallographic`), and the value `4` is attained
+exactly by linearly dependent pairs of roots
+(`RootPairing.linearIndependent_iff_coxeterWeightIn_ne_four`); distinct simple roots are
+independent, so `4` is unavailable to them.
+
+The translation `TauCeti.coxeterOrder` is defined on all of `ℤ` and takes the Cartan product `4` to
+`1`, which is the mathematically correct value rather than a junk one: product `4` means the two
+roots are proportional, so the two reflections coincide and their product is the identity. That
+choice is what makes the diagonal of the matrix come out as `1` without a case split, since a
+simple root has Cartan product `4` with itself. Products outside `{0, 1, 2, 3, 4}` do not occur
+here and are sent to `0`, Mathlib's encoding of an infinite Coxeter order.
+
+The final section checks the smallest of the intended braid relations, the one available before the
+Coxeter presentation of the Weyl group is built: the entry of two distinct simple roots is `2`
+exactly when they are orthogonal, and there the two simple reflections commute and their product
+has order exactly `2`, as the entry asserts.
+
+## Main definitions
+
+* `TauCeti.coxeterOrder` translates a Cartan product into the order of the product of the two
+  reflections.
+* `TauCeti.coxeterMatrixOfBase` is the Coxeter matrix of a base, indexed by its simple roots.
+
+## Main results
+
+* `TauCeti.cartanMatrix_mul_cartanMatrix_mem_of_ne`: the Cartan product of two distinct simple
+  roots lies in `{0, 1, 2, 3}`, so `TauCeti.coxeterOrder` reads a genuine Coxeter order off it.
+* `TauCeti.coxeterMatrixOfBase_eq_two_iff`: an entry is `2` exactly for orthogonal simple roots.
+* `TauCeti.forall_coxeterMatrixOfBase_le_three_iff`: all entries are at most `3` exactly when the
+  Cartan matrix is simply laced.
+* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`: where the matrix entry is `2`,
+  the product of the two simple reflections does have order `2`.
+
+## References
+
+This file implements “The Coxeter matrix of a base” in Layer 2 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, following the target signature
+`coxeterMatrixOfBase` in that roadmap's `Suggested.lean`. The classification of rank-two
+crystallographic configurations behind it is Bourbaki, *Lie Groups and Lie Algebras*, Chapters
+4--6, Ch. VI, §1.3.
+-/
+
+namespace TauCeti
+
+open Set
+
+universe u v w x
+
+/-! ## Reading a Coxeter order off a Cartan product -/
+
+/-- The order of the product of the reflections in two roots of Cartan product `c`.
+
+For a finite crystallographic pairing the only products that occur are `0`, `1`, `2`, `3` and `4`.
+The first four are the rank-two configurations `A₁ × A₁`, `A₂`, `B₂` and `G₂`, whose products of
+reflections are rotations of order `2`, `3`, `4` and `6`. Product `4` means the two roots are
+proportional, so the two reflections agree and their product is the identity, of order `1`; this is
+in particular the value taken by a root against itself. Every other integer is sent to `0`,
+Mathlib's encoding of an infinite order. -/
+def coxeterOrder (c : ℤ) : ℕ :=
+  if c = 0 then 2 else if c = 1 then 3 else if c = 2 then 4 else if c = 3 then 6 else
+    if c = 4 then 1 else 0
+
+@[simp] lemma coxeterOrder_zero : coxeterOrder 0 = 2 := by norm_num [coxeterOrder]
+
+@[simp] lemma coxeterOrder_one : coxeterOrder 1 = 3 := by norm_num [coxeterOrder]
+
+@[simp] lemma coxeterOrder_two : coxeterOrder 2 = 4 := by norm_num [coxeterOrder]
+
+@[simp] lemma coxeterOrder_three : coxeterOrder 3 = 6 := by norm_num [coxeterOrder]
+
+@[simp] lemma coxeterOrder_four : coxeterOrder 4 = 1 := by norm_num [coxeterOrder]
+
+/-- On the products that occur for a pair of independent roots, `coxeterOrder` takes the four
+dihedral values. -/
+lemma coxeterOrder_mem {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) :
+    coxeterOrder c ∈ ({2, 3, 4, 6} : Set ℕ) := by
+  simp only [mem_insert_iff, mem_singleton_iff] at hc ⊢
+  rcases hc with rfl | rfl | rfl | rfl <;> simp
+
+/-- The dihedral values are all at least `2`; in particular none of them is `1`, which is what a
+`CoxeterMatrix` demands off the diagonal. -/
+lemma two_le_coxeterOrder {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) : 2 ≤ coxeterOrder c := by
+  have := coxeterOrder_mem hc
+  simp only [mem_insert_iff, mem_singleton_iff] at this
+  omega
+
+/-- The dihedral values are all at most `6`; in particular none of them is `0`, so no entry of the
+Coxeter matrix of a base is infinite. -/
+lemma coxeterOrder_le_six {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) : coxeterOrder c ≤ 6 := by
+  have := coxeterOrder_mem hc
+  simp only [mem_insert_iff, mem_singleton_iff] at this
+  omega
+
+/-- The single-edge products are exactly those of Coxeter order at most `3`. -/
+lemma coxeterOrder_le_three_iff {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) :
+    coxeterOrder c ≤ 3 ↔ c = 0 ∨ c = 1 := by
+  simp only [mem_insert_iff, mem_singleton_iff] at hc
+  rcases hc with rfl | rfl | rfl | rfl <;> simp
+
+/-- The product `0` is the only one of Coxeter order `2`. -/
+lemma coxeterOrder_eq_two_iff {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) :
+    coxeterOrder c = 2 ↔ c = 0 := by
+  simp only [mem_insert_iff, mem_singleton_iff] at hc
+  rcases hc with rfl | rfl | rfl | rfl <;> simp
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N)
+
+/-! ## The Cartan product of two simple roots -/
+
+section CartanProduct
+
+variable [P.IsCrystallographic] (b : P.Base)
+
+/-- The Cartan product of a pair of simple roots is their Coxeter weight. -/
+lemma cartanMatrix_mul_cartanMatrix (i j : b.support) :
+    b.cartanMatrix i j * b.cartanMatrix j i = P.coxeterWeightIn ℤ i j := rfl
+
+variable [CharZero R] [IsDomain R]
+
+/-- The Cartan product of two simple roots vanishes exactly when the first Cartan entry does: both
+entries vanish together, since the zero pattern of a Cartan matrix is symmetric. -/
+lemma cartanMatrix_mul_cartanMatrix_eq_zero_iff (i j : b.support) :
+    b.cartanMatrix i j * b.cartanMatrix j i = 0 ↔ b.cartanMatrix i j = 0 := by
+  rw [mul_eq_zero]
+  exact or_iff_left_iff_imp.mpr fun h ↦ b.cartanMatrix_apply_eq_zero_iff_symm.mpr h
+
+/-- The Cartan product of two simple roots vanishes exactly when they are orthogonal. -/
+lemma cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal (i j : b.support) :
+    b.cartanMatrix i j * b.cartanMatrix j i = 0 ↔ P.IsOrthogonal (i : ι) (j : ι) := by
+  rw [cartanMatrix_mul_cartanMatrix_eq_zero_iff]
+  refine ⟨fun h ↦ ⟨b.cartanMatrix_apply_eq_zero_iff_pairing.mp h,
+    b.cartanMatrix_apply_eq_zero_iff_pairing.mp (b.cartanMatrix_apply_eq_zero_iff_symm.mp h)⟩,
+    fun h ↦ b.cartanMatrix_apply_eq_zero_iff_pairing.mpr h.1⟩
+
+variable [Finite ι]
+
+/-- **The Cartan product of two distinct simple roots lies in `{0, 1, 2, 3}`**, so `coxeterOrder`
+reads a genuine Coxeter order off it.
+
+Mathlib confines the Coxeter weight of a finite crystallographic pairing to `{0, 1, 2, 3, 4}`, and
+the value `4` is attained only by linearly dependent pairs of roots. Distinct simple roots are
+linearly independent, which removes it. -/
+theorem cartanMatrix_mul_cartanMatrix_mem_of_ne {i j : b.support} (hij : i ≠ j) :
+    b.cartanMatrix i j * b.cartanMatrix j i ∈ ({0, 1, 2, 3} : Set ℤ) := by
+  have : Module.IsReflexive R M := .of_isPerfPair P.toLinearMap
+  have hne : P.coxeterWeightIn ℤ (i : ι) (j : ι) ≠ 4 :=
+    (P.linearIndependent_iff_coxeterWeightIn_ne_four ℤ).mp (b.linearIndependent_pair_of_ne hij)
+  have hmem := P.coxeterWeightIn_mem_set_of_isCrystallographic (i : ι) (j : ι)
+  rw [cartanMatrix_mul_cartanMatrix]
+  simp only [mem_insert_iff, mem_singleton_iff] at hmem ⊢
+  tauto
+
+/-- The Cartan product of two distinct simple roots is `1` exactly when both Cartan entries are
+`-1`, that is, exactly when the two simple roots are joined by a single edge. Off the diagonal the
+entries are nonpositive, so the alternative factorisation `1 * 1` cannot occur. -/
+lemma cartanMatrix_mul_cartanMatrix_eq_one_iff {i j : b.support} (hij : i ≠ j) :
+    b.cartanMatrix i j * b.cartanMatrix j i = 1 ↔
+      b.cartanMatrix i j = -1 ∧ b.cartanMatrix j i = -1 := by
+  have hi := b.cartanMatrix_le_zero_of_ne i j hij
+  rw [Int.mul_eq_one_iff_eq_one_or_neg_one]
+  refine ⟨fun h ↦ ?_, Or.inr⟩
+  rcases h with ⟨h, -⟩ | h
+  · omega
+  · exact h
+
+end CartanProduct
+
+/-! ## The Coxeter matrix of a base -/
+
+section CoxeterMatrixOfBase
+
+variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] (b : P.Base)
+
+/-- **The Coxeter matrix of a base.** Its entry at a pair of distinct simple roots records the order
+of the product of the two corresponding simple reflections, read off their Cartan product by
+`0 ↦ 2`, `1 ↦ 3`, `2 ↦ 4`, `3 ↦ 6`; its diagonal entries are `1` because a simple root has Cartan
+product `4` with itself.
+
+That the entries really are those orders is the classical rank-two computation, and follows in
+general from the Coxeter presentation of the Weyl group, which is not built here; the entry `2` is
+checked directly in `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`. -/
+@[expose]
+noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support where
+  M := .of fun i j ↦ coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i)
+  isSymm := by
+    ext i j
+    simp [Matrix.transpose_apply, mul_comm]
+  diagonal i := by simp
+  off_diagonal i j hij := by
+    have := two_le_coxeterOrder (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)
+    simp only [Matrix.of_apply]
+    omega
+
+@[simp]
+lemma coxeterMatrixOfBase_apply (i j : b.support) :
+    coxeterMatrixOfBase P b i j = coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i) := rfl
+
+/-- Off the diagonal the Coxeter matrix of a base takes only the four dihedral values. -/
+lemma coxeterMatrixOfBase_mem_of_ne {i j : b.support} (hij : i ≠ j) :
+    coxeterMatrixOfBase P b i j ∈ ({2, 3, 4, 6} : Set ℕ) :=
+  coxeterOrder_mem (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)
+
+/-- No entry of the Coxeter matrix of a base is infinite: no pair of simple roots of a finite
+crystallographic root pairing generates an infinite dihedral group. -/
+lemma coxeterMatrixOfBase_ne_zero (i j : b.support) : coxeterMatrixOfBase P b i j ≠ 0 := by
+  rcases eq_or_ne i j with rfl | hij
+  · simp
+  · have := coxeterMatrixOfBase_mem_of_ne P b hij
+    simp only [mem_insert_iff, mem_singleton_iff] at this
+    omega
+
+/-- Every entry of the Coxeter matrix of a base is at most `6`, the order attained by the `G₂`
+configuration. -/
+lemma coxeterMatrixOfBase_le_six (i j : b.support) : coxeterMatrixOfBase P b i j ≤ 6 := by
+  rcases eq_or_ne i j with rfl | hij
+  · simp
+  · exact coxeterOrder_le_six (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)
+
+/-- **Two distinct simple roots carry the Coxeter entry `2` exactly when they are orthogonal.** -/
+theorem coxeterMatrixOfBase_eq_two_iff {i j : b.support} (hij : i ≠ j) :
+    coxeterMatrixOfBase P b i j = 2 ↔ P.IsOrthogonal (i : ι) (j : ι) := by
+  rw [coxeterMatrixOfBase_apply,
+    coxeterOrder_eq_two_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij),
+    cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal]
+
+/-- **The Coxeter matrix of a base has all entries at most `3` exactly when its Cartan matrix is
+simply laced**, that is, exactly when no two simple roots are joined by a multiple edge. -/
+theorem forall_coxeterMatrixOfBase_le_three_iff :
+    (∀ i j, coxeterMatrixOfBase P b i j ≤ 3) ↔ b.cartanMatrix.IsSimplyLaced := by
+  constructor
+  · intro h i j hij
+    rcases (coxeterOrder_le_three_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)).mp
+      (by simpa using h i j) with h₀ | h₁
+    · exact Or.inl ((cartanMatrix_mul_cartanMatrix_eq_zero_iff P b i j).mp h₀)
+    · exact Or.inr ((cartanMatrix_mul_cartanMatrix_eq_one_iff P b hij).mp h₁).1
+  · intro h i j
+    rcases eq_or_ne i j with rfl | hij
+    · simp
+    · rw [coxeterMatrixOfBase_apply,
+        coxeterOrder_le_three_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)]
+      rcases h hij with h₁ | h₁ <;> rcases h hij.symm with h₂ | h₂ <;> rw [h₁, h₂] <;> norm_num
+
+end CoxeterMatrixOfBase
+
+/-! ## The orthogonal case: commuting simple reflections -/
+
+namespace RootPairing.weylGroup
+
+/-- A simple reflection of the Weyl group is the corresponding reflection of the root pairing. -/
+@[simp]
+lemma coe_ofIdx (i : ι) :
+    ((_root_.RootPairing.weylGroup.ofIdx P i : P.weylGroup) : P.Aut) =
+      _root_.RootPairing.Equiv.reflection P i :=
+  rfl
+
+/-- A simple reflection of the Weyl group is an involution. -/
+lemma ofIdx_mul_self (i : ι) :
+    _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P i = 1 := by
+  rw [mul_eq_one_iff_eq_inv]
+  exact Subtype.ext (_root_.RootPairing.Equiv.reflection_inv P i).symm
+
+/-- **Orthogonal simple roots have commuting simple reflections**: this is the braid relation that
+the Coxeter entry `2` asserts. -/
+theorem commute_ofIdx_of_isOrthogonal {i j : ι} (h : P.IsOrthogonal i j) :
+    Commute (_root_.RootPairing.weylGroup.ofIdx P i) (_root_.RootPairing.weylGroup.ofIdx P j) := by
+  refine Subtype.ext ?_
+  simp only [Subgroup.coe_mul]
+  apply _root_.RootPairing.Equiv.weightHom_injective P
+  simpa only [coe_ofIdx, map_mul, _root_.RootPairing.Equiv.weightHom_apply,
+    _root_.RootPairing.Equiv.reflection_weightEquiv] using
+    (_root_.RootPairing.isOrthogonal_comm P i j h).eq
+
+variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
+
+/-- Distinct simple roots give distinct simple reflections: a simple reflection turns its own
+simple root negative and leaves every other one positive. -/
+theorem ofIdx_ne_ofIdx_of_ne (b : P.Base) {i j : ι}
+    (hi : i ∈ b.support) (hj : j ∈ b.support) (hij : i ≠ j) :
+    _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
+  letI := P.indexNeg
+  intro hEq
+  have hpos : b.IsPos (P.reflectionPerm i j) :=
+    (b.isPos_of_mem_support hj).reflectionPerm hi hij.symm
+  have hneg : ¬ b.IsPos (P.reflectionPerm j j) := by
+    rw [← _root_.RootPairing.indexNeg_neg, _root_.RootPairing.Base.IsPos.neg_iff_not]
+    exact not_not_intro (b.isPos_of_mem_support hj)
+  refine hneg ?_
+  rw [← weylGroupToPerm_ofIdx_apply P j j, ← hEq, weylGroupToPerm_ofIdx_apply P i j]
+  exact hpos
+
+/-- **Where the Coxeter matrix of a base has the entry `2`, the product of the two simple
+reflections does have order `2`.** This is the one entry of `coxeterMatrixOfBase` that can be
+checked before the Coxeter presentation of the Weyl group is available. -/
+theorem orderOf_ofIdx_mul_ofIdx_of_eq_two (b : P.Base) {i j : b.support} (hij : i ≠ j)
+    (h : coxeterMatrixOfBase P b i j = 2) :
+    orderOf (_root_.RootPairing.weylGroup.ofIdx P (i : ι) *
+      _root_.RootPairing.weylGroup.ofIdx P (j : ι)) = 2 := by
+  have hij' : (i : ι) ≠ (j : ι) := fun h ↦ hij (Subtype.ext h)
+  have hcomm := commute_ofIdx_of_isOrthogonal P ((coxeterMatrixOfBase_eq_two_iff P b hij).mp h)
+  refine orderOf_eq_prime ?_ ?_
+  · rw [hcomm.mul_pow, sq, sq, ofIdx_mul_self, ofIdx_mul_self, mul_one]
+  · rw [Ne, mul_eq_one_iff_eq_inv, inv_eq_of_mul_eq_one_right (ofIdx_mul_self P (j : ι))]
+    exact ofIdx_ne_ofIdx_of_ne P b i.property j.property hij'
+
+end RootPairing.weylGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -7,8 +7,7 @@ module
 public import Mathlib.GroupTheory.Coxeter.Matrix
 public import Mathlib.LinearAlgebra.Matrix.Cartan
 public import Mathlib.LinearAlgebra.RootSystem.CartanMatrix
-public import Mathlib.LinearAlgebra.RootSystem.Finite.Lemmas
-public import TauCeti.LinearAlgebra.RootSystem.WeylGroup
+public import TauCeti.LinearAlgebra.RootSystem.SimpleReflections
 
 public section
 
@@ -36,9 +35,10 @@ simple root has Cartan product `4` with itself. Products outside `{0, 1, 2, 3, 4
 here and are sent to `0`, Mathlib's encoding of an infinite Coxeter order.
 
 The final section checks the smallest of the intended braid relations, the one available before the
-Coxeter presentation of the Weyl group is built: the entry of two distinct simple roots is `2`
-exactly when they are orthogonal, and there the two simple reflections commute and their product
-has order exactly `2`, as the entry asserts.
+Coxeter presentation of the Weyl group is built: an entry is `2` exactly for orthogonal simple
+roots, and there the two simple reflections commute
+(`TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal`) and their product has order exactly
+`2`, as the entry asserts.
 
 ## Main definitions
 
@@ -51,6 +51,7 @@ has order exactly `2`, as the entry asserts.
 * `TauCeti.cartanMatrix_mul_cartanMatrix_mem_of_ne`: the Cartan product of two distinct simple
   roots lies in `{0, 1, 2, 3}`, so `TauCeti.coxeterOrder` reads a genuine Coxeter order off it.
 * `TauCeti.coxeterMatrixOfBase_eq_two_iff`: an entry is `2` exactly for orthogonal simple roots.
+  In particular the diagonal entries are not `2`, since no root is orthogonal to itself.
 * `TauCeti.forall_coxeterMatrixOfBase_le_three_iff`: all entries are at most `3` exactly when the
   Cartan matrix is simply laced.
 * `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`: where the matrix entry is `2`,
@@ -230,6 +231,8 @@ noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support where
 
 -- `(rfl)`, not `rfl`: the body of `coxeterMatrixOfBase` is deliberately left unexposed, and the
 -- parenthesised form keeps this proof out of the exported definitional-equality check.
+/-- The entry of the Coxeter matrix of a base at a pair of simple roots is `coxeterOrder` applied
+to the product of the two Cartan entries. -/
 @[simp]
 lemma coxeterMatrixOfBase_apply (i j : b.support) :
     coxeterMatrixOfBase P b i j = coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i) := (rfl)
@@ -255,12 +258,16 @@ lemma coxeterMatrixOfBase_le_six (i j : b.support) : coxeterMatrixOfBase P b i j
   · simp
   · exact coxeterOrder_le_six (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij)
 
-/-- **Two distinct simple roots carry the Coxeter entry `2` exactly when they are orthogonal.** -/
-theorem coxeterMatrixOfBase_eq_two_iff {i j : b.support} (hij : i ≠ j) :
+/-- **Two simple roots carry the Coxeter entry `2` exactly when they are orthogonal.** On the
+diagonal both sides fail: the entry there is `1`, and no root is orthogonal to itself. -/
+theorem coxeterMatrixOfBase_eq_two_iff (i j : b.support) :
     coxeterMatrixOfBase P b i j = 2 ↔ P.IsOrthogonal (i : ι) (j : ι) := by
-  rw [coxeterMatrixOfBase_apply,
-    coxeterOrder_eq_two_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij),
-    cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal]
+  rcases eq_or_ne i j with rfl | hij
+  · rw [← cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal P b]
+    simp
+  · rw [coxeterMatrixOfBase_apply,
+      coxeterOrder_eq_two_iff (cartanMatrix_mul_cartanMatrix_mem_of_ne P b hij),
+      cartanMatrix_mul_cartanMatrix_eq_zero_iff_isOrthogonal]
 
 /-- **The Coxeter matrix of a base has all entries at most `3` exactly when its Cartan matrix is
 simply laced**, that is, exactly when no two simple roots are joined by a multiple edge. -/
@@ -285,57 +292,18 @@ end CoxeterMatrixOfBase
 
 namespace RootPairing.weylGroup
 
-/-- A simple reflection of the Weyl group is the corresponding reflection of the root pairing. -/
-@[simp]
-lemma coe_ofIdx (i : ι) :
-    ((_root_.RootPairing.weylGroup.ofIdx P i : P.weylGroup) : P.Aut) =
-      _root_.RootPairing.Equiv.reflection P i :=
-  rfl
-
-/-- A simple reflection of the Weyl group is an involution. -/
-lemma ofIdx_mul_self (i : ι) :
-    _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P i = 1 := by
-  rw [mul_eq_one_iff_eq_inv]
-  exact Subtype.ext (_root_.RootPairing.Equiv.reflection_inv P i).symm
-
-/-- **Orthogonal simple roots have commuting simple reflections**: this is the braid relation that
-the Coxeter entry `2` asserts. -/
-theorem commute_ofIdx_of_isOrthogonal {i j : ι} (h : P.IsOrthogonal i j) :
-    Commute (_root_.RootPairing.weylGroup.ofIdx P i) (_root_.RootPairing.weylGroup.ofIdx P j) := by
-  refine Subtype.ext ?_
-  simp only [Subgroup.coe_mul]
-  apply _root_.RootPairing.Equiv.weightHom_injective P
-  simpa only [coe_ofIdx, map_mul, _root_.RootPairing.Equiv.weightHom_apply,
-    _root_.RootPairing.Equiv.reflection_weightEquiv] using
-    (_root_.RootPairing.isOrthogonal_comm P i j h).eq
-
 variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
-
-/-- Distinct simple roots give distinct simple reflections: a simple reflection turns its own
-simple root negative and leaves every other one positive. -/
-theorem ofIdx_ne_ofIdx_of_ne (b : P.Base) {i j : ι}
-    (hi : i ∈ b.support) (hj : j ∈ b.support) (hij : i ≠ j) :
-    _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
-  letI := P.indexNeg
-  intro hEq
-  have hpos : b.IsPos (P.reflectionPerm i j) :=
-    (b.isPos_of_mem_support hj).reflectionPerm hi hij.symm
-  have hneg : ¬ b.IsPos (P.reflectionPerm j j) := by
-    rw [← _root_.RootPairing.indexNeg_neg, _root_.RootPairing.Base.IsPos.neg_iff_not]
-    exact not_not_intro (b.isPos_of_mem_support hj)
-  refine hneg ?_
-  rw [← weylGroupToPerm_ofIdx_apply P j j, ← hEq, weylGroupToPerm_ofIdx_apply P i j]
-  exact hpos
 
 /-- **Where the Coxeter matrix of a base has the entry `2`, the product of the two simple
 reflections does have order `2`.** This is the one entry of `coxeterMatrixOfBase` that can be
 checked before the Coxeter presentation of the Weyl group is available. -/
-theorem orderOf_ofIdx_mul_ofIdx_of_eq_two (b : P.Base) {i j : b.support} (hij : i ≠ j)
+theorem orderOf_ofIdx_mul_ofIdx_of_eq_two (b : P.Base) {i j : b.support}
     (h : coxeterMatrixOfBase P b i j = 2) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (i : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (j : ι)) = 2 := by
+  have hij : i ≠ j := by rintro rfl; simp at h
   have hij' : (i : ι) ≠ (j : ι) := fun h ↦ hij (Subtype.ext h)
-  have hcomm := commute_ofIdx_of_isOrthogonal P ((coxeterMatrixOfBase_eq_two_iff P b hij).mp h)
+  have hcomm := commute_ofIdx_of_isOrthogonal P ((coxeterMatrixOfBase_eq_two_iff P b i j).mp h)
   refine orderOf_eq_prime ?_ ?_
   · rw [hcomm.mul_pow, sq, sq, ofIdx_mul_self, ofIdx_mul_self, mul_one]
   · rw [Ne, mul_eq_one_iff_eq_inv, inv_eq_of_mul_eq_one_right (ofIdx_mul_self P (j : ι))]

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -149,7 +149,7 @@ section CartanProduct
 variable [P.IsCrystallographic] (b : P.Base)
 
 /-- The Cartan product of a pair of simple roots is their Coxeter weight. -/
-lemma cartanMatrix_mul_cartanMatrix (i j : b.support) :
+lemma cartanMatrix_mul_cartanMatrix_eq_coxeterWeightIn (i j : b.support) :
     b.cartanMatrix i j * b.cartanMatrix j i = P.coxeterWeightIn ℤ i j := rfl
 
 variable [CharZero R] [IsDomain R]
@@ -183,7 +183,7 @@ theorem cartanMatrix_mul_cartanMatrix_mem_of_ne {i j : b.support} (hij : i ≠ j
   have hne : P.coxeterWeightIn ℤ (i : ι) (j : ι) ≠ 4 :=
     (P.linearIndependent_iff_coxeterWeightIn_ne_four ℤ).mp (b.linearIndependent_pair_of_ne hij)
   have hmem := P.coxeterWeightIn_mem_set_of_isCrystallographic (i : ι) (j : ι)
-  rw [cartanMatrix_mul_cartanMatrix]
+  rw [cartanMatrix_mul_cartanMatrix_eq_coxeterWeightIn]
   simp only [mem_insert_iff, mem_singleton_iff] at hmem ⊢
   tauto
 

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -95,6 +95,14 @@ def coxeterOrder (c : ℤ) : ℕ :=
 
 @[simp] lemma coxeterOrder_four : coxeterOrder 4 = 1 := by norm_num [coxeterOrder]
 
+/-- Outside `{0, 1, 2, 3, 4}` the translation falls back to `0`, Mathlib's encoding of an infinite
+order. No such Cartan product occurs for a finite crystallographic pairing; this lemma pins the
+value down at the remaining integers, so the five equation lemmas above determine `coxeterOrder`
+everywhere. -/
+lemma coxeterOrder_eq_zero_iff {c : ℤ} : coxeterOrder c = 0 ↔ c ∉ ({0, 1, 2, 3, 4} : Set ℤ) := by
+  simp only [mem_insert_iff, mem_singleton_iff, not_or, coxeterOrder]
+  split_ifs with h₀ h₁ h₂ h₃ h₄ <;> simp_all
+
 /-- On the products that occur for a pair of independent roots, `coxeterOrder` takes the four
 dihedral values. -/
 lemma coxeterOrder_mem {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) :
@@ -116,7 +124,8 @@ lemma coxeterOrder_le_six {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) : coxe
   simp only [mem_insert_iff, mem_singleton_iff] at this
   omega
 
-/-- The single-edge products are exactly those of Coxeter order at most `3`. -/
+/-- The products with at most one edge, namely `0` (no edge) and `1` (a single edge), are exactly
+those of Coxeter order at most `3`. -/
 lemma coxeterOrder_le_three_iff {c : ℤ} (hc : c ∈ ({0, 1, 2, 3} : Set ℤ)) :
     coxeterOrder c ≤ 3 ↔ c = 0 ∨ c = 1 := by
   simp only [mem_insert_iff, mem_singleton_iff] at hc
@@ -205,8 +214,9 @@ product `4` with itself.
 
 That the entries really are those orders is the classical rank-two computation, and follows in
 general from the Coxeter presentation of the Weyl group, which is not built here; the entry `2` is
-checked directly in `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`. -/
-@[expose]
+checked directly in `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`.
+
+The body is not exposed: `TauCeti.coxeterMatrixOfBase_apply` is the entry API. -/
 noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support where
   M := .of fun i j ↦ coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i)
   isSymm := by
@@ -218,9 +228,11 @@ noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support where
     simp only [Matrix.of_apply]
     omega
 
+-- `(rfl)`, not `rfl`: the body of `coxeterMatrixOfBase` is deliberately left unexposed, and the
+-- parenthesised form keeps this proof out of the exported definitional-equality check.
 @[simp]
 lemma coxeterMatrixOfBase_apply (i j : b.support) :
-    coxeterMatrixOfBase P b i j = coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i) := rfl
+    coxeterMatrixOfBase P b i j = coxeterOrder (b.cartanMatrix i j * b.cartanMatrix j i) := (rfl)
 
 /-- Off the diagonal the Coxeter matrix of a base takes only the four dihedral values. -/
 lemma coxeterMatrixOfBase_mem_of_ne {i j : b.support} (hij : i ≠ j) :

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -294,7 +294,7 @@ end CoxeterMatrixOfBase
 
 namespace RootPairing.weylGroup
 
-variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced]
+variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic]
 
 /-- **Where the Coxeter matrix of a base has the entry `2`, the product of the two simple
 reflections does have order `2`.** This is the one entry of `coxeterMatrixOfBase` that can be

--- a/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean
@@ -54,8 +54,8 @@ roots, and there the two simple reflections commute
   In particular the diagonal entries are not `2`, since no root is orthogonal to itself.
 * `TauCeti.forall_coxeterMatrixOfBase_le_three_iff`: all entries are at most `3` exactly when the
   Cartan matrix is simply laced.
-* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`: where the matrix entry is `2`,
-  the product of the two simple reflections does have order `2`.
+* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`:
+  where the matrix entry is `2`, the product of the two simple reflections does have order `2`.
 
 ## References
 
@@ -215,7 +215,8 @@ product `4` with itself.
 
 That the entries really are those orders is the classical rank-two computation, and follows in
 general from the Coxeter presentation of the Weyl group, which is not built here; the entry `2` is
-checked directly in `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_of_eq_two`.
+checked directly in
+`TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two`.
 
 The body is not exposed: `TauCeti.coxeterMatrixOfBase_apply` is the entry API. -/
 noncomputable def coxeterMatrixOfBase : CoxeterMatrix b.support where
@@ -297,8 +298,8 @@ variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduc
 /-- **Where the Coxeter matrix of a base has the entry `2`, the product of the two simple
 reflections does have order `2`.** This is the one entry of `coxeterMatrixOfBase` that can be
 checked before the Coxeter presentation of the Weyl group is available. -/
-theorem orderOf_ofIdx_mul_ofIdx_of_eq_two (b : P.Base) {i j : b.support}
-    (h : coxeterMatrixOfBase P b i j = 2) :
+theorem orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two
+    (b : P.Base) {i j : b.support} (h : coxeterMatrixOfBase P b i j = 2) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (i : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (j : ι)) = 2 := by
   have hij : i ≠ j := by rintro rfl; simp at h

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -129,10 +129,11 @@ theorem exists_list_prod_ofIdx_eq (w : P.weylGroup) :
 
 namespace RootPairing.weylGroup
 
-omit [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
+omit [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
 /-- Distinct simple roots give distinct simple reflections: the two reflections already disagree on
 the second simple root, since the two simple roots are linearly independent. -/
-theorem ofIdx_ne_ofIdx_of_ne {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) (hij : i ≠ j) :
+theorem ofIdx_ne_ofIdx_of_ne [NeZero (2 : R)] {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support)
+    (hij : i ≠ j) :
     _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
   intro hEq
   have hindep : LinearIndependent R ![P.root i, P.root j] :=

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.RootSystem.Base
-public import Mathlib.LinearAlgebra.RootSystem.WeylGroup
+public import TauCeti.LinearAlgebra.RootSystem.WeylGroup
 import Mathlib.Algebra.Group.Submonoid.Membership
 import Mathlib.GroupTheory.OrderOfElement
 
@@ -29,6 +29,8 @@ while root negation does not change the reflection.
   its simple reflections.
 * `TauCeti.exists_list_prod_ofIdx_eq` writes every Weyl-group element as a product of simple
   reflections.
+* `TauCeti.RootPairing.weylGroup.ofIdx_ne_ofIdx_of_ne` says distinct simple roots give distinct
+  simple reflections.
 
 ## References
 
@@ -70,19 +72,7 @@ omit [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] 
 private lemma ofIdx_reflectionPerm_self_eq (i : ι) :
     RootPairing.weylGroup.ofIdx P (P.reflectionPerm i i) =
     RootPairing.weylGroup.ofIdx P i := by
-  rw [ofIdx_reflectionPerm_eq P i i]
-  have hsquare :
-      RootPairing.weylGroup.ofIdx P i * RootPairing.weylGroup.ofIdx P i = 1 := by
-    rw [mul_eq_one_iff_eq_inv]
-    apply Subtype.ext
-    exact (RootPairing.Equiv.reflection_inv P i).symm
-  rw [hsquare, one_mul]
-
-omit [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
-private lemma ofIdx_inv_eq (i : ι) :
-    (RootPairing.weylGroup.ofIdx P i)⁻¹ = RootPairing.weylGroup.ofIdx P i := by
-  apply Subtype.ext
-  exact RootPairing.Equiv.reflection_inv P i
+  rw [ofIdx_reflectionPerm_eq P i i, RootPairing.weylGroup.ofIdx_mul_self, one_mul]
 
 private lemma ofIdx_mem_closure_simple (i : ι) :
     RootPairing.weylGroup.ofIdx P i ∈
@@ -128,7 +118,7 @@ theorem exists_list_prod_ofIdx_eq (w : P.weylGroup) :
       apply Subgroup.closure_toSubmonoid_of_isOfFinOrder
       rintro x ⟨i, rfl⟩
       exact isOfFinOrder_iff_pow_eq_one.2 ⟨2, Nat.zero_lt_succ 1, by
-        rw [sq, mul_eq_one_iff_eq_inv, ofIdx_inv_eq P i]⟩
+        rw [sq, RootPairing.weylGroup.ofIdx_mul_self]⟩
     rw [← hclosure, ← weylGroup_eq_closure_simple P b]
     exact Submonoid.mem_top w
   rw [← FreeMonoid.mrange_lift] at hw
@@ -136,5 +126,24 @@ theorem exists_list_prod_ofIdx_eq (w : P.weylGroup) :
   refine ⟨l.toList, ?_⟩
   rw [← FreeMonoid.lift_apply]
   exact hl
+
+namespace RootPairing.weylGroup
+
+/-- Distinct simple roots give distinct simple reflections: a simple reflection turns its own
+simple root negative and leaves every other one positive. -/
+theorem ofIdx_ne_ofIdx_of_ne {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) (hij : i ≠ j) :
+    _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
+  letI := P.indexNeg
+  intro hEq
+  have hpos : b.IsPos (P.reflectionPerm i j) :=
+    (b.isPos_of_mem_support hj).reflectionPerm hi hij.symm
+  have hneg : ¬ b.IsPos (P.reflectionPerm j j) := by
+    rw [← _root_.RootPairing.indexNeg_neg, _root_.RootPairing.Base.IsPos.neg_iff_not]
+    exact not_not_intro (b.isPos_of_mem_support hj)
+  refine hneg ?_
+  rw [← weylGroupToPerm_ofIdx_apply P j j, ← hEq, weylGroupToPerm_ofIdx_apply P i j]
+  exact hpos
+
+end RootPairing.weylGroup
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/SimpleReflections.lean
@@ -129,20 +129,23 @@ theorem exists_list_prod_ofIdx_eq (w : P.weylGroup) :
 
 namespace RootPairing.weylGroup
 
-/-- Distinct simple roots give distinct simple reflections: a simple reflection turns its own
-simple root negative and leaves every other one positive. -/
+omit [Finite ι] [IsDomain R] [P.IsCrystallographic] [P.IsReduced] in
+/-- Distinct simple roots give distinct simple reflections: the two reflections already disagree on
+the second simple root, since the two simple roots are linearly independent. -/
 theorem ofIdx_ne_ofIdx_of_ne {i j : ι} (hi : i ∈ b.support) (hj : j ∈ b.support) (hij : i ≠ j) :
     _root_.RootPairing.weylGroup.ofIdx P i ≠ _root_.RootPairing.weylGroup.ofIdx P j := by
-  letI := P.indexNeg
   intro hEq
-  have hpos : b.IsPos (P.reflectionPerm i j) :=
-    (b.isPos_of_mem_support hj).reflectionPerm hi hij.symm
-  have hneg : ¬ b.IsPos (P.reflectionPerm j j) := by
-    rw [← _root_.RootPairing.indexNeg_neg, _root_.RootPairing.Base.IsPos.neg_iff_not]
-    exact not_not_intro (b.isPos_of_mem_support hj)
-  refine hneg ?_
-  rw [← weylGroupToPerm_ofIdx_apply P j j, ← hEq, weylGroupToPerm_ofIdx_apply P i j]
-  exact hpos
+  have hindep : LinearIndependent R ![P.root i, P.root j] :=
+    b.linearIndependent_pair_of_ne (i := ⟨i, hi⟩) (j := ⟨j, hj⟩) (by simpa using hij)
+  have happ : P.root (P.reflectionPerm i j) = P.root (P.reflectionPerm j j) := by
+    rw [← weylGroupToPerm_ofIdx_apply P i j, ← weylGroupToPerm_ofIdx_apply P j j, hEq]
+  rw [P.root_reflectionPerm, P.root_reflectionPerm, P.reflection_apply_root,
+    P.reflection_apply_self] at happ
+  -- `happ` now reads `αⱼ - ⟨αⱼ, αᵢ^∨⟩ • αᵢ = -αⱼ`, so `2 • αⱼ` is a multiple of `αᵢ`.
+  have h2 : (2 : R) = 0 :=
+    (LinearIndependent.pair_iff.mp hindep (-P.pairing j i) 2
+      (by linear_combination (norm := module) happ)).2
+  exact two_ne_zero h2
 
 end RootPairing.weylGroup
 

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -25,6 +25,9 @@ on its own coroot functional.
   coroot functional.
 * `TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
 * `TauCeti.RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
+* `TauCeti.RootPairing.weylGroup.ofIdx_mul_self` says a simple reflection is an involution.
+* `TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal` says orthogonal roots have
+  commuting reflections.
 * `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
   a finite root system is finite.
 * `TauCeti.RootPairing.finite_weylGroup` is the resulting finiteness theorem for the Weyl group.
@@ -130,6 +133,38 @@ lemma weylGroupToPerm_neg (w : P.weylGroup) (j : ι) :
       congrArg Neg.neg (P.weylGroup_apply_root w j)
     _ = P.root (-(P.weylGroupToPerm w j)) := by
       rw [_root_.RootPairing.indexNeg_neg, P.root_reflectionPerm, P.reflection_apply_self]
+
+namespace weylGroup
+
+/-- A simple reflection of the Weyl group is the corresponding reflection of the root pairing. -/
+@[simp]
+lemma coe_ofIdx (i : ι) :
+    ((_root_.RootPairing.weylGroup.ofIdx P i : P.weylGroup) : P.Aut) =
+      _root_.RootPairing.Equiv.reflection P i :=
+  rfl
+
+/-- A simple reflection of the Weyl group is its own inverse. -/
+lemma ofIdx_inv_eq (i : ι) :
+    (_root_.RootPairing.weylGroup.ofIdx P i)⁻¹ = _root_.RootPairing.weylGroup.ofIdx P i :=
+  Subtype.ext (_root_.RootPairing.Equiv.reflection_inv P i)
+
+/-- A simple reflection of the Weyl group is an involution. -/
+@[simp]
+lemma ofIdx_mul_self (i : ι) :
+    _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P i = 1 := by
+  rw [mul_eq_one_iff_eq_inv, ofIdx_inv_eq]
+
+/-- **Orthogonal roots have commuting reflections** in the Weyl group. -/
+theorem commute_ofIdx_of_isOrthogonal {i j : ι} (h : P.IsOrthogonal i j) :
+    Commute (_root_.RootPairing.weylGroup.ofIdx P i) (_root_.RootPairing.weylGroup.ofIdx P j) := by
+  refine Subtype.ext ?_
+  simp only [Subgroup.coe_mul]
+  apply _root_.RootPairing.Equiv.weightHom_injective P
+  simpa only [coe_ofIdx, map_mul, _root_.RootPairing.Equiv.weightHom_apply,
+    _root_.RootPairing.Equiv.reflection_weightEquiv] using
+    (_root_.RootPairing.isOrthogonal_comm P i j h).eq
+
+end weylGroup
 
 variable [Finite ι]
 

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -144,6 +144,7 @@ lemma coe_ofIdx (i : ι) :
   rfl
 
 /-- A simple reflection of the Weyl group is its own inverse. -/
+@[simp]
 lemma ofIdx_inv_eq (i : ι) :
     (_root_.RootPairing.weylGroup.ofIdx P i)⁻¹ = _root_.RootPairing.weylGroup.ofIdx P i :=
   Subtype.ext (_root_.RootPairing.Equiv.reflection_inv P i)


### PR DESCRIPTION
This PR adds the Coxeter matrix of a base of a finite crystallographic root pairing: the symmetric matrix indexed by the simple roots whose off-diagonal entry is the order of the product of the two corresponding simple reflections, read off the Cartan product `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩` by `0 ↦ 2`, `1 ↦ 3`, `2 ↦ 4`, `3 ↦ 6`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"coxetermatrixofbase"}-->

The target is the first item of Layer 2 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, "**The Coxeter matrix of a base.** `coxeterMatrixOfBase b : CoxeterMatrix b.support` ... That the product lands in `{0,1,2,3}`, so the entry is a genuine Coxeter order, needs the full reduced crystallographic finite-type context ... Prove it is a genuine `CoxeterMatrix` (symmetric, diagonal `1`)", pinned as `coxeterMatrixOfBase` in that roadmap's `Suggested.lean`. It sits on the layer's existing foundation in `TauCeti/LinearAlgebra/RootSystem/` (positive roots, inversions, generation by simple reflections, the faithful permutation action) and is a prerequisite for `weylCoxeterSystem`, which is not attempted here.

`TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean` proves:

- `cartanMatrix_mul_cartanMatrix_mem_of_ne`, that the Cartan product of two distinct simple roots lies in `{0, 1, 2, 3}`. Mathlib pins the Coxeter weight of a finite crystallographic pairing to `{0, 1, 2, 3, 4}` and identifies the value `4` with linear dependence of the two roots; distinct simple roots are independent, which is what removes it. Reducedness is not needed for this, so the statement asks only for `[Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic]`, weaker than the pinned signature;
- `coxeterOrder`, the translation of a Cartan product into an order, and `coxeterMatrixOfBase`, the resulting `CoxeterMatrix b.support`, with its symmetry, diagonal and off-diagonal conditions discharged. `coxeterOrder` sends the product `4` to `1` rather than to a junk value, which is the honest value — product `4` means the two roots are proportional, so the two reflections agree and their product is the identity — and is what makes the diagonal come out as `1` with no case split, since a simple root has Cartan product `4` with itself;
- the entry lemmas: off the diagonal only the four dihedral values `2, 3, 4, 6` occur, so no entry is `0` (Mathlib's encoding of an infinite order) and none exceeds `6`; `coxeterMatrixOfBase_eq_two_iff`, that the entry `2` characterises orthogonal simple roots; and `forall_coxeterMatrixOfBase_le_three_iff`, that every entry is at most `3` exactly when the Cartan matrix is simply laced, which is the Coxeter-matrix reading of `Matrix.IsSimplyLaced`;
- the entry-`2` braid relation, the one available before the Coxeter presentation: `commute_ofIdx_of_isOrthogonal` lifts Mathlib's `RootPairing.isOrthogonal_comm` from reflections of the weight space to the Weyl group, `ofIdx_ne_ofIdx_of_ne` separates distinct simple reflections by noting that only its own simple root is turned negative by a simple reflection, and `orderOf_ofIdx_mul_ofIdx_of_eq_two` concludes that where the matrix says `2`, the product of the two simple reflections does have order exactly `2`.

The general statement that every off-diagonal entry is the order of the corresponding product is the Coxeter presentation of the Weyl group, and is left to that later target; the file's docstring says so.

No Mathlib infrastructure was vendored, and no material was taken from the supplementary source snapshot.

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` are green locally, the last reporting no new violations.

🤖 Prepared with Claude Code
