### PR TITLE
refactor(HopfAlgebra): decompose antipode_comul_antidistrib into its three steps

### DIFF
--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -77,15 +77,14 @@ private lemma algHom_comp_antipode_mul_self {D : Type w} [Semiring D] [Algebra R
 section AlgebraCoalgebra
 
 variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C] [Algebra R C]
-  [_root_.Coalgebra R C]
+  [_root_.CoalgebraStruct R C]
 
 /-- **Comultiplication is the convolution product of the two tensor inclusions.** In the
 convolution monoid of maps `C →ₗ[R] C ⊗[R] C`, the product of `includeLeft` and `includeRight`
 multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
 
-Neither the antipode nor the bialgebra compatibility axioms are involved: the statement needs
-only the algebra structure (for the inclusions) and the coalgebra structure (for `Δ` and for the
-convolution product). -/
+Only the comultiplication *data* is used, so this needs `CoalgebraStruct` rather than
+`Coalgebra`: no coalgebra law, bialgebra compatibility or antipode axiom enters. -/
 private lemma comul_eq_convMul_includeLeft_includeRight :
     (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
       toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
@@ -105,33 +104,25 @@ private lemma comul_eq_convMul_includeLeft_includeRight :
   rw [← LinearMap.comp_assoc, hmul]
   simp
 
-end AlgebraCoalgebra
+/-- **Swapping the legs of `Δ` and applying `S` to each is the reversed convolution product.**
+For any linear endomorphism `S`, precomposing the two inclusions with `S` and multiplying them in
+the opposite order gives `(S ⊗ S) ∘ swap ∘ Δ`.
 
-section HopfAlgebraStruct
-
-variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C]
-  [_root_.HopfAlgebraStruct R C]
-
-/-- **The proposed opposite comultiplication is the reversed convolution product.** Precomposing
-each inclusion with the antipode and multiplying them in the opposite order gives
-`(S ⊗ S) ∘ swap ∘ Δ` — the right-hand side of `antipode_comul_antidistrib`. -/
-private lemma antipode_comul_op_eq_convMul :
-    (toConv (TensorProduct.map (antipode R) (antipode R) ∘ₗ
+Nothing about `S` is assumed — the identity is natural in it — so it is stated for an arbitrary
+`S : C →ₗ[R] C` and specialized to the antipode at the call site. -/
+private lemma map_comp_comm_comp_comul_eq_convMul (S : C →ₗ[R] C) :
+    (toConv (TensorProduct.map S S ∘ₗ
         (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul) :
           WithConv (C →ₗ[R] C ⊗[R] C)) =
-      toConv ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
-          antipode R) *
+      toConv ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ S) *
         toConv ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
-          antipode R) := by
+          S) := by
   apply WithConv.ofConv_injective
   have hmul : LinearMap.mul' R (C ⊗[R] C) ∘ₗ
       TensorProduct.map
-        ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
-          antipode R)
-        ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
-          antipode R) =
-      TensorProduct.map (antipode R) (antipode R) ∘ₗ
-        (TensorProduct.comm R C C).toLinearMap := by
+        ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ S)
+        ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ S) =
+      TensorProduct.map S S ∘ₗ (TensorProduct.comm R C C).toLinearMap := by
     apply TensorProduct.ext
     ext x y
     simp
@@ -139,13 +130,11 @@ private lemma antipode_comul_op_eq_convMul :
   have h := congrArg (fun f => f ∘ₗ (Coalgebra.comul (R := R) (A := C))) hmul
   simpa only [LinearMap.comp_assoc] using h.symm
 
-end HopfAlgebraStruct
+end AlgebraCoalgebra
 
-/-- **The proposed opposite comultiplication is a left convolution inverse of
-comultiplication.** Expanding both sides into convolution products of the tensor inclusions, the
-two inner factors cancel by `algHom_comp_antipode_mul_self`, leaving the outer pair to cancel in
-turn. -/
-private lemma antipode_comul_op_mul_comul :
+/-- **The right-hand side of `antipode_comul_antidistrib` is a left convolution inverse of
+comultiplication.** -/
+private lemma antipode_comul_antidistrib_rhs_mul_comul :
     (toConv (TensorProduct.map (antipode R) (antipode R) ∘ₗ
         (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul) :
           WithConv (C →ₗ[R] C ⊗[R] C)) * toConv Coalgebra.comul = 1 := by
@@ -153,9 +142,10 @@ private lemma antipode_comul_op_mul_comul :
     (Algebra.TensorProduct.includeLeft : C →ₐ[R] C ⊗[R] C)
   have hP := algHom_comp_antipode_mul_self (R := R) (C := C) (D := C ⊗[R] C)
     (Algebra.TensorProduct.includeRight : C →ₐ[R] C ⊗[R] C)
-  -- Expand both factors. `congrArg₂` rather than `rw`, since `WithConv` is a type synonym:
-  -- rewriting under `toConv` would re-wrap the result through `ofConv`.
-  rw [congrArg₂ (· * ·) antipode_comul_op_eq_convMul
+  -- Expand both sides into convolution products of the inclusions; the inner pair cancels by
+  -- `algHom_comp_antipode_mul_self`, then the outer pair does. `congrArg₂` rather than `rw`:
+  -- `WithConv` is a type synonym, so rewriting under `toConv` re-wraps through `ofConv`.
+  rw [congrArg₂ (· * ·) (map_comp_comm_comp_comul_eq_convMul (antipode R))
     comul_eq_convMul_includeLeft_includeRight]
   set L : WithConv (C →ₗ[R] C ⊗[R] C) :=
     toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
@@ -171,16 +161,14 @@ private lemma antipode_comul_op_mul_comul :
 
 /-- The antipode reverses comultiplication: after comultiplication, swap the tensor factors
 and apply the antipode to each of them. This is the coalgebraic counterpart of
-`HopfAlgebra.antipode_mul_antidistrib`.
-
-`antipode_comul_op_mul_comul` makes the right-hand side a left convolution inverse of `Δ`, and
-`LinearMap.comul_right_inv` makes `Δ ∘ₗ S` a right inverse; the two therefore coincide. -/
+`HopfAlgebra.antipode_mul_antidistrib`. -/
 theorem antipode_comul_antidistrib :
     Coalgebra.comul ∘ₗ antipode R =
       TensorProduct.map (antipode R) (antipode R) ∘ₗ
         (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul :=
   (WithConv.toConv_injective
-    (left_inv_eq_right_inv antipode_comul_op_mul_comul LinearMap.comul_right_inv)).symm
+    (left_inv_eq_right_inv antipode_comul_antidistrib_rhs_mul_comul
+      LinearMap.comul_right_inv)).symm
 
 /-- Pointwise form of `antipode_comul_antidistrib`. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -74,79 +74,101 @@ private lemma algHom_comp_antipode_mul_self {D : Type w} [Semiring D] [Algebra R
         ext c
         simp
 
+section Bialgebra
+
+variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C] [_root_.Bialgebra R C]
+
+/-- **Comultiplication is the convolution product of the two tensor inclusions.** In the
+convolution monoid of maps `C →ₗ[R] C ⊗[R] C`, the product of `includeLeft` and `includeRight`
+multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
+
+No antipode is involved, so this holds over any bialgebra. -/
+private lemma comul_eq_convMul_includeLeft_includeRight :
+    (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
+      toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
+        toConv (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap := by
+  apply WithConv.ofConv_injective
+  have hmul : LinearMap.mul' R (C ⊗[R] C) ∘ₗ
+      TensorProduct.map
+        (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
+        (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap =
+      LinearMap.id := by
+    apply TensorProduct.ext
+    ext x y
+    simp
+  simp only [LinearMap.convMul_def]
+  rw [← LinearMap.comp_assoc, hmul]
+  simp
+
+end Bialgebra
+
+/-- **The proposed opposite comultiplication is the reversed convolution product.** Precomposing
+each inclusion with the antipode and multiplying them in the opposite order gives
+`(S ⊗ S) ∘ swap ∘ Δ` — the right-hand side of `antipode_comul_antidistrib`. -/
+private lemma antipode_comul_op_eq_convMul :
+    (toConv (TensorProduct.map (antipode R) (antipode R) ∘ₗ
+        (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul) :
+          WithConv (C →ₗ[R] C ⊗[R] C)) =
+      toConv ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
+          antipode R) *
+        toConv ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
+          antipode R) := by
+  apply WithConv.ofConv_injective
+  have hmul : LinearMap.mul' R (C ⊗[R] C) ∘ₗ
+      TensorProduct.map
+        ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
+          antipode R)
+        ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ
+          antipode R) =
+      TensorProduct.map (antipode R) (antipode R) ∘ₗ
+        (TensorProduct.comm R C C).toLinearMap := by
+    apply TensorProduct.ext
+    ext x y
+    simp
+  simp only [LinearMap.convMul_def]
+  have h := congrArg (fun f => f ∘ₗ (Coalgebra.comul (R := R) (A := C))) hmul
+  simpa only [LinearMap.comp_assoc] using h.symm
+
+/-- **The proposed opposite comultiplication is a left convolution inverse of
+comultiplication.** Expanding both sides into convolution products of the tensor inclusions, the
+two inner factors cancel by `algHom_comp_antipode_mul_self`, leaving the outer pair to cancel in
+turn. -/
+private lemma antipode_comul_op_mul_comul :
+    (toConv (TensorProduct.map (antipode R) (antipode R) ∘ₗ
+        (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul) :
+          WithConv (C →ₗ[R] C ⊗[R] C)) * toConv Coalgebra.comul = 1 := by
+  have hL := algHom_comp_antipode_mul_self (R := R) (C := C) (D := C ⊗[R] C)
+    (Algebra.TensorProduct.includeLeft : C →ₐ[R] C ⊗[R] C)
+  have hP := algHom_comp_antipode_mul_self (R := R) (C := C) (D := C ⊗[R] C)
+    (Algebra.TensorProduct.includeRight : C →ₐ[R] C ⊗[R] C)
+  -- Expand both factors. `congrArg₂` rather than `rw`, since `WithConv` is a type synonym:
+  -- rewriting under `toConv` would re-wrap the result through `ofConv`.
+  rw [congrArg₂ (· * ·) antipode_comul_op_eq_convMul
+    comul_eq_convMul_includeLeft_includeRight]
+  set L : WithConv (C →ₗ[R] C ⊗[R] C) :=
+    toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
+  set P : WithConv (C →ₗ[R] C ⊗[R] C) :=
+    toConv (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap
+  set LS : WithConv (C →ₗ[R] C ⊗[R] C) := toConv
+    ((Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap ∘ₗ antipode R)
+  set PS : WithConv (C →ₗ[R] C ⊗[R] C) := toConv
+    ((Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap ∘ₗ antipode R)
+  calc PS * LS * (L * P) = PS * (LS * L * P) := by simp only [mul_assoc]
+    _ = PS * P := by rw [hL, one_mul]
+    _ = 1 := hP
+
 /-- The antipode reverses comultiplication: after comultiplication, swap the tensor factors
 and apply the antipode to each of them. This is the coalgebraic counterpart of
-`HopfAlgebra.antipode_mul_antidistrib`. -/
+`HopfAlgebra.antipode_mul_antidistrib`.
+
+`antipode_comul_op_mul_comul` makes the right-hand side a left convolution inverse of `Δ`, and
+`LinearMap.comul_right_inv` makes `Δ ∘ₗ S` a right inverse; the two therefore coincide. -/
 theorem antipode_comul_antidistrib :
     Coalgebra.comul ∘ₗ antipode R =
       TensorProduct.map (antipode R) (antipode R) ∘ₗ
-        (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul := by
-  let ιl : C →ₗ[R] C ⊗[R] C :=
-    Algebra.TensorProduct.includeLeft.toLinearMap
-  let ιr : C →ₗ[R] C ⊗[R] C :=
-    Algebra.TensorProduct.includeRight.toLinearMap
-  let Δ : WithConv (C →ₗ[R] C ⊗[R] C) :=
-    toConv Coalgebra.comul
-  let SΔop : WithConv (C →ₗ[R] C ⊗[R] C) :=
-    toConv
-      (TensorProduct.map (antipode R) (antipode R) ∘ₗ
-        (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul)
-  let L : WithConv (C →ₗ[R] C ⊗[R] C) := toConv ιl
-  let P : WithConv (C →ₗ[R] C ⊗[R] C) := toConv ιr
-  let LS : WithConv (C →ₗ[R] C ⊗[R] C) :=
-    toConv (ιl ∘ₗ antipode R)
-  let PS : WithConv (C →ₗ[R] C ⊗[R] C) :=
-    toConv (ιr ∘ₗ antipode R)
-  -- Comultiplication is the convolution product of the two tensor inclusions.
-  have hmul_ιl_ιr :
-      LinearMap.mul' R (C ⊗[R] C) ∘ₗ TensorProduct.map ιl ιr =
-        LinearMap.id := by
-    apply TensorProduct.ext
-    ext x y
-    simp [ιl, ιr]
-  have hΔ : Δ = L * P := by
-    apply WithConv.ofConv_injective
-    simp only [Δ, L, P, LinearMap.convMul_def]
-    rw [← LinearMap.comp_assoc, hmul_ιl_ιr]
-    simp
-  -- Reversing the inclusions gives the proposed opposite comultiplication.
-  have hmul_ιrS_ιlS :
-      LinearMap.mul' R (C ⊗[R] C) ∘ₗ
-          TensorProduct.map (ιr ∘ₗ antipode R) (ιl ∘ₗ antipode R) =
-        TensorProduct.map (antipode R) (antipode R) ∘ₗ
-          (TensorProduct.comm R C C).toLinearMap := by
-    apply TensorProduct.ext
-    ext x y
-    simp [ιl, ιr]
-  have hSΔop : SΔop = PS * LS := by
-    apply WithConv.ofConv_injective
-    simp only [SΔop, PS, LS, LinearMap.convMul_def]
-    have h := congrArg (fun f => f ∘ₗ (Coalgebra.comul (R := R) (A := C)))
-      hmul_ιrS_ιlS
-    simpa only [LinearMap.comp_assoc] using h.symm
-  -- Each inclusion, precomposed with the antipode, is a left convolution inverse of itself.
-  have hLS : LS * L = 1 := by
-    simpa only [LS, L, ιl] using
-      (algHom_comp_antipode_mul_self
-        (R := R) (C := C) (D := C ⊗[R] C)
-        (Algebra.TensorProduct.includeLeft : C →ₐ[R] C ⊗[R] C))
-  have hPS : PS * P = 1 := by
-    simpa only [PS, P, ιr] using
-      (algHom_comp_antipode_mul_self
-        (R := R) (C := C) (D := C ⊗[R] C)
-        (Algebra.TensorProduct.includeRight : C →ₐ[R] C ⊗[R] C))
-  -- So the proposed opposite comultiplication is a left inverse of comultiplication, while
-  -- `LinearMap.comul_right_inv` makes `comul ∘ₗ antipode` a right inverse of it.
-  have hleft : SΔop * Δ = 1 := by
-    rw [hΔ, hSΔop]
-    calc
-      (PS * LS) * (L * P) = PS * ((LS * L) * P) := by
-        simp only [mul_assoc]
-      _ = PS * P := by rw [hLS, one_mul]
-      _ = 1 := hPS
-  -- A left inverse and a right inverse of the same element coincide.
-  exact (WithConv.toConv_injective
-    (left_inv_eq_right_inv hleft LinearMap.comul_right_inv)).symm
+        (TensorProduct.comm R C C).toLinearMap ∘ₗ Coalgebra.comul :=
+  (WithConv.toConv_injective
+    (left_inv_eq_right_inv antipode_comul_op_mul_comul LinearMap.comul_right_inv)).symm
 
 /-- Pointwise form of `antipode_comul_antidistrib`. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -74,15 +74,18 @@ private lemma algHom_comp_antipode_mul_self {D : Type w} [Semiring D] [Algebra R
         ext c
         simp
 
-section Bialgebra
+section AlgebraCoalgebra
 
-variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C] [_root_.Bialgebra R C]
+variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C] [Algebra R C]
+  [_root_.Coalgebra R C]
 
 /-- **Comultiplication is the convolution product of the two tensor inclusions.** In the
 convolution monoid of maps `C →ₗ[R] C ⊗[R] C`, the product of `includeLeft` and `includeRight`
 multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
 
-No antipode is involved, so this holds over any bialgebra. -/
+Neither the antipode nor the bialgebra compatibility axioms are involved: the statement needs
+only the algebra structure (for the inclusions) and the coalgebra structure (for `Δ` and for the
+convolution product). -/
 private lemma comul_eq_convMul_includeLeft_includeRight :
     (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
       toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
@@ -93,6 +96,8 @@ private lemma comul_eq_convMul_includeLeft_includeRight :
         (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
         (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap =
       LinearMap.id := by
+    -- Mathlib's `lmul'_comp_map` + `lift_includeLeft_includeRight` state this as an algebra-hom
+    -- identity, but bridging that to linear maps exceeds `maxHeartbeats`; see the PR discussion.
     apply TensorProduct.ext
     ext x y
     simp
@@ -100,7 +105,12 @@ private lemma comul_eq_convMul_includeLeft_includeRight :
   rw [← LinearMap.comp_assoc, hmul]
   simp
 
-end Bialgebra
+end AlgebraCoalgebra
+
+section HopfAlgebraStruct
+
+variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C]
+  [_root_.HopfAlgebraStruct R C]
 
 /-- **The proposed opposite comultiplication is the reversed convolution product.** Precomposing
 each inclusion with the antipode and multiplying them in the opposite order gives
@@ -128,6 +138,8 @@ private lemma antipode_comul_op_eq_convMul :
   simp only [LinearMap.convMul_def]
   have h := congrArg (fun f => f ∘ₗ (Coalgebra.comul (R := R) (A := C))) hmul
   simpa only [LinearMap.comp_assoc] using h.symm
+
+end HopfAlgebraStruct
 
 /-- **The proposed opposite comultiplication is a left convolution inverse of
 comultiplication.** Expanding both sides into convolution products of the tensor inclusions, the


### PR DESCRIPTION
`antipode_comul_antidistrib` landed in #1514 with a **66-line** proof body — the only body over
50 lines in the library. It bundled eight `let` abbreviations together with three independent
algebraic facts. Those facts are now named `private` lemmas above it, and the theorem is a
two-line term.

## The three steps

| lemma | content |
|---|---|
| `comul_eq_convMul_includeLeft_includeRight` | `Δ` is the convolution product of the two tensor inclusions |
| `antipode_comul_op_eq_convMul` | precomposing each inclusion with `S` and multiplying in the *opposite* order gives `(S ⊗ S) ∘ swap ∘ Δ` |
| `antipode_comul_op_mul_comul` | that map is a left convolution inverse of `Δ` |

The theorem is then exactly what the file's existing implementation note already described:
`left_inv_eq_right_inv` against Mathlib's `LinearMap.comul_right_inv`.

```lean
theorem antipode_comul_antidistrib : … :=
  (WithConv.toConv_injective
    (left_inv_eq_right_inv antipode_comul_op_mul_comul LinearMap.comul_right_inv)).symm
```

## Minimal hypotheses at the point of extraction

`comul_eq_convMul_includeLeft_includeRight` mentions **no antipode** — it is a statement about a
bialgebra's comultiplication and the two inclusions. It is therefore stated in its own section
over `[Bialgebra R C]` rather than inheriting the ambient `[HopfAlgebra R C]`. The parent still
applies it unchanged, since `HopfAlgebra` extends `Bialgebra`.

The other two genuinely need the antipode and keep `[HopfAlgebra R C]`.

## Measurements

Bodies go **66 → 19 / 15 / 13 / 12**, with the parent in term mode. Largest body in the file is
now 19.

## A trap worth recording for this file

`WithConv` is a type synonym, so `toConv`/`ofConv` are identities up to defeq and `rw` matches at
the wrong level: rewriting `comul_eq_convMul_includeLeft_includeRight` under `toConv` produced

```
toConv ((toConv ιl * toConv ιr).ofConv)
```

rather than `toConv ιl * toConv ιr`. The expansion step therefore uses `congrArg₂ (· * ·)` to
build the product equation directly instead of rewriting inside the term. The four `set`
abbreviations that follow carry explicit `WithConv (C →ₗ[R] C ⊗[R] C)` ascriptions — without
them `toConv`'s target type stays a metavariable and instance search gets stuck on
`SMulCommClass R ?m C`.

## Scope

One file, one topic. **No statement changes**: both public declarations
(`antipode_comul_antidistrib` and `antipode_comul_antidistrib_apply`) keep their exact
signatures, and all three new lemmas are `private`, so the module's `## Main declarations` list
is unchanged and still accurate.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`,
`lake exe module-system`, `scripts/lint-env.sh`.


## Dry-run round 1

**`generality` — applied in `e92182b`.** Both points were right and both are now weakened:

- `comul_eq_convMul_includeLeft_includeRight` → `[Algebra R C] [Coalgebra R C]` (was `Bialgebra`).
  It uses the algebra structure for the inclusions and the coalgebra structure for `Δ` and the
  convolution product, independently; the compatibility axioms never appear.
- `antipode_comul_op_eq_convMul` → `[HopfAlgebraStruct R C]` (was `HopfAlgebra`). It only
  transports the antipode map through the inclusions and invokes neither antipode axiom.

`antipode_comul_op_mul_comul` and the public theorem keep `[HopfAlgebra R C]`, which they need
through `algHom_comp_antipode_mul_self`.

**`reuse` — not applied; the proposed route does not elaborate within the heartbeat limit.**

The suggestion was to derive `hmul` from `Algebra.TensorProduct.lmul'_comp_map` and
`Algebra.TensorProduct.lift_includeLeft_includeRight` instead of proving it directly. I tried it
twice rather than assuming, and both formulations hit the 200000-heartbeat wall:

```
error: …/Antipode.lean:101:4: (deterministic) timeout at `whnf`,
  maximum number of heartbeats (200000) has been reached
error: …/Antipode.lean:109:2: (deterministic) timeout at `«tactic execution»`,
  maximum number of heartbeats (200000) has been reached
```

— once with `simpa using congrArg AlgHom.toLinearMap (…)`, and again with the bridge lemmas
supplied explicitly (`AlgHom.comp_toLinearMap`, `Algebra.TensorProduct.toLinearMap_map`,
`Algebra.TensorProduct.lmul'_toLinearMap`, `AlgHom.toLinearMap_id`) so that no general
normalization was needed. The cost is in the defeq check itself, not in simp search:
`lift_includeLeft_includeRight` carries `set_option backward.isDefEq.respectTransparency false in`
in Mathlib, and the conversion also has to cross
`Algebra.TensorProduct.map → TensorProduct.AlgebraTensorModule.map → TensorProduct.map`.

CI forbids `set_option maxHeartbeats` overrides, so there is no version of this route that can
land. The direct proof stays, now with a comment recording the attempt so the next reader does
not repeat it:

```lean
-- Mathlib's `lmul'_comp_map` + `lift_includeLeft_includeRight` state this as an algebra-hom
-- identity, but bridging that to linear maps exceeds `maxHeartbeats`; see the PR discussion.
apply TensorProduct.ext
ext x y
simp
```

I do not think this is duplicated API in the sense the rubric targets: the lemma is a `private`
three-line fact about linear maps, not a restatement of a Mathlib declaration, and no Mathlib
lemma states it in the linear-map form the convolution monoid needs.

Roadmap: none

