### PR TITLE
feat: prove the Skolem-Noether theorem

### DIFF
--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -4,19 +4,27 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.CentralSimple.TensorProduct
-public import TauCeti.RingTheory.Semisimple.SimpleArtinian
-public import Mathlib.Algebra.Azumaya.Defs
-public import Mathlib.RingTheory.TensorProduct.Maps
--- Non-public: none of these appears in the type of an exported declaration. Finiteness of a tensor
--- product, the passage from a finite-dimensional algebra to an Artinian ring, and the `Aᵐᵒᵖ`
--- linear equivalence are used only inside the proof of Skolem-Noether.
+-- Public: exactly the modules supplying types and classes that occur in the statements exported
+-- from here. `Mathlib.RingTheory.TensorProduct.Basic` carries the algebra structure on
+-- `B ⊗[K] Aᵐᵒᵖ` (and with it `AlgHom`, `AlgEquiv` and `Subalgebra`); the other three carry
+-- `Algebra.IsCentral`, `IsSimpleRing` and `FiniteDimensional`.
+public import Mathlib.Algebra.Central.Defs
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+public import Mathlib.RingTheory.SimpleRing.Defs
+public import Mathlib.RingTheory.TensorProduct.Basic
+-- Non-public: none of these appears in the type of an exported declaration. Simplicity of a tensor
+-- product, the classification of modules over a simple Artinian algebra, `AlgHom.mulLeftRight`,
+-- `Algebra.TensorProduct.map` and finiteness of a tensor product are used only inside proofs, and
+-- the matrix, complex and quaternion modules only by the worked examples at the end of the file.
+import Mathlib.Algebra.Azumaya.Defs
 import Mathlib.Algebra.Central.Matrix
 import Mathlib.Data.Complex.Basic
-import Mathlib.RingTheory.Artinian.Algebra
 import Mathlib.RingTheory.SimpleRing.Matrix
 import Mathlib.RingTheory.TensorProduct.Finite
+import Mathlib.RingTheory.TensorProduct.Maps
 import TauCeti.Algebra.Central.Quaternion
+import TauCeti.Algebra.CentralSimple.TensorProduct
+import TauCeti.RingTheory.Semisimple.SimpleArtinian
 
 /-!
 # The Skolem-Noether theorem
@@ -42,9 +50,9 @@ particular linear for the right action of `A`, hence is multiplication on the le
 * `TauCeti.Bimodule`: `A` as a module over `B ⊗[K] Aᵐᵒᵖ` through an algebra homomorphism
   `f : B →ₐ[K] A`, with its basic API (`TauCeti.Bimodule.of`, `TauCeti.Bimodule.smul_of`).
 * `TauCeti.skolemNoether`: **the Skolem-Noether theorem**.
-* `TauCeti.exists_units_conj_of_algEquiv`: every `K`-algebra automorphism of a finite-dimensional
+* `TauCeti.exists_unit_conj_of_algEquiv`: every `K`-algebra automorphism of a finite-dimensional
   central simple `K`-algebra is inner.
-* `TauCeti.exists_units_conj_subalgebra_val`: a `K`-algebra homomorphism out of a central simple
+* `TauCeti.exists_unit_conj_subalgebra_val`: a `K`-algebra homomorphism out of a central simple
   subalgebra `B ⊆ A` is conjugate to the inclusion of `B`. This is the form the centralizer theorem
   consumes.
 
@@ -56,7 +64,7 @@ and `A` simple. So the statement here is slightly stronger than the usual one, w
 central simple as well; the roadmap's central simple form is the case `Algebra.IsCentral K A`, which
 the statement covers because a central simple algebra is in particular simple. Finite-dimensionality
 of `B` is essential and is carried explicitly: the classification of modules that supplies `φ` needs
-`B ⊗[K] Aᵐᵒᵖ` to be Artinian.
+`B ⊗[K] Aᵐᵒᵖ` to be finite-dimensional over `K`, and with it Artinian.
 
 Centrality of the source really is needed, and not just by this proof: the worked example at the end
 of the file exhibits `ℂ` as a simple finite-dimensional `ℝ`-algebra, not central over `ℝ`, whose
@@ -107,12 +115,17 @@ instance : AddCommGroup (Bimodule f) := inferInstanceAs (AddCommGroup A)
 
 instance : Module K (Bimodule f) := inferInstanceAs (Module K A)
 
+/-- `TauCeti.Bimodule f` is `A` again as a `K`-module: only the `B ⊗[K] Aᵐᵒᵖ`-action is new. -/
+def of : A ≃ₗ[K] Bimodule f := LinearEquiv.refl K A
+
 /-- The action of `B ⊗[K] Aᵐᵒᵖ` on `A` defining `TauCeti.Bimodule f`, as an algebra homomorphism
 into `Module.End K A`. It is Mathlib's `AlgHom.mulLeftRight` restricted along `f` on the left
 factor, so for `f = AlgHom.id K A` it is `AlgHom.mulLeftRight K A` itself. -/
 noncomputable def toEnd : B ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A :=
   (AlgHom.mulLeftRight K A).comp (Algebra.TensorProduct.map f (AlgHom.id K Aᵐᵒᵖ))
 
+/-- A pure tensor `b ⊗ₜ op a` acts on `x : A` through `TauCeti.Bimodule.toEnd f` by
+`x ↦ f b * x * a`. -/
 @[simp]
 theorem toEnd_tmul_apply (b : B) (a : Aᵐᵒᵖ) (x : A) : toEnd f (b ⊗ₜ a) x = f b * x * a.unop := by
   simp [toEnd]
@@ -120,22 +133,30 @@ theorem toEnd_tmul_apply (b : B) (a : Aᵐᵒᵖ) (x : A) : toEnd f (b ⊗ₜ a)
 noncomputable instance : Module (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) :=
   Module.compHom (M := A) (toEnd f).toRingHom
 
+/-- A scalar `r : B ⊗[K] Aᵐᵒᵖ` acts on `TauCeti.Bimodule f` through `TauCeti.Bimodule.toEnd f`.
+This is the defining equation of the module structure, and the single place it is unfolded: the
+scalar tower instance below rewrites with it instead of reasoning up to definitional equality. It is
+`private` because its proof is that unfolding, and the bodies of `TauCeti.Bimodule.of` and
+`TauCeti.Bimodule.toEnd` are not exposed, so a module-exported theorem may not appeal to them; the
+public interface is `TauCeti.Bimodule.smul_of` and `TauCeti.Bimodule.symm_smul`. -/
+private theorem smul_def (r : B ⊗[K] Aᵐᵒᵖ) (x : A) : r • of f x = of f (toEnd f r x) := rfl
+
 instance : IsScalarTower K (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) where
   smul_assoc c r x := by
-    change (toEnd f (c • r)) _ = c • (toEnd f r) _
-    rw [map_smul]
-    rfl
+    rw [← (of f).apply_symm_apply x, smul_def, smul_def, map_smul (toEnd f),
+      LinearMap.smul_apply, map_smul (of f)]
 
 instance [Module.Finite K A] : Module.Finite K (Bimodule f) := inferInstanceAs (Module.Finite K A)
 
-/-- `TauCeti.Bimodule f` is `A` again as a `K`-module: only the `B ⊗[K] Aᵐᵒᵖ`-action is new. -/
-def of : A ≃ₗ[K] Bimodule f := LinearEquiv.refl K A
-
+/-- A pure tensor `b ⊗ₜ op a` acts on `TauCeti.Bimodule f` by `x ↦ f b * x * a`: the left factor
+acts on the left through `f`, the right factor on the right by multiplication. -/
 @[simp]
 theorem smul_of (b : B) (a : Aᵐᵒᵖ) (x : A) :
     (b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • of f x = of f (f b * x * a.unop) :=
   toEnd_tmul_apply f b a x
 
+/-- `TauCeti.Bimodule.smul_of` read back through `TauCeti.Bimodule.of`: the action of a pure tensor
+`b ⊗ₜ op a`, transported to `A`, is `x ↦ f b * x * a`. -/
 @[simp]
 theorem symm_smul (b : B) (a : Aᵐᵒᵖ) (y : Bimodule f) :
     (of f).symm ((b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • y) = f b * (of f).symm y * a.unop :=
@@ -159,8 +180,8 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
     [Algebra.IsCentral K B] [IsSimpleRing B] [FiniteDimensional K B] (f g : B →ₐ[K] A) :
     ∃ u : Aˣ, ∀ x : B, g x = (u : A) * f x * (↑u⁻¹ : A) := by
   have : FiniteDimensional K Aᵐᵒᵖ := Module.Finite.equiv (MulOpposite.opLinearEquiv K)
-  have : IsArtinianRing (B ⊗[K] Aᵐᵒᵖ) := IsArtinianRing.of_finite K _
-  have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) := rfl
+  have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) :=
+    ((Bimodule.of f).symm.trans (Bimodule.of g)).finrank_eq
   obtain ⟨φ⟩ := IsSimpleRing.nonempty_linearEquiv_of_finrank_eq (R := B ⊗[K] Aᵐᵒᵖ) K hrank
   set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
   -- Linearity of `φ` for the right action of `A` makes it left multiplication by `u`.
@@ -205,12 +226,11 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
       _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
       _ = g b * u := by rw [Bimodule.smul_of]; simp
   refine ⟨⟨u, v, huv, hvu⟩, fun x ↦ ?_⟩
-  change g x = u * f x * v
-  rw [hb x, mul_assoc, huv, mul_one]
+  rw [Units.inv_mk, Units.val_mk, Units.val_mk, hb x, mul_assoc, huv, mul_one]
 
 /-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a
 finite-dimensional central simple `K`-algebra `A` is conjugation by a unit of `A`. -/
-theorem exists_units_conj_of_algEquiv [Algebra.IsCentral K A] [IsSimpleRing A]
+theorem exists_unit_conj_of_algEquiv [Algebra.IsCentral K A] [IsSimpleRing A]
     [FiniteDimensional K A] (e : A ≃ₐ[K] A) :
     ∃ u : Aˣ, ∀ x : A, e x = (u : A) * x * (↑u⁻¹ : A) :=
   skolemNoether K (AlgHom.id K A) e.toAlgHom
@@ -218,7 +238,7 @@ theorem exists_units_conj_of_algEquiv [Algebra.IsCentral K A] [IsSimpleRing A]
 /-- A `K`-algebra homomorphism out of a **central simple** subalgebra `B` of a finite-dimensional
 simple `K`-algebra `A` is conjugate to the inclusion of `B`: it extends to an inner automorphism of
 `A`. This is the form the centralizer theorem consumes. -/
-theorem exists_units_conj_subalgebra_val [IsSimpleRing A] [FiniteDimensional K A]
+theorem exists_unit_conj_subalgebra_val [IsSimpleRing A] [FiniteDimensional K A]
     (B : Subalgebra K A) [Algebra.IsCentral K B] [IsSimpleRing B] (f : B →ₐ[K] A) :
     ∃ u : Aˣ, ∀ x : B, f x = (u : A) * (x : A) * (↑u⁻¹ : A) :=
   skolemNoether K B.val f
@@ -234,20 +254,20 @@ section Examples
 open scoped _root_.Quaternion
 
 /-- **Every automorphism of a matrix algebra is inner.** All three hypotheses of
-`TauCeti.exists_units_conj_of_algEquiv` are found by instance search: `Mₙ(K)` is central over `K`,
+`TauCeti.exists_unit_conj_of_algEquiv` are found by instance search: `Mₙ(K)` is central over `K`,
 simple, and finite-dimensional. -/
 example (K : Type*) [Field K] (n : ℕ) [NeZero n]
     (e : Matrix (Fin n) (Fin n) K ≃ₐ[K] Matrix (Fin n) (Fin n) K) :
     ∃ u : (Matrix (Fin n) (Fin n) K)ˣ, ∀ x, e x =
       (u : Matrix (Fin n) (Fin n) K) * x * (↑u⁻¹ : Matrix (Fin n) (Fin n) K) :=
-  exists_units_conj_of_algEquiv K e
+  exists_unit_conj_of_algEquiv K e
 
 /-- **Skolem-Noether in the small**: every `ℝ`-algebra automorphism of the real quaternions is
 inner. Centrality comes from `TauCeti.Quaternion.instIsCentral`, simplicity from `ℍ[ℝ]` being a
 division ring. -/
 example (e : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]) :
     ∃ u : ℍ[ℝ]ˣ, ∀ x : ℍ[ℝ], e x = (u : ℍ[ℝ]) * x * (↑u⁻¹ : ℍ[ℝ]) :=
-  exists_units_conj_of_algEquiv ℝ e
+  exists_unit_conj_of_algEquiv ℝ e
 
 /-- The negative control for `TauCeti.skolemNoether`: centrality of the **source** cannot be
 dropped. Take `K = ℝ` and `A = B = ℂ`, a simple finite-dimensional `ℝ`-algebra which is not central

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -5,9 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 -- Public: exactly the modules supplying types and classes that occur in the statements exported
--- from here. `Mathlib.RingTheory.TensorProduct.Basic` carries the algebra structure on
--- `B ⊗[K] Aᵐᵒᵖ` (and with it `AlgHom`, `AlgEquiv` and `Subalgebra`); the other three carry
--- `Algebra.IsCentral`, `IsSimpleRing` and `FiniteDimensional`.
+-- from here. `Mathlib.RingTheory.TensorProduct.Basic` carries `AlgHom`, `AlgEquiv` and `Subalgebra`
+-- (and the algebra structure on `B ⊗[K] Aᵐᵒᵖ` that the private construction below uses); the other
+-- three carry `Algebra.IsCentral`, `IsSimpleRing` and `FiniteDimensional`.
 public import Mathlib.Algebra.Central.Defs
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.SimpleRing.Defs
@@ -37,18 +37,16 @@ automorphism of a finite-dimensional central simple algebra is inner.
 
 The proof is the classical module-theoretic one. A homomorphism `f : B →ₐ[K] A` makes `A` into a
 module over `R = B ⊗[K] Aᵐᵒᵖ`, with `B` acting on the left through `f` and `A` on the right by
-multiplication; this is `TauCeti.Bimodule f`. Because `B` is central simple and `Aᵐᵒᵖ` is simple,
-`R` is a simple ring (`TauCeti.IsSimpleRing.tensorProduct`), and it is finite-dimensional over `K`,
-hence Artinian. The two modules `TauCeti.Bimodule f` and `TauCeti.Bimodule g` are carried by one
-and the same `K`-vector space `A`, so they have equal dimension, so they are isomorphic `R`-modules
+multiplication; this is the private `Bimodule f` below. Because `B` is central simple and `Aᵐᵒᵖ` is
+simple, `R` is a simple ring (`TauCeti.IsSimpleRing.tensorProduct`), and it is finite-dimensional
+over `K`, hence Artinian. The two modules `Bimodule f` and `Bimodule g` are carried by one and the
+same `K`-vector space `A`, so they have equal dimension, so they are isomorphic `R`-modules
 (`TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`). An `R`-linear isomorphism is in
 particular linear for the right action of `A`, hence is multiplication on the left by the unit
 `u = φ 1`, and its linearity for the left action of `B` is exactly `u * f x = g x * u`.
 
 ## Main results
 
-* `TauCeti.Bimodule`: `A` as a module over `B ⊗[K] Aᵐᵒᵖ` through an algebra homomorphism
-  `f : B →ₐ[K] A`, with its basic API (`TauCeti.Bimodule.of`, `TauCeti.Bimodule.smul_of`).
 * `TauCeti.skolemNoether`: **the Skolem-Noether theorem**.
 * `TauCeti.exists_unit_conj_of_algEquiv`: every `K`-algebra automorphism of a finite-dimensional
   central simple `K`-algebra is inner.
@@ -63,8 +61,10 @@ Centrality is asked of the **source** `B`, not of the target `A`: what the proof
 and `A` simple. So the statement here is slightly stronger than the usual one, which asks `A` to be
 central simple as well; the roadmap's central simple form is the case `Algebra.IsCentral K A`, which
 the statement covers because a central simple algebra is in particular simple. Finite-dimensionality
-of `B` is essential and is carried explicitly: the classification of modules that supplies `φ` needs
-`B ⊗[K] Aᵐᵒᵖ` to be finite-dimensional over `K`, and with it Artinian.
+of `B` is *not* assumed: the proof does need it, because the classification of modules that supplies
+`φ` needs `B ⊗[K] Aᵐᵒᵖ` to be finite-dimensional over `K` and with it Artinian, but it comes for
+free from the other hypotheses, since a homomorphism out of the simple ring `B` into the nontrivial
+ring `A` is injective and `A` is finite-dimensional.
 
 Centrality of the source really is needed, and not just by this proof: the worked example at the end
 of the file exhibits `ℂ` as a simple finite-dimensional `ℝ`-algebra, not central over `ℝ`, whose
@@ -73,13 +73,21 @@ simple `B` provided the ambient `A` is central simple, but that form needs the c
 and is a separate, later target; the central simple form pinned here is what the centralizer theorem
 itself consumes.
 
-`TauCeti.Bimodule f` is a type synonym for `A` rather than a `Module` instance on `A` itself,
-because the whole point is to compare the two different `B ⊗[K] Aᵐᵒᵖ`-module structures coming from
-`f` and from `g`; indexing the synonym by the homomorphism keeps both available at once. Mathlib
-takes the same route for `A ⊗[R] Aᵐᵒᵖ` acting on `A` in `Mathlib/Algebra/Azumaya/Defs.lean`, where
+`Bimodule f` is a type synonym for `A` rather than a `Module` instance on `A` itself, because the
+whole point is to compare the two different `B ⊗[K] Aᵐᵒᵖ`-module structures coming from `f` and from
+`g`; indexing the synonym by the homomorphism keeps both available at once. Mathlib takes the same
+route for `A ⊗[R] Aᵐᵒᵖ` acting on `A` in `Mathlib/Algebra/Azumaya/Defs.lean`, where
 `instModuleTensorProductMop` is deliberately not an instance. The action map is built from Mathlib's
 `AlgHom.mulLeftRight` by restricting along `f` on the left factor, so the two agree for `f` the
 identity of `A`.
+
+The whole construction is `private`: it is the mechanism of the proof below and has no consumer
+outside this file, so none of it — the synonym, its representation as `A`, the action map, or the
+instances — reaches the interface, and no importer can depend on `Bimodule f` being `A`
+definitionally. A type synonym cannot be carried by a `Module` instance without unfolding its body,
+so making it public would mean exposing that body; the exported statements are the three theorems
+below, all phrased in `A` and `B` alone. Should a later file need the bimodule, it can be made
+public then, together with an interface that pins down what that file actually uses.
 
 ## References
 
@@ -104,61 +112,60 @@ variable {K A B : Type*} [CommSemiring K] [Ring A] [Algebra K A] [Semiring B] [A
 
 Equivalently this is the `B`-`A`-bimodule `A` obtained by restricting the left action along `f`,
 packaged as a left module over `B ⊗[K] Aᵐᵒᵖ` in the usual way. It is a type synonym for `A`
-precisely so that the structures coming from two different homomorphisms can be compared. -/
-@[expose] def Bimodule (_f : B →ₐ[K] A) : Type _ := A
+precisely so that the structures coming from two different homomorphisms can be compared, and it is
+`private` because it is the mechanism of the proof below rather than part of the interface. -/
+private def Bimodule (_f : B →ₐ[K] A) : Type _ := A
 
 namespace Bimodule
 
 variable (f : B →ₐ[K] A)
 
-instance : AddCommGroup (Bimodule f) := inferInstanceAs (AddCommGroup A)
+private instance : AddCommGroup (Bimodule f) := inferInstanceAs (AddCommGroup A)
 
-instance : Module K (Bimodule f) := inferInstanceAs (Module K A)
+private instance : Module K (Bimodule f) := inferInstanceAs (Module K A)
 
-/-- `TauCeti.Bimodule f` is `A` again as a `K`-module: only the `B ⊗[K] Aᵐᵒᵖ`-action is new. -/
-def of : A ≃ₗ[K] Bimodule f := LinearEquiv.refl K A
+/-- `Bimodule f` is `A` again as a `K`-module: only the `B ⊗[K] Aᵐᵒᵖ`-action is new. -/
+private def of : A ≃ₗ[K] Bimodule f := LinearEquiv.refl K A
 
-/-- The action of `B ⊗[K] Aᵐᵒᵖ` on `A` defining `TauCeti.Bimodule f`, as an algebra homomorphism
-into `Module.End K A`. It is Mathlib's `AlgHom.mulLeftRight` restricted along `f` on the left
-factor, so for `f = AlgHom.id K A` it is `AlgHom.mulLeftRight K A` itself. -/
-noncomputable def toEnd : B ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A :=
+/-- The action of `B ⊗[K] Aᵐᵒᵖ` on `A` defining `Bimodule f`, as an algebra homomorphism into
+`Module.End K A`. It is Mathlib's `AlgHom.mulLeftRight` restricted along `f` on the left factor, so
+for `f = AlgHom.id K A` it is `AlgHom.mulLeftRight K A` itself. -/
+private noncomputable def toEnd : B ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A :=
   (AlgHom.mulLeftRight K A).comp (Algebra.TensorProduct.map f (AlgHom.id K Aᵐᵒᵖ))
 
-/-- A pure tensor `b ⊗ₜ op a` acts on `x : A` through `TauCeti.Bimodule.toEnd f` by
-`x ↦ f b * x * a`. -/
+/-- A pure tensor `b ⊗ₜ op a` acts on `x : A` through `toEnd f` by `x ↦ f b * x * a`. -/
 @[simp]
-theorem toEnd_tmul_apply (b : B) (a : Aᵐᵒᵖ) (x : A) : toEnd f (b ⊗ₜ a) x = f b * x * a.unop := by
+private theorem toEnd_tmul_apply (b : B) (a : Aᵐᵒᵖ) (x : A) :
+    toEnd f (b ⊗ₜ a) x = f b * x * a.unop := by
   simp [toEnd]
 
-noncomputable instance : Module (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) :=
+private noncomputable instance : Module (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) :=
   Module.compHom (M := A) (toEnd f).toRingHom
 
-/-- A scalar `r : B ⊗[K] Aᵐᵒᵖ` acts on `TauCeti.Bimodule f` through `TauCeti.Bimodule.toEnd f`.
-This is the defining equation of the module structure, and the single place it is unfolded: the
-scalar tower instance below rewrites with it instead of reasoning up to definitional equality. It is
-`private` because its proof is that unfolding, and the bodies of `TauCeti.Bimodule.of` and
-`TauCeti.Bimodule.toEnd` are not exposed, so a module-exported theorem may not appeal to them; the
-public interface is `TauCeti.Bimodule.smul_of` and `TauCeti.Bimodule.symm_smul`. -/
+/-- A scalar `r : B ⊗[K] Aᵐᵒᵖ` acts on `Bimodule f` through `toEnd f`. This is the defining equation
+of the module structure, and the single place it is unfolded: the scalar tower instance below
+rewrites with it instead of reasoning up to definitional equality. -/
 private theorem smul_def (r : B ⊗[K] Aᵐᵒᵖ) (x : A) : r • of f x = of f (toEnd f r x) := rfl
 
-instance : IsScalarTower K (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) where
+private instance : IsScalarTower K (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) where
   smul_assoc c r x := by
     rw [← (of f).apply_symm_apply x, smul_def, smul_def, map_smul (toEnd f),
       LinearMap.smul_apply, map_smul (of f)]
 
-instance [Module.Finite K A] : Module.Finite K (Bimodule f) := inferInstanceAs (Module.Finite K A)
+private instance [Module.Finite K A] : Module.Finite K (Bimodule f) :=
+  inferInstanceAs (Module.Finite K A)
 
-/-- A pure tensor `b ⊗ₜ op a` acts on `TauCeti.Bimodule f` by `x ↦ f b * x * a`: the left factor
-acts on the left through `f`, the right factor on the right by multiplication. -/
+/-- A pure tensor `b ⊗ₜ op a` acts on `Bimodule f` by `x ↦ f b * x * a`: the left factor acts on the
+left through `f`, the right factor on the right by multiplication. -/
 @[simp]
-theorem smul_of (b : B) (a : Aᵐᵒᵖ) (x : A) :
+private theorem smul_of (b : B) (a : Aᵐᵒᵖ) (x : A) :
     (b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • of f x = of f (f b * x * a.unop) :=
   toEnd_tmul_apply f b a x
 
-/-- `TauCeti.Bimodule.smul_of` read back through `TauCeti.Bimodule.of`: the action of a pure tensor
-`b ⊗ₜ op a`, transported to `A`, is `x ↦ f b * x * a`. -/
+/-- `smul_of` read back through `of`: the action of a pure tensor `b ⊗ₜ op a`, transported to `A`,
+is `x ↦ f b * x * a`. -/
 @[simp]
-theorem symm_smul (b : B) (a : Aᵐᵒᵖ) (y : Bimodule f) :
+private theorem symm_smul (b : B) (a : Aᵐᵒᵖ) (y : Bimodule f) :
     (of f).symm ((b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • y) = f b * (of f).symm y * a.unop :=
   toEnd_tmul_apply f b a ((of f).symm y)
 
@@ -174,11 +181,15 @@ variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Al
 finite-dimensional **central simple** `K`-algebra `B` to a finite-dimensional **simple** `K`-algebra
 `A` are conjugate: there is a unit `u` of `A` with `g x = u * f x * u⁻¹` for all `x : B`.
 
-Finite-dimensionality of `B` cannot be dropped; it is what makes `B ⊗[K] Aᵐᵒᵖ` Artinian, and with it
-the classification of modules that produces the conjugating isomorphism. -/
+Finite-dimensionality of `B` is not among the hypotheses: it follows from them, because `f` is
+injective, `B` being simple and `A` nontrivial. The proof does use it, to make `B ⊗[K] Aᵐᵒᵖ`
+Artinian, and with it the classification of modules that produces the conjugating isomorphism. -/
 theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
-    [Algebra.IsCentral K B] [IsSimpleRing B] [FiniteDimensional K B] (f g : B →ₐ[K] A) :
+    [Algebra.IsCentral K B] [IsSimpleRing B] (f g : B →ₐ[K] A) :
     ∃ u : Aˣ, ∀ x : B, g x = (u : A) * f x * (↑u⁻¹ : A) := by
+  -- `B` is simple and `A` nontrivial, so `f` is injective and `B` inherits finite-dimensionality.
+  have hf : Function.Injective f := f.toRingHom.injective
+  have : FiniteDimensional K B := FiniteDimensional.of_injective f.toLinearMap hf
   have : FiniteDimensional K Aᵐᵒᵖ := Module.Finite.equiv (MulOpposite.opLinearEquiv K)
   have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) :=
     ((Bimodule.of f).symm.trans (Bimodule.of g)).finrank_eq

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.CentralSimple.TensorProduct
+public import TauCeti.RingTheory.Semisimple.SimpleArtinian
+public import Mathlib.Algebra.Azumaya.Defs
+public import Mathlib.RingTheory.TensorProduct.Maps
+-- Non-public: none of these appears in the type of an exported declaration. Finiteness of a tensor
+-- product, the passage from a finite-dimensional algebra to an Artinian ring, and the `Aᵐᵒᵖ`
+-- linear equivalence are used only inside the proof of Skolem-Noether.
+import Mathlib.Algebra.Central.Matrix
+import Mathlib.Data.Complex.Basic
+import Mathlib.RingTheory.Artinian.Algebra
+import Mathlib.RingTheory.SimpleRing.Matrix
+import Mathlib.RingTheory.TensorProduct.Finite
+import TauCeti.Algebra.Central.Quaternion
+
+/-!
+# The Skolem-Noether theorem
+
+Let `K` be a field, let `A` be a finite-dimensional **simple** `K`-algebra and let `B` be a
+finite-dimensional **central simple** `K`-algebra. The Skolem-Noether theorem says that two
+`K`-algebra homomorphisms `f g : B →ₐ[K] A` differ by conjugation: there is a unit `u` of `A` with
+`g x = u * f x * u⁻¹` for every `x`. Taking `B = A` and `f` the identity, every `K`-algebra
+automorphism of a finite-dimensional central simple algebra is inner.
+
+The proof is the classical module-theoretic one. A homomorphism `f : B →ₐ[K] A` makes `A` into a
+module over `R = B ⊗[K] Aᵐᵒᵖ`, with `B` acting on the left through `f` and `A` on the right by
+multiplication; this is `TauCeti.Bimodule f`. Because `B` is central simple and `Aᵐᵒᵖ` is simple,
+`R` is a simple ring (`TauCeti.IsSimpleRing.tensorProduct`), and it is finite-dimensional over `K`,
+hence Artinian. The two modules `TauCeti.Bimodule f` and `TauCeti.Bimodule g` are carried by one
+and the same `K`-vector space `A`, so they have equal dimension, so they are isomorphic `R`-modules
+(`TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`). An `R`-linear isomorphism is in
+particular linear for the right action of `A`, hence is multiplication on the left by the unit
+`u = φ 1`, and its linearity for the left action of `B` is exactly `u * f x = g x * u`.
+
+## Main results
+
+* `TauCeti.Bimodule`: `A` as a module over `B ⊗[K] Aᵐᵒᵖ` through an algebra homomorphism
+  `f : B →ₐ[K] A`, with its basic API (`TauCeti.Bimodule.of`, `TauCeti.Bimodule.smul_of`).
+* `TauCeti.skolemNoether`: **the Skolem-Noether theorem**.
+* `TauCeti.exists_units_conj_of_algEquiv`: every `K`-algebra automorphism of a finite-dimensional
+  central simple `K`-algebra is inner.
+* `TauCeti.exists_units_conj_subalgebra_val`: a `K`-algebra homomorphism out of a central simple
+  subalgebra `B ⊆ A` is conjugate to the inclusion of `B`. This is the form the centralizer theorem
+  consumes.
+
+## Implementation notes
+
+Centrality is asked of the **source** `B`, not of the target `A`: what the proof needs is that
+`B ⊗[K] Aᵐᵒᵖ` is simple, and `TauCeti.IsSimpleRing.tensorProduct` gets that from `B` central simple
+and `A` simple. So the statement here is slightly stronger than the usual one, which asks `A` to be
+central simple as well; the roadmap's central simple form is the case `Algebra.IsCentral K A`, which
+the statement covers because a central simple algebra is in particular simple. Finite-dimensionality
+of `B` is essential and is carried explicitly: the classification of modules that supplies `φ` needs
+`B ⊗[K] Aᵐᵒᵖ` to be Artinian.
+
+Centrality of the source really is needed, and not just by this proof: the worked example at the end
+of the file exhibits `ℂ` as a simple finite-dimensional `ℝ`-algebra, not central over `ℝ`, whose
+complex conjugation is not conjugation by a unit. The classical theorem does hold for a merely
+simple `B` provided the ambient `A` is central simple, but that form needs the centralizer theorem
+and is a separate, later target; the central simple form pinned here is what the centralizer theorem
+itself consumes.
+
+`TauCeti.Bimodule f` is a type synonym for `A` rather than a `Module` instance on `A` itself,
+because the whole point is to compare the two different `B ⊗[K] Aᵐᵒᵖ`-module structures coming from
+`f` and from `g`; indexing the synonym by the homomorphism keeps both available at once. Mathlib
+takes the same route for `A ⊗[R] Aᵐᵒᵖ` acting on `A` in `Mathlib/Algebra/Azumaya/Defs.lean`, where
+`instModuleTensorProductMop` is deliberately not an instance. The action map is built from Mathlib's
+`AlgHom.mulLeftRight` by restricting along `f` on the left factor, so the two agree for `f` the
+identity of `A`.
+
+## References
+
+This implements the Layer 5 target `skolemNoether` of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See R. S. Pierce, *Associative Algebras*, GTM 88, Chapter 12, and P. Gille, T. Szamuely, *Central
+Simple Algebras and Galois Cohomology*, Chapter 2.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped TensorProduct
+
+section Construction
+
+variable {K A B : Type*} [CommSemiring K] [Ring A] [Algebra K A] [Semiring B] [Algebra K B]
+
+/-- `A` regarded as a left module over `B ⊗[K] Aᵐᵒᵖ` through an algebra homomorphism
+`f : B →ₐ[K] A`: the element `b ⊗ₜ op a` acts by `x ↦ f b * x * a`.
+
+Equivalently this is the `B`-`A`-bimodule `A` obtained by restricting the left action along `f`,
+packaged as a left module over `B ⊗[K] Aᵐᵒᵖ` in the usual way. It is a type synonym for `A`
+precisely so that the structures coming from two different homomorphisms can be compared. -/
+@[expose] def Bimodule (_f : B →ₐ[K] A) : Type _ := A
+
+namespace Bimodule
+
+variable (f : B →ₐ[K] A)
+
+instance : AddCommGroup (Bimodule f) := inferInstanceAs (AddCommGroup A)
+
+instance : Module K (Bimodule f) := inferInstanceAs (Module K A)
+
+/-- The action of `B ⊗[K] Aᵐᵒᵖ` on `A` defining `TauCeti.Bimodule f`, as an algebra homomorphism
+into `Module.End K A`. It is Mathlib's `AlgHom.mulLeftRight` restricted along `f` on the left
+factor, so for `f = AlgHom.id K A` it is `AlgHom.mulLeftRight K A` itself. -/
+noncomputable def toEnd : B ⊗[K] Aᵐᵒᵖ →ₐ[K] Module.End K A :=
+  (AlgHom.mulLeftRight K A).comp (Algebra.TensorProduct.map f (AlgHom.id K Aᵐᵒᵖ))
+
+@[simp]
+theorem toEnd_tmul_apply (b : B) (a : Aᵐᵒᵖ) (x : A) : toEnd f (b ⊗ₜ a) x = f b * x * a.unop := by
+  simp [toEnd]
+
+noncomputable instance : Module (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) :=
+  Module.compHom (M := A) (toEnd f).toRingHom
+
+instance : IsScalarTower K (B ⊗[K] Aᵐᵒᵖ) (Bimodule f) where
+  smul_assoc c r x := by
+    change (toEnd f (c • r)) _ = c • (toEnd f r) _
+    rw [map_smul]
+    rfl
+
+instance [Module.Finite K A] : Module.Finite K (Bimodule f) := inferInstanceAs (Module.Finite K A)
+
+/-- `TauCeti.Bimodule f` is `A` again as a `K`-module: only the `B ⊗[K] Aᵐᵒᵖ`-action is new. -/
+def of : A ≃ₗ[K] Bimodule f := LinearEquiv.refl K A
+
+@[simp]
+theorem smul_of (b : B) (a : Aᵐᵒᵖ) (x : A) :
+    (b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • of f x = of f (f b * x * a.unop) :=
+  toEnd_tmul_apply f b a x
+
+@[simp]
+theorem symm_smul (b : B) (a : Aᵐᵒᵖ) (y : Bimodule f) :
+    (of f).symm ((b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • y) = f b * (of f).symm y * a.unop :=
+  toEnd_tmul_apply f b a ((of f).symm y)
+
+end Bimodule
+
+end Construction
+
+section SkolemNoether
+
+variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Algebra K B]
+
+/-- **The Skolem-Noether theorem.** Two `K`-algebra homomorphisms `f g : B →ₐ[K] A` from a
+finite-dimensional **central simple** `K`-algebra `B` to a finite-dimensional **simple** `K`-algebra
+`A` are conjugate: there is a unit `u` of `A` with `g x = u * f x * u⁻¹` for all `x : B`.
+
+Finite-dimensionality of `B` cannot be dropped; it is what makes `B ⊗[K] Aᵐᵒᵖ` Artinian, and with it
+the classification of modules that produces the conjugating isomorphism. -/
+theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
+    [Algebra.IsCentral K B] [IsSimpleRing B] [FiniteDimensional K B] (f g : B →ₐ[K] A) :
+    ∃ u : Aˣ, ∀ x : B, g x = (u : A) * f x * (↑u⁻¹ : A) := by
+  have : FiniteDimensional K Aᵐᵒᵖ := Module.Finite.equiv (MulOpposite.opLinearEquiv K)
+  have : IsArtinianRing (B ⊗[K] Aᵐᵒᵖ) := IsArtinianRing.of_finite K _
+  have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) := rfl
+  obtain ⟨φ⟩ := IsSimpleRing.nonempty_linearEquiv_of_finrank_eq (R := B ⊗[K] Aᵐᵒᵖ) K hrank
+  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
+  -- Linearity of `φ` for the right action of `A` makes it left multiplication by `u`.
+  have key : ∀ a : A, (Bimodule.of g).symm (φ (Bimodule.of f a)) = u * a := by
+    intro a
+    have ha : Bimodule.of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 := by
+      rw [Bimodule.smul_of]; simp
+    rw [ha, map_smul, Bimodule.symm_smul]
+    simp [hu]
+  have hu' : φ (Bimodule.of f 1) = Bimodule.of g u := by
+    have h1 := key 1
+    rw [mul_one] at h1
+    rw [← h1]
+    simp
+  -- Surjectivity of `φ` gives a right inverse of `u`; injectivity makes it two-sided.
+  obtain ⟨y, hy⟩ := φ.surjective (Bimodule.of g 1)
+  set v : A := (Bimodule.of f).symm y with hv
+  have huv : u * v = 1 := by
+    have h := key v
+    rw [hv, LinearEquiv.apply_symm_apply, hy] at h
+    simpa using h.symm
+  have hinj : ∀ z : A, u * z = 0 → z = 0 := by
+    intro z hz
+    have h := key z
+    rw [hz] at h
+    have h' : φ (Bimodule.of f z) = 0 := (Bimodule.of g).symm.map_eq_zero_iff.mp h
+    have := φ.injective (h'.trans (map_zero φ).symm)
+    simpa using congrArg (Bimodule.of f).symm this
+  have hvu : v * u = 1 := by
+    refine sub_eq_zero.mp (hinj _ ?_)
+    rw [mul_sub, ← mul_assoc, huv, one_mul, mul_one, sub_self]
+  -- Linearity of `φ` for the left action of `B` is the conjugation relation.
+  have hb : ∀ b : B, u * f b = g b * u := by
+    intro b
+    have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 = Bimodule.of f (f b) := by
+      rw [Bimodule.smul_of]; simp
+    calc u * f b = (Bimodule.of g).symm (φ (Bimodule.of f (f b))) := (key (f b)).symm
+      _ = (Bimodule.of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1)) := by
+            rw [h1]
+      _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (Bimodule.of f 1)) := by
+            rw [map_smul]
+      _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
+      _ = g b * u := by rw [Bimodule.smul_of]; simp
+  refine ⟨⟨u, v, huv, hvu⟩, fun x ↦ ?_⟩
+  change g x = u * f x * v
+  rw [hb x, mul_assoc, huv, mul_one]
+
+/-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a
+finite-dimensional central simple `K`-algebra `A` is conjugation by a unit of `A`. -/
+theorem exists_units_conj_of_algEquiv [Algebra.IsCentral K A] [IsSimpleRing A]
+    [FiniteDimensional K A] (e : A ≃ₐ[K] A) :
+    ∃ u : Aˣ, ∀ x : A, e x = (u : A) * x * (↑u⁻¹ : A) :=
+  skolemNoether K (AlgHom.id K A) e.toAlgHom
+
+/-- A `K`-algebra homomorphism out of a **central simple** subalgebra `B` of a finite-dimensional
+simple `K`-algebra `A` is conjugate to the inclusion of `B`: it extends to an inner automorphism of
+`A`. This is the form the centralizer theorem consumes. -/
+theorem exists_units_conj_subalgebra_val [IsSimpleRing A] [FiniteDimensional K A]
+    (B : Subalgebra K A) [Algebra.IsCentral K B] [IsSimpleRing B] (f : B →ₐ[K] A) :
+    ∃ u : Aˣ, ∀ x : B, f x = (u : A) * (x : A) * (↑u⁻¹ : A) :=
+  skolemNoether K B.val f
+
+end SkolemNoether
+
+/-! ### Worked examples -/
+
+section Examples
+
+-- `_root_.` is needed because `TauCeti.Quaternion` is also a namespace, so a bare
+-- `open scoped Quaternion` would open that one and leave the `ℍ[·]` notation out of scope.
+open scoped _root_.Quaternion
+
+/-- **Every automorphism of a matrix algebra is inner.** All three hypotheses of
+`TauCeti.exists_units_conj_of_algEquiv` are found by instance search: `Mₙ(K)` is central over `K`,
+simple, and finite-dimensional. -/
+example (K : Type*) [Field K] (n : ℕ) [NeZero n]
+    (e : Matrix (Fin n) (Fin n) K ≃ₐ[K] Matrix (Fin n) (Fin n) K) :
+    ∃ u : (Matrix (Fin n) (Fin n) K)ˣ, ∀ x, e x =
+      (u : Matrix (Fin n) (Fin n) K) * x * (↑u⁻¹ : Matrix (Fin n) (Fin n) K) :=
+  exists_units_conj_of_algEquiv K e
+
+/-- **Skolem-Noether in the small**: every `ℝ`-algebra automorphism of the real quaternions is
+inner. Centrality comes from `TauCeti.Quaternion.instIsCentral`, simplicity from `ℍ[ℝ]` being a
+division ring. -/
+example (e : ℍ[ℝ] ≃ₐ[ℝ] ℍ[ℝ]) :
+    ∃ u : ℍ[ℝ]ˣ, ∀ x : ℍ[ℝ], e x = (u : ℍ[ℝ]) * x * (↑u⁻¹ : ℍ[ℝ]) :=
+  exists_units_conj_of_algEquiv ℝ e
+
+/-- The negative control for `TauCeti.skolemNoether`: centrality of the **source** cannot be
+dropped. Take `K = ℝ` and `A = B = ℂ`, a simple finite-dimensional `ℝ`-algebra which is not central
+over `ℝ`. The identity and complex conjugation are then two `ℝ`-algebra endomorphisms of `ℂ` that
+are *not* conjugate, because `ℂ` is commutative, so conjugation by a unit is the identity while
+conjugation is not. -/
+example : ¬ ∃ u : ℂˣ, ∀ x : ℂ, (starRingEnd ℂ) x = (u : ℂ) * x * (↑u⁻¹ : ℂ) := by
+  rintro ⟨u, hu⟩
+  have h := hu Complex.I
+  rw [mul_comm (u : ℂ) Complex.I, mul_assoc, u.mul_inv, mul_one, Complex.conj_I] at h
+  have him : (-1 : ℝ) = 1 := by simpa using congrArg Complex.im h
+  norm_num at him
+
+end Examples
+
+end TauCeti

--- a/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
+++ b/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
@@ -39,7 +39,7 @@ is exactly the input the Skolem-Noether theorem needs, in
   which compares simple submodules of a single module, to a comparison against a fixed simple
   module, which is what lets two different modules be compared with each other.
 * `TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`: two finite-dimensional modules over a
-  simple Artinian `K`-algebra with the same `K`-dimension are isomorphic.
+  finite-dimensional simple `K`-algebra with the same `K`-dimension are isomorphic.
 * `TauCeti.IsSimpleRing.nonempty_linearEquiv_iff_finrank_eq`: the two-way form, the classification
   itself.
 
@@ -49,6 +49,11 @@ The chosen simple module is a minimal left ideal `S : Submodule R R`, produced a
 lattice of submodules of the regular module rather than assumed. Taking it inside `R` rather than
 inside `M` is what makes it available to `M` and `N` at once, and it inherits the `K`-module
 structure from `R`, so its dimension is finite and nonzero and can be cancelled.
+
+The two classification statements ask `R` to be finite-dimensional over `K` and do not also ask it
+to be Artinian: `IsArtinianRing.of_finite` derives that from finite-dimensionality, so callers never
+have to supply it. Only `TauCeti.IsIsotypicOfType.of_isSimpleRing`, which has no field in sight,
+takes `IsArtinianRing R` as a hypothesis.
 
 Simplicity of `R` is not weakened to semisimplicity: over a semisimple ring with more than one block
 the dimension is not a complete invariant, since a module can distribute the same total dimension
@@ -69,7 +74,7 @@ namespace TauCeti
 
 open Module
 
-variable {R : Type*} [Ring R] [IsSimpleRing R] [IsArtinianRing R]
+variable {R : Type*} [Ring R] [IsSimpleRing R]
 
 /-- Over a **simple Artinian** ring `R`, every `R`-module is isotypic of the type of a chosen
 minimal left ideal `S`: every simple submodule of every `R`-module is isomorphic to `S`.
@@ -79,7 +84,7 @@ content added here is that the comparison can be made against a fixed simple mod
 itself, so that simple submodules of *different* modules become comparable: a simple submodule of
 `M` is isomorphic to some ideal of `R` because `R` is semisimple, and that ideal is isomorphic to
 `S` because `R` is isotypic over itself. -/
-theorem IsIsotypicOfType.of_isSimpleRing (S : Submodule R R) [IsSimpleModule R S]
+theorem IsIsotypicOfType.of_isSimpleRing [IsArtinianRing R] (S : Submodule R R) [IsSimpleModule R S]
     (M : Type*) [AddCommGroup M] [Module R M] : IsIsotypicOfType R M S := by
   intro m _
   obtain ⟨I, ⟨e⟩⟩ := IsSemisimpleRing.exists_linearEquiv_ideal_of_isSimpleModule (R := R) (M := m)
@@ -103,6 +108,7 @@ Both modules are direct sums of copies of one and the same simple module `S`
 `n * finrank K S = m * finrank K S`, and `finrank K S ≠ 0`, so `n = m`. -/
 theorem nonempty_linearEquiv_of_finrank_eq (h : finrank K M = finrank K N) :
     Nonempty (M ≃ₗ[R] N) := by
+  haveI : IsArtinianRing R := IsArtinianRing.of_finite K R
   obtain ⟨S, hS⟩ := IsAtomic.exists_atom (Submodule R R)
   rw [← isSimpleModule_iff_isAtom] at hS
   have : Module.Finite R M := Module.Finite.of_restrictScalars_finite K R M
@@ -111,12 +117,14 @@ theorem nonempty_linearEquiv_of_finrank_eq (h : finrank K M = finrank K N) :
   obtain ⟨m, ⟨eN⟩⟩ := (IsIsotypicOfType.of_isSimpleRing S N).linearEquiv_fun
   have : Nontrivial S := IsSimpleModule.nontrivial R S
   have hSpos : 0 < finrank K S := Module.finrank_pos
+  -- `Sᵏ` has `K`-dimension `k * finrank K S`; this is the only dimension count the proof makes.
+  have hpow : ∀ k : ℕ, finrank K (Fin k → S) = k * finrank K S := fun k ↦ by
+    rw [Module.finrank_pi_fintype, Finset.sum_const, Finset.card_univ, Fintype.card_fin,
+      smul_eq_mul]
   have hM : finrank K M = n * finrank K S := by
-    rw [(eM.restrictScalars K).finrank_eq, Module.finrank_pi_fintype, Finset.sum_const,
-      Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+    rw [(eM.restrictScalars K).finrank_eq, hpow]
   have hN : finrank K N = m * finrank K S := by
-    rw [(eN.restrictScalars K).finrank_eq, Module.finrank_pi_fintype, Finset.sum_const,
-      Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+    rw [(eN.restrictScalars K).finrank_eq, hpow]
   obtain rfl : n = m := Nat.eq_of_mul_eq_mul_right hSpos (hM.symm.trans (h.trans hN))
   exact ⟨eM.trans eN.symm⟩
 

--- a/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
+++ b/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
@@ -35,9 +35,9 @@ is exactly the input the Skolem-Noether theorem needs, in
 ## Main results
 
 * `TauCeti.IsIsotypicOfType.of_isSimpleRing`: over a simple Artinian ring, every module is isotypic
-  of the type of any chosen minimal left ideal. This upgrades Mathlib's `IsSimpleRing.isIsotypic`,
-  which compares simple submodules of a single module, to a comparison against a fixed simple
-  module, which is what lets two different modules be compared with each other.
+  of the type of any fixed simple module. This upgrades Mathlib's `IsSimpleRing.isIsotypic`, which
+  compares simple submodules of a single module, to a comparison against a fixed simple module,
+  which is what lets two different modules be compared with each other.
 * `TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`: two finite-dimensional modules over a
   finite-dimensional simple `K`-algebra with the same `K`-dimension are isomorphic.
 * `TauCeti.IsSimpleRing.nonempty_linearEquiv_iff_finrank_eq`: the two-way form, the classification
@@ -45,10 +45,11 @@ is exactly the input the Skolem-Noether theorem needs, in
 
 ## Implementation notes
 
-The chosen simple module is a minimal left ideal `S : Submodule R R`, produced as an atom of the
-lattice of submodules of the regular module rather than assumed. Taking it inside `R` rather than
-inside `M` is what makes it available to `M` and `N` at once, and it inherits the `K`-module
-structure from `R`, so its dimension is finite and nonzero and can be cancelled.
+The simple module the classification compares `M` and `N` against is a minimal left ideal
+`S : Submodule R R`, produced as an atom of the lattice of submodules of the regular module rather
+than assumed. Taking it inside `R` rather than inside `M` is what makes it available to `M` and `N`
+at once, and it inherits the `K`-module structure from `R`, so its dimension is finite and nonzero
+and can be cancelled.
 
 The two classification statements ask `R` to be finite-dimensional over `K` and do not also ask it
 to be Artinian: `IsArtinianRing.of_finite` derives that from finite-dimensionality, so callers never
@@ -76,20 +77,24 @@ open Module
 
 variable {R : Type*} [Ring R] [IsSimpleRing R]
 
-/-- Over a **simple Artinian** ring `R`, every `R`-module is isotypic of the type of a chosen
-minimal left ideal `S`: every simple submodule of every `R`-module is isomorphic to `S`.
+variable (R) in
+/-- Over a **simple Artinian** ring `R`, every `R`-module is isotypic of the type of any fixed
+simple module `S`: every simple submodule of every `R`-module is isomorphic to `S`.
 
 Mathlib's `IsSimpleRing.isIsotypic` compares two simple submodules of one and the same module. The
-content added here is that the comparison can be made against a fixed simple module living in `R`
-itself, so that simple submodules of *different* modules become comparable: a simple submodule of
-`M` is isomorphic to some ideal of `R` because `R` is semisimple, and that ideal is isomorphic to
-`S` because `R` is isotypic over itself. -/
-theorem IsIsotypicOfType.of_isSimpleRing [IsArtinianRing R] (S : Submodule R R) [IsSimpleModule R S]
-    (M : Type*) [AddCommGroup M] [Module R M] : IsIsotypicOfType R M S := by
+content added here is that the comparison can be made against a simple module fixed once and for
+all, so that simple submodules of *different* modules become comparable: because `R` is semisimple,
+a simple submodule of `M` and `S` itself are both isomorphic to ideals of `R`, and those two ideals
+are isomorphic because `R` is isotypic over itself. -/
+theorem IsIsotypicOfType.of_isSimpleRing [IsArtinianRing R] (S : Type*) [AddCommGroup S]
+    [Module R S] [IsSimpleModule R S] (M : Type*) [AddCommGroup M] [Module R M] :
+    IsIsotypicOfType R M S := by
   intro m _
   obtain ⟨I, ⟨e⟩⟩ := IsSemisimpleRing.exists_linearEquiv_ideal_of_isSimpleModule (R := R) (M := m)
+  obtain ⟨J, ⟨eS⟩⟩ := IsSemisimpleRing.exists_linearEquiv_ideal_of_isSimpleModule (R := R) (M := S)
   have : IsSimpleModule R I := IsSimpleModule.congr e.symm
-  exact ⟨e.trans (IsSimpleRing.isIsotypic R R I S).some.symm⟩
+  have : IsSimpleModule R J := IsSimpleModule.congr eS.symm
+  exact ⟨(e.trans (IsSimpleRing.isIsotypic R R I J).some.symm).trans eS.symm⟩
 
 namespace IsSimpleRing
 
@@ -113,8 +118,8 @@ theorem nonempty_linearEquiv_of_finrank_eq (h : finrank K M = finrank K N) :
   rw [← isSimpleModule_iff_isAtom] at hS
   have : Module.Finite R M := Module.Finite.of_restrictScalars_finite K R M
   have : Module.Finite R N := Module.Finite.of_restrictScalars_finite K R N
-  obtain ⟨n, ⟨eM⟩⟩ := (IsIsotypicOfType.of_isSimpleRing S M).linearEquiv_fun
-  obtain ⟨m, ⟨eN⟩⟩ := (IsIsotypicOfType.of_isSimpleRing S N).linearEquiv_fun
+  obtain ⟨n, ⟨eM⟩⟩ := (IsIsotypicOfType.of_isSimpleRing R ↥S M).linearEquiv_fun
+  obtain ⟨m, ⟨eN⟩⟩ := (IsIsotypicOfType.of_isSimpleRing R ↥S N).linearEquiv_fun
   have : Nontrivial S := IsSimpleModule.nontrivial R S
   have hSpos : 0 < finrank K S := Module.finrank_pos
   -- `Sᵏ` has `K`-dimension `k * finrank K S`; this is the only dimension count the proof makes.

--- a/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
+++ b/TauCeti/RingTheory/Semisimple/SimpleArtinian.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
+-- Non-public: `Module.finrank_pi_fintype` and `Module.Finite.of_restrictScalars_finite` are used
+-- only inside proofs, and no exported statement here mentions a product module or `Module.Finite`
+-- over the ring, so downstream importers do not pay for either module.
+import Mathlib.LinearAlgebra.Dimension.Constructions
+import Mathlib.RingTheory.Finiteness.Basic
+
+/-!
+# Modules over a simple Artinian ring are classified by their dimension
+
+Over a simple Artinian ring `R` all simple modules are isomorphic: Mathlib records this as
+`IsSimpleRing.isIsotypic`, which says that any two simple submodules of any `R`-module are
+isomorphic. A semisimple module is a direct sum of simple ones, so a finitely generated `R`-module
+is `Sⁿ` for a **fixed** simple module `S` and a single natural number `n`, and `n` is the only
+invariant there is.
+
+This file turns that into the working statement: if `R` is moreover an algebra over a field `K` and
+`M`, `N` are `R`-modules which are finite-dimensional over `K`, then
+
+  `M ≃ₗ[R] N ↔ finrank K M = finrank K N`.
+
+The dimension count is the bookkeeping that converts "the same number of simple summands" into a
+condition that can be checked, and it is what makes the classification usable: two `R`-module
+structures put on the *same* finite-dimensional `K`-vector space are automatically isomorphic. That
+is exactly the input the Skolem-Noether theorem needs, in
+`TauCeti/Algebra/CentralSimple/SkolemNoether.lean`.
+
+## Main results
+
+* `TauCeti.IsIsotypicOfType.of_isSimpleRing`: over a simple Artinian ring, every module is isotypic
+  of the type of any chosen minimal left ideal. This upgrades Mathlib's `IsSimpleRing.isIsotypic`,
+  which compares simple submodules of a single module, to a comparison against a fixed simple
+  module, which is what lets two different modules be compared with each other.
+* `TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`: two finite-dimensional modules over a
+  simple Artinian `K`-algebra with the same `K`-dimension are isomorphic.
+* `TauCeti.IsSimpleRing.nonempty_linearEquiv_iff_finrank_eq`: the two-way form, the classification
+  itself.
+
+## Implementation notes
+
+The chosen simple module is a minimal left ideal `S : Submodule R R`, produced as an atom of the
+lattice of submodules of the regular module rather than assumed. Taking it inside `R` rather than
+inside `M` is what makes it available to `M` and `N` at once, and it inherits the `K`-module
+structure from `R`, so its dimension is finite and nonzero and can be cancelled.
+
+Simplicity of `R` is not weakened to semisimplicity: over a semisimple ring with more than one block
+the dimension is not a complete invariant, since a module can distribute the same total dimension
+over the blocks in different ways.
+
+## References
+
+This supplies the classification of modules over a simple Artinian ring used by the Layer 5 target
+`skolemNoether` of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
+See T. Y. Lam, *A First Course in Noncommutative Rings*, GTM 131, Chapter 1, and R. S. Pierce,
+*Associative Algebras*, GTM 88, Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module
+
+variable {R : Type*} [Ring R] [IsSimpleRing R] [IsArtinianRing R]
+
+/-- Over a **simple Artinian** ring `R`, every `R`-module is isotypic of the type of a chosen
+minimal left ideal `S`: every simple submodule of every `R`-module is isomorphic to `S`.
+
+Mathlib's `IsSimpleRing.isIsotypic` compares two simple submodules of one and the same module. The
+content added here is that the comparison can be made against a fixed simple module living in `R`
+itself, so that simple submodules of *different* modules become comparable: a simple submodule of
+`M` is isomorphic to some ideal of `R` because `R` is semisimple, and that ideal is isomorphic to
+`S` because `R` is isotypic over itself. -/
+theorem IsIsotypicOfType.of_isSimpleRing (S : Submodule R R) [IsSimpleModule R S]
+    (M : Type*) [AddCommGroup M] [Module R M] : IsIsotypicOfType R M S := by
+  intro m _
+  obtain ⟨I, ⟨e⟩⟩ := IsSemisimpleRing.exists_linearEquiv_ideal_of_isSimpleModule (R := R) (M := m)
+  have : IsSimpleModule R I := IsSimpleModule.congr e.symm
+  exact ⟨e.trans (IsSimpleRing.isIsotypic R R I S).some.symm⟩
+
+namespace IsSimpleRing
+
+variable (K : Type*) [Field K] [Algebra K R] [FiniteDimensional K R]
+  {M : Type*} [AddCommGroup M] [Module K M] [Module R M] [IsScalarTower K R M]
+  [FiniteDimensional K M]
+  {N : Type*} [AddCommGroup N] [Module K N] [Module R N] [IsScalarTower K R N]
+  [FiniteDimensional K N]
+
+/-- **Modules over a simple Artinian algebra are classified by their dimension.** If `R` is a
+finite-dimensional simple `K`-algebra and `M`, `N` are `R`-modules which are finite-dimensional over
+`K`, then equal `K`-dimension forces an `R`-linear isomorphism.
+
+Both modules are direct sums of copies of one and the same simple module `S`
+(`TauCeti.IsIsotypicOfType.of_isSimpleRing`), say `Sⁿ` and `Sᵐ`; comparing dimensions gives
+`n * finrank K S = m * finrank K S`, and `finrank K S ≠ 0`, so `n = m`. -/
+theorem nonempty_linearEquiv_of_finrank_eq (h : finrank K M = finrank K N) :
+    Nonempty (M ≃ₗ[R] N) := by
+  obtain ⟨S, hS⟩ := IsAtomic.exists_atom (Submodule R R)
+  rw [← isSimpleModule_iff_isAtom] at hS
+  have : Module.Finite R M := Module.Finite.of_restrictScalars_finite K R M
+  have : Module.Finite R N := Module.Finite.of_restrictScalars_finite K R N
+  obtain ⟨n, ⟨eM⟩⟩ := (IsIsotypicOfType.of_isSimpleRing S M).linearEquiv_fun
+  obtain ⟨m, ⟨eN⟩⟩ := (IsIsotypicOfType.of_isSimpleRing S N).linearEquiv_fun
+  have : Nontrivial S := IsSimpleModule.nontrivial R S
+  have hSpos : 0 < finrank K S := Module.finrank_pos
+  have hM : finrank K M = n * finrank K S := by
+    rw [(eM.restrictScalars K).finrank_eq, Module.finrank_pi_fintype, Finset.sum_const,
+      Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+  have hN : finrank K N = m * finrank K S := by
+    rw [(eN.restrictScalars K).finrank_eq, Module.finrank_pi_fintype, Finset.sum_const,
+      Finset.card_univ, Fintype.card_fin, smul_eq_mul]
+  obtain rfl : n = m := Nat.eq_of_mul_eq_mul_right hSpos (hM.symm.trans (h.trans hN))
+  exact ⟨eM.trans eN.symm⟩
+
+/-- **The classification of finite-dimensional modules over a simple Artinian algebra**: the
+`K`-dimension is a complete invariant. The forward implication holds over any ring; the content is
+the converse, `TauCeti.IsSimpleRing.nonempty_linearEquiv_of_finrank_eq`. -/
+theorem nonempty_linearEquiv_iff_finrank_eq :
+    Nonempty (M ≃ₗ[R] N) ↔ finrank K M = finrank K N :=
+  ⟨fun ⟨e⟩ ↦ (e.restrictScalars K).finrank_eq, nonempty_linearEquiv_of_finrank_eq K⟩
+
+end IsSimpleRing
+
+end TauCeti


### PR DESCRIPTION
This PR proves the **Skolem-Noether theorem**: two `K`-algebra homomorphisms `f g : B →ₐ[K] A` from a finite-dimensional central simple `K`-algebra `B` into a finite-dimensional simple `K`-algebra `A` are conjugate by a unit of `A`. In particular every `K`-algebra automorphism of a finite-dimensional central simple algebra is inner, and a homomorphism out of a central simple subalgebra `B ⊆ A` is conjugate to the inclusion of `B` (the form the centralizer theorem consumes).

This is the Layer 5 target `skolemNoether` of `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md`, pinned as a `sorry`-target in that roadmap's `Suggested.lean`. The layer's other statements (the centralizer theorem, `centralizer_isSimpleRing` and `finrank_mul_finrank_centralizer`) are deliberately left for a follow-up: they rest on this one.

The proof is the classical module-theoretic argument. A homomorphism `f : B →ₐ[K] A` makes `A` into a module over `R = B ⊗[K] Aᵐᵒᵖ`, with `B` acting on the left through `f` and `A` on the right by multiplication; that is `TauCeti.Bimodule f`, a type synonym for `A` indexed by the homomorphism so that the structures coming from `f` and from `g` can both be in scope at once (Mathlib takes the same route for `A ⊗[R] Aᵐᵒᵖ` acting on `A` in `Mathlib/Algebra/Azumaya/Defs.lean`, where `instModuleTensorProductMop` is deliberately not an instance). Since `B` is central simple and `Aᵐᵒᵖ` is simple, `R` is simple by the already-merged `TauCeti.IsSimpleRing.tensorProduct`, and it is finite-dimensional over `K`, hence Artinian. The two modules are carried by one and the same `K`-vector space `A`, so they have equal dimension and are therefore isomorphic; an `R`-linear isomorphism is in particular linear for the right action of `A`, hence is left multiplication by the unit `u = φ 1`, and its linearity for the left action of `B` is exactly `u * f x = g x * u`.

The prerequisite that makes the dimension count work is proved first, in `TauCeti/RingTheory/Semisimple/SimpleArtinian.lean`: over a simple Artinian ring every module is isotypic of the type of a fixed minimal left ideal, upgrading Mathlib's `IsSimpleRing.isIsotypic` (which compares simple submodules of a single module) to a comparison against a fixed simple module, which is what makes two different modules comparable with each other. From it, finite-dimensional modules over a simple Artinian `K`-algebra are classified by their `K`-dimension.

Centrality is asked of the source `B`, not of the target `A`: what the argument needs is that `B ⊗[K] Aᵐᵒᵖ` is simple. The statement is therefore slightly more general than the roadmap's, which asks `A` to be central simple as well, and it covers that case because a central simple algebra is in particular simple. Three worked examples check that the hypotheses are honest: every automorphism of a matrix algebra is inner, every `ℝ`-algebra automorphism of `ℍ[ℝ]` is inner (the roadmap's "Skolem-Noether in the small" acceptance criterion), and the negative control that centrality of the source cannot be dropped, since `ℂ` is a simple finite-dimensional `ℝ`-algebra whose complex conjugation is not conjugation by a unit.

Nothing is vendored from Mathlib, and no material is derived from any external source: the two files are new and self-contained on top of the pinned Mathlib and the existing `TauCeti/Algebra/CentralSimple/` and `TauCeti/RingTheory/Semisimple/` modules.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"skolemnoether"}-->

🤖 Prepared with Claude Code
