### PR TITLE
refactor(Algebra): decompose the central-simple tensor-product simplicity proof

### DIFF
--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -222,8 +222,10 @@ private lemma exists_mem_repr_eq_one [IsSimpleRing A] {ι : Type*} (𝓑 : Basis
 
 -- Minimality forces the additive commutators to vanish. For each `a`, the commutator
 -- `(a ⊗ₜ 1) * y - y * (a ⊗ₜ 1)` lies in `I` and is supported in `S.erase i₀` — the `i₀` term
--- cancels because that coordinate of `y` is `1`, and everything off `S` was already zero — so it
--- has strictly smaller support than `y` and minimality kills it.
+-- cancels because that coordinate of `y` is `1`, and everything off `S` was already zero — so its
+-- support cardinality is strictly below `S.card` and the supplied minimality hypothesis kills it.
+-- (`S` is an arbitrary `Finset` here; the caller instantiates it at the support of the
+-- minimal-support element, which is what makes `hmin` available.)
 private lemma commute_tmul_one_of_repr_eq_one {ι : Type*} (𝓑 : Basis ι K B)
     {I : TwoSidedIdeal (A ⊗[K] B)} {S : Finset ι} {i₀ : ι} (hi₀ : i₀ ∈ S) {y : A ⊗[K] B}
     (hyI : y ∈ I) (hyS : ∀ j ∉ S, (Algebra.TensorProduct.basis A 𝓑).repr y j = 0)

--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -246,18 +246,6 @@ private lemma commute_tmul_one_of_repr_eq_one {ι : Type*} (𝓑 : Basis ι K B)
       (lt_of_le_of_lt (Finset.card_le_card hsupp) (Finset.card_erase_lt_of_mem hi₀))
   exact sub_eq_zero.mp hz
 
--- If `1 ⊗ₜ b` lies in the ideal for some `b ≠ 0`, the ideal is everything: the `c` with
--- `1 ⊗ₜ c ∈ I` form the preimage of `I` along `includeRight`, a two-sided ideal of the simple
--- ring `B`. Only simplicity of `B` is used — not of `A`, and not centrality.
-private lemma one_mem_of_one_tmul_mem [IsSimpleRing B] {I : TwoSidedIdeal (A ⊗[K] B)} {b : B}
-    (hb : b ≠ 0) (hyI : (1 : A) ⊗ₜ[K] b ∈ I) : (1 : A ⊗[K] B) ∈ I := by
-  have honeB : (1 : B) ∈
-      I.comap (Algebra.TensorProduct.includeRight : B →ₐ[K] A ⊗[K] B) :=
-    _root_.IsSimpleRing.one_mem_of_ne_zero_mem _ hb
-      ((TwoSidedIdeal.mem_comap _).mpr (by simpa using hyI))
-  rw [TwoSidedIdeal.mem_comap] at honeB
-  simpa [Algebra.TensorProduct.one_def] using honeB
-
 variable (K A B) in
 /-- **The tensor product of a central simple `K`-algebra with a simple `K`-algebra is simple.**
 Together with `TauCeti.Algebra.IsCentral.tensorProduct` this says that central simple `K`-algebras
@@ -291,7 +279,14 @@ instance tensorProduct [Algebra.IsCentral K A] [IsSimpleRing A] [IsSimpleRing B]
   have hb : b ≠ 0 := by rintro rfl; exact hy0 (by simp)
   -- The `c : B` with `1 ⊗ₜ c ∈ I` form a two-sided ideal of `B`, namely the preimage of `I` along
   -- `Algebra.TensorProduct.includeRight`; it contains `b ≠ 0`, hence it is everything.
-  exact one_mem_of_one_tmul_mem hb hyI
+  -- The `c : B` with `1 ⊗ₜ c ∈ I` form the preimage of `I` along `includeRight`, a two-sided
+  -- ideal of the simple ring `B`; it contains `b ≠ 0`, hence it is everything.
+  have honeB : (1 : B) ∈
+      I.comap (Algebra.TensorProduct.includeRight : B →ₐ[K] A ⊗[K] B) :=
+    _root_.IsSimpleRing.one_mem_of_ne_zero_mem _ hb
+      ((TwoSidedIdeal.mem_comap _).mpr (by simpa using hyI))
+  rw [TwoSidedIdeal.mem_comap] at honeB
+  simpa [Algebra.TensorProduct.one_def] using honeB
 
 variable (K A B) in
 /-- **The tensor product of a simple `K`-algebra with a central simple `K`-algebra is simple.** This

--- a/TauCeti/Algebra/CentralSimple/TensorProduct.lean
+++ b/TauCeti/Algebra/CentralSimple/TensorProduct.lean
@@ -163,34 +163,34 @@ namespace IsSimpleRing
 
 variable {K A B : Type*} [Field K] [Ring A] [Ring B] [Algebra K A] [Algebra K B]
 
-variable (K A B) in
-/-- **The tensor product of a central simple `K`-algebra with a simple `K`-algebra is simple.**
-Together with `TauCeti.Algebra.IsCentral.tensorProduct` this says that central simple `K`-algebras
-are closed under `⊗[K]`.
-
-No finite-dimensionality is needed on either side. -/
-instance tensorProduct [Algebra.IsCentral K A] [IsSimpleRing A] [IsSimpleRing B] :
-    IsSimpleRing (A ⊗[K] B) := by
+-- A nonzero two-sided ideal contains a nonzero element whose coordinate support against the
+-- tensor basis is minimal: `Nat.find` on the set of achievable support cardinalities. Neither
+-- simplicity nor centrality is used, only that the ideal is nonzero.
+private lemma exists_minimal_support_mem {ι : Type*} (𝓑 : Basis ι K B)
+    {I : TwoSidedIdeal (A ⊗[K] B)} (hI : I ≠ ⊥) :
+    ∃ y ∈ I, y ≠ 0 ∧ ∀ z ∈ I,
+      ((Algebra.TensorProduct.basis A 𝓑).repr z).support.card <
+        ((Algebra.TensorProduct.basis A 𝓑).repr y).support.card → z = 0 := by
   classical
-  have : Nontrivial (A ⊗[K] B) :=
-    Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left K A B
-      (FaithfulSMul.algebraMap_injective K B)
-  refine IsSimpleRing.of_eq_bot_or_eq_top fun I => ?_
-  rw [or_iff_not_imp_left, ← I.one_mem_iff]
-  intro hI
-  obtain ⟨ι, 𝓑⟩ : Σ ι : Type _, Basis ι K B := ⟨_, Basis.ofVectorSpace K B⟩
   obtain ⟨x, hxI, hx0 : x ≠ 0⟩ := SetLike.exists_of_lt (bot_lt_iff_ne_bot.mpr hI : ⊥ < I)
   have hex : ∃ n : ℕ, ∃ y ∈ I, y ≠ 0 ∧
       ((Algebra.TensorProduct.basis A 𝓑).repr y).support.card = n := ⟨_, x, hxI, hx0, rfl⟩
   obtain ⟨y₀, hy₀I, hy₀0, hcard⟩ := Nat.find_spec hex
-  have hmin : ∀ y ∈ I,
-      ((Algebra.TensorProduct.basis A 𝓑).repr y).support.card < Nat.find hex → y = 0 := by
-    intro y hy hlt
-    by_contra h0
-    exact Nat.find_min hex hlt ⟨y, hy, h0, rfl⟩
-  set S := ((Algebra.TensorProduct.basis A 𝓑).repr y₀).support
-  obtain ⟨i₀, hi₀⟩ : S.Nonempty := Finsupp.support_nonempty_iff.mpr (by simpa using hy₀0)
-  -- The `i₀`-th coordinates of the elements of `I` supported on `S` form a two-sided ideal of `A`.
+  refine ⟨y₀, hy₀I, hy₀0, fun z hz hlt => ?_⟩
+  by_contra h0
+  exact Nat.find_min hex (hcard ▸ hlt) ⟨z, hz, h0, rfl⟩
+
+-- Rescale a coordinate to `1`. The `i₀`-th coordinates of the elements of `I` supported in `S`
+-- form a two-sided ideal of `A`; it is nonzero because `y₀` contributes a nonzero one, so
+-- simplicity of `A` puts `1` in it. Only simplicity of `A` is used — not of `B`, not centrality,
+-- and not minimality of the support.
+private lemma exists_mem_repr_eq_one [IsSimpleRing A] {ι : Type*} (𝓑 : Basis ι K B)
+    {I : TwoSidedIdeal (A ⊗[K] B)} {S : Finset ι} {i₀ : ι} {y₀ : A ⊗[K] B} (hy₀I : y₀ ∈ I)
+    (hy₀S : ∀ j ∉ S, (Algebra.TensorProduct.basis A 𝓑).repr y₀ j = 0)
+    (hne : (Algebra.TensorProduct.basis A 𝓑).repr y₀ i₀ ≠ 0) :
+    ∃ y ∈ I, (∀ j ∉ S, (Algebra.TensorProduct.basis A 𝓑).repr y j = 0) ∧
+      (Algebra.TensorProduct.basis A 𝓑).repr y i₀ = 1 := by
+  classical
   set carrier : Set A :=
     {a | ∃ y ∈ I, (∀ j ∉ S, (Algebra.TensorProduct.basis A 𝓑).repr y j = 0) ∧
       (Algebra.TensorProduct.basis A 𝓑).repr y i₀ = a}
@@ -212,45 +212,86 @@ instance tensorProduct [Algebra.IsCentral K A] [IsSimpleRing A] [IsSimpleRing B]
     exact ⟨y * (a' ⊗ₜ[K] (1 : B)), I.mul_mem_right _ _ hy,
       fun j hj => by rw [Algebra.TensorProduct.basis_repr_mul_tmul_one, hys j hj, zero_mul],
       Algebra.TensorProduct.basis_repr_mul_tmul_one ..⟩
-  obtain ⟨y, hyI, hyS, hy1⟩ : (1 : A) ∈ carrier := by
-    have hne : (Algebra.TensorProduct.basis A 𝓑).repr y₀ i₀ ≠ 0 := Finsupp.mem_support_iff.mp hi₀
-    have hmem : (Algebra.TensorProduct.basis A 𝓑).repr y₀ i₀ ∈ carrier :=
-      ⟨y₀, hy₀I, fun j hj => Finsupp.notMem_support_iff.mp hj, rfl⟩
-    have := IsSimpleRing.one_mem_of_ne_zero_mem
+  have hone : (1 : A) ∈ carrier := by
+    have hmem : (Algebra.TensorProduct.basis A 𝓑).repr y₀ i₀ ∈ carrier := ⟨y₀, hy₀I, hy₀S, rfl⟩
+    have := _root_.IsSimpleRing.one_mem_of_ne_zero_mem
       (TwoSidedIdeal.mk' carrier hzero hadd hneg hmulleft hmulright) hne
       ((TwoSidedIdeal.mem_mk' ..).mpr hmem)
     exact (TwoSidedIdeal.mem_mk' ..).mp this
+  exact hone
+
+-- Minimality forces the additive commutators to vanish. For each `a`, the commutator
+-- `(a ⊗ₜ 1) * y - y * (a ⊗ₜ 1)` lies in `I` and is supported in `S.erase i₀` — the `i₀` term
+-- cancels because that coordinate of `y` is `1`, and everything off `S` was already zero — so it
+-- has strictly smaller support than `y` and minimality kills it.
+private lemma commute_tmul_one_of_repr_eq_one {ι : Type*} (𝓑 : Basis ι K B)
+    {I : TwoSidedIdeal (A ⊗[K] B)} {S : Finset ι} {i₀ : ι} (hi₀ : i₀ ∈ S) {y : A ⊗[K] B}
+    (hyI : y ∈ I) (hyS : ∀ j ∉ S, (Algebra.TensorProduct.basis A 𝓑).repr y j = 0)
+    (hy1 : (Algebra.TensorProduct.basis A 𝓑).repr y i₀ = 1)
+    (hmin : ∀ z ∈ I, ((Algebra.TensorProduct.basis A 𝓑).repr z).support.card < S.card → z = 0)
+    (a : A) : Commute (a ⊗ₜ[K] (1 : B)) y := by
+  classical
+  have hsupp : ((Algebra.TensorProduct.basis A 𝓑).repr
+      ((a ⊗ₜ[K] (1 : B)) * y - y * (a ⊗ₜ[K] (1 : B)))).support ⊆ S.erase i₀ := by
+    intro j hj
+    rw [Finsupp.mem_support_iff, map_sub, Finsupp.sub_apply,
+      Algebra.TensorProduct.tmul_one_mul_eq_smul, map_smul, Finsupp.smul_apply, smul_eq_mul,
+      Algebra.TensorProduct.basis_repr_mul_tmul_one] at hj
+    refine Finset.mem_erase.mpr ⟨?_, not_imp_comm.mp (fun hjS => ?_) hj⟩
+    · rintro rfl
+      exact hj (by rw [hy1, mul_one, one_mul, sub_self])
+    · rw [hyS j hjS, mul_zero, zero_mul, sub_self]
+  have hz : (a ⊗ₜ[K] (1 : B)) * y - y * (a ⊗ₜ[K] (1 : B)) = 0 :=
+    hmin _ (I.sub_mem (I.mul_mem_left _ _ hyI) (I.mul_mem_right _ _ hyI))
+      (lt_of_le_of_lt (Finset.card_le_card hsupp) (Finset.card_erase_lt_of_mem hi₀))
+  exact sub_eq_zero.mp hz
+
+-- If `1 ⊗ₜ b` lies in the ideal for some `b ≠ 0`, the ideal is everything: the `c` with
+-- `1 ⊗ₜ c ∈ I` form the preimage of `I` along `includeRight`, a two-sided ideal of the simple
+-- ring `B`. Only simplicity of `B` is used — not of `A`, and not centrality.
+private lemma one_mem_of_one_tmul_mem [IsSimpleRing B] {I : TwoSidedIdeal (A ⊗[K] B)} {b : B}
+    (hb : b ≠ 0) (hyI : (1 : A) ⊗ₜ[K] b ∈ I) : (1 : A ⊗[K] B) ∈ I := by
+  have honeB : (1 : B) ∈
+      I.comap (Algebra.TensorProduct.includeRight : B →ₐ[K] A ⊗[K] B) :=
+    _root_.IsSimpleRing.one_mem_of_ne_zero_mem _ hb
+      ((TwoSidedIdeal.mem_comap _).mpr (by simpa using hyI))
+  rw [TwoSidedIdeal.mem_comap] at honeB
+  simpa [Algebra.TensorProduct.one_def] using honeB
+
+variable (K A B) in
+/-- **The tensor product of a central simple `K`-algebra with a simple `K`-algebra is simple.**
+Together with `TauCeti.Algebra.IsCentral.tensorProduct` this says that central simple `K`-algebras
+are closed under `⊗[K]`.
+
+No finite-dimensionality is needed on either side. -/
+instance tensorProduct [Algebra.IsCentral K A] [IsSimpleRing A] [IsSimpleRing B] :
+    IsSimpleRing (A ⊗[K] B) := by
+  classical
+  have : Nontrivial (A ⊗[K] B) :=
+    Algebra.TensorProduct.nontrivial_of_algebraMap_injective_of_flat_left K A B
+      (FaithfulSMul.algebraMap_injective K B)
+  refine IsSimpleRing.of_eq_bot_or_eq_top fun I => ?_
+  rw [or_iff_not_imp_left, ← I.one_mem_iff]
+  intro hI
+  obtain ⟨ι, 𝓑⟩ : Σ ι : Type _, Basis ι K B := ⟨_, Basis.ofVectorSpace K B⟩
+  obtain ⟨y₀, hy₀I, hy₀0, hmin⟩ := exists_minimal_support_mem 𝓑 hI
+  set S := ((Algebra.TensorProduct.basis A 𝓑).repr y₀).support
+  obtain ⟨i₀, hi₀⟩ : S.Nonempty := Finsupp.support_nonempty_iff.mpr (by simpa using hy₀0)
+  -- Rescale the `i₀`-th coordinate to `1`, using simplicity of `A`.
+  obtain ⟨y, hyI, hyS, hy1⟩ := exists_mem_repr_eq_one 𝓑 hy₀I
+    (fun j hj => Finsupp.notMem_support_iff.mp hj) (Finsupp.mem_support_iff.mp hi₀)
   have hy0 : y ≠ 0 := by
     rintro rfl
     simp only [map_zero, Finsupp.coe_zero, Pi.zero_apply] at hy1
     exact zero_ne_one hy1
   -- Every coordinate of `y` commutes with `A`, so `y = 1 ⊗ₜ b`.
-  have hcomm : ∀ a : A, Commute (a ⊗ₜ[K] (1 : B)) y := by
-    intro a
-    have hsupp : ((Algebra.TensorProduct.basis A 𝓑).repr
-        ((a ⊗ₜ[K] (1 : B)) * y - y * (a ⊗ₜ[K] (1 : B)))).support ⊆ S.erase i₀ := by
-      intro j hj
-      rw [Finsupp.mem_support_iff, map_sub, Finsupp.sub_apply,
-        Algebra.TensorProduct.tmul_one_mul_eq_smul, map_smul, Finsupp.smul_apply, smul_eq_mul,
-        Algebra.TensorProduct.basis_repr_mul_tmul_one] at hj
-      refine Finset.mem_erase.mpr ⟨?_, not_imp_comm.mp (fun hjS => ?_) hj⟩
-      · rintro rfl
-        exact hj (by rw [hy1, mul_one, one_mul, sub_self])
-      · rw [hyS j hjS, mul_zero, zero_mul, sub_self]
-    have hz : (a ⊗ₜ[K] (1 : B)) * y - y * (a ⊗ₜ[K] (1 : B)) = 0 :=
-      hmin _ (I.sub_mem (I.mul_mem_left _ _ hyI) (I.mul_mem_right _ _ hyI))
-        (lt_of_le_of_lt (Finset.card_le_card hsupp)
-          (hcard ▸ Finset.card_erase_lt_of_mem hi₀))
-    exact sub_eq_zero.mp hz
+  -- Every coordinate of `y` commutes with `A`, so `y = 1 ⊗ₜ b`.
+  have hcomm := commute_tmul_one_of_repr_eq_one 𝓑 hi₀ hyI hyS hy1 hmin
   obtain ⟨b, rfl⟩ := Algebra.TensorProduct.forall_commute_tmul_one_iff.mp hcomm
   have hb : b ≠ 0 := by rintro rfl; exact hy0 (by simp)
   -- The `c : B` with `1 ⊗ₜ c ∈ I` form a two-sided ideal of `B`, namely the preimage of `I` along
   -- `Algebra.TensorProduct.includeRight`; it contains `b ≠ 0`, hence it is everything.
-  have honeB : (1 : B) ∈
-      I.comap (Algebra.TensorProduct.includeRight : B →ₐ[K] A ⊗[K] B) :=
-    IsSimpleRing.one_mem_of_ne_zero_mem _ hb ((TwoSidedIdeal.mem_comap _).mpr (by simpa using hyI))
-  rw [TwoSidedIdeal.mem_comap] at honeB
-  simpa [Algebra.TensorProduct.one_def] using honeB
+  exact one_mem_of_one_tmul_mem hb hyI
 
 variable (K A B) in
 /-- **The tensor product of a simple `K`-algebra with a central simple `K`-algebra is simple.** This


### PR DESCRIPTION
Decomposes `TauCeti.IsSimpleRing.tensorProduct` in
`TauCeti/Algebra/CentralSimple/TensorProduct.lean`, at 80 lines the longest proof body on main. No
statement changes: the instance keeps its signature, and the four extracted helpers are `private`
and local to the file.

The file's own module docstring already describes the argument as four steps — *"pick a nonzero
`y ∈ I` with as few nonzero coordinates as possible; after rescaling one coordinate to `1` (which
is where simplicity of `A` is used), minimality forces every additive commutator … to vanish …;
simplicity of `B` then pushes `1` into `I`"* — but the proof ran them as one block. Each is now
stated on its own, in that order:

| helper | what it proves | body |
|---|---|---|
| `exists_minimal_support_mem` | a nonzero ideal has a nonzero element of minimal coordinate support | 8 |
| `exists_mem_repr_eq_one` | simplicity of `A` rescales the `i₀`-th coordinate to `1` | 29 |
| `commute_tmul_one_of_repr_eq_one` | minimality forces `a ⊗ₜ 1` to commute with that element | 15 |

`tensorProduct` goes from 80 lines to 33, and now reads as those three steps plus the final
appeal to simplicity of `B`, which stays inline: a dry-run `reuse` finding noted that wrapping it
would only specialise `IsSimpleRing.one_mem_of_ne_zero_mem` for a single caller.

**Hypotheses were re-derived at extraction, and each step turns out to need strictly less than the
whole theorem does.** The instance assumes `[Algebra.IsCentral K A] [IsSimpleRing A]
[IsSimpleRing B]`; of the four helpers:

* `exists_minimal_support_mem` needs **none** of them — only that the ideal is nonzero. It is pure
  `Nat.find` bookkeeping on support cardinalities.
* `exists_mem_repr_eq_one` needs **only `[IsSimpleRing A]`**. This is the step that builds the
  two-sided ideal of `i₀`-th coordinates; it does not see `B`'s simplicity, centrality, or the
  minimality of the support.
* `commute_tmul_one_of_repr_eq_one` needs **none** of them. It takes minimality as an ordinary
  hypothesis (`∀ z ∈ I, support.card < S.card → z = 0`) rather than re-deriving it, so it says
  nothing about *why* the support is minimal.

Centrality (`Algebra.IsCentral K A`) is therefore used nowhere in the four steps — it enters only
through `Algebra.TensorProduct.forall_commute_tmul_one_iff` in the parent, which is where the
commutation conclusion is converted into `y = 1 ⊗ₜ b`. That is now visible from the signatures.

One consequence of the split: the old proof carried `hcard`, an equation between the support
cardinality and `Nat.find hex`, purely to bridge the minimality hypothesis. `exists_minimal_support_mem`
states minimality directly against the support cardinality, so `hcard` and the `▸` rewrite that
used it are gone.

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: RepresentationTheory
