### PR TITLE
style(Conformal): pack underfilled signature lines in Reflection/

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Arc.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Arc.lean
@@ -64,8 +64,7 @@ private theorem mapsTo_symm_inter_im {P : ℝ → Prop} :
 
 /-- If both coordinate domains are conjugation-invariant, the reflected coordinate values stay
 in the target coordinate domain. -/
-private theorem mapsTo_schwarzReflection
-    (he_symm : MapsTo (starRingEnd ℂ) e.target e.target)
+private theorem mapsTo_schwarzReflection (he_symm : MapsTo (starRingEnd ℂ) e.target e.target)
     (hd_symm : MapsTo (starRingEnd ℂ) d.target d.target)
     (hf : MapsTo f (e.source ∩ {z : ℂ | 0 ≤ (e z).im}) d.source) :
     MapsTo (schwarzReflection (fun w => d (f (e.symm w)))) e.target d.target := by
@@ -83,8 +82,7 @@ private theorem mapsTo_schwarzReflection
     exact neg_nonneg.mpr him_neg.le
 
 /-- Charted Schwarz reflection maps the source chart domain into the target chart domain. -/
-theorem mapsTo_chartedSchwarzReflection
-    (he_symm : MapsTo (starRingEnd ℂ) e.target e.target)
+theorem mapsTo_chartedSchwarzReflection (he_symm : MapsTo (starRingEnd ℂ) e.target e.target)
     (hd_symm : MapsTo (starRingEnd ℂ) d.target d.target)
     (hf : MapsTo f (e.source ∩ {z : ℂ | 0 ≤ (e z).im}) d.source) :
     MapsTo (chartedSchwarzReflection e d f) e.source d.source := by
@@ -186,8 +184,7 @@ theorem chartedSchwarzReflection_sourceReflection
     (he_symm : MapsTo (starRingEnd ℂ) e.target e.target)
     (hd_symm : MapsTo (starRingEnd ℂ) d.target d.target)
     (hf_maps : MapsTo f (e.source ∩ {z : ℂ | 0 ≤ (e z).im}) d.source)
-    (hf_real : ∀ z ∈ e.source, (e z).im = 0 → (d (f z)).im = 0)
-    {z : ℂ} (hz : z ∈ e.source) :
+    (hf_real : ∀ z ∈ e.source, (e z).im = 0 → (d (f z)).im = 0) {z : ℂ} (hz : z ∈ e.source) :
     chartedSchwarzReflection e d f
         (e.symm ((starRingEnd ℂ) (e z))) =
       d.symm ((starRingEnd ℂ) (d (chartedSchwarzReflection e d f z))) := by

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Basic.lean
@@ -75,15 +75,13 @@ lemma schwarzReflection_of_im_zero {z : ℂ} (hz : z.im = 0) :
 
 /-- On any subset of the closed upper half-plane, Schwarz reflection agrees with the original
 function. -/
-lemma eqOn_schwarzReflection_of_subset_im_nonneg
-    (hS : S ⊆ {z : ℂ | 0 ≤ z.im}) :
+lemma eqOn_schwarzReflection_of_subset_im_nonneg (hS : S ⊆ {z : ℂ | 0 ≤ z.im}) :
     Set.EqOn (schwarzReflection f) f S :=
   fun _ hz => schwarzReflection_of_im_nonneg (f := f) (hS hz)
 
 /-- On any subset of the lower half-plane, Schwarz reflection agrees with the reflected
 branch. -/
-lemma eqOn_schwarzReflection_of_subset_im_neg
-    (hS : S ⊆ {z : ℂ | z.im < 0}) :
+lemma eqOn_schwarzReflection_of_subset_im_neg (hS : S ⊆ {z : ℂ | z.im < 0}) :
     Set.EqOn (schwarzReflection f) (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z))) S :=
   fun _ hz => schwarzReflection_of_im_neg (f := f) (hS hz)
 
@@ -118,8 +116,7 @@ private lemma apply_eq_conj_apply_conj_of_im_zero_of_apply_im_zero
 The Schwarz-reflection extension is conjugation-symmetric when the original function has real
 value at the real-axis point under consideration.
 -/
-lemma schwarzReflection_conj
-    (z : ℂ) (hreal : z.im = 0 → ((f z).im = 0)) :
+lemma schwarzReflection_conj (z : ℂ) (hreal : z.im = 0 → ((f z).im = 0)) :
     schwarzReflection f ((starRingEnd ℂ) z) =
       (starRingEnd ℂ) (schwarzReflection f z) := by
   rcases lt_trichotomy z.im 0 with hneg | hzero | hpos
@@ -162,8 +159,7 @@ lemma eqOn_schwarzReflection_conj_of_real_on_axis {Ω : Set ℂ}
 For a domain closed under conjugation, conjugation carries the upper half-plane part of the
 domain to its lower half-plane part.
 -/
-lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
+lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ} (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
     (starRingEnd ℂ) '' (Ω ∩ {z | 0 < z.im}) = Ω ∩ {z | z.im < 0} := by
   ext z
   constructor
@@ -183,8 +179,7 @@ lemma image_conj_inter_im_pos_of_symmetric {Ω : Set ℂ}
 For a domain closed under conjugation, conjugation carries the lower half-plane part of the
 domain to its upper half-plane part.
 -/
-lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
+lemma image_conj_inter_im_neg_of_symmetric {Ω : Set ℂ} (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
     (starRingEnd ℂ) '' (Ω ∩ {z | z.im < 0}) = Ω ∩ {z | 0 < z.im} := by
   ext z
   constructor
@@ -246,8 +241,7 @@ part, then the reflected branch `z ↦ conj (f (conj z))` is continuous on the l
 half-plane part.
 -/
 lemma continuousOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : ContinuousOn f (Ω ∩ {z | 0 < z.im})) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) (hf : ContinuousOn f (Ω ∩ {z | 0 < z.im})) :
     ContinuousOn (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       (Ω ∩ {z | z.im < 0}) := by
   simpa [image_conj_inter_im_pos_of_symmetric hΩ] using
@@ -259,8 +253,7 @@ reflection extension is continuous whenever the original function is continuous 
 upper half-plane part.
 -/
 lemma continuousOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : ContinuousOn f (Ω ∩ {z | 0 < z.im})) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) (hf : ContinuousOn f (Ω ∩ {z | 0 < z.im})) :
     ContinuousOn (schwarzReflection f) (Ω ∩ {z | z.im < 0}) := by
   intro z hz
   exact ((continuousOn_conj_conj_inter_im_neg_of_symmetric
@@ -272,8 +265,7 @@ lemma continuousOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ}
 For a domain closed under conjugation, conjugation carries the closed upper half-plane part of
 the domain to its closed lower half-plane part.
 -/
-lemma image_conj_inter_im_nonneg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
+lemma image_conj_inter_im_nonneg_of_symmetric {Ω : Set ℂ} (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) :
     (starRingEnd ℂ) '' (Ω ∩ {z | 0 ≤ z.im}) = Ω ∩ {z | z.im ≤ 0} := by
   ext w
   simp only [Set.mem_image, Set.mem_inter_iff, Set.mem_ofPred_eq]
@@ -293,10 +285,8 @@ If a domain `Ω` is closed under conjugation, `f` is continuous on its closed up
 part, and `f` takes real values at the real-axis points of `Ω`, then the explicit
 Schwarz-reflection extension is continuous on `Ω`.
 -/
-lemma continuousOn_schwarzReflection_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : ContinuousOn f (Ω ∩ {z : ℂ | 0 ≤ z.im}))
-    (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) :
+lemma continuousOn_schwarzReflection_of_symmetric {Ω : Set ℂ} (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
+    (hf : ContinuousOn f (Ω ∩ {z : ℂ | 0 ≤ z.im})) (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) :
     ContinuousOn (schwarzReflection f) Ω := by
   have hUclosed : IsClosed {z : ℂ | 0 ≤ z.im} :=
     isClosed_Ici.preimage Complex.continuous_im
@@ -322,8 +312,7 @@ lemma continuousOn_schwarzReflection_of_symmetric {Ω : Set ℂ}
 If `f` is continuous on the closed upper half-plane and takes real values on the real axis,
 then its explicit Schwarz-reflection extension is continuous on the plane.
 -/
-lemma continuous_schwarzReflection
-    (hf : ContinuousOn f {z : ℂ | 0 ≤ z.im})
+lemma continuous_schwarzReflection (hf : ContinuousOn f {z : ℂ | 0 ≤ z.im})
     (hreal : ∀ z : ℂ, z.im = 0 → (f z).im = 0) :
     Continuous (schwarzReflection f) := by
   rw [← continuousOn_univ]
@@ -331,20 +320,15 @@ lemma continuous_schwarzReflection
     (Set.mapsTo_univ _ _) ?_ (fun z _ => hreal z)
   rwa [Set.univ_inter]
 
-private lemma starRingEnd_eq_starL (z : ℂ) :
-    (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
+private lemma starRingEnd_eq_starL (z : ℂ) : (starRingEnd ℂ) z = (starL ℂ : ℂ ≃L⋆[ℂ] ℂ) z := by
   rw [starL_apply, starRingEnd_apply]
 
 private lemma HasFDerivWithinAt.comp_semilinear_preimage
     {𝕜 V V' W W' : Type*} [NontriviallyNormedField 𝕜] {σ σ' : RingHom 𝕜 𝕜}
-    [NormedAddCommGroup V] [NormedSpace 𝕜 V]
-    [NormedAddCommGroup V'] [NormedSpace 𝕜 V']
-    [NormedAddCommGroup W] [NormedSpace 𝕜 W]
-    [NormedAddCommGroup W'] [NormedSpace 𝕜 W']
-    [RingHomIsometric σ] [RingHomInvPair σ σ']
-    (L : W →SL[σ] W') (R : V' →SL[σ'] V)
-    {g : V → W} {g' : V →L[𝕜] W} {T : Set V} {x : V'}
-    (hg : HasFDerivWithinAt g g' T (R x)) :
+    [NormedAddCommGroup V] [NormedSpace 𝕜 V] [NormedAddCommGroup V'] [NormedSpace 𝕜 V']
+    [NormedAddCommGroup W] [NormedSpace 𝕜 W] [NormedAddCommGroup W'] [NormedSpace 𝕜 W']
+    [RingHomIsometric σ] [RingHomInvPair σ σ'] (L : W →SL[σ] W') (R : V' →SL[σ'] V)
+    {g : V → W} {g' : V →L[𝕜] W} {T : Set V} {x : V'} (hg : HasFDerivWithinAt g g' T (R x)) :
     HasFDerivWithinAt (L ∘ g ∘ R) (L.comp (g'.comp R)) (R ⁻¹' T) x := by
   rw [hasFDerivWithinAt_iff_isLittleO] at ⊢ hg
   have : RingHomIsometric σ' := .inv σ
@@ -429,8 +413,7 @@ part, then the reflected branch `z ↦ conj (f (conj z))` is holomorphic on the 
 half-plane part.
 -/
 lemma differentiableOn_conj_conj_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
     DifferentiableOn ℂ (fun z => (starRingEnd ℂ) (f ((starRingEnd ℂ) z)))
       (Ω ∩ {z | z.im < 0}) := by
   simpa [image_conj_inter_im_pos_of_symmetric hΩ] using
@@ -442,8 +425,7 @@ reflection extension is holomorphic whenever the original function is holomorphi
 upper half-plane part.
 -/
 lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
     DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im < 0}) := by
   intro z hz
   exact ((differentiableOn_conj_conj_inter_im_neg_of_symmetric
@@ -455,8 +437,7 @@ lemma differentiableOn_schwarzReflection_inter_im_neg_of_symmetric {Ω : Set ℂ
 conjugation-symmetric domain whenever the original function is holomorphic on its upper
 half-plane part. -/
 lemma differentiableOn_schwarzReflection_inter_im_ne_zero_of_symmetric {Ω : Set ℂ}
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
-    (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
+    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω) (hf : DifferentiableOn ℂ f (Ω ∩ {z | 0 < z.im})) :
     DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | z.im ≠ 0}) := by
   have hupper : DifferentiableOn ℂ (schwarzReflection f) (Ω ∩ {z | 0 < z.im}) :=
     differentiableOn_schwarzReflection_of_subset_im_nonneg (f := f)
@@ -486,8 +467,7 @@ lemma differentiableOn_schwarzReflection_inter_im_ne_zero_of_symmetric {Ω : Set
 
 /-- At a point in the open upper half-plane, the Schwarz-reflection extension has the same
 derivative as the original function. -/
-lemma hasDerivAt_schwarzReflection_of_im_pos {z f' : ℂ} (hz : 0 < z.im)
-    (hf : HasDerivAt f f' z) :
+lemma hasDerivAt_schwarzReflection_of_im_pos {z f' : ℂ} (hz : 0 < z.im) (hf : HasDerivAt f f' z) :
     HasDerivAt (schwarzReflection f) f' z :=
   hf.congr_of_eventuallyEq
     (mem_of_superset ((isOpen_lt continuous_const Complex.continuous_im).mem_nhds hz)

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Injective.lean
@@ -100,8 +100,7 @@ theorem mapsTo_schwarzReflection_im_pos
 /-- The reflected branch takes the lower part of a conjugation-symmetric domain into the open
 lower half-plane: it conjugates a value of `f` at a point of the open upper part, and conjugation
 reverses the sign of the imaginary part. -/
-theorem mapsTo_schwarzReflection_im_neg
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
+theorem mapsTo_schwarzReflection_im_neg (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hupper : Set.MapsTo f (Ω ∩ {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im}) :
     Set.MapsTo (schwarzReflection f) (Ω ∩ {z : ℂ | z.im < 0}) {z : ℂ | z.im < 0} := by
   rintro z ⟨hzΩ, (hzim : z.im < 0)⟩
@@ -135,11 +134,9 @@ branch the injectivity of `f` applies, on the lower branch after cancelling the 
 
 Injectivity alone does not need `f` to be *real* on the axis, only to stay in the closed upper
 half-plane there; the corollaries below feed `haxis` from the reflection principle's `hreal`. -/
-theorem injOn_schwarzReflection_of_symmetric
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
+theorem injOn_schwarzReflection_of_symmetric (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hupper : Set.MapsTo f (Ω ∩ {z : ℂ | 0 < z.im}) {z : ℂ | 0 < z.im})
-    (haxis : ∀ z ∈ Ω, z.im = 0 → 0 ≤ (f z).im)
-    (hinj : Set.InjOn f (Ω ∩ {z : ℂ | 0 ≤ z.im})) :
+    (haxis : ∀ z ∈ Ω, z.im = 0 → 0 ≤ (f z).im) (hinj : Set.InjOn f (Ω ∩ {z : ℂ | 0 ≤ z.im})) :
     Set.InjOn (schwarzReflection f) Ω := by
   intro z hz w hw hzw
   rcases le_or_gt 0 z.im with hz0 | hz0 <;> rcases le_or_gt 0 w.im with hw0 | hw0
@@ -167,8 +164,7 @@ theorem injOn_schwarzReflection_of_symmetric
 /-- The image of the reflection extension is the image of the closed upper part together with its
 mirror image in the real axis. The real axis contributes to both pieces, since `f` is real
 there. -/
-theorem image_schwarzReflection_of_symmetric
-    (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
+theorem image_schwarzReflection_of_symmetric (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0) :
     schwarzReflection f '' Ω =
       f '' (Ω ∩ {z : ℂ | 0 ≤ z.im}) ∪ (starRingEnd ℂ) '' (f '' (Ω ∩ {z : ℂ | 0 ≤ z.im})) := by
@@ -196,8 +192,7 @@ hypotheses of the reflection principle, together with injectivity of `f` on the 
 and the requirement that the open upper part goes to the open upper half-plane, the derivative of
 the extension vanishes nowhere on `Ω`. At a point of `Ω ∩ ℝ` this is a statement about the
 boundary behaviour of `f`, which is not assumed differentiable there. -/
-theorem deriv_schwarzReflection_ne_zero
-    (hΩopen : IsOpen Ω) (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
+theorem deriv_schwarzReflection_ne_zero (hΩopen : IsOpen Ω) (hΩ : Set.MapsTo (starRingEnd ℂ) Ω Ω)
     (hcont : ContinuousOn f (Ω ∩ {z : ℂ | 0 ≤ z.im}))
     (hholo : DifferentiableOn ℂ f (Ω ∩ {z : ℂ | 0 < z.im}))
     (hreal : ∀ z ∈ Ω, z.im = 0 → (f z).im = 0)

--- a/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Reflection/Line.lean
@@ -79,13 +79,11 @@ private lemma affineChart_left_inv {p a : ℂ} (ha : a ≠ 0) (z : ℂ) :
   rw [mul_div_cancel₀ _ ha]
   ring
 
-private lemma affineChart_right_inv {p a : ℂ} (ha : a ≠ 0) (w : ℂ) :
-    (p + a * w - p) / a = w := by
+private lemma affineChart_right_inv {p a : ℂ} (ha : a ≠ 0) (w : ℂ) : (p + a * w - p) / a = w := by
   rw [add_sub_cancel_left, mul_div_cancel_left₀ _ ha]
 
 private lemma affineChart_reflection_coord {p a z : ℂ} (ha : a ≠ 0) :
-    (p + a * (starRingEnd ℂ) ((z - p) / a) - p) / a =
-      (starRingEnd ℂ) ((z - p) / a) :=
+    (p + a * (starRingEnd ℂ) ((z - p) / a) - p) / a = (starRingEnd ℂ) ((z - p) / a) :=
   affineChart_right_inv ha _
 
 /-- **The affine chart carries a pulled-back imaginary-coordinate cut to the original one.** For
@@ -155,8 +153,7 @@ The side and boundary conditions are expressed in the affine coordinates `(z - p
 `(f z - q) / b`. The target direction `b` need not be nonzero for holomorphy: when `b = 0`, the
 conclusion is the constant function with value `q`. The packaged reflection theorem below assumes
 `b ≠ 0` to obtain branch agreement and target-line symmetry. -/
-theorem differentiableOn_lineSchwarzReflection_of_symmetric
-    {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ}
+theorem differentiableOn_lineSchwarzReflection_of_symmetric {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ}
     (ha : a ≠ 0) (hΩopen : IsOpen Ω)
     (hΩ : MapsTo (fun z => p + a * (starRingEnd ℂ) ((z - p) / a)) Ω Ω)
     (hcont : ContinuousOn f (Ω ∩ {z : ℂ | 0 ≤ ((z - p) / a).im}))
@@ -184,10 +181,8 @@ theorem differentiableOn_lineSchwarzReflection_of_symmetric
 /-- Affine-line Schwarz reflection intertwines reflection in the source line with reflection in
 the target line. The boundary hypothesis says precisely that the original function takes the
 source line into the target line. -/
-theorem lineSchwarzReflection_sourceReflection
-    {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ}
-    (ha : a ≠ 0) (hb : b ≠ 0)
-    (hline : ∀ z ∈ Ω, ((z - p) / a).im = 0 → ((f z - q) / b).im = 0)
+theorem lineSchwarzReflection_sourceReflection {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ}
+    (ha : a ≠ 0) (hb : b ≠ 0) (hline : ∀ z ∈ Ω, ((z - p) / a).im = 0 → ((f z - q) / b).im = 0)
     {z : ℂ} (hz : z ∈ Ω) :
     lineSchwarzReflection p a q b f
         (p + a * (starRingEnd ℂ) ((z - p) / a)) =
@@ -208,8 +203,7 @@ directions nonzero, there is a holomorphic extension which agrees with `f` on th
 side and intertwines reflection in the source and target lines. The witness is the explicit
 function `lineSchwarzReflection p a q b f`. -/
 theorem exists_differentiableOn_eqOn_lineReflection_of_symmetric
-    {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ}
-    (ha : a ≠ 0) (hb : b ≠ 0) (hΩopen : IsOpen Ω)
+    {Ω : Set ℂ} {p a q b : ℂ} {f : ℂ → ℂ} (ha : a ≠ 0) (hb : b ≠ 0) (hΩopen : IsOpen Ω)
     (hΩ : MapsTo (fun z => p + a * (starRingEnd ℂ) ((z - p) / a)) Ω Ω)
     (hcont : ContinuousOn f (Ω ∩ {z : ℂ | 0 ≤ ((z - p) / a).im}))
     (hholo : DifferentiableOn ℂ f (Ω ∩ {z : ℂ | 0 < ((z - p) / a).im}))


### PR DESCRIPTION
Third in the series after #1688 (`AffineGroupScheme/`) and #1693 (`Bernstein/Measures.lean`), both
of which merged at one review round. A repo-wide scan for this defect class ranked
`Reflection/Basic.lean` joint-highest; this PR takes the whole `Reflection/` folder.

Thirty-four signature lines were split below the 100-column limit, so Lean's pretty-printer at
`format.width := 100` would not have emitted them that way:

| file | joins |
|---|---|
| `Basic.lean` | 20 |
| `Line.lean` | 6 |
| `Injective.lean` | 5 |
| `Arc.lean` | 3 |

`Circle.lean` and `Principle.lean` are in the folder and needed no change.

Each join was checked arithmetically before applying — `current + 1 + next-token ≤ 100` — and
verified in **codepoints, not bytes**, since these files carry `ℂ ℝ ≤ ↦` at three bytes each and a
byte-based check reports phantom violations. All four files have zero lines over 100 codepoints
both before and after.

No statements, proofs or docstrings changed; whitespace only, `-34` lines.

Roadmap: none