### PR TITLE
feat: prove finite comodule right rigidity

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/Monoidal.lean
@@ -33,6 +33,10 @@ inherited from `SemimoduleCat` along the faithful forgetful functor.
 * `TauCeti.FGComoduleCat.leftUnitor_hom_apply`,
   `TauCeti.FGComoduleCat.rightUnitor_hom_apply`, and
   `TauCeti.FGComoduleCat.associator_hom_apply`: concrete formulas for the coherence maps.
+* `TauCeti.FGComoduleCat.leftUnitor_hom_toLinearMap`,
+  `TauCeti.FGComoduleCat.rightUnitor_hom_toLinearMap`, and
+  `TauCeti.FGComoduleCat.associator_hom_toLinearMap`: the same formulas at the level of
+  underlying linear maps, together with their inverse variants.
 
 ## References
 
@@ -243,6 +247,54 @@ theorem associator_inv_apply (m : M) (n : N) (p : P) :
   by
     rw [← associator_hom_apply]
     exact Iso.hom_inv_id_apply (α_ M N P) _
+
+/-- The associator has the associativity equivalence of tensor products underneath. -/
+@[simp]
+theorem associator_hom_toLinearMap :
+    ((α_ M N P).hom).hom.toLinearMap = (TensorProduct.assoc R M N P).toLinearMap := by
+  apply TensorProduct.ext_threefold
+  intro m n p
+  exact associator_hom_apply m n p
+
+/-- The inverse associator has the inverse associativity equivalence underneath. -/
+@[simp]
+theorem associator_inv_toLinearMap :
+    ((α_ M N P).inv).hom.toLinearMap = (TensorProduct.assoc R M N P).symm.toLinearMap := by
+  apply TensorProduct.ext_threefold'
+  intro m n p
+  exact associator_inv_apply m n p
+
+/-- The left unitor has the left tensor identity underneath. -/
+@[simp]
+theorem leftUnitor_hom_toLinearMap :
+    ((λ_ M).hom).hom.toLinearMap = (TensorProduct.lid R M).toLinearMap := by
+  apply TensorProduct.ext'
+  intro r m
+  exact leftUnitor_hom_apply r m
+
+/-- The inverse left unitor has the inverse left tensor identity underneath. -/
+@[simp]
+theorem leftUnitor_inv_toLinearMap :
+    ((λ_ M).inv).hom.toLinearMap = (TensorProduct.lid R M).symm.toLinearMap := by
+  apply LinearMap.ext
+  intro m
+  exact leftUnitor_inv_apply m
+
+/-- The right unitor has the right tensor identity underneath. -/
+@[simp]
+theorem rightUnitor_hom_toLinearMap :
+    ((ρ_ M).hom).hom.toLinearMap = (TensorProduct.rid R M).toLinearMap := by
+  apply TensorProduct.ext'
+  intro m r
+  exact rightUnitor_hom_apply m r
+
+/-- The inverse right unitor has the inverse right tensor identity underneath. -/
+@[simp]
+theorem rightUnitor_inv_toLinearMap :
+    ((ρ_ M).inv).hom.toLinearMap = (TensorProduct.rid R M).symm.toLinearMap := by
+  apply LinearMap.ext
+  intro m
+  exact rightUnitor_inv_apply m
 
 end FGComoduleCat
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -1,0 +1,388 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Monoidal.Rigid.Basic
+public import Mathlib.LinearAlgebra.Coevaluation
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Dual
+public import TauCeti.Algebra.Coalgebra.Comodule.Finite.Monoidal
+
+/-!
+# Right rigidity of finite-dimensional comodules
+
+Let `H` be a Hopf algebra over a field `k`. This file equips the monoidal category
+`FGComoduleCat.{u,v,u} k H` with right duals. The right dual of a finite-dimensional
+comodule is its antipode-twisted linear dual; evaluation and coevaluation are the
+ordinary finite-dimensional linear maps, proved colinear using the two antipode
+identities.
+
+No commutativity or finite-dimensionality hypothesis is imposed on `H`, and the
+antipode need not be bijective.
+
+## Main declarations
+
+* `TauCeti.FGComoduleCat.dualEvaluation`: evaluation as a finite-comodule morphism.
+* `TauCeti.FGComoduleCat.dualCoevaluation`: coevaluation as a finite-comodule morphism.
+* `TauCeti.FGComoduleCat.instRightRigidCategory`: finite-dimensional comodules form a
+  right rigid monoidal category.
+
+## References
+
+See Etingof--Gelaki--Nikshych--Ostrik, *Tensor Categories*, Definition 2.10.1 and
+Remark 5.3.8; Milne, *Algebraic Groups* (2017), Section 9.26; and Humphreys,
+*Linear Algebraic Groups*, Section 8.2.
+-/
+
+public section
+
+open CategoryTheory MonoidalCategory
+open scoped TensorProduct
+
+namespace TauCeti.FGComoduleCat
+
+universe u v
+
+variable (k : Type u) [Field k]
+variable (H : Type v) [Semiring H] [HopfAlgebra k H]
+
+attribute [local instance] Comodule.dual Comodule.tensor
+
+private theorem coact_eq_sum_basis_matrixCoefficient
+    {M : FGComoduleCat.{u, v, u} k H}
+    (b : Module.Basis (Module.Basis.ofVectorSpaceIndex k M) k M) (m : M) :
+    Comodule.coact (R := k) (C := H) (M := M) m =
+      ∑ i, b i ⊗ₜ[k]
+        Comodule.matrixCoefficient (R := k) (C := H) (b.coord i) m := by
+  classical
+  let e := TensorProduct.equivFinsuppOfBasisLeft (N := H) b
+  calc
+    Comodule.coact (R := k) (C := H) (M := M) m =
+        e.symm (e (Comodule.coact (R := k) (C := H) (M := M) m)) :=
+      ((e.symm_apply_apply _).symm)
+    _ = (e (Comodule.coact (R := k) (C := H) (M := M) m)).sum
+        fun i h ↦ b i ⊗ₜ[k] h :=
+      TensorProduct.equivFinsuppOfBasisLeft_symm_apply b _
+    _ = ∑ i, b i ⊗ₜ[k]
+        (e (Comodule.coact (R := k) (C := H) (M := M) m)) i :=
+      Finsupp.sum_fintype _ _ (by simp)
+    _ = ∑ i, b i ⊗ₜ[k]
+        Comodule.matrixCoefficient (R := k) (C := H) (b.coord i) m := by
+      congr 1
+      funext i
+      rw [TensorProduct.equivFinsuppOfBasisLeft_apply]
+      rfl
+
+private theorem dualCoact_coord_eq_sum
+    {M : FGComoduleCat.{u, v, u} k H}
+    (b : Module.Basis (Module.Basis.ofVectorSpaceIndex k M) k M)
+    (i : Module.Basis.ofVectorSpaceIndex k M) :
+    Comodule.dualCoact (R := k) (H := H) (M := M) (b.coord i) =
+      ∑ j, b.coord j ⊗ₜ[k]
+        HopfAlgebra.antipode k
+          (Comodule.matrixCoefficient (R := k) (C := H) (b.coord i) (b j)) := by
+  classical
+  apply (dualTensorHom_bijective (R := k) (M := M) (N := H)).1
+  apply b.ext
+  intro j
+  rw [Comodule.dualTensorHom_dualCoact_apply]
+  simp only [map_sum, LinearMap.sum_apply, dualTensorHom_apply, Module.Basis.coord_apply,
+    Module.Basis.repr_self_apply]
+  simp
+
+private theorem lid_map_contractLeft_tensorCombine
+    {M : FGComoduleCat.{u, v, u} k H}
+    (x : Module.Dual k M ⊗[k] H) (y : M ⊗[k] H) :
+    TensorProduct.lid k H
+        (TensorProduct.map (contractLeft k M) (LinearMap.id : H →ₗ[k] H)
+          (Comodule.tensorCombine (R := k) (C := H) (M := Module.Dual k M) (N := M)
+            (x ⊗ₜ[k] y))) =
+      LinearMap.mul' k H
+        (TensorProduct.map (dualTensorHom k M H x) (LinearMap.id : H →ₗ[k] H) y) := by
+  induction x using TensorProduct.induction_on with
+  | zero => simp
+  | add x z hx hz =>
+      simpa only [TensorProduct.add_tmul, map_add, TensorProduct.map_add_left,
+        LinearMap.add_apply] using congrArg₂ (· + ·) hx hz
+  | tmul φ a =>
+      induction y using TensorProduct.induction_on with
+      | zero => simp
+      | add y z hy hz =>
+          simpa only [TensorProduct.tmul_add, map_add] using congrArg₂ (· + ·) hy hz
+      | tmul m b =>
+          simp only [Comodule.tensorCombine_tmul_tmul, TensorProduct.map_tmul,
+            LinearMap.id_apply, contractLeft_apply, TensorProduct.lid_tmul,
+            dualTensorHom_apply, LinearMap.mul'_apply]
+          exact (smul_mul_assoc (φ m) a b).symm
+
+/-- Evaluation of the antipode-twisted dual against a finite-dimensional comodule, as a
+finite-comodule morphism. -/
+@[expose]
+noncomputable def dualEvaluation (M : FGComoduleCat.{u, v, u} k H) :
+    dual k H M ⊗ M ⟶ 𝟙_ (FGComoduleCat.{u, v, u} k H) :=
+  letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
+  ofHom (R := k) (C := H) {
+    toLinearMap := contractLeft k M
+    map_coact := by
+      apply TensorProduct.ext'
+      intro φ m
+      simp only [LinearMap.comp_apply, Comodule.tensor_coact, Comodule.tensorCoact_tmul,
+        dual_coact, Comodule.trivial_coact_apply]
+      apply (TensorProduct.lid k H).injective
+      calc
+        _ = LinearMap.mul' k H
+            (TensorProduct.map
+              (dualTensorHom k M H
+                (Comodule.dualCoact (R := k) (H := H) (M := M) φ))
+              LinearMap.id (Comodule.coact (R := k) (C := H) (M := M) m)) :=
+          lid_map_contractLeft_tensorCombine k H _ _
+        _ = LinearMap.mul' k H
+            ((HopfAlgebra.antipode k).rTensor H
+              (Coalgebra.comul
+                (Comodule.matrixCoefficient (R := k) (C := H) φ m))) := by
+          rw [Comodule.dualTensorHom_dualCoact]
+          simp only [Comodule.matrixCoefficientBilinear_apply]
+          rw [Comodule.comul_matrixCoefficient, LinearMap.rTensor_def,
+            TensorProduct.map_map, LinearMap.id_comp]
+        _ = TensorProduct.lid k H (φ m ⊗ₜ[k] (1 : H)) := by
+          rw [HopfAlgebra.mul_antipode_rTensor_comul_apply,
+            Comodule.counit_matrixCoefficient]
+          simp [Algebra.smul_def]
+  }
+
+/-- Evaluation applies the underlying functional to the vector. -/
+@[simp]
+theorem dualEvaluation_apply (M : FGComoduleCat.{u, v, u} k H)
+    (φ : dual k H M) (m : M) :
+    dualEvaluation k H M (φ ⊗ₜ[k] m) = φ m :=
+  rfl
+
+@[simp]
+theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
+    (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
+  rfl
+
+private theorem tensorCoact_coevaluation_apply_one
+    (M : FGComoduleCat.{u, v, u} k H) :
+    Comodule.tensorCoact (R := k) (C := H) (M := M) (N := Module.Dual k M)
+        (coevaluation k M 1) =
+      coevaluation k M 1 ⊗ₜ[k] (1 : H) := by
+  classical
+  let b := Module.Basis.ofVectorSpace k M
+  rw [coevaluation_apply_one]
+  dsimp only [b]
+  simp only [map_sum, Comodule.tensorCoact_tmul,
+    coact_eq_sum_basis_matrixCoefficient k H (Module.Basis.ofVectorSpace k M),
+    Comodule.dual_coact,
+    dualCoact_coord_eq_sum k H (Module.Basis.ofVectorSpace k M),
+    TensorProduct.sum_tmul, TensorProduct.tmul_sum,
+    Comodule.tensorCombine_tmul_tmul]
+  have hrepr (i j : Module.Basis.ofVectorSpaceIndex k M) :
+      (Module.Basis.ofVectorSpace k M).repr (i : M) j =
+        if i = j then 1 else 0 := by
+    rw [← Module.Basis.ofVectorSpace_apply_self k M i]
+    exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
+  let bt := (Module.Basis.ofVectorSpace k M).tensorProduct
+    (Module.Basis.ofVectorSpace k M).dualBasis
+  apply (TensorProduct.equivFinsuppOfBasisLeft (N := H) bt).injective
+  ext ⟨p, q⟩
+  suffices h :
+      (∑ x : Module.Basis.ofVectorSpaceIndex k M,
+        Comodule.matrixCoefficient (R := k) (C := H)
+          ((Module.Basis.ofVectorSpace k M).coord p) (x : M) *
+        HopfAlgebra.antipode k
+          (Comodule.matrixCoefficient (R := k) (C := H)
+            ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
+        if q = p then 1 else 0 by
+    simpa [bt, Module.Basis.coe_ofVectorSpace,
+      Module.Basis.tensorProduct_repr_tmul_apply, Module.Basis.dualBasis_repr,
+      hrepr] using h
+  calc
+    _ = LinearMap.mul' k H
+        ((HopfAlgebra.antipode k).lTensor H
+          (Coalgebra.comul
+            (Comodule.matrixCoefficient (R := k) (C := H)
+              ((Module.Basis.ofVectorSpace k M).coord p)
+              ((Module.Basis.ofVectorSpace k M) q)))) := by
+      rw [Comodule.comul_matrixCoefficient_eq_sum (Module.Basis.ofVectorSpace k M)]
+      simp only [map_sum, LinearMap.lTensor_tmul, LinearMap.mul'_apply,
+        Module.Basis.coe_ofVectorSpace]
+    _ = algebraMap k H
+        (Coalgebra.counit
+          (Comodule.matrixCoefficient (R := k) (C := H)
+            ((Module.Basis.ofVectorSpace k M).coord p)
+            ((Module.Basis.ofVectorSpace k M) q))) :=
+      HopfAlgebra.mul_antipode_lTensor_comul_apply _
+    _ = if q = p then 1 else 0 := by
+      rw [Comodule.counit_matrixCoefficient]
+      simp [Module.Basis.coord_apply, hrepr]
+
+/-- The ordinary finite-dimensional coevaluation, as a finite-comodule morphism into the
+tensor product with the antipode-twisted dual. -/
+@[expose]
+noncomputable def dualCoevaluation (M : FGComoduleCat.{u, v, u} k H) :
+    𝟙_ (FGComoduleCat.{u, v, u} k H) ⟶ M ⊗ dual k H M :=
+  letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
+  ofHom (R := k) (C := H) {
+    toLinearMap := coevaluation k M
+    map_coact := by
+      apply LinearMap.ext_ring
+      simp only [LinearMap.comp_apply, Comodule.trivial_coact_apply,
+        TensorProduct.map_tmul, LinearMap.id_apply, Comodule.tensor_coact]
+      exact (tensorCoact_coevaluation_apply_one k H M).symm
+  }
+
+/-- Coevaluation at one is the canonical basis-independent tensor. -/
+theorem dualCoevaluation_apply_one (M : FGComoduleCat.{u, v, u} k H) :
+    dualCoevaluation k H M (1 : k) =
+      ∑ i : Module.Basis.ofVectorSpaceIndex k M,
+        (Module.Basis.ofVectorSpace k M) i ⊗ₜ[k]
+          (Module.Basis.ofVectorSpace k M).coord i :=
+  coevaluation_apply_one k M
+
+@[simp]
+theorem dualCoevaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
+    (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=
+  rfl
+
+private theorem associator_hom_toLinearMap
+    (M N P : FGComoduleCat.{u, v, u} k H) :
+    ((α_ M N P).hom).hom.toLinearMap =
+      (TensorProduct.assoc k M N P).toLinearMap := by
+  apply TensorProduct.ext_threefold
+  intro m n p
+  exact associator_hom_apply m n p
+
+private theorem associator_inv_toLinearMap
+    (M N P : FGComoduleCat.{u, v, u} k H) :
+    ((α_ M N P).inv).hom.toLinearMap =
+      (TensorProduct.assoc k M N P).symm.toLinearMap := by
+  apply TensorProduct.ext_threefold'
+  intro m n p
+  exact associator_inv_apply m n p
+
+private theorem leftUnitor_hom_toLinearMap
+    (M : FGComoduleCat.{u, v, u} k H) :
+    ((λ_ M).hom).hom.toLinearMap = (TensorProduct.lid k M).toLinearMap := by
+  apply TensorProduct.ext'
+  intro r m
+  exact leftUnitor_hom_apply r m
+
+private theorem leftUnitor_inv_toLinearMap
+    (M : FGComoduleCat.{u, v, u} k H) :
+    ((λ_ M).inv).hom.toLinearMap = (TensorProduct.lid k M).symm.toLinearMap := by
+  apply LinearMap.ext
+  intro m
+  exact leftUnitor_inv_apply m
+
+private theorem rightUnitor_hom_toLinearMap
+    (M : FGComoduleCat.{u, v, u} k H) :
+    ((ρ_ M).hom).hom.toLinearMap = (TensorProduct.rid k M).toLinearMap := by
+  apply TensorProduct.ext'
+  intro m r
+  exact rightUnitor_hom_apply m r
+
+private theorem rightUnitor_inv_toLinearMap
+    (M : FGComoduleCat.{u, v, u} k H) :
+    ((ρ_ M).inv).hom.toLinearMap = (TensorProduct.rid k M).symm.toLinearMap := by
+  apply LinearMap.ext
+  intro m
+  exact rightUnitor_inv_apply m
+
+set_option backward.privateInPublic true in
+private theorem coevaluation_evaluation
+    (M : FGComoduleCat.{u, v, u} k H) :
+    letI M' : FGComoduleCat.{u, v, u} k H := dual k H M
+    M' ◁ dualCoevaluation k H M ≫ (α_ M' M M').inv ≫
+        dualEvaluation k H M ▷ M' =
+      (ρ_ M').hom ≫ (λ_ M').inv := by
+  have hleft :
+      ((dual k H M ◁ dualCoevaluation k H M ≫
+          (α_ (dual k H M) M (dual k H M)).inv ≫
+            dualEvaluation k H M ▷ dual k H M).hom).toLinearMap =
+        (contractLeft k M).rTensor (Module.Dual k M) ∘ₗ
+          (TensorProduct.assoc k (Module.Dual k M) M (Module.Dual k M)).symm.toLinearMap ∘ₗ
+            (coevaluation k M).lTensor (Module.Dual k M) := by
+    rw [← id_tensorHom, ← tensorHom_id]
+    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+      tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
+      ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
+      dualEvaluation_toLinearMap, associator_inv_toLinearMap,
+      dual_coe, LinearMap.lTensor_def, LinearMap.rTensor_def,
+      LinearMap.comp_assoc]
+  have hright :
+      (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap =
+        (TensorProduct.lid k (Module.Dual k M)).symm.toLinearMap ∘ₗ
+          (TensorProduct.rid k (Module.Dual k M)).toLinearMap := by
+    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+      rightUnitor_hom_toLinearMap, leftUnitor_inv_toLinearMap]
+  apply ObjectProperty.hom_ext
+  apply ComoduleCat.hom_ext
+  intro x
+  change
+    ((dual k H M ◁ dualCoevaluation k H M ≫
+        (α_ (dual k H M) M (dual k H M)).inv ≫
+          dualEvaluation k H M ▷ dual k H M).hom).toLinearMap x =
+      (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap x
+  rw [hleft, hright]
+  exact LinearMap.congr_fun (contractLeft_assoc_coevaluation k M) x
+
+set_option backward.privateInPublic true in
+private theorem evaluation_coevaluation
+    (M : FGComoduleCat.{u, v, u} k H) :
+    dualCoevaluation k H M ▷ M ≫
+        (α_ M (dual k H M) M).hom ≫ M ◁ dualEvaluation k H M =
+      (λ_ M).hom ≫ (ρ_ M).inv := by
+  have hleft :
+      ((dualCoevaluation k H M ▷ M ≫
+          (α_ M (dual k H M) M).hom ≫
+            M ◁ dualEvaluation k H M).hom).toLinearMap =
+        (contractLeft k M).lTensor M ∘ₗ
+          (TensorProduct.assoc k M (Module.Dual k M) M).toLinearMap ∘ₗ
+            (coevaluation k M).rTensor M := by
+    rw [← tensorHom_id, ← id_tensorHom]
+    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+      tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
+      ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
+      dualEvaluation_toLinearMap, associator_hom_toLinearMap,
+      dual_coe, LinearMap.lTensor_def, LinearMap.rTensor_def,
+      LinearMap.comp_assoc]
+  have hright :
+      (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap =
+        (TensorProduct.rid k M).symm.toLinearMap ∘ₗ
+          (TensorProduct.lid k M).toLinearMap := by
+    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+      leftUnitor_hom_toLinearMap, rightUnitor_inv_toLinearMap]
+  apply ObjectProperty.hom_ext
+  apply ComoduleCat.hom_ext
+  intro x
+  change
+    ((dualCoevaluation k H M ▷ M ≫
+        (α_ M (dual k H M) M).hom ≫
+          M ◁ dualEvaluation k H M).hom).toLinearMap x =
+      (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap x
+  rw [hleft, hright]
+  exact LinearMap.congr_fun (contractLeft_assoc_coevaluation' k M) x
+
+set_option backward.privateInPublic true in
+set_option backward.privateInPublic.warn false in
+/-- The antipode-twisted linear dual is an exact right dual of a finite-dimensional
+comodule. -/
+noncomputable instance instExactPairingDual
+    (M : FGComoduleCat.{u, v, u} k H) : ExactPairing M (dual k H M) where
+  coevaluation' := dualCoevaluation k H M
+  evaluation' := dualEvaluation k H M
+  coevaluation_evaluation' := coevaluation_evaluation k H M
+  evaluation_coevaluation' := evaluation_coevaluation k H M
+
+/-- Every finite-dimensional comodule has the antipode-twisted linear dual as a right dual. -/
+noncomputable instance instHasRightDual
+    (M : FGComoduleCat.{u, v, u} k H) : HasRightDual M :=
+  ⟨dual k H M⟩
+
+/-- Finite-dimensional comodules over a Hopf algebra form a right rigid monoidal category. -/
+noncomputable instance instRightRigidCategory :
+    RightRigidCategory (FGComoduleCat.{u, v, u} k H) where
+
+end TauCeti.FGComoduleCat

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -49,31 +49,6 @@ variable (H : Type v) [Semiring H] [HopfAlgebra k H]
 
 attribute [local instance] Comodule.dual Comodule.tensor
 
-private theorem coact_eq_sum_basis_matrixCoefficient
-    {M : FGComoduleCat.{u, v, u} k H}
-    (b : Module.Basis (Module.Basis.ofVectorSpaceIndex k M) k M) (m : M) :
-    Comodule.coact (R := k) (C := H) (M := M) m =
-      ∑ i, b i ⊗ₜ[k]
-        Comodule.matrixCoefficient (R := k) (C := H) (b.coord i) m := by
-  classical
-  let e := TensorProduct.equivFinsuppOfBasisLeft (N := H) b
-  calc
-    Comodule.coact (R := k) (C := H) (M := M) m =
-        e.symm (e (Comodule.coact (R := k) (C := H) (M := M) m)) :=
-      ((e.symm_apply_apply _).symm)
-    _ = (e (Comodule.coact (R := k) (C := H) (M := M) m)).sum
-        fun i h ↦ b i ⊗ₜ[k] h :=
-      TensorProduct.equivFinsuppOfBasisLeft_symm_apply b _
-    _ = ∑ i, b i ⊗ₜ[k]
-        (e (Comodule.coact (R := k) (C := H) (M := M) m)) i :=
-      Finsupp.sum_fintype _ _ (by simp)
-    _ = ∑ i, b i ⊗ₜ[k]
-        Comodule.matrixCoefficient (R := k) (C := H) (b.coord i) m := by
-      congr 1
-      funext i
-      rw [TensorProduct.equivFinsuppOfBasisLeft_apply]
-      rfl
-
 private theorem dualCoact_coord_eq_sum
     {M : FGComoduleCat.{u, v, u} k H}
     (b : Module.Basis (Module.Basis.ofVectorSpaceIndex k M) k M)
@@ -173,7 +148,7 @@ private theorem tensorCoact_coevaluation_apply_one
   rw [coevaluation_apply_one]
   dsimp only [b]
   simp only [map_sum, Comodule.tensorCoact_tmul,
-    coact_eq_sum_basis_matrixCoefficient k H (Module.Basis.ofVectorSpace k M),
+    Comodule.coact_eq_sum_basis_matrixCoefficient (C := H) (Module.Basis.ofVectorSpace k M),
     Comodule.dual_coact,
     dualCoact_coord_eq_sum k H (Module.Basis.ofVectorSpace k M),
     TensorProduct.sum_tmul, TensorProduct.tmul_sum,
@@ -246,50 +221,6 @@ theorem dualCoevaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=
   rfl
 
-private theorem associator_hom_toLinearMap
-    (M N P : FGComoduleCat.{u, v, u} k H) :
-    ((α_ M N P).hom).hom.toLinearMap =
-      (TensorProduct.assoc k M N P).toLinearMap := by
-  apply TensorProduct.ext_threefold
-  intro m n p
-  exact associator_hom_apply m n p
-
-private theorem associator_inv_toLinearMap
-    (M N P : FGComoduleCat.{u, v, u} k H) :
-    ((α_ M N P).inv).hom.toLinearMap =
-      (TensorProduct.assoc k M N P).symm.toLinearMap := by
-  apply TensorProduct.ext_threefold'
-  intro m n p
-  exact associator_inv_apply m n p
-
-private theorem leftUnitor_hom_toLinearMap
-    (M : FGComoduleCat.{u, v, u} k H) :
-    ((λ_ M).hom).hom.toLinearMap = (TensorProduct.lid k M).toLinearMap := by
-  apply TensorProduct.ext'
-  intro r m
-  exact leftUnitor_hom_apply r m
-
-private theorem leftUnitor_inv_toLinearMap
-    (M : FGComoduleCat.{u, v, u} k H) :
-    ((λ_ M).inv).hom.toLinearMap = (TensorProduct.lid k M).symm.toLinearMap := by
-  apply LinearMap.ext
-  intro m
-  exact leftUnitor_inv_apply m
-
-private theorem rightUnitor_hom_toLinearMap
-    (M : FGComoduleCat.{u, v, u} k H) :
-    ((ρ_ M).hom).hom.toLinearMap = (TensorProduct.rid k M).toLinearMap := by
-  apply TensorProduct.ext'
-  intro m r
-  exact rightUnitor_hom_apply m r
-
-private theorem rightUnitor_inv_toLinearMap
-    (M : FGComoduleCat.{u, v, u} k H) :
-    ((ρ_ M).inv).hom.toLinearMap = (TensorProduct.rid k M).symm.toLinearMap := by
-  apply LinearMap.ext
-  intro m
-  exact rightUnitor_inv_apply m
-
 /-- The first triangle identity for the antipode-twisted dual: coevaluation followed by
 evaluation is the identity on the dual, up to the unitors. -/
 theorem dualCoevaluation_dualEvaluation
@@ -298,36 +229,22 @@ theorem dualCoevaluation_dualEvaluation
     M' ◁ dualCoevaluation k H M ≫ (α_ M' M M').inv ≫
         dualEvaluation k H M ▷ M' =
       (ρ_ M').hom ≫ (λ_ M').inv := by
-  have hleft :
+  have h :
       ((dual k H M ◁ dualCoevaluation k H M ≫
           (α_ (dual k H M) M (dual k H M)).inv ≫
             dualEvaluation k H M ▷ dual k H M).hom).toLinearMap =
-        (contractLeft k M).rTensor (Module.Dual k M) ∘ₗ
-          (TensorProduct.assoc k (Module.Dual k M) M (Module.Dual k M)).symm.toLinearMap ∘ₗ
-            (coevaluation k M).lTensor (Module.Dual k M) := by
+        (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap := by
     rw [← id_tensorHom, ← tensorHom_id]
     simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
       tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
       ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
       dualEvaluation_toLinearMap, associator_inv_toLinearMap,
-      dual_coe, LinearMap.lTensor_def, LinearMap.rTensor_def,
-      LinearMap.comp_assoc]
-  have hright :
-      (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap =
-        (TensorProduct.lid k (Module.Dual k M)).symm.toLinearMap ∘ₗ
-          (TensorProduct.rid k (Module.Dual k M)).toLinearMap := by
-    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
-      rightUnitor_hom_toLinearMap, leftUnitor_inv_toLinearMap]
+      rightUnitor_hom_toLinearMap, leftUnitor_inv_toLinearMap,
+      dual_coe, LinearMap.comp_assoc]
+    exact contractLeft_assoc_coevaluation k M
   apply ObjectProperty.hom_ext
   apply ComoduleCat.hom_ext
-  intro x
-  change
-    ((dual k H M ◁ dualCoevaluation k H M ≫
-        (α_ (dual k H M) M (dual k H M)).inv ≫
-          dualEvaluation k H M ▷ dual k H M).hom).toLinearMap x =
-      (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap x
-  rw [hleft, hright]
-  exact LinearMap.congr_fun (contractLeft_assoc_coevaluation k M) x
+  exact fun x => LinearMap.congr_fun h x
 
 /-- The second triangle identity for the antipode-twisted dual: coevaluation followed by
 evaluation is the identity on the comodule, up to the unitors. -/
@@ -336,36 +253,22 @@ theorem dualEvaluation_dualCoevaluation
     dualCoevaluation k H M ▷ M ≫
         (α_ M (dual k H M) M).hom ≫ M ◁ dualEvaluation k H M =
       (λ_ M).hom ≫ (ρ_ M).inv := by
-  have hleft :
+  have h :
       ((dualCoevaluation k H M ▷ M ≫
           (α_ M (dual k H M) M).hom ≫
             M ◁ dualEvaluation k H M).hom).toLinearMap =
-        (contractLeft k M).lTensor M ∘ₗ
-          (TensorProduct.assoc k M (Module.Dual k M) M).toLinearMap ∘ₗ
-            (coevaluation k M).rTensor M := by
+        (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap := by
     rw [← tensorHom_id, ← id_tensorHom]
     simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
       tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
       ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
       dualEvaluation_toLinearMap, associator_hom_toLinearMap,
-      dual_coe, LinearMap.lTensor_def, LinearMap.rTensor_def,
-      LinearMap.comp_assoc]
-  have hright :
-      (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap =
-        (TensorProduct.rid k M).symm.toLinearMap ∘ₗ
-          (TensorProduct.lid k M).toLinearMap := by
-    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
-      leftUnitor_hom_toLinearMap, rightUnitor_inv_toLinearMap]
+      leftUnitor_hom_toLinearMap, rightUnitor_inv_toLinearMap,
+      dual_coe, LinearMap.comp_assoc]
+    exact contractLeft_assoc_coevaluation' k M
   apply ObjectProperty.hom_ext
   apply ComoduleCat.hom_ext
-  intro x
-  change
-    ((dualCoevaluation k H M ▷ M ≫
-        (α_ M (dual k H M) M).hom ≫
-          M ◁ dualEvaluation k H M).hom).toLinearMap x =
-      (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap x
-  rw [hleft, hright]
-  exact LinearMap.congr_fun (contractLeft_assoc_coevaluation' k M) x
+  exact fun x => LinearMap.congr_fun h x
 
 /-- The antipode-twisted linear dual is an exact right dual of a finite-dimensional
 comodule. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -290,8 +290,9 @@ private theorem rightUnitor_inv_toLinearMap
   intro m
   exact rightUnitor_inv_apply m
 
-set_option backward.privateInPublic true in
-private theorem coevaluation_evaluation
+/-- The first triangle identity for the antipode-twisted dual: coevaluation followed by
+evaluation is the identity on the dual, up to the unitors. -/
+theorem dualCoevaluation_dualEvaluation
     (M : FGComoduleCat.{u, v, u} k H) :
     letI M' : FGComoduleCat.{u, v, u} k H := dual k H M
     M' ◁ dualCoevaluation k H M ≫ (α_ M' M M').inv ≫
@@ -328,8 +329,9 @@ private theorem coevaluation_evaluation
   rw [hleft, hright]
   exact LinearMap.congr_fun (contractLeft_assoc_coevaluation k M) x
 
-set_option backward.privateInPublic true in
-private theorem evaluation_coevaluation
+/-- The second triangle identity for the antipode-twisted dual: coevaluation followed by
+evaluation is the identity on the comodule, up to the unitors. -/
+theorem dualEvaluation_dualCoevaluation
     (M : FGComoduleCat.{u, v, u} k H) :
     dualCoevaluation k H M ▷ M ≫
         (α_ M (dual k H M) M).hom ≫ M ◁ dualEvaluation k H M =
@@ -365,16 +367,14 @@ private theorem evaluation_coevaluation
   rw [hleft, hright]
   exact LinearMap.congr_fun (contractLeft_assoc_coevaluation' k M) x
 
-set_option backward.privateInPublic true in
-set_option backward.privateInPublic.warn false in
 /-- The antipode-twisted linear dual is an exact right dual of a finite-dimensional
 comodule. -/
 noncomputable instance instExactPairingDual
     (M : FGComoduleCat.{u, v, u} k H) : ExactPairing M (dual k H M) where
   coevaluation' := dualCoevaluation k H M
   evaluation' := dualEvaluation k H M
-  coevaluation_evaluation' := coevaluation_evaluation k H M
-  evaluation_coevaluation' := evaluation_coevaluation k H M
+  coevaluation_evaluation' := dualCoevaluation_dualEvaluation k H M
+  evaluation_coevaluation' := dualEvaluation_dualCoevaluation k H M
 
 /-- Every finite-dimensional comodule has the antipode-twisted linear dual as a right dual. -/
 noncomputable instance instHasRightDual

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -136,6 +136,7 @@ theorem dualEvaluation_apply (M : FGComoduleCat.{u, v, u} k H)
     dualEvaluation k H M (φ ⊗ₜ[k] m) = φ m :=
   rfl
 
+/-- The underlying linear map of evaluation is ordinary contraction. -/
 @[simp]
 theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
@@ -147,6 +148,8 @@ private theorem tensorCoact_coevaluation_apply_one
         (coevaluation k M 1) =
       coevaluation k M 1 ⊗ₜ[k] (1 : H) := by
   classical
+  -- Expand coevaluation and both coactions in a basis, then compare tensor coordinates.
+  -- The remaining matrix-coefficient sum collapses by the left antipode/counit identity.
   let b := Module.Basis.ofVectorSpace k M
   rw [coevaluation_apply_one]
   dsimp only [b]
@@ -222,6 +225,7 @@ theorem dualCoevaluation_apply_one (M : FGComoduleCat.{u, v, u} k H) :
           (Module.Basis.ofVectorSpace k M).coord i :=
   coevaluation_apply_one k M
 
+/-- The underlying linear map of coevaluation is ordinary finite-dimensional coevaluation. -/
 @[simp]
 theorem dualCoevaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -96,7 +96,6 @@ private theorem lid_map_contractLeft_tensorCombine
 
 /-- Evaluation of the antipode-twisted dual against a finite-dimensional comodule, as a
 finite-comodule morphism. -/
-@[expose]
 noncomputable def dualEvaluation (M : FGComoduleCat.{u, v, u} k H) :
     dual k H M ⊗ M ⟶ 𝟙_ (FGComoduleCat.{u, v, u} k H) :=
   letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
@@ -129,18 +128,27 @@ noncomputable def dualEvaluation (M : FGComoduleCat.{u, v, u} k H) :
           simp [Algebra.smul_def]
   }
 
+private theorem dualEvaluation_apply_aux (M : FGComoduleCat.{u, v, u} k H)
+    (φ : dual k H M) (m : M) :
+    dualEvaluation k H M (φ ⊗ₜ[k] m) = φ m :=
+  rfl
+
+private theorem dualEvaluation_toLinearMap_aux (M : FGComoduleCat.{u, v, u} k H) :
+    (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
+  rfl
+
 /-- Evaluation applies the underlying functional to the vector. -/
 @[simp]
 theorem dualEvaluation_apply (M : FGComoduleCat.{u, v, u} k H)
     (φ : dual k H M) (m : M) :
     dualEvaluation k H M (φ ⊗ₜ[k] m) = φ m :=
-  rfl
+  dualEvaluation_apply_aux k H M φ m
 
 /-- The underlying linear map of evaluation is ordinary contraction. -/
 @[simp]
 theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
-  rfl
+  dualEvaluation_toLinearMap_aux k H M
 
 private theorem tensorCoact_coevaluation_apply_one
     (M : FGComoduleCat.{u, v, u} k H) :
@@ -204,7 +212,6 @@ private theorem tensorCoact_coevaluation_apply_one
 
 /-- The ordinary finite-dimensional coevaluation, as a finite-comodule morphism into the
 tensor product with the antipode-twisted dual. -/
-@[expose]
 noncomputable def dualCoevaluation (M : FGComoduleCat.{u, v, u} k H) :
     𝟙_ (FGComoduleCat.{u, v, u} k H) ⟶ M ⊗ dual k H M :=
   letI : Comodule k H k := Comodule.trivial (R := k) (C := H) (M := k)
@@ -216,6 +223,10 @@ noncomputable def dualCoevaluation (M : FGComoduleCat.{u, v, u} k H) :
         TensorProduct.map_tmul, LinearMap.id_apply, Comodule.tensor_coact]
       exact (tensorCoact_coevaluation_apply_one k H M).symm
   }
+
+private theorem dualCoevaluation_toLinearMap_aux (M : FGComoduleCat.{u, v, u} k H) :
+    (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=
+  rfl
 
 /-- Coevaluation at one is the canonical basis-independent tensor. -/
 theorem dualCoevaluation_apply_one (M : FGComoduleCat.{u, v, u} k H) :
@@ -229,7 +240,7 @@ theorem dualCoevaluation_apply_one (M : FGComoduleCat.{u, v, u} k H) :
 @[simp]
 theorem dualCoevaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=
-  rfl
+  dualCoevaluation_toLinearMap_aux k H M
 
 /-- The antipode-twisted linear dual is an exact right dual of a finite-dimensional
 comodule. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -30,6 +30,9 @@ antipode need not be bijective.
 
 ## References
 
+The exact-pairing packaging adapts the finite-dimensional module construction in
+`Mathlib/Algebra/Category/FGModuleCat/Basic.lean`.
+
 See Etingof--Gelaki--Nikshych--Ostrik, *Tensor Categories*, Definition 2.10.1 and
 Remark 5.3.8; Milne, *Algebraic Groups* (2017), Section 9.26; and Humphreys,
 *Linear Algebraic Groups*, Section 8.2.
@@ -170,9 +173,12 @@ private theorem tensorCoact_coevaluation_apply_one
           (Comodule.matrixCoefficient (R := k) (C := H)
             ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
         if q = p then 1 else 0 by
-    simpa [bt, Module.Basis.coe_ofVectorSpace,
-      Module.Basis.tensorProduct_repr_tmul_apply, Module.Basis.dualBasis_repr,
-      hrepr] using h
+    simpa only [Module.Basis.coe_ofVectorSpace, map_sum,
+      TensorProduct.equivFinsuppOfBasisLeft_apply_tmul, Finsupp.coe_finsetSum,
+      Finset.sum_apply, Finsupp.mapRange_apply, Module.Basis.tensorProduct_repr_tmul_apply,
+      Module.Basis.dualBasis_repr, Module.Basis.coord_apply, hrepr, smul_eq_mul, mul_ite,
+      mul_one, mul_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq',
+      Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt] using h
   calc
     _ = LinearMap.mul' k H
         ((HopfAlgebra.antipode k).lTensor H
@@ -221,63 +227,46 @@ theorem dualCoevaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualCoevaluation k H M).hom.toLinearMap = coevaluation k M :=
   rfl
 
-/-- The first triangle identity for the antipode-twisted dual: coevaluation followed by
-evaluation is the identity on the dual, up to the unitors. -/
-theorem dualCoevaluation_dualEvaluation
-    (M : FGComoduleCat.{u, v, u} k H) :
-    letI M' : FGComoduleCat.{u, v, u} k H := dual k H M
-    M' ◁ dualCoevaluation k H M ≫ (α_ M' M M').inv ≫
-        dualEvaluation k H M ▷ M' =
-      (ρ_ M').hom ≫ (λ_ M').inv := by
-  have h :
-      ((dual k H M ◁ dualCoevaluation k H M ≫
-          (α_ (dual k H M) M (dual k H M)).inv ≫
-            dualEvaluation k H M ▷ dual k H M).hom).toLinearMap =
-        (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap := by
-    rw [← id_tensorHom, ← tensorHom_id]
-    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
-      tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
-      ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
-      dualEvaluation_toLinearMap, associator_inv_toLinearMap,
-      rightUnitor_hom_toLinearMap, leftUnitor_inv_toLinearMap,
-      dual_coe, LinearMap.comp_assoc]
-    exact contractLeft_assoc_coevaluation k M
-  apply ObjectProperty.hom_ext
-  apply ComoduleCat.hom_ext
-  exact fun x => LinearMap.congr_fun h x
-
-/-- The second triangle identity for the antipode-twisted dual: coevaluation followed by
-evaluation is the identity on the comodule, up to the unitors. -/
-theorem dualEvaluation_dualCoevaluation
-    (M : FGComoduleCat.{u, v, u} k H) :
-    dualCoevaluation k H M ▷ M ≫
-        (α_ M (dual k H M) M).hom ≫ M ◁ dualEvaluation k H M =
-      (λ_ M).hom ≫ (ρ_ M).inv := by
-  have h :
-      ((dualCoevaluation k H M ▷ M ≫
-          (α_ M (dual k H M) M).hom ≫
-            M ◁ dualEvaluation k H M).hom).toLinearMap =
-        (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap := by
-    rw [← tensorHom_id, ← id_tensorHom]
-    simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
-      tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
-      ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
-      dualEvaluation_toLinearMap, associator_hom_toLinearMap,
-      leftUnitor_hom_toLinearMap, rightUnitor_inv_toLinearMap,
-      dual_coe, LinearMap.comp_assoc]
-    exact contractLeft_assoc_coevaluation' k M
-  apply ObjectProperty.hom_ext
-  apply ComoduleCat.hom_ext
-  exact fun x => LinearMap.congr_fun h x
-
 /-- The antipode-twisted linear dual is an exact right dual of a finite-dimensional
 comodule. -/
 noncomputable instance instExactPairingDual
     (M : FGComoduleCat.{u, v, u} k H) : ExactPairing M (dual k H M) where
   coevaluation' := dualCoevaluation k H M
   evaluation' := dualEvaluation k H M
-  coevaluation_evaluation' := dualCoevaluation_dualEvaluation k H M
-  evaluation_coevaluation' := dualEvaluation_dualCoevaluation k H M
+  coevaluation_evaluation' := by
+    have h :
+        ((dual k H M ◁ dualCoevaluation k H M ≫
+            (α_ (dual k H M) M (dual k H M)).inv ≫
+              dualEvaluation k H M ▷ dual k H M).hom).toLinearMap =
+          (((ρ_ (dual k H M)).hom ≫ (λ_ (dual k H M)).inv).hom).toLinearMap := by
+      rw [← id_tensorHom, ← tensorHom_id]
+      simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+        tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
+        ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
+        dualEvaluation_toLinearMap, associator_inv_toLinearMap,
+        rightUnitor_hom_toLinearMap, leftUnitor_inv_toLinearMap,
+        dual_coe, LinearMap.comp_assoc]
+      exact contractLeft_assoc_coevaluation k M
+    apply ObjectProperty.hom_ext
+    apply ComoduleCat.hom_ext
+    exact fun x => LinearMap.congr_fun h x
+  evaluation_coevaluation' := by
+    have h :
+        ((dualCoevaluation k H M ▷ M ≫
+            (α_ M (dual k H M) M).hom ≫
+              M ◁ dualEvaluation k H M).hom).toLinearMap =
+          (((λ_ M).hom ≫ (ρ_ M).inv).hom).toLinearMap := by
+      rw [← tensorHom_id, ← id_tensorHom]
+      simp only [ObjectProperty.FullSubcategory.comp_hom, ComoduleCat.toLinearMap_comp,
+        tensorHom_toLinearMap, ObjectProperty.FullSubcategory.id_hom,
+        ComoduleCat.toLinearMap_id, dualCoevaluation_toLinearMap,
+        dualEvaluation_toLinearMap, associator_hom_toLinearMap,
+        leftUnitor_hom_toLinearMap, rightUnitor_inv_toLinearMap,
+        dual_coe, LinearMap.comp_assoc]
+      exact contractLeft_assoc_coevaluation' k M
+    apply ObjectProperty.hom_ext
+    apply ComoduleCat.hom_ext
+    exact fun x => LinearMap.congr_fun h x
 
 /-- Every finite-dimensional comodule has the antipode-twisted linear dual as a right dual. -/
 noncomputable instance instHasRightDual

--- a/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Comul.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/MatrixCoefficient/Comul.lean
@@ -31,6 +31,8 @@ makes the coefficient submodule of a finite free comodule stable under comultipl
 
 * `TauCeti.Comodule.comul_matrixCoefficient`: the basis-free comultiplication formula.
 * `TauCeti.Comodule.comul_matrixCoefficient_eq_sum`: its expansion in a finite basis.
+* `TauCeti.Comodule.coact_eq_sum_basis_matrixCoefficient`: the expansion of the coaction itself
+  in a finite basis.
 
 ## References
 
@@ -122,7 +124,9 @@ private theorem tensor_eq_sum_basis_tmul {ι : Type x} [Fintype ι]
       rw [TensorProduct.equivFinsuppOfBasisLeft_apply]
       simp only [LinearMap.rTensor]
 
-private theorem coact_eq_sum_basis_matrixCoefficient {ι : Type x} [Fintype ι]
+/-- The coaction of a comodule with a finite basis `(eᵢ)` expands as
+`ρ(m) = ∑ i, eᵢ ⊗ c(eⁱ, m)` in matrix coefficients. -/
+theorem coact_eq_sum_basis_matrixCoefficient {ι : Type x} [Fintype ι]
     (b : Basis ι R M) (m : M) :
     coact (R := R) (C := C) (M := M) m =
       ∑ i, b i ⊗ₜ[R]


### PR DESCRIPTION
This PR equips the same-universe category of finite-dimensional right comodules over an arbitrary Hopf algebra with categorical right duals. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, “representations = comodules,” specifically the rigid monoidal category of finite-dimensional comodules, and the `ReductiveGroups/STATUS.md` frontier item “Duals of finitely generated comodules.”

Roadmap: ReductiveGroups

It constructs evaluation and coevaluation from finite-dimensional linear duality and proves their colinearity through the two antipode identities for matrix coefficients. The resulting exact pairing supplies `HasRightDual` for every object and a `RightRigidCategory` instance without assuming that the Hopf algebra is commutative or finite-dimensional, or that its antipode is bijective. The categorical packaging adapts Mathlib’s finite-dimensional module exact-pairing pattern to Tau Ceti’s comodule category while using Tau Ceti’s public monoidal coherence maps.

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-comodule-right-rigidity"}-->

🤖 Prepared with Codex
