### PR TITLE
feat: assemble the lattice chain complex

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
@@ -1,0 +1,117 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Homology.HomologicalComplex
+public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
+public import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
+public import TauCeti.LowDimTopology.Plumbing.Grading
+
+/-!
+# The cubically graded lattice chain complex
+
+This file assembles the cubical-degree pieces of the plumbing chain module into an
+`ℕ`-indexed chain complex. In degree `q` its object is the free submodule supported on
+`q`-dimensional plumbing cubes, and its differential is the restriction of Némethi's weighted
+lattice differential from degree `q + 1` to degree `q`.
+
+The degreewise square-zero result from `Grading.lean` is exactly the compatibility required by
+Mathlib's `ChainComplex.of`. Consequently the standard homology API for homological complexes is
+available without introducing a parallel quotient construction. The homology in cubical degree
+`q` is named `latticeHomologyDegree`.
+
+## Main definitions
+
+* `TauCeti.PlumbingGraph.latticeChainComplex`: the cubically graded lattice chain complex over
+  `𝔽₂[U]`.
+* `TauCeti.PlumbingGraph.latticeHomologyDegree`: its homology in a specified cubical degree.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, which asks for
+Némethi's lattice homology `ℍ⁻` as a graded `ℤ[U]`-module built from lattice points and weight
+functions. This is the roadmap's characteristic-two first stage. The cubical chain complex is
+the complex of A. Némethi, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The degreewise lattice differential regarded as a morphism in the category of
+`PlumbingCoefficient`-modules. -/
+noncomputable def latticeDifferentialDegreeHom
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V (q + 1)) ⟶
+      ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q) :=
+  ModuleCat.ofHom (P.latticeDifferentialDegree k q)
+
+/-- Consecutive degreewise lattice differentials compose to zero as morphisms of module
+objects. -/
+theorem latticeDifferentialDegreeHom_comp
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    P.latticeDifferentialDegreeHom k (q + 1) ≫
+      P.latticeDifferentialDegreeHom k q = 0 := by
+  rw [latticeDifferentialDegreeHom, latticeDifferentialDegreeHom,
+    ← ModuleCat.ofHom_comp, P.latticeDifferentialDegree_comp k q,
+      ModuleCat.ofHom_zero]
+
+/-- The cubically graded lattice chain complex of a plumbing graph and a characteristic
+covector. Its degree-`q` object consists of chains supported on `q`-dimensional cubes. -/
+noncomputable def latticeChainComplex
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
+  ChainComplex.of
+    (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q))
+    (fun q => P.latticeDifferentialDegreeHom k q)
+    fun q => P.latticeDifferentialDegreeHom_comp k q
+
+/-- The object in cubical degree `q` is the submodule of chains supported on
+`q`-dimensional cubes. -/
+@[simp]
+theorem latticeChainComplex_X
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    (P.latticeChainComplex k).X q =
+      ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q) :=
+  (rfl)
+
+/-- The differential from cubical degree `q + 1` to degree `q` is the restriction of the total
+lattice differential. -/
+@[simp]
+theorem latticeChainComplex_d
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    HEq ((P.latticeChainComplex k).d (q + 1) q)
+      (P.latticeDifferentialDegreeHom k q) :=
+  by
+    rw [latticeChainComplex]
+    exact heq_of_eq (ChainComplex.of_d
+      (fun r => ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V r))
+      (fun r => P.latticeDifferentialDegreeHom k r)
+      q)
+
+/-- The characteristic-two lattice homology in cubical degree `q`, obtained from Mathlib's
+canonical homology object of the graded lattice chain complex. -/
+noncomputable def latticeHomologyDegree
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    ModuleCat PlumbingCoefficient :=
+  (P.latticeChainComplex k).homology q
+
+/-- Degreewise lattice homology is the canonical homology object of the cubically graded lattice
+chain complex. -/
+@[simp]
+theorem latticeHomologyDegree_def
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    P.latticeHomologyDegree k q = (P.latticeChainComplex k).homology q :=
+  (rfl)
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Homology.HomologicalComplex
 public import Mathlib.Algebra.Homology.ShortComplex.HomologicalComplex
 public import Mathlib.Algebra.Homology.ShortComplex.ModuleCat
 public import TauCeti.LowDimTopology.Plumbing.Grading
@@ -20,13 +19,13 @@ lattice differential from degree `q + 1` to degree `q`.
 The degreewise square-zero result from `Grading.lean` is exactly the compatibility required by
 Mathlib's `ChainComplex.of`. Consequently the standard homology API for homological complexes is
 available without introducing a parallel quotient construction. The homology in cubical degree
-`q` is named `latticeHomologyDegree`.
+`q` is named `latticeChainHomology`.
 
 ## Main definitions
 
 * `TauCeti.PlumbingGraph.latticeChainComplex`: the cubically graded lattice chain complex over
   `𝔽₂[U]`.
-* `TauCeti.PlumbingGraph.latticeHomologyDegree`: its homology in a specified cubical degree.
+* `TauCeti.PlumbingGraph.latticeChainHomology`: its homology in a specified cubical degree.
 
 ## References
 
@@ -64,8 +63,9 @@ noncomputable def latticeChainComplex
 theorem latticeChainComplex_X
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     (P.latticeChainComplex k).X q =
-      ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q) :=
-  (rfl)
+      ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q) := by
+  unfold latticeChainComplex
+  exact congrFun (ChainComplex.of_X _ _ _) q
 
 /-- The differential from cubical degree `q + 1` to degree `q` is the restriction of the total
 lattice differential. -/
@@ -85,7 +85,7 @@ theorem latticeChainComplex_d
 
 /-- The characteristic-two lattice homology in cubical degree `q`, obtained from Mathlib's
 canonical homology object of the graded lattice chain complex. -/
-noncomputable def latticeHomologyDegree
+noncomputable def latticeChainHomology
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     ModuleCat PlumbingCoefficient :=
   (P.latticeChainComplex k).homology q
@@ -93,9 +93,9 @@ noncomputable def latticeHomologyDegree
 /-- Degreewise lattice homology is the canonical homology object of the cubically graded lattice
 chain complex. -/
 @[simp]
-theorem latticeHomologyDegree_def
+theorem latticeChainHomology_def
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
-    P.latticeHomologyDegree k q = (P.latticeChainComplex k).homology q :=
+    P.latticeChainHomology k q = (P.latticeChainComplex k).homology q :=
   (rfl)
 
 end PlumbingGraph

--- a/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
+++ b/TauCeti/LowDimTopology/Plumbing/ChainComplex.lean
@@ -46,24 +46,6 @@ namespace PlumbingGraph
 
 variable {V : Type*} [DecidableEq V] [Fintype V]
 
-/-- The degreewise lattice differential regarded as a morphism in the category of
-`PlumbingCoefficient`-modules. -/
-noncomputable def latticeDifferentialDegreeHom
-    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
-    ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V (q + 1)) ⟶
-      ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q) :=
-  ModuleCat.ofHom (P.latticeDifferentialDegree k q)
-
-/-- Consecutive degreewise lattice differentials compose to zero as morphisms of module
-objects. -/
-theorem latticeDifferentialDegreeHom_comp
-    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
-    P.latticeDifferentialDegreeHom k (q + 1) ≫
-      P.latticeDifferentialDegreeHom k q = 0 := by
-  rw [latticeDifferentialDegreeHom, latticeDifferentialDegreeHom,
-    ← ModuleCat.ofHom_comp, P.latticeDifferentialDegree_comp k q,
-      ModuleCat.ofHom_zero]
-
 /-- The cubically graded lattice chain complex of a plumbing graph and a characteristic
 covector. Its degree-`q` object consists of chains supported on `q`-dimensional cubes. -/
 noncomputable def latticeChainComplex
@@ -71,8 +53,10 @@ noncomputable def latticeChainComplex
     ChainComplex (ModuleCat PlumbingCoefficient) ℕ :=
   ChainComplex.of
     (fun q => ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q))
-    (fun q => P.latticeDifferentialDegreeHom k q)
-    fun q => P.latticeDifferentialDegreeHom_comp k q
+    (fun q => ModuleCat.ofHom (R := PlumbingCoefficient) (P.latticeDifferentialDegree k q))
+    fun q => by
+      rw [← ModuleCat.ofHom_comp, P.latticeDifferentialDegree_comp k q,
+        ModuleCat.ofHom_zero]
 
 /-- The object in cubical degree `q` is the submodule of chains supported on
 `q`-dimensional cubes. -/
@@ -89,12 +73,14 @@ lattice differential. -/
 theorem latticeChainComplex_d
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     HEq ((P.latticeChainComplex k).d (q + 1) q)
-      (P.latticeDifferentialDegreeHom k q) :=
+      (ModuleCat.ofHom (P.latticeDifferentialDegree k q) :
+        ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V (q + 1)) ⟶
+          ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V q)) :=
   by
     rw [latticeChainComplex]
     exact heq_of_eq (ChainComplex.of_d
       (fun r => ModuleCat.of PlumbingCoefficient (PlumbingChain.degreePart V r))
-      (fun r => P.latticeDifferentialDegreeHom k r)
+      (fun r => ModuleCat.ofHom (R := PlumbingCoefficient) (P.latticeDifferentialDegree k r))
       q)
 
 /-- The characteristic-two lattice homology in cubical degree `q`, obtained from Mathlib's


### PR DESCRIPTION
This PR assembles the cubical-degree pieces of the plumbing chain module into Mathlib's `ℕ`-indexed `ChainComplex (ModuleCat (Polynomial (ZMod 2))) ℕ`. Regard each restricted degree differential as a `ModuleCat` morphism, prove consecutive morphisms compose to zero, identify the complex object and differential in every degree, and define the canonical degreewise lattice homology object.

This directly advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, specifically “Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions.” It implements the roadmap's `𝔽₂`-first coefficient stage. This is the lowest-hanging unfinished target because the immediately preceding merged PR #1592 already supplies the cubical-degree submodules, restricted differentials, and their square-zero identity, while no open PR assembles them into a chain complex; the only open CombinatorialHeegaardFloer PR concerns grid-homology symmetries.

Add `TauCeti/LowDimTopology/Plumbing/ChainComplex.lean` (117 lines). Follow the cubical complex in A. Némethi, arXiv:0709.0841, §3, as recorded in the module docstring. Reuse Mathlib's `ChainComplex.of`, `ModuleCat.ofHom`, and canonical homology construction, together with Tau Ceti's `PlumbingChain.degreePart`, `latticeDifferentialDegree`, and `latticeDifferentialDegree_comp`. Vendor no Mathlib infrastructure and copy or adapt no external formalization.

`lake exe cache get` completes with `Decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6023 jobs).` `lake exe axioms` reports `axioms: audited 17467 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The lint environment passes with no new violations.

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-chain-complex"}-->

🤖 Prepared with Codex
