### PR TITLE
refactor(Poincare): extract the coordinate frame of an origin-fixing isometry

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Classification.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Classification.lean
@@ -169,15 +169,13 @@ theorem real_inner_map_map_of_pseudoHyperbolicExpr_map_eq (h0 : g 0 = 0)
   rw [hsub, hnz, hnw] at h1
   linarith
 
-/-- **An isometry fixing the origin induces a coordinate frame.** Doubling the images of the probe
-points `1 / 2` and `I / 2` gives an orthonormal pair whose real inner products with `g z` are the
-Cartesian coordinates of `z`. This is the whole content of the two evaluations that pin such an
-isometry down; `TauCeti.exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj` then only has to
-recognise which of the two quarter turns relates the frame. -/
-theorem exists_orthonormal_pair_real_inner_map_eq (h0 : g 0 = 0) :
+/-- **An isometry fixing the origin admits a coordinate frame.** There is an orthonormal pair whose
+real inner products with `g z` recover the real and imaginary parts of `z`. -/
+private theorem exists_orthonormal_pair_real_inner_map_eq (h0 : g 0 = 0) :
     ∃ e₁ e₂ : ℂ, ‖e₁‖ = 1 ∧ ‖e₂‖ = 1 ∧ ⟪e₁, e₂⟫_ℝ = 0 ∧
       (∀ z ∈ ball (0 : ℂ) 1, ⟪e₁, g z⟫_ℝ = z.re) ∧
       (∀ z ∈ ball (0 : ℂ) 1, ⟪e₂, g z⟫_ℝ = z.im) := by
+  -- Take the doubled images of the probe points `1 / 2` and `I / 2`.
   set p : ℂ := ((1 / 2 : ℝ) : ℂ) with hp_def
   set q : ℂ := I * ((1 / 2 : ℝ) : ℂ) with hq_def
   have hnp : ‖p‖ = 1 / 2 := by rw [hp_def, Complex.norm_real]; norm_num

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Classification.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Isometry/Classification.lean
@@ -169,6 +169,41 @@ theorem real_inner_map_map_of_pseudoHyperbolicExpr_map_eq (h0 : g 0 = 0)
   rw [hsub, hnz, hnw] at h1
   linarith
 
+/-- **An isometry fixing the origin induces a coordinate frame.** Doubling the images of the probe
+points `1 / 2` and `I / 2` gives an orthonormal pair whose real inner products with `g z` are the
+Cartesian coordinates of `z`. This is the whole content of the two evaluations that pin such an
+isometry down; `TauCeti.exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj` then only has to
+recognise which of the two quarter turns relates the frame. -/
+theorem exists_orthonormal_pair_real_inner_map_eq (h0 : g 0 = 0) :
+    ∃ e₁ e₂ : ℂ, ‖e₁‖ = 1 ∧ ‖e₂‖ = 1 ∧ ⟪e₁, e₂⟫_ℝ = 0 ∧
+      (∀ z ∈ ball (0 : ℂ) 1, ⟪e₁, g z⟫_ℝ = z.re) ∧
+      (∀ z ∈ ball (0 : ℂ) 1, ⟪e₂, g z⟫_ℝ = z.im) := by
+  set p : ℂ := ((1 / 2 : ℝ) : ℂ) with hp_def
+  set q : ℂ := I * ((1 / 2 : ℝ) : ℂ) with hq_def
+  have hnp : ‖p‖ = 1 / 2 := by rw [hp_def, Complex.norm_real]; norm_num
+  have hnq : ‖q‖ = 1 / 2 := by
+    rw [hq_def, norm_mul, Complex.norm_I, one_mul, Complex.norm_real]
+    norm_num
+  have hp : p ∈ ball (0 : ℂ) 1 := by rw [mem_ball_zero_iff, hnp]; norm_num
+  have hq : q ∈ ball (0 : ℂ) 1 := by rw [mem_ball_zero_iff, hnq]; norm_num
+  refine ⟨(2 : ℝ) • g p, (2 : ℝ) • g q, ?_, ?_, ?_, fun z hz => ?_, fun z hz => ?_⟩
+  · rw [norm_smul, norm_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp, hnp]; norm_num
+  · rw [norm_smul, norm_map_of_pseudoHyperbolicExpr_map_eq hg h0 hq, hnq]; norm_num
+  · rw [real_inner_smul_left, real_inner_smul_right,
+      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp hq, real_inner_eq]
+    simp only [hp_def, hq_def, Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im,
+      Complex.ofReal_re, Complex.ofReal_im]
+    ring
+  · rw [real_inner_smul_left,
+      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp hz, real_inner_eq]
+    simp only [hp_def, Complex.ofReal_re, Complex.ofReal_im]
+    ring
+  · rw [real_inner_smul_left,
+      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hq hz, real_inner_eq]
+    simp only [hq_def, Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im,
+      Complex.ofReal_re, Complex.ofReal_im]
+    ring
+
 end FixZero
 
 /-- Two unit complex numbers with vanishing real inner product differ by a quarter turn. -/
@@ -206,44 +241,10 @@ theorem exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj
     ∃ u : ℂ, ‖u‖ = 1 ∧
       (EqOn g (fun z => u * z) (ball (0 : ℂ) 1) ∨
         EqOn g (fun z => u * conj z) (ball (0 : ℂ) 1)) := by
-  set p : ℂ := ((1 / 2 : ℝ) : ℂ) with hp_def
-  set q : ℂ := I * ((1 / 2 : ℝ) : ℂ) with hq_def
-  have hnp : ‖p‖ = 1 / 2 := by rw [hp_def, Complex.norm_real]; norm_num
-  have hnq : ‖q‖ = 1 / 2 := by
-    rw [hq_def, norm_mul, Complex.norm_I, one_mul, Complex.norm_real]
-    norm_num
-  have hp : p ∈ ball (0 : ℂ) 1 := by rw [mem_ball_zero_iff, hnp]; norm_num
-  have hq : q ∈ ball (0 : ℂ) 1 := by rw [mem_ball_zero_iff, hnq]; norm_num
-  set e₁ : ℂ := (2 : ℝ) • g p with he₁_def
-  set e₂ : ℂ := (2 : ℝ) • g q with he₂_def
-  have hn₁ : ‖e₁‖ = 1 := by
-    rw [he₁_def, norm_smul, norm_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp, hnp]
-    norm_num
-  have hn₂ : ‖e₂‖ = 1 := by
-    rw [he₂_def, norm_smul, norm_map_of_pseudoHyperbolicExpr_map_eq hg h0 hq, hnq]
-    norm_num
+  -- The orthonormal frame reading off the coordinates of `g z`.
+  obtain ⟨e₁, e₂, hn₁, hn₂, horth, hcoord₁, hcoord₂⟩ :=
+    exists_orthonormal_pair_real_inner_map_eq hg h0
   have hmul₁ : e₁ * conj e₁ = 1 := by rw [Complex.mul_conj', hn₁]; norm_num
-  -- The frame is orthonormal.
-  have horth : ⟪e₁, e₂⟫_ℝ = 0 := by
-    rw [he₁_def, he₂_def, real_inner_smul_left, real_inner_smul_right,
-      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp hq, real_inner_eq]
-    simp only [hp_def, hq_def, Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im,
-      Complex.ofReal_re, Complex.ofReal_im]
-    ring
-  -- The frame reads off the coordinates of `g z`.
-  have hcoord₁ : ∀ z ∈ ball (0 : ℂ) 1, ⟪e₁, g z⟫_ℝ = z.re := by
-    intro z hz
-    rw [he₁_def, real_inner_smul_left,
-      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hp hz, real_inner_eq]
-    simp only [hp_def, Complex.ofReal_re, Complex.ofReal_im]
-    ring
-  have hcoord₂ : ∀ z ∈ ball (0 : ℂ) 1, ⟪e₂, g z⟫_ℝ = z.im := by
-    intro z hz
-    rw [he₂_def, real_inner_smul_left,
-      real_inner_map_map_of_pseudoHyperbolicExpr_map_eq hg h0 hq hz, real_inner_eq]
-    simp only [hq_def, Complex.mul_re, Complex.mul_im, Complex.I_re, Complex.I_im,
-      Complex.ofReal_re, Complex.ofReal_im]
-    ring
   have hre : ∀ z ∈ ball (0 : ℂ) 1, (conj e₁ * g z).re = z.re := fun z hz => by
     rw [mul_comm, ← Complex.inner e₁ (g z)]; exact hcoord₁ z hz
   refine ⟨e₁, hn₁, ?_⟩


### PR DESCRIPTION
`exists_norm_eq_one_eqOn_ball_const_mul_or_const_mul_conj` had a **65-line body** — the longest on `main` when this was written. No statement changes; the body is now **31 lines**.

## What was inline

Before the argument proper began, 34 lines built an orthonormal frame: the two probe points `1/2` and `I/2` with their norms and disc membership, their doubled images `e₁`, `e₂`, the norms of those, orthogonality, and the two coordinate readouts `⟪e₁, g z⟫_ℝ = z.re`, `⟪e₂, g z⟫_ℝ = z.im`.

That construction uses nothing but `hg` and `h0` — none of the case analysis, and none of `hmul₁`, `hre` or the quarter-turn lemma. So it is now a lemma in `section FixZero`, where `hg` is already a section variable:

```lean
theorem exists_orthonormal_pair_real_inner_map_eq (h0 : g 0 = 0) :
    ∃ e₁ e₂ : ℂ, ‖e₁‖ = 1 ∧ ‖e₂‖ = 1 ∧ ⟪e₁, e₂⟫_ℝ = 0 ∧
      (∀ z ∈ ball (0 : ℂ) 1, ⟪e₁, g z⟫_ℝ = z.re) ∧
      (∀ z ∈ ball (0 : ℂ) 1, ⟪e₂, g z⟫_ℝ = z.im)
```

The classification now opens by obtaining the frame and proceeds directly to recognising which quarter turn relates `e₁` and `e₂`, which is the part with actual content. The probe points are an implementation detail of the frame and no longer appear in it.

The statement is the natural one: it says exactly what the module docstring already described as the key step — "the images of `1 / 2` and of `I / 2`, doubled, are orthogonal unit vectors `e₁, e₂`, while `⟪e₁, h z⟫_ℝ = z.re` and `⟪e₂, h z⟫_ℝ = z.im` read off the coordinates".

## Granularity

I first tried the smaller extraction — a shared engine for the two near-identical coordinate readouts, which differ only in probe point and component. It compiled but took the body only 65 → 61, still over the bar, in exchange for new API: the duplication between those two `have`s is mostly in their `simp only` sets, which genuinely differ. The frame as a whole is the unit that carries its own weight, so that attempt was discarded rather than shipped.

Longest body in the file is now 42 (`exists_eq_unitDiscStandardAutomorphismIsometryEquiv_or_comp_star`), and the new lemma is 25.

Gates: `lake build` (6220 jobs) · `lake exe axioms` (19938 declarations, allowlist clean) · `lake exe module-system` (1091 modules) · `scripts/lint-env.sh` PASS.

Roadmap: ConformalMapping