### PR TITLE
feat: align Zulip PR posts with status labels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           python3 scripts/pr_status/test_stuck_alerts.py
           python3 scripts/test_roadmap_label.py
           python3 scripts/pr_status/test_pr_labels.py
+          python3 scripts/pr_status/test_zulip.py
           python3 scripts/test_structure_nudge.py
 
       # The two-library split is build convenience, not a trust boundary.

--- a/.github/workflows/zulip-pr-backfill.yml
+++ b/.github/workflows/zulip-pr-backfill.yml
@@ -1,0 +1,61 @@
+name: Zulip PR backfill
+
+# Manually rewrite every existing bot-authored post in "Tau Ceti" > "PRs"
+# from current GitHub metadata. This is deliberately separate from the
+# event-driven workflows: normal updates stay fast, while a format migration
+# can edit the full history in place without reposting or duplicating messages.
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Read every post and report changes without writing them"
+        required: true
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  pull-requests: read
+  statuses: read
+
+concurrency:
+  group: zulip-pr-backfill
+  cancel-in-progress: false
+
+jobs:
+  backfill:
+    if: github.repository == 'TauCetiProject/TauCeti'
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: scripts/pr_status
+      - name: Reconcile all existing PR posts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
+          ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
+          ZULIP_SITE: https://leanprover.zulipchat.com
+          DRY_RUN: ${{ inputs.dry_run }}
+        run: |
+          set -euo pipefail
+          args=(--strict)
+          if [ "$DRY_RUN" = "true" ]; then args+=(--dry-run); fi
+
+          # Pass the paginated listing's complete PR metadata to one long-lived
+          # process. This stays well below GITHUB_TOKEN's 1,000 requests/hour
+          # repository limit and authenticates the Zulip bot only once.
+          gh api --paginate \
+            'repos/TauCetiProject/TauCeti/pulls?state=all&sort=created&direction=asc&per_page=100' \
+            --jq '.[] | {
+              number,
+              state,
+              merged: (.merged_at != null),
+              head: .head.sha,
+              title,
+              author: .user.login,
+              roadmaps: [.labels[].name | select(startswith("roadmap/"))]
+            }' |
+            python3 scripts/pr_status/zulip.py backfill "${args[@]}"

--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -1,16 +1,20 @@
 name: Zulip PR status (lifecycle)
 
 # Maintain the per-PR message + emoji in the "Tau Ceti" Zulip channel as a PR is
-# opened, reopened, merged, or closed. CI- and review-status changes are handled
-# by zulip-pr-status.yml; this one owns the message's existence and its
-# merged/closed lifecycle. A one-off reaction hiccup is cosmetic and the script
-# swallows it (exit 0); a *config* break (bad ZULIP_API_KEY, bot not subscribed)
-# makes the script exit non-zero so this run goes red -- that is the only way the
-# breakage is visible, since the integration otherwise fails silently.
+# opened, reopened, merged, closed, or relabeled. CI- and review-status changes
+# are also handled by zulip-pr-status.yml; label events keep the roadmap shown in
+# the post current and make the emoji follow the automatic status-label changes
+# promptly. A one-off reaction hiccup is cosmetic and the script swallows it
+# (exit 0); a *config* break (bad ZULIP_API_KEY, bot not subscribed) makes the
+# script exit non-zero so this run goes red -- that is the only way the breakage
+# is visible, since the integration otherwise fails silently.
 
 on:
+  # These label writes use the repository GitHub App, not GITHUB_TOKEN, so they
+  # generate workflow events. That is what makes review/roadmap changes refresh
+  # the Zulip post promptly.
   pull_request_target:
-    types: [opened, reopened, closed]
+    types: [opened, reopened, closed, labeled, unlabeled]
 
 permissions:
   contents: read        # checkout the script
@@ -52,8 +56,23 @@ jobs:
           PR_MERGED: ${{ github.event.pull_request.merged }}
           PR_HEAD: ${{ github.event.pull_request.head.sha }}
           PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_AUTHOR: ${{ github.event.pull_request.user.login }}
+          PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels) }}
         run: |
-          # Create the message when a PR opens/reopens; otherwise only react to it.
+          # A label event's payload can be stale when several label writes race.
+          # Force those events through the API fallback so they read current truth.
+          if [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; then
+            unset PR_STATE PR_MERGED PR_HEAD PR_TITLE PR_AUTHOR PR_LABELS_JSON
+          fi
+
+          # Only opening/reopening may create a post. Label churn on a closed PR
+          # must never resurrect a missing announcement out of chronological order.
           CREATE=""
-          if [ "$ACTION" != "closed" ]; then CREATE="--create"; fi
+          if [ "$ACTION" = "opened" ] || [ "$ACTION" = "reopened" ]; then
+            CREATE="--create"
+          elif [ "$ACTION" = "labeled" ] || [ "$ACTION" = "unlabeled" ]; then
+            # Self-heal a transient failure in the original opened run, but
+            # only while current GitHub truth still says the PR is open.
+            CREATE="--create-if-open"
+          fi
           python3 scripts/pr_status/zulip.py reconcile "$PR" $CREATE

--- a/scripts/pr_status/README.md
+++ b/scripts/pr_status/README.md
@@ -20,12 +20,12 @@ reactions can never disagree:
 | --- | --- | --- |
 | lifecycle `merged` / `closed` | *(no label)* | `:merge:` / `:closed-pr:` |
 | ci `running` | `awaiting-CI` | 🟡 `yellow` |
-| ci not reported | `awaiting-CI` | *(no CI reaction)* |
+| ci not reported | `awaiting-CI` | 🟡 `yellow` |
 | ci `failure` | `awaiting-author` | 🔴 `red_circle` |
 | ci `success`, review `changes` | `awaiting-author` | 🟢 + ✍️ `writing` |
 | ci `success`, review `approved` | `ready-to-merge` | 🟢 + ✔️ `check` |
-| ci `success`, review pending, live marker | `review-in-progress` | 🟢 + 👀/▶️ |
-| ci `success`, review pending, no marker | `awaiting-review` | 🟢 + 👀/▶️ |
+| ci `success`, review pending, live marker | `review-in-progress` | 🟢 + 👀 |
+| ci `success`, review pending, no marker | `awaiting-review` | 🟢 |
 
 Both review signals (the scoreboard meta and the in-progress marker) are read
 only from comments by a repo-associated author (OWNER/MEMBER/COLLABORATOR), from
@@ -85,27 +85,33 @@ reconciles two independent, mutually-exclusive reaction groups from `core.derive
 
 | Group | State | Emoji |
 | --- | --- | --- |
-| **CI (build)** | running | 🟡 `yellow` |
+| **CI (build)** | waiting / running | 🟡 `yellow` |
 | | passed | 🟢 `green_circle` |
 | | failed | 🔴 `red_circle` |
-| **Review / lifecycle** | review has begun | 👀 `eyes` |
-| | running, green so far | ▶️ `play` |
+| **Review / lifecycle** | review in progress | 👀 `eyes` |
+| | waiting for review | *(none)* |
 | | changes requested / blocked | ✍️ `writing` |
 | | all review done, all green | ✔️ `check` |
 | | merged | `:merge:` |
 | | closed, not merged | `:closed-pr:` |
 
-The message is found-or-created from the PR's title *before* the fallible CI and
-review reads, so a transient GitHub hiccup can never leave a PR without its
-durable Zulip message. Only the bot's *own* reactions are authoritative (presence
-is judged by the bot's user id), so a human reacting on a status message never
-confuses reconciliation.
+Each message includes the PR's author and the area from every `roadmap/...`
+label (with `unlabelled` distinct from the deliberate `roadmap/none`). A later
+label change edits the existing message in place, so a roadmap label added after
+the PR opens is still shown. The message is found-or-created from the PR's
+metadata *before* the fallible CI and review reads, so a transient GitHub hiccup
+can never leave a PR without its durable Zulip message. Only the bot's *own*
+reactions are authoritative (presence is judged by the bot's user id), so a
+human reacting on a status message never confuses reconciliation.
 
-Three workflows drive it:
+Three event-driven workflows drive it:
 
 - [`zulip-pr.yml`](../../.github/workflows/zulip-pr.yml): on PR
-  `opened`/`reopened`/`closed`. Creates the message and owns the merged/closed
-  ending.
+  `opened`/`reopened`/`closed` and label changes. Creates the message, keeps its
+  roadmap metadata current, and owns the merged/closed ending. The automatic
+  status-label transitions also make review reactions refresh promptly; on an
+  open PR they can self-heal a message missed by a transient opening failure,
+  while label churn on a closed PR can never create a late post.
 - [`zulip-pr-status.yml`](../../.github/workflows/zulip-pr-status.yml): on
   `workflow_run` of `pr-build` and `Review`. Refreshes the CI and review groups.
 - [`zulip-healthcheck.yml`](../../.github/workflows/zulip-healthcheck.yml): a
@@ -194,25 +200,43 @@ for pr in $(gh pr list --repo TauCetiProject/TauCeti --state open --json number 
   python3 scripts/pr_status/labels.py reconcile "$pr"
 done
 
-# Zulip: needs the bot credentials exported. Ascending == chronological.
+# Zulip: needs the status bot credentials exported. This paginates the complete
+# PR history in one low-request stream and edits existing posts in place,
+# including posts whose URL predates the FormalFrontier -> TauCetiProject transfer.
 export ZULIP_API_KEY=... ZULIP_EMAIL=... ZULIP_SITE=https://leanprover.zulipchat.com
-for pr in $(gh pr list --repo TauCetiProject/TauCeti --state all --limit 1000 --json number --jq '.[].number' | sort -n); do
-  python3 scripts/pr_status/zulip.py reconcile "$pr" --create
-done
+gh api --paginate \
+  'repos/TauCetiProject/TauCeti/pulls?state=all&sort=created&direction=asc&per_page=100' \
+  --jq '.[] | {
+    number,
+    state,
+    merged: (.merged_at != null),
+    head: .head.sha,
+    title,
+    author: .user.login,
+    roadmaps: [.labels[].name | select(startswith("roadmap/"))]
+  }' | python3 scripts/pr_status/zulip.py backfill --dry-run --strict
+
+# After reviewing the dry-run summary, omit --dry-run to apply it.
 ```
 
 Re-running either is safe: it converges to current GitHub state and changes
-nothing else. `pr-labels.yml` also has a `workflow_dispatch` that reconciles a
-single PR's label from the Actions tab.
+nothing else. The `Zulip PR backfill` workflow runs the same full-history post
+update with the repository's status-bot secrets, so old posts can be migrated
+without copying credentials locally. It defaults to a dry run, continues past
+individual failures and reports them together, retries transient Zulip failures,
+and intentionally does not create missing messages. `pr-labels.yml` also has a
+`workflow_dispatch` that reconciles a single PR's label from the Actions tab.
 
 ## Unit tests
 
 ```bash
 cd scripts/pr_status
-python3 -m unittest test_pr_labels test_stuck_alerts
+python3 -m unittest test_pr_labels test_zulip test_stuck_alerts
 ```
 
 `test_pr_labels` covers the derivation (`core.review_state`, `core.inprogress_from`,
-`core.derive`), the label collapse (`labels.derived_label`), and the reconcile
-convergence, all with the GitHub reads and label writes stubbed, so it needs no
+`core.derive`), metadata plumbing, the label collapse (`labels.derived_label`),
+and reconcile convergence. `test_zulip` covers review reactions, PR post
+rendering, legacy-message rewriting, batch continuation, dry runs, and rate-limit
+retry. All GitHub and Zulip reads and writes are stubbed, so these need no
 network.

--- a/scripts/pr_status/core.py
+++ b/scripts/pr_status/core.py
@@ -56,24 +56,40 @@ def gh_api(path, jq=None, paginate=False):
     return out.stdout
 
 
+def _roadmap_labels(labels):
+    """Sorted `roadmap/...` names from REST label objects or plain label names."""
+    names = [label.get("name", "") if isinstance(label, dict) else str(label)
+             for label in labels]
+    return sorted(name for name in names if name.startswith("roadmap/"))
+
+
 def pr_state(pr):
-    """{'state','merged','head','title'} for the PR.
+    """{'state','merged','head','title','author','roadmaps'} for the PR.
 
     Prefer the triggering event's payload, passed in via PR_STATE/PR_HEAD/
-    PR_MERGED/PR_TITLE (a workflow that has the pull_request object can set these
-    from github.event.pull_request, so a close/merge needs no GitHub API call at
-    all). Fall back to the REST API when they aren't set (the workflow_run and
-    issue_comment triggers, and the backfill), where the payload is absent or
-    isn't the PR we're reconciling.
+    PR_MERGED/PR_TITLE/PR_AUTHOR/PR_LABELS_JSON (a workflow that has the
+    pull_request object can set these from github.event.pull_request, so a
+    close/merge needs no GitHub API call at all). Fall back to the REST API when
+    PR state/head aren't set (the workflow_run and issue_comment triggers, and
+    the backfill), where the payload is absent or isn't the PR we're
+    reconciling.
     """
     env_state = os.environ.get("PR_STATE")
     env_head = os.environ.get("PR_HEAD")
     if env_state and env_head:
+        try:
+            labels = json.loads(os.environ.get("PR_LABELS_JSON") or "[]")
+        except json.JSONDecodeError:
+            labels = []
+        if not isinstance(labels, list):
+            labels = []
         return {
             "state": env_state,
             "merged": os.environ.get("PR_MERGED") == "true",
             "head": env_head,
             "title": os.environ.get("PR_TITLE") or f"PR #{pr}",
+            "author": os.environ.get("PR_AUTHOR") or "",
+            "roadmaps": _roadmap_labels(labels),
         }
     d = json.loads(gh_api(f"/repos/{REPO}/pulls/{pr}"))
     return {
@@ -81,6 +97,8 @@ def pr_state(pr):
         "merged": bool(d.get("merged")),
         "head": d["head"]["sha"],
         "title": d.get("title") or f"PR #{pr}",
+        "author": (d.get("user") or {}).get("login") or "",
+        "roadmaps": _roadmap_labels(d.get("labels") or []),
     }
 
 
@@ -189,8 +207,8 @@ def review_state(meta, head):
     scoreboard with no `states` map. State not at the current head (a fix landed since the last
     review) reads as "running, green so far".
 
-        "none"     nothing posted yet          (Zulip 👀 / label awaiting-review)
-        "running"  behind HEAD, or undecided    (Zulip ▶️ / label awaiting-review)
+        "none"     nothing posted yet          (no Zulip review emoji / label awaiting-review)
+        "running"  behind HEAD, or undecided    (no Zulip review emoji / label awaiting-review)
         "changes"  at HEAD, a blocking rubric   (Zulip ✍️ / label awaiting-author)
         "approved" at HEAD, every rubric green  (Zulip ✔️ / label ready-to-merge)
     """

--- a/scripts/pr_status/test_pr_labels.py
+++ b/scripts/pr_status/test_pr_labels.py
@@ -8,6 +8,7 @@ these run with no network and no `gh`. Run with:  python3 -m unittest test_pr_la
 import os
 import sys
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import core  # noqa: E402
@@ -74,6 +75,54 @@ class ScoreboardMeta(unittest.TestCase):
 
     def test_no_marker_is_empty(self):
         self.assertEqual(core.scoreboard_meta_from([{"body": "hi", "updated": "x"}]), {})
+
+
+class RoadmapLabels(unittest.TestCase):
+    def test_extracts_and_sorts_roadmaps_from_rest_objects(self):
+        self.assertEqual(
+            core._roadmap_labels([
+                {"name": "awaiting-review"},
+                {"name": "roadmap/Zeta"},
+                {"name": "roadmap/Alpha"},
+            ]),
+            ["roadmap/Alpha", "roadmap/Zeta"],
+        )
+
+    def test_accepts_plain_names(self):
+        self.assertEqual(
+            core._roadmap_labels(["roadmap/PDE", "documentation"]),
+            ["roadmap/PDE"],
+        )
+
+    def test_event_metadata_fast_path(self):
+        env = {
+            "PR_STATE": "open",
+            "PR_HEAD": "abc",
+            "PR_MERGED": "false",
+            "PR_TITLE": "Title",
+            "PR_AUTHOR": "alice",
+            "PR_LABELS_JSON": '[{"name":"awaiting-CI"},{"name":"roadmap/PDE"}]',
+        }
+        with (
+            mock.patch.dict(os.environ, env, clear=True),
+            mock.patch.object(core, "gh_api", side_effect=AssertionError("must not fetch")),
+        ):
+            self.assertEqual(
+                core.pr_state("9"),
+                {
+                    "state": "open",
+                    "merged": False,
+                    "head": "abc",
+                    "title": "Title",
+                    "author": "alice",
+                    "roadmaps": ["roadmap/PDE"],
+                },
+            )
+
+    def test_non_list_event_labels_degrade_to_empty(self):
+        env = {"PR_STATE": "open", "PR_HEAD": "abc", "PR_LABELS_JSON": "null"}
+        with mock.patch.dict(os.environ, env, clear=True):
+            self.assertEqual(core.pr_state("9")["roadmaps"], [])
 
 
 class InProgress(unittest.TestCase):

--- a/scripts/pr_status/test_zulip.py
+++ b/scripts/pr_status/test_zulip.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Unit tests for Zulip PR post rendering and review reactions."""
+
+import io
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import labels  # noqa: E402
+import zulip  # noqa: E402
+
+
+class ReviewEmoji(unittest.TestCase):
+    def emoji(self, review="none", inprogress=False):
+        return zulip.review_emoji({
+            "lifecycle": "open",
+            "ci": "success",
+            "review": review,
+            "review_inprogress": inprogress,
+            "head": "h",
+            "title": "t",
+        })
+
+    def test_waiting_for_review_has_no_reaction(self):
+        self.assertIsNone(self.emoji())
+        self.assertIsNone(self.emoji(review="running"))
+
+    def test_live_review_marker_is_eyes(self):
+        self.assertEqual(self.emoji(inprogress=True), "eyes")
+        self.assertEqual(self.emoji(review="running", inprogress=True), "eyes")
+
+    def test_completed_blocking_review_is_writing(self):
+        self.assertEqual(self.emoji(review="changes"), "writing")
+
+    def test_completed_green_review_is_check(self):
+        self.assertEqual(self.emoji(review="approved"), "check")
+
+    def test_verdict_wins_over_leftover_marker(self):
+        self.assertEqual(self.emoji(review="changes", inprogress=True), "writing")
+        self.assertEqual(self.emoji(review="approved", inprogress=True), "check")
+
+    def test_tracks_the_review_status_label_transitions(self):
+        cases = [
+            ("none", False, "awaiting-review", None),
+            ("none", True, "review-in-progress", "eyes"),
+            ("changes", False, "awaiting-author", "writing"),
+            ("approved", False, "ready-to-merge", "check"),
+        ]
+        for review, inprogress, expected_label, expected_emoji in cases:
+            status = {
+                "lifecycle": "open",
+                "ci": "success",
+                "review": review,
+                "review_inprogress": inprogress,
+                "head": "h",
+                "title": "t",
+            }
+            with self.subTest(review=review, inprogress=inprogress):
+                self.assertEqual(labels.derived_label(status), expected_label)
+                self.assertEqual(zulip.review_emoji(status), expected_emoji)
+
+
+class MessageContent(unittest.TestCase):
+    def test_includes_author_and_roadmap(self):
+        content = zulip.pr_message_content(
+            "1520",
+            "feat: symmetric Rouché",
+            "jeremy-kahn-brown-ai",
+            ["roadmap/ConformalMapping"],
+        )
+        self.assertIn("https://github.com/TauCetiProject/TauCeti/pull/1520", content)
+        self.assertIn(
+            "[jeremy-kahn-brown-ai](https://github.com/jeremy-kahn-brown-ai)",
+            content,
+        )
+        self.assertIn("roadmap: ConformalMapping", content)
+
+    def test_multiple_or_missing_roadmaps(self):
+        content = zulip.pr_message_content("1", "title", "author", ["roadmap/A", "roadmap/B"])
+        self.assertIn("roadmap: A, B", content)
+        missing = zulip.pr_message_content("1", "title", "author", [])
+        self.assertIn("roadmap: unlabelled", missing)
+
+    def test_bot_author_is_plain_text(self):
+        content = zulip.pr_message_content(
+            "1", "title", "tauceti-review-bot[bot]", ["roadmap/none"])
+        self.assertIn("author: tauceti-review-bot[bot]", content)
+        self.assertNotIn("github.com/tauceti-review-bot", content)
+        self.assertIn("roadmap: none", content)
+
+    def test_metadata_is_sanitized(self):
+        content = zulip.pr_message_content("1", "@title #12", "@author", ["roadmap/#area"])
+        self.assertNotIn("@title", content)
+        self.assertNotIn("#12", content)
+        self.assertNotIn("roadmap/#area", content)
+        self.assertNotIn("[@author]", content)
+
+
+class FindMessage(unittest.TestCase):
+    class FakeZulip:
+        def __init__(self, message):
+            self.message = message
+            self.searches = []
+
+        def get_messages(self, narrow, num_before=1000):
+            query = narrow[-1]["operand"]
+            self.searches.append(query)
+            return [self.message] if query in self.message["content"] else []
+
+    def test_finds_pre_transfer_message(self):
+        old_url = "https://github.com/FormalFrontier/TauCeti/pull/12"
+        z = self.FakeZulip({"id": 7, "sender_id": 42, "content": old_url, "reactions": []})
+        self.assertEqual(zulip.find_message(z, "12", 42)["id"], 7)
+        self.assertEqual(len(z.searches), 2)
+
+    def test_ignores_another_authors_matching_message(self):
+        url = "https://github.com/TauCetiProject/TauCeti/pull/12"
+        z = self.FakeZulip({"id": 7, "sender_id": 99, "content": url, "reactions": []})
+        self.assertIsNone(zulip.find_message(z, "12", 42))
+
+
+class StrictMode(unittest.TestCase):
+    def run_main(self, *extra):
+        with (
+            mock.patch.dict(
+                os.environ,
+                {"ZULIP_EMAIL": "bot@example.com", "ZULIP_API_KEY": "secret"},
+            ),
+            mock.patch.object(zulip, "Zulip", return_value=object()),
+            mock.patch.object(zulip, "reconcile", side_effect=RuntimeError("boom")),
+        ):
+            return zulip.main(["zulip.py", "reconcile", "12", *extra])
+
+    def test_normal_reconcile_keeps_transient_failure_cosmetic(self):
+        self.assertEqual(self.run_main(), 0)
+
+    def test_strict_reconcile_fails_on_transient_failure(self):
+        self.assertEqual(self.run_main("--strict"), 1)
+
+
+class Reconcile(unittest.TestCase):
+    class FakeZulip(FindMessage.FakeZulip):
+        def __init__(self, message):
+            super().__init__(message)
+            self.updated = []
+            self.sent = []
+            self.added = []
+            self.removed = []
+
+        def get_messages(self, narrow, num_before=1000):
+            if self.message is None:
+                return []
+            return super().get_messages(narrow, num_before)
+
+        def send_message(self, content):
+            self.sent.append(content)
+            return 8
+
+        def update_message(self, message_id, content):
+            self.updated.append((message_id, content))
+
+        def add_reaction(self, message_id, name):
+            self.added.append((message_id, name))
+
+        def remove_reaction(self, message_id, name):
+            self.removed.append((message_id, name))
+
+    STATE = {
+        "state": "closed",
+        "merged": True,
+        "head": "h",
+        "title": "Old PR",
+        "author": "alice",
+        "roadmaps": ["roadmap/PDE"],
+    }
+
+    def test_legacy_post_is_rewritten_in_place(self):
+        old = "https://github.com/FormalFrontier/TauCeti/pull/12"
+        message = {"id": 7, "sender_id": 42, "content": old, "reactions": []}
+        z = self.FakeZulip(message)
+        changes = zulip.reconcile(
+            z, "12", create=False, ci_override=None, bot_id=42, state=self.STATE)
+        self.assertEqual(changes, 2)  # content plus the terminal merge reaction
+        self.assertEqual(z.updated[0][0], 7)
+        self.assertIn("https://github.com/TauCetiProject/TauCeti/pull/12", z.updated[0][1])
+        self.assertIn("author: [alice]", z.updated[0][1])
+        self.assertIn("roadmap: PDE", z.updated[0][1])
+        self.assertEqual(z.added, [(7, "merge")])
+
+    def test_dry_run_reports_without_writing(self):
+        old = "https://github.com/FormalFrontier/TauCeti/pull/12"
+        message = {"id": 7, "sender_id": 42, "content": old, "reactions": []}
+        z = self.FakeZulip(message)
+        changes = zulip.reconcile(
+            z, "12", create=False, ci_override=None, bot_id=42,
+            state=self.STATE, dry_run=True)
+        self.assertEqual(changes, 2)
+        self.assertEqual(z.updated, [])
+        self.assertEqual(z.added, [])
+
+    def test_unreported_ci_is_yellow_but_waiting_review_has_no_review_emoji(self):
+        content = zulip.pr_message_content(
+            "12", self.STATE["title"], self.STATE["author"], self.STATE["roadmaps"])
+        current = "https://github.com/TauCetiProject/TauCeti/pull/12"
+        message = {"id": 7, "sender_id": 42, "content": content, "reactions": []}
+        z = self.FakeZulip(message)
+        open_state = {**self.STATE, "state": "open", "merged": False}
+        status = {
+            "lifecycle": "open",
+            "ci": None,
+            "review": "none",
+            "review_inprogress": False,
+            "head": "h",
+            "title": "Old PR",
+        }
+        with mock.patch.object(zulip.core, "derive", return_value=status):
+            changes = zulip.reconcile(
+                z, "12", create=False, ci_override=None,
+                bot_id=42, state=open_state)
+        self.assertIn(current, z.searches)
+        self.assertEqual(changes, 1)
+        self.assertEqual(z.added, [(7, "yellow")])
+
+    def test_label_event_self_heals_only_an_open_pr(self):
+        status = {
+            "lifecycle": "open",
+            "ci": None,
+            "review": "none",
+            "review_inprogress": False,
+            "head": "h",
+            "title": "Old PR",
+        }
+        open_state = {**self.STATE, "state": "open", "merged": False}
+        z = self.FakeZulip(None)
+        with mock.patch.object(zulip.core, "derive", return_value=status):
+            zulip.reconcile(
+                z, "12", create=False, ci_override=None,
+                bot_id=42, state=open_state, create_if_open=True)
+        self.assertEqual(len(z.sent), 1)
+
+        z = self.FakeZulip(None)
+        changes = zulip.reconcile(
+            z, "12", create=False, ci_override=None,
+            bot_id=42, state=self.STATE, create_if_open=True)
+        self.assertEqual(changes, 0)
+        self.assertEqual(z.sent, [])
+
+
+class Backfill(unittest.TestCase):
+    def test_continues_and_collects_item_failures(self):
+        class Z:
+            def __init__(self):
+                self.auth_calls = 0
+
+            def my_user_id(self):
+                self.auth_calls += 1
+                return 42
+
+        rows = [
+            json.dumps({"number": 1, **Reconcile.STATE}),
+            json.dumps({"number": 2, **Reconcile.STATE}),
+        ]
+        z = Z()
+        with (
+            mock.patch.object(zulip, "topic_message_index", return_value={}),
+            mock.patch.object(
+                zulip, "reconcile",
+                side_effect=[3, RuntimeError("temporary")],
+            ) as rec,
+        ):
+            seen, changes, failures = zulip.backfill(z, rows)
+        self.assertEqual((seen, changes), (2, 3))
+        self.assertEqual(failures, [("PR #2", "temporary")])
+        self.assertEqual(z.auth_calls, 1)
+        self.assertEqual(rec.call_count, 2)
+
+
+class TopicMessageIndex(unittest.TestCase):
+    def test_pages_once_and_indexes_current_and_legacy_urls(self):
+        class Z:
+            def __init__(self):
+                self.anchors = []
+
+            def get_message_page(self, narrow, anchor="newest", num_before=1000):
+                self.anchors.append(anchor)
+                if anchor == "newest":
+                    return {
+                        "found_oldest": False,
+                        "messages": [
+                            {
+                                "id": 20,
+                                "sender_id": 42,
+                                "content": "https://github.com/TauCetiProject/TauCeti/pull/2",
+                            },
+                            {
+                                "id": 10,
+                                "sender_id": 42,
+                                "content": "https://github.com/TauCetiProject/TauCeti/pull/1",
+                            },
+                            {
+                                "id": 15,
+                                "sender_id": 99,
+                                "content": "https://github.com/TauCetiProject/TauCeti/pull/99",
+                            },
+                        ],
+                    }
+                return {
+                    "found_oldest": True,
+                    "messages": [
+                        {
+                            "id": 10,
+                            "sender_id": 42,
+                            "content": "https://github.com/TauCetiProject/TauCeti/pull/1",
+                        },
+                        {
+                            "id": 5,
+                            "sender_id": 42,
+                            "content": "https://github.com/FormalFrontier/TauCeti/pull/3",
+                        },
+                    ],
+                }
+
+        z = Z()
+        index = zulip.topic_message_index(z, 42)
+        self.assertEqual(z.anchors, ["newest", 10])
+        self.assertEqual({pr: message["id"] for pr, message in index.items()},
+                         {"1": 10, "2": 20, "3": 5})
+
+
+class Retry(unittest.TestCase):
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def read(self):
+            return b'{"result":"success"}'
+
+    def test_rate_limit_retries_after_server_delay(self):
+        error = zulip.urllib.error.HTTPError(
+            "https://example.test", 429, "rate limit",
+            {"Retry-After": "2.5"},
+            io.BytesIO(b'{"code":"RATE_LIMIT_HIT"}'),
+        )
+        z = zulip.Zulip("bot@example.com", "key", "https://example.test")
+        with (
+            mock.patch.object(
+                zulip.urllib.request, "urlopen",
+                side_effect=[error, self.Response()],
+            ),
+            mock.patch.object(zulip, "sleep_for") as sleep,
+        ):
+            self.assertEqual(z._call("GET", "/messages", None)["result"], "success")
+        sleep.assert_called_once_with(2.5)
+
+    def test_send_message_does_not_retry_lost_responses(self):
+        error = zulip.urllib.error.HTTPError(
+            "https://example.test", 503, "unavailable", {},
+            io.BytesIO(b'{"code":"TEMPORARY"}'),
+        )
+        z = zulip.Zulip("bot@example.com", "key", "https://example.test")
+        with (
+            mock.patch.object(
+                zulip.urllib.request, "urlopen",
+                side_effect=[error, self.Response()],
+            ) as urlopen,
+            mock.patch.object(zulip, "sleep_for") as sleep,
+        ):
+            with self.assertRaises(RuntimeError):
+                z.send_message("hello")
+        self.assertEqual(urlopen.call_count, 1)
+        sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/pr_status/zulip.py
+++ b/scripts/pr_status/zulip.py
@@ -7,7 +7,7 @@ groups of emoji reactions on it from the PR's status (see core.derive):
 
   CI (build) group        review / lifecycle group
     running   -> yellow      review has begun        -> eyes
-    passed    -> green_circle running, green so far   -> play
+    passed    -> green_circle review is pending       -> (none)
     failed    -> red_circle  changes_requested/block -> writing
                              all review done, green   -> check
                              merged                   -> merge      (realm emoji)
@@ -24,12 +24,25 @@ bot's user id, so a human reacting on a message never confuses reconciliation,
 and we only ever add/remove our own reactions.
 
 Usage:
-    zulip.py reconcile <pr_number> [--create] [--ci STATE]
+    zulip.py reconcile <pr_number> [--create|--create-if-open] [--strict] [--ci STATE]
+    zulip.py backfill [--dry-run] [--strict]  # JSONL PR states on stdin
     zulip.py check
 
 `--create` posts the per-PR message if it does not exist yet (used by the PR
-"opened" workflow and by backfill). Without it, a PR with no message yet is left
-alone (other events only react to an existing message, never create one).
+"opened" workflow and when intentionally seeding missing posts). Without it, a
+PR with no message yet is left alone (other events only react to an existing
+message, never create one). `--create-if-open` is the label-event self-heal: it
+creates a missing post only if current GitHub truth still says the PR is open.
+
+`--strict` makes a transient reconciliation error exit non-zero instead of
+being swallowed as cosmetic. Normal event-driven runs stay self-healing; the
+historical backfill uses strict mode so a partial migration is visible and can
+be safely rerun.
+
+`backfill` reads one PR-state JSON object per line from stdin, authenticates the
+bot once, edits only messages that already exist, continues past per-PR errors,
+and reports all failures at the end. `--dry-run` performs every read and reports
+the number of changes without writing messages or reactions.
 
 `check` is a credentials/health probe: it authenticates and confirms the bot is
 subscribed to the channel, then exits 0. It touches no PR and no message, so a
@@ -69,6 +82,7 @@ import json
 import os
 import re
 import sys
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -79,6 +93,10 @@ REPO = core.REPO
 CHANNEL = os.environ.get("ZULIP_CHANNEL", "Tau Ceti")
 TOPIC = os.environ.get("ZULIP_TOPIC", "PRs")
 ZWSP = "​"  # zero-width space, used to defuse mentions/linkifiers
+# Messages from before the repository transfer still contain this URL. Reconcile
+# recognizes it, then updates the post to REPO's canonical URL in place.
+LEGACY_REPOS = ("FormalFrontier/TauCeti",)
+_MESSAGE_NOT_GIVEN = object()
 
 
 class ConfigError(RuntimeError):
@@ -97,24 +115,33 @@ EMOJI = {
     "red_circle":       ("unicode_emoji", None),
     # review / lifecycle group
     "eyes":             ("unicode_emoji", None),
-    "play":    ("unicode_emoji", None),
+    # Legacy state, retained in the group so reconcile removes old ▶️ reactions.
+    "play":             ("unicode_emoji", None),
     "writing":          ("unicode_emoji", None),
-    "check": ("unicode_emoji", None),
+    "check":            ("unicode_emoji", None),
     "merge":            ("realm_emoji", "18527"),
     "closed-pr":        ("realm_emoji", "61293"),
 }
 CI_GROUP = ["yellow", "green_circle", "red_circle"]
 REVIEW_GROUP = ["eyes", "play", "writing", "check", "merge", "closed-pr"]
 
-# core.derive's neutral states -> this sink's emoji.
+# core.derive's CI states -> this sink's emoji. An unreported build is the
+# `awaiting-CI` state, so it is yellow too; terminal PRs clear the group.
 CI_EMOJI = {"running": "yellow", "success": "green_circle",
-            "failure": "red_circle", None: None}
-REVIEW_EMOJI = {"none": "eyes", "running": "play",
-                "changes": "writing", "approved": "check"}
+            "failure": "red_circle", None: "yellow"}
 
 
 def log(msg):
     print(msg, flush=True)
+
+
+def sleep_for(delay):
+    """Sleep for all of `delay`, in chunks so one wait never exceeds 60 seconds."""
+    remaining = max(0.1, delay)
+    while remaining > 0:
+        chunk = min(remaining, 60)
+        time.sleep(chunk)
+        remaining -= chunk
 
 
 def pr_url(pr):
@@ -128,39 +155,66 @@ class Zulip:
         self.base = site.rstrip("/") + "/api/v1"
         self.auth = "Basic " + base64.b64encode(f"{email}:{api_key}".encode()).decode()
 
-    def _call(self, method, path, params, tolerate=()):
-        data = urllib.parse.urlencode(params).encode() if params else None
-        url = self.base + path
-        if method in ("GET", "DELETE") and data:
-            url += "?" + data.decode()
-            data = None
-        req = urllib.request.Request(url, data=data, method=method)
-        req.add_header("Authorization", self.auth)
-        if data:
-            req.add_header("Content-Type", "application/x-www-form-urlencoded")
-        try:
-            with urllib.request.urlopen(req) as resp:
-                return json.loads(resp.read().decode())
-        except urllib.error.HTTPError as e:
-            payload = {}
+    def _call(self, method, path, params, tolerate=(), retry=True):
+        attempts = 6 if retry else 1
+        for attempt in range(attempts):
+            data = urllib.parse.urlencode(params).encode() if params else None
+            url = self.base + path
+            if method in ("GET", "DELETE") and data:
+                url += "?" + data.decode()
+                data = None
+            req = urllib.request.Request(url, data=data, method=method)
+            req.add_header("Authorization", self.auth)
+            if data:
+                req.add_header("Content-Type", "application/x-www-form-urlencoded")
             try:
-                payload = json.loads(e.read().decode())
-            except Exception:
-                pass
-            if payload.get("code") in tolerate:
-                return payload
-            detail = f"Zulip {method} {path} failed: {e.code} {payload or e.reason}"
-            # A persistent creds/permission break (vs a one-off hiccup) is a
-            # ConfigError, so main() fails loudly instead of swallowing it. 401
-            # and Zulip's UNAUTHORIZED code (e.g. "Malformed API key") are always
-            # auth. A 403 counts only when Zulip itself answered with a JSON body
-            # (a real permission error); an opaque 403 from a WAF/proxy has no
-            # payload and is treated as a transient hiccup, not a config break.
-            if (e.code == 401
-                    or payload.get("code") == "UNAUTHORIZED"
-                    or (e.code == 403 and payload)):
-                raise ConfigError(detail)
-            raise RuntimeError(detail)
+                with urllib.request.urlopen(req) as resp:
+                    return json.loads(resp.read().decode())
+            except urllib.error.HTTPError as e:
+                payload = {}
+                try:
+                    payload = json.loads(e.read().decode())
+                except Exception:
+                    pass
+                if payload.get("code") in tolerate:
+                    return payload
+                if attempt + 1 < attempts and (e.code == 429 or 500 <= e.code < 600):
+                    if e.code == 429:
+                        raw_delay = (
+                            e.headers.get("Retry-After")
+                            or payload.get("retry-after")
+                            or 1
+                        )
+                        try:
+                            delay = max(0.1, float(raw_delay))
+                        except (TypeError, ValueError):
+                            delay = 1
+                        reason = "rate limit"
+                    else:
+                        delay = 2 ** attempt
+                        reason = f"HTTP {e.code}"
+                    log(f"Zulip {reason}; retrying in {delay:.1f}s")
+                    sleep_for(delay)
+                    continue
+                detail = f"Zulip {method} {path} failed: {e.code} {payload or e.reason}"
+                # A persistent creds/permission break (vs a one-off hiccup) is a
+                # ConfigError, so main() fails loudly instead of swallowing it. 401
+                # and Zulip's UNAUTHORIZED code (e.g. "Malformed API key") are always
+                # auth. A 403 counts only when Zulip itself answered with a JSON body
+                # (a real permission error); an opaque 403 from a WAF/proxy has no
+                # payload and is treated as a transient hiccup, not a config break.
+                if (e.code == 401
+                        or payload.get("code") == "UNAUTHORIZED"
+                        or (e.code == 403 and payload)):
+                    raise ConfigError(detail)
+                raise RuntimeError(detail)
+            except urllib.error.URLError as e:
+                if attempt + 1 < attempts:
+                    delay = 2 ** attempt
+                    log(f"Zulip network error; retrying in {delay:.1f}s: {e.reason}")
+                    sleep_for(delay)
+                    continue
+                raise RuntimeError(f"Zulip {method} {path} failed: {e.reason}") from e
 
     def my_user_id(self):
         return self._call("GET", "/users/me", None)["user_id"]
@@ -169,18 +223,23 @@ class Zulip:
         return [s["name"] for s in
                 self._call("GET", "/users/me/subscriptions", None)["subscriptions"]]
 
-    def get_messages(self, narrow, num_before=1000):
+    def get_message_page(self, narrow, anchor="newest", num_before=1000):
         params = {
-            "anchor": "newest", "num_before": num_before, "num_after": 0,
+            "anchor": anchor, "num_before": num_before, "num_after": 0,
             "apply_markdown": "false",  # raw markdown, so content compares exactly
             "narrow": json.dumps(narrow),
         }
-        return self._call("GET", "/messages", params)["messages"]
+        return self._call("GET", "/messages", params)
+
+    def get_messages(self, narrow, num_before=1000):
+        return self.get_message_page(narrow, num_before=num_before)["messages"]
 
     def send_message(self, content):
+        # Sending is not idempotent: if Zulip accepts the request but the
+        # response is lost, retrying would create a permanent duplicate post.
         r = self._call("POST", "/messages", {
             "type": "stream", "to": CHANNEL, "topic": TOPIC, "content": content,
-        })
+        }, retry=False)
         return r["id"]
 
     def update_message(self, message_id, content):
@@ -212,19 +271,95 @@ def find_message(z, pr, bot_id):
     AND that the bot authored the message, so a human's message that quotes the
     link can never be mistaken for the status message.
     """
-    url = pr_url(pr)
-    msgs = z.get_messages([
-        {"operator": "channel", "operand": CHANNEL},
-        {"operator": "topic", "operand": TOPIC},
-        {"operator": "search", "operand": url},
-    ])
-    pat = re.compile(re.escape(url) + r"(?![0-9])")
-    hits = [m for m in msgs if m["sender_id"] == bot_id and pat.search(m["content"])]
+    urls = [pr_url(pr)] + [
+        f"https://github.com/{repo}/pull/{pr}" for repo in LEGACY_REPOS
+    ]
+    hits = []
+    for url in urls:
+        msgs = z.get_messages([
+            {"operator": "channel", "operand": CHANNEL},
+            {"operator": "topic", "operand": TOPIC},
+            {"operator": "search", "operand": url},
+        ])
+        pat = re.compile(re.escape(url) + r"(?![0-9])")
+        hits.extend(
+            m for m in msgs if m["sender_id"] == bot_id and pat.search(m["content"])
+        )
+        if hits:
+            break
     return min(hits, key=lambda m: m["id"]) if hits else None
 
 
-def pr_message_content(pr, title):
-    return f"**{zulip_sanitize(title)}** · {pr_url(pr)}"
+def topic_message_index(z, bot_id):
+    """Index every bot-authored PR post with a handful of paginated topic reads.
+
+    The event-driven path searches for one PR. A historical backfill instead
+    reads the topic once, avoiding thousands of full-text searches and sharing
+    the Zulip rate-limit budget politely.
+    """
+    repos = tuple(dict.fromkeys((REPO, *LEGACY_REPOS)))
+    url_re = re.compile(
+        r"https://github\.com/(?:"
+        + "|".join(re.escape(repo) for repo in repos)
+        + r")/pull/([0-9]+)(?![0-9])"
+    )
+    narrow = [
+        {"operator": "channel", "operand": CHANNEL},
+        {"operator": "topic", "operand": TOPIC},
+    ]
+    messages_by_id = {}
+    anchor = "newest"
+    while True:
+        page = z.get_message_page(narrow, anchor=anchor)
+        messages = page.get("messages") or []
+        for message in messages:
+            messages_by_id[message["id"]] = message
+        if page.get("found_oldest") or not messages:
+            break
+        next_anchor = min(message["id"] for message in messages)
+        if next_anchor == anchor:
+            raise RuntimeError("Zulip message pagination did not advance")
+        anchor = next_anchor
+
+    result = {}
+    for message in messages_by_id.values():
+        if message.get("sender_id") != bot_id:
+            continue
+        match = url_re.search(message.get("content") or "")
+        if not match:
+            continue
+        pr = match.group(1)
+        if pr not in result or message["id"] < result[pr]["id"]:
+            result[pr] = message
+    return result
+
+
+def pr_message_content(pr, title, author, roadmaps):
+    """The durable two-line PR post.
+
+    Author and roadmap come from the same PR payload/API read as the title.
+    Roadmap labels may be added after opening; labeled/unlabeled events run
+    reconcile again and edit this message in place.
+    """
+    if author:
+        safe_author = zulip_sanitize(author)
+        if author.endswith("[bot]"):
+            # GitHub App logins contain brackets, which do not form a reliable
+            # Markdown link and do not have a github.com/<login> profile page.
+            author_text = safe_author
+        else:
+            author_text = (
+                f"[{safe_author}]"
+                f"(https://github.com/{urllib.parse.quote(author, safe='')})"
+            )
+    else:
+        author_text = "unknown"
+    roadmap_text = (
+        ", ".join(zulip_sanitize(name.removeprefix("roadmap/")) for name in roadmaps)
+        or "unlabelled"
+    )
+    return (f"**{zulip_sanitize(title)}** · {pr_url(pr)}  \n"
+            f"author: {author_text} · roadmap: {roadmap_text}")
 
 
 def zulip_sanitize(text):
@@ -236,53 +371,142 @@ def zulip_sanitize(text):
     return re.sub(r"([@#])", lambda m: m.group(1) + ZWSP, text)
 
 
-def set_group(z, message, bot_id, group, desired):
+def set_group(z, message, bot_id, group, desired, dry_run=False):
     """Ensure `desired` (or nothing) is the only reaction from `group` that the
     bot owns. Only the bot's own reactions count, so human reactions are left
     untouched and never block convergence."""
     mine = {r["emoji_name"] for r in message.get("reactions", [])
             if r["emoji_name"] in group and r.get("user_id") == bot_id}
+    changes = 0
     for name in group:
         if name in mine and name != desired:
-            log(f"removing {name}")
-            z.remove_reaction(message["id"], name)
+            changes += 1
+            log(f"{'would remove' if dry_run else 'removing'} {name}")
+            if not dry_run:
+                z.remove_reaction(message["id"], name)
     if desired and desired not in mine:
-        log(f"adding {desired}")
-        z.add_reaction(message["id"], desired)
+        changes += 1
+        log(f"{'would add' if dry_run else 'adding'} {desired}")
+        if not dry_run:
+            z.add_reaction(message["id"], desired)
+    return changes
 
 
-def reconcile(z, pr, create, ci_override):
-    bot_id = z.my_user_id()
+def review_emoji(status):
+    """Review reaction derived from the same truth as the automatic labels.
+
+    In particular, the live review marker that produces `review-in-progress`
+    produces 👀 here. A completed blocking review produces ✍️, and an all-green
+    review produces ✔️. Merely waiting for review has no review reaction.
+    """
+    if status["review"] == "approved":
+        return "check"
+    if status["review"] == "changes":
+        return "writing"
+    if status.get("review_inprogress"):
+        return "eyes"
+    return None
+
+
+def reconcile(
+        z, pr, create, ci_override, bot_id=None, state=None, dry_run=False,
+        message=_MESSAGE_NOT_GIVEN, create_if_open=False):
+    bot_id = z.my_user_id() if bot_id is None else bot_id
     # Read only the PR's own metadata first and find-or-create the durable message from its title,
     # BEFORE the fallible CI/scoreboard reads. Otherwise a transient GitHub hiccup during those reads
     # would abort the sole --create run and the PR would stay absent from Zulip indefinitely (later
     # events don't pass --create). Passing this state into derive() reads the PR just once.
-    st = core.pr_state(pr)
-    content = pr_message_content(pr, st["title"])
-    message = find_message(z, pr, bot_id)
+    st = core.pr_state(pr) if state is None else state
+    create = create or (
+        create_if_open and st["state"] == "open" and not st["merged"]
+    )
+    content = pr_message_content(
+        pr, st["title"], st.get("author", ""), st.get("roadmaps", []))
+    if message is _MESSAGE_NOT_GIVEN:
+        message = find_message(z, pr, bot_id)
     if message is None:
         if not create:
             log(f"no message for PR #{pr} yet and --create not set; nothing to do")
-            return
+            return 0
+        if dry_run:
+            log(f"would create message for PR #{pr}")
+            return 1
         mid = z.send_message(content)
         log(f"created message {mid} for PR #{pr}")
         message = {"id": mid, "reactions": []}
+        changes = 1
     elif message.get("content") != content:
         # Self-heal: the title changed, or an older format/sanitizer left stale text.
-        log(f"updating content of message {message['id']} for PR #{pr}")
-        z.update_message(message["id"], content)
+        changes = 1
+        log(f"{'would update' if dry_run else 'updating'} content "
+            f"of message {message['id']} for PR #{pr}")
+        if not dry_run:
+            z.update_message(message["id"], content)
+    else:
+        changes = 0
 
     status = core.derive(pr, ci_override, state=st)
     rev = {"merged": "merge", "closed": "closed-pr"}.get(status["lifecycle"])
     if rev is None:  # open PR: render the review state
-        rev = REVIEW_EMOJI[status["review"]]
-    set_group(z, message, bot_id, REVIEW_GROUP, rev)
+        rev = review_emoji(status)
+    changes += set_group(z, message, bot_id, REVIEW_GROUP, rev, dry_run)
 
     # CI status is only meaningful while the PR is open; core.derive already
     # clears it (ci=None) on a terminal PR, so this maps straight through.
-    ci_emoji = CI_EMOJI[status["ci"]]
-    set_group(z, message, bot_id, CI_GROUP, ci_emoji)
+    ci_emoji = None if status["lifecycle"] != "open" else CI_EMOJI[status["ci"]]
+    changes += set_group(z, message, bot_id, CI_GROUP, ci_emoji, dry_run)
     log(f"PR #{pr}: review={rev} ci={ci_emoji}")
+    return changes
+
+
+def backfill(z, rows, dry_run=False):
+    """Reconcile JSONL PR states, continuing past item failures.
+
+    Returns `(seen, changes, failures)`, where failures is a list of
+    `(pr-or-line, message)` pairs. Persistent configuration failures still raise
+    immediately because no later item can succeed.
+    """
+    bot_id = z.my_user_id()
+    messages = topic_message_index(z, bot_id)
+    log(f"indexed {len(messages)} existing PR posts")
+    seen = 0
+    changes = 0
+    failures = []
+    for line_number, line in enumerate(rows, 1):
+        if not line.strip():
+            continue
+        try:
+            state = json.loads(line)
+            pr = str(state.pop("number"))
+            if not pr.isdigit():
+                raise ValueError("number is not a PR number")
+            if not isinstance(state.get("roadmaps"), list):
+                state["roadmaps"] = []
+        except (json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+            failures.append((f"line {line_number}", f"invalid PR state: {exc}"))
+            continue
+        seen += 1
+        try:
+            changes += reconcile(
+                z,
+                pr,
+                create=False,
+                ci_override=None,
+                bot_id=bot_id,
+                state=state,
+                dry_run=dry_run,
+                message=messages.get(pr),
+            )
+        except ConfigError:
+            raise
+        except Exception as exc:
+            log(f"PR #{pr} failed; continuing: {exc}")
+            failures.append((f"PR #{pr}", str(exc)))
+    mode = "dry-run" if dry_run else "backfill"
+    log(f"{mode}: {seen} PRs, {changes} changes, {len(failures)} failures")
+    for item, message in failures:
+        log(f"FAILED {item}: {message}")
+    return seen, changes, failures
 
 
 def check(z):
@@ -315,7 +539,7 @@ def fail_config(msg):
 
 def main(argv):
     cmd = argv[1] if len(argv) > 1 else None
-    if cmd not in ("reconcile", "check"):
+    if cmd not in ("reconcile", "backfill", "check"):
         print(__doc__)
         return 2
 
@@ -339,6 +563,19 @@ def main(argv):
             log(f"check failed (non-fatal): {exc}")
         return 0
 
+    if cmd == "backfill":
+        rest = argv[2:]
+        strict = "--strict" in rest
+        dry_run = "--dry-run" in rest
+        try:
+            _, _, failures = backfill(z, sys.stdin, dry_run=dry_run)
+        except ConfigError as exc:
+            return fail_config(str(exc))
+        except Exception as exc:
+            log(f"backfill failed: {exc}")
+            return 1 if strict else 0
+        return 1 if strict and failures else 0
+
     # cmd == "reconcile"
     pr = argv[2].lstrip("#") if len(argv) > 2 else ""
     if not pr.isdigit():
@@ -346,15 +583,20 @@ def main(argv):
         return 0
     rest = argv[3:]
     create = "--create" in rest
+    create_if_open = "--create-if-open" in rest
+    strict = "--strict" in rest
     ci_override = None
     if "--ci" in rest:
         ci_override = rest[rest.index("--ci") + 1]
 
     try:
-        reconcile(z, pr, create, ci_override)
+        reconcile(z, pr, create, ci_override, create_if_open=create_if_open)
     except ConfigError as exc:  # broken creds/permissions: loud, fails the run
         return fail_config(str(exc))
     except Exception as exc:  # cosmetic: never fail the caller over one reaction
+        if strict:
+            log(f"reconcile failed: {exc}")
+            return 1
         log(f"reconcile failed (non-fatal): {exc}")
     return 0
 


### PR DESCRIPTION
This PR aligns Zulip PR reactions with the automatic status labels: waiting for review has no review reaction, an active review shows `:eyes:`, blocking results show `:writing:`, and an all-green review shows `:check:`. Posts now include the GitHub author and roadmap area, refresh from current label state, and keep `awaiting-CI` visibly yellow.

It also adds a dry-run-first, rate-limit-aware backfill that edits existing bot posts in place, including pre-transfer `FormalFrontier/TauCeti` links, without creating missing historical announcements.

Tested with the complete infrastructure policy test set, 79 focused PR-status tests, workflow YAML parsing, a live read-only index of the 1,474 existing Zulip posts, and two rounds of independent Claude review.

:robot: Prepared with OpenAI Codex
