### PR TITLE
feat: add finite winding partitions

### DIFF
--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -78,8 +78,9 @@ versus `MeromorphicOn` (on a set).
   needs no existence hypothesis.
 * `HasCauchyPVAt.symm`, `CauchyPVExistsAt.symm`, `cauchyPVAt_symm` — reversing the interval
   orientation negates the single-point principal value.
-* `HasCauchyPVAt.concat` — the principal values on `[a, b]` and `[b, c]` add
-  (`CauchyPVExistsAt.concat` is the existence form).
+* `HasCauchyPVAt.concat`, `HasCauchyPVAt.concat_range` — principal values add over two adjacent
+  intervals or a finite partition (`CauchyPVExistsAt.concat` and `CauchyPVExistsAt.concat_range`
+  are the existence forms, and `cauchyPVAt_concat_range` computes the canonical finite value).
 
 ## Provenance
 
@@ -721,6 +722,14 @@ theorem CauchyPVExistsAt.concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀
   refine CauchyPVExistsAt.intro (HasCauchyPVAt.concat_range (L := fun k =>
     cauchyPVAt γ (t k) (t (k + 1)) f z₀) ?_)
   exact fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
+
+/-- Value form of `HasCauchyPVAt.concat_range`: the canonical principal value on a finite
+partition is the sum of its canonical values on the adjacent intervals. -/
+theorem cauchyPVAt_concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {n : ℕ}
+    {t : ℕ → ℝ} (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) f z₀) :
+    cauchyPVAt γ (t 0) (t n) f z₀ =
+      ∑ k ∈ Finset.range n, cauchyPVAt γ (t k) (t (k + 1)) f z₀ :=
+  (HasCauchyPVAt.concat_range fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt).cauchyPVAt_eq
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -488,6 +488,21 @@ theorem HasCauchyPVAt.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} 
     filter_upwards [h_ab.1, h_bc.1] with ε hab_int hbc_int
     exact intervalIntegral.integral_add_adjacent_intervals hab_int hbc_int
 
+/-- **Finite concatenation.** If the principal value on every adjacent interval
+`[t k, t (k + 1)]` is `L k`, then the principal value on `[t 0, t n]` is their sum. The
+endpoints need not be ordered. -/
+theorem HasCauchyPVAt.concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {n : ℕ}
+    {t : ℕ → ℝ} {L : ℕ → ℂ}
+    (h : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) f z₀ (L k)) :
+    HasCauchyPVAt γ (t 0) (t n) f z₀ (∑ k ∈ Finset.range n, L k) := by
+  induction n with
+  | zero => simpa using HasCauchyPVAt.refl γ (t 0) f z₀
+  | succ n ih =>
+      have hprefix : HasCauchyPVAt γ (t 0) (t n) f z₀
+          (∑ k ∈ Finset.range n, L k) :=
+        ih fun k hk => h k (hk.trans n.lt_succ_self)
+      simpa only [Finset.sum_range_succ] using hprefix.concat (h n n.lt_succ_self)
+
 /-- Existence form of `HasCauchyPVAt.of_dist_lower_bound`. -/
 theorem cauchyPVExistsAt_of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ} {a b m : ℝ}
     (hm_pos : 0 < m) (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
@@ -697,6 +712,15 @@ theorem CauchyPVExistsAt.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → �
   let ⟨_, hL₁⟩ := h_ab
   let ⟨_, hL₂⟩ := h_bc
   ⟨_, hL₁.concat hL₂⟩
+
+/-- Existence form of `HasCauchyPVAt.concat_range`: existence on every adjacent interval of a
+finite partition gives existence on the whole interval. -/
+theorem CauchyPVExistsAt.concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {n : ℕ}
+    {t : ℕ → ℝ} (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) f z₀) :
+    CauchyPVExistsAt γ (t 0) (t n) f z₀ := by
+  refine CauchyPVExistsAt.intro (HasCauchyPVAt.concat_range (L := fun k =>
+    cauchyPVAt γ (t k) (t (k + 1)) f z₀) ?_)
+  exact fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -1,0 +1,122 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.Number.Concat
+
+/-!
+# Finite partitions of contour winding numbers
+
+This file upgrades the two-interval additivity of `Contour.windingNumber` to a finite partition
+`t 0, ..., t n` of the parameter interval.  No monotonicity of `t` is needed: oriented interval
+integrals, and hence their Cauchy principal values, telescope over arbitrary adjacent endpoints.
+
+The finite form is the bookkeeping prerequisite for the winding decomposition in
+Hungerbühler--Wasem Proposition 2.2.  There a closed immersed curve is replaced by a part avoiding
+the distinguished point and finitely many model sectors, one for each crossing.  Once those pieces
+are assembled on adjacent parameter intervals, the results here identify the winding number of the
+whole curve with the sum of their winding numbers.  The geometric construction of those pieces is
+separate; this file only proves the finite additivity it consumes.
+
+As in `Winding.Number.Concat`, every statement carries principal-value existence.  Without it the
+`limUnder`-based `windingNumber` is a junk value, so unconditional finite additivity would be false
+as an API statement even though it looked formally convenient.
+
+## Main results
+
+* `Contour.hasCauchyPVAt_inv_sub_sum_range` concatenates explicit Cauchy-kernel principal values
+  over a finite partition.
+* `Contour.windingNumber_eq_sum_range` writes the winding number on the whole interval as the sum
+  over its adjacent pieces.
+* `Contour.windingNumber_eq_sum_range_of_eqOn` allows each piece to be computed using a different
+  curve that agrees with the assembled curve on that open subinterval.  This is the form used by
+  an avoiding-part plus model-sector decomposition.
+
+## Provenance
+
+This is routine finite-partition infrastructure around the generalized winding number; no formal
+source is vendored.  Its role is prescribed by N. Hungerbühler and M. Wasem, *Non-integer valued
+winding numbers and a generalized Residue Theorem*, arXiv:1808.00997, Proposition 2.2.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Contour
+
+variable {γ : ℝ → ℂ} {z₀ : ℂ}
+
+/-- The Cauchy kernel about `z₀`, used throughout the winding-number API. -/
+local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
+
+/-- **Finite concatenation of explicit Cauchy-kernel principal values.**  If the principal value
+on every adjacent interval `[t k, t (k + 1)]` is `L k`, then the principal value on
+`[t 0, t n]` is their sum.  The endpoints need not be ordered. -/
+theorem hasCauchyPVAt_inv_sub_sum_range {n : ℕ} {t : ℕ → ℝ} {L : ℕ → ℂ}
+    (h : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k)) :
+    HasCauchyPVAt γ (t 0) (t n) κ[z₀] z₀ (∑ k ∈ Finset.range n, L k) := by
+  induction n with
+  | zero =>
+      simpa using HasCauchyPVAt.refl γ (t 0) κ[z₀] z₀
+  | succ n ih =>
+      have hprefix : HasCauchyPVAt γ (t 0) (t n) κ[z₀] z₀
+          (∑ k ∈ Finset.range n, L k) :=
+        ih fun k hk => h k (hk.trans n.lt_succ_self)
+      simpa only [Finset.sum_range_succ] using hprefix.concat (h n n.lt_succ_self)
+
+/-- Existence of the Cauchy-kernel principal value on every adjacent interval of a finite
+partition gives existence on the whole interval. -/
+theorem cauchyPVExistsAt_inv_sub_of_forall_lt {n : ℕ} {t : ℕ → ℝ}
+    (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀) :
+    CauchyPVExistsAt γ (t 0) (t n) κ[z₀] z₀ := by
+  refine CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_sum_range (L := fun k =>
+    cauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀) ?_)
+  exact fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
+
+/-- **Finite-partition additivity of the generalized winding number.**  If the Cauchy-kernel
+principal value exists on every adjacent interval, the winding number from `t 0` to `t n` is the
+sum of the winding numbers of those pieces. -/
+theorem windingNumber_eq_sum_range {n : ℕ} {t : ℕ → ℝ}
+    (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀) :
+    windingNumber γ (t 0) (t n) z₀ =
+      ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ := by
+  let L : ℕ → ℂ := fun k => cauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀
+  have hpiece : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k) :=
+    fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
+  rw [windingNumber_eq_of_hasCauchyPVAt (hasCauchyPVAt_inv_sub_sum_range hpiece),
+    Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [windingNumber_eq_of_hasCauchyPVAt (h k (Finset.mem_range.mp hk)).hasCauchyPVAt_cauchyPVAt]
+
+/-- **Finite winding decomposition using separately computed pieces.**  Suppose that on the open
+subinterval between `t k` and `t (k + 1)`, the assembled curve `γ` agrees with a model curve
+`piece k`, and the Cauchy-kernel principal value exists along that model curve.  Then the winding
+number of `γ` over the whole partition is the sum of the winding numbers of the model curves.
+
+Agreement only on `uIoo` is sharp for this purpose: interval integrals ignore endpoints, and local
+agreement on the open interval also identifies derivatives there.  In Proposition 2.2 the model
+curves are the point-avoiding remainder and the finitely many model sectors. -/
+theorem windingNumber_eq_sum_range_of_eqOn {n : ℕ} {t : ℕ → ℝ} (piece : ℕ → ℝ → ℂ)
+    (heq : ∀ k < n, Set.EqOn (piece k) γ (Set.uIoo (t k) (t (k + 1))))
+    (hpv : ∀ k < n, CauchyPVExistsAt (piece k) (t k) (t (k + 1)) κ[z₀] z₀) :
+    windingNumber γ (t 0) (t n) z₀ =
+      ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
+  have hpvγ : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀ :=
+    fun k hk => (hpv k hk).congr_curve (heq k hk)
+  calc
+    windingNumber γ (t 0) (t n) z₀ =
+        ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ :=
+      windingNumber_eq_sum_range hpvγ
+    _ = ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
+      apply Finset.sum_congr rfl
+      intro k hk
+      exact (windingNumber_congr_curve (heq k (Finset.mem_range.mp hk))).symm
+
+end TauCeti.Contour
+
+end

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -5,7 +5,7 @@ Authors: Tau Ceti contributors
 -/
 module
 
-public import TauCeti.Analysis.Contour.Winding.Number.Concat
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
 
 /-!
 # Finite partitions of contour winding numbers
@@ -102,20 +102,16 @@ theorem windingNumber_eq_sum_range_of_eqOn {n : ℕ} {t : ℕ → ℝ} (piece : 
     (hpv : ∀ k < n, CauchyPVExistsAt (piece k) (t k) (t (k + 1)) κ[z₀] z₀) :
     windingNumber γ (t 0) (t n) z₀ =
       ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
-  apply windingNumber_eq_sum_range_of_ae piece (hpv := hpv)
-  · intro k hk
-    have hrestrict : MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))) =
-        MeasureTheory.volume.restrict (Set.uIoo (t k) (t (k + 1))) :=
-      MeasureTheory.restrict_Ioo_eq_restrict_Ioc.symm
-    rw [hrestrict]
-    exact (heq k hk).aeEq_restrict measurableSet_Ioo
-  · intro k hk
-    have hrestrict : MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))) =
-        MeasureTheory.volume.restrict (Set.uIoo (t k) (t (k + 1))) :=
-      MeasureTheory.restrict_Ioo_eq_restrict_Ioc.symm
-    rw [hrestrict]
-    exact ((heq k hk).deriv isOpen_Ioo).aeEq_restrict measurableSet_Ioo |>.mono
-      fun _ hs _ => hs
+  have hpvγ : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀ :=
+    fun k hk => (hpv k hk).congr_curve (heq k hk)
+  calc
+    windingNumber γ (t 0) (t n) z₀ =
+        ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ :=
+      windingNumber_eq_sum_range hpvγ
+    _ = ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
+      apply Finset.sum_congr rfl
+      intro k hk
+      exact (windingNumber_congr_curve (heq k (Finset.mem_range.mp hk))).symm
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -27,10 +27,8 @@ as an API statement even though it looked formally convenient.
 
 ## Main results
 
-* `Contour.hasCauchyPVAt_inv_sub_sum_range` concatenates explicit Cauchy-kernel principal values
-  over a finite partition.
-* `Contour.windingNumber_eq_sum_range` writes the winding number on the whole interval as the sum
-  over its adjacent pieces.
+* `Contour.windingNumber_eq_sum_range` uses the generic finite principal-value concatenation API
+  to write a winding number as a sum over a finite partition.
 * `Contour.windingNumber_eq_sum_range_of_eqOn` allows each piece to be computed using a different
   curve that agrees with the assembled curve on that open subinterval.  This is the form used by
   an avoiding-part plus model-sector decomposition.
@@ -53,30 +51,6 @@ variable {γ : ℝ → ℂ} {z₀ : ℂ}
 /-- The Cauchy kernel about `z₀`, used throughout the winding-number API. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
-/-- **Finite concatenation of explicit Cauchy-kernel principal values.**  If the principal value
-on every adjacent interval `[t k, t (k + 1)]` is `L k`, then the principal value on
-`[t 0, t n]` is their sum.  The endpoints need not be ordered. -/
-theorem hasCauchyPVAt_inv_sub_sum_range {n : ℕ} {t : ℕ → ℝ} {L : ℕ → ℂ}
-    (h : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k)) :
-    HasCauchyPVAt γ (t 0) (t n) κ[z₀] z₀ (∑ k ∈ Finset.range n, L k) := by
-  induction n with
-  | zero =>
-      simpa using HasCauchyPVAt.refl γ (t 0) κ[z₀] z₀
-  | succ n ih =>
-      have hprefix : HasCauchyPVAt γ (t 0) (t n) κ[z₀] z₀
-          (∑ k ∈ Finset.range n, L k) :=
-        ih fun k hk => h k (hk.trans n.lt_succ_self)
-      simpa only [Finset.sum_range_succ] using hprefix.concat (h n n.lt_succ_self)
-
-/-- Existence of the Cauchy-kernel principal value on every adjacent interval of a finite
-partition gives existence on the whole interval. -/
-theorem cauchyPVExistsAt_inv_sub_of_forall_lt {n : ℕ} {t : ℕ → ℝ}
-    (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀) :
-    CauchyPVExistsAt γ (t 0) (t n) κ[z₀] z₀ := by
-  refine CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_sum_range (L := fun k =>
-    cauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀) ?_)
-  exact fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
-
 /-- **Finite-partition additivity of the generalized winding number.**  If the Cauchy-kernel
 principal value exists on every adjacent interval, the winding number from `t 0` to `t n` is the
 sum of the winding numbers of those pieces. -/
@@ -87,7 +61,7 @@ theorem windingNumber_eq_sum_range {n : ℕ} {t : ℕ → ℝ}
   let L : ℕ → ℂ := fun k => cauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀
   have hpiece : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k) :=
     fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
-  rw [windingNumber_eq_of_hasCauchyPVAt (hasCauchyPVAt_inv_sub_sum_range hpiece),
+  rw [windingNumber_eq_of_hasCauchyPVAt (HasCauchyPVAt.concat_range hpiece),
     Finset.mul_sum]
   apply Finset.sum_congr rfl
   intro k hk

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -29,9 +29,10 @@ as an API statement even though it looked formally convenient.
 
 * `Contour.windingNumber_eq_sum_range` uses the generic finite principal-value concatenation API
   to write a winding number as a sum over a finite partition.
+* `Contour.windingNumber_eq_sum_range_of_ae` allows each piece to be computed using a different
+  curve under the principal-value API's almost-everywhere curve and derivative hypotheses.
 * `Contour.windingNumber_eq_sum_range_of_eqOn` allows each piece to be computed using a different
-  curve that agrees with the assembled curve on that open subinterval.  This is the form used by
-  an avoiding-part plus model-sector decomposition.
+  curve that agrees with the assembled curve on that open subinterval.
 
 ## Provenance
 
@@ -58,30 +59,25 @@ theorem windingNumber_eq_sum_range {n : ℕ} {t : ℕ → ℝ}
     (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀) :
     windingNumber γ (t 0) (t n) z₀ =
       ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ := by
-  let L : ℕ → ℂ := fun k => cauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀
-  have hpiece : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k) :=
-    fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
-  rw [windingNumber_eq_of_hasCauchyPVAt (HasCauchyPVAt.concat_range hpiece),
-    Finset.mul_sum]
+  rw [windingNumber_eq_cauchyPVAt, cauchyPVAt_concat_range h, Finset.mul_sum]
   apply Finset.sum_congr rfl
-  intro k hk
-  rw [windingNumber_eq_of_hasCauchyPVAt (h k (Finset.mem_range.mp hk)).hasCauchyPVAt_cauchyPVAt]
+  intro k _
+  rw [windingNumber_eq_cauchyPVAt]
 
-/-- **Finite winding decomposition using separately computed pieces.**  Suppose that on the open
-subinterval between `t k` and `t (k + 1)`, the assembled curve `γ` agrees with a model curve
-`piece k`, and the Cauchy-kernel principal value exists along that model curve.  Then the winding
-number of `γ` over the whole partition is the sum of the winding numbers of the model curves.
-
-Agreement only on `uIoo` is sharp for this purpose: interval integrals ignore endpoints, and local
-agreement on the open interval also identifies derivatives there.  In Proposition 2.2 the model
-curves are the point-avoiding remainder and the finitely many model sectors. -/
-theorem windingNumber_eq_sum_range_of_eqOn {n : ℕ} {t : ℕ → ℝ} (piece : ℕ → ℝ → ℂ)
-    (heq : ∀ k < n, Set.EqOn (piece k) γ (Set.uIoo (t k) (t (k + 1))))
+/-- **Finite winding decomposition using a.e.-equal, separately computed pieces.** Suppose that
+on each adjacent interval the model curve and assembled curve, and their derivatives off `z₀`,
+agree almost everywhere. If the Cauchy-kernel principal value exists along every model curve, the
+winding number of the assembled curve is the sum of the model-curve winding numbers. -/
+theorem windingNumber_eq_sum_range_of_ae {n : ℕ} {t : ℕ → ℝ} (piece : ℕ → ℝ → ℂ)
+    (heq : ∀ k < n, piece k =ᵐ[MeasureTheory.volume.restrict
+      (Set.uIoc (t k) (t (k + 1)))] γ)
+    (hderiv : ∀ k < n, ∀ᵐ s ∂MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))),
+      piece k s ≠ z₀ → deriv (piece k) s = deriv γ s)
     (hpv : ∀ k < n, CauchyPVExistsAt (piece k) (t k) (t (k + 1)) κ[z₀] z₀) :
     windingNumber γ (t 0) (t n) z₀ =
       ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
   have hpvγ : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀ :=
-    fun k hk => (hpv k hk).congr_curve (heq k hk)
+    fun k hk => (hpv k hk).congr_curve_ae (heq k hk) (hderiv k hk)
   calc
     windingNumber γ (t 0) (t n) z₀ =
         ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ :=
@@ -89,7 +85,37 @@ theorem windingNumber_eq_sum_range_of_eqOn {n : ℕ} {t : ℕ → ℝ} (piece : 
     _ = ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
       apply Finset.sum_congr rfl
       intro k hk
-      exact (windingNumber_congr_curve (heq k (Finset.mem_range.mp hk))).symm
+      exact (windingNumber_congr_curve_ae (heq k (Finset.mem_range.mp hk))
+        (hderiv k (Finset.mem_range.mp hk))).symm
+
+/-- **Finite winding decomposition using separately computed pieces.**  Suppose that on the open
+subinterval between `t k` and `t (k + 1)`, the assembled curve `γ` agrees with a model curve
+`piece k`, and the Cauchy-kernel principal value exists along that model curve.  Then the winding
+number of `γ` over the whole partition is the sum of the winding numbers of the model curves.
+
+This convenient pointwise form follows from `windingNumber_eq_sum_range_of_ae`: interval integrals
+ignore endpoints, and local equality on an open interval also identifies derivatives there. In
+Proposition 2.2 the model curves are the point-avoiding remainder and the finitely many model
+sectors. -/
+theorem windingNumber_eq_sum_range_of_eqOn {n : ℕ} {t : ℕ → ℝ} (piece : ℕ → ℝ → ℂ)
+    (heq : ∀ k < n, Set.EqOn (piece k) γ (Set.uIoo (t k) (t (k + 1))))
+    (hpv : ∀ k < n, CauchyPVExistsAt (piece k) (t k) (t (k + 1)) κ[z₀] z₀) :
+    windingNumber γ (t 0) (t n) z₀ =
+      ∑ k ∈ Finset.range n, windingNumber (piece k) (t k) (t (k + 1)) z₀ := by
+  apply windingNumber_eq_sum_range_of_ae piece (hpv := hpv)
+  · intro k hk
+    have hrestrict : MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))) =
+        MeasureTheory.volume.restrict (Set.uIoo (t k) (t (k + 1))) :=
+      MeasureTheory.restrict_Ioo_eq_restrict_Ioc.symm
+    rw [hrestrict]
+    exact (heq k hk).aeEq_restrict measurableSet_Ioo
+  · intro k hk
+    have hrestrict : MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))) =
+        MeasureTheory.volume.restrict (Set.uIoo (t k) (t (k + 1))) :=
+      MeasureTheory.restrict_Ioo_eq_restrict_Ioc.symm
+    rw [hrestrict]
+    exact ((heq k hk).deriv isOpen_Ioo).aeEq_restrict measurableSet_Ioo |>.mono
+      fun _ hs _ => hs
 
 end TauCeti.Contour
 

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -27,6 +27,8 @@ as an API statement even though it looked formally convenient.
 
 ## Main results
 
+* `Contour.windingNumber_eq_sum_range_of_hasCauchyPVAt` proves finite additivity from explicit
+  principal-value witnesses on every adjacent interval.
 * `Contour.windingNumber_eq_sum_range` uses the generic finite principal-value concatenation API
   to write a winding number as a sum over a finite partition.
 * `Contour.windingNumber_eq_sum_range_of_ae` allows each piece to be computed using a different
@@ -52,6 +54,18 @@ variable {γ : ℝ → ℂ} {z₀ : ℂ}
 /-- The Cauchy kernel about `z₀`, used throughout the winding-number API. -/
 local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 
+/-- **Finite-partition additivity from explicit principal-value witnesses.** If the Cauchy-kernel
+principal value on every adjacent interval is `L k`, the winding number from `t 0` to `t n` is the
+sum of the winding numbers of those pieces. -/
+theorem windingNumber_eq_sum_range_of_hasCauchyPVAt {n : ℕ} {t : ℕ → ℝ} {L : ℕ → ℂ}
+    (h : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) κ[z₀] z₀ (L k)) :
+    windingNumber γ (t 0) (t n) z₀ =
+      ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ := by
+  rw [windingNumber_eq_of_hasCauchyPVAt (HasCauchyPVAt.concat_range h), Finset.mul_sum]
+  apply Finset.sum_congr rfl
+  intro k hk
+  rw [windingNumber_eq_of_hasCauchyPVAt (h k (Finset.mem_range.mp hk))]
+
 /-- **Finite-partition additivity of the generalized winding number.**  If the Cauchy-kernel
 principal value exists on every adjacent interval, the winding number from `t 0` to `t n` is the
 sum of the winding numbers of those pieces. -/
@@ -59,10 +73,8 @@ theorem windingNumber_eq_sum_range {n : ℕ} {t : ℕ → ℝ}
     (h : ∀ k < n, CauchyPVExistsAt γ (t k) (t (k + 1)) κ[z₀] z₀) :
     windingNumber γ (t 0) (t n) z₀ =
       ∑ k ∈ Finset.range n, windingNumber γ (t k) (t (k + 1)) z₀ := by
-  rw [windingNumber_eq_cauchyPVAt, cauchyPVAt_concat_range h, Finset.mul_sum]
-  apply Finset.sum_congr rfl
-  intro k _
-  rw [windingNumber_eq_cauchyPVAt]
+  exact windingNumber_eq_sum_range_of_hasCauchyPVAt
+    fun k hk => (h k hk).hasCauchyPVAt_cauchyPVAt
 
 /-- **Finite winding decomposition using a.e.-equal, separately computed pieces.** Suppose that
 on each adjacent interval the model curve and assembled curve, and their derivatives off `z₀`,


### PR DESCRIPTION
This PR adds finite-partition additivity for the generalized winding number: concatenate explicit Cauchy-kernel principal values over adjacent intervals, propagate existence to the whole partition, identify the winding number on `[t 0, t n]` with the finite sum over its pieces, and permit each piece to be evaluated using a separate curve that agrees with the assembled curve on the corresponding open subinterval. Keep principal-value existence explicit throughout, because the `limUnder`-based winding number has no meaningful unconditional additivity when the defining principal value does not exist.

This advances `TauCetiRoadmap/ContourIntegration/README.md`, Layer 1, the item “HW Proposition 2.2 (finite crossings and the winding decomposition),” specifically the finite-additivity prerequisite for the asserted decomposition `n_{z₀}(Λ) = n_{z₀}(Λ̃) + Σ_ℓ α_ℓ/2π`. The crossing-finiteness theorem, pairwise concatenation, and model-sector values already exist on `main`; the missing bookkeeping step was to pass from pairwise concatenation to a finite family and to replace each assembled subinterval by its independently computed avoiding or model-sector curve. This PR supplies that step but does not claim to construct the geometric decomposition itself.

The result is stated for an arbitrary endpoint map `t : ℕ → ℝ`, with no monotonicity hypothesis: oriented interval integrals telescope across arbitrary adjacent endpoints, and `HasCauchyPVAt.concat` already proves the corresponding two-piece fact without ordering assumptions. The separately-computed-pieces theorem assumes `Set.EqOn` only on `Set.uIoo`; this is the sharp existing congruence interface because interval endpoints are invisible and equality on the open interval identifies the derivatives there.

The implementation reuses `TauCeti.Contour.HasCauchyPVAt.concat`, `CauchyPVExistsAt.hasCauchyPVAt_cauchyPVAt`, `windingNumber_eq_of_hasCauchyPVAt`, and `windingNumber_congr_curve`, together with Mathlib's `Finset.sum_range_succ` and finite-sum API. No Mathlib or AINTLIB code or infrastructure is vendored. The mathematical role is attributed in the module docstring to N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue Theorem*, Proposition 2.2.

The new file is `TauCeti/Analysis/Contour/Winding/Number/Partition.lean` (122 lines). `lake exe cache get` exits 0; `lake build` reports `Build completed successfully (6094 jobs).`; `lake exe axioms` reports `axioms: audited 18191 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` The supplemental module-system check covers all 1004 TauCeti modules, and the lint ratchet reports no new violations.

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"winding-number-finite-partition"}-->

Roadmap: ContourIntegration

🤖 Prepared with Codex
