### PR TITLE
feat: add normalized Clifford bivector exterior map

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -91,7 +91,7 @@ theorem cliffordBivectorAlternating_apply (a b : M) :
     cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
 
 /-- The linear map from the second exterior power induced by the Clifford bivector. -/
-@[expose] noncomputable def cliffordBivectorExterior : ⋀[R]^2 M →ₗ[R] CliffordAlgebra Q :=
+noncomputable def cliffordBivectorExterior : ⋀[R]^2 M →ₗ[R] CliffordAlgebra Q :=
   exteriorPower.alternatingMapLinearEquiv (cliffordBivectorAlternating Q)
 
 /-- The exterior-square Clifford bivector map on a decomposable bivector. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -70,7 +70,7 @@ noncomputable def cliffordBivector (a b : M) : CliffordAlgebra Q :=
   (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a)
 
 /-- The alternating map whose value on two vectors is their half-normalized Clifford bivector. -/
-@[expose] noncomputable def cliffordBivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordAlgebra Q :=
+noncomputable def cliffordBivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordAlgebra Q :=
   { toFun := fun v => cliffordBivector Q (v 0) (v 1)
     map_update_add' := by
       intro _ v i x y
@@ -85,10 +85,14 @@ noncomputable def cliffordBivector (a b : M) : CliffordAlgebra Q :=
       intro v i j h hij
       fin_cases i <;> fin_cases j <;> simp_all [cliffordBivector] }
 
+private theorem cliffordBivectorAlternating_apply_internal (a b : M) :
+    cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
+
 /-- The alternating map agrees with the half-normalized Clifford bivector on a pair of vectors. -/
 @[simp]
 theorem cliffordBivectorAlternating_apply (a b : M) :
-    cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
+    cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b :=
+  cliffordBivectorAlternating_apply_internal Q a b
 
 /-- The linear map from the second exterior power induced by the Clifford bivector. -/
 noncomputable def cliffordBivectorExterior : ⋀[R]^2 M →ₗ[R] CliffordAlgebra Q :=
@@ -103,14 +107,19 @@ theorem cliffordBivectorExterior_apply_ιMulti (a b : M) :
 /-- Interchanging the two vectors negates their Clifford bivector. -/
 theorem cliffordBivector_swap (a b : M) :
     cliffordBivector Q b a = -cliffordBivector Q a b := by
-  rw [cliffordBivector, cliffordBivector, ← smul_neg]
+  rw [← cliffordBivectorAlternating_apply, ← cliffordBivectorAlternating_apply]
+  convert (cliffordBivectorAlternating Q).map_swap (v := ![a, b])
+    (by decide : (0 : Fin 2) ≠ 1) using 1
   congr 1
-  noncomm_ring
+  funext i
+  fin_cases i <;> rfl
 
 /-- The Clifford bivector of a repeated vector is zero. -/
 @[simp]
 theorem cliffordBivector_self (a : M) : cliffordBivector Q a a = 0 := by
-  rw [cliffordBivector, sub_self, smul_zero]
+  simpa only [cliffordBivectorAlternating_apply] using
+    (cliffordBivectorAlternating Q).map_eq_zero_of_eq ![a, a] (by simp)
+      (by decide : (0 : Fin 2) ≠ 1)
 
 /-- Clifford bivectors are even. -/
 theorem cliffordBivector_mem_evenOdd_zero (a b : M) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+import Mathlib.Tactic.NoncommRing
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
+
+/-!
+# Half-normalized Clifford bivectors
+
+The Layer 3 bivector realization of the orthogonal Lie algebra is normalized by its action on
+vectors. This module records the generic Clifford-algebra calculation that fixes that normalization
+before choosing a standard basis: the half commutator of two generators acts on a third generator
+by the polarization of the quadratic form.
+
+The formula is valid over every commutative ring in which `2` is invertible. The factor `⅟2` is
+forced: the commutator of the unnormalized expression acts by twice the desired infinitesimal
+rotation. This gives the local algebraic input for the roadmap's standard-form
+`soEquivBivector_wedge_mulVec` theorem without constructing the transported Lie bracket, the
+Lie-algebra equivalence, or a group action.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.cliffordBivector`: the half-normalized commutator of two Clifford
+  generators.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.cliffordBivector_lie_ι`: its commutator action on a generator is the
+  infinitesimal rotation determined by `QuadraticMap.polar`.
+* `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
+  `TauCeti.CliffordAlgebra.cliffordBivector_mem_filtration_two`: it is even and has filtration
+  degree at most two.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 3, "the Lie algebra `𝔰𝔬(V) ≅ ⋀²V` inside the Clifford algebra".
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+section CommRing
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) [Invertible (2 : R)]
+
+/-- The half-normalized Clifford commutator of two generators. Its action on a third generator is
+the infinitesimal rotation in `cliffordBivector_lie_ι`; that action, rather than this expression,
+fixes the normalization. -/
+noncomputable def cliffordBivector (a b : M) : CliffordAlgebra Q :=
+  (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a)
+
+/-- Interchanging the two vectors negates their Clifford bivector. -/
+theorem cliffordBivector_swap (a b : M) :
+    cliffordBivector Q b a = -cliffordBivector Q a b := by
+  rw [cliffordBivector, cliffordBivector, ← smul_neg]
+  congr 1
+  noncomm_ring
+
+/-- The Clifford bivector of a repeated vector is zero. -/
+@[simp]
+theorem cliffordBivector_self (a : M) : cliffordBivector Q a a = 0 := by
+  rw [cliffordBivector, sub_self, smul_zero]
+
+/-- Clifford bivectors are even. -/
+theorem cliffordBivector_mem_evenOdd_zero (a b : M) :
+    cliffordBivector Q a b ∈ evenOdd Q 0 := by
+  rw [cliffordBivector]
+  exact Submodule.smul_mem _ _ <|
+    Submodule.sub_mem _ (ι_mul_ι_mem_evenOdd_zero Q a b) (ι_mul_ι_mem_evenOdd_zero Q b a)
+
+/-- Clifford bivectors have filtration degree at most two. -/
+theorem cliffordBivector_mem_filtration_two (a b : M) :
+    cliffordBivector Q a b ∈ filtration Q 2 := by
+  rw [cliffordBivector]
+  exact Submodule.smul_mem _ _ <|
+    Submodule.sub_mem _ (ι_mul_ι_mem_filtration_two Q a b) (ι_mul_ι_mem_filtration_two Q b a)
+
+/-- The action-normalization identity for the half-normalized Clifford bivector. -/
+theorem cliffordBivector_lie_ι (a b x : M) :
+    ⁅cliffordBivector Q a b, ι Q x⁆ =
+      ι Q (QuadraticMap.polar Q b x • a - QuadraticMap.polar Q a x • b) := by
+  rw [cliffordBivector, Ring.lie_def]
+  rw [smul_mul_assoc, mul_smul_comm, ← smul_sub]
+  rw [map_sub, map_smul, map_smul]
+  have hbx := ι_mul_ι_add_swap (Q := Q) b x
+  have hax := ι_mul_ι_add_swap (Q := Q) a x
+  have hA (r : R) : ι Q a * algebraMap R (CliffordAlgebra Q) r = r • ι Q a := by
+    calc
+      ι Q a * algebraMap R (CliffordAlgebra Q) r = algebraMap R (CliffordAlgebra Q) r * ι Q a :=
+        (Algebra.commutes r (ι Q a)).symm
+      _ = r • ι Q a := (Algebra.smul_def r (ι Q a)).symm
+  have hB (r : R) : ι Q b * algebraMap R (CliffordAlgebra Q) r = r • ι Q b := by
+    calc
+      ι Q b * algebraMap R (CliffordAlgebra Q) r = algebraMap R (CliffordAlgebra Q) r * ι Q b :=
+        (Algebra.commutes r (ι Q b)).symm
+      _ = r • ι Q b := (Algebra.smul_def r (ι Q b)).symm
+  have h :
+      (ι Q a * ι Q b - ι Q b * ι Q a) * ι Q x -
+          ι Q x * (ι Q a * ι Q b - ι Q b * ι Q a) =
+        (2 : R) • (QuadraticMap.polar Q b x • ι Q a -
+          QuadraticMap.polar Q a x • ι Q b) := by
+    calc
+      (ι Q a * ι Q b - ι Q b * ι Q a) * ι Q x -
+          ι Q x * (ι Q a * ι Q b - ι Q b * ι Q a) =
+        ι Q a * (ι Q b * ι Q x + ι Q x * ι Q b) -
+          ι Q b * (ι Q a * ι Q x + ι Q x * ι Q a) -
+          (ι Q a * ι Q x + ι Q x * ι Q a) * ι Q b +
+          (ι Q b * ι Q x + ι Q x * ι Q b) * ι Q a := by
+            noncomm_ring
+      _ = ι Q a * algebraMap R (CliffordAlgebra Q) (QuadraticMap.polar Q b x) -
+          ι Q b * algebraMap R (CliffordAlgebra Q) (QuadraticMap.polar Q a x) -
+          algebraMap R (CliffordAlgebra Q) (QuadraticMap.polar Q a x) * ι Q b +
+          algebraMap R (CliffordAlgebra Q) (QuadraticMap.polar Q b x) * ι Q a := by
+            rw [hbx, hax]
+      _ = (2 : R) • (QuadraticMap.polar Q b x • ι Q a -
+          QuadraticMap.polar Q a x • ι Q b) := by
+            rw [hA, hB, ← Algebra.smul_def, ← Algebra.smul_def]
+            rw [two_smul R]
+            abel
+  rw [h]
+  exact invOf_smul_smul (2 : R) _
+
+end CommRing
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -69,21 +69,26 @@ fixes the normalization. -/
 noncomputable def cliffordBivector (a b : M) : CliffordAlgebra Q :=
   (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a)
 
+/-- The defining half-normalized commutator formula for a Clifford bivector. -/
+theorem cliffordBivector_def (a b : M) :
+    cliffordBivector Q a b = (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a) := by
+  rw [cliffordBivector]
+
 /-- The alternating map whose value on two vectors is their half-normalized Clifford bivector. -/
 noncomputable def cliffordBivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordAlgebra Q :=
   { toFun := fun v => cliffordBivector Q (v 0) (v 1)
     map_update_add' := by
       intro _ v i x y
       fin_cases i <;>
-        simp [cliffordBivector, add_mul, mul_add, smul_sub] <;>
+        simp [cliffordBivector_def, add_mul, mul_add, smul_sub] <;>
         module
     map_update_smul' := by
       intro _ v i c x
       fin_cases i <;>
-        simp [cliffordBivector, smul_sub, smul_smul, mul_comm]
+        simp [cliffordBivector_def, smul_sub, smul_smul, mul_comm]
     map_eq_zero_of_eq' := by
       intro v i j h hij
-      fin_cases i <;> fin_cases j <;> simp_all [cliffordBivector] }
+      fin_cases i <;> fin_cases j <;> simp_all [cliffordBivector_def] }
 
 private theorem cliffordBivectorAlternating_apply_internal (a b : M) :
     cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
@@ -124,22 +129,48 @@ theorem cliffordBivector_self (a : M) : cliffordBivector Q a a = 0 := by
 /-- Clifford bivectors are even. -/
 theorem cliffordBivector_mem_evenOdd_zero (a b : M) :
     cliffordBivector Q a b ∈ evenOdd Q 0 := by
-  rw [cliffordBivector]
+  rw [cliffordBivector_def]
   exact Submodule.smul_mem _ _ <|
     Submodule.sub_mem _ (ι_mul_ι_mem_evenOdd_zero Q a b) (ι_mul_ι_mem_evenOdd_zero Q b a)
 
 /-- Clifford bivectors have filtration degree at most two. -/
 theorem cliffordBivector_mem_filtration_two (a b : M) :
     cliffordBivector Q a b ∈ filtration Q 2 := by
-  rw [cliffordBivector]
+  rw [cliffordBivector_def]
   exact Submodule.smul_mem _ _ <|
     Submodule.sub_mem _ (ι_mul_ι_mem_filtration_two Q a b) (ι_mul_ι_mem_filtration_two Q b a)
+
+private theorem cliffordBivectorExterior_range_le (P : Submodule R (CliffordAlgebra Q))
+    (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
+    LinearMap.range (cliffordBivectorExterior Q) ≤ P := by
+  rw [LinearMap.range_eq_map, Submodule.map_le_iff_le_comap,
+    ← exteriorPower.ιMulti_span R 2 M]
+  refine Submodule.span_le.2 ?_
+  rintro _ ⟨v, rfl⟩
+  have hv : v = ![v 0, v 1] := by
+    funext i
+    fin_cases i <;> rfl
+  rw [hv]
+  -- Rewriting does not unfold membership in the comap, so expose the map application explicitly.
+  change cliffordBivectorExterior Q (exteriorPower.ιMulti R 2 ![v 0, v 1]) ∈ P
+  rw [cliffordBivectorExterior_apply_ιMulti]
+  exact hP _ _
+
+/-- The exterior-square Clifford bivector map takes values in the even component. -/
+theorem cliffordBivectorExterior_range_le_evenOdd_zero :
+    LinearMap.range (cliffordBivectorExterior Q) ≤ evenOdd Q 0 :=
+  cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_evenOdd_zero Q)
+
+/-- The exterior-square Clifford bivector map takes values in filtration degree at most two. -/
+theorem cliffordBivectorExterior_range_le_filtration_two :
+    LinearMap.range (cliffordBivectorExterior Q) ≤ filtration Q 2 :=
+  cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_filtration_two Q)
 
 /-- The action-normalization identity for the half-normalized Clifford bivector. -/
 theorem cliffordBivector_lie_ι (a b x : M) :
     ⁅cliffordBivector Q a b, ι Q x⁆ =
       ι Q (QuadraticMap.polar Q b x • a - QuadraticMap.polar Q a x • b) := by
-  rw [cliffordBivector, Ring.lie_def]
+  rw [cliffordBivector_def, Ring.lie_def]
   rw [smul_mul_assoc, mul_smul_comm, ← smul_sub]
   rw [map_sub, map_smul, map_smul]
   have hbx := ι_mul_ι_add_swap (Q := Q) b x

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -20,8 +20,9 @@ forced: the commutator of the unnormalized expression acts by twice the desired 
 rotation.
 
 This is a shared generic prerequisite for the roadmap's Layer 3 standard-form normalization and
-the later Layer 9 arbitrary-form realization. It does not construct `soEquivBivector`, a
-transported Lie bracket, a Spin action, or the Layer 9 CAR worked instance.
+the later Layer 9 arbitrary-form realization. It constructs neither `soEquivBivector` nor
+`soEquivQuadratic`, and it does not construct a transported Lie bracket, a Spin action, or the
+Layer 9 CAR worked instance.
 
 ## Main definitions
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -5,31 +5,38 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 import Mathlib.Tactic.NoncommRing
+public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 
 /-!
-# Half-normalized Clifford bivectors
+# Clifford bivectors and exterior squares
 
-The Layer 3 bivector realization of the orthogonal Lie algebra is normalized by its action on
-vectors. This module records the generic Clifford-algebra calculation that fixes that normalization
-before choosing a standard basis: the half commutator of two generators acts on a third generator
+This module packages the generic half-normalized Clifford commutator into an alternating map and
+the induced linear map from the second exterior power. Its action on a Clifford generator is given
 by the polarization of the quadratic form.
 
 The formula is valid over every commutative ring in which `2` is invertible. The factor `⅟2` is
 forced: the commutator of the unnormalized expression acts by twice the desired infinitesimal
-rotation. This gives the local algebraic input for the roadmap's standard-form
-`soEquivBivector_wedge_mulVec` theorem without constructing the transported Lie bracket, the
-Lie-algebra equivalence, or a group action.
+rotation.
+
+This is a shared generic prerequisite for the roadmap's Layer 3 standard-form normalization and
+the later Layer 9 arbitrary-form realization. It does not construct `soEquivBivector`, a
+transported Lie bracket, a Spin action, or the Layer 9 CAR worked instance.
 
 ## Main definitions
 
 * `TauCeti.CliffordAlgebra.cliffordBivector`: the half-normalized commutator of two Clifford
   generators.
+* `TauCeti.CliffordAlgebra.cliffordBivectorAlternating`: the corresponding alternating map.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExterior`: the induced linear map from the second
+  exterior power.
 
 ## Main results
 
 * `TauCeti.CliffordAlgebra.cliffordBivector_lie_ι`: its commutator action on a generator is the
   infinitesimal rotation determined by `QuadraticMap.polar`.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_apply_ιMulti`: the exterior-square map on a
+  decomposable bivector.
 * `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
   `TauCeti.CliffordAlgebra.cliffordBivector_mem_filtration_two`: it is even and has filtration
   degree at most two.
@@ -60,6 +67,37 @@ the infinitesimal rotation in `cliffordBivector_lie_ι`; that action, rather tha
 fixes the normalization. -/
 noncomputable def cliffordBivector (a b : M) : CliffordAlgebra Q :=
   (⅟ (2 : R)) • (ι Q a * ι Q b - ι Q b * ι Q a)
+
+/-- The alternating map whose value on two vectors is their half-normalized Clifford bivector. -/
+@[expose] noncomputable def cliffordBivectorAlternating : M [⋀^Fin 2]→ₗ[R] CliffordAlgebra Q :=
+  { toFun := fun v => cliffordBivector Q (v 0) (v 1)
+    map_update_add' := by
+      intro _ v i x y
+      fin_cases i <;>
+        simp [cliffordBivector, add_mul, mul_add, smul_sub] <;>
+        module
+    map_update_smul' := by
+      intro _ v i c x
+      fin_cases i <;>
+        simp [cliffordBivector, smul_sub, smul_smul, mul_comm]
+    map_eq_zero_of_eq' := by
+      intro v i j h hij
+      fin_cases i <;> fin_cases j <;> simp_all [cliffordBivector] }
+
+/-- The alternating map agrees with the half-normalized Clifford bivector on a pair of vectors. -/
+@[simp]
+theorem cliffordBivectorAlternating_apply (a b : M) :
+    cliffordBivectorAlternating Q ![a, b] = cliffordBivector Q a b := rfl
+
+/-- The linear map from the second exterior power induced by the Clifford bivector. -/
+@[expose] noncomputable def cliffordBivectorExterior : ⋀[R]^2 M →ₗ[R] CliffordAlgebra Q :=
+  exteriorPower.alternatingMapLinearEquiv (cliffordBivectorAlternating Q)
+
+/-- The exterior-square Clifford bivector map on a decomposable bivector. -/
+@[simp]
+theorem cliffordBivectorExterior_apply_ιMulti (a b : M) :
+    cliffordBivectorExterior Q (exteriorPower.ιMulti R 2 ![a, b]) = cliffordBivector Q a b := by
+  simp [cliffordBivectorExterior]
 
 /-- Interchanging the two vectors negates their Clifford bivector. -/
 theorem cliffordBivector_swap (a b : M) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the generic half-normalized Clifford-bivector calculus supplying the exterior-square side of the Layer 3 action-normalization target.

- Packages the bivector as `cliffordBivectorAlternating`.
- Uses Mathlib's exterior-power universal property for `cliffordBivectorExterior`.
- Supplies decomposable-bivector and generator-action equations, together with evenness and filtration facts.

## Roadmap target

Advances the Layer 3 `soEquivBivector_wedge_mulVec` normalization pin:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L161-L170

This is shared prerequisite calculus, not either `soEquivBivector` or Layer 9's `soEquivQuadratic`.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#soEquivBivector_wedge_mulVec"}-->

## Verification

The prior full CI run passed at `bc6ed5ac`; the focused `lake build TauCeti.LinearAlgebra.CliffordAlgebra.Bivector` passes at `6d730c62`; refreshed CI and an independent TauCeti-rubric review are in progress on that exact head.

## Scope

Does not add a transported Lie bracket, either Lie equivalence, a Spin action, coordinates/PBW/basis transport, or CAR work.

<sub>🤖 GPT-5.6 Terra max · rubrics @ [222eed0](https://github.com/TauCetiProject/TauCetiReview/commit/222eed046013fbee91239aea4a5186b12f086e65) · local review fixed: api-design (1), documentation (2)</sub>


