### PR TITLE
style(InnerProductSpace): pack underfilled signature lines

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Ball.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Ball.lean
@@ -62,8 +62,7 @@ theorem harmonicOnNhd_comp_add_right_ball_zero_iff (x : E) (r : ℝ) {f : E → 
 
 /-- Harmonicity on a neighbourhood of `Metric.ball x r` is equivalent to harmonicity of the
 normalized function `y ↦ f (x + r • y)` on a neighbourhood of the unit ball. -/
-theorem harmonicOnNhd_comp_const_add_smul_ball_iff (x : E) {r : ℝ} (hr : 0 < r)
-    {f : E → F} :
+theorem harmonicOnNhd_comp_const_add_smul_ball_iff (x : E) {r : ℝ} (hr : 0 < r) {f : E → F} :
     HarmonicOnNhd (fun y ↦ f (x + r • y)) (Metric.ball 0 1) ↔
       HarmonicOnNhd f (Metric.ball x r) := by
   simpa [Real.norm_of_nonneg hr.le] using

--- a/TauCeti/Analysis/InnerProductSpace/Harmonic/Dilation.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Harmonic/Dilation.lean
@@ -71,8 +71,7 @@ omit [FiniteDimensional ℝ E] in
 
 For `c ≠ 0`, the function `y ↦ f (AffineMap.homothety a c y)` is `C²` at `x` iff `f` is `C²`
 at `AffineMap.homothety a c x`. -/
-private lemma contDiffAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F}
-    {x : E} :
+private lemma contDiffAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F} {x : E} :
     ContDiffAt ℝ 2 (fun y : E ↦ f (AffineMap.homothety a c y)) x ↔
       ContDiffAt ℝ 2 f (AffineMap.homothety a c x) := by
   constructor
@@ -105,8 +104,7 @@ private lemma contDiffAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 
 For `c ≠ 0`, the Laplacian of `y ↦ f (AffineMap.homothety a c y)` vanishes near `x` iff the
 Laplacian of `f` vanishes near `AffineMap.homothety a c x`. -/
 private lemma laplacian_eventuallyEq_zero_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0)
-    {f : E → F} {x : E} :
-    (Δ (fun y : E ↦ f (AffineMap.homothety a c y)) =ᶠ[𝓝 x] 0) ↔
+    {f : E → F} {x : E} : (Δ (fun y : E ↦ f (AffineMap.homothety a c y)) =ᶠ[𝓝 x] 0) ↔
       (Δ f =ᶠ[𝓝 (AffineMap.homothety a c x)] 0) := by
   -- `e` realises the homothety as a homeomorphism so we can transport the neighbourhood filter.
   let e : E ≃ₜ E := homothetyHomeomorph a c hc
@@ -151,8 +149,7 @@ private lemma laplacian_eventuallyEq_zero_comp_homothety_right_iff (a : E) (c : 
 
 For `c ≠ 0`, the function `y ↦ f (AffineMap.homothety a c y)` is harmonic at `x` iff `f`
 is harmonic at `AffineMap.homothety a c x`. -/
-theorem harmonicAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F}
-    {x : E} :
+theorem harmonicAt_comp_homothety_right_iff (a : E) (c : ℝ) (hc : c ≠ 0) {f : E → F} {x : E} :
     HarmonicAt (fun y ↦ f (AffineMap.homothety a c y)) x ↔
       HarmonicAt f (AffineMap.homothety a c x) :=
   ⟨fun hf ↦ ⟨(contDiffAt_comp_homothety_right_iff a c hc).1 hf.1,
@@ -196,8 +193,7 @@ theorem harmonicAt_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F} {x
   rw [hfun, harmonicAt_comp_homothety_right_iff (0 : E) c hc, hx]
 
 /-- Harmonicity on a neighbourhood of a set is invariant under nonzero dilation. -/
-theorem harmonicOnNhd_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F}
-    {s : Set E} :
+theorem harmonicOnNhd_comp_smul_right_iff (c : ℝ) (hc : c ≠ 0) {f : E → F} {s : Set E} :
     HarmonicOnNhd (fun y ↦ f (c • y)) ((fun y ↦ c • y) ⁻¹' s) ↔
       HarmonicOnNhd f s := by
   have hfun : (fun y : E ↦ f (c • y)) =
@@ -236,8 +232,7 @@ theorem harmonicAt_comp_const_add_smul_iff (x : E) {c : ℝ} (hc : c ≠ 0) {f :
 
 For `c ≠ 0`, the function `z ↦ f (x + c • z)` is harmonic near `(fun z ↦ x + c • z) ⁻¹' s`
 iff `f` is harmonic near `s`. -/
-theorem harmonicOnNhd_comp_const_add_smul_iff (x : E) {c : ℝ} (hc : c ≠ 0) {f : E → F}
-    {s : Set E} :
+theorem harmonicOnNhd_comp_const_add_smul_iff (x : E) {c : ℝ} (hc : c ≠ 0) {f : E → F} {s : Set E} :
     HarmonicOnNhd (fun z ↦ f (x + c • z)) ((fun z ↦ x + c • z) ⁻¹' s) ↔
       HarmonicOnNhd f s := by
   have hfun : (fun z : E ↦ f (x + c • z)) = fun z ↦ (fun w : E ↦ f (w + x)) (c • z) := by

--- a/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
+++ b/TauCeti/Analysis/InnerProductSpace/HilbertBasisMap.lean
@@ -38,15 +38,13 @@ protected noncomputable def _root_.HilbertBasis.mapₗᵢ
 
 /-- The coordinate representation of `b.mapₗᵢ e` is `b.repr` after applying `e.symm`. -/
 @[simp]
-theorem _root_.HilbertBasis.repr_mapₗᵢ
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+theorem _root_.HilbertBasis.repr_mapₗᵢ (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e).repr = e.symm.trans b.repr :=
   congrArg _root_.HilbertBasis.repr (_root_.HilbertBasis.mapₗᵢ.eq_1 b e)
 
 /-- The `i`th vector of the transported basis is the image of the `i`th vector. -/
 @[simp]
-theorem _root_.HilbertBasis.mapₗᵢ_apply
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (i : ι) :
+theorem _root_.HilbertBasis.mapₗᵢ_apply (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) (i : ι) :
     b.mapₗᵢ e i = e (b i) :=
   by
     classical
@@ -57,8 +55,7 @@ theorem _root_.HilbertBasis.mapₗᵢ_apply
 
 /-- Function-level form of `HilbertBasis.mapₗᵢ_apply`. -/
 @[simp]
-theorem _root_.HilbertBasis.coe_mapₗᵢ
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+theorem _root_.HilbertBasis.coe_mapₗᵢ (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     ⇑(b.mapₗᵢ e) = e ∘ b :=
   funext (b.mapₗᵢ_apply e)
 
@@ -80,16 +77,14 @@ theorem _root_.HilbertBasis.mapₗᵢ_trans {G : Type*} [NormedAddCommGroup G] [
 
 /-- Transporting a Hilbert basis across an isometry and then back across the inverse isometry
 recovers the original basis. -/
-theorem _root_.HilbertBasis.mapₗᵢ_symm
-    (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
+theorem _root_.HilbertBasis.mapₗᵢ_symm (b : _root_.HilbertBasis ι 𝕜 E) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e).mapₗᵢ e.symm = b := by
   rw [_root_.HilbertBasis.mapₗᵢ_trans]
   simp
 
 /-- Transporting a Hilbert basis back across an inverse isometry and then forward again recovers
 the original basis. -/
-theorem _root_.HilbertBasis.mapₗᵢ_symm_self
-    (b : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
+theorem _root_.HilbertBasis.mapₗᵢ_symm_self (b : _root_.HilbertBasis ι 𝕜 F) (e : E ≃ₗᵢ[𝕜] F) :
     (b.mapₗᵢ e.symm).mapₗᵢ e = b := by
   rw [_root_.HilbertBasis.mapₗᵢ_trans]
   simp

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -360,8 +360,7 @@ theorem orthogonal_span_range_L2piMul_eq_bot {κ : ι → Type*}
 
 /-- **The `Fintype`-indexed product Hilbert basis.** Pointwise products of coordinatewise Hilbert
 bases form a Hilbert basis of `L²(Measure.pi μ)`, indexed by the dependent function type. -/
-noncomputable def piHilbertBasis {κ : ι → Type*}
-    (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) :
+noncomputable def piHilbertBasis {κ : ι → Type*} (b : ∀ i, HilbertBasis (κ i) 𝕜 (Lp 𝕜 2 (μ i))) :
     HilbertBasis (∀ i, κ i) 𝕜 (Lp 𝕜 2 (Measure.pi μ)) :=
   HilbertBasis.mkOfOrthogonalEqBot (orthonormal_L2piMul fun i => (b i).orthonormal)
     (orthogonal_span_range_L2piMul_eq_bot b)

--- a/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Product.lean
@@ -183,8 +183,7 @@ theorem inner_L2prodMul [SFinite μ] [SFinite ν] (F₁ F₂ : Lp 𝕜 2 μ) (G�
 `L²(ν)`, their pointwise products form an orthonormal family of `L²(μ ⊗ ν)`, indexed by the product
 of index types. -/
 theorem orthonormal_L2prodMul [SFinite μ] [SFinite ν] {ι₁ ι₂ : Type*}
-    {b : ι₁ → Lp 𝕜 2 μ} {c : ι₂ → Lp 𝕜 2 ν}
-    (hb : Orthonormal 𝕜 b) (hc : Orthonormal 𝕜 c) :
+    {b : ι₁ → Lp 𝕜 2 μ} {c : ι₂ → Lp 𝕜 2 ν} (hb : Orthonormal 𝕜 b) (hc : Orthonormal 𝕜 c) :
     Orthonormal 𝕜 (fun ij : ι₁ × ι₂ => L2prodMul (b ij.1) (c ij.2)) := by
   classical
   rw [orthonormal_iff_ite] at hb hc ⊢
@@ -251,8 +250,7 @@ theorem inner_L2prodMul_eq_zero_of_forall_basis [SFinite μ] [SFinite ν] {ι₁
 
 /-- The tensor of two indicators is the indicator of the rectangle, so orthogonality to every
 elementary tensor makes the integral over every finite-measure rectangle vanish. -/
-theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν]
-    {h : Lp 𝕜 2 (μ.prod ν)}
+theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν] {h : Lp 𝕜 2 (μ.prod ν)}
     (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
     {A : Set α} (hA : MeasurableSet A) (hμA : μ A ≠ ⊤)
     {B : Set β} (hB : MeasurableSet B) (hνB : ν B ≠ ⊤) :
@@ -277,8 +275,7 @@ theorem setIntegral_prod_eq_zero_of_forall_inner [SFinite μ] [SFinite ν]
 /-- **Orthogonality kills every finite-measure set integral.** Exhaust the product space by finite
 boxes `spanningSets μ n ×ˢ spanningSets ν n`, run the Dynkin step inside each box, and pass to the
 monotone limit. -/
-theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν]
-    {h : Lp 𝕜 2 (μ.prod ν)}
+theorem setIntegral_eq_zero_of_forall_inner [SigmaFinite μ] [SigmaFinite ν] {h : Lp 𝕜 2 (μ.prod ν)}
     (hz : ∀ (F : Lp 𝕜 2 μ) (G : Lp 𝕜 2 ν), inner 𝕜 (L2prodMul F G) h = 0)
     (u : Set (α × β)) (hu : MeasurableSet u) (hfin : (μ.prod ν) u < ⊤) :
     ∫ p in u, h p ∂(μ.prod ν) = 0 := by
@@ -330,8 +327,7 @@ trivial orthogonal complement in `L²(μ ⊗ ν)`: a vector orthogonal to all of
 every elementary tensor, hence integrates to zero on every rectangle, hence on every finite-measure
 set, hence vanishes. -/
 theorem orthogonal_span_range_L2prodMul_eq_bot [SigmaFinite μ] [SigmaFinite ν] {ι₁ ι₂ : Type*}
-    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) :
-    (Submodule.span 𝕜
+    (b₁ : HilbertBasis ι₁ 𝕜 (Lp 𝕜 2 μ)) (b₂ : HilbertBasis ι₂ 𝕜 (Lp 𝕜 2 ν)) : (Submodule.span 𝕜
       (Set.range (fun ij : ι₁ × ι₂ => L2prodMul (b₁ ij.1) (b₂ ij.2))))ᗮ = ⊥ := by
   refine (Submodule.eq_bot_iff _).2 fun h hh => ?_
   rw [Submodule.mem_orthogonal] at hh

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/Comparison.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/Comparison.lean
@@ -62,8 +62,7 @@ theorem le_of_laplacian_le_of_le_frontier (hK : IsCompact K)
     (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ g x ≤ Δ f x)
-    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
+    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ g x ≤ Δ f x) (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
     ∀ ⦃x⦄, x ∈ K → f x ≤ g x := by
   intro x hxK
   -- Bound the difference `f - g` above by `0` via the weak maximum principle.
@@ -89,8 +88,7 @@ theorem eqOn_of_laplacian_eqOn_of_eqOn_frontier (hK : IsCompact K)
     (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
     (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x = Δ g x)
-    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x = g x) :
+    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x = Δ g x) (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x = g x) :
     Set.EqOn f g K := by
   intro x hxK
   refine le_antisymm ?_ ?_

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/DriftMaximumPrinciple.lean
@@ -269,8 +269,7 @@ bounded there (`‖b x‖ ≤ β`), and `0 ≤ Δ f x + fderiv ℝ f x (b x)` (a
 `Δ + b·∇`), then any bound `m` that `f` respects on `frontier K` bounds `f` on all of `K`. -/
 theorem le_of_laplacian_add_fderiv_nonneg_le_frontier {K : Set E} (hK : IsCompact K)
     {f : E → ℝ} {b : E → E} {β m : ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ Δ f x + fderiv ℝ f x (b x))
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
     ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
@@ -294,8 +293,7 @@ theorem le_of_laplacian_add_fderiv_nonneg_le_frontier {K : Set E} (hK : IsCompac
 (`Δ f x + fderiv ℝ f x (b x) ≤ 0`). -/
 theorem ge_of_laplacian_add_fderiv_nonpos_ge_frontier {K : Set E} (hK : IsCompact K)
     {f : E → ℝ} {b : E → E} {β m : ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x + fderiv ℝ f x (b x) ≤ 0)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → m ≤ f x) :
     ∀ ⦃x⦄, x ∈ K → m ≤ f x := by
@@ -317,8 +315,7 @@ theorem le_of_laplacian_add_fderiv_le_laplacian_add_fderiv_of_le_frontier {K : S
     (hK : IsCompact K) {f g : E → ℝ} {b : E → E} {β : ℝ}
     (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hL : ∀ ⦃x⦄, x ∈ interior K →
       Δ g x + fderiv ℝ g x (b x) ≤ Δ f x + fderiv ℝ f x (b x))
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
@@ -338,11 +335,9 @@ theorem le_of_laplacian_add_fderiv_le_laplacian_add_fderiv_of_le_frontier {K : S
 /-- **Uniqueness principle for `Δ + b·∇`.** Functions with equal operator values for the same
 bounded drift and equal frontier data agree throughout the compact set. -/
 theorem eqOn_of_laplacian_add_fderiv_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
-    {f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K)
-    (hgcont : ContinuousOn g K)
+    {f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hL : ∀ ⦃x⦄, x ∈ interior K →
       Δ f x + fderiv ℝ f x (b x) = Δ g x + fderiv ℝ g x (b x))
     (hbdry : Set.EqOn f g (frontier K)) :
@@ -358,8 +353,7 @@ theorem eqOn_of_laplacian_add_fderiv_eq_of_eqOn_frontier {K : Set E} (hK : IsCom
 on a nonempty compact set attains a maximum on the frontier. -/
 theorem exists_mem_frontier_isMaxOn_of_laplacian_add_fderiv_nonneg {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} {b : E → E} {β : ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ Δ f x + fderiv ℝ f x (b x)) :
     ∃ x ∈ frontier K, IsMaxOn f K x := by
   exact exists_mem_frontier_isMaxOn_of_le_frontier hK hne hcont fun hbdry =>
@@ -369,8 +363,7 @@ theorem exists_mem_frontier_isMaxOn_of_laplacian_add_fderiv_nonneg {K : Set E} (
 drift on a nonempty compact set attains a minimum on the frontier. -/
 theorem exists_mem_frontier_isMinOn_of_laplacian_add_fderiv_nonpos {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} {b : E → E} {β : ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x + fderiv ℝ f x (b x) ≤ 0) :
     ∃ x ∈ frontier K, IsMinOn f K x := by
   obtain ⟨z, hzfr, hzmax⟩ := exists_mem_frontier_isMaxOn_of_laplacian_add_fderiv_nonneg

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -50,8 +50,7 @@ If `c` is nonnegative, `b` has norm at most `β` on the interior of a compact se
 bound on the whole set. -/
 theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompact K)
     {c f : E → ℝ} {b : E → E} {β m : ℝ} (hm : 0 ≤ m) (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
     (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
     (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x + fderiv ℝ f x (b x))
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
@@ -106,10 +105,8 @@ theorem le_of_mul_le_laplacian_add_fderiv_le_frontier {K : Set E} (hK : IsCompac
 `le_of_mul_le_laplacian_add_fderiv_le_frontier`. -/
 theorem ge_of_laplacian_add_fderiv_le_mul_ge_frontier {K : Set E} (hK : IsCompact K)
     {c f : E → ℝ} {b : E → E} {β m : ℝ} (hm : m ≤ 0) (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
-    (hsuper : ∀ ⦃x⦄, x ∈ interior K →
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β) (hsuper : ∀ ⦃x⦄, x ∈ interior K →
       Δ f x + fderiv ℝ f x (b x) ≤ c x * f x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → m ≤ f x) :
     ∀ ⦃x⦄, x ∈ K → m ≤ f x := by
@@ -128,10 +125,8 @@ theorem ge_of_laplacian_add_fderiv_le_mul_ge_frontier {K : Set E} (hK : IsCompac
 nonnegative bound for its absolute value on the frontier. -/
 theorem abs_le_of_laplacian_add_fderiv_eq_mul_abs_le_frontier {K : Set E} (hK : IsCompact K)
     {c f : E → ℝ} {b : E → E} {β M : ℝ} (hM : 0 ≤ M) (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
-    (hsol : ∀ ⦃x⦄, x ∈ interior K →
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β) (hsol : ∀ ⦃x⦄, x ∈ interior K →
       Δ f x + fderiv ℝ f x (b x) = c x * f x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → |f x| ≤ M) :
     ∀ ⦃x⦄, x ∈ K → |f x| ≤ M := by
@@ -150,10 +145,8 @@ theorem le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le
     {K : Set E} (hK : IsCompact K) {c f g : E → ℝ}
     {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
-    (hL : ∀ ⦃x⦄, x ∈ interior K →
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β) (hL : ∀ ⦃x⦄, x ∈ interior K →
       Δ g x + fderiv ℝ g x (b x) - c x * g x ≤
         Δ f x + fderiv ℝ f x (b x) - c x * f x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
@@ -171,13 +164,10 @@ theorem le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le
 /-- **Dirichlet uniqueness for `-Δ - b·∇ + c`.** Equal operator values and equal frontier data
 force two functions to agree throughout the compact set. -/
 theorem eqOn_of_laplacian_add_fderiv_sub_mul_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
-    {c f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K)
-    (hgcont : ContinuousOn g K)
+    {c f g : E → ℝ} {b : E → E} {β : ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β)
-    (hL : ∀ ⦃x⦄, x ∈ interior K →
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hb : ∀ ⦃x⦄, x ∈ interior K → ‖b x‖ ≤ β) (hL : ∀ ⦃x⦄, x ∈ interior K →
       Δ f x + fderiv ℝ f x (b x) - c x * f x =
         Δ g x + fderiv ℝ g x (b x) - c x * g x)
     (hbdry : Set.EqOn f g (frontier K)) : Set.EqOn f g K := by

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/MaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/MaximumPrinciple.lean
@@ -76,8 +76,7 @@ and satisfies `0 < Δ f x` throughout `interior K`, then some maximum point of `
 `frontier K`. -/
 theorem exists_mem_frontier_isMaxOn_of_laplacian_pos {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 < Δ f x) :
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 < Δ f x) :
     ∃ x ∈ frontier K, IsMaxOn f K x := by
   exact exists_mem_frontier_isMaxOn_of_forall_mem_interior_not_isLocalMax hK hne hcont
     fun {x} hxint => not_isLocalMax_of_laplacian_pos (hcd (x := x) hxint) (hlap (x := x) hxint)
@@ -89,8 +88,7 @@ and satisfies `Δ f x < 0` throughout `interior K`, then some minimum point of `
 `frontier K`. -/
 theorem exists_mem_frontier_isMinOn_of_laplacian_neg {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x < 0) :
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x < 0) :
     ∃ x ∈ frontier K, IsMinOn f K x := by
   exact exists_mem_frontier_isMinOn_of_forall_mem_interior_not_isLocalMin hK hne hcont
     fun {x} hxint => not_isLocalMin_of_laplacian_neg (hcd (x := x) hxint) (hlap (x := x) hxint)

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/WeakMaximumPrinciple.lean
@@ -163,8 +163,7 @@ finite-dimensional real inner product space attains a maximum on the frontier. T
 `exists_mem_frontier_isMaxOn_of_laplacian_pos` for the strict case. -/
 theorem exists_mem_frontier_isMaxOn_of_laplacian_nonneg {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ Δ f x) :
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hlap : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ Δ f x) :
     ∃ x ∈ frontier K, IsMaxOn f K x := by
   exact exists_mem_frontier_isMaxOn_of_le_frontier hK hne hcont fun hbdry =>
     le_of_laplacian_nonneg_le_frontier hK hcont hcd hlap hbdry
@@ -173,8 +172,7 @@ theorem exists_mem_frontier_isMaxOn_of_laplacian_nonneg {K : Set E} (hK : IsComp
 finite-dimensional real inner product space attains a minimum on the frontier. -/
 theorem exists_mem_frontier_isMinOn_of_laplacian_nonpos {K : Set E} (hK : IsCompact K)
     (hne : K.Nonempty) {f : E → ℝ} (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x ≤ 0) :
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x ≤ 0) :
     ∃ x ∈ frontier K, IsMinOn f K x := by
   obtain ⟨z, hzfr, hzmax⟩ := exists_mem_frontier_isMaxOn_of_laplacian_nonneg hK hne hcont.neg
     (fun y hy => (hcd hy).neg)

--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/ZerothOrderMaximumPrinciple.lean
@@ -70,8 +70,7 @@ The nonnegativity of `m` cannot be dropped once `c ≠ 0`; it encodes the `sup u
 of the estimate. -/
 theorem le_of_mul_le_laplacian_le_frontier {K : Set E} (hK : IsCompact K) {c f : E → ℝ} {m : ℝ}
     (hm : 0 ≤ m) (hcont : ContinuousOn f K) (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x) (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ m) :
     ∀ ⦃x⦄, x ∈ K → f x ≤ m := by
   intro x hxK
@@ -110,8 +109,7 @@ the two-function form of `le_of_mul_le_laplacian_le_frontier`. -/
 theorem le_of_mul_le_laplacian_le_of_le_frontier {K : Set E} (hK : IsCompact K) {c f g : E → ℝ}
     (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
     (hsub : ∀ ⦃x⦄, x ∈ interior K → c x * f x ≤ Δ f x)
     (hsuper : ∀ ⦃x⦄, x ∈ interior K → Δ g x ≤ c x * g x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x ≤ g x) :
@@ -138,8 +136,7 @@ The dual of `le_of_mul_le_laplacian_le_frontier`: a continuous, `C²`, supersolu
 lower bound it respects on `frontier K`. -/
 theorem ge_of_laplacian_le_mul_ge_frontier {K : Set E} (hK : IsCompact K) {c f : E → ℝ} {m : ℝ}
     (hm : m ≤ 0) (hcont : ContinuousOn f K) (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hsuper : ∀ ⦃x⦄, x ∈ interior K → Δ f x ≤ c x * f x)
+    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x) (hsuper : ∀ ⦃x⦄, x ∈ interior K → Δ f x ≤ c x * f x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → m ≤ f x) :
     ∀ ⦃x⦄, x ∈ K → m ≤ f x := by
   intro x hxK
@@ -158,10 +155,8 @@ theorem ge_of_laplacian_le_mul_ge_frontier {K : Set E} (hK : IsCompact K) {c f :
 `frontier K`. -/
 theorem abs_le_of_laplacian_eq_mul_abs_le_frontier {K : Set E} (hK : IsCompact K) {c f : E → ℝ}
     {M : ℝ} (hM : 0 ≤ M) (hcont : ContinuousOn f K)
-    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
-    (hsol : ∀ ⦃x⦄, x ∈ interior K → Δ f x = c x * f x)
-    (hbdry : ∀ ⦃x⦄, x ∈ frontier K → |f x| ≤ M) :
+    (hcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hsol : ∀ ⦃x⦄, x ∈ interior K → Δ f x = c x * f x) (hbdry : ∀ ⦃x⦄, x ∈ frontier K → |f x| ≤ M) :
     ∀ ⦃x⦄, x ∈ K → |f x| ≤ M := by
   intro x hxK
   rw [abs_le]
@@ -179,8 +174,7 @@ they agree on all of `K`. -/
 theorem eqOn_of_laplacian_sub_mul_eq_of_eqOn_frontier {K : Set E} (hK : IsCompact K)
     {c f g : E → ℝ} (hfcont : ContinuousOn f K) (hgcont : ContinuousOn g K)
     (hfcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 f x)
-    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x)
-    (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
+    (hgcd : ∀ ⦃x⦄, x ∈ interior K → ContDiffAt ℝ 2 g x) (hc : ∀ ⦃x⦄, x ∈ interior K → 0 ≤ c x)
     (hlap : ∀ ⦃x⦄, x ∈ interior K → Δ f x - c x * f x = Δ g x - c x * g x)
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → f x = g x) :
     Set.EqOn f g K := by

--- a/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
+++ b/TauCeti/Analysis/InnerProductSpace/LaxMilgram.lean
@@ -82,8 +82,7 @@ theorem apply_solutionOfInner_eq_inner (hB : IsCoercive B) (F v : V) :
   simp [solutionOfInner]
 
 /-- A vector satisfying the represented variational equation is the Lax--Milgram solution. -/
-theorem eq_solutionOfInner (hB : IsCoercive B) {F u : V}
-    (hu : ∀ v : V, B u v = ⟪F, v⟫_ℝ) :
+theorem eq_solutionOfInner (hB : IsCoercive B) {F u : V} (hu : ∀ v : V, B u v = ⟪F, v⟫_ℝ) :
     u = solutionOfInner hB F := by
   apply hB.continuousLinearEquivOfBilin.injective
   apply ext_inner_right ℝ

--- a/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
+++ b/TauCeti/Analysis/InnerProductSpace/PolynomialCompleteness.lean
@@ -49,8 +49,7 @@ variable {𝕜 : Type*} [RCLike 𝕜]
 
 /-- Every polynomial lies in `L²` of a measure carrying one finite exponential moment. -/
 theorem memLp_two_algebraMap_eval {ν : Measure ℝ}
-    (hexp : ∃ a : ℝ, 0 < a ∧ Integrable (fun x : ℝ => Real.exp (a * |x|)) ν)
-    (q : Polynomial ℝ) :
+    (hexp : ∃ a : ℝ, 0 < a ∧ Integrable (fun x : ℝ => Real.exp (a * |x|)) ν) (q : Polynomial ℝ) :
     MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) (q.eval x)) 2 ν :=
   memLp_two_algebraMap_eval_of_forall_integrable_pow (𝕜 := 𝕜)
     (integrable_pow_of_exp_moment hexp) q

--- a/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
+++ b/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
@@ -96,8 +96,7 @@ private theorem integral_mul_withDensity {μ : Measure α}
 /-- The `w·μ`-integral of the product of two normalized real functions is the Kronecker delta. -/
 private theorem integral_bareNormalized_real {μ : Measure α}
     (hwnn : ∀ᵐ x ∂μ, 0 ≤ w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
-    (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
-    (m n : ℕ) :
+    (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0) (m n : ℕ) :
     (∫ x, (f m x / Real.sqrt (c m)) * (f n x / Real.sqrt (c n))
         ∂(μ.withDensity (fun x => ENNReal.ofReal (w x))))
       = if m = n then 1 else 0 := by
@@ -168,8 +167,7 @@ noncomputable def hilbertBasisOfWeightedMeasure {μ : Measure α}
     (hwnn : ∀ᵐ x ∂μ, 0 ≤ w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) (f n x / Real.sqrt (c n))) 2
-      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
-    (hcomplete :
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (hcomplete :
       (Submodule.span 𝕜 (Set.range (bareNormalizedLp (𝕜 := 𝕜) f w c hmem)))ᗮ = ⊥) :
     HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (μ.withDensity (fun x => ENNReal.ofReal (w x)))) :=
   HilbertBasis.mkOfOrthogonalEqBot
@@ -180,8 +178,7 @@ theorem coe_hilbertBasisOfWeightedMeasure {μ : Measure α}
     (hwnn : ∀ᵐ x ∂μ, 0 ≤ w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) (f n x / Real.sqrt (c n))) 2
-      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
-    (hcomplete :
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (hcomplete :
       (Submodule.span 𝕜 (Set.range (bareNormalizedLp (𝕜 := 𝕜) f w c hmem)))ᗮ = ⊥) :
     ⇑(hilbertBasisOfWeightedMeasure f w c hwnn hwm hc horth hmem hcomplete)
       = bareNormalizedLp (𝕜 := 𝕜) f w c hmem :=
@@ -194,8 +191,7 @@ noncomputable def hilbertBasisOfOrthogonalSystem {μ : Measure α}
     (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) (f n x / Real.sqrt (c n))) 2
-      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
-    (hcomplete :
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (hcomplete :
       (Submodule.span 𝕜 (Set.range (bareNormalizedLp (𝕜 := 𝕜) f w c hmem)))ᗮ = ⊥) :
     HilbertBasis ℕ 𝕜 (Lp 𝕜 2 μ) :=
   (hilbertBasisOfWeightedMeasure f w c (hwpos.mono fun _ hx => hx.le) hwm hc horth hmem
@@ -207,8 +203,7 @@ theorem coe_hilbertBasisOfOrthogonalSystem {μ : Measure α}
     (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
     (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
     (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) (f n x / Real.sqrt (c n))) 2
-      (μ.withDensity (fun x => ENNReal.ofReal (w x))))
-    (hcomplete :
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (hcomplete :
       (Submodule.span 𝕜 (Set.range (bareNormalizedLp (𝕜 := 𝕜) f w c hmem)))ᗮ = ⊥) (n : ℕ) :
     hilbertBasisOfOrthogonalSystem f w c hwpos hwm hc horth hmem hcomplete n
       = weightL2Isometry μ w hwpos hwm (bareNormalizedLp (𝕜 := 𝕜) f w c hmem n) := by


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/Analysis/InnerProductSpace/`: 52 joins across 14 files, `-52` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 14 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Width is measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports. Widest resulting line is exactly 100 codepoints (`WeightedOrthogonalBasis.lean:187`), at the limit and legal; nothing exceeds it.

Scope is the whole directory so the convention lands uniformly and does not invite a follow-up over the leftovers. No open PR touches `Analysis/InnerProductSpace`.

Gates: `lake build` (6166 jobs) · `lake exe axioms` (19325 declarations, allowlist clean) · `lake exe module-system` (1057 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none