### PR TITLE
feat: define the tangent-space exponential

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Basic.lean
@@ -1,0 +1,77 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.IntegralCurve
+
+/-!
+# The exponential map of a Lie group
+
+This file defines the tangent-space exponential of a finite-dimensional real Lie group by
+evaluating the canonical invariant one-parameter subgroup at time one.
+
+## Main results
+
+* `mulInvariantExp`: the time-one value of the invariant curve attached to a tangent vector.
+* `mulInvariantExp_smul`: scaling a tangent vector is evaluation at the corresponding time.
+* `mulInvariantExp_add_smul`: the exponential along a fixed line is a one-parameter subgroup.
+* `mulInvariantExp_zero`: the exponential sends zero to the group identity.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The exponential map".
+-/
+
+public section
+
+open Function Manifold VectorField
+open scoped Manifold
+
+noncomputable section
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+/-- The tangent-space exponential obtained by evaluating the canonical invariant curve at time
+one. This is the tangent-vector precursor of the roadmap's derivation-based `lieExp`. -/
+noncomputable def mulInvariantExp [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) : G :=
+  mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1)
+
+/-- Scaling a tangent vector corresponds to evaluating its invariant integral curve at the scale
+factor. -/
+theorem mulInvariantExp_smul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (t : ℝ) :
+    mulInvariantExp (t • v) = mulInvariantIntegralCurve v 1 t := by
+  let γ := mulInvariantIntegralCurve v 1
+  have hscaled : IsMIntegralCurve (γ ∘ (· * t)) (mulInvariantVectorField (t • v)) := by
+    rw [mulInvariantVectorField_smul]
+    exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).comp_mul t
+  have heq : γ ∘ (· * t) = mulInvariantIntegralCurve (t • v) 1 := by
+    apply eq_mulInvariantIntegralCurve (t • v) 1
+    · simp [γ]
+    · exact hscaled
+  rw [mulInvariantExp, mulInvariantOneParameterSubgroup_apply]
+  simpa [γ] using (congrFun heq 1).symm
+
+/-- The exponential along a line satisfies the one-parameter subgroup law. -/
+@[simp]
+theorem mulInvariantExp_add_smul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (s t : ℝ) :
+    mulInvariantExp ((s + t) • v) = mulInvariantExp (s • v) * mulInvariantExp (t • v) := by
+  rw [mulInvariantExp_smul, mulInvariantExp_smul, mulInvariantExp_smul,
+    mulInvariantIntegralCurve_add]
+
+/-- The tangent-space exponential sends zero to the group identity. -/
+@[simp]
+theorem mulInvariantExp_zero [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] : mulInvariantExp (0 : GroupLieAlgebra I G) = 1 := by
+  simpa using mulInvariantExp_smul (0 : GroupLieAlgebra I G) 0

--- a/TauCeti/Geometry/Lie/Exponential/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Basic.lean
@@ -9,15 +9,17 @@ public import TauCeti.Geometry.Lie.IntegralCurve
 /-!
 # The exponential map of a Lie group
 
-This file defines the tangent-space exponential of a finite-dimensional real Lie group by
-evaluating the canonical invariant one-parameter subgroup at time one.
+This file defines the tangent-space exponential of a real Lie group modeled on a complete normed
+space by evaluating the canonical invariant one-parameter subgroup at time one.
 
 ## Main results
 
 * `mulInvariantExp`: the time-one value of the invariant curve attached to a tangent vector.
 * `mulInvariantExp_smul`: scaling a tangent vector is evaluation at the corresponding time.
+* `mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul`: the bundled subgroup is the
+  exponential along a line.
 * `mulInvariantExp_add_smul`: the exponential along a fixed line is a one-parameter subgroup.
-* `mulInvariantExp_zero`: the exponential sends zero to the group identity.
+* `mulInvariantExp_zero`, `mulInvariantExp_neg`: the identity and inverse laws.
 
 ## References
 
@@ -43,22 +45,29 @@ noncomputable def mulInvariantExp [CompleteSpace E]
     [BoundarylessManifold I G] (v : GroupLieAlgebra I G) : G :=
   mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1)
 
+/-- The tangent-space exponential is the canonical invariant integral curve evaluated at time
+one. -/
+theorem mulInvariantExp_eq_mulInvariantIntegralCurve [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) :
+    mulInvariantExp v = mulInvariantIntegralCurve v 1 1 := by
+  rw [mulInvariantExp, mulInvariantOneParameterSubgroup_apply]
+
 /-- Scaling a tangent vector corresponds to evaluating its invariant integral curve at the scale
 factor. -/
 theorem mulInvariantExp_smul [CompleteSpace E]
     [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
     [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (t : ℝ) :
     mulInvariantExp (t • v) = mulInvariantIntegralCurve v 1 t := by
-  let γ := mulInvariantIntegralCurve v 1
-  have hscaled : IsMIntegralCurve (γ ∘ (· * t)) (mulInvariantVectorField (t • v)) := by
-    rw [mulInvariantVectorField_smul]
-    exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).comp_mul t
-  have heq : γ ∘ (· * t) = mulInvariantIntegralCurve (t • v) 1 := by
-    apply eq_mulInvariantIntegralCurve (t • v) 1
-    · simp [γ]
-    · exact hscaled
-  rw [mulInvariantExp, mulInvariantOneParameterSubgroup_apply]
-  simpa [γ] using (congrFun heq 1).symm
+  rw [mulInvariantExp_eq_mulInvariantIntegralCurve, mulInvariantIntegralCurve_smul, one_mul]
+
+/-- The canonical one-parameter subgroup is the tangent-space exponential along its generating
+line. -/
+theorem mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (t : ℝ) :
+    mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd t) = mulInvariantExp (t • v) := by
+  rw [mulInvariantOneParameterSubgroup_apply, mulInvariantExp_smul]
 
 /-- The exponential along a line satisfies the one-parameter subgroup law. -/
 @[simp]
@@ -75,3 +84,20 @@ theorem mulInvariantExp_zero [CompleteSpace E]
     [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
     [BoundarylessManifold I G] : mulInvariantExp (0 : GroupLieAlgebra I G) = 1 := by
   simpa using mulInvariantExp_smul (0 : GroupLieAlgebra I G) 0
+
+/-- The tangent-space exponential sends negation to inversion. -/
+@[simp]
+theorem mulInvariantExp_neg [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) :
+    mulInvariantExp (-v) = (mulInvariantExp v)⁻¹ := by
+  calc
+    mulInvariantExp (-v) =
+        mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd (-1)) := by
+      rw [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul]
+      simp
+    _ = mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1)⁻¹ := by simp
+    _ = (mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1))⁻¹ := by
+      rw [map_inv]
+    _ = (mulInvariantExp v)⁻¹ := by
+      rw [mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul, one_smul]

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -26,6 +26,7 @@ every point, after which Mathlib's uniform-time theorem produces global integral
 * `mulInvariantIntegralCurve_eq_const_mul`: curves through arbitrary points are left translates of
   the curve through the identity.
 * `mulInvariantIntegralCurve_add`: the identity curve satisfies the one-parameter subgroup law.
+* `mulInvariantIntegralCurve_smul`: scaling the vector field rescales time along its curves.
 * `mulInvariantOneParameterSubgroup`: the identity curve bundled as a continuous homomorphism.
 
 ## References
@@ -197,6 +198,21 @@ theorem mulInvariantIntegralCurve_add [CompleteSpace E]
     γ (s + t) = (γ ∘ (· + s)) t := by simp [add_comm]
     _ = mulInvariantIntegralCurve v (γ s) t := congrFun hshift t
     _ = γ s * γ t := congrFun (mulInvariantIntegralCurve_eq_const_mul v (γ s)) t
+
+/-- Scaling an invariant vector field rescales time along its canonical integral curves. -/
+theorem mulInvariantIntegralCurve_smul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (x : G) (t s : ℝ) :
+    mulInvariantIntegralCurve (t • v) x s = mulInvariantIntegralCurve v x (s * t) := by
+  let γ := mulInvariantIntegralCurve v x
+  have hscaled : IsMIntegralCurve (γ ∘ (· * t)) (mulInvariantVectorField (t • v)) := by
+    rw [mulInvariantVectorField_smul]
+    exact (isMIntegralCurve_mulInvariantIntegralCurve v x).comp_mul t
+  have heq : γ ∘ (· * t) = mulInvariantIntegralCurve (t • v) x := by
+    apply eq_mulInvariantIntegralCurve (t • v) x
+    · simp [γ]
+    · exact hscaled
+  exact (congrFun heq s).symm
 
 /-- The canonical invariant curve through the identity, bundled as a continuous one-parameter
 subgroup. -/

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -27,7 +27,6 @@ every point, after which Mathlib's uniform-time theorem produces global integral
   the curve through the identity.
 * `mulInvariantIntegralCurve_add`: the identity curve satisfies the one-parameter subgroup law.
 * `mulInvariantOneParameterSubgroup`: the identity curve bundled as a continuous homomorphism.
-* `mulInvariantExp`: the time-one value of the invariant curve attached to a tangent vector.
 
 ## References
 
@@ -221,34 +220,3 @@ theorem mulInvariantOneParameterSubgroup_apply [CompleteSpace E]
     mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd t) =
       mulInvariantIntegralCurve v 1 t :=
   (rfl)
-
-/-- The tangent-space exponential obtained by evaluating the canonical invariant curve at time
-one. This is the tangent-vector precursor of the roadmap's derivation-based `lieExp`. -/
-noncomputable def mulInvariantExp [CompleteSpace E]
-    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
-    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) : G :=
-  mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1)
-
-/-- Scaling a tangent vector corresponds to evaluating its invariant integral curve at the scale
-factor. -/
-theorem mulInvariantExp_smul [CompleteSpace E]
-    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
-    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (t : ℝ) :
-    mulInvariantExp (t • v) = mulInvariantIntegralCurve v 1 t := by
-  let γ := mulInvariantIntegralCurve v 1
-  have hscaled : IsMIntegralCurve (γ ∘ (· * t)) (mulInvariantVectorField (t • v)) := by
-    rw [mulInvariantVectorField_smul]
-    exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).comp_mul t
-  have heq : γ ∘ (· * t) = mulInvariantIntegralCurve (t • v) 1 := by
-    apply eq_mulInvariantIntegralCurve (t • v) 1
-    · simp [γ]
-    · exact hscaled
-  rw [mulInvariantExp, mulInvariantOneParameterSubgroup_apply]
-  simpa [γ] using (congrFun heq 1).symm
-
-/-- The tangent-space exponential sends zero to the group identity. -/
-@[simp]
-theorem mulInvariantExp_zero [CompleteSpace E]
-    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
-    [BoundarylessManifold I G] : mulInvariantExp (0 : GroupLieAlgebra I G) = 1 := by
-  simpa using mulInvariantExp_smul (0 : GroupLieAlgebra I G) 0

--- a/TauCeti/Geometry/Lie/IntegralCurve.lean
+++ b/TauCeti/Geometry/Lie/IntegralCurve.lean
@@ -27,6 +27,7 @@ every point, after which Mathlib's uniform-time theorem produces global integral
   the curve through the identity.
 * `mulInvariantIntegralCurve_add`: the identity curve satisfies the one-parameter subgroup law.
 * `mulInvariantOneParameterSubgroup`: the identity curve bundled as a continuous homomorphism.
+* `mulInvariantExp`: the time-one value of the invariant curve attached to a tangent vector.
 
 ## References
 
@@ -220,3 +221,34 @@ theorem mulInvariantOneParameterSubgroup_apply [CompleteSpace E]
     mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd t) =
       mulInvariantIntegralCurve v 1 t :=
   (rfl)
+
+/-- The tangent-space exponential obtained by evaluating the canonical invariant curve at time
+one. This is the tangent-vector precursor of the roadmap's derivation-based `lieExp`. -/
+noncomputable def mulInvariantExp [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) : G :=
+  mulInvariantOneParameterSubgroup v (Multiplicative.ofAdd 1)
+
+/-- Scaling a tangent vector corresponds to evaluating its invariant integral curve at the scale
+factor. -/
+theorem mulInvariantExp_smul [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] (v : GroupLieAlgebra I G) (t : ℝ) :
+    mulInvariantExp (t • v) = mulInvariantIntegralCurve v 1 t := by
+  let γ := mulInvariantIntegralCurve v 1
+  have hscaled : IsMIntegralCurve (γ ∘ (· * t)) (mulInvariantVectorField (t • v)) := by
+    rw [mulInvariantVectorField_smul]
+    exact (isMIntegralCurve_mulInvariantIntegralCurve v 1).comp_mul t
+  have heq : γ ∘ (· * t) = mulInvariantIntegralCurve (t • v) 1 := by
+    apply eq_mulInvariantIntegralCurve (t • v) 1
+    · simp [γ]
+    · exact hscaled
+  rw [mulInvariantExp, mulInvariantOneParameterSubgroup_apply]
+  simpa [γ] using (congrFun heq 1).symm
+
+/-- The tangent-space exponential sends zero to the group identity. -/
+@[simp]
+theorem mulInvariantExp_zero [CompleteSpace E]
+    [LieGroup I (minSmoothness ℝ 3) G] [IsManifold I 1 G] [T2Space G]
+    [BoundarylessManifold I G] : mulInvariantExp (0 : GroupLieAlgebra I G) = 1 := by
+  simpa using mulInvariantExp_smul (0 : GroupLieAlgebra I G) 0


### PR DESCRIPTION
## Goal

Package the time-one value of the canonical left-invariant integral curve as the tangent-space precursor of the roadmap exponential map.

## Why this is correct

- `mulInvariantExp v` evaluates the canonical one-parameter subgroup from #1763 at time one.
- `mulInvariantExp_smul` identifies scaling a tangent vector with evaluation of its canonical integral curve at the scale factor, using integral-curve uniqueness.
- `mulInvariantIntegralCurve_smul` records the underlying arbitrary-time, arbitrary-basepoint rescaling identity.
- `mulInvariantOneParameterSubgroup_eq_mulInvariantExp_smul` identifies the bundled subgroup directly with the exponential along a line.
- `mulInvariantExp_add_smul` exposes the fundamental one-parameter subgroup law.
- `mulInvariantExp_zero` and `mulInvariantExp_neg` expose the identity and inverse laws.

The API lives in `Geometry/Lie/Exponential/Basic.lean`; the integral-curve implementation remains in its lower-level topic file.

## Scope

This PR intentionally packages the canonical construction first on `GroupLieAlgebra I G`. The merged derivation–tangent equivalence from #1795 now supplies the exact transport needed for a focused follow-up defining the roadmap-facing `lieExp : LeftInvariantDerivation I G → G`, without duplicating the ODE construction.

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 0, “The exponential map”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-0-the-exponential-map-and-one-parameter-subgroups).

## Verification

- `lake build TauCeti.Geometry.Lie.Exponential.Basic`
- `bash scripts/sandbox-build.sh`
  - build: 6,255 jobs
  - axioms: 20,441 declarations, all within the allowlist
  - module system: 1,120 modules
  - lint: no new violations

Roadmap: RepresentationTheory
