### PR TITLE
style(Symplectic): pack underfilled signature lines in JHolomorphic/

### DIFF
--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Basic.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Basic.lean
@@ -89,8 +89,7 @@ def IsConstStructureJHolomorphicAt (J : AlmostComplexStructure V) (J' : AlmostCo
 within the
 set exists there and intertwines the source and target almost complex structures. -/
 def IsConstStructureJHolomorphicWithinAt (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (f : V → W) (s : Set V) (x : V) : Prop :=
+    (J' : AlmostComplexStructure W) (f : V → W) (s : Set V) (x : V) : Prop :=
   ∃ f' : V →L[ℝ] W, HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'.toLinearMap
 
 /-- A map is constant-structure `J`-holomorphic on a set if it is constant-structure `J`-holomorphic
@@ -109,8 +108,7 @@ def IsConstStructureJHolomorphic (J : AlmostComplexStructure V) (J' : AlmostComp
 /-- Restate pointwise constant-structure `J`-holomorphicity as existence of a complex-linear Frechet
 derivative. -/
 lemma isConstStructureJHolomorphicAt_iff (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (f : V → W) (x : V) :
+    (J' : AlmostComplexStructure W) (f : V → W) (x : V) :
     IsConstStructureJHolomorphicAt J J' f x ↔
       ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧ IsComplexLinearMap J J' f'.toLinearMap :=
   Iff.rfl
@@ -129,8 +127,7 @@ lemma isConstStructureJHolomorphicWithinAt_iff (J : AlmostComplexStructure V)
 each
 point of the set. -/
 lemma isConstStructureJHolomorphicOn_iff (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (f : V → W) (s : Set V) :
+    (J' : AlmostComplexStructure W) (f : V → W) (s : Set V) :
     IsConstStructureJHolomorphicOn J J' f s ↔
       ∀ x ∈ s, ∃ f' : V →L[ℝ] W,
         HasFDerivWithinAt f f' s x ∧ IsComplexLinearMap J J' f'.toLinearMap :=
@@ -139,8 +136,7 @@ lemma isConstStructureJHolomorphicOn_iff (J : AlmostComplexStructure V)
 /-- Restate global constant-structure `J`-holomorphicity as the pointwise derivative condition at
 every point. -/
 lemma isConstStructureJHolomorphic_iff (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (f : V → W) :
+    (J' : AlmostComplexStructure W) (f : V → W) :
     IsConstStructureJHolomorphic J J' f ↔
       ∀ x, ∃ f' : V →L[ℝ] W, HasFDerivAt f f' x ∧
         IsComplexLinearMap J J' f'.toLinearMap :=
@@ -182,8 +178,7 @@ lemma isConstStructureJHolomorphicOn_of_forall {J : AlmostComplexStructure V}
 
 /-- Extract pointwise constant-structure `J`-holomorphicity from a global one. -/
 lemma IsConstStructureJHolomorphic.isConstStructureJHolomorphicAt {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
+    {J' : AlmostComplexStructure W} {f : V → W} (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
     IsConstStructureJHolomorphicAt J J' f x :=
   (isConstStructureJHolomorphicAt_iff J J' f x).mpr
     ((isConstStructureJHolomorphic_iff J J' f).mp hf x)
@@ -200,8 +195,7 @@ lemma isConstStructureJHolomorphic_of_forall {J : AlmostComplexStructure V}
 constant-structure `J`-holomorphicity. -/
 @[simp]
 lemma isConstStructureJHolomorphicOn_univ (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (f : V → W) :
+    (J' : AlmostComplexStructure W) (f : V → W) :
     IsConstStructureJHolomorphicOn J J' f Set.univ ↔ IsConstStructureJHolomorphic J J' f := by
   simp [IsConstStructureJHolomorphicOn, IsConstStructureJHolomorphicWithinAt,
     IsConstStructureJHolomorphic, IsConstStructureJHolomorphicAt, hasFDerivWithinAt_univ]
@@ -263,8 +257,7 @@ lemma IsConstStructureJHolomorphicAt.fderiv_apply_commute {J : AlmostComplexStru
 /-- A pointwise constant-structure `J`-holomorphic map is constant-structure `J`-holomorphic within
 any set. -/
 lemma IsConstStructureJHolomorphicAt.isConstStructureJHolomorphicWithinAt
-    {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsConstStructureJHolomorphicAt J J' f x) :
     IsConstStructureJHolomorphicWithinAt J J' f s x :=
   ⟨_, hf.hasFDerivAt.hasFDerivWithinAt, hf.derivative_isComplexLinear⟩
@@ -305,8 +298,7 @@ lemma IsConstStructureJHolomorphicWithinAt.continuousWithinAt {J : AlmostComplex
 
 /-- The within-set Frechet derivative is complex-linear when the set has unique derivatives. -/
 lemma IsConstStructureJHolomorphicWithinAt.fderivWithin_isComplexLinear
-    {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsConstStructureJHolomorphicWithinAt J J' f s x) (hs : UniqueDiffWithinAt ℝ s x) :
     IsComplexLinearMap J J' (fderivWithin ℝ f s x).toLinearMap := by
   simpa [hf.hasFDerivWithinAt.fderivWithin hs] using hf.derivative_isComplexLinear
@@ -323,8 +315,7 @@ lemma IsConstStructureJHolomorphicWithinAt.fderivWithin_apply_commute {J : Almos
 `J`-holomorphic when the set is a
 neighborhood of the point. -/
 lemma IsConstStructureJHolomorphicWithinAt.isConstStructureJHolomorphicAt_of_mem_nhds
-    {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsConstStructureJHolomorphicWithinAt J J' f s x) (hs : s ∈ nhds x) :
     IsConstStructureJHolomorphicAt J J' f x :=
   ⟨_, (hasFDerivWithinAt_of_mem_nhds hs).mp hf.hasFDerivWithinAt,
@@ -343,8 +334,7 @@ lemma IsConstStructureJHolomorphicWithinAt.continuousAt_of_mem_nhds {J : AlmostC
 differentiable at the
 point. -/
 lemma IsConstStructureJHolomorphicWithinAt.differentiableAt_of_mem_nhds
-    {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
+    {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W} {f : V → W} {s : Set V} {x : V}
     (hf : IsConstStructureJHolomorphicWithinAt J J' f s x) (hs : s ∈ nhds x) :
     DifferentiableAt ℝ f x :=
   (hf.isConstStructureJHolomorphicAt_of_mem_nhds hs).differentiableAt
@@ -380,8 +370,7 @@ lemma isConstStructureJHolomorphicAt_id' (J : AlmostComplexStructure V) (x : V) 
 
 /-- Chain rule for pointwise constant-structure `J`-holomorphic maps. -/
 lemma IsConstStructureJHolomorphicAt.comp {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
-    {f : V → W} {g : W → X} {x : V}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X} {f : V → W} {g : W → X} {x : V}
     (hg : IsConstStructureJHolomorphicAt J' J'' g (f x))
     (hf : IsConstStructureJHolomorphicAt J J' f x) :
     IsConstStructureJHolomorphicAt J J'' (g ∘ f) x := by
@@ -528,29 +517,25 @@ lemma IsConstStructureJHolomorphic.isConstStructureJHolomorphicOn {J : AlmostCom
 
 /-- A globally constant-structure `J`-holomorphic map is differentiable. -/
 lemma IsConstStructureJHolomorphic.differentiable {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f) :
+    {J' : AlmostComplexStructure W} {f : V → W} (hf : IsConstStructureJHolomorphic J J' f) :
     Differentiable ℝ f :=
   fun x => (hf x).differentiableAt
 
 /-- A globally constant-structure `J`-holomorphic map is differentiable at every point. -/
 lemma IsConstStructureJHolomorphic.differentiableAt {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
+    {J' : AlmostComplexStructure W} {f : V → W} (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
     DifferentiableAt ℝ f x :=
   (hf x).differentiableAt
 
 /-- A globally constant-structure `J`-holomorphic map is continuous. -/
 lemma IsConstStructureJHolomorphic.continuous {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f) :
+    {J' : AlmostComplexStructure W} {f : V → W} (hf : IsConstStructureJHolomorphic J J' f) :
     Continuous f :=
   continuous_iff_continuousAt.mpr fun x => (hf x).continuousAt
 
 /-- A globally constant-structure `J`-holomorphic map is continuous at every point. -/
 lemma IsConstStructureJHolomorphic.continuousAt {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
+    {J' : AlmostComplexStructure W} {f : V → W} (hf : IsConstStructureJHolomorphic J J' f) (x : V) :
     ContinuousAt f x :=
   (hf x).continuousAt
 
@@ -571,8 +556,7 @@ lemma IsConstStructureJHolomorphic.continuousOn {J : AlmostComplexStructure V}
 /-- A constant map is globally constant-structure `J`-holomorphic. -/
 @[simp]
 lemma isConstStructureJHolomorphic_const (J : AlmostComplexStructure V)
-    (J' : AlmostComplexStructure W)
-    (c : W) : IsConstStructureJHolomorphic J J' (fun _ : V => c) :=
+    (J' : AlmostComplexStructure W) (c : W) : IsConstStructureJHolomorphic J J' (fun _ : V => c) :=
   fun x => isConstStructureJHolomorphicAt_const J J' c x
 
 /-- The identity map is globally constant-structure `J`-holomorphic. -/
@@ -589,8 +573,7 @@ lemma isConstStructureJHolomorphic_id' (J : AlmostComplexStructure V) :
 
 /-- Chain rule for global constant-structure `J`-holomorphic maps. -/
 lemma IsConstStructureJHolomorphic.comp {J : AlmostComplexStructure V}
-    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X}
-    {f : V → W} {g : W → X}
+    {J' : AlmostComplexStructure W} {J'' : AlmostComplexStructure X} {f : V → W} {g : W → X}
     (hg : IsConstStructureJHolomorphic J' J'' g) (hf : IsConstStructureJHolomorphic J J' f) :
     IsConstStructureJHolomorphic J J'' (g ∘ f) :=
   fun x => (hg (f x)).comp (hf x)
@@ -743,8 +726,7 @@ lemma IsConstStructureJHolomorphic.sub {f g : V → W}
 
 /-- A real scalar multiple of a globally constant-structure `J`-holomorphic map is
 constant-structure `J`-holomorphic. -/
-lemma IsConstStructureJHolomorphic.const_smul {f : V → W}
-    (hf : IsConstStructureJHolomorphic J J' f)
+lemma IsConstStructureJHolomorphic.const_smul {f : V → W} (hf : IsConstStructureJHolomorphic J J' f)
     (c : ℝ) :
     IsConstStructureJHolomorphic J J' (c • f) :=
   fun x => (hf x).const_smul c

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Congruence.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Congruence.lean
@@ -196,8 +196,7 @@ lemma isConstStructureJHolomorphicOn_congr (hfg : Set.EqOn f g s) :
     fun hg => hg.congr hfg⟩
 
 /-- A globally constant-structure `J`-holomorphic map may be replaced by a pointwise equal map. -/
-lemma IsConstStructureJHolomorphic.congr
-    (hf : IsConstStructureJHolomorphic J J' f)
+lemma IsConstStructureJHolomorphic.congr (hf : IsConstStructureJHolomorphic J J' f)
     (hfg : ∀ x, g x = f x) :
     IsConstStructureJHolomorphic J J' g :=
   isConstStructureJHolomorphic_of_forall fun x =>

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Conj.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Conj.lean
@@ -210,8 +210,7 @@ changes the source structure from the standard one to its negation, provided ref
 reflected source set into the original one. -/
 lemma comp_stdComplexLineConj
     (hf : IsConstStructureJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J f t
-      (stdComplexLineConjCLM x))
-    (hst : Set.MapsTo stdComplexLineConjCLM s t) :
+      (stdComplexLineConjCLM x)) (hst : Set.MapsTo stdComplexLineConjCLM s t) :
     IsConstStructureJHolomorphicWithinAt (-(AlmostComplexStructure.product ℝ)) J
       (fun z => f (stdComplexLineConjCLM z)) s x :=
   hf.comp
@@ -223,8 +222,7 @@ standard structure by standard-line conjugation restores the standard source str
 reflection maps the reflected source set into the original one. -/
 lemma comp_neg_stdComplexLineConj
     (hf : IsConstStructureJHolomorphicWithinAt (-(AlmostComplexStructure.product ℝ)) J f t
-      (stdComplexLineConjCLM x))
-    (hst : Set.MapsTo stdComplexLineConjCLM s t) :
+      (stdComplexLineConjCLM x)) (hst : Set.MapsTo stdComplexLineConjCLM s t) :
     IsConstStructureJHolomorphicWithinAt (AlmostComplexStructure.product ℝ) J
       (fun z => f (stdComplexLineConjCLM z)) s x :=
   hf.comp

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Line.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Line.lean
@@ -147,8 +147,7 @@ variable {ω : SymplecticForm V}
 
 /-- Under tameness, the pointwise symplectic area of a complex-linear image of `(v, J₀ v)` is
 nonnegative. -/
-lemma symplecticForm_apply_apply_nonneg (hF : IsComplexLinearMap J₀ J F₀)
-    (hω : ω.Tames J) (v : U) :
+lemma symplecticForm_apply_apply_nonneg (hF : IsComplexLinearMap J₀ J F₀) (hω : ω.Tames J) (v : U) :
     0 ≤ ω (F₀ v) (F₀ (J₀ v)) := by
   rw [(isComplexLinearMap_iff_apply J₀ J F₀).mp hF v]
   rcases eq_or_ne (F₀ v) 0 with hzero | hne
@@ -167,21 +166,18 @@ variable {F : (ℝ × ℝ) →ₗ[ℝ] V}
 
 /-- A real-linear map out of the standard complex line is complex-linear when it satisfies the
 coordinate Cauchy--Riemann equation `F(0,1) = J(F(1,0))`. -/
-lemma of_apply_stdComplexLineImag
-    (hF : F stdComplexLineImag = J (F stdComplexLineReal)) :
+lemma of_apply_stdComplexLineImag (hF : F stdComplexLineImag = J (F stdComplexLineReal)) :
     IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F :=
   (isComplexLinearMap_stdComplexLine_iff F).mpr hF
 
 /-- For a complex-linear map from the standard complex line, the imaginary coordinate derivative
 is `J` applied to the real coordinate derivative. -/
-lemma apply_stdComplexLineImag
-    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
+lemma apply_stdComplexLineImag (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     F stdComplexLineImag = J (F stdComplexLineReal) :=
   (isComplexLinearMap_stdComplexLine_iff F).mp hF
 
 /-- The real coordinate derivative is `-J` applied to the imaginary coordinate derivative. -/
-lemma apply_stdComplexLineReal
-    (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
+lemma apply_stdComplexLineReal (hF : IsComplexLinearMap (AlmostComplexStructure.product ℝ) J F) :
     F stdComplexLineReal = -J (F stdComplexLineImag) := by
   rw [hF.apply_stdComplexLineImag]
   simp

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Transport.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Transport.lean
@@ -64,8 +64,7 @@ variable {J : AlmostComplexStructure V} {J' : AlmostComplexStructure W}
 equivalences of the
 source and target coordinates. -/
 lemma IsConstStructureJHolomorphicAt.transport {f : V → W} {x : V}
-    (hf : IsConstStructureJHolomorphicAt J J' f x)
-    (eV : V ≃L[ℝ] V') (eW : W ≃L[ℝ] W') :
+    (hf : IsConstStructureJHolomorphicAt J J' f x) (eV : V ≃L[ℝ] V') (eW : W ≃L[ℝ] W') :
     IsConstStructureJHolomorphicAt (J.transport eV.toLinearEquiv) (J'.transport eW.toLinearEquiv)
       (fun y : V' => eW (f (eV.symm y))) (eV x) := by
   have hsource :
@@ -206,8 +205,7 @@ lemma isConstStructureJHolomorphicOn_transport_iff (f : V → W) (s : Set V)
 /-- Global constant-structure `J`-holomorphicity is invariant under continuous real-linear
 coordinate changes. -/
 @[simp]
-lemma isConstStructureJHolomorphic_transport_iff (f : V → W)
-    (eV : V ≃L[ℝ] V') (eW : W ≃L[ℝ] W') :
+lemma isConstStructureJHolomorphic_transport_iff (f : V → W) (eV : V ≃L[ℝ] V') (eW : W ≃L[ℝ] W') :
     IsConstStructureJHolomorphic (J.transport eV.toLinearEquiv) (J'.transport eW.toLinearEquiv)
       (fun y : V' => eW (f (eV.symm y))) ↔ IsConstStructureJHolomorphic J J' f := by
   refine ⟨fun h => isConstStructureJHolomorphic_of_forall fun x => ?_,

--- a/TauCeti/Geometry/Symplectic/JHolomorphic/Varying.lean
+++ b/TauCeti/Geometry/Symplectic/JHolomorphic/Varying.lean
@@ -110,15 +110,13 @@ lemma isJHolomorphicWithinAt_of_hasFDerivWithinAt {J : U → AlmostComplexStruct
 
 /-- The continuous-linear derivative witnessing J-holomorphicity at a point. -/
 lemma IsJHolomorphicAt.hasFDerivAt {J : U → AlmostComplexStructure U}
-    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U}
-    (hf : IsJHolomorphicAt J J' f x) :
+    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U} (hf : IsJHolomorphicAt J J' f x) :
     HasFDerivAt f (Classical.choose ((isJHolomorphicAt_iff J J' f x).mp hf)) x :=
   IsConstStructureJHolomorphicAt.hasFDerivAt hf
 
 /-- The chosen derivative at a J-holomorphic point is complex-linear. -/
 lemma IsJHolomorphicAt.derivative_isComplexLinear {J : U → AlmostComplexStructure U}
-    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U}
-    (hf : IsJHolomorphicAt J J' f x) :
+    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U} (hf : IsJHolomorphicAt J J' f x) :
     IsComplexLinearMap (J x) (J' (f x))
       (Classical.choose ((isJHolomorphicAt_iff J J' f x).mp hf)).toLinearMap :=
   IsConstStructureJHolomorphicAt.derivative_isComplexLinear hf
@@ -157,15 +155,13 @@ lemma IsJHolomorphicWithinAt.continuousWithinAt {J : U → AlmostComplexStructur
 
 /-- The Fréchet derivative of a J-holomorphic map is complex-linear. -/
 lemma IsJHolomorphicAt.fderiv_isComplexLinear {J : U → AlmostComplexStructure U}
-    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U}
-    (hf : IsJHolomorphicAt J J' f x) :
+    {J' : V → AlmostComplexStructure V} {f : U → V} {x : U} (hf : IsJHolomorphicAt J J' f x) :
     IsComplexLinearMap (J x) (J' (f x)) (fderiv ℝ f x).toLinearMap :=
   IsConstStructureJHolomorphicAt.fderiv_isComplexLinear hf
 
 /-- The Fréchet derivative of a J-holomorphic map commutes with the structures. -/
 lemma IsJHolomorphicAt.fderiv_apply_commute {J : U → AlmostComplexStructure U}
-    {J' : V → AlmostComplexStructure V} {f : U → V} {x v : U}
-    (hf : IsJHolomorphicAt J J' f x) :
+    {J' : V → AlmostComplexStructure V} {f : U → V} {x v : U} (hf : IsJHolomorphicAt J J' f x) :
     fderiv ℝ f x (J x v) = J' (f x) (fderiv ℝ f x v) :=
   IsConstStructureJHolomorphicAt.fderiv_apply_commute hf
 
@@ -214,8 +210,7 @@ lemma IsJHolomorphicOn.isJHolomorphicWithinAt {J : U → AlmostComplexStructure 
   hf x hx
 
 /-- Restrict the domain set of a setwise J-holomorphic map. -/
-lemma IsJHolomorphicOn.mono
-    {J : U → AlmostComplexStructure U} {J' : V → AlmostComplexStructure V}
+lemma IsJHolomorphicOn.mono {J : U → AlmostComplexStructure U} {J' : V → AlmostComplexStructure V}
     {f : U → V} {s t : Set U} (hf : IsJHolomorphicOn J J' f t) (hst : s ⊆ t) :
     IsJHolomorphicOn J J' f s :=
   fun x hx ↦
@@ -249,8 +244,7 @@ lemma IsJHolomorphic.differentiable {J : U → AlmostComplexStructure U}
 
 /-- A globally J-holomorphic map is continuous. -/
 lemma IsJHolomorphic.continuous {J : U → AlmostComplexStructure U}
-    {J' : V → AlmostComplexStructure V} {f : U → V}
-    (hf : IsJHolomorphic J J' f) : Continuous f :=
+    {J' : V → AlmostComplexStructure V} {f : U → V} (hf : IsJHolomorphic J J' f) : Continuous f :=
   hf.differentiable.continuous
 
 /-- J-holomorphicity on the whole space is equivalent to global J-holomorphicity. -/


### PR DESCRIPTION
Same defect class as #1688, #1693, #1695, #1699, #1700 and #1702 — all merged at one review round
each. Signature lines split below the 100-column limit, which Lean's pretty-printer at
`format.width := 100` would not emit that way.

Thirty-three joins across six files, `-33` lines:

| file | joins |
|---|---|
| `Basic.lean` | 18 |
| `Varying.lean` | 6 |
| `Line.lean` | 4 |
| `Conj.lean` | 2 |
| `Transport.lean` | 2 |
| `Congruence.lean` | 1 |

**`Energy.lean` is deliberately excluded.** PR #1358 is developing `JHolomorphic/Energy/`; although
that is a different path, staying out of that neighbourhood avoids creating churn against work in
progress.

Each join was checked arithmetically before applying — `current + 1 + next-token ≤ 100` — and
verified in **codepoints, not bytes**, since these files carry `ℝ ω J ∇ ⟪⟫` at three bytes each and a
byte-based check reports phantom violations. All six files have zero lines over 100 codepoints
before and after.

No statements, proofs or docstrings changed.

Roadmap: none