### PR TITLE
feat: the points action of a comodule

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+
+/-!
+# The points action of a comodule, by automorphisms
+
+Over a Hopf algebra the points of the corresponding affine group scheme form a group
+under convolution, so the points action of a comodule (`TauCeti.Comodule.endOfPoint`,
+`TauCeti.Comodule.pointsRepresentation`) lands in the units of the endomorphism
+monoid: the action upgrades to linear automorphisms of the scalar extension via
+`Representation.asGroupHom`, with inverses provided by the group structure rather
+than by an antipode computation.
+
+## Main declarations
+
+* `TauCeti.Comodule.pointsAction`: the action of the group of points by linear
+  automorphisms of `A ⊗[R] V`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Comodule
+
+open Coalgebra WithConv TensorProduct
+
+variable {R H V A : Type*} [CommSemiring R] [Semiring H] [HopfAlgebra R H]
+  [AddCommMonoid V] [Module R V] [Comodule R H V]
+  [CommSemiring A] [Algebra R A]
+
+variable (V) in
+/-- Over a Hopf algebra the points act by linear automorphisms of the scalar
+extension: the group of points lands in the units of the endomorphism monoid, with
+inverses provided by the group structure rather than by an antipode computation. -/
+noncomputable def pointsAction :
+    WithConv (H →ₐ[R] A) →* ((A ⊗[R] V) ≃ₗ[A] (A ⊗[R] V)) :=
+  (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).toMonoidHom.comp
+    (pointsRepresentation V).asGroupHom
+
+variable (V) in
+@[simp]
+lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
+    (pointsAction V g : A ⊗[R] V →ₗ[A] A ⊗[R] V) = endOfPoint V g.ofConv := by
+  -- `pointsAction` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change ((LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V))
+    ((pointsRepresentation V).asGroupHom g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
+  rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap,
+    Representation.asGroupHom_apply, pointsRepresentation_apply]
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -11,8 +11,9 @@ public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
 /-!
 # The points action of a comodule, by automorphisms
 
-Over a Hopf algebra the points of the corresponding affine group scheme form a group
-under convolution, so the points action of a comodule (`TauCeti.Comodule.endOfPoint`,
+Over a Hopf algebra the points form a group under convolution — the points of the
+corresponding affine group scheme, when `H` is commutative — so the points action of
+a comodule (`TauCeti.Comodule.endOfPoint`,
 `TauCeti.Comodule.pointsRepresentation`) lands in the units of the endomorphism
 monoid: the action upgrades to linear automorphisms of the scalar extension via
 `Representation.asGroupHom`, with inverses provided by the group structure rather

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
+public import TauCeti.Algebra.Coalgebra.Comodule.Basic
+public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+
+/-!
+# The points action of a comodule
+
+A right comodule `V` over a bialgebra `H` makes the `A`-points of the corresponding
+affine monoid act on the scalar extension `A ⊗[R] V`: a point `g : H →ₐ[R] A` acts by
+pushing the coaction coefficients through `g`, `A`-linearly. The two comodule axioms
+are exactly the two monoid-action laws: the counit law sends the convolution unit to
+the identity, and coassociativity sends convolution products to composites. Over a
+Hopf algebra the points form a group, so the action upgrades to linear automorphisms
+via `MonoidHom.toHomUnits` — no antipode computation is needed.
+
+This is the comodule-to-representation direction of the Layer 1 dictionary
+"representations = comodules": it realizes a comodule as an action of the functor of
+points on scalar extensions of `V`.
+
+## Main declarations
+
+* `TauCeti.Comodule.endOfPoint`: the endomorphism of `A ⊗[R] V` attached to a point.
+* `TauCeti.Comodule.pointsEndHom`: the action, as a monoid homomorphism from the
+  convolution monoid of points to the endomorphism monoid.
+* `TauCeti.Comodule.pointsAction`: over a Hopf algebra, the action by linear
+  automorphisms.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Comodule
+
+open Coalgebra WithConv TensorProduct
+
+variable {R H V A : Type*} [CommSemiring R] [Semiring H] [Bialgebra R H]
+  [AddCommMonoid V] [Module R V] [Comodule R H V]
+  [CommSemiring A] [Algebra R A]
+
+variable (V) in
+/-- The endomorphism of the scalar extension `A ⊗[R] V` attached to an `A`-point of
+the bialgebra: push the coaction coefficients through the point. -/
+noncomputable def endOfPoint (g : H →ₐ[R] A) : A ⊗[R] V →ₗ[A] A ⊗[R] V :=
+  LinearMap.liftBaseChange A
+    ((TensorProduct.comm R V A).toLinearMap ∘ₗ
+      LinearMap.lTensor V g.toLinearMap ∘ₗ coact (R := R) (C := H))
+
+variable (V) in
+@[simp]
+lemma endOfPoint_tmul (g : H →ₐ[R] A) (a : A) (v : V) :
+    endOfPoint V g (a ⊗ₜ[R] v) =
+      a • TensorProduct.comm R V A (LinearMap.lTensor V g.toLinearMap (coact v)) := by
+  simp [endOfPoint]
+
+variable (V) in
+/-- The convolution unit acts as the identity: the counit law of the comodule. -/
+lemma endOfPoint_ofConv_one :
+    endOfPoint V ((1 : WithConv (H →ₐ[R] A)).ofConv) = LinearMap.id := by
+  apply LinearMap.restrictScalars_injective R
+  refine TensorProduct.ext' fun a v => ?_
+  have hlin : ((1 : WithConv (H →ₐ[R] A)).ofConv).toLinearMap =
+      Algebra.linearMap R A ∘ₗ counit := by
+    have h := AlgHom.toLinearMap_convOne (R := R) (C := H) (A := A)
+    rw [LinearMap.convOne_def] at h
+    exact toConv_injective h
+  have hcomp : LinearMap.lTensor V ((1 : WithConv (H →ₐ[R] A)).ofConv).toLinearMap ∘ₗ
+      coact (R := R) (C := H) =
+      LinearMap.lTensor V (Algebra.linearMap R A) ∘ₗ (TensorProduct.mk R V R).flip 1 := by
+    rw [hlin, LinearMap.lTensor_comp, LinearMap.comp_assoc, lTensor_counit_comp_coact]
+  have hv := DFunLike.congr_fun hcomp v
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.flip_apply,
+    TensorProduct.mk_apply, LinearMap.lTensor_tmul, Algebra.linearMap_apply,
+    map_one] at hv
+  simp [endOfPoint_tmul, hv, TensorProduct.smul_tmul', smul_eq_mul]
+
+omit [Comodule R H V] in
+/-- The coact-free shuffle underlying `endOfPoint_ofConv_mul`: with the two coaction
+columns already peeled off, the two ways of multiplying the pushed coefficients agree,
+by commutativity of the value algebra. -/
+private lemma shuffle (g h : WithConv (H →ₐ[R] A)) :
+    (TensorProduct.lift ((Algebra.lsmul R R (A ⊗[R] V)).toLinearMap)).comp
+        ((TensorProduct.comm R (A ⊗[R] V) A).toLinearMap.comp
+          ((TensorProduct.map (TensorProduct.comm R V A).toLinearMap LinearMap.id).comp
+            ((TensorProduct.map (LinearMap.lTensor V (g.ofConv).toLinearMap)
+                LinearMap.id).comp
+              (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)))) =
+      (TensorProduct.comm R V A).toLinearMap.comp
+        ((LinearMap.lTensor V (LinearMap.mul' R A)).comp
+          ((LinearMap.lTensor V
+              (TensorProduct.map (g.ofConv).toLinearMap (h.ofConv).toLinearMap)).comp
+            (TensorProduct.assoc R V H H).toLinearMap)) := by
+  refine TensorProduct.ext (TensorProduct.ext' fun w x => LinearMap.ext fun y => ?_)
+  simp [Algebra.lsmul_coe, TensorProduct.smul_tmul', smul_eq_mul, mul_comm]
+
+/-- Restricting the endomorphism of a point along the flip is scalar collapse against
+the one-column form of the action: the pure-tensor characterization of `endOfPoint`,
+as a composite. -/
+private lemma endOfPoint_comp_comm (g : WithConv (H →ₐ[R] A)) :
+    (endOfPoint V g.ofConv).restrictScalars R ∘ₗ (TensorProduct.comm R V A).toLinearMap =
+      (TensorProduct.lift ((Algebra.lsmul R R (A ⊗[R] V)).toLinearMap)).comp
+        ((TensorProduct.comm R (A ⊗[R] V) A).toLinearMap.comp
+          (TensorProduct.map
+            ((TensorProduct.comm R V A).toLinearMap.comp
+              ((LinearMap.lTensor V (g.ofConv).toLinearMap).comp
+                (coact (R := R) (C := H))))
+            LinearMap.id)) := by
+  refine TensorProduct.ext' fun w c => ?_
+  simp [endOfPoint_tmul, Algebra.lsmul_coe]
+
+/-- Peeling the coaction column off `map (pre g) id`: the two-column form of the
+`g`-leg against an untouched `h`-coefficient leg. Pure-tensor identity; the inner
+coaction value rides through opaquely. -/
+private lemma map_comp_lTensor (g h : WithConv (H →ₐ[R] A)) :
+    TensorProduct.map
+        ((TensorProduct.comm R V A).toLinearMap.comp
+          ((LinearMap.lTensor V (g.ofConv).toLinearMap).comp (coact (R := R) (C := H))))
+        LinearMap.id ∘ₗ
+      LinearMap.lTensor V (h.ofConv).toLinearMap =
+    (TensorProduct.map (TensorProduct.comm R V A).toLinearMap LinearMap.id).comp
+        ((TensorProduct.map (LinearMap.lTensor V (g.ofConv).toLinearMap)
+            LinearMap.id).comp
+          (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)) ∘ₗ
+      (coact (R := R) (C := H) (M := V)).rTensor H := by
+  refine TensorProduct.ext' fun w x => ?_
+  simp
+
+variable (V) in
+/-- Convolution products act as composites: the coassociativity law of the comodule. -/
+lemma endOfPoint_ofConv_mul (g h : WithConv (H →ₐ[R] A)) :
+    endOfPoint V ((g * h).ofConv) = endOfPoint V g.ofConv ∘ₗ endOfPoint V h.ofConv := by
+  have hmul : ((g * h).ofConv).toLinearMap =
+      LinearMap.mul' R A ∘ₗ
+        TensorProduct.map (g.ofConv).toLinearMap (h.ofConv).toLinearMap ∘ₗ comul := by
+    have hb := AlgHom.toLinearMap_convMul g h
+    rw [LinearMap.convMul_def] at hb
+    exact toConv_injective hb
+  apply LinearMap.restrictScalars_injective R
+  refine TensorProduct.ext' fun a v => ?_
+  -- the endomorphism of the point `g`, evaluated on the flip of the `h`-column
+  have c1 := DFunLike.congr_fun (endOfPoint_comp_comm (V := V) g)
+    (LinearMap.lTensor V (h.ofConv).toLinearMap (coact (R := R) (C := H) v))
+  -- peel the coaction column off the `g`-leg
+  have c2 := DFunLike.congr_fun (map_comp_lTensor (V := V) g h) (coact (R := R) (C := H) v)
+  -- the coact-free shuffle at the doubled coaction
+  have c3 := DFunLike.congr_fun (shuffle (V := V) g h)
+    ((coact (R := R) (C := H) (M := V)).rTensor H (coact (R := R) (C := H) v))
+  -- coassociativity, valuewise
+  have c4 := DFunLike.congr_fun (coassoc (R := R) (C := H) (M := V)) v
+  -- fold the convolution product back together, valuewise at the coaction
+  have c5 := DFunLike.congr_fun
+    (congrArg (LinearMap.lTensor V) hmul) (coact (R := R) (C := H) v)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    LinearEquiv.coe_toLinearMap] at c1 c2 c3 c4 c5
+  rw [LinearMap.lTensor_comp, LinearMap.lTensor_comp] at c5
+  simp only [LinearMap.coe_comp, Function.comp_apply] at c5
+  simp only [LinearMap.restrictScalars_apply, LinearMap.coe_comp, Function.comp_apply,
+    endOfPoint_tmul, map_smul, c1, c2, c3, c4, c5]
+
+variable (V) in
+/-- The points action of a comodule, as a monoid homomorphism from the convolution
+monoid of points to the endomorphism monoid of the scalar extension. -/
+noncomputable def pointsEndHom :
+    WithConv (H →ₐ[R] A) →* Module.End A (A ⊗[R] V) where
+  toFun g := endOfPoint V g.ofConv
+  map_one' := endOfPoint_ofConv_one V
+  map_mul' g h := endOfPoint_ofConv_mul V g h
+
+variable (V) in
+@[simp]
+lemma pointsEndHom_apply (g : WithConv (H →ₐ[R] A)) :
+    pointsEndHom V g = endOfPoint V g.ofConv := by
+  -- `pointsEndHom` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change endOfPoint V g.ofConv = _
+  rfl
+
+section Hopf
+
+variable {R H V A : Type*} [CommSemiring R] [Semiring H] [HopfAlgebra R H]
+  [AddCommMonoid V] [Module R V] [Comodule R H V]
+  [CommSemiring A] [Algebra R A]
+
+variable (V) in
+/-- Over a Hopf algebra the points act by linear automorphisms of the scalar
+extension: the group of points lands in the units of the endomorphism monoid, with
+inverses provided by the group structure rather than by an antipode computation. -/
+noncomputable def pointsAction :
+    WithConv (H →ₐ[R] A) →* ((A ⊗[R] V) ≃ₗ[A] (A ⊗[R] V)) :=
+  (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).toMonoidHom.comp
+    (pointsEndHom V).toHomUnits
+
+variable (V) in
+@[simp]
+lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
+    (pointsAction V g : A ⊗[R] V →ₗ[A] A ⊗[R] V) = endOfPoint V g.ofConv := by
+  -- `pointsAction` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change ((LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V))
+    ((pointsEndHom V).toHomUnits g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
+  rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap]
+  rfl
+
+end Hopf
+
+end Comodule
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.Coalgebra.Comodule.Basic
 public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+public import Mathlib.RepresentationTheory.Basic
 
 /-!
 # The points action of a comodule
@@ -19,17 +20,22 @@ the identity, and coassociativity sends convolution products to composites. Over
 Hopf algebra the points form a group, so the action upgrades to linear automorphisms
 via `MonoidHom.toHomUnits` — no antipode computation is needed.
 
-This is the comodule-to-representation direction of the Layer 1 dictionary
-"representations = comodules": it realizes a comodule as an action of the functor of
-points on scalar extensions of `V`.
+This is the comodule-to-representation direction of the "representations = comodules"
+dictionary (ReductiveGroups roadmap, Layer 1): it realizes a comodule as an action of
+the functor of points on scalar extensions of `V`.
 
 ## Main declarations
 
 * `TauCeti.Comodule.endOfPoint`: the endomorphism of `A ⊗[R] V` attached to a point.
-* `TauCeti.Comodule.pointsEndHom`: the action, as a monoid homomorphism from the
-  convolution monoid of points to the endomorphism monoid.
+* `TauCeti.Comodule.pointsRepresentation`: the action, as a `Representation` of the
+  convolution monoid of points on the scalar extension.
 * `TauCeti.Comodule.pointsAction`: over a Hopf algebra, the action by linear
   automorphisms.
+
+## References
+
+* W. C. Waterhouse, *Introduction to Affine Group Schemes*, §3.1–3.2.
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 4.
 -/
 
 public section
@@ -61,7 +67,8 @@ lemma endOfPoint_tmul (g : H →ₐ[R] A) (a : A) (v : V) :
 
 variable (V) in
 /-- The convolution unit acts as the identity: the counit law of the comodule. -/
-lemma endOfPoint_ofConv_one :
+@[simp]
+lemma endOfPoint_convOne :
     endOfPoint V ((1 : WithConv (H →ₐ[R] A)).ofConv) = LinearMap.id := by
   apply LinearMap.restrictScalars_injective R
   refine TensorProduct.ext' fun a v => ?_
@@ -81,7 +88,7 @@ lemma endOfPoint_ofConv_one :
   simp [endOfPoint_tmul, hv, TensorProduct.smul_tmul', smul_eq_mul]
 
 omit [Comodule R H V] in
-/-- The coact-free shuffle underlying `endOfPoint_ofConv_mul`: with the two coaction
+/-- The coact-free shuffle underlying `endOfPoint_convMul`: with the two coaction
 columns already peeled off, the two ways of multiplying the pushed coefficients agree,
 by commutativity of the value algebra. -/
 private lemma shuffle (g h : WithConv (H →ₐ[R] A)) :
@@ -133,7 +140,8 @@ private lemma map_comp_lTensor (g h : WithConv (H →ₐ[R] A)) :
 
 variable (V) in
 /-- Convolution products act as composites: the coassociativity law of the comodule. -/
-lemma endOfPoint_ofConv_mul (g h : WithConv (H →ₐ[R] A)) :
+@[simp]
+lemma endOfPoint_convMul (g h : WithConv (H →ₐ[R] A)) :
     endOfPoint V ((g * h).ofConv) = endOfPoint V g.ofConv ∘ₗ endOfPoint V h.ofConv := by
   have hmul : ((g * h).ofConv).toLinearMap =
       LinearMap.mul' R A ∘ₗ
@@ -164,20 +172,20 @@ lemma endOfPoint_ofConv_mul (g h : WithConv (H →ₐ[R] A)) :
     endOfPoint_tmul, map_smul, c1, c2, c3, c4, c5]
 
 variable (V) in
-/-- The points action of a comodule, as a monoid homomorphism from the convolution
-monoid of points to the endomorphism monoid of the scalar extension. -/
-noncomputable def pointsEndHom :
-    WithConv (H →ₐ[R] A) →* Module.End A (A ⊗[R] V) where
+/-- The points action of a comodule, as a representation of the convolution monoid of
+points on the scalar extension. -/
+noncomputable def pointsRepresentation :
+    Representation A (WithConv (H →ₐ[R] A)) (A ⊗[R] V) where
   toFun g := endOfPoint V g.ofConv
-  map_one' := endOfPoint_ofConv_one V
-  map_mul' g h := endOfPoint_ofConv_mul V g h
+  map_one' := endOfPoint_convOne V
+  map_mul' g h := endOfPoint_convMul V g h
 
 variable (V) in
 @[simp]
-lemma pointsEndHom_apply (g : WithConv (H →ₐ[R] A)) :
-    pointsEndHom V g = endOfPoint V g.ofConv := by
-  -- `pointsEndHom` has no equation lemma to rewrite with; `change` spells out its
-  -- definitional unfolding once, explicitly.
+lemma pointsRepresentation_apply (g : WithConv (H →ₐ[R] A)) :
+    pointsRepresentation V g = endOfPoint V g.ofConv := by
+  -- `pointsRepresentation` has no equation lemma to rewrite with; `change` spells out
+  -- its definitional unfolding once, explicitly.
   change endOfPoint V g.ofConv = _
   rfl
 
@@ -194,7 +202,7 @@ inverses provided by the group structure rather than by an antipode computation.
 noncomputable def pointsAction :
     WithConv (H →ₐ[R] A) →* ((A ⊗[R] V) ≃ₗ[A] (A ⊗[R] V)) :=
   (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).toMonoidHom.comp
-    (pointsEndHom V).toHomUnits
+    (pointsRepresentation V).asGroupHom
 
 variable (V) in
 @[simp]
@@ -203,8 +211,9 @@ lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
   -- `pointsAction` has no equation lemma to rewrite with; `change` spells out its
   -- definitional unfolding once, explicitly.
   change ((LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V))
-    ((pointsEndHom V).toHomUnits g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
-  rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap]
+    ((pointsRepresentation V).asGroupHom g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
+  rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap,
+    Representation.asGroupHom_apply]
   rfl
 
 end Hopf

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.Coalgebra.Comodule.Basic
-public import Mathlib.LinearAlgebra.GeneralLinearGroup.Basic
+public import Mathlib.RingTheory.Bialgebra.Convolution
 public import Mathlib.RepresentationTheory.Basic
 
 /-!
@@ -16,9 +15,10 @@ A right comodule `V` over a bialgebra `H` makes the `A`-points of the correspond
 affine monoid act on the scalar extension `A ⊗[R] V`: a point `g : H →ₐ[R] A` acts by
 pushing the coaction coefficients through `g`, `A`-linearly. The two comodule axioms
 are exactly the two monoid-action laws: the counit law sends the convolution unit to
-the identity, and coassociativity sends convolution products to composites. Over a
-Hopf algebra the points form a group, so the action upgrades to linear automorphisms
-via `MonoidHom.toHomUnits` — no antipode computation is needed.
+the identity, and coassociativity sends convolution products to composites. (The
+upgrade to automorphisms over a Hopf algebra is in
+`TauCeti.Algebra.AlgebraicGroup.Representation.PointsAction`, with the group of
+points.)
 
 This is the comodule-to-representation direction of the "representations = comodules"
 dictionary (ReductiveGroups roadmap, Layer 1): it realizes a comodule as an action of
@@ -29,8 +29,6 @@ the functor of points on scalar extensions of `V`.
 * `TauCeti.Comodule.endOfPoint`: the endomorphism of `A ⊗[R] V` attached to a point.
 * `TauCeti.Comodule.pointsRepresentation`: the action, as a `Representation` of the
   convolution monoid of points on the scalar extension.
-* `TauCeti.Comodule.pointsAction`: over a Hopf algebra, the action by linear
-  automorphisms.
 
 ## References
 
@@ -135,8 +133,8 @@ private lemma map_comp_lTensor (g h : WithConv (H →ₐ[R] A)) :
             LinearMap.id).comp
           (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)) ∘ₗ
       (coact (R := R) (C := H) (M := V)).rTensor H := by
-  refine TensorProduct.ext' fun w x => ?_
-  simp
+  simp only [LinearMap.lTensor, LinearMap.rTensor, ← TensorProduct.map_comp,
+    LinearMap.comp_id, LinearMap.id_comp, LinearMap.comp_assoc]
 
 variable (V) in
 /-- Convolution products act as composites: the coassociativity law of the comodule. -/
@@ -223,35 +221,6 @@ lemma pointsRepresentation_apply (g : WithConv (H →ₐ[R] A)) :
   -- its definitional unfolding once, explicitly.
   change endOfPoint V g.ofConv = _
   rfl
-
-section Hopf
-
-variable {R H V A : Type*} [CommSemiring R] [Semiring H] [HopfAlgebra R H]
-  [AddCommMonoid V] [Module R V] [Comodule R H V]
-  [CommSemiring A] [Algebra R A]
-
-variable (V) in
-/-- Over a Hopf algebra the points act by linear automorphisms of the scalar
-extension: the group of points lands in the units of the endomorphism monoid, with
-inverses provided by the group structure rather than by an antipode computation. -/
-noncomputable def pointsAction :
-    WithConv (H →ₐ[R] A) →* ((A ⊗[R] V) ≃ₗ[A] (A ⊗[R] V)) :=
-  (LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V)).toMonoidHom.comp
-    (pointsRepresentation V).asGroupHom
-
-variable (V) in
-@[simp]
-lemma pointsAction_toLinearMap (g : WithConv (H →ₐ[R] A)) :
-    (pointsAction V g : A ⊗[R] V →ₗ[A] A ⊗[R] V) = endOfPoint V g.ofConv := by
-  -- `pointsAction` has no equation lemma to rewrite with; `change` spells out its
-  -- definitional unfolding once, explicitly.
-  change ((LinearMap.GeneralLinearGroup.generalLinearEquiv A (A ⊗[R] V))
-    ((pointsRepresentation V).asGroupHom g) : A ⊗[R] V →ₗ[A] A ⊗[R] V) = _
-  rw [LinearMap.GeneralLinearGroup.generalLinearEquiv_to_linearMap,
-    Representation.asGroupHom_apply]
-  rfl
-
-end Hopf
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -44,13 +44,16 @@ namespace Comodule
 
 open Coalgebra WithConv TensorProduct
 
-variable {R H V A : Type*} [CommSemiring R] [Semiring H] [Bialgebra R H]
+section Coalgebra
+
+variable {R H V A : Type*} [CommSemiring R] [Semiring H] [Algebra R H] [Coalgebra R H]
   [AddCommMonoid V] [Module R V] [Comodule R H V]
   [CommSemiring A] [Algebra R A]
 
 variable (V) in
-/-- The endomorphism of the scalar extension `A ⊗[R] V` attached to an `A`-point of
-the bialgebra: push the coaction coefficients through the point. -/
+/-- The endomorphism of the scalar extension `A ⊗[R] V` attached to an `A`-point:
+push the coaction coefficients through the point. Only the coalgebra structure of `H`
+enters; the bialgebra compatibility is needed for the action laws, not the map. -/
 noncomputable def endOfPoint (g : H →ₐ[R] A) : A ⊗[R] V →ₗ[A] A ⊗[R] V :=
   LinearMap.liftBaseChange A
     ((TensorProduct.comm R V A).toLinearMap ∘ₗ
@@ -62,6 +65,50 @@ lemma endOfPoint_tmul (g : H →ₐ[R] A) (a : A) (v : V) :
     endOfPoint V g (a ⊗ₜ[R] v) =
       a • TensorProduct.comm R V A (LinearMap.lTensor V g.toLinearMap (coact v)) := by
   simp [endOfPoint]
+
+
+section BaseChange
+
+variable {A' : Type*} [CommSemiring A'] [Algebra R A']
+
+variable (V) in
+/-- Base-change compatibility of the action: pushing a point forward along a morphism
+of value algebras and acting agrees with acting first and then extending scalars.
+Stated on the underlying `R`-linear maps, where both composites live. -/
+lemma rTensor_comp_endOfPoint (φ : A →ₐ[R] A') (g : H →ₐ[R] A) :
+    LinearMap.rTensor V φ.toLinearMap ∘ₗ (endOfPoint V g).restrictScalars R =
+      (endOfPoint V (φ.comp g)).restrictScalars R ∘ₗ
+        LinearMap.rTensor V φ.toLinearMap := by
+  have hsmul : ∀ (a : A) (z : A ⊗[R] V),
+      LinearMap.rTensor V φ.toLinearMap (a • z) =
+        φ a • LinearMap.rTensor V φ.toLinearMap z := by
+    intro a z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x v => simp [TensorProduct.smul_tmul', smul_eq_mul, map_mul]
+    | add x y hx hy => simp [smul_add, hx, hy]
+  have hcol : LinearMap.rTensor V φ.toLinearMap ∘ₗ
+      (TensorProduct.comm R V A).toLinearMap ∘ₗ LinearMap.lTensor V g.toLinearMap =
+      (TensorProduct.comm R V A').toLinearMap ∘ₗ
+        LinearMap.lTensor V (φ.comp g).toLinearMap := by
+    refine TensorProduct.ext' fun w x => ?_
+    simp
+  refine TensorProduct.ext' fun a v => ?_
+  have hc := DFunLike.congr_fun hcol (coact (R := R) (C := H) v)
+  simp only [LinearMap.coe_comp, Function.comp_apply,
+    LinearEquiv.coe_toLinearMap] at hc
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    LinearMap.rTensor_tmul, endOfPoint_tmul, hsmul, hc, AlgHom.toLinearMap_apply]
+
+end BaseChange
+
+end Coalgebra
+
+section Bialgebra
+
+variable {R H V A : Type*} [CommSemiring R] [Semiring H] [Bialgebra R H]
+  [AddCommMonoid V] [Module R V] [Comodule R H V]
+  [CommSemiring A] [Algebra R A]
 
 variable (V) in
 /-- The convolution unit acts as the identity: the counit law of the comodule. -/
@@ -148,7 +195,11 @@ lemma endOfPoint_convMul (g h : WithConv (H →ₐ[R] A)) :
               LinearMap.id).comp
             (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)) ∘ₗ
         (coact (R := R) (C := H) (M := V)).rTensor H from by
-    simp only [LinearMap.lTensor, LinearMap.rTensor, ← TensorProduct.map_comp,
+    -- Assembled from the tensor-map composition lemmas (`map_comp`, `lTensor_def`,
+    -- `rTensor_def`); stated inline as a `show` because it is single-use, and the goal
+    -- is not otherwise reachable by rewriting: the composite must be produced before
+    -- it can be evaluated at the opaque coaction value below.
+    simp only [LinearMap.lTensor_def, LinearMap.rTensor_def, ← TensorProduct.map_comp,
       LinearMap.comp_id, LinearMap.id_comp, LinearMap.comp_assoc])
     (coact (R := R) (C := H) v)
   -- the coact-free shuffle at the doubled coaction
@@ -165,41 +216,6 @@ lemma endOfPoint_convMul (g h : WithConv (H →ₐ[R] A)) :
   simp only [LinearMap.coe_comp, Function.comp_apply] at c5
   simp only [LinearMap.restrictScalars_apply, LinearMap.coe_comp, Function.comp_apply,
     endOfPoint_tmul, map_smul, c1, c2, c3, c4, c5]
-
-section BaseChange
-
-variable {A' : Type*} [CommSemiring A'] [Algebra R A']
-
-variable (V) in
-/-- Base-change compatibility of the action: pushing a point forward along a morphism
-of value algebras and acting agrees with acting first and then extending scalars.
-Stated on the underlying `R`-linear maps, where both composites live. -/
-lemma rTensor_comp_endOfPoint (φ : A →ₐ[R] A') (g : H →ₐ[R] A) :
-    LinearMap.rTensor V φ.toLinearMap ∘ₗ (endOfPoint V g).restrictScalars R =
-      (endOfPoint V (φ.comp g)).restrictScalars R ∘ₗ
-        LinearMap.rTensor V φ.toLinearMap := by
-  have hsmul : ∀ (a : A) (z : A ⊗[R] V),
-      LinearMap.rTensor V φ.toLinearMap (a • z) =
-        φ a • LinearMap.rTensor V φ.toLinearMap z := by
-    intro a z
-    induction z using TensorProduct.induction_on with
-    | zero => simp
-    | tmul x v => simp [TensorProduct.smul_tmul', smul_eq_mul, map_mul]
-    | add x y hx hy => simp [smul_add, hx, hy]
-  have hcol : LinearMap.rTensor V φ.toLinearMap ∘ₗ
-      (TensorProduct.comm R V A).toLinearMap ∘ₗ LinearMap.lTensor V g.toLinearMap =
-      (TensorProduct.comm R V A').toLinearMap ∘ₗ
-        LinearMap.lTensor V (φ.comp g).toLinearMap := by
-    refine TensorProduct.ext' fun w x => ?_
-    simp
-  refine TensorProduct.ext' fun a v => ?_
-  have hc := DFunLike.congr_fun hcol (coact (R := R) (C := H) v)
-  simp only [LinearMap.coe_comp, Function.comp_apply,
-    LinearEquiv.coe_toLinearMap] at hc
-  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
-    LinearMap.rTensor_tmul, endOfPoint_tmul, hsmul, hc, AlgHom.toLinearMap_apply]
-
-end BaseChange
 
 variable (V) in
 /-- The points action of a comodule, as a representation of the convolution monoid of
@@ -218,6 +234,8 @@ lemma pointsRepresentation_apply (g : WithConv (H →ₐ[R] A)) :
   -- its definitional unfolding once, explicitly.
   change endOfPoint V g.ofConv = _
   rfl
+
+end Bialgebra
 
 end Comodule
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -119,23 +119,6 @@ private lemma endOfPoint_comp_comm (g : WithConv (H →ₐ[R] A)) :
   refine TensorProduct.ext' fun w c => ?_
   simp [endOfPoint_tmul, Algebra.lsmul_coe]
 
-/-- Peeling the coaction column off `map (pre g) id`: the two-column form of the
-`g`-leg against an untouched `h`-coefficient leg. Pure-tensor identity; the inner
-coaction value rides through opaquely. -/
-private lemma map_comp_lTensor (g h : WithConv (H →ₐ[R] A)) :
-    TensorProduct.map
-        ((TensorProduct.comm R V A).toLinearMap.comp
-          ((LinearMap.lTensor V (g.ofConv).toLinearMap).comp (coact (R := R) (C := H))))
-        LinearMap.id ∘ₗ
-      LinearMap.lTensor V (h.ofConv).toLinearMap =
-    (TensorProduct.map (TensorProduct.comm R V A).toLinearMap LinearMap.id).comp
-        ((TensorProduct.map (LinearMap.lTensor V (g.ofConv).toLinearMap)
-            LinearMap.id).comp
-          (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)) ∘ₗ
-      (coact (R := R) (C := H) (M := V)).rTensor H := by
-  simp only [LinearMap.lTensor, LinearMap.rTensor, ← TensorProduct.map_comp,
-    LinearMap.comp_id, LinearMap.id_comp, LinearMap.comp_assoc]
-
 variable (V) in
 /-- Convolution products act as composites: the coassociativity law of the comodule. -/
 @[simp]
@@ -152,8 +135,22 @@ lemma endOfPoint_convMul (g h : WithConv (H →ₐ[R] A)) :
   -- the endomorphism of the point `g`, evaluated on the flip of the `h`-column
   have c1 := DFunLike.congr_fun (endOfPoint_comp_comm (V := V) g)
     (LinearMap.lTensor V (h.ofConv).toLinearMap (coact (R := R) (C := H) v))
-  -- peel the coaction column off the `g`-leg
-  have c2 := DFunLike.congr_fun (map_comp_lTensor (V := V) g h) (coact (R := R) (C := H) v)
+  -- peel the coaction column off the `g`-leg: a composite of Mathlib's tensor-map
+  -- composition lemmas
+  have c2 := DFunLike.congr_fun (show
+      TensorProduct.map
+          ((TensorProduct.comm R V A).toLinearMap.comp
+            ((LinearMap.lTensor V (g.ofConv).toLinearMap).comp (coact (R := R) (C := H))))
+          LinearMap.id ∘ₗ
+        LinearMap.lTensor V (h.ofConv).toLinearMap =
+      (TensorProduct.map (TensorProduct.comm R V A).toLinearMap LinearMap.id).comp
+          ((TensorProduct.map (LinearMap.lTensor V (g.ofConv).toLinearMap)
+              LinearMap.id).comp
+            (LinearMap.lTensor (V ⊗[R] H) (h.ofConv).toLinearMap)) ∘ₗ
+        (coact (R := R) (C := H) (M := V)).rTensor H from by
+    simp only [LinearMap.lTensor, LinearMap.rTensor, ← TensorProduct.map_comp,
+      LinearMap.comp_id, LinearMap.id_comp, LinearMap.comp_assoc])
+    (coact (R := R) (C := H) v)
   -- the coact-free shuffle at the doubled coaction
   have c3 := DFunLike.congr_fun (shuffle (V := V) g h)
     ((coact (R := R) (C := H) (M := V)).rTensor H (coact (R := R) (C := H) v))

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -11,8 +11,9 @@ public import Mathlib.RepresentationTheory.Basic
 /-!
 # The points action of a comodule
 
-A right comodule `V` over a bialgebra `H` makes the `A`-points of the corresponding
-affine monoid act on the scalar extension `A ⊗[R] V`: a point `g : H →ₐ[R] A` acts by
+A right comodule `V` over a bialgebra `H` makes the `A`-points of `H` — those of the
+corresponding affine monoid scheme, when `H` is commutative — act on the scalar
+extension `A ⊗[R] V`: a point `g : H →ₐ[R] A` acts by
 pushing the coaction coefficients through `g`, `A`-linearly. The two comodule axioms
 are exactly the two monoid-action laws: the counit law sends the convolution unit to
 the identity, and coassociativity sends convolution products to composites. (The
@@ -29,6 +30,8 @@ the functor of points on scalar extensions of `V`.
 * `TauCeti.Comodule.endOfPoint`: the endomorphism of `A ⊗[R] V` attached to a point.
 * `TauCeti.Comodule.pointsRepresentation`: the action, as a `Representation` of the
   convolution monoid of points on the scalar extension.
+* `TauCeti.Comodule.baseChange_comp_endOfPoint`: the action is functorial in the
+  comodule.
 
 ## References
 
@@ -101,6 +104,32 @@ lemma rTensor_comp_endOfPoint (φ : A →ₐ[R] A') (g : H →ₐ[R] A) :
     LinearMap.rTensor_tmul, endOfPoint_tmul, hsmul, hc, AlgHom.toLinearMap_apply]
 
 end BaseChange
+
+section Functorial
+
+variable {W : Type*} [AddCommMonoid W] [Module R W] [Comodule R H W]
+
+/-- Scalar extension of a comodule morphism intertwines the point actions: the action
+is functorial in the comodule. -/
+lemma baseChange_comp_endOfPoint (f : Hom R H V W) (g : H →ₐ[R] A) :
+    f.toLinearMap.baseChange A ∘ₗ endOfPoint V g =
+      endOfPoint W g ∘ₗ f.toLinearMap.baseChange A := by
+  have hcol : (f.toLinearMap.baseChange A).restrictScalars R ∘ₗ
+      (TensorProduct.comm R V A).toLinearMap ∘ₗ LinearMap.lTensor V g.toLinearMap =
+      (TensorProduct.comm R W A).toLinearMap ∘ₗ LinearMap.lTensor W g.toLinearMap ∘ₗ
+        TensorProduct.map f.toLinearMap LinearMap.id := by
+    refine TensorProduct.ext' fun w x => ?_
+    simp
+  apply LinearMap.restrictScalars_injective R
+  refine TensorProduct.ext' fun a v => ?_
+  have hc := DFunLike.congr_fun hcol (coact (R := R) (C := H) v)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    LinearEquiv.coe_toLinearMap] at hc
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    endOfPoint_tmul, map_smul, LinearMap.baseChange_tmul, hc, Hom.map_coact_apply,
+    Hom.coe_toLinearMap]
+
+end Functorial
 
 end Coalgebra
 

--- a/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/PointsAction.lean
@@ -171,6 +171,41 @@ lemma endOfPoint_convMul (g h : WithConv (H →ₐ[R] A)) :
   simp only [LinearMap.restrictScalars_apply, LinearMap.coe_comp, Function.comp_apply,
     endOfPoint_tmul, map_smul, c1, c2, c3, c4, c5]
 
+section BaseChange
+
+variable {A' : Type*} [CommSemiring A'] [Algebra R A']
+
+variable (V) in
+/-- Base-change compatibility of the action: pushing a point forward along a morphism
+of value algebras and acting agrees with acting first and then extending scalars.
+Stated on the underlying `R`-linear maps, where both composites live. -/
+lemma rTensor_comp_endOfPoint (φ : A →ₐ[R] A') (g : H →ₐ[R] A) :
+    LinearMap.rTensor V φ.toLinearMap ∘ₗ (endOfPoint V g).restrictScalars R =
+      (endOfPoint V (φ.comp g)).restrictScalars R ∘ₗ
+        LinearMap.rTensor V φ.toLinearMap := by
+  have hsmul : ∀ (a : A) (z : A ⊗[R] V),
+      LinearMap.rTensor V φ.toLinearMap (a • z) =
+        φ a • LinearMap.rTensor V φ.toLinearMap z := by
+    intro a z
+    induction z using TensorProduct.induction_on with
+    | zero => simp
+    | tmul x v => simp [TensorProduct.smul_tmul', smul_eq_mul, map_mul]
+    | add x y hx hy => simp [smul_add, hx, hy]
+  have hcol : LinearMap.rTensor V φ.toLinearMap ∘ₗ
+      (TensorProduct.comm R V A).toLinearMap ∘ₗ LinearMap.lTensor V g.toLinearMap =
+      (TensorProduct.comm R V A').toLinearMap ∘ₗ
+        LinearMap.lTensor V (φ.comp g).toLinearMap := by
+    refine TensorProduct.ext' fun w x => ?_
+    simp
+  refine TensorProduct.ext' fun a v => ?_
+  have hc := DFunLike.congr_fun hcol (coact (R := R) (C := H) v)
+  simp only [LinearMap.coe_comp, Function.comp_apply,
+    LinearEquiv.coe_toLinearMap] at hc
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    LinearMap.rTensor_tmul, endOfPoint_tmul, hsmul, hc, AlgHom.toLinearMap_apply]
+
+end BaseChange
+
 variable (V) in
 /-- The points action of a comodule, as a representation of the convolution monoid of
 points on the scalar extension. -/


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"comodule-points-action"}-->

A right comodule `V` over a bialgebra `H` makes the `A`-points of the corresponding affine monoid act on the scalar extension `A ⊗[R] V`: a point `g : H →ₐ[R] A` acts by pushing the coaction coefficients through `g`, `A`-linearly (`Comodule.endOfPoint`, via `LinearMap.liftBaseChange`). The two comodule axioms are exactly the two action laws — the counit law sends the convolution unit to the identity, and coassociativity sends convolution products to composites — so the action is a monoid homomorphism `pointsEndHom` from the convolution monoid of points to the endomorphism monoid. Over a Hopf algebra the points form a group, so `MonoidHom.toHomUnits` upgrades the action to linear automorphisms (`pointsAction`) with no antipode computation.

This is the comodule-to-representation direction of the Layer 1 dictionary "representations = comodules" (ReductiveGroups roadmap; the STATUS frontier lists the representation ⇆ comodule dictionary as the missing Layer-1 item). It realizes a comodule as an action of the functor of points on scalar extensions of `V`, in the same idiom as `GeneralLinear.scalarExtensionAutomorphisms`.

Proof architecture: no Sweedler-style sums and no comodule-`Repr` machinery (none exists). The product law reduces along `LinearMap.restrictScalars`-injectivity to pure tensors, then proceeds by valuewise congruence of four composite lemmas — the pure-tensor characterization of `endOfPoint` against the flip, a coaction-column peel, a coact-free shuffle whose cross-multiplication closes by `mul_comm` in `A` (the one place commutativity of the value algebra enters), and coassociativity — with the convolution product folded back through `AlgHom.toLinearMap_convMul`.

Generality: bialgebra suffices for the monoid action; Hopf enters only for the automorphism upgrade; no finiteness, freeness, or flatness hypotheses on `V`.

Roadmap: ReductiveGroups