### PR TITLE
docs(Conformal/Montel): Vitali is proved, update the L1 status note

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Montel.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel.lean
@@ -16,7 +16,8 @@ A locally bounded family of holomorphic functions on an open set `Ω ⊆ ℂ` is
 sequence drawn from it has a subsequence converging locally uniformly on `Ω`, and the limit is
 again holomorphic. This is the **Montel selection** component of layer **L1 (normal families /
 Montel)** of the conformal-mapping roadmap, and the compactness engine the Riemann mapping theorem
-runs on. L1 also lists Vitali's theorem, which is not proved here, so the layer is not complete.
+runs on. The other component L1 lists, Vitali's theorem, is proved in `Conformal/Vitali.lean`,
+which applies the selection theorem below.
 
 The equicontinuity half is already available in `Conformal/NormalFamilies.lean`
 (`TauCeti.IsLocallyBoundedOn.equicontinuousOn`, from Cauchy's estimate); what is added here is the


### PR DESCRIPTION
Documentation-only fix to a stale claim in `TauCeti/Analysis/Complex/Conformal/Montel.lean`.

The module docstring closed its roadmap paragraph with:

> L1 also lists Vitali's theorem, which is not proved here, so the layer is not complete.

That was true when `Montel.lean` landed (#1226), but Vitali has since been proved in #1319 as
`TauCeti/Analysis/Complex/Conformal/Vitali.lean` — which `public import`s this file and proves
`TauCeti.vitali` by applying `TauCeti.montel` twice. So the sentence now asserts something false
about the state of the library, and a reader of `Montel.lean` is pointed away from the file that
consumes it.

It is replaced by a pointer to that file:

> The other component L1 lists, Vitali's theorem, is proved in `Conformal/Vitali.lean`, which
> applies the selection theorem below.

Deliberately a pointer rather than a "layer L1 is now complete" claim: completeness of a roadmap
layer is the roadmap's verdict to make, and a docstring that asserts it would go stale the same
way the old sentence did.

**Roadmap:** `TauCetiRoadmap/ConformalMapping/README.md`, layer **L1 — normal families / Montel**.
Per `.claude/CLAUDE.md`, documenting and correcting existing code is in scope without a new roadmap
entry; this PR adds no declaration and changes no statement or proof.

Verified with `lake build TauCeti.Analysis.Complex.Conformal.Montel
TauCeti.Analysis.Complex.Conformal.Vitali` on `d6ecf7c`.
