### PR TITLE
feat: package canonical invariant integral curves

### DIFF
--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -18,10 +18,13 @@ every point, after which Mathlib's uniform-time theorem produces global integral
 
 * `IsMIntegralCurveOn.const_mul_mulInvariantVectorField`: left translation preserves invariant
   integral curves.
+* `IsMIntegralCurve.const_mul_mulInvariantVectorField`: the global version of that translation law.
 * `exists_isMIntegralCurve_mulInvariantVectorField`: every left-invariant vector field has a global
   integral curve through every point.
 * `existsUnique_isMIntegralCurve_mulInvariantVectorField`: that global curve is unique.
 * `mulInvariantIntegralCurve`: the resulting canonical global integral curve.
+* `mulInvariantIntegralCurve_eq_const_mul`: curves through arbitrary points are left translates of
+  the curve through the identity.
 
 ## References
 
@@ -89,6 +92,18 @@ theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
 
 end IsMIntegralCurveOn
 
+namespace IsMIntegralCurve
+
+/-- Left translation preserves global integral curves of a left-invariant vector field. -/
+theorem const_mul_mulInvariantVectorField [LieGroup I (minSmoothness ℝ 3) G]
+    {v : GroupLieAlgebra I G} {γ : ℝ → G}
+    (hγ : IsMIntegralCurve γ (mulInvariantVectorField v)) (g : G) :
+    IsMIntegralCurve (fun t ↦ g * γ t) (mulInvariantVectorField v) := by
+  rw [isMIntegralCurve_iff_isMIntegralCurveOn]
+  exact (hγ.isMIntegralCurveOn univ).const_mul_mulInvariantVectorField g
+
+end IsMIntegralCurve
+
 /-- Every left-invariant vector field on a real Lie group modeled on a complete space has a global
 integral curve through every point. -/
 theorem exists_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
@@ -153,3 +168,14 @@ theorem eq_mulInvariantIntegralCurve [CompleteSpace E]
     γ = mulInvariantIntegralCurve v x :=
   (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).unique ⟨hγ0, hγ⟩
     (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).choose_spec.1
+
+/-- The canonical invariant integral curve through `x` is the left translate by `x` of the
+canonical curve through the identity. -/
+theorem mulInvariantIntegralCurve_eq_const_mul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) :
+    mulInvariantIntegralCurve v x = fun t ↦ x * mulInvariantIntegralCurve v 1 t := by
+  symm
+  apply eq_mulInvariantIntegralCurve v x
+  · simp
+  · exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).const_mul_mulInvariantVectorField x

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -138,6 +138,8 @@ theorem existsUnique_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
   rw [hδ.1, hγ0]
 
 /-- The unique global integral curve of a left-invariant vector field through a given point. -/
+-- Exposure is required for the exported characteristic theorems below to unfold the choice under
+-- the module system. Callers should use those theorems rather than unfold the definition.
 @[expose]
 noncomputable def mulInvariantIntegralCurve [CompleteSpace E]
     [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -20,6 +20,8 @@ every point, after which Mathlib's uniform-time theorem produces global integral
   integral curves.
 * `exists_isMIntegralCurve_mulInvariantVectorField`: every left-invariant vector field has a global
   integral curve through every point.
+* `existsUnique_isMIntegralCurve_mulInvariantVectorField`: that global curve is unique.
+* `mulInvariantIntegralCurve`: the resulting canonical global integral curve.
 
 ## References
 
@@ -106,3 +108,48 @@ theorem exists_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
   intro y
   refine ⟨fun t ↦ y * γ t, by simp [hγ0], ?_⟩
   exact hγ.const_mul_mulInvariantVectorField y
+
+/-- Every left-invariant vector field on a real Lie group modeled on a complete space has a unique
+global integral curve through every point. -/
+theorem existsUnique_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) :
+    ∃! γ : ℝ → G, γ 0 = x ∧ IsMIntegralCurve γ (mulInvariantVectorField v) := by
+  obtain ⟨γ, hγ0, hγ⟩ := exists_isMIntegralCurve_mulInvariantVectorField v x
+  refine ⟨γ, ⟨hγ0, hγ⟩, ?_⟩
+  intro δ hδ
+  apply isMIntegralCurve_Ioo_eq_of_contMDiff_boundaryless (t₀ := 0)
+    ((contMDiff_mulInvariantVectorField v).of_le (by simp)) hδ.2 hγ
+  rw [hδ.1, hγ0]
+
+/-- The unique global integral curve of a left-invariant vector field through a given point. -/
+@[expose]
+noncomputable def mulInvariantIntegralCurve [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) : ℝ → G :=
+  (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).choose
+
+/-- The canonical invariant integral curve starts at its specified point. -/
+@[simp]
+theorem mulInvariantIntegralCurve_zero [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) :
+    mulInvariantIntegralCurve v x 0 = x :=
+  (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).choose_spec.1.1
+
+/-- The canonical invariant curve is a global integral curve of its left-invariant vector field. -/
+theorem isMIntegralCurve_mulInvariantIntegralCurve [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) :
+    IsMIntegralCurve (mulInvariantIntegralCurve v x) (mulInvariantVectorField v) :=
+  (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).choose_spec.1.2
+
+/-- Any global integral curve of a left-invariant vector field is the canonical one determined by
+its value at zero. -/
+theorem eq_mulInvariantIntegralCurve [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) {γ : ℝ → G}
+    (hγ0 : γ 0 = x) (hγ : IsMIntegralCurve γ (mulInvariantVectorField v)) :
+    γ = mulInvariantIntegralCurve v x :=
+  (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).unique ⟨hγ0, hγ⟩
+    (existsUnique_isMIntegralCurve_mulInvariantVectorField v x).choose_spec.1

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -138,9 +138,6 @@ theorem existsUnique_isMIntegralCurve_mulInvariantVectorField [CompleteSpace E]
   rw [hδ.1, hγ0]
 
 /-- The unique global integral curve of a left-invariant vector field through a given point. -/
--- Exposure is required for the exported characteristic theorems below to unfold the choice under
--- the module system. Callers should use those theorems rather than unfold the definition.
-@[expose]
 noncomputable def mulInvariantIntegralCurve [CompleteSpace E]
     [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
     [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) : ℝ → G :=


### PR DESCRIPTION
## Summary

- strengthen global existence to unique global integral curves using the Mathlib uniqueness theorem
- package the unique curve through each point with initial-value and integral-curve characteristic theorems
- prove every canonical curve is the left translate of the canonical curve through the identity

## Roadmap fit

This advances Deliverable A, Layer 0, "The exponential map" in `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`. That target defines the exponential from the unique integral curve through the identity of a left-invariant vector field; this PR supplies exactly that canonical curve API on top of the global existence theorem merged in #1743.

## Verification

- `lake env lean TauCeti/Geometry/Lie/IntegralCurve.lean`
- `git diff --check origin/main...HEAD`
- full sandbox build, axiom audit, module-system audit, and environment lint passed on the equivalent pre-rebase stack

Roadmap: RepresentationTheory