### PR TITLE
docs: drop Main-results bullets naming another file's declaration

### DIFF
--- a/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
+++ b/TauCeti/Analysis/Contour/Winding/RealIntegral.lean
@@ -28,7 +28,6 @@ real formula — the computational workhorse of Layer 1; the on-curve bounded-in
 
 ## Main results
 
-* `TauCeti.Contour.realWindingIntegrand` — the real coordinate winding integrand.
 * `TauCeti.Contour.windingNumber_eq_real_integral_of_closed` — the winding number of a closed curve
   off `w` equals the real bounded integral `(1 / 2π) ∫ (x ẏ − y ẋ) / (x² + y²)`.
 

--- a/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
+++ b/TauCeti/KnotTheory/Grid/SmallGrid/Differential.lean
@@ -23,8 +23,6 @@ count defining the fully blocked grid complex.
 
 ## Main results
 
-* `TauCeti.Grid.cIoo_eq_empty_of_le_two`: open cyclic intervals in grids of size at most two
-  are empty.
 * `TauCeti.GridDiagram.fullyBlockedRectangleCount_eq_zero_of_le_two`: every fully blocked
   rectangle coefficient vanishes in grid size at most two.
 * `TauCeti.GridDiagram.fullyBlockedDifferential_eq_zero_of_le_two`: the fully blocked


### PR DESCRIPTION
Two module docstrings advertise, under `## Main results`, a declaration that
is defined in a *prerequisite* file:

| file | bullet removed | actually declared in |
|---|---|---|
| `Analysis/Contour/Winding/RealIntegral.lean` | `TauCeti.Contour.realWindingIntegrand` | `Winding/Integrand.lean:30` |
| `KnotTheory/Grid/SmallGrid/Differential.lean` | `TauCeti.Grid.cIoo_eq_empty_of_le_two` | `Grid/CyclicInterval.lean:272` |

In both cases the name occurs **only** in that bullet — nowhere else in the
file, not even in a proof — so the section was pointing a reader at the wrong
module. `RealIntegral.lean` proves exactly one theorem
(`windingNumber_eq_real_integral_of_closed`), which the section still names;
`Differential.lean` keeps its three `GridDiagram.*` results.

Scope note: I checked the whole library for this pattern. Most apparent hits
are **not** defects and are deliberately excluded here —

* umbrella modules with no declarations of their own (e.g.
  `Symplectic/JHolomorphic/MapOps.lean`), which legitimately document what
  they aggregate;
* files that genuinely *consume* the cited lemma (e.g.
  `Grid/Differential/Support/Basic.lean` applies its cited theorem);
* declarations introduced with `irreducible_def`, which a naive declaration
  scan misses (e.g. `PlumbingCube.characteristicWeight`, which **is** defined
  in the file that lists it).

Only the two above survive the check "named in the inventory, defined
elsewhere, and referenced nowhere else in the file".

Documentation-only; no Lean code changes. Gates run locally: `lake build`,
`lake exe axioms` (20179 decls in allowlist), `lake exe module-system` (1100
modules), `scripts/lint-env.sh` PASS.

Roadmap: none