### PR TITLE
refactor(Laplacian): close two lower-order maximum-principle proofs in term mode

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
+++ b/TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean
@@ -131,12 +131,10 @@ theorem abs_le_of_laplacian_add_fderiv_eq_mul_abs_le_frontier {K : Set E} (hK : 
     (hbdry : ∀ ⦃x⦄, x ∈ frontier K → |f x| ≤ M) :
     ∀ ⦃x⦄, x ∈ K → |f x| ≤ M := by
   intro x hx
-  rw [abs_le]
-  constructor
-  · exact ge_of_laplacian_add_fderiv_le_mul_ge_frontier hK (neg_nonpos.mpr hM) hcont hcd hc hb
-      (fun y hy => (hsol hy).le) (fun y hy => (abs_le.mp (hbdry hy)).1) hx
-  · exact le_of_mul_le_laplacian_add_fderiv_le_frontier hK hM hcont hcd hc hb
-      (fun y hy => (hsol hy).ge) (fun y hy => (abs_le.mp (hbdry hy)).2) hx
+  refine abs_le.mpr ⟨ge_of_laplacian_add_fderiv_le_mul_ge_frontier hK (neg_nonpos.mpr hM) hcont
+      hcd hc hb (fun y hy => (hsol hy).le) (fun y hy => (abs_le.mp (hbdry hy)).1) hx,
+    le_of_mul_le_laplacian_add_fderiv_le_frontier hK hM hcont hcd hc hb
+      (fun y hy => (hsol hy).ge) (fun y hy => (abs_le.mp (hbdry hy)).2) hx⟩
 
 /-- **Comparison principle for `-Δ - b·∇ + c`.** Functions acted on by the same lower-order
 coefficients are ordered on a compact set when their operator values and frontier values are
@@ -172,13 +170,11 @@ theorem eqOn_of_laplacian_add_fderiv_sub_mul_eq_of_eqOn_frontier {K : Set E} (hK
         Δ g x + fderiv ℝ g x (b x) - c x * g x)
     (hbdry : Set.EqOn f g (frontier K)) : Set.EqOn f g K := by
   intro x hx
-  apply le_antisymm
-  · exact le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
-      hK hfcont hgcont hfcd hgcd hc hb
-      (fun y hy => (hL hy).ge) (fun y hy => (hbdry hy).le) hx
-  · exact le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
-      hK hgcont hfcont hgcd hfcd hc hb
-      (fun y hy => (hL hy).le) (fun y hy => (hbdry hy).ge) hx
+  exact le_antisymm
+    (le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
+      hK hfcont hgcont hfcd hgcd hc hb (fun y hy => (hL hy).ge) (fun y hy => (hbdry hy).le) hx)
+    (le_of_laplacian_add_fderiv_sub_mul_le_laplacian_add_fderiv_sub_mul_of_le_frontier
+      hK hgcont hfcont hgcd hfcd hc hb (fun y hy => (hL hy).le) (fun y hy => (hbdry hy).ge) hx)
 
 end TauCeti
 


### PR DESCRIPTION
A small `/cleanup` pass over `TauCeti/Analysis/InnerProductSpace/Laplacian/LowerOrderMaximumPrinciple.lean`. No statements change; `-4` lines.

Two proofs opened a tactic block only to fill both fields of a two-field structure:

* `abs_le_of_laplacian_add_fderiv_eq_mul_abs_le_frontier` — `rw [abs_le]; constructor` with an `exact` in each branch, now `refine abs_le.mpr ⟨_, _⟩`.
* `eqOn_of_laplacian_add_fderiv_sub_mul_eq_of_eqOn_frontier` — `apply le_antisymm` with an `exact` in each branch, now `exact le_antisymm _ _`.

Both are the anonymous-constructor rule; the arguments are unchanged.

**The 45-line body of `le_of_mul_le_laplacian_add_fderiv_le_frontier` is deliberately untouched.** Its one plausible extraction — the `hfz : f z ≤ m` block establishing the frontier bound at the maximiser — depends on roughly fifteen items of ambient context (`f`, `w`, the perturbation `g`, `b`, `c`, `m`, `ε`, `z`, plus `hm`, `hcd`, `hc`, `hb`, `hsub`, `hbdry`, `hwcd`, `hzmax`). Lifting that out yields a single-use helper whose hypothesis list is longer than the proof it shortens, which is worse than leaving it inline. The barrier argument reads as one continuous piece and is left that way.

Gates: `lake build` (6191 jobs) · `lake exe axioms` (19642 declarations, allowlist clean) · `lake exe module-system` (1077 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none