### PR TITLE
refactor(Exchangeability): extract measurable_tailFamily_blockAverage

### DIFF
--- a/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
+++ b/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
@@ -66,17 +66,14 @@ and only `r ≤ k j` is used. -/
 private theorem measurable_tailFamily_blockAverage {X : ℕ → Ω → α} {f : α → ℝ}
     (hf : Measurable f) {r n : ℕ} {k : Fin n → ℕ} (hk : ∀ j, r ≤ k j) :
     Measurable[tailFamily X r] (blockAverage (fun i ω => f (X i ω)) k) := by
-  rw [blockAverage_eq_sum]
   have hterm : ∀ j : Fin n,
       Measurable[tailFamily X r] fun ω => f (X (k j) ω) := fun j =>
     hf.comp (measurable_tailFamily_of_le (hk j))
-  refine Measurable.const_smul ?_ ((n : ℝ)⁻¹)
-  have hsum : (∑ j : Fin n, fun ω => f (X (k j) ω))
-      = fun ω => ∑ j : Fin n, f (X (k j) ω) := by
-    funext ω
-    simp [Finset.sum_apply]
-  rw [hsum]
-  exact Finset.measurable_sum Finset.univ fun j _ => hterm j
+  have happly : (blockAverage (fun i ω => f (X i ω)) k)
+      = fun ω => (n : ℝ)⁻¹ * ∑ j : Fin n, f (X (k j) ω) :=
+    funext fun ω => blockAverage_apply _ _
+  rw [happly]
+  exact (Finset.measurable_fun_sum Finset.univ fun j _ => hterm j).const_mul _
 
 /-- **The Cesàro limit lives on the tail.** For a measurable observable `f` whose composite with a
 single coordinate is square-integrable, the common `L¹` limit of the fixed-start Cesàro windows

--- a/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
+++ b/TauCeti/Probability/Exchangeability/L2/TailMeasurability.lean
@@ -56,6 +56,28 @@ namespace Probability
 
 variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
 
+omit [MeasurableSpace Ω] in
+/-- **A block average over tail indices is tail-measurable.** If every index of the family `k` is at
+least `r`, each coordinate `f ∘ X (k j)` is `tailFamily X r`-measurable, hence so is their average.
+Only measurability of `f` is needed: no measure, and no contractability of `X`.
+
+The indices need not be consecutive — `blockAverage` averages over an arbitrary `k : Fin n → ℕ`,
+and only `r ≤ k j` is used. -/
+private theorem measurable_tailFamily_blockAverage {X : ℕ → Ω → α} {f : α → ℝ}
+    (hf : Measurable f) {r n : ℕ} {k : Fin n → ℕ} (hk : ∀ j, r ≤ k j) :
+    Measurable[tailFamily X r] (blockAverage (fun i ω => f (X i ω)) k) := by
+  rw [blockAverage_eq_sum]
+  have hterm : ∀ j : Fin n,
+      Measurable[tailFamily X r] fun ω => f (X (k j) ω) := fun j =>
+    hf.comp (measurable_tailFamily_of_le (hk j))
+  refine Measurable.const_smul ?_ ((n : ℝ)⁻¹)
+  have hsum : (∑ j : Fin n, fun ω => f (X (k j) ω))
+      = fun ω => ∑ j : Fin n, f (X (k j) ω) := by
+    funext ω
+    simp [Finset.sum_apply]
+  rw [hsum]
+  exact Finset.measurable_sum Finset.univ fun j _ => hterm j
+
 /-- **The Cesàro limit lives on the tail.** For a measurable observable `f` whose composite with a
 single coordinate is square-integrable, the common `L¹` limit of the fixed-start Cesàro windows
 supplied by `weighted_sums_converge_L1_of_memLp` has a **`tailProcess X`-measurable**
@@ -79,20 +101,6 @@ theorem Contractable.exists_tailProcess_measurable_cesaro_limit_of_memLp {μ : M
   have hY_L2 : ∀ i : ℕ, MemLp (fun ω => f (X i ω)) 2 μ := fun i =>
     (hY.identDistrib_coord (hf.comp_aemeasurable (hX_ae 0))
       (hf.comp_aemeasurable (hX_ae i))).memLp_snd hf_L2
-  have hg_meas : ∀ r m : ℕ, Measurable[tailFamily X r]
-      (blockAverage (fun i ω => f (X i ω)) (fun j : Fin (m + 1) => r + j)) := by
-    intro r m
-    rw [blockAverage_eq_sum]
-    have hterm : ∀ j : Fin (m + 1),
-        Measurable[tailFamily X r] fun ω => f (X (r + (j : ℕ)) ω) := fun j =>
-      hf.comp (measurable_tailFamily_of_le (Nat.le_add_right r (j : ℕ)))
-    refine Measurable.const_smul ?_ (((m + 1 : ℕ) : ℝ)⁻¹)
-    have hsum : (∑ j : Fin (m + 1), fun ω => f (X (r + (j : ℕ)) ω))
-        = fun ω => ∑ j : Fin (m + 1), f (X (r + (j : ℕ)) ω) := by
-      funext ω
-      simp [Finset.sum_apply]
-    rw [hsum]
-    exact Finset.measurable_sum Finset.univ fun j _ => hterm j
   have hg_int : ∀ r m : ℕ, Integrable
       (blockAverage (fun i ω => f (X i ω)) (fun j : Fin (m + 1) => r + j)) μ := fun r m =>
     MemLp.integrable one_le_two
@@ -119,7 +127,8 @@ theorem Contractable.exists_tailProcess_measurable_cesaro_limit_of_memLp {μ : M
         (fun m => (hg_int r m).aestronglyMeasurable) ha₀_int.aestronglyMeasurable hL1
     obtain ⟨ns, -, hae⟩ := hmeasure.exists_seq_tendsto_ae
     exact TauCeti.MeasureTheory.aestronglyMeasurable_of_tendsto_ae' (m := tailFamily X r)
-      (fun k => ((hg_meas r (ns k)).stronglyMeasurable).aestronglyMeasurable) hae
+      (fun k => (measurable_tailFamily_blockAverage hf
+        fun j => Nat.le_add_right r (j : ℕ)).stronglyMeasurable.aestronglyMeasurable) hae
   have hiInf := TauCeti.MeasureTheory.aestronglyMeasurable_iInf_of_antitone
     (tailFamily_antitone X) a₀ haes
   rw [← tailProcess_eq_iInf_tailFamily] at hiInf


### PR DESCRIPTION
`Contractable.exists_tailProcess_measurable_cesaro_limit_of_memLp` had a
**59-line body**, 14 lines of which were a single `have` proving that a block
average over the window `r, r + 1, …, r + m` is `tailFamily X r`-measurable.

That fact mentions **none** of the theorem's other machinery — not the measure
`μ`, not contractability of `X`, not square-integrability of `f ∘ X 0`. It was
used exactly once, so it is now a named lemma above the theorem:

```lean
omit [MeasurableSpace Ω] in
private theorem measurable_tailFamily_blockAverage {X : ℕ → Ω → α} {f : α → ℝ}
    (hf : Measurable f) {r n : ℕ} {k : Fin n → ℕ} (hk : ∀ j, r ≤ k j) :
    Measurable[tailFamily X r] (blockAverage (fun i ω => f (X i ω)) k)
```

Two hypotheses that looked necessary are not:

* **The window need not be consecutive.** `blockAverage` averages over an
  arbitrary `k : Fin n → ℕ`, and the proof only ever uses `r ≤ k j`. Stating it
  for the hardcoded `fun j : Fin (m + 1) => r + j` would under-generalise
  relative to the API it is built on; the caller instantiates with
  `fun j => Nat.le_add_right r j`.
* **No `MeasurableSpace` instance on `Ω`.** The statement quantifies over the
  explicit σ-algebra `tailFamily X r`, never the ambient instance, so the
  section variable is omitted. Lean's unused-section-variable check is what
  surfaced that.

Bodies: **59 → 46**, with an 11-line helper. The helper is `private`; the
public signature is unchanged.

Gates run locally: `lake build` (6287 jobs), `lake exe axioms` (20828 decls in
allowlist), `lake exe module-system` (1142 modules), `scripts/lint-env.sh`
PASS.

Roadmap: Exchangeability