### PR TITLE
style(Multiquadratic): pack underfilled signature lines

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CMField/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CMField/GaloisGroup.lean
@@ -72,8 +72,7 @@ noncomputable def galoisGroupEquivISqrtPrimes :
 
 /-- The inverse CM Galois equivalence realizes a sign pattern by sending each generator to
 `(-1)^(ε x)` times itself: `i ↦ ±i` and `√(p i) ↦ ±√(p i)`. -/
-@[simp] theorem galoisGroupEquivISqrtPrimes_symm_apply_gen (ε : Option ι → ZMod 2)
-    (x : Option ι) :
+@[simp] theorem galoisGroupEquivISqrtPrimes_symm_apply_gen (ε : Option ι → ZMod 2) (x : Option ι) :
     ((galoisGroupEquivISqrtPrimes p hp hinj).symm (Multiplicative.ofAdd ε)) (gen (cmRoot p) x)
       = (-1) ^ (ε x).val * gen (cmRoot p) x :=
   galoisGroupEquiv_symm_apply_gen (cmRoot_sq p) (not_isSquare_prod_cmRadicand p hp hinj) ε x

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/GaloisGroup.lean
@@ -160,8 +160,7 @@ chosen generator to `(-1)^(ε P)` times that generator. -/
     (hd : Squarefree d) (ε : {P // P ∈ genusPrimeDiscriminants hd} → ZMod 2)
     (P : {P // P ∈ genusPrimeDiscriminants hd}) :
     ((galoisGroupEquivCandidateGenusField hd).symm (Multiplicative.ofAdd ε))
-        (candidateGenusFieldGen hd P) =
-      (-1) ^ (ε P).val * candidateGenusFieldGen hd P := by
+        (candidateGenusFieldGen hd P) = (-1) ^ (ε P).val * candidateGenusFieldGen hd P := by
   apply (candidateGenusFieldEquivAdjoin hd).injective
   simp only [map_mul, candidateGenusFieldEquivAdjoin_apply_gen]
   exact galoisGroupEquivPrimeDiscriminantRadicands_symm_apply_gen

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RelativeGaloisGroup.lean
@@ -153,8 +153,7 @@ private theorem candidateGenusField_apply_prodRoot {d : ℤ} (hd : Squarefree d)
   simp_rw [candidateGenusField_apply_gen]
   rw [Finset.prod_mul_distrib, Finset.prod_pow_eq_pow_sum]
 
-private theorem sum_zmod_eq_zero_iff_even_sum_val
-    {ι : Type*} [Fintype ι] (v : ι → ZMod 2) :
+private theorem sum_zmod_eq_zero_iff_even_sum_val {ι : Type*} [Fintype ι] (v : ι → ZMod 2) :
     (∑ i, v i) = 0 ↔ Even (∑ i, (v i).val) := by
   have hcast : ((∑ i, (v i).val : ℕ) : ZMod 2) = ∑ i, v i := by
     rw [Nat.cast_sum]
@@ -241,8 +240,7 @@ noncomputable local instance candidateGenusFieldAdjoinAlgebra {d : ℤ} (hd : Sq
     Algebra ℚ (adjoin ℚ (Set.range (genusFieldRoot hd))) :=
   (adjoin ℚ (Set.range (genusFieldRoot hd))).algebra'
 
-private noncomputable def candidateGenusFieldEquivAdjoinRelative {d : ℤ}
-    (hd : Squarefree d) :
+private noncomputable def candidateGenusFieldEquivAdjoinRelative {d : ℤ} (hd : Squarefree d) :
     candidateGenusField hd ≃ₐ[ℚ]
       @adjoin ℚ _ ℂ _ _ (Set.range (genusFieldRoot hd)) :=
   AlgEquiv.ofRingEquiv
@@ -324,8 +322,7 @@ private noncomputable def candidateGenusFieldRelativeAutCongr {d : ℤ} (hd : Sq
         ((MulEquiv.subgroupCongr (candidateGenusField_map_fixingSubgroup hd)).trans
           (IntermediateField.fixingSubgroupEquiv (candidateGenusFieldBaseAdjoin hd))))
 
-@[simp] private theorem candidateGenusFieldRelativeAutCongr_apply {d : ℤ}
-    (hd : Squarefree d)
+@[simp] private theorem candidateGenusFieldRelativeAutCongr_apply {d : ℤ} (hd : Squarefree d)
     (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd)
     (x : candidateGenusField hd) :
     candidateGenusFieldRelativeAutCongr hd σ
@@ -427,8 +424,7 @@ noncomputable def galoisGroupEquivCandidateGenusFieldRelative {d : ℤ} (hd : Sq
 
 /-- The relative Galois equivalence sends an automorphism to the sign pattern of its restriction
 to an absolute `ℚ`-automorphism. -/
-@[simp] theorem galoisGroupEquivCandidateGenusFieldRelative_apply {d : ℤ}
-    (hd : Squarefree d)
+@[simp] theorem galoisGroupEquivCandidateGenusFieldRelative_apply {d : ℤ} (hd : Squarefree d)
     (σ : candidateGenusField hd ≃ₐ[candidateGenusFieldBase hd] candidateGenusField hd) :
     galoisGroupEquivCandidateGenusFieldRelative hd σ =
       Multiplicative.ofAdd

--- a/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/EvenPrimeDiscriminant.lean
@@ -81,8 +81,7 @@ def evenPrimeDiscriminantRadicand (D : ℤ) : ℤ :=
   norm_num [evenPrimeDiscriminantRadicand]
 
 /-- An even prime discriminant is four times its associated squarefree radicand. -/
-theorem evenPrimeDiscriminant_eq_four_mul_radicand {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem evenPrimeDiscriminant_eq_four_mul_radicand {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     D = 4 * evenPrimeDiscriminantRadicand D := by
   rcases hD with rfl | rfl | rfl <;> norm_num [evenPrimeDiscriminantRadicand]
 
@@ -97,20 +96,17 @@ theorem evenPrimeDiscriminantRadicand_eq_neg_one_or_eq_two_or_eq_neg_two {D : �
 
 /-- The absolute value of the radicand attached to an even prime discriminant is `1` or `2`. -/
 theorem evenPrimeDiscriminantRadicand_natAbs_eq_one_or_two {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
-    (evenPrimeDiscriminantRadicand D).natAbs = 1 ∨
+    (hD : IsEvenPrimeDiscriminant D) : (evenPrimeDiscriminantRadicand D).natAbs = 1 ∨
       (evenPrimeDiscriminantRadicand D).natAbs = 2 := by
   rcases hD with rfl | rfl | rfl <;> simp
 
 /-- The radicand attached to an even prime discriminant is nonzero. -/
-theorem evenPrimeDiscriminantRadicand_ne_zero {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem evenPrimeDiscriminantRadicand_ne_zero {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     evenPrimeDiscriminantRadicand D ≠ 0 := by
   rcases hD with rfl | rfl | rfl <;> simp
 
 /-- The radicand attached to an even prime discriminant is squarefree. -/
-theorem squarefree_evenPrimeDiscriminantRadicand {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem squarefree_evenPrimeDiscriminantRadicand {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     Squarefree (evenPrimeDiscriminantRadicand D) := by
   rcases hD with rfl | rfl | rfl
   · norm_num
@@ -120,9 +116,7 @@ theorem squarefree_evenPrimeDiscriminantRadicand {D : ℤ}
     exact Nat.prime_two.squarefree
 
 /-- The even prime discriminants themselves are even. -/
-theorem two_dvd_evenPrimeDiscriminant {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
-    (2 : ℤ) ∣ D := by
+theorem two_dvd_evenPrimeDiscriminant {D : ℤ} (hD : IsEvenPrimeDiscriminant D) : (2 : ℤ) ∣ D := by
   rcases hD with rfl | rfl | rfl <;> norm_num
 
 /-- The radicand attached to an even prime discriminant is congruent to `-1` or `2`
@@ -134,26 +128,22 @@ theorem evenPrimeDiscriminantRadicand_mod_four_eq_three_or_two {D : ℤ}
   rcases hD with rfl | rfl | rfl <;> norm_num
 
 /-- The rational radicand associated to an even prime discriminant is not a square. -/
-theorem not_isSquare_evenPrimeDiscriminantRadicand_rat {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem not_isSquare_evenPrimeDiscriminantRadicand_rat {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     ¬ IsSquare ((evenPrimeDiscriminantRadicand D : ℤ) : ℚ) := by
   rcases hD with rfl | rfl | rfl <;> norm_num [evenPrimeDiscriminantRadicand]
 
 /-- The discriminant `-4` gives the radicand `-1`. -/
-theorem evenPrimeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem evenPrimeDiscriminantRadicand_eq_neg_one_iff {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     evenPrimeDiscriminantRadicand D = -1 ↔ D = -4 := by
   rcases hD with rfl | rfl | rfl <;> norm_num
 
 /-- The discriminant `8` gives the radicand `2`. -/
-theorem evenPrimeDiscriminantRadicand_eq_two_iff {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem evenPrimeDiscriminantRadicand_eq_two_iff {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     evenPrimeDiscriminantRadicand D = 2 ↔ D = 8 := by
   rcases hD with rfl | rfl | rfl <;> norm_num
 
 /-- The discriminant `-8` gives the radicand `-2`. -/
-theorem evenPrimeDiscriminantRadicand_eq_neg_two_iff {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem evenPrimeDiscriminantRadicand_eq_neg_two_iff {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     evenPrimeDiscriminantRadicand D = -2 ↔ D = -8 := by
   rcases hD with rfl | rfl | rfl <;> norm_num
 

--- a/TauCeti/NumberTheory/Multiquadratic/Frobenius.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Frobenius.lean
@@ -63,10 +63,8 @@ an ideal `Q` of `𝓞 K` above `p`. Then `σ = 1` iff every `d i` is a quadratic
 Combined with the splitting law, this is the Frobenius-theoretic reading of complete
 splitting. -/
 theorem isArithFrobAt_multiquadratic_eq_one_iff (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i))
-    (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
-    (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
-    (Q : Ideal (𝓞 K)) [Q.LiesOver (span {(p : ℤ)})]
+    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
+    (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i) (Q : Ideal (𝓞 K)) [Q.LiesOver (span {(p : ℤ)})]
     {σ : K ≃ₐ[ℚ] K} (hσ : IsArithFrobAt ℤ σ Q) :
     σ = 1 ↔ ∀ i, legendreSym p (d i) = 1 := by
   constructor
@@ -87,8 +85,7 @@ the multiquadratic splitting law; the sign-vector description under `galoisGroup
 formed here (see the module docstring). The `IsGalois ℚ K` hypothesis holds in particular when
 the `r i` generate `K` (`TauCeti.Multiquadratic.isGalois` transported along `adjoin ℚ … = ⊤`). -/
 theorem exists_isArithFrobAt_multiquadratic [IsGalois ℚ K] (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i))
-    (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
+    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
     (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})] :
     ∃ σ : K ≃ₐ[ℚ] K, IsArithFrobAt ℤ σ Q ∧
       ∀ i, σ (r i) = legendreSym p (d i) • r i := by
@@ -127,8 +124,7 @@ arithmetic Frobenius `σ` on `M` at a prime `Q` above `p`, the `i`-th coordinate
 pattern is `0` when `dᵢ` is a quadratic residue mod `p` and `1` otherwise. -/
 theorem signPattern_frobenius (hroot : ∀ i, root i ^ 2 = algebraMap ℤ L (d i))
     (p : ℕ) [Fact p.Prime] (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
-    (Q : Ideal (𝓞 ↥(IntermediateField.adjoin ℚ (Set.range root))))
-    [Q.LiesOver (span {(p : ℤ)})]
+    (Q : Ideal (𝓞 ↥(IntermediateField.adjoin ℚ (Set.range root)))) [Q.LiesOver (span {(p : ℤ)})]
     {σ : ↥(IntermediateField.adjoin ℚ (Set.range root)) ≃ₐ[ℚ]
         ↥(IntermediateField.adjoin ℚ (Set.range root))}
     (hσ : IsArithFrobAt ℤ σ Q) (i : ι) :
@@ -155,12 +151,10 @@ independence of the `dᵢ` (so `TauCeti.Multiquadratic.galoisGroupEquiv` is the 
 `Gal(M/ℚ) ≅ (ℤ/2)ⁿ`), an arithmetic Frobenius `σ` at a prime `Q` above the odd prime `p ∤ dᵢ`
 maps to the vector of Legendre symbols `i ↦ (dᵢ/p)`. This is the roadmap's Layer 1 Frobenius
 statement. -/
-theorem galoisGroupEquiv_frobenius [Finite ι]
-    (hroot : ∀ i, root i ^ 2 = algebraMap ℤ L (d i))
+theorem galoisGroupEquiv_frobenius [Finite ι] (hroot : ∀ i, root i ^ 2 = algebraMap ℤ L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, (d i : ℚ)))
     (p : ℕ) [Fact p.Prime] (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i)
-    (Q : Ideal (𝓞 ↥(IntermediateField.adjoin ℚ (Set.range root))))
-    [Q.LiesOver (span {(p : ℤ)})]
+    (Q : Ideal (𝓞 ↥(IntermediateField.adjoin ℚ (Set.range root)))) [Q.LiesOver (span {(p : ℤ)})]
     {σ : ↥(IntermediateField.adjoin ℚ (Set.range root)) ≃ₐ[ℚ]
         ↥(IntermediateField.adjoin ℚ (Set.range root))}
     (hσ : IsArithFrobAt ℤ σ Q) :

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/Basic.lean
@@ -163,8 +163,7 @@ theorem odd_prod_oddPrimeDiscriminant (hodd : ∀ i ∈ s, Odd (p i)) :
   omega
 
 /-- A product of odd prime discriminants at pairwise distinct primes is squarefree. -/
-theorem squarefree_prod_oddPrimeDiscriminant (hp : ∀ i ∈ s, (p i).Prime)
-    (hinj : Set.InjOn p s) :
+theorem squarefree_prod_oddPrimeDiscriminant (hp : ∀ i ∈ s, (p i).Prime) (hinj : Set.InjOn p s) :
     Squarefree (∏ i ∈ s, oddPrimeDiscriminant (p i)) := by
   refine Finset.squarefree_prod_of_pairwise_isCoprime (fun i hi j hj hij => ?_)
     fun i hi => squarefree_oddPrimeDiscriminant (hp i hi).squarefree
@@ -231,8 +230,7 @@ private theorem prod_oddPrimeDiscriminant_natAbs_of_not_isEvenPrimeDiscriminant 
 /-- **A product of distinct prime discriminants with at most one even value is a fundamental
 discriminant.** -/
 theorem isFundamentalDiscriminant_prod {D : ι → ℤ} (hD : ∀ i ∈ s, IsPrimeDiscriminant (D i))
-    (hDinj : Set.InjOn D s)
-    (heven : ∀ i ∈ s, ∀ j ∈ s, IsEvenPrimeDiscriminant (D i) →
+    (hDinj : Set.InjOn D s) (heven : ∀ i ∈ s, ∀ j ∈ s, IsEvenPrimeDiscriminant (D i) →
       IsEvenPrimeDiscriminant (D j) → D i = D j) :
     IsFundamentalDiscriminant (∏ i ∈ s, D i) := by
   classical

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Group.lean
@@ -99,8 +99,7 @@ theorem signPattern_injective (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
   exact hgen
 
 /-- The sign is `0` exactly where the automorphism fixes the generator. -/
-theorem signPattern_eq_zero
-    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+theorem signPattern_eq_zero (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
     (h : σ (gen root i) = gen root i) : signPattern root σ i = 0 := by
   simp [signPattern, h]
 
@@ -112,8 +111,7 @@ theorem signPattern_eq_zero
   by_cases h : σ (gen root i) = gen root i <;> simp [h]
 
 /-- The sign is `1` where the automorphism negates a generator that differs from its negation. -/
-theorem signPattern_eq_one
-    (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
+theorem signPattern_eq_one (σ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι)
     (hne : gen (K := K) root i ≠ -gen root i)
     (h : σ (gen root i) = -gen root i) : signPattern root σ i = 1 := by
   have hni : σ (gen root i) ≠ gen root i := fun hh => hne (h ▸ hh.symm)
@@ -149,10 +147,8 @@ private theorem signed_pow_add_mul (x : adjoin K (Set.range root)) (a b : ZMod 2
 
 private theorem zmod_two_eq_zero_or_one (t : ZMod 2) : t = 0 ∨ t = 1 := by revert t; decide
 
-private theorem aut_mul_gen_eq_signPattern_add
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) :
-    (σ * τ) (gen root i)
+private theorem aut_mul_gen_eq_signPattern_add (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    (σ τ : adjoin K (Set.range root) ≃ₐ[K] adjoin K (Set.range root)) (i : ι) : (σ * τ) (gen root i)
       = (-1) ^ (signPattern root σ i + signPattern root τ i).val * gen root i := by
   rw [AlgEquiv.mul_apply, aut_gen_eq_signPattern hroot τ i, map_mul, map_pow, map_neg,
     map_one, aut_gen_eq_signPattern hroot σ i]
@@ -255,8 +251,7 @@ theorem aut_nontrivial [Finite ι] [NeZero (2 : K)] [Nonempty ι]
 generator `rootᵢ` to `(-1)^(εᵢ) · rootᵢ`. -/
 @[simp] theorem galoisGroupEquiv_symm_apply_gen [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
-    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
-    (ε : ι → ZMod 2) (i : ι) :
+    (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i)) (ε : ι → ZMod 2) (i : ι) :
     ((galoisGroupEquiv hroot hindep).symm (Multiplicative.ofAdd ε)) (gen root i)
       = (-1) ^ (ε i).val * gen root i := by
   have hσ : signPattern root

--- a/TauCeti/NumberTheory/Multiquadratic/Galois/Relative.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Galois/Relative.lean
@@ -171,8 +171,7 @@ noncomputable def galoisGroupEquivIntermediateFieldSubmodule [Finite ι] [NeZero
 attached to `F` as the `F`-automorphism sending each generator `rootᵢ` to `(-1)^(vᵢ) · rootᵢ`. This
 is the relative reading of `TauCeti.Multiquadratic.galoisGroupEquiv_symm_apply_gen`. -/
 @[simp] theorem galoisGroupEquivIntermediateFieldSubmodule_symm_apply_gen [Finite ι]
-    [NeZero (2 : K)]
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+    [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
     (F : IntermediateField K (adjoin K (Set.range root)))
     (v : (intermediateFieldEquivSubmodule hroot hindep F).ofDual) (i : ι) :
@@ -214,8 +213,7 @@ everything. This is the group the genus-field constructions read off over the qu
 theorem card_aut_top_over_intermediateField_of_finrank_eq_two [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
-    (F : IntermediateField K (adjoin K (Set.range root)))
-    (hF : Module.finrank K F = 2) :
+    (F : IntermediateField K (adjoin K (Set.range root))) (hF : Module.finrank K F = 2) :
     Nat.card (adjoin K (Set.range root) ≃ₐ[F] adjoin K (Set.range root)) =
       2 ^ (Nat.card ι - 1) := by
   rw [card_aut_top_over_intermediateField hroot hindep F]

--- a/TauCeti/NumberTheory/Multiquadratic/GenusField.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/GenusField.lean
@@ -58,8 +58,7 @@ private lemma primeDiscriminant_eq_sq_mul_radicand {P : ℤ} (hP : IsPrimeDiscri
 /-- The product of the radicands of prime discriminants whose product is
 `fundamentalDiscriminant d` is a nonzero rational square times `d`. -/
 theorem exists_prod_radicand_eq_sq_mul_of_prod_primeDiscriminant_eq {d : ℤ} {s : Finset ℤ}
-    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
-    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) :
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P) (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) :
     ∃ a : ℚ, a ≠ 0 ∧
       (∏ P ∈ s.attach, ((primeDiscriminantRadicand P.val : ℤ) : ℚ)) =
         a ^ 2 * ((d : ℤ) : ℚ) := by
@@ -100,8 +99,7 @@ finite set of prime discriminants whose product is the fundamental discriminant
 squaring to `d`. This is the square-class containment underlying the genus-field construction. -/
 theorem exists_mem_adjoin_sq_eq_of_prod_primeDiscriminant_eq {d : ℤ} {s : Finset ℤ}
     (hs : ∀ P ∈ s, IsPrimeDiscriminant P) (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d)
-    {L : Type*} [Field L] [Algebra ℚ L] (root : {P // P ∈ s} → L)
-    (hroot : ∀ P : {P // P ∈ s},
+    {L : Type*} [Field L] [Algebra ℚ L] (root : {P // P ∈ s} → L) (hroot : ∀ P : {P // P ∈ s},
       root P ^ 2 = algebraMap ℚ L ((primeDiscriminantRadicand P.val : ℤ) : ℚ)) :
     ∃ x ∈ IntermediateField.adjoin ℚ (Set.range root), x ^ 2 = algebraMap ℚ L ((d : ℤ) : ℚ) := by
   classical

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/EvenPrimeDiscriminant.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/EvenPrimeDiscriminant.lean
@@ -79,8 +79,7 @@ every odd prime `q`: they differ by the square factor `4`, which contributes a t
 symbol. This is the form used by the genus-field splitting law, where the prime discriminant
 `D` itself is the splitting character. -/
 theorem legendreSym_evenPrimeDiscriminant_eq_legendreSym_radicand {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D)
-    (hq : q ≠ 2) :
+    (hD : IsEvenPrimeDiscriminant D) (hq : q ≠ 2) :
     legendreSym q D = legendreSym q (evenPrimeDiscriminantRadicand D) := by
   have hsq : D = evenPrimeDiscriminantRadicand D * 2 ^ 2 := by
     calc

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminant/Basic.lean
@@ -88,8 +88,7 @@ theorem legendreSym_oddPrimeDiscriminant_eq_one_iff [Fact p.Prime] [Fact q.Prime
 `p i`, the conditions that all odd prime discriminants `p i*` are quadratic residues modulo
 an odd prime `q` are exactly the reciprocal conditions `(q / p i) = 1`. -/
 theorem forall_legendreSym_oddPrimeDiscriminant_eq_one_iff {ι : Type*} (p : ι → ℕ)
-    {q : ℕ} [Fact q.Prime] (hpprime : ∀ i, (p i).Prime) (hpodd : ∀ i, p i ≠ 2)
-    (hq : q ≠ 2) :
+    {q : ℕ} [Fact q.Prime] (hpprime : ∀ i, (p i).Prime) (hpodd : ∀ i, p i ≠ 2) (hq : q ≠ 2) :
     (∀ i, legendreSym q (oddPrimeDiscriminant (p i)) = 1) ↔
       ∀ i, @legendreSym (p i) ⟨hpprime i⟩ (q : ℤ) = 1 := by
   refine forall_congr' fun i => ?_

--- a/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Legendre/PrimeDiscriminants.lean
@@ -62,8 +62,7 @@ family are quadratic residues modulo an odd prime `q` is equivalent to the same 
 their associated squarefree radicands. This is the conversion used before applying the
 multiquadratic splitting law to genus-field prime discriminants. -/
 theorem forall_legendreSym_primeDiscriminant_eq_one_iff_radicand {ι : Type*} (D : ι → ℤ)
-    (hq : q ≠ 2) :
-    (∀ i, legendreSym q (D i) = 1) ↔
+    (hq : q ≠ 2) : (∀ i, legendreSym q (D i) = 1) ↔
       ∀ i, legendreSym q (primeDiscriminantRadicand (D i)) = 1 := by
   refine forall_congr' fun i => ?_
   rw [legendreSym_eq_legendreSym_primeDiscriminantRadicand (D i) hq]
@@ -72,8 +71,7 @@ theorem forall_legendreSym_primeDiscriminant_eq_one_iff_radicand {ι : Type*} (D
 For the three even prime discriminants this is the corresponding supplementary congruence
 condition on `q`; for an odd prime discriminant `p*` it is the reciprocal condition
 `(q / p) = 1`. -/
-theorem legendreSym_primeDiscriminant_eq_one_iff {D : ℤ}
-    (hD : IsPrimeDiscriminant D) (hq : q ≠ 2) :
+theorem legendreSym_primeDiscriminant_eq_one_iff {D : ℤ} (hD : IsPrimeDiscriminant D) (hq : q ≠ 2) :
     legendreSym q D = 1 ↔
       (IsEvenPrimeDiscriminant D ∧
         (if D = -4 then q % 4 = 1
@@ -123,8 +121,7 @@ theorem legendreSym_primeDiscriminantRadicand_eq_one_iff {D : ℤ}
 
 /-- Indexed-family form of the uniform prime-discriminant residue criterion. -/
 theorem forall_legendreSym_primeDiscriminant_eq_one_iff {ι : Type*} (D : ι → ℤ)
-    (hD : ∀ i, IsPrimeDiscriminant (D i)) (hq : q ≠ 2) :
-    (∀ i, legendreSym q (D i) = 1) ↔
+    (hD : ∀ i, IsPrimeDiscriminant (D i)) (hq : q ≠ 2) : (∀ i, legendreSym q (D i) = 1) ↔
       ∀ i,
         (IsEvenPrimeDiscriminant (D i) ∧
           (if D i = -4 then q % 4 = 1

--- a/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/MultiquadraticSplitting.lean
@@ -128,10 +128,8 @@ private theorem two_mul_mem_of_mul_mem_of_map_eq_neg {S : Type*} [Ring S] {Q : I
 
 /-- If `d` is a quadratic residue mod the odd prime `p` (with `p ∤ d`), no element `σ` of the
 decomposition group of a prime `Q` above `p` sends the generator `r` to its negation. -/
-private theorem map_ne_neg_of_legendreSym_eq_one (d : ℤ) (r : K)
-    (hr : r ^ 2 = algebraMap ℤ K d)
-    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
-    (hqr : legendreSym p d = 1)
+private theorem map_ne_neg_of_legendreSym_eq_one (d : ℤ) (r : K) (hr : r ^ 2 = algebraMap ℤ K d)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hqr : legendreSym p d = 1)
     (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})]
     {σ : K ≃ₐ[ℚ] K} (hσ : σ ∈ stabilizer (K ≃ₐ[ℚ] K) Q) : σ r ≠ - r := by
   intro hflip
@@ -175,10 +173,8 @@ private theorem map_ne_neg_of_legendreSym_eq_one (d : ℤ) (r : K)
 
 /-- Backward core (pointwise): if `p` is odd and `d` is a quadratic residue mod `p`, then every
 `σ` in the decomposition group of `Q` fixes the generator `r`. -/
-private theorem decompositionGroup_fixes_gen (d : ℤ) (r : K)
-    (hr : r ^ 2 = algebraMap ℤ K d)
-    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
-    (hqr : legendreSym p d = 1)
+private theorem decompositionGroup_fixes_gen (d : ℤ) (r : K) (hr : r ^ 2 = algebraMap ℤ K d)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hqr : legendreSym p d = 1)
     (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})]
     {σ : K ≃ₐ[ℚ] K} (hσ : σ ∈ stabilizer (K ≃ₐ[ℚ] K) Q) : σ r = r := by
   -- From `σ r² = r²`, `σ r = ± r`; the `+` case is immediate and the `-` case is
@@ -192,10 +188,8 @@ private theorem decompositionGroup_fixes_gen (d : ℤ) (r : K)
 /-- Backward wrapper: for `K` generated over `ℚ` by the `r i` (`ℚ(rᵢ) = K`), if `p` is odd and
 every `d i` is a quadratic residue mod `p`, then the decomposition group of `Q` is trivial. -/
 private theorem stabilizer_eq_bot_of_forall_legendreSym_eq_one {ι : Type*} (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i))
-    (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
-    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2)
-    (hqr : ∀ i, legendreSym p (d i) = 1)
+    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
+    {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hqr : ∀ i, legendreSym p (d i) = 1)
     (Q : Ideal (𝓞 K)) [Q.IsPrime] [Q.LiesOver (span {(p : ℤ)})] :
     stabilizer (K ≃ₐ[ℚ] K) Q = ⊥ := by
   rw [eq_bot_iff]
@@ -220,8 +214,7 @@ private theorem stabilizer_eq_bot_of_forall_legendreSym_eq_one {ι : Type*} (d :
 roots `r i` of integers `d i`, and an odd prime `p` dividing none of the `d i`, `p` splits
 completely in `K` iff every `d i` is a quadratic residue mod `p`. -/
 theorem ncard_primesOver_multiquadratic_iff {ι : Type*} [Finite ι] (d : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i))
-    (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
+    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (d i)) (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ d i) :
     (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = finrank ℚ K ↔
       ∀ i, legendreSym p (d i) = 1 := by

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Basic.lean
@@ -70,8 +70,7 @@ theorem oddPrimeDiscriminant_of_mod_four_eq_three {p : ℕ} (hp : p % 4 = 3) :
   oddPrimeDiscriminant_of_mod_four_ne_one (by omega)
 
 /-- The absolute value of the odd prime discriminant is the underlying natural number. -/
-@[simp] theorem oddPrimeDiscriminant_natAbs (p : ℕ) :
-    (oddPrimeDiscriminant p).natAbs = p := by
+@[simp] theorem oddPrimeDiscriminant_natAbs (p : ℕ) : (oddPrimeDiscriminant p).natAbs = p := by
   by_cases hp : p % 4 = 1 <;> simp [oddPrimeDiscriminant, hp]
 
 /-- The odd prime discriminant is nonzero exactly when `p` is nonzero. -/

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Examples/Basic.lean
@@ -68,8 +68,7 @@ private theorem forall_not_dvd_negFourNegThreeNegSevenPrimeDiscriminants {p : �
 by square roots of the radicands attached to `[-4, 5]`, namely `-1` and `5`. An odd prime
 `p ≠ 5` splits completely in `K` exactly under the two character conditions
 `p ≡ 1 (mod 4)` and `(p / 5) = 1`. -/
-theorem ncard_primesOver_neg_four_five_iff (r : Fin 2 → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K
+theorem ncard_primesOver_neg_four_five_iff (r : Fin 2 → K) (hr : ∀ i, r i ^ 2 = algebraMap ℤ K
       (TauCeti.Multiquadratic.primeDiscriminantRadicand
         (TauCeti.Multiquadratic.negFourFivePrimeDiscriminants i)))
     (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
@@ -86,8 +85,7 @@ by square roots of the radicands attached to `[-4, -3, -7]`, namely `-1`, `-3`, 
 An odd prime `p` not among `3` and `7` splits completely in `K` exactly under the three
 character conditions `p ≡ 1 (mod 4)`, `(p / 3) = 1`, and `(p / 7) = 1`. -/
 theorem ncard_primesOver_neg_four_neg_three_neg_seven_iff (r : Fin 3 → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K
-      (TauCeti.Multiquadratic.primeDiscriminantRadicand
+    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (TauCeti.Multiquadratic.primeDiscriminantRadicand
         (TauCeti.Multiquadratic.negFourNegThreeNegSevenPrimeDiscriminants i)))
     (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hthree : p ≠ 3) (hseven : p ≠ 7) :

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/GaloisGroup.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/GaloisGroup.lean
@@ -71,8 +71,7 @@ chosen radicand roots. -/
 
 /-- The inverse prime-discriminant Galois equivalence realizes a sign pattern by sending each
 chosen generator to `(-1)^(ε i)` times that generator. -/
-@[simp] theorem galoisGroupEquivPrimeDiscriminantRadicands_symm_apply_gen
-    (ε : ι → ZMod 2) (i : ι) :
+@[simp] theorem galoisGroupEquivPrimeDiscriminantRadicands_symm_apply_gen (ε : ι → ZMod 2) (i : ι) :
     ((galoisGroupEquivPrimeDiscriminantRadicands D hD hinj heven root hroot).symm
         (Multiplicative.ofAdd ε)) (gen root i)
       = (-1) ^ (ε i).val * gen root i :=

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Independence.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Independence.lean
@@ -47,8 +47,7 @@ namespace TauCeti.Multiquadratic
 
 /-- Products over odd prime-discriminant radicands, with no `-4` radicand, are not `-1`. -/
 private theorem prod_primeDiscriminantRadicands_ne_neg_one {ι : Type*} {D : ι → ℤ}
-    (hD : ∀ i, IsPrimeDiscriminant (D i)) {S : Finset ι}
-    (hno_neg_four : ∀ i ∈ S, D i ≠ -4) :
+    (hD : ∀ i, IsPrimeDiscriminant (D i)) {S : Finset ι} (hno_neg_four : ∀ i ∈ S, D i ≠ -4) :
     (∏ i ∈ S, primeDiscriminantRadicand (D i)) ≠ -1 := by
   classical
   intro hprod
@@ -93,8 +92,7 @@ private theorem not_isSquare_prod_primeDiscriminantRadicands_of_pairwise_isCopri
 injective and the selected set is nonempty. -/
 private theorem prod_primeDiscriminantRadicands_ne_one_of_nonempty {ι : Type*} {D : ι → ℤ}
     (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D) {S : Finset ι}
-    (hS : S.Nonempty) :
-    (∏ i ∈ S, primeDiscriminantRadicand (D i)) ≠ 1 := by
+    (hS : S.Nonempty) : (∏ i ∈ S, primeDiscriminantRadicand (D i)) ≠ 1 := by
   intro hP
   have hnp := map_prod Int.natAbsHom (fun i => primeDiscriminantRadicand (D i)) S
   simp only [Int.natAbsHom_apply] at hnp
@@ -150,8 +148,7 @@ and `-8` but none for `-4`: the product of the radicands `primeDiscriminantRadic
 is not a rational square. -/
 private theorem not_isSquare_prod_primeDiscriminantRadicands_of_mem_eight_neg_eight {ι : Type*}
     {D : ι → ℤ} (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D)
-    {S : Finset ι} (hno4S : ∀ i ∈ S, D i ≠ -4)
-    (hboth : (∃ i ∈ S, D i = 8) ∧ (∃ i ∈ S, D i = -8)) :
+    {S : Finset ι} (hno4S : ∀ i ∈ S, D i ≠ -4) (hboth : (∃ i ∈ S, D i = 8) ∧ (∃ i ∈ S, D i = -8)) :
     ¬ IsSquare (∏ i ∈ S, ((primeDiscriminantRadicand (D i) : ℤ) : ℚ)) := by
   classical
   obtain ⟨⟨i8, hi8S, hi8D⟩, im8, him8S, him8D⟩ := hboth
@@ -224,8 +221,7 @@ discriminants must carry the same discriminant value. This is the form supplied 
 prime-discriminant factorization of a quadratic discriminant, where there is only one 2-adic
 factor. -/
 theorem not_all_three_evenPrimeDiscriminants_of_forall_isEvenPrimeDiscriminant_eq {ι : Type*}
-    {D : ι → ℤ}
-    (heven_unique : ∀ i j,
+    {D : ι → ℤ} (heven_unique : ∀ i j,
       IsEvenPrimeDiscriminant (D i) → IsEvenPrimeDiscriminant (D j) → D i = D j) :
     ¬ ((∃ i, D i = -4) ∧ (∃ i, D i = 8) ∧ (∃ i, D i = -8)) := by
   rintro ⟨⟨i4, hi4⟩, ⟨i8, hi8⟩, _⟩
@@ -244,8 +240,7 @@ This is the genus-field specialization of
 discriminant have at most one even member, so the exceptional product
 `(-1) * 2 * (-2) = 4` cannot occur. -/
 theorem not_isSquare_prod_primeDiscriminantRadicands_of_forall_isEvenPrimeDiscriminant_eq
-    {ι : Type*} (D : ι → ℤ) (hD : ∀ i, IsPrimeDiscriminant (D i))
-    (hinj : Function.Injective D)
+    {ι : Type*} (D : ι → ℤ) (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D)
     (heven_unique : ∀ i j,
       IsEvenPrimeDiscriminant (D i) → IsEvenPrimeDiscriminant (D j) → D i = D j) :
     ∀ S : Finset ι, S.Nonempty →
@@ -262,8 +257,7 @@ square-class independence `not_isSquare_prod_primeDiscriminantRadicands`. -/
 theorem finrank_adjoin_roots_primeDiscriminantRadicands {ι : Type*} [Finite ι]
     {L : Type*} [Field L] [Algebra ℚ L] (D : ι → ℤ)
     (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D)
-    (heven : ¬ ((∃ i, D i = -4) ∧ (∃ i, D i = 8) ∧ (∃ i, D i = -8)))
-    (root : ι → L)
+    (heven : ¬ ((∃ i, D i = -4) ∧ (∃ i, D i = 8) ∧ (∃ i, D i = -8))) (root : ι → L)
     (hroot : ∀ i, root i ^ 2 = algebraMap ℚ L ((primeDiscriminantRadicand (D i) : ℤ) : ℚ)) :
     Module.finrank ℚ (IntermediateField.adjoin ℚ (Set.range root)) = 2 ^ Nat.card ι :=
   finrank_adjoin_range hroot
@@ -278,8 +272,7 @@ This is the degree theorem in the form needed for genus-field generator lists co
 discriminants of a quadratic discriminant. -/
 theorem finrank_adjoin_roots_primeDiscriminantRadicands_of_forall_isEvenPrimeDiscriminant_eq
     {ι : Type*} [Finite ι] {L : Type*} [Field L] [Algebra ℚ L] (D : ι → ℤ)
-    (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D)
-    (heven_unique : ∀ i j,
+    (hD : ∀ i, IsPrimeDiscriminant (D i)) (hinj : Function.Injective D) (heven_unique : ∀ i j,
       IsEvenPrimeDiscriminant (D i) → IsEvenPrimeDiscriminant (D j) → D i = D j)
     (root : ι → L)
     (hroot : ∀ i, root i ^ 2 = algebraMap ℚ L ((primeDiscriminantRadicand (D i) : ℤ) : ℚ)) :

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Splitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminant/Splitting.lean
@@ -40,8 +40,7 @@ variable {K : Type*} [Field K] [NumberField K]
 prime `p` dividing none of the `D i`, `p` splits completely in `K` exactly when every `D i` is
 a quadratic residue modulo `p`. -/
 theorem ncard_primesOver_primeDiscriminantRadicands_iff {ι : Type*} [Finite ι]
-    (D : ι → ℤ) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 =
+    (D : ι → ℤ) (r : ι → K) (hr : ∀ i, r i ^ 2 =
       algebraMap ℤ K (TauCeti.Multiquadratic.primeDiscriminantRadicand (D i)))
     (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ∀ i, ¬ (p : ℤ) ∣ D i) :

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
@@ -53,8 +53,7 @@ theorem isPrimeDiscriminant_iff {D : ℤ} :
   Iff.rfl
 
 /-- Every even prime discriminant is a prime discriminant. -/
-theorem IsEvenPrimeDiscriminant.isPrimeDiscriminant {D : ℤ}
-    (hD : IsEvenPrimeDiscriminant D) :
+theorem IsEvenPrimeDiscriminant.isPrimeDiscriminant {D : ℤ} (hD : IsEvenPrimeDiscriminant D) :
     IsPrimeDiscriminant D :=
   Or.inl hD
 
@@ -79,8 +78,7 @@ theorem isPrimeDiscriminant_oddPrimeDiscriminant {p : ℕ} (hp : p.Prime) (hodd 
   Or.inr ⟨p, hp, hodd, rfl⟩
 
 /-- An odd prime discriminant is not one of the even prime discriminants. -/
-theorem not_isEvenPrimeDiscriminant_oddPrimeDiscriminant {p : ℕ}
-    (hodd : Odd p) :
+theorem not_isEvenPrimeDiscriminant_oddPrimeDiscriminant {p : ℕ} (hodd : Odd p) :
     ¬ IsEvenPrimeDiscriminant (oddPrimeDiscriminant p) := by
   intro hD
   have hp_ne_four : p ≠ 4 := by
@@ -139,8 +137,7 @@ theorem primeDiscriminantRadicand_of_isEvenPrimeDiscriminant {D : ℤ}
 
 /-- The radicand attached to an odd prime discriminant is the discriminant itself. -/
 @[simp]
-theorem primeDiscriminantRadicand_oddPrimeDiscriminant {p : ℕ}
-    (hodd : Odd p) :
+theorem primeDiscriminantRadicand_oddPrimeDiscriminant {p : ℕ} (hodd : Odd p) :
     primeDiscriminantRadicand (oddPrimeDiscriminant p) = oddPrimeDiscriminant p := by
   have hnot : ¬ (oddPrimeDiscriminant p = -4 ∨
       oddPrimeDiscriminant p = 8 ∨ oddPrimeDiscriminant p = -8) := by
@@ -149,8 +146,7 @@ theorem primeDiscriminantRadicand_oddPrimeDiscriminant {p : ℕ}
 
 /-- A prime discriminant is either its own radicand, or four times its radicand in the even
 cases. -/
-theorem primeDiscriminant_eq_radicand_or_eq_four_mul_radicand {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminant_eq_radicand_or_eq_four_mul_radicand {D : ℤ} (hD : IsPrimeDiscriminant D) :
     D = primeDiscriminantRadicand D ∨ D = 4 * primeDiscriminantRadicand D := by
   rcases hD with hD | ⟨p, _hp, hodd, rfl⟩
   · exact Or.inr <| by
@@ -180,16 +176,14 @@ theorem dvd_primeDiscriminant_iff_dvd_radicand (D : ℤ) (hq : q ≠ 2) :
 
 /-- Away from `2`, an indexed family of integers and its associated prime-discriminant
 radicands have the same unramifiedness condition at `q`. -/
-theorem forall_not_dvd_primeDiscriminant_iff_radicand {ι : Type*} (D : ι → ℤ)
-    (hq : q ≠ 2) :
+theorem forall_not_dvd_primeDiscriminant_iff_radicand {ι : Type*} (D : ι → ℤ) (hq : q ≠ 2) :
     (∀ i, ¬ (q : ℤ) ∣ D i) ↔
       ∀ i, ¬ (q : ℤ) ∣ primeDiscriminantRadicand (D i) := by
   refine forall_congr' fun i => ?_
   exact not_congr (dvd_primeDiscriminant_iff_dvd_radicand (q := q) (D i) hq)
 
 /-- The radicand attached to a prime discriminant is nonzero. -/
-theorem primeDiscriminantRadicand_ne_zero {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminantRadicand_ne_zero {D : ℤ} (hD : IsPrimeDiscriminant D) :
     primeDiscriminantRadicand D ≠ 0 := by
   rcases hD with hD | ⟨p, hp, hodd, rfl⟩
   · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hD]
@@ -198,8 +192,7 @@ theorem primeDiscriminantRadicand_ne_zero {D : ℤ}
     exact (oddPrimeDiscriminant_ne_zero).2 hp.ne_zero
 
 /-- The radicand attached to a prime discriminant is squarefree. -/
-theorem squarefree_primeDiscriminantRadicand {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem squarefree_primeDiscriminantRadicand {D : ℤ} (hD : IsPrimeDiscriminant D) :
     Squarefree (primeDiscriminantRadicand D) := by
   rcases hD with hD | ⟨p, hp, hodd, rfl⟩
   · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hD]
@@ -208,8 +201,7 @@ theorem squarefree_primeDiscriminantRadicand {D : ℤ}
     exact squarefree_oddPrimeDiscriminant hp.squarefree
 
 /-- The radicand attached to a prime discriminant is not a rational square. -/
-theorem not_isSquare_primeDiscriminantRadicand_rat {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem not_isSquare_primeDiscriminantRadicand_rat {D : ℤ} (hD : IsPrimeDiscriminant D) :
     ¬ IsSquare ((primeDiscriminantRadicand D : ℤ) : ℚ) := by
   rcases hD with hD | ⟨p, hp, hodd, rfl⟩
   · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hD]
@@ -222,8 +214,7 @@ theorem not_isSquare_primeDiscriminantRadicand_rat {D : ℤ}
         simpa [oddPrimeDiscriminant_natAbs] using hp.ne_one)
 
 /-- An odd prime discriminant has odd radicand congruent to `1` modulo `4`. -/
-theorem primeDiscriminantRadicand_mod_four_eq_one_of_odd {p : ℕ}
-    (hodd : Odd p) :
+theorem primeDiscriminantRadicand_mod_four_eq_one_of_odd {p : ℕ} (hodd : Odd p) :
     primeDiscriminantRadicand (oddPrimeDiscriminant p) % 4 = 1 := by
   rw [primeDiscriminantRadicand_oddPrimeDiscriminant hodd]
   exact oddPrimeDiscriminant_mod_four_eq_one hodd
@@ -247,8 +238,7 @@ theorem isEvenPrimeDiscriminant_or_primeDiscriminantRadicand_mod_four_eq_one {D 
 /-- The only prime discriminant whose radicand has absolute value `1` is `-4`. This is the
 small exceptional case in the radicand map: the odd prime-discriminant radicands have prime
 absolute value, and the other even prime-discriminant radicands have absolute value `2`. -/
-theorem primeDiscriminantRadicand_natAbs_eq_one_iff {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminantRadicand_natAbs_eq_one_iff {D : ℤ} (hD : IsPrimeDiscriminant D) :
     (primeDiscriminantRadicand D).natAbs = 1 ↔ D = -4 := by
   constructor
   · intro h
@@ -267,8 +257,7 @@ theorem primeDiscriminantRadicand_natAbs_eq_one_iff {D : ℤ}
 
 /-- Among prime discriminants, radicand `-1` comes only from the even prime discriminant
 `-4`. -/
-theorem primeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminantRadicand_eq_neg_one_iff {D : ℤ} (hD : IsPrimeDiscriminant D) :
     primeDiscriminantRadicand D = -1 ↔ D = -4 := by
   constructor
   · intro h
@@ -277,8 +266,7 @@ theorem primeDiscriminantRadicand_eq_neg_one_iff {D : ℤ}
     rw [h, primeDiscriminantRadicand_neg_four]
 
 /-- Among prime discriminants, radicand `2` comes only from the even prime discriminant `8`. -/
-theorem primeDiscriminantRadicand_eq_two_iff {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminantRadicand_eq_two_iff {D : ℤ} (hD : IsPrimeDiscriminant D) :
     primeDiscriminantRadicand D = 2 ↔ D = 8 := by
   constructor
   · intro h
@@ -295,8 +283,7 @@ theorem primeDiscriminantRadicand_eq_two_iff {D : ℤ}
 
 /-- Among prime discriminants, radicand `-2` comes only from the even prime discriminant
 `-8`. -/
-theorem primeDiscriminantRadicand_eq_neg_two_iff {D : ℤ}
-    (hD : IsPrimeDiscriminant D) :
+theorem primeDiscriminantRadicand_eq_neg_two_iff {D : ℤ} (hD : IsPrimeDiscriminant D) :
     primeDiscriminantRadicand D = -2 ↔ D = -8 := by
   constructor
   · intro h

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/RadicandSplitting.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/RadicandSplitting.lean
@@ -53,8 +53,7 @@ roots of a finite family of rational primes `p i`. If `q` is an odd rational pri
 every `p i`, then `q` splits completely in `K` exactly when every `p i` is a quadratic residue
 modulo `q`. -/
 theorem ncard_primesOver_sqrt_primes_iff {ι : Type*} [Finite ι] (p : ι → ℕ)
-    (hp : ∀ i, (p i).Prime) (r : ι → K)
-    (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (p i : ℤ))
+    (hp : ∀ i, (p i).Prime) (r : ι → K) (hr : ∀ i, r i ^ 2 = algebraMap ℤ K (p i : ℤ))
     (htop : IntermediateField.adjoin ℚ (Set.range r) = ⊤)
     {q : ℕ} [Fact q.Prime] (hodd : q ≠ 2) (hne : ∀ i, q ≠ p i) :
     (primesOver (span {(q : ℤ)}) (𝓞 K)).ncard = finrank ℚ K ↔
@@ -65,8 +64,7 @@ theorem ncard_primesOver_sqrt_primes_iff {ι : Type*} [Finite ι] (p : ι → �
 /-- The character condition for the radicands `2` and `3`, with the `√2` condition expanded
 using the supplementary law for `2`. -/
 private theorem forall_legendreSym_two_three_eq_one_iff_mod_eight {q : ℕ} [Fact q.Prime]
-    (htwo : q ≠ 2) :
-    (∀ i : Fin 2, legendreSym q ((![2, 3] : Fin 2 → ℕ) i : ℤ) = 1) ↔
+    (htwo : q ≠ 2) : (∀ i : Fin 2, legendreSym q ((![2, 3] : Fin 2 → ℕ) i : ℤ) = 1) ↔
       (q % 8 = 1 ∨ q % 8 = 7) ∧ legendreSym q (3 : ℤ) = 1 := by
   simp only [Fin.forall_fin_two]
   simpa [Multiquadratic.evenPrimeDiscriminantRadicand_eight] using

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Radicands.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Radicands.lean
@@ -46,10 +46,8 @@ namespace TauCeti.Multiquadratic
 /-- **Square-class independence of distinct primes.** If the selected `p i` are prime and pairwise
 distinct, then no nonempty subset product `∏_{i ∈ S} (p i : ℚ)` is a square in `ℚ`. This is the
 hypothesis the multiquadratic degree theorem `finrank_adjoin_range` consumes. -/
-theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι}
-    (hp : ∀ i ∈ S, (p i).Prime)
-    (hdist : Set.Pairwise (S : Set ι) (fun i j => p i ≠ p j))
-    (hS : S.Nonempty) :
+theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι} (hp : ∀ i ∈ S, (p i).Prime)
+    (hdist : Set.Pairwise (S : Set ι) (fun i j => p i ≠ p j)) (hS : S.Nonempty) :
     ¬ IsSquare (∏ i ∈ S, (p i : ℚ)) := by
   rw [← Nat.cast_prod, Rat.isSquare_natCast_iff]
   refine Squarefree.not_isSquare ?_ ?_
@@ -66,8 +64,7 @@ theorem not_isSquare_prod_primes {ι : Type*} (p : ι → ℕ) {S : Finset ι}
 `(√n)² = algebraMap ℚ ℝ n`. This supplies the `hroot` hypothesis that the multiquadratic degree and
 Galois-group theorems consume for the family of square roots of a prime family. It is the `0 ≤ n`
 special case of `sq_sqrt_intCast`. -/
-theorem sq_sqrt_natCast (n : ℕ) :
-    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
+theorem sq_sqrt_natCast (n : ℕ) : (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
   have h := sq_sqrt_intCast (n := (n : ℤ)) (Int.natCast_nonneg n)
   rwa [Int.cast_natCast, Int.cast_natCast] at h
 

--- a/TauCeti/NumberTheory/Multiquadratic/QuadraticSubfield.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/QuadraticSubfield.lean
@@ -81,8 +81,7 @@ private theorem prod_root_notMem_bot (hroot : ∀ i, root i ^ 2 = algebraMap K L
 /-- **A nonempty subset-product root generates a quadratic subfield.** When the subset product
 `∏_{i ∈ S} d i` of the radicands is not a square, the subset-product root of `S` lies outside `K`
 yet squares into `K`, so `[K(∏_{i ∈ S} root i) : K] = 2`. -/
-theorem finrank_adjoin_prod_root [NeZero (2 : K)]
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+theorem finrank_adjoin_prod_root [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     {S : Finset ι} (hSsq : ¬ IsSquare (∏ i ∈ S, d i)) :
     Module.finrank K (IntermediateField.adjoin K {∏ i ∈ S, root i}) = 2 := by
   have hx2 : (∏ i ∈ S, root i) ^ 2 ∈ (⊥ : IntermediateField K L) := by
@@ -101,11 +100,9 @@ theorem adjoin_prod_root_le (S : Finset ι) :
 /-- **Distinct subsets give distinct quadratic subfields.** Under square-class independence the map
 `S ↦ K(∏_{i ∈ S} root i)` from the nonempty subsets of the index type to the quadratic subfields of
 `M` is injective: if two nonempty subsets generate the same subfield, they are equal. -/
-theorem eq_of_adjoin_prod_root_eq [NeZero (2 : K)]
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+theorem eq_of_adjoin_prod_root_eq [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
-    {S T : Finset ι} (hS : S.Nonempty)
-    (hST : IntermediateField.adjoin K {∏ i ∈ S, root i}
+    {S T : Finset ι} (hS : S.Nonempty) (hST : IntermediateField.adjoin K {∏ i ∈ S, root i}
         = IntermediateField.adjoin K {∏ i ∈ T, root i}) :
     S = T := by
   classical

--- a/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/RelativeDegree.lean
@@ -130,8 +130,7 @@ degree that the genus-field constructions read off over the quadratic base. -/
 theorem finrank_top_over_intermediateField_of_finrank_eq_two [Finite ι] [NeZero (2 : K)]
     (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     (hindep : ∀ S : Finset ι, S.Nonempty → ¬ IsSquare (∏ i ∈ S, d i))
-    (F : IntermediateField K (adjoin K (Set.range root)))
-    (hF : Module.finrank K F = 2) :
+    (F : IntermediateField K (adjoin K (Set.range root))) (hF : Module.finrank K F = 2) :
     Module.finrank F (adjoin K (Set.range root)) = 2 ^ (Nat.card ι - 1) := by
   rw [finrank_top_over_intermediateField hroot hindep F]
   congr 1

--- a/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/SquareClass/Basic.lean
@@ -144,8 +144,7 @@ private theorem sqrtTower_sup_adjoin_eq_of_mem (root : ℕ → L) {n : ℕ}
 /-- Square-class reconstruction across one tower level: from `r * dₙ = s² * ∏_T dⱼ` with
 `dₙ ≠ 0` and `n ∉ T`, the radicand `r` equals `(s / dₙ)²` times the product over `insert n T`. -/
 private theorem eq_sq_mul_prod_insert_of_mul_radicand {d : ℕ → K} {n : ℕ} {r s : K}
-    {T : Finset ℕ} (hnT : n ∉ T) (hdn : d n ≠ 0)
-    (hmul : r * d n = s ^ 2 * ∏ j ∈ T, d j) :
+    {T : Finset ℕ} (hnT : n ∉ T) (hdn : d n ≠ 0) (hmul : r * d n = s ^ 2 * ∏ j ∈ T, d j) :
     r = (s / d n) ^ 2 * ∏ j ∈ insert n T, d j := by
   rw [Finset.prod_insert hnT]
   -- `r = (r * dₙ) / dₙ = (s² * ∏_T) / dₙ = (s / dₙ)² * (dₙ * ∏_T)`.
@@ -172,8 +171,7 @@ private theorem radicand_ne_zero_of_root_notMem (d : ℕ → K) (root : ℕ → 
 `n`-th tower and squares to `r · dₙ`, so the level-`n` descent hypothesis produces a
 representation of `r` over `Set.Iio (n + 1)` with `n` adjoined to the subset. -/
 private theorem exists_sq_mul_prod_of_eq_mul_root (d : ℕ → K) (root : ℕ → L)
-    {n : ℕ} {r : K} {y b : L}
-    (hroot : root n ^ 2 = algebraMap K L (d n)) (hdn0 : d n ≠ 0)
+    {n : ℕ} {r : K} {y b : L} (hroot : root n ^ 2 = algebraMap K L (d n)) (hdn0 : d n ≠ 0)
     (hb : b ∈ sqrtTower (K := K) root n) (heq : y = b * root n)
     (hy : y ^ 2 = algebraMap K L r)
     (ih : ∀ r : K, ∀ y : L, y ^ 2 = algebraMap K L r → y ∈ sqrtTower (K := K) root n →
@@ -345,8 +343,7 @@ theorem squareClass_of_sqrt_mem (c : ℕ → ℚ) (hc : ∀ j, 0 ≤ c j) :
 `(√n)² = algebraMap ℚ ℝ n`. This supplies the `hroot` hypothesis of the degree theorem for the real
 square roots of integer radicands. The natural-number form `sq_sqrt_natCast` is the special case
 `0 ≤ n`. -/
-theorem sq_sqrt_intCast {n : ℤ} (hn : 0 ≤ n) :
-    (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
+theorem sq_sqrt_intCast {n : ℤ} (hn : 0 ≤ n) : (Real.sqrt n) ^ 2 = algebraMap ℚ ℝ (n : ℚ) := by
   rw [Real.sq_sqrt (by exact_mod_cast hn), map_intCast]
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Classification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Classification.lean
@@ -68,8 +68,7 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
 /-- **A nonempty subset-product subfield of `M` is quadratic.** Computed inside `M`, the simple
 extension `K(∏_{i ∈ S} root i)` has the same degree as its `L`-level counterpart, which is `2`
 when the radicand product `∏_{i ∈ S} d i` is not a square. -/
-theorem finrank_adjoin_prodRootMem [NeZero (2 : K)]
-    (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
+theorem finrank_adjoin_prodRootMem [NeZero (2 : K)] (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
     {S : Finset ι} (hSsq : ¬ IsSquare (∏ i ∈ S, d i)) :
     Module.finrank K (adjoin K {prodRootMem (K := K) root S}) = 2 := by
   -- Transport the degree across the `M`-into-`L` lift algebra equivalence.
@@ -83,8 +82,7 @@ variable (hroot : ∀ i, root i ^ 2 = algebraMap K L (d i))
 /-- **The subset-product quadratic subfield of `M` attached to a nonempty subset.** Under
 square-class independence, each nonempty subset `S` of the index type names the quadratic subfield
 `K(∏_{i ∈ S} root i)` of `M = K(rootᵢ : i)`. -/
-@[expose] def quadraticSubfieldOfFinset [NeZero (2 : K)]
-    (S : {S : Finset ι // S.Nonempty}) :
+@[expose] def quadraticSubfieldOfFinset [NeZero (2 : K)] (S : {S : Finset ι // S.Nonempty}) :
     {F : IntermediateField K (adjoin K (Set.range root)) // Module.finrank K F = 2} :=
   ⟨adjoin K {prodRootMem (K := K) root S.1}, finrank_adjoin_prodRootMem hroot (hindep S.1 S.2)⟩
 

--- a/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Subfield/Degree.lean
@@ -61,8 +61,7 @@ variable {K L : Type*} [Field K] [Field L] [Algebra K L] {ι : Type*}
   {d : ι → K} {root : ι → L}
 
 /-- The cardinality of an `𝔽₂`-subspace `U` of `ι → ℤ/2` is `2` to its dimension. -/
-private theorem card_submodule_eq_pow_finrank [Finite ι]
-    (U : Submodule (ZMod 2) (ι → ZMod 2)) :
+private theorem card_submodule_eq_pow_finrank [Finite ι] (U : Submodule (ZMod 2) (ι → ZMod 2)) :
     Nat.card U = 2 ^ Module.finrank (ZMod 2) U := by
   classical
   haveI : Fact (Nat.Prime 2) := ⟨Nat.prime_two⟩


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/NumberTheory/Multiquadratic/`: 85 joins across 26 files, `-85` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 26 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Width is measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports. Widest resulting line is exactly 100 codepoints (`Subfield/Classification.lean:130`), at the limit and legal; nothing exceeds it.

Scope is the whole directory so the convention lands uniformly and does not invite a follow-up over the leftovers. No open PR touches `NumberTheory/Multiquadratic`.

Gates: `lake build` (6166 jobs) · `lake exe axioms` (19325 declarations, allowlist clean) · `lake exe module-system` (1057 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none