### PR TITLE
feat: prove naturality of Hopf spectrum points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -1,0 +1,129 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.Group.Affine
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.Basic
+
+/-!
+# Scheme-valued points of affine Hopf spectra
+
+For a commutative ring `R`, a same-universe commutative Hopf algebra `H`, and a
+same-universe commutative `R`-algebra `A`, this file identifies the convolution group
+`WithConv (H →ₐ[R] A)` with the group of morphisms over `Spec R` from `Spec A` into
+`Spec H`.
+
+The group law on the scheme side is the pointwise group law induced by the group object
+represented by `H`; the source `Spec A` need not itself be a group object. No
+cocommutativity assumption is made, so the resulting group of points need not be
+commutative. The target `(Spec H).asOver (Spec R)` below is definitionally the underlying
+object of `(AlgebraicGeometry.hopfSpec R).obj (Opposite.op H)`.
+
+The equivalence and its multiplicativity are Mathlib's
+`AlgebraicGeometry.Spec.mapMulEquiv`. This file gives that result a reusable
+Hopf-spectrum-facing boundary, records its two computations, and proves its covariance in
+the value algebra and contravariance in the coordinate Hopf algebra.
+
+## Main declarations
+
+* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv`: convolution points are morphisms into
+  the affine Hopf spectrum over the base spectrum.
+* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv_mapValue`: a value-algebra map becomes
+  precomposition by the corresponding spectrum morphism.
+* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv_mapDomain`: a coordinate Hopf morphism
+  becomes postcomposition by its contravariant `hopfSpec` image.
+-/
+
+public section
+
+open CategoryTheory WithConv
+open scoped CategoryTheory.MonObj
+
+namespace TauCeti
+
+universe u
+
+namespace CommHopfAlgCat
+
+open AlgebraicGeometry
+
+variable {R : Type u} [CommRing R]
+
+/-- The convolution group of `A`-valued points of a commutative Hopf algebra `H` is
+multiplicatively equivalent to the morphisms over `Spec R` from `Spec A` to `Spec H`.
+
+The target is the underlying object of the affine group scheme
+`(AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)`. Multiplication on
+the hom-set is therefore induced by the group-object multiplication dual to the
+comultiplication of `H`. -/
+noncomputable def hopfSpecPointsMulEquiv
+    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R) :
+    HopfAlgebra.points (R := R) (H := H) A ≃*
+      ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+        (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :=
+  AlgebraicGeometry.Spec.mapMulEquiv
+
+/-- An algebra-valued point is sent to its contravariant spectrum morphism over the base
+spectrum. -/
+@[simp]
+theorem hopfSpecPointsMulEquiv_apply
+    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R)
+    (p : HopfAlgebra.points (R := R) (H := H) A) :
+    hopfSpecPointsMulEquiv H A p =
+      (Spec.map (CommRingCat.ofHom p.ofConv.toRingHom)).asOver
+        (Spec (CommRingCat.of R)) := by
+  rfl
+
+/-- The inverse scheme-points equivalence recovers the map on coordinate rings induced by
+the underlying morphism of affine schemes. -/
+@[simp]
+theorem hopfSpecPointsMulEquiv_symm_apply_toRingHom
+    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R)
+    (f : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+      (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
+    (↑((hopfSpecPointsMulEquiv H A).symm f).ofConv : H →+* A) =
+      (Spec.preimage f.left).hom := by
+  rfl
+
+/-- The Hopf-spectrum points equivalence is natural in the value algebra. Postcomposing an
+`A`-valued algebra point by `φ : A ⟶ B` corresponds on spectra to precomposing by
+`Spec B ⟶ Spec A`. -/
+theorem hopfSpecPointsMulEquiv_mapValue
+    (H : _root_.CommHopfAlgCat.{u} R) {A B : CommAlgCat.{u} R}
+    (φ : A ⟶ B) (p : HopfAlgebra.points (R := R) (H := H) A) :
+    hopfSpecPointsMulEquiv H B (HopfAlgebra.mapPoints (H := H) φ p) =
+      (Spec.map (CommRingCat.ofHom φ.hom.toRingHom)).asOver
+          (Spec (CommRingCat.of R)) ≫
+        hopfSpecPointsMulEquiv H A p := by
+  apply Over.OverMorphism.ext
+  -- On underlying affine schemes this is contravariance of `Spec` applied to the
+  -- composite coordinate map `H → A → B`.
+  change Spec.map (CommRingCat.ofHom (φ.hom.comp p.ofConv).toRingHom) =
+    Spec.map (CommRingCat.ofHom φ.hom.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom p.ofConv.toRingHom)
+  rw [← Spec.map_comp]
+  rfl
+
+/-- The Hopf-spectrum points equivalence is contravariantly natural in the coordinate Hopf
+algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to
+postcomposing by the group-scheme morphism `Spec K ⟶ Spec H` induced by `hopfSpec`. -/
+theorem hopfSpecPointsMulEquiv_mapDomain
+    {H K : _root_.CommHopfAlgCat.{u} R} (A : CommAlgCat.{u} R)
+    (φ : H ⟶ K) (p : HopfAlgebra.points (R := R) (H := K) A) :
+    hopfSpecPointsMulEquiv H A ((mapPointsFunctor φ).app A p) =
+      hopfSpecPointsMulEquiv K A p ≫
+        ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom := by
+  apply Over.OverMorphism.ext
+  -- The underlying map of `hopfSpec.map φ.op` is definitionally `Spec.map φ`; the
+  -- square is therefore contravariance of `Spec` for `H → K → A`.
+  change Spec.map (CommRingCat.ofHom (p.ofConv.comp φ.hom).toRingHom) =
+    Spec.map (CommRingCat.ofHom p.ofConv.toRingHom) ≫
+      Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom)
+  rw [← Spec.map_comp]
+  rfl
+
+end CommHopfAlgCat
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -48,6 +48,19 @@ open AlgebraicGeometry
 
 variable {R : Type u} [CommRing R]
 
+private lemma mapMulEquiv_left
+    {S T : Type u} [CommRing S] [CommRing T] [Bialgebra R S] [Algebra R T]
+    (f : WithConv (S →ₐ[R] T)) :
+    (AlgebraicGeometry.Spec.mapMulEquiv f).left =
+      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) :=
+  rfl
+
+private lemma hopfSpec_map_left
+    {H K : _root_.CommHopfAlgCat.{u} R} (φ : H ⟶ K) :
+    ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom.left =
+      Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom) :=
+  rfl
+
 /-- Mathlib's spectrum-points equivalence is natural in the value algebra. Postcomposing
 an `A`-valued algebra point by `φ : A ⟶ B` corresponds on spectra to precomposing by
 `Spec B ⟶ Spec A`. -/
@@ -58,13 +71,11 @@ theorem mapMulEquiv_mapValue
       (Spec.map (CommRingCat.ofHom φ.hom.toRingHom)).asOver
           (Spec (CommRingCat.of R)) ≫
         AlgebraicGeometry.Spec.mapMulEquiv p := by
+  rw [HopfAlgebra.mapPoints_apply]
   apply Over.OverMorphism.ext
-  -- On underlying affine schemes this is contravariance of `Spec` applied to the
-  -- composite coordinate map `H → A → B`.
-  change Spec.map (CommRingCat.ofHom (φ.hom.comp p.ofConv).toRingHom) =
-    Spec.map (CommRingCat.ofHom φ.hom.toRingHom) ≫
-      Spec.map (CommRingCat.ofHom p.ofConv.toRingHom)
-  rw [← Spec.map_comp]
+  erw [Over.comp_left]
+  simp only [mapMulEquiv_left, OverClass.asOverHom_left]
+  erw [← Spec.map_comp]
   rfl
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
@@ -76,13 +87,11 @@ theorem mapMulEquiv_mapDomain
     AlgebraicGeometry.Spec.mapMulEquiv ((mapPointsFunctor φ).app A p) =
       AlgebraicGeometry.Spec.mapMulEquiv p ≫
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom := by
+  rw [mapPointsFunctor_app_apply]
   apply Over.OverMorphism.ext
-  -- The underlying map of `hopfSpec.map φ.op` is definitionally `Spec.map φ`; the
-  -- square is therefore contravariance of `Spec` for `H → K → A`.
-  change Spec.map (CommRingCat.ofHom (p.ofConv.comp φ.hom).toRingHom) =
-    Spec.map (CommRingCat.ofHom p.ofConv.toRingHom) ≫
-      Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom)
-  rw [← Spec.map_comp]
+  erw [Over.comp_left]
+  simp only [mapMulEquiv_left, hopfSpec_map_left]
+  erw [← Spec.map_comp]
   rfl
 
 end CommHopfAlgCat

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -22,17 +22,14 @@ commutative. The target `(Spec H).asOver (Spec R)` below is definitionally the u
 object of `(AlgebraicGeometry.hopfSpec R).obj (Opposite.op H)`.
 
 The equivalence and its multiplicativity are Mathlib's
-`AlgebraicGeometry.Spec.mapMulEquiv`. This file gives that result a reusable
-Hopf-spectrum-facing boundary, records its two computations, and proves its covariance in
-the value algebra and contravariance in the coordinate Hopf algebra.
+`AlgebraicGeometry.Spec.mapMulEquiv`. This file proves its covariance in the value algebra
+and contravariance in the coordinate Hopf algebra.
 
 ## Main declarations
 
-* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv`: convolution points are morphisms into
-  the affine Hopf spectrum over the base spectrum.
-* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv_mapValue`: a value-algebra map becomes
+* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapValue`: a value-algebra map becomes
   precomposition by the corresponding spectrum morphism.
-* `TauCeti.CommHopfAlgCat.hopfSpecPointsMulEquiv_mapDomain`: a coordinate Hopf morphism
+* `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate Hopf morphism
   becomes postcomposition by its contravariant `hopfSpec` image.
 -/
 
@@ -51,52 +48,16 @@ open AlgebraicGeometry
 
 variable {R : Type u} [CommRing R]
 
-/-- The convolution group of `A`-valued points of a commutative Hopf algebra `H` is
-multiplicatively equivalent to the morphisms over `Spec R` from `Spec A` to `Spec H`.
-
-The target is the underlying object of the affine group scheme
-`(AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)`. Multiplication on
-the hom-set is therefore induced by the group-object multiplication dual to the
-comultiplication of `H`. -/
-noncomputable def hopfSpecPointsMulEquiv
-    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R) :
-    HopfAlgebra.points (R := R) (H := H) A ≃*
-      ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
-        (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :=
-  AlgebraicGeometry.Spec.mapMulEquiv
-
-/-- An algebra-valued point is sent to its contravariant spectrum morphism over the base
-spectrum. -/
-@[simp]
-theorem hopfSpecPointsMulEquiv_apply
-    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R)
-    (p : HopfAlgebra.points (R := R) (H := H) A) :
-    hopfSpecPointsMulEquiv H A p =
-      (Spec.map (CommRingCat.ofHom p.ofConv.toRingHom)).asOver
-        (Spec (CommRingCat.of R)) := by
-  rfl
-
-/-- The inverse scheme-points equivalence recovers the map on coordinate rings induced by
-the underlying morphism of affine schemes. -/
-@[simp]
-theorem hopfSpecPointsMulEquiv_symm_apply_toRingHom
-    (H : _root_.CommHopfAlgCat.{u} R) (A : CommAlgCat.{u} R)
-    (f : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
-      (Spec (CommRingCat.of H)).asOver (Spec (CommRingCat.of R))) :
-    (↑((hopfSpecPointsMulEquiv H A).symm f).ofConv : H →+* A) =
-      (Spec.preimage f.left).hom := by
-  rfl
-
-/-- The Hopf-spectrum points equivalence is natural in the value algebra. Postcomposing an
-`A`-valued algebra point by `φ : A ⟶ B` corresponds on spectra to precomposing by
+/-- Mathlib's spectrum-points equivalence is natural in the value algebra. Postcomposing
+an `A`-valued algebra point by `φ : A ⟶ B` corresponds on spectra to precomposing by
 `Spec B ⟶ Spec A`. -/
-theorem hopfSpecPointsMulEquiv_mapValue
+theorem mapMulEquiv_mapValue
     (H : _root_.CommHopfAlgCat.{u} R) {A B : CommAlgCat.{u} R}
     (φ : A ⟶ B) (p : HopfAlgebra.points (R := R) (H := H) A) :
-    hopfSpecPointsMulEquiv H B (HopfAlgebra.mapPoints (H := H) φ p) =
+    AlgebraicGeometry.Spec.mapMulEquiv (HopfAlgebra.mapPoints (H := H) φ p) =
       (Spec.map (CommRingCat.ofHom φ.hom.toRingHom)).asOver
           (Spec (CommRingCat.of R)) ≫
-        hopfSpecPointsMulEquiv H A p := by
+        AlgebraicGeometry.Spec.mapMulEquiv p := by
   apply Over.OverMorphism.ext
   -- On underlying affine schemes this is contravariance of `Spec` applied to the
   -- composite coordinate map `H → A → B`.
@@ -106,14 +67,14 @@ theorem hopfSpecPointsMulEquiv_mapValue
   rw [← Spec.map_comp]
   rfl
 
-/-- The Hopf-spectrum points equivalence is contravariantly natural in the coordinate Hopf
-algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to
+/-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
+Hopf algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to
 postcomposing by the group-scheme morphism `Spec K ⟶ Spec H` induced by `hopfSpec`. -/
-theorem hopfSpecPointsMulEquiv_mapDomain
+theorem mapMulEquiv_mapDomain
     {H K : _root_.CommHopfAlgCat.{u} R} (A : CommAlgCat.{u} R)
     (φ : H ⟶ K) (p : HopfAlgebra.points (R := R) (H := K) A) :
-    hopfSpecPointsMulEquiv H A ((mapPointsFunctor φ).app A p) =
-      hopfSpecPointsMulEquiv K A p ≫
+    AlgebraicGeometry.Spec.mapMulEquiv ((mapPointsFunctor φ).app A p) =
+      AlgebraicGeometry.Spec.mapMulEquiv p ≫
         ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map φ.op).hom.hom := by
   apply Over.OverMorphism.ext
   -- The underlying map of `hopfSpec.map φ.op` is definitionally `Spec.map φ`; the


### PR DESCRIPTION
This PR proves that Mathlib's canonical identification of algebra-valued convolution points with morphisms over `Spec R` into a same-universe commutative Hopf spectrum is natural in the value algebra and contravariantly natural in the coordinate Hopf algebra.

It advances `TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0, “the functor of points and the three-way dictionary,” by synchronizing the Hopf-algebra, affine group-scheme, and functor-of-points views at their scheme-valued-points boundary.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-spec-scheme-points"}-->

This contribution directly reuses Mathlib's `AlgebraicGeometry.Spec.mapMulEquiv` and its affine group-object formalization without adding a duplicate wrapper.

🤖 Prepared with Codex
