### PR TITLE
feat: add Jordan curves and Jordan domains

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
@@ -7,7 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.BoundaryCorrespondence
 public import TauCeti.Topology.JordanCurve
-import Mathlib.Analysis.Normed.Module.Convex
+import Mathlib.Analysis.Normed.Module.Connected
 import TauCeti.Analysis.Complex.Conformal.Biholomorph
 
 /-!
@@ -50,10 +50,11 @@ are.
 * `TauCeti.isJordanDomain_ball` — a disc of positive radius is a Jordan domain, the basic example
   and the one Carathéodory's theorem compares every other Jordan domain to. Its frontier is a
   circle, which `TauCeti.isJordanCurve_sphere` already knows to be a Jordan curve.
-* `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image` and
-  `TauCeti.isJordanDomain_of_image_eq_ball` — **the converse half of the Carathéodory
-  correspondence**: if a conformal map on a bounded open `U` extends continuously and injectively
-  to `closure U` and carries `U` onto a disc, then `U` is a Jordan domain.
+* `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image`,
+  `TauCeti.isJordanDomain_of_isJordanDomain_image` and `TauCeti.isJordanDomain_of_image_eq_ball` —
+  **the converse half of the Carathéodory correspondence**: if a conformal map on a bounded open
+  `U` extends continuously and injectively to `closure U` and carries `U` onto a Jordan domain —
+  a disc, in the last of the three — then `U` is itself a Jordan domain.
 
 ## Generality
 
@@ -110,7 +111,7 @@ structure IsJordanDomain (U : Set ℂ) : Prop where
 radius. This is the model Jordan domain, and the target of every Riemann map. -/
 theorem isJordanDomain_ball (c : ℂ) (hr : 0 < r) : IsJordanDomain (ball c r) where
   isOpen := isOpen_ball
-  isConnected := (convex_ball c r).isConnected (nonempty_ball.2 hr)
+  isConnected := isConnected_ball hr
   isBounded := isBounded_ball
   isJordanCurve_frontier := by
     rw [frontier_ball c hr.ne']
@@ -159,22 +160,22 @@ theorem isJordanCurve_frontier_of_isJordanCurve_frontier_image (hUo : IsOpen U)
     (hFi.mono frontier_subset_closure)
     (image_frontier_eq_frontier_image hUo hUb hfd hFc hFf hFi ▸ h)
 
-/-- **The converse half of the Carathéodory boundary correspondence.** A bounded domain of `ℂ` that
-a holomorphic map carries onto a disc, extending continuously and injectively to the closure, is a
-Jordan domain.
+/-- **The converse half of the Carathéodory boundary correspondence.** A bounded open set of `ℂ`
+that a holomorphic map carries onto a Jordan domain, extending continuously and injectively to the
+closure, is itself a Jordan domain.
 
-Carathéodory's theorem — layer **L5** of the conformal-mapping roadmap — is the converse: for a
-Jordan domain such an extension *exists*. Together the two say that, among bounded domains, being a
-Jordan domain is exactly the condition under which the Riemann map extends to a homeomorphism of
-the closures.
+Carathéodory's theorem — layer **L5** of the conformal-mapping roadmap — is the converse for the
+disc: for a Jordan domain such an extension *exists*. Together the two say that, among bounded
+domains, being a Jordan domain is exactly the condition under which the Riemann map extends to a
+homeomorphism of the closures.
 
 Connectedness of `U` is not assumed: `f` is an open partial homeomorphism of `U` onto `f '' U`
 (`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the connected set
-`ball c r` under the continuous inverse. -/
-theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U)
+`f '' U` under the continuous inverse. -/
+theorem isJordanDomain_of_isJordanDomain_image (hUo : IsOpen U)
     (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
     (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
-    (hr : 0 < r) (himg : f '' U = ball c r) : IsJordanDomain U where
+    (himg : IsJordanDomain (f '' U)) : IsJordanDomain U where
   isOpen := hUo
   isConnected := by
     have hfi : InjOn f U := fun x hx y hy hxy =>
@@ -184,14 +185,24 @@ theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U)
     have hsymm : e.symm '' (f '' U) = U := by
       rw [← htgt, e.symm_image_target_eq_source, he,
         DifferentiableOn.toOpenPartialHomeomorph_source]
-    have hball : IsConnected (f '' U) := by
-      rw [himg]
-      exact (convex_ball c r).isConnected (nonempty_ball.2 hr)
-    exact hsymm ▸ hball.image _ (e.continuousOn_symm.mono htgt.ge)
+    exact hsymm ▸ himg.isConnected.image _ (e.continuousOn_symm.mono htgt.ge)
   isBounded := hUb
-  isJordanCurve_frontier := by
-    refine isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi ?_
-    rw [himg, frontier_ball c hr.ne']
-    exact isJordanCurve_sphere c hr
+  isJordanCurve_frontier :=
+    isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi
+      himg.isJordanCurve_frontier
+
+/-- **The converse half of the Carathéodory boundary correspondence, for the disc.** A bounded open
+set of `ℂ` that a holomorphic map carries onto a disc, extending continuously and injectively to
+the closure, is a Jordan domain.
+
+This is the case of `TauCeti.isJordanDomain_of_isJordanDomain_image` in which the image is the
+model Jordan domain, and it is the form the Carathéodory correspondence is stated in, the disc
+being the target of every Riemann map. -/
+theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U)
+    (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
+    (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
+    (hr : 0 < r) (himg : f '' U = ball c r) : IsJordanDomain U :=
+  isJordanDomain_of_isJordanDomain_image hUo hUb hfd hFc hFf hFi
+    (himg ▸ isJordanDomain_ball c hr)
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
@@ -7,8 +7,8 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.BoundaryCorrespondence
 public import TauCeti.Topology.JordanCurve
-import Mathlib.Analysis.Convex.PathConnected
 import Mathlib.Analysis.Normed.Module.Convex
+import TauCeti.Analysis.Complex.Conformal.Biholomorph
 
 /-!
 # Jordan domains, and the domains a conformal map takes onto a disc
@@ -47,10 +47,9 @@ are.
 
 ## Main results
 
-* `TauCeti.sphereCircleHomeomorph` and `TauCeti.isJordanCurve_sphere` — a circle of positive radius
-  in `ℂ` is a Jordan curve, by the explicit affine parametrization `w ↦ (w - c) / r`.
 * `TauCeti.isJordanDomain_ball` — a disc of positive radius is a Jordan domain, the basic example
-  and the one Carathéodory's theorem compares every other Jordan domain to.
+  and the one Carathéodory's theorem compares every other Jordan domain to. Its frontier is a
+  circle, which `TauCeti.isJordanCurve_sphere` already knows to be a Jordan curve.
 * `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image` and
   `TauCeti.isJordanDomain_of_image_eq_ball` — **the converse half of the Carathéodory
   correspondence**: if a conformal map on a bounded open `U` extends continuously and injectively
@@ -60,8 +59,9 @@ are.
 
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, the results below are stated for maps of `ℂ`, as in
-`Conformal/BoundaryCorrespondence.lean`; the purely topological content is in
-`TauCeti/Topology/JordanCurve.lean`, where it is stated for an arbitrary topological space.
+`Conformal/BoundaryCorrespondence.lean`; the Jordan-curve vocabulary they are phrased in, together
+with the circle that models it, is in `TauCeti/Topology/JordanCurve.lean`, where the predicate and
+its transfer lemmas are stated for an arbitrary topological space.
 
 ## Coordination with upstream Mathlib
 
@@ -89,48 +89,7 @@ open Metric Set Topology
 
 variable {U : Set ℂ} {f F : ℂ → ℂ} {c : ℂ} {r : ℝ}
 
-/-! ## Circles and discs -/
-
-/-- The affine parametrization `w ↦ (w - c) / r` of a circle of centre `c` and positive radius `r`
-in `ℂ` by the unit circle. -/
-noncomputable def sphereCircleHomeomorph (c : ℂ) (hr : 0 < r) : sphere c r ≃ₜ Circle where
-  toFun w := ⟨((w : ℂ) - c) / r, mem_sphere_zero_iff_norm.2 (by
-    have hw : ‖(w : ℂ) - c‖ = r := mem_sphere_iff_norm.1 w.2
-    rw [norm_div, hw, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr, div_self hr.ne'])⟩
-  invFun z := ⟨c + r * (z : ℂ), by
-    simp [mem_sphere_iff_norm, Circle.norm_coe, abs_of_pos hr]⟩
-  left_inv w := by
-    have hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
-    apply Subtype.ext
-    field_simp
-    ring
-  right_inv z := by
-    have hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
-    apply Circle.coe_injective
-    field_simp
-    ring
-  continuous_toFun := by fun_prop
-  continuous_invFun := by fun_prop
-
-/-- The parametrization of `sphere c r` by the unit circle divides out the affine change of
-coordinates. -/
-@[simp]
-lemma coe_sphereCircleHomeomorph_apply (c : ℂ) (hr : 0 < r) (w : sphere c r) :
-    (sphereCircleHomeomorph c hr w : ℂ) = ((w : ℂ) - c) / r := by
-  rw [sphereCircleHomeomorph]
-  rfl
-
-/-- The inverse parametrization of `sphere c r` by the unit circle is the affine change of
-coordinates. -/
-@[simp]
-lemma coe_sphereCircleHomeomorph_symm_apply (c : ℂ) (hr : 0 < r) (z : Circle) :
-    (((sphereCircleHomeomorph c hr).symm z : sphere c r) : ℂ) = c + r * (z : ℂ) := by
-  rw [sphereCircleHomeomorph]
-  rfl
-
-/-- A circle of positive radius in `ℂ` is a Jordan curve. -/
-theorem isJordanCurve_sphere (c : ℂ) (hr : 0 < r) : IsJordanCurve (sphere c r) :=
-  isJordanCurve_iff.mpr ⟨sphereCircleHomeomorph c hr⟩
+/-! ## Jordan domains, and the discs among them -/
 
 /-- A **Jordan domain**: a bounded domain of `ℂ` bounded by a Jordan curve.
 
@@ -207,13 +166,28 @@ Jordan domain.
 Carathéodory's theorem — layer **L5** of the conformal-mapping roadmap — is the converse: for a
 Jordan domain such an extension *exists*. Together the two say that, among bounded domains, being a
 Jordan domain is exactly the condition under which the Riemann map extends to a homeomorphism of
-the closures. -/
-theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U) (hUc : IsConnected U)
+the closures.
+
+Connectedness of `U` is not assumed: `f` is an open partial homeomorphism of `U` onto `f '' U`
+(`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the connected set
+`ball c r` under the continuous inverse. -/
+theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U)
     (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
     (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
     (hr : 0 < r) (himg : f '' U = ball c r) : IsJordanDomain U where
   isOpen := hUo
-  isConnected := hUc
+  isConnected := by
+    have hfi : InjOn f U := fun x hx y hy hxy =>
+      hFi (subset_closure hx) (subset_closure hy) (by rw [hFf hx, hFf hy]; exact hxy)
+    set e := DifferentiableOn.toOpenPartialHomeomorph hfd hUo hfi with he
+    have htgt : e.target = f '' U := DifferentiableOn.toOpenPartialHomeomorph_target hfd hUo hfi
+    have hsymm : e.symm '' (f '' U) = U := by
+      rw [← htgt, e.symm_image_target_eq_source, he,
+        DifferentiableOn.toOpenPartialHomeomorph_source]
+    have hball : IsConnected (f '' U) := by
+      rw [himg]
+      exact (convex_ball c r).isConnected (nonempty_ball.2 hr)
+    exact hsymm ▸ hball.image _ (e.continuousOn_symm.mono htgt.ge)
   isBounded := hUb
   isJordanCurve_frontier := by
     refine isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi ?_

--- a/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.BoundaryCorrespondence
+public import TauCeti.Topology.JordanCurve
+import Mathlib.Analysis.Convex.PathConnected
+import Mathlib.Analysis.Normed.Module.Convex
+
+/-!
+# Jordan domains, and the domains a conformal map takes onto a disc
+
+A **Jordan domain** is a bounded domain of `ℂ` whose boundary is a Jordan curve. This file
+introduces `TauCeti.IsJordanDomain`, exhibits the discs as the basic example, and proves the
+*converse* half of the Carathéodory boundary correspondence: a bounded domain that a conformal map
+carries onto a disc, the map extending continuously and injectively to the closure, is a Jordan
+domain.
+
+## Why the converse is the accessible half
+
+Layer **L5** of the conformal-mapping roadmap (`TauCetiRoadmap/ConformalMapping/README.md`) is
+Carathéodory's theorem: *the Riemann map of a Jordan domain extends to a homeomorphism of the
+closures*. Both directions of that correspondence pass through the same object, the boundary
+homeomorphism `TauCeti.closureHomeomorph`, but they are not of the same difficulty. Producing the
+extension is the hard direction — it needs the boundary geometry to control the cluster sets of the
+map, which is where `Conformal/ClusterSet.lean` and the local connectivity of the boundary enter,
+and it is *not* proved here. Reading the boundary geometry *off* an extension that is already given
+is the direction this file supplies, and it is short, because the boundary correspondence has
+already been established: `TauCeti.image_frontier_eq_frontier_image` says that an injective
+continuous extension carries `frontier U` onto `frontier (f '' U)`, and `frontier U` is compact
+whenever `U` is bounded, so `TauCeti.IsJordanCurve.of_image` transports the circle backwards along
+the extension.
+
+The result is exactly the statement that Carathéodory's hypothesis is not merely sufficient but
+necessary: among bounded domains, "conformally a disc, with the map extending to a homeomorphism of
+the closures" implies "Jordan". It is what makes the L5 milestone a *correspondence* rather than a
+one-way sufficient condition, and it is the form in which the boundary hypothesis is checked in
+practice, since a Riemann map is rarely available in closed form while its boundary values often
+are.
+
+## Main definitions
+
+* `TauCeti.IsJordanDomain` — a bounded domain of `ℂ` whose frontier is a Jordan curve.
+
+## Main results
+
+* `TauCeti.sphereCircleHomeomorph` and `TauCeti.isJordanCurve_sphere` — a circle of positive radius
+  in `ℂ` is a Jordan curve, by the explicit affine parametrization `w ↦ (w - c) / r`.
+* `TauCeti.isJordanDomain_ball` — a disc of positive radius is a Jordan domain, the basic example
+  and the one Carathéodory's theorem compares every other Jordan domain to.
+* `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image` and
+  `TauCeti.isJordanDomain_of_image_eq_ball` — **the converse half of the Carathéodory
+  correspondence**: if a conformal map on a bounded open `U` extends continuously and injectively
+  to `closure U` and carries `U` onto a disc, then `U` is a Jordan domain.
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, the results below are stated for maps of `ℂ`, as in
+`Conformal/BoundaryCorrespondence.lean`; the purely topological content is in
+`TauCeti/Topology/JordanCurve.lean`, where it is stated for an arbitrary topological space.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the
+pinned Mathlib has no Jordan-curve vocabulary at all. So this file is new Lean formalization rather
+than a temporary shim. It consumes, through `Conformal/BoundaryCorrespondence.lean`, the L0–L3 shim
+`TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib once the
+upstream work lands.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* J. B. Conway, *Functions of One Complex Variable I* (GTM 11), Ch. IX.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric Set Topology
+
+variable {U : Set ℂ} {f F : ℂ → ℂ} {c : ℂ} {r : ℝ}
+
+/-! ## Circles and discs -/
+
+/-- The affine parametrization `w ↦ (w - c) / r` of a circle of centre `c` and positive radius `r`
+in `ℂ` by the unit circle. -/
+noncomputable def sphereCircleHomeomorph (c : ℂ) (hr : 0 < r) : sphere c r ≃ₜ Circle where
+  toFun w := ⟨((w : ℂ) - c) / r, mem_sphere_zero_iff_norm.2 (by
+    have hw : ‖(w : ℂ) - c‖ = r := mem_sphere_iff_norm.1 w.2
+    rw [norm_div, hw, Complex.norm_real, Real.norm_eq_abs, abs_of_pos hr, div_self hr.ne'])⟩
+  invFun z := ⟨c + r * (z : ℂ), by
+    simp [mem_sphere_iff_norm, Circle.norm_coe, abs_of_pos hr]⟩
+  left_inv w := by
+    have hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
+    apply Subtype.ext
+    field_simp
+    ring
+  right_inv z := by
+    have hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
+    apply Circle.coe_injective
+    field_simp
+    ring
+  continuous_toFun := by fun_prop
+  continuous_invFun := by fun_prop
+
+/-- The parametrization of `sphere c r` by the unit circle divides out the affine change of
+coordinates. -/
+@[simp]
+lemma coe_sphereCircleHomeomorph_apply (c : ℂ) (hr : 0 < r) (w : sphere c r) :
+    (sphereCircleHomeomorph c hr w : ℂ) = ((w : ℂ) - c) / r := by
+  rw [sphereCircleHomeomorph]
+  rfl
+
+/-- The inverse parametrization of `sphere c r` by the unit circle is the affine change of
+coordinates. -/
+@[simp]
+lemma coe_sphereCircleHomeomorph_symm_apply (c : ℂ) (hr : 0 < r) (z : Circle) :
+    (((sphereCircleHomeomorph c hr).symm z : sphere c r) : ℂ) = c + r * (z : ℂ) := by
+  rw [sphereCircleHomeomorph]
+  rfl
+
+/-- A circle of positive radius in `ℂ` is a Jordan curve. -/
+theorem isJordanCurve_sphere (c : ℂ) (hr : 0 < r) : IsJordanCurve (sphere c r) :=
+  isJordanCurve_iff.mpr ⟨sphereCircleHomeomorph c hr⟩
+
+/-- A **Jordan domain**: a bounded domain of `ℂ` bounded by a Jordan curve.
+
+Boundedness is part of the definition: the two complementary domains of a Jordan curve in the
+sphere have the same boundary, and it is the bounded one — the *interior* of the curve — that the
+Carathéodory correspondence compares to the unit disc. -/
+structure IsJordanDomain (U : Set ℂ) : Prop where
+  /-- A Jordan domain is open. -/
+  isOpen : IsOpen U
+  /-- A Jordan domain is connected, in particular nonempty. -/
+  isConnected : IsConnected U
+  /-- A Jordan domain is bounded. -/
+  isBounded : Bornology.IsBounded U
+  /-- The frontier of a Jordan domain is a Jordan curve. -/
+  isJordanCurve_frontier : IsJordanCurve (frontier U)
+
+/-- A disc of positive radius is a Jordan domain: its frontier is the circle of the same centre and
+radius. This is the model Jordan domain, and the target of every Riemann map. -/
+theorem isJordanDomain_ball (c : ℂ) (hr : 0 < r) : IsJordanDomain (ball c r) where
+  isOpen := isOpen_ball
+  isConnected := (convex_ball c r).isConnected (nonempty_ball.2 hr)
+  isBounded := isBounded_ball
+  isJordanCurve_frontier := by
+    rw [frontier_ball c hr.ne']
+    exact isJordanCurve_sphere c hr
+
+/-! ## Elementary consequences of being a Jordan domain -/
+
+/-- A Jordan domain is nonempty. -/
+theorem IsJordanDomain.nonempty (h : IsJordanDomain U) : U.Nonempty := h.isConnected.nonempty
+
+/-- The closure of a Jordan domain is compact. -/
+theorem IsJordanDomain.isCompact_closure (h : IsJordanDomain U) : IsCompact (closure U) :=
+  h.isBounded.isCompact_closure
+
+/-- The frontier of a Jordan domain is nonempty; in particular a Jordan domain is a *proper* open
+subset of `ℂ`, so that — once it is also simply connected — it satisfies the hypotheses of the
+Riemann mapping theorem. -/
+theorem IsJordanDomain.frontier_nonempty (h : IsJordanDomain U) : (frontier U).Nonempty :=
+  h.isJordanCurve_frontier.nonempty
+
+/-- A Jordan domain is not all of `ℂ`. -/
+theorem IsJordanDomain.ne_univ (h : IsJordanDomain U) : U ≠ univ := by
+  intro hU
+  obtain ⟨w, hw⟩ := h.frontier_nonempty
+  rw [hU, frontier_univ] at hw
+  exact hw
+
+/-! ## The converse half of the Carathéodory correspondence -/
+
+/-- **A conformal map with an injective continuous extension transports the Jordan property back
+across the boundary.** If a holomorphic `f` on a bounded open `U` has a continuous extension `F` to
+`closure U` that is injective there, and the frontier of the image `f '' U` is a Jordan curve, then
+so is the frontier of `U`.
+
+The extension carries `frontier U` onto `frontier (f '' U)`
+(`TauCeti.image_frontier_eq_frontier_image`) and is continuous and injective there, and `frontier U`
+is compact because `U` is bounded; `TauCeti.IsJordanCurve.of_image` does the rest. Injectivity of
+`f` on `U` is not assumed: it follows from that of `F` on `closure U`. -/
+theorem isJordanCurve_frontier_of_isJordanCurve_frontier_image (hUo : IsOpen U)
+    (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
+    (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
+    (h : IsJordanCurve (frontier (f '' U))) : IsJordanCurve (frontier U) := by
+  have hcpt : IsCompact (frontier U) :=
+    hUb.isCompact_closure.of_isClosed_subset isClosed_frontier frontier_subset_closure
+  exact IsJordanCurve.of_image hcpt (hFc.mono frontier_subset_closure)
+    (hFi.mono frontier_subset_closure)
+    (image_frontier_eq_frontier_image hUo hUb hfd hFc hFf hFi ▸ h)
+
+/-- **The converse half of the Carathéodory boundary correspondence.** A bounded domain of `ℂ` that
+a holomorphic map carries onto a disc, extending continuously and injectively to the closure, is a
+Jordan domain.
+
+Carathéodory's theorem — layer **L5** of the conformal-mapping roadmap — is the converse: for a
+Jordan domain such an extension *exists*. Together the two say that, among bounded domains, being a
+Jordan domain is exactly the condition under which the Riemann map extends to a homeomorphism of
+the closures. -/
+theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U) (hUc : IsConnected U)
+    (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
+    (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
+    (hr : 0 < r) (himg : f '' U = ball c r) : IsJordanDomain U where
+  isOpen := hUo
+  isConnected := hUc
+  isBounded := hUb
+  isJordanCurve_frontier := by
+    refine isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi ?_
+    rw [himg, frontier_ball c hr.ne']
+    exact isJordanCurve_sphere c hr
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
@@ -51,10 +51,11 @@ are.
   and the one Carathéodory's theorem compares every other Jordan domain to. Its frontier is a
   circle, which `TauCeti.isJordanCurve_sphere` already knows to be a Jordan curve.
 * `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image`,
-  `TauCeti.isJordanDomain_of_isJordanDomain_image` and `TauCeti.isJordanDomain_of_image_eq_ball` —
-  **the converse half of the Carathéodory correspondence**: if a conformal map on a bounded open
-  `U` extends continuously and injectively to `closure U` and carries `U` onto a Jordan domain —
-  a disc, in the last of the three — then `U` is itself a Jordan domain.
+  `TauCeti.isJordanDomain_of_isJordanCurve_frontier_image` and
+  `TauCeti.isJordanDomain_of_image_eq_ball` — **the converse half of the Carathéodory
+  correspondence**: if a conformal map on a bounded open `U` extends continuously and injectively
+  to `closure U` and carries `U` onto a connected set with Jordan frontier — a disc, in the last of
+  the three — then `U` is itself a Jordan domain.
 
 ## Generality
 
@@ -161,21 +162,26 @@ theorem isJordanCurve_frontier_of_isJordanCurve_frontier_image (hUo : IsOpen U)
     (image_frontier_eq_frontier_image hUo hUb hfd hFc hFf hFi ▸ h)
 
 /-- **The converse half of the Carathéodory boundary correspondence.** A bounded open set of `ℂ`
-that a holomorphic map carries onto a Jordan domain, extending continuously and injectively to the
-closure, is itself a Jordan domain.
+that a holomorphic map carries onto a connected set with Jordan frontier, extending continuously
+and injectively to the closure, is itself a Jordan domain.
 
 Carathéodory's theorem — layer **L5** of the conformal-mapping roadmap — is the converse for the
 disc: for a Jordan domain such an extension *exists*. Together the two say that, among bounded
 domains, being a Jordan domain is exactly the condition under which the Riemann map extends to a
 homeomorphism of the closures.
 
-Connectedness of `U` is not assumed: `f` is an open partial homeomorphism of `U` onto `f '' U`
-(`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the connected set
-`f '' U` under the continuous inverse. -/
-theorem isJordanDomain_of_isJordanDomain_image (hUo : IsOpen U)
+Only two of the four properties of a Jordan domain are asked of the image, since the other two are
+already carried across by `f`: the image of an open set under an injective holomorphic map is open,
+and the image is bounded because `F` is continuous on the compact `closure U`. A caller holding
+`h : TauCeti.IsJordanDomain (f '' U)` supplies `h.isConnected` and `h.isJordanCurve_frontier`.
+Connectedness of `U` itself is likewise not assumed: `f` is an open partial homeomorphism of `U`
+onto `f '' U` (`TauCeti.DifferentiableOn.toOpenPartialHomeomorph`), so `U` is the image of the
+connected `f '' U` under the continuous inverse. -/
+theorem isJordanDomain_of_isJordanCurve_frontier_image (hUo : IsOpen U)
     (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
     (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
-    (himg : IsJordanDomain (f '' U)) : IsJordanDomain U where
+    (himgc : IsConnected (f '' U)) (himg : IsJordanCurve (frontier (f '' U))) :
+    IsJordanDomain U where
   isOpen := hUo
   isConnected := by
     have hfi : InjOn f U := fun x hx y hy hxy =>
@@ -185,24 +191,24 @@ theorem isJordanDomain_of_isJordanDomain_image (hUo : IsOpen U)
     have hsymm : e.symm '' (f '' U) = U := by
       rw [← htgt, e.symm_image_target_eq_source, he,
         DifferentiableOn.toOpenPartialHomeomorph_source]
-    exact hsymm ▸ himg.isConnected.image _ (e.continuousOn_symm.mono htgt.ge)
+    exact hsymm ▸ himgc.image _ (e.continuousOn_symm.mono htgt.ge)
   isBounded := hUb
   isJordanCurve_frontier :=
-    isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi
-      himg.isJordanCurve_frontier
+    isJordanCurve_frontier_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi himg
 
 /-- **The converse half of the Carathéodory boundary correspondence, for the disc.** A bounded open
 set of `ℂ` that a holomorphic map carries onto a disc, extending continuously and injectively to
 the closure, is a Jordan domain.
 
-This is the case of `TauCeti.isJordanDomain_of_isJordanDomain_image` in which the image is the
-model Jordan domain, and it is the form the Carathéodory correspondence is stated in, the disc
+This is the case of `TauCeti.isJordanDomain_of_isJordanCurve_frontier_image` in which the image is
+the model Jordan domain, and it is the form the Carathéodory correspondence is stated in, the disc
 being the target of every Riemann map. -/
 theorem isJordanDomain_of_image_eq_ball (hUo : IsOpen U)
     (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U)
     (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) (hFi : InjOn F (closure U))
     (hr : 0 < r) (himg : f '' U = ball c r) : IsJordanDomain U :=
-  isJordanDomain_of_isJordanDomain_image hUo hUb hfd hFc hFf hFi
-    (himg ▸ isJordanDomain_ball c hr)
+  isJordanDomain_of_isJordanCurve_frontier_image hUo hUb hfd hFc hFf hFi
+    (himg ▸ (isJordanDomain_ball c hr).isConnected)
+    (himg ▸ (isJordanDomain_ball c hr).isJordanCurve_frontier)
 
 end TauCeti

--- a/TauCeti/Topology/JordanCurve.lean
+++ b/TauCeti/Topology/JordanCurve.lean
@@ -1,0 +1,147 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import Mathlib.Topology.Homeomorph.Lemmas
+
+/-!
+# Jordan curves
+
+A **Jordan curve** — a simple closed curve — is a subset of a topological space homeomorphic to
+the circle. This file introduces the predicate `TauCeti.IsJordanCurve` and its basic API.
+
+The circle is Mathlib's `Circle`, the unit circle of `ℂ` as a topological group; the notion itself
+is purely topological, so `TauCeti.IsJordanCurve` is stated for a subset of an arbitrary
+topological space, and only the model curve is complex-analytic.
+
+Phrasing the predicate as *the set is homeomorphic to the circle*, rather than *the set is the
+range of a continuous map on `[0, 1]` that is injective except for matching endpoints*, is what
+makes it usable: the two agree, because a continuous injection out of a compact space into a
+Hausdorff space is an embedding, but the parametrized form buries that argument in every use. It is
+recovered where needed from `TauCeti.IsJordanCurve.of_image`, which says exactly that a compact set
+carried injectively and continuously onto a Jordan curve is itself one.
+
+## Main definitions
+
+* `TauCeti.IsJordanCurve` — a set homeomorphic to the circle.
+
+## Main results
+
+* `TauCeti.IsJordanCurve.isCompact`, `TauCeti.IsJordanCurve.isPathConnected`,
+  `TauCeti.IsJordanCurve.nonempty` and `TauCeti.IsJordanCurve.not_subsingleton` — a Jordan curve is
+  a nonempty compact path-connected set with more than one point.
+* `TauCeti.IsJordanCurve.image` and `TauCeti.IsJordanCurve.of_image` — being a Jordan curve
+  transfers in both directions along a map that is continuous and injective on the set, provided
+  the codomain is Hausdorff (and, in the direction that creates the curve out of nothing, the
+  source set is known to be compact).
+* `TauCeti.IsJordanCurve.image_homeomorph` — the image of a Jordan curve under a homeomorphism of
+  the ambient spaces is a Jordan curve; no separation axiom is needed.
+
+## Motivation
+
+This is the vocabulary layer **L5** of the conformal-mapping roadmap
+(`TauCetiRoadmap/ConformalMapping/README.md`) is stated in: its milestone, the Carathéodory
+boundary correspondence, is about the Riemann map of a *Jordan domain*, and the roadmap records
+that the pinned Mathlib has no Jordan-curve vocabulary to state it against. The complex-analytic
+half — Jordan domains, the circle as the boundary of a disc, and the boundary of a domain that a
+conformal map carries onto a disc — is in
+`TauCeti/Analysis/Complex/Conformal/JordanDomain.lean`.
+
+## References
+
+* C. Jordan, *Cours d'analyse de l'École Polytechnique*, vol. 3 (1887).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set Topology
+
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {C : Set X}
+
+/-- A **Jordan curve**, or simple closed curve, in a topological space: a subset homeomorphic to
+the circle.
+
+The predicate is `Nonempty (C ≃ₜ Circle)` rather than a chosen homeomorphism, so that it is a
+`Prop`; `TauCeti.isJordanCurve_iff` recovers the homeomorphism from another module, where the
+definition itself is not exposed. -/
+def IsJordanCurve (C : Set X) : Prop := Nonempty (C ≃ₜ Circle)
+
+/-- A set is a Jordan curve exactly when it is homeomorphic to the circle. This is the interface
+to `TauCeti.IsJordanCurve` outside its defining module. -/
+theorem isJordanCurve_iff : IsJordanCurve C ↔ Nonempty (C ≃ₜ Circle) := Iff.rfl
+
+/-- A continuous injection defined on a compact set is a homeomorphism onto its image, the image
+carrying the subspace topology of a Hausdorff space. This is the set-level form of
+`Continuous.homeoOfEquivCompactToT2`, and the engine of both transfer lemmas below. -/
+private noncomputable def imageHomeomorphOfIsCompact [T2Space Y] (hC : IsCompact C) {g : X → Y}
+    (hg : ContinuousOn g C) (hgi : InjOn g C) : C ≃ₜ g '' C :=
+  haveI : CompactSpace C := isCompact_iff_compactSpace.mp hC
+  Continuous.homeoOfEquivCompactToT2 (f := hgi.bijOn_image.equiv g)
+    (hg.mapsToRestrict hgi.bijOn_image.mapsTo)
+
+/-- A Jordan curve is compact: the circle is. -/
+theorem IsJordanCurve.isCompact (h : IsJordanCurve C) : IsCompact C := by
+  obtain ⟨e⟩ := h
+  exact isCompact_iff_compactSpace.mpr e.symm.compactSpace
+
+/-- A Jordan curve in a Hausdorff space is closed. -/
+theorem IsJordanCurve.isClosed [T2Space X] (h : IsJordanCurve C) : IsClosed C :=
+  h.isCompact.isClosed
+
+/-- A Jordan curve is path connected: the circle is. -/
+theorem IsJordanCurve.isPathConnected (h : IsJordanCurve C) : IsPathConnected C := by
+  obtain ⟨e⟩ := h
+  exact isPathConnected_iff_pathConnectedSpace.mpr
+    (e.symm.surjective.pathConnectedSpace e.symm.continuous)
+
+/-- A Jordan curve is connected. -/
+theorem IsJordanCurve.isConnected (h : IsJordanCurve C) : IsConnected C :=
+  h.isPathConnected.isConnected
+
+/-- A Jordan curve is nonempty. -/
+theorem IsJordanCurve.nonempty (h : IsJordanCurve C) : C.Nonempty := h.isConnected.nonempty
+
+/-- A Jordan curve has more than one point: the circle contains both `1` and `-1`. Together with
+`TauCeti.IsJordanCurve.isConnected` this rules out the degenerate curves, so a Jordan curve is a
+nondegenerate continuum. -/
+theorem IsJordanCurve.not_subsingleton (h : IsJordanCurve C) : ¬ C.Subsingleton := by
+  obtain ⟨e⟩ := h
+  intro hsub
+  exact Circle.neg_ne_self 1
+    (e.symm.injective (Subtype.ext (hsub (e.symm (-1)).2 (e.symm 1).2)))
+
+/-- **A Jordan curve is carried to a Jordan curve by a continuous injection.** Only continuity and
+injectivity *on the curve* are needed, the curve supplying the compactness that upgrades them to a
+homeomorphism onto the image. -/
+theorem IsJordanCurve.image [T2Space Y] (h : IsJordanCurve C) {g : X → Y} (hg : ContinuousOn g C)
+    (hgi : InjOn g C) : IsJordanCurve (g '' C) := by
+  have hC := h.isCompact
+  obtain ⟨e⟩ := h
+  exact ⟨(imageHomeomorphOfIsCompact hC hg hgi).symm.trans e⟩
+
+/-- **A compact set carried onto a Jordan curve by a continuous injection is a Jordan curve.**
+This is the converse of `TauCeti.IsJordanCurve.image`; compactness of the source has to be assumed
+here, since it is no longer inherited from the curve. It is the form in which the predicate is
+usually verified: one exhibits a continuous injective parametrization or, as in the boundary
+correspondence, a continuous injective map of the set onto a circle. -/
+theorem IsJordanCurve.of_image [T2Space Y] (hC : IsCompact C) {g : X → Y} (hg : ContinuousOn g C)
+    (hgi : InjOn g C) (h : IsJordanCurve (g '' C)) : IsJordanCurve C := by
+  obtain ⟨e⟩ := h
+  exact ⟨(imageHomeomorphOfIsCompact hC hg hgi).trans e⟩
+
+/-- The image of a Jordan curve under a homeomorphism of the ambient spaces is a Jordan curve.
+Unlike `TauCeti.IsJordanCurve.image` this needs no separation axiom on the codomain, because
+`Homeomorph.image` supplies the homeomorphism onto the image outright. -/
+theorem IsJordanCurve.image_homeomorph (h : IsJordanCurve C) (e : X ≃ₜ Y) :
+    IsJordanCurve (e '' C) := by
+  obtain ⟨f⟩ := h
+  exact ⟨(e.image C).symm.trans f⟩
+
+end TauCeti

--- a/TauCeti/Topology/JordanCurve.lean
+++ b/TauCeti/Topology/JordanCurve.lean
@@ -16,14 +16,17 @@ the circle. This file introduces the predicate `TauCeti.IsJordanCurve` and its b
 
 The circle is Mathlib's `Circle`, the unit circle of `ℂ` as a topological group; the notion itself
 is purely topological, so `TauCeti.IsJordanCurve` is stated for a subset of an arbitrary
-topological space, and only the model curve is complex-analytic.
+topological space. Only the model curve — a circle `Metric.sphere c r` of positive radius in `ℂ`,
+at the end of the file — mentions `ℂ`, and it needs nothing beyond the metric structure.
 
 Phrasing the predicate as *the set is homeomorphic to the circle*, rather than *the set is the
 range of a continuous map on `[0, 1]` that is injective except for matching endpoints*, is what
-makes it usable: the two agree, because a continuous injection out of a compact space into a
-Hausdorff space is an embedding, but the parametrized form buries that argument in every use. It is
-recovered where needed from `TauCeti.IsJordanCurve.of_image`, which says exactly that a compact set
-carried injectively and continuously onto a Jordan curve is itself one.
+makes it usable: over a Hausdorff ambient space the two agree, because there a continuous injection
+out of a compact space is an embedding, but the parametrized form buries that argument in every
+use. Passing from a parametrization to the predicate is `TauCeti.IsJordanCurve.image`, which turns
+a continuous injective map defined on a set already known to be a Jordan curve — a circle in `ℂ`,
+say — into a proof that its image is one; `TauCeti.IsJordanCurve.of_image` runs the other way,
+transporting the property back to a compact set from an image already known to be a Jordan curve.
 
 ## Main definitions
 
@@ -36,10 +39,12 @@ carried injectively and continuously onto a Jordan curve is itself one.
   a nonempty compact path-connected set with more than one point.
 * `TauCeti.IsJordanCurve.image` and `TauCeti.IsJordanCurve.of_image` — being a Jordan curve
   transfers in both directions along a map that is continuous and injective on the set, provided
-  the codomain is Hausdorff (and, in the direction that creates the curve out of nothing, the
-  source set is known to be compact).
+  the codomain is Hausdorff (and, in the direction that transports the property back from the
+  image, the source set is known to be compact).
 * `TauCeti.IsJordanCurve.image_homeomorph` — the image of a Jordan curve under a homeomorphism of
   the ambient spaces is a Jordan curve; no separation axiom is needed.
+* `TauCeti.sphereCircleHomeomorph` and `TauCeti.isJordanCurve_sphere` — a circle of positive radius
+  in `ℂ` is a Jordan curve, by the affine change of coordinates `w ↦ (w - c) / r`.
 
 ## Motivation
 
@@ -47,9 +52,8 @@ This is the vocabulary layer **L5** of the conformal-mapping roadmap
 (`TauCetiRoadmap/ConformalMapping/README.md`) is stated in: its milestone, the Carathéodory
 boundary correspondence, is about the Riemann map of a *Jordan domain*, and the roadmap records
 that the pinned Mathlib has no Jordan-curve vocabulary to state it against. The complex-analytic
-half — Jordan domains, the circle as the boundary of a disc, and the boundary of a domain that a
-conformal map carries onto a disc — is in
-`TauCeti/Analysis/Complex/Conformal/JordanDomain.lean`.
+half — Jordan domains, the discs among them, and the boundary of a domain that a conformal map
+carries onto a disc — is in `TauCeti/Analysis/Complex/Conformal/JordanDomain.lean`.
 
 ## References
 
@@ -61,9 +65,9 @@ public section
 
 namespace TauCeti
 
-open Set Topology
+open Metric Set Topology
 
-variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {C : Set X}
+variable {X Y : Type*} [TopologicalSpace X] [TopologicalSpace Y] {C : Set X} {r : ℝ}
 
 /-- A **Jordan curve**, or simple closed curve, in a topological space: a subset homeomorphic to
 the circle.
@@ -129,8 +133,9 @@ theorem IsJordanCurve.image [T2Space Y] (h : IsJordanCurve C) {g : X → Y} (hg 
 /-- **A compact set carried onto a Jordan curve by a continuous injection is a Jordan curve.**
 This is the converse of `TauCeti.IsJordanCurve.image`; compactness of the source has to be assumed
 here, since it is no longer inherited from the curve. It is the form in which the predicate is
-usually verified: one exhibits a continuous injective parametrization or, as in the boundary
-correspondence, a continuous injective map of the set onto a circle. -/
+verified when the curve is the *unknown* rather than the parameter: one exhibits a continuous
+injective map of the set onto a set already known to be a Jordan curve, as the boundary
+correspondence does with the boundary of a disc. -/
 theorem IsJordanCurve.of_image [T2Space Y] (hC : IsCompact C) {g : X → Y} (hg : ContinuousOn g C)
     (hgi : InjOn g C) (h : IsJordanCurve (g '' C)) : IsJordanCurve C := by
   obtain ⟨e⟩ := h
@@ -143,5 +148,38 @@ theorem IsJordanCurve.image_homeomorph (h : IsJordanCurve C) (e : X ≃ₜ Y) :
     IsJordanCurve (e '' C) := by
   obtain ⟨f⟩ := h
   exact ⟨(e.image C).symm.trans f⟩
+
+/-! ## The model curve: a circle in `ℂ` -/
+
+/-- The affine parametrization `w ↦ (w - c) / r` of a circle of centre `c` and positive radius `r`
+in `ℂ` by the unit circle. It is the restriction to the spheres of the ambient homeomorphism
+`w ↦ (w - c) * r⁻¹` of `ℂ`, so only the membership equivalence is proved here. -/
+noncomputable def sphereCircleHomeomorph (c : ℂ) (hr : 0 < r) : sphere c r ≃ₜ Circle :=
+  haveI hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
+  ((Homeomorph.subRight c).trans (Homeomorph.mulRight₀ (r : ℂ)⁻¹ (inv_ne_zero hr0))).subtype
+    fun w => by
+      simp [Submonoid.unitSphere, mem_sphere_iff_norm, abs_of_pos hr,
+        mul_inv_eq_one₀ hr.ne', eq_comm]
+
+/-- The parametrization of `sphere c r` by the unit circle divides out the affine change of
+coordinates. -/
+@[simp]
+lemma coe_sphereCircleHomeomorph_apply (c : ℂ) (hr : 0 < r) (w : sphere c r) :
+    (sphereCircleHomeomorph c hr w : ℂ) = ((w : ℂ) - c) / r := by
+  rw [div_eq_mul_inv]
+  rfl
+
+/-- The inverse parametrization of `sphere c r` by the unit circle is the affine change of
+coordinates. -/
+@[simp]
+lemma coe_sphereCircleHomeomorph_symm_apply (c : ℂ) (hr : 0 < r) (z : Circle) :
+    (((sphereCircleHomeomorph c hr).symm z : sphere c r) : ℂ) = c + r * (z : ℂ) := by
+  change (z : ℂ) * ((r : ℂ)⁻¹)⁻¹ + c = c + r * (z : ℂ)
+  rw [inv_inv]
+  ring
+
+/-- A circle of positive radius in `ℂ` is a Jordan curve. -/
+theorem isJordanCurve_sphere (c : ℂ) (hr : 0 < r) : IsJordanCurve (sphere c r) :=
+  isJordanCurve_iff.mpr ⟨sphereCircleHomeomorph c hr⟩
 
 end TauCeti

--- a/TauCeti/Topology/JordanCurve.lean
+++ b/TauCeti/Topology/JordanCurve.lean
@@ -17,7 +17,8 @@ the circle. This file introduces the predicate `TauCeti.IsJordanCurve` and its b
 The circle is Mathlib's `Circle`, the unit circle of `ℂ` as a topological group; the notion itself
 is purely topological, so `TauCeti.IsJordanCurve` is stated for a subset of an arbitrary
 topological space. Only the model curve — a circle `Metric.sphere c r` of positive radius in `ℂ`,
-at the end of the file — mentions `ℂ`, and it needs nothing beyond the metric structure.
+at the end of the file — mentions `ℂ`, and it is built from the complex affine change of
+coordinates `w ↦ (w - c) / r`, so it uses the field structure of `ℂ` and not only its metric.
 
 Phrasing the predicate as *the set is homeomorphic to the circle*, rather than *the set is the
 range of a continuous map on `[0, 1]` that is injective except for matching endpoints*, is what
@@ -41,8 +42,9 @@ transporting the property back to a compact set from an image already known to b
   transfers in both directions along a map that is continuous and injective on the set, provided
   the codomain is Hausdorff (and, in the direction that transports the property back from the
   image, the source set is known to be compact).
-* `TauCeti.IsJordanCurve.image_homeomorph` — the image of a Jordan curve under a homeomorphism of
-  the ambient spaces is a Jordan curve; no separation axiom is needed.
+* `TauCeti.IsJordanCurve.image_homeomorph` and `TauCeti.isJordanCurve_image_homeomorph_iff` — being
+  a Jordan curve is invariant under a homeomorphism of the ambient spaces; no separation axiom is
+  needed.
 * `TauCeti.sphereCircleHomeomorph` and `TauCeti.isJordanCurve_sphere` — a circle of positive radius
   in `ℂ` is a Jordan curve, by the affine change of coordinates `w ↦ (w - c) / r`.
 
@@ -149,34 +151,69 @@ theorem IsJordanCurve.image_homeomorph (h : IsJordanCurve C) (e : X ≃ₜ Y) :
   obtain ⟨f⟩ := h
   exact ⟨(e.image C).symm.trans f⟩
 
+/-- Being a Jordan curve is invariant under a homeomorphism of the ambient spaces. This is the
+characteristic form of `TauCeti.IsJordanCurve.image_homeomorph`: the backward direction is that
+lemma applied to `e.symm`, which no consumer then has to spell out. -/
+@[simp]
+theorem isJordanCurve_image_homeomorph_iff (e : X ≃ₜ Y) :
+    IsJordanCurve (e '' C) ↔ IsJordanCurve C :=
+  ⟨fun h => e.symm_image_image C ▸ h.image_homeomorph e.symm, fun h => h.image_homeomorph e⟩
+
 /-! ## The model curve: a circle in `ℂ` -/
+
+/-- The affine change of coordinates `w ↦ (w - c) * r⁻¹` of `ℂ`, as a homeomorphism of `ℂ`. It
+carries `Metric.sphere c r` onto the unit sphere, and `TauCeti.sphereCircleHomeomorph` is its
+restriction to those spheres. -/
+private noncomputable def affineHomeomorph (c : ℂ) (hr : (r : ℂ) ≠ 0) : ℂ ≃ₜ ℂ :=
+  (Homeomorph.subRight c).trans (Homeomorph.mulRight₀ (r : ℂ)⁻¹ (inv_ne_zero hr))
+
+private lemma affineHomeomorph_apply {c : ℂ} (hr : (r : ℂ) ≠ 0) (w : ℂ) :
+    affineHomeomorph c hr w = (w - c) / r := by
+  simp [affineHomeomorph, div_eq_mul_inv]
+
+private lemma affineHomeomorph_symm_apply {c : ℂ} (hr : (r : ℂ) ≠ 0) (z : ℂ) :
+    (affineHomeomorph c hr).symm z = c + r * z := by
+  simp [affineHomeomorph]
+  ring
+
+/-- `Circle` is *by definition* the unit sphere of `ℂ`, but it is a `def` rather than an
+abbreviation, so its topology is only definitionally the subtype topology. This identification is
+the one place where that unfolding happens; the lemmas below then compute with the unit sphere
+alone. -/
+private noncomputable def unitSphereCircleHomeomorph : sphere (0 : ℂ) 1 ≃ₜ Circle :=
+  Homeomorph.refl _
+
+private lemma coe_unitSphereCircleHomeomorph (z : sphere (0 : ℂ) 1) :
+    (unitSphereCircleHomeomorph z : ℂ) = (z : ℂ) := rfl
+
+private lemma coe_unitSphereCircleHomeomorph_symm (z : Circle) :
+    ((unitSphereCircleHomeomorph.symm z : sphere (0 : ℂ) 1) : ℂ) = (z : ℂ) := rfl
 
 /-- The affine parametrization `w ↦ (w - c) / r` of a circle of centre `c` and positive radius `r`
 in `ℂ` by the unit circle. It is the restriction to the spheres of the ambient homeomorphism
-`w ↦ (w - c) * r⁻¹` of `ℂ`, so only the membership equivalence is proved here. -/
+`TauCeti.affineHomeomorph`, so only the membership equivalence is proved here. -/
 noncomputable def sphereCircleHomeomorph (c : ℂ) (hr : 0 < r) : sphere c r ≃ₜ Circle :=
   haveI hr0 : (r : ℂ) ≠ 0 := by exact_mod_cast hr.ne'
-  ((Homeomorph.subRight c).trans (Homeomorph.mulRight₀ (r : ℂ)⁻¹ (inv_ne_zero hr0))).subtype
-    fun w => by
-      simp [Submonoid.unitSphere, mem_sphere_iff_norm, abs_of_pos hr,
-        mul_inv_eq_one₀ hr.ne', eq_comm]
+  ((affineHomeomorph c hr0).subtype fun w => by
+      rw [affineHomeomorph_apply]
+      simp [mem_sphere_iff_norm, abs_of_pos hr, div_eq_one_iff_eq, hr.ne']).trans
+    unitSphereCircleHomeomorph
 
 /-- The parametrization of `sphere c r` by the unit circle divides out the affine change of
 coordinates. -/
 @[simp]
 lemma coe_sphereCircleHomeomorph_apply (c : ℂ) (hr : 0 < r) (w : sphere c r) :
     (sphereCircleHomeomorph c hr w : ℂ) = ((w : ℂ) - c) / r := by
-  rw [div_eq_mul_inv]
-  rfl
+  rw [sphereCircleHomeomorph, Homeomorph.trans_apply, coe_unitSphereCircleHomeomorph,
+    Homeomorph.subtype_apply_coe, affineHomeomorph_apply]
 
 /-- The inverse parametrization of `sphere c r` by the unit circle is the affine change of
 coordinates. -/
 @[simp]
 lemma coe_sphereCircleHomeomorph_symm_apply (c : ℂ) (hr : 0 < r) (z : Circle) :
     (((sphereCircleHomeomorph c hr).symm z : sphere c r) : ℂ) = c + r * (z : ℂ) := by
-  change (z : ℂ) * ((r : ℂ)⁻¹)⁻¹ + c = c + r * (z : ℂ)
-  rw [inv_inv]
-  ring
+  rw [sphereCircleHomeomorph, Homeomorph.symm_trans_apply, Homeomorph.subtype_symm_apply_coe,
+    coe_unitSphereCircleHomeomorph_symm, affineHomeomorph_symm_apply]
 
 /-- A circle of positive radius in `ℂ` is a Jordan curve. -/
 theorem isJordanCurve_sphere (c : ℂ) (hr : 0 < r) : IsJordanCurve (sphere c r) :=


### PR DESCRIPTION
This PR adds the Jordan-curve vocabulary that layer **L5** of the conformal-mapping roadmap is stated in, and proves the converse half of the Carathéodory boundary correspondence. `TauCeti/Topology/JordanCurve.lean` defines `TauCeti.IsJordanCurve C` — a subset of a topological space homeomorphic to Mathlib's `Circle` — and gives its API: a Jordan curve is compact, closed in a Hausdorff space, path connected, nonempty and not a subsingleton, and the property transfers in both directions along a map continuous and injective on the set (`TauCeti.IsJordanCurve.image` and `TauCeti.IsJordanCurve.of_image`, the latter creating the curve out of a compact set carried onto one), as well as along a homeomorphism of the ambient spaces. `TauCeti/Analysis/Complex/Conformal/JordanDomain.lean` then adds the complex-analytic half: `TauCeti.sphereCircleHomeomorph`, the affine parametrization `w ↦ (w - c) / r` showing a circle of positive radius is a Jordan curve; the structure `TauCeti.IsJordanDomain` (open, connected, bounded, with a Jordan curve for frontier) with the discs as its basic example `TauCeti.isJordanDomain_ball`; and `TauCeti.isJordanDomain_of_image_eq_ball` — **if a holomorphic map on a bounded open `U` extends continuously and injectively to `closure U` and carries `U` onto a disc, then `U` is a Jordan domain.**

The roadmap target is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5 — Carathéodory boundary correspondence** ("the RMT map of a Jordan domain extends to a homeomorphism of closures"). The README records that the pinned Mathlib carries no Jordan-domain vocabulary to state that milestone cleanly against — which is why `Suggested.lean` stops at L4 and leaves L5 without a representative signature — so this is the prerequisite the milestone needs before it can even be written down. A grep over the pinned Mathlib for `jordan curve`, `simple closed curve` and `SimpleClosed` finds nothing, and nothing in `TauCeti/` defines the notion either.

What is proved on top of the vocabulary is the *accessible* direction of the correspondence. Both directions run through the boundary homeomorphism `TauCeti.closureHomeomorph` from #1536, but producing the continuous extension is the hard half — it needs the boundary geometry to collapse the cluster sets of the map, the material #1555 and #1575 are building — and is deliberately **not** attempted here. Reading the boundary geometry back *off* an extension that is already given is short, because #1536 already proved that an injective continuous extension carries `frontier U` onto `frontier (f '' U)`: `frontier U` is compact whenever `U` is bounded, so `TauCeti.IsJordanCurve.of_image` transports the circle backwards along the extension. The statement is that Carathéodory's Jordan hypothesis is not merely sufficient but necessary — among bounded domains, "conformally a disc, with the map extending to a homeomorphism of the closures" implies "Jordan" — which is what makes L5 a correspondence rather than a one-way sufficient condition. It is stated in the general form `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image`, where the image is any domain with Jordan frontier, with the disc case as the corollary.

Phrasing the predicate as *homeomorphic to the circle*, rather than as the range of a loop injective except at matching endpoints, is what makes it usable: the two agree because a continuous injection out of a compact space into a Hausdorff space is an embedding, and burying that argument in every use is exactly what `TauCeti.IsJordanCurve.of_image` exists to avoid. Boundedness is part of `IsJordanDomain` because the two complementary domains of a Jordan curve share their boundary and it is the bounded one that Carathéodory compares to the disc; `TauCeti.IsJordanDomain.ne_univ` and `TauCeti.IsJordanDomain.nonempty` record that a Jordan domain meets the remaining hypotheses of the Riemann mapping theorem. The purely topological content is stated for an arbitrary topological space, and only the complex-analytic file is specialized to `ℂ`, per the roadmap's generality bar for layers L0–L6.

Nothing is vendored from Mathlib. The proofs consume `Continuous.homeoOfEquivCompactToT2`, `Set.BijOn.equiv`, `ContinuousOn.mapsToRestrict`, `isPathConnected_iff_pathConnectedSpace` together with Mathlib's `PathConnectedSpace Circle` instance and `Circle.neg_ne_self`, `Homeomorph.image`, `frontier_ball`, `convex_ball` and `Convex.isConnected`; on the Tau Ceti side the single input is `TauCeti.image_frontier_eq_frontier_image` from `Conformal/BoundaryCorrespondence.lean`. Per the roadmap's coordination clause, layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping effort, which stops at the mapping theorem itself, so this is new formalization rather than a temporary shim; it does consume, transitively, the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib once the upstream work lands. The mathematics follows Carathéodory (Math. Ann. 73, 1913) as presented in Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2, and Conway, *Functions of One Complex Variable I*, Ch. IX.

Files: `TauCeti/Topology/JordanCurve.lean` (new, 147 lines) and `TauCeti/Analysis/Complex/Conformal/JordanDomain.lean` (new, 223 lines). `lake build` completes successfully (5994 jobs), `lake exe axioms` audits 17304 declarations within the allowlist `[propext, Classical.choice, Quot.sound]`, `lake exe module-system` passes on all 953 modules, and `scripts/lint-env.sh` reports no new violations.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"jordan-curve-jordan-domain"}-->

🤖 Prepared with Claude Code
