### PR TITLE
refactor(Conformal): decompose the monodromy-theorem proof

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -150,12 +150,13 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
 
-/-- **Shearing a path to a nearby endpoint.** Adding `x • (w - z)` to a path ending at `z` produces
-a path ending at `w`, with the same start, that stays within `dist w z` of the original — hence
-within `r` whenever `w` is `r`-close to `z`.
+/-- **A nearby path with a prescribed endpoint.** Given a path ending at `z` and a point `w` within
+`r` of it, there is a continuous path with the same start, ending at `w`, staying everywhere within
+`r` of the original.
 
+The witness is the shear `x ↦ δ x + x • (w - z)`, which moves each point by at most `dist w z`.
 Purely a statement about paths in `ℂ`: no analytic continuation, and no reference to `U`. -/
-private lemma exists_path_shear {z w : ℂ} {r : ℝ} (hδ : Continuous δ) (hδ1 : δ 1 = z)
+private lemma exists_continuous_path_dist_lt {z w : ℂ} {r : ℝ} (hδ : Continuous δ) (hδ1 : δ 1 = z)
     (hw : dist w z < r) :
     ∃ δ' : I → ℂ, Continuous δ' ∧ (∀ x, dist (δ' x) (δ x) < r) ∧ δ' 0 = δ 0 ∧ δ' 1 = w := by
   refine ⟨fun x => δ x + (x : ℝ) • (w - z), by fun_prop, fun x => ?_, by simp, by simp [hδ1]⟩
@@ -202,7 +203,7 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     filter_upwards [ball_mem_nhds z (lt_min hρ hε), hGone] with w hw hwG
     -- The path `δ` sheared to end at `w` instead of `z`.
     obtain ⟨δ', hδ'c, hdist, hδ'start, hδ'1⟩ :=
-      exists_path_shear hδ hδ1 (r := min ρ ε) (mem_ball.1 hw)
+      exists_continuous_path_dist_lt hδ hδ1 (r := min ρ ε) (mem_ball.1 hw)
     have hδ'U : ∀ x, δ' x ∈ U := fun x =>
       hεU (mem_thickening_iff.2 ⟨δ x, mem_range_self x, (hdist x).trans_le (min_le_right _ _)⟩)
     have hδ'0 : δ' 0 = z₀ := hδ'start.trans hδ0

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -150,21 +150,23 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
 
-/-- **A nearby path with a prescribed endpoint.** Given a path ending at `z` and a point `w` within
-`r` of it, there is a continuous path with the same start, ending at `w`, staying everywhere within
-`r` of the original.
+/-- **A nearby path with a prescribed endpoint.** Given a point `w` within `r` of the endpoint of a
+path, there is a continuous path with the same start, ending at `w`, staying everywhere within `r`
+of the original.
 
-The witness is the shear `x ↦ δ x + x • (w - z)`, which moves each point by at most `dist w z`.
-Purely a statement about paths in `ℂ`: no analytic continuation, and no reference to `U`. -/
-private lemma exists_continuous_path_dist_lt {z w : ℂ} {r : ℝ} (hδ : Continuous δ) (hδ1 : δ 1 = z)
-    (hw : dist w z < r) :
+The witness is the shear `x ↦ δ x + x • (w - δ 1)`, which moves each point by at most
+`dist w (δ 1)`. Purely a statement about paths in `ℂ`: no analytic continuation, and no reference
+to `U`. -/
+private lemma exists_continuous_path_dist_lt {w : ℂ} {r : ℝ} (hδ : Continuous δ)
+    (hw : dist w (δ 1) < r) :
     ∃ δ' : I → ℂ, Continuous δ' ∧ (∀ x, dist (δ' x) (δ x) < r) ∧ δ' 0 = δ 0 ∧ δ' 1 = w := by
-  refine ⟨fun x => δ x + (x : ℝ) • (w - z), by fun_prop, fun x => ?_, by simp, by simp [hδ1]⟩
+  refine ⟨fun x => δ x + (x : ℝ) • (w - δ 1), by fun_prop, fun x => ?_, by simp, by simp⟩
   have hx : |(x : ℝ)| ≤ 1 := abs_le.2 ⟨by linarith [x.2.1], x.2.2⟩
-  have hd : dist (δ x + (x : ℝ) • (w - z)) (δ x) = |(x : ℝ)| * dist w z := by
+  have hd : dist (δ x + (x : ℝ) • (w - δ 1)) (δ x) = |(x : ℝ)| * dist w (δ 1) := by
     rw [dist_eq_norm, dist_eq_norm]
     simp
-  have hle : |(x : ℝ)| * dist w z ≤ dist w z := mul_le_of_le_one_left dist_nonneg hx
+  have hle : |(x : ℝ)| * dist w (δ 1) ≤ dist w (δ 1) :=
+    mul_le_of_le_one_left dist_nonneg hx
   linarith [hd ▸ hle]
 
 /-- **The monodromy theorem for a simply connected domain.** A germ that continues along every
@@ -203,7 +205,7 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     filter_upwards [ball_mem_nhds z (lt_min hρ hε), hGone] with w hw hwG
     -- The path `δ` sheared to end at `w` instead of `z`.
     obtain ⟨δ', hδ'c, hdist, hδ'start, hδ'1⟩ :=
-      exists_continuous_path_dist_lt hδ hδ1 (r := min ρ ε) (mem_ball.1 hw)
+      exists_continuous_path_dist_lt hδ (r := min ρ ε) (hδ1 ▸ mem_ball.1 hw)
     have hδ'U : ∀ x, δ' x ∈ U := fun x =>
       hεU (mem_thickening_iff.2 ⟨δ x, mem_range_self x, (hdist x).trans_le (min_le_right _ _)⟩)
     have hδ'0 : δ' 0 = z₀ := hδ'start.trans hδ0

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -150,14 +150,6 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
 
-/-- A path inside `U` from `z₀` to any other point, as a plain continuous map on `I`. Only
-path-connectedness is needed; the simply connected hypothesis of the theorem below plays no part
-here. -/
-private lemma exists_path_mem (hU : IsPathConnected U) (hz₀ : z₀ ∈ U) {w : ℂ} (hw : w ∈ U) :
-    ∃ γ : I → ℂ, Continuous γ ∧ (∀ x, γ x ∈ U) ∧ γ 0 = z₀ ∧ γ 1 = w := by
-  obtain ⟨c, hc⟩ := hU.joinedIn z₀ hz₀ w hw
-  exact ⟨c, c.continuous, hc, c.source, c.target⟩
-
 /-- **Shearing a path to a nearby endpoint.** Adding `x • (w - z)` to a path ending at `z` produces
 a path ending at `w`, with the same start, that stays within `dist w z` of the original — hence
 within `r` whenever `w` is `r`-close to `z`.
@@ -184,8 +176,11 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     (H : ContinuesInside f₀ U z₀) :
     ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ := by
   -- A path from `z₀` to each point of `U`, and a continuation of the germ along it.
-  choose! γ hγc hγU hγ0 hγ1 using fun w (hw : w ∈ U) =>
-    exists_path_mem hUc.isPathConnected hz₀ hw
+  have hpath : ∀ w ∈ U, ∃ γ : I → ℂ,
+      Continuous γ ∧ (∀ x, γ x ∈ U) ∧ γ 0 = z₀ ∧ γ 1 = w := fun w hw =>
+    have h := hUc.isPathConnected.joinedIn z₀ hz₀ w hw
+    ⟨h.somePath, h.somePath.continuous, h.somePath_mem, h.somePath.source, h.somePath.target⟩
+  choose! γ hγc hγU hγ0 hγ1 using hpath
   choose! f hf hf₀ using fun w (hw : w ∈ U) =>
     continuesAlong_iff_exists.1 (H.continuesAlong (hγc w hw) (hγU w hw) (hγ0 w hw))
   have hf₀' : ∀ w ∈ U, f w 0 =ᶠ[𝓝 z₀] f₀ := fun w hw => by
@@ -203,8 +198,7 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     -- ... and an `ε`-neighbourhood of the compact `δ '' I` is still inside `U`.
     obtain ⟨ε, hε, hεU⟩ := (isCompact_range hδ).exists_thickening_subset_open hUo
       (range_subset_iff.2 hδU)
-    have hGone : G 1 =ᶠ[𝓝 z] g 1 := by
-      have := hGg 1 (mem_univ 1); rwa [hδ1] at this
+    have hGone : G 1 =ᶠ[𝓝 z] g 1 := hδ1 ▸ hGg 1 (mem_univ 1)
     filter_upwards [ball_mem_nhds z (lt_min hρ hε), hGone] with w hw hwG
     -- The path `δ` sheared to end at `w` instead of `z`.
     obtain ⟨δ', hδ'c, hdist, hδ'start, hδ'1⟩ :=
@@ -215,19 +209,17 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     have hwU : w ∈ U := hδ'1 ▸ hδ'U 1
     have hGδ' : IsAnalyticContinuationAlong G δ' univ :=
       hGcont δ' hδ'c.continuousOn fun t _ => (hdist t).trans_le (min_le_left _ _)
-    have hG0 : G 0 =ᶠ[𝓝 z₀] f₀ := by
-      have := hGg 0 (mem_univ 0); rw [hδ0] at this; exact this.trans hg0
+    have hG0 : G 0 =ᶠ[𝓝 z₀] f₀ := (hδ0 ▸ hGg 0 (mem_univ 0)).trans hg0
     -- Path independence: the chosen continuation to `w` and `G` end at the same germ.
-    have hterm := H.eventuallyEq_at_one hUc (hγc w hwU) (hγU w hwU) (hγ0 w hwU) hδ'c hδ'U hδ'0
-      (by rw [hδ'1, hγ1 w hwU]) (hf w hwU) (hf₀' w hwU) hGδ' hG0
-    have hval := hterm.eq_of_nhds
+    have hval := (H.eventuallyEq_at_one hUc (hγc w hwU) (hγU w hwU) (hγ0 w hwU) hδ'c hδ'U hδ'0
+      (by rw [hδ'1, hγ1 w hwU]) (hf w hwU) (hf₀' w hwU) hGδ' hG0).eq_of_nhds
     rw [hγ1 w hwU] at hval
     rw [hFdef]
     exact hval.trans hwG
   refine ⟨F, fun z hz => ?_, ?_⟩
   · -- Analyticity at `z`: `F` agrees near `z` with the terminal germ of the continuation to `z`.
     have han : AnalyticAt ℂ (f z 1) z := by
-      have := (hf z hz).analyticAt 1 (mem_univ 1); rwa [hγ1 z hz] at this
+      simpa [hγ1 z hz] using (hf z hz).analyticAt 1 (mem_univ 1)
     exact han.congr
       (key z (γ z) (f z) (hγc z hz) (hγU z hz) (hγ0 z hz) (hγ1 z hz) (hf z hz) (hf₀' z hz)).symm
   · -- The prescribed germ at `z₀`: apply the key step to the constant path.

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -150,6 +150,30 @@ theorem eventuallyEq_at_one (hUc : IsSimplyConnected U) (H : ContinuesInside f�
   rw [hend] at e₁
   exact (e₀.trans hmono.symm).trans e₁.symm
 
+/-- A path inside `U` from `z₀` to any other point, as a plain continuous map on `I`. Only
+path-connectedness is needed; the simply connected hypothesis of the theorem below plays no part
+here. -/
+private lemma exists_path_mem (hU : IsPathConnected U) (hz₀ : z₀ ∈ U) {w : ℂ} (hw : w ∈ U) :
+    ∃ γ : I → ℂ, Continuous γ ∧ (∀ x, γ x ∈ U) ∧ γ 0 = z₀ ∧ γ 1 = w := by
+  obtain ⟨c, hc⟩ := hU.joinedIn z₀ hz₀ w hw
+  exact ⟨c, c.continuous, hc, c.source, c.target⟩
+
+/-- **Shearing a path to a nearby endpoint.** Adding `x • (w - z)` to a path ending at `z` produces
+a path ending at `w`, with the same start, that stays within `dist w z` of the original — hence
+within `r` whenever `w` is `r`-close to `z`.
+
+Purely a statement about paths in `ℂ`: no analytic continuation, and no reference to `U`. -/
+private lemma exists_path_shear {z w : ℂ} {r : ℝ} (hδ : Continuous δ) (hδ1 : δ 1 = z)
+    (hw : dist w z < r) :
+    ∃ δ' : I → ℂ, Continuous δ' ∧ (∀ x, dist (δ' x) (δ x) < r) ∧ δ' 0 = δ 0 ∧ δ' 1 = w := by
+  refine ⟨fun x => δ x + (x : ℝ) • (w - z), by fun_prop, fun x => ?_, by simp, by simp [hδ1]⟩
+  have hx : |(x : ℝ)| ≤ 1 := abs_le.2 ⟨by linarith [x.2.1], x.2.2⟩
+  have hd : dist (δ x + (x : ℝ) • (w - z)) (δ x) = |(x : ℝ)| * dist w z := by
+    rw [dist_eq_norm, dist_eq_norm]
+    simp
+  have hle : |(x : ℝ)| * dist w z ≤ dist w z := mul_le_of_le_one_left dist_nonneg hx
+  linarith [hd ▸ hle]
+
 /-- **The monodromy theorem for a simply connected domain.** A germ that continues along every
 path of a simply connected open set `U` issuing from `z₀` is the germ at `z₀` of a single function
 analytic on all of `U`.
@@ -160,12 +184,8 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
     (H : ContinuesInside f₀ U z₀) :
     ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ := by
   -- A path from `z₀` to each point of `U`, and a continuation of the germ along it.
-  have hpath : ∀ w ∈ U, ∃ γ : I → ℂ,
-      Continuous γ ∧ (∀ x, γ x ∈ U) ∧ γ 0 = z₀ ∧ γ 1 = w := by
-    intro w hw
-    obtain ⟨c, hc⟩ := hUc.isPathConnected.joinedIn z₀ hz₀ w hw
-    exact ⟨c, c.continuous, hc, c.source, c.target⟩
-  choose! γ hγc hγU hγ0 hγ1 using hpath
+  choose! γ hγc hγU hγ0 hγ1 using fun w (hw : w ∈ U) =>
+    exists_path_mem hUc.isPathConnected hz₀ hw
   choose! f hf hf₀ using fun w (hw : w ∈ U) =>
     continuesAlong_iff_exists.1 (H.continuesAlong (hγc w hw) (hγU w hw) (hγ0 w hw))
   have hf₀' : ∀ w ∈ U, f w 0 =ᶠ[𝓝 z₀] f₀ := fun w hw => by
@@ -187,22 +207,11 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
       have := hGg 1 (mem_univ 1); rwa [hδ1] at this
     filter_upwards [ball_mem_nhds z (lt_min hρ hε), hGone] with w hw hwG
     -- The path `δ` sheared to end at `w` instead of `z`.
-    set δ' : I → ℂ := fun x => δ x + (x : ℝ) • (w - z) with hδ'def
-    have hδ'c : Continuous δ' := by fun_prop
-    have hdist : ∀ x : I, dist (δ' x) (δ x) < min ρ ε := by
-      intro x
-      have hx : |(x : ℝ)| ≤ 1 := abs_le.2 ⟨by linarith [x.2.1], x.2.2⟩
-      have hd : dist (δ' x) (δ x) = |(x : ℝ)| * dist w z := by
-        rw [dist_eq_norm, dist_eq_norm, hδ'def]
-        simp
-      have hwz : dist w z < min ρ ε := mem_ball.1 hw
-      have : |(x : ℝ)| * dist w z ≤ dist w z :=
-        mul_le_of_le_one_left dist_nonneg hx
-      linarith [hd ▸ this]
+    obtain ⟨δ', hδ'c, hdist, hδ'start, hδ'1⟩ :=
+      exists_path_shear hδ hδ1 (r := min ρ ε) (mem_ball.1 hw)
     have hδ'U : ∀ x, δ' x ∈ U := fun x =>
       hεU (mem_thickening_iff.2 ⟨δ x, mem_range_self x, (hdist x).trans_le (min_le_right _ _)⟩)
-    have hδ'0 : δ' 0 = z₀ := by simp [hδ'def, hδ0]
-    have hδ'1 : δ' 1 = w := by simp [hδ'def, hδ1]
+    have hδ'0 : δ' 0 = z₀ := hδ'start.trans hδ0
     have hwU : w ∈ U := hδ'1 ▸ hδ'U 1
     have hGδ' : IsAnalyticContinuationAlong G δ' univ :=
       hGcont δ' hδ'c.continuousOn fun t _ => (hdist t).trans_le (min_le_left _ _)


### PR DESCRIPTION
`TauCeti.ContinuesInside.exists_analyticOnNhd` (added in #1648) carried a 65-line proof body.
Pure refactor — no statement changes.

Two private helpers, both stated at hypotheses strictly weaker than the parent's:

* `exists_path_mem` (2 lines) — a path inside `U` from `z₀` to any other point. This needs only
  `IsPathConnected U`; the parent's `IsSimplyConnected` is not used, so the helper does not take
  it and the parent passes `hUc.isPathConnected`.
* `exists_path_shear` (7 lines) — shearing a path to a nearby endpoint: adding `x • (w - z)` to a
  path ending at `z` yields one ending at `w`, with the same start, staying within `dist w z` of
  the original and hence within `r` when `w` is `r`-close to `z`. This is purely a statement about
  paths in `ℂ` — no analytic continuation, no reference to `U` — and it replaces an 18-line inline
  block that mixed the geometry with the containment argument.

The parent drops to 50 lines, and the remaining `key` step now reads as the monodromy argument
proper: pick a continuation, shear the path to a nearby endpoint, and apply path independence.

Roadmap: ConformalMapping