### PR TITLE
feat: prove the vertex projectives and injectives of an acyclic quiver indecomposable

### DIFF
--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -26,7 +26,7 @@ extra hypothesis and is not needed by any consumer here.
 
 ## Main results
 
-* `TauCeti.indecomposable_of_forall_idempotent`: a nonzero object whose only idempotent
+* `TauCeti.indecomposable_of_idempotent_eq_zero_or_id`: a nonzero object whose only idempotent
   endomorphisms are `0` and the identity is indecomposable.
 * `TauCeti.exists_eq_smul_id_of_finrank_end_eq_one`: in a `k`-linear category, an object with a
   one-dimensional endomorphism space has every endomorphism a scalar multiple of the identity.
@@ -38,9 +38,9 @@ The idempotent hypothesis is phrased with composition, `e ≫ e = e`, rather tha
 `CategoryTheory.End X`, whose multiplication is composition in the opposite order; for an
 idempotent the two agree, but the hypothesis is easier to discharge as stated.
 
-`indecomposable_of_forall_idempotent` extracts, from an isomorphism `X ≅ Y ⊞ Z`, the idempotent
-`biprod.fst ≫ biprod.inl` transported to `X`. It is `0` exactly when `Y` is zero and the identity
-exactly when `Z` is zero, so the hypothesis splits the decomposition; the proof reads off
+`indecomposable_of_idempotent_eq_zero_or_id` extracts, from an isomorphism `X ≅ Y ⊞ Z`, the
+idempotent `biprod.fst ≫ biprod.inl` transported to `X`. It is `0` exactly when `Y` is zero and the
+identity exactly when `Z` is zero, so the hypothesis splits the decomposition; the proof reads off
 `𝟙 Y` and `𝟙 Z` from it using only the biproduct equations `biprod.inl_fst`, `biprod.inr_snd` and
 `biprod.inr_fst`.
 
@@ -62,7 +62,7 @@ variable {C : Type u} [Category.{v} C] [Preadditive C]
 /-- **An object with no nontrivial idempotent endomorphism is indecomposable.** A decomposition
 `X ≅ Y ⊞ Z` produces the idempotent `biprod.fst ≫ biprod.inl` on `X`; it is `0` only if `Y` is
 zero, and the identity only if `Z` is zero. -/
-theorem indecomposable_of_forall_idempotent [HasBinaryBiproducts C] {X : C} (hX : ¬ IsZero X)
+theorem indecomposable_of_idempotent_eq_zero_or_id [HasBinaryBiproducts C] {X : C} (hX : ¬ IsZero X)
     (h : ∀ e : X ⟶ X, e ≫ e = e → e = 0 ∨ e = 𝟙 X) : Indecomposable X := by
   refine ⟨hX, fun Y Z i ↦ ?_⟩
   have hidem : (i.hom ≫ biprod.fst ≫ biprod.inl ≫ i.inv) ≫
@@ -104,11 +104,12 @@ theorem exists_eq_smul_id_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X
 
 /-- **A brick is indecomposable.** If the endomorphism space of `X` is one-dimensional over the
 base field then every endomorphism is a scalar, so the only idempotents are `0` and the identity
-and `TauCeti.indecomposable_of_forall_idempotent` applies. -/
+and `TauCeti.indecomposable_of_idempotent_eq_zero_or_id` applies. -/
 theorem indecomposable_of_finrank_end_eq_one [HasBinaryBiproducts C] {X : C}
     (h : Module.finrank k (X ⟶ X) = 1) :
     Indecomposable X := by
-  refine indecomposable_of_forall_idempotent (not_isZero_of_finrank_end_eq_one h) fun e he ↦ ?_
+  refine indecomposable_of_idempotent_eq_zero_or_id (not_isZero_of_finrank_end_eq_one h)
+    fun e he ↦ ?_
   obtain ⟨c, rfl⟩ := exists_eq_smul_id_of_finrank_end_eq_one h e
   rw [Linear.smul_comp, Linear.comp_smul, Category.comp_id, smul_smul] at he
   rcases eq_or_ne c 0 with rfl | hc

--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Limits.Shapes.BinaryBiproducts
+public import Mathlib.CategoryTheory.Linear.Basic
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+
+/-!
+# Recognizing indecomposable objects from their endomorphisms
+
+Mathlib defines `CategoryTheory.Indecomposable X` as the conjunction "`X` is not a zero object,
+and in every decomposition `X ≅ Y ⊞ Z` one of `Y`, `Z` is zero", and proves exactly one criterion
+for it: a simple object is indecomposable (`CategoryTheory.indecomposable_of_simple`). That
+criterion is too strong for the objects that carry the theory of a finite-dimensional algebra: an
+indecomposable projective module is almost never simple. The criterion that does apply is the one
+this file supplies — an object all of whose idempotent endomorphisms are trivial is
+indecomposable — together with the form in which it is used in practice: over a field, an object
+whose endomorphism space is one-dimensional (a *brick*) is indecomposable.
+
+Only one direction is proved. The converse needs a decomposition `X ≅ im e ⊞ ker e` attached to an
+idempotent `e`, that is, idempotent completeness of the ambient category, which is a genuinely
+extra hypothesis and is not needed by any consumer here.
+
+## Main results
+
+* `TauCeti.indecomposable_of_forall_idempotent`: a nonzero object whose only idempotent
+  endomorphisms are `0` and the identity is indecomposable.
+* `TauCeti.exists_eq_smul_id_of_finrank_end_eq_one`: in a `k`-linear category, an object with a
+  one-dimensional endomorphism space has every endomorphism a scalar multiple of the identity.
+* `TauCeti.indecomposable_of_finrank_end_eq_one`: **a brick is indecomposable**.
+
+## Implementation notes
+
+The idempotent hypothesis is phrased with composition, `e ≫ e = e`, rather than through the ring
+`CategoryTheory.End X`, whose multiplication is composition in the opposite order; for an
+idempotent the two agree, but the hypothesis is easier to discharge as stated.
+
+`indecomposable_of_forall_idempotent` extracts, from an isomorphism `X ≅ Y ⊞ Z`, the idempotent
+`biprod.fst ≫ biprod.inl` transported to `X`. It is `0` exactly when `Y` is zero and the identity
+exactly when `Z` is zero, so the hypothesis splits the decomposition; the proof reads off
+`𝟙 Y` and `𝟙 Z` from it using only the biproduct equations `biprod.inl_fst`, `biprod.inr_snd` and
+`biprod.inr_fst`.
+
+The brick criterion is stated for a field. The argument itself only inverts one scalar, so it
+would run over a division ring, but `CategoryTheory.Linear` takes a commutative base and
+`Module.finrank` is the invariant used by the consumers, so no generality is lost in practice.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory CategoryTheory.Limits
+
+universe v u
+
+variable {C : Type u} [Category.{v} C] [Preadditive C]
+
+/-- **An object with no nontrivial idempotent endomorphism is indecomposable.** A decomposition
+`X ≅ Y ⊞ Z` produces the idempotent `biprod.fst ≫ biprod.inl` on `X`; it is `0` only if `Y` is
+zero, and the identity only if `Z` is zero. -/
+theorem indecomposable_of_forall_idempotent [HasBinaryBiproducts C] {X : C} (hX : ¬ IsZero X)
+    (h : ∀ e : X ⟶ X, e ≫ e = e → e = 0 ∨ e = 𝟙 X) : Indecomposable X := by
+  refine ⟨hX, fun Y Z i ↦ ?_⟩
+  have hidem : (i.hom ≫ biprod.fst ≫ biprod.inl ≫ i.inv) ≫
+      (i.hom ≫ biprod.fst ≫ biprod.inl ≫ i.inv) = i.hom ≫ biprod.fst ≫ biprod.inl ≫ i.inv := by
+    simp
+  rcases h _ hidem with h0 | h1
+  · refine Or.inl ((IsZero.iff_id_eq_zero Y).mpr ?_)
+    -- Conjugating back and framing with `biprod.inl`, `biprod.fst` turns the idempotent into `𝟙 Y`.
+    have := congrArg (fun f : X ⟶ X ↦ biprod.inl ≫ i.inv ≫ f ≫ i.hom ≫ biprod.fst) h0
+    simpa using this
+  · refine Or.inr ((IsZero.iff_id_eq_zero Z).mpr ?_)
+    -- Framing instead with `biprod.inr`, `biprod.snd` kills the idempotent and leaves `𝟙 Z`.
+    have := congrArg (fun f : X ⟶ X ↦ biprod.inr ≫ i.inv ≫ f ≫ i.hom ≫ biprod.snd) h1
+    simpa using this.symm
+
+variable {k : Type*} [Field k] [Linear k C]
+
+/-- An object whose endomorphism space is one-dimensional has a nonzero identity, hence is not a
+zero object. -/
+theorem id_ne_zero_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X ⟶ X) = 1) :
+    𝟙 X ≠ 0 := by
+  haveI : Nontrivial (X ⟶ X) := Module.nontrivial_of_finrank_pos (R := k) (by rw [h]; exact one_pos)
+  obtain ⟨f, g, hfg⟩ := exists_pair_ne (X ⟶ X)
+  intro hid
+  exact hfg (by rw [← Category.comp_id f, ← Category.comp_id g, hid, comp_zero, comp_zero])
+
+/-- An object whose endomorphism space is one-dimensional is not a zero object. -/
+theorem not_isZero_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X ⟶ X) = 1) :
+    ¬ IsZero X := fun hX ↦
+  id_ne_zero_of_finrank_end_eq_one h ((IsZero.iff_id_eq_zero X).mp hX)
+
+/-- **Every endomorphism of a brick is a scalar.** If the endomorphism space of `X` is
+one-dimensional then the identity spans it, so each endomorphism is `c • 𝟙 X`. -/
+theorem exists_eq_smul_id_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X ⟶ X) = 1)
+    (f : X ⟶ X) : ∃ c : k, f = c • 𝟙 X := by
+  obtain ⟨c, hc⟩ :=
+    (finrank_eq_one_iff_of_nonzero' (𝟙 X) (id_ne_zero_of_finrank_end_eq_one h)).mp h f
+  exact ⟨c, hc.symm⟩
+
+/-- **A brick is indecomposable.** If the endomorphism space of `X` is one-dimensional over the
+base field then every endomorphism is a scalar, so the only idempotents are `0` and the identity
+and `TauCeti.indecomposable_of_forall_idempotent` applies. -/
+theorem indecomposable_of_finrank_end_eq_one [HasBinaryBiproducts C] {X : C}
+    (h : Module.finrank k (X ⟶ X) = 1) :
+    Indecomposable X := by
+  refine indecomposable_of_forall_idempotent (not_isZero_of_finrank_end_eq_one h) fun e he ↦ ?_
+  obtain ⟨c, rfl⟩ := exists_eq_smul_id_of_finrank_end_eq_one h e
+  rw [Linear.smul_comp, Linear.comp_smul, Category.comp_id, smul_smul] at he
+  rcases eq_or_ne c 0 with rfl | hc
+  · exact Or.inl (zero_smul k (𝟙 X))
+  · refine Or.inr ?_
+    -- Scaling the idempotent equation `(c * c) • 𝟙 X = c • 𝟙 X` by `c⁻¹` gives `c • 𝟙 X = 𝟙 X`.
+    have := congrArg (fun f : X ⟶ X ↦ c⁻¹ • f) he
+    simpa [smul_smul, ← mul_assoc, inv_mul_cancel₀ hc] using this
+
+end TauCeti

--- a/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
+++ b/TauCeti/CategoryTheory/Preadditive/Indecomposable.lean
@@ -28,9 +28,8 @@ extra hypothesis and is not needed by any consumer here.
 
 * `TauCeti.indecomposable_of_idempotent_eq_zero_or_id`: a nonzero object whose only idempotent
   endomorphisms are `0` and the identity is indecomposable.
-* `TauCeti.exists_eq_smul_id_of_finrank_end_eq_one`: in a `k`-linear category, an object with a
-  one-dimensional endomorphism space has every endomorphism a scalar multiple of the identity.
-* `TauCeti.indecomposable_of_finrank_end_eq_one`: **a brick is indecomposable**.
+* `TauCeti.indecomposable_of_finrank_end_eq_one`: in a `k`-linear category over a field,
+  **a brick is indecomposable**.
 
 ## Implementation notes
 
@@ -43,6 +42,9 @@ idempotent `biprod.fst ≫ biprod.inl` transported to `X`. It is `0` exactly whe
 identity exactly when `Z` is zero, so the hypothesis splits the decomposition; the proof reads off
 `𝟙 Y` and `𝟙 Z` from it using only the biproduct equations `biprod.inl_fst`, `biprod.inr_snd` and
 `biprod.inr_fst`.
+
+That every endomorphism of a brick is a scalar is Mathlib's `finrank_eq_one_iff_of_nonzero'`
+applied to the identity, which spans the endomorphism space because it is nonzero.
 
 The brick criterion is stated for a field. The argument itself only inverts one scalar, so it
 would run over a division ring, but `CategoryTheory.Linear` takes a commutative base and
@@ -94,23 +96,16 @@ theorem not_isZero_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X ⟶ X)
     ¬ IsZero X := fun hX ↦
   id_ne_zero_of_finrank_end_eq_one h ((IsZero.iff_id_eq_zero X).mp hX)
 
-/-- **Every endomorphism of a brick is a scalar.** If the endomorphism space of `X` is
-one-dimensional then the identity spans it, so each endomorphism is `c • 𝟙 X`. -/
-theorem exists_eq_smul_id_of_finrank_end_eq_one {X : C} (h : Module.finrank k (X ⟶ X) = 1)
-    (f : X ⟶ X) : ∃ c : k, f = c • 𝟙 X := by
-  obtain ⟨c, hc⟩ :=
-    (finrank_eq_one_iff_of_nonzero' (𝟙 X) (id_ne_zero_of_finrank_end_eq_one h)).mp h f
-  exact ⟨c, hc.symm⟩
-
 /-- **A brick is indecomposable.** If the endomorphism space of `X` is one-dimensional over the
-base field then every endomorphism is a scalar, so the only idempotents are `0` and the identity
-and `TauCeti.indecomposable_of_idempotent_eq_zero_or_id` applies. -/
+base field then the identity spans it, so every endomorphism is a scalar, the only idempotents are
+`0` and the identity and `TauCeti.indecomposable_of_idempotent_eq_zero_or_id` applies. -/
 theorem indecomposable_of_finrank_end_eq_one [HasBinaryBiproducts C] {X : C}
     (h : Module.finrank k (X ⟶ X) = 1) :
     Indecomposable X := by
   refine indecomposable_of_idempotent_eq_zero_or_id (not_isZero_of_finrank_end_eq_one h)
     fun e he ↦ ?_
-  obtain ⟨c, rfl⟩ := exists_eq_smul_id_of_finrank_end_eq_one h e
+  obtain ⟨c, rfl⟩ :=
+    (finrank_eq_one_iff_of_nonzero' (𝟙 X) (id_ne_zero_of_finrank_end_eq_one h)).mp h e
   rw [Linear.smul_comp, Linear.comp_smul, Category.comp_id, smul_smul] at he
   rcases eq_or_ne c 0 with rfl | hc
   · exact Or.inl (zero_smul k (𝟙 X))

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Combinatorics.Quiver.Path.Vertices
 public import Mathlib.Data.List.Nodup
+public import Mathlib.SetTheory.Cardinal.Finite
 
 /-!
 # Acyclic quivers
@@ -158,6 +159,12 @@ theorem isEmpty_hom_of_hom (h : Quiver.IsAcyclic V) {a b : V}
 theorem subsingleton_path_self (h : Quiver.IsAcyclic V) (a : V) :
     Subsingleton (Path a a) :=
   ⟨fun p q ↦ (h.eq_nil p).trans (h.eq_nil q).symm⟩
+
+/-- An acyclic quiver has exactly one closed path at each vertex, the trivial one. -/
+theorem card_path_self (h : Quiver.IsAcyclic V) (a : V) : Nat.card (Path a a) = 1 := by
+  haveI : Nonempty (Path a a) := ⟨Path.nil⟩
+  letI : Subsingleton (Path a a) := h.subsingleton_path_self a
+  exact Nat.card_unique
 
 /-- A quiver with no arrows is acyclic. -/
 theorem of_isEmpty_hom [∀ a b : V, IsEmpty (a ⟶ b)] :

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -74,6 +74,8 @@ namespace Quiver.IsAcyclic
 theorem length_lt_card (h : Quiver.IsAcyclic V) [Fintype V] {a b : V}
     (p : _root_.Quiver.Path a b) :
     p.length < Fintype.card V := by
+  -- The bound is unfolded by hand rather than by `simpa`: `Quiver.IsAcyclic.card_path_self` puts
+  -- `Nat.card` in scope for this file, and simp then exceeds `maxRecDepth` on this goal.
   have hle := List.Nodup.length_le_card (h.vertices_nodup p)
   rw [_root_.Quiver.Path.vertices_length] at hle
   omega

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -74,7 +74,9 @@ namespace Quiver.IsAcyclic
 theorem length_lt_card (h : Quiver.IsAcyclic V) [Fintype V] {a b : V}
     (p : _root_.Quiver.Path a b) :
     p.length < Fintype.card V := by
-  simpa [Nat.lt_iff_add_one_le] using List.Nodup.length_le_card (h.vertices_nodup p)
+  have hle := List.Nodup.length_le_card (h.vertices_nodup p)
+  rw [_root_.Quiver.Path.vertices_length] at hle
+  omega
 
 private theorem finite_paths [Finite V] [∀ a b : V, Finite (a ⟶ b)] (h : Quiver.IsAcyclic V) :
     Finite (Σ a b : V, _root_.Quiver.Path a b) := by

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
@@ -70,11 +70,10 @@ The non-isomorphism results are stated as `¬ Nonempty (… ≅ …)` rather tha
 objects, matching `TauCeti.not_nonempty_simpleRep_iso`: representations are compared up to
 isomorphism, never by equality.
 
-Two private helpers carry the shared combinatorics — that an acyclic quiver has exactly one closed
-path at each vertex, and that a path count of `1` in each direction between two vertices forces
-them equal. They are private because they are `Nat.card` repackagings of
-`Quiver.IsAcyclic.subsingleton_path_self` and `Quiver.IsAcyclic.eq_of_paths`, which are the public
-statements of those facts.
+The count of closed paths in an acyclic quiver is `Quiver.IsAcyclic.card_path_self`, stated with
+the rest of the acyclic path API. A private helper turns a path count of `1` in each direction
+between two vertices into their equality; it is private because it is a `Nat.card` repackaging of
+`Quiver.IsAcyclic.eq_of_paths`, which is the public statement of that fact.
 
 ## References
 
@@ -99,13 +98,6 @@ representations. No hypothesis on the quiver is needed. -/
 theorem indecomposable_simpleRep (i : Q) : Indecomposable (simpleRep k Q i) :=
   indecomposable_of_simple _
 
-/-- Over an acyclic quiver there is exactly one closed path at every vertex, the trivial one. -/
-private theorem card_path_self_of_isAcyclic (h : Quiver.IsAcyclic Q) (a : Q) :
-    Nat.card (Quiver.Path a a) = 1 := by
-  letI : Subsingleton (Quiver.Path a a) := h.subsingleton_path_self a
-  letI : Unique (Quiver.Path a a) := uniqueOfSubsingleton Quiver.Path.nil
-  exact Nat.card_unique
-
 /-- Two vertices of an acyclic quiver joined by a path in each direction coincide, in the form the
 path counts below produce. -/
 private theorem eq_of_card_path_eq_one (h : Quiver.IsAcyclic Q) {i j : Q}
@@ -119,7 +111,7 @@ private theorem eq_of_card_path_eq_one (h : Quiver.IsAcyclic Q) {i j : Q}
 of `TauCeti.finrank_end_indecProjRep_of_isAcyclic`. -/
 theorem finrank_end_indecInjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
     Module.finrank k (indecInjRep k Q i ⟶ indecInjRep k Q i) = 1 := by
-  rw [finrank_hom_indecInjRep_indecInjRep, card_path_self_of_isAcyclic h]
+  rw [finrank_hom_indecInjRep_indecInjRep, h.card_path_self]
 
 /-- **The vertex projective `Pᵢ` of an acyclic quiver is indecomposable.** Its endomorphism space
 is spanned by the identity, so it admits no nontrivial idempotent and hence no nontrivial
@@ -144,11 +136,10 @@ theorem not_nonempty_indecProjRep_iso_of_isAcyclic (h : Quiver.IsAcyclic Q) {i j
   have hd := congrFun (dimVector_eq_of_iso e)
   have hji : Nat.card (Quiver.Path j i) = 1 := by
     have h' := hd i
-    rwa [dimVector_indecProjRep, dimVector_indecProjRep, card_path_self_of_isAcyclic h i,
-      eq_comm] at h'
+    rwa [dimVector_indecProjRep, dimVector_indecProjRep, h.card_path_self i, eq_comm] at h'
   have hij' : Nat.card (Quiver.Path i j) = 1 := by
     have h' := hd j
-    rwa [dimVector_indecProjRep, dimVector_indecProjRep, card_path_self_of_isAcyclic h j] at h'
+    rwa [dimVector_indecProjRep, dimVector_indecProjRep, h.card_path_self j] at h'
   exact hij (eq_of_card_path_eq_one h hij' hji)
 
 /-- **The vertex injectives of an acyclic quiver at distinct vertices are not isomorphic**, by the
@@ -159,11 +150,10 @@ theorem not_nonempty_indecInjRep_iso_of_isAcyclic (h : Quiver.IsAcyclic Q) {i j 
   have hd := congrFun (dimVector_eq_of_iso e)
   have hij' : Nat.card (Quiver.Path i j) = 1 := by
     have h' := hd i
-    rwa [dimVector_indecInjRep, dimVector_indecInjRep, card_path_self_of_isAcyclic h i,
-      eq_comm] at h'
+    rwa [dimVector_indecInjRep, dimVector_indecInjRep, h.card_path_self i, eq_comm] at h'
   have hji : Nat.card (Quiver.Path j i) = 1 := by
     have h' := hd j
-    rwa [dimVector_indecInjRep, dimVector_indecInjRep, card_path_self_of_isAcyclic h j] at h'
+    rwa [dimVector_indecInjRep, dimVector_indecInjRep, h.card_path_self j] at h'
   exact hij (eq_of_card_path_eq_one h hij' hji)
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
@@ -8,7 +8,6 @@ public import Mathlib.CategoryTheory.Abelian.FunctorCategory
 public import TauCeti.CategoryTheory.Preadditive.Indecomposable
 public import TauCeti.RepresentationTheory.Quiver.Representation.Injective
 public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Acyclic
-public import TauCeti.RepresentationTheory.Quiver.Representation.Simple
 
 /-!
 # The vertex representations of an acyclic quiver: indecomposability and distinctness
@@ -32,7 +31,6 @@ assumption on `Q`, nor an algebraically closed base field.
 
 ## Main results
 
-* `TauCeti.indecomposable_simpleRep`: `Sᵢ` is indecomposable, over any quiver.
 * `TauCeti.finrank_end_indecInjRep_of_isAcyclic`: `dim End(Iᵢ) = 1` over an acyclic quiver, the
   injective counterpart of `TauCeti.finrank_end_indecProjRep_of_isAcyclic`.
 * `TauCeti.indecomposable_indecProjRep_of_isAcyclic` and
@@ -45,18 +43,11 @@ assumption on `Q`, nor an algebraically closed base field.
 
 ## Implementation notes
 
-`Sᵢ` is a simple object of the category of representations
-(`TauCeti.simpleRep_simple`), so its indecomposability is Mathlib's
-`CategoryTheory.indecomposable_of_simple`; it is recorded here so that the three vertex
-representations carry the property under a uniform name. `Pᵢ` and `Iᵢ` are almost never simple —
-`Pᵢ` surjects onto `Sᵢ` with a kernel spanned by the nontrivial paths out of `i` — so that route
-is unavailable for them, and the brick criterion is what replaces it.
-
-The three statements are proved separately rather than for a common universe of vertex spaces:
-`Sᵢ` is built on `k` itself while `Pᵢ` and `Iᵢ` are built on the paths at `i`, so the three objects
-live in a common category only after the universe alignment made in
-`TauCeti.RepresentationTheory.Quiver.Representation.Comparison`. Indecomposability is a property of
-one object at a time and needs no such alignment.
+`Sᵢ` needs nothing from this file: it is a simple object of the category of representations by the
+instance `TauCeti.simpleRep_simple`, so `CategoryTheory.indecomposable_of_simple (simpleRep k Q i)`
+already proves it indecomposable, over any quiver. `Pᵢ` and `Iᵢ` are almost never simple — `Pᵢ`
+surjects onto `Sᵢ` with a kernel spanned by the nontrivial paths out of `i` — so that route is
+unavailable for them, and the brick criterion is what replaces it.
 
 `finrank_end_indecInjRep_of_isAcyclic` is stated here, next to its single consumer, rather than
 beside `TauCeti.finrank_hom_indecInjRep_indecInjRep`, which it specializes: the file holding that
@@ -92,11 +83,6 @@ open CategoryTheory
 universe u v w
 
 variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
-
-/-- **The vertex simple `Sᵢ` is indecomposable**, being a simple object of the category of
-representations. No hypothesis on the quiver is needed. -/
-theorem indecomposable_simpleRep (i : Q) : Indecomposable (simpleRep k Q i) :=
-  indecomposable_of_simple _
 
 /-- Two vertices of an acyclic quiver joined by a path in each direction coincide, in the form the
 path counts below produce. -/

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Abelian.FunctorCategory
+public import TauCeti.CategoryTheory.Preadditive.Indecomposable
+public import TauCeti.RepresentationTheory.Quiver.Representation.Injective
+public import TauCeti.RepresentationTheory.Quiver.Representation.Projective.Acyclic
+public import TauCeti.RepresentationTheory.Quiver.Representation.Simple
+
+/-!
+# The vertex representations of an acyclic quiver: indecomposability and distinctness
+
+Three representations are attached to a vertex `i` of a quiver `Q`: the simple `Sᵢ`, the projective
+`Pᵢ` and the injective `Iᵢ`. The names `TauCeti.indecProjRep` and `TauCeti.indecInjRep` record the
+expectation that the last two are indecomposable, but neither file proves it. This file does, for
+an **acyclic** quiver, and it needs no Krull-Schmidt theory to do so: over an acyclic quiver the
+trivial path is the only closed path at `i`, so `Pᵢ` and `Iᵢ` are *bricks*, their endomorphism
+spaces are one-dimensional, and `TauCeti.indecomposable_of_finrank_end_eq_one` applies.
+
+The same path count makes the list irredundant: `Pᵢ ≅ Pⱼ` forces paths `i → j` and `j → i`, which
+over an acyclic quiver forces `i = j`, and dually for the injectives. So over an acyclic quiver the
+vertices index the projectives and the injectives without repetition, the property that lets them
+label the rows and columns of a Cartan matrix.
+
+Acyclicity is genuinely needed. Over the loop quiver, `Pᵢ` is the regular representation of
+`k[X]`, whose endomorphism algebra is `k[X]` itself; the statements below therefore carry
+`Quiver.IsAcyclic Q` rather than being unconditional. What is *not* needed is any finiteness
+assumption on `Q`, nor an algebraically closed base field.
+
+## Main results
+
+* `TauCeti.indecomposable_simpleRep`: `Sᵢ` is indecomposable, over any quiver.
+* `TauCeti.finrank_end_indecInjRep_of_isAcyclic`: `dim End(Iᵢ) = 1` over an acyclic quiver, the
+  injective counterpart of `TauCeti.finrank_end_indecProjRep_of_isAcyclic`.
+* `TauCeti.indecomposable_indecProjRep_of_isAcyclic` and
+  `TauCeti.indecomposable_indecInjRep_of_isAcyclic`: `Pᵢ` and `Iᵢ` are indecomposable over an
+  acyclic quiver.
+* `TauCeti.not_nonempty_indecProjRep_iso_of_isAcyclic` and
+  `TauCeti.not_nonempty_indecInjRep_iso_of_isAcyclic`: over an acyclic quiver those
+  indecomposables at distinct vertices are not isomorphic, the counterpart for `Pᵢ` and `Iᵢ` of
+  `TauCeti.not_nonempty_simpleRep_iso`.
+
+## Implementation notes
+
+`Sᵢ` is a simple object of the category of representations
+(`TauCeti.simpleRep_simple`), so its indecomposability is Mathlib's
+`CategoryTheory.indecomposable_of_simple`; it is recorded here so that the three vertex
+representations carry the property under a uniform name. `Pᵢ` and `Iᵢ` are almost never simple —
+`Pᵢ` surjects onto `Sᵢ` with a kernel spanned by the nontrivial paths out of `i` — so that route
+is unavailable for them, and the brick criterion is what replaces it.
+
+The three statements are proved separately rather than for a common universe of vertex spaces:
+`Sᵢ` is built on `k` itself while `Pᵢ` and `Iᵢ` are built on the paths at `i`, so the three objects
+live in a common category only after the universe alignment made in
+`TauCeti.RepresentationTheory.Quiver.Representation.Comparison`. Indecomposability is a property of
+one object at a time and needs no such alignment.
+
+`finrank_end_indecInjRep_of_isAcyclic` is stated here, next to its single consumer, rather than
+beside `TauCeti.finrank_hom_indecInjRep_indecInjRep`, which it specializes: the file holding that
+lemma is deliberately free of any acyclicity hypothesis, exactly as
+`TauCeti.RepresentationTheory.Quiver.Representation.Projective.Basic` is, its acyclic consequences
+living in a separate file. The two non-isomorphism results are here for the same reason, while
+`TauCeti.not_nonempty_simpleRep_iso` can stay with the simples because it needs no hypothesis on
+the quiver at all.
+
+The non-isomorphism results are stated as `¬ Nonempty (… ≅ …)` rather than as an inequality of
+objects, matching `TauCeti.not_nonempty_simpleRep_iso`: representations are compared up to
+isomorphism, never by equality.
+
+Two private helpers carry the shared combinatorics — that an acyclic quiver has exactly one closed
+path at each vertex, and that a path count of `1` in each direction between two vertices forces
+them equal. They are private because they are `Nat.card` repackagings of
+`Quiver.IsAcyclic.subsingleton_path_self` and `Quiver.IsAcyclic.eq_of_paths`, which are the public
+statements of those facts.
+
+## References
+
+This proves the indecomposability asserted by the names of the vertex projectives and injectives in
+Layer 1, by the brick route that Layer 4 identifies, of
+`TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`. See Assem--Simson--
+Skowroński, *Elements of the Representation Theory of Associative Algebras I*, Ch. III.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory
+
+universe u v w
+
+variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
+
+/-- **The vertex simple `Sᵢ` is indecomposable**, being a simple object of the category of
+representations. No hypothesis on the quiver is needed. -/
+theorem indecomposable_simpleRep (i : Q) : Indecomposable (simpleRep k Q i) :=
+  indecomposable_of_simple _
+
+/-- Over an acyclic quiver there is exactly one closed path at every vertex, the trivial one. -/
+private theorem card_path_self_of_isAcyclic (h : Quiver.IsAcyclic Q) (a : Q) :
+    Nat.card (Quiver.Path a a) = 1 := by
+  letI : Subsingleton (Quiver.Path a a) := h.subsingleton_path_self a
+  letI : Unique (Quiver.Path a a) := uniqueOfSubsingleton Quiver.Path.nil
+  exact Nat.card_unique
+
+/-- Two vertices of an acyclic quiver joined by a path in each direction coincide, in the form the
+path counts below produce. -/
+private theorem eq_of_card_path_eq_one (h : Quiver.IsAcyclic Q) {i j : Q}
+    (hij : Nat.card (Quiver.Path i j) = 1) (hji : Nat.card (Quiver.Path j i) = 1) : i = j := by
+  obtain ⟨p, -⟩ := Nat.card_eq_one_iff_exists.mp hij
+  obtain ⟨q, -⟩ := Nat.card_eq_one_iff_exists.mp hji
+  exact h.eq_of_paths p q
+
+/-- Over an acyclic quiver the endomorphism algebra of `Iᵢ` is one-dimensional, the trivial path at
+`i` being the only path `i → i`: the injective `Iᵢ` is a brick. This is the injective counterpart
+of `TauCeti.finrank_end_indecProjRep_of_isAcyclic`. -/
+theorem finrank_end_indecInjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
+    Module.finrank k (indecInjRep k Q i ⟶ indecInjRep k Q i) = 1 := by
+  rw [finrank_hom_indecInjRep_indecInjRep, card_path_self_of_isAcyclic h]
+
+/-- **The vertex projective `Pᵢ` of an acyclic quiver is indecomposable.** Its endomorphism space
+is spanned by the identity, so it admits no nontrivial idempotent and hence no nontrivial
+decomposition. -/
+theorem indecomposable_indecProjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
+    Indecomposable (indecProjRep k Q i) :=
+  indecomposable_of_finrank_end_eq_one (finrank_end_indecProjRep_of_isAcyclic h i)
+
+/-- **The vertex injective `Iᵢ` of an acyclic quiver is indecomposable**, by the same brick
+argument as for `Pᵢ`. -/
+theorem indecomposable_indecInjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
+    Indecomposable (indecInjRep k Q i) :=
+  indecomposable_of_finrank_end_eq_one (finrank_end_indecInjRep_of_isAcyclic h i)
+
+/-- **The vertex projectives of an acyclic quiver at distinct vertices are not isomorphic.** An
+isomorphism `Pᵢ ≅ Pⱼ` equates their dimension vectors, so the single closed path at each of `i` and
+`j` is matched by a path `j → i` and a path `i → j`; an acyclic quiver admits paths in both
+directions only between equal vertices. -/
+theorem not_nonempty_indecProjRep_iso_of_isAcyclic (h : Quiver.IsAcyclic Q) {i j : Q}
+    (hij : i ≠ j) : ¬ Nonempty (indecProjRep k Q i ≅ indecProjRep k Q j) := by
+  rintro ⟨e⟩
+  have hd := congrFun (dimVector_eq_of_iso e)
+  have hji : Nat.card (Quiver.Path j i) = 1 := by
+    have h' := hd i
+    rwa [dimVector_indecProjRep, dimVector_indecProjRep, card_path_self_of_isAcyclic h i,
+      eq_comm] at h'
+  have hij' : Nat.card (Quiver.Path i j) = 1 := by
+    have h' := hd j
+    rwa [dimVector_indecProjRep, dimVector_indecProjRep, card_path_self_of_isAcyclic h j] at h'
+  exact hij (eq_of_card_path_eq_one h hij' hji)
+
+/-- **The vertex injectives of an acyclic quiver at distinct vertices are not isomorphic**, by the
+same path count as for the projectives, read in the other variable. -/
+theorem not_nonempty_indecInjRep_iso_of_isAcyclic (h : Quiver.IsAcyclic Q) {i j : Q}
+    (hij : i ≠ j) : ¬ Nonempty (indecInjRep k Q i ≅ indecInjRep k Q j) := by
+  rintro ⟨e⟩
+  have hd := congrFun (dimVector_eq_of_iso e)
+  have hij' : Nat.card (Quiver.Path i j) = 1 := by
+    have h' := hd i
+    rwa [dimVector_indecInjRep, dimVector_indecInjRep, card_path_self_of_isAcyclic h i,
+      eq_comm] at h'
+  have hji : Nat.card (Quiver.Path j i) = 1 := by
+    have h' := hd j
+    rwa [dimVector_indecInjRep, dimVector_indecInjRep, card_path_self_of_isAcyclic h j] at h'
+  exact hij (eq_of_card_path_eq_one h hij' hji)
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Acyclic.lean
@@ -42,9 +42,7 @@ variable {k : Type u} {Q : Type v} [Field k] [Quiver.{w} Q]
 `i` being the only path `i → i`: the projective `Pᵢ` is a brick. -/
 theorem finrank_end_indecProjRep_of_isAcyclic (h : Quiver.IsAcyclic Q) (i : Q) :
     Module.finrank k (indecProjRep k Q i ⟶ indecProjRep k Q i) = 1 := by
-  letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
-  letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
-  rw [finrank_hom_indecProjRep_indecProjRep, Nat.card_unique]
+  rw [finrank_hom_indecProjRep_indecProjRep, h.card_path_self]
 
 /-- **Over an acyclic quiver the dimension vector of `Pᵢ` is a root of the Tits form**: its Tits
 norm is `1`, the trivial path being the only closed path at `i`. Acyclicity also supplies the
@@ -57,8 +55,6 @@ theorem titsForm_dimVector_indecProjRep_of_isAcyclic [Fintype Q] [∀ a b : Q, F
   haveI : ∀ a : Q, Finite (Quiver.Path i a) := fun a ↦
     Finite.of_injective (fun p : Quiver.Path i a ↦ (⟨i, a, p⟩ : Σ x y : Q, Quiver.Path x y))
       fun p q hpq ↦ by simpa using hpq
-  letI : Subsingleton (Quiver.Path i i) := h.subsingleton_path_self i
-  letI : Unique (Quiver.Path i i) := uniqueOfSubsingleton Quiver.Path.nil
-  rw [titsForm_dimVector_indecProjRep, Nat.card_unique, Nat.cast_one]
+  rw [titsForm_dimVector_indecProjRep, h.card_path_self, Nat.cast_one]
 
 end TauCeti


### PR DESCRIPTION
This PR proves that the vertex projective `Pᵢ` and the vertex injective `Iᵢ` of an acyclic quiver are indecomposable, and supplies the general categorical criteria that get there. `TauCeti/RepresentationTheory/Quiver/Representation/Projective/Basic.lean` and `.../Injective.lean` both record that indecomposability "needs the Krull-Schmidt theory of Layer 2, which is not yet available"; over an acyclic quiver it does not. The trivial path is the only closed path at a vertex, so `dim End(Pᵢ) = dim End(Iᵢ) = 1` and both are bricks, and a brick is indecomposable outright.

Mathlib defines `CategoryTheory.Indecomposable` but proves exactly one criterion for it, `indecomposable_of_simple`, which is useless for a projective. `TauCeti/CategoryTheory/Preadditive/Indecomposable.lean` adds the two that apply: in a preadditive category with binary biproducts, an object whose only idempotent endomorphisms are `0` and the identity is indecomposable (a decomposition `X ≅ Y ⊞ Z` produces the idempotent `biprod.fst ≫ biprod.inl`, which is `0` only if `Y` is zero and the identity only if `Z` is zero); and, in a `k`-linear category over a field, an object with a one-dimensional endomorphism space is indecomposable, since every endomorphism is then a scalar. Only that direction is proved: the converse needs idempotent completeness of the ambient category, which no consumer here has or wants.

`TauCeti/RepresentationTheory/Quiver/Representation/Indecomposable.lean` applies them. It computes `dim End(Iᵢ) = 1` over an acyclic quiver as the injective counterpart of the existing `finrank_end_indecProjRep_of_isAcyclic`, and concludes `Indecomposable (indecProjRep k Q i)` and `Indecomposable (indecInjRep k Q i)`. `Sᵢ` needs nothing new: it is simple, so Mathlib's `indecomposable_of_simple` applies to it directly. The same path count also makes the list irredundant: `Pᵢ ≅ Pⱼ` equates dimension vectors, hence forces a path each way between `i` and `j`, hence `i = j` over an acyclic quiver, and dually for the injectives, so `not_nonempty_indecProjRep_iso_of_isAcyclic` and `not_nonempty_indecInjRep_iso_of_isAcyclic` join `not_nonempty_simpleRep_iso`. Nothing here needs finiteness of the quiver or an algebraically closed field; acyclicity is genuinely needed, and the loop quiver, where `End(Pᵢ)` is `k[X]`, is the boundary the roadmap already records.

This advances Layer 1 of `TauCetiRoadmap/RepresentationTheory/QuiverRepresentations/README.md`, "Vertex simples, projectives, injectives", whose pinned objects `simpleRep`, `indecProjRep` and `indecInjRep` are named for a property none of them had been given, by the brick route that the same roadmap's Layer 4 identifies ("every ADE indecomposable is a brick with `End = k`"). It also removes a stated blocker: Layer 2's Krull-Schmidt theory is not a prerequisite for these particular objects.

No Mathlib infrastructure is vendored, and no material is taken from any external source; everything reuses Mathlib's `Indecomposable`, `indecomposable_of_simple`, `biprod` API and `finrank_eq_one_iff_of_nonzero'`, together with the existing `TauCeti` path-algebra and dimension-vector API.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"indecomposable-indecprojrep"}-->

🤖 Prepared with Claude Code

