### PR TITLE
feat: Hopf ideals cut out closed subgroup schemes

### DIFF
--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/Kernel.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/Kernel.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Morphisms.ClosedImmersion
+public import Mathlib.RingTheory.HopfAlgebra.Quotient
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.Basic
+
+/-!
+# Hopf ideals give closed immersions of affine group schemes
+
+A Hopf ideal `I` of a commutative Hopf algebra `A` over `S` induces a morphism of
+affine group schemes `Spec (A ⧸ I) ⟶ Spec A` over `Spec S`, and the underlying
+morphism of schemes is a closed immersion: the scheme-side closed subgroup scheme cut
+out by a Hopf ideal (reductive-groups roadmap, Layer 3). Group-theoretic kernel
+properties of this inclusion are follow-up work; this file provides the morphism and
+its closed-immersion property.
+-/
+
+public section
+
+namespace TauCeti
+
+open CategoryTheory AlgebraicGeometry HopfAlgebra Opposite
+
+universe u
+
+variable (S : CommRingCat.{u}) (A : Type u) [CommRing A] [HopfAlgebra S A]
+  (I : Ideal A) [I.IsTwoSided] [I.IsHopfIdeal S]
+
+/-- The morphism of affine group schemes over `Spec S` induced by a Hopf ideal
+`I ⊆ A`: the `Spec` of the quotient map `A →ₐc[S] A ⧸ I`. -/
+noncomputable def hopfIdealSpecMap :
+    (hopfSpec S).obj (op (CommHopfAlgCat.of S (A ⧸ I))) ⟶
+      (hopfSpec S).obj (op (CommHopfAlgCat.of S A)) :=
+  (hopfSpec S).map (CommHopfAlgCat.ofHom (Bialgebra.Quotient.mkBialgHom I)).op
+
+/-- The underlying scheme morphism of `hopfIdealSpecMap` is `Spec` of the quotient map. -/
+theorem hopfIdealSpecMap_hom_hom_left :
+    (hopfIdealSpecMap S A I).hom.hom.left =
+      Spec.map (CommRingCat.ofHom (Ideal.Quotient.mk I)) := by
+  rfl
+
+/-- The underlying scheme morphism of `hopfIdealSpecMap` is a closed immersion:
+a Hopf ideal cuts out a closed subgroup scheme. -/
+theorem isClosedImmersion_hopfIdealSpecMap :
+    IsClosedImmersion (hopfIdealSpecMap S A I).hom.hom.left := by
+  rw [hopfIdealSpecMap_hom_hom_left]
+  exact IsClosedImmersion.spec_of_surjective _ Ideal.Quotient.mk_surjective
+
+end TauCeti


### PR DESCRIPTION
A Hopf ideal `I` of a commutative Hopf algebra `A` over `S` cuts out a closed subgroup scheme: this PR provides the induced morphism `Spec (A ⧸ I) ⟶ Spec A` of affine group schemes over `Spec S` (`hopfIdealSpecMap`, via `hopfSpec` applied to `Bialgebra.Quotient.mkBialgHom`, with the quotient's Hopf structure from Mathlib's `RingTheory/HopfAlgebra/Quotient`), the identification of its underlying scheme morphism as `Spec` of the quotient map, and the theorem that this underlying morphism is a closed immersion (`IsClosedImmersion.spec_of_surjective`).

This opens the scheme side of the reductive-groups roadmap's Layer 3 ("Hopf ideals ↔ closed subgroup schemes"), building on the Layer 0 dictionary merged in #1626. Group-theoretic kernel properties of the inclusion (normality, the kernel of the corresponding quotient of group schemes) are follow-up work.

Validation:

- `lake build` (full library, green)
- `bash scripts/lint-env.sh` — PASS, no new violations

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-closed-immersion"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
