### PR TITLE
refactor(ConditionallyIID): name the symmetry consequences of the conditional predicate

### DIFF
--- a/TauCeti/Probability/DeFinetti/Theorem.lean
+++ b/TauCeti/Probability/DeFinetti/Theorem.lean
@@ -11,6 +11,7 @@ public import TauCeti.Probability.DeFinetti.BlockFactorization
 import TauCeti.Probability.Exchangeability.MixedIID.Implications
 import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Map
+import TauCeti.Probability.Exchangeability.ConditionallyIID.Implications
 
 /-!
 # The de Finetti–Ryll-Nardzewski theorem and equivalences
@@ -157,7 +158,7 @@ theorem deFinetti_equivalence [StandardBorelSpace α] [Nonempty α] {μ : Measur
     [IsFiniteMeasure μ] {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) :
     Exchangeable μ X ↔ ConditionallyIID μ X :=
   ⟨fun hX => conditionallyIID_of_exchangeable hX hX_meas,
-    fun hX => (mixedIID_of_conditionallyIID hX).exchangeable⟩
+    fun hX => hX.exchangeable⟩
 
 /-- **The de Finetti–Ryll-Nardzewski equivalence.** A process with measurable coordinates, valued
 in a nonempty standard Borel space, is contractable iff it is both exchangeable and conditionally
@@ -169,8 +170,8 @@ theorem deFinetti_RyllNardzewski_equivalence [StandardBorelSpace α] [Nonempty �
   constructor
   · intro hX
     have hX_cond := conditionallyIID_of_contractable hX hX_meas
-    exact ⟨(mixedIID_of_conditionallyIID hX_cond).exchangeable, hX_cond⟩
-  · exact fun hX => (mixedIID_of_conditionallyIID hX.2).contractable
+    exact ⟨hX_cond.exchangeable, hX_cond⟩
+  · exact fun hX => hX.2.contractable
 
 end Probability
 

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
+-- Non-public: the mixture-side bridges `MixedIID.exchangeable` and `MixedIID.contractable` are
+-- used only inside the proofs below.
+import TauCeti.Probability.Exchangeability.MixedIID.Implications
+
+/-!
+# Basic implications from conditional i.i.d.-ness
+
+The symmetry consequences of the conditional predicate: a conditionally i.i.d. sequence is
+exchangeable, and it is contractable.
+
+Both factor through `mixedIID_of_conditionallyIID`, so this file is the conditional counterpart of
+`TauCeti.Probability.Exchangeability.MixedIID.Implications`, and sits one layer above it for the
+same reason that file sits above `MixedIID.Basic`: the projection belongs with the predicate, the
+implications out of it do not.
+
+## Main results
+
+* `ConditionallyIIDWith.exchangeable`, `ConditionallyIIDWith.contractable` — at a named directing
+  measure.
+* `ConditionallyIID.exchangeable`, `ConditionallyIID.contractable` — their existential corollaries.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- A sequence with a named directing measure is exchangeable. -/
+theorem ConditionallyIIDWith.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Exchangeable μ X :=
+  (mixedIIDWith_of_conditionallyIIDWith h).exchangeable
+
+/-- A conditionally i.i.d. sequence is exchangeable. -/
+theorem ConditionallyIID.exchangeable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) : Exchangeable μ X :=
+  let ⟨_, hν⟩ := h.exists_directing
+  hν.exchangeable
+
+/-- A sequence with a named directing measure is contractable. -/
+theorem ConditionallyIIDWith.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
+    {ν : Ω → ProbabilityMeasure α} (h : ConditionallyIIDWith μ X ν) : Contractable μ X :=
+  (mixedIIDWith_of_conditionallyIIDWith h).contractable
+
+/-- A conditionally i.i.d. sequence is contractable. -/
+theorem ConditionallyIID.contractable {μ : Measure Ω} {X : ℕ → Ω → α}
+    (h : ConditionallyIID μ X) : Contractable μ X :=
+  let ⟨_, hν⟩ := h.exists_directing
+  hν.contractable
+
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
+++ b/TauCeti/Probability/Exchangeability/ConditionallyIID/Implications.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Basic
--- Non-public: the mixture-side bridges `MixedIID.exchangeable` and `MixedIID.contractable` are
--- used only inside the proofs below.
+-- Non-public: the mixture-side bridges `MixedIIDWith.exchangeable` and `MixedIIDWith.contractable`
+-- are used only inside the proofs below.
 import TauCeti.Probability.Exchangeability.MixedIID.Implications
 
 /-!
@@ -15,10 +15,16 @@ import TauCeti.Probability.Exchangeability.MixedIID.Implications
 The symmetry consequences of the conditional predicate: a conditionally i.i.d. sequence is
 exchangeable, and it is contractable.
 
-Both factor through `mixedIID_of_conditionallyIID`, so this file is the conditional counterpart of
-`TauCeti.Probability.Exchangeability.MixedIID.Implications`, and sits one layer above it for the
-same reason that file sits above `MixedIID.Basic`: the projection belongs with the predicate, the
-implications out of it do not.
+The witness-level forms compose the projection `mixedIIDWith_of_conditionallyIIDWith` with the
+corresponding `MixedIIDWith` implication, so the directing measure is carried through unchanged; the
+existential forms destruct `exists_directing` and apply them. This is the same layering as the
+mixture side, where `MixedIIDWith.exchangeable` does the work and `MixedIID.exchangeable` destructs
+the existential.
+
+The file is therefore the conditional counterpart of
+`TauCeti.Probability.Exchangeability.MixedIID.Implications`, and sits one layer above
+`ConditionallyIID.Basic` for the same reason that file sits above `MixedIID.Basic`: the projection
+belongs with the predicate, the implications out of it do not.
 
 ## Main results
 


### PR DESCRIPTION
## What

Four named symmetry consequences of the conditional predicate, replacing a composition that
`DeFinetti/Theorem.lean` inlines at three sites:

```lean
ConditionallyIIDWith.exchangeable   ConditionallyIIDWith.contractable   -- at a named directing measure
ConditionallyIID.exchangeable       ConditionallyIID.contractable       -- existential corollaries
```

They live in a new `Exchangeability/ConditionallyIID/Implications.lean`, mirroring
`MixedIID/Implications.lean`: the predicate and its projection stay in `Basic`, the implications out
of the predicate sit one layer above, so `Basic` keeps its original import set. `Exchangeable` and
`Contractable` already arrive through `MixedIID.Basic`, so the statements need no new *public*
import; `MixedIID.Implications` enters proof-only.

The layering matches the mixture side exactly. The `With` forms compose
`mixedIIDWith_of_conditionallyIIDWith` with the corresponding `MixedIIDWith` implication, preserving
the witness; the existential forms destruct `exists_directing`. So a caller holding a named directing
measure never has to weaken to the existential to obtain exchangeability or contractability.

## Why this is a new PR

This replaces **#1450**, which I am closing. That PR sat unreviewed at its head for over four hours,
including across a manual `/review`, while five other PRs of mine reviewed and merged normally. It
had also drifted far enough behind `main` that its branch diff would have *reverted* unrelated files
across `Algebra`, `Topology`, and `RingTheory`.

The content here is the same as #1450's final state, rebuilt from current `main`. That state had
already addressed all four of its findings:

* `placement` — arrows moved out of `Basic.lean` into their own `Implications` module;
* `generality` — the `With`-level forms added, with the existentials derived from them;
* `documentation` — proof narration removed from the docstrings;
* `api-design` — the `deFinetti` argument-order change dropped. I contested that one and was wrong:
  the roadmap pins `deFinetti (X) (hX_meas) (hX_exch)`, so the rubric had specification precedent.
  `deFinetti` is untouched here.

## Scope

**No roadmap intention, and no new mathematics.** Every one of the four arrows is a named
composition of declarations already on `main` — `mixedIIDWith_of_conditionallyIIDWith` with
`MixedIIDWith.exchangeable` / `MixedIIDWith.contractable`, and `exists_directing` for the
existential forms. `DeFinetti/Theorem.lean` already performed exactly these compositions inline at
the three call sites this PR rewires. `AGENTS.md` puts naming and relocating existing results in
scope without a roadmap entry.

## Verification

`lake build` green (5914 jobs); `scripts/lint-env.sh` PASS (54 grandfathered, 0 new). Net diff is the
new file plus three call sites.

Roadmap: Exchangeability