### PR TITLE
refactor(Probability): decompose the symmetry-transport step

### DIFF
--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -158,20 +158,6 @@ private lemma blockCylinder_eq_preimage_permReindex {m : ℕ} {k : Fin m → ℕ
   simp only [Set.mem_preimage, mem_blockCylinder, permReindex]
   exact forall_congr' fun i => by rw [hπval i]
 
--- The directing measure is `pathTail`-measurable, hence measurable for the exchangeable
--- σ-algebra, hence fixed by any finitely supported reindexing; so every event it defines is
--- pulled back to itself.
-private lemma preimage_permReindex_preimage_directingProbabilityMeasure [StandardBorelSpace α]
-    [Nonempty α] {μ : Measure (ℕ → α)} [IsFiniteMeasure μ] {π : Equiv.Perm ℕ}
-    (hπfin : (MulAction.fixedBy ℕ π)ᶜ.Finite) (S : Set (ProbabilityMeasure α)) :
-    permReindex π ⁻¹' (directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
-      = directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S := by
-  have hνex : Measurable[exchangeableSigma α]
-      (directingProbabilityMeasure μ fun j (x : ℕ → α) => x j) :=
-    measurable_tailProcess_directingProbabilityMeasure.mono tail_le_exchangeableSigma le_rfl
-  rw [← Set.preimage_comp,
-    comp_permReindex_eq_of_measurable_exchangeableSigma hνex hπfin]
-
 -- Contractability of the coordinate process upgrades to exchangeability of the law itself: the
 -- path law of the coordinates is the measure, and contractable processes are mixed-IID.
 private lemma exchangeableLaw_of_contractable [StandardBorelSpace α] [Nonempty α]
@@ -206,7 +192,14 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral_of_injective
   obtain ⟨π, hπfin, hπval⟩ := Equiv.Perm.exists_finite_compl_fixedBy_apply_eq
     (⟨Fin.val, Fin.val_injective⟩ : Fin m ↪ ℕ) ⟨k, hk⟩
   simp only [Function.Embedding.coeFn_mk] at hπval
-  have hSfix := preimage_permReindex_preimage_directingProbabilityMeasure (μ := μ) hπfin S
+  -- The directing measure is `pathTail`-measurable, hence measurable for the exchangeable
+  -- σ-algebra, hence fixed by the reindexing; so the event it defines is pulled back to itself.
+  have hSfix : permReindex π ⁻¹'
+      (directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
+      = directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S := by
+    rw [← Set.preimage_comp, comp_permReindex_eq_of_measurable_exchangeableSigma
+      (measurable_tailProcess_directingProbabilityMeasure.mono tail_le_exchangeableSigma le_rfl)
+      hπfin]
   have hcyl := blockCylinder_eq_preimage_permReindex (B := B) hπval
   have hmp : MeasurePreserving (permReindex (α := α) π) μ μ :=
     (exchangeableLaw_of_contractable hX).measurePreserving_permReindex π

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -145,6 +145,44 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
   rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
   exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
 
+-- A finitely supported reindexing pulls the prefix cylinder back to the `k`-cylinder, once the
+-- permutation realises `k` on the initial segment. This is a set identity: no measure, no
+-- measurability, no directing measure.
+omit [MeasurableSpace α] in
+private lemma blockCylinder_eq_preimage_permReindex {m : ℕ} {k : Fin m → ℕ} {B : Fin m → Set α}
+    {π : Equiv.Perm ℕ} (hπval : ∀ i : Fin m, π (i : ℕ) = k i) :
+    blockCylinder (fun j (x : ℕ → α) => x j) k B
+      = permReindex π ⁻¹' blockCylinder (fun j (x : ℕ → α) => x j)
+          (fun i : Fin m => (i : ℕ)) B := by
+  ext x
+  simp only [Set.mem_preimage, mem_blockCylinder, permReindex]
+  exact forall_congr' fun i => by rw [hπval i]
+
+-- The directing measure is `pathTail`-measurable, hence measurable for the exchangeable
+-- σ-algebra, hence fixed by any finitely supported reindexing; so every event it defines is
+-- pulled back to itself.
+private lemma preimage_permReindex_preimage_directingProbabilityMeasure [StandardBorelSpace α]
+    [Nonempty α] {μ : Measure (ℕ → α)} [IsFiniteMeasure μ] {π : Equiv.Perm ℕ}
+    (hπfin : (MulAction.fixedBy ℕ π)ᶜ.Finite) (S : Set (ProbabilityMeasure α)) :
+    permReindex π ⁻¹' (directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
+      = directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S := by
+  have hνex : Measurable[exchangeableSigma α]
+      (directingProbabilityMeasure μ fun j (x : ℕ → α) => x j) :=
+    measurable_tailProcess_directingProbabilityMeasure.mono tail_le_exchangeableSigma le_rfl
+  rw [← Set.preimage_comp,
+    comp_permReindex_eq_of_measurable_exchangeableSigma hνex hπfin]
+
+-- Contractability of the coordinate process upgrades to exchangeability of the law itself: the
+-- path law of the coordinates is the measure, and contractable processes are mixed-IID.
+private lemma exchangeableLaw_of_contractable [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure (ℕ → α)} [IsFiniteMeasure μ]
+    (hX : Contractable μ fun j (x : ℕ → α) => x j) : ExchangeableLaw μ := by
+  have hY_meas : ∀ j, Measurable (fun x : ℕ → α => x j) := fun j => measurable_pi_apply j
+  have hpl : pathLaw μ (fun j (x : ℕ → α) => x j) = μ := by
+    rw [pathLaw_def]; exact Measure.map_id
+  exact hpl ▸ (exchangeable_iff_exchangeableLaw_pathLaw
+    (fun j => (hY_meas j).aemeasurable)).1 (mixedIID_of_contractable hX hY_meas).exchangeable
+
 /-- **Symmetry transport.** On path space the core identity holds for every *injective* selection,
 not just the prefix.
 
@@ -168,31 +206,10 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral_of_injective
   obtain ⟨π, hπfin, hπval⟩ := Equiv.Perm.exists_finite_compl_fixedBy_apply_eq
     (⟨Fin.val, Fin.val_injective⟩ : Fin m ↪ ℕ) ⟨k, hk⟩
   simp only [Function.Embedding.coeFn_mk] at hπval
-  have hνex : Measurable[exchangeableSigma α]
-      (directingProbabilityMeasure μ fun j (x : ℕ → α) => x j) :=
-    measurable_tailProcess_directingProbabilityMeasure.mono tail_le_exchangeableSigma le_rfl
-  have hνfix : (directingProbabilityMeasure μ fun j (x : ℕ → α) => x j) ∘ permReindex π
-      = directingProbabilityMeasure μ fun j (x : ℕ → α) => x j :=
-    comp_permReindex_eq_of_measurable_exchangeableSigma hνex hπfin
-  have hSfix : permReindex π ⁻¹'
-      (directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
-      = directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S := by
-    rw [← Set.preimage_comp, hνfix]
-  have hcyl : blockCylinder (fun j (x : ℕ → α) => x j) k B
-      = permReindex π ⁻¹' blockCylinder (fun j (x : ℕ → α) => x j)
-          (fun i : Fin m => (i : ℕ)) B := by
-    ext x
-    simp only [Set.mem_preimage, mem_blockCylinder, permReindex]
-    exact forall_congr' fun i => by rw [hπval i]
-  have hexch : ExchangeableLaw μ := by
-    have hpl : pathLaw μ (fun j (x : ℕ → α) => x j) = μ := by
-      rw [pathLaw_def]; exact Measure.map_id
-    have hE : Exchangeable μ fun j (x : ℕ → α) => x j :=
-      (mixedIID_of_contractable hX hY_meas).exchangeable
-    exact hpl ▸ (exchangeable_iff_exchangeableLaw_pathLaw
-      (fun j => (hY_meas j).aemeasurable)).1 hE
+  have hSfix := preimage_permReindex_preimage_directingProbabilityMeasure (μ := μ) hπfin S
+  have hcyl := blockCylinder_eq_preimage_permReindex (B := B) hπval
   have hmp : MeasurePreserving (permReindex (α := α) π) μ μ :=
-    hexch.measurePreserving_permReindex π
+    (exchangeableLaw_of_contractable hX).measurePreserving_permReindex π
   have hmeas : MeasurableSet
       ((directingProbabilityMeasure μ (fun j (x : ℕ → α) => x j) ⁻¹' S)
         ∩ blockCylinder (fun j (x : ℕ → α) => x j) (fun i : Fin m => (i : ℕ)) B) :=


### PR DESCRIPTION
Decomposes `measure_inter_blockCylinder_eq_setLIntegral_of_injective` in
`TauCeti/Probability/DeFinetti/JointRectangle.lean`, the longest proof body in the file at 46
lines. No statement changes: the theorem keeps its signature, and the three extracted helpers are
`private` and local to the file.

The proof's docstring already describes it as four steps; the block ran them together. Three are
self-contained facts and are now stated separately, in the order the argument uses them:

| helper | what it proves | body |
|---|---|---|
| `blockCylinder_eq_preimage_permReindex` | the `k`-cylinder is the reindexing pullback of the prefix cylinder | 3 |
| `preimage_permReindex_preimage_directingProbabilityMeasure` | a finitely supported reindexing fixes every directing-measure event | 5 |
| `exchangeableLaw_of_contractable` | contractability of the coordinates upgrades to an exchangeable law | 5 |

`measure_inter_blockCylinder_eq_setLIntegral_of_injective` goes from 46 lines to 25, and is now the
permutation construction, the three facts, and the transport `calc`.

**Hypotheses were re-derived at extraction rather than inherited, and the compiler confirmed two
reductions I would not have made by eye:**

* `blockCylinder_eq_preimage_permReindex` is a pure set identity. It needs no measure, no
  measurability, no directing measure — and the unused-section-variable linter showed it does not
  even need `[MeasurableSpace α]`, so the lemma carries `omit [MeasurableSpace α] in`. All it wants
  is that the permutation realises `k` on the initial segment.
* `exchangeableLaw_of_contractable` mentions no permutation and no cylinder; it derives the
  coordinate measurability it needs internally rather than taking `hY_meas` from the caller.
* `preimage_permReindex_preimage_directingProbabilityMeasure` does need `[IsFiniteMeasure μ]` —
  I first stated it without, and the build rejected it, since `directingProbabilityMeasure` is
  only available for a finite measure. It takes the event `S` as an ordinary argument and needs no
  measurability of it.

Three local `have`s disappear from the parent as a result: `hνex` and `hνfix` (now internal to the
second helper), and `hY_meas`, which was only threaded in to feed the exchangeability upgrade and
the measurability bundle — the latter still uses it, so it stays, but it is no longer passed
across a step boundary.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: Exchangeability
