### PR TITLE
feat: bound the lattice chain complex

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Bounded.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Bounded.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LowDimTopology.Plumbing.ChainComplex
+
+/-!
+# Boundedness of the lattice chain complex
+
+The cubical degree of a plumbing-lattice generator is the cardinality of its finite set of
+directions. For a plumbing graph on `V`, this degree is therefore at most `Fintype.card V`.
+This file turns that elementary bound into the corresponding structural facts about Némethi's
+lattice complex: its degree pieces are zero precisely above the number of vertices, its chain
+maps with source above that range are zero, and its homology vanishes in every degree above that
+bound.
+
+The characterization of the zero chain groups is sharp. In every degree at most
+`Fintype.card V`, a subset of the vertex set of that cardinality supplies a cube generator and
+hence a nonzero chain. This rules out obtaining boundedness from a degenerate chain model and
+makes the result useful when reducing explicit lattice-homology computations to finitely many
+cubical degrees.
+
+## Main results
+
+* `TauCeti.PlumbingChain.degreePart_eq_bot_iff_card_lt`: the degree-`q` chain group is zero
+  exactly when the plumbing graph has fewer than `q` vertices.
+* `TauCeti.PlumbingGraph.latticeDifferentialDegree_eq_zero_of_card_le`: no differential leaves
+  an impossible source degree above the number of vertices.
+* `TauCeti.PlumbingGraph.latticeChainComplex_X_isZero_iff_card_lt`: the categorical chain object
+  has the same sharp vanishing range.
+* `TauCeti.PlumbingGraph.latticeChainHomology_isZero_of_card_lt`: lattice homology vanishes
+  above the number of plumbing vertices.
+
+## References
+
+This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, which asks for
+Némethi's lattice homology from lattice points and weight functions, including computations for
+explicit plumbings. The cubical complex and its grading follow A. Némethi,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841), Section 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory Limits
+
+namespace PlumbingChain
+
+variable (V : Type*) [Fintype V]
+
+/-- The degree-`q` part of the plumbing chain module is zero exactly when `q` is larger than the
+number of plumbing vertices. -/
+theorem degreePart_eq_bot_iff_card_lt (q : ℕ) :
+    degreePart V q = ⊥ ↔ Fintype.card V < q := by
+  classical
+  constructor
+  · intro hzero
+    by_contra hq
+    obtain ⟨S, _hSsub, hScard⟩ :=
+      Finset.exists_subset_card_eq (s := (Finset.univ : Finset V)) (Nat.le_of_not_gt hq)
+    let C : PlumbingCube V := { base := 0, directions := S }
+    have hsingle : Finsupp.single C (1 : PlumbingCoefficient) ∈ degreePart V q :=
+      single_mem_degreePart V C 1 (by simpa [C] using hScard)
+    rw [hzero, Submodule.mem_bot] at hsingle
+    exact one_ne_zero (Finsupp.single_eq_zero.mp hsingle)
+  · intro hq
+    refine le_antisymm ?_ bot_le
+    intro c hc
+    rw [mem_degreePart] at hc
+    apply Finsupp.ext
+    intro C
+    by_cases hC : C ∈ c.support
+    · have hdim := hc C hC
+      have hle : C.dimension ≤ Fintype.card V := C.dimension_le_card
+      omega
+    · exact Finsupp.notMem_support_iff.mp hC
+
+/-- The degree-`q` part of the plumbing chain module is nonzero exactly in the possible cubical
+range. -/
+theorem degreePart_ne_bot_iff_le_card (q : ℕ) :
+    degreePart V q ≠ ⊥ ↔ q ≤ Fintype.card V := by
+  rw [ne_eq, degreePart_eq_bot_iff_card_lt]
+  omega
+
+end PlumbingChain
+
+namespace PlumbingGraph
+
+variable {V : Type*} [DecidableEq V] [Fintype V]
+
+/-- The degreewise differential is zero once its source degree `q + 1` lies above the number of
+plumbing vertices. -/
+theorem latticeDifferentialDegree_eq_zero_of_card_le
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
+    (hq : Fintype.card V ≤ q) :
+    P.latticeDifferentialDegree k q = 0 := by
+  have hsource :=
+    (PlumbingChain.degreePart_eq_bot_iff_card_lt V (q + 1)).mpr (Nat.lt_succ_of_le hq)
+  haveI : Subsingleton (PlumbingChain.degreePart V (q + 1)) := by
+    rw [hsource]
+    infer_instance
+  ext c
+  rw [Subsingleton.elim c 0]
+  simp
+
+/-- The differential from the first impossible cubical degree into the top possible degree is
+zero. -/
+@[simp]
+theorem latticeDifferentialDegree_card_eq_zero
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeDifferentialDegree k (Fintype.card V) = 0 :=
+  P.latticeDifferentialDegree_eq_zero_of_card_le k _ le_rfl
+
+/-- A chain object in the cubically graded lattice complex is zero exactly above the number of
+plumbing vertices. -/
+theorem latticeChainComplex_X_isZero_iff_card_lt
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
+    IsZero ((P.latticeChainComplex k).X q) ↔ Fintype.card V < q := by
+  rw [P.latticeChainComplex_X k q, ModuleCat.isZero_iff_subsingleton,
+    Submodule.subsingleton_iff_eq_bot, PlumbingChain.degreePart_eq_bot_iff_card_lt]
+
+/-- The cubically graded lattice complex is exact in every degree above the number of plumbing
+vertices because its chain object there is zero. -/
+theorem latticeChainComplex_exactAt_of_card_lt
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
+    (hq : Fintype.card V < q) :
+    (P.latticeChainComplex k).ExactAt q :=
+  ShortComplex.exact_of_isZero_X₂ _
+    ((P.latticeChainComplex_X_isZero_iff_card_lt k q).mpr hq)
+
+/-- Lattice homology vanishes in every cubical degree above the number of plumbing vertices. -/
+theorem latticeChainHomology_isZero_of_card_lt
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
+    (hq : Fintype.card V < q) :
+    IsZero (P.latticeChainHomology k q) := by
+  rw [P.latticeChainHomology_def k q]
+  exact (P.latticeChainComplex_exactAt_of_card_lt k q hq).isZero_homology
+
+end PlumbingGraph
+
+end TauCeti

--- a/TauCeti/LowDimTopology/Plumbing/Bounded.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Bounded.lean
@@ -49,6 +49,7 @@ variable {V : Type*} [DecidableEq V] [Fintype V]
 
 /-- A chain object in the cubically graded lattice complex is zero exactly above the number of
 plumbing vertices. -/
+@[simp]
 theorem isZero_latticeChainComplex_X_iff_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     IsZero ((P.latticeChainComplex k).X q) ↔ Fintype.card V < q := by
@@ -57,7 +58,7 @@ theorem isZero_latticeChainComplex_X_iff_card_lt
 
 /-- The cubically graded lattice complex is exact in every degree above the number of plumbing
 vertices because its chain object there is zero. -/
-theorem latticeChainComplex_exactAt_of_card_lt
+theorem exactAt_latticeChainComplex_of_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
     (hq : Fintype.card V < q) :
     (P.latticeChainComplex k).ExactAt q :=
@@ -70,7 +71,7 @@ theorem isZero_latticeChainHomology_of_card_lt
     (hq : Fintype.card V < q) :
     IsZero (P.latticeChainHomology k q) := by
   rw [P.latticeChainHomology_def k q]
-  exact (P.latticeChainComplex_exactAt_of_card_lt k q hq).isZero_homology
+  exact (P.exactAt_latticeChainComplex_of_card_lt k q hq).isZero_homology
 
 end PlumbingGraph
 

--- a/TauCeti/LowDimTopology/Plumbing/Bounded.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Bounded.lean
@@ -49,7 +49,6 @@ variable {V : Type*} [DecidableEq V] [Fintype V]
 
 /-- A chain object in the cubically graded lattice complex is zero exactly above the number of
 plumbing vertices. -/
-@[simp]
 theorem isZero_latticeChainComplex_X_iff_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     IsZero ((P.latticeChainComplex k).X q) ↔ Fintype.card V < q := by

--- a/TauCeti/LowDimTopology/Plumbing/Bounded.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Bounded.lean
@@ -11,10 +11,10 @@ public import TauCeti.LowDimTopology.Plumbing.ChainComplex
 
 The cubical degree of a plumbing-lattice generator is the cardinality of its finite set of
 directions. For a plumbing graph on `V`, this degree is therefore at most `Fintype.card V`.
-This file turns that elementary bound into the corresponding structural facts about Némethi's
-lattice complex: its degree pieces are zero precisely above the number of vertices, its chain
-maps with source above that range are zero, and its homology vanishes in every degree above that
-bound.
+The grading-level bounds are established in `Grading.lean`. This file turns them into the
+corresponding categorical facts about Némethi's lattice complex: its chain objects are zero
+precisely above the number of vertices, the complex is exact there, and its homology vanishes in
+every degree above that bound.
 
 The characterization of the zero chain groups is sharp. In every degree at most
 `Fintype.card V`, a subset of the vertex set of that cardinality supplies a cube generator and
@@ -24,13 +24,9 @@ cubical degrees.
 
 ## Main results
 
-* `TauCeti.PlumbingChain.degreePart_eq_bot_iff_card_lt`: the degree-`q` chain group is zero
-  exactly when the plumbing graph has fewer than `q` vertices.
-* `TauCeti.PlumbingGraph.latticeDifferentialDegree_eq_zero_of_card_le`: no differential leaves
-  an impossible source degree above the number of vertices.
-* `TauCeti.PlumbingGraph.latticeChainComplex_X_isZero_iff_card_lt`: the categorical chain object
+* `TauCeti.PlumbingGraph.isZero_latticeChainComplex_X_iff_card_lt`: the categorical chain object
   has the same sharp vanishing range.
-* `TauCeti.PlumbingGraph.latticeChainHomology_isZero_of_card_lt`: lattice homology vanishes
+* `TauCeti.PlumbingGraph.isZero_latticeChainHomology_of_card_lt`: lattice homology vanishes
   above the number of plumbing vertices.
 
 ## References
@@ -47,76 +43,14 @@ namespace TauCeti
 
 open CategoryTheory Limits
 
-namespace PlumbingChain
-
-variable (V : Type*) [Fintype V]
-
-/-- The degree-`q` part of the plumbing chain module is zero exactly when `q` is larger than the
-number of plumbing vertices. -/
-theorem degreePart_eq_bot_iff_card_lt (q : ℕ) :
-    degreePart V q = ⊥ ↔ Fintype.card V < q := by
-  classical
-  constructor
-  · intro hzero
-    by_contra hq
-    obtain ⟨S, _hSsub, hScard⟩ :=
-      Finset.exists_subset_card_eq (s := (Finset.univ : Finset V)) (Nat.le_of_not_gt hq)
-    let C : PlumbingCube V := { base := 0, directions := S }
-    have hsingle : Finsupp.single C (1 : PlumbingCoefficient) ∈ degreePart V q :=
-      single_mem_degreePart V C 1 (by simpa [C] using hScard)
-    rw [hzero, Submodule.mem_bot] at hsingle
-    exact one_ne_zero (Finsupp.single_eq_zero.mp hsingle)
-  · intro hq
-    refine le_antisymm ?_ bot_le
-    intro c hc
-    rw [mem_degreePart] at hc
-    apply Finsupp.ext
-    intro C
-    by_cases hC : C ∈ c.support
-    · have hdim := hc C hC
-      have hle : C.dimension ≤ Fintype.card V := C.dimension_le_card
-      omega
-    · exact Finsupp.notMem_support_iff.mp hC
-
-/-- The degree-`q` part of the plumbing chain module is nonzero exactly in the possible cubical
-range. -/
-theorem degreePart_ne_bot_iff_le_card (q : ℕ) :
-    degreePart V q ≠ ⊥ ↔ q ≤ Fintype.card V := by
-  rw [ne_eq, degreePart_eq_bot_iff_card_lt]
-  omega
-
-end PlumbingChain
-
 namespace PlumbingGraph
 
 variable {V : Type*} [DecidableEq V] [Fintype V]
 
-/-- The degreewise differential is zero once its source degree `q + 1` lies above the number of
-plumbing vertices. -/
-theorem latticeDifferentialDegree_eq_zero_of_card_le
-    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
-    (hq : Fintype.card V ≤ q) :
-    P.latticeDifferentialDegree k q = 0 := by
-  have hsource :=
-    (PlumbingChain.degreePart_eq_bot_iff_card_lt V (q + 1)).mpr (Nat.lt_succ_of_le hq)
-  haveI : Subsingleton (PlumbingChain.degreePart V (q + 1)) := by
-    rw [hsource]
-    infer_instance
-  ext c
-  rw [Subsingleton.elim c 0]
-  simp
-
-/-- The differential from the first impossible cubical degree into the top possible degree is
-zero. -/
-@[simp]
-theorem latticeDifferentialDegree_card_eq_zero
-    (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    P.latticeDifferentialDegree k (Fintype.card V) = 0 :=
-  P.latticeDifferentialDegree_eq_zero_of_card_le k _ le_rfl
-
 /-- A chain object in the cubically graded lattice complex is zero exactly above the number of
 plumbing vertices. -/
-theorem latticeChainComplex_X_isZero_iff_card_lt
+@[simp]
+theorem isZero_latticeChainComplex_X_iff_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ) :
     IsZero ((P.latticeChainComplex k).X q) ↔ Fintype.card V < q := by
   rw [P.latticeChainComplex_X k q, ModuleCat.isZero_iff_subsingleton,
@@ -128,11 +62,11 @@ theorem latticeChainComplex_exactAt_of_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
     (hq : Fintype.card V < q) :
     (P.latticeChainComplex k).ExactAt q :=
-  ShortComplex.exact_of_isZero_X₂ _
-    ((P.latticeChainComplex_X_isZero_iff_card_lt k q).mpr hq)
+  HomologicalComplex.ExactAt.of_isZero
+    ((P.isZero_latticeChainComplex_X_iff_card_lt k q).mpr hq)
 
 /-- Lattice homology vanishes in every cubical degree above the number of plumbing vertices. -/
-theorem latticeChainHomology_isZero_of_card_lt
+theorem isZero_latticeChainHomology_of_card_lt
     (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
     (hq : Fintype.card V < q) :
     IsZero (P.latticeChainHomology k q) := by

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -103,6 +103,13 @@ theorem dimension_mk (x : V → ℤ) (S : Finset V) :
     dimension ({ base := x, directions := S } : PlumbingCube V) = S.card :=
   rfl
 
+omit [DecidableEq V] in
+/-- The dimension of a plumbing cube is at most the number of plumbing vertices. -/
+theorem dimension_le_card [Fintype V] (C : PlumbingCube V) :
+    C.dimension ≤ Fintype.card V := by
+  classical
+  exact Finset.card_le_univ C.directions
+
 @[simp]
 theorem eraseDirection_mk (x : V → ℤ) (S : Finset V) (v : V) :
     eraseDirection ({ base := x, directions := S } : PlumbingCube V) v =

--- a/TauCeti/LowDimTopology/Plumbing/Grading.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Grading.lean
@@ -111,13 +111,6 @@ theorem degreePart_eq_bot_iff_card_lt (q : ℕ) :
       omega
     · exact Finsupp.notMem_support_iff.mp hC
 
-/-- The degree-`q` part of the plumbing chain module is nonzero exactly in the possible cubical
-range. -/
-theorem degreePart_ne_bot_iff_le_card (q : ℕ) :
-    degreePart V q ≠ ⊥ ↔ q ≤ Fintype.card V := by
-  rw [ne_eq, degreePart_eq_bot_iff_card_lt]
-  omega
-
 end
 
 /-- Distinct cubical-degree submodules intersect trivially. -/
@@ -206,14 +199,6 @@ theorem latticeDifferentialDegree_eq_zero_of_card_le
     rw [hsource]
     infer_instance
   exact Subsingleton.elim _ _
-
-/-- The differential from the first impossible cubical degree into the top possible degree is
-zero. -/
-@[simp]
-theorem latticeDifferentialDegree_card_eq_zero
-    (P : PlumbingGraph V) (k : P.characteristicVectors) :
-    P.latticeDifferentialDegree k (Fintype.card V) = 0 :=
-  P.latticeDifferentialDegree_eq_zero_of_card_le k _ le_rfl
 
 /-- Consecutive cubical-degree lattice differentials compose to zero. -/
 theorem latticeDifferentialDegree_comp

--- a/TauCeti/LowDimTopology/Plumbing/Grading.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Grading.lean
@@ -22,6 +22,10 @@ square-zero identity then shows that consecutive graded differentials compose to
 maps are the data needed to package lattice homology as a `ℕ`-indexed chain complex, rather than
 only as the ungraded short complex currently used for its total homology.
 
+Since a cube's directions form a finite subset of the plumbing vertices, this file also records
+the sharp bound on the nonzero cubical degrees and the resulting vanishing of differentials whose
+source lies above that range.
+
 ## Main definitions
 
 * `TauCeti.PlumbingChain.degreePart`: chains supported on cubes of one cubical dimension.
@@ -36,6 +40,10 @@ only as the ungraded short complex currently used for its total homology.
   degree-`q + 1` submodule into the degree-`q` submodule.
 * `TauCeti.PlumbingGraph.latticeDifferentialDegree_comp`: consecutive graded differentials
   compose to zero.
+* `TauCeti.PlumbingChain.degreePart_eq_bot_iff_card_lt`: the degree-`q` chain group is zero
+  exactly when the plumbing graph has fewer than `q` vertices.
+* `TauCeti.PlumbingGraph.latticeDifferentialDegree_eq_zero_of_card_le`: no differential leaves
+  an impossible source degree above the number of vertices.
 
 ## References
 
@@ -70,6 +78,47 @@ theorem single_mem_degreePart {q : ℕ} (C : PlumbingCube V) (a : PlumbingCoeffi
     (hC : C.dimension = q) :
     Finsupp.single C a ∈ degreePart V q :=
   Finsupp.single_mem_supported PlumbingCoefficient a hC
+
+section
+
+variable [Fintype V]
+
+/-- The degree-`q` part of the plumbing chain module is zero exactly when `q` is larger than the
+number of plumbing vertices. -/
+@[simp]
+theorem degreePart_eq_bot_iff_card_lt (q : ℕ) :
+    degreePart V q = ⊥ ↔ Fintype.card V < q := by
+  classical
+  constructor
+  · intro hzero
+    by_contra hq
+    obtain ⟨S, _hSsub, hScard⟩ :=
+      Finset.exists_subset_card_eq (s := (Finset.univ : Finset V)) (Nat.le_of_not_gt hq)
+    let C : PlumbingCube V := { base := 0, directions := S }
+    have hsingle : Finsupp.single C (1 : PlumbingCoefficient) ∈ degreePart V q :=
+      single_mem_degreePart V C 1 (by simpa [C] using hScard)
+    rw [hzero, Submodule.mem_bot] at hsingle
+    exact one_ne_zero (Finsupp.single_eq_zero.mp hsingle)
+  · intro hq
+    refine le_antisymm ?_ bot_le
+    intro c hc
+    rw [mem_degreePart] at hc
+    apply Finsupp.ext
+    intro C
+    by_cases hC : C ∈ c.support
+    · have hdim := hc C hC
+      have hle : C.dimension ≤ Fintype.card V := C.dimension_le_card
+      omega
+    · exact Finsupp.notMem_support_iff.mp hC
+
+/-- The degree-`q` part of the plumbing chain module is nonzero exactly in the possible cubical
+range. -/
+theorem degreePart_ne_bot_iff_le_card (q : ℕ) :
+    degreePart V q ≠ ⊥ ↔ q ≤ Fintype.card V := by
+  rw [ne_eq, degreePart_eq_bot_iff_card_lt]
+  omega
+
+end
 
 /-- Distinct cubical-degree submodules intersect trivially. -/
 theorem disjoint_degreePart {q r : ℕ} (hqr : q ≠ r) :
@@ -144,6 +193,27 @@ theorem latticeDifferentialDegree_apply
     (P.latticeDifferentialDegree k q c : PlumbingChain V) =
       P.latticeDifferential k c :=
   (rfl)
+
+/-- The degreewise differential is zero once its source degree `q + 1` lies above the number of
+plumbing vertices. -/
+theorem latticeDifferentialDegree_eq_zero_of_card_le
+    (P : PlumbingGraph V) (k : P.characteristicVectors) (q : ℕ)
+    (hq : Fintype.card V ≤ q) :
+    P.latticeDifferentialDegree k q = 0 := by
+  have hsource :=
+    (PlumbingChain.degreePart_eq_bot_iff_card_lt V (q + 1)).mpr (Nat.lt_succ_of_le hq)
+  haveI : Subsingleton (PlumbingChain.degreePart V (q + 1)) := by
+    rw [hsource]
+    infer_instance
+  exact Subsingleton.elim _ _
+
+/-- The differential from the first impossible cubical degree into the top possible degree is
+zero. -/
+@[simp]
+theorem latticeDifferentialDegree_card_eq_zero
+    (P : PlumbingGraph V) (k : P.characteristicVectors) :
+    P.latticeDifferentialDegree k (Fintype.card V) = 0 :=
+  P.latticeDifferentialDegree_eq_zero_of_card_le k _ le_rfl
 
 /-- Consecutive cubical-degree lattice differentials compose to zero. -/
 theorem latticeDifferentialDegree_comp


### PR DESCRIPTION
This PR bounds the cubically graded lattice chain complex by the number of plumbing vertices. It proves sharply that the degree-`q` chain group is zero exactly when `Fintype.card V < q`, identifies the same vanishing range for the corresponding `ModuleCat` objects, shows maps whose source lies above that range are zero, and deduces exactness and vanishing lattice homology in every degree above the bound.

This advances `TauCetiRoadmap/CombinatorialHeegaardFloer/README.md`, Lane L, specifically “Némethi's lattice (co)homology `ℍ⁻`/`ℍ⁰` as a `ℤ[U]`-module from lattice points and weight functions” and the subsequent target “computations for Seifert-fibered examples.” It is the lowest-hanging distinct prerequisite because PR #1602 has just assembled the graded lattice chain complex, while finite cubical amplitude is the immediate reduction needed before explicit homology computations; the only open CombinatorialHeegaardFloer PR, #1178, concerns grid-homology symmetries instead.

Add `TauCeti/LowDimTopology/Plumbing/Bounded.lean` (144 lines) and the seven-line cube-dimension bound `PlumbingCube.dimension_le_card` beside the cube dimension definition in `Cube/Generator.lean`. The converse direction in `degreePart_eq_bot_iff_card_lt` constructs a cube from a vertex subset of prescribed cardinality, so the vanishing range is non-vacuous and sharp.

The construction follows the cubical grading in A. Némethi, arXiv:0709.0841, Section 3, as cited in the new module docstring. No Mathlib infrastructure is vendored or adapted. The proofs reuse Mathlib's `Finset.exists_subset_card_eq`, `ModuleCat.isZero_iff_subsingleton`, `ShortComplex.exact_of_isZero_X₂`, and `HomologicalComplex.ExactAt.isZero_homology`.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6052 jobs).` `lake exe axioms` reports `axioms: audited 17696 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: CombinatorialHeegaardFloer

<!--tauceti-target:v1 {"focus":"CombinatorialHeegaardFloer","id":"lattice-chain-complex-boundedness"}-->

🤖 Prepared with Codex
