### PR TITLE
feat: characterize regular connected covers

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Regular.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Regular.lean
@@ -1,0 +1,84 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.Pointed
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular.Monodromy
+public import TauCeti.Topology.Homotopy.Monodromy
+
+/-!
+# Regular connected covers and normal subgroups
+
+A pointed connected covering recovers the image of the fundamental group of its total space in
+the fundamental group of the base. This file proves the regular-cover criterion: over a
+path-connected base, the covering is regular exactly when that recovered subgroup is normal.
+
+The proof combines two existing classification results. Normality says that the recovered
+subgroup is independent of the chosen point in a fibre, while pointed-cover classification says
+that equality of those subgroups is exactly the existence of a deck transformation carrying one
+chosen point to the other. The monodromy transport API then promotes transitivity on the chosen
+fibre to regularity on every fibre.
+
+## Main declaration
+
+* `TauCeti.IsCoveringMap.isRegular_iff_normal_range`: a connected covering is regular exactly
+  when its recovered subgroup of the fundamental group is normal.
+
+## References
+
+This is the regular-cover criterion in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2,
+item 8: a cover attached to `H` is regular (normal/Galois) exactly when `H` is normal. It uses
+Mathlib's covering-space lifting criterion, due to Junyan Xu, through Tau Ceti's pointed-cover
+classification; no external proof is copied or adapted here.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.FundamentalGroup
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X} {x : X}
+
+/-- **Regular-cover criterion.** Let `p : E → X` be a covering map with path-connected,
+locally path-connected total space and path-connected base. For any chosen lift `e` of `x`, the
+deck action is regular exactly when the recovered subgroup
+`p_* π₁(E, e) ≤ π₁(X, x)` is normal. -/
+theorem IsCoveringMap.isRegular_iff_normal_range
+    [PathConnectedSpace E] [LocallyPathConnectedSpace E] [PathConnectedSpace X]
+    (hp : _root_.IsCoveringMap p) (e : p ⁻¹' {x}) :
+    Deck.IsRegular p ↔
+      (mapOfEq ⟨p, hp.continuous⟩ e.2).range.Normal := by
+  rw [Deck.isRegular_iff_fiber_isPretransitive hp e,
+    TauCeti.IsCoveringMap.normal_range_iff hp e]
+  constructor
+  · intro htrans e'
+    letI := htrans
+    obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) e e'
+    have hhome : ∃ h : E ≃ₜ E, h e = e' ∧ p ∘ h = p := by
+      refine ⟨φ.1, ?_, ?_⟩
+      · simpa only [Deck.fiber_smul_coe] using congrArg Subtype.val hφ
+      · funext z
+        exact Deck.map_proj φ z
+    have hrange :=
+      (TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_iff_range_eq
+        hp hp e.2 e'.2).mp hhome
+    simpa only using hrange.symm
+  · intro hrange
+    refine MulAction.IsPretransitive.mk ?_
+    intro e₀ e₁
+    have h₀₁ :
+        (mapOfEq ⟨p, hp.continuous⟩ e₀.2).range =
+          (mapOfEq ⟨p, hp.continuous⟩ e₁.2).range :=
+      (hrange e₀).trans (hrange e₁).symm
+    obtain ⟨h, he, hcomp⟩ :=
+      TauCeti.IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq
+        hp hp e₀.2 e₁.2 h₀₁
+    let φ : Deck p := ⟨h, fun z ↦ congrFun hcomp z⟩
+    refine ⟨φ, ?_⟩
+    apply Subtype.ext
+    simpa only [Deck.fiber_smul_coe] using he
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Lifting
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber.Basic
+
+/-!
+# Deck actions and monodromy transport
+
+Deck transformations commute with transport between fibres by covering-space monodromy.
+
+## Main declaration
+
+* `TauCeti.Deck.monodromy_smul`: deck transformations commute with monodromy along a path.
+
+## References
+
+The proof uses Junyan Xu's path-lifting and monodromy API in
+`Mathlib.Topology.Homotopy.Lifting`. It supplies the fibre-transport step needed for the regular
+cover criterion in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
+  {x y : X}
+
+/-- Transport by covering-space monodromy commutes with the action of a deck transformation.
+
+Both sides transport a point of the fibre over `x` to the fibre over `y`: one first applies the
+deck transformation and then lifts the path, while the other first lifts the path and then
+applies the deck transformation. -/
+@[simp]
+theorem monodromy_smul (hp : IsCoveringMap p)
+    (γ : Path.Homotopic.Quotient x y) (φ : Deck p) (e : p ⁻¹' {x}) :
+    hp.monodromy γ (φ • e) = φ • hp.monodromy γ e := by
+  let Γ := hp.liftPathQuotient γ e
+  let g : C(E, E) := ⟨φ.1, φ.1.continuous⟩
+  let p' : C(E, X) := ⟨p, hp.continuous⟩
+  have hgp : p'.comp g = p' := by
+    ext z
+    exact map_proj φ z
+  have hmapComp : Γ.map (p'.comp g) ≍ Γ.map p' :=
+    congr_arg_heq (fun q : C(E, X) ↦ Γ.map q) hgp
+  have hmapMap : (Γ.map g).map p' = Γ.map (p'.comp g) :=
+    Path.Homotopic.Quotient.map_comp.symm
+  have hmap : (Γ.map g).map p' ≍ Γ.map p' :=
+    (heq_of_eq hmapMap).trans hmapComp
+  let Γ' : Path.Homotopic.Quotient ((φ • e : p ⁻¹' {x}) : E)
+      ((φ • hp.monodromy γ e : p ⁻¹' {y}) : E) :=
+    (Γ.map g).cast (fiber_smul_coe φ e) (fiber_smul_coe φ (hp.monodromy γ e))
+  apply hp.monodromy_eq_of_map_eq Γ'
+  dsimp only [Γ']
+  rw [Path.Homotopic.Quotient.map_cast]
+  apply eq_of_heq
+  have hcastSource :
+      ((Γ.map g).map p').cast
+          (congrArg p' (fiber_smul_coe φ e))
+          (congrArg p' (fiber_smul_coe φ (hp.monodromy γ e))) ≍
+        (Γ.map g).map p' :=
+    Path.Homotopic.Quotient.cast_heq _ _
+  have hlift : Γ.map p' ≍ γ.cast e.2 (hp.monodromy γ e).2 :=
+    heq_of_eq (hp.map_liftPathQuotient γ e)
+  have hcastLift : γ.cast e.2 (hp.monodromy γ e).2 ≍ γ :=
+    Path.Homotopic.Quotient.cast_heq _ _
+  have hcastTarget : γ ≍ γ.cast (φ • e).2 (φ • hp.monodromy γ e).2 :=
+    (Path.Homotopic.Quotient.cast_heq _ _).symm
+  exact hcastSource.trans (hmap.trans (hlift.trans (hcastLift.trans hcastTarget)))
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
@@ -18,9 +18,10 @@ Deck transformations commute with transport between fibres by covering-space mon
 
 ## References
 
-The proof uses Junyan Xu's path-lifting and monodromy API in
-`Mathlib.Topology.Homotopy.Lifting`. It supplies the fibre-transport step needed for the regular
-cover criterion in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8.
+The proof adapts Junyan Xu's proof of Mathlib's
+`IsQuotientCoveringMap.monodromy_toPermFiber`, replacing the quotient-cover group action with the
+deck-transformation action. It supplies the fibre-transport step needed for the regular-cover
+criterion in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8.
 -/
 
 public section
@@ -48,6 +49,8 @@ theorem monodromy_smul (hp : IsCoveringMap p)
     ext z
     exact map_proj φ z
   apply hp.monodromy_eq_of_map_eq (Γ.map g)
+  -- The displayed goal hides the mapped lifted path behind its endpoint transports; expose that
+  -- path-map wrapper before rewriting the composition of maps.
   change (Γ.map g).map p' = _
   rw [← Path.Homotopic.Quotient.map_comp]
   convert hp.map_liftPathQuotient γ e using 2

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Monodromy.lean
@@ -47,32 +47,11 @@ theorem monodromy_smul (hp : IsCoveringMap p)
   have hgp : p'.comp g = p' := by
     ext z
     exact map_proj φ z
-  have hmapComp : Γ.map (p'.comp g) ≍ Γ.map p' :=
-    congr_arg_heq (fun q : C(E, X) ↦ Γ.map q) hgp
-  have hmapMap : (Γ.map g).map p' = Γ.map (p'.comp g) :=
-    Path.Homotopic.Quotient.map_comp.symm
-  have hmap : (Γ.map g).map p' ≍ Γ.map p' :=
-    (heq_of_eq hmapMap).trans hmapComp
-  let Γ' : Path.Homotopic.Quotient ((φ • e : p ⁻¹' {x}) : E)
-      ((φ • hp.monodromy γ e : p ⁻¹' {y}) : E) :=
-    (Γ.map g).cast (fiber_smul_coe φ e) (fiber_smul_coe φ (hp.monodromy γ e))
-  apply hp.monodromy_eq_of_map_eq Γ'
-  dsimp only [Γ']
-  rw [Path.Homotopic.Quotient.map_cast]
-  apply eq_of_heq
-  have hcastSource :
-      ((Γ.map g).map p').cast
-          (congrArg p' (fiber_smul_coe φ e))
-          (congrArg p' (fiber_smul_coe φ (hp.monodromy γ e))) ≍
-        (Γ.map g).map p' :=
-    Path.Homotopic.Quotient.cast_heq _ _
-  have hlift : Γ.map p' ≍ γ.cast e.2 (hp.monodromy γ e).2 :=
-    heq_of_eq (hp.map_liftPathQuotient γ e)
-  have hcastLift : γ.cast e.2 (hp.monodromy γ e).2 ≍ γ :=
-    Path.Homotopic.Quotient.cast_heq _ _
-  have hcastTarget : γ ≍ γ.cast (φ • e).2 (φ • hp.monodromy γ e).2 :=
-    (Path.Homotopic.Quotient.cast_heq _ _).symm
-  exact hcastSource.trans (hmap.trans (hlift.trans (hcastLift.trans hcastTarget)))
+  apply hp.monodromy_eq_of_map_eq (Γ.map g)
+  change (Γ.map g).map p' = _
+  rw [← Path.Homotopic.Quotient.map_comp]
+  convert hp.map_liftPathQuotient γ e using 2
+  grind
 
 end Deck
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Homotopy.Lifting
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular.Basic
+
+/-!
+# Regular deck actions and monodromy transport
+
+Deck transformations commute with transport between fibres by covering-space monodromy. Thus,
+over a path-connected base, transitivity of the deck action on one nonempty fibre implies
+transitivity on every fibre (and also supplies surjectivity of the covering map). This reduces
+regularity to a condition at a single chosen fibre.
+
+## Main declarations
+
+* `TauCeti.Deck.monodromy_fiber_smul`: deck transformations commute with monodromy along a path.
+* `TauCeti.Deck.isRegular_iff_fiber_isPretransitive`: over a path-connected base, a covering is
+  regular exactly when its deck group acts transitively on one chosen fibre.
+
+## References
+
+The proof uses Junyan Xu's path-lifting and monodromy API in
+`Mathlib.Topology.Homotopy.Lifting`. It supplies the fibre-transport step needed for the regular
+cover criterion in `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Deck
+
+variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
+  {x y : X}
+
+/-- Transport by covering-space monodromy commutes with the action of a deck transformation.
+
+Both sides transport a point of the fibre over `x` to the fibre over `y`: one first applies the
+deck transformation and then lifts the path, while the other first lifts the path and then
+applies the deck transformation. -/
+theorem monodromy_fiber_smul (hp : IsCoveringMap p)
+    (γ : Path.Homotopic.Quotient x y) (φ : Deck p) (e : p ⁻¹' {x}) :
+    hp.monodromy γ (φ • e) = φ • hp.monodromy γ e := by
+  let Γ := hp.liftPathQuotient γ e
+  let g : C(E, E) := ⟨φ.1, φ.1.continuous⟩
+  let p' : C(E, X) := ⟨p, hp.continuous⟩
+  have hgp : p'.comp g = p' := by
+    ext z
+    exact map_proj φ z
+  have hmapComp : Γ.map (p'.comp g) ≍ Γ.map p' :=
+    congr_arg_heq (fun q : C(E, X) ↦ Γ.map q) hgp
+  have hmapMap : (Γ.map g).map p' = Γ.map (p'.comp g) :=
+    Path.Homotopic.Quotient.map_comp.symm
+  have hmap : (Γ.map g).map p' ≍ Γ.map p' :=
+    (heq_of_eq hmapMap).trans hmapComp
+  let Γ' : Path.Homotopic.Quotient ((φ • e : p ⁻¹' {x}) : E)
+      ((φ • hp.monodromy γ e : p ⁻¹' {y}) : E) :=
+    (Γ.map g).cast (fiber_smul_coe φ e) (fiber_smul_coe φ (hp.monodromy γ e))
+  apply hp.monodromy_eq_of_map_eq Γ'
+  dsimp only [Γ']
+  rw [Path.Homotopic.Quotient.map_cast]
+  apply eq_of_heq
+  have hcastSource :
+      ((Γ.map g).map p').cast
+          (congrArg p' (fiber_smul_coe φ e))
+          (congrArg p' (fiber_smul_coe φ (hp.monodromy γ e))) ≍
+        (Γ.map g).map p' :=
+    Path.Homotopic.Quotient.cast_heq _ _
+  have hlift : Γ.map p' ≍ γ.cast e.2 (hp.monodromy γ e).2 :=
+    heq_of_eq (hp.map_liftPathQuotient γ e)
+  have hcastLift : γ.cast e.2 (hp.monodromy γ e).2 ≍ γ :=
+    Path.Homotopic.Quotient.cast_heq _ _
+  have hcastTarget : γ ≍ γ.cast (φ • e).2 (φ • hp.monodromy γ e).2 :=
+    (Path.Homotopic.Quotient.cast_heq _ _).symm
+  exact hcastSource.trans (hmap.trans (hlift.trans (hcastLift.trans hcastTarget)))
+
+/-- Over a path-connected base, a covering map with a chosen point in one fibre is regular
+exactly when the deck action on that one fibre is transitive.
+
+Monodromy transports transitivity to every other fibre. The chosen point also transports to
+every fibre, proving the surjectivity required by `Deck.IsRegular`. -/
+theorem isRegular_iff_fiber_isPretransitive [PathConnectedSpace X]
+    (hp : IsCoveringMap p) (e : p ⁻¹' {x}) :
+    IsRegular p ↔ MulAction.IsPretransitive (Deck p) (p ⁻¹' {x}) := by
+  constructor
+  · intro hreg
+    exact hreg.fiber_isPretransitive x
+  · intro htrans
+    letI := htrans
+    refine ⟨?_, fun y ↦ MulAction.IsPretransitive.mk ?_⟩
+    · intro y
+      let γ : Path.Homotopic.Quotient x y :=
+        Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath x y)
+      exact ⟨hp.monodromy γ e, Set.mem_singleton_iff.mp (hp.monodromy γ e).2⟩
+    · intro u v
+      let γ : Path.Homotopic.Quotient x y :=
+        Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath x y)
+      obtain ⟨u₀, hu₀⟩ := (hp.monodromy_bijective γ).2 u
+      obtain ⟨v₀, hv₀⟩ := (hp.monodromy_bijective γ).2 v
+      obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) u₀ v₀
+      refine ⟨φ, ?_⟩
+      rw [← hu₀, ← hv₀, ← monodromy_fiber_smul hp γ φ u₀, hφ]
+
+end Deck
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
@@ -42,6 +42,7 @@ variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
 Both sides transport a point of the fibre over `x` to the fibre over `y`: one first applies the
 deck transformation and then lifts the path, while the other first lifts the path and then
 applies the deck transformation. -/
+@[simp]
 theorem monodromy_fiber_smul (hp : IsCoveringMap p)
     (γ : Path.Homotopic.Quotient x y) (φ : Deck p) (e : p ⁻¹' {x}) :
     hp.monodromy γ (φ • e) = φ • hp.monodromy γ e := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean
@@ -4,11 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Homotopy.Lifting
+public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Fiber.Monodromy
 public import TauCeti.AlgebraicTopology.UniversalCover.Deck.Regular.Basic
 
 /-!
-# Regular deck actions and monodromy transport
+# Regularity from one fibre
 
 Deck transformations commute with transport between fibres by covering-space monodromy. Thus,
 over a path-connected base, transitivity of the deck action on one nonempty fibre implies
@@ -17,7 +17,6 @@ regularity to a condition at a single chosen fibre.
 
 ## Main declarations
 
-* `TauCeti.Deck.monodromy_fiber_smul`: deck transformations commute with monodromy along a path.
 * `TauCeti.Deck.isRegular_iff_fiber_isPretransitive`: over a path-connected base, a covering is
   regular exactly when its deck group acts transitively on one chosen fibre.
 
@@ -36,48 +35,6 @@ namespace Deck
 
 variable {E X : Type*} [TopologicalSpace E] [TopologicalSpace X] {p : E → X}
   {x y : X}
-
-/-- Transport by covering-space monodromy commutes with the action of a deck transformation.
-
-Both sides transport a point of the fibre over `x` to the fibre over `y`: one first applies the
-deck transformation and then lifts the path, while the other first lifts the path and then
-applies the deck transformation. -/
-@[simp]
-theorem monodromy_fiber_smul (hp : IsCoveringMap p)
-    (γ : Path.Homotopic.Quotient x y) (φ : Deck p) (e : p ⁻¹' {x}) :
-    hp.monodromy γ (φ • e) = φ • hp.monodromy γ e := by
-  let Γ := hp.liftPathQuotient γ e
-  let g : C(E, E) := ⟨φ.1, φ.1.continuous⟩
-  let p' : C(E, X) := ⟨p, hp.continuous⟩
-  have hgp : p'.comp g = p' := by
-    ext z
-    exact map_proj φ z
-  have hmapComp : Γ.map (p'.comp g) ≍ Γ.map p' :=
-    congr_arg_heq (fun q : C(E, X) ↦ Γ.map q) hgp
-  have hmapMap : (Γ.map g).map p' = Γ.map (p'.comp g) :=
-    Path.Homotopic.Quotient.map_comp.symm
-  have hmap : (Γ.map g).map p' ≍ Γ.map p' :=
-    (heq_of_eq hmapMap).trans hmapComp
-  let Γ' : Path.Homotopic.Quotient ((φ • e : p ⁻¹' {x}) : E)
-      ((φ • hp.monodromy γ e : p ⁻¹' {y}) : E) :=
-    (Γ.map g).cast (fiber_smul_coe φ e) (fiber_smul_coe φ (hp.monodromy γ e))
-  apply hp.monodromy_eq_of_map_eq Γ'
-  dsimp only [Γ']
-  rw [Path.Homotopic.Quotient.map_cast]
-  apply eq_of_heq
-  have hcastSource :
-      ((Γ.map g).map p').cast
-          (congrArg p' (fiber_smul_coe φ e))
-          (congrArg p' (fiber_smul_coe φ (hp.monodromy γ e))) ≍
-        (Γ.map g).map p' :=
-    Path.Homotopic.Quotient.cast_heq _ _
-  have hlift : Γ.map p' ≍ γ.cast e.2 (hp.monodromy γ e).2 :=
-    heq_of_eq (hp.map_liftPathQuotient γ e)
-  have hcastLift : γ.cast e.2 (hp.monodromy γ e).2 ≍ γ :=
-    Path.Homotopic.Quotient.cast_heq _ _
-  have hcastTarget : γ ≍ γ.cast (φ • e).2 (φ • hp.monodromy γ e).2 :=
-    (Path.Homotopic.Quotient.cast_heq _ _).symm
-  exact hcastSource.trans (hmap.trans (hlift.trans (hcastLift.trans hcastTarget)))
 
 /-- Over a path-connected base, a covering map with a chosen point in one fibre is regular
 exactly when the deck action on that one fibre is transitive.
@@ -104,7 +61,7 @@ theorem isRegular_iff_fiber_isPretransitive [PathConnectedSpace X]
       obtain ⟨v₀, hv₀⟩ := (hp.monodromy_bijective γ).2 v
       obtain ⟨φ, hφ⟩ := MulAction.exists_smul_eq (Deck p) u₀ v₀
       refine ⟨φ, ?_⟩
-      rw [← hu₀, ← hv₀, ← monodromy_fiber_smul hp γ φ u₀, hφ]
+      rw [← hu₀, ← hv₀, ← monodromy_smul hp γ φ u₀, hφ]
 
 end Deck
 


### PR DESCRIPTION
This PR characterizes regular connected covers by the subgroup of the fundamental group they recover. Prove first that deck transformations commute with monodromy along any path, so over a path-connected base transitivity of the deck action on one chosen fibre propagates to every fibre and supplies surjectivity. Combine that reduction with pointed-cover classification and the existing basepoint-independence criterion to prove that a connected covering is regular exactly when its recovered subgroup is normal.

This directly advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 8, specifically: “It is a regular (normal/Galois) cover iff `H ◁ π₁(X, x₀)`.” It is the lowest-hanging unfinished direct bridge on `main`: the recovered-subgroup normality criterion and pointed-cover classification have landed, while open PR #1594 handles the distinct Stage 1 universal-cover deck-group identification and open PR #1603 handles the distinct Stage 2 subgroup-quotient construction.

Add `TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Monodromy.lean` (110 lines) with monodromy/deck equivariance and the one-fibre regularity criterion. Add `TauCeti/AlgebraicTopology/UniversalCover/Classification/Regular.lean` (84 lines) with the regular-cover/normal-subgroup equivalence.

No Mathlib infrastructure is vendored. The monodromy equivariance proof adapts Junyan Xu’s direct proof pattern for `IsQuotientCoveringMap.monodromy_toPermFiber` in `Mathlib.Topology.Homotopy.Lifting`, replacing the quotient-cover group action with deck transformations. The one-fibre criterion also uses `monodromy_bijective`; the classification step reuses Tau Ceti’s pointed-cover comparison and recovered-subgroup API.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6064 jobs).` `lake exe axioms` reports `axioms: audited 17868 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"regular-cover-iff-normal-recovered-subgroup"}-->

🤖 Prepared with Codex