### PR TITLE
feat: act on quadratic spaces by the spin group

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Vectors
+public import TauCeti.LinearAlgebra.QuadraticForm.OrthogonalGroup
+public import Mathlib.LinearAlgebra.CliffordAlgebra.SpinGroup
+
+/-!
+# The spin group acting on its quadratic space
+
+Mathlib defines `spinGroup Q` inside `CliffordAlgebra Q` and proves that its conjugation action
+preserves the range of the generating map `CliffordAlgebra.ι Q`. This file transports that action
+through `TauCeti.CliffordAlgebra.ιRangeEquiv`, proves that it preserves `Q`, and packages the result
+as `spinToOrthogonal Q : spinGroup Q →* QuadraticMap.orthogonalGroup Q`.
+
+This is the representation underlying the double cover from the spin group to the special
+orthogonal group. The determinant-one property and surjectivity require the later
+Cartan--Dieudonné argument and are deliberately not asserted here.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.spinAction Q x` is the linear automorphism induced by conjugation by
+  the spin element `x`.
+* `TauCeti.CliffordAlgebra.spinToOrthogonal Q` is the resulting homomorphism into `O(Q)`.
+
+## References
+
+This supplies the action prerequisite for Layer 2, "The Pin and Spin groups and the double
+covers", of `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`. See H. B. Lawson
+and M.-L. Michelsohn, *Spin Geometry* (1989), Chapter I §2.
+-/
+
+public section
+
+open CliffordAlgebra
+
+namespace TauCeti
+
+universe u v
+
+namespace CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) [Invertible (2 : R)]
+
+private def spinActionLinear (x : spinGroup Q) : M →ₗ[R] M where
+  toFun m := ιInv Q ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q))
+  map_add' a b := by simp [map_add, mul_add, add_mul]
+  map_smul' r m := by
+    rw [map_smul]
+    rw [show (x : CliffordAlgebra Q) * (r • ι Q m) * star (x : CliffordAlgebra Q) =
+      r • ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) by
+        simp only [Algebra.smul_def, mul_assoc]
+        simp_rw [Algebra.commutes r]
+        noncomm_ring]
+    exact map_smul (ιInv Q) r _
+
+private theorem ι_spinActionLinear (x : spinGroup Q) (m : M) :
+    ι Q (spinActionLinear Q x m) =
+      (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) := by
+  apply ι_ιInv_of_mem Q
+  have h := spinGroup.involute_act_ι_mem_range_ι (x := spinGroup.toUnits x) x.2 m
+  change involute (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) ∈ _ at h
+  rwa [spinGroup.involute_eq x.2] at h
+
+private theorem spinActionLinear_inv_apply (x : spinGroup Q) (m : M) :
+    spinActionLinear Q x⁻¹ (spinActionLinear Q x m) = m := by
+  apply ι_injective Q
+  rw [ι_spinActionLinear, ι_spinActionLinear]
+  change star (x : CliffordAlgebra Q) *
+      ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) *
+        star (star (x : CliffordAlgebra Q)) = ι Q m
+  rw [star_star]
+  calc
+    star (x : CliffordAlgebra Q) *
+          ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) *
+          (x : CliffordAlgebra Q) =
+        (star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q)) * ι Q m *
+          (star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q)) := by noncomm_ring
+    _ = ι Q m := by rw [spinGroup.star_mul_self_of_mem x.2, one_mul, mul_one]
+
+/-- The action of a spin element on the generating vectors of its Clifford algebra, transported
+back to the underlying module. It is characterized by
+`spinAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
+noncomputable def spinAction (x : spinGroup Q) : M ≃ₗ[R] M where
+  toLinearMap := spinActionLinear Q x
+  invFun := spinActionLinear Q x⁻¹
+  left_inv := spinActionLinear_inv_apply Q x
+  right_inv m := by simpa using spinActionLinear_inv_apply Q x⁻¹ m
+
+/-- A spin element acts on a vector by conjugation inside the Clifford algebra. -/
+@[simp]
+theorem ι_spinAction_apply (x : spinGroup Q) (m : M) :
+    ι Q (spinAction Q x m) =
+      (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) :=
+  ι_spinActionLinear Q x m
+
+/-- Conjugation by a spin element preserves the quadratic form. -/
+@[simp]
+theorem spinAction_map_app (x : spinGroup Q) (m : M) : Q (spinAction Q x m) = Q m := by
+  apply algebraMap_injective Q
+  rw [← ι_sq_scalar Q (spinAction Q x m), ← ι_sq_scalar Q m, ι_spinAction_apply]
+  calc
+    (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) *
+          ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) =
+        (x : CliffordAlgebra Q) * ι Q m *
+          (star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q)) * ι Q m *
+            star (x : CliffordAlgebra Q) := by noncomm_ring
+    _ = (x : CliffordAlgebra Q) * (ι Q m * ι Q m) * star (x : CliffordAlgebra Q) := by
+      rw [spinGroup.star_mul_self_of_mem x.2, mul_one]
+      noncomm_ring
+    _ = ι Q m * ι Q m := by
+      rw [ι_sq_scalar]
+      calc
+        (x : CliffordAlgebra Q) * algebraMap R (CliffordAlgebra Q) (Q m) *
+              star (x : CliffordAlgebra Q) =
+            algebraMap R (CliffordAlgebra Q) (Q m) *
+              ((x : CliffordAlgebra Q) * star (x : CliffordAlgebra Q)) := by
+                rw [mul_assoc, Algebra.commutes (Q m) (star (x : CliffordAlgebra Q)), ← mul_assoc,
+                  Algebra.commutes]
+        _ = algebraMap R (CliffordAlgebra Q) (Q m) := by
+          rw [spinGroup.mul_star_self_of_mem x.2, mul_one]
+
+/-- The representation of the spin group on the quadratic space by Clifford conjugation. -/
+noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGroup Q where
+  toFun x := ⟨spinAction Q x, QuadraticMap.mem_orthogonalGroup_iff.mpr (spinAction_map_app Q x)⟩
+  map_one' := by
+    ext m
+    apply ι_injective Q
+    simp
+  map_mul' x y := by
+    apply Subtype.ext
+    apply LinearEquiv.ext
+    intro m
+    change spinAction Q (x * y) m = spinAction Q x (spinAction Q y m)
+    apply ι_injective Q
+    rw [ι_spinAction_apply, ι_spinAction_apply, ι_spinAction_apply]
+    change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) * ι Q m *
+        star ((x : CliffordAlgebra Q) * (y : CliffordAlgebra Q)) =
+      (x : CliffordAlgebra Q) *
+        ((y : CliffordAlgebra Q) * ι Q m * star (y : CliffordAlgebra Q)) *
+          star (x : CliffordAlgebra Q)
+    rw [star_mul]
+    noncomm_ring
+
+@[simp]
+theorem coe_spinToOrthogonal_apply (x : spinGroup Q) (m : M) :
+    ((spinToOrthogonal Q x : QuadraticMap.orthogonalGroup Q) : M ≃ₗ[R] M) m =
+      spinAction Q x m := by
+  rw [spinToOrthogonal]
+  rfl
+
+end CliffordAlgebra
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -70,7 +70,7 @@ private noncomputable def spinConjRange (x : spinGroup Q) :
 
 private theorem coe_spinConjRange_apply (x : spinGroup Q) (a : LinearMap.range (ι Q)) :
     (spinConjRange Q x a : CliffordAlgebra Q) = spinConj Q x (a : CliffordAlgebra Q) :=
-  rfl
+  by rw [spinConjRange, LinearEquiv.ofSubmodules_apply]
 
 private noncomputable def spinConjRangeHom :
     spinGroup Q →* LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) where

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -46,14 +46,16 @@ namespace CliffordAlgebra
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
 
-private noncomputable def spinConj (x : spinGroup Q) :
-    CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
-  DistribMulAction.toLinearEquiv R _ (ConjAct.toConjAct (spinGroup.toUnits x))
+private noncomputable def spinConj :
+    spinGroup Q →* CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
+  (DistribMulAction.toModuleAut R (CliffordAlgebra Q)).comp
+    ((ConjAct.toConjAct.toMonoidHom).comp spinGroup.toUnits)
 
 omit [Invertible (2 : R)] in
 private theorem spinConj_apply (x : spinGroup Q) (a : CliffordAlgebra Q) :
     spinConj Q x a = (x : CliffordAlgebra Q) * a * star (x : CliffordAlgebra Q) := by
-  simp [spinConj, ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct,
+  change ConjAct.toConjAct (spinGroup.toUnits x) • a = _
+  simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct,
     ← spinGroup.star_eq_inv]
 
 private theorem spinConj_map_range (x : spinGroup Q) :
@@ -64,11 +66,33 @@ private noncomputable def spinConjRange (x : spinGroup Q) :
     LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) :=
   (spinConj Q x).ofSubmodules _ _ (spinConj_map_range Q x)
 
+private noncomputable def spinConjRangeHom :
+    spinGroup Q →* LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) where
+  toFun := spinConjRange Q
+  map_one' := by
+    ext a
+    change spinConj Q 1 (a : CliffordAlgebra Q) = (a : CliffordAlgebra Q)
+    exact DFunLike.congr_fun (map_one (spinConj Q)) (a : CliffordAlgebra Q)
+  map_mul' x y := by
+    ext a
+    change spinConj Q (x * y) (a : CliffordAlgebra Q) =
+      spinConj Q x (spinConj Q y (a : CliffordAlgebra Q))
+    exact DFunLike.congr_fun (map_mul (spinConj Q) x y) (a : CliffordAlgebra Q)
+
+private noncomputable def spinVectorActionHom : spinGroup Q →* M ≃ₗ[R] M where
+  toFun x := (ιRangeEquiv Q).trans ((spinConjRangeHom Q x).trans (ιRangeEquiv Q).symm)
+  map_one' := by
+    ext m
+    simp
+  map_mul' x y := by
+    ext m
+    simp
+
 /-- The action of a spin element on the generating vectors of its Clifford algebra, transported
 back to the underlying module. It is characterized by
 `ι_spinVectorAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
-noncomputable def spinVectorAction (x : spinGroup Q) : M ≃ₗ[R] M where
-  __ := (ιRangeEquiv Q).trans ((spinConjRange Q x).trans (ιRangeEquiv Q).symm)
+noncomputable def spinVectorAction (x : spinGroup Q) : M ≃ₗ[R] M :=
+  spinVectorActionHom Q x
 
 /-- A spin element acts on a vector by conjugation inside the Clifford algebra. -/
 @[simp]
@@ -76,8 +100,12 @@ theorem ι_spinVectorAction_apply (x : spinGroup Q) (m : M) :
     ι Q (spinVectorAction Q x m) =
       (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) :=
   by
-    rw [spinVectorAction, LinearEquiv.trans_apply, LinearEquiv.trans_apply,
+    rw [spinVectorAction, spinVectorActionHom]
+    change ι Q (((ιRangeEquiv Q).trans
+      ((spinConjRangeHom Q x).trans (ιRangeEquiv Q).symm)) m) = _
+    rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply,
       ι_ιRangeEquiv_symm_apply]
+    rw [show spinConjRangeHom Q x = spinConjRange Q x from rfl]
     rw [spinConjRange, LinearEquiv.ofSubmodules_apply]
     rw [coe_ιRangeEquiv_apply]
     exact spinConj_apply Q x (ι Q m)
@@ -116,26 +144,11 @@ noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGro
     ⟨spinVectorAction Q x,
       QuadraticMap.mem_orthogonalGroup_iff.mpr (spinVectorAction_map_app Q x)⟩
   map_one' := by
-    ext m
-    apply ι_injective Q
-    simp
+    apply Subtype.ext
+    exact map_one (spinVectorActionHom Q)
   map_mul' x y := by
     apply Subtype.ext
-    apply LinearEquiv.ext
-    intro m
-    -- Multiplication of bundled linear equivalences is composition on their underlying functions.
-    change spinVectorAction Q (x * y) m =
-      spinVectorAction Q x (spinVectorAction Q y m)
-    apply ι_injective Q
-    rw [ι_spinVectorAction_apply, ι_spinVectorAction_apply, ι_spinVectorAction_apply]
-    -- Coercion of a product in `spinGroup` is multiplication in the Clifford algebra.
-    change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) * ι Q m *
-        star ((x : CliffordAlgebra Q) * (y : CliffordAlgebra Q)) =
-      (x : CliffordAlgebra Q) *
-        ((y : CliffordAlgebra Q) * ι Q m * star (y : CliffordAlgebra Q)) *
-          star (x : CliffordAlgebra Q)
-    rw [star_mul]
-    noncomm_ring
+    exact map_mul (spinVectorActionHom Q) x y
 
 @[simp]
 theorem coe_spinToOrthogonal_apply (x : spinGroup Q) (m : M) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -46,57 +46,56 @@ namespace CliffordAlgebra
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
   (Q : QuadraticForm R M) [Invertible (2 : R)]
 
-private def spinActionLinear (x : spinGroup Q) : M →ₗ[R] M where
-  toFun m := ιInv Q ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q))
-  map_add' a b := by simp [map_add, mul_add, add_mul]
-  map_smul' r m := by
-    rw [map_smul]
-    rw [show (x : CliffordAlgebra Q) * (r • ι Q m) * star (x : CliffordAlgebra Q) =
-      r • ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) by
-        simp only [Algebra.smul_def, mul_assoc]
-        simp_rw [Algebra.commutes r]
-        noncomm_ring]
-    exact map_smul (ιInv Q) r _
+private noncomputable def spinConj (x : spinGroup Q) :
+    CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
+  ((spinGroup.toUnits x).mulLeftLinearEquiv R _).trans
+    (((spinGroup.toUnits x)⁻¹).mulRightLinearEquiv R)
 
-private theorem ι_spinActionLinear (x : spinGroup Q) (m : M) :
-    ι Q (spinActionLinear Q x m) =
-      (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) := by
-  apply ι_ιInv_of_mem Q
-  have h := spinGroup.involute_act_ι_mem_range_ι (x := spinGroup.toUnits x) x.2 m
-  change involute (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) ∈ _ at h
-  rwa [spinGroup.involute_eq x.2] at h
+private theorem spinConj_map_range (x : spinGroup Q) :
+    (LinearMap.range (ι Q)).map (spinConj Q x).toLinearMap = LinearMap.range (ι Q) := by
+  apply le_antisymm
+  · rintro _ ⟨_, ⟨m, rfl⟩, rfl⟩
+    change (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) ∈ _
+    have h := spinGroup.conjAct_smul_ι_mem_range_ι (x := spinGroup.toUnits x) x.2 m
+    convert h using 1
+    all_goals
+      simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct, ← spinGroup.star_eq_inv]
+  · intro a ha
+    refine ⟨(spinConj Q x).symm a, ?_, (spinConj Q x).apply_symm_apply a⟩
+    · rcases ha with ⟨m, rfl⟩
+      rw [spinConj]
+      rw [LinearEquiv.symm_trans_apply, Units.symm_mulRightLinearEquiv_apply,
+        Units.symm_mulLeftLinearEquiv_apply]
+      have h := spinGroup.conjAct_smul_ι_mem_range_ι
+        (x := spinGroup.toUnits x⁻¹) (x⁻¹).2 m
+      convert h using 1
+      all_goals
+        simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct, ← spinGroup.star_eq_inv,
+            mul_assoc]
 
-private theorem spinActionLinear_inv_apply (x : spinGroup Q) (m : M) :
-    spinActionLinear Q x⁻¹ (spinActionLinear Q x m) = m := by
-  apply ι_injective Q
-  rw [ι_spinActionLinear, ι_spinActionLinear]
-  change star (x : CliffordAlgebra Q) *
-      ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) *
-        star (star (x : CliffordAlgebra Q)) = ι Q m
-  rw [star_star]
-  calc
-    star (x : CliffordAlgebra Q) *
-          ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) *
-          (x : CliffordAlgebra Q) =
-        (star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q)) * ι Q m *
-          (star (x : CliffordAlgebra Q) * (x : CliffordAlgebra Q)) := by noncomm_ring
-    _ = ι Q m := by rw [spinGroup.star_mul_self_of_mem x.2, one_mul, mul_one]
+private noncomputable def spinConjRange (x : spinGroup Q) :
+    LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) :=
+  (spinConj Q x).ofSubmodules _ _ (spinConj_map_range Q x)
 
 /-- The action of a spin element on the generating vectors of its Clifford algebra, transported
 back to the underlying module. It is characterized by
-`spinAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
+`ι_spinAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
 noncomputable def spinAction (x : spinGroup Q) : M ≃ₗ[R] M where
-  toLinearMap := spinActionLinear Q x
-  invFun := spinActionLinear Q x⁻¹
-  left_inv := spinActionLinear_inv_apply Q x
-  right_inv m := by simpa using spinActionLinear_inv_apply Q x⁻¹ m
+  __ := (ιRangeEquiv Q).trans ((spinConjRange Q x).trans (ιRangeEquiv Q).symm)
 
 /-- A spin element acts on a vector by conjugation inside the Clifford algebra. -/
 @[simp]
 theorem ι_spinAction_apply (x : spinGroup Q) (m : M) :
     ι Q (spinAction Q x m) =
       (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) :=
-  ι_spinActionLinear Q x m
+  by
+    rw [spinAction, LinearEquiv.trans_apply, LinearEquiv.trans_apply,
+      ι_ιRangeEquiv_symm_apply]
+    rw [spinConjRange, LinearEquiv.ofSubmodules_apply]
+    rw [coe_ιRangeEquiv_apply]
+    change (spinConj Q x) (ι Q m) = _
+    rw [spinConj]
+    rfl
 
 /-- Conjugation by a spin element preserves the quadratic form. -/
 @[simp]
@@ -135,9 +134,11 @@ noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGro
     apply Subtype.ext
     apply LinearEquiv.ext
     intro m
+    -- Multiplication of bundled linear equivalences is composition on their underlying functions.
     change spinAction Q (x * y) m = spinAction Q x (spinAction Q y m)
     apply ι_injective Q
     rw [ι_spinAction_apply, ι_spinAction_apply, ι_spinAction_apply]
+    -- Coercion of a product in `spinGroup` is multiplication in the Clifford algebra.
     change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) * ι Q m *
         star ((x : CliffordAlgebra Q) * (y : CliffordAlgebra Q)) =
       (x : CliffordAlgebra Q) *

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -66,18 +66,26 @@ private noncomputable def spinConjRange (x : spinGroup Q) :
     LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) :=
   (spinConj Q x).ofSubmodules _ _ (spinConj_map_range Q x)
 
+private theorem coe_spinConjRange_apply (x : spinGroup Q) (a : LinearMap.range (ι Q)) :
+    (spinConjRange Q x a : CliffordAlgebra Q) = spinConj Q x (a : CliffordAlgebra Q) :=
+  rfl
+
 private noncomputable def spinConjRangeHom :
     spinGroup Q →* LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) where
   toFun := spinConjRange Q
   map_one' := by
     ext a
-    change spinConj Q 1 (a : CliffordAlgebra Q) = (a : CliffordAlgebra Q)
+    rw [coe_spinConjRange_apply]
     exact DFunLike.congr_fun (map_one (spinConj Q)) (a : CliffordAlgebra Q)
   map_mul' x y := by
     ext a
-    change spinConj Q (x * y) (a : CliffordAlgebra Q) =
-      spinConj Q x (spinConj Q y (a : CliffordAlgebra Q))
+    rw [LinearEquiv.mul_apply, coe_spinConjRange_apply, coe_spinConjRange_apply,
+      coe_spinConjRange_apply]
     exact DFunLike.congr_fun (map_mul (spinConj Q) x y) (a : CliffordAlgebra Q)
+
+private theorem coe_spinConjRangeHom_apply (x : spinGroup Q) (a : LinearMap.range (ι Q)) :
+    (spinConjRangeHom Q x a : CliffordAlgebra Q) = spinConj Q x (a : CliffordAlgebra Q) := by
+  exact coe_spinConjRange_apply Q x a
 
 private noncomputable def spinVectorActionHom : spinGroup Q →* M ≃ₗ[R] M where
   toFun x := (ιRangeEquiv Q).trans ((spinConjRangeHom Q x).trans (ιRangeEquiv Q).symm)
@@ -94,20 +102,20 @@ back to the underlying module. It is characterized by
 noncomputable def spinVectorAction (x : spinGroup Q) : M ≃ₗ[R] M :=
   spinVectorActionHom Q x
 
+private theorem spinVectorAction_apply (x : spinGroup Q) (m : M) :
+    spinVectorAction Q x m =
+      (ιRangeEquiv Q).trans ((spinConjRangeHom Q x).trans (ιRangeEquiv Q).symm) m :=
+  rfl
+
 /-- A spin element acts on a vector by conjugation inside the Clifford algebra. -/
 @[simp]
 theorem ι_spinVectorAction_apply (x : spinGroup Q) (m : M) :
     ι Q (spinVectorAction Q x m) =
       (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) :=
   by
-    rw [spinVectorAction, spinVectorActionHom]
-    change ι Q (((ιRangeEquiv Q).trans
-      ((spinConjRangeHom Q x).trans (ιRangeEquiv Q).symm)) m) = _
-    rw [LinearEquiv.trans_apply, LinearEquiv.trans_apply,
-      ι_ιRangeEquiv_symm_apply]
-    rw [show spinConjRangeHom Q x = spinConjRange Q x from rfl]
-    rw [spinConjRange, LinearEquiv.ofSubmodules_apply]
-    rw [coe_ιRangeEquiv_apply]
+    rw [spinVectorAction_apply, LinearEquiv.trans_apply,
+      LinearEquiv.trans_apply, ι_ιRangeEquiv_symm_apply, coe_spinConjRangeHom_apply,
+      coe_ιRangeEquiv_apply]
     exact spinConj_apply Q x (ι Q m)
 
 /-- Conjugation by a spin element preserves the quadratic form. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -22,8 +22,8 @@ Cartan--Dieudonné argument and are deliberately not asserted here.
 
 ## Main definitions
 
-* `TauCeti.CliffordAlgebra.spinAction Q x` is the linear automorphism induced by conjugation by
-  the spin element `x`.
+* `TauCeti.CliffordAlgebra.spinVectorAction Q x` is the linear automorphism induced by conjugation
+  by the spin element `x`.
 * `TauCeti.CliffordAlgebra.spinToOrthogonal Q` is the resulting homomorphism into `O(Q)`.
 
 ## References
@@ -48,30 +48,17 @@ variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
 private noncomputable def spinConj (x : spinGroup Q) :
     CliffordAlgebra Q ≃ₗ[R] CliffordAlgebra Q :=
-  ((spinGroup.toUnits x).mulLeftLinearEquiv R _).trans
-    (((spinGroup.toUnits x)⁻¹).mulRightLinearEquiv R)
+  DistribMulAction.toLinearEquiv R _ (ConjAct.toConjAct (spinGroup.toUnits x))
+
+omit [Invertible (2 : R)] in
+private theorem spinConj_apply (x : spinGroup Q) (a : CliffordAlgebra Q) :
+    spinConj Q x a = (x : CliffordAlgebra Q) * a * star (x : CliffordAlgebra Q) := by
+  simp [spinConj, ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct,
+    ← spinGroup.star_eq_inv]
 
 private theorem spinConj_map_range (x : spinGroup Q) :
     (LinearMap.range (ι Q)).map (spinConj Q x).toLinearMap = LinearMap.range (ι Q) := by
-  apply le_antisymm
-  · rintro _ ⟨_, ⟨m, rfl⟩, rfl⟩
-    change (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) ∈ _
-    have h := spinGroup.conjAct_smul_ι_mem_range_ι (x := spinGroup.toUnits x) x.2 m
-    convert h using 1
-    all_goals
-      simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct, ← spinGroup.star_eq_inv]
-  · intro a ha
-    refine ⟨(spinConj Q x).symm a, ?_, (spinConj Q x).apply_symm_apply a⟩
-    · rcases ha with ⟨m, rfl⟩
-      rw [spinConj]
-      rw [LinearEquiv.symm_trans_apply, Units.symm_mulRightLinearEquiv_apply,
-        Units.symm_mulLeftLinearEquiv_apply]
-      have h := spinGroup.conjAct_smul_ι_mem_range_ι
-        (x := spinGroup.toUnits x⁻¹) (x⁻¹).2 m
-      convert h using 1
-      all_goals
-        simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct, ← spinGroup.star_eq_inv,
-            mul_assoc]
+  exact spinGroup.conjAct_smul_range_ι (x := spinGroup.toUnits x) x.2
 
 private noncomputable def spinConjRange (x : spinGroup Q) :
     LinearMap.range (ι Q) ≃ₗ[R] LinearMap.range (ι Q) :=
@@ -79,29 +66,29 @@ private noncomputable def spinConjRange (x : spinGroup Q) :
 
 /-- The action of a spin element on the generating vectors of its Clifford algebra, transported
 back to the underlying module. It is characterized by
-`ι_spinAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
-noncomputable def spinAction (x : spinGroup Q) : M ≃ₗ[R] M where
+`ι_spinVectorAction_apply`, which identifies it with conjugation inside the Clifford algebra. -/
+noncomputable def spinVectorAction (x : spinGroup Q) : M ≃ₗ[R] M where
   __ := (ιRangeEquiv Q).trans ((spinConjRange Q x).trans (ιRangeEquiv Q).symm)
 
 /-- A spin element acts on a vector by conjugation inside the Clifford algebra. -/
 @[simp]
-theorem ι_spinAction_apply (x : spinGroup Q) (m : M) :
-    ι Q (spinAction Q x m) =
+theorem ι_spinVectorAction_apply (x : spinGroup Q) (m : M) :
+    ι Q (spinVectorAction Q x m) =
       (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) :=
   by
-    rw [spinAction, LinearEquiv.trans_apply, LinearEquiv.trans_apply,
+    rw [spinVectorAction, LinearEquiv.trans_apply, LinearEquiv.trans_apply,
       ι_ιRangeEquiv_symm_apply]
     rw [spinConjRange, LinearEquiv.ofSubmodules_apply]
     rw [coe_ιRangeEquiv_apply]
-    change (spinConj Q x) (ι Q m) = _
-    rw [spinConj]
-    rfl
+    exact spinConj_apply Q x (ι Q m)
 
 /-- Conjugation by a spin element preserves the quadratic form. -/
 @[simp]
-theorem spinAction_map_app (x : spinGroup Q) (m : M) : Q (spinAction Q x m) = Q m := by
+theorem spinVectorAction_map_app (x : spinGroup Q) (m : M) :
+    Q (spinVectorAction Q x m) = Q m := by
   apply algebraMap_injective Q
-  rw [← ι_sq_scalar Q (spinAction Q x m), ← ι_sq_scalar Q m, ι_spinAction_apply]
+  rw [← ι_sq_scalar Q (spinVectorAction Q x m), ← ι_sq_scalar Q m,
+    ι_spinVectorAction_apply]
   calc
     (x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q) *
           ((x : CliffordAlgebra Q) * ι Q m * star (x : CliffordAlgebra Q)) =
@@ -125,7 +112,9 @@ theorem spinAction_map_app (x : spinGroup Q) (m : M) : Q (spinAction Q x m) = Q 
 
 /-- The representation of the spin group on the quadratic space by Clifford conjugation. -/
 noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGroup Q where
-  toFun x := ⟨spinAction Q x, QuadraticMap.mem_orthogonalGroup_iff.mpr (spinAction_map_app Q x)⟩
+  toFun x :=
+    ⟨spinVectorAction Q x,
+      QuadraticMap.mem_orthogonalGroup_iff.mpr (spinVectorAction_map_app Q x)⟩
   map_one' := by
     ext m
     apply ι_injective Q
@@ -135,9 +124,10 @@ noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGro
     apply LinearEquiv.ext
     intro m
     -- Multiplication of bundled linear equivalences is composition on their underlying functions.
-    change spinAction Q (x * y) m = spinAction Q x (spinAction Q y m)
+    change spinVectorAction Q (x * y) m =
+      spinVectorAction Q x (spinVectorAction Q y m)
     apply ι_injective Q
-    rw [ι_spinAction_apply, ι_spinAction_apply, ι_spinAction_apply]
+    rw [ι_spinVectorAction_apply, ι_spinVectorAction_apply, ι_spinVectorAction_apply]
     -- Coercion of a product in `spinGroup` is multiplication in the Clifford algebra.
     change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) * ι Q m *
         star ((x : CliffordAlgebra Q) * (y : CliffordAlgebra Q)) =
@@ -150,7 +140,7 @@ noncomputable def spinToOrthogonal : spinGroup Q →* QuadraticMap.orthogonalGro
 @[simp]
 theorem coe_spinToOrthogonal_apply (x : spinGroup Q) (m : M) :
     ((spinToOrthogonal Q x : QuadraticMap.orthogonalGroup Q) : M ≃ₗ[R] M) m =
-      spinAction Q x m := by
+      spinVectorAction Q x m := by
   rw [spinToOrthogonal]
   rfl
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean
@@ -54,6 +54,8 @@ private noncomputable def spinConj :
 omit [Invertible (2 : R)] in
 private theorem spinConj_apply (x : spinGroup Q) (a : CliffordAlgebra Q) :
     spinConj Q x a = (x : CliffordAlgebra Q) * a * star (x : CliffordAlgebra Q) := by
+  -- `toModuleAut` has no application theorem reducing through a composed `MonoidHom`, so expose
+  -- its underlying conjugation action before applying the public `ConjAct` simplification API.
   change ConjAct.toConjAct (spinGroup.toUnits x) • a = _
   simp [ConjAct.units_smul_def, ConjAct.ofConjAct_toConjAct,
     ← spinGroup.star_eq_inv]


### PR DESCRIPTION
This PR transports Clifford conjugation by the spin group to the underlying quadratic module, proves that every resulting linear automorphism preserves the quadratic form, and packages the action as `spinToOrthogonal Q : spinGroup Q →* QuadraticMap.orthogonalGroup Q`.

It supplies the immediate action prerequisite for `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, Layer 2, specifically “The twisted-conjugation homomorphism” item and its restriction `spinToSpecialOrthogonal`. The later determinant-one factorization, kernel computation, and surjectivity remain separate Cartan--Dieudonné-dependent targets. This is the lowest-hanging distinct target because Mathlib already proves that spin conjugation preserves the range of the Clifford generators, and Tau Ceti already identifies that range with the quadratic module and defines its abstract orthogonal group; no open or recently merged PR packages their composition.

Add `TauCeti/LinearAlgebra/CliffordAlgebra/SpinAction.lean` (157 lines). Reuse Mathlib's `spinGroup.involute_act_ι_mem_range_ι`, `spinGroup.involute_eq`, and unitary identities, together with Tau Ceti's `CliffordAlgebra.ιRangeEquiv` API and `QuadraticMap.orthogonalGroup`. The orthogonality proof squares the conjugated generator and applies the Clifford relation `CliffordAlgebra.ι_sq_scalar`. The construction follows Lawson--Michelsohn, *Spin Geometry*, Chapter I §2, as cited in the module docstring. No Mathlib infrastructure is vendored and no external formalization is copied or adapted.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6050 jobs).` `lake exe axioms` reports `axioms: audited 17681 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: SpinRepresentations

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"spintoorthogonal"}-->

🤖 Prepared with Codex
