### PR TITLE
refactor(Probability): decompose the pair-law square-integral step

### DIFF
--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -318,7 +318,7 @@ private lemma setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
 
 /-- Doob–Dynkin for a conditional expectation on a comap σ-algebra: `μ[φ | comap W]` factors as
 `g ∘ W` for a strongly measurable `g`, integrable against the pushforward. -/
-private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp [IsFiniteMeasure μ]
+private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp
     {W : Ω → γ} (hW : Measurable W) (φ : Ω → ℝ) :
     ∃ g : γ → ℝ, StronglyMeasurable g ∧ Integrable g (Measure.map W μ) ∧
       μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W := by
@@ -334,7 +334,8 @@ private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp [IsFini
 /-- Push the square of a conditional expectation through its Doob–Dynkin factorisation: the
 integral of `μ[φ | comap W]²` against `μ` is the integral of `g²` against the pushforward. -/
 private lemma integral_mul_self_condExp_comap_eq_integral_sq_map
-    {W : Ω → γ} (hW : Measurable W) {g : γ → ℝ} (hg : StronglyMeasurable g) {φ : Ω → ℝ}
+    {W : Ω → γ} (hW : Measurable W) {g : γ → ℝ}
+    (hg : AEStronglyMeasurable g (Measure.map W μ)) {φ : Ω → ℝ}
     (hg_eq : μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W) :
     ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
         * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
@@ -345,7 +346,7 @@ private lemma integral_mul_self_condExp_comap_eq_integral_sq_map
         refine integral_congr_ae (.of_forall fun ω => ?_)
         simp only [hg_eq, Function.comp_apply, pow_two]
     _ = ∫ y, (g y) ^ 2 ∂(Measure.map W μ) :=
-        (integral_map hW.aemeasurable (hg.pow 2).aestronglyMeasurable).symm
+        (integral_map hW.aemeasurable (hg.pow 2)).symm
 
 /-- The Doob–Dynkin factors of the two conditional expectations agree a.e. on the common law: the
 pair law makes their set-integrals over corresponding preimages match, and an integrable function
@@ -355,7 +356,8 @@ private lemma ae_eq_of_condExp_comap_comp_of_pair_law [IsFiniteMeasure μ]
     (hX : Measurable X) (hW : Measurable W) (hW' : Measurable W')
     (h_law : Measure.map (fun ω => (X ω, W ω)) μ = Measure.map (fun ω => (X ω, W' ω)) μ)
     {A : Set α} (hA : MeasurableSet A) {g₁ g₂ : γ → ℝ}
-    (hg₁_sm : StronglyMeasurable g₁) (hg₂_sm : StronglyMeasurable g₂)
+    (hg₁_sm : AEStronglyMeasurable g₁ (Measure.map W μ))
+    (hg₂_sm : AEStronglyMeasurable g₂ (Measure.map W' μ))
     (hg₁_int : Integrable g₁ (Measure.map W μ)) (hg₂_int : Integrable g₂ (Measure.map W μ))
     (hμ₁_eq : μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ))
       | MeasurableSpace.comap W inferInstance] = g₁ ∘ W)
@@ -369,14 +371,14 @@ private lemma ae_eq_of_condExp_comap_comp_of_pair_law [IsFiniteMeasure μ]
   refine Integrable.ae_eq_of_forall_setIntegral_eq g₁ g₂ hg₁_int hg₂_int fun B hB _ => ?_
   calc ∫ y in B, g₁ y ∂(Measure.map W μ)
       = ∫ ω in W ⁻¹' B, (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) ω ∂μ :=
-        setIntegral_map_eq_setIntegral_preimage_of_condExp_comp hW hg₁_sm.aestronglyMeasurable
+        setIntegral_map_eq_setIntegral_preimage_of_condExp_comp hW hg₁_sm
           hφ_int hμ₁_eq hB
     _ = ∫ ω in W' ⁻¹' B, (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) ω ∂μ :=
         setIntegral_indicator_preimage_eq_of_pair_law X W W' hX hW hW' h_law hA hB
     _ = ∫ y in B, g₂ y ∂(Measure.map W μ) := by
         rw [hρ_eq]
         exact (setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
-          hW' hg₂_sm.aestronglyMeasurable hφ_int hμ₂_eq hB).symm
+          hW' hg₂_sm hφ_int hμ₂_eq hB).symm
 
 /-- Helper for Kallenberg 1.3: the square-integrals of the two conditional expectations agree. -/
 private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
@@ -395,7 +397,6 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
   have hρ_eq : Measure.map W μ = Measure.map W' μ :=
     marginal_law_eq_of_pair_law X W W' hX hW hW' h_law
   set φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) with hφ_def
-  have hφ_int : Integrable φ μ := Integrable.indicator (integrable_const 1) (hX hA)
   -- Doob–Dynkin factorisation `μ₁ = g₁ ∘ W`, `μ₂ = g₂ ∘ W'`.
   obtain ⟨g₁, hg₁_sm, hg₁_int, hμ₁_eq⟩ :=
     exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW φ
@@ -403,18 +404,19 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
     exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW' φ
   have hg₂_int' : Integrable g₂ (Measure.map W μ) := by rw [hρ_eq]; exact hg₂_int
   have hg_eq := ae_eq_of_condExp_comap_comp_of_pair_law X W W' hX hW hW' h_law hA
-    hg₁_sm hg₂_sm hg₁_int hg₂_int' hμ₁_eq hμ₂_eq
+    hg₁_sm.aestronglyMeasurable hg₂_sm.aestronglyMeasurable hg₁_int hg₂_int' hμ₁_eq hμ₂_eq
   -- Push the square through the two factorisations; the middle step is `hg_eq`.
   calc ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
           * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
       = ∫ y, (g₁ y) ^ 2 ∂(Measure.map W μ) :=
-        integral_mul_self_condExp_comap_eq_integral_sq_map hW hg₁_sm hμ₁_eq
+        integral_mul_self_condExp_comap_eq_integral_sq_map hW hg₁_sm.aestronglyMeasurable hμ₁_eq
     _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W μ) := by
         refine integral_congr_ae ?_; filter_upwards [hg_eq] with y hy; rw [hy]
     _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W' μ) := by rw [hρ_eq]
     _ = ∫ ω, (μ[φ | MeasurableSpace.comap W' inferInstance]) ω
           * (μ[φ | MeasurableSpace.comap W' inferInstance]) ω ∂μ :=
-        (integral_mul_self_condExp_comap_eq_integral_sq_map hW' hg₂_sm hμ₂_eq).symm
+        (integral_mul_self_condExp_comap_eq_integral_sq_map hW'
+          hg₂_sm.aestronglyMeasurable hμ₂_eq).symm
 
 /-- Two real functions with equal integrals of their squares (`∫ g₁² = ∫ g₂²`) and matching cross
 integral (`∫ g₂ g₁ = ∫ g₁²`) are a.e. equal: the `L²` distance polarises to

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -316,6 +316,68 @@ private lemma setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
           setIntegral_condExp hmW_le hφ_int
             (MeasurableSpace.measurableSet_comap.mpr ⟨B, hB, rfl⟩)
 
+/-- Doob–Dynkin for a conditional expectation on a comap σ-algebra: `μ[φ | comap W]` factors as
+`g ∘ W` for a strongly measurable `g`, integrable against the pushforward. -/
+private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp [IsFiniteMeasure μ]
+    {W : Ω → γ} (hW : Measurable W) (φ : Ω → ℝ) :
+    ∃ g : γ → ℝ, StronglyMeasurable g ∧ Integrable g (Measure.map W μ) ∧
+      μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W := by
+  obtain ⟨g, hg_sm, hg_eq⟩ :=
+    (stronglyMeasurable_condExp :
+      StronglyMeasurable[MeasurableSpace.comap W inferInstance]
+        (μ[φ | MeasurableSpace.comap W inferInstance])).exists_eq_measurable_comp
+  refine ⟨g, hg_sm, ?_, hg_eq⟩
+  refine (integrable_map_measure hg_sm.aestronglyMeasurable hW.aemeasurable).mpr ?_
+  rw [← hg_eq]
+  exact integrable_condExp
+
+/-- Push the square of a conditional expectation through its Doob–Dynkin factorisation: the
+integral of `μ[φ | comap W]²` against `μ` is the integral of `g²` against the pushforward. -/
+private lemma integral_mul_self_condExp_comap_eq_integral_sq_map
+    {W : Ω → γ} (hW : Measurable W) {g : γ → ℝ} (hg : StronglyMeasurable g) {φ : Ω → ℝ}
+    (hg_eq : μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W) :
+    ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
+        * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
+      = ∫ y, (g y) ^ 2 ∂(Measure.map W μ) := by
+  calc ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
+          * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
+      = ∫ ω, (g (W ω)) ^ 2 ∂μ := by
+        refine integral_congr_ae (.of_forall fun ω => ?_)
+        simp only [hg_eq, Function.comp_apply, pow_two]
+    _ = ∫ y, (g y) ^ 2 ∂(Measure.map W μ) :=
+        (integral_map hW.aemeasurable (hg.pow 2).aestronglyMeasurable).symm
+
+/-- The Doob–Dynkin factors of the two conditional expectations agree a.e. on the common law: the
+pair law makes their set-integrals over corresponding preimages match, and an integrable function
+is determined a.e. by those. -/
+private lemma ae_eq_of_condExp_comap_comp_of_pair_law [IsFiniteMeasure μ]
+    (X : Ω → α) (W W' : Ω → γ)
+    (hX : Measurable X) (hW : Measurable W) (hW' : Measurable W')
+    (h_law : Measure.map (fun ω => (X ω, W ω)) μ = Measure.map (fun ω => (X ω, W' ω)) μ)
+    {A : Set α} (hA : MeasurableSet A) {g₁ g₂ : γ → ℝ}
+    (hg₁_sm : StronglyMeasurable g₁) (hg₂_sm : StronglyMeasurable g₂)
+    (hg₁_int : Integrable g₁ (Measure.map W μ)) (hg₂_int : Integrable g₂ (Measure.map W μ))
+    (hμ₁_eq : μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ))
+      | MeasurableSpace.comap W inferInstance] = g₁ ∘ W)
+    (hμ₂_eq : μ[(X ⁻¹' A).indicator (fun _ => (1 : ℝ))
+      | MeasurableSpace.comap W' inferInstance] = g₂ ∘ W') :
+    g₁ =ᵐ[Measure.map W μ] g₂ := by
+  have hρ_eq : Measure.map W μ = Measure.map W' μ :=
+    marginal_law_eq_of_pair_law X W W' hX hW hW' h_law
+  have hφ_int : Integrable ((X ⁻¹' A).indicator (fun _ => (1 : ℝ))) μ :=
+    Integrable.indicator (integrable_const 1) (hX hA)
+  refine Integrable.ae_eq_of_forall_setIntegral_eq g₁ g₂ hg₁_int hg₂_int fun B hB _ => ?_
+  calc ∫ y in B, g₁ y ∂(Measure.map W μ)
+      = ∫ ω in W ⁻¹' B, (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) ω ∂μ :=
+        setIntegral_map_eq_setIntegral_preimage_of_condExp_comp hW hg₁_sm.aestronglyMeasurable
+          hφ_int hμ₁_eq hB
+    _ = ∫ ω in W' ⁻¹' B, (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) ω ∂μ :=
+        setIntegral_indicator_preimage_eq_of_pair_law X W W' hX hW hW' h_law hA hB
+    _ = ∫ y in B, g₂ y ∂(Measure.map W μ) := by
+        rw [hρ_eq]
+        exact (setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
+          hW' hg₂_sm.aestronglyMeasurable hφ_int hμ₂_eq hB).symm
+
 /-- Helper for Kallenberg 1.3: the square-integrals of the two conditional expectations agree. -/
 private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
     (X : Ω → α) (W W' : Ω → γ)
@@ -333,50 +395,26 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
   have hρ_eq : Measure.map W μ = Measure.map W' μ :=
     marginal_law_eq_of_pair_law X W W' hX hW hW' h_law
   set φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) with hφ_def
-  let μ₁ : Ω → ℝ := μ[φ | MeasurableSpace.comap W inferInstance]
-  let μ₂ : Ω → ℝ := μ[φ | MeasurableSpace.comap W' inferInstance]
   have hφ_int : Integrable φ μ := Integrable.indicator (integrable_const 1) (hX hA)
   -- Doob–Dynkin factorisation `μ₁ = g₁ ∘ W`, `μ₂ = g₂ ∘ W'`.
-  have hμ₁_sm : StronglyMeasurable[MeasurableSpace.comap W inferInstance] μ₁ :=
-    stronglyMeasurable_condExp
-  obtain ⟨g₁, hg₁_sm, hμ₁_eq⟩ := hμ₁_sm.exists_eq_measurable_comp
-  have hμ₂_sm : StronglyMeasurable[MeasurableSpace.comap W' inferInstance] μ₂ :=
-    stronglyMeasurable_condExp
-  obtain ⟨g₂, hg₂_sm, hμ₂_eq⟩ := hμ₂_sm.exists_eq_measurable_comp
-  have hg₁_int : Integrable g₁ (Measure.map W μ) := by
-    have h : Integrable (g₁ ∘ W) μ := by rw [← hμ₁_eq]; exact integrable_condExp
-    exact (integrable_map_measure hg₁_sm.aestronglyMeasurable hW.aemeasurable).mpr h
-  have hg₂_int' : Integrable g₂ (Measure.map W μ) := by
-    rw [hρ_eq]
-    have h : Integrable (g₂ ∘ W') μ := by rw [← hμ₂_eq]; exact integrable_condExp
-    exact (integrable_map_measure hg₂_sm.aestronglyMeasurable hW'.aemeasurable).mpr h
-  -- `g₁ = g₂` a.e. on `ρ`, via the set-integral characterisation and the pair law.
-  have hg_eq : g₁ =ᵐ[Measure.map W μ] g₂ := by
-    refine Integrable.ae_eq_of_forall_setIntegral_eq g₁ g₂ hg₁_int hg₂_int' fun B hB _ => ?_
-    calc ∫ y in B, g₁ y ∂(Measure.map W μ)
-        = ∫ ω in W ⁻¹' B, φ ω ∂μ :=
-          setIntegral_map_eq_setIntegral_preimage_of_condExp_comp hW hg₁_sm.aestronglyMeasurable
-            hφ_int hμ₁_eq hB
-      _ = ∫ ω in W' ⁻¹' B, φ ω ∂μ :=
-          setIntegral_indicator_preimage_eq_of_pair_law X W W' hX hW hW' h_law hA hB
-      _ = ∫ y in B, g₂ y ∂(Measure.map W μ) := by
-          rw [hρ_eq]
-          exact (setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
-            hW' hg₂_sm.aestronglyMeasurable hφ_int hμ₂_eq hB).symm
-  -- Push the square through `integral_map` on both sides.
-  calc ∫ ω, μ₁ ω * μ₁ ω ∂μ
-      = ∫ ω, (g₁ (W ω)) ^ 2 ∂μ := by
-        refine integral_congr_ae (.of_forall fun ω => ?_)
-        simp only [hμ₁_eq, Function.comp_apply, pow_two]
-    _ = ∫ y, (g₁ y) ^ 2 ∂(Measure.map W μ) :=
-        (integral_map hW.aemeasurable (hg₁_sm.pow 2).aestronglyMeasurable).symm
+  obtain ⟨g₁, hg₁_sm, hg₁_int, hμ₁_eq⟩ :=
+    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW φ
+  obtain ⟨g₂, hg₂_sm, hg₂_int, hμ₂_eq⟩ :=
+    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW' φ
+  have hg₂_int' : Integrable g₂ (Measure.map W μ) := by rw [hρ_eq]; exact hg₂_int
+  have hg_eq := ae_eq_of_condExp_comap_comp_of_pair_law X W W' hX hW hW' h_law hA
+    hg₁_sm hg₂_sm hg₁_int hg₂_int' hμ₁_eq hμ₂_eq
+  -- Push the square through the two factorisations; the middle step is `hg_eq`.
+  calc ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
+          * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
+      = ∫ y, (g₁ y) ^ 2 ∂(Measure.map W μ) :=
+        integral_mul_self_condExp_comap_eq_integral_sq_map hW hg₁_sm hμ₁_eq
     _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W μ) := by
         refine integral_congr_ae ?_; filter_upwards [hg_eq] with y hy; rw [hy]
-    _ = ∫ ω, (g₂ (W' ω)) ^ 2 ∂μ := by
-        rw [hρ_eq]; exact integral_map hW'.aemeasurable (hg₂_sm.pow 2).aestronglyMeasurable
-    _ = ∫ ω, μ₂ ω * μ₂ ω ∂μ := by
-        refine integral_congr_ae (.of_forall fun ω => ?_)
-        simp only [hμ₂_eq, Function.comp_apply, pow_two]
+    _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W' μ) := by rw [hρ_eq]
+    _ = ∫ ω, (μ[φ | MeasurableSpace.comap W' inferInstance]) ω
+          * (μ[φ | MeasurableSpace.comap W' inferInstance]) ω ∂μ :=
+        (integral_mul_self_condExp_comap_eq_integral_sq_map hW' hg₂_sm hμ₂_eq).symm
 
 /-- Two real functions with equal integrals of their squares (`∫ g₁² = ∫ g₂²`) and matching cross
 integral (`∫ g₂ g₁ = ∫ g₁²`) are a.e. equal: the `L²` distance polarises to

--- a/TauCeti/Probability/Independence/Conditional.lean
+++ b/TauCeti/Probability/Independence/Conditional.lean
@@ -319,7 +319,7 @@ private lemma setIntegral_map_eq_setIntegral_preimage_of_condExp_comp
 /-- Doob–Dynkin for a conditional expectation on a comap σ-algebra: `μ[φ | comap W]` factors as
 `g ∘ W` for a strongly measurable `g`, integrable against the pushforward. -/
 private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp
-    {W : Ω → γ} (hW : Measurable W) (φ : Ω → ℝ) :
+    {W : Ω → γ} (hW : AEMeasurable W μ) (φ : Ω → ℝ) :
     ∃ g : γ → ℝ, StronglyMeasurable g ∧ Integrable g (Measure.map W μ) ∧
       μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W := by
   obtain ⟨g, hg_sm, hg_eq⟩ :=
@@ -327,14 +327,14 @@ private lemma exists_stronglyMeasurable_integrable_condExp_comap_eq_comp
       StronglyMeasurable[MeasurableSpace.comap W inferInstance]
         (μ[φ | MeasurableSpace.comap W inferInstance])).exists_eq_measurable_comp
   refine ⟨g, hg_sm, ?_, hg_eq⟩
-  refine (integrable_map_measure hg_sm.aestronglyMeasurable hW.aemeasurable).mpr ?_
+  refine (integrable_map_measure hg_sm.aestronglyMeasurable hW).mpr ?_
   rw [← hg_eq]
   exact integrable_condExp
 
 /-- Push the square of a conditional expectation through its Doob–Dynkin factorisation: the
 integral of `μ[φ | comap W]²` against `μ` is the integral of `g²` against the pushforward. -/
 private lemma integral_mul_self_condExp_comap_eq_integral_sq_map
-    {W : Ω → γ} (hW : Measurable W) {g : γ → ℝ}
+    {W : Ω → γ} (hW : AEMeasurable W μ) {g : γ → ℝ}
     (hg : AEStronglyMeasurable g (Measure.map W μ)) {φ : Ω → ℝ}
     (hg_eq : μ[φ | MeasurableSpace.comap W inferInstance] = g ∘ W) :
     ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
@@ -346,7 +346,7 @@ private lemma integral_mul_self_condExp_comap_eq_integral_sq_map
         refine integral_congr_ae (.of_forall fun ω => ?_)
         simp only [hg_eq, Function.comp_apply, pow_two]
     _ = ∫ y, (g y) ^ 2 ∂(Measure.map W μ) :=
-        (integral_map hW.aemeasurable (hg.pow 2)).symm
+        (integral_map hW (hg.pow 2)).symm
 
 /-- The Doob–Dynkin factors of the two conditional expectations agree a.e. on the common law: the
 pair law makes their set-integrals over corresponding preimages match, and an integrable function
@@ -399,9 +399,9 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
   set φ : Ω → ℝ := (X ⁻¹' A).indicator (fun _ => (1 : ℝ)) with hφ_def
   -- Doob–Dynkin factorisation `μ₁ = g₁ ∘ W`, `μ₂ = g₂ ∘ W'`.
   obtain ⟨g₁, hg₁_sm, hg₁_int, hμ₁_eq⟩ :=
-    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW φ
+    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW.aemeasurable φ
   obtain ⟨g₂, hg₂_sm, hg₂_int, hμ₂_eq⟩ :=
-    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW' φ
+    exists_stronglyMeasurable_integrable_condExp_comap_eq_comp (μ := μ) hW'.aemeasurable φ
   have hg₂_int' : Integrable g₂ (Measure.map W μ) := by rw [hρ_eq]; exact hg₂_int
   have hg_eq := ae_eq_of_condExp_comap_comp_of_pair_law X W W' hX hW hW' h_law hA
     hg₁_sm.aestronglyMeasurable hg₂_sm.aestronglyMeasurable hg₁_int hg₂_int' hμ₁_eq hμ₂_eq
@@ -409,13 +409,14 @@ private lemma integral_sq_condExp_eq_of_pair_law [IsFiniteMeasure μ]
   calc ∫ ω, (μ[φ | MeasurableSpace.comap W inferInstance]) ω
           * (μ[φ | MeasurableSpace.comap W inferInstance]) ω ∂μ
       = ∫ y, (g₁ y) ^ 2 ∂(Measure.map W μ) :=
-        integral_mul_self_condExp_comap_eq_integral_sq_map hW hg₁_sm.aestronglyMeasurable hμ₁_eq
+        integral_mul_self_condExp_comap_eq_integral_sq_map hW.aemeasurable
+          hg₁_sm.aestronglyMeasurable hμ₁_eq
     _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W μ) := by
         refine integral_congr_ae ?_; filter_upwards [hg_eq] with y hy; rw [hy]
     _ = ∫ y, (g₂ y) ^ 2 ∂(Measure.map W' μ) := by rw [hρ_eq]
     _ = ∫ ω, (μ[φ | MeasurableSpace.comap W' inferInstance]) ω
           * (μ[φ | MeasurableSpace.comap W' inferInstance]) ω ∂μ :=
-        (integral_mul_self_condExp_comap_eq_integral_sq_map hW'
+        (integral_mul_self_condExp_comap_eq_integral_sq_map hW'.aemeasurable
           hg₂_sm.aestronglyMeasurable hμ₂_eq).symm
 
 /-- Two real functions with equal integrals of their squares (`∫ g₁² = ∫ g₂²`) and matching cross


### PR DESCRIPTION
Decomposes `integral_sq_condExp_eq_of_pair_law` in
`TauCeti/Probability/Independence/Conditional.lean`, the longest proof body on main after the two
already in flight, at 47 lines. No statement changes: the lemma keeps its signature, and the three
extracted helpers are `private` and local to the file.

The proof does the same work **twice**, once for `W` and once for `W'`: factor the conditional
expectation through the map by Doob–Dynkin, check the factor is integrable against the pushforward,
and push the square through that factorisation. Those two repetitions are now one helper each, and
the a.e. agreement of the two factors — the actual content of the step — is stated on its own:

| helper | what it proves | body | uses |
|---|---|---|---|
| `exists_stronglyMeasurable_integrable_condExp_comap_eq_comp` | `μ[φ \| comap W]` factors as `g ∘ W` with `g` integrable against `Measure.map W μ` | 8 | 2 |
| `integral_mul_self_condExp_comap_eq_integral_sq_map` | `∫ μ[φ \| comap W]² ∂μ = ∫ g² ∂(Measure.map W μ)` | 7 | 2 |
| `ae_eq_of_condExp_comap_comp_of_pair_law` | the two factors agree a.e. on the common law | 15 | 1 |

`integral_sq_condExp_eq_of_pair_law` goes from 47 lines to 23, and its `calc` is now four steps:
push the square, swap the factor by the a.e. equality, move to the other pushforward, push back.

**Hypotheses were re-derived at extraction rather than inherited:**

* `exists_stronglyMeasurable_integrable_condExp_comap_eq_comp` mentions no `X`, no `A`, no second
  map and no pair law. It is a statement about one conditional expectation on a comap σ-algebra and
  an arbitrary `φ`, which is why it serves both call sites.
* `integral_mul_self_condExp_comap_eq_integral_sq_map` needs neither `[IsFiniteMeasure μ]` nor
  integrability: it is the change-of-variables identity for the square, given the factorisation.
* `ae_eq_of_condExp_comap_comp_of_pair_law` derives the marginal-law equality and the integrability
  of the indicator **internally** from `h_law` and `hX hA`, rather than taking `hρ_eq` and `hφ_int`
  from the caller as the inline version did.

Three local bindings disappear from the parent as a result: `μ₁`, `μ₂` (the two `let`-bound
conditional expectations, now written out where used) and `hρ_eq`'s role in the integrability
transfer.

The old inline proof produced `hg₂_int'` by rewriting along `hρ_eq` inside the integrability
argument; that is now a one-line `rw` at the call site, because the helper returns integrability
against `Measure.map W' μ` — the pushforward that actually matches `W'`.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: Exchangeability
