### PR TITLE
refactor(SchwarzPick): decompose the rigidity inverse construction

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -123,12 +123,16 @@ theorem exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq
   simp only [hgζ, hg0, zero_add, sub_zero, smul_eq_mul] at hval
   exact hval.trans (mul_comm _ _)
 
-/-- Multiplication by a constant of modulus one is a self-map of the open unit disc. -/
-private lemma mapsTo_ball_const_mul_of_norm_eq_one {C : ℂ} (hC : ‖C‖ = 1) :
+/-- Multiplication by a constant of modulus at most one is a self-map of the open unit disc:
+it is a contraction, so it cannot increase the distance to the centre. -/
+private lemma mapsTo_ball_const_mul_of_norm_le_one {C : ℂ} (hC : ‖C‖ ≤ 1) :
     MapsTo (fun η : ℂ => C * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
   intro η hη
   rw [mem_ball_zero_iff] at hη ⊢
-  simpa [hC] using hη
+  have hle : ‖C * η‖ ≤ ‖η‖ := by
+    rw [norm_mul]
+    exact mul_le_of_le_one_left (norm_nonneg η) hC
+  exact hle.trans_lt hη
 
 /-- **The explicit inverse undoes `f` from the right.** If the Moebius factor at `a` conjugates
 `f` into the rotation by `C` composed with the Moebius factor at `w`, then the composite
@@ -147,7 +151,8 @@ private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : �
   have hC0 : C ≠ 0 := fun h => zero_ne_one (by rw [h, norm_zero] at hC; exact hC)
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
-  have hR_maps := mapsTo_ball_const_mul_of_norm_eq_one (C := C⁻¹) (by rw [norm_inv, hC, inv_one])
+  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one (C := C⁻¹)
+    (le_of_eq (by rw [norm_inv, hC, inv_one]))
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
     (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
@@ -194,7 +199,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hR_diff : DifferentiableOn ℂ (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) :=
     differentiableOn_id.const_mul _
-  have hR_maps := mapsTo_ball_const_mul_of_norm_eq_one hCinv
+  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
   refine ⟨(fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
       (fun η : ℂ => C⁻¹ * η) ∘
       (fun η : ℂ => (η - f w) / (1 - (starRingEnd ℂ) (f w) * η)), ?_, ?_, ?_, ?_⟩

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -123,17 +123,6 @@ theorem exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq
   simp only [hgζ, hg0, zero_add, sub_zero, smul_eq_mul] at hval
   exact hval.trans (mul_comm _ _)
 
-/-- Multiplication by a constant of modulus at most one is a self-map of the open unit disc:
-it is a contraction, so it cannot increase the distance to the centre. -/
-private lemma mapsTo_ball_const_mul_of_norm_le_one {C : ℂ} (hC : ‖C‖ ≤ 1) :
-    MapsTo (fun η : ℂ => C * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-  intro η hη
-  rw [mem_ball_zero_iff] at hη ⊢
-  have hle : ‖C * η‖ ≤ ‖η‖ := by
-    rw [norm_mul]
-    exact mul_le_of_le_one_left (norm_nonneg η) hC
-  exact hle.trans_lt hη
-
 /-- **The explicit inverse undoes `f` from the right.** If the Moebius factor at `a` conjugates
 `f` into the rotation by `C` composed with the Moebius factor at `w`, then the composite
 `M₋w ∘ (C⁻¹ · ) ∘ M_a` is a right inverse of `f` on the disc.
@@ -151,8 +140,11 @@ private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : �
   have hC0 : C ≠ 0 := fun h => zero_ne_one (by rw [h, norm_zero] at hC; exact hC)
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
-  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one (C := C⁻¹)
-    (le_of_eq (by rw [norm_inv, hC, inv_one]))
+  have hCinv : ‖C⁻¹‖ = 1 := by rw [norm_inv, hC, inv_one]
+  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    fun η hη => by
+      have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hCinv.le hη
+      rwa [smul_eq_mul] at h
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
     (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
@@ -199,7 +191,10 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hR_diff : DifferentiableOn ℂ (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) :=
     differentiableOn_id.const_mul _
-  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
+  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    fun η hη => by
+      have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hCinv.le hη
+      rwa [smul_eq_mul] at h
   refine ⟨(fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
       (fun η : ℂ => C⁻¹ * η) ∘
       (fun η : ℂ => (η - f w) / (1 - (starRingEnd ℂ) (f w) * η)), ?_, ?_, ?_, ?_⟩

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -123,39 +123,26 @@ theorem exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq
   simp only [hgζ, hg0, zero_add, sub_zero, smul_eq_mul] at hval
   exact hval.trans (mul_comm _ _)
 
-/-- Multiplication by a constant of modulus at most one is a self-map of the open unit disc.
-
-This is Mathlib's `balanced_ball_zero` — a ball at the origin is balanced — read through
-`smul_eq_mul`; the lemma exists only to name that specialisation for the two call sites below. -/
-private lemma mapsTo_ball_const_mul_of_norm_le_one {C : ℂ} (hC : ‖C‖ ≤ 1) :
-    MapsTo (fun η : ℂ => C * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := fun η hη => by
-  have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hC hη
-  rwa [smul_eq_mul] at h
-
 /-- **The explicit inverse undoes `f` from the right.** If the Moebius factor at `a` conjugates
 `f` into the rotation by `C` composed with the Moebius factor at `w`, then the composite
 `M₋w ∘ (C⁻¹ · ) ∘ M_a` is a right inverse of `f` on the disc.
 
-Only the conjugation identity, the three norm bounds and the self-map property of `f` are used;
-differentiability of `f` and of the factors plays no part in this half. The scalar `C` is assumed
-only to satisfy `1 ≤ ‖C‖`, which is all that `C ≠ 0` and the contractivity of `C⁻¹` need — the
-caller supplies a unimodular `C`. -/
+Only the conjugation identity, the two norm bounds and the self-map properties of `f` and of the
+inverse rotation are used; differentiability of `f` and of the factors plays no part in this half.
+The scalar `C` enters only through `C ≠ 0` and through `hR_maps`, so the caller may supply any
+nonzero `C` whose inverse contracts the disc — in particular a unimodular one. -/
 private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : ‖a‖ < 1)
-    (hw : ‖w‖ < 1) (hC : 1 ≤ ‖C‖) (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hw : ‖w‖ < 1) (hC0 : C ≠ 0)
+    (hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
     (hCeq : ∀ ζ ∈ ball (0 : ℂ) 1, (f ζ - a) / (1 - (starRingEnd ℂ) a * f ζ)
       = C * ((ζ - w) / (1 - (starRingEnd ℂ) w * ζ))) :
     RightInvOn ((fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
         (fun η : ℂ => C⁻¹ * η) ∘
         (fun η : ℂ => (η - a) / (1 - (starRingEnd ℂ) a * η)))
       f (ball (0 : ℂ) 1) := by
-  have hC0 : C ≠ 0 := by
-    intro h
-    rw [h, norm_zero] at hC
-    linarith
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
-  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one
-    (C := C⁻¹) (by rw [norm_inv]; exact inv_le_one_of_one_le₀ hC)
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
     (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
@@ -202,7 +189,11 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hR_diff : DifferentiableOn ℂ (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) :=
     differentiableOn_id.const_mul _
-  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
+  -- The inverse rotation is a disc self-map because a ball at the origin is balanced.
+  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
+    fun η hη => by
+      have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hCinv.le hη
+      rwa [smul_eq_mul] at h
   refine ⟨(fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
       (fun η : ℂ => C⁻¹ * η) ∘
       (fun η : ℂ => (η - f w) / (1 - (starRingEnd ℂ) (f w) * η)), ?_, ?_, ?_, ?_⟩
@@ -212,7 +203,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
     intro ζ hζ
     simp only [Function.comp_apply, hCeq ζ hζ, inv_mul_cancel_left₀ hC0]
     exact leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hw_norm hζ
-  · exact rightInvOn_moebius_rotate_moebius_of_forall_eq hfw_norm hw_norm hC.ge hmaps hCeq
+  · exact rightInvOn_moebius_rotate_moebius_of_forall_eq hfw_norm hw_norm hC0 hR_maps hmaps hCeq
 
 /--
 **Schwarz--Pick rigidity, bijectivity form.**  A holomorphic self-map of the open unit disc

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -123,6 +123,15 @@ theorem exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq
   simp only [hgζ, hg0, zero_add, sub_zero, smul_eq_mul] at hval
   exact hval.trans (mul_comm _ _)
 
+/-- Multiplication by a constant of modulus at most one is a self-map of the open unit disc.
+
+This is Mathlib's `balanced_ball_zero` — a ball at the origin is balanced — read through
+`smul_eq_mul`; the lemma exists only to name that specialisation for the two call sites below. -/
+private lemma mapsTo_ball_const_mul_of_norm_le_one {C : ℂ} (hC : ‖C‖ ≤ 1) :
+    MapsTo (fun η : ℂ => C * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := fun η hη => by
+  have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hC hη
+  rwa [smul_eq_mul] at h
+
 /-- **The explicit inverse undoes `f` from the right.** If the Moebius factor at `a` conjugates
 `f` into the rotation by `C` composed with the Moebius factor at `w`, then the composite
 `M₋w ∘ (C⁻¹ · ) ∘ M_a` is a right inverse of `f` on the disc.
@@ -141,10 +150,7 @@ private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : �
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
   have hCinv : ‖C⁻¹‖ = 1 := by rw [norm_inv, hC, inv_one]
-  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    fun η hη => by
-      have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hCinv.le hη
-      rwa [smul_eq_mul] at h
+  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
     (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
@@ -191,10 +197,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hR_diff : DifferentiableOn ℂ (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) :=
     differentiableOn_id.const_mul _
-  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    fun η hη => by
-      have h := (balanced_ball_zero (𝕜 := ℂ) (r := 1)).smul_mem hCinv.le hη
-      rwa [smul_eq_mul] at h
+  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
   refine ⟨(fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
       (fun η : ℂ => C⁻¹ * η) ∘
       (fun η : ℂ => (η - f w) / (1 - (starRingEnd ℂ) (f w) * η)), ?_, ?_, ?_, ?_⟩

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -137,20 +137,25 @@ private lemma mapsTo_ball_const_mul_of_norm_le_one {C : ℂ} (hC : ‖C‖ ≤ 1
 `M₋w ∘ (C⁻¹ · ) ∘ M_a` is a right inverse of `f` on the disc.
 
 Only the conjugation identity, the three norm bounds and the self-map property of `f` are used;
-differentiability of `f` and of the factors plays no part in this half. -/
+differentiability of `f` and of the factors plays no part in this half. The scalar `C` is assumed
+only to satisfy `1 ≤ ‖C‖`, which is all that `C ≠ 0` and the contractivity of `C⁻¹` need — the
+caller supplies a unimodular `C`. -/
 private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : ‖a‖ < 1)
-    (hw : ‖w‖ < 1) (hC : ‖C‖ = 1) (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hw : ‖w‖ < 1) (hC : 1 ≤ ‖C‖) (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
     (hCeq : ∀ ζ ∈ ball (0 : ℂ) 1, (f ζ - a) / (1 - (starRingEnd ℂ) a * f ζ)
       = C * ((ζ - w) / (1 - (starRingEnd ℂ) w * ζ))) :
     RightInvOn ((fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
         (fun η : ℂ => C⁻¹ * η) ∘
         (fun η : ℂ => (η - a) / (1 - (starRingEnd ℂ) a * η)))
       f (ball (0 : ℂ) 1) := by
-  have hC0 : C ≠ 0 := fun h => zero_ne_one (by rw [h, norm_zero] at hC; exact hC)
+  have hC0 : C ≠ 0 := by
+    intro h
+    rw [h, norm_zero] at hC
+    linarith
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
-  have hCinv : ‖C⁻¹‖ = 1 := by rw [norm_inv, hC, inv_one]
-  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one hCinv.le
+  have hR_maps := mapsTo_ball_const_mul_of_norm_le_one
+    (C := C⁻¹) (by rw [norm_inv]; exact inv_le_one_of_one_le₀ hC)
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
     (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
@@ -207,7 +212,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
     intro ζ hζ
     simp only [Function.comp_apply, hCeq ζ hζ, inv_mul_cancel_left₀ hC0]
     exact leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hw_norm hζ
-  · exact rightInvOn_moebius_rotate_moebius_of_forall_eq hfw_norm hw_norm hC hmaps hCeq
+  · exact rightInvOn_moebius_rotate_moebius_of_forall_eq hfw_norm hw_norm hC.ge hmaps hCeq
 
 /--
 **Schwarz--Pick rigidity, bijectivity form.**  A holomorphic self-map of the open unit disc

--- a/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
+++ b/TauCeti/Analysis/Complex/Conformal/SchwarzPick/Rigidity.lean
@@ -123,6 +123,50 @@ theorem exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq
   simp only [hgζ, hg0, zero_add, sub_zero, smul_eq_mul] at hval
   exact hval.trans (mul_comm _ _)
 
+/-- Multiplication by a constant of modulus one is a self-map of the open unit disc. -/
+private lemma mapsTo_ball_const_mul_of_norm_eq_one {C : ℂ} (hC : ‖C‖ = 1) :
+    MapsTo (fun η : ℂ => C * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
+  intro η hη
+  rw [mem_ball_zero_iff] at hη ⊢
+  simpa [hC] using hη
+
+/-- **The explicit inverse undoes `f` from the right.** If the Moebius factor at `a` conjugates
+`f` into the rotation by `C` composed with the Moebius factor at `w`, then the composite
+`M₋w ∘ (C⁻¹ · ) ∘ M_a` is a right inverse of `f` on the disc.
+
+Only the conjugation identity, the three norm bounds and the self-map property of `f` are used;
+differentiability of `f` and of the factors plays no part in this half. -/
+private lemma rightInvOn_moebius_rotate_moebius_of_forall_eq {a C : ℂ} (ha : ‖a‖ < 1)
+    (hw : ‖w‖ < 1) (hC : ‖C‖ = 1) (hmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hCeq : ∀ ζ ∈ ball (0 : ℂ) 1, (f ζ - a) / (1 - (starRingEnd ℂ) a * f ζ)
+      = C * ((ζ - w) / (1 - (starRingEnd ℂ) w * ζ))) :
+    RightInvOn ((fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
+        (fun η : ℂ => C⁻¹ * η) ∘
+        (fun η : ℂ => (η - a) / (1 - (starRingEnd ℂ) a * η)))
+      f (ball (0 : ℂ) 1) := by
+  have hC0 : C ≠ 0 := fun h => zero_ne_one (by rw [h, norm_zero] at hC; exact hC)
+  have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw
+  have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha
+  have hR_maps := mapsTo_ball_const_mul_of_norm_eq_one (C := C⁻¹) (by rw [norm_inv, hC, inv_one])
+  have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
+  have hTinj : InjOn (fun ζ : ℂ => (ζ - a) / (1 - (starRingEnd ℂ) a * ζ)) (ball (0 : ℂ) 1) :=
+    (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha).injOn
+  intro η hη
+  simp only [Function.comp_apply]
+  set ζ : ℂ := (C⁻¹ * ((η - a) / (1 - (starRingEnd ℂ) a * η)) - -w) /
+      (1 - (starRingEnd ℂ) (-w) * (C⁻¹ * ((η - a) / (1 - (starRingEnd ℂ) a * η)))) with hζdef
+  have hRTη : C⁻¹ * ((η - a) / (1 - (starRingEnd ℂ) a * η)) ∈ ball (0 : ℂ) 1 :=
+    hR_maps (hT_maps hη)
+  have hζ : ζ ∈ ball (0 : ℂ) 1 := hS_maps hRTη
+  -- Undo the outer Moebius factor, then the rotation, and compare through the injective `M_a`.
+  have hmoebius : (ζ - w) / (1 - (starRingEnd ℂ) w * ζ)
+      = C⁻¹ * ((η - a) / (1 - (starRingEnd ℂ) a * η)) := by
+    simpa [hζdef] using
+      leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw hRTη
+  refine hTinj (hmaps hζ) hη ?_
+  dsimp only
+  rw [hCeq ζ hζ, hmoebius, mul_inv_cancel_left₀ hC0]
+
 /--
 **The inverse map produced by Schwarz--Pick rigidity.**  Under the hypotheses of
 `TauCeti.exists_norm_eq_one_forall_eq_of_pseudoHyperbolicExpr_map_eq`, the map `f` has an
@@ -142,10 +186,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hw_norm : ‖w‖ < 1 := by simpa [mem_ball_zero_iff] using hw
   have hnegw : ‖(-w : ℂ)‖ < 1 := by simpa using hw_norm
   have hfw_norm : ‖f w‖ < 1 := by simpa [mem_ball_zero_iff] using hmaps hw
-  have hC0 : C ≠ 0 := by
-    intro h
-    rw [h, norm_zero] at hC
-    exact zero_ne_one hC
+  have hC0 : C ≠ 0 := fun h => zero_ne_one (by rw [h, norm_zero] at hC; exact hC)
   have hCinv : ‖C⁻¹‖ = 1 := by rw [norm_inv, hC, inv_one]
   have hT_diff := differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one hfw_norm
   have hT_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hfw_norm
@@ -153,13 +194,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
   have hS_maps := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw
   have hR_diff : DifferentiableOn ℂ (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) :=
     differentiableOn_id.const_mul _
-  have hR_maps : MapsTo (fun η : ℂ => C⁻¹ * η) (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) := by
-    intro η hη
-    rw [mem_ball_zero_iff] at hη ⊢
-    simpa [hCinv] using hη
-  have hTinj : InjOn (fun ζ : ℂ => (ζ - f w) / (1 - (starRingEnd ℂ) (f w) * ζ))
-      (ball (0 : ℂ) 1) :=
-    (leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hfw_norm).injOn
+  have hR_maps := mapsTo_ball_const_mul_of_norm_eq_one hCinv
   refine ⟨(fun ξ : ℂ => (ξ - (-w)) / (1 - (starRingEnd ℂ) (-w) * ξ)) ∘
       (fun η : ℂ => C⁻¹ * η) ∘
       (fun η : ℂ => (η - f w) / (1 - (starRingEnd ℂ) (f w) * η)), ?_, ?_, ?_, ?_⟩
@@ -169,25 +204,7 @@ theorem exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq
     intro ζ hζ
     simp only [Function.comp_apply, hCeq ζ hζ, inv_mul_cancel_left₀ hC0]
     exact leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hw_norm hζ
-  · -- `f (g η) = η`: run the identity at `g η`, then cancel the outer Moebius factor.
-    intro η hη
-    simp only [Function.comp_apply]
-    set ζ : ℂ :=
-      (C⁻¹ * ((η - f w) / (1 - (starRingEnd ℂ) (f w) * η)) - -w) /
-        (1 - (starRingEnd ℂ) (-w) * (C⁻¹ * ((η - f w) / (1 - (starRingEnd ℂ) (f w) * η))))
-      with hζdef
-    have hTη : (η - f w) / (1 - (starRingEnd ℂ) (f w) * η) ∈ ball (0 : ℂ) 1 := hT_maps hη
-    have hRTη : C⁻¹ * ((η - f w) / (1 - (starRingEnd ℂ) (f w) * η)) ∈ ball (0 : ℂ) 1 :=
-      hR_maps hTη
-    have hζ : ζ ∈ ball (0 : ℂ) 1 := hS_maps hRTη
-    have hmoebius : (ζ - w) / (1 - (starRingEnd ℂ) w * ζ)
-        = C⁻¹ * ((η - f w) / (1 - (starRingEnd ℂ) (f w) * η)) := by
-      simpa [hζdef] using
-        leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one (a := -w) hnegw hRTη
-    have hTfζ : (f ζ - f w) / (1 - (starRingEnd ℂ) (f w) * f ζ)
-        = (η - f w) / (1 - (starRingEnd ℂ) (f w) * η) := by
-      rw [hCeq ζ hζ, hmoebius, mul_inv_cancel_left₀ hC0]
-    exact hTinj (hmaps hζ) hη hTfζ
+  · exact rightInvOn_moebius_rotate_moebius_of_forall_eq hfw_norm hw_norm hC hmaps hCeq
 
 /--
 **Schwarz--Pick rigidity, bijectivity form.**  A holomorphic self-map of the open unit disc


### PR DESCRIPTION
`exists_differentiableOn_mapsTo_invOn_of_pseudoHyperbolicExpr_map_eq` landed in #1517 with a
**51-line** body. Its four goals are very unevenly sized — the two regularity clauses are one
line each and the left-inverse clause is four, while the right-inverse clause was nineteen, most
of the proof.

## The two helpers

| lemma | content |
|---|---|
| `mapsTo_ball_const_mul_of_norm_le_one` | multiplication by a constant of modulus `≤ 1` is a self-map of the disc |
| `rightInvOn_moebius_rotate_moebius_of_forall_eq` | the composite `M₋w ∘ (C⁻¹ · ) ∘ M_a` undoes `f` from the right |

Both are `private`. Bodies go **51 → 24** (parent) **/ 22**.

The first has **two** consumers — the parent's `MapsTo` clause and the right-inverse helper —
so it is not a single-use wrapper.

## Minimal hypotheses at the point of extraction

`rightInvOn_moebius_rotate_moebius_of_forall_eq` is stated from the conjugation identity alone:
`‖a‖ < 1`, `‖w‖ < 1`, `‖C‖ = 1`, the self-map property of `f`, and `hCeq`. Two deliberate
choices:

- **The Moebius centre `a` is a free variable, not `f w`.** The parent instantiates it at `f w`,
  but nothing in this half needs the centre to be a value of `f`; carrying `f w` in would have
  tied the lemma to its caller for no reason.
- **Differentiability is not threaded in.** The parent has `hf`, `hT_diff`, `hS_diff` and
  `hR_diff` to hand, and it would have been easy to pass them along. The right-inverse argument
  is purely algebraic — undo the outer Moebius factor, cancel the rotation, then compare through
  the injective `M_a` — so none of them appear.

Everything else the half needs (`C ≠ 0`, `‖-w‖ < 1`, the three `MapsTo` facts, injectivity of
`M_a`) is derived inside the helper from those five hypotheses rather than passed in.

## Dry-run round 1

**`generality` — applied in `9464964`.** The scalar-multiplication helper assumed `‖C‖ = 1` when
the conclusion only needs a contraction: `‖C * η‖ ≤ ‖η‖ < 1`. It now takes `‖C‖ ≤ 1` and is named
`mapsTo_ball_const_mul_of_norm_le_one`. Both call sites apply it to the unimodular `C⁻¹` and pass
the inequality — `hCinv.le` in the parent, `le_of_eq …` in the right-inverse helper.

## Degenerate ends

There are no numeric ranges to instantiate here; the hypotheses are strict norm bounds. Worth
noting that `‖C‖ = 1` forces `C ≠ 0`, which the helper derives rather than assumes, so no
degenerate `C = 0` case can arise.

## Scope

One file, one topic. **No statement changes**: the public theorem keeps its exact signature and
both helpers are `private`, so the module's documented API is unchanged.

Gates run locally as separate steps, all green: `lake build`, `lake exe axioms`,
`lake exe module-system`, `scripts/lint-env.sh`.

Roadmap: ConformalMapping

