### PR TITLE
feat: compute the Euler form against the dimension vector of a vertex projective

### DIFF
--- a/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/EulerForm.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Combinatorics.Quiver.Basic
 public import Mathlib.Algebra.BigOperators.Ring.Finset
 public import Mathlib.LinearAlgebra.QuadraticForm.Basic
+public import TauCeti.RepresentationTheory.Quiver.LastArrow
 import Mathlib.Tactic.Ring
 
 /-!
@@ -14,6 +15,10 @@ import Mathlib.Tactic.Ring
 
 The Euler form records the oriented incidence data of a finite quiver. Its diagonal,
 the Tits form, is the numerical form used by reflection functors and Gabriel's theorem.
+
+`TauCeti.eulerForm_card_path_left` evaluates the Euler form against the vector counting the paths
+out of a vertex `i`: it is evaluation at `i`, the last-arrow recursion for path counts cancelling
+the arrow sum.
 
 The last section evaluates both forms on the simple dimension vectors `αᵢ = Pi.single i 1`;
 in particular `TauCeti.titsPolarForm_single_single` computes the Gram matrix of the polarized
@@ -112,6 +117,37 @@ public theorem titsPolarForm_comm (d e : Q → ℤ) :
     titsPolarForm Q d e = titsPolarForm Q e d := by
   simpa only [titsPolarForm, QuadraticMap.polarBilin_apply_apply] using
     QuadraticMap.polar_comm (titsForm Q) d e
+
+/-! ### The Euler form against a path-count vector -/
+
+/-- **The Euler form against a path-count vector is evaluation.** Pairing the vector counting the
+paths out of `i` against any `e : Q → ℤ` returns `eᵢ`: at each vertex `b` the path count `#(i → b)`
+cancels the arrow-weighted sum `∑ₐ #(a ⟶ b) · #(i → a)` up to the trivial path, by the last-arrow
+recursion `TauCeti.card_path_eq_ite_add_sum`. -/
+public theorem eulerForm_card_path_left (i : Q) [∀ a : Q, Finite (Quiver.Path i a)] (e : Q → ℤ) :
+    eulerForm Q (fun v ↦ (Nat.card (Quiver.Path i v) : ℤ)) e = e i := by
+  classical
+  have key : ∀ b : Q,
+      (Nat.card (Quiver.Path i b) : ℤ)
+          - ∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)
+        = if i = b then 1 else 0 := by
+    intro b
+    have h := congrArg (fun n : ℕ ↦ (n : ℤ)) (card_path_eq_ite_add_sum (V := Q) i b)
+    push_cast [Nat.card_eq_fintype_card] at h
+    rw [h, Finset.sum_congr rfl fun a _ ↦
+      mul_comm ((Fintype.card (a ⟶ b) : ℤ)) ((Nat.card (Quiver.Path i a) : ℤ))]
+    ring
+  have hswap : ∑ a : Q, ∑ b : Q,
+        (Fintype.card (a ⟶ b) : ℤ) * ((Nat.card (Quiver.Path i a) : ℤ) * e b)
+      = ∑ b : Q,
+          (∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)) * e b := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun b _ ↦ ?_
+    rw [Finset.sum_mul]
+    exact Finset.sum_congr rfl fun a _ ↦ by ring
+  rw [eulerForm_eq_sum_card, hswap, ← Finset.sum_sub_distrib,
+    Finset.sum_congr rfl fun b _ ↦ by rw [← sub_mul, key b]]
+  simp
 
 /-! ### The Euler and Tits forms in the simple dimension vectors -/
 

--- a/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
+++ b/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Combinatorics.Quiver.Path
+public import Mathlib.Data.Finite.Prod
+public import Mathlib.Data.Finite.Sigma
+public import Mathlib.SetTheory.Cardinal.Finite
+
+/-!
+# The last arrow of a path
+
+A path `i → b` in a quiver is either trivial, which forces `i = b`, or a path `i → a` followed by a
+last arrow `a ⟶ b`. This file records that dichotomy as an equivalence and reads off the resulting
+recursion for the number of paths out of a fixed vertex.
+
+## Main definitions
+
+* `TauCeti.pathLastArrowEquiv`: the last-arrow decomposition
+  `Path i b ≃ PLift (i = b) ⊕ Σ a, Path i a × (a ⟶ b)`.
+
+## Main results
+
+* `TauCeti.card_path_eq_ite_add_sum`: the path count `#(i → b)` equals `∑ₐ #(i → a) · #(a ⟶ b)`,
+  plus `1` when `i = b` for the trivial path.
+
+## Implementation notes
+
+The equivalence is the constructor dichotomy of `Quiver.Path`: `Quiver.Path.nil` is the left summand
+and `Quiver.Path.cons` the right one, so both directions are definitional matches. The proposition
+`i = b` is wrapped in `PLift` only to make the summand a type, so that `Nat.card` applies.
+
+The dual decomposition, by the *first* arrow of a path, is not available in this form: the
+recursion of `Quiver.Path` is on the target vertex, so the first arrow is not visible to a match.
+Mathlib's `Quiver.Path.length_ne_zero_iff_eq_comp` supplies its existence half.
+
+## References
+
+The path count is the combinatorial input to the Euler-form identity for the projective
+representation at a vertex, Layer 4 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable {V : Type u} [Quiver.{v} V]
+
+/-- The forward half of `TauCeti.pathLastArrowEquiv`, by cases on the path. -/
+private def lastArrowDecomp {i : V} : ∀ {b : V}, Quiver.Path i b →
+    PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)
+  | _, .nil => Sum.inl ⟨rfl⟩
+  | _, .cons p e => Sum.inr ⟨_, p, e⟩
+
+/-- The backward half of `TauCeti.pathLastArrowEquiv`: reassemble a path from its last arrow. -/
+private def lastArrowRecomp {i b : V} :
+    (PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)) → Quiver.Path i b
+  | Sum.inl ⟨rfl⟩ => Quiver.Path.nil
+  | Sum.inr ⟨_, p, e⟩ => p.cons e
+
+/-- **The last-arrow decomposition of a path.** A path `i → b` is either trivial, and then `i = b`,
+or a path `i → a` followed by a last arrow `a ⟶ b`, uniquely so. -/
+def pathLastArrowEquiv (i b : V) :
+    Quiver.Path i b ≃ (PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)) where
+  toFun := lastArrowDecomp
+  invFun := lastArrowRecomp
+  left_inv p := by cases p <;> rfl
+  right_inv x := by
+    cases x with
+    | inl h => cases h with | up h => subst h; rfl
+    | inr y => obtain ⟨a, p, e⟩ := y; rfl
+
+/-- **The last-arrow recursion for path counts.** The paths `i → b` are the trivial one, present
+exactly when `i = b`, together with a path `i → a` and an arrow `a ⟶ b`. All three cardinalities
+are honest counts only when the path sets are finite, which is what the hypotheses provide. -/
+theorem card_path_eq_ite_add_sum [DecidableEq V] [Fintype V] [∀ a b : V, Finite (a ⟶ b)]
+    [∀ a b : V, Finite (Quiver.Path a b)] (i b : V) :
+    Nat.card (Quiver.Path i b)
+      = (if i = b then 1 else 0)
+        + ∑ a : V, Nat.card (Quiver.Path i a) * Nat.card (a ⟶ b) := by
+  haveI hsub : Subsingleton (PLift (i = b)) := ⟨fun x y ↦ by cases x; cases y; rfl⟩
+  haveI : Finite (PLift (i = b)) := Finite.of_subsingleton
+  have hcard : Nat.card (PLift (i = b)) = if i = b then 1 else 0 := by
+    by_cases h : i = b
+    · rw [if_pos h]
+      exact Nat.card_eq_one_iff_unique.mpr ⟨hsub, ⟨⟨h⟩⟩⟩
+    · rw [if_neg h]
+      haveI : IsEmpty (PLift (i = b)) := ⟨fun x ↦ h x.down⟩
+      exact Nat.card_of_isEmpty
+  rw [Nat.card_congr (pathLastArrowEquiv i b), Nat.card_sum, hcard, Nat.card_sigma]
+  exact congrArg _ (Finset.sum_congr rfl fun a _ ↦ Nat.card_prod _ _)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
+++ b/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
@@ -30,7 +30,10 @@ recursion for the number of paths out of a fixed vertex.
 
 The equivalence is the constructor dichotomy of `Quiver.Path`: `Quiver.Path.nil` is the left summand
 and `Quiver.Path.cons` the right one, so both directions are definitional matches. The proposition
-`i = b` is wrapped in `PLift` only to make the summand a type, so that `Nat.card` applies.
+`i = b` is wrapped in `PLift` only to make the summand a type, so that `Nat.card` applies. The
+`simp` lemmas `TauCeti.pathLastArrowEquiv_nil`, `TauCeti.pathLastArrowEquiv_cons`,
+`TauCeti.pathLastArrowEquiv_symm_inl` and `TauCeti.pathLastArrowEquiv_symm_inr` record those matches
+on both summands, so consumers compute with the equivalence without unfolding it.
 
 The dual decomposition, by the *first* arrow of a path, is not available in this form: the
 recursion of `Quiver.Path` is on the target vertex, so the first arrow is not visible to a match.
@@ -51,35 +54,52 @@ universe u v
 
 variable {V : Type u} [Quiver.{v} V]
 
-/-- The forward half of `TauCeti.pathLastArrowEquiv`, by cases on the path. -/
-private def lastArrowDecomp {i : V} : ∀ {b : V}, Quiver.Path i b →
-    PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)
-  | _, .nil => Sum.inl ⟨rfl⟩
-  | _, .cons p e => Sum.inr ⟨_, p, e⟩
-
-/-- The backward half of `TauCeti.pathLastArrowEquiv`: reassemble a path from its last arrow. -/
-private def lastArrowRecomp {i b : V} :
-    (PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)) → Quiver.Path i b
-  | Sum.inl ⟨rfl⟩ => Quiver.Path.nil
-  | Sum.inr ⟨_, p, e⟩ => p.cons e
-
 /-- **The last-arrow decomposition of a path.** A path `i → b` is either trivial, and then `i = b`,
 or a path `i → a` followed by a last arrow `a ⟶ b`, uniquely so. -/
-def pathLastArrowEquiv (i b : V) :
+@[expose] def pathLastArrowEquiv (i b : V) :
     Quiver.Path i b ≃ (PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)) where
-  toFun := lastArrowDecomp
-  invFun := lastArrowRecomp
+  toFun p := match b, p with
+    | _, .nil => Sum.inl ⟨rfl⟩
+    | _, .cons q e => Sum.inr ⟨_, q, e⟩
+  invFun x := match x with
+    | Sum.inl ⟨rfl⟩ => Quiver.Path.nil
+    | Sum.inr ⟨_, q, e⟩ => q.cons e
   left_inv p := by cases p <;> rfl
   right_inv x := by
     cases x with
     | inl h => cases h with | up h => subst h; rfl
     | inr y => obtain ⟨a, p, e⟩ := y; rfl
 
+/-- The trivial path is the left summand of the last-arrow decomposition. -/
+@[simp]
+theorem pathLastArrowEquiv_nil (i : V) :
+    pathLastArrowEquiv i i Quiver.Path.nil = Sum.inl ⟨rfl⟩ :=
+  rfl
+
+/-- A path with a last arrow is the right summand of the last-arrow decomposition. -/
+@[simp]
+theorem pathLastArrowEquiv_cons {i a b : V} (p : Quiver.Path i a) (e : a ⟶ b) :
+    pathLastArrowEquiv i b (p.cons e) = Sum.inr ⟨a, p, e⟩ :=
+  rfl
+
+/-- The left summand of the last-arrow decomposition recomposes to the trivial path. -/
+@[simp]
+theorem pathLastArrowEquiv_symm_inl (i : V) :
+    (pathLastArrowEquiv i i).symm (Sum.inl ⟨rfl⟩) = Quiver.Path.nil :=
+  rfl
+
+/-- The right summand of the last-arrow decomposition recomposes by appending the last arrow. -/
+@[simp]
+theorem pathLastArrowEquiv_symm_inr {i b : V} (a : V) (p : Quiver.Path i a) (e : a ⟶ b) :
+    (pathLastArrowEquiv i b).symm (Sum.inr ⟨a, p, e⟩) = p.cons e :=
+  rfl
+
 /-- **The last-arrow recursion for path counts.** The paths `i → b` are the trivial one, present
 exactly when `i = b`, together with a path `i → a` and an arrow `a ⟶ b`. All three cardinalities
-are honest counts only when the path sets are finite, which is what the hypotheses provide. -/
+are honest counts only when the paths out of `i` are finite, which is what the hypothesis
+`[∀ a, Finite (Quiver.Path i a)]` provides. -/
 theorem card_path_eq_ite_add_sum [DecidableEq V] [Fintype V] [∀ a b : V, Finite (a ⟶ b)]
-    [∀ a b : V, Finite (Quiver.Path a b)] (i b : V) :
+    (i : V) [∀ a : V, Finite (Quiver.Path i a)] (b : V) :
     Nat.card (Quiver.Path i b)
       = (if i = b then 1 else 0)
         + ∑ a : V, Nat.card (Quiver.Path i a) * Nat.card (a ⟶ b) := by

--- a/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
+++ b/TauCeti/RepresentationTheory/Quiver/LastArrow.lean
@@ -33,7 +33,9 @@ and `Quiver.Path.cons` the right one, so both directions are definitional matche
 `i = b` is wrapped in `PLift` only to make the summand a type, so that `Nat.card` applies. The
 `simp` lemmas `TauCeti.pathLastArrowEquiv_nil`, `TauCeti.pathLastArrowEquiv_cons`,
 `TauCeti.pathLastArrowEquiv_symm_inl` and `TauCeti.pathLastArrowEquiv_symm_inr` record those matches
-on both summands, so consumers compute with the equivalence without unfolding it.
+on both summands, so consumers compute with the equivalence without unfolding it. Their proofs are
+written `(rfl)` rather than `rfl`: the parenthesised form keeps the proof opaque to the module
+system, so the equivalence itself need not be `@[expose]`d.
 
 The dual decomposition, by the *first* arrow of a path, is not available in this form: the
 recursion of `Quiver.Path` is on the target vertex, so the first arrow is not visible to a match.
@@ -56,7 +58,7 @@ variable {V : Type u} [Quiver.{v} V]
 
 /-- **The last-arrow decomposition of a path.** A path `i → b` is either trivial, and then `i = b`,
 or a path `i → a` followed by a last arrow `a ⟶ b`, uniquely so. -/
-@[expose] def pathLastArrowEquiv (i b : V) :
+def pathLastArrowEquiv (i b : V) :
     Quiver.Path i b ≃ (PLift (i = b) ⊕ Σ a : V, Quiver.Path i a × (a ⟶ b)) where
   toFun p := match b, p with
     | _, .nil => Sum.inl ⟨rfl⟩
@@ -74,32 +76,33 @@ or a path `i → a` followed by a last arrow `a ⟶ b`, uniquely so. -/
 @[simp]
 theorem pathLastArrowEquiv_nil (i : V) :
     pathLastArrowEquiv i i Quiver.Path.nil = Sum.inl ⟨rfl⟩ :=
-  rfl
+  (rfl)
 
 /-- A path with a last arrow is the right summand of the last-arrow decomposition. -/
 @[simp]
 theorem pathLastArrowEquiv_cons {i a b : V} (p : Quiver.Path i a) (e : a ⟶ b) :
     pathLastArrowEquiv i b (p.cons e) = Sum.inr ⟨a, p, e⟩ :=
-  rfl
+  (rfl)
 
 /-- The left summand of the last-arrow decomposition recomposes to the trivial path. -/
 @[simp]
 theorem pathLastArrowEquiv_symm_inl (i : V) :
     (pathLastArrowEquiv i i).symm (Sum.inl ⟨rfl⟩) = Quiver.Path.nil :=
-  rfl
+  (rfl)
 
 /-- The right summand of the last-arrow decomposition recomposes by appending the last arrow. -/
 @[simp]
 theorem pathLastArrowEquiv_symm_inr {i b : V} (a : V) (p : Quiver.Path i a) (e : a ⟶ b) :
     (pathLastArrowEquiv i b).symm (Sum.inr ⟨a, p, e⟩) = p.cons e :=
-  rfl
+  (rfl)
 
 /-- **The last-arrow recursion for path counts.** The paths `i → b` are the trivial one, present
 exactly when `i = b`, together with a path `i → a` and an arrow `a ⟶ b`. All three cardinalities
 are honest counts only when the paths out of `i` are finite, which is what the hypothesis
-`[∀ a, Finite (Quiver.Path i a)]` provides. -/
-theorem card_path_eq_ite_add_sum [DecidableEq V] [Fintype V] [∀ a b : V, Finite (a ⟶ b)]
-    (i : V) [∀ a : V, Finite (Quiver.Path i a)] (b : V) :
+`[∀ a, Finite (Quiver.Path i a)]` provides. The only arrows counted are those into `b`, so
+`[∀ a, Finite (a ⟶ b)]` suffices for the arrow factors. -/
+theorem card_path_eq_ite_add_sum [DecidableEq V] [Fintype V] (i : V)
+    [∀ a : V, Finite (Quiver.Path i a)] (b : V) [∀ a : V, Finite (a ⟶ b)] :
     Nat.card (Quiver.Path i b)
       = (if i = b then 1 else 0)
         + ∑ a : V, Nat.card (Quiver.Path i a) * Nat.card (a ⟶ b) := by

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
 public import TauCeti.RepresentationTheory.Quiver.Acyclic.FinitePaths
-public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Basic
 public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.EulerForm
 
 /-!

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
@@ -5,18 +5,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
+public import TauCeti.RepresentationTheory.Quiver.Acyclic.FinitePaths
 public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Basic
+public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.EulerForm
 
 /-!
 # The projectives at a vertex of an acyclic quiver
 
-Over an acyclic quiver the only path `i → i` is the trivial one, so the path count that
-`TauCeti.finrank_hom_indecProjRep_indecProjRep` computes collapses to `1` on the endomorphisms of
-`Pᵢ`: the projective `Pᵢ` is a brick.
+Over an acyclic quiver the only path `i → i` is the trivial one, so the path counts that
+`TauCeti.finrank_hom_indecProjRep_indecProjRep` and `TauCeti.titsForm_dimVector_indecProjRep`
+compute collapse to `1` on the endomorphisms of `Pᵢ` and on the Tits norm of its dimension vector:
+the projective `Pᵢ` is a brick, and `dim Pᵢ` is a root.
 
 ## Main results
 
 * `TauCeti.finrank_end_indecProjRep_of_isAcyclic`: `dim End(Pᵢ) = 1` over an acyclic quiver.
+* `TauCeti.titsForm_dimVector_indecProjRep_of_isAcyclic`: `titsForm (dim Pᵢ) = 1` over an acyclic
+  quiver, acyclicity supplying the finiteness of the paths out of `i` as well.
 
 ## References
 
@@ -42,5 +47,20 @@ theorem finrank_end_indecProjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
   letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
   letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
   rw [finrank_hom_indecProjRep_indecProjRep, Nat.card_unique]
+
+/-- **Over an acyclic quiver the dimension vector of `Pᵢ` is a root of the Tits form**: its Tits
+norm is `1`, the trivial path being the only closed path at `i`. Acyclicity also supplies the
+finiteness of the paths out of `i`, by `TauCeti.finite_paths_of_isAcyclic`, so no path-finiteness
+hypothesis is needed. -/
+theorem titsForm_dimVector_indecProjRep_of_isAcyclic [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+    (h : Quiver.IsAcyclic Q) (i : Q) :
+    titsForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) = 1 := by
+  haveI := finite_paths_of_isAcyclic h
+  haveI : ∀ a : Q, Finite (Quiver.Path i a) := fun a ↦
+    Finite.of_injective (fun p : Quiver.Path i a ↦ (⟨i, a, p⟩ : Σ x y : Q, Quiver.Path x y))
+      fun p q hpq ↦ by simpa using hpq
+  letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
+  letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
+  rw [titsForm_dimVector_indecProjRep, Nat.card_unique, Nat.cast_one]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
@@ -1,0 +1,152 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
+public import TauCeti.RepresentationTheory.Quiver.EulerForm
+public import TauCeti.RepresentationTheory.Quiver.LastArrow
+public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Basic
+
+/-!
+# The Euler form against the dimension vector of a vertex projective
+
+The Euler form of a finite quiver is the numerical shadow of the homological pairing: for
+finite-dimensional representations of an acyclic quiver, `⟨dim M, dim N⟩` is
+`dim Hom(M, N) - dim Ext¹(M, N)`. On the projective `Pᵢ` that identity needs no `Ext`, because
+`Ext¹(Pᵢ, -)` vanishes and `Hom(Pᵢ, N)` is `Nᵢ`. This file proves the resulting closed formula,
+
+`⟨dim Pᵢ, e⟩ = eᵢ` for every `e : Q → ℤ`,
+
+which holds over any finite quiver with finitely many paths — no acyclicity, no algebraically
+closed field, no finite-dimensionality of the representations involved.
+
+## Main results
+
+* `TauCeti.eulerForm_card_path_left`: the combinatorial core, `⟨(#(i → -)), e⟩ = eᵢ`, a restatement
+  of the last-arrow recursion `TauCeti.card_path_eq_ite_add_sum` for path counts.
+* `TauCeti.eulerForm_dimVector_indecProjRep`: `⟨dim Pᵢ, e⟩ = eᵢ`.
+* `TauCeti.eulerForm_dimVector_indecProjRep_eq_finrank_hom`: the homological reading,
+  `⟨dim Pᵢ, dim N⟩ = dim Hom(Pᵢ, N)`.
+* `TauCeti.eulerForm_dimVector_indecProjRep_indecProjRep`: the Cartan pairing of two projectives
+  counts the paths `j → i`.
+* `TauCeti.titsForm_dimVector_indecProjRep_of_isAcyclic`: over an acyclic quiver `dim Pᵢ` has Tits
+  norm `1`, so it is a root of the Tits form.
+
+## Implementation notes
+
+The hypothesis carried throughout is `∀ a b, Finite (Quiver.Path a b)`, the finiteness that makes
+`TauCeti.dimVector (indecProjRep k Q i)` an honest path count rather than the `0` that
+`Module.finrank` returns on an infinite-dimensional space. For a finite quiver it follows from
+acyclicity, by `TauCeti.finite_paths_of_isAcyclic`; the loop quiver, where it fails, is exactly the
+boundary case the roadmap records.
+
+Dimension vectors take values in `ℕ` while the Euler form is defined on `Q → ℤ`, so every statement
+below feeds the Euler form the pointwise cast `fun v ↦ (dimVector M v : ℤ)`.
+
+The dual statements, for the injective `Iᵢ` on the right-hand side of the Euler form, need the
+decomposition of a path by its *first* arrow, which
+`TauCeti.RepresentationTheory.Quiver.LastArrow` does not provide; they are left for later.
+
+## References
+
+This implements the projective case of the homological interpretation of the Euler form, Layer 4 of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Derksen--Weyman, *An
+Introduction to Quiver Representations*, Ch. 1, and Assem--Simson--Skowroński, *Elements of the
+Representation Theory of Associative Algebras I*, Ch. III.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v w
+
+variable (Q : Type v) [Quiver.{w} Q] [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
+  [∀ a b : Q, Finite (Quiver.Path a b)]
+
+/-- **The Euler form against a path-count vector is evaluation.** Pairing the vector counting the
+paths out of `i` against any `e : Q → ℤ` returns `eᵢ`: at each vertex `b` the path count `#(i → b)`
+cancels the arrow-weighted sum `∑ₐ #(a ⟶ b) · #(i → a)` up to the trivial path, by the last-arrow
+recursion `TauCeti.card_path_eq_ite_add_sum`. -/
+theorem eulerForm_card_path_left (i : Q) (e : Q → ℤ) :
+    eulerForm Q (fun v ↦ (Nat.card (Quiver.Path i v) : ℤ)) e = e i := by
+  classical
+  have key : ∀ b : Q,
+      (Nat.card (Quiver.Path i b) : ℤ)
+          - ∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)
+        = if i = b then 1 else 0 := by
+    intro b
+    have h := congrArg (fun n : ℕ ↦ (n : ℤ)) (card_path_eq_ite_add_sum (V := Q) i b)
+    push_cast [Nat.card_eq_fintype_card] at h
+    rw [h, Finset.sum_congr rfl fun a _ ↦
+      mul_comm ((Fintype.card (a ⟶ b) : ℤ)) ((Nat.card (Quiver.Path i a) : ℤ))]
+    ring
+  have hswap : ∑ a : Q, ∑ b : Q,
+        (Fintype.card (a ⟶ b) : ℤ) * ((Nat.card (Quiver.Path i a) : ℤ) * e b)
+      = ∑ b : Q,
+          (∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)) * e b := by
+    rw [Finset.sum_comm]
+    refine Finset.sum_congr rfl fun b _ ↦ ?_
+    rw [Finset.sum_mul]
+    exact Finset.sum_congr rfl fun a _ ↦ by ring
+  rw [eulerForm_eq_sum_card, hswap, ← Finset.sum_sub_distrib,
+    Finset.sum_congr rfl fun b _ ↦ by rw [← sub_mul, key b]]
+  simp
+
+variable (k : Type u) [Field k]
+
+/-- **The Euler form against the dimension vector of `Pᵢ` is evaluation at `i`.** This is the
+homological identity `⟨dim M, dim N⟩ = dim Hom(M, N) - dim Ext¹(M, N)` in the one case where it
+needs no `Ext`: the projective `Pᵢ` represents evaluation at `i`. -/
+theorem eulerForm_dimVector_indecProjRep (i : Q) (e : Q → ℤ) :
+    eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) e = e i := by
+  have hcount : (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
+      = fun v ↦ (Nat.card (Quiver.Path i v) : ℤ) := by
+    funext v
+    rw [dimVector_indecProjRep]
+  rw [hcount, eulerForm_card_path_left]
+
+/-- **The homological reading of the Euler form at a projective.** For every representation `N`,
+`⟨dim Pᵢ, dim N⟩` is the dimension of `Hom(Pᵢ, N)`; the `Ext¹` term of the general identity is
+absent because `Pᵢ` is projective. -/
+theorem eulerForm_dimVector_indecProjRep_eq_finrank_hom (i : Q) (N : QuiverRep k Q) :
+    eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
+        (fun v ↦ (dimVector N v : ℤ))
+      = (Module.finrank k (indecProjRep k Q i ⟶ N) : ℤ) := by
+  rw [eulerForm_dimVector_indecProjRep, finrank_hom_indecProjRep]
+
+/-- **The Cartan pairing of two vertex projectives.** `⟨dim Pᵢ, dim Pⱼ⟩` counts the paths `j → i`,
+which is `dim Hom(Pᵢ, Pⱼ)`: the Euler form reproduces the path-counting Cartan matrix of a path
+algebra. -/
+theorem eulerForm_dimVector_indecProjRep_indecProjRep (i j : Q) :
+    eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
+        (fun v ↦ (dimVector (indecProjRep k Q j) v : ℤ))
+      = (Nat.card (Quiver.Path j i) : ℤ) := by
+  rw [eulerForm_dimVector_indecProjRep, dimVector_indecProjRep]
+
+/-- **The Euler pairing of a projective against a vertex simple.** `⟨dim Pᵢ, αⱼ⟩ = δᵢⱼ`, the
+dimension of `Hom(Pᵢ, Sⱼ)`: the projectives and the simples are dual bases for the Euler form. -/
+theorem eulerForm_dimVector_indecProjRep_single [DecidableEq Q] (i j : Q) :
+    eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) (Pi.single j 1)
+      = if i = j then 1 else 0 := by
+  rw [eulerForm_dimVector_indecProjRep, Pi.single_apply]
+
+/-- The Tits norm of the dimension vector of `Pᵢ` counts the closed paths at `i`. -/
+theorem titsForm_dimVector_indecProjRep (i : Q) :
+    titsForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
+      = (Nat.card (Quiver.Path i i) : ℤ) := by
+  rw [titsForm_def, eulerForm_dimVector_indecProjRep, dimVector_indecProjRep]
+
+/-- **Over an acyclic quiver the dimension vector of `Pᵢ` is a root of the Tits form**: its Tits
+norm is `1`, the trivial path being the only closed path at `i`. -/
+theorem titsForm_dimVector_indecProjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
+    titsForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) = 1 := by
+  letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
+  letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
+  rw [titsForm_dimVector_indecProjRep, Nat.card_unique, Nat.cast_one]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.RepresentationTheory.Quiver.Acyclic.Basic
 public import TauCeti.RepresentationTheory.Quiver.EulerForm
-public import TauCeti.RepresentationTheory.Quiver.LastArrow
 public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Basic
 
 /-!
@@ -24,23 +22,25 @@ closed field, no finite-dimensionality of the representations involved.
 
 ## Main results
 
-* `TauCeti.eulerForm_card_path_left`: the combinatorial core, `⟨(#(i → -)), e⟩ = eᵢ`, a restatement
-  of the last-arrow recursion `TauCeti.card_path_eq_ite_add_sum` for path counts.
 * `TauCeti.eulerForm_dimVector_indecProjRep`: `⟨dim Pᵢ, e⟩ = eᵢ`.
 * `TauCeti.eulerForm_dimVector_indecProjRep_eq_finrank_hom`: the homological reading,
   `⟨dim Pᵢ, dim N⟩ = dim Hom(Pᵢ, N)`.
 * `TauCeti.eulerForm_dimVector_indecProjRep_indecProjRep`: the Cartan pairing of two projectives
   counts the paths `j → i`.
-* `TauCeti.titsForm_dimVector_indecProjRep_of_isAcyclic`: over an acyclic quiver `dim Pᵢ` has Tits
-  norm `1`, so it is a root of the Tits form.
 
 ## Implementation notes
 
-The hypothesis carried throughout is `∀ a b, Finite (Quiver.Path a b)`, the finiteness that makes
-`TauCeti.dimVector (indecProjRep k Q i)` an honest path count rather than the `0` that
-`Module.finrank` returns on an infinite-dimensional space. For a finite quiver it follows from
-acyclicity, by `TauCeti.finite_paths_of_isAcyclic`; the loop quiver, where it fails, is exactly the
-boundary case the roadmap records.
+The combinatorial core is `TauCeti.eulerForm_card_path_left`, in
+`TauCeti.RepresentationTheory.Quiver.EulerForm`, which pairs a path-count vector against the Euler
+form; the results below just rewrite `dim Pᵢ` into that path count. Over an acyclic quiver the Tits
+norm of `dim Pᵢ` is `1`; that statement lives in
+`TauCeti.RepresentationTheory.Quiver.Representation.Projective.Acyclic`.
+
+The hypothesis carried throughout is `∀ a, Finite (Quiver.Path i a)`, for the vertex `i` at hand:
+the finiteness that makes `TauCeti.dimVector (indecProjRep k Q i)` an honest path count rather than
+the `0` that `Module.finrank` returns on an infinite-dimensional space. For a finite quiver it
+follows from acyclicity, by `TauCeti.finite_paths_of_isAcyclic`; the loop quiver, where it fails, is
+exactly the boundary case the roadmap records.
 
 Dimension vectors take values in `ℕ` while the Euler form is defined on `Q → ℤ`, so every statement
 below feeds the Euler form the pointwise cast `fun v ↦ (dimVector M v : ℤ)`.
@@ -66,43 +66,12 @@ open CategoryTheory
 universe u v w
 
 variable (Q : Type v) [Quiver.{w} Q] [Fintype Q] [∀ a b : Q, Fintype (a ⟶ b)]
-  [∀ a b : Q, Finite (Quiver.Path a b)]
-
-/-- **The Euler form against a path-count vector is evaluation.** Pairing the vector counting the
-paths out of `i` against any `e : Q → ℤ` returns `eᵢ`: at each vertex `b` the path count `#(i → b)`
-cancels the arrow-weighted sum `∑ₐ #(a ⟶ b) · #(i → a)` up to the trivial path, by the last-arrow
-recursion `TauCeti.card_path_eq_ite_add_sum`. -/
-theorem eulerForm_card_path_left (i : Q) (e : Q → ℤ) :
-    eulerForm Q (fun v ↦ (Nat.card (Quiver.Path i v) : ℤ)) e = e i := by
-  classical
-  have key : ∀ b : Q,
-      (Nat.card (Quiver.Path i b) : ℤ)
-          - ∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)
-        = if i = b then 1 else 0 := by
-    intro b
-    have h := congrArg (fun n : ℕ ↦ (n : ℤ)) (card_path_eq_ite_add_sum (V := Q) i b)
-    push_cast [Nat.card_eq_fintype_card] at h
-    rw [h, Finset.sum_congr rfl fun a _ ↦
-      mul_comm ((Fintype.card (a ⟶ b) : ℤ)) ((Nat.card (Quiver.Path i a) : ℤ))]
-    ring
-  have hswap : ∑ a : Q, ∑ b : Q,
-        (Fintype.card (a ⟶ b) : ℤ) * ((Nat.card (Quiver.Path i a) : ℤ) * e b)
-      = ∑ b : Q,
-          (∑ a : Q, (Fintype.card (a ⟶ b) : ℤ) * (Nat.card (Quiver.Path i a) : ℤ)) * e b := by
-    rw [Finset.sum_comm]
-    refine Finset.sum_congr rfl fun b _ ↦ ?_
-    rw [Finset.sum_mul]
-    exact Finset.sum_congr rfl fun a _ ↦ by ring
-  rw [eulerForm_eq_sum_card, hswap, ← Finset.sum_sub_distrib,
-    Finset.sum_congr rfl fun b _ ↦ by rw [← sub_mul, key b]]
-  simp
-
-variable (k : Type u) [Field k]
+  (k : Type u) [Field k]
 
 /-- **The Euler form against the dimension vector of `Pᵢ` is evaluation at `i`.** This is the
 homological identity `⟨dim M, dim N⟩ = dim Hom(M, N) - dim Ext¹(M, N)` in the one case where it
 needs no `Ext`: the projective `Pᵢ` represents evaluation at `i`. -/
-theorem eulerForm_dimVector_indecProjRep (i : Q) (e : Q → ℤ) :
+theorem eulerForm_dimVector_indecProjRep (i : Q) [∀ a : Q, Finite (Quiver.Path i a)] (e : Q → ℤ) :
     eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) e = e i := by
   have hcount : (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
       = fun v ↦ (Nat.card (Quiver.Path i v) : ℤ) := by
@@ -113,7 +82,8 @@ theorem eulerForm_dimVector_indecProjRep (i : Q) (e : Q → ℤ) :
 /-- **The homological reading of the Euler form at a projective.** For every representation `N`,
 `⟨dim Pᵢ, dim N⟩` is the dimension of `Hom(Pᵢ, N)`; the `Ext¹` term of the general identity is
 absent because `Pᵢ` is projective. -/
-theorem eulerForm_dimVector_indecProjRep_eq_finrank_hom (i : Q) (N : QuiverRep k Q) :
+theorem eulerForm_dimVector_indecProjRep_eq_finrank_hom (i : Q) [∀ a : Q, Finite (Quiver.Path i a)]
+    (N : QuiverRep k Q) :
     eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
         (fun v ↦ (dimVector N v : ℤ))
       = (Module.finrank k (indecProjRep k Q i ⟶ N) : ℤ) := by
@@ -122,7 +92,8 @@ theorem eulerForm_dimVector_indecProjRep_eq_finrank_hom (i : Q) (N : QuiverRep k
 /-- **The Cartan pairing of two vertex projectives.** `⟨dim Pᵢ, dim Pⱼ⟩` counts the paths `j → i`,
 which is `dim Hom(Pᵢ, Pⱼ)`: the Euler form reproduces the path-counting Cartan matrix of a path
 algebra. -/
-theorem eulerForm_dimVector_indecProjRep_indecProjRep (i j : Q) :
+theorem eulerForm_dimVector_indecProjRep_indecProjRep (i : Q) [∀ a : Q, Finite (Quiver.Path i a)]
+    (j : Q) :
     eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
         (fun v ↦ (dimVector (indecProjRep k Q j) v : ℤ))
       = (Nat.card (Quiver.Path j i) : ℤ) := by
@@ -130,23 +101,16 @@ theorem eulerForm_dimVector_indecProjRep_indecProjRep (i j : Q) :
 
 /-- **The Euler pairing of a projective against a vertex simple.** `⟨dim Pᵢ, αⱼ⟩ = δᵢⱼ`, the
 dimension of `Hom(Pᵢ, Sⱼ)`: the projectives and the simples are dual bases for the Euler form. -/
-theorem eulerForm_dimVector_indecProjRep_single [DecidableEq Q] (i j : Q) :
+theorem eulerForm_dimVector_indecProjRep_single [DecidableEq Q] (i : Q)
+    [∀ a : Q, Finite (Quiver.Path i a)] (j : Q) :
     eulerForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) (Pi.single j 1)
       = if i = j then 1 else 0 := by
   rw [eulerForm_dimVector_indecProjRep, Pi.single_apply]
 
 /-- The Tits norm of the dimension vector of `Pᵢ` counts the closed paths at `i`. -/
-theorem titsForm_dimVector_indecProjRep (i : Q) :
+theorem titsForm_dimVector_indecProjRep (i : Q) [∀ a : Q, Finite (Quiver.Path i a)] :
     titsForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ))
       = (Nat.card (Quiver.Path i i) : ℤ) := by
   rw [titsForm_def, eulerForm_dimVector_indecProjRep, dimVector_indecProjRep]
-
-/-- **Over an acyclic quiver the dimension vector of `Pᵢ` is a root of the Tits form**: its Tits
-norm is `1`, the trivial path being the only closed path at `i`. -/
-theorem titsForm_dimVector_indecProjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
-    titsForm Q (fun v ↦ (dimVector (indecProjRep k Q i) v : ℤ)) = 1 := by
-  letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
-  letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
-  rw [titsForm_dimVector_indecProjRep, Nat.card_unique, Nat.cast_one]
 
 end TauCeti


### PR DESCRIPTION
This PR computes the Euler form of a finite quiver paired against the dimension vector of the projective representation `Pᵢ` at a vertex: `⟨dim Pᵢ, e⟩ = eᵢ` for every `e : Q → ℤ`. This is the homological identity `⟨dim M, dim N⟩ = dim Hom(M, N) − dim Ext¹(M, N)` in the one case where it needs no `Ext` at all, since `Ext¹(Pᵢ, −)` vanishes and `Hom(Pᵢ, N)` is `Nᵢ`; it therefore needs neither acyclicity, nor an algebraically closed field, nor finite-dimensionality of the representations paired against.

The combinatorial input is new too: a path `i → b` is either trivial, forcing `i = b`, or a path `i → a` followed by a last arrow `a ⟶ b`. `TauCeti.pathLastArrowEquiv` records that dichotomy as an equivalence, and `TauCeti.card_path_eq_ite_add_sum` reads off the recursion `#(i → b) = δ + ∑ₐ #(i → a) · #(a ⟶ b)` for path counts. Feeding it to `TauCeti.eulerForm` makes the arrow sum cancel the path count at every vertex except for the trivial path at `i`.

Consequences: `⟨dim Pᵢ, dim N⟩ = dim Hom(Pᵢ, N)`, the Cartan pairing `⟨dim Pᵢ, dim Pⱼ⟩ = #(j → i)`, the dual-basis pairing `⟨dim Pᵢ, αⱼ⟩ = δᵢⱼ` against a simple dimension vector, and, over an acyclic quiver, `titsForm (dim Pᵢ) = 1` — so the dimension vector of an indecomposable projective is a root of the Tits form, the property `dimVector_isRoot_iff` uses to match indecomposables with positive roots.

Target: Layer 4, "The homological interpretation", of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md` (`eulerForm (dimVector M) (dimVector N) = dim_k Hom(M, N) − dim_k Ext¹(M, N)`), for the projective case where the `Ext` term is absent.

Two files are added, 250 lines total: `TauCeti/RepresentationTheory/Quiver/LastArrow.lean` (the decomposition and the path count) and `TauCeti/RepresentationTheory/Quiver/Representation/Projective/EulerForm.lean` (the Euler-form results). Nothing was vendored from Mathlib. The dual statements for the injective `Iᵢ` need the decomposition of a path by its *first* arrow, which `Quiver.Path`'s recursion on the target vertex does not expose to a match; they are flagged in the module docs and left for a follow-up.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"eulerform-dimvector-indecprojrep"}-->

🤖 Prepared with Claude Code
