### PR TITLE
feat: add uniform local connectedness and its Carathéodory boundary corollaries

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
+++ b/TauCeti/Analysis/Complex/Conformal/JordanDomain.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.BoundaryCorrespondence
 public import TauCeti.Topology.JordanCurve
+public import TauCeti.Topology.UniformlyLocallyConnected
 import Mathlib.Analysis.Normed.Module.Connected
 import TauCeti.Analysis.Complex.Conformal.Biholomorph
 
@@ -54,6 +55,8 @@ are.
   locally connected, which is the hypothesis the *hard* direction of the L5 milestone runs on:
   Carathéodory's continuity theorem produces a continuous extension of the Riemann map exactly for
   a locally connected boundary.
+* `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier` — the same hypothesis in the
+  uniform `ε`–`δ` form that proof actually consumes, available because the boundary is compact.
 * `TauCeti.isJordanCurve_frontier_of_isJordanCurve_frontier_image`,
   `TauCeti.isJordanDomain_of_isJordanCurve_frontier_image` and
   `TauCeti.isJordanDomain_of_image_eq_ball` — **the converse half of the Carathéodory
@@ -148,6 +151,21 @@ boundary — is `TauCeti.locallyConnectedSpace_frontier_image` in
 theorem IsJordanDomain.locallyConnectedSpace_frontier (h : IsJordanDomain U) :
     LocallyConnectedSpace (frontier U) :=
   h.isJordanCurve_frontier.locallyConnectedSpace
+
+/-- **The boundary of a Jordan domain is uniformly locally connected**: nearby boundary points are
+joined by connected subsets of the boundary that are small at a rate independent of where they sit.
+
+This is `TauCeti.IsJordanDomain.locallyConnectedSpace_frontier` upgraded by
+`TauCeti.IsCompact.isUniformlyLocallyConnected`, the upgrade costing nothing because the boundary
+of a bounded set is compact. The uniform form is what the hard direction of the L5 milestone
+consumes: Carathéodory's continuity theorem controls the image of a crosscut by joining its two
+boundary endpoints inside a small connected piece of `frontier U`, and the estimate has to be
+uniform over all crosscuts at once. -/
+theorem IsJordanDomain.isUniformlyLocallyConnected_frontier (h : IsJordanDomain U) :
+    IsUniformlyLocallyConnected (frontier U) :=
+  haveI := h.locallyConnectedSpace_frontier
+  IsCompact.isUniformlyLocallyConnected
+    (h.isCompact_closure.of_isClosed_subset isClosed_frontier frontier_subset_closure)
 
 /-- A Jordan domain is not all of `ℂ`. -/
 theorem IsJordanDomain.ne_univ (h : IsJordanDomain U) : U ≠ univ := by

--- a/TauCeti/Analysis/Complex/Conformal/LocallyConnectedBoundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocallyConnectedBoundary.lean
@@ -18,6 +18,12 @@ if** `∂Ω` is locally connected. This file proves the "only if" half, the half
 hypothesis on the boundary at all: local connectedness is *carried along* by any continuous
 extension, so a domain whose boundary is not locally connected admits no such extension.
 
+Each conclusion comes in two forms. The pointwise one is `LocallyConnectedSpace`; the uniform one,
+`TauCeti.IsUniformlyLocallyConnected`, asks for a single `δ` per `ε` joining any two nearby points
+by a small connected subset, and is what an argument ranging over the whole boundary at once needs.
+The two agree on a compact set (`TauCeti.IsCompact.isUniformlyLocallyConnected_iff`), and every set
+appearing below is compact, so each result is recorded in both forms.
+
 The mechanism is purely topological and is isolated in `TauCeti/Topology/LocallyConnected.lean`:
 local connectedness is not preserved by continuous images in general, but it is preserved by
 quotient maps, and a continuous map of a compact space into a Hausdorff one is a quotient map onto
@@ -58,6 +64,11 @@ topological spaces.
   `TauCeti.locallyConnectedSpace_frontier_image_ball` — the Riemann-map case: if a conformal map on
   the unit disc extends continuously to the closed disc, the closure and the boundary of its image
   are locally connected.
+* `TauCeti.isUniformlyLocallyConnected_closure_image`,
+  `TauCeti.isUniformlyLocallyConnected_frontier_image`,
+  `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier_image` and
+  `TauCeti.isUniformlyLocallyConnected_frontier_image_ball` — the same four statements in the
+  uniform `ε`–`δ` form, the images in question being compact.
 
 ## Coordination with upstream Mathlib
 
@@ -164,5 +175,54 @@ theorem locallyConnectedSpace_frontier_image_ball (hfd : DifferentiableOn ℂ f 
     LocallyConnectedSpace (frontier (f '' ball (0 : ℂ) 1)) :=
   have hcl : closure (ball (0 : ℂ) 1) = closedBall 0 1 := closure_ball (0 : ℂ) one_ne_zero
   (isJordanDomain_ball 0 one_pos).locallyConnectedSpace_frontier_image hfd hfi (hcl ▸ hFc) hFf
+
+/-! ## The uniform form -/
+
+/-- **A continuous extension carries a uniformly locally connected closure to a uniformly locally
+connected closure.** The uniform companion of `TauCeti.locallyConnectedSpace_closure_image`: the
+image closure is compact, being `F '' closure U`, so the two forms of local connectedness agree on
+it. -/
+theorem isUniformlyLocallyConnected_closure_image [LocallyConnectedSpace (closure U)]
+    (hUb : Bornology.IsBounded U) (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) :
+    IsUniformlyLocallyConnected (closure (f '' U)) := by
+  have hcpt : IsCompact (closure (f '' U)) :=
+    image_closure_eq_closure_image hUb hFc hFf ▸ hUb.isCompact_closure.image_of_continuousOn hFc
+  haveI := locallyConnectedSpace_closure_image hUb hFc hFf
+  exact IsCompact.isUniformlyLocallyConnected hcpt
+
+/-- **A continuous extension carries a uniformly locally connected boundary to a uniformly locally
+connected boundary.** The uniform companion of `TauCeti.locallyConnectedSpace_frontier_image`, and
+the form in which the necessary half of Carathéodory's continuity theorem is used: the image
+boundary is compact, being `F '' frontier U` by
+`TauCeti.image_frontier_eq_frontier_image`, so the two forms of local connectedness agree on it. -/
+theorem isUniformlyLocallyConnected_frontier_image [LocallyConnectedSpace (frontier U)]
+    (hUo : IsOpen U) (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U)
+    (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) :
+    IsUniformlyLocallyConnected (frontier (f '' U)) := by
+  have hcpt : IsCompact (frontier (f '' U)) := by
+    rw [← image_frontier_eq_frontier_image hUo hUb hfd hfi hFc hFf]
+    exact (hUb.isCompact_closure.of_isClosed_subset isClosed_frontier
+      frontier_subset_closure).image_of_continuousOn (hFc.mono frontier_subset_closure)
+  haveI := locallyConnectedSpace_frontier_image hUo hUb hfd hfi hFc hFf
+  exact IsCompact.isUniformlyLocallyConnected hcpt
+
+/-- **A conformal map of a Jordan domain that extends continuously has uniformly locally connected
+image boundary.** The uniform companion of
+`TauCeti.IsJordanDomain.locallyConnectedSpace_frontier_image`; as there, the source-side hypothesis
+is discharged by `TauCeti.IsJordanDomain.locallyConnectedSpace_frontier`. -/
+theorem IsJordanDomain.isUniformlyLocallyConnected_frontier_image (hU : IsJordanDomain U)
+    (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U) (hFc : ContinuousOn F (closure U))
+    (hFf : EqOn F f U) : IsUniformlyLocallyConnected (frontier (f '' U)) :=
+  haveI := hU.locallyConnectedSpace_frontier
+  _root_.TauCeti.isUniformlyLocallyConnected_frontier_image hU.isOpen hU.isBounded hfd hfi hFc hFf
+
+/-- **The boundary of the image of a Riemann map with a continuous extension is uniformly locally
+connected.** The uniform companion of `TauCeti.locallyConnectedSpace_frontier_image_ball`. -/
+theorem isUniformlyLocallyConnected_frontier_image_ball (hfd : DifferentiableOn ℂ f (ball 0 1))
+    (hfi : InjOn f (ball 0 1)) (hFc : ContinuousOn F (closedBall 0 1))
+    (hFf : EqOn F f (ball 0 1)) :
+    IsUniformlyLocallyConnected (frontier (f '' ball (0 : ℂ) 1)) :=
+  have hcl : closure (ball (0 : ℂ) 1) = closedBall 0 1 := closure_ball (0 : ℂ) one_ne_zero
+  (isJordanDomain_ball 0 one_pos).isUniformlyLocallyConnected_frontier_image hfd hfi (hcl ▸ hFc) hFf
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/LocallyConnectedBoundary.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LocallyConnectedBoundary.lean
@@ -27,10 +27,11 @@ appearing below is compact, so each result is recorded in both forms.
 The mechanism is purely topological and is isolated in `TauCeti/Topology/LocallyConnected.lean`:
 local connectedness is not preserved by continuous images in general, but it is preserved by
 quotient maps, and a continuous map of a compact space into a Hausdorff one is a quotient map onto
-its image. `Conformal/BoundaryCorrespondence.lean` has already identified the two images in
-question — a continuous extension `F` of a conformal map carries `closure U` onto
-`closure (f '' U)` and `frontier U` onto `frontier (f '' U)` — so all that remains is to feed those
-identifications the compactness that boundedness of `U` provides.
+its image; its uniform companion `TauCeti.isUniformlyLocallyConnected_image_of_isCompact` is in
+`TauCeti/Topology/UniformlyLocallyConnected.lean`. `Conformal/BoundaryCorrespondence.lean` has
+already identified the two images in question — a continuous extension `F` of a conformal map
+carries `closure U` onto `closure (f '' U)` and `frontier U` onto `frontier (f '' U)` — so all that
+remains is to feed those identifications the compactness that boundedness of `U` provides.
 
 For a Jordan domain the source side of the hypothesis is automatic, its boundary being a Jordan
 curve, and the Riemann map is the case of the disc: so the Jordan-domain corollary below, and the
@@ -66,8 +67,9 @@ topological spaces.
   are locally connected.
 * `TauCeti.isUniformlyLocallyConnected_closure_image`,
   `TauCeti.isUniformlyLocallyConnected_frontier_image`,
-  `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier_image` and
-  `TauCeti.isUniformlyLocallyConnected_frontier_image_ball` — the same four statements in the
+  `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier_image`,
+  `TauCeti.isUniformlyLocallyConnected_closure_image_ball` and
+  `TauCeti.isUniformlyLocallyConnected_frontier_image_ball` — the same five statements in the
   uniform `ε`–`δ` form, the images in question being compact.
 
 ## Coordination with upstream Mathlib
@@ -179,32 +181,29 @@ theorem locallyConnectedSpace_frontier_image_ball (hfd : DifferentiableOn ℂ f 
 /-! ## The uniform form -/
 
 /-- **A continuous extension carries a uniformly locally connected closure to a uniformly locally
-connected closure.** The uniform companion of `TauCeti.locallyConnectedSpace_closure_image`: the
-image closure is compact, being `F '' closure U`, so the two forms of local connectedness agree on
-it. -/
+connected closure.** The uniform companion of `TauCeti.locallyConnectedSpace_closure_image`,
+obtained from the same identification of `closure (f '' U)` with `F '' closure U` and the general
+`TauCeti.isUniformlyLocallyConnected_image_of_isCompact`. -/
 theorem isUniformlyLocallyConnected_closure_image [LocallyConnectedSpace (closure U)]
     (hUb : Bornology.IsBounded U) (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) :
     IsUniformlyLocallyConnected (closure (f '' U)) := by
-  have hcpt : IsCompact (closure (f '' U)) :=
-    image_closure_eq_closure_image hUb hFc hFf ▸ hUb.isCompact_closure.image_of_continuousOn hFc
-  haveI := locallyConnectedSpace_closure_image hUb hFc hFf
-  exact IsCompact.isUniformlyLocallyConnected hcpt
+  rw [← image_closure_eq_closure_image hUb hFc hFf]
+  exact isUniformlyLocallyConnected_image_of_isCompact hUb.isCompact_closure hFc
 
 /-- **A continuous extension carries a uniformly locally connected boundary to a uniformly locally
 connected boundary.** The uniform companion of `TauCeti.locallyConnectedSpace_frontier_image`, and
 the form in which the necessary half of Carathéodory's continuity theorem is used: the image
-boundary is compact, being `F '' frontier U` by
-`TauCeti.image_frontier_eq_frontier_image`, so the two forms of local connectedness agree on it. -/
+boundary is `F '' frontier U` by `TauCeti.image_frontier_eq_frontier_image`, so the general
+`TauCeti.isUniformlyLocallyConnected_image_of_isCompact` applies to it. -/
 theorem isUniformlyLocallyConnected_frontier_image [LocallyConnectedSpace (frontier U)]
     (hUo : IsOpen U) (hUb : Bornology.IsBounded U) (hfd : DifferentiableOn ℂ f U) (hfi : InjOn f U)
     (hFc : ContinuousOn F (closure U)) (hFf : EqOn F f U) :
     IsUniformlyLocallyConnected (frontier (f '' U)) := by
-  have hcpt : IsCompact (frontier (f '' U)) := by
-    rw [← image_frontier_eq_frontier_image hUo hUb hfd hfi hFc hFf]
-    exact (hUb.isCompact_closure.of_isClosed_subset isClosed_frontier
-      frontier_subset_closure).image_of_continuousOn (hFc.mono frontier_subset_closure)
-  haveI := locallyConnectedSpace_frontier_image hUo hUb hfd hfi hFc hFf
-  exact IsCompact.isUniformlyLocallyConnected hcpt
+  rw [← image_frontier_eq_frontier_image hUo hUb hfd hfi hFc hFf]
+  exact isUniformlyLocallyConnected_image_of_isCompact
+    (isCompact_of_isClosed_isBounded isClosed_frontier
+      (hUb.closure.subset frontier_subset_closure))
+    (hFc.mono frontier_subset_closure)
 
 /-- **A conformal map of a Jordan domain that extends continuously has uniformly locally connected
 image boundary.** The uniform companion of
@@ -215,6 +214,20 @@ theorem IsJordanDomain.isUniformlyLocallyConnected_frontier_image (hU : IsJordan
     (hFf : EqOn F f U) : IsUniformlyLocallyConnected (frontier (f '' U)) :=
   haveI := hU.locallyConnectedSpace_frontier
   _root_.TauCeti.isUniformlyLocallyConnected_frontier_image hU.isOpen hU.isBounded hfd hfi hFc hFf
+
+/-- **The closure of the image of a Riemann map with a continuous extension is uniformly locally
+connected.** The uniform companion of `TauCeti.locallyConnectedSpace_closure_image_ball`; as there,
+the closed disc is convex, hence locally connected, so no hypothesis on the source boundary is
+left. -/
+theorem isUniformlyLocallyConnected_closure_image_ball (hFc : ContinuousOn F (closedBall 0 1))
+    (hFf : EqOn F f (ball 0 1)) :
+    IsUniformlyLocallyConnected (closure (f '' ball (0 : ℂ) 1)) := by
+  haveI : LocallyConnectedSpace (closure (ball (0 : ℂ) 1)) := by
+    rw [closure_ball (0 : ℂ) one_ne_zero]
+    haveI := (convex_closedBall (0 : ℂ) 1).locallyPathConnectedSpace
+    infer_instance
+  refine isUniformlyLocallyConnected_closure_image (isBounded_ball) ?_ hFf
+  rwa [closure_ball (0 : ℂ) one_ne_zero]
 
 /-- **The boundary of the image of a Riemann map with a continuous extension is uniformly locally
 connected.** The uniform companion of `TauCeti.locallyConnectedSpace_frontier_image_ball`. -/

--- a/TauCeti/Topology/UniformlyLocallyConnected.lean
+++ b/TauCeti/Topology/UniformlyLocallyConnected.lean
@@ -9,6 +9,7 @@ public import Mathlib.Analysis.Normed.Module.Convex
 public import Mathlib.Topology.Connected.LocallyConnected
 public import Mathlib.Topology.MetricSpace.Bounded
 public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+import TauCeti.Topology.LocallyConnected
 
 /-!
 # Uniform local connectedness
@@ -65,6 +66,8 @@ it, and no Lebesgue-number consequence of this shape.
 * `TauCeti.IsCompact.isUniformlyLocallyConnected_iff` — on a compact set the two notions agree.
 * `TauCeti.Convex.isUniformlyLocallyConnected` — a convex set in a real normed space is uniformly
   locally connected, with the joining segment as the connected set.
+* `TauCeti.isUniformlyLocallyConnected_image_of_isCompact` — a continuous image of a compact,
+  locally connected set is uniformly locally connected.
 
 ## References
 
@@ -96,13 +99,28 @@ def IsUniformlyLocallyConnected (s : Set X) : Prop :=
   ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
     ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ ∀ x ∈ C, ∀ y ∈ C, dist x y ≤ ε
 
+/-- `TauCeti.IsUniformlyLocallyConnected` restated as an `Iff`, so that it can be established and
+consumed in its native pairwise-distance form without unfolding the definition — which downstream
+modules cannot do, the definition being public but not exposed. -/
+theorem isUniformlyLocallyConnected_def :
+    IsUniformlyLocallyConnected s ↔ ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
+      ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ ∀ x ∈ C, ∀ y ∈ C, dist x y ≤ ε := Iff.rfl
+
+/-- The elimination form of `TauCeti.IsUniformlyLocallyConnected`: each `ε > 0` comes with a `δ > 0`
+serving every pair of points of `s` at distance less than `δ` at once. -/
+theorem IsUniformlyLocallyConnected.exists_isConnected (h : IsUniformlyLocallyConnected s) {ε : ℝ}
+    (hε : 0 < ε) :
+    ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
+      ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ ∀ x ∈ C, ∀ y ∈ C, dist x y ≤ ε :=
+  isUniformlyLocallyConnected_def.mp h ε hε
+
 /-- The diameter phrasing of `TauCeti.IsUniformlyLocallyConnected`: the joining set is bounded and
 has diameter at most `ε`. -/
 theorem IsUniformlyLocallyConnected.exists_isConnected_diam_le (h : IsUniformlyLocallyConnected s)
     {ε : ℝ} (hε : 0 < ε) :
     ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
       ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ Bornology.IsBounded C ∧ diam C ≤ ε := by
-  obtain ⟨δ, hδ, hjoin⟩ := h ε hε
+  obtain ⟨δ, hδ, hjoin⟩ := h.exists_isConnected hε
   refine ⟨δ, hδ, fun a ha b hb hab => ?_⟩
   obtain ⟨C, hCs, hCconn, hCa, hCb, hCsmall⟩ := hjoin a ha b hb hab
   exact ⟨C, hCs, hCconn, hCa, hCb, isBounded_iff.mpr ⟨ε, hCsmall⟩,
@@ -113,7 +131,8 @@ established, and not just used, from joining sets that are bounded and of diamet
 theorem isUniformlyLocallyConnected_iff_exists_isConnected_diam_le :
     IsUniformlyLocallyConnected s ↔ ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
       ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ Bornology.IsBounded C ∧ diam C ≤ ε := by
-  refine ⟨fun h ε hε => h.exists_isConnected_diam_le hε, fun h ε hε => ?_⟩
+  refine ⟨fun h ε hε => h.exists_isConnected_diam_le hε,
+    fun h => isUniformlyLocallyConnected_def.mpr fun ε hε => ?_⟩
   obtain ⟨δ, hδ, hjoin⟩ := h ε hε
   refine ⟨δ, hδ, fun a ha b hb hab => ?_⟩
   obtain ⟨C, hCs, hCconn, hCa, hCb, hCbdd, hCdiam⟩ := hjoin a ha b hb hab
@@ -123,7 +142,7 @@ theorem isUniformlyLocallyConnected_iff_exists_isConnected_diam_le :
 /-- The empty set is uniformly locally connected, vacuously. -/
 @[simp]
 theorem isUniformlyLocallyConnected_empty : IsUniformlyLocallyConnected (∅ : Set X) :=
-  fun ε hε => ⟨ε, hε, by simp⟩
+  isUniformlyLocallyConnected_def.mpr fun ε hε => ⟨ε, hε, by simp⟩
 
 /-- **A convex set is uniformly locally connected**: two points at distance less than `ε / 2` are
 joined by the segment between them, which stays in the set by convexity and, by
@@ -133,7 +152,8 @@ first endpoint, so its points are pairwise within `ε`.
 This is the basic example, and the one the closed disc supplies in the conformal application. -/
 protected theorem Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommGroup E]
     [NormedSpace ℝ E] {t : Set E} (ht : Convex ℝ t) : IsUniformlyLocallyConnected t := by
-  refine fun ε hε => ⟨ε / 2, by linarith, fun a ha b hb hab => ⟨segment ℝ a b,
+  refine isUniformlyLocallyConnected_def.mpr fun ε hε => ⟨ε / 2, by linarith,
+    fun a ha b hb hab => ⟨segment ℝ a b,
     ht.segment_subset ha hb, (convex_segment a b).isConnected ⟨a, left_mem_segment ℝ a b⟩,
     left_mem_segment ℝ a b, right_mem_segment ℝ a b, fun x hx y hy => ?_⟩⟩
   have hx' := mem_closedBall.mp (segment_subset_closedBall_left a b hx)
@@ -152,6 +172,7 @@ in a common member of the cover, whose points are pairwise within `ε` of one an
 protected theorem IsCompact.isUniformlyLocallyConnected [LocallyConnectedSpace s]
     (hs : IsCompact s) : IsUniformlyLocallyConnected s := by
   haveI : CompactSpace s := isCompact_iff_compactSpace.mp hs
+  rw [isUniformlyLocallyConnected_def]
   intro ε hε
   have hε2 : (0 : ℝ) < ε / 2 := by linarith
   -- The cover of the subspace by the connected components of the small balls.
@@ -196,7 +217,7 @@ theorem IsUniformlyLocallyConnected.locallyConnectedSpace (h : IsUniformlyLocall
   intro x U hU
   obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp hU
   have hε2 : (0 : ℝ) < ε / 2 := by linarith
-  obtain ⟨δ, hδ, hjoin⟩ := h (ε / 2) hε2
+  obtain ⟨δ, hδ, hjoin⟩ := h.exists_isConnected hε2
   refine ⟨⋃₀ {C : Set s | IsPreconnected C ∧ x ∈ C ∧ C ⊆ closedBall x (ε / 2)}, ?_,
     isPreconnected_sUnion x _ (fun C hC => hC.2.1) fun C hC => hC.1, ?_⟩
   · -- The union contains the ball of radius `δ` about `x`, hence is a neighbourhood of `x`.
@@ -220,5 +241,16 @@ compactness; the backward one is `TauCeti.IsCompact.isUniformlyLocallyConnected`
 protected theorem IsCompact.isUniformlyLocallyConnected_iff (hs : IsCompact s) :
     IsUniformlyLocallyConnected s ↔ LocallyConnectedSpace s :=
   ⟨fun h => h.locallyConnectedSpace, fun h => haveI := h; IsCompact.isUniformlyLocallyConnected hs⟩
+
+/-! ## Continuous images -/
+
+/-- **A continuous image of a compact, locally connected set is uniformly locally connected.** The
+uniform companion of `TauCeti.locallyConnectedSpace_image_of_isCompact`: that lemma makes the image
+locally connected, the image is compact, and on a compact set the two notions agree. -/
+theorem isUniformlyLocallyConnected_image_of_isCompact {Z : Type*} [TopologicalSpace Z] [T2Space X]
+    {t : Set Z} {g : Z → X} [LocallyConnectedSpace t] (ht : IsCompact t) (hg : ContinuousOn g t) :
+    IsUniformlyLocallyConnected (g '' t) :=
+  haveI := locallyConnectedSpace_image_of_isCompact ht hg
+  IsCompact.isUniformlyLocallyConnected (ht.image_of_continuousOn hg)
 
 end TauCeti

--- a/TauCeti/Topology/UniformlyLocallyConnected.lean
+++ b/TauCeti/Topology/UniformlyLocallyConnected.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Convex.PathConnected
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.Analysis.Normed.Module.Convex
+public import Mathlib.Topology.Connected.LocallyConnected
+public import Mathlib.Topology.MetricSpace.Bounded
+public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+
+/-!
+# Uniform local connectedness
+
+A set `s` in a pseudometric space is **uniformly locally connected** when the connected sets
+joining nearby points can be chosen small *at a rate independent of where they are*: for every
+`ε > 0` there is a single `δ > 0` such that any two points of `s` at distance less than `δ` lie in
+a connected subset of `s` of diameter at most `ε`.
+
+This is the metric strengthening of local connectedness, and the two notions are *equivalent on a
+compact set*. That equivalence is what this file proves:
+`TauCeti.IsCompact.isUniformlyLocallyConnected` derives the uniform statement from the local one by
+a Lebesgue-number argument, and `TauCeti.IsUniformlyLocallyConnected.locallyConnectedSpace` returns
+from the uniform statement to the local one with no compactness at all.
+
+Compactness is genuinely needed for the first direction. The graph of `x ↦ sin (1 / x)` over
+`(0, 1]` is homeomorphic to an interval, hence locally connected, but not uniformly so: points on
+it with nearly equal ordinates and wildly different abscissae are joined only by long arcs, so no
+`δ` works for a small `ε`. It fails no hypothesis but compactness.
+
+## Why this notion
+
+Local connectedness is a statement about one point at a time, and an argument that must produce a
+small connected set near *every* point of a set at once cannot use it directly. The uniform form is
+what such arguments actually consume, and on a compact set it costs nothing extra.
+
+The intended consumer is layer **L5** of the conformal-mapping roadmap
+(`TauCetiRoadmap/ConformalMapping/README.md`), Carathéodory's boundary correspondence. The
+sufficiency half of Carathéodory's continuity theorem — a conformal map of the disc onto a bounded
+domain with locally connected boundary extends continuously to the closed disc — controls the image
+of a crosscut, and what it asks of the boundary is exactly a uniform `ε`–`δ` supply of small
+connected sets joining nearby boundary points. The boundary of a bounded domain is compact, so the
+equivalence proved here converts the roadmap's hypothesis into that form once and for all; the
+conformal consequences are in `TauCeti/Analysis/Complex/Conformal/JordanDomain.lean` and
+`TauCeti/Analysis/Complex/Conformal/LocallyConnectedBoundary.lean`.
+
+Nothing here is specific to that application: the definition and both implications are stated for
+an arbitrary pseudometric space. Mathlib has `LocallyConnectedSpace` but no metric refinement of
+it, and no Lebesgue-number consequence of this shape.
+
+## Main definitions
+
+* `TauCeti.IsUniformlyLocallyConnected` — the uniform `ε`–`δ` form of local connectedness for a
+  set in a pseudometric space.
+
+## Main results
+
+* `TauCeti.IsCompact.isUniformlyLocallyConnected` — a compact locally connected set is uniformly
+  locally connected.
+* `TauCeti.IsUniformlyLocallyConnected.locallyConnectedSpace` — a uniformly locally connected set
+  is locally connected; no compactness is used.
+* `TauCeti.IsCompact.isUniformlyLocallyConnected_iff` — on a compact set the two notions agree.
+* `TauCeti.Convex.isUniformlyLocallyConnected` — a convex set in a real normed space is uniformly
+  locally connected, with the joining segment as the connected set.
+
+## References
+
+* R. L. Moore, *Foundations of Point Set Theory*, Ch. IV (uniform local connectedness, "property
+  S").
+* J. G. Hocking and G. S. Young, *Topology*, Ch. 3.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, Ch. 2 (the use in Carathéodory's
+  continuity theorem).
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric Set Topology
+
+variable {X : Type*} [PseudoMetricSpace X] {s : Set X}
+
+/-- A set `s` is **uniformly locally connected** if for every `ε > 0` there is a `δ > 0` such that
+any two points of `s` at distance less than `δ` are joined by a connected subset of `s` of diameter
+at most `ε`.
+
+The smallness of the joining set is spelled out as a pairwise distance bound rather than as
+`Metric.diam C ≤ ε`, because `Metric.diam` is `0` on an unbounded set, which would let an unbounded
+`C` satisfy the condition vacuously. The lemma
+`TauCeti.IsUniformlyLocallyConnected.exists_isConnected_diam_le` recovers the diameter phrasing,
+boundedness of the joining set being one of its consequences. -/
+def IsUniformlyLocallyConnected (s : Set X) : Prop :=
+  ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
+    ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ ∀ x ∈ C, ∀ y ∈ C, dist x y ≤ ε
+
+/-- The diameter phrasing of `TauCeti.IsUniformlyLocallyConnected`: the joining set is bounded and
+has diameter at most `ε`. -/
+theorem IsUniformlyLocallyConnected.exists_isConnected_diam_le (h : IsUniformlyLocallyConnected s)
+    {ε : ℝ} (hε : 0 < ε) :
+    ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
+      ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ Bornology.IsBounded C ∧ diam C ≤ ε := by
+  obtain ⟨δ, hδ, hjoin⟩ := h ε hε
+  refine ⟨δ, hδ, fun a ha b hb hab => ?_⟩
+  obtain ⟨C, hCs, hCconn, hCa, hCb, hCsmall⟩ := hjoin a ha b hb hab
+  exact ⟨C, hCs, hCconn, hCa, hCb, isBounded_iff.mpr ⟨ε, hCsmall⟩,
+    diam_le_of_forall_dist_le hε.le hCsmall⟩
+
+/-- The empty set is uniformly locally connected, vacuously. -/
+theorem isUniformlyLocallyConnected_empty : IsUniformlyLocallyConnected (∅ : Set X) :=
+  fun ε hε => ⟨ε, hε, by simp⟩
+
+/-- **A convex set is uniformly locally connected**: two points at distance less than `ε / 2` are
+joined by the segment between them, which stays in the set by convexity and inside the closed ball
+of radius `ε / 2` about the first endpoint because closed balls are convex too, so its points are
+pairwise within `ε`.
+
+This is the basic example, and the one the closed disc supplies in the conformal application. -/
+protected theorem Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] {t : Set E} (ht : Convex ℝ t) : IsUniformlyLocallyConnected t := by
+  refine fun ε hε => ⟨ε / 2, by linarith, fun a ha b hb hab => ⟨segment ℝ a b,
+    ht.segment_subset ha hb, (convex_segment a b).isConnected ⟨a, left_mem_segment ℝ a b⟩,
+    left_mem_segment ℝ a b, right_mem_segment ℝ a b, fun x hx y hy => ?_⟩⟩
+  have hsub : segment ℝ a b ⊆ closedBall a (ε / 2) :=
+    (convex_closedBall a (ε / 2)).segment_subset (mem_closedBall_self (by linarith))
+      (mem_closedBall'.mpr hab.le)
+  have hx' := mem_closedBall.mp (hsub hx)
+  have hy' := mem_closedBall.mp (hsub hy)
+  linarith [dist_triangle_right x y a]
+
+/-! ## The compact case: local connectedness suffices -/
+
+/-- **A compact locally connected set is uniformly locally connected.**
+
+Given `ε > 0`, local connectedness supplies for each point a connected open neighbourhood inside
+the ball of radius `ε / 2` about it — the connected component of that ball, open precisely because
+the subspace is locally connected. These cover the compact set, and a Lebesgue number `δ` for the
+cover does the rest: two points at distance less than `δ` lie in a common ball of radius `δ`, hence
+in a common member of the cover, whose points are pairwise within `ε` of one another. -/
+protected theorem IsCompact.isUniformlyLocallyConnected [LocallyConnectedSpace s]
+    (hs : IsCompact s) : IsUniformlyLocallyConnected s := by
+  haveI : CompactSpace s := isCompact_iff_compactSpace.mp hs
+  intro ε hε
+  have hε2 : (0 : ℝ) < ε / 2 := by linarith
+  -- The cover of the subspace by the connected components of the small balls.
+  have hcopen : ∀ x : s, IsOpen (connectedComponentIn (ball x (ε / 2)) x) := fun _ =>
+    isOpen_ball.connectedComponentIn
+  have hcmem : ∀ x : s, x ∈ connectedComponentIn (ball x (ε / 2)) x := fun _ =>
+    mem_connectedComponentIn (mem_ball_self hε2)
+  obtain ⟨δ, hδ, hlb⟩ :=
+    lebesgue_number_lemma_of_metric (c := fun x : s => connectedComponentIn (ball x (ε / 2)) x)
+      isCompact_univ hcopen fun x _ => mem_iUnion.mpr ⟨x, hcmem x⟩
+  refine ⟨δ, hδ, fun a ha b hb hab => ?_⟩
+  -- The Lebesgue number applied at `a`: a single member of the cover contains both `a` and `b`.
+  obtain ⟨x, hx⟩ := hlb ⟨a, ha⟩ (mem_univ _)
+  have hamem : (⟨a, ha⟩ : s) ∈ connectedComponentIn (ball x (ε / 2)) x := hx (mem_ball_self hδ)
+  have hbmem : (⟨b, hb⟩ : s) ∈ connectedComponentIn (ball x (ε / 2)) x :=
+    hx (mem_ball.mpr (by rw [Subtype.dist_eq, dist_comm]; exact hab))
+  -- Its points lie within `ε / 2` of `x`, hence within `ε` of one another.
+  have hball : ∀ w ∈ (connectedComponentIn (ball x (ε / 2)) x : Set s), dist w x < ε / 2 :=
+    fun w hw => mem_ball.mp (connectedComponentIn_subset _ _ hw)
+  -- Transport the component down to `X` along the inclusion, an inducing map.
+  refine ⟨Subtype.val '' connectedComponentIn (ball x (ε / 2)) x, Subtype.coe_image_subset _ _,
+    ⟨⟨_, mem_image_of_mem _ hamem⟩, IsInducing.subtypeVal.isPreconnected_image.mpr
+      isPreconnected_connectedComponentIn⟩, mem_image_of_mem _ hamem,
+    mem_image_of_mem _ hbmem, ?_⟩
+  rintro _ ⟨u, hu, rfl⟩ _ ⟨v, hv, rfl⟩
+  have hu' : dist (u : X) (x : X) < ε / 2 := hball u hu
+  have hv' : dist (v : X) (x : X) < ε / 2 := hball v hv
+  linarith [dist_triangle_right (u : X) (v : X) (x : X)]
+
+/-! ## The converse: uniform local connectedness implies local connectedness -/
+
+/-- **A uniformly locally connected set is locally connected.** No compactness is needed.
+
+The connected neighbourhood of a point `x` of `s` inside a prescribed ball is built by *taking all
+candidates at once*: the union of every connected subset of `s` that contains `x` and stays within
+`ε / 2` of it. The union is connected because all its members contain `x`, it stays inside the ball
+of radius `ε` about `x`, and it is a neighbourhood of `x` in `s` because the uniform hypothesis
+puts every point within `δ` of `x` into one of the sets being united. -/
+theorem IsUniformlyLocallyConnected.locallyConnectedSpace (h : IsUniformlyLocallyConnected s) :
+    LocallyConnectedSpace s := by
+  rw [locallyConnectedSpace_iff_connected_subsets]
+  intro x U hU
+  obtain ⟨ε, hε, hball⟩ := Metric.mem_nhds_iff.mp hU
+  have hε2 : (0 : ℝ) < ε / 2 := by linarith
+  obtain ⟨δ, hδ, hjoin⟩ := h (ε / 2) hε2
+  refine ⟨⋃₀ {C : Set s | IsPreconnected C ∧ x ∈ C ∧ C ⊆ closedBall x (ε / 2)}, ?_,
+    isPreconnected_sUnion x _ (fun C hC => hC.2.1) fun C hC => hC.1, ?_⟩
+  · -- The union contains the ball of radius `δ` about `x`, hence is a neighbourhood of `x`.
+    refine Filter.mem_of_superset (ball_mem_nhds x hδ) fun y hy => ?_
+    obtain ⟨C, hCs, hCconn, hCx, hCy, hCsmall⟩ :=
+      hjoin x x.2 y y.2 (by rw [dist_comm, ← Subtype.dist_eq]; exact mem_ball.mp hy)
+    -- Pull the joining set back to the subspace; it stays preconnected because it already lies
+    -- in `s` and the inclusion is inducing.
+    refine ⟨(Subtype.val ⁻¹' C : Set s),
+      ⟨?_, hCx, fun z hz => mem_closedBall.mpr (hCsmall _ hz _ hCx)⟩, hCy⟩
+    refine IsInducing.subtypeVal.isPreconnected_image.mp ?_
+    rw [Subtype.image_preimage_coe, inter_eq_self_of_subset_right hCs]
+    exact hCconn.isPreconnected
+  · -- The union lies in the ball of radius `ε`, hence in `U`.
+    rintro y ⟨C, hC, hyC⟩
+    exact hball (mem_ball.mpr (lt_of_le_of_lt (mem_closedBall.mp (hC.2.2 hyC)) (by linarith)))
+
+/-- **On a compact set, uniform local connectedness and local connectedness agree.** The forward
+implication is `TauCeti.IsUniformlyLocallyConnected.locallyConnectedSpace`, which needs no
+compactness; the backward one is `TauCeti.IsCompact.isUniformlyLocallyConnected`, which does. -/
+protected theorem IsCompact.isUniformlyLocallyConnected_iff (hs : IsCompact s) :
+    IsUniformlyLocallyConnected s ↔ LocallyConnectedSpace s :=
+  ⟨fun h => h.locallyConnectedSpace, fun h => haveI := h; IsCompact.isUniformlyLocallyConnected hs⟩
+
+end TauCeti

--- a/TauCeti/Topology/UniformlyLocallyConnected.lean
+++ b/TauCeti/Topology/UniformlyLocallyConnected.lean
@@ -7,8 +7,6 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Convex
 public import Mathlib.Topology.Connected.LocallyConnected
-public import Mathlib.Topology.MetricSpace.Bounded
-public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
 import TauCeti.Topology.LocallyConnected
 
 /-!

--- a/TauCeti/Topology/UniformlyLocallyConnected.lean
+++ b/TauCeti/Topology/UniformlyLocallyConnected.lean
@@ -5,8 +5,6 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Convex.PathConnected
-public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.Analysis.Normed.Module.Convex
 public import Mathlib.Topology.Connected.LocallyConnected
 public import Mathlib.Topology.MetricSpace.Bounded
@@ -27,9 +25,11 @@ a Lebesgue-number argument, and `TauCeti.IsUniformlyLocallyConnected.locallyConn
 from the uniform statement to the local one with no compactness at all.
 
 Compactness is genuinely needed for the first direction. The graph of `x ↦ sin (1 / x)` over
-`(0, 1]` is homeomorphic to an interval, hence locally connected, but not uniformly so: points on
-it with nearly equal ordinates and wildly different abscissae are joined only by long arcs, so no
-`δ` works for a small `ε`. It fails no hypothesis but compactness.
+`(0, 1]` is homeomorphic to an interval, hence locally connected, but not uniformly so: the
+oscillations crowd together as `x → 0`, so two points of equal ordinate on distinct oscillations
+come arbitrarily close to one another, while every connected subset of the graph joining them
+sweeps out a whole oscillation and so meets ordinates near both `1` and `-1`. Such a set has
+diameter at least `2`, so no `δ` works for `ε = 1`. It fails no hypothesis but compactness.
 
 ## Why this notion
 
@@ -108,14 +108,27 @@ theorem IsUniformlyLocallyConnected.exists_isConnected_diam_le (h : IsUniformlyL
   exact ⟨C, hCs, hCconn, hCa, hCb, isBounded_iff.mpr ⟨ε, hCsmall⟩,
     diam_le_of_forall_dist_le hε.le hCsmall⟩
 
+/-- `TauCeti.IsUniformlyLocallyConnected` is equivalent to its diameter phrasing: it may be
+established, and not just used, from joining sets that are bounded and of diameter at most `ε`. -/
+theorem isUniformlyLocallyConnected_iff_exists_isConnected_diam_le :
+    IsUniformlyLocallyConnected s ↔ ∀ ε > 0, ∃ δ > 0, ∀ a ∈ s, ∀ b ∈ s, dist a b < δ →
+      ∃ C ⊆ s, IsConnected C ∧ a ∈ C ∧ b ∈ C ∧ Bornology.IsBounded C ∧ diam C ≤ ε := by
+  refine ⟨fun h ε hε => h.exists_isConnected_diam_le hε, fun h ε hε => ?_⟩
+  obtain ⟨δ, hδ, hjoin⟩ := h ε hε
+  refine ⟨δ, hδ, fun a ha b hb hab => ?_⟩
+  obtain ⟨C, hCs, hCconn, hCa, hCb, hCbdd, hCdiam⟩ := hjoin a ha b hb hab
+  exact ⟨C, hCs, hCconn, hCa, hCb,
+    fun x hx y hy => (dist_le_diam_of_mem hCbdd hx hy).trans hCdiam⟩
+
 /-- The empty set is uniformly locally connected, vacuously. -/
+@[simp]
 theorem isUniformlyLocallyConnected_empty : IsUniformlyLocallyConnected (∅ : Set X) :=
   fun ε hε => ⟨ε, hε, by simp⟩
 
 /-- **A convex set is uniformly locally connected**: two points at distance less than `ε / 2` are
-joined by the segment between them, which stays in the set by convexity and inside the closed ball
-of radius `ε / 2` about the first endpoint because closed balls are convex too, so its points are
-pairwise within `ε`.
+joined by the segment between them, which stays in the set by convexity and, by
+`segment_subset_closedBall_left`, inside the closed ball of radius `dist a b < ε / 2` about the
+first endpoint, so its points are pairwise within `ε`.
 
 This is the basic example, and the one the closed disc supplies in the conformal application. -/
 protected theorem Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommGroup E]
@@ -123,11 +136,8 @@ protected theorem Convex.isUniformlyLocallyConnected {E : Type*} [NormedAddCommG
   refine fun ε hε => ⟨ε / 2, by linarith, fun a ha b hb hab => ⟨segment ℝ a b,
     ht.segment_subset ha hb, (convex_segment a b).isConnected ⟨a, left_mem_segment ℝ a b⟩,
     left_mem_segment ℝ a b, right_mem_segment ℝ a b, fun x hx y hy => ?_⟩⟩
-  have hsub : segment ℝ a b ⊆ closedBall a (ε / 2) :=
-    (convex_closedBall a (ε / 2)).segment_subset (mem_closedBall_self (by linarith))
-      (mem_closedBall'.mpr hab.le)
-  have hx' := mem_closedBall.mp (hsub hx)
-  have hy' := mem_closedBall.mp (hsub hy)
+  have hx' := mem_closedBall.mp (segment_subset_closedBall_left a b hx)
+  have hy' := mem_closedBall.mp (segment_subset_closedBall_left a b hy)
   linarith [dist_triangle_right x y a]
 
 /-! ## The compact case: local connectedness suffices -/


### PR DESCRIPTION
This PR adds `TauCeti.IsUniformlyLocallyConnected`, the metric refinement of local connectedness in which a single `δ` serves every pair of nearby points at once, and shows that on a compact set it is exactly `LocallyConnectedSpace`. The forward implication `TauCeti.IsCompact.isUniformlyLocallyConnected` is a Lebesgue-number argument: the connected component of a small ball around each point is open because the subspace is locally connected, these components cover, and a Lebesgue number for that cover is the `δ` sought. The converse `TauCeti.IsUniformlyLocallyConnected.locallyConnectedSpace` needs no compactness at all — the connected neighbourhood is built by uniting every small connected set through the point, and the uniform hypothesis is what makes that union a neighbourhood. `TauCeti.IsCompact.isUniformlyLocallyConnected_iff` packages the two, `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_diam_le` recovers the textbook `Metric.diam` phrasing (the definition itself uses a pairwise distance bound instead, because `Metric.diam` is `0` on an unbounded set and would make the condition vacuously satisfiable), and `TauCeti.Convex.isUniformlyLocallyConnected` supplies the basic example. Compactness is not decoration in the first direction, and the docstring records the failure: the graph of `sin (1 / x)` over `(0, 1]` is homeomorphic to an interval, hence locally connected, but points on it with nearly equal ordinates and wildly different abscissae are joined only by long arcs.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "Carathéodory boundary correspondence … the RMT map of a Jordan domain extends to a homeomorphism of closures" — and specifically the hypothesis under which its hard direction runs. Carathéodory's continuity theorem controls the image of a crosscut by joining its two boundary endpoints inside a small connected piece of the boundary, and that estimate has to be uniform over all crosscuts at once, so what the proof consumes is not the pointwise `LocallyConnectedSpace (frontier U)` the repository currently offers but its uniform form. Since the boundary of a bounded domain is compact, the equivalence proved here converts the roadmap's hypothesis into that form once and for all. `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier` states it for a Jordan domain, with no hypothesis left over; and the four necessity results of `Conformal/LocallyConnectedBoundary.lean`, which say what a continuous extension of a conformal map *forces* on the image boundary, gain their uniform companions `TauCeti.isUniformlyLocallyConnected_closure_image`, `TauCeti.isUniformlyLocallyConnected_frontier_image`, `TauCeti.IsJordanDomain.isUniformlyLocallyConnected_frontier_image` and `TauCeti.isUniformlyLocallyConnected_frontier_image_ball`, each set in question being compact.

Nothing here duplicates existing work. Mathlib has `LocallyConnectedSpace` with its `connectedComponentIn` characterization but no metric refinement of it and no Lebesgue-number consequence of this shape; a search of the pinned source for uniform local connectedness and for "property S" turns up nothing. Within the repository, `TauCeti/Topology/LocallyConnected.lean` is about the behaviour of local connectedness under quotient maps and is untouched. No declaration is renamed, moved or restated: one new file of 214 lines is added under `TauCeti/Topology/`, where the general topology it proves belongs, and the two conformal files gain 78 lines of corollaries and documentation between them. No Mathlib infrastructure was vendored — the proof is built from `lebesgue_number_lemma_of_metric`, `IsOpen.connectedComponentIn`, `locallyConnectedSpace_iff_connected_subsets`, `isPreconnected_sUnion` and `Topology.IsInducing.subtypeVal.isPreconnected_image`.

Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and Mathlib has no boundary correspondence for conformal maps; so this is new Lean formalization rather than a temporary shim, though the conformal corollaries consume the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn` through `Conformal/BoundaryCorrespondence.lean`, to be refactored onto Mathlib once the upstream work lands. `lake build`, `lake exe axioms` (17777 declarations, allowlist `propext`, `Classical.choice`, `Quot.sound`) and `lake exe module-system` are all green.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"uniformly-locally-connected"}-->

🤖 Prepared with Claude Code
