### PR TITLE
feat: add the circular crosscut of a disc at a boundary point

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -46,9 +46,11 @@ missing the crosscut lies entirely in one of them.
 
 ## The boundary criterion
 
-The frontier of the crosscut neighbourhood consists of two pieces of circle
+The frontier of the crosscut neighbourhood is contained in the union of two pieces of circle
 (`TauCeti.frontier_ball_inter_ball_subset`): the arc `closedBall c r ∩ sphere ζ ρ`, and the cap
-`sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc. Since the crosscut neighbourhood
+`sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc. Equality can fail — for
+`2 * r ≤ ρ` the crosscut neighbourhood is the whole disc, and its frontier misses the arc — but
+containment is all a frontier bound needs. Since the crosscut neighbourhood
 is bounded and open, the maximum modulus principle bounds `f` inside it by its values on those two
 pieces (`TauCeti.norm_sub_le_of_mem_ball_inter_ball`).
 
@@ -61,7 +63,7 @@ gives `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`: only hol
 disc is assumed, the arc bound is asked for on `ball c r ∩ sphere ζ ρ`, and the cap bound is
 replaced by a bound on a *collar* `r₀ ≤ dist w c` of the boundary inside the crosscut
 neighbourhood — all of it data about `f` inside the disc. Letting `ρ` shrink and feeding the
-resulting oscillation bound to `TauCeti.clusterSetOn_subsingleton_of_forall_exists`, one gets:
+resulting oscillation bound to `TauCeti.subsingleton_clusterSetOn_of_forall_exists`, one gets:
 
 > a bounded holomorphic function on a disc has a limit at a boundary point `ζ` as soon as it is
 > *nearly constant on the crosscut arc and on a collar of the boundary* at arbitrarily small radii
@@ -202,9 +204,12 @@ The set is *not* convex, and the proof is the Möbius reduction of the module do
 inversion `z ↦ (z - ζ)⁻¹` carries `ball c r` to the half-plane `{w | 1 < 2 * ((c - ζ) * w).re}` by
 `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv`, and the complement of `closedBall ζ ρ` to
 `ball 0 ρ⁻¹`; the intersection of those two is convex, and `w ↦ ζ + w⁻¹` carries it back
-continuously, `0` not being in it. -/
-theorem isConnected_ball_diff_closedBall (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ)
+continuously, `0` not being in it.
+
+Positivity of `r` is not a separate hypothesis: `0 < ρ < 2 * r` already forces it. -/
+theorem isConnected_ball_diff_closedBall (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρ' : ρ < 2 * r) : IsConnected (ball c r \ closedBall ζ ρ) := by
+  have hr : 0 < r := by linarith
   have hac : ‖c - ζ‖ = r := by rw [← dist_eq_norm, dist_comm, hζ]
   have ha0 : c - ζ ≠ 0 := by
     intro h
@@ -284,12 +289,11 @@ theorem ball_diff_sphere_eq_union :
     · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
     · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
 
-/-- The two sides of a circular crosscut are disjoint. -/
+/-- The two sides of a circular crosscut are disjoint, the near side lying inside `closedBall ζ ρ`
+and the far side outside it. -/
 theorem disjoint_ball_inter_ball_ball_diff_closedBall :
-    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) := by
-  rw [Set.disjoint_left]
-  rintro y ⟨-, hy⟩ ⟨-, hy'⟩
-  exact hy' (closedBall_subset_closedBall le_rfl (ball_subset_closedBall hy))
+    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) :=
+  Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
 
 /-- **A connected set in the disc missing a circular crosscut lies on one side of it.** This is the
 separation statement the decomposition exists for: the two sides are open and disjoint, so a
@@ -319,12 +323,12 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
 /-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
 of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball`; here the connectedness of the
 piece is the substantial `TauCeti.isConnected_ball_diff_closedBall`. -/
-theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall (hr : 0 < r)
+theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
   have hsub : ball c r \ closedBall ζ ρ ⊆ ball c r \ sphere ζ ρ :=
     ball_diff_sphere_eq_union ▸ subset_union_right
-  refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hr hζ hρ hρ').isPreconnected
+  refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hζ hρ hρ').isPreconnected
     |>.subset_connectedComponentIn hz hsub)
   rcases subset_ball_inter_ball_or_subset_ball_diff_closedBall isPreconnected_connectedComponentIn
     (connectedComponentIn_subset _ _) with h | h
@@ -340,41 +344,36 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall (hr : 0 < 
 has to be controlled for the maximum principle to control it inside. Only the inclusion is claimed,
 which is all a frontier bound needs, and it is what holds without further hypotheses — for
 `2 * r ≤ ρ` the crosscut neighbourhood is the whole disc and its frontier misses the arc
-entirely. -/
+entirely.
+
+This is Mathlib's `frontier_inter_subset` for the two balls, whose two summands are pinned down by
+`frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`. -/
 theorem frontier_ball_inter_ball_subset :
     frontier (ball c r ∩ ball ζ ρ)
-      ⊆ sphere c r ∩ closedBall ζ ρ ∪ closedBall c r ∩ sphere ζ ρ := by
-  intro y hy
-  rw [(isOpen_ball.inter isOpen_ball).frontier_eq, Set.mem_sdiff] at hy
-  obtain ⟨hycl, hynot⟩ := hy
-  have hy₁ : dist y c ≤ r := by
-    have := closure_mono (inter_subset_left (t := ball ζ ρ)) hycl
-    exact Metric.mem_closedBall.mp (closure_ball_subset_closedBall this)
-  have hy₂ : dist y ζ ≤ ρ := by
-    have := closure_mono (inter_subset_right (s := ball c r)) hycl
-    exact Metric.mem_closedBall.mp (closure_ball_subset_closedBall this)
-  simp only [Set.mem_inter_iff, Metric.mem_ball, not_and, not_lt] at hynot
-  rcases eq_or_lt_of_le hy₁ with h | h
-  · exact Or.inl ⟨Metric.mem_sphere.mpr h, Metric.mem_closedBall.mpr hy₂⟩
-  · exact Or.inr ⟨Metric.mem_closedBall.mpr hy₁,
-      Metric.mem_sphere.mpr (le_antisymm hy₂ (hynot h))⟩
+      ⊆ sphere c r ∩ closedBall ζ ρ ∪ closedBall c r ∩ sphere ζ ρ :=
+  (frontier_inter_subset _ _).trans <| union_subset_union
+    (inter_subset_inter frontier_ball_subset_sphere closure_ball_subset_closedBall)
+    (inter_subset_inter closure_ball_subset_closedBall frontier_ball_subset_sphere)
 
 variable {f : ℂ → ℂ} {a : ℂ} {C r₀ : ℝ}
 
-/-- **The maximum modulus principle on a crosscut neighbourhood.** A function holomorphic on
-`ball c r` and continuous up to the closed disc that stays within `C` of a value `a` on the closed
-crosscut arc and on the boundary cap stays within `C` of `a` on the whole crosscut neighbourhood.
+/-- **The maximum modulus principle on a crosscut neighbourhood.** A function holomorphic on the
+crosscut neighbourhood and continuous up to its closure that stays within `C` of a value `a` on the
+closed crosscut arc and on the boundary cap stays within `C` of `a` on the whole crosscut
+neighbourhood.
 
 The crosscut neighbourhood is a bounded open set whose frontier is covered by those two pieces
 (`TauCeti.frontier_ball_inter_ball_subset`), so this is Mathlib's
 `Complex.norm_le_of_forall_mem_frontier_norm_le` applied to `f - a` on it. Neither injectivity of
-`f` nor connectivity of anything is used. -/
-theorem norm_sub_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
+`f` nor connectivity of anything is used. Regularity is asked for on the crosscut neighbourhood
+alone rather than on the disc, which is all the maximum principle consumes; a caller holding
+`DiffContOnCl ℂ f (ball c r)` supplies it by `DiffContOnCl.mono inter_subset_left`. -/
+theorem norm_sub_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r ∩ ball ζ ρ))
     (harc : ∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
     (hcap : ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ C)
     (hz : z ∈ ball c r ∩ ball ζ ρ) : ‖f z - a‖ ≤ C := by
   refine Complex.norm_le_of_forall_mem_frontier_norm_le
-    (isBounded_ball.subset inter_subset_left) ((hf.mono inter_subset_left).sub_const a)
+    (isBounded_ball.subset inter_subset_left) (hf.sub_const a)
     (fun w hw => ?_) (subset_closure hz)
   rcases frontier_ball_inter_ball_subset hw with h | h
   · exact hcap w h
@@ -410,7 +409,8 @@ theorem norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn
       have h₃ := max_lt hr₀ hzr
       exact ⟨by linarith, by linarith, by linarith⟩⟩
   have hsub : closedBall c s ⊆ ball c r := closedBall_subset_ball hsr
-  refine norm_sub_le_of_mem_ball_inter_ball (r := s) (hd.diffContOnCl_ball hsub)
+  refine norm_sub_le_of_mem_ball_inter_ball (r := s)
+    ((hd.diffContOnCl_ball hsub).mono inter_subset_left)
     (fun w hw => harc w ⟨hsub hw.1, hw.2⟩) (fun w hw => ?_) ⟨mem_ball.mpr hzs, hz.2⟩
   have hwc : dist w c = s := mem_sphere.mp hw.1
   exact hcap w ⟨hsub (mem_closedBall.mpr hwc.le), hw.2⟩ (hwc ▸ hr₀s)
@@ -442,14 +442,14 @@ The maximum modulus principle turns each such estimate into an oscillation bound
 neighbourhood `ball c r ∩ ball ζ ρ`
 (`TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`), and those neighbourhoods are
 exactly the traces on the disc of the balls around `ζ`, so
-`TauCeti.clusterSetOn_subsingleton_of_forall_exists` applies verbatim. Only the values of `f` on
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists` applies verbatim. Only the values of `f` on
 the *open* disc are constrained, and only holomorphy there is assumed; note that `ζ` need not be
 on the boundary circle for this statement, and that `ρ`, `r₀` and `a` may all depend on `ε`. -/
-theorem clusterSetOn_ball_subsingleton (hd : DifferentiableOn ℂ f (ball c r))
+theorem subsingleton_clusterSetOn_ball (hd : DifferentiableOn ℂ f (ball c r))
     (h : ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ, (∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
       ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
     (clusterSetOn f (ball c r) ζ).Subsingleton := by
-  refine clusterSetOn_subsingleton_of_forall_exists fun ε hε => ?_
+  refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
   obtain ⟨ρ, hρ, r₀, hr₀, a, harc, hcap⟩ := h (ε / 2) (by positivity)
   refine ⟨ρ, hρ, fun x hx y hy => ?_⟩
   have := dist_le_of_mem_ball_inter_ball hd hr₀ harc hcap hx hy
@@ -465,7 +465,7 @@ function on a disc need not have any limit at a given boundary point — so the 
 carries the content; it is exactly the estimate the length–area method produces on the arc and
 local connectedness of the image boundary produces on the collar.
 
-The cluster set is a subsingleton by `TauCeti.clusterSetOn_ball_subsingleton`, and it is nonempty
+The cluster set is a subsingleton by `TauCeti.subsingleton_clusterSetOn_ball`, and it is nonempty
 because `f` maps the disc into the compact closure of its bounded image; that is exactly what
 `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` needs. -/
 theorem exists_tendsto_nhdsWithin_ball (hr : 0 < r) (hd : DifferentiableOn ℂ f (ball c r))
@@ -474,7 +474,7 @@ theorem exists_tendsto_nhdsWithin_ball (hr : 0 < r) (hd : DifferentiableOn ℂ f
       ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
     ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) := by
   refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
-    (fun w hw => subset_closure ⟨w, hw, rfl⟩) ?_ (clusterSetOn_ball_subsingleton hd h)
+    (fun w hw => subset_closure ⟨w, hw, rfl⟩) ?_ (subsingleton_clusterSetOn_ball hd h)
   rw [closure_ball c hr.ne']
   exact mem_closedBall.mpr hζ.le
 
@@ -496,7 +496,7 @@ theorem exists_continuousOn_closedBall_eqOn (hr : 0 < r) (hd : DifferentiableOn 
     ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
   obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball
     hd.continuousOn hb fun ζ hζ => by
-      refine clusterSetOn_ball_subsingleton hd (h ζ ?_)
+      refine subsingleton_clusterSetOn_ball hd (h ζ ?_)
       rwa [frontier_ball c hr.ne'] at hζ
   exact ⟨F, closure_ball c hr.ne' ▸ hFc, hFe⟩
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -175,7 +175,7 @@ theorem mem_ball_iff_one_lt_two_mul_re_mul_inv (hζ : dist ζ c = r) (hz : z ≠
 /-- **The crosscut neighbourhood is nonempty.** For `ζ` on the circle `sphere c r` and any positive
 `ρ`, the intersection `ball c r ∩ ball ζ ρ` contains points of the radius from `ζ` to `c` close
 enough to `ζ`. -/
-theorem ball_inter_ball_nonempty (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
+theorem nonempty_ball_inter_ball (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
     (ball c r ∩ ball ζ ρ).Nonempty := by
   have hnc : ‖ζ - c‖ = r := by rw [← dist_eq_norm, hζ]
   set t : ℝ := min (1 / 2) (ρ / (2 * r))
@@ -194,10 +194,10 @@ theorem ball_inter_ball_nonempty (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < �
       _ < ρ := by linarith
 
 /-- **The crosscut neighbourhood is connected**, being an intersection of two balls, hence convex.
-Its nonemptiness is `TauCeti.ball_inter_ball_nonempty`. -/
+Its nonemptiness is `TauCeti.nonempty_ball_inter_ball`. -/
 theorem isConnected_ball_inter_ball (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
     IsConnected (ball c r ∩ ball ζ ρ) :=
-  ((convex_ball c r).inter (convex_ball ζ ρ)).isConnected (ball_inter_ball_nonempty hr hζ hρ)
+  ((convex_ball c r).inter (convex_ball ζ ρ)).isConnected (nonempty_ball_inter_ball hr hζ hρ)
 
 /-- **The part of a disc outside a circular crosscut is connected.** For `ζ` on the circle
 `sphere c r` and `0 < ρ < 2 * r`, the set `ball c r \ closedBall ζ ρ` is connected — and nonempty,

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -66,11 +66,15 @@ neighbourhood — all of it data about `f` inside the disc. Feeding those oscill
 each tolerance `ε`, to `TauCeti.subsingleton_clusterSetOn_of_forall_exists`, one gets:
 
 > a bounded holomorphic function on a disc has a limit at a boundary point `ζ` as soon as, for
-> every `ε > 0`, there is *some* crosscut radius `ρ > 0` at which `f` is within `ε` of a single
-> value on the crosscut arc and on a collar of the boundary.
+> every `ε > 0`, there is *some* radius `ρ > 0` at which `f` is within `ε` of a single value on
+> the part `ball c r ∩ sphere ζ ρ` of the circle around `ζ` inside the disc and on a collar of
+> the boundary.
 
 The radius is quantified per `ε`, and need not tend to zero: it is `ε` that shrinks, while `ρ`
-(along with the collar and the value approximated) is merely allowed to depend on it.
+(along with the collar and the value approximated) is merely allowed to depend on it. Nor is `ρ`
+asked to stay below `2 * r`, so a witness need not describe a circular crosscut: admitting the
+larger radii too only weakens the hypothesis, and the crosscut radii the application supplies are
+among the admissible ones.
 
 This is `TauCeti.exists_tendsto_nhdsWithin_ball`, and `TauCeti.exists_continuousOn_closedBall_eqOn`
 is its global form, a continuous extension to the closed disc. Boundedness alone is far from
@@ -437,10 +441,10 @@ theorem dist_le_of_mem_ball_inter_ball (hd : DifferentiableOn ℂ f (ball c r)) 
 
 /-! ## The crosscut criterion for boundary behaviour -/
 
-/-- **The crosscut criterion, cluster-set form.** If for every `ε > 0` there is *some* crosscut
-radius `ρ > 0` at which the function `f` is within `ε` of a single value on the part of the crosscut
-circle inside the disc and on a collar of the boundary, then `f` has at most one cluster value at
-`ζ` along the disc.
+/-- **The crosscut criterion, cluster-set form.** If for every `ε > 0` there is *some* radius
+`ρ > 0` at which the function `f` is within `ε` of a single value on the part
+`ball c r ∩ sphere ζ ρ` of the circle around `ζ` inside the disc and on a collar of the boundary,
+then `f` has at most one cluster value at `ζ` along the disc.
 
 The maximum modulus principle turns each such estimate into an oscillation bound on the crosscut
 neighbourhood `ball c r ∩ ball ζ ρ`
@@ -448,7 +452,8 @@ neighbourhood `ball c r ∩ ball ζ ρ`
 exactly the traces on the disc of the balls around `ζ`, so
 `TauCeti.subsingleton_clusterSetOn_of_forall_exists` applies verbatim. Only the values of `f` on
 the *open* disc are constrained, and only holomorphy there is assumed; note that `ζ` need not be
-on the boundary circle for this statement, and that `ρ`, `r₀` and `a` may all depend on `ε`. -/
+on the boundary circle for this statement, that `ρ`, `r₀` and `a` may all depend on `ε`, and that
+`ρ` is not bounded above by `2 * r`, so a witness need not cut a circular crosscut. -/
 theorem subsingleton_clusterSetOn_ball (hd : DifferentiableOn ℂ f (ball c r))
     (h : ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ, (∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
       ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
@@ -460,9 +465,11 @@ theorem subsingleton_clusterSetOn_ball (hd : DifferentiableOn ℂ f (ball c r))
   linarith
 
 /-- **The crosscut criterion for a boundary limit.** A bounded holomorphic function on a disc has a
-limit at a boundary point `ζ`, along the disc, as soon as for every `ε > 0` there is some crosscut
-radius at which it is within `ε` of a single value on the crosscut arc and on a collar of the
-boundary.
+limit at a boundary point `ζ`, along the disc, as soon as for every `ε > 0` there is some radius
+`ρ > 0` at which it is within `ε` of a single value on the part `ball c r ∩ sphere ζ ρ` of the
+circle around `ζ` inside the disc and on a collar of the boundary. As in
+`TauCeti.subsingleton_clusterSetOn_ball`, no upper bound on `ρ` is imposed, so a witness need not
+cut a circular crosscut.
 
 Nothing is assumed at the boundary circle itself: the input is the behaviour of `f` inside the
 disc, and the limit is a conclusion. Boundedness alone is far from enough — a bounded holomorphic
@@ -489,10 +496,11 @@ holomorphic function `f` extends continuously to `closedBall c r`.
 
 This is the shape in which the Carathéodory boundary correspondence is proved: whatever geometric
 hypothesis is placed on the image, it is used only to produce, at each boundary point and each
-`ε`, a crosscut radius along which `f` varies by at most `ε` on the arc and on the collar. The
-extension is genuinely produced here rather than assumed, since only holomorphy and boundedness on
-the *open* disc are hypotheses. Nothing here asserts that the extension is injective, which is an
-independent matter. -/
+`ε`, a radius `ρ > 0` — a crosscut radius in the application, though the statement imposes no
+upper bound on it — along which `f` varies by at most `ε` on `ball c r ∩ sphere ζ ρ` and on the
+collar. The extension is genuinely produced here rather than assumed, since only holomorphy and
+boundedness on the *open* disc are hypotheses. Nothing here asserts that the extension is
+injective, which is an independent matter. -/
 theorem exists_continuousOn_closedBall_eqOn (hr : 0 < r) (hd : DifferentiableOn ℂ f (ball c r))
     (hb : IsBounded (f '' ball c r))
     (h : ∀ ζ ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ,

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -1,0 +1,448 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Complex.AbsMax
+public import TauCeti.Topology.ClusterSet
+import Mathlib.Analysis.Convex.PathConnected
+import Mathlib.Analysis.Normed.Module.RCLike.Real
+
+/-!
+# The circular crosscut of a disc at a boundary point
+
+Fix a disc `ball c r` and a point `ζ` of its boundary circle. For `0 < ρ < 2 * r` the circle
+`sphere ζ ρ` meets the disc in an arc, the **circular crosscut** of `ball c r` at `ζ` of radius
+`ρ`, and that arc cuts the disc in two: the *crosscut neighbourhood* `ball c r ∩ ball ζ ρ` of `ζ`,
+and the rest, `ball c r \ closedBall ζ ρ`. This file proves that decomposition, and then uses the
+crosscut neighbourhoods as the approach regions along which the boundary behaviour of a holomorphic
+function is read off.
+
+Both halves are needed for layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the
+Carathéodory boundary correspondence: the crosscut neighbourhoods are the regions the length–area
+method estimates on, and the criterion below is what converts such an estimate into the continuous
+extension the L5 milestone asks for.
+
+## The decomposition
+
+That `ball c r ∩ ball ζ ρ` is connected is immediate — it is an intersection of two balls, hence
+convex. The other piece is not convex, and the proof is the **Möbius reduction** the roadmap
+prescribes for circles: the inversion `z ↦ (z - ζ)⁻¹` at the boundary point `ζ` carries the disc to
+a half-plane, because a circle through the centre of an inversion goes to a line. Concretely,
+writing `a = c - ζ`, a point `z ≠ ζ` lies in `ball c r` exactly when `1 < 2 * (a * (z - ζ)⁻¹).re`
+(`TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv`): the disc becomes the open half-plane
+`{w | 1 < 2 * (a * w).re}`. The inversion simultaneously turns the *complement* of `closedBall ζ ρ`
+into the ball `ball 0 ρ⁻¹`, since `‖(z - ζ)⁻¹‖ = ‖z - ζ‖⁻¹`. So `ball c r \ closedBall ζ ρ` is
+carried onto an intersection of a half-plane with a ball — convex, and nonempty exactly when
+`ρ < 2 * r` — and is therefore connected, being the image of a connected set under the continuous
+inverse inversion `w ↦ ζ + w⁻¹`.
+
+The two pieces are open, disjoint and cover `ball c r \ sphere ζ ρ`, so they *are* its connected
+components (`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion):
+a circular crosscut separates the disc into exactly two parts, and a connected subset of the disc
+missing the crosscut lies entirely in one of them.
+
+## The boundary criterion
+
+The frontier of the crosscut neighbourhood consists of two pieces of circle
+(`TauCeti.frontier_ball_inter_ball_subset`): the arc `closedBall c r ∩ sphere ζ ρ`, and the cap
+`sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc. Since the crosscut neighbourhood
+is bounded and open, the maximum modulus principle bounds `f` inside it by its values on those two
+pieces. Letting `ρ` run over a sequence tending to `0` and feeding the resulting oscillation bound
+to `TauCeti.clusterSetOn_subsingleton_of_forall_exists`, one gets:
+
+> a holomorphic function on a disc, continuous up to the closed disc, has a limit at a boundary
+> point `ζ` as soon as it is *nearly constant on the crosscut arc and on the boundary cap* at
+> arbitrarily small radii `ρ`.
+
+This is `TauCeti.exists_tendsto_nhdsWithin_ball`, and `TauCeti.exists_continuousOn_closedBall_eqOn`
+is its global form, a continuous extension to the closed disc. Neither injectivity of `f` nor any
+hypothesis on the image is used — the estimate on the two boundary pieces is the whole input, and
+supplying it for a Riemann map of a Jordan domain is precisely what the remaining L5 work consists
+of. The length–area method delivers the bound on the arc; the bound on the cap is where local
+connectedness of the image boundary enters.
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, everything below is stated for `ℂ`. The geometric half is not
+merely a convenience of that bar: the map that performs the decomposition is the complex inversion
+`z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for reducing circles to lines, and the analytic
+half is the maximum modulus principle for holomorphic functions.
+
+## Main results
+
+* `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` — the inversion at a boundary point carries a
+  disc to a half-plane.
+* `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
+  connected.
+* `TauCeti.ball_diff_sphere_eq_union`,
+  `TauCeti.subset_ball_inter_ball_or_subset_ball_diff_closedBall` and
+  `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
+  separates the disc into exactly two connected components.
+* `TauCeti.norm_sub_le_of_mem_ball_inter_ball` — the maximum modulus principle on a crosscut
+  neighbourhood: a bound on the arc and on the cap is a bound inside.
+* `TauCeti.exists_tendsto_nhdsWithin_ball` and `TauCeti.exists_continuousOn_closedBall_eqOn` — the
+  crosscut criterion for a boundary limit, and for a continuous extension to the closed disc.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and
+Mathlib has no boundary correspondence for conformal maps. So this file is new Lean formalization
+rather than a temporary shim, and it consumes no L0–L3 shim: its analytic input is Mathlib's own
+maximum modulus principle, `Complex.norm_le_of_forall_mem_frontier_norm_le`.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2 (crosscuts).
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Complex Filter Metric Set Topology
+
+variable {c ζ z : ℂ} {r ρ : ℝ}
+
+/-! ## The inversion at a boundary point -/
+
+/-- **The inversion at a boundary point carries a disc to a half-plane.** If `ζ` lies on the circle
+`sphere c r`, then a point `z ≠ ζ` lies in `ball c r` exactly when its image `(z - ζ)⁻¹` under the
+inversion centred at `ζ` lies in the open half-plane `{w | 1 < 2 * ((c - ζ) * w).re}`.
+
+This is the classical fact that a Möbius map sends a circle through the centre of the inversion to
+a line, in the one form the crosscut decomposition needs: which *side* of that line the disc goes
+to. The computation is `‖z - c‖ < r ↔ normSq (z - ζ) < 2 * ((z - ζ) * conj (c - ζ)).re`, obtained by
+expanding `normSq ((z - ζ) - (c - ζ))` and cancelling `normSq (c - ζ) = r ^ 2`; dividing by
+`normSq (z - ζ)` turns the left side into `1` and the right side into the half-plane condition. -/
+theorem mem_ball_iff_one_lt_two_mul_re_mul_inv (hζ : dist ζ c = r) (hz : z ≠ ζ) :
+    z ∈ ball c r ↔ 1 < 2 * ((c - ζ) * (z - ζ)⁻¹).re := by
+  have hu : z - ζ ≠ 0 := sub_ne_zero.mpr hz
+  have hns : 0 < normSq (z - ζ) := normSq_pos.mpr hu
+  have hr : 0 ≤ r := hζ ▸ dist_nonneg
+  have ha : normSq (c - ζ) = r ^ 2 := by
+    rw [Complex.normSq_eq_norm_sq, ← norm_neg, neg_sub, ← dist_eq_norm, hζ]
+  -- the real part of the inverted point, cleared of its denominator
+  have hre : ((c - ζ) * (z - ζ)⁻¹).re * normSq (z - ζ)
+      = ((z - ζ) * (starRingEnd ℂ) (c - ζ)).re := by
+    have hinv : (z - ζ)⁻¹ * ((normSq (z - ζ) : ℝ) : ℂ) = (starRingEnd ℂ) (z - ζ) := by
+      rw [← Complex.mul_conj, inv_mul_cancel_left₀ hu]
+    calc ((c - ζ) * (z - ζ)⁻¹).re * normSq (z - ζ)
+        = ((c - ζ) * (z - ζ)⁻¹ * ((normSq (z - ζ) : ℝ) : ℂ)).re := by simp [Complex.mul_re]
+      _ = ((c - ζ) * (starRingEnd ℂ) (z - ζ)).re := by rw [mul_assoc, hinv]
+      _ = ((z - ζ) * (starRingEnd ℂ) (c - ζ)).re := by simp [Complex.mul_re]; ring
+  -- the disc, in terms of `normSq`
+  have hdisc : z ∈ ball c r ↔ normSq (z - c) < r ^ 2 := by
+    rw [mem_ball, dist_eq_norm, Complex.normSq_eq_norm_sq]
+    constructor
+    · intro h; nlinarith [norm_nonneg (z - c)]
+    · intro h; nlinarith [norm_nonneg (z - c)]
+  have hsub : z - c = z - ζ - (c - ζ) := by ring
+  rw [hdisc, hsub, Complex.normSq_sub, ha]
+  rw [← hre]
+  constructor
+  · intro h; nlinarith
+  · intro h; nlinarith
+
+/-! ## The two sides of a circular crosscut -/
+
+/-- **The crosscut neighbourhood is nonempty.** For `ζ` on the circle `sphere c r` and any positive
+`ρ`, the intersection `ball c r ∩ ball ζ ρ` contains points of the radius from `ζ` to `c` close
+enough to `ζ`. -/
+theorem ball_inter_ball_nonempty (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
+    (ball c r ∩ ball ζ ρ).Nonempty := by
+  have hnc : ‖ζ - c‖ = r := by rw [← dist_eq_norm, hζ]
+  set t : ℝ := min (1 / 2) (ρ / (2 * r))
+  have ht0 : 0 < t := lt_min (by norm_num) (by positivity)
+  have ht1 : t < 1 := lt_of_le_of_lt (min_le_left _ _) (by norm_num)
+  refine ⟨ζ + (t : ℂ) * (c - ζ), ?_, ?_⟩
+  · have : ζ + (t : ℂ) * (c - ζ) - c = ((1 : ℂ) - (t : ℂ)) * (ζ - c) := by ring
+    rw [mem_ball, dist_eq_norm, this, norm_mul, hnc, ← Complex.ofReal_one, ← Complex.ofReal_sub,
+      Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith)]
+    nlinarith
+  · have : ζ + (t : ℂ) * (c - ζ) - ζ = (t : ℂ) * (c - ζ) := by ring
+    rw [mem_ball, dist_eq_norm, this, norm_mul, Complex.norm_real, Real.norm_eq_abs,
+      abs_of_pos ht0, ← norm_neg, neg_sub, hnc]
+    calc t * r ≤ ρ / (2 * r) * r := by nlinarith [min_le_right (1 / 2 : ℝ) (ρ / (2 * r))]
+      _ = ρ / 2 := by field_simp
+      _ < ρ := by linarith
+
+/-- **The crosscut neighbourhood is connected**, being an intersection of two balls, hence convex.
+Its nonemptiness is `TauCeti.ball_inter_ball_nonempty`. -/
+theorem isConnected_ball_inter_ball (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
+    IsConnected (ball c r ∩ ball ζ ρ) :=
+  ((convex_ball c r).inter (convex_ball ζ ρ)).isConnected (ball_inter_ball_nonempty hr hζ hρ)
+
+/-- **The part of a disc outside a circular crosscut is connected.** For `ζ` on the circle
+`sphere c r` and `0 < ρ < 2 * r`, the set `ball c r \ closedBall ζ ρ` is connected — and nonempty,
+which is where `ρ < 2 * r` is used: a larger `ρ` would swallow the disc.
+
+The set is *not* convex, and the proof is the Möbius reduction of the module docstring. The
+inversion `z ↦ (z - ζ)⁻¹` carries `ball c r` to the half-plane `{w | 1 < 2 * ((c - ζ) * w).re}` by
+`TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv`, and the complement of `closedBall ζ ρ` to
+`ball 0 ρ⁻¹`; the intersection of those two is convex, and `w ↦ ζ + w⁻¹` carries it back
+continuously, `0` not being in it. -/
+theorem isConnected_ball_diff_closedBall (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρ' : ρ < 2 * r) : IsConnected (ball c r \ closedBall ζ ρ) := by
+  have hac : ‖c - ζ‖ = r := by rw [← dist_eq_norm, dist_comm, hζ]
+  have ha0 : c - ζ ≠ 0 := by
+    intro h
+    rw [h, norm_zero] at hac
+    exact hr.ne hac
+  set T : Set ℂ := {w : ℂ | 1 < 2 * ((c - ζ) * w).re} ∩ ball 0 ρ⁻¹
+  -- `T` is convex: a half-plane meets a ball
+  have hlin : IsLinearMap ℝ fun w : ℂ => 2 * ((c - ζ) * w).re :=
+    { map_add := by intro x y; simp [mul_add, Complex.mul_re]
+      map_smul := by intro s x; simp [Complex.real_smul, Complex.mul_re]; ring }
+  have hTconv : Convex ℝ T := (convex_halfSpace_gt hlin 1).inter (convex_ball _ _)
+  -- points of `T` are nonzero
+  have hTne0 : ∀ w ∈ T, w ≠ 0 := by
+    rintro w ⟨hw, -⟩ rfl
+    rw [mem_ofPred_eq, mul_zero, Complex.zero_re] at hw
+    linarith
+  -- `T` is nonempty, and this is where `ρ < 2 * r` enters
+  have hTne : T.Nonempty := by
+    have hhalf : (1 : ℝ) / 2 < r / ρ := by rw [lt_div_iff₀ hρ]; linarith
+    obtain ⟨s, hs1, hs2⟩ : ∃ s : ℝ, 1 / 2 < s ∧ s < r / ρ :=
+      ⟨(1 / 2 + r / ρ) / 2, by linarith, by linarith⟩
+    have hs0 : 0 < s := by linarith
+    refine ⟨(s : ℂ) / (c - ζ), ?_, ?_⟩
+    · have : (c - ζ) * ((s : ℂ) / (c - ζ)) = (s : ℂ) := by field_simp
+      rw [mem_ofPred_eq, this, Complex.ofReal_re]
+      linarith
+    · rw [mem_ball, dist_zero_right, norm_div, Complex.norm_real, Real.norm_eq_abs,
+        abs_of_pos hs0, hac, div_lt_iff₀ hr, inv_mul_eq_div]
+      rw [lt_div_iff₀ hρ] at hs2 ⊢
+      linarith
+  -- the inversion carries `T` onto the region in question
+  have himg : (fun w : ℂ => ζ + w⁻¹) '' T = ball c r \ closedBall ζ ρ := by
+    ext y
+    constructor
+    · rintro ⟨w, hwT, rfl⟩
+      have hw0 : w ≠ 0 := hTne0 w hwT
+      have hyζ : ζ + w⁻¹ - ζ = w⁻¹ := by ring
+      have hne : ζ + w⁻¹ ≠ ζ := by
+        simpa [hyζ, sub_eq_zero] using inv_ne_zero hw0
+      have hwnorm : 0 < ‖w‖ := norm_pos_iff.mpr hw0
+      refine ⟨?_, ?_⟩
+      · rw [mem_ball_iff_one_lt_two_mul_re_mul_inv hζ hne, hyζ, inv_inv]
+        exact hwT.1
+      · rw [mem_closedBall, dist_eq_norm, hyζ, norm_inv, not_le]
+        have := hwT.2
+        rw [mem_ball, dist_zero_right] at this
+        rw [lt_inv_comm₀ hρ hwnorm]
+        exact this
+    · rintro ⟨hy1, hy2⟩
+      rw [mem_closedBall, dist_eq_norm, not_le] at hy2
+      have hyne : y ≠ ζ := by
+        intro h
+        rw [h, sub_self, norm_zero] at hy2
+        linarith
+      have hu : y - ζ ≠ 0 := sub_ne_zero.mpr hyne
+      refine ⟨(y - ζ)⁻¹, ⟨?_, ?_⟩, by simp⟩
+      · exact (mem_ball_iff_one_lt_two_mul_re_mul_inv hζ hyne).mp hy1
+      · rw [mem_ball, dist_zero_right, norm_inv, inv_lt_inv₀ (by linarith) hρ]
+        exact hy2
+  rw [← himg]
+  refine (hTconv.isConnected hTne).image _ fun w hw => ?_
+  exact (continuousAt_const.add (continuousAt_inv₀ (hTne0 w hw))).continuousWithinAt
+
+/-- **A circular crosscut splits the disc into the crosscut neighbourhood and the rest.** The
+underlying set identity: removing the crosscut `sphere ζ ρ` from `ball c r` leaves the points at
+distance less than `ρ` from `ζ` together with those at distance more than `ρ`. -/
+theorem ball_diff_sphere_eq_union :
+    ball c r \ sphere ζ ρ = ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ := by
+  ext y
+  constructor
+  · rintro ⟨hy, hne⟩
+    rw [Metric.mem_sphere] at hne
+    rcases lt_or_gt_of_ne hne with h | h
+    · exact Or.inl ⟨hy, Metric.mem_ball.mpr h⟩
+    · exact Or.inr ⟨hy, fun hc => absurd (Metric.mem_closedBall.mp hc) (not_le.mpr h)⟩
+  · rintro (⟨hy, h⟩ | ⟨hy, h⟩)
+    · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
+    · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
+
+/-- The two sides of a circular crosscut are disjoint. -/
+theorem disjoint_ball_inter_ball_ball_diff_closedBall :
+    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) := by
+  rw [Set.disjoint_left]
+  rintro y ⟨-, hy⟩ ⟨-, hy'⟩
+  exact hy' (closedBall_subset_closedBall le_rfl (ball_subset_closedBall hy))
+
+/-- **A connected set in the disc missing a circular crosscut lies on one side of it.** This is the
+separation statement the decomposition exists for: the two sides are open and disjoint, so a
+preconnected subset of their union cannot meet both. -/
+theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS : IsPreconnected S)
+    (hSsub : S ⊆ ball c r \ sphere ζ ρ) :
+    S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
+  hS.subset_or_subset (isOpen_ball.inter isOpen_ball) (isOpen_ball.sdiff isClosed_closedBall)
+    disjoint_ball_inter_ball_ball_diff_closedBall (ball_diff_sphere_eq_union ▸ hSsub)
+
+/-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
+`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular
+crosscut cuts the disc into *exactly two* pieces. -/
+theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
+    (hz : z ∈ ball c r ∩ ball ζ ρ) :
+    connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
+  have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
+    ball_diff_sphere_eq_union ▸ subset_union_left
+  refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
+    |>.subset_connectedComponentIn hz hsub)
+  rcases subset_ball_inter_ball_or_subset_ball_diff_closedBall isPreconnected_connectedComponentIn
+    (connectedComponentIn_subset _ _) with h | h
+  · exact h
+  · exact absurd (h (mem_connectedComponentIn (hsub hz)))
+      (Set.disjoint_left.mp disjoint_ball_inter_ball_ball_diff_closedBall hz)
+
+/-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
+of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball`; here the connectedness of the
+piece is the substantial `TauCeti.isConnected_ball_diff_closedBall`. -/
+theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall (hr : 0 < r)
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
+    connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
+  have hsub : ball c r \ closedBall ζ ρ ⊆ ball c r \ sphere ζ ρ :=
+    ball_diff_sphere_eq_union ▸ subset_union_right
+  refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hr hζ hρ hρ').isPreconnected
+    |>.subset_connectedComponentIn hz hsub)
+  rcases subset_ball_inter_ball_or_subset_ball_diff_closedBall isPreconnected_connectedComponentIn
+    (connectedComponentIn_subset _ _) with h | h
+  · exact absurd hz (Set.disjoint_left.mp disjoint_ball_inter_ball_ball_diff_closedBall
+      (h (mem_connectedComponentIn (hsub hz))))
+  · exact h
+
+/-! ## The maximum modulus principle on a crosscut neighbourhood -/
+
+/-- **The frontier of a crosscut neighbourhood lies on the two circles.** It is covered by the
+*cap* `sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc together with the closed
+*arc* `closedBall c r ∩ sphere ζ ρ` of the crosscut; these are the two pieces on which a function
+has to be controlled for the maximum principle to control it inside. Only the inclusion is claimed,
+which is all a frontier bound needs, and it is what holds without further hypotheses — for
+`2 * r ≤ ρ` the crosscut neighbourhood is the whole disc and its frontier misses the arc
+entirely. -/
+theorem frontier_ball_inter_ball_subset :
+    frontier (ball c r ∩ ball ζ ρ)
+      ⊆ sphere c r ∩ closedBall ζ ρ ∪ closedBall c r ∩ sphere ζ ρ := by
+  intro y hy
+  rw [(isOpen_ball.inter isOpen_ball).frontier_eq, Set.mem_sdiff] at hy
+  obtain ⟨hycl, hynot⟩ := hy
+  have hy₁ : dist y c ≤ r := by
+    have := closure_mono (inter_subset_left (t := ball ζ ρ)) hycl
+    exact Metric.mem_closedBall.mp (closure_ball_subset_closedBall this)
+  have hy₂ : dist y ζ ≤ ρ := by
+    have := closure_mono (inter_subset_right (s := ball c r)) hycl
+    exact Metric.mem_closedBall.mp (closure_ball_subset_closedBall this)
+  simp only [Set.mem_inter_iff, Metric.mem_ball, not_and, not_lt] at hynot
+  rcases eq_or_lt_of_le hy₁ with h | h
+  · exact Or.inl ⟨Metric.mem_sphere.mpr h, Metric.mem_closedBall.mpr hy₂⟩
+  · exact Or.inr ⟨Metric.mem_closedBall.mpr hy₁,
+      Metric.mem_sphere.mpr (le_antisymm hy₂ (hynot h))⟩
+
+variable {f : ℂ → ℂ} {a : ℂ} {C : ℝ}
+
+/-- **The maximum modulus principle on a crosscut neighbourhood.** A function holomorphic on
+`ball c r` and continuous up to the closed disc that stays within `C` of a value `a` on the closed
+crosscut arc and on the boundary cap stays within `C` of `a` on the whole crosscut neighbourhood.
+
+The crosscut neighbourhood is a bounded open set whose frontier is covered by those two pieces
+(`TauCeti.frontier_ball_inter_ball_subset`), so this is Mathlib's
+`Complex.norm_le_of_forall_mem_frontier_norm_le` applied to `f - a` on it. Neither injectivity of
+`f` nor connectivity of anything is used. -/
+theorem norm_sub_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
+    (harc : ∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
+    (hcap : ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ C)
+    (hz : z ∈ ball c r ∩ ball ζ ρ) : ‖f z - a‖ ≤ C := by
+  refine Complex.norm_le_of_forall_mem_frontier_norm_le
+    (isBounded_ball.subset inter_subset_left) ((hf.mono inter_subset_left).sub_const a)
+    (fun w hw => ?_) (subset_closure hz)
+  rcases frontier_ball_inter_ball_subset hw with h | h
+  · exact hcap w h
+  · exact harc w h
+
+/-- **The oscillation of a holomorphic function on a crosscut neighbourhood** is at most twice a
+bound holding on the crosscut arc and on the boundary cap. This is the form
+`TauCeti.norm_sub_le_of_mem_ball_inter_ball` is consumed in: what a Cauchy criterion needs is a
+bound on distances between *pairs* of values, and the intermediate value `a` disappears. -/
+theorem dist_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
+    (harc : ∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
+    (hcap : ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ C)
+    {x y : ℂ} (hx : x ∈ ball c r ∩ ball ζ ρ) (hy : y ∈ ball c r ∩ ball ζ ρ) :
+    dist (f x) (f y) ≤ 2 * C := by
+  have hx' := norm_sub_le_of_mem_ball_inter_ball hf harc hcap hx
+  have hy' := norm_sub_le_of_mem_ball_inter_ball hf harc hcap hy
+  have : dist (f x) (f y) = ‖f x - a - (f y - a)‖ := by rw [dist_eq_norm]; ring_nf
+  rw [this]
+  calc ‖f x - a - (f y - a)‖ ≤ ‖f x - a‖ + ‖f y - a‖ := norm_sub_le _ _
+    _ ≤ 2 * C := by linarith
+
+/-! ## The crosscut criterion for boundary behaviour -/
+
+/-- **The crosscut criterion, cluster-set form.** If, at arbitrarily small crosscut radii `ρ`, the
+function `f` is within `ε` of some value on the closed crosscut arc and on the boundary cap at `ζ`,
+then `f` has at most one cluster value at `ζ` along the disc.
+
+The maximum modulus principle turns each such boundary estimate into an oscillation bound on the
+crosscut neighbourhood `ball c r ∩ ball ζ ρ`, and those neighbourhoods are exactly the traces on
+the disc of the balls around `ζ`, so `TauCeti.clusterSetOn_subsingleton_of_forall_exists` applies
+verbatim. Note that `ζ` need not be on the boundary circle for this statement, and that the value
+`a` may depend on `ε`. -/
+theorem clusterSetOn_ball_subsingleton (hf : DiffContOnCl ℂ f (ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ, (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+      ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+    (clusterSetOn f (ball c r) ζ).Subsingleton := by
+  refine clusterSetOn_subsingleton_of_forall_exists fun ε hε => ?_
+  obtain ⟨ρ, hρ, a, harc, hcap⟩ := h (ε / 2) (by positivity)
+  refine ⟨ρ, hρ, fun x hx y hy => ?_⟩
+  have := dist_le_of_mem_ball_inter_ball hf harc hcap hx hy
+  linarith
+
+/-- **The crosscut criterion for a boundary limit.** A function holomorphic on a disc and
+continuous up to the closed disc has a limit at a boundary point `ζ`, along the disc, as soon as at
+arbitrarily small crosscut radii it is nearly constant on the crosscut arc and on the boundary cap.
+
+The cluster set is a subsingleton by `TauCeti.clusterSetOn_ball_subsingleton`, and it is nonempty
+because `f` maps the disc into the compact image of the closed disc; that is exactly what
+`TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` needs. -/
+theorem exists_tendsto_nhdsWithin_ball (hr : 0 < r) (hf : DiffContOnCl ℂ f (ball c r))
+    (hζ : dist ζ c = r)
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ, (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+      ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+    ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) := by
+  have hcl : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
+  refine exists_tendsto_of_clusterSetOn_subsingleton
+    ((isCompact_closedBall c r).image_of_continuousOn (hcl ▸ hf.continuousOn))
+    (fun w hw => ⟨w, ball_subset_closedBall hw, rfl⟩) ?_ (clusterSetOn_ball_subsingleton hf h)
+  rw [hcl]
+  exact mem_closedBall.mpr hζ.le
+
+/-- **The crosscut criterion for a continuous extension to the closed disc.** If the hypothesis of
+`TauCeti.exists_tendsto_nhdsWithin_ball` holds at *every* point of the boundary circle, the function
+extends continuously to `closedBall c r`.
+
+This is the shape in which the Carathéodory boundary correspondence is proved: whatever geometric
+hypothesis is placed on the image, it is used only to produce, at each boundary point and each
+`ε`, a crosscut radius along which `f` varies by at most `ε` on the arc and on the cap. Nothing
+here asserts that the extension is injective, which is an independent matter. -/
+theorem exists_continuousOn_closedBall_eqOn (hr : 0 < r) (hf : DiffContOnCl ℂ f (ball c r))
+    (h : ∀ ζ ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ,
+      (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+        ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+    ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
+  have hcl : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
+  have hbdd : IsBounded (f '' ball c r) :=
+    (((isCompact_closedBall c r).image_of_continuousOn (hcl ▸ hf.continuousOn)).isBounded).subset
+      (image_mono ball_subset_closedBall)
+  obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball
+    hf.differentiableOn.continuousOn hbdd fun ζ hζ => by
+      refine clusterSetOn_ball_subsingleton hf (h ζ ?_)
+      rwa [frontier_ball c hr.ne'] at hζ
+  exact ⟨F, hcl ▸ hFc, hFe⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -62,12 +62,15 @@ automatically continuous, and their crosscut neighbourhoods exhaust `ball c r �
 gives `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`: only holomorphy on the open
 disc is assumed, the arc bound is asked for on `ball c r ∩ sphere ζ ρ`, and the cap bound is
 replaced by a bound on a *collar* `r₀ ≤ dist w c` of the boundary inside the crosscut
-neighbourhood — all of it data about `f` inside the disc. Letting `ρ` shrink and feeding the
-resulting oscillation bound to `TauCeti.subsingleton_clusterSetOn_of_forall_exists`, one gets:
+neighbourhood — all of it data about `f` inside the disc. Feeding those oscillation bounds, one for
+each tolerance `ε`, to `TauCeti.subsingleton_clusterSetOn_of_forall_exists`, one gets:
 
-> a bounded holomorphic function on a disc has a limit at a boundary point `ζ` as soon as it is
-> *nearly constant on the crosscut arc and on a collar of the boundary* at arbitrarily small radii
-> `ρ`.
+> a bounded holomorphic function on a disc has a limit at a boundary point `ζ` as soon as, for
+> every `ε > 0`, there is *some* crosscut radius `ρ > 0` at which `f` is within `ε` of a single
+> value on the crosscut arc and on a collar of the boundary.
+
+The radius is quantified per `ε`, and need not tend to zero: it is `ε` that shrinks, while `ρ`
+(along with the collar and the value approximated) is merely allowed to depend on it.
 
 This is `TauCeti.exists_tendsto_nhdsWithin_ball`, and `TauCeti.exists_continuousOn_closedBall_eqOn`
 is its global form, a continuous extension to the closed disc. Boundedness alone is far from
@@ -434,9 +437,10 @@ theorem dist_le_of_mem_ball_inter_ball (hd : DifferentiableOn ℂ f (ball c r)) 
 
 /-! ## The crosscut criterion for boundary behaviour -/
 
-/-- **The crosscut criterion, cluster-set form.** If, at arbitrarily small crosscut radii `ρ`, the
-function `f` is within `ε` of some value on the part of the crosscut circle inside the disc and on
-a collar of the boundary, then `f` has at most one cluster value at `ζ` along the disc.
+/-- **The crosscut criterion, cluster-set form.** If for every `ε > 0` there is *some* crosscut
+radius `ρ > 0` at which the function `f` is within `ε` of a single value on the part of the crosscut
+circle inside the disc and on a collar of the boundary, then `f` has at most one cluster value at
+`ζ` along the disc.
 
 The maximum modulus principle turns each such estimate into an oscillation bound on the crosscut
 neighbourhood `ball c r ∩ ball ζ ρ`
@@ -456,8 +460,9 @@ theorem subsingleton_clusterSetOn_ball (hd : DifferentiableOn ℂ f (ball c r))
   linarith
 
 /-- **The crosscut criterion for a boundary limit.** A bounded holomorphic function on a disc has a
-limit at a boundary point `ζ`, along the disc, as soon as at arbitrarily small crosscut radii it is
-nearly constant on the crosscut arc and on a collar of the boundary.
+limit at a boundary point `ζ`, along the disc, as soon as for every `ε > 0` there is some crosscut
+radius at which it is within `ε` of a single value on the crosscut arc and on a collar of the
+boundary.
 
 Nothing is assumed at the boundary circle itself: the input is the behaviour of `f` inside the
 disc, and the limit is a conclusion. Boundedness alone is far from enough — a bounded holomorphic

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut.lean
@@ -50,19 +50,30 @@ The frontier of the crosscut neighbourhood consists of two pieces of circle
 (`TauCeti.frontier_ball_inter_ball_subset`): the arc `closedBall c r ∩ sphere ζ ρ`, and the cap
 `sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc. Since the crosscut neighbourhood
 is bounded and open, the maximum modulus principle bounds `f` inside it by its values on those two
-pieces. Letting `ρ` run over a sequence tending to `0` and feeding the resulting oscillation bound
-to `TauCeti.clusterSetOn_subsingleton_of_forall_exists`, one gets:
+pieces (`TauCeti.norm_sub_le_of_mem_ball_inter_ball`).
 
-> a holomorphic function on a disc, continuous up to the closed disc, has a limit at a boundary
-> point `ζ` as soon as it is *nearly constant on the crosscut arc and on the boundary cap* at
-> arbitrarily small radii `ρ`.
+That frontier form is not what a boundary criterion can be built on, because reading `f` on the cap
+presupposes that `f` is continuous up to the boundary — and continuity up to the boundary *is* the
+conclusion one is after, at `ζ` and everywhere else. So the estimate is re-run on the concentric
+subdiscs `ball c s` with `s < r`, on whose closures a function holomorphic on `ball c r` is
+automatically continuous, and their crosscut neighbourhoods exhaust `ball c r ∩ ball ζ ρ`. This
+gives `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`: only holomorphy on the open
+disc is assumed, the arc bound is asked for on `ball c r ∩ sphere ζ ρ`, and the cap bound is
+replaced by a bound on a *collar* `r₀ ≤ dist w c` of the boundary inside the crosscut
+neighbourhood — all of it data about `f` inside the disc. Letting `ρ` shrink and feeding the
+resulting oscillation bound to `TauCeti.clusterSetOn_subsingleton_of_forall_exists`, one gets:
+
+> a bounded holomorphic function on a disc has a limit at a boundary point `ζ` as soon as it is
+> *nearly constant on the crosscut arc and on a collar of the boundary* at arbitrarily small radii
+> `ρ`.
 
 This is `TauCeti.exists_tendsto_nhdsWithin_ball`, and `TauCeti.exists_continuousOn_closedBall_eqOn`
-is its global form, a continuous extension to the closed disc. Neither injectivity of `f` nor any
-hypothesis on the image is used — the estimate on the two boundary pieces is the whole input, and
-supplying it for a Riemann map of a Jordan domain is precisely what the remaining L5 work consists
-of. The length–area method delivers the bound on the arc; the bound on the cap is where local
-connectedness of the image boundary enters.
+is its global form, a continuous extension to the closed disc. Boundedness alone is far from
+sufficient — a bounded holomorphic function need not have a limit at a given boundary point — so
+the estimate is what carries the content. Neither injectivity of `f` nor any hypothesis on the
+image is used, and supplying that estimate for a Riemann map of a Jordan domain is precisely what
+the remaining L5 work consists of. The length–area method delivers the bound on the arc; the bound
+on the collar is where local connectedness of the image boundary enters.
 
 ## Generality
 
@@ -82,8 +93,11 @@ half is the maximum modulus principle for holomorphic functions.
   `TauCeti.subset_ball_inter_ball_or_subset_ball_diff_closedBall` and
   `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
   separates the disc into exactly two connected components.
-* `TauCeti.norm_sub_le_of_mem_ball_inter_ball` — the maximum modulus principle on a crosscut
-  neighbourhood: a bound on the arc and on the cap is a bound inside.
+* `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
+  `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
+  on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
+  boundary-free form, where only holomorphy on the open disc is assumed and the cap is replaced by
+  a collar of the boundary.
 * `TauCeti.exists_tendsto_nhdsWithin_ball` and `TauCeti.exists_continuousOn_closedBall_eqOn` — the
   crosscut criterion for a boundary limit, and for a continuous extension to the closed disc.
 
@@ -345,7 +359,7 @@ theorem frontier_ball_inter_ball_subset :
   · exact Or.inr ⟨Metric.mem_closedBall.mpr hy₁,
       Metric.mem_sphere.mpr (le_antisymm hy₂ (hynot h))⟩
 
-variable {f : ℂ → ℂ} {a : ℂ} {C : ℝ}
+variable {f : ℂ → ℂ} {a : ℂ} {C r₀ : ℝ}
 
 /-- **The maximum modulus principle on a crosscut neighbourhood.** A function holomorphic on
 `ball c r` and continuous up to the closed disc that stays within `C` of a value `a` on the closed
@@ -366,17 +380,53 @@ theorem norm_sub_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
   · exact hcap w h
   · exact harc w h
 
+/-- **The maximum modulus principle on a crosscut neighbourhood, from interior values alone.** A
+function holomorphic on `ball c r`, with *no* regularity assumed at the boundary circle, that stays
+within `C` of a value `a` on the part `ball c r ∩ sphere ζ ρ` of the crosscut circle inside the disc
+and on the collar `r₀ ≤ dist w c` of the crosscut neighbourhood, stays within `C` of `a` throughout
+that neighbourhood.
+
+This is `TauCeti.norm_sub_le_of_mem_ball_inter_ball` applied on a slightly smaller concentric disc
+`ball c s`, on whose closure `f` is continuous for free: choosing `max r₀ (dist z c) < s < r` puts
+the given point `z` inside `ball c s` and the whole cap `sphere c s ∩ closedBall ζ ρ` inside the
+collar, and letting `s` exhaust `r` covers the crosscut neighbourhood.
+
+It is this form, not the frontier form, that the boundary criteria below consume. Their hypotheses
+then constrain only the values `f` takes *inside* the disc, so that a boundary limit is a
+conclusion rather than a restatement of an assumed continuity up to the boundary: a hypothesis
+of the shape `DiffContOnCl ℂ f (ball c r)` already contains `ContinuousOn f (closedBall c r)` and
+so would make the criteria vacuous. Assuming continuity only on the closure of each crosscut
+neighbourhood would not help, since that closure contains `ζ` itself; hence the exhaustion. -/
+theorem norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn
+    (hd : DifferentiableOn ℂ f (ball c r)) (hr₀ : r₀ < r)
+    (harc : ∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
+    (hcap : ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ C)
+    (hz : z ∈ ball c r ∩ ball ζ ρ) : ‖f z - a‖ ≤ C := by
+  have hzr : dist z c < r := mem_ball.mp hz.1
+  obtain ⟨s, hzs, hr₀s, hsr⟩ : ∃ s, dist z c < s ∧ r₀ ≤ s ∧ s < r :=
+    ⟨(max r₀ (dist z c) + r) / 2, by
+      have h₁ := le_max_left r₀ (dist z c)
+      have h₂ := le_max_right r₀ (dist z c)
+      have h₃ := max_lt hr₀ hzr
+      exact ⟨by linarith, by linarith, by linarith⟩⟩
+  have hsub : closedBall c s ⊆ ball c r := closedBall_subset_ball hsr
+  refine norm_sub_le_of_mem_ball_inter_ball (r := s) (hd.diffContOnCl_ball hsub)
+    (fun w hw => harc w ⟨hsub hw.1, hw.2⟩) (fun w hw => ?_) ⟨mem_ball.mpr hzs, hz.2⟩
+  have hwc : dist w c = s := mem_sphere.mp hw.1
+  exact hcap w ⟨hsub (mem_closedBall.mpr hwc.le), hw.2⟩ (hwc ▸ hr₀s)
+
 /-- **The oscillation of a holomorphic function on a crosscut neighbourhood** is at most twice a
-bound holding on the crosscut arc and on the boundary cap. This is the form
-`TauCeti.norm_sub_le_of_mem_ball_inter_ball` is consumed in: what a Cauchy criterion needs is a
-bound on distances between *pairs* of values, and the intermediate value `a` disappears. -/
-theorem dist_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
-    (harc : ∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
-    (hcap : ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ C)
+bound holding on the crosscut arc and on the collar of the boundary. This is the form
+`TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` is consumed in: what a Cauchy
+criterion needs is a bound on distances between *pairs* of values, and the intermediate value `a`
+disappears. -/
+theorem dist_le_of_mem_ball_inter_ball (hd : DifferentiableOn ℂ f (ball c r)) (hr₀ : r₀ < r)
+    (harc : ∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ C)
+    (hcap : ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ C)
     {x y : ℂ} (hx : x ∈ ball c r ∩ ball ζ ρ) (hy : y ∈ ball c r ∩ ball ζ ρ) :
     dist (f x) (f y) ≤ 2 * C := by
-  have hx' := norm_sub_le_of_mem_ball_inter_ball hf harc hcap hx
-  have hy' := norm_sub_le_of_mem_ball_inter_ball hf harc hcap hy
+  have hx' := norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn hd hr₀ harc hcap hx
+  have hy' := norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn hd hr₀ harc hcap hy
   have : dist (f x) (f y) = ‖f x - a - (f y - a)‖ := by rw [dist_eq_norm]; ring_nf
   rw [this]
   calc ‖f x - a - (f y - a)‖ ≤ ‖f x - a‖ + ‖f y - a‖ := norm_sub_le _ _
@@ -385,64 +435,69 @@ theorem dist_le_of_mem_ball_inter_ball (hf : DiffContOnCl ℂ f (ball c r))
 /-! ## The crosscut criterion for boundary behaviour -/
 
 /-- **The crosscut criterion, cluster-set form.** If, at arbitrarily small crosscut radii `ρ`, the
-function `f` is within `ε` of some value on the closed crosscut arc and on the boundary cap at `ζ`,
-then `f` has at most one cluster value at `ζ` along the disc.
+function `f` is within `ε` of some value on the part of the crosscut circle inside the disc and on
+a collar of the boundary, then `f` has at most one cluster value at `ζ` along the disc.
 
-The maximum modulus principle turns each such boundary estimate into an oscillation bound on the
-crosscut neighbourhood `ball c r ∩ ball ζ ρ`, and those neighbourhoods are exactly the traces on
-the disc of the balls around `ζ`, so `TauCeti.clusterSetOn_subsingleton_of_forall_exists` applies
-verbatim. Note that `ζ` need not be on the boundary circle for this statement, and that the value
-`a` may depend on `ε`. -/
-theorem clusterSetOn_ball_subsingleton (hf : DiffContOnCl ℂ f (ball c r))
-    (h : ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ, (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
-      ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+The maximum modulus principle turns each such estimate into an oscillation bound on the crosscut
+neighbourhood `ball c r ∩ ball ζ ρ`
+(`TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`), and those neighbourhoods are
+exactly the traces on the disc of the balls around `ζ`, so
+`TauCeti.clusterSetOn_subsingleton_of_forall_exists` applies verbatim. Only the values of `f` on
+the *open* disc are constrained, and only holomorphy there is assumed; note that `ζ` need not be
+on the boundary circle for this statement, and that `ρ`, `r₀` and `a` may all depend on `ε`. -/
+theorem clusterSetOn_ball_subsingleton (hd : DifferentiableOn ℂ f (ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ, (∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+      ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
     (clusterSetOn f (ball c r) ζ).Subsingleton := by
   refine clusterSetOn_subsingleton_of_forall_exists fun ε hε => ?_
-  obtain ⟨ρ, hρ, a, harc, hcap⟩ := h (ε / 2) (by positivity)
+  obtain ⟨ρ, hρ, r₀, hr₀, a, harc, hcap⟩ := h (ε / 2) (by positivity)
   refine ⟨ρ, hρ, fun x hx y hy => ?_⟩
-  have := dist_le_of_mem_ball_inter_ball hf harc hcap hx hy
+  have := dist_le_of_mem_ball_inter_ball hd hr₀ harc hcap hx hy
   linarith
 
-/-- **The crosscut criterion for a boundary limit.** A function holomorphic on a disc and
-continuous up to the closed disc has a limit at a boundary point `ζ`, along the disc, as soon as at
-arbitrarily small crosscut radii it is nearly constant on the crosscut arc and on the boundary cap.
+/-- **The crosscut criterion for a boundary limit.** A bounded holomorphic function on a disc has a
+limit at a boundary point `ζ`, along the disc, as soon as at arbitrarily small crosscut radii it is
+nearly constant on the crosscut arc and on a collar of the boundary.
+
+Nothing is assumed at the boundary circle itself: the input is the behaviour of `f` inside the
+disc, and the limit is a conclusion. Boundedness alone is far from enough — a bounded holomorphic
+function on a disc need not have any limit at a given boundary point — so the estimate `h` is what
+carries the content; it is exactly the estimate the length–area method produces on the arc and
+local connectedness of the image boundary produces on the collar.
 
 The cluster set is a subsingleton by `TauCeti.clusterSetOn_ball_subsingleton`, and it is nonempty
-because `f` maps the disc into the compact image of the closed disc; that is exactly what
+because `f` maps the disc into the compact closure of its bounded image; that is exactly what
 `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` needs. -/
-theorem exists_tendsto_nhdsWithin_ball (hr : 0 < r) (hf : DiffContOnCl ℂ f (ball c r))
-    (hζ : dist ζ c = r)
-    (h : ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ, (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
-      ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+theorem exists_tendsto_nhdsWithin_ball (hr : 0 < r) (hd : DifferentiableOn ℂ f (ball c r))
+    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r)
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ, (∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+      ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
     ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) := by
-  have hcl : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
-  refine exists_tendsto_of_clusterSetOn_subsingleton
-    ((isCompact_closedBall c r).image_of_continuousOn (hcl ▸ hf.continuousOn))
-    (fun w hw => ⟨w, ball_subset_closedBall hw, rfl⟩) ?_ (clusterSetOn_ball_subsingleton hf h)
-  rw [hcl]
+  refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
+    (fun w hw => subset_closure ⟨w, hw, rfl⟩) ?_ (clusterSetOn_ball_subsingleton hd h)
+  rw [closure_ball c hr.ne']
   exact mem_closedBall.mpr hζ.le
 
 /-- **The crosscut criterion for a continuous extension to the closed disc.** If the hypothesis of
-`TauCeti.exists_tendsto_nhdsWithin_ball` holds at *every* point of the boundary circle, the function
-extends continuously to `closedBall c r`.
+`TauCeti.exists_tendsto_nhdsWithin_ball` holds at *every* point of the boundary circle, the bounded
+holomorphic function `f` extends continuously to `closedBall c r`.
 
 This is the shape in which the Carathéodory boundary correspondence is proved: whatever geometric
 hypothesis is placed on the image, it is used only to produce, at each boundary point and each
-`ε`, a crosscut radius along which `f` varies by at most `ε` on the arc and on the cap. Nothing
-here asserts that the extension is injective, which is an independent matter. -/
-theorem exists_continuousOn_closedBall_eqOn (hr : 0 < r) (hf : DiffContOnCl ℂ f (ball c r))
-    (h : ∀ ζ ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ a : ℂ,
-      (∀ w ∈ closedBall c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
-        ∀ w ∈ sphere c r ∩ closedBall ζ ρ, ‖f w - a‖ ≤ ε) :
+`ε`, a crosscut radius along which `f` varies by at most `ε` on the arc and on the collar. The
+extension is genuinely produced here rather than assumed, since only holomorphy and boundedness on
+the *open* disc are hypotheses. Nothing here asserts that the extension is injective, which is an
+independent matter. -/
+theorem exists_continuousOn_closedBall_eqOn (hr : 0 < r) (hd : DifferentiableOn ℂ f (ball c r))
+    (hb : IsBounded (f '' ball c r))
+    (h : ∀ ζ ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ r₀ < r, ∃ a : ℂ,
+      (∀ w ∈ ball c r ∩ sphere ζ ρ, ‖f w - a‖ ≤ ε) ∧
+        ∀ w ∈ ball c r ∩ closedBall ζ ρ, r₀ ≤ dist w c → ‖f w - a‖ ≤ ε) :
     ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
-  have hcl : closure (ball c r) = closedBall c r := closure_ball c hr.ne'
-  have hbdd : IsBounded (f '' ball c r) :=
-    (((isCompact_closedBall c r).image_of_continuousOn (hcl ▸ hf.continuousOn)).isBounded).subset
-      (image_mono ball_subset_closedBall)
   obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball
-    hf.differentiableOn.continuousOn hbdd fun ζ hζ => by
-      refine clusterSetOn_ball_subsingleton hf (h ζ ?_)
+    hd.continuousOn hb fun ζ hζ => by
+      refine clusterSetOn_ball_subsingleton hd (h ζ ?_)
       rwa [frontier_ball c hr.ne'] at hζ
-  exact ⟨F, hcl ▸ hFc, hFe⟩
+  exact ⟨F, closure_ball c hr.ne' ▸ hFc, hFe⟩
 
 end TauCeti

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -340,7 +340,7 @@ hypothesis holds them within `ε` of each other.
 Nothing is claimed about *existence* of a cluster value, which is a compactness matter; the
 codomain is a genuine metric space rather than a pseudometric one because the conclusion is an
 equality of points. -/
-theorem clusterSetOn_subsingleton_of_forall_exists
+theorem subsingleton_clusterSetOn_of_forall_exists
     (h : ∀ ε > 0, ∃ δ > 0, ∀ x ∈ U ∩ Metric.ball w δ, ∀ y ∈ U ∩ Metric.ball w δ,
       dist (f x) (f y) ≤ ε) :
     (clusterSetOn f U w).Subsingleton := by

--- a/TauCeti/Topology/ClusterSet.lean
+++ b/TauCeti/Topology/ClusterSet.lean
@@ -321,6 +321,42 @@ lemma mem_clusterSetOn_iff_forall_exists :
 
 end PseudoMetricSpace
 
+/-! ## The Cauchy criterion for a subsingleton cluster set -/
+
+section MetricSpace
+
+variable {X Y : Type*} [PseudoMetricSpace X] [MetricSpace Y] {U : Set X} {f : X → Y} {w : X}
+
+/-- **A uniformly small oscillation on the approach regions makes the cluster set a
+subsingleton.** If, for every `ε > 0`, the values of `f` on `U ∩ ball w δ` are within `ε` of one
+another for some `δ > 0`, then `f` has at most one cluster value at `w` along `U`.
+
+This is the Cauchy criterion in cluster-set form, and it is how a *quantitative* boundary estimate
+is turned into the hypothesis of `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` and of
+`TauCeti.exists_continuousOn_closure_eqOn`: two cluster values are approached at points of
+`U` arbitrarily close to `w`, hence at two points of a single approach region, where the
+hypothesis holds them within `ε` of each other.
+
+Nothing is claimed about *existence* of a cluster value, which is a compactness matter; the
+codomain is a genuine metric space rather than a pseudometric one because the conclusion is an
+equality of points. -/
+theorem clusterSetOn_subsingleton_of_forall_exists
+    (h : ∀ ε > 0, ∃ δ > 0, ∀ x ∈ U ∩ Metric.ball w δ, ∀ y ∈ U ∩ Metric.ball w δ,
+      dist (f x) (f y) ≤ ε) :
+    (clusterSetOn f U w).Subsingleton := by
+  intro v₁ h₁ v₂ h₂
+  refine eq_of_forall_dist_le fun ε hε => ?_
+  obtain ⟨δ, hδ, hosc⟩ := h (ε / 3) (by positivity)
+  obtain ⟨x, hxU, hxd, hx⟩ := mem_clusterSetOn_iff_forall_exists.mp h₁ (ε / 3) (by positivity) δ hδ
+  obtain ⟨y, hyU, hyd, hy⟩ := mem_clusterSetOn_iff_forall_exists.mp h₂ (ε / 3) (by positivity) δ hδ
+  have hxy := hosc x ⟨hxU, Metric.mem_ball.mpr hxd⟩ y ⟨hyU, Metric.mem_ball.mpr hyd⟩
+  have h₁' : dist v₁ (f x) < ε / 3 := by rwa [dist_comm]
+  calc dist v₁ v₂ ≤ dist v₁ (f x) + dist (f x) (f y) + dist (f y) v₂ := dist_triangle4 _ _ _ _
+    _ ≤ ε / 3 + ε / 3 + ε / 3 := add_le_add (add_le_add h₁'.le hxy) hy.le
+    _ = ε := by ring
+
+end MetricSpace
+
 /-! ## The extension criterion -/
 
 section Extension


### PR DESCRIPTION
This PR adds the **circular crosscut** of a disc at a boundary point, in the new module `TauCeti/Analysis/Complex/Conformal/Crosscut.lean` (449 lines), together with one general prerequisite in `TauCeti/Topology/ClusterSet.lean` (36 lines). Fix a disc `ball c r` and a point `ζ` of its boundary circle; for `0 < ρ < 2 * r` the circle `sphere ζ ρ` meets the disc in an arc, and that arc cuts the disc into the *crosscut neighbourhood* `ball c r ∩ ball ζ ρ` of `ζ` and the rest, `ball c r \ closedBall ζ ρ`. The file proves that decomposition and then uses the crosscut neighbourhoods as the approach regions along which the boundary behaviour of a holomorphic function is read off, ending in a maximum-principle criterion for a boundary limit and for a continuous extension to the closed disc.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "Carathéodory boundary correspondence. The concrete L5 milestone is the **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of closures" — and specifically the approach-region vocabulary and the extension mechanism its hard direction runs on. This is a prerequisite for that milestone, not a discharge of it: nothing here produces the boundary estimate for a Riemann map, and the criterion below takes that estimate as a hypothesis.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"circular-crosscut-of-a-disc"}-->

That `ball c r ∩ ball ζ ρ` is connected is immediate, being an intersection of two balls, hence convex (`TauCeti.nonempty_ball_inter_ball`, `TauCeti.isConnected_ball_inter_ball`). The other piece is not convex, and the proof is the **Möbius reduction** the roadmap prescribes for circles: `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` says that for `z ≠ ζ` on the boundary circle, `z ∈ ball c r ↔ 1 < 2 * ((c - ζ) * (z - ζ)⁻¹).re` — the inversion at `ζ` carries the disc to an open half-plane, which is the classical fact that a circle through the centre of an inversion goes to a line, in the one form the decomposition needs, namely *which side* the disc lands on. The computation expands `normSq ((z - ζ) - (c - ζ))`, cancels `normSq (c - ζ) = r ^ 2`, and divides by `normSq (z - ζ)`. Since the same inversion turns the complement of `closedBall ζ ρ` into `ball 0 ρ⁻¹`, the far side is carried onto a half-plane meeting a ball — convex, and nonempty exactly when `ρ < 2 * r`, which is where that hypothesis is spent — and `TauCeti.isConnected_ball_diff_closedBall` follows by pushing it back along the continuous `w ↦ ζ + w⁻¹`. The two sides are open, disjoint and cover `ball c r \ sphere ζ ρ` (`TauCeti.ball_diff_sphere_eq_union`, `TauCeti.disjoint_ball_inter_ball_ball_diff_closedBall`), so a preconnected subset of the cut disc lies in one of them (`TauCeti.subset_ball_inter_ball_or_subset_ball_diff_closedBall`) and they *are* its connected components (`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall`): a circular crosscut separates the disc into exactly two parts.

The frontier of the crosscut neighbourhood is covered by two pieces of circle, the closed arc `closedBall c r ∩ sphere ζ ρ` of the crosscut and the cap `sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc (`TauCeti.frontier_ball_inter_ball_subset`; only the inclusion is claimed, since for `2 * r ≤ ρ` the crosscut neighbourhood is the whole disc and its frontier misses the arc). The neighbourhood is bounded and open, so Mathlib's `Complex.norm_le_of_forall_mem_frontier_norm_le` gives `TauCeti.norm_sub_le_of_mem_ball_inter_ball`: a function holomorphic on the disc and continuous up to its closure that stays within `C` of a value `a` on the arc and on the cap stays within `C` of `a` throughout the crosscut neighbourhood.

That frontier form cannot carry a boundary criterion, because reading `f` on the cap presupposes continuity up to the boundary, which is the conclusion one is after — and assuming continuity only on the closure of a crosscut neighbourhood does not help, since that closure contains `ζ` itself. So the estimate is re-run on the concentric subdiscs `ball c s` with `s < r`, on whose closures a function holomorphic on `ball c r` is continuous for free, and whose crosscut neighbourhoods exhaust `ball c r ∩ ball ζ ρ`. This is `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn`: only holomorphy on the *open* disc is assumed, the arc bound is asked for on `ball c r ∩ sphere ζ ρ`, and the cap is replaced by a collar `r₀ ≤ dist w c` of the boundary inside the crosscut neighbourhood — all of it data about the values `f` takes inside the disc — whence the oscillation bound `TauCeti.dist_le_of_mem_ball_inter_ball`. Because the crosscut neighbourhoods are exactly the traces on the disc of the balls around `ζ`, arbitrarily small such bounds make the boundary cluster set a subsingleton (`TauCeti.clusterSetOn_ball_subsingleton`), hence give a limit at `ζ` for a bounded holomorphic function (`TauCeti.exists_tendsto_nhdsWithin_ball`) and, when the hypothesis holds at every boundary point, a continuous extension to `closedBall c r` (`TauCeti.exists_continuousOn_closedBall_eqOn`). Boundedness alone is far from sufficient — a bounded holomorphic function need not have a limit at a given boundary point — so the estimate is what carries the content. Neither injectivity of the map nor any hypothesis on its image is used, and supplying that estimate for a Riemann map of a Jordan domain is what the remaining L5 work consists of — the length–area method delivers the bound on the arc, and local connectedness of the image boundary is what will deliver the bound on the collar.

The step from an oscillation bound to a subsingleton cluster set is not about complex analysis, so it is added where the cluster-set vocabulary lives: `TauCeti.clusterSetOn_subsingleton_of_forall_exists` in `TauCeti/Topology/ClusterSet.lean` is the Cauchy criterion in cluster-set form, stated for a map between metric spaces and proved from the `ε`-`δ` characterization `TauCeti.mem_clusterSetOn_iff_forall_exists` already in that file. No existing declaration is renamed, moved or restated.

Nothing here duplicates existing work. The pinned Mathlib has no crosscut vocabulary; it knows that a ball is connected (`Mathlib/Analysis/Normed/Module/Connected.lean`) and that an inversion carries a sphere through its centre to a perpendicular bisector (`EuclideanGeometry.image_inversion_sphere_dist_center`), but says nothing about which side of that hyperplane the *open* ball goes to, which is the content used here, and has no connectedness statement for a ball with a boundary cap removed. Its maximum modulus principle, polar and inversion API, `convex_halfSpace_gt` and `IsPreconnected.subset_or_subset` are consumed rather than restated, and no Mathlib infrastructure is vendored. Within the repository the in-flight L5 threads are disjoint from this one: the length–area inequality (#1636) estimates the image of the arc and proves no separation and no extension; boundary uniqueness across a circular arc (#1629) is an analytic non-degeneracy statement about a map already continuous up to the arc; uniform local connectedness (#1624) is a property of the boundary of the target; and `Conformal/ClusterSet.lean` and `Conformal/BoundaryCorrespondence.lean` on `main` concern what a continuous extension does once it exists, whereas this is the geometry of the approach regions plus the mechanism that produces the extension.

In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for every theorem added in layers L0–L6, everything is stated for `ℂ`; the geometric half is not merely a convenience of that bar, since the map performing the decomposition is the complex inversion `z ↦ (z - ζ)⁻¹`, and the analytic half is the maximum modulus principle for holomorphic functions. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, so this is new Lean formalization rather than a temporary shim, and unusually for this area it consumes no L0–L3 shim at all: its only analytic input is Mathlib's own `Complex.norm_le_of_forall_mem_frontier_norm_le`.

`lake build` (6078 jobs), `lake exe axioms` (`audited 18016 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`), `lake exe module-system` (990 modules) and `bash scripts/lint-env.sh` (`PASS — no new violations`) are all green.

Roadmap: ConformalMapping

🤖 Prepared with Claude Code


