### PR TITLE
fix: fail a docs rebuild that produces nothing, rather than advancing docgen

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -226,11 +226,27 @@ jobs:
       # /docs inside the site artifact. deploy-pages replaces the whole site each time, so the
       # docs must ride along in every deploy — hence the cache that keeps them available on
       # runs that did not rebuild them.
+      # A missing doc tree is only tolerable when this run did not intend to rebuild one. When it
+      # DID, deploying anyway would break the invariant the `docgen` branch carries: `docs-rebuilt`
+      # is `docs-plan.outputs.build`, which records the *intention* to rebuild, and it is what
+      # `advance-docgen-ref` keys on. So a run that planned a rebuild, produced no docs, and
+      # deployed without them would still advance `docgen` — asserting that documentation is live
+      # for a commit whose documentation was never published, which is exactly what the branch
+      # exists to rule out.
       - name: Fold the API docs into the site under /docs
+        env:
+          REBUILT: ${{ steps.docs-plan.outputs.build }}
         run: |
           if [ -d ../docbuild/.lake/build/doc ]; then
             rm -rf _out/docs
             cp -a ../docbuild/.lake/build/doc _out/docs
+            if [ ! -s _out/docs/index.html ]; then
+              echo "::error title=API docs are empty::the doc tree exists but has no index.html, so /docs would deploy unusable"
+              exit 1
+            fi
+          elif [ "$REBUILT" = "true" ]; then
+            echo "::error title=API docs missing after a rebuild::this run planned to rebuild the docs but produced no doc tree; failing rather than deploying without /docs and advancing the docgen branch"
+            exit 1
           else
             echo "::warning::no generated API docs found; /docs will be absent from this deploy"
           fi


### PR DESCRIPTION
This PR makes the Pages build fail when it planned to rebuild the API documentation but produced none, instead of deploying without `/docs` and letting `advance-docgen-ref` move the `docgen` branch anyway.

The `docgen` branch carries one invariant: it names a commit whose documentation is built and live. `advance-docgen-ref` keys on `docs-rebuilt`, which is `docs-plan.outputs.build` — and that records the *intention* to rebuild, decided before anything is built. Nothing downstream re-checks the outcome. The fold step in between treats a missing doc tree as a warning:

    else
      echo "::warning::no generated API docs found; /docs will be absent from this deploy"

So a run that planned a rebuild, produced no doc tree, and deployed successfully would still satisfy `docs-rebuilt == 'true'` and advance `docgen` to a commit whose documentation was never published. A failed `lake build` fails the job today, so the window is narrow, but it is the same class of mistake as a branch pointing at undocumented commits, and consumers of `docgen` cannot detect it.

The fold step now fails in two cases: no doc tree when a rebuild was planned, and a doc tree with no `index.html`. A missing doc tree with no rebuild planned stays a warning, since reusing cached docs is the normal path for a `web/`-only deploy and does not advance the branch.

Exercised against all four combinations of (rebuild planned, doc tree present) before opening, including the empty-tree case.

🤖 Prepared with Claude Code