### PR TITLE
refactor(Exchangeability): make blockLaw index-generic and stop exposing its body

### DIFF
--- a/TauCeti/Probability/Exchangeability/Basic.lean
+++ b/TauCeti/Probability/Exchangeability/Basic.lean
@@ -12,10 +12,14 @@ public import Mathlib.Tactic.Measurability
 /-!
 # Basic exchangeability definitions
 
-This file starts the Layer 0 exchangeability API: indexed block laws of a process,
+This file starts the Layer 0 exchangeability API: indexed block laws of a family,
 prefix laws, path laws, finite exchangeability, full exchangeability, and
 contractability. The definitions are intentionally hypothesis-light; measurability
 hypotheses enter only in lemmas that compose `Measure.map`s.
+
+`blockLaw` and its characteristic lemmas are stated for an arbitrary index type; the remaining
+definitions here are about the order structure of `ℕ` (prefixes, shifts, strictly increasing
+selections) and stay sequence-level.
 
 These declarations follow the roadmap signatures in
 `TauCetiRoadmap/Exchangeability/README.md` and
@@ -34,11 +38,14 @@ namespace TauCeti
 
 namespace Probability
 
-variable {Ω α β : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+variable {Ω α β ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
-/-- The finite-dimensional law of a process along a coordinate selection `k`. -/
-@[expose]
-def blockLaw (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+/-- The finite-dimensional law of a family along a coordinate selection `k`.
+
+The index type is arbitrary: nothing about a finite selection needs the indices to be natural
+numbers, and `ExchangeableFamily` selects from an arbitrary type. Sequence-level users get the
+`ι = ℕ` case by unification. -/
+def blockLaw (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     Measure (Fin m → α) :=
   μ.map fun ω i => X (k i) ω
 
@@ -90,9 +97,9 @@ def Contractable (μ : Measure Ω) (X : ℕ → Ω → α) : Prop :=
   ∀ (m : ℕ) (k : Fin m → ℕ), StrictMono k → blockLaw μ X k = prefixLaw μ X m
 
 @[simp]
-theorem blockLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ) :
+theorem blockLaw_def (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι) :
     blockLaw μ X k = μ.map (fun ω i => X (k i) ω) :=
-  rfl
+  (rfl)
 
 -- Annotated `@[grind =>]` rather than `@[simp]`: `blockLaw_def` already simp-normalizes
 -- `blockLaw μ X k` to `μ.map …` (so a `@[simp]` here would be shadowed), and the preimage form
@@ -101,7 +108,7 @@ theorem blockLaw_def (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fi
 coordinate-wise preimage. This is the characteristic evaluation of `blockLaw` as a pushforward;
 `blockLaw_apply_rectangle` is the rectangle specialization. -/
 @[grind =>]
-theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) {S : Set (Fin m → α)} (hS : MeasurableSet S) :
     blockLaw μ X k S = μ ((fun ω i => X (k i) ω) ⁻¹' S) := by
   rw [blockLaw_def, Measure.map_apply_of_aemeasurable (aemeasurable_pi_lambda _ hXk) hS]
@@ -110,7 +117,7 @@ theorem blockLaw_apply_of_measurable (μ : Measure Ω) (X : ℕ → Ω → α) {
 measure of the coordinate-wise preimage `{ω | ∀ i, X (k i) ω ∈ B i}` — the rectangle specialization
 of `blockLaw_apply_of_measurable`. -/
 @[grind =>]
-theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ℕ → Ω → α) {m : ℕ} (k : Fin m → ℕ)
+theorem blockLaw_apply_rectangle (μ : Measure Ω) (X : ι → Ω → α) {m : ℕ} (k : Fin m → ι)
     (hXk : ∀ i, AEMeasurable (X (k i)) μ) (B : Fin m → Set α) (hB : ∀ i, MeasurableSet (B i)) :
     blockLaw μ X k (Set.univ.pi B) = μ {ω | ∀ i, X (k i) ω ∈ B i} := by
   rw [blockLaw_apply_of_measurable μ X k hXk (MeasurableSet.univ_pi hB)]
@@ -173,7 +180,7 @@ theorem map_prefixProj_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
   rfl
 
 /-- A coordinatewise measurable map sends block laws to block laws. -/
-theorem map_blockLaw (μ : Measure Ω) {X : ℕ → Ω → α} {m : ℕ} (k : Fin m → ℕ)
+theorem map_blockLaw (μ : Measure Ω) {X : ι → Ω → α} {m : ℕ} (k : Fin m → ι)
     {f : α → β} [MeasurableSpace β] (hf : Measurable f)
     (hXk : ∀ i : Fin m, AEMeasurable (X (k i)) μ) :
     (blockLaw μ X k).map (fun x : Fin m → α => fun i => f (x i)) =
@@ -208,8 +215,8 @@ theorem map_pathLaw (μ : Measure Ω) {X : ℕ → Ω → α}
 
 /-- Push a block law forward along a coordinate reindexing: selecting the coordinates of
 `blockLaw μ X k` through `g : Fin p → Fin n` yields the block law along `k ∘ g`. -/
-theorem map_blockLaw_reindex (μ : Measure Ω) {X : ℕ → Ω → α} {n p : ℕ}
-    (k : Fin n → ℕ) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
+theorem map_blockLaw_reindex (μ : Measure Ω) {X : ι → Ω → α} {n p : ℕ}
+    (k : Fin n → ι) (g : Fin p → Fin n) (hXk : ∀ j : Fin n, AEMeasurable (X (k j)) μ) :
     (blockLaw μ X k).map (fun x : Fin n → α => fun i : Fin p => x (g i)) =
       blockLaw μ X (k ∘ g) := by
   rw [blockLaw_def, blockLaw_def,

--- a/TauCeti/Probability/Exchangeability/Contractability.lean
+++ b/TauCeti/Probability/Exchangeability/Contractability.lean
@@ -120,11 +120,14 @@ theorem Contractable.comp {μ : Measure Ω} {X : ℕ → Ω → α} (h : Contrac
   intro m k hk
   calc
     blockLaw μ (fun n ω => X (φ n) ω) k =
-        blockLaw μ X (φ ∘ k) := rfl
+        blockLaw μ X (φ ∘ k) := by
+      simp only [blockLaw_def, Function.comp_apply]
     _ = prefixLaw μ X m := h.map (hφ.comp hk)
     _ = blockLaw μ (fun n ω => X (φ n) ω) (fun i : Fin m => i.val) := by
-      exact (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
-    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := rfl
+      have := (h.map (hφ.comp (Fin.val_strictMono : StrictMono (fun i : Fin m => i.val)))).symm
+      simpa only [blockLaw_def, Function.comp_apply] using this
+    _ = prefixLaw μ (fun n ω => X (φ n) ω) m := by
+      simp only [prefixLaw_def]
 
 /-- **An exchangeable sequence has the prefix law along any injective finite selection:**
 `blockLaw μ X k = prefixLaw μ X n` for injective `k : Fin n → ℕ`. -/

--- a/TauCeti/Probability/Exchangeability/Family.lean
+++ b/TauCeti/Probability/Exchangeability/Family.lean
@@ -45,12 +45,12 @@ variable {Ω α ι κ : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 selection of indices by another of the same size. -/
 def ExchangeableFamily (μ : Measure Ω) (X : ι → Ω → α) : Prop :=
   ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω
+    blockLaw μ X k = blockLaw μ X l
 
 /-- Constructor for exchangeability of an arbitrary family. -/
 theorem ExchangeableFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
     (h : ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-      μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω) :
+      blockLaw μ X k = blockLaw μ X l) :
     ExchangeableFamily μ X :=
   h
 
@@ -59,7 +59,7 @@ theorem ExchangeableFamily.intro {μ : Measure Ω} {X : ι → Ω → α}
 theorem exchangeableFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
     ExchangeableFamily μ X ↔
       ∀ (m : ℕ) (k l : Fin m → ι), Function.Injective k → Function.Injective l →
-        μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+        blockLaw μ X k = blockLaw μ X l :=
   Iff.rfl
 
 /-- The finite-block law equality defining an exchangeable family. -/
@@ -67,7 +67,7 @@ theorem exchangeableFamily_iff {μ : Measure Ω} {X : ι → Ω → α} :
 theorem ExchangeableFamily.blockLaw_eq {μ : Measure Ω} {X : ι → Ω → α}
     (h : ExchangeableFamily μ X) {m : ℕ} (k l : Fin m → ι)
     (hk : Function.Injective k) (hl : Function.Injective l) :
-    μ.map (fun ω i => X (k i) ω) = μ.map fun ω i => X (l i) ω :=
+    blockLaw μ X k = blockLaw μ X l :=
   h m k l hk hl
 
 /-- A conditionally i.i.d. family with a named directing measure is exchangeable. -/
@@ -75,6 +75,7 @@ theorem ConditionallyIIDWith.exchangeableFamily
     {μ : Measure Ω} {X : ι → Ω → α} {ν : Ω → ProbabilityMeasure α}
     (h : ConditionallyIIDWith μ X ν) : ExchangeableFamily μ X := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
+  rw [blockLaw_def, blockLaw_def]
   calc
     μ.map (fun ω i => X (k i) ω) =
         (μ.map fun ω => (ν ω, fun i : Fin m => X (k i) ω)).snd := by
@@ -100,7 +101,7 @@ theorem ExchangeableFamily.comp_injective {μ : Measure Ω} {X : ι → Ω → �
     (h : ExchangeableFamily μ X) {f : κ → ι} (hf : Function.Injective f) :
     ExchangeableFamily μ fun j => X (f j) := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  simpa only [Function.comp_apply] using
+  simpa only [blockLaw_def, Function.comp_apply] using
     h.blockLaw_eq (f ∘ k) (f ∘ l) (hf.comp hk) (hf.comp hl)
 
 /-! ## Comparison with the sequence predicates -/
@@ -119,7 +120,6 @@ theorem Exchangeable.exchangeableFamily {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ℕ → Ω → α} (h : Exchangeable μ X) (hX : ∀ i, AEMeasurable (X i) μ) :
     ExchangeableFamily μ X := by
   refine ExchangeableFamily.intro fun m k l hk hl => ?_
-  rw [← blockLaw_def, ← blockLaw_def]
   exact (h.blockLaw_eq_prefixLaw_of_injective hX k hk).trans
     (h.blockLaw_eq_prefixLaw_of_injective hX l hl).symm
 


### PR DESCRIPTION
## The defect

`blockLaw μ X k` is by definition `μ.map fun ω i => X (k i) ω` — the law of a finite selection of
coordinates. Nothing about a finite selection requires the indices to be natural numbers, but the
declaration pinned them.

That became load-bearing when #1451 added families over an arbitrary index type.
`ExchangeableFamily` could not use `blockLaw`, so it wrote the pushforward out longhand in **four**
places — the definition, `ExchangeableFamily.intro`, `exchangeableFamily_iff`, and a lemma named
`ExchangeableFamily.blockLaw_eq` that could not mention `blockLaw`. All four now read
`blockLaw μ X k = blockLaw μ X l`.

## What changes

**Index type.** `blockLaw` and the five equally index-agnostic lemmas — `blockLaw_def`,
`blockLaw_apply_of_measurable`, `blockLaw_apply_rectangle`, `map_blockLaw`, `map_blockLaw_reindex` —
take an arbitrary `ι`. No call site changes: `ι` unifies with `ℕ`.

**Exposure.** `blockLaw` loses `@[expose]`, so nothing outside `Basic.lean` depends on its body. Its
characteristic lemmas are proved with `(rfl)`, which — unlike bare `rfl` — exports against an opaque
definition. Four downstream sites that relied on definitional unfolding now go through the public
API: two calc steps in `Contractable.comp`, `ExchangeableFamily.comp_injective`, and the opening of
`ConditionallyIIDWith.exchangeableFamily`.

## What deliberately stays sequence-level

`prefixLaw`, `pathLaw`, `shift`, `permReindex`, `ExchangeableAt`, `Exchangeable`, and `Contractable`
are about the **order structure** of `ℕ` — prefixes, shifts, strictly increasing selections — not
merely about being indexed. The module docstring now says which half is which.

## Why this is a new PR

This replaces **#1479**, which I am closing. It sat unreviewed at head `ec82de8` for three hours
while four other PRs of mine reviewed and merged, and its branch had drifted far enough behind
`main` that its diff would have reverted unrelated files across `Algebra`, `Topology`, and
`RingTheory`.

The content is that PR's final state replayed onto current `main` — `main` had not touched any of
the three files, so it applied cleanly. It had already resolved all its findings:

* `api-design` — `@[expose]` removed. I first contested this and was wrong: I had tested only the
  removal, not the `(rfl)` half of the suggestion, and the complete fix compiles.
* `reuse` — `blockLaw_comp` dropped as a restatement of `blockLaw_def` plus `Function.comp_apply`.
  That rubric and `api-design` had pulled in opposite directions on this lemma; the structure here
  satisfies both, since downstream still reaches `blockLaw` only through its characteristic lemma.
* `documentation` — moot once the lemma it described was removed.

## Verification

`lake build` green (5914 jobs); `scripts/lint-env.sh` PASS (54 grandfathered, 0 new).