### PR TITLE
feat: prove smooth Hadamard factorization

### DIFF
--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.TaylorIntegral
+public import Mathlib.Analysis.Calculus.ParametricIntegral
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
 public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 
 /-!
@@ -25,20 +27,118 @@ public section
 noncomputable section
 
 open MeasureTheory
+open scoped ContDiff
 
-variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+universe u
+
+variable {E F : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+
+/-- The averaged derivative along the segment from `x` to `y`. -/
+noncomputable def hadamardFactor (f : E → F) (x y : E) : E →L[ℝ] F :=
+  ∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))
+
+omit [CompleteSpace F] in
+private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
+    (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
+    HasFDerivAt (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t)
+      (∫ t in Set.Icc (0 : ℝ) 1,
+        (fderiv ℝ h.uncurry (x₀, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)) x₀ := by
+  let h' : E → ℝ → E →L[ℝ] F := fun x t ↦
+    (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)
+  have hh' : Continuous h'.uncurry := by
+    have hd : Continuous (fderiv ℝ h.uncurry) :=
+      (hh.fderiv_right (m := 0) (by norm_num)).continuous
+    fun_prop
+  obtain ⟨C, hC⟩ :=
+    ((isCompact_closedBall x₀ 1).prod isCompact_Icc).bddAbove_image hh'.norm.continuousOn
+  apply hasFDerivAt_integral_of_dominated_of_fderiv_le
+    (μ := volume.restrict (Set.Icc (0 : ℝ) 1))
+    (F := h) (F' := h') (bound := fun _ ↦ C) (s := Metric.closedBall x₀ 1)
+  · exact Metric.closedBall_mem_nhds x₀ zero_lt_one
+  · exact Filter.Eventually.of_forall fun x ↦
+      (hh.continuous.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
+  · exact (hh.continuous.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  · exact (hh'.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
+  · filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+    intro x hx
+    have hxt : (x, t) ∈ Metric.closedBall x₀ 1 ×ˢ Set.Icc (0 : ℝ) 1 := ⟨hx, ht⟩
+    have hbound := hC (Set.mem_image_of_mem (fun z : E × ℝ ↦ ‖h'.uncurry z‖) hxt)
+    change ‖h' x t‖ ≤ C at hbound
+    exact hbound
+  · exact continuous_const.integrableOn_Icc
+  · filter_upwards with t
+    intro x _hx
+    have hd := hh.differentiable_one.differentiableAt.hasFDerivAt.comp x
+        (hasFDerivAt_id x |>.prodMk (hasFDerivAt_const t x))
+    change HasFDerivAt (fun y ↦ h y t)
+      ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
+    simpa only [h', ContinuousLinearMap.inl] using hd
+
+private theorem contDiff_integral_Icc_of_contDiff [FiniteDimensional ℝ E] (n : ℕ)
+    (h : E → ℝ → F) (hh : ContDiff ℝ n h.uncurry) :
+    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  induction n generalizing F with
+  | zero =>
+      have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
+        contDiff_zero.2 (continuous_parametric_integral_of_continuous hh.continuous isCompact_Icc)
+      simpa using hc
+  | succ n ih =>
+      let h' : E → ℝ → E →L[ℝ] F := fun x t ↦
+        (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)
+      have hh' : ContDiff ℝ n h'.uncurry := by
+        have hd : ContDiff ℝ n (fderiv ℝ h.uncurry) :=
+          hh.fderiv_right (m := n) (by norm_num)
+        fun_prop
+      have hsmooth : ContDiff ℝ ((n : ℕ∞ω) + 1)
+          (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+        rw [contDiff_succ_iff_hasFDerivAt]
+        exact ⟨fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h' x t, ih h' hh',
+          hasFDerivAt_integral_Icc_of_contDiff h (hh.of_le (by norm_num))⟩
+      simpa only [Nat.cast_add, Nat.cast_one] using hsmooth
 
 /-- First-order Taylor expansion along a segment, with its coefficient bundled as a continuous
 linear map. -/
-theorem ContDiff.sub_eq_intervalIntegral_fderiv (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
-    f y - f x =
-      (∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))) (y - x) := by
+theorem ContDiff.sub_eq_hadamardFactor_apply (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
+    f y - f x = hadamardFactor f x y (y - x) := by
   have hTaylor := map_add_eq_sum_add_integral_iteratedFDeriv (n := 0) (x := x) (y := y - x)
     (fun _ _ ↦ hf.contDiffAt)
   have hIntegrable : IntervalIntegrable (fun t : ℝ ↦ fderiv ℝ f (x + t • (y - x)))
       volume 0 1 := by
     apply Continuous.intervalIntegrable
     exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
-  rw [ContinuousLinearMap.intervalIntegral_apply hIntegrable (y - x)]
+  rw [hadamardFactor, ContinuousLinearMap.intervalIntegral_apply hIntegrable (y - x)]
   simpa [sub_eq_iff_eq_add, add_comm] using hTaylor
+
+omit [CompleteSpace F] in
+/-- The averaged derivative in Hadamard's factorization depends continuously on the endpoint. -/
+theorem ContDiff.continuous_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
+    (hf : ContDiff ℝ 1 f) (x : E) : Continuous (hadamardFactor f x) := by
+  rw [show hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
+      fderiv ℝ f (x + t • (y - x)) by
+    funext y
+    rw [hadamardFactor, intervalIntegral.integral_of_le zero_le_one,
+      ← integral_Icc_eq_integral_Ioc]]
+  apply continuous_parametric_integral_of_continuous
+  · exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
+  · exact isCompact_Icc
+
+/-- The averaged derivative in Hadamard's factorization depends smoothly on the endpoint. -/
+theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
+    (hf : ContDiff ℝ ∞ f)
+    (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
+  rw [show hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
+      fderiv ℝ f (x + t • (y - x)) by
+    funext y
+    rw [hadamardFactor, intervalIntegral.integral_of_le zero_le_one,
+      ← integral_Icc_eq_integral_Ioc]]
+  rw [contDiff_infty]
+  intro n
+  apply contDiff_integral_Icc_of_contDiff n
+  have hd : ContDiff ℝ ∞ (fderiv ℝ f) := hf.fderiv_right (m := ∞) (by simp)
+  have hc : ContDiff ℝ ∞ (fun _ : E × ℝ ↦ x) := contDiff_const
+  have hfst : ContDiff ℝ ∞ (Prod.fst : E × ℝ → E) := contDiff_fst
+  have hsnd : ContDiff ℝ ∞ (Prod.snd : E × ℝ → ℝ) := contDiff_snd
+  have hi : ContDiff ℝ ∞ (fun p : E × ℝ ↦ x + p.2 • (p.1 - x)) :=
+    ContDiff.add hc (ContDiff.smul hsnd (ContDiff.sub hfst hc))
+  exact (hd.comp hi).of_le (WithTop.coe_le_coe.2 le_top)

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -38,6 +38,15 @@ variable {E : Type u} {F : Type v} [NormedAddCommGroup E] [NormedSpace ℝ E]
 noncomputable def hadamardFactor (f : E → F) (x y : E) : E →L[ℝ] F :=
   ∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))
 
+omit [CompleteSpace F] in
+/-- The averaged derivative written as an integral over the compact unit interval. -/
+theorem hadamardFactor_eq_integral_Icc (f : E → F) (x : E) :
+    hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
+      fderiv ℝ f (x + t • (y - x)) := by
+  funext y
+  rw [hadamardFactor, intervalIntegral.integral_of_le zero_le_one,
+    ← integral_Icc_eq_integral_Ioc]
+
 /-- At the basepoint, the averaged derivative is the ordinary derivative. -/
 @[simp]
 theorem hadamardFactor_self (f : E → F) (x : E) : hadamardFactor f x x = fderiv ℝ f x := by
@@ -81,7 +90,7 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     simpa only [h', ContinuousLinearMap.inl] using hd
 
 private theorem contDiff_integral_Icc_of_contDiff
-    {V W : Type u} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
     [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
     [FiniteDimensional ℝ V] (n : ℕ)
     (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
@@ -105,6 +114,17 @@ private theorem contDiff_integral_Icc_of_contDiff
           hasFDerivAt_integral_Icc_of_contDiff h (hh.of_le (by norm_num))⟩
       simpa only [Nat.cast_add, Nat.cast_one] using hsmooth
 
+/-- If `f` is `n + 1` times continuously differentiable, its Hadamard factor is `n` times
+continuously differentiable in the endpoint. -/
+theorem ContDiff.contDiff_hadamardFactor_of_succ
+    {F : Type v} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+    [FiniteDimensional ℝ E] (n : ℕ) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
+    ContDiff ℝ n (hadamardFactor f x) := by
+  rw [hadamardFactor_eq_integral_Icc]
+  apply contDiff_integral_Icc_of_contDiff n
+  have hd : ContDiff ℝ n (fderiv ℝ f) := hf.fderiv_right (m := n) (by norm_num)
+  exact hd.comp <| by fun_prop
+
 /-- First-order Taylor expansion along a segment, with its coefficient bundled as a continuous
 linear map. -/
 theorem ContDiff.sub_eq_hadamardFactor_apply (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
@@ -122,33 +142,17 @@ omit [CompleteSpace F] in
 /-- The averaged derivative in Hadamard's factorization depends continuously on the endpoint. -/
 theorem ContDiff.continuous_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
     (hf : ContDiff ℝ 1 f) (x : E) : Continuous (hadamardFactor f x) := by
-  rw [show hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
-      fderiv ℝ f (x + t • (y - x)) by
-    funext y
-    rw [hadamardFactor, intervalIntegral.integral_of_le zero_le_one,
-      ← integral_Icc_eq_integral_Ioc]]
+  rw [hadamardFactor_eq_integral_Icc]
   apply continuous_parametric_integral_of_continuous
   · exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
   · exact isCompact_Icc
 
-omit [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F] in
-/-- For a smooth real-valued function, the averaged derivative in Hadamard's factorization depends
-smoothly on the endpoint. -/
-theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → ℝ)
+/-- For a smooth function, the averaged derivative in Hadamard's factorization depends smoothly on
+the endpoint. -/
+theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
-  rw [show hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
-      fderiv ℝ f (x + t • (y - x)) by
-    funext y
-    rw [hadamardFactor, intervalIntegral.integral_of_le zero_le_one,
-      ← integral_Icc_eq_integral_Ioc]]
   rw [contDiff_infty]
   intro n
-  apply contDiff_integral_Icc_of_contDiff n
-  have hd : ContDiff ℝ ∞ (fderiv ℝ f) := hf.fderiv_right (m := ∞) (by simp)
-  have hc : ContDiff ℝ ∞ (fun _ : E × ℝ ↦ x) := contDiff_const
-  have hfst : ContDiff ℝ ∞ (Prod.fst : E × ℝ → E) := contDiff_fst
-  have hsnd : ContDiff ℝ ∞ (Prod.snd : E × ℝ → ℝ) := contDiff_snd
-  have hi : ContDiff ℝ ∞ (fun p : E × ℝ ↦ x + p.2 • (p.1 - x)) :=
-    ContDiff.add hc (ContDiff.smul hsnd (ContDiff.sub hfst hc))
-  exact (hd.comp hi).of_le (WithTop.coe_le_coe.2 le_top)
+  exact ContDiff.contDiff_hadamardFactor_of_succ n f
+    (hf.of_le (WithTop.coe_le_coe.2 le_top)) x

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -184,13 +184,23 @@ private theorem contDiff_integral_Icc_of_contDiff_nat
 /-- Integration over the compact unit interval preserves continuous differentiability of any
 possibly infinite order in a parameter. -/
 theorem contDiff_integral_Icc_of_contDiff
-    {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    {V : Type u} {W : Type v} [NormedAddCommGroup V] [NormedSpace ℝ V]
     [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
     (n : ℕ∞) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
     ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  rw [contDiff_iff_forall_nat_le]
-  intro m hm
-  exact contDiff_integral_Icc_of_contDiff_nat m h (hh.of_le (by exact_mod_cast hm))
+  let eW : Type max u v := ULift.{u} W
+  let isoW : eW ≃L[ℝ] W := ContinuousLinearEquiv.ulift
+  let eh : V → ℝ → eW := fun x t ↦ isoW.symm (h x t)
+  have heh : ContDiff ℝ n eh.uncurry := by
+    apply isoW.symm.contDiff.comp hh
+  have he : ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, eh x t) := by
+    rw [contDiff_iff_forall_nat_le]
+    intro m hm
+    exact contDiff_integral_Icc_of_contDiff_nat m eh (heh.of_le (by exact_mod_cast hm))
+  convert isoW.contDiff.comp he using 1
+  funext x
+  simpa only [Function.comp_apply, eh, ContinuousLinearEquiv.apply_symm_apply] using
+    (isoW.integral_comp_comm (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (fun t ↦ eh x t))
 
 /-- If `f` is `n + 1` times continuously differentiable, its Hadamard factor is `n` times
 continuously differentiable in the endpoint. -/

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.TaylorIntegral
+public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+
+/-!
+# Smooth Hadamard factorization
+
+This file develops the first-order factorization of a smooth map through displacement from a
+basepoint. It is the analytic input for identifying point derivations on a finite-dimensional
+smooth manifold with tangent vectors.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The Lie algebra and the tangent space at `1`".
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+variable {E F : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+
+/-- First-order Taylor expansion along a segment, with its coefficient bundled as a continuous
+linear map. -/
+theorem ContDiff.sub_eq_intervalIntegral_fderiv (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
+    f y - f x =
+      (∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))) (y - x) := by
+  have hTaylor := map_add_eq_sum_add_integral_iteratedFDeriv (n := 0) (x := x) (y := y - x)
+    (fun _ _ ↦ hf.contDiffAt)
+  have hIntegrable : IntervalIntegrable (fun t : ℝ ↦ fderiv ℝ f (x + t • (y - x)))
+      volume 0 1 := by
+    apply Continuous.intervalIntegrable
+    exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
+  rw [ContinuousLinearMap.intervalIntegral_apply hIntegrable (y - x)]
+  simpa [sub_eq_iff_eq_add, add_comm] using hTaylor

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -32,15 +32,14 @@ open scoped ContDiff
 universe u v
 
 variable {E : Type u} {F : Type v} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
+  [NormedAddCommGroup F] [NormedSpace ℝ F]
 
 /-- The averaged derivative along the segment from `x` to `y`. -/
-noncomputable def hadamardFactor (f : E → F) (x y : E) : E →L[ℝ] F :=
+noncomputable def hadamardFactor [CompleteSpace F] (f : E → F) (x y : E) : E →L[ℝ] F :=
   ∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))
 
-omit [CompleteSpace F] in
 /-- The averaged derivative written as an integral over the compact unit interval. -/
-theorem hadamardFactor_eq_integral_Icc (f : E → F) (x : E) :
+theorem hadamardFactor_eq_integral_Icc [CompleteSpace F] (f : E → F) (x : E) :
     hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,
       fderiv ℝ f (x + t • (y - x)) := by
   funext y
@@ -49,10 +48,10 @@ theorem hadamardFactor_eq_integral_Icc (f : E → F) (x : E) :
 
 /-- At the basepoint, the averaged derivative is the ordinary derivative. -/
 @[simp]
-theorem hadamardFactor_self (f : E → F) (x : E) : hadamardFactor f x x = fderiv ℝ f x := by
+theorem hadamardFactor_self [CompleteSpace F] (f : E → F) (x : E) :
+    hadamardFactor f x x = fderiv ℝ f x := by
   simp [hadamardFactor]
 
-omit [CompleteSpace F] in
 private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
     HasFDerivAt (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t)
@@ -129,7 +128,8 @@ theorem ContDiff.contDiff_hadamardFactor_of_succ
 
 /-- First-order Taylor expansion along a segment, with its coefficient bundled as a continuous
 linear map. -/
-theorem ContDiff.sub_eq_hadamardFactor_apply (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
+theorem ContDiff.sub_eq_hadamardFactor_apply [CompleteSpace F]
+    (f : E → F) (hf : ContDiff ℝ 1 f) (x y : E) :
     f y - f x = hadamardFactor f x y (y - x) := by
   have hTaylor := map_add_eq_sum_add_integral_iteratedFDeriv (n := 0) (x := x) (y := y - x)
     (fun _ _ ↦ hf.contDiffAt)
@@ -140,9 +140,8 @@ theorem ContDiff.sub_eq_hadamardFactor_apply (f : E → F) (hf : ContDiff ℝ 1 
   rw [hadamardFactor, ContinuousLinearMap.intervalIntegral_apply hIntegrable (y - x)]
   simpa [sub_eq_iff_eq_add, add_comm] using hTaylor
 
-omit [CompleteSpace F] in
 /-- The averaged derivative in Hadamard's factorization depends continuously on the endpoint. -/
-theorem ContDiff.continuous_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
+theorem ContDiff.continuous_hadamardFactor [CompleteSpace F] [FiniteDimensional ℝ E] (f : E → F)
     (hf : ContDiff ℝ 1 f) (x : E) : Continuous (hadamardFactor f x) := by
   rw [hadamardFactor_eq_integral_Icc]
   apply continuous_parametric_integral_of_continuous
@@ -151,7 +150,7 @@ theorem ContDiff.continuous_hadamardFactor [FiniteDimensional ℝ E] (f : E → 
 
 /-- For a smooth function, the averaged derivative in Hadamard's factorization depends smoothly on
 the endpoint. -/
-theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
+theorem ContDiff.contDiff_hadamardFactor [CompleteSpace F] [FiniteDimensional ℝ E] (f : E → F)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
   rw [contDiff_infty]

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -5,9 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.TaylorIntegral
-public import Mathlib.Analysis.Calculus.ParametricIntegral
-public import Mathlib.Analysis.Calculus.ContDiff.Operations
-public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+public import TauCeti.Analysis.Calculus.ParametricIntegral
 
 /-!
 # Smooth Hadamard factorization
@@ -15,10 +13,6 @@ public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 This file develops the first-order factorization of a smooth map through displacement from a
 basepoint. It is the analytic input for identifying point derivations on a finite-dimensional
 smooth manifold with tangent vectors.
-
-It also provides reusable compact-interval integration results: joint continuity gives continuous
-dependence on an arbitrary topological parameter, while continuous differentiability is preserved
-at every finite or infinite order.
 
 ## References
 
@@ -55,152 +49,6 @@ theorem hadamardFactor_eq_integral_Icc [CompleteSpace F] (f : E → F) (x : E) :
 theorem hadamardFactor_self [CompleteSpace F] (f : E → F) (x : E) :
     hadamardFactor f x x = fderiv ℝ f x := by
   simp [hadamardFactor]
-
-omit [NormedSpace ℝ F] in
-private theorem exists_eventually_norm_le_on_Icc
-    {X : Type*} [TopologicalSpace X]
-    (h : X → ℝ → F) (hh : Continuous h.uncurry) (x₀ : X) :
-    ∃ C : ℝ, ∀ᶠ x in nhds x₀, ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h x t‖ ≤ C := by
-  have hfiber : Continuous (fun t : ℝ ↦ ‖h x₀ t‖) :=
-    hh.norm.comp (continuous_const.prodMk continuous_id)
-  obtain ⟨C, hC⟩ := (isCompact_Icc : IsCompact (Set.Icc (0 : ℝ) 1)).bddAbove_image
-    hfiber.continuousOn
-  let n : Set (X × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
-  have hn : IsOpen n := isOpen_lt hh.norm continuous_const
-  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
-    rintro ⟨x, t⟩ ⟨hx, ht⟩
-    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
-    subst x
-    exact lt_of_le_of_lt (hC (Set.mem_image_of_mem (fun t : ℝ ↦ ‖h x₀ t‖) ht))
-      (lt_add_of_pos_right C zero_lt_one)
-  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
-    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
-  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
-  refine ⟨C + 1, ?_⟩
-  filter_upwards [hu.mem_nhds hx₀u] with x hx
-  intro t ht
-  have hxt := huv (show (x, t) ∈ u ×ˢ v from ⟨hx, hIv ht⟩)
-  change ‖h x t‖ < C + 1 at hxt
-  exact hxt.le
-
-/-- Integration over the compact unit interval preserves continuity in a topological parameter. -/
-theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
-    {X : Type*} [TopologicalSpace X]
-    (h : X → ℝ → F) (hh : Continuous h.uncurry) :
-    Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  rw [continuous_iff_continuousAt]
-  intro x₀
-  rw [Metric.continuousAt_iff']
-  intro ε hε
-  let n : Set (X × ℝ) := {z | ‖h z.1 z.2 - h x₀ z.2‖ < ε / 2}
-  have hn : IsOpen n := isOpen_lt (hh.sub (hh.comp (continuous_const.prodMk continuous_snd))).norm
-    continuous_const
-  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
-    rintro ⟨x, t⟩ ⟨hx, _ht⟩
-    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
-    subst x
-    change ‖h x₀ t - h x₀ t‖ < ε / 2
-    simpa only [sub_self, norm_zero] using half_pos hε
-  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
-    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
-  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
-  filter_upwards [hu.mem_nhds hx₀u] with x hx
-  have hxi : Integrable (fun t ↦ h x t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
-    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
-  have hx₀i : Integrable (fun t ↦ h x₀ t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
-    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
-  rw [dist_eq_norm, ← integral_sub hxi hx₀i]
-  calc
-    ‖∫ t in Set.Icc (0 : ℝ) 1, h x t - h x₀ t‖
-        ≤ ε / 2 * (volume.restrict (Set.Icc (0 : ℝ) 1)).real Set.univ :=
-      norm_integral_le_of_norm_le_const <| by
-        filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
-        have hxt := huv (show (x, t) ∈ u ×ˢ v from ⟨hx, hIv ht⟩)
-        change ‖h x t - h x₀ t‖ < ε / 2 at hxt
-        exact hxt.le
-    _ = ε / 2 := by simp
-    _ < ε := half_lt_self hε
-
-/-- Differentiation under an integral over the compact unit interval for a continuously
-differentiable parameterized function. -/
-theorem hasFDerivAt_integral_Icc_of_contDiff
-    [CompleteSpace F] (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
-    HasFDerivAt (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t)
-      (∫ t in Set.Icc (0 : ℝ) 1,
-        (fderiv ℝ h.uncurry (x₀, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)) x₀ := by
-  let h' : E → ℝ → E →L[ℝ] F := fun x t ↦
-    (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)
-  have hh' : Continuous h'.uncurry := by
-    have hd : Continuous (fderiv ℝ h.uncurry) :=
-      (hh.fderiv_right (m := 0) (by norm_num)).continuous
-    fun_prop
-  obtain ⟨C, hC⟩ := exists_eventually_norm_le_on_Icc h' hh' x₀
-  let s : Set E := {x | ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h' x t‖ ≤ C}
-  apply hasFDerivAt_integral_of_dominated_of_fderiv_le
-    (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (F := h) (F' := h')
-    (bound := fun _ ↦ C) (s := s)
-  · exact hC
-  · exact Filter.Eventually.of_forall fun x ↦
-      (hh.continuous.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
-  · exact (hh.continuous.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
-  · exact (hh'.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
-  · filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
-    intro x hx
-    exact hx t ht
-  · exact continuous_const.integrableOn_Icc
-  · filter_upwards with t
-    intro x _hx
-    have hd := hh.differentiable_one.differentiableAt.hasFDerivAt.comp x
-        (hasFDerivAt_id x |>.prodMk (hasFDerivAt_const t x))
-    -- Expose the derivative of the fixed-`t` slice; `inl` is definitionally `id.prod 0`.
-    change HasFDerivAt (fun y ↦ h y t)
-      ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
-    simpa only [h', ContinuousLinearMap.inl] using hd
-
-private theorem contDiff_integral_Icc_of_contDiff_nat
-    {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
-    (n : ℕ) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
-    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  induction n generalizing W with
-  | zero =>
-      have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
-        contDiff_zero.2 (continuous_integral_Icc_of_continuous h hh.continuous)
-      simpa using hc
-  | succ n ih =>
-      let h' : V → ℝ → V →L[ℝ] W := fun x t ↦
-        (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ V ℝ)
-      have hh' : ContDiff ℝ n h'.uncurry := by
-        have hd : ContDiff ℝ n (fderiv ℝ h.uncurry) :=
-          hh.fderiv_right (m := n) (by norm_num)
-        fun_prop
-      have hsmooth : ContDiff ℝ ((n : ℕ∞ω) + 1)
-          (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-        rw [contDiff_succ_iff_hasFDerivAt]
-        exact ⟨fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h' x t, ih h' hh',
-          hasFDerivAt_integral_Icc_of_contDiff h (hh.of_le (by norm_num))⟩
-      simpa only [Nat.cast_add, Nat.cast_one] using hsmooth
-
-/-- Integration over the compact unit interval preserves continuous differentiability of any
-possibly infinite order in a parameter. -/
-theorem contDiff_integral_Icc_of_contDiff
-    {V : Type u} {W : Type v} [NormedAddCommGroup V] [NormedSpace ℝ V]
-    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
-    (n : ℕ∞) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
-    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  let eW : Type max u v := ULift.{u} W
-  let isoW : eW ≃L[ℝ] W := ContinuousLinearEquiv.ulift
-  let eh : V → ℝ → eW := fun x t ↦ isoW.symm (h x t)
-  have heh : ContDiff ℝ n eh.uncurry := by
-    apply isoW.symm.contDiff.comp hh
-  have he : ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, eh x t) := by
-    rw [contDiff_iff_forall_nat_le]
-    intro m hm
-    exact contDiff_integral_Icc_of_contDiff_nat m eh (heh.of_le (by exact_mod_cast hm))
-  convert isoW.contDiff.comp he using 1
-  funext x
-  simpa only [Function.comp_apply, eh, ContinuousLinearEquiv.apply_symm_apply] using
-    (isoW.integral_comp_comm (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (fun t ↦ eh x t))
 
 /-- If `f` is `n + 1` times continuously differentiable, its Hadamard factor is `n` times
 continuously differentiable in the endpoint. -/

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -52,8 +52,54 @@ theorem hadamardFactor_self [CompleteSpace F] (f : E → F) (x : E) :
     hadamardFactor f x x = fderiv ℝ f x := by
   simp [hadamardFactor]
 
-private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
-    (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
+omit [NormedSpace ℝ E] [NormedSpace ℝ F] in
+private theorem exists_eventually_norm_le_on_Icc
+    (h : E → ℝ → F) (hh : Continuous h.uncurry) (x₀ : E) :
+    ∃ C : ℝ, ∀ᶠ x in nhds x₀, ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h x t‖ ≤ C := by
+  have hfiber : Continuous (fun t : ℝ ↦ ‖h x₀ t‖) :=
+    hh.norm.comp (continuous_const.prodMk continuous_id)
+  obtain ⟨C, hC⟩ := (isCompact_Icc : IsCompact (Set.Icc (0 : ℝ) 1)).bddAbove_image
+    hfiber.continuousOn
+  let n : Set (E × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
+  have hn : IsOpen n := isOpen_lt hh.norm continuous_const
+  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
+    rintro ⟨x, t⟩ ⟨hx, ht⟩
+    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
+    subst x
+    exact lt_of_le_of_lt (hC (Set.mem_image_of_mem (fun t : ℝ ↦ ‖h x₀ t‖) ht))
+      (lt_add_of_pos_right C zero_lt_one)
+  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
+    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
+  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
+  refine ⟨C + 1, ?_⟩
+  filter_upwards [hu.mem_nhds hx₀u] with x hx
+  intro t ht
+  have hxt := huv (show (x, t) ∈ u ×ˢ v from ⟨hx, hIv ht⟩)
+  change ‖h x t‖ < C + 1 at hxt
+  exact hxt.le
+
+omit [NormedSpace ℝ E] in
+/-- Integration over the compact unit interval preserves continuity in a normed parameter. -/
+theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
+    (h : E → ℝ → F) (hh : Continuous h.uncurry) :
+    Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  rw [continuous_iff_continuousAt]
+  intro x₀
+  obtain ⟨C, hC⟩ := exists_eventually_norm_le_on_Icc h hh x₀
+  apply continuousAt_of_dominated
+  · filter_upwards with x using Continuous.aestronglyMeasurable (by fun_prop)
+  · filter_upwards [hC] with x hx
+    rw [ae_restrict_iff]
+    · filter_upwards with t ht
+      exact hx t ht
+    · exact (isClosed_le (by fun_prop) (by fun_prop)).measurableSet
+  · exact (show Continuous (fun _ : ℝ ↦ C) from continuous_const).integrableOn_Icc
+  · filter_upwards using (by fun_prop)
+
+/-- Differentiation under an integral over the compact unit interval for a continuously
+differentiable parameterized function. -/
+theorem hasFDerivAt_integral_Icc_of_contDiff
+    [CompleteSpace F] (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
     HasFDerivAt (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t)
       (∫ t in Set.Icc (0 : ℝ) 1,
         (fderiv ℝ h.uncurry (x₀, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)) x₀ := by
@@ -63,23 +109,19 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     have hd : Continuous (fderiv ℝ h.uncurry) :=
       (hh.fderiv_right (m := 0) (by norm_num)).continuous
     fun_prop
-  obtain ⟨C, hC⟩ :=
-    ((isCompact_closedBall x₀ 1).prod isCompact_Icc).bddAbove_image hh'.norm.continuousOn
+  obtain ⟨C, hC⟩ := exists_eventually_norm_le_on_Icc h' hh' x₀
+  let s : Set E := {x | ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h' x t‖ ≤ C}
   apply hasFDerivAt_integral_of_dominated_of_fderiv_le
-    (μ := volume.restrict (Set.Icc (0 : ℝ) 1))
-    (F := h) (F' := h') (bound := fun _ ↦ C) (s := Metric.closedBall x₀ 1)
-  · exact Metric.closedBall_mem_nhds x₀ zero_lt_one
+    (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (F := h) (F' := h')
+    (bound := fun _ ↦ C) (s := s)
+  · exact hC
   · exact Filter.Eventually.of_forall fun x ↦
       (hh.continuous.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
   · exact (hh.continuous.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
   · exact (hh'.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
   · filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
     intro x hx
-    have hxt : (x, t) ∈ Metric.closedBall x₀ 1 ×ˢ Set.Icc (0 : ℝ) 1 := ⟨hx, ht⟩
-    have hbound := hC (Set.mem_image_of_mem (fun z : E × ℝ ↦ ‖h'.uncurry z‖) hxt)
-    -- Uncurry the parameterized derivative so the compact bound has the form required below.
-    change ‖h' x t‖ ≤ C at hbound
-    exact hbound
+    exact hx t ht
   · exact continuous_const.integrableOn_Icc
   · filter_upwards with t
     intro x _hx
@@ -90,16 +132,17 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
       ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
     simpa only [h', ContinuousLinearMap.inl] using hd
 
-private theorem contDiff_integral_Icc_of_contDiff
+/-- Integration over the compact unit interval preserves any finite order of continuous
+differentiability in a parameter. -/
+theorem contDiff_integral_Icc_of_contDiff
     {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
     [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
-    [FiniteDimensional ℝ V] (n : ℕ)
-    (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
+    (n : ℕ) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
     ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
   induction n generalizing W with
   | zero =>
       have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
-        contDiff_zero.2 (continuous_parametric_integral_of_continuous hh.continuous isCompact_Icc)
+        contDiff_zero.2 (continuous_integral_Icc_of_continuous h hh.continuous)
       simpa using hc
   | succ n ih =>
       let h' : V → ℝ → V →L[ℝ] W := fun x t ↦
@@ -119,7 +162,7 @@ private theorem contDiff_integral_Icc_of_contDiff
 continuously differentiable in the endpoint. -/
 theorem ContDiff.contDiff_hadamardFactor_of_succ
     {F : Type v} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
-    [FiniteDimensional ℝ E] (n : ℕ) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
+    (n : ℕ) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
     ContDiff ℝ n (hadamardFactor f x) := by
   rw [hadamardFactor_eq_integral_Icc]
   apply contDiff_integral_Icc_of_contDiff n
@@ -141,16 +184,13 @@ theorem ContDiff.sub_eq_hadamardFactor_apply [CompleteSpace F]
   simpa [sub_eq_iff_eq_add, add_comm] using hTaylor
 
 /-- The averaged derivative in Hadamard's factorization depends continuously on the endpoint. -/
-theorem ContDiff.continuous_hadamardFactor [CompleteSpace F] [FiniteDimensional ℝ E] (f : E → F)
+theorem ContDiff.continuous_hadamardFactor [CompleteSpace F] (f : E → F)
     (hf : ContDiff ℝ 1 f) (x : E) : Continuous (hadamardFactor f x) := by
-  rw [hadamardFactor_eq_integral_Icc]
-  apply continuous_parametric_integral_of_continuous
-  · exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
-  · exact isCompact_Icc
+  exact (ContDiff.contDiff_hadamardFactor_of_succ 0 f hf x).continuous
 
 /-- For a smooth function, the averaged derivative in Hadamard's factorization depends smoothly on
 the endpoint. -/
-theorem ContDiff.contDiff_hadamardFactor [CompleteSpace F] [FiniteDimensional ℝ E] (f : E → F)
+theorem ContDiff.contDiff_hadamardFactor [CompleteSpace F] (f : E → F)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
   rw [contDiff_infty]

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -153,9 +153,7 @@ theorem hasFDerivAt_integral_Icc_of_contDiff
       ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
     simpa only [h', ContinuousLinearMap.inl] using hd
 
-/-- Integration over the compact unit interval preserves any finite order of continuous
-differentiability in a parameter. -/
-theorem contDiff_integral_Icc_of_contDiff
+private theorem contDiff_integral_Icc_of_contDiff_nat
     {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
     [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
     (n : ℕ) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
@@ -179,6 +177,17 @@ theorem contDiff_integral_Icc_of_contDiff
           hasFDerivAt_integral_Icc_of_contDiff h (hh.of_le (by norm_num))⟩
       simpa only [Nat.cast_add, Nat.cast_one] using hsmooth
 
+/-- Integration over the compact unit interval preserves continuous differentiability of any
+possibly infinite order in a parameter. -/
+theorem contDiff_integral_Icc_of_contDiff
+    {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
+    (n : ℕ∞) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
+    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  rw [contDiff_iff_forall_nat_le]
+  intro m hm
+  exact contDiff_integral_Icc_of_contDiff_nat m h (hh.of_le (by exact_mod_cast hm))
+
 /-- If `f` is `n + 1` times continuously differentiable, its Hadamard factor is `n` times
 continuously differentiable in the endpoint. -/
 theorem ContDiff.contDiff_hadamardFactor_of_succ
@@ -186,7 +195,7 @@ theorem ContDiff.contDiff_hadamardFactor_of_succ
     (n : ℕ) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
     ContDiff ℝ n (hadamardFactor f x) := by
   rw [hadamardFactor_eq_integral_Icc]
-  apply contDiff_integral_Icc_of_contDiff n
+  apply contDiff_integral_Icc_of_contDiff (n : ℕ∞)
   have hd : ContDiff ℝ n (fderiv ℝ f) := hf.fderiv_right (m := n) (by norm_num)
   exact hd.comp <| by fun_prop
 
@@ -209,7 +218,7 @@ the endpoint. -/
 theorem ContDiff.contDiff_hadamardFactor [CompleteSpace F] (f : E → F)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
-  rw [contDiff_infty]
-  intro n
-  exact ContDiff.contDiff_hadamardFactor_of_succ n f
-    (hf.of_le (WithTop.coe_le_coe.2 le_top)) x
+  rw [hadamardFactor_eq_integral_Icc]
+  apply contDiff_integral_Icc_of_contDiff (⊤ : ℕ∞)
+  have hd : ContDiff ℝ ∞ (fderiv ℝ f) := hf.fderiv_right (m := ∞) (by simp)
+  exact hd.comp <| by fun_prop

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -16,6 +16,10 @@ This file develops the first-order factorization of a smooth map through displac
 basepoint. It is the analytic input for identifying point derivations on a finite-dimensional
 smooth manifold with tangent vectors.
 
+It also provides reusable compact-interval integration results: joint continuity gives continuous
+dependence on an arbitrary topological parameter, while continuous differentiability is preserved
+at every finite or infinite order.
+
 ## References
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -192,10 +192,10 @@ theorem contDiff_integral_Icc_of_contDiff
 continuously differentiable in the endpoint. -/
 theorem ContDiff.contDiff_hadamardFactor_of_succ
     {F : Type v} [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
-    (n : ℕ) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
+    (n : ℕ∞) (f : E → F) (hf : ContDiff ℝ (n + 1) f) (x : E) :
     ContDiff ℝ n (hadamardFactor f x) := by
   rw [hadamardFactor_eq_integral_Icc]
-  apply contDiff_integral_Icc_of_contDiff (n : ℕ∞)
+  apply contDiff_integral_Icc_of_contDiff n
   have hd : ContDiff ℝ n (fderiv ℝ f) := hf.fderiv_right (m := n) (by norm_num)
   exact hd.comp <| by fun_prop
 
@@ -218,7 +218,4 @@ the endpoint. -/
 theorem ContDiff.contDiff_hadamardFactor [CompleteSpace F] (f : E → F)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
-  rw [hadamardFactor_eq_integral_Icc]
-  apply contDiff_integral_Icc_of_contDiff (⊤ : ℕ∞)
-  have hd : ContDiff ℝ ∞ (fderiv ℝ f) := hf.fderiv_right (m := ∞) (by simp)
-  exact hd.comp <| by fun_prop
+  simpa using ContDiff.contDiff_hadamardFactor_of_succ (⊤ : ℕ∞) f (by simpa using hf) x

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -78,6 +78,7 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     intro x hx
     have hxt : (x, t) ∈ Metric.closedBall x₀ 1 ×ˢ Set.Icc (0 : ℝ) 1 := ⟨hx, ht⟩
     have hbound := hC (Set.mem_image_of_mem (fun z : E × ℝ ↦ ‖h'.uncurry z‖) hxt)
+    -- Uncurry the parameterized derivative so the compact bound has the form required below.
     change ‖h' x t‖ ≤ C at hbound
     exact hbound
   · exact continuous_const.integrableOn_Icc
@@ -85,6 +86,7 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     intro x _hx
     have hd := hh.differentiable_one.differentiableAt.hasFDerivAt.comp x
         (hasFDerivAt_id x |>.prodMk (hasFDerivAt_const t x))
+    -- Expose the derivative of the fixed-`t` slice; `inl` is definitionally `id.prod 0`.
     change HasFDerivAt (fun y ↦ h y t)
       ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
     simpa only [h', ContinuousLinearMap.inl] using hd

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -29,9 +29,9 @@ noncomputable section
 open MeasureTheory
 open scoped ContDiff
 
-universe u
+universe u v
 
-variable {E F : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type u} {F : Type v} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F]
 
 /-- The averaged derivative along the segment from `x` to `y`. -/
@@ -80,17 +80,20 @@ private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
       ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
     simpa only [h', ContinuousLinearMap.inl] using hd
 
-private theorem contDiff_integral_Icc_of_contDiff [FiniteDimensional ℝ E] (n : ℕ)
-    (h : E → ℝ → F) (hh : ContDiff ℝ n h.uncurry) :
+private theorem contDiff_integral_Icc_of_contDiff
+    {V W : Type u} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
+    [FiniteDimensional ℝ V] (n : ℕ)
+    (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
     ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  induction n generalizing F with
+  induction n generalizing W with
   | zero =>
       have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
         contDiff_zero.2 (continuous_parametric_integral_of_continuous hh.continuous isCompact_Icc)
       simpa using hc
   | succ n ih =>
-      let h' : E → ℝ → E →L[ℝ] F := fun x t ↦
-        (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)
+      let h' : V → ℝ → V →L[ℝ] W := fun x t ↦
+        (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ V ℝ)
       have hh' : ContDiff ℝ n h'.uncurry := by
         have hd : ContDiff ℝ n (fderiv ℝ h.uncurry) :=
           hh.fderiv_right (m := n) (by norm_num)
@@ -128,8 +131,10 @@ theorem ContDiff.continuous_hadamardFactor [FiniteDimensional ℝ E] (f : E → 
   · exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
   · exact isCompact_Icc
 
-/-- The averaged derivative in Hadamard's factorization depends smoothly on the endpoint. -/
-theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → F)
+omit [NormedAddCommGroup F] [NormedSpace ℝ F] [CompleteSpace F] in
+/-- For a smooth real-valued function, the averaged derivative in Hadamard's factorization depends
+smoothly on the endpoint. -/
+theorem ContDiff.contDiff_hadamardFactor [FiniteDimensional ℝ E] (f : E → ℝ)
     (hf : ContDiff ℝ ∞ f)
     (x : E) : ContDiff ℝ ∞ (hadamardFactor f x) := by
   rw [show hadamardFactor f x = fun y ↦ ∫ t in Set.Icc (0 : ℝ) 1,

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -52,15 +52,16 @@ theorem hadamardFactor_self [CompleteSpace F] (f : E → F) (x : E) :
     hadamardFactor f x x = fderiv ℝ f x := by
   simp [hadamardFactor]
 
-omit [NormedSpace ℝ E] [NormedSpace ℝ F] in
+omit [NormedSpace ℝ F] in
 private theorem exists_eventually_norm_le_on_Icc
-    (h : E → ℝ → F) (hh : Continuous h.uncurry) (x₀ : E) :
+    {X : Type*} [TopologicalSpace X]
+    (h : X → ℝ → F) (hh : Continuous h.uncurry) (x₀ : X) :
     ∃ C : ℝ, ∀ᶠ x in nhds x₀, ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h x t‖ ≤ C := by
   have hfiber : Continuous (fun t : ℝ ↦ ‖h x₀ t‖) :=
     hh.norm.comp (continuous_const.prodMk continuous_id)
   obtain ⟨C, hC⟩ := (isCompact_Icc : IsCompact (Set.Icc (0 : ℝ) 1)).bddAbove_image
     hfiber.continuousOn
-  let n : Set (E × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
+  let n : Set (X × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
   have hn : IsOpen n := isOpen_lt hh.norm continuous_const
   have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
     rintro ⟨x, t⟩ ⟨hx, ht⟩
@@ -78,10 +79,11 @@ private theorem exists_eventually_norm_le_on_Icc
   change ‖h x t‖ < C + 1 at hxt
   exact hxt.le
 
-omit [NormedSpace ℝ E] in
-/-- Integration over the compact unit interval preserves continuity in a normed parameter. -/
+/-- Integration over the compact unit interval preserves continuity in a first-countable
+topological parameter. -/
 theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
-    (h : E → ℝ → F) (hh : Continuous h.uncurry) :
+    {X : Type*} [TopologicalSpace X] [FirstCountableTopology X]
+    (h : X → ℝ → F) (hh : Continuous h.uncurry) :
     Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
   rw [continuous_iff_continuousAt]
   intro x₀
@@ -182,11 +184,6 @@ theorem ContDiff.sub_eq_hadamardFactor_apply [CompleteSpace F]
     exact (hf.fderiv_right (m := 0) (by norm_num)).continuous.comp (by fun_prop)
   rw [hadamardFactor, ContinuousLinearMap.intervalIntegral_apply hIntegrable (y - x)]
   simpa [sub_eq_iff_eq_add, add_comm] using hTaylor
-
-/-- The averaged derivative in Hadamard's factorization depends continuously on the endpoint. -/
-theorem ContDiff.continuous_hadamardFactor [CompleteSpace F] (f : E → F)
-    (hf : ContDiff ℝ 1 f) (x : E) : Continuous (hadamardFactor f x) := by
-  exact (ContDiff.contDiff_hadamardFactor_of_succ 0 f hf x).continuous
 
 /-- For a smooth function, the averaged derivative in Hadamard's factorization depends smoothly on
 the endpoint. -/

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -38,6 +38,11 @@ variable {E F : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
 noncomputable def hadamardFactor (f : E → F) (x y : E) : E →L[ℝ] F :=
   ∫ t in (0 : ℝ)..1, fderiv ℝ f (x + t • (y - x))
 
+/-- At the basepoint, the averaged derivative is the ordinary derivative. -/
+@[simp]
+theorem hadamardFactor_self (f : E → F) (x : E) : hadamardFactor f x x = fderiv ℝ f x := by
+  simp [hadamardFactor]
+
 omit [CompleteSpace F] in
 private theorem hasFDerivAt_integral_Icc_of_contDiff [FiniteDimensional ℝ E]
     (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :

--- a/TauCeti/Analysis/Calculus/Hadamard.lean
+++ b/TauCeti/Analysis/Calculus/Hadamard.lean
@@ -79,24 +79,43 @@ private theorem exists_eventually_norm_le_on_Icc
   change ‖h x t‖ < C + 1 at hxt
   exact hxt.le
 
-/-- Integration over the compact unit interval preserves continuity in a first-countable
-topological parameter. -/
+/-- Integration over the compact unit interval preserves continuity in a topological parameter. -/
 theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
-    {X : Type*} [TopologicalSpace X] [FirstCountableTopology X]
+    {X : Type*} [TopologicalSpace X]
     (h : X → ℝ → F) (hh : Continuous h.uncurry) :
     Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
   rw [continuous_iff_continuousAt]
   intro x₀
-  obtain ⟨C, hC⟩ := exists_eventually_norm_le_on_Icc h hh x₀
-  apply continuousAt_of_dominated
-  · filter_upwards with x using Continuous.aestronglyMeasurable (by fun_prop)
-  · filter_upwards [hC] with x hx
-    rw [ae_restrict_iff]
-    · filter_upwards with t ht
-      exact hx t ht
-    · exact (isClosed_le (by fun_prop) (by fun_prop)).measurableSet
-  · exact (show Continuous (fun _ : ℝ ↦ C) from continuous_const).integrableOn_Icc
-  · filter_upwards using (by fun_prop)
+  rw [Metric.continuousAt_iff']
+  intro ε hε
+  let n : Set (X × ℝ) := {z | ‖h z.1 z.2 - h x₀ z.2‖ < ε / 2}
+  have hn : IsOpen n := isOpen_lt (hh.sub (hh.comp (continuous_const.prodMk continuous_snd))).norm
+    continuous_const
+  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
+    rintro ⟨x, t⟩ ⟨hx, _ht⟩
+    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
+    subst x
+    change ‖h x₀ t - h x₀ t‖ < ε / 2
+    simpa only [sub_self, norm_zero] using half_pos hε
+  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
+    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
+  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
+  filter_upwards [hu.mem_nhds hx₀u] with x hx
+  have hxi : Integrable (fun t ↦ h x t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
+    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  have hx₀i : Integrable (fun t ↦ h x₀ t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
+    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  rw [dist_eq_norm, ← integral_sub hxi hx₀i]
+  calc
+    ‖∫ t in Set.Icc (0 : ℝ) 1, h x t - h x₀ t‖
+        ≤ ε / 2 * (volume.restrict (Set.Icc (0 : ℝ) 1)).real Set.univ :=
+      norm_integral_le_of_norm_le_const <| by
+        filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+        have hxt := huv (show (x, t) ∈ u ×ˢ v from ⟨hx, hIv ht⟩)
+        change ‖h x t - h x₀ t‖ < ε / 2 at hxt
+        exact hxt.le
+    _ = ε / 2 := by simp
+    _ < ε := half_lt_self hε
 
 /-- Differentiation under an integral over the compact unit interval for a continuously
 differentiable parameterized function. -/

--- a/TauCeti/Analysis/Calculus/ParametricIntegral.lean
+++ b/TauCeti/Analysis/Calculus/ParametricIntegral.lean
@@ -11,10 +11,10 @@ public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 /-!
 # Compact-parameter integration
 
-This file proves that integration over the compact unit interval preserves joint continuity and
-continuous differentiability in a parameter. Continuity holds for an arbitrary topological
-parameter space, while differentiability is preserved at every finite or infinite order and with
-independent domain and codomain universes.
+This file uses Mathlib's continuity theorem for parameterized interval integrals and proves that
+integration over the compact unit interval preserves differentiation and continuous
+differentiability in a normed-space parameter. Continuous differentiability is preserved at every
+finite or infinite order and with independent domain and codomain universes.
 
 These results supply the analytic regularity used by smooth Hadamard factorization, a prerequisite
 for the point-derivation/tangent-space equivalence in the Lie groups roadmap.

--- a/TauCeti/Analysis/Calculus/ParametricIntegral.lean
+++ b/TauCeti/Analysis/Calculus/ParametricIntegral.lean
@@ -65,44 +65,6 @@ private theorem exists_eventually_norm_le_on_Icc
   have hbound : ‖h x t‖ < C + 1 := by simpa [n] using hxt
   exact hbound.le
 
-/-- Integration over the compact unit interval preserves continuity in a topological parameter. -/
-theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
-    {X : Type*} [TopologicalSpace X]
-    (h : X → ℝ → F) (hh : Continuous h.uncurry) :
-    Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
-  rw [continuous_iff_continuousAt]
-  intro x₀
-  rw [Metric.continuousAt_iff']
-  intro ε hε
-  let n : Set (X × ℝ) := {z | ‖h z.1 z.2 - h x₀ z.2‖ < ε / 2}
-  have hn : IsOpen n := isOpen_lt (hh.sub (hh.comp (continuous_const.prodMk continuous_snd))).norm
-    continuous_const
-  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
-    rintro ⟨x, t⟩ ⟨hx, _ht⟩
-    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
-    subst x
-    simpa [n] using half_pos hε
-  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
-    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
-  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
-  filter_upwards [hu.mem_nhds hx₀u] with x hx
-  have hxi : Integrable (fun t ↦ h x t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
-    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
-  have hx₀i : Integrable (fun t ↦ h x₀ t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
-    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
-  rw [dist_eq_norm, ← integral_sub hxi hx₀i]
-  calc
-    ‖∫ t in Set.Icc (0 : ℝ) 1, h x t - h x₀ t‖
-        ≤ ε / 2 * (volume.restrict (Set.Icc (0 : ℝ) 1)).real Set.univ :=
-      norm_integral_le_of_norm_le_const <| by
-        filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
-        have hmem : (x, t) ∈ u ×ˢ v := ⟨hx, hIv ht⟩
-        have hxt := huv hmem
-        have hbound : ‖h x t - h x₀ t‖ < ε / 2 := by simpa [n] using hxt
-        exact hbound.le
-    _ = ε / 2 := by simp
-    _ < ε := half_lt_self hε
-
 /-- Differentiation under an integral over the compact unit interval for a continuously
 differentiable parameterized function. -/
 theorem hasFDerivAt_integral_Icc_of_contDiff
@@ -146,9 +108,12 @@ private theorem contDiff_integral_Icc_of_contDiff_nat
     ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
   induction n generalizing W with
   | zero =>
-      have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
-        contDiff_zero.2 (continuous_integral_Icc_of_continuous h hh.continuous)
-      simpa using hc
+      have hc : Continuous (fun x ↦ ∫ t in (0 : ℝ)..1, h x t) :=
+        intervalIntegral.continuous_parametric_intervalIntegral_of_continuous'
+          hh.continuous 0 1
+      apply contDiff_zero.2
+      simpa only [intervalIntegral.integral_of_le zero_le_one, integral_Icc_eq_integral_Ioc]
+        using hc
   | succ n ih =>
       let h' : V → ℝ → V →L[ℝ] W := fun x t ↦
         (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ V ℝ)

--- a/TauCeti/Analysis/Calculus/ParametricIntegral.lean
+++ b/TauCeti/Analysis/Calculus/ParametricIntegral.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.Analysis.Calculus.ParametricIntegral
 public import Mathlib.Analysis.Calculus.ContDiff.Operations
-public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
 
 /-!
 # Compact-parameter integration
@@ -46,24 +45,16 @@ private theorem exists_eventually_norm_le_on_Icc
     hh.norm.comp (continuous_const.prodMk continuous_id)
   obtain ⟨C, hC⟩ := (isCompact_Icc : IsCompact (Set.Icc (0 : ℝ) 1)).bddAbove_image
     hfiber.continuousOn
-  let n : Set (X × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
-  have hn : IsOpen n := isOpen_lt hh.norm continuous_const
-  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
-    rintro ⟨x, t⟩ ⟨hx, ht⟩
-    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
-    subst x
-    exact lt_of_le_of_lt (hC (Set.mem_image_of_mem (fun t : ℝ ↦ ‖h x₀ t‖) ht))
-      (lt_add_of_pos_right C zero_lt_one)
-  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
-    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
-  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
   refine ⟨C + 1, ?_⟩
-  filter_upwards [hu.mem_nhds hx₀u] with x hx
+  apply isCompact_Icc.eventually_forall_of_forall_eventually
   intro t ht
-  have hmem : (x, t) ∈ u ×ˢ v := ⟨hx, hIv ht⟩
-  have hxt := huv hmem
-  have hbound : ‖h x t‖ < C + 1 := by simpa [n] using hxt
-  exact hbound.le
+  have hlt : ‖h x₀ t‖ < C + 1 :=
+    lt_of_le_of_lt (hC (Set.mem_image_of_mem (fun t : ℝ ↦ ‖h x₀ t‖) ht))
+      (lt_add_of_pos_right C zero_lt_one)
+  have hn : {z : X × ℝ | ‖h.uncurry z‖ < C + 1} ∈ nhds (x₀, t) :=
+    (isOpen_lt hh.norm continuous_const).mem_nhds hlt
+  filter_upwards [hn] with z hz
+  exact hz.le
 
 /-- Differentiation under an integral over the compact unit interval for a continuously
 differentiable parameterized function. -/

--- a/TauCeti/Analysis/Calculus/ParametricIntegral.lean
+++ b/TauCeti/Analysis/Calculus/ParametricIntegral.lean
@@ -1,0 +1,185 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ParametricIntegral
+public import Mathlib.Analysis.Calculus.ContDiff.Operations
+public import Mathlib.MeasureTheory.Integral.Bochner.ContinuousLinearMap
+
+/-!
+# Compact-parameter integration
+
+This file proves that integration over the compact unit interval preserves joint continuity and
+continuous differentiability in a parameter. Continuity holds for an arbitrary topological
+parameter space, while differentiability is preserved at every finite or infinite order and with
+independent domain and codomain universes.
+
+These results supply the analytic regularity used by smooth Hadamard factorization, a prerequisite
+for the point-derivation/tangent-space equivalence in the Lie groups roadmap.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The Lie algebra and the tangent space at `1`".
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+open scoped ContDiff
+
+universe u v
+
+variable {E : Type u} {F : Type v} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+omit [NormedSpace ℝ F] in
+private theorem exists_eventually_norm_le_on_Icc
+    {X : Type*} [TopologicalSpace X]
+    (h : X → ℝ → F) (hh : Continuous h.uncurry) (x₀ : X) :
+    ∃ C : ℝ, ∀ᶠ x in nhds x₀, ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h x t‖ ≤ C := by
+  have hfiber : Continuous (fun t : ℝ ↦ ‖h x₀ t‖) :=
+    hh.norm.comp (continuous_const.prodMk continuous_id)
+  obtain ⟨C, hC⟩ := (isCompact_Icc : IsCompact (Set.Icc (0 : ℝ) 1)).bddAbove_image
+    hfiber.continuousOn
+  let n : Set (X × ℝ) := {z | ‖h.uncurry z‖ < C + 1}
+  have hn : IsOpen n := isOpen_lt hh.norm continuous_const
+  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
+    rintro ⟨x, t⟩ ⟨hx, ht⟩
+    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
+    subst x
+    exact lt_of_le_of_lt (hC (Set.mem_image_of_mem (fun t : ℝ ↦ ‖h x₀ t‖) ht))
+      (lt_add_of_pos_right C zero_lt_one)
+  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
+    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
+  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
+  refine ⟨C + 1, ?_⟩
+  filter_upwards [hu.mem_nhds hx₀u] with x hx
+  intro t ht
+  have hmem : (x, t) ∈ u ×ˢ v := ⟨hx, hIv ht⟩
+  have hxt := huv hmem
+  have hbound : ‖h x t‖ < C + 1 := by simpa [n] using hxt
+  exact hbound.le
+
+/-- Integration over the compact unit interval preserves continuity in a topological parameter. -/
+theorem continuous_integral_Icc_of_continuous [CompleteSpace F]
+    {X : Type*} [TopologicalSpace X]
+    (h : X → ℝ → F) (hh : Continuous h.uncurry) :
+    Continuous (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  rw [continuous_iff_continuousAt]
+  intro x₀
+  rw [Metric.continuousAt_iff']
+  intro ε hε
+  let n : Set (X × ℝ) := {z | ‖h z.1 z.2 - h x₀ z.2‖ < ε / 2}
+  have hn : IsOpen n := isOpen_lt (hh.sub (hh.comp (continuous_const.prodMk continuous_snd))).norm
+    continuous_const
+  have hfiber_subset : {x₀} ×ˢ Set.Icc (0 : ℝ) 1 ⊆ n := by
+    rintro ⟨x, t⟩ ⟨hx, _ht⟩
+    have hxx₀ : x = x₀ := by simpa only [Set.mem_singleton_iff] using hx
+    subst x
+    simpa [n] using half_pos hε
+  obtain ⟨u, v, hu, -, hxu, hIv, huv⟩ :=
+    generalized_tube_lemma isCompact_singleton isCompact_Icc hn hfiber_subset
+  have hx₀u : x₀ ∈ u := hxu (Set.mem_singleton x₀)
+  filter_upwards [hu.mem_nhds hx₀u] with x hx
+  have hxi : Integrable (fun t ↦ h x t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
+    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  have hx₀i : Integrable (fun t ↦ h x₀ t) (volume.restrict (Set.Icc (0 : ℝ) 1)) :=
+    (hh.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  rw [dist_eq_norm, ← integral_sub hxi hx₀i]
+  calc
+    ‖∫ t in Set.Icc (0 : ℝ) 1, h x t - h x₀ t‖
+        ≤ ε / 2 * (volume.restrict (Set.Icc (0 : ℝ) 1)).real Set.univ :=
+      norm_integral_le_of_norm_le_const <| by
+        filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+        have hmem : (x, t) ∈ u ×ˢ v := ⟨hx, hIv ht⟩
+        have hxt := huv hmem
+        have hbound : ‖h x t - h x₀ t‖ < ε / 2 := by simpa [n] using hxt
+        exact hbound.le
+    _ = ε / 2 := by simp
+    _ < ε := half_lt_self hε
+
+/-- Differentiation under an integral over the compact unit interval for a continuously
+differentiable parameterized function. -/
+theorem hasFDerivAt_integral_Icc_of_contDiff
+    [CompleteSpace F] (h : E → ℝ → F) (hh : ContDiff ℝ 1 h.uncurry) (x₀ : E) :
+    HasFDerivAt (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t)
+      (∫ t in Set.Icc (0 : ℝ) 1,
+        (fderiv ℝ h.uncurry (x₀, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)) x₀ := by
+  let h' : E → ℝ → E →L[ℝ] F := fun x t ↦
+    (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ E ℝ)
+  have hh' : Continuous h'.uncurry := by
+    have hd : Continuous (fderiv ℝ h.uncurry) :=
+      (hh.fderiv_right (m := 0) (by norm_num)).continuous
+    fun_prop
+  obtain ⟨C, hC⟩ := exists_eventually_norm_le_on_Icc h' hh' x₀
+  let s : Set E := {x | ∀ t ∈ Set.Icc (0 : ℝ) 1, ‖h' x t‖ ≤ C}
+  apply hasFDerivAt_integral_of_dominated_of_fderiv_le
+    (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (F := h) (F' := h')
+    (bound := fun _ ↦ C) (s := s)
+  · exact hC
+  · exact Filter.Eventually.of_forall fun x ↦
+      (hh.continuous.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
+  · exact (hh.continuous.comp (continuous_const.prodMk continuous_id)).integrableOn_Icc
+  · exact (hh'.comp (continuous_const.prodMk continuous_id)).aestronglyMeasurable
+  · filter_upwards [ae_restrict_mem measurableSet_Icc] with t ht
+    intro x hx
+    exact hx t ht
+  · exact continuous_const.integrableOn_Icc
+  · filter_upwards with t
+    intro x _hx
+    have hd := hh.differentiable_one.differentiableAt.hasFDerivAt.comp x
+        (hasFDerivAt_id x |>.prodMk (hasFDerivAt_const t x))
+    -- Expose the derivative of the fixed-`t` slice; `inl` is definitionally `id.prod 0`.
+    change HasFDerivAt (fun y ↦ h y t)
+      ((fderiv ℝ h.uncurry (x, t)).comp ((ContinuousLinearMap.id ℝ E).prod 0)) x at hd
+    simpa only [h', ContinuousLinearMap.inl] using hd
+
+private theorem contDiff_integral_Icc_of_contDiff_nat
+    {V : Type u} {W : Type max u v} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
+    (n : ℕ) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
+    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  induction n generalizing W with
+  | zero =>
+      have hc : ContDiff ℝ (0 : ℕ∞ω) (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) :=
+        contDiff_zero.2 (continuous_integral_Icc_of_continuous h hh.continuous)
+      simpa using hc
+  | succ n ih =>
+      let h' : V → ℝ → V →L[ℝ] W := fun x t ↦
+        (fderiv ℝ h.uncurry (x, t)).comp (ContinuousLinearMap.inl ℝ V ℝ)
+      have hh' : ContDiff ℝ n h'.uncurry := by
+        have hd : ContDiff ℝ n (fderiv ℝ h.uncurry) :=
+          hh.fderiv_right (m := n) (by norm_num)
+        fun_prop
+      have hsmooth : ContDiff ℝ ((n : ℕ∞ω) + 1)
+          (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+        rw [contDiff_succ_iff_hasFDerivAt]
+        exact ⟨fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h' x t, ih h' hh',
+          hasFDerivAt_integral_Icc_of_contDiff h (hh.of_le (by norm_num))⟩
+      simpa only [Nat.cast_add, Nat.cast_one] using hsmooth
+
+/-- Integration over the compact unit interval preserves continuous differentiability of any
+possibly infinite order in a parameter. -/
+theorem contDiff_integral_Icc_of_contDiff
+    {V : Type u} {W : Type v} [NormedAddCommGroup V] [NormedSpace ℝ V]
+    [NormedAddCommGroup W] [NormedSpace ℝ W] [CompleteSpace W]
+    (n : ℕ∞) (h : V → ℝ → W) (hh : ContDiff ℝ n h.uncurry) :
+    ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, h x t) := by
+  let eW : Type max u v := ULift.{u} W
+  let isoW : eW ≃L[ℝ] W := ContinuousLinearEquiv.ulift
+  let eh : V → ℝ → eW := fun x t ↦ isoW.symm (h x t)
+  have heh : ContDiff ℝ n eh.uncurry := by
+    apply isoW.symm.contDiff.comp hh
+  have he : ContDiff ℝ n (fun x ↦ ∫ t in Set.Icc (0 : ℝ) 1, eh x t) := by
+    rw [contDiff_iff_forall_nat_le]
+    intro m hm
+    exact contDiff_integral_Icc_of_contDiff_nat m eh (heh.of_le (by exact_mod_cast hm))
+  convert isoW.contDiff.comp he using 1
+  funext x
+  simpa only [Function.comp_apply, eh, ContinuousLinearEquiv.apply_symm_apply] using
+    (isoW.integral_comp_comm (μ := volume.restrict (Set.Icc (0 : ℝ) 1)) (fun t ↦ eh x t))


### PR DESCRIPTION
## Goal

Provide the smooth first-order Hadamard factorization needed to reconstruct a tangent vector from an algebraic point derivation.

## Construction

For a smooth map `f : E → F` into a complete normed space, define `hadamardFactor f x y` as the average of `fderiv ℝ f` along the segment from `x` to `y`. The first commit proves

`f y - f x = hadamardFactor f x y (y - x)`.

The second commit proves that the coefficient depends smoothly on `y` for a smooth vector-valued function. Its core is a reusable public result that compact parameter integration over `[0,1]` preserves finite-order differentiability; a compact-fiber tube argument provides a uniform bound on a common parameter neighborhood without assuming finite-dimensionality. The public API includes continuity, differentiation under the integral, arbitrary finite orders, and independent domain/codomain universes.

`hadamardFactor_eq_integral_Icc` is the public characterization lemma for the defining compact-interval integral and centralizes the interval-integral conversion used by the regularity proofs.

## Why this advances the roadmap

A point derivation can apply the Leibniz rule to the coordinate expansion supplied by this factorization. Smoothness of the coefficient functions is the missing analytic input for proving `tangentToPointDerivation` surjective, and therefore for constructing the roadmap equivalence `PointDerivation I x ≃ₗ[ℝ] TangentSpace I x` tracked by [intention #135](https://github.com/TauCetiProject/TauCetiRoadmap/issues/135).

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 0, “The Lie algebra and the tangent space at 1”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-0-the-exponential-map-and-one-parameter-subgroups).

## Verification

- `lake env lean TauCeti/Analysis/Calculus/Hadamard.lean`
- `bash scripts/sandbox-build.sh`
  - build: 6,233 jobs
  - axioms: 20,199 declarations, all within the allowlist
  - module system: 1,102 modules
  - lint: no new violations

Roadmap: RepresentationTheory