### PR TITLE
feat: compute the dimension of a Clifford algebra

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -34,7 +34,8 @@ commutative ring, as soon as some vector `v` has `Q v` a unit, right multiplicat
 linear automorphism of the Clifford algebra carrying `evenOdd Q i` onto `evenOdd Q (i + 1)`, because
 a vector is odd and because `ι Q v * ι Q v = Q v` makes `ι Q v` a unit
 (`CliffordAlgebra.isUnit_ι_of_isUnit`). Over a field the two halves therefore have the same
-dimension, `2 ^ (n - 1)` each, and so in particular does the even subalgebra
+dimension, and over a field in which `2` is invertible, where the count `2 ^ n` above is available,
+that dimension is `2 ^ (n - 1)` each, as is the dimension of the even subalgebra
 `CliffordAlgebra.even Q`.
 
 These counts are what make the structure theory of Clifford algebras run: over an algebraically
@@ -77,9 +78,9 @@ separate milestone.
   coefficients.
 * `TauCeti.CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector whose norm is a
   unit exchanges the two halves of the `ℤ/2`-grading.
-* `TauCeti.CliffordAlgebra.finrank_evenOdd` and `TauCeti.CliffordAlgebra.finrank_even`: over a field
-  each half of the grading, and in particular the even subalgebra, has dimension
-  `2 ^ (finrank K V - 1)`.
+* `TauCeti.CliffordAlgebra.finrank_evenOdd` and `TauCeti.CliffordAlgebra.finrank_even`: over a
+  field in which `2` is invertible, each half of the grading, and in particular the even
+  subalgebra, has dimension `2 ^ (finrank K V - 1)`.
 
 ## References
 
@@ -115,6 +116,7 @@ has to unfold this definition. -/
     Basis (Finset I) R (CliffordAlgebra Q) :=
   b.ExteriorAlgebra.map (equivExterior Q).symm
 
+@[simp]
 theorem basis_apply {I : Type w} [LinearOrder I] (b : Basis I R M) (s : Finset I) :
     basis Q b s = (equivExterior Q).symm (b.ExteriorAlgebra s) :=
   rfl
@@ -246,8 +248,10 @@ section Field
 variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
   (Q : QuadraticForm K V) {v : V}
 
-/-- Each half of the `ℤ/2`-grading of a Clifford algebra on a finite-dimensional space carrying a
-vector of nonzero norm has half the dimension of the whole: `2 ^ (n - 1)` for `n = finrank K V`.
+/-- Over a field in which `2` is invertible, each half of the `ℤ/2`-grading of a Clifford algebra on
+a finite-dimensional space carrying a vector of nonzero norm has half the dimension of the whole:
+`2 ^ (n - 1)` for `n = finrank K V`. The invertibility of `2` is inherited from
+`finrank_eq_two_pow`, which counts the whole algebra.
 
 The vector of nonzero norm is what the proof multiplies by; it is not the sharpest hypothesis,
 since for the zero form the two halves of the exterior algebra are equidimensional as well
@@ -269,10 +273,10 @@ theorem finrank_evenOdd [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0
     rw [← pow_succ', Nat.sub_add_cancel hpos]
   omega
 
-/-- The even Clifford algebra of a finite-dimensional space carrying a vector of nonzero norm has
-dimension `2 ^ (n - 1)`, one power of two below the whole algebra. This is the dimension count
-behind the identification of the even subalgebra with a product of two matrix algebras one size
-down. -/
+/-- Over a field in which `2` is invertible, the even Clifford algebra of a finite-dimensional space
+carrying a vector of nonzero norm has dimension `2 ^ (n - 1)`, one power of two below the whole
+algebra. This is the dimension count behind the identification of the even subalgebra with a
+product of two matrix algebras one size down. -/
 theorem finrank_even [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0) :
     finrank K (_root_.CliffordAlgebra.even Q) = 2 ^ (finrank K V - 1) :=
   (LinearEquiv.ofEq _ _ (_root_.CliffordAlgebra.even_toSubmodule Q)).finrank_eq.trans

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -1,0 +1,257 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
+public import TauCeti.LinearAlgebra.ExteriorAlgebra.Dimension
+
+/-!
+# Freeness and dimension of a Clifford algebra
+
+The Clifford relation `ι Q m * ι Q m = Q m` does not preserve the number of generators in a
+product, so a Clifford algebra is not graded by degree; what it does do is leave the *size* of the
+algebra alone. In characteristic not two this is Mathlib's `CliffordAlgebra.equivExterior`, a
+linear (not algebra) isomorphism `CliffordAlgebra Q ≃ₗ[R] ExteriorAlgebra R M` valid for every
+quadratic form. Deforming the form therefore deforms the multiplication and nothing else, and the
+underlying module of `CliffordAlgebra Q` is as free, and as large, as the exterior algebra of `M`.
+
+This file records that. Over a commutative ring in which `2` is invertible, `CliffordAlgebra Q` is a
+free `R`-module whenever `M` is, with an explicit basis
+`TauCeti.CliffordAlgebra.basis Q b : Basis (Finset I) R (CliffordAlgebra Q)` attached to a basis `b`
+of `M` indexed by a linearly ordered `I`, and it is finite of rank `2 ^ finrank R M` whenever `M` is
+finite free. The `2 ^ n` is `∑ₖ (n choose k)` (`finrank_eq_sum_choose`), the count that a
+degree-graded argument would produce one exterior power at a time; here it is the count of subsets
+of a basis index set instead, because the basis is transported from Mathlib's basis
+`Module.Basis.ExteriorAlgebra` of the exterior algebra, indexed by finite subsets.
+
+A second section splits that count in half along Mathlib's `ℤ/2`-grading `evenOdd Q`. Over a field,
+and as soon as some vector `v` has `Q v ≠ 0`, right multiplication by `ι Q v` is a linear
+automorphism of the Clifford algebra carrying `evenOdd Q i` onto `evenOdd Q (i + 1)`, because a
+vector is odd and because `ι Q v * ι Q v = Q v` supplies the inverse. The two halves therefore have
+the same dimension, `2 ^ (n - 1)` each, and so in particular does the even subalgebra
+`CliffordAlgebra.even Q`.
+
+These counts are what make the structure theory of Clifford algebras run: over an algebraically
+closed field a nondegenerate `Q` on a `2l`-dimensional space has
+`finrank (CliffordAlgebra Q) = 2 ^ (2 * l) = (2 ^ l) ^ 2`, matching `Module.End` of the
+`2 ^ l`-dimensional spin module, so a surjection between the two is forced to be an isomorphism,
+while `finrank (even Q) = 2 ^ (2 * l - 1) = 2 * (2 ^ (l - 1)) ^ 2` matches the product of two
+matrix algebras one size down, acting on the two half-spin summands.
+
+## Implementation notes
+
+`basis` transports Mathlib's `Module.Basis.ExteriorAlgebra` along `equivExterior`, so its elements
+are not by definition the products `ι Q (b i₁) * ⋯ * ι Q (b iₖ)` of generators: `equivExterior` is
+built from `CliffordAlgebra.changeForm`, which corrects a product of generators by lower-order
+terms. Nothing below needs the products, only their number. Identifying
+the two families is the Clifford analogue of a Poincaré-Birkhoff-Witt theorem, and is the content
+of the associated-graded isomorphism `gr (CliffordAlgebra Q) ≅ ExteriorAlgebra R M` against the
+degree filtration of `TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean`; it is left to that
+separate milestone.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.basis`: the basis of `CliffordAlgebra Q` indexed by the finite subsets of
+  the index set of a basis of `M`, in characteristic not two.
+* `TauCeti.CliffordAlgebra.mulRightιEquiv`: right multiplication by a vector of nonzero norm, as a
+  linear automorphism of the Clifford algebra, and
+  `TauCeti.CliffordAlgebra.evenOddEquivAddOne`, the isomorphism between consecutive halves of the
+  `ℤ/2`-grading that it restricts to.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.rank_eq_rank_exteriorAlgebra` and
+  `TauCeti.CliffordAlgebra.finrank_eq_finrank_exteriorAlgebra`: the rank of `CliffordAlgebra Q`
+  is the rank of `ExteriorAlgebra R M`. The right-hand sides do not mention `Q`, so this is the
+  statement that the size of a Clifford algebra does not depend on the quadratic form.
+* `TauCeti.CliffordAlgebra.instFree` and `TauCeti.CliffordAlgebra.instFinite`: the Clifford algebra
+  of a free module is free, and of a finite free module is finite.
+* `TauCeti.CliffordAlgebra.finrank_eq_two_pow`: `finrank R (CliffordAlgebra Q) = 2 ^ finrank R M`,
+  with `TauCeti.CliffordAlgebra.finrank_eq_sum_choose` the same count as a sum of binomial
+  coefficients.
+* `TauCeti.CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector of nonzero norm
+  exchanges the two halves of the `ℤ/2`-grading.
+* `TauCeti.CliffordAlgebra.finrank_evenOdd` and `TauCeti.CliffordAlgebra.finrank_even`: over a field
+  each half of the grading, and in particular the even subalgebra, has dimension
+  `2 ^ (finrank K V - 1)`.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 0, "The associated graded is the exterior algebra (a PBW-type theorem)".
+* C. Chevalley, *The Algebraic Theory of Spinors* (1954), Chapter II.
+-/
+
+public section
+
+open Module CliffordAlgebra
+
+universe u v w
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+section CommRing
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M] [Invertible (2 : R)]
+  (Q : QuadraticForm R M)
+
+/-- The basis of `CliffordAlgebra Q` attached to a basis `b` of `M`, indexed by the finite subsets
+of the index set of `b`, obtained by transporting Mathlib's basis of `ExteriorAlgebra R M` along
+`CliffordAlgebra.equivExterior`.
+
+Its elements are not products of generators by construction; see the implementation notes. -/
+@[expose] noncomputable def basis {I : Type w} [LinearOrder I] (b : Basis I R M) :
+    Basis (Finset I) R (CliffordAlgebra Q) :=
+  b.ExteriorAlgebra.map (equivExterior Q).symm
+
+theorem basis_apply {I : Type w} [LinearOrder I] (b : Basis I R M) (s : Finset I) :
+    basis Q b s = (equivExterior Q).symm (b.ExteriorAlgebra s) :=
+  rfl
+
+/-- Not a `simp` lemma: `simp` unfolds `CliffordAlgebra.equivExterior` to the underlying
+`CliffordAlgebra.changeForm`, so the left-hand side is not in normal form. -/
+theorem equivExterior_basis {I : Type w} [LinearOrder I] (b : Basis I R M) (s : Finset I) :
+    equivExterior Q (basis Q b s) = b.ExteriorAlgebra s := by
+  rw [basis_apply, LinearEquiv.apply_symm_apply]
+
+/-- The Clifford algebra of a free module is a free module, in characteristic not two. -/
+instance instFree [Module.Free R M] : Module.Free R (CliffordAlgebra Q) :=
+  Module.Free.of_equiv (equivExterior Q).symm
+
+/-- The Clifford algebra of a finite free module is a finite module, in characteristic not two. -/
+instance instFinite [Module.Free R M] [Module.Finite R M] :
+    Module.Finite R (CliffordAlgebra Q) :=
+  Module.Finite.equiv (equivExterior Q).symm
+
+/-- A Clifford algebra has the rank of the exterior algebra of the same module. The right-hand side
+does not mention `Q`: deforming the quadratic form deforms the multiplication and leaves the
+underlying module alone. -/
+theorem rank_eq_rank_exteriorAlgebra :
+    Module.rank R (CliffordAlgebra Q) = Module.rank R (ExteriorAlgebra R M) :=
+  (equivExterior Q).rank_eq
+
+/-- A Clifford algebra has the finite rank of the exterior algebra of the same module; the
+finite-rank form of `rank_eq_rank_exteriorAlgebra`, again independent of `Q`. -/
+theorem finrank_eq_finrank_exteriorAlgebra :
+    finrank R (CliffordAlgebra Q) = finrank R (ExteriorAlgebra R M) :=
+  (equivExterior Q).finrank_eq
+
+/-- The Clifford algebra of a finite free module of rank `n` has rank `2 ^ n`, for every quadratic
+form on it. -/
+theorem finrank_eq_two_pow [Nontrivial R] [Module.Free R M] [Module.Finite R M] :
+    finrank R (CliffordAlgebra Q) = 2 ^ finrank R M := by
+  rw [finrank_eq_finrank_exteriorAlgebra, ExteriorAlgebra.finrank_eq_two_pow]
+
+/-- The rank of a Clifford algebra as a sum of binomial coefficients: `2 ^ n = ∑ₖ (n choose k)`,
+the count that adding up the exterior powers `⋀[R]^k M`, of ranks `(n choose k)`, produces. -/
+theorem finrank_eq_sum_choose [Nontrivial R] [Module.Free R M] [Module.Finite R M] :
+    finrank R (CliffordAlgebra Q) =
+      ∑ k ∈ Finset.range (finrank R M + 1), (finrank R M).choose k := by
+  rw [finrank_eq_two_pow, Nat.sum_range_choose]
+
+/-- A Clifford algebra of a finite free module has positive rank, its rank being a power of two. -/
+theorem finrank_pos [Nontrivial R] [Module.Free R M] [Module.Finite R M] :
+    0 < finrank R (CliffordAlgebra Q) := by
+  rw [finrank_eq_two_pow]
+  positivity
+
+end CommRing
+
+section EvenOdd
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+  (Q : QuadraticForm K V) {v : V}
+
+/-- Right multiplication by a vector of nonzero norm, as a linear automorphism of the Clifford
+algebra. The Clifford relation `ι Q v * ι Q v = Q v` makes it invertible, its inverse being the
+same multiplication scaled by `(Q v)⁻¹`. -/
+@[expose] noncomputable def mulRightιEquiv (hv : Q v ≠ 0) :
+    CliffordAlgebra Q ≃ₗ[K] CliffordAlgebra Q :=
+  LinearEquiv.ofLinear (LinearMap.mulRight K (ι Q v)) ((Q v)⁻¹ • LinearMap.mulRight K (ι Q v))
+    (by
+      ext y
+      simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.mulRight_apply,
+        LinearMap.id_apply, smul_mul_assoc, mul_assoc, ι_sq_scalar]
+      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul])
+    (by
+      ext y
+      simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.mulRight_apply,
+        LinearMap.id_apply, mul_assoc, ι_sq_scalar]
+      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul])
+
+@[simp]
+theorem mulRightιEquiv_apply (hv : Q v ≠ 0) (x : CliffordAlgebra Q) :
+    mulRightιEquiv Q hv x = x * ι Q v :=
+  rfl
+
+/-- Multiplying by a vector of nonzero norm exchanges the two halves of the `ℤ/2`-grading, since a
+vector is odd. This is what makes the even and the odd part of a Clifford algebra equidimensional
+as soon as the form is not identically zero. -/
+theorem map_evenOdd_mulRightιEquiv (hv : Q v ≠ 0) (i : ZMod 2) :
+    (evenOdd Q i).map (mulRightιEquiv Q hv).toLinearMap = evenOdd Q (i + 1) := by
+  have h2 : (1 : ZMod 2) + 1 = 0 := by decide
+  refine le_antisymm (Submodule.map_le_iff_le_comap.2 fun x hx => ?_) fun y hy => ?_
+  · exact evenOdd_mul_le Q i 1 (Submodule.mul_mem_mul hx (ι_mem_evenOdd_one Q v))
+  · refine Submodule.mem_map.2 ⟨(Q v)⁻¹ • (y * ι Q v), ?_, ?_⟩
+    · have hmem : (Q v)⁻¹ • (y * ι Q v) ∈ evenOdd Q (i + 1 + 1) :=
+        Submodule.smul_mem _ _
+          (evenOdd_mul_le Q (i + 1) 1 (Submodule.mul_mem_mul hy (ι_mem_evenOdd_one Q v)))
+      rwa [add_assoc, h2, add_zero] at hmem
+    · simp only [LinearEquiv.coe_coe, mulRightιEquiv_apply, smul_mul_assoc, mul_assoc,
+        ι_sq_scalar]
+      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul]
+
+/-- The two halves of the `ℤ/2`-grading of a Clifford algebra are isomorphic as modules, provided
+some vector has nonzero norm: multiplication by that vector carries one onto the other. -/
+@[expose] noncomputable def evenOddEquivAddOne (hv : Q v ≠ 0) (i : ZMod 2) :
+    evenOdd Q i ≃ₗ[K] evenOdd Q (i + 1) :=
+  (Submodule.equivMapOfInjective _ (mulRightιEquiv Q hv).injective _).trans
+    (LinearEquiv.ofEq _ _ (map_evenOdd_mulRightιEquiv Q hv i))
+
+@[simp]
+theorem coe_evenOddEquivAddOne (hv : Q v ≠ 0) (i : ZMod 2) (x : evenOdd Q i) :
+    (evenOddEquivAddOne Q hv i x : CliffordAlgebra Q) = x * ι Q v :=
+  rfl
+
+/-- Each half of the `ℤ/2`-grading of a Clifford algebra on a finite-dimensional space carrying a
+vector of nonzero norm has half the dimension of the whole: `2 ^ (n - 1)` for `n = finrank K V`.
+
+The vector of nonzero norm is what the proof multiplies by; it is not the sharpest hypothesis,
+since for the zero form the two halves of the exterior algebra are equidimensional as well
+whenever `V ≠ 0`. What it does rule out is `V = 0`, where the Clifford algebra is `K` and entirely
+even, so no such statement can hold. -/
+theorem finrank_evenOdd [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0) (i : ZMod 2) :
+    finrank K (evenOdd Q i) = 2 ^ (finrank K V - 1) := by
+  have hV : Nontrivial V := ⟨v, 0, fun h => hv (h ▸ (QuadraticMap.map_zero Q))⟩
+  have hpos : 0 < finrank K V := Module.finrank_pos
+  have hsum : finrank K (evenOdd Q 0) + finrank K (evenOdd Q 1) = 2 ^ finrank K V := by
+    rw [Submodule.finrank_add_eq_of_isCompl (evenOdd_isCompl Q), finrank_eq_two_pow]
+  have hswap : finrank K (evenOdd Q 0) = finrank K (evenOdd Q 1) :=
+    (evenOddEquivAddOne Q hv 0).finrank_eq
+  have hi : finrank K (evenOdd Q i) = finrank K (evenOdd Q 0) := by
+    fin_cases i
+    · rfl
+    · exact hswap.symm
+  have h2 : 2 * 2 ^ (finrank K V - 1) = 2 ^ finrank K V := by
+    rw [← pow_succ', Nat.sub_add_cancel hpos]
+  omega
+
+/-- The even Clifford algebra of a finite-dimensional space carrying a vector of nonzero norm has
+dimension `2 ^ (n - 1)`, one power of two below the whole algebra. This is the dimension count
+behind the identification of the even subalgebra with a product of two matrix algebras one size
+down. -/
+theorem finrank_even [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0) :
+    finrank K (_root_.CliffordAlgebra.even Q) = 2 ^ (finrank K V - 1) :=
+  (LinearEquiv.ofEq _ _ (_root_.CliffordAlgebra.even_toSubmodule Q)).finrank_eq.trans
+    (finrank_evenOdd Q hv 0)
+
+end EvenOdd
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Contraction
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Inversion
 public import TauCeti.LinearAlgebra.ExteriorAlgebra.Dimension
 
 /-!
@@ -13,7 +14,8 @@ public import TauCeti.LinearAlgebra.ExteriorAlgebra.Dimension
 
 The Clifford relation `ι Q m * ι Q m = Q m` does not preserve the number of generators in a
 product, so a Clifford algebra is not graded by degree; what it does do is leave the *size* of the
-algebra alone. In characteristic not two this is Mathlib's `CliffordAlgebra.equivExterior`, a
+algebra alone. Over a ring in which `2` is invertible this is Mathlib's
+`CliffordAlgebra.equivExterior`, a
 linear (not algebra) isomorphism `CliffordAlgebra Q ≃ₗ[R] ExteriorAlgebra R M` valid for every
 quadratic form. Deforming the form therefore deforms the multiplication and nothing else, and the
 underlying module of `CliffordAlgebra Q` is as free, and as large, as the exterior algebra of `M`.
@@ -27,11 +29,12 @@ degree-graded argument would produce one exterior power at a time; here it is th
 of a basis index set instead, because the basis is transported from Mathlib's basis
 `Module.Basis.ExteriorAlgebra` of the exterior algebra, indexed by finite subsets.
 
-A second section splits that count in half along Mathlib's `ℤ/2`-grading `evenOdd Q`. Over a field,
-and as soon as some vector `v` has `Q v ≠ 0`, right multiplication by `ι Q v` is a linear
-automorphism of the Clifford algebra carrying `evenOdd Q i` onto `evenOdd Q (i + 1)`, because a
-vector is odd and because `ι Q v * ι Q v = Q v` supplies the inverse. The two halves therefore have
-the same dimension, `2 ^ (n - 1)` each, and so in particular does the even subalgebra
+A second section splits that count in half along Mathlib's `ℤ/2`-grading `evenOdd Q`. Over any
+commutative ring, as soon as some vector `v` has `Q v` a unit, right multiplication by `ι Q v` is a
+linear automorphism of the Clifford algebra carrying `evenOdd Q i` onto `evenOdd Q (i + 1)`, because
+a vector is odd and because `ι Q v * ι Q v = Q v` makes `ι Q v` a unit
+(`CliffordAlgebra.isUnit_ι_of_isUnit`). Over a field the two halves therefore have the same
+dimension, `2 ^ (n - 1)` each, and so in particular does the even subalgebra
 `CliffordAlgebra.even Q`.
 
 These counts are what make the structure theory of Clifford algebras run: over an algebraically
@@ -55,9 +58,9 @@ separate milestone.
 ## Main definitions
 
 * `TauCeti.CliffordAlgebra.basis`: the basis of `CliffordAlgebra Q` indexed by the finite subsets of
-  the index set of a basis of `M`, in characteristic not two.
-* `TauCeti.CliffordAlgebra.mulRightιEquiv`: right multiplication by a vector of nonzero norm, as a
-  linear automorphism of the Clifford algebra, and
+  the index set of a basis of `M`, over a ring in which `2` is invertible.
+* `TauCeti.CliffordAlgebra.mulRightιEquiv`: right multiplication by a vector whose norm is a unit,
+  as a linear automorphism of the Clifford algebra, and
   `TauCeti.CliffordAlgebra.evenOddEquivAddOne`, the isomorphism between consecutive halves of the
   `ℤ/2`-grading that it restricts to.
 
@@ -72,8 +75,8 @@ separate milestone.
 * `TauCeti.CliffordAlgebra.finrank_eq_two_pow`: `finrank R (CliffordAlgebra Q) = 2 ^ finrank R M`,
   with `TauCeti.CliffordAlgebra.finrank_eq_sum_choose` the same count as a sum of binomial
   coefficients.
-* `TauCeti.CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector of nonzero norm
-  exchanges the two halves of the `ℤ/2`-grading.
+* `TauCeti.CliffordAlgebra.map_evenOdd_mulRightιEquiv`: multiplying by a vector whose norm is a
+  unit exchanges the two halves of the `ℤ/2`-grading.
 * `TauCeti.CliffordAlgebra.finrank_evenOdd` and `TauCeti.CliffordAlgebra.finrank_even`: over a field
   each half of the grading, and in particular the even subalgebra, has dimension
   `2 ^ (finrank K V - 1)`.
@@ -104,7 +107,10 @@ variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M] [I
 of the index set of `b`, obtained by transporting Mathlib's basis of `ExteriorAlgebra R M` along
 `CliffordAlgebra.equivExterior`.
 
-Its elements are not products of generators by construction; see the implementation notes. -/
+Its elements are not products of generators by construction; see the implementation notes.
+
+`@[expose]` because the characteristic equation `basis_apply` below is a public theorem whose proof
+has to unfold this definition. -/
 @[expose] noncomputable def basis {I : Type w} [LinearOrder I] (b : Basis I R M) :
     Basis (Finset I) R (CliffordAlgebra Q) :=
   b.ExteriorAlgebra.map (equivExterior Q).symm
@@ -113,17 +119,22 @@ theorem basis_apply {I : Type w} [LinearOrder I] (b : Basis I R M) (s : Finset I
     basis Q b s = (equivExterior Q).symm (b.ExteriorAlgebra s) :=
   rfl
 
-/-- Not a `simp` lemma: `simp` unfolds `CliffordAlgebra.equivExterior` to the underlying
+/-- `CliffordAlgebra.equivExterior` sends the basis element `basis Q b s` back to the exterior
+algebra basis element `b.ExteriorAlgebra s` it was transported from.
+
+Not a `simp` lemma: `simp` unfolds `CliffordAlgebra.equivExterior` to the underlying
 `CliffordAlgebra.changeForm`, so the left-hand side is not in normal form. -/
 theorem equivExterior_basis {I : Type w} [LinearOrder I] (b : Basis I R M) (s : Finset I) :
     equivExterior Q (basis Q b s) = b.ExteriorAlgebra s := by
   rw [basis_apply, LinearEquiv.apply_symm_apply]
 
-/-- The Clifford algebra of a free module is a free module, in characteristic not two. -/
+/-- The Clifford algebra of a free module is a free module, over a ring in which `2` is
+invertible. -/
 instance instFree [Module.Free R M] : Module.Free R (CliffordAlgebra Q) :=
   Module.Free.of_equiv (equivExterior Q).symm
 
-/-- The Clifford algebra of a finite free module is a finite module, in characteristic not two. -/
+/-- The Clifford algebra of a finite free module is a finite module, over a ring in which `2` is
+invertible. -/
 instance instFinite [Module.Free R M] [Module.Finite R M] :
     Module.Finite R (CliffordAlgebra Q) :=
   Module.Finite.equiv (equivExterior Q).symm
@@ -164,59 +175,76 @@ end CommRing
 
 section EvenOdd
 
-variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
-  (Q : QuadraticForm K V) {v : V}
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) {v : M}
 
-/-- Right multiplication by a vector of nonzero norm, as a linear automorphism of the Clifford
-algebra. The Clifford relation `ι Q v * ι Q v = Q v` makes it invertible, its inverse being the
-same multiplication scaled by `(Q v)⁻¹`. -/
-@[expose] noncomputable def mulRightιEquiv (hv : Q v ≠ 0) :
-    CliffordAlgebra Q ≃ₗ[K] CliffordAlgebra Q :=
-  LinearEquiv.ofLinear (LinearMap.mulRight K (ι Q v)) ((Q v)⁻¹ • LinearMap.mulRight K (ι Q v))
-    (by
-      ext y
-      simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.mulRight_apply,
-        LinearMap.id_apply, smul_mul_assoc, mul_assoc, ι_sq_scalar]
-      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul])
-    (by
-      ext y
-      simp only [LinearMap.comp_apply, LinearMap.smul_apply, LinearMap.mulRight_apply,
-        LinearMap.id_apply, mul_assoc, ι_sq_scalar]
-      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul])
+/-- Right multiplication by a vector whose norm is a unit, as a linear automorphism of the Clifford
+algebra. The Clifford relation `ι Q v * ι Q v = Q v` makes `ι Q v` itself a unit
+(`CliffordAlgebra.isUnit_ι_of_isUnit`), and right multiplication by a unit is
+`Units.mulRightLinearEquiv`. -/
+noncomputable def mulRightιEquiv (hv : IsUnit (Q v)) :
+    CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
+  (isUnit_ι_of_isUnit Q hv).unit.mulRightLinearEquiv R
 
 @[simp]
-theorem mulRightιEquiv_apply (hv : Q v ≠ 0) (x : CliffordAlgebra Q) :
-    mulRightιEquiv Q hv x = x * ι Q v :=
-  rfl
+theorem mulRightιEquiv_apply (hv : IsUnit (Q v)) (x : CliffordAlgebra Q) :
+    mulRightιEquiv Q hv x = x * ι Q v := by
+  rw [mulRightιEquiv, Units.mulRightLinearEquiv_apply, IsUnit.unit_spec]
 
-/-- Multiplying by a vector of nonzero norm exchanges the two halves of the `ℤ/2`-grading, since a
-vector is odd. This is what makes the even and the odd part of a Clifford algebra equidimensional
-as soon as the form is not identically zero. -/
-theorem map_evenOdd_mulRightιEquiv (hv : Q v ≠ 0) (i : ZMod 2) :
+@[simp]
+theorem mulRightιEquiv_symm_apply (hv : IsUnit (Q v)) (x : CliffordAlgebra Q) :
+    (mulRightιEquiv Q hv).symm x = x * ι Q (Ring.inverse (Q v) • v) := by
+  refine (LinearEquiv.symm_apply_eq _).2 ?_
+  rw [mulRightιEquiv_apply, map_smul, mul_smul_comm, smul_mul_assoc, mul_assoc, ι_sq_scalar,
+    ← Algebra.commutes, ← Algebra.smul_def, smul_smul, Ring.inverse_mul_cancel _ hv, one_smul]
+
+/-- Multiplying by a vector whose norm is a unit exchanges the two halves of the `ℤ/2`-grading,
+since a vector is odd. This is what makes the even and the odd part of a Clifford algebra
+equidimensional as soon as some vector has a unit norm; over a field that is exactly the
+condition that the form is not identically zero. -/
+theorem map_evenOdd_mulRightιEquiv (hv : IsUnit (Q v)) (i : ZMod 2) :
     (evenOdd Q i).map (mulRightιEquiv Q hv).toLinearMap = evenOdd Q (i + 1) := by
   have h2 : (1 : ZMod 2) + 1 = 0 := by decide
   refine le_antisymm (Submodule.map_le_iff_le_comap.2 fun x hx => ?_) fun y hy => ?_
-  · exact evenOdd_mul_le Q i 1 (Submodule.mul_mem_mul hx (ι_mem_evenOdd_one Q v))
-  · refine Submodule.mem_map.2 ⟨(Q v)⁻¹ • (y * ι Q v), ?_, ?_⟩
-    · have hmem : (Q v)⁻¹ • (y * ι Q v) ∈ evenOdd Q (i + 1 + 1) :=
-        Submodule.smul_mem _ _
-          (evenOdd_mul_le Q (i + 1) 1 (Submodule.mul_mem_mul hy (ι_mem_evenOdd_one Q v)))
+  · rw [Submodule.mem_comap, LinearEquiv.coe_coe, mulRightιEquiv_apply]
+    exact evenOdd_mul_le Q i 1 (Submodule.mul_mem_mul hx (ι_mem_evenOdd_one Q v))
+  · refine Submodule.mem_map.2 ⟨(mulRightιEquiv Q hv).symm y, ?_, ?_⟩
+    · have hmem : (mulRightιEquiv Q hv).symm y ∈ evenOdd Q (i + 1 + 1) := by
+        rw [mulRightιEquiv_symm_apply]
+        exact evenOdd_mul_le Q (i + 1) 1
+          (Submodule.mul_mem_mul hy (ι_mem_evenOdd_one Q _))
       rwa [add_assoc, h2, add_zero] at hmem
-    · simp only [LinearEquiv.coe_coe, mulRightιEquiv_apply, smul_mul_assoc, mul_assoc,
-        ι_sq_scalar]
-      rw [← Algebra.commutes, ← Algebra.smul_def, smul_smul, inv_mul_cancel₀ hv, one_smul]
+    · rw [LinearEquiv.coe_coe, LinearEquiv.apply_symm_apply]
 
 /-- The two halves of the `ℤ/2`-grading of a Clifford algebra are isomorphic as modules, provided
-some vector has nonzero norm: multiplication by that vector carries one onto the other. -/
-@[expose] noncomputable def evenOddEquivAddOne (hv : Q v ≠ 0) (i : ZMod 2) :
-    evenOdd Q i ≃ₗ[K] evenOdd Q (i + 1) :=
+some vector has a unit norm: multiplication by that vector carries one onto the other. -/
+noncomputable def evenOddEquivAddOne (hv : IsUnit (Q v)) (i : ZMod 2) :
+    evenOdd Q i ≃ₗ[R] evenOdd Q (i + 1) :=
   (Submodule.equivMapOfInjective _ (mulRightιEquiv Q hv).injective _).trans
     (LinearEquiv.ofEq _ _ (map_evenOdd_mulRightιEquiv Q hv i))
 
 @[simp]
-theorem coe_evenOddEquivAddOne (hv : Q v ≠ 0) (i : ZMod 2) (x : evenOdd Q i) :
-    (evenOddEquivAddOne Q hv i x : CliffordAlgebra Q) = x * ι Q v :=
-  rfl
+theorem coe_evenOddEquivAddOne_apply (hv : IsUnit (Q v)) (i : ZMod 2) (x : evenOdd Q i) :
+    (evenOddEquivAddOne Q hv i x : CliffordAlgebra Q) = x * ι Q v := by
+  rw [evenOddEquivAddOne, LinearEquiv.trans_apply, LinearEquiv.coe_ofEq_apply,
+    Submodule.coe_equivMapOfInjective_apply, LinearEquiv.coe_coe, mulRightιEquiv_apply]
+
+@[simp]
+theorem coe_evenOddEquivAddOne_symm_apply (hv : IsUnit (Q v)) (i : ZMod 2)
+    (y : evenOdd Q (i + 1)) :
+    ((evenOddEquivAddOne Q hv i).symm y : CliffordAlgebra Q) =
+      y * ι Q (Ring.inverse (Q v) • v) := by
+  have h := coe_evenOddEquivAddOne_apply Q hv i ((evenOddEquivAddOne Q hv i).symm y)
+  rw [LinearEquiv.apply_symm_apply] at h
+  rw [h, ← mulRightιEquiv_apply Q hv, ← mulRightιEquiv_symm_apply Q hv,
+    LinearEquiv.symm_apply_apply]
+
+end EvenOdd
+
+section Field
+
+variable {K : Type u} {V : Type v} [Field K] [AddCommGroup V] [Module K V]
+  (Q : QuadraticForm K V) {v : V}
 
 /-- Each half of the `ℤ/2`-grading of a Clifford algebra on a finite-dimensional space carrying a
 vector of nonzero norm has half the dimension of the whole: `2 ^ (n - 1)` for `n = finrank K V`.
@@ -232,7 +260,7 @@ theorem finrank_evenOdd [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0
   have hsum : finrank K (evenOdd Q 0) + finrank K (evenOdd Q 1) = 2 ^ finrank K V := by
     rw [Submodule.finrank_add_eq_of_isCompl (evenOdd_isCompl Q), finrank_eq_two_pow]
   have hswap : finrank K (evenOdd Q 0) = finrank K (evenOdd Q 1) :=
-    (evenOddEquivAddOne Q hv 0).finrank_eq
+    (evenOddEquivAddOne Q (isUnit_iff_ne_zero.2 hv) 0).finrank_eq
   have hi : finrank K (evenOdd Q i) = finrank K (evenOdd Q 0) := by
     fin_cases i
     · rfl
@@ -250,7 +278,7 @@ theorem finrank_even [Invertible (2 : K)] [Module.Finite K V] (hv : Q v ≠ 0) :
   (LinearEquiv.ofEq _ _ (_root_.CliffordAlgebra.even_toSubmodule Q)).finrank_eq.trans
     (finrank_evenOdd Q hv 0)
 
-end EvenOdd
+end Field
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
@@ -20,10 +20,11 @@ This file supplies that. Nothing here is new mathematics — the basis does all 
 rank count is `Fintype.card_finset`, the observation that a finite set with `n` elements has `2 ^ n`
 subsets, which is the same `∑ₖ (n choose k) = 2 ^ n` that summing `exteriorPower.finrank_eq` over
 the graded pieces would give. The point is to have the statement, because it is what the dimension
-count for a Clifford algebra rests on: in characteristic not two `CliffordAlgebra.equivExterior`
-identifies `CliffordAlgebra Q` with `ExteriorAlgebra R M` as a module, so every rank statement about
-the Clifford algebra is a rank statement about the exterior algebra transported along that
-isomorphism. See `TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean`.
+count for a Clifford algebra rests on: over a ring in which `2` is invertible,
+`CliffordAlgebra.equivExterior` identifies `CliffordAlgebra Q` with `ExteriorAlgebra R M` as a
+module, so every rank statement about the Clifford algebra is a rank statement about the exterior
+algebra transported along that isomorphism. See
+`TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean`.
 
 The hypotheses are the weakest the basis needs: a commutative ring `R` and a free `R`-module `M`,
 with no invertibility of `2` anywhere, since the exterior algebra has a basis over any commutative

--- a/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
+++ b/TauCeti/LinearAlgebra/ExteriorAlgebra/Dimension.lean
@@ -1,0 +1,83 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.ExteriorAlgebra.Basis
+
+/-!
+# Freeness and dimension of an exterior algebra
+
+Mathlib records the graded pieces of an exterior algebra in full: `exteriorPower.instFree` says
+that `⋀[R]^n M` is free when `M` is, and `exteriorPower.finrank_eq` computes its rank as
+`(finrank R M).choose n`. It also builds the basis `Module.Basis.ExteriorAlgebra` of the whole
+algebra, indexed by the *finite subsets* of the index set of a basis of `M`. What it does not
+record is the consequence: `ExteriorAlgebra R M` is itself a free module, of rank `2 ^ finrank R M`
+when `M` is finite free.
+
+This file supplies that. Nothing here is new mathematics — the basis does all the work, and the
+rank count is `Fintype.card_finset`, the observation that a finite set with `n` elements has `2 ^ n`
+subsets, which is the same `∑ₖ (n choose k) = 2 ^ n` that summing `exteriorPower.finrank_eq` over
+the graded pieces would give. The point is to have the statement, because it is what the dimension
+count for a Clifford algebra rests on: in characteristic not two `CliffordAlgebra.equivExterior`
+identifies `CliffordAlgebra Q` with `ExteriorAlgebra R M` as a module, so every rank statement about
+the Clifford algebra is a rank statement about the exterior algebra transported along that
+isomorphism. See `TauCeti/LinearAlgebra/CliffordAlgebra/Dimension.lean`.
+
+The hypotheses are the weakest the basis needs: a commutative ring `R` and a free `R`-module `M`,
+with no invertibility of `2` anywhere, since the exterior algebra has a basis over any commutative
+ring.
+
+## Main results
+
+* `TauCeti.ExteriorAlgebra.instFree`: the exterior algebra of a free module is free.
+* `TauCeti.ExteriorAlgebra.instFinite`: the exterior algebra of a finite free module is a finite
+  module.
+* `TauCeti.ExteriorAlgebra.finrank_eq_two_pow`: `finrank R (ExteriorAlgebra R M) = 2 ^ finrank R M`.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 0, "The associated graded is the exterior algebra (a PBW-type theorem)".
+-/
+
+public section
+
+open Module
+
+universe u v w
+
+namespace TauCeti
+
+namespace ExteriorAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- The exterior algebra of a free module is free, on the finite subsets of a basis index set. -/
+instance instFree [Module.Free R M] : Module.Free R (ExteriorAlgebra R M) := by
+  classical
+  have ⟨I, b⟩ := Module.Free.exists_basis R M
+  let : LinearOrder I := linearOrderOfSTO WellOrderingRel
+  exact Module.Free.of_basis b.ExteriorAlgebra
+
+/-- The exterior algebra of a finite free module is a finite module: its basis is indexed by the
+finite subsets of a finite basis index set. -/
+instance instFinite [Module.Free R M] [Module.Finite R M] :
+    Module.Finite R (ExteriorAlgebra R M) := by
+  classical
+  let : LinearOrder (Module.Free.ChooseBasisIndex R M) := linearOrderOfSTO WellOrderingRel
+  exact Module.Finite.of_basis (Module.Free.chooseBasis R M).ExteriorAlgebra
+
+/-- The exterior algebra of a finite free module of rank `n` has rank `2 ^ n`: a basis of it is
+indexed by the subsets of a basis index set of `M`. -/
+theorem finrank_eq_two_pow [Nontrivial R] [Module.Free R M] [Module.Finite R M] :
+    finrank R (ExteriorAlgebra R M) = 2 ^ finrank R M := by
+  classical
+  let : LinearOrder (Module.Free.ChooseBasisIndex R M) := linearOrderOfSTO WellOrderingRel
+  rw [finrank_eq_card_basis (Module.Free.chooseBasis R M).ExteriorAlgebra,
+    finrank_eq_card_basis (Module.Free.chooseBasis R M), Fintype.card_finset]
+
+end ExteriorAlgebra
+
+end TauCeti


### PR DESCRIPTION
This PR computes the dimension of a Clifford algebra. Over a commutative ring in which `2` is invertible, `CliffordAlgebra Q` is a free module whenever `M` is, with an explicit basis `TauCeti.CliffordAlgebra.basis Q b : Basis (Finset I) R (CliffordAlgebra Q)` attached to a basis `b` of `M`, and it is finite of rank `2 ^ finrank R M` (`finrank_eq_two_pow`, restated as `∑ₖ (n choose k)` in `finrank_eq_sum_choose`) whenever `M` is finite free. Underneath sit the same two facts for the exterior algebra, which Mathlib also lacks and which need no invertibility of `2`: `TauCeti.ExteriorAlgebra.instFree`, `instFinite`, and `finrank_eq_two_pow`, read off from Mathlib's basis `Module.Basis.ExteriorAlgebra`, indexed by the finite subsets of a basis index set. The rank statements about the Clifford algebra are transported from these along Mathlib's `CliffordAlgebra.equivExterior`, and `rank_eq_rank_exteriorAlgebra` / `finrank_eq_finrank_exteriorAlgebra` record the transport itself: the right-hand sides do not mention `Q`, so deforming the quadratic form deforms the multiplication and leaves the size of the underlying module alone.

A second section splits that count in half along Mathlib's `ℤ/2`-grading. Over any commutative ring, as soon as some vector `v` has `Q v` a unit, right multiplication by `ι Q v` is a linear automorphism `mulRightιEquiv` of the Clifford algebra (Mathlib's `CliffordAlgebra.isUnit_ι_of_isUnit` makes `ι Q v` a unit, and `Units.mulRightLinearEquiv` multiplies by it) which carries `evenOdd Q i` onto `evenOdd Q (i + 1)`, because a vector is odd. So the two halves are isomorphic, and `finrank_evenOdd` and `finrank_even` give `2 ^ (n - 1)` for each of them and for the even subalgebra `CliffordAlgebra.even Q`. The nonzero-norm hypothesis is what the proof multiplies by rather than the sharpest possible one, and the docstring says so: for the zero form the two halves are equidimensional too whenever `V ≠ 0`; what it does rule out is `V = 0`, where the algebra is `K` and entirely even.

The target is `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, Layer 0 ("The Clifford algebra, its universal property, and the two gradings"), the closing sentence of the bullet "The associated graded is the exterior algebra (a PBW-type theorem)": "In particular `finrank (CliffordAlgebra Q) = 2 ^ finrank M` for finite free `M`, matching `∑ₖ (finrank M).choose k`." The layer's headline milestone, the graded-algebra isomorphism `gr Cliff(V, Q) ≅ ExteriorAlgebra R M`, is deliberately not attempted here; the implementation notes say why the basis built here is not the family of products of generators, and leave that identification to its own PR. The dimension counts are the arithmetic Layer 1's structure theorem runs on, `dim Cliff(V, Q) = 2 ^ (2l) = (2 ^ l) ^ 2 = dim (End S)` and `dim (even Q) = 2 ^ (2l - 1) = 2 * (2 ^ (l-1)) ^ 2`, which is why the even half is computed alongside the whole.

Everything is derived, not reproved. Mathlib supplies `Module.Basis.ExteriorAlgebra` and `CliffordAlgebra.equivExterior`, `evenOdd_mul_le`, `evenOdd_isCompl`, `ι_mem_evenOdd_one`, `even_toSubmodule`, and the transport lemmas `Module.Free.of_equiv`, `Module.Finite.equiv`, `LinearEquiv.rank_eq`, `LinearEquiv.finrank_eq`, `Submodule.equivMapOfInjective`, `Submodule.finrank_add_eq_of_isCompl`, `Fintype.card_finset`, `Nat.sum_range_choose`; the two files follow the shape of Mathlib's `exteriorPower.instFree` / `exteriorPower.finrank_eq`, which do the same job one graded piece at a time. Nothing is vendored. This does not overlap #1510, which identifies `M` inside `CliffordAlgebra Q` via injectivity of `ι Q` and sizes the first filtration step, nor #1473, which builds the degree filtration; neither computes the rank of the algebra, and this PR uses neither.

`equivExterior_basis` is deliberately not a `simp` lemma, with a docstring saying why: `simp` unfolds `equivExterior` to the underlying `changeForm`, the same wart Mathlib records as `attribute [nolint simpNF] equivExterior.eq_1`.

`lake build`, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` are green locally.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finrank-clifford-algebra-eq-two-pow-finrank"}-->

Roadmap: SpinRepresentations

🤖 Prepared with Claude Code

