### PR TITLE
feat: show comodules are directed unions of finite subcomodules

### DIFF
--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -37,6 +37,10 @@ No flatness or noetherian hypothesis is needed.
 
 ## References
 
+The directed-union theorem sequence from `finiteSubcomodules_nonempty` through
+`iUnion_finiteSubcomodules_eq_univ_of_exists_mem` is adapted from the corresponding
+subcoalgebra development in `TauCeti.Algebra.Coalgebra.Subcoalgebra.Finite`.
+
 See Sweedler, *Hopf Algebras*, Chapter 2.
 -/
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -4,17 +4,25 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
-public import TauCeti.Algebra.Coalgebra.Subcomodule.Basic
+public import Mathlib.Order.SupClosed
+public import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
 
 /-!
 # Finite subcomodules
 
 This file proves that, when the coalgebra is free as a module over a commutative
 semiring, every element of a right comodule is contained in a finitely generated
-subcomodule. The carrier is the span of the finitely many coefficients occurring
-when the element's coaction is expanded in a basis of the coalgebra. The counit
-shows that the original element lies in this span, and coordinate slices of
+subcomodule. It also packages the order-theoretic consequences: finite subcomodules
+form a nonempty directed family, finite subsets and finitely generated submodules
+are contained in one finite subcomodule, and the supremum and literal union of the
+finite subcomodules are the whole comodule. Over a field these become statements
+about finite-dimensional subcomodules.
+
+For the elementwise result, the carrier is the span of the finitely many coefficients
+occurring when the element's coaction is expanded in a basis of the coalgebra. The
+counit shows that the original element lies in this span, and coordinate slices of
 coassociativity show that the span is stable under the coaction.
 
 No flatness or noetherian hypothesis is needed.
@@ -23,6 +31,12 @@ No flatness or noetherian hypothesis is needed.
 
 * `TauCeti.Subcomodule.exists_finite_subcomodule_mem`: every element belongs to a
   subcomodule whose underlying module is finite.
+* `TauCeti.Subcomodule.finiteSubcomodules_directedOn`: finite subcomodules form a
+  directed family.
+* `TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`: for a free coefficient coalgebra,
+  the finite subcomodules have supremum `⊤`.
+* `TauCeti.Subcomodule.exists_finiteDimensional_subcomodule_mem`: over a field, every
+  element belongs to a finite-dimensional subcomodule.
 
 ## References
 
@@ -37,12 +51,14 @@ namespace TauCeti
 
 universe u v w
 
+namespace Subcomodule
+
+section General
+
 variable {R : Type u} {C : Type v} {M : Type w}
 variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
 variable [AddCommMonoid M] [Module R M] [Comodule R C M]
-
-namespace Subcomodule
 
 private theorem coeff_rTensor_coact
     {ι : Type*} [DecidableEq ι] (b : Module.Basis ι R C) (x : M ⊗[R] C) (i : ι) :
@@ -157,6 +173,196 @@ theorem exists_finite_subcomodule_mem [Module.Free R C] (m : M) :
     rw [hSN]
     exact Module.Finite.span_of_finite R a.finite_range
   · exact mem_ofSubmodule.mpr (mem_of_forall_coeff_mem b m ha_mem)
+
+/-- The set of subcomodules that are finitely generated as `R`-modules. -/
+def finiteSubcomodules : Set (Subcomodule R C M) :=
+  {N | Module.Finite R N.toSubmodule}
+
+@[simp]
+theorem mem_finiteSubcomodules {N : Subcomodule R C M} :
+    N ∈ finiteSubcomodules (R := R) (C := C) (M := M) ↔
+      Module.Finite R N.toSubmodule :=
+  Iff.rfl
+
+/-- The zero subcomodule makes the family of finite subcomodules nonempty. -/
+theorem finiteSubcomodules_nonempty :
+    (finiteSubcomodules (R := R) (C := C) (M := M)).Nonempty := by
+  refine ⟨⊥, ?_⟩
+  rw [mem_finiteSubcomodules]
+  exact Module.Finite.bot R M
+
+/-- Finite subcomodules are closed under binary joins. -/
+theorem finiteSubcomodules_supClosed :
+    SupClosed (finiteSubcomodules (R := R) (C := C) (M := M)) := by
+  intro N hN P hP
+  rw [mem_finiteSubcomodules] at hN hP ⊢
+  letI : Module.Finite R N.toSubmodule := hN
+  letI : Module.Finite R P.toSubmodule := hP
+  exact sup_finite N P
+
+/-- Finite subcomodules form a directed family under inclusion. -/
+theorem finiteSubcomodules_directedOn :
+    DirectedOn (· ≤ ·) (finiteSubcomodules (R := R) (C := C) (M := M)) :=
+  finiteSubcomodules_supClosed.directedOn
+
+/-- The carrier of the supremum of all finite subcomodules is their literal union. -/
+@[simp]
+theorem coe_sSup_finiteSubcomodules :
+    ((sSup (finiteSubcomodules (R := R) (C := C) (M := M)) :
+        Subcomodule R C M) : Set M) =
+      ⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M) :=
+  coe_sSup_of_directed finiteSubcomodules_nonempty finiteSubcomodules_directedOn
+
+/-- Membership in the supremum of all finite subcomodules means membership in one finite
+subcomodule. -/
+theorem mem_sSup_finiteSubcomodules {m : M} :
+    m ∈ sSup (finiteSubcomodules (R := R) (C := C) (M := M)) ↔
+      ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N := by
+  simpa only [mem_finiteSubcomodules] using
+    (mem_sSup_of_directed finiteSubcomodules_nonempty finiteSubcomodules_directedOn (m := m))
+
+/-- If every element lies in a finite subcomodule, then every finite set lies in one finite
+subcomodule. -/
+theorem exists_finite_subcomodule_of_setFinite_of_exists_mem
+    (hM : ∀ m : M, ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N)
+    {s : Set M} (hs : s.Finite) :
+    ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ s ⊆ N := by
+  classical
+  letI : Fintype s := hs.fintype
+  choose N hNfinite hNmem using fun m : s ↦ hM m
+  refine ⟨⨆ m : s, N m, iSup_finite N hNfinite, ?_⟩
+  intro m hm
+  exact (le_sSup (s := Set.range N) (Set.mem_range_self ⟨m, hm⟩))
+    (hNmem ⟨m, hm⟩)
+
+/-- If every element lies in a finite subcomodule, then every finitely generated submodule lies
+in one finite subcomodule. -/
+theorem exists_finite_subcomodule_of_fg_of_exists_mem
+    (hM : ∀ m : M, ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N)
+    (P : Submodule R M) (hP : P.FG) :
+    ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ P ≤ N.toSubmodule := by
+  obtain ⟨s, hs, hspan⟩ := Submodule.fg_def.mp hP
+  obtain ⟨N, hNfinite, hsN⟩ :=
+    exists_finite_subcomodule_of_setFinite_of_exists_mem hM hs
+  refine ⟨N, hNfinite, ?_⟩
+  rw [← hspan]
+  exact Submodule.span_le.2 hsN
+
+/-- If every element lies in a finite subcomodule, then the supremum of all finite
+subcomodules is the whole comodule. -/
+theorem sSup_finiteSubcomodules_eq_top_of_exists_mem
+    (hM : ∀ m : M, ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N) :
+    sSup (finiteSubcomodules (R := R) (C := C) (M := M)) = ⊤ := by
+  apply top_unique
+  intro m _
+  exact mem_sSup_finiteSubcomodules.2 (hM m)
+
+/-- If every element lies in a finite subcomodule, then the union of all finite subcomodules is
+the whole carrier. -/
+theorem iUnion_finiteSubcomodules_eq_univ_of_exists_mem
+    (hM : ∀ m : M, ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N) :
+    (⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M)) =
+      Set.univ := by
+  rw [← coe_sSup_finiteSubcomodules, sSup_finiteSubcomodules_eq_top_of_exists_mem hM]
+  rfl
+
+/-- If the coefficient coalgebra is free, every finite set lies in a finite subcomodule. -/
+theorem exists_finite_subcomodule_of_setFinite [Module.Free R C]
+    {s : Set M} (hs : s.Finite) :
+    ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ s ⊆ N :=
+  exists_finite_subcomodule_of_setFinite_of_exists_mem exists_finite_subcomodule_mem hs
+
+/-- If the coefficient coalgebra is free, every finitely generated submodule lies in a finite
+subcomodule. -/
+theorem exists_finite_subcomodule_of_fg [Module.Free R C]
+    (P : Submodule R M) (hP : P.FG) :
+    ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ P ≤ N.toSubmodule :=
+  exists_finite_subcomodule_of_fg_of_exists_mem exists_finite_subcomodule_mem P hP
+
+/-- If the coefficient coalgebra is free, the finite subcomodules have supremum `⊤`. -/
+theorem sSup_finiteSubcomodules_eq_top [Module.Free R C] :
+    sSup (finiteSubcomodules (R := R) (C := C) (M := M)) = ⊤ :=
+  sSup_finiteSubcomodules_eq_top_of_exists_mem exists_finite_subcomodule_mem
+
+/-- If the coefficient coalgebra is free, the union of the finite subcomodules is the whole
+carrier. -/
+theorem iUnion_finiteSubcomodules_eq_univ [Module.Free R C] :
+    (⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M)) =
+      Set.univ :=
+  iUnion_finiteSubcomodules_eq_univ_of_exists_mem exists_finite_subcomodule_mem
+
+end General
+
+section Field
+
+variable {k : Type u} {C : Type v} {M : Type w}
+variable [Field k]
+variable [AddCommGroup C] [Module k C] [Coalgebra k C]
+variable [AddCommGroup M] [Module k M] [Comodule k C M]
+
+/-- The set of finite-dimensional subcomodules of a comodule over a field. -/
+def finiteDimensionalSubcomodules : Set (Subcomodule k C M) :=
+  {N | FiniteDimensional k N.toSubmodule}
+
+@[simp]
+theorem mem_finiteDimensionalSubcomodules {N : Subcomodule k C M} :
+    N ∈ finiteDimensionalSubcomodules (k := k) (C := C) (M := M) ↔
+      FiniteDimensional k N.toSubmodule :=
+  Iff.rfl
+
+/-- Finite-dimensional subcomodules form a nonempty family. -/
+theorem finiteDimensionalSubcomodules_nonempty :
+    (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)).Nonempty :=
+  finiteSubcomodules_nonempty
+
+/-- Finite-dimensional subcomodules form a directed family under inclusion. -/
+theorem finiteDimensionalSubcomodules_directedOn :
+    DirectedOn (· ≤ ·)
+      (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) :=
+  finiteSubcomodules_directedOn
+
+/-- The carrier of the supremum of the finite-dimensional subcomodules is their literal union. -/
+@[simp]
+theorem coe_sSup_finiteDimensionalSubcomodules :
+    ((sSup (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) :
+        Subcomodule k C M) : Set M) =
+      ⋃ N : finiteDimensionalSubcomodules (k := k) (C := C) (M := M), (N.1 : Set M) :=
+  coe_sSup_of_directed finiteDimensionalSubcomodules_nonempty
+    finiteDimensionalSubcomodules_directedOn
+
+/-- Every element of a comodule over a field lies in a finite-dimensional subcomodule. -/
+theorem exists_finiteDimensional_subcomodule_mem (m : M) :
+    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ m ∈ N :=
+  exists_finite_subcomodule_mem (R := k) (C := C) (M := M) m
+
+/-- Every finite subset of a comodule over a field lies in a finite-dimensional subcomodule. -/
+theorem exists_finiteDimensional_subcomodule_of_setFinite {s : Set M} (hs : s.Finite) :
+    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ s ⊆ N :=
+  exists_finite_subcomodule_of_setFinite (R := k) (C := C) (M := M) hs
+
+/-- Every finite-dimensional subspace of a comodule over a field lies in a finite-dimensional
+subcomodule. -/
+theorem exists_finiteDimensional_subcomodule_of_submodule (P : Submodule k M)
+    [FiniteDimensional k P] :
+    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ P ≤ N.toSubmodule :=
+  exists_finite_subcomodule_of_fg (R := k) (C := C) (M := M) P
+    (Module.Finite.iff_fg.mp inferInstance)
+
+/-- The supremum of the finite-dimensional subcomodules of a comodule over a field is `⊤`. -/
+theorem sSup_finiteDimensionalSubcomodules_eq_top :
+    sSup (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) = ⊤ :=
+  sSup_finiteSubcomodules_eq_top (R := k) (C := C) (M := M)
+
+/-- The union of the finite-dimensional subcomodules of a comodule over a field is the whole
+carrier. -/
+theorem iUnion_finiteDimensionalSubcomodules_eq_univ :
+    (⋃ N : finiteDimensionalSubcomodules (k := k) (C := C) (M := M), (N.1 : Set M)) =
+      Set.univ := by
+  rw [← coe_sSup_finiteDimensionalSubcomodules,
+    sSup_finiteDimensionalSubcomodules_eq_top]
+  rfl
+
+end Field
 
 end Subcomodule
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -226,12 +226,17 @@ theorem exists_finite_subcomodule_of_setFinite_of_exists_mem
     {s : Set M} (hs : s.Finite) :
     ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ s ⊆ N := by
   classical
-  letI : Fintype s := hs.fintype
-  choose N hNfinite hNmem using fun m : s ↦ hM m
-  refine ⟨⨆ m : s, N m, iSup_finite N hNfinite, ?_⟩
-  intro m hm
-  exact (le_sSup (s := Set.range N) (Set.mem_range_self ⟨m, hm⟩))
-    (hNmem ⟨m, hm⟩)
+  obtain ⟨N, hNfinite, hsN⟩ :=
+    DirectedOn.exists_mem_subset_of_finset_subset_biUnion
+      (f := fun N : Subcomodule R C M => (N : Set M))
+      finiteSubcomodules_nonempty directedOn_finiteSubcomodules
+      (s := hs.toFinset) (by
+        intro m _
+        obtain ⟨N, hNfinite, hmN⟩ := hM m
+        exact Set.mem_iUnion₂_of_mem
+          (mem_finiteSubcomodules.mpr hNfinite) hmN)
+  exact ⟨N, mem_finiteSubcomodules.mp hNfinite, by
+    simpa only [hs.coe_toFinset] using hsN⟩
 
 /-- If every element lies in a finite subcomodule, then every finitely generated submodule lies
 in one finite subcomodule. -/

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.LinearAlgebra.TensorProduct.Basis
 public import Mathlib.Order.SupClosed
 public import TauCeti.Algebra.Coalgebra.Subcomodule.Lattice
@@ -18,7 +17,7 @@ subcomodule. It also packages the order-theoretic consequences: finite subcomodu
 form a nonempty directed family, finite subsets and finitely generated submodules
 are contained in one finite subcomodule, and the supremum and literal union of the
 finite subcomodules are the whole comodule. Over a field these become statements
-about finite-dimensional subcomodules.
+about finite-dimensional subcomodules through the same generic API.
 
 For the elementwise result, the carrier is the span of the finitely many coefficients
 occurring when the element's coaction is expanded in a basis of the coalgebra. The
@@ -31,12 +30,10 @@ No flatness or noetherian hypothesis is needed.
 
 * `TauCeti.Subcomodule.exists_finite_subcomodule_mem`: every element belongs to a
   subcomodule whose underlying module is finite.
-* `TauCeti.Subcomodule.finiteSubcomodules_directedOn`: finite subcomodules form a
+* `TauCeti.Subcomodule.directedOn_finiteSubcomodules`: finite subcomodules form a
   directed family.
 * `TauCeti.Subcomodule.sSup_finiteSubcomodules_eq_top`: for a free coefficient coalgebra,
   the finite subcomodules have supremum `⊤`.
-* `TauCeti.Subcomodule.exists_finiteDimensional_subcomodule_mem`: over a field, every
-  element belongs to a finite-dimensional subcomodule.
 
 ## References
 
@@ -192,7 +189,7 @@ theorem finiteSubcomodules_nonempty :
   exact Module.Finite.bot R M
 
 /-- Finite subcomodules are closed under binary joins. -/
-theorem finiteSubcomodules_supClosed :
+theorem supClosed_finiteSubcomodules :
     SupClosed (finiteSubcomodules (R := R) (C := C) (M := M)) := by
   intro N hN P hP
   rw [mem_finiteSubcomodules] at hN hP ⊢
@@ -201,9 +198,9 @@ theorem finiteSubcomodules_supClosed :
   exact sup_finite N P
 
 /-- Finite subcomodules form a directed family under inclusion. -/
-theorem finiteSubcomodules_directedOn :
+theorem directedOn_finiteSubcomodules :
     DirectedOn (· ≤ ·) (finiteSubcomodules (R := R) (C := C) (M := M)) :=
-  finiteSubcomodules_supClosed.directedOn
+  supClosed_finiteSubcomodules.directedOn
 
 /-- The carrier of the supremum of all finite subcomodules is their literal union. -/
 @[simp]
@@ -211,15 +208,16 @@ theorem coe_sSup_finiteSubcomodules :
     ((sSup (finiteSubcomodules (R := R) (C := C) (M := M)) :
         Subcomodule R C M) : Set M) =
       ⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M) :=
-  coe_sSup_of_directed finiteSubcomodules_nonempty finiteSubcomodules_directedOn
+  coe_sSup_of_directed finiteSubcomodules_nonempty directedOn_finiteSubcomodules
 
 /-- Membership in the supremum of all finite subcomodules means membership in one finite
 subcomodule. -/
+@[simp]
 theorem mem_sSup_finiteSubcomodules {m : M} :
     m ∈ sSup (finiteSubcomodules (R := R) (C := C) (M := M)) ↔
       ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N := by
   simpa only [mem_finiteSubcomodules] using
-    (mem_sSup_of_directed finiteSubcomodules_nonempty finiteSubcomodules_directedOn (m := m))
+    (mem_sSup_of_directed finiteSubcomodules_nonempty directedOn_finiteSubcomodules (m := m))
 
 /-- If every element lies in a finite subcomodule, then every finite set lies in one finite
 subcomodule. -/
@@ -292,77 +290,6 @@ theorem iUnion_finiteSubcomodules_eq_univ [Module.Free R C] :
   iUnion_finiteSubcomodules_eq_univ_of_exists_mem exists_finite_subcomodule_mem
 
 end General
-
-section Field
-
-variable {k : Type u} {C : Type v} {M : Type w}
-variable [Field k]
-variable [AddCommGroup C] [Module k C] [Coalgebra k C]
-variable [AddCommGroup M] [Module k M] [Comodule k C M]
-
-/-- The set of finite-dimensional subcomodules of a comodule over a field. -/
-def finiteDimensionalSubcomodules : Set (Subcomodule k C M) :=
-  {N | FiniteDimensional k N.toSubmodule}
-
-@[simp]
-theorem mem_finiteDimensionalSubcomodules {N : Subcomodule k C M} :
-    N ∈ finiteDimensionalSubcomodules (k := k) (C := C) (M := M) ↔
-      FiniteDimensional k N.toSubmodule :=
-  Iff.rfl
-
-/-- Finite-dimensional subcomodules form a nonempty family. -/
-theorem finiteDimensionalSubcomodules_nonempty :
-    (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)).Nonempty :=
-  finiteSubcomodules_nonempty
-
-/-- Finite-dimensional subcomodules form a directed family under inclusion. -/
-theorem finiteDimensionalSubcomodules_directedOn :
-    DirectedOn (· ≤ ·)
-      (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) :=
-  finiteSubcomodules_directedOn
-
-/-- The carrier of the supremum of the finite-dimensional subcomodules is their literal union. -/
-@[simp]
-theorem coe_sSup_finiteDimensionalSubcomodules :
-    ((sSup (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) :
-        Subcomodule k C M) : Set M) =
-      ⋃ N : finiteDimensionalSubcomodules (k := k) (C := C) (M := M), (N.1 : Set M) :=
-  coe_sSup_of_directed finiteDimensionalSubcomodules_nonempty
-    finiteDimensionalSubcomodules_directedOn
-
-/-- Every element of a comodule over a field lies in a finite-dimensional subcomodule. -/
-theorem exists_finiteDimensional_subcomodule_mem (m : M) :
-    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ m ∈ N :=
-  exists_finite_subcomodule_mem (R := k) (C := C) (M := M) m
-
-/-- Every finite subset of a comodule over a field lies in a finite-dimensional subcomodule. -/
-theorem exists_finiteDimensional_subcomodule_of_setFinite {s : Set M} (hs : s.Finite) :
-    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ s ⊆ N :=
-  exists_finite_subcomodule_of_setFinite (R := k) (C := C) (M := M) hs
-
-/-- Every finite-dimensional subspace of a comodule over a field lies in a finite-dimensional
-subcomodule. -/
-theorem exists_finiteDimensional_subcomodule_of_submodule (P : Submodule k M)
-    [FiniteDimensional k P] :
-    ∃ N : Subcomodule k C M, FiniteDimensional k N.toSubmodule ∧ P ≤ N.toSubmodule :=
-  exists_finite_subcomodule_of_fg (R := k) (C := C) (M := M) P
-    (Module.Finite.iff_fg.mp inferInstance)
-
-/-- The supremum of the finite-dimensional subcomodules of a comodule over a field is `⊤`. -/
-theorem sSup_finiteDimensionalSubcomodules_eq_top :
-    sSup (finiteDimensionalSubcomodules (k := k) (C := C) (M := M)) = ⊤ :=
-  sSup_finiteSubcomodules_eq_top (R := k) (C := C) (M := M)
-
-/-- The union of the finite-dimensional subcomodules of a comodule over a field is the whole
-carrier. -/
-theorem iUnion_finiteDimensionalSubcomodules_eq_univ :
-    (⋃ N : finiteDimensionalSubcomodules (k := k) (C := C) (M := M), (N.1 : Set M)) =
-      Set.univ := by
-  rw [← coe_sSup_finiteDimensionalSubcomodules,
-    sSup_finiteDimensionalSubcomodules_eq_top]
-  rfl
-
-end Field
 
 end Subcomodule
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -212,7 +212,7 @@ theorem coe_sSup_finiteSubcomodules :
     ((sSup (finiteSubcomodules (R := R) (C := C) (M := M)) :
         Subcomodule R C M) : Set M) =
       ⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M) :=
-  coe_sSup_of_directed finiteSubcomodules_nonempty directedOn_finiteSubcomodules
+  coe_sSup_of_directedOn finiteSubcomodules_nonempty directedOn_finiteSubcomodules
 
 /-- Membership in the supremum of all finite subcomodules means membership in one finite
 subcomodule. -/
@@ -221,7 +221,7 @@ theorem mem_sSup_finiteSubcomodules {m : M} :
     m ∈ sSup (finiteSubcomodules (R := R) (C := C) (M := M)) ↔
       ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N := by
   simpa only [mem_finiteSubcomodules] using
-    (mem_sSup_of_directed finiteSubcomodules_nonempty directedOn_finiteSubcomodules (m := m))
+    (mem_sSup_of_directedOn finiteSubcomodules_nonempty directedOn_finiteSubcomodules (m := m))
 
 /-- If every element lies in a finite subcomodule, then every finite set lies in one finite
 subcomodule. -/
@@ -287,16 +287,19 @@ theorem exists_finite_subcomodule_of_fg [Module.Free R C]
   exists_finite_subcomodule_of_fg_of_exists_mem exists_finite_subcomodule_mem P hP
 
 /-- If the coefficient coalgebra is free, the finite subcomodules have supremum `⊤`. -/
+@[simp]
 theorem sSup_finiteSubcomodules_eq_top [Module.Free R C] :
     sSup (finiteSubcomodules (R := R) (C := C) (M := M)) = ⊤ :=
   sSup_finiteSubcomodules_eq_top_of_exists_mem exists_finite_subcomodule_mem
 
 /-- If the coefficient coalgebra is free, the union of the finite subcomodules is the whole
 carrier. -/
+@[simp]
 theorem iUnion_finiteSubcomodules_eq_univ [Module.Free R C] :
-    (⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M)) =
-      Set.univ :=
-  iUnion_finiteSubcomodules_eq_univ_of_exists_mem exists_finite_subcomodule_mem
+    (⋃ (N : Subcomodule R C M) (_ : Module.Finite R N.toSubmodule), (N : Set M)) =
+      Set.univ := by
+  simpa only [Set.iUnion_coe_set, mem_finiteSubcomodules] using
+    iUnion_finiteSubcomodules_eq_univ_of_exists_mem exists_finite_subcomodule_mem
 
 end General
 

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Finite.lean
@@ -37,7 +37,7 @@ No flatness or noetherian hypothesis is needed.
 
 ## References
 
-The directed-union theorem sequence from `finiteSubcomodules_nonempty` through
+The directed-union theorem sequence from `nonempty_finiteSubcomodules` through
 `iUnion_finiteSubcomodules_eq_univ_of_exists_mem` is adapted from the corresponding
 subcoalgebra development in `TauCeti.Algebra.Coalgebra.Subcoalgebra.Finite`.
 
@@ -186,7 +186,7 @@ theorem mem_finiteSubcomodules {N : Subcomodule R C M} :
   Iff.rfl
 
 /-- The zero subcomodule makes the family of finite subcomodules nonempty. -/
-theorem finiteSubcomodules_nonempty :
+theorem nonempty_finiteSubcomodules :
     (finiteSubcomodules (R := R) (C := C) (M := M)).Nonempty := by
   refine ⟨⊥, ?_⟩
   rw [mem_finiteSubcomodules]
@@ -212,7 +212,7 @@ theorem coe_sSup_finiteSubcomodules :
     ((sSup (finiteSubcomodules (R := R) (C := C) (M := M)) :
         Subcomodule R C M) : Set M) =
       ⋃ N : finiteSubcomodules (R := R) (C := C) (M := M), (N.1 : Set M) :=
-  coe_sSup_of_directedOn finiteSubcomodules_nonempty directedOn_finiteSubcomodules
+  coe_sSup_of_directedOn nonempty_finiteSubcomodules directedOn_finiteSubcomodules
 
 /-- Membership in the supremum of all finite subcomodules means membership in one finite
 subcomodule. -/
@@ -221,7 +221,7 @@ theorem mem_sSup_finiteSubcomodules {m : M} :
     m ∈ sSup (finiteSubcomodules (R := R) (C := C) (M := M)) ↔
       ∃ N : Subcomodule R C M, Module.Finite R N.toSubmodule ∧ m ∈ N := by
   simpa only [mem_finiteSubcomodules] using
-    (mem_sSup_of_directedOn finiteSubcomodules_nonempty directedOn_finiteSubcomodules (m := m))
+    (mem_sSup_of_directedOn nonempty_finiteSubcomodules directedOn_finiteSubcomodules (m := m))
 
 /-- If every element lies in a finite subcomodule, then every finite set lies in one finite
 subcomodule. -/
@@ -233,7 +233,7 @@ theorem exists_finite_subcomodule_of_setFinite_of_exists_mem
   obtain ⟨N, hNfinite, hsN⟩ :=
     DirectedOn.exists_mem_subset_of_finset_subset_biUnion
       (f := fun N : Subcomodule R C M => (N : Set M))
-      finiteSubcomodules_nonempty directedOn_finiteSubcomodules
+      nonempty_finiteSubcomodules directedOn_finiteSubcomodules
       (s := hs.toFinset) (by
         intro m _
         obtain ⟨N, hNfinite, hmN⟩ := hM m

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -198,12 +198,23 @@ instance instCompleteSemilatticeSup : CompleteSemilatticeSup (Subcomodule R C M)
 theorem coe_iSup_of_directed {iota : Type*} [Nonempty iota]
     (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) :
     ((↑(⨆ i, N i) : Set M)) = ⋃ i, (N i : Set M) := by
-  change (((⨆ i, N i).toSubmodule : Submodule R M) : Set M) =
-    ⋃ i, ((N i).toSubmodule : Set M)
-  rw [iSup_toSubmodule]
-  exact Submodule.coe_iSup_of_directed (fun i ↦ (N i).toSubmodule) fun i j ↦ by
+  have hN' : Directed (· ≤ ·) (fun i ↦ (N i).toSubmodule) := fun i j ↦ by
     obtain ⟨k, hik, hjk⟩ := hN i j
     exact ⟨k, toSubmodule_le_toSubmodule.2 hik, toSubmodule_le_toSubmodule.2 hjk⟩
+  ext m
+  constructor
+  · intro hm
+    have hm' : m ∈ (⨆ i, N i).toSubmodule := mem_toSubmodule.2 hm
+    rw [iSup_toSubmodule] at hm'
+    obtain ⟨i, hi⟩ :=
+      (Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) hN').1 hm'
+    exact Set.mem_iUnion.2 ⟨i, mem_toSubmodule.1 hi⟩
+  · intro hm
+    obtain ⟨i, hi⟩ := Set.mem_iUnion.1 hm
+    apply mem_toSubmodule.1
+    rw [iSup_toSubmodule]
+    exact (Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) hN').2
+      ⟨i, mem_toSubmodule.2 hi⟩
 
 /-- An element belongs to a directed supremum of subcomodules exactly when it belongs to one
 member of the family. -/

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -26,7 +26,7 @@ subcomodules: finite sums of finite subcomodules remain finite.
 * `Subcomodule.iSup_toSubmodule`, `Subcomodule.mem_iSup`, `Subcomodule.mem_sSup`:
   characteristic API for arbitrary joins.
 * `Subcomodule.coe_iSup_of_directed`, `Subcomodule.mem_iSup_of_directed`:
-  a directed join has carrier equal to the union of the carriers.
+  a nonempty directed join has carrier equal to the union of the carriers.
 * `Subcomodule.sup_toSubmodule`, `Subcomodule.mem_sup`: characteristic API for binary joins.
 * `Subcomodule.iSup_finite`, `Subcomodule.sup_finite`, `Subcomodule.finset_sup_finite`:
   finite generation is preserved by finite joins.
@@ -193,7 +193,7 @@ instance instCompleteSemilatticeSup : CompleteSemilatticeSup (Subcomodule R C M)
         exact toSubmodule_le_toSubmodule.2 (hN P.2)
       exact hle hm⟩
 
-/-- The carrier of a directed supremum of subcomodules is the union of their carriers. -/
+/-- The carrier of a nonempty directed supremum of subcomodules is the union of their carriers. -/
 @[simp]
 theorem coe_iSup_of_directed {iota : Type*} [Nonempty iota]
     (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) :
@@ -206,8 +206,8 @@ theorem coe_iSup_of_directed {iota : Type*} [Nonempty iota]
     Submodule.coe_iSup_of_directed _ hN']
   simp only [Set.mem_iUnion, SetLike.mem_coe, mem_toSubmodule]
 
-/-- An element belongs to a directed supremum of subcomodules exactly when it belongs to one
-member of the family. -/
+/-- An element belongs to a nonempty directed supremum of subcomodules exactly when it belongs to
+one member of the family. -/
 @[simp]
 theorem mem_iSup_of_directed {iota : Type*} [Nonempty iota]
     (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) {m : M} :
@@ -218,7 +218,7 @@ theorem mem_iSup_of_directed {iota : Type*} [Nonempty iota]
 /-- The carrier of the supremum of a nonempty directed set of subcomodules is the union of its
 carriers. -/
 @[simp]
-theorem coe_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
+theorem coe_sSup_of_directedOn {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
     (hdir : DirectedOn (· ≤ ·) S) :
     ((sSup S : Subcomodule R C M) : Set M) = ⋃ N : S, (N.1 : Set M) := by
   letI : Nonempty S := hS.to_subtype
@@ -228,7 +228,7 @@ theorem coe_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
 /-- Membership in the supremum of a nonempty directed set of subcomodules reduces to membership
 in one member of the set. -/
 @[simp]
-theorem mem_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
+theorem mem_sSup_of_directedOn {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
     (hdir : DirectedOn (· ≤ ·) S) {m : M} :
     m ∈ sSup S ↔ ∃ N ∈ S, m ∈ N := by
   letI : Nonempty S := hS.to_subtype

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -227,6 +227,7 @@ theorem coe_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
 
 /-- Membership in the supremum of a nonempty directed set of subcomodules reduces to membership
 in one member of the set. -/
+@[simp]
 theorem mem_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
     (hdir : DirectedOn (· ≤ ·) S) {m : M} :
     m ∈ sSup S ↔ ∃ N ∈ S, m ∈ N := by

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -202,29 +202,18 @@ theorem coe_iSup_of_directed {iota : Type*} [Nonempty iota]
     obtain ⟨k, hik, hjk⟩ := hN i j
     exact ⟨k, toSubmodule_le_toSubmodule.2 hik, toSubmodule_le_toSubmodule.2 hjk⟩
   ext m
-  constructor
-  · intro hm
-    have hm' : m ∈ (⨆ i, N i).toSubmodule := mem_toSubmodule.2 hm
-    rw [iSup_toSubmodule] at hm'
-    obtain ⟨i, hi⟩ :=
-      (Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) hN').1 hm'
-    exact Set.mem_iUnion.2 ⟨i, mem_toSubmodule.1 hi⟩
-  · intro hm
-    obtain ⟨i, hi⟩ := Set.mem_iUnion.1 hm
-    apply mem_toSubmodule.1
-    rw [iSup_toSubmodule]
-    exact (Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) hN').2
-      ⟨i, mem_toSubmodule.2 hi⟩
+  rw [SetLike.mem_coe, ← mem_toSubmodule, iSup_toSubmodule, ← SetLike.mem_coe,
+    Submodule.coe_iSup_of_directed _ hN']
+  simp only [Set.mem_iUnion, SetLike.mem_coe, mem_toSubmodule]
 
 /-- An element belongs to a directed supremum of subcomodules exactly when it belongs to one
 member of the family. -/
+@[simp]
 theorem mem_iSup_of_directed {iota : Type*} [Nonempty iota]
     (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) {m : M} :
     m ∈ ⨆ i, N i ↔ ∃ i, m ∈ N i := by
-  rw [← mem_toSubmodule, iSup_toSubmodule]
-  exact Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) fun i j ↦ by
-    obtain ⟨k, hik, hjk⟩ := hN i j
-    exact ⟨k, toSubmodule_le_toSubmodule.2 hik, toSubmodule_le_toSubmodule.2 hjk⟩
+  rw [← SetLike.mem_coe, coe_iSup_of_directed N hN, Set.mem_iUnion]
+  simp only [SetLike.mem_coe]
 
 /-- The carrier of the supremum of a nonempty directed set of subcomodules is the union of its
 carriers. -/

--- a/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcomodule/Lattice.lean
@@ -25,6 +25,8 @@ subcomodules: finite sums of finite subcomodules remain finite.
 * `Subcomodule.instCompleteSemilatticeSup`: arbitrary suprema of subcomodules.
 * `Subcomodule.iSup_toSubmodule`, `Subcomodule.mem_iSup`, `Subcomodule.mem_sSup`:
   characteristic API for arbitrary joins.
+* `Subcomodule.coe_iSup_of_directed`, `Subcomodule.mem_iSup_of_directed`:
+  a directed join has carrier equal to the union of the carriers.
 * `Subcomodule.sup_toSubmodule`, `Subcomodule.mem_sup`: characteristic API for binary joins.
 * `Subcomodule.iSup_finite`, `Subcomodule.sup_finite`, `Subcomodule.finset_sup_finite`:
   finite generation is preserved by finite joins.
@@ -190,6 +192,47 @@ instance instCompleteSemilatticeSup : CompleteSemilatticeSup (Subcomodule R C M)
         refine iSup_le fun P : S => ?_
         exact toSubmodule_le_toSubmodule.2 (hN P.2)
       exact hle hm⟩
+
+/-- The carrier of a directed supremum of subcomodules is the union of their carriers. -/
+@[simp]
+theorem coe_iSup_of_directed {iota : Type*} [Nonempty iota]
+    (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) :
+    ((↑(⨆ i, N i) : Set M)) = ⋃ i, (N i : Set M) := by
+  change (((⨆ i, N i).toSubmodule : Submodule R M) : Set M) =
+    ⋃ i, ((N i).toSubmodule : Set M)
+  rw [iSup_toSubmodule]
+  exact Submodule.coe_iSup_of_directed (fun i ↦ (N i).toSubmodule) fun i j ↦ by
+    obtain ⟨k, hik, hjk⟩ := hN i j
+    exact ⟨k, toSubmodule_le_toSubmodule.2 hik, toSubmodule_le_toSubmodule.2 hjk⟩
+
+/-- An element belongs to a directed supremum of subcomodules exactly when it belongs to one
+member of the family. -/
+theorem mem_iSup_of_directed {iota : Type*} [Nonempty iota]
+    (N : iota → Subcomodule R C M) (hN : Directed (· ≤ ·) N) {m : M} :
+    m ∈ ⨆ i, N i ↔ ∃ i, m ∈ N i := by
+  rw [← mem_toSubmodule, iSup_toSubmodule]
+  exact Submodule.mem_iSup_of_directed (fun i ↦ (N i).toSubmodule) fun i j ↦ by
+    obtain ⟨k, hik, hjk⟩ := hN i j
+    exact ⟨k, toSubmodule_le_toSubmodule.2 hik, toSubmodule_le_toSubmodule.2 hjk⟩
+
+/-- The carrier of the supremum of a nonempty directed set of subcomodules is the union of its
+carriers. -/
+@[simp]
+theorem coe_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
+    (hdir : DirectedOn (· ≤ ·) S) :
+    ((sSup S : Subcomodule R C M) : Set M) = ⋃ N : S, (N.1 : Set M) := by
+  letI : Nonempty S := hS.to_subtype
+  rw [sSup_eq_iSup']
+  exact coe_iSup_of_directed (fun N : S ↦ N.1) hdir.directed_val
+
+/-- Membership in the supremum of a nonempty directed set of subcomodules reduces to membership
+in one member of the set. -/
+theorem mem_sSup_of_directed {S : Set (Subcomodule R C M)} (hS : S.Nonempty)
+    (hdir : DirectedOn (· ≤ ·) S) {m : M} :
+    m ∈ sSup S ↔ ∃ N ∈ S, m ∈ N := by
+  letI : Nonempty S := hS.to_subtype
+  simp only [sSup_eq_iSup', mem_iSup_of_directed (fun N : S ↦ N.1) hdir.directed_val,
+    SetCoe.exists, exists_prop]
 
 /-- The join of finitely generated subcomodules is finitely generated as an `R`-module. -/
 theorem sup_finite (N P : Subcomodule R C M)


### PR DESCRIPTION
This PR shows that subcomodules form directed suprema and packages finite subcomodules as a directed family under an elementwise finite-subcomodule cover. It derives finite-set and finitely generated submodule containment, supremum-top and carrier-union results, then specializes them to free coefficient coalgebras and to finite-dimensional comodules over fields.

It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, “Finite-dimensional subcoalgebras (the fundamental theorem of comodules),” specifically the passage that every comodule is the union of its finite-dimensional subcomodules.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"finite-subcomodule-directed-union"}-->

🤖 Prepared with Codex
