### PR TITLE
feat: measure the piece a crosscut cuts off by its boundary

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -1,0 +1,260 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
+public import TauCeti.Analysis.Normed.Module.DiamFrontier
+public import TauCeti.Topology.ClusterSet
+
+/-!
+# The piece a crosscut cuts off, measured by its boundary
+
+`Conformal/Crosscut.lean` cuts a disc `ball c r` at a boundary point `ζ` by the circle
+`sphere ζ ρ`, leaving the *crosscut neighbourhood* `ball c r ∩ ball ζ ρ` of `ζ`, and turns an
+oscillation bound on that neighbourhood into a boundary limit. This file supplies such a bound for a
+*conformal* map, in the geometric form that layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory boundary correspondence — produces
+it: the image of the crosscut neighbourhood is no wider than the image of the crosscut arc together
+with the piece of `∂Ω` that arc cuts off.
+
+## The boundary of the image of a crosscut neighbourhood
+
+Write `Ω = f '' ball c r` for the image domain and `A = f '' (ball c r ∩ ball ζ ρ)` for the image of
+the crosscut neighbourhood, `f` being holomorphic and injective on the disc. Then
+(`TauCeti.frontier_image_ball_inter_ball_subset`)
+
+> `frontier A ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier Ω`:
+
+the boundary of `A` consists of the *image crosscut* and of boundary points of `Ω`, and nothing
+else. The proof is the open mapping theorem applied three times. A point `p` of `frontier A` lies in
+`closure Ω = Ω ∪ frontier Ω`; if it is not on `frontier Ω` it is `f w` for a unique `w` in the disc,
+and `w` is at distance `< ρ`, `= ρ` or `> ρ` from `ζ`. The first case puts `p` in the open set `A`,
+which is disjoint from `frontier A`. The third puts `p` in the *open* image of the far side
+`ball c r \ closedBall ζ ρ`, which injectivity makes disjoint from `A`, contradicting `p ∈ closure
+A`. So only the middle case survives, and there `p` lies on the image crosscut. Simple connectivity
+of the disc plays no role, and neither does the geometry of `Ω`.
+
+## From the boundary to the piece
+
+A bounded set in a normed space is exactly as wide as its frontier
+(`TauCeti.diam_frontier`, in `TauCeti/Analysis/Normed/Module/DiamFrontier.lean`), so the inclusion
+above is already a diameter bound: for any `E` containing the boundary points of `Ω` that lie on
+`frontier A`,
+
+> `diam A ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E)`
+
+(`TauCeti.diam_image_ball_inter_ball_le`). Feeding those bounds, one for each tolerance, to the
+Cauchy criterion of `Topology/ClusterSet.lean` gives the boundary limit
+`TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` and, if the bounds are
+available at every point of the boundary circle, the continuous extension to the closed disc
+`TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le`.
+
+This is the **geometric** counterpart of the analytic criterion
+`TauCeti.exists_continuousOn_closedBall_eqOn` of `Conformal/Crosscut.lean`. That one asks for a
+bound on the values of `f` along the crosscut arc *and along a collar* of the boundary circle, and
+runs on the maximum modulus principle; this one replaces the collar bound by a hypothesis about the
+*image*, namely that the boundary points of `Ω` clinging to the cut-off piece can be enclosed in a
+small set `E`. That is the shape in which the two remaining L5 inputs arrive: the length–area method
+makes the image crosscut short, and local connectedness of `∂Ω` supplies the small connected `E`
+joining its two ends. Neither is proved here; what is proved here is that those two data suffice,
+with no maximum principle and no estimate on `f` inside the disc.
+
+Nothing below assumes that `ζ` lies on the boundary circle, that `ρ` is smaller than `2 * r`, or
+that `Ω` is anything but bounded, so the hypotheses stay checkable; only the final two theorems,
+which produce a limit, ask `ζ` to be a boundary point.
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The two ingredients
+are stated at their own generality elsewhere: `TauCeti.diam_frontier` for an arbitrary real normed
+space, and `TauCeti.IsPreconnected.inter_frontier_nonempty` for an arbitrary topological space.
+
+## Main results
+
+* `TauCeti.frontier_image_ball_inter_ball_subset` — the boundary of the image of a crosscut
+  neighbourhood is covered by the image crosscut and the boundary of the image domain.
+* `TauCeti.diam_image_ball_inter_ball_le` — the image of a crosscut neighbourhood is no wider than
+  the image crosscut together with the boundary piece it cuts off.
+* `TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_le` and
+  `TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le` — small cut-off pieces
+  make the boundary cluster set a subsingleton.
+* `TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` and
+  `TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le` — the resulting
+  boundary limit and continuous extension to the closed disc.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and Mathlib
+has no boundary correspondence for conformal maps. So this file is new Lean formalization rather
+than a temporary shim. It consumes the L0–L3 shim
+`TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib's open mapping
+API once the upstream work lands.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2–2.3.
+* P. L. Duren, *Univalent Functions*, Ch. 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Complex Filter Metric Set Topology
+
+variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+
+/-! ## The boundary of the image of a crosscut neighbourhood -/
+
+/-- **The boundary of the image of a crosscut neighbourhood lies on the image crosscut and on the
+boundary of the image domain.** For `f` holomorphic and injective on `ball c r`, the frontier of the
+image `f '' (ball c r ∩ ball ζ ρ)` of the crosscut neighbourhood is covered by the image
+`f '' (ball c r ∩ sphere ζ ρ)` of the crosscut arc together with `frontier (f '' ball c r)`.
+
+The three sets `f '' (ball c r ∩ ball ζ ρ)`, `f '' (ball c r \ closedBall ζ ρ)` and `f '' ball c r`
+are open by the open mapping theorem, and injectivity makes the first two disjoint. A frontier point
+of the first that is not a frontier point of the third is therefore a value `f w` with
+`dist w ζ = ρ`: the case `dist w ζ < ρ` would place it inside an open set disjoint from its own
+frontier, and the case `dist w ζ > ρ` would place it inside an open set disjoint from a set it is in
+the closure of. -/
+theorem frontier_image_ball_inter_ball_subset (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) :
+    frontier (f '' (ball c r ∩ ball ζ ρ))
+      ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) := by
+  have hAopen : IsOpen (f '' (ball c r ∩ ball ζ ρ)) :=
+    isOpen_image_of_differentiableOn_of_injOn (isOpen_ball.inter isOpen_ball)
+      (hd.mono inter_subset_left) (hinj.mono inter_subset_left)
+  intro p hp
+  have hpΩ : p ∈ closure (f '' ball c r) :=
+    closure_mono (image_mono inter_subset_left) hp.1
+  rw [closure_eq_self_union_frontier] at hpΩ
+  rcases hpΩ with hpin | hpfr
+  · obtain ⟨w, hw, rfl⟩ := hpin
+    rcases lt_trichotomy (dist w ζ) ρ with hlt | heq | hgt
+    · exact absurd ⟨⟨w, ⟨hw, mem_ball.mpr hlt⟩, rfl⟩, hp⟩
+        (eq_empty_iff_forall_notMem.mp hAopen.inter_frontier_eq (f w))
+    · exact Or.inl ⟨w, ⟨hw, mem_sphere.mpr heq⟩, rfl⟩
+    · exfalso
+      have hBopen : IsOpen (f '' (ball c r \ closedBall ζ ρ)) :=
+        isOpen_image_of_differentiableOn_of_injOn (isOpen_ball.sdiff isClosed_closedBall)
+          (hd.mono sdiff_subset) (hinj.mono sdiff_subset)
+      have hwB : f w ∈ f '' (ball c r \ closedBall ζ ρ) :=
+        ⟨w, ⟨hw, fun hc => absurd (mem_closedBall.mp hc) (not_le.mpr hgt)⟩, rfl⟩
+      obtain ⟨q, ⟨u, hu, hfu⟩, ⟨v, hv, hfv⟩⟩ := mem_closure_iff.mp hp.1 _ hBopen hwB
+      have huv : u = v := hinj hu.1 hv.1 (hfu.trans hfv.symm)
+      subst huv
+      exact hu.2 (ball_subset_closedBall hv.2)
+  · exact Or.inr hpfr
+
+/-! ## The diameter of the cut-off piece -/
+
+/-- **The image of a crosscut neighbourhood is no wider than the image crosscut together with the
+boundary piece it cuts off.** If every boundary point of the image domain `f '' ball c r` that lies
+on the frontier of `f '' (ball c r ∩ ball ζ ρ)` belongs to a bounded set `E`, then the diameter of
+that image is at most the diameter of `f '' (ball c r ∩ sphere ζ ρ) ∪ E`.
+
+This is `TauCeti.frontier_image_ball_inter_ball_subset` read through `TauCeti.diam_frontier`, which
+says a bounded set has exactly the diameter of its frontier. No estimate on `f` is used: the width
+of the cut-off piece is entirely determined by the width of what bounds it. -/
+theorem diam_image_ball_inter_ball_le (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E) :
+    diam (f '' (ball c r ∩ ball ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) := by
+  have harc : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
+    hb.subset (image_mono inter_subset_left)
+  rw [← diam_frontier (hb.subset (image_mono inter_subset_left))]
+  refine diam_mono (fun p hp => ?_) (harc.union hE)
+  rcases frontier_image_ball_inter_ball_subset hd hinj hp with h | h
+  · exact Or.inl h
+  · exact Or.inr (hEsub ⟨h, hp⟩)
+
+/-! ## The boundary limit -/
+
+/-- **Small cut-off pieces make the boundary cluster set a subsingleton.** If for every `ε > 0`
+there is a radius `ρ > 0` at which the image `f '' (ball c r ∩ ball ζ ρ)` of the crosscut
+neighbourhood has diameter at most `ε`, then `f` has at most one cluster value at `ζ` along the
+disc.
+
+Only boundedness of the image is assumed — no holomorphy, no injectivity — because the diameter
+hypothesis *is* the Cauchy criterion of `TauCeti.subsingleton_clusterSetOn_of_forall_exists`: the
+crosscut neighbourhoods are exactly the traces on the disc of the balls around `ζ`. Boundedness is
+needed only because `Metric.diam` vanishes on unbounded sets, so a diameter bound is otherwise no
+bound at all. -/
+theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_le (hb : IsBounded (f '' ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε) :
+    (clusterSetOn f (ball c r) ζ).Subsingleton := by
+  refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
+  obtain ⟨ρ, hρ, hdiam⟩ := h ε hε
+  refine ⟨ρ, hρ, fun x hx y hy => le_trans ?_ hdiam⟩
+  exact dist_le_diam_of_mem (hb.subset (image_mono inter_subset_left))
+    (mem_image_of_mem f hx) (mem_image_of_mem f hy)
+
+/-- **The crosscut criterion in geometric form, cluster-set version.** If for every `ε > 0` there
+is a crosscut radius `ρ > 0` and a bounded set `E` enclosing the boundary points of the image domain
+that cling to the cut-off piece, such that the image crosscut together with `E` has diameter at most
+`ε`, then `f` has at most one cluster value at `ζ` along the disc.
+
+This is `TauCeti.diam_image_ball_inter_ball_le` fed to
+`TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_le`. -/
+theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    (clusterSetOn f (ball c r) ζ).Subsingleton := by
+  refine subsingleton_clusterSetOn_ball_of_forall_exists_diam_le hb fun ε hε => ?_
+  obtain ⟨ρ, hρ, E, hEb, hEsub, hEdiam⟩ := h ε hε
+  exact ⟨ρ, hρ, (diam_image_ball_inter_ball_le hd hinj hb hEb hEsub).trans hEdiam⟩
+
+/-- **The crosscut criterion in geometric form, boundary-limit version.** A conformal map of a disc
+with bounded image has a limit at a boundary point `ζ`, along the disc, as soon as the pieces it
+cuts off at `ζ` can be made small in the sense of
+`TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le`.
+
+The cluster set is a subsingleton by that theorem, and it is nonempty because `f` maps the disc into
+the compact closure of its bounded image, which is what
+`TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` needs. -/
+theorem exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le (hr : 0 < r)
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r)
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) := by
+  refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
+    (fun w hw => subset_closure ⟨w, hw, rfl⟩) ?_
+    (subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le hd hinj hb h)
+  rw [closure_ball c hr.ne']
+  exact mem_closedBall.mpr hζ.le
+
+/-- **The crosscut criterion in geometric form, continuous-extension version.** If the hypothesis of
+`TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` holds at *every* point
+of the boundary circle, the conformal map `f` extends continuously to `closedBall c r`.
+
+This is the shape the Carathéodory boundary correspondence is proved in once the two geometric
+inputs are available: the length–area method makes the image crosscut short at some radius, and
+local connectedness of the image boundary supplies the small set `E` joining its ends. Nothing here
+asserts that the extension is injective, which is an independent matter. -/
+theorem exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le (hr : 0 < r)
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r))
+    (h : ∀ w ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball w ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere w ρ) ∪ E) ≤ ε) :
+    ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
+  obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball
+    hd.continuousOn hb fun w hw => by
+      refine subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le hd hinj hb (h w ?_)
+      rwa [frontier_ball c hr.ne'] at hw
+  exact ⟨F, closure_ball c hr.ne' ▸ hFc, hFe⟩
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/DiamFrontier.lean
+++ b/TauCeti/Analysis/Normed/Module/DiamFrontier.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.Topology.MetricSpace.Bounded
+public import TauCeti.Topology.Frontier
+
+/-!
+# A bounded set is exactly as wide as its frontier
+
+In a real normed space a bounded set `V` and its frontier have the same diameter:
+`TauCeti.diam_frontier`. One inequality is trivial, `frontier V` being contained in `closure V`.
+The other says that the frontier already realises every distance realised inside `V`, and it is
+the geometric content: a set cannot be wide and have a narrow boundary.
+
+The mechanism is that a ray leaving a bounded set has to cross the frontier, and crossing it only
+*later* than it passes through a given point of the set. Precisely
+(`TauCeti.exists_mem_frontier_dist_le`), for `x ∈ V` and any base point `y ≠ x` the ray
+`t ↦ y + t • (x - y)`, followed from `t = 1` outwards, eventually leaves the bounded set `V`, and
+the segment it traces is connected, so `TauCeti.IsPreconnected.inter_frontier_nonempty` produces a
+frontier point `p = y + t • (x - y)` with `t ≥ 1`, whence `dist y p = t * dist y x ≥ dist y x`.
+
+Applying this twice turns a pair of points of `V` into a pair of frontier points at least as far
+apart: first push `x` away from `y` to a frontier point `p`, then push `y` away from `p` to a
+frontier point `q`, and `dist x y ≤ dist y p ≤ dist p q`. Boundedness is essential and not merely
+a convenience of `Metric.diam`, which vanishes on unbounded sets: in `ℝ` the unbounded set
+`Metric.ball 0 1 ∪ Set.Ici 2` has frontier `{-1, 1, 2}` of diameter `3`.
+
+Nothing here needs `V` to be open, connected, or measurable, and the ambient space is an arbitrary
+real normed space: only the segment and the norm are used.
+
+The intended consumer is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's
+boundary correspondence. There the piece of a domain that a crosscut cuts off has to be shown small,
+and what is small is its boundary — the crosscut itself together with the arc of the domain boundary
+it separates; `TauCeti.diam_frontier` is what converts that into a bound on the piece.
+`TauCeti/Analysis/Complex/Conformal/CutDiameter.lean` carries out that conversion.
+
+## Main results
+
+* `TauCeti.exists_mem_frontier_dist_le` — from a point of a bounded set, the ray away from any other
+  base point reaches the frontier no sooner than it reaches that point.
+* `TauCeti.diam_le_diam_frontier` and `TauCeti.diam_frontier` — a bounded set is exactly as wide as
+  its frontier.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Metric Set
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {V : Set E} {x y : E}
+
+/-- **A ray leaving a bounded set crosses its frontier, and does so no sooner than it passes
+through a given point of the set.** For `x` in a bounded set `V` and any base point `y ≠ x`, the
+ray from `y` through `x` meets `frontier V` at a point `p` with `dist y x ≤ dist y p`.
+
+The ray is followed from `x` outwards. It leaves `V` because `V` is bounded, the segment traced is
+connected, and `TauCeti.IsPreconnected.inter_frontier_nonempty` therefore hands back a frontier
+point on it; being beyond `x` on the ray, that point is at least as far from `y` as `x` is. -/
+theorem exists_mem_frontier_dist_le (hV : IsBounded V) (hx : x ∈ V) (hne : y ≠ x) :
+    ∃ p ∈ frontier V, dist y x ≤ dist y p := by
+  obtain ⟨R, hR⟩ := hV.subset_closedBall y
+  set d : E := x - y with hd
+  have hdpos : 0 < ‖d‖ := norm_pos_iff.mpr (sub_ne_zero.mpr hne.symm)
+  set γ : ℝ → E := fun t => y + t • d with hγ
+  have hγdist : ∀ t : ℝ, 0 ≤ t → dist y (γ t) = t * ‖d‖ := by
+    intro t ht
+    rw [hγ, dist_eq_norm]
+    simp [norm_smul, abs_of_nonneg ht]
+  have hγ1 : γ 1 = x := by simp [hγ, hd]
+  set T : ℝ := max 1 ((R + 1) / ‖d‖) with hT
+  have hT1 : (1 : ℝ) ≤ T := le_max_left _ _
+  have hTd : R + 1 ≤ T * ‖d‖ := by
+    have := le_max_right 1 ((R + 1) / ‖d‖)
+    calc R + 1 = (R + 1) / ‖d‖ * ‖d‖ := by field_simp
+      _ ≤ T * ‖d‖ := by gcongr
+  have hTV : γ T ∉ V := by
+    intro hmem
+    have := mem_closedBall.mp (hR hmem)
+    rw [dist_comm] at this
+    rw [hγdist T (by linarith)] at this
+    linarith
+  have hcont : Continuous γ := by fun_prop
+  have hSconn : IsPreconnected (γ '' Icc 1 T) :=
+    isPreconnected_Icc.image γ hcont.continuousOn
+  obtain ⟨p, hpS, hpf⟩ := IsPreconnected.inter_frontier_nonempty hSconn
+    ⟨x, ⟨1, ⟨le_rfl, hT1⟩, hγ1⟩, hx⟩ ⟨γ T, ⟨T, ⟨hT1, le_rfl⟩, rfl⟩, hTV⟩
+  obtain ⟨t, ht, rfl⟩ := hpS
+  refine ⟨γ t, hpf, ?_⟩
+  rw [← hγ1, hγdist 1 zero_le_one, hγdist t (by linarith [ht.1])]
+  nlinarith [ht.1]
+
+/-- **A bounded set is no wider than its frontier.** Every distance realised between two points of
+a bounded set `V` is already realised between two points of `frontier V`: push the first point away
+from the second to the frontier, then the second away from the resulting frontier point. -/
+theorem diam_le_diam_frontier (hV : IsBounded V) : diam V ≤ diam (frontier V) := by
+  have hfb : IsBounded (frontier V) := hV.closure.subset frontier_subset_closure
+  refine diam_le_of_forall_dist_le diam_nonneg fun a ha b hb => ?_
+  rcases eq_or_ne a b with rfl | hab
+  · simpa using diam_nonneg
+  obtain ⟨p, hp, hple⟩ := exists_mem_frontier_dist_le hV ha hab.symm
+  have hpb : p ≠ b := by
+    rintro rfl
+    exact hab (dist_le_zero.mp (le_trans hple (by simp))).symm
+  obtain ⟨q, hq, hqle⟩ := exists_mem_frontier_dist_le hV hb hpb
+  calc dist a b = dist b a := dist_comm a b
+    _ ≤ dist b p := hple
+    _ = dist p b := dist_comm b p
+    _ ≤ dist p q := hqle
+    _ ≤ diam (frontier V) := dist_le_diam_of_mem hfb hp hq
+
+/-- **The diameter of a bounded set is the diameter of its frontier.** The frontier is contained in
+the closure, which gives one inequality, and `TauCeti.diam_le_diam_frontier` gives the other.
+
+Boundedness cannot be dropped: `Metric.diam` is `0` on an unbounded set, while the frontier of
+`Metric.ball 0 1 ∪ Set.Ici 2` in `ℝ` is `{-1, 1, 2}`. -/
+theorem diam_frontier (hV : IsBounded V) : diam (frontier V) = diam V := by
+  refine le_antisymm ?_ (diam_le_diam_frontier hV)
+  calc diam (frontier V) ≤ diam (closure V) := diam_mono frontier_subset_closure hV.closure
+    _ = diam V := diam_closure V
+
+end TauCeti

--- a/TauCeti/Topology/Frontier.lean
+++ b/TauCeti/Topology/Frontier.lean
@@ -1,0 +1,67 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Connected.Basic
+
+/-!
+# A connected set that straddles a set meets its frontier
+
+A preconnected set that meets both a set `V` and its complement must meet `frontier V`: it cannot
+cross from the inside of `V` to the outside without touching the boundary. This is the
+intermediate-value principle in its purely topological form, and it is the mechanism by which a
+*path* leaving a set produces a *boundary point* of that set.
+
+Mathlib records the two extreme cases — `frontier_eq_empty_iff` and `nonempty_frontier_iff` say
+that in a preconnected *space* the frontier of `V` is empty exactly when `V` is `∅` or `univ` — but
+not this relative form, which is the one an argument along a segment or a path needs. No hypothesis
+is placed on `V`; only preconnectedness of the straddling set is used.
+
+The proof is the standard clopen argument: the complement of `frontier V` is the disjoint union of
+the two open sets `interior V` and `interior Vᶜ` (`compl_frontier_eq_union_interior`), so a
+preconnected set avoiding the frontier lies inside one of them, and then it misses `V` entirely or
+is contained in `V` entirely.
+
+The intended consumer is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's
+boundary correspondence, through `TauCeti/Analysis/Normed/Module/DiamFrontier.lean`: a ray leaving a
+bounded set crosses its frontier, which is what makes the frontier of such a set as wide as the set
+itself. Nothing here is specific to that use.
+
+## Main results
+
+* `TauCeti.IsPreconnected.inter_frontier_nonempty` — a preconnected set meeting both a set and its
+  complement meets the frontier of that set.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set
+
+variable {X : Type*} [TopologicalSpace X] {S V : Set X}
+
+/-- **A preconnected set that meets both a set and its complement meets its frontier.** If `S` is
+preconnected and contains a point of `V` and a point outside `V`, then `S` meets `frontier V`.
+
+Nothing is assumed about `V`; the argument is that `(frontier V)ᶜ` is the union of the two disjoint
+open sets `interior V` and `interior Vᶜ`, so a preconnected set missing the frontier is confined to
+one of them and therefore cannot straddle `V`. -/
+theorem IsPreconnected.inter_frontier_nonempty (hS : IsPreconnected S) (h₁ : (S ∩ V).Nonempty)
+    (h₂ : (S \ V).Nonempty) : (S ∩ frontier V).Nonempty := by
+  by_contra hcon
+  have hsub : S ⊆ interior V ∪ interior Vᶜ := by
+    rw [← compl_frontier_eq_union_interior]
+    exact fun x hx hxf => hcon ⟨x, hx, hxf⟩
+  have hdisj : Disjoint (interior V) (interior Vᶜ) :=
+    disjoint_compl_right.mono interior_subset interior_subset
+  rcases hS.subset_or_subset isOpen_interior isOpen_interior hdisj hsub with h | h
+  · obtain ⟨x, hxS, hxV⟩ := h₂
+    exact hxV (interior_subset (h hxS))
+  · obtain ⟨x, hxS, hxV⟩ := h₁
+    exact interior_subset (h hxS) hxV
+
+end TauCeti


### PR DESCRIPTION
This PR measures the piece a crosscut cuts off a domain by its own boundary, supplying the geometric half of the crosscut criterion that layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "Carathéodory boundary correspondence … the RMT map of a Jordan domain extends to a homeomorphism of closures" — runs on. `Conformal/Crosscut.lean` on `main` states the remaining L5 work in its module docstring: its criterion turns an oscillation bound on the crosscut neighbourhood `ball c r ∩ ball ζ ρ` into a boundary limit, and "the length–area method delivers the bound on the arc; the bound on the collar is where local connectedness of the image boundary enters". This PR builds the second, geometric route to that bound, which bypasses the collar entirely: `TauCeti.frontier_image_ball_inter_ball_subset` shows that for `f` holomorphic and injective on `ball c r` the frontier of the image `A = f '' (ball c r ∩ ball ζ ρ)` of the crosscut neighbourhood is covered by the image crosscut `f '' (ball c r ∩ sphere ζ ρ)` together with `frontier (f '' ball c r)` — the open mapping theorem applied three times, with injectivity separating the near side of the crosscut from the far side — and `TauCeti.diam_image_ball_inter_ball_le` reads that inclusion as a diameter bound `diam A ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E)` for any bounded `E` enclosing the boundary points of the image domain that cling to `A`. Feeding those bounds to the Cauchy criterion of `Topology/ClusterSet.lean` gives `TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_le` and its geometric form, then the boundary limit `TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` and the continuous extension to the closed disc `TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le`. That is the exact shape in which the two remaining L5 inputs arrive — the length–area method makes the image crosscut short, local connectedness of `∂Ω` supplies the small connected `E` joining its two ends — and what is proved here is that those two data suffice, with no maximum principle and no estimate on `f` inside the disc. Neither input is proved here, and nothing here asserts the extension is injective.

The step that carries the content is that a bounded set is exactly as wide as its frontier, `TauCeti.diam_frontier` in the new `TauCeti/Analysis/Normed/Module/DiamFrontier.lean` (127 lines): one inequality is `frontier V ⊆ closure V`, and the other says the frontier already realises every distance realised inside `V`. Its mechanism is that a ray leaving a bounded set crosses the frontier, and crosses it no sooner than it passes through a given point of the set (`TauCeti.exists_mem_frontier_dist_le`); applying that twice turns a pair of points of `V` into a pair of frontier points at least as far apart. Boundedness is essential rather than a convenience of `Metric.diam`, which vanishes on unbounded sets: in `ℝ` the unbounded `Metric.ball 0 1 ∪ Set.Ici 2` has frontier `{-1, 1, 2}` of diameter `3`. The ray argument needs the purely topological fact that a preconnected set meeting both a set and its complement meets its frontier, which is `TauCeti.IsPreconnected.inter_frontier_nonempty` in the new `TauCeti/Topology/Frontier.lean` (67 lines); Mathlib records only the absolute cases `frontier_eq_empty_iff` and `nonempty_frontier_iff` for a preconnected *space*, not this relative form. Both are stated at their natural generality — an arbitrary topological space and an arbitrary real normed space — while the conformal file `TauCeti/Analysis/Complex/Conformal/CutDiameter.lean` (260 lines) is scalar `ℂ`, as the generality bar of the roadmap fixes for layers L0–L6.

Nothing here duplicates existing work. The pinned Mathlib has no lemma relating `Metric.diam` to `frontier` and no preconnected-set-meets-frontier lemma; `compl_frontier_eq_union_interior`, `IsPreconnected.subset_or_subset`, `Metric.diam_closure`, `Metric.diam_mono` and `mem_closure_iff` are consumed rather than restated, and no Mathlib infrastructure is vendored. Within the repository the open mapping input is `TauCeti.isOpen_image_of_differentiableOn_of_injOn` from `Conformal/ImageSimplyConnected.lean` and the cluster-set machinery is `Topology/ClusterSet.lean`, both reused rather than redone. The in-flight L5 threads are disjoint: the length–area inequality (#1636) is the quantitative estimate on the map itself with no statement about frontiers, while boundary cluster sets, uniform local connectedness and boundary constancy across an arc concern a map that already extends or the topology of the boundary; this is the geometric identification of what bounds the cut-off piece, and `Conformal/Crosscut.lean` supplies only the *analytic* criterion, via the maximum modulus principle on the same neighbourhood.

Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and Mathlib has no boundary correspondence for conformal maps, so this is new Lean formalization rather than a temporary shim. It does consume the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib's open mapping API once the upstream work lands. `lake build` (6100 jobs), `lake exe axioms` (18314 declarations, allowlist `propext`, `Classical.choice`, `Quot.sound`), `lake exe module-system` (1010 modules) and `scripts/lint-env.sh` are all green.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"crosscut-diameter-boundary-limit"}-->

🤖 Prepared with Claude Code
