### PR TITLE
fix: sequence consecutive mathlib incompatibilities

### DIFF
--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -3,9 +3,10 @@ name: Update Dependencies
 # Keeps the mathlib pin moving using the leanprover-community/downstream-reports
 # composite actions (TauCeti is registered as a downstream there). Daily behavior:
 #   - mathlib compatible: open/update a single "bump to last-known-good" PR.
-#   - mathlib incompatible: open a tracking issue naming the first-known-bad mathlib
-#     commit, plus a fix PR pinned at that commit (a ready-made branch to fix in
-#     place — not for merging as-is), and close the LKG bump PR until resolved.
+#   - mathlib incompatible: if main is still pinned at an earlier incompatibility,
+#     first open an LKG de-pin PR; otherwise open a tracking issue naming the
+#     first-known-bad mathlib commit, plus a fix PR pinned at that commit (a
+#     ready-made branch to fix in place — not for merging as-is).
 # PRs and pushes use the tauceti-review-bot App token so pr-build/review trigger
 # normally. The LKG bump is de-pinned below to a manifest- and toolchain-only forward move,
 # so bump-guard validates it and it auto-merges. A first-known-bad fix PR keeps its exact
@@ -23,6 +24,8 @@ env:
 jobs:
   bump:
     runs-on: ubuntu-latest
+    outputs:
+      depinning: ${{ steps.transition.outputs.depinning }}
     permissions:
       contents: write
       pull-requests: write
@@ -38,17 +41,56 @@ jobs:
         with:
           token: ${{ steps.app-token.outputs.token }}
 
-      # Suppress the LKG bump while a regression is active: the only open PR
-      # should be the fix one pinned at the first-known-bad commit.
+      # Usually suppress the LKG bump while a regression is active. The
+      # transition check below makes the one exception needed to leave an
+      # earlier exact incompatibility pin safely.
       - name: Check whether an incompatibility is reported
         id: fkb
         uses: leanprover-community/downstream-reports/.github/actions/query-latest@43df0aa23fd0d157988f154b9e636c2d0efe2822
         with:
           query-type: first-known-bad
 
+      # A repair PR leaves main exactly pinned at its first-known-bad SHA. If a
+      # later report discovers another incompatibility before any compatible
+      # report has run, a direct old-FKB -> new-FKB PR would violate bump-guard's
+      # two trusted transitions. Land the reported LKG and restore `master`
+      # first; the next updater run can then open the new repair PR.
+      - name: Check whether the previous incompatibility must be de-pinned
+        id: transition
+        env:
+          FKB_COMMIT: ${{ steps.fkb.outputs.commit }}
+        run: |
+          set -euo pipefail
+          python3 - <<'PY'
+          from pathlib import Path
+          import os
+          import re
+
+          fkb = os.environ["FKB_COMMIT"]
+          parts = Path("lakefile.toml").read_text().split("[[require]]")
+          revisions = []
+          for part in parts[1:]:
+              if re.search(r'^[ \t]*name[ \t]*=[ \t]*"mathlib"[ \t]*$', part, re.MULTILINE):
+                  match = re.search(
+                      r'^[ \t]*rev[ \t]*=[ \t]*"([^"]+)"[ \t]*$', part, re.MULTILINE)
+                  if match:
+                      revisions.append(match.group(1))
+          if len(revisions) != 1:
+              raise SystemExit(f"expected one Mathlib rev in lakefile.toml; found {revisions}")
+
+          current = revisions[0]
+          depinning = bool(
+              fkb and re.fullmatch(r"[0-9a-f]{40}", current) and current != fkb)
+          with open(os.environ["GITHUB_OUTPUT"], "a") as output:
+              output.write(f"depinning={'true' if depinning else 'false'}\n")
+          print(f"current Mathlib rev: {current}")
+          print(f"reported first-known-bad: {fkb or '<none>'}")
+          print(f"de-pin previous incompatibility first: {depinning}")
+          PY
+
       - name: Bump to latest mathlib
         id: bump
-        if: steps.fkb.outputs.commit == ''
+        if: steps.fkb.outputs.commit == '' || steps.transition.outputs.depinning == 'true'
         uses: leanprover-community/downstream-reports/.github/actions/bump-to-latest@43df0aa23fd0d157988f154b9e636c2d0efe2822
 
       # TauCeti tracks mathlib `master` and lets bump-guard (scripts/check-bump.sh) validate
@@ -58,7 +100,9 @@ jobs:
       # after an incompatibility PR temporarily pinned the base lakefile, it also performs the
       # trusted bot's validated one-line de-pin back to `master`.
       - name: De-pin to keep tracking master (so bump-guard can auto-merge)
-        if: steps.fkb.outputs.commit == '' && steps.bump.outputs.updated == 'true'
+        if: >-
+          (steps.fkb.outputs.commit == '' && steps.bump.outputs.updated == 'true') ||
+          steps.transition.outputs.depinning == 'true'
         run: |
           set -euo pipefail
           # Restore only Mathlib's nominated rev to master. `git checkout -- lakefile.toml` is not
@@ -102,6 +146,20 @@ jobs:
           git-user-name: tauceti-review-bot[bot]
           git-user-email: 290224625+tauceti-review-bot[bot]@users.noreply.github.com
 
+      - name: Open or update transition PR
+        if: steps.transition.outputs.depinning == 'true'
+        uses: leanprover-community/downstream-reports/.github/actions/open-bump-pr@43df0aa23fd0d157988f154b9e636c2d0efe2822
+        with:
+          branch: ${{ env.LKG_BRANCH }}
+          title: "chore: de-pin mathlib at the last-known-good commit"
+          message: >-
+            Restore Mathlib's `master` nomination at the reported last-known-good
+            commit before opening the newly reported incompatibility repair.
+          commit-message: "chore: de-pin mathlib at the last-known-good commit"
+          token: ${{ steps.app-token.outputs.token }}
+          git-user-name: tauceti-review-bot[bot]
+          git-user-email: 290224625+tauceti-review-bot[bot]@users.noreply.github.com
+
   open-issue:
     runs-on: ubuntu-latest
     needs: bump
@@ -121,6 +179,7 @@ jobs:
 
       - name: Open or update incompatibility issue and fix PR
         id: track
+        if: needs.bump.outputs.depinning != 'true'
         uses: leanprover-community/downstream-reports/.github/actions/track-incompatibility@43df0aa23fd0d157988f154b9e636c2d0efe2822
         with:
           open-pr: true

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -65,20 +65,13 @@ jobs:
           from pathlib import Path
           import os
           import re
+          import sys
+
+          sys.path.insert(0, "scripts")
+          from check_bot_lakefile import mathlib_rev
 
           fkb = os.environ["FKB_COMMIT"]
-          parts = Path("lakefile.toml").read_text().split("[[require]]")
-          revisions = []
-          for part in parts[1:]:
-              if re.search(r'^[ \t]*name[ \t]*=[ \t]*"mathlib"[ \t]*$', part, re.MULTILINE):
-                  match = re.search(
-                      r'^[ \t]*rev[ \t]*=[ \t]*"([^"]+)"[ \t]*$', part, re.MULTILINE)
-                  if match:
-                      revisions.append(match.group(1))
-          if len(revisions) != 1:
-              raise SystemExit(f"expected one Mathlib rev in lakefile.toml; found {revisions}")
-
-          current = revisions[0]
+          current = mathlib_rev(Path("lakefile.toml"))
           depinning = bool(
               fkb and re.fullmatch(r"[0-9a-f]{40}", current) and current != fkb)
           with open(os.environ["GITHUB_OUTPUT"], "a") as output:

--- a/scripts/check-bump.sh
+++ b/scripts/check-bump.sh
@@ -81,7 +81,8 @@ if ! diff -q "$b" "$p" >/dev/null 2>&1; then
 fi
 if [ "$MODE" = "--allow-bot-lakefile" ]; then
   python3 "$BASE/scripts/check_bot_lakefile.py" \
-    "$BASE/lakefile.toml" "$PR/lakefile.toml" "$PR/lake-manifest.json" \
+    "$BASE/lakefile.toml" "$PR/lakefile.toml" \
+    "$BASE/lake-manifest.json" "$PR/lake-manifest.json" \
     || fail "review-bot lakefile pin is not the exact validated Mathlib revision change"
 else
   b="$BASE/lakefile.toml"; p="$PR/lakefile.toml"
@@ -149,11 +150,23 @@ ML_SLUG="$(slug "$ML_URL_P")"
 
 # --- 2. mathlib moved forward on the nominated branch -------------------------
 if [ "$ML_REV_B" = "$ML_REV_P" ]; then
-  # mathlib pin unchanged: then NOTHING in the manifest may change (the rest is derived from it).
-  if ! diff -q "$BASE/lake-manifest.json" "$PR/lake-manifest.json" >/dev/null 2>&1; then
+  # Usually an unchanged Mathlib pin means NOTHING in the manifest may change.
+  # The bot-only same-revision de-pin is the sole exception: the validator above
+  # has proved that only Mathlib's inputRev changed from the exact SHA to master.
+  same_revision_depin=0
+  if [ "$MODE" = "--allow-bot-lakefile" ] \
+    && [ "$ML_IR_B" = "$ML_REV_B" ] && [ "$ML_IR_P" = "master" ]; then
+    same_revision_depin=1
+  fi
+  if [ "$same_revision_depin" = 0 ] \
+    && ! diff -q "$BASE/lake-manifest.json" "$PR/lake-manifest.json" >/dev/null 2>&1; then
     fail "mathlib rev unchanged but the manifest changed — not a derived bump"
   fi
-  echo "bump-guard: mathlib pin unchanged."
+  if [ "$same_revision_depin" = 1 ]; then
+    echo "bump-guard: Mathlib pin unchanged; exact nomination safely restored to master."
+  else
+    echo "bump-guard: mathlib pin unchanged."
+  fi
 else
   st_fwd="$(gh api "repos/$ML_SLUG/compare/$ML_REV_B...$ML_REV_P" --jq '.status' 2>/dev/null)" \
     || fail "compare API failed for $ML_SLUG $ML_REV_B...$ML_REV_P"

--- a/scripts/check_bot_lakefile.py
+++ b/scripts/check_bot_lakefile.py
@@ -47,6 +47,16 @@ def _mathlib_require(config: dict, source: str) -> dict:
     return matches[0]
 
 
+def mathlib_rev(path: pathlib.Path) -> str:
+    """Return the unique Mathlib requirement's nominated revision."""
+
+    require = _mathlib_require(_load_toml(path), path.name)
+    rev = require.get("rev") or ""
+    if not isinstance(rev, str):
+        raise ValidationError(f"{path.name} Mathlib rev must be a string")
+    return rev
+
+
 def _single_changed_line(base_text: str, pr_text: str) -> tuple[str, str]:
     base_lines = base_text.splitlines(keepends=True)
     pr_lines = pr_text.splitlines(keepends=True)
@@ -56,8 +66,21 @@ def _single_changed_line(base_text: str, pr_text: str) -> tuple[str, str]:
     return changed[0]
 
 
+def _load_manifest(path: pathlib.Path, source: str) -> tuple[dict, dict]:
+    try:
+        manifest = json.loads(path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValidationError(f"cannot parse {path.name}: {exc}") from exc
+    packages = manifest.get("packages") or []
+    mathlib = [item for item in packages if item.get("name") == "mathlib"]
+    if len(mathlib) != 1:
+        raise ValidationError(
+            f"{source} must contain exactly one package named mathlib; found {len(mathlib)}")
+    return manifest, mathlib[0]
+
+
 def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
-             pr_manifest: pathlib.Path) -> str:
+             base_manifest: pathlib.Path, pr_manifest: pathlib.Path) -> str:
     """Validate the lakefile/Mathlib-manifest relationship for a bot pin or de-pin.
 
     The PR must change only Mathlib's ``rev`` line, to either a 40-hex commit or
@@ -80,8 +103,8 @@ def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
     pr_config = _load_toml(pr_lakefile)
     base_mathlib = _mathlib_require(base_config, "base lakefile.toml")
     pr_mathlib = _mathlib_require(pr_config, "PR lakefile.toml")
-    base_rev = base_mathlib.get("rev") or ""
-    pr_rev = pr_mathlib.get("rev") or ""
+    base_rev = mathlib_rev(base_lakefile)
+    pr_rev = mathlib_rev(pr_lakefile)
     if before_match.group(2) != base_rev or after_match.group(2) != pr_rev:
         raise ValidationError("the changed rev line is not Mathlib's [[require]] revision")
     if pr_rev != "master" and not SHA_RE.fullmatch(pr_rev):
@@ -92,17 +115,11 @@ def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
     if pr_config != base_config:
         raise ValidationError("lakefile.toml changes settings other than Mathlib's rev")
 
-    try:
-        manifest = json.loads(pr_manifest.read_text())
-    except (OSError, json.JSONDecodeError) as exc:
-        raise ValidationError(f"cannot parse {pr_manifest.name}: {exc}") from exc
-    packages = manifest.get("packages") or []
-    mathlib = [item for item in packages if item.get("name") == "mathlib"]
-    if len(mathlib) != 1:
-        raise ValidationError(
-            f"PR manifest must contain exactly one package named mathlib; found {len(mathlib)}")
-    manifest_rev = mathlib[0].get("rev") or ""
-    manifest_input = mathlib[0].get("inputRev") or ""
+    base_manifest_data, base_manifest_mathlib = _load_manifest(
+        base_manifest, "base manifest")
+    manifest, manifest_mathlib = _load_manifest(pr_manifest, "PR manifest")
+    manifest_rev = manifest_mathlib.get("rev") or ""
+    manifest_input = manifest_mathlib.get("inputRev") or ""
     if not SHA_RE.fullmatch(manifest_rev):
         raise ValidationError(f"manifest Mathlib rev {manifest_rev!r} is not a 40-hex SHA")
     if pr_rev != "master" and manifest_rev != pr_rev:
@@ -111,6 +128,20 @@ def validate(base_lakefile: pathlib.Path, pr_lakefile: pathlib.Path,
     if manifest_input != pr_rev:
         raise ValidationError(
             f"manifest inputRev {manifest_input!r} must equal the bot's lakefile rev {pr_rev!r}")
+
+    # A consecutive incompatibility can have its LKG exactly at the old FKB.
+    # In that case the safe transition changes only the nomination from the
+    # exact SHA back to master while leaving every resolved pin unchanged.
+    base_manifest_rev = base_manifest_mathlib.get("rev") or ""
+    base_manifest_input = base_manifest_mathlib.get("inputRev") or ""
+    if pr_rev == "master" and manifest_rev == base_manifest_rev:
+        if base_rev != base_manifest_rev or base_manifest_input != base_manifest_rev:
+            raise ValidationError(
+                "same-revision de-pin requires a consistently exact-pinned base")
+        manifest_mathlib["inputRev"] = base_manifest_input
+        if manifest != base_manifest_data:
+            raise ValidationError(
+                "same-revision de-pin may change only Mathlib's manifest inputRev")
     return pr_rev
 
 
@@ -118,10 +149,12 @@ def main() -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument("base_lakefile", type=pathlib.Path)
     parser.add_argument("pr_lakefile", type=pathlib.Path)
+    parser.add_argument("base_manifest", type=pathlib.Path)
     parser.add_argument("pr_manifest", type=pathlib.Path)
     args = parser.parse_args()
     try:
-        rev = validate(args.base_lakefile, args.pr_lakefile, args.pr_manifest)
+        rev = validate(
+            args.base_lakefile, args.pr_lakefile, args.base_manifest, args.pr_manifest)
     except (OSError, ValidationError) as exc:
         print(f"bot lakefile validation failed: {exc}", file=sys.stderr)
         return 1

--- a/scripts/check_bot_lakefile.py
+++ b/scripts/check_bot_lakefile.py
@@ -4,11 +4,14 @@
 The ordinary bump guard requires the Lake configuration to be byte-identical to
 the trusted base.  The incompatibility tracker is the one exception: its PR
 replaces Mathlib's nominated branch with the immutable first-known-bad SHA so the
-PR builds against the commit it is meant to repair.  Once compatible again, the
-same bot changes that line back to ``master`` while advancing the manifest pin.
-This helper proves that the sole lakefile change is Mathlib's revision and that
-Mathlib's manifest ``rev``/``inputRev`` fields agree with it.  ``check-bump.sh``
-validates the rest of the manifest and the direction of the pin transition.
+PR builds against the commit it is meant to repair.  To leave an exact pin, the
+same bot changes that line back to ``master`` while either advancing the manifest
+pin or, when the reported last-known-good commit equals the existing pin, changing
+only Mathlib's manifest ``inputRev``.  This helper proves that the sole lakefile
+change is Mathlib's revision, that Mathlib's manifest ``rev``/``inputRev`` fields
+agree with it, and that a same-revision de-pin leaves every other manifest field
+unchanged.  ``check-bump.sh`` validates the remaining manifest derivation and the
+direction of any resolved-pin transition.
 """
 
 from __future__ import annotations

--- a/scripts/test_check_bot_lakefile.py
+++ b/scripts/test_check_bot_lakefile.py
@@ -29,13 +29,17 @@ def _case(pr_text: str, *, manifest_rev: str = NEW, input_rev: str = NEW):
     root = pathlib.Path(tmp.name)
     base = root / "base.toml"
     pr = root / "pr.toml"
+    base_manifest = root / "base-manifest.json"
     manifest = root / "lake-manifest.json"
     base.write_text(BASE)
     pr.write_text(pr_text)
+    base_manifest.write_text(json.dumps({"packages": [{
+        "name": "mathlib", "type": "git", "rev": OLD, "inputRev": "master",
+    }]}))
     manifest.write_text(json.dumps({"packages": [{
         "name": "mathlib", "type": "git", "rev": manifest_rev, "inputRev": input_rev,
     }]}))
-    return tmp, base, pr, manifest
+    return tmp, base, pr, base_manifest, manifest
 
 
 def _valid_text() -> str:
@@ -43,25 +47,67 @@ def _valid_text() -> str:
 
 
 def test_accepts_the_exact_bot_pin():
-    tmp, base, pr, manifest = _case(_valid_text())
+    tmp, base, pr, base_manifest, manifest = _case(_valid_text())
     with tmp:
-        assert validate(base, pr, manifest) == NEW
+        assert validate(base, pr, base_manifest, manifest) == NEW
 
 
 def test_accepts_depinning_back_to_master_with_a_forward_manifest_pin():
     pinned_base = BASE.replace('rev = "master"', f'rev = "{OLD}"')
-    tmp, base, pr, manifest = _case(BASE, manifest_rev=NEW, input_rev="master")
+    tmp, base, pr, base_manifest, manifest = _case(
+        BASE, manifest_rev=NEW, input_rev="master")
     with tmp:
         base.write_text(pinned_base)
-        assert validate(base, pr, manifest) == "master"
+        base_manifest.write_text(json.dumps({"packages": [{
+            "name": "mathlib", "type": "git", "rev": OLD, "inputRev": OLD,
+        }]}))
+        assert validate(base, pr, base_manifest, manifest) == "master"
+
+
+def test_accepts_depinning_back_to_master_without_advancing_the_manifest_pin():
+    pinned_base = BASE.replace('rev = "master"', f'rev = "{OLD}"')
+    tmp, base, pr, base_manifest, manifest = _case(
+        BASE, manifest_rev=OLD, input_rev="master")
+    with tmp:
+        base.write_text(pinned_base)
+        base_manifest.write_text(json.dumps({"packages": [{
+            "name": "mathlib", "type": "git", "rev": OLD, "inputRev": OLD,
+        }]}))
+        assert validate(base, pr, base_manifest, manifest) == "master"
+
+
+def test_rejects_other_manifest_changes_during_same_revision_depin():
+    pinned_base = BASE.replace('rev = "master"', f'rev = "{OLD}"')
+    tmp, base, pr, base_manifest, manifest = _case(
+        BASE, manifest_rev=OLD, input_rev="master")
+    with tmp:
+        base.write_text(pinned_base)
+        base_manifest.write_text(json.dumps({
+            "version": "1.1.0",
+            "packages": [{
+                "name": "mathlib", "type": "git", "rev": OLD, "inputRev": OLD,
+            }],
+        }))
+        manifest.write_text(json.dumps({
+            "version": "changed",
+            "packages": [{
+                "name": "mathlib", "type": "git", "rev": OLD, "inputRev": "master",
+            }],
+        }))
+        try:
+            validate(base, pr, base_manifest, manifest)
+        except ValidationError as exc:
+            assert "only Mathlib's manifest inputRev" in str(exc)
+        else:
+            raise AssertionError("accepted another manifest change during a same-revision de-pin")
 
 
 def test_rejects_any_second_lakefile_change():
     text = _valid_text().replace('name = "TauCeti"', 'name = "Other"', 1)
-    tmp, base, pr, manifest = _case(text)
+    tmp, base, pr, base_manifest, manifest = _case(text)
     with tmp:
         try:
-            validate(base, pr, manifest)
+            validate(base, pr, base_manifest, manifest)
         except ValidationError as exc:
             assert "exactly one" in str(exc)
         else:
@@ -69,11 +115,12 @@ def test_rejects_any_second_lakefile_change():
 
 
 def test_rejects_a_branch_or_tag_instead_of_an_immutable_sha():
-    tmp, base, pr, manifest = _case(BASE.replace('rev = "master"', 'rev = "stable"'),
-                                    manifest_rev="stable", input_rev="stable")
+    tmp, base, pr, base_manifest, manifest = _case(
+        BASE.replace('rev = "master"', 'rev = "stable"'),
+        manifest_rev="stable", input_rev="stable")
     with tmp:
         try:
-            validate(base, pr, manifest)
+            validate(base, pr, base_manifest, manifest)
         except ValidationError as exc:
             assert "neither master nor a 40-hex" in str(exc)
         else:
@@ -81,10 +128,10 @@ def test_rejects_a_branch_or_tag_instead_of_an_immutable_sha():
 
 
 def test_rejects_manifest_revision_mismatch():
-    tmp, base, pr, manifest = _case(_valid_text(), manifest_rev=OLD)
+    tmp, base, pr, base_manifest, manifest = _case(_valid_text(), manifest_rev=OLD)
     with tmp:
         try:
-            validate(base, pr, manifest)
+            validate(base, pr, base_manifest, manifest)
         except ValidationError as exc:
             assert "does not match manifest" in str(exc)
         else:
@@ -92,10 +139,10 @@ def test_rejects_manifest_revision_mismatch():
 
 
 def test_rejects_a_non_exact_manifest_input():
-    tmp, base, pr, manifest = _case(_valid_text(), input_rev="master")
+    tmp, base, pr, base_manifest, manifest = _case(_valid_text(), input_rev="master")
     with tmp:
         try:
-            validate(base, pr, manifest)
+            validate(base, pr, base_manifest, manifest)
         except ValidationError as exc:
             assert "inputRev" in str(exc)
         else:
@@ -104,12 +151,12 @@ def test_rejects_a_non_exact_manifest_input():
 
 def test_rejects_editing_another_dependency_rev():
     other = '''\n[[require]]\nname = "other"\ngit = "https://example.com/other"\nrev = "stable"\n'''
-    tmp, base, pr, manifest = _case(BASE + other)
+    tmp, base, pr, base_manifest, manifest = _case(BASE + other)
     with tmp:
         base.write_text(BASE + other)
         pr.write_text((BASE + other).replace('rev = "stable"', f'rev = "{NEW}"'))
         try:
-            validate(base, pr, manifest)
+            validate(base, pr, base_manifest, manifest)
         except ValidationError as exc:
             assert "not Mathlib" in str(exc)
         else:
@@ -118,10 +165,10 @@ def test_rejects_editing_another_dependency_rev():
 
 def test_rejects_adding_or_removing_a_lakefile_line():
     for text in (_valid_text() + "# extra\n", _valid_text().replace('name = "TauCeti"\n', "", 1)):
-        tmp, base, pr, manifest = _case(text)
+        tmp, base, pr, base_manifest, manifest = _case(text)
         with tmp:
             try:
-                validate(base, pr, manifest)
+                validate(base, pr, base_manifest, manifest)
             except ValidationError as exc:
                 assert "exactly one existing line" in str(exc)
             else:


### PR DESCRIPTION
This PR makes the dependency updater de-pin an earlier first-known-bad Mathlib commit at the newly reported last-known-good boundary before opening the next incompatibility repair. It extends the trusted bump validator to accept the exact same-revision SHA-to-`master` nomination transition while requiring every resolved pin and every other manifest field to remain unchanged.

Validated the workflow YAML, exercised the transition classifier, ran all 10 bot-lakefile validator tests, and passed an end-to-end bump-guard check for a same-revision de-pin.

:robot: Prepared with OpenAI Codex