### PR TITLE
feat: identify the general linear functor of points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
@@ -68,9 +68,15 @@ abbrev CoordinateRing :=
 
 /-- The canonical algebra map from the matrix-monoid coordinate ring into its determinant
 localization. -/
-@[expose] noncomputable def coordinateRingMap :
+noncomputable def coordinateRingMap :
     MatrixMonoid.CoordinateRing R n →ₐ[R] CoordinateRing R n :=
   IsScalarTower.toAlgHom R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
+
+/-- The canonical map into the determinant localization agrees with its algebra map. -/
+theorem coordinateRingMap_apply (x : MatrixMonoid.CoordinateRing R n) :
+    coordinateRingMap R n x =
+      algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x :=
+  (rfl)
 
 /-- Mathlib's generic matrix after applying the canonical map into the determinant localization. -/
 noncomputable def localizedGenericMatrix :

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
@@ -73,6 +73,7 @@ noncomputable def coordinateRingMap :
   IsScalarTower.toAlgHom R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
 
 /-- The canonical map into the determinant localization agrees with its algebra map. -/
+@[simp← ]
 theorem coordinateRingMap_apply (x : MatrixMonoid.CoordinateRing R n) :
     coordinateRingMap R n x =
       algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x :=
@@ -162,13 +163,13 @@ theorem comul_coordinateRingMap (x : MatrixMonoid.CoordinateRing R n) :
     comul R n (coordinateRingMap R n x) =
       Algebra.TensorProduct.map (coordinateRingMap R n) (coordinateRingMap R n)
         (MatrixMonoid.comul R n x) := by
-  simp [comul, coordinateRingMap, comulBase]
+  simp [-coordinateRingMap_apply, comul, coordinateRingMap, comulBase]
 
 /-- The localized counit restricts to the matrix-monoid counit. -/
 @[simp low]
 theorem counit_coordinateRingMap (x : MatrixMonoid.CoordinateRing R n) :
     counit R n (coordinateRingMap R n x) = MatrixMonoid.counit R n x := by
-  simp [counit, coordinateRingMap]
+  simp [-coordinateRingMap_apply, counit, coordinateRingMap]
 
 private noncomputable def antipodeBase :
     MatrixMonoid.CoordinateRing R n →ₐ[R] CoordinateRing R n :=
@@ -195,7 +196,7 @@ theorem antipode_coordinateRingMap (x : MatrixMonoid.CoordinateRing R n) :
     antipode R n (coordinateRingMap R n x) =
       MvPolynomial.aeval
         (fun ij : Fin n × Fin n => ((localizedGenericMatrix R n)⁻¹) ij.1 ij.2) x := by
-  simp [antipode, coordinateRingMap, antipodeBase]
+  simp [-coordinateRingMap_apply, antipode, coordinateRingMap, antipodeBase]
 
 /-- Two algebra homomorphisms out of the determinant localization are equal if they agree on the
 matrix-monoid coordinate ring. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
@@ -72,6 +72,12 @@ noncomputable def coordinateRingMap :
     MatrixMonoid.CoordinateRing R n →ₐ[R] CoordinateRing R n :=
   IsScalarTower.toAlgHom R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
 
+/-- The canonical coordinate-ring map is the algebra map into the determinant localization. -/
+theorem coordinateRingMap_apply (x : MatrixMonoid.CoordinateRing R n) :
+    coordinateRingMap R n x =
+      algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x := by
+  rfl
+
 /-- Mathlib's generic matrix after applying the canonical map into the determinant localization. -/
 noncomputable def localizedGenericMatrix :
     Matrix (Fin n) (Fin n) (CoordinateRing R n) :=

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
@@ -68,15 +68,9 @@ abbrev CoordinateRing :=
 
 /-- The canonical algebra map from the matrix-monoid coordinate ring into its determinant
 localization. -/
-noncomputable def coordinateRingMap :
+@[expose] noncomputable def coordinateRingMap :
     MatrixMonoid.CoordinateRing R n →ₐ[R] CoordinateRing R n :=
   IsScalarTower.toAlgHom R (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n)
-
-/-- The canonical coordinate-ring map is the algebra map into the determinant localization. -/
-theorem coordinateRingMap_apply (x : MatrixMonoid.CoordinateRing R n) :
-    coordinateRingMap R n x =
-      algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x := by
-  rfl
 
 /-- Mathlib's generic matrix after applying the canonical map into the determinant localization. -/
 noncomputable def localizedGenericMatrix :
@@ -197,7 +191,9 @@ theorem antipode_coordinateRingMap (x : MatrixMonoid.CoordinateRing R n) :
         (fun ij : Fin n × Fin n => ((localizedGenericMatrix R n)⁻¹) ij.1 ij.2) x := by
   simp [antipode, coordinateRingMap, antipodeBase]
 
-private theorem algHom_ext_away {T : Type*} [Semiring T] [Algebra R T]
+/-- Two algebra homomorphisms out of the determinant localization are equal if they agree on the
+matrix-monoid coordinate ring. -/
+theorem algHom_ext_away {T : Type*} [Semiring T] [Algebra R T]
     {f g : CoordinateRing R n →ₐ[R] T}
     (h : f.comp (coordinateRingMap R n) = g.comp (coordinateRingMap R n)) : f = g := by
   apply AlgHom.ext

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -1,0 +1,363 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.CoordinateHopfAlgebra
+public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
+
+/-!
+# The functor of points of the general linear group
+
+For a commutative ring `R` and `n : ℕ`, this file identifies the convolution group of
+algebra-valued points of the coordinate Hopf algebra
+
+`R[Xᵢⱼ][det(X)⁻¹]`
+
+with Mathlib's general linear group. A point is sent to the matrix of its values on the
+localized generic entries. Conversely, an invertible matrix defines polynomial evaluation,
+which extends uniquely across the determinant localization. The matrix-multiplication
+comultiplication makes this equivalence multiplicative in the ordinary, rather than opposite,
+order.
+
+The equivalences are natural in the commutative value algebra. They therefore assemble into a
+natural isomorphism from `HopfAlgebra.pointsFunctor` for `coordinateHopfAlgebra` to the functor
+of invertible matrices. The construction includes rank zero and zero rings, without a
+nontriviality or positive-rank assumption.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.pointToGeneralLinear`: the invertible matrix read from a point.
+* `TauCeti.GeneralLinear.generalLinearToPoint`: the point obtained by matrix evaluation.
+* `TauCeti.GeneralLinear.pointsMulEquiv`: the group equivalence between convolution points and
+  invertible matrices.
+* `TauCeti.GeneralLinear.generalLinearFunctor`: the group-valued functor of invertible matrices.
+* `TauCeti.GeneralLinear.pointsNatIso`: the natural isomorphism between the two functors.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §2.8 and §§3.2--3.6.
+* The Stacks Project, Tags
+  [022W](https://stacks.math.columbia.edu/tag/022W),
+  [022X](https://stacks.math.columbia.edu/tag/022X), and
+  [00CM](https://stacks.math.columbia.edu/tag/00CM).
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+namespace GeneralLinear
+
+universe u w
+
+variable {R : Type u} [CommRing R] (n : ℕ)
+
+section Pointwise
+
+variable {A : Type w} [CommRing A] [Algebra R A]
+
+private theorem coordinateRing_algHom_ext
+    {f g : CoordinateRing R n →ₐ[R] A}
+    (h : f.comp (coordinateRingMap R n) = g.comp (coordinateRingMap R n)) : f = g := by
+  apply AlgHom.ext
+  have h' : f.toRingHom = g.toRingHom := by
+    apply IsLocalization.ringHom_ext
+      (Submonoid.powers
+        (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)))
+    apply RingHom.ext
+    intro x
+    change f (algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x) =
+      g (algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x)
+    have hx := DFunLike.congr_fun h x
+    simpa only [AlgHom.comp_apply, coordinateRingMap_apply] using hx
+  exact RingHom.congr_fun h'
+
+/-- The matrix of values of a point on the localized generic matrix. -/
+@[expose] noncomputable def matrixOfPoint
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) : Matrix (Fin n) (Fin n) A :=
+  (localizedGenericMatrix R n).map
+    (f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom)
+
+/-- An entry of `matrixOfPoint f` is the value of `f` on the corresponding bundled coordinate. -/
+@[simp]
+theorem matrixOfPoint_apply
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) (i j : Fin n) :
+    matrixOfPoint n f i j =
+      f.ofConv (coordinateHopfAlgebraAlgEquiv R n
+        (coordinateRingMap R n (MvPolynomial.X (i, j)))) := by
+  simp [matrixOfPoint]
+
+private theorem isUnit_det_matrixOfPoint
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    IsUnit (Matrix.det (matrixOfPoint n f)) := by
+  rw [matrixOfPoint, ← AlgHom.mapMatrix_apply, ← AlgHom.map_det]
+  exact (isUnit_det_localizedGenericMatrix R n).map
+    (f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom)
+
+/-- The invertible matrix obtained by evaluating a point on the localized generic matrix. -/
+noncomputable def pointToGeneralLinear
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    Matrix.GeneralLinearGroup (Fin n) A :=
+  Matrix.GeneralLinearGroup.mk'' (matrixOfPoint n f) (isUnit_det_matrixOfPoint n f)
+
+/-- Reading a point as an invertible matrix evaluates it on the corresponding bundled
+coordinate. -/
+@[simp]
+theorem pointToGeneralLinear_apply
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) (i j : Fin n) :
+    pointToGeneralLinear n f i j =
+      f.ofConv (coordinateHopfAlgebraAlgEquiv R n
+        (coordinateRingMap R n (MvPolynomial.X (i, j)))) := by
+  exact matrixOfPoint_apply n f i j
+
+private noncomputable def evaluationOfGeneralLinear
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    MatrixMonoid.CoordinateRing R n →ₐ[R] A :=
+  MvPolynomial.aeval fun ij : Fin n × Fin n ↦
+    g.val ij.1 ij.2
+
+private theorem evaluationOfGeneralLinear_determinant_isUnit
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    IsUnit (evaluationOfGeneralLinear (R := R) n g
+      (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))) := by
+  rw [evaluationOfGeneralLinear, AlgHom.map_det,
+    Matrix.mvPolynomialX_mapMatrix_aeval]
+  exact Matrix.isUnits_det_units g
+
+private noncomputable def localizedEvaluationOfGeneralLinear
+    (g : Matrix.GeneralLinearGroup (Fin n) A) : CoordinateRing R n →ₐ[R] A :=
+  IsLocalization.Away.liftAlgHom
+    (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R))
+    (evaluationOfGeneralLinear_determinant_isUnit (R := R) n g)
+
+private theorem localizedEvaluationOfGeneralLinear_coordinateRingMap
+    (g : Matrix.GeneralLinearGroup (Fin n) A) (x : MatrixMonoid.CoordinateRing R n) :
+    localizedEvaluationOfGeneralLinear (R := R) n g (coordinateRingMap R n x) =
+      evaluationOfGeneralLinear (R := R) n g x := by
+  simp [localizedEvaluationOfGeneralLinear, coordinateRingMap_apply]
+
+/-- The point of the bundled general linear coordinate Hopf algebra obtained by evaluating the
+generic matrix at an invertible matrix. -/
+noncomputable def generalLinearToPoint
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
+  toConv ((localizedEvaluationOfGeneralLinear (R := R) n g).comp
+    (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom)
+
+private theorem generalLinearToPoint_ofConv
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    (generalLinearToPoint (R := R) n g).ofConv =
+      (localizedEvaluationOfGeneralLinear (R := R) n g).comp
+        (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom := by
+  rw [generalLinearToPoint]
+
+private theorem generalLinearToPoint_coordinateRingMap
+    (g : Matrix.GeneralLinearGroup (Fin n) A) (x : MatrixMonoid.CoordinateRing R n) :
+    (generalLinearToPoint (R := R) n g).ofConv
+        (coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n x)) =
+      evaluationOfGeneralLinear (R := R) n g x := by
+  rw [generalLinearToPoint_ofConv, AlgHom.comp_apply]
+  have heq :
+      (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom
+          (coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n x)) =
+        coordinateRingMap R n x :=
+    (coordinateHopfAlgebraAlgEquiv R n).symm_apply_apply _
+  rw [heq]
+  exact localizedEvaluationOfGeneralLinear_coordinateRingMap n g x
+
+/-- The point obtained from an invertible matrix sends a bundled generic coordinate to the
+corresponding matrix entry. -/
+@[simp]
+theorem generalLinearToPoint_apply
+    (g : Matrix.GeneralLinearGroup (Fin n) A) (i j : Fin n) :
+    (generalLinearToPoint (R := R) n g).ofConv
+        (coordinateHopfAlgebraAlgEquiv R n
+          (coordinateRingMap R n (MvPolynomial.X (i, j)))) =
+      g.val i j := by
+  rw [generalLinearToPoint_coordinateRingMap]
+  exact MvPolynomial.aeval_X _ _
+
+/-- Evaluating the point associated to an invertible matrix recovers that matrix. -/
+@[simp]
+theorem pointToGeneralLinear_generalLinearToPoint
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    pointToGeneralLinear (R := R) n (generalLinearToPoint (R := R) n g) = g := by
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  rw [pointToGeneralLinear_apply, generalLinearToPoint_apply]
+
+/-- Forming a point from the invertible matrix read from a point recovers the original point. -/
+@[simp]
+theorem generalLinearToPoint_pointToGeneralLinear
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    generalLinearToPoint (R := R) n (pointToGeneralLinear n f) = f := by
+  have hraw :
+      localizedEvaluationOfGeneralLinear (R := R) n (pointToGeneralLinear n f) =
+        f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom := by
+    apply coordinateRing_algHom_ext n
+    apply MvPolynomial.algHom_ext
+    rintro ⟨i, j⟩
+    simp only [AlgHom.comp_apply]
+    rw [localizedEvaluationOfGeneralLinear_coordinateRingMap]
+    simp [evaluationOfGeneralLinear]
+  rw [generalLinearToPoint]
+  apply WithConv.ext
+  change (localizedEvaluationOfGeneralLinear (R := R) n
+      (pointToGeneralLinear n f)).comp
+        (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom = f.ofConv
+  rw [hraw]
+  ext x
+  simp
+
+/-- Reading points as invertible matrices carries convolution to ordinary matrix
+multiplication, with the tensor-factor order unchanged. -/
+theorem pointToGeneralLinear_mul
+    (f g : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    pointToGeneralLinear n (f * g) = pointToGeneralLinear n f * pointToGeneralLinear n g := by
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  simp only [pointToGeneralLinear_apply, Matrix.GeneralLinearGroup.coe_mul,
+    Matrix.mul_apply]
+  rw [AlgHom.convMul_apply, coordinateHopfAlgebra_comul_X]
+  simp
+
+/-- The convolution group of points of the general linear coordinate Hopf algebra is the
+ordinary general linear group. Multiplication has the same order on both sides. -/
+@[expose] noncomputable def pointsMulEquiv :
+    WithConv (coordinateHopfAlgebra R n →ₐ[R] A) ≃*
+      Matrix.GeneralLinearGroup (Fin n) A where
+  toFun := pointToGeneralLinear n
+  invFun := generalLinearToPoint (R := R) n
+  left_inv := generalLinearToPoint_pointToGeneralLinear n
+  right_inv := pointToGeneralLinear_generalLinearToPoint n
+  map_mul' := pointToGeneralLinear_mul n
+
+/-- The forward map of `pointsMulEquiv` is evaluation on the localized generic matrix. -/
+@[simp]
+theorem pointsMulEquiv_apply
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    pointsMulEquiv n f = pointToGeneralLinear n f :=
+  rfl
+
+/-- The inverse map of `pointsMulEquiv` is the extension of matrix evaluation across the
+determinant localization. -/
+@[simp]
+theorem pointsMulEquiv_symm_apply (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    (pointsMulEquiv (R := R) n).symm g = generalLinearToPoint (R := R) n g :=
+  rfl
+
+end Pointwise
+
+section Naturality
+
+variable {A B : Type w} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+
+/-- Reading a point as an invertible matrix commutes with maps of value algebras. -/
+theorem pointToGeneralLinear_mapValue (phi : A →ₐ[R] B)
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    pointToGeneralLinear n
+        (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
+      Matrix.GeneralLinearGroup.map phi.toRingHom (pointToGeneralLinear n f) := by
+  apply Matrix.GeneralLinearGroup.ext
+  intro i j
+  simp
+
+/-- The pointwise group equivalence is natural in the value algebra. -/
+theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    pointsMulEquiv n (AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi f) =
+      Matrix.GeneralLinearGroup.map phi.toRingHom (pointsMulEquiv n f) := by
+  exact pointToGeneralLinear_mapValue n phi f
+
+/-- Naturality of the inverse pointwise equivalence in the value algebra. -/
+theorem mapValue_pointsMulEquiv_symm_apply (phi : A →ₐ[R] B)
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    AlgHom.mapValue (H := coordinateHopfAlgebra R n) phi
+        ((pointsMulEquiv (R := R) n).symm g) =
+      (pointsMulEquiv (R := R) n).symm
+        (Matrix.GeneralLinearGroup.map phi.toRingHom g) := by
+  apply (pointsMulEquiv (R := R) (A := B) n).injective
+  rw [pointsMulEquiv_mapValue]
+  simp
+
+end Naturality
+
+section Functor
+
+/-- The group-valued functor sending a commutative `R`-algebra to its general linear group and
+a value-algebra morphism to entrywise application. Its values are universe-lifted so that its
+codomain agrees with the generic Hopf-algebra points functor. -/
+@[expose] noncomputable def generalLinearFunctor :
+    CommAlgCat.{w} R ⥤ GrpCat.{max u w} where
+  obj A := GrpCat.of
+    (ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) (A : Type w)))
+  map phi := GrpCat.ofHom
+    (MulEquiv.ulift.symm.toMonoidHom.comp
+      ((Matrix.GeneralLinearGroup.map phi.hom.toRingHom).comp
+        MulEquiv.ulift.toMonoidHom))
+  map_id _ := rfl
+  map_comp _ _ := rfl
+
+/-- The object part of `generalLinearFunctor` is the universe lift of the ordinary general
+linear group. -/
+theorem generalLinearFunctor_obj (A : CommAlgCat.{w} R) :
+    (generalLinearFunctor (R := R) n).obj A =
+      GrpCat.of (ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) :=
+  rfl
+
+/-- The morphism part of `generalLinearFunctor` applies the value-algebra map entrywise. -/
+theorem generalLinearFunctor_map {A B : CommAlgCat.{w} R} (phi : A ⟶ B) :
+    (generalLinearFunctor (R := R) n).map phi =
+      GrpCat.ofHom
+        (MulEquiv.ulift.symm.toMonoidHom.comp
+          ((Matrix.GeneralLinearGroup.map phi.hom.toRingHom).comp
+            MulEquiv.ulift.toMonoidHom)) :=
+  rfl
+
+/-- Entrywise computation of the value-algebra map on the general linear functor. -/
+@[simp]
+theorem generalLinearFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (phi : A ⟶ B)
+    (g : ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) (i j : Fin n) :
+    ((generalLinearFunctor (R := R) n).map phi g).down i j =
+      phi.hom (g.down.val i j) :=
+  rfl
+
+/-- The convolution-points functor of the general linear coordinate Hopf algebra is naturally
+isomorphic to the ordinary general linear group functor. -/
+@[expose] noncomputable def pointsNatIso :
+    HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R n) ≅
+      generalLinearFunctor (R := R) n :=
+  NatIso.ofComponents
+    (fun A ↦ ((pointsMulEquiv (R := R) (A := A) n).trans
+      MulEquiv.ulift.symm).toGrpIso)
+    (by
+      intro A B phi
+      ext f
+      apply ULift.ext
+      exact pointsMulEquiv_mapValue n phi.hom f)
+
+/-- The forward component of `pointsNatIso` is the pointwise general-linear equivalence. -/
+@[simp]
+theorem pointsNatIso_hom_app_apply (A : CommAlgCat.{w} R)
+    (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n) A) :
+    ((pointsNatIso (R := R) n).hom.app A f).down = pointsMulEquiv n f :=
+  rfl
+
+/-- The inverse component of `pointsNatIso` is evaluation at an invertible matrix. -/
+@[simp]
+theorem pointsNatIso_inv_app_apply (A : CommAlgCat.{w} R)
+    (g : ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) :
+    (pointsNatIso (R := R) n).inv.app A g =
+      (pointsMulEquiv (R := R) n).symm g.down :=
+  rfl
+
+end Functor
+
+end GeneralLinear
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -62,14 +62,14 @@ section Pointwise
 variable {A : Type w} [CommRing A] [Algebra R A]
 
 /-- The matrix of values of a point on the localized generic matrix. -/
-noncomputable def matrixOfPoint
+private noncomputable def matrixOfPoint
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) : Matrix (Fin n) (Fin n) A :=
   (localizedGenericMatrix R n).map
     (f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom)
 
 /-- An entry of `matrixOfPoint f` is the value of `f` on the corresponding bundled coordinate. -/
 @[simp]
-theorem matrixOfPoint_apply
+private theorem matrixOfPoint_apply
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) (i j : Fin n) :
     matrixOfPoint n f i j =
       f.ofConv (coordinateHopfAlgebraAlgEquiv R n
@@ -275,24 +275,12 @@ section Functor
 
 /-- The group-valued functor sending a commutative `R`-algebra to its general linear group, before
 the universe lift used by `generalLinearFunctor`. -/
-noncomputable abbrev generalLinearFunctorUnlifted :
+private noncomputable abbrev generalLinearFunctorUnlifted :
     CommAlgCat.{w} R ⥤ GrpCat.{w} where
   obj A := GrpCat.of (Matrix.GeneralLinearGroup (Fin n) (A : Type w))
   map phi := GrpCat.ofHom (Matrix.GeneralLinearGroup.map phi.hom.toRingHom)
   map_id _ := rfl
   map_comp _ _ := rfl
-
-/-- The object part of `generalLinearFunctorUnlifted` is the ordinary general linear group. -/
-theorem generalLinearFunctorUnlifted_obj (A : CommAlgCat.{w} R) :
-    (generalLinearFunctorUnlifted (R := R) n).obj A =
-      GrpCat.of (Matrix.GeneralLinearGroup (Fin n) A) :=
-  rfl
-
-/-- The morphism part of `generalLinearFunctorUnlifted` applies the value-algebra map entrywise. -/
-theorem generalLinearFunctorUnlifted_map {A B : CommAlgCat.{w} R} (phi : A ⟶ B) :
-    (generalLinearFunctorUnlifted (R := R) n).map phi =
-      GrpCat.ofHom (Matrix.GeneralLinearGroup.map phi.hom.toRingHom) :=
-  rfl
 
 /-- The group-valued functor sending a commutative `R`-algebra to its general linear group and
 a value-algebra morphism to entrywise application. Its values are universe-lifted so that its

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -200,6 +200,7 @@ theorem generalLinearToPoint_pointToGeneralLinear
 
 /-- Reading points as invertible matrices carries convolution to ordinary matrix
 multiplication, with the tensor-factor order unchanged. -/
+@[simp]
 theorem pointToGeneralLinear_mul
     (f g : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointToGeneralLinear n (f * g) = pointToGeneralLinear n f * pointToGeneralLinear n g := by
@@ -251,6 +252,13 @@ theorem pointToGeneralLinear_mapValue (phi : A →ₐ[R] B)
   intro i j
   simp
 
+@[simp]
+private theorem pointToGeneralLinear_toConv_comp (phi : A →ₐ[R] B)
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    pointToGeneralLinear n (toConv (phi.comp f.ofConv)) =
+      Matrix.GeneralLinearGroup.map phi.toRingHom (pointToGeneralLinear n f) := by
+  simpa only [AlgHom.mapValue_apply] using pointToGeneralLinear_mapValue n phi f
+
 /-- The pointwise group equivalence is natural in the value algebra. -/
 theorem pointsMulEquiv_mapValue (phi : A →ₐ[R] B)
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
@@ -268,6 +276,15 @@ theorem mapValue_pointsMulEquiv_symm_apply (phi : A →ₐ[R] B)
   apply (pointsMulEquiv (R := R) (A := B) n).injective
   rw [pointsMulEquiv_mapValue]
   simp
+
+@[simp]
+private theorem toConv_comp_generalLinearToPoint_ofConv (phi : A →ₐ[R] B)
+    (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    toConv (phi.comp (generalLinearToPoint (R := R) n g).ofConv) =
+      generalLinearToPoint (R := R) n
+        (Matrix.GeneralLinearGroup.map phi.toRingHom g) := by
+  simpa only [AlgHom.mapValue_apply, pointsMulEquiv_symm_apply] using
+    mapValue_pointsMulEquiv_symm_apply n phi g
 
 end Naturality
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -61,22 +61,6 @@ section Pointwise
 
 variable {A : Type w} [CommRing A] [Algebra R A]
 
-private theorem coordinateRing_algHom_ext
-    {f g : CoordinateRing R n →ₐ[R] A}
-    (h : f.comp (coordinateRingMap R n) = g.comp (coordinateRingMap R n)) : f = g := by
-  apply AlgHom.ext
-  have h' : f.toRingHom = g.toRingHom := by
-    apply IsLocalization.ringHom_ext
-      (Submonoid.powers
-        (Matrix.det (Matrix.mvPolynomialX (Fin n) (Fin n) R)))
-    apply RingHom.ext
-    intro x
-    change f (algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x) =
-      g (algebraMap (MatrixMonoid.CoordinateRing R n) (CoordinateRing R n) x)
-    have hx := DFunLike.congr_fun h x
-    simpa only [AlgHom.comp_apply, coordinateRingMap_apply] using hx
-  exact RingHom.congr_fun h'
-
 /-- The matrix of values of a point on the localized generic matrix. -/
 @[expose] noncomputable def matrixOfPoint
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) : Matrix (Fin n) (Fin n) A :=
@@ -139,7 +123,7 @@ private theorem localizedEvaluationOfGeneralLinear_coordinateRingMap
     (g : Matrix.GeneralLinearGroup (Fin n) A) (x : MatrixMonoid.CoordinateRing R n) :
     localizedEvaluationOfGeneralLinear (R := R) n g (coordinateRingMap R n x) =
       evaluationOfGeneralLinear (R := R) n g x := by
-  simp [localizedEvaluationOfGeneralLinear, coordinateRingMap_apply]
+  simp [localizedEvaluationOfGeneralLinear, coordinateRingMap]
 
 /-- The point of the bundled general linear coordinate Hopf algebra obtained by evaluating the
 generic matrix at an invertible matrix. -/
@@ -199,7 +183,7 @@ theorem generalLinearToPoint_pointToGeneralLinear
   have hraw :
       localizedEvaluationOfGeneralLinear (R := R) n (pointToGeneralLinear n f) =
         f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom := by
-    apply coordinateRing_algHom_ext n
+    apply algHom_ext_away R n
     apply MvPolynomial.algHom_ext
     rintro ⟨i, j⟩
     simp only [AlgHom.comp_apply]
@@ -289,19 +273,33 @@ end Naturality
 
 section Functor
 
+/-- The group-valued functor sending a commutative `R`-algebra to its general linear group, before
+the universe lift used by `generalLinearFunctor`. -/
+noncomputable abbrev generalLinearFunctorUnlifted :
+    CommAlgCat.{w} R ⥤ GrpCat.{w} where
+  obj A := GrpCat.of (Matrix.GeneralLinearGroup (Fin n) (A : Type w))
+  map phi := GrpCat.ofHom (Matrix.GeneralLinearGroup.map phi.hom.toRingHom)
+  map_id _ := rfl
+  map_comp _ _ := rfl
+
+/-- The object part of `generalLinearFunctorUnlifted` is the ordinary general linear group. -/
+theorem generalLinearFunctorUnlifted_obj (A : CommAlgCat.{w} R) :
+    (generalLinearFunctorUnlifted (R := R) n).obj A =
+      GrpCat.of (Matrix.GeneralLinearGroup (Fin n) A) :=
+  rfl
+
+/-- The morphism part of `generalLinearFunctorUnlifted` applies the value-algebra map entrywise. -/
+theorem generalLinearFunctorUnlifted_map {A B : CommAlgCat.{w} R} (phi : A ⟶ B) :
+    (generalLinearFunctorUnlifted (R := R) n).map phi =
+      GrpCat.ofHom (Matrix.GeneralLinearGroup.map phi.hom.toRingHom) :=
+  rfl
+
 /-- The group-valued functor sending a commutative `R`-algebra to its general linear group and
 a value-algebra morphism to entrywise application. Its values are universe-lifted so that its
 codomain agrees with the generic Hopf-algebra points functor. -/
 @[expose] noncomputable def generalLinearFunctor :
-    CommAlgCat.{w} R ⥤ GrpCat.{max u w} where
-  obj A := GrpCat.of
-    (ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) (A : Type w)))
-  map phi := GrpCat.ofHom
-    (MulEquiv.ulift.symm.toMonoidHom.comp
-      ((Matrix.GeneralLinearGroup.map phi.hom.toRingHom).comp
-        MulEquiv.ulift.toMonoidHom))
-  map_id _ := rfl
-  map_comp _ _ := rfl
+    CommAlgCat.{w} R ⥤ GrpCat.{max u w} :=
+  generalLinearFunctorUnlifted (R := R) n ⋙ GrpCat.uliftFunctor.{u, w}
 
 /-- The object part of `generalLinearFunctor` is the universe lift of the ordinary general
 linear group. -/

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -62,7 +62,7 @@ section Pointwise
 variable {A : Type w} [CommRing A] [Algebra R A]
 
 /-- The matrix of values of a point on the localized generic matrix. -/
-@[expose] noncomputable def matrixOfPoint
+noncomputable def matrixOfPoint
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) : Matrix (Fin n) (Fin n) A :=
   (localizedGenericMatrix R n).map
     (f.ofConv.comp (coordinateHopfAlgebraAlgEquiv R n).toAlgHom)
@@ -123,7 +123,8 @@ private theorem localizedEvaluationOfGeneralLinear_coordinateRingMap
     (g : Matrix.GeneralLinearGroup (Fin n) A) (x : MatrixMonoid.CoordinateRing R n) :
     localizedEvaluationOfGeneralLinear (R := R) n g (coordinateRingMap R n x) =
       evaluationOfGeneralLinear (R := R) n g x := by
-  simp [localizedEvaluationOfGeneralLinear, coordinateRingMap]
+  rw [coordinateRingMap_apply]
+  simp [localizedEvaluationOfGeneralLinear]
 
 /-- The point of the bundled general linear coordinate Hopf algebra obtained by evaluating the
 generic matrix at an invertible matrix. -/
@@ -140,11 +141,14 @@ private theorem generalLinearToPoint_ofConv
         (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom := by
   rw [generalLinearToPoint]
 
-private theorem generalLinearToPoint_coordinateRingMap
+/-- Evaluation at an invertible matrix sends a polynomial in the bundled coordinate ring to its
+multivariable polynomial evaluation at the matrix entries. -/
+@[simp]
+theorem generalLinearToPoint_coordinateRingMap
     (g : Matrix.GeneralLinearGroup (Fin n) A) (x : MatrixMonoid.CoordinateRing R n) :
     (generalLinearToPoint (R := R) n g).ofConv
         (coordinateHopfAlgebraAlgEquiv R n (coordinateRingMap R n x)) =
-      evaluationOfGeneralLinear (R := R) n g x := by
+      MvPolynomial.aeval (fun ij : Fin n × Fin n ↦ g.val ij.1 ij.2) x := by
   rw [generalLinearToPoint_ofConv, AlgHom.comp_apply]
   have heq :
       (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom
@@ -152,11 +156,11 @@ private theorem generalLinearToPoint_coordinateRingMap
         coordinateRingMap R n x :=
     (coordinateHopfAlgebraAlgEquiv R n).symm_apply_apply _
   rw [heq]
-  exact localizedEvaluationOfGeneralLinear_coordinateRingMap n g x
+  rw [localizedEvaluationOfGeneralLinear_coordinateRingMap]
+  rfl
 
 /-- The point obtained from an invertible matrix sends a bundled generic coordinate to the
 corresponding matrix entry. -/
-@[simp]
 theorem generalLinearToPoint_apply
     (g : Matrix.GeneralLinearGroup (Fin n) A) (i j : Fin n) :
     (generalLinearToPoint (R := R) n g).ofConv
@@ -189,12 +193,8 @@ theorem generalLinearToPoint_pointToGeneralLinear
     simp only [AlgHom.comp_apply]
     rw [localizedEvaluationOfGeneralLinear_coordinateRingMap]
     simp [evaluationOfGeneralLinear]
-  rw [generalLinearToPoint]
   apply WithConv.ext
-  change (localizedEvaluationOfGeneralLinear (R := R) n
-      (pointToGeneralLinear n f)).comp
-        (coordinateHopfAlgebraAlgEquiv R n).symm.toAlgHom = f.ofConv
-  rw [hraw]
+  rw [generalLinearToPoint_ofConv, hraw]
   ext x
   simp
 
@@ -212,7 +212,7 @@ theorem pointToGeneralLinear_mul
 
 /-- The convolution group of points of the general linear coordinate Hopf algebra is the
 ordinary general linear group. Multiplication has the same order on both sides. -/
-@[expose] noncomputable def pointsMulEquiv :
+noncomputable def pointsMulEquiv :
     WithConv (coordinateHopfAlgebra R n →ₐ[R] A) ≃*
       Matrix.GeneralLinearGroup (Fin n) A where
   toFun := pointToGeneralLinear n
@@ -226,14 +226,14 @@ ordinary general linear group. Multiplication has the same order on both sides. 
 theorem pointsMulEquiv_apply
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     pointsMulEquiv n f = pointToGeneralLinear n f :=
-  rfl
+  (rfl)
 
 /-- The inverse map of `pointsMulEquiv` is the extension of matrix evaluation across the
 determinant localization. -/
 @[simp]
 theorem pointsMulEquiv_symm_apply (g : Matrix.GeneralLinearGroup (Fin n) A) :
     (pointsMulEquiv (R := R) n).symm g = generalLinearToPoint (R := R) n g :=
-  rfl
+  (rfl)
 
 end Pointwise
 
@@ -297,7 +297,7 @@ theorem generalLinearFunctorUnlifted_map {A B : CommAlgCat.{w} R} (phi : A ⟶ B
 /-- The group-valued functor sending a commutative `R`-algebra to its general linear group and
 a value-algebra morphism to entrywise application. Its values are universe-lifted so that its
 codomain agrees with the generic Hopf-algebra points functor. -/
-@[expose] noncomputable def generalLinearFunctor :
+noncomputable def generalLinearFunctor :
     CommAlgCat.{w} R ⥤ GrpCat.{max u w} :=
   generalLinearFunctorUnlifted (R := R) n ⋙ GrpCat.uliftFunctor.{u, w}
 
@@ -306,28 +306,34 @@ linear group. -/
 theorem generalLinearFunctor_obj (A : CommAlgCat.{w} R) :
     (generalLinearFunctor (R := R) n).obj A =
       GrpCat.of (ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) :=
-  rfl
+  (rfl)
 
-/-- The morphism part of `generalLinearFunctor` applies the value-algebra map entrywise. -/
+/-- The morphism part of `generalLinearFunctor` applies the value-algebra map entrywise. The
+equality transports along `generalLinearFunctor_obj` because the functor's implementation is
+opaque. -/
 theorem generalLinearFunctor_map {A B : CommAlgCat.{w} R} (phi : A ⟶ B) :
     (generalLinearFunctor (R := R) n).map phi =
-      GrpCat.ofHom
-        (MulEquiv.ulift.symm.toMonoidHom.comp
-          ((Matrix.GeneralLinearGroup.map phi.hom.toRingHom).comp
-            MulEquiv.ulift.toMonoidHom)) :=
-  rfl
+      eqToHom (generalLinearFunctor_obj (R := R) n A) ≫
+        GrpCat.ofHom
+          (MulEquiv.ulift.symm.toMonoidHom.comp
+            ((Matrix.GeneralLinearGroup.map phi.hom.toRingHom).comp
+              MulEquiv.ulift.toMonoidHom)) ≫
+        eqToHom (generalLinearFunctor_obj (R := R) n B).symm :=
+  (rfl)
 
 /-- Entrywise computation of the value-algebra map on the general linear functor. -/
 @[simp]
 theorem generalLinearFunctor_map_apply_apply {A B : CommAlgCat.{w} R} (phi : A ⟶ B)
     (g : ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) (i j : Fin n) :
-    ((generalLinearFunctor (R := R) n).map phi g).down i j =
+    (eqToHom (generalLinearFunctor_obj (R := R) n B)
+      ((generalLinearFunctor (R := R) n).map phi
+        (eqToHom (generalLinearFunctor_obj (R := R) n A).symm g))).down i j =
       phi.hom (g.down.val i j) :=
-  rfl
+  (rfl)
 
 /-- The convolution-points functor of the general linear coordinate Hopf algebra is naturally
 isomorphic to the ordinary general linear group functor. -/
-@[expose] noncomputable def pointsNatIso :
+noncomputable def pointsNatIso :
     HopfAlgebra.pointsFunctor (R := R) (H := coordinateHopfAlgebra R n) ≅
       generalLinearFunctor (R := R) n :=
   NatIso.ofComponents
@@ -339,20 +345,24 @@ isomorphic to the ordinary general linear group functor. -/
       apply ULift.ext
       exact pointsMulEquiv_mapValue n phi.hom f)
 
-/-- The forward component of `pointsNatIso` is the pointwise general-linear equivalence. -/
+/-- After transport along `generalLinearFunctor_obj`, the forward component of `pointsNatIso` is
+the pointwise general-linear equivalence. -/
 @[simp]
 theorem pointsNatIso_hom_app_apply (A : CommAlgCat.{w} R)
     (f : HopfAlgebra.points (R := R) (H := coordinateHopfAlgebra R n) A) :
-    ((pointsNatIso (R := R) n).hom.app A f).down = pointsMulEquiv n f :=
-  rfl
+    (eqToHom (generalLinearFunctor_obj (R := R) n A)
+      ((pointsNatIso (R := R) n).hom.app A f)).down = pointsMulEquiv n f :=
+  (rfl)
 
-/-- The inverse component of `pointsNatIso` is evaluation at an invertible matrix. -/
+/-- After transport back along `generalLinearFunctor_obj`, the inverse component of `pointsNatIso`
+is evaluation at an invertible matrix. -/
 @[simp]
 theorem pointsNatIso_inv_app_apply (A : CommAlgCat.{w} R)
     (g : ULift.{u, w} (Matrix.GeneralLinearGroup (Fin n) A)) :
-    (pointsNatIso (R := R) n).inv.app A g =
+    (pointsNatIso (R := R) n).inv.app A
+        (eqToHom (generalLinearFunctor_obj (R := R) n A).symm g) =
       (pointsMulEquiv (R := R) n).symm g.down :=
-  rfl
+  (rfl)
 
 end Functor
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/FunctorOfPoints.lean
@@ -124,7 +124,7 @@ private theorem localizedEvaluationOfGeneralLinear_coordinateRingMap
     localizedEvaluationOfGeneralLinear (R := R) n g (coordinateRingMap R n x) =
       evaluationOfGeneralLinear (R := R) n g x := by
   rw [coordinateRingMap_apply]
-  simp [localizedEvaluationOfGeneralLinear]
+  simp [-coordinateRingMap_apply, localizedEvaluationOfGeneralLinear]
 
 /-- The point of the bundled general linear coordinate Hopf algebra obtained by evaluating the
 generic matrix at an invertible matrix. -/


### PR DESCRIPTION
This PR identifies the convolution group of algebra-valued points of the general linear coordinate Hopf algebra with Mathlib's general linear group, naturally in the value algebra. It constructs the pointwise multiplicative equivalence, proves that convolution becomes ordinary matrix multiplication in the same order, and packages the result as a natural isomorphism of group-valued functors.

The forward map evaluates the localized generic matrix, while the inverse extends polynomial evaluation across determinant localization. The characteristic lemmas expose both directions, multiplication, and value-algebra maps without unfolding the Hopf structure. The construction supports rank zero and zero rings and adds no nontriviality, domain, field, or positive-rank hypothesis.

This advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, “the functor of points and the three-way dictionary,” specifically the agreement between convolution on represented points and the represented group's ordinary multiplication, and the “Worked examples” target for the concrete group `GL_n`. Scheme packaging remains separate. The implementation reuses Mathlib's localization, multivariable-polynomial evaluation, and matrix general-linear-group APIs; no Mathlib infrastructure is copied or adapted.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-points-functor"}-->

🤖 Prepared with Codex
