### PR TITLE
feat: differentiate the semigroup resolvent in the spectral parameter

### DIFF
--- a/TauCeti/Analysis/Semigroups/Defs.lean
+++ b/TauCeti/Analysis/Semigroups/Defs.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+public import TauCeti.Analysis.Semigroups.Resolvent.Deriv
 public import TauCeti.Analysis.Semigroups.Resolvent.PowerBounds
 public import TauCeti.Analysis.Semigroups.BoundedGenerator
 public import TauCeti.Analysis.Semigroups.Generator
@@ -13,7 +13,8 @@ public import TauCeti.Analysis.Semigroups.Generator
 # Strongly continuous semigroups
 
 This module re-exports the strongly continuous semigroup, generator, orbit-derivative,
-growth-bound, and Laplace-transform resolvent API.
+growth-bound, and Laplace-transform resolvent API, the latter including the derivatives of the
+resolvent in the spectral parameter.
 
 ## References
 Ported and adapted (Apache 2.0) from `mrdouglasny/hille-yosida`; references include

--- a/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
@@ -16,7 +16,10 @@ public import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 
 This file develops the pointwise Bochner-integral resolvent for a C₀-semigroup with a
 growth bound, proves that it maps into the generator domain, and establishes the
-right-inverse identity and norm estimate.
+right-inverse identity and norm estimate. It also packages the resolvent as a function of
+the spectral parameter alone (`resolventFun`, extended by the junk value `0` below the
+growth exponent), the form in which it is differentiated in
+`TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean`.
 
 ## References
 Ported and adapted (Apache 2.0) from `mrdouglasny/hille-yosida`; references include
@@ -294,6 +297,48 @@ theorem StronglyContinuousSemigroup.resolvent_norm_le
   LinearMap.mkContinuous_norm_le _
     (div_nonneg (by linarith [hb.one_le]) (by linarith)) _
 
+/-! ## The resolvent as a function of the spectral parameter
+
+`StronglyContinuousSemigroup.resolvent` carries the proof `ω < λ` as an argument, so it is not
+a function of `λ` alone. The variant below drops that argument, extending the resolvent by the
+junk value `0` on `λ ≤ ω`, which is what lets one speak of its limits, derivatives and
+integrals in `λ`. -/
+
+/-- The Laplace-transform resolvent of `S` as a function of the spectral parameter alone,
+extended by the junk value `0` on `λ ≤ ω`. Unlike `StronglyContinuousSemigroup.resolvent` it
+does not carry the proof `ω < λ`, so it can be differentiated in `λ`. -/
+noncomputable def StronglyContinuousSemigroup.resolventFun
+    (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M) (lambda : ℝ) :
+    X →L[ℝ] X :=
+  if h : ω < lambda then S.resolvent hb lambda h else 0
+
+/-- Above the growth exponent, `resolventFun` is the Laplace-transform resolvent. -/
+@[simp] theorem StronglyContinuousSemigroup.resolventFun_of_lt
+    (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M) {lambda : ℝ}
+    (h : ω < lambda) : S.resolventFun hb lambda = S.resolvent hb lambda h :=
+  dif_pos h
+
+/-- Below the growth exponent, `resolventFun` takes its junk value `0`. -/
+@[simp] theorem StronglyContinuousSemigroup.resolventFun_of_le
+    (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M) {lambda : ℝ}
+    (h : lambda ≤ ω) : S.resolventFun hb lambda = 0 :=
+  dif_neg (not_lt.mpr h)
+
+/-- `resolventFun` in integral form. -/
+theorem StronglyContinuousSemigroup.resolventFun_apply
+    (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M) {lambda : ℝ}
+    (h : ω < lambda) (x : X) :
+    S.resolventFun hb lambda x
+      = ∫ t in Set.Ioi 0, Real.exp (-(lambda * t)) • S.realOperator t x := by
+  rw [S.resolventFun_of_lt hb h, S.resolvent_apply]
+
+/-- The Hille--Yosida bound `‖R λ‖ ≤ M/(λ-ω)` for `resolventFun`. -/
+theorem StronglyContinuousSemigroup.resolventFun_norm_le
+    (S : StronglyContinuousSemigroup X) {ω M : ℝ} (hb : S.HasGrowthBound ω M) {lambda : ℝ}
+    (h : ω < lambda) : ‖S.resolventFun hb lambda‖ ≤ M / (lambda - ω) := by
+  rw [S.resolventFun_of_lt hb h]
+  exact S.resolvent_norm_le hb lambda h
+
 /-! ## Contraction-semigroup specializations (`M = 1`, `ω = 0`) -/
 
 /-- The resolvent of a contraction semigroup, the `(0, 1)` case. -/
@@ -336,6 +381,25 @@ theorem ContractionSemigroup.resolvent_norm_le (S : ContractionSemigroup X)
     (by simpa using hlam)
   rw [sub_zero] at h
   exact h
+
+/-- The resolvent of a contraction semigroup as a function of the spectral parameter alone,
+the `(ω, M) = (0, 1)` case of `StronglyContinuousSemigroup.resolventFun`. It is `@[expose]`d so
+that the calculus corollaries in `Resolvent/Deriv.lean` can read it as that case. -/
+@[expose] noncomputable def ContractionSemigroup.resolventFun (S : ContractionSemigroup X)
+    (lambda : ℝ) : X →L[ℝ] X :=
+  S.toStronglyContinuousSemigroup.resolventFun S.hasGrowthBound lambda
+
+/-- For a positive parameter, `resolventFun` is the contraction resolvent. -/
+@[simp] theorem ContractionSemigroup.resolventFun_of_pos (S : ContractionSemigroup X)
+    {lambda : ℝ} (h : 0 < lambda) : S.resolventFun lambda = S.resolvent lambda h := by
+  ext x
+  rw [resolventFun, S.toStronglyContinuousSemigroup.resolventFun_of_lt S.hasGrowthBound h,
+    S.toStronglyContinuousSemigroup.resolvent_apply, S.resolvent_apply]
+
+/-- For a nonpositive parameter, `resolventFun` takes its junk value `0`. -/
+@[simp] theorem ContractionSemigroup.resolventFun_of_nonpos (S : ContractionSemigroup X)
+    {lambda : ℝ} (h : lambda ≤ 0) : S.resolventFun lambda = 0 :=
+  S.toStronglyContinuousSemigroup.resolventFun_of_le S.hasGrowthBound h
 
 end TauCeti.Semigroups
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Basic.lean
@@ -383,17 +383,24 @@ theorem ContractionSemigroup.resolvent_norm_le (S : ContractionSemigroup X)
   exact h
 
 /-- The resolvent of a contraction semigroup as a function of the spectral parameter alone,
-the `(ω, M) = (0, 1)` case of `StronglyContinuousSemigroup.resolventFun`. It is `@[expose]`d so
-that the calculus corollaries in `Resolvent/Deriv.lean` can read it as that case. -/
-@[expose] noncomputable def ContractionSemigroup.resolventFun (S : ContractionSemigroup X)
+the `(ω, M) = (0, 1)` case of `StronglyContinuousSemigroup.resolventFun`. -/
+noncomputable def ContractionSemigroup.resolventFun (S : ContractionSemigroup X)
     (lambda : ℝ) : X →L[ℝ] X :=
   S.toStronglyContinuousSemigroup.resolventFun S.hasGrowthBound lambda
+
+/-- The contraction resolvent function is the `(ω, M) = (0, 1)` case of
+`StronglyContinuousSemigroup.resolventFun`. -/
+theorem ContractionSemigroup.resolventFun_eq (S : ContractionSemigroup X) :
+    S.resolventFun = S.toStronglyContinuousSemigroup.resolventFun S.hasGrowthBound :=
+  -- the parentheses suppress the automatic `@[defeq]` tag, which an exported theorem may not
+  -- carry when its proof unfolds an unexposed definition
+  (rfl)
 
 /-- For a positive parameter, `resolventFun` is the contraction resolvent. -/
 @[simp] theorem ContractionSemigroup.resolventFun_of_pos (S : ContractionSemigroup X)
     {lambda : ℝ} (h : 0 < lambda) : S.resolventFun lambda = S.resolvent lambda h := by
   ext x
-  rw [resolventFun, S.toStronglyContinuousSemigroup.resolventFun_of_lt S.hasGrowthBound h,
+  rw [S.resolventFun_eq, S.toStronglyContinuousSemigroup.resolventFun_of_lt S.hasGrowthBound h,
     S.toStronglyContinuousSemigroup.resolvent_apply, S.resolvent_apply]
 
 /-- For a nonpositive parameter, `resolventFun` takes its junk value `0`. -/

--- a/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
@@ -240,25 +240,29 @@ variable (S : ContractionSemigroup X)
 
 /-- The derivative of the contraction resolvent is `-R(lambda)²`. -/
 theorem hasDerivAt_resolventFun {lambda : ℝ} (h : 0 < lambda) :
-    HasDerivAt S.resolventFun (-(S.resolventFun lambda ^ 2)) lambda :=
-  S.toStronglyContinuousSemigroup.hasDerivAt_resolventFun S.hasGrowthBound h
+    HasDerivAt S.resolventFun (-(S.resolventFun lambda ^ 2)) lambda := by
+  rw [S.resolventFun_eq]
+  exact S.toStronglyContinuousSemigroup.hasDerivAt_resolventFun S.hasGrowthBound h
 
 /-- The iterated derivative of the contraction resolvent. -/
 theorem iteratedDeriv_resolventFun (n : ℕ) {lambda : ℝ} (h : 0 < lambda) :
     iteratedDeriv n S.resolventFun lambda
-      = ((-1 : ℝ) ^ n * n !) • S.resolventFun lambda ^ (n + 1) :=
-  S.toStronglyContinuousSemigroup.iteratedDeriv_resolventFun S.hasGrowthBound n h
+      = ((-1 : ℝ) ^ n * n !) • S.resolventFun lambda ^ (n + 1) := by
+  rw [S.resolventFun_eq]
+  exact S.toStronglyContinuousSemigroup.iteratedDeriv_resolventFun S.hasGrowthBound n h
 
 /-- The Hille--Yosida derivative bound `‖dⁿR(lambda)/dlambdaⁿ‖ ≤ n! / lambdaⁿ⁺¹` in the
 contraction case. -/
 theorem norm_iteratedDeriv_resolventFun_le (n : ℕ) {lambda : ℝ} (h : 0 < lambda) :
     ‖iteratedDeriv n S.resolventFun lambda‖ ≤ n ! * (1 / lambda) ^ (n + 1) := by
   have := S.toStronglyContinuousSemigroup.norm_iteratedDeriv_resolventFun_le S.hasGrowthBound n h
-  rwa [sub_zero] at this
+  rw [sub_zero] at this
+  rwa [S.resolventFun_eq]
 
 /-- The contraction resolvent is smooth on `(0, ∞)`. -/
-theorem contDiffOn_resolventFun : ContDiffOn ℝ ∞ S.resolventFun (Set.Ioi 0) :=
-  S.toStronglyContinuousSemigroup.contDiffOn_resolventFun S.hasGrowthBound
+theorem contDiffOn_resolventFun : ContDiffOn ℝ ∞ S.resolventFun (Set.Ioi 0) := by
+  rw [S.resolventFun_eq]
+  exact S.toStronglyContinuousSemigroup.contDiffOn_resolventFun S.hasGrowthBound
 
 end ContractionSemigroup
 

--- a/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Semigroups.Resolvent.Identity
+public import Mathlib.Analysis.Calculus.Deriv.Mul
+public import Mathlib.Analysis.Calculus.ContDiff.Deriv
+public import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
+
+/-!
+# Differentiating a semigroup resolvent in the spectral parameter
+
+The Laplace-transform resolvent `R(lambda) x = ∫₀^∞ e^{-lambda t} S(t)x dt` of a C₀-semigroup
+`S` with growth bound `(omega, M)` is defined for `lambda > omega`, and it carries the proof
+`omega < lambda` as an argument. To speak about its dependence on `lambda` we package it as an
+honest function `StronglyContinuousSemigroup.resolventFun`, extended by the junk value `0`
+below the growth exponent.
+
+The resolvent identity then upgrades to a second-order expansion
+
+`R(mu) - R(lambda) + (mu - lambda) R(lambda)² = (mu - lambda)² R(lambda)² R(mu)`,
+
+whose right-hand side is `O((mu - lambda)²)` because `‖R(mu)‖ ≤ M / (mu - omega)` stays bounded
+near `lambda`. Hence `lambda ↦ R(lambda)` is differentiable *in operator norm* with
+
+`R'(lambda) = -R(lambda)²`,
+
+and inductively `dᵏR(lambda)/dlambdaᵏ = (-1)ᵏ k! R(lambda)^{k+1}`; in particular the resolvent
+is smooth on `(omega, ∞)`.
+
+## Main results
+
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.resolventFun`: the resolvent as a function of
+  the spectral parameter alone.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.hasDerivAt_resolventFun`:
+  `R'(lambda) = -R(lambda)²`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.hasDerivAt_resolventFun_pow`:
+  the derivative of `lambda ↦ R(lambda)ⁿ` is `-n R(lambda)ⁿ⁺¹`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.iteratedDeriv_resolventFun`:
+  `dᵏR(lambda)/dlambdaᵏ = (-1)ᵏ k! R(lambda)^{k+1}`.
+* `TauCeti.Semigroups.StronglyContinuousSemigroup.contDiffOn_resolventFun`: the resolvent is
+  smooth on `(omega, ∞)`.
+
+The contraction case `(omega, M) = (0, 1)` is recorded as a corollary.
+
+## Implementation notes
+
+Mathlib's `spectrum.hasDerivAt_resolvent_const_left` proves the same derivative formula for the
+resolvent of an element of a Banach algebra. It does not apply here: the generator of a
+C₀-semigroup is an unbounded operator, so `R(lambda)` is not `resolvent a lambda` for any
+algebra element `a`, and the present proof runs off the semigroup resolvent identity instead of
+off differentiability of `Ring.inverse`.
+
+## References
+
+Engel--Nagel, *One-Parameter Semigroups for Linear Evolution Equations*, Theorem II.1.10 and
+Corollary IV.1.3; Pazy, *Semigroups of Linear Operators and Applications to PDE*, Chapter 1.
+-/
+
+public section
+
+noncomputable section
+
+open scoped ContDiff Nat NNReal Topology
+
+namespace TauCeti.Semigroups
+
+variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X]
+
+namespace StronglyContinuousSemigroup
+
+variable (S : StronglyContinuousSemigroup X) {omega M : ℝ}
+
+/-! ## The resolvent as a function of the spectral parameter -/
+
+/-- The Laplace-transform resolvent of `S` as a function of the spectral parameter alone,
+extended by the junk value `0` on `lambda ≤ omega`. Unlike
+`StronglyContinuousSemigroup.resolvent` it does not carry the proof `omega < lambda`, so it can
+be differentiated in `lambda`. -/
+def resolventFun (hb : S.HasGrowthBound omega M) (lambda : ℝ) : X →L[ℝ] X :=
+  if h : omega < lambda then S.resolvent hb lambda h else 0
+
+/-- Above the growth exponent, `resolventFun` is the Laplace-transform resolvent. -/
+theorem resolventFun_of_lt (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda) :
+    S.resolventFun hb lambda = S.resolvent hb lambda h :=
+  dif_pos h
+
+/-- Below the growth exponent, `resolventFun` takes its junk value `0`. -/
+theorem resolventFun_of_le (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : lambda ≤ omega) :
+    S.resolventFun hb lambda = 0 :=
+  dif_neg (not_lt.mpr h)
+
+/-- `resolventFun` in integral form. -/
+theorem resolventFun_apply (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda)
+    (x : X) :
+    S.resolventFun hb lambda x
+      = ∫ t in Set.Ioi 0, Real.exp (-(lambda * t)) • S.realOperator t x := by
+  rw [S.resolventFun_of_lt hb h, S.resolvent_apply]
+
+/-- The Hille--Yosida bound `‖R(lambda)‖ ≤ M / (lambda - omega)` for `resolventFun`. -/
+theorem norm_resolventFun_le (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda) :
+    ‖S.resolventFun hb lambda‖ ≤ M / (lambda - omega) := by
+  rw [S.resolventFun_of_lt hb h]
+  exact S.resolvent_norm_le hb lambda h
+
+/-- The resolvent identity for `resolventFun`, written in the ring `X →L[ℝ] X`. -/
+theorem resolventFun_sub_resolventFun (hb : S.HasGrowthBound omega M) {lambda mu : ℝ}
+    (hl : omega < lambda) (hm : omega < mu) :
+    S.resolventFun hb lambda - S.resolventFun hb mu
+      = (mu - lambda) • (S.resolventFun hb lambda * S.resolventFun hb mu) := by
+  rw [S.resolventFun_of_lt hb hl, S.resolventFun_of_lt hb hm]
+  exact S.resolvent_sub_resolvent hb hb lambda mu hl hm
+
+/-! ## The first derivative -/
+
+/-- The second-order form of the resolvent identity: the remainder left by the candidate
+derivative `-R(lambda)²` is exactly `(mu - lambda)² R(lambda)² R(mu)`. -/
+private theorem resolventFun_second_order_eq (hb : S.HasGrowthBound omega M) {lambda mu : ℝ}
+    (hl : omega < lambda) (hm : omega < mu) :
+    S.resolventFun hb mu - S.resolventFun hb lambda
+        + (mu - lambda) • S.resolventFun hb lambda ^ 2
+      = (mu - lambda) ^ 2 • (S.resolventFun hb lambda ^ 2 * S.resolventFun hb mu) := by
+  set a := S.resolventFun hb lambda
+  set b := S.resolventFun hb mu
+  set c := mu - lambda
+  have h : a - b = c • (a * b) := S.resolventFun_sub_resolventFun hb hl hm
+  have h2 : b - a + c • a ^ 2 = c • (a * (a - b)) := by
+    rw [mul_sub, ← sq, smul_sub, ← h]
+    abel
+  rw [h2, h, mul_smul_comm, smul_smul, ← sq, ← mul_assoc, ← sq]
+
+/-- The quantitative second-order estimate behind differentiability of the resolvent. -/
+private theorem norm_resolventFun_second_order_le (hb : S.HasGrowthBound omega M) {lambda mu : ℝ}
+    (hl : omega < lambda) (hm : omega < mu) :
+    ‖S.resolventFun hb mu - S.resolventFun hb lambda
+        + (mu - lambda) • S.resolventFun hb lambda ^ 2‖
+      ≤ (mu - lambda) ^ 2 * ((M / (lambda - omega)) ^ 2 * (M / (mu - omega))) := by
+  have hMpos : (0 : ℝ) < M := lt_of_lt_of_le zero_lt_one hb.one_le
+  have hnorm : ‖S.resolventFun hb lambda ^ 2 * S.resolventFun hb mu‖
+      ≤ (M / (lambda - omega)) ^ 2 * (M / (mu - omega)) := by
+    calc ‖S.resolventFun hb lambda ^ 2 * S.resolventFun hb mu‖
+        ≤ ‖S.resolventFun hb lambda ^ 2‖ * ‖S.resolventFun hb mu‖ := norm_mul_le _ _
+      _ ≤ ‖S.resolventFun hb lambda‖ ^ 2 * ‖S.resolventFun hb mu‖ := by
+          gcongr
+          exact norm_pow_le' _ two_pos
+      _ ≤ (M / (lambda - omega)) ^ 2 * (M / (mu - omega)) :=
+          mul_le_mul
+            (pow_le_pow_left₀ (norm_nonneg _) (S.norm_resolventFun_le hb hl) 2)
+            (S.norm_resolventFun_le hb hm) (norm_nonneg _)
+            (pow_nonneg (div_nonneg hMpos.le (by linarith)) 2)
+  rw [S.resolventFun_second_order_eq hb hl hm, norm_smul, Real.norm_eq_abs,
+    abs_of_nonneg (sq_nonneg _)]
+  exact mul_le_mul_of_nonneg_left hnorm (sq_nonneg _)
+
+/-- **The resolvent is differentiable in the spectral parameter**, with derivative `-R(lambda)²`
+taken in the operator norm. This is the semigroup analogue of Mathlib's
+`spectrum.hasDerivAt_resolvent_const_left`, proved from the resolvent identity because the
+generator is unbounded. -/
+theorem hasDerivAt_resolventFun (hb : S.HasGrowthBound omega M) {lambda : ℝ}
+    (hl : omega < lambda) :
+    HasDerivAt (S.resolventFun hb) (-(S.resolventFun hb lambda ^ 2)) lambda := by
+  have hMpos : (0 : ℝ) < M := lt_of_lt_of_le zero_lt_one hb.one_le
+  have hd : (0 : ℝ) < lambda - omega := sub_pos.mpr hl
+  set C : ℝ := (M / (lambda - omega)) ^ 2 * (M / ((lambda - omega) / 2)) with hC
+  have hCpos : 0 < C := by
+    have h1 : 0 < M / (lambda - omega) := div_pos hMpos hd
+    exact mul_pos (pow_pos h1 2) (div_pos hMpos (by linarith))
+  refine HasDerivAt.of_isLittleO (Asymptotics.isLittleO_iff.mpr ?_)
+  intro c hc
+  filter_upwards [Metric.ball_mem_nhds lambda
+    (lt_min (half_pos hd) (div_pos hc hCpos))] with mu hmu
+  rw [Metric.mem_ball, Real.dist_eq] at hmu
+  have habs : |mu - lambda| < (lambda - omega) / 2 := lt_of_lt_of_le hmu (min_le_left _ _)
+  have habs' : |mu - lambda| < c / C := lt_of_lt_of_le hmu (min_le_right _ _)
+  have hmu_lb : (lambda - omega) / 2 < mu - omega := by
+    have := neg_lt_of_abs_lt habs
+    linarith
+  have hm : omega < mu := by linarith
+  have hstep : ‖S.resolventFun hb mu - S.resolventFun hb lambda
+      - (mu - lambda) • -(S.resolventFun hb lambda ^ 2)‖
+      ≤ (mu - lambda) ^ 2 * C := by
+    rw [smul_neg, sub_neg_eq_add]
+    refine (S.norm_resolventFun_second_order_le hb hl hm).trans ?_
+    have hMdiv : M / (mu - omega) ≤ M / ((lambda - omega) / 2) := by gcongr
+    exact mul_le_mul_of_nonneg_left
+      (mul_le_mul_of_nonneg_left hMdiv (sq_nonneg _)) (sq_nonneg _)
+  refine hstep.trans ?_
+  rw [Real.norm_eq_abs]
+  calc (mu - lambda) ^ 2 * C = |mu - lambda| ^ 2 * C := by rw [sq_abs]
+    _ = |mu - lambda| * (|mu - lambda| * C) := by ring
+    _ ≤ |mu - lambda| * (c / C * C) := by gcongr
+    _ = c * |mu - lambda| := by rw [div_mul_cancel₀ _ hCpos.ne']; ring
+
+/-- The derivative of the resolvent in the spectral parameter. -/
+theorem deriv_resolventFun (hb : S.HasGrowthBound omega M) {lambda : ℝ} (hl : omega < lambda) :
+    deriv (S.resolventFun hb) lambda = -(S.resolventFun hb lambda ^ 2) :=
+  (S.hasDerivAt_resolventFun hb hl).deriv
+
+/-- The resolvent is differentiable on the half-line above the growth exponent. -/
+theorem differentiableOn_resolventFun (hb : S.HasGrowthBound omega M) :
+    DifferentiableOn ℝ (S.resolventFun hb) (Set.Ioi omega) := fun _ hl =>
+  (S.hasDerivAt_resolventFun hb hl).differentiableAt.differentiableWithinAt
+
+/-! ## Higher derivatives -/
+
+/-- The derivative of `lambda ↦ R(lambda)ⁿ` is `-n R(lambda)ⁿ⁺¹`. -/
+theorem hasDerivAt_resolventFun_pow (hb : S.HasGrowthBound omega M) {lambda : ℝ}
+    (hl : omega < lambda) (n : ℕ) :
+    HasDerivAt (fun l => S.resolventFun hb l ^ n)
+      (-(n • S.resolventFun hb lambda ^ (n + 1))) lambda := by
+  induction n with
+  | zero => simpa using hasDerivAt_const lambda (1 : X →L[ℝ] X)
+  | succ n ih =>
+      have hfun : (fun l => S.resolventFun hb l ^ (n + 1))
+          = fun l => S.resolventFun hb l ^ n * S.resolventFun hb l := by
+        funext l
+        rw [pow_succ]
+      rw [hfun]
+      refine (ih.mul (S.hasDerivAt_resolventFun hb hl)).congr_deriv ?_
+      noncomm_ring
+      rw [succ_nsmul, smul_add]
+
+/-- **The iterated derivative of the resolvent**:
+`dⁿR(lambda)/dlambdaⁿ = (-1)ⁿ n! R(lambda)ⁿ⁺¹`. -/
+theorem iteratedDeriv_resolventFun (hb : S.HasGrowthBound omega M) (n : ℕ) {lambda : ℝ}
+    (hl : omega < lambda) :
+    iteratedDeriv n (S.resolventFun hb) lambda
+      = ((-1 : ℝ) ^ n * n !) • S.resolventFun hb lambda ^ (n + 1) := by
+  induction n generalizing lambda with
+  | zero => simp
+  | succ n ih =>
+      have heq : iteratedDeriv n (S.resolventFun hb)
+          =ᶠ[𝓝 lambda] fun l => ((-1 : ℝ) ^ n * n !) • S.resolventFun hb l ^ (n + 1) := by
+        filter_upwards [isOpen_Ioi.mem_nhds (Set.mem_Ioi.mpr hl)] with l hl' using ih hl'
+      have hderiv : HasDerivAt
+          (fun l => ((-1 : ℝ) ^ n * n !) • S.resolventFun hb l ^ (n + 1))
+          (((-1 : ℝ) ^ n * n !) • -((n + 1) • S.resolventFun hb lambda ^ (n + 1 + 1))) lambda :=
+        (S.hasDerivAt_resolventFun_pow hb hl (n + 1)).const_smul ((-1 : ℝ) ^ n * n !)
+      rw [iteratedDeriv_succ, heq.deriv_eq, hderiv.deriv,
+        ← Nat.cast_smul_eq_nsmul ℝ, smul_neg, smul_smul, ← neg_smul]
+      congr 1
+      push_cast [Nat.factorial_succ]
+      ring
+
+/-- **The Hille--Yosida derivative bound**
+`‖dⁿR(lambda)/dlambdaⁿ‖ ≤ n! (M / (lambda - omega))ⁿ⁺¹`, obtained by combining the iterated
+derivative formula with `‖R(lambda)‖ ≤ M / (lambda - omega)`. -/
+theorem norm_iteratedDeriv_resolventFun_le (hb : S.HasGrowthBound omega M) (n : ℕ) {lambda : ℝ}
+    (hl : omega < lambda) :
+    ‖iteratedDeriv n (S.resolventFun hb) lambda‖
+      ≤ n ! * (M / (lambda - omega)) ^ (n + 1) := by
+  have hscalar : ‖((-1 : ℝ) ^ n * n !)‖ = (n ! : ℝ) := by
+    rw [Real.norm_eq_abs, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul, Nat.abs_cast]
+  rw [S.iteratedDeriv_resolventFun hb n hl, norm_smul, hscalar]
+  refine mul_le_mul_of_nonneg_left ?_ (Nat.cast_nonneg _)
+  exact (norm_pow_le' _ n.succ_pos).trans
+    (pow_le_pow_left₀ (norm_nonneg _) (S.norm_resolventFun_le hb hl) (n + 1))
+
+/-- The resolvent is smooth on the half-line above the growth exponent. -/
+theorem contDiffOn_resolventFun (hb : S.HasGrowthBound omega M) :
+    ContDiffOn ℝ ∞ (S.resolventFun hb) (Set.Ioi omega) := by
+  rw [contDiffOn_infty]
+  intro n
+  induction n with
+  | zero => exact contDiffOn_zero.mpr (S.differentiableOn_resolventFun hb).continuousOn
+  | succ n ih =>
+      rw [Nat.cast_succ, contDiffOn_succ_iff_deriv_of_isOpen isOpen_Ioi]
+      refine ⟨S.differentiableOn_resolventFun hb, by simp, ?_⟩
+      exact ((ih.pow 2).neg).congr fun l hl => S.deriv_resolventFun hb hl
+
+end StronglyContinuousSemigroup
+
+/-! ## The contraction case -/
+
+namespace ContractionSemigroup
+
+variable (S : ContractionSemigroup X)
+
+/-- The resolvent of a contraction semigroup as a function of the spectral parameter alone,
+the `(omega, M) = (0, 1)` case of `StronglyContinuousSemigroup.resolventFun`. -/
+def resolventFun (lambda : ℝ) : X →L[ℝ] X :=
+  S.toStronglyContinuousSemigroup.resolventFun S.hasGrowthBound lambda
+
+/-- For a positive parameter, `resolventFun` is the contraction resolvent. -/
+theorem resolventFun_of_pos {lambda : ℝ} (h : 0 < lambda) :
+    S.resolventFun lambda = S.resolvent lambda h := by
+  ext x
+  rw [resolventFun, S.toStronglyContinuousSemigroup.resolventFun_of_lt S.hasGrowthBound h,
+    S.toStronglyContinuousSemigroup.resolvent_apply, S.resolvent_apply]
+
+/-- The derivative of the contraction resolvent is `-R(lambda)²`. -/
+theorem hasDerivAt_resolventFun {lambda : ℝ} (h : 0 < lambda) :
+    HasDerivAt S.resolventFun (-(S.resolventFun lambda ^ 2)) lambda :=
+  S.toStronglyContinuousSemigroup.hasDerivAt_resolventFun S.hasGrowthBound h
+
+/-- The iterated derivative of the contraction resolvent. -/
+theorem iteratedDeriv_resolventFun (n : ℕ) {lambda : ℝ} (h : 0 < lambda) :
+    iteratedDeriv n S.resolventFun lambda
+      = ((-1 : ℝ) ^ n * n !) • S.resolventFun lambda ^ (n + 1) :=
+  S.toStronglyContinuousSemigroup.iteratedDeriv_resolventFun S.hasGrowthBound n h
+
+/-- The Hille--Yosida derivative bound `‖dⁿR(lambda)/dlambdaⁿ‖ ≤ n! / lambdaⁿ⁺¹` in the
+contraction case. -/
+theorem norm_iteratedDeriv_resolventFun_le (n : ℕ) {lambda : ℝ} (h : 0 < lambda) :
+    ‖iteratedDeriv n S.resolventFun lambda‖ ≤ n ! * (1 / lambda) ^ (n + 1) := by
+  have := S.toStronglyContinuousSemigroup.norm_iteratedDeriv_resolventFun_le S.hasGrowthBound n h
+  rwa [sub_zero] at this
+
+/-- The contraction resolvent is smooth on `(0, ∞)`. -/
+theorem contDiffOn_resolventFun : ContDiffOn ℝ ∞ S.resolventFun (Set.Ioi 0) :=
+  S.toStronglyContinuousSemigroup.contDiffOn_resolventFun S.hasGrowthBound
+
+end ContractionSemigroup
+
+end TauCeti.Semigroups
+
+end

--- a/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Deriv.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Semigroups.Resolvent.Identity
-public import Mathlib.Analysis.Calculus.Deriv.Mul
+public import Mathlib.Analysis.Calculus.Deriv.Pow
 public import Mathlib.Analysis.Calculus.ContDiff.Deriv
 public import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
 
@@ -14,9 +14,8 @@ public import Mathlib.Analysis.Calculus.IteratedDeriv.Defs
 
 The Laplace-transform resolvent `R(lambda) x = ∫₀^∞ e^{-lambda t} S(t)x dt` of a C₀-semigroup
 `S` with growth bound `(omega, M)` is defined for `lambda > omega`, and it carries the proof
-`omega < lambda` as an argument. To speak about its dependence on `lambda` we package it as an
-honest function `StronglyContinuousSemigroup.resolventFun`, extended by the junk value `0`
-below the growth exponent.
+`omega < lambda` as an argument; `StronglyContinuousSemigroup.resolventFun` packages it as an
+honest function of `lambda`, extended by the junk value `0` below the growth exponent.
 
 The resolvent identity then upgrades to a second-order expansion
 
@@ -32,8 +31,6 @@ is smooth on `(omega, ∞)`.
 
 ## Main results
 
-* `TauCeti.Semigroups.StronglyContinuousSemigroup.resolventFun`: the resolvent as a function of
-  the spectral parameter alone.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.hasDerivAt_resolventFun`:
   `R'(lambda) = -R(lambda)²`.
 * `TauCeti.Semigroups.StronglyContinuousSemigroup.hasDerivAt_resolventFun_pow`:
@@ -49,9 +46,10 @@ The contraction case `(omega, M) = (0, 1)` is recorded as a corollary.
 
 Mathlib's `spectrum.hasDerivAt_resolvent_const_left` proves the same derivative formula for the
 resolvent of an element of a Banach algebra. It does not apply here: the generator of a
-C₀-semigroup is an unbounded operator, so `R(lambda)` is not `resolvent a lambda` for any
-algebra element `a`, and the present proof runs off the semigroup resolvent identity instead of
-off differentiability of `Ring.inverse`.
+C₀-semigroup need not be bounded (it is a densely defined operator on a subspace, and is
+bounded exactly for the uniformly continuous semigroups), so in general there is no algebra
+element `a` with `R(lambda) = resolvent a lambda`. The present proof therefore runs off the
+semigroup resolvent identity instead of off differentiability of `Ring.inverse`.
 
 ## References
 
@@ -72,46 +70,6 @@ variable {X : Type*} [NormedAddCommGroup X] [NormedSpace ℝ X] [CompleteSpace X
 namespace StronglyContinuousSemigroup
 
 variable (S : StronglyContinuousSemigroup X) {omega M : ℝ}
-
-/-! ## The resolvent as a function of the spectral parameter -/
-
-/-- The Laplace-transform resolvent of `S` as a function of the spectral parameter alone,
-extended by the junk value `0` on `lambda ≤ omega`. Unlike
-`StronglyContinuousSemigroup.resolvent` it does not carry the proof `omega < lambda`, so it can
-be differentiated in `lambda`. -/
-def resolventFun (hb : S.HasGrowthBound omega M) (lambda : ℝ) : X →L[ℝ] X :=
-  if h : omega < lambda then S.resolvent hb lambda h else 0
-
-/-- Above the growth exponent, `resolventFun` is the Laplace-transform resolvent. -/
-theorem resolventFun_of_lt (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda) :
-    S.resolventFun hb lambda = S.resolvent hb lambda h :=
-  dif_pos h
-
-/-- Below the growth exponent, `resolventFun` takes its junk value `0`. -/
-theorem resolventFun_of_le (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : lambda ≤ omega) :
-    S.resolventFun hb lambda = 0 :=
-  dif_neg (not_lt.mpr h)
-
-/-- `resolventFun` in integral form. -/
-theorem resolventFun_apply (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda)
-    (x : X) :
-    S.resolventFun hb lambda x
-      = ∫ t in Set.Ioi 0, Real.exp (-(lambda * t)) • S.realOperator t x := by
-  rw [S.resolventFun_of_lt hb h, S.resolvent_apply]
-
-/-- The Hille--Yosida bound `‖R(lambda)‖ ≤ M / (lambda - omega)` for `resolventFun`. -/
-theorem norm_resolventFun_le (hb : S.HasGrowthBound omega M) {lambda : ℝ} (h : omega < lambda) :
-    ‖S.resolventFun hb lambda‖ ≤ M / (lambda - omega) := by
-  rw [S.resolventFun_of_lt hb h]
-  exact S.resolvent_norm_le hb lambda h
-
-/-- The resolvent identity for `resolventFun`, written in the ring `X →L[ℝ] X`. -/
-theorem resolventFun_sub_resolventFun (hb : S.HasGrowthBound omega M) {lambda mu : ℝ}
-    (hl : omega < lambda) (hm : omega < mu) :
-    S.resolventFun hb lambda - S.resolventFun hb mu
-      = (mu - lambda) • (S.resolventFun hb lambda * S.resolventFun hb mu) := by
-  rw [S.resolventFun_of_lt hb hl, S.resolventFun_of_lt hb hm]
-  exact S.resolvent_sub_resolvent hb hb lambda mu hl hm
 
 /-! ## The first derivative -/
 
@@ -147,8 +105,8 @@ private theorem norm_resolventFun_second_order_le (hb : S.HasGrowthBound omega M
           exact norm_pow_le' _ two_pos
       _ ≤ (M / (lambda - omega)) ^ 2 * (M / (mu - omega)) :=
           mul_le_mul
-            (pow_le_pow_left₀ (norm_nonneg _) (S.norm_resolventFun_le hb hl) 2)
-            (S.norm_resolventFun_le hb hm) (norm_nonneg _)
+            (pow_le_pow_left₀ (norm_nonneg _) (S.resolventFun_norm_le hb hl) 2)
+            (S.resolventFun_norm_le hb hm) (norm_nonneg _)
             (pow_nonneg (div_nonneg hMpos.le (by linarith)) 2)
   rw [S.resolventFun_second_order_eq hb hl hm, norm_smul, Real.norm_eq_abs,
     abs_of_nonneg (sq_nonneg _)]
@@ -157,7 +115,7 @@ private theorem norm_resolventFun_second_order_le (hb : S.HasGrowthBound omega M
 /-- **The resolvent is differentiable in the spectral parameter**, with derivative `-R(lambda)²`
 taken in the operator norm. This is the semigroup analogue of Mathlib's
 `spectrum.hasDerivAt_resolvent_const_left`, proved from the resolvent identity because the
-generator is unbounded. -/
+generator need not be a bounded operator. -/
 theorem hasDerivAt_resolventFun (hb : S.HasGrowthBound omega M) {lambda : ℝ}
     (hl : omega < lambda) :
     HasDerivAt (S.resolventFun hb) (-(S.resolventFun hb lambda ^ 2)) lambda := by
@@ -210,17 +168,21 @@ theorem hasDerivAt_resolventFun_pow (hb : S.HasGrowthBound omega M) {lambda : �
     (hl : omega < lambda) (n : ℕ) :
     HasDerivAt (fun l => S.resolventFun hb l ^ n)
       (-(n • S.resolventFun hb lambda ^ (n + 1))) lambda := by
-  induction n with
-  | zero => simpa using hasDerivAt_const lambda (1 : X →L[ℝ] X)
-  | succ n ih =>
-      have hfun : (fun l => S.resolventFun hb l ^ (n + 1))
-          = fun l => S.resolventFun hb l ^ n * S.resolventFun hb l := by
-        funext l
-        rw [pow_succ]
-      rw [hfun]
-      refine (ih.mul (S.hasDerivAt_resolventFun hb hl)).congr_deriv ?_
-      noncomm_ring
-      rw [succ_nsmul, smul_add]
+  refine ((S.hasDerivAt_resolventFun hb hl).fun_pow' n).congr_deriv ?_
+  cases n with
+  | zero => simp
+  | succ n =>
+      have hterm : ∀ i ∈ Finset.range (n + 1),
+          S.resolventFun hb lambda ^ ((n + 1).pred - i) * -(S.resolventFun hb lambda ^ 2)
+              * S.resolventFun hb lambda ^ i
+            = -(S.resolventFun hb lambda ^ (n + 1 + 1)) := by
+        intro i hi
+        have hexp : (n + 1).pred - i + 2 + i = n + 1 + 1 := by
+          have := Finset.mem_range.mp hi
+          simp only [Nat.pred_eq_sub_one]
+          omega
+        rw [mul_neg, neg_mul, ← pow_add, ← pow_add, hexp]
+      rw [Finset.sum_congr rfl hterm, Finset.sum_const, Finset.card_range, smul_neg]
 
 /-- **The iterated derivative of the resolvent**:
 `dⁿR(lambda)/dlambdaⁿ = (-1)ⁿ n! R(lambda)ⁿ⁺¹`. -/
@@ -238,9 +200,8 @@ theorem iteratedDeriv_resolventFun (hb : S.HasGrowthBound omega M) (n : ℕ) {la
           (fun l => ((-1 : ℝ) ^ n * n !) • S.resolventFun hb l ^ (n + 1))
           (((-1 : ℝ) ^ n * n !) • -((n + 1) • S.resolventFun hb lambda ^ (n + 1 + 1))) lambda :=
         (S.hasDerivAt_resolventFun_pow hb hl (n + 1)).const_smul ((-1 : ℝ) ^ n * n !)
-      rw [iteratedDeriv_succ, heq.deriv_eq, hderiv.deriv,
-        ← Nat.cast_smul_eq_nsmul ℝ, smul_neg, smul_smul, ← neg_smul]
-      congr 1
+      rw [iteratedDeriv_succ, heq.deriv_eq, hderiv.deriv]
+      match_scalars
       push_cast [Nat.factorial_succ]
       ring
 
@@ -251,12 +212,11 @@ theorem norm_iteratedDeriv_resolventFun_le (hb : S.HasGrowthBound omega M) (n : 
     (hl : omega < lambda) :
     ‖iteratedDeriv n (S.resolventFun hb) lambda‖
       ≤ n ! * (M / (lambda - omega)) ^ (n + 1) := by
-  have hscalar : ‖((-1 : ℝ) ^ n * n !)‖ = (n ! : ℝ) := by
-    rw [Real.norm_eq_abs, abs_mul, abs_pow, abs_neg, abs_one, one_pow, one_mul, Nat.abs_cast]
+  have hscalar : ‖((-1 : ℝ) ^ n * n !)‖ = (n ! : ℝ) := by simp
   rw [S.iteratedDeriv_resolventFun hb n hl, norm_smul, hscalar]
   refine mul_le_mul_of_nonneg_left ?_ (Nat.cast_nonneg _)
   exact (norm_pow_le' _ n.succ_pos).trans
-    (pow_le_pow_left₀ (norm_nonneg _) (S.norm_resolventFun_le hb hl) (n + 1))
+    (pow_le_pow_left₀ (norm_nonneg _) (S.resolventFun_norm_le hb hl) (n + 1))
 
 /-- The resolvent is smooth on the half-line above the growth exponent. -/
 theorem contDiffOn_resolventFun (hb : S.HasGrowthBound omega M) :
@@ -277,18 +237,6 @@ end StronglyContinuousSemigroup
 namespace ContractionSemigroup
 
 variable (S : ContractionSemigroup X)
-
-/-- The resolvent of a contraction semigroup as a function of the spectral parameter alone,
-the `(omega, M) = (0, 1)` case of `StronglyContinuousSemigroup.resolventFun`. -/
-def resolventFun (lambda : ℝ) : X →L[ℝ] X :=
-  S.toStronglyContinuousSemigroup.resolventFun S.hasGrowthBound lambda
-
-/-- For a positive parameter, `resolventFun` is the contraction resolvent. -/
-theorem resolventFun_of_pos {lambda : ℝ} (h : 0 < lambda) :
-    S.resolventFun lambda = S.resolvent lambda h := by
-  ext x
-  rw [resolventFun, S.toStronglyContinuousSemigroup.resolventFun_of_lt S.hasGrowthBound h,
-    S.toStronglyContinuousSemigroup.resolvent_apply, S.resolvent_apply]
 
 /-- The derivative of the contraction resolvent is `-R(lambda)²`. -/
 theorem hasDerivAt_resolventFun {lambda : ℝ} (h : 0 < lambda) :

--- a/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
+++ b/TauCeti/Analysis/Semigroups/Resolvent/Identity.lean
@@ -12,7 +12,9 @@ public import TauCeti.Analysis.Semigroups.Generator.OrbitDerivative
 
 This file proves that the Laplace-transform resolvent is also a left inverse of
 `lambda • I - A` on the generator domain. It then derives the resolvent identity
-`R(lambda) - R(mu) = (mu - lambda) R(lambda) R(mu)` and commutativity of resolvents.
+`R(lambda) - R(mu) = (mu - lambda) R(lambda) R(mu)` and commutativity of resolvents. The
+identity is recorded both for `resolvent` and for `resolventFun`, the resolvent seen as a
+function of the spectral parameter alone.
 
 ## References
 
@@ -184,6 +186,15 @@ theorem resolvent_sub_resolvent (S : StronglyContinuousSemigroup X)
         (S.resolvent hbLambda lambda hlambda ∘L S.resolvent hbMu mu hmu) := by
   ext x
   exact S.resolvent_sub_resolvent_apply hbLambda hbMu lambda mu hlambda hmu x
+
+/-- The resolvent identity for `resolventFun`, written in the ring `X →L[ℝ] X`. -/
+theorem resolventFun_sub_resolventFun (S : StronglyContinuousSemigroup X) {omega M : ℝ}
+    [CompleteSpace X] (hb : S.HasGrowthBound omega M) {lambda mu : ℝ}
+    (hl : omega < lambda) (hm : omega < mu) :
+    S.resolventFun hb lambda - S.resolventFun hb mu
+      = (mu - lambda) • (S.resolventFun hb lambda * S.resolventFun hb mu) := by
+  rw [S.resolventFun_of_lt hb hl, S.resolventFun_of_lt hb hm]
+  exact S.resolvent_sub_resolvent hb hb lambda mu hl hm
 
 /-- Resolvents at two admissible parameters commute. -/
 theorem resolvent_comm (S : StronglyContinuousSemigroup X)


### PR DESCRIPTION
This PR differentiates the Laplace-transform resolvent of a strongly continuous semigroup in
its spectral parameter. `StronglyContinuousSemigroup.resolvent` carries the proof
`omega < lambda` as an argument, so it cannot be fed to `HasDerivAt` directly; the new
`StronglyContinuousSemigroup.resolventFun` packages it as an honest function of `lambda`,
extended by the junk value `0` below the growth exponent, and comes with the expected
unfolding, integral, norm-bound and resolvent-identity lemmas. Rewriting the resolvent
identity as the second-order expansion
`R(mu) - R(lambda) + (mu - lambda) R(lambda)^2 = (mu - lambda)^2 R(lambda)^2 R(mu)` and
estimating the right-hand side with `‖R(mu)‖ ≤ M / (mu - omega)` gives operator-norm
differentiability with `R'(lambda) = -R(lambda)^2`; induction then yields
`d^n R(lambda)/dlambda^n = (-1)^n n! R(lambda)^(n+1)`, the Hille–Yosida derivative bound
`‖d^n R(lambda)/dlambda^n‖ ≤ n! (M / (lambda - omega))^(n+1)`, and smoothness of the resolvent
on `(omega, ∞)`. Everything is stated at the general growth bound `(M, omega)`, with the
contraction case `(1, 0)` recorded as a corollary.

This is the derivative half of the "derivative / power formulas" bullet of the resolvent-theory
list in Part A of `TauCetiRoadmap/OneParameterSemigroups/README.md` ("the derivative / power
formulas ... with `dᵏR(λ,A)/dλᵏ = (−1)ᵏ k! · R(λ,A)^{k+1}`"). The companion integral formula
`R(λ,A)ⁿ x = ∫₀^∞ tⁿ⁻¹/(n−1)! e^{−λt} S(t)x dt` and complex analyticity via complexification are
left for follow-up PRs; the real-variable smoothness proved here is what the same list's
analyticity bullet asks for on the real half-line.

Mathlib's `spectrum.hasDerivAt_resolvent_const_left` proves the same derivative formula for the
resolvent of a Banach-algebra element. It does not apply: the generator of a C₀-semigroup need
not be bounded (it is bounded exactly for the uniformly continuous semigroups), so in general
there is no algebra element `a` with `R(lambda) = resolvent a lambda`, and the proof here runs
off the semigroup resolvent identity rather than off differentiability of `Ring.inverse`. No Mathlib code was vendored.

Roadmap: OneParameterSemigroups

<!--tauceti-target:v1 {"focus":"OneParameterSemigroups","id":"resolvent-derivative-in-lambda"}-->

🤖 Prepared with Claude Code

