### PR TITLE
feat: identify the hyperbolic balls of the Poincaré disc as Euclidean discs

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -47,7 +47,7 @@ the left side is negative, zero or positive exactly when `‖z - c‖` is less t
 greater than the radius, which is the whole content: the pseudo-hyperbolic condition
 `‖z - a‖ < t * ‖1 - conj a * z‖` is a Euclidean disc.
 
-Two features of the statement are worth noting. First, the identity — and hence the description
+Three features of the statement are worth noting. First, the identity — and hence the description
 of the sublevel set of `‖z - a‖ - t * ‖1 - conj a * z‖` — needs no hypothesis on `z` at all; it is
 only the passage to the *quotient* `p (z, a)` that requires `z` in the disc, so that the Moebius
 denominator does not vanish. Second, the resulting Euclidean disc automatically lies inside the
@@ -55,6 +55,12 @@ unit disc: `‖c‖ + s < 1` because
 `1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / D`
 (`TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`). So the restriction to
 the disc in the set equalities is a genuine description of a subset of `𝔻`, not an artefact.
+Third, the endpoint `t = 1` is allowed wherever it is true: the denominator `D` stays positive, and
+`c = 0`, `s = 1`, so the descriptions of the *open* ball
+(`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
+`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`) degenerate to the statement that `p (·, a) < 1`
+cuts out all of `𝔻`. Only the closed disc and the circle need `t < 1`: at `t = 1` they would
+contain the unit circle, which the pseudo-hyperbolic conditions never reach.
 
 The Euclidean centre `c` is *not* `a` unless `a = 0` or `t = 0`: a hyperbolic ball is a Euclidean
 disc, but an off-centre one, its Euclidean centre pulled towards the origin by the factor
@@ -96,8 +102,9 @@ analogue in a general normed space.
 
 * `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` — the Apollonius identity the file runs
   on.
-* `TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one` and
-  `TauCeti.closedBall_pseudoHyperbolicCenter_subset_ball` — the Euclidean disc lies inside `𝔻`.
+* `TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`,
+  `TauCeti.closedBall_pseudoHyperbolicCenter_subset_ball` and
+  `TauCeti.ball_pseudoHyperbolicCenter_subset_ball` — the Euclidean disc lies inside `𝔻`.
 * `TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
   `TauCeti.pseudoHyperbolicExpr_le_iff_mem_closedBall` and
   `TauCeti.pseudoHyperbolicExpr_eq_iff_mem_sphere` — the pointwise form.
@@ -119,8 +126,23 @@ metric. As with the rest of the L0–L3 conformal-mapping material it is coordin
 upstream Mathlib Riemann mapping effort leanprover-community/mathlib4#33505, which contains the
 preceding human-curated work along with `Analysis/Complex/RiemannMapping.lean` and
 `Analysis/Complex/BranchLogRoot.lean`; none of that material describes the hyperbolic metric on
-the disc, and Mathlib's `Analysis/Complex/UpperHalfPlane` hyperbolic metric carries no ball
-description of this kind, so nothing here duplicates it.
+the disc.
+
+The closest formal precedent anywhere is Mathlib's *upper half-plane* model,
+`Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean`, which does carry the analogous ball
+description, and whose API shape the development below follows: `UpperHalfPlane.center z r` is
+the Euclidean centre of the hyperbolic ball of centre `z` and radius `r`,
+`UpperHalfPlane.cmp_dist_eq_cmp_dist_coe_center` and its consequences
+`UpperHalfPlane.dist_lt_iff_dist_coe_center_lt`,
+`UpperHalfPlane.dist_le_iff_dist_coe_center_le` and
+`UpperHalfPlane.dist_eq_iff_dist_coe_center_eq` are the pointwise comparisons, and
+`UpperHalfPlane.image_coe_ball`, `UpperHalfPlane.image_coe_closedBall` and
+`UpperHalfPlane.image_coe_sphere` are the set-level identifications. What is supplied here is the
+disc-model counterpart: the two models are conformally but not Euclidean-equivalent, so the
+formulas differ (`z.im * Real.cosh r` and `z.im * Real.sinh r` on `ℍ`, against
+`TauCeti.pseudoHyperbolicCenter` and `TauCeti.pseudoHyperbolicRadius` here), and Mathlib has no
+metric on `𝔻` to state them about. Nothing here duplicates that file; the parallel is one of
+shape, and it is what fixes the shape of the API below.
 
 ## References
 
@@ -247,6 +269,22 @@ lemma closedBall_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 
     simpa [dist_eq_norm, add_comm] using
       norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one ha ht₀ ht₁
 
+/-- The open Euclidean disc describing a pseudo-hyperbolic ball is contained in the open unit
+disc. Unlike `TauCeti.closedBall_pseudoHyperbolicCenter_subset_ball` this survives the endpoint
+`t = 1`, where the Euclidean centre is `0`, the Euclidean radius is `1` and the two open discs are
+equal. -/
+lemma ball_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) ⊆ ball (0 : ℂ) 1 := by
+  rcases ht₁.lt_or_eq with ht | ht
+  · exact ball_subset_closedBall.trans (closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht)
+  · subst ht
+    have hne : 1 - ‖a‖ ^ 2 ≠ 0 := by nlinarith [norm_nonneg a]
+    have hc : pseudoHyperbolicCenter a 1 = 0 := by simp [pseudoHyperbolicCenter_def]
+    have hs : pseudoHyperbolicRadius a 1 = 1 := by
+      rw [pseudoHyperbolicRadius_def, one_pow, one_mul, one_mul, div_self hne]
+    intro w hw
+    rwa [hc, hs] at hw
+
 /-! ### The Apollonius identity -/
 
 /-- **The Apollonius identity for the Moebius factor.** For every `z : ℂ`,
@@ -297,41 +335,45 @@ theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
 Clearing the Moebius denominator — legitimate because `z` and `a` lie in the disc — turns the
 left-hand condition into `‖z - a‖ < t * ‖1 - conj a * z‖`, and squaring both sides makes
 `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` applicable; the factor
-`1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive, so it does not affect the sign. -/
+`1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive, so it does not affect the sign.
+
+The endpoint `t = 1` is allowed, and there both sides say that `z` lies in the unit disc. -/
 theorem pseudoHyperbolicExpr_lt_iff_mem_ball (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a < t ↔
       z ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_lt_iff₀ hdenpos, mem_ball, dist_eq_norm,
     ← sq_lt_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁.le), mul_pow]
+    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The closed pseudo-hyperbolic ball is a closed Euclidean disc**, the `≤` companion of
-`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof. -/
+`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof, and like it valid up to the
+endpoint `t = 1`, where the closed Euclidean disc is the closed unit disc. -/
 theorem pseudoHyperbolicExpr_le_iff_mem_closedBall (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a ≤ t ↔
       z ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_le_iff₀ hdenpos, mem_closedBall, dist_eq_norm,
     ← sq_le_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁.le), mul_pow]
+    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The pseudo-hyperbolic circle is a Euclidean circle.** A point `z` of the unit disc satisfies
 `pseudoHyperbolicExpr z a = t` exactly when it lies on the Euclidean circle of centre
 `TauCeti.pseudoHyperbolicCenter a t` and radius `TauCeti.pseudoHyperbolicRadius a t`: the level
-set is what the closed disc has and the open one has not. -/
+set is what the closed disc has and the open one has not. The endpoint `t = 1` is allowed, and
+there both sides are empty. -/
 theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a = t ↔
       z ∈ sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   have hle := pseudoHyperbolicExpr_le_iff_mem_closedBall ha hz ht₀ ht₁
@@ -346,19 +388,20 @@ theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ 
 
 /-- The hyperbolic centre of a ball of positive radius lies in the Euclidean disc describing it —
 off centre, but inside. -/
-theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t < 1) :
+theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t ≤ 1) :
     a ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
   (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha ht₀.le ht₁).1 (by simpa using ht₀)
 
-/-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. -/
-theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+/-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. The endpoint
+`t = 1` is allowed, and there both sides are the unit disc. -/
+theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a < t}
       = ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   ext w
   simp only [mem_ball_zero_iff]
   refine ⟨fun h => (pseudoHyperbolicExpr_lt_iff_mem_ball ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
-  have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
-    ha ht₀ ht₁ (ball_subset_closedBall h)
+  have hw : ‖w‖ < 1 :=
+    mem_ball_zero_iff.1 <| ball_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ h
   exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 h⟩
 
 /-- **A closed pseudo-hyperbolic ball of the unit disc is a closed Euclidean disc**, in set
@@ -369,10 +412,11 @@ theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀
       = closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   ext w
   simp only [mem_ball_zero_iff]
-  refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 ht₀ ht₁.le).1 h.2,
+    fun h => ?_⟩
   have hw : ‖w‖ < 1 :=
     mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ h
-  exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).2 h⟩
+  exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁.le).2 h⟩
 
 /-- **A pseudo-hyperbolic circle of the unit disc is a Euclidean circle**: the level set is the
 difference of the closed and the open disc. -/
@@ -381,10 +425,10 @@ theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : 0
       = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   ext w
   simp only [mem_ball_zero_iff]
-  refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 ht₀ ht₁.le).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
     ha ht₀ ht₁ (sphere_subset_closedBall h)
-  exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw ht₀ ht₁).2 h⟩
+  exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw ht₀ ht₁.le).2 h⟩
 
 /-! ### Hyperbolic balls -/
 
@@ -454,7 +498,8 @@ theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
   · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_tanh_neg ha hR).le]
     exact eq_empty_of_forall_notMem fun w hw =>
       absurd (hw.2.trans hR) (not_lt.2 (hyperbolicDist_nonneg w a))
-  · rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R)]
+  · rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg_iff.2 hR)
+      (Real.tanh_lt_one R).le]
     ext w
     simp only [mem_ball_zero_iff]
     exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
@@ -524,7 +569,7 @@ theorem mem_ball_iff (x w : PoincareDisc) :
     exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
       (toUnitDisc w).norm_lt_one).trans
       (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
-        (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
+        (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
 
 /-- **The closed balls of the Poincaré metric space, read on the Euclidean disc**, the `≤`
 companion of `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -541,7 +586,7 @@ theorem mem_closedBall_iff (x w : PoincareDisc) :
     exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
       (toUnitDisc w).norm_lt_one).trans
       (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
-        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
+        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
 
 /-- **The spheres of the Poincaré metric space, read on the Euclidean disc**, the `=` companion of
 `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -558,7 +603,7 @@ theorem mem_sphere_iff (x w : PoincareDisc) :
     exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
       (toUnitDisc w).norm_lt_one).trans
       (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
-        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
+        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
 
 end PoincareDisc
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -444,9 +444,9 @@ radius `pseudoHyperbolicRadius a (Real.tanh R)`; for `R < 0` both sides are empt
 radius being negative.
 
 The Euclidean centre is `a` only for `a = 0` or `R = 0`; for `a ≠ 0` the hyperbolic ball is an
-off-centre Euclidean disc, pulled towards the origin. Specialising to `a = 0` recovers
-`TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh` of `Poincare/Topology.lean`, where the
-Euclidean centre is the origin and the Euclidean radius is `Real.tanh R`. -/
+off-centre Euclidean disc, pulled towards the origin. For `a = 0` the Euclidean centre is the
+origin and the Euclidean radius is `Real.tanh R`
+(`TauCeti.pseudoHyperbolicCenter_zero_left`, `TauCeti.pseudoHyperbolicRadius_zero_left`). -/
 theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R}
       = ball (pseudoHyperbolicCenter a (Real.tanh R)) (pseudoHyperbolicRadius a (Real.tanh R)) := by
@@ -460,7 +460,11 @@ theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
     exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
 
 /-- **A closed hyperbolic ball of the Poincaré disc is a closed Euclidean disc**, the `≤`
-companion of `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`. -/
+companion of `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`.
+
+Specialising to `a = 0` recovers `TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh` of
+`Poincare/Topology.lean`: the Euclidean centre is then the origin and the Euclidean radius is
+`Real.tanh R`. -/
 theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a ≤ R}
       = closedBall (pseudoHyperbolicCenter a (Real.tanh R))

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -14,8 +14,9 @@ The hyperbolic (Poincaré) metric `TauCeti.hyperbolicDist` on the open unit disc
 `Real.artanh` of the pseudo-hyperbolic expression
 `p (z, a) = ‖(z - a) / (1 - conj a * z)‖`, and both are visibly non-Euclidean: the metric blows
 up at the boundary circle, and `p` is a Moebius quotient rather than a norm. Nevertheless the
-*balls* of the two metrics are the same sets. This file proves that, with the centre and radius
-computed explicitly.
+hyperbolic ball of radius `R` is the pseudo-hyperbolic ball of radius `Real.tanh R`, and every
+pseudo-hyperbolic ball of radius `t ∈ [0, 1)` is a Euclidean disc. This file proves that, with the
+centre and radius computed explicitly.
 
 Fix `a` in the disc and a pseudo-hyperbolic radius `t ∈ [0, 1)`. Writing
 `D = 1 - t ^ 2 * ‖a‖ ^ 2`, which is positive, put
@@ -39,9 +40,9 @@ Everything comes from a single algebraic identity between real quadratics
 > `‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2`
 > `  = D * (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2)`,
 
-valid for every `z : ℂ` as soon as `D ≠ 0`. Expanding both norms as
-`‖w‖ ^ 2 = w.re ^ 2 + w.im ^ 2` turns each side into a real polynomial in
-`a.re, a.im, z.re, z.im, t`, and the two agree after clearing the denominator `D`. Since `D > 0`,
+valid for every `z : ℂ` as soon as `D ≠ 0`. Expanding the three norms with `Complex.normSq_sub`
+turns each side into a real polynomial in `‖z‖`, `‖a‖`, `(z * conj a).re` and `t`, and the two
+agree after clearing the denominator `D`. Since `D > 0`,
 the left side is negative, zero or positive exactly when `‖z - c‖` is less than, equal to or
 greater than the radius, which is the whole content: the pseudo-hyperbolic condition
 `‖z - a‖ < t * ‖1 - conj a * z‖` is a Euclidean disc.
@@ -95,17 +96,20 @@ analogue in a general normed space.
   on.
 * `TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one` and
   `TauCeti.closedBall_pseudoHyperbolicCenter_subset_ball` — the Euclidean disc lies inside `𝔻`.
-* `TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` and
-  `TauCeti.pseudoHyperbolicExpr_le_iff_mem_closedBall` — the pointwise form.
+* `TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
+  `TauCeti.pseudoHyperbolicExpr_le_iff_mem_closedBall` and
+  `TauCeti.pseudoHyperbolicExpr_eq_iff_mem_sphere` — the pointwise form.
 * `TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`,
   `TauCeti.sep_ball_pseudoHyperbolicExpr_le_eq_closedBall` and
   `TauCeti.sep_ball_pseudoHyperbolicExpr_eq_eq_sphere` — pseudo-hyperbolic balls, closed balls and
   circles are Euclidean ones.
-* `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball` and
-  `TauCeti.sep_ball_hyperbolicDist_le_eq_closedBall` — the same for the hyperbolic metric, with
+* `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`,
+  `TauCeti.sep_ball_hyperbolicDist_le_eq_closedBall` and
+  `TauCeti.sep_ball_hyperbolicDist_eq_eq_sphere` — the same for the hyperbolic metric, with
   `t = Real.tanh R`.
-* `TauCeti.PoincareDisc.mem_ball_iff` — the balls of the Poincaré metric space, read on the
-  Euclidean disc.
+* `TauCeti.PoincareDisc.mem_ball_iff`, `TauCeti.PoincareDisc.mem_closedBall_iff` and
+  `TauCeti.PoincareDisc.mem_sphere_iff` — the balls, closed balls and spheres of the Poincaré
+  metric space, read on the Euclidean disc.
 
 This carries the conformal-mapping roadmap's L2 target "the hyperbolic / Poincaré metric on `𝔻`"
 (see `ConformalMapping/README.md`) onto its metric geometry, completing the basic ball API of that
@@ -137,20 +141,20 @@ variable {a z : ℂ} {t R : ℝ}
 /-- The Euclidean centre of the pseudo-hyperbolic ball of centre `a` and radius `t`: the
 hyperbolic centre `a` pulled towards the origin by the factor
 `(1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)`. -/
-@[expose] noncomputable def pseudoHyperbolicCenter (a : ℂ) (t : ℝ) : ℂ :=
+noncomputable def pseudoHyperbolicCenter (a : ℂ) (t : ℝ) : ℂ :=
   ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a
 
 /-- The Euclidean radius of the pseudo-hyperbolic ball of centre `a` and radius `t`. -/
-@[expose] noncomputable def pseudoHyperbolicRadius (a : ℂ) (t : ℝ) : ℝ :=
+noncomputable def pseudoHyperbolicRadius (a : ℂ) (t : ℝ) : ℝ :=
   t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)
 
 /-- The defining formula for `TauCeti.pseudoHyperbolicCenter`. -/
 lemma pseudoHyperbolicCenter_def (a : ℂ) (t : ℝ) :
-    pseudoHyperbolicCenter a t = ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a := rfl
+    pseudoHyperbolicCenter a t = ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a := (rfl)
 
 /-- The defining formula for `TauCeti.pseudoHyperbolicRadius`. -/
 lemma pseudoHyperbolicRadius_def (a : ℂ) (t : ℝ) :
-    pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := rfl
+    pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := (rfl)
 
 /-- Balls centred at the origin are unmoved: the Euclidean centre of a pseudo-hyperbolic ball
 about `0` is `0`. -/
@@ -198,6 +202,18 @@ lemma pseudoHyperbolicRadius_pos (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t �
   have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
   exact div_pos (mul_pos ht₀ (by linarith))
     (one_sub_sq_mul_sq_norm_pos ha ht₀.le ht₁)
+
+/-- A negative pseudo-hyperbolic radius `t ∈ (-1, 0)` gives a negative Euclidean radius, so that
+the Euclidean disc it describes is empty — as is the pseudo-hyperbolic ball of radius `t`. -/
+lemma pseudoHyperbolicRadius_neg (ha : ‖a‖ < 1) (ht₀ : -1 < t) (ht₁ : t < 0) :
+    pseudoHyperbolicRadius a t < 0 := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := by
+    nlinarith [mul_nonneg (sq_nonneg t) (by linarith : (0 : ℝ) ≤ 1 - ‖a‖ ^ 2),
+      mul_pos (by linarith : (0 : ℝ) < 1 - t) (by linarith : (0 : ℝ) < 1 + t)]
+  rw [pseudoHyperbolicRadius_def]
+  exact div_neg_of_neg_of_pos (mul_neg_of_neg_of_pos ht₁ (by linarith)) hD
 
 /-! ### The Euclidean disc lies inside the unit disc -/
 
@@ -250,22 +266,23 @@ theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
     ‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2
       = (1 - t ^ 2 * ‖a‖ ^ 2) *
         (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2) := by
+  have hre : (a * conj z).re = (z * conj a).re := by
+    rw [← Complex.conj_re (a * conj z), map_mul, Complex.conj_conj, mul_comm]
   have hshift : ∀ k : ℝ, ‖z - k • a‖ ^ 2
-      = ‖z‖ ^ 2 - 2 * k * (z.re * a.re + z.im * a.im) + k ^ 2 * ‖a‖ ^ 2 := by
+      = ‖z‖ ^ 2 - 2 * k * (z * conj a).re + k ^ 2 * ‖a‖ ^ 2 := by
     intro k
-    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im,
-      Complex.real_smul, Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im]
+    have hk : (k • a : ℂ) = (k : ℂ) * a := Complex.real_smul
+    simp only [← Complex.normSq_eq_norm_sq, hk, Complex.normSq_sub,
+      Complex.normSq_ofReal, map_mul, Complex.conj_ofReal, mul_left_comm z (k : ℂ) (conj a),
+      Complex.re_ofReal_mul]
     ring
   have hsub : ‖z - a‖ ^ 2
-      = ‖z‖ ^ 2 - 2 * (z.re * a.re + z.im * a.im) + ‖a‖ ^ 2 := by
-    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im]
-    ring
+      = ‖z‖ ^ 2 + ‖a‖ ^ 2 - 2 * (z * conj a).re := by
+    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_sub]
   have hmoebius : ‖1 - conj a * z‖ ^ 2
-      = 1 - 2 * (z.re * a.re + z.im * a.im) + ‖a‖ ^ 2 * ‖z‖ ^ 2 := by
-    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im,
-      Complex.mul_re, Complex.mul_im, Complex.one_re, Complex.one_im, Complex.conj_re,
-      Complex.conj_im]
-    ring
+      = 1 + ‖a‖ ^ 2 * ‖z‖ ^ 2 - 2 * (z * conj a).re := by
+    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_sub, Complex.normSq_one,
+      Complex.normSq_conj, map_mul, Complex.conj_conj, one_mul, hre]
   rw [pseudoHyperbolicCenter_def, pseudoHyperbolicRadius_def, hshift, hsub, hmoebius]
   obtain ⟨D, hDdef⟩ : ∃ D : ℝ, D = 1 - t ^ 2 * ‖a‖ ^ 2 := ⟨_, rfl⟩
   rw [← hDdef] at hD ⊢
@@ -311,6 +328,24 @@ theorem pseudoHyperbolicExpr_le_iff_mem_closedBall (ha : ‖a‖ < 1) (hz : ‖z
     ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁.le), mul_pow]
   constructor <;> intro h <;> nlinarith
 
+/-- **The pseudo-hyperbolic circle is a Euclidean circle.** A point `z` of the unit disc satisfies
+`pseudoHyperbolicExpr z a = t` exactly when it lies on the Euclidean circle of centre
+`TauCeti.pseudoHyperbolicCenter a t` and radius `TauCeti.pseudoHyperbolicRadius a t`: the level
+set is what the closed disc has and the open one has not. -/
+theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
+    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    pseudoHyperbolicExpr z a = t ↔
+      z ∈ sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hle := pseudoHyperbolicExpr_le_iff_mem_closedBall ha hz ht₀ ht₁
+  have hlt := pseudoHyperbolicExpr_lt_iff_mem_ball ha hz ht₀ ht₁
+  rw [mem_closedBall] at hle
+  rw [mem_ball] at hlt
+  rw [mem_sphere]
+  refine ⟨fun h => le_antisymm (hle.1 h.le) (not_lt.1 fun hd => ?_),
+    fun h => le_antisymm (hle.2 h.le) (not_lt.1 fun hp => ?_)⟩
+  · exact absurd (hlt.2 hd) (by rw [h]; exact lt_irrefl t)
+  · exact absurd (hlt.1 hp) (by rw [h]; exact lt_irrefl _)
+
 /-- The hyperbolic centre of a ball of positive radius lies in the Euclidean disc describing it —
 off centre, but inside. -/
 theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t < 1) :
@@ -347,40 +382,29 @@ theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : 0
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a = t}
       = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   ext w
-  constructor
-  · rintro ⟨hw, heq⟩
-    rw [mem_ball_zero_iff] at hw
-    have hle := (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).1 heq.le
-    have hnlt : ¬ dist w (pseudoHyperbolicCenter a t) < pseudoHyperbolicRadius a t := fun hd => by
-      have := (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 (mem_ball.2 hd)
-      rw [heq] at this
-      exact lt_irrefl t this
-    exact mem_sphere.2 (le_antisymm (mem_closedBall.1 hle) (not_lt.1 hnlt))
-  · intro h
-    rw [mem_sphere] at h
-    have hle : w ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
-      mem_closedBall.2 h.le
-    have hw : ‖w‖ < 1 := mem_ball_zero_iff.1
-      (closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ hle)
-    refine ⟨mem_ball_zero_iff.2 hw,
-      le_antisymm ((pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).2 hle) ?_⟩
-    by_contra hlt
-    have hb := (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).1 (not_le.1 hlt)
-    rw [mem_ball, h] at hb
-    exact lt_irrefl _ hb
+  simp only [mem_ball_zero_iff]
+  refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
+    ha ht₀ ht₁ (sphere_subset_closedBall h)
+  exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw ht₀ ht₁).2 h⟩
 
 /-! ### Hyperbolic balls -/
 
-/-- `Real.tanh` is nonnegative on the nonnegative reals, so a hyperbolic radius `R ≥ 0`
-corresponds to a pseudo-hyperbolic radius `Real.tanh R ∈ [0, 1)`. -/
-lemma tanh_nonneg (hR : 0 ≤ R) : 0 ≤ Real.tanh R := by
-  by_contra h
-  have hneg : Real.tanh R < 0 := not_le.1 h
-  have hle : R ≤ 0 := by
-    have := Real.artanh_nonpos hneg.le
-    rwa [Real.artanh_tanh] at this
-  rw [le_antisymm hle hR, Real.tanh_zero] at hneg
-  exact lt_irrefl 0 hneg
+/-- `Real.tanh` is nonnegative exactly on the nonnegative reals, so a hyperbolic radius `R ≥ 0`
+corresponds to a pseudo-hyperbolic radius `Real.tanh R ∈ [0, 1)` and a negative one to a negative
+`Real.tanh R`. This reads off the sign of `Real.tanh` from its exponential form; it is a local
+helper, not part of the API of this file. -/
+private lemma tanh_nonneg_iff : 0 ≤ Real.tanh R ↔ 0 ≤ R := by
+  have hpos : 0 < Real.exp R + Real.exp (-R) := by positivity
+  rw [Real.tanh_eq, le_div_iff₀ hpos, zero_mul, sub_nonneg, Real.exp_le_exp]
+  constructor <;> intro h <;> linarith
+
+/-- For a negative hyperbolic radius the Euclidean radius is negative, so that the Euclidean disc
+attached to it — like the hyperbolic ball itself — is empty. -/
+private lemma pseudoHyperbolicRadius_tanh_neg (ha : ‖a‖ < 1) (hR : R < 0) :
+    pseudoHyperbolicRadius a (Real.tanh R) < 0 :=
+  pseudoHyperbolicRadius_neg ha (Real.neg_one_lt_tanh R)
+    (not_le.1 fun h => absurd (tanh_nonneg_iff.1 h) (not_le.2 hR))
 
 /-- The hyperbolic distance is below `R` exactly when the pseudo-hyperbolic expression is below
 `Real.tanh R`: the hyperbolic distance is `Real.artanh` of the pseudo-hyperbolic expression, and
@@ -404,57 +428,135 @@ lemma hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (ha : ‖a‖ < 1) (hz 
     (y := Real.tanh R) ⟨by linarith, hp₁⟩ ⟨Real.neg_one_lt_tanh R, Real.tanh_lt_one R⟩)
   rw [Real.artanh_tanh]
 
+/-- The hyperbolic distance equals `R` exactly when the pseudo-hyperbolic expression equals
+`Real.tanh R`, the `=` companion of
+`TauCeti.hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh`. -/
+lemma hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    hyperbolicDist z a = R ↔ pseudoHyperbolicExpr z a = Real.tanh R := by
+  have hp₀ : 0 ≤ pseudoHyperbolicExpr z a := pseudoHyperbolicExpr_nonneg z a
+  have hp₁ : pseudoHyperbolicExpr z a < 1 := pseudoHyperbolicExpr_lt_one_of_norm_lt_one hz ha
+  rw [hyperbolicDist_def]
+  refine ⟨fun h => ?_, fun h => by rw [h, Real.artanh_tanh]⟩
+  rw [← h]
+  exact (Real.tanh_artanh ⟨by linarith, hp₁⟩).symm
+
 /-- **A hyperbolic ball of the Poincaré disc is a Euclidean disc.** The hyperbolic ball of centre
-`a` and radius `R ≥ 0` is the Euclidean disc of centre
-`pseudoHyperbolicCenter a (Real.tanh R)` and radius `pseudoHyperbolicRadius a (Real.tanh R)`.
+`a` and radius `R` is the Euclidean disc of centre `pseudoHyperbolicCenter a (Real.tanh R)` and
+radius `pseudoHyperbolicRadius a (Real.tanh R)`; for `R < 0` both sides are empty, the Euclidean
+radius being negative.
 
 The Euclidean centre is `a` only for `a = 0` or `R = 0`; for `a ≠ 0` the hyperbolic ball is an
 off-centre Euclidean disc, pulled towards the origin. Specialising to `a = 0` recovers
 `TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh` of `Poincare/Topology.lean`, where the
 Euclidean centre is the origin and the Euclidean radius is `Real.tanh R`. -/
-theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R}
       = ball (pseudoHyperbolicCenter a (Real.tanh R)) (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg hR) (Real.tanh_lt_one R)]
-  ext w
-  simp only [mem_ball_zero_iff]
-  exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_tanh_neg ha hR).le]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd (hw.2.trans hR) (not_lt.2 (hyperbolicDist_nonneg w a))
+  · rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R)]
+    ext w
+    simp only [mem_ball_zero_iff]
+    exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
 
 /-- **A closed hyperbolic ball of the Poincaré disc is a closed Euclidean disc**, the `≤`
 companion of `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`. -/
-theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a ≤ R}
       = closedBall (pseudoHyperbolicCenter a (Real.tanh R))
         (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (tanh_nonneg hR) (Real.tanh_lt_one R)]
-  ext w
-  simp only [mem_ball_zero_iff]
-  exact and_congr_right fun hw => hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh ha hw
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_tanh_neg ha hR)]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd (hw.2.trans_lt hR) (not_lt.2 (hyperbolicDist_nonneg w a))
+  · rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (tanh_nonneg_iff.2 hR)
+      (Real.tanh_lt_one R)]
+    ext w
+    simp only [mem_ball_zero_iff]
+    exact and_congr_right fun hw => hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh ha hw
+
+/-- **A hyperbolic circle of the Poincaré disc is a Euclidean circle**, the `=` companion of
+`TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`. -/
+theorem sep_ball_hyperbolicDist_eq_eq_sphere (ha : ‖a‖ < 1) :
+    {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a = R}
+      = sphere (pseudoHyperbolicCenter a (Real.tanh R))
+        (pseudoHyperbolicRadius a (Real.tanh R)) := by
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_tanh_neg ha hR)]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd (hw.2 ▸ hyperbolicDist_nonneg w a) (not_le.2 hR)
+  · rw [← sep_ball_pseudoHyperbolicExpr_eq_eq_sphere ha (tanh_nonneg_iff.2 hR)
+      (Real.tanh_lt_one R)]
+    ext w
+    simp only [mem_ball_zero_iff]
+    exact and_congr_right fun hw => hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh ha hw
 
 /-- **Hyperbolic balls are Euclidean-convex.** Being Euclidean discs, the balls of the hyperbolic
-metric are convex for the linear structure of `ℂ`. This is not the geodesic convexity of the
-hyperbolic metric, which is a separate statement about the hyperbolic geodesics of
-`Poincare/Geodesic.lean`; it is the stronger Euclidean one, and it has no proof internal to the
-hyperbolic metric. -/
-theorem convex_sep_ball_hyperbolicDist_lt (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+metric are convex for the linear structure of `ℂ`. This is a different notion from the geodesic
+convexity of the hyperbolic metric, which is a separate statement about the hyperbolic geodesics
+of `Poincare/Geodesic.lean`: it is convexity for the Euclidean structure, and it has no proof
+internal to the hyperbolic metric. -/
+theorem convex_sep_ball_hyperbolicDist_lt (ha : ‖a‖ < 1) :
     Convex ℝ {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R} := by
-  rw [sep_ball_hyperbolicDist_lt_eq_ball ha hR]
+  rw [sep_ball_hyperbolicDist_lt_eq_ball ha]
   exact convex_ball _ _
 
 namespace PoincareDisc
 
 /-- **The balls of the Poincaré metric space, read on the Euclidean disc.** A point of
-`TauCeti.PoincareDisc` lies in the hyperbolic ball of centre `x` and radius `R ≥ 0` exactly when
-its Euclidean coordinate lies in the corresponding Euclidean disc. -/
-theorem mem_ball_iff (x w : PoincareDisc) (hR : 0 ≤ R) :
+`TauCeti.PoincareDisc` lies in the hyperbolic ball of centre `x` and radius `R` exactly when its
+Euclidean coordinate lies in the corresponding Euclidean disc; for `R < 0` both sides are
+empty. -/
+theorem mem_ball_iff (x w : PoincareDisc) :
     w ∈ ball x R ↔ (toUnitDisc w : ℂ) ∈
       ball (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
         (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
-  rw [mem_ball, dist_eq]
-  exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
-    (toUnitDisc w).norm_lt_one).trans
-    (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
-      (tanh_nonneg hR) (Real.tanh_lt_one R))
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [mem_ball, mem_ball, dist_eq]
+    exact iff_of_false (not_lt.2 (hR.le.trans (hyperbolicDist_nonneg _ _)))
+      (not_lt.2 ((pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR).le.trans
+        dist_nonneg))
+  · rw [mem_ball, dist_eq]
+    exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
+      (toUnitDisc w).norm_lt_one).trans
+      (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
+        (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
+
+/-- **The closed balls of the Poincaré metric space, read on the Euclidean disc**, the `≤`
+companion of `TauCeti.PoincareDisc.mem_ball_iff`. -/
+theorem mem_closedBall_iff (x w : PoincareDisc) :
+    w ∈ closedBall x R ↔ (toUnitDisc w : ℂ) ∈
+      closedBall (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
+        (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [mem_closedBall, mem_closedBall, dist_eq]
+    exact iff_of_false (not_le.2 (hR.trans_le (hyperbolicDist_nonneg _ _)))
+      (not_le.2 ((pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR).trans_le
+        dist_nonneg))
+  · rw [mem_closedBall, dist_eq]
+    exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
+      (toUnitDisc w).norm_lt_one).trans
+      (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
+        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
+
+/-- **The spheres of the Poincaré metric space, read on the Euclidean disc**, the `=` companion of
+`TauCeti.PoincareDisc.mem_ball_iff`. -/
+theorem mem_sphere_iff (x w : PoincareDisc) :
+    w ∈ sphere x R ↔ (toUnitDisc w : ℂ) ∈
+      sphere (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
+        (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
+  rcases lt_or_ge R 0 with hR | hR
+  · rw [mem_sphere, mem_sphere, dist_eq]
+    exact iff_of_false (fun h => absurd (h ▸ hyperbolicDist_nonneg _ _) (not_le.2 hR))
+      (fun h => absurd (h ▸ dist_nonneg)
+        (not_le.2 (pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR)))
+  · rw [mem_sphere, dist_eq]
+    exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
+      (toUnitDisc w).norm_lt_one).trans
+      (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
+        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R))
 
 end PoincareDisc
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -68,8 +68,10 @@ Euclidean ball (`TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh`, the case `a =
 Moebius denominator is `1` and the computation is immediate) and uses it for properness. The
 general centre is what a *local* argument needs, and it is not a formal consequence of the special
 case: the disc automorphism moving `a` to the origin is a hyperbolic isometry but not a Euclidean
-one, so it does not transport a Euclidean ball to a Euclidean ball. The explicit centre and radius
-are the point.
+one. Being a Moebius map it does carry the centred Euclidean disc onto a Euclidean disc — that is
+the very fact being proved here — but it preserves neither the Euclidean centre nor the Euclidean
+radius, so transport through it still leaves both to be computed. Those transformed values are the
+point.
 
 Two immediate consequences are recorded: hyperbolic balls are convex for the *Euclidean* structure
 (`TauCeti.convex_sep_ball_hyperbolicDist_lt`), a fact with no hyperbolic proof at this stage of the
@@ -240,14 +242,10 @@ lemma norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one
 /-- The closed Euclidean disc describing a pseudo-hyperbolic ball is contained in the open unit
 disc; a fortiori so is the open one. -/
 lemma closedBall_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
-    closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) ⊆ ball (0 : ℂ) 1 := by
-  intro w hw
-  have h := norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one ha ht₀ ht₁
-  have hle : ‖w - pseudoHyperbolicCenter a t‖ ≤ pseudoHyperbolicRadius a t := by
-    simpa [dist_eq_norm] using hw
-  have : ‖w‖ ≤ ‖w - pseudoHyperbolicCenter a t‖ + ‖pseudoHyperbolicCenter a t‖ := by
-    simpa using norm_add_le (w - pseudoHyperbolicCenter a t) (pseudoHyperbolicCenter a t)
-  exact mem_ball_zero_iff.2 (by linarith)
+    closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) ⊆ ball (0 : ℂ) 1 :=
+  closedBall_subset_ball' <| by
+    simpa [dist_eq_norm, add_comm] using
+      norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one ha ht₀ ht₁
 
 /-! ### The Apollonius identity -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -55,18 +55,25 @@ unit disc: `‖c‖ + s < 1` because
 `1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / D`
 (`TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`). So the restriction to
 the disc in the set equalities is a genuine description of a subset of `𝔻`, not an artefact.
-Third, both ends of the range `-1 ≤ t ≤ 1` are allowed wherever they are true. The endpoint
-`t = 1` is admitted by the *open* ball (`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
-`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`): the denominator `D` stays positive, and
-`c = 0`, `s = 1`, so the description degenerates to the statement that `p (·, a) < 1` cuts out all
-of `𝔻`. Only the closed disc and the circle need `t < 1`: at `t = 1` they would contain the unit
-circle, which the pseudo-hyperbolic conditions never reach. At the other end a negative `t` is
-admitted throughout and is vacuous on both sides: `p` is nonnegative, so the pseudo-hyperbolic
-condition is unsatisfiable, and the Euclidean radius `s` is then negative
-(`TauCeti.pseudoHyperbolicRadius_neg`), so the Euclidean disc is empty as well. The lower bound
-`-1 ≤ t` is needed: for `t < -1` the denominator `D` can be negative and `s` positive again, and
-the Euclidean disc is no longer empty. It is exactly this range that makes the statements about
-the hyperbolic metric unconditional in `R`, since `Real.tanh R` always lies in `(-1, 1)`.
+Third, each statement asks of the radius only what it uses. The *pointwise* comparisons
+(`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` and its `≤`/`=` companions) place no bound on `t`
+at all: they assume `0 < D`, which is what turns the identity into a comparison of discs. That is
+strictly weaker than `-1 ≤ t ≤ 1`, which implies it (`TauCeti.one_sub_sq_mul_sq_norm_pos`) and is
+how every application below discharges it; for `a = 0`, where `D = 1`, every real `t` is allowed.
+Positivity of `D` cannot be dropped: for `t < -1` it can fail, and then `s` is positive while the
+pseudo-hyperbolic condition is still unsatisfiable. A negative `t` is admitted and is vacuous on
+both sides: `p` is nonnegative, so the pseudo-hyperbolic condition is unsatisfiable, and the
+Euclidean radius `s` is then negative (`TauCeti.pseudoHyperbolicRadius_neg`), so the Euclidean
+disc is empty as well.
+
+The *set-level* statements do restrict `t`, because they describe the intersection with `𝔻` and
+so need the Euclidean disc to lie inside it. The endpoint `t = 1` is admitted by the open ball
+(`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`, on `-1 ≤ t ≤ 1`), where `c = 0` and `s = 1`
+and the description degenerates to the statement that `p (·, a) < 1` cuts out all of `𝔻`; the
+closed disc and the circle need `t < 1`, since at `t = 1` they would contain the unit circle,
+which the pseudo-hyperbolic conditions never reach. It is exactly this range that makes the
+statements about the hyperbolic metric unconditional in `R`, since `Real.tanh R` always lies in
+`(-1, 1)`.
 
 The Euclidean centre `c` is *not* `a` unless `a = 0` or `t = 0`: a hyperbolic ball is a Euclidean
 disc, but an off-centre one, its Euclidean centre pulled towards the origin by the factor
@@ -178,73 +185,60 @@ noncomputable def pseudoHyperbolicCenter (a : ℂ) (t : ℝ) : ℂ :=
 noncomputable def pseudoHyperbolicRadius (a : ℂ) (t : ℝ) : ℝ :=
   t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)
 
-/-- The defining formula for `TauCeti.pseudoHyperbolicCenter`. -/
-lemma pseudoHyperbolicCenter_def (a : ℂ) (t : ℝ) :
-    pseudoHyperbolicCenter a t = ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a := (rfl)
-
-/-- The defining formula for `TauCeti.pseudoHyperbolicRadius`. -/
-lemma pseudoHyperbolicRadius_def (a : ℂ) (t : ℝ) :
-    pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := (rfl)
-
 /-- Balls centred at the origin are unmoved: the Euclidean centre of a pseudo-hyperbolic ball
 about `0` is `0`. -/
 @[simp]
 lemma pseudoHyperbolicCenter_zero_left (t : ℝ) : pseudoHyperbolicCenter 0 t = 0 := by
-  simp [pseudoHyperbolicCenter_def]
+  simp [pseudoHyperbolicCenter]
 
 /-- Balls centred at the origin have their Euclidean radius equal to the pseudo-hyperbolic one,
 so that at the origin the two descriptions of a ball coincide. -/
 @[simp]
 lemma pseudoHyperbolicRadius_zero_left (t : ℝ) : pseudoHyperbolicRadius 0 t = t := by
-  simp [pseudoHyperbolicRadius_def]
+  simp [pseudoHyperbolicRadius]
 
 /-- A ball of radius `0` is centred at its hyperbolic centre. -/
 @[simp]
 lemma pseudoHyperbolicCenter_zero_right (a : ℂ) : pseudoHyperbolicCenter a 0 = a := by
-  simp [pseudoHyperbolicCenter_def]
+  simp [pseudoHyperbolicCenter]
 
 /-- A ball of radius `0` has Euclidean radius `0`. -/
 @[simp]
 lemma pseudoHyperbolicRadius_zero_right (a : ℂ) : pseudoHyperbolicRadius a 0 = 0 := by
-  simp [pseudoHyperbolicRadius_def]
+  simp [pseudoHyperbolicRadius]
 
-/-- The denominator `1 - t ^ 2 * ‖a‖ ^ 2` is positive for a disc centre and a radius in `[0, 1]`.
-This is what makes the Apollonius identity a genuine comparison of discs rather than a degenerate
-one. -/
-lemma one_sub_sq_mul_sq_norm_pos (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+/-- The denominator `1 - t ^ 2 * ‖a‖ ^ 2` is positive for a disc centre and a radius in
+`[-1, 1]`. Its positivity — the hypothesis the pointwise results below actually run on — is what
+makes the Apollonius identity a genuine comparison of discs rather than a degenerate one. -/
+lemma one_sub_sq_mul_sq_norm_pos (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     0 < 1 - t ^ 2 * ‖a‖ ^ 2 := by
-  have hn : 0 ≤ ‖a‖ := norm_nonneg a
-  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
-  nlinarith [mul_nonneg (by nlinarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
-
-/-- The Euclidean radius of a pseudo-hyperbolic ball is nonnegative. -/
-lemma pseudoHyperbolicRadius_nonneg (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
-    0 ≤ pseudoHyperbolicRadius a t := by
-  have hn : 0 ≤ ‖a‖ := norm_nonneg a
-  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
-  exact div_nonneg (mul_nonneg ht₀ (by linarith))
-    (one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁).le
-
-/-- The Euclidean radius of a pseudo-hyperbolic ball of positive radius is positive. -/
-lemma pseudoHyperbolicRadius_pos (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t ≤ 1) :
-    0 < pseudoHyperbolicRadius a t := by
-  have hn : 0 ≤ ‖a‖ := norm_nonneg a
-  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
-  exact div_pos (mul_pos ht₀ (by linarith))
-    (one_sub_sq_mul_sq_norm_pos ha ht₀.le ht₁)
-
-/-- A negative pseudo-hyperbolic radius `t ∈ [-1, 0)` gives a negative Euclidean radius, so that
-the Euclidean disc it describes is empty — as is the pseudo-hyperbolic ball of radius `t`. -/
-lemma pseudoHyperbolicRadius_neg (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t < 0) :
-    pseudoHyperbolicRadius a t < 0 := by
   have hn : 0 ≤ ‖a‖ := norm_nonneg a
   have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
   have ht2 : t ^ 2 ≤ 1 := by
     nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 + t) (by linarith : (0 : ℝ) ≤ 1 - t)]
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := by
-    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
-  rw [pseudoHyperbolicRadius_def]
-  exact div_neg_of_neg_of_pos (mul_neg_of_neg_of_pos ht₁ (by linarith)) hD
+  nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
+
+/-- The Euclidean radius of a pseudo-hyperbolic ball of nonnegative radius is nonnegative. -/
+lemma pseudoHyperbolicRadius_nonneg (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht : 0 ≤ t) :
+    0 ≤ pseudoHyperbolicRadius a t := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  exact div_nonneg (mul_nonneg ht (by linarith)) hD.le
+
+/-- The Euclidean radius of a pseudo-hyperbolic ball of positive radius is positive. -/
+lemma pseudoHyperbolicRadius_pos (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht : 0 < t) :
+    0 < pseudoHyperbolicRadius a t := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  exact div_pos (mul_pos ht (by linarith)) hD
+
+/-- A negative pseudo-hyperbolic radius gives a negative Euclidean radius, so that the Euclidean
+disc it describes is empty — as is the pseudo-hyperbolic ball of radius `t`. -/
+lemma pseudoHyperbolicRadius_neg (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht : t < 0) :
+    pseudoHyperbolicRadius a t < 0 := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  exact div_neg_of_neg_of_pos (mul_neg_of_neg_of_pos ht (by linarith)) hD
 
 /-! ### The Euclidean disc lies inside the unit disc -/
 
@@ -256,16 +250,16 @@ lemma norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one
     (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
     ‖pseudoHyperbolicCenter a t‖ + pseudoHyperbolicRadius a t < 1 := by
   have hn : 0 ≤ ‖a‖ := norm_nonneg a
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha (by linarith) ht₁.le
   have hnum : 0 ≤ (1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := by
     apply div_nonneg _ hD.le
     nlinarith
   have hcnorm : ‖pseudoHyperbolicCenter a t‖ = (1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) * ‖a‖ := by
-    rw [pseudoHyperbolicCenter_def, norm_smul, Real.norm_eq_abs, abs_of_nonneg hnum]
+    rw [pseudoHyperbolicCenter, norm_smul, Real.norm_eq_abs, abs_of_nonneg hnum]
   have hkey : 0 < (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) := by
     refine mul_pos (mul_pos (by linarith) (by linarith)) ?_
     nlinarith
-  rw [hcnorm, pseudoHyperbolicRadius_def, div_mul_eq_mul_div, ← add_div, div_lt_one hD]
+  rw [hcnorm, pseudoHyperbolicRadius, div_mul_eq_mul_div, ← add_div, div_lt_one hD]
   nlinarith [hkey]
 
 /-- The closed Euclidean disc describing a pseudo-hyperbolic ball is contained in the open unit
@@ -286,9 +280,9 @@ lemma ball_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ 
   · exact ball_subset_closedBall.trans (closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht)
   · subst ht
     have hne : 1 - ‖a‖ ^ 2 ≠ 0 := by nlinarith [norm_nonneg a]
-    have hc : pseudoHyperbolicCenter a 1 = 0 := by simp [pseudoHyperbolicCenter_def]
+    have hc : pseudoHyperbolicCenter a 1 = 0 := by simp [pseudoHyperbolicCenter]
     have hs : pseudoHyperbolicRadius a 1 = 1 := by
-      rw [pseudoHyperbolicRadius_def, one_pow, one_mul, one_mul, div_self hne]
+      rw [pseudoHyperbolicRadius, one_pow, one_mul, one_mul, div_self hne]
     intro w hw
     rwa [hc, hs] at hw
 
@@ -326,7 +320,7 @@ theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
       = 1 + ‖a‖ ^ 2 * ‖z‖ ^ 2 - 2 * (z * conj a).re := by
     simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_sub, Complex.normSq_one,
       Complex.normSq_conj, map_mul, Complex.conj_conj, one_mul, hre]
-  rw [pseudoHyperbolicCenter_def, pseudoHyperbolicRadius_def, hshift, hsub, hmoebius]
+  rw [pseudoHyperbolicCenter, pseudoHyperbolicRadius, hshift, hsub, hmoebius]
   obtain ⟨D, hDdef⟩ : ∃ D : ℝ, D = 1 - t ^ 2 * ‖a‖ ^ 2 := ⟨_, rfl⟩
   rw [← hDdef] at hD ⊢
   field_simp
@@ -342,88 +336,90 @@ theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
 Clearing the Moebius denominator — legitimate because `z` and `a` lie in the disc — turns the
 left-hand condition into `‖z - a‖ < t * ‖1 - conj a * z‖`, and squaring both sides makes
 `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` applicable; the factor
-`1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive, so it does not affect the sign.
+`1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive by hypothesis, so it does not affect the sign.
 
-Both endpoints are allowed: at `t = 1` the two sides say that `z` lies in the unit disc, and for
-`t < 0` both are empty, the Euclidean radius being negative. -/
+Positivity of that factor is all that is asked of `t`; it holds in particular for every
+`t ∈ [-1, 1]` (`TauCeti.one_sub_sq_mul_sq_norm_pos`), and for every real `t` when `a = 0`. A
+negative `t` is allowed and makes both sides empty, the Euclidean radius being negative. -/
 theorem pseudoHyperbolicExpr_lt_iff_mem_ball (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) :
     pseudoHyperbolicExpr z a < t ↔
       z ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   rcases lt_or_ge t 0 with ht | ht
   · rw [mem_ball]
     exact iff_of_false (not_lt.2 (ht.le.trans (pseudoHyperbolicExpr_nonneg z a)))
-      (not_lt.2 ((pseudoHyperbolicRadius_neg ha ht₀ ht).le.trans dist_nonneg))
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht ht₁
+      (not_lt.2 ((pseudoHyperbolicRadius_neg ha hD ht).le.trans dist_nonneg))
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_lt_iff₀ hdenpos, mem_ball, dist_eq_norm,
     ← sq_lt_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht ht₁), mul_pow]
+    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha hD ht), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The closed pseudo-hyperbolic ball is a closed Euclidean disc**, the `≤` companion of
-`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof, and like it valid on the whole
-range `-1 ≤ t ≤ 1`: at `t = 1` the closed Euclidean disc is the closed unit disc, and for `t < 0`
-both sides are empty. -/
+`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof, and under the same hypothesis:
+at `t = 1` the closed Euclidean disc is the closed unit disc, and for `t < 0` both sides are
+empty. -/
 theorem pseudoHyperbolicExpr_le_iff_mem_closedBall (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) :
     pseudoHyperbolicExpr z a ≤ t ↔
       z ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   rcases lt_or_ge t 0 with ht | ht
   · rw [mem_closedBall]
     exact iff_of_false (not_le.2 (ht.trans_le (pseudoHyperbolicExpr_nonneg z a)))
-      (not_le.2 ((pseudoHyperbolicRadius_neg ha ht₀ ht).trans_le dist_nonneg))
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht ht₁
+      (not_le.2 ((pseudoHyperbolicRadius_neg ha hD ht).trans_le dist_nonneg))
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_le_iff₀ hdenpos, mem_closedBall, dist_eq_norm,
     ← sq_le_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht ht₁), mul_pow]
+    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha hD ht), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The pseudo-hyperbolic circle is a Euclidean circle.** A point `z` of the unit disc satisfies
 `pseudoHyperbolicExpr z a = t` exactly when it lies on the Euclidean circle of centre
 `TauCeti.pseudoHyperbolicCenter a t` and radius `TauCeti.pseudoHyperbolicRadius a t`: the level
 set is what the closed disc has and the open one has not. The endpoint `t = 1` is allowed, and
-there — as for `t < 0` — both sides are empty. -/
+there — as for `t < 0` — both sides are empty.
+
+Both directions are the antisymmetry of `≤` (`le_antisymm_iff`), with the missing inequality
+supplied by the `<` statement through `not_lt`. -/
 theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) :
     pseudoHyperbolicExpr z a = t ↔
       z ∈ sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hle := pseudoHyperbolicExpr_le_iff_mem_closedBall ha hz ht₀ ht₁
-  have hlt := pseudoHyperbolicExpr_lt_iff_mem_ball ha hz ht₀ ht₁
+  have hle := pseudoHyperbolicExpr_le_iff_mem_closedBall ha hz hD
+  have hlt := pseudoHyperbolicExpr_lt_iff_mem_ball ha hz hD
   rw [mem_closedBall] at hle
   rw [mem_ball] at hlt
   rw [mem_sphere]
-  refine ⟨fun h => le_antisymm (hle.1 h.le) (not_lt.1 fun hd => ?_),
-    fun h => le_antisymm (hle.2 h.le) (not_lt.1 fun hp => ?_)⟩
-  · exact absurd (hlt.2 hd) (by rw [h]; exact lt_irrefl t)
-  · exact absurd (hlt.1 hp) (by rw [h]; exact lt_irrefl _)
+  exact le_antisymm_iff.trans
+    ((and_congr hle (not_lt.symm.trans ((not_congr hlt).trans not_lt))).trans le_antisymm_iff.symm)
 
 /-- The hyperbolic centre of a ball of positive radius lies in the Euclidean disc describing it —
 off centre, but inside. -/
-theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t ≤ 1) :
+theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2)
+    (ht : 0 < t) :
     a ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
-  (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha (by linarith) ht₁).1 (by simpa using ht₀)
+  (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha hD).1 (by simpa using ht)
 
 /-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. The endpoint
 `t = 1` is allowed, and there both sides are the unit disc; for `t < 0` both sides are empty. -/
 theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a < t}
       = ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
   rcases lt_or_ge t 0 with ht | ht
-  · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_neg ha ht₀ ht).le]
+  · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_neg ha hD ht).le]
     exact eq_empty_of_forall_notMem fun w hw =>
       absurd hw.2 (not_lt.2 (ht.le.trans (pseudoHyperbolicExpr_nonneg w a)))
   ext w
   simp only [mem_ball_zero_iff]
-  refine ⟨fun h => (pseudoHyperbolicExpr_lt_iff_mem_ball ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  refine ⟨fun h => (pseudoHyperbolicExpr_lt_iff_mem_ball ha h.1 hD).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 :=
     mem_ball_zero_iff.1 <| ball_pseudoHyperbolicCenter_subset_ball ha ht ht₁ h
-  exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 h⟩
+  exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw hD).2 h⟩
 
 /-- **A closed pseudo-hyperbolic ball of the unit disc is a closed Euclidean disc**, in set
 form. For `t < 0` both sides are empty. -/
@@ -431,33 +427,34 @@ theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀
     (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a ≤ t}
       = closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
   rcases lt_or_ge t 0 with ht | ht
-  · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_neg ha ht₀ ht)]
+  · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_neg ha hD ht)]
     exact eq_empty_of_forall_notMem fun w hw =>
       absurd hw.2 (not_le.2 (ht.trans_le (pseudoHyperbolicExpr_nonneg w a)))
   ext w
   simp only [mem_ball_zero_iff]
-  refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 ht₀ ht₁.le).1 h.2,
-    fun h => ?_⟩
+  refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 hD).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 :=
     mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball ha ht ht₁ h
-  exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁.le).2 h⟩
+  exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw hD).2 h⟩
 
 /-- **A pseudo-hyperbolic circle of the unit disc is a Euclidean circle**: the level set is the
 difference of the closed and the open disc. For `t < 0` both sides are empty. -/
 theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a = t}
       = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
   rcases lt_or_ge t 0 with ht | ht
-  · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_neg ha ht₀ ht)]
+  · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_neg ha hD ht)]
     exact eq_empty_of_forall_notMem fun w hw =>
       absurd (hw.2 ▸ pseudoHyperbolicExpr_nonneg w a) (not_le.2 ht)
   ext w
   simp only [mem_ball_zero_iff]
-  refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 ht₀ ht₁.le).1 h.2, fun h => ?_⟩
+  refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 hD).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
     ha ht ht₁ (sphere_subset_closedBall h)
-  exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw ht₀ ht₁.le).2 h⟩
+  exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw hD).2 h⟩
 
 /-! ### Hyperbolic balls -/
 
@@ -553,6 +550,13 @@ theorem convex_sep_ball_hyperbolicDist_lt (ha : ‖a‖ < 1) :
 
 namespace PoincareDisc
 
+/-- The denominator of the Apollonius identity is positive at any point of the Poincaré disc and
+any hyperbolic radius, since `Real.tanh` takes values in `(-1, 1)`. -/
+private lemma one_sub_sq_tanh_mul_sq_norm_pos (x : PoincareDisc) (R : ℝ) :
+    0 < 1 - Real.tanh R ^ 2 * ‖(toUnitDisc x : ℂ)‖ ^ 2 :=
+  one_sub_sq_mul_sq_norm_pos (toUnitDisc x).norm_lt_one (Real.neg_one_lt_tanh R).le
+    (Real.tanh_lt_one R).le
+
 /-- **The balls of the Poincaré metric space, read on the Euclidean disc.** A point of
 `TauCeti.PoincareDisc` lies in the hyperbolic ball of centre `x` and radius `R` exactly when its
 Euclidean coordinate lies in the corresponding Euclidean disc; for `R < 0` both sides are
@@ -565,7 +569,7 @@ theorem mem_ball_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
-      (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
+      (one_sub_sq_tanh_mul_sq_norm_pos x R))
 
 /-- **The closed balls of the Poincaré metric space, read on the Euclidean disc**, the `≤`
 companion of `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -577,7 +581,7 @@ theorem mem_closedBall_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
+      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos x R))
 
 /-- **The spheres of the Poincaré metric space, read on the Euclidean disc**, the `=` companion of
 `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -589,7 +593,7 @@ theorem mem_sphere_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
+      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos x R))
 
 end PoincareDisc
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -1,0 +1,461 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Poincare.MetricSpace
+
+/-!
+# Hyperbolic balls of the Poincaré disc are Euclidean discs
+
+The hyperbolic (Poincaré) metric `TauCeti.hyperbolicDist` on the open unit disc is
+`Real.artanh` of the pseudo-hyperbolic expression
+`p (z, a) = ‖(z - a) / (1 - conj a * z)‖`, and both are visibly non-Euclidean: the metric blows
+up at the boundary circle, and `p` is a Moebius quotient rather than a norm. Nevertheless the
+*balls* of the two metrics are the same sets. This file proves that, with the centre and radius
+computed explicitly.
+
+Fix `a` in the disc and a pseudo-hyperbolic radius `t ∈ [0, 1)`. Writing
+`D = 1 - t ^ 2 * ‖a‖ ^ 2`, which is positive, put
+
+* `TauCeti.pseudoHyperbolicCenter a t = ((1 - t ^ 2) / D) • a`,
+* `TauCeti.pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / D`.
+
+Then `{z ∈ 𝔻 | p (z, a) < t}` is exactly the Euclidean disc of that centre and radius
+(`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`), and likewise for `≤` and `=` with the
+closed disc and the circle. Substituting `t = Real.tanh R` converts these into statements about
+the hyperbolic metric, since `Real.artanh` and `Real.tanh` are inverse increasing bijections
+between `(-1, 1)` and `ℝ`: the hyperbolic ball of centre `a` and radius `R` is the Euclidean
+disc of centre `pseudoHyperbolicCenter a (Real.tanh R)` and radius
+`pseudoHyperbolicRadius a (Real.tanh R)` (`TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`).
+
+## The computation
+
+Everything comes from a single algebraic identity between real quadratics
+(`TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul`):
+
+> `‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2`
+> `  = D * (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2)`,
+
+valid for every `z : ℂ` as soon as `D ≠ 0`. Expanding both norms as
+`‖w‖ ^ 2 = w.re ^ 2 + w.im ^ 2` turns each side into a real polynomial in
+`a.re, a.im, z.re, z.im, t`, and the two agree after clearing the denominator `D`. Since `D > 0`,
+the left side is negative, zero or positive exactly when `‖z - c‖` is less than, equal to or
+greater than the radius, which is the whole content: the pseudo-hyperbolic condition
+`‖z - a‖ < t * ‖1 - conj a * z‖` is a Euclidean disc.
+
+Two features of the statement are worth noting. First, the identity — and hence the description
+of the sublevel set of `‖z - a‖ - t * ‖1 - conj a * z‖` — needs no hypothesis on `z` at all; it is
+only the passage to the *quotient* `p (z, a)` that requires `z` in the disc, so that the Moebius
+denominator does not vanish. Second, the resulting Euclidean disc automatically lies inside the
+unit disc: `‖c‖ + s < 1` because
+`1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / D`
+(`TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`). So the restriction to
+the disc in the set equalities is a genuine description of a subset of `𝔻`, not an artefact.
+
+The Euclidean centre `c` is *not* `a` unless `a = 0` or `t = 0`: a hyperbolic ball is a Euclidean
+disc, but an off-centre one, its Euclidean centre pulled towards the origin by the factor
+`(1 - t ^ 2) / D`. The hyperbolic centre does lie inside it
+(`TauCeti.mem_ball_pseudoHyperbolicCenter`), as it must.
+
+## What this adds
+
+`Poincare/Topology.lean` already identifies the closed hyperbolic ball *about the origin* with a
+Euclidean ball (`TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh`, the case `a = 0`, where the
+Moebius denominator is `1` and the computation is immediate) and uses it for properness. The
+general centre is what a *local* argument needs, and it is not a formal consequence of the special
+case: the disc automorphism moving `a` to the origin is a hyperbolic isometry but not a Euclidean
+one, so it does not transport a Euclidean ball to a Euclidean ball. The explicit centre and radius
+are the point.
+
+Two immediate consequences are recorded: hyperbolic balls are convex for the *Euclidean* structure
+(`TauCeti.convex_sep_ball_hyperbolicDist_lt`), a fact with no hyperbolic proof at this stage of the
+development, since geodesic convexity is a different statement; and the balls of the metric space
+`TauCeti.PoincareDisc` are characterised in Euclidean terms
+(`TauCeti.PoincareDisc.mem_ball_iff`).
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, everything below is stated for `ℂ`. The statements are not
+merely specialised but genuinely two-dimensional: the identity above is the complex-analytic
+Apollonius computation, and its conclusion — that a Moebius sublevel set is a disc — has no
+analogue in a general normed space.
+
+## Main definitions
+
+* `TauCeti.pseudoHyperbolicCenter` — the Euclidean centre of the pseudo-hyperbolic ball.
+* `TauCeti.pseudoHyperbolicRadius` — its Euclidean radius.
+
+## Main results
+
+* `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` — the Apollonius identity the file runs
+  on.
+* `TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one` and
+  `TauCeti.closedBall_pseudoHyperbolicCenter_subset_ball` — the Euclidean disc lies inside `𝔻`.
+* `TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` and
+  `TauCeti.pseudoHyperbolicExpr_le_iff_mem_closedBall` — the pointwise form.
+* `TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`,
+  `TauCeti.sep_ball_pseudoHyperbolicExpr_le_eq_closedBall` and
+  `TauCeti.sep_ball_pseudoHyperbolicExpr_eq_eq_sphere` — pseudo-hyperbolic balls, closed balls and
+  circles are Euclidean ones.
+* `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball` and
+  `TauCeti.sep_ball_hyperbolicDist_le_eq_closedBall` — the same for the hyperbolic metric, with
+  `t = Real.tanh R`.
+* `TauCeti.PoincareDisc.mem_ball_iff` — the balls of the Poincaré metric space, read on the
+  Euclidean disc.
+
+This carries the conformal-mapping roadmap's L2 target "the hyperbolic / Poincaré metric on `𝔻`"
+(see `ConformalMapping/README.md`) onto its metric geometry, completing the basic ball API of that
+metric. As with the rest of the L0–L3 conformal-mapping material it is coordinated with the
+upstream Mathlib Riemann mapping effort leanprover-community/mathlib4#33505, which contains the
+preceding human-curated work along with `Analysis/Complex/RiemannMapping.lean` and
+`Analysis/Complex/BranchLogRoot.lean`; none of that material describes the hyperbolic metric on
+the disc, and Mathlib's `Analysis/Complex/UpperHalfPlane` hyperbolic metric carries no ball
+description of this kind, so nothing here duplicates it.
+
+## References
+
+* L. V. Ahlfors, *Conformal Invariants*, Ch. 1.
+* J. B. Garnett and D. E. Marshall, *Harmonic Measure*, Ch. I §1.
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §1.2.
+-/
+
+public section
+
+namespace TauCeti
+
+open _root_.Complex Metric Set
+open scoped ComplexConjugate
+
+variable {a z : ℂ} {t R : ℝ}
+
+/-! ### The Euclidean centre and radius -/
+
+/-- The Euclidean centre of the pseudo-hyperbolic ball of centre `a` and radius `t`: the
+hyperbolic centre `a` pulled towards the origin by the factor
+`(1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)`. -/
+@[expose] noncomputable def pseudoHyperbolicCenter (a : ℂ) (t : ℝ) : ℂ :=
+  ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a
+
+/-- The Euclidean radius of the pseudo-hyperbolic ball of centre `a` and radius `t`. -/
+@[expose] noncomputable def pseudoHyperbolicRadius (a : ℂ) (t : ℝ) : ℝ :=
+  t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)
+
+/-- The defining formula for `TauCeti.pseudoHyperbolicCenter`. -/
+lemma pseudoHyperbolicCenter_def (a : ℂ) (t : ℝ) :
+    pseudoHyperbolicCenter a t = ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a := rfl
+
+/-- The defining formula for `TauCeti.pseudoHyperbolicRadius`. -/
+lemma pseudoHyperbolicRadius_def (a : ℂ) (t : ℝ) :
+    pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := rfl
+
+/-- Balls centred at the origin are unmoved: the Euclidean centre of a pseudo-hyperbolic ball
+about `0` is `0`. -/
+@[simp]
+lemma pseudoHyperbolicCenter_zero_left (t : ℝ) : pseudoHyperbolicCenter 0 t = 0 := by
+  simp [pseudoHyperbolicCenter_def]
+
+/-- Balls centred at the origin have their Euclidean radius equal to the pseudo-hyperbolic one,
+so that at the origin the two descriptions of a ball coincide. -/
+@[simp]
+lemma pseudoHyperbolicRadius_zero_left (t : ℝ) : pseudoHyperbolicRadius 0 t = t := by
+  simp [pseudoHyperbolicRadius_def]
+
+/-- A ball of radius `0` is centred at its hyperbolic centre. -/
+@[simp]
+lemma pseudoHyperbolicCenter_zero_right (a : ℂ) : pseudoHyperbolicCenter a 0 = a := by
+  simp [pseudoHyperbolicCenter_def]
+
+/-- A ball of radius `0` has Euclidean radius `0`. -/
+@[simp]
+lemma pseudoHyperbolicRadius_zero_right (a : ℂ) : pseudoHyperbolicRadius a 0 = 0 := by
+  simp [pseudoHyperbolicRadius_def]
+
+/-- The denominator `1 - t ^ 2 * ‖a‖ ^ 2` is positive for a disc centre and a radius in `[0, 1]`.
+This is what makes the Apollonius identity a genuine comparison of discs rather than a degenerate
+one. -/
+lemma one_sub_sq_mul_sq_norm_pos (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    0 < 1 - t ^ 2 * ‖a‖ ^ 2 := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  nlinarith [mul_nonneg (by nlinarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
+
+/-- The Euclidean radius of a pseudo-hyperbolic ball is nonnegative. -/
+lemma pseudoHyperbolicRadius_nonneg (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    0 ≤ pseudoHyperbolicRadius a t := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  exact div_nonneg (mul_nonneg ht₀ (by linarith))
+    (one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁).le
+
+/-- The Euclidean radius of a pseudo-hyperbolic ball of positive radius is positive. -/
+lemma pseudoHyperbolicRadius_pos (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t ≤ 1) :
+    0 < pseudoHyperbolicRadius a t := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  exact div_pos (mul_pos ht₀ (by linarith))
+    (one_sub_sq_mul_sq_norm_pos ha ht₀.le ht₁)
+
+/-! ### The Euclidean disc lies inside the unit disc -/
+
+/-- **A pseudo-hyperbolic ball stays inside the unit disc**, quantitatively: the Euclidean centre
+and radius satisfy `‖c‖ + s < 1`, because
+`1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / (1 - t ^ 2 * ‖a‖ ^ 2)`
+and each of the three factors is positive. -/
+lemma norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one
+    (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    ‖pseudoHyperbolicCenter a t‖ + pseudoHyperbolicRadius a t < 1 := by
+  have hn : 0 ≤ ‖a‖ := norm_nonneg a
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hnum : 0 ≤ (1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := by
+    apply div_nonneg _ hD.le
+    nlinarith
+  have hcnorm : ‖pseudoHyperbolicCenter a t‖ = (1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) * ‖a‖ := by
+    rw [pseudoHyperbolicCenter_def, norm_smul, Real.norm_eq_abs, abs_of_nonneg hnum]
+  have hkey : 0 < (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) := by
+    refine mul_pos (mul_pos (by linarith) (by linarith)) ?_
+    nlinarith
+  rw [hcnorm, pseudoHyperbolicRadius_def, div_mul_eq_mul_div, ← add_div, div_lt_one hD]
+  nlinarith [hkey]
+
+/-- The closed Euclidean disc describing a pseudo-hyperbolic ball is contained in the open unit
+disc; a fortiori so is the open one. -/
+lemma closedBall_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) ⊆ ball (0 : ℂ) 1 := by
+  intro w hw
+  have h := norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one ha ht₀ ht₁
+  have hle : ‖w - pseudoHyperbolicCenter a t‖ ≤ pseudoHyperbolicRadius a t := by
+    simpa [dist_eq_norm] using hw
+  have : ‖w‖ ≤ ‖w - pseudoHyperbolicCenter a t‖ + ‖pseudoHyperbolicCenter a t‖ := by
+    simpa using norm_add_le (w - pseudoHyperbolicCenter a t) (pseudoHyperbolicCenter a t)
+  exact mem_ball_zero_iff.2 (by linarith)
+
+/-! ### The Apollonius identity -/
+
+/-- **The Apollonius identity for the Moebius factor.** For every `z : ℂ`,
+
+`‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2`
+`  = (1 - t ^ 2 * ‖a‖ ^ 2)`
+`      * (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2)`.
+
+Both sides are real quadratics in `z.re` and `z.im` with the same leading coefficient
+`1 - t ^ 2 * ‖a‖ ^ 2`, and the definitions of `TauCeti.pseudoHyperbolicCenter` and
+`TauCeti.pseudoHyperbolicRadius` are exactly what completes the square. No hypothesis is placed on
+`z`, and the disc hypothesis on `a` enters only through the nonvanishing of the denominator. -/
+theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
+    (hD : 1 - t ^ 2 * ‖a‖ ^ 2 ≠ 0) :
+    ‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2
+      = (1 - t ^ 2 * ‖a‖ ^ 2) *
+        (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2) := by
+  have hshift : ∀ k : ℝ, ‖z - k • a‖ ^ 2
+      = ‖z‖ ^ 2 - 2 * k * (z.re * a.re + z.im * a.im) + k ^ 2 * ‖a‖ ^ 2 := by
+    intro k
+    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im,
+      Complex.real_smul, Complex.mul_re, Complex.mul_im, Complex.ofReal_re, Complex.ofReal_im]
+    ring
+  have hsub : ‖z - a‖ ^ 2
+      = ‖z‖ ^ 2 - 2 * (z.re * a.re + z.im * a.im) + ‖a‖ ^ 2 := by
+    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im]
+    ring
+  have hmoebius : ‖1 - conj a * z‖ ^ 2
+      = 1 - 2 * (z.re * a.re + z.im * a.im) + ‖a‖ ^ 2 * ‖z‖ ^ 2 := by
+    simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_apply, Complex.sub_re, Complex.sub_im,
+      Complex.mul_re, Complex.mul_im, Complex.one_re, Complex.one_im, Complex.conj_re,
+      Complex.conj_im]
+    ring
+  rw [pseudoHyperbolicCenter_def, pseudoHyperbolicRadius_def, hshift, hsub, hmoebius]
+  obtain ⟨D, hDdef⟩ : ∃ D : ℝ, D = 1 - t ^ 2 * ‖a‖ ^ 2 := ⟨_, rfl⟩
+  rw [← hDdef] at hD ⊢
+  field_simp
+  subst hDdef
+  ring
+
+/-! ### Pseudo-hyperbolic balls are Euclidean discs -/
+
+/-- **The pseudo-hyperbolic ball is a Euclidean disc.** A point `z` of the unit disc satisfies
+`pseudoHyperbolicExpr z a < t` exactly when it lies in the Euclidean disc of centre
+`TauCeti.pseudoHyperbolicCenter a t` and radius `TauCeti.pseudoHyperbolicRadius a t`.
+
+Clearing the Moebius denominator — legitimate because `z` and `a` lie in the disc — turns the
+left-hand condition into `‖z - a‖ < t * ‖1 - conj a * z‖`, and squaring both sides makes
+`TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` applicable; the factor
+`1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive, so it does not affect the sign. -/
+theorem pseudoHyperbolicExpr_lt_iff_mem_ball (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
+    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    pseudoHyperbolicExpr z a < t ↔
+      z ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
+    norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
+  have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
+  rw [pseudoHyperbolicExpr_def, norm_div, div_lt_iff₀ hdenpos, mem_ball, dist_eq_norm,
+    ← sq_lt_sq₀ (norm_nonneg _) (by positivity),
+    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁.le), mul_pow]
+  constructor <;> intro h <;> nlinarith
+
+/-- **The closed pseudo-hyperbolic ball is a closed Euclidean disc**, the `≤` companion of
+`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof. -/
+theorem pseudoHyperbolicExpr_le_iff_mem_closedBall (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
+    (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    pseudoHyperbolicExpr z a ≤ t ↔
+      z ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
+  have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
+    norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
+  have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
+  rw [pseudoHyperbolicExpr_def, norm_div, div_le_iff₀ hdenpos, mem_closedBall, dist_eq_norm,
+    ← sq_le_sq₀ (norm_nonneg _) (by positivity),
+    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁.le), mul_pow]
+  constructor <;> intro h <;> nlinarith
+
+/-- The hyperbolic centre of a ball of positive radius lies in the Euclidean disc describing it —
+off centre, but inside. -/
+theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t < 1) :
+    a ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
+  (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha ht₀.le ht₁).1 (by simpa using ht₀)
+
+/-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. -/
+theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a < t}
+      = ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  ext w
+  simp only [mem_ball_zero_iff]
+  refine ⟨fun h => (pseudoHyperbolicExpr_lt_iff_mem_ball ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
+    ha ht₀ ht₁ (ball_subset_closedBall h)
+  exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 h⟩
+
+/-- **A closed pseudo-hyperbolic ball of the unit disc is a closed Euclidean disc**, in set
+form. -/
+theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t)
+    (ht₁ : t < 1) :
+    {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a ≤ t}
+      = closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  ext w
+  simp only [mem_ball_zero_iff]
+  refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
+  have hw : ‖w‖ < 1 :=
+    mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ h
+  exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).2 h⟩
+
+/-- **A pseudo-hyperbolic circle of the unit disc is a Euclidean circle**: the level set is the
+difference of the closed and the open disc. -/
+theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+    {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a = t}
+      = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  ext w
+  constructor
+  · rintro ⟨hw, heq⟩
+    rw [mem_ball_zero_iff] at hw
+    have hle := (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).1 heq.le
+    have hnlt : ¬ dist w (pseudoHyperbolicCenter a t) < pseudoHyperbolicRadius a t := fun hd => by
+      have := (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 (mem_ball.2 hd)
+      rw [heq] at this
+      exact lt_irrefl t this
+    exact mem_sphere.2 (le_antisymm (mem_closedBall.1 hle) (not_lt.1 hnlt))
+  · intro h
+    rw [mem_sphere] at h
+    have hle : w ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
+      mem_closedBall.2 h.le
+    have hw : ‖w‖ < 1 := mem_ball_zero_iff.1
+      (closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ hle)
+    refine ⟨mem_ball_zero_iff.2 hw,
+      le_antisymm ((pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁).2 hle) ?_⟩
+    by_contra hlt
+    have hb := (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).1 (not_le.1 hlt)
+    rw [mem_ball, h] at hb
+    exact lt_irrefl _ hb
+
+/-! ### Hyperbolic balls -/
+
+/-- `Real.tanh` is nonnegative on the nonnegative reals, so a hyperbolic radius `R ≥ 0`
+corresponds to a pseudo-hyperbolic radius `Real.tanh R ∈ [0, 1)`. -/
+lemma tanh_nonneg (hR : 0 ≤ R) : 0 ≤ Real.tanh R := by
+  by_contra h
+  have hneg : Real.tanh R < 0 := not_le.1 h
+  have hle : R ≤ 0 := by
+    have := Real.artanh_nonpos hneg.le
+    rwa [Real.artanh_tanh] at this
+  rw [le_antisymm hle hR, Real.tanh_zero] at hneg
+  exact lt_irrefl 0 hneg
+
+/-- The hyperbolic distance is below `R` exactly when the pseudo-hyperbolic expression is below
+`Real.tanh R`: the hyperbolic distance is `Real.artanh` of the pseudo-hyperbolic expression, and
+`Real.artanh` is the increasing inverse of `Real.tanh`. -/
+lemma hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    hyperbolicDist z a < R ↔ pseudoHyperbolicExpr z a < Real.tanh R := by
+  have hp₀ : 0 ≤ pseudoHyperbolicExpr z a := pseudoHyperbolicExpr_nonneg z a
+  have hp₁ : pseudoHyperbolicExpr z a < 1 := pseudoHyperbolicExpr_lt_one_of_norm_lt_one hz ha
+  rw [hyperbolicDist_def]
+  refine Iff.trans ?_ (Real.artanh_lt_artanh_iff (x := pseudoHyperbolicExpr z a)
+    (y := Real.tanh R) ⟨by linarith, hp₁⟩ ⟨Real.neg_one_lt_tanh R, Real.tanh_lt_one R⟩)
+  rw [Real.artanh_tanh]
+
+/-- The `≤` companion of `TauCeti.hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh`. -/
+lemma hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (ha : ‖a‖ < 1) (hz : ‖z‖ < 1) :
+    hyperbolicDist z a ≤ R ↔ pseudoHyperbolicExpr z a ≤ Real.tanh R := by
+  have hp₀ : 0 ≤ pseudoHyperbolicExpr z a := pseudoHyperbolicExpr_nonneg z a
+  have hp₁ : pseudoHyperbolicExpr z a < 1 := pseudoHyperbolicExpr_lt_one_of_norm_lt_one hz ha
+  rw [hyperbolicDist_def]
+  refine Iff.trans ?_ (Real.artanh_le_artanh_iff (x := pseudoHyperbolicExpr z a)
+    (y := Real.tanh R) ⟨by linarith, hp₁⟩ ⟨Real.neg_one_lt_tanh R, Real.tanh_lt_one R⟩)
+  rw [Real.artanh_tanh]
+
+/-- **A hyperbolic ball of the Poincaré disc is a Euclidean disc.** The hyperbolic ball of centre
+`a` and radius `R ≥ 0` is the Euclidean disc of centre
+`pseudoHyperbolicCenter a (Real.tanh R)` and radius `pseudoHyperbolicRadius a (Real.tanh R)`.
+
+The Euclidean centre is `a` only for `a = 0` or `R = 0`; for `a ≠ 0` the hyperbolic ball is an
+off-centre Euclidean disc, pulled towards the origin. Specialising to `a = 0` recovers
+`TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh` of `Poincare/Topology.lean`, where the
+Euclidean centre is the origin and the Euclidean radius is `Real.tanh R`. -/
+theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+    {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R}
+      = ball (pseudoHyperbolicCenter a (Real.tanh R)) (pseudoHyperbolicRadius a (Real.tanh R)) := by
+  rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg hR) (Real.tanh_lt_one R)]
+  ext w
+  simp only [mem_ball_zero_iff]
+  exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
+
+/-- **A closed hyperbolic ball of the Poincaré disc is a closed Euclidean disc**, the `≤`
+companion of `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`. -/
+theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+    {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a ≤ R}
+      = closedBall (pseudoHyperbolicCenter a (Real.tanh R))
+        (pseudoHyperbolicRadius a (Real.tanh R)) := by
+  rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (tanh_nonneg hR) (Real.tanh_lt_one R)]
+  ext w
+  simp only [mem_ball_zero_iff]
+  exact and_congr_right fun hw => hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh ha hw
+
+/-- **Hyperbolic balls are Euclidean-convex.** Being Euclidean discs, the balls of the hyperbolic
+metric are convex for the linear structure of `ℂ`. This is not the geodesic convexity of the
+hyperbolic metric, which is a separate statement about the hyperbolic geodesics of
+`Poincare/Geodesic.lean`; it is the stronger Euclidean one, and it has no proof internal to the
+hyperbolic metric. -/
+theorem convex_sep_ball_hyperbolicDist_lt (ha : ‖a‖ < 1) (hR : 0 ≤ R) :
+    Convex ℝ {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R} := by
+  rw [sep_ball_hyperbolicDist_lt_eq_ball ha hR]
+  exact convex_ball _ _
+
+namespace PoincareDisc
+
+/-- **The balls of the Poincaré metric space, read on the Euclidean disc.** A point of
+`TauCeti.PoincareDisc` lies in the hyperbolic ball of centre `x` and radius `R ≥ 0` exactly when
+its Euclidean coordinate lies in the corresponding Euclidean disc. -/
+theorem mem_ball_iff (x w : PoincareDisc) (hR : 0 ≤ R) :
+    w ∈ ball x R ↔ (toUnitDisc w : ℂ) ∈
+      ball (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
+        (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
+  rw [mem_ball, dist_eq]
+  exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
+    (toUnitDisc w).norm_lt_one).trans
+    (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
+      (tanh_nonneg hR) (Real.tanh_lt_one R))
+
+end PoincareDisc
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -66,14 +66,16 @@ both sides: `p` is nonnegative, so the pseudo-hyperbolic condition is unsatisfia
 Euclidean radius `s` is then negative (`TauCeti.pseudoHyperbolicRadius_neg`), so the Euclidean
 disc is empty as well.
 
-The *set-level* statements do restrict `t`, because they describe the intersection with `𝔻` and
-so need the Euclidean disc to lie inside it. The endpoint `t = 1` is admitted by the open ball
-(`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`, on `-1 ≤ t ≤ 1`), where `c = 0` and `s = 1`
+The *set-level* statements assume `0 < D` as well, and add to it only an *upper* bound on `t`,
+because they describe the intersection with `𝔻` and so need the Euclidean disc to lie inside it.
+The endpoint `t = 1` is admitted by the open ball
+(`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`, on `t ≤ 1`), where `c = 0` and `s = 1`
 and the description degenerates to the statement that `p (·, a) < 1` cuts out all of `𝔻`; the
 closed disc and the circle need `t < 1`, since at `t = 1` they would contain the unit circle,
-which the pseudo-hyperbolic conditions never reach. It is exactly this range that makes the
+which the pseudo-hyperbolic conditions never reach. No lower bound on `t` is asked for: exactly as
+in the pointwise statements, a negative `t` empties both sides. It is this range that makes the
 statements about the hyperbolic metric unconditional in `R`, since `Real.tanh R` always lies in
-`(-1, 1)`.
+`(-1, 1)` (`TauCeti.one_sub_sq_tanh_mul_sq_norm_pos`).
 
 The Euclidean centre `c` is *not* `a` unless `a = 0` or `t = 0`: a hyperbolic ball is a Euclidean
 disc, but an off-centre one, its Euclidean centre pulled towards the origin by the factor
@@ -185,27 +187,39 @@ noncomputable def pseudoHyperbolicCenter (a : ℂ) (t : ℝ) : ℂ :=
 noncomputable def pseudoHyperbolicRadius (a : ℂ) (t : ℝ) : ℝ :=
   t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)
 
+/-- The defining formula for `TauCeti.pseudoHyperbolicCenter`, so that the advertised expression
+is available without unfolding the definition. -/
+lemma pseudoHyperbolicCenter_def (a : ℂ) (t : ℝ) :
+    pseudoHyperbolicCenter a t = ((1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2)) • a := by
+  rw [pseudoHyperbolicCenter]
+
+/-- The defining formula for `TauCeti.pseudoHyperbolicRadius`, so that the advertised expression
+is available without unfolding the definition. -/
+lemma pseudoHyperbolicRadius_def (a : ℂ) (t : ℝ) :
+    pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) := by
+  rw [pseudoHyperbolicRadius]
+
 /-- Balls centred at the origin are unmoved: the Euclidean centre of a pseudo-hyperbolic ball
 about `0` is `0`. -/
 @[simp]
 lemma pseudoHyperbolicCenter_zero_left (t : ℝ) : pseudoHyperbolicCenter 0 t = 0 := by
-  simp [pseudoHyperbolicCenter]
+  simp [pseudoHyperbolicCenter_def]
 
 /-- Balls centred at the origin have their Euclidean radius equal to the pseudo-hyperbolic one,
 so that at the origin the two descriptions of a ball coincide. -/
 @[simp]
 lemma pseudoHyperbolicRadius_zero_left (t : ℝ) : pseudoHyperbolicRadius 0 t = t := by
-  simp [pseudoHyperbolicRadius]
+  simp [pseudoHyperbolicRadius_def]
 
 /-- A ball of radius `0` is centred at its hyperbolic centre. -/
 @[simp]
 lemma pseudoHyperbolicCenter_zero_right (a : ℂ) : pseudoHyperbolicCenter a 0 = a := by
-  simp [pseudoHyperbolicCenter]
+  simp [pseudoHyperbolicCenter_def]
 
 /-- A ball of radius `0` has Euclidean radius `0`. -/
 @[simp]
 lemma pseudoHyperbolicRadius_zero_right (a : ℂ) : pseudoHyperbolicRadius a 0 = 0 := by
-  simp [pseudoHyperbolicRadius]
+  simp [pseudoHyperbolicRadius_def]
 
 /-- The denominator `1 - t ^ 2 * ‖a‖ ^ 2` is positive for a disc centre and a radius in
 `[-1, 1]`. Its positivity — the hypothesis the pointwise results below actually run on — is what
@@ -217,6 +231,13 @@ lemma one_sub_sq_mul_sq_norm_pos (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : 
   have ht2 : t ^ 2 ≤ 1 := by
     nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 + t) (by linarith : (0 : ℝ) ≤ 1 - t)]
   nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
+
+/-- The denominator is positive at the pseudo-hyperbolic radius `Real.tanh R` of a hyperbolic
+ball, whatever the hyperbolic radius `R`, since `Real.tanh` takes its values in `(-1, 1)`. This is
+how every statement about the hyperbolic metric discharges that hypothesis. -/
+lemma one_sub_sq_tanh_mul_sq_norm_pos (ha : ‖a‖ < 1) (R : ℝ) :
+    0 < 1 - Real.tanh R ^ 2 * ‖a‖ ^ 2 :=
+  one_sub_sq_mul_sq_norm_pos ha (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le
 
 /-- The Euclidean radius of a pseudo-hyperbolic ball of nonnegative radius is nonnegative. -/
 lemma pseudoHyperbolicRadius_nonneg (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht : 0 ≤ t) :
@@ -255,11 +276,11 @@ lemma norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one
     apply div_nonneg _ hD.le
     nlinarith
   have hcnorm : ‖pseudoHyperbolicCenter a t‖ = (1 - t ^ 2) / (1 - t ^ 2 * ‖a‖ ^ 2) * ‖a‖ := by
-    rw [pseudoHyperbolicCenter, norm_smul, Real.norm_eq_abs, abs_of_nonneg hnum]
+    rw [pseudoHyperbolicCenter_def, norm_smul, Real.norm_eq_abs, abs_of_nonneg hnum]
   have hkey : 0 < (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) := by
     refine mul_pos (mul_pos (by linarith) (by linarith)) ?_
     nlinarith
-  rw [hcnorm, pseudoHyperbolicRadius, div_mul_eq_mul_div, ← add_div, div_lt_one hD]
+  rw [hcnorm, pseudoHyperbolicRadius_def, div_mul_eq_mul_div, ← add_div, div_lt_one hD]
   nlinarith [hkey]
 
 /-- The closed Euclidean disc describing a pseudo-hyperbolic ball is contained in the open unit
@@ -280,9 +301,9 @@ lemma ball_pseudoHyperbolicCenter_subset_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ 
   · exact ball_subset_closedBall.trans (closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht)
   · subst ht
     have hne : 1 - ‖a‖ ^ 2 ≠ 0 := by nlinarith [norm_nonneg a]
-    have hc : pseudoHyperbolicCenter a 1 = 0 := by simp [pseudoHyperbolicCenter]
+    have hc : pseudoHyperbolicCenter a 1 = 0 := by simp [pseudoHyperbolicCenter_def]
     have hs : pseudoHyperbolicRadius a 1 = 1 := by
-      rw [pseudoHyperbolicRadius, one_pow, one_mul, one_mul, div_self hne]
+      rw [pseudoHyperbolicRadius_def, one_pow, one_mul, one_mul, div_self hne]
     intro w hw
     rwa [hc, hs] at hw
 
@@ -320,7 +341,7 @@ theorem sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul (a z : ℂ) (t : ℝ)
       = 1 + ‖a‖ ^ 2 * ‖z‖ ^ 2 - 2 * (z * conj a).re := by
     simp only [← Complex.normSq_eq_norm_sq, Complex.normSq_sub, Complex.normSq_one,
       Complex.normSq_conj, map_mul, Complex.conj_conj, one_mul, hre]
-  rw [pseudoHyperbolicCenter, pseudoHyperbolicRadius, hshift, hsub, hmoebius]
+  rw [pseudoHyperbolicCenter_def, pseudoHyperbolicRadius_def, hshift, hsub, hmoebius]
   obtain ⟨D, hDdef⟩ : ∃ D : ℝ, D = 1 - t ^ 2 * ‖a‖ ^ 2 := ⟨_, rfl⟩
   rw [← hDdef] at hD ⊢
   field_simp
@@ -404,12 +425,14 @@ theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (hD : 0 < 1 - t ^ 2 *
     a ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
   (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha hD).1 (by simpa using ht)
 
-/-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. The endpoint
-`t = 1` is allowed, and there both sides are the unit disc; for `t < 0` both sides are empty. -/
-theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
+/-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. Beyond the
+positivity of `1 - t ^ 2 * ‖a‖ ^ 2` shared with the pointwise form, only an upper bound on `t` is
+needed, so that the Euclidean disc lies inside `𝔻`. The endpoint `t = 1` is allowed, and there
+both sides are the unit disc; for `t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1)
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht₁ : t ≤ 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a < t}
       = ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
   rcases lt_or_ge t 0 with ht | ht
   · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_neg ha hD ht).le]
     exact eq_empty_of_forall_notMem fun w hw =>
@@ -422,12 +445,13 @@ theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : -1 
   exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw hD).2 h⟩
 
 /-- **A closed pseudo-hyperbolic ball of the unit disc is a closed Euclidean disc**, in set
-form. For `t < 0` both sides are empty. -/
-theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t)
-    (ht₁ : t < 1) :
+form. As for `TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball` the radius is bounded only from
+above, here strictly, since at `t = 1` the closed Euclidean disc would meet the unit circle. For
+`t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1)
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a ≤ t}
       = closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
   rcases lt_or_ge t 0 with ht | ht
   · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_neg ha hD ht)]
     exact eq_empty_of_forall_notMem fun w hw =>
@@ -440,11 +464,13 @@ theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀
   exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw hD).2 h⟩
 
 /-- **A pseudo-hyperbolic circle of the unit disc is a Euclidean circle**: the level set is the
-difference of the closed and the open disc. For `t < 0` both sides are empty. -/
-theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t < 1) :
+difference of the closed and the open disc. The hypotheses are those of
+`TauCeti.sep_ball_pseudoHyperbolicExpr_le_eq_closedBall`, of which this is the boundary part. For
+`t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1)
+    (hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2) (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a = t}
       = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁.le
   rcases lt_or_ge t 0 with ht | ht
   · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_neg ha hD ht)]
     exact eq_empty_of_forall_notMem fun w hw =>
@@ -504,7 +530,7 @@ origin and the Euclidean radius is `Real.tanh R`
 theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R}
       = ball (pseudoHyperbolicCenter a (Real.tanh R)) (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (Real.neg_one_lt_tanh R).le
+  rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (one_sub_sq_tanh_mul_sq_norm_pos ha R)
     (Real.tanh_lt_one R).le]
   ext w
   simp only [mem_ball_zero_iff]
@@ -520,7 +546,7 @@ theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a ≤ R}
       = closedBall (pseudoHyperbolicCenter a (Real.tanh R))
         (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (Real.neg_one_lt_tanh R).le
+  rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (one_sub_sq_tanh_mul_sq_norm_pos ha R)
     (Real.tanh_lt_one R)]
   ext w
   simp only [mem_ball_zero_iff]
@@ -532,7 +558,7 @@ theorem sep_ball_hyperbolicDist_eq_eq_sphere (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a = R}
       = sphere (pseudoHyperbolicCenter a (Real.tanh R))
         (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rw [← sep_ball_pseudoHyperbolicExpr_eq_eq_sphere ha (Real.neg_one_lt_tanh R).le
+  rw [← sep_ball_pseudoHyperbolicExpr_eq_eq_sphere ha (one_sub_sq_tanh_mul_sq_norm_pos ha R)
     (Real.tanh_lt_one R)]
   ext w
   simp only [mem_ball_zero_iff]
@@ -550,13 +576,6 @@ theorem convex_sep_ball_hyperbolicDist_lt (ha : ‖a‖ < 1) :
 
 namespace PoincareDisc
 
-/-- The denominator of the Apollonius identity is positive at any point of the Poincaré disc and
-any hyperbolic radius, since `Real.tanh` takes values in `(-1, 1)`. -/
-private lemma one_sub_sq_tanh_mul_sq_norm_pos (x : PoincareDisc) (R : ℝ) :
-    0 < 1 - Real.tanh R ^ 2 * ‖(toUnitDisc x : ℂ)‖ ^ 2 :=
-  one_sub_sq_mul_sq_norm_pos (toUnitDisc x).norm_lt_one (Real.neg_one_lt_tanh R).le
-    (Real.tanh_lt_one R).le
-
 /-- **The balls of the Poincaré metric space, read on the Euclidean disc.** A point of
 `TauCeti.PoincareDisc` lies in the hyperbolic ball of centre `x` and radius `R` exactly when its
 Euclidean coordinate lies in the corresponding Euclidean disc; for `R < 0` both sides are
@@ -569,7 +588,7 @@ theorem mem_ball_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
-      (one_sub_sq_tanh_mul_sq_norm_pos x R))
+      (one_sub_sq_tanh_mul_sq_norm_pos (toUnitDisc x).norm_lt_one R))
 
 /-- **The closed balls of the Poincaré metric space, read on the Euclidean disc**, the `≤`
 companion of `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -581,7 +600,7 @@ theorem mem_closedBall_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos x R))
+      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos (toUnitDisc x).norm_lt_one R))
 
 /-- **The spheres of the Poincaré metric space, read on the Euclidean disc**, the `=` companion of
 `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -593,7 +612,7 @@ theorem mem_sphere_iff (x w : PoincareDisc) :
   exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
     (toUnitDisc w).norm_lt_one).trans
     (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos x R))
+      (toUnitDisc w).norm_lt_one (one_sub_sq_tanh_mul_sq_norm_pos (toUnitDisc x).norm_lt_one R))
 
 end PoincareDisc
 

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean
@@ -55,12 +55,18 @@ unit disc: `‖c‖ + s < 1` because
 `1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / D`
 (`TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`). So the restriction to
 the disc in the set equalities is a genuine description of a subset of `𝔻`, not an artefact.
-Third, the endpoint `t = 1` is allowed wherever it is true: the denominator `D` stays positive, and
-`c = 0`, `s = 1`, so the descriptions of the *open* ball
-(`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
-`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`) degenerate to the statement that `p (·, a) < 1`
-cuts out all of `𝔻`. Only the closed disc and the circle need `t < 1`: at `t = 1` they would
-contain the unit circle, which the pseudo-hyperbolic conditions never reach.
+Third, both ends of the range `-1 ≤ t ≤ 1` are allowed wherever they are true. The endpoint
+`t = 1` is admitted by the *open* ball (`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball`,
+`TauCeti.sep_ball_pseudoHyperbolicExpr_lt_eq_ball`): the denominator `D` stays positive, and
+`c = 0`, `s = 1`, so the description degenerates to the statement that `p (·, a) < 1` cuts out all
+of `𝔻`. Only the closed disc and the circle need `t < 1`: at `t = 1` they would contain the unit
+circle, which the pseudo-hyperbolic conditions never reach. At the other end a negative `t` is
+admitted throughout and is vacuous on both sides: `p` is nonnegative, so the pseudo-hyperbolic
+condition is unsatisfiable, and the Euclidean radius `s` is then negative
+(`TauCeti.pseudoHyperbolicRadius_neg`), so the Euclidean disc is empty as well. The lower bound
+`-1 ≤ t` is needed: for `t < -1` the denominator `D` can be negative and `s` positive again, and
+the Euclidean disc is no longer empty. It is exactly this range that makes the statements about
+the hyperbolic metric unconditional in `R`, since `Real.tanh R` always lies in `(-1, 1)`.
 
 The Euclidean centre `c` is *not* `a` unless `a = 0` or `t = 0`: a hyperbolic ball is a Euclidean
 disc, but an off-centre one, its Euclidean centre pulled towards the origin by the factor
@@ -227,15 +233,16 @@ lemma pseudoHyperbolicRadius_pos (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t �
   exact div_pos (mul_pos ht₀ (by linarith))
     (one_sub_sq_mul_sq_norm_pos ha ht₀.le ht₁)
 
-/-- A negative pseudo-hyperbolic radius `t ∈ (-1, 0)` gives a negative Euclidean radius, so that
+/-- A negative pseudo-hyperbolic radius `t ∈ [-1, 0)` gives a negative Euclidean radius, so that
 the Euclidean disc it describes is empty — as is the pseudo-hyperbolic ball of radius `t`. -/
-lemma pseudoHyperbolicRadius_neg (ha : ‖a‖ < 1) (ht₀ : -1 < t) (ht₁ : t < 0) :
+lemma pseudoHyperbolicRadius_neg (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t < 0) :
     pseudoHyperbolicRadius a t < 0 := by
   have hn : 0 ≤ ‖a‖ := norm_nonneg a
   have hn2 : ‖a‖ ^ 2 < 1 := by nlinarith
+  have ht2 : t ^ 2 ≤ 1 := by
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 + t) (by linarith : (0 : ℝ) ≤ 1 - t)]
   have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := by
-    nlinarith [mul_nonneg (sq_nonneg t) (by linarith : (0 : ℝ) ≤ 1 - ‖a‖ ^ 2),
-      mul_pos (by linarith : (0 : ℝ) < 1 - t) (by linarith : (0 : ℝ) < 1 + t)]
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t ^ 2) (sq_nonneg ‖a‖)]
   rw [pseudoHyperbolicRadius_def]
   exact div_neg_of_neg_of_pos (mul_neg_of_neg_of_pos ht₁ (by linarith)) hD
 
@@ -337,43 +344,53 @@ left-hand condition into `‖z - a‖ < t * ‖1 - conj a * z‖`, and squaring 
 `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul` applicable; the factor
 `1 - t ^ 2 * ‖a‖ ^ 2` it produces is positive, so it does not affect the sign.
 
-The endpoint `t = 1` is allowed, and there both sides say that `z` lies in the unit disc. -/
+Both endpoints are allowed: at `t = 1` the two sides say that `z` lies in the unit disc, and for
+`t < 0` both are empty, the Euclidean radius being negative. -/
 theorem pseudoHyperbolicExpr_lt_iff_mem_ball (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a < t ↔
       z ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
+  rcases lt_or_ge t 0 with ht | ht
+  · rw [mem_ball]
+    exact iff_of_false (not_lt.2 (ht.le.trans (pseudoHyperbolicExpr_nonneg z a)))
+      (not_lt.2 ((pseudoHyperbolicRadius_neg ha ht₀ ht).le.trans dist_nonneg))
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht ht₁
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_lt_iff₀ hdenpos, mem_ball, dist_eq_norm,
     ← sq_lt_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁), mul_pow]
+    ← sq_lt_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht ht₁), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The closed pseudo-hyperbolic ball is a closed Euclidean disc**, the `≤` companion of
-`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof, and like it valid up to the
-endpoint `t = 1`, where the closed Euclidean disc is the closed unit disc. -/
+`TauCeti.pseudoHyperbolicExpr_lt_iff_mem_ball` with the same proof, and like it valid on the whole
+range `-1 ≤ t ≤ 1`: at `t = 1` the closed Euclidean disc is the closed unit disc, and for `t < 0`
+both sides are empty. -/
 theorem pseudoHyperbolicExpr_le_iff_mem_closedBall (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a ≤ t ↔
       z ∈ closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
-  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht₀ ht₁
+  rcases lt_or_ge t 0 with ht | ht
+  · rw [mem_closedBall]
+    exact iff_of_false (not_le.2 (ht.trans_le (pseudoHyperbolicExpr_nonneg z a)))
+      (not_le.2 ((pseudoHyperbolicRadius_neg ha ht₀ ht).trans_le dist_nonneg))
+  have hD : 0 < 1 - t ^ 2 * ‖a‖ ^ 2 := one_sub_sq_mul_sq_norm_pos ha ht ht₁
   have hdenpos : 0 < ‖(1 : ℂ) - conj a * z‖ :=
     norm_pos_iff.2 (one_sub_conj_mul_ne_zero_of_norm_lt_one hz ha)
   have hid := sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul a z t hD.ne'
   rw [pseudoHyperbolicExpr_def, norm_div, div_le_iff₀ hdenpos, mem_closedBall, dist_eq_norm,
     ← sq_le_sq₀ (norm_nonneg _) (by positivity),
-    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht₀ ht₁), mul_pow]
+    ← sq_le_sq₀ (norm_nonneg _) (pseudoHyperbolicRadius_nonneg ha ht ht₁), mul_pow]
   constructor <;> intro h <;> nlinarith
 
 /-- **The pseudo-hyperbolic circle is a Euclidean circle.** A point `z` of the unit disc satisfies
 `pseudoHyperbolicExpr z a = t` exactly when it lies on the Euclidean circle of centre
 `TauCeti.pseudoHyperbolicCenter a t` and radius `TauCeti.pseudoHyperbolicRadius a t`: the level
 set is what the closed disc has and the open one has not. The endpoint `t = 1` is allowed, and
-there both sides are empty. -/
+there — as for `t < 0` — both sides are empty. -/
 theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ < 1)
-    (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+    (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     pseudoHyperbolicExpr z a = t ↔
       z ∈ sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
   have hle := pseudoHyperbolicExpr_le_iff_mem_closedBall ha hz ht₀ ht₁
@@ -390,63 +407,59 @@ theorem pseudoHyperbolicExpr_eq_iff_mem_sphere (ha : ‖a‖ < 1) (hz : ‖z‖ 
 off centre, but inside. -/
 theorem mem_ball_pseudoHyperbolicCenter (ha : ‖a‖ < 1) (ht₀ : 0 < t) (ht₁ : t ≤ 1) :
     a ∈ ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) :=
-  (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha ht₀.le ht₁).1 (by simpa using ht₀)
+  (pseudoHyperbolicExpr_lt_iff_mem_ball ha ha (by linarith) ht₁).1 (by simpa using ht₀)
 
 /-- **A pseudo-hyperbolic ball of the unit disc is a Euclidean disc**, in set form. The endpoint
-`t = 1` is allowed, and there both sides are the unit disc. -/
-theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t ≤ 1) :
+`t = 1` is allowed, and there both sides are the unit disc; for `t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_lt_eq_ball (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t ≤ 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a < t}
       = ball (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  rcases lt_or_ge t 0 with ht | ht
+  · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_neg ha ht₀ ht).le]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd hw.2 (not_lt.2 (ht.le.trans (pseudoHyperbolicExpr_nonneg w a)))
   ext w
   simp only [mem_ball_zero_iff]
   refine ⟨fun h => (pseudoHyperbolicExpr_lt_iff_mem_ball ha h.1 ht₀ ht₁).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 :=
-    mem_ball_zero_iff.1 <| ball_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ h
+    mem_ball_zero_iff.1 <| ball_pseudoHyperbolicCenter_subset_ball ha ht ht₁ h
   exact ⟨hw, (pseudoHyperbolicExpr_lt_iff_mem_ball ha hw ht₀ ht₁).2 h⟩
 
 /-- **A closed pseudo-hyperbolic ball of the unit disc is a closed Euclidean disc**, in set
-form. -/
-theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t)
+form. For `t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_le_eq_closedBall (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t)
     (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a ≤ t}
       = closedBall (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  rcases lt_or_ge t 0 with ht | ht
+  · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_neg ha ht₀ ht)]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd hw.2 (not_le.2 (ht.trans_le (pseudoHyperbolicExpr_nonneg w a)))
   ext w
   simp only [mem_ball_zero_iff]
   refine ⟨fun h => (pseudoHyperbolicExpr_le_iff_mem_closedBall ha h.1 ht₀ ht₁.le).1 h.2,
     fun h => ?_⟩
   have hw : ‖w‖ < 1 :=
-    mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball ha ht₀ ht₁ h
+    mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball ha ht ht₁ h
   exact ⟨hw, (pseudoHyperbolicExpr_le_iff_mem_closedBall ha hw ht₀ ht₁.le).2 h⟩
 
 /-- **A pseudo-hyperbolic circle of the unit disc is a Euclidean circle**: the level set is the
-difference of the closed and the open disc. -/
-theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : 0 ≤ t) (ht₁ : t < 1) :
+difference of the closed and the open disc. For `t < 0` both sides are empty. -/
+theorem sep_ball_pseudoHyperbolicExpr_eq_eq_sphere (ha : ‖a‖ < 1) (ht₀ : -1 ≤ t) (ht₁ : t < 1) :
     {z ∈ ball (0 : ℂ) 1 | pseudoHyperbolicExpr z a = t}
       = sphere (pseudoHyperbolicCenter a t) (pseudoHyperbolicRadius a t) := by
+  rcases lt_or_ge t 0 with ht | ht
+  · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_neg ha ht₀ ht)]
+    exact eq_empty_of_forall_notMem fun w hw =>
+      absurd (hw.2 ▸ pseudoHyperbolicExpr_nonneg w a) (not_le.2 ht)
   ext w
   simp only [mem_ball_zero_iff]
   refine ⟨fun h => (pseudoHyperbolicExpr_eq_iff_mem_sphere ha h.1 ht₀ ht₁.le).1 h.2, fun h => ?_⟩
   have hw : ‖w‖ < 1 := mem_ball_zero_iff.1 <| closedBall_pseudoHyperbolicCenter_subset_ball
-    ha ht₀ ht₁ (sphere_subset_closedBall h)
+    ha ht ht₁ (sphere_subset_closedBall h)
   exact ⟨hw, (pseudoHyperbolicExpr_eq_iff_mem_sphere ha hw ht₀ ht₁.le).2 h⟩
 
 /-! ### Hyperbolic balls -/
-
-/-- `Real.tanh` is nonnegative exactly on the nonnegative reals, so a hyperbolic radius `R ≥ 0`
-corresponds to a pseudo-hyperbolic radius `Real.tanh R ∈ [0, 1)` and a negative one to a negative
-`Real.tanh R`. This reads off the sign of `Real.tanh` from its exponential form; it is a local
-helper, not part of the API of this file. -/
-private lemma tanh_nonneg_iff : 0 ≤ Real.tanh R ↔ 0 ≤ R := by
-  have hpos : 0 < Real.exp R + Real.exp (-R) := by positivity
-  rw [Real.tanh_eq, le_div_iff₀ hpos, zero_mul, sub_nonneg, Real.exp_le_exp]
-  constructor <;> intro h <;> linarith
-
-/-- For a negative hyperbolic radius the Euclidean radius is negative, so that the Euclidean disc
-attached to it — like the hyperbolic ball itself — is empty. -/
-private lemma pseudoHyperbolicRadius_tanh_neg (ha : ‖a‖ < 1) (hR : R < 0) :
-    pseudoHyperbolicRadius a (Real.tanh R) < 0 :=
-  pseudoHyperbolicRadius_neg ha (Real.neg_one_lt_tanh R)
-    (not_le.1 fun h => absurd (tanh_nonneg_iff.1 h) (not_le.2 hR))
 
 /-- The hyperbolic distance is below `R` exactly when the pseudo-hyperbolic expression is below
 `Real.tanh R`: the hyperbolic distance is `Real.artanh` of the pseudo-hyperbolic expression, and
@@ -494,15 +507,11 @@ origin and the Euclidean radius is `Real.tanh R`
 theorem sep_ball_hyperbolicDist_lt_eq_ball (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a < R}
       = ball (pseudoHyperbolicCenter a (Real.tanh R)) (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [ball_eq_empty.2 (pseudoHyperbolicRadius_tanh_neg ha hR).le]
-    exact eq_empty_of_forall_notMem fun w hw =>
-      absurd (hw.2.trans hR) (not_lt.2 (hyperbolicDist_nonneg w a))
-  · rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (tanh_nonneg_iff.2 hR)
-      (Real.tanh_lt_one R).le]
-    ext w
-    simp only [mem_ball_zero_iff]
-    exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
+  rw [← sep_ball_pseudoHyperbolicExpr_lt_eq_ball ha (Real.neg_one_lt_tanh R).le
+    (Real.tanh_lt_one R).le]
+  ext w
+  simp only [mem_ball_zero_iff]
+  exact and_congr_right fun hw => hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh ha hw
 
 /-- **A closed hyperbolic ball of the Poincaré disc is a closed Euclidean disc**, the `≤`
 companion of `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`.
@@ -514,15 +523,11 @@ theorem sep_ball_hyperbolicDist_le_eq_closedBall (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a ≤ R}
       = closedBall (pseudoHyperbolicCenter a (Real.tanh R))
         (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [closedBall_eq_empty.2 (pseudoHyperbolicRadius_tanh_neg ha hR)]
-    exact eq_empty_of_forall_notMem fun w hw =>
-      absurd (hw.2.trans_lt hR) (not_lt.2 (hyperbolicDist_nonneg w a))
-  · rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (tanh_nonneg_iff.2 hR)
-      (Real.tanh_lt_one R)]
-    ext w
-    simp only [mem_ball_zero_iff]
-    exact and_congr_right fun hw => hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh ha hw
+  rw [← sep_ball_pseudoHyperbolicExpr_le_eq_closedBall ha (Real.neg_one_lt_tanh R).le
+    (Real.tanh_lt_one R)]
+  ext w
+  simp only [mem_ball_zero_iff]
+  exact and_congr_right fun hw => hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh ha hw
 
 /-- **A hyperbolic circle of the Poincaré disc is a Euclidean circle**, the `=` companion of
 `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball`. -/
@@ -530,15 +535,11 @@ theorem sep_ball_hyperbolicDist_eq_eq_sphere (ha : ‖a‖ < 1) :
     {z ∈ ball (0 : ℂ) 1 | hyperbolicDist z a = R}
       = sphere (pseudoHyperbolicCenter a (Real.tanh R))
         (pseudoHyperbolicRadius a (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [sphere_eq_empty_of_neg (pseudoHyperbolicRadius_tanh_neg ha hR)]
-    exact eq_empty_of_forall_notMem fun w hw =>
-      absurd (hw.2 ▸ hyperbolicDist_nonneg w a) (not_le.2 hR)
-  · rw [← sep_ball_pseudoHyperbolicExpr_eq_eq_sphere ha (tanh_nonneg_iff.2 hR)
-      (Real.tanh_lt_one R)]
-    ext w
-    simp only [mem_ball_zero_iff]
-    exact and_congr_right fun hw => hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh ha hw
+  rw [← sep_ball_pseudoHyperbolicExpr_eq_eq_sphere ha (Real.neg_one_lt_tanh R).le
+    (Real.tanh_lt_one R)]
+  ext w
+  simp only [mem_ball_zero_iff]
+  exact and_congr_right fun hw => hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh ha hw
 
 /-- **Hyperbolic balls are Euclidean-convex.** Being Euclidean discs, the balls of the hyperbolic
 metric are convex for the linear structure of `ℂ`. This is a different notion from the geodesic
@@ -560,16 +561,11 @@ theorem mem_ball_iff (x w : PoincareDisc) :
     w ∈ ball x R ↔ (toUnitDisc w : ℂ) ∈
       ball (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
         (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [mem_ball, mem_ball, dist_eq]
-    exact iff_of_false (not_lt.2 (hR.le.trans (hyperbolicDist_nonneg _ _)))
-      (not_lt.2 ((pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR).le.trans
-        dist_nonneg))
-  · rw [mem_ball, dist_eq]
-    exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one).trans
-      (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
-        (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
+  rw [mem_ball, dist_eq]
+  exact (hyperbolicDist_lt_iff_pseudoHyperbolicExpr_lt_tanh (toUnitDisc x).norm_lt_one
+    (toUnitDisc w).norm_lt_one).trans
+    (pseudoHyperbolicExpr_lt_iff_mem_ball (toUnitDisc x).norm_lt_one (toUnitDisc w).norm_lt_one
+      (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
 
 /-- **The closed balls of the Poincaré metric space, read on the Euclidean disc**, the `≤`
 companion of `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -577,16 +573,11 @@ theorem mem_closedBall_iff (x w : PoincareDisc) :
     w ∈ closedBall x R ↔ (toUnitDisc w : ℂ) ∈
       closedBall (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
         (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [mem_closedBall, mem_closedBall, dist_eq]
-    exact iff_of_false (not_le.2 (hR.trans_le (hyperbolicDist_nonneg _ _)))
-      (not_le.2 ((pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR).trans_le
-        dist_nonneg))
-  · rw [mem_closedBall, dist_eq]
-    exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one).trans
-      (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
-        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
+  rw [mem_closedBall, dist_eq]
+  exact (hyperbolicDist_le_iff_pseudoHyperbolicExpr_le_tanh (toUnitDisc x).norm_lt_one
+    (toUnitDisc w).norm_lt_one).trans
+    (pseudoHyperbolicExpr_le_iff_mem_closedBall (toUnitDisc x).norm_lt_one
+      (toUnitDisc w).norm_lt_one (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
 
 /-- **The spheres of the Poincaré metric space, read on the Euclidean disc**, the `=` companion of
 `TauCeti.PoincareDisc.mem_ball_iff`. -/
@@ -594,16 +585,11 @@ theorem mem_sphere_iff (x w : PoincareDisc) :
     w ∈ sphere x R ↔ (toUnitDisc w : ℂ) ∈
       sphere (pseudoHyperbolicCenter (toUnitDisc x : ℂ) (Real.tanh R))
         (pseudoHyperbolicRadius (toUnitDisc x : ℂ) (Real.tanh R)) := by
-  rcases lt_or_ge R 0 with hR | hR
-  · rw [mem_sphere, mem_sphere, dist_eq]
-    exact iff_of_false (fun h => absurd (h ▸ hyperbolicDist_nonneg _ _) (not_le.2 hR))
-      (fun h => absurd (h ▸ dist_nonneg)
-        (not_le.2 (pseudoHyperbolicRadius_tanh_neg (toUnitDisc x).norm_lt_one hR)))
-  · rw [mem_sphere, dist_eq]
-    exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
-      (toUnitDisc w).norm_lt_one).trans
-      (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
-        (toUnitDisc w).norm_lt_one (tanh_nonneg_iff.2 hR) (Real.tanh_lt_one R).le)
+  rw [mem_sphere, dist_eq]
+  exact (hyperbolicDist_eq_iff_pseudoHyperbolicExpr_eq_tanh (toUnitDisc x).norm_lt_one
+    (toUnitDisc w).norm_lt_one).trans
+    (pseudoHyperbolicExpr_eq_iff_mem_sphere (toUnitDisc x).norm_lt_one
+      (toUnitDisc w).norm_lt_one (Real.neg_one_lt_tanh R).le (Real.tanh_lt_one R).le)
 
 end PoincareDisc
 


### PR DESCRIPTION
This PR identifies the hyperbolic balls of the Poincaré disc as Euclidean discs, computing their Euclidean centre and radius explicitly. The new module `TauCeti/Analysis/Complex/Conformal/Poincare/Ball.lean` (461 lines) defines `TauCeti.pseudoHyperbolicCenter a t = ((1 - t ^ 2) / D) • a` and `TauCeti.pseudoHyperbolicRadius a t = t * (1 - ‖a‖ ^ 2) / D`, where `D = 1 - t ^ 2 * ‖a‖ ^ 2`, and proves that `{z ∈ 𝔻 | pseudoHyperbolicExpr z a < t}` is exactly the Euclidean disc of that centre and radius, together with the `≤` and `=` companions giving the closed disc and the circle. Substituting `t = Real.tanh R` turns these into `TauCeti.sep_ball_hyperbolicDist_lt_eq_ball` and `TauCeti.sep_ball_hyperbolicDist_le_eq_closedBall`, the statements about the hyperbolic metric itself, and the balls of the metric space `TauCeti.PoincareDisc` are read off in `TauCeti.PoincareDisc.mem_ball_iff`.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"hyperbolic-ball-is-euclidean-ball"}-->

Roadmap: ConformalMapping

The exact target is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L2 — Schwarz lemma extensions**, whose stated goal includes "the **hyperbolic / Poincaré metric** on `𝔻`". That metric already has its metric-space instance (`Poincare/MetricSpace.lean`), its topology and properness (`Poincare/Topology.lean`) and its geodesics (`Poincare/Geodesic.lean`, `Poincare/Betweenness.lean`), but no description of its balls at a general centre; the roadmap's "done" criterion is that a researcher finds the objects "at their natural generality with full basic API", and the shape of a metric's balls is the most basic part of that API. It was the lowest-hanging item I could find in the area: it is a self-contained computation on already-merged foundations, it touches none of the in-flight L5 crosscut and boundary-correspondence work (#1682, #1677, #1670, #1667) or the L6 work (#1538), and it needs no new imports beyond `Poincare/MetricSpace.lean`.

Everything rests on one algebraic identity, `TauCeti.sq_norm_sub_sub_mul_sq_norm_one_sub_conj_mul`: for every `z : ℂ` with `D ≠ 0`,
`‖z - a‖ ^ 2 - t ^ 2 * ‖1 - conj a * z‖ ^ 2 = D * (‖z - pseudoHyperbolicCenter a t‖ ^ 2 - pseudoHyperbolicRadius a t ^ 2)`.
Expanding the three norms into real and imaginary parts reduces both sides to real polynomials in `‖z‖, ‖a‖, z.re * a.re + z.im * a.im` and `t`, and the definitions of the centre and radius are exactly what completes the square. Since `D > 0` on the range that matters, the sign of the left side is the sign of `‖z - c‖ - s`, which is the whole content: a Moebius sublevel set is a disc. The identity itself needs no hypothesis on `z`; only the passage to the quotient `pseudoHyperbolicExpr` does, so that the Moebius denominator does not vanish. The resulting disc is automatically inside `𝔻`, because `1 - ‖c‖ - s = (1 - ‖a‖) * (1 - t) * (1 - t * ‖a‖) / D` (`TauCeti.norm_pseudoHyperbolicCenter_add_pseudoHyperbolicRadius_lt_one`), so the restriction to `ball 0 1` in the set equalities describes a genuine subset of the disc rather than being an artefact of the phrasing.

The general centre is not a formal consequence of the origin case that `Poincare/Topology.lean` already has (`TauCeti.hyperbolicDist_zero_le_iff_norm_le_tanh`, used there for properness): the disc automorphism carrying `a` to `0` is a hyperbolic isometry but not a Euclidean one. Being a Moebius map it does carry the centred Euclidean disc onto a Euclidean disc — that is the fact being proved here — but it preserves neither the Euclidean centre nor the Euclidean radius, so transport through it still leaves both to be computed. The Euclidean centre `c` is not `a` unless `a = 0` or `t = 0` — a hyperbolic ball is an off-centre Euclidean disc, its centre pulled towards the origin — though the hyperbolic centre does lie inside it (`TauCeti.mem_ball_pseudoHyperbolicCenter`). Two consequences are recorded: hyperbolic balls are convex for the *Euclidean* structure (`TauCeti.convex_sep_ball_hyperbolicDist_lt`), which is a stronger and different statement from the geodesic convexity of the hyperbolic metric, and the metric-space balls of `TauCeti.PoincareDisc` are characterised in Euclidean terms.

No Mathlib infrastructure was vendored or copied. The proof consumes Mathlib's `Complex.normSq` API, `Real.artanh`/`Real.tanh` (`Analysis/SpecialFunctions/Artanh.lean`) and the `sq_lt_sq₀` / `sq_le_sq₀` comparison lemmas, and Tau Ceti's existing `pseudoHyperbolicExpr` and `hyperbolicDist` API. Mathlib has no pseudo-hyperbolic or Poincaré-disc metric at all. Its hyperbolic material lives on `UpperHalfPlane`, and `Mathlib/Analysis/Complex/UpperHalfPlane/Metric.lean` *does* carry the analogous ball description — `UpperHalfPlane.center`, the comparison `cmp_dist_eq_cmp_dist_coe_center` with its `dist_lt_iff_dist_coe_center_lt` / `dist_le_iff_dist_coe_center_le` / `dist_eq_iff_dist_coe_center_eq` consequences, and the set-level `image_coe_ball` / `image_coe_closedBall` / `image_coe_sphere`. That is the closest formal precedent and is what fixes the API shape used here; it is credited in the module docstring. What this file supplies is the disc-model counterpart, whose formulas differ (`z.im * Real.cosh r`, `z.im * Real.sinh r` on `ℍ`, against `pseudoHyperbolicCenter` and `pseudoHyperbolicRadius` here) and whose underlying metric on `𝔻` Mathlib does not have, so nothing here duplicates it. As with the rest of the L0–L3 conformal-mapping material this is coordinated with the upstream, in-progress human-curated Riemann mapping effort leanprover-community/mathlib4#33505 and the preceding work in `Analysis/Complex/RiemannMapping.lean` and `Analysis/Complex/BranchLogRoot.lean`; none of that describes the hyperbolic metric on the disc, so this file is new formalization rather than a temporary shim, and it should be refactored onto upstream API if a human-curated Poincaré metric ever lands there.

`lake build` and `lake exe axioms` both pass on the branch; the audit reports all 18795 declarations within the allowlist `[propext, Classical.choice, Quot.sound]`.

🤖 Prepared with Claude Code


