### PR TITLE
feat: build the global branch of a germ on a simply connected domain

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -78,7 +78,9 @@ holomorphic germs and deducing monodromy from it is left to a follow-up.
 * `TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo` — continuing a holomorphic function
   along a path that stays inside its domain gives that function back.
 * `TauCeti.ContinuesAlong`, `TauCeti.ContinuesInside` — continuability of a germ along one path,
-  and along every path inside a domain.
+  and along every path inside a domain. Neither body is exposed; downstream files use them through
+  `TauCeti.continuesAlong_iff_exists`, `TauCeti.ContinuesInside.continuesAlong` and
+  `TauCeti.ContinuesInside.of_forall`.
 
 ## References
 
@@ -282,8 +284,16 @@ along `c` whose germ at the initial time is that of `f₀`.
 
 Only the germ of `f₀` at `c 0` enters, so this is a property of that germ rather than of `f₀`
 (`TauCeti.continuesAlong_congr`). -/
-@[expose] def ContinuesAlong (f₀ : ℂ → ℂ) (c : I → ℂ) : Prop :=
+def ContinuesAlong (f₀ : ℂ → ℂ) (c : I → ℂ) : Prop :=
   ∃ f : I → ℂ → ℂ, IsAnalyticContinuationAlong f c Set.univ ∧ f 0 =ᶠ[𝓝 (c 0)] f₀
+
+/-- **The defining property of `TauCeti.ContinuesAlong`**: a germ continues along `c` exactly when
+some analytic continuation along `c` starts at it. This is the introduction and elimination rule
+for the predicate, whose body is not exposed. -/
+theorem continuesAlong_iff_exists :
+    ContinuesAlong f₀ c ↔
+      ∃ f : I → ℂ → ℂ, IsAnalyticContinuationAlong f c Set.univ ∧ f 0 =ᶠ[𝓝 (c 0)] f₀ :=
+  Iff.rfl
 
 namespace ContinuesAlong
 
@@ -324,25 +334,38 @@ This is the hypothesis of the monodromy theorem. It is a condition on the germ
 (`TauCeti.continuesInside_congr`) and on the domain jointly: the germ of `Complex.log` at `1`
 continues inside `ℂ \ {0}`, and continues inside the slit plane, but is single-valued only on the
 latter. -/
-@[expose] def ContinuesInside (f₀ : ℂ → ℂ) (U : Set ℂ) (z₀ : ℂ) : Prop :=
+def ContinuesInside (f₀ : ℂ → ℂ) (U : Set ℂ) (z₀ : ℂ) : Prop :=
   ∀ c : I → ℂ, Continuous c → (∀ x, c x ∈ U) → c 0 = z₀ → ContinuesAlong f₀ c
 
 namespace ContinuesInside
 
+/-- **Elimination for `TauCeti.ContinuesInside`**: a germ that continues inside `U` continues
+along each individual path that starts at `z₀` and stays in `U`. -/
+theorem continuesAlong (H : ContinuesInside f₀ U z₀) (hc : Continuous c) (hcU : ∀ x, c x ∈ U)
+    (hc0 : c 0 = z₀) : ContinuesAlong f₀ c :=
+  H c hc hcU hc0
+
+/-- **Introduction for `TauCeti.ContinuesInside`**: a germ that continues along every path
+starting at `z₀` and staying in `U` continues inside `U`. -/
+theorem of_forall
+    (h : ∀ c : I → ℂ, Continuous c → (∀ x, c x ∈ U) → c 0 = z₀ → ContinuesAlong f₀ c) :
+    ContinuesInside f₀ U z₀ :=
+  h
+
 /-- A germ that continues inside `U` is analytic at the base point, as witnessed by the constant
 path. -/
 theorem analyticAt (H : ContinuesInside f₀ U z₀) (hz₀ : z₀ ∈ U) : AnalyticAt ℂ f₀ z₀ :=
-  (H (fun _ => z₀) continuous_const (fun _ => hz₀) rfl).analyticAt
+  (H.continuesAlong (c := fun _ => z₀) continuous_const (fun _ => hz₀) rfl).analyticAt
 
 /-- **Continuability inside a domain depends only on the germ at the base point.** -/
 protected theorem congr (H : ContinuesInside f₀ U z₀) (hfg : f₀ =ᶠ[𝓝 z₀] g₀) :
     ContinuesInside g₀ U z₀ :=
-  fun c hc hcU hc0 => (H c hc hcU hc0).congr (hc0 ▸ hfg)
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).congr (hc0 ▸ hfg)
 
 /-- A function holomorphic on an open set continues inside that set from each of its points. -/
 theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) :
     ContinuesInside f₀ U z₀ :=
-  fun _ hc hcU _ => .of_differentiableOn hUo hf₀ hc hcU
+  of_forall fun _ hc hcU _ => .of_differentiableOn hUo hf₀ hc hcU
 
 end ContinuesInside
 

--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Analytic.Basic
 public import Mathlib.Analysis.Calculus.Deriv.Basic
 public import Mathlib.Analysis.Complex.Basic
+public import Mathlib.Topology.UnitInterval
 import Mathlib.Analysis.Complex.CauchyIntegral
 import Mathlib.Topology.LocallyConstant.Basic
 
@@ -44,6 +45,15 @@ germs agree at one point of `D` exactly when they agree at every point of `D` �
 A locally constant property on a preconnected parameter set is constant
 (`IsLocallyConstant.apply_eq_of_preconnectedSpace`).
 
+## Continuability as a property of the initial germ
+
+A continuation is determined by its initial germ, so *being continuable* is a property of that
+germ alone. `TauCeti.ContinuesAlong` records it for a single path of the unit interval, and
+`TauCeti.ContinuesInside` for every path inside a domain issuing from a base point; both transport
+across eventual equality of the initial function (`TauCeti.continuesAlong_congr`,
+`TauCeti.continuesInside_congr`). `TauCeti.ContinuesInside` is the hypothesis of the monodromy
+theorem for a simply connected domain (`Conformal/GlobalBranch.lean`).
+
 ## Relation to the monodromy theorem
 
 This is the L4 prerequisite that the monodromy theorem of the conformal-mapping roadmap needs:
@@ -67,6 +77,8 @@ holomorphic germs and deducing monodromy from it is left to a follow-up.
   preconnected parameter set is determined by its germ at a single time.
 * `TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo` — continuing a holomorphic function
   along a path that stays inside its domain gives that function back.
+* `TauCeti.ContinuesAlong`, `TauCeti.ContinuesInside` — continuability of a germ along one path,
+  and along every path inside a domain.
 
 ## References
 
@@ -256,5 +268,89 @@ theorem eventuallyEq_of_mapsTo {U : Set ℂ} {F : ℂ → ℂ} (hf : IsAnalyticC
   hf.eventuallyEq (of_differentiableOn hU hF hf.continuousOn hmem) hs ha hb hab
 
 end IsAnalyticContinuationAlong
+
+section Germ
+
+open unitInterval
+
+variable {U : Set ℂ} {z₀ : ℂ} {f₀ g₀ : ℂ → ℂ} {c : I → ℂ}
+
+/-! ### Continuation along a path, as a property of the initial germ -/
+
+/-- The germ of `f₀` at `c 0` **continues along the path `c`**: there is an analytic continuation
+along `c` whose germ at the initial time is that of `f₀`.
+
+Only the germ of `f₀` at `c 0` enters, so this is a property of that germ rather than of `f₀`
+(`TauCeti.continuesAlong_congr`). -/
+@[expose] def ContinuesAlong (f₀ : ℂ → ℂ) (c : I → ℂ) : Prop :=
+  ∃ f : I → ℂ → ℂ, IsAnalyticContinuationAlong f c Set.univ ∧ f 0 =ᶠ[𝓝 (c 0)] f₀
+
+namespace ContinuesAlong
+
+/-- A germ that continues along a path is a germ of an analytic function at the initial point. -/
+theorem analyticAt (h : ContinuesAlong f₀ c) : AnalyticAt ℂ f₀ (c 0) := by
+  obtain ⟨f, hf, h0⟩ := h
+  exact (hf.analyticAt 0 (Set.mem_univ 0)).congr h0
+
+/-- **Continuability along a path depends only on the initial germ.** -/
+protected theorem congr (h : ContinuesAlong f₀ c) (hfg : f₀ =ᶠ[𝓝 (c 0)] g₀) :
+    ContinuesAlong g₀ c :=
+  let ⟨f, hf, h0⟩ := h
+  ⟨f, hf, h0.trans hfg⟩
+
+/-- A function analytic at every point of a path continues itself along it: the constant family is
+the continuation. -/
+theorem of_analyticAt (hc : Continuous c) (hf₀ : ∀ x, AnalyticAt ℂ f₀ (c x)) :
+    ContinuesAlong f₀ c :=
+  ⟨fun _ => f₀, .const hc.continuousOn fun t _ => hf₀ t, .rfl⟩
+
+/-- A function holomorphic on an open set continues along every path that stays in that set. -/
+theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) (hc : Continuous c)
+    (hcU : ∀ x, c x ∈ U) : ContinuesAlong f₀ c :=
+  of_analyticAt hc fun x => hf₀.analyticOnNhd hUo _ (hcU x)
+
+end ContinuesAlong
+
+/-- Continuability along a path is a property of the germ of `f₀` at the initial point. -/
+theorem continuesAlong_congr (h : f₀ =ᶠ[𝓝 (c 0)] g₀) : ContinuesAlong f₀ c ↔ ContinuesAlong g₀ c :=
+  ⟨fun hf => hf.congr h, fun hg => hg.congr h.symm⟩
+
+/-! ### Continuation inside a domain -/
+
+/-- The germ of `f₀` at `z₀` **continues inside `U`**: it continues along every path that starts
+at `z₀` and stays in `U`.
+
+This is the hypothesis of the monodromy theorem. It is a condition on the germ
+(`TauCeti.continuesInside_congr`) and on the domain jointly: the germ of `Complex.log` at `1`
+continues inside `ℂ \ {0}`, and continues inside the slit plane, but is single-valued only on the
+latter. -/
+@[expose] def ContinuesInside (f₀ : ℂ → ℂ) (U : Set ℂ) (z₀ : ℂ) : Prop :=
+  ∀ c : I → ℂ, Continuous c → (∀ x, c x ∈ U) → c 0 = z₀ → ContinuesAlong f₀ c
+
+namespace ContinuesInside
+
+/-- A germ that continues inside `U` is analytic at the base point, as witnessed by the constant
+path. -/
+theorem analyticAt (H : ContinuesInside f₀ U z₀) (hz₀ : z₀ ∈ U) : AnalyticAt ℂ f₀ z₀ :=
+  (H (fun _ => z₀) continuous_const (fun _ => hz₀) rfl).analyticAt
+
+/-- **Continuability inside a domain depends only on the germ at the base point.** -/
+protected theorem congr (H : ContinuesInside f₀ U z₀) (hfg : f₀ =ᶠ[𝓝 z₀] g₀) :
+    ContinuesInside g₀ U z₀ :=
+  fun c hc hcU hc0 => (H c hc hcU hc0).congr (hc0 ▸ hfg)
+
+/-- A function holomorphic on an open set continues inside that set from each of its points. -/
+theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) :
+    ContinuesInside f₀ U z₀ :=
+  fun _ hc hcU _ => .of_differentiableOn hUo hf₀ hc hcU
+
+end ContinuesInside
+
+/-- Continuability inside `U` is a property of the germ of `f₀` at the base point. -/
+theorem continuesInside_congr (h : f₀ =ᶠ[𝓝 z₀] g₀) :
+    ContinuesInside f₀ U z₀ ↔ ContinuesInside g₀ U z₀ :=
+  ⟨fun hf => hf.congr h, fun hg => hg.congr h.symm⟩
+
+end Germ
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Monodromy
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
-import Mathlib.Analysis.Complex.CauchyIntegral
 import Mathlib.Topology.MetricSpace.Thickening
 
 /-!
@@ -30,8 +29,6 @@ two-way form below it is supplied by nothing else once `U` is simply connected.
 * `TauCeti.ContinuesInside.eventuallyEq_at_one` — **path independence**: on a simply connected `U`,
   two continuations of one germ along two paths in `U` with the same endpoints end at the same
   germ.
-* `TauCeti.ContinuesInside.eventuallyEq_of_loop` — the loop form: continuing a germ around a loop
-  in a simply connected `U` returns it unchanged.
 * `TauCeti.ContinuesInside.exists_analyticOnNhd` — **the monodromy theorem for a simply connected
   domain**: a germ that continues along every path of a simply connected open `U` is the germ of
   a function analytic on all of `U`.
@@ -139,8 +136,8 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   have hKq : (fun x => K (1, x)) = δ := funext fun x => by simp [hK, q]
   -- A continuation along every intermediate path, all starting from the germ of `f₀`.
   have hcont : ∀ t : I, ContinuesAlong f₀ fun x => K (t, x) := fun t =>
-    H _ (by fun_prop) (hKmem t) (hKzero t)
-  choose F hF hF₀ using hcont
+    H.continuesAlong (by fun_prop) (hKmem t) (hKzero t)
+  choose F hF hF₀ using fun t => continuesAlong_iff_exists.1 (hcont t)
   have hF₀' : ∀ t : I, F t 0 =ᶠ[𝓝 z₀] f₀ := fun t => by
     rw [← hKzero t]; exact hF₀ t
   have hmono := monodromy_theorem K hF (fun t => (hF₀' t).trans (hF₀' 0).symm) 1
@@ -153,18 +150,6 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
       (by rw [hδ0]; exact hg0.trans (hF₀' 1).symm)
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
-
-/-- **A germ continued around a loop in a simply connected domain returns to itself.** This is the
-loop form of path independence, the constant path being the second path. -/
-theorem eventuallyEq_of_loop (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
-    (hγ : Continuous γ) (hγU : ∀ x, γ x ∈ U) (hγ0 : γ 0 = z₀) (hγ1 : γ 1 = z₀)
-    (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀) :
-    f 1 =ᶠ[𝓝 z₀] f₀ := by
-  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
-  have han : AnalyticAt ℂ f₀ z₀ := H.analyticAt hz₀U
-  have := H.eventuallyEq_at_one hUc hγ hγU hγ0 continuous_const (fun _ => hz₀U) rfl (by rw [hγ1]) hf
-    hf0 (.const continuousOn_const fun _ _ => han) .rfl
-  rwa [hγ1] at this
 
 /-- **The monodromy theorem for a simply connected domain.** A germ that continues along every
 path of a simply connected open set `U` issuing from `z₀` is the germ at `z₀` of a single function
@@ -182,7 +167,8 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     obtain ⟨c, hc⟩ := hUc.isPathConnected.joinedIn z₀ hz₀ w hw
     exact ⟨c, c.continuous, hc, c.source, c.target⟩
   choose! γ hγc hγU hγ0 hγ1 using hpath
-  choose! f hf hf₀ using fun w (hw : w ∈ U) => H _ (hγc w hw) (hγU w hw) (hγ0 w hw)
+  choose! f hf hf₀ using fun w (hw : w ∈ U) =>
+    continuesAlong_iff_exists.1 (H.continuesAlong (hγc w hw) (hγU w hw) (hγ0 w hw))
   have hf₀' : ∀ w ∈ U, f w 0 =ᶠ[𝓝 z₀] f₀ := fun w hw => by
     have := hf₀ w hw; rwa [hγ0 w hw] at this
   -- The candidate branch: the value at `w` of the terminal germ of the chosen continuation.
@@ -252,8 +238,8 @@ theorem continuesInside_iff_exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimpl
     (hz₀ : z₀ ∈ U) :
     ContinuesInside f₀ U z₀ ↔ ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ := by
   refine ⟨fun H => H.exists_analyticOnNhd hUo hUc hz₀, ?_⟩
-  rintro ⟨F, hF, hFeq⟩ c hc hcU hc0
-  obtain ⟨f, hf, hf0⟩ := ContinuesAlong.of_analyticAt hc fun x => hF _ (hcU x)
-  exact ⟨f, hf, by rw [hc0] at hf0 ⊢; exact hf0.trans hFeq⟩
+  rintro ⟨F, hF, hFeq⟩
+  exact .of_forall fun c hc hcU hc0 =>
+    (ContinuesAlong.of_analyticAt hc fun x => hF _ (hcU x)).congr (hc0 ▸ hFeq)
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -101,19 +101,18 @@ namespace ContinuesInside
 
 /-- **Path independence of continuation on a simply connected domain.** Two continuations of one
 germ, along two paths in `U` that start at `z₀` and share their endpoint, carry the same germ at
-the endpoint.
-
-The proof lifts the two paths to the subspace `↥U`, where simple connectivity makes them homotopic
-rel endpoints, pushes the homotopy back to `ℂ` — every intermediate path still lies in `U`, so the
-hypothesis continues the germ along it — and applies `TauCeti.monodromy_theorem` to the resulting
-family. The two given continuations are then matched with the extreme members of that family by
-uniqueness along a fixed path. -/
+the endpoint. -/
 theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
     (hγ : Continuous γ) (hγU : ∀ x, γ x ∈ U) (hγ0 : γ 0 = z₀)
     (hδ : Continuous δ) (hδU : ∀ x, δ x ∈ U) (hδ0 : δ 0 = z₀) (hend : δ 1 = γ 1)
     (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀)
     (hg : IsAnalyticContinuationAlong g δ univ) (hg0 : g 0 =ᶠ[𝓝 z₀] f₀) :
     f 1 =ᶠ[𝓝 (γ 1)] g 1 := by
+  -- Lift the two paths to the subspace `↥U`, where simple connectivity makes them homotopic rel
+  -- endpoints; push the homotopy back to `ℂ` — every intermediate path still lies in `U`, so the
+  -- hypothesis continues the germ along it — and apply `TauCeti.monodromy_theorem` to the
+  -- resulting family. The two given continuations are then matched with the extreme members of
+  -- that family by uniqueness along a fixed path.
   haveI := hUc.simplyConnectedSpace
   have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
   -- The two paths, read in the subspace `↥U`, where simple connectivity lives.

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -1,0 +1,323 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Monodromy
+public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+import Mathlib.Analysis.Complex.CauchyIntegral
+import Mathlib.Topology.MetricSpace.Thickening
+
+/-!
+# The global branch of a germ on a simply connected domain
+
+`Monodromy.lean` proves that analytic continuation along a path depends on the path only through
+its homotopy class. This file draws the conclusion that makes monodromy usable: **on a simply
+connected domain, a germ that continues along every path is the germ of a single holomorphic
+function on the whole domain**. Equivalently, on such a domain continuation creates no new
+branches, so "multi-valued analytic function" is a phenomenon of the topology of the domain and
+not of the germ.
+
+## Main definitions
+
+* `TauCeti.ContinuesAlong f₀ γ` — the germ of `f₀` at `γ 0` continues analytically along the path
+  `γ`: some `TauCeti.IsAnalyticContinuationAlong` family along `γ` starts from that germ. Only the
+  germ of `f₀` at `γ 0` is constrained, which is the right notion: continuation is a statement
+  about germs, and two functions with the same germ at `γ 0` continue along exactly the same
+  paths.
+* `TauCeti.ContinuesInside f₀ U z₀` — the germ of `f₀` at `z₀` continues along *every* path in `U`
+  issuing from `z₀`. This is the hypothesis of the monodromy theorem, and it is exactly what a
+  holomorphic function on `U` supplies (`TauCeti.ContinuesInside.of_differentiableOn`).
+
+## Main results
+
+* `TauCeti.ContinuesInside.eventuallyEq_one` — **path independence**: on a simply connected `U`,
+  two continuations of one germ along two paths in `U` with the same endpoints end at the same
+  germ.
+* `TauCeti.ContinuesInside.eventuallyEq_of_loop` — the loop form: continuing a germ around a loop
+  in a simply connected `U` returns it unchanged.
+* `TauCeti.ContinuesInside.exists_analyticOnNhd` — **the monodromy theorem for a simply connected
+  domain**: a germ that continues along every path of a simply connected open `U` is the germ of
+  a function analytic on all of `U`.
+* `TauCeti.continuesInside_iff_exists_analyticOnNhd` — the two-way form on a simply connected open
+  set: continuable along every path inside `U` ⟺ the germ of a function analytic on `U`.
+
+The branch produced is unique as soon as `U` is preconnected, by the identity principle
+(`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`); no uniqueness statement is added here.
+
+## The construction
+
+Path independence is monodromy plus simple connectivity: two paths in `U` with the same endpoints
+lift to paths in the subspace `↥U`, where `SimplyConnectedSpace.paths_homotopic` produces a
+homotopy rel endpoints; pushing that homotopy back down to `ℂ` keeps every intermediate path
+inside `U`, so the hypothesis supplies a continuation along each of them and
+`TauCeti.monodromy_theorem` applies. Uniqueness of continuation along a *fixed* path
+(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_one`) then matches the two given continuations
+with the two extreme members of that family.
+
+The global branch is `F w = (value at w of the terminal germ of a continuation to w)`, chosen once
+per point of `U` by path connectedness; path independence says the choice does not matter. The
+work is in showing `F` analytic, that is, in comparing the terminal germs at two *different*
+points. The comparison uses the metric stability of continuation
+(`TauCeti.IsAnalyticContinuationAlong.exists_isAnalyticContinuationAlong_of_dist_lt`): a
+continuation along a path `δ` ending at `z` is carried by a family that continues along *every*
+path uniformly `ρ`-close to `δ`, so the sheared path `x ↦ δ x + x • (w - z)`, which ends at a
+nearby `w`, is continued by that same family. The shear leaves `δ` by less than `ρ`, and by less
+than the distance from the compact set `δ '' I` to the complement of `U`, so it stays inside `U`
+and path independence applies to it. Hence `F` agrees near `z` with a fixed analytic
+representative of the terminal germ at `z`, which is what analyticity at `z` needs. The same
+identification at `z₀`, applied to the constant path, is what gives `F` the prescribed germ
+there.
+
+## Relation to the roadmap and to Mathlib
+
+This completes the L4 target "the monodromy theorem (continuations along homotopic paths agree)"
+of `TauCetiRoadmap/ConformalMapping/README.md` with the statement that layer is built for: the
+passage from local germ data to a single-valued function on a simply connected domain, which is
+what the reflection and continuation layers hand to their consumers. Layer L4 lies outside the
+roadmap's shim-deletion clause for the upstream Riemann-mapping effort
+(leanprover-community/mathlib4#33505), which contains no continuation or monodromy material.
+
+Mathlib has the abstract monodromy statement `IsLocalHomeomorph.monodromy_theorem` and the lifting
+criterion `IsCoveringMap.existsUnique_continuousMap_lifts` for a simply connected base
+(`Mathlib/Topology/Homotopy/Lifting.lean`), but consuming them for germs of holomorphic functions
+would first require the étale space of those germs as a topological space, which Mathlib does not
+have; see the discussion in `Conformal/Monodromy.lean`. Mathlib's simple-connectivity API
+(`SimplyConnectedSpace.paths_homotopic`, `IsSimplyConnected.isPathConnected`), its path homotopy
+API (`Path.Homotopy.map`), and its metric thickening of a compact set are consumed rather than
+restated.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 8 §1.3.
+* J. B. Conway, *Functions of One Complex Variable I* (GTM 11), Ch. IX §3.
+* W. Rudin, *Real and Complex Analysis*, Ch. 16 (the monodromy theorem).
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Metric Set Topology unitInterval
+
+variable {U : Set ℂ} {z₀ : ℂ} {f₀ : ℂ → ℂ} {γ δ : I → ℂ} {f g : I → ℂ → ℂ}
+
+/-! ### Continuation along a path, as a property of the initial germ -/
+
+/-- The germ of `f₀` at `γ 0` **continues along the path `γ`**: there is an analytic continuation
+along `γ` whose germ at the initial time is that of `f₀`.
+
+Only the germ of `f₀` at `γ 0` enters, so this is a property of that germ rather than of `f₀`. -/
+def ContinuesAlong (f₀ : ℂ → ℂ) (γ : I → ℂ) : Prop :=
+  ∃ f : I → ℂ → ℂ, IsAnalyticContinuationAlong f γ univ ∧ f 0 =ᶠ[𝓝 (γ 0)] f₀
+
+namespace ContinuesAlong
+
+/-- A germ that continues along a path is a germ of an analytic function at the initial point. -/
+theorem analyticAt (h : ContinuesAlong f₀ γ) : AnalyticAt ℂ f₀ (γ 0) := by
+  obtain ⟨f, hf, h0⟩ := h
+  exact (hf.analyticAt 0 (mem_univ 0)).congr h0
+
+/-- A function analytic at every point of a path continues itself along it: the constant family is
+the continuation. -/
+theorem of_analyticAt (hγ : Continuous γ) (hf₀ : ∀ x, AnalyticAt ℂ f₀ (γ x)) :
+    ContinuesAlong f₀ γ :=
+  ⟨fun _ => f₀, .const hγ.continuousOn fun t _ => hf₀ t, .rfl⟩
+
+/-- A function holomorphic on an open set continues along every path that stays in that set. -/
+theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) (hγ : Continuous γ)
+    (hγU : ∀ x, γ x ∈ U) : ContinuesAlong f₀ γ :=
+  of_analyticAt hγ fun x => hf₀.analyticOnNhd hUo _ (hγU x)
+
+end ContinuesAlong
+
+namespace IsAnalyticContinuationAlong
+
+/-- **Uniqueness of the terminal germ.** Two continuations along one path that start from the same
+germ end at the same germ. This is `TauCeti.IsAnalyticContinuationAlong.eventuallyEq` for the
+parameter interval, whose preconnectedness discharges the hypothesis of the general statement. -/
+theorem eventuallyEq_one (hf : IsAnalyticContinuationAlong f γ univ)
+    (hg : IsAnalyticContinuationAlong g γ univ) (h0 : f 0 =ᶠ[𝓝 (γ 0)] g 0) :
+    f 1 =ᶠ[𝓝 (γ 1)] g 1 :=
+  hf.eventuallyEq hg isPreconnected_univ (mem_univ 0) (mem_univ 1) h0
+
+end IsAnalyticContinuationAlong
+
+/-! ### Continuation inside a domain -/
+
+/-- The germ of `f₀` at `z₀` **continues inside `U`**: it continues along every path that starts
+at `z₀` and stays in `U`.
+
+This is the hypothesis of the monodromy theorem. It is a condition on the germ and on the domain
+jointly: the germ of `Complex.log` at `1` continues inside `ℂ \ {0}`, and continues inside the
+slit plane, but is single-valued only on the latter. -/
+def ContinuesInside (f₀ : ℂ → ℂ) (U : Set ℂ) (z₀ : ℂ) : Prop :=
+  ∀ γ : I → ℂ, Continuous γ → (∀ x, γ x ∈ U) → γ 0 = z₀ → ContinuesAlong f₀ γ
+
+namespace ContinuesInside
+
+/-- A germ that continues inside `U` is analytic at the base point, as witnessed by the constant
+path. -/
+theorem analyticAt (H : ContinuesInside f₀ U z₀) (hz₀ : z₀ ∈ U) : AnalyticAt ℂ f₀ z₀ :=
+  (H (fun _ => z₀) continuous_const (fun _ => hz₀) rfl).analyticAt
+
+/-- A function holomorphic on an open set continues inside that set from each of its points. -/
+theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) :
+    ContinuesInside f₀ U z₀ :=
+  fun _ hγ hγU _ => .of_differentiableOn hUo hf₀ hγ hγU
+
+/-- **Path independence of continuation on a simply connected domain.** Two continuations of one
+germ, along two paths in `U` that start at `z₀` and share their endpoint, carry the same germ at
+the endpoint.
+
+The proof lifts the two paths to the subspace `↥U`, where simple connectivity makes them homotopic
+rel endpoints, pushes the homotopy back to `ℂ` — every intermediate path still lies in `U`, so the
+hypothesis continues the germ along it — and applies `TauCeti.monodromy_theorem` to the resulting
+family. The two given continuations are then matched with the extreme members of that family by
+uniqueness along a fixed path. -/
+theorem eventuallyEq_one (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
+    (hγ : Continuous γ) (hγU : ∀ x, γ x ∈ U) (hγ0 : γ 0 = z₀)
+    (hδ : Continuous δ) (hδU : ∀ x, δ x ∈ U) (hδ0 : δ 0 = z₀) (hend : δ 1 = γ 1)
+    (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀)
+    (hg : IsAnalyticContinuationAlong g δ univ) (hg0 : g 0 =ᶠ[𝓝 z₀] f₀) :
+    f 1 =ᶠ[𝓝 (γ 1)] g 1 := by
+  haveI := hUc.simplyConnectedSpace
+  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
+  -- The two paths, read in the subspace `↥U`, where simple connectivity lives.
+  let p : Path (⟨z₀, hz₀U⟩ : U) (⟨γ 1, hγU 1⟩ : U) :=
+    { toFun := fun x => ⟨γ x, hγU x⟩
+      continuous_toFun := hγ.subtype_mk _
+      source' := Subtype.ext hγ0
+      target' := rfl }
+  let q : Path (⟨z₀, hz₀U⟩ : U) (⟨γ 1, hγU 1⟩ : U) :=
+    { toFun := fun x => ⟨δ x, hδU x⟩
+      continuous_toFun := hδ.subtype_mk _
+      source' := Subtype.ext hδ0
+      target' := Subtype.ext hend }
+  obtain ⟨h⟩ := SimplyConnectedSpace.paths_homotopic p q
+  -- The same homotopy, read back in `ℂ`; it never leaves `U`.
+  set K := h.map (⟨Subtype.val, continuous_subtype_val⟩ : C(U, ℂ)) with hK
+  have hKmem : ∀ t x : I, K (t, x) ∈ U := fun t x => (h (t, x)).2
+  have hKzero : ∀ t : I, K (t, 0) = z₀ := fun t => by simp [hK]
+  have hKp : (fun x => K (0, x)) = γ := funext fun x => by simp [hK, p]
+  have hKq : (fun x => K (1, x)) = δ := funext fun x => by simp [hK, q]
+  -- A continuation along every intermediate path, all starting from the germ of `f₀`.
+  have hcont : ∀ t : I, ContinuesAlong f₀ fun x => K (t, x) := fun t =>
+    H _ (by fun_prop) (hKmem t) (hKzero t)
+  choose F hF hF₀ using hcont
+  have hF₀' : ∀ t : I, F t 0 =ᶠ[𝓝 z₀] f₀ := fun t => by
+    rw [← hKzero t]; exact hF₀ t
+  have hmono := monodromy_theorem K hF (fun t => (hF₀' t).trans (hF₀' 0).symm) 1
+  -- Match the two given continuations with the extremes of the family.
+  have e₀ : f 1 =ᶠ[𝓝 (γ 1)] F 0 1 :=
+    hf.eventuallyEq_one (hKp ▸ hF 0) (by rw [hγ0]; exact hf0.trans (hF₀' 0).symm)
+  have e₁ : g 1 =ᶠ[𝓝 (δ 1)] F 1 1 :=
+    hg.eventuallyEq_one (hKq ▸ hF 1) (by rw [hδ0]; exact hg0.trans (hF₀' 1).symm)
+  rw [hend] at e₁
+  exact (e₀.trans hmono.symm).trans e₁.symm
+
+/-- **A germ continued around a loop in a simply connected domain returns to itself.** This is the
+loop form of path independence, the constant path being the second path. -/
+theorem eventuallyEq_of_loop (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
+    (hγ : Continuous γ) (hγU : ∀ x, γ x ∈ U) (hγ0 : γ 0 = z₀) (hγ1 : γ 1 = z₀)
+    (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀) :
+    f 1 =ᶠ[𝓝 z₀] f₀ := by
+  have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
+  have han : AnalyticAt ℂ f₀ z₀ := H.analyticAt hz₀U
+  have := H.eventuallyEq_one hUc hγ hγU hγ0 continuous_const (fun _ => hz₀U) rfl (by rw [hγ1]) hf
+    hf0 (.const continuousOn_const fun _ _ => han) .rfl
+  rwa [hγ1] at this
+
+/-- **The monodromy theorem for a simply connected domain.** A germ that continues along every
+path of a simply connected open set `U` issuing from `z₀` is the germ at `z₀` of a single function
+analytic on all of `U`.
+
+So on a simply connected domain analytic continuation produces no new branches, and a
+"multi-valued analytic function" there is single-valued after all. -/
+theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀ : z₀ ∈ U)
+    (H : ContinuesInside f₀ U z₀) :
+    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ := by
+  -- A path from `z₀` to each point of `U`, and a continuation of the germ along it.
+  have hpath : ∀ w ∈ U, ∃ γ : I → ℂ,
+      Continuous γ ∧ (∀ x, γ x ∈ U) ∧ γ 0 = z₀ ∧ γ 1 = w := by
+    intro w hw
+    obtain ⟨c, hc⟩ := hUc.isPathConnected.joinedIn z₀ hz₀ w hw
+    exact ⟨c, c.continuous, hc, c.source, c.target⟩
+  choose! γ hγc hγU hγ0 hγ1 using hpath
+  choose! f hf hf₀ using fun w (hw : w ∈ U) => H _ (hγc w hw) (hγU w hw) (hγ0 w hw)
+  have hf₀' : ∀ w ∈ U, f w 0 =ᶠ[𝓝 z₀] f₀ := fun w hw => by
+    have := hf₀ w hw; rwa [hγ0 w hw] at this
+  -- The candidate branch: the value at `w` of the terminal germ of the chosen continuation.
+  set F : ℂ → ℂ := fun w => f w 1 w with hFdef
+  -- **The key step.** Near the endpoint of *any* continuation of the germ, `F` is the value of
+  -- that continuation's terminal germ.
+  have key : ∀ z : ℂ, ∀ δ : I → ℂ, ∀ g : I → ℂ → ℂ, Continuous δ → (∀ x, δ x ∈ U) → δ 0 = z₀ →
+      δ 1 = z → IsAnalyticContinuationAlong g δ univ → g 0 =ᶠ[𝓝 z₀] f₀ → F =ᶠ[𝓝 z] g 1 := by
+    intro z δ g hδ hδU hδ0 hδ1 hg hg0
+    -- One family of germs continues along every path uniformly `ρ`-close to `δ`, ...
+    obtain ⟨ρ, hρ, G, hGg, hGcont⟩ :=
+      hg.exists_isAnalyticContinuationAlong_of_dist_lt isCompact_univ
+    -- ... and an `ε`-neighbourhood of the compact `δ '' I` is still inside `U`.
+    obtain ⟨ε, hε, hεU⟩ := (isCompact_range hδ).exists_thickening_subset_open hUo
+      (range_subset_iff.2 hδU)
+    have hGone : G 1 =ᶠ[𝓝 z] g 1 := by
+      have := hGg 1 (mem_univ 1); rwa [hδ1] at this
+    filter_upwards [ball_mem_nhds z (lt_min hρ hε), hGone] with w hw hwG
+    -- The path `δ` sheared to end at `w` instead of `z`.
+    set δ' : I → ℂ := fun x => δ x + (x : ℝ) • (w - z) with hδ'def
+    have hδ'c : Continuous δ' := by fun_prop
+    have hdist : ∀ x : I, dist (δ' x) (δ x) < min ρ ε := by
+      intro x
+      have hx : |(x : ℝ)| ≤ 1 := abs_le.2 ⟨by linarith [x.2.1], x.2.2⟩
+      have hd : dist (δ' x) (δ x) = |(x : ℝ)| * dist w z := by
+        rw [dist_eq_norm, dist_eq_norm, hδ'def]
+        simp
+      have hwz : dist w z < min ρ ε := mem_ball.1 hw
+      have : |(x : ℝ)| * dist w z ≤ dist w z :=
+        mul_le_of_le_one_left dist_nonneg hx
+      linarith [hd ▸ this]
+    have hδ'U : ∀ x, δ' x ∈ U := fun x =>
+      hεU (mem_thickening_iff.2 ⟨δ x, mem_range_self x, (hdist x).trans_le (min_le_right _ _)⟩)
+    have hδ'0 : δ' 0 = z₀ := by simp [hδ'def, hδ0]
+    have hδ'1 : δ' 1 = w := by simp [hδ'def, hδ1]
+    have hwU : w ∈ U := hδ'1 ▸ hδ'U 1
+    have hGδ' : IsAnalyticContinuationAlong G δ' univ :=
+      hGcont δ' hδ'c.continuousOn fun t _ => (hdist t).trans_le (min_le_left _ _)
+    have hG0 : G 0 =ᶠ[𝓝 z₀] f₀ := by
+      have := hGg 0 (mem_univ 0); rw [hδ0] at this; exact this.trans hg0
+    -- Path independence: the chosen continuation to `w` and `G` end at the same germ.
+    have hterm := H.eventuallyEq_one hUc (hγc w hwU) (hγU w hwU) (hγ0 w hwU) hδ'c hδ'U hδ'0
+      (by rw [hδ'1, hγ1 w hwU]) (hf w hwU) (hf₀' w hwU) hGδ' hG0
+    have hval := hterm.eq_of_nhds
+    rw [hγ1 w hwU] at hval
+    rw [hFdef]
+    exact hval.trans hwG
+  refine ⟨F, fun z hz => ?_, ?_⟩
+  · -- Analyticity at `z`: `F` agrees near `z` with the terminal germ of the continuation to `z`.
+    have han : AnalyticAt ℂ (f z 1) z := by
+      have := (hf z hz).analyticAt 1 (mem_univ 1); rwa [hγ1 z hz] at this
+    exact han.congr
+      (key z (γ z) (f z) (hγc z hz) (hγU z hz) (hγ0 z hz) (hγ1 z hz) (hf z hz) (hf₀' z hz)).symm
+  · -- The prescribed germ at `z₀`: apply the key step to the constant path.
+    exact key z₀ (fun _ => z₀) (fun _ => f₀) continuous_const (fun _ => hz₀) rfl rfl
+      (.const continuousOn_const fun _ _ => H.analyticAt hz₀) .rfl
+
+end ContinuesInside
+
+/-- **The monodromy theorem, in two-way form.** On a simply connected open set `U`, a germ at a
+point `z₀ ∈ U` continues along every path in `U` from `z₀` if and only if it is the germ of a
+function analytic on all of `U`.
+
+The forward direction is `TauCeti.ContinuesInside.exists_analyticOnNhd`; the reverse is the
+observation that a holomorphic function is its own continuation. -/
+theorem continuesInside_iff_exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U)
+    (hz₀ : z₀ ∈ U) :
+    ContinuesInside f₀ U z₀ ↔ ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ := by
+  refine ⟨fun H => H.exists_analyticOnNhd hUo hUc hz₀, ?_⟩
+  rintro ⟨F, hF, hFeq⟩ c hc hcU hc0
+  obtain ⟨f, hf, hf0⟩ := ContinuesAlong.of_analyticAt hc fun x => hF _ (hcU x)
+  exact ⟨f, hf, by rw [hc0] at hf0 ⊢; exact hf0.trans hFeq⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -20,20 +20,14 @@ function on the whole domain**. Equivalently, on such a domain continuation crea
 branches, so "multi-valued analytic function" is a phenomenon of the topology of the domain and
 not of the germ.
 
-## Main definitions
-
-* `TauCeti.ContinuesAlong f₀ γ` — the germ of `f₀` at `γ 0` continues analytically along the path
-  `γ`: some `TauCeti.IsAnalyticContinuationAlong` family along `γ` starts from that germ. Only the
-  germ of `f₀` at `γ 0` is constrained, which is the right notion: continuation is a statement
-  about germs, and two functions with the same germ at `γ 0` continue along exactly the same
-  paths.
-* `TauCeti.ContinuesInside f₀ U z₀` — the germ of `f₀` at `z₀` continues along *every* path in `U`
-  issuing from `z₀`. This is the hypothesis of the monodromy theorem, and it is exactly what a
-  holomorphic function on `U` supplies (`TauCeti.ContinuesInside.of_differentiableOn`).
+The hypothesis is `TauCeti.ContinuesInside f₀ U z₀` from `Conformal/Continuation.lean`: the germ
+of `f₀` at `z₀` continues along *every* path in `U` issuing from `z₀`. It is exactly what a
+holomorphic function on `U` supplies (`TauCeti.ContinuesInside.of_differentiableOn`), and by the
+two-way form below it is supplied by nothing else once `U` is simply connected.
 
 ## Main results
 
-* `TauCeti.ContinuesInside.eventuallyEq_one` — **path independence**: on a simply connected `U`,
+* `TauCeti.ContinuesInside.eventuallyEq_at_one` — **path independence**: on a simply connected `U`,
   two continuations of one germ along two paths in `U` with the same endpoints end at the same
   germ.
 * `TauCeti.ContinuesInside.eventuallyEq_of_loop` — the loop form: continuing a germ around a loop
@@ -54,8 +48,8 @@ lift to paths in the subspace `↥U`, where `SimplyConnectedSpace.paths_homotopi
 homotopy rel endpoints; pushing that homotopy back down to `ℂ` keeps every intermediate path
 inside `U`, so the hypothesis supplies a continuation along each of them and
 `TauCeti.monodromy_theorem` applies. Uniqueness of continuation along a *fixed* path
-(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_one`) then matches the two given continuations
-with the two extreme members of that family.
+(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq`, over the preconnected parameter interval)
+then matches the two given continuations with the two extreme members of that family.
 
 The global branch is `F w = (value at w of the terminal germ of a continuation to w)`, chosen once
 per point of `U` by path connectedness; path independence says the choice does not matter. The
@@ -104,69 +98,9 @@ open Filter Metric Set Topology unitInterval
 
 variable {U : Set ℂ} {z₀ : ℂ} {f₀ : ℂ → ℂ} {γ δ : I → ℂ} {f g : I → ℂ → ℂ}
 
-/-! ### Continuation along a path, as a property of the initial germ -/
-
-/-- The germ of `f₀` at `γ 0` **continues along the path `γ`**: there is an analytic continuation
-along `γ` whose germ at the initial time is that of `f₀`.
-
-Only the germ of `f₀` at `γ 0` enters, so this is a property of that germ rather than of `f₀`. -/
-def ContinuesAlong (f₀ : ℂ → ℂ) (γ : I → ℂ) : Prop :=
-  ∃ f : I → ℂ → ℂ, IsAnalyticContinuationAlong f γ univ ∧ f 0 =ᶠ[𝓝 (γ 0)] f₀
-
-namespace ContinuesAlong
-
-/-- A germ that continues along a path is a germ of an analytic function at the initial point. -/
-theorem analyticAt (h : ContinuesAlong f₀ γ) : AnalyticAt ℂ f₀ (γ 0) := by
-  obtain ⟨f, hf, h0⟩ := h
-  exact (hf.analyticAt 0 (mem_univ 0)).congr h0
-
-/-- A function analytic at every point of a path continues itself along it: the constant family is
-the continuation. -/
-theorem of_analyticAt (hγ : Continuous γ) (hf₀ : ∀ x, AnalyticAt ℂ f₀ (γ x)) :
-    ContinuesAlong f₀ γ :=
-  ⟨fun _ => f₀, .const hγ.continuousOn fun t _ => hf₀ t, .rfl⟩
-
-/-- A function holomorphic on an open set continues along every path that stays in that set. -/
-theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) (hγ : Continuous γ)
-    (hγU : ∀ x, γ x ∈ U) : ContinuesAlong f₀ γ :=
-  of_analyticAt hγ fun x => hf₀.analyticOnNhd hUo _ (hγU x)
-
-end ContinuesAlong
-
-namespace IsAnalyticContinuationAlong
-
-/-- **Uniqueness of the terminal germ.** Two continuations along one path that start from the same
-germ end at the same germ. This is `TauCeti.IsAnalyticContinuationAlong.eventuallyEq` for the
-parameter interval, whose preconnectedness discharges the hypothesis of the general statement. -/
-theorem eventuallyEq_one (hf : IsAnalyticContinuationAlong f γ univ)
-    (hg : IsAnalyticContinuationAlong g γ univ) (h0 : f 0 =ᶠ[𝓝 (γ 0)] g 0) :
-    f 1 =ᶠ[𝓝 (γ 1)] g 1 :=
-  hf.eventuallyEq hg isPreconnected_univ (mem_univ 0) (mem_univ 1) h0
-
-end IsAnalyticContinuationAlong
-
-/-! ### Continuation inside a domain -/
-
-/-- The germ of `f₀` at `z₀` **continues inside `U`**: it continues along every path that starts
-at `z₀` and stays in `U`.
-
-This is the hypothesis of the monodromy theorem. It is a condition on the germ and on the domain
-jointly: the germ of `Complex.log` at `1` continues inside `ℂ \ {0}`, and continues inside the
-slit plane, but is single-valued only on the latter. -/
-def ContinuesInside (f₀ : ℂ → ℂ) (U : Set ℂ) (z₀ : ℂ) : Prop :=
-  ∀ γ : I → ℂ, Continuous γ → (∀ x, γ x ∈ U) → γ 0 = z₀ → ContinuesAlong f₀ γ
+/-! ### Path independence and the global branch -/
 
 namespace ContinuesInside
-
-/-- A germ that continues inside `U` is analytic at the base point, as witnessed by the constant
-path. -/
-theorem analyticAt (H : ContinuesInside f₀ U z₀) (hz₀ : z₀ ∈ U) : AnalyticAt ℂ f₀ z₀ :=
-  (H (fun _ => z₀) continuous_const (fun _ => hz₀) rfl).analyticAt
-
-/-- A function holomorphic on an open set continues inside that set from each of its points. -/
-theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) :
-    ContinuesInside f₀ U z₀ :=
-  fun _ hγ hγU _ => .of_differentiableOn hUo hf₀ hγ hγU
 
 /-- **Path independence of continuation on a simply connected domain.** Two continuations of one
 germ, along two paths in `U` that start at `z₀` and share their endpoint, carry the same germ at
@@ -177,7 +111,7 @@ rel endpoints, pushes the homotopy back to `ℂ` — every intermediate path sti
 hypothesis continues the germ along it — and applies `TauCeti.monodromy_theorem` to the resulting
 family. The two given continuations are then matched with the extreme members of that family by
 uniqueness along a fixed path. -/
-theorem eventuallyEq_one (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
+theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
     (hγ : Continuous γ) (hγU : ∀ x, γ x ∈ U) (hγ0 : γ 0 = z₀)
     (hδ : Continuous δ) (hδU : ∀ x, δ x ∈ U) (hδ0 : δ 0 = z₀) (hend : δ 1 = γ 1)
     (hf : IsAnalyticContinuationAlong f γ univ) (hf0 : f 0 =ᶠ[𝓝 z₀] f₀)
@@ -212,9 +146,11 @@ theorem eventuallyEq_one (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U
   have hmono := monodromy_theorem K hF (fun t => (hF₀' t).trans (hF₀' 0).symm) 1
   -- Match the two given continuations with the extremes of the family.
   have e₀ : f 1 =ᶠ[𝓝 (γ 1)] F 0 1 :=
-    hf.eventuallyEq_one (hKp ▸ hF 0) (by rw [hγ0]; exact hf0.trans (hF₀' 0).symm)
+    hf.eventuallyEq (hKp ▸ hF 0) isPreconnected_univ (mem_univ 0) (mem_univ 1)
+      (by rw [hγ0]; exact hf0.trans (hF₀' 0).symm)
   have e₁ : g 1 =ᶠ[𝓝 (δ 1)] F 1 1 :=
-    hg.eventuallyEq_one (hKq ▸ hF 1) (by rw [hδ0]; exact hg0.trans (hF₀' 1).symm)
+    hg.eventuallyEq (hKq ▸ hF 1) isPreconnected_univ (mem_univ 0) (mem_univ 1)
+      (by rw [hδ0]; exact hg0.trans (hF₀' 1).symm)
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
 
@@ -226,7 +162,7 @@ theorem eventuallyEq_of_loop (hUc : IsSimplyConnected U) (H : ContinuesInside f�
     f 1 =ᶠ[𝓝 z₀] f₀ := by
   have hz₀U : z₀ ∈ U := hγ0 ▸ hγU 0
   have han : AnalyticAt ℂ f₀ z₀ := H.analyticAt hz₀U
-  have := H.eventuallyEq_one hUc hγ hγU hγ0 continuous_const (fun _ => hz₀U) rfl (by rw [hγ1]) hf
+  have := H.eventuallyEq_at_one hUc hγ hγU hγ0 continuous_const (fun _ => hz₀U) rfl (by rw [hγ1]) hf
     hf0 (.const continuousOn_const fun _ _ => han) .rfl
   rwa [hγ1] at this
 
@@ -288,7 +224,7 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     have hG0 : G 0 =ᶠ[𝓝 z₀] f₀ := by
       have := hGg 0 (mem_univ 0); rw [hδ0] at this; exact this.trans hg0
     -- Path independence: the chosen continuation to `w` and `G` end at the same germ.
-    have hterm := H.eventuallyEq_one hUc (hγc w hwU) (hγU w hwU) (hγ0 w hwU) hδ'c hδ'U hδ'0
+    have hterm := H.eventuallyEq_at_one hUc (hγc w hwU) (hγU w hwU) (hγ0 w hwU) hδ'c hδ'U hδ'0
       (by rw [hδ'1, hγ1 w hwU]) (hf w hwU) (hf₀' w hwU) hGδ' hG0
     have hval := hterm.eq_of_nhds
     rw [hγ1 w hwU] at hval


### PR DESCRIPTION
This PR builds the **global branch of a germ on a simply connected domain**, in the new module `TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean` (259 lines), on top of the germ-level continuation predicates added to the existing `Conformal/Continuation.lean`: a germ that continues analytically along every path of a simply connected open `U` issuing from `z₀` is the germ at `z₀` of one function analytic on all of `U` (`TauCeti.ContinuesInside.exists_analyticOnNhd`), so on such a domain continuation creates no new branches and "multi-valued analytic function" is a phenomenon of the topology of the domain rather than of the germ. `TauCeti.continuesInside_iff_exists_analyticOnNhd` records the two-way form, whose converse is the observation that a holomorphic function is its own continuation.

The roadmap target is layer **L4** of `TauCetiRoadmap/ConformalMapping/README.md` — "analytic continuation & the reflection principle … the **monodromy theorem** (continuations along homotopic paths agree)" — and specifically the statement that layer exists to deliver. `Conformal/Monodromy.lean` on `main` proves the homotopy invariance itself and its loop form, and its docstring names this consequence without proving it: "together with the uniqueness of continuation along a fixed path, this is the reason a germ that can be analytically continued along every path of a simply connected domain is single-valued there". This PR proves that, which is the form in which L4 continuation is consumed downstream, where the object wanted is a function on a domain and not a family of germs along a path.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"monodromy-simply-connected-single-valued"}-->

Two definitions carry the hypothesis, and they go in `Conformal/Continuation.lean` next to `IsAnalyticContinuationAlong`, since neither needs any monodromy theory. `TauCeti.ContinuesAlong f₀ c` says some `TauCeti.IsAnalyticContinuationAlong` family along `c` starts from the germ of `f₀` at `c 0`; only that germ is constrained, which is the right notion, since two functions with the same germ at `c 0` continue along exactly the same paths — recorded as `TauCeti.continuesAlong_congr`. `TauCeti.ContinuesInside f₀ U z₀` asks for this along every path in `U` from `z₀` (`TauCeti.continuesInside_congr` again transporting it across the germ), and `TauCeti.ContinuesInside.of_differentiableOn` shows a holomorphic function on `U` supplies it — so the hypothesis class is inhabited, and by the two-way form it is inhabited by nothing else once `U` is simply connected, which is exactly the content.

`TauCeti.ContinuesInside.eventuallyEq_at_one` is path independence: two paths in `U` with the same endpoints lift to the subspace `↥U`, where `SimplyConnectedSpace.paths_homotopic` makes them homotopic rel endpoints; pushing that homotopy back to `ℂ` along `Path.Homotopy.map` keeps every intermediate path inside `U`, so the hypothesis continues the germ along each of them and `TauCeti.monodromy_theorem` applies to the resulting family, whose extreme members are matched with the two given continuations by uniqueness along a fixed path (`TauCeti.IsAnalyticContinuationAlong.eventuallyEq`, over the preconnected parameter interval).

The branch is then `F w = (value at w of the terminal germ of a continuation to w)`, one continuation chosen per point by path connectedness, path independence saying the choice does not matter. The work is analyticity, which compares terminal germs at two *different* points, and it is where `Conformal/Monodromy.lean`'s metric engine is spent: `TauCeti.IsAnalyticContinuationAlong.exists_isAnalyticContinuationAlong_of_dist_lt` produces, for a continuation along a path `δ` ending at `z`, one family carrying the same germs that continues along *every* path uniformly `ρ`-close to `δ`. The sheared path `x ↦ δ x + x • (w - z)` ends at a nearby `w` and is continued by that same family; shrinking `ρ` below the thickening radius that keeps the compact `δ '' I` inside `U` (`IsCompact.exists_thickening_subset_open`) keeps the shear inside `U`, so path independence applies to it and identifies `F` near `z` with a fixed analytic representative of the terminal germ there. The same identification at `z₀`, applied to the constant path, gives `F` the prescribed germ. Note that the shear is what avoids concatenating paths: no reparametrisation of `Path.trans` and no germ matching at a junction is needed, because perturbing the whole path is already available.

Nothing here duplicates existing work. The pinned Mathlib has no analytic continuation of germs at all — the vocabulary is `Conformal/Continuation.lean`'s — and its abstract lifting results (`IsLocalHomeomorph.monodromy_theorem`, `IsCoveringMap.existsUnique_continuousMap_lifts` for a simply connected base) would first require the étale space of holomorphic germs over `ℂ` as a topological space, which Mathlib does not have; `Conformal/Monodromy.lean` records that route as worthwhile follow-up and this file inherits that assessment. Mathlib's simple-connectivity API (`SimplyConnectedSpace.paths_homotopic`, `IsSimplyConnected.isPathConnected`), its path-homotopy API (`Path.Homotopy.map`), its identity principle and its metric thickening of a compact set are consumed rather than restated, and no Mathlib infrastructure is vendored. Uniqueness of the branch is Mathlib's `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq` and is therefore not restated. Within the repository the in-flight conformal threads are all disjoint from this one: the circular crosscut (#1642) and the length–area inequality (#1636) are L5 boundary-behaviour estimates for a map already given on a disc, and Hurwitz zero localisation (#1646) is an L0 statement about locally uniform limits.

In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for every theorem added in layers L0–L6, everything is stated for maps of `ℂ`, and simple connectivity is Mathlib's `IsSimplyConnected` — that is, `SimplyConnectedSpace ↥U` — as the bar requires, never an ad hoc condition. Layer L4 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which contains no continuation or monodromy material, so this is new Lean formalization and not a temporary shim subject to the roadmap's shim-deletion clause.

`lake build` (6091 jobs), `lake exe axioms` (`audited 18179 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound]`), `lake exe module-system` (1001 modules) and `bash scripts/lint-env.sh` (`PASS — no new violations`) are all green.

Roadmap: ConformalMapping

🤖 Prepared with Claude Code


