### PR TITLE
feat: prove uniqueness in Bernstein representation

### DIFF
--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Unique.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Unique.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.CompletelyMonotone.Bernstein.Theorem
+public import TauCeti.Probability.Moments.LaplaceDeterminacy
+
+/-!
+# Uniqueness in Bernstein's representation theorem
+
+A completely monotone function on `[0, ∞)` has a unique finite representing measure on `ℝ≥0`.
+The existence half is supplied by Bernstein's theorem, while uniqueness follows from the fact
+that a finite measure on `ℝ≥0` is determined by its Laplace transform.
+
+This completes the existence-and-uniqueness direction of the Bernstein milestone in
+`TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B. The converse direction, asserting
+complete monotonicity of Laplace transforms under the appropriate boundary regularity, is a
+separate development.
+
+## Main result
+
+* `TauCeti.existsUnique_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone`:
+  every completely monotone function has a unique finite Laplace-representing measure.
+
+## References
+
+* R. Schilling, R. Song, Z. Vondraček, *Bernstein Functions: Theory and Applications*
+  (de Gruyter, 2nd ed. 2012), Theorem 1.4.
+-/
+
+public section
+
+open MeasureTheory
+open scoped NNReal
+
+namespace TauCeti
+
+variable {f : ℝ → ℝ}
+
+/-- **Bernstein representation, existence and uniqueness.** A completely monotone function on
+`[0, ∞)` is the Laplace transform of a unique finite positive measure on `ℝ≥0`.
+
+This is the existence-and-uniqueness direction of Bernstein's theorem. The representing measure
+is unique among all finite measures whose Laplace transform agrees with `f` at every nonnegative
+real argument. -/
+theorem existsUnique_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone
+    (hcm : IsCompletelyMonotone f) :
+    ∃! μ : Measure ℝ≥0, IsFiniteMeasure μ ∧
+      ∀ t : ℝ, 0 ≤ t → f t = ∫ x, Real.exp (-t * (x : ℝ)) ∂μ := by
+  obtain ⟨μ, hμfin, hμ⟩ :=
+    exists_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone hcm
+  refine ⟨μ, ⟨hμfin, hμ⟩, ?_⟩
+  intro ν hν
+  letI : IsFiniteMeasure μ := hμfin
+  letI : IsFiniteMeasure ν := hν.1
+  apply Measure.ext_of_forall_integral_exp_neg_mul_eq
+  intro t ht
+  rw [← hμ t ht, ← hν.2 t ht]
+
+end TauCeti


### PR DESCRIPTION
This PR proves that every completely monotone function on `[0, ∞)` has a unique finite positive measure on `ℝ≥0` whose Laplace transform agrees with the function at every nonnegative real argument. Reuse the landed Bernstein existence theorem to obtain the representing measure and the landed Laplace-transform extensionality theorem to identify any second representing measure.

This advances `TauCetiRoadmap/OneParameterSemigroups/README.md`, Part B, the milestone “Bernstein's theorem,” specifically the unique finite positive representing measure and “Laplace-transform injectivity” in lines 178–186. It is the lowest-hanging unfinished target because PR #1482 landed the existence half and PR #1485 landed the independent uniqueness theorem for finite measures, explicitly leaving their `∃!` assembly as a follow-up; the only open OneParameterSemigroups PR targets the distinct GNS/Kolmogorov decomposition.

Add `TauCeti/Analysis/CompletelyMonotone/Bernstein/Unique.lean` (62 lines) with `existsUnique_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone`. The proof uses Tau Ceti's `exists_isFiniteMeasure_integral_exp_neg_mul_eq_of_isCompletelyMonotone` and `Measure.ext_of_forall_integral_exp_neg_mul_eq`. No Mathlib infrastructure is vendored or copied; the mathematical statement follows Schilling–Song–Vondraček, *Bernstein Functions: Theory and Applications*, Theorem 1.4, as cited in the module docstring.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6068 jobs).` `lake exe axioms` reports `axioms: audited 17933 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The module-system check passes all 986 modules, and the lint environment reports no new violations.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"bernstein-representation-uniqueness"}-->

🤖 Prepared with Codex
