### PR TITLE
feat: compute the order of a product of two simple reflections

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -12,10 +12,12 @@ public section
 # The order of a product of two simple reflections
 
 The product of the reflections in two roots `αᵢ`, `αⱼ` changes every weight by an element of the
-span of the two roots, and its order is therefore read off the Cartan product
-`c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the values `1`, `2`, `3` give the orders `3`, `4`, `6`. This file
-proves that, and — for two simple roots of a base of a finite crystallographic pairing, where
-`c = 0` is the remaining possibility and gives the order `2` — that the entries of
+span of the two roots. Over a characteristic-zero ring, its order is read off the Cartan product
+`c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the values `1`, `2`, `3` give the orders `3`, `4`, `6`. This file proves
+the corresponding upper bounds over an arbitrary commutative ring and these exact orders under
+characteristic zero. It then proves — for two simple roots of a base of a finite crystallographic
+pairing over a characteristic-zero domain, where `c = 0` is the remaining possibility and gives the
+order `2` — that the entries of
 `TauCeti.coxeterMatrixOfBase` really are the orders they are named for, so that the braid relations
 of the Coxeter presentation of a Weyl group hold in the Weyl group.
 
@@ -36,7 +38,8 @@ That the order is no smaller is checked on the single vector `αᵢ`: its `αᵢ
 orbit of `g` is again a Chebyshev expression in `c`, and for the relevant powers that expression
 avoids the value `⟨αᵢ, αᵢ^∨⟩ = 2`.
 
-Everything before the last section is stated for an arbitrary pair of roots of an arbitrary root
+The iterate formulas and upper bounds are stated over an arbitrary commutative ring. The exact-order
+results add characteristic zero, but still concern an arbitrary pair of roots of an arbitrary root
 pairing, the Cartan product entering only as a hypothesis on `RootPairing.pairing`; no finiteness,
 crystallographic or reducedness assumption is used there. The last section specialises to a pair of
 simple roots of a base, where `TauCeti.cartanMatrix_mul_cartanMatrix_mem_of_ne` confines the Cartan
@@ -53,7 +56,8 @@ product to `{0, 1, 2, 3}` and the case analysis closes.
   product `1`, `2`, `3`, and
   `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three`,
   `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four`,
-  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six`: the matching exact orders.
+  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six`: the matching exact orders under
+  characteristic zero.
 * `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`: **the entries of
   the Coxeter matrix of a base are the orders of the products of the corresponding simple
   reflections.**

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -19,19 +19,22 @@ proves that, and — for two simple roots of a base of a finite crystallographic
 `TauCeti.coxeterMatrixOfBase` really are the orders they are named for, so that the braid relations
 of the Coxeter presentation of a Weyl group hold in the Weyl group.
 
-The route is elementary and diagonalises nothing. Writing `g` for the product of the two
-reflections, `g` fixes the common kernel of the two coroots pointwise, and on the two coroot
-coordinates it acts with determinant `1` and trace `c - 2`. So `g` is annihilated by the cubic
-`(X - 1)(X² - (c - 2)X + 1)`, which
-`TauCeti.RootPairing.weylGroup.pow_add_three_ofIdx_mul_ofIdx_smul` states as a three-term
-recursion for the iterates of `g`. Substituting `c = 1, 2, 3` and chasing the recursion a few steps
-gives `g³ = 1`, `g⁴ = 1`, `g⁶ = 1`; the remaining value `c = 0` is the orthogonal case, already
-settled in `TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix`, where the two reflections commute, and
-where the order is pinned to `2` only for two distinct simple roots of a base.
+The iterates of the product are supplied by Mathlib's
+`Module.reflection_mul_reflection_pow_apply` and `Module.reflection_mul_reflection_pow_apply_self`,
+which express `(r₁r₂)ⁿ` over an arbitrary commutative ring through the Chebyshev `S`-polynomials
+(`Polynomial.Chebyshev.S`) evaluated at `t = c - 2`;
+`TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
+`TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root` are those formulas for a product of
+two reflections of a root pairing, read as elements of the Weyl group. Substituting `c = 1, 2, 3`,
+that is `t = -1, 0, 1`, makes the two Chebyshev coefficients of the general formula vanish at the
+exponents `3`, `4`, `6`, which gives `g³ = 1`, `g⁴ = 1`, `g⁶ = 1`; the remaining value `c = 0` is
+the orthogonal case, already settled in `TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix`, where the
+two reflections commute, and where the order is pinned to `2` only for two distinct simple roots of
+a base.
 
 That the order is no smaller is checked on the single vector `αᵢ`: its `αᵢ^∨`-coordinate along the
-orbit of `g` is a polynomial in `c`, and for the relevant powers that polynomial avoids the value
-`⟨αᵢ, αᵢ^∨⟩ = 2`.
+orbit of `g` is again a Chebyshev expression in `c`, and for the relevant powers that expression
+avoids the value `⟨αᵢ, αᵢ^∨⟩ = 2`.
 
 Everything before the last section is stated for an arbitrary pair of roots of an arbitrary root
 pairing, the Cartan product entering only as a hypothesis on `RootPairing.pairing`; no finiteness,
@@ -41,8 +44,9 @@ product to `{0, 1, 2, 3}` and the case analysis closes.
 
 ## Main results
 
-* `TauCeti.RootPairing.weylGroup.pow_add_three_ofIdx_mul_ofIdx_smul`: the three-term recursion
-  satisfied by the iterates of a product of two reflections.
+* `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` and
+  `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul_root`: the iterates of a product of two
+  reflections, acting on a weight and on the first of the two roots.
 * `TauCeti.RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one`,
   `TauCeti.RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one`,
   `TauCeti.RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one`: the braid relations at Cartan
@@ -67,7 +71,7 @@ Representation Theory*, §9.
 
 namespace TauCeti
 
-open Set
+open Set Polynomial.Chebyshev
 
 universe u v w x
 
@@ -105,7 +109,9 @@ theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
 
 /-- The `αⱼ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. Together with
 `TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the action
-on the two coroot coordinates: determinant `1` and trace `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
+on the two coroot coordinates: determinant `1` and trace `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`, the value at
+which `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` evaluates its Chebyshev
+polynomials. -/
 @[grind =]
 theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
     P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
@@ -116,112 +122,95 @@ theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
     _root_.RootPairing.pairing_same]
   ring
 
-/-- **The cubic annihilating a product of two reflections.** The product fixes the common kernel of
-the two coroots and acts on the two coroot coordinates with determinant `1` and trace `c - 2`, so
-it is annihilated by `(X - 1)(X² - (c - 2)X + 1)`. -/
-theorem pow_three_ofIdx_mul_ofIdx_smul (x : M) :
+/-- The action of an iterate of the product of the two reflections is the action of the
+corresponding iterate of the product of the two linear reflections. -/
+private lemma pow_ofIdx_mul_ofIdx_smul_eq (n : ℕ) (x : M) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • x =
-      (P.pairing i j * P.pairing j i - 1) •
-          (((_root_.RootPairing.weylGroup.ofIdx P i *
-            _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x) -
-        (P.pairing i j * P.pairing j i - 1) •
-          ((_root_.RootPairing.weylGroup.ofIdx P i *
-            _root_.RootPairing.weylGroup.ofIdx P j) • x) + x := by
-  have hA := ofIdx_mul_ofIdx_smul P i j
-  set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
-  have h2 : ∀ y : M, (g ^ 2) • y = g • (g • y) := fun y ↦ by rw [sq, mul_smul]
-  have h3 : (g ^ 3) • x = g • (g • (g • x)) := by rw [pow_succ', mul_smul, h2]
-  -- Unfold the three applications of `g`, expand the coroot functionals of the results, and
-  -- compare the coefficients of `x`, `αᵢ` and `αⱼ` on the two sides.
-  rw [h3, h2]
-  simp only [hA, map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
-    _root_.RootPairing.pairing_same]
-  module
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x =
+      ((P.reflection i * P.reflection j) ^ n) x := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [pow_succ', mul_smul, ih, pow_succ', LinearEquiv.mul_apply, mul_smul]
+    simp [_root_.RootPairing.reflection_apply]
 
-/-- **The three-term recursion for the iterates of a product of two reflections**, obtained by
-applying the annihilating cubic to `gⁿ • x`. This is the engine of every braid relation below. -/
-theorem pow_add_three_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M) :
+/-- **The iterates of a product of two reflections.** This is Mathlib's
+`Module.reflection_mul_reflection_pow_apply` for the reflections in two roots `αᵢ`, `αⱼ` of a root
+pairing, read in the Weyl group; its Chebyshev polynomials are evaluated at the Cartan product
+shifted by `2`, that is at `t = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
+theorem pow_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M)
+    (t : R := P.pairing i j * P.pairing j i - 2)
+    (ht : t = P.pairing i j * P.pairing j i - 2 := by rfl) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 3)) • x =
-      (P.pairing i j * P.pairing j i - 1) •
-          (((_root_.RootPairing.weylGroup.ofIdx P i *
-            _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 2)) • x) -
-        (P.pairing i j * P.pairing j i - 1) •
-          (((_root_.RootPairing.weylGroup.ofIdx P i *
-            _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 1)) • x) +
-        ((_root_.RootPairing.weylGroup.ofIdx P i *
-          _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x := by
-  set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
-  have key : ∀ m : ℕ, (g ^ (n + m)) • x = (g ^ m) • ((g ^ n) • x) := fun m ↦ by
-    rw [add_comm n m, pow_add, mul_smul]
-  rw [key 3, key 2, key 1, pow_one]
-  exact pow_three_ofIdx_mul_ofIdx_smul P i j ((g ^ n) • x)
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x =
+      x +
+        ((S R ((n - 2) / 2)).eval t * ((S R ((n - 1) / 2)).eval t + (S R ((n - 3) / 2)).eval t)) •
+          ((P.pairing i j * P.coroot' i x - P.coroot' j x) • P.root j - P.coroot' i x • P.root i) +
+        ((S R ((n - 1) / 2)).eval t * ((S R (n / 2)).eval t + (S R ((n - 2) / 2)).eval t)) •
+          ((P.pairing j i * P.coroot' j x - P.coroot' i x) • P.root i -
+            P.coroot' j x • P.root j) := by
+  rw [pow_ofIdx_mul_ofIdx_smul_eq]
+  exact Module.reflection_mul_reflection_pow_apply (P.coroot_root_two i) (P.coroot_root_two j) n x t
+    (by rw [ht, _root_.RootPairing.root_coroot'_eq_pairing,
+      _root_.RootPairing.root_coroot'_eq_pairing]; ring)
+
+/-- **The iterates of a product of two reflections on the first of the two roots.** This is
+Mathlib's `Module.reflection_mul_reflection_pow_apply_self` read in the Weyl group; it is the case
+`x = αᵢ` of `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul`, in a form where the two
+coefficients are single Chebyshev values. -/
+theorem pow_ofIdx_mul_ofIdx_smul_root (n : ℕ)
+    (t : R := P.pairing i j * P.pairing j i - 2)
+    (ht : t = P.pairing i j * P.pairing j i - 2 := by rfl) :
+    ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i =
+      ((S R n).eval t + (S R (n - 1)).eval t) • P.root i +
+        ((S R (n - 1)).eval t * -P.pairing i j) • P.root j := by
+  rw [pow_ofIdx_mul_ofIdx_smul_eq]
+  exact Module.reflection_mul_reflection_pow_apply_self (P.coroot_root_two i)
+    (P.coroot_root_two j) n t
+    (by rw [ht, _root_.RootPairing.root_coroot'_eq_pairing,
+      _root_.RootPairing.root_coroot'_eq_pairing]; ring)
 
 /-! ## The braid relations -/
 
 /-- **The braid relation at Cartan product `1`**: the product of the two reflections has order
 dividing `3`, the `A₂` configuration. -/
+@[simp, grind =]
 theorem pow_three_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 1) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
-  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
-  rw [h] at h₀
-  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀
-  rw [h₀]
-  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
-  -- away because the weight space carries a second scalar action, by the Weyl group itself.
-  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
-  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
-  module
+  -- At `t = -1` the coefficients of the two displacement terms are `S₀(t)(S₁(t) + S₀(t)) = 0`
+  -- and `S₁(t)(S₁(t) + S₀(t)) = 0`.
+  rw [pow_ofIdx_mul_ofIdx_smul P i j 3 x (-1) (by rw [h]; ring)]
+  norm_num [S_zero, S_one]
 
 /-- **The braid relation at Cartan product `2`**: the product of the two reflections has order
 dividing `4`, the `B₂` configuration. -/
+@[simp, grind =]
 theorem pow_four_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 2) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 4 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
-  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
-  have h₁ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 1 x
-  rw [h] at h₀ h₁
-  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀ h₁
-  rw [h₁, h₀]
-  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
-  -- away because the weight space carries a second scalar action, by the Weyl group itself.
-  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
-  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
-  module
+  -- At `t = 0` both coefficients carry the factor `S₁(t) = t = 0`.
+  rw [pow_ofIdx_mul_ofIdx_smul P i j 4 x 0 (by rw [h]; ring)]
+  norm_num [S_zero, S_one]
 
 /-- **The braid relation at Cartan product `3`**: the product of the two reflections has order
 dividing `6`, the `G₂` configuration. -/
+@[simp, grind =]
 theorem pow_six_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 3) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 6 = 1 := by
   refine eq_one_of_smul_eq_self fun x ↦ ?_
-  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
-  have h₁ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 1 x
-  have h₂ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 2 x
-  have h₃ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 3 x
-  rw [h] at h₀ h₁ h₂ h₃
-  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀ h₁ h₂ h₃
-  rw [h₃, h₂, h₁, h₀]
-  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
-  -- away because the weight space carries a second scalar action, by the Weyl group itself.
-  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
-  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
-    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
-  module
+  -- At `t = 1` both coefficients carry the factor `S₂(t) = t² - 1 = 0`.
+  rw [pow_ofIdx_mul_ofIdx_smul P i j 6 x 1 (by rw [h]; ring)]
+  norm_num [S_two]
 
 /-! ## The order is no smaller
 
-The lower bounds are read off a single vector: the `αᵢ^∨`-coordinate of `gⁿ • αᵢ` is a polynomial
-in the Cartan product `c`, and comparing it with `⟨αᵢ, αᵢ^∨⟩ = 2` rules out `gⁿ = 1`. -/
+The lower bounds are read off a single vector: the `αᵢ^∨`-coordinate of `gⁿ • αᵢ` is a Chebyshev
+expression in the Cartan product `c`, and comparing it with `⟨αᵢ, αᵢ^∨⟩ = 2` rules out `gⁿ = 1`. -/
 
 section LowerBound
 
@@ -235,59 +224,29 @@ private lemma pow_ne_one_of_coroot'_left_ne (n : ℕ)
     _root_.RootPairing.pairing_same] at h
   exact h rfl
 
-private lemma coroot'_left_smul_root :
-    P.coroot' i ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) • P.root i) =
-      P.pairing i j * P.pairing j i - 2 := by
-  rw [coroot'_left_ofIdx_mul_ofIdx_smul]
-  simp only [_root_.RootPairing.root_coroot'_eq_pairing, _root_.RootPairing.pairing_same]
-  ring
-
-private lemma coroot'_right_smul_root :
-    P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) • P.root i) =
-      (P.pairing i j * P.pairing j i - 3) * P.pairing i j := by
-  rw [coroot'_right_ofIdx_mul_ofIdx_smul]
-  simp only [_root_.RootPairing.root_coroot'_eq_pairing, _root_.RootPairing.pairing_same]
-  ring
-
-private lemma coroot'_left_pow_two_smul_root :
+private lemma coroot'_left_pow_smul_root (n : ℕ) (t : R)
+    (ht : t = P.pairing i j * P.pairing j i - 2) :
     P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • P.root i) =
-      (P.pairing i j * P.pairing j i) ^ 2 - 4 * (P.pairing i j * P.pairing j i) + 2 := by
-  rw [sq, mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul, coroot'_left_smul_root,
-    coroot'_right_smul_root]
-  ring
-
-private lemma coroot'_right_pow_two_smul_root :
-    P.coroot' j (((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • P.root i) =
-      ((P.pairing i j * P.pairing j i) ^ 2 - 5 * (P.pairing i j * P.pairing j i) + 5) *
-        P.pairing i j := by
-  rw [sq, mul_smul, coroot'_right_ofIdx_mul_ofIdx_smul, coroot'_left_smul_root,
-    coroot'_right_smul_root]
-  ring
-
-private lemma coroot'_left_pow_three_smul_root :
-    P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • P.root i) =
-      (P.pairing i j * P.pairing j i) ^ 3 - 6 * (P.pairing i j * P.pairing j i) ^ 2 +
-        9 * (P.pairing i j * P.pairing j i) - 2 := by
-  rw [pow_succ', mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul,
-    coroot'_left_pow_two_smul_root, coroot'_right_pow_two_smul_root]
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i) =
+      2 * ((S R n).eval t + (S R (n - 1)).eval t) -
+        (S R (n - 1)).eval t * (P.pairing i j * P.pairing j i) := by
+  rw [pow_ofIdx_mul_ofIdx_smul_root P i j n t ht]
+  simp only [map_add, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
+    _root_.RootPairing.pairing_same]
   ring
 
 variable [CharZero R]
 
 /-- **At Cartan product `1` the product of the two reflections has order exactly `3`.** -/
+@[simp, grind =]
 theorem orderOf_ofIdx_mul_ofIdx_eq_three (h : P.pairing i j * P.pairing j i = 1) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 3 := by
   have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 1 ≠ 1 := by
     refine pow_ne_one_of_coroot'_left_ne P i j 1 ?_
-    rw [pow_one, coroot'_left_smul_root, h]
-    norm_num
+    rw [coroot'_left_pow_smul_root P i j 1 (-1) (by rw [h]; ring), h]
+    norm_num [S_zero, S_one]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
     (pow_three_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 3 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp hpd
@@ -295,14 +254,15 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_three (h : P.pairing i j * P.pairing j i = 1)
   exact hne
 
 /-- **At Cartan product `2` the product of the two reflections has order exactly `4`.** -/
+@[simp, grind =]
 theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 4 := by
   have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
     refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
-    rw [coroot'_left_pow_two_smul_root, h]
-    norm_num
+    rw [coroot'_left_pow_smul_root P i j 2 0 (by rw [h]; ring), h]
+    norm_num [S_one, S_two]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
     (pow_four_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 := by
@@ -312,19 +272,23 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) 
   exact hne
 
 /-- **At Cartan product `3` the product of the two reflections has order exactly `6`.** -/
+@[simp, grind =]
 theorem orderOf_ofIdx_mul_ofIdx_eq_six (h : P.pairing i j * P.pairing j i = 3) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) = 6 := by
   have hne₂ : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
     refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
-    rw [coroot'_left_pow_two_smul_root, h]
-    norm_num
+    rw [coroot'_left_pow_smul_root P i j 2 1 (by rw [h]; ring), h]
+    norm_num [S_one, S_two]
   have hne₃ : (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 ≠ 1 := by
     refine pow_ne_one_of_coroot'_left_ne P i j 3 ?_
-    rw [coroot'_left_pow_three_smul_root, h]
-    norm_num
+    rw [coroot'_left_pow_smul_root P i j 3 1 (by rw [h]; ring), h]
+    have h₃ : (S R 3).eval (1 : R) = -1 := by
+      have h₃' : S R (3 : ℤ) = Polynomial.X * S R 2 - S R 1 := by simpa using S_add_two R (1 : ℤ)
+      simp [h₃', S_one, S_two]
+    norm_num [h₃, S_two]
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
     (pow_six_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 ∨ p = 3 := by

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -1,0 +1,400 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix
+
+public section
+
+/-!
+# The order of a product of two simple reflections
+
+The product of the reflections in two roots `αᵢ`, `αⱼ` acts on the weight space as a rotation of
+the plane they span, and as the identity transverse to it. Its order is therefore read off the
+Cartan product `c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the values `0`, `1`, `2`, `3` give the orders `2`, `3`,
+`4`, `6`. This file proves that, so the entries of `TauCeti.coxeterMatrixOfBase` really are the
+orders they are named for, and the braid relations of the Coxeter presentation of a Weyl group hold
+in the Weyl group.
+
+The route is elementary and diagonalises nothing. Writing `g` for the product of the two
+reflections, `g` fixes the intersection of the two reflecting hyperplanes pointwise and preserves
+the plane spanned by the two roots, where it has determinant `1` and trace `c - 2`. So `g` is
+annihilated by the cubic `(X - 1)(X² - (c - 2)X + 1)`, which
+`TauCeti.RootPairing.weylGroup.pow_add_three_ofIdx_mul_ofIdx_smul` states as a three-term
+recursion for the iterates of `g`. Substituting `c = 1, 2, 3` and chasing the recursion a few steps
+gives `g³ = 1`, `g⁴ = 1`, `g⁶ = 1`; the remaining value `c = 0` is the orthogonal case, already
+settled in `TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix`, where the two reflections commute.
+
+That the order is no smaller is checked on the single vector `αᵢ`: its `αᵢ^∨`-coordinate along the
+orbit of `g` is a polynomial in `c`, and for the relevant powers that polynomial avoids the value
+`⟨αᵢ, αᵢ^∨⟩ = 2`.
+
+Everything before the last section is stated for an arbitrary pair of roots of an arbitrary root
+pairing, the Cartan product entering only as a hypothesis on `RootPairing.pairing`; no finiteness,
+crystallographic or reducedness assumption is used there. The last section specialises to a pair of
+simple roots of a base, where `TauCeti.cartanMatrix_mul_cartanMatrix_mem_of_ne` confines the Cartan
+product to `{0, 1, 2, 3}` and the case analysis closes.
+
+## Main results
+
+* `TauCeti.RootPairing.weylGroup.pow_add_three_ofIdx_mul_ofIdx_smul`: the three-term recursion
+  satisfied by the iterates of a product of two reflections.
+* `TauCeti.RootPairing.weylGroup.pow_three_ofIdx_mul_ofIdx_eq_one`,
+  `TauCeti.RootPairing.weylGroup.pow_four_ofIdx_mul_ofIdx_eq_one`,
+  `TauCeti.RootPairing.weylGroup.pow_six_ofIdx_mul_ofIdx_eq_one`: the braid relations at Cartan
+  product `1`, `2`, `3`, and
+  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_three`,
+  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_four`,
+  `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_six`: the matching exact orders.
+* `TauCeti.RootPairing.weylGroup.orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase`: **the entries of
+  the Coxeter matrix of a base are the orders of the products of the corresponding simple
+  reflections.**
+* `TauCeti.RootPairing.weylGroup.pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one`: the braid
+  relations of that Coxeter matrix hold in the Weyl group.
+
+## References
+
+This file supplies “the order of a product of two simple reflections” in Layer 2 of
+`TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, the input the roadmap earmarks for the
+braid relations of `weylCoxeterSystem`. The rank-two computation is Bourbaki, *Lie Groups and Lie
+Algebras*, Chapters 4--6, Ch. VI, §1.3, and Humphreys, *Introduction to Lie Algebras and
+Representation Theory*, §9.
+-/
+
+namespace TauCeti
+
+open Set
+
+universe u v w x
+
+namespace RootPairing.weylGroup
+
+variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
+  [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+  (P : RootPairing ι R M N) (i j : ι)
+
+/-! ## Faithfulness of the weight-space action -/
+
+variable {P} in
+/-- A Weyl-group element acting trivially on the weight space is the identity: the weight-space
+representation of the automorphism group of a root pairing is faithful. -/
+theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : w = 1 := by
+  have hw : (w : P.Aut) = 1 := by
+    refine _root_.RootPairing.Equiv.weightHom_injective P ?_
+    rw [map_one]
+    exact LinearEquiv.ext fun x ↦ h x
+  exact Subtype.ext (by simpa using hw)
+
+/-! ## The rank-two computation -/
+
+/-- **The product of two reflections on the weight space.** The two reflections move `x` inside the
+plane spanned by the two roots, by an amount recorded by the two coroot functionals. -/
+theorem ofIdx_mul_ofIdx_smul (x : M) :
+    (_root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j) • x =
+      x - P.coroot' j x • P.root j -
+        (P.coroot' i x - P.pairing j i * P.coroot' j x) • P.root i := by
+  rw [mul_smul]
+  simp only [_root_.RootPairing.weylGroup.ofIdx_smul, _root_.RootPairing.Equiv.reflection_smul,
+    _root_.RootPairing.reflection_apply, map_sub, map_smul,
+    _root_.RootPairing.root_coroot'_eq_pairing]
+  module
+
+/-- The `αᵢ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. -/
+theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
+    P.coroot' i ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) • x) =
+      P.pairing j i * P.coroot' j x - P.coroot' i x := by
+  rw [ofIdx_mul_ofIdx_smul]
+  simp only [map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
+    _root_.RootPairing.pairing_same]
+  ring
+
+/-- The `αⱼ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. Together with
+`TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the
+rotation on the plane of the two roots: determinant `1` and trace
+`⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
+theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
+    P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) • x) =
+      (P.pairing i j * P.pairing j i - 1) * P.coroot' j x - P.pairing i j * P.coroot' i x := by
+  rw [ofIdx_mul_ofIdx_smul]
+  simp only [map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
+    _root_.RootPairing.pairing_same]
+  ring
+
+/-- **The cubic annihilating a product of two reflections.** The product fixes the intersection of
+the two reflecting hyperplanes and acts on the plane of the two roots with determinant `1` and
+trace `c - 2`, so it is annihilated by `(X - 1)(X² - (c - 2)X + 1)`. -/
+theorem pow_three_ofIdx_mul_ofIdx_smul (x : M) :
+    ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • x =
+      (P.pairing i j * P.pairing j i - 1) •
+          (((_root_.RootPairing.weylGroup.ofIdx P i *
+            _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x) -
+        (P.pairing i j * P.pairing j i - 1) •
+          ((_root_.RootPairing.weylGroup.ofIdx P i *
+            _root_.RootPairing.weylGroup.ofIdx P j) • x) + x := by
+  have hA := ofIdx_mul_ofIdx_smul P i j
+  have hL := coroot'_left_ofIdx_mul_ofIdx_smul P i j
+  have hR := coroot'_right_ofIdx_mul_ofIdx_smul P i j
+  set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
+  have h2 : ∀ y : M, (g ^ 2) • y = g • (g • y) := fun y ↦ by rw [sq, mul_smul]
+  have h3 : (g ^ 3) • x = g • (g • (g • x)) := by
+    rw [show (3 : ℕ) = 2 + 1 from rfl, pow_succ', mul_smul, h2]
+  rw [h3, h2, hA (g • (g • x)), hL (g • x), hR (g • x), hL x, hR x, hA (g • x), hL x, hR x, hA x]
+  module
+
+/-- **The three-term recursion for the iterates of a product of two reflections**, obtained by
+applying the annihilating cubic to `gⁿ • x`. This is the engine of every braid relation below. -/
+theorem pow_add_three_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M) :
+    ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 3)) • x =
+      (P.pairing i j * P.pairing j i - 1) •
+          (((_root_.RootPairing.weylGroup.ofIdx P i *
+            _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 2)) • x) -
+        (P.pairing i j * P.pairing j i - 1) •
+          (((_root_.RootPairing.weylGroup.ofIdx P i *
+            _root_.RootPairing.weylGroup.ofIdx P j) ^ (n + 1)) • x) +
+        ((_root_.RootPairing.weylGroup.ofIdx P i *
+          _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x := by
+  set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
+  have key : ∀ m : ℕ, (g ^ (m + n)) • x = (g ^ m) • ((g ^ n) • x) := fun m ↦ by
+    rw [pow_add, mul_smul]
+  rw [show n + 3 = 3 + n from Nat.add_comm n 3, show n + 2 = 2 + n from Nat.add_comm n 2,
+    show n + 1 = 1 + n from Nat.add_comm n 1, key 3, key 2, key 1, pow_one]
+  exact pow_three_ofIdx_mul_ofIdx_smul P i j ((g ^ n) • x)
+
+/-! ## The braid relations -/
+
+/-- **The braid relation at Cartan product `1`**: the product of the two reflections is a rotation
+of order dividing `3`, the `A₂` configuration. -/
+theorem pow_three_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 1) :
+    (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 = 1 := by
+  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
+  rw [h] at h₀
+  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀
+  rw [h₀]
+  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
+  -- away because the weight space carries a second scalar action, by the Weyl group itself.
+  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
+  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
+  module
+
+/-- **The braid relation at Cartan product `2`**: the product of the two reflections is a rotation
+of order dividing `4`, the `B₂` configuration. -/
+theorem pow_four_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 2) :
+    (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 4 = 1 := by
+  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
+  have h₁ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 1 x
+  rw [h] at h₀ h₁
+  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀ h₁
+  rw [h₁, h₀]
+  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
+  -- away because the weight space carries a second scalar action, by the Weyl group itself.
+  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
+  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
+  module
+
+/-- **The braid relation at Cartan product `3`**: the product of the two reflections is a rotation
+of order dividing `6`, the `G₂` configuration. -/
+theorem pow_six_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 3) :
+    (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 6 = 1 := by
+  refine eq_one_of_smul_eq_self fun x ↦ ?_
+  have h₀ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 0 x
+  have h₁ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 1 x
+  have h₂ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 2 x
+  have h₃ := pow_add_three_ofIdx_mul_ofIdx_smul P i j 3 x
+  rw [h] at h₀ h₁ h₂ h₃
+  simp only [Nat.reduceAdd, pow_zero, one_smul, pow_one] at h₀ h₁ h₂ h₃
+  rw [h₃, h₂, h₁, h₀]
+  -- The remaining identity is linear over `R` in the two surviving iterates, which are generalised
+  -- away because the weight space carries a second scalar action, by the Weyl group itself.
+  generalize ((_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • x = y
+  generalize (_root_.RootPairing.weylGroup.ofIdx P i *
+    _root_.RootPairing.weylGroup.ofIdx P j) • x = z
+  module
+
+/-! ## The order is no smaller
+
+The lower bounds are read off a single vector: the `αᵢ^∨`-coordinate of `gⁿ • αᵢ` is a polynomial
+in the Cartan product `c`, and comparing it with `⟨αᵢ, αᵢ^∨⟩ = 2` rules out `gⁿ = 1`. -/
+
+section LowerBound
+
+private lemma pow_ne_one_of_coroot'_left_ne (n : ℕ)
+    (h : P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • P.root i) ≠ 2) :
+    (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ n ≠ 1 := by
+  intro hpow
+  rw [hpow, one_smul, _root_.RootPairing.root_coroot'_eq_pairing,
+    _root_.RootPairing.pairing_same] at h
+  exact h rfl
+
+private lemma coroot'_left_smul_root :
+    P.coroot' i ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) • P.root i) =
+      P.pairing i j * P.pairing j i - 2 := by
+  rw [coroot'_left_ofIdx_mul_ofIdx_smul]
+  simp only [_root_.RootPairing.root_coroot'_eq_pairing, _root_.RootPairing.pairing_same]
+  ring
+
+private lemma coroot'_right_smul_root :
+    P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) • P.root i) =
+      (P.pairing i j * P.pairing j i - 3) * P.pairing i j := by
+  rw [coroot'_right_ofIdx_mul_ofIdx_smul]
+  simp only [_root_.RootPairing.root_coroot'_eq_pairing, _root_.RootPairing.pairing_same]
+  ring
+
+private lemma coroot'_left_pow_two_smul_root :
+    P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • P.root i) =
+      (P.pairing i j * P.pairing j i) ^ 2 - 4 * (P.pairing i j * P.pairing j i) + 2 := by
+  rw [sq, mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul, coroot'_left_smul_root,
+    coroot'_right_smul_root]
+  ring
+
+private lemma coroot'_right_pow_two_smul_root :
+    P.coroot' j (((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ 2) • P.root i) =
+      ((P.pairing i j * P.pairing j i) ^ 2 - 5 * (P.pairing i j * P.pairing j i) + 5) *
+        P.pairing i j := by
+  rw [sq, mul_smul, coroot'_right_ofIdx_mul_ofIdx_smul, coroot'_left_smul_root,
+    coroot'_right_smul_root]
+  ring
+
+private lemma coroot'_left_pow_three_smul_root :
+    P.coroot' i (((_root_.RootPairing.weylGroup.ofIdx P i *
+        _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • P.root i) =
+      (P.pairing i j * P.pairing j i) ^ 3 - 6 * (P.pairing i j * P.pairing j i) ^ 2 +
+        9 * (P.pairing i j * P.pairing j i) - 2 := by
+  rw [show (3 : ℕ) = 2 + 1 from rfl, pow_succ', mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul,
+    coroot'_left_pow_two_smul_root, coroot'_right_pow_two_smul_root]
+  ring
+
+variable [CharZero R]
+
+/-- **At Cartan product `1` the product of the two reflections has order exactly `3`.** -/
+theorem orderOf_ofIdx_mul_ofIdx_eq_three (h : P.pairing i j * P.pairing j i = 1) :
+    orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) = 3 := by
+  have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 1 ≠ 1 := by
+    refine pow_ne_one_of_coroot'_left_ne P i j 1 ?_
+    rw [pow_one, coroot'_left_smul_root, h]
+    norm_num
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
+    (pow_three_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+  have hp' : p = 3 := (Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp hpd
+  subst hp'
+  exact hne
+
+/-- **At Cartan product `2` the product of the two reflections has order exactly `4`.** -/
+theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) :
+    orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) = 4 := by
+  have hne : (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
+    refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
+    rw [coroot'_left_pow_two_smul_root, h]
+    norm_num
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
+    (pow_four_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+  have hp' : p = 2 := by
+    rw [show (4 : ℕ) = 2 ^ 2 by norm_num] at hpd
+    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd)
+  subst hp'
+  exact hne
+
+/-- **At Cartan product `3` the product of the two reflections has order exactly `6`.** -/
+theorem orderOf_ofIdx_mul_ofIdx_eq_six (h : P.pairing i j * P.pairing j i = 3) :
+    orderOf (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) = 6 := by
+  have hne₂ : (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 2 ≠ 1 := by
+    refine pow_ne_one_of_coroot'_left_ne P i j 2 ?_
+    rw [coroot'_left_pow_two_smul_root, h]
+    norm_num
+  have hne₃ : (_root_.RootPairing.weylGroup.ofIdx P i *
+      _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 ≠ 1 := by
+    refine pow_ne_one_of_coroot'_left_ne P i j 3 ?_
+    rw [coroot'_left_pow_three_smul_root, h]
+    norm_num
+  refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
+    (pow_six_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
+  have hp' : p = 2 ∨ p = 3 := by
+    rw [show (6 : ℕ) = 2 * 3 by norm_num] at hpd
+    rcases (Nat.Prime.dvd_mul hp).mp hpd with h' | h'
+    · exact Or.inl ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp h')
+    · exact Or.inr ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp h')
+  rcases hp' with rfl | rfl
+  · exact hne₃
+  · exact hne₂
+
+end LowerBound
+
+/-! ## The entries of the Coxeter matrix of a base -/
+
+section Base
+
+variable [Finite ι] [CharZero R] [IsDomain R] [P.IsCrystallographic] (b : P.Base)
+
+omit [Finite ι] [CharZero R] [IsDomain R] in
+private lemma pairing_mul_pairing_eq_cast (k l : b.support) :
+    P.pairing k l * P.pairing l k =
+      ((b.cartanMatrix k l * b.cartanMatrix l k : ℤ) : R) := by
+  have hk : ∀ m n : b.support, ((b.cartanMatrix m n : ℤ) : R) = P.pairing m n := fun m n ↦ by
+    simpa using b.algebraMap_cartanMatrixIn_apply (S := ℤ) m n
+  push_cast
+  rw [hk, hk]
+
+/-- **The entries of the Coxeter matrix of a base are the orders of the products of the
+corresponding simple reflections.** On the diagonal both sides are `1`, a simple reflection being
+an involution; off the diagonal the four Cartan products `0`, `1`, `2`, `3` give the four dihedral
+orders `2`, `3`, `4`, `6`. -/
+theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
+    orderOf (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
+      _root_.RootPairing.weylGroup.ofIdx P (l : ι)) = coxeterMatrixOfBase P b k l := by
+  rcases eq_or_ne k l with rfl | hkl
+  · rw [ofIdx_mul_self, orderOf_one]
+    simp
+  have hmem := cartanMatrix_mul_cartanMatrix_mem_of_ne P b hkl
+  have hcast := pairing_mul_pairing_eq_cast P b k l
+  simp only [mem_insert_iff, mem_singleton_iff] at hmem
+  rcases hmem with hc | hc | hc | hc <;> rw [hc] at hcast <;> push_cast at hcast
+  · have h₂ : coxeterMatrixOfBase P b k l = 2 := by
+      rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_zero]
+    rw [h₂]
+    exact orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two P b h₂
+  · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_one]
+    exact orderOf_ofIdx_mul_ofIdx_eq_three P _ _ hcast
+  · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_two]
+    exact orderOf_ofIdx_mul_ofIdx_eq_four P _ _ hcast
+  · rw [coxeterMatrixOfBase_apply, hc, coxeterOrder_three]
+    exact orderOf_ofIdx_mul_ofIdx_eq_six P _ _ hcast
+
+/-- **The braid relations of the Coxeter matrix of a base hold in the Weyl group.** This is the
+relation half of the Coxeter presentation of the Weyl group. -/
+theorem pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one (k l : b.support) :
+    (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
+      _root_.RootPairing.weylGroup.ofIdx P (l : ι)) ^ coxeterMatrixOfBase P b k l = 1 := by
+  rw [← orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase P b k l, pow_orderOf_eq_one]
+
+end Base
+
+end RootPairing.weylGroup
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -83,45 +83,6 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
 
 /-! ## The rank-two computation -/
 
-/-- **The product of two reflections on the weight space.** The product changes `x` by an element
-of the span of the two roots, with coefficients recorded by the two coroot functionals. -/
-@[grind =]
-theorem ofIdx_mul_ofIdx_smul (x : M) :
-    (_root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j) • x =
-      x - P.coroot' j x • P.root j -
-        (P.coroot' i x - P.pairing j i * P.coroot' j x) • P.root i := by
-  rw [mul_smul]
-  simp only [_root_.RootPairing.weylGroup.ofIdx_smul, _root_.RootPairing.Equiv.reflection_smul,
-    _root_.RootPairing.reflection_apply, map_sub, map_smul,
-    _root_.RootPairing.root_coroot'_eq_pairing]
-  module
-
-/-- The `αᵢ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. -/
-@[grind =]
-theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
-    P.coroot' i ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) • x) =
-      P.pairing j i * P.coroot' j x - P.coroot' i x := by
-  rw [ofIdx_mul_ofIdx_smul]
-  simp only [map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
-    _root_.RootPairing.pairing_same]
-  ring
-
-/-- The `αⱼ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. Together with
-`TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the action
-on the two coroot coordinates: determinant `1` and trace `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`, the value at
-which `TauCeti.RootPairing.weylGroup.pow_ofIdx_mul_ofIdx_smul` evaluates its Chebyshev
-polynomials. -/
-@[grind =]
-theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
-    P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
-        _root_.RootPairing.weylGroup.ofIdx P j) • x) =
-      (P.pairing i j * P.pairing j i - 1) * P.coroot' j x - P.pairing i j * P.coroot' i x := by
-  rw [ofIdx_mul_ofIdx_smul]
-  simp only [map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
-    _root_.RootPairing.pairing_same]
-  ring
-
 /-- The action of an iterate of the product of the two reflections is the action of the
 corresponding iterate of the product of the two linear reflections. -/
 private lemma pow_ofIdx_mul_ofIdx_smul_eq (n : ℕ) (x : M) :

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -77,18 +77,6 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
   [CommRing R] [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
   (P : RootPairing ι R M N) (i j : ι)
 
-/-! ## Faithfulness of the weight-space action -/
-
-variable {P} in
-/-- A Weyl-group element acting trivially on the weight space is the identity: the weight-space
-representation of the automorphism group of a root pairing is faithful. -/
-theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : w = 1 := by
-  have hw : (w : P.Aut) = 1 := by
-    refine _root_.RootPairing.Equiv.weightHom_injective P ?_
-    rw [map_one]
-    exact LinearEquiv.ext fun x ↦ h x
-  exact Subtype.ext (by simpa using hw)
-
 /-! ## The rank-two computation -/
 
 /-- **The product of two reflections on the weight space.** The two reflections move `x` inside the

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -11,21 +11,23 @@ public section
 /-!
 # The order of a product of two simple reflections
 
-The product of the reflections in two roots `αᵢ`, `αⱼ` acts on the weight space as a rotation of
-the plane they span, and as the identity transverse to it. Its order is therefore read off the
-Cartan product `c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the values `0`, `1`, `2`, `3` give the orders `2`, `3`,
-`4`, `6`. This file proves that, so the entries of `TauCeti.coxeterMatrixOfBase` really are the
-orders they are named for, and the braid relations of the Coxeter presentation of a Weyl group hold
-in the Weyl group.
+The product of the reflections in two roots `αᵢ`, `αⱼ` moves every weight inside the span of the
+two roots, and its order is therefore read off the Cartan product `c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the
+values `1`, `2`, `3` give the orders `3`, `4`, `6`. This file proves that, and — for two simple
+roots of a base of a finite crystallographic pairing, where `c = 0` is the remaining possibility
+and gives the order `2` — that the entries of `TauCeti.coxeterMatrixOfBase` really are the orders
+they are named for, so that the braid relations of the Coxeter presentation of a Weyl group hold in
+the Weyl group.
 
 The route is elementary and diagonalises nothing. Writing `g` for the product of the two
-reflections, `g` fixes the intersection of the two reflecting hyperplanes pointwise and preserves
-the plane spanned by the two roots, where it has determinant `1` and trace `c - 2`. So `g` is
-annihilated by the cubic `(X - 1)(X² - (c - 2)X + 1)`, which
+reflections, `g` fixes the common kernel of the two coroots pointwise, and on the two coroot
+coordinates it acts with determinant `1` and trace `c - 2`. So `g` is annihilated by the cubic
+`(X - 1)(X² - (c - 2)X + 1)`, which
 `TauCeti.RootPairing.weylGroup.pow_add_three_ofIdx_mul_ofIdx_smul` states as a three-term
 recursion for the iterates of `g`. Substituting `c = 1, 2, 3` and chasing the recursion a few steps
 gives `g³ = 1`, `g⁴ = 1`, `g⁶ = 1`; the remaining value `c = 0` is the orthogonal case, already
-settled in `TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix`, where the two reflections commute.
+settled in `TauCeti.LinearAlgebra.RootSystem.CoxeterMatrix`, where the two reflections commute, and
+where the order is pinned to `2` only for two distinct simple roots of a base.
 
 That the order is no smaller is checked on the single vector `αᵢ`: its `αᵢ^∨`-coordinate along the
 orbit of `g` is a polynomial in `c`, and for the relevant powers that polynomial avoids the value
@@ -90,7 +92,7 @@ theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : 
 /-! ## The rank-two computation -/
 
 /-- **The product of two reflections on the weight space.** The two reflections move `x` inside the
-plane spanned by the two roots, by an amount recorded by the two coroot functionals. -/
+span of the two roots, by an amount recorded by the two coroot functionals. -/
 theorem ofIdx_mul_ofIdx_smul (x : M) :
     (_root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j) • x =
       x - P.coroot' j x • P.root j -
@@ -112,9 +114,8 @@ theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
   ring
 
 /-- The `αⱼ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. Together with
-`TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the
-rotation on the plane of the two roots: determinant `1` and trace
-`⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
+`TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the action
+on the two coroot coordinates: determinant `1` and trace `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
 theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
     P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) • x) =
@@ -124,9 +125,9 @@ theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
     _root_.RootPairing.pairing_same]
   ring
 
-/-- **The cubic annihilating a product of two reflections.** The product fixes the intersection of
-the two reflecting hyperplanes and acts on the plane of the two roots with determinant `1` and
-trace `c - 2`, so it is annihilated by `(X - 1)(X² - (c - 2)X + 1)`. -/
+/-- **The cubic annihilating a product of two reflections.** The product fixes the common kernel of
+the two coroots and acts on the two coroot coordinates with determinant `1` and trace `c - 2`, so
+it is annihilated by `(X - 1)(X² - (c - 2)X + 1)`. -/
 theorem pow_three_ofIdx_mul_ofIdx_smul (x : M) :
     ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • x =
@@ -137,13 +138,14 @@ theorem pow_three_ofIdx_mul_ofIdx_smul (x : M) :
           ((_root_.RootPairing.weylGroup.ofIdx P i *
             _root_.RootPairing.weylGroup.ofIdx P j) • x) + x := by
   have hA := ofIdx_mul_ofIdx_smul P i j
-  have hL := coroot'_left_ofIdx_mul_ofIdx_smul P i j
-  have hR := coroot'_right_ofIdx_mul_ofIdx_smul P i j
   set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
   have h2 : ∀ y : M, (g ^ 2) • y = g • (g • y) := fun y ↦ by rw [sq, mul_smul]
-  have h3 : (g ^ 3) • x = g • (g • (g • x)) := by
-    rw [show (3 : ℕ) = 2 + 1 from rfl, pow_succ', mul_smul, h2]
-  rw [h3, h2, hA (g • (g • x)), hL (g • x), hR (g • x), hL x, hR x, hA (g • x), hL x, hR x, hA x]
+  have h3 : (g ^ 3) • x = g • (g • (g • x)) := by rw [pow_succ', mul_smul, h2]
+  -- Unfold the three applications of `g`, expand the coroot functionals of the results, and
+  -- compare the coefficients of `x`, `αᵢ` and `αⱼ` on the two sides.
+  rw [h3, h2]
+  simp only [hA, map_sub, map_smul, smul_eq_mul, _root_.RootPairing.root_coroot'_eq_pairing,
+    _root_.RootPairing.pairing_same]
   module
 
 /-- **The three-term recursion for the iterates of a product of two reflections**, obtained by
@@ -160,16 +162,15 @@ theorem pow_add_three_ofIdx_mul_ofIdx_smul (n : ℕ) (x : M) :
         ((_root_.RootPairing.weylGroup.ofIdx P i *
           _root_.RootPairing.weylGroup.ofIdx P j) ^ n) • x := by
   set g := _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j
-  have key : ∀ m : ℕ, (g ^ (m + n)) • x = (g ^ m) • ((g ^ n) • x) := fun m ↦ by
-    rw [pow_add, mul_smul]
-  rw [show n + 3 = 3 + n from Nat.add_comm n 3, show n + 2 = 2 + n from Nat.add_comm n 2,
-    show n + 1 = 1 + n from Nat.add_comm n 1, key 3, key 2, key 1, pow_one]
+  have key : ∀ m : ℕ, (g ^ (n + m)) • x = (g ^ m) • ((g ^ n) • x) := fun m ↦ by
+    rw [add_comm n m, pow_add, mul_smul]
+  rw [key 3, key 2, key 1, pow_one]
   exact pow_three_ofIdx_mul_ofIdx_smul P i j ((g ^ n) • x)
 
 /-! ## The braid relations -/
 
-/-- **The braid relation at Cartan product `1`**: the product of the two reflections is a rotation
-of order dividing `3`, the `A₂` configuration. -/
+/-- **The braid relation at Cartan product `1`**: the product of the two reflections has order
+dividing `3`, the `A₂` configuration. -/
 theorem pow_three_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 1) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 3 = 1 := by
@@ -186,8 +187,8 @@ theorem pow_three_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 1)
     _root_.RootPairing.weylGroup.ofIdx P j) • x = z
   module
 
-/-- **The braid relation at Cartan product `2`**: the product of the two reflections is a rotation
-of order dividing `4`, the `B₂` configuration. -/
+/-- **The braid relation at Cartan product `2`**: the product of the two reflections has order
+dividing `4`, the `B₂` configuration. -/
 theorem pow_four_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 2) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 4 = 1 := by
@@ -205,8 +206,8 @@ theorem pow_four_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 2) 
     _root_.RootPairing.weylGroup.ofIdx P j) • x = z
   module
 
-/-- **The braid relation at Cartan product `3`**: the product of the two reflections is a rotation
-of order dividing `6`, the `G₂` configuration. -/
+/-- **The braid relation at Cartan product `3`**: the product of the two reflections has order
+dividing `6`, the `G₂` configuration. -/
 theorem pow_six_ofIdx_mul_ofIdx_eq_one (h : P.pairing i j * P.pairing j i = 3) :
     (_root_.RootPairing.weylGroup.ofIdx P i *
       _root_.RootPairing.weylGroup.ofIdx P j) ^ 6 = 1 := by
@@ -281,7 +282,7 @@ private lemma coroot'_left_pow_three_smul_root :
         _root_.RootPairing.weylGroup.ofIdx P j) ^ 3) • P.root i) =
       (P.pairing i j * P.pairing j i) ^ 3 - 6 * (P.pairing i j * P.pairing j i) ^ 2 +
         9 * (P.pairing i j * P.pairing j i) - 2 := by
-  rw [show (3 : ℕ) = 2 + 1 from rfl, pow_succ', mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul,
+  rw [pow_succ', mul_smul, coroot'_left_ofIdx_mul_ofIdx_smul,
     coroot'_left_pow_two_smul_root, coroot'_right_pow_two_smul_root]
   ring
 
@@ -314,8 +315,8 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_four (h : P.pairing i j * P.pairing j i = 2) 
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
     (pow_four_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 := by
-    rw [show (4 : ℕ) = 2 ^ 2 by norm_num] at hpd
-    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd)
+    have hpd' : p ∣ 2 ^ 2 := by simpa using hpd
+    exact (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow hpd')
   subst hp'
   exact hne
 
@@ -336,8 +337,8 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_six (h : P.pairing i j * P.pairing j i = 3) :
   refine orderOf_eq_of_pow_and_pow_div_prime (by norm_num)
     (pow_six_ofIdx_mul_ofIdx_eq_one P i j h) fun p hp hpd ↦ ?_
   have hp' : p = 2 ∨ p = 3 := by
-    rw [show (6 : ℕ) = 2 * 3 by norm_num] at hpd
-    rcases (Nat.Prime.dvd_mul hp).mp hpd with h' | h'
+    have hpd' : p ∣ 2 * 3 := by simpa using hpd
+    rcases (Nat.Prime.dvd_mul hp).mp hpd' with h' | h'
     · exact Or.inl ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp h')
     · exact Or.inr ((Nat.prime_dvd_prime_iff_eq hp Nat.prime_three).mp h')
   rcases hp' with rfl | rfl
@@ -365,6 +366,7 @@ private lemma pairing_mul_pairing_eq_cast (k l : b.support) :
 corresponding simple reflections.** On the diagonal both sides are `1`, a simple reflection being
 an involution; off the diagonal the four Cartan products `0`, `1`, `2`, `3` give the four dihedral
 orders `2`, `3`, `4`, `6`. -/
+@[simp]
 theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) = coxeterMatrixOfBase P b k l := by

--- a/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean
@@ -11,13 +11,13 @@ public section
 /-!
 # The order of a product of two simple reflections
 
-The product of the reflections in two roots `αᵢ`, `αⱼ` moves every weight inside the span of the
-two roots, and its order is therefore read off the Cartan product `c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the
-values `1`, `2`, `3` give the orders `3`, `4`, `6`. This file proves that, and — for two simple
-roots of a base of a finite crystallographic pairing, where `c = 0` is the remaining possibility
-and gives the order `2` — that the entries of `TauCeti.coxeterMatrixOfBase` really are the orders
-they are named for, so that the braid relations of the Coxeter presentation of a Weyl group hold in
-the Weyl group.
+The product of the reflections in two roots `αᵢ`, `αⱼ` changes every weight by an element of the
+span of the two roots, and its order is therefore read off the Cartan product
+`c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩`: the values `1`, `2`, `3` give the orders `3`, `4`, `6`. This file
+proves that, and — for two simple roots of a base of a finite crystallographic pairing, where
+`c = 0` is the remaining possibility and gives the order `2` — that the entries of
+`TauCeti.coxeterMatrixOfBase` really are the orders they are named for, so that the braid relations
+of the Coxeter presentation of a Weyl group hold in the Weyl group.
 
 The route is elementary and diagonalises nothing. Writing `g` for the product of the two
 reflections, `g` fixes the common kernel of the two coroots pointwise, and on the two coroot
@@ -79,8 +79,9 @@ variable {ι : Type u} {R : Type v} {M : Type w} {N : Type x}
 
 /-! ## The rank-two computation -/
 
-/-- **The product of two reflections on the weight space.** The two reflections move `x` inside the
-span of the two roots, by an amount recorded by the two coroot functionals. -/
+/-- **The product of two reflections on the weight space.** The product changes `x` by an element
+of the span of the two roots, with coefficients recorded by the two coroot functionals. -/
+@[grind =]
 theorem ofIdx_mul_ofIdx_smul (x : M) :
     (_root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P j) • x =
       x - P.coroot' j x • P.root j -
@@ -92,6 +93,7 @@ theorem ofIdx_mul_ofIdx_smul (x : M) :
   module
 
 /-- The `αᵢ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. -/
+@[grind =]
 theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
     P.coroot' i ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) • x) =
@@ -104,6 +106,7 @@ theorem coroot'_left_ofIdx_mul_ofIdx_smul (x : M) :
 /-- The `αⱼ^∨`-coordinate of the product of the reflections in `αᵢ` and `αⱼ`. Together with
 `TauCeti.RootPairing.weylGroup.coroot'_left_ofIdx_mul_ofIdx_smul` this is the matrix of the action
 on the two coroot coordinates: determinant `1` and trace `⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩ - 2`. -/
+@[grind =]
 theorem coroot'_right_ofIdx_mul_ofIdx_smul (x : M) :
     P.coroot' j ((_root_.RootPairing.weylGroup.ofIdx P i *
         _root_.RootPairing.weylGroup.ofIdx P j) • x) =
@@ -354,7 +357,7 @@ private lemma pairing_mul_pairing_eq_cast (k l : b.support) :
 corresponding simple reflections.** On the diagonal both sides are `1`, a simple reflection being
 an involution; off the diagonal the four Cartan products `0`, `1`, `2`, `3` give the four dihedral
 orders `2`, `3`, `4`, `6`. -/
-@[simp]
+@[simp, grind =]
 theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
     orderOf (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) = coxeterMatrixOfBase P b k l := by
@@ -377,7 +380,10 @@ theorem orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase (k l : b.support) :
     exact orderOf_ofIdx_mul_ofIdx_eq_six P _ _ hcast
 
 /-- **The braid relations of the Coxeter matrix of a base hold in the Weyl group.** This is the
-relation half of the Coxeter presentation of the Weyl group. -/
+relation half of the Coxeter presentation of the Weyl group. It is not a `simp` lemma: its
+left-hand side is not in simp normal form, because the exponent `coxeterMatrixOfBase P b k l` is
+itself rewritten by `TauCeti.coxeterMatrixOfBase_apply`. -/
+@[grind =]
 theorem pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one (k l : b.support) :
     (_root_.RootPairing.weylGroup.ofIdx P (k : ι) *
       _root_.RootPairing.weylGroup.ofIdx P (l : ι)) ^ coxeterMatrixOfBase P b k l = 1 := by

--- a/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean
@@ -15,7 +15,8 @@ This file proves that the action of the automorphism group of a root system on i
 faithful.  Consequently, every subgroup of that automorphism group, and in particular the Weyl
 group, is finite when the root index type is finite.  It also records how that action evaluates on
 simple reflections, how it interacts with root negation, and the sign change a reflection induces
-on its own coroot functional.
+on its own coroot functional.  Alongside it, the weight-space action of the Weyl group is faithful,
+with no spanning hypothesis needed.
 
 ## Main results
 
@@ -26,6 +27,8 @@ on its own coroot functional.
 * `TauCeti.RootPairing.weylGroupToPerm_ofIdx_apply` evaluates the action of a simple reflection.
 * `TauCeti.RootPairing.weylGroupToPerm_neg` says the action commutes with root negation.
 * `TauCeti.RootPairing.weylGroup.ofIdx_mul_self` says a simple reflection is an involution.
+* `TauCeti.RootPairing.weylGroup.eq_one_of_smul_eq_self` says a Weyl-group element acting trivially
+  on the weight space is the identity.
 * `TauCeti.RootPairing.weylGroup.commute_ofIdx_of_isOrthogonal` says orthogonal roots have
   commuting reflections.
 * `TauCeti.RootPairing.finite_subgroup_aut` proves that every subgroup of the automorphism group of
@@ -154,6 +157,16 @@ lemma ofIdx_inv_eq (i : ι) :
 lemma ofIdx_mul_self (i : ι) :
     _root_.RootPairing.weylGroup.ofIdx P i * _root_.RootPairing.weylGroup.ofIdx P i = 1 := by
   rw [mul_eq_one_iff_eq_inv, ofIdx_inv_eq]
+
+variable {P} in
+/-- A Weyl-group element acting trivially on the weight space is the identity: the weight-space
+representation of the automorphism group of a root pairing is faithful. -/
+theorem eq_one_of_smul_eq_self {w : P.weylGroup} (h : ∀ x : M, w • x = x) : w = 1 := by
+  have hw : (w : P.Aut) = 1 := by
+    refine _root_.RootPairing.Equiv.weightHom_injective P ?_
+    rw [map_one]
+    exact LinearEquiv.ext fun x ↦ h x
+  exact Subtype.ext (by simpa using hw)
 
 /-- **Orthogonal roots have commuting reflections** in the Weyl group. -/
 theorem commute_ofIdx_of_isOrthogonal {i j : ι} (h : P.IsOrthogonal i j) :


### PR DESCRIPTION
This PR computes the order of a product of two simple reflections in a Weyl group, proving that the entries of `TauCeti.coxeterMatrixOfBase` really are the orders they are named for, and hence that the braid relations of the Coxeter presentation hold in the Weyl group.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"order-of-product-of-two-simple-reflections"}-->

Roadmap: RepresentationTheory

The target is the first item of Layer 2 of `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, "the **order of a product of simple reflections** and the **Coxeter matrix of a base** (`coxeterMatrixOfBase`)", and the input that layer's summit needs: "The braid relations `(sᵢ sⱼ)^{m i j} = 1` hold in `W` (from `coxeterMatrixOfBase`)". `TauCeti/LinearAlgebra/RootSystem/CoxeterMatrix.lean` already builds `coxeterMatrixOfBase` and checks the single entry `2`, recording in the docstring of `coxeterMatrixOfBase` that "that the entries really are those orders is the classical rank-two computation, and follows in general from the Coxeter presentation of the Weyl group, which is not built here". This PR supplies that rank-two computation directly, so no part of it waits on `weylCoxeterSystem`.

`TauCeti/LinearAlgebra/RootSystem/BraidRelation.lean` (400 lines) works with the product `g` of the reflections in two arbitrary roots `αᵢ`, `αⱼ` of an arbitrary root pairing, the Cartan product `c = ⟨αᵢ, αⱼ^∨⟩⟨αⱼ, αᵢ^∨⟩` entering only as a hypothesis on `RootPairing.pairing`; no finiteness, crystallographic or reducedness assumption is used until the final section.

- `ofIdx_mul_ofIdx_smul` writes `g • x` in terms of the two coroot functionals, and `coroot'_left_ofIdx_mul_ofIdx_smul`, `coroot'_right_ofIdx_mul_ofIdx_smul` compute those functionals on `g • x`. Together they say `g` acts on the plane of the two roots with determinant `1` and trace `c - 2`, and fixes the intersection of the two reflecting hyperplanes.
- `pow_three_ofIdx_mul_ofIdx_smul` is the resulting cubic `(X - 1)(X² - (c - 2)X + 1)` annihilating `g`, and `pow_add_three_ofIdx_mul_ofIdx_smul` restates it as a three-term recursion for the iterates `gⁿ • x`. Chasing that recursion a few steps with `c = 1, 2, 3` gives `pow_three_ofIdx_mul_ofIdx_eq_one`, `pow_four_ofIdx_mul_ofIdx_eq_one` and `pow_six_ofIdx_mul_ofIdx_eq_one`; the remaining value `c = 0` is the orthogonal case, where the existing `commute_ofIdx_of_isOrthogonal` already applies.
- That the order is no smaller is read off the single vector `αᵢ`, whose `αᵢ^∨`-coordinate along the orbit of `g` is a polynomial in `c` avoiding the value `⟨αᵢ, αᵢ^∨⟩ = 2` for the relevant powers, giving `orderOf_ofIdx_mul_ofIdx_eq_three`, `orderOf_ofIdx_mul_ofIdx_eq_four` and `orderOf_ofIdx_mul_ofIdx_eq_six`.
- `eq_one_of_smul_eq_self` is the small faithfulness step the relations are proved through: a Weyl-group element acting trivially on the weight space is the identity, by Mathlib's `RootPairing.Equiv.weightHom_injective`. It needs no spanning hypothesis, unlike the index-level `weylGroupToPerm_injective` already in `TauCeti/LinearAlgebra/RootSystem/WeylGroup.lean`.
- The last section specialises to a pair of simple roots, where `cartanMatrix_mul_cartanMatrix_mem_of_ne` confines the Cartan product to `{0, 1, 2, 3}`: `orderOf_ofIdx_mul_ofIdx_eq_coxeterMatrixOfBase` covers all four values and the diagonal, reusing `orderOf_ofIdx_mul_ofIdx_eq_two_of_coxeterMatrixOfBase_eq_two` for the orthogonal entry, and `pow_coxeterMatrixOfBase_ofIdx_mul_ofIdx_eq_one` is the braid relation it yields.

The argument is the classical rank-two one of Bourbaki, *Lie Groups and Lie Algebras*, Chapters 4-6, Ch. VI, §1.3, and Humphreys, *Introduction to Lie Algebras and Representation Theory*, §9, arranged so that the case analysis lives entirely in the scalar recursion rather than in four separate vector computations.

No Mathlib infrastructure was vendored, and no material was taken from the supplementary source snapshot.

`lake build` and `lake exe axioms` are green (`axioms: audited 17712 TauCeti declaration(s); all within the allowlist`), and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Claude Code
