### PR TITLE
feat: add Kostka numbers and their dominance triangularity

### DIFF
--- a/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
@@ -170,6 +170,7 @@ theorem rowLens_diagramOf {n : ℕ} (μ : n.Partition) :
 
 /-- The row lengths of the Young diagram of a partition are its decreasingly sorted parts, padded
 by zeros. -/
+@[simp]
 theorem rowLen_diagramOf {n : ℕ} (ν : n.Partition) (i : ℕ) :
     (diagramOf ν).rowLen i = (ν.parts.sort (· ≥ ·)).getD i 0 := by
   rw [← YoungDiagram.getD_rowLens, rowLens_diagramOf]

--- a/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
@@ -168,6 +168,12 @@ theorem rowLens_diagramOf {n : ℕ} (μ : n.Partition) :
     (diagramOf μ).rowLens = μ.parts.sort (· ≥ ·) :=
   partitionEquivYoungDiagram_apply_rowLens n μ
 
+/-- The row lengths of the Young diagram of a partition are its decreasingly sorted parts, padded
+by zeros. -/
+theorem rowLen_diagramOf {n : ℕ} (ν : n.Partition) (i : ℕ) :
+    (diagramOf ν).rowLen i = (ν.parts.sort (· ≥ ·)).getD i 0 := by
+  rw [← YoungDiagram.getD_rowLens, rowLens_diagramOf]
+
 /-- The conjugate of a partition is obtained by transposing its Young diagram. -/
 noncomputable def conjugate {n : ℕ} (μ : n.Partition) : n.Partition :=
   (partitionEquivYoungDiagram n).symm

--- a/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
+++ b/TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean
@@ -29,32 +29,6 @@ namespace TauCeti
 
 open scoped BigOperators
 
-private theorem sum_take_rowLens_eq_card_filter_fst (μ : YoungDiagram) (k : ℕ) :
-    (μ.rowLens.take k).sum = (μ.cells.filter fun c => c.1 < k).card := by
-  rw [YoungDiagram.rowLens, ← List.map_take, List.take_range,
-    ← List.sum_toFinset _ List.nodup_range, List.toFinset_range]
-  symm
-  calc
-    (μ.cells.filter fun c => c.1 < k).card =
-        ∑ i ∈ Finset.range (min k (μ.colLen 0)),
-          ((μ.cells.filter fun c => c.1 < k).filter fun c => c.1 = i).card := by
-      apply Finset.card_eq_sum_card_fiberwise
-      intro c hc
-      simp only [Finset.mem_coe, Finset.mem_filter] at hc ⊢
-      rw [Finset.mem_range]
-      refine lt_min hc.2 ?_
-      rw [← YoungDiagram.mem_iff_lt_colLen]
-      exact μ.up_left_mem (by rfl) c.2.zero_le hc.1
-    _ = ∑ i ∈ Finset.range (min k (μ.colLen 0)), μ.rowLen i := by
-      apply Finset.sum_congr rfl
-      intro i hi
-      rw [μ.rowLen_eq_card]
-      congr 1
-      ext c
-      have hik : i < k := (Finset.mem_range.mp hi).trans_le (min_le_left _ _)
-      simp only [Finset.mem_filter, YoungDiagram.mem_cells, YoungDiagram.mem_row_iff]
-      aesop
-
 private theorem sum_map_min_rowLens_eq_card_filter_snd (μ : YoungDiagram) (k : ℕ) :
     (μ.rowLens.map (min k)).sum = (μ.cells.filter fun c => c.2 < k).card := by
   rw [YoungDiagram.rowLens, List.map_map,
@@ -92,7 +66,7 @@ private theorem card_filter_fst_transpose (μ : YoungDiagram) (k : ℕ) :
 
 private theorem sum_take_transpose_rowLens (μ : YoungDiagram) (k : ℕ) :
     (μ.transpose.rowLens.take k).sum = (μ.rowLens.map (min k)).sum := by
-  rw [sum_take_rowLens_eq_card_filter_fst, card_filter_fst_transpose,
+  rw [YoungDiagram.sum_take_rowLens_eq_card_filter_fst, card_filter_fst_transpose,
     sum_map_min_rowLens_eq_card_filter_snd]
 
 private theorem sum_sub_add_mul_length_takeWhile {l : List ℕ} (hl : l.SortedGE) (k : ℕ) :

--- a/TauCeti/Combinatorics/Young/Diagram.lean
+++ b/TauCeti/Combinatorics/Young/Diagram.lean
@@ -7,12 +7,19 @@ module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 public import Mathlib.Combinatorics.Young.YoungDiagram
+public import Mathlib.Data.List.GetD
 
 /-!
-# The row lengths of a Young diagram add up to its size
+# Counting the cells of a Young diagram by rows
 
 Mathlib's `YoungDiagram.rowLens` records the lengths of the rows of a Young diagram.  This file
-proves that these lengths sum to the number of cells of the diagram.
+counts the cells of a diagram row by row: the row lengths sum to the number of cells, and the
+first `k` row lengths sum to the number of cells lying in the first `k` rows, whether those
+lengths are summed as `∑ i ∈ Finset.range k, μ.rowLen i` or as `(μ.rowLens.take k).sum`.
+
+The partial sums are the shape of every dominance statement about partitions, since dominance
+compares partial sums of decreasingly sorted parts, and the sorted parts of a partition are the
+row lengths of its Young diagram.
 -/
 
 public section
@@ -28,34 +35,75 @@ theorem card_transpose (μ : YoungDiagram) : μ.transpose.card = μ.card := by
   intro c
   simp
 
+private theorem sum_list_range (f : ℕ → ℕ) (n : ℕ) :
+    ((List.range n).map f).sum = ∑ i ∈ Finset.range n, f i := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+    rw [List.range_succ, List.map_append, List.sum_append, ih, Finset.sum_range_succ]
+    simp
+
+/-- A row past the last one of a Young diagram is empty. -/
+theorem rowLen_eq_zero_of_colLen_le {μ : YoungDiagram} {i : ℕ} (hi : μ.colLen 0 ≤ i) :
+    μ.rowLen i = 0 := by
+  by_contra h
+  exact absurd (_root_.YoungDiagram.mem_iff_lt_colLen.mp
+    (_root_.YoungDiagram.mem_iff_lt_rowLen.mpr (Nat.pos_of_ne_zero h))) (Nat.not_lt.mpr hi)
+
+/-- Reading the length of a row off `YoungDiagram.rowLens`, with `0` for the rows past the last
+one. -/
+theorem getD_rowLens (μ : YoungDiagram) (i : ℕ) : μ.rowLens.getD i 0 = μ.rowLen i := by
+  by_cases hi : i < μ.rowLens.length
+  · rw [List.getD_eq_getElem _ _ hi, _root_.YoungDiagram.get_rowLens]
+  · rw [List.getD_eq_default _ _ (Nat.le_of_not_lt hi),
+      rowLen_eq_zero_of_colLen_le
+        (le_of_eq_of_le _root_.YoungDiagram.length_rowLens.symm (Nat.le_of_not_lt hi))]
+
+/-- The first `k` row lengths of a Young diagram count its cells in the first `k` rows. -/
+theorem sum_range_rowLen_eq_card_filter_fst (μ : YoungDiagram) (k : ℕ) :
+    ∑ i ∈ Finset.range k, μ.rowLen i = (μ.cells.filter fun c => c.1 < k).card := by
+  symm
+  calc
+    (μ.cells.filter fun c => c.1 < k).card =
+        ∑ i ∈ Finset.range k,
+          ((μ.cells.filter fun c => c.1 < k).filter fun c => c.1 = i).card := by
+      apply Finset.card_eq_sum_card_fiberwise
+      intro c hc
+      simp only [Finset.mem_coe, Finset.mem_filter] at hc
+      exact Finset.mem_range.mpr hc.2
+    _ = ∑ i ∈ Finset.range k, μ.rowLen i := by
+      refine Finset.sum_congr rfl fun i hi => ?_
+      rw [μ.rowLen_eq_card]
+      congr 1
+      ext c
+      have hik : i < k := Finset.mem_range.mp hi
+      simp only [Finset.mem_filter, _root_.YoungDiagram.mem_cells,
+        _root_.YoungDiagram.mem_row_iff]
+      aesop
+
+/-- The first `k` entries of `YoungDiagram.rowLens` count the cells in the first `k` rows.  This
+is `TauCeti.YoungDiagram.sum_range_rowLen_eq_card_filter_fst` with the truncation taken on the
+list of row lengths, the form in which partial sums enter the dominance order on partitions. -/
+theorem sum_take_rowLens_eq_card_filter_fst (μ : YoungDiagram) (k : ℕ) :
+    (μ.rowLens.take k).sum = (μ.cells.filter fun c => c.1 < k).card := by
+  rw [_root_.YoungDiagram.rowLens, ← List.map_take, List.take_range, sum_list_range,
+    ← sum_range_rowLen_eq_card_filter_fst]
+  have hsub : Finset.range (min k (μ.colLen 0)) ⊆ Finset.range k := fun i hi =>
+    Finset.mem_range.mpr (lt_min_iff.mp (Finset.mem_range.mp hi)).1
+  refine Finset.sum_subset hsub fun i hi hi' => ?_
+  exact rowLen_eq_zero_of_colLen_le
+    (by simpa [lt_min_iff, Finset.mem_range.mp hi] using Finset.mem_range.not.mp hi')
+
 /-- The sum of the row lengths of a Young diagram is its number of cells. -/
 @[simp]
 theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
-  have sum_list_range (f : ℕ → ℕ) :
-      ∀ n, ((List.range n).map f).sum = ∑ i ∈ Finset.range n, f i := by
-    intro n
-    induction n with
-    | zero => simp
-    | succ n ih =>
-      rw [List.range_succ, List.map_append, List.sum_append, ih, Finset.sum_range_succ]
-      simp
   have hrange : μ.rowLens.sum = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
     rw [_root_.YoungDiagram.rowLens, sum_list_range]
-  rw [hrange]
-  symm
-  calc
-    μ.card =
-        ∑ i ∈ Finset.range (μ.colLen 0),
-          (μ.cells.filter fun c => c.fst = i).card := by
-      apply Finset.card_eq_sum_card_fiberwise
-      intro c hc
-      simpa using
-        (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
-          (μ.colLen_anti 0 c.snd c.snd.zero_le)
-    _ = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
-      apply Finset.sum_congr rfl
-      intro i _
-      exact (μ.rowLen_eq_card (i := i)).symm
+  rw [hrange, sum_range_rowLen_eq_card_filter_fst]
+  refine congrArg Finset.card (Finset.filter_true_of_mem fun c hc => ?_)
+  simpa using
+    (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+      (μ.colLen_anti 0 c.snd c.snd.zero_le)
 
 end YoungDiagram
 

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -27,26 +27,27 @@ rows.
 
 Mathlib's `SemistandardYoungTableau` fills the cells with natural numbers starting at `0`, so the
 alphabet here is `0, 1, 2, …` rather than the classical `1, 2, 3, …` and the content of the
-maximal tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen` on the nose.
+highest-weight tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen` on the nose.
 
 ## Main definitions
 
 * `TauCeti.SemistandardYoungTableau.content`: the content (or weight) of a semistandard Young
   tableau, `content T i` being the number of cells filled with `i`.
-* `TauCeti.kostkaNumber`: the number of semistandard Young tableaux of a given shape and content.
-* `TauCeti.partitionKostkaNumber`: the Kostka number of two partitions of the same natural number,
-  the shape and the content being read off their Young diagrams.
+* `TauCeti.diagramKostkaNumber`: the number of semistandard Young tableaux of a given shape and
+  content.
+* `TauCeti.kostkaNumber`: the Kostka number of two partitions of the same natural number, the
+  shape and the content being read off their Young diagrams.
 
 ## Main results
 
 * `TauCeti.SemistandardYoungTableau.sum_content_le_sum_take_rowLens`: the partial sums of the
   content of a tableau of shape `μ` are bounded by those of the row lengths of `μ`.
 * `TauCeti.SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen`: a tableau of shape `μ`
-  and content `μ.rowLen` is the maximal tableau.
+  and content `μ.rowLen` is the highest-weight tableau.
 * `TauCeti.SemistandardYoungTableau.finite_content_eq`: the tableaux of a fixed shape and content
   are finite, so the Kostka number counts them faithfully.
-* `TauCeti.kostkaNumber_rowLen`: `K_{μ μ} = 1`.
-* `TauCeti.partitionKostkaNumber_eq_zero_of_not_dominates`: `K_{μ ν} = 0` unless `μ` dominates `ν`.
+* `TauCeti.kostkaNumber_self`: `K_{μ μ} = 1`.
+* `TauCeti.kostkaNumber_eq_zero_of_not_dominates`: `K_{μ ν} = 0` unless `μ` dominates `ν`.
 
 ## References
 
@@ -143,8 +144,8 @@ theorem sum_content_le_sum_take_rowLens (T : _root_.SemistandardYoungTableau μ)
   rw [sum_content_eq_card_filter, YoungDiagram.sum_take_rowLens_eq_card_filter_fst]
   exact Finset.card_le_card (filter_entry_lt_subset_filter_fst_lt T k)
 
-/-- The maximal tableau, whose `i`-th row consists of `i`s, has content the row lengths of its
-shape. -/
+/-- The highest-weight tableau, whose `i`-th row consists of `i`s, has content the row lengths of
+its shape. -/
 @[simp]
 theorem content_highestWeight (μ : YoungDiagram) :
     content (_root_.SemistandardYoungTableau.highestWeight μ) = μ.rowLen := by
@@ -155,13 +156,9 @@ theorem content_highestWeight (μ : YoungDiagram) :
     _root_.SemistandardYoungTableau.highestWeight_apply]
   aesop
 
-/-- **Uniqueness of the maximal tableau**: a semistandard tableau of shape `μ` whose content is the
-row lengths of `μ` has an `i` in every cell of row `i`, so it is
-`SemistandardYoungTableau.highestWeight μ`.
-
-Indeed the cells with entry smaller than `k` lie in the first `k` rows, and the two sets are
-counted by the same partial sums, so they agree; taking `k = i + 1` at a cell of row `i` bounds its
-entry by `i`, and `TauCeti.SemistandardYoungTableau.le_entry` bounds it below. -/
+/-- **Uniqueness of the highest-weight tableau**: a semistandard tableau of shape `μ` whose content
+is the row lengths of `μ` has an `i` in every cell of row `i`, so it is
+`SemistandardYoungTableau.highestWeight μ`. -/
 theorem eq_highestWeight_of_content_eq_rowLen {T : _root_.SemistandardYoungTableau μ}
     (h : content T = μ.rowLen) : T = _root_.SemistandardYoungTableau.highestWeight μ := by
   have key : ∀ i j : ℕ, (i, j) ∈ μ → T i j = i := by
@@ -181,8 +178,7 @@ theorem eq_highestWeight_of_content_eq_rowLen {T : _root_.SemistandardYoungTable
   · rw [key i j hij, _root_.SemistandardYoungTableau.highestWeight_apply, if_pos hij]
   · rw [T.zeros hij, _root_.SemistandardYoungTableau.highestWeight_apply, if_neg hij]
 
-/-- The semistandard tableaux of a fixed shape and content are finite: their entries all occur in
-any one of them, so there are only finitely many values to fill the finitely many cells with. -/
+/-- The semistandard tableaux of a fixed shape and content are finite. -/
 instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
     Finite {T : _root_.SemistandardYoungTableau μ // content T = w} := by
   by_cases hne : Nonempty {T : _root_.SemistandardYoungTableau μ // content T = w}
@@ -207,16 +203,32 @@ instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
 
 end SemistandardYoungTableau
 
-/-- The **Kostka number** `K_{μ w}`: the number of semistandard Young tableaux of shape `μ` whose
-content is `w`. -/
-noncomputable def kostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
+/-- The **Kostka number** `K_{μ w}` of a shape and a weight function: the number of semistandard
+Young tableaux of shape `μ` whose content is `w`. -/
+@[expose]
+noncomputable def diagramKostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
   Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w}
 
-/-- **The diagonal Kostka number is `1`**: the maximal tableau is the only semistandard tableau of
-shape `μ` whose content is the row lengths of `μ`. -/
+/-- The Kostka number of a shape and a weight function counts the tableaux of that shape and
+content. -/
+theorem diagramKostkaNumber_def (μ : YoungDiagram) (w : ℕ → ℕ) :
+    diagramKostkaNumber μ w =
+      Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w} :=
+  rfl
+
+/-- A Kostka number is nonzero exactly when a tableau of the prescribed shape and content
+exists. -/
+theorem diagramKostkaNumber_ne_zero_iff {μ : YoungDiagram} {w : ℕ → ℕ} :
+    diagramKostkaNumber μ w ≠ 0 ↔
+      ∃ T : _root_.SemistandardYoungTableau μ, SemistandardYoungTableau.content T = w := by
+  rw [diagramKostkaNumber_def, Nat.card_ne_zero]
+  exact ⟨fun h => h.1.elim fun T => ⟨T.1, T.2⟩, fun ⟨T, hT⟩ => ⟨⟨⟨T, hT⟩⟩, inferInstance⟩⟩
+
+/-- **The diagonal Kostka number is `1`**: the highest-weight tableau is the only semistandard
+tableau of shape `μ` whose content is the row lengths of `μ`. -/
 @[simp]
-theorem kostkaNumber_rowLen (μ : YoungDiagram) : kostkaNumber μ μ.rowLen = 1 := by
-  rw [kostkaNumber, Nat.card_eq_one_iff_unique]
+theorem diagramKostkaNumber_rowLen (μ : YoungDiagram) : diagramKostkaNumber μ μ.rowLen = 1 := by
+  rw [diagramKostkaNumber_def, Nat.card_eq_one_iff_unique]
   refine ⟨⟨fun T T' => Subtype.ext ?_⟩,
     ⟨⟨_root_.SemistandardYoungTableau.highestWeight μ,
       SemistandardYoungTableau.content_highestWeight μ⟩⟩⟩
@@ -226,47 +238,54 @@ theorem kostkaNumber_rowLen (μ : YoungDiagram) : kostkaNumber μ μ.rowLen = 1 
 /-- **The Kostka numbers are supported on the dominance order**: a nonzero Kostka number
 `K_{μ w}` forces every partial sum of `w` to be bounded by the corresponding partial sum of the
 row lengths of `μ`. -/
-theorem sum_le_sum_take_rowLens_of_kostkaNumber_ne_zero {μ : YoungDiagram} {w : ℕ → ℕ}
-    (h : kostkaNumber μ w ≠ 0) (k : ℕ) :
+theorem sum_le_sum_take_rowLens_of_diagramKostkaNumber_ne_zero {μ : YoungDiagram} {w : ℕ → ℕ}
+    (h : diagramKostkaNumber μ w ≠ 0) (k : ℕ) :
     ∑ i ∈ Finset.range k, w i ≤ (μ.rowLens.take k).sum := by
-  obtain ⟨T, hT⟩ := (Nat.card_ne_zero.mp h).1
+  obtain ⟨T, hT⟩ := diagramKostkaNumber_ne_zero_iff.mp h
   calc
     ∑ i ∈ Finset.range k, w i = ∑ i ∈ Finset.range k, SemistandardYoungTableau.content T i :=
       Finset.sum_congr rfl fun i _ => (congrFun hT i).symm
     _ ≤ (μ.rowLens.take k).sum := SemistandardYoungTableau.sum_content_le_sum_take_rowLens T k
 
-/-- The row lengths of the Young diagram of a partition are its decreasingly sorted parts, padded
-by zeros. -/
-theorem rowLen_diagramOf {n : ℕ} (ν : n.Partition) (i : ℕ) :
-    (diagramOf ν).rowLen i = (ν.parts.sort (· ≥ ·)).getD i 0 := by
-  rw [← YoungDiagram.getD_rowLens, rowLens_diagramOf]
+/-- The **Kostka number** `K_{μ ν}` of two partitions of the same natural number: the number of
+semistandard tableaux of the shape of `μ` whose content is the row lengths of the diagram of `ν`,
+that is (by `TauCeti.rowLen_diagramOf`), the tableaux using the entry `i` exactly as often as the
+`i`-th largest part of `ν` prescribes. -/
+@[expose]
+noncomputable def kostkaNumber {n : ℕ} (μ ν : n.Partition) : ℕ :=
+  diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen
 
-/-- The **Kostka number of two partitions** of the same natural number: the number of semistandard
-tableaux of the shape of `μ` whose content is the row lengths of the diagram of `ν`, that is (by
-`TauCeti.rowLen_diagramOf`), the tableaux using the entry `i` exactly as often as the `i`-th
-largest part of `ν` prescribes. -/
-noncomputable def partitionKostkaNumber {n : ℕ} (μ ν : n.Partition) : ℕ :=
-  kostkaNumber (diagramOf μ) (diagramOf ν).rowLen
+/-- The Kostka number of two partitions is the Kostka number of their diagrams. -/
+theorem kostkaNumber_def {n : ℕ} (μ ν : n.Partition) :
+    kostkaNumber μ ν = diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen :=
+  rfl
+
+/-- A Kostka number of two partitions is nonzero exactly when a tableau of shape `μ` and content
+`ν` exists. -/
+theorem kostkaNumber_ne_zero_iff {n : ℕ} {μ ν : n.Partition} :
+    kostkaNumber μ ν ≠ 0 ↔ ∃ T : _root_.SemistandardYoungTableau (diagramOf μ),
+      SemistandardYoungTableau.content T = (diagramOf ν).rowLen := by
+  rw [kostkaNumber_def, diagramKostkaNumber_ne_zero_iff]
 
 /-- A partition contributes exactly one tableau to its own Kostka number. -/
 @[simp]
-theorem partitionKostkaNumber_self {n : ℕ} (μ : n.Partition) : partitionKostkaNumber μ μ = 1 :=
-  kostkaNumber_rowLen _
+theorem kostkaNumber_self {n : ℕ} (μ : n.Partition) : kostkaNumber μ μ = 1 :=
+  diagramKostkaNumber_rowLen _
 
 /-- **The Kostka numbers are triangular for the dominance order**: `K_{μ ν} ≠ 0` forces `μ` to
 dominate `ν`. -/
-theorem dominates_of_partitionKostkaNumber_ne_zero {n : ℕ} {μ ν : n.Partition}
-    (h : partitionKostkaNumber μ ν ≠ 0) : Dominates μ ν := by
+theorem dominates_of_kostkaNumber_ne_zero {n : ℕ} {μ ν : n.Partition}
+    (h : kostkaNumber μ ν ≠ 0) : Dominates μ ν := by
   refine dominates_iff.mpr fun k => ?_
-  have hk := sum_le_sum_take_rowLens_of_kostkaNumber_ne_zero h k
+  have hk := sum_le_sum_take_rowLens_of_diagramKostkaNumber_ne_zero h k
   rwa [YoungDiagram.sum_range_rowLen_eq_card_filter_fst,
     ← YoungDiagram.sum_take_rowLens_eq_card_filter_fst, rowLens_diagramOf,
     rowLens_diagramOf] at hk
 
 /-- **The Kostka numbers vanish off the dominance order**: there is no semistandard tableau of
 shape `μ` and content `ν` unless `μ` dominates `ν`. -/
-theorem partitionKostkaNumber_eq_zero_of_not_dominates {n : ℕ} {μ ν : n.Partition}
-    (h : ¬ Dominates μ ν) : partitionKostkaNumber μ ν = 0 :=
-  not_not.mp fun h' => h (dominates_of_partitionKostkaNumber_ne_zero h')
+theorem kostkaNumber_eq_zero_of_not_dominates {n : ℕ} {μ ν : n.Partition}
+    (h : ¬ Dominates μ ν) : kostkaNumber μ ν = 0 :=
+  not_not.mp fun h' => h (dominates_of_kostkaNumber_ne_zero h')
 
 end TauCeti

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Combinatorics.Young.SemistandardTableau
+public import Mathlib.Data.Finsupp.Multiset
 public import Mathlib.SetTheory.Cardinal.Finite
 public import TauCeti.Combinatorics.Enumerative.Partition.Conjugate
 
@@ -64,33 +65,23 @@ namespace SemistandardYoungTableau
 
 variable {μ : YoungDiagram}
 
-/-- The content, or weight, of a semistandard Young tableau: `content T i` is the number of cells
-of the shape whose entry is `i`. -/
-def content (T : _root_.SemistandardYoungTableau μ) (i : ℕ) : ℕ :=
-  (μ.cells.filter fun c => T c.1 c.2 = i).card
+/-- The content, or weight, of a semistandard Young tableau: the multiset of its entries, read as
+a finitely supported multiplicity function, so `content T i` is the number of cells of the shape
+whose entry is `i`. -/
+noncomputable def content (T : _root_.SemistandardYoungTableau μ) : ℕ →₀ ℕ :=
+  (μ.cells.val.map fun c => T c.1 c.2).toFinsupp
 
 /-- The content of a tableau counts the cells of its shape carrying a given entry. -/
 theorem content_def (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
-    content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card := (rfl)
+    content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card := by
+  rw [content, Multiset.toFinsupp_apply, Multiset.count_map]
+  simp [Finset.card, Finset.filter_val, eq_comm]
 
-/-- The entries of a tableau are exactly the values on which its content is nonzero. -/
-theorem mem_image_iff_content_ne_zero (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
-    i ∈ μ.cells.image (fun c => T c.1 c.2) ↔ content T i ≠ 0 := by
-  rw [content_def, ← Nat.pos_iff_ne_zero, Finset.card_pos]
-  constructor
-  · rintro hi
-    obtain ⟨c, hc, hci⟩ := Finset.mem_image.mp hi
-    exact ⟨c, Finset.mem_filter.mpr ⟨hc, hci⟩⟩
-  · rintro ⟨c, hc⟩
-    rw [Finset.mem_filter] at hc
-    exact Finset.mem_image.mpr ⟨c, hc.1, hc.2⟩
-
-/-- The content of a tableau is finitely supported: it spreads the cells of the shape over the
-finitely many entries the tableau uses. -/
-theorem finite_support_content (T : _root_.SemistandardYoungTableau μ) :
-    (Function.support (content T)).Finite :=
-  Set.Finite.subset (μ.cells.image fun c => T c.1 c.2).finite_toSet fun _ hi =>
-    (mem_image_iff_content_ne_zero T _).mpr hi
+/-- The support of the content of a tableau is the set of entries it uses. -/
+@[simp]
+theorem support_content (T : _root_.SemistandardYoungTableau μ) :
+    (content T).support = μ.cells.image fun c => T c.1 c.2 := by
+  rw [content, Multiset.toFinsupp_support, Multiset.toFinset_map, Finset.val_toFinset]
 
 /-- The entries of a semistandard Young tableau increase strictly down a column, so the entry in
 row `i` is at least `i`. -/
@@ -124,6 +115,7 @@ theorem sum_content_eq_card_filter (T : _root_.SemistandardYoungTableau μ) (k :
     _ = ∑ i ∈ Finset.range k, content T i := by
       refine Finset.sum_congr rfl fun i hi => ?_
       have hik : i < k := Finset.mem_range.mp hi
+      rw [content_def]
       refine congrArg Finset.card (Finset.ext fun c => ?_)
       simp only [Finset.mem_filter, and_assoc]
       exact ⟨fun h => ⟨h.1, h.2.2⟩, fun h => ⟨h.1, h.2 ▸ hik, h.2⟩⟩
@@ -146,7 +138,7 @@ theorem sum_content_le_sum_take_rowLens (T : _root_.SemistandardYoungTableau μ)
 its shape. -/
 @[simp]
 theorem content_highestWeight (μ : YoungDiagram) :
-    content (_root_.SemistandardYoungTableau.highestWeight μ) = μ.rowLen := by
+    ⇑(content (_root_.SemistandardYoungTableau.highestWeight μ)) = μ.rowLen := by
   funext i
   rw [content_def, μ.rowLen_eq_card]
   refine congrArg Finset.card (Finset.ext fun c => ?_)
@@ -158,7 +150,7 @@ theorem content_highestWeight (μ : YoungDiagram) :
 is the row lengths of `μ` has an `i` in every cell of row `i`, so it is
 `SemistandardYoungTableau.highestWeight μ`. -/
 theorem eq_highestWeight_of_content_eq_rowLen {T : _root_.SemistandardYoungTableau μ}
-    (h : content T = μ.rowLen) : T = _root_.SemistandardYoungTableau.highestWeight μ := by
+    (h : ⇑(content T) = μ.rowLen) : T = _root_.SemistandardYoungTableau.highestWeight μ := by
   have key : ∀ i j : ℕ, (i, j) ∈ μ → T i j = i := by
     intro i j hij
     have hcards : (μ.cells.filter fun c => T c.1 c.2 < i + 1).card =
@@ -178,20 +170,19 @@ theorem eq_highestWeight_of_content_eq_rowLen {T : _root_.SemistandardYoungTable
 
 /-- The semistandard tableaux of a fixed shape and content are finite. -/
 instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
-    Finite {T : _root_.SemistandardYoungTableau μ // content T = w} := by
-  by_cases hne : Nonempty {T : _root_.SemistandardYoungTableau μ // content T = w}
+    Finite {T : _root_.SemistandardYoungTableau μ // ⇑(content T) = w} := by
+  by_cases hne : Nonempty {T : _root_.SemistandardYoungTableau μ // ⇑(content T) = w}
   swap
   · rw [not_nonempty_iff] at hne
     infer_instance
   obtain ⟨T₀, hT₀⟩ := hne.some
-  have hmem : ∀ T : _root_.SemistandardYoungTableau μ, content T = w →
+  have hmem : ∀ T : _root_.SemistandardYoungTableau μ, ⇑(content T) = w →
       ∀ c ∈ μ.cells, T c.1 c.2 ∈ μ.cells.image fun d => T₀ d.1 d.2 := by
     intro T hT c hc
-    refine (mem_image_iff_content_ne_zero T₀ _).mpr ?_
-    rw [congrFun hT₀ (T c.1 c.2), ← congrFun hT (T c.1 c.2)]
-    exact (mem_image_iff_content_ne_zero T _).mp (Finset.mem_image.mpr ⟨c, hc, rfl⟩)
+    rw [← support_content T₀, DFunLike.coe_injective (hT₀.trans hT.symm), support_content T]
+    exact Finset.mem_image.mpr ⟨c, hc, rfl⟩
   refine Finite.of_injective
-    (fun (T : {T : _root_.SemistandardYoungTableau μ // content T = w}) (c : ↥μ.cells) =>
+    (fun (T : {T : _root_.SemistandardYoungTableau μ // ⇑(content T) = w}) (c : ↥μ.cells) =>
       (⟨T.1 (c : ℕ × ℕ).1 (c : ℕ × ℕ).2, hmem T.1 T.2 _ c.2⟩ :
         ↥(μ.cells.image fun d => T₀ d.1 d.2))) fun T T' hTT' => ?_
   refine Subtype.ext (_root_.SemistandardYoungTableau.ext fun i j => ?_)
@@ -204,20 +195,21 @@ end SemistandardYoungTableau
 /-- The **Kostka number** `K_{μ w}` of a shape and a weight function: the number of semistandard
 Young tableaux of shape `μ` whose content is `w`. -/
 noncomputable def diagramKostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
-  Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w}
+  Nat.card {T : _root_.SemistandardYoungTableau μ // ⇑(SemistandardYoungTableau.content T) = w}
 
 /-- The Kostka number of a shape and a weight function counts the semistandard tableaux of that
 shape whose content is that weight. -/
 theorem diagramKostkaNumber_def (μ : YoungDiagram) (w : ℕ → ℕ) :
     diagramKostkaNumber μ w =
-      Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w} :=
+      Nat.card
+        {T : _root_.SemistandardYoungTableau μ // ⇑(SemistandardYoungTableau.content T) = w} :=
   (rfl)
 
 /-- A Kostka number is nonzero exactly when a tableau of the prescribed shape and content
 exists. -/
 theorem diagramKostkaNumber_ne_zero_iff {μ : YoungDiagram} {w : ℕ → ℕ} :
     diagramKostkaNumber μ w ≠ 0 ↔
-      ∃ T : _root_.SemistandardYoungTableau μ, SemistandardYoungTableau.content T = w := by
+      ∃ T : _root_.SemistandardYoungTableau μ, ⇑(SemistandardYoungTableau.content T) = w := by
   rw [diagramKostkaNumber_def, Nat.card_ne_zero]
   exact ⟨fun h => h.1.elim fun T => ⟨T.1, T.2⟩, fun ⟨T, hT⟩ => ⟨⟨⟨T, hT⟩⟩, inferInstance⟩⟩
 
@@ -260,7 +252,7 @@ theorem kostkaNumber_def {n : ℕ} (μ ν : n.Partition) :
 `ν` exists. -/
 theorem kostkaNumber_ne_zero_iff {n : ℕ} {μ ν : n.Partition} :
     kostkaNumber μ ν ≠ 0 ↔ ∃ T : _root_.SemistandardYoungTableau (diagramOf μ),
-      SemistandardYoungTableau.content T = (diagramOf ν).rowLen := by
+      ⇑(SemistandardYoungTableau.content T) = (diagramOf ν).rowLen := by
   rw [kostkaNumber_def, diagramKostkaNumber_ne_zero_iff]
 
 /-- A partition contributes exactly one tableau to its own Kostka number. -/

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -17,8 +17,8 @@ entry, and the *Kostka number* `K_{μ w}` counts the semistandard tableaux of sh
 establishes the two facts that make the Kostka numbers a triangular array for the dominance order:
 the tableau of shape `μ` whose `i`-th row consists of `i`s is the only one of content
 `μ.rowLen` (so `K_{μ μ} = 1`), and a tableau of shape `μ` and content `w` forces every partial sum
-`∑_{i < k} w i` to be at most the corresponding partial sum of the row lengths of `μ` (so
-`K_{μ w} = 0` unless `μ` dominates `w`).
+`∑_{i < k} w i` to be at most the corresponding partial sum of the row lengths of `μ` (so, for
+partitions, `K_{μ ν} = 0` unless `μ` dominates `ν`).
 
 The mechanism behind both is a single observation, `TauCeti.SemistandardYoungTableau.le_entry`: the
 entries of a semistandard tableau strictly increase down each column, so the entry in row `i` is at
@@ -66,14 +66,14 @@ variable {μ : YoungDiagram}
 
 /-- The content, or weight, of a semistandard Young tableau: `content T i` is the number of cells
 of the shape whose entry is `i`. -/
-@[expose]
 def content (T : _root_.SemistandardYoungTableau μ) (i : ℕ) : ℕ :=
   (μ.cells.filter fun c => T c.1 c.2 = i).card
 
-/-- The content of a tableau counts the cells carrying a given entry. -/
+/-- The content of a tableau counts the cells carrying a given entry.  This is the whole interface
+importers get: the body of `content` is not exposed, so the parentheses in `(rfl)` keep the
+definitional step inside this module. -/
 theorem content_def (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
-    content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card :=
-  rfl
+    content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card := (rfl)
 
 /-- The entries of a tableau are exactly the values on which its content is nonzero. -/
 theorem mem_image_iff_content_ne_zero (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
@@ -205,16 +205,16 @@ end SemistandardYoungTableau
 
 /-- The **Kostka number** `K_{μ w}` of a shape and a weight function: the number of semistandard
 Young tableaux of shape `μ` whose content is `w`. -/
-@[expose]
 noncomputable def diagramKostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
   Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w}
 
 /-- The Kostka number of a shape and a weight function counts the tableaux of that shape and
-content. -/
+content.  As for `TauCeti.SemistandardYoungTableau.content_def`, this is the whole interface
+importers get. -/
 theorem diagramKostkaNumber_def (μ : YoungDiagram) (w : ℕ → ℕ) :
     diagramKostkaNumber μ w =
       Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w} :=
-  rfl
+  (rfl)
 
 /-- A Kostka number is nonzero exactly when a tableau of the prescribed shape and content
 exists. -/
@@ -251,14 +251,13 @@ theorem sum_le_sum_take_rowLens_of_diagramKostkaNumber_ne_zero {μ : YoungDiagra
 semistandard tableaux of the shape of `μ` whose content is the row lengths of the diagram of `ν`,
 that is (by `TauCeti.rowLen_diagramOf`), the tableaux using the entry `i` exactly as often as the
 `i`-th largest part of `ν` prescribes. -/
-@[expose]
 noncomputable def kostkaNumber {n : ℕ} (μ ν : n.Partition) : ℕ :=
   diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen
 
-/-- The Kostka number of two partitions is the Kostka number of their diagrams. -/
+/-- The Kostka number of two partitions is the Kostka number of their diagrams.  As for
+`TauCeti.SemistandardYoungTableau.content_def`, this is the whole interface importers get. -/
 theorem kostkaNumber_def {n : ℕ} (μ ν : n.Partition) :
-    kostkaNumber μ ν = diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen :=
-  rfl
+    kostkaNumber μ ν = diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen := (rfl)
 
 /-- A Kostka number of two partitions is nonzero exactly when a tableau of shape `μ` and content
 `ν` exists. -/
@@ -270,13 +269,14 @@ theorem kostkaNumber_ne_zero_iff {n : ℕ} {μ ν : n.Partition} :
 /-- A partition contributes exactly one tableau to its own Kostka number. -/
 @[simp]
 theorem kostkaNumber_self {n : ℕ} (μ : n.Partition) : kostkaNumber μ μ = 1 :=
-  diagramKostkaNumber_rowLen _
+  (kostkaNumber_def μ μ).trans (diagramKostkaNumber_rowLen _)
 
 /-- **The Kostka numbers are triangular for the dominance order**: `K_{μ ν} ≠ 0` forces `μ` to
 dominate `ν`. -/
 theorem dominates_of_kostkaNumber_ne_zero {n : ℕ} {μ ν : n.Partition}
     (h : kostkaNumber μ ν ≠ 0) : Dominates μ ν := by
   refine dominates_iff.mpr fun k => ?_
+  rw [kostkaNumber_def] at h
   have hk := sum_le_sum_take_rowLens_of_diagramKostkaNumber_ne_zero h k
   rwa [YoungDiagram.sum_range_rowLen_eq_card_filter_fst,
     ← YoungDiagram.sum_take_rowLens_eq_card_filter_fst, rowLens_diagramOf,

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -69,9 +69,7 @@ of the shape whose entry is `i`. -/
 def content (T : _root_.SemistandardYoungTableau μ) (i : ℕ) : ℕ :=
   (μ.cells.filter fun c => T c.1 c.2 = i).card
 
-/-- The content of a tableau counts the cells carrying a given entry.  This is the whole interface
-importers get: the body of `content` is not exposed, so the parentheses in `(rfl)` keep the
-definitional step inside this module. -/
+/-- The content of a tableau counts the cells of its shape carrying a given entry. -/
 theorem content_def (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
     content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card := (rfl)
 
@@ -208,9 +206,8 @@ Young tableaux of shape `μ` whose content is `w`. -/
 noncomputable def diagramKostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
   Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w}
 
-/-- The Kostka number of a shape and a weight function counts the tableaux of that shape and
-content.  As for `TauCeti.SemistandardYoungTableau.content_def`, this is the whole interface
-importers get. -/
+/-- The Kostka number of a shape and a weight function counts the semistandard tableaux of that
+shape whose content is that weight. -/
 theorem diagramKostkaNumber_def (μ : YoungDiagram) (w : ℕ → ℕ) :
     diagramKostkaNumber μ w =
       Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w} :=
@@ -235,9 +232,9 @@ theorem diagramKostkaNumber_rowLen (μ : YoungDiagram) : diagramKostkaNumber μ 
   rw [SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen T.2,
     SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen T'.2]
 
-/-- **The Kostka numbers are supported on the dominance order**: a nonzero Kostka number
-`K_{μ w}` forces every partial sum of `w` to be bounded by the corresponding partial sum of the
-row lengths of `μ`. -/
+/-- **Partial-sum bound for a nonzero Kostka number**: if `K_{μ w} ≠ 0` then every partial sum of
+`w` is bounded by the corresponding partial sum of the row lengths of `μ`.  For partitions this
+becomes the dominance statement `TauCeti.dominates_of_kostkaNumber_ne_zero`. -/
 theorem sum_le_sum_take_rowLens_of_diagramKostkaNumber_ne_zero {μ : YoungDiagram} {w : ℕ → ℕ}
     (h : diagramKostkaNumber μ w ≠ 0) (k : ℕ) :
     ∑ i ∈ Finset.range k, w i ≤ (μ.rowLens.take k).sum := by
@@ -254,8 +251,8 @@ that is (by `TauCeti.rowLen_diagramOf`), the tableaux using the entry `i` exactl
 noncomputable def kostkaNumber {n : ℕ} (μ ν : n.Partition) : ℕ :=
   diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen
 
-/-- The Kostka number of two partitions is the Kostka number of their diagrams.  As for
-`TauCeti.SemistandardYoungTableau.content_def`, this is the whole interface importers get. -/
+/-- The Kostka number of two partitions is the Kostka number of the diagram of `μ` together with
+the row lengths of the diagram of `ν`. -/
 theorem kostkaNumber_def {n : ℕ} (μ ν : n.Partition) :
     kostkaNumber μ ν = diagramKostkaNumber (diagramOf μ) (diagramOf ν).rowLen := (rfl)
 

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -72,7 +72,7 @@ noncomputable def content (T : _root_.SemistandardYoungTableau μ) : ℕ →₀ 
   (μ.cells.val.map fun c => T c.1 c.2).toFinsupp
 
 /-- The content of a tableau counts the cells of its shape carrying a given entry. -/
-theorem content_def (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
+theorem content_apply (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
     content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card := by
   rw [content, Multiset.toFinsupp_apply, Multiset.count_map]
   simp [Finset.card, Finset.filter_val, eq_comm]
@@ -115,7 +115,7 @@ theorem sum_content_eq_card_filter (T : _root_.SemistandardYoungTableau μ) (k :
     _ = ∑ i ∈ Finset.range k, content T i := by
       refine Finset.sum_congr rfl fun i hi => ?_
       have hik : i < k := Finset.mem_range.mp hi
-      rw [content_def]
+      rw [content_apply]
       refine congrArg Finset.card (Finset.ext fun c => ?_)
       simp only [Finset.mem_filter, and_assoc]
       exact ⟨fun h => ⟨h.1, h.2.2⟩, fun h => ⟨h.1, h.2 ▸ hik, h.2⟩⟩
@@ -140,7 +140,7 @@ its shape. -/
 theorem content_highestWeight (μ : YoungDiagram) :
     ⇑(content (_root_.SemistandardYoungTableau.highestWeight μ)) = μ.rowLen := by
   funext i
-  rw [content_def, μ.rowLen_eq_card]
+  rw [content_apply, μ.rowLen_eq_card]
   refine congrArg Finset.card (Finset.ext fun c => ?_)
   simp only [_root_.YoungDiagram.mem_row_iff,
     _root_.SemistandardYoungTableau.highestWeight_apply]

--- a/TauCeti/Combinatorics/Young/Kostka.lean
+++ b/TauCeti/Combinatorics/Young/Kostka.lean
@@ -1,0 +1,272 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Combinatorics.Young.SemistandardTableau
+public import Mathlib.SetTheory.Cardinal.Finite
+public import TauCeti.Combinatorics.Enumerative.Partition.Conjugate
+
+/-!
+# Kostka numbers
+
+The *content* of a semistandard Young tableau records how often each natural number is used as an
+entry, and the *Kostka number* `K_{μ w}` counts the semistandard tableaux of shape `μ` and content
+`w`.  This file defines both, proves that the tableaux of a given content are finite, and
+establishes the two facts that make the Kostka numbers a triangular array for the dominance order:
+the tableau of shape `μ` whose `i`-th row consists of `i`s is the only one of content
+`μ.rowLen` (so `K_{μ μ} = 1`), and a tableau of shape `μ` and content `w` forces every partial sum
+`∑_{i < k} w i` to be at most the corresponding partial sum of the row lengths of `μ` (so
+`K_{μ w} = 0` unless `μ` dominates `w`).
+
+The mechanism behind both is a single observation, `TauCeti.SemistandardYoungTableau.le_entry`: the
+entries of a semistandard tableau strictly increase down each column, so the entry in row `i` is at
+least `i`, and therefore the cells carrying an entry smaller than `k` all lie in the first `k`
+rows.
+
+Mathlib's `SemistandardYoungTableau` fills the cells with natural numbers starting at `0`, so the
+alphabet here is `0, 1, 2, …` rather than the classical `1, 2, 3, …` and the content of the
+maximal tableau `SemistandardYoungTableau.highestWeight μ` is `μ.rowLen` on the nose.
+
+## Main definitions
+
+* `TauCeti.SemistandardYoungTableau.content`: the content (or weight) of a semistandard Young
+  tableau, `content T i` being the number of cells filled with `i`.
+* `TauCeti.kostkaNumber`: the number of semistandard Young tableaux of a given shape and content.
+* `TauCeti.partitionKostkaNumber`: the Kostka number of two partitions of the same natural number,
+  the shape and the content being read off their Young diagrams.
+
+## Main results
+
+* `TauCeti.SemistandardYoungTableau.sum_content_le_sum_take_rowLens`: the partial sums of the
+  content of a tableau of shape `μ` are bounded by those of the row lengths of `μ`.
+* `TauCeti.SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen`: a tableau of shape `μ`
+  and content `μ.rowLen` is the maximal tableau.
+* `TauCeti.SemistandardYoungTableau.finite_content_eq`: the tableaux of a fixed shape and content
+  are finite, so the Kostka number counts them faithfully.
+* `TauCeti.kostkaNumber_rowLen`: `K_{μ μ} = 1`.
+* `TauCeti.partitionKostkaNumber_eq_zero_of_not_dominates`: `K_{μ ν} = 0` unless `μ` dominates `ν`.
+
+## References
+
+* [W. Fulton, *Young Tableaux*][fulton1997], Section 2.2.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 1.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace SemistandardYoungTableau
+
+variable {μ : YoungDiagram}
+
+/-- The content, or weight, of a semistandard Young tableau: `content T i` is the number of cells
+of the shape whose entry is `i`. -/
+@[expose]
+def content (T : _root_.SemistandardYoungTableau μ) (i : ℕ) : ℕ :=
+  (μ.cells.filter fun c => T c.1 c.2 = i).card
+
+/-- The content of a tableau counts the cells carrying a given entry. -/
+theorem content_def (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
+    content T i = (μ.cells.filter fun c => T c.1 c.2 = i).card :=
+  rfl
+
+/-- The entries of a tableau are exactly the values on which its content is nonzero. -/
+theorem mem_image_iff_content_ne_zero (T : _root_.SemistandardYoungTableau μ) (i : ℕ) :
+    i ∈ μ.cells.image (fun c => T c.1 c.2) ↔ content T i ≠ 0 := by
+  rw [content_def, ← Nat.pos_iff_ne_zero, Finset.card_pos]
+  constructor
+  · rintro hi
+    obtain ⟨c, hc, hci⟩ := Finset.mem_image.mp hi
+    exact ⟨c, Finset.mem_filter.mpr ⟨hc, hci⟩⟩
+  · rintro ⟨c, hc⟩
+    rw [Finset.mem_filter] at hc
+    exact Finset.mem_image.mpr ⟨c, hc.1, hc.2⟩
+
+/-- The content of a tableau is finitely supported: it spreads the cells of the shape over the
+finitely many entries the tableau uses. -/
+theorem finite_support_content (T : _root_.SemistandardYoungTableau μ) :
+    (Function.support (content T)).Finite :=
+  Set.Finite.subset (μ.cells.image fun c => T c.1 c.2).finite_toSet fun _ hi =>
+    (mem_image_iff_content_ne_zero T _).mpr hi
+
+/-- The entries of a semistandard Young tableau increase strictly down a column, so the entry in
+row `i` is at least `i`. -/
+theorem le_entry (T : _root_.SemistandardYoungTableau μ) {i j : ℕ} (h : (i, j) ∈ μ) :
+    i ≤ T i j := by
+  induction i with
+  | zero => exact Nat.zero_le _
+  | succ m ih =>
+    have hm : (m, j) ∈ μ := μ.up_left_mem (Nat.le_succ m) le_rfl h
+    exact Nat.succ_le_of_lt (lt_of_le_of_lt (ih hm) (T.col_strict (Nat.lt_succ_self m) h))
+
+/-- The cells carrying an entry smaller than `k` all lie in the first `k` rows. -/
+theorem filter_entry_lt_subset_filter_fst_lt (T : _root_.SemistandardYoungTableau μ) (k : ℕ) :
+    (μ.cells.filter fun c => T c.1 c.2 < k) ⊆ μ.cells.filter fun c => c.1 < k := by
+  intro c hc
+  rw [Finset.mem_filter] at hc ⊢
+  exact ⟨hc.1, lt_of_le_of_lt (le_entry T (by simpa using hc.1)) hc.2⟩
+
+/-- The first `k` values of the content of a tableau count the cells carrying an entry smaller
+than `k`. -/
+theorem sum_content_eq_card_filter (T : _root_.SemistandardYoungTableau μ) (k : ℕ) :
+    ∑ i ∈ Finset.range k, content T i = (μ.cells.filter fun c => T c.1 c.2 < k).card := by
+  symm
+  calc
+    (μ.cells.filter fun c => T c.1 c.2 < k).card =
+        ∑ i ∈ Finset.range k,
+          ((μ.cells.filter fun c => T c.1 c.2 < k).filter fun c => T c.1 c.2 = i).card := by
+      refine Finset.card_eq_sum_card_fiberwise fun c hc => ?_
+      simp only [Finset.mem_coe, Finset.mem_filter] at hc
+      exact Finset.mem_range.mpr hc.2
+    _ = ∑ i ∈ Finset.range k, content T i := by
+      refine Finset.sum_congr rfl fun i hi => ?_
+      have hik : i < k := Finset.mem_range.mp hi
+      refine congrArg Finset.card (Finset.ext fun c => ?_)
+      simp only [Finset.mem_filter, and_assoc]
+      exact ⟨fun h => ⟨h.1, h.2.2⟩, fun h => ⟨h.1, h.2 ▸ hik, h.2⟩⟩
+
+/-- The content of a tableau of shape `μ` is a composition of the number of cells of `μ`, once the
+range of summation covers all the entries. -/
+theorem sum_content_eq_card {T : _root_.SemistandardYoungTableau μ} {N : ℕ}
+    (hN : ∀ c ∈ μ.cells, T c.1 c.2 < N) :
+    ∑ i ∈ Finset.range N, content T i = μ.card := by
+  rw [sum_content_eq_card_filter, Finset.filter_true_of_mem hN]
+
+/-- **Dominance bound for the content of a tableau**: the partial sums of the content of a
+semistandard tableau of shape `μ` never exceed the partial sums of the row lengths of `μ`. -/
+theorem sum_content_le_sum_take_rowLens (T : _root_.SemistandardYoungTableau μ) (k : ℕ) :
+    ∑ i ∈ Finset.range k, content T i ≤ (μ.rowLens.take k).sum := by
+  rw [sum_content_eq_card_filter, YoungDiagram.sum_take_rowLens_eq_card_filter_fst]
+  exact Finset.card_le_card (filter_entry_lt_subset_filter_fst_lt T k)
+
+/-- The maximal tableau, whose `i`-th row consists of `i`s, has content the row lengths of its
+shape. -/
+@[simp]
+theorem content_highestWeight (μ : YoungDiagram) :
+    content (_root_.SemistandardYoungTableau.highestWeight μ) = μ.rowLen := by
+  funext i
+  rw [content_def, μ.rowLen_eq_card]
+  refine congrArg Finset.card (Finset.ext fun c => ?_)
+  simp only [_root_.YoungDiagram.mem_row_iff,
+    _root_.SemistandardYoungTableau.highestWeight_apply]
+  aesop
+
+/-- **Uniqueness of the maximal tableau**: a semistandard tableau of shape `μ` whose content is the
+row lengths of `μ` has an `i` in every cell of row `i`, so it is
+`SemistandardYoungTableau.highestWeight μ`.
+
+Indeed the cells with entry smaller than `k` lie in the first `k` rows, and the two sets are
+counted by the same partial sums, so they agree; taking `k = i + 1` at a cell of row `i` bounds its
+entry by `i`, and `TauCeti.SemistandardYoungTableau.le_entry` bounds it below. -/
+theorem eq_highestWeight_of_content_eq_rowLen {T : _root_.SemistandardYoungTableau μ}
+    (h : content T = μ.rowLen) : T = _root_.SemistandardYoungTableau.highestWeight μ := by
+  have key : ∀ i j : ℕ, (i, j) ∈ μ → T i j = i := by
+    intro i j hij
+    have hcards : (μ.cells.filter fun c => T c.1 c.2 < i + 1).card =
+        (μ.cells.filter fun c => c.1 < i + 1).card := by
+      rw [← sum_content_eq_card_filter, ← YoungDiagram.sum_range_rowLen_eq_card_filter_fst]
+      exact Finset.sum_congr rfl fun k _ => congrFun h k
+    have hsets := Finset.eq_of_subset_of_card_le
+      (filter_entry_lt_subset_filter_fst_lt T (i + 1)) hcards.ge
+    have hmem : ((i, j) : ℕ × ℕ) ∈ μ.cells.filter fun c => T c.1 c.2 < i + 1 := by
+      rw [hsets, Finset.mem_filter]
+      exact ⟨hij, Nat.lt_succ_self i⟩
+    exact le_antisymm (Nat.lt_succ_iff.mp (Finset.mem_filter.mp hmem).2) (le_entry T hij)
+  ext i j
+  by_cases hij : (i, j) ∈ μ
+  · rw [key i j hij, _root_.SemistandardYoungTableau.highestWeight_apply, if_pos hij]
+  · rw [T.zeros hij, _root_.SemistandardYoungTableau.highestWeight_apply, if_neg hij]
+
+/-- The semistandard tableaux of a fixed shape and content are finite: their entries all occur in
+any one of them, so there are only finitely many values to fill the finitely many cells with. -/
+instance finite_content_eq (μ : YoungDiagram) (w : ℕ → ℕ) :
+    Finite {T : _root_.SemistandardYoungTableau μ // content T = w} := by
+  by_cases hne : Nonempty {T : _root_.SemistandardYoungTableau μ // content T = w}
+  swap
+  · rw [not_nonempty_iff] at hne
+    infer_instance
+  obtain ⟨T₀, hT₀⟩ := hne.some
+  have hmem : ∀ T : _root_.SemistandardYoungTableau μ, content T = w →
+      ∀ c ∈ μ.cells, T c.1 c.2 ∈ μ.cells.image fun d => T₀ d.1 d.2 := by
+    intro T hT c hc
+    refine (mem_image_iff_content_ne_zero T₀ _).mpr ?_
+    rw [congrFun hT₀ (T c.1 c.2), ← congrFun hT (T c.1 c.2)]
+    exact (mem_image_iff_content_ne_zero T _).mp (Finset.mem_image.mpr ⟨c, hc, rfl⟩)
+  refine Finite.of_injective
+    (fun (T : {T : _root_.SemistandardYoungTableau μ // content T = w}) (c : ↥μ.cells) =>
+      (⟨T.1 (c : ℕ × ℕ).1 (c : ℕ × ℕ).2, hmem T.1 T.2 _ c.2⟩ :
+        ↥(μ.cells.image fun d => T₀ d.1 d.2))) fun T T' hTT' => ?_
+  refine Subtype.ext (_root_.SemistandardYoungTableau.ext fun i j => ?_)
+  by_cases hij : (i, j) ∈ μ
+  · exact congrArg Subtype.val (congrFun hTT' ⟨(i, j), hij⟩)
+  · rw [T.1.zeros hij, T'.1.zeros hij]
+
+end SemistandardYoungTableau
+
+/-- The **Kostka number** `K_{μ w}`: the number of semistandard Young tableaux of shape `μ` whose
+content is `w`. -/
+noncomputable def kostkaNumber (μ : YoungDiagram) (w : ℕ → ℕ) : ℕ :=
+  Nat.card {T : _root_.SemistandardYoungTableau μ // SemistandardYoungTableau.content T = w}
+
+/-- **The diagonal Kostka number is `1`**: the maximal tableau is the only semistandard tableau of
+shape `μ` whose content is the row lengths of `μ`. -/
+@[simp]
+theorem kostkaNumber_rowLen (μ : YoungDiagram) : kostkaNumber μ μ.rowLen = 1 := by
+  rw [kostkaNumber, Nat.card_eq_one_iff_unique]
+  refine ⟨⟨fun T T' => Subtype.ext ?_⟩,
+    ⟨⟨_root_.SemistandardYoungTableau.highestWeight μ,
+      SemistandardYoungTableau.content_highestWeight μ⟩⟩⟩
+  rw [SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen T.2,
+    SemistandardYoungTableau.eq_highestWeight_of_content_eq_rowLen T'.2]
+
+/-- **The Kostka numbers are supported on the dominance order**: a nonzero Kostka number
+`K_{μ w}` forces every partial sum of `w` to be bounded by the corresponding partial sum of the
+row lengths of `μ`. -/
+theorem sum_le_sum_take_rowLens_of_kostkaNumber_ne_zero {μ : YoungDiagram} {w : ℕ → ℕ}
+    (h : kostkaNumber μ w ≠ 0) (k : ℕ) :
+    ∑ i ∈ Finset.range k, w i ≤ (μ.rowLens.take k).sum := by
+  obtain ⟨T, hT⟩ := (Nat.card_ne_zero.mp h).1
+  calc
+    ∑ i ∈ Finset.range k, w i = ∑ i ∈ Finset.range k, SemistandardYoungTableau.content T i :=
+      Finset.sum_congr rfl fun i _ => (congrFun hT i).symm
+    _ ≤ (μ.rowLens.take k).sum := SemistandardYoungTableau.sum_content_le_sum_take_rowLens T k
+
+/-- The row lengths of the Young diagram of a partition are its decreasingly sorted parts, padded
+by zeros. -/
+theorem rowLen_diagramOf {n : ℕ} (ν : n.Partition) (i : ℕ) :
+    (diagramOf ν).rowLen i = (ν.parts.sort (· ≥ ·)).getD i 0 := by
+  rw [← YoungDiagram.getD_rowLens, rowLens_diagramOf]
+
+/-- The **Kostka number of two partitions** of the same natural number: the number of semistandard
+tableaux of the shape of `μ` whose content is the row lengths of the diagram of `ν`, that is (by
+`TauCeti.rowLen_diagramOf`), the tableaux using the entry `i` exactly as often as the `i`-th
+largest part of `ν` prescribes. -/
+noncomputable def partitionKostkaNumber {n : ℕ} (μ ν : n.Partition) : ℕ :=
+  kostkaNumber (diagramOf μ) (diagramOf ν).rowLen
+
+/-- A partition contributes exactly one tableau to its own Kostka number. -/
+@[simp]
+theorem partitionKostkaNumber_self {n : ℕ} (μ : n.Partition) : partitionKostkaNumber μ μ = 1 :=
+  kostkaNumber_rowLen _
+
+/-- **The Kostka numbers are triangular for the dominance order**: `K_{μ ν} ≠ 0` forces `μ` to
+dominate `ν`. -/
+theorem dominates_of_partitionKostkaNumber_ne_zero {n : ℕ} {μ ν : n.Partition}
+    (h : partitionKostkaNumber μ ν ≠ 0) : Dominates μ ν := by
+  refine dominates_iff.mpr fun k => ?_
+  have hk := sum_le_sum_take_rowLens_of_kostkaNumber_ne_zero h k
+  rwa [YoungDiagram.sum_range_rowLen_eq_card_filter_fst,
+    ← YoungDiagram.sum_take_rowLens_eq_card_filter_fst, rowLens_diagramOf,
+    rowLens_diagramOf] at hk
+
+/-- **The Kostka numbers vanish off the dominance order**: there is no semistandard tableau of
+shape `μ` and content `ν` unless `μ` dominates `ν`. -/
+theorem partitionKostkaNumber_eq_zero_of_not_dominates {n : ℕ} {μ ν : n.Partition}
+    (h : ¬ Dominates μ ν) : partitionKostkaNumber μ ν = 0 :=
+  not_not.mp fun h' => h (dominates_of_partitionKostkaNumber_ne_zero h')
+
+end TauCeti


### PR DESCRIPTION
This PR adds the Kostka numbers to the symmetric-group and Schur-Weyl development. It defines the content (weight) of a semistandard Young tableau, defines `kostkaNumber μ w` as the number of semistandard tableaux of shape `μ` and content `w`, proves that those tableaux are finite so the count is faithful, and establishes the two facts that make the Kostka numbers a triangular array for the dominance order: the maximal tableau `SemistandardYoungTableau.highestWeight μ` is the only one of shape `μ` and content `μ.rowLen`, so `K_{μ μ} = 1`, and a tableau of shape `μ` and content `w` bounds every partial sum `∑_{i < k} w i` by the corresponding partial sum of the row lengths of `μ`, so `K_{μ ν} = 0` unless `μ` dominates `ν`.

Everything rests on one observation, `TauCeti.SemistandardYoungTableau.le_entry`: entries increase strictly down a column, so the entry in row `i` is at least `i`, and the cells carrying an entry smaller than `k` all lie in the first `k` rows. Counting that containment against the row lengths gives the dominance bound; when the two counts agree for every `k` the containment is an equality, which pins each entry to its row index and yields the uniqueness of the maximal tableau.

Roadmap target: `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 1 ("Young subgroups and the permutation modules `M^λ`"), the Kostka-number item — pinned in that roadmap's `Suggested.lean` as `kostkaNumber`, "defined combinatorially as the number of semistandard tableaux of shape `μ`-diagram and content `ν`; `kostkaNumber μ μ = 1` and `kostkaNumber μ ν = 0` unless `Dominates μ ν`". The identification with the multiplicity of `S^λ` in `M^μ` (Young's rule proper) is deferred by the roadmap to Layer 4 and is not attempted here.

Mathlib's `SemistandardYoungTableau` fills cells with natural numbers starting at `0`, so the alphabet is `0, 1, 2, …` rather than the classical `1, 2, 3, …`; that is why the content of `highestWeight μ` is `μ.rowLen` on the nose. The Kostka number is stated first for a Young diagram and an arbitrary weight function `ℕ → ℕ`, as `diagramKostkaNumber`, with `kostkaNumber` the partition-indexed specialization the roadmap pins; `rowLen_diagramOf`, in `Conjugate.lean` beside `rowLens_diagramOf`, identifies the content it prescribes with the decreasingly sorted parts of the partition.

`TauCeti/Combinatorics/Young/Diagram.lean` gains the row-counting lemmas the argument needs on both sides of the comparison: `sum_range_rowLen_eq_card_filter_fst` and `sum_take_rowLens_eq_card_filter_fst` both count the cells in the first `k` rows, the first summing over `Finset.range k` and the second truncating the list `μ.rowLens` as the dominance order does, plus `getD_rowLens` and `rowLen_eq_zero_of_colLen_le`. The `take` form already existed as a private helper inside `TauCeti/Combinatorics/Enumerative/Partition/Conjugate.lean`; it is promoted rather than duplicated, and `Conjugate.lean` now consumes the public lemma.

No Mathlib infrastructure was vendored, and no material was migrated from any external source.

Roadmap: SchurWeyl

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"kostkanumber"}-->

🤖 Prepared with Claude Code

