### PR TITLE
refactor(Semigroups): use Mathlib's inter_eq_right for the right half-line

### DIFF
--- a/TauCeti/Analysis/Semigroups/Basic.lean
+++ b/TauCeti/Analysis/Semigroups/Basic.lean
@@ -434,12 +434,9 @@ theorem StronglyContinuousSemigroup.realOperator_continuousWithinAt
   have h_Ici_split : Set.Ici (0 : ℝ) =
       (Set.Ici 0 ∩ Set.Iic t₀) ∪ (Set.Ici 0 ∩ Set.Ici t₀) := by
     rw [← Set.inter_union_distrib_left, Set.Iic_union_Ici, Set.inter_univ]
-  rw [ContinuousWithinAt]
-  rw [h_Ici_split]
-  rw [nhdsWithin_union, Filter.tendsto_sup]
-  have h_right_set : Set.Ici (0 : ℝ) ∩ Set.Ici t₀ = Set.Ici t₀ := by
-    ext y; simp only [Set.mem_inter_iff, Set.mem_Ici]
-    exact ⟨fun ⟨_, h⟩ => h, fun h => ⟨le_trans ht₀ h, h⟩⟩
+  rw [ContinuousWithinAt, h_Ici_split, nhdsWithin_union, Filter.tendsto_sup]
+  have h_right_set : Set.Ici (0 : ℝ) ∩ Set.Ici t₀ = Set.Ici t₀ :=
+    Set.inter_eq_right.mpr (Set.Ici_subset_Ici.mpr ht₀)
   have h_left_set : Set.Ici (0 : ℝ) ∩ Set.Iic t₀ = Set.Icc 0 t₀ :=
     Set.Ici_inter_Iic
   rw [h_left_set, h_right_set]


### PR DESCRIPTION
In `StronglyContinuousSemigroup.realOperator_continuousWithinAt`, the two
halves of the split were proved inconsistently:

```lean
have h_right_set : Set.Ici (0 : ℝ) ∩ Set.Ici t₀ = Set.Ici t₀ := by
  ext y; simp only [Set.mem_inter_iff, Set.mem_Ici]
  exact ⟨fun ⟨_, h⟩ => h, fun h => ⟨le_trans ht₀ h, h⟩⟩
have h_left_set : Set.Ici (0 : ℝ) ∩ Set.Iic t₀ = Set.Icc 0 t₀ :=
  Set.Ici_inter_Iic
```

The left half already delegates to Mathlib; the right half hand-rolls the
same kind of fact. It is `inter_eq_right` applied to `Ici_subset_Ici` —
the exact idiom Mathlib uses at `Order/Interval/Set/Image.lean:311`
(`inter_eq_right.2 <| Ici_subset_Ici.2 b.2`):

```lean
have h_right_set : Set.Ici (0 : ℝ) ∩ Set.Ici t₀ = Set.Ici t₀ :=
  Set.inter_eq_right.mpr (Set.Ici_subset_Ici.mpr ht₀)
```

Also merges the three consecutive single-lemma `rw`s
(`ContinuousWithinAt`, `h_Ici_split`, then `nhdsWithin_union,
Filter.tendsto_sup`) into one `rw`.

Net −3 lines, no signature change, no new declarations.

Gates run locally: `lake build`, `lake exe axioms` (20234 decls in
allowlist), `lake exe module-system` (1108 modules), `scripts/lint-env.sh`
PASS.

Roadmap: none