### PR TITLE
style(WeilDivisor): pack underfilled signature lines

### DIFF
--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Basic.lean
@@ -59,8 +59,7 @@ noncomputable def weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDe
 degree-corrected point divisor. This is the canonical simp form for the subtype coercion. -/
 @[simp]
 lemma coe_weightedAbelJacobiClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
-    (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) =
+    {x₀ : X} (hx₀ : w x₀ = 1) (x : X) : (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) =
       S.divisorClass (weightedPointBaseDifference w x₀ x) :=
   rfl
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/DegreeSplitting.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/DegreeSplitting.lean
@@ -92,8 +92,7 @@ lemma classGroupAddEquivPicZeroProdInt_divisorClass_weightedPointBaseDifference
 component and its degree `w x`. -/
 lemma classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiClass (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (x : X) :
-    (S.classGroupAddEquivPicZeroProdInt w h hx₀).symm
-        (S.weightedAbelJacobiClass w h hx₀ x, w x) =
+    (S.classGroupAddEquivPicZeroProdInt w h hx₀).symm (S.weightedAbelJacobiClass w h hx₀ x, w x) =
       S.divisorClass (ofPoint x) := by
   rw [← S.classGroupAddEquivPicZeroProdInt_divisorClass_ofPoint w h hx₀ x]
   simp

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FiniteSum.lean
@@ -62,8 +62,7 @@ lemma weightedAbelJacobiDivisorClass_ofFinsupp (w : X → ℤ) (h : S.IsWeighted
 of the point Abel-Jacobi classes with those multiplicities. -/
 @[simp]
 lemma weightedAbelJacobiDivisorClass_ofFinsetWithMultiplicity (w : X → ℤ)
-    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X)
-    (m : X → ℕ) :
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (s : Finset X) (m : X → ℕ) :
     S.weightedAbelJacobiDivisorClass w h hx₀ (ofFinsetWithMultiplicity s m) =
       ∑ x ∈ s, (m x : ℤ) • S.weightedAbelJacobiClass w h hx₀ x := by
   rw [ofFinsetWithMultiplicity_eq_sum, map_sum]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/FixedDegree.lean
@@ -53,8 +53,7 @@ noncomputable section
 /-- Changing only the degree index of a fixed-degree divisor does not change its weighted
 Abel-Jacobi class. -/
 lemma weightedAbelJacobiDivisorClass_cast (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
-    {x₀ : X} (hx₀ : w x₀ = 1) {d e : ℕ} (hde : d = e)
-    (D : EffectiveDivisorOfDegree X d) :
+    {x₀ : X} (hx₀ : w x₀ = 1) {d e : ℕ} (hde : d = e) (D : EffectiveDivisorOfDegree X d) :
     S.weightedAbelJacobiDivisorClass w h hx₀
         (WeilDivisor.EffectiveDivisorOfDegree.cast hde D : WeilDivisor X) =
       S.weightedAbelJacobiDivisorClass w h hx₀ (D : WeilDivisor X) := by
@@ -63,8 +62,7 @@ lemma weightedAbelJacobiDivisorClass_cast (w : X → ℤ) (h : S.IsWeightedDegre
 
 /-- The weighted Abel-Jacobi class of the zero effective divisor is zero. -/
 lemma weightedAbelJacobiDivisorClass_effectiveDivisorOfDegree_zero (w : X → ℤ)
-    (h : S.IsWeightedDegreeZero w)
-    {x₀ : X} (hx₀ : w x₀ = 1) :
+    (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) :
     S.weightedAbelJacobiDivisorClass w h hx₀ (EffectiveDivisorOfDegree.zero X) = 0 := by
   simp
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/LinearSystem.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/LinearSystem.lean
@@ -51,8 +51,7 @@ variable {d : ℕ}
 /-- For effective divisors of the same fixed degree, equality of normalized Abel-Jacobi
 classes is exactly linear equivalence of the underlying divisors. -/
 lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_linearlyEquivalent
-    (h : S.IsUnweightedDegreeZero) (x₀ : X)
-    (D E : EffectiveDivisorOfDegree X d) :
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (D E : EffectiveDivisorOfDegree X d) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
         (D : WeilDivisor X) =
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
@@ -65,8 +64,7 @@ lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_linearl
 /-- The fixed-degree Abel-Jacobi fiber through `D` is the complete linear system `|D|`, restricted
 to effective divisors of the same degree. -/
 lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_mem_completeLinearSystem
-    (h : S.IsUnweightedDegreeZero) (x₀ : X)
-    (D E : EffectiveDivisorOfDegree X d) :
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (D E : EffectiveDivisorOfDegree X d) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
         (E : WeilDivisor X) =
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
@@ -82,8 +80,7 @@ lemma weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq_iff_mem_com
 /-- As a set of fixed-degree effective divisors, the Abel-Jacobi fiber through `D` is the
 restriction of the complete linear system `|D|`. -/
 lemma setOf_weightedAbelJacobiDivisorClass_one_effectiveDivisorOfDegree_eq
-    (h : S.IsUnweightedDegreeZero) (x₀ : X)
-    (D : EffectiveDivisorOfDegree X d) :
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (D : EffectiveDivisorOfDegree X d) :
     {E : EffectiveDivisorOfDegree X d |
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
           (E : WeilDivisor X) =
@@ -114,8 +111,7 @@ lemma weightedAbelJacobiDivisorClass_one_ofSym_eq_iff_mem_completeLinearSystem
 /-- As a set of symmetric-power points, the Abel-Jacobi fiber through `s` is the preimage of the
 complete linear system `|ofSym s|`. -/
 lemma setOf_weightedAbelJacobiDivisorClass_one_ofSym_eq
-    (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Sym X d) :
-    {t : Sym X d |
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) (s : Sym X d) : {t : Sym X d |
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl
           (EffectiveDivisorOfDegree.ofSym t : WeilDivisor X) =
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Quotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Quotient.lean
@@ -76,8 +76,7 @@ private lemma weightedAbelJacobiQuotientClass_mk_def (w : X → ℤ) {x₀ : X} 
   rfl
 
 @[simp]
-lemma weightedAbelJacobiQuotientClass_mk (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
-    (D : WeilDivisor X) :
+lemma weightedAbelJacobiQuotientClass_mk (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1) (D : WeilDivisor X) :
     S.weightedAbelJacobiQuotientClass w hx₀ D =
       QuotientAddGroup.mk (weightedAbelJacobiDegreeZeroDivisor w hx₀ D) :=
   S.weightedAbelJacobiQuotientClass_mk_def w hx₀ D
@@ -102,8 +101,7 @@ lemma weightedAbelJacobiQuotientClass_zsmul (w : X → ℤ) {x₀ : X} (hx₀ : 
 /-- The quotient representative maps to the weighted Abel-Jacobi divisor class under the
 degree-zero quotient equivalence. -/
 lemma weightedDegreeZeroQuotientEquivPicZero_weightedAbelJacobiQuotientClass
-    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
-    (D : WeilDivisor X) :
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (D : WeilDivisor X) :
     S.weightedDegreeZeroQuotientEquivPicZero w h
         (S.weightedAbelJacobiQuotientClass w hx₀ D) =
       S.weightedAbelJacobiDivisorClass w h hx₀ D := by
@@ -163,8 +161,7 @@ lemma weightedAbelJacobiQuotientClass_principalDivisor (w : X → ℤ)
 
 /-- Equality of weighted quotient Abel-Jacobi representatives is equality of the corresponding
 degree-corrected divisor classes. -/
-lemma weightedAbelJacobiQuotientClass_eq_iff_divisorClass
-    (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
+lemma weightedAbelJacobiQuotientClass_eq_iff_divisorClass (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
     {D E : WeilDivisor X} :
     S.weightedAbelJacobiQuotientClass w hx₀ D =
         S.weightedAbelJacobiQuotientClass w hx₀ E ↔
@@ -178,8 +175,7 @@ lemma weightedAbelJacobiQuotientClass_eq_iff_divisorClass
 /-- Equality of weighted quotient Abel-Jacobi representatives is linear equivalence of the
 corresponding degree-corrected divisors. -/
 lemma weightedAbelJacobiQuotientClass_eq_iff_linearlyEquivalent
-    (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1)
-    {D E : WeilDivisor X} :
+    (w : X → ℤ) {x₀ : X} (hx₀ : w x₀ = 1) {D E : WeilDivisor X} :
     S.weightedAbelJacobiQuotientClass w hx₀ D =
         S.weightedAbelJacobiQuotientClass w hx₀ E ↔
       S.LinearlyEquivalent (D - weightedDegree w D • ofPoint x₀)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/BasepointChange.lean
@@ -71,8 +71,7 @@ lemma weightedAbelJacobiDivisorClass_change_base (w : X → ℤ)
 base points is the weighted degree times the class `[x₀] - [y₀]`. -/
 lemma weightedAbelJacobiDivisorClass_sub_change_base_coe (w : X → ℤ)
     (h : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1)
-    (D : WeilDivisor X) :
-    (S.weightedAbelJacobiDivisorClass w h hy₀ D : S.ClassGroup) -
+    (D : WeilDivisor X) : (S.weightedAbelJacobiDivisorClass w h hy₀ D : S.ClassGroup) -
         (S.weightedAbelJacobiDivisorClass w h hx₀ D : S.ClassGroup) =
       weightedDegree w D • S.divisorClass (pointDifference x₀ y₀) := by
   have hchange := S.degreeCorrection_change_base w h x₀ y₀ (S.divisorClass D)

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/AbelJacobi/Sum/Basic.lean
@@ -130,8 +130,7 @@ lemma weightedAbelJacobiDivisorClass_eq_sum (w : X → ℤ) (h : S.IsWeightedDeg
 /-- Equality of weighted Abel-Jacobi sums is equality of the corresponding degree-corrected
 divisor classes. -/
 lemma weightedAbelJacobiDivisorClass_eq_iff_divisorClass
-    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
-    {D E : WeilDivisor X} :
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) {D E : WeilDivisor X} :
     S.weightedAbelJacobiDivisorClass w h hx₀ D =
         S.weightedAbelJacobiDivisorClass w h hx₀ E ↔
       S.divisorClass (D - weightedDegree w D • ofPoint x₀) =
@@ -149,8 +148,7 @@ lemma weightedAbelJacobiDivisorClass_eq_iff_divisorClass
 /-- Equality of weighted Abel-Jacobi sums is linear equivalence of the corresponding
 degree-corrected divisors. -/
 lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent
-    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
-    {D E : WeilDivisor X} :
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) {D E : WeilDivisor X} :
     S.weightedAbelJacobiDivisorClass w h hx₀ D =
         S.weightedAbelJacobiDivisorClass w h hx₀ E ↔
       S.LinearlyEquivalent (D - weightedDegree w D • ofPoint x₀)
@@ -182,8 +180,7 @@ lemma weightedAbelJacobiDivisorClass_eq_iff_linearlyEquivalent_of_weightedDegree
 /-- In the unweighted theory, equal-degree divisors have the same Abel-Jacobi class exactly when
 they are linearly equivalent. -/
 lemma weightedAbelJacobiDivisorClass_one_eq_iff_linearlyEquivalent_of_degree_eq
-    (h : S.IsUnweightedDegreeZero) (x₀ : X) {D E : WeilDivisor X}
-    (hDE : degree D = degree E) :
+    (h : S.IsUnweightedDegreeZero) (x₀ : X) {D E : WeilDivisor X} (hDE : degree D = degree E) :
     S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl D =
         S.weightedAbelJacobiDivisorClass (fun _ : X => (1 : ℤ)) h (x₀ := x₀) rfl E ↔
       S.LinearlyEquivalent D E := by
@@ -225,8 +222,7 @@ lemma classGroupAddEquivPicZeroProdInt_divisorClass (w : X → ℤ)
 /-- The inverse splitting reconstructs the divisor class from its weighted Abel-Jacobi sum and
 weighted degree. -/
 lemma classGroupAddEquivPicZeroProdInt_symm_weightedAbelJacobiDivisorClass
-    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1)
-    (D : WeilDivisor X) :
+    (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {x₀ : X} (hx₀ : w x₀ = 1) (D : WeilDivisor X) :
     (S.classGroupAddEquivPicZeroProdInt w h hx₀).symm
         (S.weightedAbelJacobiDivisorClass w h hx₀ D, weightedDegree w D) =
       S.divisorClass D := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/BasepointChange.lean
@@ -59,14 +59,12 @@ noncomputable def weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeigh
 
 @[simp]
 lemma coe_weightedBasepointChangeClass (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ y₀ : X} (hxy : w x₀ = w y₀) :
-    (S.weightedBasepointChangeClass w hdeg hxy : S.ClassGroup) =
+    {x₀ y₀ : X} (hxy : w x₀ = w y₀) : (S.weightedBasepointChangeClass w hdeg hxy : S.ClassGroup) =
       S.divisorClass (pointDifference x₀ y₀) :=
   rfl
 
 @[simp]
-lemma weightedBasepointChangeClass_self (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w)
-    {x₀ : X} :
+lemma weightedBasepointChangeClass_self (w : X → ℤ) (hdeg : S.IsWeightedDegreeZero w) {x₀ : X} :
     S.weightedBasepointChangeClass w hdeg (x₀ := x₀) rfl = 0 := by
   apply Subtype.ext
   simp
@@ -123,8 +121,7 @@ lemma weightedBasepointChangeClass_eq_abelJacobiClass (w : X → ℤ)
 /-- In the class group, the difference between two weighted Abel-Jacobi classes with different
 base points is `w(x)` times the class `[x₀] - [y₀]`. -/
 lemma weightedAbelJacobiClass_sub_change_base_coe (w : X → ℤ)
-    (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1)
-    (x : X) :
+    (hdeg : S.IsWeightedDegreeZero w) {x₀ y₀ : X} (hx₀ : w x₀ = 1) (hy₀ : w y₀ = 1) (x : X) :
     (S.weightedAbelJacobiClass w hdeg hy₀ x : S.ClassGroup) -
         (S.weightedAbelJacobiClass w hdeg hx₀ x : S.ClassGroup) =
       w x • S.divisorClass (pointDifference x₀ y₀) := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Basic.lean
@@ -701,8 +701,7 @@ lemma pushforwardWeightedDegreeZero_id (w : X → ℤ) :
   simp
 
 lemma pushforwardWeightedDegreeZero_comp (wX : X → ℤ) (wY : Y → ℤ) (wZ : Z → ℤ)
-    (f : X → Y) (g : Y → Z) (hf : ∀ x, wY (f x) = wX x)
-    (hg : ∀ y, wZ (g y) = wY y) :
+    (f : X → Y) (g : Y → Z) (hf : ∀ x, wY (f x) = wX x) (hg : ∀ y, wZ (g y) = wY y) :
     pushforwardWeightedDegreeZero wX wZ (g ∘ f) (fun x => by simp [hg (f x), hf x]) =
       (pushforwardWeightedDegreeZero wY wZ g hg).comp
         (pushforwardWeightedDegreeZero wX wY f hf) := by

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Common.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Common.lean
@@ -58,8 +58,7 @@ lemma coe_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X
   Classical.choose_spec (exists_inf D E)
 
 /-- The coefficient of the common part is the minimum of the two coefficients. -/
-lemma coeff_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e)
-    (x : X) :
+lemma coeff_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) (x : X) :
     coeff (inf D E : WeilDivisor X) x =
       coeff (D : WeilDivisor X) x ⊓ coeff (E : WeilDivisor X) x := by
   rw [coe_inf, WeilDivisor.coeff_inf]
@@ -93,15 +92,13 @@ lemma equivSym_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDeg
   simp
 
 /-- The common part lies below the left input divisor. -/
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (inf D E : WeilDivisor X) ≤ D := by
   rw [coe_inf]
   exact _root_.inf_le_left
 
 /-- The common part lies below the right input divisor. -/
-lemma inf_le_right (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_right (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (inf D E : WeilDivisor X) ≤ E := by
   rw [coe_inf]
   exact _root_.inf_le_right
@@ -114,29 +111,25 @@ lemma le_inf {F : WeilDivisor X} {D : EffectiveDivisorOfDegree X d}
   exact _root_.le_inf hFD hFE
 
 /-- The common part is the left input exactly when the left input is below the right input. -/
-lemma inf_eq_left {D : EffectiveDivisorOfDegree X d}
-    {E : EffectiveDivisorOfDegree X e} :
+lemma inf_eq_left {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e} :
     (inf D E : WeilDivisor X) = D ↔ (D : WeilDivisor X) ≤ E := by
   rw [coe_inf]
   exact _root_.inf_eq_left
 
 /-- The common part is the right input exactly when the right input is below the left input. -/
-lemma inf_eq_right {D : EffectiveDivisorOfDegree X d}
-    {E : EffectiveDivisorOfDegree X e} :
+lemma inf_eq_right {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e} :
     (inf D E : WeilDivisor X) = E ↔ (E : WeilDivisor X) ≤ D := by
   rw [coe_inf]
   exact _root_.inf_eq_right
 
 /-- The degree of the common part is bounded by the left degree index. -/
-lemma degree_inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma degree_inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (degree ((D : WeilDivisor X) ⊓ E)).toNat ≤ d :=
   by
     simpa [coe_inf] using degree_le_of_le (inf_le_left D E)
 
 /-- The degree of the common part is bounded by the right degree index. -/
-lemma degree_inf_le_right (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma degree_inf_le_right (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (degree ((D : WeilDivisor X) ⊓ E)).toNat ≤ e :=
   by
     simpa [coe_inf] using degree_le_of_le (inf_le_right D E)
@@ -184,24 +177,21 @@ lemma coeff_rightResidual (D : EffectiveDivisorOfDegree X d)
 /-- The multiplicity function of the left residual is the truncated multiplicity difference. -/
 @[simp]
 lemma multiplicityFinsupp_leftResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
-    (leftResidual D E).multiplicityFinsupp =
+    (E : EffectiveDivisorOfDegree X e) : (leftResidual D E).multiplicityFinsupp =
       D.multiplicityFinsupp - (inf D E).multiplicityFinsupp :=
   multiplicityFinsupp_subOfLe D (inf D E) (inf_le_left D E)
 
 /-- The multiplicity function of the right residual is the truncated multiplicity difference. -/
 @[simp]
 lemma multiplicityFinsupp_rightResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
-    (rightResidual D E).multiplicityFinsupp =
+    (E : EffectiveDivisorOfDegree X e) : (rightResidual D E).multiplicityFinsupp =
       E.multiplicityFinsupp - (inf D E).multiplicityFinsupp :=
   multiplicityFinsupp_subOfLe E (inf D E) (inf_le_right D E)
 
 /-- The symmetric-power representative of the left residual is the truncated multiplicity
 difference from the left divisor. -/
 @[simp]
-lemma equivSym_leftResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma equivSym_leftResidual (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     equivSym (leftResidual D E) =
       (letI := Classical.decEq X;
         (Sym.equivNatSum X (d - (degree ((D : WeilDivisor X) ⊓ E)).toNat)).symm
@@ -213,8 +203,7 @@ lemma equivSym_leftResidual (D : EffectiveDivisorOfDegree X d)
 /-- The symmetric-power representative of the right residual is the truncated multiplicity
 difference from the right divisor. -/
 @[simp]
-lemma equivSym_rightResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma equivSym_rightResidual (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     equivSym (rightResidual D E) =
       (letI := Classical.decEq X;
         (Sym.equivNatSum X (e - (degree ((D : WeilDivisor X) ⊓ E)).toNat)).symm
@@ -234,8 +223,7 @@ lemma leftResidual_inf_rightResidual_eq_zero (D : EffectiveDivisorOfDegree X d)
 /-- Removing the common part from the left divisor and adding it back recovers the left
 divisor, up to the natural degree-index cast. -/
 @[simp]
-lemma leftResidual_add_inf (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma leftResidual_add_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     add (leftResidual D E) (inf D E) =
       EffectiveDivisorOfDegree.cast
         (Nat.sub_add_cancel (degree_inf_le_left D E)).symm D :=
@@ -244,8 +232,7 @@ lemma leftResidual_add_inf (D : EffectiveDivisorOfDegree X d)
 /-- Adding the common part before the left residual also recovers the left divisor, up to the
 natural degree-index cast. -/
 @[simp]
-lemma inf_add_leftResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_add_leftResidual (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     add (inf D E) (leftResidual D E) =
       EffectiveDivisorOfDegree.cast
         (Nat.add_sub_of_le (degree_inf_le_left D E)).symm D :=
@@ -254,8 +241,7 @@ lemma inf_add_leftResidual (D : EffectiveDivisorOfDegree X d)
 /-- Removing the common part from the right divisor and adding it back recovers the right
 divisor, up to the natural degree-index cast. -/
 @[simp]
-lemma rightResidual_add_inf (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma rightResidual_add_inf (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     add (rightResidual D E) (inf D E) =
       EffectiveDivisorOfDegree.cast
         (Nat.sub_add_cancel (degree_inf_le_right D E)).symm E :=
@@ -264,8 +250,7 @@ lemma rightResidual_add_inf (D : EffectiveDivisorOfDegree X d)
 /-- Adding the common part before the right residual also recovers the right divisor, up to the
 natural degree-index cast. -/
 @[simp]
-lemma inf_add_rightResidual (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_add_rightResidual (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     add (inf D E) (rightResidual D E) =
       EffectiveDivisorOfDegree.cast
         (Nat.add_sub_of_le (degree_inf_le_right D E)).symm E :=

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Dedekind/Basic.lean
@@ -263,8 +263,7 @@ lemma coeff_principalDivisor_eq_neg_log_valuation (u : Additive Kˣ) (v : Height
 
 /-- The coefficient of a Dedekind-domain principal divisor agrees with Mathlib's exponent of the
 corresponding principal fractional ideal. -/
-lemma coeff_principalDivisor_eq_fractionalIdeal_count (u : Additive Kˣ)
-    (v : HeightOneSpectrum R) :
+lemma coeff_principalDivisor_eq_fractionalIdeal_count (u : Additive Kˣ) (v : HeightOneSpectrum R) :
     coeff ((OrderSystem.ofDedekindDomain R K).principalDivisor u) v =
       FractionalIdeal.count K v
         (toPrincipalIdeal R K (Additive.toMul u) : FractionalIdeal R⁰ K) := by
@@ -287,8 +286,7 @@ variable {R K}
 
 /-- A coefficient of a principal divisor is positive exactly when the corresponding valuation is
 strictly less than one. -/
-lemma coeff_principalDivisor_pos_iff_valuation_lt_one (u : Additive Kˣ)
-    (v : HeightOneSpectrum R) :
+lemma coeff_principalDivisor_pos_iff_valuation_lt_one (u : Additive Kˣ) (v : HeightOneSpectrum R) :
     0 < coeff ((OrderSystem.ofDedekindDomain R K).principalDivisor u) v ↔
       v.valuation K ((Additive.toMul u : Kˣ) : K) < 1 := by
   have hu : v.valuation K ((Additive.toMul u : Kˣ) : K) ≠ 0 :=
@@ -300,8 +298,7 @@ lemma coeff_principalDivisor_pos_iff_valuation_lt_one (u : Additive Kˣ)
 no poles, only zeros. The element is presented as any unit `u : Kˣ` whose value is
 `algebraMap R K r`. This is the divisor-of-functions sanity check that rules out a vacuous
 order system. -/
-lemma isEffective_principalDivisor_of_integral {r : R} {u : Kˣ}
-    (hu : (u : K) = algebraMap R K r) :
+lemma isEffective_principalDivisor_of_integral {r : R} {u : Kˣ} (hu : (u : K) = algebraMap R K r) :
     IsEffective ((OrderSystem.ofDedekindDomain R K).principalDivisor (Additive.ofMul u)) := by
   rw [isEffective_iff]
   intro v

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FiniteSum.lean
@@ -68,8 +68,7 @@ lemma isEffective_ofFinsupp (m : X →₀ ℕ) : IsEffective (ofFinsupp m : Weil
 /-- The support of a divisor from finitely supported natural multiplicities is the support of
 those multiplicities. -/
 @[simp]
-lemma support_ofFinsupp (m : X →₀ ℕ) :
-    (ofFinsupp m : WeilDivisor X).support = m.support :=
+lemma support_ofFinsupp (m : X →₀ ℕ) : (ofFinsupp m : WeilDivisor X).support = m.support :=
   Finsupp.support_mapRange_of_injective (by simp) m Nat.cast_injective
 
 /-- A divisor from finitely supported multiplicities is the corresponding sum of point divisors
@@ -313,8 +312,7 @@ lemma ofFinset_mem_effectiveSubmonoid (s : Finset X) :
 /-- The support of the named coefficient-one finite-set divisor is exactly the chosen finite
 set. -/
 @[simp]
-lemma support_ofFinset (s : Finset X) :
-    (ofFinset s : WeilDivisor X).support = s := by
+lemma support_ofFinset (s : Finset X) : (ofFinset s : WeilDivisor X).support = s := by
   ext x
   simp only [ofFinset, mem_support_ofFinsetWithMultiplicity_iff]
   simp

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Addition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Addition.lean
@@ -85,8 +85,7 @@ lemma add_assoc {n : ℕ} (D : EffectiveDivisorOfDegree X d)
 /-- Adding divisors built from finitely supported multiplicities corresponds to adding their
 multiplicity functions. -/
 @[simp]
-lemma add_ofFinsupp (m n : X →₀ ℕ) (hm : m.sum (fun _ k => k) = d)
-    (hn : n.sum (fun _ k => k) = e) :
+lemma add_ofFinsupp (m n : X →₀ ℕ) (hm : m.sum (fun _ k => k) = d) (hn : n.sum (fun _ k => k) = e) :
     add (ofFinsupp m hm) (ofFinsupp n hn) =
       ofFinsupp (m + n) (by
         rw [Finsupp.sum_add_index']

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Basic.lean
@@ -185,8 +185,7 @@ def ofSym (s : Sym X d) : EffectiveDivisorOfDegree X d :=
   equivFinsupp.symm (Sym.equivNatSum X d s)
 
 @[simp]
-lemma coe_ofSym (s : Sym X d) :
-    (ofSym s : WeilDivisor X) =
+lemma coe_ofSym (s : Sym X d) : (ofSym s : WeilDivisor X) =
       WeilDivisor.ofFinsupp (letI := Classical.decEq X; (Sym.equivNatSum X d s).1) := by
   classical
   rfl

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Subtraction.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FixedDegree/Subtraction.lean
@@ -52,8 +52,7 @@ def subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d
 underlying Weil divisors. -/
 @[simp]
 lemma coe_subOfLe (D : EffectiveDivisorOfDegree X e) (E : EffectiveDivisorOfDegree X d)
-    (hED : (E : WeilDivisor X) ≤ D) :
-    (subOfLe D E hED : WeilDivisor X) = (D : WeilDivisor X) - E :=
+    (hED : (E : WeilDivisor X) ≤ D) : (subOfLe D E hED : WeilDivisor X) = (D : WeilDivisor X) - E :=
   rfl
 
 /-- The coefficient of a residual fixed-degree divisor is the difference of coefficients. -/

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Effectivity.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/FractionalIdealDivisor/Effectivity.lean
@@ -51,8 +51,7 @@ def integralFractionalIdealSubmonoid :
 /-- Membership in `integralFractionalIdealSubmonoid` means that the fractional ideal is contained
 in the base ring. -/
 @[simp]
-lemma mem_integralFractionalIdealSubmonoid
-    (I : Additive (FractionalIdeal R⁰ K)ˣ) :
+lemma mem_integralFractionalIdealSubmonoid (I : Additive (FractionalIdeal R⁰ K)ˣ) :
     I ∈ integralFractionalIdealSubmonoid R K ↔
       Units.val (Additive.toMul I) ≤ 1 :=
   Iff.rfl
@@ -79,8 +78,7 @@ lemma isEffective_fractionalIdealDivisor_of_le_one (I : Additive (FractionalIdea
 
 /-- If the divisor of an invertible fractional ideal is effective, then the fractional ideal is
 integral. This is the converse of `isEffective_fractionalIdealDivisor_of_le_one`. -/
-lemma le_one_of_isEffective_fractionalIdealDivisor
-    (I : Additive (FractionalIdeal R⁰ K)ˣ)
+lemma le_one_of_isEffective_fractionalIdealDivisor (I : Additive (FractionalIdeal R⁰ K)ˣ)
     (hI : IsEffective (fractionalIdealDivisor R K I)) :
     Units.val (Additive.toMul I) ≤ 1 := by
   have hcount :
@@ -98,8 +96,7 @@ lemma le_one_of_isEffective_fractionalIdealDivisor
 /-- An invertible fractional ideal is integral exactly when its associated Weil divisor is
 effective. -/
 @[simp]
-lemma isEffective_fractionalIdealDivisor_iff
-    (I : Additive (FractionalIdeal R⁰ K)ˣ) :
+lemma isEffective_fractionalIdealDivisor_iff (I : Additive (FractionalIdeal R⁰ K)ˣ) :
     IsEffective (fractionalIdealDivisor R K I) ↔
       Units.val (Additive.toMul I) ≤ 1 :=
   ⟨le_one_of_isEffective_fractionalIdealDivisor I,
@@ -107,8 +104,7 @@ lemma isEffective_fractionalIdealDivisor_iff
 
 /-- The divisor of an invertible fractional ideal is effective exactly when that ideal belongs to
 the integral fractional-ideal submonoid. -/
-lemma isEffective_fractionalIdealDivisor_iff_mem
-    (I : Additive (FractionalIdeal R⁰ K)ˣ) :
+lemma isEffective_fractionalIdealDivisor_iff_mem (I : Additive (FractionalIdeal R⁰ K)ˣ) :
     IsEffective (fractionalIdealDivisor R K I) ↔
       I ∈ integralFractionalIdealSubmonoid R K := by
   rw [mem_integralFractionalIdealSubmonoid, isEffective_fractionalIdealDivisor_iff]
@@ -143,8 +139,7 @@ noncomputable def integralFractionalIdealDivisorAddEquiv :
 /-- The restricted equivalence agrees with `fractionalIdealDivisor` after forgetting
 effectivity. -/
 @[simp]
-lemma coe_integralFractionalIdealDivisorAddEquiv
-    (I : integralFractionalIdealSubmonoid R K) :
+lemma coe_integralFractionalIdealDivisorAddEquiv (I : integralFractionalIdealSubmonoid R K) :
     ((integralFractionalIdealDivisorAddEquiv R K I :
         effectiveSubmonoid (HeightOneSpectrum R)) :
       WeilDivisor (HeightOneSpectrum R)) =

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Addition.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Addition.lean
@@ -66,8 +66,7 @@ lemma add_mem_completeLinearSystem_right {D D' E E' : WeilDivisor X}
 /-- If two complete linear systems are nonempty, then the complete linear system of the sum of
 their divisor classes is nonempty. -/
 lemma nonempty_completeLinearSystem_add {D D' : WeilDivisor X}
-    (hD : (S.completeLinearSystem D).Nonempty)
-    (hD' : (S.completeLinearSystem D').Nonempty) :
+    (hD : (S.completeLinearSystem D).Nonempty) (hD' : (S.completeLinearSystem D').Nonempty) :
     (S.completeLinearSystem (D + D')).Nonempty := by
   rcases hD with ⟨E, hE⟩
   rcases hD' with ⟨E', hE'⟩
@@ -87,8 +86,7 @@ lemma mapsTo_add_effective_completeLinearSystem {D A : WeilDivisor X} (hA : IsEf
 /-- Adding an effective divisor to the indexing divisor preserves nonemptiness of complete
 linear systems. -/
 lemma nonempty_completeLinearSystem_add_effective {D A : WeilDivisor X} (hA : IsEffective A)
-    (hD : (S.completeLinearSystem D).Nonempty) :
-    (S.completeLinearSystem (D + A)).Nonempty := by
+    (hD : (S.completeLinearSystem D).Nonempty) : (S.completeLinearSystem (D + A)).Nonempty := by
   rcases hD with ⟨E, hE⟩
   exact ⟨E + A, S.add_effective_mem_completeLinearSystem hA hE⟩
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Basic.lean
@@ -207,8 +207,7 @@ lemma nonempty_completeLinearSystem_iff_divisorClass_eq_zero_of_weightedDegree_z
 /-- With positive weights and weighted-degree-zero principal divisors, the complete linear system
 of `D` is `{0}` exactly when its divisor class is zero. -/
 lemma completeLinearSystem_eq_singleton_zero_iff_divisorClass_eq_zero_of_isWeightedDegreeZero
-    {w : X → ℤ} (hw : ∀ x, 0 < w x) (h : S.IsWeightedDegreeZero w)
-    {D : WeilDivisor X} :
+    {w : X → ℤ} (hw : ∀ x, 0 < w x) (h : S.IsWeightedDegreeZero w) {D : WeilDivisor X} :
     S.completeLinearSystem D = {0} ↔ S.divisorClass D = 0 := by
   constructor
   · intro hset
@@ -230,8 +229,7 @@ lemma completeLinearSystem_eq_singleton_zero_iff_divisorClass_eq_zero_of_isWeigh
 /-- With positive weights and weighted-degree-zero principal divisors, the complete linear system
 of `D` is `{0}` exactly when `D` is linearly equivalent to zero. -/
 lemma completeLinearSystem_eq_singleton_zero_iff_linearlyEquivalent_zero_of_isWeightedDegreeZero
-    {w : X → ℤ} (hw : ∀ x, 0 < w x) (h : S.IsWeightedDegreeZero w)
-    {D : WeilDivisor X} :
+    {w : X → ℤ} (hw : ∀ x, 0 < w x) (h : S.IsWeightedDegreeZero w) {D : WeilDivisor X} :
     S.completeLinearSystem D = {0} ↔ S.LinearlyEquivalent D 0 := by
   rw [S.completeLinearSystem_eq_singleton_zero_iff_divisorClass_eq_zero_of_isWeightedDegreeZero
     hw h, ← S.divisorClass_eq_iff]
@@ -330,8 +328,7 @@ lemma nonempty_completeLinearSystem_iff_linearlyEquivalent_zero_of_degree_zero
 
 /-- A complete linear system is nonempty exactly when the divisor class of `D` contains an
 effective divisor. -/
-lemma nonempty_completeLinearSystem_iff {D : WeilDivisor X} :
-    (S.completeLinearSystem D).Nonempty ↔
+lemma nonempty_completeLinearSystem_iff {D : WeilDivisor X} : (S.completeLinearSystem D).Nonempty ↔
       ∃ E, IsEffective E ∧ S.divisorClass E = S.divisorClass D := by
   constructor
   · rintro ⟨E, hE⟩

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Monotone.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/LinearSystem/Monotone.lean
@@ -56,8 +56,7 @@ lemma mapsTo_add_sub_completeLinearSystem_of_le {D D' : WeilDivisor X} (hDD' : D
 
 /-- Nonemptiness of complete linear systems is monotone for the divisor order. -/
 lemma nonempty_completeLinearSystem_of_le {D D' : WeilDivisor X} (hDD' : D ≤ D')
-    (hD : (S.completeLinearSystem D).Nonempty) :
-    (S.completeLinearSystem D').Nonempty := by
+    (hD : (S.completeLinearSystem D).Nonempty) : (S.completeLinearSystem D').Nonempty := by
   have hdiff : IsEffective (D' - D) := le_iff_isEffective_sub.mp hDD'
   have hnonempty : (S.completeLinearSystem (D + (D' - D))).Nonempty :=
     S.nonempty_completeLinearSystem_add_effective hdiff hD

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Order.lean
@@ -106,8 +106,7 @@ lemma isEffective_inf_iff {D E : WeilDivisor X} :
     exact le_inf hD hE
 
 /-- Removing the infimum from each of two Weil divisors leaves disjoint residual divisors. -/
-lemma sub_inf_inf_sub_inf_eq_zero (D E : WeilDivisor X) :
-    ((D - D ⊓ E) ⊓ (E - D ⊓ E)) = 0 := by
+lemma sub_inf_inf_sub_inf_eq_zero (D E : WeilDivisor X) : ((D - D ⊓ E) ⊓ (E - D ⊓ E)) = 0 := by
   rw [← inf_sub, sub_self]
 
 /-! ### Positive and negative parts -/
@@ -169,8 +168,7 @@ lemma degree_posPart_sub_degree_negPart (D : WeilDivisor X) :
 /-! ### The decomposition of a point difference -/
 
 /-- For distinct points the positive part of `[x] - [y]` is the point divisor `[x]`. -/
-lemma posPart_pointDifference {x y : X} (h : x ≠ y) :
-    (pointDifference x y)⁺ = ofPoint x := by
+lemma posPart_pointDifference {x y : X} (h : x ≠ y) : (pointDifference x y)⁺ = ofPoint x := by
   classical
   ext z
   rw [coeff_posPart, coeff_pointDifference]
@@ -185,8 +183,7 @@ lemma posPart_pointDifference {x y : X} (h : x ≠ y) :
       exact sup_idem 0
 
 /-- For distinct points the negative part of `[x] - [y]` is the point divisor `[y]`. -/
-lemma negPart_pointDifference {x y : X} (h : x ≠ y) :
-    (pointDifference x y)⁻ = ofPoint y := by
+lemma negPart_pointDifference {x y : X} (h : x ≠ y) : (pointDifference x y)⁻ = ofPoint y := by
   have hneg : -pointDifference x y = pointDifference y x := by
     rw [pointDifference, pointDifference, neg_sub]
   rw [← posPart_neg, hneg, posPart_pointDifference h.symm]

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PicZeroQuotient.lean
@@ -55,8 +55,7 @@ def principalSubgroupOfWeightedDegreeZero (w : X → ℤ) :
   S.principalSubgroup.comap (weightedDegreeZeroSubgroup w).subtype
 
 @[simp]
-lemma mem_principalSubgroupOfWeightedDegreeZero {w : X → ℤ}
-    {D : weightedDegreeZeroSubgroup w} :
+lemma mem_principalSubgroupOfWeightedDegreeZero {w : X → ℤ} {D : weightedDegreeZeroSubgroup w} :
     D ∈ S.principalSubgroupOfWeightedDegreeZero w ↔
       (D : WeilDivisor X) ∈ S.principalSubgroup :=
   Iff.rfl
@@ -79,8 +78,7 @@ def weightedDegreeZeroClassHom (w : X → ℤ) (h : S.IsWeightedDegreeZero w) :
 
 @[simp]
 lemma coe_weightedDegreeZeroClassHom_apply {w : X → ℤ} (h : S.IsWeightedDegreeZero w)
-    (D : weightedDegreeZeroSubgroup w) :
-    (S.weightedDegreeZeroClassHom w h D : S.ClassGroup) =
+    (D : weightedDegreeZeroSubgroup w) : (S.weightedDegreeZeroClassHom w h D : S.ClassGroup) =
       S.divisorClass (D : WeilDivisor X) :=
   rfl
 
@@ -146,8 +144,7 @@ lemma weightedDegreeZeroQuotientEquivPicZero_mk {w : X → ℤ}
 
 lemma coe_weightedDegreeZeroQuotientEquivPicZero_mk {w : X → ℤ}
     (h : S.IsWeightedDegreeZero w) (D : weightedDegreeZeroSubgroup w) :
-    (S.weightedDegreeZeroQuotientEquivPicZero w h
-      (QuotientAddGroup.mk D) : S.ClassGroup) =
+    (S.weightedDegreeZeroQuotientEquivPicZero w h (QuotientAddGroup.mk D) : S.ClassGroup) =
       S.divisorClass (D : WeilDivisor X) := by
   simp
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/PositiveNegativeFixedDegree.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/PositiveNegativeFixedDegree.lean
@@ -55,14 +55,12 @@ abbrev negPart (D : WeilDivisor X) :
 
 /-- The underlying Weil divisor of the packaged positive part is `D⁺`. -/
 @[simp]
-lemma coe_posPart (D : WeilDivisor X) :
-    (posPart D : WeilDivisor X) = D⁺ :=
+lemma coe_posPart (D : WeilDivisor X) : (posPart D : WeilDivisor X) = D⁺ :=
   rfl
 
 /-- The underlying Weil divisor of the packaged negative part is `D⁻`. -/
 @[simp]
-lemma coe_negPart (D : WeilDivisor X) :
-    (negPart D : WeilDivisor X) = D⁻ :=
+lemma coe_negPart (D : WeilDivisor X) : (negPart D : WeilDivisor X) = D⁻ :=
   rfl
 
 /-- If a divisor is already effective, its packaged positive part is the divisor itself, up to

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Principal/Basic.lean
@@ -297,8 +297,7 @@ lemma mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {c : S.ClassGro
 /-- The class of a Weil divisor lies in `picZero` exactly when that representative has weighted
 degree zero; the value is well defined because the weighted degree descends to the class. -/
 @[simp]
-lemma divisorClass_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w)
-    {D : WeilDivisor X} :
+lemma divisorClass_mem_picZero (w : X → ℤ) (h : S.IsWeightedDegreeZero w) {D : WeilDivisor X} :
     S.divisorClass D ∈ picZero w h ↔ weightedDegree w D = 0 := by
   rw [mem_picZero, weightedDegreeClass_divisorClass]
 

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Scheme/Basic.lean
@@ -93,8 +93,7 @@ lemma toAlgebraicCycle_apply_of_coheight_ne_one (D : SchemeWeilDivisor X) (x : X
 
 /-- The support of a scheme-theoretic Weil divisor viewed as an algebraic cycle is the image of
 its finite support under the inclusion of codimension-one points. -/
-lemma support_toAlgebraicCycle (D : SchemeWeilDivisor X) :
-    (toAlgebraicCycle D).support =
+lemma support_toAlgebraicCycle (D : SchemeWeilDivisor X) : (toAlgebraicCycle D).support =
       Subtype.val '' (D.support : Set (CodimensionOnePoint X)) := by
   ext x
   constructor

--- a/TauCeti/AlgebraicGeometry/WeilDivisor/Union.lean
+++ b/TauCeti/AlgebraicGeometry/WeilDivisor/Union.lean
@@ -64,8 +64,7 @@ lemma coe_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X
   Classical.choose_spec (exists_sup D E)
 
 /-- The coefficient of the union is the maximum of the two coefficients. -/
-lemma coeff_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e)
-    (x : X) :
+lemma coeff_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) (x : X) :
     coeff (sup D E : WeilDivisor X) x =
       coeff (D : WeilDivisor X) x ⊔ coeff (E : WeilDivisor X) x := by
   rw [coe_sup, WeilDivisor.coeff_sup]
@@ -99,15 +98,13 @@ lemma equivSym_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDeg
   simp
 
 /-- The left input divisor lies below the union. -/
-lemma le_sup_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma le_sup_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (D : WeilDivisor X) ≤ sup D E := by
   rw [coe_sup]
   exact _root_.le_sup_left
 
 /-- The right input divisor lies below the union. -/
-lemma le_sup_right (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma le_sup_right (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (E : WeilDivisor X) ≤ sup D E := by
   rw [coe_sup]
   exact _root_.le_sup_right
@@ -115,21 +112,18 @@ lemma le_sup_right (D : EffectiveDivisorOfDegree X d)
 /-- Any Weil divisor above both inputs lies above their union. -/
 lemma sup_le {F : WeilDivisor X} {D : EffectiveDivisorOfDegree X d}
     {E : EffectiveDivisorOfDegree X e} (hDF : (D : WeilDivisor X) ≤ F)
-    (hEF : (E : WeilDivisor X) ≤ F) :
-    (sup D E : WeilDivisor X) ≤ F := by
+    (hEF : (E : WeilDivisor X) ≤ F) : (sup D E : WeilDivisor X) ≤ F := by
   rw [coe_sup]
   exact _root_.sup_le hDF hEF
 
 /-- The union is the left input exactly when the right input is below the left input. -/
-lemma sup_eq_left {D : EffectiveDivisorOfDegree X d}
-    {E : EffectiveDivisorOfDegree X e} :
+lemma sup_eq_left {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e} :
     (sup D E : WeilDivisor X) = D ↔ (E : WeilDivisor X) ≤ D := by
   rw [coe_sup]
   exact _root_.sup_eq_left
 
 /-- The union is the right input exactly when the left input is below the right input. -/
-lemma sup_eq_right {D : EffectiveDivisorOfDegree X d}
-    {E : EffectiveDivisorOfDegree X e} :
+lemma sup_eq_right {D : EffectiveDivisorOfDegree X d} {E : EffectiveDivisorOfDegree X e} :
     (sup D E : WeilDivisor X) = E ↔ (D : WeilDivisor X) ≤ E := by
   rw [coe_sup]
   exact _root_.sup_eq_right
@@ -142,14 +136,12 @@ lemma sup_comm (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree 
   rw [coe_sup, coe_cast, coe_sup, _root_.sup_comm]
 
 /-- The left degree index is bounded above by the degree of the union. -/
-lemma left_le_degree_sup (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma left_le_degree_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     d ≤ (degree ((D : WeilDivisor X) ⊔ E)).toNat :=
   EffectiveDivisorOfDegree.degree_le_of_le (le_sup_left D E)
 
 /-- The right degree index is bounded above by the degree of the union. -/
-lemma right_le_degree_sup (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma right_le_degree_sup (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     e ≤ (degree ((D : WeilDivisor X) ⊔ E)).toNat :=
   EffectiveDivisorOfDegree.degree_le_of_le (le_sup_right D E)
 
@@ -168,8 +160,7 @@ lemma degree_inf_toNat_add_degree_sup_toNat (D : EffectiveDivisorOfDegree X d)
   omega
 
 /-- The degree of the union is `d + e` minus the degree of the common part. -/
-lemma degree_sup_toNat (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma degree_sup_toNat (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
     (degree ((D : WeilDivisor X) ⊔ E)).toNat =
       d + e - (degree ((D : WeilDivisor X) ⊓ E)).toNat := by
   have := degree_inf_toNat_add_degree_sup_toNat D E


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/AlgebraicGeometry/WeilDivisor/`: 75 joins across 26 files, `-75` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined. Example:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 26 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Widest resulting line is exactly 100 codepoints (`FixedDegree/Subtraction.lean:55`); no line exceeds the limit. Width was measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports.

Scope is the whole directory rather than a subset, so the packing convention is applied uniformly and does not invite a follow-up pass over the leftovers.

Gates: `lake build` (6156 jobs) · `lake exe axioms` (19030 declarations, allowlist clean) · `lake exe module-system` (1048 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none