### PR TITLE
refactor(MeasureTheory): extract "a zero-one law is a.e. constant"

### DIFF
--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -204,6 +204,25 @@ theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
     exact MeasurableSpace.measurableSet_comap.1 hT'
   rw [← Measure.map_apply measurable_evalReal hU, ← Measure.map_apply measurable_evalReal hU, key]
 
+/-- **A zero-one law is almost surely constant along a measurable map.** If the pushforward lands
+in a standard Borel space it is again a zero-one probability measure, hence Dirac, and the map
+therefore agrees almost everywhere with a single value. -/
+private theorem exists_ae_eq_const_of_isZeroOneMeasure {Ω β : Type*} [MeasurableSpace Ω]
+    [MeasurableSpace β] [StandardBorelSpace β] {π : Measure Ω} [IsProbabilityMeasure π]
+    [IsZeroOneMeasure π] {f : Ω → β} (hf : Measurable f) :
+    ∃ q : β, ∀ᵐ ω ∂π, f ω = q := by
+  haveI : IsProbabilityMeasure (π.map f) := Measure.isProbabilityMeasure_map hf.aemeasurable
+  haveI : IsZeroOneMeasure (π.map f) := {
+    zero_one₀ := fun s hs => by
+      rw [Measure.map_apply hf hs]
+      exact _root_.MeasureTheory.Measure.zero_one π (f ⁻¹' s) }
+  obtain ⟨q, hq⟩ := IsZeroOneMeasure.exists_eq_dirac (μ := π.map f)
+  have hsingleton : MeasurableSet ({q} : Set β) := MeasurableSet.singleton q
+  have hmass : π (f ⁻¹' {q}) = 1 := by
+    rw [← Measure.map_apply hf hsingleton, hq]
+    simp
+  exact ⟨q, (_root_.MeasureTheory.mem_ae_iff_prob_eq_one (hsingleton.preimage hf)).2 hmass⟩
+
 /-- A nonzero zero-one law on `ProbabilityMeasure α` is a Dirac measure when the measurable
 space on `α` is countably generated.
 
@@ -243,26 +262,7 @@ theorem IsZeroOneMeasure.exists_eq_dirac_probabilityMeasure [CountablyGenerated 
     simp
   letI : ∀ _ : {s : Set α // s ∈ 𝒜}, StandardBorelSpace ℝ≥0∞ :=
     fun _ => standardBorel_of_polish
-  let πe : Measure ({s : Set α // s ∈ 𝒜} → ℝ≥0∞) := π.map e
-  haveI : IsProbabilityMeasure πe := Measure.isProbabilityMeasure_map he.aemeasurable
-  haveI : IsZeroOneMeasure πe := {
-    zero_one₀ := fun s hs => by
-      rw [Measure.map_apply he hs]
-      exact _root_.MeasureTheory.Measure.zero_one π (e ⁻¹' s) }
-  obtain ⟨q, hq⟩ := IsZeroOneMeasure.exists_eq_dirac (μ := πe)
-  have hsingleton : MeasurableSet ({q} : Set ({s : Set α // s ∈ 𝒜} → ℝ≥0∞)) :=
-    MeasurableSet.singleton q
-  have hmass : π (e ⁻¹' {q}) = 1 := by
-    rw [← Measure.map_apply he hsingleton]
-    -- Fold the local name so the Dirac equality `hq`, which is stated for `πe`, can rewrite.
-    change πe {q} = 1
-    rw [hq]
-    simp
-  have heq : ∀ᵐ P ∂π, e P = q := by
-    have hmem : e ⁻¹' {q} ∈ ae π :=
-      (_root_.MeasureTheory.mem_ae_iff_prob_eq_one (hsingleton.preimage he)).2 hmass
-    filter_upwards [hmem] with P hP
-    exact hP
+  obtain ⟨q, heq⟩ := exists_ae_eq_const_of_isZeroOneMeasure (π := π) he
   obtain ⟨P, hP⟩ := heq.exists
   have hid : (id : ProbabilityMeasure α → ProbabilityMeasure α) =ᵐ[π] fun _ => P :=
     heq.mono fun Q hQ => he_inj (hQ.trans hP.symm)

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -244,7 +244,7 @@ theorem IsZeroOneMeasure.exists_eq_dirac_probabilityMeasure [CountablyGenerated 
     simp
   letI : ∀ _ : {s : Set α // s ∈ 𝒜}, StandardBorelSpace ℝ≥0∞ :=
     fun _ => standardBorel_of_polish
-  obtain ⟨q, heq⟩ := exists_ae_eq_const_of_isZeroOneMeasure (π := π) he
+  obtain ⟨q, heq⟩ := IsZeroOneMeasure.exists_ae_eq_const (π := π) he.aemeasurable
   obtain ⟨P, hP⟩ := heq.exists
   have hid : (id : ProbabilityMeasure α → ProbabilityMeasure α) =ᵐ[π] fun _ => P :=
     heq.mono fun Q hQ => he_inj (hQ.trans hP.symm)

--- a/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
+++ b/TauCeti/MeasureTheory/Measure/ProbabilityMeasureExt.lean
@@ -9,6 +9,7 @@ public import Mathlib.MeasureTheory.Measure.ProbabilityMeasure
 public import Mathlib.MeasureTheory.Measure.Typeclasses.ZeroOne
 import Mathlib.MeasureTheory.Constructions.Projective
 import Mathlib.MeasureTheory.SetAlgebra
+import TauCeti.MeasureTheory.Measure.ZeroOne
 
 /-!
 # Finite evaluation laws determine a measure on `ProbabilityMeasure α`
@@ -203,25 +204,6 @@ theorem Measure.ext_of_forall_map_probabilityMeasure_eval_eq
       rwa [← measurableSpace_probabilityMeasure_eq_comap]
     exact MeasurableSpace.measurableSet_comap.1 hT'
   rw [← Measure.map_apply measurable_evalReal hU, ← Measure.map_apply measurable_evalReal hU, key]
-
-/-- **A zero-one law is almost surely constant along a measurable map.** If the pushforward lands
-in a standard Borel space it is again a zero-one probability measure, hence Dirac, and the map
-therefore agrees almost everywhere with a single value. -/
-private theorem exists_ae_eq_const_of_isZeroOneMeasure {Ω β : Type*} [MeasurableSpace Ω]
-    [MeasurableSpace β] [StandardBorelSpace β] {π : Measure Ω} [IsProbabilityMeasure π]
-    [IsZeroOneMeasure π] {f : Ω → β} (hf : Measurable f) :
-    ∃ q : β, ∀ᵐ ω ∂π, f ω = q := by
-  haveI : IsProbabilityMeasure (π.map f) := Measure.isProbabilityMeasure_map hf.aemeasurable
-  haveI : IsZeroOneMeasure (π.map f) := {
-    zero_one₀ := fun s hs => by
-      rw [Measure.map_apply hf hs]
-      exact _root_.MeasureTheory.Measure.zero_one π (f ⁻¹' s) }
-  obtain ⟨q, hq⟩ := IsZeroOneMeasure.exists_eq_dirac (μ := π.map f)
-  have hsingleton : MeasurableSet ({q} : Set β) := MeasurableSet.singleton q
-  have hmass : π (f ⁻¹' {q}) = 1 := by
-    rw [← Measure.map_apply hf hsingleton, hq]
-    simp
-  exact ⟨q, (_root_.MeasureTheory.mem_ae_iff_prob_eq_one (hsingleton.preimage hf)).2 hmass⟩
 
 /-- A nonzero zero-one law on `ProbabilityMeasure α` is a Dirac measure when the measurable
 space on `α` is countably generated.

--- a/TauCeti/MeasureTheory/Measure/ZeroOne.lean
+++ b/TauCeti/MeasureTheory/Measure/ZeroOne.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Constructions.Polish.Basic
+public import Mathlib.MeasureTheory.Measure.Typeclasses.ZeroOne
+
+/-!
+# Zero-one laws are almost surely constant
+
+A zero-one measure gives every measurable set mass `0` or `1`. Mathlib's
+`MeasureTheory.IsZeroOneMeasure.exists_eq_dirac` identifies such a measure with a Dirac mass, but
+only when the carrier is standard Borel. This file records the form that survives on an arbitrary
+carrier: a measurable map *into* a standard Borel space is almost surely constant, because its
+pushforward is again a zero-one probability measure and is therefore Dirac.
+
+That is the form a carrier without a standard Borel structure of its own needs, since such a space
+can still be embedded measurably into one and the conclusion pulled back along the embedding.
+
+## Main results
+
+* `TauCeti.MeasureTheory.exists_ae_eq_const_of_isZeroOneMeasure`: under a zero-one measure, a
+  measurable map into a standard Borel space agrees almost everywhere with a single value.
+-/
+
+public section
+
+open MeasureTheory
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+/-- **A zero-one law is almost surely constant along a measurable map.** The pushforward of a
+zero-one probability measure along `f` is again a zero-one probability measure; on a standard Borel
+space it is therefore a Dirac mass at some `q`, and the fibre `f ⁻¹' {q}` has full measure.
+
+Only the measurability of `f` is required: the carrier `Ω` needs no topological or Borel structure,
+which is the point of the statement. -/
+theorem exists_ae_eq_const_of_isZeroOneMeasure {Ω β : Type*} [MeasurableSpace Ω]
+    [MeasurableSpace β] [StandardBorelSpace β] {π : Measure Ω} [IsProbabilityMeasure π]
+    [IsZeroOneMeasure π] {f : Ω → β} (hf : Measurable f) :
+    ∃ q : β, ∀ᵐ ω ∂π, f ω = q := by
+  haveI : IsProbabilityMeasure (π.map f) := Measure.isProbabilityMeasure_map hf.aemeasurable
+  haveI : IsZeroOneMeasure (π.map f) := {
+    zero_one₀ := fun s hs => by
+      rw [Measure.map_apply hf hs]
+      exact _root_.MeasureTheory.Measure.zero_one π (f ⁻¹' s) }
+  obtain ⟨q, hq⟩ := IsZeroOneMeasure.exists_eq_dirac (μ := π.map f)
+  have hsingleton : MeasurableSet ({q} : Set β) := MeasurableSet.singleton q
+  have hmass : π (f ⁻¹' {q}) = 1 := by
+    rw [← Measure.map_apply hf hsingleton, hq]
+    simp
+  exact ⟨q, (_root_.MeasureTheory.mem_ae_iff_prob_eq_one (hsingleton.preimage hf)).2 hmass⟩
+
+end MeasureTheory
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/ZeroOne.lean
+++ b/TauCeti/MeasureTheory/Measure/ZeroOne.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Constructions.Polish.Basic
 public import Mathlib.MeasureTheory.Measure.Typeclasses.ZeroOne
 
 /-!
@@ -16,13 +15,17 @@ only when the carrier is standard Borel. This file records the form that survive
 carrier: a measurable map *into* a standard Borel space is almost surely constant, because its
 pushforward is again a zero-one probability measure and is therefore Dirac.
 
-That is the form a carrier without a standard Borel structure of its own needs, since such a space
-can still be embedded measurably into one and the conclusion pulled back along the embedding.
+The carrier itself needs no Borel structure, so this applies to a space that carries a measurable
+map into a standard Borel space without being one — for instance `ProbabilityMeasure α` for a
+countably generated `α`, which
+`TauCeti.MeasureTheory.IsZeroOneMeasure.exists_eq_dirac_probabilityMeasure` evaluates into a
+countable power of `ℝ≥0∞`.
 
 ## Main results
 
-* `TauCeti.MeasureTheory.exists_ae_eq_const_of_isZeroOneMeasure`: under a zero-one measure, a
-  measurable map into a standard Borel space agrees almost everywhere with a single value.
+* `TauCeti.MeasureTheory.IsZeroOneMeasure.exists_ae_eq_const`: under a zero-one measure, an
+  almost-everywhere measurable map into a standard Borel space agrees almost everywhere with a
+  single value.
 -/
 
 public section
@@ -34,26 +37,28 @@ namespace TauCeti
 namespace MeasureTheory
 
 /-- **A zero-one law is almost surely constant along a measurable map.** The pushforward of a
-zero-one probability measure along `f` is again a zero-one probability measure; on a standard Borel
-space it is therefore a Dirac mass at some `q`, and the fibre `f ⁻¹' {q}` has full measure.
+nonzero zero-one measure along `f` is again a zero-one probability measure; on a standard Borel
+space it is therefore a Dirac mass at some `q`, and `f` equals `q` almost everywhere.
 
-Only the measurability of `f` is required: the carrier `Ω` needs no topological or Borel structure,
-which is the point of the statement. -/
-theorem exists_ae_eq_const_of_isZeroOneMeasure {Ω β : Type*} [MeasurableSpace Ω]
-    [MeasurableSpace β] [StandardBorelSpace β] {π : Measure Ω} [IsProbabilityMeasure π]
-    [IsZeroOneMeasure π] {f : Ω → β} (hf : Measurable f) :
+The carrier `Ω` needs no topological or Borel structure of its own, and `f` need only be
+almost-everywhere measurable. -/
+theorem IsZeroOneMeasure.exists_ae_eq_const {Ω β : Type*} [MeasurableSpace Ω] [MeasurableSpace β]
+    [StandardBorelSpace β] {π : Measure Ω} [NeZero π] [_root_.MeasureTheory.IsZeroOneMeasure π]
+    {f : Ω → β} (hf : AEMeasurable f π) :
     ∃ q : β, ∀ᵐ ω ∂π, f ω = q := by
-  haveI : IsProbabilityMeasure (π.map f) := Measure.isProbabilityMeasure_map hf.aemeasurable
-  haveI : IsZeroOneMeasure (π.map f) := {
+  haveI : IsProbabilityMeasure π := by
+    rcases IsZeroOrProbabilityMeasure.measure_univ (μ := π) with (h | h)
+    · simp_all
+    · exact ⟨h⟩
+  haveI : IsProbabilityMeasure (π.map f) := Measure.isProbabilityMeasure_map hf
+  haveI : _root_.MeasureTheory.IsZeroOneMeasure (π.map f) := {
     zero_one₀ := fun s hs => by
-      rw [Measure.map_apply hf hs]
+      rw [Measure.map_apply_of_aemeasurable hf hs]
       exact _root_.MeasureTheory.Measure.zero_one π (f ⁻¹' s) }
-  obtain ⟨q, hq⟩ := IsZeroOneMeasure.exists_eq_dirac (μ := π.map f)
-  have hsingleton : MeasurableSet ({q} : Set β) := MeasurableSet.singleton q
-  have hmass : π (f ⁻¹' {q}) = 1 := by
-    rw [← Measure.map_apply hf hsingleton, hq]
-    simp
-  exact ⟨q, (_root_.MeasureTheory.mem_ae_iff_prob_eq_one (hsingleton.preimage hf)).2 hmass⟩
+  obtain ⟨q, hq⟩ := _root_.MeasureTheory.IsZeroOneMeasure.exists_eq_dirac (μ := π.map f)
+  refine ⟨q, ae_of_ae_map (p := fun y => y = q) hf ?_⟩
+  rw [hq]
+  simp
 
 end MeasureTheory
 


### PR DESCRIPTION
`IsZeroOneMeasure.exists_eq_dirac_probabilityMeasure` had a **55-line body**,
about twenty lines of which were a self-contained argument that never mentions
`ProbabilityMeasure α` or the countable generating algebra:

* form `π.map e`;
* equip it with `IsProbabilityMeasure` and `IsZeroOneMeasure`;
* apply Mathlib's `IsZeroOneMeasure.exists_eq_dirac` to get a Dirac point `q`;
* turn the Dirac mass back into `∀ᵐ P ∂π, e P = q`.

That is just: **a zero-one law is almost surely constant along a measurable
map into a standard Borel space.** Only the measurability of the map is
needed — the carrier `Ω` needs no Borel structure of its own, which is the
whole point, since that is why the caller has to embed into a product in the
first place.

```lean
theorem exists_ae_eq_const_of_isZeroOneMeasure {Ω β : Type*} [MeasurableSpace Ω]
    [MeasurableSpace β] [StandardBorelSpace β] {π : Measure Ω} [IsProbabilityMeasure π]
    [IsZeroOneMeasure π] {f : Ω → β} (hf : Measurable f) :
    ∃ q : β, ∀ᵐ ω ∂π, f ω = q
```

Since it is generic measure theory it lives in its own module,
`TauCeti/MeasureTheory/Measure/ZeroOne.lean`, rather than inside the
`ProbabilityMeasure` extension file, and is public there. (An earlier revision
of this PR kept it private in `ProbabilityMeasureExt.lean`; the `placement`
rubric correctly objected that a lemma mentioning none of that file's concepts
should not be hidden in it.)

Extracting it also removes the `change πe {q} = 1` step, which existed only to
fold the local name `πe` so the Dirac equality could rewrite.

One wrinkle worth recording: the call site passes `(π := π)` explicitly. `π`
occurs only in the conclusion, so at instance-resolution time
`IsZeroOneMeasure ?m` is stuck on a metavariable — Lean reports *"typeclass
instance problem is stuck"*. Supplying `β` does **not** help; `π` is the one
that must be pinned.

Body: **55 → 36**. The public signature of
`exists_eq_dirac_probabilityMeasure` is unchanged; its only consumer,
`Probability/Exchangeability/PathSpace/Law/Extreme.lean`, is untouched.

Gates run locally: `lake build` (6274 jobs), `lake exe axioms` (20554 decls in
allowlist), `lake exe module-system` (1132 modules), `scripts/lint-env.sh`
PASS.

Roadmap: Exchangeability