### PR TITLE
feat: add reversible roadmap backfill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           PYTHONPATH=scripts python3 scripts/test_participant_graph.py
           python3 scripts/pr_status/test_stuck_alerts.py
           python3 scripts/test_roadmap_label.py
+          PYTHONPATH=scripts python3 scripts/test_roadmap_refactor_backfill.py
           python3 scripts/pr_status/test_pr_labels.py
           python3 scripts/pr_status/test_zulip.py
           python3 scripts/test_structure_nudge.py

--- a/.github/workflows/roadmap-label.yml
+++ b/.github/workflows/roadmap-label.yml
@@ -1,14 +1,13 @@
 name: Roadmap label
 
-# Label every PR with the roadmap it advances, derived from the roadmap citation the
-# scope rubric already asks authors to write. No new field is required of submitters:
-# the classifier (scripts/roadmap_label.py) reads the citation back out of the body.
+# Label every PR with its declared primary roadmap association. New PRs carry a
+# standalone `Roadmap: <Area-or-none>` line; target markers and canonical roadmap
+# citations remain compatibility fallbacks for older descriptions.
 #
-#   roadmap/<Area>   the body cites exactly one canonical roadmap
+#   roadmap/<Area>   exactly one canonical association
 #   roadmap/none     the diff reaches outside the AI-ownable path set (infra, merged by
-#                    human override), or the title is a refactor/fix/chore/bump
-#   roadmap/Unknown  new mathematics with no parseable citation -> a one-time nudge asks
-#                    the author to cite the roadmap file
+#                    human override), is a pin-only bump, or explicitly declares none
+#   roadmap/Unknown  missing, invalid, or conflicting association
 #
 # The area label is created on first use, so a roadmap added in TauCetiRoadmap becomes
 # labelable with no change here.
@@ -16,8 +15,8 @@ name: Roadmap label
 # Runs on pull_request_target so it can label PRs from forks, but it NEVER checks out or
 # executes PR head code: it reads only PR metadata (title/body/files) through the API and
 # runs the trusted base-branch script. The body is untrusted, so it is only ever
-# regex-matched against the fixed set of canonical roadmap names and never interpolated
-# into a shell; the label applied always comes from a closed set.
+# parsed against the fixed set of canonical roadmap names and never interpolated into
+# a shell; the label applied always comes from a closed set.
 
 on:
   pull_request_target:
@@ -66,7 +65,7 @@ jobs:
         run: |
           set -euo pipefail
           python3 scripts/roadmap_label.py \
-            --repo "$REPO" --roadmap-dir roadmap --pr "$PR" --apply --nudge
+            --repo "$REPO" --roadmap-dir roadmap --pr "$PR" --apply
 
       # Advisory-only structure nudge (scripts/structure_nudge.py): one updatable
       # marker comment when a PR adds .lean files that sit beside an existing topic

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Assign each PR the roadmap it advances, as a `roadmap/<Area>` label.
+"""Assign each PR's declared roadmap association as a `roadmap/<Area>` label.
 
-The label is derived, not asked for: a submitter already has to name the roadmap
-their new mathematics advances (the scope rubric in TauCetiReview requires it),
-so we read that citation back out of the PR body rather than burden them with a
-second, structured field.
+Every PR should carry one standalone ``Roadmap: <Area>`` or ``Roadmap: none``
+line. This is attribution, not scope authorization: new mathematics must still
+cite the exact roadmap target that it advances, while a refactor may associate
+itself with the roadmap that chiefly motivates the cleanup.
 
 ## The classifier (see `classify`)
 
@@ -14,20 +14,16 @@ A PR gets exactly one label, decided in this order:
    `TauCeti/`, the root `TauCeti.lean`, and the two ordinary Lake pins). This also
    covers the review bot's narrowly validated first-known-bad lakefile exception:
    either way it is infrastructure, not roadmap work.
-2. `roadmap/<Area>` -- the body cites exactly one canonical roadmap, e.g.
-   `TauCetiRoadmap/OneParameterSemigroups/README.md` or `ContourIntegration/README.md`.
-   `<Area>` is the roadmap directory name, the same source of truth
-   `check_roadmap_areas.py` uses in the roadmap repo.
-3. `roadmap/none` -- no single citation, but the title is a refactor/fix/chore/...
-   (or a Mathlib bump). Reworking already-merged material needs no roadmap claim,
-   so absence of a citation is correct here, not a defect.
-4. `roadmap/Unknown` -- a new-mathematics PR (a `feat:` touching only `TauCeti/`)
-   that cites no parseable roadmap file. The live workflow leaves a one-time nudge
-   asking the author to cite the roadmap file, exactly as the scope rubric wants.
+2. `roadmap/none` -- the diff is a pin-only dependency bump.
+3. The one valid explicit ``Roadmap:`` declaration.
+4. One validated canonical ``focus`` in a ``tauceti-target:v1`` marker.
+5. One canonical roadmap-file citation, for compatibility with older PR bodies.
+6. `roadmap/Unknown` -- attribution is absent, invalid, or conflicting.
 
-The area set is read at runtime from a checkout of the roadmap repo, so a roadmap
-added there becomes labelable with no change here; the label itself is created on
-first use (`ensure_label`).
+Evidence from steps 3--5 must agree. Area names are read at runtime from active
+and completed roadmaps, and labels are created on first use (`ensure_label`).
+File paths and conventional-commit titles are deliberately not used as roadmap
+evidence.
 
 ## Usage
 
@@ -36,8 +32,11 @@ first use (`ensure_label`).
     # ... and apply it (create the label if missing, drop any stale roadmap/* label),
     # leaving a nudge if it lands in roadmap/Unknown:
     roadmap_label.py --pr 781 --repo ... --roadmap-dir roadmap --apply --nudge
-    # backfill every PR (never nudges):
-    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap --apply
+    # inspect every PR (never nudges):
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap
+    # changing an existing roadmap label is deliberately opt-in:
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap \
+        --apply --allow-relabel
 
 `--apply`/`--nudge` shell out to `gh`, which must be authenticated (GH_TOKEN).
 `classify` and the parsing helpers are pure and are what the tests exercise.
@@ -77,12 +76,8 @@ UNKNOWN_COLOR = "fbca04"   # yellow: needs a citation
 # remains an infrastructure PR and therefore still belongs under roadmap/none here.
 _ALLOWED_PATH = re.compile(r"^(?:TauCeti/|TauCeti\.lean$|lake-manifest\.json$|lean-toolchain$)")
 
-# Titles that, by convention, rework existing material rather than add new
-# mathematics; per the scope rubric these need no roadmap claim.
-_NONROADMAP_TITLE = re.compile(
-    r"^(?:refactor|fix|chore|style|test|perf|docs?|ci|build|revert|harden)(?:[(!:/]| )",
-    re.IGNORECASE,
-)
+_PINS = {"lake-manifest.json", "lean-toolchain"}
+_TARGET_MARKER = re.compile(r"<!--tauceti-target:v1 (\{[^}]*\})-->")
 
 
 def is_infra(files: list[str]) -> bool:
@@ -94,6 +89,68 @@ def is_infra(files: list[str]) -> bool:
     if not files:
         return True
     return any(not _ALLOWED_PATH.match(f) for f in files)
+
+
+def is_pin_only(files: list[str]) -> bool:
+    """True exactly when a nonempty diff changes only the two validated pins."""
+    return bool(files) and set(files) <= _PINS
+
+
+def _body_lines_outside_quotes_and_fences(body: str):
+    """Yield body lines that are not inside Markdown fences or blockquotes."""
+    fence = None
+    for line in (body or "").splitlines():
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            continue
+        if fence is None and not stripped.startswith(">"):
+            yield line
+
+
+def parse_declared_area(body: str, areas: set[str]) -> tuple[bool, str | None]:
+    """Return ``(present, value)`` for standalone ``Roadmap:`` lines.
+
+    ``value`` is an area name or ``none`` when every declaration is valid and
+    identical. It is ``None`` for invalid or conflicting declarations. Examples
+    in fenced code and blockquotes are ignored.
+    """
+    present = False
+    values = set()
+    invalid = False
+    for line in _body_lines_outside_quotes_and_fences(body):
+        if not re.match(r"^Roadmap\s*:", line):
+            continue
+        present = True
+        match = re.fullmatch(r"Roadmap:\s*(\S+)\s*", line)
+        if match is None:
+            invalid = True
+            continue
+        value = match.group(1)
+        if value != "none" and value not in areas:
+            invalid = True
+        else:
+            values.add(value)
+    if invalid or len(values) != 1:
+        return present, None
+    return present, next(iter(values))
+
+
+def parse_target_areas(body: str, areas: set[str]) -> set[str]:
+    """Canonical roadmap focuses from valid ``tauceti-target:v1`` markers."""
+    found = set()
+    for match in _TARGET_MARKER.finditer(body or ""):
+        try:
+            focus = json.loads(match.group(1)).get("focus")
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if focus in areas:
+            found.add(focus)
+    return found
 
 
 def parse_cited_areas(body: str, areas: set[str]) -> set[str]:
@@ -120,13 +177,23 @@ def classify(title: str, body: str, files: list[str], areas: set[str]) -> str:
     """Return the single roadmap label for a PR. Pure; see module docstring."""
     if is_infra(files):
         return NONE_LABEL
-    cited = parse_cited_areas(body, areas)
-    if len(cited) == 1:
-        return area_label(next(iter(cited)))
-    # Zero citations, or several (no single roadmap to name): fall through.
-    if _NONROADMAP_TITLE.match(title or ""):
+    if is_pin_only(files):
         return NONE_LABEL
-    return UNKNOWN_LABEL
+
+    declared_present, declared = parse_declared_area(body, areas)
+    if declared_present and declared is None:
+        return UNKNOWN_LABEL
+
+    targets = parse_target_areas(body, areas)
+    cited = parse_cited_areas(body, areas)
+    indirect = targets | cited
+
+    if declared is not None:
+        if declared == "none":
+            return NONE_LABEL if not indirect else UNKNOWN_LABEL
+        return area_label(declared) if indirect <= {declared} else UNKNOWN_LABEL
+
+    return area_label(next(iter(indirect))) if len(indirect) == 1 else UNKNOWN_LABEL
 
 
 # --- roadmap area discovery ------------------------------------------------
@@ -190,23 +257,25 @@ def ensure_label(repo: str, name: str, color: str, desc: str) -> None:
 
 def _label_meta(name: str, areas: set[str]) -> tuple[str, str]:
     if name == NONE_LABEL:
-        return NONE_COLOR, "PR advances no roadmap (infra, refactor, or a Mathlib bump)"
+        return NONE_COLOR, "No roadmap association (declared, infrastructure, or pin-only bump)"
     if name == UNKNOWN_LABEL:
-        return UNKNOWN_COLOR, "New mathematics PR with no parseable roadmap citation"
-    return AREA_COLOR, "PR advances the {} roadmap".format(name[len("roadmap/"):])
+        return UNKNOWN_COLOR, "Missing, invalid, or conflicting roadmap association"
+    return AREA_COLOR, "PR declares the {} roadmap as its primary association".format(
+        name[len("roadmap/"):])
 
 
 NUDGE_MARKER = "<!--roadmap-label:nudge-->"
 NUDGE_BODY = (
     NUDGE_MARKER + "\n"
-    "This PR adds new mathematics but I could not find the roadmap it advances "
-    "in its description, so I have labelled it `roadmap/Unknown`.\n\n"
-    "Per the [scope rubric](https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md), "
-    "new material should identify the roadmap file and node it advances. Please add "
-    "a reference to the roadmap file, for example "
-    "`TauCetiRoadmap/OneParameterSemigroups/README.md`, and the label will update "
-    "automatically. If this PR only reworks already-merged material, no roadmap is "
-    "needed and you can ignore this."
+    "I could not determine this PR's roadmap association, so I labelled it "
+    "`roadmap/Unknown`. Please add one standalone line to the description:\n\n"
+    "```text\nRoadmap: CanonicalAreaName\n```\n\n"
+    "Use `Roadmap: none` for genuinely general, cross-cutting, infrastructure, "
+    "or dependency work. Refactors need no fresh roadmap authorization, but should "
+    "name the one roadmap chiefly motivating them. For new mathematics, this "
+    "attribution line does not replace the [scope rubric's]"
+    "(https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md) "
+    "requirement to cite the exact roadmap file and target."
 )
 
 
@@ -256,6 +325,12 @@ def _run_one(args, areas) -> int:
     title, body, files = _pr_fields(args.repo, args.pr)
     label = classify(title, body, files, areas)
     print(f"#{args.pr}\t{label}\t{title}")
+    declared_present, declared = parse_declared_area(body, areas)
+    if (is_infra(files) or is_pin_only(files)) and declared_present and declared not in {None, "none"}:
+        reason = "infrastructure/empty diff" if is_infra(files) else "pin-only bump"
+        print(
+            f"::notice::Roadmap: {declared} is overridden by the {reason} classification"
+        )
     if args.apply:
         apply_label(args.repo, args.pr, label, areas)
         if args.nudge and label == UNKNOWN_LABEL:
@@ -266,7 +341,8 @@ def _run_one(args, areas) -> int:
 def _run_backfill(args, areas) -> int:
     prs = json.loads(_gh([
         "pr", "list", "--repo", args.repo, "--state", "all",
-        "--limit", str(args.limit), "--json", "number,title,body,files,state",
+        "--limit", str(args.limit),
+        "--json", "number,title,body,files,state,labels",
     ]))
     from collections import Counter
     tally: Counter[str] = Counter()
@@ -275,21 +351,32 @@ def _run_backfill(args, areas) -> int:
         files = [f["path"] for f in p.get("files") or []]
         label = classify(p.get("title") or "", p.get("body") or "", files, areas)
         tally[label] += 1
-        plan.append((p["number"], label))
+        current = {
+            item["name"] for item in p.get("labels") or []
+            if item["name"].startswith("roadmap/")
+        }
+        plan.append((p["number"], label, current))
         print(f"#{p['number']}\t{p['state']}\t{label}\t{p.get('title','')}")
 
     failed: list[int] = []
     if args.apply:
         # A per-PR failure must not abandon the rest of the backfill; collect and
         # retry once at the end (transient API errors are already retried in _gh).
-        for num, label in plan:
+        for num, label, current in plan:
+            if current and current != {label} and not args.allow_relabel:
+                print(
+                    f"  - #{num}: preserving {', '.join(sorted(current))}; "
+                    "pass --allow-relabel to change it",
+                    file=sys.stderr,
+                )
+                continue
             try:
                 apply_label(args.repo, num, label, areas)  # never nudges
             except Exception as e:  # noqa: BLE001 -- keep going, report at the end
                 print(f"  ! #{num}: {e}", file=sys.stderr)
                 failed.append(num)
         for num in list(failed):
-            label = dict(plan)[num]
+            label = next(label for plan_num, label, _ in plan if plan_num == num)
             try:
                 apply_label(args.repo, num, label, areas)
                 failed.remove(num)
@@ -314,6 +401,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--backfill", action="store_true", help="classify every PR")
     ap.add_argument("--limit", type=int, default=5000, help="max PRs for --backfill")
     ap.add_argument("--apply", action="store_true", help="write the label to the PR(s)")
+    ap.add_argument(
+        "--allow-relabel", action="store_true",
+        help="with --backfill --apply, permit changing an existing roadmap/* label",
+    )
     ap.add_argument("--nudge", action="store_true",
                     help="with --pr --apply: comment once when the label is roadmap/Unknown")
     a = ap.parse_args(argv)

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python3
-"""Assign each PR the roadmap it advances, as a `roadmap/<Area>` label.
+"""Assign each PR's declared roadmap association as a `roadmap/<Area>` label.
 
-The label is derived, not asked for: a submitter already has to name the roadmap
-their new mathematics advances (the scope rubric in TauCetiReview requires it),
-so we read that citation back out of the PR body rather than burden them with a
-second, structured field.
+Every PR should carry one standalone ``Roadmap: <Area>`` or ``Roadmap: none``
+line. This is attribution, not scope authorization: new mathematics must still
+cite the exact roadmap target that it advances, while a refactor may associate
+itself with the roadmap that chiefly motivates the cleanup.
 
 ## The classifier (see `classify`)
 
@@ -14,20 +14,16 @@ A PR gets exactly one label, decided in this order:
    `TauCeti/`, the root `TauCeti.lean`, and the two ordinary Lake pins). This also
    covers the review bot's narrowly validated first-known-bad lakefile exception:
    either way it is infrastructure, not roadmap work.
-2. `roadmap/<Area>` -- the body cites exactly one canonical roadmap, e.g.
-   `TauCetiRoadmap/OneParameterSemigroups/README.md` or `ContourIntegration/README.md`.
-   `<Area>` is the roadmap directory name, the same source of truth
-   `check_roadmap_areas.py` uses in the roadmap repo.
-3. `roadmap/none` -- no single citation, but the title is a refactor/fix/chore/...
-   (or a Mathlib bump). Reworking already-merged material needs no roadmap claim,
-   so absence of a citation is correct here, not a defect.
-4. `roadmap/Unknown` -- a new-mathematics PR (a `feat:` touching only `TauCeti/`)
-   that cites no parseable roadmap file. The live workflow leaves a one-time nudge
-   asking the author to cite the roadmap file, exactly as the scope rubric wants.
+2. `roadmap/none` -- the diff is a pin-only dependency bump.
+3. The one valid explicit ``Roadmap:`` declaration.
+4. One validated canonical ``focus`` in a ``tauceti-target:v1`` marker.
+5. One canonical roadmap-file citation, for compatibility with older PR bodies.
+6. `roadmap/Unknown` -- attribution is absent, invalid, or conflicting.
 
-The area set is read at runtime from a checkout of the roadmap repo, so a roadmap
-added there becomes labelable with no change here; the label itself is created on
-first use (`ensure_label`).
+Evidence from steps 3--5 must agree. Area names are read at runtime from active
+and completed roadmaps, and labels are created on first use (`ensure_label`).
+File paths and conventional-commit titles are deliberately not used as roadmap
+evidence.
 
 ## Usage
 
@@ -36,8 +32,11 @@ first use (`ensure_label`).
     # ... and apply it (create the label if missing, drop any stale roadmap/* label),
     # leaving a nudge if it lands in roadmap/Unknown:
     roadmap_label.py --pr 781 --repo ... --roadmap-dir roadmap --apply --nudge
-    # backfill every PR (never nudges):
-    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap --apply
+    # inspect every PR (never nudges):
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap
+    # changing an existing roadmap label is deliberately opt-in:
+    roadmap_label.py --backfill --repo ... --roadmap-dir roadmap \
+        --apply --allow-relabel
 
 `--apply`/`--nudge` shell out to `gh`, which must be authenticated (GH_TOKEN).
 `classify` and the parsing helpers are pure and are what the tests exercise.
@@ -77,12 +76,8 @@ UNKNOWN_COLOR = "fbca04"   # yellow: needs a citation
 # remains an infrastructure PR and therefore still belongs under roadmap/none here.
 _ALLOWED_PATH = re.compile(r"^(?:TauCeti/|TauCeti\.lean$|lake-manifest\.json$|lean-toolchain$)")
 
-# Titles that, by convention, rework existing material rather than add new
-# mathematics; per the scope rubric these need no roadmap claim.
-_NONROADMAP_TITLE = re.compile(
-    r"^(?:refactor|fix|chore|style|test|perf|docs?|ci|build|revert|harden)(?:[(!:/]| )",
-    re.IGNORECASE,
-)
+_PINS = {"lake-manifest.json", "lean-toolchain"}
+_TARGET_MARKER = re.compile(r"<!--tauceti-target:v1 (\{[^}]*\})-->")
 
 
 def is_infra(files: list[str]) -> bool:
@@ -94,6 +89,68 @@ def is_infra(files: list[str]) -> bool:
     if not files:
         return True
     return any(not _ALLOWED_PATH.match(f) for f in files)
+
+
+def is_pin_only(files: list[str]) -> bool:
+    """True exactly when a nonempty diff changes only the two validated pins."""
+    return bool(files) and set(files) <= _PINS
+
+
+def _body_lines_outside_quotes_and_fences(body: str):
+    """Yield body lines that are not inside Markdown fences or blockquotes."""
+    fence = None
+    for line in (body or "").splitlines():
+        stripped = line.lstrip()
+        marker = stripped[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            continue
+        if fence is None and not stripped.startswith(">"):
+            yield line
+
+
+def parse_declared_area(body: str, areas: set[str]) -> tuple[bool, str | None]:
+    """Return ``(present, value)`` for standalone ``Roadmap:`` lines.
+
+    ``value`` is an area name or ``none`` when every declaration is valid and
+    identical. It is ``None`` for invalid or conflicting declarations. Examples
+    in fenced code and blockquotes are ignored.
+    """
+    present = False
+    values = set()
+    invalid = False
+    for line in _body_lines_outside_quotes_and_fences(body):
+        if not re.match(r"^Roadmap\s*:", line):
+            continue
+        present = True
+        match = re.fullmatch(r"Roadmap:\s*(\S+)\s*", line)
+        if match is None:
+            invalid = True
+            continue
+        value = match.group(1)
+        if value != "none" and value not in areas:
+            invalid = True
+        else:
+            values.add(value)
+    if invalid or len(values) != 1:
+        return present, None
+    return present, next(iter(values))
+
+
+def parse_target_areas(body: str, areas: set[str]) -> set[str]:
+    """Canonical roadmap focuses from valid ``tauceti-target:v1`` markers."""
+    found = set()
+    for match in _TARGET_MARKER.finditer(body or ""):
+        try:
+            focus = json.loads(match.group(1)).get("focus")
+        except (json.JSONDecodeError, AttributeError):
+            continue
+        if focus in areas:
+            found.add(focus)
+    return found
 
 
 def parse_cited_areas(body: str, areas: set[str]) -> set[str]:
@@ -120,13 +177,23 @@ def classify(title: str, body: str, files: list[str], areas: set[str]) -> str:
     """Return the single roadmap label for a PR. Pure; see module docstring."""
     if is_infra(files):
         return NONE_LABEL
-    cited = parse_cited_areas(body, areas)
-    if len(cited) == 1:
-        return area_label(next(iter(cited)))
-    # Zero citations, or several (no single roadmap to name): fall through.
-    if _NONROADMAP_TITLE.match(title or ""):
+    if is_pin_only(files):
         return NONE_LABEL
-    return UNKNOWN_LABEL
+
+    declared_present, declared = parse_declared_area(body, areas)
+    if declared_present and declared is None:
+        return UNKNOWN_LABEL
+
+    targets = parse_target_areas(body, areas)
+    cited = parse_cited_areas(body, areas)
+    indirect = targets | cited
+
+    if declared is not None:
+        if declared == "none":
+            return NONE_LABEL if not indirect else UNKNOWN_LABEL
+        return area_label(declared) if indirect <= {declared} else UNKNOWN_LABEL
+
+    return area_label(next(iter(indirect))) if len(indirect) == 1 else UNKNOWN_LABEL
 
 
 # --- roadmap area discovery ------------------------------------------------
@@ -190,23 +257,25 @@ def ensure_label(repo: str, name: str, color: str, desc: str) -> None:
 
 def _label_meta(name: str, areas: set[str]) -> tuple[str, str]:
     if name == NONE_LABEL:
-        return NONE_COLOR, "PR advances no roadmap (infra, refactor, or a Mathlib bump)"
+        return NONE_COLOR, "No roadmap association (declared, infrastructure, or pin-only bump)"
     if name == UNKNOWN_LABEL:
-        return UNKNOWN_COLOR, "New mathematics PR with no parseable roadmap citation"
-    return AREA_COLOR, "PR advances the {} roadmap".format(name[len("roadmap/"):])
+        return UNKNOWN_COLOR, "Missing, invalid, or conflicting roadmap association"
+    return AREA_COLOR, "PR declares the {} roadmap as its primary association".format(
+        name[len("roadmap/"):])
 
 
 NUDGE_MARKER = "<!--roadmap-label:nudge-->"
 NUDGE_BODY = (
     NUDGE_MARKER + "\n"
-    "This PR adds new mathematics but I could not find the roadmap it advances "
-    "in its description, so I have labelled it `roadmap/Unknown`.\n\n"
-    "Per the [scope rubric](https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md), "
-    "new material should identify the roadmap file and node it advances. Please add "
-    "a reference to the roadmap file, for example "
-    "`TauCetiRoadmap/OneParameterSemigroups/README.md`, and the label will update "
-    "automatically. If this PR only reworks already-merged material, no roadmap is "
-    "needed and you can ignore this."
+    "I could not determine this PR's roadmap association, so I labelled it "
+    "`roadmap/Unknown`. Please add one standalone line to the description:\n\n"
+    "```text\nRoadmap: CanonicalAreaName\n```\n\n"
+    "Use `Roadmap: none` for genuinely general, cross-cutting, infrastructure, "
+    "or dependency work. Refactors need no fresh roadmap authorization, but should "
+    "name the one roadmap chiefly motivating them. For new mathematics, this "
+    "attribution line does not replace the [scope rubric's]"
+    "(https://github.com/TauCetiProject/TauCetiReview/blob/main/rubrics/scope.md) "
+    "requirement to cite the exact roadmap file and target."
 )
 
 
@@ -256,6 +325,12 @@ def _run_one(args, areas) -> int:
     title, body, files = _pr_fields(args.repo, args.pr)
     label = classify(title, body, files, areas)
     print(f"#{args.pr}\t{label}\t{title}")
+    declared_present, declared = parse_declared_area(body, areas)
+    if (is_infra(files) or is_pin_only(files)) and declared_present and declared not in {None, "none"}:
+        reason = "infrastructure/empty diff" if is_infra(files) else "pin-only bump"
+        print(
+            f"::notice::Roadmap: {declared} is overridden by the {reason} classification"
+        )
     if args.apply:
         apply_label(args.repo, args.pr, label, areas)
         if args.nudge and label == UNKNOWN_LABEL:
@@ -266,7 +341,8 @@ def _run_one(args, areas) -> int:
 def _run_backfill(args, areas) -> int:
     prs = json.loads(_gh([
         "pr", "list", "--repo", args.repo, "--state", "all",
-        "--limit", str(args.limit), "--json", "number,title,body,files,state",
+        "--limit", str(args.limit),
+        "--json", "number,title,body,files,state,labels",
     ]))
     from collections import Counter
     tally: Counter[str] = Counter()
@@ -275,21 +351,34 @@ def _run_backfill(args, areas) -> int:
         files = [f["path"] for f in p.get("files") or []]
         label = classify(p.get("title") or "", p.get("body") or "", files, areas)
         tally[label] += 1
-        plan.append((p["number"], label))
+        current = {
+            item["name"] for item in p.get("labels") or []
+            if item["name"].startswith("roadmap/")
+        }
+        plan.append((p["number"], label, current))
         print(f"#{p['number']}\t{p['state']}\t{label}\t{p.get('title','')}")
 
     failed: list[int] = []
     if args.apply:
         # A per-PR failure must not abandon the rest of the backfill; collect and
         # retry once at the end (transient API errors are already retried in _gh).
-        for num, label in plan:
+        for num, label, current in plan:
+            if current == {label}:
+                continue
+            if current and current != {label} and not args.allow_relabel:
+                print(
+                    f"  - #{num}: preserving {', '.join(sorted(current))}; "
+                    "pass --allow-relabel to change it",
+                    file=sys.stderr,
+                )
+                continue
             try:
                 apply_label(args.repo, num, label, areas)  # never nudges
             except Exception as e:  # noqa: BLE001 -- keep going, report at the end
                 print(f"  ! #{num}: {e}", file=sys.stderr)
                 failed.append(num)
         for num in list(failed):
-            label = dict(plan)[num]
+            label = next(label for plan_num, label, _ in plan if plan_num == num)
             try:
                 apply_label(args.repo, num, label, areas)
                 failed.remove(num)
@@ -314,6 +403,10 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--backfill", action="store_true", help="classify every PR")
     ap.add_argument("--limit", type=int, default=5000, help="max PRs for --backfill")
     ap.add_argument("--apply", action="store_true", help="write the label to the PR(s)")
+    ap.add_argument(
+        "--allow-relabel", action="store_true",
+        help="with --backfill --apply, permit changing an existing roadmap/* label",
+    )
     ap.add_argument("--nudge", action="store_true",
                     help="with --pr --apply: comment once when the label is roadmap/Unknown")
     a = ap.parse_args(argv)

--- a/scripts/roadmap_label.py
+++ b/scripts/roadmap_label.py
@@ -133,14 +133,28 @@ def classify(title: str, body: str, files: list[str], areas: set[str]) -> str:
 
 
 def canonical_areas(roadmap_dir: pathlib.Path) -> set[str]:
-    """Roadmap directory names (those containing a README.md) under a checkout.
+    """Active and completed roadmap directory names under a checkout.
 
-    Accepts either the roadmap repo root (areas live under its inner
-    `TauCetiRoadmap/` package dir) or the package dir itself.
+    At the repository root, active areas live under the inner
+    `TauCetiRoadmap/` package and archived areas live under the sibling
+    `Completed/` directory. Accepting the package directory itself remains
+    useful for local one-area tests and older callers.
     """
     inner = roadmap_dir / "TauCetiRoadmap"
-    base = inner if inner.is_dir() else roadmap_dir
-    return {p.name for p in base.iterdir() if p.is_dir() and (p / "README.md").is_file()}
+    if not inner.is_dir():
+        return {
+            p.name for p in roadmap_dir.iterdir()
+            if p.is_dir() and (p / "README.md").is_file()
+        }
+
+    bases = [inner]
+    completed = roadmap_dir / "Completed"
+    if completed.is_dir():
+        bases.append(completed)
+    return {
+        p.name for base in bases for p in base.iterdir()
+        if p.is_dir() and (p / "README.md").is_file()
+    }
 
 
 # --- gh plumbing (only reached in --apply/--nudge/--pr/--backfill IO paths) --

--- a/scripts/roadmap_refactor_backfill.py
+++ b/scripts/roadmap_refactor_backfill.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Safely add explicit roadmap attribution to selected historical refactor PRs.
+
+This is deliberately manifest-driven: semantic classification happens before
+this script is invoked. A proposal JSONL contains one object per high-confidence
+PR with these fields:
+
+    {"pr": 1522, "roadmap": "ContourIntegration",
+     "roadmap_file": "TauCetiRoadmap/ContourIntegration/README.md",
+     "roadmap_heading": "Layer 4: ...",
+     "roadmap_quote": "the multi-crossing PV engine",
+     "provenance": ["#949", "#950"]}
+
+``prepare`` captures the verbatim body and roadmap labels, validates the PR and
+evidence, computes the insertion, and writes a reversible execution manifest.
+``dry-run`` revalidates a tranche without writing (``check`` is a short alias).
+``apply`` edits at most twenty PRs, re-runs the production classifier on the
+post-edit state, and applies exactly its result. ``revert`` restores the
+captured body and label if the applied body has not subsequently changed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import pathlib
+import re
+import subprocess
+import sys
+import time
+
+import roadmap_label
+
+REPO = "TauCetiProject/TauCeti"
+REFACTOR_TITLE = re.compile(r"^refactor(?:[(!:/]| )", re.IGNORECASE)
+MAX_TRANCHE = 20
+
+
+def body_hash(body: str) -> str:
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def insert_roadmap_line(body: str, area: str) -> str:
+    """Insert ``Roadmap: area`` without rewriting any existing body bytes."""
+    present, declared = roadmap_label.parse_declared_area(body, {area})
+    if present:
+        if declared == area:
+            return body
+        raise ValueError("body already contains an invalid or different Roadmap: declaration")
+
+    newline = "\r\n" if "\r\n" in body else "\n"
+    line = f"Roadmap: {area}"
+    footer = re.search(
+        r"(?m)^(?::robot:|🤖)\s*Prepared with [^\r\n]+(?:\r?\n)?\Z",
+        body,
+    )
+    if footer is not None:
+        prefix = body[:footer.start()]
+        separator = "" if prefix.endswith(newline * 2) else (
+            newline if prefix.endswith(newline) else newline * 2
+        )
+        return prefix + separator + line + newline * 2 + body[footer.start():]
+
+    separator = "" if not body or body.endswith(newline * 2) else (
+        newline if body.endswith(newline) else newline * 2
+    )
+    return body + separator + line
+
+
+def _run_gh(args: list[str], *, stdin: str | None = None, retries: int = 3) -> str:
+    last = ""
+    for attempt in range(retries):
+        result = subprocess.run(
+            ["gh", *args],
+            input=stdin,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if result.returncode == 0:
+            return result.stdout or ""
+        last = result.stderr or ""
+        if attempt < retries - 1:
+            time.sleep(2 * (attempt + 1))
+    raise RuntimeError(f"gh {' '.join(args)} failed after {retries} tries: {last.strip()}")
+
+
+def pr_state(repo: str, pr: int) -> dict:
+    return json.loads(_run_gh([
+        "pr", "view", str(pr), "--repo", repo,
+        "--json", "number,title,body,files,labels,state",
+    ]))
+
+
+def roadmap_labels(state: dict) -> list[str]:
+    return sorted(
+        item["name"] for item in state.get("labels") or []
+        if item["name"].startswith("roadmap/")
+    )
+
+
+def changed_files(state: dict) -> list[str]:
+    return [item["path"] for item in state.get("files") or []]
+
+
+def patch_body(repo: str, pr: int, body: str) -> None:
+    _run_gh(
+        ["api", "--method", "PATCH", f"repos/{repo}/pulls/{pr}", "--input", "-"],
+        stdin=json.dumps({"body": body}, ensure_ascii=False),
+    )
+
+
+def read_jsonl(path: pathlib.Path) -> list[dict]:
+    rows = []
+    with path.open(encoding="utf-8") as source:
+        for line_number, line in enumerate(source, 1):
+            if not line.strip():
+                continue
+            try:
+                row = json.loads(line)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {exc}") from exc
+            if not isinstance(row, dict):
+                raise ValueError(f"{path}:{line_number}: expected an object")
+            rows.append(row)
+    return rows
+
+
+def write_jsonl(path: pathlib.Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8", newline="\n") as target:
+        for row in rows:
+            target.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
+
+
+def validate_evidence(proposal: dict, areas: set[str]) -> tuple[int, str]:
+    required = ("pr", "roadmap", "roadmap_file", "roadmap_heading", "roadmap_quote", "provenance")
+    missing = [name for name in required if name not in proposal]
+    if missing:
+        raise ValueError(f"proposal missing {', '.join(missing)}")
+    pr = proposal["pr"]
+    area = proposal["roadmap"]
+    if not isinstance(pr, int) or pr <= 0:
+        raise ValueError("proposal pr must be a positive integer")
+    if area not in areas:
+        raise ValueError(f"#{pr}: {area!r} is not an active or completed roadmap")
+    for name in ("roadmap_file", "roadmap_heading", "roadmap_quote"):
+        if not isinstance(proposal[name], str) or not proposal[name].strip():
+            raise ValueError(f"#{pr}: {name} must be nonempty")
+    provenance = proposal["provenance"]
+    if not isinstance(provenance, list) or not provenance or not all(
+        isinstance(item, str) and item.strip() for item in provenance
+    ):
+        raise ValueError(f"#{pr}: provenance must be a nonempty string list")
+    return pr, area
+
+
+def prepare_record(repo: str, proposal: dict, areas: set[str]) -> dict:
+    pr, area = validate_evidence(proposal, areas)
+    state = pr_state(repo, pr)
+    if not REFACTOR_TITLE.match(state.get("title") or ""):
+        raise ValueError(f"#{pr}: title is not a conventional refactor title")
+    if state.get("state") not in {"MERGED", "OPEN"}:
+        raise ValueError(f"#{pr}: closed-unmerged PRs are outside migration scope")
+    files = changed_files(state)
+    if roadmap_label.is_infra(files):
+        raise ValueError(f"#{pr}: infrastructure/empty diff is outside migration scope")
+    if roadmap_label.is_pin_only(files):
+        raise ValueError(f"#{pr}: pin-only diff is outside migration scope")
+    old_labels = roadmap_labels(state)
+    if old_labels != [roadmap_label.NONE_LABEL]:
+        raise ValueError(f"#{pr}: expected only roadmap/none, found {old_labels}")
+
+    old_body = state.get("body") or ""
+    new_body = insert_roadmap_line(old_body, area)
+    if new_body == old_body:
+        raise ValueError(f"#{pr}: body already has the requested declaration")
+
+    return {
+        **proposal,
+        "title": state.get("title") or "",
+        "old_body": old_body,
+        "old_body_sha256": body_hash(old_body),
+        "old_roadmap_labels": old_labels,
+        "new_body": new_body,
+        "new_body_sha256": body_hash(new_body),
+    }
+
+
+def validate_manifest_record(record: dict, areas: set[str]) -> None:
+    pr, area = validate_evidence(record, areas)
+    for field in (
+        "title", "old_body", "old_body_sha256", "old_roadmap_labels",
+        "new_body", "new_body_sha256",
+    ):
+        if field not in record:
+            raise ValueError(f"#{pr}: manifest missing {field}")
+    if body_hash(record["old_body"]) != record["old_body_sha256"]:
+        raise ValueError(f"#{pr}: old body hash is inconsistent")
+    if body_hash(record["new_body"]) != record["new_body_sha256"]:
+        raise ValueError(f"#{pr}: new body hash is inconsistent")
+    if insert_roadmap_line(record["old_body"], area) != record["new_body"]:
+        raise ValueError(f"#{pr}: new body is not the canonical insertion")
+    if record["old_roadmap_labels"] != [roadmap_label.NONE_LABEL]:
+        raise ValueError(f"#{pr}: rollback label must be roadmap/none")
+
+
+def select_tranche(rows: list[dict], offset: int, limit: int) -> list[dict]:
+    if offset < 0:
+        raise ValueError("--offset must be nonnegative")
+    if limit < 1 or limit > MAX_TRANCHE:
+        raise ValueError(f"--limit must be between 1 and {MAX_TRANCHE}")
+    return rows[offset:offset + limit]
+
+
+def check_current(repo: str, record: dict, areas: set[str], *, applied: bool) -> dict:
+    pr = record["pr"]
+    expected_hash = record["new_body_sha256"] if applied else record["old_body_sha256"]
+    for attempt in range(2):
+        state = pr_state(repo, pr)
+        actual_hash = body_hash(state.get("body") or "")
+        if actual_hash == expected_hash:
+            break
+        if attempt == 1:
+            phase = "applied" if applied else "pre-edit"
+            raise ValueError(f"#{pr}: {phase} body drift ({actual_hash} != {expected_hash})")
+    if not applied and roadmap_labels(state) != record["old_roadmap_labels"]:
+        raise ValueError(f"#{pr}: roadmap labels drifted to {roadmap_labels(state)}")
+    return state
+
+
+def restore_record(repo: str, record: dict, areas: set[str]) -> None:
+    patch_body(repo, record["pr"], record["old_body"])
+    roadmap_label.apply_label(
+        repo, record["pr"], record["old_roadmap_labels"][0], areas)
+
+
+def apply_record(repo: str, record: dict, areas: set[str]) -> None:
+    pr = record["pr"]
+    check_current(repo, record, areas, applied=False)
+    expected = roadmap_label.area_label(record["roadmap"])
+    try:
+        patch_body(repo, pr, record["new_body"])
+        after_body = pr_state(repo, pr)
+        actual_body = after_body.get("body") or ""
+        actual = roadmap_label.classify(
+            after_body.get("title") or "",
+            actual_body,
+            changed_files(after_body),
+            areas,
+        )
+        if body_hash(actual_body) != record["new_body_sha256"]:
+            raise ValueError(f"#{pr}: GitHub did not preserve the proposed body")
+        if actual != expected:
+            raise ValueError(f"#{pr}: production classifier returned {actual}, expected {expected}")
+        roadmap_label.apply_label(repo, pr, actual, areas)
+        final = check_current(repo, record, areas, applied=True)
+        if roadmap_labels(final) != [expected]:
+            raise ValueError(f"#{pr}: final roadmap labels are {roadmap_labels(final)}")
+    except Exception:
+        # Restore only when this invocation still owns the exact proposed body.
+        current = pr_state(repo, pr)
+        if body_hash(current.get("body") or "") == record["new_body_sha256"]:
+            restore_record(repo, record, areas)
+        raise
+
+
+def revert_record(repo: str, record: dict, areas: set[str]) -> None:
+    check_current(repo, record, areas, applied=True)
+    restore_record(repo, record, areas)
+    check_current(repo, record, areas, applied=False)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=REPO)
+    parser.add_argument("--roadmap-dir", required=True, type=pathlib.Path)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    prepare = sub.add_parser("prepare", help="capture rollback state from proposal JSONL")
+    prepare.add_argument("--proposals", required=True, type=pathlib.Path)
+    prepare.add_argument("--manifest", required=True, type=pathlib.Path)
+
+    for command in ("check", "dry-run", "apply", "revert"):
+        action = sub.add_parser(command)
+        action.add_argument("--manifest", required=True, type=pathlib.Path)
+        action.add_argument("--offset", type=int, default=0)
+        action.add_argument("--limit", type=int, default=MAX_TRANCHE)
+
+    args = parser.parse_args(argv)
+    areas = roadmap_label.canonical_areas(args.roadmap_dir)
+    if not areas:
+        parser.error(f"no roadmap areas found under {args.roadmap_dir}")
+
+    if args.command == "prepare":
+        proposals = read_jsonl(args.proposals)
+        records = [prepare_record(args.repo, proposal, areas) for proposal in proposals]
+        write_jsonl(args.manifest, records)
+        print(f"prepared {len(records)} reversible record(s) in {args.manifest}")
+        return 0
+
+    rows = read_jsonl(args.manifest)
+    for record in rows:
+        validate_manifest_record(record, areas)
+    try:
+        tranche = select_tranche(rows, args.offset, args.limit)
+    except ValueError as exc:
+        parser.error(str(exc))
+
+    failures = []
+    for record in tranche:
+        pr = record["pr"]
+        try:
+            if args.command in {"check", "dry-run"}:
+                check_current(args.repo, record, areas, applied=False)
+            elif args.command == "apply":
+                apply_record(args.repo, record, areas)
+            else:
+                revert_record(args.repo, record, areas)
+            print(f"{args.command}: #{pr} {record['roadmap']}")
+        except Exception as exc:  # noqa: BLE001 -- finish the tranche, then fail
+            failures.append((pr, str(exc)))
+            print(f"FAILED #{pr}: {exc}", file=sys.stderr)
+
+    print(
+        f"{args.command}: {len(tranche)} selected, "
+        f"{len(tranche) - len(failures)} succeeded, {len(failures)} failed"
+    )
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/roadmap_refactor_backfill.py
+++ b/scripts/roadmap_refactor_backfill.py
@@ -201,8 +201,11 @@ def prepare_record(
     if roadmap_label.is_pin_only(files):
         raise ValueError(f"#{pr}: pin-only diff is outside migration scope")
     old_labels = roadmap_labels(state)
-    if old_labels != [roadmap_label.NONE_LABEL]:
-        raise ValueError(f"#{pr}: expected only roadmap/none, found {old_labels}")
+    expected = roadmap_label.area_label(area)
+    if old_labels not in ([roadmap_label.NONE_LABEL], [expected]):
+        raise ValueError(
+            f"#{pr}: expected roadmap/none or {expected}, found {old_labels}"
+        )
 
     old_body = state.get("body") or ""
     new_body = insert_roadmap_line(old_body, area)
@@ -238,8 +241,11 @@ def validate_manifest_record(
         raise ValueError(f"#{pr}: new body hash is inconsistent")
     if insert_roadmap_line(record["old_body"], area) != record["new_body"]:
         raise ValueError(f"#{pr}: new body is not the canonical insertion")
-    if record["old_roadmap_labels"] != [roadmap_label.NONE_LABEL]:
-        raise ValueError(f"#{pr}: rollback label must be roadmap/none")
+    expected = roadmap_label.area_label(area)
+    if record["old_roadmap_labels"] not in ([roadmap_label.NONE_LABEL], [expected]):
+        raise ValueError(
+            f"#{pr}: rollback label must be roadmap/none or {expected}"
+        )
 
 
 def select_tranche(rows: list[dict], offset: int, limit: int) -> list[dict]:

--- a/scripts/roadmap_refactor_backfill.py
+++ b/scripts/roadmap_refactor_backfill.py
@@ -133,7 +133,11 @@ def write_jsonl(path: pathlib.Path, rows: list[dict]) -> None:
             target.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
 
-def validate_evidence(proposal: dict, areas: set[str]) -> tuple[int, str]:
+def validate_evidence(
+    proposal: dict,
+    areas: set[str],
+    roadmap_dir: pathlib.Path,
+) -> tuple[int, str]:
     required = ("pr", "roadmap", "roadmap_file", "roadmap_heading", "roadmap_quote", "provenance")
     missing = [name for name in required if name not in proposal]
     if missing:
@@ -152,11 +156,40 @@ def validate_evidence(proposal: dict, areas: set[str]) -> tuple[int, str]:
         isinstance(item, str) and item.strip() for item in provenance
     ):
         raise ValueError(f"#{pr}: provenance must be a nonempty string list")
+
+    relative = pathlib.PurePosixPath(proposal["roadmap_file"])
+    if relative.is_absolute() or ".." in relative.parts:
+        raise ValueError(f"#{pr}: roadmap_file must stay inside the roadmap checkout")
+    expected_prefixes = {
+        ("TauCetiRoadmap", area),
+        ("Completed", area),
+    }
+    if tuple(relative.parts[:2]) not in expected_prefixes:
+        raise ValueError(f"#{pr}: roadmap_file is not within the {area} roadmap")
+    path = roadmap_dir / pathlib.Path(*relative.parts)
+    if not path.is_file():
+        raise ValueError(f"#{pr}: roadmap_file does not exist: {relative}")
+    contents = path.read_text(encoding="utf-8")
+    heading = proposal["roadmap_heading"].strip()
+    heading_lines = {
+        line.lstrip("#").strip()
+        for line in contents.splitlines()
+        if line.startswith("#")
+    }
+    if heading not in heading_lines:
+        raise ValueError(f"#{pr}: roadmap_heading is not an exact Markdown heading")
+    if proposal["roadmap_quote"].strip() not in contents:
+        raise ValueError(f"#{pr}: roadmap_quote is not present in roadmap_file")
     return pr, area
 
 
-def prepare_record(repo: str, proposal: dict, areas: set[str]) -> dict:
-    pr, area = validate_evidence(proposal, areas)
+def prepare_record(
+    repo: str,
+    proposal: dict,
+    areas: set[str],
+    roadmap_dir: pathlib.Path,
+) -> dict:
+    pr, area = validate_evidence(proposal, areas, roadmap_dir)
     state = pr_state(repo, pr)
     if not REFACTOR_TITLE.match(state.get("title") or ""):
         raise ValueError(f"#{pr}: title is not a conventional refactor title")
@@ -187,8 +220,12 @@ def prepare_record(repo: str, proposal: dict, areas: set[str]) -> dict:
     }
 
 
-def validate_manifest_record(record: dict, areas: set[str]) -> None:
-    pr, area = validate_evidence(record, areas)
+def validate_manifest_record(
+    record: dict,
+    areas: set[str],
+    roadmap_dir: pathlib.Path,
+) -> None:
+    pr, area = validate_evidence(record, areas, roadmap_dir)
     for field in (
         "title", "old_body", "old_body_sha256", "old_roadmap_labels",
         "new_body", "new_body_sha256",
@@ -294,14 +331,17 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.command == "prepare":
         proposals = read_jsonl(args.proposals)
-        records = [prepare_record(args.repo, proposal, areas) for proposal in proposals]
+        records = [
+            prepare_record(args.repo, proposal, areas, args.roadmap_dir)
+            for proposal in proposals
+        ]
         write_jsonl(args.manifest, records)
         print(f"prepared {len(records)} reversible record(s) in {args.manifest}")
         return 0
 
     rows = read_jsonl(args.manifest)
     for record in rows:
-        validate_manifest_record(record, areas)
+        validate_manifest_record(record, areas, args.roadmap_dir)
     try:
         tranche = select_tranche(rows, args.offset, args.limit)
     except ValueError as exc:

--- a/scripts/roadmap_refactor_backfill.py
+++ b/scripts/roadmap_refactor_backfill.py
@@ -11,6 +11,14 @@ PR with these fields:
      "roadmap_quote": "the multi-crossing PV engine",
      "provenance": ["#949", "#950"]}
 
+The evidence fields must actually connect the PR to the roadmap, so none of them
+is taken on trust. ``roadmap_heading`` must be a real ATX heading of
+``roadmap_file`` (fenced code cannot supply one) and ``roadmap_quote`` must sit in
+that heading's own section, not merely somewhere in the file. ``provenance`` must
+be ``#N``/pull-request-URL references that resolve, against GitHub, to merged PRs
+of this repository which the production classifier already attributes to the same
+roadmap area, at least one of which touched a file the migrated PR also changes.
+
 ``prepare`` captures the verbatim body and roadmap labels, validates the PR and
 evidence, computes the insertion, and writes a reversible execution manifest.
 ``dry-run`` revalidates a tranche without writing (``check`` is a short alias).
@@ -35,6 +43,10 @@ import roadmap_label
 REPO = "TauCetiProject/TauCeti"
 REFACTOR_TITLE = re.compile(r"^refactor(?:[(!:/]| )", re.IGNORECASE)
 MAX_TRANCHE = 20
+PROVENANCE_REF = re.compile(
+    r"(?:#|https://github\.com/(?P<repo>[\w.-]+/[\w.-]+)/pull/)(?P<number>[1-9][0-9]*)"
+)
+ATX_HEADING = re.compile(r" {0,3}(#{1,6})(?:[ \t]+(.*?))?[ \t]*")
 
 
 def body_hash(body: str) -> str:
@@ -133,6 +145,115 @@ def write_jsonl(path: pathlib.Path, rows: list[dict]) -> None:
             target.write(json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n")
 
 
+def heading_sections(contents: str) -> list[tuple[str, str]]:
+    """Return ``(heading text, section text)`` for each ATX heading of a document.
+
+    A section runs to the next heading of the same or a higher level, so a quote is
+    credited only to the heading it actually sits under. Fenced code is skipped, so
+    a shell comment cannot masquerade as a heading, and the hashes must be followed
+    by a space, as CommonMark requires, so a bare ``#123`` PR reference cannot
+    either.
+    """
+    lines = contents.splitlines()
+    fence: str | None = None
+    headings: list[tuple[int, str, int]] = []
+    for index, line in enumerate(lines):
+        marker = line.lstrip()[:3]
+        if marker in {"```", "~~~"}:
+            if fence is None:
+                fence = marker
+            elif fence == marker:
+                fence = None
+            continue
+        if fence is not None:
+            continue
+        match = ATX_HEADING.fullmatch(line)
+        if match is None:
+            continue
+        text = re.sub(r"[ \t]+#+\Z", "", match.group(2) or "").strip()
+        headings.append((len(match.group(1)), text, index))
+
+    sections = []
+    for position, (level, text, start) in enumerate(headings):
+        end = next(
+            (other_start for other_level, _, other_start in headings[position + 1:]
+             if other_level <= level),
+            len(lines),
+        )
+        sections.append((text, "\n".join(lines[start + 1:end])))
+    return sections
+
+
+def parse_provenance(proposal: dict) -> list[tuple[str | None, int]]:
+    """Parse ``provenance`` into ``(repo, number)`` pull-request references.
+
+    Free text is rejected outright: provenance is the link between the PR being
+    migrated and the roadmap it is being attributed to, so every entry has to name
+    a pull request that ``verify_provenance`` can resolve and check.
+    """
+    pr = proposal["pr"]
+    provenance = proposal["provenance"]
+    if not isinstance(provenance, list) or not provenance:
+        raise ValueError(f"#{pr}: provenance must be a nonempty list of PR references")
+    refs: list[tuple[str | None, int]] = []
+    for item in provenance:
+        match = PROVENANCE_REF.fullmatch(item.strip()) if isinstance(item, str) else None
+        if match is None:
+            raise ValueError(
+                f"#{pr}: provenance entry {item!r} is not a #N or pull-request URL"
+            )
+        number = int(match.group("number"))
+        if number == pr:
+            raise ValueError(f"#{pr}: provenance cannot cite the PR being migrated")
+        if (match.group("repo"), number) not in refs:
+            refs.append((match.group("repo"), number))
+    return refs
+
+
+def verify_provenance(
+    repo: str,
+    record: dict,
+    areas: set[str],
+    target_files: list[str],
+) -> None:
+    """Check that the cited PRs really tie the migrated PR to the roadmap area.
+
+    Each one must be a merged PR of this repository that the production classifier,
+    or the label that classifier already applied, attributes to the same area; and
+    at least one must have touched a file the migrated PR also changes. Without the
+    overlap the citation would say nothing about *this* PR.
+    """
+    pr = record["pr"]
+    area = record["roadmap"]
+    expected = roadmap_label.area_label(area)
+    target = set(target_files)
+    overlapping = []
+    for ref_repo, number in parse_provenance(record):
+        if ref_repo is not None and ref_repo != repo:
+            raise ValueError(f"#{pr}: provenance #{number} is not a {repo} pull request")
+        try:
+            state = pr_state(repo, number)
+        except RuntimeError as exc:
+            raise ValueError(f"#{pr}: provenance #{number} does not resolve: {exc}") from exc
+        if state.get("state") != "MERGED":
+            raise ValueError(f"#{pr}: provenance #{number} is not merged")
+        files = changed_files(state)
+        label = roadmap_label.classify(
+            state.get("title") or "", state.get("body") or "", files, areas)
+        if label != expected and expected not in roadmap_labels(state):
+            raise ValueError(
+                f"#{pr}: provenance #{number} is not attributed to {area} "
+                f"(classifier says {label})"
+            )
+        if target & set(files):
+            overlapping.append(number)
+    if not overlapping:
+        raise ValueError(
+            f"#{pr}: no provenance PR touches a file this PR changes, so the "
+            f"citation does not connect it to {area}"
+        )
+
+
 def validate_evidence(
     proposal: dict,
     areas: set[str],
@@ -151,11 +272,7 @@ def validate_evidence(
     for name in ("roadmap_file", "roadmap_heading", "roadmap_quote"):
         if not isinstance(proposal[name], str) or not proposal[name].strip():
             raise ValueError(f"#{pr}: {name} must be nonempty")
-    provenance = proposal["provenance"]
-    if not isinstance(provenance, list) or not provenance or not all(
-        isinstance(item, str) and item.strip() for item in provenance
-    ):
-        raise ValueError(f"#{pr}: provenance must be a nonempty string list")
+    parse_provenance(proposal)
 
     relative = pathlib.PurePosixPath(proposal["roadmap_file"])
     if relative.is_absolute() or ".." in relative.parts:
@@ -171,15 +288,12 @@ def validate_evidence(
         raise ValueError(f"#{pr}: roadmap_file does not exist: {relative}")
     contents = path.read_text(encoding="utf-8")
     heading = proposal["roadmap_heading"].strip()
-    heading_lines = {
-        line.lstrip("#").strip()
-        for line in contents.splitlines()
-        if line.startswith("#")
-    }
-    if heading not in heading_lines:
+    sections = [text for name, text in heading_sections(contents) if name == heading]
+    if not sections:
         raise ValueError(f"#{pr}: roadmap_heading is not an exact Markdown heading")
-    if proposal["roadmap_quote"].strip() not in contents:
-        raise ValueError(f"#{pr}: roadmap_quote is not present in roadmap_file")
+    quote = proposal["roadmap_quote"].strip()
+    if not any(quote in section for section in sections):
+        raise ValueError(f"#{pr}: roadmap_quote is not under the cited roadmap_heading")
     return pr, area
 
 
@@ -200,6 +314,7 @@ def prepare_record(
         raise ValueError(f"#{pr}: infrastructure/empty diff is outside migration scope")
     if roadmap_label.is_pin_only(files):
         raise ValueError(f"#{pr}: pin-only diff is outside migration scope")
+    verify_provenance(repo, proposal, areas, files)
     old_labels = roadmap_labels(state)
     expected = roadmap_label.area_label(area)
     if old_labels not in ([roadmap_label.NONE_LABEL], [expected]):
@@ -280,7 +395,8 @@ def restore_record(repo: str, record: dict, areas: set[str]) -> None:
 
 def apply_record(repo: str, record: dict, areas: set[str]) -> None:
     pr = record["pr"]
-    check_current(repo, record, areas, applied=False)
+    before = check_current(repo, record, areas, applied=False)
+    verify_provenance(repo, record, areas, changed_files(before))
     expected = roadmap_label.area_label(record["roadmap"])
     try:
         patch_body(repo, pr, record["new_body"])
@@ -358,7 +474,8 @@ def main(argv: list[str] | None = None) -> int:
         pr = record["pr"]
         try:
             if args.command in {"check", "dry-run"}:
-                check_current(args.repo, record, areas, applied=False)
+                state = check_current(args.repo, record, areas, applied=False)
+                verify_provenance(args.repo, record, areas, changed_files(state))
             elif args.command == "apply":
                 apply_record(args.repo, record, areas)
             else:

--- a/scripts/test_roadmap_label.py
+++ b/scripts/test_roadmap_label.py
@@ -39,7 +39,31 @@ INFRA = ["TauCeti/Foo.lean", ".github/workflows/x.yml"]  # trips the scope guard
 
 # (name, title, body, files, expected_label)
 CASES = [
-    # 1. citation resolves the area (real bodies, abbreviated) -----------------
+    # 1. explicit declaration is the preferred source --------------------------
+    ("explicit area", "refactor: share a proof",
+     "Roadmap: ContourIntegration", TC, "roadmap/ContourIntegration"),
+    ("explicit none", "refactor: share a general proof",
+     "Roadmap: none", TC, "roadmap/none"),
+    ("duplicate identical declaration", "refactor: share a proof",
+     "Roadmap: PDE\n\nRoadmap: PDE", TC, "roadmap/PDE"),
+    ("invalid explicit area", "refactor: share a proof",
+     "Roadmap: NotARoadmap", TC, "roadmap/Unknown"),
+    ("conflicting declarations", "refactor: share a proof",
+     "Roadmap: PDE\nRoadmap: ContourIntegration", TC, "roadmap/Unknown"),
+    ("fenced example ignored", "refactor: share a proof",
+     "```\nRoadmap: PDE\n```\nRoadmap: ContourIntegration", TC,
+     "roadmap/ContourIntegration"),
+    ("quoted example ignored", "refactor: share a proof",
+     "> Roadmap: PDE\nRoadmap: ContourIntegration", TC,
+     "roadmap/ContourIntegration"),
+
+    # 2. target markers and citations are compatibility sources ---------------
+    ("target marker", "refactor: share a proof",
+     '<!--tauceti-target:v1 {"focus":"PDE","id":"helper"}-->', TC,
+     "roadmap/PDE"),
+    ("invalid target marker ignored", "refactor: share a proof",
+     '<!--tauceti-target:v1 {"focus":"pde-helper","id":"helper"}-->', TC,
+     "roadmap/Unknown"),
     ("full path", "feat: add semigroup exponential shifts",
      "It advances TauCetiRoadmap/OneParameterSemigroups/README.md, Part A.", TC,
      "roadmap/OneParameterSemigroups"),
@@ -49,22 +73,36 @@ CASES = [
     ("suggested.lean path", "feat: add quotient comodules",
      "See TauCetiRoadmap/ReductiveGroups/Suggested.lean for the target.", TC,
      "roadmap/ReductiveGroups"),
+    ("matching declaration marker and citation", "feat: add theorem",
+     'Roadmap: PDE\nTauCetiRoadmap/PDE/README.md\n'
+     '<!--tauceti-target:v1 {"focus":"PDE","id":"target"}-->',
+     TC, "roadmap/PDE"),
+    ("declaration conflicts with citation", "feat: add theorem",
+     "Roadmap: PDE\nTauCetiRoadmap/ContourIntegration/README.md",
+     TC, "roadmap/Unknown"),
+    ("none conflicts with marker", "refactor: general cleanup",
+     'Roadmap: none\n<!--tauceti-target:v1 {"focus":"PDE","id":"target"}-->',
+     TC, "roadmap/Unknown"),
 
-    # 2. infra override wins even over a citation ------------------------------
+    # 3. infra and pin-only overrides ------------------------------------------
     ("infra beats citation", "feat: add roadmap CI",
      "advances TauCetiRoadmap/ContourIntegration/README.md", INFRA, "roadmap/none"),
     ("infra feat (website)", "feat: add site favicon", "", [".github/x", "web/y"],
      "roadmap/none"),
     ("empty diff", "feat: something", "advances TauCetiRoadmap/PDE/README.md", [],
      "roadmap/none"),
+    ("pin-only bump", "chore: forward bump", "",
+     ["lake-manifest.json", "lean-toolchain"], "roadmap/none"),
 
-    # 3. non-roadmap titles, no citation --------------------------------------
-    ("refactor", "refactor: move split into Cylinder.lean", "", TC, "roadmap/none"),
-    ("fix", "fix: drop the vacuous coe lemma", "", TC, "roadmap/none"),
+    # 4. a title never supplies roadmap evidence -------------------------------
+    ("refactor missing attribution", "refactor: move split into Cylinder.lean", "",
+     TC, "roadmap/Unknown"),
+    ("fix missing attribution", "fix: drop the vacuous coe lemma", "",
+     TC, "roadmap/Unknown"),
     ("mathlib bump", "chore: bump mathlib to 40b45a0, fix breaking changes", "",
-     ["TauCeti/A.lean", "lake-manifest.json", "lean-toolchain"], "roadmap/none"),
+     ["TauCeti/A.lean", "lake-manifest.json", "lean-toolchain"], "roadmap/Unknown"),
 
-    # 4. new mathematics, no parseable citation -> Unknown --------------------
+    # 5. missing or ambiguous evidence -> Unknown ------------------------------
     ("feat cites decl not file", "feat(Analysis/Contour): continuous argument lift",
      "Prerequisite for homologyCauchyTheorem (Dixon) and the residue theorem.", TC,
      "roadmap/Unknown"),
@@ -78,9 +116,6 @@ CASES = [
     ("multi-area citation", "feat: add thing",
      "spans TauCetiRoadmap/PDE/README.md and TauCetiRoadmap/Multiquadratic/README.md",
      TC, "roadmap/Unknown"),
-    # a refactor bump touching only the pins is allowed-set + non-roadmap title
-    ("pin-only bump", "chore: forward bump", "",
-     ["lake-manifest.json", "lean-toolchain"], "roadmap/none"),
 ]
 
 
@@ -95,8 +130,16 @@ def run_unit() -> int:
     # parse helper spot checks
     assert rl.parse_cited_areas("TauCetiRoadmap/PDE/README.md", AREAS) == {"PDE"}
     assert rl.parse_cited_areas("nothing here", AREAS) == set()
+    assert rl.parse_target_areas(
+        '<!--tauceti-target:v1 {"focus":"PDE","id":"x"}-->', AREAS
+    ) == {"PDE"}
+    assert rl.parse_declared_area("Roadmap: EffectiveBounds", AREAS) == (
+        True, "EffectiveBounds")
+    assert rl.parse_declared_area("nothing here", AREAS) == (False, None)
     assert rl.is_infra(["TauCeti/A.lean"]) is False
     assert rl.is_infra(["scripts/x.sh"]) is True
+    assert rl.is_pin_only(["lake-manifest.json", "lean-toolchain"]) is True
+    assert rl.is_pin_only(["TauCeti/A.lean", "lake-manifest.json"]) is False
 
     with tempfile.TemporaryDirectory() as tmp:
         root = pathlib.Path(tmp)

--- a/scripts/test_roadmap_label.py
+++ b/scripts/test_roadmap_label.py
@@ -17,8 +17,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import pathlib
 import subprocess
 import sys
+import tempfile
 
 import roadmap_label as rl
 
@@ -26,9 +28,10 @@ import roadmap_label as rl
 # checkout, but the unit tests pin it so they need no network.
 AREAS = {
     "CombinatorialHeegaardFloer", "ConformalMapping", "ContourIntegration",
-    "Exchangeability", "GeometricTopology", "HeegaardFloer", "JacobianChallenge",
+    "EffectiveBounds", "Exchangeability", "GeometricTopology", "HeegaardFloer",
+    "JacobianChallenge",
     "Multiquadratic", "OneParameterSemigroups", "OrthogonalL2Bases", "PDE",
-    "ReductiveGroups", "UniversalCovers",
+    "ReductiveGroups", "RepresentationTheory", "UniversalCovers",
 }
 
 TC = ["TauCeti/Analysis/Foo.lean"]        # an allowed (AI-ownable) math diff
@@ -94,6 +97,19 @@ def run_unit() -> int:
     assert rl.parse_cited_areas("nothing here", AREAS) == set()
     assert rl.is_infra(["TauCeti/A.lean"]) is False
     assert rl.is_infra(["scripts/x.sh"]) is True
+
+    with tempfile.TemporaryDirectory() as tmp:
+        root = pathlib.Path(tmp)
+        for directory in (
+            root / "TauCetiRoadmap" / "ContourIntegration",
+            root / "Completed" / "EffectiveBounds",
+        ):
+            directory.mkdir(parents=True)
+            (directory / "README.md").touch()
+        # The archive container has a README of its own, but is not an area.
+        (root / "Completed" / "README.md").touch()
+        assert rl.canonical_areas(root) == {"ContourIntegration", "EffectiveBounds"}
+
     print(f"\n{len(CASES) - fails}/{len(CASES)} classifier cases passed")
     return 1 if fails else 0
 

--- a/scripts/test_roadmap_refactor_backfill.py
+++ b/scripts/test_roadmap_refactor_backfill.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Pure unit tests for the reversible refactor-roadmap migration."""
+
+import unittest
+from unittest import mock
+
+import roadmap_refactor_backfill as migration
+
+
+class BodyInsertion(unittest.TestCase):
+    def test_inserts_before_codex_footer_without_changing_prefix(self):
+        body = "This PR does a thing.\n\n:robot: Prepared with OpenAI Codex\n"
+        expected = (
+            "This PR does a thing.\n\nRoadmap: PDE\n\n"
+            ":robot: Prepared with OpenAI Codex\n"
+        )
+        self.assertEqual(migration.insert_roadmap_line(body, "PDE"), expected)
+
+    def test_inserts_before_claude_footer_and_preserves_marker(self):
+        marker = '<!--tauceti-target:v1 {"focus":"PDE","id":"x"}-->'
+        body = f"This PR does a thing.\r\n\r\n{marker}\r\n\r\n🤖 Prepared with Claude Code"
+        result = migration.insert_roadmap_line(body, "PDE")
+        self.assertIn(marker, result)
+        self.assertEqual(result.count(marker), 1)
+        self.assertTrue(result.endswith("🤖 Prepared with Claude Code"))
+        self.assertIn("\r\nRoadmap: PDE\r\n\r\n🤖", result)
+
+    def test_appends_without_footer(self):
+        self.assertEqual(
+            migration.insert_roadmap_line("This PR does a thing.", "PDE"),
+            "This PR does a thing.\n\nRoadmap: PDE",
+        )
+
+    def test_existing_matching_line_is_idempotent(self):
+        body = "This PR does a thing.\n\nRoadmap: PDE"
+        self.assertEqual(migration.insert_roadmap_line(body, "PDE"), body)
+
+    def test_existing_other_line_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "already contains"):
+            migration.insert_roadmap_line("Roadmap: none", "PDE")
+
+
+class ManifestValidation(unittest.TestCase):
+    def record(self):
+        old = "This PR does a thing."
+        new = "This PR does a thing.\n\nRoadmap: PDE"
+        return {
+            "pr": 1,
+            "roadmap": "PDE",
+            "roadmap_file": "TauCetiRoadmap/PDE/README.md",
+            "roadmap_heading": "Lane A",
+            "roadmap_quote": "Build the estimate.",
+            "provenance": ["#2"],
+            "title": "refactor: share the estimate",
+            "old_body": old,
+            "old_body_sha256": migration.body_hash(old),
+            "old_roadmap_labels": ["roadmap/none"],
+            "new_body": new,
+            "new_body_sha256": migration.body_hash(new),
+        }
+
+    def test_valid_record(self):
+        migration.validate_manifest_record(self.record(), {"PDE"})
+
+    def test_tampered_body_fails(self):
+        record = self.record()
+        record["new_body"] += " changed"
+        with self.assertRaisesRegex(ValueError, "new body hash"):
+            migration.validate_manifest_record(record, {"PDE"})
+
+    def test_requires_evidence(self):
+        record = self.record()
+        record["roadmap_quote"] = ""
+        with self.assertRaisesRegex(ValueError, "roadmap_quote"):
+            migration.validate_manifest_record(record, {"PDE"})
+
+    def test_tranche_limit(self):
+        with self.assertRaisesRegex(ValueError, "between 1 and 20"):
+            migration.select_tranche([], 0, 21)
+
+    def test_revert_checks_applied_state_then_restores(self):
+        record = self.record()
+        with (
+            mock.patch.object(migration, "check_current") as check,
+            mock.patch.object(migration, "restore_record") as restore,
+        ):
+            migration.revert_record("owner/repo", record, {"PDE"})
+        self.assertEqual(
+            check.call_args_list,
+            [
+                mock.call("owner/repo", record, {"PDE"}, applied=True),
+                mock.call("owner/repo", record, {"PDE"}, applied=False),
+            ],
+        )
+        restore.assert_called_once_with("owner/repo", record, {"PDE"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_roadmap_refactor_backfill.py
+++ b/scripts/test_roadmap_refactor_backfill.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Pure unit tests for the reversible refactor-roadmap migration."""
 
+import pathlib
+import tempfile
 import unittest
 from unittest import mock
 
@@ -41,6 +43,19 @@ class BodyInsertion(unittest.TestCase):
 
 
 class ManifestValidation(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.roadmap_dir = pathlib.Path(self.temp.name)
+        roadmap = self.roadmap_dir / "TauCetiRoadmap" / "PDE"
+        roadmap.mkdir(parents=True)
+        (roadmap / "README.md").write_text(
+            "# PDE\n\n## Lane A\n\nBuild the estimate.\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self):
+        self.temp.cleanup()
+
     def record(self):
         old = "This PR does a thing."
         new = "This PR does a thing.\n\nRoadmap: PDE"
@@ -60,19 +75,31 @@ class ManifestValidation(unittest.TestCase):
         }
 
     def test_valid_record(self):
-        migration.validate_manifest_record(self.record(), {"PDE"})
+        migration.validate_manifest_record(self.record(), {"PDE"}, self.roadmap_dir)
 
     def test_tampered_body_fails(self):
         record = self.record()
         record["new_body"] += " changed"
         with self.assertRaisesRegex(ValueError, "new body hash"):
-            migration.validate_manifest_record(record, {"PDE"})
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
 
     def test_requires_evidence(self):
         record = self.record()
         record["roadmap_quote"] = ""
         with self.assertRaisesRegex(ValueError, "roadmap_quote"):
-            migration.validate_manifest_record(record, {"PDE"})
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_evidence_must_resolve_in_the_declared_roadmap(self):
+        record = self.record()
+        record["roadmap_heading"] = "Lane B"
+        with self.assertRaisesRegex(ValueError, "exact Markdown heading"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_evidence_path_cannot_escape_checkout(self):
+        record = self.record()
+        record["roadmap_file"] = "../README.md"
+        with self.assertRaisesRegex(ValueError, "stay inside"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
 
     def test_tranche_limit(self):
         with self.assertRaisesRegex(ValueError, "between 1 and 20"):

--- a/scripts/test_roadmap_refactor_backfill.py
+++ b/scripts/test_roadmap_refactor_backfill.py
@@ -49,7 +49,10 @@ class ManifestValidation(unittest.TestCase):
         roadmap = self.roadmap_dir / "TauCetiRoadmap" / "PDE"
         roadmap.mkdir(parents=True)
         (roadmap / "README.md").write_text(
-            "# PDE\n\n## Lane A\n\nBuild the estimate.\n",
+            "# PDE\n\n"
+            "```sh\n#949 not a heading\n```\n\n"
+            "## Lane A\n\nBuild the estimate.\n\n"
+            "## Lane B\n\nSharpen the constant.\n",
             encoding="utf-8",
         )
 
@@ -96,8 +99,33 @@ class ManifestValidation(unittest.TestCase):
 
     def test_evidence_must_resolve_in_the_declared_roadmap(self):
         record = self.record()
-        record["roadmap_heading"] = "Lane B"
+        record["roadmap_heading"] = "Lane Z"
         with self.assertRaisesRegex(ValueError, "exact Markdown heading"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_quote_from_another_section_is_rejected(self):
+        record = self.record()
+        record["roadmap_quote"] = "Sharpen the constant."
+        with self.assertRaisesRegex(ValueError, "under the cited roadmap_heading"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_fenced_hash_line_is_not_a_heading(self):
+        record = self.record()
+        record["roadmap_heading"] = "949 not a heading"
+        record["roadmap_quote"] = "Build the estimate."
+        with self.assertRaisesRegex(ValueError, "exact Markdown heading"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_free_text_provenance_is_rejected(self):
+        record = self.record()
+        record["provenance"] = ["garbage"]
+        with self.assertRaisesRegex(ValueError, "not a #N or pull-request URL"):
+            migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
+    def test_provenance_cannot_cite_the_migrated_pr(self):
+        record = self.record()
+        record["provenance"] = ["#1"]
+        with self.assertRaisesRegex(ValueError, "cannot cite the PR being migrated"):
             migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
 
     def test_evidence_path_cannot_escape_checkout(self):
@@ -125,6 +153,54 @@ class ManifestValidation(unittest.TestCase):
             ],
         )
         restore.assert_called_once_with("owner/repo", record, {"PDE"})
+
+
+class ProvenanceResolution(unittest.TestCase):
+    """`verify_provenance` is what stops a citation from being mere assertion."""
+
+    def record(self, provenance=("#2",)):
+        return {"pr": 1, "roadmap": "PDE", "provenance": list(provenance)}
+
+    def source(self, **overrides):
+        state = {
+            "state": "MERGED",
+            "title": "feat: build the estimate",
+            "body": "This PR builds it.\n\nRoadmap: PDE",
+            "files": [{"path": "TauCeti/PDE/Estimate.lean"}],
+            "labels": [{"name": "roadmap/PDE"}],
+        }
+        state.update(overrides)
+        return state
+
+    def verify(self, state, target=("TauCeti/PDE/Estimate.lean",), provenance=("#2",)):
+        with mock.patch.object(migration, "pr_state", return_value=state):
+            migration.verify_provenance(
+                "owner/repo", self.record(provenance), {"PDE"}, list(target))
+
+    def test_merged_same_area_overlapping_pr_is_accepted(self):
+        self.verify(self.source())
+
+    def test_label_alone_suffices_when_the_body_predates_declarations(self):
+        self.verify(self.source(body="This PR builds it."))
+
+    def test_pr_attributed_elsewhere_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "not attributed to PDE"):
+            self.verify(self.source(body="Roadmap: none", labels=[]))
+
+    def test_unmerged_pr_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "not merged"):
+            self.verify(self.source(state="OPEN"))
+
+    def test_pr_sharing_no_file_with_the_target_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "does not connect it to PDE"):
+            self.verify(self.source(), target=("TauCeti/Other/Thing.lean",))
+
+    def test_foreign_repository_reference_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "not a owner/repo pull request"):
+            self.verify(
+                self.source(),
+                provenance=("https://github.com/other/repo/pull/2",),
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/test_roadmap_refactor_backfill.py
+++ b/scripts/test_roadmap_refactor_backfill.py
@@ -77,6 +77,11 @@ class ManifestValidation(unittest.TestCase):
     def test_valid_record(self):
         migration.validate_manifest_record(self.record(), {"PDE"}, self.roadmap_dir)
 
+    def test_matching_existing_area_label_is_valid_rollback_state(self):
+        record = self.record()
+        record["old_roadmap_labels"] = ["roadmap/PDE"]
+        migration.validate_manifest_record(record, {"PDE"}, self.roadmap_dir)
+
     def test_tampered_body_fails(self):
         record = self.record()
         record["new_body"] += " changed"


### PR DESCRIPTION
This PR adds a reversible, manifest-driven migration command for selected historical refactor PRs. It captures verbatim rollback state and either the existing `roadmap/none` or matching area label, requires target and provenance evidence, verifies each cited roadmap file, exact Markdown heading, and quote against a checkout, checks body hashes, reuses the production classifier after editing, limits application to 20-PR tranches, and restores the prior body and label on failure.

Depends on #1543. Apply historical edits only after #1541 has landed, so roadmap-attributed maintenance remains excluded from the new-mathematics chart.

Tested with 13 migration unit tests, the 26 classifier cases, and read-only prepare/dry-runs over three evidence-backed tranches containing 47 historical refactor PRs, including #1522.

Roadmap: none

:robot: Prepared with OpenAI Codex