### PR TITLE
refactor(Conformal): decompose Montel's selection theorem

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Montel.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel.lean
@@ -101,16 +101,6 @@ private theorem equicontinuous_subtype_val_range {ι X Y : Type*} [TopologicalSp
   rw [heq]
   exact h.comp σ
 
--- Locally uniform convergence of the restrictions to `s` is locally uniform convergence on `s`,
--- for any function `g` agreeing with the limit along the coercion.
-private theorem tendstoLocallyUniformlyOn_of_forall_coe_eq {ι X Y : Type*} [TopologicalSpace X]
-    [UniformSpace Y] {s : Set X} {G : ι → X → Y} {a : s → Y} {g : X → Y} {p : Filter ι}
-    (h : TendstoLocallyUniformly (fun n (x : s) => G n x) a p) (hg : ∀ x : s, g x = a x) :
-    TendstoLocallyUniformlyOn G g p s := by
-  rw [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe,
-    show g ∘ (Subtype.val : s → X) = a from funext hg]
-  exact h
-
 /-- **Montel's selection theorem.** A locally bounded family of holomorphic functions on an open
 set `Ω ⊆ ℂ` is normal: every sequence from it has a subsequence converging locally uniformly on
 `Ω`, and the limit is holomorphic.
@@ -139,9 +129,14 @@ theorem montel (hΩ : IsOpen Ω) (hF : ∀ n, DifferentiableOn ℂ (F n) Ω)
     simpa [hfdef, mem_closedBall, dist_zero_right] using hC n
   obtain ⟨a, -, φ, hφ, hconv⟩ := hcpt.tendsto_subseq (x := f) fun n => subset_closure ⟨n, rfl⟩
   -- Compact-open convergence is locally uniform convergence; extend the limit off `Ω` by zero.
-  have hconvOn := tendstoLocallyUniformlyOn_of_forall_coe_eq
-    (ContinuousMap.tendsto_iff_tendstoLocallyUniformly.mp hconv)
-    (g := fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) fun x => by simp [x.2]
+  have hlim : ((fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) ∘ (Subtype.val : Ω → ℂ))
+      = fun x : Ω => a x := by
+    funext x
+    simp [x.2]
+  have hconvOn : TendstoLocallyUniformlyOn (fun n => F (φ n))
+      (fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) atTop Ω := by
+    rw [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe, hlim]
+    exact ContinuousMap.tendsto_iff_tendstoLocallyUniformly.mp hconv
   exact ⟨φ, _, hφ, hconvOn.differentiableOn (Eventually.of_forall fun n => hF (φ n)) hΩ, hconvOn⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Montel.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel.lean
@@ -70,6 +70,47 @@ namespace TauCeti
 
 variable {Ω : Set ℂ} {F : ℕ → ℂ → ℂ}
 
+-- `C(X, Y)` sits inside the uniform-on-compacts function space as a closed subspace: the
+-- coercion is a uniform embedding, and its range is the continuous maps, which is closed when
+-- the topology of `X` is coherent with its compacts. This is the shape Arzelà–Ascoli asks for.
+private theorem isClosedEmbedding_ofFun_comp_coe {X Y : Type*} [TopologicalSpace X]
+    [CompactlyCoherentSpace X] [UniformSpace Y] :
+    IsClosedEmbedding (⇑(UniformOnFun.ofFun {K : Set X | IsCompact K}) ∘
+      (DFunLike.coe : C(X, Y) → (X → Y))) := by
+  refine ⟨ContinuousMap.isUniformEmbedding_toUniformOnFunIsCompact.isEmbedding, ?_⟩
+  -- The `rfl` below is just `ContinuousMap.toUniformOnFunIsCompact` unfolded (Mathlib
+  -- `Topology/UniformSpace/CompactConvergence.lean`): Arzelà–Ascoli asks for the map in the
+  -- `UniformOnFun.ofFun 𝔖 ∘ F` form, while `range_toUniformOnFunIsCompact` is stated for the
+  -- packaged name, so this bridges the two.
+  rw [show (⇑(UniformOnFun.ofFun {K : Set X | IsCompact K}) ∘
+      (DFunLike.coe : C(X, Y) → (X → Y))) = ContinuousMap.toUniformOnFunIsCompact from rfl,
+    ContinuousMap.range_toUniformOnFunIsCompact]
+  exact UniformOnFun.isClosed_setOfPred_continuous CompactlyCoherentSpace.isCoherentWith
+
+-- Equicontinuity of a family transfers to its range viewed as a subtype: every element of the
+-- range is some member of the family, and equicontinuity is stable under reindexing.
+private theorem equicontinuous_subtype_val_range {ι X Y : Type*} [TopologicalSpace X]
+    [UniformSpace Y] {f : ι → C(X, Y)} (h : Equicontinuous fun n => (f n : X → Y)) :
+    Equicontinuous ((DFunLike.coe : C(X, Y) → (X → Y)) ∘
+      (Subtype.val : ↥(Set.range f) → C(X, Y))) := by
+  classical
+  choose σ hσ using fun x : ↥(Set.range f) => x.2
+  have heq : ((DFunLike.coe : C(X, Y) → (X → Y)) ∘ (Subtype.val : ↥(Set.range f) → C(X, Y)))
+      = (fun n => (f n : X → Y)) ∘ σ := funext fun x => by
+    rw [Function.comp_apply, Function.comp_apply, hσ x]
+  rw [heq]
+  exact h.comp σ
+
+-- Locally uniform convergence of the restrictions to `s` is locally uniform convergence on `s`,
+-- for any function `g` agreeing with the limit along the coercion.
+private theorem tendstoLocallyUniformlyOn_of_forall_coe_eq {ι X Y : Type*} [TopologicalSpace X]
+    [UniformSpace Y] {s : Set X} {G : ι → X → Y} {a : s → Y} {g : X → Y} {p : Filter ι}
+    (h : TendstoLocallyUniformly (fun n (x : s) => G n x) a p) (hg : ∀ x : s, g x = a x) :
+    TendstoLocallyUniformlyOn G g p s := by
+  rw [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe,
+    show g ∘ (Subtype.val : s → X) = a from funext hg]
+  exact h
+
 /-- **Montel's selection theorem.** A locally bounded family of holomorphic functions on an open
 set `Ω ⊆ ℂ` is normal: every sequence from it has a subsequence converging locally uniformly on
 `Ω`, and the limit is holomorphic.
@@ -85,49 +126,22 @@ theorem montel (hΩ : IsOpen Ω) (hF : ∀ n, DifferentiableOn ℂ (F n) Ω)
   haveI : LocallyCompactSpace Ω := hΩ.locallyCompactSpace
   set f : ℕ → C(Ω, ℂ) :=
     fun n => ⟨Ω.domRestrict (F n), ((hF n).continuousOn).domRestrict⟩ with hfdef
-  -- `C(Ω, ℂ)` sits as a closed subspace of the uniform-on-compacts function space
-  have hclemb : IsClosedEmbedding (⇑(UniformOnFun.ofFun {K : Set Ω | IsCompact K}) ∘
-      (DFunLike.coe : C(Ω, ℂ) → (Ω → ℂ))) := by
-    refine ⟨ContinuousMap.isUniformEmbedding_toUniformOnFunIsCompact.isEmbedding, ?_⟩
-    -- The `rfl` below is just `ContinuousMap.toUniformOnFunIsCompact` unfolded (Mathlib
-    -- `Topology/UniformSpace/CompactConvergence.lean`): Arzelà–Ascoli asks for the map in the
-    -- `UniformOnFun.ofFun 𝔖 ∘ F` form, while `range_toUniformOnFunIsCompact` is stated for the
-    -- packaged name, so this bridges the two.
-    rw [show (⇑(UniformOnFun.ofFun {K : Set Ω | IsCompact K}) ∘
-        (DFunLike.coe : C(Ω, ℂ) → (Ω → ℂ))) = ContinuousMap.toUniformOnFunIsCompact from rfl,
-      ContinuousMap.range_toUniformOnFunIsCompact]
-    exact UniformOnFun.isClosed_setOfPred_continuous CompactlyCoherentSpace.isCoherentWith
-  -- Arzelà–Ascoli in the compact-open topology
+  -- Arzelà–Ascoli in the compact-open topology: equicontinuity comes from Cauchy's estimate and
+  -- pointwise relative compactness from local boundedness.
   have hcpt : IsCompact (closure (Set.range f)) := by
-    refine ArzelaAscoli.isCompact_closure_of_isClosedEmbedding (fun K hK => hK) hclemb ?_ ?_
-    · intro K _
-      have hbase : Equicontinuous (fun n => (f n : Ω → ℂ)) :=
-        (equicontinuous_restrict_iff F).mpr (hb.equicontinuousOn hΩ hF)
-      have hchoice : ∀ x : ↥(Set.range f), ∃ n, f n = (x : C(Ω, ℂ)) := fun x => x.2
-      choose σ hσ using hchoice
-      have heq : ((DFunLike.coe : C(Ω, ℂ) → (Ω → ℂ)) ∘ (Subtype.val : ↥(Set.range f) → C(Ω, ℂ)))
-          = (fun n => (f n : Ω → ℂ)) ∘ σ := by
-        funext x
-        rw [Function.comp_apply, Function.comp_apply, hσ x]
-      rw [heq]
-      exact (hbase.comp σ).equicontinuousOn K
-    · intro K _ x _
-      obtain ⟨C, hC⟩ := hb.exists_forall_norm_le x.2
-      refine ⟨closedBall 0 C, isCompact_closedBall _ _, fun i hi => ?_⟩
-      obtain ⟨n, rfl⟩ := hi
-      simpa [hfdef, mem_closedBall, dist_zero_right] using hC n
+    refine ArzelaAscoli.isCompact_closure_of_isClosedEmbedding (fun K hK => hK)
+      isClosedEmbedding_ofFun_comp_coe (fun K _ => (equicontinuous_subtype_val_range
+        ((equicontinuous_restrict_iff F).mpr (hb.equicontinuousOn hΩ hF))).equicontinuousOn K) ?_
+    intro K _ x _
+    obtain ⟨C, hC⟩ := hb.exists_forall_norm_le x.2
+    refine ⟨closedBall 0 C, isCompact_closedBall _ _, fun i hi => ?_⟩
+    obtain ⟨n, rfl⟩ := hi
+    simpa [hfdef, mem_closedBall, dist_zero_right] using hC n
   obtain ⟨a, -, φ, hφ, hconv⟩ := hcpt.tendsto_subseq (x := f) fun n => subset_closure ⟨n, rfl⟩
-  -- compact-open convergence is locally uniform convergence
-  have hlu : TendstoLocallyUniformly (fun n (x : Ω) => F (φ n) x) (fun x : Ω => a x) atTop :=
-    ContinuousMap.tendsto_iff_tendstoLocallyUniformly.mp hconv
-  have hlim : ((fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) ∘ (Subtype.val : Ω → ℂ))
-      = fun x : Ω => a x := by
-    funext x
-    simp [x.2]
-  have hconvOn : TendstoLocallyUniformlyOn (fun n => F (φ n))
-      (fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) atTop Ω := by
-    rw [tendstoLocallyUniformlyOn_iff_tendstoLocallyUniformly_comp_coe, hlim]
-    exact hlu
+  -- Compact-open convergence is locally uniform convergence; extend the limit off `Ω` by zero.
+  have hconvOn := tendstoLocallyUniformlyOn_of_forall_coe_eq
+    (ContinuousMap.tendsto_iff_tendstoLocallyUniformly.mp hconv)
+    (g := fun z => if hz : z ∈ Ω then a ⟨z, hz⟩ else 0) fun x => by simp [x.2]
   exact ⟨φ, _, hφ, hconvOn.differentiableOn (Eventually.of_forall fun n => hF (φ n)) hΩ, hconvOn⟩
 
 end TauCeti


### PR DESCRIPTION
Decomposes `montel` in `TauCeti/Analysis/Complex/Conformal/Montel.lean`, the longest proof body in
the file at 48 lines. No statement changes: `montel` keeps its signature, and both extracted
helpers are `private` and local to the file.

The proof is one block running three steps: exhibit `C(Ω, ℂ)` as a closed subspace of the
uniform-on-compacts function space, feed that to Arzelà–Ascoli, then turn compact-open convergence
into locally uniform convergence on `Ω`. The first two are self-contained facts and are now stated
separately; the third is a single rewrite and stays inline.

| helper | what it proves | body |
|---|---|---|
| `isClosedEmbedding_ofFun_comp_coe` | `C(X, Y) → (X →ᵤ[compacts] Y)` is a closed embedding | 12 |
| `equicontinuous_subtype_val_range` | equicontinuity of a family transfers to its range as a subtype | 7 |

`montel` itself goes from 48 lines to 26.

**Hypotheses were re-derived at extraction rather than inherited.** Neither helper mentions `ℂ`,
`Ω`, holomorphy, or local boundedness — neither was ever a complex-analytic fact:

* `isClosedEmbedding_ofFun_comp_coe` holds for `C(X, Y)` with `X` a topological space whose
  topology is coherent with its compacts and `Y` a uniform space. It needs
  `CompactlyCoherentSpace`, not `LocallyCompactSpace`.
* `equicontinuous_subtype_val_range` holds for any index type, topological space and uniform space.

The parent's `haveI : LocallyCompactSpace Ω` is retained. I checked whether moving the
closed-embedding step out had made it dead by deleting it and rebuilding: it fails, because
`IsCompact.tendsto_subseq` still needs the first countability that local compactness supplies.

The helpers are kept `private` beside their sole consumer rather than promoted into a general
topology file; that would add public API and a new file, which is a separate decision from this
refactor.

A third helper wrapping the convergence transfer was dropped before review: it was used once and
wrapped a single rewrite, so it was scaffolding rather than shared structure. That step is inline,
with the `hlim` function equality named and rewritten with explicitly rather than bridged by a
`show … from funext`.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: ConformalMapping
