### PR TITLE
fix: use review app token for Zulip status

### DIFF
--- a/.github/workflows/zulip-pr-backfill.yml
+++ b/.github/workflows/zulip-pr-backfill.yml
@@ -30,12 +30,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 360
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          repositories: TauCeti
+          permission-issues: read
+          permission-pull-requests: read
+          permission-statuses: read
       - uses: actions/checkout@v4
         with:
           sparse-checkout: scripts/pr_status
       - name: Reconcile all existing PR posts
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
           ZULIP_SITE: https://leanprover.zulipchat.com

--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -33,10 +33,20 @@ jobs:
       !(github.event.workflow_run.name == 'Review' && github.event.action == 'requested')
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          repositories: TauCeti
+          permission-issues: read
+          permission-pull-requests: read
+          permission-statuses: read
       - name: Resolve PR number
         id: pr
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           PR=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
@@ -60,7 +70,7 @@ jobs:
         # required checks, and auto-merge gates on the build status + review
         # ledger, not on this workflow.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
           ZULIP_SITE: https://leanprover.zulipchat.com

--- a/.github/workflows/zulip-pr.yml
+++ b/.github/workflows/zulip-pr.yml
@@ -34,6 +34,16 @@ jobs:
     if: github.repository == 'TauCetiProject/TauCeti'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: TauCetiProject
+          repositories: TauCeti
+          permission-issues: read
+          permission-pull-requests: read
+          permission-statuses: read
       - uses: actions/checkout@v4
         with:
           sparse-checkout: scripts/pr_status
@@ -44,7 +54,7 @@ jobs:
         # required checks, and auto-merge gates on the build status + review
         # ledger, not on this workflow.
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           ZULIP_API_KEY: ${{ secrets.ZULIP_API_KEY }}
           ZULIP_EMAIL: ${{ secrets.ZULIP_EMAIL }}
           ZULIP_SITE: https://leanprover.zulipchat.com


### PR DESCRIPTION
This PR makes the Zulip lifecycle, status, and backfill workflows use the repository App token that already reads canonical review scoreboards for status labels. The default Actions token continued returning no trusted review comments even after receiving read permissions, causing the Zulip workflows to derive every open PR as unreviewed.

Tested with `python3 -m unittest test_pr_labels test_zulip test_stuck_alerts` (79 tests).

:robot: Prepared with OpenAI Codex