### PR TITLE
docs+refactor(Probability): drop a drifted count and golf the L² polarisation ending

### DIFF
--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -252,7 +252,7 @@ theorem condExp_indicator_sup_eq_of_condIndep {Ω : Type*} {mΩ : MeasurableSpac
 
 The pair-law/L² machinery below is generic conditional-expectation infrastructure: its hypotheses
 mention only measurable maps, equality of pair laws, and the σ-algebra ordering `σ(W) ≤ σ(W')` —
-never contractability.  The four support lemmas stay `private`; the contraction-independence
+never contractability. The support lemmas stay `private`; the contraction-independence
 conclusion is public so the de Finetti prefix-deletion file can reuse it across the module boundary.
 -/
 
@@ -404,7 +404,7 @@ private lemma ae_eq_of_integral_mul_eq_of_integral_sq_eq {Ω : Type*} {mΩ : Mea
   have h_diff_zero : ∀ᵐ ω ∂μ, (g₂ ω - g₁ ω) ^ 2 = 0 :=
     (integral_eq_zero_iff_of_nonneg_ae (ae_of_all μ fun ω => sq_nonneg _) h_sq_int).mp h_L2_zero
   filter_upwards [h_diff_zero] with ω hω
-  nlinarith [sq_nonneg (g₂ ω - g₁ ω)]
+  exact (sub_eq_zero.mp (sq_eq_zero_iff.mp hω)).symm
 
 /-- The conditional expectation of a `0/1` indicator is bounded by `1` in norm almost everywhere,
 on any sub-σ-algebra: the indicator itself is, and conditioning does not increase the bound. -/


### PR DESCRIPTION
Two corrections to the Kallenberg 1.3 support block of
`Probability/Independence/Conditional.lean`.

## The count had drifted twice

The section docstring claimed:

> The **four** support lemmas stay `private`; the contraction-independence conclusion is public …

There are six, all `private`, all between the section header and the public theorem:

| line | lemma |
|---|---|
| 263 | `marginal_law_eq_of_pair_law` |
| 273 | `setIntegral_indicator_preimage_eq_of_pair_law` |
| 297 | `setIntegral_map_eq_setIntegral_preimage_of_condExp_comp` |
| 316 | `integral_sq_condExp_eq_of_pair_law` |
| 381 | `ae_eq_of_integral_mul_eq_of_integral_sq_eq` |
| 411 | `ae_norm_condExp_indicator_le_one` |

The claim was **correct when written**. `git log -S` dates it to `ebefc23` (#1072), when there
were exactly four. It then drifted twice:

- `5ce7e99` (#1155) extracted `ae_eq_of_integral_mul_eq_of_integral_sq_eq` → five;
- `f07fcdd` (#1291) extracted `ae_norm_condExp_indicator_le_one` → six.

Both were decomposition PRs that added a `private` helper to this block without touching the
prose count.

**This drops the count rather than bumping it to six.** A prose count of declarations in the
same file is exactly the kind of claim that rots, and this one has now rotted twice under the
same mechanism — any future decomposition here would break "six" the same way. The sentence's
actual content is the `private`/public split, which is what it now states. Everything else in
the paragraph checks out: none of the six mentions contractability, and the public conclusion
is indeed consumed across the module boundary by `DeFinetti/PrefixDeletion.lean`.

## `nlinarith` where two named lemmas apply

`ae_eq_of_integral_mul_eq_of_integral_sq_eq` finishes from `hω : (g₂ ω - g₁ ω) ^ 2 = 0` with
goal `g₁ ω = g₂ ω`:

```lean
-  nlinarith [sq_nonneg (g₂ ω - g₁ ω)]
+  exact (sub_eq_zero.mp (sq_eq_zero_iff.mp hω)).symm
```

`sq_eq_zero_iff` (`Mathlib/Algebra/GroupWithZero/Basic.lean:262`) and `sub_eq_zero` state this
directly, so the nonlinear-arithmetic search was doing by proof search what the library states
as an equivalence. Confirmed with `lean_multi_attempt` before editing: the replacement
elaborates with no diagnostics.

## Scope

One file, one topic: tidying that support block. No statement of any declaration changes — the
docstring edit is prose, and the golf is inside a `private` lemma's proof.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`,
`lake exe module-system`, `scripts/lint-env.sh`.
