### PR TITLE
feat: add degree-two Clifford leading-term map

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Conjugation
+public import Mathlib.LinearAlgebra.ExteriorPower.Basic
 public import Mathlib.RingTheory.Finiteness.Subalgebra
 
 /-!
@@ -50,6 +51,8 @@ supremum over the `i` of a fixed parity.
 * `TauCeti.CliffordAlgebra.filtration_succ_eq_sup`: the recursion for the successor step.
 * `TauCeti.CliffordAlgebra.filtration_eq_iSup_pow`: the comparison with the submodule powers of
   `LinearMap.range (ι Q)`.
+* `TauCeti.CliffordAlgebra.filtrationTwoLeadingTerm`: the degree-two leading-term map from the
+  second exterior power to the second graded piece.
 * `TauCeti.CliffordAlgebra.iSup_filtration_eq_top` and
   `TauCeti.CliffordAlgebra.exists_mem_filtration`: the filtration is exhaustive.
 * `TauCeti.CliffordAlgebra.involute_mem_filtration`,
@@ -241,6 +244,114 @@ theorem ι_mul_ι_add_swap_mem_filtration_zero (a b : M) :
     ι Q a * ι Q b + ι Q b * ι Q a ∈ filtration Q 0 := by
   rw [ι_mul_ι_add_swap]
   exact algebraMap_mem_filtration Q _ 0
+
+private noncomputable def filtrationTwoLeadingTermAlternating : M [⋀^Fin 2]→ₗ[R]
+    (filtration Q 2 ⧸ (filtration Q 1).comap (filtration Q 2).subtype) :=
+  { toFun := fun v =>
+      Submodule.Quotient.mk ⟨ι Q (v 0) * ι Q (v 1), ι_mul_ι_mem_filtration_two Q _ _⟩
+    map_update_add' := by
+      intro _ v i x y
+      fin_cases i
+      · simp only [Fin.zero_eta, Fin.isValue, Function.update_self, map_add, ne_eq, one_ne_zero,
+          not_false_eq_true, Function.update_of_ne, add_mul]
+        rw [← Submodule.Quotient.mk_add]
+        rfl
+      · simp only [Fin.mk_one, Fin.isValue, ne_eq, zero_ne_one, not_false_eq_true,
+          Function.update_of_ne, Function.update_self, map_add, mul_add]
+        rw [← Submodule.Quotient.mk_add]
+        rfl
+    map_update_smul' := by
+      intro _ v i c x
+      fin_cases i
+      · simp only [Fin.zero_eta, Fin.isValue, Function.update_self, map_smul, ne_eq, one_ne_zero,
+          not_false_eq_true, Function.update_of_ne, Algebra.smul_mul_assoc]
+        rw [← Submodule.Quotient.mk_smul]
+        rfl
+      · simp only [Fin.mk_one, Fin.isValue, ne_eq, zero_ne_one, not_false_eq_true,
+          Function.update_of_ne, Function.update_self, map_smul, Algebra.mul_smul_comm]
+        rw [← Submodule.Quotient.mk_smul]
+        rfl
+    map_eq_zero_of_eq' := by
+      intro v i j h hij
+      fin_cases i <;> fin_cases j
+      · simp at hij
+      · rw [Submodule.Quotient.mk_eq_zero]
+        change ι Q (v 0) * ι Q (v 1) ∈ filtration Q 1
+        have h' : v 0 = v 1 := by simpa only [id_eq, Fin.zero_eta, Fin.mk_one] using h
+        rw [h', ι_sq_scalar]
+        exact algebraMap_mem_filtration Q _ 1
+      · rw [Submodule.Quotient.mk_eq_zero]
+        change ι Q (v 0) * ι Q (v 1) ∈ filtration Q 1
+        have h' : v 1 = v 0 := by simpa only [id_eq, Fin.zero_eta, Fin.mk_one] using h
+        rw [h', ι_sq_scalar]
+        exact algebraMap_mem_filtration Q _ 1
+      · simp at hij }
+
+/-- The degree-two leading-term map from the exterior square to the second graded piece of the
+Clifford filtration. Its source is alternating because a repeated Clifford generator is scalar,
+which vanishes modulo the first filtration step. Swapping two generators negates their quotient
+class modulo that step.
+
+This is the degree-two component required on the way to the Layer 0 associated-graded equivalence
+in the [spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L65-L73). -/
+noncomputable def filtrationTwoLeadingTerm : ⋀[R]^2 M →ₗ[R]
+    (filtration Q 2 ⧸ (filtration Q 1).comap (filtration Q 2).subtype) :=
+  exteriorPower.alternatingMapLinearEquiv (filtrationTwoLeadingTermAlternating Q)
+
+/-- The degree-two leading-term map sends a decomposable exterior product to the class of the
+corresponding product of Clifford generators. -/
+@[simp]
+theorem filtrationTwoLeadingTerm_apply_ιMulti (a b : M) :
+    filtrationTwoLeadingTerm Q (exteriorPower.ιMulti R 2 ![a, b]) =
+      Submodule.Quotient.mk ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ := by
+  simp [filtrationTwoLeadingTerm, filtrationTwoLeadingTermAlternating]
+
+/-- Every element of the second graded piece is the leading term of a degree-two exterior
+product. -/
+theorem filtrationTwoLeadingTerm_surjective : Function.Surjective (filtrationTwoLeadingTerm Q) := by
+  let P : Submodule R (filtration Q 2) :=
+    (filtration Q 1).comap (filtration Q 2).subtype
+  let q : filtration Q 2 →ₗ[R] (filtration Q 2 ⧸ P) := P.mkQ
+  let T : Submodule R (filtration Q 2) :=
+    (LinearMap.range (filtrationTwoLeadingTerm Q)).comap q
+  have hle : filtration Q 2 ≤ T.map (filtration Q 2).subtype := by
+    calc
+      filtration Q 2 = filtration Q 1 ⊔ LinearMap.range (ι Q) ^ (1 + 1) :=
+        filtration_succ_eq_sup Q 1
+      _ ≤ T.map (filtration Q 2).subtype := sup_le (by
+        intro z hz
+        have hz₂ : z ∈ filtration Q 2 := filtration_mono Q (by omega) hz
+        let z₂ : filtration Q 2 := ⟨z, hz₂⟩
+        refine Submodule.mem_map.2 ⟨z₂, ?_, rfl⟩
+        change q z₂ ∈ LinearMap.range (filtrationTwoLeadingTerm Q)
+        change P.mkQ z₂ ∈ LinearMap.range (filtrationTwoLeadingTerm Q)
+        have hzP : z₂ ∈ P := by
+          change z ∈ filtration Q 1
+          exact hz
+        have hzero : P.mkQ z₂ = 0 := by
+          rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
+          exact hzP
+        rw [hzero]
+        exact Submodule.zero_mem _) (by
+        rw [pow_two, Submodule.mul_le]
+        rintro z ⟨a, rfl⟩ w ⟨b, rfl⟩
+        refine Submodule.mem_map.2 ⟨⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩, ?_, rfl⟩
+        change q ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ ∈
+          LinearMap.range (filtrationTwoLeadingTerm Q)
+        change P.mkQ ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ ∈
+          LinearMap.range (filtrationTwoLeadingTerm Q)
+        rw [Submodule.mkQ_apply]
+        exact LinearMap.mem_range.2 ⟨exteriorPower.ιMulti R 2 ![a, b],
+          filtrationTwoLeadingTerm_apply_ιMulti Q a b⟩)
+  intro z
+  obtain ⟨x, rfl⟩ := Submodule.Quotient.mk_surjective P z
+  have hx : (x : CliffordAlgebra Q) ∈ T.map (filtration Q 2).subtype := hle x.property
+  rcases Submodule.mem_map.1 hx with ⟨y, hy, hxy⟩
+  have hxy' : y = x := Subtype.ext hxy
+  subst x
+  change q y ∈ LinearMap.range (filtrationTwoLeadingTerm Q) at hy
+  change P.mkQ y ∈ LinearMap.range (filtrationTwoLeadingTerm Q) at hy
+  exact LinearMap.mem_range.1 hy
 
 section Conjugation
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -251,41 +251,22 @@ private noncomputable def filtrationTwoLeadingTermAlternating : M [⋀^Fin 2]→
       Submodule.Quotient.mk ⟨ι Q (v 0) * ι Q (v 1), ι_mul_ι_mem_filtration_two Q _ _⟩
     map_update_add' := by
       intro _ v i x y
-      fin_cases i
-      · simp only [Fin.zero_eta, Fin.isValue, Function.update_self, map_add, ne_eq, one_ne_zero,
-          not_false_eq_true, Function.update_of_ne, add_mul]
-        rw [← Submodule.Quotient.mk_add]
-        rfl
-      · simp only [Fin.mk_one, Fin.isValue, ne_eq, zero_ne_one, not_false_eq_true,
-          Function.update_of_ne, Function.update_self, map_add, mul_add]
-        rw [← Submodule.Quotient.mk_add]
-        rfl
+      fin_cases i <;>
+        simp [add_mul, mul_add, ← Submodule.Quotient.mk_add]
     map_update_smul' := by
       intro _ v i c x
-      fin_cases i
-      · simp only [Fin.zero_eta, Fin.isValue, Function.update_self, map_smul, ne_eq, one_ne_zero,
-          not_false_eq_true, Function.update_of_ne, Algebra.smul_mul_assoc]
-        rw [← Submodule.Quotient.mk_smul]
-        rfl
-      · simp only [Fin.mk_one, Fin.isValue, ne_eq, zero_ne_one, not_false_eq_true,
-          Function.update_of_ne, Function.update_self, map_smul, Algebra.mul_smul_comm]
-        rw [← Submodule.Quotient.mk_smul]
-        rfl
+      fin_cases i <;>
+        simp [Algebra.smul_mul_assoc, Algebra.mul_smul_comm, ← Submodule.Quotient.mk_smul]
     map_eq_zero_of_eq' := by
       intro v i j h hij
       fin_cases i <;> fin_cases j
       · simp at hij
-      · rw [Submodule.Quotient.mk_eq_zero]
-        change ι Q (v 0) * ι Q (v 1) ∈ filtration Q 1
-        have h' : v 0 = v 1 := by simpa only [id_eq, Fin.zero_eta, Fin.mk_one] using h
-        rw [h', ι_sq_scalar]
-        exact algebraMap_mem_filtration Q _ 1
-      · rw [Submodule.Quotient.mk_eq_zero]
-        change ι Q (v 0) * ι Q (v 1) ∈ filtration Q 1
-        have h' : v 1 = v 0 := by simpa only [id_eq, Fin.zero_eta, Fin.mk_one] using h
-        rw [h', ι_sq_scalar]
-        exact algebraMap_mem_filtration Q _ 1
-      · simp at hij }
+      all_goals rw [Submodule.Quotient.mk_eq_zero]
+      -- The quotient equality leaves membership in the embedded first step; expose its comap
+      -- carrier to use the scalar Clifford relation in `filtration Q 1`.
+      all_goals change ι Q (v 0) * ι Q (v 1) ∈ filtration Q 1
+      all_goals simp_all [ι_sq_scalar]
+      all_goals simpa only [filtration_one] using algebraMap_mem_filtration Q _ 1 }
 
 /-- The degree-two leading-term map from the exterior square to the second graded piece of the
 Clifford filtration. Its source is alternating because a repeated Clifford generator is scalar,
@@ -323,9 +304,12 @@ theorem filtrationTwoLeadingTerm_surjective : Function.Surjective (filtrationTwo
         have hz₂ : z ∈ filtration Q 2 := filtration_mono Q (by omega) hz
         let z₂ : filtration Q 2 := ⟨z, hz₂⟩
         refine Submodule.mem_map.2 ⟨z₂, ?_, rfl⟩
+        -- `T` is a comap, so expose its carrier before using the quotient map.
         change q z₂ ∈ LinearMap.range (filtrationTwoLeadingTerm Q)
+        -- The named map `q` is the quotient map for the embedded first step.
         change P.mkQ z₂ ∈ LinearMap.range (filtrationTwoLeadingTerm Q)
         have hzP : z₂ ∈ P := by
+          -- Membership in `P` is comap membership of the ambient element in the first step.
           change z ∈ filtration Q 1
           exact hz
         have hzero : P.mkQ z₂ = 0 := by
@@ -336,6 +320,7 @@ theorem filtrationTwoLeadingTerm_surjective : Function.Surjective (filtrationTwo
         rw [pow_two, Submodule.mul_le]
         rintro z ⟨a, rfl⟩ w ⟨b, rfl⟩
         refine Submodule.mem_map.2 ⟨⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩, ?_, rfl⟩
+        -- Again expose `T`'s comap carrier, then its named quotient map.
         change q ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ ∈
           LinearMap.range (filtrationTwoLeadingTerm Q)
         change P.mkQ ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ ∈
@@ -349,6 +334,7 @@ theorem filtrationTwoLeadingTerm_surjective : Function.Surjective (filtrationTwo
   rcases Submodule.mem_map.1 hx with ⟨y, hy, hxy⟩
   have hxy' : y = x := Subtype.ext hxy
   subst x
+  -- The final range witness is carried through `T`'s comap and the named quotient map.
   change q y ∈ LinearMap.range (filtrationTwoLeadingTerm Q) at hy
   change P.mkQ y ∈ LinearMap.range (filtrationTwoLeadingTerm Q) at hy
   exact LinearMap.mem_range.1 hy

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -287,8 +287,7 @@ theorem filtrationTwoLeadingTerm_apply_ιMulti (a b : M) :
       Submodule.Quotient.mk ⟨ι Q a * ι Q b, ι_mul_ι_mem_filtration_two Q a b⟩ := by
   simp [filtrationTwoLeadingTerm, filtrationTwoLeadingTermAlternating]
 
-/-- Every element of the second graded piece is the leading term of a degree-two exterior
-product. -/
+/-- Every element of the second graded piece is the image of an element of the exterior square. -/
 theorem filtrationTwoLeadingTerm_surjective : Function.Surjective (filtrationTwoLeadingTerm Q) := by
   let P : Submodule R (filtration Q 2) :=
     (filtration Q 1).comap (filtration Q 2).subtype


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the degree-two leading-term map for the Clifford degree filtration.

- Defines `filtrationTwoLeadingTerm` from `⋀[R]^2 M` to the quotient of `F₂` by the embedded `F₁`.
- Proves its value on a decomposable exterior product.
- Proves that the map is surjective.

## Roadmap target

Adds the degree-two prerequisite for the Layer 0 `filtrationGradedEquiv` target:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68

The PR does not prove the associated-graded equivalence, injectivity, or all-degree compatibility.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#filtrationGradedEquiv"}-->

## Verification

`lake build TauCeti`, the axiom audit, module-system audit, environment lint, whitespace check, and a downstream import probe pass at `b25e1f4e`.

## Scope

Changes only `TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean`. It adds no `Bivector.lean` work, Lie construction, basis or coordinate API, `equivExterior` compatibility, PBW equivalence, CAR work, or Spin action.
