### PR TITLE
style(KnotTheory/Grid): pack underfilled signature lines

### DIFF
--- a/TauCeti/KnotTheory/Grid/BasicCycles.lean
+++ b/TauCeti/KnotTheory/Grid/BasicCycles.lean
@@ -85,16 +85,14 @@ theorem fullyBlockedBoundaries_le_cycles
 
 /-- The fully blocked cycle submodule is top when the differential is the zero map. -/
 theorem fullyBlockedCycles_eq_top_of_fullyBlockedDifferential_eq_zero
-    (h : G.fullyBlockedDifferential =
-      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    (h : G.fullyBlockedDifferential = (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
     G.fullyBlockedCycles = ⊤ := by
   rw [fullyBlockedCycles]
   exact LinearMap.ker_eq_top.mpr h
 
 /-- The fully blocked boundary submodule is bottom when the differential is the zero map. -/
 theorem fullyBlockedBoundaries_eq_bot_of_fullyBlockedDifferential_eq_zero
-    (h : G.fullyBlockedDifferential =
-      (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
+    (h : G.fullyBlockedDifferential = (0 : GridChain (ZMod 2) n →ₗ[ZMod 2] GridChain (ZMod 2) n)) :
     G.fullyBlockedBoundaries = ⊥ := by
   rw [fullyBlockedBoundaries]
   exact LinearMap.range_eq_bot.mpr h

--- a/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
+++ b/TauCeti/KnotTheory/Grid/BlockedRectangle.lean
@@ -98,8 +98,7 @@ theorem fullyBlockedRectangles_subset_all :
 
 /-- There are at most two fully blocked rectangles in each matrix coefficient of the fully
 blocked differential. -/
-theorem card_fullyBlockedRectangles_le_two :
-    (G.fullyBlockedRectangles x y).card ≤ 2 :=
+theorem card_fullyBlockedRectangles_le_two : (G.fullyBlockedRectangles x y).card ≤ 2 :=
   GridRectangleBetween.card_le_two (G.fullyBlockedRectangles x y)
 
 /-- The number of fully blocked empty rectangles from `x` to `y`, reduced modulo `2`. -/

--- a/TauCeti/KnotTheory/Grid/Complex.lean
+++ b/TauCeti/KnotTheory/Grid/Complex.lean
@@ -72,15 +72,13 @@ private theorem relabelEquiv_single {R : Type*} [Semiring R] {n : ℕ}
 
 /-- The `y`-coefficient of a relabeled chain is the `e.symm y`-coefficient of the original
 chain. -/
-private theorem relabelEquiv_apply {R : Type*} [Semiring R] {n : ℕ}
-    (e : GridState n ≃ GridState n)
+private theorem relabelEquiv_apply {R : Type*} [Semiring R] {n : ℕ} (e : GridState n ≃ GridState n)
     (f : GridChain R n) (y : GridState n) : relabelEquiv e f y = f (e.symm y) := by
   rw [relabelEquiv, Finsupp.domLCongr_apply]
   exact Finsupp.equivMapDomain_apply _ _ _
 
 /-- The inverse of the relabeling along `e` is the relabeling along `e.symm`. -/
-private theorem relabelEquiv_symm {R : Type*} [Semiring R] {n : ℕ}
-    (e : GridState n ≃ GridState n) :
+private theorem relabelEquiv_symm {R : Type*} [Semiring R] {n : ℕ} (e : GridState n ≃ GridState n) :
     (relabelEquiv (R := R) e).symm = relabelEquiv e.symm := by
   unfold relabelEquiv
   rw [Finsupp.domLCongr_symm]

--- a/TauCeti/KnotTheory/Grid/CycleSymmetry.lean
+++ b/TauCeti/KnotTheory/Grid/CycleSymmetry.lean
@@ -252,8 +252,7 @@ theorem fullyBlockedCyclesSwapMarkingsEquiv_apply (c : G.fullyBlockedCycles) :
 
 /-- The inverse of the marking-swap cycle equivalence preserves underlying chains. -/
 @[simp]
-theorem fullyBlockedCyclesSwapMarkingsEquiv_symm_apply
-    (c : G.swapMarkings.fullyBlockedCycles) :
+theorem fullyBlockedCyclesSwapMarkingsEquiv_symm_apply (c : G.swapMarkings.fullyBlockedCycles) :
     ((G.fullyBlockedCyclesSwapMarkingsEquiv.symm c : G.fullyBlockedCycles) :
         GridChain (ZMod 2) n) = (c : GridChain (ZMod 2) n) := by
   simp [fullyBlockedCyclesSwapMarkingsEquiv]

--- a/TauCeti/KnotTheory/Grid/Cycles.lean
+++ b/TauCeti/KnotTheory/Grid/Cycles.lean
@@ -67,8 +67,7 @@ theorem mem_fullyBlockedCycles_of_le_two (hn : n ≤ 2) (c : GridChain (ZMod 2) 
   exact Submodule.mem_top
 
 /-- In grid size at most two, a fully blocked boundary is exactly the zero chain. -/
-theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two
-    (hn : n ≤ 2) (c : GridChain (ZMod 2) n) :
+theorem mem_fullyBlockedBoundaries_iff_eq_zero_of_le_two (hn : n ≤ 2) (c : GridChain (ZMod 2) n) :
     c ∈ G.fullyBlockedBoundaries ↔ c = 0 := by
   rw [G.fullyBlockedBoundaries_eq_bot_of_le_two hn]
   exact Submodule.mem_bot (R := ZMod 2)

--- a/TauCeti/KnotTheory/Grid/CyclicInterval.lean
+++ b/TauCeti/KnotTheory/Grid/CyclicInterval.lean
@@ -282,8 +282,7 @@ with the two endpoints reversed and exchanged.
 
 Coordinate reversal reverses the cyclic order, so it turns the clockwise arc from `a` to `b` into
 the clockwise arc from `bᵒ` to `aᵒ`. -/
-theorem cIoo_image_rev (a b : Fin n) :
-    (cIoo a b).image Fin.rev = cIoo b.rev a.rev := by
+theorem cIoo_image_rev (a b : Fin n) : (cIoo a b).image Fin.rev = cIoo b.rev a.rev := by
   ext y
   rw [Finset.mem_image]
   constructor

--- a/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Basic.lean
@@ -125,8 +125,7 @@ theorem mem_pointSet (x : GridState n) (p : Fin n × Fin n) :
     exact Finset.mem_image.mpr ⟨p.1, Finset.mem_univ _, by ext <;> simp [hp]⟩
 
 /-- The square `(c, r)` lies in a grid state's point set exactly when `x c = r`. -/
-theorem mk_mem_pointSet (x : GridState n) (c r : Fin n) :
-    (c, r) ∈ x.pointSet ↔ x c = r := by
+theorem mk_mem_pointSet (x : GridState n) (c r : Fin n) : (c, r) ∈ x.pointSet ↔ x c = r := by
   simp
 
 /-- The point set of a grid state has exactly `n` occupied squares. -/
@@ -267,8 +266,7 @@ theorem relabelRows_relabelColumns (ρ κ : Equiv.Perm (Fin n)) (x : GridState n
   simp
 
 /-- Membership in the point set after a row relabeling. -/
-theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
-    (p : Fin n × Fin n) :
+theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n) (p : Fin n × Fin n) :
     p ∈ (x.relabelRows ρ).pointSet ↔ (p.1, ρ.symm p.2) ∈ x.pointSet := by
   simp only [mem_pointSet, relabelRows_apply]
   constructor
@@ -280,8 +278,7 @@ theorem mem_pointSet_relabelRows (ρ : Equiv.Perm (Fin n)) (x : GridState n)
     simp
 
 /-- Membership in the point set after a column relabeling. -/
-theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n)
-    (p : Fin n × Fin n) :
+theorem mem_pointSet_relabelColumns (κ : Equiv.Perm (Fin n)) (x : GridState n) (p : Fin n × Fin n) :
     p ∈ (x.relabelColumns κ).pointSet ↔ (κ.symm p.1, p.2) ∈ x.pointSet := by
   simp
 
@@ -516,8 +513,7 @@ theorem mem_pointSet_inter_relabelColumns_iff (x : GridState n) (κ : Equiv.Perm
 
 /-- Swapping the same pair of rows twice is the identity on grid states. -/
 @[simp]
-theorem swapRows_swapRows (a b : Fin n) (x : GridState n) :
-    (x.swapRows a b).swapRows a b = x := by
+theorem swapRows_swapRows (a b : Fin n) (x : GridState n) : (x.swapRows a b).swapRows a b = x := by
   ext c
   simp [swapRows]
 
@@ -837,26 +833,22 @@ def relabelColumns (κ : Equiv.Perm (Fin n)) (G : GridDiagram n) : GridDiagram n
 
 /-- The `O` marking state of a row-relabeled grid diagram. -/
 @[simp]
-theorem relabelRows_O (ρ : Equiv.Perm (Fin n)) :
-    (G.relabelRows ρ).O = G.O.relabelRows ρ :=
+theorem relabelRows_O (ρ : Equiv.Perm (Fin n)) : (G.relabelRows ρ).O = G.O.relabelRows ρ :=
   rfl
 
 /-- The `X` marking state of a row-relabelled grid diagram. -/
 @[simp]
-theorem relabelRows_X (ρ : Equiv.Perm (Fin n)) :
-    (G.relabelRows ρ).X = G.X.relabelRows ρ :=
+theorem relabelRows_X (ρ : Equiv.Perm (Fin n)) : (G.relabelRows ρ).X = G.X.relabelRows ρ :=
   rfl
 
 /-- The `O` marking state of a column-relabelled grid diagram. -/
 @[simp]
-theorem relabelColumns_O (κ : Equiv.Perm (Fin n)) :
-    (G.relabelColumns κ).O = G.O.relabelColumns κ :=
+theorem relabelColumns_O (κ : Equiv.Perm (Fin n)) : (G.relabelColumns κ).O = G.O.relabelColumns κ :=
   rfl
 
 /-- The `X` marking state of a column-relabelled grid diagram. -/
 @[simp]
-theorem relabelColumns_X (κ : Equiv.Perm (Fin n)) :
-    (G.relabelColumns κ).X = G.X.relabelColumns κ :=
+theorem relabelColumns_X (κ : Equiv.Perm (Fin n)) : (G.relabelColumns κ).X = G.X.relabelColumns κ :=
   rfl
 
 /-- Row relabeling evaluates on the `O` marking by applying the row permutation. -/
@@ -915,26 +907,22 @@ def swapColumns (a b : Fin n) (G : GridDiagram n) : GridDiagram n :=
 
 /-- The `O` marking state of a row-swapped grid diagram. -/
 @[simp]
-theorem swapRows_O (a b : Fin n) :
-    (G.swapRows a b).O = G.O.swapRows a b :=
+theorem swapRows_O (a b : Fin n) : (G.swapRows a b).O = G.O.swapRows a b :=
   rfl
 
 /-- The `X` marking state of a row-swapped grid diagram. -/
 @[simp]
-theorem swapRows_X (a b : Fin n) :
-    (G.swapRows a b).X = G.X.swapRows a b :=
+theorem swapRows_X (a b : Fin n) : (G.swapRows a b).X = G.X.swapRows a b :=
   rfl
 
 /-- The `O` marking state of a column-swapped grid diagram. -/
 @[simp]
-theorem swapColumns_O (a b : Fin n) :
-    (G.swapColumns a b).O = G.O.swapColumns a b :=
+theorem swapColumns_O (a b : Fin n) : (G.swapColumns a b).O = G.O.swapColumns a b :=
   rfl
 
 /-- The `X` marking state of a column-swapped grid diagram. -/
 @[simp]
-theorem swapColumns_X (a b : Fin n) :
-    (G.swapColumns a b).X = G.X.swapColumns a b :=
+theorem swapColumns_X (a b : Fin n) : (G.swapColumns a b).X = G.X.swapColumns a b :=
   rfl
 
 /-- Row swaps transport the `O` marking set by the row transposition. -/
@@ -959,14 +947,12 @@ theorem mem_XSet_swapColumns (a b : Fin n) (p : Fin n × Fin n) :
 
 /-- Swapping the same pair of rows twice is the identity on grid diagrams. -/
 @[simp]
-theorem swapRows_swapRows (a b : Fin n) :
-    (G.swapRows a b).swapRows a b = G := by
+theorem swapRows_swapRows (a b : Fin n) : (G.swapRows a b).swapRows a b = G := by
   ext c <;> simp [swapRows]
 
 /-- Swapping the same pair of columns twice is the identity on grid diagrams. -/
 @[simp]
-theorem swapColumns_swapColumns (a b : Fin n) :
-    (G.swapColumns a b).swapColumns a b = G := by
+theorem swapColumns_swapColumns (a b : Fin n) : (G.swapColumns a b).swapColumns a b = G := by
   ext c <;> simp [swapColumns]
 
 /-- Relabeling rows by the identity permutation does not change a grid diagram. -/

--- a/TauCeti/KnotTheory/Grid/Diagram/Components.lean
+++ b/TauCeti/KnotTheory/Grid/Diagram/Components.lean
@@ -196,8 +196,7 @@ theorem componentPerm_relabelRows (ρ : Equiv.Perm (Fin n)) :
   simp [componentPerm_apply]
 
 /-- Relabeling columns conjugates the component permutation by the column relabeling. -/
-theorem componentPerm_relabelColumns (κ : Equiv.Perm (Fin n)) :
-    (G.relabelColumns κ).componentPerm =
+theorem componentPerm_relabelColumns (κ : Equiv.Perm (Fin n)) : (G.relabelColumns κ).componentPerm =
       κ * G.componentPerm * κ⁻¹ := by
   ext c
   simp [componentPerm_apply]
@@ -330,8 +329,7 @@ theorem componentCount_swapMarkings :
 
 /-- Row relabeling preserves whether a grid diagram represents a knot. -/
 @[simp]
-theorem isKnot_relabelRows (ρ : Equiv.Perm (Fin n)) :
-    (G.relabelRows ρ).IsKnot ↔ G.IsKnot := by
+theorem isKnot_relabelRows (ρ : Equiv.Perm (Fin n)) : (G.relabelRows ρ).IsKnot ↔ G.IsKnot := by
   simp [IsKnot]
 
 /-- Column relabeling preserves whether a grid diagram represents a knot. -/

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Backtracking.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Backtracking.lean
@@ -69,8 +69,7 @@ theorem sym2_mk_eq_of_swapColumns_swapColumns_eq_self (x : GridState n) {a b c d
 /-- Two nontrivial column swaps form a diagonal two-step witness exactly when they use the same
 unordered pair of columns. -/
 theorem swapColumns_swapColumns_eq_self_iff_sym2_mk_eq (x : GridState n) {a b c d : Fin n}
-    (hab : a ≠ b) (hcd : c ≠ d) :
-    (x.swapColumns a b).swapColumns c d = x ↔ s(a, b) = s(c, d) := by
+    (hab : a ≠ b) (hcd : c ≠ d) : (x.swapColumns a b).swapColumns c d = x ↔ s(a, b) = s(c, d) := by
   constructor
   · exact x.sym2_mk_eq_of_swapColumns_swapColumns_eq_self hab hcd
   · intro hsym

--- a/TauCeti/KnotTheory/Grid/Differential/Square/Support.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Square/Support.lean
@@ -149,8 +149,7 @@ theorem fullyBlockedDifferential_sq_support_card_le (c : GridChain (ZMod 2) n) :
 column transpositions. This is the finite search space for the later rectangle-pairing proof of
 `∂² = 0` on generators. -/
 theorem fullyBlockedDifferential_sq_single_support_subset (x : GridState n) :
-    (G.fullyBlockedDifferential
-      (G.fullyBlockedDifferential (Finsupp.single x 1))).support ⊆
+    (G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1))).support ⊆
         x.twoStepColumnSwapNeighbors := by
   intro z hz
   have hz' := G.fullyBlockedDifferential_sq_support_subset_biUnion (Finsupp.single x 1) hz
@@ -167,8 +166,7 @@ theorem fullyBlockedDifferential_sq_single_apply_eq_zero_of_notMem_twoStep
 
 /-- The support of `∂ (∂ x)` has at most `(n.choose 2) ^ 2` states. -/
 theorem fullyBlockedDifferential_sq_single_support_card_le (x : GridState n) :
-    (G.fullyBlockedDifferential
-      (G.fullyBlockedDifferential (Finsupp.single x 1))).support.card ≤
+    (G.fullyBlockedDifferential (G.fullyBlockedDifferential (Finsupp.single x 1))).support.card ≤
         (n.choose 2) ^ 2 :=
   (Finset.card_le_card (G.fullyBlockedDifferential_sq_single_support_subset x)).trans
     x.card_twoStepColumnSwapNeighbors_le

--- a/TauCeti/KnotTheory/Grid/Differential/Support/Cardinality.lean
+++ b/TauCeti/KnotTheory/Grid/Differential/Support/Cardinality.lean
@@ -70,8 +70,7 @@ theorem fullyBlockedDifferentialOnGenerator_support_eq_empty_of_le_one
 /-- The support of the fully blocked differential of one generator is empty in grid
 size `0`. -/
 theorem fullyBlockedDifferentialOnGenerator_support_eq_empty_of_zero (G : GridDiagram 0)
-    (x : GridState 0) :
-    (G.fullyBlockedDifferentialOnGenerator x).support = ∅ :=
+    (x : GridState 0) : (G.fullyBlockedDifferentialOnGenerator x).support = ∅ :=
   G.fullyBlockedDifferentialOnGenerator_support_eq_empty_of_le_one (Nat.zero_le 1) x
 
 /-- The fully blocked differential of a generator is zero in grid size at most `1`. -/
@@ -83,8 +82,7 @@ theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_le_one
 
 /-- The fully blocked differential of a generator is zero in grid size `0`. -/
 @[simp]
-theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_zero (G : GridDiagram 0)
-    (x : GridState 0) :
+theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_zero (G : GridDiagram 0) (x : GridState 0) :
     G.fullyBlockedDifferentialOnGenerator x = 0 :=
   G.fullyBlockedDifferentialOnGenerator_eq_zero_of_le_one (Nat.zero_le 1) x
 

--- a/TauCeti/KnotTheory/Grid/Homology.lean
+++ b/TauCeti/KnotTheory/Grid/Homology.lean
@@ -127,8 +127,7 @@ noncomputable def fullyBlockedHomologyEquivChainOfLeTwo (hn : n ≤ 2) :
 
 /-- The small-grid equivalence sends the homology class of a cycle to its underlying chain. -/
 @[simp]
-theorem fullyBlockedHomologyEquivChainOfLeTwo_apply_mk (hn : n ≤ 2)
-    (c : G.fullyBlockedCycles) :
+theorem fullyBlockedHomologyEquivChainOfLeTwo_apply_mk (hn : n ≤ 2) (c : G.fullyBlockedCycles) :
     G.fullyBlockedHomologyEquivChainOfLeTwo hn (Submodule.Quotient.mk c) =
       (c : GridChain (ZMod 2) n) := by
   rw [fullyBlockedHomologyEquivChainOfLeTwo]

--- a/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Basic.lean
@@ -466,8 +466,7 @@ theorem symmEquiv_apply (R : GridRectangleBetween x y) :
 
 /-- Applying the inverse opposite-rectangle equivalence is `GridRectangleBetween.symm`. -/
 @[simp]
-theorem symmEquiv_symm_apply (R : GridRectangleBetween y x) :
-    (symmEquiv x y).symm R = R.symm :=
+theorem symmEquiv_symm_apply (R : GridRectangleBetween y x) : (symmEquiv x y).symm R = R.symm :=
   rfl
 
 /-- The opposite rectangle has the same bottom row. -/

--- a/TauCeti/KnotTheory/Grid/Rectangle/Count.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Count.lean
@@ -136,8 +136,7 @@ theorem card_le_two (s : Finset (GridRectangleBetween x y)) : s.card ≤ 2 :=
   (Finset.card_le_card (by intro R _; exact mem_all R)).trans (card_all_le_two x y)
 
 /-- There are at most two empty oriented rectangles between two grid states. -/
-theorem card_emptyRectangles_le_two (x y : GridState n) :
-    (emptyRectangles x y).card ≤ 2 :=
+theorem card_emptyRectangles_le_two (x y : GridState n) : (emptyRectangles x y).card ≤ 2 :=
   card_le_two (emptyRectangles x y)
 
 end GridRectangleBetween

--- a/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
+++ b/TauCeti/KnotTheory/Grid/Rectangle/Swap.lean
@@ -80,8 +80,7 @@ theorem target_eq_swapColumns : y = x.swapColumns R.left R.right := by
 /-- Oriented rectangles between `x` and `y` exist exactly when `y` is a column transposition of
 `x`. A rectangle realizes its side columns as a transposition taking `x` to `y`, and conversely a
 column transposition exhibits an oriented rectangle on those two columns. -/
-theorem nonempty_all_iff :
-    (all x y).Nonempty ↔ ∃ a b : Fin n, a ≠ b ∧ y = x.swapColumns a b := by
+theorem nonempty_all_iff : (all x y).Nonempty ↔ ∃ a b : Fin n, a ≠ b ∧ y = x.swapColumns a b := by
   constructor
   · rintro ⟨R, -⟩
     exact ⟨R.left, R.right, R.left_ne_right, R.target_eq_swapColumns⟩
@@ -125,29 +124,25 @@ theorem mem_pointSet_inter_iff (p : Fin n × Fin n) :
     GridState.mem_pointSet_inter_swapColumns_iff x R.left_ne_right p
 
 /-- The lower-left corner is not shared with the target state: it sits on a side column. -/
-theorem left_bottom_notMem_inter :
-    (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
+theorem left_bottom_notMem_inter : (R.left, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
   rintro ⟨_, hleft, _⟩
   exact hleft rfl
 
 /-- The upper-right corner is not shared with the target state: it sits on a side column. -/
-theorem right_top_notMem_inter :
-    (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
+theorem right_top_notMem_inter : (R.right, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
   rintro ⟨_, _, hright⟩
   exact hright rfl
 
 /-- The upper-left target corner is not shared with the source state: it sits on a side column. -/
-theorem left_top_notMem_inter :
-    (R.left, R.top) ∉ x.pointSet ∩ y.pointSet := by
+theorem left_top_notMem_inter : (R.left, R.top) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
   rintro ⟨_, hleft, _⟩
   exact hleft rfl
 
 /-- The lower-right target corner is not shared with the source state: it sits on a side column. -/
-theorem right_bottom_notMem_inter :
-    (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
+theorem right_bottom_notMem_inter : (R.right, R.bottom) ∉ x.pointSet ∩ y.pointSet := by
   rw [mem_pointSet_inter_iff R]
   rintro ⟨_, _, hright⟩
   exact hright rfl

--- a/TauCeti/KnotTheory/Grid/Rotation.lean
+++ b/TauCeti/KnotTheory/Grid/Rotation.lean
@@ -243,8 +243,7 @@ theorem relabelRows_rotate (ρ : Equiv.Perm (Fin n)) :
 /-- Column relabeling before rotation becomes column relabeling by the conjugate permutation
 after rotation. -/
 @[simp]
-theorem relabelColumns_rotate (κ : Equiv.Perm (Fin n)) :
-    (G.relabelColumns κ).rotate =
+theorem relabelColumns_rotate (κ : Equiv.Perm (Fin n)) : (G.relabelColumns κ).rotate =
       G.rotate.relabelColumns (Fin.revPerm.trans (κ.trans Fin.revPerm)) := by
   ext c <;> simp
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
@@ -74,22 +74,19 @@ theorem fullyBlockedRectangleCount_eq_zero_of_le_two (hn : n ≤ 2) (x y : GridS
 
 /-- Every fully blocked rectangle coefficient vanishes on every `2 × 2` grid. -/
 @[simp]
-theorem fullyBlockedRectangleCount_eq_zero_of_two
-    (G : GridDiagram 2) (x y : GridState 2) :
+theorem fullyBlockedRectangleCount_eq_zero_of_two (G : GridDiagram 2) (x y : GridState 2) :
     G.fullyBlockedRectangleCount x y = 0 :=
   G.fullyBlockedRectangleCount_eq_zero_of_le_two le_rfl x y
 
 /-- The fully blocked differential of one generator vanishes in grid size at most two. -/
-theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_le_two
-    (hn : n ≤ 2) (x : GridState n) :
+theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_le_two (hn : n ≤ 2) (x : GridState n) :
     G.fullyBlockedDifferentialOnGenerator x = 0 := by
   ext y
   simp [fullyBlockedRectangleCount_eq_zero_of_le_two G hn x y]
 
 /-- The fully blocked differential of one generator vanishes on every `2 × 2` grid. -/
 @[simp]
-theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_two
-    (G : GridDiagram 2) (x : GridState 2) :
+theorem fullyBlockedDifferentialOnGenerator_eq_zero_of_two (G : GridDiagram 2) (x : GridState 2) :
     G.fullyBlockedDifferentialOnGenerator x = 0 :=
   G.fullyBlockedDifferentialOnGenerator_eq_zero_of_le_two le_rfl x
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Gradings.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Gradings.lean
@@ -60,8 +60,7 @@ theorem twoByTwo_XSet :
   rcases p with ⟨c, r⟩
   fin_cases c <;> fin_cases r <;> simp [XSet]
 
-private theorem twoByTwoId_pairCard_self :
-    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+private theorem twoByTwoId_pairCard_self : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2).card = 1 := by
   have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoId p.2) = {(0, 1)} := by
@@ -69,8 +68,7 @@ private theorem twoByTwoId_pairCard_self :
   rw [hfilter]
   simp
 
-private theorem twoByTwoSwap_pairCard_self :
-    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+private theorem twoByTwoSwap_pairCard_self : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
   have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoSwap p.2) = ∅ := by
@@ -78,8 +76,7 @@ private theorem twoByTwoSwap_pairCard_self :
   rw [hfilter]
   simp
 
-private theorem twoByTwoId_pairCard_swap :
-    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+private theorem twoByTwoId_pairCard_swap : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2).card = 0 := by
   have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoId p.1 < GridState.twoByTwoSwap p.2) = ∅ := by
@@ -87,8 +84,7 @@ private theorem twoByTwoId_pairCard_swap :
   rw [hfilter]
   simp
 
-private theorem twoByTwoSwap_pairCard_id :
-    (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
+private theorem twoByTwoSwap_pairCard_id : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2).card = 0 := by
   have hfilter : (Finset.univ.filter fun p : Fin 2 × Fin 2 =>
       p.1 < p.2 ∧ GridState.twoByTwoSwap p.1 < GridState.twoByTwoId p.2) = ∅ := by

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Homology.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Homology.lean
@@ -116,8 +116,7 @@ theorem fullyBlockedHomologyBasisOfLeTwo_apply (hn : n ≤ 2) (x : GridState n) 
 Since the differential and the boundary submodule both vanish, passing to homology does not
 change any coefficient. -/
 @[simp]
-theorem fullyBlockedHomologyBasisOfLeTwo_repr_mk (hn : n ≤ 2)
-    (c : G.fullyBlockedCycles) :
+theorem fullyBlockedHomologyBasisOfLeTwo_repr_mk (hn : n ≤ 2) (c : G.fullyBlockedCycles) :
     (G.fullyBlockedHomologyBasisOfLeTwo hn).repr (Submodule.Quotient.mk c) =
       (c : GridChain (ZMod 2) n) := by
   rw [fullyBlockedHomologyBasisOfLeTwo, Module.Basis.map_repr]
@@ -127,8 +126,7 @@ theorem fullyBlockedHomologyBasisOfLeTwo_repr_mk (hn : n ≤ 2)
 `x`. -/
 @[simp]
 theorem fullyBlockedHomologyBasisOfLeTwo_repr_class (hn : n ≤ 2) (x : GridState n) :
-    (G.fullyBlockedHomologyBasisOfLeTwo hn).repr
-        (G.fullyBlockedHomologyClassOfLeTwo hn x) =
+    (G.fullyBlockedHomologyBasisOfLeTwo hn).repr (G.fullyBlockedHomologyClassOfLeTwo hn x) =
       Finsupp.single x 1 := by
   rw [fullyBlockedHomologyClassOfLeTwo,
     G.fullyBlockedHomologyBasisOfLeTwo_repr_mk]

--- a/TauCeti/KnotTheory/Grid/Stabilization/Basic.lean
+++ b/TauCeti/KnotTheory/Grid/Stabilization/Basic.lean
@@ -69,8 +69,7 @@ theorem insertPoint_apply_newColumn (x : GridState n) (newColumn newRow : Fin (n
 
 /-- An old column contains the embedded image of its old row after inserting a point. -/
 @[simp]
-theorem insertPoint_apply_succAbove (x : GridState n) (newColumn newRow : Fin (n + 1))
-    (c : Fin n) :
+theorem insertPoint_apply_succAbove (x : GridState n) (newColumn newRow : Fin (n + 1)) (c : Fin n) :
     x.insertPoint newColumn newRow (newColumn.succAbove c) =
       newRow.succAbove (x c) := by
   simp [insertPoint]
@@ -226,8 +225,7 @@ def IsOStabilization (G : GridDiagram n) (G' : GridDiagram (n + 1)) : Prop :=
     G' = G.stabilizeO newColumn newRow splitColumn
 
 /-- A local `O`-stabilization construction is an elementary `O`-stabilization. -/
-theorem isOStabilization_stabilizeO (newColumn newRow : Fin (n + 1))
-    (splitColumn : Fin n)
+theorem isOStabilization_stabilizeO (newColumn newRow : Fin (n + 1)) (splitColumn : Fin n)
     (hColumn : finRotate (n + 1) newColumn = newColumn.succAbove splitColumn ∨
       finRotate (n + 1) (newColumn.succAbove splitColumn) = newColumn)
     (hRow : finRotate (n + 1) newRow = newRow.succAbove (G.O splitColumn) ∨
@@ -260,8 +258,7 @@ def IsXStabilization (G : GridDiagram n) (G' : GridDiagram (n + 1)) : Prop :=
     G' = G.stabilizeX newColumn newRow splitColumn
 
 /-- A local `X`-stabilization construction is an elementary `X`-stabilization. -/
-theorem isXStabilization_stabilizeX (newColumn newRow : Fin (n + 1))
-    (splitColumn : Fin n)
+theorem isXStabilization_stabilizeX (newColumn newRow : Fin (n + 1)) (splitColumn : Fin n)
     (hColumn : finRotate (n + 1) newColumn = newColumn.succAbove splitColumn ∨
       finRotate (n + 1) (newColumn.succAbove splitColumn) = newColumn)
     (hRow : finRotate (n + 1) newRow = newRow.succAbove (G.X splitColumn) ∨
@@ -283,8 +280,7 @@ theorem isXStabilization_stabilizeX_castSucc (splitColumn : Fin n) :
 /-- Exchanging the marking types turns an `O`-stabilization relation into an
 `X`-stabilization relation. -/
 @[simp]
-theorem isOStabilization_swapMarkings (G : GridDiagram n)
-    (G' : GridDiagram (n + 1)) :
+theorem isOStabilization_swapMarkings (G : GridDiagram n) (G' : GridDiagram (n + 1)) :
     IsOStabilization G.swapMarkings G'.swapMarkings ↔ IsXStabilization G G' := by
   constructor
   · rintro ⟨newColumn, newRow, splitColumn, hColumn, hRow, hG'⟩
@@ -299,8 +295,7 @@ theorem isOStabilization_swapMarkings (G : GridDiagram n)
 /-- Exchanging the marking types turns an `X`-stabilization relation into an
 `O`-stabilization relation. -/
 @[simp]
-theorem isXStabilization_swapMarkings (G : GridDiagram n)
-    (G' : GridDiagram (n + 1)) :
+theorem isXStabilization_swapMarkings (G : GridDiagram n) (G' : GridDiagram (n + 1)) :
     IsXStabilization G.swapMarkings G'.swapMarkings ↔ IsOStabilization G G' := by
   simpa only [swapMarkings_swapMarkings] using
     (isOStabilization_swapMarkings G.swapMarkings G'.swapMarkings).symm
@@ -311,8 +306,7 @@ def IsStabilization (G : GridDiagram n) (G' : GridDiagram (n + 1)) : Prop :=
 
 /-- Exchanging the marking types preserves the elementary stabilization relation. -/
 @[simp]
-theorem isStabilization_swapMarkings (G : GridDiagram n)
-    (G' : GridDiagram (n + 1)) :
+theorem isStabilization_swapMarkings (G : GridDiagram n) (G' : GridDiagram (n + 1)) :
     IsStabilization G.swapMarkings G'.swapMarkings ↔ IsStabilization G G' := by
   simp only [IsStabilization, isOStabilization_swapMarkings,
     isXStabilization_swapMarkings, or_comm]
@@ -323,15 +317,13 @@ def IsDestabilization (G' : GridDiagram (n + 1)) (G : GridDiagram n) : Prop :=
 
 /-- A destabilization from the larger diagram to the smaller one is the reverse orientation of
 the corresponding stabilization. -/
-theorem isDestabilization_iff_isStabilization (G' : GridDiagram (n + 1))
-    (G : GridDiagram n) :
+theorem isDestabilization_iff_isStabilization (G' : GridDiagram (n + 1)) (G : GridDiagram n) :
     IsDestabilization G' G ↔ IsStabilization G G' :=
   Iff.rfl
 
 /-- Exchanging the marking types preserves the elementary destabilization relation. -/
 @[simp]
-theorem isDestabilization_swapMarkings (G' : GridDiagram (n + 1))
-    (G : GridDiagram n) :
+theorem isDestabilization_swapMarkings (G' : GridDiagram (n + 1)) (G : GridDiagram n) :
     IsDestabilization G'.swapMarkings G.swapMarkings ↔ IsDestabilization G' G := by
   simpa only [IsDestabilization] using isStabilization_swapMarkings G G'
 

--- a/TauCeti/KnotTheory/Grid/TorusLink.lean
+++ b/TauCeti/KnotTheory/Grid/TorusLink.lean
@@ -72,8 +72,7 @@ private theorem isCycle_finRotate_torus : (finRotate (p + 1 + (q + 1))).IsCycle 
   isCycle_finRotate_of_le (by omega)
 
 /-- The cyclic shift of the columns of a torus link grid moves every column. -/
-private theorem support_finRotate_torus :
-    (finRotate (p + 1 + (q + 1))).support = Finset.univ :=
+private theorem support_finRotate_torus : (finRotate (p + 1 + (q + 1))).support = Finset.univ :=
   support_finRotate_of_le (by omega)
 
 /-- The cyclic shift of the columns of a torus link grid is a cycle of length the grid number. -/
@@ -116,8 +115,7 @@ theorem torusLink_O_toPerm : (torusLink p q).O.toPerm = 1 :=
 /-- The `X` markings of a standard torus link grid are the `(q + 1)`-st power of the cyclic shift
 permutation graph. -/
 @[simp]
-theorem torusLink_X_toPerm :
-    (torusLink p q).X.toPerm = finRotate (p + 1 + (q + 1)) ^ (q + 1) :=
+theorem torusLink_X_toPerm : (torusLink p q).X.toPerm = finRotate (p + 1 + (q + 1)) ^ (q + 1) :=
   (rfl)
 
 -- Not `@[simp]`: the `simp` normal form of `(torusLink p q).O c` goes through the marking-state
@@ -169,8 +167,7 @@ private theorem gcd_torus : (p + 1 + (q + 1)).gcd (q + 1) = (p + 1).gcd (q + 1) 
 /-- The components of a standard torus link grid all carry the same number of markings, and there
 are `gcd (p + 1) (q + 1)` of them: exactly the number of components of the `(p + 1, q + 1)` torus
 link. -/
-theorem componentCycleType_torusLink :
-    (torusLink p q).componentCycleType =
+theorem componentCycleType_torusLink : (torusLink p q).componentCycleType =
       Multiset.replicate ((p + 1).gcd (q + 1))
         ((p + 1 + (q + 1)) / (p + 1).gcd (q + 1)) := by
   rw [componentCycleType_def, componentPerm_torusLink, Equiv.Perm.cycleType_inv,
@@ -178,8 +175,7 @@ theorem componentCycleType_torusLink :
     card_support_finRotate_torus, gcd_torus]
 
 /-- A standard torus link grid represents a link with `gcd (p + 1) (q + 1)` components. -/
-theorem componentCount_torusLink :
-    (torusLink p q).componentCount = (p + 1).gcd (q + 1) := by
+theorem componentCount_torusLink : (torusLink p q).componentCount = (p + 1).gcd (q + 1) := by
   rw [componentCount_def, componentCycleType_torusLink, Multiset.card_replicate]
 
 /-- A standard torus link grid represents a knot exactly when its two winding numbers are
@@ -209,8 +205,7 @@ theorem not_isKnot_torusLink_one_one : ¬(torusLink 1 1).IsKnot := by
 
 /-- The `6 × 6` grid diagram `torusLink 2 2` of the `(3, 3)` torus link has three components, each
 carrying two of its six markings. -/
-theorem componentCycleType_torusLink_two_two :
-    (torusLink 2 2).componentCycleType = {2, 2, 2} := by
+theorem componentCycleType_torusLink_two_two : (torusLink 2 2).componentCycleType = {2, 2, 2} := by
   rw [componentCycleType_torusLink]
   decide
 

--- a/TauCeti/KnotTheory/Grid/Unknot.lean
+++ b/TauCeti/KnotTheory/Grid/Unknot.lean
@@ -210,16 +210,14 @@ private theorem card_filter_graph (f : Fin (n + 2) → Fin (n + 2)) :
 
 /-- The number of increasing column pairs is unchanged by additionally demanding that the two
 diagonal `O` markings be in increasing order, which they always are. -/
-private theorem card_filter_lt_O_lt_O :
-    (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
+private theorem card_filter_lt_O_lt_O : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
         p.1 < p.2 ∧ (unknot n).O p.1 < (unknot n).O p.2).card
       = (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) => p.1 < p.2).card :=
   congrArg Finset.card (Finset.filter_congr fun p _ => by simp)
 
 /-- Among the increasing column pairs, exactly the `n + 1` pairs ending in the last column fail to
 put the first diagonal `O` marking below the second shifted `X` marking. -/
-private theorem card_filter_lt_O_lt_X :
-    (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
+private theorem card_filter_lt_O_lt_X : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
         p.1 < p.2 ∧ (unknot n).O p.1 < (unknot n).X p.2).card + (n + 1)
       = (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) => p.1 < p.2).card := by
   have hset : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
@@ -245,8 +243,7 @@ private theorem card_filter_lt_O_lt_X :
 
 /-- Among the increasing column pairs, exactly the `n + 1` pairs of consecutive columns fail to
 put the first shifted `X` marking below the second diagonal `O` marking. -/
-private theorem card_filter_lt_X_lt_O :
-    (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
+private theorem card_filter_lt_X_lt_O : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
         p.1 < p.2 ∧ (unknot n).X p.1 < (unknot n).O p.2).card + (n + 1)
       = (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) => p.1 < p.2).card := by
   have hset : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
@@ -275,8 +272,7 @@ private theorem card_filter_lt_X_lt_O :
 
 /-- Among the increasing column pairs, exactly the `n + 1` pairs ending in the last column fail to
 keep the two shifted `X` markings in increasing order. -/
-private theorem card_filter_lt_X_lt_X :
-    (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
+private theorem card_filter_lt_X_lt_X : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>
         p.1 < p.2 ∧ (unknot n).X p.1 < (unknot n).X p.2).card + (n + 1)
       = (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) => p.1 < p.2).card := by
   have hset : (Finset.univ.filter fun p : Fin (n + 2) × Fin (n + 2) =>


### PR DESCRIPTION
Mechanical line-packing pass over `TauCeti/KnotTheory/Grid/`: 64 joins across 22 files, `-64` lines net.

Where a declaration's signature line and its continuation fit together inside the 100-character limit, they are joined:

```lean
-lemma inf_le_left (D : EffectiveDivisorOfDegree X d)
-    (E : EffectiveDivisorOfDegree X e) :
+lemma inf_le_left (D : EffectiveDivisorOfDegree X d) (E : EffectiveDivisorOfDegree X e) :
```

**No mathematical content changes.** Verified by whitespace-normalised comparison against `origin/main`: collapsing every whitespace run to a single space makes all 22 files byte-identical to their pre-change form, so the diff is provably pure line re-wrapping.

**No line-length regression.** Every join is asserted `≤ 100` codepoints before being applied, and a per-file before/after comparison confirms no file gains an over-100 line. Width is counted in codepoints, not bytes — `ℝ`/`≤`/`⁻¹` are multi-byte, so a byte-based check misreports. Widest resulting line is exactly 100 (`Unknot.lean:173`), at the limit and legal.

This directory was excluded from the earlier packing passes because it had work in flight; it is now clear, with no open PR touching it.

Gates: `lake build` (6217 jobs) · `lake exe axioms` (19876 declarations, allowlist clean) · `lake exe module-system` (1088 modules) · `scripts/lint-env.sh` PASS.

Roadmap: none