### PR TITLE
feat(Multiquadratic): the relative Galois group of the candidate genus field over ℚ(√d)

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -24,10 +24,11 @@ class-group side is built separately in `NumberTheory/ClassGroup`.
 The genus-field description is classical; see D. A. Cox, *Primes of the Form x² + ny²*, and
 F. Lemmermeyer, *Reciprocity Laws*.
 
+(`K_gen` is moreover abelian over `ℚ(√d)` — that instance is already supplied generically by
+Mathlib for intermediate fields of an abelian Galois extension.)
+
 ## Main results
 
-* `TauCeti.Multiquadratic.isAbelianGalois_candidateGenusField_over_base`: `K_gen` is abelian
-  Galois over its embedded quadratic base `ℚ(√d)`.
 * `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base`:
   `|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)` when `d` is not a rational square.
 -/
@@ -35,20 +36,6 @@ F. Lemmermeyer, *Reciprocity Laws*.
 public section
 
 namespace TauCeti.Multiquadratic
-
-/-- **The candidate genus field is abelian Galois over `ℚ(√d)`.** It is Galois over the intermediate
-field `candidateGenusFieldBase` because it is Galois over `ℚ`, and its relative Galois group is
-abelian because it injects (by restriction of scalars) into the abelian `Gal(K_gen/ℚ)`. -/
-noncomputable instance isAbelianGalois_candidateGenusField_over_base {d : ℤ} {hd : Squarefree d} :
-    IsAbelianGalois (candidateGenusFieldBase hd) (candidateGenusField hd) where
-  toIsGalois := inferInstance
-  is_comm.comm σ τ := by
-    have h := IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
-    ext x
-    have hx := DFunLike.congr_fun h x
-    simp only [AlgEquiv.mul_apply, AlgEquiv.restrictScalars_apply] at hx
-    simp only [AlgEquiv.mul_apply]
-    rw [hx]
 
 /-- **Order of the relative Galois group of the candidate genus field over `ℚ(√d)`.** If the
 squarefree integer `d` is not a rational square, then `K_gen` is Galois over its embedded quadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -45,7 +45,10 @@ noncomputable instance isAbelianGalois_candidateGenusField_over_base {d : ℤ} {
   is_comm.comm σ τ := by
     have h := IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
     ext x
-    simpa only [AlgEquiv.mul_apply, AlgEquiv.restrictScalars_apply] using DFunLike.congr_fun h x
+    have hx := DFunLike.congr_fun h x
+    simp only [AlgEquiv.mul_apply, AlgEquiv.restrictScalars_apply] at hx
+    simp only [AlgEquiv.mul_apply]
+    rw [hx]
 
 /-- **Order of the relative Galois group of the candidate genus field over `ℚ(√d)`.** If the
 squarefree integer `d` is not a rational square, then `K_gen` is Galois over its embedded quadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -18,8 +18,11 @@ intermediate field, so this file reads off the order of the relative Galois grou
 
 `|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)`.
 
-This is the left-hand side of the genus-theory summit isomorphism `Gal(K_gen / ℚ(√d)) ≅ Cl/Cl²`; the
-class-group side is built separately in `NumberTheory/ClassGroup`.
+For *imaginary* `d` this is the left-hand side of the genus-theory summit isomorphism
+`Gal(K_gen / ℚ(√d)) ≅ Cl/Cl²`. For *real* `d` the uniform `2 ^ (t - 1)` count matches the **narrow**
+class group instead (the ordinary `Cl/Cl²` can be smaller, since `K_gen` may ramify at the infinite
+places). Identifying `K_gen` with the relevant genus field, and building the class-group side, is
+later work; the class-group infrastructure lives in `NumberTheory/ClassGroup`.
 
 The genus-field description is classical; see D. A. Cox, *Primes of the Form x² + ny²*, and
 F. Lemmermeyer, *Reciprocity Laws*.
@@ -29,7 +32,7 @@ Mathlib for intermediate fields of an abelian Galois extension.)
 
 ## Main results
 
-* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base`:
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_candidateGenusFieldBase`:
   `|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)` when `d` is not a rational square.
 -/
 
@@ -41,8 +44,10 @@ namespace TauCeti.Multiquadratic
 squarefree integer `d` is not a rational square, then `K_gen` is Galois over its embedded quadratic
 base `ℚ(√d)` (as an intermediate field of the Galois extension `K_gen / ℚ`), and its relative Galois
 group has order `2 ^ (t - 1)`, where `t = (genusPrimeDiscriminants hd).card`. This is the
-group-order shadow of the summit isomorphism `Gal(K_gen / ℚ(√d)) ≅ Cl(ℚ(√d))/Cl(ℚ(√d))²`. -/
-theorem card_aut_candidateGenusField_over_base {d : ℤ} (hd : Squarefree d)
+group-order shadow of the genus-theory summit isomorphism, which for imaginary `d` is
+`Gal(K_gen / ℚ(√d)) ≅ Cl(ℚ(√d))/Cl(ℚ(√d))²` (for real `d` the count matches the narrow class group).
+It is the relative analogue of the absolute `card_aut_candidateGenusField = 2 ^ t`. -/
+theorem card_aut_candidateGenusField_over_candidateGenusFieldBase {d : ℤ} (hd : Squarefree d)
     (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
     Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
       = 2 ^ ((genusPrimeDiscriminants hd).card - 1) := by

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -26,6 +26,8 @@ F. Lemmermeyer, *Reciprocity Laws*.
 
 ## Main results
 
+* `TauCeti.Multiquadratic.isAbelianGalois_candidateGenusField_over_base`: `K_gen` is abelian
+  Galois over its embedded quadratic base `ℚ(√d)`.
 * `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base`:
   `|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)` when `d` is not a rational square.
 -/
@@ -33,6 +35,17 @@ F. Lemmermeyer, *Reciprocity Laws*.
 public section
 
 namespace TauCeti.Multiquadratic
+
+/-- **The candidate genus field is abelian Galois over `ℚ(√d)`.** It is Galois over the intermediate
+field `candidateGenusFieldBase` because it is Galois over `ℚ`, and its relative Galois group is
+abelian because it injects (by restriction of scalars) into the abelian `Gal(K_gen/ℚ)`. -/
+noncomputable instance isAbelianGalois_candidateGenusField_over_base {d : ℤ} {hd : Squarefree d} :
+    IsAbelianGalois (candidateGenusFieldBase hd) (candidateGenusField hd) where
+  toIsGalois := inferInstance
+  is_comm.comm σ τ := by
+    have h := IsMulCommutative.is_comm.comm (σ.restrictScalars ℚ) (τ.restrictScalars ℚ)
+    ext x
+    simpa only [AlgEquiv.mul_apply, AlgEquiv.restrictScalars_apply] using DFunLike.congr_fun h x
 
 /-- **Order of the relative Galois group of the candidate genus field over `ℚ(√d)`.** If the
 squarefree integer `d` is not a rational square, then `K_gen` is Galois over its embedded quadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.RelativeDegree
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.GaloisGroup
+
+/-!
+# The relative Galois group of the candidate genus field over `ℚ(√d)`
+
+`CandidateGenusField/GaloisGroup` shows the candidate genus field `K_gen` is abelian Galois over
+`ℚ`, with `|Gal(K_gen/ℚ)| = 2 ^ t` (`t = (genusPrimeDiscriminants hd).card`).
+`CandidateGenusField/RelativeDegree` shows `[K_gen : ℚ(√d)] = 2 ^ (t - 1)` over the embedded
+quadratic base `candidateGenusFieldBase`. Since `K_gen / ℚ` is Galois, it is Galois over every
+intermediate field, so this file reads off the order of the relative Galois group:
+
+`|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)`.
+
+This is the left-hand side of the genus-theory summit isomorphism `Gal(K_gen / ℚ(√d)) ≅ Cl/Cl²`; the
+class-group side is built separately in `NumberTheory/ClassGroup`.
+
+The genus-field description is classical; see D. A. Cox, *Primes of the Form x² + ny²*, and
+F. Lemmermeyer, *Reciprocity Laws*.
+
+## Main results
+
+* `TauCeti.Multiquadratic.card_aut_candidateGenusField_over_base`:
+  `|Gal(K_gen / ℚ(√d))| = 2 ^ (t - 1)` when `d` is not a rational square.
+-/
+
+public section
+
+namespace TauCeti.Multiquadratic
+
+/-- **Order of the relative Galois group of the candidate genus field over `ℚ(√d)`.** If the
+squarefree integer `d` is not a rational square, then `K_gen` is Galois over its embedded quadratic
+base `ℚ(√d)` (as an intermediate field of the Galois extension `K_gen / ℚ`), and its relative Galois
+group has order `2 ^ (t - 1)`, where `t = (genusPrimeDiscriminants hd).card`. This is the
+group-order shadow of the summit isomorphism `Gal(K_gen / ℚ(√d)) ≅ Cl(ℚ(√d))/Cl(ℚ(√d))²`. -/
+theorem card_aut_candidateGenusField_over_base {d : ℤ} (hd : Squarefree d)
+    (hnsq : ¬ IsSquare ((d : ℤ) : ℚ)) :
+    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
+      = 2 ^ ((genusPrimeDiscriminants hd).card - 1) := by
+  rw [IsGalois.card_aut_eq_finrank,
+    finrank_candidateGenusField_over_candidateGenusFieldBase hd hnsq]
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
## What

The **relative Galois group order** of the candidate genus field over its `ℚ(√d)` base:

```
theorem card_aut_candidateGenusField_over_base (hd : Squarefree d) (hnsq : ¬ IsSquare (d : ℚ)) :
    Nat.card (candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
      = 2 ^ ((genusPrimeDiscriminants hd).card - 1)
```

New file `CandidateGenusField/RelativeGaloisGroup.lean`.

## Why

`K_gen/ℚ` is abelian Galois with `|Gal(K_gen/ℚ)| = 2^t` (GaloisGroup.lean) and `[K_gen : ℚ(√d)] =
2^(t−1)` (RelativeDegree.lean). Since `K_gen/ℚ` is Galois it is Galois over every intermediate
field, so `|Gal(K_gen/ℚ(√d))| = 2^(t−1)`. This is the **group-order left-hand side of the Layer-3
summit isomorphism** `Gal(K_gen/ℚ(√d)) ≅ Cl/Cl²` — the natural next milestone before the class-group
side enters. The `IsGalois` and `FiniteDimensional` instances over the base are automatic
(`IsGalois.tower_top_intermediateField`, `IntermediateField.finiteDimensional_right`), so the proof
is a one-line `IsGalois.card_aut_eq_finrank` on the merged relative degree.

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"Multiquadratic/candidate-genus-field-relative-galois-card"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGBV1zq6jdgyVT9ZpXrWC
