### PR TITLE
refactor(Contour): state the residue scaling lemmas unconditionally

### DIFF
--- a/TauCeti/Analysis/Contour/Residue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Residue/Basic.lean
@@ -34,10 +34,11 @@ As an unconditional value it is junk (`0`) when `f` is not meromorphic at `z₀`
   residue is `iteratedDeriv (−1 − n) g z₀ / (−1 − n)!`, independently of the presentation.
 * `TauCeti.Contour.residue_eq_of_eventuallyEq_zpow_smul` — the same value from any presentation
   `f =ᶠ[𝓝[≠] z₀] (· − z₀) ^ n • g` with `g` analytic and `n ≤ −1`, dropping `g z₀ ≠ 0`.
-* `TauCeti.Contour.residue_add`, `TauCeti.Contour.residue_const_mul`,
-  `TauCeti.Contour.residue_const_smul`, `TauCeti.Contour.residue_sub`,
-  `TauCeti.Contour.residue_sum` — the residue is linear in `f` (over functions meromorphic at
-  `z₀`), including over finite sums.
+* `TauCeti.Contour.residue_add`, `TauCeti.Contour.residue_sub`, `TauCeti.Contour.residue_sum` —
+  additivity of the residue, over functions meromorphic at `z₀`, including over finite sums. The
+  hypotheses are essential: two functions that are not meromorphic can sum to one that is.
+* `TauCeti.Contour.residue_const_mul` and `TauCeti.Contour.residue_const_smul` — homogeneity, in
+  the applied and unapplied forms. These are unconditional, the junk value scaling correctly.
 * `TauCeti.Contour.residue_congr_nhdsNE` — the residue depends only on the germ of `f` on a
   punctured neighborhood of `z₀`.
 * `TauCeti.Contour.residue_eq_zero_of_analyticAt` — the residue vanishes where `f` is analytic.
@@ -343,10 +344,22 @@ theorem residue_add {f g : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀)
     residue_eq_of_eventuallyEq_zpow_smul hm1 (hφf_an.add hφg_an) hφfg_eq,
     iteratedDeriv_add hφf_an.contDiffAt hφg_an.contDiffAt, add_div]
 
-/-- **Scaling of the residue.** Scaling `f` by a constant scales its residue by that constant. -/
+/-- **Scaling of the residue.** Scaling `f` by a constant scales its residue by that constant.
+
+No meromorphy hypothesis is needed. Where `f` is not meromorphic at `z₀` the identity still holds
+through the junk value: for `c ≠ 0` the scaled function is not meromorphic either, so both sides are
+`0`, and `c = 0` makes both sides `0` outright. Contrast `residue_add`, whose hypotheses are
+essential — two functions that are not meromorphic can sum to one that is. -/
 @[simp]
-theorem residue_const_mul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) (hf : MeromorphicAt f z₀) :
+theorem residue_const_mul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
     residue (fun z => c * f z) z₀ = c * residue f z₀ := by
+  by_cases hf : MeromorphicAt f z₀
+  case neg =>
+    rcases eq_or_ne c 0 with rfl | hc
+    · simpa using residue_eq_zero_of_analyticAt (f := fun _ : ℂ => (0 : ℂ)) analyticAt_const
+    · have hcf : ¬ MeromorphicAt (fun z => c * f z) z₀ := fun h =>
+        hf ((meromorphicAt_mul_iff_of_ne_zero (g := fun _ => c) analyticAt_const hc).1 h)
+      rw [residue_of_not_meromorphicAt hcf, residue_of_not_meromorphicAt hf, mul_zero]
   obtain ⟨m, hm1, hmf⟩ : ∃ m : ℤ, m ≤ -1 ∧ (m : WithTop ℤ) ≤ meromorphicOrderAt f z₀ := by
     refine ⟨min (meromorphicOrderAt f z₀).untop₀ (-1), min_le_right _ _, ?_⟩
     rcases eq_or_ne (meromorphicOrderAt f z₀) ⊤ with h | h
@@ -364,11 +377,11 @@ theorem residue_const_mul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) (hf : Meromor
 /-- **Scaling of the residue (unapplied `•`).** The residue commutes with scalar multiplication;
 the `Pi.smul` companion to `residue_const_mul`. -/
 @[simp]
-theorem residue_const_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) (hf : MeromorphicAt f z₀) :
+theorem residue_const_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
     residue (c • f) z₀ = c • residue f z₀ :=
   -- `c • f` unfolds to `fun z => c * f z` by `Pi.smul_apply`, and `c • r` to `c * r` in `ℂ` by
   -- `smul_eq_mul`; both are definitional, so `residue_const_mul` applies directly.
-  residue_const_mul c hf
+  residue_const_mul c
 
 @[deprecated (since := "2026-07-30")]
 alias residue_smul := residue_const_smul
@@ -382,7 +395,7 @@ theorem residue_sub {f g : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀)
     analyticAt_const.meromorphicAt.mul hg
   have heq : f - g = f + fun z => (-1 : ℂ) * g z := by
     funext z; simp only [Pi.sub_apply, Pi.add_apply, neg_one_mul]; ring
-  rw [heq, residue_add hf hng, residue_const_mul (-1) hg]
+  rw [heq, residue_add hf hng, residue_const_mul (-1)]
   ring
 
 /-- **The residue of a finite sum.** For a finite family of functions meromorphic at `z₀`, the

--- a/TauCeti/Analysis/Contour/Residue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Residue/Basic.lean
@@ -346,15 +346,16 @@ theorem residue_add {f g : ℂ → ℂ} {z₀ : ℂ} (hf : MeromorphicAt f z₀)
 
 /-- **Scaling of the residue.** Scaling `f` by a constant scales its residue by that constant.
 
-No meromorphy hypothesis is needed. Where `f` is not meromorphic at `z₀` the identity still holds
-through the junk value: for `c ≠ 0` the scaled function is not meromorphic either, so both sides are
-`0`, and `c = 0` makes both sides `0` outright. Contrast `residue_add`, whose hypotheses are
-essential — two functions that are not meromorphic can sum to one that is. -/
+No meromorphy hypothesis is needed: the identity holds for every `f`, through the junk value where
+`f` is not meromorphic at `z₀`. Contrast `residue_add`, whose hypotheses are essential — two
+functions that are not meromorphic can sum to one that is. -/
 @[simp]
 theorem residue_const_mul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
     residue (fun z => c * f z) z₀ = c * residue f z₀ := by
   by_cases hf : MeromorphicAt f z₀
   case neg =>
+    -- `c = 0` collapses both sides to `0`; for `c ≠ 0` the scaled function is not meromorphic
+    -- either, so both sides are the junk value.
     rcases eq_or_ne c 0 with rfl | hc
     · simpa using residue_eq_zero_of_analyticAt (f := fun _ : ℂ => (0 : ℂ)) analyticAt_const
     · have hcf : ¬ MeromorphicAt (fun z => c * f z) z₀ := fun h =>
@@ -383,8 +384,12 @@ theorem residue_const_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
   -- `smul_eq_mul`; both are definitional, so `residue_const_mul` applies directly.
   residue_const_mul c
 
-@[deprecated (since := "2026-07-30")]
-alias residue_smul := residue_const_smul
+/-- Compatibility wrapper for the former name of `residue_const_smul`. Stated with the signature
+that name carried, so existing `residue_smul c hf` calls keep elaborating; the meromorphy argument
+is ignored, that lemma now being unconditional. -/
+@[deprecated residue_const_smul (since := "2026-07-30")]
+theorem residue_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) (_hf : MeromorphicAt f z₀) :
+    residue (c • f) z₀ = c • residue f z₀ := residue_const_smul c
 
 /-- **Subtractivity of the residue.** The residue distributes over subtraction of meromorphic
 functions; the `−1` scaling case of `residue_add` and `residue_const_mul`. -/

--- a/TauCeti/Analysis/Contour/Residue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Residue/Basic.lean
@@ -386,8 +386,11 @@ theorem residue_const_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) :
 
 /-- Compatibility wrapper for the former name of `residue_const_smul`. Stated with the signature
 that name carried, so existing `residue_smul c hf` calls keep elaborating; the meromorphy argument
-is ignored, that lemma now being unconditional. -/
-@[deprecated residue_const_smul (since := "2026-07-30")]
+is ignored, that lemma now being unconditional. Migrate to `residue_const_smul`, dropping that
+argument — which is why no automatic replacement is named here: `residue_const_smul c hf` would not
+elaborate. -/
+@[deprecated "Use `residue_const_smul`, which is unconditional: drop the meromorphy argument."
+  (since := "2026-07-30")]
 theorem residue_smul {f : ℂ → ℂ} {z₀ : ℂ} (c : ℂ) (_hf : MeromorphicAt f z₀) :
     residue (c • f) z₀ = c • residue f z₀ := residue_const_smul c
 

--- a/TauCeti/Analysis/Contour/Residue/SimplePole.lean
+++ b/TauCeti/Analysis/Contour/Residue/SimplePole.lean
@@ -163,10 +163,12 @@ theorem residue_sub_inv (z₀ : ℂ) : residue (fun z => (z - z₀)⁻¹) z₀ =
 
 /-- The residue of `c · (· − z₀)⁻¹` at `z₀` is `c`: scaling the elementary simple pole scales its
 residue. -/
-@[simp]
+-- Deliberately not `@[simp]`: `simp` already derives this from the unconditional
+-- `residue_const_mul` together with `residue_sub_inv`, so simpNF rejects the attribute as
+-- redundant. Kept as named API because several proofs rewrite with it directly.
 theorem residue_const_mul_sub_inv (c z₀ : ℂ) :
     residue (fun z => c * (z - z₀)⁻¹) z₀ = c := by
-  rw [residue_const_mul c (meromorphicAt_sub_inv z₀), residue_sub_inv, mul_one]
+  rw [residue_const_mul c, residue_sub_inv, mul_one]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Residue/Theorem.lean
+++ b/TauCeti/Analysis/Contour/Residue/Theorem.lean
@@ -81,7 +81,6 @@ private lemma circleIntegral_const_mul_zpow_sub {c s₀ : ℂ} {R : ℝ} {n : �
     (hs₀ : s₀ ∈ ball c R) (hn : n < 0) :
     (∮ z in C(c, R), a * (z - s₀) ^ n)
       = 2 * ↑Real.pi * Complex.I * residue (fun z => a * (z - s₀) ^ n) s₀ := by
-  have hQ_mero : MeromorphicAt (fun z => (z - s₀) ^ n) s₀ := by fun_prop
   -- Residue of the pure monomial: the Taylor coefficient of the constant `1` at index `−1 − n`.
   have hresQ : residue (fun z => (z - s₀) ^ n) s₀
       = (if (-1 - n).toNat = 0 then (1 : ℂ) else 0) / ((-1 - n).toNat.factorial : ℂ) := by

--- a/TauCeti/Analysis/Contour/Residue/Theorem.lean
+++ b/TauCeti/Analysis/Contour/Residue/Theorem.lean
@@ -88,7 +88,7 @@ private lemma circleIntegral_const_mul_zpow_sub {c s₀ : ℂ} {R : ℝ} {n : �
     have h1 : AnalyticAt ℂ (fun _ : ℂ => (1 : ℂ)) s₀ := analyticAt_const
     rw [residue_eq_of_eventuallyEq_zpow_smul (by omega : n ≤ -1) h1
       (Filter.Eventually.of_forall fun z => by simp [smul_eq_mul]), iteratedDeriv_const]
-  rw [residue_const_mul a hQ_mero, hresQ]
+  rw [residue_const_mul a, hresQ]
   rcases eq_or_ne n (-1) with hn1 | hn1
   · subst hn1
     have hinv : (fun z => a * (z - s₀) ^ (-1 : ℤ)) = fun z => a * (z - s₀)⁻¹ := by


### PR DESCRIPTION
Follow-up to #1490, split out as `scope` directed there:

> Split the unconditional weakening into its own PR and cite `TauCetiRoadmap/ContourIntegration/README.md`, Layer 2, lines 138–144 (`ℂ`-linearity); keep this PR to the rename and proof refactor.

`residue_const_mul` and `residue_const_smul` did not need `hf : MeromorphicAt f z₀`. Scaling is unconditional under the junk-value convention that `residue` already documents:

- for `c ≠ 0`, `meromorphicAt_mul_iff_of_ne_zero` makes `c * f` meromorphic exactly when `f` is, so both sides are the junk value `0` together;
- `c = 0` makes both sides `0` outright.

This is the `ℂ`-linearity of the residue named at Layer 2 of the roadmap.

**It does not extend to additivity.** `residue_add` / `residue_sub` / `residue_sum` genuinely need their hypotheses: two functions that are not meromorphic can sum to one that is — take `g = -f`. The module docstring now separates the two, since it previously claimed linearity "over functions meromorphic at `z₀`" for all five lemmas, which is no longer true of the scaling pair.

**Two consequences, both handled here:**

1. The three call sites that passed the hypothesis (`residue_sub`, `residue_const_mul_sub_inv`, `residueTheorem_step`) are rerouted.
2. `residue_const_mul_sub_inv` became `simp`-provable from the now-unconditional `residue_const_mul` plus `residue_sub_inv`, so simpNF rejected its `@[simp]` as redundant. The attribute is dropped, with a comment recording why; the lemma itself stays, since several proofs rewrite with it by name.

That second one is worth noting for review: it is a change to a third declaration in a second file, caused by the weakening. It is part of why this belongs in its own PR rather than bolted onto the rename.

**On the deprecated alias.** `residue_smul` is an `alias` of `residue_const_smul`, introduced in #1490 earlier today, so it tracks the new signature and old `residue_smul c hf` calls no longer elaborate. That is inherent to removing a hypothesis — an `alias` cannot carry a different signature — and the alias has no callers, in this repository or (being hours old) plausibly outside it. If a compatibility shim is wanted anyway, say so and I will add one carrying the old argument.

Degenerate ends check out: at `c = 0` both sides are `0` via the analytic branch; with `f` non-meromorphic and `c ≠ 0` both are the junk `0`.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`.

Roadmap: ContourIntegration