### PR TITLE
fix: resolve fork PRs by exact head

### DIFF
--- a/.github/workflows/pr-labels.yml
+++ b/.github/workflows/pr-labels.yml
@@ -97,10 +97,19 @@ jobs:
             workflow_run)
               pr="$WF_PR"
               if [ -z "$pr" ]; then
-                # Fork PRs leave pull_requests[] empty. Resolve by head, and accept it only when
-                # EXACTLY ONE open PR is at that commit, so an ambiguous match never labels the wrong PR.
-                pr=$(gh api "repos/$REPO/commits/$WF_HEAD/pulls" \
-                       --jq '[.[] | select(.state=="open")] | if length==1 then .[0].number else empty end')
+                # Fork PRs leave pull_requests[] empty, and GitHub's
+                # commits/<sha>/pulls endpoint need not associate their head
+                # commit with the base repository. Scan every open PR instead
+                # and accept EXACTLY ONE head-SHA match, so an ambiguous match
+                # can never label the wrong PR.
+                matches=$(gh api --paginate "repos/$REPO/pulls?state=open&per_page=100" \
+                  --jq ".[] | select(.head.sha == \"$WF_HEAD\") | .number")
+                mapfile -t prs <<< "$matches"
+                if [ -n "$matches" ] && [ "${#prs[@]}" -eq 1 ]; then
+                  pr="${prs[0]}"
+                else
+                  pr=""
+                fi
               fi
               ;;
           esac

--- a/.github/workflows/zulip-pr-status.yml
+++ b/.github/workflows/zulip-pr-status.yml
@@ -51,7 +51,16 @@ jobs:
         run: |
           PR=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number // empty')
           if [ -z "$PR" ]; then
-            PR=$(gh api "repos/${{ github.repository }}/commits/$HEAD_SHA/pulls" --jq '.[0].number // empty' 2>/dev/null || true)
+            # Fork PRs leave pull_requests[] empty, and commits/<sha>/pulls
+            # need not associate their head commit with the base repository.
+            # Accept exactly one open PR whose current head is this SHA.
+            MATCHES=$(gh api --paginate \
+              "repos/${{ github.repository }}/pulls?state=open&per_page=100" \
+              --jq ".[] | select(.head.sha == \"$HEAD_SHA\") | .number" 2>/dev/null || true)
+            mapfile -t PRS <<< "$MATCHES"
+            if [ -n "$MATCHES" ] && [ "${#PRS[@]}" -eq 1 ]; then
+              PR="${PRS[0]}"
+            fi
           fi
           if [ -z "$PR" ]; then
             echo "No PR for $HEAD_SHA; skipping"; echo "skip=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This PR makes the CI-label and Zulip-status workflows resolve fork PRs by scanning open PRs for an exact, unique head-SHA match. GitHub leaves `workflow_run.pull_requests` empty for these runs and does not reliably associate fork head commits through the base repository's commit-to-PR endpoint, which left CI labels and Zulip reactions stale.

Tested with the 79 focused PR-status unit tests and against the known fork heads of PRs #1519 and #1522.

:robot: Prepared with OpenAI Codex
