### PR TITLE
feat(Multiquadratic): narrow = ordinary class group for a totally complex field

### DIFF
--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup.lean
@@ -5,12 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.Finite
+public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.TotallyComplex
 
 /-!
 # The narrow class group (compatibility module)
 
 This module preserves the import path `TauCeti.NumberTheory.NumberField.NarrowClassGroup` after the
 development was split into `NarrowClassGroup/Basic.lean` (the definition, `mk`/`lift`/`toClassGroup`
-API and the exact sequence `Kˣ → Cl⁺ → Cl → 1`) and `NarrowClassGroup/Finite.lean` (finiteness).
-Since `Finite` imports `Basic`, `public import`ing `Finite` transitively re-exports both.
+API and the exact sequence `Kˣ → Cl⁺ → Cl → 1`), `NarrowClassGroup/Finite.lean` (finiteness), and
+`NarrowClassGroup/TotallyComplex.lean` (`Cl⁺ ≃ Cl` for totally complex fields). Both `Finite` and
+`TotallyComplex` import `Basic`, so these two `public import`s re-export the whole development.
 -/

--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/TotallyComplex.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/TotallyComplex.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.Basic
+
+/-!
+# The narrow class group of a totally complex field
+
+For a **totally complex** number field `K` (no real infinite places) the positivity condition is
+vacuous: every unit is totally positive (`totallyPositiveUnits_eq_top`), so the forgetful surjection
+`Cl⁺(K) → Cl(K)` is also injective. Hence the narrow and ordinary class groups **coincide** — as the
+multiquadratic roadmap notes, for imaginary fields narrow = ordinary. (The `t - 1` genus-theory rank
+formula concerns the *real* case, where the two can differ.)
+
+## Main results
+
+* `TauCeti.NumberField.NarrowClassGroup.toClassGroup_injective`: for a totally complex field the
+  forgetful map `Cl⁺(K) → Cl(K)` is injective.
+* `TauCeti.NumberField.NarrowClassGroup.toClassGroupEquiv`: the isomorphism `Cl⁺(K) ≃* Cl(K)`.
+-/
+
+public section
+
+open NumberField
+open scoped nonZeroDivisors
+
+namespace TauCeti.NumberField.NarrowClassGroup
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- For a totally complex field the forgetful map `Cl⁺(K) → Cl(K)` is injective: by exactness its
+kernel is `mkPrincipal.range`, and every principal class is already trivial because principal ideals
+have a (vacuously totally positive) generator. -/
+theorem toClassGroup_injective [IsTotallyComplex K] :
+    Function.Injective (toClassGroup (K := K)) := by
+  rw [← MonoidHom.ker_eq_bot_iff, toClassGroup_ker, Subgroup.eq_bot_iff_forall]
+  rintro _ ⟨x, rfl⟩
+  rw [mkPrincipal_apply, mk_eq_one_iff, mem_narrowPrincipalSubgroup]
+  exact ⟨x, by simp, rfl⟩
+
+/-- For a **totally complex** number field the narrow and ordinary class groups coincide:
+`Cl⁺(K) ≃* Cl(K)`, forgetting positivity. -/
+noncomputable def toClassGroupEquiv [IsTotallyComplex K] :
+    NarrowClassGroup K ≃* ClassGroup (𝓞 K) :=
+  MulEquiv.ofBijective (toClassGroup (K := K)) ⟨toClassGroup_injective, toClassGroup_surjective⟩
+
+@[simp] theorem toClassGroupEquiv_apply [IsTotallyComplex K] (z : NarrowClassGroup K) :
+    toClassGroupEquiv z = toClassGroup z := by
+  simp only [toClassGroupEquiv]
+  exact MulEquiv.ofBijective_apply (toClassGroup (K := K)) _ z
+
+end TauCeti.NumberField.NarrowClassGroup

--- a/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
+++ b/TauCeti/NumberTheory/NumberField/TotallyPositive.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Algebra.Order.Ring.Units
 public import TauCeti.GroupTheory.Index
 public import Mathlib.NumberTheory.NumberField.InfinitePlace.Basic
+public import Mathlib.NumberTheory.NumberField.InfinitePlace.TotallyRealComplex
 
 /-!
 # Totally positive elements of a number field
@@ -37,7 +38,9 @@ the narrow class group finite (see `NarrowClassGroup.Finite`).
   `isTotallyPositive_sq`: the multiplicative structure, including that nonzero squares are totally
   positive.
 * `TauCeti.NumberField.totallyPositiveUnits`: the subgroup of totally positive units of `Kˣ` (the
-  kernel of the unit signature map), with `sq_mem_totallyPositiveUnits`.
+  kernel of the unit signature map), with `sq_mem_totallyPositiveUnits`. For a totally complex field
+  it is everything (`totallyPositiveUnits_eq_top`), since total positivity is then vacuous
+  (`not_isReal_of_isTotallyComplex` makes `IsTotallyPositive` `simp` to `True`).
 * `TauCeti.NumberField.totallyPositiveIntegerUnits`: the corresponding subgroup of the arithmetic
   units `(𝓞 K)ˣ`, the preimage of `totallyPositiveUnits` under `(𝓞 K)ˣ → Kˣ`, with
   `mem_totallyPositiveIntegerUnits` and `sq_mem_totallyPositiveIntegerUnits`.
@@ -108,6 +111,19 @@ theorem sq_mem_totallyPositiveUnits (u : Kˣ) : u ^ 2 ∈ totallyPositiveUnits :
   rw [mem_totallyPositiveUnits, Units.val_pow_eq_pow_val]
   exact isTotallyPositive_sq (Units.ne_zero u)
 
+/-- A **totally complex** field has no real infinite places. As a `simp` lemma this discharges the
+vacuous real-place hypotheses in totally-positive statements: `IsTotallyPositive x` then reduces to
+`True` (via `isTotallyPositive_iff`), so total positivity is automatic for every element. -/
+@[simp] theorem not_isReal_of_isTotallyComplex [IsTotallyComplex K] (w : InfinitePlace K) :
+    ¬ w.IsReal :=
+  not_isReal_iff_isComplex.mpr (IsTotallyComplex.isComplex w)
+
+/-- For a totally complex field every unit is (vacuously) totally positive:
+`totallyPositiveUnits = ⊤`. -/
+@[simp] theorem totallyPositiveUnits_eq_top [IsTotallyComplex K] :
+    totallyPositiveUnits (K := K) = ⊤ := by
+  ext u; simp
+
 variable [NumberField K]
 
 /-- The subgroup of **totally positive integer units** of `(𝓞 K)ˣ`: the preimage of
@@ -131,6 +147,13 @@ theorem sq_mem_totallyPositiveIntegerUnits (u : (𝓞 K)ˣ) :
     u ^ 2 ∈ totallyPositiveIntegerUnits := by
   rw [totallyPositiveIntegerUnits, Subgroup.mem_comap, map_pow]
   exact sq_mem_totallyPositiveUnits _
+
+omit [NumberField K] in
+/-- For a totally complex field every integer unit is (vacuously) totally positive:
+`totallyPositiveIntegerUnits = ⊤`. -/
+@[simp] theorem totallyPositiveIntegerUnits_eq_top [IsTotallyComplex K] :
+    totallyPositiveIntegerUnits (K := K) = ⊤ := by
+  ext u; simp
 
 /-- `totallyPositiveUnits` has **finite index** in `Kˣ`: it is a finite intersection, over the real
 infinite places, of the finite-index preimages of the positive units of `ℝ` (via the general


### PR DESCRIPTION
For a **totally complex** number field `K` there are no real infinite places, so the total
positivity condition is **vacuous**: every element — hence every unit — is totally positive. Two
consequences, building on the merged narrow-class-group foundation (#1764, #1766, #1773):

- `totallyPositiveUnits = ⊤` (`totallyPositiveUnits_eq_top`), via the elementwise
  `isTotallyPositive_of_isTotallyComplex`;
- the forgetful surjection `NarrowClassGroup.toClassGroup : Cl⁺(K) → Cl(K)` is therefore also
  **injective** (`toClassGroup_injective`): a principal ideal always has a vacuously-totally-positive
  generator, so its narrow class is already trivial.

Packaged as the isomorphism `NarrowClassGroup.toClassGroupEquiv : Cl⁺(K) ≃* Cl(K)` — the narrow and
ordinary class groups **coincide** for imaginary fields, as the multiquadratic roadmap notes. (The
`t - 1` genus-theory `2`-rank formula is a statement about the *real* case, where `Cl⁺` and `Cl`
genuinely differ; this pins down the complementary case.)

New file `NarrowClassGroup/TotallyComplex.lean`. Sorry-free, default axioms.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"Multiquadratic/narrow-class-group-totally-complex"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)