### PR TITLE
feat(Multiquadratic): the narrow class number is the ordinary one times a power of 2

### DIFF
--- a/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Finite.lean
+++ b/TauCeti/NumberTheory/NumberField/NarrowClassGroup/Finite.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.GroupTheory.PGroup
 public import Mathlib.NumberTheory.NumberField.ClassNumber
 public import TauCeti.NumberTheory.NumberField.NarrowClassGroup.Basic
 
@@ -19,6 +20,8 @@ surjection is the image of the principal-class map `mkPrincipal`, which factors 
 ## Main results
 
 * `TauCeti.NumberField.NarrowClassGroup.instFinite`: `Cl⁺(K)` is finite.
+* `TauCeti.NumberField.NarrowClassGroup.exists_card_eq_card_classGroup_mul_two_pow`: the narrow
+  class number is the ordinary class number times a power of `2`.
 -/
 
 public section
@@ -41,5 +44,29 @@ instance instFinite : Finite (NarrowClassGroup K) := by
     exact ⟨x, mem_totallyPositiveUnits.mp hx, rfl⟩
   have : (mkPrincipal (K := K)).ker.FiniteIndex := Subgroup.finiteIndex_of_le htp
   exact (QuotientGroup.quotientKerEquivRange (mkPrincipal (K := K))).finite_iff.mp inferInstance
+
+/-- The kernel of the forgetful map `Cl⁺(K) → Cl(K)` is a `2`-group: it is `2`-torsion
+(`sq_eq_one_of_mem_ker_toClassGroup`). -/
+theorem isPGroup_two_ker_toClassGroup :
+    IsPGroup 2 (MonoidHom.ker (toClassGroup (K := K))) := fun g =>
+  ⟨1, Subtype.ext <| by
+    rw [pow_one, SubmonoidClass.coe_pow, OneMemClass.coe_one]
+    exact sq_eq_one_of_mem_ker_toClassGroup g.2⟩
+
+/-- The narrow class number is the ordinary class number times the order of the kernel of the
+forgetful map `Cl⁺(K) → Cl(K)`. -/
+theorem card_eq_card_classGroup_mul_card_ker :
+    Nat.card (NarrowClassGroup K) =
+      Nat.card (ClassGroup (𝓞 K)) * Nat.card (MonoidHom.ker (toClassGroup (K := K))) := by
+  rw [Subgroup.card_eq_card_quotient_mul_card_subgroup (MonoidHom.ker (toClassGroup (K := K))),
+    Nat.card_congr (QuotientGroup.quotientKerEquivOfSurjective (toClassGroup (K := K))
+      toClassGroup_surjective).toEquiv]
+
+/-- **The narrow class number is the ordinary class number times a power of `2`.** The extra factor
+is the order of the elementary abelian `2`-group `ker(Cl⁺(K) → Cl(K))`. -/
+theorem exists_card_eq_card_classGroup_mul_two_pow :
+    ∃ k, Nat.card (NarrowClassGroup K) = Nat.card (ClassGroup (𝓞 K)) * 2 ^ k := by
+  obtain ⟨k, hk⟩ := IsPGroup.iff_card.1 (isPGroup_two_ker_toClassGroup (K := K))
+  exact ⟨k, by rw [card_eq_card_classGroup_mul_card_ker, hk]⟩
 
 end TauCeti.NumberField.NarrowClassGroup


### PR DESCRIPTION
The classical result that `h⁺ = h · 2ᵏ`, building on the merged fact that `ker(Cl⁺ → Cl)` is
`2`-torsion (`sq_eq_one_of_mem_ker_toClassGroup`). Added to `NarrowClassGroup/Finite.lean`:

- `isPGroup_two_ker_toClassGroup` — the kernel of the forgetful map is a `2`-group;
- `card_eq_card_classGroup_mul_card_ker` — the first isomorphism theorem gives
  `Nat.card Cl⁺ = Nat.card Cl · Nat.card ↥(ker toClassGroup)`;
- `exists_card_eq_card_classGroup_mul_two_pow` — combining the two,
  `∃ k, Nat.card Cl⁺ = Nat.card Cl · 2 ^ k`.

So the **narrow class number is the ordinary class number times a power of `2`** — the archimedean
defect between the narrow and ordinary class groups is `2`-primary. Sorry-free, default axioms.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"Multiquadratic/narrow-class-number-two-power"}-->

🤖 Generated with [Claude Code](https://claude.com/claude-code)