### PR TITLE
refactor(Conformal): decompose the disc-automorphism classification

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Classification.lean
+++ b/TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Classification.lean
@@ -37,6 +37,49 @@ open scoped ComplexConjugate
 
 variable {f g : ℂ → ℂ}
 
+-- Conjugating `f` by the Moebius factor centred at `a` produces a disc self-map fixing the
+-- origin, with `M_a ∘ g` as a left inverse; the origin-fixing rotation theorem then applies.
+-- Only `f (a) = 0` is used, not the full right-inverse property that supplies it.
+private lemma exists_norm_eq_one_eqOn_comp_unitDiscMoebiusFormula {a : ℂ} (ha : ‖a‖ < 1)
+    (hf : DifferentiableOn ℂ f (ball (0 : ℂ) 1)) (hg : DifferentiableOn ℂ g (ball (0 : ℂ) 1))
+    (hfmaps : MapsTo f (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hgmaps : MapsTo g (ball (0 : ℂ) 1) (ball (0 : ℂ) 1))
+    (hgf : LeftInvOn g f (ball (0 : ℂ) 1)) (hfa : f a = 0) :
+    ∃ u : ℂ, ‖u‖ = 1 ∧
+      EqOn (f ∘ fun z : ℂ => (z - -a) / (1 - (starRingEnd ℂ) (-a) * z))
+        (fun z => u * z) (ball (0 : ℂ) 1) := by
+  have hneg : ‖(-a : ℂ)‖ < 1 := by simpa using ha
+  have hFdata : DifferentiableOn ℂ (f ∘ fun z : ℂ => (z - -a) /
+        (1 - (starRingEnd ℂ) (-a) * z)) (ball (0 : ℂ) 1) ∧
+      MapsTo (f ∘ fun z : ℂ => (z - -a) / (1 - (starRingEnd ℂ) (-a) * z))
+        (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) ∧
+      (f ∘ fun z : ℂ => (z - -a) / (1 - (starRingEnd ℂ) (-a) * z)) 0 = 0 := by
+    -- The target factor is centred at `f a = 0`, so it simplifies to the identity.
+    simpa [schwarzPickConjugate_def, hfa, Function.comp_def] using
+      differentiableOn_and_mapsTo_ball_and_apply_zero_schwarzPickConjugate hf hfmaps ha
+  obtain ⟨hFdiff, hFmaps, hFzero⟩ := hFdata
+  -- The two Moebius factors invert one another, so `M_a ∘ g` inverts `f ∘ M₋ₐ` by composition.
+  have hMinv : LeftInvOn (fun z : ℂ => (z - a) / (1 - (starRingEnd ℂ) a * z))
+      (fun z : ℂ => (z - -a) / (1 - (starRingEnd ℂ) (-a) * z)) (ball (0 : ℂ) 1) := by
+    simpa only [neg_neg] using leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one hneg
+  exact exists_eqOn_const_mul_of_leftInvOn_ball_of_map_zero hFdiff
+    ((differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one ha).comp hg hgmaps)
+    hFmaps ((mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha).comp hgmaps)
+    (hMinv.comp hgf (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hneg)) hFzero
+
+-- Undo the conjugation: a rotation on the conjugate is the standard form on `f` itself.
+private lemma forall_eq_const_mul_unitDiscMoebiusFormula_of_eqOn_comp {a u : ℂ} (ha : ‖a‖ < 1)
+    (h : EqOn (f ∘ fun z : ℂ => (z - -a) / (1 - (starRingEnd ℂ) (-a) * z))
+      (fun z => u * z) (ball (0 : ℂ) 1)) :
+    ∀ z ∈ ball (0 : ℂ) 1, f z = u * ((z - a) / (1 - (starRingEnd ℂ) a * z)) := by
+  intro z hz
+  have hF := h (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha hz)
+  simp only [Function.comp_apply] at hF
+  have hInv := leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha hz
+  -- Beta-reduce the scalar Moebius formula so the inverse equality rewrites `hF`.
+  dsimp only at hInv
+  rwa [hInv] at hF
+
 /--
 **Classification of holomorphic disc automorphisms.** A holomorphic self-map `f` of the open
 unit disc with a holomorphic two-sided inverse `g` has the standard form. Its center is `g 0`,
@@ -54,32 +97,10 @@ theorem exists_forall_unitDisc_eq_unitDiscStandardAutomorphismEquiv
   have hzero : (0 : ℂ) ∈ ball (0 : ℂ) 1 := by
     rw [mem_ball_zero_iff]
     norm_num
-  have hfg0 : f (g 0) = 0 := hfg hzero
-  have ha_mem : g 0 ∈ ball (0 : ℂ) 1 := hgmaps hzero
-  have ha : ‖g 0‖ < 1 := by simpa [mem_ball_zero_iff] using ha_mem
-  let F : ℂ → ℂ := f ∘ fun z =>
-    (z - (-(g 0))) / (1 - (starRingEnd ℂ) (-(g 0)) * z)
-  let G : ℂ → ℂ := (fun z =>
-    (z - g 0) / (1 - (starRingEnd ℂ) (g 0) * z)) ∘ g
-  have hneg : ‖-(g 0)‖ < 1 := by simpa using ha
-  have hFdata : DifferentiableOn ℂ F (ball (0 : ℂ) 1) ∧
-      MapsTo F (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) ∧ F 0 = 0 := by
-    -- The target factor is centered at `f (g 0) = 0`, so it simplifies to the identity.
-    simpa [F, schwarzPickConjugate_def, hfg0, Function.comp_def] using
-      differentiableOn_and_mapsTo_ball_and_apply_zero_schwarzPickConjugate hf hfmaps ha
-  obtain ⟨hFdiff, hFmaps, hFzero⟩ := hFdata
-  have hGdiff : DifferentiableOn ℂ G (ball (0 : ℂ) 1) :=
-    (differentiableOn_unitDiscMoebiusFormula_of_norm_lt_one ha).comp hg hgmaps
-  have hGmaps : MapsTo G (ball (0 : ℂ) 1) (ball (0 : ℂ) 1) :=
-    (mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha).comp hgmaps
-  have hGF : LeftInvOn G F (ball (0 : ℂ) 1) := by
-    intro z hz
-    simp only [F, G, Function.comp_apply]
-    rw [hgf ((mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one hneg) hz)]
-    simpa only [neg_neg] using
-      leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one (a := -(g 0)) hneg hz
-  obtain ⟨u, hu, hFu⟩ :=
-    exists_eqOn_const_mul_of_leftInvOn_ball_of_map_zero hFdiff hGdiff hFmaps hGmaps hGF hFzero
+  have ha : ‖g 0‖ < 1 := by simpa [mem_ball_zero_iff] using hgmaps hzero
+  obtain ⟨u, hu, hFu⟩ := exists_norm_eq_one_eqOn_comp_unitDiscMoebiusFormula ha hf hg hfmaps
+    hgmaps hgf (hfg hzero)
+  have hform := forall_eq_const_mul_unitDiscMoebiusFormula_of_eqOn_comp ha hFu
   refine ⟨⟨u, by
       have hmem : u ∈ (↑(Submonoid.unitSphere ℂ) : Set ℂ) := by
         rw [Submonoid.coe_unitSphere]
@@ -88,15 +109,7 @@ theorem exists_forall_unitDisc_eq_unitDiscStandardAutomorphismEquiv
     Complex.UnitDisc.mk (g 0) ha, Complex.UnitDisc.coe_mk _ _, fun z => ?_⟩
   have hz : (z : ℂ) ∈ ball (0 : ℂ) 1 := by
     simpa [mem_ball_zero_iff] using z.norm_lt_one
-  have hMz : ((z : ℂ) - g 0) / (1 - (starRingEnd ℂ) (g 0) * (z : ℂ)) ∈
-      ball (0 : ℂ) 1 := mapsTo_ball_unitDiscMoebiusFormula_of_norm_lt_one ha hz
-  have hF := hFu hMz
-  simp only [F, Function.comp_apply] at hF
-  have hInv := leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one ha hz
-  -- Beta-reduce the two scalar Moebius formulas so the inverse equality rewrites `hF`.
-  dsimp only at hInv
-  rw [hInv] at hF
   erw [coe_unitDiscStandardAutomorphismEquiv_apply]
-  simpa only [Complex.UnitDisc.coe_mk] using hF
+  simpa only [Complex.UnitDisc.coe_mk] using hform (z : ℂ) hz
 
 end TauCeti


### PR DESCRIPTION
Decomposes `exists_forall_unitDisc_eq_unitDiscStandardAutomorphismEquiv` in
`TauCeti/Analysis/Complex/Conformal/UnitDisc/Automorphism/Classification.lean`, the only proof in
the file and the next-longest body on main at 47 lines. No statement changes: the theorem keeps its
signature, and both extracted helpers are `private` and local to the file.

The proof runs three steps in one block — conjugate `f` by the Moebius factor centred at `g 0` so
the conjugate fixes the origin, apply the origin-fixing rotation theorem, then undo the conjugation
and repackage the result into `Circle` and `UnitDisc`. The first two steps and the third are now
separate, in the order the argument uses them:

| helper | what it proves | body |
|---|---|---|
| `exists_norm_eq_one_eqOn_comp_unitDiscMoebiusFormula` | the conjugate `f ∘ M₋ₐ` is a rotation on the disc | 19 |
| `forall_eq_const_mul_unitDiscMoebiusFormula_of_eqOn_comp` | undoing the conjugation gives `f z = u * Mₐ z` | 7 |

The parent goes from 47 lines to 17 and is now the packaging: get `‖g 0‖ < 1`, apply the two
helpers, build the `Circle` and `UnitDisc` elements.

**A hand-rolled step is replaced by Mathlib.** `hGF` proved `LeftInvOn (Mₐ ∘ g) (f ∘ M₋ₐ)` by hand
in six lines (`intro`, `simp only`, `rw`, `simpa`). That is exactly `Set.LeftInvOn.comp`
(`Mathlib/Data/Set/Function.lean:821`) applied to the Moebius inversion, `hgf`, and the fact that
`M₋ₐ` maps the disc into itself. The only remaining content is that the two Moebius factors invert
one another, which is `leftInvOn_unitDiscMoebiusFormula_of_norm_lt_one` up to `neg_neg` and is now
a named `hMinv`.

**Hypotheses were re-derived at extraction rather than inherited:**

* `exists_norm_eq_one_eqOn_comp_unitDiscMoebiusFormula` takes `hfa : f a = 0` rather than the
  parent's `hfg : RightInvOn g f (ball 0 1)`, since that is all the conjugation uses — the right
  inverse is only there to produce it, at the call site, as `hfg hzero`. It is also stated for an
  arbitrary centre `a` with `‖a‖ < 1`, not for `g 0`.
* `forall_eq_const_mul_unitDiscMoebiusFormula_of_eqOn_comp` mentions neither `g` nor any inverse
  property: it is a statement about an `EqOn` and a centre.
* Neither helper mentions `Circle`, `Complex.UnitDisc`, or `unitDiscStandardAutomorphismEquiv`;
  that packaging is the parent's job.

Two now-redundant bindings are gone: the `let F` / `let G` abbreviations (the helpers state those
composites directly) and `ha_mem`, which was only used to derive `ha`.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: ConformalMapping
