### PR TITLE
feat: complete the API of a germ that continues

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -386,8 +386,7 @@ protected theorem pow (h : ContinuesAlong f₀ c) (n : ℕ) : ContinuesAlong (f�
   let ⟨f, hf, hf0⟩ := h
   ⟨f ^ n, hf.pow n, hf0.pow_const n⟩
 
-/-- **The derivative of a germ that continues along a path continues along it**; the witness is
-the term-by-term derivative of a continuation of the germ itself. -/
+/-- The derivative of a germ that continues along a path continues along it. -/
 protected theorem deriv (h : ContinuesAlong f₀ c) : ContinuesAlong (_root_.deriv f₀) c :=
   let ⟨f, hf, hf0⟩ := h
   ⟨fun t => _root_.deriv (f t), hf.deriv, hf0.deriv⟩

--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -476,8 +476,8 @@ protected theorem pow (H : ContinuesInside f₀ U z₀) (n : ℕ) : ContinuesIns
   of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).pow n
 
 /-- **The derivative of a germ that continues inside a domain continues inside it.** On a simply
-connected `U` the branch it produces is the derivative of the branch of `f₀`
-(`TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn_deriv`). -/
+connected `U` it therefore has a branch of its own
+(`TauCeti.ContinuesInside.exists_analyticOnNhd`). -/
 protected theorem deriv (H : ContinuesInside f₀ U z₀) : ContinuesInside (_root_.deriv f₀) U z₀ :=
   of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).deriv
 

--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -54,6 +54,13 @@ across eventual equality of the initial function (`TauCeti.continuesAlong_congr`
 `TauCeti.continuesInside_congr`). `TauCeti.ContinuesInside` is the hypothesis of the monodromy
 theorem for a simply connected domain (`Conformal/GlobalBranch.lean`).
 
+Both predicates are closed under the ring operations and under differentiation, because a
+continuation of a combination of germs is the corresponding combination of continuations of the
+parts: the closure lemmas of `TauCeti.IsAnalyticContinuationAlong` transport to them verbatim, with
+no choice of continuation to reconcile. Constant germs continue outright
+(`TauCeti.ContinuesAlong.of_analyticAt`), so continuability is a condition one may check on the
+pieces of a germ built from simpler ones.
+
 ## Relation to the monodromy theorem
 
 This is the L4 prerequisite that the monodromy theorem of the conformal-mapping roadmap needs:
@@ -71,8 +78,8 @@ holomorphic germs and deducing monodromy from it is left to a follow-up.
 * `TauCeti.IsAnalyticContinuationAlong.const`, `.of_differentiableOn` — a holomorphic function
   continues itself along any path in its domain.
 * `TauCeti.IsAnalyticContinuationAlong.congr` — only the carried germs matter.
-* `TauCeti.IsAnalyticContinuationAlong.deriv`, `.add`, `.mul` — continuations are closed under the
-  germ-wise operations.
+* `TauCeti.IsAnalyticContinuationAlong.deriv`, `.add`, `.mul`, `.neg`, `.sub`, `.pow` —
+  continuations are closed under the germ-wise operations.
 * `TauCeti.IsAnalyticContinuationAlong.eventuallyEq` — **uniqueness**: a continuation over a
   preconnected parameter set is determined by its germ at a single time.
 * `TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo` — continuing a holomorphic function
@@ -81,6 +88,9 @@ holomorphic germs and deducing monodromy from it is left to a follow-up.
   and along every path inside a domain. Neither body is exposed; downstream files use them through
   `TauCeti.continuesAlong_iff_exists`, `TauCeti.ContinuesInside.continuesAlong` and
   `TauCeti.ContinuesInside.of_forall`.
+* `TauCeti.ContinuesAlong.add`, `.mul`, `.neg`, `.sub`, `.pow`, `.deriv` and their
+  `TauCeti.ContinuesInside` counterparts — continuability of a germ is inherited by sums, products,
+  differences, powers and derivatives.
 
 ## References
 
@@ -224,6 +234,30 @@ protected theorem mul (hf : IsAnalyticContinuationAlong f γ s)
   locallyEq t ht := by
     filter_upwards [hf.locallyEq t ht, hg.locallyEq t ht] with u hu hu' using hu.mul hu'
 
+/-- Continuations negate: the pointwise negation family `-f` continues along `γ` as well. -/
+protected theorem neg (hf : IsAnalyticContinuationAlong f γ s) :
+    IsAnalyticContinuationAlong (-f) γ s where
+  continuousOn := hf.continuousOn
+  analyticAt t ht := (hf.analyticAt t ht).neg
+  locallyEq t ht := (hf.locallyEq t ht).mono fun _ hu => hu.neg
+
+/-- Continuations subtract: the pointwise difference family `f - g` continues along `γ` as
+well. -/
+protected theorem sub (hf : IsAnalyticContinuationAlong f γ s)
+    (hg : IsAnalyticContinuationAlong g γ s) :
+    IsAnalyticContinuationAlong (f - g) γ s where
+  continuousOn := hf.continuousOn
+  analyticAt t ht := (hf.analyticAt t ht).sub (hg.analyticAt t ht)
+  locallyEq t ht := by
+    filter_upwards [hf.locallyEq t ht, hg.locallyEq t ht] with u hu hu' using hu.sub hu'
+
+/-- Continuations take powers: the pointwise power family `f ^ n` continues along `γ` as well. -/
+protected theorem pow (hf : IsAnalyticContinuationAlong f γ s) (n : ℕ) :
+    IsAnalyticContinuationAlong (f ^ n) γ s where
+  continuousOn := hf.continuousOn
+  analyticAt t ht := (hf.analyticAt t ht).pow n
+  locallyEq t ht := (hf.locallyEq t ht).mono fun _ hu => hu.pow_const n
+
 /-! ### Uniqueness -/
 
 /-- Agreement of two continuations along the same path is a locally constant property of the
@@ -319,6 +353,50 @@ theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ 
     (hcU : ∀ x, c x ∈ U) : ContinuesAlong f₀ c :=
   of_analyticAt hc fun x => hf₀.analyticOnNhd hUo _ (hcU x)
 
+/-! #### Closure under the germ-wise operations
+
+Continuing two germs along one path and combining the results is the same as combining first and
+continuing after: the operations act on the carried germs time by time
+(`TauCeti.IsAnalyticContinuationAlong.add` and its companions), so a continuation of the combination
+is obtained from continuations of the parts, with no new choices to make. -/
+
+/-- The sum of two germs that continue along a path continues along it. -/
+protected theorem add (h : ContinuesAlong f₀ c) (h' : ContinuesAlong g₀ c) :
+    ContinuesAlong (f₀ + g₀) c :=
+  let ⟨f, hf, hf0⟩ := h
+  let ⟨g, hg, hg0⟩ := h'
+  ⟨f + g, hf.add hg, hf0.add hg0⟩
+
+/-- The product of two germs that continue along a path continues along it. -/
+protected theorem mul (h : ContinuesAlong f₀ c) (h' : ContinuesAlong g₀ c) :
+    ContinuesAlong (f₀ * g₀) c :=
+  let ⟨f, hf, hf0⟩ := h
+  let ⟨g, hg, hg0⟩ := h'
+  ⟨f * g, hf.mul hg, hf0.mul hg0⟩
+
+/-- The negation of a germ that continues along a path continues along it. -/
+protected theorem neg (h : ContinuesAlong f₀ c) : ContinuesAlong (-f₀) c :=
+  let ⟨f, hf, hf0⟩ := h
+  ⟨-f, hf.neg, hf0.neg⟩
+
+/-- The difference of two germs that continue along a path continues along it. -/
+protected theorem sub (h : ContinuesAlong f₀ c) (h' : ContinuesAlong g₀ c) :
+    ContinuesAlong (f₀ - g₀) c :=
+  let ⟨f, hf, hf0⟩ := h
+  let ⟨g, hg, hg0⟩ := h'
+  ⟨f - g, hf.sub hg, hf0.sub hg0⟩
+
+/-- A power of a germ that continues along a path continues along it. -/
+protected theorem pow (h : ContinuesAlong f₀ c) (n : ℕ) : ContinuesAlong (f₀ ^ n) c :=
+  let ⟨f, hf, hf0⟩ := h
+  ⟨f ^ n, hf.pow n, hf0.pow_const n⟩
+
+/-- **The derivative of a germ that continues along a path continues along it**; the witness is
+the term-by-term derivative of a continuation of the germ itself. -/
+protected theorem deriv (h : ContinuesAlong f₀ c) : ContinuesAlong (_root_.deriv f₀) c :=
+  let ⟨f, hf, hf0⟩ := h
+  ⟨fun t => _root_.deriv (f t), hf.deriv, hf0.deriv⟩
+
 end ContinuesAlong
 
 /-- Continuability along a path is a property of the germ of `f₀` at the initial point. -/
@@ -366,6 +444,42 @@ protected theorem congr (H : ContinuesInside f₀ U z₀) (hfg : f₀ =ᶠ[𝓝 
 theorem of_differentiableOn (hUo : IsOpen U) (hf₀ : DifferentiableOn ℂ f₀ U) :
     ContinuesInside f₀ U z₀ :=
   of_forall fun _ hc hcU _ => .of_differentiableOn hUo hf₀ hc hcU
+
+/-! #### Closure under the germ-wise operations
+
+Continuability inside `U` is continuability along each path of `U` at once, so it inherits the
+closure properties of `TauCeti.ContinuesAlong` path by path. Read through the monodromy theorem for
+a simply connected domain (`Conformal/GlobalBranch.lean`), these are the statements that a germ
+assembled from germs extending to `U` extends to `U` itself. -/
+
+/-- The sum of two germs that continue inside a domain continues inside it. -/
+protected theorem add (H : ContinuesInside f₀ U z₀) (H' : ContinuesInside g₀ U z₀) :
+    ContinuesInside (f₀ + g₀) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).add (H'.continuesAlong hc hcU hc0)
+
+/-- The product of two germs that continue inside a domain continues inside it. -/
+protected theorem mul (H : ContinuesInside f₀ U z₀) (H' : ContinuesInside g₀ U z₀) :
+    ContinuesInside (f₀ * g₀) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).mul (H'.continuesAlong hc hcU hc0)
+
+/-- The negation of a germ that continues inside a domain continues inside it. -/
+protected theorem neg (H : ContinuesInside f₀ U z₀) : ContinuesInside (-f₀) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).neg
+
+/-- The difference of two germs that continue inside a domain continues inside it. -/
+protected theorem sub (H : ContinuesInside f₀ U z₀) (H' : ContinuesInside g₀ U z₀) :
+    ContinuesInside (f₀ - g₀) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).sub (H'.continuesAlong hc hcU hc0)
+
+/-- A power of a germ that continues inside a domain continues inside it. -/
+protected theorem pow (H : ContinuesInside f₀ U z₀) (n : ℕ) : ContinuesInside (f₀ ^ n) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).pow n
+
+/-- **The derivative of a germ that continues inside a domain continues inside it.** On a simply
+connected `U` the branch it produces is the derivative of the branch of `f₀`
+(`TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn_deriv`). -/
+protected theorem deriv (H : ContinuesInside f₀ U z₀) : ContinuesInside (_root_.deriv f₀) U z₀ :=
+  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).deriv
 
 end ContinuesInside
 

--- a/TauCeti/Analysis/Complex/Conformal/Continuation.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Continuation.lean
@@ -57,9 +57,9 @@ theorem for a simply connected domain (`Conformal/GlobalBranch.lean`).
 Both predicates are closed under the ring operations and under differentiation, because a
 continuation of a combination of germs is the corresponding combination of continuations of the
 parts: the closure lemmas of `TauCeti.IsAnalyticContinuationAlong` transport to them verbatim, with
-no choice of continuation to reconcile. Constant germs continue outright
-(`TauCeti.ContinuesAlong.of_analyticAt`), so continuability is a condition one may check on the
-pieces of a germ built from simpler ones.
+no choice of continuation to reconcile. A function analytic at every point of a continuous path
+continues along it via the constant family (`TauCeti.ContinuesAlong.of_analyticAt`), so
+continuability is a condition one may check on the pieces of a germ built from simpler ones.
 
 ## Relation to the monodromy theorem
 
@@ -245,11 +245,8 @@ protected theorem neg (hf : IsAnalyticContinuationAlong f γ s) :
 well. -/
 protected theorem sub (hf : IsAnalyticContinuationAlong f γ s)
     (hg : IsAnalyticContinuationAlong g γ s) :
-    IsAnalyticContinuationAlong (f - g) γ s where
-  continuousOn := hf.continuousOn
-  analyticAt t ht := (hf.analyticAt t ht).sub (hg.analyticAt t ht)
-  locallyEq t ht := by
-    filter_upwards [hf.locallyEq t ht, hg.locallyEq t ht] with u hu hu' using hu.sub hu'
+    IsAnalyticContinuationAlong (f - g) γ s := by
+  simpa only [sub_eq_add_neg] using hf.add hg.neg
 
 /-- Continuations take powers: the pointwise power family `f ^ n` continues along `γ` as well. -/
 protected theorem pow (hf : IsAnalyticContinuationAlong f γ s) (n : ℕ) :
@@ -381,10 +378,8 @@ protected theorem neg (h : ContinuesAlong f₀ c) : ContinuesAlong (-f₀) c :=
 
 /-- The difference of two germs that continue along a path continues along it. -/
 protected theorem sub (h : ContinuesAlong f₀ c) (h' : ContinuesAlong g₀ c) :
-    ContinuesAlong (f₀ - g₀) c :=
-  let ⟨f, hf, hf0⟩ := h
-  let ⟨g, hg, hg0⟩ := h'
-  ⟨f - g, hf.sub hg, hf0.sub hg0⟩
+    ContinuesAlong (f₀ - g₀) c := by
+  simpa only [sub_eq_add_neg] using h.add h'.neg
 
 /-- A power of a germ that continues along a path continues along it. -/
 protected theorem pow (h : ContinuesAlong f₀ c) (n : ℕ) : ContinuesAlong (f₀ ^ n) c :=
@@ -468,15 +463,15 @@ protected theorem neg (H : ContinuesInside f₀ U z₀) : ContinuesInside (-f₀
 
 /-- The difference of two germs that continue inside a domain continues inside it. -/
 protected theorem sub (H : ContinuesInside f₀ U z₀) (H' : ContinuesInside g₀ U z₀) :
-    ContinuesInside (f₀ - g₀) U z₀ :=
-  of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).sub (H'.continuesAlong hc hcU hc0)
+    ContinuesInside (f₀ - g₀) U z₀ := by
+  simpa only [sub_eq_add_neg] using H.add H'.neg
 
 /-- A power of a germ that continues inside a domain continues inside it. -/
 protected theorem pow (H : ContinuesInside f₀ U z₀) (n : ℕ) : ContinuesInside (f₀ ^ n) U z₀ :=
   of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).pow n
 
-/-- **The derivative of a germ that continues inside a domain continues inside it.** On a simply
-connected `U` it therefore has a branch of its own
+/-- **The derivative of a germ that continues inside a domain continues inside it.** If `U` is open
+and simply connected and contains `z₀`, the derivative therefore has a branch of its own on `U`
 (`TauCeti.ContinuesInside.exists_analyticOnNhd`). -/
 protected theorem deriv (H : ContinuesInside f₀ U z₀) : ContinuesInside (_root_.deriv f₀) U z₀ :=
   of_forall fun _ hc hcU hc0 => (H.continuesAlong hc hcU hc0).deriv

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -7,8 +7,6 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Monodromy
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
-import Mathlib.Analysis.Analytic.Uniqueness
-import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Topology.MetricSpace.Thickening
 
 /-!
@@ -34,23 +32,11 @@ two-way form below it is supplied by nothing else once `U` is simply connected.
 * `TauCeti.ContinuesInside.exists_analyticOnNhd` — **the monodromy theorem for a simply connected
   domain**: a germ that continues along every path of a simply connected open `U` is the germ of
   a function analytic on all of `U`.
-* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eventuallyEq` — the branch **computes** the
-  continuation: every continuation of the germ inside `U` ends at the germ of the branch.
-* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn` — the branch is **unique**: any two
-  analytic functions on `U` carrying the germ agree on `U`.
-* `TauCeti.ContinuesInside.eventuallyEq_of_loop` — a germ continued around a **loop** of `U` comes
-  back to itself.
-* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn_deriv` — the branch of the derivative
-  germ is the derivative of the branch.
 * `TauCeti.continuesInside_iff_exists_analyticOnNhd` — the two-way form on a simply connected open
   set: continuable along every path inside `U` ⟺ the germ of a function analytic on `U`.
 
-Uniqueness is the identity principle
-(`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`) and needs only preconnectedness of `U`,
-which simple connectivity supplies; the computation clause is uniqueness of continuation along a
-fixed path (`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo`), the branch being its own
-continuation along every path of `U`. It is existence of the branch that spends the monodromy
-theorem, and the loop form spends it too: no hypothesis makes the germ single-valued there.
+The branch produced is unique as soon as `U` is preconnected, by the identity principle
+(`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`); no uniqueness statement is added here.
 
 ## The construction
 
@@ -242,74 +228,6 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
   · -- The prescribed germ at `z₀`: apply the key step to the constant path.
     exact key z₀ (fun _ => z₀) (fun _ => f₀) continuous_const (fun _ => hz₀) rfl rfl
       (.const continuousOn_const fun _ _ => H.analyticAt hz₀) .rfl
-
-/-- **The global branch computes every continuation.** The function produced by
-`TauCeti.ContinuesInside.exists_analyticOnNhd` does more than carry the germ of `f₀` at `z₀`: the
-germ that *any* continuation of that germ delivers at the far end of *any* path in `U` is the germ
-of `F` there. So on a simply connected domain a continuation is never a new function, only a fresh
-reading of the branch.
-
-Given the branch, this is uniqueness of continuation along a fixed path
-(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo`, applied over the preconnected
-parameter interval), since `F` continues itself along every path that stays in `U`; what simple
-connectivity buys is the branch, not this clause. -/
-theorem exists_analyticOnNhd_forall_eventuallyEq (hUo : IsOpen U) (hUc : IsSimplyConnected U)
-    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
-    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
-      ∀ (c : I → ℂ) (g : I → ℂ → ℂ), (∀ x, c x ∈ U) → c 0 = z₀ →
-        IsAnalyticContinuationAlong g c univ → g 0 =ᶠ[𝓝 z₀] f₀ → g 1 =ᶠ[𝓝 (c 1)] F :=
-  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
-  ⟨F, hF, hF₀, fun _ _ hcU hc0 hg hg0 => hg.eventuallyEq_of_mapsTo isPreconnected_univ hUo
-    (AnalyticOnNhd.differentiableOn hF) (fun t _ => hcU t) (mem_univ 0) (mem_univ 1)
-    (hc0 ▸ hg0.trans hF₀.symm)⟩
-
-/-- **Existence and uniqueness of the global branch.** On a simply connected open `U` a germ that
-continues inside `U` extends to a function analytic on `U`, and that function is determined by the
-germ: any two analytic functions on `U` carrying it agree on all of `U`.
-
-Uniqueness needs only preconnectedness of `U`, which simple connectivity supplies, and is the
-identity principle `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`; it is existence that needs
-the full hypothesis. Note that the branches are only claimed to agree *on `U`* — their values
-outside `U`, where analyticity says nothing, are of course unconstrained. -/
-theorem exists_analyticOnNhd_forall_eqOn (hUo : IsOpen U) (hUc : IsSimplyConnected U)
-    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
-    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
-      ∀ G : ℂ → ℂ, AnalyticOnNhd ℂ G U → G =ᶠ[𝓝 z₀] f₀ → EqOn G F U :=
-  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
-  ⟨F, hF, hF₀, fun _ hG hG₀ => AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq hG hF
-    hUc.isPathConnected.isConnected.isPreconnected hz₀ (hG₀.trans hF₀.symm)⟩
-
-/-- **The branch of the derivative germ is the derivative of the branch.** The germ `deriv f₀`
-continues inside `U` whenever `f₀` does (`TauCeti.ContinuesInside.deriv`), so on a simply connected
-`U` it has a branch of its own; that branch is `deriv F`, for `F` the branch of `f₀`.
-
-Only uniqueness is at work once `F` is at hand: `deriv F` is analytic on the open `U` and carries
-the germ `deriv f₀` at `z₀`, which by the identity principle already pins it down. Iterating gives
-the branches of all the higher derivative germs. -/
-theorem exists_analyticOnNhd_forall_eqOn_deriv (hUo : IsOpen U) (hUc : IsSimplyConnected U)
-    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
-    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
-      ∀ G : ℂ → ℂ, AnalyticOnNhd ℂ G U → G =ᶠ[𝓝 z₀] deriv f₀ → EqOn G (deriv F) U :=
-  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
-  ⟨F, hF, hF₀, fun _ hG hG₀ => AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq hG
-    (hF.deriv_of_isOpen hUo) hUc.isPathConnected.isConnected.isPreconnected hz₀
-    (hG₀.trans hF₀.deriv.symm)⟩
-
-/-- **A germ continued around a loop of a simply connected domain returns to itself.** This is
-`TauCeti.monodromy_theorem_of_homotopy_refl` with the null-homotopy of the loop supplied by the
-topology of `U` rather than by hypothesis, and with the continuations along the intermediate paths
-supplied by `TauCeti.ContinuesInside`.
-
-It is the concrete reason a multi-valued analytic function needs a hole to be multi-valued: the
-germ of `Complex.log` at `1` returns to itself along every loop of the slit plane, and can come
-back changed only along a loop of `ℂ \ {0}` that winds around the puncture. -/
-theorem eventuallyEq_of_loop (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
-    (hz₀ : z₀ ∈ U) (hδU : ∀ x, δ x ∈ U) (hδ0 : δ 0 = z₀) (hδ1 : δ 1 = z₀)
-    (hg : IsAnalyticContinuationAlong g δ univ) (hg0 : g 0 =ᶠ[𝓝 z₀] f₀) :
-    g 1 =ᶠ[𝓝 z₀] f₀ :=
-  (H.eventuallyEq_at_one (γ := fun _ => z₀) (f := fun _ => f₀) hUc continuous_const
-    (fun _ => hz₀) rfl (continuousOn_univ.mp hg.continuousOn) hδU hδ0 hδ1
-    (.const continuousOn_const fun _ _ => H.analyticAt hz₀) .rfl hg hg0).symm
 
 end ContinuesInside
 

--- a/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
+++ b/TauCeti/Analysis/Complex/Conformal/GlobalBranch.lean
@@ -7,6 +7,8 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Monodromy
 public import Mathlib.AlgebraicTopology.FundamentalGroupoid.SimplyConnected
+import Mathlib.Analysis.Analytic.Uniqueness
+import Mathlib.Analysis.Calculus.FDeriv.Analytic
 import Mathlib.Topology.MetricSpace.Thickening
 
 /-!
@@ -32,11 +34,23 @@ two-way form below it is supplied by nothing else once `U` is simply connected.
 * `TauCeti.ContinuesInside.exists_analyticOnNhd` — **the monodromy theorem for a simply connected
   domain**: a germ that continues along every path of a simply connected open `U` is the germ of
   a function analytic on all of `U`.
+* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eventuallyEq` — the branch **computes** the
+  continuation: every continuation of the germ inside `U` ends at the germ of the branch.
+* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn` — the branch is **unique**: any two
+  analytic functions on `U` carrying the germ agree on `U`.
+* `TauCeti.ContinuesInside.eventuallyEq_of_loop` — a germ continued around a **loop** of `U` comes
+  back to itself.
+* `TauCeti.ContinuesInside.exists_analyticOnNhd_forall_eqOn_deriv` — the branch of the derivative
+  germ is the derivative of the branch.
 * `TauCeti.continuesInside_iff_exists_analyticOnNhd` — the two-way form on a simply connected open
   set: continuable along every path inside `U` ⟺ the germ of a function analytic on `U`.
 
-The branch produced is unique as soon as `U` is preconnected, by the identity principle
-(`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`); no uniqueness statement is added here.
+Uniqueness is the identity principle
+(`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`) and needs only preconnectedness of `U`,
+which simple connectivity supplies; the computation clause is uniqueness of continuation along a
+fixed path (`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo`), the branch being its own
+continuation along every path of `U`. It is existence of the branch that spends the monodromy
+theorem, and the loop form spends it too: no hypothesis makes the germ single-valued there.
 
 ## The construction
 
@@ -228,6 +242,74 @@ theorem exists_analyticOnNhd (hUo : IsOpen U) (hUc : IsSimplyConnected U) (hz₀
   · -- The prescribed germ at `z₀`: apply the key step to the constant path.
     exact key z₀ (fun _ => z₀) (fun _ => f₀) continuous_const (fun _ => hz₀) rfl rfl
       (.const continuousOn_const fun _ _ => H.analyticAt hz₀) .rfl
+
+/-- **The global branch computes every continuation.** The function produced by
+`TauCeti.ContinuesInside.exists_analyticOnNhd` does more than carry the germ of `f₀` at `z₀`: the
+germ that *any* continuation of that germ delivers at the far end of *any* path in `U` is the germ
+of `F` there. So on a simply connected domain a continuation is never a new function, only a fresh
+reading of the branch.
+
+Given the branch, this is uniqueness of continuation along a fixed path
+(`TauCeti.IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo`, applied over the preconnected
+parameter interval), since `F` continues itself along every path that stays in `U`; what simple
+connectivity buys is the branch, not this clause. -/
+theorem exists_analyticOnNhd_forall_eventuallyEq (hUo : IsOpen U) (hUc : IsSimplyConnected U)
+    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
+    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
+      ∀ (c : I → ℂ) (g : I → ℂ → ℂ), (∀ x, c x ∈ U) → c 0 = z₀ →
+        IsAnalyticContinuationAlong g c univ → g 0 =ᶠ[𝓝 z₀] f₀ → g 1 =ᶠ[𝓝 (c 1)] F :=
+  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
+  ⟨F, hF, hF₀, fun _ _ hcU hc0 hg hg0 => hg.eventuallyEq_of_mapsTo isPreconnected_univ hUo
+    (AnalyticOnNhd.differentiableOn hF) (fun t _ => hcU t) (mem_univ 0) (mem_univ 1)
+    (hc0 ▸ hg0.trans hF₀.symm)⟩
+
+/-- **Existence and uniqueness of the global branch.** On a simply connected open `U` a germ that
+continues inside `U` extends to a function analytic on `U`, and that function is determined by the
+germ: any two analytic functions on `U` carrying it agree on all of `U`.
+
+Uniqueness needs only preconnectedness of `U`, which simple connectivity supplies, and is the
+identity principle `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`; it is existence that needs
+the full hypothesis. Note that the branches are only claimed to agree *on `U`* — their values
+outside `U`, where analyticity says nothing, are of course unconstrained. -/
+theorem exists_analyticOnNhd_forall_eqOn (hUo : IsOpen U) (hUc : IsSimplyConnected U)
+    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
+    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
+      ∀ G : ℂ → ℂ, AnalyticOnNhd ℂ G U → G =ᶠ[𝓝 z₀] f₀ → EqOn G F U :=
+  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
+  ⟨F, hF, hF₀, fun _ hG hG₀ => AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq hG hF
+    hUc.isPathConnected.isConnected.isPreconnected hz₀ (hG₀.trans hF₀.symm)⟩
+
+/-- **The branch of the derivative germ is the derivative of the branch.** The germ `deriv f₀`
+continues inside `U` whenever `f₀` does (`TauCeti.ContinuesInside.deriv`), so on a simply connected
+`U` it has a branch of its own; that branch is `deriv F`, for `F` the branch of `f₀`.
+
+Only uniqueness is at work once `F` is at hand: `deriv F` is analytic on the open `U` and carries
+the germ `deriv f₀` at `z₀`, which by the identity principle already pins it down. Iterating gives
+the branches of all the higher derivative germs. -/
+theorem exists_analyticOnNhd_forall_eqOn_deriv (hUo : IsOpen U) (hUc : IsSimplyConnected U)
+    (hz₀ : z₀ ∈ U) (H : ContinuesInside f₀ U z₀) :
+    ∃ F : ℂ → ℂ, AnalyticOnNhd ℂ F U ∧ F =ᶠ[𝓝 z₀] f₀ ∧
+      ∀ G : ℂ → ℂ, AnalyticOnNhd ℂ G U → G =ᶠ[𝓝 z₀] deriv f₀ → EqOn G (deriv F) U :=
+  let ⟨F, hF, hF₀⟩ := H.exists_analyticOnNhd hUo hUc hz₀
+  ⟨F, hF, hF₀, fun _ hG hG₀ => AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq hG
+    (hF.deriv_of_isOpen hUo) hUc.isPathConnected.isConnected.isPreconnected hz₀
+    (hG₀.trans hF₀.deriv.symm)⟩
+
+/-- **A germ continued around a loop of a simply connected domain returns to itself.** This is
+`TauCeti.monodromy_theorem_of_homotopy_refl` with the null-homotopy of the loop supplied by the
+topology of `U` rather than by hypothesis, and with the continuations along the intermediate paths
+supplied by `TauCeti.ContinuesInside`.
+
+It is the concrete reason a multi-valued analytic function needs a hole to be multi-valued: the
+germ of `Complex.log` at `1` returns to itself along every loop of the slit plane, and can come
+back changed only along a loop of `ℂ \ {0}` that winds around the puncture. -/
+theorem eventuallyEq_of_loop (hUc : IsSimplyConnected U) (H : ContinuesInside f₀ U z₀)
+    (hz₀ : z₀ ∈ U) (hδU : ∀ x, δ x ∈ U) (hδ0 : δ 0 = z₀) (hδ1 : δ 1 = z₀)
+    (hg : IsAnalyticContinuationAlong g δ univ) (hg0 : g 0 =ᶠ[𝓝 z₀] f₀) :
+    g 1 =ᶠ[𝓝 z₀] f₀ :=
+  (H.eventuallyEq_at_one (γ := fun _ => z₀) (f := fun _ => f₀) hUc continuous_const
+    (fun _ => hz₀) rfl (continuousOn_univ.mp hg.continuousOn) hδU hδ0 hδ1
+    (.const continuousOn_const fun _ _ => H.analyticAt hz₀) .rfl hg hg0).symm
 
 end ContinuesInside
 


### PR DESCRIPTION
This PR completes the algebraic API that `TauCeti/Analysis/Complex/Conformal/Continuation.lean` left unfinished around the two predicates that record when a holomorphic germ continues: `TauCeti.ContinuesAlong` (along one path) and `TauCeti.ContinuesInside` (along every path of a domain). That file is already on `main`; nothing new is defined here and no new mathematics is introduced, so this is a fill-in under the a-priori exemption of the `scope` rubric — "modestly generalising or documenting material that already exists needs no roadmap claim". Attribution: the material it completes is layer L4 of `TauCetiRoadmap/ConformalMapping/README.md`, "analytic continuation & the reflection principle", whose monodromy statement for a simply connected domain is `TauCeti.ContinuesInside.exists_analyticOnNhd`. L4 lies outside the roadmap's shim-deletion clause for the upstream Riemann-mapping effort (leanprover-community/mathlib4#33505), which contains no continuation or monodromy material.

The gap: `TauCeti.IsAnalyticContinuationAlong` carried `.add`, `.mul` and `.deriv` but not `.neg`, `.sub` or `.pow`, and none of the four were ever handed down to `ContinuesAlong`/`ContinuesInside`, which had no algebraic API at all — so a germ known to continue gave nothing about the germ of its square or its derivative. The missing closure lemmas are added at all three levels, each a direct consequence of the level above it: a continuation of a combination of germs is the corresponding combination of continuations of the parts, so there is no choice of continuation to reconcile. The module docstring of `Continuation.lean` is updated to match.

No Mathlib infrastructure is vendored: `Filter.EventuallyEq`'s algebra and the `AnalyticAt` closure lemmas are consumed from Mathlib, and no import is added.

**Round 1 (`reuse` block).** The block was correct and is addressed by deletion, not by rework. The first commit also added four theorems to `Conformal/GlobalBranch.lean`; the review located each of them as a composition of existing results — the three `ContinuesInside.exists_analyticOnNhd_forall_*` theorems are `∧`-bundles of `exists_analyticOnNhd` with `IsAnalyticContinuationAlong.eventuallyEq_of_mapsTo` or `AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq`, and `ContinuesInside.eventuallyEq_of_loop` is the constant-path specialization of the existing `ContinuesInside.eventuallyEq_at_one`. None had a consumer, so none earns the rubric's "specialization with genuine consumers" exemption. `GlobalBranch.lean` is now restored verbatim to its state on `main`, module docstring and imports included; this PR touches `Continuation.lean` only.

`lake build` and `lake exe axioms` are green (20584 declarations audited, allowlist only).

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"isanalyticcontinuationalong-eventuallyeq-of-analyticonnhd"}-->

🤖 Prepared with Claude Code
