### PR TITLE
docs(DeFinetti): refresh status claims falsified by the conditional summit

### DIFF
--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -47,8 +47,9 @@ finite-block rectangle identity for `directingProbabilityMeasure μ X`, exactly 
 * `mixedIIDWith_of_contractable` — a contractable process on a standard Borel sample space
   is mixed i.i.d., with `directingProbabilityMeasure μ X` (the tail conditional law) as the
   witness. That witness is the canonical *directing measure*, not merely a mixing representative;
-  what this file proves about it is the mixture identity, and the sharper conditional statement
-  awaits the `ConditionallyIID` predicate.
+  what this file proves about it is the mixture identity. The sharper conditional statement at the
+  same witness is `conditionallyIIDWith_of_contractable_pathSpace` in
+  `TauCeti.Probability.DeFinetti.JointRectangle`.
 * `mixedIID_of_contractable` — the existential form, for a contractable process on an
   arbitrary measurable sample space (state space still standard Borel).
 * `mixedIID_of_exchangeable` — the exchangeable form (via `contractable_of_exchangeable`).
@@ -300,8 +301,9 @@ private theorem mixedIID_of_contractable_standardBorelOmega
 
 /-- **de Finetti's theorem, mixture form: contractable ⇒ mixed i.i.d.** A contractable process
 valued in a standard Borel space, on an arbitrary measurable sample space, is mixed i.i.d. This is
-the roadmap's `mixedIID_of_contractable`; the sharp summit `conditionallyIID_of_contractable`
-awaits the conditional predicate. -/
+the roadmap's `mixedIID_of_contractable`; the sharp summit `conditionallyIID_of_contractable`,
+which concludes the joint-law disintegration rather than only the mixture identity, is in
+`TauCeti.Probability.DeFinetti.Theorem`. -/
 theorem mixedIID_of_contractable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
     [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
     (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n)) :

--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -47,9 +47,10 @@ finite-block rectangle identity for `directingProbabilityMeasure μ X`, exactly 
 * `mixedIIDWith_of_contractable` — a contractable process on a standard Borel sample space
   is mixed i.i.d., with `directingProbabilityMeasure μ X` (the tail conditional law) as the
   witness. That witness is the canonical *directing measure*, not merely a mixing representative;
-  what this file proves about it is the mixture identity. The sharper conditional statement at the
-  same witness is `conditionallyIIDWith_of_contractable_pathSpace` in
-  `TauCeti.Probability.DeFinetti.JointRectangle`.
+  what this file proves about that witness is the mixture identity. The sharp *existential*
+  theorem on an arbitrary sample space is `conditionallyIID_of_contractable`; on path space,
+  `conditionallyIIDWith_of_contractable_pathSpace` exposes its canonical tail-law witness
+  explicitly.
 * `mixedIID_of_contractable` — the existential form, for a contractable process on an
   arbitrary measurable sample space (state space still standard Borel).
 * `mixedIID_of_exchangeable` — the exchangeable form (via `contractable_of_exchangeable`).

--- a/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/MixedIID/Basic.lean
@@ -17,8 +17,8 @@ witness `ν`; `MixedIID` is the existential wrapper.
 
 ⚠ This is a property of the **unconditional** finite-dimensional laws: the mixture identity
 constrains each finite block's marginal law, never the joint law of `(ν, X)`. It is therefore
-*not* conditional independence, and is deliberately not named `ConditionallyIID` — that name is
-reserved for the genuine joint-law disintegration
+*not* conditional independence, and is deliberately not named `ConditionallyIID` — that name
+belongs to the genuine joint-law disintegration
 `Law(ν, block) = ∫ δ_{ν ω} ⊗ (ν ω)^{⊗m} dμ(ω)` (Kallenberg 2005, §1.1 eq. (2)), which strictly
 strengthens the identity below at a fixed `ν`: for a nondegenerate mixing law an *independent
 copy* of a directing measure also witnesses `MixedIIDWith`, while the process is not


### PR DESCRIPTION
## The defect

Three places in the Exchangeability area still describe the conditional predicate and its summit as
future work. All three are false on current `main`:

| location | claim | reality |
|---|---|---|
| `DeFinetti/BlockFactorization.lean:51` | "the sharper conditional statement **awaits** the `ConditionallyIID` predicate" | `conditionallyIID_of_contractable` proves the existential on an arbitrary sample space (`Theorem.lean:126`); on path space `conditionallyIIDWith_of_contractable_pathSpace` names the witness (`JointRectangle.lean:273`) |
| `DeFinetti/BlockFactorization.lean:304` | "the sharp summit `conditionallyIID_of_contractable` **awaits** the conditional predicate" | `Theorem.lean:126` |
| `MixedIID/Basic.lean:21` | that name is "**reserved for**" the joint-law disintegration | the name is taken; the predicate exists |

The first two are the more misleading: a reader of `BlockFactorization.lean` is told the mixture
identity is the best available result for a contractable process, when the strictly stronger
conditional statement has been on `main` since #1395.

**Deliberately not claimed:** that the conditional summit holds *at the same named witness*. It does
not, as far as the public API goes. `mixedIIDWith_of_contractable` is stated on an arbitrary
standard-Borel sample space with `directingProbabilityMeasure μ X` as its witness;
`conditionallyIIDWith_of_contractable_pathSpace` is stated only for `μ : Measure (ℕ → α)`; and
`conditionallyIID_of_contractable` transfers that path-space witness back but concludes the
*existential* `ConditionallyIID μ X`, never identifying the transported witness with the
original-space directing measure. Closing that loop is a separate API target, so the wording here
says "sharp existential theorem" and confines the named-witness claim to path space.

## What changes

Each claim now points at the declaration that discharges it, and the `mixedIID_of_contractable`
docstring says what the summit adds — the joint-law disintegration rather than only the mixture
identity — so the two theorems' relationship is legible from either end.

Documentation only. No declaration, statement, or proof changes; `lake build` green (5905 jobs).

Refactor of already-merged code, so no roadmap intention — `AGENTS.md` puts documenting existing
code in scope without one.

## Note

This is the class of defect the `documentation` rubric has caught on several of my PRs: a status
claim that was true when written and was falsified by a later merge. These three were missed because
the PRs that falsified them touched different files.
