### PR TITLE
feat: assemble Schur's lemma for simple modules

### DIFF
--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RepresentationTheory.AlgebraRepresentation.Basic
-public import Mathlib.RingTheory.SimpleModule.IsAlgClosed
 
 /-!
 # Schur's lemma for simple modules
@@ -35,8 +34,10 @@ equivalence.
   when their hom group is nontrivial.
 * `TauCeti.nonempty_algEquiv_self_of_isIntegral`: an integral domain algebra over an algebraically
   closed field is isomorphic to that field as an algebra, with
-  `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing` the finite-dimensional division algebra
-  special case.
+  `TauCeti.nonempty_algEquiv_self_of_finiteDimensional_divisionRing` the finite-dimensional
+  division algebra special case (the roadmap pins this last result as
+  `algEquiv_self_of_finiteDimensional_divisionRing`; it carries the `nonempty_` prefix here
+  because its conclusion is a `Nonempty`, matching its two neighbours).
 * `TauCeti.nonempty_end_algEquiv_self_of_isSimpleModule`: the endomorphism ring of a
   finite-dimensional simple module over an algebraically closed field collapses to that field.
 
@@ -119,18 +120,13 @@ theorem nonempty_algEquiv_self_of_isIntegral [Algebra.IsIntegral k D] : Nonempty
   ⟨(AlgEquiv.ofBijective (Algebra.ofId k D)
     IsAlgClosed.algebraMap_bijective_of_isIntegral).symm⟩
 
-/-- An integral domain algebra over an algebraically closed field has dimension one. -/
-@[simp]
-theorem finrank_eq_one_of_isAlgClosed [Algebra.IsIntegral k D] : Module.finrank k D = 1 :=
-  Module.finrank_of_bijective_algebraMap IsAlgClosed.algebraMap_bijective_of_isIntegral
-
 end Domain
 
 /-- A finite-dimensional division algebra over an algebraically closed field is the field itself,
 as an isomorphism of algebras. Finite dimensionality supplies integrality, so this is the
 special case of `nonempty_algEquiv_self_of_isIntegral` that the semisimple-algebra development
 uses. -/
-theorem algEquiv_self_of_finiteDimensional_divisionRing [DivisionRing D] [Algebra k D]
+theorem nonempty_algEquiv_self_of_finiteDimensional_divisionRing [DivisionRing D] [Algebra k D]
     [FiniteDimensional k D] : Nonempty (D ≃ₐ[k] k) :=
   nonempty_algEquiv_self_of_isIntegral
 

--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -33,12 +33,12 @@ equivalence.
   the whole hom group.
 * `TauCeti.nontrivial_linearMap_iff_nonempty_linearEquiv`: two simple modules are equivalent exactly
   when their hom group is nontrivial.
-* `TauCeti.algEquiv_self_of_isIntegral`: an integral domain algebra over an algebraically closed
-  field is isomorphic to that field as an algebra, with
+* `TauCeti.nonempty_algEquiv_self_of_isIntegral`: an integral domain algebra over an algebraically
+  closed field is isomorphic to that field as an algebra, with
   `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing` the finite-dimensional division algebra
   special case.
-* `TauCeti.end_algEquiv_self_of_isSimpleModule`: the endomorphism ring of a finite-dimensional
-  simple module over an algebraically closed field collapses to that field.
+* `TauCeti.nonempty_end_algEquiv_self_of_isSimpleModule`: the endomorphism ring of a
+  finite-dimensional simple module over an algebraically closed field collapses to that field.
 
 ## References
 
@@ -115,23 +115,24 @@ isomorphism of algebras.
 
 Mathlib proves that the algebra map from an algebraically closed field to such an algebra is
 bijective; this packages that bijection as an algebra equivalence. -/
-theorem algEquiv_self_of_isIntegral [Algebra.IsIntegral k D] : Nonempty (D ≃ₐ[k] k) :=
+theorem nonempty_algEquiv_self_of_isIntegral [Algebra.IsIntegral k D] : Nonempty (D ≃ₐ[k] k) :=
   ⟨(AlgEquiv.ofBijective (Algebra.ofId k D)
     IsAlgClosed.algebraMap_bijective_of_isIntegral).symm⟩
 
-/-- A finite-dimensional domain algebra over an algebraically closed field has dimension one. -/
+/-- An integral domain algebra over an algebraically closed field has dimension one. -/
 @[simp]
-theorem finrank_eq_one_of_isAlgClosed [FiniteDimensional k D] : Module.finrank k D = 1 :=
+theorem finrank_eq_one_of_isAlgClosed [Algebra.IsIntegral k D] : Module.finrank k D = 1 :=
   Module.finrank_of_bijective_algebraMap IsAlgClosed.algebraMap_bijective_of_isIntegral
 
 end Domain
 
 /-- A finite-dimensional division algebra over an algebraically closed field is the field itself,
 as an isomorphism of algebras. Finite dimensionality supplies integrality, so this is the
-special case of `algEquiv_self_of_isIntegral` that the semisimple-algebra development uses. -/
+special case of `nonempty_algEquiv_self_of_isIntegral` that the semisimple-algebra development
+uses. -/
 theorem algEquiv_self_of_finiteDimensional_divisionRing [DivisionRing D] [Algebra k D]
     [FiniteDimensional k D] : Nonempty (D ≃ₐ[k] k) :=
-  algEquiv_self_of_isIntegral
+  nonempty_algEquiv_self_of_isIntegral
 
 end IsAlgClosed
 
@@ -150,7 +151,7 @@ Mathlib's `IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed` proves that e
 endomorphism is a scalar; this packages that bijection as an algebra equivalence. Finite
 dimensionality is needed: an infinite-dimensional simple module can have a larger division
 endomorphism ring. -/
-theorem end_algEquiv_self_of_isSimpleModule : Nonempty (Module.End A S ≃ₐ[k] k) :=
+theorem nonempty_end_algEquiv_self_of_isSimpleModule : Nonempty (Module.End A S ≃ₐ[k] k) :=
   ⟨(AlgEquiv.ofBijective (Algebra.ofId k (Module.End A S))
     (IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k)).symm⟩
 

--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -1,0 +1,119 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+
+/-!
+# Schur's lemma for simple modules
+
+This file packages the two forms of Schur's lemma used by the semisimple-algebra development.
+
+For simple modules over an arbitrary ring, Mathlib proves that a linear map is either bijective or
+zero (`LinearMap.bijective_or_eq_zero`). Consequently the entire hom group vanishes exactly when the
+two modules are not linearly equivalent. When an equivalence does exist, Mathlib's
+`LinearEquiv.arrowCongrAddEquiv` identifies the hom group with either endomorphism ring by
+composition; no separate construction is needed here.
+
+Over an algebraically closed field, a finite-dimensional division algebra is the base field. The
+proof uses Mathlib's stronger theorem that the algebra map from an algebraically closed field into
+an integral algebra is bijective. Finite dimensionality supplies integrality.
+
+## Main results
+
+* `TauCeti.hom_eq_zero_of_isEmpty_linearEquiv`: every map between inequivalent simple modules is
+  zero.
+* `TauCeti.subsingleton_linearMap_iff_isEmpty_linearEquiv`: the corresponding characterization of
+  the whole hom group.
+* `TauCeti.nontrivial_linearMap_iff_nonempty_linearEquiv`: two simple modules are equivalent exactly
+  when their hom group is nontrivial.
+* `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing`: a finite-dimensional division algebra
+  over an algebraically closed field is isomorphic to that field as an algebra.
+
+## References
+
+This implements Layer 1, "Schur, assembled", of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See N. Jacobson, *Basic Algebra II*, Chapter 3, or T. Y. Lam, *A First Course in Noncommutative
+Rings*, Chapter 1.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+/-! ### Maps between simple modules -/
+
+section SimpleModules
+
+variable {R : Type u} [Ring R]
+variable {M : Type v} {N : Type w} [AddCommGroup M] [Module R M] [AddCommGroup N] [Module R N]
+variable [IsSimpleModule R M] [IsSimpleModule R N]
+
+/-- **Schur's lemma, vanishing form.** A linear map between simple modules is zero if the two
+modules are not linearly equivalent.
+
+The `IsEmpty` hypothesis is the constructive form of saying that no equivalence exists. -/
+theorem hom_eq_zero_of_isEmpty_linearEquiv (h : IsEmpty (M ≃ₗ[R] N)) (f : M →ₗ[R] N) :
+    f = 0 := by
+  rcases f.bijective_or_eq_zero with hf | hf
+  · exact (h.false (LinearEquiv.ofBijective f hf)).elim
+  · exact hf
+
+/-- The hom group between simple modules is a subsingleton if the modules are not linearly
+equivalent. -/
+theorem subsingleton_linearMap_of_isEmpty_linearEquiv (h : IsEmpty (M ≃ₗ[R] N)) :
+    Subsingleton (M →ₗ[R] N) :=
+  ⟨fun f g ↦ sub_eq_zero.mp (hom_eq_zero_of_isEmpty_linearEquiv h (f - g))⟩
+
+/-- The hom group between two simple modules is a subsingleton exactly when the modules are not
+linearly equivalent. -/
+theorem subsingleton_linearMap_iff_isEmpty_linearEquiv :
+    Subsingleton (M →ₗ[R] N) ↔ IsEmpty (M ≃ₗ[R] N) := by
+  constructor
+  · intro h
+    letI := h
+    exact ⟨fun e ↦ by
+      have hzero : e.toLinearMap = 0 := Subsingleton.elim _ _
+      haveI := IsSimpleModule.nontrivial R M
+      exact e.toLinearMap.ne_zero_of_injective e.injective hzero⟩
+  · exact subsingleton_linearMap_of_isEmpty_linearEquiv
+
+/-- The hom group between two simple modules is nontrivial exactly when the modules are linearly
+equivalent. This is the existence form of Schur's lemma. -/
+theorem nontrivial_linearMap_iff_nonempty_linearEquiv :
+    Nontrivial (M →ₗ[R] N) ↔ Nonempty (M ≃ₗ[R] N) := by
+  rw [← not_subsingleton_iff_nontrivial, subsingleton_linearMap_iff_isEmpty_linearEquiv,
+    not_isEmpty_iff]
+
+end SimpleModules
+
+/-! ### Division algebras over algebraically closed fields -/
+
+section IsAlgClosed
+
+variable {k : Type u} {D : Type v} [Field k] [IsAlgClosed k] [DivisionRing D] [Algebra k D]
+variable [FiniteDimensional k D]
+
+/-- A finite-dimensional division algebra over an algebraically closed field is the field itself,
+as an isomorphism of algebras.
+
+Finite dimensionality makes `D` integral over `k`; Mathlib proves that the algebra map from an
+algebraically closed field to any integral division algebra is bijective. -/
+theorem algEquiv_self_of_finiteDimensional_divisionRing : Nonempty (D ≃ₐ[k] k) :=
+  ⟨(AlgEquiv.ofBijective (Algebra.ofId k D)
+    IsAlgClosed.algebraMap_bijective_of_isIntegral).symm⟩
+
+/-- A finite-dimensional division algebra over an algebraically closed field has dimension one. -/
+@[simp]
+theorem finrank_divisionRing_eq_one : Module.finrank k D = 1 := by
+  obtain ⟨e⟩ := algEquiv_self_of_finiteDimensional_divisionRing (k := k) (D := D)
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_self]
+
+end IsAlgClosed
+
+end TauCeti

--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -17,10 +17,11 @@ two modules are not linearly equivalent. When an equivalence does exist, Mathlib
 `LinearEquiv.arrowCongrAddEquiv` identifies the hom group with either endomorphism ring by
 composition; no separate construction is needed here.
 
-Over an algebraically closed field, an integral domain algebra is the base field. The proof uses
-Mathlib's theorem that the algebra map from an algebraically closed field into an integral domain
-algebra is bijective; a finite-dimensional division algebra is the special case that the roadmap
-names. The same collapse for the endomorphism ring of a finite-dimensional simple module is
+Over an algebraically closed field `k`, a domain algebra that is integral over `k` is `k` itself.
+The proof uses Mathlib's theorem that the algebra map from an algebraically closed field into such
+an algebra is bijective; a finite-dimensional division algebra is the special case that the roadmap
+names, integrality there coming from finite dimensionality. The same collapse for the endomorphism
+ring of a finite-dimensional simple module is
 Mathlib's `IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`, packaged here as an algebra
 equivalence.
 
@@ -32,12 +33,11 @@ equivalence.
   the whole hom group.
 * `TauCeti.nontrivial_linearMap_iff_nonempty_linearEquiv`: two simple modules are equivalent exactly
   when their hom group is nontrivial.
-* `TauCeti.nonempty_algEquiv_self_of_isIntegral`: an integral domain algebra over an algebraically
-  closed field is isomorphic to that field as an algebra, with
+* `TauCeti.nonempty_algEquiv_self_of_isIntegral`: a domain algebra over an algebraically closed
+  field that is integral over that field is isomorphic to it as an algebra, with
   `TauCeti.nonempty_algEquiv_self_of_finiteDimensional_divisionRing` the finite-dimensional
-  division algebra special case (the roadmap pins this last result as
-  `algEquiv_self_of_finiteDimensional_divisionRing`; it carries the `nonempty_` prefix here
-  because its conclusion is a `Nonempty`, matching its two neighbours).
+  division algebra special case, also available under the name the roadmap pins,
+  `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing`.
 * `TauCeti.nonempty_end_algEquiv_self_of_isSimpleModule`: the endomorphism ring of a
   finite-dimensional simple module over an algebraically closed field collapses to that field.
 
@@ -111,8 +111,8 @@ section Domain
 
 variable [Ring D] [IsDomain D] [Algebra k D]
 
-/-- An integral domain algebra over an algebraically closed field is the field itself, as an
-isomorphism of algebras.
+/-- A domain algebra over an algebraically closed field `k` that is integral over `k` is `k`
+itself, as an isomorphism of algebras.
 
 Mathlib proves that the algebra map from an algebraically closed field to such an algebra is
 bijective; this packages that bijection as an algebra equivalence. -/
@@ -129,6 +129,10 @@ uses. -/
 theorem nonempty_algEquiv_self_of_finiteDimensional_divisionRing [DivisionRing D] [Algebra k D]
     [FiniteDimensional k D] : Nonempty (D ≃ₐ[k] k) :=
   nonempty_algEquiv_self_of_isIntegral
+
+/-- The roadmap pins the previous theorem under this name; it is available under both. -/
+alias algEquiv_self_of_finiteDimensional_divisionRing :=
+  nonempty_algEquiv_self_of_finiteDimensional_divisionRing
 
 end IsAlgClosed
 

--- a/TauCeti/RingTheory/Semisimple/Schur.lean
+++ b/TauCeti/RingTheory/Semisimple/Schur.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.RepresentationTheory.AlgebraRepresentation.Basic
 public import Mathlib.RingTheory.SimpleModule.IsAlgClosed
 
 /-!
@@ -17,9 +18,12 @@ two modules are not linearly equivalent. When an equivalence does exist, Mathlib
 `LinearEquiv.arrowCongrAddEquiv` identifies the hom group with either endomorphism ring by
 composition; no separate construction is needed here.
 
-Over an algebraically closed field, a finite-dimensional division algebra is the base field. The
-proof uses Mathlib's stronger theorem that the algebra map from an algebraically closed field into
-an integral algebra is bijective. Finite dimensionality supplies integrality.
+Over an algebraically closed field, an integral domain algebra is the base field. The proof uses
+Mathlib's theorem that the algebra map from an algebraically closed field into an integral domain
+algebra is bijective; a finite-dimensional division algebra is the special case that the roadmap
+names. The same collapse for the endomorphism ring of a finite-dimensional simple module is
+Mathlib's `IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed`, packaged here as an algebra
+equivalence.
 
 ## Main results
 
@@ -29,8 +33,12 @@ an integral algebra is bijective. Finite dimensionality supplies integrality.
   the whole hom group.
 * `TauCeti.nontrivial_linearMap_iff_nonempty_linearEquiv`: two simple modules are equivalent exactly
   when their hom group is nontrivial.
-* `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing`: a finite-dimensional division algebra
-  over an algebraically closed field is isomorphic to that field as an algebra.
+* `TauCeti.algEquiv_self_of_isIntegral`: an integral domain algebra over an algebraically closed
+  field is isomorphic to that field as an algebra, with
+  `TauCeti.algEquiv_self_of_finiteDimensional_divisionRing` the finite-dimensional division algebra
+  special case.
+* `TauCeti.end_algEquiv_self_of_isSimpleModule`: the endomorphism ring of a finite-dimensional
+  simple module over an algebraically closed field collapses to that field.
 
 ## References
 
@@ -92,28 +100,60 @@ theorem nontrivial_linearMap_iff_nonempty_linearEquiv :
 
 end SimpleModules
 
-/-! ### Division algebras over algebraically closed fields -/
+/-! ### Domain algebras over algebraically closed fields -/
 
 section IsAlgClosed
 
-variable {k : Type u} {D : Type v} [Field k] [IsAlgClosed k] [DivisionRing D] [Algebra k D]
-variable [FiniteDimensional k D]
+variable {k : Type u} {D : Type v} [Field k] [IsAlgClosed k]
 
-/-- A finite-dimensional division algebra over an algebraically closed field is the field itself,
-as an isomorphism of algebras.
+section Domain
 
-Finite dimensionality makes `D` integral over `k`; Mathlib proves that the algebra map from an
-algebraically closed field to any integral division algebra is bijective. -/
-theorem algEquiv_self_of_finiteDimensional_divisionRing : Nonempty (D ≃ₐ[k] k) :=
+variable [Ring D] [IsDomain D] [Algebra k D]
+
+/-- An integral domain algebra over an algebraically closed field is the field itself, as an
+isomorphism of algebras.
+
+Mathlib proves that the algebra map from an algebraically closed field to such an algebra is
+bijective; this packages that bijection as an algebra equivalence. -/
+theorem algEquiv_self_of_isIntegral [Algebra.IsIntegral k D] : Nonempty (D ≃ₐ[k] k) :=
   ⟨(AlgEquiv.ofBijective (Algebra.ofId k D)
     IsAlgClosed.algebraMap_bijective_of_isIntegral).symm⟩
 
-/-- A finite-dimensional division algebra over an algebraically closed field has dimension one. -/
+/-- A finite-dimensional domain algebra over an algebraically closed field has dimension one. -/
 @[simp]
-theorem finrank_divisionRing_eq_one : Module.finrank k D = 1 := by
-  obtain ⟨e⟩ := algEquiv_self_of_finiteDimensional_divisionRing (k := k) (D := D)
-  rw [e.toLinearEquiv.finrank_eq, Module.finrank_self]
+theorem finrank_eq_one_of_isAlgClosed [FiniteDimensional k D] : Module.finrank k D = 1 :=
+  Module.finrank_of_bijective_algebraMap IsAlgClosed.algebraMap_bijective_of_isIntegral
+
+end Domain
+
+/-- A finite-dimensional division algebra over an algebraically closed field is the field itself,
+as an isomorphism of algebras. Finite dimensionality supplies integrality, so this is the
+special case of `algEquiv_self_of_isIntegral` that the semisimple-algebra development uses. -/
+theorem algEquiv_self_of_finiteDimensional_divisionRing [DivisionRing D] [Algebra k D]
+    [FiniteDimensional k D] : Nonempty (D ≃ₐ[k] k) :=
+  algEquiv_self_of_isIntegral
 
 end IsAlgClosed
+
+/-! ### Endomorphisms of a simple module over an algebraically closed field -/
+
+section SimpleEnd
+
+variable {k : Type u} {A : Type v} {S : Type w} [Field k] [IsAlgClosed k] [Ring A] [Algebra k A]
+variable [AddCommGroup S] [Module k S] [Module A S] [IsScalarTower k A S] [IsSimpleModule A S]
+variable [FiniteDimensional k S]
+
+/-- **Schur's lemma over an algebraically closed field.** The endomorphism ring of a
+finite-dimensional simple module over a `k`-algebra is the field `k` itself.
+
+Mathlib's `IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed` proves that every such
+endomorphism is a scalar; this packages that bijection as an algebra equivalence. Finite
+dimensionality is needed: an infinite-dimensional simple module can have a larger division
+endomorphism ring. -/
+theorem end_algEquiv_self_of_isSimpleModule : Nonempty (Module.End A S ≃ₐ[k] k) :=
+  ⟨(AlgEquiv.ofBijective (Algebra.ofId k (Module.End A S))
+    (IsSimpleModule.algebraMap_end_bijective_of_isAlgClosed k)).symm⟩
+
+end SimpleEnd
 
 end TauCeti


### PR DESCRIPTION
This PR assembles Schur's lemma for simple modules in the forms needed by the semisimple-algebra development: a map between inequivalent simples vanishes, the whole hom group is a subsingleton exactly for inequivalent simples and nontrivial exactly for equivalent simples, and a finite-dimensional division algebra over an algebraically closed field is the base field.

It implements `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md`, Layer 1, item **“Schur, assembled”**, including the pinned declarations `hom_eq_zero_of_isEmpty_linearEquiv` and `algEquiv_self_of_finiteDimensional_divisionRing`, the latter named `nonempty_algEquiv_self_of_finiteDimensional_divisionRing` here because its conclusion is a `Nonempty`. This is the lowest-hanging distinct item because Mathlib already supplies both engines (`LinearMap.bijective_or_eq_zero` and `IsAlgClosed.algebraMap_bijective_of_isIntegral`), while no open or historical Tau Ceti PR packages this Layer 1 API; the open semisimple-algebra work begins at Layers 1.5 and 4.

The implementation directly reuses Mathlib's `LinearMap.bijective_or_eq_zero`, `LinearEquiv.ofBijective`, `LinearMap.ne_zero_of_injective`, and `IsAlgClosed.algebraMap_bijective_of_isIntegral`. The module also records that `LinearEquiv.arrowCongrAddEquiv` already supplies the isomorphic-case identification of a hom group with an endomorphism ring, avoiding a duplicate wrapper. No Mathlib infrastructure is vendored, and no material from the supplementary source snapshot is used. The mathematical references are Jacobson, *Basic Algebra II*, Chapter 3, and Lam, *A First Course in Noncommutative Rings*, Chapter 1, also cited in the module docstring.

`lake exe cache get` completes successfully (`Already decompressed 8677 file(s)`, with the existing one-file cache warning). `lake build` reports `Build completed successfully (6114 jobs).` `lake exe axioms` reports `axioms: audited 18400 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"schur-assembled"}-->

🤖 Prepared with Codex

