### PR TITLE
feat: add Hermite function unit norm

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -83,6 +83,7 @@ lemma inner_hermiteFunctionLp_zero_zero :
         rw [integral_ofReal, integral_hermiteFunction_zero_mul_self, RCLike.ofReal_one]
 
 /-- The zeroth `Lp` Hermite function is a unit vector, over any `RCLike` scalar field. -/
+@[simp]
 lemma norm_hermiteFunctionLp_zero : ‖hermiteFunctionLp 𝕜 0‖ = 1 := by
   have h := inner_hermiteFunctionLp_zero_zero (𝕜 := 𝕜)
   rw [inner_self_eq_norm_sq_to_K, ← RCLike.ofReal_pow] at h

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -64,4 +64,34 @@ lemma coeFn_hermiteFunctionLp_real (n : ℕ) :
   filter_upwards [coeFn_hermiteFunctionLp (𝕜 := ℝ) n] with x hx
   simpa using hx
 
+/-! ## Zeroth-mode normalization -/
+
+/-- The zeroth `Lp` Hermite function has inner product one with itself, over any `RCLike`
+scalar field. This lower-level result is available without importing the full orthonormality
+development. -/
+lemma inner_hermiteFunctionLp_zero_zero :
+    inner 𝕜 (hermiteFunctionLp 𝕜 0) (hermiteFunctionLp 𝕜 0) = 1 := by
+  calc
+    inner 𝕜 (hermiteFunctionLp 𝕜 0) (hermiteFunctionLp 𝕜 0)
+      = ∫ x : ℝ, (algebraMap ℝ 𝕜) (hermiteFunction 0 x * hermiteFunction 0 x) := by
+        rw [MeasureTheory.L2.inner_def]
+        refine integral_congr_ae ?_
+        filter_upwards [coeFn_hermiteFunctionLp (𝕜 := 𝕜) 0] with x hx
+        rw [hx]
+        exact inner_algebraMap_algebraMap (𝕜 := 𝕜)
+          (hermiteFunction 0 x) (hermiteFunction 0 x)
+    _ = 1 := by
+        rw [integral_ofReal, integral_hermiteFunction_zero_mul_self, RCLike.ofReal_one]
+
+/-- The zeroth `Lp` Hermite function is a unit vector, over any `RCLike` scalar field. This
+lower-level result is available without importing the full orthonormality development. It has
+high simp priority so it remains the preferred zeroth-mode rule when the general theorem is also
+imported. -/
+@[simp high]
+lemma norm_hermiteFunctionLp_zero : ‖hermiteFunctionLp 𝕜 0‖ = 1 := by
+  have h := inner_hermiteFunctionLp_zero_zero (𝕜 := 𝕜)
+  rw [inner_self_eq_norm_sq_to_K, ← RCLike.ofReal_pow] at h
+  have h2 : ‖hermiteFunctionLp 𝕜 0‖ ^ 2 = 1 := by exact_mod_cast h
+  rw [← Real.sqrt_one, ← h2, Real.sqrt_sq (norm_nonneg _)]
+
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -64,29 +64,4 @@ lemma coeFn_hermiteFunctionLp_real (n : ℕ) :
   filter_upwards [coeFn_hermiteFunctionLp (𝕜 := ℝ) n] with x hx
   simpa using hx
 
-/-! ## Zeroth-mode normalization -/
-
-/-- The zeroth `Lp` Hermite function has inner product one with itself, over any `RCLike`
-scalar field. -/
-lemma inner_hermiteFunctionLp_zero_zero :
-    inner 𝕜 (hermiteFunctionLp 𝕜 0) (hermiteFunctionLp 𝕜 0) = 1 := by
-  calc
-    inner 𝕜 (hermiteFunctionLp 𝕜 0) (hermiteFunctionLp 𝕜 0)
-      = ∫ x : ℝ, (algebraMap ℝ 𝕜) (hermiteFunction 0 x * hermiteFunction 0 x) := by
-        rw [MeasureTheory.L2.inner_def]
-        refine integral_congr_ae ?_
-        filter_upwards [coeFn_hermiteFunctionLp (𝕜 := 𝕜) 0] with x hx
-        rw [hx]
-        exact inner_algebraMap_algebraMap (𝕜 := 𝕜)
-          (hermiteFunction 0 x) (hermiteFunction 0 x)
-    _ = 1 := by
-        rw [integral_ofReal, integral_hermiteFunction_zero_mul_self, RCLike.ofReal_one]
-
-/-- The zeroth `Lp` Hermite function is a unit vector, over any `RCLike` scalar field. -/
-lemma norm_hermiteFunctionLp_zero : ‖hermiteFunctionLp 𝕜 0‖ = 1 := by
-  have h := inner_hermiteFunctionLp_zero_zero (𝕜 := 𝕜)
-  rw [inner_self_eq_norm_sq_to_K, ← RCLike.ofReal_pow] at h
-  have h2 : ‖hermiteFunctionLp 𝕜 0‖ ^ 2 = 1 := by exact_mod_cast h
-  rw [← Real.sqrt_one, ← h2, Real.sqrt_sq (norm_nonneg _)]
-
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Lp.lean
@@ -83,7 +83,6 @@ lemma inner_hermiteFunctionLp_zero_zero :
         rw [integral_ofReal, integral_hermiteFunction_zero_mul_self, RCLike.ofReal_one]
 
 /-- The zeroth `Lp` Hermite function is a unit vector, over any `RCLike` scalar field. -/
-@[simp]
 lemma norm_hermiteFunctionLp_zero : ‖hermiteFunctionLp 𝕜 0‖ = 1 := by
   have h := inner_hermiteFunctionLp_zero_zero (𝕜 := 𝕜)
   rw [inner_self_eq_norm_sq_to_K, ← RCLike.ofReal_pow] at h

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -32,8 +32,9 @@ This file proves that the Hermite functions
   inner-product formula via `orthonormal_iff_ite`.
 * `TauCeti.norm_hermiteFunctionLp`: every Hermite mode has `L²` norm one.
 
-The zeroth-mode normalization `TauCeti.integral_hermiteFunction_zero_mul_self` and
-`TauCeti.norm_hermiteFunctionLp_zero` are the `n = 0` special cases of the results here.
+The zeroth-mode normalization `TauCeti.integral_hermiteFunction_zero_mul_self` is the `n = 0`
+special case of the pointwise result here; the `Lp` counterpart is
+`TauCeti.norm_hermiteFunctionLp 0`.
 -/
 
 public section

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -118,6 +118,7 @@ theorem orthonormal_hermiteFunctionLp : Orthonormal 𝕜 (hermiteFunctionLp 𝕜
 
 /-- **Target A2 (unit norm).** Every Hermite function has `L²` norm one, over any `RCLike`
 scalar field. -/
+@[simp]
 theorem norm_hermiteFunctionLp (n : ℕ) : ‖hermiteFunctionLp 𝕜 n‖ = 1 :=
   orthonormal_hermiteFunctionLp.norm_eq_one n
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -30,6 +30,7 @@ This file proves that the Hermite functions
   field `𝕜`, obtained by rewriting the `L²` inner product as the pointwise integral above.
 * `TauCeti.orthonormal_hermiteFunctionLp`: `Orthonormal 𝕜 (hermiteFunctionLp 𝕜)`, immediate from the
   inner-product formula via `orthonormal_iff_ite`.
+* `TauCeti.norm_hermiteFunctionLp`: every Hermite mode has `L²` norm one.
 
 The zeroth-mode normalization `TauCeti.integral_hermiteFunction_zero_mul_self` and
 `TauCeti.norm_hermiteFunctionLp_zero` are the `n = 0` special cases of the results here.
@@ -114,5 +115,11 @@ theorem inner_hermiteFunctionLp (m n : ℕ) :
 `hermiteHilbertBasis` construction feeds to `HilbertBasis.mkOfOrthogonalEqBot`. -/
 theorem orthonormal_hermiteFunctionLp : Orthonormal 𝕜 (hermiteFunctionLp 𝕜) :=
   orthonormal_iff_ite.mpr inner_hermiteFunctionLp
+
+/-- **Target A2 (unit norm).** Every Hermite function has `L²` norm one, over any `RCLike`
+scalar field. -/
+@[simp]
+theorem norm_hermiteFunctionLp (n : ℕ) : ‖hermiteFunctionLp 𝕜 n‖ = 1 :=
+  orthonormal_hermiteFunctionLp.norm_eq_one n
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -118,7 +118,6 @@ theorem orthonormal_hermiteFunctionLp : Orthonormal 𝕜 (hermiteFunctionLp 𝕜
 
 /-- **Target A2 (unit norm).** Every Hermite function has `L²` norm one, over any `RCLike`
 scalar field. -/
-@[simp]
 theorem norm_hermiteFunctionLp (n : ℕ) : ‖hermiteFunctionLp 𝕜 n‖ = 1 :=
   orthonormal_hermiteFunctionLp.norm_eq_one n
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Orthonormal.lean
@@ -32,9 +32,10 @@ This file proves that the Hermite functions
   inner-product formula via `orthonormal_iff_ite`.
 * `TauCeti.norm_hermiteFunctionLp`: every Hermite mode has `L²` norm one.
 
-The zeroth-mode normalization `TauCeti.integral_hermiteFunction_zero_mul_self` is the `n = 0`
-special case of the pointwise result here; the `Lp` counterpart is
-`TauCeti.norm_hermiteFunctionLp 0`.
+The lower-level zeroth-mode normalizations `TauCeti.integral_hermiteFunction_zero_mul_self` and
+`TauCeti.norm_hermiteFunctionLp_zero` remain available to importers that do not need the full
+orthonormality development; `TauCeti.norm_hermiteFunctionLp 0` is the general theorem specialized
+to that mode.
 -/
 
 public section

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
@@ -29,7 +29,7 @@ never has to unfold `hermiteHilbertBasis` to expand a function in Hermite functi
 Every statement holds for an arbitrary `RCLike` scalar field, so `𝕜 = ℝ` and `𝕜 = ℂ` are the same
 theorem. The roadmap `OrthogonalL2Bases` Part A3 acceptance criteria on the coordinates and norm
 of `ψ₀` follow by instantiating `hermiteHilbertBasis_repr_self` and
-`tsum_norm_sq_inner_hermiteFunctionLp` at `f = ψ₀`, together with `norm_hermiteFunctionLp_zero`;
+`tsum_norm_sq_inner_hermiteFunctionLp` at `f = ψ₀`, together with `norm_hermiteFunctionLp 0`;
 no separate declaration is needed for that specialization.
 -/
 

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Parseval.lean
@@ -29,7 +29,7 @@ never has to unfold `hermiteHilbertBasis` to expand a function in Hermite functi
 Every statement holds for an arbitrary `RCLike` scalar field, so `𝕜 = ℝ` and `𝕜 = ℂ` are the same
 theorem. The roadmap `OrthogonalL2Bases` Part A3 acceptance criteria on the coordinates and norm
 of `ψ₀` follow by instantiating `hermiteHilbertBasis_repr_self` and
-`tsum_norm_sq_inner_hermiteFunctionLp` at `f = ψ₀`, together with `norm_hermiteFunctionLp 0`;
+`tsum_norm_sq_inner_hermiteFunctionLp` at `f = ψ₀`, together with `norm_hermiteFunctionLp_zero`;
 no separate declaration is needed for that specialization.
 -/
 


### PR DESCRIPTION
This PR adds `TauCeti.norm_hermiteFunctionLp`, the all-modes unit-norm theorem for the Hermite family in `L²(ℝ; 𝕜)`. It closes the exact companion-API item `‖ψₙ‖₂ = 1` in `TauCetiRoadmap/OrthogonalL2Bases/README.md`, Part A2 (“The Hermite functions `ψₙ : ℝ → ℝ`”), uniformly for every `RCLike` scalar field.

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"norm-hermitefunctionlp"}-->

Roadmap: OrthogonalL2Bases

The proof reuses Mathlib's `Orthonormal.norm_eq_one` through the existing `TauCeti.orthonormal_hermiteFunctionLp`; it does not repeat the Gaussian integral or normalization argument. The theorem lives beside that orthonormality result, carries the expected `@[simp]` normal form, and the module documentation now advertises the completed API. No Mathlib infrastructure or external formalization is vendored.

`lake build` completes successfully (5,986 jobs). `tauceti-axioms --changed-from origin/main` audits four declarations in the changed module, all within `[propext, Classical.choice, Quot.sound]`. `tauceti-lint-env --changed-from origin/main` reports zero violations.

🤖 Prepared with Codex
