### PR TITLE
feat(Multiquadratic): totally positive elements and their unit subgroup

### DIFF
--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -14,8 +14,9 @@ every real embedding `K →+* ℝ` — equivalently, at every real infinite plac
 positivity condition underlying the *narrow* class group of the multiquadratic roadmap (Layer 3):
 the narrow class group `Cl⁺(K)` is the quotient of the fractional ideals by the principal ideals
 admitting a totally positive generator. It surjects onto the ordinary class group `Cl(K)`
-(forgetting the positivity condition), and the `2`-rank of `Cl⁺(K)` is what the `t - 1` formula
-computes in the real case.
+(forgetting the positivity condition), and the `2`-rank of `Cl⁺(K)` is what the genus-theory
+`t - 1` formula (with `t` the number of ramified primes) computes for a **real quadratic** field
+in the multiquadratic roadmap.
 
 This file introduces the predicate and its multiplicative structure. The totally positive elements
 are closed under multiplication and inversion and contain every nonzero square, so the totally
@@ -49,7 +50,7 @@ def IsTotallyPositive (x : K) : Prop :=
 
 /-- Introduction and elimination form of `IsTotallyPositive`: total positivity is exactly strict
 positivity at every real infinite place. -/
-theorem isTotallyPositive_iff {x : K} :
+@[simp, grind =] theorem isTotallyPositive_iff {x : K} :
     IsTotallyPositive x ↔ ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x :=
   Iff.rfl
 
@@ -94,6 +95,8 @@ def totallyPositiveUnits : Subgroup Kˣ where
     change IsTotallyPositive ((x⁻¹ : Kˣ) : K)
     rw [Units.val_inv_eq_inv_val]; exact hx.inv
 
+/-- A unit lies in `totallyPositiveUnits` exactly when its underlying field element is totally
+positive. -/
 @[simp]
 theorem mem_totallyPositiveUnits {u : Kˣ} :
     u ∈ totallyPositiveUnits ↔ IsTotallyPositive (u : K) := Iff.rfl

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
+
+/-!
+# Totally positive elements of a number field
+
+An element `x` of a number field `K` is **totally positive** when it is strictly positive under
+every real embedding `K →+* ℝ` — equivalently, at every real infinite place. This is the
+archimedean positivity condition that distinguishes the *narrow* class group from the ordinary one:
+the narrow class group of the multiquadratic roadmap (Layer 3) is the quotient of the fractional
+ideals by the principal ideals with a totally positive generator, and its `2`-rank is what the
+`t - 1` genus-theory formula computes in the real case.
+
+This file introduces the predicate and its multiplicative structure. The totally positive elements
+are closed under multiplication and inversion and contain every nonzero square, so the totally
+positive units form a subgroup of `Kˣ` containing the squares — the subgroup by which the narrow
+class group refines the ordinary one. The statements are made at the level of a field with its
+infinite places (`[Field K]`); for a totally complex field the condition is vacuous.
+
+## Main definitions and results
+
+* `TauCeti.NumberField.IsTotallyPositive`: strict positivity at every real place.
+* `TauCeti.NumberField.IsTotallyPositive.mul`, `isTotallyPositive_one`, `IsTotallyPositive.inv`,
+  `isTotallyPositive_sq`: the multiplicative structure, including that nonzero squares are totally
+  positive.
+* `TauCeti.NumberField.totallyPositiveUnits`: the subgroup of totally positive units of `Kˣ`, with
+  `sq_mem_totallyPositiveUnits` recording that it contains every square.
+-/
+
+public section
+
+open NumberField InfinitePlace
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K]
+
+/-- An element of a number field is **totally positive** when it is strictly positive under every
+real embedding `K →+* ℝ` (equivalently, at every real infinite place `w`). For a totally complex
+field the condition is vacuous; the content is at the real places. -/
+def IsTotallyPositive (x : K) : Prop :=
+  ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x
+
+@[simp]
+theorem isTotallyPositive_one : IsTotallyPositive (1 : K) := fun _ _ => by
+  rw [map_one]; exact one_pos
+
+theorem IsTotallyPositive.mul {x y : K} (hx : IsTotallyPositive x) (hy : IsTotallyPositive y) :
+    IsTotallyPositive (x * y) := fun w hw => by
+  rw [map_mul]; exact mul_pos (hx w hw) (hy w hw)
+
+/-- A totally positive element has a totally positive inverse: real embeddings send inverses to
+inverses, and the reciprocal of a positive real is positive. -/
+theorem IsTotallyPositive.inv {x : K} (hx : IsTotallyPositive x) : IsTotallyPositive x⁻¹ :=
+  fun w hw => by rw [map_inv₀]; exact inv_pos.mpr (hx w hw)
+
+/-- Every nonzero square is totally positive: at each real place its value is the square of a
+nonzero real. -/
+theorem isTotallyPositive_sq {x : K} (hx : x ≠ 0) : IsTotallyPositive (x ^ 2) := fun w hw => by
+  rw [map_pow]
+  exact sq_pos_iff.mpr fun h => hx ((embedding_of_isReal hw).injective (h.trans (map_zero _).symm))
+
+/-- The subgroup of **totally positive units** of `Kˣ`: those units whose underlying element is
+totally positive. The narrow class group is the quotient of the class group of ideals by the image
+of this subgroup. -/
+def totallyPositiveUnits : Subgroup Kˣ where
+  carrier := {u | IsTotallyPositive (u : K)}
+  one_mem' := by
+    change IsTotallyPositive ((1 : Kˣ) : K)
+    rw [Units.val_one]; exact isTotallyPositive_one
+  mul_mem' {x y} hx hy := by
+    change IsTotallyPositive ((x * y : Kˣ) : K)
+    rw [Units.val_mul]; exact IsTotallyPositive.mul hx hy
+  inv_mem' {x} hx := by
+    change IsTotallyPositive ((x⁻¹ : Kˣ) : K)
+    rw [Units.val_inv_eq_inv_val]; exact hx.inv
+
+@[simp]
+theorem mem_totallyPositiveUnits {u : Kˣ} :
+    u ∈ totallyPositiveUnits ↔ IsTotallyPositive (u : K) := Iff.rfl
+
+/-- The subgroup of totally positive units contains every square, so the narrow class group
+receives the squares of the ordinary class group. -/
+theorem sq_mem_totallyPositiveUnits (u : Kˣ) : u ^ 2 ∈ totallyPositiveUnits := by
+  rw [mem_totallyPositiveUnits, Units.val_pow_eq_pow_val]
+  exact isTotallyPositive_sq (Units.ne_zero u)
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -54,8 +54,8 @@ positivity at every real infinite place. -/
     IsTotallyPositive x ↔ ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x :=
   Iff.rfl
 
-/-- The element `1` is totally positive: every real embedding sends it to `1 > 0`. -/
-@[simp]
+/-- The element `1` is totally positive: every real embedding sends it to `1 > 0`. (Not a `simp`
+lemma: with `isTotallyPositive_iff` as `simp`, this is already discharged automatically.) -/
 theorem isTotallyPositive_one : IsTotallyPositive (1 : K) :=
   isTotallyPositive_iff.mpr fun _ _ => by rw [map_one]; exact one_pos
 

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -54,8 +54,7 @@ positivity at every real infinite place. -/
     IsTotallyPositive x ↔ ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x :=
   Iff.rfl
 
-/-- The element `1` is totally positive: every real embedding sends it to `1 > 0`. (Not a `simp`
-lemma: with `isTotallyPositive_iff` as `simp`, this is already discharged automatically.) -/
+/-- The element `1` is totally positive: every real embedding sends it to `1 > 0`. -/
 theorem isTotallyPositive_one : IsTotallyPositive (1 : K) :=
   isTotallyPositive_iff.mpr fun _ _ => by rw [map_one]; exact one_pos
 
@@ -74,32 +73,24 @@ theorem IsTotallyPositive.inv {x : K} (hx : IsTotallyPositive x) : IsTotallyPosi
 nonzero real. -/
 theorem isTotallyPositive_sq {x : K} (hx : x ≠ 0) : IsTotallyPositive (x ^ 2) :=
   isTotallyPositive_iff.mpr fun w hw => by
-    rw [map_pow]
-    exact sq_pos_iff.mpr fun h =>
-      hx ((embedding_of_isReal hw).injective (h.trans (map_zero _).symm))
+    rw [map_pow]; exact sq_pos_iff.mpr ((map_ne_zero _).mpr hx)
 
-/-- The subgroup of **totally positive units** of `Kˣ`: those units whose underlying element is
-totally positive. It is the kernel of the sign (signature) map on units, and controls the
-comparison between the narrow class group `Cl⁺(K)` and the ordinary class group `Cl(K)`. -/
-def totallyPositiveUnits : Subgroup Kˣ where
-  carrier := {u | IsTotallyPositive (u : K)}
-  -- Each proof `change`s across the carrier `{u | IsTotallyPositive ↑u}` and the unit coercion
-  -- (`↑(1 : Kˣ) = 1`, `↑(x * y) = ↑x * ↑y`, `↑x⁻¹ = (↑x)⁻¹`) to reduce to the element-level lemma.
-  one_mem' := by
-    change IsTotallyPositive ((1 : Kˣ) : K)
-    rw [Units.val_one]; exact isTotallyPositive_one
-  mul_mem' {x y} hx hy := by
-    change IsTotallyPositive ((x * y : Kˣ) : K)
-    rw [Units.val_mul]; exact IsTotallyPositive.mul hx hy
-  inv_mem' {x} hx := by
-    change IsTotallyPositive ((x⁻¹ : Kˣ) : K)
-    rw [Units.val_inv_eq_inv_val]; exact hx.inv
+/-- The subgroup of **totally positive units** of `Kˣ`: the intersection, over the real infinite
+places `w`, of the preimages of the positive units of `ℝ` under the real embedding `w`. It is the
+kernel of the sign (signature) map on units, and controls the comparison between the narrow class
+group `Cl⁺(K)` and the ordinary class group `Cl(K)`. -/
+noncomputable def totallyPositiveUnits : Subgroup Kˣ :=
+  ⨅ (w : InfinitePlace K) (hw : w.IsReal),
+    (Units.posSubgroup ℝ).comap (Units.map (embedding_of_isReal hw).toMonoidHom)
 
 /-- A unit lies in `totallyPositiveUnits` exactly when its underlying field element is totally
 positive. -/
 @[simp]
 theorem mem_totallyPositiveUnits {u : Kˣ} :
-    u ∈ totallyPositiveUnits ↔ IsTotallyPositive (u : K) := Iff.rfl
+    u ∈ totallyPositiveUnits ↔ IsTotallyPositive (u : K) := by
+  simp only [totallyPositiveUnits, Subgroup.mem_iInf, Subgroup.mem_comap,
+    Units.mem_posSubgroup, Units.coe_map, RingHom.toMonoidHom_eq_coe, MonoidHom.coe_coe,
+    isTotallyPositive_iff]
 
 /-- Every square of a unit is a totally positive unit. -/
 theorem sq_mem_totallyPositiveUnits (u : Kˣ) : u ^ 2 ∈ totallyPositiveUnits := by

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -10,26 +10,27 @@ public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
 # Totally positive elements of a number field
 
 An element `x` of a number field `K` is **totally positive** when it is strictly positive under
-every real embedding `K →+* ℝ` — equivalently, at every real infinite place. This is the
-archimedean positivity condition that distinguishes the *narrow* class group from the ordinary one:
-the narrow class group of the multiquadratic roadmap (Layer 3) is the quotient of the fractional
-ideals by the principal ideals with a totally positive generator, and its `2`-rank is what the
-`t - 1` genus-theory formula computes in the real case.
+every real embedding `K →+* ℝ` — equivalently, at every real infinite place. This is the archimedean
+positivity condition underlying the *narrow* class group of the multiquadratic roadmap (Layer 3):
+the narrow class group `Cl⁺(K)` is the quotient of the fractional ideals by the principal ideals
+admitting a totally positive generator. It surjects onto the ordinary class group `Cl(K)`
+(forgetting the positivity condition), and the `2`-rank of `Cl⁺(K)` is what the `t - 1` formula
+computes in the real case.
 
 This file introduces the predicate and its multiplicative structure. The totally positive elements
 are closed under multiplication and inversion and contain every nonzero square, so the totally
-positive units form a subgroup of `Kˣ` containing the squares — the subgroup by which the narrow
-class group refines the ordinary one. The statements are made at the level of a field with its
-infinite places (`[Field K]`); for a totally complex field the condition is vacuous.
+positive units form a subgroup of `Kˣ`. That subgroup is the kernel of the sign (signature) map on
+units; the signs *not* realized by units measure the difference between `Cl⁺(K)` and `Cl(K)`.
 
 ## Main definitions and results
 
-* `TauCeti.NumberField.IsTotallyPositive`: strict positivity at every real place.
-* `TauCeti.NumberField.IsTotallyPositive.mul`, `isTotallyPositive_one`, `IsTotallyPositive.inv`,
+* `TauCeti.NumberField.IsTotallyPositive`: strict positivity at every real place, with
+  `isTotallyPositive_iff` its introduction/elimination form.
+* `TauCeti.NumberField.isTotallyPositive_one`, `IsTotallyPositive.mul`, `IsTotallyPositive.inv`,
   `isTotallyPositive_sq`: the multiplicative structure, including that nonzero squares are totally
   positive.
-* `TauCeti.NumberField.totallyPositiveUnits`: the subgroup of totally positive units of `Kˣ`, with
-  `sq_mem_totallyPositiveUnits` recording that it contains every square.
+* `TauCeti.NumberField.totallyPositiveUnits`: the subgroup of totally positive units of `Kˣ` (the
+  kernel of the unit signature map), with `sq_mem_totallyPositiveUnits`.
 -/
 
 public section
@@ -46,30 +47,43 @@ field the condition is vacuous; the content is at the real places. -/
 def IsTotallyPositive (x : K) : Prop :=
   ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x
 
-@[simp]
-theorem isTotallyPositive_one : IsTotallyPositive (1 : K) := fun _ _ => by
-  rw [map_one]; exact one_pos
+/-- Introduction and elimination form of `IsTotallyPositive`: total positivity is exactly strict
+positivity at every real infinite place. -/
+theorem isTotallyPositive_iff {x : K} :
+    IsTotallyPositive x ↔ ∀ (w : InfinitePlace K) (hw : w.IsReal), 0 < embedding_of_isReal hw x :=
+  Iff.rfl
 
+/-- The element `1` is totally positive: every real embedding sends it to `1 > 0`. -/
+@[simp]
+theorem isTotallyPositive_one : IsTotallyPositive (1 : K) :=
+  isTotallyPositive_iff.mpr fun _ _ => by rw [map_one]; exact one_pos
+
+/-- Totally positive elements are closed under multiplication: a product of positives is positive at
+each real place. -/
 theorem IsTotallyPositive.mul {x y : K} (hx : IsTotallyPositive x) (hy : IsTotallyPositive y) :
-    IsTotallyPositive (x * y) := fun w hw => by
-  rw [map_mul]; exact mul_pos (hx w hw) (hy w hw)
+    IsTotallyPositive (x * y) :=
+  isTotallyPositive_iff.mpr fun w hw => by rw [map_mul]; exact mul_pos (hx w hw) (hy w hw)
 
 /-- A totally positive element has a totally positive inverse: real embeddings send inverses to
 inverses, and the reciprocal of a positive real is positive. -/
 theorem IsTotallyPositive.inv {x : K} (hx : IsTotallyPositive x) : IsTotallyPositive x⁻¹ :=
-  fun w hw => by rw [map_inv₀]; exact inv_pos.mpr (hx w hw)
+  isTotallyPositive_iff.mpr fun w hw => by rw [map_inv₀]; exact inv_pos.mpr (hx w hw)
 
 /-- Every nonzero square is totally positive: at each real place its value is the square of a
 nonzero real. -/
-theorem isTotallyPositive_sq {x : K} (hx : x ≠ 0) : IsTotallyPositive (x ^ 2) := fun w hw => by
-  rw [map_pow]
-  exact sq_pos_iff.mpr fun h => hx ((embedding_of_isReal hw).injective (h.trans (map_zero _).symm))
+theorem isTotallyPositive_sq {x : K} (hx : x ≠ 0) : IsTotallyPositive (x ^ 2) :=
+  isTotallyPositive_iff.mpr fun w hw => by
+    rw [map_pow]
+    exact sq_pos_iff.mpr fun h =>
+      hx ((embedding_of_isReal hw).injective (h.trans (map_zero _).symm))
 
 /-- The subgroup of **totally positive units** of `Kˣ`: those units whose underlying element is
-totally positive. The narrow class group is the quotient of the class group of ideals by the image
-of this subgroup. -/
+totally positive. It is the kernel of the sign (signature) map on units, and controls the
+comparison between the narrow class group `Cl⁺(K)` and the ordinary class group `Cl(K)`. -/
 def totallyPositiveUnits : Subgroup Kˣ where
   carrier := {u | IsTotallyPositive (u : K)}
+  -- Each proof `change`s across the carrier `{u | IsTotallyPositive ↑u}` and the unit coercion
+  -- (`↑(1 : Kˣ) = 1`, `↑(x * y) = ↑x * ↑y`, `↑x⁻¹ = (↑x)⁻¹`) to reduce to the element-level lemma.
   one_mem' := by
     change IsTotallyPositive ((1 : Kˣ) : K)
     rw [Units.val_one]; exact isTotallyPositive_one
@@ -84,8 +98,7 @@ def totallyPositiveUnits : Subgroup Kˣ where
 theorem mem_totallyPositiveUnits {u : Kˣ} :
     u ∈ totallyPositiveUnits ↔ IsTotallyPositive (u : K) := Iff.rfl
 
-/-- The subgroup of totally positive units contains every square, so the narrow class group
-receives the squares of the ordinary class group. -/
+/-- Every square of a unit is a totally positive unit. -/
 theorem sq_mem_totallyPositiveUnits (u : Kˣ) : u ^ 2 ∈ totallyPositiveUnits := by
   rw [mem_totallyPositiveUnits, Units.val_pow_eq_pow_val]
   exact isTotallyPositive_sq (Units.ne_zero u)


### PR DESCRIPTION
Introduces the **total-positivity** apparatus of a number field — the first prerequisite for the
narrow class group (Layer 3, real case).

An element `x : K` is `IsTotallyPositive` when it is strictly positive under every real embedding
`K →+* ℝ` (equivalently, at every real infinite place), built on Mathlib's
`InfinitePlace.embedding_of_isReal`. The file provides:

- the predicate and its multiplicative API: `isTotallyPositive_one`, `IsTotallyPositive.mul`,
  `IsTotallyPositive.inv`, and `isTotallyPositive_sq` (every **nonzero square** is totally positive);
- `totallyPositiveUnits : Subgroup Kˣ`, the subgroup of totally positive units, with
  `mem_totallyPositiveUnits` and `sq_mem_totallyPositiveUnits` (it contains every square).

`totallyPositiveUnits` is exactly the subgroup by which the **narrow** class group refines the
ordinary one: the narrow class group is the quotient of the fractional ideals by the principal
ideals with a totally positive generator, and (since it contains the squares) `Cl_narrow/Cl_narrow²`
feeds the existing `TauCeti.ClassGroup.twoRank`. Sorry-free, default axioms; stated at `[Field K]`
generality (the level of Mathlib's infinite-place API).

**Roadmap.** Directly builds a prerequisite named in the multiquadratic roadmap's Layer 3: *"⚠ The
2-rank formula `= t − 1` … is a theorem about the *narrow* class group. … Mathlib has neither;
defining the narrow class group is part of this layer and the prerequisite for the real case."*
This PR is the total-positivity foundation of that narrow-class-group definition.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"Multiquadratic/narrow-class-group"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
