### PR TITLE
feat: add dual comodules

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
@@ -1,0 +1,224 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Contraction
+public import TauCeti.Algebra.Coalgebra.Comodule.MatrixCoefficient.Comul
+public import TauCeti.Algebra.HopfAlgebra.Antipode
+
+/-!
+# Duals of finite projective comodules
+
+For a finite projective right comodule `M` over a Hopf algebra `H`, this file constructs the
+right-comodule structure on the linear dual `Module.Dual R M`. Its coaction is characterized
+basis-freely by
+
+```text
+Σ φ₀(m) φ₁ = S(c(φ, m)),
+```
+
+where `c(φ, m)` is the matrix coefficient and `S` is the antipode. The canonical equivalence
+`dualTensorHomEquiv` turns this equation into a definition without requiring a basis or any
+finiteness condition on `H`.
+
+## Main declarations
+
+* `TauCeti.Comodule.dualCoact`: the coaction map on the linear dual.
+* `TauCeti.Comodule.dualTensorHom_dualCoact`: its characteristic linear-map equation.
+* `TauCeti.Comodule.dual`: the explicit, non-global dual comodule structure.
+
+## References
+
+This is the standard finite-projective dual-comodule construction; see Sweedler,
+*Hopf Algebras*, Chapter 2.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+universe u v w
+
+variable {R : Type u} {H : Type v} {M : Type w}
+variable [CommSemiring R] [Semiring H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+variable [Module.Finite R M] [Module.Projective R M]
+
+noncomputable section
+
+/-- The basis-free coaction map on the linear dual of a finite projective right comodule.
+
+Under `dualTensorHomEquiv`, the tensor `dualCoact φ` corresponds to the linear map
+`m ↦ S(c(φ, m))`. -/
+def dualCoact : Module.Dual R M →ₗ[R] Module.Dual R M ⊗[R] H :=
+  (dualTensorHomEquiv R M H).symm.toLinearMap ∘ₗ
+    (LinearMap.compRight R (HopfAlgebra.antipode R (A := H)) ∘ₗ
+      matrixCoefficientBilinear (R := R) (C := H) (M := M))
+
+/-- The characteristic equation for the dual coaction, as an equality of linear maps in the
+vector argument. -/
+@[simp]
+theorem dualTensorHom_dualCoact (φ : Module.Dual R M) :
+    dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) =
+      (HopfAlgebra.antipode R (A := H)).comp
+        (matrixCoefficientBilinear (R := R) (C := H) (M := M) φ) := by
+  ext m
+  simp [dualCoact]
+
+/-- Pointwise characteristic equation for the dual coaction:
+`Σ φ₀(m) φ₁ = S(c(φ, m))`. -/
+theorem dualTensorHom_dualCoact_apply (φ : Module.Dual R M) (m : M) :
+    dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m =
+      HopfAlgebra.antipode R
+        (matrixCoefficient (R := R) (C := H) φ m) := by
+  rw [dualTensorHom_dualCoact]
+  rfl
+
+/-- Applying the counit to the coefficient leg of the dual coaction recovers the original
+functional. -/
+theorem dualCoact_counit :
+    (Coalgebra.counit (R := R) (A := H)).lTensor (Module.Dual R M) ∘ₗ
+        dualCoact (R := R) (H := H) (M := M) =
+      (TensorProduct.mk R (Module.Dual R M) R).flip 1 := by
+  ext φ
+  apply (dualTensorHomEquiv R M R).injective
+  ext m
+  change dualTensorHom R M R
+      ((Coalgebra.counit (R := R) (A := H)).lTensor (Module.Dual R M)
+        (dualCoact (R := R) (H := H) (M := M) φ)) m =
+    dualTensorHom R M R (φ ⊗ₜ[R] (1 : R)) m
+  have hcomp := LinearMap.congr_fun
+    (dualTensorHom_comp_lTensor (M := M)
+      (Coalgebra.counit (R := R) (A := H)))
+    (dualCoact (R := R) (H := H) (M := M) φ)
+  have hcomp' :
+      dualTensorHom R M R
+          ((Coalgebra.counit (R := R) (A := H)).lTensor (Module.Dual R M)
+            (dualCoact (R := R) (H := H) (M := M) φ)) =
+        (Coalgebra.counit (R := R) (A := H)).compRight R
+          (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
+    simpa only [LinearMap.comp_apply] using hcomp
+  rw [hcomp']
+  change Coalgebra.counit (R := R) (A := H)
+      (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m) =
+    φ m • (1 : R)
+  rw [dualTensorHom_dualCoact_apply]
+  simp
+
+/-- Contracting after coacting the dual leg can be expressed by coacting the vector leg,
+applying the contraction and antipode, and swapping the two Hopf-algebra factors. This is the
+basis-free tensor identity underlying coassociativity of `dualCoact`. -/
+private theorem dualTensorHom_assoc_dualCoact_rTensor (x : Module.Dual R M ⊗[R] H) (m : M) :
+    dualTensorHom R M (H ⊗[R] H)
+        (TensorProduct.assoc R (Module.Dual R M) H H
+          ((dualCoact (R := R) (H := H) (M := M)).rTensor H x)) m =
+      TensorProduct.comm R H H
+        (TensorProduct.map (dualTensorHom R M H x) (HopfAlgebra.antipode R)
+          (coact (R := R) (C := H) (M := M) m)) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x y hx hy =>
+      simpa only [map_add, TensorProduct.map_add_left, LinearMap.add_apply]
+        using congrArg₂ (· + ·) hx hy
+  | tmul φ h =>
+      have hleft (y : Module.Dual R M ⊗[R] H) :
+          dualTensorHom R M (H ⊗[R] H)
+              (TensorProduct.assoc R (Module.Dual R M) H H (y ⊗ₜ[R] h)) m =
+            dualTensorHom R M H y m ⊗ₜ[R] h := by
+        induction y using TensorProduct.induction_on with
+        | zero => simp
+        | add y z hy hz =>
+            simpa only [TensorProduct.add_tmul, map_add, LinearMap.add_apply]
+              using congrArg₂ (· + ·) hy hz
+        | tmul ψ a => rfl
+      rw [LinearMap.rTensor_tmul, hleft, dualTensorHom_dualCoact_apply]
+      rw [matrixCoefficient_def]
+      generalize coact (R := R) (C := H) (M := M) m = z
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add x y hx hy =>
+          simpa only [map_add, TensorProduct.add_tmul]
+            using congrArg₂ (· + ·) hx hy
+      | tmul n a =>
+          simp [TensorProduct.smul_tmul']
+
+/-- The dual coaction is coassociative. -/
+theorem dualCoact_coassoc :
+    TensorProduct.assoc R (Module.Dual R M) H H ∘ₗ
+        (dualCoact (R := R) (H := H) (M := M)).rTensor H ∘ₗ
+          dualCoact (R := R) (H := H) (M := M) =
+      (Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M) ∘ₗ
+        dualCoact (R := R) (H := H) (M := M) := by
+  ext φ
+  apply (dualTensorHomEquiv R M (H ⊗[R] H)).injective
+  ext m
+  change dualTensorHom R M (H ⊗[R] H)
+      (TensorProduct.assoc R (Module.Dual R M) H H
+        ((dualCoact (R := R) (H := H) (M := M)).rTensor H
+          (dualCoact (R := R) (H := H) (M := M) φ))) m =
+    dualTensorHom R M (H ⊗[R] H)
+      ((Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M)
+        (dualCoact (R := R) (H := H) (M := M) φ)) m
+  rw [dualTensorHom_assoc_dualCoact_rTensor]
+  have hcomp := LinearMap.congr_fun
+    (dualTensorHom_comp_lTensor (M := M)
+      (Coalgebra.comul (R := R) (A := H)))
+    (dualCoact (R := R) (H := H) (M := M) φ)
+  have hcomp' :
+      dualTensorHom R M (H ⊗[R] H)
+          ((Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M)
+            (dualCoact (R := R) (H := H) (M := M) φ)) =
+        (Coalgebra.comul (R := R) (A := H)).compRight R
+          (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
+    simpa only [LinearMap.comp_apply] using hcomp
+  rw [hcomp']
+  change TensorProduct.comm R H H
+      (TensorProduct.map
+        (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ))
+        (HopfAlgebra.antipode R)
+        (coact (R := R) (C := H) (M := M) m)) =
+    Coalgebra.comul (R := R) (A := H)
+      (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m)
+  rw [dualTensorHom_dualCoact]
+  change TensorProduct.comm R H H
+      (TensorProduct.map
+        ((HopfAlgebra.antipode R (A := H)).comp
+          (matrixCoefficientBilinear (R := R) (C := H) (M := M) φ))
+        (HopfAlgebra.antipode R)
+        (coact (R := R) (C := H) (M := M) m)) =
+    Coalgebra.comul (R := R) (A := H)
+      (HopfAlgebra.antipode R
+        (matrixCoefficient (R := R) (C := H) φ m))
+  rw [TauCeti.HopfAlgebra.antipode_comul_antidistrib_apply,
+    comul_matrixCoefficient]
+  rw [TensorProduct.map_comm]
+  rw [TensorProduct.map_map]
+  rfl
+
+variable (R H M) in
+/-- The right-comodule structure on the linear dual of a finite projective right comodule.
+
+This is deliberately not a global instance: a module can carry multiple coactions. Downstream
+code should select it explicitly, typically as a local instance. -/
+@[expose, implicit_reducible]
+noncomputable def dual : Comodule R H (Module.Dual R M) where
+  coact := dualCoact (R := R) (H := H) (M := M)
+  coassoc := dualCoact_coassoc (R := R) (H := H) (M := M)
+  lTensor_counit_comp_coact := dualCoact_counit (R := R) (H := H) (M := M)
+
+attribute [local instance] dual
+
+/-- The coaction of the explicit dual-comodule structure is `dualCoact`. -/
+@[simp]
+theorem dual_coact :
+    coact (R := R) (C := H) (M := Module.Dual R M) =
+      dualCoact (R := R) (H := H) (M := M) :=
+  rfl
+
+end
+
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
@@ -76,7 +76,7 @@ theorem dualTensorHom_dualCoact_apply (φ : Module.Dual R M) (m : M) :
       HopfAlgebra.antipode R
         (matrixCoefficient (R := R) (C := H) φ m) := by
   rw [dualTensorHom_dualCoact]
-  rfl
+  simp only [LinearMap.comp_apply, matrixCoefficientBilinear_apply_apply]
 
 /-- Applying the counit to the coefficient leg of the dual coaction recovers the original
 functional. -/
@@ -85,13 +85,9 @@ theorem dualCoact_counit :
         dualCoact (R := R) (H := H) (M := M) =
       (TensorProduct.mk R (Module.Dual R M) R).flip 1 := by
   ext φ
-  apply (dualTensorHomEquiv R M R).injective
+  apply (dualTensorHom_bijective (R := R) (M := M) (N := R)).1
   ext m
-  -- Display both tensors through the characteristic map used by the injectivity argument.
-  change dualTensorHom R M R
-      ((Coalgebra.counit (R := R) (A := H)).lTensor (Module.Dual R M)
-        (dualCoact (R := R) (H := H) (M := M) φ)) m =
-    dualTensorHom R M R (φ ⊗ₜ[R] (1 : R)) m
+  simp only [LinearMap.comp_apply, LinearMap.flip_apply, TensorProduct.mk_apply]
   have hcomp := LinearMap.congr_fun
     (dualTensorHom_comp_lTensor (M := M)
       (Coalgebra.counit (R := R) (A := H)))
@@ -104,10 +100,7 @@ theorem dualCoact_counit :
           (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
     simpa only [LinearMap.comp_apply] using hcomp
   rw [hcomp']
-  -- Evaluate `compRight` and the pure tensor under `dualTensorHom`.
-  change Coalgebra.counit (R := R) (A := H)
-      (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m) =
-    φ m • (1 : R)
+  simp only [LinearMap.compRight_apply, LinearMap.comp_apply, dualTensorHom_apply]
   rw [dualTensorHom_dualCoact_apply]
   simp
 
@@ -131,12 +124,14 @@ private theorem dualTensorHom_assoc_dualCoact_rTensor (x : Module.Dual R M ⊗[R
           dualTensorHom R M (H ⊗[R] H)
               (TensorProduct.assoc R (Module.Dual R M) H H (y ⊗ₜ[R] h)) m =
             dualTensorHom R M H y m ⊗ₜ[R] h := by
-        induction y using TensorProduct.induction_on with
-        | zero => simp
-        | add y z hy hz =>
-            simpa only [TensorProduct.add_tmul, map_add, LinearMap.add_apply]
-              using congrArg₂ (· + ·) hy hz
-        | tmul ψ a => rfl
+        calc
+          _ = (rTensorHomEquivHomRTensor R M H H
+              (dualTensorHom R M H y ⊗ₜ[R] h)) m := by
+            simp [rTensorHomEquivHomRTensor]
+          _ = _ := by
+            rw [rTensorHomEquivHomRTensor_apply]
+            exact TensorProduct.rTensorHomToHomRTensor_apply
+              (dualTensorHom R M H y) h m
       rw [LinearMap.rTensor_tmul, hleft, dualTensorHom_dualCoact_apply]
       rw [matrixCoefficient_def]
       generalize coact (R := R) (C := H) (M := M) m = z
@@ -156,53 +151,38 @@ theorem dualCoact_coassoc :
       (Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M) ∘ₗ
         dualCoact (R := R) (H := H) (M := M) := by
   ext φ
-  apply (dualTensorHomEquiv R M (H ⊗[R] H)).injective
+  apply (dualTensorHom_bijective (R := R) (M := M) (N := H ⊗[R] H)).1
   ext m
-  -- Display both iterated coactions through the characteristic map used for injectivity.
-  change dualTensorHom R M (H ⊗[R] H)
-      (TensorProduct.assoc R (Module.Dual R M) H H
-        ((dualCoact (R := R) (H := H) (M := M)).rTensor H
-          (dualCoact (R := R) (H := H) (M := M) φ))) m =
-    dualTensorHom R M (H ⊗[R] H)
-      ((Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M)
-        (dualCoact (R := R) (H := H) (M := M) φ)) m
-  rw [dualTensorHom_assoc_dualCoact_rTensor]
-  have hcomp := LinearMap.congr_fun
-    (dualTensorHom_comp_lTensor (M := M)
-      (Coalgebra.comul (R := R) (A := H)))
-    (dualCoact (R := R) (H := H) (M := M) φ)
-  have hcomp' :
-      dualTensorHom R M (H ⊗[R] H)
-          ((Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M)
-            (dualCoact (R := R) (H := H) (M := M) φ)) =
-        (Coalgebra.comul (R := R) (A := H)).compRight R
-          (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
-    simpa only [LinearMap.comp_apply] using hcomp
-  rw [hcomp']
-  -- Evaluate the postcomposition by comultiplication pointwise.
-  change TensorProduct.comm R H H
-      (TensorProduct.map
-        (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ))
-        (HopfAlgebra.antipode R)
-        (coact (R := R) (C := H) (M := M) m)) =
-    Coalgebra.comul (R := R) (A := H)
-      (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m)
-  rw [dualTensorHom_dualCoact]
-  -- Expand the characteristic equation pointwise, exposing the matrix coefficient.
-  change TensorProduct.comm R H H
-      (TensorProduct.map
-        ((HopfAlgebra.antipode R (A := H)).comp
-          (matrixCoefficientBilinear (R := R) (C := H) (M := M) φ))
-        (HopfAlgebra.antipode R)
-        (coact (R := R) (C := H) (M := M) m)) =
-    Coalgebra.comul (R := R) (A := H)
-      (HopfAlgebra.antipode R
-        (matrixCoefficient (R := R) (C := H) φ m))
-  rw [TauCeti.HopfAlgebra.antipode_comul_antidistrib_apply,
-    comul_matrixCoefficient]
-  rw [TensorProduct.map_comm]
-  rw [TensorProduct.map_map]
-  rfl
+  simp only [LinearMap.comp_apply]
+  calc
+    _ = TensorProduct.comm R H H
+        (TensorProduct.map
+          (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ))
+          (HopfAlgebra.antipode R)
+          (coact (R := R) (C := H) (M := M) m)) :=
+      dualTensorHom_assoc_dualCoact_rTensor
+        (dualCoact (R := R) (H := H) (M := M) φ) m
+    _ = _ := by
+      have hcomp := LinearMap.congr_fun
+        (dualTensorHom_comp_lTensor (M := M)
+          (Coalgebra.comul (R := R) (A := H)))
+        (dualCoact (R := R) (H := H) (M := M) φ)
+      have hcomp' :
+          dualTensorHom R M (H ⊗[R] H)
+              ((Coalgebra.comul (R := R) (A := H)).lTensor (Module.Dual R M)
+                (dualCoact (R := R) (H := H) (M := M) φ)) =
+            (Coalgebra.comul (R := R) (A := H)).compRight R
+              (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
+        simpa only [LinearMap.comp_apply] using hcomp
+      rw [hcomp']
+      simp only [LinearMap.compRight_apply, LinearMap.comp_apply]
+      rw [dualTensorHom_dualCoact]
+      simp only [LinearMap.comp_apply, matrixCoefficientBilinear_apply_apply]
+      rw [TauCeti.HopfAlgebra.antipode_comul_antidistrib_apply,
+        comul_matrixCoefficient]
+      rw [TensorProduct.map_comm]
+      rw [TensorProduct.map_map]
+      rfl
 
 variable (R H M) in
 /-- The right-comodule structure on the linear dual of a finite projective right comodule.

--- a/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Dual.lean
@@ -87,6 +87,7 @@ theorem dualCoact_counit :
   ext φ
   apply (dualTensorHomEquiv R M R).injective
   ext m
+  -- Display both tensors through the characteristic map used by the injectivity argument.
   change dualTensorHom R M R
       ((Coalgebra.counit (R := R) (A := H)).lTensor (Module.Dual R M)
         (dualCoact (R := R) (H := H) (M := M) φ)) m =
@@ -103,6 +104,7 @@ theorem dualCoact_counit :
           (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
     simpa only [LinearMap.comp_apply] using hcomp
   rw [hcomp']
+  -- Evaluate `compRight` and the pure tensor under `dualTensorHom`.
   change Coalgebra.counit (R := R) (A := H)
       (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m) =
     φ m • (1 : R)
@@ -156,6 +158,7 @@ theorem dualCoact_coassoc :
   ext φ
   apply (dualTensorHomEquiv R M (H ⊗[R] H)).injective
   ext m
+  -- Display both iterated coactions through the characteristic map used for injectivity.
   change dualTensorHom R M (H ⊗[R] H)
       (TensorProduct.assoc R (Module.Dual R M) H H
         ((dualCoact (R := R) (H := H) (M := M)).rTensor H
@@ -176,6 +179,7 @@ theorem dualCoact_coassoc :
           (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ)) := by
     simpa only [LinearMap.comp_apply] using hcomp
   rw [hcomp']
+  -- Evaluate the postcomposition by comultiplication pointwise.
   change TensorProduct.comm R H H
       (TensorProduct.map
         (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ))
@@ -184,6 +188,7 @@ theorem dualCoact_coassoc :
     Coalgebra.comul (R := R) (A := H)
       (dualTensorHom R M H (dualCoact (R := R) (H := H) (M := M) φ) m)
   rw [dualTensorHom_dualCoact]
+  -- Expand the characteristic equation pointwise, exposing the matrix coefficient.
   change TensorProduct.comm R H H
       (TensorProduct.map
         ((HopfAlgebra.antipode R (A := H)).comp
@@ -204,7 +209,7 @@ variable (R H M) in
 
 This is deliberately not a global instance: a module can carry multiple coactions. Downstream
 code should select it explicitly, typically as a local instance. -/
-@[expose, implicit_reducible]
+@[instance_reducible]
 noncomputable def dual : Comodule R H (Module.Dual R M) where
   coact := dualCoact (R := R) (H := H) (M := M)
   coassoc := dualCoact_coassoc (R := R) (H := H) (M := M)
@@ -216,8 +221,7 @@ attribute [local instance] dual
 @[simp]
 theorem dual_coact :
     coact (R := R) (C := H) (M := Module.Dual R M) =
-      dualCoact (R := R) (H := H) (M := M) :=
-  rfl
+      dualCoact (R := R) (H := H) (M := M) := (rfl)
 
 end
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
@@ -30,7 +30,7 @@ open CategoryTheory
 
 namespace TauCeti.FGComoduleCat
 
-universe u v
+universe u v w
 
 variable (k : Type u) [Field k]
 variable (H : Type v) [Semiring H] [HopfAlgebra k H]
@@ -39,40 +39,43 @@ attribute [local instance] Comodule.dual
 
 /-- The linear dual of a finite-dimensional right comodule, with the coaction induced by the
 antipode. -/
-noncomputable abbrev dual (M : FGComoduleCat.{u, v, u} k H) :
-    FGComoduleCat.{u, v, u} k H :=
+noncomputable abbrev dual (M : FGComoduleCat.{u, v, w} k H) :
+    FGComoduleCat.{u, v, max u w} k H :=
   of (R := k) (C := H) (Module.Dual k M)
 
 /-- The ambient comodule underlying the finite dual is the linear dual equipped with
 `Comodule.dual`. -/
 @[simp]
-theorem dual_obj (M : FGComoduleCat.{u, v, u} k H) :
+theorem dual_obj (M : FGComoduleCat.{u, v, w} k H) :
     (dual k H M).obj = ComoduleCat.of k H (Module.Dual k M) :=
   rfl
 
 /-- The carrier of the finite dual is the ordinary linear dual. -/
 @[simp]
-theorem dual_coe (M : FGComoduleCat.{u, v, u} k H) :
-    (dual k H M : Type u) = Module.Dual k M :=
+theorem dual_coe (M : FGComoduleCat.{u, v, w} k H) :
+    (dual k H M : Type (max u w)) = Module.Dual k M :=
   rfl
 
 /-- The coaction on the finite dual is the basis-free dual coaction. -/
-theorem dual_coact (M : FGComoduleCat.{u, v, u} k H) :
+-- Prefer this bundled normal form before `dual_coe` exposes the underlying dual comodule.
+@[simp↓ high]
+theorem dual_coact (M : FGComoduleCat.{u, v, w} k H) :
     Comodule.coact (R := k) (C := H) (M := dual k H M) =
       Comodule.dualCoact (R := k) (H := H) (M := M) :=
   Comodule.dual_coact (R := k) (H := H) (M := M)
 
 /-- The inclusion into all comodules sends the finite dual to the ambient dual comodule. -/
 @[simp]
-theorem incl_dual (M : FGComoduleCat.{u, v, u} k H) :
+theorem incl_dual (M : FGComoduleCat.{u, v, w} k H) :
     (incl (R := k) (C := H)).obj (dual k H M) =
       ComoduleCat.of k H (Module.Dual k M) :=
   rfl
 
 /-- Forgetting the finite dual to semimodules gives the ordinary linear-dual module. -/
 @[simp]
-theorem forget₂_semimoduleCat_dual_obj (M : FGComoduleCat.{u, v, u} k H) :
-    (forget₂ (FGComoduleCat.{u, v, u} k H) (SemimoduleCat.{u} k)).obj (dual k H M) =
+theorem forget₂_semimoduleCat_dual_obj (M : FGComoduleCat.{u, v, w} k H) :
+    (forget₂ (FGComoduleCat.{u, v, max u w} k H)
+      (SemimoduleCat.{max u w} k)).obj (dual k H M) =
       SemimoduleCat.of k (Module.Dual k M) :=
   rfl
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
@@ -57,11 +57,10 @@ theorem dual_coe (M : FGComoduleCat.{u, v, u} k H) :
   rfl
 
 /-- The coaction on the finite dual is the basis-free dual coaction. -/
-@[simp]
 theorem dual_coact (M : FGComoduleCat.{u, v, u} k H) :
     Comodule.coact (R := k) (C := H) (M := dual k H M) =
       Comodule.dualCoact (R := k) (H := H) (M := M) :=
-  rfl
+  Comodule.dual_coact (R := k) (H := H) (M := M)
 
 /-- The inclusion into all comodules sends the finite dual to the ambient dual comodule. -/
 @[simp]

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Dual.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.Coalgebra.Comodule.Dual
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Basic
+
+/-!
+# Duals of finite-dimensional comodules
+
+This file bundles the linear dual of a finite-dimensional right comodule over a Hopf algebra as
+an object of `FGComoduleCat`. The underlying coaction is the basis-free dual coaction constructed
+in `TauCeti.Algebra.Coalgebra.Comodule.Dual`.
+
+## Main declaration
+
+* `TauCeti.FGComoduleCat.dual`: the finite-dimensional dual comodule.
+
+## References
+
+This is the finite-dimensional specialization of the standard dual-comodule construction; see
+Sweedler, *Hopf Algebras*, Chapter 2.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti.FGComoduleCat
+
+universe u v
+
+variable (k : Type u) [Field k]
+variable (H : Type v) [Semiring H] [HopfAlgebra k H]
+
+attribute [local instance] Comodule.dual
+
+/-- The linear dual of a finite-dimensional right comodule, with the coaction induced by the
+antipode. -/
+noncomputable abbrev dual (M : FGComoduleCat.{u, v, u} k H) :
+    FGComoduleCat.{u, v, u} k H :=
+  of (R := k) (C := H) (Module.Dual k M)
+
+/-- The ambient comodule underlying the finite dual is the linear dual equipped with
+`Comodule.dual`. -/
+@[simp]
+theorem dual_obj (M : FGComoduleCat.{u, v, u} k H) :
+    (dual k H M).obj = ComoduleCat.of k H (Module.Dual k M) :=
+  rfl
+
+/-- The carrier of the finite dual is the ordinary linear dual. -/
+@[simp]
+theorem dual_coe (M : FGComoduleCat.{u, v, u} k H) :
+    (dual k H M : Type u) = Module.Dual k M :=
+  rfl
+
+/-- The coaction on the finite dual is the basis-free dual coaction. -/
+@[simp]
+theorem dual_coact (M : FGComoduleCat.{u, v, u} k H) :
+    Comodule.coact (R := k) (C := H) (M := dual k H M) =
+      Comodule.dualCoact (R := k) (H := H) (M := M) :=
+  rfl
+
+/-- The inclusion into all comodules sends the finite dual to the ambient dual comodule. -/
+@[simp]
+theorem incl_dual (M : FGComoduleCat.{u, v, u} k H) :
+    (incl (R := k) (C := H)).obj (dual k H M) =
+      ComoduleCat.of k H (Module.Dual k M) :=
+  rfl
+
+/-- Forgetting the finite dual to semimodules gives the ordinary linear-dual module. -/
+@[simp]
+theorem forget₂_semimoduleCat_dual_obj (M : FGComoduleCat.{u, v, u} k H) :
+    (forget₂ (FGComoduleCat.{u, v, u} k H) (SemimoduleCat.{u} k)).obj (dual k H M) =
+      SemimoduleCat.of k (Module.Dual k M) :=
+  rfl
+
+end TauCeti.FGComoduleCat

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import Mathlib.RingTheory.Coalgebra.CoassocSimps
 public import TauCeti.Algebra.Coalgebra.Comodule.Hom
 public import TauCeti.Algebra.Coalgebra.Comodule.Trivial
 
@@ -173,10 +174,8 @@ theorem counit_matrixCoefficient (φ : Module.Dual R M) (m : M) :
           (TensorProduct.lid R C (TensorProduct.map φ LinearMap.id x)) =
         TensorProduct.lid R R
           (TensorProduct.map φ (Coalgebra.counit (R := R) (A := C)) x) := by
-    induction x using TensorProduct.induction_on with
-    | zero => simp
-    | add x y hx hy => simp only [map_add, hx, hy]
-    | tmul x c => simp
+    exact (LinearMap.congr_fun
+      (CoassocSimps.lid_comp_map φ (Coalgebra.counit (R := R) (A := C))) x).symm
   have h := congrArg
     (fun x : M ⊗[R] R =>
       TensorProduct.lid R R (TensorProduct.map φ LinearMap.id x))

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Basic.lean
@@ -162,6 +162,30 @@ theorem matrixCoefficient_smul_functional (r : R) (φ : M →ₗ[R] R) (m : M) :
       r • matrixCoefficient (R := R) (C := C) φ m := by
   simp [matrixCoefficient_def, TensorProduct.map_smul_left]
 
+/-- Applying the coalgebra counit to a matrix coefficient recovers evaluation of the
+functional on the vector. -/
+@[simp]
+theorem counit_matrixCoefficient (φ : Module.Dual R M) (m : M) :
+    Coalgebra.counit (R := R) (A := C)
+        (matrixCoefficient (R := R) (C := C) φ m) = φ m := by
+  have hnat (x : M ⊗[R] C) :
+      Coalgebra.counit (R := R) (A := C)
+          (TensorProduct.lid R C (TensorProduct.map φ LinearMap.id x)) =
+        TensorProduct.lid R R
+          (TensorProduct.map φ (Coalgebra.counit (R := R) (A := C)) x) := by
+    induction x using TensorProduct.induction_on with
+    | zero => simp
+    | add x y hx hy => simp only [map_add, hx, hy]
+    | tmul x c => simp
+  have h := congrArg
+    (fun x : M ⊗[R] R =>
+      TensorProduct.lid R R (TensorProduct.map φ LinearMap.id x))
+    (lTensor_counit_coact (R := R) (C := C) (M := M) m)
+  rw [matrixCoefficient_def, hnat]
+  simpa only [LinearMap.lTensor, TensorProduct.map_map, LinearMap.id_comp,
+    LinearMap.comp_id, TensorProduct.map_tmul, LinearMap.id_apply, TensorProduct.lid_tmul,
+    smul_eq_mul, mul_one] using h
+
 /-- Matrix coefficients are natural in comodule morphisms: pushing the vector forward is
 the same as pulling the functional back. -/
 @[simp]


### PR DESCRIPTION
This PR constructs the dual right comodule of a finite projective comodule over an arbitrary Hopf algebra.

It adds the general matrix-coefficient counit formula, defines the dual coaction through the finite-projective tensor–Hom equivalence, proves the counit and coassociativity laws basis-freely, and exposes the result as an explicit non-global comodule structure. Over a field, the dual is also bundled in `FGComoduleCat` with its characteristic carrier and coaction API.

The construction requires neither commutativity nor finite generation of the Hopf algebra, and it does not assume that the antipode is bijective. Evaluation, coevaluation, and rigidity remain separate later steps.

Validation:

- `lake build`
- `../tc axioms --changed-from upstream/main`
- `../tc lint --changed-from upstream/main`

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"dual-comodule"}-->

🤖 Prepared by Codex
