### PR TITLE
feat: cover the frontier of a conformal image by boundary cluster sets

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
@@ -34,6 +34,9 @@ extension from the hypotheses.
 * **An extension injective on the frontier is injective on the closure.** This supplies the
   injectivity hypothesis of `TauCeti.closureHomeomorph`, reducing it to a condition on the boundary
   alone, because the boundary values have just been shown to avoid the image.
+* **Conversely, the boundary cluster sets exhaust the frontier of the image**, for a bounded
+  domain: no boundary point of `f '' U` is missed. This is the surjectivity of the boundary
+  correspondence, and it is what makes the inclusion of the first item an equality.
 
 A third ingredient is again not about conformality and is proved upstream, in
 `TauCeti/Analysis/Convex/ClusterSet.lean`: on a **convex** domain — the unit disc, in the
@@ -62,6 +65,11 @@ every theorem added in layers L0–L6, the results below are stated for maps of 
   boundary cluster value of a conformal map lies on the frontier of the image.
 * `TauCeti.injOn_closure_of_injOn_frontier` — an extension injective on the frontier is injective
   on the closure.
+* `TauCeti.exists_mem_frontier_mem_clusterSetOn` and
+  `TauCeti.biUnion_clusterSetOn_eq_frontier_image` — **the boundary correspondence is onto**: on a
+  bounded domain the boundary cluster sets cover, hence exactly exhaust, the frontier of the image.
+  `TauCeti.biUnion_clusterSetOn_sphere_eq_frontier_image` is the case of the unit disc, the one a
+  Riemann map presents.
 
 ## Coordination with upstream Mathlib
 
@@ -155,5 +163,66 @@ theorem injOn_closure_of_injOn_frontier (hUo : IsOpen U) (hfd : DifferentiableOn
     rw [hab, hFf hbU]
     exact ⟨b, hbU, rfl⟩
   · exact hFfr haF hbF hab
+
+/-! ## The boundary correspondence is onto -/
+
+/-- **Every boundary point of the image is a boundary cluster value.** If `f` is holomorphic and
+injective on a bounded open `U`, then each point of `frontier (f '' U)` is approached by `f` at some
+point of `frontier U`.
+
+Boundedness of `U` is what is doing the work, through
+`TauCeti.exists_mem_closure_mem_clusterSetOn`: it makes `closure U` compact, so the points of `U` at
+which `f` approaches a given boundary value of the image cannot escape, and accumulate somewhere on
+`closure U`. That accumulation point does not lie in `U`, because at a point of `U` the only cluster
+value is `f w` itself, which lies in the *open* set `f '' U` and so not on its frontier.
+
+This is the converse of `TauCeti.clusterSetOn_subset_frontier_image`, and the two together say that
+the boundary correspondence `w ↦ clusterSetOn f U w` is onto `frontier (f '' U)`. Carathéodory's
+theorem — layer **L5** of the conformal-mapping roadmap — refines this to a *bijection* by showing
+each of these cluster sets to be a singleton; the surjectivity below holds with no hypothesis on
+`frontier U` whatever. -/
+theorem exists_mem_frontier_mem_clusterSetOn (hUo : IsOpen U) (hUb : Bornology.IsBounded U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (hv : v ∈ frontier (f '' U)) :
+    ∃ w ∈ frontier U, v ∈ clusterSetOn f U w := by
+  rw [(isOpen_image_of_differentiableOn_of_injOn hUo hfd hfi).frontier_eq] at hv
+  obtain ⟨w, hw, hvw⟩ := exists_mem_closure_mem_clusterSetOn hUb.isCompact_closure hv.1
+  refine ⟨w, ?_, hvw⟩
+  rw [hUo.frontier_eq]
+  refine ⟨hw, fun hwU => hv.2 ?_⟩
+  rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwU (hfd.continuousOn w hwU),
+    mem_singleton_iff] at hvw
+  rw [hvw]
+  exact mem_image_of_mem f hwU
+
+/-- **The boundary cluster sets exhaust the frontier of the image.** For a conformal map of a
+bounded open set, the union of the cluster sets over `frontier U` is exactly `frontier (f '' U)`.
+
+One inclusion is `TauCeti.clusterSetOn_subset_frontier_image` — no boundary cluster value is
+attained, and none escapes the closure of the image — and the other is
+`TauCeti.exists_mem_frontier_mem_clusterSetOn`. Neither connectedness nor simple connectedness of
+`U` is used, and nothing is assumed about `frontier U`. -/
+theorem biUnion_clusterSetOn_eq_frontier_image (hUo : IsOpen U) (hUb : Bornology.IsBounded U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) :
+    ⋃ w ∈ frontier U, clusterSetOn f U w = frontier (f '' U) :=
+  subset_antisymm (iUnion₂_subset fun _ hw => clusterSetOn_subset_frontier_image hUo hfd hfi hw)
+    fun _ hv => by
+      obtain ⟨w, hw, hvw⟩ := exists_mem_frontier_mem_clusterSetOn hUo hUb hfd hfi hv
+      exact mem_biUnion hw hvw
+
+/-- **The boundary correspondence of a conformal map of the unit disc.** The case of
+`TauCeti.biUnion_clusterSetOn_eq_frontier_image` in which the domain is `ball 0 1`, so that the
+frontier is the unit circle: the frontier of the image is the union of the cluster sets taken over
+the unit circle.
+
+This is the shape in which the boundary correspondence is met in practice, a Riemann map being a
+conformal map *of* the disc. Each of the sets in the union is moreover a continuum, by
+`TauCeti.isConnected_clusterSetOn_of_convex_of_isBounded`, the disc being convex; Carathéodory's
+theorem asserts that for a Jordan image every one of them degenerates to a point. -/
+theorem biUnion_clusterSetOn_sphere_eq_frontier_image
+    (hfd : DifferentiableOn ℂ f (ball 0 1)) (hfi : InjOn f (ball 0 1)) :
+    ⋃ w ∈ sphere (0 : ℂ) 1, clusterSetOn f (ball 0 1) w = frontier (f '' ball 0 1) := by
+  have h := biUnion_clusterSetOn_eq_frontier_image (U := ball (0 : ℂ) 1) isOpen_ball isBounded_ball
+    hfd hfi
+  rwa [frontier_ball (0 : ℂ) one_ne_zero] at h
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ClusterSet.lean
@@ -68,8 +68,8 @@ every theorem added in layers L0–L6, the results below are stated for maps of 
 * `TauCeti.exists_mem_frontier_mem_clusterSetOn` and
   `TauCeti.biUnion_clusterSetOn_eq_frontier_image` — **the boundary correspondence is onto**: on a
   bounded domain the boundary cluster sets cover, hence exactly exhaust, the frontier of the image.
-  `TauCeti.biUnion_clusterSetOn_sphere_eq_frontier_image` is the case of the unit disc, the one a
-  Riemann map presents.
+  The case a Riemann map presents is the unit disc, where `frontier_ball` rewrites `frontier U` to
+  the unit circle.
 
 ## Coordination with upstream Mathlib
 
@@ -170,29 +170,25 @@ theorem injOn_closure_of_injOn_frontier (hUo : IsOpen U) (hfd : DifferentiableOn
 injective on a bounded open `U`, then each point of `frontier (f '' U)` is approached by `f` at some
 point of `frontier U`.
 
-Boundedness of `U` is what is doing the work, through
-`TauCeti.exists_mem_closure_mem_clusterSetOn`: it makes `closure U` compact, so the points of `U` at
-which `f` approaches a given boundary value of the image cannot escape, and accumulate somewhere on
-`closure U`. That accumulation point does not lie in `U`, because at a point of `U` the only cluster
-value is `f w` itself, which lies in the *open* set `f '' U` and so not on its frontier.
+All the work is done by the general covering theorem
+`TauCeti.exists_mem_frontier_mem_clusterSetOn_of_notMem_image`, which needs only that `closure U` be
+compact — here, boundedness of `U` — and that `f` be continuous on `U`. What conformality
+contributes is that `f '' U` is *open*, so that `frontier (f '' U)` is `closure (f '' U) \ f '' U`
+and the boundary value `v` is an adherent value of the image that is not attained.
 
 This is the converse of `TauCeti.clusterSetOn_subset_frontier_image`, and the two together say that
 the boundary correspondence `w ↦ clusterSetOn f U w` is onto `frontier (f '' U)`. Carathéodory's
-theorem — layer **L5** of the conformal-mapping roadmap — refines this to a *bijection* by showing
-each of these cluster sets to be a singleton; the surjectivity below holds with no hypothesis on
-`frontier U` whatever. -/
+theorem — layer **L5** of the conformal-mapping roadmap — refines this for a Riemann map of a Jordan
+domain by showing each of these cluster sets to be a singleton, which turns the correspondence into
+a continuous *map* of `frontier U` onto `frontier (f '' U)`; that this map is moreover *injective*
+is a further assertion of Carathéodory's theorem, and does not follow from the singleton property.
+The surjectivity below holds with no hypothesis on `frontier U` whatever. -/
 theorem exists_mem_frontier_mem_clusterSetOn (hUo : IsOpen U) (hUb : Bornology.IsBounded U)
     (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (hv : v ∈ frontier (f '' U)) :
     ∃ w ∈ frontier U, v ∈ clusterSetOn f U w := by
   rw [(isOpen_image_of_differentiableOn_of_injOn hUo hfd hfi).frontier_eq] at hv
-  obtain ⟨w, hw, hvw⟩ := exists_mem_closure_mem_clusterSetOn hUb.isCompact_closure hv.1
-  refine ⟨w, ?_, hvw⟩
-  rw [hUo.frontier_eq]
-  refine ⟨hw, fun hwU => hv.2 ?_⟩
-  rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwU (hfd.continuousOn w hwU),
-    mem_singleton_iff] at hvw
-  rw [hvw]
-  exact mem_image_of_mem f hwU
+  exact exists_mem_frontier_mem_clusterSetOn_of_notMem_image hUb.isCompact_closure hfd.continuousOn
+    hv.1 hv.2
 
 /-- **The boundary cluster sets exhaust the frontier of the image.** For a conformal map of a
 bounded open set, the union of the cluster sets over `frontier U` is exactly `frontier (f '' U)`.
@@ -208,21 +204,5 @@ theorem biUnion_clusterSetOn_eq_frontier_image (hUo : IsOpen U) (hUb : Bornology
     fun _ hv => by
       obtain ⟨w, hw, hvw⟩ := exists_mem_frontier_mem_clusterSetOn hUo hUb hfd hfi hv
       exact mem_biUnion hw hvw
-
-/-- **The boundary correspondence of a conformal map of the unit disc.** The case of
-`TauCeti.biUnion_clusterSetOn_eq_frontier_image` in which the domain is `ball 0 1`, so that the
-frontier is the unit circle: the frontier of the image is the union of the cluster sets taken over
-the unit circle.
-
-This is the shape in which the boundary correspondence is met in practice, a Riemann map being a
-conformal map *of* the disc. Each of the sets in the union is moreover a continuum, by
-`TauCeti.isConnected_clusterSetOn_of_convex_of_isBounded`, the disc being convex; Carathéodory's
-theorem asserts that for a Jordan image every one of them degenerates to a point. -/
-theorem biUnion_clusterSetOn_sphere_eq_frontier_image
-    (hfd : DifferentiableOn ℂ f (ball 0 1)) (hfi : InjOn f (ball 0 1)) :
-    ⋃ w ∈ sphere (0 : ℂ) 1, clusterSetOn f (ball 0 1) w = frontier (f '' ball 0 1) := by
-  have h := biUnion_clusterSetOn_eq_frontier_image (U := ball (0 : ℂ) 1) isOpen_ball isBounded_ball
-    hfd hfi
-  rwa [frontier_ball (0 : ℂ) one_ne_zero] at h
 
 end TauCeti

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -268,9 +268,11 @@ refinement of `TauCeti.closure_image_eq_biUnion_clusterSetOn` for a continuous `
 `TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt`, so the whole of the new material sits
 over `frontier U`.
 
-This is the form in which the covering is used: subtracting `f '' U` from both sides identifies the
-*frontier* of the image with the union of the boundary cluster sets, as soon as one knows that the
-boundary cluster values avoid `f '' U`. -/
+This is the form in which the covering is used: subtracting `f '' U` from both sides identifies
+`closure (f '' U) \ f '' U` with the union of the boundary cluster sets, as soon as one knows that
+the boundary cluster values avoid `f '' U`. That difference is the *frontier* of the image only
+when `f '' U` is open — which is an extra hypothesis, not part of this theorem, and is what
+conformality supplies in `TauCeti.biUnion_clusterSetOn_eq_frontier_image`. -/
 theorem closure_image_eq_image_union_biUnion_clusterSetOn [T2Space Y] (hU : IsCompact (closure U))
     (hfc : ContinuousOn f U) :
     closure (f '' U) = f '' U ∪ ⋃ w ∈ frontier U, clusterSetOn f U w := by

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -63,11 +63,13 @@ criterion adds is the production of the pointwise limits that theorem asks for.
   subsingleton cluster set at a point of `closure U` produces a limit, provided `f` maps `U` into a
   compact set.
 * `TauCeti.exists_mem_closure_mem_clusterSetOn`,
+  `TauCeti.exists_mem_frontier_mem_clusterSetOn_of_notMem_image`,
   `TauCeti.closure_image_eq_biUnion_clusterSetOn` and
   `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn` — **the cluster sets cover the closure
   of the image** once `closure U` is compact: every adherent value of `f '' U` is a cluster value at
-  some point of `closure U`, so `closure (f '' U)` is the union of the cluster sets, and — for
-  continuous `f` — is the image together with the *boundary* cluster values.
+  some point of `closure U` — at a point of `frontier U`, if the value is not attained and `f` is
+  continuous — so `closure (f '' U)` is the union of the cluster sets, and — for continuous `f` —
+  is the image together with the *boundary* cluster values.
 * `TauCeti.exists_continuousOn_closure_eqOn` — **the extension criterion**: a continuous map into a
   compact set, with subsingleton boundary cluster sets, extends continuously to `closure U`;
   `TauCeti.exists_continuousOn_closure_eqOn_of_isBounded` is the proper-metric form, where the
@@ -228,6 +230,24 @@ theorem exists_mem_closure_mem_clusterSetOn (hU : IsCompact (closure U))
   have hw' : 𝓝 w ⊓ (comap f (𝓝 v) ⊓ 𝓟 U) ≤ 𝓝[U] w :=
     le_inf inf_le_left (inf_le_right.trans inf_le_right)
   exact (hnb.map f).mono (le_inf hv' (map_mono hw'))
+
+/-- **An unattained adherent value of the image is a cluster value at a boundary point.** The
+sharpening of `TauCeti.exists_mem_closure_mem_clusterSetOn` that puts the witness on `frontier U`
+rather than merely on `closure U`, for a `f` continuous on `U`: a witness inside `U` would have the
+single cluster value `f w`, by `TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt`, and `v` is
+assumed not to be a value of `f` on `U`.
+
+Neither openness of `U` nor any hypothesis on `frontier U` is needed. -/
+theorem exists_mem_frontier_mem_clusterSetOn_of_notMem_image [T2Space Y]
+    (hU : IsCompact (closure U)) (hfc : ContinuousOn f U) (hvc : v ∈ closure (f '' U))
+    (hvn : v ∉ f '' U) : ∃ w ∈ frontier U, v ∈ clusterSetOn f U w := by
+  obtain ⟨w, hw, hvw⟩ := exists_mem_closure_mem_clusterSetOn hU hvc
+  have hwU : w ∉ U := fun hwU => by
+    rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwU (hfc w hwU), mem_singleton_iff] at hvw
+    exact hvn (hvw ▸ mem_image_of_mem f hwU)
+  refine ⟨w, ?_, hvw⟩
+  rw [← closure_sdiff_interior]
+  exact ⟨hw, fun hwi => hwU (interior_subset hwi)⟩
 
 /-- **The cluster sets cover the closure of the image.** For a compact `closure U`, the closure of
 `f '' U` is exactly the union of the cluster sets of `f` on `U` over the points of `closure U`.

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -177,7 +177,11 @@ lemma clusterSetOn_eq_singleton_of_tendsto [T2Space Y] (hw : w ∈ closure U)
 
 /-- **At a point of `U` where `f` is continuous the cluster set is the value.** Nothing but `f w`
 is approached, so a cluster set carries information only at points off `U` — which is why a
-boundary-correspondence theorem never has to say anything about the interior. -/
+boundary-correspondence theorem never has to say anything about the interior.
+
+This is the normal form of a cluster set at an interior continuity point, and is tagged `@[simp]`:
+with the two hypotheses to hand, `simp [*]` rewrites `clusterSetOn f U w` to `{f w}`. -/
+@[simp]
 lemma clusterSetOn_eq_singleton_of_continuousWithinAt [T2Space Y] (hw : w ∈ U)
     (hfc : ContinuousWithinAt f U w) : clusterSetOn f U w = {f w} :=
   clusterSetOn_eq_singleton_of_tendsto (subset_closure hw) hfc

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -56,10 +56,18 @@ criterion adds is the production of the pointwise limits that theorem asks for.
   `TauCeti.isCompact_clusterSetOn` and `TauCeti.clusterSetOn_nonempty` — the cluster set is a closed
   subset of `closure (f '' U)`, and is compact and nonempty at every point of `closure U` once `f`
   maps `U` into a compact set.
-* `TauCeti.clusterSetOn_eq_singleton_of_tendsto` and
+* `TauCeti.clusterSetOn_eq_singleton_of_tendsto`,
+  `TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt` and
   `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` — a limit along `𝓝[U] w` makes the cluster
-  set a singleton; conversely a subsingleton cluster set at a point of `closure U` produces a limit,
-  provided `f` maps `U` into a compact set.
+  set a singleton, in particular at a point of `U` where `f` is continuous; conversely a
+  subsingleton cluster set at a point of `closure U` produces a limit, provided `f` maps `U` into a
+  compact set.
+* `TauCeti.exists_mem_closure_mem_clusterSetOn`,
+  `TauCeti.closure_image_eq_biUnion_clusterSetOn` and
+  `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn` — **the cluster sets cover the closure
+  of the image** once `closure U` is compact: every adherent value of `f '' U` is a cluster value at
+  some point of `closure U`, so `closure (f '' U)` is the union of the cluster sets, and — for
+  continuous `f` — is the image together with the *boundary* cluster values.
 * `TauCeti.exists_continuousOn_closure_eqOn` — **the extension criterion**: a continuous map into a
   compact set, with subsingleton boundary cluster sets, extends continuously to `closure U`;
   `TauCeti.exists_continuousOn_closure_eqOn_of_isBounded` is the proper-metric form, where the
@@ -165,6 +173,13 @@ lemma clusterSetOn_eq_singleton_of_tendsto [T2Space Y] (hw : w ∈ closure U)
     (tendsto_nhds_unique (f := id) (tendsto_id.mono_left inf_le_left)
       (tendsto_id.mono_left (inf_le_right.trans hv')))
 
+/-- **At a point of `U` where `f` is continuous the cluster set is the value.** Nothing but `f w`
+is approached, so a cluster set carries information only at points off `U` — which is why a
+boundary-correspondence theorem never has to say anything about the interior. -/
+lemma clusterSetOn_eq_singleton_of_continuousWithinAt [T2Space Y] (hw : w ∈ U)
+    (hfc : ContinuousWithinAt f U w) : clusterSetOn f U w = {f w} :=
+  clusterSetOn_eq_singleton_of_tendsto (subset_closure hw) hfc
+
 /-- **A subsingleton cluster set is an honest limit.** If `f` maps `U` into a compact set and the
 cluster set at `w ∈ closure U` has at most one element, then `f` converges along `𝓝[U] w`.
 
@@ -179,6 +194,77 @@ theorem exists_tendsto_of_clusterSetOn_subsingleton (hK : IsCompact K) (hfK : Ma
   obtain ⟨v, hv⟩ := clusterSetOn_nonempty hK hfK hw
   exact ⟨v, hK.tendsto_nhds_of_unique_mapClusterPt
     (mem_of_superset self_mem_nhdsWithin hfK) fun _ _ hu => hsub hu hv⟩
+
+/-! ## The cluster sets cover the closure of the image -/
+
+/-- **Every adherent value of the image is a cluster value at some point of `closure U`**, provided
+`closure U` is compact.
+
+Aggregated over `w`, this is the converse of `TauCeti.clusterSetOn_subset_closure_image`, and it is
+where compactness of the *domain* side enters. That hypothesis cannot be dropped: on
+`U = Set.Ici (0 : ℝ)`, whose closure is not compact, the map `f x = 1 / (1 + x)` has image
+`Set.Ioc 0 1` and so has `0` adherent to it, yet `0` is a cluster value of `f` at no point at all —
+the approach points have escaped to infinity.
+
+No continuity is needed, and the proof is pure filter theory. The filter
+`comap f (𝓝 v) ⊓ 𝓟 U` — "inside `U`, with image near `v`" — is nontrivial *because* `v` is adherent
+to `f '' U`, and it is carried by `𝓟 (closure U)`; compactness supplies a cluster point `w` of it,
+and the witnessing filter `𝓝 w ⊓ (comap f (𝓝 v) ⊓ 𝓟 U)` is a nontrivial filter refining `𝓝[U] w`
+whose image under `f` refines `𝓝 v`, which is exactly what `v ∈ clusterSetOn f U w` asserts. -/
+theorem exists_mem_closure_mem_clusterSetOn (hU : IsCompact (closure U))
+    (hv : v ∈ closure (f '' U)) : ∃ w ∈ closure U, v ∈ clusterSetOn f U w := by
+  haveI : (comap f (𝓝 v) ⊓ 𝓟 U).NeBot := by
+    refine Filter.inf_principal_neBot_iff.mpr fun t ht => ?_
+    obtain ⟨s, hs, hst⟩ := ht
+    obtain ⟨y, hys, z, hzU, rfl⟩ := mem_closure_iff_nhds.mp hv s hs
+    exact ⟨z, hst hys, hzU⟩
+  have hle : comap f (𝓝 v) ⊓ 𝓟 U ≤ 𝓟 (closure U) :=
+    inf_le_right.trans (principal_mono.mpr subset_closure)
+  obtain ⟨w, hw, hcp⟩ := hU.exists_clusterPt hle
+  refine ⟨w, hw, ?_⟩
+  have hnb : (𝓝 w ⊓ (comap f (𝓝 v) ⊓ 𝓟 U)).NeBot := hcp
+  have hv' : map f (𝓝 w ⊓ (comap f (𝓝 v) ⊓ 𝓟 U)) ≤ 𝓝 v :=
+    (map_mono (inf_le_right.trans inf_le_left)).trans map_comap_le
+  have hw' : 𝓝 w ⊓ (comap f (𝓝 v) ⊓ 𝓟 U) ≤ 𝓝[U] w :=
+    le_inf inf_le_left (inf_le_right.trans inf_le_right)
+  exact (hnb.map f).mono (le_inf hv' (map_mono hw'))
+
+/-- **The cluster sets cover the closure of the image.** For a compact `closure U`, the closure of
+`f '' U` is exactly the union of the cluster sets of `f` on `U` over the points of `closure U`.
+
+Both inclusions have already been recorded: `TauCeti.clusterSetOn_subset_closure_image` gives one
+and `TauCeti.exists_mem_closure_mem_clusterSetOn` the other. -/
+theorem closure_image_eq_biUnion_clusterSetOn (hU : IsCompact (closure U)) :
+    closure (f '' U) = ⋃ w ∈ closure U, clusterSetOn f U w :=
+  subset_antisymm
+    (fun _ hv => by
+      obtain ⟨w, hw, hvw⟩ := exists_mem_closure_mem_clusterSetOn hU hv
+      exact mem_biUnion hw hvw)
+    (iUnion₂_subset fun _ _ => clusterSetOn_subset_closure_image)
+
+/-- **The closure of the image is the image together with the boundary cluster values.** The
+refinement of `TauCeti.closure_image_eq_biUnion_clusterSetOn` for a continuous `f`: the points of
+`U` contribute only the values `f w` themselves, by
+`TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt`, so the whole of the new material sits
+over `frontier U`.
+
+This is the form in which the covering is used: subtracting `f '' U` from both sides identifies the
+*frontier* of the image with the union of the boundary cluster sets, as soon as one knows that the
+boundary cluster values avoid `f '' U`. -/
+theorem closure_image_eq_image_union_biUnion_clusterSetOn [T2Space Y] (hU : IsCompact (closure U))
+    (hfc : ContinuousOn f U) :
+    closure (f '' U) = f '' U ∪ ⋃ w ∈ frontier U, clusterSetOn f U w := by
+  have hint : ⋃ w ∈ U, clusterSetOn f U w = f '' U := by
+    ext v
+    simp only [mem_iUnion₂, mem_image]
+    refine ⟨fun ⟨w, hw, hv⟩ => ⟨w, hw, ?_⟩, fun ⟨w, hw, hv⟩ => ⟨w, hw, ?_⟩⟩
+    · rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw),
+        mem_singleton_iff] at hv
+      exact hv.symm
+    · rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw), mem_singleton_iff]
+      exact hv.symm
+  rw [closure_image_eq_biUnion_clusterSetOn hU, closure_eq_self_union_frontier, biUnion_union,
+    hint]
 
 end TopologicalSpace
 


### PR DESCRIPTION
This PR proves the surjectivity half of the boundary correspondence for a conformal map: on a bounded open `U ⊆ ℂ`, every point of `frontier (f '' U)` is a cluster value of `f` at some point of `frontier U`, so the boundary cluster sets do not merely land on the frontier of the image — they exhaust it. `TauCeti/Analysis/Complex/Conformal/ClusterSet.lean` already had the inclusion `TauCeti.clusterSetOn_subset_frontier_image`; `TauCeti.exists_mem_frontier_mem_clusterSetOn` supplies the converse and `TauCeti.biUnion_clusterSetOn_eq_frontier_image` turns the pair into the equality `⋃ w ∈ frontier U, clusterSetOn f U w = frontier (f '' U)`. The unit-disc case a Riemann map presents is that equality at `U = ball 0 1`, where `frontier_ball` rewrites the index set to the unit circle; no separate disc declaration is added, the round-1 `reuse` review having judged one a duplicate. No hypothesis whatever is placed on `frontier U`.

The engine is general topology and lands in `TauCeti/Topology/ClusterSet.lean`, the file the conformal one was written on top of. `TauCeti.exists_mem_closure_mem_clusterSetOn` says that when `closure U` is compact every value adherent to `f '' U` is a cluster value at some point of `closure U`; the proof is pure filter theory and needs no continuity, taking a cluster point of `comap f (𝓝 v) ⊓ 𝓟 U`, the filter "inside `U`, with image near `v`". Compactness is not decoration — the docstring records the failure on `Set.Ici (0 : ℝ)`. Aggregating gives `TauCeti.closure_image_eq_biUnion_clusterSetOn`, and for continuous `f` the sharper `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`, since `TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt` (also new) collapses the cluster set at a point of `U` to the value there.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "Carathéodory boundary correspondence … the RMT map of a Jordan domain extends to a homeomorphism of closures" — and specifically the cluster-set vocabulary that milestone is stated in. Carathéodory's theorem refines the surjection proved here to a bijection by showing each boundary cluster set to be a singleton; that singleton property is not proved here, and neither is boundary injectivity. Nothing added here duplicates existing work: `TauCeti.image_frontier_eq_frontier_image` is a statement about a given continuous *extension* and assumes it injective on `closure U`, whereas these results assume no extension at all. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping effort, which stops at the mapping theorem, and the pinned Mathlib has no cluster sets for maps; so this is new Lean formalization rather than a temporary shim, though it consumes the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn` through `Conformal/BoundaryCorrespondence.lean`, to be refactored onto Mathlib once the upstream work lands.

No Mathlib infrastructure was vendored. Everything is built from Mathlib's existing `ClusterPt`/`MapClusterPt`, `IsCompact.exists_clusterPt`, `Filter.inf_principal_neBot_iff` and `closure_eq_self_union_frontier`, and from the repository's own cluster-set and boundary-correspondence API. Two existing files gain 157 lines between them; no declaration is renamed, moved or restated. `lake build`, `lake exe axioms` and `lake exe module-system` are all green.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"biunion-clusterseton-eq-frontier-image"}-->

🤖 Prepared with Claude Code

