### PR TITLE
feat: prove semigroup generators are closed

### DIFF
--- a/TauCeti/Analysis/Semigroups/Generator.lean
+++ b/TauCeti/Analysis/Semigroups/Generator.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Analysis.Semigroups.Generator.Basic
 public import TauCeti.Analysis.Semigroups.Generator.OrbitDerivative
 public import TauCeti.Analysis.Semigroups.Generator.Invariance
+public import TauCeti.Analysis.Semigroups.Generator.Closed
 
 /-!
 # Infinitesimal generators of strongly continuous semigroups

--- a/TauCeti/Analysis/Semigroups/Generator/Closed.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Closed.lean
@@ -24,7 +24,7 @@ reverse implication uses that the resolvent maps into the domain and is a right 
 
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.mem_generator_graph_iff_resolvent_eq`:
   membership in the generator graph is characterized by one resolvent equation.
-* `TauCeti.Semigroups.StronglyContinuousSemigroup.generator_isClosed`: the generator of every
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.isClosed_generator`: the generator of every
   strongly continuous semigroup is closed.
 
 ## References
@@ -87,7 +87,7 @@ theorem mem_generator_graph_iff_resolvent_eq (S : StronglyContinuousSemigroup X)
 
 /-- The infinitesimal generator of a strongly continuous semigroup on a real Banach space is a
 closed unbounded operator. -/
-theorem generator_isClosed (S : StronglyContinuousSemigroup X) : S.generator.IsClosed := by
+theorem isClosed_generator (S : StronglyContinuousSemigroup X) : S.generator.IsClosed := by
   obtain ⟨omega, M, hb⟩ := S.existsGrowthBound
   let lambda := omega + 1
   have hlambda : omega < lambda := by simp [lambda]

--- a/TauCeti/Analysis/Semigroups/Generator/Closed.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Closed.lean
@@ -86,7 +86,7 @@ theorem mem_generator_graph_iff_resolvent_eq (S : StronglyContinuousSemigroup X)
       _ = p.2 := sub_sub_cancel _ _
 
 /-- The infinitesimal generator of a strongly continuous semigroup on a real Banach space is a
-closed unbounded operator. -/
+closed linear partial map. -/
 theorem isClosed_generator (S : StronglyContinuousSemigroup X) : S.generator.IsClosed := by
   obtain ⟨omega, M, hb⟩ := S.existsGrowthBound
   let lambda := omega + 1

--- a/TauCeti/Analysis/Semigroups/Generator/Closed.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Closed.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+public import Mathlib.Topology.Algebra.Module.LinearPMap
+
+/-!
+# Closedness of semigroup generators
+
+This file proves that the infinitesimal generator of a strongly continuous semigroup on a real
+Banach space is a closed `LinearPMap`. The proof uses the Laplace-transform resolvent: for any
+parameter above a growth exponent, the generator graph is the equalizer
+
+`R(lambda) (lambda x - y) = x`.
+
+The forward implication is the resolvent left-inverse identity on the generator domain. The
+reverse implication uses that the resolvent maps into the domain and is a right inverse to
+`lambda I - A`. Since the resolvent is bounded, the equalizer is closed.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.mem_generator_graph_iff_resolvent_eq`:
+  membership in the generator graph is characterized by one resolvent equation.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.generator_isClosed`: the generator of every
+  strongly continuous semigroup is closed.
+
+## References
+
+* K.-J. Engel and R. Nagel, *One-Parameter Semigroups for Linear Evolution Equations*,
+  Proposition II.1.4.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+namespace StronglyContinuousSemigroup
+
+/-- A pair `(x, y)` belongs to the graph of the generator precisely when applying an admissible
+resolvent to `lambda x - y` recovers `x`.
+
+This characterization presents the graph as the equalizer of two continuous maps and is also a
+convenient elimination rule when a resolvent equation is easier to establish than domain
+membership directly. -/
+theorem mem_generator_graph_iff_resolvent_eq (S : StronglyContinuousSemigroup X)
+    {omega M : ℝ} (hb : S.HasGrowthBound omega M) (lambda : ℝ) (hlambda : omega < lambda)
+    (p : X × X) :
+    p ∈ S.generator.graph ↔
+      S.resolvent hb lambda hlambda (lambda • p.1 - p.2) = p.1 := by
+  constructor
+  · rw [LinearPMap.mem_graph_iff]
+    rintro ⟨x, hx, hAx⟩
+    let x' : S.domain := ⟨(x : X), by
+      rw [← S.generator_domain]
+      exact x.property⟩
+    have hgen : S.generator ⟨(x' : X), by
+        rw [S.generator_domain]
+        exact x'.property⟩ = p.2 := by
+      rw [← hAx]
+    have hleft := S.resolventLeftInv hb lambda hlambda x'
+    rw [hgen, hx] at hleft
+    exact hleft
+  · intro h
+    let z : S.generator.domain :=
+      ⟨S.resolvent hb lambda hlambda (lambda • p.1 - p.2),
+        by
+          rw [S.generator_domain]
+          exact S.resolvent_mem_domain hb lambda hlambda _⟩
+    have hz : (z : X) = p.1 := h
+    rw [LinearPMap.mem_graph_iff]
+    refine ⟨z, hz, ?_⟩
+    have hright := S.resolventRightInv hb lambda hlambda (lambda • p.1 - p.2)
+    have hright' : lambda • (z : X) - S.generator z = lambda • p.1 - p.2 := by
+      simpa only [z] using hright
+    calc
+      S.generator z = lambda • (z : X) - (lambda • (z : X) - S.generator z) :=
+        (sub_sub_cancel _ _).symm
+      _ = lambda • p.1 - (lambda • p.1 - p.2) := by rw [hright', hz]
+      _ = p.2 := sub_sub_cancel _ _
+
+/-- The infinitesimal generator of a strongly continuous semigroup on a real Banach space is a
+closed unbounded operator. -/
+theorem generator_isClosed (S : StronglyContinuousSemigroup X) : S.generator.IsClosed := by
+  obtain ⟨omega, M, hb⟩ := S.existsGrowthBound
+  let lambda := omega + 1
+  have hlambda : omega < lambda := by simp [lambda]
+  rw [LinearPMap.IsClosed]
+  have hgraph : (S.generator.graph : Set (X × X)) =
+      {p | S.resolvent hb lambda hlambda (lambda • p.1 - p.2) = p.1} := by
+    ext p
+    exact S.mem_generator_graph_iff_resolvent_eq hb lambda hlambda p
+  rw [hgraph]
+  exact isClosed_eq
+    ((S.resolvent hb lambda hlambda).continuous.comp
+      ((continuous_fst.const_smul lambda).sub continuous_snd))
+    continuous_fst
+
+end StronglyContinuousSemigroup
+
+end TauCeti.Semigroups
+
+end


### PR DESCRIPTION
This PR proves that the infinitesimal generator of every strongly continuous semigroup on a real Banach space is a closed `LinearPMap`. Characterize its graph by the resolvent equation `R(lambda) (lambda x - y) = x`: the forward direction is the landed resolvent left-inverse identity, while the reverse direction combines resolvent domain membership with the right-inverse identity. Deduce closedness because this equation is the equalizer of two continuous maps.

This directly completes the foundational API item “the generator is closed” in `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part A, under “The generator determines the semigroup uniquely; the generator is closed, with `S(t)·D(A) ⊆ D(A)` and `A S(t)x = S(t) A x`.” It is the lowest-hanging distinct target because domain invariance and commutation are already on `main`, and the existing bounded Laplace resolvent supplies exactly the inverse characterization needed for closedness; no new approximation or integration theory is required. The only open PR in this roadmap area targets the distinct GNS/Kolmogorov decomposition.

Add `TauCeti/Analysis/Semigroups/Generator/Closed.lean` (109 lines), with the reusable characteristic theorem `StronglyContinuousSemigroup.mem_generator_graph_iff_resolvent_eq` and the target theorem `StronglyContinuousSemigroup.generator_isClosed`.

Reuse Tau Ceti’s `StronglyContinuousSemigroup.resolventLeftInv`, `resolventRightInv`, `resolvent_mem_domain`, and `existsGrowthBound`, together with Mathlib’s `LinearPMap.IsClosed` and topological `isClosed_eq`. Vendor no Mathlib infrastructure and copy or adapt no external formalization. The mathematical argument follows Engel–Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Proposition II.1.4, as cited in the module docstring.

`lake exe cache get` completes successfully (`Already decompressed 8677 file(s)`, with the existing warning that one cache file is unavailable). `lake build` reports `Build completed successfully (6023 jobs).` `lake exe axioms` reports `axioms: audited 17430 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"generator-is-closed"}-->

🤖 Prepared with Codex
