### PR TITLE
feat: present the general linear group scheme in coordinates

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Group.Affine
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.FiniteType
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
 # Diagonalizable group schemes
@@ -87,8 +87,8 @@ noncomputable def groupScheme (G : FGCommGrpCat.{u}) :
 @[simp]
 lemma groupScheme_X_left (G : FGCommGrpCat.{u}) :
     (groupScheme R G).X.left = Spec (CommRingCat.of (MonoidAlgebra R G)) := by
-  unfold groupScheme
-  rfl
+  simpa only [groupScheme] using
+    hopfSpec_obj_X_left R (coordinateRing R G).obj
 
 /-- After identifying its source with `Spec R[G]`, the structural morphism of `D(G)` is
 induced by the group-algebra structure map. -/
@@ -97,15 +97,8 @@ lemma groupScheme_X_hom (G : FGCommGrpCat.{u}) :
     (groupScheme R G).X.hom =
       eqToHom (groupScheme_X_left R G) ≫
         Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G))) := by
-  simpa only [eqToHom_refl, Category.comp_id] using
-    (conj_eqToHom_iff_heq
-      (groupScheme R G).X.hom
-      (Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G))))
-      (groupScheme_X_left R G) rfl).2 (by
-        unfold groupScheme
-        exact heq_of_eq (AlgebraicGeometry.algSpec_obj_hom
-          (R := CommRingCat.of R)
-          (Opposite.op (CommAlgCat.of R (MonoidAlgebra R G)))))
+  simpa only [groupScheme] using
+    hopfSpec_obj_X_hom R (coordinateRing R G).obj
 
 /-- The source scheme of multiplication on `D(G)` is the fibre product of two copies of
 `Spec R[G]` over `Spec R`. -/
@@ -115,43 +108,8 @@ lemma groupScheme_tensor_X_left (G : FGCommGrpCat.{u}) :
       Limits.pullback
         (Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G))))
         (Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G)))) := by
-  rw [Over.tensorObj_left]
-  have h : (groupScheme R G).X.hom ≍
-      Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G))) := by
-    rw [groupScheme_X_hom]
-    exact eqToHom_comp_heq _ _
-  cases groupScheme_X_left R G
-  exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
-
-/-- Specialize Mathlib's `algSpec_map_left` computation to an explicit algebra morphism.
-
-This is the sole boundary where the `CommAlgCat`/under-category wrapper left in that public
-computation lemma is reduced: `algSpec_map_left` phrases its answer through
-`(commAlgCatEquivUnder R).functor.map`, and Mathlib provides no computation lemma for the
-`Under.Hom.right` of that morphism, so the last step is definitional. Keeping it here avoids
-proof-sensitive reductions at the public projection lemmas below. -/
-private lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
-    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
-    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
-      (CommAlgCat.ofHom f).op).left =
-        Spec.map (CommRingCat.ofHom f.toRingHom) := by
-  rw [AlgebraicGeometry.algSpec_map_left]
-  rfl
-
-/-- `D(G)` is Mathlib's group object `(Spec R[G]).asOver (Spec R)`.
-
-`hopfSpec` builds `D(G)` as the `algSpec`-image of the cogroup algebra `R[G]`, and Mathlib's
-`AlgebraicGeometry.instGrpObjSpecAsOverSpec` is defined to be exactly that image, so the two
-group objects are equal by definition. Mathlib has no lemma identifying the two instance paths:
-its computation lemmas for the operations of a functor image (`Functor.mapGrp_obj_grp_mul`,
-`Functor.obj.ι_def`) are keyed on the `Functor.grpObjObj` instance, which `rw` cannot see
-through the bundled `Grp` object here. This lemma is therefore the single place where that
-identification is made, and the operation computations below rewrite with it instead of
-reducing `hopfSpec` themselves. -/
-private lemma groupScheme_eq_asOver (G : FGCommGrpCat.{u}) :
-    groupScheme R G =
-      Grp.mk ((Spec (CommRingCat.of (MonoidAlgebra R G))).asOver (Spec (CommRingCat.of R))) :=
-  rfl
+  simpa only [groupScheme] using
+    hopfSpec_obj_tensor_X_left R (coordinateRing R G).obj
 
 /-- The unit of `D(G)` is induced by the counit of the group algebra. -/
 @[simp]
@@ -160,15 +118,8 @@ lemma groupScheme_one_left (G : FGCommGrpCat.{u}) :
       Spec.map (CommRingCat.ofHom
         (Bialgebra.counitAlgHom R (MonoidAlgebra R G))) ≫
       eqToHom (groupScheme_X_left R G).symm := by
-  simpa only [eqToHom_refl, Category.id_comp] using
-    (conj_eqToHom_iff_heq
-      η[(groupScheme R G).X].left
-      (Spec.map (CommRingCat.ofHom
-        (Bialgebra.counitAlgHom R (MonoidAlgebra R G))))
-      rfl (groupScheme_X_left R G)).2 (by
-        rw [groupScheme_eq_asOver]
-        exact heq_of_eq (AlgebraicGeometry.one_spec_asOver_spec_left
-          (R := CommRingCat.of R) (A := CommRingCat.of (MonoidAlgebra R G))))
+  unfold groupScheme
+  convert hopfSpec_obj_one_left R (coordinateRing R G).obj using 1
 
 /-- Multiplication on `D(G)` is induced by the comultiplication of the group algebra. The
 first transport identifies its opaque product source with the standard affine fibre product. -/
@@ -180,16 +131,8 @@ lemma groupScheme_mul_left (G : FGCommGrpCat.{u}) :
         Spec.map (CommRingCat.ofHom
           (Bialgebra.comulAlgHom R (MonoidAlgebra R G))) ≫
         eqToHom (groupScheme_X_left R G).symm := by
-  simpa only [Category.assoc] using
-    (conj_eqToHom_iff_heq
-      μ[(groupScheme R G).X].left
-      ((pullbackSpecIso R (MonoidAlgebra R G) (MonoidAlgebra R G)).hom ≫
-        Spec.map (CommRingCat.ofHom
-          (Bialgebra.comulAlgHom R (MonoidAlgebra R G))))
-      (groupScheme_tensor_X_left R G) (groupScheme_X_left R G)).2 (by
-        rw [groupScheme_eq_asOver]
-        exact heq_of_eq (AlgebraicGeometry.mul_spec_asOver_spec_left
-          (R := CommRingCat.of R) (A := CommRingCat.of (MonoidAlgebra R G))))
+  unfold groupScheme
+  convert hopfSpec_obj_mul_left R (coordinateRing R G).obj using 1
 
 /-- Inversion on `D(G)` is induced by the antipode of the group algebra. -/
 @[simp]
@@ -199,14 +142,8 @@ lemma groupScheme_inv_left (G : FGCommGrpCat.{u}) :
       Spec.map (CommRingCat.ofHom
         (HopfAlgebra.antipodeAlgHom R (MonoidAlgebra R G)).toRingHom) ≫
       eqToHom (groupScheme_X_left R G).symm := by
-  apply (conj_eqToHom_iff_heq _ _
-    (groupScheme_X_left R G) (groupScheme_X_left R G)).2
-  -- Mathlib computes the unit and the multiplication of `(Spec A).asOver (Spec R)` but not its
-  -- inverse, which is the `algSpec`-image of the antipode; `algSpec_map_left_ofAlgHom` turns
-  -- that image into the expected `Spec.map`.
-  rw [groupScheme_eq_asOver]
-  exact heq_of_eq (algSpec_map_left_ofAlgHom R
-    (HopfAlgebra.antipodeAlgHom R (MonoidAlgebra R G)))
+  unfold groupScheme
+  convert hopfSpec_obj_inv_left R (coordinateRing R G).obj using 1
 
 /-- A homomorphism `G ⟶ H` induces the contravariant group-scheme morphism
 `D(H) ⟶ D(G)`. -/
@@ -313,10 +250,7 @@ instance locallyOfFiniteType_groupScheme (G : FGCommGrpCat.{u}) :
     locallyOfFiniteType_of_isOpenImmersion _
   letI : LocallyOfFiniteType
       (Spec.map (CommRingCat.ofHom (algebraMap R (MonoidAlgebra R G)))) := by
-    -- `change` selects the `specOverSpec` instance path compatible with the finite-type
-    -- coordinate algebra.
-    change LocallyOfFiniteType
-      (Spec (CommRingCat.of (MonoidAlgebra R G)) ↘ Spec (CommRingCat.of R))
+    rw [← AlgebraicGeometry.specOverSpec_over]
     infer_instance
   exact locallyOfFiniteType_comp _ _
 

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -1,0 +1,319 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Group.Affine
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.CoordinateHopfAlgebra
+
+/-!
+# The general linear group scheme
+
+For a commutative ring `R` and a natural number `n`, the coordinate Hopf algebra of the general
+linear group is the determinant localization
+
+`R[Xᵢⱼ][det(X)⁻¹]`.
+
+Applying relative spectrum to the bundled coordinate Hopf algebra gives an affine group scheme
+over `Spec R`. This file presents its underlying scheme canonically as the spectrum of the raw
+determinant localization. Under that presentation, the structural morphism, unit,
+multiplication, and inversion are induced contravariantly by the algebra structure map, counit,
+comultiplication, and antipode, respectively. The multiplication source is identified with the
+spectrum of the tensor square of the raw coordinate ring.
+
+The construction includes rank zero and the zero ring. Mathlib's current `hopfSpec` construction
+requires the base ring and Hopf-algebra carrier to lie in the same universe, so this file uses that
+same-universe setting.
+
+## Main declarations
+
+* `TauCeti.GeneralLinear.groupScheme`: the general linear group scheme over `Spec R`.
+* `TauCeti.GeneralLinear.groupSchemeSpecIso`: its canonical raw-coordinate presentation.
+* `TauCeti.GeneralLinear.groupSchemeMulSourceIso`: the tensor-coordinate presentation of the
+  multiplication source.
+* `TauCeti.GeneralLinear.groupScheme_one_left`,
+  `TauCeti.GeneralLinear.groupScheme_mul_left`, and
+  `TauCeti.GeneralLinear.groupScheme_inv_left`: the raw-coordinate formulas for the group
+  operations.
+* `TauCeti.GeneralLinear.isAffine_groupScheme` and
+  `TauCeti.GeneralLinear.locallyOfFiniteType_groupScheme`: affineness and local finite type over
+  the base.
+
+## References
+
+* J. S. Milne, *Basic Theory of Affine Group Schemes*, Chapter IV, section 1.8.
+* The Stacks Project, Tags
+  [022W](https://stacks.math.columbia.edu/tag/022W) and
+  [00CM](https://stacks.math.columbia.edu/tag/00CM).
+-/
+
+public section
+
+open CategoryTheory
+open scoped TensorProduct
+
+namespace TauCeti
+
+universe u
+
+namespace GeneralLinear
+
+open AlgebraicGeometry MonObj MonoidalCategory
+
+variable (R : Type u) [CommRing R] (n : ℕ)
+
+/-- The general linear group scheme obtained by applying relative spectrum to its coordinate
+Hopf algebra.
+
+The same-universe restriction is imposed by Mathlib's current `hopfSpec` construction. -/
+noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
+  (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+    (Opposite.op (coordinateHopfAlgebra R n))
+
+private lemma groupScheme_X_left_bundled :
+    (groupScheme R n).X.left =
+      Spec (CommRingCat.of (coordinateHopfAlgebra R n)) := by
+  unfold groupScheme
+  rfl
+
+/-- The scheme underlying the general linear group scheme is canonically isomorphic to the
+spectrum of the determinant localization. -/
+noncomputable def groupSchemeSpecIso :
+    (groupScheme R n).X.left ≅ Spec (CommRingCat.of (CoordinateRing R n)) :=
+  eqToIso (groupScheme_X_left_bundled R n) ≪≫
+    Scheme.Spec.mapIso
+      (coordinateHopfAlgebraAlgEquiv R n).toRingEquiv.toCommRingCatIso.op
+
+private lemma groupScheme_X_hom_bundled :
+    (groupScheme R n).X.hom =
+      eqToHom (groupScheme_X_left_bundled R n) ≫
+        Spec.map (CommRingCat.ofHom
+          (algebraMap R (coordinateHopfAlgebra R n))) := by
+  simpa only [eqToHom_refl, Category.comp_id] using
+    (conj_eqToHom_iff_heq
+      (groupScheme R n).X.hom
+      (Spec.map (CommRingCat.ofHom
+        (algebraMap R (coordinateHopfAlgebra R n))))
+      (groupScheme_X_left_bundled R n) rfl).2 (by
+        unfold groupScheme
+        exact heq_of_eq (AlgebraicGeometry.algSpec_obj_hom
+          (R := CommRingCat.of R)
+          (Opposite.op (CommAlgCat.of R (coordinateHopfAlgebra R n)))))
+
+/-- The structural morphism of the general linear group scheme is induced by the algebra
+structure map on the determinant localization. -/
+@[simp]
+lemma groupScheme_X_hom :
+    (groupScheme R n).X.hom =
+      (groupSchemeSpecIso R n).hom ≫
+        Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n))) := by
+  calc
+    (groupScheme R n).X.hom =
+        eqToHom (groupScheme_X_left_bundled R n) ≫
+          Spec.map (CommRingCat.ofHom
+            (algebraMap R (coordinateHopfAlgebra R n))) :=
+      groupScheme_X_hom_bundled R n
+    _ = (groupSchemeSpecIso R n).hom ≫
+          Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n))) := by
+      simp only [groupSchemeSpecIso, Iso.trans_hom, eqToIso.hom,
+        Functor.mapIso_hom, Iso.op_hom, Scheme.Spec_map, Quiver.Hom.unop_op,
+        Category.assoc, ← Spec.map_comp]
+      congr 2
+      ext r
+      exact (coordinateHopfAlgebraAlgEquiv R n).commutes r |>.symm
+
+private noncomputable def coordinateTensorAlgEquiv :
+    CoordinateRing R n ⊗[R] CoordinateRing R n ≃ₐ[R]
+      coordinateHopfAlgebra R n ⊗[R] coordinateHopfAlgebra R n :=
+  Algebra.TensorProduct.congr
+    (coordinateHopfAlgebraAlgEquiv R n) (coordinateHopfAlgebraAlgEquiv R n)
+
+private lemma groupScheme_tensor_X_left_bundled :
+    ((groupScheme R n).X ⊗ (groupScheme R n).X).left =
+      Limits.pullback
+        (Spec.map (CommRingCat.ofHom
+          (algebraMap R (coordinateHopfAlgebra R n))))
+        (Spec.map (CommRingCat.ofHom
+          (algebraMap R (coordinateHopfAlgebra R n)))) := by
+  rw [Over.tensorObj_left]
+  have h : (groupScheme R n).X.hom ≍
+      Spec.map (CommRingCat.ofHom
+        (algebraMap R (coordinateHopfAlgebra R n))) := by
+    rw [groupScheme_X_hom_bundled]
+    exact eqToHom_comp_heq _ _
+  cases groupScheme_X_left_bundled R n
+  exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
+
+/-- The multiplication source is canonically the spectrum of the tensor square of the raw
+determinant-localization coordinate ring. This combines the fibre-product presentation of the
+product over `Spec R`, the standard affine pullback isomorphism, and the coordinate equivalence on
+both tensor factors. -/
+noncomputable def groupSchemeMulSourceIso :
+    ((groupScheme R n).X ⊗ (groupScheme R n).X).left ≅
+      Spec (CommRingCat.of (CoordinateRing R n ⊗[R] CoordinateRing R n)) :=
+  eqToIso (groupScheme_tensor_X_left_bundled R n) ≪≫
+    pullbackSpecIso R (coordinateHopfAlgebra R n) (coordinateHopfAlgebra R n) ≪≫
+    Scheme.Spec.mapIso (coordinateTensorAlgEquiv R n).toRingEquiv.toCommRingCatIso.op
+
+private lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
+    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
+      (CommAlgCat.ofHom f).op).left =
+        Spec.map (CommRingCat.ofHom f.toRingHom) := by
+  rw [AlgebraicGeometry.algSpec_map_left]
+  rfl
+
+private lemma groupScheme_eq_asOver :
+    groupScheme R n =
+      Grp.mk ((Spec (CommRingCat.of (coordinateHopfAlgebra R n))).asOver
+        (Spec (CommRingCat.of R))) :=
+  rfl
+
+private lemma groupScheme_one_left_bundled :
+    η[(groupScheme R n).X].left =
+      Spec.map (CommRingCat.ofHom
+        (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n))) ≫
+      eqToHom (groupScheme_X_left_bundled R n).symm := by
+  simpa only [eqToHom_refl, Category.id_comp] using
+    (conj_eqToHom_iff_heq
+      η[(groupScheme R n).X].left
+      (Spec.map (CommRingCat.ofHom
+        (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n))))
+      rfl (groupScheme_X_left_bundled R n)).2 (by
+        rw [groupScheme_eq_asOver]
+        exact heq_of_eq (AlgebraicGeometry.one_spec_asOver_spec_left
+          (R := CommRingCat.of R)
+          (A := CommRingCat.of (coordinateHopfAlgebra R n))))
+
+private lemma groupScheme_mul_left_bundled :
+    μ[(groupScheme R n).X].left =
+      eqToHom (groupScheme_tensor_X_left_bundled R n) ≫
+        (pullbackSpecIso R (coordinateHopfAlgebra R n)
+          (coordinateHopfAlgebra R n)).hom ≫
+        Spec.map (CommRingCat.ofHom
+          (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n))) ≫
+        eqToHom (groupScheme_X_left_bundled R n).symm := by
+  simpa only [Category.assoc] using
+    (conj_eqToHom_iff_heq
+      μ[(groupScheme R n).X].left
+      ((pullbackSpecIso R (coordinateHopfAlgebra R n)
+          (coordinateHopfAlgebra R n)).hom ≫
+        Spec.map (CommRingCat.ofHom
+          (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n))))
+      (groupScheme_tensor_X_left_bundled R n)
+      (groupScheme_X_left_bundled R n)).2 (by
+        rw [groupScheme_eq_asOver]
+        exact heq_of_eq (AlgebraicGeometry.mul_spec_asOver_spec_left
+          (R := CommRingCat.of R)
+          (A := CommRingCat.of (coordinateHopfAlgebra R n))))
+
+private lemma groupScheme_inv_left_bundled :
+    ι[(groupScheme R n).X].left =
+      eqToHom (groupScheme_X_left_bundled R n) ≫
+        Spec.map (CommRingCat.ofHom
+          (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)).toRingHom) ≫
+        eqToHom (groupScheme_X_left_bundled R n).symm := by
+  apply (conj_eqToHom_iff_heq _ _
+    (groupScheme_X_left_bundled R n) (groupScheme_X_left_bundled R n)).2
+  rw [groupScheme_eq_asOver]
+  exact heq_of_eq (algSpec_map_left_ofAlgHom R
+    (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)))
+
+/-- The unit of the general linear group scheme is induced by the raw coordinate counit. -/
+@[simp]
+lemma groupScheme_one_left :
+    η[(groupScheme R n).X].left =
+      Spec.map (CommRingCat.ofHom (counit R n).toRingHom) ≫
+        (groupSchemeSpecIso R n).inv := by
+  rw [groupScheme_one_left_bundled, groupSchemeSpecIso]
+  simp only [Iso.trans_inv, eqToIso.inv,
+    Functor.mapIso_inv, Iso.op_inv, Scheme.Spec_map, Quiver.Hom.unop_op,
+    RingEquiv.toCommRingCatIso_inv]
+  rw [← Category.assoc]
+  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  rw [← Spec.map_comp]
+  rw [Spec.map_inj]
+  ext x
+  change Coalgebra.counit (R := R) (A := coordinateHopfAlgebra R n) x =
+    counit R n ((coordinateHopfAlgebraAlgEquiv R n).symm x)
+  simpa only [AlgEquiv.apply_symm_apply] using
+      (coordinateHopfAlgebra_counit_apply R n
+        ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
+/-- Multiplication on the general linear group scheme is induced by the raw matrix-multiplication
+comultiplication. The source presentation fixes the tensor-factor order representing ordinary
+matrix multiplication. -/
+@[simp]
+lemma groupScheme_mul_left :
+    μ[(groupScheme R n).X].left =
+      (groupSchemeMulSourceIso R n).hom ≫
+        Spec.map (CommRingCat.ofHom (comul R n).toRingHom) ≫
+        (groupSchemeSpecIso R n).inv := by
+  rw [groupScheme_mul_left_bundled, groupSchemeMulSourceIso, groupSchemeSpecIso]
+  simp only [Iso.trans_hom, eqToIso.hom, Functor.mapIso_hom, Iso.op_hom,
+    Scheme.Spec_map, Quiver.Hom.unop_op, RingEquiv.toCommRingCatIso_hom,
+    Iso.trans_inv, eqToIso.inv, Functor.mapIso_inv, Iso.op_inv,
+    RingEquiv.toCommRingCatIso_inv, Category.assoc]
+  apply (cancel_epi (eqToHom (groupScheme_tensor_X_left_bundled R n))).2
+  apply (cancel_epi
+    (pullbackSpecIso R (coordinateHopfAlgebra R n)
+      (coordinateHopfAlgebra R n)).hom).2
+  simp only [← Category.assoc]
+  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  rw [← Spec.map_comp, ← Spec.map_comp]
+  rw [Spec.map_inj]
+  ext x
+  change Coalgebra.comul (R := R) (A := coordinateHopfAlgebra R n) x =
+    coordinateTensorAlgEquiv R n
+      (comul R n ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+  simpa only [AlgEquiv.apply_symm_apply, coordinateTensorAlgEquiv,
+    Algebra.TensorProduct.congr_apply] using
+      (coordinateHopfAlgebra_comul_apply R n
+        ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
+/-- Inversion on the general linear group scheme is induced by the raw inverse-matrix antipode. -/
+@[simp]
+lemma groupScheme_inv_left :
+    ι[(groupScheme R n).X].left =
+      (groupSchemeSpecIso R n).hom ≫
+        Spec.map (CommRingCat.ofHom (antipode R n).toRingHom) ≫
+        (groupSchemeSpecIso R n).inv := by
+  rw [groupScheme_inv_left_bundled, groupSchemeSpecIso]
+  simp only [Iso.trans_hom, eqToIso.hom, Functor.mapIso_hom, Iso.op_hom,
+    Scheme.Spec_map, Quiver.Hom.unop_op, RingEquiv.toCommRingCatIso_hom,
+    Iso.trans_inv, eqToIso.inv, Functor.mapIso_inv, Iso.op_inv,
+    RingEquiv.toCommRingCatIso_inv, Category.assoc]
+  apply (cancel_epi (eqToHom (groupScheme_X_left_bundled R n))).2
+  simp only [← Category.assoc]
+  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  rw [← Spec.map_comp, ← Spec.map_comp]
+  rw [Spec.map_inj]
+  ext x
+  change HopfAlgebra.antipode R x =
+    coordinateHopfAlgebraAlgEquiv R n
+      (antipode R n ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+  simpa only [AlgEquiv.apply_symm_apply] using
+    (coordinateHopfAlgebra_antipode_apply R n
+      ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
+/-- The general linear group scheme is affine. -/
+instance isAffine_groupScheme : IsAffine (groupScheme R n).X.left := by
+  exact .of_isIso (groupSchemeSpecIso R n).hom
+
+/-- The structural morphism of the general linear group scheme is locally of finite type. -/
+instance locallyOfFiniteType_groupScheme :
+    LocallyOfFiniteType (groupScheme R n).X.hom := by
+  rw [groupScheme_X_hom]
+  letI : LocallyOfFiniteType (groupSchemeSpecIso R n).hom :=
+    locallyOfFiniteType_of_isOpenImmersion _
+  letI : LocallyOfFiniteType
+      (Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n)))) := by
+    change LocallyOfFiniteType
+      (Spec (CommRingCat.of (CoordinateRing R n)) ↘ Spec (CommRingCat.of R))
+    infer_instance
+  exact locallyOfFiniteType_comp _ _
+
+end GeneralLinear
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -282,9 +282,9 @@ instance isAffine_groupScheme : IsAffine (groupScheme R n).X.left := by
 instance locallyOfFiniteType_groupScheme :
     LocallyOfFiniteType (groupScheme R n).X.hom := by
   rw [groupScheme_X_hom]
-  letI : LocallyOfFiniteType (groupSchemeSpecIso R n).hom :=
+  let : LocallyOfFiniteType (groupSchemeSpecIso R n).hom :=
     locallyOfFiniteType_of_isOpenImmersion _
-  letI : LocallyOfFiniteType
+  let : LocallyOfFiniteType
       (Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n)))) := by
     rw [← AlgebraicGeometry.specOverSpec_over]
     infer_instance

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.AlgebraicGeometry.Group.Affine
 public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.CoordinateHopfAlgebra
+public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
 # The general linear group scheme
@@ -71,11 +71,15 @@ noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
     (Opposite.op (coordinateHopfAlgebra R n))
 
+-- The generic `hopfSpec_obj_*` lemmas are stated for the literal functor object, while the
+-- equality proofs occurring in `eqToHom` below have the opaque wrapper `groupScheme` as source.
+-- These private specializations unfold the wrapper once and use `convert` only to rebind those
+-- proof-dependent morphism types; all spectrum and group-operation computations stay generic.
 private lemma groupScheme_X_left_bundled :
     (groupScheme R n).X.left =
       Spec (CommRingCat.of (coordinateHopfAlgebra R n)) := by
-  unfold groupScheme
-  rfl
+  simpa only [groupScheme] using
+    hopfSpec_obj_X_left R (coordinateHopfAlgebra R n)
 
 /-- The scheme underlying the general linear group scheme is canonically isomorphic to the
 spectrum of the determinant localization. -/
@@ -90,16 +94,8 @@ private lemma groupScheme_X_hom_bundled :
       eqToHom (groupScheme_X_left_bundled R n) ≫
         Spec.map (CommRingCat.ofHom
           (algebraMap R (coordinateHopfAlgebra R n))) := by
-  simpa only [eqToHom_refl, Category.comp_id] using
-    (conj_eqToHom_iff_heq
-      (groupScheme R n).X.hom
-      (Spec.map (CommRingCat.ofHom
-        (algebraMap R (coordinateHopfAlgebra R n))))
-      (groupScheme_X_left_bundled R n) rfl).2 (by
-        unfold groupScheme
-        exact heq_of_eq (AlgebraicGeometry.algSpec_obj_hom
-          (R := CommRingCat.of R)
-          (Opposite.op (CommAlgCat.of R (coordinateHopfAlgebra R n)))))
+  unfold groupScheme
+  convert hopfSpec_obj_X_hom R (coordinateHopfAlgebra R n) using 1
 
 /-- The structural morphism of the general linear group scheme is induced by the algebra
 structure map on the determinant localization. -/
@@ -129,6 +125,38 @@ private noncomputable def coordinateTensorAlgEquiv :
   Algebra.TensorProduct.congr
     (coordinateHopfAlgebraAlgEquiv R n) (coordinateHopfAlgebraAlgEquiv R n)
 
+-- These three equalities are the coordinate-specific boundary between the bundled Hopf
+-- operations used by `hopfSpec` and the raw determinant-localization operations exposed here.
+private lemma coordinateHopfAlgebra_counitAlgHom :
+    Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n) =
+      (counit R n).comp (coordinateHopfAlgebraAlgEquiv R n).symm := by
+  ext x
+  simpa only [Bialgebra.counitAlgHom_apply, AlgHom.comp_apply,
+    AlgEquiv.coe_toAlgHom, AlgEquiv.apply_symm_apply] using
+    (coordinateHopfAlgebra_counit_apply R n
+      ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
+private lemma coordinateHopfAlgebra_comulAlgHom :
+    Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n) =
+      (coordinateTensorAlgEquiv R n).toAlgHom.comp
+        ((comul R n).comp (coordinateHopfAlgebraAlgEquiv R n).symm) := by
+  ext x
+  simpa only [Bialgebra.comulAlgHom_apply, AlgHom.comp_apply,
+    AlgEquiv.coe_toAlgHom, AlgEquiv.apply_symm_apply, coordinateTensorAlgEquiv,
+    Algebra.TensorProduct.congr_apply] using
+      (coordinateHopfAlgebra_comul_apply R n
+        ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
+private lemma coordinateHopfAlgebra_antipodeAlgHom :
+    HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n) =
+      (coordinateHopfAlgebraAlgEquiv R n).toAlgHom.comp
+        ((antipode R n).comp (coordinateHopfAlgebraAlgEquiv R n).symm) := by
+  ext x
+  simpa only [HopfAlgebra.antipodeAlgHom_apply, AlgHom.comp_apply,
+    AlgEquiv.coe_toAlgHom, AlgEquiv.apply_symm_apply] using
+    (coordinateHopfAlgebra_antipode_apply R n
+      ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+
 private lemma groupScheme_tensor_X_left_bundled :
     ((groupScheme R n).X ⊗ (groupScheme R n).X).left =
       Limits.pullback
@@ -136,14 +164,8 @@ private lemma groupScheme_tensor_X_left_bundled :
           (algebraMap R (coordinateHopfAlgebra R n))))
         (Spec.map (CommRingCat.ofHom
           (algebraMap R (coordinateHopfAlgebra R n)))) := by
-  rw [Over.tensorObj_left]
-  have h : (groupScheme R n).X.hom ≍
-      Spec.map (CommRingCat.ofHom
-        (algebraMap R (coordinateHopfAlgebra R n))) := by
-    rw [groupScheme_X_hom_bundled]
-    exact eqToHom_comp_heq _ _
-  cases groupScheme_X_left_bundled R n
-  exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
+  unfold groupScheme
+  convert hopfSpec_obj_tensor_X_left R (coordinateHopfAlgebra R n) using 1
 
 /-- The multiplication source is canonically the spectrum of the tensor square of the raw
 determinant-localization coordinate ring. This combines the fibre-product presentation of the
@@ -156,35 +178,13 @@ noncomputable def groupSchemeMulSourceIso :
     pullbackSpecIso R (coordinateHopfAlgebra R n) (coordinateHopfAlgebra R n) ≪≫
     Scheme.Spec.mapIso (coordinateTensorAlgEquiv R n).toRingEquiv.toCommRingCatIso.op
 
-private lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
-    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
-    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
-      (CommAlgCat.ofHom f).op).left =
-        Spec.map (CommRingCat.ofHom f.toRingHom) := by
-  rw [AlgebraicGeometry.algSpec_map_left]
-  rfl
-
-private lemma groupScheme_eq_asOver :
-    groupScheme R n =
-      Grp.mk ((Spec (CommRingCat.of (coordinateHopfAlgebra R n))).asOver
-        (Spec (CommRingCat.of R))) :=
-  rfl
-
 private lemma groupScheme_one_left_bundled :
     η[(groupScheme R n).X].left =
       Spec.map (CommRingCat.ofHom
         (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n))) ≫
       eqToHom (groupScheme_X_left_bundled R n).symm := by
-  simpa only [eqToHom_refl, Category.id_comp] using
-    (conj_eqToHom_iff_heq
-      η[(groupScheme R n).X].left
-      (Spec.map (CommRingCat.ofHom
-        (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n))))
-      rfl (groupScheme_X_left_bundled R n)).2 (by
-        rw [groupScheme_eq_asOver]
-        exact heq_of_eq (AlgebraicGeometry.one_spec_asOver_spec_left
-          (R := CommRingCat.of R)
-          (A := CommRingCat.of (coordinateHopfAlgebra R n))))
+  unfold groupScheme
+  convert hopfSpec_obj_one_left R (coordinateHopfAlgebra R n) using 1
 
 private lemma groupScheme_mul_left_bundled :
     μ[(groupScheme R n).X].left =
@@ -194,19 +194,8 @@ private lemma groupScheme_mul_left_bundled :
         Spec.map (CommRingCat.ofHom
           (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n))) ≫
         eqToHom (groupScheme_X_left_bundled R n).symm := by
-  simpa only [Category.assoc] using
-    (conj_eqToHom_iff_heq
-      μ[(groupScheme R n).X].left
-      ((pullbackSpecIso R (coordinateHopfAlgebra R n)
-          (coordinateHopfAlgebra R n)).hom ≫
-        Spec.map (CommRingCat.ofHom
-          (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n))))
-      (groupScheme_tensor_X_left_bundled R n)
-      (groupScheme_X_left_bundled R n)).2 (by
-        rw [groupScheme_eq_asOver]
-        exact heq_of_eq (AlgebraicGeometry.mul_spec_asOver_spec_left
-          (R := CommRingCat.of R)
-          (A := CommRingCat.of (coordinateHopfAlgebra R n))))
+  unfold groupScheme
+  convert hopfSpec_obj_mul_left R (coordinateHopfAlgebra R n) using 1
 
 private lemma groupScheme_inv_left_bundled :
     ι[(groupScheme R n).X].left =
@@ -214,11 +203,8 @@ private lemma groupScheme_inv_left_bundled :
         Spec.map (CommRingCat.ofHom
           (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)).toRingHom) ≫
         eqToHom (groupScheme_X_left_bundled R n).symm := by
-  apply (conj_eqToHom_iff_heq _ _
-    (groupScheme_X_left_bundled R n) (groupScheme_X_left_bundled R n)).2
-  rw [groupScheme_eq_asOver]
-  exact heq_of_eq (algSpec_map_left_ofAlgHom R
-    (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)))
+  unfold groupScheme
+  convert hopfSpec_obj_inv_left R (coordinateHopfAlgebra R n) using 1
 
 /-- The unit of the general linear group scheme is induced by the raw coordinate counit. -/
 @[simp]
@@ -234,12 +220,9 @@ lemma groupScheme_one_left :
   apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
   rw [← Spec.map_comp]
   rw [Spec.map_inj]
-  ext x
-  change Coalgebra.counit (R := R) (A := coordinateHopfAlgebra R n) x =
-    counit R n ((coordinateHopfAlgebraAlgEquiv R n).symm x)
-  simpa only [AlgEquiv.apply_symm_apply] using
-      (coordinateHopfAlgebra_counit_apply R n
-        ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+  rw [← CommRingCat.ofHom_comp]
+  exact congrArg (fun f : coordinateHopfAlgebra R n →ₐ[R] R ↦
+    CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_counitAlgHom R n)
 
 /-- Multiplication on the general linear group scheme is induced by the raw matrix-multiplication
 comultiplication. The source presentation fixes the tensor-factor order representing ordinary
@@ -263,14 +246,11 @@ lemma groupScheme_mul_left :
   apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
   rw [← Spec.map_comp, ← Spec.map_comp]
   rw [Spec.map_inj]
-  ext x
-  change Coalgebra.comul (R := R) (A := coordinateHopfAlgebra R n) x =
-    coordinateTensorAlgEquiv R n
-      (comul R n ((coordinateHopfAlgebraAlgEquiv R n).symm x))
-  simpa only [AlgEquiv.apply_symm_apply, coordinateTensorAlgEquiv,
-    Algebra.TensorProduct.congr_apply] using
-      (coordinateHopfAlgebra_comul_apply R n
-        ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+  rw [← CommRingCat.ofHom_comp, ← CommRingCat.ofHom_comp]
+  exact congrArg
+    (fun f : coordinateHopfAlgebra R n →ₐ[R]
+      coordinateHopfAlgebra R n ⊗[R] coordinateHopfAlgebra R n ↦
+        CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_comulAlgHom R n)
 
 /-- Inversion on the general linear group scheme is induced by the raw inverse-matrix antipode. -/
 @[simp]
@@ -289,13 +269,10 @@ lemma groupScheme_inv_left :
   apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
   rw [← Spec.map_comp, ← Spec.map_comp]
   rw [Spec.map_inj]
-  ext x
-  change HopfAlgebra.antipode R x =
-    coordinateHopfAlgebraAlgEquiv R n
-      (antipode R n ((coordinateHopfAlgebraAlgEquiv R n).symm x))
-  simpa only [AlgEquiv.apply_symm_apply] using
-    (coordinateHopfAlgebra_antipode_apply R n
-      ((coordinateHopfAlgebraAlgEquiv R n).symm x))
+  rw [← CommRingCat.ofHom_comp, ← CommRingCat.ofHom_comp]
+  exact congrArg
+    (fun f : coordinateHopfAlgebra R n →ₐ[R] coordinateHopfAlgebra R n ↦
+      CommRingCat.ofHom f.toRingHom) (coordinateHopfAlgebra_antipodeAlgHom R n)
 
 /-- The general linear group scheme is affine. -/
 instance isAffine_groupScheme : IsAffine (groupScheme R n).X.left := by
@@ -309,8 +286,7 @@ instance locallyOfFiniteType_groupScheme :
     locallyOfFiniteType_of_isOpenImmersion _
   letI : LocallyOfFiniteType
       (Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n)))) := by
-    change LocallyOfFiniteType
-      (Spec (CommRingCat.of (CoordinateRing R n)) ↘ Spec (CommRingCat.of R))
+    rw [← AlgebraicGeometry.specOverSpec_over]
     infer_instance
   exact locallyOfFiniteType_comp _ _
 

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -1,0 +1,161 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Group.Affine
+
+/-!
+# Projections of Hopf spectra
+
+This file computes the underlying scheme maps of Mathlib's `AlgebraicGeometry.hopfSpec` on an
+arbitrary same-universe commutative Hopf algebra.  It identifies the underlying scheme with the
+ordinary spectrum, the structural morphism with the algebra structure map, the multiplication
+source with the standard affine fibre product, and the group operations with the counit,
+comultiplication, and antipode.
+
+These lemmas provide the common projection boundary used by concrete affine group schemes.  The
+same-universe restriction is inherited from Mathlib's current `hopfSpec` construction.
+
+## Main declarations
+
+* `TauCeti.hopfSpec_obj_X_left`: the underlying scheme of a Hopf spectrum.
+* `TauCeti.hopfSpec_obj_X_hom`: its structural morphism.
+* `TauCeti.hopfSpec_obj_tensor_X_left`: the source of its multiplication.
+* `TauCeti.algSpec_map_left_ofAlgHom`: the underlying spectrum map of an algebra morphism.
+* `TauCeti.hopfSpec_obj_one_left`, `TauCeti.hopfSpec_obj_mul_left`, and
+  `TauCeti.hopfSpec_obj_inv_left`: its three group operations.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+open AlgebraicGeometry MonObj MonoidalCategory
+
+universe u
+
+variable (R : Type u) [CommRing R]
+
+/-- The scheme underlying the Hopf spectrum of `H` is its ordinary spectrum. -/
+lemma hopfSpec_obj_X_left (H : CommHopfAlgCat.{u} R) :
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X.left = Spec (CommRingCat.of H) :=
+  rfl
+
+/-- The structural morphism of a Hopf spectrum is induced by its algebra structure map. -/
+lemma hopfSpec_obj_X_hom (H : CommHopfAlgCat.{u} R) :
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X.hom =
+        eqToHom (hopfSpec_obj_X_left R H) ≫
+          Spec.map (CommRingCat.ofHom (algebraMap R H)) := by
+  simpa only [eqToHom_refl, Category.comp_id] using
+    (conj_eqToHom_iff_heq
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+        (Opposite.op H)).X.hom
+      (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+      (hopfSpec_obj_X_left R H) rfl).2 (by
+        exact heq_of_eq (AlgebraicGeometry.algSpec_obj_hom
+          (R := CommRingCat.of R) (Opposite.op (CommAlgCat.of R H))))
+
+/-- The multiplication source of a Hopf spectrum is the standard affine fibre product of two
+copies of its underlying spectrum over the base. -/
+@[simp↓]
+lemma hopfSpec_obj_tensor_X_left (H : CommHopfAlgCat.{u} R) :
+    ((((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X ⊗
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+          (Opposite.op H)).X).left) =
+      Limits.pullback
+        (Spec.map (CommRingCat.ofHom (algebraMap R H)))
+        (Spec.map (CommRingCat.ofHom (algebraMap R H))) := by
+  rw [Over.tensorObj_left]
+  have h : ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X.hom ≍
+        Spec.map (CommRingCat.ofHom (algebraMap R H)) := by
+    rw [hopfSpec_obj_X_hom]
+    exact eqToHom_comp_heq _ _
+  cases hopfSpec_obj_X_left R H
+  exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
+
+/-- Specialize Mathlib's `algSpec_map_left` computation to an explicit algebra morphism.
+
+This is the sole boundary where the `CommAlgCat`/under-category wrapper left in that public
+computation lemma is reduced: `algSpec_map_left` phrases its answer through
+`(commAlgCatEquivUnder R).functor.map`, and Mathlib provides no computation lemma for the
+`Under.Hom.right` of that morphism, so the last step is definitional. -/
+lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
+    [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
+    ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map
+      (CommAlgCat.ofHom f).op).left =
+        Spec.map (CommRingCat.ofHom f.toRingHom) := by
+  rw [AlgebraicGeometry.algSpec_map_left]
+  rfl
+
+/-- Mathlib's `hopfSpec` object is definitionally the group object on the ordinary spectrum.
+
+This private lemma localizes the identification between the two instance paths.  Mathlib's
+operation computation lemmas are stated for `(Spec H).asOver (Spec R)`, while `hopfSpec` reaches
+that group object through the Hopf-algebra/cogroup equivalence. -/
+private lemma hopfSpec_obj_eq_asOver (H : CommHopfAlgCat.{u} R) :
+    (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H) =
+      Grp.mk ((Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :=
+  rfl
+
+/-- The unit of a Hopf spectrum is induced by the counit of its coordinate Hopf algebra. -/
+@[simp]
+lemma hopfSpec_obj_one_left (H : CommHopfAlgCat.{u} R) :
+    η[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X].left =
+      Spec.map (CommRingCat.ofHom (Bialgebra.counitAlgHom R H)) ≫
+        eqToHom (hopfSpec_obj_X_left R H).symm := by
+  simpa only [eqToHom_refl, Category.id_comp] using
+    (conj_eqToHom_iff_heq
+      η[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+        (Opposite.op H)).X].left
+      (Spec.map (CommRingCat.ofHom (Bialgebra.counitAlgHom R H)))
+      rfl (hopfSpec_obj_X_left R H)).2 (by
+        rw [hopfSpec_obj_eq_asOver]
+        exact heq_of_eq (AlgebraicGeometry.one_spec_asOver_spec_left
+          (R := CommRingCat.of R) (A := CommRingCat.of H)))
+
+/-- Multiplication on a Hopf spectrum is induced by the comultiplication of its coordinate Hopf
+algebra. -/
+@[simp]
+lemma hopfSpec_obj_mul_left (H : CommHopfAlgCat.{u} R) :
+    μ[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X].left =
+      eqToHom (hopfSpec_obj_tensor_X_left R H) ≫
+        (pullbackSpecIso R H H).hom ≫
+        Spec.map (CommRingCat.ofHom (Bialgebra.comulAlgHom R H)) ≫
+        eqToHom (hopfSpec_obj_X_left R H).symm := by
+  simpa only [Category.assoc] using
+    (conj_eqToHom_iff_heq
+      μ[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+        (Opposite.op H)).X].left
+      ((pullbackSpecIso R H H).hom ≫
+        Spec.map (CommRingCat.ofHom (Bialgebra.comulAlgHom R H)))
+      (hopfSpec_obj_tensor_X_left R H) (hopfSpec_obj_X_left R H)).2 (by
+        rw [hopfSpec_obj_eq_asOver]
+        exact heq_of_eq (AlgebraicGeometry.mul_spec_asOver_spec_left
+          (R := CommRingCat.of R) (A := CommRingCat.of H)))
+
+/-- Inversion on a Hopf spectrum is induced by the antipode of its coordinate Hopf algebra. -/
+@[simp]
+lemma hopfSpec_obj_inv_left (H : CommHopfAlgCat.{u} R) :
+    ι[((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+      (Opposite.op H)).X].left =
+      eqToHom (hopfSpec_obj_X_left R H) ≫
+        Spec.map (CommRingCat.ofHom
+          (HopfAlgebra.antipodeAlgHom R H).toRingHom) ≫
+        eqToHom (hopfSpec_obj_X_left R H).symm := by
+  apply (conj_eqToHom_iff_heq _ _
+    (hopfSpec_obj_X_left R H) (hopfSpec_obj_X_left R H)).2
+  rw [hopfSpec_obj_eq_asOver]
+  exact heq_of_eq (algSpec_map_left_ofAlgHom R
+    (HopfAlgebra.antipodeAlgHom R H))
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -84,7 +84,11 @@ lemma hopfSpec_obj_tensor_X_left (H : CommHopfAlgCat.{u} R) :
   exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
 
 /-- Applying `algSpec` to an algebra homomorphism has underlying scheme map `Spec.map` of its
-underlying ring homomorphism. -/
+underlying ring homomorphism.
+
+Mathlib's `algSpec_map_left` leaves this map expressed through the `CommAlgCat`/under-category
+equivalence, and no public computation lemma exposes the resulting `Under.Hom.right`. The final
+reduction is therefore definitional and is localized here. -/
 @[simp↓]
 lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
     [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :

--- a/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
+++ b/TauCeti/AlgebraicGeometry/AffineGroupScheme/HopfSpec.lean
@@ -41,12 +41,14 @@ universe u
 variable (R : Type u) [CommRing R]
 
 /-- The scheme underlying the Hopf spectrum of `H` is its ordinary spectrum. -/
+@[simp↓]
 lemma hopfSpec_obj_X_left (H : CommHopfAlgCat.{u} R) :
     ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
       (Opposite.op H)).X.left = Spec (CommRingCat.of H) :=
   rfl
 
 /-- The structural morphism of a Hopf spectrum is induced by its algebra structure map. -/
+@[simp↓]
 lemma hopfSpec_obj_X_hom (H : CommHopfAlgCat.{u} R) :
     ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
       (Opposite.op H)).X.hom =
@@ -81,12 +83,9 @@ lemma hopfSpec_obj_tensor_X_left (H : CommHopfAlgCat.{u} R) :
   cases hopfSpec_obj_X_left R H
   exact congrArg (fun k ↦ Limits.pullback k k) (eq_of_heq h)
 
-/-- Specialize Mathlib's `algSpec_map_left` computation to an explicit algebra morphism.
-
-This is the sole boundary where the `CommAlgCat`/under-category wrapper left in that public
-computation lemma is reduced: `algSpec_map_left` phrases its answer through
-`(commAlgCatEquivUnder R).functor.map`, and Mathlib provides no computation lemma for the
-`Under.Hom.right` of that morphism, so the last step is definitional. -/
+/-- Applying `algSpec` to an algebra homomorphism has underlying scheme map `Spec.map` of its
+underlying ring homomorphism. -/
+@[simp↓]
 lemma algSpec_map_left_ofAlgHom {A B : Type u} [CommRing A] [CommRing B]
     [Algebra R A] [Algebra R B] (f : A →ₐ[R] B) :
     ((AlgebraicGeometry.algSpec (CommRingCat.of R)).map


### PR DESCRIPTION
This PR packages the general linear coordinate Hopf algebra as an affine group scheme and presents its structural, unit, multiplication, and inversion maps in determinant-localization coordinates. It also exposes the tensor-product multiplication source and the affine and locally-finite-type instances, including rank zero and the zero ring.

It advances TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md, the Worked examples construction of GLₙ and Layer 0 synchronization of the Hopf-algebra and affine-group-scheme views.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-group-scheme"}-->

🤖 Prepared with Codex