### PR TITLE
feat: make the Fredholm index constant in families

### DIFF
--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Topology.LocallyConstant.Basic
-public import Mathlib.Topology.Homotopy.Path
 public import Mathlib.Analysis.Convex.PathConnected
+public import Mathlib.Analysis.RCLike.Basic
 public import TauCeti.Analysis.Fredholm.SmallPerturbation
 
 /-!
@@ -26,14 +26,14 @@ together with Mathlib's general API for locally constant functions on preconnect
 
 ## Main declarations
 
-* `Continuous.isLocallyConstant_fredholmIndex`: the index of a continuous Fredholm family is
+* `Continuous.isLocallyConstant_index`: the index of a continuous Fredholm family is
   locally constant.
-* `ContinuousOn.fredholmIndex_eq_of_isPreconnected`: two parameters in the same preconnected set
+* `ContinuousOn.index_eq_of_isPreconnected`: two parameters in the same preconnected set
   give operators of equal index.
-* `Continuous.fredholmIndex_eq_of_preconnectedSpace`: a continuous Fredholm family over a
+* `Continuous.index_eq_of_preconnectedSpace`: a continuous Fredholm family over a
   preconnected space has constant index.
-* `Path.fredholmIndex_eq`: the endpoints of a continuous Fredholm path have equal index.
-* `fredholmIndex_eq_of_segment`: two operators joined by a Fredholm affine segment have equal
+* `Path.index_eq`: the endpoints of a continuous Fredholm path have equal index.
+* `index_eq_of_segment`: two operators joined by a Fredholm affine segment have equal
   index.
 
 The index convention and its perturbation stability follow McDuff--Salamon,
@@ -52,7 +52,7 @@ variable [TopologicalSpace X]
 
 /-- The Fredholm index of a continuous family of Fredholm operators is locally constant on the
 parameter space. -/
-theorem Continuous.isLocallyConstant_fredholmIndex {A : X → E →L[K] F}
+theorem Continuous.isLocallyConstant_index {A : X → E →L[K] F}
     (hA : Continuous A) (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) :
     IsLocallyConstant fun x ↦ ContinuousLinearMap.index (A x) := by
   rw [IsLocallyConstant.iff_eventually_eq]
@@ -62,46 +62,49 @@ theorem Continuous.isLocallyConstant_fredholmIndex {A : X → E →L[K] F}
 
 /-- Along a continuous family of Fredholm operators, parameters in the same preconnected set give
 operators with equal index. -/
-theorem ContinuousOn.fredholmIndex_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
+theorem ContinuousOn.index_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
     (hA : ContinuousOn A s)
     (hFredholm : ∀ x ∈ s, ContinuousLinearMap.IsFredholm (A x))
     (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) := by
   letI := Subtype.preconnectedSpace hs
-  exact (Continuous.isLocallyConstant_fredholmIndex hA.domRestrict
+  exact (Continuous.isLocallyConstant_index hA.domRestrict
     (fun x ↦ hFredholm x x.2)).apply_eq_of_preconnectedSpace ⟨x, hx⟩ ⟨y, hy⟩
 
 /-- A continuous family of Fredholm operators over a preconnected parameter space has constant
 index. -/
-theorem Continuous.fredholmIndex_eq_of_preconnectedSpace [PreconnectedSpace X]
+theorem Continuous.index_eq_of_preconnectedSpace [PreconnectedSpace X]
     {A : X → E →L[K] F} (hA : Continuous A)
     (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) (x y : X) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) :=
-  (Continuous.isLocallyConstant_fredholmIndex hA hFredholm).apply_eq_of_preconnectedSpace x y
+  (Continuous.isLocallyConstant_index hA hFredholm).apply_eq_of_preconnectedSpace x y
 
 /-- The endpoints of a continuous path of Fredholm operators have the same index. -/
-theorem Path.fredholmIndex_eq {T S : E →L[K] F} (A : Path T S)
+theorem Path.index_eq {T S : E →L[K] F} (A : Path T S)
     (hFredholm : ∀ t, ContinuousLinearMap.IsFredholm (A t)) :
     ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
   simpa only [A.source, A.target] using
-    Continuous.fredholmIndex_eq_of_preconnectedSpace A.continuous hFredholm 0 1
+    Continuous.index_eq_of_preconnectedSpace A.continuous hFredholm 0 1
 
-section Real
+section Segment
 
-variable {E' F' : Type*}
-variable [NormedAddCommGroup E'] [NormedSpace ℝ E'] [CompleteSpace E']
-variable [NormedAddCommGroup F'] [NormedSpace ℝ F']
+variable {K' E' F' : Type*} [NontriviallyNormedField K'] [IsRCLikeNormedField K']
+variable [CompleteSpace K'] [NormedAddCommGroup E'] [NormedSpace K' E'] [CompleteSpace E']
+variable [NormedAddCommGroup F'] [NormedSpace K' F']
+variable [NormedSpace ℝ (E' →L[K'] F')]
 
-/-- Two real operators have equal index if every operator on the affine segment between them is
-Fredholm. -/
-theorem fredholmIndex_eq_of_segment (T S : E' →L[ℝ] F')
-    (hFredholm : ∀ t : unitInterval,
-      ContinuousLinearMap.IsFredholm ((1 - (t : ℝ)) • T + (t : ℝ) • S)) :
-    ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
-  apply Path.fredholmIndex_eq (Path.segment T S)
+/-- Two operators over an `IsRCLikeNormedField` have equal index if every operator on the affine
+segment between them is Fredholm. -/
+theorem index_eq_of_segment (T S : E' →L[K'] F') :
+    (∀ t : unitInterval,
+      ContinuousLinearMap.IsFredholm ((1 - (t : ℝ)) • T + (t : ℝ) • S)) →
+      ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
+  letI := IsRCLikeNormedField.rclike K'
+  intro hFredholm
+  apply Path.index_eq (Path.segment T S)
   simpa only [Path.segment_apply, AffineMap.lineMap_apply_module] using hFredholm
 
-end Real
+end Segment
 
 end TauCeti
 

--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.LocallyConstant.Basic
+public import Mathlib.Topology.Homotopy.Path
+public import TauCeti.Analysis.Fredholm.SmallPerturbation
+
+/-!
+# Continuous families of Fredholm operators
+
+The Fredholm index is locally constant in a continuous family of Fredholm operators. Consequently,
+it is constant when the parameter space is preconnected, and in particular at the endpoints of a
+path of Fredholm operators.
+
+This is the continuous-family form of stability under small perturbations. It is a basic input to
+the spectral-flow and Riemann--Roch-with-boundary developments in Lanes F0 and F1.3 of the analytic
+Heegaard Floer roadmap: a family can change index only by leaving the Fredholm locus.
+
+The proofs use the operator-norm neighborhood on which
+`ContinuousLinearMap.IsFredholm.eventually_isFredholm_and_index_eq` makes the index constant,
+together with Mathlib's general API for locally constant functions on preconnected spaces.
+
+## Main declarations
+
+* `Continuous.isLocallyConstant_fredholmIndex`: the index of a continuous Fredholm family is
+  locally constant.
+* `Continuous.fredholmIndex_eq_of_mem_preconnected`: two parameters in the same preconnected set
+  give operators of equal index.
+* `Continuous.fredholmIndex_eq_of_preconnectedSpace`: a continuous Fredholm family over a
+  preconnected space has constant index.
+* `Path.fredholmIndex_eq`: the endpoints of a continuous Fredholm path have equal index.
+* `fredholmIndex_eq_of_segment`: two operators joined by a Fredholm affine segment have equal
+  index.
+
+The index convention and its perturbation stability follow McDuff--Salamon,
+*J-holomorphic Curves and Symplectic Topology*, Appendix A.1.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {K E F X : Type*}
+variable [NontriviallyNormedField K] [CompleteSpace K]
+variable [NormedAddCommGroup E] [NormedSpace K E] [CompleteSpace E]
+variable [NormedAddCommGroup F] [NormedSpace K F]
+variable [TopologicalSpace X]
+
+/-- The Fredholm index of a continuous family of Fredholm operators is locally constant on the
+parameter space. -/
+theorem Continuous.isLocallyConstant_fredholmIndex {A : X → E →L[K] F}
+    (hA : Continuous A) (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) :
+    IsLocallyConstant fun x ↦ ContinuousLinearMap.index (A x) := by
+  rw [IsLocallyConstant.iff_eventually_eq]
+  intro x
+  filter_upwards [hA.continuousAt (hFredholm x).eventually_isFredholm_and_index_eq] with y hy
+  exact hy.2
+
+/-- Along a continuous family of Fredholm operators, parameters in the same preconnected set give
+operators with equal index. -/
+theorem Continuous.fredholmIndex_eq_of_mem_preconnected {A : X → E →L[K] F}
+    (hA : Continuous A) (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x))
+    {s : Set X} (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
+    ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) := by
+  exact (Continuous.isLocallyConstant_fredholmIndex hA hFredholm).apply_eq_of_isPreconnected
+    hs hx hy
+
+/-- A continuous family of Fredholm operators over a preconnected parameter space has constant
+index. -/
+theorem Continuous.fredholmIndex_eq_of_preconnectedSpace [PreconnectedSpace X]
+    {A : X → E →L[K] F} (hA : Continuous A)
+    (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x)) (x y : X) :
+    ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) :=
+  (Continuous.isLocallyConstant_fredholmIndex hA hFredholm).apply_eq_of_preconnectedSpace x y
+
+/-- The endpoints of a continuous path of Fredholm operators have the same index. -/
+theorem Path.fredholmIndex_eq {T S : E →L[K] F} (A : Path T S)
+    (hFredholm : ∀ t, ContinuousLinearMap.IsFredholm (A t)) :
+    ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
+  simpa only [A.source, A.target] using
+    Continuous.fredholmIndex_eq_of_preconnectedSpace A.continuous hFredholm 0 1
+
+section Real
+
+variable {E' F' : Type*}
+variable [NormedAddCommGroup E'] [NormedSpace ℝ E'] [CompleteSpace E']
+variable [NormedAddCommGroup F'] [NormedSpace ℝ F']
+
+/-- Two real operators have equal index if every operator on the affine segment between them is
+Fredholm. -/
+theorem fredholmIndex_eq_of_segment (T S : E' →L[ℝ] F')
+    (hFredholm : ∀ t : unitInterval,
+      ContinuousLinearMap.IsFredholm ((1 - (t : ℝ)) • T + (t : ℝ) • S)) :
+    ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
+  let A : unitInterval → E' →L[ℝ] F' := fun t ↦
+    (1 - (t : ℝ)) • T + (t : ℝ) • S
+  have hA : Continuous A := by
+    fun_prop
+  have hindex :=
+    Continuous.fredholmIndex_eq_of_preconnectedSpace hA hFredholm (0 : unitInterval) 1
+  simpa [A] using hindex
+
+end Real
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Topology.LocallyConstant.Basic
 public import Mathlib.Topology.Homotopy.Path
+public import Mathlib.Analysis.Convex.PathConnected
 public import TauCeti.Analysis.Fredholm.SmallPerturbation
 
 /-!
@@ -27,7 +28,7 @@ together with Mathlib's general API for locally constant functions on preconnect
 
 * `Continuous.isLocallyConstant_fredholmIndex`: the index of a continuous Fredholm family is
   locally constant.
-* `Continuous.fredholmIndex_eq_of_mem_preconnected`: two parameters in the same preconnected set
+* `ContinuousOn.fredholmIndex_eq_of_isPreconnected`: two parameters in the same preconnected set
   give operators of equal index.
 * `Continuous.fredholmIndex_eq_of_preconnectedSpace`: a continuous Fredholm family over a
   preconnected space has constant index.
@@ -61,12 +62,14 @@ theorem Continuous.isLocallyConstant_fredholmIndex {A : X → E →L[K] F}
 
 /-- Along a continuous family of Fredholm operators, parameters in the same preconnected set give
 operators with equal index. -/
-theorem Continuous.fredholmIndex_eq_of_mem_preconnected {A : X → E →L[K] F}
-    (hA : Continuous A) (hFredholm : ∀ x, ContinuousLinearMap.IsFredholm (A x))
-    {s : Set X} (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
+theorem ContinuousOn.fredholmIndex_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
+    (hA : ContinuousOn A s)
+    (hFredholm : ∀ x ∈ s, ContinuousLinearMap.IsFredholm (A x))
+    (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) := by
-  exact (Continuous.isLocallyConstant_fredholmIndex hA hFredholm).apply_eq_of_isPreconnected
-    hs hx hy
+  letI := Subtype.preconnectedSpace hs
+  exact (Continuous.isLocallyConstant_fredholmIndex hA.domRestrict
+    (fun x ↦ hFredholm x x.2)).apply_eq_of_preconnectedSpace ⟨x, hx⟩ ⟨y, hy⟩
 
 /-- A continuous family of Fredholm operators over a preconnected parameter space has constant
 index. -/
@@ -95,13 +98,8 @@ theorem fredholmIndex_eq_of_segment (T S : E' →L[ℝ] F')
     (hFredholm : ∀ t : unitInterval,
       ContinuousLinearMap.IsFredholm ((1 - (t : ℝ)) • T + (t : ℝ) • S)) :
     ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
-  let A : unitInterval → E' →L[ℝ] F' := fun t ↦
-    (1 - (t : ℝ)) • T + (t : ℝ) • S
-  have hA : Continuous A := by
-    fun_prop
-  have hindex :=
-    Continuous.fredholmIndex_eq_of_preconnectedSpace hA hFredholm (0 : unitInterval) 1
-  simpa [A] using hindex
+  apply Path.fredholmIndex_eq (Path.segment T S)
+  simpa only [Path.segment_apply, AffineMap.lineMap_apply_module] using hFredholm
 
 end Real
 


### PR DESCRIPTION
This PR proves that the Fredholm index is locally constant in every continuous family of Fredholm operators, then derives constancy on preconnected parameter spaces, equality at the endpoints of a Fredholm path, and equality along an everywhere-Fredholm affine segment. These results turn the already-landed small-perturbation theorem into the continuous-family API needed before spectral flow can measure crossings of noninvertible Fredholm operators.

It advances `TauCetiRoadmap/HeegaardFloer/README.md`, Lane F0, specifically “Fredholm operators (index, stability under compact and small perturbations, kernel/cokernel splitting),” and supplies a clean prerequisite for Lane F1.3, “the Maslov index for paths of Lagrangians and spectral flow (Robbin–Salamon).” This was the lowest-hanging distinct target because small-perturbation stability is already on `main`, while no Mathlib or Tau Ceti declaration promoted it to index invariance for continuous families; open Heegaard Floer PRs instead cover symmetric-power coordinates, integrated J-holomorphic energy, and cotangent graphs.

Add `TauCeti/Analysis/Fredholm/ContinuousFamily.lean` (110 lines). The argument follows the standard Fredholm-index consequence in McDuff–Salamon, *J-holomorphic Curves and Symplectic Topology*, Appendix A.1, as cited in the module docstring. Reuse Tau Ceti’s `ContinuousLinearMap.IsFredholm.eventually_isFredholm_and_index_eq` and Mathlib’s `IsLocallyConstant` preconnectedness API. No Mathlib infrastructure is vendored, and no external formalization is copied or adapted.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6047 jobs).` `lake exe axioms` reports `axioms: audited 17624 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"fredholm-index-continuous-family"}-->

🤖 Prepared with Codex
