### PR TITLE
feat: construct the kernel of an affine group-scheme morphism

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Kernel
+
+/-!
+# Points of the kernel of an affine group-scheme morphism
+
+For a morphism `f : H ⟶ K` of commutative Hopf algebras, the kernel closed subgroup
+scheme `TauCeti.CommHopfAlgCat.kernelSpec f` is cut out by the kernel Hopf ideal. This
+file records its kernel semantics on functors of points: for every commutative
+`R`-algebra `A`, an `A`-point of the source group scheme maps to the unit point exactly
+when it lies in the subgroup of points cut out by the kernel Hopf ideal — the `A`-points
+of the kernel. Since this holds for all test algebras, by Yoneda the kernel closed
+subgroup scheme represents the kernel of the induced morphism of group-valued points
+functors.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff`: the points-level kernel
+  property.
+-/
+
+public section
+
+open CategoryTheory WithConv
+
+namespace TauCeti
+
+universe u w
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
+
+/-- Kernel semantics on functors of points: for every commutative `R`-algebra `A`, an
+`A`-point of the source is sent to the unit point exactly when it lies in the subgroup of
+points cut out by the kernel Hopf ideal — the `A`-points of `kernelSpec f`. This is the
+universal property of the kernel tested against arbitrary algebras; by Yoneda,
+`kernelSpec f` represents the kernel of the induced morphism of group-valued points
+functors. -/
+theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
+    (g : HopfAlgebra.points (R := R) (H := K) A) :
+    (mapPointsFunctor f).app A g = 1 ↔
+      g ∈ quotientPointsSubgroup K (kernelHopfIdeal f) A := by
+  rw [mem_quotientPointsSubgroup_iff]
+  have hbridge : (∀ h : ↥K, h ∈ kernelHopfIdeal f → g.ofConv h = 0) ↔
+      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.ofConv.toRingHom := by
+    constructor
+    · intro hg x hx
+      exact RingHom.mem_ker.mpr (hg x (HopfIdeal.mem_toIdeal.mp hx))
+    · intro hle x hx
+      exact RingHom.mem_ker.mp (hle (HopfIdeal.mem_toIdeal.mpr hx))
+  rw [hbridge, kernelHopfIdeal_toIdeal_le_ker_iff]
+  constructor
+  · intro h1
+    ext a
+    have hval := congrArg
+      (fun ψ : HopfAlgebra.points (R := R) (H := H) A => ψ.ofConv a) h1
+    rw [mapPointsFunctor_app_apply_apply] at hval
+    simpa [Algebra.ofId_apply] using hval.trans (AlgHom.convOne_apply a)
+  · intro heq
+    rw [mapPointsFunctor_app_apply, heq]
+    refine ofConv_injective ?_
+    ext a
+    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
+    exact (AlgHom.convOne_apply a).symm
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Kernel
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel
 
 /-!
 # Points of the kernel of an affine group-scheme morphism
@@ -43,6 +43,7 @@ points cut out by the kernel Hopf ideal — the `A`-points of `kernelSpec f`. Th
 universal property of the kernel tested against arbitrary algebras; by Yoneda,
 `kernelSpec f` represents the kernel of the induced morphism of group-valued points
 functors. -/
+@[simp]
 theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K) A) :
     (mapPointsFunctor f).app A g = 1 ↔

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Points/Kernel.lean
@@ -46,9 +46,9 @@ functors. -/
 @[simp]
 theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
     (g : HopfAlgebra.points (R := R) (H := K) A) :
-    (mapPointsFunctor f).app A g = 1 ↔
+    toConv (g.ofConv.comp (f.hom : ↥H →ₐ[R] ↥K)) = 1 ↔
       g ∈ quotientPointsSubgroup K (kernelHopfIdeal f) A := by
-  rw [mem_quotientPointsSubgroup_iff]
+  rw [← mapPointsFunctor_app_apply, mem_quotientPointsSubgroup_iff]
   have hbridge : (∀ h : ↥K, h ∈ kernelHopfIdeal f → g.ofConv h = 0) ↔
       (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.ofConv.toRingHom := by
     constructor

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel.lean
@@ -58,6 +58,14 @@ represents the kernel of that morphism. -/
 noncomputable def kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
   (HopfIdeal.augmentation R H).map f.hom
 
+/-- `kernelHopfIdeal` is the extension of the augmentation ideal along the morphism. -/
+theorem kernelHopfIdeal_def (f : H ⟶ K) :
+    kernelHopfIdeal f = (HopfIdeal.augmentation R H).map f.hom := by
+  -- `kernelHopfIdeal` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change (HopfIdeal.augmentation R H).map f.hom = _
+  rfl
+
 /-- The underlying ideal of the kernel Hopf ideal is the extension of the augmentation
 ideal. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Quotient/Kernel.lean
@@ -1,0 +1,169 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
+
+/-!
+# The kernel Hopf ideal of a morphism of commutative Hopf algebras
+
+For a morphism `f : H ⟶ K` of commutative Hopf algebras, the kernel Hopf ideal is the
+extension of the augmentation ideal of `H` along `f` — the ideal `K·f(H⁺)` of the
+codomain, which is the coordinate ring of the *source* of the induced morphism of affine
+group schemes. Quotienting by it cuts out the kernel closed subgroup scheme
+(`TauCeti.CommHopfAlgCat.kernelSpec`, in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Kernel`).
+
+The kernel semantics live at this coordinate level: the trivialization criterion says a
+map out of `K` kills the kernel Hopf ideal exactly when its composite with `f` is the
+trivial (counit-unit) morphism, for an arbitrary ring-valued algebra target, for
+Hopf-algebra morphisms, and for Hopf-ideal quotients; the coordinate-ring triangle is the
+`mkQuotient` special case. The coordinate-level factorization and its uniqueness are
+`TauCeti.CommHopfAlgCat.liftQuotient` and `TauCeti.CommHopfAlgCat.liftQuotient_unique`.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal`: the kernel Hopf ideal of a morphism.
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_toIdeal_le_ker_iff` and
+  `TauCeti.CommHopfAlgCat.comp_eq_unit_comp_counit_iff`: the trivialization criterion.
+* `TauCeti.CommHopfAlgCat.comp_mkQuotient_kernelHopfIdeal`: the coordinate-ring triangle.
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_le_iff`: the Hopf-ideal-quotient form.
+
+## References
+
+Milne, *Algebraic Groups*, Proposition 4.1: the kernel of a homomorphism of affine
+algebraic groups is represented by the quotient by this ideal.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u w
+
+namespace CommHopfAlgCat
+
+variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
+
+/-- The kernel Hopf ideal of a morphism of commutative Hopf algebras: the image of the
+augmentation ideal of the source. It is an ideal of the *codomain* `K`, the coordinate
+ring of the source of the induced group-scheme morphism `Spec K ⟶ Spec H`; its quotient
+represents the kernel of that morphism. -/
+noncomputable def kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
+  (HopfIdeal.augmentation R H).map f.hom
+
+/-- The underlying ideal of the kernel Hopf ideal is the extension of the augmentation
+ideal. -/
+@[simp]
+theorem kernelHopfIdeal_toIdeal (f : H ⟶ K) :
+    (kernelHopfIdeal f).toIdeal =
+      Ideal.map (f.hom : ↥H →+* ↥K) (HopfIdeal.augmentation R H).toIdeal := by
+  -- `kernelHopfIdeal` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding to a `HopfIdeal.map` application.
+  change ((HopfIdeal.augmentation R H).map f.hom).toIdeal = _
+  rw [HopfIdeal.map_toIdeal]
+
+/-- The kernel Hopf ideal contains the image of every counit-vanishing element. -/
+theorem mem_kernelHopfIdeal_of_mem_augmentation (f : H ⟶ K) {x : H}
+    (hx : Coalgebra.counit (R := R) x = 0) : f.hom x ∈ kernelHopfIdeal f :=
+  HopfIdeal.mem_map_of_mem f.hom ((HopfIdeal.mem_augmentation R H).mpr hx)
+
+-- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
+-- definitional unfolding to `algebraMap` in one place (upstream candidate).
+private lemma unitBialgHom_apply {A : Type u} [Semiring A] [Bialgebra R A] (r : R) :
+    Bialgebra.unitBialgHom R A r = algebraMap R A r :=
+  rfl
+
+/-- The difference between a morphism value and the counit-unit value lies in the kernel
+Hopf ideal. -/
+private theorem sub_algebraMap_counit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
+    f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈ kernelHopfIdeal f := by
+  have hx : Coalgebra.counit (R := R)
+      (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
+    simp
+  simpa [map_sub, AlgHomClass.commutes] using
+    mem_kernelHopfIdeal_of_mem_augmentation f hx
+
+/-- Algebra-level trivialization criterion: an algebra map out of the coordinate ring of
+the source group scheme kills the kernel Hopf ideal exactly when its composite with `f`
+is the counit-unit composite. This is the kernel property tested against an arbitrary
+commutative `R`-algebra; `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` (in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel`) packages it on the functors of
+points. -/
+theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [Ring A]
+    [Algebra R A] (φ : ↥K →ₐ[R] A) :
+    (kernelHopfIdeal f).toIdeal ≤ RingHom.ker φ.toRingHom ↔
+      φ.comp (f.hom : ↥H →ₐ[R] ↥K) =
+        (Algebra.ofId R A).comp (Bialgebra.counitAlgHom R ↥H) := by
+  constructor
+  · intro hle
+    ext h
+    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_algebraMap_counit_mem_kernelHopfIdeal f h))
+    rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
+    simpa [Algebra.ofId_apply, AlgHomClass.commutes] using hker
+  · intro heq
+    rw [kernelHopfIdeal_toIdeal, Ideal.map_le_iff_le_comap]
+    intro x hx
+    have hx0 : Coalgebra.counit (R := R) x = 0 :=
+      (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
+    have hval := congrArg (fun ψ : ↥H →ₐ[R] A => ψ x) heq
+    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply] at hval
+    rw [Ideal.mem_comap, RingHom.mem_ker]
+    simpa [hx0] using hval
+
+/-- The trivialization criterion for Hopf-algebra morphisms: a morphism out of `K` kills
+the kernel Hopf ideal of `f` exactly when its composite with `f` is the trivial
+(counit-unit) morphism. -/
+theorem comp_eq_unit_comp_counit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
+    (g : K ⟶ L) :
+    f ≫ g =
+        _root_.CommHopfAlgCat.ofHom
+          ((Bialgebra.unitBialgHom R L).comp (Bialgebra.counitBialgHom R H)) ↔
+      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.hom.toAlgHom.toRingHom := by
+  rw [kernelHopfIdeal_toIdeal_le_ker_iff f g.hom.toAlgHom]
+  constructor
+  · intro heq
+    ext h
+    have hval := congrArg (fun ψ : H ⟶ L => ψ.hom h) heq
+    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
+      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
+  · intro heq
+    ext h
+    have hval := congrArg (fun ψ : ↥H →ₐ[R] ↥L => ψ h) heq
+    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
+      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
+
+/-- The coordinate-ring triangle: composing `f` with the quotient by its kernel Hopf
+ideal is the counit-unit composite, i.e. the coordinate map of the trivial group-scheme
+morphism. -/
+@[simp]
+theorem comp_mkQuotient_kernelHopfIdeal (f : H ⟶ K) :
+    f ≫ mkQuotient K (kernelHopfIdeal f) =
+      _root_.CommHopfAlgCat.ofHom
+        ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
+          (Bialgebra.counitBialgHom R H)) :=
+  (comp_eq_unit_comp_counit_iff f _).mpr (mkQuotient_ker K (kernelHopfIdeal f) ▸ le_rfl)
+
+/-- The Hopf-ideal-quotient form of the trivialization criterion: `f` trivializes on the
+closed subgroup scheme cut out by `J` exactly when `J` contains the kernel Hopf ideal.
+Combined with `TauCeti.CommHopfAlgCat.quotientSpecMapOfLe` and
+`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι`, such a quotient closed
+subgroup scheme includes into the kernel compatibly with the inclusions. -/
+theorem kernelHopfIdeal_le_iff (f : H ⟶ K) {J : HopfIdeal R K} :
+    kernelHopfIdeal f ≤ J ↔
+      f ≫ mkQuotient K J =
+        _root_.CommHopfAlgCat.ofHom
+          ((Bialgebra.unitBialgHom R (quotient K J)).comp
+            (Bialgebra.counitBialgHom R H)) := by
+  rw [comp_eq_unit_comp_counit_iff, mkQuotient_ker]
+  exact HopfIdeal.toIdeal_le_toIdeal.symm
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
+public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
+
+/-!
+# The kernel of a morphism of affine group schemes
+
+A morphism `f : H ⟶ K` of commutative Hopf algebras induces contravariantly a morphism of
+affine group schemes `Spec K ⟶ Spec H` over `Spec R`. Its kernel is the closed subgroup
+scheme of `Spec K` cut out by the kernel Hopf ideal: the image under `f` of the
+augmentation ideal of `H`, whose quotient coordinate ring is `K ⊗[H] R`.
+
+This file constructs the kernel Hopf ideal, the kernel closed subgroup scheme, and its
+closed immersion into the source, and proves the defining triangle: composing the induced
+group-scheme morphism with the kernel inclusion is the trivial morphism, because the
+composite coordinate map `H ⟶ K ⟶ K ⧸ K·f(H⁺)` is the counit-unit composite.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal`: the kernel Hopf ideal of a morphism.
+* `TauCeti.CommHopfAlgCat.mem_kernelHopfIdeal_of_mem_augmentation`: its generators.
+* `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the kernel
+  closed subgroup scheme and its inclusion (a closed immersion, by
+  `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`).
+* `TauCeti.CommHopfAlgCat.comp_mkQuotient_kernelHopfIdeal`: the coordinate-ring triangle.
+* `TauCeti.CommHopfAlgCat.kernelSpecι_comp`: the scheme-level triangle.
+
+## References
+
+Milne, *Algebraic Groups*, Proposition 4.1: the kernel of a homomorphism of affine
+algebraic groups is represented by `O(K) / I_H O(K)` for `I_H` the augmentation ideal.
+The same-universe restriction on the Hopf algebras is imposed by Mathlib's current
+`hopfSpec` construction, as in `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic`.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+namespace CommHopfAlgCat
+
+open AlgebraicGeometry
+
+variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
+
+/-- The kernel Hopf ideal of a morphism of commutative Hopf algebras: the image of the
+augmentation ideal of the source. Its quotient represents the kernel of the induced
+morphism of affine group schemes. -/
+noncomputable abbrev kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
+  (HopfIdeal.augmentation R H).map f.hom
+
+/-- The kernel Hopf ideal contains the image of every counit-vanishing element. -/
+theorem mem_kernelHopfIdeal_of_mem_augmentation (f : H ⟶ K) {x : H}
+    (hx : Coalgebra.counit (R := R) x = 0) : f.hom x ∈ kernelHopfIdeal f :=
+  HopfIdeal.mem_map_of_mem f.hom ((HopfIdeal.mem_augmentation R H).mpr hx)
+
+/-- The kernel of the induced morphism of affine group schemes, as an affine group
+scheme: the closed subgroup scheme of the source cut out by the kernel Hopf ideal. -/
+noncomputable abbrev kernelSpec (f : H ⟶ K) :
+    Grp (Over (Spec (CommRingCat.of R))) :=
+  quotientSpec K (kernelHopfIdeal f)
+
+/-- The inclusion of the kernel into the source group scheme. Its underlying scheme
+morphism is a closed immersion by
+`TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`. -/
+noncomputable abbrev kernelSpecι (f : H ⟶ K) :
+    kernelSpec f ⟶
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op K) :=
+  quotientSpecι K (kernelHopfIdeal f)
+
+-- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
+-- definitional unfolding to `algebraMap` in one place (upstream candidate).
+private lemma unitBialgHom_apply {A : Type u} [Semiring A] [Bialgebra R A] (r : R) :
+    Bialgebra.unitBialgHom R A r = algebraMap R A r :=
+  rfl
+
+/-- The coordinate-ring triangle defining the kernel: composing `f` with the quotient by
+the kernel Hopf ideal is the counit-unit composite, i.e. the coordinate map of the trivial
+group-scheme morphism. -/
+theorem comp_mkQuotient_kernelHopfIdeal (f : H ⟶ K) :
+    f ≫ mkQuotient K (kernelHopfIdeal f) =
+      _root_.CommHopfAlgCat.ofHom
+        ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
+          (Bialgebra.counitBialgHom R H)) := by
+  ext h
+  have hmem : f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈
+      kernelHopfIdeal f := by
+    have hx : Coalgebra.counit (R := R)
+        (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
+      simp
+    simpa [map_sub, AlgHomClass.commutes] using
+      mem_kernelHopfIdeal_of_mem_augmentation f hx
+  have hquot :
+      (mkQuotient K (kernelHopfIdeal f)).hom
+          (f.hom h - algebraMap R K (Coalgebra.counit (R := R) h)) = 0 :=
+    (mkQuotient_eq_zero_iff K (kernelHopfIdeal f) _).mpr
+      (HopfIdeal.mem_toIdeal.mpr hmem)
+  rw [map_sub, sub_eq_zero] at hquot
+  simpa [unitBialgHom_apply] using hquot
+
+/-- The scheme-level triangle: the composite of the kernel inclusion with the induced
+group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the
+counit-unit composite. -/
+theorem kernelSpecι_comp (f : H ⟶ K) :
+    kernelSpecι f ≫ (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
+        (_root_.CommHopfAlgCat.ofHom
+          ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
+            (Bialgebra.counitBialgHom R H))).op := by
+  rw [kernelSpecι, quotientSpecι_def, ← Functor.map_comp, ← op_comp,
+    comp_mkQuotient_kernelHopfIdeal]
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
@@ -54,11 +55,11 @@ The same-universe restriction on the Hopf algebras is imposed by Mathlib's curre
 
 public section
 
-open CategoryTheory
+open CategoryTheory WithConv
 
 namespace TauCeti
 
-universe u
+universe u w
 
 namespace CommHopfAlgCat
 
@@ -108,31 +109,53 @@ private theorem sub_counitUnit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
   simpa [map_sub, AlgHomClass.commutes] using
     mem_kernelHopfIdeal_of_mem_augmentation f hx
 
-/-- The trivialization criterion, the defining property of the kernel among Hopf-ideal
-quotients: a morphism out of `K` kills the kernel Hopf ideal of `f` exactly when its
-composite with `f` is the trivial (counit-unit) morphism. -/
+/-- Algebra-level trivialization criterion: an algebra map out of the coordinate ring of
+the source group scheme kills the kernel Hopf ideal exactly when its composite with `f`
+is the counit-unit composite. This is the kernel property tested against an arbitrary
+commutative `R`-algebra; `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_kernelHopfIdeal`
+packages it on the functors of points. -/
+theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [CommRing A]
+    [Algebra R A] (φ : ↥K →ₐ[R] A) :
+    (kernelHopfIdeal f).toIdeal ≤ RingHom.ker φ.toRingHom ↔
+      φ.comp (f.hom : ↥H →ₐ[R] ↥K) =
+        (Algebra.ofId R A).comp (Bialgebra.counitAlgHom R ↥H) := by
+  constructor
+  · intro hle
+    ext h
+    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_counitUnit_mem_kernelHopfIdeal f h))
+    rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
+    simpa [Algebra.ofId_apply, AlgHomClass.commutes] using hker
+  · intro heq
+    rw [HopfIdeal.map_toIdeal, Ideal.map_le_iff_le_comap]
+    intro x hx
+    have hx0 : Coalgebra.counit (R := R) x = 0 :=
+      (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
+    have hval := congrArg (fun ψ : ↥H →ₐ[R] A => ψ x) heq
+    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply] at hval
+    rw [Ideal.mem_comap, RingHom.mem_ker]
+    simpa [hx0] using hval
+
+/-- The trivialization criterion for Hopf-algebra morphisms: a morphism out of `K` kills
+the kernel Hopf ideal of `f` exactly when its composite with `f` is the trivial
+(counit-unit) morphism. -/
 theorem comp_eq_counitUnit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
     (g : K ⟶ L) :
     f ≫ g =
         _root_.CommHopfAlgCat.ofHom
           ((Bialgebra.unitBialgHom R L).comp (Bialgebra.counitBialgHom R H)) ↔
       (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.hom.toAlgHom.toRingHom := by
+  rw [kernelHopfIdeal_toIdeal_le_ker_iff f g.hom.toAlgHom]
   constructor
   · intro heq
-    rw [HopfIdeal.map_toIdeal, Ideal.map_le_iff_le_comap]
-    intro x hx
-    have hx0 : Coalgebra.counit (R := R) x = 0 :=
-      (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
-    have hval := congrArg (fun φ : H ⟶ L => φ.hom x) heq
-    simp only [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
-      BialgHom.comp_apply, unitBialgHom_apply, Bialgebra.counitBialgHom_apply] at hval
-    rw [Ideal.mem_comap, RingHom.mem_ker]
-    simpa [hx0] using hval
-  · intro hle
     ext h
-    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_counitUnit_mem_kernelHopfIdeal f h))
-    rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
-    simpa [unitBialgHom_apply, AlgHomClass.commutes] using hker
+    have hval := congrArg (fun ψ : H ⟶ L => ψ.hom h) heq
+    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
+      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
+  · intro heq
+    ext h
+    have hval := congrArg (fun ψ : ↥H →ₐ[R] ↥L => ψ h) heq
+    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
+      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
 
 /-- The coordinate-ring triangle: composing `f` with the quotient by its kernel Hopf
 ideal is the counit-unit composite, i.e. the coordinate map of the trivial group-scheme
@@ -157,6 +180,44 @@ theorem kernelHopfIdeal_le_iff (f : H ⟶ K) {J : HopfIdeal R K} :
             (Bialgebra.counitBialgHom R H)) := by
   rw [comp_eq_counitUnit_iff, mkQuotient_ker]
   exact HopfIdeal.toIdeal_le_toIdeal.symm
+
+/-- Kernel semantics on functors of points: for every commutative `R`-algebra `A`, an
+`A`-point of the source is sent to the unit point exactly when it lies in the subgroup of
+points cut out by the kernel Hopf ideal — the `A`-points of `kernelSpec f`. This is the
+universal property of the kernel tested against arbitrary algebras; by Yoneda,
+`kernelSpec f` represents the kernel of the induced morphism of group-valued points
+functors. -/
+theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
+    (g : HopfAlgebra.points (R := R) (H := K) A) :
+    (mapPointsFunctor f).app A g = 1 ↔
+      g ∈ quotientPointsSubgroup K (kernelHopfIdeal f) A := by
+  rw [mem_quotientPointsSubgroup_iff]
+  have hbridge : (∀ h : ↥K, h ∈ kernelHopfIdeal f → g.ofConv h = 0) ↔
+      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.ofConv.toRingHom := by
+    constructor
+    · intro hg x hx
+      exact RingHom.mem_ker.mpr (hg x (HopfIdeal.mem_toIdeal.mp hx))
+    · intro hle x hx
+      exact RingHom.mem_ker.mp (hle (HopfIdeal.mem_toIdeal.mpr hx))
+  rw [hbridge, kernelHopfIdeal_toIdeal_le_ker_iff]
+  constructor
+  · intro h1
+    ext a
+    have hval := congrArg
+      (fun ψ : HopfAlgebra.points (R := R) (H := H) A => ψ.ofConv a) h1
+    rw [mapPointsFunctor_app_apply_apply] at hval
+    -- `(1 : WithConv _).ofConv a = algebraMap R A (counit a)` holds by definition of the
+    -- convolution unit (`AlgHom.convOne_apply`); `rfl` performs that identification.
+    have hone : (WithConv.ofConv (1 : HopfAlgebra.points (R := R) (H := H) A)) a =
+        algebraMap R A (Coalgebra.counit (R := R) a) := rfl
+    simpa [Algebra.ofId_apply] using hval.trans hone
+  · intro heq
+    rw [mapPointsFunctor_app_apply, heq]
+    refine ofConv_injective ?_
+    ext a
+    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
+    -- Same definitional identification of the convolution unit as above.
+    exact rfl
 
 /-- The scheme-level triangle: the composite of the kernel inclusion with the induced
 group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -73,8 +73,8 @@ theorem kernelSpecι_def (f : H ⟶ K) :
 
 /-- The scheme-level triangle: the composite of the kernel inclusion with the induced
 group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the
-counit-unit composite. -/
-@[simp]
+counit-unit composite. Not a `simp` lemma: Mathlib's simp set unfolds `hopfSpec.map`
+itself, so this left-hand side is not in simp-normal form. -/
 theorem kernelSpecι_comp (f : H ⟶ K) :
     kernelSpecι f ≫ (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op =
       (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
 public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
@@ -39,8 +38,10 @@ section is future work.
 * `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the kernel
   closed subgroup scheme and its inclusion (a closed immersion, by
   `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`).
-* `TauCeti.CommHopfAlgCat.comp_eq_counitUnit_iff`: the trivialization criterion — a
-  morphism kills the kernel Hopf ideal exactly when its composite with `f` is trivial.
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_toIdeal_le_ker_iff` and
+  `TauCeti.CommHopfAlgCat.comp_eq_unit_comp_counit_iff`: the trivialization criterion — a
+  map out of the coordinate ring kills the kernel Hopf ideal exactly when its composite
+  with `f` is trivial.
 * `TauCeti.CommHopfAlgCat.kernelHopfIdeal_le_iff`: its Hopf-ideal-quotient form.
 * `TauCeti.CommHopfAlgCat.comp_mkQuotient_kernelHopfIdeal`: the coordinate-ring triangle.
 * `TauCeti.CommHopfAlgCat.kernelSpecι_comp`: the scheme-level triangle.
@@ -71,8 +72,19 @@ variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
 augmentation ideal of the source. It is an ideal of the *codomain* `K`, the coordinate
 ring of the source of the induced group-scheme morphism `Spec K ⟶ Spec H`; its quotient
 represents the kernel of that morphism. -/
-noncomputable abbrev kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
+noncomputable def kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
   (HopfIdeal.augmentation R H).map f.hom
+
+/-- The underlying ideal of the kernel Hopf ideal is the extension of the augmentation
+ideal. -/
+@[simp]
+theorem kernelHopfIdeal_toIdeal (f : H ⟶ K) :
+    (kernelHopfIdeal f).toIdeal =
+      Ideal.map (f.hom : ↥H →+* ↥K) (HopfIdeal.augmentation R H).toIdeal := by
+  -- `kernelHopfIdeal` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding to a `HopfIdeal.map` application.
+  change ((HopfIdeal.augmentation R H).map f.hom).toIdeal = _
+  rw [HopfIdeal.map_toIdeal]
 
 /-- The kernel Hopf ideal contains the image of every counit-vanishing element. -/
 theorem mem_kernelHopfIdeal_of_mem_augmentation (f : H ⟶ K) {x : H}
@@ -88,10 +100,18 @@ noncomputable abbrev kernelSpec (f : H ⟶ K) :
 /-- The inclusion of the kernel into the source group scheme. Its underlying scheme
 morphism is a closed immersion by
 `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`. -/
-noncomputable abbrev kernelSpecι (f : H ⟶ K) :
+noncomputable def kernelSpecι (f : H ⟶ K) :
     kernelSpec f ⟶
       (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op K) :=
   quotientSpecι K (kernelHopfIdeal f)
+
+/-- `kernelSpecι` is the quotient inclusion at the kernel Hopf ideal. -/
+theorem kernelSpecι_def (f : H ⟶ K) :
+    kernelSpecι f = quotientSpecι K (kernelHopfIdeal f) := by
+  -- `kernelSpecι` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change quotientSpecι K (kernelHopfIdeal f) = _
+  rfl
 
 -- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
 -- definitional unfolding to `algebraMap` in one place (upstream candidate).
@@ -101,7 +121,7 @@ private lemma unitBialgHom_apply {A : Type u} [Semiring A] [Bialgebra R A] (r : 
 
 /-- The difference between a morphism value and the counit-unit value lies in the kernel
 Hopf ideal. -/
-private theorem sub_counitUnit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
+private theorem sub_algebraMap_counit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
     f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈ kernelHopfIdeal f := by
   have hx : Coalgebra.counit (R := R)
       (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
@@ -112,9 +132,10 @@ private theorem sub_counitUnit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
 /-- Algebra-level trivialization criterion: an algebra map out of the coordinate ring of
 the source group scheme kills the kernel Hopf ideal exactly when its composite with `f`
 is the counit-unit composite. This is the kernel property tested against an arbitrary
-commutative `R`-algebra; `TauCeti.CommHopfAlgCat.quotientPointsSubgroup_kernelHopfIdeal`
-packages it on the functors of points. -/
-theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [CommRing A]
+commutative `R`-algebra; `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` (in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel`) packages it on the functors of
+points. -/
+theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [Ring A]
     [Algebra R A] (φ : ↥K →ₐ[R] A) :
     (kernelHopfIdeal f).toIdeal ≤ RingHom.ker φ.toRingHom ↔
       φ.comp (f.hom : ↥H →ₐ[R] ↥K) =
@@ -122,11 +143,11 @@ theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [CommRing 
   constructor
   · intro hle
     ext h
-    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_counitUnit_mem_kernelHopfIdeal f h))
+    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_algebraMap_counit_mem_kernelHopfIdeal f h))
     rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
     simpa [Algebra.ofId_apply, AlgHomClass.commutes] using hker
   · intro heq
-    rw [HopfIdeal.map_toIdeal, Ideal.map_le_iff_le_comap]
+    rw [kernelHopfIdeal_toIdeal, Ideal.map_le_iff_le_comap]
     intro x hx
     have hx0 : Coalgebra.counit (R := R) x = 0 :=
       (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
@@ -138,7 +159,7 @@ theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [CommRing 
 /-- The trivialization criterion for Hopf-algebra morphisms: a morphism out of `K` kills
 the kernel Hopf ideal of `f` exactly when its composite with `f` is the trivial
 (counit-unit) morphism. -/
-theorem comp_eq_counitUnit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
+theorem comp_eq_unit_comp_counit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
     (g : K ⟶ L) :
     f ≫ g =
         _root_.CommHopfAlgCat.ofHom
@@ -160,12 +181,13 @@ theorem comp_eq_counitUnit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
 /-- The coordinate-ring triangle: composing `f` with the quotient by its kernel Hopf
 ideal is the counit-unit composite, i.e. the coordinate map of the trivial group-scheme
 morphism. -/
+@[simp]
 theorem comp_mkQuotient_kernelHopfIdeal (f : H ⟶ K) :
     f ≫ mkQuotient K (kernelHopfIdeal f) =
       _root_.CommHopfAlgCat.ofHom
         ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
           (Bialgebra.counitBialgHom R H)) :=
-  (comp_eq_counitUnit_iff f _).mpr (mkQuotient_ker K (kernelHopfIdeal f) ▸ le_rfl)
+  (comp_eq_unit_comp_counit_iff f _).mpr (mkQuotient_ker K (kernelHopfIdeal f) ▸ le_rfl)
 
 /-- The Hopf-ideal-quotient form of the trivialization criterion: `f` trivializes on the
 closed subgroup scheme cut out by `J` exactly when `J` contains the kernel Hopf ideal.
@@ -178,57 +200,20 @@ theorem kernelHopfIdeal_le_iff (f : H ⟶ K) {J : HopfIdeal R K} :
         _root_.CommHopfAlgCat.ofHom
           ((Bialgebra.unitBialgHom R (quotient K J)).comp
             (Bialgebra.counitBialgHom R H)) := by
-  rw [comp_eq_counitUnit_iff, mkQuotient_ker]
+  rw [comp_eq_unit_comp_counit_iff, mkQuotient_ker]
   exact HopfIdeal.toIdeal_le_toIdeal.symm
-
-/-- Kernel semantics on functors of points: for every commutative `R`-algebra `A`, an
-`A`-point of the source is sent to the unit point exactly when it lies in the subgroup of
-points cut out by the kernel Hopf ideal — the `A`-points of `kernelSpec f`. This is the
-universal property of the kernel tested against arbitrary algebras; by Yoneda,
-`kernelSpec f` represents the kernel of the induced morphism of group-valued points
-functors. -/
-theorem mapPointsFunctor_app_eq_one_iff (f : H ⟶ K) (A : CommAlgCat.{w} R)
-    (g : HopfAlgebra.points (R := R) (H := K) A) :
-    (mapPointsFunctor f).app A g = 1 ↔
-      g ∈ quotientPointsSubgroup K (kernelHopfIdeal f) A := by
-  rw [mem_quotientPointsSubgroup_iff]
-  have hbridge : (∀ h : ↥K, h ∈ kernelHopfIdeal f → g.ofConv h = 0) ↔
-      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.ofConv.toRingHom := by
-    constructor
-    · intro hg x hx
-      exact RingHom.mem_ker.mpr (hg x (HopfIdeal.mem_toIdeal.mp hx))
-    · intro hle x hx
-      exact RingHom.mem_ker.mp (hle (HopfIdeal.mem_toIdeal.mpr hx))
-  rw [hbridge, kernelHopfIdeal_toIdeal_le_ker_iff]
-  constructor
-  · intro h1
-    ext a
-    have hval := congrArg
-      (fun ψ : HopfAlgebra.points (R := R) (H := H) A => ψ.ofConv a) h1
-    rw [mapPointsFunctor_app_apply_apply] at hval
-    -- `(1 : WithConv _).ofConv a = algebraMap R A (counit a)` holds by definition of the
-    -- convolution unit (`AlgHom.convOne_apply`); `rfl` performs that identification.
-    have hone : (WithConv.ofConv (1 : HopfAlgebra.points (R := R) (H := H) A)) a =
-        algebraMap R A (Coalgebra.counit (R := R) a) := rfl
-    simpa [Algebra.ofId_apply] using hval.trans hone
-  · intro heq
-    rw [mapPointsFunctor_app_apply, heq]
-    refine ofConv_injective ?_
-    ext a
-    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply]
-    -- Same definitional identification of the convolution unit as above.
-    exact rfl
 
 /-- The scheme-level triangle: the composite of the kernel inclusion with the induced
 group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the
 counit-unit composite. -/
+@[simp]
 theorem kernelSpecι_comp (f : H ⟶ K) :
     kernelSpecι f ≫ (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op =
       (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map
         (_root_.CommHopfAlgCat.ofHom
           ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
             (Bialgebra.counitBialgHom R H))).op := by
-  rw [kernelSpecι, quotientSpecι_def, ← Functor.map_comp, ← op_comp,
+  rw [kernelSpecι_def, quotientSpecι_def, ← Functor.map_comp, ← op_comp,
     comp_mkQuotient_kernelHopfIdeal]
 
 end CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -14,12 +14,22 @@ public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
 A morphism `f : H ⟶ K` of commutative Hopf algebras induces contravariantly a morphism of
 affine group schemes `Spec K ⟶ Spec H` over `Spec R`. Its kernel is the closed subgroup
 scheme of `Spec K` cut out by the kernel Hopf ideal: the image under `f` of the
-augmentation ideal of `H`, whose quotient coordinate ring is `K ⊗[H] R`.
+augmentation ideal of `H` — the ideal `K·f(H⁺)` of the coordinate ring of the *source*
+group scheme, which the classical theory identifies with the defining ideal of
+`Spec (K ⊗[H] R)` (that base-change identification is not formalized here).
 
 This file constructs the kernel Hopf ideal, the kernel closed subgroup scheme, and its
-closed immersion into the source, and proves the defining triangle: composing the induced
-group-scheme morphism with the kernel inclusion is the trivial morphism, because the
-composite coordinate map `H ⟶ K ⟶ K ⧸ K·f(H⁺)` is the counit-unit composite.
+closed immersion into the source, and proves the trivialization criterion that gives the
+construction its kernel semantics among Hopf-ideal quotients: a morphism out of `K` kills
+the kernel Hopf ideal *exactly* when its composite with `f` is the trivial (counit-unit)
+morphism. In particular the composite of the induced group-scheme morphism with the kernel
+inclusion is trivial, and any quotient closed subgroup scheme `quotientSpec K J` on which
+`f` trivializes satisfies `kernelHopfIdeal f ≤ J`, hence includes into the kernel via
+`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe`, compatibly with the inclusions
+(`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι`); the coordinate-level
+factorization and its uniqueness are `TauCeti.CommHopfAlgCat.liftQuotient` and
+`TauCeti.CommHopfAlgCat.liftQuotient_unique`. The pullback square against the unit
+section is future work.
 
 ## Main declarations
 
@@ -28,6 +38,9 @@ composite coordinate map `H ⟶ K ⟶ K ⧸ K·f(H⁺)` is the counit-unit compo
 * `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the kernel
   closed subgroup scheme and its inclusion (a closed immersion, by
   `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`).
+* `TauCeti.CommHopfAlgCat.comp_eq_counitUnit_iff`: the trivialization criterion — a
+  morphism kills the kernel Hopf ideal exactly when its composite with `f` is trivial.
+* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_le_iff`: its Hopf-ideal-quotient form.
 * `TauCeti.CommHopfAlgCat.comp_mkQuotient_kernelHopfIdeal`: the coordinate-ring triangle.
 * `TauCeti.CommHopfAlgCat.kernelSpecι_comp`: the scheme-level triangle.
 
@@ -54,8 +67,9 @@ open AlgebraicGeometry
 variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
 
 /-- The kernel Hopf ideal of a morphism of commutative Hopf algebras: the image of the
-augmentation ideal of the source. Its quotient represents the kernel of the induced
-morphism of affine group schemes. -/
+augmentation ideal of the source. It is an ideal of the *codomain* `K`, the coordinate
+ring of the source of the induced group-scheme morphism `Spec K ⟶ Spec H`; its quotient
+represents the kernel of that morphism. -/
 noncomputable abbrev kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
   (HopfIdeal.augmentation R H).map f.hom
 
@@ -84,29 +98,65 @@ private lemma unitBialgHom_apply {A : Type u} [Semiring A] [Bialgebra R A] (r : 
     Bialgebra.unitBialgHom R A r = algebraMap R A r :=
   rfl
 
-/-- The coordinate-ring triangle defining the kernel: composing `f` with the quotient by
-the kernel Hopf ideal is the counit-unit composite, i.e. the coordinate map of the trivial
-group-scheme morphism. -/
+/-- The difference between a morphism value and the counit-unit value lies in the kernel
+Hopf ideal. -/
+private theorem sub_counitUnit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
+    f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈ kernelHopfIdeal f := by
+  have hx : Coalgebra.counit (R := R)
+      (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
+    simp
+  simpa [map_sub, AlgHomClass.commutes] using
+    mem_kernelHopfIdeal_of_mem_augmentation f hx
+
+/-- The trivialization criterion, the defining property of the kernel among Hopf-ideal
+quotients: a morphism out of `K` kills the kernel Hopf ideal of `f` exactly when its
+composite with `f` is the trivial (counit-unit) morphism. -/
+theorem comp_eq_counitUnit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
+    (g : K ⟶ L) :
+    f ≫ g =
+        _root_.CommHopfAlgCat.ofHom
+          ((Bialgebra.unitBialgHom R L).comp (Bialgebra.counitBialgHom R H)) ↔
+      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.hom.toAlgHom.toRingHom := by
+  constructor
+  · intro heq
+    rw [HopfIdeal.map_toIdeal, Ideal.map_le_iff_le_comap]
+    intro x hx
+    have hx0 : Coalgebra.counit (R := R) x = 0 :=
+      (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
+    have hval := congrArg (fun φ : H ⟶ L => φ.hom x) heq
+    simp only [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
+      BialgHom.comp_apply, unitBialgHom_apply, Bialgebra.counitBialgHom_apply] at hval
+    rw [Ideal.mem_comap, RingHom.mem_ker]
+    simpa [hx0] using hval
+  · intro hle
+    ext h
+    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_counitUnit_mem_kernelHopfIdeal f h))
+    rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
+    simpa [unitBialgHom_apply, AlgHomClass.commutes] using hker
+
+/-- The coordinate-ring triangle: composing `f` with the quotient by its kernel Hopf
+ideal is the counit-unit composite, i.e. the coordinate map of the trivial group-scheme
+morphism. -/
 theorem comp_mkQuotient_kernelHopfIdeal (f : H ⟶ K) :
     f ≫ mkQuotient K (kernelHopfIdeal f) =
       _root_.CommHopfAlgCat.ofHom
         ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
-          (Bialgebra.counitBialgHom R H)) := by
-  ext h
-  have hmem : f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈
-      kernelHopfIdeal f := by
-    have hx : Coalgebra.counit (R := R)
-        (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
-      simp
-    simpa [map_sub, AlgHomClass.commutes] using
-      mem_kernelHopfIdeal_of_mem_augmentation f hx
-  have hquot :
-      (mkQuotient K (kernelHopfIdeal f)).hom
-          (f.hom h - algebraMap R K (Coalgebra.counit (R := R) h)) = 0 :=
-    (mkQuotient_eq_zero_iff K (kernelHopfIdeal f) _).mpr
-      (HopfIdeal.mem_toIdeal.mpr hmem)
-  rw [map_sub, sub_eq_zero] at hquot
-  simpa [unitBialgHom_apply] using hquot
+          (Bialgebra.counitBialgHom R H)) :=
+  (comp_eq_counitUnit_iff f _).mpr (mkQuotient_ker K (kernelHopfIdeal f) ▸ le_rfl)
+
+/-- The Hopf-ideal-quotient form of the trivialization criterion: `f` trivializes on the
+closed subgroup scheme cut out by `J` exactly when `J` contains the kernel Hopf ideal.
+Combined with `TauCeti.CommHopfAlgCat.quotientSpecMapOfLe` and
+`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι`, such a quotient closed
+subgroup scheme includes into the kernel compatibly with the inclusions. -/
+theorem kernelHopfIdeal_le_iff (f : H ⟶ K) {J : HopfIdeal R K} :
+    kernelHopfIdeal f ≤ J ↔
+      f ≫ mkQuotient K J =
+        _root_.CommHopfAlgCat.ofHom
+          ((Bialgebra.unitBialgHom R (quotient K J)).comp
+            (Bialgebra.counitBialgHom R H)) := by
+  rw [comp_eq_counitUnit_iff, mkQuotient_ker]
+  exact HopfIdeal.toIdeal_le_toIdeal.symm
 
 /-- The scheme-level triangle: the composite of the kernel inclusion with the induced
 group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -4,92 +4,50 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
-public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Augmentation
-public import TauCeti.Algebra.HopfAlgebra.HopfIdeal.Map
 
 /-!
 # The kernel of a morphism of affine group schemes
 
 A morphism `f : H ⟶ K` of commutative Hopf algebras induces contravariantly a morphism of
-affine group schemes `Spec K ⟶ Spec H` over `Spec R`. Its kernel is the closed subgroup
-scheme of `Spec K` cut out by the kernel Hopf ideal: the image under `f` of the
-augmentation ideal of `H` — the ideal `K·f(H⁺)` of the coordinate ring of the *source*
-group scheme, which the classical theory identifies with the defining ideal of
-`Spec (K ⊗[H] R)` (that base-change identification is not formalized here).
-
-This file constructs the kernel Hopf ideal, the kernel closed subgroup scheme, and its
-closed immersion into the source, and proves the trivialization criterion that gives the
-construction its kernel semantics among Hopf-ideal quotients: a morphism out of `K` kills
-the kernel Hopf ideal *exactly* when its composite with `f` is the trivial (counit-unit)
-morphism. In particular the composite of the induced group-scheme morphism with the kernel
-inclusion is trivial, and any quotient closed subgroup scheme `quotientSpec K J` on which
-`f` trivializes satisfies `kernelHopfIdeal f ≤ J`, hence includes into the kernel via
-`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe`, compatibly with the inclusions
-(`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι`); the coordinate-level
-factorization and its uniqueness are `TauCeti.CommHopfAlgCat.liftQuotient` and
-`TauCeti.CommHopfAlgCat.liftQuotient_unique`. The pullback square against the unit
-section is future work.
+affine group schemes `Spec K ⟶ Spec H` over `Spec R`. This file packages its kernel: the
+closed subgroup scheme of `Spec K` cut out by the kernel Hopf ideal
+(`TauCeti.CommHopfAlgCat.kernelHopfIdeal`, the extension `K·f(H⁺)` of the augmentation
+ideal, whose kernel semantics — the trivialization criterion — live in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel`). The inclusion is a closed
+immersion by `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`, and the
+scheme-level triangle here is the image of the coordinate-ring triangle under `hopfSpec`.
+The pullback square against the unit section is future work; the points-level kernel
+property is `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel`.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.kernelHopfIdeal`: the kernel Hopf ideal of a morphism.
-* `TauCeti.CommHopfAlgCat.mem_kernelHopfIdeal_of_mem_augmentation`: its generators.
-* `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the kernel
-  closed subgroup scheme and its inclusion (a closed immersion, by
-  `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`).
-* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_toIdeal_le_ker_iff` and
-  `TauCeti.CommHopfAlgCat.comp_eq_unit_comp_counit_iff`: the trivialization criterion — a
-  map out of the coordinate ring kills the kernel Hopf ideal exactly when its composite
-  with `f` is trivial.
-* `TauCeti.CommHopfAlgCat.kernelHopfIdeal_le_iff`: its Hopf-ideal-quotient form.
-* `TauCeti.CommHopfAlgCat.comp_mkQuotient_kernelHopfIdeal`: the coordinate-ring triangle.
+* `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the
+  kernel closed subgroup scheme and its inclusion.
 * `TauCeti.CommHopfAlgCat.kernelSpecι_comp`: the scheme-level triangle.
 
 ## References
 
-Milne, *Algebraic Groups*, Proposition 4.1: the kernel of a homomorphism of affine
-algebraic groups is represented by `O(K) / I_H O(K)` for `I_H` the augmentation ideal.
-The same-universe restriction on the Hopf algebras is imposed by Mathlib's current
-`hopfSpec` construction, as in `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic`.
+Milne, *Algebraic Groups*, Proposition 4.1. The same-universe restriction on the Hopf
+algebras is imposed by Mathlib's current `hopfSpec` construction, as in
+`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic`.
 -/
 
 public section
 
-open CategoryTheory WithConv
+open CategoryTheory
 
 namespace TauCeti
 
-universe u w
+universe u
 
 namespace CommHopfAlgCat
 
 open AlgebraicGeometry
 
 variable {R : Type u} [CommRing R] {H K : _root_.CommHopfAlgCat.{u} R}
-
-/-- The kernel Hopf ideal of a morphism of commutative Hopf algebras: the image of the
-augmentation ideal of the source. It is an ideal of the *codomain* `K`, the coordinate
-ring of the source of the induced group-scheme morphism `Spec K ⟶ Spec H`; its quotient
-represents the kernel of that morphism. -/
-noncomputable def kernelHopfIdeal (f : H ⟶ K) : HopfIdeal R K :=
-  (HopfIdeal.augmentation R H).map f.hom
-
-/-- The underlying ideal of the kernel Hopf ideal is the extension of the augmentation
-ideal. -/
-@[simp]
-theorem kernelHopfIdeal_toIdeal (f : H ⟶ K) :
-    (kernelHopfIdeal f).toIdeal =
-      Ideal.map (f.hom : ↥H →+* ↥K) (HopfIdeal.augmentation R H).toIdeal := by
-  -- `kernelHopfIdeal` has no equation lemma to rewrite with; `change` spells out its
-  -- definitional unfolding to a `HopfIdeal.map` application.
-  change ((HopfIdeal.augmentation R H).map f.hom).toIdeal = _
-  rw [HopfIdeal.map_toIdeal]
-
-/-- The kernel Hopf ideal contains the image of every counit-vanishing element. -/
-theorem mem_kernelHopfIdeal_of_mem_augmentation (f : H ⟶ K) {x : H}
-    (hx : Coalgebra.counit (R := R) x = 0) : f.hom x ∈ kernelHopfIdeal f :=
-  HopfIdeal.mem_map_of_mem f.hom ((HopfIdeal.mem_augmentation R H).mpr hx)
 
 /-- The kernel of the induced morphism of affine group schemes, as an affine group
 scheme: the closed subgroup scheme of the source cut out by the kernel Hopf ideal. -/
@@ -112,96 +70,6 @@ theorem kernelSpecι_def (f : H ⟶ K) :
   -- definitional unfolding once, explicitly.
   change quotientSpecι K (kernelHopfIdeal f) = _
   rfl
-
--- Mathlib has no application lemma for `Bialgebra.unitBialgHom`; this contains its
--- definitional unfolding to `algebraMap` in one place (upstream candidate).
-private lemma unitBialgHom_apply {A : Type u} [Semiring A] [Bialgebra R A] (r : R) :
-    Bialgebra.unitBialgHom R A r = algebraMap R A r :=
-  rfl
-
-/-- The difference between a morphism value and the counit-unit value lies in the kernel
-Hopf ideal. -/
-private theorem sub_algebraMap_counit_mem_kernelHopfIdeal (f : H ⟶ K) (h : H) :
-    f.hom h - algebraMap R K (Coalgebra.counit (R := R) h) ∈ kernelHopfIdeal f := by
-  have hx : Coalgebra.counit (R := R)
-      (h - algebraMap R H (Coalgebra.counit (R := R) h)) = 0 := by
-    simp
-  simpa [map_sub, AlgHomClass.commutes] using
-    mem_kernelHopfIdeal_of_mem_augmentation f hx
-
-/-- Algebra-level trivialization criterion: an algebra map out of the coordinate ring of
-the source group scheme kills the kernel Hopf ideal exactly when its composite with `f`
-is the counit-unit composite. This is the kernel property tested against an arbitrary
-commutative `R`-algebra; `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` (in
-`TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel`) packages it on the functors of
-points. -/
-theorem kernelHopfIdeal_toIdeal_le_ker_iff (f : H ⟶ K) {A : Type w} [Ring A]
-    [Algebra R A] (φ : ↥K →ₐ[R] A) :
-    (kernelHopfIdeal f).toIdeal ≤ RingHom.ker φ.toRingHom ↔
-      φ.comp (f.hom : ↥H →ₐ[R] ↥K) =
-        (Algebra.ofId R A).comp (Bialgebra.counitAlgHom R ↥H) := by
-  constructor
-  · intro hle
-    ext h
-    have hker := hle (HopfIdeal.mem_toIdeal.mpr (sub_algebraMap_counit_mem_kernelHopfIdeal f h))
-    rw [RingHom.mem_ker, map_sub, sub_eq_zero] at hker
-    simpa [Algebra.ofId_apply, AlgHomClass.commutes] using hker
-  · intro heq
-    rw [kernelHopfIdeal_toIdeal, Ideal.map_le_iff_le_comap]
-    intro x hx
-    have hx0 : Coalgebra.counit (R := R) x = 0 :=
-      (HopfIdeal.mem_augmentation R H).mp (HopfIdeal.mem_toIdeal.mp hx)
-    have hval := congrArg (fun ψ : ↥H →ₐ[R] A => ψ x) heq
-    simp only [AlgHom.comp_apply, Algebra.ofId_apply, Bialgebra.counitAlgHom_apply] at hval
-    rw [Ideal.mem_comap, RingHom.mem_ker]
-    simpa [hx0] using hval
-
-/-- The trivialization criterion for Hopf-algebra morphisms: a morphism out of `K` kills
-the kernel Hopf ideal of `f` exactly when its composite with `f` is the trivial
-(counit-unit) morphism. -/
-theorem comp_eq_unit_comp_counit_iff (f : H ⟶ K) {L : _root_.CommHopfAlgCat.{u} R}
-    (g : K ⟶ L) :
-    f ≫ g =
-        _root_.CommHopfAlgCat.ofHom
-          ((Bialgebra.unitBialgHom R L).comp (Bialgebra.counitBialgHom R H)) ↔
-      (kernelHopfIdeal f).toIdeal ≤ RingHom.ker g.hom.toAlgHom.toRingHom := by
-  rw [kernelHopfIdeal_toIdeal_le_ker_iff f g.hom.toAlgHom]
-  constructor
-  · intro heq
-    ext h
-    have hval := congrArg (fun ψ : H ⟶ L => ψ.hom h) heq
-    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
-      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
-  · intro heq
-    ext h
-    have hval := congrArg (fun ψ : ↥H →ₐ[R] ↥L => ψ h) heq
-    simpa [_root_.CommHopfAlgCat.comp_apply, _root_.CommHopfAlgCat.hom_ofHom,
-      BialgHom.comp_apply, unitBialgHom_apply, Algebra.ofId_apply] using hval
-
-/-- The coordinate-ring triangle: composing `f` with the quotient by its kernel Hopf
-ideal is the counit-unit composite, i.e. the coordinate map of the trivial group-scheme
-morphism. -/
-@[simp]
-theorem comp_mkQuotient_kernelHopfIdeal (f : H ⟶ K) :
-    f ≫ mkQuotient K (kernelHopfIdeal f) =
-      _root_.CommHopfAlgCat.ofHom
-        ((Bialgebra.unitBialgHom R (quotient K (kernelHopfIdeal f))).comp
-          (Bialgebra.counitBialgHom R H)) :=
-  (comp_eq_unit_comp_counit_iff f _).mpr (mkQuotient_ker K (kernelHopfIdeal f) ▸ le_rfl)
-
-/-- The Hopf-ideal-quotient form of the trivialization criterion: `f` trivializes on the
-closed subgroup scheme cut out by `J` exactly when `J` contains the kernel Hopf ideal.
-Combined with `TauCeti.CommHopfAlgCat.quotientSpecMapOfLe` and
-`TauCeti.CommHopfAlgCat.quotientSpecMapOfLe_comp_quotientSpecι`, such a quotient closed
-subgroup scheme includes into the kernel compatibly with the inclusions. -/
-theorem kernelHopfIdeal_le_iff (f : H ⟶ K) {J : HopfIdeal R K} :
-    kernelHopfIdeal f ≤ J ↔
-      f ≫ mkQuotient K J =
-        _root_.CommHopfAlgCat.ofHom
-          ((Bialgebra.unitBialgHom R (quotient K J)).comp
-            (Bialgebra.counitBialgHom R H)) := by
-  rw [comp_eq_unit_comp_counit_iff, mkQuotient_ker]
-  exact HopfIdeal.toIdeal_le_toIdeal.symm
 
 /-- The scheme-level triangle: the composite of the kernel inclusion with the induced
 group-scheme morphism is the trivial morphism, the image under `hopfSpec` of the

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -40,18 +40,13 @@ universe u v
 
 variable (R : Type u) (H : Type v) [CommRing R] [Ring H] [HopfAlgebra R H]
 
-/-- The counit of a Hopf algebra, as a bialgebra morphism, is surjective: it is split by
-the unit. -/
-theorem counitBialgHom_surjective :
-    Function.Surjective (Bialgebra.counitBialgHom R H) := fun r =>
-  ⟨algebraMap R H r, by simp⟩
-
-/-- The augmentation Hopf ideal of a Hopf algebra: the kernel of the counit.
+/-- The augmentation Hopf ideal of a Hopf algebra: the kernel of the counit, which is
+surjective since the unit splits it (`Bialgebra.counit_surjective`).
 
 The ring hypotheses come from the kernel Hopf ideal construction, whose coideal condition
 uses tensor-kernel exactness. -/
 noncomputable def augmentation : HopfIdeal R H :=
-  ker (Bialgebra.counitBialgHom R H) (counitBialgHom_surjective R H)
+  ker (Bialgebra.counitBialgHom R H) Bialgebra.counit_surjective
 
 /-- Membership in the augmentation ideal is vanishing of the counit. -/
 @[simp]

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -50,7 +50,7 @@ theorem counitBialgHom_surjective :
 
 The ring hypotheses come from the kernel Hopf ideal construction, whose coideal condition
 uses tensor-kernel exactness. -/
-noncomputable abbrev augmentation : HopfIdeal R H :=
+noncomputable def augmentation : HopfIdeal R H :=
   ker (Bialgebra.counitBialgHom R H) (counitBialgHom_surjective R H)
 
 /-- Membership in the augmentation ideal is vanishing of the counit. -/

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -48,6 +48,14 @@ uses tensor-kernel exactness. -/
 noncomputable def augmentation : HopfIdeal R H :=
   ker (Bialgebra.counitBialgHom R H) Bialgebra.counit_surjective
 
+/-- `augmentation` is the kernel Hopf ideal of the counit. -/
+theorem augmentation_def :
+    augmentation R H = ker (Bialgebra.counitBialgHom R H) Bialgebra.counit_surjective := by
+  -- `augmentation` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change ker (Bialgebra.counitBialgHom R H) Bialgebra.counit_surjective = _
+  rfl
+
 /-- Membership in the augmentation ideal is vanishing of the counit. -/
 @[simp]
 theorem mem_augmentation {x : H} :

--- a/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
+++ b/TauCeti/Algebra/HopfAlgebra/HopfIdeal/Augmentation.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.HopfAlgebra.Kernel
+
+/-!
+# The augmentation Hopf ideal
+
+The augmentation ideal of a Hopf algebra is the kernel of its counit. The counit is split
+by the unit, hence surjective, so the kernel Hopf ideal machinery of
+`TauCeti.Algebra.HopfAlgebra.Kernel` applies directly and no Sweedler-decomposition
+argument is needed.
+
+This is the fundamental example of a Hopf ideal: the quotient by it is the base ring, and
+its image under a morphism into a commutative Hopf algebra cuts out the kernel of the
+induced morphism of affine group schemes (`TauCeti.CommHopfAlgCat.kernelHopfIdeal`).
+
+## Main declarations
+
+* `TauCeti.HopfIdeal.augmentation`: the augmentation ideal as a Hopf ideal.
+* `TauCeti.HopfIdeal.mem_augmentation` and `TauCeti.HopfIdeal.augmentation_toIdeal`:
+  characteristic API.
+
+## References
+
+Waterhouse, *Introduction to Affine Group Schemes*, §2.1; Milne, *Algebraic Groups*,
+around Proposition 4.1, where the augmentation ideal cuts out the identity section.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace HopfIdeal
+
+universe u v
+
+variable (R : Type u) (H : Type v) [CommRing R] [Ring H] [HopfAlgebra R H]
+
+/-- The counit of a Hopf algebra, as a bialgebra morphism, is surjective: it is split by
+the unit. -/
+theorem counitBialgHom_surjective :
+    Function.Surjective (Bialgebra.counitBialgHom R H) := fun r =>
+  ⟨algebraMap R H r, by simp⟩
+
+/-- The augmentation Hopf ideal of a Hopf algebra: the kernel of the counit.
+
+The ring hypotheses come from the kernel Hopf ideal construction, whose coideal condition
+uses tensor-kernel exactness. -/
+noncomputable abbrev augmentation : HopfIdeal R H :=
+  ker (Bialgebra.counitBialgHom R H) (counitBialgHom_surjective R H)
+
+/-- Membership in the augmentation ideal is vanishing of the counit. -/
+@[simp]
+theorem mem_augmentation {x : H} :
+    x ∈ augmentation R H ↔ Coalgebra.counit (R := R) x = 0 :=
+  mem_ker _ _
+
+/-- The underlying ideal of the augmentation Hopf ideal is the kernel of the counit
+algebra homomorphism. -/
+@[simp]
+theorem augmentation_toIdeal :
+    (augmentation R H).toIdeal = RingHom.ker (Bialgebra.counitAlgHom R H) := by
+  ext x
+  rw [mem_toIdeal, mem_augmentation, RingHom.mem_ker]
+  exact Iff.rfl
+
+end HopfIdeal
+
+end TauCeti


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-ideal-kernel"}-->

Constructs the kernel of the morphism of affine group schemes induced by a morphism `f : H ⟶ K` of commutative Hopf algebras, completing the "kernels" clause of the Layer 3 Hopf-ideal dictionary:

* `TauCeti.HopfIdeal.augmentation` (new file `HopfIdeal/Augmentation.lean`): the augmentation ideal as a Hopf ideal — the kernel of the counit, which is split by the unit, so the existing kernel machinery of `TauCeti.Algebra.HopfAlgebra.Kernel` applies with no Sweedler-decomposition argument; with `counitBialgHom_surjective`, `mem_augmentation`, `augmentation_toIdeal`.
* `TauCeti.CommHopfAlgCat.kernelHopfIdeal` (new file `HopfIdeal/Scheme/Kernel.lean`): the image of the augmentation ideal under `f` (via `HopfIdeal.map`, #1697), the ideal `K·f(H⁺)` with quotient coordinate ring `K ⊗[H] R`.
* `TauCeti.CommHopfAlgCat.kernelSpec` / `kernelSpecι`: the kernel as a closed subgroup scheme of the source via the merged `quotientSpec` machinery; the inclusion is a closed immersion by the existing instance.
* `comp_mkQuotient_kernelHopfIdeal` / `kernelSpecι_comp`: the defining triangle — composing the induced group-scheme morphism with the kernel inclusion is the trivial morphism (coordinate-level: `H ⟶ K ⟶ K ⧸ K·f(H⁺)` is the counit-unit composite; scheme-level by functoriality).

The universal property of the kernel (the pullback square against the unit section) is future work; this PR supplies the object, its closed immersion, and the triangle it must satisfy.

Roadmap: ReductiveGroups

Advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 3 "subgroups, quotients, components": "Hopf ideals ↔ closed subgroup schemes … **kernels**" — the scheme-theoretic kernels item listed as remaining in STATUS.md.

🤖 Generated with [Claude Code](https://claude.com/claude-code)