### PR TITLE
feat(ConditionallyIID): fixed-set empirical frequencies converge in mean square

### DIFF
--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Moments.lean
@@ -24,6 +24,8 @@ in an exact finite-sample formula for the mean square error of an empirical freq
   frequency of a measurable set `B` along the first `n` coordinates approximates `(ν ·) B` with
   mean square error exactly `(∫ (ν ·) B - ∫ ((ν ·) B) ^ 2) / n`.
 * `ConditionallyIIDWith.integral_empiricalFrequency_sub_sq_le` — its `≤ 1 / n` corollary.
+* `ConditionallyIIDWith.tendsto_integral_empiricalFrequency_sub_sq` — the limit that corollary
+  gives: fixed-set empirical frequencies converge to `(ν ·) B` in mean square.
 
 ## Implementation
 
@@ -44,7 +46,13 @@ integrals by the private machinery below; the coordinates are only assumed a.e. 
 elsewhere in the measure-theoretic exchangeability API.
 
 These estimates are consumed by `ConditionallyIID.Unique` for a.e. uniqueness of the directing
-measure, and are the finite-sample input to empirical-frequency convergence.
+measure.
+
+The `O(1/n)` rate is **not** summable, so it gives mean-square convergence but not almost-sure
+convergence; the latter needs a different argument. Convergence on a countable determining class,
+empirical probability measures as objects, and weak convergence — which additionally requires a
+chosen Polish topology, since `StandardBorelSpace α` asserts only that *some* compatible topology
+exists — are all separate developments.
 -/
 
 public section
@@ -418,6 +426,24 @@ theorem ConditionallyIIDWith.integral_empiricalFrequency_sub_sq_le [IsProbabilit
   have hn' : (0 : ℝ) ≤ (n : ℝ)⁻¹ := by positivity
   rw [h.integral_empiricalFrequency_sub_sq hX hB hn]
   nlinarith [hA, hC, hn']
+
+/-! ### Convergence of empirical frequencies -/
+
+/-- **Fixed-set empirical frequencies converge in mean square.** For a conditionally i.i.d. process,
+the empirical frequency of a fixed measurable set `B` along the first `n` coordinates converges in
+`L²` to the directing measure's evaluation `(ν ·) B`.
+
+Indexed at `n + 1` so that no caller carries an `n ≠ 0` side condition. -/
+theorem ConditionallyIIDWith.tendsto_integral_empiricalFrequency_sub_sq [IsProbabilityMeasure μ]
+    (h : ConditionallyIIDWith μ X ν) (hX : ∀ i, AEMeasurable (X i) μ) (hB : MeasurableSet B) :
+    Tendsto (fun n : ℕ => ∫ ω, (((n + 1 : ℕ) : ℝ)⁻¹ *
+          (∑ i ∈ Finset.range (n + 1), (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω)
+        - ((ν ω : Measure α) B).toReal) ^ 2 ∂μ) atTop (nhds 0) := by
+  have hupper : Tendsto (fun n : ℕ => ((n + 1 : ℕ) : ℝ)⁻¹) atTop (nhds 0) :=
+    tendsto_one_div_add_atTop_nhds_zero_nat.congr fun n => by
+      rw [one_div]; norm_cast
+  refine squeeze_zero (fun n => integral_nonneg fun ω => sq_nonneg _) (fun n => ?_) hupper
+  exact h.integral_empiricalFrequency_sub_sq_le hX hB (Nat.succ_ne_zero n)
 
 end Probability
 


### PR DESCRIPTION
## What

```lean
theorem ConditionallyIIDWith.tendsto_integral_empiricalFrequency_sub_sq
    [IsProbabilityMeasure μ] (h : ConditionallyIIDWith μ X ν)
    (hX : ∀ i, AEMeasurable (X i) μ) (hB : MeasurableSet B) :
    Tendsto (fun n : ℕ => ∫ ω, (((n + 1 : ℕ) : ℝ)⁻¹ *
          (∑ i ∈ Finset.range (n + 1), (X i ⁻¹' B).indicator (1 : Ω → ℝ) ω)
        - ((ν ω : Measure α) B).toReal) ^ 2 ∂μ) atTop (nhds 0)
```

The first step of the empirical strand of
[`TauCetiRoadmap/Exchangeability/README.md`](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/Exchangeability/README.md):
for a conditionally i.i.d. process, the empirical frequency of a fixed measurable set converges in
`L²` to the directing measure's evaluation.

Closes TauCetiProject/TauCetiRoadmap#110

## How

The mathematics was already on `main`. `ConditionallyIIDWith.integral_empiricalFrequency_sub_sq_le`
gives `∫ (average − ν B)² ≤ 1/n` for `n ≠ 0`; the integrand is a square, so the integral is
nonnegative and is squeezed between `0` and `1/(n + 1)`. Four lines.

It builds directly on `ConditionallyIID/Moments.lean`, extracted in #1493 precisely so that
empirical work need not import the uniqueness argument to reach the rate.

## Deliberate choices

* **Indexed at `n + 1`**, so no caller carries an `n ≠ 0` side condition.
* **`[IsProbabilityMeasure μ]` retained** — the `≤ 1/n` bound uses normalization, so weakening to
  `IsFiniteMeasure` is not free and is not attempted here.
* **Coordinates stay `AEMeasurable`**, matching the rest of the measure-theoretic exchangeability
  API rather than strengthening to `Measurable`.
* **No `empiricalFrequency` definition.** The average is written inline. Where such a definition
  belongs — plausibly under `Probability/Process` — is an API-placement question that should not be
  settled as a side effect of this theorem.

## Deliberately not claimed

The module docstring now records these, because the rate invites over-reading:

* **Almost-sure convergence.** `O(1/n)` is *not* summable, so Borel–Cantelli does not apply and this
  estimate does not give it.
* **Weak convergence of empirical measures.** That needs a chosen Polish topology;
  `StandardBorelSpace α` asserts only that *some* compatible topology exists, so the statement is not
  well-posed under it.
* Simultaneous convergence on a determining class, empirical probability measures as objects,
  `deFinetti_empiricalMeasure`, and the affine/extreme-point package — all separate developments.
* An `eLpNorm`/`TendstoInMeasure` restatement is a useful wrapper but would bury this argument in
  `ENNReal` plumbing; it can follow via `tendstoInMeasure_of_tendsto_eLpNorm`.

## Verification

Full `lake build` green (5912 jobs); `scripts/lint-env.sh` PASS (54 grandfathered, 0 new);
`#print axioms` reports exactly `propext, Classical.choice, Quot.sound`.