### PR TITLE
feat: add the opposite isomorphism for central simple algebras

### DIFF
--- a/TauCeti/Algebra/CentralSimple/Degree.lean
+++ b/TauCeti/Algebra/CentralSimple/Degree.lean
@@ -59,6 +59,10 @@ columns; that is recorded as
   `TauCeti.Algebra.deg_eq_mul_deg_of_algEquiv_matrix` off a Wedderburn presentation, and the
   splitting `TauCeti.IsSimpleRing.nonempty_algEquiv_matrix_baseChange_of_isAlgClosed` restated with
   matrix size `deg K A`.
+* `TauCeti.Algebra.finrank_tensorProduct_mulOpposite` and
+  `TauCeti.Algebra.deg_tensorProduct_mulOpposite`: the dimension `(Module.finrank K A) ^ 2` and the
+  degree `Module.finrank K A` of `A ⊗[K] Aᵐᵒᵖ`, for an arbitrary `K`-algebra `A`. These are the
+  counts behind `TauCeti/Algebra/CentralSimple/Opposite.lean`.
 
 ## Implementation notes
 
@@ -176,6 +180,32 @@ variable (K A)
 @[simp]
 theorem deg_self : deg K K = 1 :=
   deg_eq_of_finrank_eq_sq (by simp)
+
+/-- Passing to the opposite algebra does not change the dimension, so `A ⊗[K] Aᵐᵒᵖ` has dimension
+`(Module.finrank K A) ^ 2`. This is the count that turns injectivity of the Azumaya map into
+surjectivity in `TauCeti/Algebra/CentralSimple/Opposite.lean`, `Module.End K A` having the same
+dimension, and it is where the matrix size in `TauCeti.Algebra.tensorOpAlgEquivMatrix` comes from: a
+dimension, not a degree.
+
+No finiteness hypothesis is needed: if `A` is infinite-dimensional both sides are `0`. -/
+theorem finrank_tensorProduct_mulOpposite :
+    Module.finrank K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A ^ 2 := by
+  rw [Module.finrank_tensorProduct, ← (MulOpposite.opLinearEquiv K (M := A)).finrank_eq, sq]
+
+/-- The degree of `A ⊗[K] Aᵐᵒᵖ` is the dimension of `A`. For `A` central simple this is the square
+of the degree of `A` (`TauCeti.Algebra.deg_sq`), and it is the degree-level shadow of
+`TauCeti.Algebra.tensorOpAlgEquivMatrix`: the reason the matrix size there is `Module.finrank K A`
+rather than `TauCeti.Algebra.deg K A`.
+
+As with the dimension count it rests on, no hypothesis on `A` is needed: the dimension of
+`A ⊗[K] Aᵐᵒᵖ` is a square for every `K`-algebra, and that alone pins the degree.
+
+Not a `simp` lemma: as soon as `A` is central simple and finite-dimensional, so is `Aᵐᵒᵖ`, and then
+`TauCeti.Algebra.deg_tensorProduct` already rewrites the left-hand side, to
+`TauCeti.Algebra.deg K A * TauCeti.Algebra.deg K Aᵐᵒᵖ`. Marking this one `simp` too would leave
+`simp` with two different normal forms for the same term. -/
+theorem deg_tensorProduct_mulOpposite : deg K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A :=
+  deg_eq_of_finrank_eq_sq (finrank_tensorProduct_mulOpposite K A)
 
 section Nontrivial
 

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -77,7 +77,7 @@ subalgebra of the `4`-dimensional `Module.End ℝ ℂ`.
 * `TauCeti.Algebra.tensorOpAlgEquivEnd`: the resulting isomorphism
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`.
 * `TauCeti.Algebra.endAlgEquivMatrix`: the matrix half of the composite,
-  `Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `K`-algebra of dimension `n`.
+  `Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `K`-vector space of dimension `n`.
 * `TauCeti.Algebra.tensorOpAlgEquivMatrix`: **the opposite isomorphism**
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `n` with `Module.finrank K A = n`.
 
@@ -166,21 +166,21 @@ namespace Algebra
 
 section Basis
 
-variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [FiniteDimensional K A]
+variable (K : Type*) [Field K] (M : Type*) [AddCommGroup M] [Module K M] [FiniteDimensional K M]
 
-/-- A `K`-algebra `A` of dimension `n` has `Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the
-matrix half of the opposite isomorphism, read off a chosen `K`-basis of `A`.
+/-- A `K`-vector space `M` of dimension `n` has `Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the
+matrix half of the opposite isomorphism, read off a chosen `K`-basis of `M`.
 
 This is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`, named here because it
 is a step of the opposite isomorphism that the roadmap asks for separately, to be reused where a
-finite-dimensional endomorphism algebra has to be turned into matrices of a known size. Central
-simplicity plays no part: only the dimension does.
+finite-dimensional endomorphism algebra has to be turned into matrices of a known size. Neither an
+algebra structure on `M` nor central simplicity plays any part: only the dimension does.
 
 The basis is a choice, and nothing downstream should depend on which one it is; there is
 deliberately no lemma computing the matrix entries. -/
-noncomputable def endAlgEquivMatrix {n : ℕ} (hn : Module.finrank K A = n) :
-    Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
-  algEquivMatrix (Module.finBasisOfFinrankEq K A hn)
+noncomputable def endAlgEquivMatrix {n : ℕ} (hn : Module.finrank K M = n) :
+    Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
+  algEquivMatrix (Module.finBasisOfFinrankEq K M hn)
 
 end Basis
 

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -80,6 +80,14 @@ subalgebra of the `4`-dimensional `Module.End ℝ ℂ`.
 * `TauCeti.Algebra.tensorOpAlgEquivMatrix`: **the opposite isomorphism**
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `n` with `Module.finrank K A = n`.
 
+The last two are stated for `[IsAzumaya K A]`, which is all their construction uses: bijectivity of
+the Azumaya map is the field `IsAzumaya.bij`, and the finiteness the matrix half needs is the
+`Module.Finite K A` that `IsAzumaya` extends. Over a field this is not a wider class -- an Azumaya
+`K`-algebra is exactly a finite-dimensional central simple one -- but it is the hypothesis the
+construction actually reads, and the one already carried by an algebra known to be Azumaya for some
+other reason (Mathlib's `IsAzumaya.matrix`, `IsAzumaya.of_AlgEquiv`). For a central simple `A` the
+way in is `TauCeti.IsSimpleRing.isAzumaya`, installed with `haveI`.
+
 The real quaternions run all of this concretely in
 `TauCeti/Algebra/CentralSimple/Quaternion.lean`.
 
@@ -88,7 +96,13 @@ The real quaternions run all of this concretely in
 `TauCeti.IsSimpleRing.isAzumaya` is deliberately **not** an instance. Mathlib's
 `Algebra.IsCentral.instIsAzumaya` goes the other way, deducing `Algebra.IsCentral K A` from
 `IsAzumaya K A`; registering the converse as an instance would let typeclass search cycle between
-the two. Apply it with `haveI` where an `IsAzumaya` hypothesis is wanted.
+the two. Apply it with `haveI` where an `IsAzumaya` hypothesis is wanted, as the worked example at
+the end of this file does:
+
+```lean
+haveI := TauCeti.IsSimpleRing.isAzumaya K A
+TauCeti.Algebra.tensorOpAlgEquivMatrix K A hn
+```
 
 `TauCeti.Algebra.tensorOpAlgEquivMatrix` takes the matrix size as a parameter `n` together with a
 proof `Module.finrank K A = n`, rather than using `Module.finrank K A` itself. Instantiating `n` at
@@ -164,24 +178,30 @@ end IsSimpleRing
 
 namespace Algebra
 
-variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
-  [IsSimpleRing A] [FiniteDimensional K A]
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [IsAzumaya K A]
 
-/-- The Azumaya map of a finite-dimensional central simple algebra, promoted to an isomorphism
+/-- The Azumaya map of an Azumaya algebra, promoted to an isomorphism
 `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`. Its value on a pure tensor is
-`TauCeti.Algebra.tensorOpAlgEquivEnd_tmul_apply`. -/
+`TauCeti.Algebra.tensorOpAlgEquivEnd_tmul_apply`.
+
+Bijectivity is the field `IsAzumaya.bij`, so this needs no hypothesis beyond `IsAzumaya K A`. For a
+finite-dimensional central simple `A` that hypothesis is
+`TauCeti.IsSimpleRing.isAzumaya K A`, which is not an instance and has to be installed by hand:
+`haveI := TauCeti.IsSimpleRing.isAzumaya K A`. -/
 noncomputable def tensorOpAlgEquivEnd : A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A :=
-  AlgEquiv.ofBijective (AlgHom.mulLeftRight K A) (IsSimpleRing.mulLeftRight_bijective K A)
+  AlgEquiv.ofBijective (AlgHom.mulLeftRight K A) IsAzumaya.bij
 
 @[simp]
 theorem tensorOpAlgEquivEnd_tmul_apply (a : A) (b : Aᵐᵒᵖ) (x : A) :
     tensorOpAlgEquivEnd K A (a ⊗ₜ[K] b) x = a * x * b.unop :=
   AlgHom.mulLeftRight_apply K A a b x
 
-/-- **The opposite isomorphism.** A finite-dimensional central simple `K`-algebra `A` of dimension
-`n` satisfies `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the tensor product of a central simple
-algebra with its opposite is a full matrix algebra, which is what makes the Brauer class of `Aᵐᵒᵖ`
-the inverse of that of `A`.
+/-- **The opposite isomorphism.** An Azumaya `K`-algebra `A` of dimension `n` -- over a field, a
+finite-dimensional central simple algebra -- satisfies `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K`:
+the tensor product of a central simple algebra with its opposite is a full matrix algebra, which is
+what makes the Brauer class of `Aᵐᵒᵖ` the inverse of that of `A`. The finiteness needed to read a
+matrix off is the `Module.Finite K A` that `IsAzumaya` extends; for a central simple `A`, install
+the hypothesis with `haveI := TauCeti.IsSimpleRing.isAzumaya K A`.
 
 The size is the **dimension** `n = Module.finrank K A`, not the degree `TauCeti.Algebra.deg K A`;
 the two are related by `TauCeti.Algebra.deg_sq`, and the resulting degree count is
@@ -213,8 +233,11 @@ section Examples
 
 variable (K : Type*) [Field K]
 
-/-- The base field itself: `K ⊗[K] Kᵐᵒᵖ` is `1 × 1` matrices over `K`. -/
+/-- The base field itself: `K ⊗[K] Kᵐᵒᵖ` is `1 × 1` matrices over `K`. This is also how a central
+simple algebra reaches `TauCeti.Algebra.tensorOpAlgEquivMatrix` in general -- by installing
+`TauCeti.IsSimpleRing.isAzumaya`, which is not an instance. -/
 noncomputable example : K ⊗[K] Kᵐᵒᵖ ≃ₐ[K] Matrix (Fin 1) (Fin 1) K :=
+  haveI := IsSimpleRing.isAzumaya K K
   Algebra.tensorOpAlgEquivMatrix K K (Module.finrank_self K)
 
 end Examples

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -128,8 +128,12 @@ of the degree of `A` (`TauCeti.Algebra.deg_sq`), and it is the degree-level shad
 rather than `TauCeti.Algebra.deg K A`.
 
 As with the dimension count it rests on, no hypothesis on `A` is needed: the dimension of
-`A ⊗[K] Aᵐᵒᵖ` is a square for every `K`-algebra, and that alone pins the degree. -/
-@[simp]
+`A ⊗[K] Aᵐᵒᵖ` is a square for every `K`-algebra, and that alone pins the degree.
+
+Not a `simp` lemma: as soon as `A` is central simple and finite-dimensional, so is `Aᵐᵒᵖ`, and then
+`TauCeti.Algebra.deg_tensorProduct` already rewrites the left-hand side, to
+`TauCeti.Algebra.deg K A * TauCeti.Algebra.deg K Aᵐᵒᵖ`. Marking this one `simp` too would leave
+`simp` with two different normal forms for the same term. -/
 theorem deg_tensorProduct_mulOpposite : deg K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A :=
   deg_eq_of_finrank_eq_sq (finrank_tensorProduct_mulOpposite K A)
 

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -88,6 +88,10 @@ construction actually reads, and the one already carried by an algebra known to 
 other reason (Mathlib's `IsAzumaya.matrix`, `IsAzumaya.of_AlgEquiv`). For a central simple `A` the
 way in is `TauCeti.IsSimpleRing.isAzumaya`, installed with `haveI`.
 
+`TauCeti.Algebra.tensorOpAlgEquivEnd` uses nothing else, so it is stated over the commutative
+semiring `K` and semiring `A` that `IsAzumaya` itself is defined over. Only the matrix half needs a
+field, to read the isomorphism off a basis.
+
 The real quaternions run all of this concretely in
 `TauCeti/Algebra/CentralSimple/Quaternion.lean`.
 
@@ -178,23 +182,34 @@ end IsSimpleRing
 
 namespace Algebra
 
-variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [IsAzumaya K A]
+section Azumaya
+
+variable (K : Type*) [CommSemiring K] (A : Type*) [Semiring A] [Algebra K A] [IsAzumaya K A]
 
 /-- The Azumaya map of an Azumaya algebra, promoted to an isomorphism
 `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`. Its value on a pure tensor is
 `TauCeti.Algebra.tensorOpAlgEquivEnd_tmul_apply`.
 
-Bijectivity is the field `IsAzumaya.bij`, so this needs no hypothesis beyond `IsAzumaya K A`. For a
-finite-dimensional central simple `A` that hypothesis is
-`TauCeti.IsSimpleRing.isAzumaya K A`, which is not an instance and has to be installed by hand:
-`haveI := TauCeti.IsSimpleRing.isAzumaya K A`. -/
+Bijectivity is the field `IsAzumaya.bij`, so this needs no hypothesis beyond `IsAzumaya K A`, and in
+particular no field and no finiteness: it is stated over the commutative semiring `K` that
+`IsAzumaya` itself is defined over. For a finite-dimensional central simple `A` over a field the
+hypothesis is `TauCeti.IsSimpleRing.isAzumaya K A`, which is not an instance and has to be installed
+by hand: `haveI := TauCeti.IsSimpleRing.isAzumaya K A`. -/
 noncomputable def tensorOpAlgEquivEnd : A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A :=
   AlgEquiv.ofBijective (AlgHom.mulLeftRight K A) IsAzumaya.bij
 
+/-- The Azumaya isomorphism `TauCeti.Algebra.tensorOpAlgEquivEnd` sends a pure tensor `a ⊗ₜ b` to
+the endomorphism `x ↦ a * x * b.unop`, since it is `AlgHom.mulLeftRight` underneath. Pure tensors
+span `A ⊗[K] Aᵐᵒᵖ`, so this determines the isomorphism, and it is the only computation rule it
+needs. -/
 @[simp]
 theorem tensorOpAlgEquivEnd_tmul_apply (a : A) (b : Aᵐᵒᵖ) (x : A) :
     tensorOpAlgEquivEnd K A (a ⊗ₜ[K] b) x = a * x * b.unop :=
   AlgHom.mulLeftRight_apply K A a b x
+
+end Azumaya
+
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [IsAzumaya K A]
 
 /-- **The opposite isomorphism.** An Azumaya `K`-algebra `A` of dimension `n` -- over a field, a
 finite-dimensional central simple algebra -- satisfies `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K`:

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -12,11 +12,12 @@ module
 -- and the algebra structure on `A ⊗[K] Aᵐᵒᵖ`, both of which occur in the statements below) and
 -- `Mathlib.Algebra.Central.Basic`, which is why none of those is imported again here.
 public import TauCeti.Algebra.CentralSimple.Degree
--- `AlgHom.mulLeftRight` and `IsAzumaya` appear in the statements below, and `Matrix` together with
--- `algEquivMatrix` and `Module.finBasisOfFinrankEq` in the type and the body of the opposite
--- isomorphism.
+-- `AlgHom.mulLeftRight` and `IsAzumaya` appear in the statements below.
 public import Mathlib.Algebra.Azumaya.Defs
-public import Mathlib.LinearAlgebra.Matrix.ToLin
+-- `TauCeti.LinearAlgebra.Matrix.ToLin` is imported publicly for the matrix half of the opposite
+-- isomorphism, `TauCeti.Algebra.endAlgEquivMatrix`; it re-exports
+-- `Mathlib.LinearAlgebra.Matrix.ToLin` and with it the `Matrix` occurring in the statements below.
+public import TauCeti.LinearAlgebra.Matrix.ToLin
 -- Non-public: the dimension count for a space of linear maps and the rank-nullity consequence that
 -- an injective linear map between equidimensional spaces is surjective are used only inside proofs,
 -- so downstream importers do not pay for them.
@@ -76,8 +77,6 @@ subalgebra of the `4`-dimensional `Module.End ℝ ℂ`.
   its base field.
 * `TauCeti.Algebra.tensorOpAlgEquivEnd`: the resulting isomorphism
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`.
-* `TauCeti.Algebra.endAlgEquivMatrix`: the matrix half of the composite,
-  `Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `K`-vector space of dimension `n`.
 * `TauCeti.Algebra.tensorOpAlgEquivMatrix`: **the opposite isomorphism**
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `n` with `Module.finrank K A = n`.
 
@@ -95,9 +94,10 @@ the two. Apply it with `haveI` where an `IsAzumaya` hypothesis is wanted.
 proof `Module.finrank K A = n`, rather than using `Module.finrank K A` itself. Instantiating `n` at
 `Module.finrank K A` and `hn` at `rfl` recovers the unparametrized form, while the parametrized one
 is what makes the quaternion example (where the dimension is `4` on the nose) come out without
-reindexing. Its second half `TauCeti.Algebra.endAlgEquivMatrix` is Mathlib's `algEquivMatrix` at the
-basis `Module.finBasisOfFinrankEq`; only the choice of basis is ours, and nothing downstream should
-depend on which basis that is.
+reindexing. Its second half is `TauCeti.Algebra.endAlgEquivMatrix`, which involves neither an
+algebra structure nor central simplicity and so lives with the linear algebra, in
+`TauCeti/LinearAlgebra/Matrix/ToLin.lean`; nothing downstream should depend on which basis it
+chooses.
 
 ## References
 
@@ -163,26 +163,6 @@ end IsSimpleRing
 /-! ### The opposite isomorphism -/
 
 namespace Algebra
-
-section Basis
-
-variable (K : Type*) [Field K] (M : Type*) [AddCommGroup M] [Module K M] [FiniteDimensional K M]
-
-/-- A `K`-vector space `M` of dimension `n` has `Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the
-matrix half of the opposite isomorphism, read off a chosen `K`-basis of `M`.
-
-This is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`, named here because it
-is a step of the opposite isomorphism that the roadmap asks for separately, to be reused where a
-finite-dimensional endomorphism algebra has to be turned into matrices of a known size. Neither an
-algebra structure on `M` nor central simplicity plays any part: only the dimension does.
-
-The basis is a choice, and nothing downstream should depend on which one it is; there is
-deliberately no lemma computing the matrix entries. -/
-noncomputable def endAlgEquivMatrix {n : ℕ} (hn : Module.finrank K M = n) :
-    Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
-  algEquivMatrix (Module.finBasisOfFinrankEq K M hn)
-
-end Basis
 
 variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
   [IsSimpleRing A] [FiniteDimensional K A]

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -189,10 +189,21 @@ the two are related by `TauCeti.Algebra.deg_sq`, and the resulting degree count 
 caller who already knows it as a numeral, as in
 `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`, gets that numeral back with no reindexing.
 
-This is `TauCeti.Algebra.tensorOpAlgEquivEnd` followed by `TauCeti.Algebra.endAlgEquivMatrix`. -/
+This is `TauCeti.Algebra.tensorOpAlgEquivEnd` followed by `TauCeti.Algebra.endAlgEquivMatrix`, as
+recorded by `TauCeti.Algebra.tensorOpAlgEquivMatrix_apply`. -/
 noncomputable def tensorOpAlgEquivMatrix {n : ℕ} (hn : Module.finrank K A = n) :
     A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
   (tensorOpAlgEquivEnd K A).trans (endAlgEquivMatrix K A hn)
+
+/-- The opposite isomorphism is the Azumaya isomorphism `TauCeti.Algebra.tensorOpAlgEquivEnd`
+followed by `TauCeti.Algebra.endAlgEquivMatrix`. This is the only handle on it: which basis
+`TauCeti.Algebra.endAlgEquivMatrix` chooses is deliberately opaque, so there is no lemma computing
+matrix entries. Together with `TauCeti.Algebra.tensorOpAlgEquivEnd_tmul_apply` it identifies the
+image of a pure tensor as the matrix of `x ↦ a * x * b.unop`. -/
+@[simp]
+theorem tensorOpAlgEquivMatrix_apply {n : ℕ} (hn : Module.finrank K A = n) (x : A ⊗[K] Aᵐᵒᵖ) :
+    tensorOpAlgEquivMatrix K A hn x = endAlgEquivMatrix K A hn (tensorOpAlgEquivEnd K A x) :=
+  AlgEquiv.trans_apply _ _ x
 
 end Algebra
 

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `TauCeti.Algebra.CentralSimple.Degree` is imported publicly: `TauCeti.Algebra.deg` appears in the
+-- statement of `TauCeti.Algebra.deg_tensorProduct_mulOpposite` below. It also re-exports
+-- `TauCeti.Algebra.CentralSimple.TensorProduct`, and with it the simplicity instance
+-- `TauCeti.IsSimpleRing.tensorProduct` that makes `A ⊗[K] Aᵐᵒᵖ` simple -- the fact the whole file
+-- rests on -- as well as `Mathlib.RingTheory.TensorProduct.Basic` (the `⊗[K]` notation and the
+-- algebra structure on `A ⊗[K] Aᵐᵒᵖ`) and `Mathlib.Algebra.Central.Basic`, which is why none of
+-- those is imported again here.
+public import TauCeti.Algebra.CentralSimple.Degree
+-- `AlgHom.mulLeftRight` and `IsAzumaya` appear in the statements below, and `Matrix` together with
+-- `algEquivMatrix` and `Module.finBasisOfFinrankEq` in the type and the body of the opposite
+-- isomorphism.
+public import Mathlib.Algebra.Azumaya.Defs
+public import Mathlib.LinearAlgebra.Matrix.ToLin
+-- Non-public: the dimension count for a space of linear maps and the rank-nullity consequence that
+-- an injective linear map between equidimensional spaces is surjective are used only inside proofs,
+-- so downstream importers do not pay for them.
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
+import Mathlib.LinearAlgebra.FreeModule.Finite.Matrix
+
+/-!
+# The opposite isomorphism `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Mₙ(K)`
+
+Let `A` be a finite-dimensional central simple algebra over a field `K`, of dimension `n` over `K`.
+This file proves that the **Azumaya map**
+
+`AlgHom.mulLeftRight K A : A ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A`,  `a ⊗ₜ b ↦ (x ↦ a * x * b.unop)`,
+
+is an isomorphism, and combines it with a choice of `K`-basis of `A` to write
+
+`A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K`.
+
+This is the fact that makes the class of `Aᵐᵒᵖ` the inverse of the class of `A` in the Brauer group:
+the tensor product of `A` with its opposite is a full matrix algebra, hence Brauer-trivial.
+
+The matrix size is `n = Module.finrank K A`, **not** the degree: for a central simple algebra of
+degree `d` one has `Module.finrank K A = d ^ 2`, so this is `Matrix (Fin (d ^ 2)) (Fin (d ^ 2)) K`.
+That is recorded as `TauCeti.Algebra.deg_tensorProduct_mulOpposite`.
+
+## The proof
+
+Both halves of bijectivity are cheap once the right facts are in place, and neither is a
+computation with the map.
+
+*Injectivity* is simplicity: `Aᵐᵒᵖ` is simple because `A` is, so `A ⊗[K] Aᵐᵒᵖ` is simple by
+`TauCeti.IsSimpleRing.tensorProduct` (this is where centrality of `A` enters), and a ring
+homomorphism out of a simple ring into a nontrivial ring is injective (`RingHom.injective`).
+No finite-dimensionality is used here.
+
+*Surjectivity* is a dimension count: `A ⊗[K] Aᵐᵒᵖ` and `Module.End K A` both have dimension `n ^ 2`
+over `K`, so an injective `K`-linear map between them is surjective. This is the only place
+finite-dimensionality is needed, and it is essential: for an infinite-dimensional central simple
+algebra the Azumaya map is injective but need not be surjective.
+
+Centrality enters only through the first half, and it cannot be dropped there. Take `A = ℂ` over
+`K = ℝ`, which is simple and finite-dimensional but not central. Then `ℂ ⊗[ℝ] ℂᵐᵒᵖ` is not simple:
+multiplication `a ⊗ₜ b ↦ a * b` is an `ℝ`-algebra map onto `ℂ` whose kernel contains the nonzero
+element `Complex.I ⊗ₜ 1 - 1 ⊗ₜ Complex.I`. Injectivity genuinely fails, and so does the conclusion:
+because `ℂ` is commutative the Azumaya map has image the scalar multiplications, a `2`-dimensional
+subalgebra of the `4`-dimensional `Module.End ℝ ℂ`.
+
+## Main results
+
+* `TauCeti.IsSimpleRing.mulLeftRight_bijective`: **the Azumaya map of a finite-dimensional central
+  simple algebra is bijective**, and its packaging `TauCeti.IsSimpleRing.isAzumaya`: such an algebra
+  is an Azumaya algebra over its base field.
+* `TauCeti.Algebra.tensorOpAlgEquivEnd`: the resulting isomorphism
+  `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`.
+* `TauCeti.Algebra.tensorOpAlgEquivMatrix`: **the opposite isomorphism**
+  `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `n` with `Module.finrank K A = n`.
+
+The real quaternions run all of this concretely in
+`TauCeti/Algebra/CentralSimple/Quaternion.lean`.
+
+## Implementation notes
+
+`TauCeti.IsSimpleRing.isAzumaya` is deliberately **not** an instance. Mathlib's
+`Algebra.IsCentral.instIsAzumaya` goes the other way, deducing `Algebra.IsCentral K A` from
+`IsAzumaya K A`; registering the converse as an instance would let typeclass search cycle between
+the two. Apply it with `haveI` where an `IsAzumaya` hypothesis is wanted.
+
+`TauCeti.Algebra.tensorOpAlgEquivMatrix` takes the matrix size as a parameter `n` together with a
+proof `Module.finrank K A = n`, rather than using `Module.finrank K A` itself. Instantiating `n` at
+`Module.finrank K A` and `hn` at `rfl` recovers the unparametrized form, while the parametrized one
+is what makes the quaternion example (where the dimension is `4` on the nose) come out without
+reindexing. Its second half is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`;
+only the choice of basis is ours, and nothing downstream should depend on which basis that is.
+
+## References
+
+This implements the fourth bullet of Layer 4 ("The opposite isomorphism") of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
+which also lists it among the Brauer-triviality prerequisites of Layer 6. See P. Gille,
+T. Szamuely, *Central Simple Algebras and Galois Cohomology*, Section 2.4, and R. S. Pierce,
+*Associative Algebras*, GTM 88, Chapter 12.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped TensorProduct
+
+/-! ### The dimension and the degree of `A ⊗[K] Aᵐᵒᵖ` -/
+
+namespace Algebra
+
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A]
+
+/-- Passing to the opposite algebra does not change the dimension, so `A ⊗[K] Aᵐᵒᵖ` has dimension
+`(Module.finrank K A) ^ 2`. This is the count that turns injectivity of the Azumaya map into
+surjectivity, `Module.End K A` having the same dimension, and it is where the matrix size in
+`TauCeti.Algebra.tensorOpAlgEquivMatrix` comes from: a dimension, not a degree.
+
+No finiteness hypothesis is needed: if `A` is infinite-dimensional both sides are `0`. -/
+theorem finrank_tensorProduct_mulOpposite :
+    Module.finrank K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A ^ 2 := by
+  rw [Module.finrank_tensorProduct, ← (MulOpposite.opLinearEquiv K (M := A)).finrank_eq, sq]
+
+/-- The degree of `A ⊗[K] Aᵐᵒᵖ` is the dimension of `A`. For `A` central simple this is the square
+of the degree of `A` (`TauCeti.Algebra.deg_sq`), and it is the degree-level shadow of
+`TauCeti.Algebra.tensorOpAlgEquivMatrix`: the reason the matrix size there is `Module.finrank K A`
+rather than `TauCeti.Algebra.deg K A`.
+
+As with the dimension count it rests on, no hypothesis on `A` is needed: the dimension of
+`A ⊗[K] Aᵐᵒᵖ` is a square for every `K`-algebra, and that alone pins the degree. -/
+@[simp]
+theorem deg_tensorProduct_mulOpposite : deg K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A :=
+  deg_eq_of_finrank_eq_sq (finrank_tensorProduct_mulOpposite K A)
+
+end Algebra
+
+/-! ### The Azumaya map is bijective -/
+
+namespace IsSimpleRing
+
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
+  [IsSimpleRing A] [FiniteDimensional K A]
+
+/-- **The Azumaya map of a finite-dimensional central simple algebra is bijective**: for `A` central
+simple and finite-dimensional over a field `K`, the map
+
+`AlgHom.mulLeftRight K A : A ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A`,  `a ⊗ₜ b ↦ (x ↦ a * x * b.unop)`,
+
+is a bijection.
+
+Injectivity holds for any central simple `A`, finite-dimensional or not: `A ⊗[K] Aᵐᵒᵖ` is a simple
+ring, and a ring homomorphism out of a simple ring into a nontrivial ring is injective.
+Finite-dimensionality is used only for surjectivity, where it makes the two sides equidimensional
+`K`-vector spaces. -/
+theorem mulLeftRight_bijective : Function.Bijective (AlgHom.mulLeftRight K A) := by
+  have hinj : Function.Injective (AlgHom.mulLeftRight K A) :=
+    RingHom.injective (AlgHom.mulLeftRight K A : (A ⊗[K] Aᵐᵒᵖ) →+* Module.End K A)
+  have hdim : Module.finrank K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K (Module.End K A) := by
+    rw [Algebra.finrank_tensorProduct_mulOpposite, Module.finrank_linearMap, sq]
+  exact ⟨hinj, (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdim
+    (f := (AlgHom.mulLeftRight K A).toLinearMap)).mp hinj⟩
+
+/-- **A finite-dimensional central simple algebra is an Azumaya algebra** over its base field.
+
+This is not an instance. Mathlib's `Algebra.IsCentral.instIsAzumaya` deduces `Algebra.IsCentral K A`
+from `IsAzumaya K A`, so making the converse an instance would let typeclass search cycle between
+the two; use `haveI := TauCeti.IsSimpleRing.isAzumaya K A` where an `IsAzumaya` hypothesis is
+wanted. -/
+theorem isAzumaya : IsAzumaya K A where
+  bij := mulLeftRight_bijective K A
+
+end IsSimpleRing
+
+/-! ### The opposite isomorphism -/
+
+namespace Algebra
+
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
+  [IsSimpleRing A] [FiniteDimensional K A]
+
+/-- The Azumaya map of a finite-dimensional central simple algebra, promoted to an isomorphism
+`A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`. Its value on a pure tensor is
+`TauCeti.Algebra.tensorOpAlgEquivEnd_tmul_apply`. -/
+noncomputable def tensorOpAlgEquivEnd : A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A :=
+  AlgEquiv.ofBijective (AlgHom.mulLeftRight K A) (IsSimpleRing.mulLeftRight_bijective K A)
+
+@[simp]
+theorem tensorOpAlgEquivEnd_tmul_apply (a : A) (b : Aᵐᵒᵖ) (x : A) :
+    tensorOpAlgEquivEnd K A (a ⊗ₜ[K] b) x = a * x * b.unop :=
+  AlgHom.mulLeftRight_apply K A a b x
+
+/-- **The opposite isomorphism.** A finite-dimensional central simple `K`-algebra `A` of dimension
+`n` satisfies `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the tensor product of a central simple
+algebra with its opposite is a full matrix algebra, which is what makes the Brauer class of `Aᵐᵒᵖ`
+the inverse of that of `A`.
+
+The size is the **dimension** `n = Module.finrank K A`, not the degree `TauCeti.Algebra.deg K A`;
+the two are related by `TauCeti.Algebra.deg_sq`, and the resulting degree count is
+`TauCeti.Algebra.deg_tensorProduct_mulOpposite`. The dimension is taken as a parameter so that a
+caller who already knows it as a numeral, as in
+`TauCeti.Quaternion.tensorSelfAlgEquivMatrix`, gets that numeral back with no reindexing. -/
+noncomputable def tensorOpAlgEquivMatrix {n : ℕ} (hn : Module.finrank K A = n) :
+    A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
+  (tensorOpAlgEquivEnd K A).trans (algEquivMatrix (Module.finBasisOfFinrankEq K A hn))
+
+end Algebra
+
+/-! ### Worked example: the base field -/
+
+section Examples
+
+variable (K : Type*) [Field K]
+
+/-- The base field itself: `K ⊗[K] Kᵐᵒᵖ` is `1 × 1` matrices over `K`. -/
+noncomputable example : K ⊗[K] Kᵐᵒᵖ ≃ₐ[K] Matrix (Fin 1) (Fin 1) K :=
+  Algebra.tensorOpAlgEquivMatrix K K (Module.finrank_self K)
+
+end Examples
+
+end TauCeti

--- a/TauCeti/Algebra/CentralSimple/Opposite.lean
+++ b/TauCeti/Algebra/CentralSimple/Opposite.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- `TauCeti.Algebra.CentralSimple.Degree` is imported publicly: `TauCeti.Algebra.deg` appears in the
--- statement of `TauCeti.Algebra.deg_tensorProduct_mulOpposite` below. It also re-exports
--- `TauCeti.Algebra.CentralSimple.TensorProduct`, and with it the simplicity instance
--- `TauCeti.IsSimpleRing.tensorProduct` that makes `A ⊗[K] Aᵐᵒᵖ` simple -- the fact the whole file
--- rests on -- as well as `Mathlib.RingTheory.TensorProduct.Basic` (the `⊗[K]` notation and the
--- algebra structure on `A ⊗[K] Aᵐᵒᵖ`) and `Mathlib.Algebra.Central.Basic`, which is why none of
--- those is imported again here.
+-- `TauCeti.Algebra.CentralSimple.Degree` is imported publicly: it supplies the dimension count
+-- `TauCeti.Algebra.finrank_tensorProduct_mulOpposite` that the surjectivity proof below runs on,
+-- and it re-exports `TauCeti.Algebra.CentralSimple.TensorProduct`, and with it the simplicity
+-- instance `TauCeti.IsSimpleRing.tensorProduct` that makes `A ⊗[K] Aᵐᵒᵖ` simple -- the fact the
+-- whole file rests on -- as well as `Mathlib.RingTheory.TensorProduct.Basic` (the `⊗[K]` notation
+-- and the algebra structure on `A ⊗[K] Aᵐᵒᵖ`, both of which occur in the statements below) and
+-- `Mathlib.Algebra.Central.Basic`, which is why none of those is imported again here.
 public import TauCeti.Algebra.CentralSimple.Degree
 -- `AlgHom.mulLeftRight` and `IsAzumaya` appear in the statements below, and `Matrix` together with
 -- `algEquivMatrix` and `Module.finBasisOfFinrankEq` in the type and the body of the opposite
@@ -40,7 +40,9 @@ the tensor product of `A` with its opposite is a full matrix algebra, hence Brau
 
 The matrix size is `n = Module.finrank K A`, **not** the degree: for a central simple algebra of
 degree `d` one has `Module.finrank K A = d ^ 2`, so this is `Matrix (Fin (d ^ 2)) (Fin (d ^ 2)) K`.
-That is recorded as `TauCeti.Algebra.deg_tensorProduct_mulOpposite`.
+The dimension and degree counts this rests on are general facts about `A ⊗[K] Aᵐᵒᵖ` and live with
+the rest of the degree API, as `TauCeti.Algebra.finrank_tensorProduct_mulOpposite` and
+`TauCeti.Algebra.deg_tensorProduct_mulOpposite`.
 
 ## The proof
 
@@ -50,7 +52,8 @@ computation with the map.
 *Injectivity* is simplicity: `Aᵐᵒᵖ` is simple because `A` is, so `A ⊗[K] Aᵐᵒᵖ` is simple by
 `TauCeti.IsSimpleRing.tensorProduct` (this is where centrality of `A` enters), and a ring
 homomorphism out of a simple ring into a nontrivial ring is injective (`RingHom.injective`).
-No finite-dimensionality is used here.
+No finite-dimensionality is used here, and the half is stated on its own as
+`TauCeti.IsSimpleRing.mulLeftRight_injective`.
 
 *Surjectivity* is a dimension count: `A ⊗[K] Aᵐᵒᵖ` and `Module.End K A` both have dimension `n ^ 2`
 over `K`, so an injective `K`-linear map between them is surjective. This is the only place
@@ -66,11 +69,15 @@ subalgebra of the `4`-dimensional `Module.End ℝ ℂ`.
 
 ## Main results
 
-* `TauCeti.IsSimpleRing.mulLeftRight_bijective`: **the Azumaya map of a finite-dimensional central
-  simple algebra is bijective**, and its packaging `TauCeti.IsSimpleRing.isAzumaya`: such an algebra
-  is an Azumaya algebra over its base field.
+* `TauCeti.IsSimpleRing.mulLeftRight_injective`: **the Azumaya map of a central simple algebra is
+  injective**, with no finiteness hypothesis, and
+  `TauCeti.IsSimpleRing.mulLeftRight_bijective`: **for a finite-dimensional one it is bijective**,
+  with its packaging `TauCeti.IsSimpleRing.isAzumaya`: such an algebra is an Azumaya algebra over
+  its base field.
 * `TauCeti.Algebra.tensorOpAlgEquivEnd`: the resulting isomorphism
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Module.End K A`.
+* `TauCeti.Algebra.endAlgEquivMatrix`: the matrix half of the composite,
+  `Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `K`-algebra of dimension `n`.
 * `TauCeti.Algebra.tensorOpAlgEquivMatrix`: **the opposite isomorphism**
   `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` for any `n` with `Module.finrank K A = n`.
 
@@ -88,8 +95,9 @@ the two. Apply it with `haveI` where an `IsAzumaya` hypothesis is wanted.
 proof `Module.finrank K A = n`, rather than using `Module.finrank K A` itself. Instantiating `n` at
 `Module.finrank K A` and `hn` at `rfl` recovers the unparametrized form, while the parametrized one
 is what makes the quaternion example (where the dimension is `4` on the nose) come out without
-reindexing. Its second half is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`;
-only the choice of basis is ours, and nothing downstream should depend on which basis that is.
+reindexing. Its second half `TauCeti.Algebra.endAlgEquivMatrix` is Mathlib's `algEquivMatrix` at the
+basis `Module.finBasisOfFinrankEq`; only the choice of basis is ours, and nothing downstream should
+depend on which basis that is.
 
 ## References
 
@@ -106,45 +114,24 @@ namespace TauCeti
 
 open scoped TensorProduct
 
-/-! ### The dimension and the degree of `A ⊗[K] Aᵐᵒᵖ` -/
-
-namespace Algebra
-
-variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A]
-
-/-- Passing to the opposite algebra does not change the dimension, so `A ⊗[K] Aᵐᵒᵖ` has dimension
-`(Module.finrank K A) ^ 2`. This is the count that turns injectivity of the Azumaya map into
-surjectivity, `Module.End K A` having the same dimension, and it is where the matrix size in
-`TauCeti.Algebra.tensorOpAlgEquivMatrix` comes from: a dimension, not a degree.
-
-No finiteness hypothesis is needed: if `A` is infinite-dimensional both sides are `0`. -/
-theorem finrank_tensorProduct_mulOpposite :
-    Module.finrank K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A ^ 2 := by
-  rw [Module.finrank_tensorProduct, ← (MulOpposite.opLinearEquiv K (M := A)).finrank_eq, sq]
-
-/-- The degree of `A ⊗[K] Aᵐᵒᵖ` is the dimension of `A`. For `A` central simple this is the square
-of the degree of `A` (`TauCeti.Algebra.deg_sq`), and it is the degree-level shadow of
-`TauCeti.Algebra.tensorOpAlgEquivMatrix`: the reason the matrix size there is `Module.finrank K A`
-rather than `TauCeti.Algebra.deg K A`.
-
-As with the dimension count it rests on, no hypothesis on `A` is needed: the dimension of
-`A ⊗[K] Aᵐᵒᵖ` is a square for every `K`-algebra, and that alone pins the degree.
-
-Not a `simp` lemma: as soon as `A` is central simple and finite-dimensional, so is `Aᵐᵒᵖ`, and then
-`TauCeti.Algebra.deg_tensorProduct` already rewrites the left-hand side, to
-`TauCeti.Algebra.deg K A * TauCeti.Algebra.deg K Aᵐᵒᵖ`. Marking this one `simp` too would leave
-`simp` with two different normal forms for the same term. -/
-theorem deg_tensorProduct_mulOpposite : deg K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K A :=
-  deg_eq_of_finrank_eq_sq (finrank_tensorProduct_mulOpposite K A)
-
-end Algebra
-
 /-! ### The Azumaya map is bijective -/
 
 namespace IsSimpleRing
 
 variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
-  [IsSimpleRing A] [FiniteDimensional K A]
+  [IsSimpleRing A]
+
+/-- **The Azumaya map of a central simple algebra is injective**: `A ⊗[K] Aᵐᵒᵖ` is a simple ring
+(`TauCeti.IsSimpleRing.tensorProduct`, which is where centrality of `A` enters), and a ring
+homomorphism out of a simple ring into a nontrivial ring is injective.
+
+No finite-dimensionality is used, and none should be added: this half of
+`TauCeti.IsSimpleRing.mulLeftRight_bijective` holds for an infinite-dimensional central simple
+algebra too, where the Azumaya map is injective but need not be surjective. -/
+theorem mulLeftRight_injective : Function.Injective (AlgHom.mulLeftRight K A) :=
+  RingHom.injective (AlgHom.mulLeftRight K A : (A ⊗[K] Aᵐᵒᵖ) →+* Module.End K A)
+
+variable [FiniteDimensional K A]
 
 /-- **The Azumaya map of a finite-dimensional central simple algebra is bijective**: for `A` central
 simple and finite-dimensional over a field `K`, the map
@@ -153,17 +140,14 @@ simple and finite-dimensional over a field `K`, the map
 
 is a bijection.
 
-Injectivity holds for any central simple `A`, finite-dimensional or not: `A ⊗[K] Aᵐᵒᵖ` is a simple
-ring, and a ring homomorphism out of a simple ring into a nontrivial ring is injective.
-Finite-dimensionality is used only for surjectivity, where it makes the two sides equidimensional
-`K`-vector spaces. -/
+Injectivity is `TauCeti.IsSimpleRing.mulLeftRight_injective`, which holds for any central simple
+`A`, finite-dimensional or not. Finite-dimensionality is used only for surjectivity, where it makes
+the two sides equidimensional `K`-vector spaces. -/
 theorem mulLeftRight_bijective : Function.Bijective (AlgHom.mulLeftRight K A) := by
-  have hinj : Function.Injective (AlgHom.mulLeftRight K A) :=
-    RingHom.injective (AlgHom.mulLeftRight K A : (A ⊗[K] Aᵐᵒᵖ) →+* Module.End K A)
   have hdim : Module.finrank K (A ⊗[K] Aᵐᵒᵖ) = Module.finrank K (Module.End K A) := by
     rw [Algebra.finrank_tensorProduct_mulOpposite, Module.finrank_linearMap, sq]
-  exact ⟨hinj, (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdim
-    (f := (AlgHom.mulLeftRight K A).toLinearMap)).mp hinj⟩
+  exact ⟨mulLeftRight_injective K A, (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hdim
+    (f := (AlgHom.mulLeftRight K A).toLinearMap)).mp (mulLeftRight_injective K A)⟩
 
 /-- **A finite-dimensional central simple algebra is an Azumaya algebra** over its base field.
 
@@ -179,6 +163,26 @@ end IsSimpleRing
 /-! ### The opposite isomorphism -/
 
 namespace Algebra
+
+section Basis
+
+variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [FiniteDimensional K A]
+
+/-- A `K`-algebra `A` of dimension `n` has `Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K`: the
+matrix half of the opposite isomorphism, read off a chosen `K`-basis of `A`.
+
+This is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`, named here because it
+is a step of the opposite isomorphism that the roadmap asks for separately, to be reused where a
+finite-dimensional endomorphism algebra has to be turned into matrices of a known size. Central
+simplicity plays no part: only the dimension does.
+
+The basis is a choice, and nothing downstream should depend on which one it is; there is
+deliberately no lemma computing the matrix entries. -/
+noncomputable def endAlgEquivMatrix {n : ℕ} (hn : Module.finrank K A = n) :
+    Module.End K A ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
+  algEquivMatrix (Module.finBasisOfFinrankEq K A hn)
+
+end Basis
 
 variable (K : Type*) [Field K] (A : Type*) [Ring A] [Algebra K A] [Algebra.IsCentral K A]
   [IsSimpleRing A] [FiniteDimensional K A]
@@ -203,10 +207,12 @@ The size is the **dimension** `n = Module.finrank K A`, not the degree `TauCeti.
 the two are related by `TauCeti.Algebra.deg_sq`, and the resulting degree count is
 `TauCeti.Algebra.deg_tensorProduct_mulOpposite`. The dimension is taken as a parameter so that a
 caller who already knows it as a numeral, as in
-`TauCeti.Quaternion.tensorSelfAlgEquivMatrix`, gets that numeral back with no reindexing. -/
+`TauCeti.Quaternion.tensorSelfAlgEquivMatrix`, gets that numeral back with no reindexing.
+
+This is `TauCeti.Algebra.tensorOpAlgEquivEnd` followed by `TauCeti.Algebra.endAlgEquivMatrix`. -/
 noncomputable def tensorOpAlgEquivMatrix {n : ℕ} (hn : Module.finrank K A = n) :
     A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
-  (tensorOpAlgEquivEnd K A).trans (algEquivMatrix (Module.finBasisOfFinrankEq K A hn))
+  (tensorOpAlgEquivEnd K A).trans (endAlgEquivMatrix K A hn)
 
 end Algebra
 

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -30,20 +30,21 @@ central simple `ℝ`-algebra of degree `2`. This file runs the opposite isomorph
 `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.
 
 The second follows from the first because quaternion conjugation is an `ℝ`-algebra isomorphism
-`ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (Mathlib's `Quaternion.starAe`): the quaternions are their own opposite. So
-the Brauer class of `ℍ[ℝ]` is its own inverse.
+`ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (Mathlib's `Quaternion.starAe`): the quaternions are their own opposite.
 
-That class is not the identity: `TauCeti.Quaternion.isEmpty_algEquiv_matrix` says `ℍ[ℝ]` is not
-isomorphic to any matrix algebra of size at least two, and the only such candidate in dimension `4`
-is `Matrix (Fin 2) (Fin 2) ℝ`. The two facts together say that the class of `ℍ[ℝ]` has order exactly
-two, which is the content of `BrauerGroup ℝ ≃ ℤ/2` that does not need the classification of real
-division algebras. That classification, and with it the statement that the class of `ℍ[ℝ]`
-generates, is a separate long-term target and is not proved here.
+Everything here is an isomorphism of `ℝ`-algebras; `BrauerGroup ℝ` is not yet a group in this
+library, so nothing below is a statement about it. Informally, the isomorphisms exhibit the Brauer
+class of `ℍ[ℝ]` as **self-inverse**. Two further steps, neither taken here, would turn that into the
+order of the class. Saying the class is nontrivial needs the passage from nonsplitting to Brauer
+nontriviality applied to `TauCeti.Quaternion.isEmpty_algEquiv_matrix`, which says `ℍ[ℝ]` is
+isomorphic to no matrix algebra of size at least two -- the only candidate in dimension `4` being
+`Matrix (Fin 2) (Fin 2) ℝ`. Saying that `BrauerGroup ℝ ≃ ℤ/2` needs, beyond that, the classification
+of real division algebras, to know the class generates. Both are separate long-term targets.
 
 The matrix size is `4` and not `2`: it is the **dimension** `Module.finrank ℝ ℍ[ℝ] = 4` of the
 algebra, not its degree `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`. Squaring the degree is exactly what taking
-the tensor product with the opposite algebra does, and
-`TauCeti.Quaternion.deg_tensorProduct_self` records it.
+the tensor product with the opposite algebra does, and the degree example at the end of the file
+checks it.
 
 ## Main results
 
@@ -51,7 +52,6 @@ the tensor product with the opposite algebra does, and
   `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.
 * `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`,
   the roadmap's worked example.
-* `TauCeti.Quaternion.deg_tensorProduct_self`: the tensor square has degree `4`.
 
 ## References
 
@@ -83,28 +83,27 @@ noncomputable def tensorOpAlgEquivMatrix :
 isomorphism `ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (`Quaternion.starAe`), so the tensor square of `ℍ[ℝ]` is its tensor
 product with its own opposite, which `TauCeti.Quaternion.tensorOpAlgEquivMatrix` splits.
 
-In Brauer-group language: the class of `ℍ[ℝ]` is its own inverse. It is not the identity class, by
-`TauCeti.Quaternion.isEmpty_algEquiv_matrix`, so it has order exactly two. -/
+In Brauer-group language this exhibits the class of `ℍ[ℝ]` as its own inverse. Whether that class is
+the identity is a separate question, not settled by this isomorphism; see the module docstring. -/
 noncomputable def tensorSelfAlgEquivMatrix :
     ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
   (Algebra.TensorProduct.congr (AlgEquiv.refl (A₁ := ℍ[ℝ])) _root_.Quaternion.starAe).trans
     tensorOpAlgEquivMatrix
 
-/-- The tensor square of the real quaternions has degree `4`: tensoring a central simple algebra
-with its opposite squares the degree, and `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`.
-
-The proof is the multiplicativity of the degree, so this is an independent check on the matrix size
-in `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `4` really is `2 · 2`, and not the degree `2` of
-either factor. Not a `simp` lemma, because `TauCeti.Algebra.deg_tensorProduct` already rewrites the
-left-hand side to `TauCeti.Algebra.deg ℝ ℍ[ℝ] * TauCeti.Algebra.deg ℝ ℍ[ℝ]`. -/
-theorem deg_tensorProduct_self : Algebra.deg ℝ (ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]) = 4 := by
+/-- The tensor square of the real quaternions has degree `4`, by the multiplicativity of the degree
+and `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`. This is an independent check on the matrix size in
+`TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `4` really is `2 · 2`, and not the degree `2` of
+either factor. A caller wanting the numeral gets it the same way, from
+`TauCeti.Algebra.deg_tensorProduct`, so this is an example rather than a lemma. -/
+example : Algebra.deg ℝ (ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]) = 4 := by
   have h : Algebra.deg ℝ ℍ[ℝ] = 2 :=
     Algebra.deg_eq_of_finrank_eq_sq (by rw [_root_.Quaternion.finrank_eq_four]; norm_num)
   rw [Algebra.deg_tensorProduct, h]
 
 /-- The tensor square is split, but `ℍ[ℝ]` itself is not: the only matrix algebra over `ℝ` of
 dimension `4` is `Matrix (Fin 2) (Fin 2) ℝ`, and `ℍ[ℝ]` is a division algebra, so no isomorphism
-exists. This is the second half of "the Brauer class of `ℍ[ℝ]` has order exactly two". -/
+exists. This is what a passage from nonsplitting to Brauer nontriviality would consume, to say that
+the self-inverse class of `ℍ[ℝ]` is not the identity. -/
 example : IsEmpty (ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ) :=
   isEmpty_algEquiv_matrix ℝ (Fin 2)
 

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -16,7 +16,9 @@ public import TauCeti.Algebra.CentralSimple.Opposite
 -- `Quaternion.starAe`, and `Quaternion.finrank_eq_four`.
 public import TauCeti.Algebra.Central.Quaternion
 -- `Mathlib.Data.Real.Basic` is imported publicly because the field structure on `ℝ` is what makes
--- the statements below typecheck.
+-- the statements below typecheck: the public imports above reach `Mathlib.Algebra.Quaternion`,
+-- which supplies `ℍ[·]` over an arbitrary base but not `ℝ` itself, so without this import `ℝ` is
+-- not even in scope as a name.
 public import Mathlib.Data.Real.Basic
 
 /-!
@@ -34,11 +36,12 @@ The second follows from the first because quaternion conjugation is an `ℝ`-alg
 
 Everything here is an isomorphism of `ℝ`-algebras; `BrauerGroup ℝ` is not yet a group in this
 library, so nothing below is a statement about it. Informally, the isomorphisms exhibit the Brauer
-class of `ℍ[ℝ]` as **self-inverse**. Two further steps, neither taken here, would turn that into the
-order of the class. Saying the class is nontrivial needs the passage from nonsplitting to Brauer
-nontriviality applied to `TauCeti.Quaternion.isEmpty_algEquiv_matrix`, which says `ℍ[ℝ]` is
-isomorphic to no matrix algebra of size at least two -- the only candidate in dimension `4` being
-`Matrix (Fin 2) (Fin 2) ℝ`. Saying that `BrauerGroup ℝ ≃ ℤ/2` needs, beyond that, the classification
+class of `ℍ[ℝ]` as **self-inverse**. One further step, not taken here, would turn that into the
+order of the class: the passage from nonsplitting to Brauer nontriviality, applied to
+`TauCeti.Quaternion.isEmpty_algEquiv_matrix` -- which says `ℍ[ℝ]` is isomorphic to no matrix algebra
+of size at least two, the only candidate in dimension `4` being `Matrix (Fin 2) (Fin 2) ℝ` -- makes
+the class nontrivial, and a self-inverse class that is not the identity has order exactly `2`.
+Saying that `BrauerGroup ℝ ≃ ℤ/2` is a further and independent matter: it needs the classification
 of real division algebras, to know the class generates. Both are separate long-term targets.
 
 The matrix size is `4` and not `2`: it is the **dimension** `Module.finrank ℝ ℍ[ℝ] = 4` of the

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -47,7 +47,7 @@ the tensor product with the opposite algebra does, and
 
 ## Main results
 
-* `TauCeti.Quaternion.tensorMulOppositeAlgEquivMatrix`:
+* `TauCeti.Quaternion.tensorOpAlgEquivMatrix`:
   `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.
 * `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`,
   the roadmap's worked example.
@@ -75,20 +75,20 @@ quaternions. All three hypotheses of `TauCeti.Algebra.tensorOpAlgEquivMatrix` ar
 search -- `Algebra.IsCentral ℝ ℍ[ℝ]` from `TauCeti.Quaternion.instIsCentral`, `IsSimpleRing ℍ[ℝ]`
 because a division ring is simple, and `FiniteDimensional ℝ ℍ[ℝ]` -- so only the dimension
 `Quaternion.finrank_eq_four` has to be supplied. -/
-noncomputable def tensorMulOppositeAlgEquivMatrix :
+noncomputable def tensorOpAlgEquivMatrix :
     ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
   Algebra.tensorOpAlgEquivMatrix ℝ ℍ[ℝ] _root_.Quaternion.finrank_eq_four
 
 /-- **`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.** Quaternion conjugation is an `ℝ`-algebra
 isomorphism `ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (`Quaternion.starAe`), so the tensor square of `ℍ[ℝ]` is its tensor
-product with its own opposite, which `TauCeti.Quaternion.tensorMulOppositeAlgEquivMatrix` splits.
+product with its own opposite, which `TauCeti.Quaternion.tensorOpAlgEquivMatrix` splits.
 
 In Brauer-group language: the class of `ℍ[ℝ]` is its own inverse. It is not the identity class, by
 `TauCeti.Quaternion.isEmpty_algEquiv_matrix`, so it has order exactly two. -/
 noncomputable def tensorSelfAlgEquivMatrix :
     ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
   (Algebra.TensorProduct.congr (AlgEquiv.refl (A₁ := ℍ[ℝ])) _root_.Quaternion.starAe).trans
-    tensorMulOppositeAlgEquivMatrix
+    tensorOpAlgEquivMatrix
 
 /-- The tensor square of the real quaternions has degree `4`: tensoring a central simple algebra
 with its opposite squares the degree, and `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`.

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -34,8 +34,9 @@ central simple `ℝ`-algebra of degree `2`. This file runs the opposite isomorph
 The second follows from the first because quaternion conjugation is an `ℝ`-algebra isomorphism
 `ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (Mathlib's `Quaternion.starAe`): the quaternions are their own opposite.
 
-Everything here is an isomorphism of `ℝ`-algebras; `BrauerGroup ℝ` is not yet a group in this
-library, so nothing below is a statement about it. Informally, the isomorphisms exhibit the Brauer
+`BrauerGroup ℝ` is not yet a group in this library, so nothing below is a statement about it: the
+two main results are isomorphisms of `ℝ`-algebras, and the two examples closing the file are a
+degree computation and a nonexistence statement. Informally, the isomorphisms exhibit the Brauer
 class of `ℍ[ℝ]` as **self-inverse**. One further step, not taken here, would turn that into the
 order of the class: the passage from nonsplitting to Brauer nontriviality, applied to
 `TauCeti.Quaternion.isEmpty_algEquiv_matrix` -- which says `ℍ[ℝ]` is isomorphic to no matrix algebra
@@ -74,12 +75,15 @@ namespace TauCeti
 namespace Quaternion
 
 /-- **`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`**: the opposite isomorphism at the real
-quaternions. All three hypotheses of `TauCeti.Algebra.tensorOpAlgEquivMatrix` are found by instance
-search -- `Algebra.IsCentral ℝ ℍ[ℝ]` from `TauCeti.Quaternion.instIsCentral`, `IsSimpleRing ℍ[ℝ]`
-because a division ring is simple, and `FiniteDimensional ℝ ℍ[ℝ]` -- so only the dimension
-`Quaternion.finrank_eq_four` has to be supplied. -/
+quaternions. `TauCeti.Algebra.tensorOpAlgEquivMatrix` asks for `IsAzumaya ℝ ℍ[ℝ]`, which
+`TauCeti.IsSimpleRing.isAzumaya` supplies and which is not an instance, so it is installed by hand;
+its own three hypotheses are found by instance search -- `Algebra.IsCentral ℝ ℍ[ℝ]` from
+`TauCeti.Quaternion.instIsCentral`, `IsSimpleRing ℍ[ℝ]` because a division ring is simple, and
+`FiniteDimensional ℝ ℍ[ℝ]` -- so beyond it only the dimension `Quaternion.finrank_eq_four` has to be
+supplied. -/
 noncomputable def tensorOpAlgEquivMatrix :
     ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
+  haveI := IsSimpleRing.isAzumaya ℝ ℍ[ℝ]
   Algebra.tensorOpAlgEquivMatrix ℝ ℍ[ℝ] _root_.Quaternion.finrank_eq_four
 
 /-- **`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.** Quaternion conjugation is an `ℝ`-algebra

--- a/TauCeti/Algebra/CentralSimple/Quaternion.lean
+++ b/TauCeti/Algebra/CentralSimple/Quaternion.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `TauCeti.Algebra.CentralSimple.Opposite` is imported publicly: it supplies
+-- `TauCeti.Algebra.tensorOpAlgEquivMatrix`, of which everything below is an instance, and it
+-- re-exports `TauCeti.Algebra.CentralSimple.Degree` (hence `TauCeti.Algebra.deg`) together with
+-- the `⊗[ℝ]` notation and the matrix algebras, which is why none of those is imported again here.
+public import TauCeti.Algebra.CentralSimple.Opposite
+-- `TauCeti.Algebra.Central.Quaternion` is imported publicly for two reasons: `ℍ[ℝ]` occurs in every
+-- statement below, and it is the instance `TauCeti.Quaternion.instIsCentral` proved there that puts
+-- `ℍ[ℝ]` in the scope of the opposite isomorphism at all. It re-exports
+-- `Mathlib.Algebra.Quaternion`, hence the `ℍ[·]` notation, quaternion conjugation
+-- `Quaternion.starAe`, and `Quaternion.finrank_eq_four`.
+public import TauCeti.Algebra.Central.Quaternion
+-- `Mathlib.Data.Real.Basic` is imported publicly because the field structure on `ℝ` is what makes
+-- the statements below typecheck.
+public import Mathlib.Data.Real.Basic
+
+/-!
+# The tensor square of the real quaternions is `M₄(ℝ)`
+
+The real quaternions `ℍ[ℝ]` are a central division algebra of dimension `4` over `ℝ`, hence a
+central simple `ℝ`-algebra of degree `2`. This file runs the opposite isomorphism of
+`TauCeti/Algebra/CentralSimple/Opposite.lean` on them, in the two forms
+
+`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`  and
+`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.
+
+The second follows from the first because quaternion conjugation is an `ℝ`-algebra isomorphism
+`ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (Mathlib's `Quaternion.starAe`): the quaternions are their own opposite. So
+the Brauer class of `ℍ[ℝ]` is its own inverse.
+
+That class is not the identity: `TauCeti.Quaternion.isEmpty_algEquiv_matrix` says `ℍ[ℝ]` is not
+isomorphic to any matrix algebra of size at least two, and the only such candidate in dimension `4`
+is `Matrix (Fin 2) (Fin 2) ℝ`. The two facts together say that the class of `ℍ[ℝ]` has order exactly
+two, which is the content of `BrauerGroup ℝ ≃ ℤ/2` that does not need the classification of real
+division algebras. That classification, and with it the statement that the class of `ℍ[ℝ]`
+generates, is a separate long-term target and is not proved here.
+
+The matrix size is `4` and not `2`: it is the **dimension** `Module.finrank ℝ ℍ[ℝ] = 4` of the
+algebra, not its degree `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`. Squaring the degree is exactly what taking
+the tensor product with the opposite algebra does, and
+`TauCeti.Quaternion.deg_tensorProduct_self` records it.
+
+## Main results
+
+* `TauCeti.Quaternion.tensorMulOppositeAlgEquivMatrix`:
+  `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.
+* `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`,
+  the roadmap's worked example.
+* `TauCeti.Quaternion.deg_tensorProduct_self`: the tensor square has degree `4`.
+
+## References
+
+This is the `ℍ[ℝ] ⊗_ℝ ℍ[ℝ] ≃ M₄(ℝ)` half of the Hamilton-quaternion worked example of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
+pinned there as `quaternion_tensor_self`; the centrality half is
+`TauCeti/Algebra/Central/Quaternion.lean`. See P. Gille, T. Szamuely, *Central Simple Algebras and
+Galois Cohomology*, CUP (2006), §1.1 and §2.1.
+-/
+
+public section
+
+open scoped Quaternion TensorProduct
+
+namespace TauCeti
+
+namespace Quaternion
+
+/-- **`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`**: the opposite isomorphism at the real
+quaternions. All three hypotheses of `TauCeti.Algebra.tensorOpAlgEquivMatrix` are found by instance
+search -- `Algebra.IsCentral ℝ ℍ[ℝ]` from `TauCeti.Quaternion.instIsCentral`, `IsSimpleRing ℍ[ℝ]`
+because a division ring is simple, and `FiniteDimensional ℝ ℍ[ℝ]` -- so only the dimension
+`Quaternion.finrank_eq_four` has to be supplied. -/
+noncomputable def tensorMulOppositeAlgEquivMatrix :
+    ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]ᵐᵒᵖ ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
+  Algebra.tensorOpAlgEquivMatrix ℝ ℍ[ℝ] _root_.Quaternion.finrank_eq_four
+
+/-- **`ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`.** Quaternion conjugation is an `ℝ`-algebra
+isomorphism `ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (`Quaternion.starAe`), so the tensor square of `ℍ[ℝ]` is its tensor
+product with its own opposite, which `TauCeti.Quaternion.tensorMulOppositeAlgEquivMatrix` splits.
+
+In Brauer-group language: the class of `ℍ[ℝ]` is its own inverse. It is not the identity class, by
+`TauCeti.Quaternion.isEmpty_algEquiv_matrix`, so it has order exactly two. -/
+noncomputable def tensorSelfAlgEquivMatrix :
+    ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ :=
+  (Algebra.TensorProduct.congr (AlgEquiv.refl (A₁ := ℍ[ℝ])) _root_.Quaternion.starAe).trans
+    tensorMulOppositeAlgEquivMatrix
+
+/-- The tensor square of the real quaternions has degree `4`: tensoring a central simple algebra
+with its opposite squares the degree, and `TauCeti.Algebra.deg ℝ ℍ[ℝ] = 2`.
+
+The proof is the multiplicativity of the degree, so this is an independent check on the matrix size
+in `TauCeti.Quaternion.tensorSelfAlgEquivMatrix`: `4` really is `2 · 2`, and not the degree `2` of
+either factor. Not a `simp` lemma, because `TauCeti.Algebra.deg_tensorProduct` already rewrites the
+left-hand side to `TauCeti.Algebra.deg ℝ ℍ[ℝ] * TauCeti.Algebra.deg ℝ ℍ[ℝ]`. -/
+theorem deg_tensorProduct_self : Algebra.deg ℝ (ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]) = 4 := by
+  have h : Algebra.deg ℝ ℍ[ℝ] = 2 :=
+    Algebra.deg_eq_of_finrank_eq_sq (by rw [_root_.Quaternion.finrank_eq_four]; norm_num)
+  rw [Algebra.deg_tensorProduct, h]
+
+/-- The tensor square is split, but `ℍ[ℝ]` itself is not: the only matrix algebra over `ℝ` of
+dimension `4` is `Matrix (Fin 2) (Fin 2) ℝ`, and `ℍ[ℝ]` is a division algebra, so no isomorphism
+exists. This is the second half of "the Brauer class of `ℍ[ℝ]` has order exactly two". -/
+example : IsEmpty (ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 2) (Fin 2) ℝ) :=
+  isEmpty_algEquiv_matrix ℝ (Fin 2)
+
+end Quaternion
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/Matrix/ToLin.lean
+++ b/TauCeti/LinearAlgebra/Matrix/ToLin.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `Module.End`, `Matrix` and `algEquivMatrix` occur in the statement and the body below; this is
+-- also the Mathlib file that `algEquivMatrix` itself lives in.
+public import Mathlib.LinearAlgebra.Matrix.ToLin
+-- `FiniteDimensional` and `Module.finrank` occur in the statement, and
+-- `Module.finBasisOfFinrankEq` in the body.
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+
+/-!
+# The endomorphism algebra of a finite-dimensional vector space, as matrices of a known size
+
+Mathlib's `algEquivMatrix` turns `Module.End K M` into matrices indexed by the index type of a
+chosen basis of `M`. This file records the form of it that is wanted when the *dimension* of `M` is
+known but no particular basis is: for `Module.finrank K M = n`, an isomorphism
+
+`Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K`.
+
+## Main results
+
+* `TauCeti.Algebra.endAlgEquivMatrix`: the above, read off the basis
+  `Module.finBasisOfFinrankEq`.
+
+It is used to turn the Azumaya isomorphism of a finite-dimensional central simple algebra into a
+matrix algebra in `TauCeti/Algebra/CentralSimple/Opposite.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Algebra
+
+variable (K : Type*) [Field K] (M : Type*) [AddCommGroup M] [Module K M] [FiniteDimensional K M]
+
+/-- A `K`-vector space `M` of dimension `n` has `Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K`,
+read off a chosen `K`-basis of `M`.
+
+This is Mathlib's `algEquivMatrix` at the basis `Module.finBasisOfFinrankEq`, named here because it
+is wanted wherever a finite-dimensional endomorphism algebra has to be turned into matrices of a
+known size -- in particular as the second half of the opposite isomorphism
+`TauCeti.Algebra.tensorOpAlgEquivMatrix`, which the roadmap asks for separately.
+
+The basis is a choice, and nothing downstream should depend on which one it is; there is
+deliberately no lemma computing the matrix entries. -/
+noncomputable def endAlgEquivMatrix {n : ℕ} (hn : Module.finrank K M = n) :
+    Module.End K M ≃ₐ[K] Matrix (Fin n) (Fin n) K :=
+  algEquivMatrix (Module.finBasisOfFinrankEq K M hn)
+
+end Algebra
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the Azumaya map

`AlgHom.mulLeftRight K A : A ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A`,  `a ⊗ₜ b ↦ (x ↦ a * x * b.unop)`,

of a finite-dimensional central simple `K`-algebra `A` is bijective, and reads off the **opposite isomorphism** `A ⊗[K] Aᵐᵒᵖ ≃ₐ[K] Matrix (Fin n) (Fin n) K` with `n = Module.finrank K A`. This is the fact that makes the Brauer class of `Aᵒᵖ` the inverse of the class of `A`: a central simple algebra tensored with its opposite is a full matrix algebra, hence Brauer-trivial.

Neither half of bijectivity is a computation with the map. Injectivity is simplicity: `Aᵐᵒᵖ` is simple because `A` is, so `A ⊗[K] Aᵐᵒᵖ` is simple by the existing `TauCeti.IsSimpleRing.tensorProduct` (this is where centrality enters), and a ring homomorphism out of a simple ring into a nontrivial ring is injective. It needs no finite-dimensionality. Surjectivity is a dimension count: both sides have dimension `n ^ 2` over `K`, so an injective `K`-linear map between them is surjective. Centrality cannot be dropped, and the module docstring records the standard witness — for `A = ℂ` over `K = ℝ`, simple and finite-dimensional but not central, the multiplication map exhibits a nontrivial two-sided ideal of `ℂ ⊗[ℝ] ℂᵐᵒᵖ`, and the Azumaya map has `2`-dimensional image inside the `4`-dimensional `Module.End ℝ ℂ`.

The matrix size is the **dimension** `Module.finrank K A`, not the degree: for a central simple algebra of degree `d` it is `M_{d²}(K)`. That is recorded degree-side as `TauCeti.Algebra.deg_tensorProduct_mulOpposite`, which together with its underlying dimension count needs no hypothesis on `A` at all beyond being a `K`-algebra. `TauCeti.Algebra.tensorOpAlgEquivMatrix` takes the size as a parameter `n` with a proof `Module.finrank K A = n`, so a caller who knows the dimension as a numeral gets that numeral back with no reindexing; instantiating at `rfl` recovers the unparametrized form pinned by the roadmap.

Bijectivity also packages as `TauCeti.IsSimpleRing.isAzumaya`: a finite-dimensional central simple algebra is an Azumaya algebra over its base field. Mathlib has `IsAzumaya` and the implication `IsAzumaya → Algebra.IsCentral`, but nothing going the other way. This is deliberately a `theorem` and not an `instance`, since registering the converse would let typeclass search cycle against Mathlib's `Algebra.IsCentral.instIsAzumaya`; the docstring says so and points at `haveI`.

`TauCeti/Algebra/CentralSimple/Quaternion.lean` runs it concretely on the real quaternions. Quaternion conjugation is an `ℝ`-algebra isomorphism `ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]ᵐᵒᵖ` (Mathlib's `Quaternion.starAe`), so the tensor square is covered too: `ℍ[ℝ] ⊗[ℝ] ℍ[ℝ] ≃ₐ[ℝ] Matrix (Fin 4) (Fin 4) ℝ`, with an independent degree check `Algebra.deg ℝ (ℍ[ℝ] ⊗[ℝ] ℍ[ℝ]) = 4` proved from multiplicativity of the degree rather than from the isomorphism. Combined with the already-merged `TauCeti.Quaternion.isEmpty_algEquiv_matrix`, this says the Brauer class of `ℍ[ℝ]` has order exactly two. That the class *generates* `BrauerGroup ℝ` needs the classification of real division algebras and is explicitly left as the long-term target it is; the Brauer group is not yet a group in this library, so the statements here are phrased as algebra isomorphisms.

The quaternion material is a separate module rather than a section of the general file so that the general theory does not publicly depend on `ℝ` or on `TauCeti/Algebra/Central/Quaternion.lean`.

This implements the fourth bullet of Layer 4 ("The opposite isomorphism", `A ⊗_K Aᵒᵖ ≅ M_{finrank K A}(K)`) of `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md`, pinned as `tensorOp_algEquiv_matrix` in that roadmap's `Suggested.lean`, together with the `ℍ[ℝ] ⊗_ℝ ℍ[ℝ] ≃ M₄(ℝ)` half of its Hamilton-quaternion worked example (`quaternion_tensor_self`). Layer 6 lists the same isomorphism among the Brauer-triviality prerequisites for the group structure on `BrauerGroup K`. Its stated prerequisites are already on `main`: the tensor-product simplicity of central simple algebras (`TauCeti/Algebra/CentralSimple/TensorProduct.lean`), the degree (`TauCeti/Algebra/CentralSimple/Degree.lean`), and the centrality and nonsplitting of `ℍ[ℝ]` (`TauCeti/Algebra/Central/Quaternion.lean`).

No Mathlib infrastructure is vendored, and nothing is adapted from an outside formalization. The mathematics follows P. Gille, T. Szamuely, *Central Simple Algebras and Galois Cohomology*, CUP (2006), §2.4 and §1.1, and R. S. Pierce, *Associative Algebras*, GTM 88, Chapter 12, as cited in the files.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"tensorop-algequiv-matrix"}-->

🤖 Prepared with Claude Code
