### PR TITLE
feat: make invariant derivation evaluation injective

### DIFF
--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -15,6 +15,7 @@ the Lie algebra of left-invariant derivations and the tangent Lie algebra at the
 
 ## Main results
 
+* `LeftInvariantDerivation.evalAt_one_injective`: identity evaluation is injective for monoids.
 * `LeftInvariantDerivation.evalAt_injective`: evaluation at any point is injective.
 
 ## References
@@ -32,18 +33,12 @@ namespace LeftInvariantDerivation
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
-  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [ContMDiffMul I ∞ G]
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G]
 
-/-- A left-invariant derivation is determined by its value at any point. -/
-theorem evalAt_injective (g₀ : G) :
-    Function.Injective (evalAt (I := I) g₀) := by
+/-- A left-invariant derivation on a monoid is determined by its value at the identity. -/
+theorem evalAt_one_injective [Monoid G] [ContMDiffMul I ∞ G] :
+    Function.Injective (evalAt (I := I) (1 : G)) := by
   intro X Y hXY
-  have hOne : evalAt (I := I) (1 : G) X = evalAt (I := I) (1 : G) Y := by
-    have hInv : evalAt (I := I) (g₀⁻¹ * g₀) X = evalAt (I := I) (g₀⁻¹ * g₀) Y := by
-      rw [evalAt_mul, evalAt_mul, hXY]
-    rw [inv_mul_cancel] at hInv
-    exact hInv
   ext f g
   have hEval : evalAt (I := I) g X = evalAt (I := I) g Y := by
     calc
@@ -51,10 +46,21 @@ theorem evalAt_injective (g₀ : G) :
           𝒅ₕ (smoothLeftMul_one I g) (evalAt (I := I) (1 : G) X) :=
         (left_invariant (I := I) (g := g) (X := X)).symm
       _ = 𝒅ₕ (smoothLeftMul_one I g) (evalAt (I := I) (1 : G) Y) :=
-        congrArg (𝒅ₕ (smoothLeftMul_one I g)) hOne
+        congrArg (𝒅ₕ (smoothLeftMul_one I g)) hXY
       _ = evalAt (I := I) g Y := left_invariant (I := I) (g := g) (X := Y)
   rw [← evalAt_apply (I := I) (g := g) (X := X) (f := f),
     ← evalAt_apply (I := I) (g := g) (X := Y) (f := f)]
   exact congrArg (fun D => D f) hEval
+
+/-- A left-invariant derivation is determined by its value at any point. -/
+theorem evalAt_injective [Group G] [ContMDiffMul I ∞ G] (g₀ : G) :
+    Function.Injective (evalAt (I := I) g₀) := by
+  intro X Y hXY
+  have hOne : evalAt (I := I) (1 : G) X = evalAt (I := I) (1 : G) Y := by
+    have hInv : evalAt (I := I) (g₀⁻¹ * g₀) X = evalAt (I := I) (g₀⁻¹ * g₀) Y := by
+      rw [evalAt_mul, evalAt_mul, hXY]
+    rw [inv_mul_cancel] at hInv
+    exact hInv
+  exact evalAt_one_injective hOne
 
 end LeftInvariantDerivation

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -1,0 +1,58 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Algebra.LeftInvariantDerivation
+
+/-!
+# Evaluation of left-invariant derivations
+
+A left-invariant derivation on a Lie group is determined by its value at any point. In particular,
+evaluation at the identity is injective. This is the injective half of the identification between
+the Lie algebra of left-invariant derivations and the tangent Lie algebra at the identity.
+
+## Main results
+
+* `LeftInvariantDerivation.evalAt_injective`: evaluation at any point is injective.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The Lie algebra and the tangent space at `1`".
+-/
+
+public section
+
+open scoped ContDiff Manifold
+
+namespace LeftInvariantDerivation
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [LieGroup I ∞ G]
+
+/-- A left-invariant derivation is determined by its value at any point. -/
+theorem evalAt_injective (g₀ : G) :
+    Function.Injective (evalAt (I := I) g₀) := by
+  intro X Y hXY
+  have hOne : evalAt (I := I) (1 : G) X = evalAt (I := I) (1 : G) Y := by
+    have hInv : evalAt (I := I) (g₀⁻¹ * g₀) X = evalAt (I := I) (g₀⁻¹ * g₀) Y := by
+      rw [evalAt_mul, evalAt_mul, hXY]
+    rw [inv_mul_cancel] at hInv
+    exact hInv
+  ext f g
+  have hEval : evalAt (I := I) g X = evalAt (I := I) g Y := by
+    calc
+      evalAt (I := I) g X =
+          𝒅ₕ (smoothLeftMul_one I g) (evalAt (I := I) (1 : G) X) :=
+        (left_invariant (I := I) (g := g) (X := X)).symm
+      _ = 𝒅ₕ (smoothLeftMul_one I g) (evalAt (I := I) (1 : G) Y) :=
+        congrArg (𝒅ₕ (smoothLeftMul_one I g)) hOne
+      _ = evalAt (I := I) g Y := left_invariant (I := I) (g := g) (X := Y)
+  exact congrArg (fun D => D f) hEval
+
+end LeftInvariantDerivation

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -33,7 +33,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [LieGroup I ∞ G]
+  [ContMDiffMul I ∞ G]
 
 /-- A left-invariant derivation is determined by its value at any point. -/
 theorem evalAt_injective (g₀ : G) :
@@ -53,6 +53,8 @@ theorem evalAt_injective (g₀ : G) :
       _ = 𝒅ₕ (smoothLeftMul_one I g) (evalAt (I := I) (1 : G) Y) :=
         congrArg (𝒅ₕ (smoothLeftMul_one I g)) hOne
       _ = evalAt (I := I) g Y := left_invariant (I := I) (g := g) (X := Y)
+  rw [← evalAt_apply (I := I) (g := g) (X := X) (f := f),
+    ← evalAt_apply (I := I) (g := g) (X := Y) (f := f)]
   exact congrArg (fun D => D f) hEval
 
 end LeftInvariantDerivation


### PR DESCRIPTION
## Goal

Establish the injective half of the roadmap’s identification of left-invariant derivations with the tangent Lie algebra at the identity: a left-invariant derivation is determined by its value at any point.

## Why this is correct and necessary

Left invariance transports evaluation at a point through left multiplication. Equality at an arbitrary point therefore gives equality at the identity after translating by its inverse; equality at the identity then gives equality at every point. Extensionality of derivations converts those pointwise equalities into equality of the original left-invariant derivations. This proves the strongest assumption-free injectivity statement and supplies the uniqueness half needed before constructing the inverse from tangent vectors.

## Roadmap scope

This is the first prerequisite in [Deliverable A, Layer 0, “The Lie algebra and the tangent space at `1`”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md). It is part of [intention #135](https://github.com/TauCetiProject/TauCetiRoadmap/issues/135); the remaining existence and equivalence results will follow separately so this PR stays one topic.

## Verification

- `lake build TauCeti.Geometry.Lie.Tangent.LeftInvariantDerivation`
- `bash scripts/sandbox-build.sh` (6,181 build jobs; axiom, module-system, and lint gates passed)

Roadmap: RepresentationTheory