### PR TITLE
feat: cut out the Weyl module of a Young tableau

### DIFF
--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.CharP.Algebra
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import Mathlib.RepresentationTheory.Intertwining
 public import TauCeti.RepresentationTheory.ClassicalGroups.TensorPower
 public import TauCeti.RepresentationTheory.Symmetric.Relabel
@@ -29,12 +30,16 @@ Two facts make the construction usable.  Relabeling the tableau moves the Weyl m
 corresponding factor permutation, which is itself `GL n k`-equivariant, so the Weyl modules of
 two tableaux of the same shape are isomorphic representations
 (`TauCeti.YoungTableau.weylRepEquiv`): up to isomorphism the Weyl module depends only on the
-shape.  And the Weyl module is nonzero as soon as the shape has at most `n` rows
-(`TauCeti.YoungTableau.weylModule_ne_bot`), which is proved by evaluating a coordinate
-functional on `c_t · (e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)})`, where `r` records the row of each label: the
-surviving terms are exactly the row group, each contributing `1`, so the value is the order of
-the row group, nonzero in characteristic zero.  The converse (the Weyl module vanishes when the
-shape has more than `n` rows) is not proved here.
+shape.  And the Weyl module is nonzero exactly when the shape has at most `n` rows
+(`TauCeti.YoungTableau.weylModule_eq_bot_iff`).  Nonvanishing
+(`TauCeti.YoungTableau.weylModule_ne_bot`) is proved by evaluating a coordinate functional on
+`c_t · (e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)})`, where `r` records the row of each label: the surviving terms
+are exactly the row group, each contributing `1`, so the value is the order of the row group,
+nonzero in characteristic zero.  Vanishing (`TauCeti.YoungTableau.weylModule_eq_bot`) is the
+transposition trick: if the first column is longer than `n` then, on each basis pure tensor, two
+of its labels carry the same basis index, so their transposition lies in the column group and
+fixes that pure tensor while negating `c_t`; the value is its own negative, hence zero because
+`2` is invertible.
 
 The Young symmetrizer is built over `ℚ`, so the coefficients are transported into the base ring
 along `algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout, which is the
@@ -55,6 +60,10 @@ characteristic-zero setting the roadmap works in.
   isomorphic representations of `GL n k`.
 * `TauCeti.YoungTableau.weylModule_ne_bot`: the Weyl module is nonzero when the shape has at
   most `n` rows.
+* `TauCeti.YoungTableau.weylModule_eq_bot`: the Weyl module vanishes when the shape has more
+  than `n` rows.
+* `TauCeti.YoungTableau.weylModule_eq_bot_iff`: the two directions combined, the vanishing
+  criterion.
 
 ## References
 
@@ -278,7 +287,7 @@ noncomputable def weylRepEquiv (t t' : YoungTableau μ) :
     (weylRep k n t).Equiv (weylRep k n t') :=
   relabel_relabelPerm t t' ▸ weylRelabelRepEquiv (relabelPerm t t') t
 
-/-! ### The Weyl module of a shape with at most `n` rows is nonzero -/
+/-! ### The vanishing criterion -/
 
 open Finset in
 /-- The Weyl module of a `μ`-tableau is nonzero as soon as `μ` has at most `n` rows.
@@ -360,6 +369,91 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
     refine Nat.cast_ne_zero.mpr (Finset.card_ne_zero_of_mem (a := 1) ?_)
     exact (hmemS 1).mpr (one_mem _)
   exact hne key.symm
+
+/-- The Weyl module of a `μ`-tableau vanishes as soon as `μ` has more than `n` rows.
+
+The `|μ|`-fold tensor power is spanned by the pure tensors `e_{p(1)} ⊗ ⋯ ⊗ e_{p(d)}` of standard
+basis vectors.  The first column of `μ` is longer than `n`, so two of its labels `x ≠ y` have
+`p x = p y`; the transposition of `x` and `y` then lies in the column group of `t`, so it fixes
+that pure tensor while multiplying `c_t` on the right by it negates `c_t`.  The value of `c_t` on
+the pure tensor is therefore its own negative, hence zero because `2` is invertible in a
+`ℚ`-algebra. -/
+theorem weylModule_eq_bot (t : YoungTableau μ) (hn : n < μ.colLen 0) :
+    (weylModule k n t).toSubmodule = ⊥ := by
+  classical
+  haveI : Invertible (2 : ℚ) := invertibleOfNonzero (by norm_num)
+  haveI : Invertible (2 : k) := by
+    have h := Invertible.map (algebraMap ℚ k) (2 : ℚ)
+    rwa [map_ofNat] at h
+  -- the labels of the first column outnumber the basis indices
+  have hcard : Fintype.card {ℓ : Fin μ.card // colIndex t ℓ = 0} = μ.colLen 0 := by
+    rw [μ.colLen_eq_card, ← Fintype.card_coe]
+    exact Fintype.card_congr (colFiberEquiv t 0)
+  have hzero : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) = 0 := by
+    refine (Basis.piTensorProduct fun _ : Fin μ.card => Pi.basisFun k (Fin n)).ext fun p => ?_
+    rw [Basis.piTensorProduct_apply, LinearMap.zero_apply]
+    simp only [Pi.basisFun_apply]
+    -- two labels of the first column carry the same basis index
+    obtain ⟨a, b, hab, hpab⟩ :=
+      Fintype.exists_ne_map_eq_of_card_lt (fun ℓ : {ℓ : Fin μ.card // colIndex t ℓ = 0} => p ℓ)
+        (by rw [hcard, Fintype.card_fin]; exact hn)
+    have hxy : (a : Fin μ.card) ≠ (b : Fin μ.card) := fun h => hab (Subtype.ext h)
+    have hτ : Equiv.swap (a : Fin μ.card) (b : Fin μ.card) ∈ colSubgroup t :=
+      swap_mem_colSubgroup (by rw [a.2, b.2])
+    -- their transposition fixes the pure tensor
+    have hfix : (fun i => (Pi.single
+          (p ((Equiv.swap (a : Fin μ.card) (b : Fin μ.card)).symm i)) (1 : k) : Fin n → k)) =
+        fun i => (Pi.single (p i) (1 : k) : Fin n → k) := by
+      funext i
+      rw [Equiv.symm_swap]
+      rcases eq_or_ne i (a : Fin μ.card) with rfl | h1
+      · rw [Equiv.swap_apply_left, hpab]
+      · rcases eq_or_ne i (b : Fin μ.card) with rfl | h2
+        · rw [Equiv.swap_apply_right, hpab]
+        · rw [Equiv.swap_apply_of_ne_of_ne h1 h2]
+    -- and multiplying the symmetrizer on the right by it negates the symmetrizer
+    have hc : youngSymmetrizerOver k t *
+        MonoidAlgebra.single (Equiv.swap (a : Fin μ.card) (b : Fin μ.card)) 1 =
+        -youngSymmetrizerOver k t := by
+      have h := mul_youngSymmetrizer_right t ⟨_, hτ⟩
+      rw [Equiv.Perm.sign_swap hxy] at h
+      have h' := congrArg (MonoidAlgebra.mapAlgHom (Equiv.Perm (Fin μ.card)) (Algebra.ofId ℚ k))
+        (by simpa using h :
+          youngSymmetrizer t *
+              MonoidAlgebra.single (Equiv.swap (a : Fin μ.card) (b : Fin μ.card)) 1 =
+            -youngSymmetrizer t)
+      rw [map_mul, map_neg, MonoidAlgebra.mapAlgHom_single, map_one] at h'
+      exact h'
+    -- so the value of the symmetrizer on the pure tensor is its own negative
+    have h : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t *
+          MonoidAlgebra.single (Equiv.swap (a : Fin μ.card) (b : Fin μ.card)) 1)
+          (PiTensorProduct.tprod k fun i => (Pi.single (p i) (1 : k) : Fin n → k)) =
+        permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+          (PiTensorProduct.tprod k fun i => (Pi.single (p i) (1 : k) : Fin n → k)) := by
+      rw [map_mul, Module.End.mul_apply, ← MonoidAlgebra.of_apply, permTensorActionAlgHom_of,
+        permTensorAction_apply, LinearEquiv.coe_toLinearMap, PiTensorProduct.reindex_tprod, hfix]
+    have hneg : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+          (PiTensorProduct.tprod k fun i => (Pi.single (p i) (1 : k) : Fin n → k)) =
+        -permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+          (PiTensorProduct.tprod k fun i => (Pi.single (p i) (1 : k) : Fin n → k)) := by
+      conv_lhs => rw [← h]
+      rw [hc, map_neg, LinearMap.neg_apply]
+    have htwo : (2 : k) • permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+        (PiTensorProduct.tprod k fun i => (Pi.single (p i) (1 : k) : Fin n → k)) = 0 := by
+      rw [two_smul]
+      nth_rewrite 2 [hneg]
+      rw [add_neg_cancel]
+    have := congrArg (fun w => (⅟(2 : k)) • w) htwo
+    simpa [smul_smul] using this
+  rw [weylModule_toSubmodule, hzero, LinearMap.range_zero]
+
+/-- **The vanishing criterion for the Weyl module**: it vanishes exactly when the shape has more
+rows than the dimension of the standard representation. -/
+theorem weylModule_eq_bot_iff [Nontrivial k] (t : YoungTableau μ) :
+    (weylModule k n t).toSubmodule = ⊥ ↔ n < μ.colLen 0 := by
+  refine ⟨fun h => ?_, weylModule_eq_bot t⟩
+  by_contra hle
+  exact weylModule_ne_bot t (not_lt.mp hle) h
 
 /-! ### Invariants of the Weyl module -/
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.CharP.Algebra
+public import Mathlib.Data.Complex.Basic
 public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import TauCeti.Combinatorics.Young.StandardTableau.Reading
 public import TauCeti.RepresentationTheory.ClassicalGroups.TensorPower
@@ -57,6 +59,7 @@ roadmap works in.
 * `TauCeti.weylModuleOfShape`: the Weyl module of a shape, namely that of its row-superstandard
   tableau, with `weylRepOfShape` the action of `GL n k` on it and `weylFDRepOfShape` its bundled
   finite-dimensional form over a field.
+* `TauCeti.schurFunctor`: the roadmap-pinned name, `weylFDRepOfShape` at `k = ℂ`.
 
 ## Main results
 
@@ -76,9 +79,11 @@ roadmap works in.
   Lecture 6, "Weyl's construction".
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
   Layer 2, "Young symmetrizers and the Schur functor", where this object is pinned as
-  `schurFunctor`.  It is named `weylModule` here because what is constructed is the module, not
-  a functor: the Schur functor of `μ` is a functor in the underlying module, and only its value
-  at `kⁿ` is built.
+  `schurFunctor`.  The construction itself is named `weylModule` here because what is constructed
+  is the module, not a functor: the Schur functor of `μ` is a functor in the underlying module,
+  and only its value at `kⁿ` is built.  The pinned name is supplied as `TauCeti.schurFunctor`,
+  the definitional re-export at `k = ℂ` of the bundled form, so that later roadmap layers can
+  consume it under the name they are written against.
 -/
 
 public section
@@ -431,5 +436,14 @@ noncomputable abbrev weylFDRepOfShape (μ : YoungDiagram) : FDRep k (GL (Fin n) 
   FDRep.of (V := (weylModuleOfShape k n μ).toSubmodule) (weylRepOfShape k n μ)
 
 end Field
+
+/-- **The Schur functor** `𝕊^μ(ℂⁿ)` in the roadmap's pinned form: the Weyl module of the shape
+`μ` over `ℂ`, bundled as an object of `FDRep ℂ (GL (Fin n) ℂ)`.
+
+This is a definitional re-export of `TauCeti.weylFDRepOfShape` at `k = ℂ`, under the name later
+roadmap layers are written against; the general form, over any field that is a `ℚ`-algebra, is
+`TauCeti.weylFDRepOfShape`, and the unbundled construction is `TauCeti.weylModuleOfShape`. -/
+noncomputable abbrev schurFunctor (n : ℕ) (μ : YoungDiagram) : FDRep ℂ (GL (Fin n) ℂ) :=
+  weylFDRepOfShape ℂ n μ
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -68,7 +68,7 @@ roadmap works in.
 * `TauCeti.YoungTableau.weylModule_eq_bot`: the Weyl module vanishes when the shape has more
   than `n` rows.
 * `TauCeti.YoungTableau.weylModule_eq_bot_iff`: the two directions combined, the vanishing
-  criterion.
+  criterion, with `TauCeti.weylModuleOfShape_eq_bot_iff` its shape-indexed form.
 
 ## References
 
@@ -382,11 +382,40 @@ noncomputable abbrev weylRepOfShape (μ : YoungDiagram) :
     Representation k (GL (Fin n) k) (weylModuleOfShape k n μ).toSubmodule :=
   (weylModuleOfShape k n μ).toRepresentation
 
+/-- The submodule underlying the Weyl module of a shape is the range of the Young symmetrizer of
+its row-superstandard tableau acting on the tensor power. -/
+theorem weylModuleOfShape_toSubmodule (μ : YoungDiagram) :
+    (weylModuleOfShape k n μ).toSubmodule =
+      LinearMap.range (permTensorActionAlgHom k n μ.card
+        (YoungTableau.youngSymmetrizerOver k
+          (StandardYoungTableau.rowSuperstandard μ).toEquiv)) :=
+  YoungTableau.weylModule_toSubmodule k n _
+
+/-- The action on the Weyl module of a shape is the restriction of the action on the tensor
+power. -/
+@[simp]
+theorem weylRepOfShape_apply_coe (μ : YoungDiagram) (g : GL (Fin n) k)
+    (x : (weylModuleOfShape k n μ).toSubmodule) :
+    ((weylRepOfShape k n μ g x : (weylModuleOfShape k n μ).toSubmodule) :
+        ⨂[k]^μ.card (Fin n → k)) = tensorPowerRep k n μ.card g x :=
+  (rfl)
+
 /-- The Weyl module of any `μ`-tableau is isomorphic, as a representation of `GL n k`, to the
 Weyl module of the shape `μ`. -/
 noncomputable def YoungTableau.weylRepEquivOfShape {μ : YoungDiagram} (t : YoungTableau μ) :
     (YoungTableau.weylRep k n t).Equiv (weylRepOfShape k n μ) :=
   YoungTableau.weylRepEquiv t _
+
+/-- **The vanishing criterion for the Weyl module of a shape**: it vanishes exactly when the
+shape has more rows than the dimension of the standard representation. -/
+theorem weylModuleOfShape_eq_bot_iff [Nontrivial k] (μ : YoungDiagram) :
+    (weylModuleOfShape k n μ).toSubmodule = ⊥ ↔ n < μ.colLen 0 :=
+  YoungTableau.weylModule_eq_bot_iff _
+
+/-- The Weyl module of a shape with at most `n` rows is nontrivial. -/
+theorem nontrivial_weylModuleOfShape [Nontrivial k] (μ : YoungDiagram) (hn : μ.colLen 0 ≤ n) :
+    Nontrivial (weylModuleOfShape k n μ).toSubmodule :=
+  YoungTableau.nontrivial_weylModule _ hn
 
 end Shape
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.CharP.Algebra
+public import Mathlib.RepresentationTheory.Intertwining
+public import TauCeti.RepresentationTheory.ClassicalGroups.TensorPower
+public import TauCeti.RepresentationTheory.Symmetric.Relabel
+
+/-!
+# The Weyl construction: a Young symmetrizer cuts out a `GL n k`-subrepresentation
+
+Weyl's construction produces representations of `GL n k` from representations of the symmetric
+group: a Young symmetrizer `c_t ∈ ℚ[S_d]` acts on the tensor power `(kⁿ)^{⊗d}` by permuting
+tensor factors, and, because that action commutes with the diagonal action of `GL n k`, its
+image is a `GL n k`-subrepresentation.  This file builds that image, the **Weyl module** of `t`.
+
+The commuting-actions input is already available
+(`TauCeti.commute_permTensorActionAlgHom_tensorPowerRep`); what is built here is the image it
+cuts out.  The construction is done in two steps.  First, for an arbitrary representation `ρ` on
+`M`, acting on `⨂[R]^d M` by an element of `R[S_d]` is an intertwining map of `ρ.tensorPower d`
+with itself, so its image is a `Subrepresentation`; this is `TauCeti.tensorPowerRange`.  Second,
+specializing `ρ` to the standard representation of `GL n k` and the group-algebra element to a
+Young symmetrizer gives `TauCeti.YoungTableau.weylModule`.
+
+Two facts make the construction usable.  Relabeling the tableau moves the Weyl module by the
+corresponding factor permutation, which is itself `GL n k`-equivariant, so the Weyl modules of
+two tableaux of the same shape are isomorphic representations
+(`TauCeti.YoungTableau.weylRepEquiv`): up to isomorphism the Weyl module depends only on the
+shape.  And the Weyl module is nonzero as soon as the shape has at most `n` rows
+(`TauCeti.YoungTableau.weylModule_ne_bot`), which is proved by evaluating a coordinate
+functional on `c_t · (e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)})`, where `r` records the row of each label: the
+surviving terms are exactly the row group, each contributing `1`, so the value is the order of
+the row group, nonzero in characteristic zero.  The converse (the Weyl module vanishes when the
+shape has more than `n` rows) is not proved here.
+
+The Young symmetrizer is built over `ℚ`, so the coefficients are transported into the base ring
+along `algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout, which is the
+characteristic-zero setting the roadmap works in.
+
+## Main definitions
+
+* `TauCeti.tensorPowerRange`: the image of an element of `R[S_d]` acting on `⨂[R]^d M` by
+  permuting tensor factors, as a subrepresentation of the tensor power of any representation.
+* `TauCeti.YoungTableau.youngSymmetrizerOver`: the Young symmetrizer with its rational
+  coefficients transported into a `ℚ`-algebra.
+* `TauCeti.YoungTableau.weylModule`: the Weyl module of a tableau, a subrepresentation of
+  `(kⁿ)^{⊗|μ|}`, with `weylRep` the action of `GL n k` on it.
+
+## Main results
+
+* `TauCeti.YoungTableau.weylRepEquiv`: the Weyl modules of two tableaux of the same shape are
+  isomorphic representations of `GL n k`.
+* `TauCeti.YoungTableau.weylModule_ne_bot`: the Weyl module is nonzero when the shape has at
+  most `n` rows.
+
+## References
+
+* [W. Fulton and J. Harris, *Representation Theory: A First Course*][fulton-harris1991],
+  Lecture 6, "Weyl's construction".
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 2, "Young symmetrizers and the Schur functor", where this object is pinned as
+  `schurFunctor`.  It is named `weylModule` here because what is constructed is the module, not
+  a functor: the Schur functor of `μ` is a functor in the underlying module, and only its value
+  at `kⁿ` is built.
+-/
+
+public section
+
+open Matrix
+open scoped TensorProduct
+
+universe u v w
+
+namespace TauCeti
+
+/-! ## The image of a group-algebra element on a tensor power -/
+
+section TensorPowerRange
+
+variable {R : Type u} {G : Type v} {M : Type w}
+variable [CommSemiring R] [Monoid G] [AddCommMonoid M] [Module R M]
+variable (ρ : Representation R G M) (d : ℕ) (a b : MonoidAlgebra R (Equiv.Perm (Fin d)))
+
+/-- Acting on `⨂[R]^d M` by an element of `R[S_d]`, permuting tensor factors, is an intertwining
+map of the diagonal action of `ρ` on the tensor power with itself: the two actions commute. -/
+noncomputable def tensorPowerPermMap :
+    Representation.IntertwiningMap (ρ.tensorPower d) (ρ.tensorPower d) where
+  toLinearMap := (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a
+  isIntertwining' g := by
+    rw [Representation.tensorPower_apply]
+    exact PiTensorProduct.commute_reindexRepresentation_asAlgebraHom_map R M (Fin d) a (ρ g)
+
+/-- The linear map underlying the tensor-power action of a group-algebra element. -/
+@[simp]
+theorem tensorPowerPermMap_toLinearMap :
+    (tensorPowerPermMap ρ d a).toLinearMap =
+      (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a :=
+  (rfl)
+
+/-- The image of `a ∈ R[S_d]`, acting on `⨂[R]^d M` by permuting tensor factors, as a
+subrepresentation of the `d`-th tensor power of `ρ`. -/
+noncomputable def tensorPowerRange : Subrepresentation (ρ.tensorPower d) :=
+  (tensorPowerPermMap ρ d a).range
+
+/-- The submodule underlying `tensorPowerRange` is the range of the group-algebra action. -/
+theorem tensorPowerRange_toSubmodule :
+    (tensorPowerRange ρ d a).toSubmodule =
+      LinearMap.range ((PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a) :=
+  (rfl)
+
+/-- Membership in the image is the existence of a preimage under the group-algebra action. -/
+theorem mem_tensorPowerRange {x : ⨂[R]^d M} :
+    x ∈ tensorPowerRange ρ d a ↔
+      ∃ y, (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a y = x :=
+  Iff.rfl
+
+/-- Every value of the group-algebra action lies in its image. -/
+theorem apply_mem_tensorPowerRange (y : ⨂[R]^d M) :
+    (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a y ∈
+      tensorPowerRange ρ d a :=
+  ⟨y, rfl⟩
+
+/-- The identity of the group algebra cuts out the whole tensor power. -/
+@[simp]
+theorem tensorPowerRange_one : (tensorPowerRange ρ d 1).toSubmodule = ⊤ := by
+  rw [tensorPowerRange_toSubmodule, map_one]
+  exact LinearMap.range_eq_top.mpr fun x => ⟨x, rfl⟩
+
+/-- The zero of the group algebra cuts out the zero subrepresentation. -/
+@[simp]
+theorem tensorPowerRange_zero : (tensorPowerRange ρ d 0).toSubmodule = ⊥ := by
+  rw [tensorPowerRange_toSubmodule, map_zero, LinearMap.range_zero]
+
+/-- Multiplying on the right shrinks the image: `⨂^d M · a b ⊆ ⨂^d M · a`. -/
+theorem tensorPowerRange_mul_le :
+    (tensorPowerRange ρ d (a * b)).toSubmodule ≤ (tensorPowerRange ρ d a).toSubmodule := by
+  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul]
+  exact LinearMap.range_comp_le_range _ _
+
+/-- Conjugating the group-algebra element by a permutation moves the image by the corresponding
+permutation of the tensor factors. -/
+theorem tensorPowerRange_conj (σ : Equiv.Perm (Fin d)) :
+    (tensorPowerRange ρ d
+        (MonoidAlgebra.single σ 1 * a * MonoidAlgebra.single σ⁻¹ 1)).toSubmodule =
+      (tensorPowerRange ρ d a).toSubmodule.map
+        (PiTensorProduct.reindex R (fun _ : Fin d => M) σ : (⨂[R]^d M) →ₗ[R] (⨂[R]^d M)) := by
+  have hsurj :
+      LinearMap.range (PiTensorProduct.reindexRepresentation R M (Fin d) σ⁻¹) = ⊤ := by
+    rw [PiTensorProduct.reindexRepresentation_apply]
+    exact LinearEquiv.range _
+  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul, map_mul,
+    Representation.asAlgebraHom_single_one, Representation.asAlgebraHom_single_one,
+    Module.End.mul_eq_comp, Module.End.mul_eq_comp,
+    LinearMap.range_comp_of_range_eq_top _ hsurj, LinearMap.range_comp,
+    PiTensorProduct.reindexRepresentation_apply]
+
+end TensorPowerRange
+
+/-! ## The Weyl module of a Young tableau -/
+
+namespace YoungTableau
+
+variable (k : Type u) [CommRing k] [Algebra ℚ k] (n : ℕ) {μ : YoungDiagram}
+
+/-- The Young symmetrizer `c_t` with its rational coefficients transported into a `ℚ`-algebra
+`k`, so that it can act on a `k`-module. -/
+noncomputable def youngSymmetrizerOver (t : YoungTableau μ) :
+    MonoidAlgebra k (Equiv.Perm (Fin μ.card)) :=
+  MonoidAlgebra.mapAlgHom _ (Algebra.ofId ℚ k) (youngSymmetrizer t)
+
+/-- The coefficients of the transported Young symmetrizer are the images of the rational
+coefficients. -/
+@[simp]
+theorem youngSymmetrizerOver_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
+    (youngSymmetrizerOver k t).coeff σ = algebraMap ℚ k ((youngSymmetrizer t).coeff σ) := by
+  rw [youngSymmetrizerOver, MonoidAlgebra.coeff_mapAlgHom, Algebra.ofId_apply]
+
+/-- Relabeling by `σ` conjugates the transported Young symmetrizer, as it does the rational
+one. -/
+theorem youngSymmetrizerOver_relabel (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ) :
+    youngSymmetrizerOver k (relabel σ t) =
+      MonoidAlgebra.single σ 1 * youngSymmetrizerOver k t * MonoidAlgebra.single σ⁻¹ 1 := by
+  rw [youngSymmetrizerOver, youngSymmetrizer_relabel, map_mul, map_mul,
+    MonoidAlgebra.mapAlgHom_single, MonoidAlgebra.mapAlgHom_single, map_one]
+  rfl
+
+/-- **The Weyl module** of a `μ`-tableau `t`: the image of the Young symmetrizer `c_t` acting on
+the `|μ|`-fold tensor power of the standard representation of `GL n k`, a subrepresentation
+because the symmetric-group and general-linear actions commute.
+
+Fulton and Harris write this as `𝕊^μ(kⁿ)`, the value at `kⁿ` of the Schur functor of `μ`; only
+the value is built here, and no functoriality in the underlying module is claimed. -/
+noncomputable def weylModule (t : YoungTableau μ) :
+    Subrepresentation (tensorPowerRep k n μ.card) :=
+  tensorPowerRange (stdRep k n) μ.card (youngSymmetrizerOver k t)
+
+/-- The submodule underlying the Weyl module is the range of the Young symmetrizer acting on the
+tensor power. -/
+theorem weylModule_toSubmodule (t : YoungTableau μ) :
+    (weylModule k n t).toSubmodule =
+      LinearMap.range (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)) := by
+  rw [weylModule, tensorPowerRange_toSubmodule, permTensorActionAlgHom_def, permTensorAction_def]
+
+/-- Membership in the Weyl module is the existence of a preimage under the Young symmetrizer. -/
+theorem mem_weylModule {t : YoungTableau μ} {x : ⨂[k]^μ.card (Fin n → k)} :
+    x ∈ (weylModule k n t).toSubmodule ↔
+      ∃ y, permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) y = x := by
+  rw [weylModule_toSubmodule]
+  exact Iff.rfl
+
+/-- Every value of the Young symmetrizer on the tensor power lies in the Weyl module. -/
+theorem apply_mem_weylModule (t : YoungTableau μ) (y : ⨂[k]^μ.card (Fin n → k)) :
+    permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) y ∈
+      (weylModule k n t).toSubmodule :=
+  (mem_weylModule k n).mpr ⟨y, rfl⟩
+
+/-- The action of `GL n k` on the Weyl module. -/
+noncomputable abbrev weylRep (t : YoungTableau μ) :
+    Representation k (GL (Fin n) k) (weylModule k n t).toSubmodule :=
+  (weylModule k n t).toRepresentation
+
+/-- The action on the Weyl module is the restriction of the action on the tensor power. -/
+@[simp]
+theorem weylRep_apply_coe (t : YoungTableau μ) (g : GL (Fin n) k)
+    (x : (weylModule k n t).toSubmodule) :
+    ((weylRep k n t g x : (weylModule k n t).toSubmodule) : ⨂[k]^μ.card (Fin n → k)) =
+      tensorPowerRep k n μ.card g x :=
+  (rfl)
+
+/-! ### Independence of the tableau -/
+
+variable {k n}
+
+/-- Relabeling the tableau by `σ` moves the Weyl module by the permutation of the tensor factors
+that `σ` induces. -/
+theorem weylModule_relabel (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ) :
+    (weylModule k n (relabel σ t)).toSubmodule =
+      (weylModule k n t).toSubmodule.map (permTensorAction k n μ.card σ) := by
+  rw [weylModule, weylModule, youngSymmetrizerOver_relabel,
+    tensorPowerRange_conj (stdRep k n) μ.card (youngSymmetrizerOver k t) σ,
+    permTensorAction_apply]
+
+/-- Permuting the tensor factors by `σ` as a linear equivalence from the Weyl module of `t` to
+the Weyl module of the relabeled tableau `σt`. -/
+noncomputable def weylRelabelEquiv (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ) :
+    (weylModule k n t).toSubmodule ≃ₗ[k] (weylModule k n (relabel σ t)).toSubmodule :=
+  (PiTensorProduct.reindex k (fun _ : Fin μ.card => Fin n → k) σ).ofSubmodules _ _
+    (by rw [weylModule_relabel σ t, permTensorAction_apply])
+
+/-- The relabeling equivalence is induced by permuting the tensor factors. -/
+@[simp]
+theorem weylRelabelEquiv_apply_coe (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ)
+    (x : (weylModule k n t).toSubmodule) :
+    ((weylRelabelEquiv σ t x : (weylModule k n (relabel σ t)).toSubmodule) :
+        ⨂[k]^μ.card (Fin n → k)) = permTensorAction k n μ.card σ x := by
+  rw [permTensorAction_apply]
+  rfl
+
+/-- Permuting the tensor factors is `GL n k`-equivariant, so it is an isomorphism of
+representations from the Weyl module of `t` to the Weyl module of `σt`. -/
+noncomputable def weylRelabelRepEquiv (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ) :
+    (weylRep k n t).Equiv (weylRep k n (relabel σ t)) :=
+  Representation.Equiv.mk (weylRelabelEquiv σ t) fun g => by
+    ext x
+    have h := congrArg (fun f : Module.End k (⨂[k]^μ.card (Fin n → k)) =>
+        f (x : ⨂[k]^μ.card (Fin n → k)))
+      (commute_permTensorAction_tensorPowerRep k n μ.card σ g)
+    simp only [Module.End.mul_apply] at h
+    simpa only [LinearMap.coe_comp, Function.comp_apply, LinearEquiv.coe_coe,
+      weylRelabelEquiv_apply_coe, weylRep_apply_coe] using h
+
+/-- The Weyl modules of two tableaux of the same shape are isomorphic representations of
+`GL n k`: up to isomorphism the Weyl module depends only on the shape. -/
+noncomputable def weylRepEquiv (t t' : YoungTableau μ) :
+    (weylRep k n t).Equiv (weylRep k n t') :=
+  relabel_relabelPerm t t' ▸ weylRelabelRepEquiv (relabelPerm t t') t
+
+/-! ### The Weyl module of a shape with at most `n` rows is nonzero -/
+
+open Finset in
+/-- The Weyl module of a `μ`-tableau is nonzero as soon as `μ` has at most `n` rows.
+
+Evaluating the coordinate functional dual to `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}` on `c_t` applied to that
+same pure tensor, where `r ℓ` is the row of the label `ℓ`, leaves exactly the terms indexed by
+the row group of `t`, each with coefficient `1`; the value is therefore the order of the row
+group, which is nonzero because the base ring has characteristic zero. -/
+theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
+    (weylModule k n t).toSubmodule ≠ ⊥ := by
+  classical
+  haveI : CharZero k := charZero_of_injective_algebraMap (algebraMap ℚ k).injective
+  -- the row of each label, as an index of the standard basis of `kⁿ`
+  have hr : ∀ ℓ : Fin μ.card, rowIndex t ℓ < n := by
+    intro ℓ
+    have hmem : ((t.symm ℓ : ℕ × ℕ).1, (t.symm ℓ : ℕ × ℕ).2) ∈ μ := (t.symm ℓ).2
+    have h1 := YoungDiagram.mem_iff_lt_colLen.mp hmem
+    rw [rowIndex_def]
+    exact lt_of_lt_of_le (lt_of_lt_of_le h1 (μ.colLen_anti 0 _ (Nat.zero_le _))) hn
+  set r : Fin μ.card → Fin n := fun ℓ => ⟨rowIndex t ℓ, hr ℓ⟩ with hrdef
+  set φ : (⨂[k]^μ.card (Fin n → k)) →ₗ[k] k :=
+    PiTensorProduct.lift
+      ((MultilinearMap.mkPiAlgebra k (Fin μ.card) k).compLinearMap fun ℓ => LinearMap.proj (r ℓ))
+    with hφdef
+  have hφ : ∀ s : Fin μ.card → Fin n,
+      φ (PiTensorProduct.tprod k fun ℓ => Pi.single (s ℓ) (1 : k)) =
+        if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := by
+    intro s
+    rw [hφdef, PiTensorProduct.lift.tprod, MultilinearMap.compLinearMap_apply,
+      MultilinearMap.mkPiAlgebra_apply]
+    simp only [LinearMap.proj_apply, Pi.single_apply]
+    exact Finset.prod_boole.trans (by simp)
+  -- the row group is exactly the set of permutations surviving the evaluation
+  set S : Finset (Equiv.Perm (Fin μ.card)) := {σ | σ ∈ rowSubgroup t} with hSdef
+  have hmemS : ∀ σ : Equiv.Perm (Fin μ.card), σ ∈ S ↔ σ ∈ rowSubgroup t := by
+    intro σ; rw [hSdef]; simp
+  have hcond : ∀ σ : Equiv.Perm (Fin μ.card),
+      (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t := by
+    intro σ
+    rw [← inv_mem_iff (G := Equiv.Perm (Fin μ.card)), mem_rowSubgroup]
+    constructor
+    · intro h ℓ; exact (congrArg Fin.val (h ℓ)).symm
+    · intro h ℓ; exact Fin.ext (h ℓ).symm
+  -- evaluate the functional on the image of the standard pure tensor
+  set v : ⨂[k]^μ.card (Fin n → k) :=
+    PiTensorProduct.tprod k fun ℓ => Pi.single (r ℓ) (1 : k) with hvdef
+  have key : φ (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) v) = (S.card : k) := by
+    rw [hvdef, permTensorActionAlgHom_apply_tprod, map_finsuppSum]
+    have hterm : ∀ σ : Equiv.Perm (Fin μ.card), ∀ x : k,
+        φ (x • PiTensorProduct.tprod k fun i => Pi.single (r (σ.symm i)) (1 : k)) =
+          if σ ∈ rowSubgroup t then x else 0 := by
+      intro σ x
+      rw [map_smul, hφ (fun i => r (σ.symm i))]
+      by_cases h : σ ∈ rowSubgroup t
+      · rw [if_pos ((hcond σ).mpr h), if_pos h, smul_eq_mul, mul_one]
+      · rw [if_neg fun hc => h ((hcond σ).mp hc), if_neg h, smul_zero]
+    rw [Finsupp.sum_congr (g2 := fun σ x => if σ ∈ rowSubgroup t then x else 0)
+      fun σ _ => hterm σ _]
+    rw [Finsupp.sum]
+    have hcoeff : ∀ σ ∈ rowSubgroup t, (youngSymmetrizerOver k t).coeff σ = 1 := by
+      intro σ hσ
+      rw [youngSymmetrizerOver_coeff, youngSymmetrizer_coeff_of_mem_rowSubgroup t hσ, map_one]
+    have hsub : S ⊆ (youngSymmetrizerOver k t).coeff.support := by
+      intro σ hσ
+      rw [Finsupp.mem_support_iff, hcoeff σ ((hmemS σ).mp hσ)]
+      exact one_ne_zero
+    rw [Finset.sum_ite, Finset.sum_const_zero, add_zero]
+    have hfilter : (youngSymmetrizerOver k t).coeff.support.filter (· ∈ rowSubgroup t) = S := by
+      ext σ
+      simp only [Finset.mem_filter, hmemS]
+      exact ⟨fun h => h.2, fun h => ⟨hsub ((hmemS σ).mpr h), h⟩⟩
+    rw [hfilter, Finset.sum_congr rfl fun σ hσ => hcoeff σ ((hmemS σ).mp hσ), Finset.sum_const,
+      nsmul_eq_mul, mul_one]
+  intro hbot
+  have hmem := apply_mem_weylModule k n t v
+  rw [hbot, Submodule.mem_bot k] at hmem
+  rw [hmem, map_zero] at key
+  have hne : (S.card : k) ≠ 0 := by
+    refine Nat.cast_ne_zero.mpr (Finset.card_ne_zero_of_mem (a := 1) ?_)
+    exact (hmemS 1).mpr (one_mem _)
+  exact hne key.symm
+
+/-! ### Invariants of the Weyl module -/
+
+/-- The dimension of the Weyl module depends only on the shape of the tableau. -/
+theorem finrank_weylModule_eq (t t' : YoungTableau μ) :
+    Module.finrank k (weylModule k n t).toSubmodule =
+      Module.finrank k (weylModule k n t').toSubmodule :=
+  (weylRepEquiv t t').toLinearEquiv.finrank_eq
+
+/-- The Weyl module of a shape with at most `n` rows is nontrivial. -/
+theorem nontrivial_weylModule [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
+    Nontrivial (weylModule k n t).toSubmodule :=
+  Submodule.nontrivial_iff_ne_bot.mpr (weylModule_ne_bot t hn)
+
+end YoungTableau
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -45,12 +45,16 @@ of its labels carry the same basis index, so their transposition lies in the col
 fixes that pure tensor while negating `c_t`; the value is its own negative, hence zero because
 `2` is invertible.
 
-The Young symmetrizer is built over `ℚ`, so the coefficients are transported into the base ring
-along `algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout.  That alone makes
-`2` invertible, which is all the vanishing statement needs.  Nonvanishing needs characteristic
-zero, and a `ℚ`-algebra has characteristic zero as soon as it is nontrivial, so the nonvanishing
-statements carry a `Nontrivial` hypothesis instead.  This is the characteristic-zero setting the
-roadmap works in.
+The Young symmetrizer available here is the one built over `ℚ` in
+`TauCeti.YoungTableau.youngSymmetrizer`, so its coefficients reach the base ring along
+`algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout.  That is a consequence of
+how `c_t` is currently defined, not of `c_t` itself, whose coefficients are integral: an integral
+Young symmetrizer would let the construction run over any commutative ring, and building one is a
+separate topic.  What the two halves of the criterion actually use of the hypothesis is much
+less.  Vanishing needs only that `2` is invertible, which a `ℚ`-algebra gives.  Nonvanishing needs
+characteristic zero, and a `ℚ`-algebra has characteristic zero as soon as it is nontrivial, so the
+nonvanishing statements carry a `Nontrivial` hypothesis instead.  This is the characteristic-zero
+setting the roadmap works in.
 
 ## Main definitions
 
@@ -58,7 +62,7 @@ roadmap works in.
   `(kⁿ)^{⊗|μ|}`, with `weylRep` the action of `GL n k` on it.
 * `TauCeti.weylModuleOfShape`: the Weyl module of a shape, namely that of its row-superstandard
   tableau, with `weylRepOfShape` the action of `GL n k` on it and `weylFDRepOfShape` its bundled
-  finite-dimensional form over a field.
+  form in `FDRep`, over a Noetherian base ring.
 * `TauCeti.schurFunctor`: the roadmap-pinned name, `weylFDRepOfShape` at `k = ℂ`.
 
 ## Main results
@@ -122,8 +126,15 @@ noncomputable def weylModule (t : YoungTableau μ) :
     Subrepresentation (tensorPowerRep k n μ.card) :=
   tensorPowerRange (stdRep k n) μ.card (youngSymmetrizerOver k t)
 
+/-- The Weyl module is the image of the Young symmetrizer of `t` acting on the tensor power, so
+the general lemmas about `TauCeti.tensorPowerRange` apply to it. -/
+theorem weylModule_def (t : YoungTableau μ) :
+    weylModule k n t = tensorPowerRange (stdRep k n) μ.card (youngSymmetrizerOver k t) :=
+  (rfl)
+
 /-- The submodule underlying the Weyl module is the range of the Young symmetrizer acting on the
 tensor power. -/
+@[simp]
 theorem weylModule_toSubmodule (t : YoungTableau μ) :
     (weylModule k n t).toSubmodule =
       LinearMap.range (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)) := by
@@ -200,7 +211,7 @@ same pure tensor, where `r ℓ` is the row of the label `ℓ`, leaves exactly th
 the row group of `t`, each with coefficient `1`; the value is therefore the order of the row
 group, which is nonzero because the base ring has characteristic zero. -/
 theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
-    (weylModule k n t).toSubmodule ≠ ⊥ := by
+    weylModule k n t ≠ ⊥ := by
   classical
   haveI : CharZero k := charZero_of_injective_algebraMap (algebraMap ℚ k).injective
   -- the row of each label, as an index of the standard basis of `kⁿ`
@@ -252,7 +263,8 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
     rw [Finsupp.sum]
     have hcoeff : ∀ σ ∈ rowSubgroup t, (youngSymmetrizerOver k t).coeff σ = 1 := by
       intro σ hσ
-      rw [youngSymmetrizerOver_coeff, youngSymmetrizer_coeff_of_mem_rowSubgroup t hσ, map_one]
+      rw [youngSymmetrizerOver_coeff, youngSymmetrizer_coeff_eq_one_of_mem_rowSubgroup t hσ,
+        map_one]
     have hsub : S ⊆ (youngSymmetrizerOver k t).coeff.support := by
       intro σ hσ
       rw [Finsupp.mem_support_iff, hcoeff σ ((hmemS σ).mp hσ)]
@@ -265,11 +277,13 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
     rw [hfilter, Finset.sum_congr rfl fun σ hσ => hcoeff σ ((hmemS σ).mp hσ), Finset.sum_const,
       nsmul_eq_mul, mul_one]
   intro hbot
+  -- the submodule underlying the zero subrepresentation is `⊥`
+  have hbot' : (weylModule k n t).toSubmodule = ⊥ := by rw [hbot]; rfl
   have hmem : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) v ∈
       (weylModule k n t).toSubmodule := by
     rw [weylModule_toSubmodule]
     exact LinearMap.mem_range_self _ v
-  rw [hbot, Submodule.mem_bot k] at hmem
+  rw [hbot', Submodule.mem_bot k] at hmem
   rw [hmem, map_zero] at key
   have hne : (S.card : k) ≠ 0 := by
     refine Nat.cast_ne_zero.mpr (Finset.card_ne_zero_of_mem (a := 1) ?_)
@@ -285,8 +299,10 @@ that pure tensor while multiplying `c_t` on the right by it negates `c_t`.  The 
 the pure tensor is therefore its own negative, hence zero because `2` is invertible in a
 `ℚ`-algebra. -/
 theorem weylModule_eq_bot (t : YoungTableau μ) (hn : n < μ.colLen 0) :
-    (weylModule k n t).toSubmodule = ⊥ := by
+    weylModule k n t = ⊥ := by
   classical
+  -- subrepresentations are equal when their underlying submodules are
+  refine Subrepresentation.toSubmodule_injective ?_
   haveI : Invertible (2 : ℚ) := invertibleOfNonzero (by norm_num)
   haveI : Invertible (2 : k) := by
     have h := Invertible.map (algebraMap ℚ k) (2 : ℚ)
@@ -352,11 +368,13 @@ theorem weylModule_eq_bot (t : YoungTableau μ) (hn : n < μ.colLen 0) :
     have := congrArg (fun w => (⅟(2 : k)) • w) htwo
     simpa [smul_smul] using this
   rw [weylModule_toSubmodule, hzero, LinearMap.range_zero]
+  -- the submodule underlying the zero subrepresentation is `⊥`
+  rfl
 
 /-- **The vanishing criterion for the Weyl module**: it vanishes exactly when the shape has more
 rows than the dimension of the standard representation. -/
 theorem weylModule_eq_bot_iff [Nontrivial k] (t : YoungTableau μ) :
-    (weylModule k n t).toSubmodule = ⊥ ↔ n < μ.colLen 0 := by
+    weylModule k n t = ⊥ ↔ n < μ.colLen 0 := by
   refine ⟨fun h => ?_, weylModule_eq_bot t⟩
   by_contra hle
   exact weylModule_ne_bot t (not_lt.mp hle) h
@@ -372,8 +390,10 @@ theorem finrank_weylModule_eq (t t' : YoungTableau μ) :
 
 /-- The Weyl module of a shape with at most `n` rows is nontrivial. -/
 theorem nontrivial_weylModule [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
-    Nontrivial (weylModule k n t).toSubmodule :=
-  Submodule.nontrivial_iff_ne_bot.mpr (weylModule_ne_bot t hn)
+    Nontrivial (weylModule k n t).toSubmodule := by
+  refine Submodule.nontrivial_iff_ne_bot.mpr ?_
+  intro h
+  exact weylModule_ne_bot t hn (Subrepresentation.toSubmodule_injective h)
 
 end YoungTableau
 
@@ -393,6 +413,13 @@ noncomputable def weylModuleOfShape (μ : YoungDiagram) :
     Subrepresentation (tensorPowerRep k n μ.card) :=
   YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toEquiv
 
+/-- The Weyl module of a shape is the Weyl module of its row-superstandard tableau, so the
+tableau-indexed lemmas apply to it. -/
+theorem weylModuleOfShape_def (μ : YoungDiagram) :
+    weylModuleOfShape k n μ =
+      YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toEquiv :=
+  (rfl)
+
 /-- The action of `GL n k` on the Weyl module of a shape. -/
 noncomputable abbrev weylRepOfShape (μ : YoungDiagram) :
     Representation k (GL (Fin n) k) (weylModuleOfShape k n μ).toSubmodule :=
@@ -400,6 +427,7 @@ noncomputable abbrev weylRepOfShape (μ : YoungDiagram) :
 
 /-- The submodule underlying the Weyl module of a shape is the range of the Young symmetrizer of
 its row-superstandard tableau acting on the tensor power. -/
+@[simp]
 theorem weylModuleOfShape_toSubmodule (μ : YoungDiagram) :
     (weylModuleOfShape k n μ).toSubmodule =
       LinearMap.range (permTensorActionAlgHom k n μ.card
@@ -425,7 +453,7 @@ noncomputable def YoungTableau.weylRepEquivOfShape {μ : YoungDiagram} (t : Youn
 /-- **The vanishing criterion for the Weyl module of a shape**: it vanishes exactly when the
 shape has more rows than the dimension of the standard representation. -/
 theorem weylModuleOfShape_eq_bot_iff [Nontrivial k] (μ : YoungDiagram) :
-    (weylModuleOfShape k n μ).toSubmodule = ⊥ ↔ n < μ.colLen 0 :=
+    weylModuleOfShape k n μ = ⊥ ↔ n < μ.colLen 0 :=
   YoungTableau.weylModule_eq_bot_iff _
 
 /-- The Weyl module of a shape with at most `n` rows is nontrivial. -/
@@ -435,25 +463,27 @@ theorem nontrivial_weylModuleOfShape [Nontrivial k] (μ : YoungDiagram) (hn : μ
 
 end Shape
 
-section Field
+section Bundled
 
-variable (k : Type u) [Field k] [Algebra ℚ k] (n : ℕ)
+variable (k : Type u) [CommRing k] [Algebra ℚ k] [IsNoetherianRing k] (n : ℕ)
 
 /-- The Weyl module of a shape, bundled as an object of `FDRep`.
 
-A submodule of the tensor power is finitely generated only once the base ring is well behaved
-enough, so this bundled form asks for a field, whereas `weylModuleOfShape` itself does not. -/
+`FDRep` is the category of finitely generated representations over any ring, and a submodule of
+the tensor power is finitely generated as soon as the base ring is Noetherian, which is all this
+bundled form asks; a field is the case of interest, and is Noetherian. -/
 noncomputable abbrev weylFDRepOfShape (μ : YoungDiagram) : FDRep k (GL (Fin n) k) :=
   FDRep.of (V := (weylModuleOfShape k n μ).toSubmodule) (weylRepOfShape k n μ)
 
-end Field
+end Bundled
 
 /-- **The Schur functor** `𝕊^μ(ℂⁿ)` in the roadmap's pinned form: the Weyl module of the shape
 `μ` over `ℂ`, bundled as an object of `FDRep ℂ (GL (Fin n) ℂ)`.
 
 This is a definitional re-export of `TauCeti.weylFDRepOfShape` at `k = ℂ`, under the name later
-roadmap layers are written against; the general form, over any field that is a `ℚ`-algebra, is
-`TauCeti.weylFDRepOfShape`, and the unbundled construction is `TauCeti.weylModuleOfShape`. -/
+roadmap layers are written against; the general form, over any Noetherian commutative ring that
+is a `ℚ`-algebra, is `TauCeti.weylFDRepOfShape`, and the unbundled construction is
+`TauCeti.weylModuleOfShape`. -/
 noncomputable abbrev schurFunctor (n : ℕ) (μ : YoungDiagram) : FDRep ℂ (GL (Fin n) ℂ) :=
   weylFDRepOfShape ℂ n μ
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -84,6 +84,17 @@ roadmap works in.
   and only its value at `kⁿ` is built.  The pinned name is supplied as `TauCeti.schurFunctor`,
   the definitional re-export at `k = ℂ` of the bundled form, so that later roadmap layers can
   consume it under the name they are written against.
+
+  Of that bullet, the `GLₙ`-subrepresentation, the fixed choice of tableau, the canonical
+  isomorphism between the images for different tableaux, and the vanishing criterion are built
+  here.  The bullet's two remaining deliverables, the extreme cases `S^{(d)} V ≅ Symᵈ V` and
+  `S^{(1ᵈ)} V ≅ ⋀ᵈ V`, are deliberately left to a follow-up, because each first needs
+  infrastructure that exists neither in Mathlib nor here: a linear map `Sym[k]^d M →ₗ[k] ⨂[k]^d M`
+  descending the symmetrizer through `SymmetricPower.mk`, injectivity and naturality for
+  `exteriorPower.toTensorPower`, and the value of `c_t` at a one-row and at a one-column shape.
+  The follow-up can state and prove both against `TauCeti.weylModuleOfShape`,
+  `TauCeti.weylModuleOfShape_toSubmodule` and `TauCeti.weylRepOfShape` without unfolding anything
+  built here.
 -/
 
 public section

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -6,9 +6,10 @@ module
 
 public import Mathlib.Algebra.CharP.Algebra
 public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
-public import Mathlib.RepresentationTheory.Intertwining
+public import TauCeti.Combinatorics.Young.StandardTableau.Reading
 public import TauCeti.RepresentationTheory.ClassicalGroups.TensorPower
 public import TauCeti.RepresentationTheory.Symmetric.Relabel
+public import TauCeti.RepresentationTheory.Tensor.PermRange
 
 /-!
 # The Weyl construction: a Young symmetrizer cuts out a `GL n k`-subrepresentation
@@ -18,19 +19,20 @@ group: a Young symmetrizer `c_t ∈ ℚ[S_d]` acts on the tensor power `(kⁿ)^{
 tensor factors, and, because that action commutes with the diagonal action of `GL n k`, its
 image is a `GL n k`-subrepresentation.  This file builds that image, the **Weyl module** of `t`.
 
-The commuting-actions input is already available
-(`TauCeti.commute_permTensorActionAlgHom_tensorPowerRep`); what is built here is the image it
-cuts out.  The construction is done in two steps.  First, for an arbitrary representation `ρ` on
-`M`, acting on `⨂[R]^d M` by an element of `R[S_d]` is an intertwining map of `ρ.tensorPower d`
-with itself, so its image is a `Subrepresentation`; this is `TauCeti.tensorPowerRange`.  Second,
-specializing `ρ` to the standard representation of `GL n k` and the group-algebra element to a
-Young symmetrizer gives `TauCeti.YoungTableau.weylModule`.
+The two inputs are already available: the image of a group-algebra element on a tensor power, as
+a subrepresentation (`TauCeti.tensorPowerRange`, built from the commuting actions), and the
+Young symmetrizer transported into the base ring
+(`TauCeti.YoungTableau.youngSymmetrizerOver`).  Specializing the first to the standard
+representation of `GL n k` and the second to a Young symmetrizer gives
+`TauCeti.YoungTableau.weylModule`.
 
 Two facts make the construction usable.  Relabeling the tableau moves the Weyl module by the
 corresponding factor permutation, which is itself `GL n k`-equivariant, so the Weyl modules of
 two tableaux of the same shape are isomorphic representations
 (`TauCeti.YoungTableau.weylRepEquiv`): up to isomorphism the Weyl module depends only on the
-shape.  And the Weyl module is nonzero exactly when the shape has at most `n` rows
+shape.  That is what makes the shape-indexed form `TauCeti.weylModuleOfShape`, the Weyl module of
+the row-superstandard tableau of `μ`, a legitimate representative of them all.  And the Weyl
+module is nonzero exactly when the shape has at most `n` rows
 (`TauCeti.YoungTableau.weylModule_eq_bot_iff`).  Nonvanishing
 (`TauCeti.YoungTableau.weylModule_ne_bot`) is proved by evaluating a coordinate functional on
 `c_t · (e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)})`, where `r` records the row of each label: the surviving terms
@@ -42,22 +44,25 @@ fixes that pure tensor while negating `c_t`; the value is its own negative, henc
 `2` is invertible.
 
 The Young symmetrizer is built over `ℚ`, so the coefficients are transported into the base ring
-along `algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout, which is the
-characteristic-zero setting the roadmap works in.
+along `algebraMap ℚ k`; the base ring is therefore a `ℚ`-algebra throughout.  That alone makes
+`2` invertible, which is all the vanishing statement needs.  Nonvanishing needs characteristic
+zero, and a `ℚ`-algebra has characteristic zero as soon as it is nontrivial, so the nonvanishing
+statements carry a `Nontrivial` hypothesis instead.  This is the characteristic-zero setting the
+roadmap works in.
 
 ## Main definitions
 
-* `TauCeti.tensorPowerRange`: the image of an element of `R[S_d]` acting on `⨂[R]^d M` by
-  permuting tensor factors, as a subrepresentation of the tensor power of any representation.
-* `TauCeti.YoungTableau.youngSymmetrizerOver`: the Young symmetrizer with its rational
-  coefficients transported into a `ℚ`-algebra.
 * `TauCeti.YoungTableau.weylModule`: the Weyl module of a tableau, a subrepresentation of
   `(kⁿ)^{⊗|μ|}`, with `weylRep` the action of `GL n k` on it.
+* `TauCeti.weylModuleOfShape`: the Weyl module of a shape, namely that of its row-superstandard
+  tableau, with `weylRepOfShape` the action of `GL n k` on it and `weylFDRepOfShape` its bundled
+  finite-dimensional form over a field.
 
 ## Main results
 
 * `TauCeti.YoungTableau.weylRepEquiv`: the Weyl modules of two tableaux of the same shape are
-  isomorphic representations of `GL n k`.
+  isomorphic representations of `GL n k`, and `TauCeti.YoungTableau.weylRepEquivOfShape`
+  identifies each of them with the shape-indexed one.
 * `TauCeti.YoungTableau.weylModule_ne_bot`: the Weyl module is nonzero when the shape has at
   most `n` rows.
 * `TauCeti.YoungTableau.weylModule_eq_bot`: the Weyl module vanishes when the shape has more
@@ -81,120 +86,15 @@ public section
 open Matrix
 open scoped TensorProduct
 
-universe u v w
+universe u
 
 namespace TauCeti
-
-/-! ## The image of a group-algebra element on a tensor power -/
-
-section TensorPowerRange
-
-variable {R : Type u} {G : Type v} {M : Type w}
-variable [CommSemiring R] [Monoid G] [AddCommMonoid M] [Module R M]
-variable (ρ : Representation R G M) (d : ℕ) (a b : MonoidAlgebra R (Equiv.Perm (Fin d)))
-
-/-- Acting on `⨂[R]^d M` by an element of `R[S_d]`, permuting tensor factors, is an intertwining
-map of the diagonal action of `ρ` on the tensor power with itself: the two actions commute. -/
-noncomputable def tensorPowerPermMap :
-    Representation.IntertwiningMap (ρ.tensorPower d) (ρ.tensorPower d) where
-  toLinearMap := (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a
-  isIntertwining' g := by
-    rw [Representation.tensorPower_apply]
-    exact PiTensorProduct.commute_reindexRepresentation_asAlgebraHom_map R M (Fin d) a (ρ g)
-
-/-- The linear map underlying the tensor-power action of a group-algebra element. -/
-@[simp]
-theorem tensorPowerPermMap_toLinearMap :
-    (tensorPowerPermMap ρ d a).toLinearMap =
-      (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a :=
-  (rfl)
-
-/-- The image of `a ∈ R[S_d]`, acting on `⨂[R]^d M` by permuting tensor factors, as a
-subrepresentation of the `d`-th tensor power of `ρ`. -/
-noncomputable def tensorPowerRange : Subrepresentation (ρ.tensorPower d) :=
-  (tensorPowerPermMap ρ d a).range
-
-/-- The submodule underlying `tensorPowerRange` is the range of the group-algebra action. -/
-theorem tensorPowerRange_toSubmodule :
-    (tensorPowerRange ρ d a).toSubmodule =
-      LinearMap.range ((PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a) :=
-  (rfl)
-
-/-- Membership in the image is the existence of a preimage under the group-algebra action. -/
-theorem mem_tensorPowerRange {x : ⨂[R]^d M} :
-    x ∈ tensorPowerRange ρ d a ↔
-      ∃ y, (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a y = x :=
-  Iff.rfl
-
-/-- Every value of the group-algebra action lies in its image. -/
-theorem apply_mem_tensorPowerRange (y : ⨂[R]^d M) :
-    (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a y ∈
-      tensorPowerRange ρ d a :=
-  ⟨y, rfl⟩
-
-/-- The identity of the group algebra cuts out the whole tensor power. -/
-@[simp]
-theorem tensorPowerRange_one : (tensorPowerRange ρ d 1).toSubmodule = ⊤ := by
-  rw [tensorPowerRange_toSubmodule, map_one]
-  exact LinearMap.range_eq_top.mpr fun x => ⟨x, rfl⟩
-
-/-- The zero of the group algebra cuts out the zero subrepresentation. -/
-@[simp]
-theorem tensorPowerRange_zero : (tensorPowerRange ρ d 0).toSubmodule = ⊥ := by
-  rw [tensorPowerRange_toSubmodule, map_zero, LinearMap.range_zero]
-
-/-- Multiplying on the right shrinks the image: `⨂^d M · a b ⊆ ⨂^d M · a`. -/
-theorem tensorPowerRange_mul_le :
-    (tensorPowerRange ρ d (a * b)).toSubmodule ≤ (tensorPowerRange ρ d a).toSubmodule := by
-  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul]
-  exact LinearMap.range_comp_le_range _ _
-
-/-- Conjugating the group-algebra element by a permutation moves the image by the corresponding
-permutation of the tensor factors. -/
-theorem tensorPowerRange_conj (σ : Equiv.Perm (Fin d)) :
-    (tensorPowerRange ρ d
-        (MonoidAlgebra.single σ 1 * a * MonoidAlgebra.single σ⁻¹ 1)).toSubmodule =
-      (tensorPowerRange ρ d a).toSubmodule.map
-        (PiTensorProduct.reindex R (fun _ : Fin d => M) σ : (⨂[R]^d M) →ₗ[R] (⨂[R]^d M)) := by
-  have hsurj :
-      LinearMap.range (PiTensorProduct.reindexRepresentation R M (Fin d) σ⁻¹) = ⊤ := by
-    rw [PiTensorProduct.reindexRepresentation_apply]
-    exact LinearEquiv.range _
-  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul, map_mul,
-    Representation.asAlgebraHom_single_one, Representation.asAlgebraHom_single_one,
-    Module.End.mul_eq_comp, Module.End.mul_eq_comp,
-    LinearMap.range_comp_of_range_eq_top _ hsurj, LinearMap.range_comp,
-    PiTensorProduct.reindexRepresentation_apply]
-
-end TensorPowerRange
 
 /-! ## The Weyl module of a Young tableau -/
 
 namespace YoungTableau
 
 variable (k : Type u) [CommRing k] [Algebra ℚ k] (n : ℕ) {μ : YoungDiagram}
-
-/-- The Young symmetrizer `c_t` with its rational coefficients transported into a `ℚ`-algebra
-`k`, so that it can act on a `k`-module. -/
-noncomputable def youngSymmetrizerOver (t : YoungTableau μ) :
-    MonoidAlgebra k (Equiv.Perm (Fin μ.card)) :=
-  MonoidAlgebra.mapAlgHom _ (Algebra.ofId ℚ k) (youngSymmetrizer t)
-
-/-- The coefficients of the transported Young symmetrizer are the images of the rational
-coefficients. -/
-@[simp]
-theorem youngSymmetrizerOver_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
-    (youngSymmetrizerOver k t).coeff σ = algebraMap ℚ k ((youngSymmetrizer t).coeff σ) := by
-  rw [youngSymmetrizerOver, MonoidAlgebra.coeff_mapAlgHom, Algebra.ofId_apply]
-
-/-- Relabeling by `σ` conjugates the transported Young symmetrizer, as it does the rational
-one. -/
-theorem youngSymmetrizerOver_relabel (σ : Equiv.Perm (Fin μ.card)) (t : YoungTableau μ) :
-    youngSymmetrizerOver k (relabel σ t) =
-      MonoidAlgebra.single σ 1 * youngSymmetrizerOver k t * MonoidAlgebra.single σ⁻¹ 1 := by
-  rw [youngSymmetrizerOver, youngSymmetrizer_relabel, map_mul, map_mul,
-    MonoidAlgebra.mapAlgHom_single, MonoidAlgebra.mapAlgHom_single, map_one]
-  rfl
 
 /-- **The Weyl module** of a `μ`-tableau `t`: the image of the Young symmetrizer `c_t` acting on
 the `|μ|`-fold tensor power of the standard representation of `GL n k`, a subrepresentation
@@ -212,19 +112,6 @@ theorem weylModule_toSubmodule (t : YoungTableau μ) :
     (weylModule k n t).toSubmodule =
       LinearMap.range (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)) := by
   rw [weylModule, tensorPowerRange_toSubmodule, permTensorActionAlgHom_def, permTensorAction_def]
-
-/-- Membership in the Weyl module is the existence of a preimage under the Young symmetrizer. -/
-theorem mem_weylModule {t : YoungTableau μ} {x : ⨂[k]^μ.card (Fin n → k)} :
-    x ∈ (weylModule k n t).toSubmodule ↔
-      ∃ y, permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) y = x := by
-  rw [weylModule_toSubmodule]
-  exact Iff.rfl
-
-/-- Every value of the Young symmetrizer on the tensor power lies in the Weyl module. -/
-theorem apply_mem_weylModule (t : YoungTableau μ) (y : ⨂[k]^μ.card (Fin n → k)) :
-    permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) y ∈
-      (weylModule k n t).toSubmodule :=
-  (mem_weylModule k n).mpr ⟨y, rfl⟩
 
 /-- The action of `GL n k` on the Weyl module. -/
 noncomputable abbrev weylRep (t : YoungTableau μ) :
@@ -362,7 +249,10 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
     rw [hfilter, Finset.sum_congr rfl fun σ hσ => hcoeff σ ((hmemS σ).mp hσ), Finset.sum_const,
       nsmul_eq_mul, mul_one]
   intro hbot
-  have hmem := apply_mem_weylModule k n t v
+  have hmem : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) v ∈
+      (weylModule k n t).toSubmodule := by
+    rw [weylModule_toSubmodule]
+    exact LinearMap.mem_range_self _ v
   rw [hbot, Submodule.mem_bot k] at hmem
   rw [hmem, map_zero] at key
   have hne : (S.card : k) ≠ 0 := by
@@ -423,7 +313,7 @@ theorem weylModule_eq_bot (t : YoungTableau μ) (hn : n < μ.colLen 0) :
               MonoidAlgebra.single (Equiv.swap (a : Fin μ.card) (b : Fin μ.card)) 1 =
             -youngSymmetrizer t)
       rw [map_mul, map_neg, MonoidAlgebra.mapAlgHom_single, map_one] at h'
-      exact h'
+      rwa [youngSymmetrizerOver_def]
     -- so the value of the symmetrizer on the pure tensor is its own negative
     have h : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t *
           MonoidAlgebra.single (Equiv.swap (a : Fin μ.card) (b : Fin μ.card)) 1)
@@ -457,7 +347,8 @@ theorem weylModule_eq_bot_iff [Nontrivial k] (t : YoungTableau μ) :
 
 /-! ### Invariants of the Weyl module -/
 
-/-- The dimension of the Weyl module depends only on the shape of the tableau. -/
+/-- The Weyl modules of two tableaux of the same shape are isomorphic `k`-modules, so their
+`Module.finrank` values agree; over a field this is the equality of their dimensions. -/
 theorem finrank_weylModule_eq (t t' : YoungTableau μ) :
     Module.finrank k (weylModule k n t).toSubmodule =
       Module.finrank k (weylModule k n t').toSubmodule :=
@@ -469,5 +360,47 @@ theorem nontrivial_weylModule [Nontrivial k] (t : YoungTableau μ) (hn : μ.colL
   Submodule.nontrivial_iff_ne_bot.mpr (weylModule_ne_bot t hn)
 
 end YoungTableau
+
+/-! ## The Weyl module of a shape -/
+
+section Shape
+
+variable (k : Type u) [CommRing k] [Algebra ℚ k] (n : ℕ)
+
+/-- **The Weyl module of a shape** `μ`: the Weyl module of the row-superstandard tableau of `μ`,
+the canonical `μ`-tableau.  Since the Weyl modules of two `μ`-tableaux are isomorphic
+representations, this is a legitimate shape-indexed representative of them all; the
+identification is `TauCeti.YoungTableau.weylRepEquivOfShape`.
+
+This is the object the classical-groups roadmap pins as `schurFunctor n μ`. -/
+noncomputable def weylModuleOfShape (μ : YoungDiagram) :
+    Subrepresentation (tensorPowerRep k n μ.card) :=
+  YoungTableau.weylModule k n (StandardYoungTableau.rowSuperstandard μ).toEquiv
+
+/-- The action of `GL n k` on the Weyl module of a shape. -/
+noncomputable abbrev weylRepOfShape (μ : YoungDiagram) :
+    Representation k (GL (Fin n) k) (weylModuleOfShape k n μ).toSubmodule :=
+  (weylModuleOfShape k n μ).toRepresentation
+
+/-- The Weyl module of any `μ`-tableau is isomorphic, as a representation of `GL n k`, to the
+Weyl module of the shape `μ`. -/
+noncomputable def YoungTableau.weylRepEquivOfShape {μ : YoungDiagram} (t : YoungTableau μ) :
+    (YoungTableau.weylRep k n t).Equiv (weylRepOfShape k n μ) :=
+  YoungTableau.weylRepEquiv t _
+
+end Shape
+
+section Field
+
+variable (k : Type u) [Field k] [Algebra ℚ k] (n : ℕ)
+
+/-- The Weyl module of a shape, bundled as an object of `FDRep`.
+
+A submodule of the tensor power is finitely generated only once the base ring is well behaved
+enough, so this bundled form asks for a field, whereas `weylModuleOfShape` itself does not. -/
+noncomputable abbrev weylFDRepOfShape (μ : YoungDiagram) : FDRep k (GL (Fin n) k) :=
+  FDRep.of (V := (weylModuleOfShape k n μ).toSubmodule) (weylRepOfShape k n μ)
+
+end Field
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Relabel.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Relabel.lean
@@ -28,7 +28,8 @@ character, depend only on the shape of `t`.
 ## Main results
 
 * `YoungTableau.youngSymmetrizer_relabel`: the Young symmetrizer of a relabeled tableau is the
-  conjugate of the Young symmetrizer.
+  conjugate of the Young symmetrizer, and `YoungTableau.youngSymmetrizerOver_relabel` says the
+  same for its transport to a `ℚ`-algebra.
 * `YoungTableau.spechtIdealRelabelRepEquiv`: right multiplication by `σ` as an isomorphism of
   representations `ℚ[Sₙ] c_{σt} ≅ ℚ[Sₙ] c_t`.
 * `YoungTableau.spechtIdealRepIso`, `YoungTableau.finrank_spechtIdeal_eq` and
@@ -152,6 +153,14 @@ theorem youngSymmetrizer_relabel :
     columnAntisymmetrizer_relabel]
   simp only [mul_assoc]
   rw [← mul_assoc (MonoidAlgebra.single σ⁻¹ (1 : ℚ)), hσ, one_mul]
+
+/-- Relabeling by `σ` conjugates the transported Young symmetrizer, as it does the rational
+one. -/
+theorem youngSymmetrizerOver_relabel (k : Type*) [CommSemiring k] [Algebra ℚ k] :
+    youngSymmetrizerOver k (relabel σ t) =
+      MonoidAlgebra.single σ 1 * youngSymmetrizerOver k t * MonoidAlgebra.single σ⁻¹ 1 := by
+  rw [youngSymmetrizerOver_def, youngSymmetrizerOver_def, youngSymmetrizer_relabel, map_mul,
+    map_mul, MonoidAlgebra.mapAlgHom_single, MonoidAlgebra.mapAlgHom_single, map_one]
 
 /-! ## The Young-symmetrizer left ideal of a relabeled tableau -/
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -22,6 +22,10 @@ sign character.  In particular, each factor squares to its subgroup order times 
 These are the elementary inputs to the essential-idempotence theorem for `c_t` and the
 construction of Specht modules.
 
+The symmetrizers are built over `ℚ`.  Constructions that let `c_t` act on a module over some
+other ring need its coefficients transported there, which is `youngSymmetrizerOver`; the target
+ring is a `ℚ`-algebra, since the coefficients of `c_t` are genuinely rational.
+
 ## References
 
 * [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 2.
@@ -273,6 +277,32 @@ theorem youngSymmetrizer_ne_zero (t : YoungTableau μ) :
   have := congrArg (fun x =>
     x.coeff (1 : Equiv.Perm (Fin μ.card))) h
   simp at this
+
+section Transport
+
+variable (k : Type*) [CommSemiring k] [Algebra ℚ k]
+
+/-- The Young symmetrizer `c_t` with its rational coefficients transported into a `ℚ`-algebra
+`k`, so that it can act on a `k`-module. -/
+noncomputable def youngSymmetrizerOver (t : YoungTableau μ) :
+    MonoidAlgebra k (Equiv.Perm (Fin μ.card)) :=
+  MonoidAlgebra.mapAlgHom _ (Algebra.ofId ℚ k) (youngSymmetrizer t)
+
+/-- The transport of a Young symmetrizer applies the structure map of the algebra to every
+coefficient. -/
+theorem youngSymmetrizerOver_def (t : YoungTableau μ) :
+    youngSymmetrizerOver k t =
+      MonoidAlgebra.mapAlgHom _ (Algebra.ofId ℚ k) (youngSymmetrizer t) :=
+  (rfl)
+
+/-- The coefficients of the transported Young symmetrizer are the images of the rational
+coefficients. -/
+@[simp]
+theorem youngSymmetrizerOver_coeff (t : YoungTableau μ) (σ : Equiv.Perm (Fin μ.card)) :
+    (youngSymmetrizerOver k t).coeff σ = algebraMap ℚ k ((youngSymmetrizer t).coeff σ) := by
+  rw [youngSymmetrizerOver_def, MonoidAlgebra.coeff_mapAlgHom, Algebra.ofId_apply]
+
+end Transport
 
 end
 

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -256,6 +256,15 @@ theorem youngSymmetrizer_coeff_one (t : YoungTableau μ) :
   · exact fun p _ hp => by simp [hp]
   · simp
 
+/-- The coefficient of a row-group permutation in a Young symmetrizer is one: the row group
+translates `c_t` to itself, so all of its coefficients on the row group agree with the
+coefficient at the identity. -/
+theorem youngSymmetrizer_coeff_of_mem_rowSubgroup (t : YoungTableau μ)
+    {p : Equiv.Perm (Fin μ.card)} (hp : p ∈ rowSubgroup t) :
+    (youngSymmetrizer t).coeff p = 1 := by
+  have h := congrArg (fun x => MonoidAlgebra.coeff x p) (mul_youngSymmetrizer_left t ⟨p, hp⟩)
+  simpa using h.symm
+
 /-- A Young symmetrizer is nonzero. -/
 @[simp]
 theorem youngSymmetrizer_ne_zero (t : YoungTableau μ) :

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -22,9 +22,14 @@ sign character.  In particular, each factor squares to its subgroup order times 
 These are the elementary inputs to the essential-idempotence theorem for `c_t` and the
 construction of Specht modules.
 
-The symmetrizers are built over `ℚ`.  Constructions that let `c_t` act on a module over some
-other ring need its coefficients transported there, which is `youngSymmetrizerOver`; the target
-ring is a `ℚ`-algebra, since the coefficients of `c_t` are genuinely rational.
+The symmetrizers are built over `ℚ`, which is what the essential-idempotence theorem and the
+Specht-module constructions downstream of this file work over.  The coefficients of `c_t` are in
+fact integral -- each is a sum of signs -- so nothing about `c_t` itself demands rational
+coefficients; it is *this* definition, over `ℚ`, whose coefficients are transported when `c_t` is
+made to act on a module over another ring, which is `youngSymmetrizerOver`.  That transport goes
+along `algebraMap ℚ k`, so it asks the target ring to be a `ℚ`-algebra.  The restriction is one
+of the present implementation, not of the mathematics: an integral `c_t`, over `ℤ` or over an
+arbitrary commutative ring, would remove it, and is a separate construction.
 
 ## References
 
@@ -263,7 +268,7 @@ theorem youngSymmetrizer_coeff_one (t : YoungTableau μ) :
 /-- The coefficient of a row-group permutation in a Young symmetrizer is one: the row group
 translates `c_t` to itself, so all of its coefficients on the row group agree with the
 coefficient at the identity. -/
-theorem youngSymmetrizer_coeff_of_mem_rowSubgroup (t : YoungTableau μ)
+theorem youngSymmetrizer_coeff_eq_one_of_mem_rowSubgroup (t : YoungTableau μ)
     {p : Equiv.Perm (Fin μ.card)} (hp : p ∈ rowSubgroup t) :
     (youngSymmetrizer t).coeff p = 1 := by
   have h := congrArg (fun x => MonoidAlgebra.coeff x p) (mul_youngSymmetrizer_left t ⟨p, hp⟩)
@@ -282,8 +287,11 @@ section Transport
 
 variable (k : Type*) [CommSemiring k] [Algebra ℚ k]
 
-/-- The Young symmetrizer `c_t` with its rational coefficients transported into a `ℚ`-algebra
-`k`, so that it can act on a `k`-module. -/
+/-- The Young symmetrizer `c_t` with the coefficients of its rational form transported into a
+`ℚ`-algebra `k`, so that it can act on a `k`-module.
+
+The `ℚ`-algebra hypothesis comes from `youngSymmetrizer` being defined over `ℚ` here, not from
+`c_t`, whose coefficients are integral. -/
 noncomputable def youngSymmetrizerOver (t : YoungTableau μ) :
     MonoidAlgebra k (Equiv.Perm (Fin μ.card)) :=
   MonoidAlgebra.mapAlgHom _ (Algebra.ofId ℚ k) (youngSymmetrizer t)

--- a/TauCeti/RepresentationTheory/Tensor/PermRange.lean
+++ b/TauCeti/RepresentationTheory/Tensor/PermRange.lean
@@ -1,0 +1,109 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.Intertwining
+public import TauCeti.RepresentationTheory.Symmetric.TensorAction.Basic
+public import TauCeti.RepresentationTheory.Tensor.Power
+
+/-!
+# The image of a group-algebra element acting on a tensor power
+
+Permuting the tensor factors of `⨂[R]^d M` commutes with the diagonal action of a representation
+`ρ` on `M`, so an element `a` of the group algebra `R[S_d]` acts on the tensor power by an
+intertwining map of `ρ.tensorPower d` with itself.  Its image is therefore a subrepresentation of
+the tensor power.  This file records that image and the elementary ways it depends on `a`: the
+identity cuts out the whole tensor power, the zero cuts out `⊥`, multiplying on the right shrinks
+the image, and conjugating by a permutation moves the image by that permutation of the factors.
+
+Nothing here is specific to Young symmetrizers; taking `a` to be one is the Weyl construction.
+
+## Main definitions
+
+* `TauCeti.tensorPowerPermMap`: acting on `⨂[R]^d M` by an element of `R[S_d]`, as an
+  intertwining map of the tensor power with itself.
+* `TauCeti.tensorPowerRange`: the image of that map, as a subrepresentation.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 2, "Young symmetrizers and the Schur functor", whose Weyl-module target consumes this
+  construction.
+-/
+
+public section
+
+open scoped TensorProduct
+
+universe u v w
+
+namespace TauCeti
+
+variable {R : Type u} {G : Type v} {M : Type w}
+variable [CommSemiring R] [Monoid G] [AddCommMonoid M] [Module R M]
+variable (ρ : Representation R G M) (d : ℕ) (a b : MonoidAlgebra R (Equiv.Perm (Fin d)))
+
+/-- Acting on `⨂[R]^d M` by an element of `R[S_d]`, permuting tensor factors, is an intertwining
+map of the diagonal action of `ρ` on the tensor power with itself: the two actions commute. -/
+noncomputable def tensorPowerPermMap :
+    Representation.IntertwiningMap (ρ.tensorPower d) (ρ.tensorPower d) where
+  toLinearMap := (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a
+  isIntertwining' g := by
+    rw [Representation.tensorPower_apply]
+    exact PiTensorProduct.commute_reindexRepresentation_asAlgebraHom_map R M (Fin d) a (ρ g)
+
+/-- The linear map underlying the tensor-power action of a group-algebra element. -/
+@[simp]
+theorem tensorPowerPermMap_toLinearMap :
+    (tensorPowerPermMap ρ d a).toLinearMap =
+      (PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a :=
+  (rfl)
+
+/-- The image of `a ∈ R[S_d]`, acting on `⨂[R]^d M` by permuting tensor factors, as a
+subrepresentation of the `d`-th tensor power of `ρ`. -/
+noncomputable def tensorPowerRange : Subrepresentation (ρ.tensorPower d) :=
+  (tensorPowerPermMap ρ d a).range
+
+/-- The submodule underlying `tensorPowerRange` is the range of the group-algebra action. -/
+theorem tensorPowerRange_toSubmodule :
+    (tensorPowerRange ρ d a).toSubmodule =
+      LinearMap.range ((PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a) :=
+  (rfl)
+
+/-- The identity of the group algebra cuts out the whole tensor power. -/
+@[simp]
+theorem tensorPowerRange_one : (tensorPowerRange ρ d 1).toSubmodule = ⊤ := by
+  rw [tensorPowerRange_toSubmodule, map_one]
+  exact LinearMap.range_eq_top.mpr fun x => ⟨x, rfl⟩
+
+/-- The zero of the group algebra cuts out the zero subrepresentation. -/
+@[simp]
+theorem tensorPowerRange_zero : (tensorPowerRange ρ d 0).toSubmodule = ⊥ := by
+  rw [tensorPowerRange_toSubmodule, map_zero, LinearMap.range_zero]
+
+/-- Multiplying on the right shrinks the image: `⨂^d M · a b ⊆ ⨂^d M · a`. -/
+theorem tensorPowerRange_mul_le :
+    (tensorPowerRange ρ d (a * b)).toSubmodule ≤ (tensorPowerRange ρ d a).toSubmodule := by
+  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul]
+  exact LinearMap.range_comp_le_range _ _
+
+/-- Conjugating the group-algebra element by a permutation moves the image by the corresponding
+permutation of the tensor factors. -/
+theorem tensorPowerRange_conj (σ : Equiv.Perm (Fin d)) :
+    (tensorPowerRange ρ d
+        (MonoidAlgebra.single σ 1 * a * MonoidAlgebra.single σ⁻¹ 1)).toSubmodule =
+      (tensorPowerRange ρ d a).toSubmodule.map
+        (PiTensorProduct.reindex R (fun _ : Fin d => M) σ : (⨂[R]^d M) →ₗ[R] (⨂[R]^d M)) := by
+  have hsurj :
+      LinearMap.range (PiTensorProduct.reindexRepresentation R M (Fin d) σ⁻¹) = ⊤ := by
+    rw [PiTensorProduct.reindexRepresentation_apply]
+    exact LinearEquiv.range _
+  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul, map_mul,
+    Representation.asAlgebraHom_single_one, Representation.asAlgebraHom_single_one,
+    Module.End.mul_eq_comp, Module.End.mul_eq_comp,
+    LinearMap.range_comp_of_range_eq_top _ hsurj, LinearMap.range_comp,
+    PiTensorProduct.reindexRepresentation_apply]
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Tensor/PermRange.lean
+++ b/TauCeti/RepresentationTheory/Tensor/PermRange.lean
@@ -67,6 +67,7 @@ noncomputable def tensorPowerRange : Subrepresentation (ρ.tensorPower d) :=
   (tensorPowerPermMap ρ d a).range
 
 /-- The submodule underlying `tensorPowerRange` is the range of the group-algebra action. -/
+@[simp]
 theorem tensorPowerRange_toSubmodule :
     (tensorPowerRange ρ d a).toSubmodule =
       LinearMap.range ((PiTensorProduct.reindexRepresentation R M (Fin d)).asAlgebraHom a) :=
@@ -74,20 +75,26 @@ theorem tensorPowerRange_toSubmodule :
 
 /-- The identity of the group algebra cuts out the whole tensor power. -/
 @[simp]
-theorem tensorPowerRange_one : (tensorPowerRange ρ d 1).toSubmodule = ⊤ := by
-  rw [tensorPowerRange_toSubmodule, map_one]
-  exact LinearMap.range_eq_top.mpr fun x => ⟨x, rfl⟩
+theorem tensorPowerRange_one : tensorPowerRange ρ d 1 = ⊤ :=
+  Subrepresentation.toSubmodule_injective <| by
+    rw [tensorPowerRange_toSubmodule, map_one]
+    exact LinearMap.range_eq_top.mpr fun x => ⟨x, rfl⟩
 
 /-- The zero of the group algebra cuts out the zero subrepresentation. -/
 @[simp]
-theorem tensorPowerRange_zero : (tensorPowerRange ρ d 0).toSubmodule = ⊥ := by
-  rw [tensorPowerRange_toSubmodule, map_zero, LinearMap.range_zero]
+theorem tensorPowerRange_zero : tensorPowerRange ρ d 0 = ⊥ :=
+  Subrepresentation.toSubmodule_injective <| by
+    rw [tensorPowerRange_toSubmodule, map_zero, LinearMap.range_zero]
+    -- the submodule underlying the zero subrepresentation is `⊥`
+    rfl
 
 /-- Multiplying on the right shrinks the image: `⨂^d M · a b ⊆ ⨂^d M · a`. -/
-theorem tensorPowerRange_mul_le :
-    (tensorPowerRange ρ d (a * b)).toSubmodule ≤ (tensorPowerRange ρ d a).toSubmodule := by
-  rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul]
-  exact LinearMap.range_comp_le_range _ _
+theorem tensorPowerRange_mul_le : tensorPowerRange ρ d (a * b) ≤ tensorPowerRange ρ d a := by
+  have h : (tensorPowerRange ρ d (a * b)).toSubmodule ≤ (tensorPowerRange ρ d a).toSubmodule := by
+    rw [tensorPowerRange_toSubmodule, tensorPowerRange_toSubmodule, map_mul]
+    exact LinearMap.range_comp_le_range _ _
+  -- the order on subrepresentations is inclusion of the underlying submodules
+  exact fun x hx => h hx
 
 /-- Conjugating the group-algebra element by a permutation moves the image by the corresponding
 permutation of the tensor factors. -/


### PR DESCRIPTION
This PR builds the Weyl construction: the image of a Young symmetrizer acting on a tensor power of the standard representation of `GL n k`, as a `GL n k`-subrepresentation. Both halves of the construction were already on `main` and separate -- the Young symmetrizer `c_t ∈ ℚ[Sₙ]` on one side, and the commuting symmetric-group and general-linear actions on `(kⁿ)^{⊗d}` (`TauCeti.commute_permTensorActionAlgHom_tensorPowerRep`) on the other -- and joining them is what is done here.

The construction is done in two steps, one generic and one specialized.

The generic step is `TauCeti.tensorPowerRange`, in the new `TauCeti/RepresentationTheory/Tensor/PermRange.lean`: for any representation `ρ` on `M`, acting on `⨂[R]^d M` by an element of `R[S_d]` permuting tensor factors is an intertwining map of `ρ.tensorPower d` with itself, so Mathlib's `Representation.IntertwiningMap.range` makes its image a `Subrepresentation`. This is stated over an arbitrary commutative semiring, monoid and module, with the identity cutting out the whole tensor power, the zero cutting out `⊥`, right multiplication shrinking the image, and conjugating the group-algebra element by a permutation moving the image by that permutation of the tensor factors. Nothing about it is specific to classical groups or to Young symmetrizers, so it sits with the tensor-power representation API rather than in the Weyl-module file.

`TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean` gains the other generic ingredient and the one lemma the nonvanishing argument needs. The Young symmetrizer is built over `ℚ`, so `youngSymmetrizerOver` transports its coefficients along `algebraMap ℚ k` (via Mathlib's `MonoidAlgebra.mapAlgHom`) into any `ℚ`-algebra, which is what lets `c_t` act on a `k`-module at all; `youngSymmetrizerOver_relabel`, the conjugation law under relabeling, joins its rational counterpart in `Symmetric/Relabel.lean`. And `youngSymmetrizer_coeff_of_mem_rowSubgroup` says the coefficient of a row-group permutation in `c_t` is `1`: it is immediate from the translation law `mul_youngSymmetrizer_left` already in that file, and it generalizes the neighbouring `youngSymmetrizer_coeff_one`.

The specialized step, in `TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean`, is `TauCeti.YoungTableau.weylModule`: the case `ρ = stdRep k n`, `d = μ.card`, `a = c_t`, with `weylRep` the action of `GL n k` on it. The base ring is a `ℚ`-algebra throughout, which is the characteristic-zero setting the roadmap works in and covers the roadmap's `ℂ`; a nontrivial `ℚ`-algebra has characteristic zero, which is what the nonvanishing statements need, while vanishing needs only that `2` is invertible.

Two theorems make it usable. Relabeling the tableau conjugates its Young symmetrizer, so it moves the Weyl module by a factor permutation, which is itself `GL n k`-equivariant: `weylRelabelRepEquiv` and, since any two tableaux of a shape differ by a relabeling, `weylRepEquiv` -- up to isomorphism the Weyl module depends only on the shape, which is the roadmap's "images for other tableaux are canonically isomorphic to it, an explicit lemma", with `finrank_weylModule_eq` as the concrete corollary. And `weylModule_ne_bot` proves the module is nonzero whenever the shape has at most `n` rows. That proof evaluates the coordinate functional dual to `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}`, where `r ℓ` is the row of the label `ℓ`, on `c_t` applied to that same pure tensor: a permutation survives exactly when it preserves every row index, that is, exactly on the row group, where the coefficient of `c_t` is `1`, so the value is the order of the row group, nonzero in characteristic zero. The converse is `weylModule_eq_bot`: when the shape has more than `n` rows the Weyl module is `⊥`. The tensor power is spanned by the pure tensors of standard basis vectors, and on each of them the first column, being longer than `n`, has two labels carrying the same basis index; their transposition then lies in the column group of `t`, so it fixes that pure tensor while multiplying `c_t` on the right by it negates `c_t`, and the value is its own negative, hence zero because `2` is invertible in a `ℚ`-algebra. `weylModule_eq_bot_iff` puts the two directions together as the roadmap's vanishing criterion.

Tableau independence is also what makes the shape-indexed form legitimate, and it is supplied: `weylModuleOfShape k n μ` is the Weyl module of the row-superstandard tableau of `μ`, `weylRepOfShape` is the action of `GL n k` on it, `YoungTableau.weylRepEquivOfShape` identifies the Weyl module of an arbitrary `μ`-tableau with it, and `weylFDRepOfShape` bundles it as an `FDRep k (GL (Fin n) k)`. The bundled form asks for a field, since a submodule of the tensor power is finitely generated only once the base ring is well behaved enough; `weylModuleOfShape` itself needs no such hypothesis.

The roadmap's `Suggested.lean` pins this object as `schurFunctor n μ : FDRep ℂ (GL (Fin n) ℂ)`. One deliberate departure, recorded in the module docstring: the name is `weylModule`, matching the layer title "the Weyl construction via Young symmetrizers" and Fulton--Harris Lecture 6, because what is constructed is a module -- the Schur functor of `μ` is a functor in the underlying module, and only its value at `kⁿ` is built here, so calling the value a functor would misname it. That pinned name is supplied all the same, as `schurFunctor n μ`, the definitional re-export of `weylFDRepOfShape ℂ n μ`, so later roadmap layers can consume the construction under the name they are written against.

No Mathlib infrastructure is vendored, and no material from the supplementary source snapshot is used.

This implements the second bullet of Layer 2, "Young symmetrizers and the Schur functor", of `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, as far as the image of `c_λ` on `V^{⊗|λ|}`, the proof that it is a `GLₙ`-subrepresentation, the canonical isomorphism between the images for different tableaux, and the vanishing criterion. The bullet's remaining two deliverables, the extreme cases `S^{(d)} V ≅ Symᵈ V` and `S^{(1ᵈ)} V ≅ ⋀ᵈ V`, are left for a follow-up: neither Mathlib nor Tau Ceti has a map `Sym[R]^d M →ₗ[R] ⨂[R]^d M`, nor injectivity or naturality for `exteriorPower.toTensorPower`, so they are a separate topic built on the API exposed here. It was the lowest-hanging distinct target: the roadmap status file names the Weyl construction as "closer than its layer number suggests: both halves exist separately ... and joining them is the next step", and no open or merged PR touches it.

`lake exe cache get` reports `Completed successfully`. `lake build` reports `Build completed successfully (6215 jobs).` `lake exe axioms` reports `axioms: audited 19815 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"schurfunctor"}-->

🤖 Prepared with Claude Code

