### PR TITLE
style(UniversalCover): pack underfilled signature lines

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -57,14 +57,12 @@ instance : SMul (FundamentalGroup X x₀) (UniversalCover x₀) where
 
 /-- The fundamental-group action prepends the inverse loop class to a representative path. -/
 @[simp]
-theorem smul_mk (g : FundamentalGroup X x₀) (x : X)
-    (q : Path.Homotopic.Quotient x₀ x) :
+theorem smul_mk (g : FundamentalGroup X x₀) (x : X) (q : Path.Homotopic.Quotient x₀ x) :
     g • mk x q = mk x (g⁻¹.toPath.trans q) :=
   rfl
 
 /-- Acting by an inverse prepends the corresponding loop class without an inverse. -/
-theorem inv_smul_mk (g : FundamentalGroup X x₀) (x : X)
-    (q : Path.Homotopic.Quotient x₀ x) :
+theorem inv_smul_mk (g : FundamentalGroup X x₀) (x : X) (q : Path.Homotopic.Quotient x₀ x) :
     g⁻¹ • mk x q = mk x (g.toPath.trans q) := by
   rw [smul_mk, inv_inv]
 
@@ -153,8 +151,7 @@ theorem proj_surjective [PathConnectedSpace X] :
   ⟨mk x (Path.Homotopic.Quotient.mk (PathConnectedSpace.somePath x₀ x)), rfl⟩
 
 /-- The endpoint projection is a quotient covering map for the fundamental-group action. -/
-theorem isQuotientCoveringMap
-    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+theorem isQuotientCoveringMap [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] :
     IsQuotientCoveringMap (proj : UniversalCover x₀ → X) (FundamentalGroup X x₀) := by
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]

--- a/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/AddCircle.lean
@@ -179,14 +179,12 @@ noncomputable def addCircleMulEquivInt [PreconnectedSpace 𝕜]
 @[simp]
 theorem addCircleMulEquivInt_apply [PreconnectedSpace 𝕜]
     [TotallyDisconnectedSpace (zmultiples p)] (hp : ¬ IsOfFinAddOrder p) (a : Multiplicative ℤ)
-    (e : 𝕜) :
-    (addCircleMulEquivInt hp a).1 e = e + a.toAdd • p := by
+    (e : 𝕜) : (addCircleMulEquivInt hp a).1 e = e + a.toAdd • p := by
   simp [addCircleMulEquivInt]
 
 theorem addCircleMulEquivInt_symm_zsmul_apply_zero [PreconnectedSpace 𝕜]
     [TotallyDisconnectedSpace (zmultiples p)] (hp : ¬ IsOfFinAddOrder p)
-    (φ : Deck ((↑) : 𝕜 → AddCircle p)) :
-    ((addCircleMulEquivInt hp).symm φ).toAdd • p = φ.1 0 := by
+    (φ : Deck ((↑) : 𝕜 → AddCircle p)) : ((addCircleMulEquivInt hp).symm φ).toAdd • p = φ.1 0 := by
   have happly :=
     addCircleMulEquivInt_apply hp ((addCircleMulEquivInt hp).symm φ) (0 : 𝕜)
   have hzero := congrArg (fun ψ : Deck ((↑) : 𝕜 → AddCircle p) => ψ.1 0)

--- a/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/BasedPath.lean
@@ -91,8 +91,7 @@ right endpoint cast to `endpoint (ofPath γ)` (`toPath_ofPath`). -/
 @[simp] public theorem endpoint_refl (x₀ : X) : endpoint (refl x₀) = x₀ :=
   endpoint_ofPath _
 
-@[simp] public theorem toPath_refl (x₀ : X) :
-    (refl x₀).toPath = Path.refl x₀ := by
+@[simp] public theorem toPath_refl (x₀ : X) : (refl x₀).toPath = Path.refl x₀ := by
   apply Path.ext; funext t; rfl
 
 @[simp] public theorem ofPath_refl (x₀ : X) :
@@ -132,8 +131,7 @@ private noncomputable def terminalTail {u : X} (γ : BasedPath x₀)
 
 /-- Replace the terminal interval of a based path by first traversing a compressed tail of the
 original path and then a new endpoint path. -/
-private noncomputable def deformTerminal {u v : X} (γ : BasedPath x₀)
-    (hu : endpoint γ = u)
+private noncomputable def deformTerminal {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
     (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) : BasedPath x₀ := by
   let tail : Path (γ.toPath.extend a) u := terminalTail γ hu a (by linarith)
   let f : ℝ → X := fun t ↦
@@ -177,21 +175,18 @@ private theorem deformTerminal_apply {u v : X} (γ : BasedPath x₀) (hu : endpo
   rfl
 
 private theorem deformTerminal_apply_of_le {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
-    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
-    (t : I) (ht : (t : ℝ) ≤ a) :
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) (t : I) (ht : (t : ℝ) ≤ a) :
     (deformTerminal γ hu δ ha hab hb).1 t = γ.toPath.extend t := by
   rw [deformTerminal_apply, dif_pos ht]
 
 private theorem deformTerminal_apply_of_lt_of_le {u v : X} (γ : BasedPath x₀)
     (hu : endpoint γ = u) (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
-    (t : I) (hta : a < (t : ℝ)) (htb : (t : ℝ) ≤ b) :
-    (deformTerminal γ hu δ ha hab hb).1 t =
+    (t : I) (hta : a < (t : ℝ)) (htb : (t : ℝ) ≤ b) : (deformTerminal γ hu δ ha hab hb).1 t =
       (terminalTail γ hu a (by linarith)).extend (((t : ℝ) - a) / (b - a)) := by
   rw [deformTerminal_apply, dif_neg (not_le_of_gt hta), dif_pos htb]
 
 private theorem deformTerminal_apply_of_lt {u v : X} (γ : BasedPath x₀) (hu : endpoint γ = u)
-    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1)
-    (t : I) (ht : b < (t : ℝ)) :
+    (δ : Path u v) {a b : ℝ} (ha : 0 ≤ a) (hab : a < b) (hb : b < 1) (t : I) (ht : b < (t : ℝ)) :
     (deformTerminal γ hu δ ha hab hb).1 t = δ.extend (((t : ℝ) - b) / (1 - b)) := by
   rw [deformTerminal_apply, dif_neg (not_le_of_gt (lt_trans hab ht)), dif_neg (not_le_of_gt ht)]
 
@@ -227,8 +222,7 @@ subbasic compact sets that do not contain `1`. -/
 theorem exists_endpointNeighborhood_of_basicNeighborhood [LocallyPathConnectedSpace X]
     {x₀ : X} (γ : BasedPath x₀) (Tgood Tbad : Finset (Set I × Set X))
     (hTgood_open_mem : ∀ KU ∈ Tgood, IsOpen KU.2 ∧ endpoint γ ∈ KU.2)
-    (hTbad_closed : ∀ KU ∈ Tbad, IsClosed KU.1)
-    (hTbad_not_mem : ∀ KU ∈ Tbad, (1 : I) ∉ KU.1) :
+    (hTbad_closed : ∀ KU ∈ Tbad, IsClosed KU.1) (hTbad_not_mem : ∀ KU ∈ Tbad, (1 : I) ∉ KU.1) :
     ∃ (W : Set X) (a₀ : I) (a b : ℝ),
       IsOpen W ∧ endpoint γ ∈ W ∧ IsPathConnected W ∧
       (∀ KU ∈ Tgood, W ⊆ KU.2) ∧
@@ -271,8 +265,7 @@ given that the terminal interval `Set.Ioc a₀ 1` maps into `W` under `γ.toPath
 `a₀ < a` (`ha₀_lt_a`) and that `a ≤ 1` (`ha1`). The tail retraces `γ` over `[a, 1]`, and every
 such time already lies in `Set.Ioc a₀ 1`, so its image lies in `W`. -/
 private theorem terminalTail_range_subset (γ : BasedPath x₀) {W : Set X} {a₀ : I} {a : ℝ}
-    (hpreim : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W)
-    (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha1 : a ≤ 1) :
+    (hpreim : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W) (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha1 : a ≤ 1) :
     Set.range (terminalTail γ rfl a ha1) ⊆ W := by
   apply Path.truncateOfLE_range_subset (h := ha1)
   intro s hs
@@ -336,14 +329,12 @@ every `Tgood` target; `hIoc` places `Set.Ioc a₀ 1` inside `γ.toPath ⁻¹' W`
 and for `a < t` the pair is forced to be `Tgood`, so the value lies in `W ⊆ U`. -/
 private theorem mapsTo_deformTerminal {v : X} (γ : BasedPath x₀) (δ : Path (endpoint γ) v)
     {S : Set (Set I × Set X)} {T Tgood Tbad : Finset (Set I × Set X)}
-    (hT_of_S : ∀ KU, KU ∈ S → KU ∈ T)
-    (hTgood_iff : ∀ KU, KU ∈ Tgood ↔ KU ∈ T ∧ (1 : I) ∈ KU.1)
+    (hT_of_S : ∀ KU, KU ∈ S → KU ∈ T) (hTgood_iff : ∀ KU, KU ∈ Tgood ↔ KU ∈ T ∧ (1 : I) ∈ KU.1)
     (hTbad_iff : ∀ KU, KU ∈ Tbad ↔ KU ∈ T ∧ (1 : I) ∉ KU.1)
     {W : Set X} (hW_good : ∀ KU ∈ Tgood, W ⊆ KU.2) {a₀ : I} {a b : ℝ}
     (hIoc : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ)
     (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha0 : 0 ≤ a) (ha1 : a ≤ 1) (hab : a < b) (hb1 : b < 1)
-    (hδW : Set.range δ ⊆ W) {K : Set I} {U : Set X} (hKU : (K, U) ∈ S)
-    (hγKU : Set.MapsTo γ.1 K U) :
+    (hδW : Set.range δ ⊆ W) {K : Set I} {U : Set X} (hKU : (K, U) ∈ S) (hγKU : Set.MapsTo γ.1 K U) :
     Set.MapsTo (deformTerminal γ rfl δ ha0 hab hb1).1 K U := by
   classical
   have htail : Set.range (terminalTail γ rfl a ha1) ⊆ W :=
@@ -373,8 +364,7 @@ theorem exists_deformTerminal_mem_basicNeighborhood
     (hTgood_iff : ∀ KU, KU ∈ Tgood ↔ KU ∈ T ∧ (1 : I) ∈ KU.1)
     (hTbad_iff : ∀ KU, KU ∈ Tbad ↔ KU ∈ T ∧ (1 : I) ∉ KU.1)
     {W : Set X} (huW : endpoint γ ∈ W) (hWpath : IsPathConnected W)
-    (hW_good : ∀ KU ∈ Tgood, W ⊆ KU.2)
-    {a₀ : I} {a b : ℝ}
+    (hW_good : ∀ KU ∈ Tgood, W ⊆ KU.2) {a₀ : I} {a b : ℝ}
     (hIoc : Set.Ioc a₀ 1 ⊆ γ.toPath ⁻¹' W ∩ ⋂ KU ∈ Tbad, KU.1ᶜ)
     (ha₀_lt_a : ((a₀ : I) : ℝ) < a) (ha0 : 0 ≤ a) (ha1 : a ≤ 1) (hab : a < b) (hb1 : b < 1) :
     ∀ v ∈ W, ∃ η : BasedPath x₀, η.1 ∈ V ∧ endpoint η = v := by
@@ -498,10 +488,8 @@ public theorem joinedIn_preimage_of_append {U : Set X} {z : X} (γ : BasedPath x
     exact hδU ⟨t, rfl⟩
   exact h_start.trans h_move
 
-theorem exists_refined_terminal_vertex
-    [LocallyPathConnectedSpace X]
-    {x₀ : X} {n' : ℕ} {U : Set X} (hU_open : IsOpen U)
-    (α : BasedPath x₀) (hα : endpoint α ∈ U)
+theorem exists_refined_terminal_vertex [LocallyPathConnectedSpace X]
+    {x₀ : X} {n' : ℕ} {U : Set X} (hU_open : IsOpen U) (α : BasedPath x₀) (hα : endpoint α ∈ U)
     (part : IntervalPartition (n' + 1)) (T : TubeData X (n' + 1))
     (hα_tube : PathInTube α.toPath part T) :
     ∃ V_last' : Set X,
@@ -520,8 +508,7 @@ theorem exists_refined_terminal_vertex
   · exact pathComponentIn_subset.trans Set.inter_subset_left
   · exact pathComponentIn_subset.trans Set.inter_subset_right
 
-theorem isOpen_refined_tubeNeighborhood
-    {x₀ : X} {n' : ℕ} (part : IntervalPartition (n' + 1))
+theorem isOpen_refined_tubeNeighborhood {x₀ : X} {n' : ℕ} (part : IntervalPartition (n' + 1))
     {U : Fin (n' + 1) → Set X} {V : Fin (n' + 2) → Set X}
     (hU_open : ∀ i, IsOpen (U i)) (hV_open : ∀ j, IsOpen (V j)) :
     IsOpen {β : BasedPath x₀ |
@@ -564,8 +551,7 @@ smaller `V_last'` that is itself open, path-connected and contains `endpoint α`
 family is again open and path-connected, is contained in `T.V` pointwise, and `α` still passes
 through it at every partition point. -/
 private theorem exists_refined_vertex_family {n' : ℕ} {part : IntervalPartition (n' + 1)}
-    {T : TubeData X (n' + 1)} {α : BasedPath x₀}
-    (hα_passes : ∀ j, α.toPath (part.t j) ∈ T.V j)
+    {T : TubeData X (n' + 1)} {α : BasedPath x₀} (hα_passes : ∀ j, α.toPath (part.t j) ∈ T.V j)
     {V_last' : Set X} (hV'_open : IsOpen V_last') (hV'_pathConn : IsPathConnected V_last')
     (hα_V' : endpoint α ∈ V_last') (hV'_sub_V : V_last' ⊆ T.V (Fin.last (n' + 1))) :
     ∃ V' : Fin (n' + 2) → Set X,
@@ -602,8 +588,7 @@ private theorem joinedIn_endpoint_preimage_of_pathInTube {n' : ℕ} {U : Set X}
     (hV'_last_sub_U : V' (Fin.last (n' + 1)) ⊆ U) {α β : BasedPath x₀}
     (hα_stays : ∀ (i : Fin (n' + 1)) (s : I),
       (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → α.toPath s ∈ T.U i)
-    (hα_passes : ∀ j, α.toPath (part.t j) ∈ V' j)
-    (hβ_stays : ∀ (i : Fin (n' + 1)) (s : I),
+    (hα_passes : ∀ j, α.toPath (part.t j) ∈ V' j) (hβ_stays : ∀ (i : Fin (n' + 1)) (s : I),
       (part.t i.castSucc : ℝ) ≤ s ∧ s ≤ (part.t i.succ : ℝ) → β.1 s ∈ T.U i)
     (hβ_passes : ∀ j, β.1 (part.t j) ∈ V' j) :
     JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β := by
@@ -791,8 +776,7 @@ private theorem joinedInSLSC_uFn_zero_left_eq_two_mul_sub_one_of_half_le
   Subtype.ext <| by
     rw [joinedInSLSC_uFn_zero_left, max_eq_right (by linarith)]
 
-private theorem joinedInSLSC_vFn_eq_two_mul_of_le_half {t s : I}
-    (hs : (s : ℝ) ≤ 1 / 2) :
+private theorem joinedInSLSC_vFn_eq_two_mul_of_le_half {t s : I} (hs : (s : ℝ) ≤ 1 / 2) :
     joinedInSLSC_vFn (t, s) =
       ⟨2 * (s : ℝ),
         (unitInterval.mul_pos_mem_iff zero_lt_two).2 ⟨s.2.1, hs⟩⟩ :=
@@ -813,10 +797,8 @@ This is the heart of the sheet-injectivity argument: a path in the based-path sp
 to a free homotopy of paths in `X` whose endpoint trace is a loop in `U`, which is killed by
 the SLSC hypothesis. -/
 public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
-    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U)
-    {α β : BasedPath x₀}
-    (heq : endpoint α = endpoint β)
-    (hAB : JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β) :
+    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U) {α β : BasedPath x₀}
+    (heq : endpoint α = endpoint β) (hAB : JoinedIn (endpoint (x₀ := x₀) ⁻¹' U) α β) :
     Path.Homotopic (α.toPath.cast rfl heq.symm) β.toPath := by
   obtain ⟨F, hF_U⟩ := hAB
   set v : X := endpoint β with hv_def
@@ -870,8 +852,7 @@ public theorem toPath_homotopic_of_joinedIn_pathHomotopyTrivial
 /-- Path components of `endpoint ⁻¹' U` are invariant under endpoint-preserving homotopy:
 if `p ≃ q` are homotopic paths from `x₀` to `y ∈ U`, then the based paths `ofPath p` and
 `ofPath q` lie in the same path component of `endpoint ⁻¹' U`. -/
-public theorem pathComponentIn_ofPath_eq_of_homotopic
-    {U : Set X} {y : X} (hy : y ∈ U)
+public theorem pathComponentIn_ofPath_eq_of_homotopic {U : Set X} {y : X} (hy : y ∈ U)
     {p q : Path x₀ y} (h : Path.Homotopic p q) :
     pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath p) =
       pathComponentIn (endpoint (x₀ := x₀) ⁻¹' U) (ofPath q) :=

--- a/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Basic.lean
@@ -212,8 +212,7 @@ noncomputable def sheet (U : Set X) (hxU : x ∈ U)
   ofBasedPath x₀ '' basedPathSheet U hxU q
 
 /-- Points of the sheet over `U` project into `U`. -/
-theorem sheet_subset_proj_preimage (U : Set X) (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) :
+theorem sheet_subset_proj_preimage (U : Set X) (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
     sheet U hxU q ⊆ proj (x₀ := x₀) ⁻¹' U := by
   rintro _ ⟨α, hα, rfl⟩
   rw [Set.mem_preimage, proj_ofBasedPath]
@@ -222,10 +221,8 @@ theorem sheet_subset_proj_preimage (U : Set X) (hxU : x ∈ U)
 /-- Two based paths with equal `ofBasedPath` images lie in the same path component of any
 endpoint preimage of a set containing their common endpoint. This expresses saturation under
 the quotient map `ofBasedPath`. -/
-private theorem pathComponent_preimage_eq_of_ofBasedPath_eq
-    {U : Set X} {α β : BasedPath x₀}
-    (hα_end : BasedPath.endpoint α ∈ U)
-    (hαβ : ofBasedPath x₀ α = ofBasedPath x₀ β) :
+private theorem pathComponent_preimage_eq_of_ofBasedPath_eq {U : Set X} {α β : BasedPath x₀}
+    (hα_end : BasedPath.endpoint α ∈ U) (hαβ : ofBasedPath x₀ α = ofBasedPath x₀ β) :
     pathComponentIn (BasedPath.endpoint (x₀ := x₀) ⁻¹' U) α =
       pathComponentIn (BasedPath.endpoint (x₀ := x₀) ⁻¹' U) β := by
   have hβ_end : BasedPath.endpoint β ∈ U :=
@@ -249,8 +246,7 @@ private theorem mem_basedPathComponent_of_ofBasedPath_eq {U : Set X} {y : X} {p 
 
 /-- The preimage of a sheet under `ofBasedPath` is the corresponding `basedPathSheet`.
 This expresses that the sheet is saturated under the `ofBasedPath` quotient. -/
-theorem ofBasedPath_preimage_sheet (U : Set X) (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) :
+theorem ofBasedPath_preimage_sheet (U : Set X) (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
     ofBasedPath x₀ ⁻¹' sheet U hxU q = basedPathSheet U hxU q := by
   apply Set.Subset.antisymm
   · intro α hα
@@ -271,8 +267,7 @@ itself lies in the corresponding `basedPathSheet`. -/
 
 /-- A sheet over an open set is open under the local hypotheses for universal covers. -/
 theorem isOpen_sheet [LocallyPathConnectedSpace X] [SemilocallySimplyConnectedSpace X]
-    (U : Set X) (hU_open : IsOpen U) (hxU : x ∈ U)
-    (q : Path.Homotopic.Quotient x₀ x) :
+    (U : Set X) (hU_open : IsOpen U) (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
     IsOpen (sheet U hxU q) := by
   rw [(isQuotientMap_ofBasedPath x₀).isOpen_preimage.symm]
   rw [ofBasedPath_preimage_sheet]
@@ -286,8 +281,7 @@ theorem mem_sheet_self {U : Set X} (hxU : x ∈ U) (p : Path x₀ x) :
     (by simpa using hxU), rfl⟩
 
 /-- Sheet surjection onto `U`: every point of `U` is the projection of a point of the sheet. -/
-theorem proj_surjOn_sheet
-    {U : Set X} (hU_pathConn : IsPathConnected U)
+theorem proj_surjOn_sheet {U : Set X} (hU_pathConn : IsPathConnected U)
     (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
     (sheet U hxU q).SurjOn (proj (x₀ := x₀)) U := by
   intro v hvU
@@ -310,8 +304,7 @@ theorem proj_surjOn_sheet
 
 /-- Sheets over the same good neighborhood, indexed by `Path.Homotopic.Quotient`, are pairwise
 disjoint. -/
-theorem pairwise_disjoint_sheet
-    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U) (hxU : x ∈ U) :
+theorem pairwise_disjoint_sheet {U : Set X} (hU_slsc : IsPathHomotopyTrivial U) (hxU : x ∈ U) :
     Pairwise fun (q₁ q₂ : Path.Homotopic.Quotient x₀ x) ↦
       Disjoint (sheet U hxU q₁) (sheet U hxU q₂) := by
   intro q₁ q₂ hne
@@ -339,9 +332,7 @@ theorem pairwise_disjoint_sheet
       exact eq_of_heq ((UniversalCover.mk.injEq _ _ _ _).mp h_uc_eq).2
 
 /-- Sheets exhaust `proj ⁻¹' U`: every element of the preimage lies in some sheet. -/
-theorem sheet_exhaustive
-    {U : Set X} (hU_pathConn : IsPathConnected U)
-    (hxU : x ∈ U) :
+theorem sheet_exhaustive {U : Set X} (hU_pathConn : IsPathConnected U) (hxU : x ∈ U) :
     (proj (x₀ := x₀) ⁻¹' U) ⊆ ⋃ q : Path.Homotopic.Quotient x₀ x, sheet U hxU q := by
   intro e he
   obtain ⟨α, rfl⟩ := surjective_ofBasedPath x₀ e
@@ -361,10 +352,8 @@ theorem sheet_exhaustive
   exact ⟨α, h_join.symm, rfl⟩
 
 /-- In a good neighborhood `U`, the projection `proj` is injective on each sheet. -/
-theorem proj_injOn_sheet
-    {U : Set X} (hU_slsc : IsPathHomotopyTrivial U)
-    (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) :
-    (sheet U hxU q).InjOn (proj (x₀ := x₀)) := by
+theorem proj_injOn_sheet {U : Set X} (hU_slsc : IsPathHomotopyTrivial U)
+    (hxU : x ∈ U) (q : Path.Homotopic.Quotient x₀ x) : (sheet U hxU q).InjOn (proj (x₀ := x₀)) := by
   rintro _ ⟨α₁, hα₁, rfl⟩ _ ⟨α₂, hα₂, rfl⟩ h_proj
   rw [proj_ofBasedPath, proj_ofBasedPath] at h_proj
   induction q using Quotient.inductionOn with

--- a/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Circle/FundamentalGroup.lean
@@ -70,8 +70,7 @@ variable {𝕜 : Type*} [AddCommGroup 𝕜] [TopologicalSpace 𝕜] [IsTopologic
 /-- For a covering projection `(↑) : 𝕜 → AddCircle p` from a simply connected preconnected
 topological additive commutative group with totally disconnected period subgroup, the
 fundamental group of `AddCircle p` is the multiplicative period subgroup. -/
-noncomputable def fundamentalGroupMulEquivZMultiples
-    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+noncomputable def fundamentalGroupMulEquivZMultiples (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) :
     FundamentalGroup (AddCircle p) x ≃* Multiplicative (zmultiples p) :=
   (Deck.IsRegular.fundamentalGroupEquiv Deck.isRegular_addCircleCoe hcov e).trans
@@ -88,8 +87,7 @@ private lemma addCircleMulEquiv_symm_addRightZMultiples (n : Multiplicative (zmu
 omit [SimplyConnectedSpace 𝕜] in
 variable [PreconnectedSpace 𝕜] in
 private lemma fundamentalGroupMulEquivZMultiples_toPeriod_symm_apply
-    (n : Multiplicative (zmultiples p)) :
-    (((MulEquiv.op Deck.addCircleMulEquiv.symm).trans
+    (n : Multiplicative (zmultiples p)) : (((MulEquiv.op Deck.addCircleMulEquiv.symm).trans
       (MulOpposite.opMulEquiv (M := Multiplicative (zmultiples p))).symm).symm n) =
         MulOpposite.op (Deck.addCircleMulEquiv n) := by
   simp
@@ -97,8 +95,7 @@ private lemma fundamentalGroupMulEquivZMultiples_toPeriod_symm_apply
 /-- Characterization of the period-subgroup element assigned by
 `fundamentalGroupMulEquivZMultiples`: a loop class maps to `n` exactly when its monodromy
 translate of the chosen lift differs by the element `n`. -/
-lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff
-    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+lemma fundamentalGroupMulEquivZMultiples_apply_eq_iff (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
     {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
     (γ : FundamentalGroup (AddCircle p) x) (n : Multiplicative (zmultiples p)) :
     fundamentalGroupMulEquivZMultiples hcov e γ = n ↔
@@ -132,8 +129,7 @@ translates the chosen lift by `n`. -/
 @[simp]
 lemma fundamentalGroupMulEquivZMultiples_symm_monodromy
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
-    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
-    (n : Multiplicative (zmultiples p)) :
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (n : Multiplicative (zmultiples p)) :
     (hcov.monodromy ((fundamentalGroupMulEquivZMultiples hcov e).symm n) e : 𝕜) =
       (e : 𝕜) + (n.toAdd : 𝕜) := by
   exact (fundamentalGroupMulEquivZMultiples_apply_eq_iff hcov e
@@ -142,10 +138,8 @@ lemma fundamentalGroupMulEquivZMultiples_symm_monodromy
 
 /-- A loop class maps to `1` under the period-subgroup equivalence exactly when its monodromy
 fixes the chosen lift. -/
-lemma fundamentalGroupMulEquivZMultiples_eq_one_iff
-    (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
-    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
-    (γ : FundamentalGroup (AddCircle p) x) :
+lemma fundamentalGroupMulEquivZMultiples_eq_one_iff (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p))
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x) :
     fundamentalGroupMulEquivZMultiples hcov e γ = 1 ↔ hcov.monodromy γ e = e := by
   rw [fundamentalGroupMulEquivZMultiples_apply_eq_iff]
   simpa using (Iff.symm Subtype.ext_iff :
@@ -190,8 +184,7 @@ lemma fundamentalGroupMulEquivInt_symm_monodromy
 fixes the chosen lift. -/
 lemma fundamentalGroupMulEquivInt_eq_one_iff
     (hcov : IsCoveringMap ((↑) : 𝕜 → AddCircle p)) (hp : ¬ IsOfFinAddOrder p)
-    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x})
-    (γ : FundamentalGroup (AddCircle p) x) :
+    {x : AddCircle p} (e : ((↑) : 𝕜 → AddCircle p) ⁻¹' {x}) (γ : FundamentalGroup (AddCircle p) x) :
     fundamentalGroupMulEquivInt hcov hp e γ = 1 ↔ hcov.monodromy γ e = e := by
   rw [fundamentalGroupMulEquivInt_apply_eq_iff]
   simpa using (Iff.symm Subtype.ext_iff :
@@ -251,8 +244,7 @@ lemma fundamentalGroupMulEquiv_zero_apply_eq_iff (hp : p ≠ 0)
   simpa using fundamentalGroupMulEquiv_apply_eq_iff p hp ⟨0, by simp⟩ γ n
 
 @[simp]
-lemma fundamentalGroupMulEquiv_zero_apply (hp : p ≠ 0)
-    (γ : FundamentalGroup (AddCircle p) 0) :
+lemma fundamentalGroupMulEquiv_zero_apply (hp : p ≠ 0) (γ : FundamentalGroup (AddCircle p) 0) :
     fundamentalGroupMulEquiv_zero p hp γ = fundamentalGroupMulEquiv p hp ⟨0, by simp⟩ γ := by
   apply (fundamentalGroupMulEquiv_zero_apply_eq_iff p hp γ _).2
   simpa using (fundamentalGroupMulEquiv_apply_eq_iff p hp ⟨0, by simp⟩ γ _).1 rfl
@@ -273,8 +265,7 @@ lemma fundamentalGroupMulEquiv_zero_symm_monodromy (hp : p ≠ 0) (n : Multiplic
 
 /-- A loop class maps to `1` under the basepoint-`0` specialization exactly when its monodromy
 fixes the zero lift. -/
-lemma fundamentalGroupMulEquiv_zero_eq_one_iff (hp : p ≠ 0)
-    (γ : FundamentalGroup (AddCircle p) 0) :
+lemma fundamentalGroupMulEquiv_zero_eq_one_iff (hp : p ≠ 0) (γ : FundamentalGroup (AddCircle p) 0) :
     fundamentalGroupMulEquiv_zero p hp γ = 1 ↔
       (AddCircle.isCoveringMap_coe p).monodromy γ ⟨0, by simp⟩ = ⟨0, by simp⟩ := by
   rw [fundamentalGroupMulEquiv_zero]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Pointed.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Pointed.lean
@@ -125,8 +125,7 @@ theorem IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq
     [PathConnectedSpace E] [LocallyPathConnectedSpace E]
     [PathConnectedSpace F] [LocallyPathConnectedSpace F]
     (hp : _root_.IsCoveringMap p) (hq : _root_.IsCoveringMap q) (hpe : p e₀ = x) (hqf : q f₀ = x)
-    (hrange : (mapOfEq ⟨p, hp.continuous⟩ hpe).range =
-      (mapOfEq ⟨q, hq.continuous⟩ hqf).range) :
+    (hrange : (mapOfEq ⟨p, hp.continuous⟩ hpe).range = (mapOfEq ⟨q, hq.continuous⟩ hqf).range) :
     ∃ h : E ≃ₜ F, h e₀ = f₀ ∧ q ∘ h = p := by
   obtain ⟨g, ⟨hg₀, hgc⟩, -⟩ :=
     IsCoveringMap.existsUnique_continuousMap_comp_eq_of_range_le hp.continuous hq hpe hqf hrange.le
@@ -176,8 +175,7 @@ noncomputable def IsCoveringMap.totalSpaceHomeomorphOfRangeEq
     [PathConnectedSpace E] [LocallyPathConnectedSpace E]
     [PathConnectedSpace F] [LocallyPathConnectedSpace F]
     (hp : _root_.IsCoveringMap p) (hq : _root_.IsCoveringMap q) (hpe : p e₀ = x) (hqf : q f₀ = x)
-    (hrange : (mapOfEq ⟨p, hp.continuous⟩ hpe).range =
-      (mapOfEq ⟨q, hq.continuous⟩ hqf).range) :
+    (hrange : (mapOfEq ⟨p, hp.continuous⟩ hpe).range = (mapOfEq ⟨q, hq.continuous⟩ hqf).range) :
     E ≃ₜ F :=
   (IsCoveringMap.exists_homeomorph_comp_eq_of_range_eq hp hq hpe hqf hrange).choose
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -73,8 +73,7 @@ def subgroupQuotientMap (H : Subgroup (FundamentalGroup X x₀)) :
 
 /-- The subgroup quotient map sends a representative to its quotient class. -/
 @[simp]
-theorem subgroupQuotientMap_apply (H : Subgroup (FundamentalGroup X x₀))
-    (e : UniversalCover x₀) :
+theorem subgroupQuotientMap_apply (H : Subgroup (FundamentalGroup X x₀)) (e : UniversalCover x₀) :
     subgroupQuotientMap x₀ H e = Quotient.mk'' e :=
   (rfl)
 
@@ -107,8 +106,7 @@ private theorem fundamentalGroup_disjoint [LocallyPathConnectedSpace X]
     exact IsCancelSMul.right_cancel g 1 u (hgu.trans (one_smul _ u).symm)
 
 /-- The quotient map by any subgroup of the fundamental group is a quotient covering map. -/
-theorem isQuotientCoveringMap_subgroupQuotientMap
-    [LocallyPathConnectedSpace X]
+theorem isQuotientCoveringMap_subgroupQuotientMap [LocallyPathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] (H : Subgroup (FundamentalGroup X x₀)) :
     IsQuotientCoveringMap (subgroupQuotientMap x₀ H) H where
   __ := isQuotientMap_quotient_mk'
@@ -133,14 +131,12 @@ def subgroupQuotientProj (H : Subgroup (FundamentalGroup X x₀)) :
 
 /-- The descended endpoint projection evaluates on an orbit representative as `proj`. -/
 @[simp]
-theorem subgroupQuotientProj_mk (H : Subgroup (FundamentalGroup X x₀))
-    (e : UniversalCover x₀) :
+theorem subgroupQuotientProj_mk (H : Subgroup (FundamentalGroup X x₀)) (e : UniversalCover x₀) :
     subgroupQuotientProj x₀ H (Quotient.mk'' e) = proj e :=
   (rfl)
 
 /-- The endpoint projection factors through the quotient by every subgroup. -/
-theorem subgroupQuotientProj_comp_subgroupQuotientMap
-    (H : Subgroup (FundamentalGroup X x₀)) :
+theorem subgroupQuotientProj_comp_subgroupQuotientMap (H : Subgroup (FundamentalGroup X x₀)) :
     subgroupQuotientProj x₀ H ∘ subgroupQuotientMap x₀ H = proj := by
   ext e
   exact subgroupQuotientProj_mk x₀ H e
@@ -151,8 +147,7 @@ theorem subgroupQuotientProj_basepoint (H : Subgroup (FundamentalGroup X x₀)) 
   subgroupQuotientProj_mk x₀ H _
 
 /-- The descended endpoint projection is continuous. -/
-theorem continuous_subgroupQuotientProj
-    (H : Subgroup (FundamentalGroup X x₀)) :
+theorem continuous_subgroupQuotientProj (H : Subgroup (FundamentalGroup X x₀)) :
     Continuous (subgroupQuotientProj x₀ H) := by
   rw [isQuotientMap_quotient_mk'.continuous_iff]
   have h := subgroupQuotientProj_comp_subgroupQuotientMap x₀ H

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/Unpointed.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/Unpointed.lean
@@ -65,8 +65,7 @@ source basepoint to a conjugate of the subgroup recovered from the target basepo
 
 The homeomorphism need not carry `e₀` to `f₀`: its image of `e₀` is another point of the
 target fibre, and changing from that point to `f₀` accounts for the conjugation. -/
-theorem exists_range_eq_map_conj_of_homeomorph_comp_eq
-    [PathConnectedSpace F]
+theorem exists_range_eq_map_conj_of_homeomorph_comp_eq [PathConnectedSpace F]
     (hp : Continuous p) (hq : _root_.IsCoveringMap q)
     (hpe : p e₀ = x) (hqf : q f₀ = x) (h : E ≃ₜ F) (hcomp : q ∘ h = p) :
     ∃ γ : FundamentalGroup X x,
@@ -135,8 +134,7 @@ map one chosen lift to the other. -/
 theorem exists_homeomorph_comp_eq_iff_exists_range_eq_map_conj
     [PathConnectedSpace E] [LocallyPathConnectedSpace E]
     [PathConnectedSpace F] [LocallyPathConnectedSpace F]
-    (hp : _root_.IsCoveringMap p) (hq : _root_.IsCoveringMap q)
-    (hpe : p e₀ = x) (hqf : q f₀ = x) :
+    (hp : _root_.IsCoveringMap p) (hq : _root_.IsCoveringMap q) (hpe : p e₀ = x) (hqf : q f₀ = x) :
     (∃ h : E ≃ₜ F, q ∘ h = p) ↔
       ∃ γ : FundamentalGroup X x,
         (mapOfEq ⟨q, hq.continuous⟩ hqf).range =

--- a/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Covering.lean
@@ -118,8 +118,7 @@ the concatenated based path `α.append γ`. -/
 theorem liftPath_apply_one_eq_ofBasedPath_append
     [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] {α : BasedPath x₀} {y : X}
-    (γ : Path (BasedPath.endpoint α) y) :
-    (isCoveringMap x₀).liftPath γ (ofBasedPath x₀ α)
+    (γ : Path (BasedPath.endpoint α) y) : (isCoveringMap x₀).liftPath γ (ofBasedPath x₀ α)
       (by simp) 1 =
       ofBasedPath x₀ (BasedPath.append α γ) := by
   let Γ : C(I, TauCeti.UniversalCover x₀) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Conjugation.lean
@@ -137,16 +137,14 @@ def conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) : Deck p ≃* Dec
 
 /-- The deck transformation produced by `conjMulEquiv` evaluates by conjugation. -/
 @[simp]
-lemma conjMulEquiv_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (φ : Deck p) (f : F) :
+lemma conjMulEquiv_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p) (f : F) :
     ((conjMulEquiv h hpq φ).1 f) = h (φ.1 (h.symm f)) := by
   rfl
 
 /-- The inverse equivalence of `conjMulEquiv` is conjugation by the inverse
 homeomorphism. -/
 @[simp]
-lemma conjMulEquiv_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (ψ : Deck q) (e : E) :
+lemma conjMulEquiv_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q) (e : E) :
     (((conjMulEquiv h hpq).symm ψ).1 e) = h.symm (ψ.1 (h e)) := by
   rfl
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Basic.lean
@@ -151,8 +151,7 @@ lemma deckEquivFiberOfSurjective_apply_coe [PreconnectedSpace E] (hp : IsCoverin
 returns: it sends the chosen fibre point to the requested fibre point. -/
 @[simp]
 lemma deckEquivFiberOfSurjective_symm_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e)
-    (e' : p ⁻¹' {b}) :
+    (e : p ⁻¹' {b}) (hsurj : Function.Surjective fun φ : Deck p => φ • e) (e' : p ⁻¹' {b}) :
     (deckEquivFiberOfSurjective hp e hsurj).symm e' • e = e' :=
   (deckEquivFiberOfSurjective hp e hsurj).apply_symm_apply e'
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Torsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Connected/Torsor.lean
@@ -63,10 +63,8 @@ noncomputable def fiberTorsorOfPretransitive [PreconnectedSpace E] (hp : IsCover
 
 /-- In the local fibre torsor, `e₁ /ₛ e₂` is the inverse local equivalence from `e₂` applied
 to `e₁`. -/
-lemma fiber_sdiv_eq_deckEquivFiberOfSurjective_symm [PreconnectedSpace E]
-    (hp : IsCoveringMap p)
-    [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
-    (e₁ e₂ : p ⁻¹' {b}) :
+lemma fiber_sdiv_eq_deckEquivFiberOfSurjective_symm [PreconnectedSpace E] (hp : IsCoveringMap p)
+    [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] (e₁ e₂ : p ⁻¹' {b}) :
     letI := fiberTorsorOfPretransitive hp b
     e₁ /ₛ e₂ =
       (deckEquivFiberOfSurjective hp e₂ (MulAction.surjective_smul (Deck p) e₂)).symm e₁ :=
@@ -77,8 +75,7 @@ by
 quotient of a point by the chosen base point. -/
 @[simp]
 lemma deckEquivFiberOfSurjective_symm_eq_sdiv [PreconnectedSpace E] (hp : IsCoveringMap p)
-    [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
-    (e e' : p ⁻¹' {b}) :
+    [Nonempty (p ⁻¹' {b})] [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] (e e' : p ⁻¹' {b}) :
     letI := fiberTorsorOfPretransitive hp b
     (deckEquivFiberOfSurjective hp e (MulAction.surjective_smul (Deck p) e)).symm e' =
       e' /ₛ e := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Basic.lean
@@ -134,8 +134,7 @@ lemma fiber_smul_eq_fiberHomeomorph (φ : Deck p) (e : p ⁻¹' {b}) :
 /-- On underlying points, the fibre action is evaluation of the underlying deck
 transformation. -/
 @[simp]
-lemma fiber_smul_coe (φ : Deck p) (e : p ⁻¹' {b}) :
-    ((φ • e : p ⁻¹' {b}) : E) = φ.1 e.1 :=
+lemma fiber_smul_coe (φ : Deck p) (e : p ⁻¹' {b}) : ((φ • e : p ⁻¹' {b}) : E) = φ.1 e.1 :=
   rfl
 
 /-- The projection value of a point in the fibre is unchanged after the restricted deck
@@ -145,8 +144,7 @@ lemma map_fiber_smul (φ : Deck p) (e : p ⁻¹' {b}) :
   exact (φ • e).2
 
 /-- The restricted deck action keeps points in the fibre over `b`. -/
-lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) :
-    (φ • e : E) ∈ p ⁻¹' {b} := by
+lemma fiber_smul_mem (φ : Deck p) (e : p ⁻¹' {b}) : (φ • e : E) ∈ p ⁻¹' {b} := by
   exact map_fiber_smul φ e
 
 /-- The restricted fibre action agrees with the ambient action on the total space after

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Orbit.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Orbit.lean
@@ -79,8 +79,7 @@ lemma fiberOrbitClass_eq_iff (e e' : p ⁻¹' {b}) :
 /-- The induced equivalence on fibre-orbit quotients sends the class of a point to the class
 of its transported point. -/
 @[simp]
-lemma fiberOrbitQuotientEquiv_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (e : p ⁻¹' {b}) :
+lemma fiberOrbitQuotientEquiv_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
     fiberOrbitQuotientEquiv h hpq b (fiberOrbitClass e) =
       fiberOrbitClass (fiberMap h hpq b e) :=
   rfl
@@ -88,8 +87,7 @@ lemma fiberOrbitQuotientEquiv_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e
 /-- The inverse induced equivalence on fibre-orbit quotients sends the class of a target
 fibre point to the class of its inverse transport. -/
 @[simp]
-lemma fiberOrbitQuotientEquiv_symm_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (f : q ⁻¹' {b}) :
+lemma fiberOrbitQuotientEquiv_symm_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f : q ⁻¹' {b}) :
     (fiberOrbitQuotientEquiv h hpq b).symm (fiberOrbitClass f) =
       fiberOrbitClass ((fiberMap h hpq b).symm f) := by
   simp only [fiberOrbitQuotientEquiv, fiberOrbitClass_eq_mk]

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Transport.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Fiber/Transport.lean
@@ -64,8 +64,7 @@ lemma fiberMap_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p �
 /-- On underlying points, the inverse fibre map is the inverse of the over-base
 homeomorphism. -/
 @[simp]
-lemma fiberMap_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (f : q ⁻¹' {b}) :
+lemma fiberMap_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f : q ⁻¹' {b}) :
     ((fiberMap h hpq b).symm f : E) = h.symm f.1 :=
   rfl
 
@@ -80,8 +79,7 @@ lemma fiberMap_refl :
 /-- The inverse of the fibre map induced by an over-base homeomorphism is the fibre map induced
 by the inverse over-base homeomorphism. -/
 @[simp]
-lemma fiberMap_symm (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) :
-    (fiberMap h hpq b).symm =
+lemma fiberMap_symm (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) : (fiberMap h hpq b).symm =
       fiberMap h.symm (map_symm_eq_of_map_eq h hpq) b := by
   ext f
   rfl
@@ -98,18 +96,15 @@ lemma fiberMap_trans (h : E ≃ₜ F) (k : F ≃ₜ G)
 /-- Fibre transport intertwines the restricted deck action with conjugation of deck
 transformations. -/
 @[simp]
-lemma fiberMap_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p)
-    (e : p ⁻¹' {b}) :
+lemma fiberMap_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p) (e : p ⁻¹' {b}) :
     fiberMap h hpq b (φ • e) = conjMulEquiv h hpq φ • fiberMap h hpq b e := by
   ext
   simp [fiber_smul_eq_fiberHomeomorph]
 
 /-- The inverse fibre transport intertwines the restricted deck action with inverse
 conjugation of deck transformations. -/
-lemma fiberMap_symm_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q)
-    (f : q ⁻¹' {b}) :
-    (fiberMap h hpq b).symm (ψ • f) =
-      (conjMulEquiv h hpq).symm ψ • (fiberMap h hpq b).symm f := by
+lemma fiberMap_symm_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q) (f : q ⁻¹' {b}) :
+    (fiberMap h hpq b).symm (ψ • f) = (conjMulEquiv h hpq).symm ψ • (fiberMap h hpq b).symm f := by
   ext
   simp [fiber_smul_eq_fiberHomeomorph]
 
@@ -117,8 +112,7 @@ lemma fiberMap_symm_smul (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Dec
 is the same as restricting first and conjugating the resulting fibre homeomorphism by the fibre
 transport map. -/
 @[simp]
-lemma fiberMap_trans_fiberHomeomorph (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (φ : Deck p) :
+lemma fiberMap_trans_fiberHomeomorph (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p) :
     (fiberMap h hpq b).trans (fiberHomeomorph (conjMulEquiv h hpq φ) b) =
       (fiberHomeomorph φ b).trans (fiberMap h hpq b) := by
   ext e
@@ -127,8 +121,7 @@ lemma fiberMap_trans_fiberHomeomorph (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p 
 /-- Restricting conjugated deck transformations to a fibre is compatible with the fibre
 restriction homomorphism. -/
 @[simp]
-lemma fiberHomeomorphHom_conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (φ : Deck p) :
+lemma fiberHomeomorphHom_conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p) :
     fiberHomeomorphHom q b (conjMulEquiv h hpq φ) =
       (fiberMap h hpq b).symm.trans ((fiberHomeomorphHom p b φ).trans (fiberMap h hpq b)) := by
   ext f
@@ -152,8 +145,7 @@ lemma mem_stabilizer_conjMulEquiv_fiberMap_iff (h : E ≃ₜ F)
 
 /-- Conjugation maps the source fibre stabilizer onto the transported target fibre
 stabilizer. -/
-theorem map_fiber_stabilizer_conjMulEquiv (h : E ≃ₜ F)
-    (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
+theorem map_fiber_stabilizer_conjMulEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
     (MulAction.stabilizer (Deck p) e).map ((conjMulEquiv h hpq : Deck p ≃* Deck q) :
         Deck p →* Deck q) =
       MulAction.stabilizer (Deck q) (fiberMap h hpq b e) := by
@@ -167,8 +159,7 @@ theorem map_fiber_stabilizer_conjMulEquiv (h : E ≃ₜ F)
       ((conjMulEquiv h hpq).symm ψ) e).mp (by simpa using hψ)
 
 /-- Fibre transport identifies stabilizers, using conjugation on deck transformations. -/
-def fiberMapStabilizerEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (e : p ⁻¹' {b}) :
+def fiberMapStabilizerEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : p ⁻¹' {b}) :
     MulAction.stabilizer (Deck p) e ≃*
       MulAction.stabilizer (Deck q) (fiberMap h hpq b e) :=
   ((conjMulEquiv h hpq).subgroupMap (MulAction.stabilizer (Deck p) e)).trans
@@ -186,14 +177,12 @@ conjugation. -/
 @[simp]
 lemma fiberMapStabilizerEquiv_symm_apply_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (e : p ⁻¹' {b}) (ψ : MulAction.stabilizer (Deck q) (fiberMap h hpq b e)) :
-    ((fiberMapStabilizerEquiv h hpq e).symm ψ : Deck p) =
-      (conjMulEquiv h hpq).symm ψ.1 :=
+    ((fiberMapStabilizerEquiv h hpq e).symm ψ : Deck p) = (conjMulEquiv h hpq).symm ψ.1 :=
   by simp [fiberMapStabilizerEquiv]
 
 /-- Applying a deck transformation and then transporting to the target fibre gives a point in
 the target deck orbit. -/
-lemma fiberMap_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p)
-    (e : p ⁻¹' {b}) :
+lemma fiberMap_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (φ : Deck p) (e : p ⁻¹' {b}) :
     fiberMap h hpq b (φ • e) ∈ MulAction.orbit (Deck q) (fiberMap h hpq b e) := by
   exact ⟨conjMulEquiv h hpq φ, fiberMap_smul h hpq φ e |>.symm⟩
 
@@ -214,16 +203,14 @@ theorem fiberMap_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : 
 
 /-- Applying a deck transformation and then transporting back to the source fibre gives a
 point in the source deck orbit. -/
-lemma fiberMap_symm_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q)
-    (f : q ⁻¹' {b}) :
+lemma fiberMap_symm_mem_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (ψ : Deck q) (f : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm (ψ • f) ∈
       MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) := by
   exact ⟨(conjMulEquiv h hpq).symm ψ, fiberMap_symm_smul h hpq ψ f |>.symm⟩
 
 /-- The inverse fibre map carries the deck orbit of a point onto the deck orbit of the
 transported point. -/
-theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (f : q ⁻¹' {b}) :
+theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm '' MulAction.orbit (Deck q) f =
       MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) := by
   ext e
@@ -237,8 +224,7 @@ theorem fiberMap_symm_image_orbit (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
 
 /-- Transporting both fibre points preserves membership in deck orbits. -/
 @[simp]
-theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (e e' : p ⁻¹' {b}) :
+theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e e' : p ⁻¹' {b}) :
     fiberMap h hpq b e' ∈ MulAction.orbit (Deck q) (fiberMap h hpq b e) ↔
       e' ∈ MulAction.orbit (Deck p) e := by
   constructor
@@ -259,8 +245,7 @@ theorem mem_orbit_fiberMap_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     exact congrArg (fiberMap h hpq b) hφ
 
 /-- Transporting both target-fibre points back preserves membership in deck orbits. -/
-theorem mem_orbit_fiberMap_symm_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (f f' : q ⁻¹' {b}) :
+theorem mem_orbit_fiberMap_symm_iff (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f f' : q ⁻¹' {b}) :
     (fiberMap h hpq b).symm f' ∈
         MulAction.orbit (Deck p) ((fiberMap h hpq b).symm f) ↔
       f' ∈ MulAction.orbit (Deck q) f := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Opposite.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/Opposite.lean
@@ -81,8 +81,7 @@ lemma deckFundamentalGroupEquiv_apply [SimplyConnectedSpace E]
 transformation corresponding to `γ` under `fundamentalGroupEquiv`. -/
 @[simp]
 lemma deckFundamentalGroupEquiv_symm_op [SimplyConnectedSpace E]
-    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x})
-    (γ : FundamentalGroup X x) :
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (γ : FundamentalGroup X x) :
     (hreg.deckFundamentalGroupEquiv hp e).symm (MulOpposite.op γ) =
       (hreg.fundamentalGroupEquiv hp e γ).unop :=
   rfl
@@ -150,8 +149,7 @@ lemma deckFundamentalGroupEquiv_eq_one_iff [SimplyConnectedSpace E]
 /-- Under the deck-to-fundamental-group comparison, the deck-to-fibre equivalence for a
 regular cover agrees with the monodromy equivalence from `π₁` to the same fibre. -/
 lemma deckEquivFiber_eq_fundamentalGroupEquivFiber [SimplyConnectedSpace E]
-    (hreg : IsRegular p) (hp : IsCoveringMap p)
-    (e : p ⁻¹' {x}) (φ : Deck p) :
+    (hreg : IsRegular p) (hp : IsCoveringMap p) (e : p ⁻¹' {x}) (φ : Deck p) :
     deckEquivFiber hp hreg e φ =
       TauCeti.IsCoveringMap.fundamentalGroupEquivFiber hp e
         ((hreg.deckFundamentalGroupEquiv hp e φ).unop) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Basic.lean
@@ -71,8 +71,7 @@ normal-case comparison, is the existing equivalence to `Deck p ⧸ H`. -/
 @[simp]
 lemma normalizerQuotientEquivQuotientOfNormal_subgroupFiberOrbitQuotientEquiv
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e x) =
       subgroupFiberOrbitQuotientEquivQuotientGroup H e x := by
@@ -99,8 +98,7 @@ normalizer quotient's normal-case comparison, is the existing equivalence to `De
 @[simp]
 lemma normalizerQuotientEquivQuotientOfNormal_regularSubgroupFiberOrbitQuotientEquiv
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.normalizerQuotientEquivQuotientOfNormal H
         (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x) =
       regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x := by
@@ -209,8 +207,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_inv
 
 /-- Equality of subgroup fibre-orbit classes of two deck translates is equality of the
 corresponding inverse representatives in the normalizer quotient. -/
-lemma subgroupFiberOrbitClass_eq_iff_normalizerQuotientMk_inv_eq
-    [IsCancelSMul (Deck p) (p ⁻¹' {b})]
+lemma subgroupFiberOrbitClass_eq_iff_normalizerQuotientMk_inv_eq [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (φ ψ : Deck p) :
     subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H (ψ • e) ↔
       Subgroup.normalizerQuotientMk H

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Equivariance.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalSubgroupFiberQuotient/Equivariance.lean
@@ -45,8 +45,7 @@ variable {E B : Type*} [TopologicalSpace E] {p : E → B} {b : B}
 
 private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_apply_eq
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (x : SubgroupFiberOrbitQuotient H b) :
     regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e x =
       @subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal E B _ p b
         (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H _ e x := by
@@ -64,8 +63,7 @@ private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_a
 
 private lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_apply_eq
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (y : Subgroup.normalizerQuotient H) :
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (y : Subgroup.normalizerQuotient H) :
     (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm y =
       (@subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal E B _ p b
         (hreg.fiber_isPretransitive b) (fiber_isCancelSMul (b := b) hp) H _ e).symm y := by
@@ -124,8 +122,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_map_smul_
 by `a⁻¹` is the same as acting by `a` on the fibre quotient. -/
 lemma subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (a y : Subgroup.normalizerQuotient H) :
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (a y : Subgroup.normalizerQuotient H) :
     (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm (y * a⁻¹) =
       a • (subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal H e).symm y := by
   rw [subgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_eq]
@@ -137,10 +134,8 @@ quotient equivalence after right multiplication by `a⁻¹` is the same as actin
 fibre quotient. -/
 lemma regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal_symm_mul_inv
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b})
-    (a y : Subgroup.normalizerQuotient H) :
-    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
-        (y * a⁻¹) =
+    (H : Subgroup (Deck p)) [H.Normal] (e : p ⁻¹' {b}) (a y : Subgroup.normalizerQuotient H) :
+    (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm (y * a⁻¹) =
       a • (regularSubgroupFiberOrbitQuotientEquivNormalizerQuotientOfNormal hp hreg H e).symm
         y := by
   letI := hreg.fiber_isPretransitive b

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/Conjugation.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/Conjugation.lean
@@ -41,8 +41,7 @@ variable {E F B : Type*} [TopologicalSpace E] [TopologicalSpace F]
 
 /-- Conjugating an over-base homeomorphism identifies the normalizer quotient of a deck
 subgroup with the normalizer quotient of the conjugated subgroup. -/
-noncomputable abbrev normalizerQuotientConjEquiv (h : E ≃ₜ F)
-    (hpq : ∀ e, q (h e) = p e)
+noncomputable abbrev normalizerQuotientConjEquiv (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
     (H : Subgroup (Deck p)) :
     Subgroup.normalizerQuotient H ≃*
       Subgroup.normalizerQuotient
@@ -51,8 +50,7 @@ noncomputable abbrev normalizerQuotientConjEquiv (h : E ≃ₜ F)
 
 /-- On normalizer representatives, the deck normalizer-quotient conjugation equivalence is
 induced by conjugating deck transformations. -/
-lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
+lemma normalizerQuotientConjEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (H : Subgroup (Deck p))
     (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ) =
       Subgroup.normalizerQuotientMk
@@ -82,8 +80,7 @@ lemma normalizerQuotientConjEquiv_refl_mk_congr (H : Subgroup (Deck p))
 /-- The inverse deck normalizer-quotient conjugation equivalence is induced by inverse
 conjugation of deck transformations. -/
 lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
-    (ψ : _root_.Subgroup.normalizer
+    (H : Subgroup (Deck p)) (ψ : _root_.Subgroup.normalizer
       ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
         Set (Deck q))) :
     (normalizerQuotientConjEquiv h hpq H).symm
@@ -95,12 +92,9 @@ lemma normalizerQuotientConjEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e)
 
 /-- Composing two deck normalizer-quotient conjugation equivalences sends representatives through
 the two successive conjugation transports. -/
-lemma normalizerQuotientConjEquiv_trans_mk
-    {G : Type*} [TopologicalSpace G] {r : G → B}
-    (h : E ≃ₜ F) (k : F ≃ₜ G)
-    (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
-    (H : Subgroup (Deck p))
-    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+lemma normalizerQuotientConjEquiv_trans_mk {G : Type*} [TopologicalSpace G] {r : G → B}
+    (h : E ≃ₜ F) (k : F ≃ₜ G) (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
+    (H : Subgroup (Deck p)) (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     normalizerQuotientConjEquiv k hqr
         (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
         (normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ)) =
@@ -117,12 +111,9 @@ lemma normalizerQuotientConjEquiv_trans_mk
 /-- After identifying the twice-conjugated subgroup with the subgroup conjugated by the
 composite over-base homeomorphism, composing deck normalizer-quotient conjugation equivalences
 agrees with conjugation by the composite on representatives. -/
-lemma normalizerQuotientConjEquiv_trans_mk_congr
-    {G : Type*} [TopologicalSpace G] {r : G → B}
-    (h : E ≃ₜ F) (k : F ≃ₜ G)
-    (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
-    (H : Subgroup (Deck p))
-    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+lemma normalizerQuotientConjEquiv_trans_mk_congr {G : Type*} [TopologicalSpace G] {r : G → B}
+    (h : E ≃ₜ F) (k : F ≃ₜ G) (hpq : ∀ e, q (h e) = p e) (hqr : ∀ f, r (k f) = q f)
+    (H : Subgroup (Deck p)) (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     Subgroup.normalizerQuotientCongr (subgroup_map_conj_trans h k hpq hqr H)
       (normalizerQuotientConjEquiv k hqr
         (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
@@ -144,8 +135,7 @@ lemma normalizerQuotientConjEquiv_trans_mk_congr
 /-- Inverse-conjugating a representative of the `h`-conjugated subgroup quotient gives the
 stated representative in the twice-mapped subgroup. -/
 lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
-    (ψ : _root_.Subgroup.normalizer
+    (H : Subgroup (Deck p)) (ψ : _root_.Subgroup.normalizer
       ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
         Set (Deck q))) :
     normalizerQuotientConjEquiv h.symm (map_symm_eq_of_map_eq h hpq)
@@ -166,8 +156,7 @@ lemma normalizerQuotientConjEquiv_symm_mk' (h : E ≃ₜ F) (hpq : ∀ e, q (h e
 /-- On underlying deck transformations, the normalizer representative in the target quotient
 is obtained by conjugation. -/
 lemma normalizerQuotientConjEquiv_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
-    (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
+    (H : Subgroup (Deck p)) (φ : _root_.Subgroup.normalizer (H : Set (Deck p))) :
     normalizerQuotientConjEquiv h hpq H (Subgroup.normalizerQuotientMk H φ) =
       Subgroup.normalizerQuotientMk
         (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q))
@@ -179,8 +168,7 @@ lemma normalizerQuotientConjEquiv_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) 
 /-- On representatives, inverse transport of the deck normalizer quotient applies inverse
 conjugation. -/
 lemma normalizerQuotientConjEquiv_symm_mk_coe (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
-    (ψ : _root_.Subgroup.normalizer
+    (H : Subgroup (Deck p)) (ψ : _root_.Subgroup.normalizer
       ((H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) :
         Set (Deck q))) :
     (normalizerQuotientConjEquiv h hpq H).symm

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/FiberAction.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/NormalizerQuotient/FiberAction.lean
@@ -127,8 +127,7 @@ lemma normalizerSubgroupFiberOrbitPermHom_eq_one_of_mem
     (X := p ⁻¹' {b}) H φ hφ
 
 /-- The action of the normalizer on subgroup fibre quotients descends to `N(H) / H`. -/
-noncomputable def normalizerQuotientSubgroupFiberOrbitPermHom
-    (H : Subgroup (Deck p)) :
+noncomputable def normalizerQuotientSubgroupFiberOrbitPermHom (H : Subgroup (Deck p)) :
     Subgroup.normalizerQuotient H →*
       Equiv.Perm (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerQuotientOrbitRelQuotientPermHom H
@@ -147,8 +146,7 @@ lemma normalizerQuotientSubgroupFiberOrbitPermHom_mk_apply (H : Subgroup (Deck p
         (X := p ⁻¹' {b}) H φ e
 
 /-- The normalizer quotient `N(H) / H` acts on the quotient of a fibre by `H`-orbits. -/
-noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction
-    (H : Subgroup (Deck p)) :
+noncomputable instance instNormalizerQuotientSubgroupFiberOrbitMulAction (H : Subgroup (Deck p)) :
     MulAction (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerQuotientOrbitRelQuotientMulAction H
 
@@ -165,8 +163,7 @@ lemma normalizerQuotient_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
           (X := p ⁻¹' {b}) H φ e
 
 /-- The identity class in `N(H) / H` fixes every subgroup fibre-orbit class. -/
-lemma normalizerQuotient_one_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p))
-    (e : p ⁻¹' {b}) :
+lemma normalizerQuotient_one_smul_subgroupFiberOrbitClass (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) :
     (1 : Subgroup.normalizerQuotient H) • subgroupFiberOrbitClass H e =
       subgroupFiberOrbitClass H e := by
   simp
@@ -184,8 +181,7 @@ lemma normalizerQuotient_mk_of_mem_smul_subgroupFiberOrbitClass
 
 /-- If the normalizer of `H` acts transitively on the chosen fibre, then the descended
 `N(H) / H` action on the quotient of that fibre by `H`-orbits is transitive. -/
-theorem normalizerQuotientSubgroupFiberOrbitIsPretransitive
-    (H : Subgroup (Deck p))
+theorem normalizerQuotientSubgroupFiberOrbitIsPretransitive (H : Subgroup (Deck p))
     [MulAction.IsPretransitive (_root_.Subgroup.normalizer (H : Set (Deck p))) (p ⁻¹' {b})] :
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
@@ -195,8 +191,7 @@ theorem normalizerQuotientSubgroupFiberOrbitIsPretransitive
 /-- If `H` is normal and the deck action on the chosen fibre is transitive, then the
 descended `N(H) / H` action on the quotient of that fibre by `H`-orbits is transitive. -/
 theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) [H.Normal] :
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) [H.Normal] :
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
   TauCeti.MulAction.normalizerQuotientOrbitRelQuotientIsPretransitiveOfNormal
@@ -205,8 +200,7 @@ theorem normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
 /-- The normalizer quotient acts transitively on a normal subgroup fibre quotient whenever the
 deck action on the fibre is transitive. -/
 noncomputable instance instNormalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})]
-    (H : Subgroup (Deck p)) [H.Normal] :
+    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) [H.Normal] :
     MulAction.IsPretransitive
       (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) :=
   normalizerQuotientSubgroupFiberOrbitIsPretransitiveOfNormal H
@@ -239,8 +233,7 @@ noncomputable instance instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul
 /-- For a preconnected covering map, the descended `N(H) / H` action on every `H`-fibre
 quotient is free. -/
 theorem normalizerQuotientSubgroupFiberOrbitIsCancelSMulOfIsCoveringMap
-    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (H : Subgroup (Deck p)) :
+    [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (H : Subgroup (Deck p)) :
     IsCancelSMul (Subgroup.normalizerQuotient H) (SubgroupFiberOrbitQuotient H b) := by
   letI := fiber_isCancelSMul (b := b) hp
   exact instNormalizerQuotientSubgroupFiberOrbitIsCancelSMul H

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Basic.lean
@@ -129,8 +129,7 @@ lemma orbitQuotientEquiv_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (e : E
 inverse homeomorphism. -/
 @[simp]
 lemma orbitQuotientEquiv_symm_mk (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e) (f : F) :
-    (orbitQuotientEquiv h hpq).symm
-      (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
+    (orbitQuotientEquiv h hpq).symm (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
         (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) :=
   rfl
 
@@ -216,8 +215,7 @@ lemma orbitQuotientEquivBase_conj (hreg : IsRegular p) (h : E ≃ₜ F)
 /-- Representative form of compatibility between over-base homeomorphisms and the regular
 orbit-quotient equivalences. -/
 lemma orbitQuotientEquivBase_conj_mk (hreg : IsRegular p) (h : E ≃ₜ F)
-    (hpq : ∀ e, q (h e) = p e) (f : F) :
-    (hreg.conj h hpq).orbitQuotientEquivBase
+    (hpq : ∀ e, q (h e) = p e) (f : F) : (hreg.conj h hpq).orbitQuotientEquivBase
       (Quotient.mk'' f : MulAction.orbitRel.Quotient (Deck q) F) =
         hreg.orbitQuotientEquivBase
           (Quotient.mk'' (h.symm f) : MulAction.orbitRel.Quotient (Deck p) E) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Homeomorph.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Quotient/Homeomorph.lean
@@ -68,8 +68,7 @@ the base. -/
 `orbitQuotientEquivBase`. -/
 @[simp]
 lemma orbitQuotientHomeomorphBase_apply (hreg : IsRegular p) (hcont : Continuous p)
-    (hopen : IsOpenMap p)
-    (x : MulAction.orbitRel.Quotient (Deck p) E) :
+    (hopen : IsOpenMap p) (x : MulAction.orbitRel.Quotient (Deck p) E) :
     hreg.orbitQuotientHomeomorphBase hcont hopen x = hreg.orbitQuotientEquivBase x :=
   rfl
 
@@ -85,8 +84,7 @@ lemma orbitQuotientHomeomorphBase_mk (hreg : IsRegular p) (hcont : Continuous p)
 lift. -/
 @[simp]
 lemma orbitQuotientHomeomorphBase_symm_apply_proj (hreg : IsRegular p) (hcont : Continuous p)
-    (hopen : IsOpenMap p) (e : E) :
-    (hreg.orbitQuotientHomeomorphBase hcont hopen).symm (p e) =
+    (hopen : IsOpenMap p) (e : E) : (hreg.orbitQuotientHomeomorphBase hcont hopen).symm (p e) =
       (Quotient.mk'' e : MulAction.orbitRel.Quotient (Deck p) E) :=
   hreg.orbitQuotientEquivBase_symm_apply_proj e
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Basic.lean
@@ -188,8 +188,7 @@ lemma deckEquivFiber_mul [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : Is
 /-- The inverse of `deckEquivFiber` is characterized by the deck transformation it returns:
 it sends the chosen fibre point to the requested fibre point. -/
 lemma deckEquivFiber_symm_smul [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (hreg : IsRegular p) (e e' : p ⁻¹' {b}) :
-    (deckEquivFiber hp hreg e).symm e' • e = e' :=
+    (hreg : IsRegular p) (e e' : p ⁻¹' {b}) : (deckEquivFiber hp hreg e).symm e' • e = e' :=
   (deckEquivFiber hp hreg e).apply_symm_apply e'
 
 /-- On underlying points, the inverse of `deckEquivFiber` sends the chosen point to the

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Torsor.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/Regular/Torsor.lean
@@ -52,8 +52,7 @@ noncomputable def fiberTorsor [PreconnectedSpace E]
 /-- In the regular-cover fibre torsor, `e₁ /ₛ e₂` is the inverse equivalence from `e₂`
 applied to `e₁`. -/
 lemma fiber_sdiv_eq_deckEquivFiber_symm [PreconnectedSpace E] (hp : IsCoveringMap p)
-    (hreg : IsRegular p)
-    (e₁ e₂ : p ⁻¹' {b}) :
+    (hreg : IsRegular p) (e₁ e₂ : p ⁻¹' {b}) :
     letI := fiberTorsor hp hreg b
     e₁ /ₛ e₂ = (deckEquivFiber hp hreg e₂).symm e₁ :=
 by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/Basic.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/Basic.lean
@@ -82,8 +82,7 @@ lemma subgroupFiberOrbitClass_eq_iff (H : Subgroup (Deck p)) (e e' : p ⁻¹' {b
 /-- A deck translate of the chosen fibre point has the same subgroup orbit class as the chosen
 point exactly when the translating deck transformation lies in the subgroup. -/
 lemma subgroupFiberOrbitClass_smul_eq_base_iff
-    [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) (e : p ⁻¹' {b})
-    (φ : Deck p) :
+    [IsCancelSMul (Deck p) (p ⁻¹' {b})] (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
     subgroupFiberOrbitClass H (φ • e) = subgroupFiberOrbitClass H e ↔ φ ∈ H := by
   exact TauCeti.MulAction.orbitRelQuotient_smul_eq_base_iff
     (G := Deck p) (X := p ⁻¹' {b}) H φ e
@@ -106,8 +105,7 @@ lemma subgroupFiberOrbitClass_smul_eq_base_iff_of_isCoveringMap
 
 /-- The map induced by `H ≤ K` sends the `H`-class of a point to its `K`-class. -/
 @[simp]
-lemma subgroupFiberOrbitMapOfLE_apply {H K : Subgroup (Deck p)} (hHK : H ≤ K)
-    (e : p ⁻¹' {b}) :
+lemma subgroupFiberOrbitMapOfLE_apply {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) :
     subgroupFiberOrbitMapOfLE (b := b) hHK (subgroupFiberOrbitClass H e) =
       subgroupFiberOrbitClass K e :=
   rfl
@@ -125,8 +123,7 @@ lemma subgroupFiberOrbitMapOfLE_refl (H : Subgroup (Deck p)) :
 
 /-- The maps induced by subgroup inclusions compose as expected. -/
 @[simp]
-lemma subgroupFiberOrbitMapOfLE_comp {H K L : Subgroup (Deck p)}
-    (hHK : H ≤ K) (hKL : K ≤ L) :
+lemma subgroupFiberOrbitMapOfLE_comp {H K L : Subgroup (Deck p)} (hHK : H ≤ K) (hKL : K ≤ L) :
     (subgroupFiberOrbitMapOfLE (b := b) hKL) ∘
         subgroupFiberOrbitMapOfLE (b := b) hHK =
       subgroupFiberOrbitMapOfLE (b := b) (hHK.trans hKL) := by
@@ -144,8 +141,7 @@ lemma subgroupFiberOrbitQuotient_subsingleton_iff (H : Subgroup (Deck p)) :
 
 /-- If the full deck group acts transitively on a fibre, then the quotient of that fibre by
 the full deck subgroup is a subsingleton. -/
-lemma subsingleton_subgroupFiberOrbitQuotient_top
-    [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] :
+lemma subsingleton_subgroupFiberOrbitQuotient_top [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] :
     Subsingleton (SubgroupFiberOrbitQuotient (⊤ : Subgroup (Deck p)) b) := by
   rw [subgroupFiberOrbitQuotient_subsingleton_iff]
   refine MulAction.IsPretransitive.mk ?_
@@ -220,9 +216,7 @@ lemma subgroupFiberOrbitQuotientEquiv_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h 
 transport. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquiv_symm_apply (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    (H : Subgroup (Deck p))
-    (f : q ⁻¹' {b}) :
-    (subgroupFiberOrbitQuotientEquiv h hpq H b).symm
+    (H : Subgroup (Deck p)) (f : q ⁻¹' {b}) : (subgroupFiberOrbitQuotientEquiv h hpq H b).symm
         (subgroupFiberOrbitClass
           (H.map ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) f) =
       subgroupFiberOrbitClass H ((fiberMap h hpq b).symm f) := by
@@ -305,8 +299,7 @@ lemma subgroupFiberOrbitQuotientEquiv_trans (h : E ≃ₜ F) (k : F ≃ₜ G)
 subgroup inclusions. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientEquiv_mapOfLE (h : E ≃ₜ F) (hpq : ∀ e, q (h e) = p e)
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) :
-    (subgroupFiberOrbitQuotientEquiv h hpq K b) ∘
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) : (subgroupFiberOrbitQuotientEquiv h hpq K b) ∘
         subgroupFiberOrbitMapOfLE (b := b) hHK =
       subgroupFiberOrbitMapOfLE (b := b) (Subgroup.map_mono
         (f := ((conjMulEquiv h hpq : Deck p ≃* Deck q) : Deck p →* Deck q)) hHK) ∘
@@ -472,8 +465,7 @@ lemma subgroupFiberOrbitMapOfLE_apply_eq_iff {H K L : Subgroup (Deck p)}
 
 /-- Equality after mapping two subgroup fibre quotients into a common supergroup quotient
 can be checked on representatives from the common supergroup orbit. -/
-lemma subgroupFiberOrbitMapOfLE_eq_iff {H K L : Subgroup (Deck p)}
-    (hHL : H ≤ L) (hKL : K ≤ L)
+lemma subgroupFiberOrbitMapOfLE_eq_iff {H K L : Subgroup (Deck p)} (hHL : H ≤ L) (hKL : K ≤ L)
     (x : SubgroupFiberOrbitQuotient H b) (y : SubgroupFiberOrbitQuotient K b) :
     subgroupFiberOrbitMapOfLE (b := b) hHL x = subgroupFiberOrbitMapOfLE (b := b) hKL y ↔
       ∃ e e' : p ⁻¹' {b}, x = subgroupFiberOrbitClass H e ∧
@@ -492,8 +484,7 @@ lemma subgroupFiberOrbitMapOfLE_eq_iff {H K L : Subgroup (Deck p)}
 
 /-- Equality after forgetting from `H`-orbits to full deck orbits is exactly membership of
 representatives in the same full deck orbit. -/
-lemma subgroupFiberOrbitMapToFiberOrbit_apply_eq_iff (H K : Subgroup (Deck p))
-    (e e' : p ⁻¹' {b}) :
+lemma subgroupFiberOrbitMapToFiberOrbit_apply_eq_iff (H K : Subgroup (Deck p)) (e e' : p ⁻¹' {b}) :
     subgroupFiberOrbitMapToFiberOrbit H (subgroupFiberOrbitClass H e) =
         subgroupFiberOrbitMapToFiberOrbit K (subgroupFiberOrbitClass K e') ↔
       e ∈ MulAction.orbit (Deck p) e' := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/QuotientGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/SubgroupFiberOrbit/QuotientGroup.lean
@@ -81,8 +81,7 @@ noncomputable def regularSubgroupFiberOrbitQuotientEquivQuotientGroup
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
-        (QuotientGroup.mk (s := H) φ) =
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm (QuotientGroup.mk (s := H) φ) =
       subgroupFiberOrbitClass H (φ⁻¹ • e) := by
   simp [subgroupFiberOrbitQuotientEquivQuotientGroup, subgroupFiberOrbitClass_eq_mk,
     MulAction.equivSubgroupOrbitsQuotientGroup_symm_mk H e φ]
@@ -106,8 +105,7 @@ class of the value of `φ⁻¹` on the chosen fibre point. -/
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_symm_mk_coe
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
     (H : Subgroup (Deck p)) (e : p ⁻¹' {b}) (φ : Deck p) :
-    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm
-        (QuotientGroup.mk φ) =
+    (subgroupFiberOrbitQuotientEquivQuotientGroup H e).symm (QuotientGroup.mk φ) =
       subgroupFiberOrbitClass H
         ⟨φ.1.symm e.1, by
           rw [Set.mem_preimage, Set.mem_singleton_iff]
@@ -261,8 +259,7 @@ the class of its inverse acting on the chosen fibre point. -/
 @[simp]
 lemma subgroupFiberOrbitQuotientBotEquivDeck_symm_apply
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    (e : p ⁻¹' {b}) (φ : Deck p) :
-    (subgroupFiberOrbitQuotientBotEquivDeck e).symm φ =
+    (e : p ⁻¹' {b}) (φ : Deck p) : (subgroupFiberOrbitQuotientBotEquivDeck e).symm φ =
       subgroupFiberOrbitClass (⊥ : Subgroup (Deck p)) (φ⁻¹ • e) := by
   apply (subgroupFiberOrbitQuotientBotEquivDeck e).injective
   rw [Equiv.apply_symm_apply, subgroupFiberOrbitQuotientBotEquivDeck_apply_smul]
@@ -308,8 +305,7 @@ lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_top
 @[simp]
 lemma subgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     [MulAction.IsPretransitive (Deck p) (p ⁻¹' {b})] [IsCancelSMul (Deck p) (p ⁻¹' {b})]
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
         (subgroupFiberOrbitQuotientEquivQuotientGroup H e x) =
       subgroupFiberOrbitQuotientEquivQuotientGroup K e
@@ -323,8 +319,7 @@ inclusions. -/
 @[simp]
 lemma regularSubgroupFiberOrbitQuotientEquivQuotientGroup_mapOfLE
     [TopologicalSpace B] [PreconnectedSpace E] (hp : IsCoveringMap p) (hreg : IsRegular p)
-    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b})
-    (x : SubgroupFiberOrbitQuotient H b) :
+    {H K : Subgroup (Deck p)} (hHK : H ≤ K) (e : p ⁻¹' {b}) (x : SubgroupFiberOrbitQuotient H b) :
     Subgroup.quotientMapOfLE hHK
         (regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg H e x) =
       regularSubgroupFiberOrbitQuotientEquivQuotientGroup hp hreg K e

--- a/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/PathHomotopyDiscreteness.lean
@@ -123,8 +123,7 @@ def TubeData.toSet {X : Type*} [TopologicalSpace X] {x y : X} {n : ℕ}
 
 /-- File-local adapter from Mathlib's unit-interval open-cover partition lemma to the segment
 data needed by the tube construction. -/
-private theorem Path.exists_partition_with_property {x y : X} (γ : Path x y)
-    (P : Set X → Prop)
+private theorem Path.exists_partition_with_property {x y : X} (γ : Path x y) (P : Set X → Prop)
     (h : ∀ z ∈ Set.range γ, ∃ U : Set X, IsOpen U ∧ z ∈ U ∧ P U) :
     ∃ (n : ℕ) (part : IntervalPartition n),
       ∀ i : Fin n, ∃ U : Set X, IsOpen U ∧ P U ∧
@@ -150,8 +149,7 @@ private theorem Path.exists_partition_with_property {x y : X} (γ : Path x y)
 /-- Given segment neighborhoods covering each subpath of `γ`, construct the vertex neighborhoods
 as path components of the finite intersections of adjacent segment neighborhoods. -/
 private theorem Path.exists_vertexNeighborhood_family [LocallyPathConnectedSpace X]
-    {x y : X} {γ : Path x y} {n : ℕ}
-    {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
+    {x y : X} {γ : Path x y} {n : ℕ} {t : Fin (n + 1) → unitInterval} {U : Fin n → Set X}
     (h_mono : Monotone t) (hU_open : ∀ i, IsOpen (U i))
     (hU_contains : ∀ i : Fin n, ∀ s : unitInterval,
       (t i.castSucc : ℝ) ≤ s ∧ s ≤ (t i.succ : ℝ) → γ s ∈ U i) :
@@ -204,8 +202,7 @@ path-homotopy-trivial tube.
 
 `public` because `TauCeti.AlgebraicTopology.UniversalCover.BasedPath` consumes the tube (partition
 and tube data) around a based path to build an open endpoint-preimage neighborhood. -/
-public theorem Path.exists_pathHomotopyTrivial_tube
-    [LocallyPathConnectedSpace X] {x y : X}
+public theorem Path.exists_pathHomotopyTrivial_tube [LocallyPathConnectedSpace X] {x y : X}
     (γ : Path x y) (hslsc : SemilocallySimplyConnectedOn (Set.range γ)) :
     ∃ (n : ℕ) (part : IntervalPartition n) (T : TubeData X n), PathInTube γ part T := by
   obtain ⟨n, part, h_partition⟩ := γ.exists_partition_with_property
@@ -296,8 +293,7 @@ theorem isOpen_pathTube {x y : X} {n : ℕ}
     (isOpen_setOf_forall_vertex_mem part V hV_open)
 
 /-- Given a partition and tube data, the set of paths in the tube is open in the path space. -/
-theorem TubeData.isOpen {x y : X} {n : ℕ}
-    (part : IntervalPartition n) (T : TubeData X n) :
+theorem TubeData.isOpen {x y : X} {n : ℕ} (part : IntervalPartition n) (T : TubeData X n) :
     IsOpen (T.toSet (x := x) (y := y) part) := by
   have : T.toSet (x := x) (y := y) part =
       {γ' : Path x y |
@@ -346,8 +342,7 @@ theorem Path.exists_rung_paths {x y y' : X} {n : ℕ} (γ : Path x y) (γ' : Pat
 
 /-- For a single segment in a path-homotopy-trivial set `U`, the path `γ.trans α_end` is
 homotopic to `α_start.trans γ'` when all four paths have range in `U`. -/
-theorem Path.segment_rung_homotopy {a b c d : X} (U : Set X)
-    (hU : IsPathHomotopyTrivial U)
+theorem Path.segment_rung_homotopy {a b c d : X} (U : Set X) (hU : IsPathHomotopyTrivial U)
     (γ : Path a b) (γ' : Path c d) (α_start : Path a c) (α_end : Path b d)
     (hγ : Set.range γ ⊆ U) (hγ' : Set.range γ' ⊆ U)
     (hα_start : Set.range α_start ⊆ U) (hα_end : Set.range α_end ⊆ U) :
@@ -432,10 +427,8 @@ open Path.Homotopic.Quotient in
 a single rung across one rectangle, and the rectangle homotopy `h_rectangles i` cancels it. -/
 private lemma Path.pasteSegmentAuxPath_succ_homotopic {x y y' : X} {n : ℕ}
     (γ : Path x y) (γ' : Path x y') (part : IntervalPartition n)
-    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
-    (i : Fin n)
-    (h_rectangle : Path.Homotopic
-        ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i))) (i : Fin n)
+    (h_rectangle : Path.Homotopic ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
         ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ)))) :
     Path.Homotopic (Path.pasteSegmentAuxPath γ γ' part α i.succ)
       (Path.pasteSegmentAuxPath γ γ' part α i.castSucc) := by
@@ -481,8 +474,7 @@ When the initial loop is null-homotopic, this identifies `γ'` with `γ` followe
 rung. If the final rung is also null-homotopic, we recover γ ≃ γ'. -/
 theorem Path.paste_segment_homotopies {x y y' : X} {n : ℕ}
     (γ : Path x y) (γ' : Path x y') (part : IntervalPartition n)
-    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
-    (h_rectangles : ∀ (i : Fin n),
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i))) (h_rectangles : ∀ (i : Fin n),
         Path.Homotopic
           ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
           ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ)))) :
@@ -507,20 +499,16 @@ theorem Path.paste_segment_homotopies {x y y' : X} {n : ℕ}
 
 /-- A loop whose range lies in a path-homotopy-trivial set is null-homotopic. -/
 theorem Path.nullhomotopic_of_range_subset_pathHomotopyTrivial {x : X} (γ : Path x x)
-    (U : Set X) (hU : IsPathHomotopyTrivial U)
-    (hγU : Set.range γ ⊆ U) :
+    (U : Set X) (hU : IsPathHomotopyTrivial U) (hγU : Set.range γ ⊆ U) :
     Path.Homotopic γ (Path.refl x) :=
   hU.apply γ (Path.refl x) hγU <| by
     rintro _ ⟨_, rfl⟩
     simpa [γ.source] using hγU ⟨0, rfl⟩
 
 private theorem Path.first_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial
-    {x y y' : X} {n : ℕ}
-    (γ : Path x y) (γ' : Path x y')
-    (part : IntervalPartition n)
+    {x y y' : X} {n : ℕ} (γ : Path x y) (γ' : Path x y') (part : IntervalPartition n)
     (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
-    (U₀ : Set X) (hU₀ : IsPathHomotopyTrivial U₀)
-    (h_α₀_in_U₀ : Set.range (α 0) ⊆ U₀) :
+    (U₀ : Set X) (hU₀ : IsPathHomotopyTrivial U₀) (h_α₀_in_U₀ : Set.range (α 0) ⊆ U₀) :
     let α₀ := (α 0).cast (Path.source_eq_eval_partition_zero γ part)
       (Path.source_eq_eval_partition_zero γ' part)
     Path.Homotopic α₀ (Path.refl x) := by
@@ -528,12 +516,10 @@ private theorem Path.first_rung_nullhomotopic_of_range_subset_pathHomotopyTrivia
   apply Path.nullhomotopic_of_range_subset_pathHomotopyTrivial α₀ U₀ hU₀
   simpa only [α₀, Path.cast_coe] using h_α₀_in_U₀
 
-private theorem Path.last_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial
-    {x y : X} {n : ℕ}
+private theorem Path.last_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial {x y : X} {n : ℕ}
     (γ γ' : Path x y) (part : IntervalPartition n)
     (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
-    (Uₙ : Set X) (hUₙ : IsPathHomotopyTrivial Uₙ)
-    (h_αₙ_in_Uₙ : Set.range (α (Fin.last n)) ⊆ Uₙ) :
+    (Uₙ : Set X) (hUₙ : IsPathHomotopyTrivial Uₙ) (h_αₙ_in_Uₙ : Set.range (α (Fin.last n)) ⊆ Uₙ) :
     let αₙ := (α (Fin.last n)).cast
       (Path.target_eq_eval_partition_last γ part)
       (Path.target_eq_eval_partition_last γ' part)
@@ -546,10 +532,8 @@ private theorem Path.last_rung_nullhomotopic_of_range_subset_pathHomotopyTrivial
 first rung has range in a path-homotopy-trivial set. Then `γ'` is homotopic to `γ` followed by
 the final rung. -/
 theorem Path.paste_segment_homotopies_pathHomotopyTrivial_source {x y y' : X} {n : ℕ}
-    (γ : Path x y) (γ' : Path x y')
-    (part : IntervalPartition n)
-    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
-    (h_rectangles : ∀ (i : Fin n),
+    (γ : Path x y) (γ' : Path x y') (part : IntervalPartition n)
+    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i))) (h_rectangles : ∀ (i : Fin n),
         Path.Homotopic
           ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
           ((α i.castSucc).trans (γ'.subpath (part.t i.castSucc) (part.t i.succ))))
@@ -576,8 +560,7 @@ followed by the final endpoint rung.
 variable-endpoint statement to move between based paths with distinct endpoints inside a common
 path component of `endpoint ⁻¹' U`; the fixed-endpoint public API does not suffice there. -/
 public theorem Path.tube_subset_homotopy_class_source {x y y' : X} {n : ℕ}
-    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n)
-    (hγ : PathInTube γ part T)
+    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n) (hγ : PathInTube γ part T)
     (γ' : Path x y') (hγ' : PathInTube γ' part T) :
     ∃ ρ : Path y y', Set.range ρ ⊆ T.V (Fin.last n) ∧ Path.Homotopic (γ.trans ρ) γ' := by
   cases n with
@@ -606,8 +589,7 @@ public theorem Path.tube_subset_homotopy_class_source {x y y' : X} {n : ℕ}
 
 /-- Two-sided specialization of `paste_segment_homotopies` killing both endpoint loops. -/
 theorem Path.paste_segment_homotopies_pathHomotopyTrivial {x y : X} {n : ℕ} (γ γ' : Path x y)
-    (part : IntervalPartition n)
-    (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
+    (part : IntervalPartition n) (α : (i : Fin (n + 1)) → Path (γ (part.t i)) (γ' (part.t i)))
     (h_rectangles : ∀ (i : Fin n),
         Path.Homotopic
           ((γ.subpath (part.t i.castSucc) (part.t i.succ)).trans (α i.succ))
@@ -630,8 +612,7 @@ theorem Path.paste_segment_homotopies_pathHomotopyTrivial {x y : X} {n : ℕ} (�
 
 /-- Any fixed-endpoint path in the same tube as `γ` is homotopic to `γ`. -/
 theorem Path.tube_subset_homotopy_class {x y : X} {n : ℕ}
-    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n)
-    (hγ : PathInTube γ part T)
+    (γ : Path x y) (part : IntervalPartition n) (T : TubeData X n) (hγ : PathInTube γ part T)
     (γ' : Path x y) (hγ' : PathInTube γ' part T) :
     Path.Homotopic γ' γ := by
   cases n with

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/EilenbergMacLane.lean
@@ -44,8 +44,7 @@ theorem isAspherical_pi (p : ι → ℝ) (x : ∀ i, AddCircle (p i)) :
 
 /-- An indexed product of real additive circles with nonzero periods is an Eilenberg--Mac
 Lane space of type `K(Π i, ℤ, 1)`. No finiteness assumption on the index type is needed. -/
-theorem isEilenbergMacLaneSpaceOne_pi (p : ι → ℝ) (hp : ∀ i, p i ≠ 0)
-    (x : ∀ i, AddCircle (p i)) :
+theorem isEilenbergMacLaneSpaceOne_pi (p : ι → ℝ) (hp : ∀ i, p i ≠ 0) (x : ∀ i, AddCircle (p i)) :
     TauCeti.IsEilenbergMacLaneSpaceOne (∀ _ : ι, Multiplicative ℤ)
       (∀ i, AddCircle (p i)) x :=
   TauCeti.IsEilenbergMacLaneSpaceOne.pi fun i ↦

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/FundamentalGroup.lean
@@ -100,8 +100,7 @@ theorem piFundamentalGroupMulEquiv_apply {ι : Type*} {p : ι → ℝ} (hp : ∀
 @[simp]
 theorem piFundamentalGroupMulEquiv_symm_apply {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
     {x : ∀ i, AddCircle (p i)} (e : ∀ i, ((↑) : ℝ → AddCircle (p i)) ⁻¹' {x i})
-    (n : ∀ _ : ι, Multiplicative ℤ) :
-    (piFundamentalGroupMulEquiv hp e).symm n =
+    (n : ∀ _ : ι, Multiplicative ℤ) : (piFundamentalGroupMulEquiv hp e).symm n =
       pi fun i => (fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm (n i) :=
   FundamentalGroup.piMulEquiv_symm_apply x
     ((MulEquiv.piCongrRight fun i => fundamentalGroupMulEquiv (p i) (hp i) (e i)).symm n)
@@ -129,8 +128,7 @@ theorem prodFundamentalGroupMulEquiv_zero_apply {p q : ℝ} (hp : p ≠ 0) (hq :
 
 @[simp]
 theorem prodFundamentalGroupMulEquiv_zero_symm_apply {p q : ℝ} (hp : p ≠ 0) (hq : q ≠ 0)
-    (mn : Multiplicative ℤ × Multiplicative ℤ) :
-    (prodFundamentalGroupMulEquiv_zero hp hq).symm mn =
+    (mn : Multiplicative ℤ × Multiplicative ℤ) : (prodFundamentalGroupMulEquiv_zero hp hq).symm mn =
       prod ((fundamentalGroupMulEquiv_zero p hp).symm mn.1)
         ((fundamentalGroupMulEquiv_zero q hq).symm mn.2) := by
   simp [prodFundamentalGroupMulEquiv_zero]
@@ -143,8 +141,7 @@ def piFundamentalGroupMulEquiv_zero {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p
   piFundamentalGroupMulEquiv hp fun i => ⟨0, by simp⟩
 
 @[simp]
-theorem piFundamentalGroupMulEquiv_zero_apply {ι : Type*} {p : ι → ℝ}
-    (hp : ∀ i, p i ≠ 0)
+theorem piFundamentalGroupMulEquiv_zero_apply {ι : Type*} {p : ι → ℝ} (hp : ∀ i, p i ≠ 0)
     (γ : FundamentalGroup (∀ i, AddCircle (p i)) (fun _ => 0)) (i : ι) :
     piFundamentalGroupMulEquiv_zero hp γ i =
       fundamentalGroupMulEquiv_zero (p i) (hp i)

--- a/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Torus/HigherHomotopy.lean
@@ -49,8 +49,7 @@ theorem homotopyGroup_pi_eq_one [DecidableEq N]
   Subsingleton.elim _ _
 
 /-- Every element of `π_(n + 2)` of an indexed product of real circles is the identity. -/
-theorem homotopyGroupPi_pi_eq_one (n : ℕ)
-    (a : π_ (n + 2) (∀ i, AddCircle (p i)) x) : a = 1 :=
+theorem homotopyGroupPi_pi_eq_one (n : ℕ) (a : π_ (n + 2) (∀ i, AddCircle (p i)) x) : a = 1 :=
   homotopyGroup_pi_eq_one p x a
 
 end AddCircle


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/AlgebraicTopology/UniversalCover/`: 152 joins across 30 files, `-152` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 30 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Width is measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports.

Two deliberate exclusions, so this does not collide with work in progress: `RealProjective/Basic.lean` (open #1679) and `Deck/FundamentalGroup/UniversalCover.lean` (open #1594). The rest of the directory is packed uniformly.

One line in the directory exceeds 100 characters — `Classification/SubgroupQuotient.lean:36`, an unsplittable markdown URL in a module docstring. It is pre-existing and untouched by this PR; it is not introduced here.

Gates: `lake build` (6159 jobs) · `lake exe axioms` (19110 declarations, allowlist clean) · `lake exe module-system` (1051 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none