### PR TITLE
feat: turn tangent vectors into point derivations

### DIFF
--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -16,6 +16,7 @@ a canonical linear map from the ordinary tangent space to the algebraic point de
 ## Main results
 
 * `tangentToPointDerivation`: the point derivation associated to a tangent vector.
+* `tangentToPointDerivation_mfderiv`: this association commutes with differentials.
 
 ## References
 
@@ -34,7 +35,10 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
-/-- A tangent vector acts on smooth functions by directional differentiation. -/
+/-- A tangent vector acts on smooth functions by directional differentiation.
+
+This definition is exposed because the exported characteristic equation
+`tangentToPointDerivation_apply` must unfold it under the module system. -/
 @[expose]
 def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDerivation I x where
   toFun v :=
@@ -69,7 +73,26 @@ def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDeriva
     change mvfderiv I f x (c • v) = _
     exact (mvfderiv I f x).map_smul c v
 
+/-- The point derivation associated to a tangent vector evaluates a smooth function by its
+directional derivative. -/
 @[simp]
 theorem tangentToPointDerivation_apply (x : M) (v : TangentSpace I x)
     (f : C^∞⟮I, M; 𝕜⟯) : tangentToPointDerivation x v f = mvfderiv I f x v :=
   rfl
+
+variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
+  {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}
+  {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M']
+
+/-- Sending tangent vectors to point derivations commutes with the differential of a smooth map. -/
+theorem tangentToPointDerivation_mfderiv (f : C^∞⟮I, M; I', M'⟯) (x : M)
+    (v : TangentSpace I x) :
+    tangentToPointDerivation (f x) (mfderiv I I' f x v) =
+      𝒅 f x (tangentToPointDerivation x v) := by
+  ext g
+  change mvfderiv I' g (f x) (mfderiv I I' f x v) =
+    tangentToPointDerivation x v (g.comp f)
+  rw [tangentToPointDerivation_apply]
+  exact (mfderiv_comp_apply x
+    (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+    (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt v).symm

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -1,0 +1,75 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.DerivationBundle
+public import Mathlib.Geometry.Manifold.MFDeriv.NormedSpace
+
+/-!
+# Tangent vectors as point derivations
+
+A tangent vector acts on smooth scalar-valued functions by directional differentiation. This gives
+a canonical linear map from the ordinary tangent space to the algebraic point derivations.
+
+## Main results
+
+* `tangentToPointDerivation`: the point derivation associated to a tangent vector.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The Lie algebra and the tangent space at `1`".
+-/
+
+public section
+
+open scoped ContDiff Derivation Manifold
+
+noncomputable section
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+
+/-- A tangent vector acts on smooth functions by directional differentiation. -/
+@[expose]
+def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDerivation I x where
+  toFun v :=
+    Derivation.mk'
+      { toFun := fun f => mvfderiv I f x v
+        map_add' := fun f g => by
+          change mvfderiv I (⇑f + ⇑g) x v = _
+          exact congr($(mvfderiv_add
+            (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+            (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
+        map_smul' := fun c f => by
+          have hc : MDiffAt (fun _ : M => c) x := mdifferentiableAt_const
+          change mvfderiv I ((fun _ : M => c) • ⇑f) x v = c • mvfderiv I f x v
+          have h := congr($(mvfderiv_smul hc
+            (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
+          calc
+            _ = (c • mvfderiv I f x +
+                (mvfderiv I (fun _ : M => c) x).smulRight (f x)) v := h
+            _ = _ := by simp [mvfderiv_const] }
+      fun f g => by
+        change mvfderiv I (⇑f * ⇑g) x v =
+          f x * mvfderiv I g x v + g x * mvfderiv I f x v
+        exact congr($(mvfderiv_mul
+          (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+          (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
+  map_add' v w := by
+    ext f
+    change mvfderiv I f x (v + w) = _
+    exact (mvfderiv I f x).map_add v w
+  map_smul' c v := by
+    ext f
+    change mvfderiv I f x (c • v) = _
+    exact (mvfderiv I f x).map_smul c v
+
+@[simp]
+theorem tangentToPointDerivation_apply (x : M) (v : TangentSpace I x)
+    (f : C^∞⟮I, M; 𝕜⟯) : tangentToPointDerivation x v f = mvfderiv I f x v :=
+  rfl

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -35,22 +35,23 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
 
-/-- A tangent vector acts on smooth functions by directional differentiation.
-
-This definition is exposed because the exported characteristic equation
-`tangentToPointDerivation_apply` must unfold it under the module system. -/
+/-- A tangent vector acts on smooth functions by directional differentiation. -/
+-- Exposure is required for the exported characteristic equation below to unfold this definition
+-- under the module system.
 @[expose]
 def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDerivation I x where
   toFun v :=
     Derivation.mk'
       { toFun := fun f => mvfderiv I f x v
         map_add' := fun f g => by
+          -- Unfold the smooth-map addition wrapper to apply the `mvfderiv_add` API.
           change mvfderiv I (⇑f + ⇑g) x v = _
           exact congr($(mvfderiv_add
             (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
             (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
         map_smul' := fun c f => by
           have hc : MDiffAt (fun _ : M => c) x := mdifferentiableAt_const
+          -- Unfold the pointed scalar action into pointwise multiplication for `mvfderiv_smul`.
           change mvfderiv I ((fun _ : M => c) • ⇑f) x v = c • mvfderiv I f x v
           have h := congr($(mvfderiv_smul hc
             (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
@@ -59,6 +60,7 @@ def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDeriva
                 (mvfderiv I (fun _ : M => c) x).smulRight (f x)) v := h
             _ = _ := by simp [mvfderiv_const] }
       fun f g => by
+        -- Unfold derivation application and smooth-map multiplication to use `mvfderiv_mul`.
         change mvfderiv I (⇑f * ⇑g) x v =
           f x * mvfderiv I g x v + g x * mvfderiv I f x v
         exact congr($(mvfderiv_mul
@@ -66,10 +68,12 @@ def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDeriva
           (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
   map_add' v w := by
     ext f
+    -- Unfold the two bundled linear maps to expose linearity of `mvfderiv` in its tangent vector.
     change mvfderiv I f x (v + w) = _
     exact (mvfderiv I f x).map_add v w
   map_smul' c v := by
     ext f
+    -- Unfold the two bundled linear maps to expose scalar linearity of `mvfderiv`.
     change mvfderiv I f x (c • v) = _
     exact (mvfderiv I f x).map_smul c v
 
@@ -90,6 +94,8 @@ theorem tangentToPointDerivation_mfderiv (f : C^∞⟮I, M; I', M'⟯) (x : M)
     tangentToPointDerivation (f x) (mfderiv I I' f x v) =
       𝒅 f x (tangentToPointDerivation x v) := by
   ext g
+  -- Unfold the derivation differential and both comparison-map applications before using the
+  -- manifold chain rule; their bundled coercions have no separate rewriting lemma.
   change mvfderiv I' g (f x) (mfderiv I I' f x v) =
     tangentToPointDerivation x v (g.comp f)
   rw [tangentToPointDerivation_apply]

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -44,14 +44,16 @@ def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDeriva
     Derivation.mk'
       { toFun := fun f => mvfderiv I f x v
         map_add' := fun f g => by
-          -- Unfold the smooth-map addition wrapper to apply the `mvfderiv_add` API.
+          -- Unfold the pointed smooth-map addition wrapper: `ContMDiffMap.coe_add` does not match
+          -- this type synonym directly.
           change mvfderiv I (⇑f + ⇑g) x v = _
           exact congr($(mvfderiv_add
             (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
             (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
         map_smul' := fun c f => by
           have hc : MDiffAt (fun _ : M => c) x := mdifferentiableAt_const
-          -- Unfold the pointed scalar action into pointwise multiplication for `mvfderiv_smul`.
+          -- Unfold the pointed smooth-map scalar wrapper: `ContMDiffMap.coe_smul` does not match
+          -- this type synonym directly.
           change mvfderiv I ((fun _ : M => c) • ⇑f) x v = c • mvfderiv I f x v
           have h := congr($(mvfderiv_smul hc
             (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt) v)
@@ -60,7 +62,9 @@ def tangentToPointDerivation (x : M) : TangentSpace I x →ₗ[𝕜] PointDeriva
                 (mvfderiv I (fun _ : M => c) x).smulRight (f x)) v := h
             _ = _ := by simp [mvfderiv_const] }
       fun f g => by
-        -- Unfold derivation application and smooth-map multiplication to use `mvfderiv_mul`.
+        -- Unfold the pointed smooth-map multiplication wrapper and the evaluation scalar action
+        -- (`PointedContMDiffMap.smul_def`): the corresponding `ContMDiffMap.coe_mul` theorem does
+        -- not match this type synonym directly.
         change mvfderiv I (⇑f * ⇑g) x v =
           f x * mvfderiv I g x v + g x * mvfderiv I f x v
         exact congr($(mvfderiv_mul


### PR DESCRIPTION
## Goal

Provide the canonical linear map from a manifold tangent space to algebraic point derivations by letting a tangent vector act through the manifold directional derivative.

## Why this is correct

- `mvfderiv` is linear in the tangent vector, giving linearity of the construction.
- Its sum, scalar-product, and product rules give the linear-map and Leibniz laws required by `PointDerivation`.
- The exported application lemma makes the construction reduce to the expected directional derivative.

## Roadmap

This is the forward direction of the tangent-space/point-derivation identification required by [Deliverable A, Layer 0](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-0-the-lie-algebra-and-the-tangent-space-at-1), and is part of intention TauCetiProject/TauCetiRoadmap#135.

## Verification

- Focused Lean build passed.
- Full sandboxed build passed (6,183 jobs).
- Axiom audit passed (19,574 declarations).
- Module-system audit passed (1,070 modules).
- Linter ratchet passed with no new violations.

Roadmap: RepresentationTheory