### PR TITLE
feat: index the polynomial weights of GL n by bounded Young diagrams

### DIFF
--- a/TauCeti/Combinatorics/Young/Diagram.lean
+++ b/TauCeti/Combinatorics/Young/Diagram.lean
@@ -15,7 +15,9 @@ public import Mathlib.Data.List.GetD
 Mathlib's `YoungDiagram.rowLens` records the lengths of the rows of a Young diagram.  This file
 counts the cells of a diagram row by row: the row lengths sum to the number of cells, and the
 first `k` row lengths sum to the number of cells lying in the first `k` rows, whether those
-lengths are summed as `∑ i ∈ Finset.range k, μ.rowLen i` or as `(μ.rowLens.take k).sum`.
+lengths are summed as `∑ i ∈ Finset.range k, μ.rowLen i` or as `(μ.rowLens.take k).sum`.  Since
+the rows exhaust the cells, the row lengths also determine the diagram
+(`TauCeti.YoungDiagram.rowLen_injective`).
 
 The partial sums are the shape of every dominance statement about partitions, since dominance
 compares partial sums of decreasingly sorted parts, and the sorted parts of a partition are the
@@ -50,6 +52,14 @@ theorem rowLen_eq_zero_of_colLen_le {μ : YoungDiagram} {i : ℕ} (hi : μ.colLe
   exact absurd (_root_.YoungDiagram.mem_iff_lt_colLen.mp
     (_root_.YoungDiagram.mem_iff_lt_rowLen.mpr (Nat.pos_of_ne_zero h))) (Nat.not_lt.mpr hi)
 
+/-- A Young diagram is determined by its row lengths. -/
+theorem rowLen_injective : Function.Injective _root_.YoungDiagram.rowLen := by
+  intro μ ν h
+  ext c
+  obtain ⟨i, j⟩ := c
+  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
+    _root_.YoungDiagram.mem_iff_lt_rowLen, _root_.YoungDiagram.mem_iff_lt_rowLen, congrFun h i]
+
 /-- Reading the length of a row off `YoungDiagram.rowLens`, with `0` for the rows past the last
 one. -/
 theorem getD_rowLens (μ : YoungDiagram) (i : ℕ) : μ.rowLens.getD i 0 = μ.rowLen i := by
@@ -81,6 +91,16 @@ theorem sum_range_rowLen_eq_card_filter_fst (μ : YoungDiagram) (k : ℕ) :
         _root_.YoungDiagram.mem_row_iff]
       aesop
 
+/-- The cells of a Young diagram, counted over any range of rows that contains all of them.  This
+is `TauCeti.YoungDiagram.sum_rowLens` with the range of summation chosen by hand instead of being
+the exact number of rows `μ.colLen 0`. -/
+theorem card_eq_sum_range_rowLen (μ : _root_.YoungDiagram) {N : ℕ} (hN : μ.colLen 0 ≤ N) :
+    μ.card = ∑ i ∈ Finset.range N, μ.rowLen i := by
+  rw [sum_range_rowLen_eq_card_filter_fst]
+  refine (congrArg Finset.card (Finset.filter_true_of_mem fun c hc => ?_)).symm
+  exact lt_of_lt_of_le ((_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+    (μ.colLen_anti 0 c.snd c.snd.zero_le)) hN
+
 /-- The first `k` entries of `YoungDiagram.rowLens` count the cells in the first `k` rows.  This
 is `TauCeti.YoungDiagram.sum_range_rowLen_eq_card_filter_fst` with the truncation taken on the
 list of row lengths, the form in which partial sums enter the dominance order on partitions. -/
@@ -97,13 +117,7 @@ theorem sum_take_rowLens_eq_card_filter_fst (μ : YoungDiagram) (k : ℕ) :
 /-- The sum of the row lengths of a Young diagram is its number of cells. -/
 @[simp]
 theorem sum_rowLens (μ : YoungDiagram) : μ.rowLens.sum = μ.card := by
-  have hrange : μ.rowLens.sum = ∑ i ∈ Finset.range (μ.colLen 0), μ.rowLen i := by
-    rw [_root_.YoungDiagram.rowLens, sum_list_range]
-  rw [hrange, sum_range_rowLen_eq_card_filter_fst]
-  refine congrArg Finset.card (Finset.filter_true_of_mem fun c hc => ?_)
-  simpa using
-    (_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
-      (μ.colLen_anti 0 c.snd c.snd.zero_le)
+  rw [_root_.YoungDiagram.rowLens, sum_list_range, ← card_eq_sum_range_rowLen μ le_rfl]
 
 end YoungDiagram
 

--- a/TauCeti/Combinatorics/Young/OfRowLens.lean
+++ b/TauCeti/Combinatorics/Young/OfRowLens.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Fin
+public import Mathlib.Data.List.OfFn
+public import Mathlib.Data.List.Sort
+public import TauCeti.Combinatorics.Young.Diagram
+
+/-!
+# Young diagrams from a bounded family of row lengths
+
+Mathlib builds a Young diagram from a weakly decreasing `List ℕ` of row lengths
+(`YoungDiagram.ofRowLens`) and reads that list back off a diagram (`YoungDiagram.rowLens`); the
+two are inverse only after the *positive* entries are singled out, since `rowLens` never records
+a row of length `0`.
+
+Indexing the row lengths by `Fin n` rather than by a list removes that mismatch: a weakly
+decreasing `f : Fin n → ℕ` is allowed to end in zeros, and `TauCeti.YoungDiagram.ofRowLensFin`
+turns any such family into the diagram whose `i`-th row has length `f i` for `i < n` and which has
+no row beyond. Reading the first `n` row lengths back off is then an honest inverse on the
+diagrams with at most `n` rows — the form consumed when partitions with a bounded number of rows
+are matched against weight data for `GL n`.
+
+## Main definitions
+
+* `TauCeti.YoungDiagram.ofRowLensFin`: the Young diagram with prescribed weakly decreasing row
+  lengths `f : Fin n → ℕ` and no further rows.
+
+## Main results
+
+* `TauCeti.YoungDiagram.rowLen_ofRowLensFin` and
+  `TauCeti.YoungDiagram.rowLen_ofRowLensFin_of_le`: the row lengths of `ofRowLensFin f hf` are
+  `f` on `Fin n` and `0` beyond it.
+* `TauCeti.YoungDiagram.colLen_zero_ofRowLensFin_le` and
+  `TauCeti.YoungDiagram.ofRowLensFin_rowLen`: `ofRowLensFin` lands in the diagrams with at most
+  `n` rows, and is there inverse to reading off the first `n` row lengths.
+* `TauCeti.YoungDiagram.card_ofRowLensFin`: its number of cells is `∑ i, f i`.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace YoungDiagram
+
+open Finset
+
+variable {n : ℕ}
+
+/-- Two Young diagrams with the same row lengths are equal. -/
+theorem eq_of_rowLen_eq {μ ν : _root_.YoungDiagram} (h : ∀ i, μ.rowLen i = ν.rowLen i) :
+    μ = ν := by
+  ext c
+  obtain ⟨i, j⟩ := c
+  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
+    _root_.YoungDiagram.mem_iff_lt_rowLen, _root_.YoungDiagram.mem_iff_lt_rowLen, h]
+
+/-- The cells of a Young diagram, counted over any range of rows that contains all of them.  This
+is `TauCeti.YoungDiagram.sum_rowLens` with the range of summation chosen by hand instead of being
+the exact number of rows. -/
+theorem card_eq_sum_range_rowLen (μ : _root_.YoungDiagram) {N : ℕ} (hN : μ.colLen 0 ≤ N) :
+    μ.card = ∑ i ∈ range N, μ.rowLen i := by
+  rw [sum_range_rowLen_eq_card_filter_fst]
+  refine (congrArg Finset.card (Finset.filter_true_of_mem fun c hc => ?_)).symm
+  exact lt_of_lt_of_le ((_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
+    (μ.colLen_anti 0 c.snd c.snd.zero_le)) hN
+
+/-- A weakly decreasing family `f : Fin n → ℕ` is a weakly decreasing list of row lengths. -/
+private theorem sortedGE_ofFn {f : Fin n → ℕ} (hf : Antitone f) : (List.ofFn f).SortedGE :=
+  List.sortedGE_iff_pairwise.mpr (List.pairwise_ofFn.mpr fun _ _ hij => hf hij.le)
+
+/-- The Young diagram whose first `n` rows have the prescribed weakly decreasing lengths
+`f : Fin n → ℕ`, and which has no row beyond.  Unlike `YoungDiagram.ofRowLens`, the family `f`
+may take the value `0`; such an entry simply contributes an empty row. -/
+def ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) : _root_.YoungDiagram :=
+  _root_.YoungDiagram.ofRowLens (List.ofFn f) (sortedGE_ofFn hf)
+
+@[simp]
+theorem rowLen_ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) (i : Fin n) :
+    (ofRowLensFin f hf).rowLen i = f i := by
+  have h : (i : ℕ) < (List.ofFn f).length := by simp
+  simpa [ofRowLensFin] using
+    _root_.YoungDiagram.rowLen_ofRowLens (w := List.ofFn f) (hw := sortedGE_ofFn hf) ⟨i, h⟩
+
+theorem rowLen_ofRowLensFin_of_le (f : Fin n → ℕ) (hf : Antitone f) {i : ℕ} (hi : n ≤ i) :
+    (ofRowLensFin f hf).rowLen i = 0 := by
+  by_contra h
+  have hmem : ((i, 0) : ℕ × ℕ) ∈ ofRowLensFin f hf :=
+    _root_.YoungDiagram.mem_iff_lt_rowLen.mpr (Nat.pos_of_ne_zero h)
+  obtain ⟨hlt, -⟩ := _root_.YoungDiagram.mem_ofRowLens.mp hmem
+  simp only [List.length_ofFn] at hlt
+  exact absurd hlt (Nat.not_lt.mpr hi)
+
+theorem colLen_zero_ofRowLensFin_le (f : Fin n → ℕ) (hf : Antitone f) :
+    (ofRowLensFin f hf).colLen 0 ≤ n := by
+  by_contra h
+  have hmem : ((n, 0) : ℕ × ℕ) ∈ ofRowLensFin f hf :=
+    _root_.YoungDiagram.mem_iff_lt_colLen.mpr (Nat.lt_of_not_le h)
+  exact absurd (rowLen_ofRowLensFin_of_le f hf (le_refl n))
+    (_root_.YoungDiagram.mem_iff_lt_rowLen.mp hmem).ne'
+
+/-- The first `n` row lengths of a Young diagram are weakly decreasing. -/
+theorem antitone_rowLen (μ : _root_.YoungDiagram) (n : ℕ) :
+    Antitone fun i : Fin n => μ.rowLen i := fun _ _ h => μ.rowLen_anti _ _ h
+
+/-- Reading the first `n` row lengths off a Young diagram with at most `n` rows recovers it. -/
+theorem ofRowLensFin_rowLen (μ : _root_.YoungDiagram) (hμ : μ.colLen 0 ≤ n) :
+    ofRowLensFin (fun i : Fin n => μ.rowLen i) (antitone_rowLen μ n) = μ := by
+  refine eq_of_rowLen_eq fun i => ?_
+  by_cases hi : i < n
+  · simpa using rowLen_ofRowLensFin (fun i : Fin n => μ.rowLen i) (antitone_rowLen μ n) ⟨i, hi⟩
+  · rw [rowLen_ofRowLensFin_of_le _ (antitone_rowLen μ n) (Nat.le_of_not_lt hi),
+      rowLen_eq_zero_of_colLen_le (hμ.trans (Nat.le_of_not_lt hi))]
+
+@[simp]
+theorem card_ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) :
+    (ofRowLensFin f hf).card = ∑ i, f i := by
+  rw [card_eq_sum_range_rowLen _ (colLen_zero_ofRowLensFin_le f hf),
+    ← Fin.sum_univ_eq_sum_range (fun i => (ofRowLensFin f hf).rowLen i) n]
+  exact Finset.sum_congr rfl fun i _ => rowLen_ofRowLensFin f hf i
+
+end YoungDiagram
+
+end TauCeti

--- a/TauCeti/Combinatorics/Young/OfRowLens.lean
+++ b/TauCeti/Combinatorics/Young/OfRowLens.lean
@@ -63,6 +63,7 @@ theorem rowLen_ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) (i : Fin n) :
     _root_.YoungDiagram.rowLen_ofRowLens (w := List.ofFn f) (hw := hf.sortedGE_ofFn) ⟨i, h⟩
 
 /-- The rows of `ofRowLensFin f hf` past the `n` prescribed ones are empty. -/
+@[simp]
 theorem rowLen_ofRowLensFin_eq_zero_of_le (f : Fin n → ℕ) (hf : Antitone f) {i : ℕ} (hi : n ≤ i) :
     (ofRowLensFin f hf).rowLen i = 0 := by
   by_contra h

--- a/TauCeti/Combinatorics/Young/OfRowLens.lean
+++ b/TauCeti/Combinatorics/Young/OfRowLens.lean
@@ -32,8 +32,8 @@ are matched against weight data for `GL n`.
 ## Main results
 
 * `TauCeti.YoungDiagram.rowLen_ofRowLensFin` and
-  `TauCeti.YoungDiagram.rowLen_ofRowLensFin_of_le`: the row lengths of `ofRowLensFin f hf` are
-  `f` on `Fin n` and `0` beyond it.
+  `TauCeti.YoungDiagram.rowLen_ofRowLensFin_eq_zero_of_le`: the row lengths of `ofRowLensFin f hf`
+  are `f` on `Fin n` and `0` beyond it.
 * `TauCeti.YoungDiagram.colLen_zero_ofRowLensFin_le` and
   `TauCeti.YoungDiagram.ofRowLensFin_rowLen`: `ofRowLensFin` lands in the diagrams with at most
   `n` rows, and is there inverse to reading off the first `n` row lengths.
@@ -46,46 +46,24 @@ namespace TauCeti
 
 namespace YoungDiagram
 
-open Finset
-
 variable {n : ℕ}
-
-/-- Two Young diagrams with the same row lengths are equal. -/
-theorem eq_of_rowLen_eq {μ ν : _root_.YoungDiagram} (h : ∀ i, μ.rowLen i = ν.rowLen i) :
-    μ = ν := by
-  ext c
-  obtain ⟨i, j⟩ := c
-  rw [_root_.YoungDiagram.mem_cells, _root_.YoungDiagram.mem_cells,
-    _root_.YoungDiagram.mem_iff_lt_rowLen, _root_.YoungDiagram.mem_iff_lt_rowLen, h]
-
-/-- The cells of a Young diagram, counted over any range of rows that contains all of them.  This
-is `TauCeti.YoungDiagram.sum_rowLens` with the range of summation chosen by hand instead of being
-the exact number of rows. -/
-theorem card_eq_sum_range_rowLen (μ : _root_.YoungDiagram) {N : ℕ} (hN : μ.colLen 0 ≤ N) :
-    μ.card = ∑ i ∈ range N, μ.rowLen i := by
-  rw [sum_range_rowLen_eq_card_filter_fst]
-  refine (congrArg Finset.card (Finset.filter_true_of_mem fun c hc => ?_)).symm
-  exact lt_of_lt_of_le ((_root_.YoungDiagram.mem_iff_lt_colLen.mp hc).trans_le
-    (μ.colLen_anti 0 c.snd c.snd.zero_le)) hN
-
-/-- A weakly decreasing family `f : Fin n → ℕ` is a weakly decreasing list of row lengths. -/
-private theorem sortedGE_ofFn {f : Fin n → ℕ} (hf : Antitone f) : (List.ofFn f).SortedGE :=
-  List.sortedGE_iff_pairwise.mpr (List.pairwise_ofFn.mpr fun _ _ hij => hf hij.le)
 
 /-- The Young diagram whose first `n` rows have the prescribed weakly decreasing lengths
 `f : Fin n → ℕ`, and which has no row beyond.  Unlike `YoungDiagram.ofRowLens`, the family `f`
 may take the value `0`; such an entry simply contributes an empty row. -/
 def ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) : _root_.YoungDiagram :=
-  _root_.YoungDiagram.ofRowLens (List.ofFn f) (sortedGE_ofFn hf)
+  _root_.YoungDiagram.ofRowLens (List.ofFn f) hf.sortedGE_ofFn
 
+/-- The rows of `ofRowLensFin f hf` indexed by `Fin n` have the prescribed lengths. -/
 @[simp]
 theorem rowLen_ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) (i : Fin n) :
     (ofRowLensFin f hf).rowLen i = f i := by
   have h : (i : ℕ) < (List.ofFn f).length := by simp
   simpa [ofRowLensFin] using
-    _root_.YoungDiagram.rowLen_ofRowLens (w := List.ofFn f) (hw := sortedGE_ofFn hf) ⟨i, h⟩
+    _root_.YoungDiagram.rowLen_ofRowLens (w := List.ofFn f) (hw := hf.sortedGE_ofFn) ⟨i, h⟩
 
-theorem rowLen_ofRowLensFin_of_le (f : Fin n → ℕ) (hf : Antitone f) {i : ℕ} (hi : n ≤ i) :
+/-- The rows of `ofRowLensFin f hf` past the `n` prescribed ones are empty. -/
+theorem rowLen_ofRowLensFin_eq_zero_of_le (f : Fin n → ℕ) (hf : Antitone f) {i : ℕ} (hi : n ≤ i) :
     (ofRowLensFin f hf).rowLen i = 0 := by
   by_contra h
   have hmem : ((i, 0) : ℕ × ℕ) ∈ ofRowLensFin f hf :=
@@ -94,27 +72,27 @@ theorem rowLen_ofRowLensFin_of_le (f : Fin n → ℕ) (hf : Antitone f) {i : ℕ
   simp only [List.length_ofFn] at hlt
   exact absurd hlt (Nat.not_lt.mpr hi)
 
+/-- `ofRowLensFin f hf` has at most `n` rows. -/
 theorem colLen_zero_ofRowLensFin_le (f : Fin n → ℕ) (hf : Antitone f) :
     (ofRowLensFin f hf).colLen 0 ≤ n := by
   by_contra h
   have hmem : ((n, 0) : ℕ × ℕ) ∈ ofRowLensFin f hf :=
     _root_.YoungDiagram.mem_iff_lt_colLen.mpr (Nat.lt_of_not_le h)
-  exact absurd (rowLen_ofRowLensFin_of_le f hf (le_refl n))
+  exact absurd (rowLen_ofRowLensFin_eq_zero_of_le f hf (le_refl n))
     (_root_.YoungDiagram.mem_iff_lt_rowLen.mp hmem).ne'
-
-/-- The first `n` row lengths of a Young diagram are weakly decreasing. -/
-theorem antitone_rowLen (μ : _root_.YoungDiagram) (n : ℕ) :
-    Antitone fun i : Fin n => μ.rowLen i := fun _ _ h => μ.rowLen_anti _ _ h
 
 /-- Reading the first `n` row lengths off a Young diagram with at most `n` rows recovers it. -/
 theorem ofRowLensFin_rowLen (μ : _root_.YoungDiagram) (hμ : μ.colLen 0 ≤ n) :
-    ofRowLensFin (fun i : Fin n => μ.rowLen i) (antitone_rowLen μ n) = μ := by
-  refine eq_of_rowLen_eq fun i => ?_
+    ofRowLensFin (fun i : Fin n => μ.rowLen i) (fun _ _ h => μ.rowLen_anti _ _ h) = μ := by
+  refine rowLen_injective (funext fun i => ?_)
   by_cases hi : i < n
-  · simpa using rowLen_ofRowLensFin (fun i : Fin n => μ.rowLen i) (antitone_rowLen μ n) ⟨i, hi⟩
-  · rw [rowLen_ofRowLensFin_of_le _ (antitone_rowLen μ n) (Nat.le_of_not_lt hi),
+  · simpa using rowLen_ofRowLensFin (fun i : Fin n => μ.rowLen i)
+      (fun _ _ h => μ.rowLen_anti _ _ h) ⟨i, hi⟩
+  · rw [rowLen_ofRowLensFin_eq_zero_of_le _ (fun _ _ h => μ.rowLen_anti _ _ h)
+        (Nat.le_of_not_lt hi),
       rowLen_eq_zero_of_colLen_le (hμ.trans (Nat.le_of_not_lt hi))]
 
+/-- `ofRowLensFin f hf` has `∑ i, f i` cells. -/
 @[simp]
 theorem card_ofRowLensFin (f : Fin n → ℕ) (hf : Antitone f) :
     (ofRowLensFin f hf).card = ∑ i, f i := by

--- a/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
@@ -1,0 +1,308 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Combinatorics.Young.OfRowLens
+
+/-!
+# Dominant weights for the general linear group
+
+The irreducible rational representations of `GL n` are indexed by the weakly decreasing integer
+sequences `λ₁ ≥ ⋯ ≥ λₙ`, the **dominant weights** of the diagonal torus.  This file builds that
+index type and its dictionary with Young diagrams, before any representation is attached to a
+weight: the combinatorics is exactly the bookkeeping that separates the *polynomial*
+representations from the general *rational* ones.
+
+Two facts organize the file.  First, the dominant weights with nonnegative entries — the
+`TauCeti.DominantWeight.IsPolynomial` ones — are precisely the Young diagrams with at most `n`
+rows, an equivalence `TauCeti.shapeEquivPolynomialWeight`.  Second, every dominant weight is a
+**determinant twist** of a polynomial one: writing `m = λₙ` for its last entry
+(`TauCeti.DominantWeight.detShift`) and subtracting it leaves a weight with nonnegative entries
+whose own last entry vanishes, so its Young diagram `TauCeti.DominantWeight.detShiftShape` has at
+most `n - 1` rows, and `λ` is recovered from that diagram by shifting back by `m`.  The vanishing
+last entry is what makes the pair `(m, μ)` unique: without the row bound the same `λ` is
+`μ + m·(1, …, 1)` for many pairs.  Downstream this is the statement that a rational irreducible
+is `det^m` tensored with a polynomial one.
+
+The last entry `λₙ` is read through the dedicated accessor `TauCeti.DominantWeight.detShift`,
+which is `0` for `n = 0`, so that the empty weight needs no special casing at the use sites.
+Being an accessor rather than a shift, it is compatible with `TauCeti.DominantWeight.shift` only
+for a nonempty weight (`TauCeti.DominantWeight.detShift_shift`).
+
+## Main definitions
+
+* `TauCeti.DominantWeight`: the weakly decreasing sequences `Fin n → ℤ`.
+* `TauCeti.DominantWeight.shift`: translating a weight by an integer multiple of `(1, …, 1)`.
+* `TauCeti.DominantWeight.detShift`: the last entry `λₙ`, the determinant-twist exponent.
+* `TauCeti.DominantWeight.IsPolynomial`: having nonnegative entries.
+* `TauCeti.DominantWeight.shape` and `TauCeti.weightOfShape`: the two directions of the
+  dictionary between weights and Young diagrams.
+* `TauCeti.DominantWeight.detShiftShape`: the Young diagram of the polynomial part `λ - λₙ`.
+
+## Main results
+
+* `TauCeti.DominantWeight.isPolynomial_iff_zero_le_detShift`: a weight is polynomial as soon as
+  its last entry is nonnegative.
+* `TauCeti.shapeEquivPolynomialWeight`: the Young diagrams with at most `n` rows are the
+  polynomial dominant weights of `GL n`.
+* `TauCeti.DominantWeight.shift_weightOfShape_detShiftShape`: the determinant twist
+  `λ = μ + λₙ·(1, …, 1)` with `μ = detShiftShape λ`, together with
+  `TauCeti.DominantWeight.colLen_zero_detShiftShape_le`, which bounds `μ` by `n - 1` rows.
+* `TauCeti.DominantWeight.eq_detShift_and_eq_detShiftShape`: that decomposition is the only one
+  whose diagram has at most `n - 1` rows.
+
+## References
+
+* [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
+  Layer 3, “Dominant weights”, and Layer 4, “The rational character is Laurent”.
+* W. Fulton and J. Harris, *Representation Theory: A First Course* (1991), Lecture 15.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A **dominant weight** for `GL n`: a weakly decreasing sequence `λ₁ ≥ ⋯ ≥ λₙ` of integers.
+These index the irreducible rational representations of `GL n`; the ones with nonnegative entries
+(`TauCeti.DominantWeight.IsPolynomial`) index the polynomial ones. -/
+abbrev DominantWeight (n : ℕ) : Type := {l : Fin n → ℤ // Antitone l}
+
+namespace DominantWeight
+
+variable {n : ℕ}
+
+theorem antitone (l : DominantWeight n) : Antitone l.1 := l.2
+
+/-- Translating a dominant weight by `m·(1, …, 1)`.  On representations this is tensoring with
+the `m`-th power of the determinant. -/
+@[expose]
+def shift (l : DominantWeight n) (m : ℤ) : DominantWeight n :=
+  ⟨fun i => l.1 i + m, fun _ _ h => by simpa using l.antitone h⟩
+
+@[simp]
+theorem shift_apply (l : DominantWeight n) (m : ℤ) (i : Fin n) : (l.shift m).1 i = l.1 i + m :=
+  rfl
+
+@[simp]
+theorem shift_zero (l : DominantWeight n) : l.shift 0 = l := by
+  ext i; simp
+
+@[simp]
+theorem shift_shift (l : DominantWeight n) (m m' : ℤ) :
+    (l.shift m).shift m' = l.shift (m + m') := by
+  ext i; simp [add_assoc]
+
+/-- The **determinant-twist exponent** of a dominant weight: its last entry `λₙ`, and `0` for the
+empty weight. -/
+@[expose]
+def detShift : {n : ℕ} → DominantWeight n → ℤ
+  | 0, _ => 0
+  | _ + 1, l => l.1 (Fin.last _)
+
+@[simp]
+theorem detShift_of_isEmpty (l : DominantWeight 0) : l.detShift = 0 := rfl
+
+@[simp]
+theorem detShift_succ (l : DominantWeight (n + 1)) : l.detShift = l.1 (Fin.last n) := rfl
+
+/-- The determinant-twist exponent is the smallest entry of a dominant weight. -/
+theorem detShift_le (l : DominantWeight n) (i : Fin n) : l.detShift ≤ l.1 i := by
+  match n, l, i with
+  | 0, _, i => exact i.elim0
+  | _ + 1, l, i => exact l.antitone (Fin.le_last i)
+
+/-- Shifting a nonempty dominant weight shifts its last entry.  The hypothesis is not decoration:
+for `n = 0` the accessor is `0` by convention and the identity fails. -/
+@[simp]
+theorem detShift_shift (l : DominantWeight (n + 1)) (m : ℤ) :
+    (l.shift m).detShift = l.detShift + m := by
+  simp
+
+/-- A dominant weight is **polynomial** when all its entries are nonnegative.  These are the
+weights of the representations occurring in tensor powers of the standard representation, as
+opposed to the general rational ones, which need a negative power of the determinant. -/
+@[expose]
+def IsPolynomial (l : DominantWeight n) : Prop := ∀ i, 0 ≤ l.1 i
+
+/-- Since a dominant weight decreases, only its last entry has to be tested for polynomiality. -/
+theorem isPolynomial_iff_zero_le_detShift (l : DominantWeight n) :
+    l.IsPolynomial ↔ 0 ≤ l.detShift := by
+  refine ⟨fun h => ?_, fun h i => h.trans (l.detShift_le i)⟩
+  match n, l, h with
+  | 0, _, _ => simp
+  | _ + 1, l, h => exact h _
+
+/-- Subtracting its last entry makes any dominant weight polynomial. -/
+theorem isPolynomial_shift_neg_detShift (l : DominantWeight n) :
+    (l.shift (-l.detShift)).IsPolynomial := fun i => by
+  have h := l.detShift_le i
+  simp only [shift_apply]
+  omega
+
+/-- The entries of a dominant weight, truncated to `ℕ`, are still weakly decreasing. -/
+theorem antitone_toNat (l : DominantWeight n) : Antitone fun i => (l.1 i).toNat :=
+  fun _ _ h => Int.toNat_le_toNat (l.antitone h)
+
+/-- The Young diagram of a dominant weight: its `i`-th row has length `λᵢ`.  Negative entries are
+truncated to `0`, so this reads off the intended diagram exactly on the polynomial weights, where
+`TauCeti.DominantWeight.natCast_rowLen_shape` recovers the entries. -/
+@[expose]
+def shape (l : DominantWeight n) : YoungDiagram :=
+  YoungDiagram.ofRowLensFin (fun i => (l.1 i).toNat) l.antitone_toNat
+
+@[simp]
+theorem rowLen_shape (l : DominantWeight n) (i : Fin n) : l.shape.rowLen i = (l.1 i).toNat :=
+  YoungDiagram.rowLen_ofRowLensFin _ _ i
+
+theorem rowLen_shape_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) : l.shape.rowLen i = 0 :=
+  YoungDiagram.rowLen_ofRowLensFin_of_le _ _ hi
+
+@[simp]
+theorem colLen_zero_shape_le (l : DominantWeight n) : l.shape.colLen 0 ≤ n :=
+  YoungDiagram.colLen_zero_ofRowLensFin_le _ _
+
+/-- On a polynomial weight the row lengths of its Young diagram are the entries themselves. -/
+theorem natCast_rowLen_shape {l : DominantWeight n} (hl : l.IsPolynomial) (i : Fin n) :
+    (l.shape.rowLen i : ℤ) = l.1 i := by
+  rw [rowLen_shape, Int.toNat_of_nonneg (hl i)]
+
+/-- The Young diagram of a polynomial weight has `∑ λᵢ` cells. -/
+theorem natCast_card_shape {l : DominantWeight n} (hl : l.IsPolynomial) :
+    (l.shape.card : ℤ) = ∑ i, l.1 i := by
+  have hcard : l.shape.card = ∑ i, (l.1 i).toNat := YoungDiagram.card_ofRowLensFin _ _
+  rw [hcard]
+  push_cast
+  exact Finset.sum_congr rfl fun i _ => Int.toNat_of_nonneg (hl i)
+
+end DominantWeight
+
+/-- The dominant weight read off the first `n` row lengths of a Young diagram.  It is the weight
+intended by `μ` exactly when `μ` has at most `n` rows; a taller diagram is silently truncated. -/
+@[expose]
+def weightOfShape (n : ℕ) (μ : YoungDiagram) : DominantWeight n :=
+  ⟨fun i => (μ.rowLen i : ℤ), fun _ _ h => Int.ofNat_le.mpr (YoungDiagram.antitone_rowLen μ n h)⟩
+
+@[simp]
+theorem weightOfShape_apply (n : ℕ) (μ : YoungDiagram) (i : Fin n) :
+    (weightOfShape n μ).1 i = (μ.rowLen i : ℤ) :=
+  rfl
+
+theorem isPolynomial_weightOfShape (n : ℕ) (μ : YoungDiagram) :
+    (weightOfShape n μ).IsPolynomial := fun _ => Int.natCast_nonneg _
+
+@[simp]
+theorem shape_weightOfShape {n : ℕ} {μ : YoungDiagram} (hμ : μ.colLen 0 ≤ n) :
+    (weightOfShape n μ).shape = μ := by
+  refine YoungDiagram.eq_of_rowLen_eq fun i => ?_
+  by_cases hi : i < n
+  · simpa using DominantWeight.rowLen_shape (weightOfShape n μ) ⟨i, hi⟩
+  · rw [DominantWeight.rowLen_shape_of_le _ (Nat.le_of_not_lt hi),
+      YoungDiagram.rowLen_eq_zero_of_colLen_le (hμ.trans (Nat.le_of_not_lt hi))]
+
+@[simp]
+theorem weightOfShape_shape {n : ℕ} {l : DominantWeight n} (hl : l.IsPolynomial) :
+    weightOfShape n l.shape = l := by
+  ext i
+  rw [weightOfShape_apply, DominantWeight.natCast_rowLen_shape hl]
+
+/-- **The polynomial weights are the bounded shapes**: the Young diagrams with at most `n` rows
+are exactly the dominant weights of `GL n` with nonnegative entries. -/
+@[expose]
+def shapeEquivPolynomialWeight (n : ℕ) :
+    {μ : YoungDiagram // μ.colLen 0 ≤ n} ≃ {l : DominantWeight n // l.IsPolynomial} where
+  toFun μ := ⟨weightOfShape n μ.1, isPolynomial_weightOfShape n μ.1⟩
+  invFun l := ⟨l.1.shape, DominantWeight.colLen_zero_shape_le l.1⟩
+  left_inv μ := Subtype.ext (shape_weightOfShape μ.2)
+  right_inv l := Subtype.ext (weightOfShape_shape l.2)
+
+@[simp]
+theorem shapeEquivPolynomialWeight_apply_coe (n : ℕ) (μ : {μ : YoungDiagram // μ.colLen 0 ≤ n}) :
+    (shapeEquivPolynomialWeight n μ).1 = weightOfShape n μ.1 :=
+  rfl
+
+@[simp]
+theorem shapeEquivPolynomialWeight_symm_apply_coe (n : ℕ)
+    (l : {l : DominantWeight n // l.IsPolynomial}) :
+    ((shapeEquivPolynomialWeight n).symm l).1 = l.1.shape :=
+  rfl
+
+namespace DominantWeight
+
+variable {n : ℕ}
+
+/-- The Young diagram of the **polynomial part** `λ - λₙ` of a dominant weight: its `i`-th row has
+length `λᵢ - λₙ`.  Together with `TauCeti.DominantWeight.detShift` it presents `λ` as a
+determinant twist of a polynomial weight. -/
+@[expose]
+def detShiftShape (l : DominantWeight n) : YoungDiagram := (l.shift (-l.detShift)).shape
+
+@[simp]
+theorem rowLen_detShiftShape (l : DominantWeight n) (i : Fin n) :
+    l.detShiftShape.rowLen i = (l.1 i - l.detShift).toNat := by
+  rw [detShiftShape, rowLen_shape, shift_apply, ← sub_eq_add_neg]
+
+theorem rowLen_detShiftShape_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
+    l.detShiftShape.rowLen i = 0 :=
+  rowLen_shape_of_le _ hi
+
+/-- The polynomial part of a dominant weight recovers it after shifting back by `λₙ`. -/
+theorem natCast_rowLen_detShiftShape_add_detShift (l : DominantWeight n) (i : Fin n) :
+    (l.detShiftShape.rowLen i : ℤ) + l.detShift = l.1 i := by
+  have h := l.detShift_le i
+  rw [rowLen_detShiftShape]
+  omega
+
+/-- The weight of the polynomial part of `λ` is `λ` itself, shifted down by `λₙ`. -/
+@[simp]
+theorem weightOfShape_detShiftShape (l : DominantWeight n) :
+    weightOfShape n l.detShiftShape = l.shift (-l.detShift) :=
+  weightOfShape_shape (isPolynomial_shift_neg_detShift l)
+
+/-- **The determinant twist**: every dominant weight is the weight of a Young diagram, shifted by
+its last entry. -/
+theorem shift_weightOfShape_detShiftShape (l : DominantWeight n) :
+    (weightOfShape n l.detShiftShape).shift l.detShift = l := by
+  rw [weightOfShape_detShiftShape, shift_shift, neg_add_cancel, shift_zero]
+
+/-- The polynomial part of a dominant weight for `GL (n + 1)` has at most `n` rows: its last
+entry is `λₙ₊₁ - λₙ₊₁ = 0`.  This is the row bound that makes the determinant twist unique. -/
+theorem colLen_zero_detShiftShape_le (l : DominantWeight (n + 1)) :
+    l.detShiftShape.colLen 0 ≤ n := by
+  by_contra h
+  have hmem : ((n, 0) : ℕ × ℕ) ∈ l.detShiftShape :=
+    YoungDiagram.mem_iff_lt_colLen.mpr (Nat.lt_of_not_le h)
+  have hpos : 0 < l.detShiftShape.rowLen n := YoungDiagram.mem_iff_lt_rowLen.mp hmem
+  have hzero : l.detShiftShape.rowLen n = (l.1 (Fin.last n) - l.detShift).toNat :=
+    rowLen_detShiftShape l (Fin.last n)
+  rw [detShift_succ, sub_self, Int.toNat_zero] at hzero
+  omega
+
+/-- **Uniqueness of the determinant twist**: a dominant weight for `GL (n + 1)` is
+`μ + m·(1, …, 1)` for exactly one integer `m` and one Young diagram `μ` with at most `n` rows,
+namely `m = λₙ₊₁` and `μ` its polynomial part.  The row bound is essential: dropping it lets `μ`
+and `m` trade a constant against each other. -/
+theorem eq_detShift_and_eq_detShiftShape (l : DominantWeight (n + 1)) {μ : YoungDiagram}
+    (hμ : μ.colLen 0 ≤ n) {m : ℤ} (hm : ∀ i : Fin (n + 1), (μ.rowLen i : ℤ) + m = l.1 i) :
+    m = l.detShift ∧ μ = l.detShiftShape := by
+  have hm' : m = l.detShift := by
+    have h := hm (Fin.last n)
+    have hlast : μ.rowLen ((Fin.last n : Fin (n + 1)) : ℕ) = 0 :=
+      YoungDiagram.rowLen_eq_zero_of_colLen_le hμ
+    rw [hlast, Nat.cast_zero, zero_add] at h
+    rw [detShift_succ, ← h]
+  refine ⟨hm', YoungDiagram.eq_of_rowLen_eq fun i => ?_⟩
+  by_cases hi : i < n + 1
+  · have h : (μ.rowLen i : ℤ) + m = l.1 ⟨i, hi⟩ := hm ⟨i, hi⟩
+    have h' : l.detShiftShape.rowLen i = (l.1 ⟨i, hi⟩ - l.detShift).toNat :=
+      rowLen_detShiftShape l ⟨i, hi⟩
+    rw [hm'] at h
+    omega
+  · have hni : n ≤ i := Nat.le_of_succ_le (Nat.le_of_not_lt hi)
+    rw [rowLen_detShiftShape_of_le _ (Nat.le_of_not_lt hi),
+      YoungDiagram.rowLen_eq_zero_of_colLen_le (hμ.trans hni)]
+
+end DominantWeight
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
@@ -102,7 +102,7 @@ def detShift : {n : ℕ} → DominantWeight n → ℤ
   | _ + 1, l => l.1 (Fin.last _)
 
 @[simp]
-theorem detShift_of_isEmpty (l : DominantWeight 0) : l.detShift = 0 := rfl
+theorem detShift_eq_zero_of_isEmpty (l : DominantWeight 0) : l.detShift = 0 := rfl
 
 @[simp]
 theorem detShift_succ (l : DominantWeight (n + 1)) : l.detShift = l.1 (Fin.last n) := rfl
@@ -123,10 +123,12 @@ theorem detShift_shift (l : DominantWeight (n + 1)) (m : ℤ) :
 /-- A dominant weight is **polynomial** when all its entries are nonnegative.  These are the
 weights of the representations occurring in tensor powers of the standard representation, as
 opposed to the general rational ones, which need a negative power of the determinant. -/
-@[expose]
 def IsPolynomial (l : DominantWeight n) : Prop := ∀ i, 0 ≤ l.1 i
 
-/-- Since a dominant weight decreases, only its last entry has to be tested for polynomiality. -/
+/-- Since a dominant weight decreases, only its last entry has to be tested for polynomiality.
+This is not a `simp` lemma: rewriting `IsPolynomial` away would put the `simp` lemmas whose
+statement or hypothesis mentions it — `TauCeti.isPolynomial_weightOfShape` and
+`TauCeti.weightOfShape_shape` — out of `simp` normal form. -/
 theorem isPolynomial_iff_zero_le_detShift (l : DominantWeight n) :
     l.IsPolynomial ↔ 0 ≤ l.detShift := by
   refine ⟨fun h => ?_, fun h i => h.trans (l.detShift_le i)⟩
@@ -148,7 +150,6 @@ theorem antitone_toNat (l : DominantWeight n) : Antitone fun i => (l.1 i).toNat 
 /-- The Young diagram of a dominant weight: its `i`-th row has length `λᵢ`.  Negative entries are
 truncated to `0`, so this reads off the intended diagram exactly on the polynomial weights, where
 `TauCeti.DominantWeight.natCast_rowLen_shape` recovers the entries. -/
-@[expose]
 def shape (l : DominantWeight n) : YoungDiagram :=
   YoungDiagram.ofRowLensFin (fun i => (l.1 i).toNat) l.antitone_toNat
 
@@ -156,8 +157,9 @@ def shape (l : DominantWeight n) : YoungDiagram :=
 theorem rowLen_shape (l : DominantWeight n) (i : Fin n) : l.shape.rowLen i = (l.1 i).toNat :=
   YoungDiagram.rowLen_ofRowLensFin _ _ i
 
-theorem rowLen_shape_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) : l.shape.rowLen i = 0 :=
-  YoungDiagram.rowLen_ofRowLensFin_of_le _ _ hi
+theorem rowLen_shape_eq_zero_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
+    l.shape.rowLen i = 0 :=
+  YoungDiagram.rowLen_ofRowLensFin_eq_zero_of_le _ _ hi
 
 @[simp]
 theorem colLen_zero_shape_le (l : DominantWeight n) : l.shape.colLen 0 ≤ n :=
@@ -182,23 +184,24 @@ end DominantWeight
 intended by `μ` exactly when `μ` has at most `n` rows; a taller diagram is silently truncated. -/
 @[expose]
 def weightOfShape (n : ℕ) (μ : YoungDiagram) : DominantWeight n :=
-  ⟨fun i => (μ.rowLen i : ℤ), fun _ _ h => Int.ofNat_le.mpr (YoungDiagram.antitone_rowLen μ n h)⟩
+  ⟨fun i => (μ.rowLen i : ℤ), fun _ _ h => Int.ofNat_le.mpr (μ.rowLen_anti _ _ h)⟩
 
 @[simp]
 theorem weightOfShape_apply (n : ℕ) (μ : YoungDiagram) (i : Fin n) :
     (weightOfShape n μ).1 i = (μ.rowLen i : ℤ) :=
   rfl
 
+@[simp]
 theorem isPolynomial_weightOfShape (n : ℕ) (μ : YoungDiagram) :
     (weightOfShape n μ).IsPolynomial := fun _ => Int.natCast_nonneg _
 
 @[simp]
 theorem shape_weightOfShape {n : ℕ} {μ : YoungDiagram} (hμ : μ.colLen 0 ≤ n) :
     (weightOfShape n μ).shape = μ := by
-  refine YoungDiagram.eq_of_rowLen_eq fun i => ?_
+  refine YoungDiagram.rowLen_injective (funext fun i => ?_)
   by_cases hi : i < n
   · simpa using DominantWeight.rowLen_shape (weightOfShape n μ) ⟨i, hi⟩
-  · rw [DominantWeight.rowLen_shape_of_le _ (Nat.le_of_not_lt hi),
+  · rw [DominantWeight.rowLen_shape_eq_zero_of_le _ (Nat.le_of_not_lt hi),
       YoungDiagram.rowLen_eq_zero_of_colLen_le (hμ.trans (Nat.le_of_not_lt hi))]
 
 @[simp]
@@ -235,7 +238,6 @@ variable {n : ℕ}
 /-- The Young diagram of the **polynomial part** `λ - λₙ` of a dominant weight: its `i`-th row has
 length `λᵢ - λₙ`.  Together with `TauCeti.DominantWeight.detShift` it presents `λ` as a
 determinant twist of a polynomial weight. -/
-@[expose]
 def detShiftShape (l : DominantWeight n) : YoungDiagram := (l.shift (-l.detShift)).shape
 
 @[simp]
@@ -243,9 +245,9 @@ theorem rowLen_detShiftShape (l : DominantWeight n) (i : Fin n) :
     l.detShiftShape.rowLen i = (l.1 i - l.detShift).toNat := by
   rw [detShiftShape, rowLen_shape, shift_apply, ← sub_eq_add_neg]
 
-theorem rowLen_detShiftShape_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
+theorem rowLen_detShiftShape_eq_zero_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
     l.detShiftShape.rowLen i = 0 :=
-  rowLen_shape_of_le _ hi
+  rowLen_shape_eq_zero_of_le _ hi
 
 /-- The polynomial part of a dominant weight recovers it after shifting back by `λₙ`. -/
 theorem natCast_rowLen_detShiftShape_add_detShift (l : DominantWeight n) (i : Fin n) :
@@ -292,7 +294,7 @@ theorem eq_detShift_and_eq_detShiftShape (l : DominantWeight (n + 1)) {μ : Youn
       YoungDiagram.rowLen_eq_zero_of_colLen_le hμ
     rw [hlast, Nat.cast_zero, zero_add] at h
     rw [detShift_succ, ← h]
-  refine ⟨hm', YoungDiagram.eq_of_rowLen_eq fun i => ?_⟩
+  refine ⟨hm', YoungDiagram.rowLen_injective (funext fun i => ?_)⟩
   by_cases hi : i < n + 1
   · have h : (μ.rowLen i : ℤ) + m = l.1 ⟨i, hi⟩ := hm ⟨i, hi⟩
     have h' : l.detShiftShape.rowLen i = (l.1 ⟨i, hi⟩ - l.detShift).toNat :=
@@ -300,7 +302,7 @@ theorem eq_detShift_and_eq_detShiftShape (l : DominantWeight (n + 1)) {μ : Youn
     rw [hm'] at h
     omega
   · have hni : n ≤ i := Nat.le_of_succ_le (Nat.le_of_not_lt hi)
-    rw [rowLen_detShiftShape_of_le _ (Nat.le_of_not_lt hi),
+    rw [rowLen_detShiftShape_eq_zero_of_le _ (Nat.le_of_not_lt hi),
       YoungDiagram.rowLen_eq_zero_of_colLen_le (hμ.trans hni)]
 
 end DominantWeight

--- a/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
@@ -199,11 +199,9 @@ theorem isPolynomial_weightOfShape (n : ℕ) (μ : YoungDiagram) :
 @[simp]
 theorem shape_weightOfShape {n : ℕ} {μ : YoungDiagram} (hμ : μ.colLen 0 ≤ n) :
     (weightOfShape n μ).shape = μ := by
-  refine YoungDiagram.rowLen_injective (funext fun i => ?_)
-  by_cases hi : i < n
-  · simpa using DominantWeight.rowLen_shape (weightOfShape n μ) ⟨i, hi⟩
-  · rw [DominantWeight.rowLen_shape_eq_zero_of_le _ (Nat.le_of_not_lt hi),
-      YoungDiagram.rowLen_eq_zero_of_colLen_le (hμ.trans (Nat.le_of_not_lt hi))]
+  rw [DominantWeight.shape]
+  simp only [weightOfShape_apply, Int.toNat_natCast]
+  exact YoungDiagram.ofRowLensFin_rowLen μ hμ
 
 @[simp]
 theorem weightOfShape_shape {n : ℕ} {l : DominantWeight n} (hl : l.IsPolynomial) :

--- a/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/DominantWeight.lean
@@ -144,19 +144,20 @@ theorem isPolynomial_shift_neg_detShift (l : DominantWeight n) :
   omega
 
 /-- The entries of a dominant weight, truncated to `ℕ`, are still weakly decreasing. -/
-theorem antitone_toNat (l : DominantWeight n) : Antitone fun i => (l.1 i).toNat :=
+theorem toNat_antitone (l : DominantWeight n) : Antitone fun i => (l.1 i).toNat :=
   fun _ _ h => Int.toNat_le_toNat (l.antitone h)
 
 /-- The Young diagram of a dominant weight: its `i`-th row has length `λᵢ`.  Negative entries are
 truncated to `0`, so this reads off the intended diagram exactly on the polynomial weights, where
 `TauCeti.DominantWeight.natCast_rowLen_shape` recovers the entries. -/
 def shape (l : DominantWeight n) : YoungDiagram :=
-  YoungDiagram.ofRowLensFin (fun i => (l.1 i).toNat) l.antitone_toNat
+  YoungDiagram.ofRowLensFin (fun i => (l.1 i).toNat) l.toNat_antitone
 
 @[simp]
 theorem rowLen_shape (l : DominantWeight n) (i : Fin n) : l.shape.rowLen i = (l.1 i).toNat :=
   YoungDiagram.rowLen_ofRowLensFin _ _ i
 
+@[simp]
 theorem rowLen_shape_eq_zero_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
     l.shape.rowLen i = 0 :=
   YoungDiagram.rowLen_ofRowLensFin_eq_zero_of_le _ _ hi
@@ -245,6 +246,7 @@ theorem rowLen_detShiftShape (l : DominantWeight n) (i : Fin n) :
     l.detShiftShape.rowLen i = (l.1 i - l.detShift).toNat := by
   rw [detShiftShape, rowLen_shape, shift_apply, ← sub_eq_add_neg]
 
+@[simp]
 theorem rowLen_detShiftShape_eq_zero_of_le (l : DominantWeight n) {i : ℕ} (hi : n ≤ i) :
     l.detShiftShape.rowLen i = 0 :=
   rowLen_shape_eq_zero_of_le _ hi


### PR DESCRIPTION
This PR builds the dominant-weight index type for `GL n` and its dictionary with Young diagrams, the combinatorial layer that sits under the highest-weight classification. `TauCeti.DominantWeight n` is the type of weakly decreasing sequences `λ₁ ≥ ⋯ ≥ λₙ` of integers, with the translation action `shift`, the accessor `detShift` for the last entry `λₙ`, and the predicate `IsPolynomial` for nonnegative entries. Two theorems organise the file. The polynomial weights are exactly the Young diagrams with at most `n` rows, an explicit equivalence `shapeEquivPolynomialWeight`. And every dominant weight is a determinant twist of a polynomial one: subtracting `λₙ` leaves a weight with nonnegative entries whose own last entry vanishes, so its Young diagram `detShiftShape` has at most `n - 1` rows (`colLen_zero_detShiftShape_le`) and `λ` is recovered from it by shifting back (`shift_weightOfShape_detShiftShape`); `eq_detShift_and_eq_detShiftShape` shows that pair is the only one with that row bound, which is where the bound earns its keep — without it the same `λ` is `μ + m·(1, …, 1)` for many pairs. Downstream this is the statement that a rational irreducible of `GL n` is `det^m` tensored with a polynomial one.

The Young-diagram half is factored into its own file rather than inlined. Mathlib's `YoungDiagram.ofRowLens` is indexed by a `List ℕ` and is inverse to `rowLens` only after the positive entries are singled out, since `rowLens` never records an empty row. `TauCeti.YoungDiagram.ofRowLensFin` takes a weakly decreasing `f : Fin n → ℕ`, which is allowed to end in zeros, and `ofRowLensFin_rowLen` makes reading the first `n` row lengths back off an honest inverse on the diagrams with at most `n` rows; `card_ofRowLensFin` counts its cells as `∑ i, f i`. Alongside it, `TauCeti/Combinatorics/Young/Diagram.lean` gains `rowLen_injective`, a Young diagram being determined by its row lengths, and `card_eq_sum_range_rowLen`, the range-of-summation variant of the existing `TauCeti.YoungDiagram.sum_rowLens`, which is now derived from it.

This advances `TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md`, Layer 3 ("Dominant weights": `DominantWeight n`, the weakly decreasing `λ : Fin n → ℤ`, "the subset with `λ n ≥ 0` corresponds to `YoungDiagram`s of at most `n` rows (polynomial representations)", and `weightOfShape`) together with the `DominantWeight.detShift` and `DominantWeight.detShiftShape` targets of Layer 4 ("The rational character is Laurent"). The names and the `abbrev` shape of `DominantWeight` follow that roadmap's `Suggested.lean`. Nothing here attaches a representation to a weight; that is the rest of Layer 3, and this is the index-set prerequisite it needs. No Mathlib source was vendored; `YoungDiagram`, `rowLen`/`colLen`, `ofRowLens` and the `List.ofFn`/`SortedGE` API are consumed from the pinned Mathlib. Verified locally: `lake build` and `lake exe axioms` are green (all declarations within `propext`, `Classical.choice`, `Quot.sound`), as are `lake exe module-system` and `scripts/lint-env.sh`.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"dominantweight"}-->

🤖 Prepared with Claude Code

