### PR TITLE
style(RepresentationTheory): pack underfilled signature lines

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -141,8 +141,7 @@ noncomputable def ofCharacter {V : Type w} [AddCommGroup V] [Module k V]
 /-- The class function of a representation evaluates to its character. -/
 @[simp]
 theorem ofCharacter_apply {V : Type w} [AddCommGroup V] [Module k V]
-    (ρ : Representation k G V) (g : G) :
-    (ofCharacter ρ).1 g = ρ.character g :=
+    (ρ : Representation k G V) (g : G) : (ofCharacter ρ).1 g = ρ.character g :=
   (rfl)
 
 /-- The character of a finite-dimensional bundled representation is a class function. -/
@@ -151,8 +150,7 @@ noncomputable def ofFDRep (V : FDRep k G) : ClassFunction k G :=
 
 /-- The class function of a bundled finite-dimensional representation evaluates to its character. -/
 @[simp]
-theorem ofFDRep_apply (V : FDRep k G) (g : G) :
-    (ofFDRep V).1 g = V.character g :=
+theorem ofFDRep_apply (V : FDRep k G) (g : G) : (ofFDRep V).1 g = V.character g :=
   (rfl)
 
 end ClassFunction

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basis.lean
@@ -125,8 +125,7 @@ noncomputable def centerEquivConjClasses :
 
 /-- The forward map of `centerEquivConjClasses` reads the coefficients of a central element. -/
 @[simp]
-theorem centerEquivConjClasses_apply
-    (z : Subalgebra.center k (MonoidAlgebra k G)) :
+theorem centerEquivConjClasses_apply (z : Subalgebra.center k (MonoidAlgebra k G)) :
     centerEquivConjClasses z = centerToConjClasses z :=
   (rfl)
 
@@ -154,8 +153,7 @@ theorem classSumBasis_apply (C : ConjClasses G) :
 /-- The coordinate of a central element in the class-sum basis is its coefficient on that
 conjugacy class. -/
 @[simp]
-theorem classSumBasis_repr_apply
-    (z : Subalgebra.center k (MonoidAlgebra k G)) (C : ConjClasses G) :
+theorem classSumBasis_repr_apply (z : Subalgebra.center k (MonoidAlgebra k G)) (C : ConjClasses G) :
     (classSumBasis (k := k)).repr z C = centerToConjClasses z C :=
   Module.Basis.ofEquivFun_repr_apply centerEquivConjClasses z C
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Eigenrow.lean
@@ -169,8 +169,7 @@ theorem eq_of_vecMul_classMultMatrix_eq_smul {v : ConjClasses G → k}
 Only the existence of *some* eigenvalue for each matrix has to be checked; the normalization forces
 it to be the row's own value. -/
 theorem isClassEigenrow_of_forall_exists_smul {v : ConjClasses G → k}
-    (hv₁ : v (ConjClasses.mk (1 : G)) = 1)
-    (h : ∀ Cᵢ : ConjClasses G,
+    (hv₁ : v (ConjClasses.mk (1 : G)) = 1) (h : ∀ Cᵢ : ConjClasses G,
       ∃ c : k, v ᵥ* (classMultMatrix Cᵢ).map (Int.cast : ℤ → k) = c • v) :
     IsClassEigenrow v := fun Cᵢ => by
   obtain ⟨c, hc⟩ := h Cᵢ
@@ -187,8 +186,7 @@ theorem isClassEigenrow_classSumRow (φ : Subalgebra.center k (MonoidAlgebra k G
 
 /-- The linear extension of a row of scalars along the class-sum basis is multiplicative as soon as
 it is multiplicative on the basis itself. -/
-private theorem map_mul_of_basis
-    {f : Subalgebra.center k (MonoidAlgebra k G) →ₗ[k] k}
+private theorem map_mul_of_basis {f : Subalgebra.center k (MonoidAlgebra k G) →ₗ[k] k}
     (hf : ∀ Cᵢ Cⱼ : ConjClasses G,
       f (classSumCenter Cᵢ * classSumCenter Cⱼ) = f (classSumCenter Cᵢ) * f (classSumCenter Cⱼ))
     (x y : Subalgebra.center k (MonoidAlgebra k G)) : f (x * y) = f x * f y :=
@@ -239,8 +237,7 @@ theorem isClassEigenrow_iff_exists_algHom (hv₁ : v (ConjClasses.mk (1 : G)) = 
 /-- **The algebra homomorphisms out of the centre of `k[G]` are the normalized common left
 eigenrows of the class-multiplication matrices**, bundled as an equivalence: a homomorphism goes to
 its row of values on the class sums, and a row extends linearly along the class-sum basis. -/
-noncomputable def algHomEquivEigenrow :
-    (Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) ≃
+noncomputable def algHomEquivEigenrow : (Subalgebra.center k (MonoidAlgebra k G) →ₐ[k] k) ≃
       {v : ConjClasses G → k // v (ConjClasses.mk (1 : G)) = 1 ∧ IsClassEigenrow v} where
   toFun φ := ⟨classSumRow φ, classSumRow_mk_one φ, isClassEigenrow_classSumRow φ⟩
   invFun v := eigenrowAlgHom v.2.1 v.2.2

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Integral.lean
@@ -30,8 +30,7 @@ public section
 namespace TauCeti
 
 /-- A class sum is integral over `ℤ` as an element of the center of `ℤ[G]`. -/
-theorem isIntegral_classSum {G : Type*} [Group G] [Fintype G] [DecidableEq G]
-    (C : ConjClasses G) :
+theorem isIntegral_classSum {G : Type*} [Group G] [Fintype G] [DecidableEq G] (C : ConjClasses G) :
     IsIntegral ℤ (classSumCenter (k := ℤ) C) :=
   Algebra.IsIntegral.isIntegral _
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/StructureConstants.lean
@@ -117,8 +117,7 @@ theorem classSumCenter_mul (k : Type*) [CommSemiring k] (Cᵢ Cⱼ : ConjClasses
 /-- The coefficient of `g` in a product of two class sums is the structure constant at the
 conjugacy class of `g`. This is the pointwise form of `TauCeti.classSum_mul`. -/
 theorem coeff_classSum_mul (k : Type*) [Semiring k] (Cᵢ Cⱼ : ConjClasses G) (g : G) :
-    (classSum k Cᵢ * classSum k Cⱼ).coeff g =
-      (structureConstant Cᵢ Cⱼ (ConjClasses.mk g) : k) := by
+    (classSum k Cᵢ * classSum k Cⱼ).coeff g = (structureConstant Cᵢ Cⱼ (ConjClasses.mk g) : k) := by
   rw [classSum_mul]
   simp only [MonoidAlgebra.coeff_sum, Finsupp.finsetSum_apply, MonoidAlgebra.coeff_smul_apply,
     smul_eq_mul, classSum_coeff]

--- a/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Pairing.lean
@@ -112,8 +112,7 @@ private noncomputable def classIndicator (x : G) : ClassFunction k G := by
   exact equivConjClasses.symm (Pi.single (ConjClasses.mk x) 1)
 
 open scoped Classical in
-private theorem classIndicator_apply (x y : G) :
-    (classIndicator (k := k) x).1 y =
+private theorem classIndicator_apply (x y : G) : (classIndicator (k := k) x).1 y =
       if ConjClasses.mk y = ConjClasses.mk x then 1 else 0 :=
   by
     classical
@@ -187,10 +186,8 @@ theorem characterPairing_nondegenerate [Invertible (Nat.card G : k)] :
     (mul_ne_zero (card_conjClass_cast_ne_zero (k := k) x) hfx)) hpair
 
 /-- The pairing of two representation characters is Mathlib's normalized character sum. -/
-theorem characterPairing_ofCharacter
-    {V W : Type*} [AddCommGroup V] [Module k V]
-    [AddCommGroup W] [Module k W]
-    (ρ : Representation k G V) (σ : Representation k G W) :
+theorem characterPairing_ofCharacter {V W : Type*} [AddCommGroup V] [Module k V]
+    [AddCommGroup W] [Module k W] (ρ : Representation k G V) (σ : Representation k G W) :
     characterPairing (ofCharacter ρ) (ofCharacter σ) =
       (Nat.card G : k)⁻¹ * ∑ g : G, ρ.character g * σ.character g⁻¹ := by
   rw [characterPairing_apply]

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Decomposition.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Decomposition.lean
@@ -45,8 +45,7 @@ variable [CommRing k] [Invertible (2 : k)]
 
 /-- The tensor square of the standard representation is equivalent to the product of its
 symmetric and exterior squares. -/
-noncomputable abbrev tensorSquareRepEquiv :
-    (tensorPowerRep k n 2).Equiv
+noncomputable abbrev tensorSquareRepEquiv : (tensorPowerRep k n 2).Equiv
       ((symPowerRep k n 2).prod (extPowerRep k n 2)) :=
   (stdRep k n).tensorSquareEquivSymmetricExterior
 
@@ -64,8 +63,7 @@ noncomputable def tensorSquareFDRepIso :
 /-- The forward map of the bundled tensor-square decomposition is the natural representation
 equivalence. -/
 @[simp]
-theorem tensorSquareFDRepIso_hom_hom :
-    (tensorSquareFDRepIso k n).hom.hom =
+theorem tensorSquareFDRepIso_hom_hom : (tensorSquareFDRepIso k n).hom.hom =
       ConcreteCategory.ofHom (tensorSquareRepEquiv k n).toLinearMap :=
   by
     rw [tensorSquareFDRepIso]
@@ -74,8 +72,7 @@ theorem tensorSquareFDRepIso_hom_hom :
 /-- The inverse map of the bundled tensor-square decomposition is the inverse natural
 representation equivalence. -/
 @[simp]
-theorem tensorSquareFDRepIso_inv_hom :
-    (tensorSquareFDRepIso k n).inv.hom =
+theorem tensorSquareFDRepIso_inv_hom : (tensorSquareFDRepIso k n).inv.hom =
       ConcreteCategory.ofHom (tensorSquareRepEquiv k n).symm.toLinearMap :=
   by
     rw [tensorSquareFDRepIso]

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Determinant.lean
@@ -77,8 +77,7 @@ theorem detPowerRep_add_apply (m l : ℤ) (g : GL (Fin n) k) (x : k) :
 
 /-- Every determinant-power representation restricts to the trivial representation of `SL n k`. -/
 @[simp]
-theorem detPowerRep_comp_toGL (m : ℤ) :
-    (detPowerRep k n m).comp Matrix.SpecialLinearGroup.toGL =
+theorem detPowerRep_comp_toGL (m : ℤ) : (detPowerRep k n m).comp Matrix.SpecialLinearGroup.toGL =
       Representation.trivial k (Matrix.SpecialLinearGroup (Fin n) k) k := by
   apply MonoidHom.ext
   intro g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Diagonal.lean
@@ -42,8 +42,7 @@ def diagGL : (Fin n → kˣ) →* GL (Fin n) k :=
 
 /-- The matrix underlying `diagGL t` is the diagonal matrix with entries `t i`. -/
 @[simp]
-theorem diagGL_coe (t : Fin n → kˣ) :
-    (diagGL t : Matrix (Fin n) (Fin n) k) =
+theorem diagGL_coe (t : Fin n → kˣ) : (diagGL t : Matrix (Fin n) (Fin n) k) =
       Matrix.diagonal fun i => (t i : k) := by
   rfl
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/ExteriorPower.lean
@@ -113,16 +113,14 @@ noncomputable def extPowerFDRepDetIso : extPowerFDRep k n n ≅ detFDRep k n :=
 /-- The forward map of the bundled identification is the underlying representation
 equivalence. -/
 @[simp]
-theorem extPowerFDRepDetIso_hom_hom :
-    (extPowerFDRepDetIso k n).hom.hom =
+theorem extPowerFDRepDetIso_hom_hom : (extPowerFDRepDetIso k n).hom.hom =
       ConcreteCategory.ofHom (topExtPowerEquivDet k n).toLinearMap := by
   rw [extPowerFDRepDetIso]
   rfl
 
 /-- The inverse map of the bundled identification is the inverse representation equivalence. -/
 @[simp]
-theorem extPowerFDRepDetIso_inv_hom :
-    (extPowerFDRepDetIso k n).inv.hom =
+theorem extPowerFDRepDetIso_inv_hom : (extPowerFDRepDetIso k n).inv.hom =
       ConcreteCategory.ofHom (topExtPowerEquivDet k n).symm.toLinearMap := by
   rw [extPowerFDRepDetIso]
   rfl
@@ -136,8 +134,7 @@ variable [Field k]
 /-- The character of the `d`th exterior power on a diagonal matrix is the `d`th elementary
 symmetric polynomial in its diagonal entries. -/
 @[simp]
-theorem char_extPowerRep_diagonal (t : Fin n → kˣ) :
-    (extPowerRep k n d).character (diagGL t) =
+theorem char_extPowerRep_diagonal (t : Fin n → kˣ) : (extPowerRep k n d).character (diagGL t) =
       MvPolynomial.eval (fun i => (t i : k)) (MvPolynomial.esymm (Fin n) k d) := by
   rw [Representation.character, Representation.exteriorPower_apply]
   rw [exteriorPower.trace_map_of_apply_basis (Pi.basisFun k (Fin n))

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Orthogonal.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Orthogonal.lean
@@ -112,8 +112,7 @@ theorem stdOrthogonalRep_dotProduct_stdOrthogonalRep
       rw [(Matrix.mem_orthogonalGroup_iff' (Fin n) k).mp g.prop, Matrix.one_mulVec]
 
 /-- The coordinate dot product identifies the standard module with its dual. -/
-noncomputable def stdOrthogonalRepToDual :
-    (Fin n → k) ≃ₗ[k] Module.Dual k (Fin n → k) :=
+noncomputable def stdOrthogonalRepToDual : (Fin n → k) ≃ₗ[k] Module.Dual k (Fin n → k) :=
   (Pi.basisFun k (Fin n)).toDualEquiv
 
 /-- `stdOrthogonalRepToDual` evaluates as the coordinate dot product. -/

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Standard.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Standard.lean
@@ -117,15 +117,13 @@ variable [Field k]
 
 /-- The character of the dual standard representation is the trace at the inverse matrix. -/
 @[simp]
-theorem char_stdDualRep (g : GL (Fin n) k) :
-    (stdDualRep k n).character g =
+theorem char_stdDualRep (g : GL (Fin n) k) : (stdDualRep k n).character g =
       Matrix.trace ((g⁻¹ : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) := by
   rw [stdDualRep, Representation.char_dual, char_stdRep]
 
 /-- The character of the bundled dual standard representation is the inverse matrix trace. -/
 @[simp]
-theorem char_stdDualFDRep (g : GL (Fin n) k) :
-    (stdDualFDRep k n).character g =
+theorem char_stdDualFDRep (g : GL (Fin n) k) : (stdDualFDRep k n).character g =
       Matrix.trace ((g⁻¹ : GL (Fin n) k) : Matrix (Fin n) (Fin n) k) := by
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using
     char_stdDualRep k n g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Symplectic.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Symplectic.lean
@@ -127,18 +127,15 @@ theorem isAlt_stdSymplecticBilinForm : (stdSymplecticBilinForm k n).IsAlt := by
     Matrix.neg_mulVec]
 
 /-- The standard symplectic form is nondegenerate. -/
-theorem stdSymplecticBilinForm_nondegenerate :
-    (stdSymplecticBilinForm k n).Nondegenerate := by
+theorem stdSymplecticBilinForm_nondegenerate : (stdSymplecticBilinForm k n).Nondegenerate := by
   rw [stdSymplecticBilinForm, Matrix.nondegenerate_toBilin'_iff]
   exact Matrix.Nondegenerate.of_det_mem_nonZeroDivisors
     (Matrix.isUnit_det_J (Fin n) k).mem_nonZeroDivisors
 
 /-- The standard symplectic action preserves the standard alternating form. -/
 @[simp]
-theorem stdSymplecticBilinForm_comp_stdSymplecticRep
-    (g : Matrix.symplecticGroup (Fin n) k) :
-    (stdSymplecticBilinForm k n).comp
-        (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k).mulVecLin
+theorem stdSymplecticBilinForm_comp_stdSymplecticRep (g : Matrix.symplecticGroup (Fin n) k) :
+    (stdSymplecticBilinForm k n).comp (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k).mulVecLin
         (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k).mulVecLin =
       stdSymplecticBilinForm k n := by
   rw [stdSymplecticBilinForm, ← Matrix.toLin'_apply', Matrix.toBilin'_comp]
@@ -148,8 +145,7 @@ theorem stdSymplecticBilinForm_comp_stdSymplecticRep
 @[simp]
 theorem stdSymplecticBilinForm_stdSymplecticRep
     (g : Matrix.symplecticGroup (Fin n) k) (v w : (Fin n ⊕ Fin n) → k) :
-    (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k).mulVec v ⬝ᵥ
-        (Matrix.J (Fin n) k *
+    (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k).mulVec v ⬝ᵥ (Matrix.J (Fin n) k *
           (g : Matrix (Fin n ⊕ Fin n) (Fin n ⊕ Fin n) k)).mulVec w =
       stdSymplecticBilinForm k n v w := by
   simpa only [LinearMap.BilinForm.comp_apply, stdSymplecticBilinForm_apply,
@@ -197,8 +193,7 @@ theorem stdSymplecticDualRep_apply (g : Matrix.symplecticGroup (Fin n) k) :
   rw [stdSymplecticDualRep, Representation.dual_apply, stdSymplecticRep_apply]
 
 /-- The standard-form identification intertwines the standard and dual actions. -/
-theorem stdSymplecticRepToDual_equivariant
-    (g : Matrix.symplecticGroup (Fin n) k) :
+theorem stdSymplecticRepToDual_equivariant (g : Matrix.symplecticGroup (Fin n) k) :
     stdSymplecticRepToDual k n ∘ₗ stdSymplecticRep k n g =
       stdSymplecticDualRep k n g ∘ₗ stdSymplecticRepToDual k n := by
   apply LinearMap.ext

--- a/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/TensorPower.lean
@@ -82,15 +82,13 @@ variable [Field k]
 
 This is intentionally not a simp lemma: `Representation.char_tensorPower` and `char_stdRep`
 already normalize its left-hand side, so registering this specialization would violate `simpNF`. -/
-theorem char_tensorPowerRep (g : GL (Fin n) k) :
-    (tensorPowerRep k n d).character g =
+theorem char_tensorPowerRep (g : GL (Fin n) k) : (tensorPowerRep k n d).character g =
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
   rw [Representation.char_tensorPower, char_stdRep]
 
 /-- The character of the bundled tensor power is the corresponding power of the matrix trace. -/
 @[simp]
-theorem char_tensorPowerFDRep (g : GL (Fin n) k) :
-    (tensorPowerFDRep k n d).character g =
+theorem char_tensorPowerFDRep (g : GL (Fin n) k) : (tensorPowerFDRep k n d).character g =
       Matrix.trace (g : Matrix (Fin n) (Fin n) k) ^ d := by
   simpa only [FDRep.character, FDRep.of_ρ', Representation.character] using
     char_tensorPowerRep k n d g

--- a/TauCeti/RepresentationTheory/ClassicalGroups/Volume.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/Volume.lean
@@ -80,8 +80,7 @@ theorem stdSLRep_exteriorPower_self_apply (g : Matrix.SpecialLinearGroup (Fin n)
 
 /-- **The volume element is invariant**: the top exterior power of the standard representation of
 `SL(n, k)` is the trivial one-dimensional representation. -/
-noncomputable def topExtPowerSLEquivTrivial :
-    ((stdSLRep k n).exteriorPower n).Equiv
+noncomputable def topExtPowerSLEquivTrivial : ((stdSLRep k n).exteriorPower n).Equiv
       (Representation.trivial k (Matrix.SpecialLinearGroup (Fin n) k) k) :=
   .mk (exteriorPower.topEquiv (Pi.basisFun k (Fin n))) fun g ↦ by
     rw [stdSLRep_exteriorPower_self_apply]
@@ -90,8 +89,7 @@ noncomputable def topExtPowerSLEquivTrivial :
 /-- The underlying linear equivalence of `TauCeti.topExtPowerSLEquivTrivial` is the top-degree
 identification of the exterior power with the scalars. -/
 @[simp]
-theorem topExtPowerSLEquivTrivial_toLinearEquiv :
-    (topExtPowerSLEquivTrivial k n).toLinearEquiv =
+theorem topExtPowerSLEquivTrivial_toLinearEquiv : (topExtPowerSLEquivTrivial k n).toLinearEquiv =
       exteriorPower.topEquiv (Pi.basisFun k (Fin n)) :=
   (rfl)
 

--- a/TauCeti/RepresentationTheory/Compact/Intertwiner.lean
+++ b/TauCeti/RepresentationTheory/Compact/Intertwiner.lean
@@ -81,8 +81,7 @@ variable (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
 omit [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G]
   [BorelSpace G] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W] [CompleteSpace W] in
 /-- An action operator composed with the action of the inverse group element is the identity. -/
-private theorem comp_inv_self (g : G) :
-    (ρ g).comp (ρ g⁻¹) = ContinuousLinearMap.id 𝕜 W := by
+private theorem comp_inv_self (g : G) : (ρ g).comp (ρ g⁻¹) = ContinuousLinearMap.id 𝕜 W := by
   rw [← ContinuousLinearMap.mul_def, ← map_mul, mul_inv_cancel, map_one]
   rfl
 
@@ -202,8 +201,7 @@ private theorem conjAction_averageOperator (T : V →L[𝕜] W) (g : G) :
     conjAction_comp_conjFamily π hπ ρ hρ T g, haarAverage_comp_mulRight]
 
 /-- **The Haar average of an operator intertwines the two representations.** -/
-theorem averageOperator_comp (T : V →L[𝕜] W) (g : G) :
-    (averageOperator π hπ ρ hρ T).comp (π g)
+theorem averageOperator_comp (T : V →L[𝕜] W) (g : G) : (averageOperator π hπ ρ hρ T).comp (π g)
       = (ρ g).comp (averageOperator π hπ ρ hρ T) := by
   have h := conjAction_averageOperator π hπ ρ hρ T g
   rw [conjAction_apply] at h
@@ -242,8 +240,7 @@ theorem averageIntertwiner_apply (T : V →L[𝕜] W) (v : V) :
 
 /-- **Averaging fixes an operator that already intertwines.** The integrand is then constant, and
 normalized Haar measure has total mass one. -/
-theorem averageOperator_eq_self (T : V →L[𝕜] W)
-    (hT : ∀ g : G, T.comp (π g) = (ρ g).comp T) :
+theorem averageOperator_eq_self (T : V →L[𝕜] W) (hT : ∀ g : G, T.comp (π g) = (ρ g).comp T) :
     averageOperator π hπ ρ hρ T = T := by
   have hT_apply (g : G) (v : V) : T (π g v) = ρ g (T v) :=
     congrArg (fun S : V →L[𝕜] W ↦ S v) (hT g)
@@ -404,8 +401,7 @@ Schur's lemma is not invoked here; it is what supplies the hypothesis for a pair
 irreducibles. Only `ρ` is required to be unitary: unitarity of `ρ` is what lets the inverse action
 be moved across the inner product, and nothing in the argument constrains `π`. -/
 theorem schur_orthogonality_distinct (hunitary : IsUnitary ρ)
-    (hdistinct : ∀ f : ContIntertwiningMap π ρ, f.toContinuousLinearMap = 0)
-    (v w : V) (v' w' : W) :
+    (hdistinct : ∀ f : ContIntertwiningMap π ρ, f.toContinuousLinearMap = 0) (v w : V) (v' w' : W) :
     ⟪matrixCoeffLp π hπ v w, matrixCoeffLp ρ hρ v' w'⟫_𝕜 = 0 := by
   have hzero : averageOperator π hπ ρ hρ (InnerProductSpace.rankOne 𝕜 w' w) = 0 := by
     simpa using hdistinct (averageIntertwiner π hπ ρ hρ (InnerProductSpace.rankOne 𝕜 w' w))

--- a/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
+++ b/TauCeti/RepresentationTheory/Continuous/MatrixCoefficient.lean
@@ -76,14 +76,12 @@ noncomputable def matrixCoeff (π : ContRepresentation 𝕜 G V) (hπ : Continuo
 
 /-- Evaluation of a matrix coefficient. -/
 @[simp]
-theorem matrixCoeff_apply (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
-    (v w : V) (g : G) :
+theorem matrixCoeff_apply (π : ContRepresentation 𝕜 G V) (hπ : Continuous π) (v w : V) (g : G) :
     matrixCoeff π hπ v w g = ⟪π g v, w⟫_𝕜 :=
   (rfl)
 
 /-- A matrix coefficient at the identity is the inner product of its defining vectors. -/
-theorem matrixCoeff_apply_one (π : ContRepresentation 𝕜 G V) (hπ : Continuous π)
-    (v w : V) :
+theorem matrixCoeff_apply_one (π : ContRepresentation 𝕜 G V) (hπ : Continuous π) (v w : V) :
     matrixCoeff π hπ v w 1 = ⟪v, w⟫_𝕜 := by
   simp
 
@@ -190,8 +188,7 @@ representation at the underlying vectors, so passing to a subrepresentation crea
 matrix coefficients; `continuous_subrepresentation hπ` is the continuity witness of the restricted
 action. -/
 @[simp]
-theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v ∈ W, π g v ∈ W)
-    (v w : W) :
+theorem matrixCoeff_subrepresentation {W : Submodule 𝕜 V} (hW : ∀ g, ∀ v ∈ W, π g v ∈ W) (v w : W) :
     matrixCoeff (subrepresentation π W hW) (continuous_subrepresentation hπ) v w =
       matrixCoeff π hπ (v : V) (w : V) := by
   ext g
@@ -257,8 +254,7 @@ with its vectors swapped, precomposed with inversion. So the span of the matrix 
 unitary representation is stable under the star operation of `C(G, 𝕜)` followed by inversion of the
 argument. -/
 @[simp]
-theorem star_matrixCoeff [ContinuousInv G] (hπ : Continuous π) (hunitary : IsUnitary π)
-    (v w : V) :
+theorem star_matrixCoeff [ContinuousInv G] (hπ : Continuous π) (hunitary : IsUnitary π) (v w : V) :
     star (matrixCoeff π hπ v w) =
       (matrixCoeff π hπ w v).comp ⟨Inv.inv, continuous_inv⟩ :=
   ContinuousMap.ext fun g ↦ (matrixCoeff_apply_inv hπ hunitary w v g).symm

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -41,8 +41,7 @@ variable (π : ContRepresentation 𝕜 G V)
 
 /-- Every continuous self-intertwiner of an irreducible finite-dimensional representation over an
 algebraically closed normed field is a scalar multiple of the identity. -/
-theorem exists_eq_smul_one_of_irreducible
-    (hirr : Representation.IsIrreducible π.toRepresentation)
+theorem exists_eq_smul_one_of_irreducible (hirr : Representation.IsIrreducible π.toRepresentation)
     (f : ContIntertwiningMap π π) :
     ∃ c : 𝕜, f = c • 1 := by
   letI : Representation.IsIrreducible π.toRepresentation := hirr

--- a/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Subrepresentation.lean
@@ -57,8 +57,7 @@ theorem coe_subrepresentation_apply (g : G) (v : W) :
 /-- The underlying representation of a restricted continuous representation is the restriction of
 the underlying representation. -/
 @[simp]
-theorem toRepresentation_subrepresentation :
-    (subrepresentation π W hW).toRepresentation
+theorem toRepresentation_subrepresentation : (subrepresentation π W hW).toRepresentation
       = π.toRepresentation.subrepresentation W fun g _ hv => hW g _ hv := by
   rfl
 

--- a/TauCeti/RepresentationTheory/ExteriorPower.lean
+++ b/TauCeti/RepresentationTheory/ExteriorPower.lean
@@ -86,8 +86,7 @@ theorem exteriorPowerZeroEquiv_toLinearEquiv (ρ : Representation R G M) :
   (rfl)
 
 /-- The first exterior power is equivalent to the original representation. -/
-noncomputable def exteriorPowerOneEquiv (ρ : Representation R G M) :
-    (ρ.exteriorPower 1).Equiv ρ :=
+noncomputable def exteriorPowerOneEquiv (ρ : Representation R G M) : (ρ.exteriorPower 1).Equiv ρ :=
   .mk (_root_.exteriorPower.oneEquiv R M) fun g =>
     _root_.exteriorPower.oneEquiv_naturality (ρ g)
 

--- a/TauCeti/RepresentationTheory/Induction/Character.lean
+++ b/TauCeti/RepresentationTheory/Induction/Character.lean
@@ -100,8 +100,7 @@ private theorem inducedCharacterTerm_eq_of_mk_eq {V : Type u} [AddCommGroup V] [
 open scoped Classical in
 /-- The trace of the induced action, computed on the right-coset model. -/
 private theorem trace_ind_eq_sum_rightCosets [S.FiniteIndex] [Fintype (RightCosets S)]
-    (A : Rep.{u} k S)
-    [FiniteDimensional k A] (g : G) :
+    (A : Rep.{u} k S) [FiniteDimensional k A] (g : G) :
     LinearMap.trace k (Rep.ind S.subtype A) ((Rep.ind S.subtype A).ρ g) =
       ∑ q : RightCosets S,
         if Quotient.mk'' (q.out * g) = q then

--- a/TauCeti/RepresentationTheory/Induction/Conjugate.lean
+++ b/TauCeti/RepresentationTheory/Induction/Conjugate.lean
@@ -99,14 +99,12 @@ theorem mem_conj_smul (s : G) (H : Subgroup G) (x : G) :
   simp
 
 /-- The canonical multiplicative equivalence `sHs⁻¹ ≃* H`, given by `x ↦ s⁻¹xs`. -/
-def conjSubgroupEquiv (s : G) (H : Subgroup G) :
-    (MulAut.conj s • H : Subgroup G) ≃* H :=
+def conjSubgroupEquiv (s : G) (H : Subgroup G) : (MulAut.conj s • H : Subgroup G) ≃* H :=
   (Subgroup.equivSMul (MulAut.conj s) H).symm
 
 @[simp]
 theorem coe_conjSubgroupEquiv_apply (s : G) (H : Subgroup G)
-    (x : (MulAut.conj s • H : Subgroup G)) :
-    (conjSubgroupEquiv s H x : G) = s⁻¹ * (x : G) * s := by
+    (x : (MulAut.conj s • H : Subgroup G)) : (conjSubgroupEquiv s H x : G) = s⁻¹ * (x : G) * s := by
   simp [conjSubgroupEquiv]
   -- `Subgroup.equivSMul (MulAut.conj s) H` acts by `x ↦ s * x * s⁻¹`, so its inverse returns
   -- `s⁻¹ * x * s` as the underlying element by definition.
@@ -130,8 +128,7 @@ def conjRep [Semiring k] (s : G) {H : Subgroup G} (A : Rep k H) :
 
 /-- Conjugation preserves the underlying module of a representation. -/
 @[simp]
-theorem conjRep_V [Semiring k] (s : G) {H : Subgroup G} (A : Rep k H) :
-    (conjRep s A).V = A.V := by
+theorem conjRep_V [Semiring k] (s : G) {H : Subgroup G} (A : Rep k H) : (conjRep s A).V = A.V := by
   -- Unfold the local wrappers to expose Mathlib's restriction carrier.
   change (Rep.res (conjSubgroupEquiv s H).toMonoidHom A).V = A.V
   exact Rep.res_obj_V _ _
@@ -224,8 +221,7 @@ theorem conj_inv_smul_smul (s : G) (H : Subgroup G) :
 
 /-- The transported form of `conjSubgroupEquiv 1`: conjugating by `1` is the identification of
 `1 · H · 1⁻¹` with `H`. -/
-private theorem conjSubgroupEquiv_one (H : Subgroup G) :
-    (conjSubgroupEquiv (1 : G) H).toMonoidHom =
+private theorem conjSubgroupEquiv_one (H : Subgroup G) : (conjSubgroupEquiv (1 : G) H).toMonoidHom =
       (MulEquiv.subgroupCongr (conj_one_smul H)).toMonoidHom :=
   MonoidHom.ext fun x => Subtype.ext (by simp)
 
@@ -243,8 +239,7 @@ composed with the one underlying `{}^s`, after identifying `(st)H(st)⁻¹` with
 This is the sole computation behind the coherence statements below: `(st)⁻¹ x (st) = t⁻¹(s⁻¹ x s)t`.
 -/
 private theorem conjSubgroupEquiv_mul (s t : G) (H : Subgroup G) :
-    (conjSubgroupEquiv (s * t) H).toMonoidHom =
-      ((conjSubgroupEquiv t H).toMonoidHom.comp
+    (conjSubgroupEquiv (s * t) H).toMonoidHom = ((conjSubgroupEquiv t H).toMonoidHom.comp
           (conjSubgroupEquiv s (MulAut.conj t • H)).toMonoidHom).comp
         (MulEquiv.subgroupCongr (conj_mul_smul s t H)).toMonoidHom :=
   MonoidHom.ext fun x => Subtype.ext (by
@@ -314,8 +309,7 @@ theorem conjRepEquiv_functor (s : G) (H : Subgroup G) :
   rw [resFunctorEquiv_functor]
 
 @[simp]
-theorem conjRepEquiv_inverse (s : G) (H : Subgroup G) :
-    (conjRepEquiv (k := k) s H).inverse =
+theorem conjRepEquiv_inverse (s : G) (H : Subgroup G) : (conjRepEquiv (k := k) s H).inverse =
       Rep.resFunctor (conjSubgroupEquiv s H).symm.toMonoidHom := by
   -- Unfold the `conjRepEquiv` wrapper to expose `resFunctorEquiv`.
   change (resFunctorEquiv (conjSubgroupEquiv s H)).inverse = _
@@ -360,8 +354,7 @@ theorem res_obj_eq_conjFDRep (s : G) (H : Subgroup G) (A : FDRep k H) :
 
 /-- Conjugation preserves the underlying module of a finite-dimensional representation. -/
 @[simp]
-theorem conjFDRep_V (s : G) {H : Subgroup G} (A : FDRep k H) :
-    (conjFDRep s A).V = A.V := by
+theorem conjFDRep_V (s : G) {H : Subgroup G} (A : FDRep k H) : (conjFDRep s A).V = A.V := by
   -- Unfold the local wrappers to expose Mathlib's restriction carrier.
   change ((Action.res (FGModuleCat k) (conjSubgroupEquiv s H).toMonoidHom).obj A).V = A.V
   exact Action.res_obj_V _ _ _
@@ -423,8 +416,7 @@ theorem conjFDRepEquiv_functor (s : G) (H : Subgroup G) :
   rfl
 
 @[simp]
-theorem conjFDRepEquiv_inverse (s : G) (H : Subgroup G) :
-    (conjFDRepEquiv (k := k) s H).inverse =
+theorem conjFDRepEquiv_inverse (s : G) (H : Subgroup G) : (conjFDRepEquiv (k := k) s H).inverse =
       Action.res (FGModuleCat k) (conjSubgroupEquiv s H).symm.toMonoidHom := by
   -- Unfold the `conjFDRepEquiv` wrapper to expose Mathlib's `Action.resEquiv`.
   change (Action.resEquiv (FGModuleCat k) (conjSubgroupEquiv s H)).inverse = _
@@ -518,8 +510,7 @@ theorem char_conjFDRep (s : G) {H : Subgroup G} (A : FDRep k H)
 
 /-- The conjugate-character formula `({}^s χ)(x) = χ(s⁻¹xs)`. -/
 theorem char_conjFDRep_mk (s : G) {H : Subgroup G} (A : FDRep k H)
-    (x : (MulAut.conj s • H : Subgroup G)) :
-    (conjFDRep s A).character x =
+    (x : (MulAut.conj s • H : Subgroup G)) : (conjFDRep s A).character x =
       A.character ⟨s⁻¹ * (x : G) * s, (mem_conj_smul s H x).mp x.2⟩ := by
   rw [char_conjFDRep]
   congr 1
@@ -740,8 +731,7 @@ theorem res_conjFDRepFunctor (g : G) :
   rfl
 
 /-- On a normal subgroup, `conjNormalFDRep` is `conjFDRep` read through `gNg⁻¹ = N`. -/
-theorem res_conjFDRep (g : G) (A : FDRep k N) :
-    (Action.res (FGModuleCat k)
+theorem res_conjFDRep (g : G) (A : FDRep k N) : (Action.res (FGModuleCat k)
         (MulEquiv.subgroupCongr (Subgroup.Normal.conj_smul_eq_self g N).symm).toMonoidHom).obj
       (conjFDRep g A) = conjNormalFDRep g A :=
   Functor.congr_obj (res_conjFDRepFunctor g) A

--- a/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
+++ b/TauCeti/RepresentationTheory/Induction/FiniteDimensional.lean
@@ -74,8 +74,7 @@ theorem rightCosetFactor_mul (s : S) (g : G) :
 
 /-- The right-coset factor carries the chosen representative back to the original element. -/
 @[simp]
-theorem rightCosetFactor_mul_out (g : G) :
-    (rightCosetFactor (S := S) g : G) *
+theorem rightCosetFactor_mul_out (g : G) : (rightCosetFactor (S := S) g : G) *
         Quotient.out (Quotient.mk'' g :
           Quotient (QuotientGroup.rightRel S)) = g := by
   simp [rightCosetFactor]
@@ -135,8 +134,7 @@ theorem coindSubtypeEquivPi_apply (A : Rep.{max u v w} k S)
 /-- The inverse coset model extends a value from each representative by `S`-equivariance. -/
 @[simp]
 theorem coindSubtypeEquivPi_symm_apply (A : Rep.{max u v w} k S)
-    (x : Quotient (QuotientGroup.rightRel S) → A) (g : G) :
-    ((coindSubtypeEquivPi A).symm x).1 g =
+    (x : Quotient (QuotientGroup.rightRel S) → A) (g : G) : ((coindSubtypeEquivPi A).symm x).1 g =
       A.ρ (rightCosetFactor (S := S) g) (x (Quotient.mk'' g)) := by
   rw [coindSubtypeEquivPi]
   rfl
@@ -198,8 +196,7 @@ along `Rep.indCoindIso`.
 Not a `simp` lemma, for the same reason as `indSubtypeEquivPi_apply`: it rewrites the coset
 model into the comparison isomorphism. -/
 theorem indSubtypeEquivPi_symm_apply [S.FiniteIndex] (A : Rep.{max u v w} k S)
-    (x : Quotient (QuotientGroup.rightRel S) → A) :
-    (indSubtypeEquivPi A).symm x =
+    (x : Quotient (QuotientGroup.rightRel S) → A) : (indSubtypeEquivPi A).symm x =
       (letI : DecidableRel (QuotientGroup.rightRel S) := Classical.decRel _
        Rep.indCoindIso.{max u v w, u, v} A).inv.hom
         ((coindSubtypeEquivPi A).symm x) := by
@@ -290,8 +287,7 @@ conjugated by `indFDRepForgetIso`. This is the only fact about `indFDRepMap` use
 @[simp]
 theorem forget₂_map_indFDRepMap {k G : Type u} [Field k] [Group G] {S : Subgroup G}
     [S.FiniteIndex] {A B : FDRep k S} (f : A ⟶ B) :
-    (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) =
-      (indFDRepForgetIso A).hom ≫
+    (forget₂ (FDRep k G) (Rep k G)).map (indFDRepMap f) = (indFDRepForgetIso A).hom ≫
         (Rep.indFunctor k S.subtype).map ((forget₂ (FDRep k S) (Rep k S)).map f) ≫
           (indFDRepForgetIso B).inv := by
   rw [indFDRepMap]

--- a/TauCeti/RepresentationTheory/Induction/Permutation.lean
+++ b/TauCeti/RepresentationTheory/Induction/Permutation.lean
@@ -142,8 +142,7 @@ private theorem quotientToIndTrivial_single (q : G ⧸ H) (r : k) :
 
 /-- **The permutation representation.** Inducing the trivial representation of a subgroup `H ≤ G`
 along `H.subtype` gives the permutation representation of `G` on the left cosets `G ⧸ H`. -/
-noncomputable def indTrivialEquiv :
-    ((Representation.trivial k H k).ind H.subtype).Equiv
+noncomputable def indTrivialEquiv : ((Representation.trivial k H k).ind H.subtype).Equiv
       (Representation.ofMulAction k G (G ⧸ H)) := by
   refine Representation.Equiv.mk
     (LinearEquiv.ofLinear (indTrivialToQuotient k H) (quotientToIndTrivial k H) ?_ ?_) ?_

--- a/TauCeti/RepresentationTheory/Induction/Transitivity.lean
+++ b/TauCeti/RepresentationTheory/Induction/Transitivity.lean
@@ -110,13 +110,11 @@ noncomputable def coindFunctorCompIso (φ : G →* H) (ψ : H →* K) :
 /-- The coinduction-in-stages isomorphism is characterized by the inverse
 restriction-composition isomorphism under the inverse adjunction equivalence. -/
 @[simp]
-lemma conjugateEquiv_symm_coindFunctorCompIso_hom (φ : G →* H) (ψ : H →* K) :
-    ((conjugateEquiv
+lemma conjugateEquiv_symm_coindFunctorCompIso_hom (φ : G →* H) (ψ : H →* K) : ((conjugateEquiv
       ((_root_.Rep.resCoindAdjunction.{max u v w x} k ψ).comp
         (_root_.Rep.resCoindAdjunction.{max u v w x} k φ))
       (_root_.Rep.resCoindAdjunction.{max u v w x} k (ψ.comp φ))).symm
-      (coindFunctorCompIso φ ψ).hom) =
-    (resFunctorCompIso φ ψ).inv := by
+      (coindFunctorCompIso φ ψ).hom) = (resFunctorCompIso φ ψ).inv := by
   unfold coindFunctorCompIso
   exact Equiv.symm_apply_apply _ _
 

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/Basic.lean
@@ -95,8 +95,7 @@ theorem iff_not_exists_ne_nil :
 
 /-- The composition of paths in opposite directions is trivial in an acyclic quiver. -/
 @[simp]
-theorem comp_eq_nil (h : Quiver.IsAcyclic V) {a b : V}
-    (p : Path a b) (q : Path b a) :
+theorem comp_eq_nil (h : Quiver.IsAcyclic V) {a b : V} (p : Path a b) (q : Path b a) :
     p.comp q = Path.nil :=
   h.eq_nil (p.comp q)
 
@@ -113,8 +112,7 @@ theorem length_eq_zero_of_paths_right (h : Quiver.IsAcyclic V) {a b : V}
   h.length_eq_zero_of_paths_left q p
 
 /-- Vertices joined by paths in both directions in an acyclic quiver are equal. -/
-theorem eq_of_paths (h : Quiver.IsAcyclic V) {a b : V}
-    (p : Path a b) (q : Path b a) :
+theorem eq_of_paths (h : Quiver.IsAcyclic V) {a b : V} (p : Path a b) (q : Path b a) :
     a = b :=
   p.eq_of_length_zero (h.length_eq_zero_of_paths_left p q)
 
@@ -133,15 +131,13 @@ theorem vertices_nodup (h : Quiver.IsAcyclic V) {a b : V} (p : Path a b) :
     omega
 
 /-- Between distinct vertices of an acyclic quiver, paths cannot exist in both directions. -/
-theorem not_nonempty_path_and_nonempty_path (h : Quiver.IsAcyclic V) {a b : V}
-    (hab : a ≠ b) :
+theorem not_nonempty_path_and_nonempty_path (h : Quiver.IsAcyclic V) {a b : V} (hab : a ≠ b) :
     ¬(Nonempty (Path a b) ∧ Nonempty (Path b a)) := by
   rintro ⟨⟨p⟩, ⟨q⟩⟩
   exact hab (h.eq_of_paths p q)
 
 /-- A path between distinct vertices of an acyclic quiver excludes every reverse path. -/
-theorem isEmpty_path_of_path (h : Quiver.IsAcyclic V) {a b : V}
-    (hab : a ≠ b) (p : Path a b) :
+theorem isEmpty_path_of_path (h : Quiver.IsAcyclic V) {a b : V} (hab : a ≠ b) (p : Path a b) :
     IsEmpty (Path b a) :=
   ⟨fun q ↦ hab (h.eq_of_paths p q)⟩
 
@@ -151,8 +147,7 @@ theorem isEmpty_hom_self (h : Quiver.IsAcyclic V) (a : V) :
   ⟨fun e ↦ Path.cons_ne_nil Path.nil e (h e.toPath)⟩
 
 /-- In an acyclic quiver, an arrow excludes every reverse arrow. -/
-theorem isEmpty_hom_of_hom (h : Quiver.IsAcyclic V) {a b : V}
-    (e : a ⟶ b) : IsEmpty (b ⟶ a) :=
+theorem isEmpty_hom_of_hom (h : Quiver.IsAcyclic V) {a b : V} (e : a ⟶ b) : IsEmpty (b ⟶ a) :=
   ⟨fun f ↦ by simpa using h.length_eq_zero_of_paths_left e.toPath f.toPath⟩
 
 /-- Closed paths in an acyclic quiver form a subsingleton. -/
@@ -176,8 +171,7 @@ theorem of_isEmpty_hom [∀ a b : V, IsEmpty (a ⟶ b)] :
 
 /-- A quiver mapping to an acyclic quiver is acyclic if the induced map on each closed-path
 type is injective. -/
-theorem of_mapPath_self_injective {W : Type*} [Quiver W] (F : V ⥤q W)
-    (hW : Quiver.IsAcyclic W)
+theorem of_mapPath_self_injective {W : Type*} [Quiver W] (F : V ⥤q W) (hW : Quiver.IsAcyclic W)
     (hinj : ∀ ⦃a : V⦄, Function.Injective (F.mapPath : Path a a → Path (F.obj a) (F.obj a))) :
     Quiver.IsAcyclic V := by
   intro a p
@@ -187,8 +181,7 @@ theorem of_mapPath_self_injective {W : Type*} [Quiver W] (F : V ⥤q W)
 
 /-- A quiver is acyclic if its induced maps on all path types are injective and its target is
 acyclic. -/
-theorem of_mapPath_injective {W : Type*} [Quiver W] (F : V ⥤q W)
-    (hW : Quiver.IsAcyclic W)
+theorem of_mapPath_injective {W : Type*} [Quiver W] (F : V ⥤q W) (hW : Quiver.IsAcyclic W)
     (hinj : ∀ ⦃a b : V⦄, Function.Injective (F.mapPath : Path a b → Path (F.obj a) (F.obj b))) :
     Quiver.IsAcyclic V :=
   of_mapPath_self_injective F hW fun {_} ↦ @hinj _ _

--- a/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Acyclic/FinitePaths.lean
@@ -71,8 +71,7 @@ private theorem finite_boundedPaths [Finite V] [∀ a b : V, Finite (a ⟶ b)] (
 namespace Quiver.IsAcyclic
 
 /-- Every path in an acyclic finite quiver has length strictly below the number of vertices. -/
-theorem length_lt_card (h : Quiver.IsAcyclic V) [Fintype V] {a b : V}
-    (p : _root_.Quiver.Path a b) :
+theorem length_lt_card (h : Quiver.IsAcyclic V) [Fintype V] {a b : V} (p : _root_.Quiver.Path a b) :
     p.length < Fintype.card V := by
   -- The bound is unfolded by hand rather than by `simpa`: `Quiver.IsAcyclic.card_path_self` puts
   -- `Nat.card` in scope for this file, and simp then exceeds `maxRecDepth` on this goal.

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/EulerForm.lean
@@ -104,8 +104,7 @@ theorem titsForm_nonneg (h : Fintype.card A ≤ 2) (d : Kronecker A → ℤ) :
 /-- The Tits form of the generalized Kronecker quiver is positive semidefinite exactly when there
 are at most two arrows. Two arrows is the Kronecker quiver `• ⇉ •`, of affine type `Ã₁`, the
 boundary case of Gabriel's theorem; three or more arrows makes the form indefinite. -/
-theorem titsForm_nonneg_iff :
-    (∀ d, 0 ≤ titsForm (Kronecker A) d) ↔ Fintype.card A ≤ 2 := by
+theorem titsForm_nonneg_iff : (∀ d, 0 ≤ titsForm (Kronecker A) d) ↔ Fintype.card A ≤ 2 := by
   refine ⟨fun h => ?_, fun h => titsForm_nonneg h⟩
   have h1 := h 1
   rw [titsForm_one] at h1
@@ -135,8 +134,7 @@ theorem titsForm_posDef (h : Fintype.card A ≤ 1) : (titsForm (Kronecker A)).Po
 /-- The Tits form of the generalized Kronecker quiver is positive definite exactly when there is at
 most one arrow: no arrow gives the disconnected Dynkin quiver `A₁ ⊔ A₁`, and one arrow gives `A₂`.
 Every other generalized Kronecker quiver falls outside the Dynkin classification. -/
-theorem titsForm_posDef_iff :
-    (titsForm (Kronecker A)).PosDef ↔ Fintype.card A ≤ 1 := by
+theorem titsForm_posDef_iff : (titsForm (Kronecker A)).PosDef ↔ Fintype.card A ≤ 1 := by
   refine ⟨fun h => ?_, titsForm_posDef⟩
   have h1 : (0 : ℤ) < titsForm (Kronecker A) 1 :=
     h 1 fun hc => one_ne_zero (congrFun hc src)

--- a/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Kronecker/UpperTriangular.lean
@@ -177,8 +177,7 @@ private theorem toMatrixAlgHom_ofMatrixLinear {M : Matrix (Fin 2) (Fin 2) k}
   ext i j
   fin_cases i <;> fin_cases j <;> simp [h₁₀]
 
-private theorem range_toMatrixAlgHom :
-    (toMatrixAlgHom (A := A) k).range
+private theorem range_toMatrixAlgHom : (toMatrixAlgHom (A := A) k).range
       = Matrix.blockTriangularSubalgebra k k (id : Fin 2 → Fin 2) := by
   refine le_antisymm ?_ fun M hM => ⟨ofMatrixLinear k M, toMatrixAlgHom_ofMatrixLinear k hM⟩
   rintro _ ⟨f, rfl⟩

--- a/TauCeti/RepresentationTheory/Quiver/PathAlgebra.lean
+++ b/TauCeti/RepresentationTheory/Quiver/PathAlgebra.lean
@@ -137,8 +137,7 @@ private theorem length_toList {a b : OneLoop}
   | nil => rfl
   | cons p e ih => simp [ih]
 
-private theorem path_eq_pathOfLength
-    (p : _root_.Quiver.Path (vertex : OneLoop) vertex) :
+private theorem path_eq_pathOfLength (p : _root_.Quiver.Path (vertex : OneLoop) vertex) :
     p = pathOfLength p.length := by
   apply (_root_.Quiver.Path.toList_injective vertex vertex)
   apply List.length_injective
@@ -774,8 +773,7 @@ private theorem oneLoopLinearEquiv_map_one :
   simp [vertexIdempotent_eq_single, oneLoopLinearEquiv_single,
     Quiver.OneLoop.totalPathEquivNat, ← AddMonoidAlgebra.one_def]
 
-private theorem oneLoopLinearEquiv_map_mul
-    (f g : pathAlgebra k Quiver.OneLoop) :
+private theorem oneLoopLinearEquiv_map_mul (f g : pathAlgebra k Quiver.OneLoop) :
     oneLoopLinearEquiv k (f * g) = oneLoopLinearEquiv k f * oneLoopLinearEquiv k g := by
   induction f using induction_linear with
   | zero => simp
@@ -807,8 +805,7 @@ end OneLoop
 end PathAlgebra
 
 /-- Over a division ring, the path algebra of the one-loop quiver is infinite-dimensional. -/
-theorem not_finiteDimensional_pathAlgebra_oneLoop
-    (k : Type w) [DivisionRing k] :
+theorem not_finiteDimensional_pathAlgebra_oneLoop (k : Type w) [DivisionRing k] :
     ¬ FiniteDimensional k (pathAlgebra k Quiver.OneLoop) := by
   letI : Infinite (Quiver.TotalPath Quiver.OneLoop) :=
     Quiver.OneLoop.totalPathEquivNat.infinite_iff.mpr inferInstance

--- a/TauCeti/RepresentationTheory/Quiver/Reflection/EulerForm.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Reflection/EulerForm.lean
@@ -66,12 +66,10 @@ the arrow-count matrix of the quiver, whose `i`-th row vanishes because `i` is a
 that of the quiver reflected at `i`; `d'` and `e'` are the reflections of `d` and `e`. -/
 private theorem sub_sum_sum_eq_of_reflect_data {W : Type*} [Fintype W] (i : W)
     (N N' : W → W → ℤ) (d e d' e' : W → ℤ)
-    (hN : ∀ b : W, N i b = 0) (hN'row : ∀ b : W, N' i b = N b i)
-    (hN'col : ∀ a : W, N' a i = 0)
+    (hN : ∀ b : W, N i b = 0) (hN'row : ∀ b : W, N' i b = N b i) (hN'col : ∀ a : W, N' a i = 0)
     (hN' : ∀ a b : W, a ≠ i → b ≠ i → N' a b = N a b)
     (hd : ∀ w : W, w ≠ i → d' w = d w) (he : ∀ w : W, w ≠ i → e' w = e w)
-    (hdi : d' i = (∑ w : W, N w i * d w) - d i)
-    (hei : e' i = (∑ w : W, N w i * e w) - e i) :
+    (hdi : d' i = (∑ w : W, N w i * d w) - d i) (hei : e' i = (∑ w : W, N w i * e w) - e i) :
     (∑ w : W, d' w * e' w) - ∑ a : W, ∑ b : W, N' a b * (d' a * e' b)
       = (∑ w : W, d w * e w) - ∑ a : W, ∑ b : W, N a b * (d a * e b) := by
   classical
@@ -128,12 +126,10 @@ private theorem sum_sum_transpose {W : Type*} [Fintype W] (N : W → W → ℤ) 
 two arrow-count matrices and exchanging the arguments of the Euler form. -/
 private theorem sub_sum_sum_eq_of_reflect_data_of_source {W : Type*} [Fintype W] (i : W)
     (N N' : W → W → ℤ) (d e d' e' : W → ℤ)
-    (hN : ∀ a : W, N a i = 0) (hN'col : ∀ a : W, N' a i = N i a)
-    (hN'row : ∀ b : W, N' i b = 0)
+    (hN : ∀ a : W, N a i = 0) (hN'col : ∀ a : W, N' a i = N i a) (hN'row : ∀ b : W, N' i b = 0)
     (hN' : ∀ a b : W, a ≠ i → b ≠ i → N' a b = N a b)
     (hd : ∀ w : W, w ≠ i → d' w = d w) (he : ∀ w : W, w ≠ i → e' w = e w)
-    (hdi : d' i = (∑ w : W, N i w * d w) - d i)
-    (hei : e' i = (∑ w : W, N i w * e w) - e i) :
+    (hdi : d' i = (∑ w : W, N i w * d w) - d i) (hei : e' i = (∑ w : W, N i w * e w) - e i) :
     (∑ w : W, d' w * e' w) - ∑ a : W, ∑ b : W, N' a b * (d' a * e' b)
       = (∑ w : W, d w * e w) - ∑ a : W, ∑ b : W, N a b * (d a * e b) := by
   have key := sub_sum_sum_eq_of_reflect_data i (fun a b ↦ N b a) (fun a b ↦ N' b a)

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Injective.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Injective.lean
@@ -179,8 +179,7 @@ theorem dimVector_indecInjRep_eq_dimVector_indecProjRep (i j : Q) :
 
 /-- The morphism `M ⟶ Iᵢ` determined by a linear functional `φ` on `M` at the vertex `i`: at the
 vertex `j` it sends `x` to the function reading off `φ` of the action of a path `j → i` on `x`. -/
-def indecInjRepHom (i : Q) (M : QuiverRep k Q)
-    (φ : Module.Dual k (M.obj ((Paths.of Q).obj i))) :
+def indecInjRepHom (i : Q) (M : QuiverRep k Q) (φ : Module.Dual k (M.obj ((Paths.of Q).obj i))) :
     M ⟶ indecInjRep k Q i where
   app j := ModuleCat.ofHom (LinearMap.pi fun q : Quiver.Path (V := Q) j i ↦ φ ∘ₗ (M.map q).hom)
   naturality {a b} p := by

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Basic.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Projective/Basic.lean
@@ -188,8 +188,7 @@ theorem dimVector_indecProjRep (i j : Q) :
 
 /-- The morphism `Pᵢ ⟶ M` determined by an element `x` of `M` at the vertex `i`: it sends the basis
 element of a path `p : i → j` to the image of `x` under the action of `p`. -/
-noncomputable def indecProjRepHom (i : Q) (M : QuiverRep k Q)
-    (x : M.obj ((Paths.of Q).obj i)) :
+noncomputable def indecProjRepHom (i : Q) (M : QuiverRep k Q) (x : M.obj ((Paths.of Q).obj i)) :
     indecProjRep k Q i ⟶ M where
   app j := ModuleCat.ofHom (Finsupp.linearCombination k fun p : Quiver.Path i j ↦ M.map p x)
   naturality {a b} p := by
@@ -205,8 +204,7 @@ noncomputable def indecProjRepHom (i : Q) (M : QuiverRep k Q)
 on `x`. -/
 @[simp]
 theorem indecProjRepHom_app_basis (i : Q) (M : QuiverRep k Q)
-    (x : M.obj ((Paths.of Q).obj i)) (j : Q)
-    (p : Quiver.Path i j) :
+    (x : M.obj ((Paths.of Q).obj i)) (j : Q) (p : Quiver.Path i j) :
     (indecProjRepHom i M x).app ((Paths.of Q).obj j) (indecProjRepBasis k i j p) = M.map p x := by
   have h : (indecProjRepHom i M x).app ((Paths.of Q).obj j)
       (indecProjRepBasis k i j p) = (1 : k) • M.map p x :=
@@ -218,8 +216,7 @@ theorem indecProjRepHom_app_basis (i : Q) (M : QuiverRep k Q)
 -- is therefore a simp-normal-form violation (`simpNF`). It remains named because it is one half of
 -- the universal property below.
 /-- The morphism attached to `x : Mᵢ` sends the basis vector of the trivial path back to `x`. -/
-theorem indecProjRepHom_app_nil (i : Q) (M : QuiverRep k Q)
-    (x : M.obj ((Paths.of Q).obj i)) :
+theorem indecProjRepHom_app_nil (i : Q) (M : QuiverRep k Q) (x : M.obj ((Paths.of Q).obj i)) :
     (indecProjRepHom i M x).app ((Paths.of Q).obj i)
       (indecProjRepBasis k i i Quiver.Path.nil) = x := by
   simp
@@ -270,8 +267,7 @@ theorem indecProjRepHomEquiv_apply (i : Q) (M : QuiverRep k Q) (f : indecProjRep
 
 @[simp]
 theorem indecProjRepHomEquiv_symm_apply (i : Q) (M : QuiverRep k Q)
-    (x : M.obj ((Paths.of Q).obj i)) :
-    (indecProjRepHomEquiv i M).symm x = indecProjRepHom i M x :=
+    (x : M.obj ((Paths.of Q).obj i)) : (indecProjRepHomEquiv i M).symm x = indecProjRepHom i M x :=
   (rfl)
 
 -- Not `@[simp]`: `simp` already proves this from `indecProjRepHomEquiv_apply` and

--- a/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
+++ b/TauCeti/RepresentationTheory/Quiver/Representation/Simple.lean
@@ -109,8 +109,7 @@ instance finiteDimensional_simpleRep_obj (i a : Q) :
 variable (k)
 
 /-- The vector space that the vertex simple `Sᵢ` puts at `i` is the base field. -/
-noncomputable def simpleRepSelfEquiv (i : Q) :
-    (simpleRep k Q i).obj ((Paths.of Q).obj i) ≃ₗ[k] k :=
+noncomputable def simpleRepSelfEquiv (i : Q) : (simpleRep k Q i).obj ((Paths.of Q).obj i) ≃ₗ[k] k :=
   (eqToIso (simpleRep_obj_self i)).toLinearEquiv
 
 /-- The canonical generator of the line `(Sᵢ)ᵢ`: the element corresponding to `1 : k`. -/
@@ -125,8 +124,7 @@ theorem simpleRepSelfEquiv_apply_generator (i : Q) :
 
 /-- **The vertex simple is a line at its vertex**: every element of `(Sᵢ)ᵢ` is a multiple of the
 generator. -/
-theorem exists_eq_smul_simpleRepGenerator {i : Q}
-    (x : (simpleRep k Q i).obj ((Paths.of Q).obj i)) :
+theorem exists_eq_smul_simpleRepGenerator {i : Q} (x : (simpleRep k Q i).obj ((Paths.of Q).obj i)) :
     ∃ c : k, x = c • simpleRepGenerator k i := by
   refine ⟨simpleRepSelfEquiv k i x, ?_⟩
   rw [simpleRepGenerator, ← LinearEquiv.map_smul, smul_eq_mul, mul_one,
@@ -143,8 +141,7 @@ variable {k}
 
 /-- Every arrow of the quiver acts by zero on the vertex simple `Sᵢ`. -/
 @[simp]
-theorem simpleRep_map_toPath (i : Q) {a b : Q} (e : a ⟶ b) :
-    (simpleRep k Q i).map e.toPath = 0 :=
+theorem simpleRep_map_toPath (i : Q) {a b : Q} (e : a ⟶ b) : (simpleRep k Q i).map e.toPath = 0 :=
   Paths.lift_toPath _ e
 
 /-- More generally, every path of positive length acts by zero on the vertex simple `Sᵢ`. -/

--- a/TauCeti/RepresentationTheory/Rep/OfMulAction.lean
+++ b/TauCeti/RepresentationTheory/Rep/OfMulAction.lean
@@ -48,8 +48,7 @@ variable (k : Type u) [Semiring k] {X : Type w} {Y : Type w'} [MulAction G X] [M
 
 /-- A `G`-equivariant equivalence of `G`-sets induces an equivalence of the permutation
 representations on their free modules. -/
-noncomputable def ofMulActionEquivCongr (e : X ≃ Y)
-    (he : ∀ (g : G) (x : X), e (g • x) = g • e x) :
+noncomputable def ofMulActionEquivCongr (e : X ≃ Y) (he : ∀ (g : G) (x : X), e (g • x) = g • e x) :
     (Representation.ofMulAction k G X).Equiv (Representation.ofMulAction k G Y) :=
   .mk (MonoidAlgebra.mapDomainLinearEquiv k k e) fun _ => by ext; simp [he]
 
@@ -76,8 +75,7 @@ variable (k : Type u) [Ring k] {X Y : Type w} [MulAction G X] [MulAction G Y]
 
 /-- A `G`-equivariant equivalence of `G`-sets induces an isomorphism of the permutation
 representations they carry. -/
-noncomputable def ofMulActionIsoCongr (e : X ≃ Y)
-    (he : ∀ (g : G) (x : X), e (g • x) = g • e x) :
+noncomputable def ofMulActionIsoCongr (e : X ≃ Y) (he : ∀ (g : G) (x : X), e (g • x) = g • e x) :
     Rep.ofMulAction k G X ≅ Rep.ofMulAction k G Y :=
   Rep.mkIso (ofMulActionEquivCongr k e he)
 
@@ -152,8 +150,7 @@ theorem quotientBotIsoLeftRegular_hom_hom_single (q : G ⧸ (⊥ : Subgroup G)) 
 representative. -/
 @[simp]
 theorem quotientBotIsoLeftRegular_hom_hom_single_mk (x : G) (r : k) :
-    (quotientBotIsoLeftRegular k).hom.hom
-        (MonoidAlgebra.single (x : G ⧸ (⊥ : Subgroup G)) r) =
+    (quotientBotIsoLeftRegular k).hom.hom (MonoidAlgebra.single (x : G ⧸ (⊥ : Subgroup G)) r) =
       MonoidAlgebra.single x r :=
   quotientBotIsoLeftRegular_hom_hom_single k _ r
 
@@ -188,8 +185,7 @@ theorem quotientTopIsoTrivial_hom_hom_single (q : G ⧸ (⊤ : Subgroup G)) (r :
   simp [quotientTopIsoTrivial, Representation.ofMulActionSubsingletonEquivTrivial]
 
 @[simp]
-theorem quotientTopIsoTrivial_inv_hom_apply (r : k) :
-    (quotientTopIsoTrivial k).inv.hom r =
+theorem quotientTopIsoTrivial_inv_hom_apply (r : k) : (quotientTopIsoTrivial k).inv.hom r =
       MonoidAlgebra.single ((1 : G) : G ⧸ (⊤ : Subgroup G)) r := by
   haveI := QuotientGroup.subsingleton_quotient_top (G := G)
   simp [quotientTopIsoTrivial, Representation.ofMulActionSubsingletonEquivTrivial]

--- a/TauCeti/RepresentationTheory/SymmetricPower.lean
+++ b/TauCeti/RepresentationTheory/SymmetricPower.lean
@@ -63,8 +63,7 @@ theorem symmetricPower_apply (ρ : Representation R G M) (d : ℕ) (g : G) :
 
 This is intentionally not a simp lemma: `symmetricPower_apply` followed by
 `SymmetricPower.map_tprod` already performs this simplification. -/
-theorem symmetricPower_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G)
-    (m : Fin d → M) :
+theorem symmetricPower_apply_tprod (ρ : Representation R G M) (d : ℕ) (g : G) (m : Fin d → M) :
     ρ.symmetricPower d g (⨂ₛ[R] i, m i) = ⨂ₛ[R] i, ρ g (m i) := by
   rw [symmetricPower_apply, SymmetricPower.map_tprod]
 
@@ -103,8 +102,7 @@ theorem symmetricPower_apply_tprod (f : IntertwiningMap ρ σ) (d : ℕ) (m : Fi
 
 /-- Symmetric powers preserve identity intertwining maps. -/
 @[simp]
-theorem symmetricPower_id (d : ℕ) :
-    (IntertwiningMap.id ρ).symmetricPower d =
+theorem symmetricPower_id (d : ℕ) : (IntertwiningMap.id ρ).symmetricPower d =
       IntertwiningMap.id (ρ.symmetricPower d) := by
   apply IntertwiningMap.ext
   simp
@@ -113,8 +111,7 @@ theorem symmetricPower_id (d : ℕ) :
 @[simp]
 theorem symmetricPower_comp {P : Type*} [AddCommMonoid P] [Module R P]
     {τ : Representation R G P} (f : IntertwiningMap ρ σ) (g : IntertwiningMap σ τ) (d : ℕ) :
-    (g.comp f).symmetricPower d =
-      (g.symmetricPower d).comp (f.symmetricPower d) := by
+    (g.comp f).symmetricPower d = (g.symmetricPower d).comp (f.symmetricPower d) := by
   apply IntertwiningMap.ext
   exact SymmetricPower.map_comp f.toLinearMap g.toLinearMap
 
@@ -167,8 +164,7 @@ private theorem symmetricPower_toLinearEquiv (e : ρ.Equiv σ) (d : ℕ) :
 
 /-- The underlying linear map is the usual map induced on symmetric powers. -/
 @[simp]
-theorem symmetricPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) :
-    (e.symmetricPower d).toLinearMap =
+theorem symmetricPower_toLinearMap (e : ρ.Equiv σ) (d : ℕ) : (e.symmetricPower d).toLinearMap =
       SymmetricPower.map (ι := Fin d) e.toLinearMap :=
   (rfl)
 
@@ -201,8 +197,7 @@ theorem symmetricPower_symm (e : ρ.Equiv σ) (d : ℕ) :
 @[simp]
 theorem symmetricPower_trans {P : Type*} [AddCommMonoid P] [Module R P]
     {τ : Representation R G P} (e : ρ.Equiv σ) (f : σ.Equiv τ) (d : ℕ) :
-    (e.trans f).symmetricPower d =
-      (e.symmetricPower d).trans (f.symmetricPower d) := by
+    (e.trans f).symmetricPower d = (e.symmetricPower d).trans (f.symmetricPower d) := by
   have h : ((e.trans f).symmetricPower d).toLinearMap =
       ((e.symmetricPower d).trans (f.symmetricPower d)).toLinearMap := by
     simp

--- a/TauCeti/RepresentationTheory/Tensor/Power.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Power.lean
@@ -54,10 +54,8 @@ private theorem append_const {α : Type*} {d e : ℕ} (x : α) :
   ext i
   refine Fin.addCases ?_ ?_ i <;> simp
 
-private theorem mulEquiv_map {d e : ℕ} (f : Fin d → M →ₗ[R] M)
-    (g : Fin e → M →ₗ[R] M) :
-    (_root_.TensorPower.mulEquiv :
-      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).toLinearMap ∘ₗ
+private theorem mulEquiv_map {d e : ℕ} (f : Fin d → M →ₗ[R] M) (g : Fin e → M →ₗ[R] M) :
+    (_root_.TensorPower.mulEquiv : (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).toLinearMap ∘ₗ
         TensorProduct.map (PiTensorProduct.map f) (PiTensorProduct.map g) =
       PiTensorProduct.map (Fin.append f g) ∘ₗ
         (_root_.TensorPower.mulEquiv :
@@ -76,8 +74,7 @@ private theorem mulEquiv_map {d e : ℕ} (f : Fin d → M →ₗ[R] M)
 /-- Splitting a tensor power intertwines separate families of maps on the two factors with
 their appended family on the combined tensor power. -/
 theorem mulEquiv_conj_map {d e : ℕ} (f : Fin d → M →ₗ[R] M) (g : Fin e → M →ₗ[R] M) :
-    (_root_.TensorPower.mulEquiv :
-      (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).conj
+    (_root_.TensorPower.mulEquiv : (⨂[R]^d M) ⊗[R] (⨂[R]^e M) ≃ₗ[R] (⨂[R]^(d + e) M)).conj
         (TensorProduct.map (PiTensorProduct.map f) (PiTensorProduct.map g)) =
       PiTensorProduct.map (Fin.append f g) := by
   apply LinearMap.ext

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -60,8 +60,7 @@ private theorem toTensorPower_ιMulti_two {R : Type} {M : Type*}
   simp [sub_eq_add_neg]
 
 private theorem mk_comp_toTensorPower {R : Type} {M : Type*}
-    [Field R] [AddCommGroup M] [Module R M] :
-    (SymmetricPower.mk R (Fin 2) M).comp
+    [Field R] [AddCommGroup M] [Module R M] : (SymmetricPower.mk R (Fin 2) M).comp
       (exteriorPower.toTensorPower R M 2) = 0 := by
   classical
   apply exteriorPower.linearMap_ext
@@ -130,8 +129,7 @@ private theorem range_toTensorPower_eq_ker_mk {R : Type} {M : Type*}
 -- Mathlib builds `exteriorPower.pairingDual` by dualizing `exteriorPower.toTensorPower`, but
 -- records that factorization only inside the definitions; this states it.
 private theorem pairingDual_ιMulti_apply {R : Type} {M : Type*}
-    [CommRing R] [AddCommGroup M] [Module R M]
-    (g : Fin 2 → Module.Dual R M) (x : ⋀[R]^2 M) :
+    [CommRing R] [AddCommGroup M] [Module R M] (g : Fin 2 → Module.Dual R M) (x : ⋀[R]^2 M) :
     exteriorPower.pairingDual R M 2 (exteriorPower.ιMulti R 2 g) x =
       TensorPower.multilinearMapToDual R M 2 g (exteriorPower.toTensorPower R M 2 x) := by
   simp [exteriorPower.pairingDual, exteriorPower.alternatingMapToDual]
@@ -169,8 +167,7 @@ private theorem snd_comp_conj_eq_comp_snd {R A B C : Type*} [Semiring R]
     [AddCommMonoid A] [Module R A] [AddCommMonoid B] [Module R B] [AddCommMonoid C] [Module R C]
     {q : B →ₗ[R] C} {fB : B →ₗ[R] B} {fC : C →ₗ[R] C} (e : B ≃ₗ[R] A × C)
     (hq : ∀ b : B, (LinearMap.snd R A C) (e b) = q b) (hfq : q.comp fB = fC.comp q) :
-    (LinearMap.snd R A C).comp
-        (((e : B →ₗ[R] A × C).comp fB).comp (e.symm : (A × C) →ₗ[R] B))
+    (LinearMap.snd R A C).comp (((e : B →ₗ[R] A × C).comp fB).comp (e.symm : (A × C) →ₗ[R] B))
       = fC.comp (LinearMap.snd R A C) := by
   have hq' : ∀ x : A × C, q (e.symm x) = (LinearMap.snd R A C) x := fun x => by
     rw [← hq (e.symm x), LinearEquiv.apply_symm_apply]
@@ -180,12 +177,9 @@ private theorem snd_comp_conj_eq_comp_snd {R A B C : Type*} [Semiring R]
 
 -- Split an exact sequence as vector spaces. In that splitting the middle action is block
 -- triangular, so its trace is the sum of the traces on the subspace and the quotient.
-private theorem trace_eq_add_of_exact
-    {K A B C : Type*} [Field K]
-    [AddCommGroup A] [Module K A] [FiniteDimensional K A]
-    [AddCommGroup B] [Module K B]
-    [AddCommGroup C] [Module K C] [FiniteDimensional K C]
-    (i : A →ₗ[K] B) (q : B →ₗ[K] C)
+private theorem trace_eq_add_of_exact {K A B C : Type*} [Field K]
+    [AddCommGroup A] [Module K A] [FiniteDimensional K A] [AddCommGroup B] [Module K B]
+    [AddCommGroup C] [Module K C] [FiniteDimensional K C] (i : A →ₗ[K] B) (q : B →ₗ[K] C)
     (fA : A →ₗ[K] A) (fB : B →ₗ[K] B) (fC : C →ₗ[K] C)
     (hi : Function.Injective i) (hq : Function.Surjective q)
     (hexact : LinearMap.range i = LinearMap.ker q)
@@ -254,8 +248,7 @@ variable [AddCommGroup M] [Module R M] [FiniteDimensional R M]
 
 /-- Over any field, the tensor-square character is the sum of the symmetric-square and
 exterior-square characters. -/
-theorem char_tensorSquare (ρ : Representation R G M) (g : G) :
-    (ρ.character g) ^ 2 =
+theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g) ^ 2 =
       (ρ.symmetricPower 2).character g + (ρ.exteriorPower 2).character g := by
   classical
   rw [← char_tensorPower ρ 2 g]


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/RepresentationTheory/`: 106 joins across 38 files, `-106` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 38 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping.

**No line-length regression.** Every join is asserted `≤ 100` codepoints before being applied, and a per-file before/after comparison confirms no file gains an over-100 line. (Width is counted in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports.) One pre-existing 217-character line survives untouched at `Compact/Intertwiner.lean:53`: an unsplittable roadmap URL inside a module docstring, identical before and after.

`RepresentationTheory/Symmetric/` is excluded because an open PR is developing there; the rest of the area is packed uniformly, so no leftovers remain to invite a follow-up.

Gates: `lake build` (6171 jobs) · `lake exe axioms` (19413 declarations, allowlist clean) · `lake exe module-system` (1061 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none