### PR TITLE
fix: recognize completed roadmap areas

### DIFF
--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -133,14 +133,28 @@ def classify(title: str, body: str, files: list[str], areas: set[str]) -> str:
 
 
 def canonical_areas(roadmap_dir: pathlib.Path) -> set[str]:
-    """Roadmap directory names (those containing a README.md) under a checkout.
+    """Active and completed roadmap directory names under a checkout.
 
-    Accepts either the roadmap repo root (areas live under its inner
-    `TauCetiRoadmap/` package dir) or the package dir itself.
+    At the repository root, active areas live under the inner
+    `TauCetiRoadmap/` package and archived areas live under the sibling
+    `Completed/` directory. Accepting the package directory itself remains
+    useful for local one-area tests and older callers.
     """
     inner = roadmap_dir / "TauCetiRoadmap"
-    base = inner if inner.is_dir() else roadmap_dir
-    return {p.name for p in base.iterdir() if p.is_dir() and (p / "README.md").is_file()}
+    if not inner.is_dir():
+        return {
+            p.name for p in roadmap_dir.iterdir()
+            if p.is_dir() and (p / "README.md").is_file()
+        }
+
+    bases = [inner]
+    completed = roadmap_dir / "Completed"
+    if completed.is_dir():
+        bases.append(completed)
+    return {
+        p.name for base in bases for p in base.iterdir()
+        if p.is_dir() and (p / "README.md").is_file()
+    }
 
 
 # --- gh plumbing (only reached in --apply/--nudge/--pr/--backfill IO paths) --

--- a/scripts/test_roadmap_label.py
+++ b/scripts/test_roadmap_label.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import subprocess
 import sys
+import tempfile
 
 import roadmap_label as rl
 
@@ -26,9 +28,10 @@ import roadmap_label as rl
 # checkout, but the unit tests pin it so they need no network.
 AREAS = {
     "CombinatorialHeegaardFloer", "ConformalMapping", "ContourIntegration",
-    "Exchangeability", "GeometricTopology", "HeegaardFloer", "JacobianChallenge",
+    "EffectiveBounds", "Exchangeability", "GeometricTopology", "HeegaardFloer",
+    "JacobianChallenge",
     "Multiquadratic", "OneParameterSemigroups", "OrthogonalL2Bases", "PDE",
-    "ReductiveGroups", "UniversalCovers",
+    "ReductiveGroups", "RepresentationTheory", "UniversalCovers",
 }
 
 TC = ["TauCeti/Analysis/Foo.lean"]        # an allowed (AI-ownable) math diff
@@ -94,6 +97,19 @@ def run_unit() -> int:
     assert rl.parse_cited_areas("nothing here", AREAS) == set()
     assert rl.is_infra(["TauCeti/A.lean"]) is False
     assert rl.is_infra(["scripts/x.sh"]) is True
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        for directory in (
+            root / "TauCetiRoadmap" / "ContourIntegration",
+            root / "Completed" / "EffectiveBounds",
+        ):
+            directory.mkdir(parents=True)
+            (directory / "README.md").touch()
+        # The archive container has a README of its own, but is not an area.
+        (root / "Completed" / "README.md").touch()
+        assert rl.canonical_areas(root) == {"ContourIntegration", "EffectiveBounds"}
+
     print(f"\n{len(CASES) - fails}/{len(CASES)} classifier cases passed")
     return 1 if fails else 0
 


### PR DESCRIPTION
This PR keeps completed roadmap areas canonical for PR attribution after they move from `TauCetiRoadmap/` to `Completed/`. It recognizes both locations without minting a `roadmap/Completed` area.

Tested with `python3 scripts/test_roadmap_label.py` and against the current TauCetiRoadmap checkout.

Roadmap: none

:robot: Prepared with OpenAI Codex
