### PR TITLE
refactor(Probability): decompose the prefix set-integral identity

### DIFF
--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -9,6 +9,7 @@ public import TauCeti.Probability.Exchangeability.Cylinder
 public import TauCeti.Probability.Exchangeability.Contractability
 public import TauCeti.Probability.Exchangeability.MixedIID.Basic
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
+public import TauCeti.Probability.DeFinetti.DirectingMeasure.Integral
 public import Mathlib.Probability.Independence.Conditional
 public import Mathlib.MeasureTheory.Constructions.Polish.Basic
 -- Non-public: used only inside proofs — the tail factorization
@@ -56,15 +57,9 @@ finite-block rectangle identity for `directingProbabilityMeasure μ X`, exactly 
 * `mixedIID_of_exchangeable` — the exchangeable form (via `contractable_of_exchangeable`).
 
 The `..._of_iCondIndepFun_tailProcess` theorems expose the intermediate reduction (de Finetti given
-tail conditional independence of the coordinates). The rectangle-mixture staging lemmas and the
-standard-Borel-`Ω` existential are `private` (proof staging), with two exceptions, which are shared
-with the joint-rectangle argument of `DeFinetti/JointRectangle.lean`:
-
-* `integrable_prod_directingMeasure_real` — the directing-measure product is `[0,1]`-valued and
-  measurable, hence integrable against a finite measure;
-* `ofReal_integral_eq_lintegral_prod_directingMeasure` — the real integral of that product is the
-  `ℝ≥0∞` one, factor by factor. It is stated for an arbitrary measure `ν`, so the set-integral form
-  used there is the instance `ν := μ.restrict A`.
+tail conditional independence of the coordinates). All of the rectangle-mixture staging lemmas and
+the standard-Borel-`Ω` existential are `private` (proof staging); the integrability and real/`ℝ≥0∞`
+conversion facts this file runs on are `DirectingMeasure/Integral.lean`.
 
 The reverse-martingale ("third") proof follows Kallenberg, *Probabilistic Symmetries and Invariance
 Principles*, Theorem 1.1 (pp. 26–28). Adapted from `cameronfreer/exchangeability`
@@ -122,40 +117,6 @@ theorem condExp_blockIndicatorProd_ae_eq_prod_of_iCondIndepFun_tailProcess
   filter_upwards [key] with ω hω
   rw [Finset.prod_apply]
   exact Finset.prod_congr rfl fun i _ => hω i
-
-/-- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
-a finite measure. Only tail-measurability of the process and measurability of the blocks are
-used. -/
-lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
-    (hB : ∀ i, MeasurableSet (B i)) :
-    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
-  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
-    Finset.measurable_prod _ fun i _ =>
-      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
-  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
-  simp only [measureReal_def]
-  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
-  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
-    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
-
-/-- Push the real integral of the directing-measure product to the `ℝ≥0∞` one, factor by factor:
-each factor is a finite measure of a set, so `ofReal_toReal` applies. Stated for an arbitrary
-measure `ν`, so the set-integral form is the instance `ν := μ.restrict A`. -/
-lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α]
-    [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} {X : ℕ → Ω → α} {r : ℕ}
-    {B : Fin r → Set α}
-    (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν) :
-    ENNReal.ofReal (∫ ω, ∏ i, (directingMeasure μ X ω).real (B i) ∂ν)
-      = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν := by
-  rw [ofReal_integral_eq_lintegral_ofReal hg_int
-    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine lintegral_congr fun ω => ?_
-  simp only [measureReal_def]
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
 
 /-- **Block law of a rectangle as a directing-measure mixture.** If the tail conditional expectation
 of the block-indicator product is a.e. the directing-measure product

--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -116,6 +116,40 @@ theorem condExp_blockIndicatorProd_ae_eq_prod_of_iCondIndepFun_tailProcess
   rw [Finset.prod_apply]
   exact Finset.prod_congr rfl fun i _ => hω i
 
+/-- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
+a finite measure. Only tail-measurability of the process and measurability of the blocks are
+used. -/
+lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
+    (hB : ∀ i, MeasurableSet (B i)) :
+    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
+  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
+    Finset.measurable_prod _ fun i _ =>
+      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
+  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
+  simp only [measureReal_def]
+  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
+  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
+    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
+
+/-- Push the real integral of the directing-measure product to the `ℝ≥0∞` one, factor by factor:
+each factor is a finite measure of a set, so `ofReal_toReal` applies. Stated for an arbitrary
+measure `ν`, so the set-integral form is the instance `ν := μ.restrict A`. -/
+lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α]
+    [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} {X : ℕ → Ω → α} {r : ℕ}
+    {B : Fin r → Set α}
+    (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν) :
+    ENNReal.ofReal (∫ ω, ∏ i, (directingMeasure μ X ω).real (B i) ∂ν)
+      = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν := by
+  rw [ofReal_integral_eq_lintegral_ofReal hg_int
+    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine lintegral_congr fun ω => ?_
+  simp only [measureReal_def]
+  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
+  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+
 /-- **Block law of a rectangle as a directing-measure mixture.** If the tail conditional expectation
 of the block-indicator product is a.e. the directing-measure product
 `∏ i, (directingMeasure μ X ω).real (C i)`, then the block law of the rectangle `∏ᵢ C i` is the
@@ -131,18 +165,7 @@ private theorem blockLaw_eq_lintegral_prod_directingMeasure_of_condExp_ae_eq
   have hTail : tailProcess X ≤ mΩ := tailProcess_le_ambient 0 fun j _ => hX_meas j
   haveI : IsFiniteMeasure (μ.trim hTail) := isFiniteMeasure_trim hTail
   set g : Ω → ℝ := fun ω => ∏ i, (directingMeasure μ X ω).real (C i) with hg
-  have hg_meas : Measurable g :=
-    Finset.measurable_prod _ fun i _ =>
-      (measurable_directingMeasure_coe hTail (hC i)).ennreal_toReal
-  have hg_bound : ∀ ω, ‖g ω‖ ≤ 1 := fun ω => by
-    have hval : g ω = ∏ i, ((directingMeasure μ X ω) (C i)).toReal := by
-      simp only [hg, measureReal_def]
-    rw [hval, Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-    refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
-    exact ENNReal.toReal_le_of_le_ofReal zero_le_one
-      (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
-  have hg_int : Integrable g μ :=
-    (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ hg_bound)
+  have hg_int : Integrable g μ := integrable_prod_directingMeasure_real hTail hC
   have hbl : (blockLaw μ X k (Set.univ.pi C)).toReal = ∫ ω, g ω ∂μ := by
     rw [← integral_blockIndicatorProd (fun i => (hX_meas (k i)).aemeasurable) hC,
       ← integral_condExp hTail]
@@ -150,13 +173,8 @@ private theorem blockLaw_eq_lintegral_prod_directingMeasure_of_condExp_ae_eq
   have hbl_ne : blockLaw μ X k (Set.univ.pi C) ≠ ⊤ := by
     rw [blockLaw_blockCylinder X (fun i => (hX_meas (k i)).aemeasurable) hC]
     exact measure_ne_top μ _
-  rw [← ENNReal.ofReal_toReal hbl_ne, hbl,
-    ofReal_integral_eq_lintegral_ofReal hg_int (ae_of_all _ fun ω =>
-      Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine lintegral_congr fun ω => ?_
-  simp only [hg, measureReal_def]
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+  rw [← ENNReal.ofReal_toReal hbl_ne, hbl, hg,
+    ofReal_integral_eq_lintegral_prod_directingMeasure hg_int]
 
 /-- **Block law of a rectangle as a directing-measure mixture** (given tail conditional
 independence). The block law of the rectangle `∏ᵢ C i` is the `μ`-average of the directing-measure

--- a/TauCeti/Probability/DeFinetti/BlockFactorization.lean
+++ b/TauCeti/Probability/DeFinetti/BlockFactorization.lean
@@ -56,8 +56,15 @@ finite-block rectangle identity for `directingProbabilityMeasure μ X`, exactly 
 * `mixedIID_of_exchangeable` — the exchangeable form (via `contractable_of_exchangeable`).
 
 The `..._of_iCondIndepFun_tailProcess` theorems expose the intermediate reduction (de Finetti given
-tail conditional independence of the coordinates). All of the rectangle-mixture staging lemmas and
-the standard-Borel-`Ω` existential are `private` (proof staging).
+tail conditional independence of the coordinates). The rectangle-mixture staging lemmas and the
+standard-Borel-`Ω` existential are `private` (proof staging), with two exceptions, which are shared
+with the joint-rectangle argument of `DeFinetti/JointRectangle.lean`:
+
+* `integrable_prod_directingMeasure_real` — the directing-measure product is `[0,1]`-valued and
+  measurable, hence integrable against a finite measure;
+* `ofReal_integral_eq_lintegral_prod_directingMeasure` — the real integral of that product is the
+  `ℝ≥0∞` one, factor by factor. It is stated for an arbitrary measure `ν`, so the set-integral form
+  used there is the instance `ν := μ.restrict A`.
 
 The reverse-martingale ("third") proof follows Kallenberg, *Probabilistic Symmetries and Invariance
 Principles*, Theorem 1.1 (pp. 26–28). Adapted from `cameronfreer/exchangeability`

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
+
+/-!
+# Integrating finite products of directing-measure evaluations
+
+Two facts about `∏ i, directingMeasure μ X ω (B i)`, read as a function of `ω`, that the de Finetti
+rectangle arguments need: it is integrable in its real form, and its real integral agrees with its
+`ℝ≥0∞` integral.
+
+## Main results
+
+* `integrable_prod_directingMeasure_real` — the product of the real evaluations is `[0,1]`-valued
+  and measurable, hence integrable against a finite measure.
+* `ofReal_integral_eq_lintegral_prod_directingMeasure` — the real integral of that product is the
+  `ℝ≥0∞` integral of the product of the evaluations themselves.
+
+Both are stated for an arbitrary measure in the integration slot, so the set-integral forms are the
+instances at `μ.restrict A`. Neither mentions conditional independence, block factorization, or any
+cylinder: they are facts about the directing measure alone, which is why they live here rather than
+in the summit modules that consume them (`DeFinetti/BlockFactorization.lean` and
+`DeFinetti/JointRectangle.lean`).
+
+This module is separate from `DirectingMeasure/Basic.lean` so that the measurability and evaluation
+API there stays free of the Bochner/Lebesgue integration dependencies these two results need.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} {mΩ : MeasurableSpace Ω} [MeasurableSpace α]
+
+/-- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
+a finite measure. Only tail-measurability of the process and measurability of the blocks are
+used. -/
+lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
+    (hB : ∀ i, MeasurableSet (B i)) :
+    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
+  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
+    Finset.measurable_prod _ fun i _ =>
+      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
+  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
+  simp only [measureReal_def]
+  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
+  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
+    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
+
+/-- The real integral of the directing-measure product is its `ℝ≥0∞` integral, factor by factor:
+each factor is a finite measure of a set, so `ENNReal.ofReal_toReal` applies. Stated for an
+arbitrary measure `ν`, so the set-integral form is the instance `ν := μ.restrict A`. -/
+lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} {X : ℕ → Ω → α} {r : ℕ}
+    {B : Fin r → Set α}
+    (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν) :
+    ENNReal.ofReal (∫ ω, ∏ i, (directingMeasure μ X ω).real (B i) ∂ν)
+      = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν := by
+  rw [ofReal_integral_eq_lintegral_ofReal hg_int
+    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine lintegral_congr fun ω => ?_
+  simp only [measureReal_def]
+  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
+  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+
+end Probability
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
 public import Mathlib.MeasureTheory.Integral.Bochner.Set
-public import Mathlib.MeasureTheory.Integral.Lebesgue.Basic
 
 /-!
 # Integrating finite products of directing-measure evaluations
@@ -22,11 +21,12 @@ rectangle arguments need: it is integrable in its real form, and its real integr
 * `ofReal_integral_eq_lintegral_prod_directingMeasure` — the real integral of that product is the
   `ℝ≥0∞` integral of the product of the evaluations themselves.
 
-Both are stated for an arbitrary measure in the integration slot, so the set-integral forms are the
-instances at `μ.restrict A`. Neither mentions conditional independence, block factorization, or any
-cylinder: they are facts about the directing measure alone, which is why they live here rather than
-in the summit modules that consume them (`DeFinetti/BlockFactorization.lean` and
-`DeFinetti/JointRectangle.lean`).
+In both, the measure in the integration slot is independent of the measure `μ` that defines the
+directing measure: `μ` is only the directing-measure parameter, and the integral is taken against a
+separate `ν`. The set-integral forms are the instances at `ν := μ.restrict A`. Neither mentions
+conditional independence, block factorization, or any cylinder: they are facts about the directing
+measure alone, which is why they live here rather than in the summit modules that consume them
+(`DeFinetti/BlockFactorization.lean` and `DeFinetti/JointRectangle.lean`).
 
 This module is separate from `DirectingMeasure/Basic.lean` so that the measurability and evaluation
 API there stays free of the Bochner/Lebesgue integration dependencies these two results need.
@@ -45,13 +45,13 @@ namespace Probability
 variable {Ω α : Type*} {mΩ : MeasurableSpace Ω} [MeasurableSpace α]
 
 /-- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
-a finite measure. Only tail-measurability of the process and measurability of the blocks are
-used. -/
+a finite measure. Only tail-measurability of the process and measurability of the blocks are used;
+the integration measure `ν` is unrelated to the `μ` defining the directing measure. -/
 lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} [IsFiniteMeasure ν] {X : ℕ → Ω → α}
     (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
     (hB : ∀ i, MeasurableSet (B i)) :
-    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
+    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν := by
   have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
     Finset.measurable_prod _ fun i _ =>
       (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
@@ -63,8 +63,8 @@ lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α
     (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
 
 /-- The real integral of the directing-measure product is its `ℝ≥0∞` integral, factor by factor:
-each factor is a finite measure of a set, so `ENNReal.ofReal_toReal` applies. Stated for an
-arbitrary measure `ν`, so the set-integral form is the instance `ν := μ.restrict A`. -/
+each factor is a finite measure of a set, so `ENNReal.ofReal_toReal` applies. As above, `ν` is an
+arbitrary integration measure, so the set-integral form is the instance `ν := μ.restrict A`. -/
 lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α] [Nonempty α]
     {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} {X : ℕ → Ω → α} {r : ℕ}
     {B : Fin r → Set α}

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -42,8 +42,8 @@ supply that, all private.
 **The set-integral identity.** The mass on the tail event `ν ⁻¹' S` meeting a *prefix* block
 cylinder is the integral of the directing-measure product over that event. Since `ν` is
 `tailProcess`-measurable, `ν ⁻¹' S` is a tail event, so `setIntegral_condExp` may be tested against
-it and the prefix factorization replaces the conditional expectation. All real/`ℝ≥0∞` conversion is
-confined here.
+it and the prefix factorization replaces the conditional expectation. The real/`ℝ≥0∞` conversion it
+runs on is `DirectingMeasure/Integral.lean`, shared with `BlockFactorization`.
 
 **Symmetry transport.** A finitely supported permutation realising an injective selection on the
 initial segment carries the prefix identity to that selection. It fixes `ν`, because tail events lie
@@ -84,23 +84,12 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
--- Integrating the block indicator over a set is the real mass of the intersection: the indicator
--- of the cylinder integrates to its measure. Needs no tail structure and no directing measure.
-private lemma setIntegral_blockIndicatorProd_eq_measureReal {μ : Measure Ω}
-    {X : ℕ → Ω → α} {r : ℕ} {k : Fin r → ℕ} (hX_meas : ∀ i, Measurable (X (k i)))
-    {B : Fin r → Set α} (hB : ∀ i, MeasurableSet (B i)) (A : Set Ω) :
-    ∫ ω in A, blockIndicatorProd X k B ω ∂μ = μ.real (A ∩ blockCylinder X k B) := by
-  rw [blockIndicatorProd_eq_indicator,
-    setIntegral_indicator (measurableSet_blockCylinder hX_meas hB),
-    setIntegral_const, Set.inter_comm]
-  simp [measureReal_def]
-
 /-- **Core set-integral identity.** The mass on the tail event `ν ⁻¹' S` intersected with a prefix
 block cylinder is the integral of the directing-measure product over that event.
 
-All real/`ℝ≥0∞` conversion for the joint-rectangle argument is confined here: the tail event is
-`tailProcess X`-measurable, so `setIntegral_condExp` may be tested against it, and the prefix
-factorization then replaces the conditional expectation. -/
+The tail event is `tailProcess X`-measurable, so `setIntegral_condExp` may be tested against it, and
+the prefix factorization then replaces the conditional expectation; the real/`ℝ≥0∞` conversion is
+`ofReal_integral_eq_lintegral_prod_directingMeasure`. -/
 private theorem measure_inter_blockCylinder_eq_setLIntegral
     [StandardBorelSpace Ω] [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ]
     {X : ℕ → Ω → α} (hX : Contractable μ X) (hX_meas : ∀ n, Measurable (X n))
@@ -130,9 +119,17 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
     filter_upwards
       [condExp_blockIndicatorProd_prefix_ae_eq_prod_directingMeasure hX hX_meas hB] with ω hω _
     exact hω
+  -- The left side is the real mass of the intersection, via the public block-indicator integral
+  -- read against the restricted measure.
+  have hleft : ∫ ω in A, blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B ω ∂μ
+      = μ.real (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) := by
+    rw [integral_blockIndicatorProd (μ := μ.restrict A) (fun i => (hX_meas _).aemeasurable) hB,
+      blockLaw_blockCylinder X (fun i => (hX_meas _).aemeasurable) hB,
+      Measure.restrict_apply (measurableSet_blockCylinder (fun i => hX_meas _) hB),
+      Set.inter_comm]
+    rfl
   have hne : μ (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) ≠ ⊤ := measure_ne_top μ _
-  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def,
-    ← setIntegral_blockIndicatorProd_eq_measureReal (fun i => hX_meas _) hB A, hchain,
+  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def, ← hleft, hchain,
     ofReal_integral_eq_lintegral_prod_directingMeasure hg_int.restrict]
 
 -- A finitely supported reindexing pulls the prefix cylinder back to the `k`-cylinder, once the

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -84,49 +84,16 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
--- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
--- a finite measure. Only tail-measurability of the process and measurability of the blocks are
--- used: no contractability, no tail event.
-private lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
-    (hTail : tailProcess X ≤ ‹MeasurableSpace Ω›) {r : ℕ} {B : Fin r → Set α}
-    (hB : ∀ i, MeasurableSet (B i)) :
-    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
-  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
-    Finset.measurable_prod _ fun i _ =>
-      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
-  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
-  simp only [measureReal_def]
-  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
-  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
-    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
-
 -- Integrating the block indicator over a set is the real mass of the intersection: the indicator
 -- of the cylinder integrates to its measure. Needs no tail structure and no directing measure.
-private lemma setIntegral_blockIndicatorProd_eq_measureReal {μ : Measure Ω} [IsFiniteMeasure μ]
-    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) {r : ℕ} {k : Fin r → ℕ} {B : Fin r → Set α}
-    (hB : ∀ i, MeasurableSet (B i)) (A : Set Ω) :
+private lemma setIntegral_blockIndicatorProd_eq_measureReal {μ : Measure Ω}
+    {X : ℕ → Ω → α} {r : ℕ} {k : Fin r → ℕ} (hX_meas : ∀ i, Measurable (X (k i)))
+    {B : Fin r → Set α} (hB : ∀ i, MeasurableSet (B i)) (A : Set Ω) :
     ∫ ω in A, blockIndicatorProd X k B ω ∂μ = μ.real (A ∩ blockCylinder X k B) := by
   rw [blockIndicatorProd_eq_indicator,
-    setIntegral_indicator (measurableSet_blockCylinder (fun i => hX_meas _) hB),
+    setIntegral_indicator (measurableSet_blockCylinder hX_meas hB),
     setIntegral_const, Set.inter_comm]
   simp [measureReal_def]
-
--- Push a real integral of the directing-measure product to the `ℝ≥0∞` one, coordinate by
--- coordinate: each factor is a finite measure of a set, so `ofReal_toReal` applies.
-private lemma ofReal_setIntegral_eq_setLIntegral_prod [StandardBorelSpace α] [Nonempty α]
-    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {r : ℕ} {B : Fin r → Set α} {A : Set Ω}
-    (hA : MeasurableSet A)
-    (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ) :
-    ENNReal.ofReal (∫ ω in A, ∏ i, (directingMeasure μ X ω).real (B i) ∂μ)
-      = ∫⁻ ω in A, ∏ i, directingMeasure μ X ω (B i) ∂μ := by
-  rw [ofReal_integral_eq_lintegral_ofReal hg_int.restrict
-    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine setLIntegral_congr_fun hA (fun ω _ => ?_)
-  simp only [measureReal_def]
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
 
 /-- **Core set-integral identity.** The mass on the tail event `ν ⁻¹' S` intersected with a prefix
 block cylinder is the integral of the directing-measure product over that event.
@@ -165,8 +132,8 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
     exact hω
   have hne : μ (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) ≠ ⊤ := measure_ne_top μ _
   rw [← ENNReal.ofReal_toReal hne, ← measureReal_def,
-    ← setIntegral_blockIndicatorProd_eq_measureReal hX_meas hB A, hchain,
-    ofReal_setIntegral_eq_setLIntegral_prod hA hg_int]
+    ← setIntegral_blockIndicatorProd_eq_measureReal (fun i => hX_meas _) hB A, hchain,
+    ofReal_integral_eq_lintegral_prod_directingMeasure hg_int.restrict]
 
 -- A finitely supported reindexing pulls the prefix cylinder back to the `k`-cylinder, once the
 -- permutation realises `k` on the initial segment. This is a set identity: no measure, no

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -126,8 +126,7 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
     rw [integral_blockIndicatorProd (μ := μ.restrict A) (fun i => (hX_meas _).aemeasurable) hB,
       blockLaw_blockCylinder X (fun i => (hX_meas _).aemeasurable) hB,
       Measure.restrict_apply (measurableSet_blockCylinder (fun i => hX_meas _) hB),
-      Set.inter_comm]
-    rfl
+      Set.inter_comm, measureReal_def]
   have hne : μ (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) ≠ ⊤ := measure_ne_top μ _
   rw [← ENNReal.ofReal_toReal hne, ← measureReal_def, ← hleft, hchain,
     ofReal_integral_eq_lintegral_prod_directingMeasure hg_int.restrict]

--- a/TauCeti/Probability/DeFinetti/JointRectangle.lean
+++ b/TauCeti/Probability/DeFinetti/JointRectangle.lean
@@ -84,6 +84,50 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
+-- The directing-measure product is a `[0,1]`-valued measurable function, hence integrable against
+-- a finite measure. Only tail-measurability of the process and measurability of the blocks are
+-- used: no contractability, no tail event.
+private lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hTail : tailProcess X ≤ ‹MeasurableSpace Ω›) {r : ℕ} {B : Fin r → Set α}
+    (hB : ∀ i, MeasurableSet (B i)) :
+    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ := by
+  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
+    Finset.measurable_prod _ fun i _ =>
+      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
+  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
+  simp only [measureReal_def]
+  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
+  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
+    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
+
+-- Integrating the block indicator over a set is the real mass of the intersection: the indicator
+-- of the cylinder integrates to its measure. Needs no tail structure and no directing measure.
+private lemma setIntegral_blockIndicatorProd_eq_measureReal {μ : Measure Ω} [IsFiniteMeasure μ]
+    {X : ℕ → Ω → α} (hX_meas : ∀ n, Measurable (X n)) {r : ℕ} {k : Fin r → ℕ} {B : Fin r → Set α}
+    (hB : ∀ i, MeasurableSet (B i)) (A : Set Ω) :
+    ∫ ω in A, blockIndicatorProd X k B ω ∂μ = μ.real (A ∩ blockCylinder X k B) := by
+  rw [blockIndicatorProd_eq_indicator,
+    setIntegral_indicator (measurableSet_blockCylinder (fun i => hX_meas _) hB),
+    setIntegral_const, Set.inter_comm]
+  simp [measureReal_def]
+
+-- Push a real integral of the directing-measure product to the `ℝ≥0∞` one, coordinate by
+-- coordinate: each factor is a finite measure of a set, so `ofReal_toReal` applies.
+private lemma ofReal_setIntegral_eq_setLIntegral_prod [StandardBorelSpace α] [Nonempty α]
+    {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α} {r : ℕ} {B : Fin r → Set α} {A : Set Ω}
+    (hA : MeasurableSet A)
+    (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ) :
+    ENNReal.ofReal (∫ ω in A, ∏ i, (directingMeasure μ X ω).real (B i) ∂μ)
+      = ∫⁻ ω in A, ∏ i, directingMeasure μ X ω (B i) ∂μ := by
+  rw [ofReal_integral_eq_lintegral_ofReal hg_int.restrict
+    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine setLIntegral_congr_fun hA (fun ω _ => ?_)
+  simp only [measureReal_def]
+  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
+  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+
 /-- **Core set-integral identity.** The mass on the tail event `ν ⁻¹' S` intersected with a prefix
 block cylinder is the integral of the directing-measure product over that event.
 
@@ -107,43 +151,22 @@ private theorem measure_inter_blockCylinder_eq_setLIntegral
   have hA_tail : MeasurableSet[tailProcess X] A :=
     measurable_tailProcess_directingProbabilityMeasure hS
   have hA : MeasurableSet A := hTail _ hA_tail
-  set g : Ω → ℝ := fun ω => ∏ i, (directingMeasure μ X ω).real (B i) with hg
-  have hg_meas : Measurable g :=
-    Finset.measurable_prod _ fun i _ =>
-      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
-  have hg_nonneg : ∀ ω, 0 ≤ g ω := fun ω =>
-    Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg
-  have hg_bound : ∀ ω, ‖g ω‖ ≤ 1 := fun ω => by
-    rw [Real.norm_of_nonneg (hg_nonneg ω)]
-    refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
-    exact ENNReal.toReal_le_of_le_ofReal zero_le_one
-      (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
-  have hg_int : Integrable g μ :=
-    (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ hg_bound)
+  have hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) μ :=
+    integrable_prod_directingMeasure_real hTail hB
   have hind_int : Integrable (blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B) μ :=
     integrable_blockIndicatorProd (fun i => (hX_meas _).aemeasurable) hB
   -- the conditional factorization, tested against the tail event `A`
   have hchain : ∫ ω in A, blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B ω ∂μ
-      = ∫ ω in A, g ω ∂μ := by
+      = ∫ ω in A, ∏ i, (directingMeasure μ X ω).real (B i) ∂μ := by
     rw [← setIntegral_condExp hTail hind_int hA_tail]
     refine setIntegral_congr_ae hA ?_
     filter_upwards
       [condExp_blockIndicatorProd_prefix_ae_eq_prod_directingMeasure hX hX_meas hB] with ω hω _
     exact hω
-  -- the left side is the real mass of the intersection
-  have hleft : ∫ ω in A, blockIndicatorProd X (fun i : Fin r => (i : ℕ)) B ω ∂μ
-      = μ.real (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) := by
-    rw [blockIndicatorProd_eq_indicator,
-      setIntegral_indicator (measurableSet_blockCylinder
-        (fun i => hX_meas _) hB), setIntegral_const, Set.inter_comm]
-    simp [measureReal_def]
   have hne : μ (A ∩ blockCylinder X (fun i : Fin r => (i : ℕ)) B) ≠ ⊤ := measure_ne_top μ _
-  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def, ← hleft, hchain,
-    ofReal_integral_eq_lintegral_ofReal (hg_int.restrict) (ae_of_all _ hg_nonneg)]
-  refine setLIntegral_congr_fun hA (fun ω _ => ?_)
-  simp only [hg, measureReal_def]
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+  rw [← ENNReal.ofReal_toReal hne, ← measureReal_def,
+    ← setIntegral_blockIndicatorProd_eq_measureReal hX_meas hB A, hchain,
+    ofReal_setIntegral_eq_setLIntegral_prod hA hg_int]
 
 -- A finitely supported reindexing pulls the prefix cylinder back to the `k`-cylinder, once the
 -- permutation realises `k` on the initial segment. This is a set identity: no measure, no


### PR DESCRIPTION
Decomposes `measure_inter_blockCylinder_eq_setLIntegral` in
`TauCeti/Probability/DeFinetti/JointRectangle.lean`, at 50 lines the longest proof body on main
after the two already in flight. No statement changes: the theorem keeps its signature.

This is the prefix sibling of `measure_inter_blockCylinder_eq_setLIntegral_of_injective`, decomposed
in #1613. Its own docstring described it as confining the real/`ℝ≥0∞` conversion, and that is
exactly the shape the block had: two generic facts about the directing measure, one restatement of
existing cylinder API, and the conditional factorization that is the actual content.

**After three rounds of review the result is mostly *deletion and relocation* rather than new
helpers**, which is a better outcome than the one I opened with:

| what | where it ended up |
|---|---|
| `integrable_prod_directingMeasure_real` | new `DeFinetti/DirectingMeasure/Integral.lean`, public, shared |
| `ofReal_integral_eq_lintegral_prod_directingMeasure` | same module, public, shared |
| the block-indicator/measure identity | **deleted** — it reproved `integral_blockIndicatorProd` at `μ.restrict A` |

`measure_inter_blockCylinder_eq_setLIntegral` goes from 50 lines to 29. What remains in it is the
conditional factorization tested against the tail event — the step that actually uses
contractability.

**The two shared lemmas already existed, nearly verbatim, elsewhere.** A `reuse` finding observed
that `blockLaw_eq_lintegral_prod_directingMeasure_of_condExp_ae_eq` in `BlockFactorization` carries
the same integrability argument and the same
`ofReal_integral_eq_lintegral_ofReal` → `ENNReal.ofReal_prod_of_nonneg` → `Finset.prod_congr` tail.
Both proofs now use the shared lemmas, so that consumer shrinks too: **38 lines to 14**.

The conversion lemma is stated over an arbitrary measure `ν` rather than as a set-integral lemma, so
the full-integral use in `BlockFactorization` and the set-integral use here are the instances
`ν := μ` and `ν := μ.restrict A`. That single generalisation also drops the `MeasurableSet A`
hypothesis a set-specific version would need.

**Why a new module rather than `DirectingMeasure/Basic.lean`.** A `placement` finding noted these
are generic directing-measure facts and do not belong in a later summit module, offering either
`Basic.lean` or a focused submodule. `Basic.lean` currently has no integral usage and imports no
integration, so hosting them there would push Bochner/Lebesgue onto every downstream importer of the
directing-measure API. The submodule keeps that dependency where it is paid for.

**Hypotheses were re-derived at extraction.** The theorem assumes `Contractable μ X`, a measurable
tail event `S`, and both standard-Borel instances; neither shared lemma needs contractability, and
neither sees `S`. `integrable_prod_directingMeasure_real` needs only tail-measurability of the
process and measurability of the blocks; `ofReal_integral_eq_lintegral_prod_directingMeasure` needs
only integrability of the product against `ν`.

Two docstrings were corrected along the way, both falsified by this PR's own movements:
`BlockFactorization`'s "all staging lemmas are `private`" (restored, now that its public exceptions
have moved out) and `JointRectangle`'s "all real/`ℝ≥0∞` conversion is confined here" (in both the
module and the theorem docstring).

Gates run locally as separate steps: `lake build` (read in full, not tailed), `lake exe axioms`,
`lake exe module-system`, `bash scripts/lint-env.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Roadmap: Exchangeability
