### PR TITLE
feat: recover subgroup from universal-cover quotient

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -36,6 +36,9 @@ The inverse-free computation rule is `inv_smul_mk`.
 
 * The `MulAction`, `FaithfulSMul`, `ContinuousConstSMul`, and `IsCancelSMul` instances for
   `FundamentalGroup X x₀` acting on `UniversalCover x₀`.
+* `TauCeti.UniversalCover.basepointLift`: the constant-path point over `x₀`.
+* `TauCeti.UniversalCover.monodromy_basepointLift`: monodromy at that point is the
+  fundamental-group action by the inverse loop class.
 * `TauCeti.UniversalCover.proj_eq_iff_mem_orbit`: the fibres of `proj` are precisely the
   action orbits.
 * `TauCeti.UniversalCover.isQuotientCoveringMap`: `proj` is the quotient covering map for
@@ -157,5 +160,57 @@ theorem isQuotientCoveringMap [LocallyPathConnectedSpace X] [PathConnectedSpace 
   rw [isQuotientCoveringMap_iff_isCoveringMap_and]
   exact
     ⟨isCoveringMap x₀, proj_surjective, inferInstance, inferInstance, proj_eq_iff_mem_orbit⟩
+
+/-- The constant-path point in the fibre of the universal covering projection over `x₀`. -/
+def basepointLift (x₀ : X) : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} :=
+  ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)),
+    Set.mem_singleton_iff.mpr (by
+      rw [proj_ofBasedPath]
+      exact BasedPath.endpoint_ofPath _)⟩
+
+/-- The underlying point of `basepointLift` is represented by the constant path. -/
+@[simp]
+theorem basepointLift_coe (x₀ : X) :
+    (basepointLift x₀ : UniversalCover x₀) =
+      mk x₀ (Path.Homotopic.Quotient.refl x₀) := by
+  simp only [basepointLift]
+  rw [ofBasedPath_ofPath, Path.Homotopic.Quotient.mk_refl]
+
+/-- Monodromy of the universal covering projection at its constant-path basepoint is the
+fundamental-group action by the inverse loop class. -/
+theorem monodromy_basepointLift [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X] (x₀ : X) (g : FundamentalGroup X x₀) :
+    ((isCoveringMap x₀).monodromy g.toPath (basepointLift x₀) : UniversalCover x₀) =
+      g⁻¹ • (basepointLift x₀ : UniversalCover x₀) := by
+  obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
+  rw [← hγ]
+  -- Unfolding monodromy after choosing `γ` exposes the endpoint of its lifted path.
+  change (isCoveringMap x₀).liftPath γ
+      (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
+  let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
+    γ.cast (BasedPath.endpoint_ofPath _) rfl
+  calc
+    _ = (isCoveringMap x₀).liftPath δ
+        (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 := by
+      congr 1
+    _ = ofBasedPath x₀ (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ) :=
+      liftPath_apply_one_eq_ofBasedPath_append δ
+    _ = g⁻¹ • (basepointLift x₀ : UniversalCover x₀) := by
+      rw [basepointLift_coe, inv_smul_mk]
+      rw [ofBasedPath_def]
+      let hend := BasedPath.endpoint_append (BasedPath.ofPath (Path.refl x₀)) δ
+      apply UniversalCover.ext hend
+      have hcast : HEq
+          (Path.Homotopic.Quotient.mk
+            (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ).toPath)
+          (Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ)) :=
+        Path.Homotopic.hpath_hext (fun _ ↦ rfl)
+      refine hcast.trans (heq_of_eq ?_)
+      -- The `HEq` has aligned the dependent endpoints; only quotient concatenation remains.
+      change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
+        g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
+      rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
+        Path.Homotopic.Quotient.refl_trans]
+      exact (Path.Homotopic.Quotient.trans_refl _).symm
 
 end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Action.lean
@@ -178,6 +178,7 @@ theorem basepointLift_coe (x₀ : X) :
 
 /-- Monodromy of the universal covering projection at its constant-path basepoint is the
 fundamental-group action by the inverse loop class. -/
+@[simp]
 theorem monodromy_basepointLift [LocallyPathConnectedSpace X] [PathConnectedSpace X]
     [SemilocallySimplyConnectedSpace X] (x₀ : X) (g : FundamentalGroup X x₀) :
     ((isCoveringMap x₀).monodromy g.toPath (basepointLift x₀) : UniversalCover x₀) =

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -85,10 +85,13 @@ theorem SubgroupQuotient.fundamentalGroupEquiv_unop_smul
     (g : FundamentalGroup (SubgroupQuotient x₀ H)
       (SubgroupQuotient.basepoint x₀ H)) :
     (SubgroupQuotient.fundamentalGroupEquiv x₀ H g).unop •
-        (SubgroupQuotient.basepointLift x₀ H : UniversalCover x₀) =
+        mk x₀ (Path.Homotopic.Quotient.refl x₀) =
       (isQuotientCoveringMap_subgroupQuotientMap x₀ H).isCoveringMap.monodromy g
-        (SubgroupQuotient.basepointLift x₀ H) :=
-  (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
+        (SubgroupQuotient.basepointLift x₀ H) := by
+  rw [← TauCeti.UniversalCover.basepointLift_coe,
+    ← SubgroupQuotient.basepointLift_coe]
+  exact
+    (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
 
 variable [LocallyPathConnectedSpace X] [PathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X]
@@ -193,10 +196,10 @@ theorem mapOfEq_subgroupQuotientProj_apply
     _ = ((isQuotientCoveringMap_subgroupQuotientMap x₀ H).isCoveringMap.monodromy g
         (SubgroupQuotient.basepointLift x₀ H) : UniversalCover x₀) :=
       monodromy_mapOfEq_subgroupQuotientProj x₀ H g
-    _ = h • (SubgroupQuotient.basepointLift x₀ H : UniversalCover x₀) := by
+    _ = h • mk x₀ (Path.Homotopic.Quotient.refl x₀) := by
       exact (SubgroupQuotient.fundamentalGroupEquiv_unop_smul x₀ H g).symm
     _ = h.1 • (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) := by
-      simp only [SubgroupQuotient.basepointLift_coe, Subgroup.smul_def]
+      simp only [TauCeti.UniversalCover.basepointLift_coe, Subgroup.smul_def]
 
 /-- The subgroup induced by the descended endpoint map is exactly the subgroup used to form
 the orbit quotient. -/

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -1,0 +1,221 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicTopology.UniversalCover.Classification.SubgroupQuotient
+
+/-!
+# The subgroup recovered from a universal-cover quotient
+
+For `H ≤ π₁(X, x₀)`, the orbit quotient `UniversalCover x₀ / H` has a distinguished
+point represented by the constant path. The quotient map from the universal cover is a quotient
+covering map with acting group `H`; since the universal cover is simply connected, this gives
+
+  `π₁(UniversalCover x₀ / H) ≃* Hᵐᵒᵖ`.
+
+The endpoint projection descends from the universal cover to the orbit quotient. This file
+computes its induced fundamental-group homomorphism and proves that its range is exactly `H`.
+The computation contains an inverse because the project uses a left action in which a loop class
+acts on the universal cover by prepending its inverse.
+
+This proves the subgroup-recovery part of `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2,
+item 7: for the pointed quotient associated to `H`, prove `p_*(π₁(–)) = H`. It reuses the
+fundamental-group action adapted from Kim Morrison's work in mathlib4#38292 and Mathlib's
+quotient-cover monodromy comparison due to Junyan Xu. No Mathlib code is vendored.
+
+## Main declarations
+
+* `TauCeti.UniversalCover.SubgroupQuotient.basepointLift`: the constant-path lift of the
+  distinguished quotient point.
+* `TauCeti.UniversalCover.SubgroupQuotient.fundamentalGroupEquiv` and
+  `TauCeti.UniversalCover.SubgroupQuotient.fundamentalGroupEquiv_unop_smul`: the fundamental
+  group of the quotient is the opposite of `H`, compatibly with monodromy.
+* `TauCeti.UniversalCover.mapOfEq_subgroupQuotientProj_apply`: the descended endpoint map sends
+  a quotient loop to the inverse of its corresponding element of `H`.
+* `TauCeti.UniversalCover.range_mapOfEq_subgroupQuotientProj`: the descended endpoint map
+  recovers exactly `H`.
+-/
+
+public section
+noncomputable section
+
+open Topology
+open scoped unitInterval
+
+variable {X : Type*} [TopologicalSpace X] (x₀ : X)
+
+namespace TauCeti.UniversalCover
+
+/-- The constant-path lift of the distinguished point of the subgroup quotient. -/
+def SubgroupQuotient.basepointLift (H : Subgroup (FundamentalGroup X x₀)) :
+    (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H} :=
+  ⟨TauCeti.UniversalCover.basepointLift x₀, by
+    rw [Set.mem_preimage, Set.mem_singleton_iff, subgroupQuotientMap_apply,
+      SubgroupQuotient.basepoint_eq_mk, TauCeti.UniversalCover.basepointLift_coe]⟩
+
+/-- The underlying universal-cover point of the distinguished lift is the constant-path
+point. -/
+@[simp]
+theorem SubgroupQuotient.basepointLift_coe (H : Subgroup (FundamentalGroup X x₀)) :
+    (SubgroupQuotient.basepointLift x₀ H : UniversalCover x₀) =
+      (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) := by
+  simp [SubgroupQuotient.basepointLift]
+
+/-- The fundamental group of the subgroup quotient at its distinguished point is the opposite
+of the acting subgroup. The opposite records the left-action convention used by quotient-cover
+monodromy. -/
+noncomputable def SubgroupQuotient.fundamentalGroupEquiv
+    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X]
+    (H : Subgroup (FundamentalGroup X x₀)) :
+    FundamentalGroup (SubgroupQuotient x₀ H)
+        (SubgroupQuotient.basepoint x₀ H) ≃* Hᵐᵒᵖ :=
+  (isQuotientCoveringMap_subgroupQuotientMap x₀ H).fundamentalGroupEquiv
+    (SubgroupQuotient.basepointLift x₀ H)
+
+/-- The subgroup element assigned to a quotient loop moves the distinguished lift to the
+endpoint of that loop's monodromy lift. -/
+@[simp]
+theorem SubgroupQuotient.fundamentalGroupEquiv_unop_smul
+    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+    [SemilocallySimplyConnectedSpace X]
+    (H : Subgroup (FundamentalGroup X x₀))
+    (g : FundamentalGroup (SubgroupQuotient x₀ H)
+      (SubgroupQuotient.basepoint x₀ H)) :
+    (SubgroupQuotient.fundamentalGroupEquiv x₀ H g).unop •
+        (SubgroupQuotient.basepointLift x₀ H : UniversalCover x₀) =
+      (isQuotientCoveringMap_subgroupQuotientMap x₀ H).isCoveringMap.monodromy g
+        (SubgroupQuotient.basepointLift x₀ H) :=
+  (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
+
+variable [LocallyPathConnectedSpace X] [PathConnectedSpace X]
+  [SemilocallySimplyConnectedSpace X]
+
+/-- Monodromy along the quotient map followed by the descended endpoint map agrees with
+monodromy of the universal-cover projection. -/
+private theorem monodromy_mapOfEq_subgroupQuotientProj
+    (H : Subgroup (FundamentalGroup X x₀))
+    (g : FundamentalGroup (SubgroupQuotient x₀ H)
+      (SubgroupQuotient.basepoint x₀ H)) :
+    ((isCoveringMap x₀).monodromy
+        (FundamentalGroup.mapOfEq
+          ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+          (subgroupQuotientProj_basepoint x₀ H) g)
+        (TauCeti.UniversalCover.basepointLift x₀) : UniversalCover x₀) =
+      ((isQuotientCoveringMap_subgroupQuotientMap x₀ H).isCoveringMap.monodromy g
+        (SubgroupQuotient.basepointLift x₀ H) : UniversalCover x₀) := by
+  let hq := isQuotientCoveringMap_subgroupQuotientMap x₀ H
+  let e := SubgroupQuotient.basepointLift x₀ H
+  have he : (e : UniversalCover x₀) =
+      (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) := by
+    dsimp only [e]
+    rw [SubgroupQuotient.basepointLift_coe]
+  let e' := hq.isCoveringMap.monodromy g e
+  have he'_basepoint : subgroupQuotientMap x₀ H e' =
+      SubgroupQuotient.basepoint x₀ H := by
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e'.2
+  have he' : proj (e' : UniversalCover x₀) = x₀ := by
+    calc
+      proj (e' : UniversalCover x₀) =
+          subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e') := by
+            exact congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e' |>.symm
+      _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by
+            rw [he'_basepoint]
+      _ = x₀ := subgroupQuotientProj_basepoint x₀ H
+  let e'' : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} := ⟨e', he'⟩
+  -- Lift `g` through the quotient map, then map that same lifted path through the descended
+  -- endpoint map; the commuting triangle identifies it as the universal-cover lift.
+  have hmon : (isCoveringMap x₀).monodromy
+      (FundamentalGroup.mapOfEq
+        ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+        (subgroupQuotientProj_basepoint x₀ H) g)
+      (TauCeti.UniversalCover.basepointLift x₀) = e'' := by
+    let Γ := (hq.isCoveringMap.liftPathQuotient g e).cast he.symm rfl
+    apply (isCoveringMap x₀).monodromy_eq_of_map_eq
+      Γ
+    rw [FundamentalGroup.mapOfEq_apply]
+    let r : C(SubgroupQuotient x₀ H, X) :=
+      ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+    let q : C(UniversalCover x₀, SubgroupQuotient x₀ H) :=
+      ⟨subgroupQuotientMap x₀ H, hq.continuous⟩
+    dsimp only [Γ]
+    rw [Path.Homotopic.Quotient.map_cast]
+    have hmapped := congrArg (fun δ ↦ δ.map r)
+      (hq.isCoveringMap.map_liftPathQuotient g e)
+    rw [← Path.Homotopic.Quotient.map_comp] at hmapped
+    erw [Path.Homotopic.Quotient.map_cast] at hmapped
+    -- The four conversion goals reconcile the dependent endpoint casts; their pointwise
+    -- equalities all come from `subgroupQuotientProj ∘ subgroupQuotientMap = proj`.
+    convert hmapped using 2
+    · calc
+        proj (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) =
+            proj (e : UniversalCover x₀) :=
+          congrArg proj he.symm
+        _ = subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
+          congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
+    · exact congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e' |>.symm
+    · induction hΓ : hq.isCoveringMap.liftPathQuotient g e using Quotient.inductionOn with
+      | h Γ =>
+        apply Path.Homotopic.hpath_hext
+        intro t
+        exact congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) (Γ t) |>.symm
+    · erw [Path.Homotopic.Quotient.cast_cast]
+      exact (Path.Homotopic.Quotient.cast_heq _ _).trans
+        (Path.Homotopic.Quotient.cast_heq _ _).symm
+  exact congrArg Subtype.val hmon
+
+/-- The descended endpoint map sends a quotient loop to the inverse of the corresponding
+element of the acting subgroup. The inverse is forced by the left-action convention. -/
+@[simp]
+theorem mapOfEq_subgroupQuotientProj_apply
+    (H : Subgroup (FundamentalGroup X x₀))
+    (g : FundamentalGroup (SubgroupQuotient x₀ H)
+      (SubgroupQuotient.basepoint x₀ H)) :
+    FundamentalGroup.mapOfEq
+        ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+        (subgroupQuotientProj_basepoint x₀ H) g =
+      ((SubgroupQuotient.fundamentalGroupEquiv x₀ H g).unop.1)⁻¹ := by
+  let f := FundamentalGroup.mapOfEq
+    ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+    (subgroupQuotientProj_basepoint x₀ H) g
+  let h := (SubgroupQuotient.fundamentalGroupEquiv x₀ H g).unop
+  apply inv_injective
+  rw [inv_inv]
+  apply IsCancelSMul.right_cancel _ _
+    (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀)
+  calc
+    f⁻¹ • (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) =
+        ((isCoveringMap x₀).monodromy f (TauCeti.UniversalCover.basepointLift x₀) :
+          UniversalCover x₀) :=
+      (monodromy_basepointLift x₀ f).symm
+    _ = ((isQuotientCoveringMap_subgroupQuotientMap x₀ H).isCoveringMap.monodromy g
+        (SubgroupQuotient.basepointLift x₀ H) : UniversalCover x₀) :=
+      monodromy_mapOfEq_subgroupQuotientProj x₀ H g
+    _ = h • (SubgroupQuotient.basepointLift x₀ H : UniversalCover x₀) := by
+      exact (SubgroupQuotient.fundamentalGroupEquiv_unop_smul x₀ H g).symm
+    _ = h.1 • (TauCeti.UniversalCover.basepointLift x₀ : UniversalCover x₀) := by
+      simp only [SubgroupQuotient.basepointLift_coe, Subgroup.smul_def]
+
+/-- The subgroup induced by the descended endpoint map is exactly the subgroup used to form
+the orbit quotient. -/
+theorem range_mapOfEq_subgroupQuotientProj
+    (H : Subgroup (FundamentalGroup X x₀)) :
+    (FundamentalGroup.mapOfEq
+      (x := SubgroupQuotient.basepoint x₀ H) (y := x₀)
+      ⟨subgroupQuotientProj x₀ H, continuous_subgroupQuotientProj x₀ H⟩
+      (subgroupQuotientProj_basepoint x₀ H)).range = H := by
+  ext g
+  constructor
+  · rintro ⟨γ, rfl⟩
+    rw [mapOfEq_subgroupQuotientProj_apply]
+    exact H.inv_mem (SubgroupQuotient.fundamentalGroupEquiv x₀ H γ).unop.2
+  · intro hg
+    let h : H := ⟨g⁻¹, H.inv_mem hg⟩
+    refine ⟨(SubgroupQuotient.fundamentalGroupEquiv x₀ H).symm
+      (MulOpposite.op h), ?_⟩
+    rw [mapOfEq_subgroupQuotientProj_apply, MulEquiv.apply_symm_apply]
+    exact inv_inv g
+
+end TauCeti.UniversalCover

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -15,8 +15,9 @@ cover and proves that this map is a quotient covering map. The class of the cons
 supplies its distinguished point.
 
 This is the first construction step in the subgroup-to-cover direction of the classification
-of covering spaces. This file descends `UniversalCover.proj` to the quotient; a later file will
-prove that the descended map is a covering map and identify the subgroup it recovers.
+of covering spaces. This file descends `UniversalCover.proj` to the quotient;
+`Classification.RecoveredSubgroup` identifies the subgroup recovered by that map, while a later
+file will prove that the descended map is a covering map.
 
 ## Main declarations
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Deck/FundamentalGroup/UniversalCover.lean
@@ -92,20 +92,6 @@ lemma loopDeckHom_apply (g : FundamentalGroup X x₀) :
     loopDeckHom x₀ g = loopDeck x₀ g :=
   (rfl)
 
-/-- The constant-path lift of the basepoint, regarded as a point of the fibre over the
-basepoint. -/
-private def reflFiberPoint : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} :=
-  ⟨ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)),
-    Set.mem_singleton_iff.mpr (by
-      rw [proj_ofBasedPath]
-      exact BasedPath.endpoint_ofPath _)⟩
-
-@[simp]
-private lemma reflFiberPoint_val :
-    (reflFiberPoint x₀ : UniversalCover x₀) =
-      ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) :=
-  rfl
-
 /-- The endpoint projection of the universal cover has regular deck action. -/
 theorem isRegular_proj [PathConnectedSpace X] :
     Deck.IsRegular (proj : UniversalCover x₀ → X) := by
@@ -123,48 +109,7 @@ noncomputable def deckFundamentalGroupEquiv
     [SemilocallySimplyConnectedSpace X] :
     Deck (proj : UniversalCover x₀ → X) ≃* (FundamentalGroup X x₀)ᵐᵒᵖ :=
   (isRegular_proj x₀).deckFundamentalGroupEquiv (isCoveringMap x₀)
-    (reflFiberPoint x₀)
-
-private lemma monodromy_reflFiberPoint
-    [LocallyPathConnectedSpace X] [PathConnectedSpace X]
-    [SemilocallySimplyConnectedSpace X]
-    (g : FundamentalGroup X x₀) :
-    ((isCoveringMap x₀).monodromy g.toPath (reflFiberPoint x₀) :
-      UniversalCover x₀) =
-      g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
-  obtain ⟨γ, hγ⟩ := Quotient.exists_rep g.toPath
-  rw [← hγ]
-  -- `monodromy` is defined by quotient-lifting the endpoint of `liftPath`; unfolding it
-  -- after choosing the representative `γ` exposes exactly that defining computation.
-  change (isCoveringMap x₀).liftPath γ
-      (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 = _
-  let δ : Path (BasedPath.endpoint (BasedPath.ofPath (Path.refl x₀))) x₀ :=
-    γ.cast (BasedPath.endpoint_ofPath _) rfl
-  calc
-    _ = (isCoveringMap x₀).liftPath δ
-        (ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀))) _ 1 := by
-      congr 1
-    _ = ofBasedPath x₀ (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ) :=
-      liftPath_apply_one_eq_ofBasedPath_append δ
-    _ = g⁻¹ • ofBasedPath x₀ (BasedPath.ofPath (Path.refl x₀)) := by
-      rw [ofBasedPath_ofPath, Path.Homotopic.Quotient.mk_refl, inv_smul_mk]
-      rw [ofBasedPath_def]
-      let hend := BasedPath.endpoint_append (BasedPath.ofPath (Path.refl x₀)) δ
-      apply UniversalCover.ext hend
-      have hcast : HEq
-          (Path.Homotopic.Quotient.mk
-            (BasedPath.append (BasedPath.ofPath (Path.refl x₀)) δ).toPath)
-          (Path.Homotopic.Quotient.mk
-            ((Path.refl x₀).trans γ)) :=
-        Path.Homotopic.hpath_hext (fun _ ↦ rfl)
-      refine hcast.trans (heq_of_eq ?_)
-      -- The preceding `HEq` has aligned the dependent path endpoints.  What remains is
-      -- its underlying quotient equality, whose displayed types differ only by those casts.
-      change Path.Homotopic.Quotient.mk ((Path.refl x₀).trans γ) =
-        g.toPath.trans (Path.Homotopic.Quotient.refl x₀)
-      rw [← hγ, Path.Homotopic.Quotient.mk_trans, Path.Homotopic.Quotient.mk_refl,
-        Path.Homotopic.Quotient.refl_trans]
-      exact (Path.Homotopic.Quotient.trans_refl _).symm
+    (basepointLift x₀)
 
 /-- The inverse deck-to-fundamental-group equivalence recovers the explicit loop deck
 transformation, with the inverse forced by the left-action convention. -/
@@ -176,13 +121,13 @@ lemma deckFundamentalGroupEquiv_symm_op
     (deckFundamentalGroupEquiv x₀).symm (MulOpposite.op g) = loopDeck x₀ g⁻¹ := by
   apply (Deck.IsRegular.deckFundamentalGroupEquiv_symm_op_eq_iff
     (isRegular_proj x₀) (isCoveringMap x₀)
-      (reflFiberPoint x₀)
+      (basepointLift x₀)
       g (loopDeck x₀ g⁻¹)).2
   -- Display the fundamental-group coercion and the chosen fibre point explicitly so the
-  -- named monodromy calculation above applies without unfolding either wrapper.
-  change ((isCoveringMap x₀).monodromy g.toPath (reflFiberPoint x₀) :
-    UniversalCover x₀) = (loopDeck x₀ g⁻¹).1 (reflFiberPoint x₀)
-  simpa only [Deck.smul_eq_apply, loopDeck_apply, reflFiberPoint_val] using
-    monodromy_reflFiberPoint x₀ g
+  -- named monodromy calculation from `UniversalCover.Action` applies without unfolding either
+  -- wrapper.
+  change ((isCoveringMap x₀).monodromy g.toPath (basepointLift x₀) :
+    UniversalCover x₀) = (loopDeck x₀ g⁻¹).1 (basepointLift x₀)
+  simpa only [Deck.smul_eq_apply, loopDeck_apply] using monodromy_basepointLift x₀ g
 
 end TauCeti.UniversalCover


### PR DESCRIPTION
This PR identifies the subgroup recovered by the descended endpoint map from `UniversalCover x₀ / H`: it constructs the canonical lifted basepoint, identifies the quotient fundamental group with `Hᵐᵒᵖ`, computes the convention-sensitive induced map as inversion, and proves its range is exactly `H`.

It advances `TauCetiRoadmap/UniversalCovers/README.md`, Stage 2, item 7, “Cover associated to `H ≤ π₁(X, x₀)`”, specifically the target “prove `p_*(π₁(–)) = H` for that pointed cover.”

To keep the proof reusable, it moves the existing constant-path monodromy calculation from a private deck-group helper into `UniversalCover.Action`, exposes its canonical basepoint lift and computation lemma, and updates the existing deck equivalence to consume that API. This extraction is used directly by the subgroup-recovery calculation in the same PR.

The proof reuses Mathlib's `IsQuotientCoveringMap.fundamentalGroupEquiv`, `unop_fundamentalGroupToMulOpposite_smul`, and `IsCoveringMap.monodromy_eq_of_map_eq` infrastructure due to Junyan Xu. It also builds on the existing fundamental-group action adapted from Kim Morrison's mathlib4#38292 work. No Mathlib code is vendored.

The final tree passes `lake exe cache get`, `lake build`, and `lake exe axioms`.

Roadmap: UniversalCovers

<!--tauceti-target:v1 {"focus":"UniversalCovers","id":"range-mapofeq-subgroupquotientproj"}-->

🤖 Prepared with Codex
