### PR TITLE
feat: require explicit roadmap attribution

### DIFF
--- a/.github/workflows/roadmap-label.yml
+++ b/.github/workflows/roadmap-label.yml
@@ -1,14 +1,13 @@
 name: Roadmap label
 
-# Label every PR with the roadmap it advances, derived from the roadmap citation the
-# scope rubric already asks authors to write. No new field is required of submitters:
-# the classifier (scripts/roadmap_label.py) reads the citation back out of the body.
+# Label every PR with its declared primary roadmap association. New PRs carry a
+# standalone `Roadmap: <Area-or-none>` line; target markers and canonical roadmap
+# citations remain compatibility fallbacks for older descriptions.
 #
-#   roadmap/<Area>   the body cites exactly one canonical roadmap
+#   roadmap/<Area>   exactly one canonical association
 #   roadmap/none     the diff reaches outside the AI-ownable path set (infra, merged by
-#                    human override), or the title is a refactor/fix/chore/bump
-#   roadmap/Unknown  new mathematics with no parseable citation -> a one-time nudge asks
-#                    the author to cite the roadmap file
+#                    human override), is a pin-only bump, or explicitly declares none
+#   roadmap/Unknown  missing, invalid, or conflicting association
 #
 # The area label is created on first use, so a roadmap added in TauCetiRoadmap becomes
 # labelable with no change here.
@@ -16,8 +15,8 @@ name: Roadmap label
 # Runs on pull_request_target so it can label PRs from forks, but it NEVER checks out or
 # executes PR head code: it reads only PR metadata (title/body/files) through the API and
 # runs the trusted base-branch script. The body is untrusted, so it is only ever
-# regex-matched against the fixed set of canonical roadmap names and never interpolated
-# into a shell; the label applied always comes from a closed set.
+# parsed against the fixed set of canonical roadmap names and never interpolated into
+# a shell; the label applied always comes from a closed set.
 
 on:
   pull_request_target:
@@ -66,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/roadmap_label.py \
-            --repo "$REPO" --roadmap-dir roadmap --pr "$PR" --apply --nudge
+            --repo "$REPO" --roadmap-dir roadmap --pr "$PR" --apply
 
       # Advisory-only structure nudge (scripts/structure_nudge.py): one updatable
       # marker comment when a PR adds .lean files that sit beside an existing topic

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Assign each PR the roadmap it advances, as a `roadmap/<Area>` label.
+"""Assign each PR's declared roadmap association as a `roadmap/<Area>` label.
 
-The label is derived, not asked for: a submitter already has to name the roadmap
-their new mathematics advances (the scope rubric in TauCetiReview requires it),
-so we read that citation back out of the PR body rather than burden them with a
-second, structured field.
+Every PR should carry one standalone ``Roadmap: <Area>`` or ``Roadmap: none``
+line. This is attribution, not scope authorization: new mathematics must still
+cite the exact roadmap target that it advances, while a refactor may associate
+itself with the roadmap that chiefly motivates the cleanup.
 
 ## The classifier (see `classify`)
 
@@ -14,20 +14,16 @@ A PR gets exactly one label, decided in this order:
    `TauCeti/`, the root `TauCeti.lean`, and the two ordinary Lake pins). This also
    covers the review bot's narrowly validated first-known-bad lakefile exception:
    either way it is infrastructure, not roadmap work.
-2. `roadmap/<Area>` -- the body cites exactly one canonical roadmap, e.g.
-   `TauCetiRoadmap/OneParameterSemigroups/README.md` or `ContourIntegration/README.md`.
-   `<Area>` is the roadmap directory name, the same source of truth
-   `check_roadmap_areas.py` uses in the roadmap repo.
-3. `roadmap/none` -- no single citation, but the title is a refactor/fix/chore/...
-   (or a Mathlib bump). Reworking already-merged material needs no roadmap claim,
-   so absence of a citation is correct here, not a defect.
-4. `roadmap/Unknown` -- a new-mathematics PR (a `feat:` touching only `TauCeti/`)
-   that cites no parseable roadmap file. The live workflow leaves a one-time nudge
-   asking the author to cite the roadmap file, exactly as the scope rubric wants.
+2. `roadmap/none` -- the diff is a pin-only dependency bump.
+3. The one valid explicit ``Roadmap:`` declaration.
+4. One validated canonical ``focus`` in a ``tauceti-target:v1`` marker.
+5. One canonical roadmap-file citation, for compatibility with older PR bodies.
+6. `roadmap/Unknown` -- attribution is absent, invalid, or conflicting.
 
-The area set is read at runtime from a checkout of the roadmap repo, so a roadmap
-added there becomes labelable with no change here; the label itself is created on
-first use (`ensure_label`).
+Evidence from steps 3--5 must agree. Area names are read at runtime from active
+and completed roadmaps, and labels are created on first use (`ensure_label`).
+File paths and conventional-commit titles are deliberately not used as roadmap
+evidence.
 
 ## Usage
 
@@ -36,8 +32,11 @@ first use (`ensure_label`).
     # ... and apply it (create the label if missing, drop any stale roadmap/* label),
     # leaving a nudge if it lands in roadmap/Unknown:
     roadmap_label.py --pr 781 --repo ... --roadmap-dir roadmap --apply --nudge
-    # backfill every PR (never nudges):
-    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap --apply
+    # inspect every PR (never nudges):
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap
+    # changing an existing roadmap label is deliberately opt-in:
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap \
+        --apply --allow-relabel
 
 `--apply`/`--nudge` shell out to `gh`, which must be authenticated (GH_TOKEN).
 `classify` and the parsing helpers are pure and are what the tests exercise.
@@ -77,12 +76,8 @@ UNKNOWN_COLOR = "fbca04"   # yellow: needs a citation
 # remains an infrastructure PR and therefore still belongs under roadmap/none here.
 _ALLOWED_PATH = re.compile(r"^(?:TauCeti/|TauCeti\.lean$|lake-manifest\.json$|lean-toolchain$)")
 
-# Titles that, by convention, rework existing material rather than add new
-# mathematics; per the scope rubric these need no roadmap claim.
-_NONROADMAP_TITLE = re.compile(
-    r"^(?:refactor|fix|chore|style|test|perf|docs?|ci|build|revert|harden)(?:[(!:/]| )",
-    re.IGNORECASE,
-)
+_PINS = {"lake-manifest.json", "lean-toolchain"}
+_TARGET_MARKER = re.compile(r"<!--tauceti-target:v1 (\{[^}]*\})-->")
 
 
 def is_infra(files: list[str]) -> bool:
@@ -94,6 +89,68 @@ def is_infra(files: list[str]) -> bool:
     if not files:
         return True
     return any(not _ALLOWED_PATH.match(f) for f in files)
+
+
+def is_pin_only(files: list[str]) -> bool:
+    """True exactly when a nonempty diff changes only the two validated pins."""
+    return bool(files) and set(files) <= _PINS
+
+
+def _body_lines_outside_quotes_and_fences(body: str):
+    """Yield body lines that are not inside Markdown fences or blockquotes."""
+    fence = None
+    for line in (body or "").splitlines():
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            continue
+        if fence is None and not stripped.startswith(">"):
+            yield line
+
+
+def parse_declared_area(body: str, areas: set[str]) -> tuple[bool, str | None]:
+    """Return ``(present, value)`` for standalone ``Roadmap:`` lines.
+
+    ``value`` is an area name or ``none`` when every declaration is valid and
+    identical. It is ``None`` for invalid or conflicting declarations. Examples
+    in fenced code and blockquotes are ignored.
+    """
+    present = False
+    values = set()
+    invalid = False
+    for line in _body_lines_outside_quotes_and_fences(body):
+        if not re.match(r"^Roadmap\s*:", line):
+            continue
+        present = True
+        match = re.fullmatch(r"Roadmap:\s*(\S+)\s*", line)
+        if match is None:
+            invalid = True
+            continue
+        value = match.group(1)
+        if value != "none" and value not in areas:
+            invalid = True
+        else:
+            values.add(value)
+    if invalid or len(values) != 1:
+        return present, None
+    return present, next(iter(values))
+
+
+def parse_target_areas(body: str, areas: set[str]) -> set[str]:
+    """Canonical roadmap focuses from valid ``tauceti-target:v1`` markers."""
+    found = set()
+    for match in _TARGET_MARKER.finditer(body or ""):
+        try:
+            focus = json.loads(match.group(1)).get("focus")
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if focus in areas:
+            found.add(focus)
+    return found
 
 
 def parse_cited_areas(body: str, areas: set[str]) -> set[str]:
@@ -120,13 +177,23 @@ def classify(title: str, body: str, files: list[str], areas: set[str]) -> str:
     """Return the single roadmap label for a PR. Pure; see module docstring."""
     if is_infra(files):
         return NONE_LABEL
-    cited = parse_cited_areas(body, areas)
-    if len(cited) == 1:
-        return area_label(next(iter(cited)))
-    # Zero citations, or several (no single roadmap to name): fall through.
-    if _NONROADMAP_TITLE.match(title or ""):
+    if is_pin_only(files):
         return NONE_LABEL
-    return UNKNOWN_LABEL
+
+    declared_present, declared = parse_declared_area(body, areas)
+    if declared_present and declared is None:
+        return UNKNOWN_LABEL
+
+    targets = parse_target_areas(body, areas)
+    cited = parse_cited_areas(body, areas)
+    indirect = targets | cited
+
+    if declared is not None:
+        if declared == "none":
+            return NONE_LABEL if not indirect else UNKNOWN_LABEL
+        return area_label(declared) if indirect <= {declared} else UNKNOWN_LABEL
+
+    return area_label(next(iter(indirect))) if len(indirect) == 1 else UNKNOWN_LABEL
 
 
 # --- roadmap area discovery ------------------------------------------------
@@ -190,23 +257,25 @@ def ensure_label(repo: str, name: str, color: str, desc: str) -> None:
 
 def _label_meta(name: str, areas: set[str]) -> tuple[str, str]:
     if name == NONE_LABEL:
-        return NONE_COLOR, "PR advances no roadmap (infra, refactor, or a Mathlib bump)"
+        return NONE_COLOR, "No roadmap association (declared, infrastructure, or pin-only bump)"
     if name == UNKNOWN_LABEL:
-        return UNKNOWN_COLOR, "New mathematics PR with no parseable roadmap citation"
-    return AREA_COLOR, "PR advances the {} roadmap".format(name[len("roadmap/"):])
+        return UNKNOWN_COLOR, "Missing, invalid, or conflicting roadmap association"
+    return AREA_COLOR, "PR declares the {} roadmap as its primary association".format(
+        name[len("roadmap/"):])
 
 
 NUDGE_MARKER = "<!--roadmap-label:nudge-->"
 NUDGE_BODY = (
     NUDGE_MARKER + "\n"
-    "This PR adds new mathematics but I could not find the roadmap it advances "
-    "in its description, so I have labelled it `roadmap/Unknown`.\n\n"
-    "Per the [scope rubric](https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md), "
-    "new material should identify the roadmap file and node it advances. Please add "
-    "a reference to the roadmap file, for example "
-    "`TauCetiRoadmap/OneParameterSemigroups/README.md`, and the label will update "
-    "automatically. If this PR only reworks already-merged material, no roadmap is "
-    "needed and you can ignore this."
+    "I could not determine this PR's roadmap association, so I labelled it "
+    "`roadmap/Unknown`. Please add one standalone line to the description:\n\n"
+    "```text\nRoadmap: CanonicalAreaName\n```\n\n"
+    "Use `Roadmap: none` for genuinely general, cross-cutting, infrastructure, "
+    "or dependency work. Refactors need no fresh roadmap authorization, but should "
+    "name the one roadmap chiefly motivating them. For new mathematics, this "
+    "attribution line does not replace the [scope rubric's]"
+    "(https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md) "
+    "requirement to cite the exact roadmap file and target."
 )
 
 
@@ -256,6 +325,12 @@ def _run_one(args, areas) -> int:
     title, body, files = _pr_fields(args.repo, args.pr)
     label = classify(title, body, files, areas)
     print(f"#{args.pr}\t{label}\t{title}")
+    declared_present, declared = parse_declared_area(body, areas)
+    if (is_infra(files) or is_pin_only(files)) and declared_present and declared not in {None, "none"}:
+        reason = "infrastructure/empty diff" if is_infra(files) else "pin-only bump"
+        print(
+            f"::notice::Roadmap: {declared} is overridden by the {reason} classification"
+        )
     if args.apply:
         apply_label(args.repo, args.pr, label, areas)
         if args.nudge and label == UNKNOWN_LABEL:
@@ -266,7 +341,8 @@ def _run_one(args, areas) -> int:
 def _run_backfill(args, areas) -> int:
     prs = json.loads(_gh([
         "pr", "list", "--repo", args.repo, "--state", "all",
-        "--limit", str(args.limit), "--json", "number,title,body,files,state",
+        "--limit", str(args.limit),
+        "--json", "number,title,body,files,state,labels",
     ]))
     from collections import Counter
     tally: Counter[str] = Counter()
@@ -275,21 +351,32 @@ def _run_backfill(args, areas) -> int:
         files = [f["path"] for f in p.get("files") or []]
         label = classify(p.get("title") or "", p.get("body") or "", files, areas)
         tally[label] += 1
-        plan.append((p["number"], label))
+        current = {
+            item["name"] for item in p.get("labels") or []
+            if item["name"].startswith("roadmap/")
+        }
+        plan.append((p["number"], label, current))
         print(f"#{p['number']}\t{p['state']}\t{label}\t{p.get('title','')}")
 
     failed: list[int] = []
     if args.apply:
         # A per-PR failure must not abandon the rest of the backfill; collect and
         # retry once at the end (transient API errors are already retried in _gh).
-        for num, label in plan:
+        for num, label, current in plan:
+            if current and current != {label} and not args.allow_relabel:
+                print(
+                    f"  - #{num}: preserving {', '.join(sorted(current))}; "
+                    "pass --allow-relabel to change it",
+                    file=sys.stderr,
+                )
+                continue
             try:
                 apply_label(args.repo, num, label, areas)  # never nudges
             except Exception as e:  # noqa: BLE001 -- keep going, report at the end
                 print(f"  ! #{num}: {e}", file=sys.stderr)
                 failed.append(num)
         for num in list(failed):
-            label = dict(plan)[num]
+            label = next(label for plan_num, label, _ in plan if plan_num == num)
             try:
                 apply_label(args.repo, num, label, areas)
                 failed.remove(num)
@@ -314,6 +401,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--backfill", action="store_true", help="classify every PR")
     ap.add_argument("--limit", type=int, default=5000, help="max PRs for --backfill")
     ap.add_argument("--apply", action="store_true", help="write the label to the PR(s)")
+    ap.add_argument(
+        "--allow-relabel", action="store_true",
+        help="with --backfill --apply, permit changing an existing roadmap/* label",
+    )
     ap.add_argument("--nudge", action="store_true",
                     help="with --pr --apply: comment once when the label is roadmap/Unknown")
     a = ap.parse_args(argv)

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -363,6 +363,8 @@ def _run_backfill(args, areas) -> int:
         # A per-PR failure must not abandon the rest of the backfill; collect and
         # retry once at the end (transient API errors are already retried in _gh).
         for num, label, current in plan:
+            if current == {label}:
+                continue
             if current and current != {label} and not args.allow_relabel:
                 print(
                     f"  - #{num}: preserving {', '.join(sorted(current))}; "

--- a/scripts/test_roadmap_label.py
+++ b/scripts/test_roadmap_label.py
@@ -39,7 +39,31 @@ INFRA = ["TauCeti/Foo.lean", ".github/workflows/x.yml"]  # trips the scope guard
 
 # (name, title, body, files, expected_label)
 CASES = [
-    # 1. citation resolves the area (real bodies, abbreviated) -----------------
+    # 1. explicit declaration is the preferred source --------------------------
+    ("explicit area", "refactor: share a proof",
+     "Roadmap: ContourIntegration", TC, "roadmap/ContourIntegration"),
+    ("explicit none", "refactor: share a general proof",
+     "Roadmap: none", TC, "roadmap/none"),
+    ("duplicate identical declaration", "refactor: share a proof",
+     "Roadmap: PDE\n\nRoadmap: PDE", TC, "roadmap/PDE"),
+    ("invalid explicit area", "refactor: share a proof",
+     "Roadmap: NotARoadmap", TC, "roadmap/Unknown"),
+    ("conflicting declarations", "refactor: share a proof",
+     "Roadmap: PDE\nRoadmap: ContourIntegration", TC, "roadmap/Unknown"),
+    ("fenced example ignored", "refactor: share a proof",
+     "```\nRoadmap: PDE\n```\nRoadmap: ContourIntegration", TC,
+     "roadmap/ContourIntegration"),
+    ("quoted example ignored", "refactor: share a proof",
+     "> Roadmap: PDE\nRoadmap: ContourIntegration", TC,
+     "roadmap/ContourIntegration"),
+
+    # 2. target markers and citations are compatibility sources ---------------
+    ("target marker", "refactor: share a proof",
+     '<!--tauceti-target:v1 {"focus":"PDE","id":"helper"}-->', TC,
+     "roadmap/PDE"),
+    ("invalid target marker ignored", "refactor: share a proof",
+     '<!--tauceti-target:v1 {"focus":"pde-helper","id":"helper"}-->', TC,
+     "roadmap/Unknown"),
     ("full path", "feat: add semigroup exponential shifts",
      "It advances TauCetiRoadmap/OneParameterSemigroups/README.md, Part A.", TC,
      "roadmap/OneParameterSemigroups"),
@@ -49,22 +73,36 @@ CASES = [
     ("suggested.lean path", "feat: add quotient comodules",
      "See TauCetiRoadmap/ReductiveGroups/Suggested.lean for the target.", TC,
      "roadmap/ReductiveGroups"),
+    ("matching declaration marker and citation", "feat: add theorem",
+     'Roadmap: PDE\nTauCetiRoadmap/PDE/README.md\n'
+     '<!--tauceti-target:v1 {"focus":"PDE","id":"target"}-->',
+     TC, "roadmap/PDE"),
+    ("declaration conflicts with citation", "feat: add theorem",
+     "Roadmap: PDE\nTauCetiRoadmap/ContourIntegration/README.md",
+     TC, "roadmap/Unknown"),
+    ("none conflicts with marker", "refactor: general cleanup",
+     'Roadmap: none\n<!--tauceti-target:v1 {"focus":"PDE","id":"target"}-->',
+     TC, "roadmap/Unknown"),
 
-    # 2. infra override wins even over a citation ------------------------------
+    # 3. infra and pin-only overrides ------------------------------------------
     ("infra beats citation", "feat: add roadmap CI",
      "advances TauCetiRoadmap/ContourIntegration/README.md", INFRA, "roadmap/none"),
     ("infra feat (website)", "feat: add site favicon", "", [".github/x", "web/y"],
      "roadmap/none"),
     ("empty diff", "feat: something", "advances TauCetiRoadmap/PDE/README.md", [],
      "roadmap/none"),
+    ("pin-only bump", "chore: forward bump", "",
+     ["lake-manifest.json", "lean-toolchain"], "roadmap/none"),
 
-    # 3. non-roadmap titles, no citation --------------------------------------
-    ("refactor", "refactor: move split into Cylinder.lean", "", TC, "roadmap/none"),
-    ("fix", "fix: drop the vacuous coe lemma", "", TC, "roadmap/none"),
+    # 4. a title never supplies roadmap evidence -------------------------------
+    ("refactor missing attribution", "refactor: move split into Cylinder.lean", "",
+     TC, "roadmap/Unknown"),
+    ("fix missing attribution", "fix: drop the vacuous coe lemma", "",
+     TC, "roadmap/Unknown"),
     ("mathlib bump", "chore: bump mathlib to 40b45a0, fix breaking changes", "",
-     ["TauCeti/A.lean", "lake-manifest.json", "lean-toolchain"], "roadmap/none"),
+     ["TauCeti/A.lean", "lake-manifest.json", "lean-toolchain"], "roadmap/Unknown"),
 
-    # 4. new mathematics, no parseable citation -> Unknown --------------------
+    # 5. missing or ambiguous evidence -> Unknown ------------------------------
     ("feat cites decl not file", "feat(Analysis/Contour): continuous argument lift",
      "Prerequisite for homologyCauchyTheorem (Dixon) and the residue theorem.", TC,
      "roadmap/Unknown"),
@@ -78,9 +116,6 @@ CASES = [
     ("multi-area citation", "feat: add thing",
      "spans TauCetiRoadmap/PDE/README.md and TauCetiRoadmap/Multiquadratic/README.md",
      TC, "roadmap/Unknown"),
-    # a refactor bump touching only the pins is allowed-set + non-roadmap title
-    ("pin-only bump", "chore: forward bump", "",
-     ["lake-manifest.json", "lean-toolchain"], "roadmap/none"),
 ]
 
 
@@ -95,8 +130,16 @@ def run_unit() -> int:
     # parse helper spot checks
     assert rl.parse_cited_areas("TauCetiRoadmap/PDE/README.md", AREAS) == {"PDE"}
     assert rl.parse_cited_areas("nothing here", AREAS) == set()
+    assert rl.parse_target_areas(
+        '<!--tauceti-target:v1 {"focus":"PDE","id":"x"}-->', AREAS
+    ) == {"PDE"}
+    assert rl.parse_declared_area("Roadmap: EffectiveBounds", AREAS) == (
+        True, "EffectiveBounds")
+    assert rl.parse_declared_area("nothing here", AREAS) == (False, None)
     assert rl.is_infra(["TauCeti/A.lean"]) is False
     assert rl.is_infra(["scripts/x.sh"]) is True
+    assert rl.is_pin_only(["lake-manifest.json", "lean-toolchain"]) is True
+    assert rl.is_pin_only(["TauCeti/A.lean", "lake-manifest.json"]) is False
 
     with tempfile.TemporaryDirectory() as tmp:
         root = pathlib.Path(tmp)


### PR DESCRIPTION
This PR makes roadmap attribution explicit and deterministic: a standalone `Roadmap:` line is preferred, validated target markers and file citations remain compatibility fallbacks, and missing or conflicting attribution becomes `roadmap/Unknown`. It removes the title-based assumption that every refactor means `none`, keeps nudges disabled during prompt rollout, and makes historical relabelling explicitly opt-in.

Depends on #1540. Deploy after the author prompts in #1542 and [TauCetiWorker #145](https://github.com/kim-em/TauCetiWorker/pull/145).

Tested with 26 focused classifier cases and a read-only replay of all 1,492 PRs against the current active and completed roadmap set.

Roadmap: none

:robot: Prepared with OpenAI Codex