### PR TITLE
fix: let Zulip workflows read review state

### DIFF
--- a/.github/workflows/zulip-pr-backfill.yml
+++ b/.github/workflows/zulip-pr-backfill.yml
@@ -16,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -13,6 +13,7 @@ on:
 
 permissions:
   contents: read
+  issues: read
   pull-requests: read
   statuses: read
 

--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -18,6 +18,7 @@ on:
 
 permissions:
   contents: read        # checkout the script
+  issues: read          # read review scoreboards and in-progress markers
   pull-requests: read   # read PR state
   statuses: read        # read the `build` commit status
 


### PR DESCRIPTION
This PR grants the Zulip lifecycle, status, and backfill workflows read access to issue comments, allowing their shared status derivation to see review scoreboards and in-progress markers and render the corresponding eyes, writing, and approval reactions.

Tested with `python3 -m unittest test_pr_labels test_zulip test_stuck_alerts` (79 tests).

:robot: Prepared with OpenAI Codex