### PR TITLE
feat(Moments): a finite measure on ℝ≥0 is determined by its Laplace transform

### DIFF
--- a/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
+++ b/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
@@ -1,0 +1,107 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Moments.Determinacy
+import Mathlib.MeasureTheory.Constructions.Polish.Basic
+
+/-!
+# A finite measure on `ℝ≥0` is determined by its Laplace transform
+
+## Main results
+
+* `TauCeti.Measure.ext_of_forall_integral_exp_neg_mul_eq`
+
+## Implementation
+
+The substitution `y = e^{-x}` converts the Laplace transform into a moment sequence: at a natural
+argument `n`, `∫ e^{-n x} dμ = ∫ yⁿ d(μ.map (x ↦ e^{-x}))`. So matching Laplace transforms give
+pushforwards with matching moments, and the pushforwards are moment-determinate because they are
+carried by `(0, 1]` — bounded support makes the exponential-moment hypothesis of
+`Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp` automatic. Finally `x ↦ e^{-x}` is
+injective and measurable between standard Borel spaces, hence a measurable embedding by
+Lusin–Souslin, and `MeasurableEmbedding.map_injective` recovers `μ = ν` from the equal pushforwards.
+
+Only the transform's values at *natural* arguments are used, so the theorem holds a fortiori under
+the stated hypothesis at all nonnegative reals.
+
+This is the uniqueness half of the Bernstein milestone in
+`TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B; the existence half is
+`TauCeti.exists_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone`. The statement
+mentions no complete monotonicity and is about two arbitrary finite measures, which is why it lives
+beside the other determinacy results rather than under `Analysis/CompletelyMonotone/`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set Filter
+open scoped NNReal
+
+namespace TauCeti
+
+/-- The substitution `x ↦ e^{-x}`, which turns Laplace transforms into moments. -/
+private def expNeg (x : ℝ≥0) : ℝ := Real.exp (-(x : ℝ))
+
+@[simp]
+private theorem expNeg_apply (x : ℝ≥0) : expNeg x = Real.exp (-(x : ℝ)) := rfl
+
+private theorem measurable_expNeg : Measurable expNeg :=
+  Real.continuous_exp.comp (continuous_subtype_val.neg) |>.measurable
+
+private theorem injective_expNeg : Function.Injective expNeg := by
+  intro x y hxy
+  exact NNReal.coe_injective (neg_injective (Real.exp_injective hxy))
+
+private theorem measurableEmbedding_expNeg : MeasurableEmbedding expNeg :=
+  measurable_expNeg.measurableEmbedding injective_expNeg
+
+private theorem abs_expNeg_le_one (x : ℝ≥0) : |expNeg x| ≤ 1 := by
+  rw [expNeg_apply, abs_of_pos (Real.exp_pos _), Real.exp_le_one_iff]
+  simp
+
+/-- The pushforward under `x ↦ e^{-x}` has every exponential moment, because it is carried by the
+bounded set `(0, 1]`. -/
+private theorem exists_integrable_exp_map_expNeg (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
+    ∃ a : ℝ, 0 < a ∧ Integrable (fun y => Real.exp (a * |y|)) (μ.map expNeg) := by
+  refine ⟨1, one_pos, ?_⟩
+  have hmeas : AEStronglyMeasurable (fun y : ℝ => Real.exp (1 * |y|)) (μ.map expNeg) :=
+    (Real.continuous_exp.comp (continuous_const.mul continuous_abs)).aestronglyMeasurable
+  rw [integrable_map_measure hmeas measurable_expNeg.aemeasurable]
+  refine Integrable.mono' (integrable_const (Real.exp 1))
+    ((Real.continuous_exp.comp
+      (continuous_const.mul (continuous_abs.comp
+        (Real.continuous_exp.comp continuous_subtype_val.neg)))).aestronglyMeasurable) ?_
+  filter_upwards with x
+  rw [Function.comp_apply, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _), one_mul]
+  exact Real.exp_le_exp.mpr (abs_expNeg_le_one x)
+
+/-- **A finite measure on `ℝ≥0` is determined by its Laplace transform.**
+
+Substituting `y = e^{-x}` turns the Laplace transform at natural arguments into the moment sequence
+of the pushforward, which is carried by `(0, 1]` and so is moment-determinate. -/
+theorem Measure.ext_of_forall_integral_exp_neg_mul_eq {μ ν : Measure ℝ≥0}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ t : ℝ, 0 ≤ t →
+      ∫ x, Real.exp (-t * (x : ℝ)) ∂μ = ∫ x, Real.exp (-t * (x : ℝ)) ∂ν) :
+    μ = ν := by
+  refine measurableEmbedding_expNeg.map_injective ?_
+  refine Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp
+    (exists_integrable_exp_map_expNeg μ) (exists_integrable_exp_map_expNeg ν) fun n => ?_
+  have hpow : ∀ (ρ : Measure ℝ≥0), ∫ y, y ^ n ∂(ρ.map expNeg)
+      = ∫ x, Real.exp (-(n : ℝ) * (x : ℝ)) ∂ρ := by
+    intro ρ
+    have hpowmeas : AEStronglyMeasurable (fun y : ℝ => y ^ n) (ρ.map expNeg) :=
+      (continuous_pow n).aestronglyMeasurable
+    rw [integral_map measurable_expNeg.aemeasurable hpowmeas]
+    refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+    change expNeg x ^ n = Real.exp (-(n : ℝ) * (x : ℝ))
+    rw [expNeg_apply, ← Real.exp_nat_mul]
+    ring_nf
+  rw [hpow, hpow]
+  exact h (n : ℝ) (Nat.cast_nonneg n)
+
+end TauCeti

--- a/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
+++ b/TauCeti/Probability/Moments/LaplaceDeterminacy.lean
@@ -12,7 +12,10 @@ import Mathlib.MeasureTheory.Constructions.Polish.Basic
 
 ## Main results
 
-* `TauCeti.Measure.ext_of_forall_integral_exp_neg_mul_eq`
+* `TauCeti.Measure.ext_of_forall_integral_exp_neg_natCast_mul_eq` — the sharp form: the transform's
+  values at the natural numbers already determine the measure.
+* `TauCeti.Measure.ext_of_forall_integral_exp_neg_mul_eq` — the convenience form, hypothesis at
+  every nonnegative real.
 
 ## Implementation
 
@@ -24,14 +27,15 @@ carried by `(0, 1]` — bounded support makes the exponential-moment hypothesis 
 injective and measurable between standard Borel spaces, hence a measurable embedding by
 Lusin–Souslin, and `MeasurableEmbedding.map_injective` recovers `μ = ν` from the equal pushforwards.
 
-Only the transform's values at *natural* arguments are used, so the theorem holds a fortiori under
-the stated hypothesis at all nonnegative reals.
+Only the transform's values at *natural* arguments are used, which is why the primary statement
+quantifies over `ℕ`; the real-argument form is a one-line corollary for callers that have it.
 
 This is the uniqueness half of the Bernstein milestone in
-`TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B; the existence half is
-`TauCeti.exists_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone`. The statement
-mentions no complete monotonicity and is about two arbitrary finite measures, which is why it lives
-beside the other determinacy results rather than under `Analysis/CompletelyMonotone/`.
+`TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B. The existence half is a separate,
+independent development, and the two are combined into the roadmap's `bernstein` biconditional
+afterwards. Nothing here mentions complete monotonicity — the statement is about two arbitrary
+finite measures — which is why it lives beside the other determinacy results rather than under
+`Analysis/CompletelyMonotone/`.
 -/
 
 public section
@@ -63,8 +67,9 @@ private theorem abs_expNeg_le_one (x : ℝ≥0) : |expNeg x| ≤ 1 := by
   rw [expNeg_apply, abs_of_pos (Real.exp_pos _), Real.exp_le_one_iff]
   simp
 
-/-- The pushforward under `x ↦ e^{-x}` has every exponential moment, because it is carried by the
-bounded set `(0, 1]`. -/
+/-- The pushforward under `x ↦ e^{-x}` has a finite exponential moment: it is carried by `(0, 1]`,
+so `e^{|y|}` is bounded on it. This is the hypothesis
+`Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp` consumes. -/
 private theorem exists_integrable_exp_map_expNeg (μ : Measure ℝ≥0) [IsFiniteMeasure μ] :
     ∃ a : ℝ, 0 < a ∧ Integrable (fun y => Real.exp (a * |y|)) (μ.map expNeg) := by
   refine ⟨1, one_pos, ?_⟩
@@ -79,14 +84,14 @@ private theorem exists_integrable_exp_map_expNeg (μ : Measure ℝ≥0) [IsFinit
   rw [Function.comp_apply, Real.norm_eq_abs, abs_of_pos (Real.exp_pos _), one_mul]
   exact Real.exp_le_exp.mpr (abs_expNeg_le_one x)
 
-/-- **A finite measure on `ℝ≥0` is determined by its Laplace transform.**
+/-- **A finite measure on `ℝ≥0` is determined by its Laplace transform at the natural numbers.**
 
-Substituting `y = e^{-x}` turns the Laplace transform at natural arguments into the moment sequence
-of the pushforward, which is carried by `(0, 1]` and so is moment-determinate. -/
-theorem Measure.ext_of_forall_integral_exp_neg_mul_eq {μ ν : Measure ℝ≥0}
+Substituting `y = e^{-x}` turns the value at `n` into the `n`-th moment of the pushforward, which is
+carried by `(0, 1]` and so is moment-determinate. -/
+theorem Measure.ext_of_forall_integral_exp_neg_natCast_mul_eq {μ ν : Measure ℝ≥0}
     [IsFiniteMeasure μ] [IsFiniteMeasure ν]
-    (h : ∀ t : ℝ, 0 ≤ t →
-      ∫ x, Real.exp (-t * (x : ℝ)) ∂μ = ∫ x, Real.exp (-t * (x : ℝ)) ∂ν) :
+    (h : ∀ n : ℕ, ∫ x, Real.exp (-(n : ℝ) * (x : ℝ)) ∂μ
+      = ∫ x, Real.exp (-(n : ℝ) * (x : ℝ)) ∂ν) :
     μ = ν := by
   refine measurableEmbedding_expNeg.map_injective ?_
   refine Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp
@@ -98,10 +103,19 @@ theorem Measure.ext_of_forall_integral_exp_neg_mul_eq {μ ν : Measure ℝ≥0}
       (continuous_pow n).aestronglyMeasurable
     rw [integral_map measurable_expNeg.aemeasurable hpowmeas]
     refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
-    change expNeg x ^ n = Real.exp (-(n : ℝ) * (x : ℝ))
-    rw [expNeg_apply, ← Real.exp_nat_mul]
+    simp only [expNeg_apply, ← Real.exp_nat_mul]
     ring_nf
   rw [hpow, hpow]
-  exact h (n : ℝ) (Nat.cast_nonneg n)
+  exact h n
+
+/-- **A finite measure on `ℝ≥0` is determined by its Laplace transform.** The convenience form
+taking the hypothesis at every nonnegative real; the proof needs only the natural numbers, so
+`Measure.ext_of_forall_integral_exp_neg_natCast_mul_eq` is the sharper statement. -/
+theorem Measure.ext_of_forall_integral_exp_neg_mul_eq {μ ν : Measure ℝ≥0}
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
+    (h : ∀ t : ℝ, 0 ≤ t →
+      ∫ x, Real.exp (-t * (x : ℝ)) ∂μ = ∫ x, Real.exp (-t * (x : ℝ)) ∂ν) :
+    μ = ν :=
+  Measure.ext_of_forall_integral_exp_neg_natCast_mul_eq fun n => h n (Nat.cast_nonneg n)
 
 end TauCeti


### PR DESCRIPTION
## What

```lean
theorem Measure.ext_of_forall_integral_exp_neg_mul_eq {μ ν : Measure ℝ≥0}
    [IsFiniteMeasure μ] [IsFiniteMeasure ν]
    (h : ∀ t : ℝ, 0 ≤ t →
      ∫ x, Real.exp (-t * (x : ℝ)) ∂μ = ∫ x, Real.exp (-t * (x : ℝ)) ∂ν) :
    μ = ν
```

The **uniqueness half** of the Bernstein milestone in
[`TauCetiRoadmap/OneParameterSemigroups/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/OneParameterSemigroups/README.md),
Part B.

Closes TauCetiProject/TauCetiRoadmap#109

**Independent of the existence half.** The statement is about two arbitrary finite measures and never
mentions complete monotonicity, so this does not depend on #1482 and the two can be reviewed and
merged in either order. The assembled `bernstein` biconditional is a third, purely-assembly PR.

## How

Substituting `y = e^{-x}` turns the Laplace transform at a natural argument into a moment:

`∫ e^{-n x} dμ = ∫ yⁿ d(μ.map (x ↦ e^{-x}))`

The pushforwards are carried by `(0, 1]`, so the exponential-moment hypothesis of the already-landed
`Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp` holds automatically, and matching
moments give equal pushforwards. Since `x ↦ e^{-x}` is injective and measurable between standard
Borel spaces, Lusin–Souslin (`Measurable.measurableEmbedding`) makes it a measurable embedding, and
`MeasurableEmbedding.map_injective` recovers `μ = ν`.

Note the proof consumes only the transform's values at **natural** arguments, so the theorem holds a
fortiori under the stated hypothesis at all nonnegative reals.

## Route not taken

My first attempt built a `StarSubalgebra ℝ (ℝ≥0 →ᵇ ℝ)` from the decaying exponentials and applied
`ext_of_forall_mem_subalgebra_integral_eq_of_polish`, mirroring
`Moments/CompactDeterminacy.lean`. That works — the exponentials are already closed under
multiplication, since `e^{-sx}e^{-tx} = e^{-(s+t)x}` — but it is strictly longer and introduces a new
private algebra plus its separates-points lemma. Going through the existing univariate moment
determinacy adds no new API at all, so that is what landed.

## Placement

Placement follows the statement rather than the application: this is a determinacy result about
finite measures, so it sits beside `Moments/Determinacy.lean` (the analytic/MGF route) and
`Moments/CompactDeterminacy.lean` (the Stone–Weierstrass route), not under
`Analysis/CompletelyMonotone/`.

## Verification

Full `lake build` green. `#print axioms` reports exactly `propext, Classical.choice, Quot.sound`; no
`sorry`.