### PR TITLE
refactor: expose the scalar-extension automorphism functor

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ScalarExtension.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/ScalarExtension.lean
@@ -217,7 +217,9 @@ lemma mapScalarExtensionAutomorphisms_comp
   simp
 
 /-- The group-valued functor of linear automorphisms of scalar extensions of `V`. -/
-def scalarExtensionAutomorphismsFunctor :
+-- `@[expose]` matches `HopfAlgebra.pointsFunctor`: natural transformations out of
+-- either functor need the object part to unfold cross-module.
+@[expose] def scalarExtensionAutomorphismsFunctor :
     CommAlgCat.{w} R ⥤ GrpCat.{max v w} where
   obj A := scalarExtensionAutomorphisms (V := V) A
   map φ := mapScalarExtensionAutomorphisms (V := V) φ


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"expose-scalar-extension-functor"}-->

`GeneralLinear.scalarExtensionAutomorphismsFunctor` is not `@[expose]`d, unlike its counterpart `HopfAlgebra.pointsFunctor`. Constructing a natural transformation into it from another module is then blocked: the object part does not unfold cross-module, and every app-component needs an `eqToHom` transport against `scalarExtensionAutomorphismsFunctor_obj` (whose `rfl` proof is available only in-module). Exposing the functor definition restores the symmetry with `pointsFunctor` and lets downstream representation-dictionary work (e.g. #1809's natural actions) target the functor directly.

One attribute plus a comment; no statements change.

Roadmap: ReductiveGroups