### PR TITLE
refactor(Coalgebra): decompose the coevaluation-coaction proof

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -150,46 +150,29 @@ theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
   dualEvaluation_toLinearMap_aux k H M
 
-private theorem tensorCoact_coevaluation_apply_one
-    (M : FGComoduleCat.{u, v, u} k H) :
-    Comodule.tensorCoact (R := k) (C := H) (M := M) (N := Module.Dual k M)
-        (coevaluation k M 1) =
-      coevaluation k M 1 ⊗ₜ[k] (1 : H) := by
+/-- The coordinates of a basis vector of `Module.Basis.ofVectorSpace` in that same basis form a
+Kronecker delta. -/
+private lemma ofVectorSpace_repr_coe (M : FGComoduleCat.{u, v, u} k H)
+    [DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]
+    (i j : Module.Basis.ofVectorSpaceIndex k M) :
+    (Module.Basis.ofVectorSpace k M).repr (i : M) j = if i = j then 1 else 0 := by
+  rw [← Module.Basis.ofVectorSpace_apply_self k M i]
+  exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
+
+/-- **The antipode inverts the matrix-coefficient matrix.** Summing a matrix coefficient against the
+antipode of the transposed one collapses to a Kronecker delta, by the left antipode identity
+followed by the counit computation of a matrix coefficient. -/
+private lemma sum_matrixCoefficient_mul_antipode (M : FGComoduleCat.{u, v, u} k H)
+    [DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]
+    (p q : Module.Basis.ofVectorSpaceIndex k M) :
+    (∑ x : Module.Basis.ofVectorSpaceIndex k M,
+      Comodule.matrixCoefficient (R := k) (C := H)
+        ((Module.Basis.ofVectorSpace k M).coord p) (x : M) *
+      HopfAlgebra.antipode k
+        (Comodule.matrixCoefficient (R := k) (C := H)
+          ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
+      if q = p then 1 else 0 := by
   classical
-  -- Expand coevaluation and both coactions in a basis, then compare tensor coordinates.
-  -- The remaining matrix-coefficient sum collapses by the left antipode/counit identity.
-  let b := Module.Basis.ofVectorSpace k M
-  rw [coevaluation_apply_one]
-  dsimp only [b]
-  simp only [map_sum, Comodule.tensorCoact_tmul,
-    Comodule.coact_eq_sum_basis_matrixCoefficient (C := H) (Module.Basis.ofVectorSpace k M),
-    Comodule.dual_coact,
-    dualCoact_coord_eq_sum k H (Module.Basis.ofVectorSpace k M),
-    TensorProduct.sum_tmul, TensorProduct.tmul_sum,
-    Comodule.tensorCombine_tmul_tmul]
-  have hrepr (i j : Module.Basis.ofVectorSpaceIndex k M) :
-      (Module.Basis.ofVectorSpace k M).repr (i : M) j =
-        if i = j then 1 else 0 := by
-    rw [← Module.Basis.ofVectorSpace_apply_self k M i]
-    exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
-  let bt := (Module.Basis.ofVectorSpace k M).tensorProduct
-    (Module.Basis.ofVectorSpace k M).dualBasis
-  apply (TensorProduct.equivFinsuppOfBasisLeft (N := H) bt).injective
-  ext ⟨p, q⟩
-  suffices h :
-      (∑ x : Module.Basis.ofVectorSpaceIndex k M,
-        Comodule.matrixCoefficient (R := k) (C := H)
-          ((Module.Basis.ofVectorSpace k M).coord p) (x : M) *
-        HopfAlgebra.antipode k
-          (Comodule.matrixCoefficient (R := k) (C := H)
-            ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
-        if q = p then 1 else 0 by
-    simpa only [Module.Basis.coe_ofVectorSpace, map_sum,
-      TensorProduct.equivFinsuppOfBasisLeft_apply_tmul, Finsupp.coe_finsetSum,
-      Finset.sum_apply, Finsupp.mapRange_apply, Module.Basis.tensorProduct_repr_tmul_apply,
-      Module.Basis.dualBasis_repr, Module.Basis.coord_apply, hrepr, smul_eq_mul, mul_ite,
-      mul_one, mul_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq',
-      Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt] using h
   calc
     _ = LinearMap.mul' k H
         ((HopfAlgebra.antipode k).lTensor H
@@ -208,7 +191,36 @@ private theorem tensorCoact_coevaluation_apply_one
       HopfAlgebra.mul_antipode_lTensor_comul_apply _
     _ = if q = p then 1 else 0 := by
       rw [Comodule.counit_matrixCoefficient]
-      simp [Module.Basis.coord_apply, hrepr]
+      simp [Module.Basis.coord_apply, ofVectorSpace_repr_coe]
+
+private theorem tensorCoact_coevaluation_apply_one
+    (M : FGComoduleCat.{u, v, u} k H) :
+    Comodule.tensorCoact (R := k) (C := H) (M := M) (N := Module.Dual k M)
+        (coevaluation k M 1) =
+      coevaluation k M 1 ⊗ₜ[k] (1 : H) := by
+  classical
+  -- Expand coevaluation and both coactions in a basis, then compare tensor coordinates.
+  -- The remaining matrix-coefficient sum collapses by `sum_matrixCoefficient_mul_antipode`.
+  let b := Module.Basis.ofVectorSpace k M
+  rw [coevaluation_apply_one]
+  dsimp only [b]
+  simp only [map_sum, Comodule.tensorCoact_tmul,
+    Comodule.coact_eq_sum_basis_matrixCoefficient (C := H) (Module.Basis.ofVectorSpace k M),
+    Comodule.dual_coact,
+    dualCoact_coord_eq_sum k H (Module.Basis.ofVectorSpace k M),
+    TensorProduct.sum_tmul, TensorProduct.tmul_sum,
+    Comodule.tensorCombine_tmul_tmul]
+  let bt := (Module.Basis.ofVectorSpace k M).tensorProduct
+    (Module.Basis.ofVectorSpace k M).dualBasis
+  apply (TensorProduct.equivFinsuppOfBasisLeft (N := H) bt).injective
+  ext ⟨p, q⟩
+  simpa only [Module.Basis.coe_ofVectorSpace, map_sum,
+    TensorProduct.equivFinsuppOfBasisLeft_apply_tmul, Finsupp.coe_finsetSum,
+    Finset.sum_apply, Finsupp.mapRange_apply, Module.Basis.tensorProduct_repr_tmul_apply,
+    Module.Basis.dualBasis_repr, Module.Basis.coord_apply, ofVectorSpace_repr_coe, smul_eq_mul,
+    mul_ite, mul_one, mul_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq',
+    Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt] using
+    sum_matrixCoefficient_mul_antipode k H M p q
 
 /-- The ordinary finite-dimensional coevaluation, as a finite-comodule morphism into the
 tensor product with the antipode-twisted dual. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -159,9 +159,9 @@ private lemma ofVectorSpace_repr_coe (M : FGComoduleCat.{u, v, u} k H)
   rw [← Module.Basis.ofVectorSpace_apply_self k M i]
   exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
 
-/-- **The antipode inverts the matrix-coefficient matrix.** Summing a matrix coefficient against the
-antipode of the transposed one collapses to a Kronecker delta, by the left antipode identity
-followed by the counit computation of a matrix coefficient. -/
+/-- Summing a matrix coefficient against the antipode of the transposed one collapses to a
+Kronecker delta: in the multiplication order displayed below, the antipode-transformed matrix is a
+right inverse of the matrix-coefficient matrix. The opposite order is not claimed here. -/
 private lemma sum_matrixCoefficient_mul_antipode (M : FGComoduleCat.{u, v, u} k H)
     [DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]
     (p q : Module.Basis.ofVectorSpaceIndex k M) :
@@ -173,6 +173,8 @@ private lemma sum_matrixCoefficient_mul_antipode (M : FGComoduleCat.{u, v, u} k 
           ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
       if q = p then 1 else 0 := by
   classical
+  -- Recognise the sum as the left antipode identity applied to a matrix coefficient, then finish
+  -- with the counit computation of that coefficient.
   calc
     _ = LinearMap.mul' k H
         ((HopfAlgebra.antipode k).lTensor H

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -150,50 +150,34 @@ theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
   dualEvaluation_toLinearMap_aux k H M
 
-/-- The coordinates of a basis vector of `Module.Basis.ofVectorSpace` in that same basis form a
-Kronecker delta. -/
-private lemma ofVectorSpace_repr_coe (M : FGComoduleCat.{u, v, u} k H)
-    [DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]
-    (i j : Module.Basis.ofVectorSpaceIndex k M) :
-    (Module.Basis.ofVectorSpace k M).repr (i : M) j = if i = j then 1 else 0 := by
-  rw [← Module.Basis.ofVectorSpace_apply_self k M i]
-  exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
-
 /-- Summing a matrix coefficient against the antipode of the transposed one collapses to a
 Kronecker delta: in the multiplication order displayed below, the antipode-transformed matrix is a
-right inverse of the matrix-coefficient matrix. The opposite order is not claimed here. -/
-private lemma sum_matrixCoefficient_mul_antipode (M : FGComoduleCat.{u, v, u} k H)
-    [DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]
-    (p q : Module.Basis.ofVectorSpaceIndex k M) :
-    (∑ x : Module.Basis.ofVectorSpaceIndex k M,
-      Comodule.matrixCoefficient (R := k) (C := H)
-        ((Module.Basis.ofVectorSpace k M).coord p) (x : M) *
+right inverse of the matrix-coefficient matrix. The opposite order is not claimed here.
+
+Stated for an arbitrary finite basis; nothing about the canonical `Module.Basis.ofVectorSpace`
+choice is used. -/
+private lemma sum_matrixCoefficient_mul_antipode {ι : Type u} [Fintype ι] [DecidableEq ι]
+    (M : FGComoduleCat.{u, v, u} k H) (b : Module.Basis ι k M) (p q : ι) :
+    (∑ x : ι,
+      Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b x) *
       HopfAlgebra.antipode k
-        (Comodule.matrixCoefficient (R := k) (C := H)
-          ((Module.Basis.ofVectorSpace k M).coord x) (q : M))) =
+        (Comodule.matrixCoefficient (R := k) (C := H) (b.coord x) (b q))) =
       if q = p then 1 else 0 := by
-  classical
   -- Recognise the sum as the left antipode identity applied to a matrix coefficient, then finish
   -- with the counit computation of that coefficient.
   calc
     _ = LinearMap.mul' k H
         ((HopfAlgebra.antipode k).lTensor H
           (Coalgebra.comul
-            (Comodule.matrixCoefficient (R := k) (C := H)
-              ((Module.Basis.ofVectorSpace k M).coord p)
-              ((Module.Basis.ofVectorSpace k M) q)))) := by
-      rw [Comodule.comul_matrixCoefficient_eq_sum (Module.Basis.ofVectorSpace k M)]
-      simp only [map_sum, LinearMap.lTensor_tmul, LinearMap.mul'_apply,
-        Module.Basis.coe_ofVectorSpace]
+            (Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b q)))) := by
+      rw [Comodule.comul_matrixCoefficient_eq_sum b]
+      simp only [map_sum, LinearMap.lTensor_tmul, LinearMap.mul'_apply]
     _ = algebraMap k H
-        (Coalgebra.counit
-          (Comodule.matrixCoefficient (R := k) (C := H)
-            ((Module.Basis.ofVectorSpace k M).coord p)
-            ((Module.Basis.ofVectorSpace k M) q))) :=
+        (Coalgebra.counit (Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b q))) :=
       HopfAlgebra.mul_antipode_lTensor_comul_apply _
     _ = if q = p then 1 else 0 := by
       rw [Comodule.counit_matrixCoefficient]
-      simp [Module.Basis.coord_apply, ofVectorSpace_repr_coe]
+      simp [Module.Basis.coord_apply, Finsupp.single_apply, apply_ite (algebraMap k H), eq_comm]
 
 private theorem tensorCoact_coevaluation_apply_one
     (M : FGComoduleCat.{u, v, u} k H) :
@@ -216,13 +200,17 @@ private theorem tensorCoact_coevaluation_apply_one
     (Module.Basis.ofVectorSpace k M).dualBasis
   apply (TensorProduct.equivFinsuppOfBasisLeft (N := H) bt).injective
   ext ⟨p, q⟩
+  have hrepr (i j : Module.Basis.ofVectorSpaceIndex k M) :
+      (Module.Basis.ofVectorSpace k M).repr (i : M) j = if i = j then 1 else 0 := by
+    rw [← Module.Basis.ofVectorSpace_apply_self k M i]
+    exact Module.Basis.repr_self_apply (Module.Basis.ofVectorSpace k M) i j
   simpa only [Module.Basis.coe_ofVectorSpace, map_sum,
     TensorProduct.equivFinsuppOfBasisLeft_apply_tmul, Finsupp.coe_finsetSum,
     Finset.sum_apply, Finsupp.mapRange_apply, Module.Basis.tensorProduct_repr_tmul_apply,
-    Module.Basis.dualBasis_repr, Module.Basis.coord_apply, ofVectorSpace_repr_coe, smul_eq_mul,
+    Module.Basis.dualBasis_repr, Module.Basis.coord_apply, hrepr, smul_eq_mul,
     mul_ite, mul_one, mul_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq',
     Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt] using
-    sum_matrixCoefficient_mul_antipode k H M p q
+    sum_matrixCoefficient_mul_antipode k H M (Module.Basis.ofVectorSpace k M) p q
 
 /-- The ordinary finite-dimensional coevaluation, as a finite-comodule morphism into the
 tensor product with the antipode-twisted dual. -/

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -155,28 +155,30 @@ theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
 `1` when they agree and `0` otherwise, so the antipode-transformed matrix is a right inverse of the
 matrix-coefficient matrix in this multiplication order; the opposite order is not claimed here.
 
-Stated for any comodule with a finite basis: neither the canonical `Module.Basis.ofVectorSpace`
-choice, nor finite-dimensionality, nor decidable equality on the index type plays a part. -/
-private lemma sum_matrixCoefficient_mul_antipode_eq_algebraMap {M : Type*} [AddCommMonoid M]
-    [Module k M] [Comodule k H M] {ι : Type*} [Fintype ι] (b : Module.Basis ι k M) (p q : ι) :
+Stated over its own base ring, for any comodule with a finite basis: neither the ambient field,
+nor the canonical `Module.Basis.ofVectorSpace` choice, nor finite-dimensionality, nor decidable
+equality on the index type plays a part. -/
+private lemma sum_matrixCoefficient_mul_antipode_eq_algebraMap (R : Type*) [CommSemiring R]
+    (A : Type*) [Semiring A] [HopfAlgebra R A] {M : Type*} [AddCommMonoid M] [Module R M]
+    [Comodule R A M] {ι : Type*} [Fintype ι] (b : Module.Basis ι R M) (p q : ι) :
     (∑ x : ι,
-      Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b x) *
-      HopfAlgebra.antipode k
-        (Comodule.matrixCoefficient (R := k) (C := H) (b.coord x) (b q))) =
-      algebraMap k H (b.coord p (b q)) := by
+      Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b x) *
+      HopfAlgebra.antipode R
+        (Comodule.matrixCoefficient (R := R) (C := A) (b.coord x) (b q))) =
+      algebraMap R A (b.coord p (b q)) := by
   -- Recognise the sum as the left antipode identity applied to a matrix coefficient, then finish
   -- with the counit computation of that coefficient.
   calc
-    _ = LinearMap.mul' k H
-        ((HopfAlgebra.antipode k).lTensor H
+    _ = LinearMap.mul' R A
+        ((HopfAlgebra.antipode R).lTensor A
           (Coalgebra.comul
-            (Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b q)))) := by
+            (Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b q)))) := by
       rw [Comodule.comul_matrixCoefficient_eq_sum b]
       simp only [map_sum, LinearMap.lTensor_tmul, LinearMap.mul'_apply]
-    _ = algebraMap k H
-        (Coalgebra.counit (Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b q))) :=
+    _ = algebraMap R A
+        (Coalgebra.counit (Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b q))) :=
       HopfAlgebra.mul_antipode_lTensor_comul_apply _
-    _ = algebraMap k H (b.coord p (b q)) := by rw [Comodule.counit_matrixCoefficient]
+    _ = algebraMap R A (b.coord p (b q)) := by rw [Comodule.counit_matrixCoefficient]
 
 private theorem tensorCoact_coevaluation_apply_one
     (M : FGComoduleCat.{u, v, u} k H) :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -150,9 +150,9 @@ theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
   dualEvaluation_toLinearMap_aux k H M
 
-/-- Summing a matrix coefficient against the antipode of the transposed one is the image under
-`algebraMap` of a single basis coordinate. Taking `p` and `q` basis indices, the right-hand side is
-`1` when they agree and `0` otherwise, so the antipode-transformed matrix is a right inverse of the
+/-- Multiplying the matrix-coefficient matrix by its entrywise antipode transform gives the image
+under `algebraMap` of a single basis coordinate. Taking `p` and `q` basis indices, the right-hand
+side is `1` when they agree and `0` otherwise, so the antipode transform is a right inverse of the
 matrix-coefficient matrix in this multiplication order; the opposite order is not claimed here.
 
 Stated over its own base ring, for any comodule with a finite basis: neither the ambient field,
@@ -166,19 +166,15 @@ private lemma sum_matrixCoefficient_mul_antipode_eq_algebraMap (R : Type*) [Comm
       HopfAlgebra.antipode R
         (Comodule.matrixCoefficient (R := R) (C := A) (b.coord x) (b q))) =
       algebraMap R A (b.coord p (b q)) := by
-  -- Recognise the sum as the left antipode identity applied to a matrix coefficient, then finish
-  -- with the counit computation of that coefficient.
-  calc
-    _ = LinearMap.mul' R A
-        ((HopfAlgebra.antipode R).lTensor A
-          (Coalgebra.comul
-            (Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b q)))) := by
-      rw [Comodule.comul_matrixCoefficient_eq_sum b]
-      simp only [map_sum, LinearMap.lTensor_tmul, LinearMap.mul'_apply]
-    _ = algebraMap R A
-        (Coalgebra.counit (Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b q))) :=
-      HopfAlgebra.mul_antipode_lTensor_comul_apply _
-    _ = algebraMap R A (b.coord p (b q)) := by rw [Comodule.counit_matrixCoefficient]
+  -- The basis expansion of `comul` is a `Coalgebra.Repr`, so Mathlib's antipode sum applies.
+  let repr : Coalgebra.Repr R
+      (Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b q)) ι :=
+    { index := Finset.univ
+      left := fun x => Comodule.matrixCoefficient (R := R) (C := A) (b.coord p) (b x)
+      right := fun x => Comodule.matrixCoefficient (R := R) (C := A) (b.coord x) (b q)
+      eq := (Comodule.comul_matrixCoefficient_eq_sum b (b.coord p) (b q)).symm }
+  rw [← Comodule.counit_matrixCoefficient (R := R) (C := A) (b.coord p) (b q)]
+  exact HopfAlgebra.sum_mul_antipode_eq_algebraMap_counit repr
 
 private theorem tensorCoact_coevaluation_apply_one
     (M : FGComoduleCat.{u, v, u} k H) :

--- a/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Finite/RightRigid.lean
@@ -150,19 +150,20 @@ theorem dualEvaluation_toLinearMap (M : FGComoduleCat.{u, v, u} k H) :
     (dualEvaluation k H M).hom.toLinearMap = contractLeft k M :=
   dualEvaluation_toLinearMap_aux k H M
 
-/-- Summing a matrix coefficient against the antipode of the transposed one collapses to a
-Kronecker delta: in the multiplication order displayed below, the antipode-transformed matrix is a
-right inverse of the matrix-coefficient matrix. The opposite order is not claimed here.
+/-- Summing a matrix coefficient against the antipode of the transposed one is the image under
+`algebraMap` of a single basis coordinate. Taking `p` and `q` basis indices, the right-hand side is
+`1` when they agree and `0` otherwise, so the antipode-transformed matrix is a right inverse of the
+matrix-coefficient matrix in this multiplication order; the opposite order is not claimed here.
 
-Stated for an arbitrary finite basis; nothing about the canonical `Module.Basis.ofVectorSpace`
-choice is used. -/
-private lemma sum_matrixCoefficient_mul_antipode {ι : Type u} [Fintype ι] [DecidableEq ι]
-    (M : FGComoduleCat.{u, v, u} k H) (b : Module.Basis ι k M) (p q : ι) :
+Stated for any comodule with a finite basis: neither the canonical `Module.Basis.ofVectorSpace`
+choice, nor finite-dimensionality, nor decidable equality on the index type plays a part. -/
+private lemma sum_matrixCoefficient_mul_antipode_eq_algebraMap {M : Type*} [AddCommMonoid M]
+    [Module k M] [Comodule k H M] {ι : Type*} [Fintype ι] (b : Module.Basis ι k M) (p q : ι) :
     (∑ x : ι,
       Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b x) *
       HopfAlgebra.antipode k
         (Comodule.matrixCoefficient (R := k) (C := H) (b.coord x) (b q))) =
-      if q = p then 1 else 0 := by
+      algebraMap k H (b.coord p (b q)) := by
   -- Recognise the sum as the left antipode identity applied to a matrix coefficient, then finish
   -- with the counit computation of that coefficient.
   calc
@@ -175,9 +176,7 @@ private lemma sum_matrixCoefficient_mul_antipode {ι : Type u} [Fintype ι] [Dec
     _ = algebraMap k H
         (Coalgebra.counit (Comodule.matrixCoefficient (R := k) (C := H) (b.coord p) (b q))) :=
       HopfAlgebra.mul_antipode_lTensor_comul_apply _
-    _ = if q = p then 1 else 0 := by
-      rw [Comodule.counit_matrixCoefficient]
-      simp [Module.Basis.coord_apply, Finsupp.single_apply, apply_ite (algebraMap k H), eq_comm]
+    _ = algebraMap k H (b.coord p (b q)) := by rw [Comodule.counit_matrixCoefficient]
 
 private theorem tensorCoact_coevaluation_apply_one
     (M : FGComoduleCat.{u, v, u} k H) :
@@ -186,7 +185,7 @@ private theorem tensorCoact_coevaluation_apply_one
       coevaluation k M 1 ⊗ₜ[k] (1 : H) := by
   classical
   -- Expand coevaluation and both coactions in a basis, then compare tensor coordinates.
-  -- The remaining matrix-coefficient sum collapses by `sum_matrixCoefficient_mul_antipode`.
+  -- The remaining matrix-coefficient sum collapses by the antipode identity below.
   let b := Module.Basis.ofVectorSpace k M
   rw [coevaluation_apply_one]
   dsimp only [b]
@@ -209,8 +208,9 @@ private theorem tensorCoact_coevaluation_apply_one
     Finset.sum_apply, Finsupp.mapRange_apply, Module.Basis.tensorProduct_repr_tmul_apply,
     Module.Basis.dualBasis_repr, Module.Basis.coord_apply, hrepr, smul_eq_mul,
     mul_ite, mul_one, mul_zero, ite_smul, one_smul, zero_smul, Finset.sum_ite_eq',
-    Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt] using
-    sum_matrixCoefficient_mul_antipode k H M (Module.Basis.ofVectorSpace k M) p q
+    Finset.mem_univ, ↓reduceIte, Finset.sum_ite_eq, bt,
+    apply_ite (algebraMap k H), map_one, map_zero] using
+    sum_matrixCoefficient_mul_antipode_eq_algebraMap k H (Module.Basis.ofVectorSpace k M) p q
 
 /-- The ordinary finite-dimensional coevaluation, as a finite-comodule morphism into the
 tensor product with the antipode-twisted dual. -/


### PR DESCRIPTION
`TauCeti.FGComoduleCat.tensorCoact_coevaluation_apply_one` (added in #1640) carried a 54-line
proof body. This is a pure refactor of that proof — no statement changes.

* `ofVectorSpace_repr_coe` (4 lines) — the coordinates of a basis vector of
  `Module.Basis.ofVectorSpace` in that same basis form a Kronecker delta. Previously an inline
  `have`, and used twice.
* `sum_matrixCoefficient_mul_antipode` (20 lines) — the mathematical core, and the reason the
  theorem is true: summing a matrix coefficient against the antipode of the transposed one
  collapses to a Kronecker delta, by the left antipode identity followed by the counit computation
  of a matrix coefficient. This says the antipode inverts the matrix-coefficient matrix, which is
  worth stating on its own rather than burying inside a coordinate calculation.

The parent drops to 23 lines: expand coevaluation and both coactions in a basis, compare tensor
coordinates, and close by citing the sum identity.

Both helpers take `[DecidableEq (Module.Basis.ofVectorSpaceIndex k M)]` as an instance argument.
The original obtained decidability from `classical` at the top of the proof, which is unavailable
once the `if` appears in a helper's *statement* rather than its body.

Roadmap: none