### PR TITLE
feat: identify universal-cover deck transformations

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -92,6 +92,20 @@ lemma loopDeckHom_apply (g : FundamentalGroup X x₀) :
     loopDeckHom x₀ g = loopDeck x₀ g :=
   (rfl)
 
+/-- The constant-path lift of the basepoint, regarded as a point of the fibre over the
+basepoint. -/
+private def reflFiberPoint : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} :=
+  ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)),
+    Set.mem_singleton_iff.mpr (by
+      rw [proj_ofBasedPath]
+      exact BasedPath.endpoint_ofPath _)⟩
+
+@[simp]
+private lemma reflFiberPoint_val :
+    (reflFiberPoint x₀ : UniversalCover x₀) =
+      ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) :=
+  rfl
+
 /-- The endpoint projection of the universal cover has regular deck action. -/
 theorem isRegular_proj [PathConnectedSpace X] :
     Deck.IsRegular (proj : UniversalCover x₀ → X) := by
@@ -109,10 +123,7 @@ noncomputable def deckFundamentalGroupEquiv
     [SemilocallySimplyConnectedSpace X] :
     Deck (proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ :=
   (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
-    ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
-      change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
-      rw [Set.mem_singleton_iff, proj_ofBasedPath]
-      exact BasedPath.endpoint_ofPath _⟩
+    (reflFiberPoint x₀)
 
 /-- The inverse deck-to-fundamental-group equivalence recovers the explicit loop deck
 transformation, with the inverse forced by the left-action convention. -/
@@ -123,14 +134,13 @@ lemma deckFundamentalGroupEquiv_symm_op
     (g : FundamentalGroup X x₀) :
     (deckFundamentalGroupEquiv x₀).symm (MulOpposite.op g) = loopDeck x₀ g⁻¹ := by
   have hmonodromy : ((isCoveringMap x₀).monodromy g.toPath
-      ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
-        change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
-        rw [Set.mem_singleton_iff, proj_ofBasedPath]
-        exact BasedPath.endpoint_ofPath _⟩ :
+      (reflFiberPoint x₀) :
         UniversalCover x₀) =
       g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
     obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
     rw [← hγ]
+    -- `monodromy` is defined by quotient-lifting the endpoint of `liftPath`; unfolding it
+    -- after choosing the representative `γ` exposes exactly that defining computation.
     change (isCoveringMap x₀).liftPath γ
         (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
     let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
@@ -153,6 +163,8 @@ lemma deckFundamentalGroupEquiv_symm_op
               ((Path.refl x₀).trans γ)) :=
           Path.Homotopic.hpath_hext (fun _ ↦ rfl)
         refine hcast.trans (heq_of_eq ?_)
+        -- The preceding `HEq` has aligned the dependent path endpoints.  What remains is
+        -- its underlying quotient equality, whose displayed types differ only by those casts.
         change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
           g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
         rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
@@ -160,11 +172,12 @@ lemma deckFundamentalGroupEquiv_symm_op
         exact (Path.Homotopic.Quotient.trans_refl _).symm
   apply (Deck.IsRegular.deckFundamentalGroupEquiv_symm_op_eq_iff
     (isRegular_proj x₀) (isCoveringMap x₀)
-      ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
-        change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
-        rw [Set.mem_singleton_iff, proj_ofBasedPath]
-        exact BasedPath.endpoint_ofPath _⟩
+      (reflFiberPoint x₀)
       g (loopDeck x₀ g⁻¹)).2
-  simpa only [Deck.smul_eq_apply, loopDeck_apply] using hmonodromy
+  -- Display the fundamental-group coercion and the chosen fibre point explicitly so the
+  -- named monodromy calculation above applies without unfolding either wrapper.
+  change ((isCoveringMap x₀).monodromy g.toPath (reflFiberPoint x₀) :
+    UniversalCover x₀) = (loopDeck x₀ g⁻¹).1 (reflFiberPoint x₀)
+  simpa only [Deck.smul_eq_apply, loopDeck_apply, reflFiberPoint_val] using hmonodromy
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -125,6 +125,47 @@ noncomputable def deckFundamentalGroupEquiv
   (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
     (reflFiberPoint x₀)
 
+private lemma monodromy_reflFiberPoint
+    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X]
+    (g : FundamentalGroup X x₀) :
+    ((isCoveringMap x₀).monodromy g.toPath (reflFiberPoint x₀) :
+      UniversalCover x₀) =
+      g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
+  obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
+  rw [← hγ]
+  -- `monodromy` is defined by quotient-lifting the endpoint of `liftPath`; unfolding it
+  -- after choosing the representative `γ` exposes exactly that defining computation.
+  change (isCoveringMap x₀).liftPath γ
+      (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
+  let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
+    γ.cast (BasedPath.endpoint_ofPath _) rfl
+  calc
+    _ = (isCoveringMap x₀).liftPath δ
+        (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 := by
+      congr 1
+    _ = ofBasedPath x₀ (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ) :=
+      liftPath_apply_one_eq_ofBasedPath_append δ
+    _ = g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
+      rw [ofBasedPath_ofPath, Path.Homotopic.Quotient.mk_refl, inv_smul_mk]
+      rw [ofBasedPath_def]
+      let hend := BasedPath.endpoint_append (BasedPath.ofPath (Path.refl x₀)) δ
+      apply UniversalCover.ext hend
+      have hcast : HEq
+          (Path.Homotopic.Quotient.mk
+            (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ).toPath)
+          (Path.Homotopic.Quotient.mk
+            ((Path.refl x₀).trans γ)) :=
+        Path.Homotopic.hpath_hext (fun _ ↦ rfl)
+      refine hcast.trans (heq_of_eq ?_)
+      -- The preceding `HEq` has aligned the dependent path endpoints.  What remains is
+      -- its underlying quotient equality, whose displayed types differ only by those casts.
+      change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
+        g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
+      rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
+        Path.Homotopic.Quotient.refl_trans]
+      exact (Path.Homotopic.Quotient.trans_refl _).symm
+
 /-- The inverse deck-to-fundamental-group equivalence recovers the explicit loop deck
 transformation, with the inverse forced by the left-action convention. -/
 @[simp]
@@ -133,43 +174,6 @@ lemma deckFundamentalGroupEquiv_symm_op
     [SemilocallySimplyConnectedSpace X]
     (g : FundamentalGroup X x₀) :
     (deckFundamentalGroupEquiv x₀).symm (MulOpposite.op g) = loopDeck x₀ g⁻¹ := by
-  have hmonodromy : ((isCoveringMap x₀).monodromy g.toPath
-      (reflFiberPoint x₀) :
-        UniversalCover x₀) =
-      g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
-    obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
-    rw [← hγ]
-    -- `monodromy` is defined by quotient-lifting the endpoint of `liftPath`; unfolding it
-    -- after choosing the representative `γ` exposes exactly that defining computation.
-    change (isCoveringMap x₀).liftPath γ
-        (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
-    let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
-      γ.cast (BasedPath.endpoint_ofPath _) rfl
-    calc
-      _ = (isCoveringMap x₀).liftPath δ
-          (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 := by
-        congr 1
-      _ = ofBasedPath x₀ (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ) :=
-        liftPath_apply_one_eq_ofBasedPath_append δ
-      _ = g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
-        rw [ofBasedPath_ofPath, Path.Homotopic.Quotient.mk_refl, inv_smul_mk]
-        rw [ofBasedPath_def]
-        let hend := BasedPath.endpoint_append (BasedPath.ofPath (Path.refl x₀)) δ
-        apply UniversalCover.ext hend
-        have hcast : HEq
-            (Path.Homotopic.Quotient.mk
-              (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ).toPath)
-            (Path.Homotopic.Quotient.mk
-              ((Path.refl x₀).trans γ)) :=
-          Path.Homotopic.hpath_hext (fun _ ↦ rfl)
-        refine hcast.trans (heq_of_eq ?_)
-        -- The preceding `HEq` has aligned the dependent path endpoints.  What remains is
-        -- its underlying quotient equality, whose displayed types differ only by those casts.
-        change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
-          g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
-        rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
-          Path.Homotopic.Quotient.refl_trans]
-        exact (Path.Homotopic.Quotient.trans_refl _).symm
   apply (Deck.IsRegular.deckFundamentalGroupEquiv_symm_op_eq_iff
     (isRegular_proj x₀) (isCoveringMap x₀)
       (reflFiberPoint x₀)
@@ -178,6 +182,7 @@ lemma deckFundamentalGroupEquiv_symm_op
   -- named monodromy calculation above applies without unfolding either wrapper.
   change ((isCoveringMap x₀).monodromy g.toPath (reflFiberPoint x₀) :
     UniversalCover x₀) = (loopDeck x₀ g⁻¹).1 (reflFiberPoint x₀)
-  simpa only [Deck.smul_eq_apply, loopDeck_apply, reflFiberPoint_val] using hmonodromy
+  simpa only [Deck.smul_eq_apply, loopDeck_apply, reflFiberPoint_val] using
+    monodromy_reflFiberPoint x₀ g
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -49,7 +49,7 @@ variable {X : Type*} [TopologicalSpace X] (x₀ : X)
 
 /-- A loop class acts on the universal cover by a deck transformation of the endpoint
 projection. -/
-@[expose] def loopDeck (g : FundamentalGroup X x₀) :
+def loopDeck (g : FundamentalGroup X x₀) :
     Deck (proj : UniversalCover x₀ → X) :=
   ⟨Homeomorph.smul g, fun p => proj_smul g p⟩
 
@@ -57,7 +57,7 @@ projection. -/
 @[simp]
 lemma loopDeck_apply (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
     (loopDeck x₀ g).1 p = g • p :=
-  rfl
+  (rfl)
 
 /-- The identity loop class induces the identity deck transformation. -/
 @[simp]
@@ -81,7 +81,7 @@ lemma loopDeck_mul (g h : FundamentalGroup X x₀) :
 
 /-- The fundamental-group action, bundled as a homomorphism into the deck group of the
 universal-cover projection. -/
-@[expose] def loopDeckHom :
+def loopDeckHom :
     FundamentalGroup X x₀ →* Deck (proj : UniversalCover x₀ → X) where
   toFun := loopDeck x₀
   map_one' := loopDeck_one x₀
@@ -90,7 +90,7 @@ universal-cover projection. -/
 @[simp]
 lemma loopDeckHom_apply (g : FundamentalGroup X x₀) :
     loopDeckHom x₀ g = loopDeck x₀ g :=
-  rfl
+  (rfl)
 
 /-- The endpoint projection of the universal cover has regular deck action. -/
 theorem isRegular_proj [PathConnectedSpace X] :

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -61,7 +61,9 @@ lemma loopDeck_apply (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
 
 /-- The identity loop class induces the identity deck transformation. -/
 @[simp]
-lemma loopDeck_one : loopDeck x₀ 1 = 1 := by
+lemma loopDeck_one :
+    loopDeck x₀ (CategoryTheory.CategoryStruct.id
+      ({ as := x₀ } : FundamentalGroupoid X)) = 1 := by
   apply Subtype.ext
   apply Homeomorph.ext
   intro p
@@ -71,7 +73,7 @@ lemma loopDeck_one : loopDeck x₀ 1 = 1 := by
 /-- Multiplication of loop classes corresponds to composition of their deck transformations. -/
 @[simp]
 lemma loopDeck_mul (g h : FundamentalGroup X x₀) :
-    loopDeck x₀ (g * h) = loopDeck x₀ g * loopDeck x₀ h := by
+    loopDeck x₀ (CategoryTheory.CategoryStruct.comp h g) = loopDeck x₀ g * loopDeck x₀ h := by
   apply Subtype.ext
   apply Homeomorph.ext
   intro p

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -67,7 +67,7 @@ lemma loopDeck_one :
   apply Subtype.ext
   apply Homeomorph.ext
   intro p
-  change (1 : FundamentalGroup X x₀) • p = p
+  rw [loopDeck_apply]
   exact one_smul _ _
 
 /-- Multiplication of loop classes corresponds to composition of their deck transformations. -/
@@ -93,8 +93,7 @@ lemma loopDeckHom_apply (g : FundamentalGroup X x₀) :
   rfl
 
 /-- The endpoint projection of the universal cover has regular deck action. -/
-theorem isRegular_proj [LocallyPathConnectedSpace X] [PathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X] :
+theorem isRegular_proj [PathConnectedSpace X] :
     Deck.IsRegular (proj : UniversalCover x₀ → X) := by
   rw [Deck.isRegular_iff_exists_apply_eq]
   refine ⟨proj_surjective, ?_⟩
@@ -105,11 +104,25 @@ theorem isRegular_proj [LocallyPathConnectedSpace X] [PathConnectedSpace X]
 
 /-- The deck transformation group of the based-path universal cover is the opposite of the
 fundamental group of the base. -/
-@[expose] noncomputable def deckFundamentalGroupEquiv
+noncomputable def deckFundamentalGroupEquiv
     [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] :
     Deck (proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ :=
   (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
     ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩
+
+/-- A deck transformation corresponds to a loop class exactly when the loop's monodromy moves
+the canonical lift by that deck transformation. -/
+lemma deckFundamentalGroupEquiv_apply_eq_op_iff
+    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X]
+    (φ : Deck (proj : UniversalCover x₀ → X)) (g : FundamentalGroup X x₀) :
+    deckFundamentalGroupEquiv x₀ φ = MulOpposite.op g ↔
+      ((isCoveringMap x₀).monodromy g
+        ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩ : UniversalCover x₀) =
+        φ • mk x₀ (Path.Homotopic.Quotient.refl x₀) := by
+  exact Deck.IsRegular.deckFundamentalGroupEquiv_apply_eq_op_iff
+    (isRegular_proj x₀) (isCoveringMap x₀)
+      ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩ φ g
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -109,20 +109,62 @@ noncomputable def deckFundamentalGroupEquiv
     [SemilocallySimplyConnectedSpace X] :
     Deck (proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ :=
   (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
-    ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩
+    ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
+      change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
+      rw [Set.mem_singleton_iff, proj_ofBasedPath]
+      exact BasedPath.endpoint_ofPath _⟩
 
-/-- A deck transformation corresponds to a loop class exactly when the loop's monodromy moves
-the canonical lift by that deck transformation. -/
-lemma deckFundamentalGroupEquiv_apply_eq_op_iff
+/-- The inverse deck-to-fundamental-group equivalence recovers the explicit loop deck
+transformation, with the inverse forced by the left-action convention. -/
+@[simp]
+lemma deckFundamentalGroupEquiv_symm_op
     [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X]
-    (φ : Deck (proj : UniversalCover x₀ → X)) (g : FundamentalGroup X x₀) :
-    deckFundamentalGroupEquiv x₀ φ = MulOpposite.op g ↔
-      ((isCoveringMap x₀).monodromy g
-        ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩ : UniversalCover x₀) =
-        φ • mk x₀ (Path.Homotopic.Quotient.refl x₀) := by
-  exact Deck.IsRegular.deckFundamentalGroupEquiv_apply_eq_op_iff
+    (g : FundamentalGroup X x₀) :
+    (deckFundamentalGroupEquiv x₀).symm (MulOpposite.op g) = loopDeck x₀ g⁻¹ := by
+  have hmonodromy : ((isCoveringMap x₀).monodromy g.toPath
+      ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
+        change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
+        rw [Set.mem_singleton_iff, proj_ofBasedPath]
+        exact BasedPath.endpoint_ofPath _⟩ :
+        UniversalCover x₀) =
+      g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
+    obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
+    rw [← hγ]
+    change (isCoveringMap x₀).liftPath γ
+        (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
+    let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
+      γ.cast (BasedPath.endpoint_ofPath _) rfl
+    calc
+      _ = (isCoveringMap x₀).liftPath δ
+          (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 := by
+        congr 1
+      _ = ofBasedPath x₀ (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ) :=
+        liftPath_apply_one_eq_ofBasedPath_append δ
+      _ = g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
+        rw [ofBasedPath_ofPath, Path.Homotopic.Quotient.mk_refl, inv_smul_mk]
+        rw [ofBasedPath_def]
+        let hend := BasedPath.endpoint_append (BasedPath.ofPath (Path.refl x₀)) δ
+        apply UniversalCover.ext hend
+        have hcast : HEq
+            (Path.Homotopic.Quotient.mk
+              (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ).toPath)
+            (Path.Homotopic.Quotient.mk
+              ((Path.refl x₀).trans γ)) :=
+          Path.Homotopic.hpath_hext (fun _ ↦ rfl)
+        refine hcast.trans (heq_of_eq ?_)
+        change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
+          g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
+        rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
+          Path.Homotopic.Quotient.refl_trans]
+        exact (Path.Homotopic.Quotient.trans_refl _).symm
+  apply (Deck.IsRegular.deckFundamentalGroupEquiv_symm_op_eq_iff
     (isRegular_proj x₀) (isCoveringMap x₀)
-      ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩ φ g
+      ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)), by
+        change proj (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) ∈ ({x₀} : Set X)
+        rw [Set.mem_singleton_iff, proj_ofBasedPath]
+        exact BasedPath.endpoint_ofPath _⟩
+      g (loopDeck x₀ g⁻¹)).2
+  simpa only [Deck.smul_eq_apply, loopDeck_apply] using hmonodromy
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Action
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.FundamentalGroup.Opposite
+
+/-!
+# Deck transformations of the universal cover
+
+For a path-connected, locally path-connected, semilocally simply connected space `X`, the
+endpoint projection from the based-path universal cover is regular. Indeed, the explicit
+fundamental-group action from `UniversalCover.Action` acts through deck transformations and is
+transitive on each fibre.
+
+Combining this regularity with the simple connectedness of the universal cover and the generic
+regular-cover comparison gives the convention-correct form of the classical calculation
+
+`Deck (UniversalCover.proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ`.
+
+The opposite is genuine: the fundamental group acts on the universal cover by prepending the
+inverse loop, while deck transformations are composed as homeomorphisms. This is the convention
+pinned by `TauCeti.Deck.IsRegular.deckFundamentalGroupEquiv`.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.loopDeck`: the deck transformation induced by a loop class.
+* `TauCeti.UniversalCover.isRegular_proj`: regularity of the universal-cover projection.
+* `TauCeti.UniversalCover.deckFundamentalGroupEquiv`: the deck group of the universal cover is
+  the opposite fundamental group.
+
+## References
+
+This completes Stage 1, item 5 of `TauCetiRoadmap/UniversalCovers/README.md`. The construction
+uses the universal-cover action adapted from Kim Morrison's mathlib4 PR
+[mathlib4#38292](https://github.com/leanprover-community/mathlib4/pull/38292), and the generic
+comparison ultimately uses Junyan Xu's `IsQuotientCoveringMap.fundamentalGroupEquiv` from
+`Mathlib.Topology.Homotopy.Lifting`.
+-/
+
+public section
+noncomputable section
+
+namespace TauCeti.UniversalCover
+
+variable {X : Type*} [TopologicalSpace X] (x₀ : X)
+
+/-- A loop class acts on the universal cover by a deck transformation of the endpoint
+projection. -/
+@[expose] def loopDeck (g : FundamentalGroup X x₀) :
+    Deck (proj : UniversalCover x₀ → X) :=
+  ⟨Homeomorph.smul g, fun p => proj_smul g p⟩
+
+/-- The deck transformation induced by a loop class acts by the fundamental-group action. -/
+@[simp]
+lemma loopDeck_apply (g : FundamentalGroup X x₀) (p : UniversalCover x₀) :
+    (loopDeck x₀ g).1 p = g • p :=
+  rfl
+
+/-- The identity loop class induces the identity deck transformation. -/
+@[simp]
+lemma loopDeck_one : loopDeck x₀ 1 = 1 := by
+  apply Subtype.ext
+  apply Homeomorph.ext
+  intro p
+  change (1 : FundamentalGroup X x₀) • p = p
+  exact one_smul _ _
+
+/-- Multiplication of loop classes corresponds to composition of their deck transformations. -/
+@[simp]
+lemma loopDeck_mul (g h : FundamentalGroup X x₀) :
+    loopDeck x₀ (g * h) = loopDeck x₀ g * loopDeck x₀ h := by
+  apply Subtype.ext
+  apply Homeomorph.ext
+  intro p
+  exact mul_smul g h p
+
+/-- The fundamental-group action, bundled as a homomorphism into the deck group of the
+universal-cover projection. -/
+@[expose] def loopDeckHom :
+    FundamentalGroup X x₀ →* Deck (proj : UniversalCover x₀ → X) where
+  toFun := loopDeck x₀
+  map_one' := loopDeck_one x₀
+  map_mul' := loopDeck_mul x₀
+
+@[simp]
+lemma loopDeckHom_apply (g : FundamentalGroup X x₀) :
+    loopDeckHom x₀ g = loopDeck x₀ g :=
+  rfl
+
+/-- The endpoint projection of the universal cover has regular deck action. -/
+theorem isRegular_proj [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] :
+    Deck.IsRegular (proj : UniversalCover x₀ → X) := by
+  rw [Deck.isRegular_iff_exists_apply_eq]
+  refine ⟨proj_surjective, ?_⟩
+  intro p q hpq
+  obtain ⟨g, hg⟩ := proj_eq_iff_mem_orbit.mp hpq
+  refine ⟨loopDeck x₀ g⁻¹, ?_⟩
+  rw [loopDeck_apply, ← hg, inv_smul_smul]
+
+/-- The deck transformation group of the based-path universal cover is the opposite of the
+fundamental group of the base. -/
+@[expose] noncomputable def deckFundamentalGroupEquiv
+    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] :
+    Deck (proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ :=
+  (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
+    ⟨mk x₀ (Path.Homotopic.Quotient.refl x₀), rfl⟩
+
+end TauCeti.UniversalCover


### PR DESCRIPTION
This PR identifies the deck transformation group of the based-path universal cover with the opposite fundamental group of the base. It bundles every loop class as a deck transformation, proves that these transformations act transitively on each projection fibre, deduces `UniversalCover.isRegular_proj`, and specializes the existing generic regular-cover comparison to obtain `UniversalCover.deckFundamentalGroupEquiv : Deck proj ≃* (FundamentalGroup X x₀)ᵐᵒᵖ`. The opposite records the convention already forced by the landed left deck action and path-concatenation order.

This completes the exact target in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 1, item 5: “`Deck(proj) ≃* π₁(X, x₀)`,” including its required convention check. It is the lowest-hanging unfinished direct target because Stage 0, the generic regular-cover comparison, and simple connectedness of `UniversalCover x₀` are already on `main`; only regularity of this particular projection and the specialization were missing.

Add `TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean` (113 lines). Reuse `UniversalCover.proj_eq_iff_mem_orbit`, `UniversalCover.proj_surjective`, `UniversalCover.isCoveringMap`, and `Deck.IsRegular.deckFundamentalGroupEquiv` rather than reproving covering-space or lifting theory.

Adapt no new external formalization and vendor no Mathlib infrastructure. The explicit action consumed here was adapted previously from Kim Morrison's mathlib4 PR #38292; the generic comparison consumed here ultimately uses Junyan Xu's `IsQuotientCoveringMap.fundamentalGroupEquiv` in `Mathlib.Topology.Homotopy.Lifting`. The module docstring records both sources.

`lake exe cache get` completes (with the existing warning that one cache file is unavailable). `lake build` reports `Build completed successfully (6022 jobs).` `lake exe axioms` reports `axioms: audited 17437 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"universal-cover-deck-fundamental-group-equiv"}-->

🤖 Prepared with Codex
