### PR TITLE
feat: add the real projective antipodal cover

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -122,7 +122,7 @@ def mk : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → RealProjectiveSpace
     (MulAction.orbitRel ℤˣ (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
 
 /-- The quotient map evaluates to the class of its representative. -/
-theorem mk_apply (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
+private theorem mk_apply (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     mk n x = Quotient.mk'' x :=
   (rfl)
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -4,10 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.GroupWithZero.Units.Fintype
 public import Mathlib.Analysis.InnerProductSpace.PiL2
-public import Mathlib.Analysis.Normed.Module.Ball.Action
 public import Mathlib.Topology.Covering.Quotient
+public import TauCeti.Analysis.Normed.Module.Ball.IntUnitsAction
 
 /-!
 # Real projective space as an antipodal quotient
@@ -22,9 +21,8 @@ This is the quotient-cover prerequisite for the computation of `π₁(RPⁿ)` in
 `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13.  The covering argument uses
 `isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul` from Mathlib's quotient-covering
 API, due to Junyan Xu.  Finiteness of `ℤˣ` supplies proper discontinuity; the only additional
-input is that the antipodal action on the unit sphere is free.  The scalar action on spheres and
-`ne_neg_of_mem_unit_sphere` are from Mathlib's `Analysis.Normed.Module.Ball.Action`, due to Yury
-Kudryashov and Heather Macbeth.
+input is that the antipodal action on the unit sphere is free.  The integer-unit sphere action is
+provided by `TauCeti.Analysis.Normed.Module.Ball.IntUnitsAction`.
 
 ## Main declarations
 
@@ -47,66 +45,6 @@ open Topology
 open scoped EuclideanSpace
 
 noncomputable section
-
-universe u
-
-namespace Sphere
-
-variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
-
-/-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
-private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
-    (x : sphere (0 : E) r) :
-    ((c • x : sphere (0 : E) r) : E) = (c : ℝ) • (x : E) :=
-  (rfl)
-
-/-- The two integer units act on every sphere centred at zero by the identity and the antipodal
-map. -/
-instance instMulActionIntUnitsSphere {r : ℝ} : MulAction ℤˣ (sphere (0 : E) r) where
-  __ := MulAction.compHom _ ({
-    toFun u := ⟨(u : ℤ), by
-      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
-    map_one' := Subtype.ext (by simp)
-    map_mul' u v := Subtype.ext (by simp) } : ℤˣ →* sphere (0 : ℝ) 1)
-
-/-- The underlying vector of the integer-unit action is multiplication by the corresponding
-integer. -/
-@[simp]
-theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
-    ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
-  by
-    rw [MulAction.compHom_smul_def, coe_sphere_smul]
-    rfl
-
-/-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
-@[simp]
-theorem negOne_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
-  apply Subtype.ext
-  simp
-
-/-- The integer-unit action on a sphere is continuous in the sphere variable. -/
-instance instContinuousConstSMulIntUnitsSphere {r : ℝ} :
-    ContinuousConstSMul ℤˣ (sphere (0 : E) r) where
-  continuous_const_smul u := by
-    let c : sphere (0 : ℝ) 1 := ⟨(u : ℤ), by
-      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
-    have hc : Continuous fun x : sphere (0 : E) r => c • x := continuous_const_smul c
-    exact hc
-
-/-- The antipodal integer-unit action on the unit sphere is free. -/
-instance instIsCancelSMulIntUnitsUnitSphere :
-    IsCancelSMul ℤˣ (sphere (0 : E) 1) where
-  right_cancel' u v x h := by
-    obtain rfl | rfl := Int.units_eq_one_or u <;>
-      obtain rfl | rfl := Int.units_eq_one_or v
-    · rfl
-    · exfalso
-      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h)
-    · exfalso
-      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h.symm)
-    · rfl
-
-end Sphere
 
 /-- Real projective `n`-space, modelled as the orbit quotient of the unit sphere `Sⁿ` under the
 antipodal action of the two-element group `ℤˣ = {1, -1}`. -/
@@ -146,8 +84,9 @@ protected def lift {α : Sort*}
     (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → α)
     (h : ∀ x, f (-x) = f x) : RealProjectiveSpace n → α :=
   Quotient.lift f fun x y hxy => by
-    change ∃ u : ℤˣ, u • y = x at hxy
-    obtain ⟨u, rfl⟩ := hxy
+    obtain ⟨u, hu⟩ :=
+      MulAction.mem_orbit_iff.mp (MulAction.orbitRel_apply.mp hxy)
+    rw [← hu]
     obtain rfl | rfl := Int.units_eq_one_or u
     · rw [one_smul]
     · simpa using h y
@@ -179,13 +118,13 @@ or antipodal. -/
 @[simp]
 theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     mk n x = mk n y ↔ x = y ∨ x = -y := by
-  change Quotient.mk'' x = Quotient.mk'' y ↔ _
+  unfold mk RealProjectiveSpace
   rw [Quotient.eq'', MulAction.orbitRel_apply]
   constructor
   · rintro ⟨u, rfl⟩
     obtain rfl | rfl := Int.units_eq_one_or u
     · exact Or.inl (one_smul ℤˣ y)
-    · exact Or.inr (Sphere.negOne_smul y)
+    · exact Or.inr (Sphere.neg_one_smul y)
   · rintro (rfl | h)
     · exact ⟨1, by simp⟩
     · exact ⟨-1, by simpa using h.symm⟩

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -52,23 +52,20 @@ namespace Sphere
 
 variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
-/-- The two integer units, embedded as the two points of the real unit sphere. -/
-def intUnitsToRealUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
-  toFun u := ⟨(u : ℤ), by
-    obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
-  map_one' := Subtype.ext (by simp)
-  map_mul' u v := Subtype.ext (by simp)
-
-/-- The underlying real number of an integer unit regarded as a point of the real unit sphere. -/
-@[simp]
-theorem coe_intUnitsToRealUnitSphere (u : ℤˣ) :
-    (intUnitsToRealUnitSphere u : ℝ) = (u : ℤ) :=
+/-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
+private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
+    (x : sphere (0 : E) r) :
+    ((c • x : sphere (0 : E) r) : E) = (c : ℝ) • (x : E) :=
   (rfl)
 
 /-- The two integer units act on every sphere centred at zero by the identity and the antipodal
 map. -/
 instance instMulActionIntUnitsSphere {r : ℝ} : MulAction ℤˣ (sphere (0 : E) r) where
-  __ := MulAction.compHom _ intUnitsToRealUnitSphere
+  __ := MulAction.compHom _ ({
+    toFun u := ⟨(u : ℤ), by
+      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+    map_one' := Subtype.ext (by simp)
+    map_mul' u v := Subtype.ext (by simp) } : ℤˣ →* sphere (0 : ℝ) 1)
 
 /-- The underlying vector of the integer-unit action is multiplication by the corresponding
 integer. -/
@@ -76,10 +73,8 @@ integer. -/
 theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
     ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
   by
-    -- Unfold only the pulled-back sphere action; its scalar is then exposed to the public
-    -- coercion lemma above.
-    change (intUnitsToRealUnitSphere u : ℝ) • (x : E) = _
-    rw [coe_intUnitsToRealUnitSphere]
+    rw [MulAction.compHom_smul_def, coe_sphere_smul]
+    rfl
 
 /-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
 @[simp]
@@ -90,7 +85,11 @@ theorem negOne_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
 /-- The integer-unit action on a sphere is continuous in the sphere variable. -/
 instance instContinuousConstSMulIntUnitsSphere {r : ℝ} :
     ContinuousConstSMul ℤˣ (sphere (0 : E) r) where
-  continuous_const_smul u := continuous_const_smul (intUnitsToRealUnitSphere u)
+  continuous_const_smul u := by
+    let c : sphere (0 : ℝ) 1 := ⟨(u : ℤ), by
+      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+    have hc : Continuous fun x : sphere (0 : E) r => c • x := continuous_const_smul c
+    exact hc
 
 /-- The antipodal integer-unit action on the unit sphere is free. -/
 instance instIsCancelSMulIntUnitsUnitSphere :
@@ -149,7 +148,7 @@ theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
 /-- Antipodal unit vectors have the same image in real projective space. -/
 @[simp]
 theorem mk_neg (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
-    Quotient.mk'' (-x) = mk n x :=
+    mk n (-x) = mk n x :=
   (mk_eq_mk_iff n (-x) x).2 (Or.inr rfl)
 
 /-- The unit sphere modulo the antipodal action is a quotient covering map.  Its fibres are the

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -1,0 +1,186 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.Units.Fintype
+public import Mathlib.Analysis.InnerProductSpace.PiL2
+public import Mathlib.Analysis.Normed.Module.Ball.Action
+public import Mathlib.Topology.Covering.Quotient
+
+/-!
+# Real projective space as an antipodal quotient
+
+Real projective `n`-space is modelled as the quotient of the unit sphere in
+`EuclideanSpace ℝ (Fin (n + 1))` by the antipodal action.  The acting group is `ℤˣ`, whose two
+elements `1` and `-1` act respectively as the identity and negation.  This file defines the
+quotient, characterizes equality of its representatives, and proves that the quotient map from
+the sphere is a two-sheeted quotient covering map.
+
+This is the quotient-cover prerequisite for the computation of `π₁(RPⁿ)` in
+`TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13.  The covering argument uses
+`isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul` from Mathlib's quotient-covering
+API, due to Junyan Xu.  Finiteness of `ℤˣ` supplies proper discontinuity; the only additional
+input is that the antipodal action on the unit sphere is free.  The scalar action on spheres and
+`ne_neg_of_mem_unit_sphere` are from Mathlib's `Analysis.Normed.Module.Ball.Action`, due to Yury
+Kudryashov and Heather Macbeth.
+
+## Main declarations
+
+* `TauCeti.RealProjectiveSpace`: real projective `n`-space as an antipodal quotient of `Sⁿ`.
+* `TauCeti.RealProjectiveSpace.mk_eq_mk_iff`: two unit vectors define the same projective point
+  exactly when they are equal or antipodal.
+* `TauCeti.RealProjectiveSpace.isQuotientCoveringMap_mk`: the unit-sphere quotient is a quotient
+  covering map with group `ℤˣ`.
+* `TauCeti.RealProjectiveSpace.isCoveringMap_mk`: the underlying covering-map statement.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric
+open Topology
+open scoped EuclideanSpace
+
+noncomputable section
+
+universe u
+
+namespace Sphere
+
+variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The two integer units, embedded as the two points of the real unit sphere. -/
+def intUnitsToRealUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
+  toFun u := ⟨(u : ℤ), by
+    obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+  map_one' := Subtype.ext (by simp)
+  map_mul' u v := Subtype.ext (by simp)
+
+/-- The underlying real number of an integer unit regarded as a point of the real unit sphere. -/
+@[simp]
+theorem coe_intUnitsToRealUnitSphere (u : ℤˣ) :
+    (intUnitsToRealUnitSphere u : ℝ) = (u : ℤ) :=
+  (rfl)
+
+/-- The two integer units act on every sphere centred at zero by the identity and the antipodal
+map. -/
+instance instMulActionIntUnitsSphere {r : ℝ} : MulAction ℤˣ (sphere (0 : E) r) where
+  __ := MulAction.compHom _ intUnitsToRealUnitSphere
+
+/-- The underlying vector of the integer-unit action is multiplication by the corresponding
+integer. -/
+@[simp]
+theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
+    ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
+  (rfl)
+
+/-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
+@[simp]
+theorem negOne_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
+  apply Subtype.ext
+  simp
+
+/-- The integer-unit action on a sphere is continuous in the sphere variable. -/
+instance instContinuousConstSMulIntUnitsSphere {r : ℝ} :
+    ContinuousConstSMul ℤˣ (sphere (0 : E) r) where
+  continuous_const_smul u := continuous_const_smul (intUnitsToRealUnitSphere u)
+
+/-- The antipodal integer-unit action on the unit sphere is free. -/
+instance instIsCancelSMulIntUnitsUnitSphere :
+    IsCancelSMul ℤˣ (sphere (0 : E) 1) where
+  right_cancel' u v x h := by
+    obtain rfl | rfl := Int.units_eq_one_or u <;>
+      obtain rfl | rfl := Int.units_eq_one_or v
+    · rfl
+    · exfalso
+      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h)
+    · exfalso
+      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h.symm)
+    · rfl
+
+/-- An integer unit fixes a point of the unit sphere exactly when it is the identity. -/
+theorem smul_eq_self_iff (u : ℤˣ) (x : sphere (0 : E) 1) : u • x = x ↔ u = 1 := by
+  constructor
+  · exact isCancelSMul_iff_eq_one_of_smul_eq.mp inferInstance u x
+  · rintro rfl
+    exact one_smul ℤˣ x
+
+end Sphere
+
+/-- Real projective `n`-space, modelled as the orbit quotient of the unit sphere `Sⁿ` under the
+antipodal action of the two-element group `ℤˣ = {1, -1}`. -/
+abbrev RealProjectiveSpace (n : ℕ) :=
+  Quotient (MulAction.orbitRel ℤˣ
+    (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
+
+namespace RealProjectiveSpace
+
+variable (n : ℕ)
+
+/-- The quotient map from the unit sphere to real projective space. -/
+def mk : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → RealProjectiveSpace n :=
+  Quotient.mk
+    (MulAction.orbitRel ℤˣ (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
+
+/-- The quotient map evaluates to the class of its representative. -/
+@[simp]
+theorem mk_apply (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
+    mk n x = Quotient.mk'' x :=
+  (rfl)
+
+/-- Every point of real projective space has a unit-vector representative. -/
+theorem mk_surjective : Function.Surjective (mk n) :=
+  Quotient.mk_surjective
+
+/-- Two unit vectors define the same point of real projective space exactly when they are equal
+or antipodal. -/
+theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
+    mk n x = mk n y ↔ x = y ∨ x = -y := by
+  rw [mk_apply, mk_apply, Quotient.eq'', MulAction.orbitRel_apply]
+  constructor
+  · rintro ⟨u, rfl⟩
+    obtain rfl | rfl := Int.units_eq_one_or u
+    · exact Or.inl (one_smul ℤˣ y)
+    · exact Or.inr (Sphere.negOne_smul y)
+  · rintro (rfl | h)
+    · exact ⟨1, by simp⟩
+    · exact ⟨-1, by simpa using h.symm⟩
+
+/-- Antipodal unit vectors have the same image in real projective space. -/
+@[simp]
+theorem mk_neg (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
+    mk n (-x) = mk n x :=
+  (mk_eq_mk_iff n (-x) x).2 (Or.inr rfl)
+
+/-- The unit sphere modulo the antipodal action is a quotient covering map.  Its fibres are the
+two-element orbits `{x, -x}`. -/
+theorem isQuotientCoveringMap_mk : IsQuotientCoveringMap (mk n) ℤˣ := by
+  simpa only [mk, RealProjectiveSpace] using
+    (isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul
+      (G := ℤˣ) (E := sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
+
+/-- The unit-sphere projection onto real projective space is a quotient map. -/
+theorem isQuotientMap_mk : IsQuotientMap (mk n) :=
+  (isQuotientCoveringMap_mk n).toIsQuotientMap
+
+/-- The unit-sphere projection onto real projective space is continuous. -/
+theorem continuous_mk : Continuous (mk n) :=
+  (isQuotientMap_mk n).continuous
+
+/-- The unit-sphere projection onto real projective space is a covering map. -/
+theorem isCoveringMap_mk : IsCoveringMap (mk n) :=
+  (isQuotientCoveringMap_mk n).isCoveringMap
+
+/-- The projection from the unit sphere onto real projective space is open. -/
+theorem isOpenMap_mk : IsOpenMap (mk n) :=
+  (isCoveringMap_mk n).isOpenMap
+
+end RealProjectiveSpace
+
+end
+
+
+end TauCeti

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -29,8 +29,8 @@ Kudryashov and Heather Macbeth.
 ## Main declarations
 
 * `TauCeti.RealProjectiveSpace`: real projective `n`-space as an antipodal quotient of `Sⁿ`.
-* `TauCeti.RealProjectiveSpace.inductionOn` and `TauCeti.RealProjectiveSpace.lift`: elimination
-  principles for the antipodal quotient.
+* `TauCeti.RealProjectiveSpace.inductionOn`, `TauCeti.RealProjectiveSpace.lift`, and
+  `TauCeti.RealProjectiveSpace.lift_unique`: elimination principles for the antipodal quotient.
 * `TauCeti.RealProjectiveSpace.mk_eq_mk_iff`: two unit vectors define the same projective point
   exactly when they are equal or antipodal.
 * `TauCeti.RealProjectiveSpace.isQuotientCoveringMap_mk`: the unit-sphere quotient is a quotient
@@ -161,6 +161,18 @@ protected theorem lift_mk {α : Sort*}
     (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     RealProjectiveSpace.lift n f h (mk n x) = f x :=
   (rfl)
+
+/-- A function out of real projective space agreeing with an antipodal-invariant function on
+representatives is its lift. -/
+protected theorem lift_unique {α : Sort*}
+    (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → α)
+    (h : ∀ x, f (-x) = f x)
+    (g : RealProjectiveSpace n → α)
+    (hg : ∀ x, g (mk n x) = f x) :
+    g = RealProjectiveSpace.lift n f h := by
+  funext x
+  exact RealProjectiveSpace.inductionOn n x fun y =>
+    (hg y).trans (RealProjectiveSpace.lift_mk n f h y).symm
 
 /-- Two unit vectors define the same point of real projective space exactly when they are equal
 or antipodal. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -152,7 +152,7 @@ theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
 /-- Antipodal unit vectors have the same image in real projective space. -/
 @[simp]
 theorem mk_neg (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
-    mk n (-x) = mk n x :=
+    Quotient.mk'' (-x) = mk n x :=
   (mk_eq_mk_iff n (-x) x).2 (Or.inr rfl)
 
 /-- The unit sphere modulo the antipodal action is a quotient covering map.  Its fibres are the

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -29,6 +29,8 @@ Kudryashov and Heather Macbeth.
 ## Main declarations
 
 * `TauCeti.RealProjectiveSpace`: real projective `n`-space as an antipodal quotient of `Sⁿ`.
+* `TauCeti.RealProjectiveSpace.inductionOn` and `TauCeti.RealProjectiveSpace.lift`: elimination
+  principles for the antipodal quotient.
 * `TauCeti.RealProjectiveSpace.mk_eq_mk_iff`: two unit vectors define the same projective point
   exactly when they are equal or antipodal.
 * `TauCeti.RealProjectiveSpace.isQuotientCoveringMap_mk`: the unit-sphere quotient is a quotient
@@ -108,7 +110,7 @@ end Sphere
 
 /-- Real projective `n`-space, modelled as the orbit quotient of the unit sphere `Sⁿ` under the
 antipodal action of the two-element group `ℤˣ = {1, -1}`. -/
-abbrev RealProjectiveSpace (n : ℕ) :=
+def RealProjectiveSpace (n : ℕ) :=
   Quotient (MulAction.orbitRel ℤˣ
     (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
 
@@ -116,26 +118,57 @@ namespace RealProjectiveSpace
 
 variable (n : ℕ)
 
+/-- The quotient topology on real projective space. -/
+instance instTopologicalSpace : TopologicalSpace (RealProjectiveSpace n) :=
+  inferInstanceAs (TopologicalSpace (Quotient (MulAction.orbitRel ℤˣ
+    (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))))
+
 /-- The quotient map from the unit sphere to real projective space. -/
 def mk : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → RealProjectiveSpace n :=
   Quotient.mk
     (MulAction.orbitRel ℤˣ (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
 
-/-- The quotient map evaluates to the class of its representative. -/
-private theorem mk_apply (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
-    mk n x = Quotient.mk'' x :=
-  (rfl)
-
 /-- Every point of real projective space has a unit-vector representative. -/
 theorem mk_surjective : Function.Surjective (mk n) :=
   Quotient.mk_surjective
+
+/-- To prove a property of every point of real projective space, it suffices to prove it on the
+image of every unit vector. -/
+@[elab_as_elim]
+protected theorem inductionOn {motive : RealProjectiveSpace n → Prop}
+    (x : RealProjectiveSpace n)
+    (h : ∀ y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1, motive (mk n y)) :
+    motive x :=
+  Quotient.inductionOn' x h
+
+/-- An antipodal-invariant function on the unit sphere descends to real projective space. -/
+protected def lift {α : Sort*}
+    (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → α)
+    (h : ∀ x, f (-x) = f x) : RealProjectiveSpace n → α :=
+  Quotient.lift f fun x y hxy => by
+    change ∃ u : ℤˣ, u • y = x at hxy
+    obtain ⟨u, rfl⟩ := hxy
+    obtain rfl | rfl := Int.units_eq_one_or u
+    · rw [one_smul]
+    · simpa using h y
+
+/-- Lifting an antipodal-invariant function and applying it to a representative recovers the
+original function. -/
+@[simp]
+protected theorem lift_mk {α : Sort*}
+    (f : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → α)
+    (h : ∀ x, f (-x) = f x)
+    (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
+    RealProjectiveSpace.lift n f h (mk n x) = f x :=
+  (rfl)
 
 /-- Two unit vectors define the same point of real projective space exactly when they are equal
 or antipodal. -/
 @[simp]
 theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     mk n x = mk n y ↔ x = y ∨ x = -y := by
-  rw [mk_apply, mk_apply, Quotient.eq'', MulAction.orbitRel_apply]
+  change Quotient.mk'' x = Quotient.mk'' y ↔ _
+  rw [Quotient.eq'', MulAction.orbitRel_apply]
   constructor
   · rintro ⟨u, rfl⟩
     obtain rfl | rfl := Int.units_eq_one_or u
@@ -154,9 +187,10 @@ theorem mk_neg (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
 /-- The unit sphere modulo the antipodal action is a quotient covering map.  Its fibres are the
 two-element orbits `{x, -x}`. -/
 theorem isQuotientCoveringMap_mk : IsQuotientCoveringMap (mk n) ℤˣ := by
-  simpa only [mk, RealProjectiveSpace] using
+  convert
     (isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul
-      (G := ℤˣ) (E := sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
+      (G := ℤˣ) (E := sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1)) using 1 <;>
+    rfl
 
 /-- The unit-sphere projection onto real projective space is a quotient map. -/
 theorem isQuotientMap_mk : IsQuotientMap (mk n) :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean
@@ -75,7 +75,11 @@ integer. -/
 @[simp]
 theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
     ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
-  (rfl)
+  by
+    -- Unfold only the pulled-back sphere action; its scalar is then exposed to the public
+    -- coercion lemma above.
+    change (intUnitsToRealUnitSphere u : ℝ) • (x : E) = _
+    rw [coe_intUnitsToRealUnitSphere]
 
 /-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
 @[simp]
@@ -101,13 +105,6 @@ instance instIsCancelSMulIntUnitsUnitSphere :
       exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h.symm)
     · rfl
 
-/-- An integer unit fixes a point of the unit sphere exactly when it is the identity. -/
-theorem smul_eq_self_iff (u : ℤˣ) (x : sphere (0 : E) 1) : u • x = x ↔ u = 1 := by
-  constructor
-  · exact isCancelSMul_iff_eq_one_of_smul_eq.mp inferInstance u x
-  · rintro rfl
-    exact one_smul ℤˣ x
-
 end Sphere
 
 /-- Real projective `n`-space, modelled as the orbit quotient of the unit sphere `Sⁿ` under the
@@ -126,7 +123,6 @@ def mk : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1 → RealProjectiveSpace
     (MulAction.orbitRel ℤˣ (sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1))
 
 /-- The quotient map evaluates to the class of its representative. -/
-@[simp]
 theorem mk_apply (x : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     mk n x = Quotient.mk'' x :=
   (rfl)
@@ -137,6 +133,7 @@ theorem mk_surjective : Function.Surjective (mk n) :=
 
 /-- Two unit vectors define the same point of real projective space exactly when they are equal
 or antipodal. -/
+@[simp]
 theorem mk_eq_mk_iff (x y : sphere (0 : EuclideanSpace ℝ (Fin (n + 1))) 1) :
     mk n x = mk n y ↔ x = y ∨ x = -y := by
   rw [mk_apply, mk_apply, Quotient.eq'', MulAction.orbitRel_apply]

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -12,16 +12,17 @@ public import Mathlib.Analysis.Normed.Module.Ball.Action
 
 The two units of the integers act on every sphere in a real normed space by the identity and the
 antipodal map.  This file restricts Mathlib's scalar action on spheres to that action, proves its
-basic coercion rules and continuity, and shows that the action on the unit sphere is free.
+basic coercion rules and continuity, and shows that the action on every nonzero-radius sphere is
+free.
 
-The scalar action on spheres and `ne_neg_of_mem_unit_sphere` are from Mathlib's
+The scalar action on spheres and `ne_neg_of_mem_sphere` are from Mathlib's
 `Analysis.Normed.Module.Ball.Action`, due to Yury Kudryashov and Heather Macbeth.
 
 ## Main declarations
 
 * `TauCeti.Sphere.instMulActionIntUnitsSphere`: the action of `ℤˣ` on a real sphere.
 * `TauCeti.Sphere.instContinuousConstSMulIntUnitsSphere`: continuity of the action.
-* `TauCeti.Sphere.instIsCancelSMulIntUnitsUnitSphere`: freeness on the unit sphere.
+* `TauCeti.Sphere.instIsCancelSMulIntUnitsSphere`: freeness on every nonzero-radius sphere.
 -/
 
 public section
@@ -37,6 +38,13 @@ universe u
 namespace Sphere
 
 variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The homomorphism that regards an integer unit as a real scalar of norm one. -/
+private def intUnitsToUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
+  toFun u := ⟨(u : ℤ), by
+    obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+  map_one' := Subtype.ext (by simp)
+  map_mul' u v := Subtype.ext (by simp)
 
 /-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
 private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
@@ -62,6 +70,13 @@ theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
     rw [MulAction.compHom_smul_def, coe_sphere_smul]
     rfl
 
+/-- The restricted integer-unit action agrees with Mathlib's sphere-scalar action. -/
+private theorem intUnits_smul_eq_sphere_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
+    u • x = intUnitsToUnitSphere u • x := by
+  apply Subtype.ext
+  rw [coe_intUnits_smul, coe_sphere_smul]
+  rfl
+
 /-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
 @[simp]
 theorem neg_one_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
@@ -72,22 +87,21 @@ theorem neg_one_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
 instance instContinuousConstSMulIntUnitsSphere {r : ℝ} :
     ContinuousConstSMul ℤˣ (sphere (0 : E) r) where
   continuous_const_smul u := by
-    let c : sphere (0 : ℝ) 1 := ⟨(u : ℤ), by
-      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
-    have hc : Continuous fun x : sphere (0 : E) r => c • x := continuous_const_smul c
-    exact hc
+    simpa only [intUnits_smul_eq_sphere_smul] using
+      (continuous_const_smul (intUnitsToUnitSphere u) :
+        Continuous fun x : sphere (0 : E) r => intUnitsToUnitSphere u • x)
 
-/-- The antipodal integer-unit action on the unit sphere is free. -/
-instance instIsCancelSMulIntUnitsUnitSphere :
-    IsCancelSMul ℤˣ (sphere (0 : E) 1) where
+/-- The antipodal integer-unit action on every nonzero-radius sphere is free. -/
+instance instIsCancelSMulIntUnitsSphere {r : ℝ} [NeZero r] :
+    IsCancelSMul ℤˣ (sphere (0 : E) r) where
   right_cancel' u v x h := by
     obtain rfl | rfl := Int.units_eq_one_or u <;>
       obtain rfl | rfl := Int.units_eq_one_or v
     · rfl
     · exfalso
-      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h)
+      exact (ne_neg_of_mem_sphere ℝ (NeZero.ne r) x) (by simpa using h)
     · exfalso
-      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h.symm)
+      exact (ne_neg_of_mem_sphere ℝ (NeZero.ne r) x) (by simpa using h.symm)
     · rfl
 
 end Sphere

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.GroupWithZero.Units.Fintype
+public import Mathlib.Analysis.Normed.Module.Ball.Action
+
+/-!
+# The integer-unit action on real spheres
+
+The two units of the integers act on every sphere in a real normed space by the identity and the
+antipodal map.  This file restricts Mathlib's scalar action on spheres to that action, proves its
+basic coercion rules and continuity, and shows that the action on the unit sphere is free.
+
+The scalar action on spheres and `ne_neg_of_mem_unit_sphere` are from Mathlib's
+`Analysis.Normed.Module.Ball.Action`, due to Yury Kudryashov and Heather Macbeth.
+
+## Main declarations
+
+* `TauCeti.Sphere.instMulActionIntUnitsSphere`: the action of `ℤˣ` on a real sphere.
+* `TauCeti.Sphere.instContinuousConstSMulIntUnitsSphere`: continuity of the action.
+* `TauCeti.Sphere.instIsCancelSMulIntUnitsUnitSphere`: freeness on the unit sphere.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric
+
+noncomputable section
+
+universe u
+
+namespace Sphere
+
+variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+
+/-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
+private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
+    (x : sphere (0 : E) r) :
+    ((c • x : sphere (0 : E) r) : E) = (c : ℝ) • (x : E) :=
+  (rfl)
+
+/-- The two integer units act on every sphere centred at zero by the identity and the antipodal
+map. -/
+instance instMulActionIntUnitsSphere {r : ℝ} : MulAction ℤˣ (sphere (0 : E) r) where
+  __ := MulAction.compHom _ ({
+    toFun u := ⟨(u : ℤ), by
+      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+    map_one' := Subtype.ext (by simp)
+    map_mul' u v := Subtype.ext (by simp) } : ℤˣ →* sphere (0 : ℝ) 1)
+
+/-- The underlying vector of the integer-unit action is multiplication by the corresponding
+integer. -/
+@[simp]
+theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
+    ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
+  by
+    rw [MulAction.compHom_smul_def, coe_sphere_smul]
+    rfl
+
+/-- The nontrivial integer unit acts on a sphere as the antipodal map. -/
+@[simp]
+theorem neg_one_smul (x : sphere (0 : E) r) : (-1 : ℤˣ) • x = -x := by
+  apply Subtype.ext
+  simp
+
+/-- The integer-unit action on a sphere is continuous in the sphere variable. -/
+instance instContinuousConstSMulIntUnitsSphere {r : ℝ} :
+    ContinuousConstSMul ℤˣ (sphere (0 : E) r) where
+  continuous_const_smul u := by
+    let c : sphere (0 : ℝ) 1 := ⟨(u : ℤ), by
+      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
+    have hc : Continuous fun x : sphere (0 : E) r => c • x := continuous_const_smul c
+    exact hc
+
+/-- The antipodal integer-unit action on the unit sphere is free. -/
+instance instIsCancelSMulIntUnitsUnitSphere :
+    IsCancelSMul ℤˣ (sphere (0 : E) 1) where
+  right_cancel' u v x h := by
+    obtain rfl | rfl := Int.units_eq_one_or u <;>
+      obtain rfl | rfl := Int.units_eq_one_or v
+    · rfl
+    · exfalso
+      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h)
+    · exfalso
+      exact (ne_neg_of_mem_unit_sphere ℝ x) (by simpa using h.symm)
+    · rfl
+
+end Sphere
+
+end
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -10,10 +10,10 @@ public import Mathlib.Analysis.Normed.Module.Ball.Action
 /-!
 # The integer-unit action on real spheres
 
-The two units of the integers act on every sphere in a real normed space by the identity and the
-antipodal map.  This file restricts Mathlib's scalar action on spheres to that action, proves its
-basic coercion rules and continuity, and shows that the action on every nonzero-radius sphere is
-free.
+The two units of the integers act on every sphere in a real seminormed space by the identity and
+the antipodal map.  This file restricts Mathlib's scalar action on spheres to that action, proves
+its basic coercion rules and continuity, and shows that the action on every nonzero-radius sphere
+is free.
 
 The scalar action on spheres and `ne_neg_of_mem_sphere` are from Mathlib's
 `Analysis.Normed.Module.Ball.Action`, due to Yury Kudryashov and Heather Macbeth.
@@ -37,7 +37,7 @@ universe u
 
 namespace Sphere
 
-variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type u} [SeminormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- The homomorphism that regards an integer unit as a real scalar of norm one. -/
 def intUnitsToUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
@@ -45,6 +45,13 @@ def intUnitsToUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
     obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
   map_one' := Subtype.ext (by simp)
   map_mul' u v := Subtype.ext (by simp)
+
+/-- An integer unit, regarded as a unit-norm real scalar, has the expected underlying value. -/
+@[simp]
+theorem coe_intUnitsToUnitSphere (u : ℤˣ) :
+    ((intUnitsToUnitSphere u : sphere (0 : ℝ) 1) : ℝ) = ((u : ℤ) : ℝ) :=
+  by
+    obtain rfl | rfl := Int.units_eq_one_or u <;> simp [intUnitsToUnitSphere]
 
 /-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
 private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
@@ -63,8 +70,7 @@ integer. -/
 theorem coe_intUnits_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :
     ((u • x : sphere (0 : E) r) : E) = ((u : ℤ) : ℝ) • (x : E) :=
   by
-    rw [MulAction.compHom_smul_def, coe_sphere_smul]
-    rfl
+    rw [MulAction.compHom_smul_def, coe_sphere_smul, coe_intUnitsToUnitSphere]
 
 /-- The restricted integer-unit action agrees with Mathlib's sphere-scalar action. -/
 private theorem intUnits_smul_eq_sphere_smul {r : ℝ} (u : ℤˣ) (x : sphere (0 : E) r) :

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -40,7 +40,7 @@ namespace Sphere
 variable {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 /-- The homomorphism that regards an integer unit as a real scalar of norm one. -/
-private def intUnitsToUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
+def intUnitsToUnitSphere : ℤˣ →* sphere (0 : ℝ) 1 where
   toFun u := ⟨(u : ℤ), by
     obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
   map_one' := Subtype.ext (by simp)
@@ -55,11 +55,7 @@ private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
 /-- The two integer units act on every sphere centred at zero by the identity and the antipodal
 map. -/
 instance instMulActionIntUnitsSphere {r : ℝ} : MulAction ℤˣ (sphere (0 : E) r) where
-  __ := MulAction.compHom _ ({
-    toFun u := ⟨(u : ℤ), by
-      obtain rfl | rfl := Int.units_eq_one_or u <;> simp⟩
-    map_one' := Subtype.ext (by simp)
-    map_mul' u v := Subtype.ext (by simp) } : ℤˣ →* sphere (0 : ℝ) 1)
+  __ := MulAction.compHom _ intUnitsToUnitSphere
 
 /-- The underlying vector of the integer-unit action is multiplication by the corresponding
 integer. -/


### PR DESCRIPTION
This PR models real projective `n`-space as the orbit quotient of the unit sphere in `EuclideanSpace ℝ (Fin (n + 1))` by the antipodal action of `ℤˣ = {1, -1}`. Restrict Mathlib's existing unit-sphere scalar action along the canonical homomorphism `ℤˣ →* sphere (0 : ℝ) 1`, prove that this action is free, characterize equality of representatives as `x = y ∨ x = -y`, and package the projection as both an `IsQuotientCoveringMap` and an `IsCoveringMap`.

This advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 4, item 13, specifically the application target `π₁(RPⁿ)`. It supplies the first missing construction prerequisite: an explicit sphere-to-real-projective-space cover to which the landed covering-space and fundamental-group APIs can be applied. The rest of the roadmap's covering foundations and higher-homotopy machinery are already on `main`; open PR #1594 concerns the distinct Stage 1 identification of universal-cover deck transformations.

Add `TauCeti/AlgebraicTopology/UniversalCover/RealProjective/Basic.lean` (186 lines). No Mathlib infrastructure is vendored. Reuse Mathlib's sphere scalar action and `ne_neg_of_mem_unit_sphere` from `Mathlib.Analysis.Normed.Module.Ball.Action`, due to Yury Kudryashov and Heather Macbeth, and `isQuotientCoveringMap_quotientMk_of_properlyDiscontinuousSMul` from `Mathlib.Topology.Covering.Quotient`, due to Junyan Xu. Mathlib's algebraic `Projectivization` has no topology or antipodal quotient, and searches of the pinned source found no existing real-projective-space covering construction.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` (and the existing one-file cache warning). `lake build` reports `Build completed successfully (6133 jobs).` `lake exe axioms` reports `axioms: audited 18607 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"real-projective-space-antipodal-cover"}-->

🤖 Prepared with Codex
