### PR TITLE
feat(ClassGroup): inversion is trivial on Cl/Cl²

### DIFF
--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
@@ -41,7 +41,8 @@ names around it. The cardinality identity is still expressed through the squarin
   trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
-  `elementaryTwoQuotientMk_prod` record its additivity.
+  `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq`
+  records that inversion is trivial in the quotient (`mk g⁻¹ = mk g`).
 * `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
   class map is surjective, and two elements have the same class iff they differ by a square.
 * `TauCeti.elementaryTwoQuotientLiftEquiv` and `TauCeti.elementaryTwoQuotientLinearLiftEquiv`: the
@@ -153,6 +154,14 @@ protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMo
 @[simp] theorem elementaryTwoQuotientMk_inv (g : G) :
     elementaryTwoQuotientMk g⁻¹ = -elementaryTwoQuotientMk g := by
   simp only [elementaryTwoQuotientMk, ofMul_inv, map_neg]
+
+/-- Inversion is trivial in `G / G²`: the class of `g⁻¹` equals the class of `g`, since the
+quotient is `2`-torsion. This is the companion of `elementaryTwoQuotientMk_inv` in the form used
+when an inverting endomorphism acts trivially on the quotient (cf.
+`elementaryTwoQuotientMap_apply_eq_self_of_apply_eq_inv`). -/
+theorem elementaryTwoQuotientMk_inv_eq (g : G) :
+    elementaryTwoQuotientMk g⁻¹ = elementaryTwoQuotientMk g := by
+  rw [elementaryTwoQuotientMk_inv, ZModModule.neg_eq_self]
 
 /-- The class map to `G / G²` sends quotients to differences. -/
 @[simp] theorem elementaryTwoQuotientMk_div (g h : G) :

--- a/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
+++ b/TauCeti/Algebra/Group/ElementaryTwoQuotient/Basic.lean
@@ -41,7 +41,7 @@ names around it. The cardinality identity is still expressed through the squarin
   trivial iff the element is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
-  `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq`
+  `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq_self`
   records that inversion is trivial in the quotient (`mk g⁻¹ = mk g`).
 * `TauCeti.elementaryTwoQuotientMk_surjective` and `TauCeti.elementaryTwoQuotientMk_eq_iff`: the
   class map is surjective, and two elements have the same class iff they differ by a square.
@@ -159,7 +159,7 @@ protected def elementaryTwoQuotientLinearLiftEquiv [AddCommGroup H] [Module (ZMo
 quotient is `2`-torsion. This is the companion of `elementaryTwoQuotientMk_inv` in the form used
 when an inverting endomorphism acts trivially on the quotient (cf.
 `elementaryTwoQuotientMap_apply_eq_self_of_apply_eq_inv`). -/
-theorem elementaryTwoQuotientMk_inv_eq (g : G) :
+theorem elementaryTwoQuotientMk_inv_eq_self (g : G) :
     elementaryTwoQuotientMk g⁻¹ = elementaryTwoQuotientMk g := by
   rw [elementaryTwoQuotientMk_inv, ZModModule.neg_eq_self]
 

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -34,9 +34,8 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
   of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
-  `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq` records
-  that inversion is trivial in the quotient; `elementaryTwoQuotientMk_surjective` and
-  `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
+  `elementaryTwoQuotientMk_prod` record its additivity, while `elementaryTwoQuotientMk_surjective`
+  and `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
 * `TauCeti.ClassGroup.elementaryTwoQuotientCongr`: a multiplicative equivalence of class groups
   induces a `ZMod 2`-linear equivalence of their elementary-2 quotients.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
@@ -81,13 +80,6 @@ noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : ElementaryTwoQuot
 @[simp] theorem elementaryTwoQuotientMk_inv (C : ClassGroup R) :
     elementaryTwoQuotientMk R C⁻¹ = -elementaryTwoQuotientMk R C :=
   TauCeti.elementaryTwoQuotientMk_inv C
-
-/-- Inversion is trivial on `Cl(R)/Cl(R)²`: the class of an inverse ideal equals the class itself,
-since the elementary two-quotient is `2`-torsion. The class-group instance of the general
-`TauCeti.elementaryTwoQuotientMk_inv_eq`. -/
-theorem elementaryTwoQuotientMk_inv_eq (C : ClassGroup R) :
-    elementaryTwoQuotientMk R C⁻¹ = elementaryTwoQuotientMk R C :=
-  TauCeti.elementaryTwoQuotientMk_inv_eq C
 
 /-- The class map to `Cl(R)/Cl(R)²` sends quotients to differences. -/
 @[simp] theorem elementaryTwoQuotientMk_div (C D : ClassGroup R) :

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -35,7 +35,7 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
   `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
   `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq` records
-  that inversion is trivial (`[I⁻¹] = [I]` in the quotient); `elementaryTwoQuotientMk_surjective` and
+  that inversion is trivial in the quotient; `elementaryTwoQuotientMk_surjective` and
   `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
 * `TauCeti.ClassGroup.elementaryTwoQuotientCongr`: a multiplicative equivalence of class groups
   induces a `ZMod 2`-linear equivalence of their elementary-2 quotients.

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -81,6 +81,15 @@ noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : ElementaryTwoQuot
     elementaryTwoQuotientMk R C⁻¹ = -elementaryTwoQuotientMk R C :=
   TauCeti.elementaryTwoQuotientMk_inv C
 
+/-- **Inversion is trivial on `Cl(R)/Cl(R)²`.** The elementary two-quotient is `2`-torsion, so the
+class of an inverse ideal equals the class itself. This is the genus-theoretic fact that an
+automorphism inverting ideal classes — such as conjugation on a quadratic field — acts trivially on
+`Cl(R)/Cl(R)²`. -/
+theorem elementaryTwoQuotientMk_inv_eq (C : ClassGroup R) :
+    elementaryTwoQuotientMk R C⁻¹ = elementaryTwoQuotientMk R C := by
+  rw [elementaryTwoQuotientMk_inv, ← neg_one_smul (R := ZMod 2),
+    (by decide : (-1 : ZMod 2) = 1), one_smul]
+
 /-- The class map to `Cl(R)/Cl(R)²` sends quotients to differences. -/
 @[simp] theorem elementaryTwoQuotientMk_div (C D : ClassGroup R) :
     elementaryTwoQuotientMk R (C / D) =

--- a/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
+++ b/TauCeti/NumberTheory/ClassGroup/ElementaryTwoQuotient.lean
@@ -34,8 +34,9 @@ square-class group `Kˣ ⧸ (Kˣ)²` of `TauCeti.FieldTheory.SquareClassGroup` f
   of an ideal class, trivial iff that class is a square; `elementaryTwoQuotientMk_mul`,
   `elementaryTwoQuotientMk_one`, `elementaryTwoQuotientMk_inv`,
   `elementaryTwoQuotientMk_div`, `elementaryTwoQuotientMk_pow`, and
-  `elementaryTwoQuotientMk_prod` record its additivity, while `elementaryTwoQuotientMk_surjective`
-  and `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
+  `elementaryTwoQuotientMk_prod` record its additivity, and `elementaryTwoQuotientMk_inv_eq` records
+  that inversion is trivial (`[I⁻¹] = [I]` in the quotient); `elementaryTwoQuotientMk_surjective` and
+  `elementaryTwoQuotientMk_eq_iff` give surjectivity and the equality criterion.
 * `TauCeti.ClassGroup.elementaryTwoQuotientCongr`: a multiplicative equivalence of class groups
   induces a `ZMod 2`-linear equivalence of their elementary-2 quotients.
 * `TauCeti.ClassGroup.card_elementaryTwoQuotient_eq_card_twoTorsion`: `|Cl(R)/Cl(R)²| = |Cl(R)[2]|`,
@@ -81,14 +82,12 @@ noncomputable def elementaryTwoQuotientMk (C : ClassGroup R) : ElementaryTwoQuot
     elementaryTwoQuotientMk R C⁻¹ = -elementaryTwoQuotientMk R C :=
   TauCeti.elementaryTwoQuotientMk_inv C
 
-/-- **Inversion is trivial on `Cl(R)/Cl(R)²`.** The elementary two-quotient is `2`-torsion, so the
-class of an inverse ideal equals the class itself. This is the genus-theoretic fact that an
-automorphism inverting ideal classes — such as conjugation on a quadratic field — acts trivially on
-`Cl(R)/Cl(R)²`. -/
+/-- Inversion is trivial on `Cl(R)/Cl(R)²`: the class of an inverse ideal equals the class itself,
+since the elementary two-quotient is `2`-torsion. The class-group instance of the general
+`TauCeti.elementaryTwoQuotientMk_inv_eq`. -/
 theorem elementaryTwoQuotientMk_inv_eq (C : ClassGroup R) :
-    elementaryTwoQuotientMk R C⁻¹ = elementaryTwoQuotientMk R C := by
-  rw [elementaryTwoQuotientMk_inv, ← neg_one_smul (R := ZMod 2),
-    (by decide : (-1 : ZMod 2) = 1), one_smul]
+    elementaryTwoQuotientMk R C⁻¹ = elementaryTwoQuotientMk R C :=
+  TauCeti.elementaryTwoQuotientMk_inv_eq C
 
 /-- The class map to `Cl(R)/Cl(R)²` sends quotients to differences. -/
 @[simp] theorem elementaryTwoQuotientMk_div (C D : ClassGroup R) :


### PR DESCRIPTION
## What

`elementaryTwoQuotientMk R C⁻¹ = elementaryTwoQuotientMk R C` in `ClassGroup/ElementaryTwoQuotient.lean`.

## Why

`Cl(R)/Cl(R)²` is 2-torsion, so the existing `elementaryTwoQuotientMk_inv` (`= -mk C`) collapses to
`= mk C`: **inversion acts trivially on `Cl/Cl²`**. Genus-theoretically this is why an
ideal-class-inverting automorphism — such as conjugation on a quadratic field, where `I·σI` is
principal — acts trivially on `Cl/Cl²`, a step toward the summit `Gal(K_gen/ℚ(√d)) ≅ Cl/Cl²`. Not
tagged `@[simp]` to avoid non-confluence with the `@[simp]` `elementaryTwoQuotientMk_inv`.

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"ClassGroup/elementaryTwoQuotient-inv-trivial"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017LGBV1zq6jdgyVT9ZpXrWC
