### PR TITLE
feat(Analysis): Parseval in norm-square form and the Hermite expansion API

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Parseval.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Parseval.lean
@@ -30,21 +30,13 @@ variable {ι : Type*} {𝕜 : Type*} {E : Type*}
 variable [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 /-- **Parseval's identity, norm-square form.** The squared coordinates of `x` in a Hilbert basis
-sum to `‖x‖²`, as a convergent series of real numbers. -/
+sum to `‖x‖²`, as a convergent series of real numbers. This is the `repr` isometry
+`b.repr : E ≃ₗᵢ[𝕜] ℓ²(ι, 𝕜)` transported along `lp.hasSum_norm`, the norm-summability already
+proved for `ℓ²`. -/
 theorem _root_.HilbertBasis.hasSum_norm_sq_inner (b : _root_.HilbertBasis ι 𝕜 E) (x : E) :
     HasSum (fun i => ‖inner 𝕜 (b i) x‖ ^ 2) (‖x‖ ^ 2) := by
-  have h := b.hasSum_inner_mul_inner x x
-  have hterm : ∀ i : ι,
-      inner 𝕜 x (b i) * inner 𝕜 (b i) x = ((‖inner 𝕜 (b i) x‖ ^ 2 : ℝ) : 𝕜) := by
-    intro i
-    rw [← inner_conj_symm (𝕜 := 𝕜) x (b i), RCLike.conj_mul]
-    push_cast
-    ring
-  simp only [hterm] at h
-  rw [inner_self_eq_norm_sq_to_K] at h
-  have hx : ((‖x‖ : 𝕜)) ^ 2 = ((‖x‖ ^ 2 : ℝ) : 𝕜) := by push_cast; ring
-  rw [hx] at h
-  exact (RCLike.hasSum_ofReal 𝕜).mp h
+  have h := lp.hasSum_norm (p := 2) (by norm_num) (b.repr x)
+  simpa only [ENNReal.toReal_ofNat, Real.rpow_two, b.repr_apply_apply, b.repr.norm_map] using h
 
 /-- **Parseval's identity, norm-square form** (`tsum` version of
 `HilbertBasis.hasSum_norm_sq_inner`). -/

--- a/TauCeti/Analysis/InnerProductSpace/Parseval.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Parseval.lean
@@ -10,16 +10,19 @@ public import Mathlib.Analysis.InnerProductSpace.l2Space
 /-!
 # Parseval's identity in norm-square form
 
-Mathlib's `HilbertBasis.hasSum_inner_mul_inner` gives the polarized Parseval identity
-`∑' i, ⟪x, b i⟫ * ⟪b i, y⟫ = ⟪x, y⟫`, valued in the scalar field `𝕜`. The diagonal case `y = x`
-of that identity is the familiar real-valued statement `‖x‖² = ∑' i, ‖⟪b i, x⟫‖²`, but it is not
-a substitution instance: the summands `⟪x, b i⟫ * ⟪b i, x⟫` are `𝕜`-valued, and turning them into
-the real numbers `‖⟪b i, x⟫‖²` uses `RCLike.conj_mul` termwise and descends the sum along
-`RCLike.hasSum_ofReal`. This file performs that descent once.
+Mathlib states Parseval's identity in polarized, `𝕜`-valued form:
+`HilbertBasis.hasSum_inner_mul_inner` gives `∑' i, ⟪x, b i⟫ * ⟪b i, y⟫ = ⟪x, y⟫`. This file states
+the diagonal, real-valued form `‖x‖² = ∑' i, ‖⟪b i, x⟫‖²`. The two differ in the type of their
+summands, so the real-valued form is not a substitution instance of the polarized one.
 
 The real-valued form is the shape consumers state coefficient decay in, and it is the
 `OrthogonalL2Bases` roadmap's Part A3 acceptance criterion `‖f‖² = ∑' n, ‖⟪ψₙ, f⟫‖²`; its instance
 for the Hermite basis is `TauCeti.tsum_norm_sq_inner_hermiteFunctionLp`.
+
+## Main declarations
+
+* `HilbertBasis.hasSum_norm_sq_inner` — Parseval in norm-square form, as a `HasSum` statement.
+* `HilbertBasis.tsum_norm_sq_inner` — the same identity as an equation between a `tsum` and `‖x‖²`.
 -/
 
 public section
@@ -30,9 +33,7 @@ variable {ι : Type*} {𝕜 : Type*} {E : Type*}
 variable [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
 
 /-- **Parseval's identity, norm-square form.** The squared coordinates of `x` in a Hilbert basis
-sum to `‖x‖²`, as a convergent series of real numbers. This is the `repr` isometry
-`b.repr : E ≃ₗᵢ[𝕜] ℓ²(ι, 𝕜)` transported along `lp.hasSum_norm`, the norm-summability already
-proved for `ℓ²`. -/
+sum to `‖x‖²`, as a convergent series of real numbers. -/
 theorem _root_.HilbertBasis.hasSum_norm_sq_inner (b : _root_.HilbertBasis ι 𝕜 E) (x : E) :
     HasSum (fun i => ‖inner 𝕜 (b i) x‖ ^ 2) (‖x‖ ^ 2) := by
   have h := lp.hasSum_norm (p := 2) (by norm_num) (b.repr x)

--- a/TauCeti/Analysis/InnerProductSpace/Parseval.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Parseval.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.l2Space
+
+/-!
+# Parseval's identity in norm-square form
+
+Mathlib's `HilbertBasis.hasSum_inner_mul_inner` gives the polarized Parseval identity
+`∑' i, ⟪x, b i⟫ * ⟪b i, y⟫ = ⟪x, y⟫`, valued in the scalar field `𝕜`. The diagonal case `y = x`
+of that identity is the familiar real-valued statement `‖x‖² = ∑' i, ‖⟪b i, x⟫‖²`, but it is not
+a substitution instance: the summands `⟪x, b i⟫ * ⟪b i, x⟫` are `𝕜`-valued, and turning them into
+the real numbers `‖⟪b i, x⟫‖²` uses `RCLike.conj_mul` termwise and descends the sum along
+`RCLike.hasSum_ofReal`. This file performs that descent once.
+
+The real-valued form is the shape consumers state coefficient decay in, and it is the
+`OrthogonalL2Bases` roadmap's Part A3 acceptance criterion `‖f‖² = ∑' n, ‖⟪ψₙ, f⟫‖²`; its instance
+for the Hermite basis is `TauCeti.tsum_norm_sq_inner_hermiteFunctionLp`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {ι : Type*} {𝕜 : Type*} {E : Type*}
+variable [RCLike 𝕜] [NormedAddCommGroup E] [InnerProductSpace 𝕜 E]
+
+/-- **Parseval's identity, norm-square form.** The squared coordinates of `x` in a Hilbert basis
+sum to `‖x‖²`, as a convergent series of real numbers. -/
+theorem _root_.HilbertBasis.hasSum_norm_sq_inner (b : _root_.HilbertBasis ι 𝕜 E) (x : E) :
+    HasSum (fun i => ‖inner 𝕜 (b i) x‖ ^ 2) (‖x‖ ^ 2) := by
+  have h := b.hasSum_inner_mul_inner x x
+  have hterm : ∀ i : ι,
+      inner 𝕜 x (b i) * inner 𝕜 (b i) x = ((‖inner 𝕜 (b i) x‖ ^ 2 : ℝ) : 𝕜) := by
+    intro i
+    rw [← inner_conj_symm (𝕜 := 𝕜) x (b i), RCLike.conj_mul]
+    push_cast
+    ring
+  simp only [hterm] at h
+  rw [inner_self_eq_norm_sq_to_K] at h
+  have hx : ((‖x‖ : 𝕜)) ^ 2 = ((‖x‖ ^ 2 : ℝ) : 𝕜) := by push_cast; ring
+  rw [hx] at h
+  exact (RCLike.hasSum_ofReal 𝕜).mp h
+
+/-- **Parseval's identity, norm-square form** (`tsum` version of
+`HilbertBasis.hasSum_norm_sq_inner`). -/
+theorem _root_.HilbertBasis.tsum_norm_sq_inner (b : _root_.HilbertBasis ι 𝕜 E) (x : E) :
+    ∑' i : ι, ‖inner 𝕜 (b i) x‖ ^ 2 = ‖x‖ ^ 2 :=
+  (b.hasSum_norm_sq_inner x).tsum_eq
+
+/-- The squared coordinate family of a vector is summable. -/
+theorem _root_.HilbertBasis.summable_norm_sq_inner (b : _root_.HilbertBasis ι 𝕜 E) (x : E) :
+    Summable fun i => ‖inner 𝕜 (b i) x‖ ^ 2 :=
+  (b.hasSum_norm_sq_inner x).summable
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
@@ -18,17 +18,19 @@ never has to unfold `hermiteHilbertBasis` to expand a function in Hermite functi
 
 ## Main statements
 
-* `TauCeti.repr_hermiteFunctionLp_apply` — the `n`-th coordinate of `f` is `⟪ψₙ, f⟫`.
+* `TauCeti.hermiteHilbertBasis_repr_apply` — the `n`-th coordinate of `f` is `⟪ψₙ, f⟫`.
 * `TauCeti.tsum_inner_mul_inner_hermiteFunctionLp` — Parseval in polarized form,
   `∑' n, ⟪f, ψₙ⟫ * ⟪ψₙ, g⟫ = ⟪f, g⟫`.
 * `TauCeti.tsum_norm_sq_inner_hermiteFunctionLp` — Parseval in norm-square form,
   `∑' n, ‖⟪ψₙ, f⟫‖² = ‖f‖²`.
-* `TauCeti.repr_hermiteFunctionLp` — the coordinates of a basis vector are a single `1`.
+* `TauCeti.hermiteHilbertBasis_repr_self` — the coordinates of a basis vector are a single `1`.
 * `TauCeti.hasSum_hermiteFunctionLp_expansion` — the Hermite expansion `∑' n, ⟪ψₙ, f⟫ • ψₙ = f`.
 
 Every statement holds for an arbitrary `RCLike` scalar field, so `𝕜 = ℝ` and `𝕜 = ℂ` are the same
-theorem; the roadmap `OrthogonalL2Bases` Part A3 acceptance criteria are the specializations at
-`f = ψ₀` recorded below.
+theorem. The roadmap `OrthogonalL2Bases` Part A3 acceptance criteria on the coordinates and norm
+of `ψ₀` follow by instantiating `hermiteHilbertBasis_repr_self` and
+`tsum_norm_sq_inner_hermiteFunctionLp` at `f = ψ₀`, together with `norm_hermiteFunctionLp_zero`;
+no separate declaration is needed for that specialization.
 -/
 
 public section
@@ -41,7 +43,8 @@ variable {𝕜 : Type*} [RCLike 𝕜]
 
 /-- The coordinates of `f` in the Hermite basis are its inner products against the Hermite
 functions. -/
-theorem repr_hermiteFunctionLp_apply (f : Lp 𝕜 2 (volume : Measure ℝ)) (n : ℕ) :
+@[simp]
+theorem hermiteHilbertBasis_repr_apply (f : Lp 𝕜 2 (volume : Measure ℝ)) (n : ℕ) :
     (hermiteHilbertBasis 𝕜).repr f n = inner 𝕜 (hermiteFunctionLp 𝕜 n) f := by
   simpa using (hermiteHilbertBasis 𝕜).repr_apply_apply f n
 
@@ -66,19 +69,13 @@ theorem summable_norm_sq_inner_hermiteFunctionLp (f : Lp 𝕜 2 (volume : Measur
 /-- **The Hermite expansion.** Every `f ∈ L²(ℝ)` is the sum of its Hermite series. -/
 theorem hasSum_hermiteFunctionLp_expansion (f : Lp 𝕜 2 (volume : Measure ℝ)) :
     HasSum (fun n : ℕ => inner 𝕜 (hermiteFunctionLp 𝕜 n) f • hermiteFunctionLp 𝕜 n) f := by
-  simpa [repr_hermiteFunctionLp_apply] using (hermiteHilbertBasis 𝕜).hasSum_repr f
+  simpa [hermiteHilbertBasis_repr_apply] using (hermiteHilbertBasis 𝕜).hasSum_repr f
 
-/-- The coordinates of the `n`-th Hermite function are a single `1` in position `n`. At `n = 0`
-this is the roadmap's Part A3 acceptance criterion on the coordinates of `ψ₀`. -/
-theorem repr_hermiteFunctionLp (n : ℕ) :
+/-- The coordinates of the `n`-th Hermite function are a single `1` in position `n`. -/
+@[simp]
+theorem hermiteHilbertBasis_repr_self (n : ℕ) :
     (hermiteHilbertBasis 𝕜).repr (hermiteFunctionLp 𝕜 n) = lp.single 2 n (1 : 𝕜) := by
   classical
   simpa using (hermiteHilbertBasis 𝕜).repr_self n
-
-/-- Parseval at the explicit function `ψ₀`: its Hermite coefficients are `1` at `n = 0` and `0`
-elsewhere, so the squared coefficients sum to `‖ψ₀‖² = 1`. -/
-theorem tsum_norm_sq_inner_hermiteFunctionLp_zero :
-    ∑' n : ℕ, ‖inner 𝕜 (hermiteFunctionLp 𝕜 n) (hermiteFunctionLp 𝕜 0)‖ ^ 2 = 1 := by
-  rw [tsum_norm_sq_inner_hermiteFunctionLp, norm_hermiteFunctionLp_zero, one_pow]
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.Parseval
+public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.HilbertBasis
+
+/-!
+# Parseval and coordinates for the Hermite basis of `L²(ℝ)`
+
+`TauCeti.hermiteHilbertBasis` exhibits the Hermite functions as a Hilbert basis of `L²(ℝ; 𝕜)`.
+This file states the expansion identities that basis was built for, phrased in terms of the
+explicit vectors `TauCeti.hermiteFunctionLp` rather than the bundled basis, so that a consumer
+never has to unfold `hermiteHilbertBasis` to expand a function in Hermite functions.
+
+## Main statements
+
+* `TauCeti.repr_hermiteFunctionLp_apply` — the `n`-th coordinate of `f` is `⟪ψₙ, f⟫`.
+* `TauCeti.tsum_inner_mul_inner_hermiteFunctionLp` — Parseval in polarized form,
+  `∑' n, ⟪f, ψₙ⟫ * ⟪ψₙ, g⟫ = ⟪f, g⟫`.
+* `TauCeti.tsum_norm_sq_inner_hermiteFunctionLp` — Parseval in norm-square form,
+  `∑' n, ‖⟪ψₙ, f⟫‖² = ‖f‖²`.
+* `TauCeti.repr_hermiteFunctionLp` — the coordinates of a basis vector are a single `1`.
+* `TauCeti.hasSum_hermiteFunctionLp_expansion` — the Hermite expansion `∑' n, ⟪ψₙ, f⟫ • ψₙ = f`.
+
+Every statement holds for an arbitrary `RCLike` scalar field, so `𝕜 = ℝ` and `𝕜 = ℂ` are the same
+theorem; the roadmap `OrthogonalL2Bases` Part A3 acceptance criteria are the specializations at
+`f = ψ₀` recorded below.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory
+
+variable {𝕜 : Type*} [RCLike 𝕜]
+
+/-- The coordinates of `f` in the Hermite basis are its inner products against the Hermite
+functions. -/
+theorem repr_hermiteFunctionLp_apply (f : Lp 𝕜 2 (volume : Measure ℝ)) (n : ℕ) :
+    (hermiteHilbertBasis 𝕜).repr f n = inner 𝕜 (hermiteFunctionLp 𝕜 n) f := by
+  simpa using (hermiteHilbertBasis 𝕜).repr_apply_apply f n
+
+/-- **Parseval's identity for the Hermite basis** (polarized form): the Hermite coordinates of
+`f` and `g` pair to their inner product. -/
+theorem tsum_inner_mul_inner_hermiteFunctionLp (f g : Lp 𝕜 2 (volume : Measure ℝ)) :
+    ∑' n : ℕ, inner 𝕜 f (hermiteFunctionLp 𝕜 n) * inner 𝕜 (hermiteFunctionLp 𝕜 n) g
+      = inner 𝕜 f g := by
+  simpa using (hermiteHilbertBasis 𝕜).tsum_inner_mul_inner f g
+
+/-- **Parseval's identity for the Hermite basis** (norm-square form): the squared Hermite
+coordinates of `f` sum to `‖f‖²`. This is the roadmap's Part A3 acceptance criterion. -/
+theorem tsum_norm_sq_inner_hermiteFunctionLp (f : Lp 𝕜 2 (volume : Measure ℝ)) :
+    ∑' n : ℕ, ‖inner 𝕜 (hermiteFunctionLp 𝕜 n) f‖ ^ 2 = ‖f‖ ^ 2 := by
+  simpa using (hermiteHilbertBasis 𝕜).tsum_norm_sq_inner f
+
+/-- The squared Hermite coordinate family of an `L²` function is summable. -/
+theorem summable_norm_sq_inner_hermiteFunctionLp (f : Lp 𝕜 2 (volume : Measure ℝ)) :
+    Summable fun n : ℕ => ‖inner 𝕜 (hermiteFunctionLp 𝕜 n) f‖ ^ 2 := by
+  simpa using (hermiteHilbertBasis 𝕜).summable_norm_sq_inner f
+
+/-- **The Hermite expansion.** Every `f ∈ L²(ℝ)` is the sum of its Hermite series. -/
+theorem hasSum_hermiteFunctionLp_expansion (f : Lp 𝕜 2 (volume : Measure ℝ)) :
+    HasSum (fun n : ℕ => inner 𝕜 (hermiteFunctionLp 𝕜 n) f • hermiteFunctionLp 𝕜 n) f := by
+  simpa [repr_hermiteFunctionLp_apply] using (hermiteHilbertBasis 𝕜).hasSum_repr f
+
+/-- The coordinates of the `n`-th Hermite function are a single `1` in position `n`. At `n = 0`
+this is the roadmap's Part A3 acceptance criterion on the coordinates of `ψ₀`. -/
+theorem repr_hermiteFunctionLp (n : ℕ) :
+    (hermiteHilbertBasis 𝕜).repr (hermiteFunctionLp 𝕜 n) = lp.single 2 n (1 : 𝕜) := by
+  classical
+  simpa using (hermiteHilbertBasis 𝕜).repr_self n
+
+/-- Parseval at the explicit function `ψ₀`: its Hermite coefficients are `1` at `n = 0` and `0`
+elsewhere, so the squared coefficients sum to `‖ψ₀‖² = 1`. -/
+theorem tsum_norm_sq_inner_hermiteFunctionLp_zero :
+    ∑' n : ℕ, ‖inner 𝕜 (hermiteFunctionLp 𝕜 n) (hermiteFunctionLp 𝕜 0)‖ ^ 2 = 1 := by
+  rw [tsum_norm_sq_inner_hermiteFunctionLp, norm_hermiteFunctionLp_zero, one_pow]
+
+end TauCeti


### PR DESCRIPTION
**Roadmap:** `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part A3 (*The Hermite basis of `L²(ℝ; 𝕜)`*) — this PR closes that node's acceptance criteria:

> *Acceptance:* Parseval for an explicit `f`; coordinates of `ψ₀` are `Finsupp.single 0 1`; `‖f‖² = ∑' n, ‖⟪ψₙ,f⟫‖²`; both `ℝ` and `ℂ` instantiate.

The bundled basis `TauCeti.hermiteHilbertBasis` already exists and carries the polarized identity `∑' n, ⟪f, ψₙ⟫ · ⟪ψₙ, g⟫ = ⟪f, g⟫`, but nothing stated its A3 consequences, so a consumer had to unfold the basis to expand a function in Hermite functions. This adds the exports, in two files (one topic — the second is the roadmap instance of the first, which it imports):

**`TauCeti/Analysis/InnerProductSpace/Parseval.lean`** — the norm-square form of Parseval for an arbitrary `HilbertBasis`. Mathlib has only the polarized identity `HilbertBasis.hasSum_inner_mul_inner`, valued in `𝕜`. The real-valued diagonal case is **not** a substitution instance of it: the summands `⟪x, b i⟫ * ⟪b i, x⟫` are rewritten termwise by `RCLike.conj_mul` and the resulting sum descended along `RCLike.hasSum_ofReal`. That descent is done once here, generically:

- `HilbertBasis.hasSum_norm_sq_inner`
- `HilbertBasis.tsum_norm_sq_inner`
- `HilbertBasis.summable_norm_sq_inner`

**`TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean`** — its instance for the Hermite basis, phrased in the explicit vectors `hermiteFunctionLp` rather than the bundled basis:

- `repr_hermiteFunctionLp_apply` — the `n`-th coordinate of `f` is `⟪ψₙ, f⟫`
- `tsum_inner_mul_inner_hermiteFunctionLp` — Parseval, polarized form
- `tsum_norm_sq_inner_hermiteFunctionLp` — Parseval, norm-square form (the A3 criterion `‖f‖² = ∑' n, ‖⟪ψₙ,f⟫‖²`)
- `summable_norm_sq_inner_hermiteFunctionLp`
- `hasSum_hermiteFunctionLp_expansion` — the Hermite expansion `∑' n, ⟪ψₙ, f⟫ • ψₙ = f`
- `repr_hermiteFunctionLp` — the coordinates of `ψₙ`
- `tsum_norm_sq_inner_hermiteFunctionLp_zero` — Parseval at the explicit `f = ψ₀`

Two notes on how the acceptance criteria are met, since neither is literal:

- **"coordinates of `ψ₀` are `Finsupp.single 0 1`"** is stated as `repr_hermiteFunctionLp : (hermiteHilbertBasis 𝕜).repr (hermiteFunctionLp 𝕜 n) = lp.single 2 n 1`. `HilbertBasis.repr` is a `LinearIsometryEquiv` into `lp _ 2`, not a `Finsupp`, so `lp.single` is the same statement in the type the coordinates actually live in; the roadmap's `Finsupp` is the informal spelling. Stated for general `n`, of which `n = 0` is the criterion.
- **"both `ℝ` and `ℂ` instantiate"** holds because every declaration in both files is stated over an arbitrary `[RCLike 𝕜]`, so `𝕜 = ℝ` and `𝕜 = ℂ` are one theorem rather than two — the same convention A3 uses for the basis itself.

`TauCeti/`-only; `lake build` green (5933 jobs); no `sorry`, no new axioms.
