### PR TITLE
refactor(Analysis): name the affine-isometry decomposition shared by Δ and harmonicity

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Isometry.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Isometry.lean
@@ -102,16 +102,10 @@ theorem harmonicAt_comp_add_right_iff {f : E → F} {x a : E} :
 `e`, the function `f ∘ e` is harmonic at `x` iff `f` is harmonic at `e x`. -/
 theorem harmonicAt_comp_affineIsometryEquiv_right_iff (e : E ≃ᵃⁱ[ℝ] E') {f : E' → F}
     {x : E} : HarmonicAt (f ∘ e) x ↔ HarmonicAt f (e x) := by
-  have hcomp : f ∘ e = (fun y ↦ f (y + e 0)) ∘ e.linearIsometryEquiv := by
-    funext y
-    have hy : e y = e.linearIsometryEquiv y + e 0 := by
-      simpa using e.map_vadd (0 : E) y
-    simp [Function.comp_apply, hy]
-  rw [hcomp, harmonicAt_comp_linearIsometryEquiv_right_iff e.linearIsometryEquiv,
-    harmonicAt_comp_add_right_iff]
-  have hx : e x = e.linearIsometryEquiv x + e 0 := by
-    simpa using e.map_vadd (0 : E) x
-  rw [← hx]
+  rw [comp_affineIsometryEquiv_eq_comp_linearIsometryEquiv e f,
+    harmonicAt_comp_linearIsometryEquiv_right_iff e.linearIsometryEquiv,
+    harmonicAt_comp_add_right_iff,
+    ← affineIsometryEquiv_apply_eq_linearIsometryEquiv_add e x]
 
 /-- Harmonicity on a neighbourhood of a set is invariant under an affine isometry equivalence. -/
 theorem harmonicOnNhd_comp_affineIsometryEquiv_right_iff (e : E ≃ᵃⁱ[ℝ] E') {f : E' → F}

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/Basic.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/Basic.lean
@@ -43,6 +43,11 @@ The file also records the base second-derivative computation `laplacian_norm_sq`
 
 ## Main declarations
 
+* `TauCeti.affineIsometryEquiv_apply_eq_linearIsometryEquiv_add` and
+  `TauCeti.comp_affineIsometryEquiv_eq_comp_linearIsometryEquiv`: an affine isometry equivalence
+  is its linear part translated by its value at the origin, and the resulting factorisation of
+  right composition. These are what reduce the affine case below to the linear and translation
+  cases, and the companion harmonicity file uses them for the same reduction.
 * `TauCeti.laplacian_comp_affineIsometryEquiv_right`: `Δ (f ∘ e) = (Δ f) ∘ e` for an
   affine isometry equivalence `e`.
 * `TauCeti.laplacian_comp_linearIsometryEquiv_right`: `Δ (f ∘ l) = (Δ f) ∘ l` for an
@@ -110,23 +115,40 @@ theorem laplacian_comp_add_right (f : E → F) (a : E) :
   refine Finset.sum_congr rfl fun i _ ↦ ?_
   rw [iteratedFDeriv_comp_add_right']
 
+section AffineIsometryDecomposition
+
+variable {V W : Type*} [NormedAddCommGroup V] [NormedSpace ℝ V]
+  [NormedAddCommGroup W] [NormedSpace ℝ W]
+
+/-- **An affine isometry equivalence is its linear part translated by its value at the origin**:
+`e x = e.linearIsometryEquiv x + e 0`. This is `AffineIsometryEquiv.map_vadd` read at the base
+point `0`, where the `+ᵥ` action of a normed space on itself is addition. -/
+theorem affineIsometryEquiv_apply_eq_linearIsometryEquiv_add (e : V ≃ᵃⁱ[ℝ] W) (x : V) :
+    e x = e.linearIsometryEquiv x + e 0 := by
+  simpa using e.map_vadd (0 : V) x
+
+/-- **Right composition with an affine isometry equivalence factors through its linear part**:
+`f ∘ e = (f ∘ (· + e 0)) ∘ e.linearIsometryEquiv`. This is the reduction that lets a statement
+about `e` be assembled from the linear-isometry and translation cases; nothing is assumed about
+the codomain `F`. -/
+theorem comp_affineIsometryEquiv_eq_comp_linearIsometryEquiv {F : Type*} (e : V ≃ᵃⁱ[ℝ] W)
+    (f : W → F) :
+    f ∘ e = (fun y ↦ f (y + e 0)) ∘ e.linearIsometryEquiv := by
+  funext x
+  simp [Function.comp_apply, affineIsometryEquiv_apply_eq_linearIsometryEquiv_add e x]
+
+end AffineIsometryDecomposition
+
 /-- **Geometric invariance of the Laplacian under affine isometries.** For an affine isometry
 equivalence `e`, the Laplacian commutes with right composition by `e`:
 `Δ (f ∘ e) = (Δ f) ∘ e`. No differentiability hypothesis is needed. -/
 theorem laplacian_comp_affineIsometryEquiv_right (e : E ≃ᵃⁱ[ℝ] E') (f : E' → F) :
     Δ (f ∘ e) = (Δ f) ∘ e := by
-  have hcomp : f ∘ e = (fun y ↦ f (y + e 0)) ∘ e.linearIsometryEquiv := by
-    funext x
-    have hx : e x = e.linearIsometryEquiv x + e 0 := by
-      simpa using e.map_vadd (0 : E) x
-    simp [Function.comp_apply, hx]
-  rw [hcomp, laplacian_comp_linearIsometryEquiv_right e.linearIsometryEquiv
-      (fun y ↦ f (y + e 0)),
+  rw [comp_affineIsometryEquiv_eq_comp_linearIsometryEquiv e f,
+    laplacian_comp_linearIsometryEquiv_right e.linearIsometryEquiv (fun y ↦ f (y + e 0)),
     laplacian_comp_add_right f (e 0)]
   ext x
-  have hx : e x = e.linearIsometryEquiv x + e 0 := by
-    simpa using e.map_vadd (0 : E) x
-  simp [Function.comp_apply, hx]
+  simp [Function.comp_apply, affineIsometryEquiv_apply_eq_linearIsometryEquiv_add e x]
 
 /-- **Scaling law for the Laplacian under origin-centered dilation.**
 


### PR DESCRIPTION
`laplacian_comp_affineIsometryEquiv_right` (`Laplacian/Basic.lean`) and
`harmonicAt_comp_affineIsometryEquiv_right_iff` (`Harmonic/Isometry.lean`) make the same
reduction: an affine isometry equivalence is its linear part translated by its value at the
origin, so right composition by it factors through a linear isometry and a translation. That is
exactly why each can be assembled from the file's linear-isometry and translation lemmas.

Both spelled the reduction out inline. `e x = e.linearIsometryEquiv x + e 0` appeared **four
times** across the two files with the identical proof `by simpa using e.map_vadd (0 : E) x`, and
the enclosing `funext` / `simp [Function.comp_apply, hx]` block appeared twice, differing only in
the bound variable's name.

## What is named

Both go in `Laplacian/Basic.lean`, which `Harmonic/Isometry.lean` already `public import`s:

```lean
theorem affineIsometryEquiv_apply_eq_linearIsometryEquiv_add (e : V ≃ᵃⁱ[ℝ] W) (x : V) :
    e x = e.linearIsometryEquiv x + e 0

theorem comp_affineIsometryEquiv_eq_comp_linearIsometryEquiv {F : Type*} (e : V ≃ᵃⁱ[ℝ] W)
    (f : W → F) :
    f ∘ e = (fun y ↦ f (y + e 0)) ∘ e.linearIsometryEquiv
```

The first is Mathlib's `AffineIsometryEquiv.map_vadd` read at the base point `0`: that lemma
states `e (v +ᵥ p) = e.linearIsometryEquiv v +ᵥ e p`, and at `p = 0` the `+ᵥ` action of a normed
space on itself is addition, so it becomes the displayed form. Mathlib has `AffineMap.decomp`
for the `AffineMap`/`linear` pair but nothing in the `AffineIsometryEquiv`/`linearIsometryEquiv`
vector form, so this is not a duplicate of existing API.

## Minimal hypotheses

They are stated in **their own section** over `NormedAddCommGroup` / `NormedSpace` rather than
reusing the file's section variables, which carry `InnerProductSpace ℝ E` and
`FiniteDimensional ℝ E`. Neither fact needs an inner product or finite dimension. Reusing the
file's variables would have silently imported both, and `omit`ting them is not available here
because `InnerProductSpace ℝ E` is what supplies `NormedSpace ℝ E` for the `≃ᵃⁱ[ℝ]` notation.
The composition form additionally assumes **nothing at all** about the codomain `F` — it is a
bare `Type*`.

## Degenerate check

At `x = 0` the first lemma reads `e 0 = e.linearIsometryEquiv 0 + e 0`, consistent since a
linear isometry equivalence fixes `0`.

## Consumers

Both are rerouted, and `grep` confirms no occurrence of the inline form remains anywhere in
`TauCeti/` — the only surviving `map_vadd` is inside the new lemma's own proof. Both parent
proofs shrink: the harmonicity one from ten lines to four.

## Scope

Two files, one topic. The two parent statements are untouched. Both new lemmas are listed in
`Laplacian/Basic.lean`'s `## Main declarations`.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`,
`lake exe module-system`, `scripts/lint-env.sh`.
