### PR TITLE
style(PDE): pack underfilled signature lines in EnergyForm/

### DIFF
--- a/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Basic.lean
@@ -125,15 +125,13 @@ lemma energyIntegrand_one_zero_zero_self (U : ℝ × EuclideanSpace ℝ n) :
 
 /-- The shifted Laplacian model `-Δ + c` has jet form
 `(U, V) ↦ ∇u · ∇v + c u v`. -/
-lemma energyIntegrand_one_zero_mass_apply (c : ℝ)
-    (U V : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_mass_apply (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U V = V.2 ⬝ᵥ U.2 + c * U.1 * V.1 := by
   simp [energyIntegrand_apply, massForm_apply]
 
 /-- The shifted Laplacian model `-Δ + c` has diagonal jet density
 `‖∇u‖² + c u²`. -/
-lemma energyIntegrand_one_zero_mass_self (c : ℝ)
-    (U : ℝ × EuclideanSpace ℝ n) :
+lemma energyIntegrand_one_zero_mass_self (c : ℝ) (U : ℝ × EuclideanSpace ℝ n) :
     energyIntegrand (1 : Matrix n n ℝ) 0 c U U = ‖U.2‖ ^ 2 + c * U.1 ^ 2 := by
   rw [energyIntegrand_self, toQuadraticForm'_one]
   simp
@@ -168,8 +166,7 @@ norms. -/
 lemma norm_energyIntegrand_apply_le_of_bounds (hLam : 0 ≤ Lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (ha : ∀ η ξ : EuclideanSpace ℝ n, |η ⬝ᵥ (A *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
-    (hb : ‖b₀‖ ≤ beta) (hc : ‖c₀‖ ≤ gamma)
-    (U V : ℝ × EuclideanSpace ℝ n) :
+    (hb : ‖b₀‖ ≤ beta) (hc : ‖c₀‖ ≤ gamma) (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand A b₀ c₀ U V‖ ≤ (Lam + beta + gamma) * ‖U‖ * ‖V‖ := by
   have step : ∀ {K p q : ℝ}, 0 ≤ K → 0 ≤ p → 0 ≤ q → p ≤ ‖U‖ → q ≤ ‖V‖ →
       K * p * q ≤ K * ‖U‖ * ‖V‖ := by
@@ -230,8 +227,7 @@ lemma opNorm_energyIntegrand_le_of_bounds (hLam : 0 ≤ Lam)
   exact norm_energyIntegrand_apply_le_of_bounds hLam ha hb hc U V
 
 /-- Pointwise boundedness of the shifted Laplacian jet form with constant `1 + ‖c‖`. -/
-lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ)
-    (U V : ℝ × EuclideanSpace ℝ n) :
+lemma norm_energyIntegrand_one_zero_mass_apply_le (c : ℝ) (U V : ℝ × EuclideanSpace ℝ n) :
     ‖energyIntegrand (1 : Matrix n n ℝ) 0 c U V‖ ≤
       (1 + ‖c‖) * ‖U‖ * ‖V‖ := by
   simpa using
@@ -255,8 +251,7 @@ mass defect proportional to `β²/λ`. Integrating over `Ω` this is Gårding's 
 lemma garding_energyIntegrand_self_of_bounds (hlam : 0 < lam)
     {A : Matrix n n ℝ} {b₀ : EuclideanSpace ℝ n} {c₀ : ℝ}
     (hQ : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
-    (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀)
-    (U : ℝ × EuclideanSpace ℝ n) :
+    (hb : ‖b₀‖ ≤ beta) (hc : 0 ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
     lam / 2 * ‖U.2‖ ^ 2 - beta ^ 2 / (2 * lam) * U.1 ^ 2
       ≤ energyIntegrand A b₀ c₀ U U := by
   rw [energyIntegrand_self]

--- a/TauCeti/Analysis/PDE/EnergyForm/Continuity.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Continuity.lean
@@ -40,8 +40,7 @@ open scoped InnerProductSpace
 variable {X n : Type*} [Fintype n]
 
 /-- The coefficient triple-to-energy-integrand map as a continuous linear map. -/
-noncomputable def energyIntegrandLinear :
-    (Matrix n n ℝ × EuclideanSpace ℝ n × ℝ) →L[ℝ]
+noncomputable def energyIntegrandLinear : (Matrix n n ℝ × EuclideanSpace ℝ n × ℝ) →L[ℝ]
       (ℝ × EuclideanSpace ℝ n) →L[ℝ] (ℝ × EuclideanSpace ℝ n) →L[ℝ] ℝ :=
   LinearMap.toContinuousLinearMap
     { toFun := fun p => energyIntegrand p.1 p.2.1 p.2.2

--- a/TauCeti/Analysis/PDE/EnergyForm/Integrability.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Integrability.lean
@@ -56,11 +56,9 @@ noncomputable local instance energyFormIntegrabilityDecidableEq : DecidableEq n 
 integrable scalar energy density. -/
 lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul
     {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
-    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ}
-    (hLam : 0 ≤ Lam)
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ} (hLam : 0 ≤ Lam)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
-    (hV : AEStronglyMeasurable V μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ) (hV : AEStronglyMeasurable V μ)
     (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
     (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
@@ -76,8 +74,7 @@ lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul
 scalar energy density. -/
 lemma integrable_energyIntegrand_apply₂_of_memLp_two
     {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
-    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ}
-    (hLam : 0 ≤ Lam)
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma : ℝ} (hLam : 0 ≤ Lam)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
     (hc : AEStronglyMeasurable c μ) (hU : MemLp U 2 μ) (hV : MemLp V 2 μ)
     (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
@@ -98,11 +95,9 @@ lemma integrable_energyIntegrand_apply₂_of_memLp_two
 scalar energy density on a finite-measure space. -/
 lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
     {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
-    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma R S : ℝ}
-    (hLam : 0 ≤ Lam)
+    {U V : α → ℝ × EuclideanSpace ℝ n} {Lam beta gamma R S : ℝ} (hLam : 0 ≤ Lam)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
-    (hV : AEStronglyMeasurable V μ)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ) (hV : AEStronglyMeasurable V μ)
     (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
     (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
@@ -120,12 +115,9 @@ lemma integrable_energyIntegrand_apply₂_of_bounds [IsFiniteMeasure μ]
 
 /-- Fixed-jet specialization of `integrable_energyIntegrand_apply₂_of_bounds`. -/
 lemma integrable_energyIntegrand_apply_of_bounds [IsFiniteMeasure μ]
-    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ}
-    {Lam beta gamma : ℝ}
-    (hLam : 0 ≤ Lam)
-    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ)
-    (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
+    {a : α → Matrix n n ℝ} {b : α → EuclideanSpace ℝ n} {c : α → ℝ} {Lam beta gamma : ℝ}
+    (hLam : 0 ≤ Lam) (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
+    (hc : AEStronglyMeasurable c μ) (ha_bound : ∀ᵐ x ∂μ, ∀ η ξ : EuclideanSpace ℝ n,
       |η ⬝ᵥ (a x *ᵥ ξ)| ≤ Lam * ‖η‖ * ‖ξ‖)
     (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
     (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
@@ -151,10 +143,8 @@ If `μ` is a.e. supported on `Ω`, the named principal coefficient hypothesis
 lemma integrable_energyIntegrand_apply₂_of_integrable_norm_mul_on
     (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
-    (hV : AEStronglyMeasurable V μ)
-    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
-    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ) (hV : AEStronglyMeasurable V μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
     (hUV : Integrable (fun x => ‖U x‖ * ‖V x‖) μ) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
   integrable_energyIntegrand_apply₂_of_integrable_norm_mul h.upper_nonneg ha hb hc hU hV
@@ -165,8 +155,7 @@ lemma integrable_energyIntegrand_apply₂_of_memLp_two_on
     (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
     (hc : AEStronglyMeasurable c μ) (hU : MemLp U 2 μ) (hV : MemLp V 2 μ)
-    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
-    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma) :
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
   integrable_energyIntegrand_apply₂_of_memLp_two h.upper_nonneg ha hb hc hU hV
     (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound
@@ -175,12 +164,9 @@ lemma integrable_energyIntegrand_apply₂_of_memLp_two_on
 lemma integrable_energyIntegrand_apply₂_of_bounds_on [IsFiniteMeasure μ]
     (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
     (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ)
-    (hV : AEStronglyMeasurable V μ)
-    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
-    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
-    (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R)
-    (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
+    (hc : AEStronglyMeasurable c μ) (hU : AEStronglyMeasurable U μ) (hV : AEStronglyMeasurable V μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (hU_bound : ∀ᵐ x ∂μ, ‖U x‖ ≤ R) (hV_bound : ∀ᵐ x ∂μ, ‖V x‖ ≤ S) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) (U x) (V x)) μ :=
   integrable_energyIntegrand_apply₂_of_bounds h.upper_nonneg ha hb hc hU hV
     (hΩ.mono fun _ hx => h.upper_bound hx) hb_bound hc_bound hU_bound hV_bound
@@ -189,10 +175,8 @@ lemma integrable_energyIntegrand_apply₂_of_bounds_on [IsFiniteMeasure μ]
 `UniformlyEllipticOn.integrable_energyIntegrand_apply₂_of_bounds_on`. -/
 lemma integrable_energyIntegrand_apply_of_bounds_on [IsFiniteMeasure μ]
     (h : UniformlyEllipticOn Ω a lam Lam) (hΩ : ∀ᵐ x ∂μ, x ∈ Ω)
-    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ)
-    (hc : AEStronglyMeasurable c μ)
-    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta)
-    (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
+    (ha : AEStronglyMeasurable a μ) (hb : AEStronglyMeasurable b μ) (hc : AEStronglyMeasurable c μ)
+    (hb_bound : ∀ᵐ x ∂μ, ‖b x‖ ≤ beta) (hc_bound : ∀ᵐ x ∂μ, ‖c x‖ ≤ gamma)
     (U V : ℝ × EuclideanSpace ℝ n) :
     Integrable (fun x => energyIntegrand (a x) (b x) (c x) U V) μ :=
   integrable_energyIntegrand_apply_of_bounds h.upper_nonneg ha hb hc

--- a/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/Lp.lean
@@ -58,16 +58,14 @@ value-gradient jets.
 
 This is the Hölder pairing induced by `energyIntegrand A b c`; in particular it is bundled as
 a continuous bilinear map, with no integrability hypotheses required at use sites. -/
-noncomputable def energyFormLp (μ : Measure X) (A : Matrix n n ℝ)
-    (b : EuclideanSpace ℝ n) (c : ℝ) :
+noncomputable def energyFormLp (μ : Measure X) (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ) :
     Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ]
       Lp (ℝ × EuclideanSpace ℝ n) 2 μ →L[ℝ] ℝ :=
   (energyIntegrand A b c).lpPairing μ 2 2
 
 /-- The `L²` energy form is the integral of the pointwise jet energy density. -/
 @[simp]
-theorem energyFormLp_apply (μ : Measure X) (A : Matrix n n ℝ)
-    (b : EuclideanSpace ℝ n) (c : ℝ)
+theorem energyFormLp_apply (μ : Measure X) (A : Matrix n n ℝ) (b : EuclideanSpace ℝ n) (c : ℝ)
     (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLp μ A b c U V =
       ∫ x, energyIntegrand A b c (U x) (V x) ∂μ := by
@@ -84,8 +82,7 @@ theorem energyFormLp_one_zero_mass_apply (μ : Measure X) (c : ℝ)
   exact energyIntegrand_one_zero_mass_apply c (U x) (V x)
 
 /-- The Dirichlet energy form pairs the gradient components of two `L²` jets. -/
-theorem energyFormLp_one_zero_zero_apply (μ : Measure X)
-    (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+theorem energyFormLp_one_zero_zero_apply (μ : Measure X) (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLp μ (1 : Matrix n n ℝ) 0 0 U V =
       ∫ x, (V x).2 ⬝ᵥ (U x).2 ∂μ := by
   rw [energyFormLp_one_zero_mass_apply]
@@ -103,8 +100,7 @@ theorem energyFormLp_one_zero_mass_self (μ : Measure X) (c : ℝ)
 
 /-- The diagonal of the Dirichlet `L²` energy form is the integral of the squared gradient
 norm. -/
-theorem energyFormLp_one_zero_zero_self (μ : Measure X)
-    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+theorem energyFormLp_one_zero_zero_self (μ : Measure X) (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLp μ (1 : Matrix n n ℝ) 0 0 U U =
       ∫ x, ‖(U x).2‖ ^ 2 ∂μ := by
   rw [energyFormLp_one_zero_mass_self]
@@ -113,8 +109,7 @@ theorem energyFormLp_one_zero_zero_self (μ : Measure X)
 /-- Replacing the principal coefficient by its symmetric part does not change the diagonal
 `L²` energy form. -/
 theorem energyFormLp_coefficientSymmetricPart_self (μ : Measure X) (A : Matrix n n ℝ)
-    (b : EuclideanSpace ℝ n) (c : ℝ)
-    (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
+    (b : EuclideanSpace ℝ n) (c : ℝ) (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLp μ (coefficientSymmetricPart A) b c U U =
       energyFormLp μ A b c U U := by
   rw [energyFormLp_apply, energyFormLp_apply]
@@ -164,8 +159,7 @@ theorem energyFormLp_zero_drift_comm_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSy
 flip. -/
 @[simp]
 theorem energyFormLp_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
-    (μ : Measure X) (c : ℝ) :
-    (energyFormLp μ A 0 c).flip = energyFormLp μ A 0 c := by
+    (μ : Measure X) (c : ℝ) : (energyFormLp μ A 0 c).flip = energyFormLp μ A 0 c := by
   ext U V
   exact energyFormLp_zero_drift_comm_of_isSymm hA μ c V U
 
@@ -179,8 +173,7 @@ theorem energyFormLp_coefficientSymmetricPart_zero_drift_comm (μ : Measure X)
 /-- The symmetric-part zero-drift `L²` energy form is equal to its flip. -/
 @[simp]
 theorem energyFormLp_coefficientSymmetricPart_zero_drift_flip_eq (μ : Measure X)
-    (A : Matrix n n ℝ) (c : ℝ) :
-    (energyFormLp μ (coefficientSymmetricPart A) 0 c).flip =
+    (A : Matrix n n ℝ) (c : ℝ) : (energyFormLp μ (coefficientSymmetricPart A) 0 c).flip =
       energyFormLp μ (coefficientSymmetricPart A) 0 c :=
   energyFormLp_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) μ c
 

--- a/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
+++ b/TauCeti/Analysis/PDE/EnergyForm/VariableLp.lean
@@ -148,8 +148,7 @@ theorem energyFormLpVariable_zero_drift_flip_eq_of_isSymm_ae {μ : Measure X}
 variable energy form. -/
 theorem energyFormLpVariable_coefficientSymmetricPart_self (μ : Measure X)
     (a : X → Matrix n n ℝ) (b : X → EuclideanSpace ℝ n) (c : X → ℝ)
-    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x))
-      (b x) (c x)) ⊤ μ)
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) (b x) (c x)) ⊤ μ)
     (hcoeff' : MemLp (fun x => energyIntegrand (a x) (b x) (c x)) ⊤ μ)
     (U : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x)) b c hcoeff U U =
@@ -163,8 +162,7 @@ theorem energyFormLpVariable_coefficientSymmetricPart_self (μ : Measure X)
 its transpose. -/
 theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_apply (μ : Measure X)
     (a : X → Matrix n n ℝ) (c : X → ℝ)
-    (hsymm : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
-      (c x)) ⊤ μ)
+    (hsymm : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0 (c x)) ⊤ μ)
     (hcoeff : MemLp (fun x => energyIntegrand (a x) 0 (c x)) ⊤ μ)
     (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
@@ -185,8 +183,7 @@ theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_apply (μ : Mea
 /-- The symmetric-part variable zero-drift energy form is symmetric. -/
 theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_comm (μ : Measure X)
     (a : X → Matrix n n ℝ) (c : X → ℝ)
-    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
-      (c x)) ⊤ μ)
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0 (c x)) ⊤ μ)
     (U V : Lp (ℝ × EuclideanSpace ℝ n) 2 μ) :
     energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
         (fun _ => 0) c hcoeff U V =
@@ -199,10 +196,8 @@ theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_comm (μ : Meas
 @[simp]
 theorem energyFormLpVariable_coefficientSymmetricPart_zero_drift_flip_eq (μ : Measure X)
     (a : X → Matrix n n ℝ) (c : X → ℝ)
-    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0
-      (c x)) ⊤ μ) :
-    (energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
-      (fun _ => 0) c hcoeff).flip =
+    (hcoeff : MemLp (fun x => energyIntegrand (coefficientSymmetricPart (a x)) 0 (c x)) ⊤ μ) :
+    (energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x)) (fun _ => 0) c hcoeff).flip =
       energyFormLpVariable μ (fun x => coefficientSymmetricPart (a x))
         (fun _ => 0) c hcoeff :=
   energyFormLpVariable_zero_drift_flip_eq_of_isSymm_ae


### PR DESCRIPTION
Same defect class as #1688, #1693, #1695 and #1699 — all merged at one review round each.
Signature lines split below the 100-column limit, which Lean's pretty-printer at
`format.width := 100` would not emit that way.

Thirty-four joins across five files, `-34` lines:

| file | joins |
|---|---|
| `Integrability.lean` | 16 |
| `Lp.lean` | 7 |
| `Basic.lean` | 5 |
| `VariableLp.lean` | 5 |
| `Continuity.lean` | 1 |

`Linearity.lean` and `Measurability.lean` are in the folder and needed no change.

Each join was checked arithmetically before applying — `current + 1 + next-token ≤ 100` — and
verified in **codepoints, not bytes**, since these files carry `ℝ ≤ ∫ ‖ ∇` at three bytes each and a
byte-based check reports phantom violations. All five files have zero lines over 100 codepoints
before and after.

No statements, proofs or docstrings changed.

Scope note: `Analysis/PDE/` has more of this class outside `EnergyForm/` (`Uniform/Ellipticity.lean`
16, `ShiftedLaplacianEnergy.lean` 8, and others). `Integrated/EnergyForm.lean` is deliberately
excluded — it was #1699's subject.

Roadmap: none