### PR TITLE
feat: prove first Schur orthogonality

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Compact.Intertwiner
+public import Mathlib.Analysis.InnerProductSpace.Trace
+public import Mathlib.RepresentationTheory.Irreducible
+
+/-!
+# Schur orthogonality for one irreducible compact-group representation
+
+This file proves the first Schur orthogonality relation for matrix coefficients of a
+finite-dimensional irreducible unitary representation of a compact group. Haar-averaging a
+rank-one operator produces a self-intertwiner. Schur's lemma makes that intertwiner scalar, and
+preservation of the trace determines the scalar to be the reciprocal of the dimension.
+
+The coordinate-free result is accompanied by its orthonormal-basis form. The latter fixes both the
+order of the Kronecker deltas and the placement of complex conjugation in Mathlib's convention that
+the inner product is conjugate-linear in its first argument.
+
+## Main statements
+
+* `TauCeti.ContRepresentation.exists_eq_smul_one_of_irreducible`: every continuous
+  self-intertwiner of an irreducible finite-dimensional representation over an algebraically closed
+  normed field is scalar.
+* `TauCeti.ContRepresentation.averageOperator_eq_finrank_inv_smul`: the average of a self-map is
+  its normalized trace times the identity.
+* `TauCeti.ContRepresentation.schur_orthogonality_self`: the coordinate-free first Schur
+  orthogonality relation.
+* `TauCeti.ContRepresentation.schur_orthogonality_basis`: the corresponding Kronecker-delta
+  formula in an orthonormal basis.
+
+This completes the first-orthogonality item of Layer 4 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md).
+The mathematical argument follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+open MeasureTheory
+open scoped InnerProductSpace
+open scoped MonoidAlgebra
+
+namespace TauCeti
+
+namespace ContRepresentation
+
+/-! ### Schur's lemma for continuous self-intertwiners -/
+
+section Schur
+
+variable {𝕜 G V : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] [Group G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+
+variable (π : ContRepresentation 𝕜 G V)
+
+/-- Every continuous self-intertwiner of an irreducible finite-dimensional representation over an
+algebraically closed normed field is a scalar multiple of the identity.
+
+This is Mathlib's algebraic Schur lemma
+`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`, applied after
+forgetting the continuity of the intertwiner. -/
+theorem exists_eq_smul_one_of_irreducible
+    (hirr : Representation.IsIrreducible π.toRepresentation)
+    (f : ContIntertwiningMap π π) :
+    ∃ c : 𝕜, f = c • 1 := by
+  letI : Representation.IsIrreducible π.toRepresentation := hirr
+  obtain ⟨c, hc⟩ :=
+    (Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed
+      (ρ := π.toRepresentation)).2 f.toIntertwiningMap
+  refine ⟨c, ?_⟩
+  apply ContIntertwiningMap.ext
+  ext v
+  simpa using (congrArg
+    (fun T : Representation.IntertwiningMap π.toRepresentation π.toRepresentation ↦ T v) hc).symm
+
+end Schur
+
+section CompactGroup
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] [Group G] [TopologicalSpace G]
+  [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+local instance instCompleteSpaceSchurOrthogonality : CompleteSpace V :=
+  FiniteDimensional.complete 𝕜 V
+
+variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
+
+/-! ### The scalar selected by Haar averaging -/
+
+/-- On an irreducible finite-dimensional representation, the Haar average of a self-map is its
+normalized trace times the identity.
+
+Schur's lemma first gives an unspecified scalar. Since averaging preserves the trace, that scalar
+times `finrank 𝕜 V` equals the trace of the original map; irreducibility ensures that the dimension
+is nonzero. -/
+theorem averageOperator_eq_finrank_inv_smul
+    (hirr : Representation.IsIrreducible π.toRepresentation) (T : V →L[𝕜] V) :
+    averageOperator π hπ π hπ T =
+      ((Module.finrank 𝕜 V : 𝕜)⁻¹ * LinearMap.trace 𝕜 V (T : V →ₗ[𝕜] V)) •
+        ContinuousLinearMap.id 𝕜 V := by
+  letI : Representation.IsIrreducible π.toRepresentation := hirr
+  haveI : IsSimpleModule 𝕜[G] π.toRepresentation.asModule := inferInstance
+  haveI : Nontrivial V := IsSimpleModule.nontrivial 𝕜[G] π.toRepresentation.asModule
+  obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
+    (averageIntertwiner π hπ π hπ T)
+  have hc := congrArg ContIntertwiningMap.toContinuousLinearMap hc
+  simp only [toContinuousLinearMap_averageIntertwiner,
+    ContIntertwiningMap.toContinuousLinearMap_smul,
+    ContIntertwiningMap.toContinuousLinearMap_one] at hc
+  have htrace := trace_averageOperator π hπ T
+  rw [hc] at htrace
+  have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
+    exact_mod_cast (Module.finrank_pos (R := 𝕜) (M := V)).ne'
+  have hc' : c = (Module.finrank 𝕜 V : 𝕜)⁻¹ *
+      LinearMap.trace 𝕜 V (T : V →ₗ[𝕜] V) := by
+    apply (eq_inv_mul_iff_mul_eq₀ hdim).2
+    simpa [mul_comm] using htrace
+  rw [hc, hc']
+  rfl
+
+/-! ### The first Schur orthogonality relation -/
+
+/-- **Schur orthogonality for one irreducible representation, in coordinate-free form.**
+
+For a unitary irreducible representation of dimension `d`, the `L²` inner product of the matrix
+coefficients determined by `(v₁, w₁)` and `(v₂, w₂)` is
+`d⁻¹ * conj ⟪v₁, v₂⟫ * ⟪w₁, w₂⟫`. The conjugation on the first vector factor is forced by Mathlib's
+inner-product convention. -/
+theorem schur_orthogonality_self (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation) (v₁ w₁ v₂ w₂ : V) :
+    ⟪matrixCoeffLp π hπ v₁ w₁, matrixCoeffLp π hπ v₂ w₂⟫_𝕜 =
+      (Module.finrank 𝕜 V : 𝕜)⁻¹ *
+        ((starRingEnd 𝕜) ⟪v₁, v₂⟫_𝕜 * ⟪w₁, w₂⟫_𝕜) := by
+  rw [inner_matrixCoeffLp_eq_inner_averageOperator π hπ π hπ hunitary,
+    averageOperator_eq_finrank_inv_smul π hπ hirr,
+    smul_apply, ContinuousLinearMap.id_apply, InnerProductSpace.trace_rankOne, inner_smul_right]
+  rw [← inner_conj_symm v₂ v₁]
+  ring
+
+/-- **Schur orthogonality in an orthonormal basis.** If
+`πᵢⱼ(g) = ⟪π(g)eⱼ, eᵢ⟫`, then
+`⟪πᵢⱼ, πₖₗ⟫_{L²} = d⁻¹ δⱼₗ δᵢₖ`.
+
+This is the convention check for `schur_orthogonality_self`: Kronecker deltas are real, so the
+coordinate-free conjugation becomes invisible here, while the order of all four indices remains
+explicit. -/
+theorem schur_orthogonality_basis (hunitary : IsUnitary π)
+    (hirr : Representation.IsIrreducible π.toRepresentation)
+    {d : ℕ} (e : OrthonormalBasis (Fin d) 𝕜 V) (i j k l : Fin d) :
+    ⟪matrixCoeffLp π hπ (e j) (e i), matrixCoeffLp π hπ (e l) (e k)⟫_𝕜 =
+      (d : 𝕜)⁻¹ *
+        ((if j = l then (1 : 𝕜) else 0) * (if i = k then (1 : 𝕜) else 0)) := by
+  rw [schur_orthogonality_self π hπ hunitary hirr]
+  rw [Module.finrank_eq_card_basis e.toBasis, Fintype.card_fin]
+  simp only [orthonormal_iff_ite.mp e.orthonormal]
+  split_ifs <;> simp_all
+
+end CompactGroup
+
+end ContRepresentation
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -63,11 +63,7 @@ variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
 /-! ### The scalar selected by Haar averaging -/
 
 /-- On an irreducible finite-dimensional representation, the Haar average of a self-map is its
-normalized trace times the identity.
-
-Schur's lemma first gives an unspecified scalar. Since averaging preserves the trace, that scalar
-times `finrank 𝕜 V` equals the trace of the original map; irreducibility ensures that the dimension
-is nonzero. -/
+normalized trace times the identity. -/
 theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
     (hirr : Representation.IsIrreducible π.toRepresentation) (T : V →L[𝕜] V) :
     averageOperator π hπ π hπ T =

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -44,14 +44,14 @@ namespace TauCeti
 
 namespace ContRepresentation
 
-section CompactGroup
+section Average
 
 variable {𝕜 G V : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] [Group G] [TopologicalSpace G]
   [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
-  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
   [FiniteDimensional 𝕜 V]
 
-local instance instCompleteSpaceSchurOrthogonality : CompleteSpace V :=
+local instance instCompleteSpaceSchurAverage : CompleteSpace V :=
   FiniteDimensional.complete 𝕜 V
 
 variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
@@ -71,7 +71,11 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
         ContinuousLinearMap.id 𝕜 V := by
   letI : Representation.IsIrreducible π.toRepresentation := hirr
   haveI : IsSimpleModule 𝕜[G] π.toRepresentation.asModule := inferInstance
-  haveI : Nontrivial V := IsSimpleModule.nontrivial 𝕜[G] π.toRepresentation.asModule
+  haveI : Nontrivial π.toRepresentation.asModule :=
+    IsSimpleModule.nontrivial 𝕜[G] π.toRepresentation.asModule
+  -- Nontriviality lives on the `Representation.asModule` type synonym; transport it along
+  -- `Representation.asModuleEquiv` rather than through the synonym's definitional unfolding.
+  haveI : Nontrivial V := π.toRepresentation.asModuleEquiv.symm.toEquiv.nontrivial
   obtain ⟨c, hc⟩ := exists_eq_smul_one_of_irreducible π hirr
     (averageIntertwiner π hπ π hπ T)
   have hc := congrArg ContIntertwiningMap.toContinuousLinearMap hc
@@ -87,6 +91,20 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
     apply (eq_inv_mul_iff_mul_eq₀ hdim).2
     simpa [mul_comm] using htrace
   rw [hc, hc']
+
+end Average
+
+section Orthogonality
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [IsAlgClosed 𝕜] [Group G] [TopologicalSpace G]
+  [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [NormedSpace ℝ V] [SMulCommClass ℝ 𝕜 V]
+  [FiniteDimensional 𝕜 V]
+
+local instance instCompleteSpaceSchurOrthogonality : CompleteSpace V :=
+  FiniteDimensional.complete 𝕜 V
+
+variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
 
 /-! ### The first Schur orthogonality relation -/
 
@@ -125,7 +143,7 @@ theorem schur_orthogonality_basis (hunitary : IsUnitary π)
   simp only [orthonormal_iff_ite.mp e.orthonormal]
   split_ifs <;> simp_all
 
-end CompactGroup
+end Orthogonality
 
 end ContRepresentation
 

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.RepresentationTheory.Compact.Intertwiner
+public import TauCeti.RepresentationTheory.Continuous.Schur
 public import Mathlib.Analysis.InnerProductSpace.Trace
-public import Mathlib.RepresentationTheory.Irreducible
 
 /-!
 # Schur orthogonality for one irreducible compact-group representation
@@ -22,11 +22,8 @@ the inner product is conjugate-linear in its first argument.
 
 ## Main statements
 
-* `TauCeti.ContRepresentation.exists_eq_smul_one_of_irreducible`: every continuous
-  self-intertwiner of an irreducible finite-dimensional representation over an algebraically closed
-  normed field is scalar.
-* `TauCeti.ContRepresentation.averageOperator_eq_finrank_inv_smul`: the average of a self-map is
-  its normalized trace times the identity.
+* `TauCeti.ContRepresentation.averageOperator_eq_finrank_inv_mul_trace_smul_id`: the average of a
+  self-map is its normalized trace times the identity.
 * `TauCeti.ContRepresentation.schur_orthogonality_self`: the coordinate-free first Schur
   orthogonality relation.
 * `TauCeti.ContRepresentation.schur_orthogonality_basis`: the corresponding Kronecker-delta
@@ -46,37 +43,6 @@ open scoped MonoidAlgebra
 namespace TauCeti
 
 namespace ContRepresentation
-
-/-! ### Schur's lemma for continuous self-intertwiners -/
-
-section Schur
-
-variable {𝕜 G V : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] [Group G]
-  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
-
-variable (π : ContRepresentation 𝕜 G V)
-
-/-- Every continuous self-intertwiner of an irreducible finite-dimensional representation over an
-algebraically closed normed field is a scalar multiple of the identity.
-
-This is Mathlib's algebraic Schur lemma
-`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`, applied after
-forgetting the continuity of the intertwiner. -/
-theorem exists_eq_smul_one_of_irreducible
-    (hirr : Representation.IsIrreducible π.toRepresentation)
-    (f : ContIntertwiningMap π π) :
-    ∃ c : 𝕜, f = c • 1 := by
-  letI : Representation.IsIrreducible π.toRepresentation := hirr
-  obtain ⟨c, hc⟩ :=
-    (Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed
-      (ρ := π.toRepresentation)).2 f.toIntertwiningMap
-  refine ⟨c, ?_⟩
-  apply ContIntertwiningMap.ext
-  ext v
-  simpa using (congrArg
-    (fun T : Representation.IntertwiningMap π.toRepresentation π.toRepresentation ↦ T v) hc).symm
-
-end Schur
 
 section CompactGroup
 
@@ -98,7 +64,7 @@ normalized trace times the identity.
 Schur's lemma first gives an unspecified scalar. Since averaging preserves the trace, that scalar
 times `finrank 𝕜 V` equals the trace of the original map; irreducibility ensures that the dimension
 is nonzero. -/
-theorem averageOperator_eq_finrank_inv_smul
+theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
     (hirr : Representation.IsIrreducible π.toRepresentation) (T : V →L[𝕜] V) :
     averageOperator π hπ π hπ T =
       ((Module.finrank 𝕜 V : 𝕜)⁻¹ * LinearMap.trace 𝕜 V (T : V →ₗ[𝕜] V)) •
@@ -137,7 +103,7 @@ theorem schur_orthogonality_self (hunitary : IsUnitary π)
       (Module.finrank 𝕜 V : 𝕜)⁻¹ *
         ((starRingEnd 𝕜) ⟪v₁, v₂⟫_𝕜 * ⟪w₁, w₂⟫_𝕜) := by
   rw [inner_matrixCoeffLp_eq_inner_averageOperator π hπ π hπ hunitary,
-    averageOperator_eq_finrank_inv_smul π hπ hirr,
+    averageOperator_eq_finrank_inv_mul_trace_smul_id π hπ hirr,
     smul_apply, ContinuousLinearMap.id_apply, InnerProductSpace.trace_rankOne, inner_smul_right]
   rw [← inner_conj_symm v₂ v₁]
   ring

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -77,7 +77,7 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
   have hc := congrArg ContIntertwiningMap.toContinuousLinearMap hc
   simp only [toContinuousLinearMap_averageIntertwiner,
     ContIntertwiningMap.toContinuousLinearMap_smul,
-    ContIntertwiningMap.toContinuousLinearMap_one] at hc
+    ContIntertwiningMap.toContinuousLinearMap_one, ContinuousLinearMap.one_def] at hc
   have htrace := trace_averageOperator π hπ T
   rw [hc] at htrace
   have hdim : (Module.finrank 𝕜 V : 𝕜) ≠ 0 := by
@@ -87,7 +87,6 @@ theorem averageOperator_eq_finrank_inv_mul_trace_smul_id
     apply (eq_inv_mul_iff_mul_eq₀ hdim).2
     simpa [mul_comm] using htrace
   rw [hc, hc']
-  rfl
 
 /-! ### The first Schur orthogonality relation -/
 

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -29,8 +29,12 @@ the inner product is conjugate-linear in its first argument.
 * `TauCeti.ContRepresentation.schur_orthogonality_basis`: the corresponding Kronecker-delta
   formula in an orthonormal basis.
 
-This completes the first-orthogonality item of Layer 4 of the
-[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md).
+This supplies the two formulas pinned by the first-orthogonality item of Layer 4 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md);
+that item's remaining request, checking the convention against `fourierBasis` on `AddCircle`, waits
+on the `AddCircle` material and is not done here. The roadmap sketches the basis identity as the
+primitive one; here the coordinate-free statement is the primitive and the basis identity is read
+off from it, which is the shorter route and fixes the same convention.
 The mathematical argument follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
 -/
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -40,11 +40,7 @@ variable {𝕜 G V : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] [M
 variable (π : ContRepresentation 𝕜 G V)
 
 /-- Every continuous self-intertwiner of an irreducible finite-dimensional representation over an
-algebraically closed normed field is a scalar multiple of the identity.
-
-This is Mathlib's algebraic Schur lemma
-`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`, applied after
-forgetting the continuity of the intertwiner. -/
+algebraically closed normed field is a scalar multiple of the identity. -/
 theorem exists_eq_smul_one_of_irreducible
     (hirr : Representation.IsIrreducible π.toRepresentation)
     (f : ContIntertwiningMap π π) :
@@ -53,11 +49,15 @@ theorem exists_eq_smul_one_of_irreducible
   obtain ⟨c, hc⟩ :=
     (Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed
       (ρ := π.toRepresentation)).2 f.toIntertwiningMap
-  refine ⟨c, ?_⟩
-  apply ContIntertwiningMap.ext
-  ext v
-  simpa using (congrArg
-    (fun T : Representation.IntertwiningMap π.toRepresentation π.toRepresentation ↦ T v) hc).symm
+  refine ⟨c, ContIntertwiningMap.toIntertwiningMap_injective ?_⟩
+  -- Forgetting continuity is compatible with scalar multiplication and with the identity, so it
+  -- sends the scalar continuous intertwiner `c • 1` to the algebra map's value at `c`.
+  have hsmul : (c • (1 : ContIntertwiningMap π π)).toIntertwiningMap
+      = c • (1 : ContIntertwiningMap π π).toIntertwiningMap := rfl
+  have hone : (1 : ContIntertwiningMap π π).toIntertwiningMap
+      = (1 : Representation.IntertwiningMap π.toRepresentation π.toRepresentation) := rfl
+  simp only [hsmul, hone]
+  rw [← Algebra.algebraMap_eq_smul_one, hc]
 
 end ContRepresentation
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Basic
+public import Mathlib.RepresentationTheory.Continuous.Basic
+public import Mathlib.RepresentationTheory.Irreducible
+
+/-!
+# Schur's lemma for continuous self-intertwiners
+
+Over an algebraically closed field, every self-intertwiner of a finite-dimensional irreducible
+representation is scalar. This file records that statement for Mathlib's bundled continuous
+intertwining maps, which is the form the analytic theory uses.
+
+No topology on the acting monoid and no invariant measure are involved: the proof forgets the
+continuity of the intertwiner and applies Mathlib's algebraic Schur lemma
+`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`.
+
+## Main statements
+
+* `TauCeti.ContRepresentation.exists_eq_smul_one_of_irreducible`: every continuous self-intertwiner
+  of an irreducible finite-dimensional representation over an algebraically closed normed field is
+  scalar.
+
+The mathematical argument follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace ContRepresentation
+
+variable {𝕜 G V : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] [Monoid G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+
+variable (π : ContRepresentation 𝕜 G V)
+
+/-- Every continuous self-intertwiner of an irreducible finite-dimensional representation over an
+algebraically closed normed field is a scalar multiple of the identity.
+
+This is Mathlib's algebraic Schur lemma
+`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`, applied after
+forgetting the continuity of the intertwiner. -/
+theorem exists_eq_smul_one_of_irreducible
+    (hirr : Representation.IsIrreducible π.toRepresentation)
+    (f : ContIntertwiningMap π π) :
+    ∃ c : 𝕜, f = c • 1 := by
+  letI : Representation.IsIrreducible π.toRepresentation := hirr
+  obtain ⟨c, hc⟩ :=
+    (Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed
+      (ρ := π.toRepresentation)).2 f.toIntertwiningMap
+  refine ⟨c, ?_⟩
+  apply ContIntertwiningMap.ext
+  ext v
+  simpa using (congrArg
+    (fun T : Representation.IntertwiningMap π.toRepresentation π.toRepresentation ↦ T v) hc).symm
+
+end ContRepresentation
+
+end TauCeti


### PR DESCRIPTION
This PR proves the first Schur orthogonality relation for matrix coefficients of one finite-dimensional irreducible unitary representation of a compact group. Haar-average a rank-one operator into a self-intertwiner, use Schur's lemma to make the average scalar, and use preservation of trace to identify that scalar as the reciprocal dimension. The resulting coordinate-free formula places conjugation on the first vector factor in Mathlib's convention, and the orthonormal-basis corollary records the corresponding Kronecker-delta indices.

Add `TauCeti/RepresentationTheory/Continuous/Schur.lean`, holding the reusable bundled Schur statement `exists_eq_smul_one_of_irreducible` for a monoid acting over any algebraically closed normed field, and `TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean`, which proves `averageOperator_eq_finrank_inv_mul_trace_smul_id`, `schur_orthogonality_self`, and `schur_orthogonality_basis` over an algebraically closed `RCLike` field. Irreducibility rules out dimension zero, including the degenerate zero-space edge case.

This implements `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`, Layer 4, “First orthogonality (fixed irreducible),” specifically the fixed-irrep coordinate-free and orthonormal-basis formulas pinned as `schur_orthogonality_self` and `schur_orthogonality_basis`. It is the lowest-hanging uncovered target because the preceding Haar averaging, trace preservation, rank-one matrix-entry identity, and distinct-representation orthogonality already live on `main` in `Compact/Intertwiner.lean`; this PR supplies the missing scalar-Schur and normalized-trace step rather than adding peripheral infrastructure. No open PR covers this target. The target's own proof route in the roadmap, averaging a rank-one operator into a self-intertwiner and reading off the scalar from the trace, uses Layer 0's Haar averaging, Layer 1's unitarity, and Layer 3's `matrixCoeffLp`, all of which are on `main`; it uses neither Layer 2's complete reducibility nor Layer 3's representative `StarSubalgebra`, and neither is in this file's import closure. `Continuous/Schur.lean` here also supplies Layer 2's own “Schur's lemma, transported” bullet.

No Mathlib infrastructure is vendored, and no material is taken from the supplementary source snapshot. The proof directly reuses Mathlib's `Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`, `InnerProductSpace.trace_rankOne`, the finite-dimensional and orthonormal-basis APIs, and Tau Ceti's landed `trace_averageOperator` and `inner_matrixCoeffLp_eq_inner_averageOperator`. The mathematical argument follows Daniel Bump, *Lie Groups*, second edition, Chapter 2, as cited in the module docstring.

`lake exe cache get` completes with `Already decompressed 8677 file(s)` and the existing one-file cache warning. `lake build` reports `Build completed successfully (6148 jobs).` `lake exe axioms` reports `axioms: audited 18793 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: CompactGroups

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"schur-orthogonality-self"}-->

🤖 Prepared with Codex

