### PR TITLE
refactor(Contour): decompose the second-order chord expansion

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/CrossingValue/Curvature.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue/Curvature.lean
@@ -68,10 +68,10 @@ variable {γ : ℝ → ℂ} {t₀ : ℝ} {A : ℂ}
 -- The second-order remainder `γ t - γ t₀ - (t - t₀) · L - (t - t₀)² · A / 2` differentiates to
 -- `deriv γ t - L - (t - t₀) · A`. Only differentiability of `γ` at the single point is used: no
 -- neighbourhood, no second derivative, and `L`, `A` are arbitrary.
-private theorem hasDerivAt_chordRemainder {L : ℂ} {t : ℝ} (hγt : HasDerivAt γ (deriv γ t) t) :
+private theorem hasDerivAt_chordRemainder {D L : ℂ} {t : ℝ} (hγt : HasDerivAt γ D t) :
     HasDerivAt (fun s : ℝ ↦ γ s - γ t₀ - ((s - t₀ : ℝ) : ℂ) * L
         - ((s - t₀ : ℝ) : ℂ) ^ 2 * (A / 2))
-      (deriv γ t - L - ((t - t₀ : ℝ) : ℂ) * A) t := by
+      (D - L - ((t - t₀ : ℝ) : ℂ) * A) t := by
   have hu : HasDerivAt (fun x : ℝ ↦ ((x - t₀ : ℝ) : ℂ)) 1 t := by
     simpa using (((hasDerivAt_id t).sub_const t₀).ofReal_comp)
   refine (((hγt.sub_const (γ t₀)).sub (hu.mul_const L)).sub
@@ -122,8 +122,9 @@ private theorem tendsto_chord_secondOrder
   set F : ℝ → ℂ :=
     fun t ↦ γ t - γ t₀ - ((t - t₀ : ℝ) : ℂ) * L - ((t - t₀ : ℝ) : ℂ) ^ 2 * (A / 2) with hF
   set F' : ℝ → ℂ := fun t ↦ deriv γ t - L - ((t - t₀ : ℝ) : ℂ) * A with hF'
-  have hff' : ∀ t ∈ V, HasDerivWithinAt F (F' t) V t := fun t ht =>
-    (hasDerivAt_chordRemainder (hball (Metric.mem_ball.1 ht)).hasDerivAt).hasDerivWithinAt
+  have hff' : ∀ t ∈ V, HasDerivWithinAt F (F' t) V t := fun t ht => by
+    simpa only [hF, hF'] using
+      (hasDerivAt_chordRemainder (hball (Metric.mem_ball.1 ht)).hasDerivAt).hasDerivWithinAt
   have hFo : F' =o[𝓝[V] t₀] fun t ↦ (t - t₀) ^ 1 := by
     have hlit := hasDerivAt_iff_isLittleO.1 hA
     refine (hlit.mono nhdsWithin_le_nhds).congr' ?_ (Eventually.of_forall fun t ↦ ?_)

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue/Curvature.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue/Curvature.lean
@@ -65,6 +65,44 @@ open Asymptotics Complex Filter Topology
 
 variable {γ : ℝ → ℂ} {t₀ : ℝ} {A : ℂ}
 
+-- The second-order remainder `γ t - γ t₀ - (t - t₀) · L - (t - t₀)² · A / 2` differentiates to
+-- `deriv γ t - L - (t - t₀) · A`. Only differentiability of `γ` at the single point is used: no
+-- neighbourhood, no second derivative, and `L`, `A` are arbitrary.
+private theorem hasDerivAt_chordRemainder {L : ℂ} {t : ℝ} (hγt : HasDerivAt γ (deriv γ t) t) :
+    HasDerivAt (fun s : ℝ ↦ γ s - γ t₀ - ((s - t₀ : ℝ) : ℂ) * L
+        - ((s - t₀ : ℝ) : ℂ) ^ 2 * (A / 2))
+      (deriv γ t - L - ((t - t₀ : ℝ) : ℂ) * A) t := by
+  have hu : HasDerivAt (fun x : ℝ ↦ ((x - t₀ : ℝ) : ℂ)) 1 t := by
+    simpa using (((hasDerivAt_id t).sub_const t₀).ofReal_comp)
+  refine (((hγt.sub_const (γ t₀)).sub (hu.mul_const L)).sub
+    ((hu.pow 2).mul_const (A / 2))).congr_deriv ?_
+  push_cast
+  ring
+
+-- A little-o against the real power `(t - t₀) ^ (1 + 1)` is one against the complex-coerced
+-- square, since the two comparison functions have equal norms pointwise.
+private theorem isLittleO_ofReal_sq_of_isLittleO_pow {F : ℝ → ℂ} {l : Filter ℝ}
+    (h : F =o[l] fun t ↦ (t - t₀) ^ (1 + 1)) :
+    F =o[l] fun t ↦ ((t - t₀ : ℝ) : ℂ) ^ 2 := by
+  have hnorm : ∀ t : ℝ, ‖(t - t₀) ^ (1 + 1)‖ = ‖((t - t₀ : ℝ) : ℂ) ^ 2‖ := fun t ↦ by
+    rw [norm_pow, norm_pow, Complex.norm_real]
+  rw [← isLittleO_norm_right] at h ⊢
+  exact h.congr' EventuallyEq.rfl (Eventually.of_forall hnorm)
+
+-- Divide a second-order estimate by the square: if `G` agrees with `(t - t₀)² · c` to higher
+-- order, its quotient by `(t - t₀)²` tends to `c` along the punctured neighbourhood.
+private theorem tendsto_div_ofReal_sq_of_isLittleO {G : ℝ → ℂ} {c : ℂ}
+    (h : (fun t ↦ G t - ((t - t₀ : ℝ) : ℂ) ^ 2 * c) =o[𝓝 t₀] fun t ↦ ((t - t₀ : ℝ) : ℂ) ^ 2) :
+    Tendsto (fun t ↦ G t / ((t - t₀ : ℝ) : ℂ) ^ 2) (𝓝[≠] t₀) (𝓝 c) := by
+  have hshift := (h.tendsto_div_nhds_zero.mono_left
+    (nhdsWithin_le_nhds (s := {t₀}ᶜ))).add_const c
+  rw [zero_add] at hshift
+  refine hshift.congr' ?_
+  filter_upwards [self_mem_nhdsWithin] with t ht
+  have hτ : ((t - t₀ : ℝ) : ℂ) ≠ 0 := by exact_mod_cast sub_ne_zero.mpr ht
+  field_simp
+  ring
+
 /-- The second-order chord expansion at `t₀`: if `γ` is differentiable near `t₀` and its derivative
 has derivative `A` at `t₀`, then the chord `γ t - γ t₀` differs from its first-order part by
 `(t - t₀)² · A / 2` to leading order.
@@ -84,17 +122,8 @@ private theorem tendsto_chord_secondOrder
   set F : ℝ → ℂ :=
     fun t ↦ γ t - γ t₀ - ((t - t₀ : ℝ) : ℂ) * L - ((t - t₀ : ℝ) : ℂ) ^ 2 * (A / 2) with hF
   set F' : ℝ → ℂ := fun t ↦ deriv γ t - L - ((t - t₀ : ℝ) : ℂ) * A with hF'
-  have hff' : ∀ t ∈ V, HasDerivWithinAt F (F' t) V t := by
-    intro t ht
-    have hu : HasDerivAt (fun x : ℝ ↦ ((x - t₀ : ℝ) : ℂ)) 1 t := by
-      simpa using (((hasDerivAt_id t).sub_const t₀).ofReal_comp)
-    have hγt : HasDerivAt γ (deriv γ t) t := (hball (Metric.mem_ball.1 ht)).hasDerivAt
-    refine HasDerivAt.hasDerivWithinAt ?_
-    refine (((hγt.sub_const (γ t₀)).sub (hu.mul_const L)).sub
-      ((hu.pow 2).mul_const (A / 2))).congr_deriv ?_
-    simp only [hF']
-    push_cast
-    ring
+  have hff' : ∀ t ∈ V, HasDerivWithinAt F (F' t) V t := fun t ht =>
+    (hasDerivAt_chordRemainder (hball (Metric.mem_ball.1 ht)).hasDerivAt).hasDerivWithinAt
   have hFo : F' =o[𝓝[V] t₀] fun t ↦ (t - t₀) ^ 1 := by
     have hlit := hasDerivAt_iff_isLittleO.1 hA
     refine (hlit.mono nhdsWithin_le_nhds).congr' ?_ (Eventually.of_forall fun t ↦ ?_)
@@ -105,22 +134,8 @@ private theorem tendsto_chord_secondOrder
   have hFt₀ : F t₀ = 0 := by simp [hF]
   rw [hFt₀, hVopen.nhdsWithin_eq ht₀V] at hmain
   simp only [sub_zero] at hmain
-  -- Move the comparison function to the complex square, then divide. The real square `(t - t₀) ^ 2`
-  -- and its complex coercion have the same norm, so comparing norms transfers the estimate.
-  have hnorm : ∀ t : ℝ, ‖(t - t₀) ^ (1 + 1)‖ = ‖((t - t₀ : ℝ) : ℂ) ^ 2‖ := fun t ↦ by
-    rw [norm_pow, norm_pow, Complex.norm_real]
-  have hcx : F =o[𝓝 t₀] fun t ↦ ((t - t₀ : ℝ) : ℂ) ^ 2 := by
-    rw [← isLittleO_norm_right] at hmain ⊢
-    exact hmain.congr' EventuallyEq.rfl (Eventually.of_forall hnorm)
-  have hzero := (hcx.tendsto_div_nhds_zero).mono_left (nhdsWithin_le_nhds (s := {t₀}ᶜ))
-  have hshift := hzero.add_const (A / 2)
-  rw [zero_add] at hshift
-  refine hshift.congr' ?_
-  filter_upwards [self_mem_nhdsWithin] with t ht
-  have hτ : ((t - t₀ : ℝ) : ℂ) ≠ 0 := by
-    exact_mod_cast sub_ne_zero.mpr ht
-  field_simp [hF]
-  ring
+  -- Move the comparison to the complex square, then divide by it.
+  exact tendsto_div_ofReal_sq_of_isLittleO (isLittleO_ofReal_sq_of_isLittleO_pow hmain)
 
 /-- **Hungerbühler–Wasem Proposition 2.3, crossing value, in second-derivative form.** Let `γ` be
 differentiable near `t₀`, with `deriv γ` differentiable at `t₀` with derivative `A`, and let the


### PR DESCRIPTION
Decomposes `tendsto_chord_secondOrder` in
`TauCeti/Analysis/Contour/Winding/CrossingValue/Curvature.lean`, at 46 lines the longest proof body
on main outside the PRs already in flight. No statement changes: the theorem keeps its signature,
and the three extracted helpers are `private` and local to the file.

The proof runs four steps in one block — differentiate the second-order remainder, feed the
first-order expansion of `deriv γ` into Mathlib's `Convex.isLittleO_pow_succ_real`, move the
resulting little-o from the real square onto the complex-coerced one, then divide by that square.
The first, third and fourth are self-contained and now stated separately; the mean-value
application stays in the parent, where the ball and its convexity live:

| helper | what it proves | body |
|---|---|---|
| `hasDerivAt_chordRemainder` | the second-order remainder differentiates to `deriv γ t - L - (t - t₀)·A` | 6 |
| `isLittleO_ofReal_sq_of_isLittleO_pow` | a little-o against `(t - t₀)^(1+1)` is one against `(↑(t - t₀))²` | 4 |
| `tendsto_div_ofReal_sq_of_isLittleO` | dividing a second-order estimate by the square gives the limit | 8 |

`tendsto_chord_secondOrder` goes from 46 lines to 23.

**Hypotheses were re-derived at extraction rather than inherited:**

* `hasDerivAt_chordRemainder` needs only `HasDerivAt γ (deriv γ t) t` at the single point `t`. It
  does not need the eventual differentiability `hdiff`, the ball `V`, its radius `δ`, or the
  second-derivative hypothesis `hA`; `L` and `A` are arbitrary complex constants. The parent
  supplies the pointwise derivative from `hball` at each `t ∈ V`.
* `isLittleO_ofReal_sq_of_isLittleO_pow` mentions neither `γ` nor `A` nor the ball, and holds along
  an arbitrary filter — the content is just that the two comparison functions have equal norms.
* `tendsto_div_ofReal_sq_of_isLittleO` likewise mentions no `γ`: it says that a function agreeing
  with `(t - t₀)²·c` to higher order has quotient tending to `c`, for arbitrary `G` and `c`.

Two `have`s disappear from the parent as a consequence: `hnorm` (now internal to the second helper)
and the `hzero`/`hshift` pair that set up the division.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: ContourIntegration
