### PR TITLE
feat: package the diagonalizable group-scheme equivalence

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
@@ -1,0 +1,154 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.EssentialImage
+public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme
+
+import Mathlib.CategoryTheory.MorphismProperty.Limits
+
+/-!
+# The anti-equivalence for diagonalizable group schemes
+
+Over a field `k`, a group scheme over `Spec k` is diagonalizable when it is isomorphic to the
+spectrum of a finite-type commutative Hopf algebra whose group-like elements span its carrier.
+This file identifies that property with the essential image of
+`DiagonalizableGroup.schemeFunctor` and packages the resulting anti-equivalence from finitely
+generated commutative groups.
+
+The equivalence is contravariant: its source is `FGCommGrpCatᵒᵖ`. Its forward functor recovers
+`DiagonalizableGroup.schemeFunctor` after inclusion into all group schemes. Bundled
+diagonalizable group schemes automatically expose affineness and local finite type over `Spec k`.
+
+All categories and carriers lie in the universe of `k`, as required by the current
+`AlgebraicGeometry.hopfSpec` construction.
+
+## Main declarations
+
+* `TauCeti.DiagonalizableGroup.diagonalizableGroupSchemeProperty`: the coordinate-side object
+  property on group schemes over `Spec k`.
+* `TauCeti.DiagonalizableGroup.essImage_schemeFunctor`: this property is the essential image of
+  the diagonalizable group-scheme functor.
+* `TauCeti.DiagonalizableGroup.DiagonalizableGroupSchemeCat`: the corresponding full
+  subcategory.
+* `TauCeti.DiagonalizableGroup.schemeEquivalence`: the anti-equivalence from finitely generated
+  commutative groups.
+* `TauCeti.DiagonalizableGroup.schemeEquivalence.functorCompιIso`: the forward functor recovers
+  `schemeFunctor` after inclusion.
+
+## References
+
+See Milne, *Algebraic Groups*, Definition 12.7 and Theorems 12.8--12.9.
+-/
+
+public section
+
+open CategoryTheory
+
+namespace TauCeti
+
+universe u
+
+namespace DiagonalizableGroup
+
+open AlgebraicGeometry Opposite
+
+variable (k : Type u) [Field k]
+
+/-- The property of group schemes over `Spec k` that are spectra of finite-type commutative Hopf
+algebras spanned by their group-like elements. -/
+def diagonalizableGroupSchemeProperty :
+    ObjectProperty (Grp (Over (Spec (CommRingCat.of k)))) :=
+  (groupLikeSpannedProperty k).op.map
+    ((finiteTypeCommHopfAlgProperty k).ι.op ⋙
+      AlgebraicGeometry.hopfSpec (CommRingCat.of k))
+
+/-- A group scheme over `Spec k` is diagonalizable exactly when it is isomorphic to the spectrum
+of a finite-type commutative Hopf algebra spanned by its group-like elements. -/
+@[simp]
+theorem diagonalizableGroupSchemeProperty_iff
+    (G : Grp (Over (Spec (CommRingCat.of k)))) :
+    diagonalizableGroupSchemeProperty k G ↔
+      ∃ H : FiniteTypeCommHopfAlgCat.{u, u} k,
+        groupLikeSpannedProperty k H ∧
+          Nonempty
+            ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).obj (op H.obj) ≅ G) := by
+  constructor
+  · rintro ⟨H, hH, e⟩
+    exact ⟨H.unop, hH, e⟩
+  · rintro ⟨H, hH, e⟩
+    exact ⟨op H, hH, e⟩
+
+/-- The diagonalizable group schemes are precisely the essential image of the existing
+contravariant diagonalizable group-scheme functor. -/
+theorem essImage_schemeFunctor :
+    (schemeFunctor k).essImage = diagonalizableGroupSchemeProperty k := by
+  ext G
+  constructor
+  · rintro ⟨M, ⟨e⟩⟩
+    rw [diagonalizableGroupSchemeProperty_iff]
+    refine ⟨(coordinateRingFunctor k).obj M.unop, ?_, ?_⟩
+    · rw [← essImage_coordinateRingFunctor k]
+      exact (coordinateRingFunctor k).obj_mem_essImage M.unop
+    · exact ⟨(schemeFunctorIsoHopfSpec k).symm.app M ≪≫ e⟩
+  · rw [diagonalizableGroupSchemeProperty_iff]
+    rintro ⟨H, hH, ⟨e⟩⟩
+    rw [← essImage_coordinateRingFunctor k] at hH
+    obtain ⟨M, ⟨c⟩⟩ := hH
+    refine ⟨op M, ⟨?_⟩⟩
+    exact (schemeFunctorIsoHopfSpec k).app (op M) ≪≫
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of k)).mapIso
+        (((finiteTypeCommHopfAlgProperty k).ι.mapIso c).op.symm)).trans e
+
+/-- The category of diagonalizable group schemes over `Spec k`. -/
+abbrev DiagonalizableGroupSchemeCat :=
+  (diagonalizableGroupSchemeProperty k).FullSubcategory
+
+/-- A bundled diagonalizable group scheme is affine. -/
+instance (G : DiagonalizableGroupSchemeCat k) : IsAffine G.obj.X.left := by
+  have hG : (schemeFunctor k).essImage G.obj :=
+    (essImage_schemeFunctor k).symm ▸ G.property
+  obtain ⟨M, ⟨e⟩⟩ := hG
+  apply (IsAffine.iff_of_isIso
+    ((Over.forget _).mapIso ((Grp.forget _).mapIso e)).hom).mp
+  exact isAffine_schemeFunctor_obj k M
+
+/-- The structural morphism of a bundled diagonalizable group scheme is locally of finite type. -/
+instance (G : DiagonalizableGroupSchemeCat k) : LocallyOfFiniteType G.obj.X.hom := by
+  have hG : (schemeFunctor k).essImage G.obj :=
+    (essImage_schemeFunctor k).symm ▸ G.property
+  obtain ⟨M, ⟨e⟩⟩ := hG
+  -- Local finite type is stable under base change, hence invariant under isomorphisms. Install
+  -- that consequence at the schemes' universe for the over-category transport lemma.
+  letI : MorphismProperty.RespectsIso
+      (@LocallyOfFiniteType : MorphismProperty Scheme.{u}) :=
+    MorphismProperty.IsStableUnderBaseChange.respectsIso
+  apply (MorphismProperty.over_iso_iff
+    (@LocallyOfFiniteType : MorphismProperty Scheme.{u}) ((Grp.forget _).mapIso e)).mp
+  exact locallyOfFiniteType_schemeFunctor_obj k M
+
+/-- Finitely generated commutative groups, with arrows reversed, are equivalent to
+diagonalizable group schemes over `Spec k`. -/
+noncomputable def schemeEquivalence :
+    (FGCommGrpCat.{u})ᵒᵖ ≌ DiagonalizableGroupSchemeCat k :=
+  (schemeFunctor k).toEssImage.asEquivalence.trans
+    (ObjectProperty.fullSubcategoryCongr (essImage_schemeFunctor k))
+
+/-- The forward functor of `schemeEquivalence`, followed by the inclusion into all group schemes,
+is the existing diagonalizable group-scheme functor. -/
+noncomputable def schemeEquivalence.functorCompιIso :
+    (schemeEquivalence k).functor ⋙ (diagonalizableGroupSchemeProperty k).ι ≅
+      schemeFunctor k := by
+  change ((schemeFunctor k).toEssImage ⋙
+      ObjectProperty.ιOfLE (essImage_schemeFunctor k).le) ⋙
+      (diagonalizableGroupSchemeProperty k).ι ≅ schemeFunctor k
+  exact (Functor.associator _ _ _).trans
+    ((Functor.isoWhiskerLeft (schemeFunctor k).toEssImage
+      (ObjectProperty.ιOfLECompιIso _)).trans
+        (schemeFunctor k).toEssImageCompι)
+
+end DiagonalizableGroup
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
@@ -7,8 +7,6 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.EssentialImage
 public import TauCeti.Algebra.AlgebraicGroup.DiagonalizableGroup.Scheme
 
-import Mathlib.CategoryTheory.MorphismProperty.Limits
-
 /-!
 # The anti-equivalence for diagonalizable group schemes
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
@@ -125,7 +125,7 @@ instance (G : DiagonalizableGroupSchemeCat k) : LocallyOfFiniteType G.obj.X.hom 
   obtain ⟨M, ⟨e⟩⟩ := hG
   -- Local finite type is stable under base change, hence invariant under isomorphisms. Install
   -- that consequence at the schemes' universe for the over-category transport lemma.
-  letI : MorphismProperty.RespectsIso
+  let : MorphismProperty.RespectsIso
       (@LocallyOfFiniteType : MorphismProperty Scheme.{u}) :=
     MorphismProperty.IsStableUnderBaseChange.respectsIso
   apply (MorphismProperty.over_iso_iff

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Equivalence.lean
@@ -41,6 +41,11 @@ All categories and carriers lie in the universe of `k`, as required by the curre
 ## References
 
 See Milne, *Algebraic Groups*, Definition 12.7 and Theorems 12.8--12.9.
+
+The equivalence packaging follows
+`TauCeti.AlgebraicGeometry.AffineGroupScheme.Equivalence`, specifically
+`commHopfAlgCatOpEquivAffineGroupSchemeCat` and
+`commHopfAlgCatOpEquivAffineGroupSchemeCat.functorCompιIso`.
 -/
 
 public section
@@ -136,18 +141,26 @@ noncomputable def schemeEquivalence :
   (schemeFunctor k).toEssImage.asEquivalence.trans
     (ObjectProperty.fullSubcategoryCongr (essImage_schemeFunctor k))
 
+/-- The forward functor of `schemeEquivalence` is definitionally the composite of the lift to
+the essential image and the property-change functor. This private isomorphism isolates that
+representation boundary from the public compatibility proof. -/
+private noncomputable def schemeEquivalenceFunctorIso :
+    (schemeEquivalence k).functor ≅
+      (schemeFunctor k).toEssImage ⋙
+        ObjectProperty.ιOfLE (essImage_schemeFunctor k).le :=
+  Iso.refl _
+
 /-- The forward functor of `schemeEquivalence`, followed by the inclusion into all group schemes,
 is the existing diagonalizable group-scheme functor. -/
 noncomputable def schemeEquivalence.functorCompιIso :
     (schemeEquivalence k).functor ⋙ (diagonalizableGroupSchemeProperty k).ι ≅
       schemeFunctor k := by
-  change ((schemeFunctor k).toEssImage ⋙
-      ObjectProperty.ιOfLE (essImage_schemeFunctor k).le) ⋙
-      (diagonalizableGroupSchemeProperty k).ι ≅ schemeFunctor k
-  exact (Functor.associator _ _ _).trans
-    ((Functor.isoWhiskerLeft (schemeFunctor k).toEssImage
-      (ObjectProperty.ιOfLECompιIso _)).trans
-        (schemeFunctor k).toEssImageCompι)
+  exact Functor.isoWhiskerRight (schemeEquivalenceFunctorIso k)
+      (diagonalizableGroupSchemeProperty k).ι ≪≫
+    Functor.associator _ _ _ ≪≫
+    Functor.isoWhiskerLeft (schemeFunctor k).toEssImage
+      (ObjectProperty.ιOfLECompιIso _) ≪≫
+    (schemeFunctor k).toEssImageCompι
 
 end DiagonalizableGroup
 

--- a/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/DiagonalizableGroup/Scheme.lean
@@ -42,6 +42,8 @@ ring in `Type u`.
   induced by a homomorphism of finitely generated commutative groups.
 * `TauCeti.DiagonalizableGroup.schemeFunctor`: the functor `FGCommGrpCatᵒᵖ ⟶
   Grp (Over (Spec R))`.
+* `TauCeti.DiagonalizableGroup.schemeFunctorIsoHopfSpec`: its factorization through the
+  coordinate-ring functor and relative spectrum.
 * `TauCeti.DiagonalizableGroup.isAffine_groupScheme`: `D(G)` is affine.
 * `TauCeti.DiagonalizableGroup.locallyOfFiniteType_groupScheme`: `D(G) ⟶ Spec R` is
   locally of finite type.
@@ -210,6 +212,18 @@ noncomputable def schemeFunctor :
     (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
       (_root_.CommHopfAlgCat.{u} R)).op ⋙
     AlgebraicGeometry.hopfSpec (CommRingCat.of R)
+
+/-- The diagonalizable group-scheme functor is the composite of the opposite coordinate-ring
+functor, the inclusion from finite-type to unrestricted commutative Hopf algebras, and relative
+spectrum. This is the categorical interface for factoring `schemeFunctor` without unfolding its
+implementation. -/
+noncomputable def schemeFunctorIsoHopfSpec :
+    schemeFunctor R ≅
+      (coordinateRingFunctor R).op ⋙
+        (forget₂ (FiniteTypeCommHopfAlgCat.{u, u} R)
+          (_root_.CommHopfAlgCat.{u} R)).op ⋙
+        AlgebraicGeometry.hopfSpec (CommRingCat.of R) :=
+  Iso.refl _
 
 /-- On objects, the diagonalizable group-scheme functor is `G ↦ Spec R[G]`. -/
 @[simp]


### PR DESCRIPTION
This PR packages diagonalizable affine finite-type group schemes over a field as a full subcategory and constructs the anti-equivalence from finitely generated commutative groups. It identifies the target property with the essential image of the existing scheme functor, supplies affine and locally-finite-type instances, and exposes a public compatibility isomorphism with Mathlib’s hopfSpec construction.

It advances TauCetiRoadmap/ReductiveGroups/README.md, Layer 4, “Diagonalizable groups and groups of multiplicative type,” specifically the anti-equivalence M ↦ D(M) = Spec k[M] between finitely generated abelian groups and diagonalizable groups. The construction adapts Mathlib’s hopfSpec infrastructure and categorical equivalence interfaces.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"diagonalizable-group-scheme-equivalence"}-->

🤖 Prepared with Codex