### PR TITLE
docs: require explicit roadmap attribution

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+<!--
+Every PR must replace the line below with exactly one canonical roadmap directory name,
+or with `none` for genuinely general, cross-cutting, infrastructure, or dependency work.
+For new mathematics, also cite the exact roadmap file and target in the prose below.
+Refactors need no fresh roadmap claim, but should name the roadmap chiefly motivating them.
+Do not infer a roadmap from the TauCeti/ directory being changed.
+-->
+Roadmap: <CanonicalAreaName or none>

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,25 @@ expanding the project's mathematical scope), relocating a misplaced declaration,
 cleaner idiom, and documenting existing code are all welcome at any time. The roadmap conditions
 what new mathematics gets *added*, not whether already-merged code may be made better.
 
+Every pull request description must also contain one standalone attribution line:
+
+```text
+Roadmap: CanonicalAreaName
+```
+
+or:
+
+```text
+Roadmap: none
+```
+
+Use the canonical roadmap directory name. This is attribution, not authorization: new
+mathematics must still cite the exact roadmap file and target it advances, while a refactor
+needs no fresh roadmap claim but should name the one roadmap chiefly motivating it. Use
+`Roadmap: none` for genuinely general, cross-cutting, infrastructure, or dependency work.
+Do not infer the association from a `TauCeti/` directory name; code organization and roadmap
+scope do not coincide.
+
 ## The rules of the repo
 
 - `main` is always green. CI builds against pinned Mathlib and enforces: no `sorry`, no


### PR DESCRIPTION
This PR establishes an explicit roadmap-attribution line for every pull request while preserving the rule that refactors need no new roadmap authorization. It also adds a GitHub template that warns authors not to infer roadmap scope from code directories.

Roadmap: none

:robot: Prepared with OpenAI Codex
