### PR TITLE
feat: show the Poincaré inequality fails on the whole space

### DIFF
--- a/TauCeti/Analysis/Sobolev/Dilation.lean
+++ b/TauCeti/Analysis/Sobolev/Dilation.lean
@@ -4,8 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Calculus.FDeriv.Add
-public import Mathlib.Analysis.Calculus.FDeriv.Comp
+public import Mathlib.Analysis.Calculus.FDeriv.Equiv
 public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
 
@@ -22,8 +21,9 @@ For `0 < p < ∞` the two scaling laws are
 
 `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p` and `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`,
 
-the extra `r⁻¹` in the second coming from the chain rule. The mismatch of the two exponents is
-the scaling obstruction behind `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`: a
+the extra `r⁻¹` in the second coming from the chain rule, in the shape of Mathlib's
+`fderiv_comp_smul`. The mismatch of the two exponents is the scaling obstruction behind
+`TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`: a
 Poincaré-type inequality cannot hold with one constant for all compactly supported functions on
 the whole space.
 
@@ -36,8 +36,6 @@ from `MeasureTheory.Measure.map_addHaar_smul`, and is what the `eLpNorm` stateme
 * `TauCeti.lintegral_comp_smul`: `∫⁻ x, g (r • x) ∂μ = |(r ^ n)⁻¹| * ∫⁻ x, g x ∂μ`.
 * `TauCeti.lintegral_comp_inv_smul`: the same law written for `r⁻¹` and `0 < r`.
 * `TauCeti.eLpNorm_comp_inv_smul`: `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`.
-* `TauCeti.hasFDerivAt_comp_inv_smul`, `TauCeti.fderiv_comp_inv_smul`: the chain rule for a
-  dilation, `D(u (r⁻¹ • ·)) x = r⁻¹ • Du (r⁻¹ • x)`.
 * `TauCeti.eLpNorm_fderiv_comp_inv_smul`: `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`.
 -/
 
@@ -50,26 +48,6 @@ open scoped ENNReal
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
-
-section Calculus
-
-/-- **Chain rule for a dilation.** If `u` has derivative `u'` at `r⁻¹ • x`, then the dilate
-`y ↦ u (r⁻¹ • y)` has derivative `r⁻¹ • u'` at `x`. -/
-theorem hasFDerivAt_comp_inv_smul {u : E → F} {u' : E →L[ℝ] F} {x : E} (r : ℝ)
-    (h : HasFDerivAt u u' (r⁻¹ • x)) :
-    HasFDerivAt (fun y => u (r⁻¹ • y)) (r⁻¹ • u') x := by
-  have hid : HasFDerivAt (fun y : E => r⁻¹ • y) (r⁻¹ • ContinuousLinearMap.id ℝ E) x :=
-    (hasFDerivAt_id x).const_smul r⁻¹
-  have key : u' ∘L (r⁻¹ • ContinuousLinearMap.id ℝ E) = r⁻¹ • u' := by ext v; simp
-  exact key ▸ h.comp x hid
-
-/-- The derivative of a dilate is the dilate of the derivative, scaled by `r⁻¹`. -/
-theorem fderiv_comp_inv_smul {u : E → F} (hu : Differentiable ℝ u) (r : ℝ) :
-    (fderiv ℝ fun y => u (r⁻¹ • y)) = r⁻¹ • fun x => fderiv ℝ u (r⁻¹ • x) := by
-  funext x
-  exact (hasFDerivAt_comp_inv_smul r (hu (r⁻¹ • x)).hasFDerivAt).fderiv
-
-end Calculus
 
 section Measure
 
@@ -114,11 +92,13 @@ theorem eLpNorm_comp_inv_smul (f : E → G) {r : ℝ} (hr : 0 < r) {p : ℝ≥0�
 /-- **Dilation scaling of the `Lᵖ` seminorm of the derivative:**
 `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`. The exponent drops by one relative to
 `TauCeti.eLpNorm_comp_inv_smul` because the chain rule contributes a factor `r⁻¹`. -/
-theorem eLpNorm_fderiv_comp_inv_smul {u : E → F} (hu : Differentiable ℝ u) {r : ℝ} (hr : 0 < r)
+theorem eLpNorm_fderiv_comp_inv_smul (u : E → F) {r : ℝ} (hr : 0 < r)
     {p : ℝ≥0∞} (hp₀ : p ≠ 0) (hp : p ≠ ∞) :
     eLpNorm (fderiv ℝ fun y => u (r⁻¹ • y)) p μ =
       ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal - 1)) * eLpNorm (fderiv ℝ u) p μ := by
-  rw [fderiv_comp_inv_smul hu r, eLpNorm_const_smul r⁻¹ (fun x => fderiv ℝ u (r⁻¹ • x)) p μ,
+  have hfderiv : (fderiv ℝ fun y => u (r⁻¹ • y)) = r⁻¹ • fun x => fderiv ℝ u (r⁻¹ • x) :=
+    funext fun x => fderiv_comp_smul (f := u) (x := x) r⁻¹
+  rw [hfderiv, eLpNorm_const_smul r⁻¹ (fun x => fderiv ℝ u (r⁻¹ • x)) p μ,
     eLpNorm_comp_inv_smul μ (fderiv ℝ u) hr hp₀ hp, ← mul_assoc]
   congr 1
   rw [Real.enorm_eq_ofReal_abs, abs_of_pos (by positivity : (0 : ℝ) < r⁻¹),

--- a/TauCeti/Analysis/Sobolev/Dilation.lean
+++ b/TauCeti/Analysis/Sobolev/Dilation.lean
@@ -1,0 +1,131 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.FDeriv.Add
+public import Mathlib.Analysis.Calculus.FDeriv.Comp
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+
+/-!
+# Dilation scaling of the Sobolev seminorms
+
+Fix a finite-dimensional real normed space `E` of dimension `n` carrying an additive Haar
+measure `μ`, and dilate the variable of a function by `r > 0`, i.e. replace `u` by
+`x ↦ u (r⁻¹ • x)`. This file records how that operation rescales the two quantities a
+first-order Sobolev estimate compares: the `Lᵖ` seminorm of the function, and the `Lᵖ`
+seminorm of its derivative.
+
+For `0 < p < ∞` the two scaling laws are
+
+`‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p` and `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`,
+
+the extra `r⁻¹` in the second coming from the chain rule. The mismatch of the two exponents is
+the scaling obstruction behind `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`: a
+Poincaré-type inequality cannot hold with one constant for all compactly supported functions on
+the whole space.
+
+Mathlib has the Bochner-integral scaling law `MeasureTheory.Measure.integral_comp_inv_smul`;
+`TauCeti.lintegral_comp_smul` is its lower-Lebesgue-integral counterpart, proved the same way
+from `MeasureTheory.Measure.map_addHaar_smul`, and is what the `eLpNorm` statements consume.
+
+## Main declarations
+
+* `TauCeti.lintegral_comp_smul`: `∫⁻ x, g (r • x) ∂μ = |(r ^ n)⁻¹| * ∫⁻ x, g x ∂μ`.
+* `TauCeti.lintegral_comp_inv_smul`: the same law written for `r⁻¹` and `0 < r`.
+* `TauCeti.eLpNorm_comp_inv_smul`: `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`.
+* `TauCeti.hasFDerivAt_comp_inv_smul`, `TauCeti.fderiv_comp_inv_smul`: the chain rule for a
+  dilation, `D(u (r⁻¹ • ·)) x = r⁻¹ • Du (r⁻¹ • x)`.
+* `TauCeti.eLpNorm_fderiv_comp_inv_smul`: `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Module
+open scoped ENNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+section Calculus
+
+/-- **Chain rule for a dilation.** If `u` has derivative `u'` at `r⁻¹ • x`, then the dilate
+`y ↦ u (r⁻¹ • y)` has derivative `r⁻¹ • u'` at `x`. -/
+theorem hasFDerivAt_comp_inv_smul {u : E → F} {u' : E →L[ℝ] F} {x : E} (r : ℝ)
+    (h : HasFDerivAt u u' (r⁻¹ • x)) :
+    HasFDerivAt (fun y => u (r⁻¹ • y)) (r⁻¹ • u') x := by
+  have hid : HasFDerivAt (fun y : E => r⁻¹ • y) (r⁻¹ • ContinuousLinearMap.id ℝ E) x :=
+    (hasFDerivAt_id x).const_smul r⁻¹
+  have key : u' ∘L (r⁻¹ • ContinuousLinearMap.id ℝ E) = r⁻¹ • u' := by ext v; simp
+  exact key ▸ h.comp x hid
+
+/-- The derivative of a dilate is the dilate of the derivative, scaled by `r⁻¹`. -/
+theorem fderiv_comp_inv_smul {u : E → F} (hu : Differentiable ℝ u) (r : ℝ) :
+    (fderiv ℝ fun y => u (r⁻¹ • y)) = r⁻¹ • fun x => fderiv ℝ u (r⁻¹ • x) := by
+  funext x
+  exact (hasFDerivAt_comp_inv_smul r (hu (r⁻¹ • x)).hasFDerivAt).fderiv
+
+end Calculus
+
+section Measure
+
+variable [MeasurableSpace E] [BorelSpace E] [FiniteDimensional ℝ E] (μ : Measure E)
+  [μ.IsAddHaarMeasure] {G : Type*} [NormedAddCommGroup G]
+
+/-- **Dilation scaling of the lower Lebesgue integral.** This is the counterpart, for `∫⁻`, of
+Mathlib's `MeasureTheory.Measure.integral_comp_smul`; as there, no integrability of `g` is
+needed. -/
+theorem lintegral_comp_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : r ≠ 0) :
+    ∫⁻ x, g (r • x) ∂μ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
+  calc ∫⁻ x, g (r • x) ∂μ = ∫⁻ y, g y ∂Measure.map (fun x => r • x) μ :=
+        (lintegral_map_equiv g
+          (Homeomorph.smul (isUnit_iff_ne_zero.2 hr).unit).toMeasurableEquiv).symm
+    _ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
+        rw [Measure.map_addHaar_smul μ hr, lintegral_smul_measure, smul_eq_mul]
+
+/-- Dilating the variable by `r⁻¹`, for `0 < r`, multiplies a lower Lebesgue integral by
+`r ^ n`, where `n` is the dimension of the ambient space. -/
+theorem lintegral_comp_inv_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : 0 < r) :
+    ∫⁻ x, g (r⁻¹ • x) ∂μ = ENNReal.ofReal (r ^ finrank ℝ E) * ∫⁻ x, g x ∂μ := by
+  rw [lintegral_comp_smul μ g (inv_ne_zero hr.ne'), inv_pow, inv_inv,
+    abs_of_nonneg (by positivity)]
+
+/-- **Dilation scaling of the `Lᵖ` seminorm:** `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`, where
+`n` is the dimension of the ambient space. -/
+theorem eLpNorm_comp_inv_smul (f : E → G) {r : ℝ} (hr : 0 < r) {p : ℝ≥0∞} (hp₀ : p ≠ 0)
+    (hp : p ≠ ∞) :
+    eLpNorm (fun x => f (r⁻¹ • x)) p μ =
+      ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal)) * eLpNorm f p μ := by
+  have ht : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp
+  have key := lintegral_comp_inv_smul μ (fun y => ‖f y‖ₑ ^ p.toReal) hr
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp, eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp,
+    key, ENNReal.mul_rpow_of_nonneg _ _ (by positivity)]
+  have hpow : ((r ^ finrank ℝ E : ℝ)) ^ (1 / p.toReal) = r ^ ((finrank ℝ E : ℝ) / p.toReal) := by
+    rw [← Real.rpow_natCast r (finrank ℝ E), ← Real.rpow_mul hr.le]
+    ring_nf
+  congr 1
+  rw [← hpow]
+  exact ENNReal.ofReal_rpow_of_pos (by positivity : (0 : ℝ) < r ^ finrank ℝ E)
+
+/-- **Dilation scaling of the `Lᵖ` seminorm of the derivative:**
+`‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`. The exponent drops by one relative to
+`TauCeti.eLpNorm_comp_inv_smul` because the chain rule contributes a factor `r⁻¹`. -/
+theorem eLpNorm_fderiv_comp_inv_smul {u : E → F} (hu : Differentiable ℝ u) {r : ℝ} (hr : 0 < r)
+    {p : ℝ≥0∞} (hp₀ : p ≠ 0) (hp : p ≠ ∞) :
+    eLpNorm (fderiv ℝ fun y => u (r⁻¹ • y)) p μ =
+      ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal - 1)) * eLpNorm (fderiv ℝ u) p μ := by
+  rw [fderiv_comp_inv_smul hu r, eLpNorm_const_smul r⁻¹ (fun x => fderiv ℝ u (r⁻¹ • x)) p μ,
+    eLpNorm_comp_inv_smul μ (fderiv ℝ u) hr hp₀ hp, ← mul_assoc]
+  congr 1
+  rw [Real.enorm_eq_ofReal_abs, abs_of_pos (by positivity : (0 : ℝ) < r⁻¹),
+    ← ENNReal.ofReal_mul (by positivity), Real.rpow_sub hr, Real.rpow_one]
+  congr 1
+  field_simp
+
+end Measure
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/Dilation.lean
+++ b/TauCeti/Analysis/Sobolev/Dilation.lean
@@ -4,18 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Calculus.FDeriv.Equiv
-public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
-public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+-- `TauCeti.MeasureTheory.Function.Lp.Dilation` is imported publicly:
+-- `TauCeti.eLpNorm_comp_inv_smul` is the companion of the statement below, and supplies the
+-- `eLpNorm` and Haar measure API appearing in its signature.
+public import TauCeti.MeasureTheory.Function.Lp.Dilation
+public import Mathlib.Analysis.Calculus.FDeriv.Basic
+-- `Mathlib.Analysis.Calculus.FDeriv.Equiv` is imported privately: its `fderiv_comp_smul` is used
+-- only inside the proof, so downstream importers do not pay for the equivalence machinery.
+import Mathlib.Analysis.Calculus.FDeriv.Equiv
 
 /-!
 # Dilation scaling of the Sobolev seminorms
 
 Fix a finite-dimensional real normed space `E` of dimension `n` carrying an additive Haar
 measure `μ`, and dilate the variable of a function by `r > 0`, i.e. replace `u` by
-`x ↦ u (r⁻¹ • x)`. This file records how that operation rescales the two quantities a
-first-order Sobolev estimate compares: the `Lᵖ` seminorm of the function, and the `Lᵖ`
-seminorm of its derivative.
+`x ↦ u (r⁻¹ • x)`. This file records how that operation rescales the `Lᵖ` seminorm of the
+derivative, the second of the two quantities a first-order Sobolev estimate compares; the first,
+the `Lᵖ` seminorm of the function itself, is `TauCeti.eLpNorm_comp_inv_smul`.
 
 For `0 < p < ∞` the two scaling laws are
 
@@ -27,15 +32,8 @@ the extra `r⁻¹` in the second coming from the chain rule, in the shape of Mat
 Poincaré-type inequality cannot hold with one constant for all compactly supported functions on
 the whole space.
 
-Mathlib has the Bochner-integral scaling law `MeasureTheory.Measure.integral_comp_inv_smul`;
-`TauCeti.lintegral_comp_smul` is its lower-Lebesgue-integral counterpart, proved the same way
-from `MeasureTheory.Measure.map_addHaar_smul`, and is what the `eLpNorm` statements consume.
-
 ## Main declarations
 
-* `TauCeti.lintegral_comp_smul`: `∫⁻ x, g (r • x) ∂μ = |(r ^ n)⁻¹| * ∫⁻ x, g x ∂μ`.
-* `TauCeti.lintegral_comp_inv_smul`: the same law written for `r⁻¹` and `0 < r`.
-* `TauCeti.eLpNorm_comp_inv_smul`: `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`.
 * `TauCeti.eLpNorm_fderiv_comp_inv_smul`: `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`.
 -/
 
@@ -46,48 +44,9 @@ namespace TauCeti
 open MeasureTheory Module
 open scoped ENNReal
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E] (μ : Measure E) [μ.IsAddHaarMeasure]
   {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
-
-section Measure
-
-variable [MeasurableSpace E] [BorelSpace E] [FiniteDimensional ℝ E] (μ : Measure E)
-  [μ.IsAddHaarMeasure] {G : Type*} [NormedAddCommGroup G]
-
-/-- **Dilation scaling of the lower Lebesgue integral.** This is the counterpart, for `∫⁻`, of
-Mathlib's `MeasureTheory.Measure.integral_comp_smul`; as there, no integrability of `g` is
-needed. -/
-theorem lintegral_comp_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : r ≠ 0) :
-    ∫⁻ x, g (r • x) ∂μ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
-  calc ∫⁻ x, g (r • x) ∂μ = ∫⁻ y, g y ∂Measure.map (fun x => r • x) μ :=
-        (lintegral_map_equiv g
-          (Homeomorph.smul (isUnit_iff_ne_zero.2 hr).unit).toMeasurableEquiv).symm
-    _ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
-        rw [Measure.map_addHaar_smul μ hr, lintegral_smul_measure, smul_eq_mul]
-
-/-- Dilating the variable by `r⁻¹`, for `0 < r`, multiplies a lower Lebesgue integral by
-`r ^ n`, where `n` is the dimension of the ambient space. -/
-theorem lintegral_comp_inv_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : 0 < r) :
-    ∫⁻ x, g (r⁻¹ • x) ∂μ = ENNReal.ofReal (r ^ finrank ℝ E) * ∫⁻ x, g x ∂μ := by
-  rw [lintegral_comp_smul μ g (inv_ne_zero hr.ne'), inv_pow, inv_inv,
-    abs_of_nonneg (by positivity)]
-
-/-- **Dilation scaling of the `Lᵖ` seminorm:** `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`, where
-`n` is the dimension of the ambient space. -/
-theorem eLpNorm_comp_inv_smul (f : E → G) {r : ℝ} (hr : 0 < r) {p : ℝ≥0∞} (hp₀ : p ≠ 0)
-    (hp : p ≠ ∞) :
-    eLpNorm (fun x => f (r⁻¹ • x)) p μ =
-      ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal)) * eLpNorm f p μ := by
-  have ht : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp
-  have key := lintegral_comp_inv_smul μ (fun y => ‖f y‖ₑ ^ p.toReal) hr
-  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp, eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp,
-    key, ENNReal.mul_rpow_of_nonneg _ _ (by positivity)]
-  have hpow : ((r ^ finrank ℝ E : ℝ)) ^ (1 / p.toReal) = r ^ ((finrank ℝ E : ℝ) / p.toReal) := by
-    rw [← Real.rpow_natCast r (finrank ℝ E), ← Real.rpow_mul hr.le]
-    ring_nf
-  congr 1
-  rw [← hpow]
-  exact ENNReal.ofReal_rpow_of_pos (by positivity : (0 : ℝ) < r ^ finrank ℝ E)
 
 /-- **Dilation scaling of the `Lᵖ` seminorm of the derivative:**
 `‖D(u (r⁻¹ • ·))‖_p = r ^ (n / p - 1) * ‖Du‖_p`. The exponent drops by one relative to
@@ -105,7 +64,5 @@ theorem eLpNorm_fderiv_comp_inv_smul (u : E → F) {r : ℝ} (hr : 0 < r)
     ← ENNReal.ofReal_mul (by positivity), Real.rpow_sub hr, Real.rpow_one]
   congr 1
   field_simp
-
-end Measure
 
 end TauCeti

--- a/TauCeti/Analysis/Sobolev/Poincare.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare.lean
@@ -1,0 +1,139 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Sobolev.Dilation
+public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
+public import Mathlib.Analysis.FunctionalSpaces.SobolevInequality
+public import Mathlib.MeasureTheory.Function.LpSpace.Indicator
+public import Mathlib.MeasureTheory.Measure.OpenPos
+
+/-!
+# The Poincaré inequality fails on the whole space
+
+A Poincaré inequality bounds the `Lᵖ` seminorm of a function by the `Lᵖ` seminorm of its
+derivative, `‖u‖_p ≤ C ‖Du‖_p`. Mathlib proves such an estimate in
+`MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, for `1 ≤ p < n` and functions supported in a *fixed
+bounded* set `s`, with a constant that depends on `s`. The PDE roadmap asks for the companion
+fact that pins the role of that hypothesis: on the whole of a finite-dimensional space no single
+constant works for *all* compactly supported functions, so the boundedness of the support is
+load-bearing rather than an artefact of the proof.
+
+The obstruction is scaling. Dilating the variable by `r > 0` multiplies `‖u‖_p` by `r ^ (n / p)`
+and `‖Du‖_p` by `r ^ (n / p - 1)` (`TauCeti.eLpNorm_comp_inv_smul` and
+`TauCeti.eLpNorm_fderiv_comp_inv_smul`), so applying a putative inequality to the dilates of one
+fixed bump function forces `‖u‖_p ≤ C r⁻¹ ‖Du‖_p` for every `r`, and letting `r → ∞` makes the
+bump's own seminorm vanish. Note that the two hypotheses `p ≠ 0` and `p ≠ ∞` are the only ones
+needed: the failure is not confined to the subcritical range `p < n` in which the positive
+result lives.
+
+The two statements are recorded side by side, over the same space and in the same shape
+(`∃ C, ∀ u, …` against `¬ ∃ C, ∀ u, …`), so that the difference between them is exactly the
+hypothesis on the supports.
+
+## Main declarations
+
+* `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`: no constant `C` satisfies
+  `‖u‖_p ≤ C ‖Du‖_p` for all compactly supported `C¹` functions on a finite-dimensional real
+  normed space with an additive Haar measure.
+* `TauCeti.exists_eLpNorm_le_const_mul_eLpNorm_fderiv_of_isBounded`: for `1 ≤ p < n` such a
+  constant does exist once all the functions are supported in one fixed bounded set (a
+  restatement of Mathlib's `MeasureTheory.eLpNorm_le_eLpNorm_fderiv` in that shape).
+* `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv_euclideanSpace`: the roadmap's
+  `ℝⁿ` form, for Lebesgue measure on `EuclideanSpace ℝ (Fin n)`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Filter MeasureTheory Module Topology
+open scoped ENNReal NNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E] (μ : Measure E) [μ.IsAddHaarMeasure]
+
+/-- **No Poincaré inequality holds on the whole space.** There is no constant `C` with
+`‖u‖_p ≤ C ‖Du‖_p` for every compactly supported `C¹` function `u`, for any `0 < p < ∞`.
+
+Compare `MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, which supplies such a constant once every
+`u` is supported in one fixed bounded set; the proof here shows that hypothesis cannot be
+dropped. -/
+theorem not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv {p : ℝ≥0∞} (hp₀ : p ≠ 0) (hp : p ≠ ∞) :
+    ¬ ∃ C : ℝ≥0, ∀ u : E → ℝ, ContDiff ℝ 1 u → HasCompactSupport u →
+      eLpNorm u p μ ≤ C * eLpNorm (fderiv ℝ u) p μ := by
+  rintro ⟨C, hC⟩
+  -- Fix one bump function; every dilate of it is an admissible test function.
+  set φ : ContDiffBump (0 : E) := ⟨1, 2, one_pos, one_lt_two⟩
+  have hφ2 : ContDiff ℝ 2 (φ : E → ℝ) := φ.contDiff
+  have hφ1 : ContDiff ℝ 1 (φ : E → ℝ) := φ.contDiff
+  have hφcs : HasCompactSupport (φ : E → ℝ) := φ.hasCompactSupport
+  have hφdiff : Differentiable ℝ (φ : E → ℝ) := hφ1.differentiable (by norm_num)
+  set A := eLpNorm (φ : E → ℝ) p μ
+  set D := eLpNorm (fderiv ℝ (φ : E → ℝ)) p μ
+  -- The bump has positive seminorm: it is continuous and equal to `1` at the origin.
+  have hA : A ≠ 0 := by
+    intro h
+    have hae := (eLpNorm_eq_zero_iff hφ1.continuous.aestronglyMeasurable hp₀).1 h
+    have hzero : (φ : E → ℝ) = 0 :=
+      (Continuous.ae_eq_iff_eq μ hφ1.continuous continuous_const).1 hae
+    have h0 : (φ : E → ℝ) 0 = 1 := φ.one_of_mem_closedBall (by simp [φ.rIn_pos.le])
+    rw [hzero] at h0
+    norm_num at h0
+  -- Its derivative is continuous with compact support, hence of finite seminorm.
+  have hD : D ≠ ∞ :=
+    ((hφ2.continuous_fderiv (by norm_num)).memLp_of_hasCompactSupport
+      (μ := μ) (p := p) (hφcs.fderiv (𝕜 := ℝ))).eLpNorm_lt_top.ne
+  -- Testing the putative inequality on the dilate by `r` and cancelling the common factor
+  -- `r ^ (n / p)` leaves a bound that degrades like `r⁻¹`.
+  have key : ∀ r : ℝ, 0 < r → A ≤ ENNReal.ofReal r⁻¹ * (C * D) := by
+    intro r hr
+    have h1 := hC (fun x => φ (r⁻¹ • x))
+      (hφ1.comp (ContDiff.const_smul r⁻¹ (contDiff_id (𝕜 := ℝ) (E := E))))
+      (hφcs.comp_homeomorph (Homeomorph.smul (Units.mk0 r⁻¹ (inv_ne_zero hr.ne'))))
+    rw [eLpNorm_comp_inv_smul μ _ hr hp₀ hp, eLpNorm_fderiv_comp_inv_smul μ hφdiff hr hp₀ hp] at h1
+    set s := ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal)) with hs_def
+    have hs0 : s ≠ 0 := by
+      rw [hs_def, Ne, ENNReal.ofReal_eq_zero, not_le]
+      positivity
+    have hsplit : ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal - 1))
+        = s * ENNReal.ofReal r⁻¹ := by
+      rw [hs_def, ← ENNReal.ofReal_mul (by positivity), Real.rpow_sub hr, Real.rpow_one,
+        div_eq_mul_inv]
+    rw [hsplit] at h1
+    refine (ENNReal.mul_le_mul_iff_right hs0 ENNReal.ofReal_ne_top).1 (h1.trans (le_of_eq ?_))
+    ring
+  -- Letting `r → ∞` forces the bump's own seminorm to vanish, a contradiction.
+  have hlim : Tendsto (fun r : ℝ => ENNReal.ofReal r⁻¹ * (C * D)) atTop (𝓝 (0 * (C * D))) :=
+    ENNReal.Tendsto.mul_const
+      (by simpa using ENNReal.tendsto_ofReal (tendsto_inv_atTop_zero (𝕜 := ℝ)))
+      (Or.inr (ENNReal.mul_ne_top ENNReal.coe_ne_top hD))
+  have hle : A ≤ 0 * (C * D) := by
+    refine ge_of_tendsto hlim ?_
+    filter_upwards [eventually_gt_atTop (0 : ℝ)] with r hr using key r hr
+  rw [zero_mul, le_zero_iff] at hle
+  exact hA hle
+
+/-- **A Poincaré inequality does hold on a fixed bounded set.** For `1 ≤ p < n` there is a
+constant `C` with `‖u‖_p ≤ C ‖Du‖_p` for every `C¹` function `u` supported in a fixed bounded
+set `s`. This is `MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, stated in the same
+constant-then-function order as `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv` so that
+the two can be compared directly. -/
+theorem exists_eLpNorm_le_const_mul_eLpNorm_fderiv_of_isBounded {s : Set E} (hs : IsBounded s)
+    {p : ℝ≥0} (hp : 1 ≤ p) (hpn : p < finrank ℝ E) :
+    ∃ C : ℝ≥0, ∀ u : E → ℝ, ContDiff ℝ 1 u → Function.support u ⊆ s →
+      eLpNorm u p μ ≤ C * eLpNorm (fderiv ℝ u) p μ :=
+  ⟨eLpNormLESNormFDerivOfLeConst ℝ μ s p p,
+    fun _ hu hsupp => eLpNorm_le_eLpNorm_fderiv μ hu hsupp hp hpn hs⟩
+
+/-- The Poincaré inequality fails on `ℝⁿ` with Lebesgue measure: the roadmap's form of
+`TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. -/
+theorem not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv_euclideanSpace (n : ℕ) {p : ℝ≥0∞}
+    (hp₀ : p ≠ 0) (hp : p ≠ ∞) :
+    ¬ ∃ C : ℝ≥0, ∀ u : EuclideanSpace ℝ (Fin n) → ℝ, ContDiff ℝ 1 u → HasCompactSupport u →
+      eLpNorm u p volume ≤ C * eLpNorm (fderiv ℝ u) p volume :=
+  not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv volume hp₀ hp
+
+end TauCeti

--- a/TauCeti/Analysis/Sobolev/Poincare.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Analysis.Sobolev.Dilation
 public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
-public import Mathlib.Analysis.FunctionalSpaces.SobolevInequality
 public import Mathlib.MeasureTheory.Function.LpSpace.Indicator
 public import Mathlib.MeasureTheory.Measure.OpenPos
 
@@ -16,7 +15,8 @@ public import Mathlib.MeasureTheory.Measure.OpenPos
 A Poincaré inequality bounds the `Lᵖ` seminorm of a function by the `Lᵖ` seminorm of its
 derivative, `‖u‖_p ≤ C ‖Du‖_p`. Mathlib proves such an estimate in
 `MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, for `1 ≤ p < n` and functions supported in a *fixed
-bounded* set `s`, with a constant that depends on `s`. The PDE roadmap asks for the companion
+bounded* set `s`, with the explicit `s`-dependent constant
+`MeasureTheory.eLpNormLESNormFDerivOfLeConst ℝ μ s p p`. The PDE roadmap asks for the companion
 fact that pins the role of that hypothesis: on the whole of a finite-dimensional space no single
 constant works for *all* compactly supported functions, so the boundedness of the support is
 load-bearing rather than an artefact of the proof.
@@ -29,18 +29,11 @@ bump's own seminorm vanish. Note that the two hypotheses `p ≠ 0` and `p ≠ �
 needed: the failure is not confined to the subcritical range `p < n` in which the positive
 result lives.
 
-The two statements are recorded side by side, over the same space and in the same shape
-(`∃ C, ∀ u, …` against `¬ ∃ C, ∀ u, …`), so that the difference between them is exactly the
-hypothesis on the supports.
-
 ## Main declarations
 
 * `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`: no constant `C` satisfies
   `‖u‖_p ≤ C ‖Du‖_p` for all compactly supported `C¹` functions on a finite-dimensional real
   normed space with an additive Haar measure.
-* `TauCeti.exists_eLpNorm_le_const_mul_eLpNorm_fderiv_of_isBounded`: for `1 ≤ p < n` such a
-  constant does exist once all the functions are supported in one fixed bounded set (a
-  restatement of Mathlib's `MeasureTheory.eLpNorm_le_eLpNorm_fderiv` in that shape).
 * `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv_euclideanSpace`: the roadmap's
   `ℝⁿ` form, for Lebesgue measure on `EuclideanSpace ℝ (Fin n)`.
 -/
@@ -49,7 +42,7 @@ public section
 
 namespace TauCeti
 
-open Bornology Filter MeasureTheory Module Topology
+open Filter MeasureTheory Module Topology
 open scoped ENNReal NNReal
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
@@ -70,7 +63,6 @@ theorem not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv {p : ℝ≥0∞} (hp₀ :
   have hφ2 : ContDiff ℝ 2 (φ : E → ℝ) := φ.contDiff
   have hφ1 : ContDiff ℝ 1 (φ : E → ℝ) := φ.contDiff
   have hφcs : HasCompactSupport (φ : E → ℝ) := φ.hasCompactSupport
-  have hφdiff : Differentiable ℝ (φ : E → ℝ) := hφ1.differentiable (by norm_num)
   set A := eLpNorm (φ : E → ℝ) p μ
   set D := eLpNorm (fderiv ℝ (φ : E → ℝ)) p μ
   -- The bump has positive seminorm: it is continuous and equal to `1` at the origin.
@@ -93,7 +85,7 @@ theorem not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv {p : ℝ≥0∞} (hp₀ :
     have h1 := hC (fun x => φ (r⁻¹ • x))
       (hφ1.comp (ContDiff.const_smul r⁻¹ (contDiff_id (𝕜 := ℝ) (E := E))))
       (hφcs.comp_homeomorph (Homeomorph.smul (Units.mk0 r⁻¹ (inv_ne_zero hr.ne'))))
-    rw [eLpNorm_comp_inv_smul μ _ hr hp₀ hp, eLpNorm_fderiv_comp_inv_smul μ hφdiff hr hp₀ hp] at h1
+    rw [eLpNorm_comp_inv_smul μ _ hr hp₀ hp, eLpNorm_fderiv_comp_inv_smul μ _ hr hp₀ hp] at h1
     set s := ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal)) with hs_def
     have hs0 : s ≠ 0 := by
       rw [hs_def, Ne, ENNReal.ofReal_eq_zero, not_le]
@@ -115,18 +107,6 @@ theorem not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv {p : ℝ≥0∞} (hp₀ :
     filter_upwards [eventually_gt_atTop (0 : ℝ)] with r hr using key r hr
   rw [zero_mul, le_zero_iff] at hle
   exact hA hle
-
-/-- **A Poincaré inequality does hold on a fixed bounded set.** For `1 ≤ p < n` there is a
-constant `C` with `‖u‖_p ≤ C ‖Du‖_p` for every `C¹` function `u` supported in a fixed bounded
-set `s`. This is `MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, stated in the same
-constant-then-function order as `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv` so that
-the two can be compared directly. -/
-theorem exists_eLpNorm_le_const_mul_eLpNorm_fderiv_of_isBounded {s : Set E} (hs : IsBounded s)
-    {p : ℝ≥0} (hp : 1 ≤ p) (hpn : p < finrank ℝ E) :
-    ∃ C : ℝ≥0, ∀ u : E → ℝ, ContDiff ℝ 1 u → Function.support u ⊆ s →
-      eLpNorm u p μ ≤ C * eLpNorm (fderiv ℝ u) p μ :=
-  ⟨eLpNormLESNormFDerivOfLeConst ℝ μ s p p,
-    fun _ hu hsupp => eLpNorm_le_eLpNorm_fderiv μ hu hsupp hp hpn hs⟩
 
 /-- The Poincaré inequality fails on `ℝⁿ` with Lebesgue measure: the roadmap's form of
 `TauCeti.not_exists_eLpNorm_le_const_mul_eLpNorm_fderiv`. -/

--- a/TauCeti/Analysis/Sobolev/Poincare.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare.lean
@@ -4,10 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+-- The two dilation laws and `Mathlib.Analysis.Calculus.ContDiff.Defs` are imported publicly:
+-- between them they supply every notion appearing in the statements below (`eLpNorm`, `fderiv`,
+-- the Haar measure and `EuclideanSpace` API, and `ContDiff`).
 public import TauCeti.Analysis.Sobolev.Dilation
-public import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
-public import Mathlib.MeasureTheory.Function.LpSpace.Indicator
-public import Mathlib.MeasureTheory.Measure.OpenPos
+public import Mathlib.Analysis.Calculus.ContDiff.Defs
+-- The remaining three imports are private: the bump function, the compact-support `MemLp`
+-- criterion and the open-positivity of Haar measure are used only to build the counterexample,
+-- so downstream importers do not pay for them.
+import Mathlib.Analysis.Calculus.BumpFunction.FiniteDimension
+import Mathlib.MeasureTheory.Function.LpSpace.Indicator
+import Mathlib.MeasureTheory.Measure.OpenPos
 
 /-!
 # The Poincaré inequality fails on the whole space

--- a/TauCeti/MeasureTheory/Function/Lp/Dilation.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/Dilation.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+-- `TauCeti.MeasureTheory.Integral.Dilation` is imported publicly: `TauCeti.lintegral_comp_inv_smul`
+-- is the `∫⁻` form of the statement below, so the two belong together for a reader of either.
+public import TauCeti.MeasureTheory.Integral.Dilation
+
+/-!
+# Dilation scaling of the `Lᵖ` seminorm
+
+Dilating the variable of a function on a finite-dimensional real normed space `E` by `r⁻¹`, for
+`r > 0`, multiplies its `Lᵖ` seminorm against an additive Haar measure by `r ^ (n / p)`, where
+`n` is the dimension of `E` and `0 < p < ∞`. This is the `eLpNorm` form of the lower Lebesgue
+integral law `TauCeti.lintegral_comp_inv_smul`, obtained by applying the latter to
+`y ↦ ‖f y‖ₑ ^ p` and taking a `p`-th root.
+
+## Main declarations
+
+* `TauCeti.eLpNorm_comp_inv_smul`: `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Module
+open scoped ENNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E] (μ : Measure E) [μ.IsAddHaarMeasure]
+  {G : Type*} [NormedAddCommGroup G]
+
+/-- **Dilation scaling of the `Lᵖ` seminorm:** `‖u (r⁻¹ • ·)‖_p = r ^ (n / p) * ‖u‖_p`, where
+`n` is the dimension of the ambient space. -/
+theorem eLpNorm_comp_inv_smul (f : E → G) {r : ℝ} (hr : 0 < r) {p : ℝ≥0∞} (hp₀ : p ≠ 0)
+    (hp : p ≠ ∞) :
+    eLpNorm (fun x => f (r⁻¹ • x)) p μ =
+      ENNReal.ofReal (r ^ ((finrank ℝ E : ℝ) / p.toReal)) * eLpNorm f p μ := by
+  have ht : 0 < p.toReal := ENNReal.toReal_pos hp₀ hp
+  have key := lintegral_comp_inv_smul μ (fun y => ‖f y‖ₑ ^ p.toReal) hr
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp, eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp,
+    key, ENNReal.mul_rpow_of_nonneg _ _ (by positivity)]
+  have hpow : ((r ^ finrank ℝ E : ℝ)) ^ (1 / p.toReal) = r ^ ((finrank ℝ E : ℝ) / p.toReal) := by
+    rw [← Real.rpow_natCast r (finrank ℝ E), ← Real.rpow_mul hr.le]
+    ring_nf
+  congr 1
+  rw [← hpow]
+  exact ENNReal.ofReal_rpow_of_pos (by positivity : (0 : ℝ) < r ^ finrank ℝ E)
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Dilation.lean
+++ b/TauCeti/MeasureTheory/Integral/Dilation.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Haar.NormedSpace
+
+/-!
+# Dilation scaling of the lower Lebesgue integral
+
+Dilating the variable of a function on a finite-dimensional real normed space `E` by a nonzero
+scalar `r` rescales its integral against an additive Haar measure by `|(r ^ n)⁻¹|`, where `n` is
+the dimension of `E`. Mathlib records this for the Bochner integral as
+`MeasureTheory.Measure.integral_comp_smul`; this file is the lower-Lebesgue-integral counterpart,
+proved the same way from `MeasureTheory.Measure.map_addHaar_smul`, and, like the Bochner version,
+needing no integrability hypothesis.
+
+## Main declarations
+
+* `TauCeti.lintegral_comp_smul`: `∫⁻ x, g (r • x) ∂μ = |(r ^ n)⁻¹| * ∫⁻ x, g x ∂μ`.
+* `TauCeti.lintegral_comp_inv_smul`: the same law written for `r⁻¹` and `0 < r`.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Module
+open scoped ENNReal
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [MeasurableSpace E] [BorelSpace E]
+  [FiniteDimensional ℝ E] (μ : Measure E) [μ.IsAddHaarMeasure]
+
+/-- **Dilation scaling of the lower Lebesgue integral.** This is the counterpart, for `∫⁻`, of
+Mathlib's `MeasureTheory.Measure.integral_comp_smul`; as there, no integrability of `g` is
+needed. -/
+theorem lintegral_comp_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : r ≠ 0) :
+    ∫⁻ x, g (r • x) ∂μ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
+  calc ∫⁻ x, g (r • x) ∂μ = ∫⁻ y, g y ∂Measure.map (fun x => r • x) μ :=
+        (lintegral_map_equiv g
+          (Homeomorph.smul (isUnit_iff_ne_zero.2 hr).unit).toMeasurableEquiv).symm
+    _ = ENNReal.ofReal |(r ^ finrank ℝ E)⁻¹| * ∫⁻ x, g x ∂μ := by
+        rw [Measure.map_addHaar_smul μ hr, lintegral_smul_measure, smul_eq_mul]
+
+/-- Dilating the variable by `r⁻¹`, for `0 < r`, multiplies a lower Lebesgue integral by
+`r ^ n`, where `n` is the dimension of the ambient space. -/
+theorem lintegral_comp_inv_smul (g : E → ℝ≥0∞) {r : ℝ} (hr : 0 < r) :
+    ∫⁻ x, g (r⁻¹ • x) ∂μ = ENNReal.ofReal (r ^ finrank ℝ E) * ∫⁻ x, g x ∂μ := by
+  rw [lintegral_comp_smul μ g (inv_ne_zero hr.ne'), inv_pow, inv_inv,
+    abs_of_nonneg (by positivity)]
+
+end TauCeti


### PR DESCRIPTION
This PR proves that no Poincaré inequality holds on the whole of a finite-dimensional real normed space: there is no constant `C` with `‖u‖_p ≤ C ‖Du‖_p` for every compactly supported `C¹` function `u`, for any `0 < p < ∞`. Mathlib's `MeasureTheory.eLpNorm_le_eLpNorm_fderiv` supplies such a constant once all the functions are supported in one fixed bounded set, and this is the companion fact that pins the role of that hypothesis. The obstruction is scaling, so the PR also adds the two dilation laws that carry it: dilating the variable by `r > 0` multiplies `‖u‖_p` by `r ^ (n / p)` and `‖Du‖_p` by `r ^ (n / p - 1)`, the extra `r⁻¹` coming from the chain rule (Mathlib's `fderiv_comp_smul`). Applying a putative inequality to the dilates of one fixed bump function and cancelling the common factor forces `‖u‖_p ≤ C r⁻¹ ‖Du‖_p` for every `r`, and letting `r → ∞` makes the bump's own seminorm vanish.

The positive direction stays in Mathlib: `MeasureTheory.eLpNorm_le_eLpNorm_fderiv`, with the explicit constant `MeasureTheory.eLpNormLESNormFDerivOfLeConst ℝ μ s p p`, is cited from the module docstring so that the difference between the two directions — the hypothesis on the supports — is visible without restating it here. The `ℝⁿ` form of the failure, with Lebesgue measure, is recorded as well. The failure needs only `p ≠ 0` and `p ≠ ∞`: it is not confined to the subcritical range `p < n` in which the positive result lives.

This advances `TauCetiRoadmap/PDE/README.md`, Lane A.5 ("Poincaré on `W^{1,p}_0(Ω)` (bounded `Ω`)") together with the acceptance criterion "**Poincaré is non-vacuous:** ... the inequality genuinely *fails* on `ℝⁿ`. Formalize both directions so the hypothesis is known to be load-bearing."

New modules:

* `TauCeti/MeasureTheory/Integral/Dilation.lean` — the lower-Lebesgue-integral scaling law under a dilation (the `∫⁻` counterpart of Mathlib's `MeasureTheory.Measure.integral_comp_smul`).
* `TauCeti/MeasureTheory/Function/Lp/Dilation.lean` — the resulting `eLpNorm` scaling law.
* `TauCeti/Analysis/Sobolev/Dilation.lean` — the `eLpNorm` scaling law for the derivative, where the chain rule contributes the extra factor `r⁻¹`.
* `TauCeti/Analysis/Sobolev/Poincare.lean` — the non-existence theorem and its `EuclideanSpace ℝ (Fin n)` specialization.

No Mathlib source was vendored.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"not-exists-poincare-constant"}-->

🤖 Prepared with Claude Code

