### PR TITLE
feat: separate tangent vectors by derivations

### DIFF
--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -4,7 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+import Mathlib.Analysis.LocallyConvex.SeparatingDual
 public import Mathlib.Geometry.Manifold.DerivationBundle
+import Mathlib.Geometry.Manifold.BumpFunction
+import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
 public import Mathlib.Geometry.Manifold.MFDeriv.NormedSpace
 
 /-!
@@ -16,6 +19,8 @@ a canonical linear map from the ordinary tangent space to the algebraic point de
 ## Main results
 
 * `tangentToPointDerivation`: the point derivation associated to a tangent vector.
+* `tangentToPointDerivation_injective`: distinct tangent vectors induce distinct point derivations
+  on finite-dimensional Hausdorff real manifolds.
 * `tangentToPointDerivation_mfderiv`: this association commutes with differentials.
 
 ## References
@@ -26,7 +31,7 @@ a canonical linear map from the ordinary tangent space to the algebraic point de
 
 public section
 
-open scoped ContDiff Derivation Manifold
+open scoped ContDiff Derivation Manifold Topology
 
 noncomputable section
 
@@ -87,6 +92,50 @@ directional derivative. -/
 theorem tangentToPointDerivation_apply (x : M) (v : TangentSpace I x)
     (f : C^∞⟮I, M; 𝕜⟯) : tangentToPointDerivation x v f = mvfderiv I f x v :=
   rfl
+
+/-- On a finite-dimensional Hausdorff real manifold, smooth scalar-valued functions distinguish
+tangent vectors. -/
+theorem tangentToPointDerivation_injective
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M] [T2Space M]
+    (x : M) :
+    Function.Injective (tangentToPointDerivation (I := I) x) := by
+  intro v w hvw
+  -- The tangent-space type synonym carries no normed-space instance of its own, so expose the
+  -- model space before applying the separating-dual theorem.
+  change E at v w
+  change v = w
+  rw [SeparatingDual.eq_iff_forall_dual_eq (R := ℝ)]
+  intro φ
+  let b : SmoothBumpFunction I x := Classical.choice inferInstance
+  let f : C^∞⟮I, M; ℝ⟯ :=
+    ⟨fun y ↦ φ (b y • extChartAt I x y),
+      φ.contMDiff.comp (b.contMDiff_smul contMDiffOn_extChartAt)⟩
+  have hlocal : (f : M → ℝ) =ᶠ[𝓝 x] φ ∘ extChartAt I x := by
+    filter_upwards [b.eventuallyEq_one] with y hy
+    simp [f, hy]
+  have hfv : mvfderiv I f x v = mvfderiv I f x w := by
+    have h := congrArg (fun D ↦ D f) hvw
+    -- Unbundle the comparison map after evaluating the two point derivations at `f`.
+    change mvfderiv I f x v = mvfderiv I f x w at h
+    exact h
+  have hderiv (u : TangentSpace I x) : mvfderiv I f x u = φ u := by
+    have hφ : mfderiv 𝓘(ℝ, E) 𝓘(ℝ, ℝ) φ (extChartAt I x x) = φ :=
+      φ.hasFDerivAt.hasMFDerivAt.mfderiv
+    rw [mvfderiv, hlocal.mfderiv_eq,
+      mfderiv_comp x φ.mdifferentiableAt
+        (mdifferentiableAt_extChartAt (I := I) (mem_chart_source H x)),
+      hφ, mfderiv_extChartAt_self]
+    -- Unwrap the tangent-space synonym and apply the resulting identity linear map; there is no
+    -- separate simplification lemma for this final coercion boundary.
+    change φ u = φ u
+    rfl
+  -- The separating-dual goal is stated on the model space after the tangent-space synonym was
+  -- exposed above, so return to the corresponding scalar equality before using `hderiv`.
+  change φ v = φ w
+  rw [← hderiv v, ← hderiv w]
+  exact hfv
 
 variable {E' : Type*} [NormedAddCommGroup E'] [NormedSpace 𝕜 E']
   {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners 𝕜 E' H'}


### PR DESCRIPTION
## Summary

- prove that the canonical linear map from tangent vectors to point derivations is injective on finite-dimensional real manifolds
- separate unequal tangent vectors with a continuous linear functional
- realize that functional locally as a smooth scalar-valued function using a smooth bump function and the extended chart

## Roadmap

This advances [Deliverable A, Layer 0, milestone (ii)](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md): identifying point derivations with the tangent space. It supplies the injectivity half of the required equivalence and advances [intention #135](https://github.com/TauCetiProject/TauCetiRoadmap/issues/135).

## Verification

- `lake env lean TauCeti/Geometry/Manifold/DerivationBundle.lean`
- `bash scripts/sandbox-build.sh` (6,220 build jobs; axiom audit, module-system check, and lint ratchet all pass)

Roadmap: RepresentationTheory