### PR TITLE
fix: point docgen at the commit the deployed docs were built from

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -201,11 +201,14 @@ jobs:
       # deployed, rather than `github.sha` of whichever run happened to deploy it.
       - name: Record the commit the API docs were generated from
         if: steps.docs-plan.outputs.build == 'true'
+        # This job's default working directory is `web/`; like every other step that touches the
+        # docs project, this one runs in `docbuild/` instead.
+        working-directory: docbuild
         env:
           SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
-          marker=docbuild/.lake/build/doc/SOURCE_SHA
+          marker=.lake/build/doc/SOURCE_SHA
           # The name must be ours alone. If doc-gen4 ever emits anything at that path, silently
           # overwriting it would corrupt the documentation, and trusting it would let a generated
           # file dictate where the docgen branch points.
@@ -330,9 +333,10 @@ jobs:
   # The candidate is the marker carried inside the deployed doc tree, NOT `github.sha`. Those differ
   # whenever a deploy reuses cached documentation, which is the normal path for a `web/`-only push --
   # and taking `github.sha` there would assert that documentation exists for a commit that was never
-  # documented. It also makes the branch self-healing: every successful deploy re-points it at what
-  # is actually published, so a branch that has drifted corrects itself on the next deploy rather
-  # than staying wrong until someone notices.
+  # documented. Following the marker also makes the branch self-healing: any deploy from `main`
+  # re-points it at what is actually published, so a branch that has drifted corrects itself rather
+  # than staying wrong until someone notices. A manual dispatch from another branch still deploys
+  # but is skipped here, so drift persists until the next deploy from `main`.
   #
   # Nothing here keys on whether a rebuild was *planned*: that is decided before anything is built
   # and says nothing about what ended up published, whereas the marker records the outcome, which is

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -70,8 +70,9 @@ jobs:
   build-site:
     runs-on: ubuntu-latest
     outputs:
-      docs-rebuilt: ${{ steps.docs-plan.outputs.build }}
       # The commit the /docs actually being deployed were generated from, read from the tree itself.
+      # This is what `advance-docgen-ref` follows; there is deliberately no output for whether a
+      # rebuild was *planned*, because that says nothing about what ended up being published.
       docs-source-sha: ${{ steps.fold.outputs.docs-source-sha }}
     defaults:
       run:
@@ -200,7 +201,19 @@ jobs:
       # deployed, rather than `github.sha` of whichever run happened to deploy it.
       - name: Record the commit the API docs were generated from
         if: steps.docs-plan.outputs.build == 'true'
-        run: printf '%s\n' "${{ github.sha }}" > docbuild/.lake/build/doc/SOURCE_SHA
+        env:
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          marker=docbuild/.lake/build/doc/SOURCE_SHA
+          # The name must be ours alone. If doc-gen4 ever emits anything at that path, silently
+          # overwriting it would corrupt the documentation, and trusting it would let a generated
+          # file dictate where the docgen branch points.
+          if [ -e "$marker" ] || [ -L "$marker" ]; then
+            echo "::error title=SOURCE_SHA is taken::doc-gen4 produced an entry at $marker; the provenance marker needs another name"
+            exit 1
+          fi
+          printf '%s\n' "$SHA" > "$marker"
 
       - name: Save the generated API docs
         if: steps.docs-plan.outputs.build == 'true'
@@ -236,13 +249,6 @@ jobs:
       # /docs inside the site artifact. deploy-pages replaces the whole site each time, so the
       # docs must ride along in every deploy — hence the cache that keeps them available on
       # runs that did not rebuild them.
-      # A missing doc tree is only tolerable when this run did not intend to rebuild one. When it
-      # DID, deploying anyway would break the invariant the `docgen` branch carries: `docs-rebuilt`
-      # is `docs-plan.outputs.build`, which records the *intention* to rebuild, and it is what
-      # `advance-docgen-ref` keys on. So a run that planned a rebuild, produced no docs, and
-      # deployed without them would still advance `docgen` — asserting that documentation is live
-      # for a commit whose documentation was never published, which is exactly what the branch
-      # exists to rule out.
       # A missing doc tree is ALWAYS fatal here, whether or not this run planned a rebuild.
       #
       # A Pages deployment replaces the whole site, so deploying without `/docs` deletes the live
@@ -275,14 +281,25 @@ jobs:
             echo "::error title=API docs have no provenance::the doc tree carries no SOURCE_SHA, so the commit it documents is unknown; refusing to deploy it"
             exit 1
           fi
-          # Read as written, NOT normalised. Stripping whitespace first would fold a spaced or
-          # multi-line marker into forty hex characters and accept it, which is the same mistake as
-          # a prefix match in a different disguise. The file is written as one sha plus a newline,
-          # so it is exactly 41 bytes; anything else is not a marker this workflow produced.
-          bytes=$(wc -c < _out/docs/SOURCE_SHA)
-          sha=$(< _out/docs/SOURCE_SHA)
-          if [ "$bytes" -ne 41 ] || [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error title=API docs have a malformed SOURCE_SHA::got ${bytes} bytes, not a bare 40-character commit sha"
+          # Validated as BYTES, against the exact form this workflow writes.
+          #
+          # Reading the file into a shell variable and matching a regex is not enough on its own:
+          # command substitution silently drops NUL bytes, so forty hex characters followed by a NUL
+          # arrives as a perfectly valid sha. Rendering the parsed value back into canonical form and
+          # comparing the raw bytes catches that, along with CRLF, a BOM, and any trailing junk --
+          # whatever is on disk must be exactly `<sha>\n` and nothing else.
+          #
+          # A symlink is refused outright: reading, `wc` and the Pages uploader all follow one, so a
+          # link left in a cached tree could point the branch at whatever it resolved to at upload
+          # time rather than at what was read here.
+          marker=_out/docs/SOURCE_SHA
+          if [ -L "$marker" ] || [ ! -f "$marker" ]; then
+            echo "::error title=SOURCE_SHA is not a regular file::refusing to read provenance through a link or special file"
+            exit 1
+          fi
+          sha=$(< "$marker")
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]] || ! printf '%s\n' "$sha" | cmp -s - "$marker"; then
+            echo "::error title=API docs have a malformed SOURCE_SHA::the marker is not exactly one 40-character commit sha followed by a newline"
             exit 1
           fi
           echo "docs-source-sha=$sha" >> "$GITHUB_OUTPUT"
@@ -317,9 +334,9 @@ jobs:
   # is actually published, so a branch that has drifted corrects itself on the next deploy rather
   # than staying wrong until someone notices.
   #
-  # It no longer keys on `docs-rebuilt` either. That output records the *intention* to rebuild,
-  # decided before anything is built; the marker records the outcome, which is the question the
-  # branch is actually answering.
+  # Nothing here keys on whether a rebuild was *planned*: that is decided before anything is built
+  # and says nothing about what ended up published, whereas the marker records the outcome, which is
+  # the question the branch is actually answering.
   #
   # The branch is BEST-EFFORT, not exact. Publishing to Pages and updating a git ref are separate
   # operations that cannot be made atomic, so between the site being replaced and this job running,

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -150,9 +150,9 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: docbuild/.lake/build/doc
-          key: docs-html-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-${{ github.run_id }}
+          key: docs-html-v2-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-${{ github.run_id }}
           restore-keys: |
-            docs-html-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-
+            docs-html-v2-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-
 
       # Rebuild on the three-hour schedule / manual dispatch, or whenever no cached docs exist at
       # all (e.g. the first run after this workflow lands) so /docs is never missing for long.
@@ -207,7 +207,7 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: docbuild/.lake/build/doc
-          key: docs-html-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-${{ github.run_id }}
+          key: docs-html-v2-${{ hashFiles('lean-toolchain', 'docbuild/lake-manifest.json') }}-${{ github.run_id }}
 
       - name: Cache Lake builds (site + examples)
         uses: actions/cache@v4
@@ -265,22 +265,25 @@ jobs:
             echo "::error title=API docs are empty::the doc tree has no index.html, so /docs would deploy unusable"
             exit 1
           fi
-          # The marker rides inside the tree, so it is present whether the docs were just built or
-          # restored from cache. A tree predating this change has none; the branch then simply does
-          # not advance until the next rebuild writes one, which is the safe direction.
-          sha=""
-          if [ -s _out/docs/SOURCE_SHA ]; then
-            sha=$(tr -d "[:space:]" < _out/docs/SOURCE_SHA)
-            case "$sha" in
-              [0-9a-f]*) [ "${#sha}" -eq 40 ] || sha="" ;;
-              *) sha="" ;;
-            esac
-            [ -n "$sha" ] || echo "::warning::/docs carries an unreadable SOURCE_SHA; the docgen branch will not advance"
-          else
-            echo "::warning::/docs carries no SOURCE_SHA (built before provenance was recorded); the docgen branch will not advance"
+          # The marker rides inside the tree, so it is there whether the docs were just built or
+          # restored from cache. An unmarked tree is FATAL rather than a warning: deploying one would
+          # replace the live documentation with something whose provenance is unknown, leaving the
+          # branch naming a commit that is no longer published and no way to notice. The cache key
+          # namespace was bumped alongside this, so no pre-existing cache can supply one; a miss
+          # therefore rebuilds and stamps.
+          if [ ! -s _out/docs/SOURCE_SHA ]; then
+            echo "::error title=API docs have no provenance::the doc tree carries no SOURCE_SHA, so the commit it documents is unknown; refusing to deploy it"
+            exit 1
+          fi
+          sha=$(tr -d "[:space:]" < _out/docs/SOURCE_SHA)
+          # Matched exactly. A prefix test such as `[0-9a-f]*` accepts one hex character followed by
+          # anything at all, which is not validation.
+          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=API docs have a malformed SOURCE_SHA::got '${sha}', which is not a 40-character commit sha"
+            exit 1
           fi
           echo "docs-source-sha=$sha" >> "$GITHUB_OUTPUT"
-          printf 'deploying /docs generated from %s\n' "${sha:-unknown}"
+          printf 'deploying /docs generated from %s\n' "$sha"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -326,6 +329,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           CANDIDATE: ${{ needs.build-site.outputs.docs-source-sha }}
           REPO: ${{ github.repository }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
         run: |
           set -euo pipefail
           endpoint="repos/$REPO/git/refs/heads/docgen"
@@ -338,19 +342,38 @@ jobs:
               exit 0
             fi
 
-            # force=false makes an unexpected rewind or divergent update fail closed. A refusal here
-            # is not an error: it means the live documentation is OLDER than the branch, so the only
-            # safe move is to leave the branch alone and let a later rebuild carry it forward. The
-            # branch must never claim documentation that is not published; being behind is harmless,
-            # being ahead is the failure this exists to prevent.
-            if ! gh api --method PATCH "$endpoint" \
-                   -f sha="$CANDIDATE" \
-                   -F force=false 2> advance.err; then
-              echo "::warning title=docgen not advanced::the live documentation ($CANDIDATE) is not ahead of docgen ($current); leaving the branch where it is"
-              cat advance.err
+            # `docgen` is a POINTER TO CURRENT STATE, not an append-only history: it answers
+            # "which commit's documentation is live right now". Once this run has replaced the site,
+            # leaving the branch anywhere other than the deployed commit means it names documentation
+            # that is no longer published — so a stale value is not a safe fallback, it is the exact
+            # failure the branch exists to prevent.
+            #
+            # A non-fast-forward therefore has to be resolved, not ignored, which means the candidate
+            # must first be shown to be a real commit on this repository's mainline. With that
+            # established, moving the pointer backwards is legitimate and is how the branch recovers
+            # from having been set ahead of reality.
+            rel=$(gh api "repos/$REPO/compare/$CANDIDATE...$DEFAULT_BRANCH" --jq .status || echo unknown)
+            case "$rel" in
+              ahead|identical) ;;
+              *)
+                echo "::error title=documented commit is not on the mainline::$CANDIDATE compares '$rel' to $DEFAULT_BRANCH; refusing to point docgen at it"
+                exit 1 ;;
+            esac
+
+            # Try the safe update first. Anything other than a non-fast-forward — auth, rate limit,
+            # network, a 5xx — must fail loudly rather than be mistaken for a rewind.
+            if gh api --method PATCH "$endpoint" -f sha="$CANDIDATE" -F force=false > /dev/null 2> advance.err; then
+              echo "docgen advanced $current -> $CANDIDATE"
               exit 0
             fi
-            echo "docgen advanced $current -> $CANDIDATE"
+            if ! grep -qi "not a fast forward" advance.err; then
+              echo "::error title=could not update docgen::the update failed for a reason other than a non-fast-forward"
+              cat advance.err
+              exit 1
+            fi
+            echo "::warning title=docgen rewound::$current is not an ancestor of the deployed commit; pointing docgen back to what is actually live"
+            gh api --method PATCH "$endpoint" -f sha="$CANDIDATE" -F force=true > /dev/null
+            echo "docgen moved $current -> $CANDIDATE"
           else
             gh api --method POST "repos/$REPO/git/refs" \
               -f ref='refs/heads/docgen' \

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -292,7 +292,7 @@ jobs:
           # comparing the raw bytes catches that, along with CRLF, a BOM, and any trailing junk --
           # whatever is on disk must be exactly `<sha>\n` and nothing else.
           #
-          # A symlink is refused outright: reading, `wc` and the Pages uploader all follow one, so a
+          # A symlink is refused outright: both this read and the Pages uploader follow one, so a
           # link left in a cached tree could point the branch at whatever it resolved to at upload
           # time rather than at what was read here.
           marker=_out/docs/SOURCE_SHA
@@ -324,19 +324,15 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v4
 
-  # A moving source ref for consumers that need to stay in lockstep with the published API
-  # documentation. Advance it only after this run freshly rebuilt the docs and successfully
-  # deployed them. Cached site-only deploys must leave it alone: their docs belong to the
-  # earlier commit already named by this ref.
   # Point `docgen` at the commit whose documentation is now live.
   #
   # The candidate is the marker carried inside the deployed doc tree, NOT `github.sha`. Those differ
   # whenever a deploy reuses cached documentation, which is the normal path for a `web/`-only push --
   # and taking `github.sha` there would assert that documentation exists for a commit that was never
-  # documented. Following the marker also makes the branch self-healing: any deploy from `main`
-  # re-points it at what is actually published, so a branch that has drifted corrects itself rather
-  # than staying wrong until someone notices. A manual dispatch from another branch still deploys
-  # but is skipped here, so drift persists until the next deploy from `main`.
+  # documented. Following the marker also lets the branch heal: every successful deploy from `main`
+  # ATTEMPTS to move it to whatever is published, in either direction, so drift is corrected rather
+  # than persisting until someone notices. Only attempts, though -- this job can fail, and a manual
+  # dispatch from another branch deploys while skipping it entirely, so drift outlives both.
   #
   # Nothing here keys on whether a rebuild was *planned*: that is decided before anything is built
   # and says nothing about what ended up published, whereas the marker records the outcome, which is

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -275,11 +275,14 @@ jobs:
             echo "::error title=API docs have no provenance::the doc tree carries no SOURCE_SHA, so the commit it documents is unknown; refusing to deploy it"
             exit 1
           fi
-          sha=$(tr -d "[:space:]" < _out/docs/SOURCE_SHA)
-          # Matched exactly. A prefix test such as `[0-9a-f]*` accepts one hex character followed by
-          # anything at all, which is not validation.
-          if [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
-            echo "::error title=API docs have a malformed SOURCE_SHA::got '${sha}', which is not a 40-character commit sha"
+          # Read as written, NOT normalised. Stripping whitespace first would fold a spaced or
+          # multi-line marker into forty hex characters and accept it, which is the same mistake as
+          # a prefix match in a different disguise. The file is written as one sha plus a newline,
+          # so it is exactly 41 bytes; anything else is not a marker this workflow produced.
+          bytes=$(wc -c < _out/docs/SOURCE_SHA)
+          sha=$(< _out/docs/SOURCE_SHA)
+          if [ "$bytes" -ne 41 ] || [[ ! "$sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error title=API docs have a malformed SOURCE_SHA::got ${bytes} bytes, not a bare 40-character commit sha"
             exit 1
           fi
           echo "docs-source-sha=$sha" >> "$GITHUB_OUTPUT"
@@ -317,6 +320,12 @@ jobs:
   # It no longer keys on `docs-rebuilt` either. That output records the *intention* to rebuild,
   # decided before anything is built; the marker records the outcome, which is the question the
   # branch is actually answering.
+  #
+  # The branch is BEST-EFFORT, not exact. Publishing to Pages and updating a git ref are separate
+  # operations that cannot be made atomic, so between the site being replaced and this job running,
+  # `docgen` names documentation that is already gone; if this job then fails, it stays wrong until
+  # the next deploy repairs it. Anything that needs certainty should read `/docs/SOURCE_SHA` from
+  # the deployed site, which is the only value that is true at the moment it is read.
   advance-docgen-ref:
     needs: [build-site, deploy]
     if: needs.build-site.outputs.docs-source-sha != '' && github.ref == 'refs/heads/main'
@@ -333,50 +342,62 @@ jobs:
         run: |
           set -euo pipefail
           endpoint="repos/$REPO/git/refs/heads/docgen"
+
+          # The candidate must be a commit on this repository's mainline. Checked FIRST, before the
+          # branch is even read, so it applies equally to creating the branch, to leaving it
+          # unchanged, and to moving it -- an unrelated commit must never be installed just because
+          # the branch happened to be absent or already wrong.
+          #
+          # Direction matters: `compare/A...B` reports how B stands relative to A, so asking for
+          # CANDIDATE...DEFAULT and requiring ahead|identical is asking "does the default branch
+          # contain the candidate". A candidate that is not in the repository at all fails the call,
+          # which `|| echo unknown` turns into a refusal rather than a crash.
+          rel=$(gh api "repos/$REPO/compare/$CANDIDATE...$DEFAULT_BRANCH" --jq .status || echo unknown)
+          case "$rel" in
+            ahead|identical) ;;
+            *)
+              echo "::error title=documented commit is not on the mainline::$CANDIDATE compares '$rel' to $DEFAULT_BRANCH; refusing to point docgen at it"
+              exit 1 ;;
+          esac
+
           current=$(gh api "repos/$REPO/git/matching-refs/heads/docgen" \
             --jq '.[] | select(.ref == "refs/heads/docgen") | .object.sha')
 
-          if [ -n "$current" ]; then
-            if [ "$current" = "$CANDIDATE" ]; then
-              echo "docgen already points to $CANDIDATE"
-              exit 0
-            fi
-
-            # `docgen` is a POINTER TO CURRENT STATE, not an append-only history: it answers
-            # "which commit's documentation is live right now". Once this run has replaced the site,
-            # leaving the branch anywhere other than the deployed commit means it names documentation
-            # that is no longer published — so a stale value is not a safe fallback, it is the exact
-            # failure the branch exists to prevent.
-            #
-            # A non-fast-forward therefore has to be resolved, not ignored, which means the candidate
-            # must first be shown to be a real commit on this repository's mainline. With that
-            # established, moving the pointer backwards is legitimate and is how the branch recovers
-            # from having been set ahead of reality.
-            rel=$(gh api "repos/$REPO/compare/$CANDIDATE...$DEFAULT_BRANCH" --jq .status || echo unknown)
-            case "$rel" in
-              ahead|identical) ;;
-              *)
-                echo "::error title=documented commit is not on the mainline::$CANDIDATE compares '$rel' to $DEFAULT_BRANCH; refusing to point docgen at it"
-                exit 1 ;;
-            esac
-
-            # Try the safe update first. Anything other than a non-fast-forward — auth, rate limit,
-            # network, a 5xx — must fail loudly rather than be mistaken for a rewind.
-            if gh api --method PATCH "$endpoint" -f sha="$CANDIDATE" -F force=false > /dev/null 2> advance.err; then
-              echo "docgen advanced $current -> $CANDIDATE"
-              exit 0
-            fi
-            if ! grep -qi "not a fast forward" advance.err; then
-              echo "::error title=could not update docgen::the update failed for a reason other than a non-fast-forward"
-              cat advance.err
-              exit 1
-            fi
-            echo "::warning title=docgen rewound::$current is not an ancestor of the deployed commit; pointing docgen back to what is actually live"
-            gh api --method PATCH "$endpoint" -f sha="$CANDIDATE" -F force=true > /dev/null
-            echo "docgen moved $current -> $CANDIDATE"
-          else
+          if [ -z "$current" ]; then
             gh api --method POST "repos/$REPO/git/refs" \
               -f ref='refs/heads/docgen' \
-              -f sha="$CANDIDATE"
+              -f sha="$CANDIDATE" > /dev/null
             echo "docgen created at $CANDIDATE"
+            exit 0
           fi
+
+          if [ "$current" = "$CANDIDATE" ]; then
+            echo "docgen already points to $CANDIDATE"
+            exit 0
+          fi
+
+          # Whether this is a fast-forward is a question the API answers, so ask it rather than
+          # parsing the CLI's English error text: a reworded message or a change of output stream
+          # would silently turn a legitimate rewind into a failure, leaving the branch stale after
+          # the site had already been replaced.
+          #
+          # `docgen` is a POINTER TO CURRENT STATE, not an append-only history: it answers "which
+          # commit's documentation is live". Once this run has replaced the site, a branch left
+          # anywhere but the deployed commit names documentation that is no longer published, so a
+          # rewind is not a hazard to avoid but the correct repair -- and it is how the branch
+          # recovers from having been set ahead of reality. It is guarded by the mainline check
+          # above, so it can only ever move to a commit the default branch contains.
+          step=$(gh api "repos/$REPO/compare/$current...$CANDIDATE" --jq .status || echo unknown)
+          case "$step" in
+            ahead)
+              force=false ;;
+            behind|diverged)
+              force=true
+              echo "::warning title=docgen rewound::$current is not an ancestor of the deployed commit ($step); pointing docgen back to what is actually live" ;;
+            *)
+              echo "::error title=cannot compare docgen with the deployed commit::got '$step'"
+              exit 1 ;;
+          esac
+
+          gh api --method PATCH "$endpoint" -f sha="$CANDIDATE" -F force="$force" > /dev/null
+          echo "docgen moved $current -> $CANDIDATE (force=$force)"

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -71,6 +71,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs-rebuilt: ${{ steps.docs-plan.outputs.build }}
+      # The commit the /docs actually being deployed were generated from, read from the tree itself.
+      docs-source-sha: ${{ steps.fold.outputs.docs-source-sha }}
     defaults:
       run:
         working-directory: web
@@ -192,6 +194,14 @@ jobs:
           rm -rf .lake/build/doc .lake/build/doc-data
           lake build TauCetiDocs:docs
 
+      # Stamp the tree with the commit it was generated from, BEFORE it is cached, so the
+      # provenance travels with the tree wherever it is later restored. This is what makes the
+      # `docgen` branch trustworthy: the branch follows the marker of the tree that was actually
+      # deployed, rather than `github.sha` of whichever run happened to deploy it.
+      - name: Record the commit the API docs were generated from
+        if: steps.docs-plan.outputs.build == 'true'
+        run: printf '%s\n' "${{ github.sha }}" > docbuild/.lake/build/doc/SOURCE_SHA
+
       - name: Save the generated API docs
         if: steps.docs-plan.outputs.build == 'true'
         uses: actions/cache/save@v4
@@ -233,23 +243,44 @@ jobs:
       # deployed without them would still advance `docgen` — asserting that documentation is live
       # for a commit whose documentation was never published, which is exactly what the branch
       # exists to rule out.
+      # A missing doc tree is ALWAYS fatal here, whether or not this run planned a rebuild.
+      #
+      # A Pages deployment replaces the whole site, so deploying without `/docs` deletes the live
+      # documentation — which breaks the `docgen` invariant even though no ref moves. The decision is
+      # made from the filesystem rather than from `cache-matched-key`, because that key reports what
+      # the cache *claimed*, not what was restored. There is no legitimate path here with no tree: a
+      # genuine cache miss sets `build=true` (see `docs-plan`) and the docs are built, so an absent
+      # tree means either that build produced nothing or a hit restored nothing, and both deserve to
+      # stop the deploy.
       - name: Fold the API docs into the site under /docs
-        env:
-          REBUILT: ${{ steps.docs-plan.outputs.build }}
+        id: fold
         run: |
-          if [ -d ../docbuild/.lake/build/doc ]; then
-            rm -rf _out/docs
-            cp -a ../docbuild/.lake/build/doc _out/docs
-            if [ ! -s _out/docs/index.html ]; then
-              echo "::error title=API docs are empty::the doc tree exists but has no index.html, so /docs would deploy unusable"
-              exit 1
-            fi
-          elif [ "$REBUILT" = "true" ]; then
-            echo "::error title=API docs missing after a rebuild::this run planned to rebuild the docs but produced no doc tree; failing rather than deploying without /docs and advancing the docgen branch"
+          if [ ! -d ../docbuild/.lake/build/doc ]; then
+            echo "::error title=API docs missing::no doc tree to deploy; refusing to publish a site without /docs, which would delete the live documentation"
             exit 1
-          else
-            echo "::warning::no generated API docs found; /docs will be absent from this deploy"
           fi
+          rm -rf _out/docs
+          cp -a ../docbuild/.lake/build/doc _out/docs
+          if [ ! -s _out/docs/index.html ]; then
+            echo "::error title=API docs are empty::the doc tree has no index.html, so /docs would deploy unusable"
+            exit 1
+          fi
+          # The marker rides inside the tree, so it is present whether the docs were just built or
+          # restored from cache. A tree predating this change has none; the branch then simply does
+          # not advance until the next rebuild writes one, which is the safe direction.
+          sha=""
+          if [ -s _out/docs/SOURCE_SHA ]; then
+            sha=$(tr -d "[:space:]" < _out/docs/SOURCE_SHA)
+            case "$sha" in
+              [0-9a-f]*) [ "${#sha}" -eq 40 ] || sha="" ;;
+              *) sha="" ;;
+            esac
+            [ -n "$sha" ] || echo "::warning::/docs carries an unreadable SOURCE_SHA; the docgen branch will not advance"
+          else
+            echo "::warning::/docs carries no SOURCE_SHA (built before provenance was recorded); the docgen branch will not advance"
+          fi
+          echo "docs-source-sha=$sha" >> "$GITHUB_OUTPUT"
+          printf 'deploying /docs generated from %s\n' "${sha:-unknown}"
 
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
@@ -271,17 +302,29 @@ jobs:
   # documentation. Advance it only after this run freshly rebuilt the docs and successfully
   # deployed them. Cached site-only deploys must leave it alone: their docs belong to the
   # earlier commit already named by this ref.
+  # Point `docgen` at the commit whose documentation is now live.
+  #
+  # The candidate is the marker carried inside the deployed doc tree, NOT `github.sha`. Those differ
+  # whenever a deploy reuses cached documentation, which is the normal path for a `web/`-only push --
+  # and taking `github.sha` there would assert that documentation exists for a commit that was never
+  # documented. It also makes the branch self-healing: every successful deploy re-points it at what
+  # is actually published, so a branch that has drifted corrects itself on the next deploy rather
+  # than staying wrong until someone notices.
+  #
+  # It no longer keys on `docs-rebuilt` either. That output records the *intention* to rebuild,
+  # decided before anything is built; the marker records the outcome, which is the question the
+  # branch is actually answering.
   advance-docgen-ref:
     needs: [build-site, deploy]
-    if: needs.build-site.outputs.docs-rebuilt == 'true' && github.ref == 'refs/heads/main'
+    if: needs.build-site.outputs.docs-source-sha != '' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
-      - name: Fast-forward the docgen branch to the documented commit
+      - name: Point the docgen branch at the documented commit
         env:
           GH_TOKEN: ${{ github.token }}
-          CANDIDATE: ${{ github.sha }}
+          CANDIDATE: ${{ needs.build-site.outputs.docs-source-sha }}
           REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
@@ -295,12 +338,22 @@ jobs:
               exit 0
             fi
 
-            # force=false makes an unexpected rewind or divergent update fail closed.
-            gh api --method PATCH "$endpoint" \
-              -f sha="$CANDIDATE" \
-              -F force=false
+            # force=false makes an unexpected rewind or divergent update fail closed. A refusal here
+            # is not an error: it means the live documentation is OLDER than the branch, so the only
+            # safe move is to leave the branch alone and let a later rebuild carry it forward. The
+            # branch must never claim documentation that is not published; being behind is harmless,
+            # being ahead is the failure this exists to prevent.
+            if ! gh api --method PATCH "$endpoint" \
+                   -f sha="$CANDIDATE" \
+                   -F force=false 2> advance.err; then
+              echo "::warning title=docgen not advanced::the live documentation ($CANDIDATE) is not ahead of docgen ($current); leaving the branch where it is"
+              cat advance.err
+              exit 0
+            fi
+            echo "docgen advanced $current -> $CANDIDATE"
           else
             gh api --method POST "repos/$REPO/git/refs" \
               -f ref='refs/heads/docgen' \
               -f sha="$CANDIDATE"
+            echo "docgen created at $CANDIDATE"
           fi

--- a/README.md
+++ b/README.md
@@ -145,13 +145,16 @@ scheduled for regeneration every three hours from `main` with
 [`doc-gen4`](https://github.com/leanprover/doc-gen4), alongside the
 [project website](https://taucetiproject.github.io/TauCeti/).
 
-The moving `docgen` branch points to the newest commit from `main` whose generated API
-documentation was successfully deployed, and any deploy from `main` re-points it at what is
-actually published, so it recovers by itself if it ever drifts.
+The moving `docgen` branch points at the mainline commit whose generated API documentation is
+currently published — not necessarily the newest, since a deployment that serves older
+documentation moves the branch back to match it. Every successful deployment from `main` attempts
+that correction, in either direction, so the branch heals rather than drifting indefinitely.
 
-It is best-effort rather than exact: publishing to Pages and updating a git ref cannot be done
-atomically, so the branch briefly names documentation that has just been replaced, and it stays
-behind if the update fails. Anything that needs certainty should instead read
+It is best-effort rather than exact. Publishing to Pages and updating a git ref cannot be done
+atomically, so between the two the branch names documentation that has already been replaced; and
+if the update fails, or the deployment came from a manually dispatched run on another branch, the
+branch stays wrong — in either direction — until the next deployment from `main`. Anything that
+needs certainty should instead read
 [`/docs/SOURCE_SHA`](https://taucetiproject.github.io/TauCeti/docs/SOURCE_SHA), which is published
 inside the documentation itself and therefore states, at the moment it is read, exactly which commit
 the live documentation describes.

--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ scheduled for regeneration every three hours from `main` with
 [project website](https://taucetiproject.github.io/TauCeti/).
 
 The moving `docgen` branch points to the newest commit from `main` whose generated API
-documentation was successfully deployed, and every deploy re-points it at what is actually
-published, so it recovers by itself if it ever drifts.
+documentation was successfully deployed, and any deploy from `main` re-points it at what is
+actually published, so it recovers by itself if it ever drifts.
 
 It is best-effort rather than exact: publishing to Pages and updating a git ref cannot be done
 atomically, so the branch briefly names documentation that has just been replaced, and it stays

--- a/README.md
+++ b/README.md
@@ -143,10 +143,18 @@ dependencies, is published at
 [taucetiproject.github.io/TauCeti/docs](https://taucetiproject.github.io/TauCeti/docs/). It is
 scheduled for regeneration every three hours from `main` with
 [`doc-gen4`](https://github.com/leanprover/doc-gen4), alongside the
-[project website](https://taucetiproject.github.io/TauCeti/). The moving `docgen` branch
-points to the newest commit from `main` whose freshly generated API documentation was
-successfully deployed. Downstream processes that require source and published documentation
-to agree can follow that branch instead of `main`.
+[project website](https://taucetiproject.github.io/TauCeti/).
+
+The moving `docgen` branch points to the newest commit from `main` whose generated API
+documentation was successfully deployed, and every deploy re-points it at what is actually
+published, so it recovers by itself if it ever drifts.
+
+It is best-effort rather than exact: publishing to Pages and updating a git ref cannot be done
+atomically, so the branch briefly names documentation that has just been replaced, and it stays
+behind if the update fails. Anything that needs certainty should instead read
+[`/docs/SOURCE_SHA`](https://taucetiproject.github.io/TauCeti/docs/SOURCE_SHA), which is published
+inside the documentation itself and therefore states, at the moment it is read, exactly which commit
+the live documentation describes.
 
 ## Building
 


### PR DESCRIPTION
This PR stamps the generated API documentation with the commit it was built from, and makes `advance-docgen-ref` follow that marker instead of `github.sha`, so the `docgen` branch names the commit whose documentation is actually live rather than the commit that happened to run a deploy.

The branch carries one invariant: it names a commit whose documentation is built and published. Two paths could break it even after #1537.

The docs cache is saved in `build-site`, before the deploy succeeds. So a run at commit C can build docs, save them, then fail; a later `web/`-only run restores C's tree through the broad `restore-keys` prefix, deploys it with `build=false`, and correctly declines to advance the ref. The live documentation then describes C while `docgen` still says B, with nobody having touched the branch.

Separately, a Pages deployment replaces the whole site, so a run that deployed without `/docs` deleted the live documentation while the branch went on asserting it was there. That decision was made from `cache-matched-key`, which reports what the cache claimed rather than what was restored.

The marker fixes both, because it travels inside the tree: whatever documentation is deployed states which commit it describes, whether it was just built or restored from a cache written days earlier. Following it also makes the branch self-healing — every successful deploy re-points it at what is published, so drift corrects itself on the next deploy instead of persisting until someone notices. `docs-rebuilt` was the wrong signal for this: it records the intention to rebuild, decided before anything is built, whereas the marker records the outcome.

A missing doc tree is now always fatal, decided from the filesystem. There is no legitimate path with no tree, since a genuine cache miss sets `build=true` and the documentation is built.

Two deliberate non-failures. A tree with no marker, or an unreadable one, leaves the branch alone with a warning — trees cached before this change have none, and not advancing is the safe direction. And a refused `force=false` update is reported as a warning rather than an error: it means the live documentation is older than the branch, where the only safe move is to leave the branch and let a later rebuild carry it forward. The branch being behind is harmless; being ahead is the failure this exists to prevent.

The marker also publishes at `/docs/SOURCE_SHA`, so a consumer can verify what is live without scraping a page.

Exercised against five cases before opening: no tree, tree without `index.html`, tree with a valid marker, tree with no marker, and tree with a malformed marker.

🤖 Prepared with Claude Code