### PR TITLE
feat(Multiquadratic): the narrow class group and its surjection to the class group

### DIFF
--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -1,0 +1,89 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.ClassGroup.Basic
+public import TauCeti.NumberTheory.NumberField.TotallyPositive
+
+/-!
+# The narrow class group of a number field
+
+The **narrow class group** `Cl⁺(K)` of a number field `K` is the group of invertible fractional
+ideals of `𝓞 K` modulo the principal ones admitting a **totally positive** generator. It refines the
+ordinary class group `Cl(K)`, which quotients by *all* principal ideals: forgetting the positivity
+condition on generators gives a surjection `Cl⁺(K) → Cl(K)`.
+
+The narrow class group is the object whose `2`-rank the genus-theory `t - 1` formula computes for a
+real quadratic field (Layer 3 of the multiquadratic roadmap); for imaginary fields, where every unit
+is totally positive (there are no real places), `Cl⁺(K)` and `Cl(K)` coincide.
+
+## Main definitions and results
+
+* `TauCeti.NumberField.narrowPrincipalSubgroup`: the subgroup of principal fractional ideals with a
+  totally positive generator.
+* `TauCeti.NumberField.narrowClassGroup`: the quotient `Cl⁺(K)`, a `CommGroup`.
+* `TauCeti.NumberField.narrowClassGroup.mk`: the class of an invertible fractional ideal.
+* `TauCeti.NumberField.narrowClassGroup.toClassGroup`: the surjection `Cl⁺(K) → Cl(K)` forgetting
+  positivity, with `toClassGroup_surjective`.
+-/
+
+public section
+
+open NumberField FractionalIdeal
+open scoped nonZeroDivisors
+
+namespace TauCeti.NumberField
+
+variable (K : Type*) [Field K] [NumberField K]
+
+/-- The subgroup of `(FractionalIdeal (𝓞 K)⁰ K)ˣ` of **principal fractional ideals with a totally
+positive generator**: the image of `totallyPositiveUnits` under `toPrincipalIdeal`. The narrow class
+group quotients by this subgroup. -/
+noncomputable def narrowPrincipalSubgroup : Subgroup (FractionalIdeal (𝓞 K)⁰ K)ˣ :=
+  Subgroup.map (toPrincipalIdeal (𝓞 K) K) totallyPositiveUnits
+
+/-- The **narrow class group** `Cl⁺(K)`: invertible fractional ideals of `𝓞 K` modulo the principal
+ones with a totally positive generator. -/
+def narrowClassGroup : Type _ :=
+  (FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K
+
+noncomputable instance : CommGroup (narrowClassGroup K) :=
+  inferInstanceAs (CommGroup ((FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K))
+
+noncomputable instance : Inhabited (narrowClassGroup K) := ⟨1⟩
+
+namespace narrowClassGroup
+
+variable {K}
+
+/-- The class of an invertible fractional ideal in the narrow class group. -/
+noncomputable def mk : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* narrowClassGroup K :=
+  QuotientGroup.mk' (narrowPrincipalSubgroup K)
+
+/-- Principal fractional ideals with a totally positive generator have the same class as the whole
+ring: they map to `1` in the ordinary class group. -/
+theorem narrowPrincipalSubgroup_le_ker :
+    narrowPrincipalSubgroup K ≤ MonoidHom.ker (ClassGroup.mk (R := 𝓞 K) K) := by
+  rintro _ ⟨x, -, rfl⟩
+  rw [MonoidHom.mem_ker, ClassGroup.mk_eq_one_iff, coe_toPrincipalIdeal]
+  exact ⟨⟨(x : K), coe_spanSingleton _ _⟩⟩
+
+/-- The **surjection `Cl⁺(K) → Cl(K)`** onto the ordinary class group, forgetting the positivity
+condition on generators. -/
+noncomputable def toClassGroup : narrowClassGroup K →* ClassGroup (𝓞 K) :=
+  QuotientGroup.lift (narrowPrincipalSubgroup K) (ClassGroup.mk (R := 𝓞 K) K)
+    narrowPrincipalSubgroup_le_ker
+
+@[simp] theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
+    toClassGroup (mk I) = ClassGroup.mk K I :=
+  QuotientGroup.lift_mk' _ narrowPrincipalSubgroup_le_ker I
+
+theorem toClassGroup_surjective : Function.Surjective (toClassGroup (K := K)) :=
+  fun C => ClassGroup.induction (K := K)
+    (P := fun C => ∃ D, toClassGroup D = C) (fun I => ⟨mk I, rfl⟩) C
+
+end narrowClassGroup
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -102,7 +102,7 @@ with a totally positive generator. -/
     mk I = mk J ↔ ∃ z ∈ narrowPrincipalSubgroup K, I * z = J :=
   QuotientGroup.mk'_eq_mk' (narrowPrincipalSubgroup K)
 
-variable {M : Type*} [CommGroup M]
+variable {M : Type*} [Monoid M]
 
 /-- **Universal property of the narrow class group.** A homomorphism `φ` out of the invertible
 fractional ideals whose kernel contains `narrowPrincipalSubgroup` (i.e. `φ` is trivial on principal
@@ -111,6 +111,7 @@ noncomputable def lift (φ : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* M)
     (h : narrowPrincipalSubgroup K ≤ MonoidHom.ker φ) : NarrowClassGroup K →* M :=
   QuotientGroup.lift (narrowPrincipalSubgroup K) φ h
 
+/-- The descended homomorphism `lift φ h` agrees with `φ` on the class of each representative. -/
 @[simp] theorem lift_mk (φ : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* M)
     (h : narrowPrincipalSubgroup K ≤ MonoidHom.ker φ) (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     lift φ h (mk I) = φ I :=
@@ -135,6 +136,7 @@ condition on generators. -/
 noncomputable def toClassGroup : NarrowClassGroup K →* ClassGroup (𝓞 K) :=
   lift (ClassGroup.mk (R := 𝓞 K) K) narrowPrincipalSubgroup_le_ker
 
+/-- Forgetting positivity sends the narrow class of `I` to its ordinary ideal class. -/
 @[simp] theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     toClassGroup (mk I) = ClassGroup.mk K I :=
   lift_mk _ _ I

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -102,7 +102,7 @@ noncomputable def toClassGroup : NarrowClassGroup K →* ClassGroup (𝓞 K) :=
   QuotientGroup.lift (narrowPrincipalSubgroup K) (ClassGroup.mk (R := 𝓞 K) K)
     narrowPrincipalSubgroup_le_ker
 
-@[simp] theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
+theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     toClassGroup (mk I) = ClassGroup.mk K I :=
   QuotientGroup.lift_mk' _ narrowPrincipalSubgroup_le_ker I
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -63,34 +63,46 @@ variable (K)
 
 /-- The **narrow class group** `Cl⁺(K)`: invertible fractional ideals of `𝓞 K` modulo the principal
 ones with a totally positive generator. -/
-abbrev NarrowClassGroup : Type _ :=
+def NarrowClassGroup : Type _ :=
   (FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K
+
+noncomputable instance : CommGroup (NarrowClassGroup K) :=
+  inferInstanceAs (CommGroup ((FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K))
+
+noncomputable instance : Inhabited (NarrowClassGroup K) := ⟨1⟩
 
 namespace NarrowClassGroup
 
 variable {K}
 
 /-- The class of an invertible fractional ideal in the narrow class group. -/
-noncomputable abbrev mk : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* NarrowClassGroup K :=
+noncomputable def mk : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* NarrowClassGroup K :=
   QuotientGroup.mk' (narrowPrincipalSubgroup K)
 
+/-- Induction on the narrow class group: to prove a property of every class it suffices to prove it
+for the class `mk I` of every invertible fractional ideal. -/
+@[elab_as_elim] theorem induction {P : NarrowClassGroup K → Prop}
+    (h : ∀ I, P (mk I)) (x : NarrowClassGroup K) : P x :=
+  QuotientGroup.induction_on x h
+
+/-- Every narrow ideal class is represented by an invertible fractional ideal. -/
 theorem mk_surjective : Function.Surjective (mk : _ → NarrowClassGroup K) :=
   QuotientGroup.mk'_surjective _
 
 /-- A fractional ideal has trivial narrow class exactly when it has a totally positive generator. -/
-theorem mk_eq_one_iff {I : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
+@[simp] theorem mk_eq_one_iff {I : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
     mk I = 1 ↔ I ∈ narrowPrincipalSubgroup K :=
   QuotientGroup.eq_one_iff I
 
 /-- Two fractional ideals have the same narrow class exactly when they differ by a principal ideal
 with a totally positive generator. -/
-theorem mk_eq_mk_iff {I J : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
+@[simp] theorem mk_eq_mk_iff {I J : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
     mk I = mk J ↔ ∃ z ∈ narrowPrincipalSubgroup K, I * z = J :=
   QuotientGroup.mk'_eq_mk' (narrowPrincipalSubgroup K)
 
 /-- Principal fractional ideals with a totally positive generator have the same class as the whole
 ring: they map to `1` in the ordinary class group. -/
-theorem narrowPrincipalSubgroup_le_ker :
+private theorem narrowPrincipalSubgroup_le_ker :
     narrowPrincipalSubgroup K ≤ MonoidHom.ker (ClassGroup.mk (R := 𝓞 K) K) := by
   rintro _ ⟨x, -, rfl⟩
   rw [MonoidHom.mem_ker, ClassGroup.mk_eq_one_iff, coe_toPrincipalIdeal]
@@ -102,7 +114,7 @@ noncomputable def toClassGroup : NarrowClassGroup K →* ClassGroup (𝓞 K) :=
   QuotientGroup.lift (narrowPrincipalSubgroup K) (ClassGroup.mk (R := 𝓞 K) K)
     narrowPrincipalSubgroup_le_ker
 
-theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
+@[simp] theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     toClassGroup (mk I) = ClassGroup.mk K I :=
   QuotientGroup.lift_mk' _ narrowPrincipalSubgroup_le_ker I
 

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -30,7 +30,9 @@ is totally positive (there are no real places), `Cl⁺(K)` and `Cl(K)` coincide.
   totally positive generator, with `mem_narrowPrincipalSubgroup`.
 * `TauCeti.NumberField.NarrowClassGroup`: the quotient `Cl⁺(K)`, a `CommGroup`.
 * `TauCeti.NumberField.NarrowClassGroup.mk`: the class of an invertible fractional ideal, with
-  `mk_surjective`, `mk_eq_one_iff`, and `mk_eq_mk_iff`.
+  `mk_surjective`, `mk_eq_one_iff`, `mk_eq_mk_iff`, and the eliminator `induction`.
+* `TauCeti.NumberField.NarrowClassGroup.lift`: the universal property — a homomorphism trivial on
+  `narrowPrincipalSubgroup` descends to `Cl⁺(K)`, with `lift_mk` and `lift_unique`.
 * `TauCeti.NumberField.NarrowClassGroup.toClassGroup`: the surjection `Cl⁺(K) → Cl(K)` forgetting
   positivity, with `toClassGroup_surjective`.
 -/
@@ -100,6 +102,26 @@ with a totally positive generator. -/
     mk I = mk J ↔ ∃ z ∈ narrowPrincipalSubgroup K, I * z = J :=
   QuotientGroup.mk'_eq_mk' (narrowPrincipalSubgroup K)
 
+variable {M : Type*} [CommGroup M]
+
+/-- **Universal property of the narrow class group.** A homomorphism `φ` out of the invertible
+fractional ideals whose kernel contains `narrowPrincipalSubgroup` (i.e. `φ` is trivial on principal
+ideals with a totally positive generator) descends to a homomorphism `Cl⁺(K) → M`. -/
+noncomputable def lift (φ : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* M)
+    (h : narrowPrincipalSubgroup K ≤ MonoidHom.ker φ) : NarrowClassGroup K →* M :=
+  QuotientGroup.lift (narrowPrincipalSubgroup K) φ h
+
+@[simp] theorem lift_mk (φ : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* M)
+    (h : narrowPrincipalSubgroup K ≤ MonoidHom.ker φ) (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
+    lift φ h (mk I) = φ I :=
+  QuotientGroup.lift_mk' _ h I
+
+/-- The lift is the unique homomorphism `Cl⁺(K) → M` factoring `φ` through `mk`. -/
+theorem lift_unique (φ : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* M)
+    (h : narrowPrincipalSubgroup K ≤ MonoidHom.ker φ) (ψ : NarrowClassGroup K →* M)
+    (hψ : ∀ I, ψ (mk I) = φ I) : ψ = lift φ h :=
+  MonoidHom.ext fun x => induction (fun I => (hψ I).trans (lift_mk φ h I).symm) x
+
 /-- Principal fractional ideals with a totally positive generator have the same class as the whole
 ring: they map to `1` in the ordinary class group. -/
 private theorem narrowPrincipalSubgroup_le_ker :
@@ -111,12 +133,11 @@ private theorem narrowPrincipalSubgroup_le_ker :
 /-- The **surjection `Cl⁺(K) → Cl(K)`** onto the ordinary class group, forgetting the positivity
 condition on generators. -/
 noncomputable def toClassGroup : NarrowClassGroup K →* ClassGroup (𝓞 K) :=
-  QuotientGroup.lift (narrowPrincipalSubgroup K) (ClassGroup.mk (R := 𝓞 K) K)
-    narrowPrincipalSubgroup_le_ker
+  lift (ClassGroup.mk (R := 𝓞 K) K) narrowPrincipalSubgroup_le_ker
 
 @[simp] theorem toClassGroup_mk (I : (FractionalIdeal (𝓞 K)⁰ K)ˣ) :
     toClassGroup (mk I) = ClassGroup.mk K I :=
-  QuotientGroup.lift_mk' _ narrowPrincipalSubgroup_le_ker I
+  lift_mk _ _ I
 
 /-- The forgetful homomorphism `Cl⁺(K) → Cl(K)` onto the ordinary class group is surjective. -/
 theorem toClassGroup_surjective : Function.Surjective (toClassGroup (K := K)) :=

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -15,6 +15,11 @@ ideals of `𝓞 K` modulo the principal ones admitting a **totally positive** ge
 ordinary class group `Cl(K)`, which quotients by *all* principal ideals: forgetting the positivity
 condition on generators gives a surjection `Cl⁺(K) → Cl(K)`.
 
+This construction adapts Mathlib's `ClassGroup` (`Mathlib.RingTheory.ClassGroup.Basic`): where
+`ClassGroup R` is `(FractionalIdeal R⁰ (FractionRing R))ˣ ⧸ (toPrincipalIdeal R _).range`, the
+narrow class group quotients the invertible fractional ideals over `K` by the *smaller* subgroup
+`narrowPrincipalSubgroup` of principal ideals with a totally positive generator.
+
 The narrow class group is the object whose `2`-rank the genus-theory `t - 1` formula computes for a
 real quadratic field (Layer 3 of the multiquadratic roadmap); for imaginary fields, where every unit
 is totally positive (there are no real places), `Cl⁺(K)` and `Cl(K)` coincide.
@@ -22,10 +27,11 @@ is totally positive (there are no real places), `Cl⁺(K)` and `Cl(K)` coincide.
 ## Main definitions and results
 
 * `TauCeti.NumberField.narrowPrincipalSubgroup`: the subgroup of principal fractional ideals with a
-  totally positive generator.
-* `TauCeti.NumberField.narrowClassGroup`: the quotient `Cl⁺(K)`, a `CommGroup`.
-* `TauCeti.NumberField.narrowClassGroup.mk`: the class of an invertible fractional ideal.
-* `TauCeti.NumberField.narrowClassGroup.toClassGroup`: the surjection `Cl⁺(K) → Cl(K)` forgetting
+  totally positive generator, with `mem_narrowPrincipalSubgroup`.
+* `TauCeti.NumberField.NarrowClassGroup`: the quotient `Cl⁺(K)`, a `CommGroup`.
+* `TauCeti.NumberField.NarrowClassGroup.mk`: the class of an invertible fractional ideal, with
+  `mk_surjective`, `mk_eq_one_iff`, and `mk_eq_mk_iff`.
+* `TauCeti.NumberField.NarrowClassGroup.toClassGroup`: the surjection `Cl⁺(K) → Cl(K)` forgetting
   positivity, with `toClassGroup_surjective`.
 -/
 
@@ -44,23 +50,43 @@ group quotients by this subgroup. -/
 noncomputable def narrowPrincipalSubgroup : Subgroup (FractionalIdeal (𝓞 K)⁰ K)ˣ :=
   Subgroup.map (toPrincipalIdeal (𝓞 K) K) totallyPositiveUnits
 
+variable {K}
+
+/-- A fractional ideal lies in `narrowPrincipalSubgroup` exactly when it is `toPrincipalIdeal` of a
+totally positive unit. -/
+@[simp] theorem mem_narrowPrincipalSubgroup {I : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
+    I ∈ narrowPrincipalSubgroup K ↔
+      ∃ x : Kˣ, IsTotallyPositive (x : K) ∧ toPrincipalIdeal (𝓞 K) K x = I := by
+  simp only [narrowPrincipalSubgroup, Subgroup.mem_map, mem_totallyPositiveUnits]
+
+variable (K)
+
 /-- The **narrow class group** `Cl⁺(K)`: invertible fractional ideals of `𝓞 K` modulo the principal
 ones with a totally positive generator. -/
-def narrowClassGroup : Type _ :=
+abbrev NarrowClassGroup : Type _ :=
   (FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K
 
-noncomputable instance : CommGroup (narrowClassGroup K) :=
-  inferInstanceAs (CommGroup ((FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K))
-
-noncomputable instance : Inhabited (narrowClassGroup K) := ⟨1⟩
-
-namespace narrowClassGroup
+namespace NarrowClassGroup
 
 variable {K}
 
 /-- The class of an invertible fractional ideal in the narrow class group. -/
-noncomputable def mk : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* narrowClassGroup K :=
+noncomputable abbrev mk : (FractionalIdeal (𝓞 K)⁰ K)ˣ →* NarrowClassGroup K :=
   QuotientGroup.mk' (narrowPrincipalSubgroup K)
+
+theorem mk_surjective : Function.Surjective (mk : _ → NarrowClassGroup K) :=
+  QuotientGroup.mk'_surjective _
+
+/-- A fractional ideal has trivial narrow class exactly when it has a totally positive generator. -/
+theorem mk_eq_one_iff {I : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
+    mk I = 1 ↔ I ∈ narrowPrincipalSubgroup K :=
+  QuotientGroup.eq_one_iff I
+
+/-- Two fractional ideals have the same narrow class exactly when they differ by a principal ideal
+with a totally positive generator. -/
+theorem mk_eq_mk_iff {I J : (FractionalIdeal (𝓞 K)⁰ K)ˣ} :
+    mk I = mk J ↔ ∃ z ∈ narrowPrincipalSubgroup K, I * z = J :=
+  QuotientGroup.mk'_eq_mk' (narrowPrincipalSubgroup K)
 
 /-- Principal fractional ideals with a totally positive generator have the same class as the whole
 ring: they map to `1` in the ordinary class group. -/
@@ -72,7 +98,7 @@ theorem narrowPrincipalSubgroup_le_ker :
 
 /-- The **surjection `Cl⁺(K) → Cl(K)`** onto the ordinary class group, forgetting the positivity
 condition on generators. -/
-noncomputable def toClassGroup : narrowClassGroup K →* ClassGroup (𝓞 K) :=
+noncomputable def toClassGroup : NarrowClassGroup K →* ClassGroup (𝓞 K) :=
   QuotientGroup.lift (narrowPrincipalSubgroup K) (ClassGroup.mk (R := 𝓞 K) K)
     narrowPrincipalSubgroup_le_ker
 
@@ -80,10 +106,11 @@ noncomputable def toClassGroup : narrowClassGroup K →* ClassGroup (𝓞 K) :=
     toClassGroup (mk I) = ClassGroup.mk K I :=
   QuotientGroup.lift_mk' _ narrowPrincipalSubgroup_le_ker I
 
+/-- The forgetful homomorphism `Cl⁺(K) → Cl(K)` onto the ordinary class group is surjective. -/
 theorem toClassGroup_surjective : Function.Surjective (toClassGroup (K := K)) :=
   fun C => ClassGroup.induction (K := K)
-    (P := fun C => ∃ D, toClassGroup D = C) (fun I => ⟨mk I, rfl⟩) C
+    (P := fun C => ∃ D, toClassGroup D = C) (fun I => ⟨mk I, toClassGroup_mk I⟩) C
 
-end narrowClassGroup
+end NarrowClassGroup
 
 end TauCeti.NumberField


### PR DESCRIPTION
Introduces the **narrow class group** `Cl⁺(K)` of a number field — the central object of the
genus-theory `t − 1` (real case) branch of Layer 3.

`Cl⁺(K)` is the group of invertible fractional ideals of `𝓞 K` modulo the principal ones admitting
a **totally positive** generator. Concretely:

- `narrowPrincipalSubgroup K` — the subgroup of `(FractionalIdeal (𝓞 K)⁰ K)ˣ` of principal ideals
  with a totally positive generator, i.e. the image of `totallyPositiveUnits` (from the merged
  total-positivity API) under `toPrincipalIdeal`;
- `narrowClassGroup K := (FractionalIdeal (𝓞 K)⁰ K)ˣ ⧸ narrowPrincipalSubgroup K`, a `CommGroup`,
  with class map `narrowClassGroup.mk`;
- `narrowClassGroup.toClassGroup : Cl⁺(K) →* Cl(K)` — the **surjection onto the ordinary class
  group** obtained by forgetting the positivity condition (since totally-positive-principal ⊆
  all-principal), with `toClassGroup_surjective`.

This mirrors Mathlib's `ClassGroup R := (FractionalIdeal R⁰ (FractionRing R))ˣ ⧸ (toPrincipalIdeal
_).range`, refining the quotient to the totally-positive principal subgroup. Sorry-free, default
axioms. For imaginary `K` (no real places) every unit is totally positive, so `Cl⁺(K) = Cl(K)`; the
gap is the real-place signature data, whose `2`-rank the `t − 1` formula counts.

Roadmap: Multiquadratic

Roadmap target: Layer 3 states *"defining the narrow class group is part of this layer and the
prerequisite for the real case"* of the 2-rank `= t − 1` theorem. This is that definition, plus the
`Cl⁺ ↠ Cl` comparison map.

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"Multiquadratic/narrow-class-group"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
