### PR TITLE
feat: construct the matrix-coordinate bialgebra

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -66,10 +66,6 @@ section Semiring
 
 variable (R : Type u) [CommSemiring R] (n : ℕ)
 
-/-- The generic `n × n` matrix, whose `(i, j)` entry is the variable `X (i, j)`. -/
-noncomputable abbrev genericMatrix : Matrix (Fin n) (Fin n) (CoordinateRing R n) :=
-  Matrix.mvPolynomialX (Fin n) (Fin n) R
-
 /-- The comultiplication dual to multiplication of square matrices. -/
 noncomputable def comul :
     CoordinateRing R n →ₐ[R] CoordinateRing R n ⊗[R] CoordinateRing R n :=
@@ -99,23 +95,23 @@ theorem counit_X (i j : Fin n) :
 /-- Applying the counit entrywise to the generic matrix gives the identity matrix. -/
 @[simp]
 theorem map_counit_genericMatrix :
-    (genericMatrix R n).map (counit R n) = 1 := by
-  simpa only [genericMatrix, counit, AlgHom.mapMatrix_apply] using
+    (Matrix.mvPolynomialX (Fin n) (Fin n) R).map (counit R n) = 1 := by
+  simpa only [counit, AlgHom.mapMatrix_apply] using
     Matrix.mvPolynomialX_mapMatrix_aeval R (1 : Matrix (Fin n) (Fin n) R)
 
 /-- Applying the comultiplication entrywise to the generic matrix gives the product of its
 left-tensor and right-tensor copies. The order represents ordinary matrix multiplication, not
 the opposite monoid. -/
 theorem map_comul_genericMatrix :
-    (genericMatrix R n).map (comul R n) =
-      (genericMatrix R n).map
+    (Matrix.mvPolynomialX (Fin n) (Fin n) R).map (comul R n) =
+      (Matrix.mvPolynomialX (Fin n) (Fin n) R).map
           (includeLeft : CoordinateRing R n →ₐ[R]
             CoordinateRing R n ⊗[R] CoordinateRing R n) *
-        (genericMatrix R n).map
+        (Matrix.mvPolynomialX (Fin n) (Fin n) R).map
           (includeRight : CoordinateRing R n →ₐ[R]
             CoordinateRing R n ⊗[R] CoordinateRing R n) := by
   ext i j
-  simp [Matrix.mul_apply, genericMatrix]
+  simp [Matrix.mul_apply]
 
 /-- The matrix-coordinate bialgebra structure on the polynomial algebra `R[Xᵢⱼ]`.
 
@@ -152,12 +148,6 @@ noncomputable def bialgebra : Bialgebra R (CoordinateRing R n) :=
         simp [hkj]
       · simp)
 
--- These private defining equations expose the operations stored in the named bialgebra. Their
--- public wrappers below are the abstraction boundary used by downstream code.
-private theorem bialgebra_comul_def :
-    (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul = (comul R n).toLinearMap :=
-  rfl
-
 /-- Selecting `bialgebra R n` makes its comultiplication the explicit matrix-multiplication map
 `comul R n`. The equality is heterogeneous because opacity also hides the dictionary's stored
 module structure. -/
@@ -165,11 +155,7 @@ theorem bialgebra_comul :
     HEq (letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
       letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
       Coalgebra.comul (R := R) (A := CoordinateRing R n)) (comul R n).toLinearMap :=
-  heq_of_eq (bialgebra_comul_def R n)
-
-private theorem bialgebra_counit_def :
-    (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit = (counit R n).toLinearMap :=
-  rfl
+  heq_of_eq rfl
 
 /-- Selecting `bialgebra R n` makes its counit the explicit identity-matrix map `counit R n`.
 As for `bialgebra_comul`, opacity makes the map equality heterogeneous. -/
@@ -177,14 +163,7 @@ theorem bialgebra_counit :
     HEq (letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
       letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
       Coalgebra.counit (R := R) (A := CoordinateRing R n)) (counit R n).toLinearMap :=
-  heq_of_eq (bialgebra_counit_def R n)
-
-private theorem bialgebra_comul_X_def (i j : Fin n) :
-    letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
-    (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul (MvPolynomial.X (i, j)) =
-      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) := by
-  rw [eq_of_heq (bialgebra_comul R n), AlgHom.toLinearMap_apply]
-  exact comul_X R n i j
+  heq_of_eq rfl
 
 /-- Under `bialgebra R n`, comultiplication has the matrix-multiplication formula on generators. -/
 @[simp]
@@ -192,14 +171,9 @@ theorem bialgebra_comul_X (i j : Fin n) :
     letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
     letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
     Coalgebra.comul (R := R) (A := CoordinateRing R n) (MvPolynomial.X (i, j)) =
-      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) :=
-  bialgebra_comul_X_def R n i j
-
-private theorem bialgebra_counit_X_def (i j : Fin n) :
-    (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit (MvPolynomial.X (i, j)) =
-      if i = j then 1 else 0 := by
-  rw [eq_of_heq (bialgebra_counit R n), AlgHom.toLinearMap_apply]
-  exact counit_X R n i j
+      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) := by
+  rw [eq_of_heq (bialgebra_comul R n), AlgHom.toLinearMap_apply]
+  exact comul_X R n i j
 
 /-- Under `bialgebra R n`, the counit has the identity-matrix formula on generators. -/
 @[simp]
@@ -207,8 +181,9 @@ theorem bialgebra_counit_X (i j : Fin n) :
     letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
     letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
     Coalgebra.counit (R := R) (A := CoordinateRing R n) (MvPolynomial.X (i, j)) =
-      if i = j then 1 else 0 :=
-  bialgebra_counit_X_def R n i j
+      if i = j then 1 else 0 := by
+  rw [eq_of_heq (bialgebra_counit R n), AlgHom.toLinearMap_apply]
+  exact counit_X R n i j
 
 end Semiring
 
@@ -216,34 +191,25 @@ section Ring
 
 variable (R : Type u) [CommRing R] (n : ℕ)
 
-/-- The determinant of the generic `n × n` matrix. -/
-noncomputable def determinant : CoordinateRing R n :=
-  Matrix.det (genericMatrix R n)
-
-private theorem determinant_def_internal :
-    determinant R n = Matrix.det (genericMatrix R n) :=
-  rfl
-
-/-- The generic determinant is the determinant of `genericMatrix`. -/
-theorem determinant_def : determinant R n = Matrix.det (genericMatrix R n) :=
-  determinant_def_internal R n
-
 /-- Evaluating the generic determinant at the identity-matrix counit gives one. -/
 @[simp]
-theorem counit_determinant : counit R n (determinant R n) = 1 := by
-  rw [determinant_def, AlgHom.map_det, AlgHom.mapMatrix_apply, map_counit_genericMatrix,
-    Matrix.det_one]
+theorem counit_determinant :
+    counit R n (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) = 1 := by
+  rw [AlgHom.map_det, AlgHom.mapMatrix_apply, map_counit_genericMatrix, Matrix.det_one]
 
 /-- Matrix-multiplication comultiplication sends the generic determinant to its tensor square. -/
 @[simp]
 theorem comul_determinant :
-    comul R n (determinant R n) = determinant R n ⊗ₜ[R] determinant R n := by
-  rw [determinant_def, AlgHom.map_det, AlgHom.mapMatrix_apply, map_comul_genericMatrix,
-    Matrix.det_mul]
+    comul R n (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)) =
+      Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R) ⊗ₜ[R]
+        Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R) := by
+  rw [AlgHom.map_det, AlgHom.mapMatrix_apply, map_comul_genericMatrix, Matrix.det_mul]
   rw [← AlgHom.mapMatrix_apply (includeLeft : CoordinateRing R n →ₐ[R]
-        CoordinateRing R n ⊗[R] CoordinateRing R n) (genericMatrix R n),
+        CoordinateRing R n ⊗[R] CoordinateRing R n)
+          (Matrix.mvPolynomialX (Fin n) (Fin n) R),
       ← AlgHom.mapMatrix_apply (includeRight : CoordinateRing R n →ₐ[R]
-        CoordinateRing R n ⊗[R] CoordinateRing R n) (genericMatrix R n)]
+        CoordinateRing R n ⊗[R] CoordinateRing R n)
+          (Matrix.mvPolynomialX (Fin n) (Fin n) R)]
   rw [← AlgHom.map_det, ← AlgHom.map_det]
   simp
 
@@ -252,85 +218,72 @@ matrix-coordinate bialgebra structure.
 
 The object stores `bialgebra R n`; it does not depend on whichever bialgebra instance may be
 available globally for the raw `MvPolynomial` carrier. -/
-@[expose]
 noncomputable def coordinateBialgebra : CommBialgCat R :=
   letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
   CommBialgCat.of R (CoordinateRing R n)
 
-private theorem coordinateBialgebra_comul_def (x : CoordinateRing R n) :
+/-- The canonical algebra equivalence from the polynomial coordinate ring to the carrier of its
+bundled matrix-coordinate bialgebra. -/
+noncomputable def coordinateBialgebraAlgEquiv :
+    CoordinateRing R n ≃ₐ[R] coordinateBialgebra R n := by
+  letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
+  exact AlgEquiv.refl
+
+/-- Comultiplication on the bundled coordinate bialgebra agrees with the explicit
+matrix-multiplication comultiplication after transport through `coordinateBialgebraAlgEquiv`. -/
+theorem coordinateBialgebra_comul_apply (x : CoordinateRing R n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
-        (x : coordinateBialgebra R n) = comul R n x :=
+        (coordinateBialgebraAlgEquiv R n x) =
+      Algebra.TensorProduct.map (coordinateBialgebraAlgEquiv R n).toAlgHom
+          (coordinateBialgebraAlgEquiv R n).toAlgHom (comul R n x) := by
+  change (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul x = _
+  rw [eq_of_heq (bialgebra_comul R n)]
+  change comul R n x =
+    Algebra.TensorProduct.map (AlgHom.id R (CoordinateRing R n))
+      (AlgHom.id R (CoordinateRing R n)) (comul R n x)
+  rw [Algebra.TensorProduct.map_id]
   rfl
 
-/-- The bundled coordinate bialgebra uses the explicit matrix-multiplication comultiplication.
-The equality is heterogeneous because the opaque dictionary also hides its module structure. -/
-theorem coordinateBialgebra_comul (x : CoordinateRing R n) :
-    HEq (Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
-        (x : coordinateBialgebra R n)) (comul R n x) :=
-  heq_of_eq (coordinateBialgebra_comul_def R n x)
-
-private theorem coordinateBialgebra_counit_def (x : CoordinateRing R n) :
+/-- The counit on the bundled coordinate bialgebra agrees with the explicit identity-matrix
+counit after transport through `coordinateBialgebraAlgEquiv`. -/
+@[simp]
+theorem coordinateBialgebra_counit_apply (x : CoordinateRing R n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
-        (x : coordinateBialgebra R n) = counit R n x :=
+        (coordinateBialgebraAlgEquiv R n x) = counit R n x := by
   rfl
-
-/-- The bundled coordinate bialgebra uses the explicit identity-matrix counit. -/
-theorem coordinateBialgebra_counit (x : CoordinateRing R n) :
-    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
-        (x : coordinateBialgebra R n) = counit R n x :=
-  coordinateBialgebra_counit_def R n x
-
-private theorem coordinateBialgebra_comul_X_def (i j : Fin n) :
-    Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
-        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
-      ∑ k : Fin n,
-        (MvPolynomial.X (i, k) : coordinateBialgebra R n) ⊗ₜ[R]
-          (MvPolynomial.X (k, j) : coordinateBialgebra R n) := by
-  rw [eq_of_heq (coordinateBialgebra_comul R n (MvPolynomial.X (i, j)))]
-  exact comul_X R n i j
 
 /-- The bundled coordinate bialgebra retains the matrix-multiplication comultiplication on its
 generic entries. -/
 @[simp]
 theorem coordinateBialgebra_comul_X (i j : Fin n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
-        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
+        (coordinateBialgebraAlgEquiv R n (MvPolynomial.X (i, j))) =
       (∑ k : Fin n,
-        (MvPolynomial.X (i, k) : coordinateBialgebra R n) ⊗ₜ[R]
-          (MvPolynomial.X (k, j) : coordinateBialgebra R n) :
-        coordinateBialgebra R n ⊗[R] coordinateBialgebra R n) :=
-  coordinateBialgebra_comul_X_def R n i j
-
-private theorem coordinateBialgebra_counit_X_def (i j : Fin n) :
-    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
-        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
-      if i = j then 1 else 0 := by
-  rw [coordinateBialgebra_counit]
-  exact counit_X R n i j
+        coordinateBialgebraAlgEquiv R n (MvPolynomial.X (i, k)) ⊗ₜ[R]
+          coordinateBialgebraAlgEquiv R n (MvPolynomial.X (k, j)) :
+        coordinateBialgebra R n ⊗[R] coordinateBialgebra R n) := by
+  rw [coordinateBialgebra_comul_apply, comul_X, map_sum]
+  simp
 
 /-- The bundled coordinate bialgebra retains the identity-matrix counit on its generic
 entries. -/
-@[simp]
 theorem coordinateBialgebra_counit_X (i j : Fin n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
-        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
-      if i = j then 1 else 0 :=
-  coordinateBialgebra_counit_X_def R n i j
-
-private theorem isGroupLikeElem_determinant_def :
-    IsGroupLikeElem (A := coordinateBialgebra R n) R
-      (determinant R n : coordinateBialgebra R n) := by
-  constructor
-  · rw [coordinateBialgebra_counit]
-    exact counit_determinant R n
-  · rw [eq_of_heq (coordinateBialgebra_comul R n (determinant R n))]
-    exact comul_determinant R n
+        (coordinateBialgebraAlgEquiv R n (MvPolynomial.X (i, j))) =
+      if i = j then 1 else 0 := by
+  rw [coordinateBialgebra_counit_apply]
+  exact counit_X R n i j
 
 /-- The determinant of the generic matrix is group-like in the matrix-coordinate bialgebra. -/
 theorem isGroupLikeElem_determinant :
     IsGroupLikeElem (A := coordinateBialgebra R n) R
-      (determinant R n : coordinateBialgebra R n) :=
-  isGroupLikeElem_determinant_def R n
+      (coordinateBialgebraAlgEquiv R n
+        (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))) := by
+  constructor
+  · rw [coordinateBialgebra_counit_apply]
+    exact counit_determinant R n
+  · rw [coordinateBialgebra_comul_apply, comul_determinant]
+    simp
 
 end Ring
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -152,10 +152,8 @@ noncomputable def bialgebra : Bialgebra R (CoordinateRing R n) :=
         simp [hkj]
       · simp)
 
--- These private defining equations are elaborated with compatibility transparency so that Lean
--- recognizes the module structure stored in the opaque bialgebra as the canonical one. Their
+-- These private defining equations expose the operations stored in the named bialgebra. Their
 -- public wrappers below are the abstraction boundary used by downstream code.
-set_option backward.isDefEq.respectTransparency false in
 private theorem bialgebra_comul_def :
     (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul = (comul R n).toLinearMap :=
   rfl
@@ -169,7 +167,6 @@ theorem bialgebra_comul :
       Coalgebra.comul (R := R) (A := CoordinateRing R n)) (comul R n).toLinearMap :=
   heq_of_eq (bialgebra_comul_def R n)
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem bialgebra_counit_def :
     (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit = (counit R n).toLinearMap :=
   rfl
@@ -182,7 +179,6 @@ theorem bialgebra_counit :
       Coalgebra.counit (R := R) (A := CoordinateRing R n)) (counit R n).toLinearMap :=
   heq_of_eq (bialgebra_counit_def R n)
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem bialgebra_comul_X_def (i j : Fin n) :
     letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
     (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul (MvPolynomial.X (i, j)) =
@@ -199,7 +195,6 @@ theorem bialgebra_comul_X (i j : Fin n) :
       ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) :=
   bialgebra_comul_X_def R n i j
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem bialgebra_counit_X_def (i j : Fin n) :
     (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit (MvPolynomial.X (i, j)) =
       if i = j then 1 else 0 := by
@@ -262,7 +257,6 @@ noncomputable def coordinateBialgebra : CommBialgCat R :=
   letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
   CommBialgCat.of R (CoordinateRing R n)
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem coordinateBialgebra_comul_def (x : CoordinateRing R n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
         (x : coordinateBialgebra R n) = comul R n x :=
@@ -275,7 +269,6 @@ theorem coordinateBialgebra_comul (x : CoordinateRing R n) :
         (x : coordinateBialgebra R n)) (comul R n x) :=
   heq_of_eq (coordinateBialgebra_comul_def R n x)
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem coordinateBialgebra_counit_def (x : CoordinateRing R n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
         (x : coordinateBialgebra R n) = counit R n x :=
@@ -287,7 +280,6 @@ theorem coordinateBialgebra_counit (x : CoordinateRing R n) :
         (x : coordinateBialgebra R n) = counit R n x :=
   coordinateBialgebra_counit_def R n x
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem coordinateBialgebra_comul_X_def (i j : Fin n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
         (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
@@ -309,7 +301,6 @@ theorem coordinateBialgebra_comul_X (i j : Fin n) :
         coordinateBialgebra R n ⊗[R] coordinateBialgebra R n) :=
   coordinateBialgebra_comul_X_def R n i j
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem coordinateBialgebra_counit_X_def (i j : Fin n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
         (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
@@ -326,7 +317,6 @@ theorem coordinateBialgebra_counit_X (i j : Fin n) :
       if i = j then 1 else 0 :=
   coordinateBialgebra_counit_X_def R n i j
 
-set_option backward.isDefEq.respectTransparency false in
 private theorem isGroupLikeElem_determinant_def :
     IsGroupLikeElem (A := coordinateBialgebra R n) R
       (determinant R n : coordinateBialgebra R n) := by

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -102,6 +102,7 @@ theorem map_counit_genericMatrix :
 /-- Applying the comultiplication entrywise to the generic matrix gives the product of its
 left-tensor and right-tensor copies. The order represents ordinary matrix multiplication, not
 the opposite monoid. -/
+@[simp]
 theorem map_comul_genericMatrix :
     (Matrix.mvPolynomialX (Fin n) (Fin n) R).map (comul R n) =
       (Matrix.mvPolynomialX (Fin n) (Fin n) R).map
@@ -231,6 +232,7 @@ noncomputable def coordinateBialgebraAlgEquiv :
 
 /-- Comultiplication on the bundled coordinate bialgebra agrees with the explicit
 matrix-multiplication comultiplication after transport through `coordinateBialgebraAlgEquiv`. -/
+@[simp low]
 theorem coordinateBialgebra_comul_apply (x : CoordinateRing R n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
         (coordinateBialgebraAlgEquiv R n x) =
@@ -267,6 +269,7 @@ theorem coordinateBialgebra_comul_X (i j : Fin n) :
 
 /-- The bundled coordinate bialgebra retains the identity-matrix counit on its generic
 entries. -/
+@[simp high]
 theorem coordinateBialgebra_counit_X (i j : Fin n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
         (coordinateBialgebraAlgEquiv R n (MvPolynomial.X (i, j))) =

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Category.CommBialgCat
+public import Mathlib.LinearAlgebra.Matrix.MvPolynomial
+public import Mathlib.RingTheory.Coalgebra.GroupLike
+
+/-!
+# The matrix-monoid coordinate bialgebra
+
+For a commutative semiring `R`, this file equips the polynomial coordinate algebra
+`R[Xᵢⱼ]` of square matrices with the explicit bialgebra structure dual to matrix
+multiplication. Its comultiplication and counit satisfy
+
+`Δ(Xᵢⱼ) = ∑ₖ Xᵢₖ ⊗ Xₖⱼ` and `ε(Xᵢⱼ) = if i = j then 1 else 0`.
+
+The structure is a named `Bialgebra` value rather than a global instance. This distinction is
+essential: `MvPolynomial` is definitionally an additive monoid algebra, and importing the
+monoid-algebra bialgebra gives its variables a different, group-like comultiplication. Over a
+commutative ring, `coordinateBialgebra` locally selects the matrix-coordinate structure and
+stores it in a `CommBialgCat` object, providing a collision-free boundary for statements using
+typeclass-selected coalgebra operations.
+
+The determinant of the generic matrix is group-like for this bundled structure. This is the
+algebraic input for subsequently localizing at the determinant to construct the coordinate Hopf
+algebra of `GLₙ`; localization and the antipode are deliberately not constructed here.
+
+The construction includes `n = 0` and requires no nontriviality hypothesis on the base.
+
+## Main declarations
+
+* `TauCeti.MatrixMonoid.comul`: matrix-multiplication comultiplication on `R[Xᵢⱼ]`.
+* `TauCeti.MatrixMonoid.counit`: identity-matrix counit on `R[Xᵢⱼ]`.
+* `TauCeti.MatrixMonoid.bialgebra`: the explicit matrix-coordinate bialgebra dictionary.
+* `TauCeti.MatrixMonoid.coordinateBialgebra`: the selected commutative bialgebra object.
+* `TauCeti.MatrixMonoid.isGroupLikeElem_determinant`: the generic determinant is group-like.
+
+## References
+
+The coordinate formulas are standard; see J. S. Milne, *Algebraic Groups*, §§3.3--3.6 and
+4.2. The role of determinant localization in constructing `GLₙ` is described in §2.8.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace MatrixMonoid
+
+open Algebra.TensorProduct
+
+universe u
+
+/-- The polynomial coordinate algebra of the monoid of `n × n` matrices over `R`. -/
+abbrev CoordinateRing (R : Type u) [CommSemiring R] (n : ℕ) :=
+  MvPolynomial (Fin n × Fin n) R
+
+section Semiring
+
+variable (R : Type u) [CommSemiring R] (n : ℕ)
+
+/-- The generic `n × n` matrix, whose `(i, j)` entry is the variable `X (i, j)`. -/
+noncomputable abbrev genericMatrix : Matrix (Fin n) (Fin n) (CoordinateRing R n) :=
+  Matrix.mvPolynomialX (Fin n) (Fin n) R
+
+/-- The comultiplication dual to multiplication of square matrices. -/
+noncomputable def comul :
+    CoordinateRing R n →ₐ[R] CoordinateRing R n ⊗[R] CoordinateRing R n :=
+  MvPolynomial.aeval fun ij : Fin n × Fin n =>
+    ∑ k : Fin n, MvPolynomial.X (ij.1, k) ⊗ₜ[R] MvPolynomial.X (k, ij.2)
+
+/-- The counit dual to the identity matrix. -/
+noncomputable def counit : CoordinateRing R n →ₐ[R] R :=
+  MvPolynomial.aeval fun ij : Fin n × Fin n =>
+    (1 : Matrix (Fin n) (Fin n) R) ij.1 ij.2
+
+/-- The matrix-coordinate comultiplication sends a generic entry to the corresponding entry of
+the product of the generic matrices in the two tensor factors. -/
+@[simp]
+theorem comul_X (i j : Fin n) :
+    comul R n (MvPolynomial.X (i, j)) =
+      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) := by
+  simp [comul]
+
+/-- The matrix-coordinate counit sends a generic entry to the corresponding identity-matrix
+entry. -/
+@[simp]
+theorem counit_X (i j : Fin n) :
+    counit R n (MvPolynomial.X (i, j)) = if i = j then 1 else 0 := by
+  simp [counit, Matrix.one_apply]
+
+/-- Applying the counit entrywise to the generic matrix gives the identity matrix. -/
+@[simp]
+theorem map_counit_genericMatrix :
+    (genericMatrix R n).map (counit R n) = 1 := by
+  simpa only [genericMatrix, counit, AlgHom.mapMatrix_apply] using
+    (show
+      (MvPolynomial.aeval fun ij : Fin n × Fin n =>
+        (1 : Matrix (Fin n) (Fin n) R) ij.1 ij.2).mapMatrix
+          (Matrix.mvPolynomialX (Fin n) (Fin n) R) = 1 from
+      Matrix.mvPolynomialX_mapMatrix_aeval R (1 : Matrix (Fin n) (Fin n) R))
+
+/-- Applying the comultiplication entrywise to the generic matrix gives the product of its
+left-tensor and right-tensor copies. The order represents ordinary matrix multiplication, not
+the opposite monoid. -/
+theorem map_comul_genericMatrix :
+    (genericMatrix R n).map (comul R n) =
+      (genericMatrix R n).map
+          (includeLeft : CoordinateRing R n →ₐ[R]
+            CoordinateRing R n ⊗[R] CoordinateRing R n) *
+        (genericMatrix R n).map
+          (includeRight : CoordinateRing R n →ₐ[R]
+            CoordinateRing R n ⊗[R] CoordinateRing R n) := by
+  ext i j
+  simp [Matrix.mul_apply, genericMatrix]
+
+/-- The matrix-coordinate bialgebra structure on the polynomial algebra `R[Xᵢⱼ]`.
+
+This is intentionally a named value, not an instance. Callers that need typeclass-selected
+coalgebra operations should use `coordinateBialgebra`, or install this value in a deliberately
+local scope. -/
+@[expose, instance_reducible]
+noncomputable def bialgebra : Bialgebra R (CoordinateRing R n) :=
+  Bialgebra.ofAlgHom (comul R n) (counit R n)
+    (by
+      apply MvPolynomial.algHom_ext
+      rintro ⟨i, j⟩
+      simp only [AlgHom.comp_apply, comul_X, map_sum, map_tmul, AlgHom.id_apply]
+      simp only [TensorProduct.sum_tmul, TensorProduct.tmul_sum]
+      simp only [map_sum]
+      rw [Finset.sum_comm]
+      rfl)
+    (by
+      apply MvPolynomial.algHom_ext
+      rintro ⟨i, j⟩
+      simp only [AlgHom.comp_apply, comul_X, map_sum, map_tmul, counit_X, AlgHom.id_apply]
+      rw [Finset.sum_eq_single i]
+      · simp
+      · intro k _ hki
+        simp [hki.symm]
+      · simp)
+    (by
+      apply MvPolynomial.algHom_ext
+      rintro ⟨i, j⟩
+      simp only [AlgHom.comp_apply, comul_X, map_sum, map_tmul, counit_X, AlgHom.id_apply]
+      rw [Finset.sum_eq_single j]
+      · simp
+      · intro k _ hkj
+        simp [hkj]
+      · simp)
+
+end Semiring
+
+section Ring
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-- The determinant of the generic `n × n` matrix. -/
+@[expose]
+noncomputable def determinant : CoordinateRing R n :=
+  Matrix.det (genericMatrix R n)
+
+/-- The generic determinant is the determinant of `genericMatrix`. -/
+theorem determinant_def : determinant R n = Matrix.det (genericMatrix R n) :=
+  rfl
+
+/-- Evaluating the generic determinant at the identity-matrix counit gives one. -/
+@[simp]
+theorem counit_determinant : counit R n (determinant R n) = 1 := by
+  rw [determinant_def, AlgHom.map_det, AlgHom.mapMatrix_apply, map_counit_genericMatrix,
+    Matrix.det_one]
+
+/-- Matrix-multiplication comultiplication sends the generic determinant to its tensor square. -/
+@[simp]
+theorem comul_determinant :
+    comul R n (determinant R n) = determinant R n ⊗ₜ[R] determinant R n := by
+  rw [determinant_def, AlgHom.map_det, AlgHom.mapMatrix_apply, map_comul_genericMatrix,
+    Matrix.det_mul]
+  change Matrix.det
+      ((includeLeft : CoordinateRing R n →ₐ[R]
+        CoordinateRing R n ⊗[R] CoordinateRing R n).mapMatrix (genericMatrix R n)) *
+    Matrix.det
+      ((includeRight : CoordinateRing R n →ₐ[R]
+        CoordinateRing R n ⊗[R] CoordinateRing R n).mapMatrix (genericMatrix R n)) = _
+  rw [← AlgHom.map_det, ← AlgHom.map_det]
+  simp
+
+/-- The polynomial coordinate algebra of the matrix monoid, bundled with the selected
+matrix-coordinate bialgebra structure.
+
+The object stores `bialgebra R n`; it does not depend on whichever bialgebra instance may be
+available globally for the raw `MvPolynomial` carrier. -/
+@[expose]
+noncomputable def coordinateBialgebra : CommBialgCat R :=
+  letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
+  CommBialgCat.of R (CoordinateRing R n)
+
+/-- The bundled coordinate bialgebra retains the matrix-multiplication comultiplication on its
+generic entries. -/
+@[simp]
+theorem coordinateBialgebra_comul_X (i j : Fin n) :
+    Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
+        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
+      ∑ k : Fin n,
+        (MvPolynomial.X (i, k) : coordinateBialgebra R n) ⊗ₜ[R]
+          (MvPolynomial.X (k, j) : coordinateBialgebra R n) := by
+  change comul R n (MvPolynomial.X (i, j)) = _
+  exact comul_X R n i j
+
+/-- The bundled coordinate bialgebra retains the identity-matrix counit on its generic
+entries. -/
+@[simp]
+theorem coordinateBialgebra_counit_X (i j : Fin n) :
+    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
+        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
+      if i = j then 1 else 0 := by
+  change counit R n (MvPolynomial.X (i, j)) = _
+  exact counit_X R n i j
+
+/-- The determinant of the generic matrix is group-like in the matrix-coordinate bialgebra. -/
+theorem isGroupLikeElem_determinant :
+    IsGroupLikeElem (A := coordinateBialgebra R n) R
+      (determinant R n : coordinateBialgebra R n) := by
+  constructor
+  · change counit R n (determinant R n) = 1
+    exact counit_determinant R n
+  · change comul R n (determinant R n) = determinant R n ⊗ₜ[R] determinant R n
+    exact comul_determinant R n
+
+end Ring
+
+end MatrixMonoid
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -41,7 +41,9 @@ The construction includes `n = 0` and requires no nontriviality hypothesis on th
 ## References
 
 The coordinate formulas are standard; see J. S. Milne, *Algebraic Groups*, §§3.3--3.6 and
-4.2. The role of determinant localization in constructing `GLₙ` is described in §2.8.
+4.2. The same construction appears in the Stacks Project, Example 39.5.4,
+[Tag 022W](https://stacks.math.columbia.edu/tag/022W). The role of determinant localization in
+constructing `GLₙ` is described in Milne, §2.8.
 -/
 
 public section
@@ -99,11 +101,7 @@ theorem counit_X (i j : Fin n) :
 theorem map_counit_genericMatrix :
     (genericMatrix R n).map (counit R n) = 1 := by
   simpa only [genericMatrix, counit, AlgHom.mapMatrix_apply] using
-    (show
-      (MvPolynomial.aeval fun ij : Fin n × Fin n =>
-        (1 : Matrix (Fin n) (Fin n) R) ij.1 ij.2).mapMatrix
-          (Matrix.mvPolynomialX (Fin n) (Fin n) R) = 1 from
-      Matrix.mvPolynomialX_mapMatrix_aeval R (1 : Matrix (Fin n) (Fin n) R))
+    Matrix.mvPolynomialX_mapMatrix_aeval R (1 : Matrix (Fin n) (Fin n) R)
 
 /-- Applying the comultiplication entrywise to the generic matrix gives the product of its
 left-tensor and right-tensor copies. The order represents ordinary matrix multiplication, not
@@ -124,7 +122,7 @@ theorem map_comul_genericMatrix :
 This is intentionally a named value, not an instance. Callers that need typeclass-selected
 coalgebra operations should use `coordinateBialgebra`, or install this value in a deliberately
 local scope. -/
-@[expose, instance_reducible]
+@[instance_reducible]
 noncomputable def bialgebra : Bialgebra R (CoordinateRing R n) :=
   Bialgebra.ofAlgHom (comul R n) (counit R n)
     (by
@@ -154,6 +152,69 @@ noncomputable def bialgebra : Bialgebra R (CoordinateRing R n) :=
         simp [hkj]
       · simp)
 
+-- These private defining equations are elaborated with compatibility transparency so that Lean
+-- recognizes the module structure stored in the opaque bialgebra as the canonical one. Their
+-- public wrappers below are the abstraction boundary used by downstream code.
+set_option backward.isDefEq.respectTransparency false in
+private theorem bialgebra_comul_def :
+    (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul = (comul R n).toLinearMap :=
+  rfl
+
+/-- Selecting `bialgebra R n` makes its comultiplication the explicit matrix-multiplication map
+`comul R n`. The equality is heterogeneous because opacity also hides the dictionary's stored
+module structure. -/
+theorem bialgebra_comul :
+    HEq (letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
+      letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
+      Coalgebra.comul (R := R) (A := CoordinateRing R n)) (comul R n).toLinearMap :=
+  heq_of_eq (bialgebra_comul_def R n)
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem bialgebra_counit_def :
+    (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit = (counit R n).toLinearMap :=
+  rfl
+
+/-- Selecting `bialgebra R n` makes its counit the explicit identity-matrix map `counit R n`.
+As for `bialgebra_comul`, opacity makes the map equality heterogeneous. -/
+theorem bialgebra_counit :
+    HEq (letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
+      letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
+      Coalgebra.counit (R := R) (A := CoordinateRing R n)) (counit R n).toLinearMap :=
+  heq_of_eq (bialgebra_counit_def R n)
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem bialgebra_comul_X_def (i j : Fin n) :
+    letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
+    (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul (MvPolynomial.X (i, j)) =
+      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) := by
+  rw [eq_of_heq (bialgebra_comul R n), AlgHom.toLinearMap_apply]
+  exact comul_X R n i j
+
+/-- Under `bialgebra R n`, comultiplication has the matrix-multiplication formula on generators. -/
+@[simp]
+theorem bialgebra_comul_X (i j : Fin n) :
+    letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
+    letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
+    Coalgebra.comul (R := R) (A := CoordinateRing R n) (MvPolynomial.X (i, j)) =
+      ∑ k : Fin n, MvPolynomial.X (i, k) ⊗ₜ[R] MvPolynomial.X (k, j) :=
+  bialgebra_comul_X_def R n i j
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem bialgebra_counit_X_def (i j : Fin n) :
+    (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit (MvPolynomial.X (i, j)) =
+      if i = j then 1 else 0 := by
+  rw [eq_of_heq (bialgebra_counit R n), AlgHom.toLinearMap_apply]
+  exact counit_X R n i j
+
+/-- Under `bialgebra R n`, the counit has the identity-matrix formula on generators. -/
+@[simp]
+theorem bialgebra_counit_X (i j : Fin n) :
+    letI : Module R (CoordinateRing R n) := (bialgebra R n).toAlgebra.toModule
+    letI : Coalgebra R (CoordinateRing R n) := (bialgebra R n).toCoalgebra
+    Coalgebra.counit (R := R) (A := CoordinateRing R n) (MvPolynomial.X (i, j)) =
+      if i = j then 1 else 0 :=
+  bialgebra_counit_X_def R n i j
+
 end Semiring
 
 section Ring
@@ -161,13 +222,16 @@ section Ring
 variable (R : Type u) [CommRing R] (n : ℕ)
 
 /-- The determinant of the generic `n × n` matrix. -/
-@[expose]
 noncomputable def determinant : CoordinateRing R n :=
   Matrix.det (genericMatrix R n)
 
+private theorem determinant_def_internal :
+    determinant R n = Matrix.det (genericMatrix R n) :=
+  rfl
+
 /-- The generic determinant is the determinant of `genericMatrix`. -/
 theorem determinant_def : determinant R n = Matrix.det (genericMatrix R n) :=
-  rfl
+  determinant_def_internal R n
 
 /-- Evaluating the generic determinant at the identity-matrix counit gives one. -/
 @[simp]
@@ -181,12 +245,10 @@ theorem comul_determinant :
     comul R n (determinant R n) = determinant R n ⊗ₜ[R] determinant R n := by
   rw [determinant_def, AlgHom.map_det, AlgHom.mapMatrix_apply, map_comul_genericMatrix,
     Matrix.det_mul]
-  change Matrix.det
-      ((includeLeft : CoordinateRing R n →ₐ[R]
-        CoordinateRing R n ⊗[R] CoordinateRing R n).mapMatrix (genericMatrix R n)) *
-    Matrix.det
-      ((includeRight : CoordinateRing R n →ₐ[R]
-        CoordinateRing R n ⊗[R] CoordinateRing R n).mapMatrix (genericMatrix R n)) = _
+  rw [← AlgHom.mapMatrix_apply (includeLeft : CoordinateRing R n →ₐ[R]
+        CoordinateRing R n ⊗[R] CoordinateRing R n) (genericMatrix R n),
+      ← AlgHom.mapMatrix_apply (includeRight : CoordinateRing R n →ₐ[R]
+        CoordinateRing R n ⊗[R] CoordinateRing R n) (genericMatrix R n)]
   rw [← AlgHom.map_det, ← AlgHom.map_det]
   simp
 
@@ -200,17 +262,60 @@ noncomputable def coordinateBialgebra : CommBialgCat R :=
   letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
   CommBialgCat.of R (CoordinateRing R n)
 
+set_option backward.isDefEq.respectTransparency false in
+private theorem coordinateBialgebra_comul_def (x : CoordinateRing R n) :
+    Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
+        (x : coordinateBialgebra R n) = comul R n x :=
+  rfl
+
+/-- The bundled coordinate bialgebra uses the explicit matrix-multiplication comultiplication.
+The equality is heterogeneous because the opaque dictionary also hides its module structure. -/
+theorem coordinateBialgebra_comul (x : CoordinateRing R n) :
+    HEq (Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
+        (x : coordinateBialgebra R n)) (comul R n x) :=
+  heq_of_eq (coordinateBialgebra_comul_def R n x)
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem coordinateBialgebra_counit_def (x : CoordinateRing R n) :
+    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
+        (x : coordinateBialgebra R n) = counit R n x :=
+  rfl
+
+/-- The bundled coordinate bialgebra uses the explicit identity-matrix counit. -/
+theorem coordinateBialgebra_counit (x : CoordinateRing R n) :
+    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
+        (x : coordinateBialgebra R n) = counit R n x :=
+  coordinateBialgebra_counit_def R n x
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem coordinateBialgebra_comul_X_def (i j : Fin n) :
+    Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
+        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
+      ∑ k : Fin n,
+        (MvPolynomial.X (i, k) : coordinateBialgebra R n) ⊗ₜ[R]
+          (MvPolynomial.X (k, j) : coordinateBialgebra R n) := by
+  rw [eq_of_heq (coordinateBialgebra_comul R n (MvPolynomial.X (i, j)))]
+  exact comul_X R n i j
+
 /-- The bundled coordinate bialgebra retains the matrix-multiplication comultiplication on its
 generic entries. -/
 @[simp]
 theorem coordinateBialgebra_comul_X (i j : Fin n) :
     Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
         (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
-      ∑ k : Fin n,
+      (∑ k : Fin n,
         (MvPolynomial.X (i, k) : coordinateBialgebra R n) ⊗ₜ[R]
-          (MvPolynomial.X (k, j) : coordinateBialgebra R n) := by
-  change comul R n (MvPolynomial.X (i, j)) = _
-  exact comul_X R n i j
+          (MvPolynomial.X (k, j) : coordinateBialgebra R n) :
+        coordinateBialgebra R n ⊗[R] coordinateBialgebra R n) :=
+  coordinateBialgebra_comul_X_def R n i j
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem coordinateBialgebra_counit_X_def (i j : Fin n) :
+    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
+        (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
+      if i = j then 1 else 0 := by
+  rw [coordinateBialgebra_counit]
+  exact counit_X R n i j
 
 /-- The bundled coordinate bialgebra retains the identity-matrix counit on its generic
 entries. -/
@@ -218,19 +323,24 @@ entries. -/
 theorem coordinateBialgebra_counit_X (i j : Fin n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
         (MvPolynomial.X (i, j) : coordinateBialgebra R n) =
-      if i = j then 1 else 0 := by
-  change counit R n (MvPolynomial.X (i, j)) = _
-  exact counit_X R n i j
+      if i = j then 1 else 0 :=
+  coordinateBialgebra_counit_X_def R n i j
+
+set_option backward.isDefEq.respectTransparency false in
+private theorem isGroupLikeElem_determinant_def :
+    IsGroupLikeElem (A := coordinateBialgebra R n) R
+      (determinant R n : coordinateBialgebra R n) := by
+  constructor
+  · rw [coordinateBialgebra_counit]
+    exact counit_determinant R n
+  · rw [eq_of_heq (coordinateBialgebra_comul R n (determinant R n))]
+    exact comul_determinant R n
 
 /-- The determinant of the generic matrix is group-like in the matrix-coordinate bialgebra. -/
 theorem isGroupLikeElem_determinant :
     IsGroupLikeElem (A := coordinateBialgebra R n) R
-      (determinant R n : coordinateBialgebra R n) := by
-  constructor
-  · change counit R n (determinant R n) = 1
-    exact counit_determinant R n
-  · change comul R n (determinant R n) = determinant R n ⊗ₜ[R] determinant R n
-    exact comul_determinant R n
+      (determinant R n : coordinateBialgebra R n) :=
+  isGroupLikeElem_determinant_def R n
 
 end Ring
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateBialgebra.lean
@@ -230,6 +230,34 @@ noncomputable def coordinateBialgebraAlgEquiv :
   letI : Bialgebra R (CoordinateRing R n) := bialgebra R n
   exact AlgEquiv.refl
 
+/-- Mathlib has no `CommBialgCat.of_comul` lemma exposing the comultiplication stored by
+`CommBialgCat.of`. This bridge isolates the two definitional equalities needed here:
+`coordinateBialgebra` stores `(bialgebra R n).toCoalgebra` on the raw coordinate ring, and
+`coordinateBialgebraAlgEquiv` is the identity algebra equivalence on that carrier. After those
+reductions, transporting the stored comultiplication is `Algebra.TensorProduct.map_id`. -/
+private theorem coordinateBialgebra_comul_transport (x : CoordinateRing R n) :
+    Coalgebra.comul (R := R) (A := coordinateBialgebra R n)
+        (coordinateBialgebraAlgEquiv R n x) =
+      Algebra.TensorProduct.map (coordinateBialgebraAlgEquiv R n).toAlgHom
+          (coordinateBialgebraAlgEquiv R n).toAlgHom
+          ((bialgebra R n).toCoalgebra.toCoalgebraStruct.comul x) := by
+  change (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul x =
+    Algebra.TensorProduct.map (AlgHom.id R (CoordinateRing R n))
+      (AlgHom.id R (CoordinateRing R n))
+      ((bialgebra R n).toCoalgebra.toCoalgebraStruct.comul x)
+  rw [Algebra.TensorProduct.map_id]
+  rfl
+
+/-- Mathlib has no `CommBialgCat.of_counit` lemma exposing the counit stored by
+`CommBialgCat.of`. This bridge isolates the definitional equalities that `coordinateBialgebra`
+stores `(bialgebra R n).toCoalgebra` on the raw coordinate ring and that
+`coordinateBialgebraAlgEquiv` is the identity algebra equivalence on that carrier. -/
+private theorem coordinateBialgebra_counit_transport (x : CoordinateRing R n) :
+    Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
+        (coordinateBialgebraAlgEquiv R n x) =
+      (bialgebra R n).toCoalgebra.toCoalgebraStruct.counit x := by
+  rfl
+
 /-- Comultiplication on the bundled coordinate bialgebra agrees with the explicit
 matrix-multiplication comultiplication after transport through `coordinateBialgebraAlgEquiv`. -/
 @[simp low]
@@ -238,13 +266,8 @@ theorem coordinateBialgebra_comul_apply (x : CoordinateRing R n) :
         (coordinateBialgebraAlgEquiv R n x) =
       Algebra.TensorProduct.map (coordinateBialgebraAlgEquiv R n).toAlgHom
           (coordinateBialgebraAlgEquiv R n).toAlgHom (comul R n x) := by
-  change (bialgebra R n).toCoalgebra.toCoalgebraStruct.comul x = _
-  rw [eq_of_heq (bialgebra_comul R n)]
-  change comul R n x =
-    Algebra.TensorProduct.map (AlgHom.id R (CoordinateRing R n))
-      (AlgHom.id R (CoordinateRing R n)) (comul R n x)
-  rw [Algebra.TensorProduct.map_id]
-  rfl
+  rw [coordinateBialgebra_comul_transport, eq_of_heq (bialgebra_comul R n),
+    AlgHom.toLinearMap_apply]
 
 /-- The counit on the bundled coordinate bialgebra agrees with the explicit identity-matrix
 counit after transport through `coordinateBialgebraAlgEquiv`. -/
@@ -252,7 +275,8 @@ counit after transport through `coordinateBialgebraAlgEquiv`. -/
 theorem coordinateBialgebra_counit_apply (x : CoordinateRing R n) :
     Coalgebra.counit (R := R) (A := coordinateBialgebra R n)
         (coordinateBialgebraAlgEquiv R n x) = counit R n x := by
-  rfl
+  rw [coordinateBialgebra_counit_transport, eq_of_heq (bialgebra_counit R n),
+    AlgHom.toLinearMap_apply]
 
 /-- The bundled coordinate bialgebra retains the matrix-multiplication comultiplication on its
 generic entries. -/


### PR DESCRIPTION
This PR constructs the coordinate bialgebra of the multiplicative monoid of square matrices. It gives the polynomial coordinate algebra explicit matrix-multiplication comultiplication and identity-matrix counit maps, packages the selected structure without introducing a conflicting global polynomial bialgebra instance, and proves that the generic determinant is group-like over a commutative ring, including rank zero and the zero ring.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, “Worked examples,” specifically the `GLₙ` example's first algebraic prerequisite before determinant localization. The construction follows the coordinate formulas in Milne's *Algebraic Groups* and the Stacks Project's general-linear-group example, and adapts pinned Mathlib's `Matrix.mvPolynomialX`, `MvPolynomial.aeval`, `Bialgebra.ofAlgHom`, `CommBialgCat`, and determinant infrastructure while keeping the matrix-coordinate dictionary explicit.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"matrix-coordinate-bialgebra"}-->

🤖 Prepared with Codex
