### PR TITLE
feat: precomposition of counit-valued derivations along a bialgebra morphism

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -20,9 +20,13 @@ therefore comes from those two facts and is not reproved here.
 ## Main declarations
 
 * `TauCeti.derivationComp`: precomposition of counit-valued derivations along a
-  bialgebra morphism.
-* `TauCeti.derivationComp_apply`: it acts by precomposition.
-The intertwining with the tangent dictionaries is
+  bialgebra morphism, as an `R`-linear map — the derivation form of the differential.
+* `TauCeti.derivationComp_apply`, `TauCeti.derivationComp_id`,
+  `TauCeti.derivationComp_comp`: it acts by precomposition, functorially.
+
+(`TauCeti.derivationCompAux` is the underlying construction; the module system does
+not allow a public definition to have a private body, so it is public but carries no
+API — use `derivationComp`.) The intertwining with the tangent dictionaries is
 `TauCeti.tangentKerMap_derivationMulEquivTangentKer` in
 `TauCeti.Algebra.AlgebraicGroup.Tangent.Map`.
 -/
@@ -39,12 +43,11 @@ variable {R A A' B : Type*} [CommSemiring R]
   [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
   [Semiring B] [Algebra R B]
 
-/-- Precomposition of a counit-valued derivation with a bialgebra morphism: the map
-sending an `R`-derivation `d : A → B` at the identity point of `A` to the derivation
-`a ↦ d (φ a)` at the identity point of `A'` — the additive form of the differential.
-
-(The commutativity hypotheses on `A` and `A'` are those of `Derivation` itself.) -/
-noncomputable def derivationComp (φ : A' →ₐc[R] A)
+/-- Implementation of `derivationComp`: the underlying function on derivations. Use
+the bundled `derivationComp` — this definition carries no API. (It cannot be
+`private`: the module system does not allow the public bundled map to have a private
+body.) -/
+noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     Derivation R A' (Bialgebra.CounitAlgebra R A' B) := by
   letI : Algebra A' A := (φ : A' →ₐ[R] A).toAlgebra
@@ -53,17 +56,27 @@ noncomputable def derivationComp (φ : A' →ₐc[R] A)
     (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B)).comp (φ : A' →ₐ[R] A)
   letI : Algebra A' (Bialgebra.CounitAlgebra R A B) := ρ.toRingHom.toAlgebra'
     (fun a x => by
-      -- `ρ` factors through `algebraMap R _`, whose image is central.
+      -- The centrality obligation of `toAlgebra'` arrives phrased through `RingHom`
+      -- coercions of `ρ`; no rewrite lemma applies to that shape, since it is
+      -- definitional to this construction, so `change` restates it once.
       change ρ a * x = x * ρ a
       rw [show ρ a = algebraMap R (Bialgebra.CounitAlgebra R A B)
           (counit (R := R) ((φ : A' →ₐ[R] A) a)) from by
         simp [ρ, IsScalarTower.coe_toAlgHom',
           Bialgebra.CounitAlgebra.algebraMap_apply R A B]
+        -- The residual is the definitional identification of the coefficient synonym
+        -- with `B` itself, which `simp` exposes but no lemma states.
         rfl]
       exact Algebra.commutes _ x)
   letI : IsScalarTower R A' (Bialgebra.CounitAlgebra R A B) :=
     IsScalarTower.of_algebraMap_eq fun r => by
+      -- The goal is stated through the `letI` algebra structure just installed, whose
+      -- `algebraMap` is definitionally `ρ`; no global lemma can name a local
+      -- instance, so `change` performs that definitional unfolding once.
       change algebraMap R (Bialgebra.CounitAlgebra R A B) r = ρ (algebraMap R A' r)
+      -- `ρ` is a `let`-bound composite, so its value at `algebraMap R A' r` has no
+      -- equation lemma; the `show … from` states the one unfolding-and-`commutes`
+      -- step explicitly.
       rw [show ρ (algebraMap R A' r) =
           (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B))
             (algebraMap R A r) from by simp [ρ, AlgHomClass.commutes],
@@ -82,6 +95,9 @@ noncomputable def derivationComp (φ : A' →ₐc[R] A)
       -- both sides then reduce through the counit.
       simp only [eRing, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
         Bialgebra.CounitAlgebra.algEquivSelf_apply]
+      -- The `A'`-algebra map on the left is the local `letI` instance, whose value
+      -- is definitionally `ρ a = algebraMap A _ (φ a)`; this holds by `rfl` only, as
+      -- no lemma describes an instance local to this construction.
       rw [show (algebraMap A' (Bialgebra.CounitAlgebra R A B)) a =
           algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a) from rfl,
         Bialgebra.CounitAlgebra.algebraMap_apply R A B,
@@ -91,12 +107,10 @@ noncomputable def derivationComp (φ : A' →ₐc[R] A)
         (DFunLike.congr_fun (BialgHom.counitAlgHom_comp φ) a))
   exact e.toLinearEquiv.compDer (d.compAlgebraMap A')
 
-/-- The differential acts on derivations by precomposition. -/
-@[simp]
-lemma derivationComp_apply (φ : A' →ₐc[R] A)
+private lemma derivationCompAux_apply (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
-    derivationComp (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
-  simp only [derivationComp, Derivation.linearEquiv_coe_comp, LinearMap.coe_comp,
+    derivationCompAux (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
+  simp only [derivationCompAux, Derivation.linearEquiv_coe_comp, LinearMap.coe_comp,
     Function.comp_apply, LinearMap.restrictScalars_apply, AlgEquiv.toLinearMap_apply,
     AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
     Bialgebra.CounitAlgebra.algEquivSelf_apply]
@@ -104,58 +118,45 @@ lemma derivationComp_apply (φ : A' →ₐc[R] A)
   -- definitional in Mathlib's `compAlgebraMap`.
   exact (Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B _).trans rfl
 
-/-- Precomposition of counit-valued derivations, bundled as an `R`-linear map. -/
-noncomputable def derivationCompₗ (φ : A' →ₐc[R] A) :
+/-- Precomposition of counit-valued derivations along a bialgebra morphism, as an
+`R`-linear map: the derivation form of the differential, sending an `R`-derivation
+`d : A → B` at the identity point of `A` to `a ↦ d (φ a)` at the identity point of
+`A'`.
+
+(The commutativity hypotheses on `A` and `A'` are those of `Derivation` itself.) -/
+noncomputable def derivationComp (φ : A' →ₐc[R] A) :
     Derivation R A (Bialgebra.CounitAlgebra R A B) →ₗ[R]
       Derivation R A' (Bialgebra.CounitAlgebra R A' B) where
-  toFun := derivationComp φ
+  toFun := derivationCompAux φ
   -- After simplification both sides are the same value of `B`; the residual is the
   -- definitional identification of the two coefficient indexings.
-  map_add' d₁ d₂ := by ext a; simp; rfl
-  map_smul' r d := by ext a; simp; rfl
+  map_add' d₁ d₂ := by ext a; simp [derivationCompAux_apply]; rfl
+  map_smul' r d := by ext a; simp [derivationCompAux_apply]; rfl
 
+/-- The differential acts on derivations by precomposition. -/
 @[simp]
-lemma derivationCompₗ_apply (φ : A' →ₐc[R] A)
-    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    derivationCompₗ (B := B) φ d = derivationComp φ d := by
-  -- `derivationCompₗ` has no equation lemma to rewrite with; `change` spells out its
+lemma derivationComp_apply (φ : A' →ₐc[R] A)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
+    derivationComp (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
+  -- `derivationComp` has no equation lemma to rewrite with; `change` spells out its
   -- definitional unfolding once, explicitly.
-  change derivationComp φ d = _
-  rfl
+  change derivationCompAux (B := B) φ d a = _
+  rw [derivationCompAux_apply]
 
-/-- Precomposition along the identity is the identity. -/
+/-- Precomposition along the identity is the identity map. -/
 @[simp]
-theorem derivationComp_id (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    derivationComp (B := B) (BialgHom.id R A) d = d := by
-  ext a
-  simp
-
-/-- Precomposition along a composite is the composite of the precompositions. -/
-@[simp]
-theorem derivationComp_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
-    (φ : A' →ₐc[R] A) (χ : A'' →ₐc[R] A')
-    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    derivationComp (B := B) (φ.comp χ) d = derivationComp χ (derivationComp φ d) := by
-  ext a
-  simp
-  -- The residual is the definitional identification of the coefficient indexings.
-  rfl
-
-/-- Bundled identity law: precomposition along the identity is the identity map. -/
-@[simp]
-theorem derivationCompₗ_id :
-    derivationCompₗ (B := B) (BialgHom.id R A) =
+theorem derivationComp_id :
+    derivationComp (B := B) (BialgHom.id R A) =
       LinearMap.id (R := R) (M := Derivation R A (Bialgebra.CounitAlgebra R A B)) := by
   ext d a
   simp
 
-/-- Bundled composition law: precomposition along a composite is the composition of the
-precompositions. -/
+/-- Precomposition along a composite is the composition of the precompositions. -/
 @[simp]
-theorem derivationCompₗ_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
+theorem derivationComp_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
     (φ : A' →ₐc[R] A) (χ : A'' →ₐc[R] A') :
-    derivationCompₗ (B := B) (φ.comp χ) =
-      (derivationCompₗ (B := B) χ).comp (derivationCompₗ (B := B) φ) := by
+    derivationComp (B := B) (φ.comp χ) =
+      (derivationComp (B := B) χ).comp (derivationComp (B := B) φ) := by
   ext d a
   simp
   -- The residual is the definitional identification of the coefficient indexings.

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -37,15 +37,13 @@ section DerivationMap
 
 variable {R A A' B : Type*} [CommSemiring R]
   [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
-  [CommSemiring B] [Algebra R B]
+  [Semiring B] [Algebra R B]
 
 /-- Precomposition of a counit-valued derivation with a bialgebra morphism: the map
 sending an `R`-derivation `d : A → B` at the identity point of `A` to the derivation
 `a ↦ d (φ a)` at the identity point of `A'` — the additive form of the differential.
 
-(The commutativity hypotheses on `A` and `A'` are those of `Derivation` itself;
-commutativity of `B` is used to install the restricted algebra structure via
-`RingHom.toAlgebra`.) -/
+(The commutativity hypotheses on `A` and `A'` are those of `Derivation` itself.) -/
 noncomputable def derivationComp (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     Derivation R A' (Bialgebra.CounitAlgebra R A' B) := by
@@ -53,8 +51,23 @@ noncomputable def derivationComp (φ : A' →ₐc[R] A)
   letI : IsScalarTower R A' A := IsScalarTower.of_algHom (φ : A' →ₐ[R] A)
   let ρ : A' →ₐ[R] Bialgebra.CounitAlgebra R A B :=
     (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B)).comp (φ : A' →ₐ[R] A)
-  letI : Algebra A' (Bialgebra.CounitAlgebra R A B) := ρ.toAlgebra
-  letI : IsScalarTower R A' (Bialgebra.CounitAlgebra R A B) := IsScalarTower.of_algHom ρ
+  letI : Algebra A' (Bialgebra.CounitAlgebra R A B) := ρ.toRingHom.toAlgebra'
+    (fun a x => by
+      -- `ρ` factors through `algebraMap R _`, whose image is central.
+      change ρ a * x = x * ρ a
+      rw [show ρ a = algebraMap R (Bialgebra.CounitAlgebra R A B)
+          (counit (R := R) ((φ : A' →ₐ[R] A) a)) from by
+        simp [ρ, IsScalarTower.coe_toAlgHom',
+          Bialgebra.CounitAlgebra.algebraMap_apply R A B]
+        rfl]
+      exact Algebra.commutes _ x)
+  letI : IsScalarTower R A' (Bialgebra.CounitAlgebra R A B) :=
+    IsScalarTower.of_algebraMap_eq fun r => by
+      change algebraMap R (Bialgebra.CounitAlgebra R A B) r = ρ (algebraMap R A' r)
+      rw [show ρ (algebraMap R A' r) =
+          (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B))
+            (algebraMap R A r) from by simp [ρ, AlgHomClass.commutes],
+        IsScalarTower.coe_toAlgHom', ← IsScalarTower.algebraMap_apply]
   letI : IsScalarTower A' A (Bialgebra.CounitAlgebra R A B) :=
     IsScalarTower.of_algebraMap_eq' rfl
   let eRing : Bialgebra.CounitAlgebra R A B ≃+* Bialgebra.CounitAlgebra R A' B :=
@@ -124,6 +137,26 @@ theorem derivationComp_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     derivationComp (B := B) (φ.comp χ) d = derivationComp χ (derivationComp φ d) := by
   ext a
+  simp
+  -- The residual is the definitional identification of the coefficient indexings.
+  rfl
+
+/-- Bundled identity law: precomposition along the identity is the identity map. -/
+@[simp]
+theorem derivationCompₗ_id :
+    derivationCompₗ (B := B) (BialgHom.id R A) =
+      LinearMap.id (R := R) (M := Derivation R A (Bialgebra.CounitAlgebra R A B)) := by
+  ext d a
+  simp
+
+/-- Bundled composition law: precomposition along a composite is the composition of the
+precompositions. -/
+@[simp]
+theorem derivationCompₗ_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
+    (φ : A' →ₐc[R] A) (χ : A'' →ₐc[R] A') :
+    derivationCompₗ (B := B) (φ.comp χ) =
+      (derivationCompₗ (B := B) χ).comp (derivationCompₗ (B := B) φ) := by
+  ext d a
   simp
   -- The residual is the definitional identification of the coefficient indexings.
   rfl

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
 
 /-!
 # The differential on derivations
@@ -22,8 +22,9 @@ therefore comes from those two facts and is not reproved here.
 * `TauCeti.derivationComp`: precomposition of counit-valued derivations along a
   bialgebra morphism.
 * `TauCeti.derivationComp_apply`: it acts by precomposition.
-* `TauCeti.tangentKerMap_derivationMulEquivTangentKer`: the differential intertwines the
-  tangent dictionaries — on points of derivations it is precomposition.
+The intertwining with the tangent dictionaries is
+`TauCeti.tangentKerMap_derivationMulEquivTangentKer` in
+`TauCeti.Algebra.AlgebraicGroup.Tangent.Map`.
 -/
 
 public section
@@ -38,13 +39,13 @@ variable {R A A' B : Type*} [CommSemiring R]
   [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
   [CommSemiring B] [Algebra R B]
 
-/-- Precomposition of a counit-valued derivation with a bialgebra morphism: the additive
-form of the differential.
+/-- Precomposition of a counit-valued derivation with a bialgebra morphism: the map
+sending an `R`-derivation `d : A → B` at the identity point of `A` to the derivation
+`a ↦ d (φ a)` at the identity point of `A'` — the additive form of the differential.
 
-The domain restriction is `Derivation.compAlgebraMap` over local scalar-tower instances
-making `φ` the canonical algebra map, and the coefficients then move across the canonical
-`A'`-linear identification of the two counit coefficient algebras, whose linearity is the
-counit compatibility of `φ`. -/
+(The commutativity hypotheses on `A` and `A'` are those of `Derivation` itself;
+commutativity of `B` is used to install the restricted algebra structure via
+`RingHom.toAlgebra`.) -/
 noncomputable def derivationComp (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     Derivation R A' (Bialgebra.CounitAlgebra R A' B) := by
@@ -90,32 +91,43 @@ lemma derivationComp_apply (φ : A' →ₐc[R] A)
   -- definitional in Mathlib's `compAlgebraMap`.
   exact (Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B _).trans rfl
 
+/-- Precomposition of counit-valued derivations, bundled as an `R`-linear map. -/
+noncomputable def derivationCompₗ (φ : A' →ₐc[R] A) :
+    Derivation R A (Bialgebra.CounitAlgebra R A B) →ₗ[R]
+      Derivation R A' (Bialgebra.CounitAlgebra R A' B) where
+  toFun := derivationComp φ
+  -- After simplification both sides are the same value of `B`; the residual is the
+  -- definitional identification of the two coefficient indexings.
+  map_add' d₁ d₂ := by ext a; simp; rfl
+  map_smul' r d := by ext a; simp; rfl
+
+@[simp]
+lemma derivationCompₗ_apply (φ : A' →ₐc[R] A)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    derivationCompₗ (B := B) φ d = derivationComp φ d := by
+  -- `derivationCompₗ` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change derivationComp φ d = _
+  rfl
+
+/-- Precomposition along the identity is the identity. -/
+@[simp]
+theorem derivationComp_id (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    derivationComp (B := B) (BialgHom.id R A) d = d := by
+  ext a
+  simp
+
+/-- Precomposition along a composite is the composite of the precompositions. -/
+@[simp]
+theorem derivationComp_comp {A'' : Type*} [CommSemiring A''] [Bialgebra R A'']
+    (φ : A' →ₐc[R] A) (χ : A'' →ₐc[R] A')
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    derivationComp (B := B) (φ.comp χ) d = derivationComp χ (derivationComp φ d) := by
+  ext a
+  simp
+  -- The residual is the definitional identification of the coefficient indexings.
+  rfl
+
 end DerivationMap
-
-section Naturality
-
-variable {R A A' B : Type*} [CommSemiring R]
-  [CommSemiring A] [HopfAlgebra R A] [CommSemiring A'] [HopfAlgebra R A']
-  [CommSemiring B] [Algebra R B]
-
-/-- The differential intertwines the tangent dictionaries: the image of the dual-number
-point of a derivation `d` under `tangentKerMap φ` is the point of the precomposed
-derivation `derivationComp φ d`. -/
-theorem tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
-    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) :
-    tangentKerMap (B := B) φ (derivationMulEquivTangentKer R A B d) =
-      derivationMulEquivTangentKer R A' B
-        (Multiplicative.ofAdd (derivationComp φ d.toAdd)) := by
-  refine Subtype.ext (WithConv.ofConv_injective (AlgHom.ext fun a => ?_))
-  refine TrivSqZeroExt.ext ?_ ?_
-  · rw [fst_apply_of_mem_tangentKer (tangentKerMap (B := B) φ
-        (derivationMulEquivTangentKer R A B d)).2 a,
-      fst_apply_of_mem_tangentKer (derivationMulEquivTangentKer R A' B
-        (Multiplicative.ofAdd (derivationComp φ d.toAdd))).2 a]
-  · rw [tangentKerMap_apply_val_ofConv, derivationMulEquivTangentKer_apply_snd,
-      toAdd_ofAdd, derivationComp_apply]
-    exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
-
-end Naturality
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -22,6 +22,8 @@ therefore comes from those two facts and is not reproved here.
 * `TauCeti.derivationComp`: precomposition of counit-valued derivations along a
   bialgebra morphism.
 * `TauCeti.derivationComp_apply`: it acts by precomposition.
+* `TauCeti.tangentKerMap_derivationMulEquivTangentKer`: the differential intertwines the
+  tangent dictionaries — on points of derivations it is precomposition.
 -/
 
 public section
@@ -89,5 +91,31 @@ lemma derivationComp_apply (φ : A' →ₐc[R] A)
   exact (Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B _).trans rfl
 
 end DerivationMap
+
+section Naturality
+
+variable {R A A' B : Type*} [CommSemiring R]
+  [CommSemiring A] [HopfAlgebra R A] [CommSemiring A'] [HopfAlgebra R A']
+  [CommSemiring B] [Algebra R B]
+
+/-- The differential intertwines the tangent dictionaries: the image of the dual-number
+point of a derivation `d` under `tangentKerMap φ` is the point of the precomposed
+derivation `derivationComp φ d`. -/
+theorem tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
+    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) :
+    tangentKerMap (B := B) φ (derivationMulEquivTangentKer R A B d) =
+      derivationMulEquivTangentKer R A' B
+        (Multiplicative.ofAdd (derivationComp φ d.toAdd)) := by
+  refine Subtype.ext (WithConv.ofConv_injective (AlgHom.ext fun a => ?_))
+  refine TrivSqZeroExt.ext ?_ ?_
+  · rw [fst_apply_of_mem_tangentKer (tangentKerMap (B := B) φ
+        (derivationMulEquivTangentKer R A B d)).2 a,
+      fst_apply_of_mem_tangentKer (derivationMulEquivTangentKer R A' B
+        (Multiplicative.ofAdd (derivationComp φ d.toAdd))).2 a]
+  · rw [tangentKerMap_apply_val_ofConv, derivationMulEquivTangentKer_apply_snd,
+      toAdd_ofAdd, derivationComp_apply]
+    exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
+
+end Naturality
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
+
+/-!
+# The differential on derivations
+
+A morphism `φ : A' →ₐc[R] A` of bialgebras sends a counit-valued derivation of `A` to
+one of `A'` by precomposition. The construction splits the transport into the two halves
+Mathlib provides: restricting the domain along `φ` (`Derivation.compAlgebraMap`, over
+local scalar-tower instances for `φ`), and moving the coefficients across the canonical
+identification of the two counit coefficient algebras, which is `A'`-linear precisely
+because bialgebra morphisms intertwine counits (`LinearEquiv.compDer`). The Leibniz rule
+therefore comes from those two facts and is not reproved here.
+
+## Main declarations
+
+* `TauCeti.derivationComp`: precomposition of counit-valued derivations along a
+  bialgebra morphism.
+* `TauCeti.derivationComp_apply`: it acts by precomposition.
+-/
+
+public section
+
+namespace TauCeti
+
+open Coalgebra
+
+section DerivationMap
+
+variable {R A A' B : Type*} [CommSemiring R]
+  [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
+  [CommSemiring B] [Algebra R B]
+
+/-- Precomposition of a counit-valued derivation with a bialgebra morphism: the additive
+form of the differential.
+
+The domain restriction is `Derivation.compAlgebraMap` over local scalar-tower instances
+making `φ` the canonical algebra map, and the coefficients then move across the canonical
+`A'`-linear identification of the two counit coefficient algebras, whose linearity is the
+counit compatibility of `φ`. -/
+noncomputable def derivationComp (φ : A' →ₐc[R] A)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    Derivation R A' (Bialgebra.CounitAlgebra R A' B) := by
+  letI : Algebra A' A := (φ : A' →ₐ[R] A).toAlgebra
+  letI : IsScalarTower R A' A := IsScalarTower.of_algHom (φ : A' →ₐ[R] A)
+  let ρ : A' →ₐ[R] Bialgebra.CounitAlgebra R A B :=
+    (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B)).comp (φ : A' →ₐ[R] A)
+  letI : Algebra A' (Bialgebra.CounitAlgebra R A B) := ρ.toAlgebra
+  letI : IsScalarTower R A' (Bialgebra.CounitAlgebra R A B) := IsScalarTower.of_algHom ρ
+  letI : IsScalarTower A' A (Bialgebra.CounitAlgebra R A B) :=
+    IsScalarTower.of_algebraMap_eq' rfl
+  let eRing : Bialgebra.CounitAlgebra R A B ≃+* Bialgebra.CounitAlgebra R A' B :=
+    (Bialgebra.CounitAlgebra.algEquivSelf R A B).toRingEquiv.trans
+      (Bialgebra.CounitAlgebra.algEquivSelf R A' B).symm.toRingEquiv
+  let e : Bialgebra.CounitAlgebra R A B ≃ₐ[A'] Bialgebra.CounitAlgebra R A' B :=
+    AlgEquiv.ofRingEquiv (f := eRing) (by
+      intro a
+      -- The single mathematical obligation: the two `A'`-algebra maps agree because
+      -- `φ` intertwines the counits. The transports erase pointwise, the left algebra
+      -- map is `algebraMap A (CounitAlgebra R A B)` at `φ a` by the local instance, and
+      -- both sides then reduce through the counit.
+      simp only [eRing, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
+        Bialgebra.CounitAlgebra.algEquivSelf_apply]
+      rw [show (algebraMap A' (Bialgebra.CounitAlgebra R A B)) a =
+          algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a) from rfl,
+        Bialgebra.CounitAlgebra.algebraMap_apply R A B,
+        Bialgebra.CounitAlgebra.algebraMap_apply R A' B,
+        Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B]
+      exact congrArg (algebraMap R B)
+        (DFunLike.congr_fun (BialgHom.counitAlgHom_comp φ) a))
+  exact e.toLinearEquiv.compDer (d.compAlgebraMap A')
+
+/-- The differential acts on derivations by precomposition. -/
+@[simp]
+lemma derivationComp_apply (φ : A' →ₐc[R] A)
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
+    derivationComp (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
+  simp only [derivationComp, Derivation.linearEquiv_coe_comp, LinearMap.coe_comp,
+    Function.comp_apply, LinearMap.restrictScalars_apply, AlgEquiv.toLinearMap_apply,
+    AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
+    Bialgebra.CounitAlgebra.algEquivSelf_apply]
+  -- The remaining transport erases at this value, and the precomposition is
+  -- definitional in Mathlib's `compAlgebraMap`.
+  exact (Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B _).trans rfl
+
+end DerivationMap
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -24,9 +24,7 @@ therefore comes from those two facts and is not reproved here.
 * `TauCeti.derivationComp_apply`, `TauCeti.derivationComp_id`,
   `TauCeti.derivationComp_comp`: it acts by precomposition, functorially.
 
-(`TauCeti.derivationCompAux` is the underlying construction; the module system does
-not allow a public definition to have a private body, so it is public but carries no
-API — use `derivationComp`.) The intertwining with the tangent dictionaries is
+The intertwining with the tangent dictionaries is
 `TauCeti.tangentKerMap_derivationMulEquivTangentKer` in
 `TauCeti.Algebra.AlgebraicGroup.Tangent.Map`.
 -/
@@ -43,11 +41,8 @@ variable {R A A' B : Type*} [CommSemiring R]
   [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
   [Semiring B] [Algebra R B]
 
-/-- Implementation of `derivationComp`: the underlying function on derivations. Use
-the bundled `derivationComp` — this definition carries no API. (It cannot be
-`private`: the module system does not allow the public bundled map to have a private
-body.) -/
-noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
+/-- Implementation of the bundled `derivationComp`, which is the API. -/
+private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     Derivation R A' (Bialgebra.CounitAlgebra R A' B) := by
   letI : Algebra A' A := (φ : A' →ₐ[R] A).toAlgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -24,6 +24,9 @@ the tangent kernels.
 * `TauCeti.tangentKerMap`: the differential, as a group homomorphism between tangent
   kernels.
 * `TauCeti.tangentKerMap_id` and `TauCeti.tangentKerMap_comp`: functoriality.
+* `TauCeti.tangentKerMap_derivationMulEquivTangentKer`: the differential is
+  compatible with the derivation–tangent dictionary — transporting a derivation to a
+  tangent point and mapping it forward is precomposition of derivations.
 -/
 
 public section
@@ -130,6 +133,7 @@ variable {R A A' B : Type*} [CommSemiring R]
 /-- The differential intertwines the tangent dictionaries: the image of the dual-number
 point of a derivation `d` under `tangentKerMap φ` is the point of the precomposed
 derivation `derivationComp φ d`. -/
+@[simp]
 theorem tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
     (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) :
     tangentKerMap (B := B) φ (derivationMulEquivTangentKer R A B d) =

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.DerivationMap
 
 /-!
 # The differential of a Hopf-algebra morphism on tangent spaces
@@ -120,6 +121,32 @@ lemma tangentKerMap_comp {A'' : Type*} [CommSemiring A''] [HopfAlgebra R A'']
     AlgHom.mapDomain_comp (A := DualNumber (Bialgebra.CounitAlgebra R A'' B)) φ χ,
     ← mapDomain_transport (A'' := A'') φ ψ.val]
   exact MonoidHom.comp_apply _ _ _
+
+section Naturality
+
+variable {R A A' B : Type*} [CommSemiring R]
+  [CommSemiring A] [HopfAlgebra R A] [CommSemiring A'] [HopfAlgebra R A']
+  [CommSemiring B] [Algebra R B]
+
+/-- The differential intertwines the tangent dictionaries: the image of the dual-number
+point of a derivation `d` under `tangentKerMap φ` is the point of the precomposed
+derivation `derivationComp φ d`. -/
+theorem tangentKerMap_derivationMulEquivTangentKer (φ : A' →ₐc[R] A)
+    (d : Multiplicative (Derivation R A (Bialgebra.CounitAlgebra R A B))) :
+    tangentKerMap (B := B) φ (derivationMulEquivTangentKer R A B d) =
+      derivationMulEquivTangentKer R A' B
+        (Multiplicative.ofAdd (derivationComp φ d.toAdd)) := by
+  refine Subtype.ext (WithConv.ofConv_injective (AlgHom.ext fun a => ?_))
+  refine TrivSqZeroExt.ext ?_ ?_
+  · rw [fst_apply_of_mem_tangentKer (tangentKerMap (B := B) φ
+        (derivationMulEquivTangentKer R A B d)).2 a,
+      fst_apply_of_mem_tangentKer (derivationMulEquivTangentKer R A' B
+        (Multiplicative.ofAdd (derivationComp φ d.toAdd))).2 a]
+  · rw [tangentKerMap_apply_val_ofConv, derivationMulEquivTangentKer_apply_snd,
+      toAdd_ofAdd, derivationComp_apply]
+    exact derivationMulEquivTangentKer_apply_snd d ((φ : A' →ₐ[R] A) a)
+
+end Naturality
 
 end Differential
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Algebra.AlgebraicGroup.Hopf.Map
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.DerivationMap
 
 /-!


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"tangent-derivation-transport"}-->

Adds `TauCeti.derivationComp`: a bialgebra morphism `φ : A' →ₐc[R] A` sends a counit-valued derivation of `A` to one of `A'` by precomposition — the additive form of the differential of #1729, and the missing half of the tangent dictionary's naturality.

The scalar actions of the two counit coefficient algebras agree only propositionally (through `ε_A ∘ φ = ε_{A'}`), so the construction splits the transport into the two halves Mathlib provides: `Derivation.compAlgebraMap` restricts the domain along `φ` over local scalar-tower instances, and `LinearEquiv.compDer` moves the coefficients across the canonical identification of the two counit algebras, packaged as an `A'`-algebra equivalence by `AlgEquiv.ofRingEquiv` whose sole obligation is `BialgHom.counitAlgHom_comp`. The Leibniz rule therefore comes from those two Mathlib facts and is not reproved. Stated at bialgebra generality (no antipode is used); with the pointwise `derivationComp_apply`.

The intertwining square with `derivationMulEquivTangentKer` is the natural follow-up now that both sides exist.

Roadmap: ReductiveGroups

Advances `TauCetiRoadmap/ReductiveGroups/README.md`, Layer 2 "Lie algebra and the adjoint representation": the differential of a homomorphism, on tangent vectors as derivations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)