### PR TITLE
refactor(Contour): share the crossing-window setup between the two PV summits

### DIFF
--- a/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
@@ -29,6 +29,8 @@ compact `[[a, b]]` would have an accumulation point.
 * `Contour.IsPwC1ImmersionOn.eventually_ne_nhdsNE` — crossings of an immersion are isolated.
 * `Contour.IsPwC1ImmersionOn.finite_crossings` — **HW Proposition 2.2**: the crossing set
   `[[a, b]] ∩ γ ⁻¹' {z₀}` of an immersion is finite.
+* `Contour.IsPwC1ImmersionOn.mem_toFinset_finite_crossings` — membership in the resulting
+  crossing finset, for `a ≤ b`.
 
 ## Provenance
 
@@ -206,6 +208,16 @@ theorem IsPwC1ImmersionOn.finite_crossings (h : IsPwC1ImmersionOn γ a b) :
       exact (hfreq.and_eventually hev).exists.elim fun t ht => ht.2 ht.1
     · have hev := crossing_isolated_right h ⟨ht₀_Icc.1, hlt⟩ ht₀_mem.2
       exact (hfreq.and_eventually hev).exists.elim fun t ht => ht.2 ht.1.2
+
+/-- **Membership in the crossing finset.** For `a ≤ b`, the finset supplied by
+`IsPwC1ImmersionOn.finite_crossings` consists of exactly the parameters of `Icc a b` at which
+`γ` takes the value `z₀`. Multi-crossing principal-value arguments index their windows by this
+finset, so they need the characterisation and not just the finiteness. -/
+theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings (h : IsPwC1ImmersionOn γ a b)
+    (hab : a ≤ b) {t : ℝ} :
+    t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ Icc a b ∧ γ t = z₀ := by
+  rw [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage, Set.mem_singleton_iff,
+    uIcc_of_le hab]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Finiteness.lean
@@ -30,7 +30,7 @@ compact `[[a, b]]` would have an accumulation point.
 * `Contour.IsPwC1ImmersionOn.finite_crossings` — **HW Proposition 2.2**: the crossing set
   `[[a, b]] ∩ γ ⁻¹' {z₀}` of an immersion is finite.
 * `Contour.IsPwC1ImmersionOn.mem_toFinset_finite_crossings` — membership in the resulting
-  crossing finset, for `a ≤ b`.
+  crossing finset.
 
 ## Provenance
 
@@ -209,15 +209,14 @@ theorem IsPwC1ImmersionOn.finite_crossings (h : IsPwC1ImmersionOn γ a b) :
     · have hev := crossing_isolated_right h ⟨ht₀_Icc.1, hlt⟩ ht₀_mem.2
       exact (hfreq.and_eventually hev).exists.elim fun t ht => ht.2 ht.1.2
 
-/-- **Membership in the crossing finset.** For `a ≤ b`, the finset supplied by
-`IsPwC1ImmersionOn.finite_crossings` consists of exactly the parameters of `Icc a b` at which
+/-- **Membership in the crossing finset.** The finset supplied by
+`IsPwC1ImmersionOn.finite_crossings` consists of exactly the parameters of `[[a, b]]` at which
 `γ` takes the value `z₀`. Multi-crossing principal-value arguments index their windows by this
-finset, so they need the characterisation and not just the finiteness. -/
-theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings (h : IsPwC1ImmersionOn γ a b)
-    (hab : a ≤ b) {t : ℝ} :
-    t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ Icc a b ∧ γ t = z₀ := by
-  rw [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage, Set.mem_singleton_iff,
-    uIcc_of_le hab]
+finset, so they need the characterisation and not just the finiteness; for ordered endpoints
+follow with `uIcc_of_le`. -/
+theorem IsPwC1ImmersionOn.mem_toFinset_finite_crossings (h : IsPwC1ImmersionOn γ a b) {t : ℝ} :
+    t ∈ (h.finite_crossings (z₀ := z₀)).toFinset ↔ t ∈ uIcc a b ∧ γ t = z₀ := by
+  rw [Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage, Set.mem_singleton_iff]
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -181,23 +181,26 @@ theorem exists_common_window_radius_le {a b : ℝ} {crossings : Finset ℝ}
     fun t ht t' ht' hne => by linarith [h_pair t ht t' ht' hne],
     fun t ht => le_of_lt (by simpa using hr_all (some ⟨t, ht⟩))⟩
 
-/-- **In-window uniqueness of the crossing**: with windows inside `[a, b]`, distinct crossings
-more than `r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value
-`s` is a listed crossing — the only parameter of the window `[t_i - r, t_i + r]` where `γ`
-takes the value `s` is `t_i` itself. Stated for a bare function; no regularity is used. -/
+/-- **In-window uniqueness of the crossing**: if the window `[t_i - r, t_i + r]` lies inside
+`[a, b]`, every listed crossing other than `t_i` is more than `r` from `t_i`, and the listing is
+complete — every parameter of `[a, b]` where `γ` takes the value `s` is listed — then the only
+parameter of that window where `γ` takes the value `s` is `t_i` itself.
+
+Both margin hypotheses are pointwise at `t_i`; nothing is assumed about the other crossings'
+windows, and `t_i` need not itself be listed. Stated for a bare function; no regularity is
+used. -/
 theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
-    {crossings : Finset ℝ} {r : ℝ}
-    (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
-    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → r < |t - t'|)
+    {crossings : Finset ℝ} {r t_i : ℝ}
+    (h_endpts : a + r ≤ t_i ∧ t_i ≤ b - r)
+    (h_pairwise : ∀ t' ∈ crossings, t' ≠ t_i → r < |t_i - t'|)
     (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
-    {t_i : ℝ} (ht_i : t_i ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
     t = t_i := by
-  obtain ⟨h_ge, h_le⟩ := h_endpts t_i ht_i
+  obtain ⟨h_ge, h_le⟩ := h_endpts
   have h_t_cross : t ∈ crossings :=
     h_complete t ⟨by linarith [ht.1], by linarith [ht.2]⟩ h_eq
   by_contra h_ne
-  have h_dist := h_pairwise t_i ht_i t h_t_cross h_ne
+  have h_dist := h_pairwise t h_t_cross h_ne
   have : |t_i - t| ≤ r := by
     rw [abs_sub_comm, abs_le]
     exact ⟨by linarith [ht.1], by linarith [ht.2]⟩
@@ -205,21 +208,20 @@ theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : �
 
 /-- **In-window uniqueness of the crossing, from a common window radius.** The variant of
 `eq_of_mem_window_of_eq` whose margins are the *strict* ones `exists_common_window_radius_le`
-returns: crossings more than `r` inside the endpoints, and distinct crossings more than `2 * r`
-apart. No sign condition on `r` is required — halving the pairwise margin needs `0 ≤ r`, but a
-negative radius leaves the window `[t_i - r, t_i + r]` empty, so `ht` supplies it. -/
+returns, read off at `t_i`: `t_i` more than `r` inside the endpoints, and every other crossing
+more than `2 * r` from it. No sign condition on `r` is required — halving the pairwise margin
+needs `0 ≤ r`, but a negative radius leaves the window `[t_i - r, t_i + r]` empty, so `ht`
+supplies it. -/
 theorem eq_of_mem_window_of_eq_of_lt_of_two_mul_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
-    {crossings : Finset ℝ} {r : ℝ}
-    (h_endpts : ∀ t ∈ crossings, a + r < t ∧ t < b - r)
-    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)
+    {crossings : Finset ℝ} {r t_i : ℝ}
+    (h_endpts : a + r < t_i ∧ t_i < b - r)
+    (h_pairwise : ∀ t' ∈ crossings, t' ≠ t_i → 2 * r < |t_i - t'|)
     (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
-    {t_i : ℝ} (ht_i : t_i ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
     t = t_i := by
   have hr : 0 ≤ r := by linarith [ht.1, ht.2]
-  exact eq_of_mem_window_of_eq (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
-    (fun u hu u' hu' hne => by linarith [h_pairwise u hu u' hu' hne])
-    h_complete ht_i ht h_eq
+  exact eq_of_mem_window_of_eq ⟨h_endpts.1.le, h_endpts.2.le⟩
+    (fun t' ht' hne => by linarith [h_pairwise t' ht' hne]) h_complete ht h_eq
 
 /-- **Positive distance bound on the half-windows**: when the crossing is unique in its window,
 `‖γ t - s‖` is bounded below by a common `m > 0` on the two closed half-windows

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -30,6 +30,8 @@ scaffolding that localizes the principal-value analysis to one crossing per wind
 * `Contour.exists_common_window_radius_le` — a common window radius additionally held below a
   positive per-crossing bound, with strict endpoint margins.
 * `Contour.eq_of_mem_window_of_eq` — in-window uniqueness of the crossing.
+* `Contour.eq_of_mem_window_of_eq'` — the same, from the strict margins returned by
+  `exists_common_window_radius_le`.
 * `Contour.exists_window_dist_lower_bound` — a positive lower bound for `‖γ t - s‖` on the two
   closed half-windows excluding the crossing.
 * `Contour.exists_complement_windows_dist_lower_bound` — a positive lower bound for
@@ -200,6 +202,24 @@ theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : �
     rw [abs_sub_comm, abs_le]
     exact ⟨by linarith [ht.1], by linarith [ht.2]⟩
   linarith [abs_nonneg (t_i - t)]
+
+/-- **In-window uniqueness of the crossing, from a common window radius.** The variant of
+`eq_of_mem_window_of_eq` whose margins are the *strict* ones `exists_common_window_radius_le`
+returns: crossings more than `r` inside the endpoints, and distinct crossings more than `2 * r`
+apart. No sign condition on `r` is required — halving the pairwise margin needs `0 ≤ r`, but a
+negative radius leaves the window `[t_i - r, t_i + r]` empty, so `ht` supplies it. -/
+theorem eq_of_mem_window_of_eq' {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
+    {crossings : Finset ℝ} {r : ℝ}
+    (h_endpts : ∀ t ∈ crossings, a + r < t ∧ t < b - r)
+    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)
+    (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
+    {t_i : ℝ} (ht_i : t_i ∈ crossings)
+    {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
+    t = t_i := by
+  have hr : 0 ≤ r := by linarith [ht.1, ht.2]
+  exact eq_of_mem_window_of_eq (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
+    (fun u hu u' hu' hne => by linarith [h_pairwise u hu u' hu' hne])
+    h_complete ht_i ht h_eq
 
 /-- **Positive distance bound on the half-windows**: when the crossing is unique in its window,
 `‖γ t - s‖` is bounded below by a common `m > 0` on the two closed half-windows

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -30,8 +30,8 @@ scaffolding that localizes the principal-value analysis to one crossing per wind
 * `Contour.exists_common_window_radius_le` — a common window radius additionally held below a
   positive per-crossing bound, with strict endpoint margins.
 * `Contour.eq_of_mem_window_of_eq` — in-window uniqueness of the crossing.
-* `Contour.eq_of_mem_window_of_eq'` — the same, from the strict margins returned by
-  `exists_common_window_radius_le`.
+* `Contour.eq_of_mem_window_of_eq_of_lt_of_two_mul_lt` — the same, from the strict margins
+  returned by `exists_common_window_radius_le`.
 * `Contour.exists_window_dist_lower_bound` — a positive lower bound for `‖γ t - s‖` on the two
   closed half-windows excluding the crossing.
 * `Contour.exists_complement_windows_dist_lower_bound` — a positive lower bound for
@@ -208,7 +208,7 @@ theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : �
 returns: crossings more than `r` inside the endpoints, and distinct crossings more than `2 * r`
 apart. No sign condition on `r` is required — halving the pairwise margin needs `0 ≤ r`, but a
 negative radius leaves the window `[t_i - r, t_i + r]` empty, so `ht` supplies it. -/
-theorem eq_of_mem_window_of_eq' {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
+theorem eq_of_mem_window_of_eq_of_lt_of_two_mul_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
     {crossings : Finset ℝ} {r : ℝ}
     (h_endpts : ∀ t ∈ crossings, a + r < t ∧ t < b - r)
     (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|)

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -29,7 +29,9 @@ scaffolding that localizes the principal-value analysis to one crossing per wind
 * `Contour.exists_common_window_radius` — the common window radius.
 * `Contour.exists_common_window_radius_le` — a common window radius additionally held below a
   positive per-crossing bound, with strict endpoint margins.
-* `Contour.eq_of_mem_window_of_eq` — in-window uniqueness of the crossing.
+* `Contour.eq_of_mem_window_of_eq_of_le_of_lt` — in-window uniqueness of the crossing, from
+  margins at that crossing alone.
+* `Contour.eq_of_mem_window_of_eq` — the same for a whole crossing family.
 * `Contour.eq_of_mem_window_of_eq_of_lt_of_two_mul_lt` — the same, from the strict margins
   returned by `exists_common_window_radius_le`.
 * `Contour.exists_window_dist_lower_bound` — a positive lower bound for `‖γ t - s‖` on the two
@@ -181,15 +183,17 @@ theorem exists_common_window_radius_le {a b : ℝ} {crossings : Finset ℝ}
     fun t ht t' ht' hne => by linarith [h_pair t ht t' ht' hne],
     fun t ht => le_of_lt (by simpa using hr_all (some ⟨t, ht⟩))⟩
 
-/-- **In-window uniqueness of the crossing**: if the window `[t_i - r, t_i + r]` lies inside
-`[a, b]`, every listed crossing other than `t_i` is more than `r` from `t_i`, and the listing is
-complete — every parameter of `[a, b]` where `γ` takes the value `s` is listed — then the only
-parameter of that window where `γ` takes the value `s` is `t_i` itself.
+/-- **In-window uniqueness of the crossing, from margins at that crossing alone.** If the window
+`[t_i - r, t_i + r]` lies inside `[a, b]`, every listed crossing other than `t_i` is more than
+`r` from `t_i`, and the listing is complete — every parameter of `[a, b]` where `γ` takes the
+value `s` is listed — then the only parameter of that window where `γ` takes the value `s` is
+`t_i` itself.
 
-Both margin hypotheses are pointwise at `t_i`; nothing is assumed about the other crossings'
-windows, and `t_i` need not itself be listed. Stated for a bare function; no regularity is
+This is the pointwise core: nothing is assumed about the other crossings' own windows, and
+`t_i` need not itself be listed. `eq_of_mem_window_of_eq` is the family-wide form, for callers
+holding margins for every crossing at once. Stated for a bare function; no regularity is
 used. -/
-theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
+theorem eq_of_mem_window_of_eq_of_le_of_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
     {crossings : Finset ℝ} {r t_i : ℝ}
     (h_endpts : a + r ≤ t_i ∧ t_i ≤ b - r)
     (h_pairwise : ∀ t' ∈ crossings, t' ≠ t_i → r < |t_i - t'|)
@@ -206,12 +210,29 @@ theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : �
     exact ⟨by linarith [ht.1], by linarith [ht.2]⟩
   linarith [abs_nonneg (t_i - t)]
 
+/-- **In-window uniqueness of the crossing**: with windows inside `[a, b]`, distinct crossings
+more than `r` apart, and completeness — every parameter of `[a, b]` where `γ` takes the value
+`s` is a listed crossing — the only parameter of the window `[t_i - r, t_i + r]` where `γ`
+takes the value `s` is `t_i` itself. Stated for a bare function; no regularity is used.
+
+The family-wide form, for callers holding margins for every crossing at once; it reads them off
+at `t_i` and defers to `eq_of_mem_window_of_eq_of_le_of_lt`. -/
+theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
+    {crossings : Finset ℝ} {r : ℝ}
+    (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
+    (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → r < |t - t'|)
+    (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
+    {t_i : ℝ} (ht_i : t_i ∈ crossings)
+    {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
+    t = t_i :=
+  eq_of_mem_window_of_eq_of_le_of_lt (h_endpts t_i ht_i) (h_pairwise t_i ht_i) h_complete ht h_eq
+
 /-- **In-window uniqueness of the crossing, from a common window radius.** The variant of
-`eq_of_mem_window_of_eq` whose margins are the *strict* ones `exists_common_window_radius_le`
-returns, read off at `t_i`: `t_i` more than `r` inside the endpoints, and every other crossing
-more than `2 * r` from it. No sign condition on `r` is required — halving the pairwise margin
-needs `0 ≤ r`, but a negative radius leaves the window `[t_i - r, t_i + r]` empty, so `ht`
-supplies it. -/
+`eq_of_mem_window_of_eq_of_le_of_lt` whose margins are the *strict* ones
+`exists_common_window_radius_le` returns, read off at `t_i`: `t_i` more than `r` inside the
+endpoints, and every other crossing more than `2 * r` from it. No sign condition on `r` is
+required — halving the pairwise margin needs `0 ≤ r`, but a negative radius leaves the window
+`[t_i - r, t_i + r]` empty, so `ht` supplies it. -/
 theorem eq_of_mem_window_of_eq_of_lt_of_two_mul_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
     {crossings : Finset ℝ} {r t_i : ℝ}
     (h_endpts : a + r < t_i ∧ t_i < b - r)
@@ -220,7 +241,7 @@ theorem eq_of_mem_window_of_eq_of_lt_of_two_mul_lt {α : Type*} {γ : ℝ → α
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
     t = t_i := by
   have hr : 0 ≤ r := by linarith [ht.1, ht.2]
-  exact eq_of_mem_window_of_eq ⟨h_endpts.1.le, h_endpts.2.le⟩
+  exact eq_of_mem_window_of_eq_of_le_of_lt ⟨h_endpts.1.le, h_endpts.2.le⟩
     (fun t' ht' hne => by linarith [h_pairwise t' ht' hne]) h_complete ht h_eq
 
 /-- **Positive distance bound on the half-windows**: when the crossing is unique in its window,

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -143,9 +143,8 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
   rcases hab.eq_or_lt with rfl | hab
   · simpa using HasCauchyPVAt.of_eq γ rfl (fun z => c / (z - s) ^ k) s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
-  have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {t} => by
-    rw [hT_def, Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage,
-      Set.mem_singleton_iff, uIcc_of_le hab.le]
+  have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
+    rw [hT_def]; exact h_imm.mem_toFinset_finite_crossings hab.le
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2
@@ -180,10 +179,7 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
         (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
         (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq
-          (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
-          (fun u hu u' hu' hne => by linarith [h_pair u hu u' hu' hne])
-          h_complete ht₀ ht h_eq)
+        fun t ht h_eq => eq_of_mem_window_of_eq' h_endpts h_pair h_complete ht₀ ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -144,7 +144,7 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
   · simpa using HasCauchyPVAt.of_eq γ rfl (fun z => c / (z - s) ^ k) s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def]; exact h_imm.mem_toFinset_finite_crossings hab.le
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2
@@ -179,7 +179,8 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
         (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
         (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq' h_endpts h_pair h_complete ht₀ ht h_eq)
+        fun t ht h_eq =>
+          eq_of_mem_window_of_eq_of_lt_of_two_mul_lt h_endpts h_pair h_complete ht₀ ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -179,8 +179,8 @@ theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {
         (hT_mem.mp ht₀).2 hk hkn (h_flat t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2)
         (h_B t₀ (hT_mem.mp ht₀).1 (hT_mem.mp ht₀).2) c p.countable_toSet hp hρ_pos
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq =>
-          eq_of_mem_window_of_eq_of_lt_of_two_mul_lt h_endpts h_pair h_complete ht₀ ht h_eq)
+        fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
+          (h_pair t₀ ht₀) h_complete ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -124,7 +124,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
   · exact CauchyPVExistsAt.of_eq γ rfl _ s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
   have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
-    rw [hT_def]; exact h_imm.mem_toFinset_finite_crossings hab.le
+    rw [hT_def, h_imm.mem_toFinset_finite_crossings, uIcc_of_le hab.le]
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2
@@ -151,7 +151,8 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       h_int_tr
       (fun t₀ ht₀ => h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq' h_endpts h_pair h_complete ht₀ ht h_eq)
+        fun t ht h_eq =>
+          eq_of_mem_window_of_eq_of_lt_of_two_mul_lt h_endpts h_pair h_complete ht₀ ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -123,9 +123,8 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
   rcases hab.eq_or_lt with rfl | hab
   · exact CauchyPVExistsAt.of_eq γ rfl _ s
   set T : Finset ℝ := (h_imm.finite_crossings (z₀ := s)).toFinset with hT_def
-  have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {t} => by
-    rw [hT_def, Set.Finite.mem_toFinset, Set.mem_inter_iff, Set.mem_preimage,
-      Set.mem_singleton_iff, uIcc_of_le hab.le]
+  have hT_mem : ∀ {t : ℝ}, t ∈ T ↔ t ∈ Icc a b ∧ γ t = s := fun {_} => by
+    rw [hT_def]; exact h_imm.mem_toFinset_finite_crossings hab.le
   have h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ T := fun t ht h_eq => hT_mem.mpr ⟨ht, h_eq⟩
   have h_Ioo : ∀ t ∈ T, t ∈ Ioo a b := fun t ht =>
     h_interior t (hT_mem.mp ht).1 (hT_mem.mp ht).2
@@ -152,10 +151,7 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       h_int_tr
       (fun t₀ ht₀ => h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq => eq_of_mem_window_of_eq
-          (fun u hu => ⟨(h_endpts u hu).1.le, (h_endpts u hu).2.le⟩)
-          (fun u hu u' hu' hne => by linarith [h_pair u hu u' hu' hne])
-          h_complete ht₀ ht h_eq)
+        fun t ht h_eq => eq_of_mem_window_of_eq' h_endpts h_pair h_complete ht₀ ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 

--- a/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
+++ b/TauCeti/Analysis/Contour/InvSubCPVExistence.lean
@@ -151,8 +151,8 @@ theorem IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub {γ : ℝ → ℂ} {a b : ℝ
       h_int_tr
       (fun t₀ ht₀ => h_spec t₀ ht₀ ρ hρ_pos (hρ_le_R t₀ ht₀)
         (by linarith [(h_endpts t₀ ht₀).1]) (by linarith [(h_endpts t₀ ht₀).2])
-        fun t ht h_eq =>
-          eq_of_mem_window_of_eq_of_lt_of_two_mul_lt h_endpts h_pair h_complete ht₀ ht h_eq)
+        fun t ht h_eq => eq_of_mem_window_of_eq_of_lt_of_two_mul_lt (h_endpts t₀ ht₀)
+          (h_pair t₀ ht₀) h_complete ht h_eq)
       (exists_complement_windows_dist_lower_bound hγ_cont h_complete (fun _ => ρ)
         fun t _ => hρ_pos)
 


### PR DESCRIPTION
`IsPwC1ImmersionOn.cauchyPVExistsAt_inv_sub` (`InvSubCPVExistence.lean`) and
`IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv` (`HigherOrder/CPV.lean`) are the same
multi-crossing principal-value argument run on two different integrands. They carried two
verbatim-identical blocks; both now route through named lemmas in the support files they
already import.

## What moved

**`IsPwC1ImmersionOn.mem_toFinset_finite_crossings`** → `Crossing/Finiteness.lean`, next to
`finite_crossings` whose finset it characterises. Each summit repeated the same four-rewrite
unfolding of the intersection/preimage.

**`eq_of_mem_window_of_eq_of_lt_of_two_mul_lt`** → `Crossing/Windows.lean`, next to the lemma
it varies. Each summit repeated the same four-line margin conversion inline.

## Minimal hypotheses, not inherited context

`eq_of_mem_window_of_eq` wants non-strict margins and `r < |t_i - t'|`.
`exists_common_window_radius_le` returns strict margins and `2 * r < |t_i - t'|` — and it is
the *only* producer of the strict endpoint form (`exists_common_window_radius` returns the
non-strict one), which is why the docstring names it specifically.

Weakening the pairwise margin from `2 * r` to `r` needs `0 ≤ r`. Both callers had that to
hand as `hρ_pos.le`, so threading it through would have been the path of least resistance —
but it is not necessary: a negative radius leaves the window `[t_i - r, t_i + r]` empty, so
`ht : t ∈ Icc (t_i - r) (t_i + r)` already yields `0 ≤ r` by `linarith`. The lemma derives it
rather than demanding it, and neither call site passes a sign hypothesis.

## Degenerate ends

- `r = 0`: the window collapses to `{t_i}`, so the conclusion is immediate.
- `r < 0`: the window is empty, `ht` is unsatisfiable, statement vacuous — this is the case
  that makes the sign hypothesis droppable.
- `crossings = ∅`: `h_pairwise` is vacuous and `h_complete` forces the window to contain no
  value-`s` parameter at all, so the conclusion is again vacuous.
- `a = b` in `mem_toFinset_finite_crossings`: `uIcc a a = {a}`, characterisation still holds.

## Review rounds

**Round 1 (`generality`, `naming`) — applied in `ca039a6`:**

- `mem_toFinset_finite_crossings` no longer takes `a ≤ b`; it is stated over `uIcc a b`,
  matching `finite_crossings`. Both call sites recover the ordered form with
  `uIcc_of_le hab.le` in the same `rw`.
- `eq_of_mem_window_of_eq'` → `eq_of_mem_window_of_eq_of_lt_of_two_mul_lt`, naming the two
  distinguishing hypotheses after `of` rather than using a prime.

**Round 1 (`api-design`, `@[simp]` on `mem_toFinset_finite_crossings`) — not applied; it
fails the lint gate.** I tried it rather than assuming. With the attribute added,
`scripts/lint-env.sh` reports a *new* simpNF violation:

```
  [simpNF]
  #check @TauCeti.Contour.IsPwC1ImmersionOn.mem_toFinset_finite_crossings /- simp can prove this:
LINT-ENV: FAIL —        1 new violation(s); see the list above
```

`Set.Finite.mem_toFinset` is itself `@[simp]` (`Mathlib/Data/Set/Finite/Basic.lean:105`), as
are `Set.mem_inter_iff`, `Set.mem_preimage` and `Set.mem_singleton_iff`, so simp already
rewrites the LHS straight through to the RHS and the attribute is redundant. Note the two
findings interact: it is `generality`'s (correct) move to `uIcc a b` that made the statement
simp-provable — in the `Icc a b` + `hab` form simp could not close it. *(This rubric passed on
`ca039a6`.)*

**Round 2 (`generality`) — applied in `13c5ec4`.** The margin hypotheses were quantified over
every crossing when only the margins at the selected `t_i` are used. Both are now pointwise:
`a + r < t_i ∧ t_i < b - r` and `∀ t' ∈ crossings, t' ≠ t_i → 2 * r < |t_i - t'|`.

## Round 3 (`api-design`) — applied in `9406aa6`

The round-2 commit changed the public signature of `eq_of_mem_window_of_eq`. That is now undone;
the pointwise implementation lives under a new name and the original is a wrapper over it:

- `eq_of_mem_window_of_eq_of_le_of_lt` — the pointwise core.
- `eq_of_mem_window_of_eq` — **restored byte-identically to its signature on `main`**, a one-line
  delegation reading its family-wide margins off at `t_i`.
- `eq_of_mem_window_of_eq_of_lt_of_two_mul_lt` — pointwise strict margins, same core.

`git diff origin/main -- …/Crossing/Windows.lean` shows the new theorems as pure additions; no
line of the existing declaration appears on either side. **There are no signature changes in
this PR.**

This resolves against the round-2 `generality` finding rather than trading one for the other:
that finding was raised against the strict-margin variant, which stays pointwise, while the
family-wide entry point is a separate convenience for callers holding margins for every
crossing — the shape `exists_common_window_radius(_le)` returns.

Gates run locally as separate steps on `9406aa6`, all green: `lake build`, `lake exe axioms`,
`lake exe module-system`, `scripts/lint-env.sh`.

## Notes

- The red `profile` check is the known fork-checkout outage in `.github/workflows/pr-profile.yml`
  (`allow-unsafe-pr-checkout: false` under `pull_request_target`); it fails in ~7s at checkout
  on every fork PR, before any Lean runs, and is unrelated to this diff. `sandboxed-build`,
  `build`, `scope` and `bump-guard` pass.

Roadmap: ContourIntegration