### PR TITLE
refactor: publish the classical-part law of tangent-kernel points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -222,7 +222,9 @@ theorem tangentKer_def :
     Subgroup (WithConv (A →ₐ[R] DualNumber (Bialgebra.CounitAlgebra R A B)))) = _
   rfl
 
-private lemma fst_apply_of_mem_ker
+/-- The classical part of any tangent-kernel point is the identity point: pointwise, the
+first component of its value at `x` is `algebraMap R _ (counit x)`. -/
+lemma fst_apply_of_mem_ker
     {ψ : WithConv (A →ₐ[R] DualNumber (CounitAlgebra R A B))}
     (h : ψ ∈ tangentKer R A B) (x : A) :
     fst (R := CounitAlgebra R A B) (ψ.ofConv x) =

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -224,7 +224,8 @@ theorem tangentKer_def :
 
 /-- The classical part of any tangent-kernel point is the identity point: pointwise, the
 first component of its value at `x` is `algebraMap R _ (counit x)`. -/
-lemma fst_apply_of_mem_ker
+@[simp]
+lemma tangentKer_apply_fst
     {ψ : WithConv (A →ₐ[R] DualNumber (CounitAlgebra R A B))}
     (h : ψ ∈ tangentKer R A B) (x : A) :
     fst (R := CounitAlgebra R A B) (ψ.ofConv x) =
@@ -255,7 +256,7 @@ private lemma snd_convMul_apply
           counit (R := R) ((ℛ R a).right i) • snd (R := CounitAlgebra R A B)
             (ψ₁.ofConv ((ℛ R a).left i)) := by
     intro i _
-    rw [snd_mul, fst_apply_of_mem_ker h₁, fst_apply_of_mem_ker h₂, op_smul_eq_smul,
+    rw [snd_mul, tangentKer_apply_fst h₁, tangentKer_apply_fst h₂, op_smul_eq_smul,
       algebraMap_smul, algebraMap_smul]
   rw [Finset.sum_congr rfl expand, Finset.sum_add_distrib, add_comm]
   congr 1
@@ -310,8 +311,8 @@ noncomputable def derivationMulEquivTangentKer :
     have hprod := toConv_mem_ker_iff.mpr
       (derivationToDualNumberEquivLift R A (Bialgebra.CounitAlgebra R A B) (d₁.toAdd + d₂.toAdd)).2
     refine Subtype.ext (ofConv_injective (AlgHom.ext fun a => TrivSqZeroExt.ext ?_ ?_))
-    · exact (fst_apply_of_mem_ker hprod a).trans
-        (fst_apply_of_mem_ker (mul_mem h₁ h₂) a).symm
+    · exact (tangentKer_apply_fst hprod a).trans
+        (tangentKer_apply_fst (mul_mem h₁ h₂) a).symm
     · simp only [MulMemClass.mk_mul_mk]
       rw [snd_convMul_apply h₁ h₂ a]
       simp

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -327,7 +327,8 @@ lemma mem_tangentKer_iff {ψ : WithConv (A →ₐ[R] DualNumber (CounitAlgebra R
         IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B) := by
   simpa using toConv_mem_ker_iff (ψ₀ := ψ.ofConv)
 
-@[simp]
+/- Not a `simp` lemma: the general `tangentKer_apply_fst` (with `SetLike.coe_mem`)
+already rewrites this left-hand side. -/
 lemma derivationMulEquivTangentKer_apply_fst
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A) :
     fst (R := CounitAlgebra R A B)

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -225,7 +225,7 @@ theorem tangentKer_def :
 /-- The classical part of any tangent-kernel point is the identity point: pointwise, the
 first component of its value at `x` is `algebraMap R _ (counit x)`. -/
 @[simp]
-lemma tangentKer_apply_fst
+lemma fst_apply_of_mem_tangentKer
     {ψ : WithConv (A →ₐ[R] DualNumber (CounitAlgebra R A B))}
     (h : ψ ∈ tangentKer R A B) (x : A) :
     fst (R := CounitAlgebra R A B) (ψ.ofConv x) =
@@ -256,7 +256,7 @@ private lemma snd_convMul_apply
           counit (R := R) ((ℛ R a).right i) • snd (R := CounitAlgebra R A B)
             (ψ₁.ofConv ((ℛ R a).left i)) := by
     intro i _
-    rw [snd_mul, tangentKer_apply_fst h₁, tangentKer_apply_fst h₂, op_smul_eq_smul,
+    rw [snd_mul, fst_apply_of_mem_tangentKer h₁, fst_apply_of_mem_tangentKer h₂, op_smul_eq_smul,
       algebraMap_smul, algebraMap_smul]
   rw [Finset.sum_congr rfl expand, Finset.sum_add_distrib, add_comm]
   congr 1
@@ -311,8 +311,8 @@ noncomputable def derivationMulEquivTangentKer :
     have hprod := toConv_mem_ker_iff.mpr
       (derivationToDualNumberEquivLift R A (Bialgebra.CounitAlgebra R A B) (d₁.toAdd + d₂.toAdd)).2
     refine Subtype.ext (ofConv_injective (AlgHom.ext fun a => TrivSqZeroExt.ext ?_ ?_))
-    · exact (tangentKer_apply_fst hprod a).trans
-        (tangentKer_apply_fst (mul_mem h₁ h₂) a).symm
+    · exact (fst_apply_of_mem_tangentKer hprod a).trans
+        (fst_apply_of_mem_tangentKer (mul_mem h₁ h₂) a).symm
     · simp only [MulMemClass.mk_mul_mk]
       rw [snd_convMul_apply h₁ h₂ a]
       simp
@@ -327,7 +327,7 @@ lemma mem_tangentKer_iff {ψ : WithConv (A →ₐ[R] DualNumber (CounitAlgebra R
         IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B) := by
   simpa using toConv_mem_ker_iff (ψ₀ := ψ.ofConv)
 
-/- Not a `simp` lemma: the general `tangentKer_apply_fst` (with `SetLike.coe_mem`)
+/- Not a `simp` lemma: the general `fst_apply_of_mem_tangentKer` (with `SetLike.coe_mem`)
 already rewrites this left-hand side. -/
 lemma derivationMulEquivTangentKer_apply_fst
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A) :

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -24,7 +24,7 @@ the tangent kernels.
 * `TauCeti.tangentKerMap`: the differential, as a group homomorphism between tangent
   kernels.
 * `TauCeti.tangentKerMap_id` and `TauCeti.tangentKerMap_comp`: functoriality.
-* `TauCeti.fst_tangentKerMap_apply`: the differential preserves lying over the identity.
+* `TauCeti.tangentKerMap_apply_fst`: the differential preserves lying over the identity.
 * `TauCeti.tangentKerMap_derivationMulEquivTangentKer_apply_snd`: on the derivation
   dictionary, the differential acts by precomposition of derivations.
 -/
@@ -126,7 +126,7 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
 
 /-- The differential preserves lying over the identity: the classical part of the image
 of any tangent-kernel point is the identity point of `A'`. -/
-lemma fst_tangentKerMap_apply (φ : A' →ₐc[R] A) (ψ : tangentKer R A B) (a : A') :
+lemma tangentKerMap_apply_fst (φ : A' →ₐc[R] A) (ψ : tangentKer R A B) (a : A') :
     TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
         ((tangentKerMap (B := B) φ ψ).val.ofConv a) =
       algebraMap A' (Bialgebra.CounitAlgebra R A' B) a := by

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -24,6 +24,9 @@ the tangent kernels.
 * `TauCeti.tangentKerMap`: the differential, as a group homomorphism between tangent
   kernels.
 * `TauCeti.tangentKerMap_id` and `TauCeti.tangentKerMap_comp`: functoriality.
+* `TauCeti.fst_tangentKerMap_apply`: the differential preserves lying over the identity.
+* `TauCeti.tangentKerMap_derivationMulEquivTangentKer_apply_snd`: on the derivation
+  dictionary, the differential acts by precomposition of derivations.
 -/
 
 public section
@@ -121,12 +124,24 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
     ← mapDomain_transport (A'' := A'') φ ψ.val]
   exact MonoidHom.comp_apply _ _ _
 
+/-- The differential preserves lying over the identity: the classical part of the image
+of any tangent-kernel point is the identity point of `A'`. -/
+lemma fst_tangentKerMap_apply (φ : A' →ₐc[R] A) (ψ : tangentKer R A B) (a : A') :
+    TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
+        ((tangentKerMap (B := B) φ ψ).val.ofConv a) =
+      algebraMap A' (Bialgebra.CounitAlgebra R A' B) a := by
+  have h := (tangentKerMap (B := B) φ ψ).2
+  rw [mem_tangentKer_iff] at h
+  have happ := congrArg
+    (fun χ : A' →ₐ[R] Bialgebra.CounitAlgebra R A' B => χ a) h
+  simpa [IsScalarTower.coe_toAlgHom', TrivSqZeroExt.fstHom_apply] using happ
+
 /-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
 morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal
 part at `a` is `d (φ a)` — the differential acts on derivations by precomposition.
 Not a `simp` lemma: `tangentKerMap_apply_val_ofConv` already rewrites the left-hand
 side, and `simp` reaches the right-hand side through it. -/
-lemma snd_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
+lemma tangentKerMap_derivationMulEquivTangentKer_apply_snd (φ : A' →ₐc[R] A)
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
     TrivSqZeroExt.snd (R := Bialgebra.CounitAlgebra R A' B)
         ((tangentKerMap (B := B) φ
@@ -134,17 +149,6 @@ lemma snd_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
       d.toAdd ((φ : A' →ₐ[R] A) a) := by
   rw [tangentKerMap_apply_val_ofConv]
   exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
-
-/-- Naturality of the tangent dictionary on classical parts: the differential preserves
-lying over the identity point. Not a `simp` lemma, as above. -/
-lemma fst_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
-    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
-    TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
-        ((tangentKerMap (B := B) φ
-          (derivationMulEquivTangentKer R A B d)).val.ofConv a) =
-      algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a) := by
-  rw [tangentKerMap_apply_val_ofConv]
-  exact derivationMulEquivTangentKer_apply_fst d ((φ : A' →ₐ[R] A) a)
 
 end Differential
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -24,8 +24,6 @@ the tangent kernels.
 * `TauCeti.tangentKerMap`: the differential, as a group homomorphism between tangent
   kernels.
 * `TauCeti.tangentKerMap_id` and `TauCeti.tangentKerMap_comp`: functoriality.
-* `TauCeti.tangentKerMap_derivationMulEquivTangentKer_apply_snd`: on the derivation
-  dictionary, the differential acts by precomposition of derivations.
 -/
 
 public section
@@ -122,20 +120,6 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
     AlgHom.mapDomain_comp (A := DualNumber (Bialgebra.CounitAlgebra R A'' B)) φ χ,
     ← mapDomain_transport (A'' := A'') φ ψ.val]
   exact MonoidHom.comp_apply _ _ _
-
-/-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
-morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal
-part at `a` is `d (φ a)` — the differential acts on derivations by precomposition.
-Not a `simp` lemma: `tangentKerMap_apply_val_ofConv` already rewrites the left-hand
-side, and `simp` reaches the right-hand side through it. -/
-lemma tangentKerMap_derivationMulEquivTangentKer_apply_snd (φ : A' →ₐc[R] A)
-    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
-    TrivSqZeroExt.snd (R := Bialgebra.CounitAlgebra R A' B)
-        ((tangentKerMap (B := B) φ
-          (derivationMulEquivTangentKer R A B d)).val.ofConv a) =
-      d.toAdd ((φ : A' →ₐ[R] A) a) := by
-  rw [tangentKerMap_apply_val_ofConv]
-  exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
 
 end Differential
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -24,7 +24,6 @@ the tangent kernels.
 * `TauCeti.tangentKerMap`: the differential, as a group homomorphism between tangent
   kernels.
 * `TauCeti.tangentKerMap_id` and `TauCeti.tangentKerMap_comp`: functoriality.
-* `TauCeti.tangentKerMap_apply_fst`: the differential preserves lying over the identity.
 * `TauCeti.tangentKerMap_derivationMulEquivTangentKer_apply_snd`: on the derivation
   dictionary, the differential acts by precomposition of derivations.
 -/
@@ -123,25 +122,6 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
     AlgHom.mapDomain_comp (A := DualNumber (Bialgebra.CounitAlgebra R A'' B)) φ χ,
     ← mapDomain_transport (A'' := A'') φ ψ.val]
   exact MonoidHom.comp_apply _ _ _
-
-/-- The differential preserves lying over the identity: the classical part of the image
-of any tangent-kernel point is the identity point of `A'`. -/
-lemma tangentKerMap_apply_fst (φ : A' →ₐc[R] A) (ψ : tangentKer R A B) (a : A') :
-    TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
-        ((tangentKerMap (B := B) φ ψ).val.ofConv a) =
-      algebraMap A' (Bialgebra.CounitAlgebra R A' B) a := by
-  have h := (tangentKerMap (B := B) φ ψ).2
-  rw [mem_tangentKer_iff] at h
-  have happ := congrArg
-    (fun χ : A' →ₐ[R] Bialgebra.CounitAlgebra R A' B => χ a) h
-  -- `fst` is the underlying function of `fstHom`.
-  have hfst : TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
-      ((tangentKerMap (B := B) φ ψ).val.ofConv a) =
-      TrivSqZeroExt.fstHom R (Bialgebra.CounitAlgebra R A' B)
-        (Bialgebra.CounitAlgebra R A' B)
-        ((tangentKerMap (B := B) φ ψ).val.ofConv a) := rfl
-  rw [hfst]
-  simpa [IsScalarTower.coe_toAlgHom'] using happ
 
 /-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
 morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -123,8 +123,9 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
 
 /-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
 morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal
-part at `a` is `d (φ a)` — the differential acts on derivations by precomposition. -/
-@[simp]
+part at `a` is `d (φ a)` — the differential acts on derivations by precomposition.
+Not a `simp` lemma: `tangentKerMap_apply_val_ofConv` already rewrites the left-hand
+side, and `simp` reaches the right-hand side through it. -/
 lemma snd_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
     TrivSqZeroExt.snd (R := Bialgebra.CounitAlgebra R A' B)
@@ -135,8 +136,7 @@ lemma snd_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
   exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
 
 /-- Naturality of the tangent dictionary on classical parts: the differential preserves
-lying over the identity point. -/
-@[simp]
+lying over the identity point. Not a `simp` lemma, as above. -/
 lemma fst_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
     TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -121,6 +121,31 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
     ← mapDomain_transport (A'' := A'') φ ψ.val]
   exact MonoidHom.comp_apply _ _ _
 
+/-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
+morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal
+part at `a` is `d (φ a)` — the differential acts on derivations by precomposition. -/
+@[simp]
+lemma snd_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
+    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
+    TrivSqZeroExt.snd (R := Bialgebra.CounitAlgebra R A' B)
+        ((tangentKerMap (B := B) φ
+          (derivationMulEquivTangentKer R A B d)).val.ofConv a) =
+      d.toAdd ((φ : A' →ₐ[R] A) a) := by
+  rw [tangentKerMap_apply_val_ofConv]
+  exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
+
+/-- Naturality of the tangent dictionary on classical parts: the differential preserves
+lying over the identity point. -/
+@[simp]
+lemma fst_tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
+    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) (a : A') :
+    TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
+        ((tangentKerMap (B := B) φ
+          (derivationMulEquivTangentKer R A B d)).val.ofConv a) =
+      algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a) := by
+  rw [tangentKerMap_apply_val_ofConv]
+  exact derivationMulEquivTangentKer_apply_fst d ((φ : A' →ₐ[R] A) a)
+
 end Differential
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -134,7 +134,14 @@ lemma fst_tangentKerMap_apply (φ : A' →ₐc[R] A) (ψ : tangentKer R A B) (a 
   rw [mem_tangentKer_iff] at h
   have happ := congrArg
     (fun χ : A' →ₐ[R] Bialgebra.CounitAlgebra R A' B => χ a) h
-  simpa [IsScalarTower.coe_toAlgHom', TrivSqZeroExt.fstHom_apply] using happ
+  -- `fst` is the underlying function of `fstHom`.
+  have hfst : TrivSqZeroExt.fst (R := Bialgebra.CounitAlgebra R A' B)
+      ((tangentKerMap (B := B) φ ψ).val.ofConv a) =
+      TrivSqZeroExt.fstHom R (Bialgebra.CounitAlgebra R A' B)
+        (Bialgebra.CounitAlgebra R A' B)
+        ((tangentKerMap (B := B) φ ψ).val.ofConv a) := rfl
+  rw [hfst]
+  simpa [IsScalarTower.coe_toAlgHom'] using happ
 
 /-- Naturality of the tangent dictionary on infinitesimal parts: the differential of a
 morphism sends the dual-number point of a derivation `d` to a point whose infinitesimal


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tangent-dictionary-naturality"}-->

Makes `TauCeti.fst_apply_of_mem_ker` public with a docstring: the classical part of any tangent-kernel point is the identity point. Previously private in `Tangent/Basic.lean`, this is the general form covering, in particular, images under the differential `tangentKerMap` (#1729) — the reviewed replacement for a differential-specific restatement.

The infinitesimal-part naturality (the differential acts on derivations by precomposition) is simp-derivable from `tangentKerMap_apply_val_ofConv` and `derivationMulEquivTangentKer_apply_snd` and, per review, is not separately named; its bundled form arrives with the derivation-transport follow-up.

Roadmap: ReductiveGroups

Motivated by `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 2 "Lie algebra and the adjoint representation" (supporting API for the differential of a homomorphism).

🤖 Generated with [Claude Code](https://claude.com/claude-code)