### PR TITLE
feat: make the diagonalizable coordinate functor faithful

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean
@@ -38,6 +38,10 @@ on the general Hopf-algebra/affine-group-scheme anti-equivalence.
   homomorphism.
 * `TauCeti.DiagonalizableGroup.coordinateRingFunctor`: the group-algebra functor from
   finitely generated commutative groups to finite-type commutative Hopf algebras.
+* `TauCeti.DiagonalizableGroup.coordinateMap_injective`: coordinate maps remember their
+  underlying group homomorphisms over a nontrivial base.
+* `TauCeti.DiagonalizableGroup.coordinateRingFunctor_faithful`: the coordinate-ring
+  functor is faithful over a nontrivial base.
 
 ## References
 
@@ -92,6 +96,24 @@ theorem coordinateMap_single {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) (g : G) (r 
   rw [toBialgHom_coordinateMap]
   exact MonoidAlgebra.mapDomain_single
 
+/-- Over a nontrivial base ring, the coordinate morphism remembers the group homomorphism
+that induced it. -/
+theorem coordinateMap_injective [Nontrivial R] {G H : FGCommGrpCat.{v}} :
+    Function.Injective (coordinateMap R :
+      (G ⟶ H) → (coordinateRing R G ⟶ coordinateRing R H)) := by
+  intro φ ψ h
+  apply FGCommGrpCat.hom_ext
+  ext g
+  apply MonoidAlgebra.single_left_injective (R := R) (M := H) one_ne_zero
+  calc
+    MonoidAlgebra.single (FGCommGrpCat.toMonoidHom φ g) 1 =
+        FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R φ)
+          (MonoidAlgebra.single g 1) := (coordinateMap_single R φ g 1).symm
+    _ = FiniteTypeCommHopfAlgCat.toBialgHom (coordinateMap R ψ)
+          (MonoidAlgebra.single g 1) := by rw [h]
+    _ = MonoidAlgebra.single (FGCommGrpCat.toMonoidHom ψ g) 1 :=
+      coordinateMap_single R ψ g 1
+
 /-- The coordinate-ring construction for finite-type diagonalizable groups.
 
 It is covariant on coordinate Hopf algebras. After applying the contravariant spectrum
@@ -125,6 +147,12 @@ Hopf-algebra morphism. -/
 theorem coordinateRingFunctor_map {G H : FGCommGrpCat.{v}} (φ : G ⟶ H) :
     (coordinateRingFunctor R).map φ = coordinateMap R φ :=
   rfl
+
+/-- The coordinate-ring functor of finite-type diagonalizable groups is faithful over a
+nontrivial base ring. -/
+noncomputable instance coordinateRingFunctor_faithful [Nontrivial R] :
+    (coordinateRingFunctor R).Faithful where
+  map_injective h := coordinateMap_injective R h
 
 end DiagonalizableGroup
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-coordinate-faithful"}-->

This PR proves that the coordinate morphism `R[G] → R[H]` remembers the homomorphism
`G → H` over a nontrivial base ring, and registers
`DiagonalizableGroup.coordinateRingFunctor R` as faithful.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, “Diagonalizable groups and
groups of multiplicative type,” toward the anti-equivalence between finitely generated abelian
groups and diagonalizable groups. This faithful half is distinct and presently useful on the
existing coordinate-Hopf-algebra side; fullness and scheme-side essential surjectivity remain
separate later steps.

The implementation extends
`TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/FiniteType.lean` with
`coordinateMap_injective` and `coordinateRingFunctor_faithful`. It evaluates equal coordinate
maps on `MonoidAlgebra.single g 1`, reusing `coordinateMap_single` and
`MonoidAlgebra.single_left_injective`. The construction is the standard diagonalizable-group
correspondence described in Waterhouse, *Introduction to Affine Group Schemes*, Chapter 2.

Validation on the final commit:

- `lake exe cache get`: no files to download; 8641 files already decompressed
- `LAKE_RESTORE_ARTIFACTS=true lake build`: success (5929 jobs)
- `../tc axioms`: 12 declarations audited; only `propext`, `Classical.choice`, and `Quot.sound`
- `../tc lint`: 3 declarations documented; no new violations

🤖 Prepared by Codex
