### PR TITLE
style(Probability): put the copyright header before `module`

### DIFF
--- a/TauCeti/Probability/Distributions/Gaussian/Basic.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Basic.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import Mathlib.Probability.Distributions.Gaussian.Real
 
 /-!

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Basic
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Orthogonality

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/PiBasis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/PiBasis.lean
@@ -1,10 +1,10 @@
-module
-
 /-
 Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Claude
 -/
+module
+
 public import TauCeti.Analysis.InnerProductSpace.L2.Pi
 public import TauCeti.Probability.Distributions.Gaussian.Hermite.Basis
 


### PR DESCRIPTION
Three files under `TauCeti/Probability/Distributions/Gaussian/` open with the
`module` keyword and place the copyright block after it:

```lean
module

/-
Copyright (c) 2026 The Tau Ceti contributors. ...
-/
public import ...
```

Every other file in the library puts the copyright first — **1096 files vs
these 3** — and that is also the order `lake exe module-system` describes in
its own guidance: *"Add `module` as the first line of each (after the
copyright header)"*.

The concrete cost of the outlier form: any header check that reads the first
few lines of a file reports these three as having **no copyright header at
all**. That is how I found them.

The diff is a pure block move — verified by comparing the sorted non-blank
lines of each file before and after, which are identical. No content, no
declaration, and no import is changed.

Gates run locally: `lake build`, `lake exe axioms` (20181 decls in allowlist),
`lake exe module-system` (1100 modules), `scripts/lint-env.sh` PASS.

Roadmap: none