### PR TITLE
feat: add Brauer diagrams and count them

### DIFF
--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -13,9 +13,11 @@ public import TauCeti.Combinatorics.Enumerative.PerfectMatching
 
 A **Brauer diagram** on `k` strands is a perfect matching of the `2 * k` boundary points
 `Fin k ⊕ Fin k`, where `Sum.inl i` is the `i`-th bottom point and `Sum.inr j` the `j`-th top
-point; the matched pairs are the arcs of the diagram. Brauer diagrams index the basis of the
-Brauer algebra `B_k(δ)`, the centralizer of the orthogonal and symplectic groups acting on a
-tensor power.
+point; the matched pairs are the arcs of the diagram. Brauer diagrams index a basis of the
+Brauer algebra `B_k(δ)`, which acts on the `k`-th tensor power of the defining representation
+of an orthogonal or symplectic group. The image of that action is the centralizer of the
+group, but the action is faithful, so that `B_k(δ)` is itself that centralizer, only when the
+defining representation is large enough relative to `k`.
 
 Every boundary point lies on exactly one of three kinds of arc: a **through strand**, joining
 a bottom point to a top point; a **cap**, joining two bottom points; or a **cup**, joining two
@@ -35,7 +37,8 @@ diagrams in all.
 * `TauCeti.card_brauerDiagram`: there are `(2 * k - 1)‼` Brauer diagrams on `k` strands.
 * `TauCeti.BrauerDiagram.isThrough_or_isCap_or_isCup`, together with the three exclusivity
   lemmas: every boundary point lies on an arc of exactly one of the three kinds.
-* `TauCeti.card_isThrough`: there are `k !` diagrams all of whose arcs go through.
+* `TauCeti.card_brauerDiagram_forall_isThrough`: there are `k !` diagrams all of whose arcs go
+  through.
 
 ## References
 
@@ -61,9 +64,8 @@ abbrev BrauerDiagram (k : ℕ) := PerfectMatching (Fin k ⊕ Fin k)
 theorem card_brauerDiagram (k : ℕ) : Fintype.card (BrauerDiagram k) = (2 * k - 1)‼ :=
   card_perfectMatching (Fin k ⊕ Fin k) (by simp [Fintype.card_sum, two_mul])
 
-/-- On two strands there are three Brauer diagrams: the identity, the crossing, and the
-cap-cup. -/
-theorem card_brauerDiagram_two : Fintype.card (BrauerDiagram 2) = 3 := by
+-- On two strands there are three Brauer diagrams: the identity, the crossing, and the cap-cup.
+example : Fintype.card (BrauerDiagram 2) = 3 := by
   rw [card_brauerDiagram]
   decide
 
@@ -73,17 +75,14 @@ variable {k : ℕ} (D : BrauerDiagram k) (x : Fin k ⊕ Fin k)
 
 /-- The boundary point `x` lies on a **through strand**: it is matched with a point on the
 opposite boundary. -/
-@[expose]
 def IsThrough : Prop := (D.val x).isLeft ≠ x.isLeft
 
 /-- The boundary point `x` lies on a **cap**: it is a bottom point matched with another bottom
 point. -/
-@[expose]
 def IsCap : Prop := x.isLeft ∧ (D.val x).isLeft
 
 /-- The boundary point `x` lies on a **cup**: it is a top point matched with another top
 point. -/
-@[expose]
 def IsCup : Prop := x.isRight ∧ (D.val x).isRight
 
 instance : Decidable (D.IsThrough x) :=
@@ -92,6 +91,15 @@ instance : Decidable (D.IsThrough x) :=
 instance : Decidable (D.IsCap x) := inferInstanceAs (Decidable (x.isLeft ∧ (D.val x).isLeft))
 
 instance : Decidable (D.IsCup x) := inferInstanceAs (Decidable (x.isRight ∧ (D.val x).isRight))
+
+/-- Lying on a through strand means being matched across the two boundaries. -/
+theorem isThrough_def : D.IsThrough x ↔ (D.val x).isLeft ≠ x.isLeft := Iff.rfl
+
+/-- Lying on a cap means being a bottom point matched with a bottom point. -/
+theorem isCap_def : D.IsCap x ↔ x.isLeft ∧ (D.val x).isLeft := Iff.rfl
+
+/-- Lying on a cup means being a top point matched with a top point. -/
+theorem isCup_def : D.IsCup x ↔ x.isRight ∧ (D.val x).isRight := Iff.rfl
 
 /-- Every boundary point lies on a through strand, on a cap, or on a cup. -/
 theorem isThrough_or_isCap_or_isCup : D.IsThrough x ∨ D.IsCap x ∨ D.IsCup x := by
@@ -118,16 +126,19 @@ theorem not_isCup_of_isCap (h : D.IsCap x) : ¬D.IsCup x := by
   · simp [IsCap] at h
 
 /-- Lying on a through strand is a property of the arc, not of the endpoint chosen. -/
+@[simp]
 theorem isThrough_val : D.IsThrough (D.val x) ↔ D.IsThrough x := by
   simp only [IsThrough, D.apply_apply]
   exact ne_comm
 
 /-- Lying on a cap is a property of the arc, not of the endpoint chosen. -/
+@[simp]
 theorem isCap_val : D.IsCap (D.val x) ↔ D.IsCap x := by
   simp only [IsCap, D.apply_apply]
   exact and_comm
 
 /-- Lying on a cup is a property of the arc, not of the endpoint chosen. -/
+@[simp]
 theorem isCup_val : D.IsCup (D.val x) ↔ D.IsCup x := by
   simp only [IsCup, D.apply_apply]
   exact and_comm
@@ -221,8 +232,16 @@ noncomputable def permToBrauerEquiv (k : ℕ) :
   left_inv σ := BrauerDiagram.throughPerm_permToBrauer σ
   right_inv D := Subtype.ext (BrauerDiagram.permToBrauer_throughPerm D.2)
 
+@[simp]
+theorem permToBrauerEquiv_apply {k : ℕ} (σ : Equiv.Perm (Fin k)) :
+    (permToBrauerEquiv k σ : BrauerDiagram k) = permToBrauer σ := rfl
+
+@[simp]
+theorem permToBrauerEquiv_symm_apply {k : ℕ} (D : {D : BrauerDiagram k // ∀ x, D.IsThrough x}) :
+    (permToBrauerEquiv k).symm D = BrauerDiagram.throughPerm D.1 D.2 := rfl
+
 /-- The Brauer diagrams with no cap and no cup are `k !` in number. -/
-theorem card_isThrough (k : ℕ) :
+theorem card_brauerDiagram_forall_isThrough (k : ℕ) :
     Fintype.card {D : BrauerDiagram k // ∀ x, D.IsThrough x} = k ! := by
   rw [← Fintype.card_congr (permToBrauerEquiv k), Fintype.card_perm, Fintype.card_fin]
 

--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -1,0 +1,233 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Data.Fintype.Sum
+public import TauCeti.Combinatorics.Enumerative.PerfectMatching
+
+/-!
+# Brauer diagrams
+
+A **Brauer diagram** on `k` strands is a perfect matching of the `2 * k` boundary points
+`Fin k ⊕ Fin k`, where `Sum.inl i` is the `i`-th bottom point and `Sum.inr j` the `j`-th top
+point; the matched pairs are the arcs of the diagram. Brauer diagrams index the basis of the
+Brauer algebra `B_k(δ)`, the centralizer of the orthogonal and symplectic groups acting on a
+tensor power.
+
+Every boundary point lies on exactly one of three kinds of arc: a **through strand**, joining
+a bottom point to a top point; a **cap**, joining two bottom points; or a **cup**, joining two
+top points. The diagrams with no cap and no cup are exactly the diagrams `permToBrauer σ` of
+permutations `σ : Equiv.Perm (Fin k)`, so there are `k !` of them among the `(2 * k - 1)‼`
+diagrams in all.
+
+## Main definitions
+
+* `TauCeti.BrauerDiagram k`: the Brauer diagrams on `k` strands.
+* `TauCeti.BrauerDiagram.IsThrough`, `IsCap`, `IsCup`: the three kinds of arc.
+* `TauCeti.permToBrauer`: the diagram of a permutation.
+* `TauCeti.permToBrauerEquiv`: permutations are the diagrams all of whose arcs go through.
+
+## Main results
+
+* `TauCeti.card_brauerDiagram`: there are `(2 * k - 1)‼` Brauer diagrams on `k` strands.
+* `TauCeti.BrauerDiagram.isThrough_or_isCap_or_isCup`, together with the three exclusivity
+  lemmas: every boundary point lies on an arc of exactly one of the three kinds.
+* `TauCeti.card_isThrough`: there are `k !` diagrams all of whose arcs go through.
+
+## References
+
+* [R. Brauer, *On algebras which are connected with the semisimple continuous groups*][brauer1937],
+  Annals of Mathematics 38 (1937), 857-872.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 9.
+-/
+
+public section
+
+open scoped Nat
+
+namespace TauCeti
+
+/-- A **Brauer diagram** on `k` strands: a perfect matching of the `2 * k` boundary points
+`Fin k ⊕ Fin k`, with `Sum.inl i` the `i`-th bottom point and `Sum.inr j` the `j`-th top
+point.  The value `D.val x` is the boundary point that the diagram matches with `x`. -/
+abbrev BrauerDiagram (k : ℕ) := PerfectMatching (Fin k ⊕ Fin k)
+
+/-- **The number of Brauer diagrams.** There are `(2 * k - 1)‼` perfect matchings of the
+`2 * k` boundary points, hence `(2 * k - 1)‼` Brauer diagrams on `k` strands. -/
+theorem card_brauerDiagram (k : ℕ) : Fintype.card (BrauerDiagram k) = (2 * k - 1)‼ :=
+  card_perfectMatching (Fin k ⊕ Fin k) (by simp [Fintype.card_sum, two_mul])
+
+/-- On two strands there are three Brauer diagrams: the identity, the crossing, and the
+cap-cup. -/
+theorem card_brauerDiagram_two : Fintype.card (BrauerDiagram 2) = 3 := by
+  rw [card_brauerDiagram]
+  decide
+
+namespace BrauerDiagram
+
+variable {k : ℕ} (D : BrauerDiagram k) (x : Fin k ⊕ Fin k)
+
+/-- The boundary point `x` lies on a **through strand**: it is matched with a point on the
+opposite boundary. -/
+@[expose]
+def IsThrough : Prop := (D.val x).isLeft ≠ x.isLeft
+
+/-- The boundary point `x` lies on a **cap**: it is a bottom point matched with another bottom
+point. -/
+@[expose]
+def IsCap : Prop := x.isLeft ∧ (D.val x).isLeft
+
+/-- The boundary point `x` lies on a **cup**: it is a top point matched with another top
+point. -/
+@[expose]
+def IsCup : Prop := x.isRight ∧ (D.val x).isRight
+
+instance : Decidable (D.IsThrough x) :=
+  inferInstanceAs (Decidable ((D.val x).isLeft ≠ x.isLeft))
+
+instance : Decidable (D.IsCap x) := inferInstanceAs (Decidable (x.isLeft ∧ (D.val x).isLeft))
+
+instance : Decidable (D.IsCup x) := inferInstanceAs (Decidable (x.isRight ∧ (D.val x).isRight))
+
+/-- Every boundary point lies on a through strand, on a cap, or on a cup. -/
+theorem isThrough_or_isCap_or_isCup : D.IsThrough x ∨ D.IsCap x ∨ D.IsCup x := by
+  rcases x with i | i
+  · rcases h : D.val (Sum.inl i) with j | j <;> simp [IsThrough, IsCap, IsCup, h]
+  · rcases h : D.val (Sum.inr i) with j | j <;> simp [IsThrough, IsCap, IsCup, h]
+
+/-- A cap is not a through strand. -/
+theorem not_isThrough_of_isCap (h : D.IsCap x) : ¬D.IsThrough x := by
+  simp [IsThrough, h.1, h.2]
+
+/-- A cup is not a through strand. -/
+theorem not_isThrough_of_isCup (h : D.IsCup x) : ¬D.IsThrough x := by
+  rcases x with i | i
+  · simp [IsCup] at h
+  · rcases hx : D.val (Sum.inr i) with j | j
+    · rw [IsCup, hx] at h; simp at h
+    · simp [IsThrough, hx]
+
+/-- A cap is not a cup. -/
+theorem not_isCup_of_isCap (h : D.IsCap x) : ¬D.IsCup x := by
+  rcases x with i | i
+  · simp [IsCup]
+  · simp [IsCap] at h
+
+/-- Lying on a through strand is a property of the arc, not of the endpoint chosen. -/
+theorem isThrough_val : D.IsThrough (D.val x) ↔ D.IsThrough x := by
+  simp only [IsThrough, D.apply_apply]
+  exact ne_comm
+
+/-- Lying on a cap is a property of the arc, not of the endpoint chosen. -/
+theorem isCap_val : D.IsCap (D.val x) ↔ D.IsCap x := by
+  simp only [IsCap, D.apply_apply]
+  exact and_comm
+
+/-- Lying on a cup is a property of the arc, not of the endpoint chosen. -/
+theorem isCup_val : D.IsCup (D.val x) ↔ D.IsCup x := by
+  simp only [IsCup, D.apply_apply]
+  exact and_comm
+
+end BrauerDiagram
+
+/-- The **permutation diagram** of `σ`, joining the bottom point `i` to the top point `σ i`. -/
+@[expose]
+def permToBrauer {k : ℕ} (σ : Equiv.Perm (Fin k)) : BrauerDiagram k :=
+  ⟨(Equiv.sumComm (Fin k) (Fin k)).trans (Equiv.sumCongr σ.symm σ),
+    fun x => by rcases x with i | i <;> simp, fun x => by rcases x with i | i <;> simp⟩
+
+namespace BrauerDiagram
+
+variable {k : ℕ}
+
+@[simp]
+theorem permToBrauer_val_inl (σ : Equiv.Perm (Fin k)) (i : Fin k) :
+    (permToBrauer σ).val (Sum.inl i) = Sum.inr (σ i) := rfl
+
+@[simp]
+theorem permToBrauer_val_inr (σ : Equiv.Perm (Fin k)) (j : Fin k) :
+    (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := rfl
+
+/-- A permutation diagram has no cap and no cup: every arc goes through. -/
+theorem isThrough_permToBrauer (σ : Equiv.Perm (Fin k)) (x : Fin k ⊕ Fin k) :
+    (permToBrauer σ).IsThrough x := by rcases x with i | i <;> simp [IsThrough]
+
+variable {D : BrauerDiagram k}
+
+/-- On a diagram all of whose arcs go through, a bottom point is matched with a top point. -/
+theorem isRight_val_inl (hD : ∀ x, D.IsThrough x) (i : Fin k) :
+    (D.val (Sum.inl i)).isRight := by
+  rcases h : D.val (Sum.inl i) with j | j
+  · have := hD (Sum.inl i); rw [IsThrough, h] at this; simp at this
+  · simp
+
+/-- On a diagram all of whose arcs go through, a top point is matched with a bottom point. -/
+theorem isLeft_val_inr (hD : ∀ x, D.IsThrough x) (j : Fin k) :
+    (D.val (Sum.inr j)).isLeft := by
+  rcases h : D.val (Sum.inr j) with i | i
+  · simp
+  · have := hD (Sum.inr j); rw [IsThrough, h] at this; simp at this
+
+/-- Reading off the top endpoint of a through strand. -/
+theorem getRight_val_inl (hD : ∀ x, D.IsThrough x) {i j : Fin k}
+    (h : D.val (Sum.inl i) = Sum.inr j) :
+    (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) = j :=
+  (Sum.eq_right_iff_getRight_eq.mp h).2
+
+/-- The permutation read off a Brauer diagram all of whose arcs go through: it sends the
+bottom point `i` to the top point matched with it. -/
+@[expose]
+noncomputable def throughPerm (D : BrauerDiagram k) (hD : ∀ x, D.IsThrough x) :
+    Equiv.Perm (Fin k) :=
+  Equiv.ofBijective (fun i => (D.val (Sum.inl i)).getRight (isRight_val_inl hD i))
+    (Finite.injective_iff_bijective.mp fun i i' h => by
+      have h₁ : D.val (Sum.inl i) = D.val (Sum.inl i') := by
+        rw [← Sum.inr_getRight _ (isRight_val_inl hD i),
+          ← Sum.inr_getRight _ (isRight_val_inl hD i'), h]
+      simpa using D.val.injective h₁)
+
+@[simp]
+theorem throughPerm_apply (hD : ∀ x, D.IsThrough x) (i : Fin k) :
+    throughPerm D hD i = (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) := rfl
+
+/-- The diagram of the permutation read off a through diagram is the diagram itself. -/
+theorem permToBrauer_throughPerm (hD : ∀ x, D.IsThrough x) :
+    permToBrauer (throughPerm D hD) = D := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rcases x with i | j
+  · rw [permToBrauer_val_inl, throughPerm_apply, Sum.inr_getRight]
+  · obtain ⟨m, hm⟩ : ∃ m, D.val (Sum.inr j) = Sum.inl m :=
+      ⟨_, (Sum.inl_getLeft _ (isLeft_val_inr hD j)).symm⟩
+    rw [permToBrauer_val_inr, hm, Sum.inl.injEq, Equiv.symm_apply_eq, throughPerm_apply]
+    exact (getRight_val_inl hD (by rw [← hm, D.apply_apply])).symm
+
+/-- The permutation read off the diagram of `σ` is `σ`. -/
+theorem throughPerm_permToBrauer (σ : Equiv.Perm (Fin k)) :
+    throughPerm (permToBrauer σ) (isThrough_permToBrauer σ) = σ :=
+  Equiv.ext fun i => getRight_val_inl (isThrough_permToBrauer σ) (permToBrauer_val_inl σ i)
+
+end BrauerDiagram
+
+/-- **Permutations are exactly the Brauer diagrams with no horizontal arc.** -/
+@[expose]
+noncomputable def permToBrauerEquiv (k : ℕ) :
+    Equiv.Perm (Fin k) ≃ {D : BrauerDiagram k // ∀ x, D.IsThrough x} where
+  toFun σ := ⟨permToBrauer σ, BrauerDiagram.isThrough_permToBrauer σ⟩
+  invFun D := BrauerDiagram.throughPerm D.1 D.2
+  left_inv σ := BrauerDiagram.throughPerm_permToBrauer σ
+  right_inv D := Subtype.ext (BrauerDiagram.permToBrauer_throughPerm D.2)
+
+/-- The Brauer diagrams with no cap and no cup are `k !` in number. -/
+theorem card_isThrough (k : ℕ) :
+    Fintype.card {D : BrauerDiagram k // ∀ x, D.IsThrough x} = k ! := by
+  rw [← Fintype.card_congr (permToBrauerEquiv k), Fintype.card_perm, Fintype.card_fin]
+
+/-- The permutation diagram determines the permutation. -/
+theorem permToBrauer_injective (k : ℕ) : Function.Injective (permToBrauer (k := k)) :=
+  fun _ _ h => (permToBrauerEquiv k).injective (Subtype.ext h)
+
+end TauCeti

--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -146,7 +146,6 @@ theorem isCup_val : D.IsCup (D.val x) ↔ D.IsCup x := by
 end BrauerDiagram
 
 /-- The **permutation diagram** of `σ`, joining the bottom point `i` to the top point `σ i`. -/
-@[expose]
 def permToBrauer {k : ℕ} (σ : Equiv.Perm (Fin k)) : BrauerDiagram k :=
   ⟨(Equiv.sumComm (Fin k) (Fin k)).trans (Equiv.sumCongr σ.symm σ),
     fun x => by rcases x with i | i <;> simp, fun x => by rcases x with i | i <;> simp⟩
@@ -157,11 +156,11 @@ variable {k : ℕ}
 
 @[simp]
 theorem permToBrauer_val_inl (σ : Equiv.Perm (Fin k)) (i : Fin k) :
-    (permToBrauer σ).val (Sum.inl i) = Sum.inr (σ i) := rfl
+    (permToBrauer σ).val (Sum.inl i) = Sum.inr (σ i) := (rfl)
 
 @[simp]
 theorem permToBrauer_val_inr (σ : Equiv.Perm (Fin k)) (j : Fin k) :
-    (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := rfl
+    (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := (rfl)
 
 /-- A permutation diagram has no cap and no cup: every arc goes through. -/
 theorem isThrough_permToBrauer (σ : Equiv.Perm (Fin k)) (x : Fin k ⊕ Fin k) :
@@ -191,7 +190,6 @@ theorem getRight_val_inl (hD : ∀ x, D.IsThrough x) {i j : Fin k}
 
 /-- The permutation read off a Brauer diagram all of whose arcs go through: it sends the
 bottom point `i` to the top point matched with it. -/
-@[expose]
 noncomputable def throughPerm (D : BrauerDiagram k) (hD : ∀ x, D.IsThrough x) :
     Equiv.Perm (Fin k) :=
   Equiv.ofBijective (fun i => (D.val (Sum.inl i)).getRight (isRight_val_inl hD i))
@@ -203,7 +201,7 @@ noncomputable def throughPerm (D : BrauerDiagram k) (hD : ∀ x, D.IsThrough x) 
 
 @[simp]
 theorem throughPerm_apply (hD : ∀ x, D.IsThrough x) (i : Fin k) :
-    throughPerm D hD i = (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) := rfl
+    throughPerm D hD i = (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) := (rfl)
 
 /-- The diagram of the permutation read off a through diagram is the diagram itself. -/
 theorem permToBrauer_throughPerm (hD : ∀ x, D.IsThrough x) :
@@ -224,7 +222,6 @@ theorem throughPerm_permToBrauer (σ : Equiv.Perm (Fin k)) :
 end BrauerDiagram
 
 /-- **Permutations are exactly the Brauer diagrams with no horizontal arc.** -/
-@[expose]
 noncomputable def permToBrauerEquiv (k : ℕ) :
     Equiv.Perm (Fin k) ≃ {D : BrauerDiagram k // ∀ x, D.IsThrough x} where
   toFun σ := ⟨permToBrauer σ, BrauerDiagram.isThrough_permToBrauer σ⟩
@@ -234,11 +231,11 @@ noncomputable def permToBrauerEquiv (k : ℕ) :
 
 @[simp]
 theorem permToBrauerEquiv_apply {k : ℕ} (σ : Equiv.Perm (Fin k)) :
-    (permToBrauerEquiv k σ : BrauerDiagram k) = permToBrauer σ := rfl
+    (permToBrauerEquiv k σ : BrauerDiagram k) = permToBrauer σ := (rfl)
 
 @[simp]
 theorem permToBrauerEquiv_symm_apply {k : ℕ} (D : {D : BrauerDiagram k // ∀ x, D.IsThrough x}) :
-    (permToBrauerEquiv k).symm D = BrauerDiagram.throughPerm D.1 D.2 := rfl
+    (permToBrauerEquiv k).symm D = BrauerDiagram.throughPerm D.1 D.2 := (rfl)
 
 /-- The Brauer diagrams with no cap and no cup are `k !` in number. -/
 theorem card_brauerDiagram_forall_isThrough (k : ℕ) :

--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -163,61 +163,65 @@ theorem permToBrauer_val_inr (σ : Equiv.Perm (Fin k)) (j : Fin k) :
     (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := (rfl)
 
 /-- A permutation diagram has no cap and no cup: every arc goes through. -/
+@[simp]
 theorem isThrough_permToBrauer (σ : Equiv.Perm (Fin k)) (x : Fin k ⊕ Fin k) :
     (permToBrauer σ).IsThrough x := by rcases x with i | i <;> simp [IsThrough]
 
 variable {D : BrauerDiagram k}
 
-/-- On a diagram all of whose arcs go through, a bottom point is matched with a top point. -/
-theorem isRight_val_inl (hD : ∀ x, D.IsThrough x) (i : Fin k) :
+/-- A bottom point on a through strand is matched with a top point. -/
+theorem isRight_val_inl {i : Fin k} (hi : D.IsThrough (Sum.inl i)) :
     (D.val (Sum.inl i)).isRight := by
   rcases h : D.val (Sum.inl i) with j | j
-  · have := hD (Sum.inl i); rw [IsThrough, h] at this; simp at this
+  · rw [IsThrough, h] at hi; simp at hi
   · simp
 
-/-- On a diagram all of whose arcs go through, a top point is matched with a bottom point. -/
-theorem isLeft_val_inr (hD : ∀ x, D.IsThrough x) (j : Fin k) :
+/-- A top point on a through strand is matched with a bottom point. -/
+theorem isLeft_val_inr {j : Fin k} (hj : D.IsThrough (Sum.inr j)) :
     (D.val (Sum.inr j)).isLeft := by
   rcases h : D.val (Sum.inr j) with i | i
   · simp
-  · have := hD (Sum.inr j); rw [IsThrough, h] at this; simp at this
+  · rw [IsThrough, h] at hj; simp at hj
 
 /-- Reading off the top endpoint of a through strand. -/
-theorem getRight_val_inl (hD : ∀ x, D.IsThrough x) {i j : Fin k}
+theorem getRight_val_inl {i j : Fin k} (hi : D.IsThrough (Sum.inl i))
     (h : D.val (Sum.inl i) = Sum.inr j) :
-    (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) = j :=
+    (D.val (Sum.inl i)).getRight (isRight_val_inl hi) = j :=
   (Sum.eq_right_iff_getRight_eq.mp h).2
 
 /-- The permutation read off a Brauer diagram all of whose arcs go through: it sends the
 bottom point `i` to the top point matched with it. -/
 noncomputable def throughPerm (D : BrauerDiagram k) (hD : ∀ x, D.IsThrough x) :
     Equiv.Perm (Fin k) :=
-  Equiv.ofBijective (fun i => (D.val (Sum.inl i)).getRight (isRight_val_inl hD i))
+  Equiv.ofBijective (fun i => (D.val (Sum.inl i)).getRight (isRight_val_inl (hD (Sum.inl i))))
     (Finite.injective_iff_bijective.mp fun i i' h => by
       have h₁ : D.val (Sum.inl i) = D.val (Sum.inl i') := by
-        rw [← Sum.inr_getRight _ (isRight_val_inl hD i),
-          ← Sum.inr_getRight _ (isRight_val_inl hD i'), h]
+        rw [← Sum.inr_getRight _ (isRight_val_inl (hD (Sum.inl i))),
+          ← Sum.inr_getRight _ (isRight_val_inl (hD (Sum.inl i'))), h]
       simpa using D.val.injective h₁)
 
 @[simp]
 theorem throughPerm_apply (hD : ∀ x, D.IsThrough x) (i : Fin k) :
-    throughPerm D hD i = (D.val (Sum.inl i)).getRight (isRight_val_inl hD i) := (rfl)
+    throughPerm D hD i = (D.val (Sum.inl i)).getRight (isRight_val_inl (hD (Sum.inl i))) := (rfl)
 
 /-- The diagram of the permutation read off a through diagram is the diagram itself. -/
+@[simp]
 theorem permToBrauer_throughPerm (hD : ∀ x, D.IsThrough x) :
     permToBrauer (throughPerm D hD) = D := by
   refine Subtype.ext (Equiv.ext fun x => ?_)
   rcases x with i | j
   · rw [permToBrauer_val_inl, throughPerm_apply, Sum.inr_getRight]
   · obtain ⟨m, hm⟩ : ∃ m, D.val (Sum.inr j) = Sum.inl m :=
-      ⟨_, (Sum.inl_getLeft _ (isLeft_val_inr hD j)).symm⟩
+      ⟨_, (Sum.inl_getLeft _ (isLeft_val_inr (hD (Sum.inr j)))).symm⟩
     rw [permToBrauer_val_inr, hm, Sum.inl.injEq, Equiv.symm_apply_eq, throughPerm_apply]
-    exact (getRight_val_inl hD (by rw [← hm, D.apply_apply])).symm
+    exact (getRight_val_inl (hD (Sum.inl m)) (by rw [← hm, D.apply_apply])).symm
 
 /-- The permutation read off the diagram of `σ` is `σ`. -/
+@[simp]
 theorem throughPerm_permToBrauer (σ : Equiv.Perm (Fin k)) :
     throughPerm (permToBrauer σ) (isThrough_permToBrauer σ) = σ :=
-  Equiv.ext fun i => getRight_val_inl (isThrough_permToBrauer σ) (permToBrauer_val_inl σ i)
+  Equiv.ext fun i =>
+    getRight_val_inl (isThrough_permToBrauer σ (Sum.inl i)) (permToBrauer_val_inl σ i)
 
 end BrauerDiagram
 

--- a/TauCeti/Combinatorics/Brauer/Diagram.lean
+++ b/TauCeti/Combinatorics/Brauer/Diagram.lean
@@ -147,8 +147,8 @@ end BrauerDiagram
 
 /-- The **permutation diagram** of `σ`, joining the bottom point `i` to the top point `σ i`. -/
 def permToBrauer {k : ℕ} (σ : Equiv.Perm (Fin k)) : BrauerDiagram k :=
-  ⟨(Equiv.sumComm (Fin k) (Fin k)).trans (Equiv.sumCongr σ.symm σ),
-    fun x => by rcases x with i | i <;> simp, fun x => by rcases x with i | i <;> simp⟩
+  .mk ((Equiv.sumComm (Fin k) (Fin k)).trans (Equiv.sumCongr σ.symm σ))
+    (fun x => by rcases x with i | i <;> simp) fun x => by rcases x with i | i <;> simp
 
 namespace BrauerDiagram
 
@@ -156,11 +156,11 @@ variable {k : ℕ}
 
 @[simp]
 theorem permToBrauer_val_inl (σ : Equiv.Perm (Fin k)) (i : Fin k) :
-    (permToBrauer σ).val (Sum.inl i) = Sum.inr (σ i) := (rfl)
+    (permToBrauer σ).val (Sum.inl i) = Sum.inr (σ i) := by simp [permToBrauer]
 
 @[simp]
 theorem permToBrauer_val_inr (σ : Equiv.Perm (Fin k)) (j : Fin k) :
-    (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := (rfl)
+    (permToBrauer σ).val (Sum.inr j) = Sum.inl (σ.symm j) := by simp [permToBrauer]
 
 /-- A permutation diagram has no cap and no cup: every arc goes through. -/
 @[simp]
@@ -182,12 +182,6 @@ theorem isLeft_val_inr {j : Fin k} (hj : D.IsThrough (Sum.inr j)) :
   rcases h : D.val (Sum.inr j) with i | i
   · simp
   · rw [IsThrough, h] at hj; simp at hj
-
-/-- Reading off the top endpoint of a through strand. -/
-theorem getRight_val_inl {i j : Fin k} (hi : D.IsThrough (Sum.inl i))
-    (h : D.val (Sum.inl i) = Sum.inr j) :
-    (D.val (Sum.inl i)).getRight (isRight_val_inl hi) = j :=
-  (Sum.eq_right_iff_getRight_eq.mp h).2
 
 /-- The permutation read off a Brauer diagram all of whose arcs go through: it sends the
 bottom point `i` to the top point matched with it. -/
@@ -214,14 +208,13 @@ theorem permToBrauer_throughPerm (hD : ∀ x, D.IsThrough x) :
   · obtain ⟨m, hm⟩ : ∃ m, D.val (Sum.inr j) = Sum.inl m :=
       ⟨_, (Sum.inl_getLeft _ (isLeft_val_inr (hD (Sum.inr j)))).symm⟩
     rw [permToBrauer_val_inr, hm, Sum.inl.injEq, Equiv.symm_apply_eq, throughPerm_apply]
-    exact (getRight_val_inl (hD (Sum.inl m)) (by rw [← hm, D.apply_apply])).symm
+    exact ((Sum.getRight_eq_iff _).mpr (by rw [← hm, D.apply_apply])).symm
 
 /-- The permutation read off the diagram of `σ` is `σ`. -/
 @[simp]
 theorem throughPerm_permToBrauer (σ : Equiv.Perm (Fin k)) :
     throughPerm (permToBrauer σ) (isThrough_permToBrauer σ) = σ :=
-  Equiv.ext fun i =>
-    getRight_val_inl (isThrough_permToBrauer σ (Sum.inl i)) (permToBrauer_val_inl σ i)
+  Equiv.ext fun i => (Sum.getRight_eq_iff _).mpr (permToBrauer_val_inl σ i)
 
 end BrauerDiagram
 

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -54,9 +54,13 @@ variable {α : Type u}
 
 /-- A permutation of `α` is a **perfect matching** when it is an involution with no fixed
 point, so that it pairs off the elements of `α`. -/
-@[expose]
 def IsPerfectMatching (f : Equiv.Perm α) : Prop :=
   (∀ a, f (f a) = a) ∧ ∀ a, f a ≠ a
+
+/-- A permutation is a perfect matching exactly when it is an involution with no fixed
+point. -/
+theorem isPerfectMatching_iff {f : Equiv.Perm α} :
+    IsPerfectMatching f ↔ (∀ a, f (f a) = a) ∧ ∀ a, f a ≠ a := Iff.rfl
 
 instance instDecidableIsPerfectMatching [DecidableEq α] [Fintype α] (f : Equiv.Perm α) :
     Decidable (IsPerfectMatching f) :=
@@ -74,6 +78,14 @@ instance [DecidableEq α] [Fintype α] : Fintype (PerfectMatching α) :=
 
 instance [DecidableEq α] [Fintype α] : DecidableEq (PerfectMatching α) :=
   inferInstanceAs (DecidableEq {f : Equiv.Perm α // IsPerfectMatching f})
+
+/-- Bundle a permutation that is an involution with no fixed point as a perfect matching. -/
+def mk (f : Equiv.Perm α) (hinv : ∀ a, f (f a) = a) (hne : ∀ a, f a ≠ a) : PerfectMatching α :=
+  ⟨f, hinv, hne⟩
+
+@[simp]
+theorem val_mk (f : Equiv.Perm α) (hinv : ∀ a, f (f a) = a) (hne : ∀ a, f a ≠ a) :
+    (mk f hinv hne).val = f := (rfl)
 
 variable {a b : α} {D : PerfectMatching α}
 

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -1,0 +1,289 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
+public import Mathlib.Data.Fintype.EquivFin
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.Nat.Factorial.DoubleFactorial
+public import Mathlib.GroupTheory.Perm.Support
+
+/-!
+# Perfect matchings of a finite type
+
+A **perfect matching** of a type `α` is a permutation of `α` that is an involution without
+fixed points; equivalently, it partitions `α` into the unordered pairs `{a, f a}`. This file
+defines perfect matchings, shows that a perfect matching restricted to the complement of one
+of its arcs is again a perfect matching, and counts the perfect matchings of a finite type:
+a type of cardinality `2 * m` has `(2 * m - 1)‼` of them, and a type of odd cardinality has
+none.
+
+The counting theorem is the combinatorial content behind the dimension of the Brauer algebra;
+see `TauCeti/Combinatorics/Brauer/Diagram.lean`.
+
+## Main definitions
+
+* `TauCeti.IsPerfectMatching f`: the permutation `f` is an involution with no fixed point.
+* `TauCeti.PerfectMatching α`: the type of perfect matchings of `α`.
+* `TauCeti.PerfectMatching.restrict`: the perfect matching induced on the complement of an arc.
+* `TauCeti.PerfectMatching.extend`: the perfect matching obtained by adjoining an arc.
+* `TauCeti.PerfectMatching.fiberEquiv`: the two constructions above are mutually inverse.
+
+## Main results
+
+* `TauCeti.even_card_of_nonempty_perfectMatching`: a matched type has even cardinality.
+* `TauCeti.card_perfectMatching`: a type of cardinality `2 * m` has `(2 * m - 1)‼` perfect
+  matchings.
+
+## References
+
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 9.
+-/
+
+public section
+
+open scoped Nat
+
+namespace TauCeti
+
+universe u
+
+variable {α : Type u}
+
+/-- A permutation of `α` is a **perfect matching** when it is an involution with no fixed
+point, so that it pairs off the elements of `α`. -/
+@[expose]
+def IsPerfectMatching (f : Equiv.Perm α) : Prop :=
+  (∀ a, f (f a) = a) ∧ ∀ a, f a ≠ a
+
+instance instDecidableIsPerfectMatching [DecidableEq α] [Fintype α] (f : Equiv.Perm α) :
+    Decidable (IsPerfectMatching f) :=
+  inferInstanceAs (Decidable ((∀ a, f (f a) = a) ∧ ∀ a, f a ≠ a))
+
+/-- The type of perfect matchings of `α`, a subtype of `Equiv.Perm α` so that the finiteness
+and decidability instances of permutations carry over unchanged. -/
+@[expose]
+def PerfectMatching (α : Type u) := {f : Equiv.Perm α // IsPerfectMatching f}
+
+namespace PerfectMatching
+
+instance [DecidableEq α] [Fintype α] : Fintype (PerfectMatching α) :=
+  inferInstanceAs (Fintype {f : Equiv.Perm α // IsPerfectMatching f})
+
+instance [DecidableEq α] [Fintype α] : DecidableEq (PerfectMatching α) :=
+  inferInstanceAs (DecidableEq {f : Equiv.Perm α // IsPerfectMatching f})
+
+variable {a b : α} {D : PerfectMatching α}
+
+/-- A perfect matching is an involution. -/
+theorem apply_apply (D : PerfectMatching α) (x : α) : D.val (D.val x) = x := D.prop.1 x
+
+/-- A perfect matching moves every point. -/
+theorem apply_ne (D : PerfectMatching α) (x : α) : D.val x ≠ x := D.prop.2 x
+
+/-- The two ends of an arc determine each other. -/
+theorem apply_eq_of_apply_eq (D : PerfectMatching α) {x y : α} (h : D.val x = y) :
+    D.val y = x := by rw [← h, D.apply_apply]
+
+/-- A perfect matching that joins `a` to `b` preserves the complement of `{a, b}`. -/
+theorem apply_mem_iff (hab : D.val a = b) (x : α) :
+    (D.val x ≠ a ∧ D.val x ≠ b) ↔ (x ≠ a ∧ x ≠ b) := by
+  have hba : D.val b = a := D.apply_eq_of_apply_eq hab
+  constructor
+  · rintro ⟨h₁, h₂⟩
+    exact ⟨fun h => h₂ (h ▸ hab), fun h => h₁ (h ▸ hba)⟩
+  · rintro ⟨h₁, h₂⟩
+    refine ⟨fun h => h₂ ?_, fun h => h₁ ?_⟩
+    · rw [← hab, ← D.apply_eq_of_apply_eq h]
+    · rw [← hba, ← D.apply_eq_of_apply_eq h]
+
+/-- The perfect matching induced on the complement of the arc joining `a` to `b`. -/
+@[expose]
+def restrict (D : PerfectMatching α) (hab : D.val a = b) :
+    PerfectMatching {x : α // x ≠ a ∧ x ≠ b} :=
+  ⟨D.val.subtypePerm (apply_mem_iff hab), fun x => Subtype.ext (D.apply_apply x.val),
+    fun x h => D.apply_ne x.val (congrArg Subtype.val h)⟩
+
+@[simp]
+theorem restrict_apply_coe (D : PerfectMatching α) (hab : D.val a = b)
+    (x : {x : α // x ≠ a ∧ x ≠ b}) : ((D.restrict hab).val x : α) = D.val x := rfl
+
+section Extend
+
+variable [DecidableEq α]
+
+/-- The permutation of `α` that acts as `E` away from `{a, b}` and swaps `a` with `b`; it
+underlies `PerfectMatching.extend`. -/
+@[expose]
+def extendPerm (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) : Equiv.Perm α :=
+  Equiv.swap a b * Equiv.Perm.ofSubtype E.val
+
+/-- Away from `{a, b}`, the extended permutation acts through `E`. -/
+theorem extendPerm_apply_of_mem (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) {x : α}
+    (hx : x ≠ a ∧ x ≠ b) : extendPerm E x = (E.val ⟨x, hx⟩ : α) := by
+  have hmem : Equiv.Perm.ofSubtype E.val x = (E.val ⟨x, hx⟩ : α) :=
+    Equiv.Perm.ofSubtype_apply_of_mem E.val hx
+  have hne := (E.val ⟨x, hx⟩).2
+  rw [extendPerm, Equiv.Perm.mul_apply, hmem, Equiv.swap_apply_of_ne_of_ne hne.1 hne.2]
+
+/-- The extended permutation sends `a` to `b`. -/
+theorem extendPerm_apply_left (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    extendPerm E a = b := by
+  rw [extendPerm, Equiv.Perm.mul_apply,
+    Equiv.Perm.ofSubtype_apply_of_not_mem E.val (by simp), Equiv.swap_apply_left]
+
+/-- The extended permutation sends `b` to `a`. -/
+theorem extendPerm_apply_right (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    extendPerm E b = a := by
+  rw [extendPerm, Equiv.Perm.mul_apply,
+    Equiv.Perm.ofSubtype_apply_of_not_mem E.val (by simp), Equiv.swap_apply_right]
+
+/-- The perfect matching of `α` obtained from a perfect matching of the complement of
+`{a, b}` by adjoining the arc joining `a` to `b`. -/
+@[expose]
+def extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) : PerfectMatching α := by
+  refine ⟨extendPerm E, fun x => ?_, fun x => ?_⟩
+  · by_cases hx : x ≠ a ∧ x ≠ b
+    · rw [extendPerm_apply_of_mem E hx, extendPerm_apply_of_mem E (E.val ⟨x, hx⟩).2]
+      exact congrArg Subtype.val (E.apply_apply ⟨x, hx⟩)
+    · rcases not_and_or.mp hx with hx | hx
+      · rw [not_ne_iff.mp hx, extendPerm_apply_left, extendPerm_apply_right]
+      · rw [not_ne_iff.mp hx, extendPerm_apply_right, extendPerm_apply_left]
+  · by_cases hx : x ≠ a ∧ x ≠ b
+    · rw [extendPerm_apply_of_mem E hx]
+      exact fun h => E.apply_ne ⟨x, hx⟩ (Subtype.ext h)
+    · rcases not_and_or.mp hx with hx | hx
+      · rw [not_ne_iff.mp hx, extendPerm_apply_left]; exact hab.symm
+      · rw [not_ne_iff.mp hx, extendPerm_apply_right]; exact hab
+
+@[simp]
+theorem extend_apply (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) (x : α) :
+    (extend hab E).val x = extendPerm E x := rfl
+
+/-- Adjoining the arc `{a, b}` sends `a` to `b`. -/
+@[simp]
+theorem extend_apply_left (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    (extend hab E).val a = b := extendPerm_apply_left E
+
+/-- Adjoining an arc and then restricting it away recovers the smaller matching. -/
+theorem restrict_extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    (extend hab E).restrict (extend_apply_left hab E) = E := by
+  refine Subtype.ext (Equiv.ext fun x => Subtype.ext ?_)
+  rw [restrict_apply_coe, extend_apply, extendPerm_apply_of_mem E x.2]
+
+/-- Restricting away an arc and then adjoining it back recovers the original matching. -/
+theorem extend_restrict (hab : a ≠ b) (D : PerfectMatching α) (h : D.val a = b) :
+    extend hab (D.restrict h) = D := by
+  refine Subtype.ext (Equiv.ext fun x => ?_)
+  rw [extend_apply]
+  by_cases hx : x ≠ a ∧ x ≠ b
+  · rw [extendPerm_apply_of_mem (D.restrict h) hx, restrict_apply_coe]
+  · rcases not_and_or.mp hx with hx | hx
+    · rw [not_ne_iff.mp hx, extendPerm_apply_left]; exact h.symm
+    · rw [not_ne_iff.mp hx, extendPerm_apply_right]
+      exact (D.apply_eq_of_apply_eq h).symm
+
+/-- Restricting away an arc and adjoining it back are mutually inverse: the perfect matchings
+of `α` joining `a` to `b` are the perfect matchings of the complement of `{a, b}`. -/
+def fiberEquiv (hab : a ≠ b) :
+    {D : PerfectMatching α // D.val a = b} ≃ PerfectMatching {x : α // x ≠ a ∧ x ≠ b} where
+  toFun D := D.1.restrict D.2
+  invFun E := ⟨extend hab E, extend_apply_left hab E⟩
+  left_inv D := Subtype.ext (extend_restrict hab D.1 D.2)
+  right_inv E := restrict_extend hab E
+
+end Extend
+
+end PerfectMatching
+
+private theorem even_card_aux :
+    ∀ (n : ℕ) {α : Type u} [Fintype α], Fintype.card α = n →
+      Nonempty (PerfectMatching α) → Even n := by
+  intro n
+  induction n using Nat.strong_induction_on with
+  | _ n ih =>
+    intro α _ hcard hne
+    classical
+    obtain ⟨D⟩ := hne
+    rcases Nat.eq_zero_or_pos n with rfl | hn
+    · exact ⟨0, rfl⟩
+    obtain ⟨a⟩ := (Fintype.card_pos_iff (α := α)).mp (by omega)
+    have hab : a ≠ D.val a := (D.apply_ne a).symm
+    have hlt : 1 < Fintype.card α := Fintype.one_lt_card_iff_nontrivial.mpr ⟨a, D.val a, hab⟩
+    have hsub : Fintype.card {x : α // x ≠ a ∧ x ≠ D.val a} = n - 2 := by
+      rw [Fintype.card_subtype,
+        show (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ D.val a)
+            = (Finset.univ.erase a).erase (D.val a) by
+          ext x
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
+          tauto,
+        Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩),
+        Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard]
+      omega
+    obtain ⟨r, hr⟩ := ih (n - 2) (by omega) hsub ⟨D.restrict rfl⟩
+    exact ⟨r + 1, by omega⟩
+
+/-- A type carrying a perfect matching has even cardinality: the arcs pair its elements. -/
+theorem even_card_of_nonempty_perfectMatching (α : Type u) [Fintype α]
+    (h : Nonempty (PerfectMatching α)) : Even (Fintype.card α) :=
+  even_card_aux _ rfl h
+
+/-- A type of odd cardinality carries no perfect matching. -/
+theorem isEmpty_perfectMatching_of_not_even {α : Type u} [Fintype α]
+    (h : ¬Even (Fintype.card α)) : IsEmpty (PerfectMatching α) :=
+  ⟨fun D => h (even_card_of_nonempty_perfectMatching α ⟨D⟩)⟩
+
+private theorem card_perfectMatching_aux :
+    ∀ (m : ℕ) {α : Type u} [Fintype α] [DecidableEq α], Fintype.card α = 2 * m →
+      Fintype.card (PerfectMatching α) = (2 * m - 1)‼ := by
+  intro m
+  induction m with
+  | zero =>
+    intro α _ _ hcard
+    have : IsEmpty α := Fintype.card_eq_zero_iff.mp (by omega)
+    have : Subsingleton (PerfectMatching α) :=
+      ⟨fun D E => Subtype.ext (Equiv.ext fun x => isEmptyElim x)⟩
+    have : Unique (PerfectMatching α) :=
+      uniqueOfSubsingleton ⟨1, fun a => isEmptyElim a, fun a => isEmptyElim a⟩
+    rw [Fintype.card_unique]
+    rfl
+  | succ m ih =>
+    intro α _ _ hcard
+    obtain ⟨a⟩ := (Fintype.card_pos_iff (α := α)).mp (by omega)
+    have key : ∀ b ∈ Finset.univ.erase a,
+        (Finset.univ.filter fun D : PerfectMatching α => D.val a = b).card = (2 * m - 1)‼ := by
+      intro b hb
+      have hba : b ≠ a := (Finset.mem_erase.mp hb).1
+      have hsub : Fintype.card {x : α // x ≠ a ∧ x ≠ b} = 2 * m := by
+        rw [Fintype.card_subtype,
+          show (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ b)
+              = (Finset.univ.erase a).erase b by
+            ext x
+            simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
+            tauto,
+          Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hba, Finset.mem_univ _⟩),
+          Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard]
+        omega
+      calc (Finset.univ.filter fun D : PerfectMatching α => D.val a = b).card
+          = Fintype.card {D : PerfectMatching α // D.val a = b} := (Fintype.card_subtype _).symm
+        _ = Fintype.card (PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :=
+            Fintype.card_congr (PerfectMatching.fiberEquiv hba.symm)
+        _ = (2 * m - 1)‼ := ih hsub
+    have hmem : ∀ D ∈ (Finset.univ : Finset (PerfectMatching α)),
+        D.val a ∈ Finset.univ.erase a :=
+      fun D _ => Finset.mem_erase.mpr ⟨D.apply_ne a, Finset.mem_univ _⟩
+    rw [← Finset.card_univ, Finset.card_eq_sum_card_fiberwise hmem, Finset.sum_const_nat key,
+      Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard,
+      show 2 * (m + 1) - 1 = 2 * m + 1 from by omega, Nat.doubleFactorial_add_one]
+
+/-- **The number of perfect matchings of a finite type.** A type with `2 * m` elements has
+exactly `(2 * m - 1)‼ = 1 · 3 · 5 ⋯ (2 * m - 1)` perfect matchings. -/
+theorem card_perfectMatching (α : Type u) [Fintype α] [DecidableEq α] {m : ℕ}
+    (hcard : Fintype.card α = 2 * m) : Fintype.card (PerfectMatching α) = (2 * m - 1)‼ :=
+  card_perfectMatching_aux m hcard
+
+end TauCeti

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -131,12 +131,14 @@ theorem extendPerm_apply_of_mem (E : PerfectMatching {x : α // x ≠ a ∧ x �
   rw [extendPerm, Equiv.Perm.mul_apply, hmem, Equiv.swap_apply_of_ne_of_ne hne.1 hne.2]
 
 /-- The extended permutation sends `a` to `b`. -/
+@[simp]
 theorem extendPerm_apply_left (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     extendPerm E a = b := by
   rw [extendPerm, Equiv.Perm.mul_apply,
     Equiv.Perm.ofSubtype_apply_of_not_mem E.val (by simp), Equiv.swap_apply_left]
 
 /-- The extended permutation sends `b` to `a`. -/
+@[simp]
 theorem extendPerm_apply_right (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     extendPerm E b = a := by
   rw [extendPerm, Equiv.Perm.mul_apply,
@@ -165,7 +167,6 @@ theorem extend_apply (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧
     (extend hab E).val x = extendPerm E x := rfl
 
 /-- Adjoining the arc `{a, b}` sends `a` to `b`. -/
-@[simp]
 theorem extend_apply_left (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     (extend hab E).val a = b := extendPerm_apply_left E
 

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -5,8 +5,8 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
 public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.Fintype.Sum
 public import Mathlib.Data.Nat.Factorial.DoubleFactorial
 
 /-!
@@ -102,7 +102,6 @@ theorem apply_ne_and_ne_iff (hab : D.val a = b) (x : α) :
     · rw [← hba, ← D.apply_eq_of_apply_eq h]
 
 /-- The perfect matching induced on the complement of the arc joining `a` to `b`. -/
-@[expose]
 def restrict (D : PerfectMatching α) (hab : D.val a = b) :
     PerfectMatching {x : α // x ≠ a ∧ x ≠ b} :=
   ⟨D.val.subtypePerm (apply_ne_and_ne_iff hab), fun x => Subtype.ext (D.apply_apply x.val),
@@ -110,7 +109,7 @@ def restrict (D : PerfectMatching α) (hab : D.val a = b) :
 
 @[simp]
 theorem restrict_apply_coe (D : PerfectMatching α) (hab : D.val a = b)
-    (x : {x : α // x ≠ a ∧ x ≠ b}) : ((D.restrict hab).val x : α) = D.val x := rfl
+    (x : {x : α // x ≠ a ∧ x ≠ b}) : ((D.restrict hab).val x : α) = D.val x := (rfl)
 
 section Extend
 
@@ -199,6 +198,16 @@ def fiberEquiv (hab : a ≠ b) :
   left_inv D := Subtype.ext (extend_restrict hab D.1 D.2)
   right_inv E := restrict_extend hab E
 
+/-- The fiber equivalence restricts away the arc joining `a` to `b`. -/
+@[simp]
+theorem fiberEquiv_apply (hab : a ≠ b) (D : {D : PerfectMatching α // D.val a = b}) :
+    fiberEquiv hab D = D.1.restrict D.2 := (rfl)
+
+/-- The inverse of the fiber equivalence adjoins the arc joining `a` to `b`. -/
+@[simp]
+theorem fiberEquiv_symm_apply (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    ((fiberEquiv hab).symm E : PerfectMatching α) = extend hab E := (rfl)
+
 end Extend
 
 end PerfectMatching
@@ -206,15 +215,10 @@ end PerfectMatching
 /-- Deleting two distinct points from a finite type drops its cardinality by two. -/
 private theorem card_subtype_ne_ne {α : Type u} [Fintype α] [DecidableEq α] {a b : α}
     (hab : a ≠ b) : Fintype.card {x : α // x ≠ a ∧ x ≠ b} = Fintype.card α - 2 := by
-  have hfilter : (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ b)
-      = (Finset.univ.erase a).erase b := by
-    ext x
-    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
-    tauto
-  rw [Fintype.card_subtype, hfilter,
-    Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩),
-    Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ]
-  omega
+  have hcompl : Fintype.card {x : α // x ≠ a ∧ x ≠ b}
+      = Fintype.card {x : α // ¬(x = a ∨ x = b)} :=
+    Fintype.card_congr (Equiv.subtypeEquivRight fun _ => not_or.symm)
+  rw [hcompl, Fintype.card_subtype_compl, Fintype.card_subtype_eq_or_eq_of_ne hab]
 
 private theorem even_card_aux :
     ∀ (n : ℕ) {α : Type u} [Fintype α], Fintype.card α = n →
@@ -278,9 +282,18 @@ private theorem card_perfectMatching_aux :
         D.val a ∈ Finset.univ.erase a :=
       fun D _ => Finset.mem_erase.mpr ⟨D.apply_ne a, Finset.mem_univ _⟩
     have hodd : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
-    rw [← Finset.card_univ, Finset.card_eq_sum_card_fiberwise hmem, Finset.sum_const_nat key,
-      Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard, hodd,
-      Nat.doubleFactorial_add_one]
+    have herase : (Finset.univ.erase a).card = 2 * m + 1 := by
+      rw [Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard]
+      omega
+    calc Fintype.card (PerfectMatching α)
+        = (Finset.univ : Finset (PerfectMatching α)).card := Finset.card_univ.symm
+      _ = ∑ b ∈ Finset.univ.erase a,
+            (Finset.univ.filter fun D : PerfectMatching α => D.val a = b).card :=
+          Finset.card_eq_sum_card_fiberwise hmem
+      _ = (Finset.univ.erase a).card * (2 * m - 1)‼ := Finset.sum_const_nat key
+      _ = (2 * m + 1) * (2 * m - 1)‼ := by rw [herase]
+      _ = (2 * m + 1)‼ := (Nat.doubleFactorial_add_one (2 * m)).symm
+      _ = (2 * (m + 1) - 1)‼ := by rw [hodd]
 
 /-- **The number of perfect matchings of a finite type.** A type with `2 * m` elements has
 exactly `(2 * m - 1)‼ = 1 · 3 · 5 ⋯ (2 * m - 1)` perfect matchings. -/

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -173,12 +173,14 @@ theorem extend_apply_right (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠
     (extend hab E).val b = a := extendPerm_apply_right E
 
 /-- Adjoining an arc and then restricting it away recovers the smaller matching. -/
+@[simp]
 theorem restrict_extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     (extend hab E).restrict (extend_apply_left hab E) = E := by
   refine Subtype.ext (Equiv.ext fun x => Subtype.ext ?_)
   rw [restrict_apply_coe, extend_apply_of_mem hab E x.2]
 
 /-- Restricting away an arc and then adjoining it back recovers the original matching. -/
+@[simp]
 theorem extend_restrict (hab : a ≠ b) (D : PerfectMatching α) (h : D.val a = b) :
     extend hab (D.restrict h) = D := by
   refine Subtype.ext (Equiv.ext fun x => ?_)

--- a/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
+++ b/TauCeti/Combinatorics/Enumerative/PerfectMatching.lean
@@ -6,10 +6,8 @@ Authors: Claude
 module
 
 public import Mathlib.Algebra.BigOperators.Group.Finset.Basic
-public import Mathlib.Data.Fintype.EquivFin
 public import Mathlib.Data.Fintype.Perm
 public import Mathlib.Data.Nat.Factorial.DoubleFactorial
-public import Mathlib.GroupTheory.Perm.Support
 
 /-!
 # Perfect matchings of a finite type
@@ -80,9 +78,11 @@ instance [DecidableEq α] [Fintype α] : DecidableEq (PerfectMatching α) :=
 variable {a b : α} {D : PerfectMatching α}
 
 /-- A perfect matching is an involution. -/
+@[simp]
 theorem apply_apply (D : PerfectMatching α) (x : α) : D.val (D.val x) = x := D.prop.1 x
 
 /-- A perfect matching moves every point. -/
+@[simp]
 theorem apply_ne (D : PerfectMatching α) (x : α) : D.val x ≠ x := D.prop.2 x
 
 /-- The two ends of an arc determine each other. -/
@@ -90,7 +90,7 @@ theorem apply_eq_of_apply_eq (D : PerfectMatching α) {x y : α} (h : D.val x = 
     D.val y = x := by rw [← h, D.apply_apply]
 
 /-- A perfect matching that joins `a` to `b` preserves the complement of `{a, b}`. -/
-theorem apply_mem_iff (hab : D.val a = b) (x : α) :
+theorem apply_ne_and_ne_iff (hab : D.val a = b) (x : α) :
     (D.val x ≠ a ∧ D.val x ≠ b) ↔ (x ≠ a ∧ x ≠ b) := by
   have hba : D.val b = a := D.apply_eq_of_apply_eq hab
   constructor
@@ -105,7 +105,7 @@ theorem apply_mem_iff (hab : D.val a = b) (x : α) :
 @[expose]
 def restrict (D : PerfectMatching α) (hab : D.val a = b) :
     PerfectMatching {x : α // x ≠ a ∧ x ≠ b} :=
-  ⟨D.val.subtypePerm (apply_mem_iff hab), fun x => Subtype.ext (D.apply_apply x.val),
+  ⟨D.val.subtypePerm (apply_ne_and_ne_iff hab), fun x => Subtype.ext (D.apply_apply x.val),
     fun x h => D.apply_ne x.val (congrArg Subtype.val h)⟩
 
 @[simp]
@@ -118,12 +118,11 @@ variable [DecidableEq α]
 
 /-- The permutation of `α` that acts as `E` away from `{a, b}` and swaps `a` with `b`; it
 underlies `PerfectMatching.extend`. -/
-@[expose]
-def extendPerm (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) : Equiv.Perm α :=
+private def extendPerm (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) : Equiv.Perm α :=
   Equiv.swap a b * Equiv.Perm.ofSubtype E.val
 
 /-- Away from `{a, b}`, the extended permutation acts through `E`. -/
-theorem extendPerm_apply_of_mem (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) {x : α}
+private theorem extendPerm_apply_of_mem (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) {x : α}
     (hx : x ≠ a ∧ x ≠ b) : extendPerm E x = (E.val ⟨x, hx⟩ : α) := by
   have hmem : Equiv.Perm.ofSubtype E.val x = (E.val ⟨x, hx⟩ : α) :=
     Equiv.Perm.ofSubtype_apply_of_mem E.val hx
@@ -131,22 +130,19 @@ theorem extendPerm_apply_of_mem (E : PerfectMatching {x : α // x ≠ a ∧ x �
   rw [extendPerm, Equiv.Perm.mul_apply, hmem, Equiv.swap_apply_of_ne_of_ne hne.1 hne.2]
 
 /-- The extended permutation sends `a` to `b`. -/
-@[simp]
-theorem extendPerm_apply_left (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+private theorem extendPerm_apply_left (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     extendPerm E a = b := by
   rw [extendPerm, Equiv.Perm.mul_apply,
     Equiv.Perm.ofSubtype_apply_of_not_mem E.val (by simp), Equiv.swap_apply_left]
 
 /-- The extended permutation sends `b` to `a`. -/
-@[simp]
-theorem extendPerm_apply_right (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+private theorem extendPerm_apply_right (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     extendPerm E b = a := by
   rw [extendPerm, Equiv.Perm.mul_apply,
     Equiv.Perm.ofSubtype_apply_of_not_mem E.val (by simp), Equiv.swap_apply_right]
 
 /-- The perfect matching of `α` obtained from a perfect matching of the complement of
 `{a, b}` by adjoining the arc joining `a` to `b`. -/
-@[expose]
 def extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) : PerfectMatching α := by
   refine ⟨extendPerm E, fun x => ?_, fun x => ?_⟩
   · by_cases hx : x ≠ a ∧ x ≠ b
@@ -162,30 +158,36 @@ def extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b})
       · rw [not_ne_iff.mp hx, extendPerm_apply_left]; exact hab.symm
       · rw [not_ne_iff.mp hx, extendPerm_apply_right]; exact hab
 
-@[simp]
-theorem extend_apply (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) (x : α) :
-    (extend hab E).val x = extendPerm E x := rfl
+/-- Away from `{a, b}`, the extended matching acts through `E`. -/
+theorem extend_apply_of_mem (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) {x : α}
+    (hx : x ≠ a ∧ x ≠ b) : (extend hab E).val x = (E.val ⟨x, hx⟩ : α) :=
+  extendPerm_apply_of_mem E hx
 
 /-- Adjoining the arc `{a, b}` sends `a` to `b`. -/
+@[simp]
 theorem extend_apply_left (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     (extend hab E).val a = b := extendPerm_apply_left E
+
+/-- Adjoining the arc `{a, b}` sends `b` to `a`. -/
+@[simp]
+theorem extend_apply_right (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
+    (extend hab E).val b = a := extendPerm_apply_right E
 
 /-- Adjoining an arc and then restricting it away recovers the smaller matching. -/
 theorem restrict_extend (hab : a ≠ b) (E : PerfectMatching {x : α // x ≠ a ∧ x ≠ b}) :
     (extend hab E).restrict (extend_apply_left hab E) = E := by
   refine Subtype.ext (Equiv.ext fun x => Subtype.ext ?_)
-  rw [restrict_apply_coe, extend_apply, extendPerm_apply_of_mem E x.2]
+  rw [restrict_apply_coe, extend_apply_of_mem hab E x.2]
 
 /-- Restricting away an arc and then adjoining it back recovers the original matching. -/
 theorem extend_restrict (hab : a ≠ b) (D : PerfectMatching α) (h : D.val a = b) :
     extend hab (D.restrict h) = D := by
   refine Subtype.ext (Equiv.ext fun x => ?_)
-  rw [extend_apply]
   by_cases hx : x ≠ a ∧ x ≠ b
-  · rw [extendPerm_apply_of_mem (D.restrict h) hx, restrict_apply_coe]
+  · rw [extend_apply_of_mem hab _ hx, restrict_apply_coe]
   · rcases not_and_or.mp hx with hx | hx
-    · rw [not_ne_iff.mp hx, extendPerm_apply_left]; exact h.symm
-    · rw [not_ne_iff.mp hx, extendPerm_apply_right]
+    · rw [not_ne_iff.mp hx, extend_apply_left]; exact h.symm
+    · rw [not_ne_iff.mp hx, extend_apply_right]
       exact (D.apply_eq_of_apply_eq h).symm
 
 /-- Restricting away an arc and adjoining it back are mutually inverse: the perfect matchings
@@ -200,6 +202,19 @@ def fiberEquiv (hab : a ≠ b) :
 end Extend
 
 end PerfectMatching
+
+/-- Deleting two distinct points from a finite type drops its cardinality by two. -/
+private theorem card_subtype_ne_ne {α : Type u} [Fintype α] [DecidableEq α] {a b : α}
+    (hab : a ≠ b) : Fintype.card {x : α // x ≠ a ∧ x ≠ b} = Fintype.card α - 2 := by
+  have hfilter : (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ b)
+      = (Finset.univ.erase a).erase b := by
+    ext x
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
+    tauto
+  rw [Fintype.card_subtype, hfilter,
+    Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩),
+    Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ]
+  omega
 
 private theorem even_card_aux :
     ∀ (n : ℕ) {α : Type u} [Fintype α], Fintype.card α = n →
@@ -216,15 +231,7 @@ private theorem even_card_aux :
     have hab : a ≠ D.val a := (D.apply_ne a).symm
     have hlt : 1 < Fintype.card α := Fintype.one_lt_card_iff_nontrivial.mpr ⟨a, D.val a, hab⟩
     have hsub : Fintype.card {x : α // x ≠ a ∧ x ≠ D.val a} = n - 2 := by
-      rw [Fintype.card_subtype,
-        show (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ D.val a)
-            = (Finset.univ.erase a).erase (D.val a) by
-          ext x
-          simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
-          tauto,
-        Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hab.symm, Finset.mem_univ _⟩),
-        Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard]
-      omega
+      rw [card_subtype_ne_ne hab, hcard]
     obtain ⟨r, hr⟩ := ih (n - 2) (by omega) hsub ⟨D.restrict rfl⟩
     exact ⟨r + 1, by omega⟩
 
@@ -260,14 +267,7 @@ private theorem card_perfectMatching_aux :
       intro b hb
       have hba : b ≠ a := (Finset.mem_erase.mp hb).1
       have hsub : Fintype.card {x : α // x ≠ a ∧ x ≠ b} = 2 * m := by
-        rw [Fintype.card_subtype,
-          show (Finset.univ.filter fun x : α => x ≠ a ∧ x ≠ b)
-              = (Finset.univ.erase a).erase b by
-            ext x
-            simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_erase]
-            tauto,
-          Finset.card_erase_of_mem (Finset.mem_erase.mpr ⟨hba, Finset.mem_univ _⟩),
-          Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard]
+        rw [card_subtype_ne_ne hba.symm, hcard]
         omega
       calc (Finset.univ.filter fun D : PerfectMatching α => D.val a = b).card
           = Fintype.card {D : PerfectMatching α // D.val a = b} := (Fintype.card_subtype _).symm
@@ -277,9 +277,10 @@ private theorem card_perfectMatching_aux :
     have hmem : ∀ D ∈ (Finset.univ : Finset (PerfectMatching α)),
         D.val a ∈ Finset.univ.erase a :=
       fun D _ => Finset.mem_erase.mpr ⟨D.apply_ne a, Finset.mem_univ _⟩
+    have hodd : 2 * (m + 1) - 1 = 2 * m + 1 := by omega
     rw [← Finset.card_univ, Finset.card_eq_sum_card_fiberwise hmem, Finset.sum_const_nat key,
-      Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard,
-      show 2 * (m + 1) - 1 = 2 * m + 1 from by omega, Nat.doubleFactorial_add_one]
+      Finset.card_erase_of_mem (Finset.mem_univ _), Finset.card_univ, hcard, hodd,
+      Nat.doubleFactorial_add_one]
 
 /-- **The number of perfect matchings of a finite type.** A type with `2 * m` elements has
 exactly `(2 * m - 1)‼ = 1 · 3 · 5 ⋯ (2 * m - 1)` perfect matchings. -/


### PR DESCRIPTION
This PR adds Brauer diagrams and counts them. A Brauer diagram on `k` strands is a perfect matching of the `2 * k` boundary points `Fin k ⊕ Fin k`, and the count of those diagrams, `(2 * k - 1)‼`, is the dimension of the Brauer algebra `B_k(δ)`. The counting argument is really a statement about arbitrary finite types, so it is stated there: `TauCeti.card_perfectMatching` says a type of cardinality `2 * m` has exactly `(2 * m - 1)‼` perfect matchings, where a perfect matching is a fixed-point-free involution.

The proof is the usual recursion, made explicit as an API rather than buried in an induction. `PerfectMatching.restrict` cuts the arc through a chosen point `a` and restricts the matching to the complement of `{a, D a}`; `PerfectMatching.extend` puts an arc back; `PerfectMatching.fiberEquiv` says the two are mutually inverse, so the matchings sending `a` to a fixed `b ≠ a` are exactly the matchings of a type with two fewer elements. Summing that over the `2 * m - 1` choices of `b` and using `Nat.doubleFactorial_add_one` gives the count. The complementary fact `even_card_of_nonempty_perfectMatching` (a matched type has even cardinality, so a type of odd cardinality has no perfect matching at all) comes from the same restriction step by strong induction.

On the Brauer side, `BrauerDiagram k` is `PerfectMatching (Fin k ⊕ Fin k)` with `Sum.inl i` the `i`-th bottom point and `Sum.inr j` the `j`-th top point. Each boundary point lies on a **through strand**, a **cap** (two bottom points) or a **cup** (two top points), and `isThrough_or_isCap_or_isCup` together with the three exclusivity lemmas pins that trichotomy down; `isThrough_val`, `isCap_val`, `isCup_val` record that the classification depends on the arc and not on which of its two endpoints one names. `permToBrauer` builds the diagram of a permutation out of `Equiv.sumComm` and `Equiv.sumCongr`, and `permToBrauerEquiv` shows that the diagrams with no horizontal arc are exactly the permutation diagrams, so `card_brauerDiagram_forall_isThrough` gives `k !` of them. An `example` records the roadmap's worked example: `B_2` has the three diagrams `1`, `s` and `e`.

Roadmap target: `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, Layer 9 ("Schur-Weyl duality for the orthogonal and symplectic groups (the Brauer algebra)"), the first build item, "Brauer diagrams and the Brauer algebra": `brauerDiagram k`, "a perfect matching of the `2k` boundary points `Fin k ⊕ Fin k` ... i.e. a fixed-point-free involution"; "There are `(2k-1)!! = Nat.doubleFactorial (2k-1)` of them (`card_brauerDiagram`), of which the `k!` matchings with no horizontal arc ... are the permutation diagrams"; and, from the named diagram API of that item, "the edge-type predicates `isThrough`/`isCap`/`isCup`" and "the permutation-diagram inclusion `permToBrauer`". The remaining named items of that build item — `composeDiagram`, `middleLoopCount`, `compose_assoc` and the algebra `brauerAlgebra δ k` itself — are deliberately left for a follow-up: the loop-weighted composition is a separate piece of combinatorics and does not belong in the same PR as the diagram type.

Placement: the general counting lives in `TauCeti/Combinatorics/Enumerative/PerfectMatching.lean`, beside the existing `Combinatorics/Enumerative/Partition/`, because it is a fact about finite types and not about representation theory; the Brauer-specific material lives in `TauCeti/Combinatorics/Brauer/Diagram.lean`, mirroring how the Schur-Weyl roadmap's tableau combinatorics already sits under `TauCeti/Combinatorics/Young/`. A directory is used rather than a flat `Brauer.lean` because the composition and algebra files will join it.

Mathlib has `Nat.doubleFactorial` and the permutation infrastructure (`Equiv.Perm.subtypePerm`, `Equiv.Perm.ofSubtype`, `Equiv.swap`, `Sum.getLeft`/`Sum.getRight`) that this consumes, but nothing counting fixed-point-free involutions or perfect matchings of a type, and no Brauer diagrams; no Mathlib infrastructure was vendored. No material was migrated from any external source.

Roadmap: SchurWeyl

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"brauerdiagram"}-->

🤖 Prepared with Claude Code

