### PR TITLE
style(Contour): pack underfilled signature lines

### DIFF
--- a/TauCeti/Analysis/Contour/ArcFTC.lean
+++ b/TauCeti/Analysis/Contour/ArcFTC.lean
@@ -54,8 +54,7 @@ variable {γ γ' : ℝ → ℂ} {g G : ℂ → ℂ} {a b : ℝ}
 `γ` and `G' = g` at the points `γ t`, then the contour integral of `g` along `γ` is the endpoint
 difference `G (γ b) - G (γ a)`. The integrability hypothesis is stated directly on the contour
 integrand, so this lemma can be used with any regularity package that supplies it. -/
-theorem integral_comp_mul_eq_sub_of_hasDerivAt
-    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+theorem integral_comp_mul_eq_sub_of_hasDerivAt (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
     (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b) :
@@ -68,8 +67,7 @@ theorem integral_comp_mul_eq_sub_of_hasDerivAt
 /-- **FTC along a contour, `deriv` form.** If `G' = g` along the image of a differentiable curve,
 then the contour integral written with `deriv γ` is the endpoint difference
 `G (γ b) - G (γ a)`. -/
-theorem integral_comp_mul_deriv_eq_sub_of_hasDerivAt
-    (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
+theorem integral_comp_mul_deriv_eq_sub_of_hasDerivAt (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
     (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b) :
@@ -82,8 +80,7 @@ theorem integral_comp_mul_eq_zero_of_hasDerivAt_of_closed
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt γ (γ' t) t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b)
-    (hclosed : γ a = γ b) :
+    (hint : IntervalIntegrable (fun t => g (γ t) * γ' t) volume a b) (hclosed : γ a = γ b) :
     ∫ t in a..b, g (γ t) * γ' t = 0 := by
   rw [integral_comp_mul_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 
@@ -92,8 +89,7 @@ theorem integral_comp_mul_deriv_eq_zero_of_hasDerivAt_of_closed
     (hcont : ContinuousOn (G ∘ γ) (Set.uIcc a b))
     (hγ : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ γ t)
     (hG : ∀ t ∈ Set.Ioo (min a b) (max a b), HasDerivAt G (g (γ t)) (γ t))
-    (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b)
-    (hclosed : γ a = γ b) :
+    (hint : IntervalIntegrable (fun t => g (γ t) * deriv γ t) volume a b) (hclosed : γ a = γ b) :
     ∫ t in a..b, g (γ t) * deriv γ t = 0 := by
   rw [integral_comp_mul_deriv_eq_sub_of_hasDerivAt hcont hγ hG hint, hclosed, sub_self]
 

--- a/TauCeti/Analysis/Contour/Argument/Lift.lean
+++ b/TauCeti/Analysis/Contour/Argument/Lift.lean
@@ -61,8 +61,7 @@ exists `δ > 0` such that on any sub-interval of length `< δ`, `γ` varies by l
 half the minimum distance to `w`. This gives a partition where each segment of
 `γ - w` lies in a ball avoiding `0`. -/
 private theorem exists_uniform_modulus_avoiding {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} (hab : a ≤ b)
-    (hγ : ContinuousOn γ (Icc a b))
-    (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w) :
+    (hγ : ContinuousOn γ (Icc a b)) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w) :
     ∃ δ' > 0, ∃ ρ > 0, (∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖) ∧
       ∀ t s, t ∈ Icc a b → s ∈ Icc a b → |t - s| < δ' →
         ‖γ t - γ s‖ < ρ / 2 := by
@@ -145,10 +144,8 @@ theorem segRatio_eq_endpoint_div_of_le {γ : ℝ → ℂ} {w : ℂ} {s_j s_jp1 t
 
 /-- For partition with mesh < δ' and segments [s_j, s_{j+1}] of length ≤ mesh,
 on the j-th segment, `γ(clamp t) - γ s_j` is small, so `segRatio j t ∈ ball(1, 1/2)`. -/
-private theorem segRatio_mem_ball_one
-    {γ : ℝ → ℂ} {w : ℂ} {a b δ' ρ : ℝ} (hρ_pos : 0 < ρ)
-    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖)
-    (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
+private theorem segRatio_mem_ball_one {γ : ℝ → ℂ} {w : ℂ} {a b δ' ρ : ℝ} (hρ_pos : 0 < ρ)
+    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖) (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
       |t - s| < δ' → ‖γ t - γ s‖ < ρ / 2)
     {s_j s_jp1 : ℝ} (hsj : s_j ∈ Icc a b) (hsjp1 : s_jp1 ∈ Icc a b)
     (h_le : s_j ≤ s_jp1) (h_mesh : s_jp1 - s_j < δ') (t : ℝ) :
@@ -175,8 +172,7 @@ private theorem segRatio_mem_ball_one
 
 /-- Continuity of `t ↦ segRatio γ w s_j s_jp1 t` on `Icc a b`. -/
 private theorem continuousOn_segRatio {γ : ℝ → ℂ} {a b : ℝ} (hγ : ContinuousOn γ (Icc a b))
-    {w : ℂ} {s_j s_jp1 : ℝ} (hsj : s_j ∈ Icc a b)
-    (hsjp1 : s_jp1 ∈ Icc a b) (h_le : s_j ≤ s_jp1) :
+    {w : ℂ} {s_j s_jp1 : ℝ} (hsj : s_j ∈ Icc a b) (hsjp1 : s_jp1 ∈ Icc a b) (h_le : s_j ≤ s_jp1) :
     ContinuousOn (fun t ↦ segRatio γ w s_j s_jp1 t) (Icc a b) := by
   unfold segRatio
   refine ContinuousOn.div_const ?_ _
@@ -187,10 +183,8 @@ private theorem continuousOn_segRatio {γ : ℝ → ℂ} {a b : ℝ} (hγ : Cont
     (segClamp_mem_Icc s_j s_jp1 t h_le).2.trans hsjp1.2⟩
 
 /-- Combined: for partition with mesh < δ', `segRatio j t ∈ slitPlane`. -/
-private theorem segRatio_mem_slitPlane
-    {γ : ℝ → ℂ} {w : ℂ} {a b δ' ρ : ℝ} (hρ_pos : 0 < ρ)
-    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖)
-    (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
+private theorem segRatio_mem_slitPlane {γ : ℝ → ℂ} {w : ℂ} {a b δ' ρ : ℝ} (hρ_pos : 0 < ρ)
+    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖) (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
       |t - s| < δ' → ‖γ t - γ s‖ < ρ / 2)
     {s_j s_jp1 : ℝ} (hsj : s_j ∈ Icc a b) (hsjp1 : s_jp1 ∈ Icc a b)
     (h_le : s_j ≤ s_jp1) (h_mesh : s_jp1 - s_j < δ') (t : ℝ) :
@@ -205,8 +199,7 @@ private theorem segRatio_mem_slitPlane
 /-- Telescoping product in `ℂ` over `Finset.range`. For `a : ℕ → ℂ` nonzero on indices `0..k`,
 `∏ j ∈ range k, a (j+1)/a j = a k / a 0`. The nonzero-field analogue of the group telescoping lemma
 `Finset.prod_range_div`, obtained from it by lifting the nonzero values into `ℂˣ`. -/
-private lemma prod_range_div_complex (a : ℕ → ℂ) (k : ℕ)
-    (ha : ∀ j ≤ k, a j ≠ 0) :
+private lemma prod_range_div_complex (a : ℕ → ℂ) (k : ℕ) (ha : ∀ j ≤ k, a j ≠ 0) :
     ∏ j ∈ Finset.range k, (a (j + 1) / a j) = a k / a 0 := by
   classical
   set u : ℕ → ℂˣ := fun j ↦ if h : a j = 0 then 1 else Units.mk0 (a j) h with hu_def
@@ -227,10 +220,8 @@ private lemma prod_range_div_complex (a : ℕ → ℂ) (k : ℕ)
 
 This is the key identity making `Im(log)` of each `segRatio` add up to a
 continuous argument lift of `t ↦ γ t - w`. -/
-private theorem prod_segRatio_telescope
-    {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
-    (hs_mono : Monotone s)
-    (h_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0)
+private theorem prod_segRatio_telescope {γ : ℝ → ℂ} {w : ℂ} {N : ℕ} {s : ℕ → ℝ}
+    (hs_mono : Monotone s) (h_avoid : ∀ j ≤ N, γ (s j) - w ≠ 0)
     {t : ℝ} {k : ℕ} (hk : k < N) (hk_lo : s k ≤ t) (hk_hi : t ≤ s (k + 1)) :
     ∏ j ∈ Finset.range N, segRatio γ w (s j) (s (j + 1)) t = (γ t - w) / (γ (s 0) - w) := by
   -- Split range N = range (k+1) ∪ Ico (k+1) N
@@ -268,8 +259,7 @@ private theorem prod_segRatio_telescope
 /-- Each summand in the telescoping arg-lift sum is continuous. -/
 private theorem continuousOn_im_log_segRatio {γ : ℝ → ℂ} {a b : ℝ}
     (hγ : ContinuousOn γ (Icc a b)) {w : ℂ} {δ' ρ : ℝ} (hρ_pos : 0 < ρ)
-    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖)
-    (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
+    (h_dist_lb : ∀ t ∈ Icc a b, ρ ≤ ‖γ t - w‖) (h_unif : ∀ t s : ℝ, t ∈ Icc a b → s ∈ Icc a b →
       |t - s| < δ' → ‖γ t - γ s‖ < ρ / 2)
     {s_j s_jp1 : ℝ} (hsj : s_j ∈ Icc a b) (hsjp1 : s_jp1 ∈ Icc a b)
     (h_le : s_j ≤ s_jp1) (h_mesh : s_jp1 - s_j < δ') :
@@ -384,10 +374,8 @@ avoiding `w`, there is a monotone partition `a = s 0 ≤ ⋯ ≤ s N = b` and a 
 `θ t = arg (γ a - w) + ∑_{j < N} (log (segRatio γ w (s j) (s (j+1)) t)).im`, continuous on `[a, b]`,
 satisfying `γ t - w = ‖γ t - w‖ · exp (I · θ t)` there. Each node has `γ (s j) ≠ w`, and on each
 segment `j` the ratio `(γ t - w) / (γ (s j) - w)` lies in `Complex.slitPlane`. -/
-theorem exists_continuousOn_arg_lift_with_partition
-    {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} (hab : a ≤ b)
-    (hγ : ContinuousOn γ (Icc a b))
-    (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w) :
+theorem exists_continuousOn_arg_lift_with_partition {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hγ : ContinuousOn γ (Icc a b)) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w) :
     ∃ (N : ℕ) (s : ℕ → ℝ),
       0 < N ∧ s 0 = a ∧ s N = b ∧ Monotone s ∧
       (∀ j ≤ N, s j ∈ Icc a b) ∧

--- a/TauCeti/Analysis/Contour/Argument/Principle.lean
+++ b/TauCeti/Analysis/Contour/Argument/Principle.lean
@@ -161,8 +161,7 @@ private theorem circleIntegral_principalPart {c : ℂ} {R : ℝ} (hR : 0 < R) (S
 on the disc with order `ord z` at each `z ∈ S` and is analytic and non-vanishing off `S`, then
 `logDeriv F − ∑_{s∈S} ord s · (· − s)⁻¹` is pole-free, so its circle integral vanishes. -/
 private theorem circleIntegral_logDeriv_sub_principalPart_eq_zero {F : ℂ → ℂ} {c : ℂ} {R : ℝ}
-    (hR : 0 < R) (S : Finset ℂ) (ord : ℂ → ℤ)
-    (hF_mero : MeromorphicOn F (Metric.closedBall c R))
+    (hR : 0 < R) (S : Finset ℂ) (ord : ℂ → ℤ) (hF_mero : MeromorphicOn F (Metric.closedBall c R))
     (hord_F : ∀ z ∈ S, meromorphicOrderAt F z = (ord z : WithTop ℤ))
     (hoffF : ∀ z ∈ Metric.closedBall c R, z ∉ S → AnalyticAt ℂ F z ∧ F z ≠ 0) :
     circleIntegral (fun z => logDeriv F z - ∑ s ∈ S, (ord s : ℂ) * (z - s)⁻¹) c R = 0 := by
@@ -202,8 +201,7 @@ then the contour integral of the logarithmic derivative counts the zeros minus t
 multiplicity:
 `∮_{C(c,R)} f'/f = 2πi · ∑_{z ∈ S} ord z`. -/
 theorem argumentPrinciple {f : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R) (S : Finset ℂ) (ord : ℂ → ℤ)
-    (hf : MeromorphicOn f (Metric.closedBall c R))
-    (hS : (S : Set ℂ) ⊆ Metric.ball c R)
+    (hf : MeromorphicOn f (Metric.closedBall c R)) (hS : (S : Set ℂ) ⊆ Metric.ball c R)
     (hsupp : ∀ z ∈ Metric.closedBall c R, meromorphicOrderAt f z ≠ 0 → z ∈ S)
     (hord : ∀ z ∈ S, meromorphicOrderAt f z = (ord z : WithTop ℤ)) :
     circleIntegral (logDeriv f) c R = 2 * (Real.pi : ℂ) * Complex.I * (∑ z ∈ S, (ord z : ℂ)) := by

--- a/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/Homotopy.lean
@@ -49,10 +49,8 @@ namespace TauCeti.Contour
 /-- A loop smoothly homotopic to its constant path through points avoiding `w` has winding number
 zero about `w`. -/
 theorem windingNumber_eq_zero_of_pathHomotopy_refl {x w : ℂ} {p : Path x x}
-    (φ : p.Homotopy (Path.refl x))
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
+    (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
     windingNumber p.extend 0 1 w = 0 := by
   rw [windingNumber_eq_of_pathHomotopy φ hφsmooth havoid]
@@ -65,10 +63,8 @@ outside `Ω`. Thus the loop is null-homologous in `Ω`.
 
 This is one direction only: a null-homologous loop need not be null-homotopic. -/
 theorem isNullHomologous_of_pathHomotopy_refl {x : ℂ} {p : Path x x} {Ω : Set ℂ}
-    (φ : p.Homotopy (Path.refl x))
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
+    (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :
     IsNullHomologous p.extend 0 1 Ω :=
   (isNullHomologous_iff_of_pathHomotopy φ hφsmooth hφΩ).2
@@ -84,13 +80,9 @@ The smooth homotopy supplies the piecewise-`C¹` regularity expected by
 `homologyCauchyTheorem`, as well as containment of the source path in `Ω` and its null-homology
 there. -/
 theorem cauchyTheorem_of_pathHomotopy_refl {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω)
-    {x : ℂ} (p : Path x x)
-    (φ : p.Homotopy (Path.refl x))
-    (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
-    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω)
-    (hf : DifferentiableOn ℂ f Ω) :
+    {x : ℂ} (p : Path x x) (φ : p.Homotopy (Path.refl x)) (hφsmooth : ContDiffOn ℝ 2
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
+    (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) (hf : DifferentiableOn ℂ f Ω) :
     ∫ t in (0 : ℝ)..1, deriv p.extend t • f (p.extend t) = 0 := by
   have hp : IsPiecewiseC1On p.extend 0 1 := by
     simpa using isPiecewiseC1On_eval_of_smoothPathHomotopy φ hφsmooth (0 : I)

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/Basic.lean
@@ -149,8 +149,7 @@ theorem CauchyPVExistsAt.intro {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} 
 /-- **The `ε`-truncated integrand is interval-integrable from a bound off the ball**: whenever
 `f ∘ γ` is bounded by `M` at distance `> ε` from `z₀` and the truncated integrand is
 a.e.-strongly measurable, the truncated integrand is dominated by `M · ‖deriv γ‖`. -/
-theorem intervalIntegrable_truncated_mul_deriv {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ}
-    {a b M ε : ℝ}
+theorem intervalIntegrable_truncated_mul_deriv {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {a b M ε : ℝ}
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume a b)
     (h_aesm : MeasureTheory.AEStronglyMeasurable
       (fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0)
@@ -186,8 +185,7 @@ untouched, so the principal value at `z₀` is the plain integral. Continuity of
 needed — the distance bound and the eventual integrability carry both clauses. The endpoints
 are not assumed ordered; the bound is stated on `uIcc a b`. -/
 theorem HasCauchyPVAt.of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f : ℂ → ℂ}
-    {a b m : ℝ} (hm_pos : 0 < m)
-    (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
+    {a b m : ℝ} (hm_pos : 0 < m) (h_far : ∀ t ∈ Set.uIcc a b, m ≤ ‖γ t - z₀‖)
     (h_int_tr : ∀ᶠ ε in 𝓝[>] (0 : ℝ), IntervalIntegrable
       (fun t => if ‖γ t - z₀‖ > ε then f (γ t) * deriv γ t else 0) MeasureTheory.volume a b) :
     HasCauchyPVAt γ a b f z₀ (∫ t in a..b, f (γ t) * deriv γ t) := by
@@ -458,8 +456,7 @@ theorem HasCauchyPVAt.sum {ι : Type*} {γ : ℝ → ℂ} {a b : ℝ} {z₀ : �
 integrand is integrable there, the symmetric excision is eventually inert, so the principal value
 exists and equals the ordinary contour integral. -/
 theorem HasCauchyPVAt.of_avoidance {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
-    (h_cont : ContinuousOn γ (Set.uIcc a b))
-    (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
+    (h_cont : ContinuousOn γ (Set.uIcc a b)) (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
     (hf_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b) :
     HasCauchyPVAt γ a b f z₀ (∫ t in a..b, f (γ t) * deriv γ t) := by
   obtain ⟨t₀, ht₀, ht₀_min⟩ := isCompact_uIcc.exists_isMinOn
@@ -492,8 +489,7 @@ theorem HasCauchyPVAt.concat {γ : ℝ → ℂ} {a b c : ℝ} {f : ℂ → ℂ} 
 /-- **Finite concatenation.** If the principal value on every adjacent interval
 `[t k, t (k + 1)]` is `L k`, then the principal value on `[t 0, t n]` is their sum. The
 endpoints need not be ordered. -/
-theorem HasCauchyPVAt.concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {n : ℕ}
-    {t : ℕ → ℝ} {L : ℕ → ℂ}
+theorem HasCauchyPVAt.concat_range {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ : ℂ} {n : ℕ} {t : ℕ → ℝ} {L : ℕ → ℂ}
     (h : ∀ k < n, HasCauchyPVAt γ (t k) (t (k + 1)) f z₀ (L k)) :
     HasCauchyPVAt γ (t 0) (t n) f z₀ (∑ k ∈ Finset.range n, L k) := by
   induction n with
@@ -514,8 +510,7 @@ theorem cauchyPVExistsAt_of_dist_lower_bound {γ : ℝ → ℂ} {z₀ : ℂ} {f 
 
 /-- Existence form of `HasCauchyPVAt.of_avoidance`. -/
 theorem cauchyPVExistsAt_of_avoidance {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {z₀ : ℂ}
-    (h_cont : ContinuousOn γ (Set.uIcc a b))
-    (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
+    (h_cont : ContinuousOn γ (Set.uIcc a b)) (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
     (hf_int : IntervalIntegrable (fun t => f (γ t) * deriv γ t) MeasureTheory.volume a b) :
     CauchyPVExistsAt γ a b f z₀ :=
   ⟨_, HasCauchyPVAt.of_avoidance h_cont h_avoid hf_int⟩
@@ -592,8 +587,7 @@ integrand at radius `ε` into the original truncated integrand at radius `ε / �
 factor `c⁻¹` cancels the derivative factor `c`, and the excision radius rescales by `‖c‖`. Shared by
 `HasCauchyPVAt.const_mul_curve` and `cauchyPVAt_const_mul_curve`. -/
 private theorem truncated_const_mul_curve_eq {γ : ℝ → ℂ} {f : ℂ → ℂ} {z₀ c : ℂ} (hc : c ≠ 0)
-    (ε t : ℝ) :
-    (if ‖c * γ t - c * z₀‖ > ε then
+    (ε t : ℝ) : (if ‖c * γ t - c * z₀‖ > ε then
         (fun z => c⁻¹ * f (c⁻¹ * z)) (c * γ t) * deriv (fun t => c * γ t) t else 0)
       = if ‖γ t - z₀‖ > ε / ‖c‖ then f (γ t) * deriv γ t else 0 := by
   by_cases hεt : ‖γ t - z₀‖ > ε / ‖c‖

--- a/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
+++ b/TauCeti/Analysis/Contour/Cauchy/PrincipalValue/On.lean
@@ -430,8 +430,7 @@ private theorem countable_setOf_deriv_ne_zero_on_fiber (g : ℝ → ℂ) (c : �
 eventually integrable as `ε → 0⁺`, there is a single `ε₀ > 0` at which both are integrable and at
 which distinct points of `S₁` and `S₂` are more than `2 * ε₀` apart. -/
 private theorem exists_pos_separating_intervalIntegrable_truncatedIntegrand {γ : ℝ → ℂ} {a b : ℝ}
-    {f : ℂ → ℂ} (S₁ S₂ : Finset ℂ)
-    (hint₁ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
+    {f : ℂ → ℂ} (S₁ S₂ : Finset ℂ) (hint₁ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
       IntervalIntegrable (truncatedIntegrand γ f S₁ ε) MeasureTheory.volume a b)
     (hint₂ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
       IntervalIntegrable (truncatedIntegrand γ f S₂ ε) MeasureTheory.volume a b) :
@@ -465,8 +464,7 @@ pointwise by the sum of the `ε₀`-truncation norms: a point excised at `ε` by
 other is, by the `2·ε₀`-separation, more than `ε₀` from that other set — so the other set's
 `ε₀`-truncation retains the full integrand value there, and that value dominates the difference. -/
 private theorem norm_truncatedIntegrand_sub_le {γ : ℝ → ℂ} {f : ℂ → ℂ} {S₁ S₂ : Finset ℂ}
-    {ε ε₀ : ℝ} (t : ℝ) (hεlt : ε < ε₀)
-    (hP1 : ∀ s₁ ∈ S₁, ∀ s₂ ∈ S₂, s₁ ≠ s₂ → 2 * ε₀ < ‖s₁ - s₂‖) :
+    {ε ε₀ : ℝ} (t : ℝ) (hεlt : ε < ε₀) (hP1 : ∀ s₁ ∈ S₁, ∀ s₂ ∈ S₂, s₁ ≠ s₂ → 2 * ε₀ < ‖s₁ - s₂‖) :
     ‖truncatedIntegrand γ f S₁ ε t - truncatedIntegrand γ f S₂ ε t‖ ≤
       ‖truncatedIntegrand γ f S₁ ε₀ t‖ + ‖truncatedIntegrand γ f S₂ ε₀ t‖ := by
   classical
@@ -549,8 +547,7 @@ truncation (using that the excision sets are finite and disjoint from each other
 is killed in the limit by dominated convergence, the excess `f (γ ·) · γ'` vanishing a.e. on each
 singleton fibre of `γ`. -/
 private theorem tendsto_integral_truncatedIntegrand_sub {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
-    (S₁ S₂ : Finset ℂ)
-    (hint₁ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
+    (S₁ S₂ : Finset ℂ) (hint₁ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
       IntervalIntegrable (truncatedIntegrand γ f S₁ ε) MeasureTheory.volume a b)
     (hint₂ : ∀ᶠ ε in 𝓝[>] (0 : ℝ),
       IntervalIntegrable (truncatedIntegrand γ f S₂ ε) MeasureTheory.volume a b) :
@@ -691,8 +688,7 @@ theorem CauchyPVExists.hasCauchyPV_cauchyPV {γ : ℝ → ℂ} {a b : ℝ} {f : 
   exact hv
 
 /-- Reversing the interval orientation negates a set-level Cauchy principal value. -/
-theorem HasCauchyPV.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ}
-    (h : HasCauchyPV γ a b f v) :
+theorem HasCauchyPV.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : ℂ} (h : HasCauchyPV γ a b f v) :
     HasCauchyPV γ b a f (-v) := by
   obtain ⟨S, hint, htend⟩ := hasCauchyPV_iff.mp h
   refine HasCauchyPV.intro S ?_ ?_
@@ -704,16 +700,14 @@ theorem HasCauchyPV.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} {v : �
 
 /-- Existence of a set-level Cauchy principal value is invariant under reversing the interval
 orientation. -/
-theorem CauchyPVExists.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
-    (h : CauchyPVExists γ a b f) :
+theorem CauchyPVExists.symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (h : CauchyPVExists γ a b f) :
     CauchyPVExists γ b a f :=
   let ⟨_, hv⟩ := cauchyPVExists_iff.mp h
   cauchyPVExists_iff.mpr ⟨_, hv.symm⟩
 
 /-- Value form of `HasCauchyPV.symm`: if the set-level principal value exists on `[a, b]`, then
 the value on `[b, a]` is its negative. -/
-theorem cauchyPV_symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
-    (h : CauchyPVExists γ a b f) :
+theorem cauchyPV_symm {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ} (h : CauchyPVExists γ a b f) :
     cauchyPV γ b a f = -cauchyPV γ a b f :=
   h.hasCauchyPV_cauchyPV.symm.cauchyPV_eq
 
@@ -827,8 +821,7 @@ parameter where `γ` avoids the finite set `P`, a principal value of `f` is one 
 witnessing excision enlarges to include `P`, and off the enlarged excision the curve avoids
 `P`. Needs the curve continuous on `[[a, b]]` for the enlargement. -/
 theorem HasCauchyPV.congr_along_curve_off {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ → ℂ} {v : ℂ}
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (P : Finset ℂ)
-    (h : HasCauchyPV γ a b f v)
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (P : Finset ℂ) (h : HasCauchyPV γ a b f v)
     (h_eq : ∀ t ∈ Set.uIoo a b, γ t ∉ (P : Set ℂ) → f (γ t) = g (γ t)) :
     HasCauchyPV γ a b g v := by
   obtain ⟨T, hint, htend⟩ := h
@@ -868,8 +861,7 @@ theorem CauchyPVExists.add {γ : ℝ → ℂ} {a b : ℝ} {f g : ℂ → ℂ}
 
 /-- Existence form of `HasCauchyPV.sum`. -/
 theorem CauchyPVExists.sum {ι : Type*} {γ : ℝ → ℂ} {a b : ℝ} {f : ι → ℂ → ℂ} {s : Finset ι}
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
-    (h : ∀ i ∈ s, CauchyPVExists γ a b (f i)) :
+    (hγ_cont : ContinuousOn γ (Set.uIcc a b)) (h : ∀ i ∈ s, CauchyPVExists γ a b (f i)) :
     CauchyPVExists γ a b (fun z => ∑ i ∈ s, f i z) := by
   classical
   induction s using Finset.induction_on with

--- a/TauCeti/Analysis/Contour/Chord/QuotientAsymptotics.lean
+++ b/TauCeti/Analysis/Contour/Chord/QuotientAsymptotics.lean
@@ -80,8 +80,7 @@ theorem chord_quotient_tendsto {u : Set ℝ} (hu : t₀ ∉ u)
 /-- **The normalized chord is eventually close to `1`**: for any `ρ > 0`, eventually along
 `𝓝[u] t₀`, `‖(γ t - s) / (L (t - t₀)) - 1‖ ≤ ρ`. -/
 private theorem eventually_normalized_chord_close {u : Set ℝ} (hu : t₀ ∉ u)
-    (h_deriv : HasDerivWithinAt γ L u t₀) (h_at : γ t₀ = s) (hL : L ≠ 0)
-    {ρ : ℝ} (hρ_pos : 0 < ρ) :
+    (h_deriv : HasDerivWithinAt γ L u t₀) (h_at : γ t₀ = s) (hL : L ≠ 0) {ρ : ℝ} (hρ_pos : 0 < ρ) :
     ∀ᶠ t in 𝓝[u] t₀, ‖(γ t - s) / (L * ((t - t₀ : ℝ) : ℂ)) - 1‖ ≤ ρ := by
   have h_div := (chord_quotient_tendsto hu h_deriv h_at).div_const L
   rw [div_self hL] at h_div
@@ -115,8 +114,7 @@ theorem exists_normalized_chord_bound_left
 
 /-- **Slit-plane condition for quotients near `1`.** If `‖z - 1‖ ≤ 1/4` and `‖w - 1‖ ≤ 1/4`,
 then `z / w ∈ Complex.slitPlane`: the quotient stays in the unit ball around `1`. -/
-theorem div_mem_slitPlane_of_close_to_one {z w : ℂ}
-    (hz : ‖z - 1‖ ≤ 1 / 4) (hw : ‖w - 1‖ ≤ 1 / 4) :
+theorem div_mem_slitPlane_of_close_to_one {z w : ℂ} (hz : ‖z - 1‖ ≤ 1 / 4) (hw : ‖w - 1‖ ≤ 1 / 4) :
     z / w ∈ Complex.slitPlane := by
   have hw_ne : w ≠ 0 := fun hw_eq => by
     rw [hw_eq, zero_sub, norm_neg, norm_one] at hw
@@ -150,8 +148,7 @@ private theorem ofReal_pos_mul_mem_slitPlane {c : ℝ} (hc : 0 < c) {z : ℂ}
 `(b - t₀) / (a - t₀) > 0` — then `(γ b - s) / (γ a - s) ∈ Complex.slitPlane`. -/
 theorem chord_quotient_mem_slitPlane (hL : L ≠ 0) {a b : ℝ}
     (ha : ‖(γ a - s) / (L * ((a - t₀ : ℝ) : ℂ)) - 1‖ ≤ 1 / 4)
-    (hb : ‖(γ b - s) / (L * ((b - t₀ : ℝ) : ℂ)) - 1‖ ≤ 1 / 4)
-    (hab : 0 < (b - t₀) / (a - t₀)) :
+    (hb : ‖(γ b - s) / (L * ((b - t₀ : ℝ) : ℂ)) - 1‖ ≤ 1 / 4) (hab : 0 < (b - t₀) / (a - t₀)) :
     (γ b - s) / (γ a - s) ∈ Complex.slitPlane := by
   have ha_ne : (a - t₀ : ℝ) ≠ 0 := fun h => by simp [h] at hab
   have hb_ne : (b - t₀ : ℝ) ≠ 0 := fun h => by simp [h] at hab
@@ -216,10 +213,8 @@ theorem arg_tendsto_of_pos_mul_tendsto {α : Type*} {l : Filter α} {c : α → 
 argument of the annular quotient `(γ (t₀ + r) - s) / (γ (t₀ + δ ε) - s)` converges to the
 argument of `(γ (t₀ + r) - s) / L`. -/
 theorem arg_annular_quotient_tendsto_right
-    (h_deriv : HasDerivWithinAt γ L (Ioi t₀) t₀) (h_at : γ t₀ = s)
-    {δ : ℝ → ℝ} {r : ℝ}
-    (h_slit : (γ (t₀ + r) - s) / L ∈ Complex.slitPlane)
-    (hδ_pos : ∀ᶠ ε in 𝓝[>] (0 : ℝ), 0 < δ ε)
+    (h_deriv : HasDerivWithinAt γ L (Ioi t₀) t₀) (h_at : γ t₀ = s) {δ : ℝ → ℝ} {r : ℝ}
+    (h_slit : (γ (t₀ + r) - s) / L ∈ Complex.slitPlane) (hδ_pos : ∀ᶠ ε in 𝓝[>] (0 : ℝ), 0 < δ ε)
     (hδ_to_zero : Tendsto δ (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ))) :
     Tendsto (fun ε : ℝ => Complex.arg ((γ (t₀ + r) - s) / (γ (t₀ + δ ε) - s)))
       (𝓝[>] (0 : ℝ)) (𝓝 ((γ (t₀ + r) - s) / L).arg) := by
@@ -244,10 +239,8 @@ theorem arg_annular_quotient_tendsto_right
 argument of the annular quotient `(γ (t₀ - δ ε) - s) / (γ (t₀ - r) - s)` converges to the
 argument of `(-L) / (γ (t₀ - r) - s)`. -/
 theorem arg_annular_quotient_tendsto_left
-    (h_deriv : HasDerivWithinAt γ L (Iio t₀) t₀) (h_at : γ t₀ = s)
-    {δ : ℝ → ℝ} {r : ℝ}
-    (h_slit : (-L) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
-    (hδ_pos : ∀ᶠ ε in 𝓝[>] (0 : ℝ), 0 < δ ε)
+    (h_deriv : HasDerivWithinAt γ L (Iio t₀) t₀) (h_at : γ t₀ = s) {δ : ℝ → ℝ} {r : ℝ}
+    (h_slit : (-L) / (γ (t₀ - r) - s) ∈ Complex.slitPlane) (hδ_pos : ∀ᶠ ε in 𝓝[>] (0 : ℝ), 0 < δ ε)
     (hδ_to_zero : Tendsto δ (𝓝[>] (0 : ℝ)) (𝓝[>] (0 : ℝ))) :
     Tendsto (fun ε : ℝ => Complex.arg ((γ (t₀ - δ ε) - s) / (γ (t₀ - r) - s)))
       (𝓝[>] (0 : ℝ)) (𝓝 ((-L) / (γ (t₀ - r) - s)).arg) := by

--- a/TauCeti/Analysis/Contour/ConditionDischarge.lean
+++ b/TauCeti/Analysis/Contour/ConditionDischarge.lean
@@ -166,8 +166,7 @@ tangent powers through the crossing-angle bridge. -/
 theorem ConditionB.pow_unit_tangent_eq_of_coeff_ne_zero {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
     (hB : ConditionB γ a b f) {S : Finset ℂ} {U : Set ℂ}
     (decomp : PolarPartDecomposition f S U) (hU : IsOpen U) (hSU : (S : Set ℂ) ⊆ U)
-    (s : S) (hMero : MeromorphicAt f ↑s)
-    (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
+    (s : S) (hMero : MeromorphicAt f ↑s) (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
     (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
     (h_ord : decomp.order s = meromorphicPolarOrderAt f ↑s) :
     ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →

--- a/TauCeti/Analysis/Contour/Crossing/Monotonicity.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Monotonicity.lean
@@ -58,8 +58,7 @@ derivative of `‖γ t - s‖²` (up to the factor `2`) deviates from its leadin
 `(t - t₀)‖L‖²` by at most `|t - t₀|‖L‖²/2`. Both one-sided strict-monotonicity statements read
 off their sign from this single bound. -/
 private theorem abs_inner_chord_deriv_sub_le {γ : ℝ → F} {t₀ : ℝ} {s : F} (h_at : γ t₀ = s)
-    {L : F} (hL : L ≠ 0) {u : Set ℝ}
-    (h_deriv : HasDerivWithinAt γ L u t₀)
+    {L : F} (hL : L ≠ 0) {u : Set ℝ} (h_deriv : HasDerivWithinAt γ L u t₀)
     (hL_tendsto : Tendsto (deriv γ) (𝓝[u] t₀) (𝓝 L)) :
     ∀ᶠ t in 𝓝[u] t₀,
       |inner ℝ (γ t - s) (deriv γ t) - (t - t₀) * ‖L‖ ^ 2| ≤ |t - t₀| * ‖L‖ ^ 2 / 2 := by
@@ -109,10 +108,8 @@ for a curve through `s = γ t₀` with non-zero right derivative limit `L`, cont
 and eventual differentiability on the right, `‖γ t - s‖` is strictly monotone on `[t₀, t₀ + r]`
 for some `r > 0` — the curve exits each small disc around `s` exactly once. -/
 theorem exists_strictMonoOn_norm_sub_right {γ : ℝ → F} {t₀ : ℝ} {s : F} (h_at : γ t₀ = s)
-    {L : F} (hL : L ≠ 0)
-    (hL_right : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L))
-    (hγ_cont : ContinuousAt γ t₀)
-    (hγ_diff : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t) :
+    {L : F} (hL : L ≠ 0) (hL_right : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L))
+    (hγ_cont : ContinuousAt γ t₀) (hγ_diff : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t) :
     ∃ r > 0, StrictMonoOn (fun t => ‖γ t - s‖) (Icc t₀ (t₀ + r)) := by
   have h_combined : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t ∧
       (t - t₀) * ‖L‖ ^ 2 / 2 ≤ inner ℝ (γ t - s) (deriv γ t) := by
@@ -162,9 +159,7 @@ counterpart of `exists_strictMonoOn_norm_sub_right`, derived from it by the refl
 `t ↦ 2t₀ - t` (which carries the left data of `γ` to right data of the reflected curve with
 derivative limit `-L`). -/
 theorem exists_strictAntiOn_norm_sub_left {γ : ℝ → F} {t₀ : ℝ} {s : F} (h_at : γ t₀ = s)
-    {L : F} (hL : L ≠ 0)
-    (hL_left : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L))
-    (hγ_cont : ContinuousAt γ t₀)
+    {L : F} (hL : L ≠ 0) (hL_left : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L)) (hγ_cont : ContinuousAt γ t₀)
     (hγ_diff : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t) :
     ∃ r > 0, StrictAntiOn (fun t => ‖γ t - s‖) (Icc (t₀ - r) t₀) := by
   have ht₀ : 2 * t₀ - t₀ = t₀ := by ring

--- a/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
+++ b/TauCeti/Analysis/Contour/Crossing/PVAggregation.lean
@@ -68,8 +68,7 @@ open scoped Fin.NatCast
 `[a, b]`, by restriction. -/
 private theorem eventually_intervalIntegrable_truncated_window {γ : ℝ → ℂ} {s : ℂ}
     {g : ℂ → ℂ} {a b r t : ℝ} (hab : a ≤ b) (h_lo : a ≤ t - r) (h_hi : t + r ≤ b)
-    (hr_nonneg : 0 ≤ r)
-    (h_int_tr : ∀ ε : ℝ, 0 < ε →
+    (hr_nonneg : 0 ≤ r) (h_int_tr : ∀ ε : ℝ, 0 < ε →
       IntervalIntegrable (fun u => if ‖γ u - s‖ > ε then g (γ u) * deriv γ u else 0)
         MeasureTheory.volume a b) :
     ∀ᶠ ε in 𝓝[>] (0 : ℝ),
@@ -84,8 +83,7 @@ private theorem eventually_intervalIntegrable_truncated_window {γ : ℝ → ℂ
 `s`: the plain integral, with the truncated integrability restricted from `[a, b]`. Both public
 aggregations discharge their piece hypothesis through this. -/
 private theorem hasCauchyPVAt_plain_piece {γ : ℝ → ℂ} {s : ℂ} {g : ℂ → ℂ} {a b m : ℝ}
-    (hab : a ≤ b) (hm_pos : 0 < m)
-    (h_int_tr : ∀ ε : ℝ, 0 < ε →
+    (hab : a ≤ b) (hm_pos : 0 < m) (h_int_tr : ∀ ε : ℝ, 0 < ε →
       IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
         MeasureTheory.volume a b)
     {l u : ℝ} (hA : a ≤ l) (hlu : l ≤ u) (hu : u ≤ b)
@@ -164,8 +162,7 @@ positive distance from `s` off the windows, then the principal value at `s` exis
 `[a, b]`. The per-window limits are hypotheses, so both the simple-pole and higher-order
 per-window theorems discharge them. -/
 theorem cauchyPVExistsAt_of_perWindow_tendsto_of_interiorDisjoint {γ : ℝ → ℂ} {s : ℂ} {g : ℂ → ℂ}
-    {a b r : ℝ} (hab : a ≤ b) (crossings : Finset ℝ)
-    (hr_nonneg : crossings.Nonempty → 0 ≤ r)
+    {a b r : ℝ} (hab : a ≤ b) (crossings : Finset ℝ) (hr_nonneg : crossings.Nonempty → 0 ≤ r)
     (h_lo : ∀ t ∈ crossings, a ≤ t - r) (h_hi : ∀ t ∈ crossings, t + r ≤ b)
     (h_pair : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r ≤ |t - t'|)
     (h_int_tr : ∀ ε : ℝ, 0 < ε →
@@ -288,8 +285,7 @@ private theorem windowPieceSum_eq_sum_intervalGapsWithin_add_sum {p : ℝ → �
 /-- **The window aggregation telescopes to the endpoint difference.** Reading the pieces as the
 gaps of the window finset `F = {(t - r, t + r) : t ∈ crossings}` inside `[a, b]`, this is exactly
 `Finset.sum_intervalGapsWithin_add_sum_eq_sub` for `g = Φ ∘ γ`. -/
-private theorem windowPieceSum_boundary {γ : ℝ → ℂ} {Φ : ℂ → ℂ} {a b r : ℝ}
-    {crossings : Finset ℝ} :
+private theorem windowPieceSum_boundary {γ : ℝ → ℂ} {Φ : ℂ → ℂ} {a b r : ℝ} {crossings : Finset ℝ} :
     windowPieceSum r (fun l u => Φ (γ u) - Φ (γ l))
         (fun t => Φ (γ (t + r)) - Φ (γ (t - r))) b (crossings.sort (· ≤ ·)) a
       = Φ (γ b) - Φ (γ a) := by
@@ -323,8 +319,7 @@ private theorem windowPieceSum_boundary {γ : ℝ → ℂ} {Φ : ℂ → ℂ} {a
 principal value on `[a, b]` is `Φ (γ b) - Φ (γ a)` — in particular zero around a closed curve.
 The higher-order per-window limits have exactly this boundary-difference shape. -/
 theorem hasCauchyPVAt_of_perWindow_boundary_tendsto_of_interiorDisjoint {γ : ℝ → ℂ} {s : ℂ}
-    {g : ℂ → ℂ}
-    {Φ : ℂ → ℂ} {a b r : ℝ} (hab : a ≤ b) (crossings : Finset ℝ)
+    {g : ℂ → ℂ} {Φ : ℂ → ℂ} {a b r : ℝ} (hab : a ≤ b) (crossings : Finset ℝ)
     (hr_nonneg : crossings.Nonempty → 0 ≤ r)
     (h_lo : ∀ t ∈ crossings, a ≤ t - r) (h_hi : ∀ t ∈ crossings, t + r ≤ b)
     (h_pair : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r ≤ |t - t'|)

--- a/TauCeti/Analysis/Contour/Crossing/Windows.lean
+++ b/TauCeti/Analysis/Contour/Crossing/Windows.lean
@@ -61,8 +61,7 @@ open Set
 
 /-- The minimum pairwise distance of a finite set with at least two elements is positive:
 `Set.infsep` positivity for finite sets. -/
-private theorem min_pairwise_distance_pos {crossings : Finset ℝ}
-    (h_card : 2 ≤ crossings.card) :
+private theorem min_pairwise_distance_pos {crossings : Finset ℝ} (h_card : 2 ≤ crossings.card) :
     ∃ d > 0, ∀ t₁ ∈ crossings, ∀ t₂ ∈ crossings, t₁ ≠ t₂ → d ≤ |t₁ - t₂| := by
   have h_nt : (↑crossings : Set ℝ).Nontrivial := by
     obtain ⟨p, hp, q, hq, hpq⟩ := Finset.one_lt_card.mp h_card
@@ -77,8 +76,7 @@ private theorem min_pairwise_distance_pos {crossings : Finset ℝ}
 /-- A finite subset of the open interval `(a, b)` is uniformly separated from both
 endpoints. -/
 private theorem crossings_bounded_from_endpoints {a b : ℝ} {crossings : Finset ℝ}
-    (h_nonempty : crossings.Nonempty)
-    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b) :
+    (h_nonempty : crossings.Nonempty) (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b) :
     ∃ c > 0, ∀ t ∈ crossings, a + c ≤ t ∧ t ≤ b - c := by
   obtain ⟨t_min, ht_min_mem, ht_min⟩ :=
     Finset.exists_min_image crossings (fun t => min (t - a) (b - t)) h_nonempty
@@ -91,8 +89,7 @@ private theorem crossings_bounded_from_endpoints {a b : ℝ} {crossings : Finset
 
 /-- A finite set disjoint from a finite exceptional set is uniformly separated from it. -/
 private theorem crossings_bounded_from_exceptional {crossings P : Finset ℝ}
-    (h_nonempty : crossings.Nonempty)
-    (h_off : ∀ t ∈ crossings, t ∉ P) :
+    (h_nonempty : crossings.Nonempty) (h_off : ∀ t ∈ crossings, t ∉ P) :
     ∃ c > 0, ∀ t ∈ crossings, ∀ p ∈ P, c ≤ |t - p| := by
   by_cases hP : P = ∅
   · exact ⟨1, one_pos, fun _ _ p hp => absurd (hP ▸ hp) (Finset.notMem_empty p)⟩
@@ -111,8 +108,7 @@ exceptional set `P`, there is `r > 0` such that every window `[t_i - r, t_i + r]
 `[a, b]`, distinct crossings are more than `2r` apart (so the windows are pairwise disjoint),
 and no exceptional point comes within `r` of a crossing. -/
 theorem exists_common_window_radius {a b : ℝ} {crossings P : Finset ℝ}
-    (h_nonempty : crossings.Nonempty)
-    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
+    (h_nonempty : crossings.Nonempty) (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
     (h_off : ∀ t ∈ crossings, t ∉ P) :
     ∃ r > 0,
       (∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r) ∧
@@ -157,8 +153,7 @@ conditions are vacuous and any positive radius serves.
 The endpoint margins come out *strict* here: the radius is chosen strictly below the one that lemma
 supplies, so it clears both endpoints with room to spare. -/
 theorem exists_common_window_radius_le {a b : ℝ} {crossings : Finset ℝ}
-    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b)
-    (R : ℝ → ℝ) (hR_pos : ∀ t ∈ crossings, 0 < R t) :
+    (h_Ioo : ∀ t ∈ crossings, t ∈ Ioo a b) (R : ℝ → ℝ) (hR_pos : ∀ t ∈ crossings, 0 < R t) :
     ∃ r > 0,
       (∀ t ∈ crossings, a + r < t ∧ t < b - r) ∧
       (∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → 2 * r < |t - t'|) ∧
@@ -194,8 +189,7 @@ This is the pointwise core: nothing is assumed about the other crossings' own wi
 holding margins for every crossing at once. Stated for a bare function; no regularity is
 used. -/
 theorem eq_of_mem_window_of_eq_of_le_of_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
-    {crossings : Finset ℝ} {r t_i : ℝ}
-    (h_endpts : a + r ≤ t_i ∧ t_i ≤ b - r)
+    {crossings : Finset ℝ} {r t_i : ℝ} (h_endpts : a + r ≤ t_i ∧ t_i ≤ b - r)
     (h_pairwise : ∀ t' ∈ crossings, t' ≠ t_i → r < |t_i - t'|)
     (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
@@ -218,11 +212,9 @@ takes the value `s` is `t_i` itself. Stated for a bare function; no regularity i
 The family-wide form, for callers holding margins for every crossing at once; it reads them off
 at `t_i` and defers to `eq_of_mem_window_of_eq_of_le_of_lt`. -/
 theorem eq_of_mem_window_of_eq {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
-    {crossings : Finset ℝ} {r : ℝ}
-    (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
+    {crossings : Finset ℝ} {r : ℝ} (h_endpts : ∀ t ∈ crossings, a + r ≤ t ∧ t ≤ b - r)
     (h_pairwise : ∀ t ∈ crossings, ∀ t' ∈ crossings, t' ≠ t → r < |t - t'|)
-    (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
-    {t_i : ℝ} (ht_i : t_i ∈ crossings)
+    (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings) {t_i : ℝ} (ht_i : t_i ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :
     t = t_i :=
   eq_of_mem_window_of_eq_of_le_of_lt (h_endpts t_i ht_i) (h_pairwise t_i ht_i) h_complete ht h_eq
@@ -234,8 +226,7 @@ endpoints, and every other crossing more than `2 * r` from it. No sign condition
 required — halving the pairwise margin needs `0 ≤ r`, but a negative radius leaves the window
 `[t_i - r, t_i + r]` empty, so `ht` supplies it. -/
 theorem eq_of_mem_window_of_eq_of_lt_of_two_mul_lt {α : Type*} {γ : ℝ → α} {s : α} {a b : ℝ}
-    {crossings : Finset ℝ} {r t_i : ℝ}
-    (h_endpts : a + r < t_i ∧ t_i < b - r)
+    {crossings : Finset ℝ} {r t_i : ℝ} (h_endpts : a + r < t_i ∧ t_i < b - r)
     (h_pairwise : ∀ t' ∈ crossings, t' ≠ t_i → 2 * r < |t_i - t'|)
     (h_complete : ∀ t ∈ Icc a b, γ t = s → t ∈ crossings)
     {t : ℝ} (ht : t ∈ Icc (t_i - r) (t_i + r)) (h_eq : γ t = s) :

--- a/TauCeti/Analysis/Contour/Curve/IntegralBound.lean
+++ b/TauCeti/Analysis/Contour/Curve/IntegralBound.lean
@@ -48,8 +48,7 @@ namespace TauCeti.Contour
 `L¹` norm. Only the bound on the half-open interval `Ι a b` matters; the endpoints do not affect the
 integral. -/
 theorem norm_integral_inv_sub_mul_le {γ g : ℝ → ℂ} {a b R : ℝ} {w : ℂ}
-    (hg : IntervalIntegrable g volume a b)
-    (hR : ∀ t ∈ Ι a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
+    (hg : IntervalIntegrable g volume a b) (hR : ∀ t ∈ Ι a b, ‖γ t‖ ≤ R) (hw : R < ‖w‖) :
     ‖∫ t in a..b, (γ t - w)⁻¹ * g t‖ ≤ (∫ t in Ι a b, ‖g t‖) / (‖w‖ - R) := by
   have hpos : 0 < ‖w‖ - R := by linarith
   have h_dist_lb : ∀ t ∈ Ι a b, ‖w‖ - R ≤ ‖γ t - w‖ := fun t ht => by

--- a/TauCeti/Analysis/Contour/Curve/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Curve/Reparam.lean
@@ -93,10 +93,8 @@ end Regularity
 consumer of the reparametrized contour integrand needs for integrability. As elsewhere, `φ` has an
 ambient derivative `φ' t` at each `t ∈ [[a, b]]` with `φ'` continuous there, and `γ` is
 ambient-differentiable with continuous derivative on the swept image `φ '' [[a, b]]`. -/
-theorem continuousOn_deriv_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc a b))
-    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+theorem continuousOn_deriv_comp_reparam (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b)) (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
     (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b)) :
     ContinuousOn (deriv (γ ∘ φ)) (Set.uIcc a b) := by
   have hφcont : ContinuousOn φ (Set.uIcc a b) :=
@@ -108,10 +106,8 @@ theorem continuousOn_deriv_comp_reparam
 continuous derivative on the swept image `φ '' [[a, b]]`, and `f` is continuous on the image of the
 curve, then integrating `f` along the reparametrized curve `γ ∘ φ` over `[[a, b]]` gives the same
 value as integrating along `γ` over `[[φ a, φ b]]`. -/
-theorem integral_deriv_smul_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc a b))
-    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+theorem integral_deriv_smul_comp_reparam (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b)) (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
     (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
     (hf : ContinuousOn f (γ '' (φ '' Set.uIcc a b))) :
     ∫ t in a..b, deriv (γ ∘ φ) t • f ((γ ∘ φ) t) = ∫ u in φ a..φ b, deriv γ u • f (γ u) := by

--- a/TauCeti/Analysis/Contour/Dixon/FunctionDiff.lean
+++ b/TauCeti/Analysis/Contour/Dixon/FunctionDiff.lean
@@ -98,8 +98,7 @@ identity. This is the gluing core; `differentiable_dixonFunction` discharges the
 for a null-homologous closed curve. -/
 private theorem differentiable_dixonFunction_of_windingNumber_zero_near (hU : IsOpen U)
     (hf : DifferentiableOn ℂ f U) (hγ_cont : ContinuousOn γ (uIcc a b))
-    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
-    (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
+    (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
     (h_local : ∀ w ∉ U, ∃ ε > 0, ∀ w' ∈ Metric.ball w ε,
       (∀ t ∈ uIcc a b, γ t ≠ w') ∧ windingNumber γ a b w' = 0) :
     Differentiable ℂ (dixonFunction f U γ a b) := by

--- a/TauCeti/Analysis/Contour/Dixon/H2/Diff.lean
+++ b/TauCeti/Analysis/Contour/Dixon/H2/Diff.lean
@@ -63,8 +63,7 @@ private theorem h2_kernel_continuousOn (hγ_cont : ContinuousOn γ (uIcc a b)) {
   (hγ_cont.sub continuousOn_const).inv₀ fun t ht ↦ sub_ne_zero.mpr (hoff t ht)
 
 /-- A continuous factor times the a.e. strongly measurable numerator is a.e. strongly measurable. -/
-private theorem h2_factor_mul_num_aestronglyMeasurable {g : ℝ → ℂ}
-    (hg : ContinuousOn g (uIcc a b))
+private theorem h2_factor_mul_num_aestronglyMeasurable {g : ℝ → ℂ} (hg : ContinuousOn g (uIcc a b))
     (hnum : AEStronglyMeasurable (fun t ↦ f (γ t) * deriv γ t) (volume.restrict (Ι a b))) :
     AEStronglyMeasurable (fun t ↦ g t * (f (γ t) * deriv γ t)) (volume.restrict (Ι a b)) :=
   ((hg.mono Set.uIoc_subset_uIcc).aestronglyMeasurable measurableSet_uIoc).mul hnum

--- a/TauCeti/Analysis/Contour/ExitTime.lean
+++ b/TauCeti/Analysis/Contour/ExitTime.lean
@@ -83,8 +83,7 @@ theorem firstExitTimeRight_mem_Icc {γ : ℝ → E} {t₀ δ ε : ℝ} {s : E} (
 /-- **Radius lower bound at the right exit time**: the `sInf` of the closed set of
 outside-the-ball times is itself outside the open ball. -/
 theorem le_norm_at_firstExitTimeRight {γ : ℝ → E} {t₀ δ ε : ℝ} {s : E}
-    (hδ : 0 ≤ δ) (hγ_cont : ContinuousOn γ (Icc t₀ (t₀ + δ)))
-    (hε_le : ε ≤ ‖γ (t₀ + δ) - s‖) :
+    (hδ : 0 ≤ δ) (hγ_cont : ContinuousOn γ (Icc t₀ (t₀ + δ))) (hε_le : ε ≤ ‖γ (t₀ + δ) - s‖) :
     ε ≤ ‖γ (firstExitTimeRight γ t₀ δ s ε) - s‖ :=
   (((hγ_cont.sub continuousOn_const).norm.preimage_isClosed_of_isClosed
       isClosed_Icc isClosed_Ici).csInf_mem
@@ -163,8 +162,7 @@ theorem firstExitTimeLeft_mem_Icc {γ : ℝ → E} {t₀ δ ε : ℝ} {s : E} (h
 /-- **Radius lower bound at the left exit time**: the `sSup` of the closed set of
 outside-the-ball times is itself outside the open ball. -/
 theorem le_norm_at_firstExitTimeLeft {γ : ℝ → E} {t₀ δ ε : ℝ} {s : E}
-    (hδ : 0 ≤ δ) (hγ_cont : ContinuousOn γ (Icc (t₀ - δ) t₀))
-    (hε_le : ε ≤ ‖γ (t₀ - δ) - s‖) :
+    (hδ : 0 ≤ δ) (hγ_cont : ContinuousOn γ (Icc (t₀ - δ) t₀)) (hε_le : ε ≤ ‖γ (t₀ - δ) - s‖) :
     ε ≤ ‖γ (firstExitTimeLeft γ t₀ δ s ε) - s‖ :=
   (((hγ_cont.sub continuousOn_const).norm.preimage_isClosed_of_isClosed
       isClosed_Icc isClosed_Ici).csSup_mem

--- a/TauCeti/Analysis/Contour/HigherOrder/Asymptotics.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/Asymptotics.lean
@@ -65,8 +65,7 @@ open Asymptotics Complex Filter Set Topology
 
 /-- **The antiderivative of `1/(z-s)^k`** (`k ≥ 2`): the function
 `F(z) = -1/[(k-1)(z-s)^(k-1)]` has complex derivative `1/(z-s)^k` at any `z ≠ s`. -/
-theorem hasDerivAt_antiderivative_pow_inv
-    {s : ℂ} {k : ℕ} (hk : 2 ≤ k) {z : ℂ} (hz : z ≠ s) :
+theorem hasDerivAt_antiderivative_pow_inv {s : ℂ} {k : ℕ} (hk : 2 ≤ k) {z : ℂ} (hz : z ≠ s) :
     HasDerivAt (fun w => -(↑(k - 1) : ℂ)⁻¹ * ((w - s) ^ (k - 1))⁻¹)
       (1 / (z - s) ^ k) z := by
   have h_pow : HasDerivAt (fun w : ℂ => (w - s) ^ (k - 1))
@@ -151,10 +150,8 @@ private theorem eventually_ne_of_hasDerivWithinAt
 `s`, the chord from `γ t` to the tangent target at the same distance is dominated by the
 perpendicular deviation, hence `o(‖γ t - s‖ ^ n)` whenever the deviation is. The right side
 instantiates `T = L`, `l = 𝓝[>] t₀`; the left side `T = -L`, `l = 𝓝[<] t₀`. -/
-theorem chord_to_tangent_isLittleO
-    {γ : ℝ → ℂ} {s : ℂ} {l : Filter ℝ} {T : ℂ} {n : ℕ} (hT : T ≠ 0)
-    (h_re : ∀ᶠ t in l, 0 ≤ ((γ t - s) * starRingEnd ℂ T).re)
-    (h_ne : ∀ᶠ t in l, γ t ≠ s)
+theorem chord_to_tangent_isLittleO {γ : ℝ → ℂ} {s : ℂ} {l : Filter ℝ} {T : ℂ} {n : ℕ} (hT : T ≠ 0)
+    (h_re : ∀ᶠ t in l, 0 ≤ ((γ t - s) * starRingEnd ℂ T).re) (h_ne : ∀ᶠ t in l, γ t ≠ s)
     (h_dev : (fun t => ‖tangentDeviation (γ t - s) T‖) =o[l]
       fun t => ‖γ t - s‖ ^ n) :
     (fun t => ‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖) =o[l]
@@ -180,10 +177,8 @@ theorem chord_to_tangent_isLittleO
 
 /-- On the segment between two points equidistant (distance `d`) from `s`, every point satisfies
 `‖z - s‖² ≥ d² - ‖z₁ - z₂‖²/4`. -/
-private theorem norm_sq_segment_to_pole_lower_bound
-    {z₁ z₂ s : ℂ} {d : ℝ}
-    (h₁ : ‖z₁ - s‖ = d) (h₂ : ‖z₂ - s‖ = d)
-    {z : ℂ} (hz : z ∈ segment ℝ z₁ z₂) :
+private theorem norm_sq_segment_to_pole_lower_bound {z₁ z₂ s : ℂ} {d : ℝ}
+    (h₁ : ‖z₁ - s‖ = d) (h₂ : ‖z₂ - s‖ = d) {z : ℂ} (hz : z ∈ segment ℝ z₁ z₂) :
     d ^ 2 - ‖z₁ - z₂‖ ^ 2 / 4 ≤ ‖z - s‖ ^ 2 := by
   obtain ⟨α, β, hα, hβ, h_sum, rfl⟩ := hz
   rw [show α • z₁ + β • z₂ - s = α • (z₁ - s) + β • (z₂ - s) by
@@ -216,8 +211,7 @@ private theorem norm_sq_segment_to_pole_lower_bound
 
 /-- When the chord between two points at distance `d` from `s` is at most `d`, their segment
 stays at distance `≥ d/2` from `s`. -/
-private theorem norm_segment_to_pole_lower_bound_half
-    {z₁ z₂ s : ℂ} {d : ℝ}
+private theorem norm_segment_to_pole_lower_bound_half {z₁ z₂ s : ℂ} {d : ℝ}
     (h₁ : ‖z₁ - s‖ = d) (h₂ : ‖z₂ - s‖ = d) (h_chord : ‖z₁ - z₂‖ ≤ d)
     {z : ℂ} (hz : z ∈ segment ℝ z₁ z₂) :
     d / 2 ≤ ‖z - s‖ := by
@@ -229,10 +223,8 @@ private theorem norm_segment_to_pole_lower_bound_half
 /-- For `w ≠ s` with the chord to the tangent target at most `‖w - s‖`, the antiderivative
 difference between `w` and the tangent target `s + (‖w - s‖/‖L‖) • L` is bounded by
 `(1/(‖w - s‖/2)^k) · chord`. -/
-private theorem norm_antiderivative_diff_at_tangent_target_le
-    {w s L : ℂ} {k : ℕ} (hk : 2 ≤ k)
-    (hL : L ≠ 0) (hw_ne : w ≠ s)
-    (h_chord_le : ‖w - (s + (‖w - s‖ / ‖L‖ : ℝ) • L)‖ ≤ ‖w - s‖) :
+private theorem norm_antiderivative_diff_at_tangent_target_le {w s L : ℂ} {k : ℕ} (hk : 2 ≤ k)
+    (hL : L ≠ 0) (hw_ne : w ≠ s) (h_chord_le : ‖w - (s + (‖w - s‖ / ‖L‖ : ℝ) • L)‖ ≤ ‖w - s‖) :
     ‖(-(↑(k - 1) : ℂ)⁻¹ * ((w - s) ^ (k - 1))⁻¹) -
       (-(↑(k - 1) : ℂ)⁻¹ * (((s + (‖w - s‖ / ‖L‖ : ℝ) • L) - s) ^ (k - 1))⁻¹)‖ ≤
       (1 / (‖w - s‖ / 2) ^ k) * ‖w - (s + (‖w - s‖ / ‖L‖ : ℝ) • L)‖ := by
@@ -255,8 +247,7 @@ private theorem norm_antiderivative_diff_at_tangent_target_le
   exact h_F_diff
 
 /-- If `chord = o(d^n)`, `d → 0` with `d > 0` eventually, and `k ≤ n`, then `chord/d^k → 0`. -/
-private theorem tendsto_div_pow_zero_of_isLittleO
-    {chord d : ℝ → ℝ} {l : Filter ℝ} {n k : ℕ}
+private theorem tendsto_div_pow_zero_of_isLittleO {chord d : ℝ → ℝ} {l : Filter ℝ} {n k : ℕ}
     (h_chord : chord =o[l] (fun t => d t ^ n)) (h_d : Tendsto d l (𝓝 0))
     (h_d_pos : ∀ᶠ t in l, 0 < d t) (hkn : k ≤ n) :
     Tendsto (fun t => chord t / d t ^ k) l (𝓝 0) := by
@@ -285,8 +276,7 @@ chord to the `+T` tangent target is `o(‖γ t - s‖ ^ n)` along `l`, `γ → s
 `2 ≤ k ≤ n`, then `F(γ t) - F(target)` tends to `0` along `l`, for the antiderivative `F` of the
 order-`k` pole integrand. -/
 theorem antiderivative_diff_at_tangent_target_tendsto_zero
-    {γ : ℝ → ℂ} {s : ℂ} {l : Filter ℝ} {T : ℂ} {n k : ℕ}
-    (hT : T ≠ 0) (hk : 2 ≤ k) (hkn : k ≤ n)
+    {γ : ℝ → ℂ} {s : ℂ} {l : Filter ℝ} {T : ℂ} {n k : ℕ} (hT : T ≠ 0) (hk : 2 ≤ k) (hkn : k ≤ n)
     (h_chord : (fun t => ‖γ t - s - (‖γ t - s‖ / ‖T‖ : ℝ) • T‖) =o[l]
       fun t => ‖γ t - s‖ ^ n)
     (h_ne : ∀ᶠ t in l, γ t ≠ s) (h_to : Tendsto γ l (𝓝 s)) :

--- a/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
+++ b/TauCeti/Analysis/Contour/HigherOrder/CPV.lean
@@ -62,8 +62,7 @@ antiderivative, at every window radius whose window lies inside `[a, b]` and con
 crossing. -/
 private theorem perWindow_boundary_tendsto_of_interior {γ : ℝ → ℂ} {a b t₀ : ℝ} {s : ℂ}
     {k n : ℕ} {P : Set ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b)
-    (ht₀ : t₀ ∈ Ioo a b) (h_at : γ t₀ = s) (hk : 2 ≤ k) (hkn : k ≤ n)
-    (h_flat : FlatOfOrder γ t₀ n)
+    (ht₀ : t₀ ∈ Ioo a b) (h_at : γ t₀ = s) (hk : 2 ≤ k) (hkn : k ≤ n) (h_flat : FlatOfOrder γ t₀ n)
     (h_B : ∀ L_R L_L : ℂ, Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R) →
       Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L) →
       (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1))
@@ -104,8 +103,7 @@ piecewise-`C¹` curve is the boundary difference of its antiderivative — the p
 to the telescoping aggregation. -/
 private theorem plain_piece_integral_eq {γ : ℝ → ℂ} {a b : ℝ} {s : ℂ} {k : ℕ}
     (h_imm : IsPwC1ImmersionOn γ a b) (hab : a < b) (hk : 2 ≤ k) (c : ℂ)
-    {l u : ℝ} (hal : a ≤ l) (hlu : l ≤ u) (hub : u ≤ b)
-    (h_ne : ∀ t ∈ Icc l u, γ t ≠ s) :
+    {l u : ℝ} (hal : a ≤ l) (hlu : l ≤ u) (hub : u ≤ b) (h_ne : ∀ t ∈ Icc l u, γ t ≠ s) :
     ∫ t in l..u, c / (γ t - s) ^ k * deriv γ t =
       c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ u - s) ^ (k - 1))⁻¹) -
         c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ l - s) ^ (k - 1))⁻¹) := by
@@ -129,8 +127,7 @@ curve. Endpoint crossings are excluded by `h_interior`; for a closed curve this 
 of a basepoint off `s`. -/
 theorem IsPwC1ImmersionOn.hasCauchyPVAt_pow_inv {γ : ℝ → ℂ} {a b : ℝ} {s : ℂ} {k n : ℕ}
     (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
-    (h_interior : ∀ t ∈ Icc a b, γ t = s → t ∈ Ioo a b)
-    (hk : 2 ≤ k) (hkn : k ≤ n)
+    (h_interior : ∀ t ∈ Icc a b, γ t = s → t ∈ Ioo a b) (hk : 2 ≤ k) (hkn : k ≤ n)
     (h_flat : ∀ t ∈ Icc a b, γ t = s → FlatOfOrder γ t n)
     (h_B : ∀ t ∈ Icc a b, γ t = s → ∀ L_R L_L : ℂ,
       Tendsto (deriv γ) (𝓝[>] t) (𝓝 L_R) → Tendsto (deriv γ) (𝓝[<] t) (𝓝 L_L) →

--- a/TauCeti/Analysis/Contour/HomologyCauchy.lean
+++ b/TauCeti/Analysis/Contour/HomologyCauchy.lean
@@ -81,8 +81,7 @@ theorem homologyCauchyTheorem_of_point_off_curve {f : ℂ → ℂ} {U : Set ℂ}
     (hγ_cont : ContinuousOn γ (uIcc a b)) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b) (hclosed : γ a = γ b)
     (hP : P.Countable) (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
-    (h_null : IsNullHomologous γ a b U) (hw₀U : w₀ ∈ U)
-    (hw₀off : ∀ t ∈ uIcc a b, γ t ≠ w₀) :
+    (h_null : IsNullHomologous γ a b U) (hw₀U : w₀ ∈ U) (hw₀off : ∀ t ∈ uIcc a b, γ t ≠ w₀) :
     ∫ t in a..b, deriv γ t • f (γ t) = 0 := by
   have hg : DifferentiableOn ℂ (fun z ↦ (z - w₀) * f z) U := by
     fun_prop
@@ -106,10 +105,8 @@ the compact curve image cannot exhaust the open `Ω`, giving a base point `w₀ 
 (`exists_mem_off_curve`); and `homologyCauchyTheorem_of_point_off_curve` — vanishing of the glued
 Dixon function by Liouville, then the Cauchy integral formula at `w₀` — concludes. -/
 theorem homologyCauchyTheorem {f : ℂ → ℂ} {Ω : Set ℂ} (hΩ : IsOpen Ω) (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ_pc1 : IsPiecewiseC1On γ a b)
-    (hγ : ∀ t ∈ uIcc a b, γ t ∈ Ω) (hclosed : γ a = γ b)
-    (hf : DifferentiableOn ℂ f Ω)
-    (hnull : IsNullHomologous γ a b Ω) :
+    (hγ_pc1 : IsPiecewiseC1On γ a b) (hγ : ∀ t ∈ uIcc a b, γ t ∈ Ω) (hclosed : γ a = γ b)
+    (hf : DifferentiableOn ℂ f Ω) (hnull : IsNullHomologous γ a b Ω) :
     ∫ t in a..b, deriv γ t • f (γ t) = 0 := by
   obtain ⟨P, hP, hγ_diff⟩ := hγ_pc1.exists_countable_differentiableAt
   obtain ⟨w₀, hw₀Ω, hw₀off⟩ := exists_mem_off_curve hΩ hγ_pc1.continuousOn hγ

--- a/TauCeti/Analysis/Contour/HungerbuhlerWasem.lean
+++ b/TauCeti/Analysis/Contour/HungerbuhlerWasem.lean
@@ -71,13 +71,10 @@ open Filter Set Topology
 polar decomposition, discharge conditions (A′) and (B) into the per-pole hypotheses, and
 assemble the residue sum. -/
 private theorem hungerbuhlerWasem_residueTheorem_of_le {f : ℂ → ℂ} {U : Set ℂ}
-    (hU : IsOpen U) (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ_imm : IsPwC1ImmersionOn γ a b)
+    (hU : IsOpen U) (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ) (hγ_imm : IsPwC1ImmersionOn γ a b)
     (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
-    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
-    (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
-    (hmero : ∀ s ∈ S, MeromorphicAt f s)
-    (hnull : IsNullHomologous γ a b U)
+    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U) (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
+    (hmero : ∀ s ∈ S, MeromorphicAt f s) (hnull : IsNullHomologous γ a b U)
     (hA : ConditionAprime γ a b f S) (hB : ConditionB γ a b f) (hab : a ≤ b) :
     HasCauchyPV γ a b f
       (2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, windingNumber γ a b s * residue f s)) := by
@@ -101,13 +98,10 @@ set-level Cauchy principal value of `f` along `γ` is
 `2πi · Σ_{s ∈ S} n_s(γ) · Res_s f`, with the generalized (non-integer) winding numbers as
 weights — valid when singularities of `f` lie **on** the curve. -/
 theorem hungerbuhlerWasem_residueTheorem {f : ℂ → ℂ} {U : Set ℂ} (hU : IsOpen U)
-    (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ_imm : IsPwC1ImmersionOn γ a b)
+    (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ) (hγ_imm : IsPwC1ImmersionOn γ a b)
     (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
-    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
-    (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
-    (hmero : ∀ s ∈ S, MeromorphicAt f s)
-    (hnull : IsNullHomologous γ a b U)
+    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U) (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
+    (hmero : ∀ s ∈ S, MeromorphicAt f s) (hnull : IsNullHomologous γ a b U)
     (hA : ConditionAprime γ a b f S) (hB : ConditionB γ a b f) :
     HasCauchyPV γ a b f
       (2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, windingNumber γ a b s * residue f s)) := by
@@ -199,8 +193,7 @@ forced to `1` and `IsPwC1ImmersionOn.flatOfOrder_one` supplies the first-order f
 curve with no interior crossing the clause holds because there is nothing to discharge. -/
 theorem conditionAprime_of_simple_poles {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
     {U : Set ℂ} {S : Finset ℂ} (hU : IsOpen U) (hγ_imm : IsPwC1ImmersionOn γ a b)
-    (hymin : γ (min a b) ∉ (S : Set ℂ))
-    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
+    (hymin : γ (min a b) ∉ (S : Set ℂ)) (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (h_simple : ∀ s ∈ S, ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s) :
     ConditionAprime γ a b f S := by
@@ -222,8 +215,7 @@ The companion instantiation lemma to `conditionAprime_of_simple_poles`: together
 discharge both regularity hypotheses of HW Thm 3.3 from the same simple-pole hypothesis, which
 is what makes `hungerbuhlerWasem_residueTheorem_of_simple_poles` unconditional. -/
 theorem conditionB_of_simple_poles {γ : ℝ → ℂ} {a b : ℝ} {f : ℂ → ℂ}
-    {U : Set ℂ} {S : Finset ℂ} (hU : IsOpen U)
-    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
+    {U : Set ℂ} {S : Finset ℂ} (hU : IsOpen U) (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
     (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
     (h_simple : ∀ s ∈ S, ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s) :
     ConditionB γ a b f := by
@@ -239,13 +231,10 @@ when every prescribed singularity is at worst a simple pole
 principal value is the winding-weighted residue sum with no regularity hypotheses beyond the
 immersion. The form the argument principle and the valence formula consume. -/
 theorem hungerbuhlerWasem_residueTheorem_of_simple_poles {f : ℂ → ℂ} {U : Set ℂ}
-    (hU : IsOpen U) (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ)
-    (hγ_imm : IsPwC1ImmersionOn γ a b)
+    (hU : IsOpen U) (S : Finset ℂ) (γ : ℝ → ℂ) (a b : ℝ) (hγ_imm : IsPwC1ImmersionOn γ a b)
     (hSU : (S : Set ℂ) ⊆ U) (hclosed : γ a = γ b) (hγa : γ a ∉ (S : Set ℂ))
-    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U)
-    (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
-    (hmero : ∀ s ∈ S, MeromorphicAt f s)
-    (hnull : IsNullHomologous γ a b U)
+    (hγU : ∀ t ∈ Set.uIcc a b, γ t ∈ U) (hf : DifferentiableOn ℂ f (U \ (S : Set ℂ)))
+    (hmero : ∀ s ∈ S, MeromorphicAt f s) (hnull : IsNullHomologous γ a b U)
     (h_simple : ∀ s ∈ S, ((-1 : ℤ) : WithTop ℤ) ≤ meromorphicOrderAt f s) :
     HasCauchyPV γ a b f
       (2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, windingNumber γ a b s * residue f s)) :=

--- a/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
+++ b/TauCeti/Analysis/Contour/MeromorphicLaurent.lean
@@ -78,8 +78,7 @@ theorem meromorphicPolarOrderAt_eq_of_order_eq {f : ℂ → ℂ} {s : ℂ}
 /-- **At a simple pole the canonical polar order is `1`.** With flatness of order one
 (`IsPwC1ImmersionOn.flatOfOrder_one`), this discharges condition (A′) of the generalized residue
 theorem at simple poles. -/
-theorem meromorphicPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ}
-    (h : meromorphicOrderAt f s = -1) :
+theorem meromorphicPolarOrderAt_eq_one {f : ℂ → ℂ} {s : ℂ} (h : meromorphicOrderAt f s = -1) :
     meromorphicPolarOrderAt f s = 1 := by
   rw [meromorphicPolarOrderAt_eq_of_order_eq h]
   rfl
@@ -139,8 +138,7 @@ theorem meromorphicPolarOrderAt_le_one_iff {f : ℂ → ℂ} {s : ℂ} :
 /-- Taylor decomposition of an analytic function to order `k`:
 `g z = ∑ j < k, c j * (z - s)^j + (z - s)^k * R z` with `R` analytic at `s`. Mathlib's
 `AnalyticAt.exists_eventuallyEq_sum_add_pow_mul` at the translate `g (· + s)`. -/
-private theorem analyticAt_taylor_decomp {g : ℂ → ℂ} {s : ℂ}
-    (hg : AnalyticAt ℂ g s) (k : ℕ) :
+private theorem analyticAt_taylor_decomp {g : ℂ → ℂ} {s : ℂ} (hg : AnalyticAt ℂ g s) (k : ℕ) :
     ∃ (c : Fin k → ℂ) (R : ℂ → ℂ), AnalyticAt ℂ R s ∧
       ∀ᶠ z in 𝓝 s, g z = (∑ j : Fin k, c j * (z - s) ^ j.val) + (z - s) ^ k * R z := by
   have h1 : AnalyticAt ℂ (fun w : ℂ => w + s) 0 := analyticAt_id.add analyticAt_const
@@ -197,8 +195,7 @@ private theorem reindex_sum_fin_neg {k : ℕ} (c : Fin k → ℂ) (w : ℂ) :
 /-- Laurent data of length exactly `k` from a `(z - s)^(-k)`-factorisation with analytic
 cofactor: Taylor-expand the cofactor to order `k` and divide. -/
 private theorem laurent_data_of_zpow_factor {f g₀ : ℂ → ℂ} {s : ℂ} (k : ℕ)
-    (hg₀_an : AnalyticAt ℂ g₀ s)
-    (hg₀_eq : ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(k : ℤ)) • g₀ z) :
+    (hg₀_an : AnalyticAt ℂ g₀ s) (hg₀_eq : ∀ᶠ z in 𝓝[≠] s, f z = (z - s) ^ (-(k : ℤ)) • g₀ z) :
     ∃ (a : Fin k → ℂ) (g : ℂ → ℂ),
       AnalyticAt ℂ g s ∧
       ∀ᶠ z in 𝓝[≠] s, f z = g z + ∑ i : Fin k, a i / (z - s) ^ (i.val + 1) := by
@@ -260,8 +257,7 @@ theorem eventuallyEq_meromorphicAnalyticPartAt_add_meromorphicPolarPartAt {f : �
 
 /-- The polar part as its explicit Laurent sum — the characteristic unfolding of
 `meromorphicPolarPartAt`. -/
-theorem meromorphicPolarPartAt_eq_sum {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) (z : ℂ) :
+theorem meromorphicPolarPartAt_eq_sum {f : ℂ → ℂ} {s : ℂ} (hMero : MeromorphicAt f s) (z : ℂ) :
     meromorphicPolarPartAt hMero z =
       ∑ k : Fin (meromorphicPolarOrderAt f s),
         meromorphicPolarCoeffAt hMero k / (z - s) ^ (k.val + 1) := by
@@ -298,8 +294,7 @@ canonical polar data. Internally the coefficients are total functions `ℕ → �
 /-- The top coefficient of a finite principal part that agrees with a function continuous at
 `s` vanishes. -/
 private theorem coeff_top_eq_zero_of_eventuallyEq {s : ℂ} {N : ℕ} {c : ℕ → ℂ}
-    {g : ℂ → ℂ} (hg : ContinuousAt g s)
-    (h_eq : ∀ᶠ z in 𝓝[≠] s,
+    {g : ℂ → ℂ} (hg : ContinuousAt g s) (h_eq : ∀ᶠ z in 𝓝[≠] s,
       ∑ k ∈ Finset.range (N + 1), c k / (z - s) ^ (k + 1) = g z) :
     c N = 0 := by
   have h_mul : ∀ᶠ z in 𝓝[≠] s,
@@ -339,8 +334,7 @@ private theorem coeff_top_eq_zero_of_eventuallyEq {s : ℂ} {N : ℕ} {c : ℕ �
 
 /-- A finite principal part agreeing with a function continuous at `s` is zero: all its
 coefficients vanish. -/
-private theorem laurent_coeff_eq_zero_of_eventuallyEq {s : ℂ} {g : ℂ → ℂ}
-    (hg : ContinuousAt g s) :
+private theorem laurent_coeff_eq_zero_of_eventuallyEq {s : ℂ} {g : ℂ → ℂ} (hg : ContinuousAt g s) :
     ∀ {N : ℕ} {c : ℕ → ℂ},
       (∀ᶠ z in 𝓝[≠] s, ∑ k ∈ Finset.range N, c k / (z - s) ^ (k + 1) = g z) →
       ∀ k < N, c k = 0 := by
@@ -380,8 +374,7 @@ private theorem sum_fin_div_pow_eq_sum_range {s : ℂ} {N L : ℕ} (hNL : N ≤ 
 near `s` with remainders continuous at `s` have the same coefficients, compared through
 their zero-paddings. -/
 theorem laurent_coeff_unique {s : ℂ} {N M : ℕ} {a : Fin N → ℂ} {b : Fin M → ℂ}
-    {g h : ℂ → ℂ} (hg : ContinuousAt g s) (hh : ContinuousAt h s)
-    (h_eq : ∀ᶠ z in 𝓝[≠] s,
+    {g h : ℂ → ℂ} (hg : ContinuousAt g s) (hh : ContinuousAt h s) (h_eq : ∀ᶠ z in 𝓝[≠] s,
       g z + ∑ k : Fin N, a k / (z - s) ^ (k.val + 1)
         = h z + ∑ k : Fin M, b k / (z - s) ^ (k.val + 1)) (k : ℕ) :
     (if hk : k < N then a ⟨k, hk⟩ else 0) = (if hk : k < M then b ⟨k, hk⟩ else 0) := by
@@ -409,8 +402,7 @@ coefficient through zero-padding, with the canonical polar data. This is what tr
 sector condition (B)'s resonance constraints from its own Laurent witness to
 `meromorphicPolarCoeffAt`. -/
 theorem laurent_coeff_eq_meromorphicPolarCoeffAt {f : ℂ → ℂ} {s : ℂ}
-    (hMero : MeromorphicAt f s) {N : ℕ} {a : Fin N → ℂ} {g : ℂ → ℂ}
-    (hg : ContinuousAt g s)
+    (hMero : MeromorphicAt f s) {N : ℕ} {a : Fin N → ℂ} {g : ℂ → ℂ} (hg : ContinuousAt g s)
     (h_eq : ∀ᶠ z in 𝓝[≠] s, f z = g z + ∑ k : Fin N, a k / (z - s) ^ (k.val + 1)) (k : ℕ) :
     (if hk : k < N then a ⟨k, hk⟩ else 0)
       = (if hk : k < meromorphicPolarOrderAt f s then

--- a/TauCeti/Analysis/Contour/ModelSector/Closed.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Closed.lean
@@ -145,8 +145,7 @@ Hungerbühler–Wasem model sector of *interior angle* `α` only for `0 < α < 2
 radii coincide, and at `α ≥ 2π` the arc wraps — `α = 4π` traverses the circle twice, giving winding
 `2`. At both ends the formula stands; it is the corner reading that lapses. -/
 @[simp]
-theorem windingNumber_closedModelSector
-    {z₀ : ℂ} {r : ℝ} (hr : 0 < r) (φ : ℝ) {α : ℝ} (hα : 0 ≤ α) :
+theorem windingNumber_closedModelSector {z₀ : ℂ} {r : ℝ} (hr : 0 < r) (φ : ℝ) {α : ℝ} (hα : 0 ≤ α) :
     windingNumber (modelSector z₀ r φ α) (-r) (r + α) z₀ = (α : ℂ) / (2 * (Real.pi : ℂ)) := by
   have hrne : r ≠ 0 := ne_of_gt hr
   have hcorner := modelSector_eqOn_corner z₀ hr.le φ α

--- a/TauCeti/Analysis/Contour/ModelSector/Corner.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Corner.lean
@@ -108,8 +108,7 @@ theorem deriv_twoRayCorner_of_ne {z₀ u v : ℂ} {t : ℝ} (ht : t ≠ 0) :
 
 /-- **The index integrand along a two-ray corner is `1 / t`,** on both rays: the direction cancels
 against itself, leaving the same real function on either side of the corner. -/
-private theorem integrand_twoRayCorner {z₀ u v : ℂ} (hu : u ≠ 0) (hv : v ≠ 0) {t : ℝ}
-    (ht : t ≠ 0) :
+private theorem integrand_twoRayCorner {z₀ u v : ℂ} (hu : u ≠ 0) (hv : v ≠ 0) {t : ℝ} (ht : t ≠ 0) :
     (twoRayCorner z₀ u v t - z₀)⁻¹ * deriv (twoRayCorner z₀ u v) t = ((t : ℂ))⁻¹ := by
   have htC : (t : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr ht
   rw [deriv_twoRayCorner_of_ne (z₀ := z₀) (u := u) (v := v) ht]

--- a/TauCeti/Analysis/Contour/ModelSector/Winding.lean
+++ b/TauCeti/Analysis/Contour/ModelSector/Winding.lean
@@ -52,8 +52,7 @@ semicircle (`[0, π]`) specialization of `indexIntegral_arc` (`π / 2π = ½`): 
 *smooth* boundary point of the fundamental domain, so the valence contour indents around it by a
 **semicircle** (opening angle `α = π`). The statement is the generic arc computation; the point `i`
 names its downstream valence-formula role. -/
-theorem windingNumber_at_i {z₀ : ℂ} {r : ℝ} (hr : r ≠ 0) :
-    (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
+theorem windingNumber_at_i {z₀ : ℂ} {r : ℝ} (hr : r ≠ 0) : (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
         ∫ θ in (0 : ℝ)..Real.pi, deriv (circleMap z₀ r) θ / (circleMap z₀ r θ - z₀)
       = 1 / 2 := by
   have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero
@@ -65,8 +64,7 @@ theorem windingNumber_at_i {z₀ : ℂ} {r : ℝ} (hr : r ≠ 0) :
 of the fundamental domain, so the contour indents around it by a `π/3` arc, and the two such corners
 (`ρ` and `ρ+1`) each contribute `1/6`, summing to the `1/3` coefficient of `ord_ρ(f)`. The statement
 is the generic arc computation; the point `ρ` names its downstream valence-formula role. -/
-theorem windingNumber_at_rho {z₀ : ℂ} {r : ℝ} (hr : r ≠ 0) :
-    (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
+theorem windingNumber_at_rho {z₀ : ℂ} {r : ℝ} (hr : r ≠ 0) : (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
         ∫ θ in (0 : ℝ)..(Real.pi / 3), deriv (circleMap z₀ r) θ / (circleMap z₀ r θ - z₀)
       = 1 / 6 := by
   have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero

--- a/TauCeti/Analysis/Contour/NullHomologous.lean
+++ b/TauCeti/Analysis/Contour/NullHomologous.lean
@@ -141,8 +141,7 @@ theorem IsNullHomologous.union_right (h : IsNullHomologous γ a b Ω') :
 
 /-- If a curve is null-homologous in each of two domains, it is null-homologous in their
 intersection. -/
-theorem IsNullHomologous.inter (hΩ : IsNullHomologous γ a b Ω)
-    (hΩ' : IsNullHomologous γ a b Ω') :
+theorem IsNullHomologous.inter (hΩ : IsNullHomologous γ a b Ω) (hΩ' : IsNullHomologous γ a b Ω') :
     IsNullHomologous γ a b (Ω ∩ Ω') := by
   rw [isNullHomologous_iff] at hΩ hΩ' ⊢
   intro w hw

--- a/TauCeti/Analysis/Contour/PerWindow/CPV.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/CPV.lean
@@ -110,8 +110,7 @@ theorem intervalIntegrable_inv_sub_truncated {γ : ℝ → ℂ} {s : ℂ} {a b :
 with the chord quotients anchored at the left endpoint in the slit plane: the `Icc`-hypothesis
 form of `integral_inv_sub_mul_deriv_eq_log`, with the integrability discharged. -/
 private theorem integral_inv_sub_mul_deriv_eq_log_window {γ : ℝ → ℂ} {s : ℂ} {P : Set ℝ}
-    {l u : ℝ} (hlu : l ≤ u) (hP : P.Countable)
-    (hγ_cont : ContinuousOn γ (Icc l u))
+    {l u : ℝ} (hlu : l ≤ u) (hP : P.Countable) (hγ_cont : ContinuousOn γ (Icc l u))
     (hγ_diffP : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume l u)
     (h_ne : ∀ t ∈ Icc l u, γ t ≠ s)
@@ -215,20 +214,15 @@ the anchored slit-plane chord quotients on each side, and the window-split ident
 `ε`-truncated simple-pole integrand, the truncated window integral equals the log-norm difference
 of the window endpoints plus the two boundary chord arguments times `I`. -/
 private theorem perWindow_truncated_integral_eq_log_form {γ : ℝ → ℂ} {s : ℂ} {t₀ r ε : ℝ}
-    {P : Set ℝ} {τl τr : ℝ} (hP : P.Countable)
-    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
+    {P : Set ℝ} {τl τr : ℝ} (hP : P.Countable) (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
     (hγ_diffP : ∀ t ∈ Ioo (t₀ - r) (t₀ + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume
-      (t₀ - r) (t₀ + r))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t₀ - r) (t₀ + r))
     (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀)
-    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r →
-      (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
-    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ →
-      (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
+    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
+    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ → (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
     (hτL : τl ∈ Ioo (t₀ - r) t₀) (hτR : τr ∈ Ioo t₀ (t₀ + r))
     (hradL : ‖γ τl - s‖ = ε) (hradR : ‖γ τr - s‖ = ε) (hε : 0 < ε)
-    (hsplit : ∫ u in (t₀ - r)..(t₀ + r),
-        (if ‖γ u - s‖ > ε then (γ u - s)⁻¹ * deriv γ u else 0) =
+    (hsplit : ∫ u in (t₀ - r)..(t₀ + r), (if ‖γ u - s‖ > ε then (γ u - s)⁻¹ * deriv γ u else 0) =
       (∫ u in (t₀ - r)..τl, (γ u - s)⁻¹ * deriv γ u) +
       (∫ u in τr..(t₀ + r), (γ u - s)⁻¹ * deriv γ u)) :
     ∫ t in (t₀ - r)..(t₀ + r),
@@ -282,16 +276,12 @@ theorem perWindow_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {t₀ 
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
-    (h_diff_L : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t)
-    (hP : P.Countable)
+    (h_diff_L : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t) (hP : P.Countable)
     (hγ_diffP : ∀ t ∈ Ioo (t₀ - r) (t₀ + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume
-      (t₀ - r) (t₀ + r))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t₀ - r) (t₀ + r))
     (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀)
-    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r →
-      (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
-    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ →
-      (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
+    (h_slit_R : ∀ a b, t₀ < a → a ≤ b → b ≤ t₀ + r → (γ b - s) / (γ a - s) ∈ Complex.slitPlane)
+    (h_slit_L : ∀ b, t₀ - r ≤ b → b < t₀ → (γ b - s) / (γ (t₀ - r) - s) ∈ Complex.slitPlane)
     (h_slit_plus : (γ (t₀ + r) - s) / L_R ∈ Complex.slitPlane)
     (h_slit_minus : (-L_L) / (γ (t₀ - r) - s) ∈ Complex.slitPlane) :
     Tendsto (fun ε : ℝ => ∫ t in (t₀ - r)..(t₀ + r),

--- a/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
+++ b/TauCeti/Analysis/Contour/PerWindow/HigherOrder.lean
@@ -125,10 +125,8 @@ theorem intervalIntegrable_pow_inv_mul_deriv_truncated {γ : ℝ → ℂ} {s : �
 interval avoiding the pole: the integral is the boundary difference of the antiderivative
 `c · (-(k-1)⁻¹ (· - s)^{-(k-1)}) ∘ γ`. -/
 theorem integral_pow_inv_mul_deriv_eq_sub {γ : ℝ → ℂ} {s : ℂ} {k : ℕ} (hk : 2 ≤ k) (c : ℂ)
-    {l u : ℝ} (hlu : l ≤ u) {P : Set ℝ} (hP : P.Countable)
-    (h_ne : ∀ t ∈ Icc l u, γ t ≠ s)
-    (h_diff : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t)
-    (hγ_cont : ContinuousOn γ (Icc l u))
+    {l u : ℝ} (hlu : l ≤ u) {P : Set ℝ} (hP : P.Countable) (h_ne : ∀ t ∈ Icc l u, γ t ≠ s)
+    (h_diff : ∀ t ∈ Ioo l u \ P, DifferentiableAt ℝ γ t) (hγ_cont : ContinuousOn γ (Icc l u))
     (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume l u) :
     ∫ t in l..u, c / (γ t - s) ^ k * deriv γ t =
       c * (-(↑(k - 1) : ℂ)⁻¹ * ((γ u - s) ^ (k - 1))⁻¹) -
@@ -188,8 +186,7 @@ private lemma integral_pow_inv_mul_deriv_eq_sub_of_subinterval {γ : ℝ → ℂ
     {k : ℕ} (hk : 2 ≤ k) (c : ℂ) {P : Set ℝ} (hP : P.Countable)
     (hγ_cont : ContinuousOn γ (Icc (t_i - r) (t_i + r)))
     (hγ_diffP : ∀ t ∈ Ioo (t_i - r) (t_i + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume
-      (t_i - r) (t_i + r))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t_i - r) (t_i + r))
     (h_unique : ∀ t ∈ Icc (t_i - r) (t_i + r), γ t = s → t = t_i)
     {l u : ℝ} (hlu : l ≤ u) (hl : t_i - r ≤ l) (hu : u ≤ t_i + r) (h_excl : t_i ∉ Icc l u) :
     ∫ t in l..u, c / (γ t - s) ^ k * deriv γ t =
@@ -210,20 +207,16 @@ unique crossing on the window, the `ε`-truncated window integral of the order-`
 `c / (z - s)^k` converges as `ε → 0⁺` to the boundary difference of its antiderivative. -/
 theorem perWindow_higherOrder_truncated_integral_tendsto {γ : ℝ → ℂ} {s : ℂ} {t_i r : ℝ}
     {L_R L_L : ℂ} {n k : ℕ} {P : Set ℝ} (hr_pos : 0 < r) (h_at : γ t_i = s)
-    (hγ_cont : ContinuousOn γ (Icc (t_i - r) (t_i + r)))
-    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (hγ_cont : ContinuousOn γ (Icc (t_i - r) (t_i + r))) (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t_i) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t_i) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t_i, DifferentiableAt ℝ γ t)
-    (h_diff_L : ∀ᶠ t in 𝓝[<] t_i, DifferentiableAt ℝ γ t)
-    (hP : P.Countable)
+    (h_diff_L : ∀ᶠ t in 𝓝[<] t_i, DifferentiableAt ℝ γ t) (hP : P.Countable)
     (hγ_diffP : ∀ t ∈ Ioo (t_i - r) (t_i + r) \ P, DifferentiableAt ℝ γ t)
-    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume
-      (t_i - r) (t_i + r))
+    (hderiv_int : IntervalIntegrable (fun t => deriv γ t) MeasureTheory.volume (t_i - r) (t_i + r))
     (h_unique : ∀ t ∈ Icc (t_i - r) (t_i + r), γ t = s → t = t_i)
     (h_flat : FlatOfOrder γ t_i n) (hk : 2 ≤ k) (hkn : k ≤ n)
-    (h_B : (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1))
-    (c : ℂ) :
+    (h_B : (L_R / (‖L_R‖ : ℂ)) ^ (k - 1) = ((-L_L) / (‖L_L‖ : ℂ)) ^ (k - 1)) (c : ℂ) :
     Tendsto (fun ε : ℝ => ∫ t in (t_i - r)..(t_i + r),
         if ‖γ t - s‖ > ε then c / (γ t - s) ^ k * deriv γ t else 0)
       (𝓝[>] (0 : ℝ))

--- a/TauCeti/Analysis/Contour/PolarPart/CPV.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/CPV.lean
@@ -60,8 +60,7 @@ variable {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
 `coeff · cauchyPVAt` of the winding kernel, and every higher-order term carries zero around a
 closed curve. -/
 private theorem hasCauchyPVAt_polarPart_term (decomp : PolarPartDecomposition f S U) (s : S)
-    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
-    (hclosed : γ a = γ b)
+    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b) (hclosed : γ a = γ b)
     (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
     (h_flat : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
       ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))
@@ -94,8 +93,7 @@ principal value of `decomp.polarPart s` at `s` is `2πi · n_s(γ) · Res_s f`. 
 coefficients contribute nothing — this is the term the Hungerbühler–Wasem sum attributes to
 `s`. -/
 theorem hasCauchyPVAt_polarPart (decomp : PolarPartDecomposition f S U) (s : S)
-    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
-    (hclosed : γ a = γ b)
+    {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b) (hclosed : γ a = γ b)
     (h_interior : ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
     (h_flat : ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
       ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))

--- a/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
+++ b/TauCeti/Analysis/Contour/PolarPart/Decomposition.lean
@@ -126,8 +126,7 @@ extends differentiably to all of `U`. The homology Cauchy theorem applied to the
 theorem intervalIntegral_deriv_smul_analyticRemainder_eq_zero
     (decomp : PolarPartDecomposition f S U)
     (hU : IsOpen U) {γ : ℝ → ℂ} {a b : ℝ} (hγ_pc1 : IsPiecewiseC1On γ a b)
-    (hγ : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
-    (hnull : IsNullHomologous γ a b U) :
+    (hγ : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b) (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • decomp.analyticRemainder (γ t) = 0 :=
   homologyCauchyTheorem hU γ a b hγ_pc1 hγ hclosed decomp.analyticRemainder_differentiableOn hnull
 

--- a/TauCeti/Analysis/Contour/RegularityConditions.lean
+++ b/TauCeti/Analysis/Contour/RegularityConditions.lean
@@ -204,8 +204,7 @@ normalization, so no `ℝ`-valued form is available without pinning a branch. -/
 theorem coe_crossingAngle_eq_arg_neg_div_add_arg_div_sub_arg_div {γ : ℝ → ℂ} {t₀ : ℝ}
     {L_R L_L w_L w_R : ℂ} (hL_L : L_L ≠ 0) (hL_R : L_R ≠ 0) (hw_L : w_L ≠ 0) (hw_R : w_R ≠ 0)
     (h_R : Filter.Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
-    (h_L : Filter.Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) :
-    (crossingAngle γ t₀ : Real.Angle)
+    (h_L : Filter.Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L)) : (crossingAngle γ t₀ : Real.Angle)
       = ((((-L_L) / w_L).arg : ℝ) : Real.Angle) + (((w_R / L_R).arg : ℝ) : Real.Angle)
         - (((w_R / w_L).arg : ℝ) : Real.Angle) := by
   rw [crossingAngle_eq_of_tendsto h_R h_L, Real.Angle.coe_toIcoMod,
@@ -495,8 +494,7 @@ one-sided derivative limits at `t₀` are `L_R` and `L_L`, both non-zero, then t
 of the unit tangent directions agree — the raw sector equation the higher-order
 principal-value theorems consume. -/
 theorem pow_unit_tangent_eq_of_resonance {γ : ℝ → ℂ} {t₀ : ℝ} {L_R L_L : ℂ} {k : ℕ}
-    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
-    (h_R : Filter.Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
+    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0) (h_R : Filter.Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_L : Filter.Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_res : ∃ m : ℤ, (k : ℝ) * crossingAngle γ t₀ = (m : ℝ) * (2 * Real.pi)) :
     (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by
@@ -509,8 +507,7 @@ theorem pow_unit_tangent_eq_of_resonance {γ : ℝ → ℂ} {t₀ : ℝ} {L_R L_
 `pow_unit_tangent_eq_of_resonance`, with the outgoing tangent limit at `a` and the incoming
 tangent limit at `b` — the raw sector equation at the basepoint of a closed curve. -/
 theorem pow_unit_tangent_eq_of_basepoint_resonance {γ : ℝ → ℂ} {a b : ℝ} {L_R L_L : ℂ}
-    {k : ℕ} (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
-    (h_R : Filter.Tendsto (deriv γ) (𝓝[>] a) (𝓝 L_R))
+    {k : ℕ} (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0) (h_R : Filter.Tendsto (deriv γ) (𝓝[>] a) (𝓝 L_R))
     (h_L : Filter.Tendsto (deriv γ) (𝓝[<] b) (𝓝 L_L))
     (h_res : ∃ m : ℤ, (k : ℝ) * basepointAngle γ a b = (m : ℝ) * (2 * Real.pi)) :
     (L_R / (‖L_R‖ : ℂ)) ^ k = ((-L_L) / (‖L_L‖ : ℂ)) ^ k := by

--- a/TauCeti/Analysis/Contour/Residue/Assembly.lean
+++ b/TauCeti/Analysis/Contour/Residue/Assembly.lean
@@ -57,8 +57,7 @@ gated-flat and gated-sector-compatible, the set-level principal value of `f` is
 theorem hasCauchyPV_residue_sum {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     (decomp : PolarPartDecomposition f S U) (hU : IsOpen U)
     {γ : ℝ → ℂ} {a b : ℝ} (h_imm : IsPwC1ImmersionOn γ a b) (hab : a ≤ b)
-    (hclosed : γ a = γ b) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U)
-    (hnull : IsNullHomologous γ a b U)
+    (hclosed : γ a = γ b) (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hnull : IsNullHomologous γ a b U)
     (h_interior : ∀ s : S, ∀ t ∈ Icc a b, γ t = (s : ℂ) → t ∈ Ioo a b)
     (h_flat : ∀ s : S, ∀ k : Fin (decomp.order s), 1 ≤ k.val → decomp.coeff s k ≠ 0 →
       ∀ t ∈ Icc a b, γ t = (s : ℂ) → FlatOfOrder γ t (k.val + 1))

--- a/TauCeti/Analysis/Contour/Residue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Residue/Basic.lean
@@ -279,8 +279,7 @@ drops the hypothesis `g z₀ ≠ 0`, so the presentation exponent `n` need not b
 of `f`: `g` may vanish at `z₀`, raising the true pole order above `n`; only when `g`'s vanishing
 order is at least `-n` is `f` analytic (residue `0`). -/
 theorem residue_eq_of_eventuallyEq_zpow_smul {f g : ℂ → ℂ} {z₀ : ℂ} {n : ℤ}
-    (hn : n ≤ -1) (hg : AnalyticAt ℂ g z₀)
-    (hfg : f =ᶠ[𝓝[≠] z₀] fun z => (z - z₀) ^ n • g z) :
+    (hn : n ≤ -1) (hg : AnalyticAt ℂ g z₀) (hfg : f =ᶠ[𝓝[≠] z₀] fun z => (z - z₀) ^ n • g z) :
     residue f z₀ = iteratedDeriv (-1 - n).toNat g z₀ / ((-1 - n).toNat.factorial : ℂ) := by
   have hf : MeromorphicAt f z₀ :=
     MeromorphicAt.iff_eventuallyEq_zpow_smul_analyticAt.mpr ⟨n, g, hg, hfg⟩

--- a/TauCeti/Analysis/Contour/Residue/Cycle.lean
+++ b/TauCeti/Analysis/Contour/Residue/Cycle.lean
@@ -202,8 +202,7 @@ genuinely a Layer 3 statement; the round-circle case with the poles inside is
 Hungerbühler–Wasem theorem `Contour.hungerbuhlerWasem_residueTheorem`. -/
 theorem classicalResidueTheorem_nullHomologous {f : ℂ → ℂ} {S : Finset ℂ} {U : Set ℂ}
     (hU : IsOpen U) (hf : DifferentiableOn ℂ f (U \ (↑S : Set ℂ)))
-    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s) {γ : ℝ → ℂ} {a b : ℝ}
-    (hγ : IsPiecewiseC1On γ a b)
+    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s) {γ : ℝ → ℂ} {a b : ℝ} (hγ : IsPiecewiseC1On γ a b)
     (hγU : ∀ t ∈ uIcc a b, γ t ∈ U) (hclosed : γ a = γ b)
     (hoff : ∀ t ∈ uIcc a b, γ t ∉ (↑S : Set ℂ)) (hnull : IsNullHomologous γ a b U) :
     ∫ t in a..b, deriv γ t • f (γ t)

--- a/TauCeti/Analysis/Contour/Residue/Theorem.lean
+++ b/TauCeti/Analysis/Contour/Residue/Theorem.lean
@@ -78,8 +78,7 @@ private theorem meromorphicOrderAt_sub_leadingTerm_gt {g : ℂ → ℂ} {s : ℂ
 disc and `n < 0`, `∮_{C(c,R)} a·(· − s₀) ^ n = 2πi · residue (a·(· − s₀) ^ n) s₀` (the integral is
 `2πi·a` for a simple pole `n = −1` and `0` otherwise). -/
 private lemma circleIntegral_const_mul_zpow_sub {c s₀ : ℂ} {R : ℝ} {n : ℤ} (a : ℂ)
-    (hs₀ : s₀ ∈ ball c R) (hn : n < 0) :
-    (∮ z in C(c, R), a * (z - s₀) ^ n)
+    (hs₀ : s₀ ∈ ball c R) (hn : n < 0) : (∮ z in C(c, R), a * (z - s₀) ^ n)
       = 2 * ↑Real.pi * Complex.I * residue (fun z => a * (z - s₀) ^ n) s₀ := by
   -- Residue of the pure monomial: the Taylor coefficient of the constant `1` at index `−1 − n`.
   have hresQ : residue (fun z => (z - s₀) ^ n) s₀
@@ -330,8 +329,7 @@ closed disc `C(c, R)` (`R > 0`) and every point of nonzero meromorphic order lie
 non-poles vanish, `classicalResidueTheorem_circle_of_meromorphicOrderAt_neg` proves the same
 conclusion asking only the poles (points of negative order) to lie in `S`. -/
 theorem classicalResidueTheorem_circle {f : ℂ → ℂ} {c : ℂ} {R : ℝ} (hR : 0 < R) (S : Finset ℂ)
-    (hf : MeromorphicOn f (Metric.closedBall c R))
-    (hS : (S : Set ℂ) ⊆ Metric.ball c R)
+    (hf : MeromorphicOn f (Metric.closedBall c R)) (hS : (S : Set ℂ) ⊆ Metric.ball c R)
     (hsupp : ∀ z ∈ Metric.closedBall c R, meromorphicOrderAt f z ≠ 0 → z ∈ S) :
     circleIntegral f c R = 2 * (Real.pi : ℂ) * Complex.I * (∑ s ∈ S, residue f s) :=
   classicalResidueTheorem_circle_of_meromorphicOrderAt_neg hR S hf hS

--- a/TauCeti/Analysis/Contour/SectorCancellation.lean
+++ b/TauCeti/Analysis/Contour/SectorCancellation.lean
@@ -55,8 +55,7 @@ under the power identity `(L₊ / ‖L₊‖)^(k-1) = (-L₋ / ‖L₋‖)^(k-1)
 Hungerbühler–Wasem. When the curve is `C¹` at the crossing (`L₋ = L₊`), condition (B) holds
 automatically for `k` odd, since `(-1)^(k-1) = 1`. -/
 theorem smul_pow_eq_of_div_norm_pow_eq (L_minus L_plus : ℂ) (k : ℕ)
-    (h_B : (L_plus / (‖L_plus‖ : ℂ)) ^ (k - 1) =
-      ((-L_minus) / (‖L_minus‖ : ℂ)) ^ (k - 1)) (ε : ℝ) :
+    (h_B : (L_plus / (‖L_plus‖ : ℂ)) ^ (k - 1) = ((-L_minus) / (‖L_minus‖ : ℂ)) ^ (k - 1)) (ε : ℝ) :
     (((ε / ‖L_plus‖ : ℝ) • L_plus : ℂ)) ^ (k - 1) =
     (((ε / ‖L_minus‖ : ℝ) • (-L_minus) : ℂ)) ^ (k - 1) := by
   have h_smul : ∀ (r : ℝ) (v : ℂ), ((ε / r : ℝ) • v : ℂ) = (ε : ℂ) * (v / (r : ℂ)) := by
@@ -73,15 +72,12 @@ reaching radius `ε` on each side: the difference of `F(z) = -1/((k-1)(z-s)^(k-1
 curve between the two exits tends to `0` as `ε → 0⁺` (`2 ≤ k ≤ n`). This is the cancellation
 half of the Hungerbühler–Wasem principal-value mechanism at a condition-(B) crossing. -/
 theorem antiderivative_diff_across_crossing_tendsto_zero
-    {γ : ℝ → ℂ} {t₀ : ℝ} {s L_minus L_plus : ℂ} {n k : ℕ}
-    (h_flat : FlatOfOrder γ t₀ n)
+    {γ : ℝ → ℂ} {t₀ : ℝ} {s L_minus L_plus : ℂ} {n k : ℕ} (h_flat : FlatOfOrder γ t₀ n)
     (hL_minus : L_minus ≠ 0) (hL_plus : L_plus ≠ 0)
     (h_deriv_right : HasDerivWithinAt γ L_plus (Ioi t₀) t₀)
     (h_deriv_left : HasDerivWithinAt γ L_minus (Iio t₀) t₀)
-    (h_s : γ t₀ = s) (hk : 2 ≤ k) (hkn : k ≤ n)
-    (h_B : (L_plus / (‖L_plus‖ : ℂ)) ^ (k - 1) =
-      ((-L_minus) / (‖L_minus‖ : ℂ)) ^ (k - 1))
-    {t_eps_plus t_eps_minus : ℝ → ℝ}
+    (h_s : γ t₀ = s) (hk : 2 ≤ k) (hkn : k ≤ n) (h_B : (L_plus / (‖L_plus‖ : ℂ)) ^ (k - 1) =
+      ((-L_minus) / (‖L_minus‖ : ℂ)) ^ (k - 1)) {t_eps_plus t_eps_minus : ℝ → ℝ}
     (h_plus_to : Tendsto t_eps_plus (𝓝[>] (0 : ℝ)) (𝓝[>] t₀))
     (h_plus_radius : ∀ᶠ ε in 𝓝[>] (0 : ℝ), ‖γ (t_eps_plus ε) - s‖ = ε)
     (h_minus_to : Tendsto t_eps_minus (𝓝[>] (0 : ℝ)) (𝓝[<] t₀))

--- a/TauCeti/Analysis/Contour/TangentForcing.lean
+++ b/TauCeti/Analysis/Contour/TangentForcing.lean
@@ -89,8 +89,7 @@ private theorem abs_im_mul_conj_div_mul_le_of_sub_smul {γ : ℝ → ℂ} {t₀ 
 `|Im(L * conj v)| / ‖v‖` is bounded by the given positive `ε`. (The zero-forcing conclusion
 `Im(L · conj v) = 0` is drawn by the caller `im_mul_conj_eq_zero_of_flat_right`.) -/
 private theorem abs_im_mul_conj_div_le_of_isLittleO {γ : ℝ → ℂ} {t₀ : ℝ} {v L : ℂ} {n : ℕ}
-    (hv : v ≠ 0) (hn : 1 ≤ n)
-    (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[>] t₀]
+    (hv : v ≠ 0) (hn : 1 ≤ n) (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[>] t₀]
       fun t => ‖γ t - γ t₀‖ ^ n)
     (h_deriv : HasDerivWithinAt γ L (Ioi t₀) t₀) {ε : ℝ} (hε : 0 < ε) :
     |(L * starRingEnd ℂ v).im| / ‖v‖ ≤ ε := by
@@ -127,8 +126,7 @@ private theorem abs_im_mul_conj_div_le_of_isLittleO {γ : ℝ → ℂ} {t₀ : �
 together with a right derivative `L`, forces `Im(L · conj v) = 0` — the flatness direction and
 the tangent are colinear. -/
 private theorem im_mul_conj_eq_zero_of_flat_right {γ : ℝ → ℂ} {t₀ : ℝ} {v L : ℂ} {n : ℕ}
-    (hv : v ≠ 0) (hn : 1 ≤ n)
-    (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[>] t₀]
+    (hv : v ≠ 0) (hn : 1 ≤ n) (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[>] t₀]
       fun t => ‖γ t - γ t₀‖ ^ n)
     (h_deriv : HasDerivWithinAt γ L (Ioi t₀) t₀) :
     (L * starRingEnd ℂ v).im = 0 := by
@@ -146,8 +144,7 @@ private theorem im_mul_conj_eq_zero_of_flat_right {γ : ℝ → ℂ} {t₀ : ℝ
 reflection `t ↦ 2t₀ - t`, which carries the left data of `γ` to right data of the reflected
 curve with tangent `-L` — and `Im((-L) · conj v) = 0` iff `Im(L · conj v) = 0`. -/
 private theorem im_mul_conj_eq_zero_of_flat_left {γ : ℝ → ℂ} {t₀ : ℝ} {v L : ℂ} {n : ℕ}
-    (hv : v ≠ 0) (hn : 1 ≤ n)
-    (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[<] t₀]
+    (hv : v ≠ 0) (hn : 1 ≤ n) (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[𝓝[<] t₀]
       fun t => ‖γ t - γ t₀‖ ^ n)
     (h_deriv : HasDerivWithinAt γ L (Iio t₀) t₀) :
     (L * starRingEnd ℂ v).im = 0 := by
@@ -184,8 +181,7 @@ private theorem im_mul_conj_eq_zero_of_flat_left {γ : ℝ → ℂ} {t₀ : ℝ}
 (`Im(L · conj v) = 0`, so `L ∈ ℝ • v`), the deviation bound against `v` becomes a deviation
 bound against `L` by line-invariance of the deviation norm. -/
 private theorem tangentDeviation_isLittleO_of_im_mul_conj_eq_zero {γ : ℝ → ℂ} {t₀ : ℝ}
-    {v L : ℂ} {n : ℕ} {l : Filter ℝ} (hv : v ≠ 0) (hL : L ≠ 0)
-    (h_im : (L * starRingEnd ℂ v).im = 0)
+    {v L : ℂ} {n : ℕ} {l : Filter ℝ} (hv : v ≠ 0) (hL : L ≠ 0) (h_im : (L * starRingEnd ℂ v).im = 0)
     (h_dev : (fun t => |((γ t - γ t₀) * star v).im| / ‖v‖) =o[l]
       fun t => ‖γ t - γ t₀‖ ^ n) :
     (fun t => ‖tangentDeviation (γ t - γ t₀) L‖) =o[l]

--- a/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/CrossingValue/Basic.lean
@@ -52,10 +52,8 @@ The hypotheses are precisely the normalized second-order position expansion and 
 velocity expansion. -/
 private theorem tendsto_realWindingIntegrand_mul_add {α : Type*} {l : Filter α}
     {τ : α → ℝ} {q r d : α → ℂ} {L A : ℂ} (hL : L ≠ 0)
-    (hq : Tendsto q l (𝓝 L)) (hr : Tendsto r l (𝓝 (A / 2)))
-    (hd : Tendsto d l (𝓝 A))
-    (hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i)
-    (hτ : ∀ᶠ i in l, τ i ≠ 0) :
+    (hq : Tendsto q l (𝓝 L)) (hr : Tendsto r l (𝓝 (A / 2))) (hd : Tendsto d l (𝓝 A))
+    (hqr : ∀ᶠ i in l, q i - L = ((τ i : ℝ) : ℂ) * r i) (hτ : ∀ᶠ i in l, τ i ≠ 0) :
     Tendsto (fun i ↦ realWindingIntegrand (((τ i : ℝ) : ℂ) * q i)
       (L + ((τ i : ℝ) : ℂ) * d i)) l
       (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by
@@ -108,12 +106,9 @@ matching first-order velocity expansion, implies
 The conclusion refers only to the coefficients in the assumed filter expansions. -/
 theorem tendsto_realWindingIntegrand_at_crossing {α : Type*} {l : Filter α}
     {t : α → ℝ} {t₀ : ℝ} {γ : ℝ → ℂ} {s L A : ℂ} (hL : L ≠ 0)
-    (htend : Tendsto t l (𝓝 t₀)) (hcross : γ t₀ = s)
-    (hpos₂ : Tendsto (fun i ↦
-      (((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ))) - L) /
-        (((t i - t₀ : ℝ) : ℂ))) l (𝓝 (A / 2)))
-    (hvel : Tendsto (fun i ↦ (deriv γ (t i) - L) /
-      (((t i - t₀ : ℝ) : ℂ))) l (𝓝 A))
+    (htend : Tendsto t l (𝓝 t₀)) (hcross : γ t₀ = s) (hpos₂ : Tendsto (fun i ↦
+      (((γ (t i) - s) / (((t i - t₀ : ℝ) : ℂ))) - L) / (((t i - t₀ : ℝ) : ℂ))) l (𝓝 (A / 2)))
+    (hvel : Tendsto (fun i ↦ (deriv γ (t i) - L) / (((t i - t₀ : ℝ) : ℂ))) l (𝓝 A))
     (ht : ∀ᶠ i in l, t i ≠ t₀) :
     Tendsto (fun i ↦ realWindingIntegrand (γ (t i) - s) (deriv γ (t i))) l
       (𝓝 ((L.re * A.im - L.im * A.re) / (2 * Complex.normSq L))) := by

--- a/TauCeti/Analysis/Contour/Winding/Integer.lean
+++ b/TauCeti/Analysis/Contour/Winding/Integer.lean
@@ -80,10 +80,8 @@ same continuity, differentiability-off-a-countable-set, avoidance, and interval-
 assumptions on `[a, b]`, the winding number of the closed curve `γ` about `w` is an integer. The
 general oriented-interval statement reduces to this case by orientation reversal. -/
 private theorem exists_int_windingNumber_of_closed_of_le {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
-    (hab : a ≤ b) (hclosed : γ a = γ b) (hP : P.Countable)
-    (hγ_cont : ContinuousOn γ (Icc a b))
-    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
-    (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w)
+    (hab : a ≤ b) (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (Icc a b))
+    (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t) (h_avoid : ∀ t ∈ Icc a b, γ t ≠ w)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∃ n : ℤ, windingNumber γ a b w = n := by
   -- The argument lift gives a monotone partition `s` and a polar form of `γ t - w` at each `t`.
@@ -133,8 +131,7 @@ differentiable off a countable set `P`, avoids `w` throughout `Set.uIcc a b`, an
 interval-integrable index integrand `(γ · - w)⁻¹ * deriv γ`, the generalized winding number
 `windingNumber γ a b w` is an integer. -/
 theorem exists_int_windingNumber_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
-    (hclosed : γ a = γ b) (hP : P.Countable)
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (Set.uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Affine.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Affine.lean
@@ -58,8 +58,7 @@ private lemma affine_apply_preimage (hc : c ≠ 0) (z d : ℂ) :
 `z ↦ c * z + d` to both the curve and the distinguished point transports the single-point Cauchy
 principal value of the winding kernel without changing its value. This is the composed
 translation/scaling form of `hasCauchyPVAt_inv_sub_const_mul`. -/
-theorem hasCauchyPVAt_inv_sub_affine
-    (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
+theorem hasCauchyPVAt_inv_sub_affine (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t + d) a b κ[c * z₀ + d] (c * z₀ + d) L := by
   refine ((hasCauchyPVAt_inv_sub_const_mul (c := c) h hc).translate d).congr_along_curve ?_
   intro t _ht
@@ -68,8 +67,7 @@ theorem hasCauchyPVAt_inv_sub_affine
 
 /-- Existence form of `hasCauchyPVAt_inv_sub_affine`: affine coordinate changes with nonzero
 linear coefficient preserve existence of the index principal value. -/
-theorem cauchyPVExistsAt_inv_sub_affine
-    (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+theorem cauchyPVExistsAt_inv_sub_affine (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
     CauchyPVExistsAt (fun t => c * γ t + d) a b κ[c * z₀ + d] (c * z₀ + d) :=
   let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
   CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_affine (d := d) hL hc)
@@ -108,8 +106,7 @@ theorem IsNullHomologous.affine (h : IsNullHomologous γ a b Ω) (hc : c ≠ 0) 
 /-- If the affine image of a curve is null-homologous in the affine image of a set, then the
 original curve is null-homologous in the original set. -/
 theorem IsNullHomologous.of_affine
-    (h : IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω))
-    (hc : c ≠ 0) :
+    (h : IsNullHomologous (fun t => c * γ t + d) a b ((fun z => c * z + d) '' Ω)) (hc : c ≠ 0) :
     IsNullHomologous γ a b Ω := by
   rw [isNullHomologous_iff] at h ⊢
   intro z hz

--- a/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Basic.lean
@@ -168,8 +168,7 @@ theorem intervalIntegrable_inv_sub_mul_deriv {γ : ℝ → ℂ} {w : ℂ} {a b :
 interval-integrable, the generalized winding number is the ordinary index integral: the principal
 value collapses to `(2πi)⁻¹ · ∮_γ dz/(z − z₀)`. -/
 theorem windingNumber_eq_integral_of_avoidance {γ : ℝ → ℂ} {a b : ℝ} {z₀ : ℂ}
-    (h_cont : ContinuousOn γ (Set.uIcc a b))
-    (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
+    (h_cont : ContinuousOn γ (Set.uIcc a b)) (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ z₀)
     (hf_int : IntervalIntegrable (fun t => (γ t - z₀)⁻¹ * deriv γ t) MeasureTheory.volume a b) :
     windingNumber γ a b z₀
       = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, (γ t - z₀)⁻¹ * deriv γ t :=

--- a/TauCeti/Analysis/Contour/Winding/Number/Circle.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Circle.lean
@@ -134,8 +134,7 @@ alias windingNumber_modelSector := indexIntegral_arc
 `[0, 2π]` specialization of `indexIntegral_arc` (`2π / 2π = 1`). Its value also follows from
 Mathlib's `circleIntegral.integral_sub_center_inv`; this is the raw-index-integral form of that
 normalization used as a Layer-1 target. -/
-theorem windingNumber_circle {c : ℂ} {r : ℝ} (hr : r ≠ 0) :
-    (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
+theorem windingNumber_circle {c : ℂ} {r : ℝ} (hr : r ≠ 0) : (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
         ∫ θ in (0 : ℝ)..(2 * Real.pi), deriv (circleMap c r) θ / (circleMap c r θ - c)
       = 1 := by
   have hpi : (Real.pi : ℂ) ≠ 0 := Complex.ofReal_ne_zero.mpr Real.pi_ne_zero

--- a/TauCeti/Analysis/Contour/Winding/Number/Concat.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Concat.lean
@@ -57,8 +57,7 @@ local notation "κ[" z "]" => (fun w : ℂ => (w - z)⁻¹)
 /-- **Additivity of the generalized winding number from explicit principal-value witnesses.**
 If the index-integrand principal values about `z₀` on `[a, b]` and `[b, c]` are `L₁` and `L₂`,
 then the winding number over `[a, c]` is the sum of the two winding numbers. -/
-theorem windingNumber_eq_add_of_hasCauchyPVAt {L₁ L₂ : ℂ}
-    (h_ab : HasCauchyPVAt γ a b κ[z₀] z₀ L₁)
+theorem windingNumber_eq_add_of_hasCauchyPVAt {L₁ L₂ : ℂ} (h_ab : HasCauchyPVAt γ a b κ[z₀] z₀ L₁)
     (h_bc : HasCauchyPVAt γ b c κ[z₀] z₀ L₂) :
     windingNumber γ a c z₀ = windingNumber γ a b z₀ + windingNumber γ b c z₀ := by
   rw [windingNumber_eq_of_hasCauchyPVAt (h_ab.concat h_bc),
@@ -68,8 +67,7 @@ theorem windingNumber_eq_add_of_hasCauchyPVAt {L₁ L₂ : ℂ}
 /-- **Additivity of the generalized winding number over adjacent intervals.** It is enough to know
 that the principal values defining the two summand winding numbers exist; the principal value on
 the concatenated interval is then supplied by `HasCauchyPVAt.concat`. -/
-theorem windingNumber_concat
-    (h_ab : CauchyPVExistsAt γ a b κ[z₀] z₀)
+theorem windingNumber_concat (h_ab : CauchyPVExistsAt γ a b κ[z₀] z₀)
     (h_bc : CauchyPVExistsAt γ b c κ[z₀] z₀) :
     windingNumber γ a c z₀ = windingNumber γ a b z₀ + windingNumber γ b c z₀ := by
   exact windingNumber_eq_add_of_hasCauchyPVAt
@@ -78,10 +76,8 @@ theorem windingNumber_concat
 /-- If the winding numbers about `z₀` vanish on two adjacent intervals, and the two corresponding
 principal values exist, then the winding number about `z₀` also vanishes on the concatenated
 interval. -/
-theorem windingNumber_eq_zero_concat
-    (h_ab : windingNumber γ a b z₀ = 0)
-    (h_bc : windingNumber γ b c z₀ = 0)
-    (hpv_ab : CauchyPVExistsAt γ a b κ[z₀] z₀)
+theorem windingNumber_eq_zero_concat (h_ab : windingNumber γ a b z₀ = 0)
+    (h_bc : windingNumber γ b c z₀ = 0) (hpv_ab : CauchyPVExistsAt γ a b κ[z₀] z₀)
     (hpv_bc : CauchyPVExistsAt γ b c κ[z₀] z₀) :
     windingNumber γ a c z₀ = 0 := by
   rw [windingNumber_concat hpv_ab hpv_bc, h_ab, h_bc, add_zero]
@@ -90,9 +86,7 @@ theorem windingNumber_eq_zero_concat
 pointwise principal values defining the exterior winding numbers exist on the two pieces. This is
 the form used by finite decomposition arguments: after proving the exterior winding numbers vanish
 piecewise, they vanish on the concatenation. -/
-theorem IsNullHomologous.concat
-    (h_ab : IsNullHomologous γ a b Ω)
-    (h_bc : IsNullHomologous γ b c Ω)
+theorem IsNullHomologous.concat (h_ab : IsNullHomologous γ a b Ω) (h_bc : IsNullHomologous γ b c Ω)
     (hpv_ab : ∀ z ∉ Ω, CauchyPVExistsAt γ a b κ[z] z)
     (hpv_bc : ∀ z ∉ Ω, CauchyPVExistsAt γ b c κ[z] z) :
     IsNullHomologous γ a c Ω := by
@@ -104,14 +98,10 @@ theorem IsNullHomologous.concat
 case. If both pieces of the curve lie in `Ω`, then every exterior point is avoided; under
 continuity and interval-integrability of the exterior index integrands, the needed principal values
 are supplied by `cauchyPVExistsAt_of_avoidance`. -/
-theorem IsNullHomologous.concat_of_avoidance
-    (h_ab : IsNullHomologous γ a b Ω)
-    (h_bc : IsNullHomologous γ b c Ω)
-    (hγ_ab : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
-    (hγ_bc : ∀ t ∈ Set.uIcc b c, γ t ∈ Ω)
-    (hcont_ab : ContinuousOn γ (Set.uIcc a b))
-    (hcont_bc : ContinuousOn γ (Set.uIcc b c))
-    (hint_ab : ∀ z ∉ Ω,
+theorem IsNullHomologous.concat_of_avoidance (h_ab : IsNullHomologous γ a b Ω)
+    (h_bc : IsNullHomologous γ b c Ω) (hγ_ab : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
+    (hγ_bc : ∀ t ∈ Set.uIcc b c, γ t ∈ Ω) (hcont_ab : ContinuousOn γ (Set.uIcc a b))
+    (hcont_bc : ContinuousOn γ (Set.uIcc b c)) (hint_ab : ∀ z ∉ Ω,
       IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b)
     (hint_bc : ∀ z ∉ Ω,
       IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume b c) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Homotopy.lean
@@ -92,11 +92,9 @@ theorem windingNumber_eq_two_pi_I_inv_mul_curveIntegral {x y w : ℂ} {p : Path 
 
 /-- If the extension of a path homotopy is `C²` on the unit square, then every intermediate
 path, extended constantly from the unit interval to `ℝ`, is piecewise `C¹` on `[0, 1]`. -/
-theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y}
-    (φ : p.Homotopy q)
+theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y} (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (s : I) :
     IsPiecewiseC1On (φ.eval s).extend 0 1 := by
   apply IsPiecewiseC1On.of_contDiffOn
@@ -113,11 +111,9 @@ theorem isPiecewiseC1On_eval_of_smoothPathHomotopy {x y : ℂ} {p q : Path x y}
 /-- **Homotopy invariance of the winding number off the curve.** Two closed paths joined through
 `ℂ \ {w}` by a path homotopy whose extension to the unit square is `C²` have the same winding number
 about `w`. -/
-theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x}
-    (φ : p.Homotopy q)
+theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x} (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (havoid : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ≠ w) :
     windingNumber p.extend 0 1 w = windingNumber q.extend 0 1 w := by
   have hrange : IsClosed (Set.range φ) :=
@@ -164,11 +160,9 @@ theorem windingNumber_eq_of_pathHomotopy {x w : ℂ} {p q : Path x x}
     hcurve']
 
 /-- Null-homology in `Ω` is invariant under a `C²` path homotopy whose image lies in `Ω`. -/
-theorem isNullHomologous_iff_of_pathHomotopy {x : ℂ} {p q : Path x x} {Ω : Set ℂ}
-    (φ : p.Homotopy q)
+theorem isNullHomologous_iff_of_pathHomotopy {x : ℂ} {p q : Path x x} {Ω : Set ℂ} (φ : p.Homotopy q)
     (hφsmooth : ContDiffOn ℝ 2
-      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2)
-      (Set.Icc 0 1))
+      (fun st : ℝ × ℝ ↦ Set.IccExtend zero_le_one (φ.toHomotopy.extend st.1) st.2) (Set.Icc 0 1))
     (hφΩ : ∀ st : Set.Icc (0 : ℝ) 1 × Set.Icc (0 : ℝ) 1, φ st ∈ Ω) :
     IsNullHomologous p.extend 0 1 Ω ↔ IsNullHomologous q.extend 0 1 Ω := by
   constructor

--- a/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Partition.lean
@@ -81,8 +81,7 @@ on each adjacent interval the model curve and assembled curve, and their derivat
 agree almost everywhere. If the Cauchy-kernel principal value exists along every model curve, the
 winding number of the assembled curve is the sum of the model-curve winding numbers. -/
 theorem windingNumber_eq_sum_range_of_ae {n : ℕ} {t : ℕ → ℝ} (piece : ℕ → ℝ → ℂ)
-    (heq : ∀ k < n, piece k =ᵐ[MeasureTheory.volume.restrict
-      (Set.uIoc (t k) (t (k + 1)))] γ)
+    (heq : ∀ k < n, piece k =ᵐ[MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1)))] γ)
     (hderiv : ∀ k < n, ∀ᵐ s ∂MeasureTheory.volume.restrict (Set.uIoc (t k) (t (k + 1))),
       piece k s ≠ z₀ → deriv (piece k) s = deriv γ s)
     (hpv : ∀ k < n, CauchyPVExistsAt (piece k) (t k) (t (k + 1)) κ[z₀] z₀) :

--- a/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Reparam.lean
@@ -69,10 +69,8 @@ The hypotheses on `γ` are stated on the swept image `φ '' [[a, b]]`, which con
 by the intermediate value theorem, so `φ` need not be monotone. Off-curve is essential: on the
 curve the winding number is a principal value, whose excision windows are themselves
 reparametrized. -/
-theorem windingNumber_comp_reparam
-    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc a b))
-    (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
+theorem windingNumber_comp_reparam (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
+    (hφ' : ContinuousOn φ' (Set.uIcc a b)) (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
     (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
     (havoid : ∀ u ∈ φ '' Set.uIcc a b, γ u ≠ z₀) :
     windingNumber (γ ∘ φ) a b z₀ = windingNumber γ (φ a) (φ b) z₀ := by
@@ -131,13 +129,10 @@ theorem windingNumber_comp_mul_add {r s : ℝ}
 /-- **Null-homology transports along a reparametrization.** If a curve lies in `Ω` and is
 null-homologous there, then so is its precomposition with any change of parameter `φ` that has an
 ambient derivative `φ' t` at each `t ∈ [[a, b]]`, with `φ'` continuous. -/
-theorem IsNullHomologous.comp_reparam
-    (h : IsNullHomologous γ (φ a) (φ b) Ω)
-    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t)
-    (hφ' : ContinuousOn φ' (Set.uIcc a b))
+theorem IsNullHomologous.comp_reparam (h : IsNullHomologous γ (φ a) (φ b) Ω)
+    (hφ : ∀ t ∈ Set.uIcc a b, HasDerivAt φ (φ' t) t) (hφ' : ContinuousOn φ' (Set.uIcc a b))
     (hγ : ∀ u ∈ φ '' Set.uIcc a b, DifferentiableAt ℝ γ u)
-    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b))
-    (hγΩ : ∀ u ∈ φ '' Set.uIcc a b, γ u ∈ Ω) :
+    (hγ' : ContinuousOn (deriv γ) (φ '' Set.uIcc a b)) (hγΩ : ∀ u ∈ φ '' Set.uIcc a b, γ u ∈ Ω) :
     IsNullHomologous (γ ∘ φ) a b Ω := by
   rw [isNullHomologous_iff] at h ⊢
   intro z hz

--- a/TauCeti/Analysis/Contour/Winding/Number/Reverse.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Reverse.lean
@@ -74,9 +74,7 @@ theorem IsNullHomologous.symm (h : IsNullHomologous γ a b Ω)
 curve lies in `Ω`, every exterior point is avoided, so the required principal values are ordinary
 integrals. -/
 theorem IsNullHomologous.symm_of_avoidance (h : IsNullHomologous γ a b Ω)
-    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω)
-    (hcont : ContinuousOn γ (Set.uIcc a b))
-    (hint : ∀ z ∉ Ω,
+    (hγ : ∀ t ∈ Set.uIcc a b, γ t ∈ Ω) (hcont : ContinuousOn γ (Set.uIcc a b)) (hint : ∀ z ∉ Ω,
       IntervalIntegrable (fun t => (γ t - z)⁻¹ * deriv γ t) MeasureTheory.volume a b) :
     IsNullHomologous γ b a Ω := by
   refine h.symm ?_

--- a/TauCeti/Analysis/Contour/Winding/Number/Scale.lean
+++ b/TauCeti/Analysis/Contour/Winding/Number/Scale.lean
@@ -62,16 +62,14 @@ nonzero complex number `c` transports the single-point Cauchy principal value of
 general `HasCauchyPVAt.const_mul_curve` to the winding kernel, where the rescaled integrand
 `z ↦ c⁻¹ * κ[z₀] (c⁻¹ * z)` agrees with `κ[c * z₀]` along the scaled curve. Exposed so downstream
 normalization steps can chain further principal-value APIs from the scaled fact. -/
-theorem hasCauchyPVAt_inv_sub_const_mul
-    (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
+theorem hasCauchyPVAt_inv_sub_const_mul (h : HasCauchyPVAt γ a b κ[z₀] z₀ L) (hc : c ≠ 0) :
     HasCauchyPVAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) L := by
   refine (h.const_mul_curve hc).congr_along_curve fun t _ => ?_
   exact inv_sub_const_mul_eq (z₀ := z₀) hc (γ t)
 
 /-- Existence form of `hasCauchyPVAt_inv_sub_const_mul`: nonzero scaling of the curve and base
 point preserves existence of the index principal value, exposed for the same downstream chaining. -/
-theorem cauchyPVExistsAt_inv_sub_const_mul
-    (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
+theorem cauchyPVExistsAt_inv_sub_const_mul (h : CauchyPVExistsAt γ a b κ[z₀] z₀) (hc : c ≠ 0) :
     CauchyPVExistsAt (fun t => c * γ t) a b κ[c * z₀] (c * z₀) :=
   let ⟨_, hL⟩ := cauchyPVExistsAt_iff.mp h
   CauchyPVExistsAt.intro (hasCauchyPVAt_inv_sub_const_mul hL hc)

--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -69,8 +69,7 @@ part is this real integral (`realWindingIntegrand_eq_div`), while its real part 
 increment of `log ‖γ − w‖` —
 vanishes by closedness. -/
 theorem windingNumber_eq_real_integral_of_closed {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
-    (hclosed : γ a = γ b) (hP : P.Countable)
-    (hγ_cont : ContinuousOn γ (Set.uIcc a b))
+    (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (Set.uIcc a b))
     (hγ_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (h_avoid : ∀ t ∈ Set.uIcc a b, γ t ≠ w)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) MeasureTheory.volume a b) :

--- a/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
+++ b/TauCeti/Analysis/Contour/Winding/SegmentSum.lean
@@ -59,11 +59,9 @@ off a countable set `P`, and with the normalized segment ratio `(γ t - w) / (γ
 the per-segment `Complex.log` increments. -/
 theorem integral_deriv_div_sub_eq_sum_log {γ γ' : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
-    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s) (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, HasDerivAt γ (γ' t) t)
-    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
-      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)), (γ t - w) / (γ (s j) - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ γ' t / (γ t - w)) volume a b) :
     ∫ t in a..b, γ' t / (γ t - w)
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
@@ -95,11 +93,9 @@ theorem integral_deriv_div_sub_eq_sum_log {γ γ' : ℝ → ℂ} {w : ℂ} {a b 
 consumed by the winding-number computation. -/
 theorem integral_inv_sub_mul_deriv_eq_sum_log {γ : ℝ → ℂ} {w : ℂ} {a b : ℝ} {P : Set ℝ}
     {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
-    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s) (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
-    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
-      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)), (γ t - w) / (γ (s j) - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ∑ j ∈ Finset.range N, Complex.log ((γ (s (j + 1)) - w) / (γ (s j) - w)) := by
@@ -115,11 +111,9 @@ logarithm sum. For a closed curve the real increment vanishes, isolating the tot
 change. -/
 theorem integral_deriv_div_sub_eq_log_norm_add_I_mul_sum_log_im {γ γ' : ℝ → ℂ} {w : ℂ}
     {a b : ℝ} {P : Set ℝ} {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
-    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s) (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, HasDerivAt γ (γ' t) t)
-    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
-      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)), (γ t - w) / (γ (s j) - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ γ' t / (γ t - w)) volume a b) :
     ∫ t in a..b, γ' t / (γ t - w)
       = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)
@@ -155,11 +149,9 @@ winding integrand `(γ t - w)⁻¹ * deriv γ t`, as consumed by the closed-curv
 computation. -/
 theorem integral_inv_sub_mul_deriv_eq_log_norm_add_I_mul_sum_log_im {γ : ℝ → ℂ} {w : ℂ}
     {a b : ℝ} {P : Set ℝ} {N : ℕ} {s : ℕ → ℝ} (hP : P.Countable)
-    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s)
-    (hγ_cont : ContinuousOn γ (Icc a b))
+    (hs_zero : s 0 = a) (hs_N : s N = b) (hs_mono : Monotone s) (hγ_cont : ContinuousOn γ (Icc a b))
     (hγ_diff : ∀ t ∈ Ioo a b \ P, DifferentiableAt ℝ γ t)
-    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)),
-      (γ t - w) / (γ (s j) - w) ∈ slitPlane)
+    (h_slit : ∀ j, j < N → ∀ t ∈ Icc (s j) (s (j + 1)), (γ t - w) / (γ (s j) - w) ∈ slitPlane)
     (h_int : IntervalIntegrable (fun t ↦ (γ t - w)⁻¹ * deriv γ t) volume a b) :
     ∫ t in a..b, (γ t - w)⁻¹ * deriv γ t
       = ((Real.log ‖γ b - w‖ - Real.log ‖γ a - w‖ : ℝ) : ℂ)

--- a/TauCeti/Analysis/Contour/Winding/Vanishing.lean
+++ b/TauCeti/Analysis/Contour/Winding/Vanishing.lean
@@ -54,8 +54,7 @@ private theorem windingNumber_eq_zero_of_far {γ : ℝ → ℂ} {a b R : ℝ} {P
     (hclosed : γ a = γ b) (hP : P.Countable) (hγ_cont : ContinuousOn γ (uIcc a b))
     (hγ_diff : ∀ t ∈ Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ γ t)
     (hderiv_int : IntervalIntegrable (fun t ↦ deriv γ t) volume a b)
-    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R)
-    (hw : R + (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖) :
+    (hR : ∀ t ∈ uIcc a b, ‖γ t‖ ≤ R) (hw : R + (∫ t in Ι a b, ‖deriv γ t‖) / (2 * Real.pi) < ‖w‖) :
     windingNumber γ a b w = 0 := by
   have h2pi_pos : (0 : ℝ) < 2 * Real.pi := by positivity
   have hD_nonneg : 0 ≤ ∫ t in Ι a b, ‖deriv γ t‖ := integral_nonneg fun _ => norm_nonneg _

--- a/TauCeti/Analysis/Contour/WindowSplitting.lean
+++ b/TauCeti/Analysis/Contour/WindowSplitting.lean
@@ -81,8 +81,7 @@ one-sided windows the distance profile is strictly monotone and the curve leaves
 point. -/
 private theorem exists_monotone_leave_radius {γ : ℝ → ℂ} {s : ℂ} {t₀ r : ℝ}
     {L_R L_L : ℂ} (hr_pos : 0 < r) (h_at : γ t₀ = s)
-    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
-    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r))) (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
@@ -122,8 +121,7 @@ private theorem exists_monotone_leave_radius {γ : ℝ → ℂ} {s : ℂ} {t₀ 
 monotone half-windows and both exit radii equal to `ε`, the curve stays within the closed `ε`-ball
 on `[cₗ, cᵣ]`, so the `ε`-truncation annihilates the integrand there. -/
 private theorem integral_truncated_eq_zero_between_exits {γ : ℝ → ℂ} {g : ℂ → ℂ} {s : ℂ}
-    {t₀ ρ ε cₗ cᵣ : ℝ}
-    (hmono : MonotoneOn (fun t => ‖γ t - s‖) (Icc t₀ (t₀ + ρ)))
+    {t₀ ρ ε cₗ cᵣ : ℝ} (hmono : MonotoneOn (fun t => ‖γ t - s‖) (Icc t₀ (t₀ + ρ)))
     (hanti : AntitoneOn (fun t => ‖γ t - s‖) (Icc (t₀ - ρ) t₀))
     (hcₗ : cₗ ∈ Ioo (t₀ - ρ) t₀) (hcᵣ : cᵣ ∈ Ioo t₀ (t₀ + ρ))
     (hεₗ : ‖γ cₗ - s‖ = ε) (hεᵣ : ‖γ cᵣ - s‖ = ε) :
@@ -188,14 +186,12 @@ truncated integral over the window eventually equals the sum of the two plain si
 up to the exit times. -/
 theorem exists_exit_times_truncated_integral_split {γ : ℝ → ℂ} {s : ℂ} {t₀ r : ℝ}
     {L_R L_L : ℂ} (hr_pos : 0 < r) (h_at : γ t₀ = s)
-    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r)))
-    (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
+    (hγ_cont : ContinuousOn γ (Icc (t₀ - r) (t₀ + r))) (hL_R : L_R ≠ 0) (hL_L : L_L ≠ 0)
     (h_tendsto_R : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L_R))
     (h_tendsto_L : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L_L))
     (h_diff_R : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
     (h_diff_L : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t)
-    (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀)
-    (g : ℂ → ℂ)
+    (h_unique : ∀ t ∈ Icc (t₀ - r) (t₀ + r), γ t = s → t = t₀) (g : ℂ → ℂ)
     (h_int : ∀ ε : ℝ, 0 < ε → ∀ a b : ℝ, t₀ - r ≤ a → a ≤ b → b ≤ t₀ + r →
       IntervalIntegrable (fun t => if ‖γ t - s‖ > ε then g (γ t) * deriv γ t else 0)
         MeasureTheory.volume a b) :

--- a/TauCeti/Analysis/Contour/WorkedExamples/TwoSimplePoles.lean
+++ b/TauCeti/Analysis/Contour/WorkedExamples/TwoSimplePoles.lean
@@ -55,8 +55,7 @@ theorem twoPrincipalParts_eq (A B s₁ s₂ : ℂ) :
 
 /-- `twoPrincipalParts` is analytic where each nonzero principal part is away from its designated
 point, or where coincident principal parts cancel. -/
-theorem analyticAt_twoPrincipalParts {A B s₁ s₂ z : ℂ}
-    (h : ((A = 0 ∨ z ≠ s₁) ∧ (B = 0 ∨ z ≠ s₂)) ∨
+theorem analyticAt_twoPrincipalParts {A B s₁ s₂ z : ℂ} (h : ((A = 0 ∨ z ≠ s₁) ∧ (B = 0 ∨ z ≠ s₂)) ∨
       (s₁ = s₂ ∧ A + B = 0)) :
     AnalyticAt ℂ (twoPrincipalParts A B s₁ s₂) z := by
   rcases h with ⟨hz₁, hz₂⟩ | ⟨rfl, hAB⟩
@@ -181,8 +180,7 @@ theorem circleIntegral_twoPrincipalParts {A B c s₁ s₂ : ℂ} {R : ℝ}
 point of each nonzero principal part inside the circle, the integral is `2πi` times the sum of the
 two residues. -/
 theorem circleIntegral_twoPrincipalParts_eq_residue_sum {A B c s₁ s₂ : ℂ} {R : ℝ}
-    (hs : s₁ ≠ s₂) (hs₁ : A = 0 ∨ s₁ ∈ ball c R)
-    (hs₂ : B = 0 ∨ s₂ ∈ ball c R) :
+    (hs : s₁ ≠ s₂) (hs₁ : A = 0 ∨ s₁ ∈ ball c R) (hs₂ : B = 0 ∨ s₂ ∈ ball c R) :
     circleIntegral (twoPrincipalParts A B s₁ s₂) c R =
       2 * (Real.pi : ℂ) * Complex.I *
         (residue (twoPrincipalParts A B s₁ s₂) s₁ +


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/Analysis/Contour/`: 207 joins across 52 files, `-207` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 52 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Width is measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports. Widest resulting line is exactly 100 codepoints (`WorkedExamples/TwoSimplePoles.lean:152`), which is at the limit and legal; nothing exceeds it.

Scope is the whole directory so the packing convention lands uniformly and does not invite a follow-up over the leftovers. No open PR touches `Analysis/Contour`.

Gates: `lake build` (6164 jobs) · `lake exe axioms` (19290 declarations, allowlist clean) · `lake exe module-system` (1056 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none