### PR TITLE
feat: base change the endomorphism ring of an abelian variety

### DIFF
--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
@@ -19,7 +19,7 @@ change respects the pointwise group law on homomorphisms
 
 * `AbelianVariety.End.baseChange`: the ring homomorphism, with
   `AbelianVariety.End.toHom_baseChange` translating it back into base change of morphisms;
-* `AbelianVariety.End.congr_baseChange`: base change commutes with the identification of
+* `AbelianVariety.End.baseChange_congr`: base change commutes with the identification of
   endomorphism rings along an isomorphism of abelian varieties;
 * `AbelianVariety.baseChange_mulBy`: multiplication by `n` base changes to multiplication by `n`.
 
@@ -112,7 +112,7 @@ and `AbelianVariety.baseChangeFunctor_obj` identifies its endpoints with the bas
 conjugating isomorphism is the composite of the three; writing it that way keeps the statement
 type-correct without unfolding the functor. -/
 @[simp]
-lemma congr_baseChange (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] (x : End A) :
+lemma baseChange_congr (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] (x : End A) :
     baseChange B L (congr e x) =
       congr (eqToIso (baseChangeFunctor_obj L A).symm ≪≫ (baseChangeFunctor L).mapIso e ≪≫
         eqToIso (baseChangeFunctor_obj L B)) (baseChange A L x) := by
@@ -127,13 +127,12 @@ end End
 
 variable (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L]
 
-/-- Multiplication by `n` is compatible with extension of the base field.
-
-Proved directly from `AbelianVariety.mulBy_eq_zpow`: `[n]` is the `n`-th power of the identity for
-the pointwise group law, and base change preserves that law and the identity. -/
+/-- Multiplication by `n` is compatible with extension of the base field. -/
 @[simp]
 lemma baseChange_mulBy (n : ℤ) :
     Hom.baseChange (mulBy A n) L = mulBy (A.baseChange L) n := by
+  -- `[n]` is the `n`-th power of the identity for the pointwise group law, and base change
+  -- preserves that law and the identity.
   rw [mulBy_eq_zpow, mulBy_eq_zpow, Hom.baseChange_zpow, Hom.baseChange_id]
 
 end

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
@@ -104,12 +104,21 @@ variable {B : AbelianVariety K}
 
 /-- Base change commutes with conjugation by an isomorphism of abelian varieties: conjugating and
 then extending the base field is the same as extending the base field and conjugating by the
-base-changed isomorphism. -/
+base-changed isomorphism, `CategoryTheory.Functor.mapIso` for `AbelianVariety.baseChangeFunctor`.
+
+The two objects conjugated between are named explicitly because `Functor.mapIso` produces an
+isomorphism `(baseChangeFunctor L).obj A ≅ (baseChangeFunctor L).obj B`, which is the base change
+only definitionally; supplying them keeps the statement — and hence every rewrite with it —
+type-correct without unfolding the functor. -/
 lemma congr_baseChange (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] (x : End A) :
-    baseChange B L (congr e x) = congr (baseChangeIso e L) (baseChange A L x) := by
+    baseChange B L (congr e x) =
+      congr (A := A.baseChange L) (B := B.baseChange L) ((baseChangeFunctor L).mapIso e)
+        (baseChange A L x) := by
   apply toHom_injective
-  simp only [toHom_baseChange, toHom_congr, Hom.baseChange_comp, baseChangeIso_hom,
-    baseChangeIso_inv]
+  rw [toHom_baseChange, toHom_congr, toHom_congr, toHom_baseChange, Hom.baseChange_comp,
+    Hom.baseChange_comp, Functor.mapIso_hom, Functor.mapIso_inv]
+  -- What is left is that the functor's action on morphisms is `Hom.baseChange`, by definition.
+  rfl
 
 end End
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
@@ -1,0 +1,146 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.AbelianVariety.End.Basic
+public import TauCeti.AlgebraicGeometry.AbelianVariety.Hom.BaseChange
+
+/-!
+# Base change of the endomorphism ring of an abelian variety
+
+Extending the base field along `K → L` sends an endomorphism of an abelian variety `A` over `K`
+to an endomorphism of `A.baseChange L`. This assignment is a ring homomorphism
+`AbelianVariety.End.baseChange : End A →+* End (A.baseChange L)`: it is additive because base
+change respects the pointwise group law on homomorphisms
+(`AbelianVariety.Hom.baseChangeMonoidHom`), and multiplicative because it is functorial
+(`AbelianVariety.Hom.baseChange_comp`).
+
+* `AbelianVariety.End.baseChange`: the ring homomorphism, with
+  `AbelianVariety.End.toHom_baseChange` translating it back into base change of morphisms;
+* `AbelianVariety.End.congr_baseChange`: base change commutes with the identification of
+  endomorphism rings along an isomorphism of abelian varieties;
+* `AbelianVariety.baseChange_mulBy` and `AbelianVariety.End.baseChange_ofHom_mulBy`: multiplication
+  by `n` base changes to multiplication by `n`.
+
+The last two statements are the concrete check that the ring homomorphism is the expected one:
+`[n]` is the image of the integer `n` in the endomorphism ring, and a ring homomorphism preserves
+integers, so `[n]` is intrinsic to the abelian variety and does not depend on the base field. That
+is also what a later Layer E statement about `[n]` being an isogeny needs in order to be checked
+after base change to an algebraic closure.
+
+This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
+proper, geometrically connected group scheme over `k`; basic API" and its item "`[n]` as an
+isogeny", together with the base-change compatibility required in the roadmap's end goal: the
+Jacobian's universal property produces homomorphisms of abelian varieties, and comparing them
+after base change is exactly comparing them in the base-changed endomorphism ring.
+
+No external mathematics is vendored. The ring structure is Mathlib's, transported along the
+already-established base-change functoriality of abelian-variety homomorphisms.
+-/
+
+public section
+
+open CategoryTheory AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+namespace AbelianVariety
+
+open scoped Hom
+
+variable {K : Type u} [Field K]
+
+noncomputable section
+
+namespace End
+
+variable (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L]
+
+/-- Extension of the base field along `K → L`, as a ring homomorphism between endomorphism rings.
+
+Addition in an endomorphism ring is the pointwise group law of the abelian variety and
+multiplication is composition, so additivity is `AbelianVariety.Hom.baseChange_mul` and
+multiplicativity is `AbelianVariety.Hom.baseChange_comp` (composition being taken in the reversed
+order in which `AbelianVariety.End` multiplies). -/
+@[expose]
+def baseChange : End A →+* End (A.baseChange L) where
+  toFun x := ofHom (Hom.baseChange (toHom x) L)
+  map_one' := by
+    apply toHom_injective
+    simp only [toHom_ofHom, toHom_one, Hom.baseChange_id]
+  map_mul' x y := by
+    apply toHom_injective
+    simp only [toHom_ofHom, toHom_mul, Hom.baseChange_comp]
+  map_zero' := by
+    apply toHom_injective
+    simp only [toHom_ofHom, toHom_zero, Hom.baseChange_one]
+  map_add' x y := by
+    apply toHom_injective
+    simp only [toHom_ofHom, toHom_add, Hom.baseChange_mul]
+
+variable {A L}
+
+/-- The endomorphism denoted by a base-changed element of the endomorphism ring is the base change
+of the endomorphism denoted by that element. -/
+@[simp]
+lemma toHom_baseChange (x : End A) :
+    toHom (baseChange A L x) = Hom.baseChange (toHom x) L :=
+  toHom_ofHom _
+
+/-- Base change of an endomorphism, read back in the endomorphism ring. -/
+@[simp]
+lemma baseChange_ofHom (f : A ⟶ A) :
+    baseChange A L (ofHom f) = ofHom (Hom.baseChange f L) := by
+  apply toHom_injective
+  simp only [toHom_baseChange, toHom_ofHom]
+
+variable {B : AbelianVariety K}
+
+/-- Base change commutes with conjugation by an isomorphism of abelian varieties: conjugating and
+then extending the base field is the same as extending the base field and conjugating by the
+base-changed isomorphism. -/
+lemma congr_baseChange (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] (x : End A) :
+    baseChange B L (congr e x) = congr (baseChangeIso e L) (baseChange A L x) := by
+  apply toHom_injective
+  simp only [toHom_baseChange, toHom_congr, Hom.baseChange_comp, baseChangeIso_hom,
+    baseChangeIso_inv]
+
+end End
+
+/-! ### Multiplication by `n` -/
+
+variable (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L]
+
+/-- Multiplication by `n` is compatible with extension of the base field.
+
+Proved directly from `AbelianVariety.mulBy_eq_zpow`: `[n]` is the `n`-th power of the identity for
+the pointwise group law, and base change preserves that law and the identity. -/
+@[simp]
+lemma baseChange_mulBy (n : ℤ) :
+    Hom.baseChange (mulBy A n) L = mulBy (A.baseChange L) n := by
+  rw [mulBy_eq_zpow, mulBy_eq_zpow, Hom.baseChange_zpow, Hom.baseChange_id]
+
+/-- The same compatibility read in the endomorphism rings, where it says that
+`AbelianVariety.End.baseChange` preserves the integer `n`. Proving it from Mathlib's
+`map_intCast` rather than from `AbelianVariety.baseChange_mulBy` checks that the ring structure
+transported here really is the one for which `[n]` is the integer `n`.
+
+Deliberately not `@[simp]`: `AbelianVariety.End.ofHom_mulBy` rewrites both sides to an integer
+cast, so this left-hand side is not in `simp` normal form. -/
+lemma End.baseChange_ofHom_mulBy (n : ℤ) :
+    End.baseChange A L (End.ofHom (mulBy A n)) = End.ofHom (mulBy (A.baseChange L) n) := by
+  rw [End.ofHom_mulBy, End.ofHom_mulBy, map_intCast]
+
+end
+
+end AbelianVariety
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/End/BaseChange.lean
@@ -21,14 +21,13 @@ change respects the pointwise group law on homomorphisms
   `AbelianVariety.End.toHom_baseChange` translating it back into base change of morphisms;
 * `AbelianVariety.End.congr_baseChange`: base change commutes with the identification of
   endomorphism rings along an isomorphism of abelian varieties;
-* `AbelianVariety.baseChange_mulBy` and `AbelianVariety.End.baseChange_ofHom_mulBy`: multiplication
-  by `n` base changes to multiplication by `n`.
+* `AbelianVariety.baseChange_mulBy`: multiplication by `n` base changes to multiplication by `n`.
 
-The last two statements are the concrete check that the ring homomorphism is the expected one:
-`[n]` is the image of the integer `n` in the endomorphism ring, and a ring homomorphism preserves
-integers, so `[n]` is intrinsic to the abelian variety and does not depend on the base field. That
-is also what a later Layer E statement about `[n]` being an isogeny needs in order to be checked
-after base change to an algebraic closure.
+The last statement is the concrete check that the ring homomorphism is the expected one: `[n]` is
+the image of the integer `n` in the endomorphism ring, and a ring homomorphism preserves integers,
+so `[n]` is intrinsic to the abelian variety and does not depend on the base field. That is also
+what a later Layer E statement about `[n]` being an isogeny needs in order to be checked after
+base change to an algebraic closure.
 
 This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth,
 proper, geometrically connected group scheme over `k`; basic API" and its item "`[n]` as an
@@ -67,8 +66,10 @@ variable (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L]
 Addition in an endomorphism ring is the pointwise group law of the abelian variety and
 multiplication is composition, so additivity is `AbelianVariety.Hom.baseChange_mul` and
 multiplicativity is `AbelianVariety.Hom.baseChange_comp` (composition being taken in the reversed
-order in which `AbelianVariety.End` multiplies). -/
-@[expose]
+order in which `AbelianVariety.End` multiplies).
+
+The action is characterized by `AbelianVariety.End.toHom_baseChange` and
+`AbelianVariety.End.baseChange_ofHom`, so the implementation is not exposed. -/
 def baseChange : End A →+* End (A.baseChange L) where
   toFun x := ofHom (Hom.baseChange (toHom x) L)
   map_one' := by
@@ -106,19 +107,19 @@ variable {B : AbelianVariety K}
 then extending the base field is the same as extending the base field and conjugating by the
 base-changed isomorphism, `CategoryTheory.Functor.mapIso` for `AbelianVariety.baseChangeFunctor`.
 
-The two objects conjugated between are named explicitly because `Functor.mapIso` produces an
-isomorphism `(baseChangeFunctor L).obj A ≅ (baseChangeFunctor L).obj B`, which is the base change
-only definitionally; supplying them keeps the statement — and hence every rewrite with it —
+`Functor.mapIso` produces an isomorphism `(baseChangeFunctor L).obj A ≅ (baseChangeFunctor L).obj B`
+and `AbelianVariety.baseChangeFunctor_obj` identifies its endpoints with the base changes, so the
+conjugating isomorphism is the composite of the three; writing it that way keeps the statement
 type-correct without unfolding the functor. -/
+@[simp]
 lemma congr_baseChange (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] (x : End A) :
     baseChange B L (congr e x) =
-      congr (A := A.baseChange L) (B := B.baseChange L) ((baseChangeFunctor L).mapIso e)
-        (baseChange A L x) := by
+      congr (eqToIso (baseChangeFunctor_obj L A).symm ≪≫ (baseChangeFunctor L).mapIso e ≪≫
+        eqToIso (baseChangeFunctor_obj L B)) (baseChange A L x) := by
   apply toHom_injective
-  rw [toHom_baseChange, toHom_congr, toHom_congr, toHom_baseChange, Hom.baseChange_comp,
-    Hom.baseChange_comp, Functor.mapIso_hom, Functor.mapIso_inv]
-  -- What is left is that the functor's action on morphisms is `Hom.baseChange`, by definition.
-  rfl
+  -- Both sides unfold to a conjugate of `Hom.baseChange (toHom x) L`, the transport isomorphisms
+  -- of `baseChangeFunctor_obj` cancelling because they are equalities of the same object.
+  simp
 
 end End
 
@@ -134,17 +135,6 @@ the pointwise group law, and base change preserves that law and the identity. -/
 lemma baseChange_mulBy (n : ℤ) :
     Hom.baseChange (mulBy A n) L = mulBy (A.baseChange L) n := by
   rw [mulBy_eq_zpow, mulBy_eq_zpow, Hom.baseChange_zpow, Hom.baseChange_id]
-
-/-- The same compatibility read in the endomorphism rings, where it says that
-`AbelianVariety.End.baseChange` preserves the integer `n`. Proving it from Mathlib's
-`map_intCast` rather than from `AbelianVariety.baseChange_mulBy` checks that the ring structure
-transported here really is the one for which `[n]` is the integer `n`.
-
-Deliberately not `@[simp]`: `AbelianVariety.End.ofHom_mulBy` rewrites both sides to an integer
-cast, so this left-hand side is not in `simp` normal form. -/
-lemma End.baseChange_ofHom_mulBy (n : ℤ) :
-    End.baseChange A L (End.ofHom (mulBy A n)) = End.ofHom (mulBy (A.baseChange L) n) := by
-  rw [End.ofHom_mulBy, End.ofHom_mulBy, map_intCast]
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -151,26 +151,27 @@ lemma baseChangeFunctor_map {A B : AbelianVariety K} (L : Type u) [Field L] [Alg
 /-! ### Compatibility with the pointwise group law
 
 Base change is a homomorphism for the pointwise group law of
-`TauCeti.AlgebraicGeometry.AbelianVariety.MorphismGroup`, not merely a functor. The two
+`TauCeti.AlgebraicGeometry.AbelianVariety.MorphismGroup`, not merely a functor. The two private
 instances below say that the transport isomorphism `eqToHom (baseChange_toOver A L)` between the
 group scheme underlying `A.baseChange L` and the pullback of the one underlying `A` is an
-isomorphism of monoid objects; everything else follows from Mathlib's multiplicativity of a
-monoidal functor on morphisms into a monoid object. -/
+isomorphism of monoid objects; they are proof support for the two lemmas that follow, which
+together with Mathlib's multiplicativity of a monoidal functor on morphisms into a monoid object
+give the public interface. -/
 
 open scoped Hom
 
 /-- The transport isomorphism identifying the group scheme underlying `A.baseChange L` with the
 pullback of the group scheme underlying `A` preserves the unit and the multiplication: by
 construction, those of the base change *are* the pulled-back ones. -/
-instance isMonHom_eqToHom_baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L]
+private instance isMonHom_eqToHom_baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L]
     [Algebra K L] :
     IsMonHom (eqToHom (baseChange_toOver A L)) where
   one_hom := by rw [baseChange_one, Functor.obj.η_def]
   mul_hom := by rw [baseChange_mul, Functor.obj.μ_def]
 
 /-- The inverse transport isomorphism is a homomorphism of monoid objects as well. -/
-instance isMonHom_eqToHom_baseChange_toOver_symm (A : AbelianVariety K) (L : Type u) [Field L]
-    [Algebra K L] :
+private instance isMonHom_eqToHom_baseChange_toOver_symm (A : AbelianVariety K) (L : Type u)
+    [Field L] [Algebra K L] :
     IsMonHom (eqToHom (baseChange_toOver A L).symm) :=
   haveI : IsMonHom (eqToIso (baseChange_toOver A L)).hom :=
     isMonHom_eqToHom_baseChange_toOver A L

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -125,9 +125,8 @@ lemma Hom.baseChange_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C)
 
 /-- Extension of the base field defines a functor between the categories of abelian varieties.
 
-Exposed so that `(baseChangeFunctor L).obj A` reduces to `A.baseChange L`, the form the rest of
-the base-change API is stated in. -/
-@[expose]
+Its action is characterized by `AbelianVariety.baseChangeFunctor_obj` and
+`AbelianVariety.baseChangeFunctor_map`. -/
 noncomputable def baseChangeFunctor (L : Type u) [Field L] [Algebra K L] :
     AbelianVariety K ⥤ AbelianVariety L where
   obj A := A.baseChange L

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.AbelianVariety.Hom.Basic
+public import TauCeti.AlgebraicGeometry.AbelianVariety.MorphismGroup
 
 /-!
 # Base change of abelian-variety homomorphisms
@@ -14,6 +14,14 @@ extension `K → L`, pullback from schemes over `Spec K` to schemes over `Spec L
 abelian-variety homomorphism `A ⟶ B` to a homomorphism `A.baseChange L ⟶ B.baseChange L`.
 These maps assemble into `AbelianVariety.baseChangeFunctor`.
 
+Base change also respects the pointwise group law on homomorphisms of
+`TauCeti.AlgebraicGeometry.AbelianVariety.MorphismGroup`:
+`AbelianVariety.Hom.baseChangeMonoidHom` bundles it as a homomorphism
+`(A ⟶ B) →* (A.baseChange L ⟶ B.baseChange L)` of the homomorphism groups, with
+`AbelianVariety.Hom.baseChange_one`, `baseChange_mul`, `baseChange_inv`, `baseChange_div` and
+`baseChange_zpow` its unbundled forms. `AbelianVariety.baseChangeIso` is the action of base change
+on isomorphisms, which the functor supplies but which is worth having in `Iso` form.
+
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E's basic
 abelian-variety API and the base-change compatibility required in the end goal. It will allow
 the Jacobian base-change comparison to be stated and used as an isomorphism of abelian varieties,
@@ -21,7 +29,8 @@ not merely as an isomorphism of their underlying schemes.
 
 No external mathematics is vendored. The implementation uses Mathlib's lax monoidal pullback
 functor on `Over` categories, whose action on group objects proves that the pulled-back morphism
-preserves the unit and multiplication.
+preserves the unit and multiplication, together with Mathlib's multiplicativity of a monoidal
+functor on morphisms into a monoid object (`CategoryTheory.Functor.map_mul`).
 -/
 
 public section
@@ -137,6 +146,122 @@ lemma baseChangeFunctor_map {A B : AbelianVariety K} (L : Type u) [Field L] [Alg
       eqToHom (baseChangeFunctor_obj L A) ≫ Hom.baseChange f L ≫
         eqToHom (baseChangeFunctor_obj L B).symm :=
   (rfl)
+
+/-! ### Compatibility with the pointwise group law
+
+Base change is a homomorphism for the pointwise group law of
+`TauCeti.AlgebraicGeometry.AbelianVariety.MorphismGroup`, not merely a functor. The two
+instances below say that the transport isomorphism `eqToHom (baseChange_toOver A L)` between the
+group scheme underlying `A.baseChange L` and the pullback of the one underlying `A` is an
+isomorphism of monoid objects; everything else follows from Mathlib's multiplicativity of a
+monoidal functor on morphisms into a monoid object. -/
+
+open scoped Hom
+
+/-- The transport isomorphism identifying the group scheme underlying `A.baseChange L` with the
+pullback of the group scheme underlying `A` preserves the unit and the multiplication: by
+construction, those of the base change *are* the pulled-back ones. -/
+instance isMonHom_eqToHom_baseChange_toOver (A : AbelianVariety K) (L : Type u) [Field L]
+    [Algebra K L] :
+    IsMonHom (eqToHom (baseChange_toOver A L)) where
+  one_hom := by rw [baseChange_one, Functor.obj.η_def]
+  mul_hom := by rw [baseChange_mul, Functor.obj.μ_def]
+
+/-- The inverse transport isomorphism is a homomorphism of monoid objects as well. -/
+instance isMonHom_eqToHom_baseChange_toOver_symm (A : AbelianVariety K) (L : Type u) [Field L]
+    [Algebra K L] :
+    IsMonHom (eqToHom (baseChange_toOver A L).symm) :=
+  haveI : IsMonHom (eqToIso (baseChange_toOver A L)).hom :=
+    isMonHom_eqToHom_baseChange_toOver A L
+  inferInstanceAs (IsMonHom (eqToIso (baseChange_toOver A L)).inv)
+
+/-- Base change carries the identity element of the group of homomorphisms — the homomorphism
+factoring through the unit section — to the identity element. -/
+@[simp]
+lemma Hom.baseChange_one (A B : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChange (1 : A ⟶ B) L = 1 := by
+  apply Hom.toOverFunctor.map_injective
+  simp only [Hom.toOverHom_baseChange, Hom.toOverHom_one, Functor.map_one, MonObj.one_comp,
+    MonObj.comp_one]
+
+/-- Base change is multiplicative for the pointwise group law: pulling back the pointwise product
+of two homomorphisms gives the pointwise product of their pullbacks. -/
+@[simp]
+lemma Hom.baseChange_mul {A B : AbelianVariety K} (f g : A ⟶ B)
+    (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChange (f * g) L = Hom.baseChange f L * Hom.baseChange g L := by
+  apply Hom.toOverFunctor.map_injective
+  simp only [Hom.toOverHom_baseChange, Hom.toOverHom_mul, Functor.map_mul, MonObj.mul_comp,
+    MonObj.comp_mul]
+
+/-- Base change along a field extension, as a homomorphism of the groups of homomorphisms of
+abelian varieties. -/
+def Hom.baseChangeMonoidHom (A B : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    (A ⟶ B) →* (A.baseChange L ⟶ B.baseChange L) where
+  toFun f := Hom.baseChange f L
+  map_one' := Hom.baseChange_one A B L
+  map_mul' f g := Hom.baseChange_mul f g L
+
+@[simp]
+lemma Hom.baseChangeMonoidHom_apply {A B : AbelianVariety K} (f : A ⟶ B)
+    (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChangeMonoidHom A B L f = Hom.baseChange f L :=
+  (rfl)
+
+/-- Base change preserves pointwise inverses of homomorphisms. -/
+@[simp]
+lemma Hom.baseChange_inv {A B : AbelianVariety K} (f : A ⟶ B)
+    (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChange f⁻¹ L = (Hom.baseChange f L)⁻¹ :=
+  map_inv (Hom.baseChangeMonoidHom A B L) f
+
+/-- Base change preserves pointwise quotients of homomorphisms. -/
+@[simp]
+lemma Hom.baseChange_div {A B : AbelianVariety K} (f g : A ⟶ B)
+    (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChange (f / g) L = Hom.baseChange f L / Hom.baseChange g L :=
+  map_div (Hom.baseChangeMonoidHom A B L) f g
+
+/-- Base change preserves pointwise integer powers of homomorphisms. -/
+@[simp]
+lemma Hom.baseChange_zpow {A B : AbelianVariety K} (f : A ⟶ B) (n : ℤ)
+    (L : Type u) [Field L] [Algebra K L] :
+    Hom.baseChange (f ^ n) L = Hom.baseChange f L ^ n :=
+  map_zpow (Hom.baseChangeMonoidHom A B L) f n
+
+/-! ### Base change of an isomorphism -/
+
+/-- Base change of an isomorphism of abelian varieties along a field extension `K → L`. -/
+@[expose, simps]
+def baseChangeIso {A B : AbelianVariety K} (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] :
+    A.baseChange L ≅ B.baseChange L where
+  hom := Hom.baseChange e.hom L
+  inv := Hom.baseChange e.inv L
+  hom_inv_id := by rw [← Hom.baseChange_comp, e.hom_inv_id, Hom.baseChange_id]
+  inv_hom_id := by rw [← Hom.baseChange_comp, e.inv_hom_id, Hom.baseChange_id]
+
+/-- Base change of the identity isomorphism is the identity. -/
+@[simp]
+lemma baseChangeIso_refl (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
+    baseChangeIso (Iso.refl A) L = Iso.refl (A.baseChange L) := by
+  apply Iso.ext
+  simp only [baseChangeIso_hom, Iso.refl_hom, Hom.baseChange_id]
+
+/-- Base change commutes with inverting an isomorphism. -/
+@[simp]
+lemma baseChangeIso_symm {A B : AbelianVariety K} (e : A ≅ B)
+    (L : Type u) [Field L] [Algebra K L] :
+    baseChangeIso e.symm L = (baseChangeIso e L).symm := by
+  apply Iso.ext
+  simp only [baseChangeIso_hom, Iso.symm_hom, baseChangeIso_inv]
+
+/-- Base change commutes with composing isomorphisms. -/
+@[simp]
+lemma baseChangeIso_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C)
+    (L : Type u) [Field L] [Algebra K L] :
+    baseChangeIso (e.trans f) L = (baseChangeIso e L).trans (baseChangeIso f L) := by
+  apply Iso.ext
+  simp only [baseChangeIso_hom, Iso.trans_hom, Hom.baseChange_comp]
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -19,8 +19,8 @@ Base change also respects the pointwise group law on homomorphisms of
 `AbelianVariety.Hom.baseChangeMonoidHom` bundles it as a homomorphism
 `(A ⟶ B) →* (A.baseChange L ⟶ B.baseChange L)` of the homomorphism groups, with
 `AbelianVariety.Hom.baseChange_one`, `baseChange_mul`, `baseChange_inv`, `baseChange_div` and
-`baseChange_zpow` its unbundled forms. `AbelianVariety.baseChangeIso` is the action of base change
-on isomorphisms, which the functor supplies but which is worth having in `Iso` form.
+`baseChange_zpow` its unbundled forms. `AbelianVariety.baseChangeIso` is the functor's action on
+isomorphisms, `CategoryTheory.Functor.mapIso`, restated at the types the rest of this API uses.
 
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E's basic
 abelian-variety API and the base-change compatibility required in the end goal. It will allow
@@ -125,7 +125,10 @@ lemma Hom.baseChange_comp {A B C : AbelianVariety K} (f : A ⟶ B) (g : B ⟶ C)
   simp [Category.assoc]
 
 /-- Extension of the base field defines a functor between the categories of abelian varieties.
--/
+
+Exposed so that `(baseChangeFunctor L).obj A` reduces to `A.baseChange L`, the form the rest of
+the base-change API is stated in. -/
+@[expose]
 noncomputable def baseChangeFunctor (L : Type u) [Field L] [Algebra K L] :
     AbelianVariety K ⥤ AbelianVariety L where
   obj A := A.baseChange L
@@ -231,37 +234,32 @@ lemma Hom.baseChange_zpow {A B : AbelianVariety K} (f : A ⟶ B) (n : ℤ)
 
 /-! ### Base change of an isomorphism -/
 
-/-- Base change of an isomorphism of abelian varieties along a field extension `K → L`. -/
-@[expose, simps]
+/-- Base change of an isomorphism of abelian varieties along a field extension `K → L`.
+
+This is nothing but `AbelianVariety.baseChangeFunctor` acting on isomorphisms; it is worth naming
+only because `Functor.mapIso` produces the type
+`(baseChangeFunctor L).obj A ≅ (baseChangeFunctor L).obj B`, whereas the rest of the base-change
+API — and the `simp` lemmas keyed on it — is stated for `A.baseChange L` and `B.baseChange L`.
+Compatibility with `Iso.refl`, `Iso.symm` and `Iso.trans` is Mathlib's `Functor.mapIso_refl`,
+`Functor.mapIso_symm` and `Functor.mapIso_trans`, applied through this definitional equality. -/
+@[expose]
 def baseChangeIso {A B : AbelianVariety K} (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] :
-    A.baseChange L ≅ B.baseChange L where
-  hom := Hom.baseChange e.hom L
-  inv := Hom.baseChange e.inv L
-  hom_inv_id := by rw [← Hom.baseChange_comp, e.hom_inv_id, Hom.baseChange_id]
-  inv_hom_id := by rw [← Hom.baseChange_comp, e.inv_hom_id, Hom.baseChange_id]
+    A.baseChange L ≅ B.baseChange L :=
+  (baseChangeFunctor L).mapIso e
 
-/-- Base change of the identity isomorphism is the identity. -/
+/-- The forward map of a base-changed isomorphism is the base change of its forward map. -/
 @[simp]
-lemma baseChangeIso_refl (A : AbelianVariety K) (L : Type u) [Field L] [Algebra K L] :
-    baseChangeIso (Iso.refl A) L = Iso.refl (A.baseChange L) := by
-  apply Iso.ext
-  simp only [baseChangeIso_hom, Iso.refl_hom, Hom.baseChange_id]
-
-/-- Base change commutes with inverting an isomorphism. -/
-@[simp]
-lemma baseChangeIso_symm {A B : AbelianVariety K} (e : A ≅ B)
+lemma baseChangeIso_hom {A B : AbelianVariety K} (e : A ≅ B)
     (L : Type u) [Field L] [Algebra K L] :
-    baseChangeIso e.symm L = (baseChangeIso e L).symm := by
-  apply Iso.ext
-  simp only [baseChangeIso_hom, Iso.symm_hom, baseChangeIso_inv]
+    (baseChangeIso e L).hom = Hom.baseChange e.hom L :=
+  (rfl)
 
-/-- Base change commutes with composing isomorphisms. -/
+/-- The inverse map of a base-changed isomorphism is the base change of its inverse map. -/
 @[simp]
-lemma baseChangeIso_trans {A B C : AbelianVariety K} (e : A ≅ B) (f : B ≅ C)
+lemma baseChangeIso_inv {A B : AbelianVariety K} (e : A ≅ B)
     (L : Type u) [Field L] [Algebra K L] :
-    baseChangeIso (e.trans f) L = (baseChangeIso e L).trans (baseChangeIso f L) := by
-  apply Iso.ext
-  simp only [baseChangeIso_hom, Iso.trans_hom, Hom.baseChange_comp]
+    (baseChangeIso e L).inv = Hom.baseChange e.inv L :=
+  (rfl)
 
 end
 

--- a/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
+++ b/TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean
@@ -19,8 +19,7 @@ Base change also respects the pointwise group law on homomorphisms of
 `AbelianVariety.Hom.baseChangeMonoidHom` bundles it as a homomorphism
 `(A ⟶ B) →* (A.baseChange L ⟶ B.baseChange L)` of the homomorphism groups, with
 `AbelianVariety.Hom.baseChange_one`, `baseChange_mul`, `baseChange_inv`, `baseChange_div` and
-`baseChange_zpow` its unbundled forms. `AbelianVariety.baseChangeIso` is the functor's action on
-isomorphisms, `CategoryTheory.Functor.mapIso`, restated at the types the rest of this API uses.
+`baseChange_zpow` its unbundled forms.
 
 The construction advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E's basic
 abelian-variety API and the base-change compatibility required in the end goal. It will allow
@@ -231,35 +230,6 @@ lemma Hom.baseChange_zpow {A B : AbelianVariety K} (f : A ⟶ B) (n : ℤ)
     (L : Type u) [Field L] [Algebra K L] :
     Hom.baseChange (f ^ n) L = Hom.baseChange f L ^ n :=
   map_zpow (Hom.baseChangeMonoidHom A B L) f n
-
-/-! ### Base change of an isomorphism -/
-
-/-- Base change of an isomorphism of abelian varieties along a field extension `K → L`.
-
-This is nothing but `AbelianVariety.baseChangeFunctor` acting on isomorphisms; it is worth naming
-only because `Functor.mapIso` produces the type
-`(baseChangeFunctor L).obj A ≅ (baseChangeFunctor L).obj B`, whereas the rest of the base-change
-API — and the `simp` lemmas keyed on it — is stated for `A.baseChange L` and `B.baseChange L`.
-Compatibility with `Iso.refl`, `Iso.symm` and `Iso.trans` is Mathlib's `Functor.mapIso_refl`,
-`Functor.mapIso_symm` and `Functor.mapIso_trans`, applied through this definitional equality. -/
-@[expose]
-def baseChangeIso {A B : AbelianVariety K} (e : A ≅ B) (L : Type u) [Field L] [Algebra K L] :
-    A.baseChange L ≅ B.baseChange L :=
-  (baseChangeFunctor L).mapIso e
-
-/-- The forward map of a base-changed isomorphism is the base change of its forward map. -/
-@[simp]
-lemma baseChangeIso_hom {A B : AbelianVariety K} (e : A ≅ B)
-    (L : Type u) [Field L] [Algebra K L] :
-    (baseChangeIso e L).hom = Hom.baseChange e.hom L :=
-  (rfl)
-
-/-- The inverse map of a base-changed isomorphism is the base change of its inverse map. -/
-@[simp]
-lemma baseChangeIso_inv {A B : AbelianVariety K} (e : A ≅ B)
-    (L : Type u) [Field L] [Algebra K L] :
-    (baseChangeIso e L).inv = Hom.baseChange e.inv L :=
-  (rfl)
 
 end
 


### PR DESCRIPTION
This PR makes extension of the base field a ring homomorphism on endomorphism rings of abelian varieties. For an abelian variety `A` over a field `K` and a field extension `K → L`, `AbelianVariety.End.baseChange : End A →+* End (A.baseChange L)` sends an endomorphism to its pullback; it is additive because base change respects the pointwise group law on homomorphisms, and multiplicative because base change is functorial. As the concrete check that the transported ring structure is the expected one, `AbelianVariety.baseChange_mulBy` proves that `[n]` base changes to `[n]`, directly from `mulBy_eq_zpow`.

Getting there needs the group-law half first, which is added to the existing `TauCeti/AlgebraicGeometry/AbelianVariety/Hom/BaseChange.lean`. The two new instances there record that the transport isomorphism `eqToHom (baseChange_toOver A L)`, identifying the group scheme underlying `A.baseChange L` with the pullback of the group scheme underlying `A`, is an isomorphism of monoid objects — by construction the unit and multiplication of the base change *are* the pulled-back ones, which is exactly what the already-merged `baseChange_one` and `baseChange_mul` say. With those in place, Mathlib's `CategoryTheory.Functor.map_mul` for a monoidal functor gives `Hom.baseChange_one` and `Hom.baseChange_mul`, bundled as `Hom.baseChangeMonoidHom : (A ⟶ B) →* (A.baseChange L ⟶ B.baseChange L)`, from which the inverse, quotient and integer-power forms follow. On top of that, `End.congr_baseChange` says that base change commutes with conjugating an endomorphism ring along an isomorphism of abelian varieties; the base-changed isomorphism there is Mathlib's `CategoryTheory.Functor.mapIso` applied to `baseChangeFunctor`, used directly. That import edge is the only change to the existing file's header: it now imports `AbelianVariety.MorphismGroup`, where the pointwise group law lives.

This advances `TauCetiRoadmap/JacobianChallenge/README.md`, Layer E, "Abelian variety = smooth, proper, geometrically connected group scheme over `k`; basic API" and its item "`[n]` as an isogeny", together with the base-change compatibility required in the roadmap's end goal (`jacobian_baseChange`): the Jacobian's universal property produces homomorphisms of abelian varieties, and comparing them after base change is comparing them in the base-changed endomorphism ring. It builds on the merged `AbelianVariety.baseChange`, `Hom.baseChange`/`baseChangeFunctor`, `Hom.instCommGroup` and `End`.

No formalization is vendored. The mathematics is Mathlib's: `CategoryTheory.Functor.map_mul` and `Functor.map_one` for a monoidal functor acting on morphisms into a monoid object, `MonObj.mul_comp`/`MonObj.comp_mul`, the lax monoidal structure on `Over.pullback`, and `map_inv`/`map_div`/`map_zpow` for bundled homomorphisms.

`lake build`, `lake exe axioms` and `lake exe module-system` are green; the environment linters report no new violations.

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"abelianvariety-end-basechange"}-->

🤖 Prepared with Claude Code


