### PR TITLE
style(Analysis): pack underfilled signature lines

### DIFF
--- a/TauCeti/Analysis/Bochner/CharFun/PosDef.lean
+++ b/TauCeti/Analysis/Bochner/CharFun/PosDef.lean
@@ -70,8 +70,7 @@ private theorem exp_mul_conj_exp_inner (y a b : E) :
 
 omit [MeasurableSpace E] [OpensMeasurableSpace E] in
 private theorem normSq_finset_sum_exp_eq_sum {ι : Type*} (s : Finset ι) (c : ι → ℂ)
-    (t : ι → E) (y : E) :
-    ((normSq (∑ i ∈ s, c i * exp (⟪y, t i⟫ * I)) : ℝ) : ℂ)
+    (t : ι → E) (y : E) : ((normSq (∑ i ∈ s, c i * exp (⟪y, t i⟫ * I)) : ℝ) : ℂ)
       = ∑ i ∈ s, ∑ j ∈ s, c i * conj (c j) * exp (⟪y, t i - t j⟫ * I) := by
   have hconj : conj (∑ i ∈ s, c i * exp (⟪y, t i⟫ * I))
       = ∑ j ∈ s, conj (c j) * conj (exp (⟪y, t j⟫ * I)) := by

--- a/TauCeti/Analysis/Bochner/CharFun/PositiveDefinite.lean
+++ b/TauCeti/Analysis/Bochner/CharFun/PositiveDefinite.lean
@@ -71,8 +71,7 @@ theorem charFun_star_kernel_isPositiveDefiniteKernel_of_star_eq_neg [StarAddMono
 involution that is explicitly negation. This is the generic-predicate form of
 `charFun_fintype_sum_mul_conj_nonneg`, using
 `F (vᵢ + star vⱼ) = charFun μ (vᵢ - vⱼ)`. -/
-theorem charFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoid E]
-    (hstar : ∀ x : E, star x = -x) :
+theorem charFun_isPositiveDefinite_of_star_eq_neg [StarAddMonoid E] (hstar : ∀ x : E, star x = -x) :
     IsPositiveDefinite (MeasureTheory.charFun μ) := by
   intro n c v
   have h := charFun_fintype_sum_mul_conj_nonneg (μ := μ) c v

--- a/TauCeti/Analysis/Calculus/DSlopeIntegral.lean
+++ b/TauCeti/Analysis/Calculus/DSlopeIntegral.lean
@@ -158,8 +158,7 @@ private theorem continuousOn_dslope_prod_of_convex {U : Set ℂ} (hU : Convex �
 
 /-- **Joint continuity of `(c, w) ↦ dslope f c w` on `U ×ˢ U`** for `f` differentiable on an
 arbitrary open set `U` (no convexity assumption). -/
-theorem continuousOn_dslope_prod {U : Set ℂ} (hU_open : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) :
+theorem continuousOn_dslope_prod {U : Set ℂ} (hU_open : IsOpen U) (hf : DifferentiableOn ℂ f U) :
     ContinuousOn (fun p : ℂ × ℂ ↦ dslope f p.1 p.2) (U ×ˢ U) := by
   rintro ⟨c₀, w₀⟩ ⟨hc₀, hw₀⟩
   by_cases h_eq : c₀ = w₀

--- a/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
+++ b/TauCeti/Analysis/Calculus/IteratedDerivWithin.lean
@@ -33,8 +33,7 @@ the derivative of the `k`-th iterated derivative-within-`s` of a `C^(k+1)` funct
 `(k+1)`-th iterated derivative-within-`s`. -/
 theorem ContDiffOn.hasDerivAt_iteratedDerivWithin
     {𝕜 E : Type*} [NontriviallyNormedField 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ}
-    (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
+    {g : 𝕜 → E} {s : Set 𝕜} {k : ℕ} (hf : ContDiffOn 𝕜 ((k + 1 : ℕ) : WithTop ℕ∞) g s)
     (hs : UniqueDiffOn 𝕜 s) {x : 𝕜} (hx : s ∈ nhds x) :
     HasDerivAt (iteratedDerivWithin k g s) (iteratedDerivWithin (k + 1) g s x) x := by
   rw [iteratedDerivWithin_succ, derivWithin_of_mem_nhds hx]

--- a/TauCeti/Analysis/Calculus/OneSidedDerivLimit.lean
+++ b/TauCeti/Analysis/Calculus/OneSidedDerivLimit.lean
@@ -42,8 +42,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 /-- A function continuous at `t₀`, eventually differentiable on the right, whose derivative
 tends to `L` from the right, has right derivative `L` at `t₀`. -/
 theorem hasDerivWithinAt_Ioi_of_tendsto_deriv {γ : ℝ → E} {t₀ : ℝ} {L : E}
-    (hγ_cont : ContinuousAt γ t₀)
-    (hγ_diff : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
+    (hγ_cont : ContinuousAt γ t₀) (hγ_diff : ∀ᶠ t in 𝓝[>] t₀, DifferentiableAt ℝ γ t)
     (hL : Tendsto (deriv γ) (𝓝[>] t₀) (𝓝 L)) :
     HasDerivWithinAt γ L (Ioi t₀) t₀ := by
   obtain ⟨s, hs_mem, hs_diff⟩ := hγ_diff.exists_mem
@@ -55,8 +54,7 @@ theorem hasDerivWithinAt_Ioi_of_tendsto_deriv {γ : ℝ → E} {t₀ : ℝ} {L :
 /-- A function continuous at `t₀`, eventually differentiable on the left, whose derivative
 tends to `L` from the left, has left derivative `L` at `t₀`. -/
 theorem hasDerivWithinAt_Iio_of_tendsto_deriv {γ : ℝ → E} {t₀ : ℝ} {L : E}
-    (hγ_cont : ContinuousAt γ t₀)
-    (hγ_diff : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t)
+    (hγ_cont : ContinuousAt γ t₀) (hγ_diff : ∀ᶠ t in 𝓝[<] t₀, DifferentiableAt ℝ γ t)
     (hL : Tendsto (deriv γ) (𝓝[<] t₀) (𝓝 L)) :
     HasDerivWithinAt γ L (Iio t₀) t₀ := by
   obtain ⟨s, hs_mem, hs_diff⟩ := hγ_diff.exists_mem

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Basic.lean
@@ -184,8 +184,7 @@ theorem const_add {f : ℝ → ℝ} (hf : IsBernsteinFunction f) {c : ℝ} (hc :
   ((isBernsteinFunction_const hc).add hf).congr fun _ _ => by simp [Pi.add_apply]
 
 /-- Bernstein functions are closed under finite sums. -/
-theorem sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
-    (hf : ∀ i ∈ s, IsBernsteinFunction (f i)) :
+theorem sum {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ} (hf : ∀ i ∈ s, IsBernsteinFunction (f i)) :
     IsBernsteinFunction (fun t => ∑ i ∈ s, f i t) := by
   have h := Finset.sum_induction f IsBernsteinFunction (fun _ _ => IsBernsteinFunction.add)
     isBernsteinFunction_zero hf

--- a/TauCeti/Analysis/CompletelyMonotone/Bernstein/Tightness.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Bernstein/Tightness.lean
@@ -52,8 +52,7 @@ variable {f : ℝ → ℝ}
 
 for every positive `R`. The derivative is taken within `[0, ∞)`, as in the definition of
 complete monotonicity. -/
-lemma chafaiRescaled_measure_Ioi_le (hcm : IsCompletelyMonotone f) (n : ℕ)
-    {R : ℝ≥0} (hR : R ≠ 0) :
+lemma chafaiRescaled_measure_Ioi_le (hcm : IsCompletelyMonotone f) (n : ℕ) {R : ℝ≥0} (hR : R ≠ 0) :
     chafaiRescaled f n (Ioi R) ≤
       ENNReal.ofReal (-derivWithin f (Ici 0) 0) / (R : ℝ≥0∞) := by
   let μ := chafaiRescaled f n

--- a/TauCeti/Analysis/CompletelyMonotone/Closure.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Closure.lean
@@ -87,8 +87,7 @@ theorem mul (hf : IsCompletelyMonotone f) (hg : IsCompletelyMonotone g) :
   exact mul_nonneg (mul_nonneg (Nat.cast_nonneg _) e1) e2
 
 /-- Completely monotone functions are closed under finite products. -/
-theorem prod {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ}
-    (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
+theorem prod {ι : Type*} {s : Finset ι} {f : ι → ℝ → ℝ} (hf : ∀ i ∈ s, IsCompletelyMonotone (f i)) :
     IsCompletelyMonotone (fun t => ∏ i ∈ s, f i t) := by
   have h := Finset.prod_induction f IsCompletelyMonotone
     (fun _ _ => IsCompletelyMonotone.mul) (isCompletelyMonotone_const zero_le_one) hf

--- a/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/FiniteMixture.lean
@@ -48,8 +48,7 @@ namespace TauCeti
 
 The weights and rates are indexed by a finset. Both take values in `ℝ≥0`, making their
 nonnegativity intrinsic to the data. -/
-noncomputable def finiteExponentialMixture {ι : Type*} (s : Finset ι)
-    (w p : ι → ℝ≥0) (t : ℝ) : ℝ :=
+noncomputable def finiteExponentialMixture {ι : Type*} (s : Finset ι) (w p : ι → ℝ≥0) (t : ℝ) : ℝ :=
   ∑ i ∈ s, (w i : ℝ) * Real.exp (-(p i : ℝ) * t)
 
 /-- The empty exponential mixture is the zero function. -/
@@ -67,8 +66,7 @@ theorem finiteExponentialMixture_singleton {ι : Type*} (i : ι) (w p : ι → �
   simp [finiteExponentialMixture]
 
 /-- Every finite positive mixture of exponential extreme rays is completely monotone. -/
-theorem isCompletelyMonotone_finiteExponentialMixture {ι : Type*} (s : Finset ι)
-    (w p : ι → ℝ≥0) :
+theorem isCompletelyMonotone_finiteExponentialMixture {ι : Type*} (s : Finset ι) (w p : ι → ℝ≥0) :
     IsCompletelyMonotone (finiteExponentialMixture s w p) := by
   apply IsCompletelyMonotone.sum
   intro i hi
@@ -104,15 +102,13 @@ theorem finiteExponentialMixtureMeasure_empty {ι : Type*} (w p : ι → ℝ≥0
 
 /-- A singleton mixture has the corresponding weighted Dirac representing measure. -/
 @[simp]
-theorem finiteExponentialMixtureMeasure_singleton {ι : Type*} (i : ι)
-    (w p : ι → ℝ≥0) :
+theorem finiteExponentialMixtureMeasure_singleton {ι : Type*} (i : ι) (w p : ι → ℝ≥0) :
     finiteExponentialMixtureMeasure {i} w p =
       (w i : ℝ≥0∞) • Measure.dirac (p i) := by
   simp [finiteExponentialMixtureMeasure]
 
 /-- A finite exponential mixture is the Laplace transform of its discrete representing measure. -/
-theorem finiteExponentialMixture_eq_integral {ι : Type*} (s : Finset ι)
-    (w p : ι → ℝ≥0) (t : ℝ) :
+theorem finiteExponentialMixture_eq_integral {ι : Type*} (s : Finset ι) (w p : ι → ℝ≥0) (t : ℝ) :
     finiteExponentialMixture s w p t =
       ∫ q : ℝ≥0, Real.exp (-t * (q : ℝ)) ∂finiteExponentialMixtureMeasure s w p := by
   rw [finiteExponentialMixtureMeasure, integral_finsetSum_measure]

--- a/TauCeti/Analysis/CompletelyMonotone/Integral.lean
+++ b/TauCeti/Analysis/CompletelyMonotone/Integral.lean
@@ -141,8 +141,7 @@ lemma IsCompletelyMonotone.integral_neg_iteratedDerivWithin_one_Ici_eq_sub
 
 /-- `-f'` is integrable on `(0, ∞)` for a completely monotone function, where the derivative is
 taken within the closed half-line `[0, ∞)`. -/
-lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
-    (hcm : IsCompletelyMonotone f) :
+lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn (hcm : IsCompletelyMonotone f) :
     IntegrableOn (fun t => -iteratedDerivWithin 1 f (Ici 0) t) (Ioi 0) := by
   obtain ⟨L, hL, -⟩ := hcm.exists_nonneg_tendsto_atTop
   have hcont : ContinuousWithinAt f (Ici 0) 0 :=
@@ -158,8 +157,7 @@ lemma IsCompletelyMonotone.neg_iteratedDerivWithin_one_integrableOn
 /-- The improper integral `∫ₓ^∞ (-f') dt = f x - L` from an arbitrary nonnegative endpoint `x`,
 for a completely monotone function with limit `L` at infinity. -/
 lemma IsCompletelyMonotone.integral_Ioi_neg_iteratedDerivWithin_one_of_nonneg
-    (hcm : IsCompletelyMonotone f) {x : ℝ} (hx : 0 ≤ x) {L : ℝ}
-    (hL : Tendsto f atTop (nhds L)) :
+    (hcm : IsCompletelyMonotone f) {x : ℝ} (hx : 0 ≤ x) {L : ℝ} (hL : Tendsto f atTop (nhds L)) :
     ∫ t in Ioi x, -iteratedDerivWithin 1 f (Ici 0) t = f x - L := by
   have hcont : ContinuousWithinAt f (Ici x) x :=
     (hcm.contDiffOn.continuousOn.continuousWithinAt hx).mono (Ici_subset_Ici.mpr hx)

--- a/TauCeti/Analysis/Fredholm/Adjoint.lean
+++ b/TauCeti/Analysis/Fredholm/Adjoint.lean
@@ -71,8 +71,7 @@ noncomputable def orthogonalKerEquivRange (T : E →L[𝕜] F)
 @[simp]
 theorem orthogonalKerEquivRange_apply (T : E →L[𝕜] F)
     (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F))
-    (x : (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ) :
-    (orthogonalKerEquivRange T hT x :
+    (x : (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ) : (orthogonalKerEquivRange T hT x :
       F) = T x := by
   letI : CompleteSpace (LinearMap.ker (T : E →ₗ[𝕜] F))ᗮ :=
     (LinearMap.ker (T : E →ₗ[𝕜] F)).isClosed_orthogonal.completeSpace_coe
@@ -230,8 +229,7 @@ theorem coe_cokerEquivKerAdjoint_apply_mk (T : E →L[𝕜] F)
 class. -/
 @[simp]
 theorem cokerEquivKerAdjoint_symm_apply (T : E →L[𝕜] F)
-    (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F))
-    (y : LinearMap.ker (T† : F →ₗ[𝕜] E)) :
+    (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (y : LinearMap.ker (T† : F →ₗ[𝕜] E)) :
     (cokerEquivKerAdjoint T hT).symm y = Submodule.Quotient.mk (y : F) := by
   let range := LinearMap.range (T : E →ₗ[𝕜] F)
   letI : CompleteSpace range := hT.completeSpace_coe
@@ -259,8 +257,7 @@ theorem coe_cokerAdjointEquivKer_apply_mk (T : E →L[𝕜] F)
 class. -/
 @[simp]
 theorem cokerAdjointEquivKer_symm_apply (T : E →L[𝕜] F)
-    (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F))
-    (x : LinearMap.ker (T : E →ₗ[𝕜] F)) :
+    (hT : IsClosed (LinearMap.range (T : E →ₗ[𝕜] F) : Set F)) (x : LinearMap.ker (T : E →ₗ[𝕜] F)) :
     (cokerAdjointEquivKer T hT).symm x = Submodule.Quotient.mk (x : E) := by
   simp [cokerAdjointEquivKer]
 

--- a/TauCeti/Analysis/Fredholm/Basic.lean
+++ b/TauCeti/Analysis/Fredholm/Basic.lean
@@ -140,14 +140,12 @@ variable {T : E →L[𝕜] F}
 
 /-- The underlying linear map of `e.comp T`, for a continuous linear equivalence `e`, written with
 the linear-equivalence coercion so that submodule and quotient lemmas apply. -/
-private lemma coe_equiv_comp (e : F ≃L[𝕜] G) :
-    (((e : F →L[𝕜] G).comp T : E →L[𝕜] G) : E →ₗ[𝕜] G) =
+private lemma coe_equiv_comp (e : F ≃L[𝕜] G) : (((e : F →L[𝕜] G).comp T : E →L[𝕜] G) : E →ₗ[𝕜] G) =
       (e.toLinearEquiv : F →ₗ[𝕜] G).comp (T : E →ₗ[𝕜] F) := by
   ext x; simp
 
 /-- The underlying linear map of `T.comp e`, for a continuous linear equivalence `e`. -/
-private lemma coe_comp_equiv (e : G ≃L[𝕜] E) :
-    ((T.comp (e : G →L[𝕜] E) : G →L[𝕜] F) : G →ₗ[𝕜] F) =
+private lemma coe_comp_equiv (e : G ≃L[𝕜] E) : ((T.comp (e : G →L[𝕜] E) : G →L[𝕜] F) : G →ₗ[𝕜] F) =
       (T : E →ₗ[𝕜] F).comp (e.toLinearEquiv : G →ₗ[𝕜] E) := by
   ext x; simp
 

--- a/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
+++ b/TauCeti/Analysis/Fredholm/ContinuousFamily.lean
@@ -63,8 +63,7 @@ theorem Continuous.isLocallyConstant_index {A : X → E →L[K] F}
 /-- Along a continuous family of Fredholm operators, parameters in the same preconnected set give
 operators with equal index. -/
 theorem ContinuousOn.index_eq_of_isPreconnected {A : X → E →L[K] F} {s : Set X}
-    (hA : ContinuousOn A s)
-    (hFredholm : ∀ x ∈ s, ContinuousLinearMap.IsFredholm (A x))
+    (hA : ContinuousOn A s) (hFredholm : ∀ x ∈ s, ContinuousLinearMap.IsFredholm (A x))
     (hs : IsPreconnected s) {x y : X} (hx : x ∈ s) (hy : y ∈ s) :
     ContinuousLinearMap.index (A x) = ContinuousLinearMap.index (A y) := by
   letI := Subtype.preconnectedSpace hs
@@ -95,8 +94,7 @@ variable [NormedSpace ℝ (E' →L[K'] F')]
 
 /-- Two operators over an `IsRCLikeNormedField` have equal index if every operator on the affine
 segment between them is Fredholm. -/
-theorem index_eq_of_segment (T S : E' →L[K'] F') :
-    (∀ t : unitInterval,
+theorem index_eq_of_segment (T S : E' →L[K'] F') : (∀ t : unitInterval,
       ContinuousLinearMap.IsFredholm ((1 - (t : ℝ)) • T + (t : ℝ) • S)) →
       ContinuousLinearMap.index T = ContinuousLinearMap.index S := by
   letI := IsRCLikeNormedField.rclike K'

--- a/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
+++ b/TauCeti/Analysis/Fredholm/SelfAdjoint.lean
@@ -43,8 +43,7 @@ variable [NormedAddCommGroup E] [InnerProductSpace 𝕜 E] [CompleteSpace E]
 /-- The cokernel of a Fredholm operator is linearly equivalent to its kernel if the operator and
 its adjoint have the same kernel. -/
 noncomputable def _root_.ContinuousLinearMap.IsFredholm.cokerEquivKerOfKerAdjointEq {T : E →L[𝕜] E}
-    (hT : ContinuousLinearMap.IsFredholm T)
-    (hker : (ContinuousLinearMap.adjoint T).ker = T.ker) :
+    (hT : ContinuousLinearMap.IsFredholm T) (hker : (ContinuousLinearMap.adjoint T).ker = T.ker) :
     (E ⧸ LinearMap.range (T : E →ₗ[𝕜] E)) ≃ₗ[𝕜]
       LinearMap.ker (T : E →ₗ[𝕜] E) :=
   (TauCeti.ContinuousLinearMap.cokerEquivKerAdjoint T hT.isClosed_range).toLinearEquiv.trans
@@ -52,8 +51,7 @@ noncomputable def _root_.ContinuousLinearMap.IsFredholm.cokerEquivKerOfKerAdjoin
 
 /-- The cokernel of a self-adjoint Fredholm operator is linearly equivalent to its kernel. -/
 noncomputable def _root_.ContinuousLinearMap.IsFredholm.cokerEquivKer {T : E →L[𝕜] E}
-    (hT : ContinuousLinearMap.IsFredholm T)
-    (hself : IsSelfAdjoint T) :
+    (hT : ContinuousLinearMap.IsFredholm T) (hself : IsSelfAdjoint T) :
     (E ⧸ LinearMap.range (T : E →ₗ[𝕜] E)) ≃ₗ[𝕜]
       LinearMap.ker (T : E →ₗ[𝕜] E) :=
   hT.cokerEquivKerOfKerAdjointEq <| by rw [hself.adjoint_eq]

--- a/TauCeti/Analysis/Fredholm/SmallPerturbation.lean
+++ b/TauCeti/Analysis/Fredholm/SmallPerturbation.lean
@@ -47,13 +47,9 @@ open scoped Topology
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
 
-private def blockCorner
-    {K X Y C : Type*}
-    [NormedAddCommGroup K] [NormedSpace 𝕜 K]
-    [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
-    [NormedAddCommGroup C] [NormedSpace 𝕜 C]
-    (A : K × X →L[𝕜] Y × C) : X →L[𝕜] Y :=
+private def blockCorner {K X Y C : Type*} [NormedAddCommGroup K] [NormedSpace 𝕜 K]
+    [NormedAddCommGroup X] [NormedSpace 𝕜 X] [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+    [NormedAddCommGroup C] [NormedSpace 𝕜 C] (A : K × X →L[𝕜] Y × C) : X →L[𝕜] Y :=
   (ContinuousLinearMap.fst 𝕜 Y C).comp
     (A.comp (ContinuousLinearMap.inr 𝕜 K X))
 
@@ -68,12 +64,9 @@ swap in the statement comes from.
 Only the factorization is recorded, not the Schur complement itself: all the index computation
 needs is that the remaining factor is *some* operator `K → C`, since between finite-dimensional
 spaces every operator has index `finrank K - finrank C`. -/
-private theorem exists_factorization_of_blocks
-    {K X Y C : Type*}
-    [NormedAddCommGroup K] [NormedSpace 𝕜 K]
-    [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
-    [NormedAddCommGroup C] [NormedSpace 𝕜 C]
+private theorem exists_factorization_of_blocks {K X Y C : Type*}
+    [NormedAddCommGroup K] [NormedSpace 𝕜 K] [NormedAddCommGroup X] [NormedSpace 𝕜 X]
+    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y] [NormedAddCommGroup C] [NormedSpace 𝕜 C]
     (A : K × X →L[𝕜] Y × C) (a : K →L[𝕜] Y) (c : K →L[𝕜] C) (d : X →L[𝕜] C) (e : X ≃L[𝕜] Y)
     (hA : ∀ (k : K) (x : X), A (k, x) = (a k + e x, c k + d x)) :
     ∃ (f : K →L[𝕜] C) (P : (K × X) ≃L[𝕜] (K × X)) (Q : (C × Y) ≃L[𝕜] (Y × C)),
@@ -95,11 +88,9 @@ private theorem exists_factorization_of_blocks
   · simp [hA, add_comm]
   · simp [hA, map_add]
 
-private theorem isFredholm_and_index_eq_of_blocks
-    {K X Y C : Type*}
+private theorem isFredholm_and_index_eq_of_blocks {K X Y C : Type*}
     [NormedAddCommGroup K] [NormedSpace 𝕜 K] [FiniteDimensional 𝕜 K]
-    [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+    [NormedAddCommGroup X] [NormedSpace 𝕜 X] [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
     [NormedAddCommGroup C] [NormedSpace 𝕜 C] [FiniteDimensional 𝕜 C]
     (A : K × X →L[𝕜] Y × C) (a : K →L[𝕜] Y) (c : K →L[𝕜] C) (d : X →L[𝕜] C) (e : X ≃L[𝕜] Y)
     (hA : ∀ (k : K) (x : X), A (k, x) = (a k + e x, c k + d x)) :
@@ -124,14 +115,11 @@ private theorem isFredholm_and_index_eq_of_blocks
       simp
     _ = (finrank 𝕜 K : ℤ) - finrank 𝕜 C := add_zero _
 
-private theorem isFredholm_and_index_eq_of_blockCorner_equiv
-    {K X Y C : Type*}
+private theorem isFredholm_and_index_eq_of_blockCorner_equiv {K X Y C : Type*}
     [NormedAddCommGroup K] [NormedSpace 𝕜 K] [FiniteDimensional 𝕜 K]
-    [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+    [NormedAddCommGroup X] [NormedSpace 𝕜 X] [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
     [NormedAddCommGroup C] [NormedSpace 𝕜 C] [FiniteDimensional 𝕜 C]
-    (A : K × X →L[𝕜] Y × C) (e : X ≃L[𝕜] Y)
-    (he : blockCorner A = (e : X →L[𝕜] Y)) :
+    (A : K × X →L[𝕜] Y × C) (e : X ≃L[𝕜] Y) (he : blockCorner A = (e : X →L[𝕜] Y)) :
     ContinuousLinearMap.IsFredholm A ∧
       ContinuousLinearMap.index A = (finrank 𝕜 K : ℤ) - finrank 𝕜 C := by
   -- Read off the other three corners of `A`, so that `isFredholm_and_index_eq_of_blocks`
@@ -186,11 +174,9 @@ omit [CompleteSpace E] [CompleteSpace F] in
 as `K × X` and the codomain as `Y × C`, with `K` and `C` finite-dimensional, and that in the
 resulting block form of `S` the corner `X → Y` is an equivalence. Then `S` is Fredholm of index
 `finrank K - finrank C`. -/
-private theorem isFredholm_and_index_eq_of_splitting
-    {K X Y C : Type*}
+private theorem isFredholm_and_index_eq_of_splitting {K X Y C : Type*}
     [NormedAddCommGroup K] [NormedSpace 𝕜 K] [FiniteDimensional 𝕜 K]
-    [NormedAddCommGroup X] [NormedSpace 𝕜 X]
-    [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
+    [NormedAddCommGroup X] [NormedSpace 𝕜 X] [NormedAddCommGroup Y] [NormedSpace 𝕜 Y]
     [NormedAddCommGroup C] [NormedSpace 𝕜 C] [FiniteDimensional 𝕜 C]
     (S : E →L[𝕜] F) (p : (K × X) ≃L[𝕜] E) (q : (Y × C) ≃L[𝕜] F) {e : X ≃L[𝕜] Y}
     (he : blockCorner ((q.symm : F →L[𝕜] Y × C).comp (S.comp (p : K × X →L[𝕜] E))) =

--- a/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/IntUnitsAction.lean
@@ -54,8 +54,7 @@ theorem coe_intUnitsToUnitSphere (u : ℤˣ) :
     obtain rfl | rfl := Int.units_eq_one_or u <;> simp [intUnitsToUnitSphere]
 
 /-- The coercion of Mathlib's sphere action is scalar multiplication in the ambient space. -/
-private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1)
-    (x : sphere (0 : E) r) :
+private theorem coe_sphere_smul {r : ℝ} (c : sphere (0 : ℝ) 1) (x : sphere (0 : E) r) :
     ((c • x : sphere (0 : E) r) : E) = (c : ℝ) • (x : E) :=
   (rfl)
 

--- a/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
+++ b/TauCeti/Analysis/PDE/EnergyLowerBounds.lean
@@ -126,8 +126,7 @@ lemma min_diagonal_lower_bound_mul_norm_sq_le_energyIntegrand_self (hlam : 0 < l
 /-- Zero-drift diagonal lower bound from a principal quadratic lower bound and nonnegative
 mass coefficient. -/
 lemma min_lam_mass_mul_norm_sq_le_energyIntegrand_zero_drift_self {A : Matrix n n ℝ}
-    {c₀ : ℝ} (hlam : 0 ≤ lam)
-    (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
+    {c₀ : ℝ} (hlam : 0 ≤ lam) (hA : ∀ ξ : EuclideanSpace ℝ n, lam * ‖ξ‖ ^ 2 ≤ A.toQuadraticForm' ξ)
     (hc : 0 ≤ c₀) (U : ℝ × EuclideanSpace ℝ n) :
     min lam c₀ * ‖U‖ ^ 2 ≤ energyIntegrand A 0 c₀ U U := by
   have hprod := min_mul_prod_norm_sq_le_add hlam hc U

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Flux.lean
@@ -74,8 +74,7 @@ theorem fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
 
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle around its pole. -/
-theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
-    {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
+theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal {a : ℂ} {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ (fun w ↦ planarNewtonianKernel (w - a)) (circleMap a r θ)
         ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
   rw [fderiv_planarNewtonianKernel_sub_circle_normal hr]
@@ -83,8 +82,7 @@ theorem radius_mul_fderiv_planarNewtonianKernel_sub_circle_normal
 
 /-- The arclength-weighted normal derivative of the planar Newtonian kernel is constant on every
 positively oriented circle centered at the origin. -/
-theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal
-    {r θ : ℝ} (hr : 0 < r) :
+theorem radius_mul_fderiv_planarNewtonianKernel_circle_normal {r θ : ℝ} (hr : 0 < r) :
     r * fderiv ℝ planarNewtonianKernel (circleMap 0 r θ)
         ((r : ℂ)⁻¹ * circleMap 0 r θ) = -(2 * Real.pi)⁻¹ := by
   simpa only [sub_zero] using

--- a/TauCeti/Analysis/PDE/Harnack/Planar.lean
+++ b/TauCeti/Analysis/PDE/Harnack/Planar.lean
@@ -41,8 +41,7 @@ namespace TauCeti
 
 open Complex Filter InnerProductSpace Metric Real Topology
 
-private lemma continuousOn_re_herglotzRieszKernel {c w : ℂ} {R : ℝ}
-    (hw : w ∈ ball c R) :
+private lemma continuousOn_re_herglotzRieszKernel {c w : ℂ} {R : ℝ} (hw : w ∈ ball c R) :
     ContinuousOn (re ∘ herglotzRieszKernel c w) (sphere c R) := by
   rw [herglotzRieszKernel_fun_def]
   have hne : ∀ z ∈ sphere c R, z - c - (w - c) ≠ 0 := by
@@ -93,8 +92,7 @@ nonnegative on its boundary circle, then every `w` in the open disk satisfies
 
 The boundary-only sign assumption is sufficient: both inequalities follow from the Poisson
 integral formula and the pointwise bounds on the Poisson kernel. -/
-theorem harnack_inequality_center_of_nonneg_on_sphere
-    (hf : HarmonicOnNhd f (closedBall c R))
+theorem harnack_inequality_center_of_nonneg_on_sphere (hf : HarmonicOnNhd f (closedBall c R))
     (hnonneg : ∀ z ∈ sphere c R, 0 ≤ f z) (hw : w ∈ ball c R) :
     (R - ‖w - c‖) / (R + ‖w - c‖) * f c ≤ f w ∧
       f w ≤ (R + ‖w - c‖) / (R - ‖w - c‖) * f c := by
@@ -170,8 +168,7 @@ its boundary, then for any `x, y ∈ closedBall c r`,
 `f x ≤ ((R + r) / (R - r)) ^ 2 * f y`.
 
 This pairwise form follows by comparing both values with `f c`. -/
-theorem harnack_inequality_of_nonneg_on_sphere
-    (hf : HarmonicOnNhd f (closedBall c R))
+theorem harnack_inequality_of_nonneg_on_sphere (hf : HarmonicOnNhd f (closedBall c R))
     (hnonneg : ∀ z ∈ sphere c R, 0 ≤ f z) {r : ℝ} (hr : 0 ≤ r) (hrR : r < R)
     {x y : ℂ} (hx : x ∈ closedBall c r) (hy : y ∈ closedBall c r) :
     f x ≤ ((R + r) / (R - r)) ^ 2 * f y := by
@@ -324,8 +321,7 @@ theorem harnack_inequality (hf : HarmonicOnNhd f (ball c R))
 
 /-- A nonnegative harmonic function on an open planar disk that vanishes at one point vanishes
 throughout the disk.  This is the zero case of Harnack's inequality. -/
-theorem eq_zero_on_ball_of_harmonicOnNhd_of_nonneg_of_eq_zero
-    (hf : HarmonicOnNhd f (ball c R))
+theorem eq_zero_on_ball_of_harmonicOnNhd_of_nonneg_of_eq_zero (hf : HarmonicOnNhd f (ball c R))
     (hnonneg : ∀ z ∈ ball c R, 0 ≤ f z) (hw : w ∈ ball c R) (hfw : f w = 0) :
     Set.EqOn f 0 (ball c R) := by
   intro z hz

--- a/TauCeti/Analysis/PDE/Integrated/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/Integrated/SymmetricEnergy.lean
@@ -69,8 +69,7 @@ lemma energyFormIntegral_zero_drift_transpose_apply :
 
 /-- A.e. symmetric principal coefficients make the zero-drift integrated energy form
 symmetric. -/
-lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
-    (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
+lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
     energyFormIntegral μ a (fun _ => 0) c U V =
       energyFormIntegral μ a (fun _ => 0) c V U := by
   calc
@@ -91,8 +90,7 @@ lemma energyFormIntegral_zero_drift_comm_of_isSymm_ae
 /-- Bundled-map form of symmetry for a zero-drift integrated energy form with a.e. symmetric
 principal coefficients. -/
 @[simp]
-lemma energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae
-    (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
+lemma energyFormIntegral_zero_drift_swap_eq_of_isSymm_ae (ha : ∀ᵐ x ∂μ, (a x).IsSymm) :
     Function.swap (energyFormIntegral μ a (fun _ => 0) c) =
       energyFormIntegral μ a (fun _ => 0) c := by
   funext U V

--- a/TauCeti/Analysis/PDE/LowerOrder.lean
+++ b/TauCeti/Analysis/PDE/LowerOrder.lean
@@ -149,8 +149,7 @@ end Continuity
 /-! ## Drift form bounds -/
 
 /-- The drift form is bounded by the norm of the drift coefficient. -/
-lemma norm_driftForm_apply_le (b : EuclideanSpace ℝ n) (u : ℝ)
-    (ξ : EuclideanSpace ℝ n) :
+lemma norm_driftForm_apply_le (b : EuclideanSpace ℝ n) (u : ℝ) (ξ : EuclideanSpace ℝ n) :
     ‖driftForm b u ξ‖ ≤ ‖b‖ * ‖u‖ * ‖ξ‖ := by
   rw [driftForm_apply, norm_mul]
   calc
@@ -187,8 +186,7 @@ grind_pattern opNorm_driftForm_le_of_norm_le =>
 
 /-- Radius-restricted drift estimate from a coefficient bound. -/
 lemma norm_driftForm_apply_le_of_norm_le_of_le {b : EuclideanSpace ℝ n}
-    {β R S : ℝ} (hb : ‖b‖ ≤ β) {u : ℝ} {ξ : EuclideanSpace ℝ n}
-    (hu : ‖u‖ ≤ R) (hξ : ‖ξ‖ ≤ S) :
+    {β R S : ℝ} (hb : ‖b‖ ≤ β) {u : ℝ} {ξ : EuclideanSpace ℝ n} (hu : ‖u‖ ≤ R) (hξ : ‖ξ‖ ≤ S) :
     ‖driftForm b u ξ‖ ≤ β * R * S :=
   (driftForm b).le_of_opNorm₂_le_of_le (opNorm_driftForm_le_of_norm_le hb) hu hξ
 

--- a/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
+++ b/TauCeti/Analysis/PDE/ShiftedLaplacianEnergy.lean
@@ -58,10 +58,8 @@ Pointwise, `energyIntegrand 1 0 (m x) (U x) (U x)` is
 `‖(U x).2‖² + m x * (U x).1²`, so for `m x ≥ 0` it controls the full product jet norm
 with coefficient `min 1 (m x)`. -/
 lemma integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
-    (hm : ∀ᵐ x ∂μ, 0 ≤ m x)
-    (hlower : Integrable (fun x => min 1 (m x) * ‖U x‖ ^ 2) μ)
-    (henergy : Integrable
-      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (U x)) μ) :
+    (hm : ∀ᵐ x ∂μ, 0 ≤ m x) (hlower : Integrable (fun x => min 1 (m x) * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 (m x) (U x) (U x)) μ) :
     ∫ x, (min 1 (m x) * ‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
   refine integral_min_lam_mass_mul_norm_sq_le_energyFormIntegral_zero_drift_self
@@ -73,8 +71,7 @@ lemma integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
   simp
 
 /-- The shifted-Laplacian diagonal form is nonnegative when the mass is a.e. nonnegative. -/
-lemma energyFormIntegral_one_zero_mass_self_nonneg
-    (hm : ∀ᵐ x ∂μ, 0 ≤ m x) :
+lemma energyFormIntegral_one_zero_mass_self_nonneg (hm : ∀ᵐ x ∂μ, 0 ≤ m x) :
     0 ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) m U U := by
   refine energyFormIntegral_zero_drift_self_nonneg
     (μ := μ) (a := fun _ => (1 : Matrix n n ℝ)) (c := m) (U := U) ?_ hm
@@ -91,10 +88,8 @@ lemma energyFormIntegral_one_zero_zero_self_nonneg :
 
 /-- Constant-mass specialization of the integrated shifted-Laplacian lower bound. -/
 lemma integral_min_one_const_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
-    {c : ℝ} (hc : 0 ≤ c)
-    (hlower : Integrable (fun x => min 1 c * ‖U x‖ ^ 2) μ)
-    (henergy : Integrable
-      (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 c (U x) (U x)) μ) :
+    {c : ℝ} (hc : 0 ≤ c) (hlower : Integrable (fun x => min 1 c * ‖U x‖ ^ 2) μ)
+    (henergy : Integrable (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 c (U x) (U x)) μ) :
     ∫ x, (min 1 c * ‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => c) U U :=
   integral_min_one_mass_mul_norm_sq_le_energyFormIntegral_one_zero_mass_self
@@ -108,10 +103,8 @@ lemma energyFormIntegral_one_zero_const_mass_self_nonneg {c : ℝ} (hc : 0 ≤ c
 
 /-- If the constant mass is at least `1`, the shifted-Laplacian diagonal form controls the
 full raw jet `L²` density with constant `1`. -/
-lemma integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le
-    {c : ℝ} (hc : 1 ≤ c)
-    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ)
-    (henergy : Integrable
+lemma integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le {c : ℝ} (hc : 1 ≤ c)
+    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ) (henergy : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 c (U x) (U x)) μ) :
     ∫ x, (‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => c) U U := by
@@ -123,8 +116,7 @@ lemma integral_norm_sq_le_energyFormIntegral_one_zero_mass_self_of_one_le
 /-- For constant mass `1`, the shifted-Laplacian diagonal form controls the full raw jet
 `L²` density with constant `1`. -/
 lemma integral_norm_sq_le_energyFormIntegral_one_zero_one_self
-    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ)
-    (henergy : Integrable
+    (hlower : Integrable (fun x => ‖U x‖ ^ 2) μ) (henergy : Integrable
       (fun x => energyIntegrand (1 : Matrix n n ℝ) 0 1 (U x) (U x)) μ) :
     ∫ x, (‖U x‖ ^ 2) ∂μ
       ≤ energyFormIntegral μ (fun _ => (1 : Matrix n n ℝ)) (fun _ => 0) (fun _ => 1) U U :=

--- a/TauCeti/Analysis/PDE/SymmetricEnergy.lean
+++ b/TauCeti/Analysis/PDE/SymmetricEnergy.lean
@@ -80,8 +80,7 @@ nonsymmetric principal coefficient, first pass to `coefficientSymmetricPart` usi
 ellipticity API in `TauCeti.Analysis.PDE.Uniform.Ellipticity`, then apply this lemma to the
 symmetric coefficient field. -/
 @[simp]
-lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm)
-    (c : ℝ) :
+lemma energyIntegrand_zero_drift_flip_eq_of_isSymm {A : Matrix n n ℝ} (hA : A.IsSymm) (c : ℝ) :
     (energyIntegrand A 0 c).flip = energyIntegrand A 0 c := by
   apply ContinuousLinearMap.ext
   intro U
@@ -111,8 +110,7 @@ lemma energyIntegrand_coefficientSymmetricPart_self (A : Matrix n n ℝ)
 
 /-- Bundled-map form of symmetry for the symmetric-part zero-drift jet integrand. -/
 @[simp]
-lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ)
-    (c : ℝ) :
+lemma energyIntegrand_coefficientSymmetricPart_zero_drift_flip_eq (A : Matrix n n ℝ) (c : ℝ) :
     (energyIntegrand (coefficientSymmetricPart A) 0 c).flip =
       energyIntegrand (coefficientSymmetricPart A) 0 c :=
   energyIntegrand_zero_drift_flip_eq_of_isSymm (coefficientSymmetricPart_isSymm A) c

--- a/TauCeti/Analysis/PositiveDefinite/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Basic.lean
@@ -93,8 +93,7 @@ namespace IsPositiveDefinite
 /-- Positive-definiteness holds for an arbitrary finite index type, not just `Fin n`: for every
 finite family of scalars `c : ι → ℂ` and points `v : ι → M`, the Hermitian form
 `∑_{i,j} c i · conj (c j) · F (v i + star (v j))` is a nonnegative real number. -/
-theorem sum_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι]
-    (c : ι → ℂ) (v : ι → M) :
+theorem sum_nonneg (hF : IsPositiveDefinite F) {ι : Type*} [Fintype ι] (c : ι → ℂ) (v : ι → M) :
     0 ≤ ∑ i, ∑ j, c i * conj (c j) * F (v i + star (v j)) := by
   classical
   let e : Fin (Fintype.card ι) ≃ ι := (Fintype.equivFin ι).symm
@@ -282,15 +281,13 @@ theorem isPositiveDefinite_zero : IsPositiveDefinite (fun _ : M => (0 : ℂ)) :=
 namespace IsPositiveDefinite
 
 /-- Positive-definite functions are closed under finite sums. -/
-theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
-    (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+theorem sum {ι : Type*} {s : Finset ι} {F : ι → M → ℂ} (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∑ i ∈ s, F i x) :=
   of_isPositiveDefiniteKernel <|
     isPositiveDefiniteKernel_sum fun i hi => (hF i hi).isPositiveDefiniteKernel
 
 /-- Positive-definite functions are closed under finite products (Schur product). -/
-theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ}
-    (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
+theorem prod {ι : Type*} {s : Finset ι} {F : ι → M → ℂ} (hF : ∀ i ∈ s, IsPositiveDefinite (F i)) :
     IsPositiveDefinite (fun x => ∏ i ∈ s, F i x) :=
   of_isPositiveDefiniteKernel <|
     isPositiveDefiniteKernel_prod fun i hi => (hF i hi).isPositiveDefiniteKernel

--- a/TauCeti/Analysis/PositiveDefinite/Continuity.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Continuity.lean
@@ -62,11 +62,9 @@ variable {E : Type*} [AddMonoid E] [StarAddMonoid E] {F : E → ℂ}
 private theorem gram_three_add_star_expand_of_values
     {x y : E} {lam : ℂ} {c : Fin 3 → ℂ} {p : Fin 3 → E}
     (hc0 : c 0 = 1) (hc1 : c 1 = -1) (hc2 : c 2 = lam)
-    (hp0 : p 0 = x) (hp1 : p 1 = y) (hp2 : p 2 = 0)
-    (hx : x + star x = 0) (hy : y + star y = 0)
+    (hp0 : p 0 = x) (hp1 : p 1 = y) (hp2 : p 2 = 0) (hx : x + star x = 0) (hy : y + star y = 0)
     (hyx : F (y + star x) = conj (F (x + star y)))
-    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y)) :
-    (∑ i : Fin 3, ∑ j : Fin 3,
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y)) : (∑ i : Fin 3, ∑ j : Fin 3,
       c i * conj (c j) * F (p i + star (p j)))
       = F 0 - F (x + star y) + conj lam * F x - conj (F (x + star y)) + F 0
         - conj lam * F y + lam * conj (F x) - lam * conj (F y)
@@ -76,11 +74,9 @@ private theorem gram_three_add_star_expand_of_values
   simp
   ring_nf
 
-private theorem gram_three_add_star_expand
-    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
+private theorem gram_three_add_star_expand {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
     (hyx : F (y + star x) = conj (F (x + star y)))
-    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y))
-    {lam : ℂ} :
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y)) {lam : ℂ} :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j)))
@@ -107,10 +103,8 @@ private theorem gram_three_sub_re_complex_algebra {r : ℝ} {z d lam : ℂ}
 private theorem gram_three_add_star_re_algebra (hF : IsPositiveDefinite F)
     {x y : E} (hx : x + star x = 0) (hy : y + star y = 0)
     (hyx : F (y + star x) = conj (F (x + star y)))
-    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y))
-    {C d lam : ℂ}
-    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
-    (hCpos : 0 < (F 0).re) :
+    (hnx : F (star x) = conj (F x)) (hny : F (0 + star y) = conj (F y)) {C d lam : ℂ}
+    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C) (hCpos : 0 < (F 0).re) :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
@@ -135,8 +129,7 @@ private theorem gram_three_add_star_re_algebra (hF : IsPositiveDefinite F)
 
 private theorem gram_three_add_star_re_eq (hF : IsPositiveDefinite F)
     {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) {C d lam : ℂ}
-    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C)
-    (hCpos : 0 < (F 0).re) :
+    (hC : C = F 0) (hd : d = F x - F y) (hlam : lam = -d / C) (hCpos : 0 < (F 0).re) :
     (∑ i : Fin 3, ∑ j : Fin 3,
       ![1, -1, lam] i * conj (![1, -1, lam] j) *
         F (![x, y, 0] i + star (![x, y, 0] j))).re
@@ -154,8 +147,7 @@ private theorem gram_three_add_star_re_eq (hF : IsPositiveDefinite F)
 
 /-- The local monoid-level real-part form of the standard positive-definite continuity estimate. -/
 theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero
-    (hF : IsPositiveDefinite F)
-    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
+    (hF : IsPositiveDefinite F) {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
     ‖F x - F y‖ ^ 2
       ≤ 2 * (F 0).re * ((F 0).re - (F (x + star y)).re) := by
   by_cases hC0 : (F 0).re = 0
@@ -194,8 +186,7 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_add_star_eq_zero
 /-- The local monoid-level norm-valued form of the standard positive-definite continuity
 estimate. -/
 theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_add_star_eq_zero
-    (hF : IsPositiveDefinite F)
-    {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
+    (hF : IsPositiveDefinite F) {x y : E} (hx : x + star x = 0) (hy : y + star y = 0) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x + star y) - F 0‖ := by
   have hre :
       (F 0).re - (F (x + star y)).re ≤ ‖F (x + star y) - F 0‖ := by
@@ -214,8 +205,7 @@ section GroupAlgebra
 variable {E : Type*} [AddGroup E] [StarAddMonoid E] {F : E → ℂ}
 
 /-- The local real-part form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
-    (hF : IsPositiveDefinite F)
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg (hF : IsPositiveDefinite F)
     {x y : E} (hx : star x = -x) (hy : star y = -y) :
     ‖F x - F y‖ ^ 2
       ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) := by
@@ -227,15 +217,13 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg
 /-- The real-part form of the standard positive-definite continuity estimate under a globally
 negating involution. -/
 theorem norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_forall_star_eq_neg
-    (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    (hF : IsPositiveDefinite F) (hstar : ∀ x : E, star x = -x) (x y : E) :
     ‖F x - F y‖ ^ 2
       ≤ 2 * (F 0).re * ((F 0).re - (F (x - y)).re) :=
   hF.norm_sub_sq_le_two_mul_map_zero_re_mul_re_sub_of_star_eq_neg (hstar x) (hstar y)
 
 /-- The local norm-valued form of the standard positive-definite continuity estimate. -/
-theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg
-    (hF : IsPositiveDefinite F)
+theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg (hF : IsPositiveDefinite F)
     {x y : E} (hx : star x = -x) (hy : star y = -y) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ := by
   have hx0 : x + star x = 0 := by rw [hx, add_neg_cancel]
@@ -246,8 +234,7 @@ theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg
 /-- The norm-valued form of the standard positive-definite continuity estimate under a globally
 negating involution. -/
 theorem norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_forall_star_eq_neg
-    (hF : IsPositiveDefinite F)
-    (hstar : ∀ x : E, star x = -x) (x y : E) :
+    (hF : IsPositiveDefinite F) (hstar : ∀ x : E, star x = -x) (x y : E) :
     ‖F x - F y‖ ^ 2 ≤ 2 * (F 0).re * ‖F (x - y) - F 0‖ :=
   hF.norm_sub_sq_le_two_mul_map_zero_re_mul_norm_sub_of_star_eq_neg (hstar x) (hstar y)
 

--- a/TauCeti/Analysis/PositiveDefinite/Function/Closure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Function/Closure.lean
@@ -94,8 +94,7 @@ variable {N : Type*}
 /-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
 value at that point is the sum of the weights. -/
 theorem sum_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, w i • F i x) = ∑ i ∈ s, w i := by
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) : (∑ i ∈ s, w i • F i x) = ∑ i ∈ s, w i := by
   refine Finset.sum_congr rfl fun i hi => ?_
   rw [hFx i hi]
   simp
@@ -103,8 +102,7 @@ theorem sum_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → 
 /-- A finite complex-weighted sum of functions normalized at a point is normalized at that point
 when the weights sum to `1`. -/
 theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa using (sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx).trans
     hw_sum
@@ -112,16 +110,14 @@ theorem sum_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
 /-- If each summand in a finite complex-weighted sum is normalized at a point, then the sum's
 multiplication-form value at that point is the sum of the weights. -/
 theorem sum_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) :
-    (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) : (∑ i ∈ s, w i * F i x) = ∑ i ∈ s, w i := by
   simpa [Algebra.smul_def] using
     sum_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
 
 /-- A finite complex-weighted sum, in multiplication form, of functions normalized at a point is
 normalized at that point when the weights sum to `1`. -/
 theorem sum_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℂ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun y => ∑ i ∈ s, w i * F i y) x = 1 := by
   simpa [Algebra.smul_def] using
     sum_smul_apply_eq_one (s := s) (w := w) (F := F) hFx hw_sum
@@ -137,8 +133,7 @@ theorem sum_real_smul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι
 /-- A finite real-weighted sum of functions normalized at a point is normalized at that point when
 the weights sum to `1`. -/
 theorem sum_real_smul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun y => ∑ i ∈ s, w i • F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_smul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx
@@ -154,8 +149,7 @@ theorem sum_real_const_mul_apply_of_apply_eq_one {ι : Type*} {s : Finset ι}
 /-- A finite real-weighted sum, in multiplication form, of functions normalized at a point is
 normalized at that point when the weights sum to `1`. -/
 theorem sum_real_const_mul_apply_eq_one {ι : Type*} {s : Finset ι} {w : ι → ℝ}
-    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1)
-    (hw_sum : ∑ i ∈ s, w i = 1) :
+    {F : ι → N → ℂ} {x : N} (hFx : ∀ i ∈ s, F i x = 1) (hw_sum : ∑ i ∈ s, w i = 1) :
     (fun y => ∑ i ∈ s, (w i : ℂ) * F i y) x = 1 := by
   simpa [hw_sum] using
     sum_real_const_mul_apply_of_apply_eq_one (s := s) (w := w) (F := F) hFx

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Basic.lean
@@ -141,8 +141,7 @@ theorem isPositiveDefiniteKernel_mul {K L : α → α → 𝕜}
   rfl
 
 private theorem posSemidef_of_support_posSemidef (K : α → α → 𝕜)
-    (hHerm : (Matrix.of fun a b => K a b).IsHermitian)
-    (hgram : ∀ x : α →₀ 𝕜,
+    (hHerm : (Matrix.of fun a b => K a b).IsHermitian) (hgram : ∀ x : α →₀ 𝕜,
       (Matrix.of fun i j : x.support => K (i : α) (j : α)).PosSemidef) :
     (Matrix.of fun a b => K a b).PosSemidef := by
   classical

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Closure.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Closure.lean
@@ -81,8 +81,7 @@ theorem isPositiveDefiniteKernel_sum_smul {ι : Type w} {s : Finset ι}
     isPositiveDefiniteKernel_smul_of_nonneg (hr i hi) (hK i hi)
 
 /-- Schur powers of a positive-definite kernel are positive definite. -/
-theorem isPositiveDefiniteKernel_pow {K : α → α → 𝕜}
-    (hK : IsPositiveDefiniteKernel K) (n : ℕ) :
+theorem isPositiveDefiniteKernel_pow {K : α → α → 𝕜} (hK : IsPositiveDefiniteKernel K) (n : ℕ) :
     IsPositiveDefiniteKernel (fun a b => K a b ^ n) := by
   induction n with
   | zero =>
@@ -93,16 +92,14 @@ theorem isPositiveDefiniteKernel_pow {K : α → α → 𝕜}
 /-- Finite sums of rank-one kernels `(a, b) ↦ conj (gᵢ a) * gᵢ b` are positive definite.
 These are the finite-rank positive-definite kernels used as the elementary building blocks for
 the later GNS/Kolmogorov decomposition. -/
-theorem isPositiveDefiniteKernel_sum_conj_mul {ι : Type w} (s : Finset ι)
-    (g : ι → α → 𝕜) :
+theorem isPositiveDefiniteKernel_sum_conj_mul {ι : Type w} (s : Finset ι) (g : ι → α → 𝕜) :
     IsPositiveDefiniteKernel
       (fun a b => ∑ i ∈ s, conj (g i a) * g i b) :=
   isPositiveDefiniteKernel_sum fun i _ => isPositiveDefiniteKernel_conj_mul (g i)
 
 /-- Finite products of rank-one kernels are positive definite. This is the Schur-product
 companion to `TauCeti.isPositiveDefiniteKernel_sum_conj_mul`. -/
-theorem isPositiveDefiniteKernel_prod_conj_mul {ι : Type w} (s : Finset ι)
-    (g : ι → α → 𝕜) :
+theorem isPositiveDefiniteKernel_prod_conj_mul {ι : Type w} (s : Finset ι) (g : ι → α → 𝕜) :
     IsPositiveDefiniteKernel
       (fun a b => ∏ i ∈ s, conj (g i a) * g i b) :=
   isPositiveDefiniteKernel_prod fun i _ => isPositiveDefiniteKernel_conj_mul (g i)

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Finsupp.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Finsupp.lean
@@ -59,8 +59,7 @@ For positive-definite `K`, the diagonal value
 `positiveDefiniteKernelFinsuppForm K x x` is nonnegative, and the form is Hermitian. This is the
 pre-inner-product expression used before quotienting by its null space in the GNS/Kolmogorov
 construction. -/
-noncomputable def positiveDefiniteKernelFinsuppForm (K : α → α → 𝕜)
-    (x y : α →₀ 𝕜) : 𝕜 :=
+noncomputable def positiveDefiniteKernelFinsuppForm (K : α → α → 𝕜) (x y : α →₀ 𝕜) : 𝕜 :=
   x.sum fun a xa => y.sum fun b yb => conj xa * yb * K a b
 
 variable {K : α → α → 𝕜}
@@ -165,8 +164,7 @@ theorem positiveDefiniteKernelFinsuppForm_zero_kernel (x y : α →₀ 𝕜) :
   simp [positiveDefiniteKernelFinsuppForm]
 
 /-- The finitely supported Gram form is additive in the kernel. -/
-theorem positiveDefiniteKernelFinsuppForm_add_kernel
-    (K L : α → α → 𝕜) (x y : α →₀ 𝕜) :
+theorem positiveDefiniteKernelFinsuppForm_add_kernel (K L : α → α → 𝕜) (x y : α →₀ 𝕜) :
     positiveDefiniteKernelFinsuppForm (fun a b => K a b + L a b) x y =
       positiveDefiniteKernelFinsuppForm K x y + positiveDefiniteKernelFinsuppForm L x y := by
   classical
@@ -178,8 +176,7 @@ theorem positiveDefiniteKernelFinsuppForm_add_kernel
   ring
 
 /-- The finitely supported Gram form is homogeneous in the kernel. -/
-theorem positiveDefiniteKernelFinsuppForm_smul_kernel
-    (c : 𝕜) (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
+theorem positiveDefiniteKernelFinsuppForm_smul_kernel (c : 𝕜) (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
     positiveDefiniteKernelFinsuppForm (fun a b => c • K a b) x y =
       c * positiveDefiniteKernelFinsuppForm K x y := by
   classical
@@ -191,8 +188,7 @@ theorem positiveDefiniteKernelFinsuppForm_smul_kernel
   ring
 
 /-- The finitely supported Gram form is homogeneous in a real scalar on the kernel. -/
-theorem positiveDefiniteKernelFinsuppForm_real_smul_kernel
-    (r : ℝ) (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
+theorem positiveDefiniteKernelFinsuppForm_real_smul_kernel (r : ℝ) (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
     positiveDefiniteKernelFinsuppForm (fun a b => r • K a b) x y =
       r • positiveDefiniteKernelFinsuppForm K x y := by
   simpa [Algebra.smul_def] using
@@ -224,8 +220,7 @@ noncomputable def positiveDefiniteKernelFinsuppSesqForm (K : α → α → 𝕜)
 
 /-- Applying the bundled sesquilinear form gives the finitely supported Gram expression. -/
 @[simp]
-theorem positiveDefiniteKernelFinsuppSesqForm_apply
-    (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
+theorem positiveDefiniteKernelFinsuppSesqForm_apply (K : α → α → 𝕜) (x y : α →₀ 𝕜) :
     positiveDefiniteKernelFinsuppSesqForm K x y =
       positiveDefiniteKernelFinsuppForm K x y := by
   rfl
@@ -255,8 +250,7 @@ theorem positiveDefiniteKernelFinsuppForm_conj_symm
     (isPositiveDefiniteKernel_conj_symm hK) x y
 
 /-- Positive-definite kernels give positive-semidefinite finitely supported sesquilinear forms. -/
-theorem positiveDefiniteKernelFinsuppSesqForm_isPosSemidef
-    (hK : IsPositiveDefiniteKernel K) :
+theorem positiveDefiniteKernelFinsuppSesqForm_isPosSemidef (hK : IsPositiveDefiniteKernel K) :
     (positiveDefiniteKernelFinsuppSesqForm K).IsPosSemidef where
   isSymm := ⟨fun x y => positiveDefiniteKernelFinsuppForm_conj_symm hK x y⟩
   isNonneg := ⟨fun x => by

--- a/TauCeti/Analysis/PositiveDefinite/Kernel/Radical.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Kernel/Radical.lean
@@ -56,15 +56,13 @@ variable {𝕜 : Type u} [RCLike 𝕜] {α : Type v} {K : α → α → 𝕜}
 This is the submodule by which the free space `α →₀ 𝕜` is quotiented in the algebraic
 GNS/Kolmogorov construction. It is defined as the kernel of the bundled sesquilinear form, so
 membership means pairing to zero with every finitely supported vector. -/
-noncomputable def positiveDefiniteKernelFinsuppSesqFormKer
-    (K : α → α → 𝕜) : Submodule 𝕜 (α →₀ 𝕜) :=
+noncomputable def positiveDefiniteKernelFinsuppSesqFormKer (K : α → α → 𝕜) : Submodule 𝕜 (α →₀ 𝕜) :=
   LinearMap.ker (positiveDefiniteKernelFinsuppSesqForm K)
 
 /-- Membership in the null submodule means that the finitely supported vector pairs to zero with
 every vector. -/
 @[simp]
-theorem mem_positiveDefiniteKernelFinsuppSesqFormKer
-    (x : α →₀ 𝕜) :
+theorem mem_positiveDefiniteKernelFinsuppSesqFormKer (x : α →₀ 𝕜) :
     x ∈ positiveDefiniteKernelFinsuppSesqFormKer K ↔
       ∀ y : α →₀ 𝕜, positiveDefiniteKernelFinsuppForm K x y = 0 := by
   rw [positiveDefiniteKernelFinsuppSesqFormKer, LinearMap.mem_ker]

--- a/TauCeti/Analysis/PositiveDefinite/Limits.lean
+++ b/TauCeti/Analysis/PositiveDefinite/Limits.lean
@@ -56,8 +56,7 @@ variable {𝕜 : Type*} [RCLike 𝕜] {α : Type*}
 hypothesis on positive-definiteness is eventual, so this applies equally to nets that are
 eventually positive definite. -/
 theorem isPositiveDefiniteKernel_of_tendsto {ι : Type*} {l : Filter ι} [NeBot l]
-    {K : ι → α → α → 𝕜} {L : α → α → 𝕜}
-    (hK : ∀ᶠ i in l, IsPositiveDefiniteKernel (K i))
+    {K : ι → α → α → 𝕜} {L : α → α → 𝕜} (hK : ∀ᶠ i in l, IsPositiveDefiniteKernel (K i))
     (hlim : ∀ a b : α, Tendsto (fun i => K i a b) l (𝓝 (L a b))) :
     IsPositiveDefiniteKernel L := by
   rw [isPositiveDefiniteKernel_def]
@@ -105,14 +104,12 @@ theorem of_tendsto {ι : Type*} {l : Filter ι} [NeBot l] {F : ι → M → ℂ}
 /-- A pointwise limit of a family of positive-definite functions is positive definite. This is the
 non-eventual form of `TauCeti.IsPositiveDefinite.of_tendsto`. -/
 theorem of_forall_tendsto {ι : Type*} {l : Filter ι} [NeBot l] {F : ι → M → ℂ} {G : M → ℂ}
-    (hF : ∀ i, IsPositiveDefinite (F i))
-    (hlim : ∀ x : M, Tendsto (fun i => F i x) l (𝓝 (G x))) :
+    (hF : ∀ i, IsPositiveDefinite (F i)) (hlim : ∀ x : M, Tendsto (fun i => F i x) l (𝓝 (G x))) :
     IsPositiveDefinite G :=
   of_tendsto (Eventually.of_forall hF) hlim
 
 /-- Sequential pointwise limits of eventually positive-definite functions are positive definite. -/
-theorem of_seq_tendsto {F : ℕ → M → ℂ} {G : M → ℂ}
-    (hF : ∀ᶠ n in atTop, IsPositiveDefinite (F n))
+theorem of_seq_tendsto {F : ℕ → M → ℂ} {G : M → ℂ} (hF : ∀ᶠ n in atTop, IsPositiveDefinite (F n))
     (hlim : ∀ x : M, Tendsto (fun n => F n x) atTop (𝓝 (G x))) :
     IsPositiveDefinite G :=
   of_tendsto hF hlim
@@ -124,10 +121,8 @@ variable [TopologicalSpace M]
 Unlike continuity, positive-definiteness itself only needs pointwise convergence; local uniform
 convergence is converted to pointwise convergence before applying
 `TauCeti.IsPositiveDefinite.of_tendsto`. -/
-theorem of_tendstoLocallyUniformly {ι : Type*} {l : Filter ι} [NeBot l]
-    {F : ι → M → ℂ} {G : M → ℂ}
-    (hF : ∀ᶠ i in l, IsPositiveDefinite (F i))
-    (hlim : TendstoLocallyUniformly F G l) :
+theorem of_tendstoLocallyUniformly {ι : Type*} {l : Filter ι} [NeBot l] {F : ι → M → ℂ} {G : M → ℂ}
+    (hF : ∀ᶠ i in l, IsPositiveDefinite (F i)) (hlim : TendstoLocallyUniformly F G l) :
     IsPositiveDefinite G :=
   of_tendsto hF fun x =>
     hlim.tendstoLocallyUniformlyOn.tendsto_at (Set.mem_univ x)

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Basic.lean
@@ -108,13 +108,11 @@ private theorem zero_point [AddCommGroup V] : (0 : BCRPoint V).point = 0 :=
   rfl
 
 @[simp]
-private theorem add_time [AddCommGroup V] (p q : BCRPoint V) :
-    (p + q).time = p.time + q.time :=
+private theorem add_time [AddCommGroup V] (p q : BCRPoint V) : (p + q).time = p.time + q.time :=
   rfl
 
 @[simp]
-private theorem add_point [AddCommGroup V] (p q : BCRPoint V) :
-    (p + q).point = p.point + q.point :=
+private theorem add_point [AddCommGroup V] (p q : BCRPoint V) : (p + q).point = p.point + q.point :=
   rfl
 
 @[simp]

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Product.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Product.lean
@@ -54,8 +54,7 @@ variable {V : Type*} [AddCommGroup V]
 /-- If the time factor gives a positive-definite kernel `(t, u) ↦ f (t + u)`, and the spatial
 factor gives a positive-definite subtraction kernel `(v, w) ↦ g (v - w)`, then their separated
 product is semigroup-group positive definite. -/
-theorem isSemigroupGroupPD_mul_time_spatial_of_kernels
-    {f : ℝ≥0 → ℂ} {g : V → ℂ}
+theorem isSemigroupGroupPD_mul_time_spatial_of_kernels {f : ℝ≥0 → ℂ} {g : V → ℂ}
     (hf : IsPositiveDefiniteKernel fun t u : ℝ≥0 => f (t + u))
     (hg : IsPositiveDefiniteKernel fun v w : V => g (v - w)) :
     IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
@@ -69,10 +68,8 @@ theorem isSemigroupGroupPD_mul_time_spatial_of_kernels
 /-- A separated product of a time positive-definite function and a spatial positive-definite
 function is semigroup-group positive definite. The time factor uses Mathlib's trivial involution
 on `ℝ≥0`; the spatial factor uses the supplied negation-involution hypothesis. -/
-theorem isSemigroupGroupPD_mul_time_spatial [StarAddMonoid V]
-    {f : ℝ≥0 → ℂ} {g : V → ℂ}
-    (hf : IsPositiveDefinite f) (hg : IsPositiveDefinite g)
-    (hstar : ∀ v : V, star v = -v) :
+theorem isSemigroupGroupPD_mul_time_spatial [StarAddMonoid V] {f : ℝ≥0 → ℂ} {g : V → ℂ}
+    (hf : IsPositiveDefinite f) (hg : IsPositiveDefinite g) (hstar : ∀ v : V, star v = -v) :
     IsSemigroupGroupPD fun p : ℝ≥0 × V => f p.1 * g p.2 := by
   refine isSemigroupGroupPD_mul_time_spatial_of_kernels ?_ (hg.isPositiveDefiniteKernel_sub hstar)
   have hK := hf.isPositiveDefiniteKernel

--- a/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Pullback.lean
+++ b/TauCeti/Analysis/PositiveDefinite/SemigroupGroup/Pullback.lean
@@ -118,8 +118,7 @@ theorem comp_spatial_iff_of_surjective {Φ : Type*} [FunLike Φ W V] [AddHomClas
   ⟨of_comp_spatial_surjective φ hsurj, fun hF => hF.comp_spatial φ⟩
 
 /-- The explicit `AddMonoidHom` form of the spatial pullback equivalence for surjective maps. -/
-theorem comp_spatial_addMonoidHom_iff_of_surjective (φ : W →+ V)
-    (hsurj : Function.Surjective φ) :
+theorem comp_spatial_addMonoidHom_iff_of_surjective (φ : W →+ V) (hsurj : Function.Surjective φ) :
     IsSemigroupGroupPD (fun p : ℝ≥0 × W => F (p.1, φ p.2)) ↔ IsSemigroupGroupPD F :=
   comp_spatial_iff_of_surjective φ hsurj
 

--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -303,8 +303,7 @@ private theorem StronglyContinuousSemigroup.pointwiseBoundedOnUnitInterval
 
 One direction of [EN] Prop. I.5.3: strong continuity implies uniform boundedness
 on compact intervals. -/
-theorem StronglyContinuousSemigroup.normBoundedOnUnitInterval
-    (S : StronglyContinuousSemigroup X) :
+theorem StronglyContinuousSemigroup.normBoundedOnUnitInterval (S : StronglyContinuousSemigroup X) :
     ∃ (M : ℝ), 1 ≤ M ∧
       ∀ (t : ℝ), 0 ≤ t → t ≤ 1 → ‖S.realOperator t‖ ≤ M := by
   obtain ⟨C, hC⟩ := banach_steinhaus S.pointwiseBoundedOnUnitInterval

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Basic.lean
@@ -86,8 +86,7 @@ def ofBounded (A : X →L[ℝ] X) : StronglyContinuousSemigroup X where
 
 /-- The operator of `ofBounded A` at nonnegative time `t` is `exp (t • A)`. -/
 @[simp]
-theorem ofBounded_apply (A : X →L[ℝ] X) (t : ℝ≥0) :
-    (ofBounded A) t = exp ((t : ℝ) • A) := by
+theorem ofBounded_apply (A : X →L[ℝ] X) (t : ℝ≥0) : (ofBounded A) t = exp ((t : ℝ) • A) := by
   rw [ofBounded]; rfl
 
 /-- The operator of `ofBounded A` at nonnegative time `t`, applied to `x`, is `exp (t • A) x`. -/
@@ -119,8 +118,7 @@ theorem ofBounded_realOperator_continuousOn_Ici (A : X →L[ℝ] X) :
   exact fun t ht => ofBounded_realOperator_of_nonneg A ht
 
 /-- The semigroup `ofBounded A` has the growth bound `(‖A‖, 1)`: `‖exp (t • A)‖ ≤ e^{‖A‖ t}`. -/
-theorem ofBounded_hasGrowthBound (A : X →L[ℝ] X) :
-    (ofBounded A).HasGrowthBound ‖A‖ 1 := by
+theorem ofBounded_hasGrowthBound (A : X →L[ℝ] X) : (ofBounded A).HasGrowthBound ‖A‖ 1 := by
   refine hasGrowthBound_of_bound le_rfl (fun t ht => ?_)
   rw [one_mul, ofBounded_realOperator_of_nonneg A ht]
   calc ‖exp (t • A)‖ ≤ Real.exp ‖t • A‖ := norm_exp_le_exp_norm _
@@ -159,15 +157,13 @@ theorem mem_ofBounded_domain (A : X →L[ℝ] X) (x : X) :
 
 /-- The generator domain of `ofBounded A` is the whole space. -/
 @[simp]
-theorem ofBounded_domain_eq_top (A : X →L[ℝ] X) :
-    (ofBounded A).domain = ⊤ :=
+theorem ofBounded_domain_eq_top (A : X →L[ℝ] X) : (ofBounded A).domain = ⊤ :=
   ((ofBounded A).generator_eq_toPMap_top_of_forall_tendsto (A : X →ₗ[ℝ] X)
     (ofBounded_genQuot_tendsto A)).1
 
 /-- The generator of `ofBounded A` is `A` itself, viewed as a total unbounded operator. -/
 @[simp]
-theorem ofBounded_generator (A : X →L[ℝ] X) :
-    (ofBounded A).generator = (A : X →ₗ[ℝ] X).toPMap ⊤ :=
+theorem ofBounded_generator (A : X →L[ℝ] X) : (ofBounded A).generator = (A : X →ₗ[ℝ] X).toPMap ⊤ :=
   ((ofBounded A).generator_eq_toPMap_top_of_forall_tendsto (A : X →ₗ[ℝ] X)
     (ofBounded_genQuot_tendsto A)).2
 

--- a/TauCeti/Analysis/Semigroups/BoundedGenerator/Resolvent.lean
+++ b/TauCeti/Analysis/Semigroups/BoundedGenerator/Resolvent.lean
@@ -46,8 +46,7 @@ private theorem norm_inv_smul_lt_one (A : X →L[ℝ] X) {lambda : ℝ}
   rw [norm_smul, Real.norm_eq_abs, abs_inv]
   exact (inv_mul_lt_one₀ (lt_of_le_of_lt (norm_nonneg A) hlambda)).2 hlambda
 
-private theorem inv_smul_tsum_pow_mul_sub (A : X →L[ℝ] X) {lambda : ℝ}
-    (hlambda : ‖A‖ < |lambda|) :
+private theorem inv_smul_tsum_pow_mul_sub (A : X →L[ℝ] X) {lambda : ℝ} (hlambda : ‖A‖ < |lambda|) :
     lambda⁻¹ • ((∑' n : ℕ, (lambda⁻¹ • A) ^ n) * (lambda • 1 - A)) = 1 := by
   have hlambda_ne : lambda ≠ 0 := abs_pos.mp (lt_of_le_of_lt (norm_nonneg A) hlambda)
   have hfactor : lambda • (1 - lambda⁻¹ • A) = lambda • 1 - A := by
@@ -59,8 +58,7 @@ private theorem inv_smul_tsum_pow_mul_sub (A : X →L[ℝ] X) {lambda : ℝ}
 /-- For `λ > ‖A‖`, the Laplace-transform resolvent of `t ↦ exp (tA)` is the Neumann series
 `λ⁻¹ ∑' n, (λ⁻¹ A)ⁿ`. -/
 @[simp] theorem ofBounded_resolvent_eq_inv_smul_tsum_pow (A : X →L[ℝ] X) {lambda : ℝ}
-    (hlambda : ‖A‖ < lambda) :
-    (ofBounded A).resolvent (ofBounded_hasGrowthBound A) lambda hlambda =
+    (hlambda : ‖A‖ < lambda) : (ofBounded A).resolvent (ofBounded_hasGrowthBound A) lambda hlambda =
       lambda⁻¹ • ∑' n : ℕ, (lambda⁻¹ • A) ^ n := by
   have hlambda_pos : 0 < lambda := lt_of_le_of_lt (norm_nonneg A) hlambda
   have hlambda_abs : ‖A‖ < |lambda| := by simpa [abs_of_pos hlambda_pos] using hlambda
@@ -93,8 +91,7 @@ private theorem inv_smul_tsum_pow_mul_sub (A : X →L[ℝ] X) {lambda : ℝ}
 
 /-- For `λ > ‖A‖`, the Laplace-transform resolvent of `t ↦ exp (tA)` agrees with
 Mathlib's Banach-algebra resolvent of `A`. -/
-theorem ofBounded_resolvent_eq_resolvent (A : X →L[ℝ] X) {lambda : ℝ}
-    (hlambda : ‖A‖ < lambda) :
+theorem ofBounded_resolvent_eq_resolvent (A : X →L[ℝ] X) {lambda : ℝ} (hlambda : ‖A‖ < lambda) :
     (ofBounded A).resolvent (ofBounded_hasGrowthBound A) lambda hlambda =
       _root_.resolvent A lambda := by
   have hlambda_pos : 0 < lambda := lt_of_le_of_lt (norm_nonneg A) hlambda

--- a/TauCeti/Analysis/Semigroups/CauchyProblem.lean
+++ b/TauCeti/Analysis/Semigroups/CauchyProblem.lean
@@ -111,15 +111,12 @@ theorem isMildSolution_iff [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u :
   Iff.rfl
 
 /-- The time integral of a mild solution belongs to the operator domain. -/
-theorem IsMildSolution.integral_mem_domain [CompleteSpace X]
-    {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
-    (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
-    (∫ s in Set.Ioc 0 t, u s) ∈ A.domain :=
+theorem IsMildSolution.integral_mem_domain [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+    (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) : (∫ s in Set.Ioc 0 t, u s) ∈ A.domain :=
   (hu.2.2 t ht).choose
 
 /-- The integrated Cauchy equation satisfied by a mild solution. -/
-theorem IsMildSolution.map_integral_eq_sub [CompleteSpace X]
-    {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
+theorem IsMildSolution.map_integral_eq_sub [CompleteSpace X] {A : X →ₗ.[ℝ] X} {x : X} {u : ℝ → X}
     (hu : IsMildSolution A x u) {t : ℝ} (ht : 0 ≤ t) :
     A ⟨∫ s in Set.Ioc 0 t, u s, hu.integral_mem_domain ht⟩ = u t - x := by
   obtain ⟨hut, hmap⟩ := hu.2.2 t ht

--- a/TauCeti/Analysis/Semigroups/Dissipative/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Dissipative/Basic.lean
@@ -323,8 +323,7 @@ variable [CompleteSpace X]
 This is the Hille--Yosida resolvent bound `‖R(lambda)‖ ≤ M / (lambda - ω)` read backwards
 through the left-inverse identity `R(lambda) (lambda x - A x) = x`. -/
 theorem norm_le_norm_smul_sub_generator (S : StronglyContinuousSemigroup X) {ω M : ℝ}
-    (hb : S.HasGrowthBound ω M) {lambda : ℝ} (hlambda : ω < lambda)
-    (x : S.generator.domain) :
+    (hb : S.HasGrowthBound ω M) {lambda : ℝ} (hlambda : ω < lambda) (x : S.generator.domain) :
     ‖(x : X)‖ ≤ M / (lambda - ω) * ‖lambda • (x : X) - S.generator x‖ := by
   have hx : (x : X) ∈ S.domain := by
     rw [← S.generator_domain]

--- a/TauCeti/Analysis/Semigroups/ExponentialShift.lean
+++ b/TauCeti/Analysis/Semigroups/ExponentialShift.lean
@@ -67,8 +67,7 @@ theorem expShift_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : �
 
 omit [CompleteSpace X] in
 /-- Pointwise form of `StronglyContinuousSemigroup.expShift_apply`. -/
-theorem expShift_apply_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ)
-    (t : ℝ≥0) (x : X) :
+theorem expShift_apply_apply (S : StronglyContinuousSemigroup X) (lambda : ℝ) (t : ℝ≥0) (x : X) :
     S.expShift lambda t x = Real.exp (-(lambda * (t : ℝ))) • S t x :=
   by rw [expShift_apply, smul_apply]
 
@@ -102,8 +101,7 @@ theorem expShift_realOperator_of_nonneg (S : StronglyContinuousSemigroup X)
 omit [CompleteSpace X] in
 /-- Pointwise real-time form of the shifted operator at nonnegative times. -/
 theorem expShift_realOperator_apply_of_nonneg (S : StronglyContinuousSemigroup X)
-    (lambda t : ℝ) (ht : 0 ≤ t) (x : X) :
-    (S.expShift lambda).realOperator t x =
+    (lambda t : ℝ) (ht : 0 ≤ t) (x : X) : (S.expShift lambda).realOperator t x =
       Real.exp (-(lambda * t)) • S.realOperator t x := by
   rw [S.expShift_realOperator_of_nonneg lambda t ht]
   rw [smul_apply]

--- a/TauCeti/Analysis/Semigroups/Generator/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Basic.lean
@@ -35,8 +35,7 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 /-- The integral averages `(1/t) • ∫_{(0,t]} g u du` of a function that is locally strongly
 measurable and continuous at `0` from the right tend to `g 0` as `t → 0⁺`. -/
 private theorem tendsto_average_Ioc_zero_of_stronglyMeasurableAtFilter_continuousWithinAt_Ioi
-    {g : ℝ → X}
-    (hmeas : StronglyMeasurableAtFilter g (nhdsWithin (0 : ℝ) (Set.Ioi 0)) volume)
+    {g : ℝ → X} (hmeas : StronglyMeasurableAtFilter g (nhdsWithin (0 : ℝ) (Set.Ioi 0)) volume)
     (hg0 : ContinuousWithinAt g (Set.Ioi 0) 0) :
     Filter.Tendsto
       (fun t => (1 / t) • ∫ u in Set.Ioc 0 t, g u)

--- a/TauCeti/Analysis/Semigroups/Generator/Invariance.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/Invariance.lean
@@ -34,8 +34,7 @@ namespace StronglyContinuousSemigroup
 omit [CompleteSpace X] in
 /-- The difference quotient based at `S s x` is `S s` applied to the difference quotient
 based at `x`. -/
-private theorem tendsto_genQuot_apply (S : StronglyContinuousSemigroup X) (s : ℝ≥0)
-    {x y : X}
+private theorem tendsto_genQuot_apply (S : StronglyContinuousSemigroup X) (s : ℝ≥0) {x y : X}
     (h : Filter.Tendsto (fun t => (1 / t) • (S.realOperator t x - x))
       (nhdsWithin 0 (Set.Ioi 0)) (nhds y)) :
     Filter.Tendsto (fun t => (1 / t) • (S.realOperator t (S s x) - S s x))
@@ -50,8 +49,7 @@ private theorem tendsto_genQuot_apply (S : StronglyContinuousSemigroup X) (s : �
 
 omit [CompleteSpace X] in
 /-- Every semigroup operator preserves the domain of the infinitesimal generator. -/
-theorem map_mem_domain (S : StronglyContinuousSemigroup X) (s : ℝ≥0) {x : X}
-    (hx : x ∈ S.domain) :
+theorem map_mem_domain (S : StronglyContinuousSemigroup X) (s : ℝ≥0) {x : X} (hx : x ∈ S.domain) :
     S s x ∈ S.domain := by
   rw [S.mem_domain_iff_tendsto] at hx ⊢
   obtain ⟨y, hy⟩ := hx

--- a/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
+++ b/TauCeti/Analysis/Semigroups/Generator/OrbitDerivative.lean
@@ -37,8 +37,7 @@ namespace StronglyContinuousSemigroup
 
 /-- At time zero, the right derivative of the orbit of a generator-domain vector is its
 generator. -/
-theorem realOperator_hasDerivWithinAt_zero (S : StronglyContinuousSemigroup X)
-    (x : S.domain) :
+theorem realOperator_hasDerivWithinAt_zero (S : StronglyContinuousSemigroup X) (x : S.domain) :
     HasDerivWithinAt (fun s : ℝ => S.realOperator s (x : X))
       (S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩) (Set.Ici 0) 0 := by
   rw [hasDerivWithinAt_iff_tendsto_slope]
@@ -53,16 +52,14 @@ theorem realOperator_differentiableWithinAt_zero (S : StronglyContinuousSemigrou
 
 /-- The right derivative at zero of the orbit of a generator-domain vector is its generator. -/
 @[simp]
-theorem realOperator_derivWithin_zero (S : StronglyContinuousSemigroup X)
-    (x : S.domain) :
+theorem realOperator_derivWithin_zero (S : StronglyContinuousSemigroup X) (x : S.domain) :
     derivWithin (fun s : ℝ => S.realOperator s (x : X)) (Set.Ici 0) 0 =
       S.generator ⟨x, by rw [S.generator_domain]; exact x.property⟩ :=
   (S.realOperator_hasDerivWithinAt_zero x).derivWithin (uniqueDiffWithinAt_Ici 0)
 
 /-- The orbit has right derivative `y` at zero exactly when its initial vector belongs to the
 generator domain and the generator value is `y`. -/
-theorem realOperator_hasDerivWithinAt_zero_iff (S : StronglyContinuousSemigroup X)
-    (x y : X) :
+theorem realOperator_hasDerivWithinAt_zero_iff (S : StronglyContinuousSemigroup X) (x y : X) :
     HasDerivWithinAt (fun s : ℝ => S.realOperator s x) y (Set.Ici 0) 0 ↔
       ∃ hx : x ∈ S.domain,
         S.generator ⟨x, by rw [S.generator_domain]; exact hx⟩ = y := by

--- a/TauCeti/Analysis/Semigroups/GrowthBound.lean
+++ b/TauCeti/Analysis/Semigroups/GrowthBound.lean
@@ -78,16 +78,14 @@ theorem StronglyContinuousSemigroup.HasGrowthBound.mono
 omit [CompleteSpace X] in
 /-- A growth bound can be weakened by increasing the exponential rate. -/
 theorem StronglyContinuousSemigroup.HasGrowthBound.mono_omega
-    {S : StronglyContinuousSemigroup X} {ω M ω' : ℝ}
-    (hb : S.HasGrowthBound ω M) (hω : ω ≤ ω') :
+    {S : StronglyContinuousSemigroup X} {ω M ω' : ℝ} (hb : S.HasGrowthBound ω M) (hω : ω ≤ ω') :
     S.HasGrowthBound ω' M :=
   hb.mono hω le_rfl
 
 omit [CompleteSpace X] in
 /-- A growth bound can be weakened by increasing the multiplicative constant. -/
 theorem StronglyContinuousSemigroup.HasGrowthBound.mono_const
-    {S : StronglyContinuousSemigroup X} {ω M M' : ℝ}
-    (hb : S.HasGrowthBound ω M) (hM : M ≤ M') :
+    {S : StronglyContinuousSemigroup X} {ω M M' : ℝ} (hb : S.HasGrowthBound ω M) (hM : M ≤ M') :
     S.HasGrowthBound ω M' :=
   hb.mono le_rfl hM
 
@@ -123,8 +121,7 @@ theorem ContractionSemigroup.hasGrowthBound_of_nonneg_omega_of_one_le_const
 
 /-- Every C₀-semigroup has a finite exponential growth bound
 ([EN] Prop. I.5.5, [Linares] Thm. 1). -/
-theorem StronglyContinuousSemigroup.existsGrowthBound
-    (S : StronglyContinuousSemigroup X) :
+theorem StronglyContinuousSemigroup.existsGrowthBound (S : StronglyContinuousSemigroup X) :
     ∃ (ω : ℝ) (M : ℝ), S.HasGrowthBound ω M := by
   obtain ⟨M, hM1, hMbound⟩ := S.normBoundedOnUnitInterval
   have hM_pos : 0 < M := by linarith

--- a/TauCeti/Analysis/Semigroups/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Identity.lean
@@ -45,15 +45,13 @@ variable {X}
 
 /-- The identity C₀-semigroup is constantly the identity operator. -/
 @[simp]
-theorem id_apply (t : ℝ≥0) :
-    (StronglyContinuousSemigroup.id X) t = ContinuousLinearMap.id ℝ X :=
+theorem id_apply (t : ℝ≥0) : (StronglyContinuousSemigroup.id X) t = ContinuousLinearMap.id ℝ X :=
   by
     rw [StronglyContinuousSemigroup.id]
     rfl
 
 /-- Pointwise form of `StronglyContinuousSemigroup.id_apply`. -/
-theorem id_apply_apply (t : ℝ≥0) (x : X) :
-    (StronglyContinuousSemigroup.id X) t x = x := by
+theorem id_apply_apply (t : ℝ≥0) (x : X) : (StronglyContinuousSemigroup.id X) t x = x := by
   rw [id_apply]
   exact ContinuousLinearMap.id_apply x
 
@@ -75,15 +73,13 @@ variable {X}
 
 /-- The identity contraction semigroup is constantly the identity operator. -/
 @[simp]
-theorem id_apply (t : ℝ≥0) :
-    (ContractionSemigroup.id X) t = ContinuousLinearMap.id ℝ X :=
+theorem id_apply (t : ℝ≥0) : (ContractionSemigroup.id X) t = ContinuousLinearMap.id ℝ X :=
   by
     rw [ContractionSemigroup.id]
     rfl
 
 /-- Pointwise form of `ContractionSemigroup.id_apply`. -/
-theorem id_apply_apply (t : ℝ≥0) (x : X) :
-    (ContractionSemigroup.id X) t x = x := by
+theorem id_apply_apply (t : ℝ≥0) (x : X) : (ContractionSemigroup.id X) t x = x := by
   rw [id_apply]
   exact ContinuousLinearMap.id_apply x
 
@@ -102,8 +98,7 @@ namespace StronglyContinuousSemigroup
 variable {X}
 
 /-- The identity semigroup has the contraction growth bound `(0, 1)`. -/
-theorem id_hasGrowthBound :
-    (StronglyContinuousSemigroup.id X).HasGrowthBound 0 1 := by
+theorem id_hasGrowthBound : (StronglyContinuousSemigroup.id X).HasGrowthBound 0 1 := by
   rw [← ContractionSemigroup.id_toStronglyContinuousSemigroup]
   exact (ContractionSemigroup.id X).hasGrowthBound
 
@@ -127,15 +122,13 @@ theorem mem_id_domain (x : X) :
 
 /-- The generator domain of the identity semigroup is all of the space. -/
 @[simp]
-theorem id_domain_eq_top :
-    (StronglyContinuousSemigroup.id X).domain = ⊤ :=
+theorem id_domain_eq_top : (StronglyContinuousSemigroup.id X).domain = ⊤ :=
   ((StronglyContinuousSemigroup.id X).generator_eq_toPMap_top_of_forall_tendsto 0
     (by simpa using id_genQuot_tendsto (X := X))).1
 
 /-- The generator of the identity semigroup is the zero operator. -/
 @[simp]
-theorem id_generator_eq_zero :
-    (StronglyContinuousSemigroup.id X).generator = 0 := by
+theorem id_generator_eq_zero : (StronglyContinuousSemigroup.id X).generator = 0 := by
   rw [((StronglyContinuousSemigroup.id X).generator_eq_toPMap_top_of_forall_tendsto 0
     (by simpa using id_genQuot_tendsto (X := X))).2]
   rfl

--- a/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
@@ -267,8 +267,7 @@ private theorem StronglyContinuousSemigroup.resolvent_generator_tendsto
 ([EN] Thm. II.1.10(i), [Linares] eq. 0.15). -/
 theorem StronglyContinuousSemigroup.resolvent_mem_domain
     (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M)
-    (lambda : ℝ) (hlam : ω < lambda) (x : X) :
-    (S.resolvent hb lambda hlam x) ∈ S.domain :=
+    (lambda : ℝ) (hlam : ω < lambda) (x : X) : (S.resolvent hb lambda hlam x) ∈ S.domain :=
   (S.mem_domain_iff_tendsto _).mpr ⟨_, S.resolvent_generator_tendsto hb lambda hlam x⟩
 
 /-- The fundamental resolvent identity: `(λI - A) R(λ) x = x`. -/

--- a/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
@@ -37,8 +37,7 @@ namespace StronglyContinuousSemigroup
 /-- The exponentially weighted orbit of a generator-domain vector tends to zero when the
 exponential rate is larger than the semigroup growth exponent. -/
 private theorem tendsto_exp_neg_smul_realOperator_atTop (S : StronglyContinuousSemigroup X)
-    {omega M lambda : ℝ} (hb : S.HasGrowthBound omega M) (hlambda : omega < lambda)
-    (x : S.domain) :
+    {omega M lambda : ℝ} (hb : S.HasGrowthBound omega M) (hlambda : omega < lambda) (x : S.domain) :
     Filter.Tendsto (fun t : ℝ => Real.exp (-(lambda * t)) • S.realOperator t (x : X))
       Filter.atTop (nhds 0) := by
   apply tendsto_zero_iff_norm_tendsto_zero.mpr
@@ -93,10 +92,8 @@ private theorem hasDerivAt_exp_neg_smul_realOperator
 
 /-- The Laplace-transform resolvent is a left inverse to `lambda • I - A` on the generator
 domain: `R(lambda) (lambda x - A x) = x`. -/
-@[simp] theorem resolventLeftInv (S : StronglyContinuousSemigroup X) {omega M : ℝ}
-    [CompleteSpace X]
-    (hb : S.HasGrowthBound omega M) (lambda : ℝ) (hlambda : omega < lambda)
-    (x : S.domain) :
+@[simp] theorem resolventLeftInv (S : StronglyContinuousSemigroup X) {omega M : ℝ} [CompleteSpace X]
+    (hb : S.HasGrowthBound omega M) (lambda : ℝ) (hlambda : omega < lambda) (x : S.domain) :
     S.resolvent hb lambda hlambda
         (lambda • (x : X) - S.generator
           ⟨x, by rw [S.generator_domain]; exact x.property⟩) = x := by
@@ -133,8 +130,7 @@ domain: `R(lambda) (lambda x - A x) = x`. -/
 /-- Pointwise form of the resolvent identity
 `R(lambda) - R(mu) = (mu - lambda) R(lambda) R(mu)`. -/
 theorem resolvent_sub_resolvent_apply (S : StronglyContinuousSemigroup X)
-    {omegaLambda MLambda omegaMu MMu : ℝ}
-    [CompleteSpace X]
+    {omegaLambda MLambda omegaMu MMu : ℝ} [CompleteSpace X]
     (hbLambda : S.HasGrowthBound omegaLambda MLambda)
     (hbMu : S.HasGrowthBound omegaMu MMu) (lambda mu : ℝ)
     (hlambda : omegaLambda < lambda) (hmu : omegaMu < mu) (x : X) :
@@ -186,10 +182,8 @@ theorem resolvent_sub_resolvent (S : StronglyContinuousSemigroup X)
   exact S.resolvent_sub_resolvent_apply hbLambda hbMu lambda mu hlambda hmu x
 
 /-- Resolvents at two admissible parameters commute. -/
-theorem resolvent_comm (S : StronglyContinuousSemigroup X)
-    {omegaLambda MLambda omegaMu MMu : ℝ}
-    [CompleteSpace X]
-    (hbLambda : S.HasGrowthBound omegaLambda MLambda)
+theorem resolvent_comm (S : StronglyContinuousSemigroup X) {omegaLambda MLambda omegaMu MMu : ℝ}
+    [CompleteSpace X] (hbLambda : S.HasGrowthBound omegaLambda MLambda)
     (hbMu : S.HasGrowthBound omegaMu MMu) (lambda mu : ℝ)
     (hlambda : omegaLambda < lambda) (hmu : omegaMu < mu) :
     S.resolvent hbLambda lambda hlambda ∘L S.resolvent hbMu mu hmu =

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/Fourier.lean
@@ -299,10 +299,8 @@ private theorem fourier_twoPiHermiteFunction_zero :
     _ = fun x : ℝ => (twoPiHermiteFunction 0 x : ℂ) := hfun.symm
 
 private theorem twoPiHermiteFunction_succ_complex (n : ℕ) :
-    (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) =
-      (Real.sqrt (2 * ((n : ℝ) + 1)) : ℂ)⁻¹ •
-        ((Real.sqrt (2 * Real.pi) : ℂ) •
-            (fun x : ℝ => x • (twoPiHermiteFunction n x : ℂ))
+    (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) = (Real.sqrt (2 * ((n : ℝ) + 1)) : ℂ)⁻¹ •
+        ((Real.sqrt (2 * Real.pi) : ℂ) • (fun x : ℝ => x • (twoPiHermiteFunction n x : ℂ))
           + (-(Real.sqrt (2 * Real.pi) : ℂ)⁻¹) •
             (fun x : ℝ => ((deriv (twoPiHermiteFunction n) x : ℝ) : ℂ))) := by
   funext x
@@ -330,8 +328,7 @@ private theorem twoPiHermiteFunction_succ_complex (n : ℕ) :
       rw [Complex.real_smul]
       ring
 
-private theorem fourier_mul_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : ℂ)
-    (hfourier :
+private theorem fourier_mul_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : ℂ) (hfourier :
       𝓕 (fun x : ℝ => (twoPiHermiteFunction n x : ℂ)) =
         fun x => eigen * twoPiHermiteFunction n x) :
     𝓕 (fun x : ℝ => x • (twoPiHermiteFunction n x : ℂ)) =
@@ -362,8 +359,7 @@ private theorem fourier_mul_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : ℂ
   rw [pow_two, Complex.I_mul_I]
   ring
 
-private theorem fourier_deriv_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : ℂ)
-    (hfourier :
+private theorem fourier_deriv_twoPiHermiteFunction_of_eigen (n : ℕ) (eigen : ℂ) (hfourier :
       𝓕 (fun x : ℝ => (twoPiHermiteFunction n x : ℂ)) =
         fun x => eigen * twoPiHermiteFunction n x) :
     𝓕 (fun x : ℝ => ((deriv (twoPiHermiteFunction n) x : ℝ) : ℂ)) =
@@ -404,8 +400,7 @@ private theorem fourier_twoPiHermiteFunction_succ_eq (n : ℕ) (w : ℝ) :
     hadd, Pi.add_apply, fourier_const_smul, fourier_const_smul, Pi.smul_apply, Pi.smul_apply,
     smul_eq_mul, smul_eq_mul]
 
-private theorem fourier_twoPiHermiteFunction_succ (n : ℕ) (eigen : ℂ)
-    (hfourier :
+private theorem fourier_twoPiHermiteFunction_succ (n : ℕ) (eigen : ℂ) (hfourier :
       𝓕 (fun x : ℝ => (twoPiHermiteFunction n x : ℂ)) =
         fun x => eigen * twoPiHermiteFunction n x) :
     𝓕 (fun x : ℝ => (twoPiHermiteFunction (n + 1) x : ℂ)) =

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Transfer.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Cosine/Transfer.lean
@@ -237,8 +237,7 @@ lemma integral_eval_T_real_measureT_eq_integral_chebyshevCosine (n : ℕ) :
 
 /-- Transfer a product of two Chebyshev `T` polynomials from `measureT` to the
 angular cosine-side integral. -/
-lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_mul
-    (m n : ℕ) :
+lemma integral_eval_T_real_mul_eval_T_real_measureT_eq_integral_chebyshevCosine_mul (m n : ℕ) :
     ∫ x, (T ℝ m).eval x * (T ℝ n).eval x ∂Polynomial.Chebyshev.measureT =
       ∫ θ in (0)..Real.pi, chebyshevCosine m θ * chebyshevCosine n θ := by
   rw [integral_measureT_eq_integral_cos]

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Measure.lean
@@ -154,8 +154,7 @@ lemma ae_mem_Icc_measureT :
 This is the compact-support consumer form used by the Chebyshev completeness
 argument. -/
 lemma integrable_exp_mul_abs_smul_measureT {𝕜 β : Type*} [RCLike 𝕜] [NormedAddCommGroup β]
-    [NormedSpace 𝕜 β] {g : ℝ → β} (a : ℝ)
-    (hg : Integrable g Polynomial.Chebyshev.measureT) :
+    [NormedSpace 𝕜 β] {g : ℝ → β} (a : ℝ) (hg : Integrable g Polynomial.Chebyshev.measureT) :
     Integrable (fun x : ℝ => (Real.exp (a * |x|) : 𝕜) • g x)
       Polynomial.Chebyshev.measureT := by
   exact Integrable.exp_abs_smul_of_ae_abs_le hg a 1 (by

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Span.lean
@@ -110,8 +110,7 @@ lemma inner_polynomialEvalChebyshevLp (g : Lp ℝ 2 Polynomial.Chebyshev.measure
 
 /-- A vector orthogonal to every normalized Chebyshev mode has vanishing polynomial moments: this
 is the concrete integral form of `inner_polynomialEvalChebyshevLp_eq_zero`. -/
-theorem integral_polynomialEval_measureT_eq_zero
-    (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
+theorem integral_polynomialEval_measureT_eq_zero (g : Lp ℝ 2 Polynomial.Chebyshev.measureT)
     (hmode : ∀ n, inner ℝ g (normalizedChebyshevTLp ℝ n) = 0) (q : Polynomial ℝ) :
     ∫ x, g x * q.eval x ∂Polynomial.Chebyshev.measureT = 0 := by
   rw [← inner_polynomialEvalChebyshevLp g q]


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/Analysis/`: 150 joins across 51 files, `-150` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 51 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping. Width is measured in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports. Widest resulting line is exactly 100 codepoints (`Semigroups/Resolvent/Identity.lean:95`), at the limit and legal; nothing exceeds it.

Subdirectories covered: `PositiveDefinite` (45), `Semigroups` (37), `Fredholm` (22), `PDE` (21), `CompletelyMonotone` (9), `SpecialFunctions` (8), `Calculus` (4), `Bochner` (2), `Normed` (1).

Two deliberate exclusions: `Analysis/Complex/` is left alone because an open PR is developing there, and `Analysis/Contour/` was already packed in #1712. Everything else under `Analysis/` is packed, so no leftovers remain to invite a follow-up.

Gates: `lake build` (6166 jobs) · `lake exe axioms` (19325 declarations, allowlist clean) · `lake exe module-system` (1057 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none