### PR TITLE
feat: characterize diagonalizable coordinate Hopf algebras

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
@@ -1,0 +1,241 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.CategoryTheory.Equivalence
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import TauCeti.Algebra.HopfAlgebra.GroupLike.FiniteGeneration
+
+import TauCeti.Algebra.Bialgebra.GroupLike.Evaluation
+
+/-!
+# The essential image of diagonalizable coordinate Hopf algebras
+
+Over a field `k`, a finite-type commutative Hopf algebra is the coordinate algebra of a
+diagonalizable group exactly when its group-like elements span the whole carrier. This file
+identifies that intrinsic object property with the essential image of
+`DiagonalizableGroup.coordinateRingFunctor` and packages the resulting equivalence of categories.
+
+The proof reconstructs a group-like-spanned Hopf algebra `H` from its group of group-like elements.
+The canonical evaluation map `k[GroupLike k H] → H` is a bialgebra equivalence: spanning gives
+surjectivity, while linear independence of group-like elements over a field gives injectivity.
+Finite type then implies that `GroupLike k H` is finitely generated. Conversely, the standard
+basis elements of every group algebra are group-like and span, and this property is invariant
+under bialgebra equivalence.
+
+All categories and carriers in the equivalence lie in the universe of `k`. Applying `Spec`, and
+the resulting scheme-side anti-equivalence, are outside the scope of this file.
+
+## Main declarations
+
+* `TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top`: the group-like elements of a group algebra span.
+* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv`: group-like spanning is invariant
+  under bialgebra equivalence.
+* `TauCeti.DiagonalizableGroup.groupLikeSpannedProperty`: the intrinsic object property on
+  finite-type commutative Hopf algebras.
+* `TauCeti.DiagonalizableGroup.essImage_coordinateRingFunctor`: the essential image of the
+  coordinate-ring functor is the group-like-spanned property.
+* `TauCeti.DiagonalizableGroup.GroupLikeSpannedCommHopfAlgCat`: the corresponding full
+  subcategory.
+* `TauCeti.DiagonalizableGroup.coordinateRingEquivalence`: the equivalence from finitely generated
+  commutative groups to group-like-spanned finite-type commutative Hopf algebras.
+
+## References
+
+See Milne, *Algebraic Groups*, Proposition 4.23 and Definition 12.7 with Theorems 12.8--12.9.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u v w
+
+namespace MonoidAlgebra
+
+/-- The group-like elements of a monoid algebra span the whole algebra: every standard basis
+element is group-like, and the standard basis spans. -/
+theorem groupLikeSetSpan_eq_top (R : Type u) (G : Type v) [CommSemiring R] [Monoid G] :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := _root_.MonoidAlgebra R G) Set.univ = ⊤ := by
+  apply Subcoalgebra.ext
+  intro x
+  rw [Subcoalgebra.mem_groupLikeSetSpan]
+  constructor
+  · intro
+    exact Subcoalgebra.mem_top x
+  · intro
+    have hbasis :
+        Submodule.span R
+            (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) = ⊤ := by
+      rw [show Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R)) =
+          Set.range (_root_.MonoidAlgebra.basis G R) by
+        ext y
+        constructor <;> rintro ⟨g, rfl⟩
+        · exact ⟨g, (_root_.MonoidAlgebra.basis_apply R g).symm⟩
+        · exact ⟨g, _root_.MonoidAlgebra.basis_apply R g⟩]
+      exact (_root_.MonoidAlgebra.basis G R).span_eq
+    have hx : x ∈ Submodule.span R
+        (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) := by
+      rw [hbasis]
+      exact Submodule.mem_top
+    apply (Submodule.span_mono ?_) hx
+    rintro _ ⟨g, rfl⟩
+    exact ⟨⟨_root_.MonoidAlgebra.single g 1,
+      TauCeti.MonoidAlgebra.isGroupLikeElem_single_one R g⟩, Set.mem_univ _, rfl⟩
+
+end MonoidAlgebra
+
+namespace GroupLike
+
+/-- A bialgebra equivalence preserves the property that the group-like elements span the whole
+carrier. -/
+theorem groupLikeSetSpan_eq_top_iff_of_bialgEquiv
+    (R : Type u) (A : Type v) (B : Type w) [CommSemiring R]
+    [Semiring A] [Semiring B] [Bialgebra R A] [Bialgebra R B]
+    (e : A ≃ₐc[R] B) :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := A) Set.univ = ⊤ ↔
+      Subcoalgebra.groupLikeSetSpan (R := R) (C := B) Set.univ = ⊤ := by
+  let f : A ≃ₗ[R] B := e.toCoalgEquiv.toLinearEquiv
+  have hgroupLike :
+      f '' Set.range (_root_.GroupLike.val (R := R) (A := A)) =
+        Set.range (_root_.GroupLike.val (R := R) (A := B)) := by
+    ext b
+    constructor
+    · rintro ⟨_, ⟨g, rfl⟩, rfl⟩
+      exact ⟨⟨e g, g.isGroupLikeElem_val.map e⟩, rfl⟩
+    · rintro ⟨g, rfl⟩
+      refine ⟨e.symm (g : B), ⟨⟨e.symm (g : B), ?_⟩, rfl⟩, ?_⟩
+      · exact g.isGroupLikeElem_val.map e.symm
+      · exact e.apply_symm_apply (g : B)
+  constructor
+  · intro hA
+    have hA' :
+        Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := A))) = ⊤ := by
+      have h := congrArg Subcoalgebra.toSubmodule hA
+      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
+        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
+    have hB' :
+        Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := B))) = ⊤ := by
+      rw [← hgroupLike, Submodule.span_image_linearEquiv, hA', Submodule.map_top,
+        LinearEquiv.range]
+    apply Subcoalgebra.ext
+    intro b
+    rw [Subcoalgebra.mem_groupLikeSetSpan]
+    simp [hB']
+  · intro hB
+    have hB' :
+        Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := B))) = ⊤ := by
+      have h := congrArg Subcoalgebra.toSubmodule hB
+      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
+        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
+    have hA' :
+        Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := A))) = ⊤ := by
+      apply Submodule.map_injective_of_injective (f := f.toLinearMap) f.injective
+      calc
+        (Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := A)))).map f.toLinearMap =
+            Submodule.span R
+              (f '' Set.range (_root_.GroupLike.val (R := R) (A := A))) :=
+          Submodule.map_span f.toLinearMap _
+        _ = Submodule.span R
+              (Set.range (_root_.GroupLike.val (R := R) (A := B))) := by rw [hgroupLike]
+        _ = ⊤ := hB'
+        _ = (⊤ : Submodule R A).map f.toLinearMap := by
+          rw [Submodule.map_top, LinearEquiv.range]
+    apply Subcoalgebra.ext
+    intro a
+    rw [Subcoalgebra.mem_groupLikeSetSpan]
+    simp [hA']
+
+end GroupLike
+
+namespace DiagonalizableGroup
+
+variable (k : Type u) [Field k]
+
+/-- The object property selecting finite-type commutative Hopf algebras whose group-like elements
+span the whole carrier. -/
+@[expose] def groupLikeSpannedProperty :
+    ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
+  fun H ↦ Subcoalgebra.groupLikeSetSpan (R := k) (C := H) Set.univ = ⊤
+
+/-- Membership in the group-like-spanned object property. -/
+@[simp]
+theorem groupLikeSpannedProperty_iff (H : FiniteTypeCommHopfAlgCat.{u, u} k) :
+    groupLikeSpannedProperty k H ↔
+      Subcoalgebra.groupLikeSetSpan (R := k) (C := H) Set.univ = ⊤ :=
+  Iff.rfl
+
+/-- The essential image of the finite-type diagonalizable coordinate-ring functor consists
+exactly of the finite-type commutative Hopf algebras spanned by their group-like elements. -/
+theorem essImage_coordinateRingFunctor :
+    (coordinateRingFunctor k).essImage = groupLikeSpannedProperty k := by
+  funext H
+  apply propext
+  constructor
+  · rintro ⟨G, ⟨e⟩⟩
+    let e' : ((coordinateRingFunctor k).obj G).obj ≅ H.obj :=
+      (finiteTypeCommHopfAlgProperty k).ι.mapIso e
+    exact (TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv k
+      ((coordinateRingFunctor k).obj G) H (_root_.CommHopfAlgCat.ofIso e')).mp
+        (TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top k G)
+  · intro hH
+    letI : Group.FG (_root_.GroupLike k H) :=
+      TauCeti.GroupLike.fg_of_finiteType_of_groupLikeSetSpan_eq_top k H
+        (inferInstanceAs (Algebra.FiniteType k H)) hH
+    let G : FGCommGrpCat.{u} := FGCommGrpCat.of (_root_.GroupLike k H)
+    have hspan :
+        Submodule.span k
+            (Set.range (_root_.GroupLike.val (R := k) (A := H))) = ⊤ := by
+      have h := congrArg Subcoalgebra.toSubmodule hH
+      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
+        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
+    let e : _root_.CommHopfAlgCat.of k (_root_.MonoidAlgebra k (_root_.GroupLike k H)) ≅
+        H.obj :=
+      _root_.CommHopfAlgCat.isoMk
+          (TauCeti.GroupLike.evaluationBialgEquiv k H hspan) ≪≫
+        _root_.CommHopfAlgCat.ofIsoSelf H.obj
+    exact ⟨G, ⟨ObjectProperty.isoMk (finiteTypeCommHopfAlgProperty k) e⟩⟩
+
+/-- The property of being spanned by group-like elements is invariant under isomorphisms of
+finite-type commutative Hopf algebras. -/
+instance groupLikeSpannedProperty_isClosedUnderIsomorphisms :
+    (groupLikeSpannedProperty k).IsClosedUnderIsomorphisms := by
+  rw [← essImage_coordinateRingFunctor k]
+  infer_instance
+
+/-- The category of finite-type commutative Hopf algebras spanned by their group-like elements. -/
+abbrev GroupLikeSpannedCommHopfAlgCat :=
+  (groupLikeSpannedProperty k).FullSubcategory
+
+/-- Finitely generated commutative groups are equivalent to finite-type commutative Hopf
+algebras spanned by their group-like elements, via the group-algebra coordinate-ring functor. -/
+noncomputable def coordinateRingEquivalence :
+    FGCommGrpCat.{u} ≌ GroupLikeSpannedCommHopfAlgCat k :=
+  (coordinateRingFunctor k).toEssImage.asEquivalence.trans
+    (ObjectProperty.fullSubcategoryCongr (essImage_coordinateRingFunctor k))
+
+/-- The forward functor of `coordinateRingEquivalence`, followed by the inclusion into all
+finite-type commutative Hopf algebras, is the coordinate-ring functor. -/
+noncomputable def coordinateRingEquivalence.functorCompιIso :
+    (coordinateRingEquivalence k).functor ⋙ (groupLikeSpannedProperty k).ι ≅
+      coordinateRingFunctor k := by
+  change (((coordinateRingFunctor k).toEssImage ⋙
+      ObjectProperty.ιOfLE (essImage_coordinateRingFunctor k).le) ⋙
+        (groupLikeSpannedProperty k).ι) ≅ coordinateRingFunctor k
+  exact Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft (coordinateRingFunctor k).toEssImage
+      (ObjectProperty.ιOfLECompιIso _) ≪≫
+    (coordinateRingFunctor k).toEssImageCompι
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
@@ -23,7 +23,7 @@ The canonical evaluation map `k[GroupLike k H] → H` is a bialgebra equivalence
 surjectivity, while linear independence of group-like elements over a field gives injectivity.
 Finite type then implies that `GroupLike k H` is finitely generated. Conversely, the standard
 basis elements of every group algebra are group-like and span, and this property is invariant
-under bialgebra equivalence.
+under coalgebra equivalence.
 
 All categories and carriers in the equivalence lie in the universe of `k`. Applying `Spec`, and
 the resulting scheme-side anti-equivalence, are outside the scope of this file.
@@ -82,8 +82,8 @@ theorem essImage_coordinateRingFunctor :
     let e' : ((coordinateRingFunctor k).obj G).obj ≅ H.obj :=
       (finiteTypeCommHopfAlgProperty k).ι.mapIso e
     apply (groupLikeSpannedProperty_iff k H).2
-    exact (TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv k
-      ((coordinateRingFunctor k).obj G) H (_root_.CommHopfAlgCat.ofIso e')).mp
+    exact (Subcoalgebra.groupLikeSetSpan_eq_top_iff_of_coalgEquiv
+      (_root_.CommHopfAlgCat.ofIso e').toCoalgEquiv).mp
         (TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top k G)
   · intro hH
     have hH' := (groupLikeSpannedProperty_iff k H).1 hH
@@ -94,7 +94,7 @@ theorem essImage_coordinateRingFunctor :
     have hspan :
         Submodule.span k
             (Set.range (_root_.GroupLike.val (R := k) (A := H))) = ⊤ :=
-      (TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_span_eq_top k H).1 hH'
+      (Subcoalgebra.groupLikeSetSpan_eq_top_iff_span_eq_top (R := k) (C := H)).1 hH'
     let e : _root_.CommHopfAlgCat.of k (_root_.MonoidAlgebra k (_root_.GroupLike k H)) ≅
         H.obj :=
       _root_.CommHopfAlgCat.isoMk

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/EssentialImage.lean
@@ -30,9 +30,6 @@ the resulting scheme-side anti-equivalence, are outside the scope of this file.
 
 ## Main declarations
 
-* `TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top`: the group-like elements of a group algebra span.
-* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv`: group-like spanning is invariant
-  under bialgebra equivalence.
 * `TauCeti.DiagonalizableGroup.groupLikeSpannedProperty`: the intrinsic object property on
   finite-type commutative Hopf algebras.
 * `TauCeti.DiagonalizableGroup.essImage_coordinateRingFunctor`: the essential image of the
@@ -41,6 +38,8 @@ the resulting scheme-side anti-equivalence, are outside the scope of this file.
   subcategory.
 * `TauCeti.DiagonalizableGroup.coordinateRingEquivalence`: the equivalence from finitely generated
   commutative groups to group-like-spanned finite-type commutative Hopf algebras.
+* `TauCeti.DiagonalizableGroup.coordinateRingEquivalence.functorCompιIso`: the forward functor of
+  the equivalence recovers the coordinate-ring functor after inclusion.
 
 ## References
 
@@ -53,109 +52,7 @@ open CategoryTheory
 
 namespace TauCeti
 
-universe u v w
-
-namespace MonoidAlgebra
-
-/-- The group-like elements of a monoid algebra span the whole algebra: every standard basis
-element is group-like, and the standard basis spans. -/
-theorem groupLikeSetSpan_eq_top (R : Type u) (G : Type v) [CommSemiring R] [Monoid G] :
-    Subcoalgebra.groupLikeSetSpan (R := R) (C := _root_.MonoidAlgebra R G) Set.univ = ⊤ := by
-  apply Subcoalgebra.ext
-  intro x
-  rw [Subcoalgebra.mem_groupLikeSetSpan]
-  constructor
-  · intro
-    exact Subcoalgebra.mem_top x
-  · intro
-    have hbasis :
-        Submodule.span R
-            (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) = ⊤ := by
-      rw [show Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R)) =
-          Set.range (_root_.MonoidAlgebra.basis G R) by
-        ext y
-        constructor <;> rintro ⟨g, rfl⟩
-        · exact ⟨g, (_root_.MonoidAlgebra.basis_apply R g).symm⟩
-        · exact ⟨g, _root_.MonoidAlgebra.basis_apply R g⟩]
-      exact (_root_.MonoidAlgebra.basis G R).span_eq
-    have hx : x ∈ Submodule.span R
-        (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) := by
-      rw [hbasis]
-      exact Submodule.mem_top
-    apply (Submodule.span_mono ?_) hx
-    rintro _ ⟨g, rfl⟩
-    exact ⟨⟨_root_.MonoidAlgebra.single g 1,
-      TauCeti.MonoidAlgebra.isGroupLikeElem_single_one R g⟩, Set.mem_univ _, rfl⟩
-
-end MonoidAlgebra
-
-namespace GroupLike
-
-/-- A bialgebra equivalence preserves the property that the group-like elements span the whole
-carrier. -/
-theorem groupLikeSetSpan_eq_top_iff_of_bialgEquiv
-    (R : Type u) (A : Type v) (B : Type w) [CommSemiring R]
-    [Semiring A] [Semiring B] [Bialgebra R A] [Bialgebra R B]
-    (e : A ≃ₐc[R] B) :
-    Subcoalgebra.groupLikeSetSpan (R := R) (C := A) Set.univ = ⊤ ↔
-      Subcoalgebra.groupLikeSetSpan (R := R) (C := B) Set.univ = ⊤ := by
-  let f : A ≃ₗ[R] B := e.toCoalgEquiv.toLinearEquiv
-  have hgroupLike :
-      f '' Set.range (_root_.GroupLike.val (R := R) (A := A)) =
-        Set.range (_root_.GroupLike.val (R := R) (A := B)) := by
-    ext b
-    constructor
-    · rintro ⟨_, ⟨g, rfl⟩, rfl⟩
-      exact ⟨⟨e g, g.isGroupLikeElem_val.map e⟩, rfl⟩
-    · rintro ⟨g, rfl⟩
-      refine ⟨e.symm (g : B), ⟨⟨e.symm (g : B), ?_⟩, rfl⟩, ?_⟩
-      · exact g.isGroupLikeElem_val.map e.symm
-      · exact e.apply_symm_apply (g : B)
-  constructor
-  · intro hA
-    have hA' :
-        Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := A))) = ⊤ := by
-      have h := congrArg Subcoalgebra.toSubmodule hA
-      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
-        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
-    have hB' :
-        Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := B))) = ⊤ := by
-      rw [← hgroupLike, Submodule.span_image_linearEquiv, hA', Submodule.map_top,
-        LinearEquiv.range]
-    apply Subcoalgebra.ext
-    intro b
-    rw [Subcoalgebra.mem_groupLikeSetSpan]
-    simp [hB']
-  · intro hB
-    have hB' :
-        Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := B))) = ⊤ := by
-      have h := congrArg Subcoalgebra.toSubmodule hB
-      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
-        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
-    have hA' :
-        Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := A))) = ⊤ := by
-      apply Submodule.map_injective_of_injective (f := f.toLinearMap) f.injective
-      calc
-        (Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := A)))).map f.toLinearMap =
-            Submodule.span R
-              (f '' Set.range (_root_.GroupLike.val (R := R) (A := A))) :=
-          Submodule.map_span f.toLinearMap _
-        _ = Submodule.span R
-              (Set.range (_root_.GroupLike.val (R := R) (A := B))) := by rw [hgroupLike]
-        _ = ⊤ := hB'
-        _ = (⊤ : Submodule R A).map f.toLinearMap := by
-          rw [Submodule.map_top, LinearEquiv.range]
-    apply Subcoalgebra.ext
-    intro a
-    rw [Subcoalgebra.mem_groupLikeSetSpan]
-    simp [hA']
-
-end GroupLike
+universe u
 
 namespace DiagonalizableGroup
 
@@ -163,7 +60,7 @@ variable (k : Type u) [Field k]
 
 /-- The object property selecting finite-type commutative Hopf algebras whose group-like elements
 span the whole carrier. -/
-@[expose] def groupLikeSpannedProperty :
+def groupLikeSpannedProperty :
     ObjectProperty (FiniteTypeCommHopfAlgCat.{u, u} k) :=
   fun H ↦ Subcoalgebra.groupLikeSetSpan (R := k) (C := H) Set.univ = ⊤
 
@@ -184,20 +81,20 @@ theorem essImage_coordinateRingFunctor :
   · rintro ⟨G, ⟨e⟩⟩
     let e' : ((coordinateRingFunctor k).obj G).obj ≅ H.obj :=
       (finiteTypeCommHopfAlgProperty k).ι.mapIso e
+    apply (groupLikeSpannedProperty_iff k H).2
     exact (TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv k
       ((coordinateRingFunctor k).obj G) H (_root_.CommHopfAlgCat.ofIso e')).mp
         (TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top k G)
   · intro hH
+    have hH' := (groupLikeSpannedProperty_iff k H).1 hH
     letI : Group.FG (_root_.GroupLike k H) :=
       TauCeti.GroupLike.fg_of_finiteType_of_groupLikeSetSpan_eq_top k H
-        (inferInstanceAs (Algebra.FiniteType k H)) hH
+        (inferInstanceAs (Algebra.FiniteType k H)) hH'
     let G : FGCommGrpCat.{u} := FGCommGrpCat.of (_root_.GroupLike k H)
     have hspan :
         Submodule.span k
-            (Set.range (_root_.GroupLike.val (R := k) (A := H))) = ⊤ := by
-      have h := congrArg Subcoalgebra.toSubmodule hH
-      simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
-        Subcoalgebra.top_toSubmodule, Set.image_univ] using h
+            (Set.range (_root_.GroupLike.val (R := k) (A := H))) = ⊤ :=
+      (TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_span_eq_top k H).1 hH'
     let e : _root_.CommHopfAlgCat.of k (_root_.MonoidAlgebra k (_root_.GroupLike k H)) ≅
         H.obj :=
       _root_.CommHopfAlgCat.isoMk
@@ -223,15 +120,23 @@ noncomputable def coordinateRingEquivalence :
   (coordinateRingFunctor k).toEssImage.asEquivalence.trans
     (ObjectProperty.fullSubcategoryCongr (essImage_coordinateRingFunctor k))
 
+/-- The forward functor of `coordinateRingEquivalence` is definitionally the composite of the
+lift to the essential image and the property-change functor. This private isomorphism isolates
+that representation boundary from the public compatibility proof. -/
+private noncomputable def coordinateRingEquivalenceFunctorIso :
+    (coordinateRingEquivalence k).functor ≅
+      (coordinateRingFunctor k).toEssImage ⋙
+        ObjectProperty.ιOfLE (essImage_coordinateRingFunctor k).le :=
+  Iso.refl _
+
 /-- The forward functor of `coordinateRingEquivalence`, followed by the inclusion into all
 finite-type commutative Hopf algebras, is the coordinate-ring functor. -/
 noncomputable def coordinateRingEquivalence.functorCompιIso :
     (coordinateRingEquivalence k).functor ⋙ (groupLikeSpannedProperty k).ι ≅
       coordinateRingFunctor k := by
-  change (((coordinateRingFunctor k).toEssImage ⋙
-      ObjectProperty.ιOfLE (essImage_coordinateRingFunctor k).le) ⋙
-        (groupLikeSpannedProperty k).ι) ≅ coordinateRingFunctor k
-  exact Functor.associator _ _ _ ≪≫
+  exact Functor.isoWhiskerRight (coordinateRingEquivalenceFunctorIso k)
+      (groupLikeSpannedProperty k).ι ≪≫
+    Functor.associator _ _ _ ≪≫
     Functor.isoWhiskerLeft (coordinateRingFunctor k).toEssImage
       (ObjectProperty.ιOfLECompιIso _) ≪≫
     (coordinateRingFunctor k).toEssImageCompι

--- a/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
@@ -10,8 +10,6 @@ public import Mathlib.RingTheory.Bialgebra.GroupLike
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.Map
 
-import Mathlib.LinearAlgebra.Span.Basic
-
 /-!
 # Evaluation of the group-like monoid algebra
 
@@ -21,8 +19,7 @@ underlying group-like element. Its linear range is exactly the span of the group
 and its subcoalgebra image is the subcoalgebra spanned by all group-like elements. The morphism is
 injective exactly when the underlying group-like elements are linearly independent, and it is a
 bialgebra equivalence when they are also spanning. Over a commutative domain, linear independence
-is automatic when the carrier of `H` is torsion-free. The spanning condition is invariant under
-bialgebra equivalence.
+is automatic when the carrier of `H` is torsion-free.
 
 ## Main declarations
 
@@ -32,10 +29,6 @@ bialgebra equivalence.
   elements.
 * `TauCeti.GroupLike.map_top_evaluationBialgHom`: its subcoalgebra image is the subcoalgebra
   spanned by all group-like elements.
-* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_span_eq_top`: the subcoalgebra and linear-span
-  formulations of spanning are equivalent.
-* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv`: group-like spanning is invariant
-  under bialgebra equivalence.
 * `TauCeti.GroupLike.evaluationBialgHom_injective_iff_linearIndependent`: injectivity is equivalent
   to linear independence of the group-like elements.
 * `TauCeti.GroupLike.evaluationBialgEquivOfLinearIndependentOfSpanEqTop`: the equivalence obtained
@@ -57,7 +50,7 @@ public section
 
 namespace TauCeti
 
-universe u v w
+universe u v
 
 namespace GroupLike
 
@@ -250,54 +243,6 @@ theorem evaluationBialgHom_surjective_iff_groupLikeSetSpan_eq_top :
     have hsubmodule := congrArg Subcoalgebra.toSubmodule h
     simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
       Subcoalgebra.top_toSubmodule, Set.image_univ] using hsubmodule
-
-/-- The group-like-set subcoalgebra is top exactly when the underlying group-like elements span
-the carrier as a module. -/
-theorem groupLikeSetSpan_eq_top_iff_span_eq_top :
-    Subcoalgebra.groupLikeSetSpan (R := R) (C := H) Set.univ = ⊤ ↔
-      Submodule.span R
-        (Set.range (_root_.GroupLike.val (R := R) (A := H))) = ⊤ :=
-  (evaluationBialgHom_surjective_iff_groupLikeSetSpan_eq_top R H).symm.trans
-    (evaluationBialgHom_surjective_iff_span_eq_top R H)
-
-/-- A bialgebra equivalence preserves the property that the group-like elements span the whole
-carrier. -/
-theorem groupLikeSetSpan_eq_top_iff_of_bialgEquiv
-    (A : Type v) (B : Type w) [Semiring A] [Semiring B] [Bialgebra R A] [Bialgebra R B]
-    (e : A ≃ₐc[R] B) :
-    Subcoalgebra.groupLikeSetSpan (R := R) (C := A) Set.univ = ⊤ ↔
-      Subcoalgebra.groupLikeSetSpan (R := R) (C := B) Set.univ = ⊤ := by
-  rw [groupLikeSetSpan_eq_top_iff_span_eq_top R A,
-    groupLikeSetSpan_eq_top_iff_span_eq_top R B]
-  let f : A ≃ₗ[R] B := e.toCoalgEquiv.toLinearEquiv
-  have hgroupLike :
-      f '' Set.range (_root_.GroupLike.val (R := R) (A := A)) =
-        Set.range (_root_.GroupLike.val (R := R) (A := B)) := by
-    ext b
-    constructor
-    · rintro ⟨_, ⟨g, rfl⟩, rfl⟩
-      exact ⟨⟨e g, g.isGroupLikeElem_val.map e⟩, rfl⟩
-    · rintro ⟨g, rfl⟩
-      refine ⟨e.symm (g : B), ⟨⟨e.symm (g : B), ?_⟩, rfl⟩, ?_⟩
-      · exact g.isGroupLikeElem_val.map e.symm
-      · exact e.apply_symm_apply (g : B)
-  constructor
-  · intro hA
-    rw [← hgroupLike, Submodule.span_image_linearEquiv, hA, Submodule.map_top,
-      LinearEquiv.range]
-  · intro hB
-    apply Submodule.map_injective_of_injective (f := f.toLinearMap) f.injective
-    calc
-      (Submodule.span R
-          (Set.range (_root_.GroupLike.val (R := R) (A := A)))).map f.toLinearMap =
-          Submodule.span R
-            (f '' Set.range (_root_.GroupLike.val (R := R) (A := A))) :=
-        Submodule.map_span f.toLinearMap _
-      _ = Submodule.span R
-            (Set.range (_root_.GroupLike.val (R := R) (A := B))) := by rw [hgroupLike]
-      _ = ⊤ := hB
-      _ = (⊤ : Submodule R A).map f.toLinearMap := by
-        rw [Submodule.map_top, LinearEquiv.range]
 
 /-- Evaluation is injective exactly when the underlying group-like elements are linearly
 independent. -/

--- a/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
+++ b/TauCeti/Algebra/Bialgebra/GroupLike/Evaluation.lean
@@ -10,6 +10,8 @@ public import Mathlib.RingTheory.Bialgebra.GroupLike
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.Map
 
+import Mathlib.LinearAlgebra.Span.Basic
+
 /-!
 # Evaluation of the group-like monoid algebra
 
@@ -19,7 +21,8 @@ underlying group-like element. Its linear range is exactly the span of the group
 and its subcoalgebra image is the subcoalgebra spanned by all group-like elements. The morphism is
 injective exactly when the underlying group-like elements are linearly independent, and it is a
 bialgebra equivalence when they are also spanning. Over a commutative domain, linear independence
-is automatic when the carrier of `H` is torsion-free.
+is automatic when the carrier of `H` is torsion-free. The spanning condition is invariant under
+bialgebra equivalence.
 
 ## Main declarations
 
@@ -29,6 +32,10 @@ is automatic when the carrier of `H` is torsion-free.
   elements.
 * `TauCeti.GroupLike.map_top_evaluationBialgHom`: its subcoalgebra image is the subcoalgebra
   spanned by all group-like elements.
+* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_span_eq_top`: the subcoalgebra and linear-span
+  formulations of spanning are equivalent.
+* `TauCeti.GroupLike.groupLikeSetSpan_eq_top_iff_of_bialgEquiv`: group-like spanning is invariant
+  under bialgebra equivalence.
 * `TauCeti.GroupLike.evaluationBialgHom_injective_iff_linearIndependent`: injectivity is equivalent
   to linear independence of the group-like elements.
 * `TauCeti.GroupLike.evaluationBialgEquivOfLinearIndependentOfSpanEqTop`: the equivalence obtained
@@ -50,7 +57,7 @@ public section
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 namespace GroupLike
 
@@ -243,6 +250,54 @@ theorem evaluationBialgHom_surjective_iff_groupLikeSetSpan_eq_top :
     have hsubmodule := congrArg Subcoalgebra.toSubmodule h
     simpa only [Subcoalgebra.groupLikeSetSpan_toSubmodule,
       Subcoalgebra.top_toSubmodule, Set.image_univ] using hsubmodule
+
+/-- The group-like-set subcoalgebra is top exactly when the underlying group-like elements span
+the carrier as a module. -/
+theorem groupLikeSetSpan_eq_top_iff_span_eq_top :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := H) Set.univ = ⊤ ↔
+      Submodule.span R
+        (Set.range (_root_.GroupLike.val (R := R) (A := H))) = ⊤ :=
+  (evaluationBialgHom_surjective_iff_groupLikeSetSpan_eq_top R H).symm.trans
+    (evaluationBialgHom_surjective_iff_span_eq_top R H)
+
+/-- A bialgebra equivalence preserves the property that the group-like elements span the whole
+carrier. -/
+theorem groupLikeSetSpan_eq_top_iff_of_bialgEquiv
+    (A : Type v) (B : Type w) [Semiring A] [Semiring B] [Bialgebra R A] [Bialgebra R B]
+    (e : A ≃ₐc[R] B) :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := A) Set.univ = ⊤ ↔
+      Subcoalgebra.groupLikeSetSpan (R := R) (C := B) Set.univ = ⊤ := by
+  rw [groupLikeSetSpan_eq_top_iff_span_eq_top R A,
+    groupLikeSetSpan_eq_top_iff_span_eq_top R B]
+  let f : A ≃ₗ[R] B := e.toCoalgEquiv.toLinearEquiv
+  have hgroupLike :
+      f '' Set.range (_root_.GroupLike.val (R := R) (A := A)) =
+        Set.range (_root_.GroupLike.val (R := R) (A := B)) := by
+    ext b
+    constructor
+    · rintro ⟨_, ⟨g, rfl⟩, rfl⟩
+      exact ⟨⟨e g, g.isGroupLikeElem_val.map e⟩, rfl⟩
+    · rintro ⟨g, rfl⟩
+      refine ⟨e.symm (g : B), ⟨⟨e.symm (g : B), ?_⟩, rfl⟩, ?_⟩
+      · exact g.isGroupLikeElem_val.map e.symm
+      · exact e.apply_symm_apply (g : B)
+  constructor
+  · intro hA
+    rw [← hgroupLike, Submodule.span_image_linearEquiv, hA, Submodule.map_top,
+      LinearEquiv.range]
+  · intro hB
+    apply Submodule.map_injective_of_injective (f := f.toLinearMap) f.injective
+    calc
+      (Submodule.span R
+          (Set.range (_root_.GroupLike.val (R := R) (A := A)))).map f.toLinearMap =
+          Submodule.span R
+            (f '' Set.range (_root_.GroupLike.val (R := R) (A := A))) :=
+        Submodule.map_span f.toLinearMap _
+      _ = Submodule.span R
+            (Set.range (_root_.GroupLike.val (R := R) (A := B))) := by rw [hgroupLike]
+      _ = ⊤ := hB
+      _ = (⊤ : Submodule R A).map f.toLinearMap := by
+        rw [Submodule.map_top, LinearEquiv.range]
 
 /-- Evaluation is injective exactly when the underlying group-like elements are linearly
 independent. -/

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -10,8 +10,6 @@ public import Mathlib.RingTheory.Spectrum.Prime.Topology
 public import Mathlib.RingTheory.TensorProduct.MonoidAlgebra
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
 
-import Mathlib.Algebra.MonoidAlgebra.Module
-
 /-!
 # Group-like elements of monoid algebras
 
@@ -67,29 +65,13 @@ private theorem eq_zero_or_eq_one_of_isIdempotentElem
 element is group-like, and the standard basis spans. -/
 theorem groupLikeSetSpan_eq_top [CommSemiring R] (G : Type v) [Monoid G] :
     Subcoalgebra.groupLikeSetSpan (R := R) (C := _root_.MonoidAlgebra R G) Set.univ = ⊤ := by
-  apply Subcoalgebra.ext
-  intro x
-  rw [Subcoalgebra.mem_groupLikeSetSpan]
-  constructor
-  · intro
-    exact Subcoalgebra.mem_top x
-  · intro
-    have hbasis :
-        Submodule.span R
-            (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) = ⊤ := by
-      rw [← Set.image_univ,
-        ← _root_.MonoidAlgebra.supported_eq_span_single R (Set.univ : Set G),
-        _root_.MonoidAlgebra.supported_eq_map, Finsupp.supported_univ, Submodule.map_top,
-        LinearEquiv.range]
-    have hx : x ∈ Submodule.span R
-        (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) := by
-      rw [hbasis]
-      exact Submodule.mem_top
-    apply (Submodule.span_mono ?_) hx
-    rintro _ ⟨g, rfl⟩
-    exact ⟨⟨_root_.MonoidAlgebra.single g 1,
-      _root_.MonoidAlgebra.isGroupLikeElem_single_one (R := R) (A := R) g⟩,
-      Set.mem_univ _, rfl⟩
+  rw [Subcoalgebra.groupLikeSetSpan_eq_top_iff_span_eq_top]
+  have hrange : Set.range (_root_.GroupLike.val (R := R) (A := _root_.MonoidAlgebra R G)) =
+      {x : _root_.MonoidAlgebra R G | IsGroupLikeElem R x} :=
+    Set.ext fun x ↦
+      ⟨fun ⟨g, hg⟩ ↦ hg ▸ g.isGroupLikeElem_val, fun hx ↦ ⟨⟨x, hx⟩, rfl⟩⟩
+  rw [hrange]
+  exact _root_.MonoidAlgebra.span_isGroupLikeElem
 
 private theorem tensorEquiv_comul_apply [CommSemiring R]
     {H : Type v} [Monoid H] [DecidableEq H]

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -78,11 +78,9 @@ theorem groupLikeSetSpan_eq_top [CommSemiring R] (G : Type v) [Monoid G] :
         Submodule.span R
             (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) = ⊤ := by
       rw [← Set.image_univ,
-        ← _root_.MonoidAlgebra.supported_eq_span_single R (Set.univ : Set G)]
-      apply top_unique
-      intro y _
-      rw [_root_.MonoidAlgebra.mem_supported]
-      exact Set.subset_univ _
+        ← _root_.MonoidAlgebra.supported_eq_span_single R (Set.univ : Set G),
+        _root_.MonoidAlgebra.supported_eq_map, Finsupp.supported_univ, Submodule.map_top,
+        LinearEquiv.range]
     have hx : x ∈ Submodule.span R
         (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) := by
       rw [hbasis]

--- a/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Bialgebra/MonoidAlgebra/GroupLike.lean
@@ -8,14 +8,18 @@ public import Mathlib.RingTheory.Bialgebra.MonoidAlgebra
 public import Mathlib.RingTheory.Coalgebra.GroupLike
 public import Mathlib.RingTheory.Spectrum.Prime.Topology
 public import Mathlib.RingTheory.TensorProduct.MonoidAlgebra
+public import TauCeti.Algebra.Coalgebra.Subcoalgebra.GroupLike
+
+import Mathlib.Algebra.MonoidAlgebra.Module
 
 /-!
 # Group-like elements of monoid algebras
 
-Over a commutative ring with connected prime spectrum, the group-like elements of a
-monoid algebra are exactly its standard basis elements. The proof compares coefficients
-in the group-like comultiplication identity. Connectedness makes every idempotent
-coefficient zero or one, and the counit condition excludes the zero element.
+The standard basis elements of a monoid algebra over a commutative semiring are group-like and
+span the whole algebra. Over a commutative ring with connected prime spectrum, these are exactly
+the group-like elements. The proof of the classification compares coefficients in the group-like
+comultiplication identity. Connectedness makes every idempotent coefficient zero or one, and the
+counit condition excludes the zero element.
 
 Consequently, a bialgebra morphism between monoid algebras over such a base uniquely
 recovers the monoid homomorphism on their standard basis indices. This gives a two-sided
@@ -23,6 +27,8 @@ inverse to `MonoidAlgebra.mapDomainBialgHom` on the corresponding hom-sets.
 
 ## Main declarations
 
+* `TauCeti.MonoidAlgebra.groupLikeSetSpan_eq_top`: the group-like elements span every monoid
+  algebra.
 * `TauCeti.MonoidAlgebra.isGroupLikeElem_iff_eq_single`: classification of group-like
   elements in a monoid algebra over a connected base.
 * `TauCeti.MonoidAlgebra.mapDomainBialgHomPreimage`: recover the monoid homomorphism
@@ -56,6 +62,36 @@ private theorem eq_zero_or_eq_one_of_isIdempotentElem
     apply PrimeSpectrum.basicOpen_injOn_isIdempotentElem he .one
     apply SetLike.ext'
     simpa only [PrimeSpectrum.basicOpen_one, TopologicalSpace.Opens.coe_top] using huniv
+
+/-- The group-like elements of a monoid algebra span the whole algebra: every standard basis
+element is group-like, and the standard basis spans. -/
+theorem groupLikeSetSpan_eq_top [CommSemiring R] (G : Type v) [Monoid G] :
+    Subcoalgebra.groupLikeSetSpan (R := R) (C := _root_.MonoidAlgebra R G) Set.univ = ⊤ := by
+  apply Subcoalgebra.ext
+  intro x
+  rw [Subcoalgebra.mem_groupLikeSetSpan]
+  constructor
+  · intro
+    exact Subcoalgebra.mem_top x
+  · intro
+    have hbasis :
+        Submodule.span R
+            (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) = ⊤ := by
+      rw [← Set.image_univ,
+        ← _root_.MonoidAlgebra.supported_eq_span_single R (Set.univ : Set G)]
+      apply top_unique
+      intro y _
+      rw [_root_.MonoidAlgebra.mem_supported]
+      exact Set.subset_univ _
+    have hx : x ∈ Submodule.span R
+        (Set.range (fun g : G ↦ _root_.MonoidAlgebra.single g (1 : R))) := by
+      rw [hbasis]
+      exact Submodule.mem_top
+    apply (Submodule.span_mono ?_) hx
+    rintro _ ⟨g, rfl⟩
+    exact ⟨⟨_root_.MonoidAlgebra.single g 1,
+      _root_.MonoidAlgebra.isGroupLikeElem_single_one (R := R) (A := R) g⟩,
+      Set.mem_univ _, rfl⟩
 
 private theorem tensorEquiv_comul_apply [CommSemiring R]
     {H : Type v} [Monoid H] [DecidableEq H]

--- a/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
+++ b/TauCeti/Algebra/Coalgebra/Subcoalgebra/GroupLike.lean
@@ -8,12 +8,18 @@ public import Mathlib.RingTheory.Coalgebra.GroupLike
 public import Mathlib.RingTheory.Finiteness.Basic
 public import TauCeti.Algebra.Coalgebra.Subcoalgebra.Basic
 
+import Mathlib.LinearAlgebra.Span.Basic
+
 /-!
 # Subcoalgebras spanned by group-like elements
 
 This file defines the subcoalgebra spanned by a set of group-like elements, together with the
 singleton span, a finite-generation theorem for finite sets of group-like elements, and a
 `Module.Finite` instance for singleton spans.
+
+The subcoalgebra spanned by all group-like elements is the full subcoalgebra exactly when the
+group-like elements span the carrier as a module, a condition invariant under coalgebra
+equivalence.
 
 ## References
 
@@ -27,7 +33,7 @@ open scoped TensorProduct
 
 namespace TauCeti
 
-universe u v
+universe u v w
 
 variable (R : Type u) (C : Type v)
 variable [CommSemiring R] [AddCommMonoid C] [Module R C] [Coalgebra R C]
@@ -105,6 +111,40 @@ theorem groupLikeSetSpan_mono {s t : Set (GroupLike R C)} (hst : s ⊆ t) :
   rw [groupLikeSetSpan_le]
   intro g hg
   exact groupLike_mem_groupLikeSetSpan (R := R) (C := C) (hst hg)
+
+/-- The subcoalgebra spanned by all group-like elements is the full subcoalgebra exactly when the
+underlying group-like elements span the carrier as a module. -/
+theorem groupLikeSetSpan_eq_top_iff_span_eq_top :
+    groupLikeSetSpan (R := R) (C := C) Set.univ = ⊤ ↔
+      Submodule.span R (Set.range (GroupLike.val (R := R) (A := C))) = ⊤ := by
+  constructor
+  · intro h
+    rw [← Set.image_univ, ← groupLikeSetSpan_toSubmodule (R := R) (C := C) Set.univ, h,
+      top_toSubmodule]
+  · intro h
+    ext c
+    rw [mem_groupLikeSetSpan, Set.image_univ, h]
+    simp only [Submodule.mem_top, mem_top]
+
+/-- A coalgebra equivalence preserves the property that the group-like elements span the whole
+carrier. -/
+theorem groupLikeSetSpan_eq_top_iff_of_coalgEquiv {D : Type w} [AddCommMonoid D] [Module R D]
+    [Coalgebra R D] (e : C ≃ₗc[R] D) :
+    groupLikeSetSpan (R := R) (C := C) Set.univ = ⊤ ↔
+      groupLikeSetSpan (R := R) (C := D) Set.univ = ⊤ := by
+  rw [groupLikeSetSpan_eq_top_iff_span_eq_top (R := R) (C := C),
+    groupLikeSetSpan_eq_top_iff_span_eq_top (R := R) (C := D)]
+  have hgroupLike :
+      (e : C ≃ₗ[R] D) '' Set.range (GroupLike.val (R := R) (A := C)) =
+        Set.range (GroupLike.val (R := R) (A := D)) := by
+    ext d
+    constructor
+    · rintro ⟨_, ⟨g, rfl⟩, rfl⟩
+      exact ⟨⟨e g, g.isGroupLikeElem_val.map e⟩, rfl⟩
+    · rintro ⟨g, rfl⟩
+      exact ⟨e.symm (g : D), ⟨⟨e.symm (g : D), g.isGroupLikeElem_val.map e.symm⟩, rfl⟩,
+        e.apply_symm_apply (g : D)⟩
+  rw [← hgroupLike, Submodule.span_image_linearEquiv, Submodule.map_eq_top_iff]
 
 /-- The subcoalgebra spanned by a group-like element. -/
 def groupLikeSpan (g : GroupLike R C) : Subcoalgebra R C :=


### PR DESCRIPTION
This PR characterizes the essential image of the finite-type diagonalizable coordinate-ring functor over a field as the finite-type commutative Hopf algebras whose group-like elements span the carrier, and packages the resulting same-universe equivalence with that intrinsic full subcategory. It advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 4, the “Diagonalizable groups and groups of multiplicative type” item specifying the anti-equivalence `M ↦ D(M) = Spec k[M]` between finitely generated abelian groups and diagonalizable groups.

For the forward direction, standard basis elements of a group algebra are group-like and span, with the property transported across bialgebra equivalences. For the reverse direction, the existing finite-generation theorem makes the group-like group finitely generated, and the existing evaluation bialgebra equivalence identifies its group algebra with the original Hopf algebra. The categorical result then reuses the fully faithful essential-image equivalence and full-subcategory transport, leaving the already implemented scheme functor unchanged.

The mathematical characterization follows Milne, *Algebraic Groups*, Proposition 4.23 and Definition 12.7 with Theorems 12.8–12.9. No Mathlib infrastructure is copied or adapted.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-essential-image"}-->

🤖 Prepared with Codex
