### PR TITLE
feat: assemble the orthonormal systems of Schur orthogonality

### DIFF
--- a/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
+++ b/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Compact.Character
+
+/-!
+# The orthonormal systems cut out by Schur orthogonality
+
+Fix a family `π i` of pairwise inequivalent finite-dimensional irreducible unitary representations
+of a compact group `G`, one for each index `i`. This file assembles the two orthogonality relations
+of `TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean` and
+`TauCeti/RepresentationTheory/Compact/Character.lean` into `Orthonormal` families in `L²(G)`:
+
+* the **normalized matrix coefficients** `√(dim V_i) • (π i)_{ab}`, indexed by
+  `Σ i, Fin (dim V_i) × Fin (dim V_i)`;
+* the **characters** `χ_(π i)`, indexed by `i`.
+
+The first is the system that the Peter-Weyl theorem proves complete; the second is the system that
+lies in the central subspace of `L²(G)`.
+
+## Main statements
+
+* `TauCeti.ContRepresentation.orthonormal_matrixCoeffLp`: the normalized matrix coefficients of a
+  family of pairwise inequivalent irreducible unitary representations form an orthonormal system
+  in `L²(G)`.
+* `TauCeti.ContRepresentation.orthonormal_characterLp`: the characters of such a family form an
+  orthonormal system in `L²(G)`.
+
+## Implementation notes
+
+Inequivalence is the hypothesis `Pairwise fun i j ↦ IsEmpty (ContRepresentation.Equiv (π i) (π j))`.
+Nothing here selects the family: "one representative per equivalence class" is chosen data,
+supplied by the caller as `π` together with the orthonormal bases `e`, exactly as the Peter-Weyl
+basis of Layer 5 will need it.
+
+Both systems live in the *same* `L²(G)`, so the index of the matrix-coefficient system is a sigma
+type over the family rather than a product: different `i` contribute different numbers of
+coefficients.
+
+The normalizing scalar is `√(n i)`, where `n i` is the cardinality of the index type of the chosen
+basis of `V i` and so equals `Module.finrank 𝕜 (V i)` by `Module.finrank_eq_card_basis`. Taking the
+basis index as data rather than reading it off `Module.finrank` is what lets the caller keep
+whatever indexing the representation came with.
+
+This is the orthonormal-system item of Layer 4, together with the system half of the
+character-orthonormality item of Layer 6, of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md).
+The completeness of the first system (Peter-Weyl) and of the second (class-function completeness)
+are Layer 5 and Layer 6 targets and are not proved here. The mathematical development follows
+Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+open MeasureTheory
+open scoped InnerProductSpace
+
+namespace TauCeti
+
+namespace ContRepresentation
+
+section OrthonormalSystem
+
+variable {𝕜 G ι : Type*} {V : ι → Type*} [RCLike 𝕜] [IsAlgClosed 𝕜]
+  [Group G] [TopologicalSpace G] [IsTopologicalGroup G] [CompactSpace G]
+  [MeasurableSpace G] [BorelSpace G]
+  [∀ i, NormedAddCommGroup (V i)] [∀ i, InnerProductSpace 𝕜 (V i)]
+  [∀ i, NormedSpace ℝ (V i)] [∀ i, SMulCommClass ℝ 𝕜 (V i)]
+  [∀ i, FiniteDimensional 𝕜 (V i)]
+
+local instance instCompleteSpaceOrthonormalSystem (i : ι) : CompleteSpace (V i) :=
+  FiniteDimensional.complete 𝕜 (V i)
+
+variable (π : ∀ i, ContRepresentation 𝕜 G (V i)) (hπ : ∀ i, Continuous (π i))
+
+/-- **The normalized matrix coefficients are orthonormal.** For a family `π` of pairwise
+inequivalent finite-dimensional irreducible unitary representations of a compact group, with a
+chosen orthonormal basis `e i` of each carrier, the functions
+`√(dim V_i) • ⟪(π i) · (e i a), e i b⟫` form an orthonormal system in `L²(G)` indexed by
+`Σ i, Fin (n i) × Fin (n i)`.
+
+Within a single `i` this is the first Schur orthogonality relation, whose value `(n i)⁻¹` on the
+diagonal is exactly what the normalization `√(n i)` cancels; across distinct `i` it is the second
+relation, whose hypothesis Schur's lemma supplies from inequivalence.
+
+This is the system that the Peter-Weyl theorem completes to a Hilbert basis of `L²(G)`. -/
+theorem orthonormal_matrixCoeffLp {n : ι → ℕ} (hunitary : ∀ i, IsUnitary (π i))
+    (hirr : ∀ i, Representation.IsIrreducible (π i).toRepresentation)
+    (hne : Pairwise fun i j ↦ IsEmpty (_root_.ContRepresentation.Equiv (π i) (π j)))
+    (e : ∀ i, OrthonormalBasis (Fin (n i)) 𝕜 (V i)) :
+    Orthonormal 𝕜 fun x : Σ i, Fin (n i) × Fin (n i) ↦
+      (Real.sqrt (n x.1) : 𝕜) •
+        matrixCoeffLp (π x.1) (hπ x.1) (e x.1 x.2.1) (e x.1 x.2.2) := by
+  classical
+  rw [orthonormal_iff_ite]
+  rintro ⟨i, a, b⟩ ⟨j, c, d⟩
+  rw [inner_smul_left, inner_smul_right, RCLike.conj_ofReal]
+  rcases eq_or_ne i j with rfl | hij
+  · -- `Fin (n i)` is inhabited by `a`, so the dimension is positive and the normalization is legal.
+    have hn : (0 : ℝ) < n i := by
+      exact_mod_cast Fin.pos a
+    have hsq : (Real.sqrt (n i) : 𝕜) * (Real.sqrt (n i) : 𝕜) = (n i : 𝕜) := by
+      rw [← RCLike.ofReal_mul, Real.mul_self_sqrt hn.le, RCLike.ofReal_natCast]
+    rw [schur_orthogonality_basis (π i) (hπ i) (hunitary i) (hirr i) (e i) b a d c,
+      ← mul_assoc, ← mul_assoc, hsq]
+    have hn' : (n i : 𝕜) ≠ 0 := by
+      exact_mod_cast hn.ne'
+    split_ifs <;> simp_all [Sigma.ext_iff, Prod.ext_iff]
+  · rw [schur_orthogonality (π i) (hπ i) (π j) (hπ j) (hunitary j) (hirr i) (hirr j) (hne hij)]
+    simp [Sigma.ext_iff, hij]
+
+/-- **The irreducible characters are orthonormal.** The characters of a family of pairwise
+inequivalent finite-dimensional irreducible unitary representations of a compact group form an
+orthonormal system in `L²(G)`.
+
+This is the system form of the two character orthogonality relations: normalization is the first,
+and orthogonality across the family is the second, whose intertwiner hypothesis Schur's lemma
+supplies from inequivalence. For a finite group it is the statement that the irreducible characters
+are an orthonormal set of class functions. -/
+theorem orthonormal_characterLp (hunitary : ∀ i, IsUnitary (π i))
+    (hirr : ∀ i, Representation.IsIrreducible (π i).toRepresentation)
+    (hne : Pairwise fun i j ↦ IsEmpty (_root_.ContRepresentation.Equiv (π i) (π j))) :
+    Orthonormal 𝕜 fun i ↦ characterLp (π i) (hπ i) := by
+  classical
+  rw [orthonormal_iff_ite]
+  intro i j
+  rcases eq_or_ne i j with rfl | hij
+  · simpa using character_orthonormal_self (π i) (hπ i) (hunitary i) (hirr i)
+  · -- The second character orthogonality asks for the intertwiners `π j → π i`, not `π i → π j`,
+    -- so it is the pair `(j, i)` that Schur's lemma is applied to.
+    rw [character_orthonormal_distinct (π i) (hπ i) (π j) (hπ j) (hunitary i)
+      fun f ↦ toContinuousLinearMap_eq_zero_of_isEmpty_equiv (hirr j) (hirr i) (hne hij.symm) f]
+    simp [hij]
+
+end OrthonormalSystem
+
+end ContRepresentation
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
+++ b/TauCeti/RepresentationTheory/Compact/Orthonormal.lean
@@ -18,8 +18,10 @@ of `TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean` and
   `Σ i, Fin (dim V_i) × Fin (dim V_i)`;
 * the **characters** `χ_(π i)`, indexed by `i`.
 
-The first is the system that the Peter-Weyl theorem proves complete; the second is the system that
-lies in the central subspace of `L²(G)`.
+The family is arbitrary apart from being pairwise inequivalent, so the first is a subsystem of the
+system that the Peter-Weyl theorem proves complete: it is the whole of it only when the family runs
+over one representative of every irreducible equivalence class. The second lies in the central
+subspace of `L²(G)`.
 
 ## Main statements
 
@@ -86,7 +88,9 @@ Within a single `i` this is the first Schur orthogonality relation, whose value 
 diagonal is exactly what the normalization `√(n i)` cancels; across distinct `i` it is the second
 relation, whose hypothesis Schur's lemma supplies from inequivalence.
 
-This is the system that the Peter-Weyl theorem completes to a Hilbert basis of `L²(G)`. -/
+The family is not asked to be exhaustive, so this is in general a subsystem of the system that the
+Peter-Weyl theorem completes to a Hilbert basis of `L²(G)`; it is that whole system exactly when `π`
+contains a representative of every irreducible equivalence class. -/
 theorem orthonormal_matrixCoeffLp {n : ι → ℕ} (hunitary : ∀ i, IsUnitary (π i))
     (hirr : ∀ i, Representation.IsIrreducible (π i).toRepresentation)
     (hne : Pairwise fun i j ↦ IsEmpty (_root_.ContRepresentation.Equiv (π i) (π j)))
@@ -132,7 +136,7 @@ theorem orthonormal_characterLp (hunitary : ∀ i, IsUnitary (π i))
   · -- The second character orthogonality asks for the intertwiners `π j → π i`, not `π i → π j`,
     -- so it is the pair `(j, i)` that Schur's lemma is applied to.
     rw [character_orthonormal_distinct (π i) (hπ i) (π j) (hπ j) (hunitary i)
-      fun f ↦ toContinuousLinearMap_eq_zero_of_isEmpty_equiv (hirr j) (hirr i) (hne hij.symm) f]
+      fun f ↦ by simp [eq_zero_of_isEmpty_equiv (hirr j) (hirr i) (hne hij.symm) f]]
     simp [hij]
 
 end OrthonormalSystem

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -9,7 +9,7 @@ public import TauCeti.RepresentationTheory.Continuous.Schur
 public import Mathlib.Analysis.InnerProductSpace.Trace
 
 /-!
-# Schur orthogonality for one irreducible compact-group representation
+# Schur orthogonality for irreducible compact-group representations
 
 This file proves the first Schur orthogonality relation for matrix coefficients of a
 finite-dimensional irreducible unitary representation of a compact group. Haar-averaging a
@@ -20,6 +20,11 @@ The coordinate-free result is accompanied by its orthonormal-basis form. The lat
 order of the Kronecker deltas and the placement of complex conjugation in Mathlib's convention that
 the inner product is conjugate-linear in its first argument.
 
+The second relation, for a pair of representations, is proved in
+`TauCeti/RepresentationTheory/Compact/Intertwiner.lean` from the vanishing of the intertwiners
+between them; the last section here packages it with the hypothesis Schur's lemma actually
+discharges, namely that the two irreducibles are inequivalent.
+
 ## Main statements
 
 * `TauCeti.ContRepresentation.averageOperator_eq_finrank_inv_mul_trace_smul_id`: the average of a
@@ -28,8 +33,10 @@ the inner product is conjugate-linear in its first argument.
   orthogonality relation.
 * `TauCeti.ContRepresentation.schur_orthogonality_basis`: the corresponding Kronecker-delta
   formula in an orthonormal basis.
+* `TauCeti.ContRepresentation.schur_orthogonality`: the second Schur orthogonality relation, for
+  a pair of inequivalent irreducible unitary representations.
 
-This supplies the two formulas pinned by the first-orthogonality item of Layer 4 of the
+This supplies the three formulas pinned by the orthogonality items of Layer 4 of the
 [compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md);
 that item's remaining request, checking the convention against `fourierBasis` on `AddCircle`, waits
 on the `AddCircle` material and is not done here. The roadmap sketches the basis identity as the
@@ -144,6 +151,33 @@ theorem schur_orthogonality_basis (hunitary : IsUnitary π)
   split_ifs <;> simp_all
 
 end Orthogonality
+
+section Inequivalent
+
+variable {𝕜 G V W : Type*} [RCLike 𝕜] [Group G] [TopologicalSpace G]
+  [IsTopologicalGroup G] [CompactSpace G] [MeasurableSpace G] [BorelSpace G]
+  [NormedAddCommGroup V] [InnerProductSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [InnerProductSpace 𝕜 W] [NormedSpace ℝ W] [SMulCommClass ℝ 𝕜 W]
+  [CompleteSpace W]
+
+/-- **The second Schur orthogonality relation.** Matrix coefficients of inequivalent
+finite-dimensional irreducible representations of a compact group are `L²`-orthogonal, provided the
+second one is unitary.
+
+This is `TauCeti.ContRepresentation.schur_orthogonality_distinct` with its hypothesis discharged:
+the vanishing half of Schur's lemma turns inequivalence into the vanishing of every continuous
+intertwiner `π → ρ`. Algebraic closedness is not needed, since only the vanishing half of Schur's
+lemma is used. -/
+theorem schur_orthogonality (π : ContRepresentation 𝕜 G V)
+    (hπ : Continuous π) (ρ : ContRepresentation 𝕜 G W) (hρ : Continuous ρ) (hunitary : IsUnitary ρ)
+    (hirrπ : Representation.IsIrreducible π.toRepresentation)
+    (hirrρ : Representation.IsIrreducible ρ.toRepresentation)
+    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (v w : V) (v' w' : W) :
+    ⟪matrixCoeffLp π hπ v w, matrixCoeffLp ρ hρ v' w'⟫_𝕜 = 0 :=
+  schur_orthogonality_distinct π hπ ρ hρ hunitary
+    (fun f ↦ toContinuousLinearMap_eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f) v w v' w'
+
+end Inequivalent
 
 end ContRepresentation
 

--- a/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
+++ b/TauCeti/RepresentationTheory/Compact/SchurOrthogonality.lean
@@ -175,7 +175,7 @@ theorem schur_orthogonality (π : ContRepresentation 𝕜 G V)
     (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (v w : V) (v' w' : W) :
     ⟪matrixCoeffLp π hπ v w, matrixCoeffLp ρ hρ v' w'⟫_𝕜 = 0 :=
   schur_orthogonality_distinct π hπ ρ hρ hunitary
-    (fun f ↦ toContinuousLinearMap_eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f) v w v' w'
+    (fun f ↦ by simp [eq_zero_of_isEmpty_equiv hirrπ hirrρ hne f]) v w v' w'
 
 end Inequivalent
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -7,20 +7,35 @@ module
 public import Mathlib.Analysis.Normed.Module.Basic
 public import Mathlib.RepresentationTheory.Continuous.Basic
 public import Mathlib.RepresentationTheory.Irreducible
+public import Mathlib.Topology.Algebra.Module.FiniteDimension
 
 /-!
-# Schur's lemma for continuous self-intertwiners
+# Schur's lemma for continuous intertwiners
 
-Over an algebraically closed field, every self-intertwiner of a finite-dimensional irreducible
-representation is scalar. This file records that statement for Mathlib's bundled continuous
-intertwining maps, which is the form the analytic theory uses.
+Schur's lemma has two halves. Between inequivalent irreducible representations every intertwiner
+vanishes; and, over an algebraically closed field, every self-intertwiner of a finite-dimensional
+irreducible representation is scalar. This file records both halves for Mathlib's bundled
+continuous intertwining maps, which is the form the analytic theory uses.
 
-No topology on the acting monoid and no invariant measure are involved: the proof forgets the
-continuity of the intertwiner and applies Mathlib's algebraic Schur lemma
-`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed`.
+No topology on the acting monoid and no invariant measure are involved: both proofs forget the
+continuity of the intertwiner and apply Mathlib's algebraic Schur lemma, in the form of the
+instance `Representation.IsIrreducible.instSubsingletonIntertwiningMap` for the vanishing half and
+`Representation.IsIrreducible.algebraMap_intertwiningMap_bijective_of_isAlgClosed` for the scalar
+half.
+
+Forgetting continuity is only sound in the direction "continuous intertwiner ↦ intertwiner"; the
+hypothesis of the vanishing half is inequivalence as *continuous* representations, which is the
+weaker of the two hypotheses to discharge. `TauCeti.ContRepresentation.nonempty_equiv_iff` is what
+closes the gap: in finite dimensions over a complete field the two notions of equivalence agree,
+because every linear map out of a finite-dimensional normed space is continuous.
 
 ## Main statements
 
+* `TauCeti.ContRepresentation.nonempty_equiv_iff`: two finite-dimensional continuous
+  representations are equivalent as continuous representations if and only if they are equivalent
+  as abstract representations.
+* `TauCeti.ContRepresentation.eq_zero_of_isEmpty_equiv`: every continuous intertwiner between
+  inequivalent irreducible finite-dimensional representations is zero.
 * `TauCeti.ContRepresentation.exists_eq_smul_one_of_irreducible`: every continuous self-intertwiner
   of an irreducible finite-dimensional representation over an algebraically closed normed field is
   scalar.
@@ -33,6 +48,66 @@ public section
 namespace TauCeti
 
 namespace ContRepresentation
+
+section Vanishing
+
+variable {𝕜 G V W : Type*} [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜] [Monoid G]
+  [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
+  [NormedAddCommGroup W] [NormedSpace 𝕜 W]
+
+variable {π : ContRepresentation 𝕜 G V} {ρ : ContRepresentation 𝕜 G W}
+
+/-- **Continuity is automatic for finite-dimensional representations.** Two finite-dimensional
+continuous representations over a complete field are equivalent as continuous representations
+exactly when their underlying abstract representations are equivalent.
+
+The forward direction forgets continuity. The reverse direction is where the finite-dimensionality
+is used: a linear equivalence of finite-dimensional normed spaces is a homeomorphism, so an
+abstract equivalence carries no extra data. -/
+theorem nonempty_equiv_iff :
+    Nonempty (_root_.ContRepresentation.Equiv π ρ) ↔
+      Nonempty (Representation.Equiv π.toRepresentation ρ.toRepresentation) := by
+  constructor
+  · rintro ⟨φ⟩
+    refine ⟨Representation.Equiv.mk φ.toContinuousLinearEquiv.toLinearEquiv fun g ↦ ?_⟩
+    ext v
+    exact congr($(φ.isIntertwining g) v)
+  · rintro ⟨φ⟩
+    refine ⟨_root_.ContRepresentation.Equiv.mk φ.toLinearEquiv.toContinuousLinearEquiv fun g ↦ ?_⟩
+    ext v
+    exact congr($(φ.isIntertwining' g) v)
+
+/-- **Schur's lemma, vanishing half.** A continuous intertwiner between inequivalent irreducible
+finite-dimensional continuous representations is zero.
+
+Inequivalence is asked of the continuous representations, which by `nonempty_equiv_iff` is the same
+condition as inequivalence of the underlying abstract representations. No hypothesis on the field
+beyond completeness is needed: this half of Schur's lemma does not need eigenvalues, so it does not
+need algebraic closedness. -/
+theorem eq_zero_of_isEmpty_equiv (hπ : Representation.IsIrreducible π.toRepresentation)
+    (hρ : Representation.IsIrreducible ρ.toRepresentation)
+    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (f : ContIntertwiningMap π ρ) :
+    f = 0 := by
+  letI : Representation.IsIrreducible π.toRepresentation := hπ
+  letI : Representation.IsIrreducible ρ.toRepresentation := hρ
+  haveI : IsEmpty (Representation.Equiv π.toRepresentation ρ.toRepresentation) :=
+    ⟨fun φ ↦ hne.false (nonempty_equiv_iff.2 ⟨φ⟩).some⟩
+  exact ContIntertwiningMap.toIntertwiningMap_injective (Subsingleton.elim _ _)
+
+/-- The underlying continuous linear map of a continuous intertwiner between inequivalent
+irreducibles vanishes. This is the form in which the Schur orthogonality relations consume
+`eq_zero_of_isEmpty_equiv`. -/
+theorem toContinuousLinearMap_eq_zero_of_isEmpty_equiv
+    (hπ : Representation.IsIrreducible π.toRepresentation)
+    (hρ : Representation.IsIrreducible ρ.toRepresentation)
+    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (f : ContIntertwiningMap π ρ) :
+    f.toContinuousLinearMap = 0 := by
+  rw [eq_zero_of_isEmpty_equiv hπ hρ hne f]
+  rfl
+
+end Vanishing
+
+section Scalar
 
 variable {𝕜 G V : Type*} [NontriviallyNormedField 𝕜] [IsAlgClosed 𝕜] [Monoid G]
   [NormedAddCommGroup V] [NormedSpace 𝕜 V] [FiniteDimensional 𝕜 V]
@@ -57,6 +132,8 @@ theorem exists_eq_smul_one_of_irreducible (hirr : Representation.IsIrreducible �
       = (1 : Representation.IntertwiningMap π.toRepresentation π.toRepresentation) := rfl
   simp only [hsmul, hone]
   rw [← Algebra.algebraMap_eq_smul_one, hc]
+
+end Scalar
 
 end ContRepresentation
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -88,9 +88,9 @@ theorem eq_zero_of_isEmpty_equiv (hπ : Representation.IsIrreducible π.toRepres
     (hρ : Representation.IsIrreducible ρ.toRepresentation)
     (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (f : ContIntertwiningMap π ρ) :
     f = 0 := by
-  letI : Representation.IsIrreducible π.toRepresentation := hπ
-  letI : Representation.IsIrreducible ρ.toRepresentation := hρ
-  haveI : IsEmpty (Representation.Equiv π.toRepresentation ρ.toRepresentation) :=
+  let : Representation.IsIrreducible π.toRepresentation := hπ
+  let : Representation.IsIrreducible ρ.toRepresentation := hρ
+  have : IsEmpty (Representation.Equiv π.toRepresentation ρ.toRepresentation) :=
     ⟨fun φ ↦ hne.false (nonempty_equiv_iff.2 ⟨φ⟩).some⟩
   exact ContIntertwiningMap.toIntertwiningMap_injective (Subsingleton.elim _ _)
 

--- a/TauCeti/RepresentationTheory/Continuous/Schur.lean
+++ b/TauCeti/RepresentationTheory/Continuous/Schur.lean
@@ -94,17 +94,6 @@ theorem eq_zero_of_isEmpty_equiv (hπ : Representation.IsIrreducible π.toRepres
     ⟨fun φ ↦ hne.false (nonempty_equiv_iff.2 ⟨φ⟩).some⟩
   exact ContIntertwiningMap.toIntertwiningMap_injective (Subsingleton.elim _ _)
 
-/-- The underlying continuous linear map of a continuous intertwiner between inequivalent
-irreducibles vanishes. This is the form in which the Schur orthogonality relations consume
-`eq_zero_of_isEmpty_equiv`. -/
-theorem toContinuousLinearMap_eq_zero_of_isEmpty_equiv
-    (hπ : Representation.IsIrreducible π.toRepresentation)
-    (hρ : Representation.IsIrreducible ρ.toRepresentation)
-    (hne : IsEmpty (_root_.ContRepresentation.Equiv π ρ)) (f : ContIntertwiningMap π ρ) :
-    f.toContinuousLinearMap = 0 := by
-  rw [eq_zero_of_isEmpty_equiv hπ hρ hne f]
-  rfl
-
 end Vanishing
 
 section Scalar


### PR DESCRIPTION
This PR assembles the Schur orthogonality relations for a compact group into the two orthonormal systems they cut out in `L²(G)`. For a family `π i` of pairwise inequivalent finite-dimensional irreducible unitary continuous representations, `TauCeti.ContRepresentation.orthonormal_matrixCoeffLp` says the normalized matrix coefficients `√(dim V i) • ⟪(π i) · (e i a), e i b⟫`, indexed by `Σ i, Fin (n i) × Fin (n i)`, are an `Orthonormal` family, and `TauCeti.ContRepresentation.orthonormal_characterLp` says the characters `χ_(π i)` are an `Orthonormal` family indexed by `i`. The first is the system Peter-Weyl will complete to a Hilbert basis; the second is the one that lands in the central subspace.

Both relations already existed pointwise, but with the vanishing of the intertwiner space as a hypothesis rather than inequivalence, so the prerequisite this PR supplies first is the vanishing half of Schur's lemma for Mathlib's bundled continuous intertwiners: `TauCeti.ContRepresentation.eq_zero_of_isEmpty_equiv`, together with `TauCeti.ContRepresentation.nonempty_equiv_iff`, which says that in finite dimensions over a complete field a `ContRepresentation.Equiv` and a `Representation.Equiv` are the same thing, so that the continuous notion of inequivalence is what the caller has to discharge. Neither needs algebraic closedness: this half of Schur's lemma does not go through eigenvalues. With it, `TauCeti.ContRepresentation.schur_orthogonality` states the second orthogonality relation in the form the roadmap names, taking inequivalence of two irreducibles rather than the vanishing of the intertwiners between them.

Targets the orthonormal-system item of Layer 4 of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md` ("The normalized matrix coefficients are orthonormal. `√d · π_ij` over all irreducibles `π` ... form an orthonormal system in `L²(G, haarProb G)` (`Orthonormal`) ... Their indexing set is `Σ π, Fin (dim V_π) × Fin (dim V_π)`"), that layer's request that the packaged second relation be named `schur_orthogonality`, and the system form of the character-orthonormality item of Layer 6. The completeness of either system (Peter-Weyl in Layer 5, class-function completeness in Layer 6) is a separate target and is not touched here. Nothing was vendored from Mathlib or from any other source; the mathematical development follows Bump, *Lie Groups*, second edition, Chapter 2, as the surrounding files already do.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"normalized-matrix-coefficients-orthonormal"}-->

🤖 Prepared with Claude Code
