### PR TITLE
feat: identify fixed-object representations with comodules

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -18,9 +18,10 @@ Let `H` be a commutative Hopf algebra over a commutative ring `R`, and let `V` b
 
 `A ↦ Hom_{R-alg}(H, A)`
 
-on the scalar extensions `A ⊗[R] V` with right `H`-comodule structures on `V`. Both `H` and
-the value algebras are kept in the same universe as `R` and `V`, so the universal point of `H`
-and the tensor-square value algebra can be used directly.
+on the scalar extensions `A ⊗[R] V` with right `H`-comodule structures on `V`. The base ring,
+Hopf algebra, and module may lie in separate universes. The value-algebra category is placed in
+their maximum universe, so the universal values `H`, `R`, and `H ⊗[R] H` are accessed through
+their canonical universe lifts.
 
 The action associated to a coaction `ρ(v) = ∑ v₀ ⊗ v₁` is characterized by
 
@@ -53,9 +54,9 @@ namespace TauCeti
 
 namespace HopfAlgebra
 
-universe u
+universe u v w
 
-variable {R H V : Type u} [CommRing R] [CommRing H]
+variable {R : Type u} {H : Type v} {V : Type w} [CommRing R] [CommRing H]
 variable [_root_.HopfAlgebra R H]
 variable [AddCommMonoid V] [Module R V]
 
@@ -64,14 +65,26 @@ variable [AddCommMonoid V] [Module R V]
 It is a natural family of group homomorphisms from the convolution group of `A`-points to the
 linear automorphisms of `A ⊗[R] V`, for every commutative `R`-algebra `A`. -/
 noncomputable abbrev PointRepresentation :=
-  pointsFunctor (R := R) (H := H) ⟶
-    GeneralLinear.scalarExtensionAutomorphismsFunctor (R := R) (V := V)
+  (pointsFunctor (R := R) (H := H) :
+      CommAlgCat.{max u v w} R ⥤ GrpCat.{max u v w}) ⟶
+    (GeneralLinear.scalarExtensionAutomorphismsFunctor (R := R) (V := V) :
+      CommAlgCat.{max u v w} R ⥤ GrpCat.{max u v w})
 
 namespace PointRepresentation
 
+private noncomputable def liftedCounitAlgHom (_V : Type w) :
+    ULift.{max u v w} H →ₐ[R] ULift.{max u v w} R :=
+  ULift.algEquiv.symm.toAlgHom.comp
+    ((Bialgebra.counitAlgHom R H).comp ULift.algEquiv.toAlgHom)
+
+private noncomputable def liftedComulAlgHom (_V : Type w) :
+    ULift.{max u v w} H →ₐ[R] ULift.{max u v w} (H ⊗[R] H) :=
+  ULift.algEquiv.symm.toAlgHom.comp
+    ((Bialgebra.comulAlgHom R H).comp ULift.algEquiv.toAlgHom)
+
 /-- The group homomorphism at a value algebra, with the opaque functor object equalities removed. -/
 noncomputable def action (Theta : PointRepresentation (R := R) (H := H) (V := V))
-    (A : CommAlgCat.{u} R) :
+    (A : CommAlgCat.{max u v w} R) :
     points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A :=
   Theta.app A ≫
     eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A)
@@ -79,7 +92,7 @@ noncomputable def action (Theta : PointRepresentation (R := R) (H := H) (V := V)
 /-- Naturality of a point representation, expressed using the concrete point and scalar-extension
 groups. -/
 theorem action_naturality (Theta : PointRepresentation (R := R) (H := H) (V := V))
-    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) :
+    {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) :
     GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi (Theta.action A x) =
       Theta.action B (mapPoints (H := H) phi x) := by
   have h := Theta.naturality phi
@@ -87,21 +100,13 @@ theorem action_naturality (Theta : PointRepresentation (R := R) (H := H) (V := V
     f ≫ eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) B)) h
   simp only [pointsFunctor_map, GeneralLinear.scalarExtensionAutomorphismsFunctor_map,
     Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id] at h'
-  have h'' := congrArg (fun f ↦ f x) h'.symm
-  change
-    GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi
-        ((Theta.app A ≫
-          eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A)) x) =
-      (Theta.app B ≫
-          eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) B))
-        (mapPoints (H := H) phi x) at h''
-  exact h''
+  exact (ConcreteCategory.congr_hom h'.symm x)
 
 /-- Naturality determines the action of a transported point on the canonical copy of `V`. -/
 @[simp]
 theorem action_mapPoints_one_tmul
     (Theta : PointRepresentation (R := R) (H := H) (V := V))
-    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
+    {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
     (Theta.action B (mapPoints (H := H) phi x)).val (1 ⊗ₜ[R] v) =
       GeneralLinear.scalarExtensionMap (V := V) phi
         ((Theta.action A x).val (1 ⊗ₜ[R] v)) := by
@@ -111,13 +116,13 @@ theorem action_mapPoints_one_tmul
       (V := V) phi (Theta.action A x) (1 ⊗ₜ[R] v))
 
 private noncomputable def evaluatedCoaction (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
     V →ₗ[R] A ⊗[R] V :=
   (TensorProduct.comm R V A).toLinearMap ∘ₗ
     TensorProduct.map LinearMap.id x.ofConv.toLinearMap ∘ₗ rho.coact
 
 private noncomputable def pointActionEnd (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
     Module.End A (A ⊗[R] V) := by
   let u := evaluatedCoaction rho A x
   exact TensorProduct.AlgebraTensorModule.lift
@@ -129,17 +134,19 @@ private noncomputable def pointActionEnd (rho : Comodule R H V)
             exact smul_comm a r (u v) }
       map_add' := fun a b ↦ LinearMap.ext fun v ↦ add_smul a b (u v)
       map_smul' := fun a b ↦ LinearMap.ext fun v ↦ by
+        -- `AlgebraTensorModule.lift` stores this law through two bundled linear maps, and no
+        -- projection lemma normalizes their scalar actions to multiplication in `A`.
         change (a * b) • u v = a • b • u v
         exact (smul_smul a b (u v)).symm }
 
 @[simp]
 private theorem pointActionEnd_tmul (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x : points (H := H) A) (a : A) (v : V) :
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) (a : A) (v : V) :
     pointActionEnd rho A x (a ⊗ₜ[R] v) = a • evaluatedCoaction rho A x v :=
   by simp [pointActionEnd]
 
 private theorem evaluatedCoaction_one (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (v : V) :
+    (A : CommAlgCat.{max u v w} R) (v : V) :
     evaluatedCoaction rho A (1 : points (H := H) A) v = 1 ⊗ₜ[R] v := by
   letI : Comodule R H V := rho
   have hmap :
@@ -157,13 +164,13 @@ private theorem evaluatedCoaction_one (rho : Comodule R H V)
   simp
 
 private theorem pointActionEnd_one (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) :
+    (A : CommAlgCat.{max u v w} R) :
     pointActionEnd rho A (1 : points (H := H) A) = 1 := by
   refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
   rw [pointActionEnd_tmul, evaluatedCoaction_one]
   exact (TensorProduct.tmul_eq_smul_one_tmul (M := V) a v).symm
 
-private noncomputable def pairedEvaluation (A : CommAlgCat.{u} R)
+private noncomputable def pairedEvaluation (A : CommAlgCat.{max u v w} R)
     (x y : points (H := H) A) :
     V ⊗[R] (H ⊗[R] H) →ₗ[R] A ⊗[R] V :=
   (TensorProduct.comm R V A).toLinearMap ∘ₗ
@@ -171,7 +178,7 @@ private noncomputable def pairedEvaluation (A : CommAlgCat.{u} R)
       (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)).toLinearMap
 
 private theorem pairedEvaluation_comul (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x y : points (H := H) A) (v : V) :
+    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) (v : V) :
     pairedEvaluation A x y
         (Coalgebra.comul.lTensor V (rho.coact v)) =
       evaluatedCoaction rho A (x * y) v := by
@@ -180,6 +187,8 @@ private theorem pairedEvaluation_comul (rho : Comodule R H V)
         (TensorProduct.comm R V A).toLinearMap ∘ₗ
           TensorProduct.map LinearMap.id (x * y).ofConv.toLinearMap := by
     ext m h
+    -- `TensorProduct.ext'` presents the composite through `AlgebraTensorModule.curry`; there is
+    -- no curry computation lemma exposing the pure-tensor evaluation of these bundled maps.
     change
       (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)
           (Coalgebra.comul h)) ⊗ₜ[R] m =
@@ -189,7 +198,7 @@ private theorem pairedEvaluation_comul (rho : Comodule R H V)
   rfl
 
 private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x y : points (H := H) A) (v : V) :
+    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) (v : V) :
     pointActionEnd rho A x (evaluatedCoaction rho A y v) =
       pairedEvaluation A x y
         (TensorProduct.assoc R V H H (rho.coact.rTensor H (rho.coact v))) := by
@@ -200,6 +209,8 @@ private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
         pairedEvaluation (V := V) A x y ∘ₗ
           (TensorProduct.assoc R V H H).toLinearMap ∘ₗ rho.coact.rTensor H := by
     ext m h
+    -- The tensor extensionality goal is again curried, while the available computation rules are
+    -- stated for uncurried `map`, `rTensor`, and associator applications.
     change
       pointActionEnd rho A x (y.ofConv h ⊗ₜ[R] m) =
         pairedEvaluation A x y
@@ -220,6 +231,8 @@ private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
     exact hz (rho.coact m)
   have hv := congrArg (fun f : V ⊗[R] H →ₗ[R] A ⊗[R] V ↦ f (rho.coact v)) hmap
   simp only [LinearMap.comp_apply] at hv
+  -- `restrictScalars` and the tensor linear-equivalence coercion remain in `hv`; their public
+  -- application lemmas do not rewrite the bundled function coercions simultaneously.
   change
     pointActionEnd rho A x
         (TensorProduct.comm R V A
@@ -227,7 +240,7 @@ private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
   exact hv
 
 private theorem pointActionEnd_mul (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x y : points (H := H) A) :
+    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) :
     pointActionEnd rho A (x * y) = pointActionEnd rho A x * pointActionEnd rho A y := by
   letI : Comodule R H V := rho
   refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
@@ -236,25 +249,25 @@ private theorem pointActionEnd_mul (rho : Comodule R H V)
     pairedEvaluation_comul]
 
 private noncomputable def pointActionMonoidHom (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) :
+    (A : CommAlgCat.{max u v w} R) :
     points (H := H) A →* Module.End A (A ⊗[R] V) where
   toFun := pointActionEnd rho A
   map_one' := pointActionEnd_one rho A
   map_mul' := pointActionEnd_mul rho A
 
 private noncomputable def rawPointAction (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) :
+    (A : CommAlgCat.{max u v w} R) :
     points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A :=
   GrpCat.ofHom (pointActionMonoidHom rho A).toHomUnits
 
 @[simp]
 private theorem rawPointAction_val (rho : Comodule R H V)
-    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
     (rawPointAction rho A x).val = pointActionEnd rho A x :=
   rfl
 
 private theorem evaluatedCoaction_naturality (rho : Comodule R H V)
-    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
+    {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
     GeneralLinear.scalarExtensionMap (V := V) phi (evaluatedCoaction rho A x v) =
       evaluatedCoaction rho B (mapPoints (H := H) phi x) v := by
   have hz : ∀ z : V ⊗[R] H,
@@ -276,7 +289,7 @@ private theorem evaluatedCoaction_naturality (rho : Comodule R H V)
   exact hz (rho.coact v)
 
 private theorem rawPointAction_naturality (rho : Comodule R H V)
-    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) :
+    {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) :
     GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi (rawPointAction rho A x) =
       rawPointAction rho B (mapPoints (H := H) phi x) := by
   symm
@@ -288,6 +301,8 @@ private theorem rawPointAction_naturality (rho : Comodule R H V)
   | zero => simp
   | tmul a v =>
       rw [GeneralLinear.scalarExtensionMap_tmul]
+      -- `rawPointAction` is wrapped successively as a unit and a `GrpCat` morphism; its value
+      -- theorem does not match until those function coercions are exposed.
       change
         pointActionEnd rho B (mapPoints (H := H) phi x)
             (phi.hom a ⊗ₜ[R] v) =
@@ -303,6 +318,8 @@ noncomputable def ofComodule (rho : Comodule R H V) :
   app A := rawPointAction rho A ≫
     eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm
   naturality A B phi := by
+    -- `pointsFunctor_obj` and the scalar-extension object theorem are categorical equalities,
+    -- with no computation lemma that rewrites this structure-field goal before it is exposed.
     change
       mapPoints (H := H) phi ≫ rawPointAction rho B ≫
           eqToHom
@@ -311,7 +328,6 @@ noncomputable def ofComodule (rho : Comodule R H V) :
           eqToHom
             (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm ≫
           (GeneralLinear.scalarExtensionAutomorphismsFunctor (V := V)).map phi
-    rw [GeneralLinear.scalarExtensionAutomorphismsFunctor_map]
     have hraw :
         mapPoints (H := H) phi ≫ rawPointAction rho B =
           rawPointAction rho A ≫
@@ -319,13 +335,17 @@ noncomputable def ofComodule (rho : Comodule R H V) :
       apply GrpCat.ext
       intro x
       exact (rawPointAction_naturality rho phi x).symm
+    rw [GeneralLinear.scalarExtensionAutomorphismsFunctor_map]
     rw [← Category.assoc, hraw]
     simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
 
 @[simp]
-private theorem action_ofComodule (rho : Comodule R H V) (A : CommAlgCat.{u} R) :
+private theorem action_ofComodule (rho : Comodule R H V)
+    (A : CommAlgCat.{max u v w} R) :
     (ofComodule rho).action A = rawPointAction rho A := by
   rw [action, ofComodule]
+  -- The natural-transformation component is stored with the inverse of the opaque object
+  -- equality; expose that categorical composite before cancelling the two transports.
   change
     (rawPointAction rho A ≫
         eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm) ≫
@@ -335,7 +355,8 @@ private theorem action_ofComodule (rho : Comodule R H V) (A : CommAlgCat.{u} R) 
 
 /-- The action induced by a coaction, evaluated on a pure tensor. -/
 @[simp]
-theorem ofComodule_action_tmul (rho : Comodule R H V) (A : CommAlgCat.{u} R)
+theorem ofComodule_action_tmul (rho : Comodule R H V)
+    (A : CommAlgCat.{max u v w} R)
     (x : points (H := H) A) (a : A) (v : V) :
     ((ofComodule rho).action A x).val (a ⊗ₜ[R] v) =
       a • TensorProduct.comm R V A
@@ -346,66 +367,119 @@ theorem ofComodule_action_tmul (rho : Comodule R H V) (A : CommAlgCat.{u} R)
 /-- At the universal point, the action induced by a coaction is the flipped coaction. -/
 @[simp]
 theorem ofComodule_action_universal_one_tmul (rho : Comodule R H V) (v : V) :
-    ((ofComodule rho).action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
-        (1 ⊗ₜ[R] v) =
-      TensorProduct.comm R V H (rho.coact v) := by
+    ((ofComodule rho).action (CommAlgCat.of R (ULift.{max u v w} H))
+        (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v) =
+      TensorProduct.comm R V (ULift.{max u v w} H)
+        (TensorProduct.map LinearMap.id ULift.algEquiv.symm.toLinearMap (rho.coact v)) := by
   rw [ofComodule_action_tmul]
-  simp only [one_smul, AlgHom.toLinearMap_id, TensorProduct.map_id,
-    LinearMap.id_apply]
+  exact one_smul (ULift.{max u v w} H)
+    (TensorProduct.comm R V (ULift.{max u v w} H)
+      (TensorProduct.map LinearMap.id ULift.algEquiv.symm.toLinearMap (rho.coact v)))
 
 private noncomputable def universalGenerator
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    V →ₗ[R] ULift.{max u v w} H ⊗[R] V :=
+  ((Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+      (toConv ULift.algEquiv.symm.toAlgHom)).val.restrictScalars R) ∘ₗ
+    TensorProduct.mk R (ULift.{max u v w} H) V 1
+
+private noncomputable def universalGeneratorDown
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
     V →ₗ[R] H ⊗[R] V :=
-  ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val.restrictScalars R) ∘ₗ
-    TensorProduct.mk R H V 1
+  TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id ∘ₗ universalGenerator Theta
 
 private noncomputable def recoveredCoaction
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
     V →ₗ[R] V ⊗[R] H :=
-  (TensorProduct.comm R H V).toLinearMap ∘ₗ universalGenerator Theta
+  (TensorProduct.comm R H V).toLinearMap ∘ₗ universalGeneratorDown Theta
 
 @[simp]
 private theorem universalGenerator_apply
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
     universalGenerator Theta v =
-      (Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
-        (1 ⊗ₜ[R] v) :=
+      (Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+        (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v) :=
+  rfl
+
+@[simp]
+private theorem universalGeneratorDown_apply
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    universalGeneratorDown Theta v =
+      TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id (universalGenerator Theta v) :=
   rfl
 
 @[simp]
 private theorem recoveredCoaction_apply
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
-    recoveredCoaction Theta v = TensorProduct.comm R H V (universalGenerator Theta v) :=
+    recoveredCoaction Theta v = TensorProduct.comm R H V (universalGeneratorDown Theta v) :=
   rfl
 
-private theorem mapPoints_universal {A : Type u} [CommRing A] [Algebra R A]
-    (phi : H →ₐ[R] A) :
-    mapPoints (H := H) (CommAlgCat.ofHom phi) (toConv (AlgHom.id R H)) =
-      toConv phi := by
-  apply WithConv.ofConv_injective
-  ext h
+omit [AddCommMonoid V] [Module R V] in
+private theorem mapPoints_universal {A : Type (max u v w)} [CommRing A] [Algebra R A]
+    (phi : ULift.{max u v w} H →ₐ[R] A) :
+    mapPoints (H := H) (CommAlgCat.ofHom phi)
+        (toConv ULift.algEquiv.symm.toAlgHom) =
+      toConv (phi.comp ULift.algEquiv.symm.toAlgHom) := by
   rfl
 
+omit [AddCommMonoid V] [Module R V] in
 private theorem mapPoints_universal_counit :
-    mapPoints (H := H) (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H))
-        (toConv (AlgHom.id R H)) = 1 := by
+    mapPoints (H := H) (CommAlgCat.ofHom (liftedCounitAlgHom (R := R) (H := H) V))
+        (toConv ULift.algEquiv.symm.toAlgHom) = 1 := by
   rw [mapPoints_universal]
   apply WithConv.ofConv_injective
   ext h
-  simp only [AlgHom.convOne_apply, Bialgebra.counitAlgHom_apply]
+  simp only [AlgHom.convOne_apply, Bialgebra.counitAlgHom_apply, AlgHom.coe_comp,
+    Function.comp_apply, liftedCounitAlgHom]
   rfl
 
 private theorem scalarExtensionMap_counit_universalGenerator
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
     GeneralLinear.scalarExtensionMap (V := V)
-        (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H)) (universalGenerator Theta v) =
+        (CommAlgCat.ofHom (liftedCounitAlgHom (R := R) (H := H) V))
+          (universalGenerator Theta v) =
       1 ⊗ₜ[R] v := by
   have h := Theta.action_mapPoints_one_tmul
-    (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H))
-      (toConv (AlgHom.id R H)) v
+    (CommAlgCat.ofHom (liftedCounitAlgHom (R := R) (H := H) V))
+      (toConv ULift.algEquiv.symm.toAlgHom) v
   rw [mapPoints_universal_counit,
-    (Theta.action (CommAlgCat.of R R)).hom.map_one] at h
+    (Theta.action (CommAlgCat.of R (ULift.{max u v w} R))).hom.map_one] at h
   simpa only [universalGenerator_apply, Units.val_one, Module.End.one_apply] using h.symm
+
+private theorem counit_rTensor_universalGeneratorDown
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    Coalgebra.counit.rTensor V (universalGeneratorDown Theta v) = 1 ⊗ₜ[R] v := by
+  have hvalue := scalarExtensionMap_counit_universalGenerator Theta v
+  have h := congrArg
+    (TensorProduct.map (R := R) ULift.algEquiv.toLinearMap LinearMap.id)
+    hvalue
+  have hmap : ∀ z : ULift.{max u v w} H ⊗[R] V,
+      TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+          (GeneralLinear.scalarExtensionMap (V := V)
+            (CommAlgCat.ofHom (liftedCounitAlgHom (R := R) (H := H) V)) z) =
+        Coalgebra.counit.rTensor V
+          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id z) := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | add z t hz ht => simpa only [map_add] using congrArg₂ (fun a b ↦ a + b) hz ht
+    | tmul a n =>
+        rw [GeneralLinear.scalarExtensionMap_tmul]
+        simp only [TensorProduct.map_tmul, LinearMap.id_apply, LinearMap.rTensor_tmul]
+        rfl
+  rw [hmap] at h
+  have hone : (ULift.algEquiv (R := R) (A := R)).toLinearMap
+      (1 : ULift.{max u v w} R) = 1 := rfl
+  simp only [TensorProduct.map_tmul, LinearMap.id_apply] at h
+  rw [hone] at h
+  simpa only [universalGeneratorDown_apply] using h
+
+private theorem comm_lTensor_comm_apply {P : Type*} [AddCommMonoid P] [Module R P]
+    (g : H →ₗ[R] P) (z : H ⊗[R] V) :
+    TensorProduct.comm R V P
+        (g.lTensor V (TensorProduct.comm R H V z)) =
+      g.rTensor V z := by
+  exact LinearMap.congr_fun (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) g) z
 
 private theorem recoveredCoaction_counit
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
@@ -414,35 +488,62 @@ private theorem recoveredCoaction_counit
   apply LinearMap.ext
   intro v
   apply (TensorProduct.comm R V R).injective
-  have hbridge := LinearMap.congr_fun
-    (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) (Coalgebra.counit (R := R) (A := H)))
-      (universalGenerator Theta v)
-  simp only [LinearMap.comp_apply] at hbridge
   simp only [LinearMap.comp_apply]
   rw [recoveredCoaction_apply]
-  change
-    TensorProduct.comm R V R
-        (Coalgebra.counit.lTensor V
-          (TensorProduct.comm R H V (universalGenerator Theta v))) =
-      Coalgebra.counit.rTensor V (universalGenerator Theta v) at hbridge
-  rw [hbridge]
+  rw [comm_lTensor_comm_apply]
   simp only [LinearMap.flip_apply, TensorProduct.mk_apply, TensorProduct.comm_tmul]
-  have hmap :
-      GeneralLinear.scalarExtensionMap (V := V)
-          (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H)) =
-        Coalgebra.counit.rTensor V := by
-    apply TensorProduct.ext'
-    intro h w
-    rw [GeneralLinear.scalarExtensionMap_tmul, LinearMap.rTensor_tmul]
-    rfl
-  rw [← hmap]
-  exact scalarExtensionMap_counit_universalGenerator Theta v
+  exact counit_rTensor_universalGeneratorDown Theta v
 
 private noncomputable abbrev includeLeftAlgHom : H →ₐ[R] H ⊗[R] H :=
   (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom
 
 private noncomputable abbrev includeRightAlgHom : H →ₐ[R] H ⊗[R] H :=
   (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom
+
+private theorem includeRight_mul_includeLeft (a b : H) :
+    includeRightAlgHom (R := R) (H := H) a *
+        includeLeftAlgHom (R := R) (H := H) b =
+      b ⊗ₜ[R] a := by
+  have hleft : includeLeftAlgHom (R := R) (H := H) b = b ⊗ₜ[R] 1 :=
+    Bialgebra.TensorProduct.includeLeft_apply b
+  have hright : includeRightAlgHom (R := R) (H := H) a = 1 ⊗ₜ[R] a :=
+    Bialgebra.TensorProduct.includeRight_apply a
+  rw [hleft, hright, Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
+
+private noncomputable def liftedIncludeLeftAlgHom (_V : Type w) :
+    ULift.{max u v w} H →ₐ[R] ULift.{max u v w} (H ⊗[R] H) :=
+  ULift.algEquiv.symm.toAlgHom.comp
+    ((includeLeftAlgHom (R := R) (H := H)).comp ULift.algEquiv.toAlgHom)
+
+private noncomputable def liftedIncludeRightAlgHom (_V : Type w) :
+    ULift.{max u v w} H →ₐ[R] ULift.{max u v w} (H ⊗[R] H) :=
+  ULift.algEquiv.symm.toAlgHom.comp
+    ((includeRightAlgHom (R := R) (H := H)).comp ULift.algEquiv.toAlgHom)
+
+private noncomputable def liftTensorSquare :
+    (H ⊗[R] H) ⊗[R] V ≃ₗ[R] ULift.{max u v w} (H ⊗[R] H) ⊗[R] V :=
+  TensorProduct.congr ULift.algEquiv.symm.toLinearEquiv (LinearEquiv.refl R V)
+
+omit [AddCommMonoid V] [Module R V] in
+@[simp]
+private theorem ofHom_liftedIncludeLeft_apply (a : ULift.{max u v w} H) :
+    (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V)).hom a =
+      liftedIncludeLeftAlgHom (R := R) (H := H) V a :=
+  rfl
+
+omit [AddCommMonoid V] [Module R V] in
+@[simp]
+private theorem ofHom_liftedIncludeRight_apply (a : ULift.{max u v w} H) :
+    (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V)).hom a =
+      liftedIncludeRightAlgHom (R := R) (H := H) V a :=
+  rfl
+
+omit [AddCommMonoid V] [Module R V] in
+@[simp]
+private theorem ofHom_liftedComul_apply (a : ULift.{max u v w} H) :
+    (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V)).hom a =
+      liftedComulAlgHom (R := R) (H := H) V a :=
+  rfl
 
 private theorem comulPoint_eq_include_mul :
     toConv (Bialgebra.comulAlgHom R H) =
@@ -457,106 +558,208 @@ private theorem comulPoint_eq_include_mul :
     Algebra.TensorProduct.lift_includeLeft_includeRight]
   rfl
 
+omit [AddCommMonoid V] [Module R V] in
+private theorem liftedComulPoint_eq_include_mul :
+    mapPoints (H := H)
+        (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+          (toConv ULift.algEquiv.symm.toAlgHom) =
+      mapPoints (H := H)
+          (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+            (toConv ULift.algEquiv.symm.toAlgHom) *
+        mapPoints (H := H)
+          (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+            (toConv ULift.algEquiv.symm.toAlgHom) := by
+  rw [mapPoints_universal, mapPoints_universal, mapPoints_universal]
+  let up : H ⊗[R] H →ₐ[R] ULift.{max u v w} (H ⊗[R] H) :=
+    ULift.algEquiv.symm.toAlgHom
+  have hcomul :
+      (liftedComulAlgHom (R := R) (H := H) V).comp ULift.algEquiv.symm.toAlgHom =
+        up.comp (Bialgebra.comulAlgHom R H) := by
+    ext h
+    rfl
+  have hleft :
+      (liftedIncludeLeftAlgHom (R := R) (H := H) V).comp
+          ULift.algEquiv.symm.toAlgHom =
+        up.comp (includeLeftAlgHom (R := R) (H := H)) := by
+    ext h
+    rfl
+  have hright :
+      (liftedIncludeRightAlgHom (R := R) (H := H) V).comp
+          ULift.algEquiv.symm.toAlgHom =
+        up.comp (includeRightAlgHom (R := R) (H := H)) := by
+    ext h
+    rfl
+  rw [hcomul, hleft, hright]
+  calc
+    toConv (up.comp (Bialgebra.comulAlgHom R H)) =
+        (AlgHom.mapValue (H := H) up) (toConv (Bialgebra.comulAlgHom R H)) := rfl
+    _ = (AlgHom.mapValue (H := H) up)
+        (toConv (includeLeftAlgHom (R := R) (H := H)) *
+          toConv (includeRightAlgHom (R := R) (H := H))) := by
+      rw [comulPoint_eq_include_mul]
+    _ = toConv (up.comp (includeLeftAlgHom (R := R) (H := H))) *
+        toConv (up.comp (includeRightAlgHom (R := R) (H := H))) := by
+      rw [map_mul]
+      rfl
+
+private theorem action_comul_eq_include_actions
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+        (mapPoints (H := H)
+          (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+            (toConv ULift.algEquiv.symm.toAlgHom)) =
+      Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+              (toConv ULift.algEquiv.symm.toAlgHom)) *
+        Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+              (toConv ULift.algEquiv.symm.toAlgHom)) := by
+  rw [liftedComulPoint_eq_include_mul]
+  exact (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))).hom.map_mul _ _
+
+private theorem action_includeLeft_includeRight_tmul
+    (Theta : PointRepresentation (R := R) (H := H) (V := V))
+    (a : ULift.{max u v w} H) (n : V) :
+    (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+        (mapPoints (H := H)
+          (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+            (toConv ULift.algEquiv.symm.toAlgHom))).val
+      (liftedIncludeRightAlgHom (R := R) (H := H) V a ⊗ₜ[R] n) =
+      liftedIncludeRightAlgHom (R := R) (H := H) V a •
+        GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+            (universalGenerator Theta n) := by
+  rw [TensorProduct.tmul_eq_smul_one_tmul (M := V), map_smul,
+    Theta.action_mapPoints_one_tmul
+      (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+        (toConv ULift.algEquiv.symm.toAlgHom) n]
+  rw [universalGenerator_apply]
+
+private theorem liftTensorSquare_iterated_tmul
+    (a : ULift.{max u v w} H) (z : ULift.{max u v w} H ⊗[R] V) :
+    liftTensorSquare (R := R) (H := H) (V := V)
+        (TensorProduct.comm R V (H ⊗[R] H)
+          (TensorProduct.assoc R V H H
+            (TensorProduct.comm R H V
+                (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id z) ⊗ₜ[R]
+              a.down))) =
+      liftedIncludeRightAlgHom (R := R) (H := H) V a •
+        GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V)) z := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z t hz ht =>
+      simpa only [map_add, TensorProduct.add_tmul, smul_add] using
+        congrArg₂ (fun x y ↦ x + y) hz ht
+  | tmul b n =>
+      simp only [TensorProduct.map_tmul, LinearMap.id_apply, TensorProduct.comm_tmul,
+        TensorProduct.assoc_tmul]
+      rw [GeneralLinear.scalarExtensionMap_tmul]
+      rw [ofHom_liftedIncludeLeft_apply]
+      simp only [liftTensorSquare, TensorProduct.congr_tmul]
+      apply congrArg (fun c : ULift.{max u v w} (H ⊗[R] H) ↦ c ⊗ₜ[R] n)
+      apply ULift.down_injective
+      exact (includeRight_mul_includeLeft (R := R) (H := H) a.down b.down).symm
+
 private theorem recoveredCoaction_iterate_eq_include_actions
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
-    TensorProduct.comm R V (H ⊗[R] H)
-        (TensorProduct.assoc R V H H
-          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
-      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-          (mapPoints (H := H)
-            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)))).val
-        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
-            (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) := by
-  rw [Theta.action_mapPoints_one_tmul
-    (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-      (toConv (AlgHom.id R H)) v]
-  change
-    TensorProduct.comm R V (H ⊗[R] H)
-        (TensorProduct.assoc R V H H
-          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
-      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-          (mapPoints (H := H)
-            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)))).val
-        (GeneralLinear.scalarExtensionMap (V := V)
-          (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-            (universalGenerator Theta v))
-  have hz : ∀ z : H ⊗[R] V,
-      TensorProduct.comm R V (H ⊗[R] H)
+    liftTensorSquare (R := R) (H := H) (V := V)
+        (TensorProduct.comm R V (H ⊗[R] H)
           (TensorProduct.assoc R V H H
-            ((recoveredCoaction Theta).rTensor H (TensorProduct.comm R H V z))) =
-        (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v)))) =
+      (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+              (toConv ULift.algEquiv.symm.toAlgHom))).val
+        ((Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
             (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H)))).val
+              (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+                (toConv ULift.algEquiv.symm.toAlgHom))).val (1 ⊗ₜ[R] v)) := by
+  rw [Theta.action_mapPoints_one_tmul
+    (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+      (toConv ULift.algEquiv.symm.toAlgHom) v]
+  rw [← universalGenerator_apply]
+  have hz : ∀ z : ULift.{max u v w} H ⊗[R] V,
+      liftTensorSquare (R := R) (H := H) (V := V)
+          (TensorProduct.comm R V (H ⊗[R] H)
+            (TensorProduct.assoc R V H H
+              ((recoveredCoaction Theta).rTensor H
+                (TensorProduct.comm R H V
+                  (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id z))))) =
+        (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+                (toConv ULift.algEquiv.symm.toAlgHom))).val
           (GeneralLinear.scalarExtensionMap (V := V)
-            (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H))) z) := by
+            (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V)) z) := by
     intro z
     induction z using TensorProduct.induction_on with
     | zero => simp
     | add z w hz hw => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) hz hw
-    | tmul h w =>
+    | tmul a n =>
         rw [GeneralLinear.scalarExtensionMap_tmul]
-        have haction :
-            (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-                (mapPoints (H := H)
-                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                    (toConv (AlgHom.id R H)))).val
-              (includeRightAlgHom (R := R) (H := H) h ⊗ₜ[R] w) =
-            includeRightAlgHom (R := R) (H := H) h •
-              GeneralLinear.scalarExtensionMap (V := V)
-                (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                  (universalGenerator Theta w) := by
-          rw [TensorProduct.tmul_eq_smul_one_tmul (M := V), map_smul,
-            Theta.action_mapPoints_one_tmul
-              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H)) w]
-          rfl
-        change
-          TensorProduct.comm R V (H ⊗[R] H)
-              (TensorProduct.assoc R V H H
-                ((recoveredCoaction Theta).rTensor H
-                  (TensorProduct.comm R H V (h ⊗ₜ[R] w)))) =
-            (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-                (mapPoints (H := H)
-                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                    (toConv (AlgHom.id R H)))).val
-              (includeRightAlgHom (R := R) (H := H) h ⊗ₜ[R] w)
-        rw [haction, TensorProduct.comm_tmul, LinearMap.rTensor_tmul,
-          recoveredCoaction_apply]
-        have hwz : ∀ z : H ⊗[R] V,
-            TensorProduct.comm R V (H ⊗[R] H)
-                (TensorProduct.assoc R V H H
-                  (TensorProduct.comm R H V z ⊗ₜ[R] h)) =
-              includeRightAlgHom (R := R) (H := H) h •
-                GeneralLinear.scalarExtensionMap (V := V)
-                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H))) z := by
-          intro z
-          induction z using TensorProduct.induction_on with
-          | zero => simp
-          | add z w hz hw =>
-              simpa only [map_add, smul_add, TensorProduct.add_tmul] using
-                congrArg₂ (fun p q ↦ p + q) hz hw
-          | tmul k n =>
-              simp only [TensorProduct.comm_tmul, TensorProduct.assoc_tmul]
-              rw [GeneralLinear.scalarExtensionMap_tmul]
-              change
-                (k ⊗ₜ[R] h) ⊗ₜ[R] n =
-                  includeRightAlgHom (R := R) (H := H) h •
-                    (includeLeftAlgHom (R := R) (H := H) k ⊗ₜ[R] n)
-              have hleft : includeLeftAlgHom (R := R) (H := H) k = k ⊗ₜ[R] 1 :=
-                Bialgebra.TensorProduct.includeLeft_apply k
-              have hright : includeRightAlgHom (R := R) (H := H) h = 1 ⊗ₜ[R] h :=
-                Bialgebra.TensorProduct.includeRight_apply h
-              rw [hleft, hright, TensorProduct.smul_tmul']
-              rw [smul_eq_mul]
-              rw [Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
-        exact hwz (universalGenerator Theta w)
-  rw [recoveredCoaction_apply]
+        rw [ofHom_liftedIncludeRight_apply]
+        rw [action_includeLeft_includeRight_tmul]
+        simp only [TensorProduct.map_tmul, LinearMap.id_apply, TensorProduct.comm_tmul,
+          LinearMap.rTensor_tmul, recoveredCoaction_apply, universalGeneratorDown_apply]
+        exact liftTensorSquare_iterated_tmul a (universalGenerator Theta n)
+  rw [recoveredCoaction_apply, universalGeneratorDown_apply]
   exact hz (universalGenerator Theta v)
+
+private theorem scalarExtensionMap_comul_eq_liftTensorSquare
+    (z : ULift.{max u v w} H ⊗[R] V) :
+    GeneralLinear.scalarExtensionMap (V := V)
+        (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V)) z =
+      liftTensorSquare (R := R) (H := H) (V := V)
+        (Coalgebra.comul.rTensor V
+          (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id z)) := by
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | add z t hz ht => simpa only [map_add] using congrArg₂ (fun x y ↦ x + y) hz ht
+  | tmul a n =>
+      rw [GeneralLinear.scalarExtensionMap_tmul, ofHom_liftedComul_apply,
+        TensorProduct.map_tmul, LinearMap.rTensor_tmul]
+      simp only [liftTensorSquare, TensorProduct.congr_tmul]
+      rfl
+
+private theorem include_actions_eq_scalarExtensionMap_comul
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+        (mapPoints (H := H)
+          (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+            (toConv ULift.algEquiv.symm.toAlgHom))).val
+      ((Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+              (toConv ULift.algEquiv.symm.toAlgHom))).val (1 ⊗ₜ[R] v)) =
+      GeneralLinear.scalarExtensionMap (V := V)
+        (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+          (universalGenerator Theta v) := by
+  have hvalue := congrArg
+    (fun g : GeneralLinear.scalarExtensionAutomorphisms (V := V)
+        (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H))) ↦ g.val (1 ⊗ₜ[R] v))
+    (action_comul_eq_include_actions Theta)
+  have hnatural := Theta.action_mapPoints_one_tmul
+    (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+      (toConv ULift.algEquiv.symm.toAlgHom) v
+  have hcompose :
+      (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+              (toConv ULift.algEquiv.symm.toAlgHom))).val (1 ⊗ₜ[R] v) =
+        (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+                (toConv ULift.algEquiv.symm.toAlgHom))).val
+          ((Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+              (mapPoints (H := H)
+                (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+                  (toConv ULift.algEquiv.symm.toAlgHom))).val (1 ⊗ₜ[R] v)) := by
+    simpa only [Units.val_mul, Module.End.mul_apply] using hvalue
+  rw [← hcompose, hnatural]
+  rw [universalGenerator_apply]
 
 private theorem recoveredCoaction_coassoc
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
@@ -566,97 +769,36 @@ private theorem recoveredCoaction_coassoc
   apply LinearMap.ext
   intro v
   apply (TensorProduct.comm R V (H ⊗[R] H)).injective
+  apply (liftTensorSquare (R := R) (H := H) (V := V)).injective
   simp only [LinearMap.comp_apply]
-  change
-    TensorProduct.comm R V (H ⊗[R] H)
-        (TensorProduct.assoc R V H H
-          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
-      TensorProduct.comm R V (H ⊗[R] H)
-        (Coalgebra.comul.lTensor V (recoveredCoaction Theta v))
-  rw [recoveredCoaction_iterate_eq_include_actions]
-  have hpoint :
-      mapPoints (H := H)
-          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
-            (toConv (AlgHom.id R H)) =
-        mapPoints (H := H)
-            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)) *
-          mapPoints (H := H)
-            (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)) := by
-    rw [mapPoints_universal, mapPoints_universal, mapPoints_universal]
-    exact comulPoint_eq_include_mul (R := R) (H := H)
-  have haction :
-      Theta.action (CommAlgCat.of R (H ⊗[R] H))
-          (mapPoints (H := H)
-            (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
-              (toConv (AlgHom.id R H))) =
-        Theta.action (CommAlgCat.of R (H ⊗[R] H))
+  calc
+    _ =
+        (Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
             (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H))) *
-          Theta.action (CommAlgCat.of R (H ⊗[R] H))
-            (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H))) := by
-    rw [hpoint]
-    exact (Theta.action (CommAlgCat.of R (H ⊗[R] H))).hom.map_mul _ _
-  have hvalue := congrArg
-    (fun g : GeneralLinear.scalarExtensionAutomorphisms (V := V)
-        (CommAlgCat.of R (H ⊗[R] H)) ↦ g.val (1 ⊗ₜ[R] v)) haction
-  change
-    (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-        (mapPoints (H := H)
-          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
-            (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v) =
-      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-          (mapPoints (H := H)
-            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)))).val
-        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
-            (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) at hvalue
-  have hforward :
-      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
-          (mapPoints (H := H)
-            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
-              (toConv (AlgHom.id R H)))).val
-        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
-            (mapPoints (H := H)
-              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
-                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) =
-      GeneralLinear.scalarExtensionMap (V := V)
-        (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H)) (universalGenerator Theta v) := by
-    rw [← hvalue]
-    simpa only [universalGenerator_apply] using
-      Theta.action_mapPoints_one_tmul
-        (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
-          (toConv (AlgHom.id R H)) v
-  rw [hforward, recoveredCoaction_apply]
-  have hbridge := LinearMap.congr_fun
-    (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) (Coalgebra.comul (R := R) (A := H)))
-      (universalGenerator Theta v)
-  simp only [LinearMap.comp_apply] at hbridge
-  change
-    TensorProduct.comm R V (H ⊗[R] H)
-        (Coalgebra.comul.lTensor V
-          (TensorProduct.comm R H V (universalGenerator Theta v))) =
-      Coalgebra.comul.rTensor V (universalGenerator Theta v) at hbridge
-  rw [hbridge]
-  have hmap :
-      GeneralLinear.scalarExtensionMap (V := V)
-          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H)) =
-        Coalgebra.comul.rTensor V := by
-    apply TensorProduct.ext'
-    intro h w
-    rw [GeneralLinear.scalarExtensionMap_tmul, LinearMap.rTensor_tmul]
-    rfl
-  rw [hmap]
+              (CommAlgCat.ofHom (liftedIncludeLeftAlgHom (R := R) (H := H) V))
+                (toConv ULift.algEquiv.symm.toAlgHom))).val
+          ((Theta.action (CommAlgCat.of R (ULift.{max u v w} (H ⊗[R] H)))
+              (mapPoints (H := H)
+                (CommAlgCat.ofHom (liftedIncludeRightAlgHom (R := R) (H := H) V))
+                  (toConv ULift.algEquiv.symm.toAlgHom))).val (1 ⊗ₜ[R] v)) :=
+      recoveredCoaction_iterate_eq_include_actions Theta v
+    _ = GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (liftedComulAlgHom (R := R) (H := H) V))
+            (universalGenerator Theta v) :=
+      include_actions_eq_scalarExtensionMap_comul Theta v
+    _ = liftTensorSquare (R := R) (H := H) (V := V)
+          (Coalgebra.comul.rTensor V (universalGeneratorDown Theta v)) := by
+      simpa only [universalGeneratorDown_apply] using
+        scalarExtensionMap_comul_eq_liftTensorSquare (R := R) (H := H) (V := V)
+          (universalGenerator Theta v)
+    _ = _ := by
+      rw [recoveredCoaction_apply, comm_lTensor_comm_apply]
 
 /-- Recover a right `H`-comodule structure from a natural point representation by evaluating at
-the universal point and flipping the tensor factors. -/
-@[instance_reducible] noncomputable def toComodule
+the universal point and flipping the tensor factors. The definition is intentionally opaque; use
+`toComodule_coact_apply` to expose its coaction. -/
+@[irreducible]
+noncomputable def toComodule
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) : Comodule R H V where
   coact := recoveredCoaction Theta
   coassoc := recoveredCoaction_coassoc Theta
@@ -666,9 +808,12 @@ private theorem toComodule_coact_apply_private
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
     (toComodule Theta).coact v =
       TensorProduct.comm R H V
-        ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
-          (1 ⊗ₜ[R] v)) :=
-  rfl
+        (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+          ((Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+            (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v))) :=
+  by
+    unfold toComodule
+    rfl
 
 /-- The coaction recovered from a point representation is the flipped universal-point action. -/
 @[simp]
@@ -676,26 +821,36 @@ theorem toComodule_coact_apply
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
     (toComodule Theta).coact v =
       TensorProduct.comm R H V
-        ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
-          (1 ⊗ₜ[R] v)) :=
+        (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
+          ((Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+            (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v))) :=
   toComodule_coact_apply_private Theta v
-
-private theorem comodule_ext {rho sigma : Comodule R H V}
-    (h : rho.coact = sigma.coact) : rho = sigma := by
-  cases rho
-  cases sigma
-  cases h
-  rfl
 
 /-- Recovering a comodule from its induced point representation returns the original comodule. -/
 @[simp]
 theorem toComodule_ofComodule (rho : Comodule R H V) :
     toComodule (ofComodule rho) = rho := by
-  apply comodule_ext
+  apply Comodule.ext
   apply LinearMap.ext
   intro v
   rw [toComodule_coact_apply, ofComodule_action_universal_one_tmul]
-  exact TensorProduct.comm_comm R H V (rho.coact v)
+  induction rho.coact v using TensorProduct.induction_on with
+  | zero => simp
+  | add z t hz ht => simpa only [map_add] using congrArg₂ (fun x y ↦ x + y) hz ht
+  | tmul n h =>
+      simp only [TensorProduct.map_tmul, LinearMap.id_apply, TensorProduct.comm_tmul]
+      rfl
+
+private theorem mapPoints_universal_ofConv
+    {A : CommAlgCat.{max u v w} R} (x : points (H := H) A) :
+    mapPoints (H := H)
+        (CommAlgCat.ofHom (x.ofConv.comp
+          (ULift.algEquiv (R := R) : ULift.{max u v w} H ≃ₐ[R] H).toAlgHom))
+          (toConv ULift.algEquiv.symm.toAlgHom) = x := by
+  rw [mapPoints_universal]
+  apply WithConv.ofConv_injective
+  ext h
+  rfl
 
 /-- Reconstructing the point representation from its recovered comodule returns the original
 natural action. -/
@@ -704,33 +859,45 @@ theorem ofComodule_toComodule
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
     ofComodule (toComodule Theta) = Theta := by
   have huniversal :
-      (ofComodule (toComodule Theta)).action (CommAlgCat.of R H)
-          (toConv (AlgHom.id R H)) =
-        Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H)) := by
+      (ofComodule (toComodule Theta)).action
+          (CommAlgCat.of R (ULift.{max u v w} H))
+            (toConv ULift.algEquiv.symm.toAlgHom) =
+        Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+          (toConv ULift.algEquiv.symm.toAlgHom) := by
     apply Units.ext
-    refine TensorProduct.AlgebraTensorModule.ext fun h v ↦ ?_
+    refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
     rw [TensorProduct.tmul_eq_smul_one_tmul (M := V), map_smul, map_smul]
     congr 1
     rw [ofComodule_action_universal_one_tmul, toComodule_coact_apply]
-    exact TensorProduct.comm_comm R V H
-      ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
-        (1 ⊗ₜ[R] v))
-  have haction : ∀ (A : CommAlgCat.{u} R) (x : points (H := H) A),
+    induction (Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
+        (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v)
+        using TensorProduct.induction_on with
+    | zero => simp
+    | add z t hz ht => simpa only [map_add] using congrArg₂ (fun x y ↦ x + y) hz ht
+    | tmul h n =>
+        simp only [TensorProduct.map_tmul, LinearMap.id_apply, TensorProduct.comm_tmul]
+        rfl
+  have haction : ∀ (A : CommAlgCat.{max u v w} R) (x : points (H := H) A),
       (ofComodule (toComodule Theta)).action A x = Theta.action A x := by
     intro A x
     have hforward := (ofComodule (toComodule Theta)).action_naturality
-      (CommAlgCat.ofHom x.ofConv) (toConv (AlgHom.id R H))
+      (CommAlgCat.ofHom (x.ofConv.comp
+        (ULift.algEquiv (R := R) : ULift.{max u v w} H ≃ₐ[R] H).toAlgHom))
+        (toConv ULift.algEquiv.symm.toAlgHom)
     have hTheta := Theta.action_naturality
-      (CommAlgCat.ofHom x.ofConv) (toConv (AlgHom.id R H))
-    rw [mapPoints_universal, toConv_ofConv, huniversal] at hforward
-    rw [mapPoints_universal, toConv_ofConv] at hTheta
+      (CommAlgCat.ofHom (x.ofConv.comp
+        (ULift.algEquiv (R := R) : ULift.{max u v w} H ≃ₐ[R] H).toAlgHom))
+        (toConv ULift.algEquiv.symm.toAlgHom)
+    rw [mapPoints_universal_ofConv, huniversal] at hforward
+    rw [mapPoints_universal_ofConv] at hTheta
     exact hforward.symm.trans hTheta
   apply NatTrans.ext
   funext A
   apply (cancel_mono
     (eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A))).1
-  change
-    (ofComodule (toComodule Theta)).action A = Theta.action A
+  -- `pointsFunctor_obj` is an opaque categorical equality, so expose the concrete action source
+  -- after cancelling the scalar-extension object transport.
+  change (ofComodule (toComodule Theta)).action A = Theta.action A
   apply GrpCat.ext
   intro x
   exact haction A x
@@ -745,6 +912,30 @@ noncomputable def pointRepresentationEquivComodule :
   invFun := PointRepresentation.ofComodule
   left_inv := PointRepresentation.ofComodule_toComodule
   right_inv := PointRepresentation.toComodule_ofComodule
+
+private theorem pointRepresentationEquivComodule_apply_private
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    pointRepresentationEquivComodule Theta = PointRepresentation.toComodule Theta :=
+  rfl
+
+private theorem pointRepresentationEquivComodule_symm_apply_private (rho : Comodule R H V) :
+    pointRepresentationEquivComodule.symm rho = PointRepresentation.ofComodule rho :=
+  rfl
+
+/-- The forward map of the representation--comodule equivalence recovers the coaction at the
+universal point. -/
+@[simp]
+theorem pointRepresentationEquivComodule_apply
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    pointRepresentationEquivComodule Theta = PointRepresentation.toComodule Theta :=
+  pointRepresentationEquivComodule_apply_private Theta
+
+/-- The inverse map of the representation--comodule equivalence is the point action induced by a
+coaction. -/
+@[simp]
+theorem pointRepresentationEquivComodule_symm_apply (rho : Comodule R H V) :
+    pointRepresentationEquivComodule.symm rho = PointRepresentation.ofComodule rho :=
+  pointRepresentationEquivComodule_symm_apply_private rho
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -165,7 +165,7 @@ private theorem pointActionEnd_tmul (rho : Comodule R H V)
 private theorem evaluatedCoaction_one (rho : Comodule R H V)
     (A : CommAlgCat.{max u v w} R) (v : V) :
     evaluatedCoaction rho A (1 : points (H := H) A) v = 1 ⊗ₜ[R] v := by
-  letI : Comodule R H V := rho
+  let : Comodule R H V := rho
   have hmap :
       (TensorProduct.comm R V A).toLinearMap ∘ₗ
           TensorProduct.map LinearMap.id
@@ -259,7 +259,7 @@ private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
 private theorem pointActionEnd_mul (rho : Comodule R H V)
     (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) :
     pointActionEnd rho A (x * y) = pointActionEnd rho A x * pointActionEnd rho A y := by
-  letI : Comodule R H V := rho
+  let : Comodule R H V := rho
   refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
   rw [Module.End.mul_apply, pointActionEnd_tmul, pointActionEnd_tmul, map_smul,
     pointActionEnd_evaluatedCoaction, Comodule.coassoc_apply,

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -350,13 +350,6 @@ private theorem counit_rTensor_universalGeneratorDown
   rw [hone] at h
   simpa only [universalGeneratorDown_apply] using h
 
-private theorem comm_lTensor_comm_apply {P : Type*} [AddCommMonoid P] [Module R P]
-    (g : H →ₗ[R] P) (z : H ⊗[R] V) :
-    TensorProduct.comm R V P
-        (g.lTensor V (TensorProduct.comm R H V z)) =
-      g.rTensor V z := by
-  exact LinearMap.congr_fun (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) g) z
-
 private theorem recoveredCoaction_counit
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
     Coalgebra.counit.lTensor V ∘ₗ recoveredCoaction Theta =
@@ -366,7 +359,15 @@ private theorem recoveredCoaction_counit
   apply (TensorProduct.comm R V R).injective
   simp only [LinearMap.comp_apply]
   rw [recoveredCoaction_apply]
-  rw [comm_lTensor_comm_apply]
+  have hcomm :
+      TensorProduct.comm R V R
+          (Coalgebra.counit.lTensor V
+            (TensorProduct.comm R H V (universalGeneratorDown Theta v))) =
+        Coalgebra.counit.rTensor V (universalGeneratorDown Theta v) := by
+    exact LinearMap.congr_fun
+      (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) Coalgebra.counit)
+      (universalGeneratorDown Theta v)
+  rw [hcomm]
   simp only [LinearMap.flip_apply, TensorProduct.mk_apply, TensorProduct.comm_tmul]
   exact counit_rTensor_universalGeneratorDown Theta v
 
@@ -668,7 +669,16 @@ private theorem recoveredCoaction_coassoc
         scalarExtensionMap_comul_eq_liftTensorSquare (R := R) (H := H) (V := V)
           (universalGenerator Theta v)
     _ = _ := by
-      rw [recoveredCoaction_apply, comm_lTensor_comm_apply]
+      rw [recoveredCoaction_apply]
+      have hcomm :
+          TensorProduct.comm R V (H ⊗[R] H)
+              (Coalgebra.comul.lTensor V
+                (TensorProduct.comm R H V (universalGeneratorDown Theta v))) =
+            Coalgebra.comul.rTensor V (universalGeneratorDown Theta v) := by
+        exact LinearMap.congr_fun
+          (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) Coalgebra.comul)
+          (universalGeneratorDown Theta v)
+      rw [hcomm]
 
 /-- Recover a right `H`-comodule structure from a natural point representation by evaluating at
 the universal point and flipping the tensor factors. The definition is intentionally opaque; use

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -9,6 +9,7 @@ public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
 
 import TauCeti.Algebra.Bialgebra.TensorProduct
+import TauCeti.Algebra.HopfAlgebra.Antipode
 
 /-!
 # Point representations and comodules
@@ -143,13 +144,20 @@ private noncomputable def rawPointAction (rho : Comodule R H V)
       (Comodule.pointsAction V)
 
 @[simp]
+private theorem rawPointAction_apply (rho : Comodule R H V)
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
+    rawPointAction rho A x =
+      let _ : Comodule R H V := rho
+      (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).symm
+        (Comodule.pointsAction V x) := by
+  rfl
+
+@[simp]
 private theorem rawPointAction_val (rho : Comodule R H V)
     (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
     (rawPointAction rho A x).val = Comodule.endOfPoint V x.ofConv := by
   let : Comodule R H V := rho
-  change
-    (Comodule.pointsAction V x : A ⊗[R] V →ₗ[A] A ⊗[R] V) =
-      Comodule.endOfPoint V x.ofConv
+  rw [rawPointAction_apply]
   exact Comodule.pointsAction_toLinearMap V x
 
 private theorem rawPointAction_naturality (rho : Comodule R H V)
@@ -418,13 +426,13 @@ private theorem comulPoint_eq_include_mul :
       toConv (includeLeftAlgHom (R := R) (H := H)) *
         toConv (includeRightAlgHom (R := R) (H := H)) := by
   apply WithConv.ofConv_injective
-  ext h
-  rw [AlgHom.convMul_apply, Bialgebra.comulAlgHom_apply]
-  unfold includeLeftAlgHom includeRightAlgHom
-  rw [Bialgebra.TensorProduct.includeLeft_toAlgHom,
-    Bialgebra.TensorProduct.includeRight_toAlgHom,
-    Algebra.TensorProduct.lift_includeLeft_includeRight]
-  rfl
+  apply AlgHom.toLinearMap_injective
+  apply WithConv.toConv_injective
+  rw [AlgHom.toLinearMap_convMul]
+  simpa only [Bialgebra.toLinearMap_comulAlgHom,
+    Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    Bialgebra.TensorProduct.includeRight_toAlgHom] using
+      (comul_eq_convMul_includeLeft_includeRight (R := R) (C := H))
 
 omit [AddCommMonoid V] [Module R V] in
 private theorem liftedComulPoint_eq_include_mul :

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -9,7 +9,7 @@ public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
 public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
 
 import TauCeti.Algebra.Bialgebra.TensorProduct
-import TauCeti.Algebra.HopfAlgebra.Antipode
+import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!
 # Point representations and comodules
@@ -432,7 +432,7 @@ private theorem comulPoint_eq_include_mul :
   simpa only [Bialgebra.toLinearMap_comulAlgHom,
     Bialgebra.TensorProduct.includeLeft_toAlgHom,
     Bialgebra.TensorProduct.includeRight_toAlgHom] using
-      (comul_eq_convMul_includeLeft_includeRight (R := R) (C := H))
+      (Coalgebra.comul_eq_convMul_includeLeft_includeRight (R := R) (C := H))
 
 omit [AddCommMonoid V] [Module R V] in
 private theorem liftedComulPoint_eq_include_mul :

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -89,6 +89,23 @@ noncomputable def action (Theta : PointRepresentation (R := R) (H := H) (V := V)
   Theta.app A ≫
     eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A)
 
+/-- Point representations are equal when their concrete actions agree at every value algebra and
+point. -/
+@[ext]
+theorem ext
+    {Theta Psi : PointRepresentation (R := R) (H := H) (V := V)}
+    (h : ∀ (A : CommAlgCat.{max u v w} R) (x : points (H := H) A),
+      Theta.action A x = Psi.action A x) :
+    Theta = Psi := by
+  apply NatTrans.ext
+  funext A
+  apply (cancel_mono
+    (eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A))).1
+  change Theta.action A = Psi.action A
+  apply GrpCat.ext
+  intro x
+  exact h A x
+
 /-- Naturality of a point representation, expressed using the concrete point and scalar-extension
 groups. -/
 theorem action_naturality (Theta : PointRepresentation (R := R) (H := H) (V := V))
@@ -891,16 +908,7 @@ theorem ofComodule_toComodule
     rw [mapPoints_universal_ofConv, huniversal] at hforward
     rw [mapPoints_universal_ofConv] at hTheta
     exact hforward.symm.trans hTheta
-  apply NatTrans.ext
-  funext A
-  apply (cancel_mono
-    (eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A))).1
-  -- `pointsFunctor_obj` is an opaque categorical equality, so expose the concrete action source
-  -- after cancelling the scalar-extension object transport.
-  change (ofComodule (toComodule Theta)).action A = Theta.action A
-  apply GrpCat.ext
-  intro x
-  exact haction A x
+  exact ext haction
 
 end PointRepresentation
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -1,0 +1,751 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.ScalarExtension
+public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
+public import TauCeti.Algebra.Coalgebra.Comodule.Basic
+
+import TauCeti.Algebra.Bialgebra.TensorProduct
+
+/-!
+# Point representations and comodules
+
+Let `H` be a commutative Hopf algebra over a commutative ring `R`, and let `V` be an
+`R`-module. This file identifies natural actions of the represented point groups
+
+`A ↦ Hom_{R-alg}(H, A)`
+
+on the scalar extensions `A ⊗[R] V` with right `H`-comodule structures on `V`. Both `H` and
+the value algebras are kept in the same universe as `R` and `V`, so the universal point of `H`
+and the tensor-square value algebra can be used directly.
+
+The action associated to a coaction `ρ(v) = ∑ v₀ ⊗ v₁` is characterized by
+
+`(a ⊗ v) ↦ ∑ a * x(v₁) ⊗ v₀`
+
+at a point `x : H →ₐ[R] A`. Conversely, the coaction is recovered by evaluating at the
+universal point `id_H` and flipping the two tensor factors. The constructions are inverse without
+any finiteness, freeness, projectivity, flatness, or nontriviality hypothesis.
+
+## Main declarations
+
+* `HopfAlgebra.PointRepresentation`: a natural action on the scalar extensions of `V`.
+* `HopfAlgebra.PointRepresentation.ofComodule`: the point representation induced by a coaction.
+* `HopfAlgebra.PointRepresentation.toComodule`: recovery of a coaction from the universal point.
+* `HopfAlgebra.pointRepresentationEquivComodule`: the fixed-object representation--comodule
+  correspondence.
+
+## References
+
+* J. S. Milne, *Basic Theory of Affine Group Schemes*, Chapter VIII, §§2, 4, and 6.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 4(a), Remark 4.1.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace HopfAlgebra
+
+universe u
+
+variable {R H V : Type u} [CommRing R] [CommRing H]
+variable [_root_.HopfAlgebra R H]
+variable [AddCommMonoid V] [Module R V]
+
+/-- A point representation of the affine group represented by `H` on an `R`-module `V`.
+
+It is a natural family of group homomorphisms from the convolution group of `A`-points to the
+linear automorphisms of `A ⊗[R] V`, for every commutative `R`-algebra `A`. -/
+noncomputable abbrev PointRepresentation :=
+  pointsFunctor (R := R) (H := H) ⟶
+    GeneralLinear.scalarExtensionAutomorphismsFunctor (R := R) (V := V)
+
+namespace PointRepresentation
+
+/-- The group homomorphism at a value algebra, with the opaque functor object equalities removed. -/
+noncomputable def action (Theta : PointRepresentation (R := R) (H := H) (V := V))
+    (A : CommAlgCat.{u} R) :
+    points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A :=
+  Theta.app A ≫
+    eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A)
+
+/-- Naturality of a point representation, expressed using the concrete point and scalar-extension
+groups. -/
+theorem action_naturality (Theta : PointRepresentation (R := R) (H := H) (V := V))
+    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) :
+    GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi (Theta.action A x) =
+      Theta.action B (mapPoints (H := H) phi x) := by
+  have h := Theta.naturality phi
+  have h' := congrArg (fun f ↦
+    f ≫ eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) B)) h
+  simp only [pointsFunctor_map, GeneralLinear.scalarExtensionAutomorphismsFunctor_map,
+    Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id] at h'
+  have h'' := congrArg (fun f ↦ f x) h'.symm
+  change
+    GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi
+        ((Theta.app A ≫
+          eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A)) x) =
+      (Theta.app B ≫
+          eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) B))
+        (mapPoints (H := H) phi x) at h''
+  exact h''
+
+/-- Naturality determines the action of a transported point on the canonical copy of `V`. -/
+@[simp]
+theorem action_mapPoints_one_tmul
+    (Theta : PointRepresentation (R := R) (H := H) (V := V))
+    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
+    (Theta.action B (mapPoints (H := H) phi x)).val (1 ⊗ₜ[R] v) =
+      GeneralLinear.scalarExtensionMap (V := V) phi
+        ((Theta.action A x).val (1 ⊗ₜ[R] v)) := by
+  rw [← Theta.action_naturality phi x]
+  simpa using
+    (GeneralLinear.mapScalarExtensionAutomorphisms_apply_scalarExtensionMap
+      (V := V) phi (Theta.action A x) (1 ⊗ₜ[R] v))
+
+private noncomputable def evaluatedCoaction (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    V →ₗ[R] A ⊗[R] V :=
+  (TensorProduct.comm R V A).toLinearMap ∘ₗ
+    TensorProduct.map LinearMap.id x.ofConv.toLinearMap ∘ₗ rho.coact
+
+private noncomputable def pointActionEnd (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    Module.End A (A ⊗[R] V) := by
+  let u := evaluatedCoaction rho A x
+  exact TensorProduct.AlgebraTensorModule.lift
+    { toFun := fun a ↦
+        { toFun := fun v ↦ a • u v
+          map_add' := fun v w ↦ by simp
+          map_smul' := fun r v ↦ by
+            rw [u.map_smul]
+            exact smul_comm a r (u v) }
+      map_add' := fun a b ↦ LinearMap.ext fun v ↦ add_smul a b (u v)
+      map_smul' := fun a b ↦ LinearMap.ext fun v ↦ by
+        change (a * b) • u v = a • b • u v
+        exact (smul_smul a b (u v)).symm }
+
+@[simp]
+private theorem pointActionEnd_tmul (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x : points (H := H) A) (a : A) (v : V) :
+    pointActionEnd rho A x (a ⊗ₜ[R] v) = a • evaluatedCoaction rho A x v :=
+  by simp [pointActionEnd]
+
+private theorem evaluatedCoaction_one (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (v : V) :
+    evaluatedCoaction rho A (1 : points (H := H) A) v = 1 ⊗ₜ[R] v := by
+  letI : Comodule R H V := rho
+  have hmap :
+      (TensorProduct.comm R V A).toLinearMap ∘ₗ
+          TensorProduct.map LinearMap.id
+            ((1 : points (H := H) A).ofConv.toLinearMap) =
+        (Algebra.linearMap R A).rTensor V ∘ₗ
+          (TensorProduct.comm R V R).toLinearMap ∘ₗ
+            Coalgebra.counit.lTensor V := by
+    ext m h
+    rfl
+  rw [evaluatedCoaction, ← LinearMap.comp_assoc, hmap]
+  simp only [LinearMap.comp_apply]
+  rw [Comodule.lTensor_counit_coact]
+  simp
+
+private theorem pointActionEnd_one (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) :
+    pointActionEnd rho A (1 : points (H := H) A) = 1 := by
+  refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
+  rw [pointActionEnd_tmul, evaluatedCoaction_one]
+  exact (TensorProduct.tmul_eq_smul_one_tmul (M := V) a v).symm
+
+private noncomputable def pairedEvaluation (A : CommAlgCat.{u} R)
+    (x y : points (H := H) A) :
+    V ⊗[R] (H ⊗[R] H) →ₗ[R] A ⊗[R] V :=
+  (TensorProduct.comm R V A).toLinearMap ∘ₗ
+    TensorProduct.map LinearMap.id
+      (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)).toLinearMap
+
+private theorem pairedEvaluation_comul (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x y : points (H := H) A) (v : V) :
+    pairedEvaluation A x y
+        (Coalgebra.comul.lTensor V (rho.coact v)) =
+      evaluatedCoaction rho A (x * y) v := by
+  have hmap :
+      pairedEvaluation (V := V) A x y ∘ₗ Coalgebra.comul.lTensor V =
+        (TensorProduct.comm R V A).toLinearMap ∘ₗ
+          TensorProduct.map LinearMap.id (x * y).ofConv.toLinearMap := by
+    ext m h
+    change
+      (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)
+          (Coalgebra.comul h)) ⊗ₜ[R] m =
+        (x * y).ofConv h ⊗ₜ[R] m
+    rw [AlgHom.convMul_apply]
+  rw [← LinearMap.comp_apply, hmap]
+  rfl
+
+private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x y : points (H := H) A) (v : V) :
+    pointActionEnd rho A x (evaluatedCoaction rho A y v) =
+      pairedEvaluation A x y
+        (TensorProduct.assoc R V H H (rho.coact.rTensor H (rho.coact v))) := by
+  have hmap :
+      (pointActionEnd rho A x).restrictScalars R ∘ₗ
+          (TensorProduct.comm R V A).toLinearMap ∘ₗ
+            TensorProduct.map LinearMap.id y.ofConv.toLinearMap =
+        pairedEvaluation (V := V) A x y ∘ₗ
+          (TensorProduct.assoc R V H H).toLinearMap ∘ₗ rho.coact.rTensor H := by
+    ext m h
+    change
+      pointActionEnd rho A x (y.ofConv h ⊗ₜ[R] m) =
+        pairedEvaluation A x y
+          (TensorProduct.assoc R V H H (rho.coact m ⊗ₜ[R] h))
+    rw [pointActionEnd_tmul]
+    have hz : ∀ z : V ⊗[R] H,
+        y.ofConv h •
+            (TensorProduct.comm R V A
+              (TensorProduct.map LinearMap.id x.ofConv.toLinearMap z)) =
+          pairedEvaluation A x y (TensorProduct.assoc R V H H (z ⊗ₜ[R] h)) := by
+      intro z
+      induction z using TensorProduct.induction_on with
+      | zero => simp [pairedEvaluation]
+      | tmul n k => simp [pairedEvaluation, TensorProduct.smul_tmul', mul_comm]
+      | add z w hz hw =>
+          simpa only [map_add, smul_add, TensorProduct.add_tmul] using
+            congrArg₂ (fun p q ↦ p + q) hz hw
+    exact hz (rho.coact m)
+  have hv := congrArg (fun f : V ⊗[R] H →ₗ[R] A ⊗[R] V ↦ f (rho.coact v)) hmap
+  simp only [LinearMap.comp_apply] at hv
+  change
+    pointActionEnd rho A x
+        (TensorProduct.comm R V A
+          (TensorProduct.map LinearMap.id y.ofConv.toLinearMap (rho.coact v))) = _ at hv
+  exact hv
+
+private theorem pointActionEnd_mul (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x y : points (H := H) A) :
+    pointActionEnd rho A (x * y) = pointActionEnd rho A x * pointActionEnd rho A y := by
+  letI : Comodule R H V := rho
+  refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
+  rw [Module.End.mul_apply, pointActionEnd_tmul, pointActionEnd_tmul, map_smul,
+    pointActionEnd_evaluatedCoaction, Comodule.coassoc_apply,
+    pairedEvaluation_comul]
+
+private noncomputable def pointActionMonoidHom (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) :
+    points (H := H) A →* Module.End A (A ⊗[R] V) where
+  toFun := pointActionEnd rho A
+  map_one' := pointActionEnd_one rho A
+  map_mul' := pointActionEnd_mul rho A
+
+private noncomputable def rawPointAction (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) :
+    points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A :=
+  GrpCat.ofHom (pointActionMonoidHom rho A).toHomUnits
+
+@[simp]
+private theorem rawPointAction_val (rho : Comodule R H V)
+    (A : CommAlgCat.{u} R) (x : points (H := H) A) :
+    (rawPointAction rho A x).val = pointActionEnd rho A x :=
+  rfl
+
+private theorem evaluatedCoaction_naturality (rho : Comodule R H V)
+    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
+    GeneralLinear.scalarExtensionMap (V := V) phi (evaluatedCoaction rho A x v) =
+      evaluatedCoaction rho B (mapPoints (H := H) phi x) v := by
+  have hz : ∀ z : V ⊗[R] H,
+      GeneralLinear.scalarExtensionMap (V := V) phi
+          (TensorProduct.comm R V A
+            (TensorProduct.map LinearMap.id x.ofConv.toLinearMap z)) =
+        TensorProduct.comm R V B
+          (TensorProduct.map LinearMap.id
+            (mapPoints (H := H) phi x).ofConv.toLinearMap z) := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul m h =>
+        simp only [TensorProduct.map_tmul, LinearMap.id_apply,
+          TensorProduct.comm_tmul, GeneralLinear.scalarExtensionMap_tmul,
+          AlgHom.coe_toLinearMap]
+        rfl
+    | add z w hz hw => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) hz hw
+  exact hz (rho.coact v)
+
+private theorem rawPointAction_naturality (rho : Comodule R H V)
+    {A B : CommAlgCat.{u} R} (phi : A ⟶ B) (x : points (H := H) A) :
+    GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi (rawPointAction rho A x) =
+      rawPointAction rho B (mapPoints (H := H) phi x) := by
+  symm
+  apply GeneralLinear.eq_mapScalarExtensionAutomorphisms_of_apply_scalarExtensionMap_eq
+    (V := V) phi (rawPointAction rho A x)
+      (rawPointAction rho B (mapPoints (H := H) phi x))
+  intro z
+  induction z using TensorProduct.induction_on with
+  | zero => simp
+  | tmul a v =>
+      rw [GeneralLinear.scalarExtensionMap_tmul]
+      change
+        pointActionEnd rho B (mapPoints (H := H) phi x)
+            (phi.hom a ⊗ₜ[R] v) =
+          GeneralLinear.scalarExtensionMap (V := V) phi
+            (pointActionEnd rho A x (a ⊗ₜ[R] v))
+      rw [pointActionEnd_tmul, pointActionEnd_tmul,
+        GeneralLinear.scalarExtensionMap_smul, evaluatedCoaction_naturality]
+  | add z w hz hw => simp [hz, hw]
+
+/-- The natural point representation induced by a right `H`-comodule structure. -/
+noncomputable def ofComodule (rho : Comodule R H V) :
+    PointRepresentation (R := R) (H := H) (V := V) where
+  app A := rawPointAction rho A ≫
+    eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm
+  naturality A B phi := by
+    change
+      mapPoints (H := H) phi ≫ rawPointAction rho B ≫
+          eqToHom
+            (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) B).symm =
+        rawPointAction rho A ≫
+          eqToHom
+            (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm ≫
+          (GeneralLinear.scalarExtensionAutomorphismsFunctor (V := V)).map phi
+    rw [GeneralLinear.scalarExtensionAutomorphismsFunctor_map]
+    have hraw :
+        mapPoints (H := H) phi ≫ rawPointAction rho B =
+          rawPointAction rho A ≫
+            GeneralLinear.mapScalarExtensionAutomorphisms (V := V) phi := by
+      apply GrpCat.ext
+      intro x
+      exact (rawPointAction_naturality rho phi x).symm
+    rw [← Category.assoc, hraw]
+    simp only [Category.assoc, eqToHom_trans_assoc, eqToHom_refl, Category.id_comp]
+
+@[simp]
+private theorem action_ofComodule (rho : Comodule R H V) (A : CommAlgCat.{u} R) :
+    (ofComodule rho).action A = rawPointAction rho A := by
+  rw [action, ofComodule]
+  change
+    (rawPointAction rho A ≫
+        eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A).symm) ≫
+      eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A) =
+        rawPointAction rho A
+  rw [Category.assoc, eqToHom_trans, eqToHom_refl, Category.comp_id]
+
+/-- The action induced by a coaction, evaluated on a pure tensor. -/
+@[simp]
+theorem ofComodule_action_tmul (rho : Comodule R H V) (A : CommAlgCat.{u} R)
+    (x : points (H := H) A) (a : A) (v : V) :
+    ((ofComodule rho).action A x).val (a ⊗ₜ[R] v) =
+      a • TensorProduct.comm R V A
+        (TensorProduct.map LinearMap.id x.ofConv.toLinearMap (rho.coact v)) := by
+  rw [action_ofComodule]
+  exact pointActionEnd_tmul rho A x a v
+
+/-- At the universal point, the action induced by a coaction is the flipped coaction. -/
+@[simp]
+theorem ofComodule_action_universal_one_tmul (rho : Comodule R H V) (v : V) :
+    ((ofComodule rho).action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
+        (1 ⊗ₜ[R] v) =
+      TensorProduct.comm R V H (rho.coact v) := by
+  rw [ofComodule_action_tmul]
+  simp only [one_smul, AlgHom.toLinearMap_id, TensorProduct.map_id,
+    LinearMap.id_apply]
+
+private noncomputable def universalGenerator
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    V →ₗ[R] H ⊗[R] V :=
+  ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val.restrictScalars R) ∘ₗ
+    TensorProduct.mk R H V 1
+
+private noncomputable def recoveredCoaction
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    V →ₗ[R] V ⊗[R] H :=
+  (TensorProduct.comm R H V).toLinearMap ∘ₗ universalGenerator Theta
+
+@[simp]
+private theorem universalGenerator_apply
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    universalGenerator Theta v =
+      (Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
+        (1 ⊗ₜ[R] v) :=
+  rfl
+
+@[simp]
+private theorem recoveredCoaction_apply
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    recoveredCoaction Theta v = TensorProduct.comm R H V (universalGenerator Theta v) :=
+  rfl
+
+private theorem mapPoints_universal {A : Type u} [CommRing A] [Algebra R A]
+    (phi : H →ₐ[R] A) :
+    mapPoints (H := H) (CommAlgCat.ofHom phi) (toConv (AlgHom.id R H)) =
+      toConv phi := by
+  apply WithConv.ofConv_injective
+  ext h
+  rfl
+
+private theorem mapPoints_universal_counit :
+    mapPoints (H := H) (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H))
+        (toConv (AlgHom.id R H)) = 1 := by
+  rw [mapPoints_universal]
+  apply WithConv.ofConv_injective
+  ext h
+  simp only [AlgHom.convOne_apply, Bialgebra.counitAlgHom_apply]
+  rfl
+
+private theorem scalarExtensionMap_counit_universalGenerator
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    GeneralLinear.scalarExtensionMap (V := V)
+        (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H)) (universalGenerator Theta v) =
+      1 ⊗ₜ[R] v := by
+  have h := Theta.action_mapPoints_one_tmul
+    (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H))
+      (toConv (AlgHom.id R H)) v
+  rw [mapPoints_universal_counit,
+    (Theta.action (CommAlgCat.of R R)).hom.map_one] at h
+  simpa only [universalGenerator_apply, Units.val_one, Module.End.one_apply] using h.symm
+
+private theorem recoveredCoaction_counit
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    Coalgebra.counit.lTensor V ∘ₗ recoveredCoaction Theta =
+      (TensorProduct.mk R V R).flip 1 := by
+  apply LinearMap.ext
+  intro v
+  apply (TensorProduct.comm R V R).injective
+  have hbridge := LinearMap.congr_fun
+    (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) (Coalgebra.counit (R := R) (A := H)))
+      (universalGenerator Theta v)
+  simp only [LinearMap.comp_apply] at hbridge
+  simp only [LinearMap.comp_apply]
+  rw [recoveredCoaction_apply]
+  change
+    TensorProduct.comm R V R
+        (Coalgebra.counit.lTensor V
+          (TensorProduct.comm R H V (universalGenerator Theta v))) =
+      Coalgebra.counit.rTensor V (universalGenerator Theta v) at hbridge
+  rw [hbridge]
+  simp only [LinearMap.flip_apply, TensorProduct.mk_apply, TensorProduct.comm_tmul]
+  have hmap :
+      GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (Bialgebra.counitAlgHom R H)) =
+        Coalgebra.counit.rTensor V := by
+    apply TensorProduct.ext'
+    intro h w
+    rw [GeneralLinear.scalarExtensionMap_tmul, LinearMap.rTensor_tmul]
+    rfl
+  rw [← hmap]
+  exact scalarExtensionMap_counit_universalGenerator Theta v
+
+private noncomputable abbrev includeLeftAlgHom : H →ₐ[R] H ⊗[R] H :=
+  (Bialgebra.TensorProduct.includeLeft (R := R) (H₁ := H) (H₂ := H)).toAlgHom
+
+private noncomputable abbrev includeRightAlgHom : H →ₐ[R] H ⊗[R] H :=
+  (Bialgebra.TensorProduct.includeRight (R := R) (H₁ := H) (H₂ := H)).toAlgHom
+
+private theorem comulPoint_eq_include_mul :
+    toConv (Bialgebra.comulAlgHom R H) =
+      toConv (includeLeftAlgHom (R := R) (H := H)) *
+        toConv (includeRightAlgHom (R := R) (H := H)) := by
+  apply WithConv.ofConv_injective
+  ext h
+  rw [AlgHom.convMul_apply, Bialgebra.comulAlgHom_apply]
+  unfold includeLeftAlgHom includeRightAlgHom
+  rw [Bialgebra.TensorProduct.includeLeft_toAlgHom,
+    Bialgebra.TensorProduct.includeRight_toAlgHom,
+    Algebra.TensorProduct.lift_includeLeft_includeRight]
+  rfl
+
+private theorem recoveredCoaction_iterate_eq_include_actions
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    TensorProduct.comm R V (H ⊗[R] H)
+        (TensorProduct.assoc R V H H
+          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
+      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)))).val
+        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) := by
+  rw [Theta.action_mapPoints_one_tmul
+    (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+      (toConv (AlgHom.id R H)) v]
+  change
+    TensorProduct.comm R V (H ⊗[R] H)
+        (TensorProduct.assoc R V H H
+          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
+      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)))).val
+        (GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+            (universalGenerator Theta v))
+  have hz : ∀ z : H ⊗[R] V,
+      TensorProduct.comm R V (H ⊗[R] H)
+          (TensorProduct.assoc R V H H
+            ((recoveredCoaction Theta).rTensor H (TensorProduct.comm R H V z))) =
+        (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H)))).val
+          (GeneralLinear.scalarExtensionMap (V := V)
+            (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H))) z) := by
+    intro z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | add z w hz hw => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) hz hw
+    | tmul h w =>
+        rw [GeneralLinear.scalarExtensionMap_tmul]
+        have haction :
+            (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+                (mapPoints (H := H)
+                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                    (toConv (AlgHom.id R H)))).val
+              (includeRightAlgHom (R := R) (H := H) h ⊗ₜ[R] w) =
+            includeRightAlgHom (R := R) (H := H) h •
+              GeneralLinear.scalarExtensionMap (V := V)
+                (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                  (universalGenerator Theta w) := by
+          rw [TensorProduct.tmul_eq_smul_one_tmul (M := V), map_smul,
+            Theta.action_mapPoints_one_tmul
+              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H)) w]
+          rfl
+        change
+          TensorProduct.comm R V (H ⊗[R] H)
+              (TensorProduct.assoc R V H H
+                ((recoveredCoaction Theta).rTensor H
+                  (TensorProduct.comm R H V (h ⊗ₜ[R] w)))) =
+            (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+                (mapPoints (H := H)
+                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                    (toConv (AlgHom.id R H)))).val
+              (includeRightAlgHom (R := R) (H := H) h ⊗ₜ[R] w)
+        rw [haction, TensorProduct.comm_tmul, LinearMap.rTensor_tmul,
+          recoveredCoaction_apply]
+        have hwz : ∀ z : H ⊗[R] V,
+            TensorProduct.comm R V (H ⊗[R] H)
+                (TensorProduct.assoc R V H H
+                  (TensorProduct.comm R H V z ⊗ₜ[R] h)) =
+              includeRightAlgHom (R := R) (H := H) h •
+                GeneralLinear.scalarExtensionMap (V := V)
+                  (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H))) z := by
+          intro z
+          induction z using TensorProduct.induction_on with
+          | zero => simp
+          | add z w hz hw =>
+              simpa only [map_add, smul_add, TensorProduct.add_tmul] using
+                congrArg₂ (fun p q ↦ p + q) hz hw
+          | tmul k n =>
+              simp only [TensorProduct.comm_tmul, TensorProduct.assoc_tmul]
+              rw [GeneralLinear.scalarExtensionMap_tmul]
+              change
+                (k ⊗ₜ[R] h) ⊗ₜ[R] n =
+                  includeRightAlgHom (R := R) (H := H) h •
+                    (includeLeftAlgHom (R := R) (H := H) k ⊗ₜ[R] n)
+              have hleft : includeLeftAlgHom (R := R) (H := H) k = k ⊗ₜ[R] 1 :=
+                Bialgebra.TensorProduct.includeLeft_apply k
+              have hright : includeRightAlgHom (R := R) (H := H) h = 1 ⊗ₜ[R] h :=
+                Bialgebra.TensorProduct.includeRight_apply h
+              rw [hleft, hright, TensorProduct.smul_tmul']
+              rw [smul_eq_mul]
+              rw [Algebra.TensorProduct.tmul_mul_tmul, one_mul, mul_one]
+        exact hwz (universalGenerator Theta w)
+  rw [recoveredCoaction_apply]
+  exact hz (universalGenerator Theta v)
+
+private theorem recoveredCoaction_coassoc
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    TensorProduct.assoc R V H H ∘ₗ (recoveredCoaction Theta).rTensor H ∘ₗ
+        recoveredCoaction Theta =
+      Coalgebra.comul.lTensor V ∘ₗ recoveredCoaction Theta := by
+  apply LinearMap.ext
+  intro v
+  apply (TensorProduct.comm R V (H ⊗[R] H)).injective
+  simp only [LinearMap.comp_apply]
+  change
+    TensorProduct.comm R V (H ⊗[R] H)
+        (TensorProduct.assoc R V H H
+          ((recoveredCoaction Theta).rTensor H (recoveredCoaction Theta v))) =
+      TensorProduct.comm R V (H ⊗[R] H)
+        (Coalgebra.comul.lTensor V (recoveredCoaction Theta v))
+  rw [recoveredCoaction_iterate_eq_include_actions]
+  have hpoint :
+      mapPoints (H := H)
+          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
+            (toConv (AlgHom.id R H)) =
+        mapPoints (H := H)
+            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)) *
+          mapPoints (H := H)
+            (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)) := by
+    rw [mapPoints_universal, mapPoints_universal, mapPoints_universal]
+    exact comulPoint_eq_include_mul (R := R) (H := H)
+  have haction :
+      Theta.action (CommAlgCat.of R (H ⊗[R] H))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
+              (toConv (AlgHom.id R H))) =
+        Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H))) *
+          Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H))) := by
+    rw [hpoint]
+    exact (Theta.action (CommAlgCat.of R (H ⊗[R] H))).hom.map_mul _ _
+  have hvalue := congrArg
+    (fun g : GeneralLinear.scalarExtensionAutomorphisms (V := V)
+        (CommAlgCat.of R (H ⊗[R] H)) ↦ g.val (1 ⊗ₜ[R] v)) haction
+  change
+    (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+        (mapPoints (H := H)
+          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
+            (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v) =
+      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)))).val
+        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) at hvalue
+  have hforward :
+      (Theta.action (CommAlgCat.of R (H ⊗[R] H))
+          (mapPoints (H := H)
+            (CommAlgCat.ofHom (includeLeftAlgHom (R := R) (H := H)))
+              (toConv (AlgHom.id R H)))).val
+        ((Theta.action (CommAlgCat.of R (H ⊗[R] H))
+            (mapPoints (H := H)
+              (CommAlgCat.ofHom (includeRightAlgHom (R := R) (H := H)))
+                (toConv (AlgHom.id R H)))).val (1 ⊗ₜ[R] v)) =
+      GeneralLinear.scalarExtensionMap (V := V)
+        (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H)) (universalGenerator Theta v) := by
+    rw [← hvalue]
+    simpa only [universalGenerator_apply] using
+      Theta.action_mapPoints_one_tmul
+        (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H))
+          (toConv (AlgHom.id R H)) v
+  rw [hforward, recoveredCoaction_apply]
+  have hbridge := LinearMap.congr_fun
+    (LinearMap.comm_comp_lTensor_comp_comm_eq (Q := V) (Coalgebra.comul (R := R) (A := H)))
+      (universalGenerator Theta v)
+  simp only [LinearMap.comp_apply] at hbridge
+  change
+    TensorProduct.comm R V (H ⊗[R] H)
+        (Coalgebra.comul.lTensor V
+          (TensorProduct.comm R H V (universalGenerator Theta v))) =
+      Coalgebra.comul.rTensor V (universalGenerator Theta v) at hbridge
+  rw [hbridge]
+  have hmap :
+      GeneralLinear.scalarExtensionMap (V := V)
+          (CommAlgCat.ofHom (Bialgebra.comulAlgHom R H)) =
+        Coalgebra.comul.rTensor V := by
+    apply TensorProduct.ext'
+    intro h w
+    rw [GeneralLinear.scalarExtensionMap_tmul, LinearMap.rTensor_tmul]
+    rfl
+  rw [hmap]
+
+/-- Recover a right `H`-comodule structure from a natural point representation by evaluating at
+the universal point and flipping the tensor factors. -/
+@[instance_reducible] noncomputable def toComodule
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) : Comodule R H V where
+  coact := recoveredCoaction Theta
+  coassoc := recoveredCoaction_coassoc Theta
+  lTensor_counit_comp_coact := recoveredCoaction_counit Theta
+
+private theorem toComodule_coact_apply_private
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    (toComodule Theta).coact v =
+      TensorProduct.comm R H V
+        ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
+          (1 ⊗ₜ[R] v)) :=
+  rfl
+
+/-- The coaction recovered from a point representation is the flipped universal-point action. -/
+@[simp]
+theorem toComodule_coact_apply
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
+    (toComodule Theta).coact v =
+      TensorProduct.comm R H V
+        ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
+          (1 ⊗ₜ[R] v)) :=
+  toComodule_coact_apply_private Theta v
+
+private theorem comodule_ext {rho sigma : Comodule R H V}
+    (h : rho.coact = sigma.coact) : rho = sigma := by
+  cases rho
+  cases sigma
+  cases h
+  rfl
+
+/-- Recovering a comodule from its induced point representation returns the original comodule. -/
+@[simp]
+theorem toComodule_ofComodule (rho : Comodule R H V) :
+    toComodule (ofComodule rho) = rho := by
+  apply comodule_ext
+  apply LinearMap.ext
+  intro v
+  rw [toComodule_coact_apply, ofComodule_action_universal_one_tmul]
+  exact TensorProduct.comm_comm R H V (rho.coact v)
+
+/-- Reconstructing the point representation from its recovered comodule returns the original
+natural action. -/
+@[simp]
+theorem ofComodule_toComodule
+    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
+    ofComodule (toComodule Theta) = Theta := by
+  have huniversal :
+      (ofComodule (toComodule Theta)).action (CommAlgCat.of R H)
+          (toConv (AlgHom.id R H)) =
+        Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H)) := by
+    apply Units.ext
+    refine TensorProduct.AlgebraTensorModule.ext fun h v ↦ ?_
+    rw [TensorProduct.tmul_eq_smul_one_tmul (M := V), map_smul, map_smul]
+    congr 1
+    rw [ofComodule_action_universal_one_tmul, toComodule_coact_apply]
+    exact TensorProduct.comm_comm R V H
+      ((Theta.action (CommAlgCat.of R H) (toConv (AlgHom.id R H))).val
+        (1 ⊗ₜ[R] v))
+  have haction : ∀ (A : CommAlgCat.{u} R) (x : points (H := H) A),
+      (ofComodule (toComodule Theta)).action A x = Theta.action A x := by
+    intro A x
+    have hforward := (ofComodule (toComodule Theta)).action_naturality
+      (CommAlgCat.ofHom x.ofConv) (toConv (AlgHom.id R H))
+    have hTheta := Theta.action_naturality
+      (CommAlgCat.ofHom x.ofConv) (toConv (AlgHom.id R H))
+    rw [mapPoints_universal, toConv_ofConv, huniversal] at hforward
+    rw [mapPoints_universal, toConv_ofConv] at hTheta
+    exact hforward.symm.trans hTheta
+  apply NatTrans.ext
+  funext A
+  apply (cancel_mono
+    (eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A))).1
+  change
+    (ofComodule (toComodule Theta)).action A = Theta.action A
+  apply GrpCat.ext
+  intro x
+  exact haction A x
+
+end PointRepresentation
+
+/-- Natural point representations on `V` are equivalent to right `H`-comodule structures on
+`V`. -/
+noncomputable def pointRepresentationEquivComodule :
+    PointRepresentation (R := R) (H := H) (V := V) ≃ Comodule R H V where
+  toFun := PointRepresentation.toComodule
+  invFun := PointRepresentation.ofComodule
+  left_inv := PointRepresentation.ofComodule_toComodule
+  right_inv := PointRepresentation.toComodule_ofComodule
+
+end HopfAlgebra
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.ScalarExtension
 public import TauCeti.Algebra.AlgebraicGroup.PointsFunctor
-public import TauCeti.Algebra.Coalgebra.Comodule.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction
 
 import TauCeti.Algebra.Bialgebra.TensorProduct
 
@@ -101,6 +101,8 @@ theorem ext
   funext A
   apply (cancel_mono
     (eqToHom (GeneralLinear.scalarExtensionAutomorphismsFunctor_obj (V := V) A))).1
+  -- Once the opaque functor-object transport is cancelled, the concrete-action wrapper unfolds
+  -- definitionally to the remaining natural-transformation component.
   change Theta.action A = Psi.action A
   apply GrpCat.ext
   intro x
@@ -132,178 +134,23 @@ theorem action_mapPoints_one_tmul
     (GeneralLinear.mapScalarExtensionAutomorphisms_apply_scalarExtensionMap
       (V := V) phi (Theta.action A x) (1 ⊗ₜ[R] v))
 
-private noncomputable def evaluatedCoaction (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
-    V →ₗ[R] A ⊗[R] V :=
-  (TensorProduct.comm R V A).toLinearMap ∘ₗ
-    TensorProduct.map LinearMap.id x.ofConv.toLinearMap ∘ₗ rho.coact
-
-private noncomputable def pointActionEnd (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
-    Module.End A (A ⊗[R] V) := by
-  let u := evaluatedCoaction rho A x
-  exact TensorProduct.AlgebraTensorModule.lift
-    { toFun := fun a ↦
-        { toFun := fun v ↦ a • u v
-          map_add' := fun v w ↦ by simp
-          map_smul' := fun r v ↦ by
-            rw [u.map_smul]
-            exact smul_comm a r (u v) }
-      map_add' := fun a b ↦ LinearMap.ext fun v ↦ add_smul a b (u v)
-      map_smul' := fun a b ↦ LinearMap.ext fun v ↦ by
-        -- `AlgebraTensorModule.lift` stores this law through two bundled linear maps, and no
-        -- projection lemma normalizes their scalar actions to multiplication in `A`.
-        change (a * b) • u v = a • b • u v
-        exact (smul_smul a b (u v)).symm }
-
-@[simp]
-private theorem pointActionEnd_tmul (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) (a : A) (v : V) :
-    pointActionEnd rho A x (a ⊗ₜ[R] v) = a • evaluatedCoaction rho A x v :=
-  by simp [pointActionEnd]
-
-private theorem evaluatedCoaction_one (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (v : V) :
-    evaluatedCoaction rho A (1 : points (H := H) A) v = 1 ⊗ₜ[R] v := by
-  let : Comodule R H V := rho
-  have hmap :
-      (TensorProduct.comm R V A).toLinearMap ∘ₗ
-          TensorProduct.map LinearMap.id
-            ((1 : points (H := H) A).ofConv.toLinearMap) =
-        (Algebra.linearMap R A).rTensor V ∘ₗ
-          (TensorProduct.comm R V R).toLinearMap ∘ₗ
-            Coalgebra.counit.lTensor V := by
-    ext m h
-    rfl
-  rw [evaluatedCoaction, ← LinearMap.comp_assoc, hmap]
-  simp only [LinearMap.comp_apply]
-  rw [Comodule.lTensor_counit_coact]
-  simp
-
-private theorem pointActionEnd_one (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) :
-    pointActionEnd rho A (1 : points (H := H) A) = 1 := by
-  refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
-  rw [pointActionEnd_tmul, evaluatedCoaction_one]
-  exact (TensorProduct.tmul_eq_smul_one_tmul (M := V) a v).symm
-
-private noncomputable def pairedEvaluation (A : CommAlgCat.{max u v w} R)
-    (x y : points (H := H) A) :
-    V ⊗[R] (H ⊗[R] H) →ₗ[R] A ⊗[R] V :=
-  (TensorProduct.comm R V A).toLinearMap ∘ₗ
-    TensorProduct.map LinearMap.id
-      (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)).toLinearMap
-
-private theorem pairedEvaluation_comul (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) (v : V) :
-    pairedEvaluation A x y
-        (Coalgebra.comul.lTensor V (rho.coact v)) =
-      evaluatedCoaction rho A (x * y) v := by
-  have hmap :
-      pairedEvaluation (V := V) A x y ∘ₗ Coalgebra.comul.lTensor V =
-        (TensorProduct.comm R V A).toLinearMap ∘ₗ
-          TensorProduct.map LinearMap.id (x * y).ofConv.toLinearMap := by
-    ext m h
-    -- `TensorProduct.ext'` presents the composite through `AlgebraTensorModule.curry`; there is
-    -- no curry computation lemma exposing the pure-tensor evaluation of these bundled maps.
-    change
-      (Algebra.TensorProduct.lift x.ofConv y.ofConv (fun _ _ ↦ .all _ _)
-          (Coalgebra.comul h)) ⊗ₜ[R] m =
-        (x * y).ofConv h ⊗ₜ[R] m
-    rw [AlgHom.convMul_apply]
-  rw [← LinearMap.comp_apply, hmap]
-  rfl
-
-private theorem pointActionEnd_evaluatedCoaction (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) (v : V) :
-    pointActionEnd rho A x (evaluatedCoaction rho A y v) =
-      pairedEvaluation A x y
-        (TensorProduct.assoc R V H H (rho.coact.rTensor H (rho.coact v))) := by
-  have hmap :
-      (pointActionEnd rho A x).restrictScalars R ∘ₗ
-          (TensorProduct.comm R V A).toLinearMap ∘ₗ
-            TensorProduct.map LinearMap.id y.ofConv.toLinearMap =
-        pairedEvaluation (V := V) A x y ∘ₗ
-          (TensorProduct.assoc R V H H).toLinearMap ∘ₗ rho.coact.rTensor H := by
-    ext m h
-    -- The tensor extensionality goal is again curried, while the available computation rules are
-    -- stated for uncurried `map`, `rTensor`, and associator applications.
-    change
-      pointActionEnd rho A x (y.ofConv h ⊗ₜ[R] m) =
-        pairedEvaluation A x y
-          (TensorProduct.assoc R V H H (rho.coact m ⊗ₜ[R] h))
-    rw [pointActionEnd_tmul]
-    have hz : ∀ z : V ⊗[R] H,
-        y.ofConv h •
-            (TensorProduct.comm R V A
-              (TensorProduct.map LinearMap.id x.ofConv.toLinearMap z)) =
-          pairedEvaluation A x y (TensorProduct.assoc R V H H (z ⊗ₜ[R] h)) := by
-      intro z
-      induction z using TensorProduct.induction_on with
-      | zero => simp [pairedEvaluation]
-      | tmul n k => simp [pairedEvaluation, TensorProduct.smul_tmul', mul_comm]
-      | add z w hz hw =>
-          simpa only [map_add, smul_add, TensorProduct.add_tmul] using
-            congrArg₂ (fun p q ↦ p + q) hz hw
-    exact hz (rho.coact m)
-  have hv := congrArg (fun f : V ⊗[R] H →ₗ[R] A ⊗[R] V ↦ f (rho.coact v)) hmap
-  simp only [LinearMap.comp_apply] at hv
-  -- `restrictScalars` and the tensor linear-equivalence coercion remain in `hv`; their public
-  -- application lemmas do not rewrite the bundled function coercions simultaneously.
-  change
-    pointActionEnd rho A x
-        (TensorProduct.comm R V A
-          (TensorProduct.map LinearMap.id y.ofConv.toLinearMap (rho.coact v))) = _ at hv
-  exact hv
-
-private theorem pointActionEnd_mul (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) (x y : points (H := H) A) :
-    pointActionEnd rho A (x * y) = pointActionEnd rho A x * pointActionEnd rho A y := by
-  let : Comodule R H V := rho
-  refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
-  rw [Module.End.mul_apply, pointActionEnd_tmul, pointActionEnd_tmul, map_smul,
-    pointActionEnd_evaluatedCoaction, Comodule.coassoc_apply,
-    pairedEvaluation_comul]
-
-private noncomputable def pointActionMonoidHom (rho : Comodule R H V)
-    (A : CommAlgCat.{max u v w} R) :
-    points (H := H) A →* Module.End A (A ⊗[R] V) where
-  toFun := pointActionEnd rho A
-  map_one' := pointActionEnd_one rho A
-  map_mul' := pointActionEnd_mul rho A
-
 private noncomputable def rawPointAction (rho : Comodule R H V)
     (A : CommAlgCat.{max u v w} R) :
-    points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A :=
-  GrpCat.ofHom (pointActionMonoidHom rho A).toHomUnits
+    points (H := H) A ⟶ GeneralLinear.scalarExtensionAutomorphisms (V := V) A := by
+  letI : Comodule R H V := rho
+  exact GrpCat.ofHom <|
+    (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).symm.toMonoidHom.comp
+      (Comodule.pointsAction V)
 
 @[simp]
 private theorem rawPointAction_val (rho : Comodule R H V)
     (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
-    (rawPointAction rho A x).val = pointActionEnd rho A x :=
-  rfl
-
-private theorem evaluatedCoaction_naturality (rho : Comodule R H V)
-    {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) (v : V) :
-    GeneralLinear.scalarExtensionMap (V := V) phi (evaluatedCoaction rho A x v) =
-      evaluatedCoaction rho B (mapPoints (H := H) phi x) v := by
-  have hz : ∀ z : V ⊗[R] H,
-      GeneralLinear.scalarExtensionMap (V := V) phi
-          (TensorProduct.comm R V A
-            (TensorProduct.map LinearMap.id x.ofConv.toLinearMap z)) =
-        TensorProduct.comm R V B
-          (TensorProduct.map LinearMap.id
-            (mapPoints (H := H) phi x).ofConv.toLinearMap z) := by
-    intro z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul m h =>
-        simp only [TensorProduct.map_tmul, LinearMap.id_apply,
-          TensorProduct.comm_tmul, GeneralLinear.scalarExtensionMap_tmul,
-          AlgHom.coe_toLinearMap]
-        rfl
-    | add z w hz hw => simpa only [map_add] using congrArg₂ (fun p q ↦ p + q) hz hw
-  exact hz (rho.coact v)
+    (rawPointAction rho A x).val = Comodule.endOfPoint V x.ofConv := by
+  let : Comodule R H V := rho
+  change
+    (Comodule.pointsAction V x : A ⊗[R] V →ₗ[A] A ⊗[R] V) =
+      Comodule.endOfPoint V x.ofConv
+  exact Comodule.pointsAction_toLinearMap V x
 
 private theorem rawPointAction_naturality (rho : Comodule R H V)
     {A B : CommAlgCat.{max u v w} R} (phi : A ⟶ B) (x : points (H := H) A) :
@@ -314,20 +161,21 @@ private theorem rawPointAction_naturality (rho : Comodule R H V)
     (V := V) phi (rawPointAction rho A x)
       (rawPointAction rho B (mapPoints (H := H) phi x))
   intro z
-  induction z using TensorProduct.induction_on with
-  | zero => simp
-  | tmul a v =>
-      rw [GeneralLinear.scalarExtensionMap_tmul]
-      -- `rawPointAction` is wrapped successively as a unit and a `GrpCat` morphism; its value
-      -- theorem does not match until those function coercions are exposed.
-      change
-        pointActionEnd rho B (mapPoints (H := H) phi x)
-            (phi.hom a ⊗ₜ[R] v) =
-          GeneralLinear.scalarExtensionMap (V := V) phi
-            (pointActionEnd rho A x (a ⊗ₜ[R] v))
-      rw [pointActionEnd_tmul, pointActionEnd_tmul,
-        GeneralLinear.scalarExtensionMap_smul, evaluatedCoaction_naturality]
-  | add z w hz hw => simp [hz, hw]
+  rw [rawPointAction_val, rawPointAction_val]
+  let : Comodule R H V := rho
+  have hscalar :
+      GeneralLinear.scalarExtensionMap (V := V) phi =
+        LinearMap.rTensor V phi.hom.toLinearMap := by
+    refine TensorProduct.ext' fun a v ↦ ?_
+    rw [GeneralLinear.scalarExtensionMap_tmul, LinearMap.rTensor_tmul]
+    rfl
+  have hpoint :
+      (mapPoints (H := H) phi x).ofConv = phi.hom.comp x.ofConv := by
+    rfl
+  have h := DFunLike.congr_fun
+    (Comodule.rTensor_comp_endOfPoint V phi.hom x.ofConv) z
+  rw [hscalar, hpoint]
+  simpa only [LinearMap.comp_apply, LinearMap.restrictScalars_apply] using h.symm
 
 /-- The natural point representation induced by a right `H`-comodule structure. -/
 noncomputable def ofComodule (rho : Comodule R H V) :
@@ -379,7 +227,10 @@ theorem ofComodule_action_tmul (rho : Comodule R H V)
       a • TensorProduct.comm R V A
         (TensorProduct.map LinearMap.id x.ofConv.toLinearMap (rho.coact v)) := by
   rw [action_ofComodule]
-  exact pointActionEnd_tmul rho A x a v
+  rw [rawPointAction_val]
+  let : Comodule R H V := rho
+  simpa only [LinearMap.lTensor_def] using
+    (Comodule.endOfPoint_tmul (R := R) (H := H) V x.ofConv a v)
 
 /-- At the universal point, the action induced by a coaction is the flipped coaction. -/
 @[simp]
@@ -821,17 +672,6 @@ noncomputable def toComodule
   coassoc := recoveredCoaction_coassoc Theta
   lTensor_counit_comp_coact := recoveredCoaction_counit Theta
 
-private theorem toComodule_coact_apply_private
-    (Theta : PointRepresentation (R := R) (H := H) (V := V)) (v : V) :
-    (toComodule Theta).coact v =
-      TensorProduct.comm R H V
-        (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
-          ((Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
-            (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v))) :=
-  by
-    unfold toComodule
-    rfl
-
 /-- The coaction recovered from a point representation is the flipped universal-point action. -/
 @[simp]
 theorem toComodule_coact_apply
@@ -841,7 +681,9 @@ theorem toComodule_coact_apply
         (TensorProduct.map ULift.algEquiv.toLinearMap LinearMap.id
           ((Theta.action (CommAlgCat.of R (ULift.{max u v w} H))
             (toConv ULift.algEquiv.symm.toAlgHom)).val (1 ⊗ₜ[R] v))) :=
-  toComodule_coact_apply_private Theta v
+  by
+    unfold toComodule
+    rfl
 
 /-- Recovering a comodule from its induced point representation returns the original comodule. -/
 @[simp]
@@ -921,29 +763,24 @@ noncomputable def pointRepresentationEquivComodule :
   left_inv := PointRepresentation.ofComodule_toComodule
   right_inv := PointRepresentation.toComodule_ofComodule
 
-private theorem pointRepresentationEquivComodule_apply_private
-    (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
-    pointRepresentationEquivComodule Theta = PointRepresentation.toComodule Theta :=
-  rfl
-
-private theorem pointRepresentationEquivComodule_symm_apply_private (rho : Comodule R H V) :
-    pointRepresentationEquivComodule.symm rho = PointRepresentation.ofComodule rho :=
-  rfl
-
 /-- The forward map of the representation--comodule equivalence recovers the coaction at the
 universal point. -/
 @[simp]
 theorem pointRepresentationEquivComodule_apply
     (Theta : PointRepresentation (R := R) (H := H) (V := V)) :
     pointRepresentationEquivComodule Theta = PointRepresentation.toComodule Theta :=
-  pointRepresentationEquivComodule_apply_private Theta
+  by
+    unfold pointRepresentationEquivComodule
+    rfl
 
 /-- The inverse map of the representation--comodule equivalence is the point action induced by a
 coaction. -/
 @[simp]
 theorem pointRepresentationEquivComodule_symm_apply (rho : Comodule R H V) :
     pointRepresentationEquivComodule.symm rho = PointRepresentation.ofComodule rho :=
-  pointRepresentationEquivComodule_symm_apply_private rho
+  by
+    unfold pointRepresentationEquivComodule
+    rfl
 
 end HopfAlgebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Basic.lean
@@ -65,7 +65,17 @@ attribute [simp] Comodule.lTensor_counit_comp_coact
 variable {R : Type u} {C : Type v} {M : Type w} {N : Type x}
 variable [CommSemiring R]
 variable [AddCommMonoid C] [Module R C] [Coalgebra R C]
-variable [AddCommMonoid M] [Module R M] [Comodule R C M]
+variable [AddCommMonoid M] [Module R M]
+
+/-- Two right-comodule structures are equal when their coactions are equal. -/
+@[ext]
+theorem ext {rho sigma : Comodule R C M} (h : rho.coact = sigma.coact) : rho = sigma := by
+  cases rho
+  cases sigma
+  cases h
+  rfl
+
+variable [Comodule R C M]
 variable [AddCommMonoid N] [Module R N] [Comodule R C N]
 
 /-- Coassociativity of the coaction, as an equality of linear maps. -/

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -46,8 +46,9 @@ theorem comul_eq_convMul_includeLeft_includeRight :
         (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
         (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap =
       LinearMap.id := by
-    -- Mathlib's `lmul'_comp_map` + `lift_includeLeft_includeRight` state this as an algebra-hom
-    -- identity, but bridging that to linear maps exceeds `maxHeartbeats`; see the PR discussion.
+    -- Mathlib's `lmul'_comp_map` requires a commutative target algebra, whereas `C ⊗[R] C`
+    -- is only a semiring here. `lift_includeLeft_includeRight` computes the same pure tensors,
+    -- but identifying this linear composite still requires tensor-product extensionality.
     apply TensorProduct.ext
     ext x y
     simp

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Coalgebra.Convolution
+
+/-!
+# Comultiplication as a convolution product
+
+Let `C` be an `R`-algebra carrying a comultiplication. This file records that, in the convolution
+monoid of linear maps `C →ₗ[R] C ⊗[R] C`, comultiplication is the convolution product of the two
+canonical inclusions `c ↦ c ⊗ₜ 1` and `c ↦ 1 ⊗ₜ c` of `C` into its tensor square.
+
+## Main declarations
+
+* `TauCeti.Coalgebra.comul_eq_convMul_includeLeft_includeRight`: comultiplication as the
+  convolution product of the two tensor inclusions.
+-/
+
+public section
+
+open TensorProduct WithConv
+
+namespace TauCeti
+
+namespace Coalgebra
+
+variable {R : Type*} {C : Type*} [CommSemiring R] [Semiring C] [Algebra R C]
+  [_root_.CoalgebraStruct R C]
+
+/-- **Comultiplication is the convolution product of the two tensor inclusions.** In the
+convolution monoid of maps `C →ₗ[R] C ⊗[R] C`, the product of `includeLeft` and `includeRight`
+multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
+
+Only the comultiplication *data* is used, so this needs `CoalgebraStruct` rather than
+`Coalgebra`: no coalgebra law, bialgebra compatibility or antipode axiom enters. -/
+theorem comul_eq_convMul_includeLeft_includeRight :
+    (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
+      toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
+        toConv (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap := by
+  apply WithConv.ofConv_injective
+  have hmul : LinearMap.mul' R (C ⊗[R] C) ∘ₗ
+      TensorProduct.map
+        (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
+        (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap =
+      LinearMap.id := by
+    -- Mathlib's `lmul'_comp_map` + `lift_includeLeft_includeRight` state this as an algebra-hom
+    -- identity, but bridging that to linear maps exceeds `maxHeartbeats`; see the PR discussion.
+    apply TensorProduct.ext
+    ext x y
+    simp
+  simp only [LinearMap.convMul_def]
+  rw [← LinearMap.comp_assoc, hmul]
+  simp
+
+end Coalgebra
+
+end TauCeti

--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.HopfAlgebra.Convolution
+public import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!
 # The antipode reverses comultiplication
@@ -17,8 +18,6 @@ factors, and applying the antipode to each factor.
 
 ## Main declarations
 
-* `TauCeti.HopfAlgebra.comul_eq_convMul_includeLeft_includeRight`: comultiplication as the
-  convolution product of the two tensor inclusions.
 * `TauCeti.HopfAlgebra.antipode_comul_antidistrib`: the identity as an equality of linear maps.
 * `TauCeti.HopfAlgebra.antipode_comul_antidistrib_apply`: the pointwise form.
 
@@ -81,31 +80,6 @@ section AlgebraCoalgebra
 variable {R : Type u} {C : Type v} [CommSemiring R] [Semiring C] [Algebra R C]
   [_root_.CoalgebraStruct R C]
 
-/-- **Comultiplication is the convolution product of the two tensor inclusions.** In the
-convolution monoid of maps `C →ₗ[R] C ⊗[R] C`, the product of `includeLeft` and `includeRight`
-multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
-
-Only the comultiplication *data* is used, so this needs `CoalgebraStruct` rather than
-`Coalgebra`: no coalgebra law, bialgebra compatibility or antipode axiom enters. -/
-theorem comul_eq_convMul_includeLeft_includeRight :
-    (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
-      toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
-        toConv (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap := by
-  apply WithConv.ofConv_injective
-  have hmul : LinearMap.mul' R (C ⊗[R] C) ∘ₗ
-      TensorProduct.map
-        (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
-        (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap =
-      LinearMap.id := by
-    -- Mathlib's `lmul'_comp_map` + `lift_includeLeft_includeRight` state this as an algebra-hom
-    -- identity, but bridging that to linear maps exceeds `maxHeartbeats`; see the PR discussion.
-    apply TensorProduct.ext
-    ext x y
-    simp
-  simp only [LinearMap.convMul_def]
-  rw [← LinearMap.comp_assoc, hmul]
-  simp
-
 /-- **Swapping the legs of `Δ` and applying `S` to each is the reversed convolution product.**
 For any linear endomorphism `S`, precomposing the two inclusions with `S` and multiplying them in
 the opposite order gives `(S ⊗ S) ∘ swap ∘ Δ`.
@@ -148,7 +122,7 @@ private lemma antipode_comul_antidistrib_rhs_mul_comul :
   -- `algHom_comp_antipode_mul_self`, then the outer pair does. `congrArg₂` rather than `rw`:
   -- `WithConv` is a type synonym, so rewriting under `toConv` re-wraps through `ofConv`.
   rw [congrArg₂ (· * ·) (map_comp_comm_comp_comul_eq_convMul (antipode R))
-    comul_eq_convMul_includeLeft_includeRight]
+    Coalgebra.comul_eq_convMul_includeLeft_includeRight]
   set L : WithConv (C →ₗ[R] C ⊗[R] C) :=
     toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap
   set P : WithConv (C →ₗ[R] C ⊗[R] C) :=

--- a/TauCeti/Algebra/HopfAlgebra/Antipode.lean
+++ b/TauCeti/Algebra/HopfAlgebra/Antipode.lean
@@ -17,6 +17,8 @@ factors, and applying the antipode to each factor.
 
 ## Main declarations
 
+* `TauCeti.HopfAlgebra.comul_eq_convMul_includeLeft_includeRight`: comultiplication as the
+  convolution product of the two tensor inclusions.
 * `TauCeti.HopfAlgebra.antipode_comul_antidistrib`: the identity as an equality of linear maps.
 * `TauCeti.HopfAlgebra.antipode_comul_antidistrib_apply`: the pointwise form.
 
@@ -85,7 +87,7 @@ multiplies the two legs of `Δ c` back together in order, which is `Δ` itself.
 
 Only the comultiplication *data* is used, so this needs `CoalgebraStruct` rather than
 `Coalgebra`: no coalgebra law, bialgebra compatibility or antipode axiom enters. -/
-private lemma comul_eq_convMul_includeLeft_includeRight :
+theorem comul_eq_convMul_includeLeft_includeRight :
     (toConv (Coalgebra.comul : C →ₗ[R] C ⊗[R] C) : WithConv (C →ₗ[R] C ⊗[R] C)) =
       toConv (Algebra.TensorProduct.includeLeft (R := R) (A := C) (B := C)).toLinearMap *
         toConv (Algebra.TensorProduct.includeRight (R := R) (A := C) (B := C)).toLinearMap := by


### PR DESCRIPTION
This PR identifies natural actions of a represented points functor on scalar extensions of a fixed module with right comodules. It constructs both directions, proves their inverse laws, and exposes characteristic formulas at arbitrary points and at the universal point.

It advances TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md, Layer 1, specifically the passage establishing the dictionary between functor-of-points representations and comodules.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"representation-comodule-object"}-->

🤖 Prepared with Codex