### PR TITLE
feat: identify point derivations with tangent vectors

### DIFF
--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -7,8 +7,10 @@ module
 import Mathlib.Analysis.LocallyConvex.SeparatingDual
 public import Mathlib.Geometry.Manifold.DerivationBundle
 import Mathlib.Geometry.Manifold.BumpFunction
+public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
 import Mathlib.Geometry.Manifold.MFDeriv.FDeriv
 public import Mathlib.Geometry.Manifold.MFDeriv.NormedSpace
+import TauCeti.Analysis.Calculus.Hadamard
 
 /-!
 # Tangent vectors as point derivations
@@ -21,6 +23,9 @@ a canonical linear map from the ordinary tangent space to the algebraic point de
 * `tangentToPointDerivation`: the point derivation associated to a tangent vector.
 * `tangentToPointDerivation_injective`: distinct tangent vectors induce distinct point derivations
   on finite-dimensional Hausdorff real manifolds.
+* `tangentToPointDerivation_surjective`: every point derivation on a finite-dimensional Hausdorff
+  boundaryless real manifold comes from a tangent vector.
+* `pointDerivationEquivTangentSpace`: the resulting canonical linear equivalence.
 * `PointDerivation.congr_of_eventuallyEq`: on a finite-dimensional Hausdorff real manifold, a point
   derivation depends only on the germ of a smooth function at its basepoint.
 * `tangentToPointDerivation_mfderiv`: this association commutes with differentials.
@@ -139,6 +144,89 @@ theorem tangentToPointDerivation_injective
   rw [← hderiv v, ← hderiv w]
   exact hfv
 
+private theorem tangentToPointDerivation_surjective_model
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E] (x : E) :
+    Function.Surjective
+      (tangentToPointDerivation (I := modelWithCornersSelf ℝ E) x) := by
+  intro D
+  let b := Module.finBasis ℝ E
+  let c (i : Fin (Module.finrank ℝ E)) : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
+    ⟨b.coord i, (b.coord i).toContinuousLinearMap.contDiff.contMDiff⟩
+  let pointed (q : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) :
+      C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯⟨x⟩ := ⟨q, q.contMDiff⟩
+  let δ (q : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) : ℝ := D (pointed q)
+  let v : TangentSpace (modelWithCornersSelf ℝ E) x := ∑ i, δ (c i) • b i
+  refine ⟨v, ?_⟩
+  ext f
+  let f' : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ := ⟨f, f.contMDiff⟩
+  change mvfderiv (modelWithCornersSelf ℝ E) f' x v = δ f'
+  rw [mvfderiv, mfderiv_eq_fderiv]
+  let a (i : Fin (Module.finrank ℝ E)) : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
+    ⟨fun y ↦ hadamardFactor f' x y (b i), by
+      have hfac : ContDiff ℝ ∞ (hadamardFactor f' x) :=
+        f'.contMDiff.contDiff.contDiff_hadamardFactor f' x
+      exact (hfac.clm_apply (show ContDiff ℝ ∞ (fun _ : E ↦ b i) from
+        contDiff_const)).contMDiff⟩
+  let k : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
+    ⟨fun _ ↦ f' x, contDiff_const.contMDiff⟩
+  let kcoord (i : Fin (Module.finrank ℝ E)) :
+      C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
+    ⟨fun _ ↦ c i x, contDiff_const.contMDiff⟩
+  have hfactor : f' - k = ∑ i, a i * (c i - kcoord i) := by
+    ext y
+    calc
+      (f' - k) y = f' y - f' x := rfl
+      _ = hadamardFactor f' x y (y - x) :=
+        (f'.contMDiff.contDiff.of_le (by norm_num)).sub_eq_hadamardFactor_apply f' x y
+      _ = ∑ i, hadamardFactor f' x y (b i) * (b.coord i y - b.coord i x) := by
+        rw [← b.sum_repr (y - x), map_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        rw [map_smul]
+        simp [b, mul_comm]
+      _ = (∑ i, a i * (c i - kcoord i)) y := by
+        change _ = ContMDiffMap.evalRingHom y (∑ i, a i * (c i - kcoord i))
+        rw [map_sum]
+        apply Finset.sum_congr rfl
+        intro i _
+        rfl
+  have hδconst (r : ℝ) :
+      δ (⟨fun _ : E ↦ r, contDiff_const.contMDiff⟩ :
+        C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) = 0 := by
+    change D (algebraMap ℝ C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯⟨x⟩ r) = 0
+    exact D.map_algebraMap r
+  have hδsub (p q : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) :
+      δ (p - q) = δ p - δ q := by
+    change D (pointed (p - q)) = D (pointed p) - D (pointed q)
+    change D (pointed p - pointed q) = D (pointed p) - D (pointed q)
+    exact D.map_sub _ _
+  have hterm (i : Fin (Module.finrank ℝ E)) :
+      δ (a i * (c i - kcoord i)) = fderiv ℝ f' x (b i) * δ (c i) := by
+    have hleibniz := D.leibniz (pointed (a i)) (pointed (c i - kcoord i))
+    change δ (a i * (c i - kcoord i)) =
+      a i x * δ (c i - kcoord i) + (c i x - kcoord i x) * δ (a i) at hleibniz
+    rw [hleibniz, hδsub, hδconst]
+    simp [a, kcoord]
+  have hδsum (q : Fin (Module.finrank ℝ E) →
+      C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) :
+      δ (∑ i, q i) = ∑ i, δ (q i) := by
+    change D (pointed (∑ i, q i)) = ∑ i, D (pointed (q i))
+    change D (∑ i, pointed (q i)) = ∑ i, D (pointed (q i))
+    exact map_sum D _ _
+  calc
+    fderiv ℝ f' x v = ∑ i, fderiv ℝ f' x (b i) * δ (c i) := by
+      change fderiv ℝ f' x (∑ i, δ (c i) • b i) = _
+      rw [map_sum]
+      apply Finset.sum_congr rfl
+      intro i _
+      rw [map_smul]
+      simp [smul_eq_mul, mul_comm]
+    _ = δ (∑ i, a i * (c i - kcoord i)) := by
+      rw [hδsum]
+      exact Finset.sum_congr rfl fun i _ ↦ (hterm i).symm
+    _ = δ (f' - k) := congrArg δ hfactor.symm
+    _ = δ f' := by rw [hδsub, hδconst, sub_zero]
+
 namespace PointDerivation
 
 /-- A point derivation on a finite-dimensional Hausdorff real manifold depends only on the germ of
@@ -198,3 +286,119 @@ theorem tangentToPointDerivation_mfderiv (f : C^∞⟮I, M; I', M'⟯) (x : M)
   exact (mfderiv_comp_apply x
     (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
     (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt v).symm
+
+/-- Every point derivation on a finite-dimensional Hausdorff boundaryless real manifold is
+directional differentiation along a tangent vector. -/
+theorem tangentToPointDerivation_surjective
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [T2Space M] [BoundarylessManifold I M] (x : M) :
+    Function.Surjective (tangentToPointDerivation (I := I) x) := by
+  intro D
+  let b : SmoothBumpFunction I x := Classical.choice inferInstance
+  let F : C^∞⟮I, M; modelWithCornersSelf ℝ E, E⟯ :=
+    ⟨fun y ↦ b y • extChartAt I x y,
+      b.contMDiff_smul contMDiffOn_extChartAt⟩
+  have hF : Filter.EventuallyEq (nhds x) (F : M → E) (extChartAt I x) := by
+    filter_upwards [b.eventuallyEq_one] with y hy
+    simp [F, hy]
+  have hFx : F x = extChartAt I x x := hF.eq_of_nhds
+  obtain ⟨w, hw⟩ := tangentToPointDerivation_surjective_model (F x) (fdifferential F x D)
+  let v : TangentSpace I x := w
+  have hv : mfderiv I (modelWithCornersSelf ℝ E) F x v = w := by
+    rw [hF.mfderiv_eq, mfderiv_extChartAt_self]
+    rfl
+  refine ⟨v, ?_⟩
+  ext f
+  have htarget_at (y : E) (hy : y ∈ (extChartAt I x).target) :
+      (extChartAt I x).target ∈ nhds y := by
+    let m := (extChartAt I x).symm y
+    have hm : m ∈ (extChartAt I x).source := (extChartAt I x).map_target hy
+    have hmInterior : I.IsInteriorPoint m := BoundarylessManifold.isInteriorPoint
+    have hi : extChartAt I x m ∈ interior (extChartAt I x).target := by
+      have hi' := (ModelWithCorners.isInteriorPoint_iff_of_mem_atlas (n := ∞) (by simp)
+        (chart_mem_atlas H x) (by simpa [extChartAt_source] using hm)).1 hmInterior
+      simpa [extChartAt] using hi'
+    have hey : extChartAt I x m = y := (extChartAt I x).right_inv hy
+    rw [hey] at hi
+    exact Filter.mem_of_superset (isOpen_interior.mem_nhds hi) interior_subset
+  have htarget : (extChartAt I x).target ∈ nhds (F x) := by
+    rw [hFx]
+    exact htarget_at _ (mem_extChartAt_target x)
+  obtain ⟨β, hβ, -⟩ :=
+    (SmoothBumpFunction.nhds_basis_support
+      (I := modelWithCornersSelf ℝ E) htarget).mem_iff.mp htarget
+  let g : E → ℝ := fun y ↦ β y * f ((extChartAt I x).symm y)
+  have hg : ContDiff ℝ ∞ g := by
+    apply ContMDiff.contDiff
+    refine contMDiff_of_tsupport fun y hy ↦ ?_
+    have hytarget : y ∈ (extChartAt I x).target :=
+      hβ (tsupport_mul_subset_left hy)
+    have hsymmWithin := contMDiffWithinAt_extChartAt_symm_target (n := ∞) x hytarget
+    have hsymm := hsymmWithin.contMDiffAt (htarget_at y hytarget)
+    exact β.contMDiffAt.mul (f.contMDiff.contMDiffAt.comp y hsymm)
+  let g' : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ := ⟨g, hg.contMDiff⟩
+  have hβF : Filter.EventuallyEq (nhds x) (β ∘ F) (fun _ ↦ 1) :=
+    β.eventuallyEq_one.comp_tendsto F.contMDiff.continuous.continuousAt
+  have hsource : ∀ᶠ y in nhds x, y ∈ (extChartAt I x).source :=
+    (isOpen_extChartAt_source x).mem_nhds (mem_extChartAt_source x)
+  have hlocal : Filter.EventuallyEq (nhds x) (f : M → ℝ) (g' ∘ F) := by
+    filter_upwards [hF, hβF, hsource] with y hFy hβy hy
+    change f y = β (F y) * f ((extChartAt I x).symm (F y))
+    change β (F y) = 1 at hβy
+    rw [hβy, one_mul, hFy, (extChartAt I x).left_inv hy]
+  rw [(tangentToPointDerivation x v).congr_of_eventuallyEq f (g'.comp F) hlocal,
+    D.congr_of_eventuallyEq f (g'.comp F) hlocal]
+  have hpush : fdifferential F x (tangentToPointDerivation x v) =
+      tangentToPointDerivation (F x) w := by
+    rw [← tangentToPointDerivation_mfderiv F x v, hv]
+  exact congrArg (fun d : PointDerivation (modelWithCornersSelf ℝ E) (F x) ↦ d g')
+    (hpush.trans hw)
+
+/-- Point derivations and tangent vectors are canonically linearly equivalent on a
+finite-dimensional Hausdorff boundaryless real manifold. -/
+noncomputable def pointDerivationEquivTangentSpace
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [T2Space M] [BoundarylessManifold I M] (x : M) :
+    PointDerivation I x ≃ₗ[ℝ] TangentSpace I x :=
+  (LinearEquiv.ofBijective (tangentToPointDerivation x)
+    ⟨tangentToPointDerivation_injective x, tangentToPointDerivation_surjective x⟩).symm
+
+/-- The inverse of the point-derivation equivalence is directional differentiation. -/
+@[simp]
+theorem pointDerivationEquivTangentSpace_symm_apply
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [T2Space M] [BoundarylessManifold I M] (x : M) (v : TangentSpace I x) :
+    (pointDerivationEquivTangentSpace x).symm v = tangentToPointDerivation x v := by
+  apply (pointDerivationEquivTangentSpace x).injective
+  rw [(pointDerivationEquivTangentSpace x).apply_symm_apply]
+  exact ((LinearEquiv.ofBijective (tangentToPointDerivation x)
+    ⟨tangentToPointDerivation_injective x,
+      tangentToPointDerivation_surjective x⟩).symm_apply_apply v).symm
+
+/-- Converting a point derivation to a tangent vector and back recovers the derivation. -/
+@[simp]
+theorem tangentToPointDerivation_pointDerivationEquivTangentSpace
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [T2Space M] [BoundarylessManifold I M] (x : M) (D : PointDerivation I x) :
+    tangentToPointDerivation x (pointDerivationEquivTangentSpace x D) = D := by
+  rw [← pointDerivationEquivTangentSpace_symm_apply]
+  exact (pointDerivationEquivTangentSpace x).symm_apply_apply D
+
+/-- Converting a tangent vector to a point derivation and back recovers the vector. -/
+@[simp]
+theorem pointDerivationEquivTangentSpace_tangentToPointDerivation
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
+    [T2Space M] [BoundarylessManifold I M] (x : M) (v : TangentSpace I x) :
+    pointDerivationEquivTangentSpace x (tangentToPointDerivation x v) = v := by
+  rw [← pointDerivationEquivTangentSpace_symm_apply]
+  exact (pointDerivationEquivTangentSpace x).apply_symm_apply v

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -23,8 +23,8 @@ a canonical linear map from the ordinary tangent space to the algebraic point de
 * `tangentToPointDerivation`: the point derivation associated to a tangent vector.
 * `tangentToPointDerivation_injective`: distinct tangent vectors induce distinct point derivations
   on finite-dimensional Hausdorff real manifolds.
-* `tangentToPointDerivation_surjective`: every point derivation on a finite-dimensional Hausdorff
-  boundaryless real manifold comes from a tangent vector.
+* `tangentToPointDerivation_surjective`: at an interior point of a finite-dimensional Hausdorff
+  real manifold, every point derivation comes from a tangent vector.
 * `pointDerivationEquivTangentSpace`: the resulting canonical linear equivalence.
 * `PointDerivation.congr_of_eventuallyEq`: on a finite-dimensional Hausdorff real manifold, a point
   derivation depends only on the germ of a smooth function at its basepoint.
@@ -287,13 +287,13 @@ theorem tangentToPointDerivation_mfderiv (f : C^∞⟮I, M; I', M'⟯) (x : M)
     (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
     (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt v).symm
 
-/-- Every point derivation on a finite-dimensional Hausdorff boundaryless real manifold is
+/-- Every point derivation at an interior point of a finite-dimensional Hausdorff real manifold is
 directional differentiation along a tangent vector. -/
 theorem tangentToPointDerivation_surjective
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
-    [T2Space M] [BoundarylessManifold I M] (x : M) :
+    [T2Space M] (x : M) (hx : I.IsInteriorPoint x) :
     Function.Surjective (tangentToPointDerivation (I := I) x) := by
   intro D
   let b : SmoothBumpFunction I x := Classical.choice inferInstance
@@ -311,21 +311,10 @@ theorem tangentToPointDerivation_surjective
     rfl
   refine ⟨v, ?_⟩
   ext f
-  have htarget_at (y : E) (hy : y ∈ (extChartAt I x).target) :
-      (extChartAt I x).target ∈ nhds y := by
-    let m := (extChartAt I x).symm y
-    have hm : m ∈ (extChartAt I x).source := (extChartAt I x).map_target hy
-    have hmInterior : I.IsInteriorPoint m := BoundarylessManifold.isInteriorPoint
-    have hi : extChartAt I x m ∈ interior (extChartAt I x).target := by
-      have hi' := (ModelWithCorners.isInteriorPoint_iff_of_mem_atlas (n := ∞) (by simp)
-        (chart_mem_atlas H x) (by simpa [extChartAt_source] using hm)).1 hmInterior
-      simpa [extChartAt] using hi'
-    have hey : extChartAt I x m = y := (extChartAt I x).right_inv hy
-    rw [hey] at hi
-    exact Filter.mem_of_superset (isOpen_interior.mem_nhds hi) interior_subset
-  have htarget : (extChartAt I x).target ∈ nhds (F x) := by
+  have htarget : interior (extChartAt I x).target ∈ nhds (F x) := by
     rw [hFx]
-    exact htarget_at _ (mem_extChartAt_target x)
+    exact isOpen_interior.mem_nhds
+      ((ModelWithCorners.isInteriorPoint_iff (I := I)).mp hx)
   obtain ⟨β, hβ, -⟩ :=
     (SmoothBumpFunction.nhds_basis_support
       (I := modelWithCornersSelf ℝ E) htarget).mem_iff.mp htarget
@@ -333,10 +322,12 @@ theorem tangentToPointDerivation_surjective
   have hg : ContDiff ℝ ∞ g := by
     apply ContMDiff.contDiff
     refine contMDiff_of_tsupport fun y hy ↦ ?_
-    have hytarget : y ∈ (extChartAt I x).target :=
+    have hytarget : y ∈ interior (extChartAt I x).target :=
       hβ (tsupport_mul_subset_left hy)
-    have hsymmWithin := contMDiffWithinAt_extChartAt_symm_target (n := ∞) x hytarget
-    have hsymm := hsymmWithin.contMDiffAt (htarget_at y hytarget)
+    have hsymmWithin :=
+      contMDiffWithinAt_extChartAt_symm_target (n := ∞) x (interior_subset hytarget)
+    have hsymm := hsymmWithin.contMDiffAt
+      (Filter.mem_of_superset (isOpen_interior.mem_nhds hytarget) interior_subset)
     exact β.contMDiffAt.mul (f.contMDiff.contMDiffAt.comp y hsymm)
   let g' : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ := ⟨g, hg.contMDiff⟩
   have hβF : Filter.EventuallyEq (nhds x) (β ∘ F) (fun _ ↦ 1) :=
@@ -356,16 +347,16 @@ theorem tangentToPointDerivation_surjective
   exact congrArg (fun d : PointDerivation (modelWithCornersSelf ℝ E) (F x) ↦ d g')
     (hpush.trans hw)
 
-/-- Point derivations and tangent vectors are canonically linearly equivalent on a
-finite-dimensional Hausdorff boundaryless real manifold. -/
+/-- Point derivations and tangent vectors are canonically linearly equivalent at an interior point
+of a finite-dimensional Hausdorff real manifold. -/
 noncomputable def pointDerivationEquivTangentSpace
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
-    [T2Space M] [BoundarylessManifold I M] (x : M) :
+    [T2Space M] (x : M) (hx : I.IsInteriorPoint x) :
     PointDerivation I x ≃ₗ[ℝ] TangentSpace I x :=
   (LinearEquiv.ofBijective (tangentToPointDerivation x)
-    ⟨tangentToPointDerivation_injective x, tangentToPointDerivation_surjective x⟩).symm
+    ⟨tangentToPointDerivation_injective x, tangentToPointDerivation_surjective x hx⟩).symm
 
 /-- The inverse of the point-derivation equivalence is directional differentiation. -/
 @[simp]
@@ -373,13 +364,13 @@ theorem pointDerivationEquivTangentSpace_symm_apply
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
-    [T2Space M] [BoundarylessManifold I M] (x : M) (v : TangentSpace I x) :
-    (pointDerivationEquivTangentSpace x).symm v = tangentToPointDerivation x v := by
-  apply (pointDerivationEquivTangentSpace x).injective
-  rw [(pointDerivationEquivTangentSpace x).apply_symm_apply]
+    [T2Space M] (x : M) (hx : I.IsInteriorPoint x) (v : TangentSpace I x) :
+    (pointDerivationEquivTangentSpace x hx).symm v = tangentToPointDerivation x v := by
+  apply (pointDerivationEquivTangentSpace x hx).injective
+  rw [(pointDerivationEquivTangentSpace x hx).apply_symm_apply]
   exact ((LinearEquiv.ofBijective (tangentToPointDerivation x)
     ⟨tangentToPointDerivation_injective x,
-      tangentToPointDerivation_surjective x⟩).symm_apply_apply v).symm
+      tangentToPointDerivation_surjective x hx⟩).symm_apply_apply v).symm
 
 /-- Converting a point derivation to a tangent vector and back recovers the derivation. -/
 @[simp]
@@ -387,10 +378,10 @@ theorem tangentToPointDerivation_pointDerivationEquivTangentSpace
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
-    [T2Space M] [BoundarylessManifold I M] (x : M) (D : PointDerivation I x) :
-    tangentToPointDerivation x (pointDerivationEquivTangentSpace x D) = D := by
-  rw [← pointDerivationEquivTangentSpace_symm_apply]
-  exact (pointDerivationEquivTangentSpace x).symm_apply_apply D
+    [T2Space M] (x : M) (hx : I.IsInteriorPoint x) (D : PointDerivation I x) :
+    tangentToPointDerivation x (pointDerivationEquivTangentSpace x hx D) = D := by
+  rw [← pointDerivationEquivTangentSpace_symm_apply x hx]
+  exact (pointDerivationEquivTangentSpace x hx).symm_apply_apply D
 
 /-- Converting a tangent vector to a point derivation and back recovers the vector. -/
 @[simp]
@@ -398,7 +389,7 @@ theorem pointDerivationEquivTangentSpace_tangentToPointDerivation
     {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
     {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
-    [T2Space M] [BoundarylessManifold I M] (x : M) (v : TangentSpace I x) :
-    pointDerivationEquivTangentSpace x (tangentToPointDerivation x v) = v := by
-  rw [← pointDerivationEquivTangentSpace_symm_apply]
-  exact (pointDerivationEquivTangentSpace x).apply_symm_apply v
+    [T2Space M] (x : M) (hx : I.IsInteriorPoint x) (v : TangentSpace I x) :
+    pointDerivationEquivTangentSpace x hx (tangentToPointDerivation x v) = v := by
+  rw [← pointDerivationEquivTangentSpace_symm_apply x hx]
+  exact (pointDerivationEquivTangentSpace x hx).apply_symm_apply v

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -366,11 +366,8 @@ theorem pointDerivationEquivTangentSpace_symm_apply
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M]
     [T2Space M] (x : M) (hx : I.IsInteriorPoint x) (v : TangentSpace I x) :
     (pointDerivationEquivTangentSpace x hx).symm v = tangentToPointDerivation x v := by
-  apply (pointDerivationEquivTangentSpace x hx).injective
-  rw [(pointDerivationEquivTangentSpace x hx).apply_symm_apply]
-  exact ((LinearEquiv.ofBijective (tangentToPointDerivation x)
-    ⟨tangentToPointDerivation_injective x,
-      tangentToPointDerivation_surjective x hx⟩).symm_apply_apply v).symm
+  simpa only [pointDerivationEquivTangentSpace, LinearEquiv.symm_symm] using
+    (LinearEquiv.ofBijective_apply (tangentToPointDerivation x) v)
 
 /-- Converting a point derivation to a tangent vector and back recovers the derivation. -/
 @[simp]
@@ -393,3 +390,21 @@ theorem pointDerivationEquivTangentSpace_tangentToPointDerivation
     pointDerivationEquivTangentSpace x hx (tangentToPointDerivation x v) = v := by
   rw [← pointDerivationEquivTangentSpace_symm_apply x hx]
   exact (pointDerivationEquivTangentSpace x hx).apply_symm_apply v
+
+/-- The equivalence between point derivations and tangent vectors is natural under smooth maps. -/
+@[simp]
+theorem pointDerivationEquivTangentSpace_fdifferential
+    {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [FiniteDimensional ℝ E]
+    {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I ∞ M] [T2Space M]
+    {E' : Type*} [NormedAddCommGroup E'] [NormedSpace ℝ E'] [FiniteDimensional ℝ E']
+    {H' : Type*} [TopologicalSpace H'] {I' : ModelWithCorners ℝ E' H'}
+    {M' : Type*} [TopologicalSpace M'] [ChartedSpace H' M'] [IsManifold I' ∞ M'] [T2Space M']
+    (f : C^∞⟮I, M; I', M'⟯) (x : M) (hx : I.IsInteriorPoint x)
+    (hfx : I'.IsInteriorPoint (f x)) (D : PointDerivation I x) :
+    pointDerivationEquivTangentSpace (f x) hfx (𝒅 f x D) =
+      mfderiv I I' f x (pointDerivationEquivTangentSpace x hx D) := by
+  apply tangentToPointDerivation_injective (I := I') (f x)
+  rw [tangentToPointDerivation_pointDerivationEquivTangentSpace (f x) hfx,
+    tangentToPointDerivation_mfderiv,
+    tangentToPointDerivation_pointDerivationEquivTangentSpace x hx]

--- a/TauCeti/Geometry/Manifold/DerivationBundle.lean
+++ b/TauCeti/Geometry/Manifold/DerivationBundle.lean
@@ -149,6 +149,8 @@ private theorem tangentToPointDerivation_surjective_model
     Function.Surjective
       (tangentToPointDerivation (I := modelWithCornersSelf ℝ E) x) := by
   intro D
+  -- Read `D` on a finite coordinate system and use those values as the coordinates of the
+  -- candidate tangent vector.
   let b := Module.finBasis ℝ E
   let c (i : Fin (Module.finrank ℝ E)) : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
     ⟨b.coord i, (b.coord i).toContinuousLinearMap.contDiff.contMDiff⟩
@@ -159,12 +161,18 @@ private theorem tangentToPointDerivation_surjective_model
   refine ⟨v, ?_⟩
   ext f
   let f' : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ := ⟨f, f.contMDiff⟩
+  -- The domain of `D` and `TangentSpace` are pointed-map and model-space type synonyms. Unfold
+  -- their evaluation here so the rest of the argument can stay in the ordinary smooth-map API.
   change mvfderiv (modelWithCornersSelf ℝ E) f' x v = δ f'
   rw [mvfderiv, mfderiv_eq_fderiv]
+  -- Hadamard's lemma factors `f - f(x)` through the coordinate functions. The factors are smooth,
+  -- so this identity lives in the algebra on which the derivation acts.
   let a (i : Fin (Module.finrank ℝ E)) : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
     ⟨fun y ↦ hadamardFactor f' x y (b i), by
       have hfac : ContDiff ℝ ∞ (hadamardFactor f' x) :=
         f'.contMDiff.contDiff.contDiff_hadamardFactor f' x
+      -- Applying a smooth continuous-linear-map-valued function to the constant vector `b i`
+      -- is the available API for smoothness of each scalar Hadamard factor.
       exact (hfac.clm_apply (show ContDiff ℝ ∞ (fun _ : E ↦ b i) from
         contDiff_const)).contMDiff⟩
   let k : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯ :=
@@ -185,6 +193,8 @@ private theorem tangentToPointDerivation_surjective_model
         rw [map_smul]
         simp [b, mul_comm]
       _ = (∑ i, a i * (c i - kcoord i)) y := by
+        -- Evaluation of bundled smooth maps is a ring homomorphism, but the pointwise coercion on
+        -- the left does not expose that homomorphism to `rw` automatically.
         change _ = ContMDiffMap.evalRingHom y (∑ i, a i * (c i - kcoord i))
         rw [map_sum]
         apply Finset.sum_congr rfl
@@ -193,16 +203,22 @@ private theorem tangentToPointDerivation_surjective_model
   have hδconst (r : ℝ) :
       δ (⟨fun _ : E ↦ r, contDiff_const.contMDiff⟩ :
         C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) = 0 := by
+    -- A constant ordinary smooth map becomes `algebraMap r` after passing to the pointed-map
+    -- synonym; exposing that boundary lets us use the derivation's algebra-map law.
     change D (algebraMap ℝ C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯⟨x⟩ r) = 0
     exact D.map_algebraMap r
   have hδsub (p q : C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) :
       δ (p - q) = δ p - δ q := by
+    -- First unfold `δ`, then expose that the pointed-map constructor preserves subtraction.
+    -- There is no coercion lemma for this type synonym, so both equalities are definitional.
     change D (pointed (p - q)) = D (pointed p) - D (pointed q)
     change D (pointed p - pointed q) = D (pointed p) - D (pointed q)
     exact D.map_sub _ _
   have hterm (i : Fin (Module.finrank ℝ E)) :
       δ (a i * (c i - kcoord i)) = fderiv ℝ f' x (b i) * δ (c i) := by
     have hleibniz := D.leibniz (pointed (a i)) (pointed (c i - kcoord i))
+    -- Unfold `δ` and pointed-map evaluation in the Leibniz identity. The scalar action there is
+    -- evaluation at `x`, which is definitionally the displayed multiplication.
     change δ (a i * (c i - kcoord i)) =
       a i x * δ (c i - kcoord i) + (c i x - kcoord i x) * δ (a i) at hleibniz
     rw [hleibniz, hδsub, hδconst]
@@ -210,11 +226,14 @@ private theorem tangentToPointDerivation_surjective_model
   have hδsum (q : Fin (Module.finrank ℝ E) →
       C^∞⟮modelWithCornersSelf ℝ E, E; ℝ⟯) :
       δ (∑ i, q i) = ∑ i, δ (q i) := by
+    -- As for subtraction, unfold `δ` and then expose that the pointed-map constructor preserves
+    -- finite sums; both steps cross only the pointed-map type synonym.
     change D (pointed (∑ i, q i)) = ∑ i, D (pointed (q i))
     change D (∑ i, pointed (q i)) = ∑ i, D (pointed (q i))
     exact map_sum D _ _
   calc
     fderiv ℝ f' x v = ∑ i, fderiv ℝ f' x (b i) * δ (c i) := by
+      -- Unfold the chosen vector `v` across the tangent-space synonym before using linearity.
       change fderiv ℝ f' x (∑ i, δ (c i) • b i) = _
       rw [map_sum]
       apply Finset.sum_congr rfl
@@ -296,6 +315,8 @@ theorem tangentToPointDerivation_surjective
     [T2Space M] (x : M) (hx : I.IsInteriorPoint x) :
     Function.Surjective (tangentToPointDerivation (I := I) x) := by
   intro D
+  -- A bump-localized extended chart is globally smooth and agrees with the chart germ at `x`.
+  -- Push `D` through it and apply the model-space theorem to obtain the candidate vector `v`.
   let b : SmoothBumpFunction I x := Classical.choice inferInstance
   let F : C^∞⟮I, M; modelWithCornersSelf ℝ E, E⟯ :=
     ⟨fun y ↦ b y • extChartAt I x y,
@@ -308,9 +329,13 @@ theorem tangentToPointDerivation_surjective
   let v : TangentSpace I x := w
   have hv : mfderiv I (modelWithCornersSelf ℝ E) F x v = w := by
     rw [hF.mfderiv_eq, mfderiv_extChartAt_self]
+    -- `TangentSpace I x` is the model space as a type synonym, so the identity derivative applies
+    -- to `v` definitionally as the model-space vector `w`.
     rfl
   refine ⟨v, ?_⟩
   ext f
+  -- To compare the two derivations on an arbitrary global `f`, cut its chart expression off inside
+  -- the interior of the chart target. This produces a globally smooth model-space function `g'`.
   have htarget : interior (extChartAt I x).target ∈ nhds (F x) := by
     rw [hFx]
     exact isOpen_interior.mem_nhds
@@ -336,9 +361,14 @@ theorem tangentToPointDerivation_surjective
     (isOpen_extChartAt_source x).mem_nhds (mem_extChartAt_source x)
   have hlocal : Filter.EventuallyEq (nhds x) (f : M → ℝ) (g' ∘ F) := by
     filter_upwards [hF, hβF, hsource] with y hFy hβy hy
+    -- Unfold composition and the bundled chart-local function `g'`; no theorem rewrites through
+    -- both bundled-map coercions at once.
     change f y = β (F y) * f ((extChartAt I x).symm (F y))
+    -- Likewise expose the constant function in the eventual equality supplied by the bump.
     change β (F y) = 1 at hβy
     rw [hβy, one_mul, hFy, (extChartAt I x).left_inv hy]
+  -- Germ invariance replaces `f` by `g' ∘ F` on both sides. Naturality of the tangent comparison
+  -- then reduces the result exactly to the model-space equality `hw`.
   rw [(tangentToPointDerivation x v).congr_of_eventuallyEq f (g'.comp F) hlocal,
     D.congr_of_eventuallyEq f (g'.comp F) hlocal]
   have hpush : fdifferential F x (tangentToPointDerivation x v) =


### PR DESCRIPTION
## Goal

Complete the roadmap’s Layer 0 identification of algebraic point derivations with tangent vectors at interior points of finite-dimensional Hausdorff real manifolds. The existing comparison map already sends each tangent vector to directional differentiation and is injective; this PR proves it is surjective, packages the resulting canonical linear equivalence, and proves that equivalence is natural under smooth maps.

## Why this proves the goal

Surjectivity first reduces to the model vector space. A finite basis supplies coordinate functions, and the smooth Hadamard factorization from #1770 writes every smooth function minus its value at the basepoint as a finite sum of coordinate differences with smooth coefficients. Applying the Leibniz rule shows that any point derivation is completely determined by its values on those coordinates, hence equals differentiation along the corresponding basis expansion.

For a general manifold, a bump-localized extended chart transports the derivation to the model space. Interiority places the chart image of the basepoint in the interior of the chart target, where a second bump function turns each local chart representative into a globally smooth model-space function. Germ invariance and functoriality of the derivation differential then transport the model-space equality back to the original point. Combining this surjectivity theorem with the existing injectivity theorem yields the linear equivalence and inverse simp laws. Applying the tangent-vector comparison map on both sides then proves naturality under smooth maps.

## Verification

The trusted local gate passes: 6,244 build jobs; 20,284 Tau Ceti declarations use only the axiom allowlist; all 1,112 modules opt into the module system; and the environment lint reports no new violations.

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 0, “The Lie algebra and the tangent space at `1`”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md).

Roadmap: RepresentationTheory
