### PR TITLE
feat: add contour cycles

### DIFF
--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -73,6 +73,36 @@ namespace PiecewiseC1ClosedCurve
 instance : CoeFun PiecewiseC1ClosedCurve fun _ ↦ ℝ → ℂ :=
   ⟨fun γ ↦ Function.extend Subtype.val γ.toFun 0⟩
 
+/-- On its parameter interval, a closed curve's coercion agrees with its stored function. -/
+theorem coe_apply (γ : PiecewiseC1ClosedCurve) (t : uIcc γ.a γ.b) : γ t = γ.toFun t :=
+  Subtype.val_injective.extend_apply γ.toFun 0 t
+
+/-- Bundle a raw closed piecewise-`C¹` curve by restricting it to its parameter interval. -/
+def of {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b) :
+    PiecewiseC1ClosedCurve where
+  a := a
+  b := b
+  toFun t := γ t
+  isPiecewiseC1On := by
+    rw [isPiecewiseC1On_iff] at hγ ⊢
+    refine ⟨hγ.1.congr (fun t ht ↦ ?_), ?_⟩
+    · exact Subtype.val_injective.extend_apply (fun t : uIcc a b ↦ γ t) 0 ⟨t, ht⟩
+    · obtain ⟨p, hp, hpieces⟩ := hγ.2
+      refine ⟨p, hp, fun c d hcd hdis ↦ (hpieces c d hcd hdis).congr fun t ht ↦ ?_⟩
+      exact Subtype.val_injective.extend_apply (fun t : uIcc a b ↦ γ t) 0 ⟨t, hcd ht⟩
+  source_eq_target := by
+    rw [← show (⟨a, left_mem_uIcc⟩ : uIcc a b).1 = a from rfl,
+      ← show (⟨b, right_mem_uIcc⟩ : uIcc a b).1 = b from rfl,
+      Subtype.val_injective.extend_apply, Subtype.val_injective.extend_apply]
+    exact hclosed
+
+/-- Bundling a raw curve preserves its values on the parameter interval. -/
+@[simp]
+theorem of_apply {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) {t : ℝ} (ht : t ∈ uIcc a b) :
+    of γ hγ hclosed t = γ t := by
+  exact coe_apply (of γ hγ hclosed) ⟨t, ht⟩
+
 /-- The underlying parametrization is continuous on its parameter interval. -/
 theorem continuousOn (γ : PiecewiseC1ClosedCurve) : ContinuousOn γ (uIcc γ.a γ.b) :=
   γ.isPiecewiseC1On.continuousOn

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -135,6 +135,22 @@ theorem mem_trace_iff {C : Cycle} {z : ℂ} :
 theorem trace_zero : trace (0 : Cycle) = ∅ := by
   simp [trace]
 
+/-- The trace of a raw curve bundled as a generator is its raw interval image. -/
+@[simp]
+theorem trace_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) :
+    PiecewiseC1ClosedCurve.of γ hγ hclosed ''
+        uIcc (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
+          (PiecewiseC1ClosedCurve.of γ hγ hclosed).b =
+      γ '' uIcc a b := by
+  change PiecewiseC1ClosedCurve.of γ hγ hclosed '' uIcc a b = γ '' uIcc a b
+  ext z
+  constructor
+  · rintro ⟨t, ht, rfl⟩
+    exact ⟨t, ht, (PiecewiseC1ClosedCurve.of_apply γ hγ hclosed ht).symm⟩
+  · rintro ⟨t, ht, rfl⟩
+    exact ⟨t, ht, PiecewiseC1ClosedCurve.of_apply γ hγ hclosed ht⟩
+
 /-- The trace of a single generator is its image on its parameter interval. -/
 @[simp]
 theorem trace_of (γ : PiecewiseC1ClosedCurve) :
@@ -168,6 +184,16 @@ def IsIn (C : Cycle) (Ω : Set ℂ) : Prop :=
 /-- Restatement of cycle containment in terms of its trace. -/
 theorem isIn_iff {C : Cycle} {Ω : Set ℂ} : IsIn C Ω ↔ trace C ⊆ Ω :=
   Iff.rfl
+
+/-- A raw curve bundled as a generator lies in `Ω` exactly when it maps its interval into `Ω`. -/
+@[simp]
+theorem isIn_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (Ω : Set ℂ) :
+    MapsTo (PiecewiseC1ClosedCurve.of γ hγ hclosed)
+        (uIcc (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
+          (PiecewiseC1ClosedCurve.of γ hγ hclosed).b) Ω ↔
+      MapsTo γ (uIcc a b) Ω := by
+  rw [Set.mapsTo_iff_image_subset, Set.mapsTo_iff_image_subset, trace_of_raw]
 
 /-- A one-generator cycle lies in `Ω` exactly when its parametrization maps its interval into
 `Ω`. -/
@@ -206,6 +232,23 @@ def integral {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     (C : Cycle) (f : ℂ → E) : E :=
   FreeAbelianGroup.lift
     (fun γ : PiecewiseC1ClosedCurve ↦ ∫ t in γ.a..γ.b, deriv γ t • f (γ t)) C
+
+/-- Integrating over a raw curve bundled as a generator gives its raw contour integral. -/
+@[simp]
+theorem integral_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (f : ℂ → E) :
+    (∫ t in (PiecewiseC1ClosedCurve.of γ hγ hclosed).a..
+        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b,
+        deriv (PiecewiseC1ClosedCurve.of γ hγ hclosed) t •
+          f (PiecewiseC1ClosedCurve.of γ hγ hclosed t)) =
+      ∫ t in a..b, deriv γ t • f (γ t) := by
+  change (∫ t in a..b, deriv (PiecewiseC1ClosedCurve.of γ hγ hclosed) t •
+    f (PiecewiseC1ClosedCurve.of γ hγ hclosed t)) = _
+  have heq : EqOn (PiecewiseC1ClosedCurve.of γ hγ hclosed) γ (uIoo a b) :=
+    fun _ ht ↦ PiecewiseC1ClosedCurve.of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
+  exact intervalIntegral.integral_congr_uIoo fun t ht ↦ by
+    rw [heq ht, heq.deriv isOpen_Ioo ht]
 
 /-- Integrating over a one-generator cycle gives the raw contour integral over that curve. -/
 @[simp]
@@ -254,6 +297,19 @@ def windingNumber (C : Cycle) (z₀ : ℂ) : ℂ :=
   FreeAbelianGroup.lift
     (fun γ : PiecewiseC1ClosedCurve ↦ TauCeti.Contour.windingNumber γ γ.a γ.b z₀) C
 
+/-- The winding number of a raw curve bundled as a generator is its raw winding number. -/
+@[simp]
+theorem windingNumber_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (z₀ : ℂ) :
+    TauCeti.Contour.windingNumber (PiecewiseC1ClosedCurve.of γ hγ hclosed)
+        (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
+        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b z₀ =
+      TauCeti.Contour.windingNumber γ a b z₀ := by
+  change TauCeti.Contour.windingNumber (PiecewiseC1ClosedCurve.of γ hγ hclosed) a b z₀ = _
+  apply TauCeti.Contour.windingNumber_congr_curve
+  intro t ht
+  exact PiecewiseC1ClosedCurve.of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
+
 /-- The winding number of a one-generator cycle is the winding number of that curve. -/
 @[simp]
 theorem windingNumber_of (γ : PiecewiseC1ClosedCurve) (z₀ : ℂ) :
@@ -299,6 +355,16 @@ def IsNullHomologous (C : Cycle) (Ω : Set ℂ) : Prop :=
 theorem isNullHomologous_iff {C : Cycle} {Ω : Set ℂ} :
     IsNullHomologous C Ω ↔ ∀ z ∉ Ω, windingNumber C z = 0 :=
   Iff.rfl
+
+/-- Null-homology of a raw curve bundled as a generator is the raw-curve predicate. -/
+@[simp]
+theorem isNullHomologous_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ)
+    (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b) (Ω : Set ℂ) :
+    TauCeti.Contour.IsNullHomologous (PiecewiseC1ClosedCurve.of γ hγ hclosed)
+        (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
+        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b Ω ↔
+      TauCeti.Contour.IsNullHomologous γ a b Ω := by
+  simp only [TauCeti.Contour.isNullHomologous_iff, windingNumber_of_raw]
 
 /-- Cycle null-homology specializes on a generator to the raw-curve predicate. -/
 @[simp]

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -183,6 +183,7 @@ def trace (C : Cycle) : Set ℂ :=
 
 /-- Membership in the trace means membership in the image of a generator with nonzero
 coefficient. -/
+@[simp]
 theorem mem_trace_iff {C : Cycle} {z : ℂ} :
     z ∈ trace C ↔ ∃ γ ∈ FreeAbelianGroup.support C, z ∈ γ '' uIcc γ.a γ.b := by
   simp only [trace, mem_iUnion, exists_prop]

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -144,12 +144,8 @@ theorem isIn_iff {C : Cycle} {Ω : Set ℂ} : IsIn C Ω ↔ trace C ⊆ Ω :=
 @[simp]
 theorem isIn_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
     IsIn (FreeAbelianGroup.of γ) Ω ↔ MapsTo γ (uIcc γ.a γ.b) Ω := by
-  rw [isIn_iff, trace_of]
-  constructor
-  · intro h x hx
-    exact h ⟨x, hx, rfl⟩
-  · rintro h z ⟨x, hx, rfl⟩
-    exact h hx
+  simpa [IsIn] using
+    (Set.mapsTo_iff_image_subset (f := γ) (s := uIcc γ.a γ.b) (t := Ω)).symm
 
 /-- The zero cycle lies in every set. -/
 @[simp]

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -91,10 +91,15 @@ def of {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b) (hclosed : 
       refine ⟨p, hp, fun c d hcd hdis ↦ (hpieces c d hcd hdis).congr fun t ht ↦ ?_⟩
       exact Subtype.val_injective.extend_apply (fun t : uIcc a b ↦ γ t) 0 ⟨t, hcd ht⟩
   source_eq_target := by
-    rw [← show (⟨a, left_mem_uIcc⟩ : uIcc a b).1 = a from rfl,
-      ← show (⟨b, right_mem_uIcc⟩ : uIcc a b).1 = b from rfl,
-      Subtype.val_injective.extend_apply, Subtype.val_injective.extend_apply]
-    exact hclosed
+    calc
+      Function.extend Subtype.val (fun t : uIcc a b ↦ γ t) 0 a =
+          γ (⟨a, left_mem_uIcc⟩ : uIcc a b) :=
+        Subtype.val_injective.extend_apply (fun t : uIcc a b ↦ γ t) 0
+          ⟨a, left_mem_uIcc⟩
+      _ = γ (⟨b, right_mem_uIcc⟩ : uIcc a b) := hclosed
+      _ = Function.extend Subtype.val (fun t : uIcc a b ↦ γ t) 0 b :=
+        (Subtype.val_injective.extend_apply (fun t : uIcc a b ↦ γ t) 0
+          ⟨b, right_mem_uIcc⟩).symm
 
 /-- Bundling a raw curve preserves its values on the parameter interval. -/
 @[simp]

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -224,13 +224,17 @@ theorem trace_zsmul (C : Cycle) {n : ℤ} (hn : n ≠ 0) : trace (n • C) = tra
 def IsIn (C : Cycle) (Ω : Set ℂ) : Prop :=
   trace C ⊆ Ω
 
+/-- Restatement of cycle containment in terms of its trace. -/
+theorem isIn_iff {C : Cycle} {Ω : Set ℂ} : IsIn C Ω ↔ trace C ⊆ Ω :=
+  Iff.rfl
+
 /-- A raw curve bundled as a one-generator cycle lies in `Ω` exactly when it maps its interval
 into `Ω`. -/
 theorem isIn_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
     (hclosed : γ a = γ b) (Ω : Set ℂ) :
     IsIn (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) Ω ↔
       MapsTo γ (uIcc a b) Ω := by
-  rw [IsIn, trace_of, ← Set.mapsTo_iff_image_subset,
+  rw [isIn_iff, trace_of, ← Set.mapsTo_iff_image_subset,
     PiecewiseC1ClosedCurve.mapsTo_of_iff]
 
 /-- A one-generator cycle lies in `Ω` exactly when its parametrization maps its interval into
@@ -238,30 +242,32 @@ theorem isIn_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ
 @[simp]
 theorem isIn_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
     IsIn (FreeAbelianGroup.of γ) Ω ↔ MapsTo γ (uIcc γ.a γ.b) Ω := by
-  simpa [IsIn] using
+  simpa [isIn_iff] using
     (Set.mapsTo_iff_image_subset (f := γ) (s := uIcc γ.a γ.b) (t := Ω)).symm
 
 /-- The zero cycle lies in every set. -/
 @[simp]
 theorem IsIn.zero (Ω : Set ℂ) : IsIn (0 : Cycle) Ω := by
-  simp [IsIn]
+  simp [isIn_iff]
 
 /-- A sum of two cycles in `Ω` is in `Ω`. -/
 theorem IsIn.add {C D : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (hD : IsIn D Ω) :
-    IsIn (C + D) Ω :=
-  (trace_add_subset C D).trans (union_subset hC hD)
+    IsIn (C + D) Ω := by
+  rw [isIn_iff] at hC hD ⊢
+  exact (trace_add_subset C D).trans (union_subset hC hD)
 
 /-- Negation preserves containment in a set. -/
 @[simp]
 theorem isIn_neg_iff {C : Cycle} {Ω : Set ℂ} : IsIn (-C) Ω ↔ IsIn C Ω := by
-  simp [IsIn]
+  simp [isIn_iff]
 
 /-- Every integer multiple of a cycle in `Ω` is in `Ω`. -/
 theorem IsIn.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (n : ℤ) : IsIn (n • C) Ω := by
+  rw [isIn_iff] at hC
   by_cases hn : n = 0
   · subst n
     simpa only [zero_zsmul] using IsIn.zero Ω
-  · rw [IsIn, trace_zsmul C hn]
+  · rw [isIn_iff, trace_zsmul C hn]
     exact hC
 
 /-- The integral of `f` over a cycle, obtained by additively extending the raw contour integral
@@ -313,12 +319,17 @@ theorem windingNumber_of (γ : PiecewiseC1ClosedCurve) (z₀ : ℂ) :
 def IsNullHomologous (C : Cycle) (Ω : Set ℂ) : Prop :=
   ∀ z ∉ Ω, windingNumber z C = 0
 
+/-- Restatement of null-homology as vanishing of the cycle winding number outside the domain. -/
+theorem isNullHomologous_iff {C : Cycle} {Ω : Set ℂ} :
+    IsNullHomologous C Ω ↔ ∀ z ∉ Ω, windingNumber z C = 0 :=
+  Iff.rfl
+
 /-- Null-homology of a raw curve bundled as a one-generator cycle is the raw-curve predicate. -/
 theorem isNullHomologous_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ)
     (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b) (Ω : Set ℂ) :
     IsNullHomologous (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) Ω ↔
       TauCeti.Contour.IsNullHomologous γ a b Ω := by
-  simp only [IsNullHomologous, windingNumber, FreeAbelianGroup.lift_apply_of,
+  simp only [isNullHomologous_iff, windingNumber, FreeAbelianGroup.lift_apply_of,
     PiecewiseC1ClosedCurve.windingNumber_of, TauCeti.Contour.isNullHomologous_iff]
 
 /-- Cycle null-homology specializes on a generator to the raw-curve predicate. -/
@@ -326,18 +337,20 @@ theorem isNullHomologous_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ)
 theorem isNullHomologous_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
     IsNullHomologous (FreeAbelianGroup.of γ) Ω ↔
       TauCeti.Contour.IsNullHomologous γ γ.a γ.b Ω := by
-  simp only [IsNullHomologous, windingNumber_of,
+  simp only [isNullHomologous_iff, windingNumber_of,
     TauCeti.Contour.isNullHomologous_iff]
 
 /-- The zero cycle is null-homologous in every set. -/
 @[simp]
 theorem IsNullHomologous.zero (Ω : Set ℂ) : IsNullHomologous (0 : Cycle) Ω := by
+  rw [isNullHomologous_iff]
   intro z hz
   simp
 
 /-- A sum of null-homologous cycles is null-homologous. -/
 theorem IsNullHomologous.add {C D : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω)
     (hD : IsNullHomologous D Ω) : IsNullHomologous (C + D) Ω := by
+  rw [isNullHomologous_iff] at hC hD ⊢
   intro z hz
   rw [map_add, hC z hz, hD z hz, add_zero]
 
@@ -345,6 +358,7 @@ theorem IsNullHomologous.add {C D : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous
 @[simp]
 theorem isNullHomologous_neg_iff {C : Cycle} {Ω : Set ℂ} :
     IsNullHomologous (-C) Ω ↔ IsNullHomologous C Ω := by
+  rw [isNullHomologous_iff, isNullHomologous_iff]
   constructor <;> intro h z hz
   · simpa only [map_neg, neg_eq_zero] using h z hz
   · simpa only [map_neg, neg_eq_zero] using h z hz
@@ -352,6 +366,7 @@ theorem isNullHomologous_neg_iff {C : Cycle} {Ω : Set ℂ} :
 /-- Every integer multiple of a null-homologous cycle is null-homologous. -/
 theorem IsNullHomologous.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω) (n : ℤ) :
     IsNullHomologous (n • C) Ω := by
+  rw [isNullHomologous_iff] at hC ⊢
   intro z hz
   rw [map_zsmul, hC z hz, smul_zero]
 

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -15,10 +15,12 @@ A contour cycle is a finite formal `ℤ`-linear combination of closed piecewise-
 file packages that definition as the free abelian group on parametrized closed curves and extends
 the contour integral and winding number additively from curves to cycles.
 
-Individual curves remain raw functions on real intervals, as elsewhere in the contour library. The
+Individual curves remain functions on real intervals, as elsewhere in the contour library. The
 small `PiecewiseC1ClosedCurve` bundle exists only because `FreeAbelianGroup` needs a type of
-generators; it records exactly a function, its oriented parameter interval, its regularity, and its
-closedness. In particular, it does not introduce a second notion of contour integral.
+generators; it records exactly an interval-restricted function, its oriented parameter interval,
+its regularity, and its closedness. Its canonical extension to `ℝ` lets existing raw-function
+contour results apply directly. In particular, it does not introduce a second notion of contour
+integral.
 
 The geometric trace of a cycle is the union of the images of the generators with nonzero
 coefficient. Thus cancellation removes a curve from the trace, just as it removes that curve's
@@ -49,26 +51,27 @@ open MeasureTheory Set intervalIntegral
 
 namespace TauCeti.Contour
 
-/-- A parametrized closed piecewise-`C¹` curve on an oriented real interval. The function is kept
-on `ℝ`, rather than restricted to the interval, so all existing raw-function contour results apply
-directly. -/
+/-- A parametrized closed piecewise-`C¹` curve on an oriented real interval. The parametrization
+is stored only on its interval, so curves cannot differ merely in irrelevant values outside it. -/
 @[ext]
 structure PiecewiseC1ClosedCurve where
-  /-- The parametrization of the curve. -/
-  toFun : ℝ → ℂ
   /-- The initial parameter. -/
   a : ℝ
   /-- The terminal parameter. -/
   b : ℝ
+  /-- The interval-restricted parametrization of the curve. -/
+  toFun : uIcc a b → ℂ
   /-- Piecewise-`C¹` regularity on the parameter interval. -/
-  isPiecewiseC1On : IsPiecewiseC1On toFun a b
+  isPiecewiseC1On : IsPiecewiseC1On (Function.extend Subtype.val toFun 0) a b
   /-- The parametrization has equal endpoints. -/
-  source_eq_target : toFun a = toFun b
+  source_eq_target :
+    Function.extend Subtype.val toFun 0 a = Function.extend Subtype.val toFun 0 b
 
 namespace PiecewiseC1ClosedCurve
 
+/-- A closed curve coerces to the canonical extension of its parametrization to `ℝ`. -/
 instance : CoeFun PiecewiseC1ClosedCurve fun _ ↦ ℝ → ℂ :=
-  ⟨PiecewiseC1ClosedCurve.toFun⟩
+  ⟨fun γ ↦ Function.extend Subtype.val γ.toFun 0⟩
 
 /-- The underlying parametrization is continuous on its parameter interval. -/
 theorem continuousOn (γ : PiecewiseC1ClosedCurve) : ContinuousOn γ (uIcc γ.a γ.b) :=
@@ -173,42 +176,49 @@ theorem IsIn.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (n : ℤ) : IsIn 
 
 /-- The integral of `f` over a cycle, obtained by additively extending the raw contour integral
 `∫ t in γ.a..γ.b, deriv γ t • f (γ t)` from generators. -/
-def integral (C : Cycle) (f : ℂ → ℂ) : ℂ :=
+def integral {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (C : Cycle) (f : ℂ → E) : E :=
   FreeAbelianGroup.lift
     (fun γ : PiecewiseC1ClosedCurve ↦ ∫ t in γ.a..γ.b, deriv γ t • f (γ t)) C
 
 /-- Integrating over a one-generator cycle gives the raw contour integral over that curve. -/
 @[simp]
-theorem integral_of (γ : PiecewiseC1ClosedCurve) (f : ℂ → ℂ) :
+theorem integral_of {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (γ : PiecewiseC1ClosedCurve) (f : ℂ → E) :
     integral (FreeAbelianGroup.of γ) f =
       ∫ t in γ.a..γ.b, deriv γ t • f (γ t) := by
   rw [integral, FreeAbelianGroup.lift_apply_of]
 
 /-- The integral over the zero cycle vanishes. -/
 @[simp]
-theorem integral_zero (f : ℂ → ℂ) : integral 0 f = 0 :=
+theorem integral_zero {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (f : ℂ → E) : integral 0 f = 0 :=
   by rw [integral, map_zero]
 
 /-- The integral is additive in the cycle. -/
 @[simp]
-theorem integral_add (C D : Cycle) (f : ℂ → ℂ) :
+theorem integral_add {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (C D : Cycle) (f : ℂ → E) :
     integral (C + D) f = integral C f + integral D f := by
   simp only [integral, map_add]
 
 /-- Reversing every coefficient negates the integral. -/
 @[simp]
-theorem integral_neg (C : Cycle) (f : ℂ → ℂ) : integral (-C) f = -integral C f := by
+theorem integral_neg {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (C : Cycle) (f : ℂ → E) : integral (-C) f = -integral C f := by
   simp only [integral, map_neg]
 
 /-- The integral respects subtraction of cycles. -/
 @[simp]
-theorem integral_sub (C D : Cycle) (f : ℂ → ℂ) :
+theorem integral_sub {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (C D : Cycle) (f : ℂ → E) :
     integral (C - D) f = integral C f - integral D f := by
   simp only [sub_eq_add_neg, integral_add, integral_neg]
 
 /-- The integral respects integer multiplicities. -/
 @[simp]
-theorem integral_zsmul (n : ℤ) (C : Cycle) (f : ℂ → ℂ) :
+theorem integral_zsmul {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (n : ℤ) (C : Cycle) (f : ℂ → E) :
     integral (n • C) f = n • integral C f := by
   simp only [integral, map_zsmul]
 

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -103,6 +103,58 @@ theorem of_apply {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
     of γ hγ hclosed t = γ t := by
   exact coe_apply (of γ hγ hclosed) ⟨t, ht⟩
 
+/-- Bundling a raw curve preserves its interval image. -/
+@[simp]
+theorem image_of {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) :
+    of γ hγ hclosed '' uIcc (of γ hγ hclosed).a (of γ hγ hclosed).b =
+      γ '' uIcc a b := by
+  ext z
+  constructor
+  · rintro ⟨t, ht, rfl⟩
+    exact ⟨t, ht, (of_apply γ hγ hclosed ht).symm⟩
+  · rintro ⟨t, ht, rfl⟩
+    exact ⟨t, ht, of_apply γ hγ hclosed ht⟩
+
+/-- Bundling a raw curve preserves the set into which it maps its parameter interval. -/
+@[simp]
+theorem mapsTo_of_iff {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (Ω : Set ℂ) :
+    MapsTo (of γ hγ hclosed) (uIcc (of γ hγ hclosed).a (of γ hγ hclosed).b) Ω ↔
+      MapsTo γ (uIcc a b) Ω := by
+  rw [Set.mapsTo_iff_image_subset, Set.mapsTo_iff_image_subset, image_of]
+
+/-- Bundling a raw curve preserves its contour integral. -/
+@[simp]
+theorem integral_of {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
+    (f : ℂ → E) :
+    (∫ t in (of γ hγ hclosed).a..(of γ hγ hclosed).b,
+        deriv (of γ hγ hclosed) t • f (of γ hγ hclosed t)) =
+      ∫ t in a..b, deriv γ t • f (γ t) := by
+  have heq : EqOn (of γ hγ hclosed) γ (uIoo a b) :=
+    fun _ ht ↦ of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
+  exact intervalIntegral.integral_congr_uIoo fun t ht ↦ by
+    rw [heq ht, heq.deriv isOpen_Ioo ht]
+
+/-- Bundling a raw curve preserves its winding number. -/
+@[simp]
+theorem windingNumber_of {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) (z₀ : ℂ) :
+    TauCeti.Contour.windingNumber (of γ hγ hclosed) (of γ hγ hclosed).a
+        (of γ hγ hclosed).b z₀ = TauCeti.Contour.windingNumber γ a b z₀ := by
+  apply TauCeti.Contour.windingNumber_congr_curve
+  intro t ht
+  exact of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
+
+/-- Bundling a raw curve preserves null-homology. -/
+@[simp]
+theorem isNullHomologous_of_iff {a b : ℝ} (γ : ℝ → ℂ)
+    (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b) (Ω : Set ℂ) :
+    TauCeti.Contour.IsNullHomologous (of γ hγ hclosed) (of γ hγ hclosed).a
+        (of γ hγ hclosed).b Ω ↔ TauCeti.Contour.IsNullHomologous γ a b Ω := by
+  simp only [TauCeti.Contour.isNullHomologous_iff, windingNumber_of]
+
 /-- The underlying parametrization is continuous on its parameter interval. -/
 theorem continuousOn (γ : PiecewiseC1ClosedCurve) : ContinuousOn γ (uIcc γ.a γ.b) :=
   γ.isPiecewiseC1On.continuousOn
@@ -135,27 +187,18 @@ theorem mem_trace_iff {C : Cycle} {z : ℂ} :
 theorem trace_zero : trace (0 : Cycle) = ∅ := by
   simp [trace]
 
-/-- The trace of a raw curve bundled as a generator is its raw interval image. -/
-@[simp]
-theorem trace_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
-    (hclosed : γ a = γ b) :
-    PiecewiseC1ClosedCurve.of γ hγ hclosed ''
-        uIcc (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
-          (PiecewiseC1ClosedCurve.of γ hγ hclosed).b =
-      γ '' uIcc a b := by
-  change PiecewiseC1ClosedCurve.of γ hγ hclosed '' uIcc a b = γ '' uIcc a b
-  ext z
-  constructor
-  · rintro ⟨t, ht, rfl⟩
-    exact ⟨t, ht, (PiecewiseC1ClosedCurve.of_apply γ hγ hclosed ht).symm⟩
-  · rintro ⟨t, ht, rfl⟩
-    exact ⟨t, ht, PiecewiseC1ClosedCurve.of_apply γ hγ hclosed ht⟩
-
 /-- The trace of a single generator is its image on its parameter interval. -/
 @[simp]
 theorem trace_of (γ : PiecewiseC1ClosedCurve) :
     trace (FreeAbelianGroup.of γ) = γ '' uIcc γ.a γ.b := by
   simp [trace]
+
+/-- The trace of a raw curve bundled as a one-generator cycle is its raw interval image. -/
+theorem trace_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
+    (hclosed : γ a = γ b) :
+    trace (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) =
+      γ '' uIcc a b := by
+  rw [trace_of, PiecewiseC1ClosedCurve.image_of]
 
 /-- Negating every coefficient does not change the trace. -/
 @[simp]
@@ -181,19 +224,14 @@ theorem trace_zsmul (C : Cycle) {n : ℤ} (hn : n ≠ 0) : trace (n • C) = tra
 def IsIn (C : Cycle) (Ω : Set ℂ) : Prop :=
   trace C ⊆ Ω
 
-/-- Restatement of cycle containment in terms of its trace. -/
-theorem isIn_iff {C : Cycle} {Ω : Set ℂ} : IsIn C Ω ↔ trace C ⊆ Ω :=
-  Iff.rfl
-
-/-- A raw curve bundled as a generator lies in `Ω` exactly when it maps its interval into `Ω`. -/
-@[simp]
+/-- A raw curve bundled as a one-generator cycle lies in `Ω` exactly when it maps its interval
+into `Ω`. -/
 theorem isIn_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
     (hclosed : γ a = γ b) (Ω : Set ℂ) :
-    MapsTo (PiecewiseC1ClosedCurve.of γ hγ hclosed)
-        (uIcc (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
-          (PiecewiseC1ClosedCurve.of γ hγ hclosed).b) Ω ↔
+    IsIn (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) Ω ↔
       MapsTo γ (uIcc a b) Ω := by
-  rw [Set.mapsTo_iff_image_subset, Set.mapsTo_iff_image_subset, trace_of_raw]
+  rw [IsIn, trace_of, ← Set.mapsTo_iff_image_subset,
+    PiecewiseC1ClosedCurve.mapsTo_of_iff]
 
 /-- A one-generator cycle lies in `Ω` exactly when its parametrization maps its interval into
 `Ω`. -/
@@ -206,7 +244,7 @@ theorem isIn_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
 /-- The zero cycle lies in every set. -/
 @[simp]
 theorem IsIn.zero (Ω : Set ℂ) : IsIn (0 : Cycle) Ω := by
-  simp [isIn_iff]
+  simp [IsIn]
 
 /-- A sum of two cycles in `Ω` is in `Ω`. -/
 theorem IsIn.add {C D : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (hD : IsIn D Ω) :
@@ -216,162 +254,79 @@ theorem IsIn.add {C D : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (hD : IsIn D Ω) 
 /-- Negation preserves containment in a set. -/
 @[simp]
 theorem isIn_neg_iff {C : Cycle} {Ω : Set ℂ} : IsIn (-C) Ω ↔ IsIn C Ω := by
-  simp [isIn_iff]
+  simp [IsIn]
 
 /-- Every integer multiple of a cycle in `Ω` is in `Ω`. -/
 theorem IsIn.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (n : ℤ) : IsIn (n • C) Ω := by
   by_cases hn : n = 0
   · subst n
     simpa only [zero_zsmul] using IsIn.zero Ω
-  · rw [isIn_iff, trace_zsmul C hn]
+  · rw [IsIn, trace_zsmul C hn]
     exact hC
 
 /-- The integral of `f` over a cycle, obtained by additively extending the raw contour integral
 `∫ t in γ.a..γ.b, deriv γ t • f (γ t)` from generators. -/
 def integral {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (C : Cycle) (f : ℂ → E) : E :=
+    (f : ℂ → E) : Cycle →+ E :=
   FreeAbelianGroup.lift
-    (fun γ : PiecewiseC1ClosedCurve ↦ ∫ t in γ.a..γ.b, deriv γ t • f (γ t)) C
+    fun γ : PiecewiseC1ClosedCurve ↦ ∫ t in γ.a..γ.b, deriv γ t • f (γ t)
 
-/-- Integrating over a raw curve bundled as a generator gives its raw contour integral. -/
-@[simp]
+/-- Integrating over a raw curve bundled as a one-generator cycle gives its raw contour integral. -/
 theorem integral_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
     (hclosed : γ a = γ b) {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     (f : ℂ → E) :
-    (∫ t in (PiecewiseC1ClosedCurve.of γ hγ hclosed).a..
-        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b,
-        deriv (PiecewiseC1ClosedCurve.of γ hγ hclosed) t •
-          f (PiecewiseC1ClosedCurve.of γ hγ hclosed t)) =
+    integral f (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) =
       ∫ t in a..b, deriv γ t • f (γ t) := by
-  change (∫ t in a..b, deriv (PiecewiseC1ClosedCurve.of γ hγ hclosed) t •
-    f (PiecewiseC1ClosedCurve.of γ hγ hclosed t)) = _
-  have heq : EqOn (PiecewiseC1ClosedCurve.of γ hγ hclosed) γ (uIoo a b) :=
-    fun _ ht ↦ PiecewiseC1ClosedCurve.of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
-  exact intervalIntegral.integral_congr_uIoo fun t ht ↦ by
-    rw [heq ht, heq.deriv isOpen_Ioo ht]
+  rw [integral, FreeAbelianGroup.lift_apply_of, PiecewiseC1ClosedCurve.integral_of]
 
 /-- Integrating over a one-generator cycle gives the raw contour integral over that curve. -/
 @[simp]
 theorem integral_of {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
     (γ : PiecewiseC1ClosedCurve) (f : ℂ → E) :
-    integral (FreeAbelianGroup.of γ) f =
+    integral f (FreeAbelianGroup.of γ) =
       ∫ t in γ.a..γ.b, deriv γ t • f (γ t) := by
   rw [integral, FreeAbelianGroup.lift_apply_of]
 
-/-- The integral over the zero cycle vanishes. -/
-@[simp]
-theorem integral_zero {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (f : ℂ → E) : integral 0 f = 0 :=
-  by rw [integral, map_zero]
-
-/-- The integral is additive in the cycle. -/
-@[simp]
-theorem integral_add {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (C D : Cycle) (f : ℂ → E) :
-    integral (C + D) f = integral C f + integral D f := by
-  simp only [integral, map_add]
-
-/-- Reversing every coefficient negates the integral. -/
-@[simp]
-theorem integral_neg {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (C : Cycle) (f : ℂ → E) : integral (-C) f = -integral C f := by
-  simp only [integral, map_neg]
-
-/-- The integral respects subtraction of cycles. -/
-@[simp]
-theorem integral_sub {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (C D : Cycle) (f : ℂ → E) :
-    integral (C - D) f = integral C f - integral D f := by
-  simp only [sub_eq_add_neg, integral_add, integral_neg]
-
-/-- The integral respects integer multiplicities. -/
-@[simp]
-theorem integral_zsmul {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E]
-    (n : ℤ) (C : Cycle) (f : ℂ → E) :
-    integral (n • C) f = n • integral C f := by
-  simp only [integral, map_zsmul]
-
 /-- The winding number of a cycle, obtained by additively extending the generalized winding number
 of its generators. -/
-def windingNumber (C : Cycle) (z₀ : ℂ) : ℂ :=
+def windingNumber (z₀ : ℂ) : Cycle →+ ℂ :=
   FreeAbelianGroup.lift
-    (fun γ : PiecewiseC1ClosedCurve ↦ TauCeti.Contour.windingNumber γ γ.a γ.b z₀) C
+    fun γ : PiecewiseC1ClosedCurve ↦ TauCeti.Contour.windingNumber γ γ.a γ.b z₀
 
-/-- The winding number of a raw curve bundled as a generator is its raw winding number. -/
-@[simp]
+/-- The winding number of a raw curve bundled as a one-generator cycle is its raw winding number. -/
 theorem windingNumber_of_raw {a b : ℝ} (γ : ℝ → ℂ) (hγ : IsPiecewiseC1On γ a b)
     (hclosed : γ a = γ b) (z₀ : ℂ) :
-    TauCeti.Contour.windingNumber (PiecewiseC1ClosedCurve.of γ hγ hclosed)
-        (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
-        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b z₀ =
+    windingNumber z₀ (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) =
       TauCeti.Contour.windingNumber γ a b z₀ := by
-  change TauCeti.Contour.windingNumber (PiecewiseC1ClosedCurve.of γ hγ hclosed) a b z₀ = _
-  apply TauCeti.Contour.windingNumber_congr_curve
-  intro t ht
-  exact PiecewiseC1ClosedCurve.of_apply γ hγ hclosed (uIoo_subset_uIcc_self ht)
+  rw [windingNumber, FreeAbelianGroup.lift_apply_of,
+    PiecewiseC1ClosedCurve.windingNumber_of]
 
 /-- The winding number of a one-generator cycle is the winding number of that curve. -/
 @[simp]
 theorem windingNumber_of (γ : PiecewiseC1ClosedCurve) (z₀ : ℂ) :
-    windingNumber (FreeAbelianGroup.of γ) z₀ =
+    windingNumber z₀ (FreeAbelianGroup.of γ) =
       TauCeti.Contour.windingNumber γ γ.a γ.b z₀ := by
   rw [windingNumber, FreeAbelianGroup.lift_apply_of]
-
-/-- The zero cycle has winding number zero. -/
-@[simp]
-theorem windingNumber_zero (z₀ : ℂ) : windingNumber 0 z₀ = 0 :=
-  by rw [windingNumber, map_zero]
-
-/-- The winding number is additive in the cycle. -/
-@[simp]
-theorem windingNumber_add (C D : Cycle) (z₀ : ℂ) :
-    windingNumber (C + D) z₀ = windingNumber C z₀ + windingNumber D z₀ := by
-  simp only [windingNumber, map_add]
-
-/-- Negating every coefficient negates the winding number. -/
-@[simp]
-theorem windingNumber_neg (C : Cycle) (z₀ : ℂ) :
-    windingNumber (-C) z₀ = -windingNumber C z₀ := by
-  simp only [windingNumber, map_neg]
-
-/-- The winding number respects subtraction of cycles. -/
-@[simp]
-theorem windingNumber_sub (C D : Cycle) (z₀ : ℂ) :
-    windingNumber (C - D) z₀ = windingNumber C z₀ - windingNumber D z₀ := by
-  simp only [sub_eq_add_neg, windingNumber_add, windingNumber_neg]
-
-/-- The winding number respects integer multiplicities. -/
-@[simp]
-theorem windingNumber_zsmul (n : ℤ) (C : Cycle) (z₀ : ℂ) :
-    windingNumber (n • C) z₀ = n • windingNumber C z₀ := by
-  simp only [windingNumber, map_zsmul]
 
 /-- A cycle is null-homologous in `Ω` when its winding number vanishes at every point outside
 `Ω`. -/
 def IsNullHomologous (C : Cycle) (Ω : Set ℂ) : Prop :=
-  ∀ z ∉ Ω, windingNumber C z = 0
+  ∀ z ∉ Ω, windingNumber z C = 0
 
-/-- Restatement of null-homology as vanishing of the cycle winding number outside the domain. -/
-theorem isNullHomologous_iff {C : Cycle} {Ω : Set ℂ} :
-    IsNullHomologous C Ω ↔ ∀ z ∉ Ω, windingNumber C z = 0 :=
-  Iff.rfl
-
-/-- Null-homology of a raw curve bundled as a generator is the raw-curve predicate. -/
-@[simp]
+/-- Null-homology of a raw curve bundled as a one-generator cycle is the raw-curve predicate. -/
 theorem isNullHomologous_of_raw_iff {a b : ℝ} (γ : ℝ → ℂ)
     (hγ : IsPiecewiseC1On γ a b) (hclosed : γ a = γ b) (Ω : Set ℂ) :
-    TauCeti.Contour.IsNullHomologous (PiecewiseC1ClosedCurve.of γ hγ hclosed)
-        (PiecewiseC1ClosedCurve.of γ hγ hclosed).a
-        (PiecewiseC1ClosedCurve.of γ hγ hclosed).b Ω ↔
+    IsNullHomologous (FreeAbelianGroup.of (PiecewiseC1ClosedCurve.of γ hγ hclosed)) Ω ↔
       TauCeti.Contour.IsNullHomologous γ a b Ω := by
-  simp only [TauCeti.Contour.isNullHomologous_iff, windingNumber_of_raw]
+  simp only [IsNullHomologous, windingNumber, FreeAbelianGroup.lift_apply_of,
+    PiecewiseC1ClosedCurve.windingNumber_of, TauCeti.Contour.isNullHomologous_iff]
 
 /-- Cycle null-homology specializes on a generator to the raw-curve predicate. -/
 @[simp]
 theorem isNullHomologous_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
     IsNullHomologous (FreeAbelianGroup.of γ) Ω ↔
       TauCeti.Contour.IsNullHomologous γ γ.a γ.b Ω := by
-  simp only [isNullHomologous_iff, windingNumber_of,
+  simp only [IsNullHomologous, windingNumber_of,
     TauCeti.Contour.isNullHomologous_iff]
 
 /-- The zero cycle is null-homologous in every set. -/
@@ -384,21 +339,21 @@ theorem IsNullHomologous.zero (Ω : Set ℂ) : IsNullHomologous (0 : Cycle) Ω :
 theorem IsNullHomologous.add {C D : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω)
     (hD : IsNullHomologous D Ω) : IsNullHomologous (C + D) Ω := by
   intro z hz
-  rw [windingNumber_add, hC z hz, hD z hz, add_zero]
+  rw [map_add, hC z hz, hD z hz, add_zero]
 
 /-- Negation preserves null-homology. -/
 @[simp]
 theorem isNullHomologous_neg_iff {C : Cycle} {Ω : Set ℂ} :
     IsNullHomologous (-C) Ω ↔ IsNullHomologous C Ω := by
   constructor <;> intro h z hz
-  · simpa only [windingNumber_neg, neg_eq_zero] using h z hz
-  · simpa only [windingNumber_neg, neg_eq_zero] using h z hz
+  · simpa only [map_neg, neg_eq_zero] using h z hz
+  · simpa only [map_neg, neg_eq_zero] using h z hz
 
 /-- Every integer multiple of a null-homologous cycle is null-homologous. -/
 theorem IsNullHomologous.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω) (n : ℤ) :
     IsNullHomologous (n • C) Ω := by
   intro z hz
-  rw [windingNumber_zsmul, hC z hz, smul_zero]
+  rw [map_zsmul, hC z hz, smul_zero]
 
 end Cycle
 

--- a/TauCeti/Analysis/Contour/Cycle/Basic.lean
+++ b/TauCeti/Analysis/Contour/Cycle/Basic.lean
@@ -1,0 +1,305 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.FreeAbelianGroup.Finsupp
+public import TauCeti.Analysis.Contour.PiecewiseC1On
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
+
+/-!
+# Cycles of piecewise-`C¹` curves
+
+A contour cycle is a finite formal `ℤ`-linear combination of closed piecewise-`C¹` curves. This
+file packages that definition as the free abelian group on parametrized closed curves and extends
+the contour integral and winding number additively from curves to cycles.
+
+Individual curves remain raw functions on real intervals, as elsewhere in the contour library. The
+small `PiecewiseC1ClosedCurve` bundle exists only because `FreeAbelianGroup` needs a type of
+generators; it records exactly a function, its oriented parameter interval, its regularity, and its
+closedness. In particular, it does not introduce a second notion of contour integral.
+
+The geometric trace of a cycle is the union of the images of the generators with nonzero
+coefficient. Thus cancellation removes a curve from the trace, just as it removes that curve's
+contribution to every additive invariant.
+
+## Main definitions
+
+* `TauCeti.Contour.PiecewiseC1ClosedCurve` — a closed piecewise-`C¹` parametrized curve.
+* `TauCeti.Contour.Cycle` — the free abelian group on such curves.
+* `TauCeti.Contour.Cycle.trace` — the geometric trace of a cycle.
+* `TauCeti.Contour.Cycle.integral` — the additive extension of the contour integral.
+* `TauCeti.Contour.Cycle.windingNumber` — the additive extension of the winding number.
+* `TauCeti.Contour.Cycle.IsIn` and `TauCeti.Contour.Cycle.IsNullHomologous` — the cycle-level
+  domain and null-homology predicates.
+
+## References
+
+* N. Hungerbühler and M. Wasem, *Non-integer valued winding numbers and a generalized Residue
+  Theorem*, Definition 2.1 and Theorem 3.3.
+* L. Ahlfors, *Complex Analysis*, Chapter 4.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set intervalIntegral
+
+namespace TauCeti.Contour
+
+/-- A parametrized closed piecewise-`C¹` curve on an oriented real interval. The function is kept
+on `ℝ`, rather than restricted to the interval, so all existing raw-function contour results apply
+directly. -/
+@[ext]
+structure PiecewiseC1ClosedCurve where
+  /-- The parametrization of the curve. -/
+  toFun : ℝ → ℂ
+  /-- The initial parameter. -/
+  a : ℝ
+  /-- The terminal parameter. -/
+  b : ℝ
+  /-- Piecewise-`C¹` regularity on the parameter interval. -/
+  isPiecewiseC1On : IsPiecewiseC1On toFun a b
+  /-- The parametrization has equal endpoints. -/
+  source_eq_target : toFun a = toFun b
+
+namespace PiecewiseC1ClosedCurve
+
+instance : CoeFun PiecewiseC1ClosedCurve fun _ ↦ ℝ → ℂ :=
+  ⟨PiecewiseC1ClosedCurve.toFun⟩
+
+/-- The underlying parametrization is continuous on its parameter interval. -/
+theorem continuousOn (γ : PiecewiseC1ClosedCurve) : ContinuousOn γ (uIcc γ.a γ.b) :=
+  γ.isPiecewiseC1On.continuousOn
+
+/-- The derivative of a closed piecewise-`C¹` curve is interval-integrable. -/
+theorem intervalIntegrable_deriv (γ : PiecewiseC1ClosedCurve) :
+    IntervalIntegrable (fun t ↦ deriv γ t) volume γ.a γ.b :=
+  γ.isPiecewiseC1On.intervalIntegrable_deriv
+
+end PiecewiseC1ClosedCurve
+
+/-- A contour cycle is a finite formal `ℤ`-linear combination of closed piecewise-`C¹` curves. -/
+abbrev Cycle := FreeAbelianGroup PiecewiseC1ClosedCurve
+
+namespace Cycle
+
+/-- The geometric trace of a cycle: the union of the images of the curves occurring with nonzero
+coefficient. -/
+def trace (C : Cycle) : Set ℂ :=
+  ⋃ γ ∈ FreeAbelianGroup.support C, γ '' uIcc γ.a γ.b
+
+/-- Membership in the trace means membership in the image of a generator with nonzero
+coefficient. -/
+theorem mem_trace_iff {C : Cycle} {z : ℂ} :
+    z ∈ trace C ↔ ∃ γ ∈ FreeAbelianGroup.support C, z ∈ γ '' uIcc γ.a γ.b := by
+  simp only [trace, mem_iUnion, exists_prop]
+
+/-- The zero cycle has empty trace. -/
+@[simp]
+theorem trace_zero : trace (0 : Cycle) = ∅ := by
+  simp [trace]
+
+/-- The trace of a single generator is its image on its parameter interval. -/
+@[simp]
+theorem trace_of (γ : PiecewiseC1ClosedCurve) :
+    trace (FreeAbelianGroup.of γ) = γ '' uIcc γ.a γ.b := by
+  simp [trace]
+
+/-- Negating every coefficient does not change the trace. -/
+@[simp]
+theorem trace_neg (C : Cycle) : trace (-C) = trace C := by
+  simp [trace]
+
+/-- The trace of a sum is contained in the union of the traces. Equality can fail when a generator
+occurs with opposite coefficients and cancels. -/
+theorem trace_add_subset (C D : Cycle) : trace (C + D) ⊆ trace C ∪ trace D := by
+  classical
+  intro z hz
+  rw [mem_trace_iff] at hz
+  obtain ⟨γ, hγ, hz⟩ := hz
+  rcases Finset.mem_union.mp (FreeAbelianGroup.support_add C D hγ) with hγC | hγD
+  · exact Set.mem_union_left _ (mem_trace_iff.mpr ⟨γ, hγC, hz⟩)
+  · exact Set.mem_union_right _ (mem_trace_iff.mpr ⟨γ, hγD, hz⟩)
+
+/-- A nonzero integer multiple has the same trace as the original cycle. -/
+theorem trace_zsmul (C : Cycle) {n : ℤ} (hn : n ≠ 0) : trace (n • C) = trace C := by
+  simp [trace, hn]
+
+/-- A cycle lies in `Ω` when its geometric trace is contained in `Ω`. -/
+def IsIn (C : Cycle) (Ω : Set ℂ) : Prop :=
+  trace C ⊆ Ω
+
+/-- Restatement of cycle containment in terms of its trace. -/
+theorem isIn_iff {C : Cycle} {Ω : Set ℂ} : IsIn C Ω ↔ trace C ⊆ Ω :=
+  Iff.rfl
+
+/-- A one-generator cycle lies in `Ω` exactly when its parametrization maps its interval into
+`Ω`. -/
+@[simp]
+theorem isIn_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
+    IsIn (FreeAbelianGroup.of γ) Ω ↔ MapsTo γ (uIcc γ.a γ.b) Ω := by
+  rw [isIn_iff, trace_of]
+  constructor
+  · intro h x hx
+    exact h ⟨x, hx, rfl⟩
+  · rintro h z ⟨x, hx, rfl⟩
+    exact h hx
+
+/-- The zero cycle lies in every set. -/
+@[simp]
+theorem IsIn.zero (Ω : Set ℂ) : IsIn (0 : Cycle) Ω := by
+  simp [isIn_iff]
+
+/-- A sum of two cycles in `Ω` is in `Ω`. -/
+theorem IsIn.add {C D : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (hD : IsIn D Ω) :
+    IsIn (C + D) Ω :=
+  (trace_add_subset C D).trans (union_subset hC hD)
+
+/-- Negation preserves containment in a set. -/
+@[simp]
+theorem isIn_neg_iff {C : Cycle} {Ω : Set ℂ} : IsIn (-C) Ω ↔ IsIn C Ω := by
+  simp [isIn_iff]
+
+/-- Every integer multiple of a cycle in `Ω` is in `Ω`. -/
+theorem IsIn.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsIn C Ω) (n : ℤ) : IsIn (n • C) Ω := by
+  by_cases hn : n = 0
+  · subst n
+    simpa only [zero_zsmul] using IsIn.zero Ω
+  · rw [isIn_iff, trace_zsmul C hn]
+    exact hC
+
+/-- The integral of `f` over a cycle, obtained by additively extending the raw contour integral
+`∫ t in γ.a..γ.b, deriv γ t • f (γ t)` from generators. -/
+def integral (C : Cycle) (f : ℂ → ℂ) : ℂ :=
+  FreeAbelianGroup.lift
+    (fun γ : PiecewiseC1ClosedCurve ↦ ∫ t in γ.a..γ.b, deriv γ t • f (γ t)) C
+
+/-- Integrating over a one-generator cycle gives the raw contour integral over that curve. -/
+@[simp]
+theorem integral_of (γ : PiecewiseC1ClosedCurve) (f : ℂ → ℂ) :
+    integral (FreeAbelianGroup.of γ) f =
+      ∫ t in γ.a..γ.b, deriv γ t • f (γ t) := by
+  rw [integral, FreeAbelianGroup.lift_apply_of]
+
+/-- The integral over the zero cycle vanishes. -/
+@[simp]
+theorem integral_zero (f : ℂ → ℂ) : integral 0 f = 0 :=
+  by rw [integral, map_zero]
+
+/-- The integral is additive in the cycle. -/
+@[simp]
+theorem integral_add (C D : Cycle) (f : ℂ → ℂ) :
+    integral (C + D) f = integral C f + integral D f := by
+  simp only [integral, map_add]
+
+/-- Reversing every coefficient negates the integral. -/
+@[simp]
+theorem integral_neg (C : Cycle) (f : ℂ → ℂ) : integral (-C) f = -integral C f := by
+  simp only [integral, map_neg]
+
+/-- The integral respects subtraction of cycles. -/
+@[simp]
+theorem integral_sub (C D : Cycle) (f : ℂ → ℂ) :
+    integral (C - D) f = integral C f - integral D f := by
+  simp only [sub_eq_add_neg, integral_add, integral_neg]
+
+/-- The integral respects integer multiplicities. -/
+@[simp]
+theorem integral_zsmul (n : ℤ) (C : Cycle) (f : ℂ → ℂ) :
+    integral (n • C) f = n • integral C f := by
+  simp only [integral, map_zsmul]
+
+/-- The winding number of a cycle, obtained by additively extending the generalized winding number
+of its generators. -/
+def windingNumber (C : Cycle) (z₀ : ℂ) : ℂ :=
+  FreeAbelianGroup.lift
+    (fun γ : PiecewiseC1ClosedCurve ↦ TauCeti.Contour.windingNumber γ γ.a γ.b z₀) C
+
+/-- The winding number of a one-generator cycle is the winding number of that curve. -/
+@[simp]
+theorem windingNumber_of (γ : PiecewiseC1ClosedCurve) (z₀ : ℂ) :
+    windingNumber (FreeAbelianGroup.of γ) z₀ =
+      TauCeti.Contour.windingNumber γ γ.a γ.b z₀ := by
+  rw [windingNumber, FreeAbelianGroup.lift_apply_of]
+
+/-- The zero cycle has winding number zero. -/
+@[simp]
+theorem windingNumber_zero (z₀ : ℂ) : windingNumber 0 z₀ = 0 :=
+  by rw [windingNumber, map_zero]
+
+/-- The winding number is additive in the cycle. -/
+@[simp]
+theorem windingNumber_add (C D : Cycle) (z₀ : ℂ) :
+    windingNumber (C + D) z₀ = windingNumber C z₀ + windingNumber D z₀ := by
+  simp only [windingNumber, map_add]
+
+/-- Negating every coefficient negates the winding number. -/
+@[simp]
+theorem windingNumber_neg (C : Cycle) (z₀ : ℂ) :
+    windingNumber (-C) z₀ = -windingNumber C z₀ := by
+  simp only [windingNumber, map_neg]
+
+/-- The winding number respects subtraction of cycles. -/
+@[simp]
+theorem windingNumber_sub (C D : Cycle) (z₀ : ℂ) :
+    windingNumber (C - D) z₀ = windingNumber C z₀ - windingNumber D z₀ := by
+  simp only [sub_eq_add_neg, windingNumber_add, windingNumber_neg]
+
+/-- The winding number respects integer multiplicities. -/
+@[simp]
+theorem windingNumber_zsmul (n : ℤ) (C : Cycle) (z₀ : ℂ) :
+    windingNumber (n • C) z₀ = n • windingNumber C z₀ := by
+  simp only [windingNumber, map_zsmul]
+
+/-- A cycle is null-homologous in `Ω` when its winding number vanishes at every point outside
+`Ω`. -/
+def IsNullHomologous (C : Cycle) (Ω : Set ℂ) : Prop :=
+  ∀ z ∉ Ω, windingNumber C z = 0
+
+/-- Restatement of null-homology as vanishing of the cycle winding number outside the domain. -/
+theorem isNullHomologous_iff {C : Cycle} {Ω : Set ℂ} :
+    IsNullHomologous C Ω ↔ ∀ z ∉ Ω, windingNumber C z = 0 :=
+  Iff.rfl
+
+/-- Cycle null-homology specializes on a generator to the raw-curve predicate. -/
+@[simp]
+theorem isNullHomologous_of_iff {γ : PiecewiseC1ClosedCurve} {Ω : Set ℂ} :
+    IsNullHomologous (FreeAbelianGroup.of γ) Ω ↔
+      TauCeti.Contour.IsNullHomologous γ γ.a γ.b Ω := by
+  simp only [isNullHomologous_iff, windingNumber_of,
+    TauCeti.Contour.isNullHomologous_iff]
+
+/-- The zero cycle is null-homologous in every set. -/
+@[simp]
+theorem IsNullHomologous.zero (Ω : Set ℂ) : IsNullHomologous (0 : Cycle) Ω := by
+  intro z hz
+  simp
+
+/-- A sum of null-homologous cycles is null-homologous. -/
+theorem IsNullHomologous.add {C D : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω)
+    (hD : IsNullHomologous D Ω) : IsNullHomologous (C + D) Ω := by
+  intro z hz
+  rw [windingNumber_add, hC z hz, hD z hz, add_zero]
+
+/-- Negation preserves null-homology. -/
+@[simp]
+theorem isNullHomologous_neg_iff {C : Cycle} {Ω : Set ℂ} :
+    IsNullHomologous (-C) Ω ↔ IsNullHomologous C Ω := by
+  constructor <;> intro h z hz
+  · simpa only [windingNumber_neg, neg_eq_zero] using h z hz
+  · simpa only [windingNumber_neg, neg_eq_zero] using h z hz
+
+/-- Every integer multiple of a null-homologous cycle is null-homologous. -/
+theorem IsNullHomologous.zsmul {C : Cycle} {Ω : Set ℂ} (hC : IsNullHomologous C Ω) (n : ℤ) :
+    IsNullHomologous (n • C) Ω := by
+  intro z hz
+  rw [windingNumber_zsmul, hC z hz, smul_zero]
+
+end Cycle
+
+end TauCeti.Contour
+
+end


### PR DESCRIPTION
This PR introduces contour cycles as finite formal `ℤ`-combinations of closed piecewise-`C¹` curves, together with the small additive interface needed by the cycle-level Cauchy and residue theorems. It adds the generator bundle `PiecewiseC1ClosedCurve`, the free abelian group `Cycle`, its geometric trace and containment predicate, and additive extensions of the raw interval contour integral, generalized winding number, and null-homology predicate.

It advances `TauCetiRoadmap/ContourIntegration/README.md`, the frontier item **“Cycles”** (“Everything is stated for a single closed curve on `[a, b]`. The roadmap's `ℤ`-combinations of closed curves are not yet a type, and both the residue theorems and HW Thm 3.3 would want them”), implementing the roadmap's standing convention that a cycle is a finite formal `ℤ`-combination of closed curves. This is the lowest-hanging distinct frontier target: integrality off the curve already landed in #828, the open #1787 owns the bounded-integrand direction, and the remaining HW Proposition 2.2 decomposition and regularity/homotopy weakenings require deeper analytic or geometric arguments.

The implementation reuses Mathlib's `FreeAbelianGroup`, `FreeAbelianGroup.lift`, and canonical finite-support API instead of building a parallel formal-sum type. Single-curve integration remains exactly the roadmap's raw interval integral `∫ t in a..b, deriv γ t • f (γ t)`; only its uniquely determined additive extension to a cycle is named. The trace is the union of the images of generators with nonzero canonical coefficient, so algebraic cancellation removes both a curve's trace and every additive contribution. The generator lemmas connect cycle containment and null-homology directly back to the existing raw-curve predicates.

No Mathlib infrastructure is vendored, and no external formalization is copied or adapted. The module credits Hungerbühler–Wasem, Definition 2.1 and Theorem 3.3, and Ahlfors, *Complex Analysis*, Chapter 4, for the cycle-level mathematical context.

`lake exe cache get` completes successfully (`Completed successfully in 795 ms!`). `lake build` reports `Build completed successfully (6243 jobs).` `lake exe axioms` reports `axioms: audited 20336 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: ContourIntegration

<!--tauceti-target:v1 {"focus":"ContourIntegration","id":"cycles"}-->

🤖 Prepared with Codex
