### PR TITLE
refactor(ClassicalGroups): decompose weylModule_ne_bot

### DIFF
--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -203,53 +203,78 @@ noncomputable def weylRepEquiv (t t' : YoungTableau μ) :
 
 /-! ### The vanishing criterion -/
 
-open Finset in
-/-- The Weyl module of a `μ`-tableau is nonzero as soon as `μ` has at most `n` rows.
+/-- **Every label of a `μ`-tableau has row index below `n`** once `μ` has at most `n` rows: the
+row of a label is bounded by the length of the first column. -/
+private theorem rowIndex_lt_of_colLen_le (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n)
+    (ℓ : Fin μ.card) : rowIndex t ℓ < n := by
+  have hmem : ((t.symm ℓ : ℕ × ℕ).1, (t.symm ℓ : ℕ × ℕ).2) ∈ μ := (t.symm ℓ).2
+  have h1 := YoungDiagram.mem_iff_lt_colLen.mp hmem
+  rw [rowIndex_def]
+  exact lt_of_lt_of_le (lt_of_lt_of_le h1 (μ.colLen_anti 0 _ (Nat.zero_le _))) hn
 
-Evaluating the coordinate functional dual to `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}` on `c_t` applied to that
-same pure tensor, where `r ℓ` is the row of the label `ℓ`, leaves exactly the terms indexed by
-the row group of `t`, each with coefficient `1`; the value is therefore the order of the row
-group, which is nonzero because the base ring has characteristic zero. -/
-theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
-    weylModule k n t ≠ ⊥ := by
+omit [Algebra ℚ k] in
+/-- **The coordinate functional dual to a multi-index detects exactly that multi-index.**
+Multiplying the `r ℓ`-th coordinates sends the pure tensor of standard basis vectors indexed by `s`
+to `1` when `s` agrees with `r`, and to `0` otherwise. -/
+private theorem lift_proj_apply_tprod_single {d : ℕ} (r s : Fin d → Fin n) :
+    PiTensorProduct.lift
+        ((MultilinearMap.mkPiAlgebra k (Fin d) k).compLinearMap fun ℓ => LinearMap.proj (r ℓ))
+        (PiTensorProduct.tprod k fun ℓ => (Pi.single (s ℓ) (1 : k) : Fin n → k))
+      = if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := by
+  rw [PiTensorProduct.lift.tprod, MultilinearMap.compLinearMap_apply,
+    MultilinearMap.mkPiAlgebra_apply]
+  simp only [LinearMap.proj_apply, Pi.single_apply]
+  exact Finset.prod_boole.trans (by simp)
+
+/-- **A permutation lies in the row group exactly when it preserves every row index.** Stated for
+any `r` that computes the row of a label, so that it applies to the basis-index function used to
+build the coordinate functional. -/
+private theorem forall_eq_comp_symm_iff_mem_rowSubgroup (t : YoungTableau μ)
+    (r : Fin μ.card → Fin n) (hrv : ∀ ℓ, (r ℓ : ℕ) = rowIndex t ℓ)
+    (σ : Equiv.Perm (Fin μ.card)) :
+    (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t := by
+  rw [← inv_mem_iff (G := Equiv.Perm (Fin μ.card)), mem_rowSubgroup]
+  constructor
+  · intro h ℓ
+    exact (hrv (σ.symm ℓ)).symm.trans ((congrArg Fin.val (h ℓ)).symm.trans (hrv ℓ))
+  · intro h ℓ
+    exact Fin.ext ((hrv ℓ).trans ((h ℓ).symm.trans (hrv (σ.symm ℓ)).symm))
+
+/-- **The symmetrizer does not annihilate the standard pure tensor of a tableau.** Write `r ℓ` for
+the row of the label `ℓ`, an index of the standard basis of `kⁿ`. Evaluating the coordinate
+functional dual to `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}` on `c_t` applied to that same pure tensor leaves
+exactly the terms indexed by the row group of `t`, each with coefficient `1`; the value is the
+order of the row group, which is nonzero because the base ring has characteristic zero. -/
+private theorem lift_proj_symmetrizer_tprod_ne_zero [Nontrivial k] (t : YoungTableau μ)
+    (hn : μ.colLen 0 ≤ n) :
+    PiTensorProduct.lift
+        ((MultilinearMap.mkPiAlgebra k (Fin μ.card) k).compLinearMap fun ℓ =>
+          LinearMap.proj (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n))
+        (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+          (PiTensorProduct.tprod k fun ℓ =>
+            (Pi.single (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n) (1 : k) :
+              Fin n → k))) ≠ 0 := by
   classical
   have : CharZero k := charZero_of_injective_algebraMap (algebraMap ℚ k).injective
-  -- the row of each label, as an index of the standard basis of `kⁿ`
-  have hr : ∀ ℓ : Fin μ.card, rowIndex t ℓ < n := by
-    intro ℓ
-    have hmem : ((t.symm ℓ : ℕ × ℕ).1, (t.symm ℓ : ℕ × ℕ).2) ∈ μ := (t.symm ℓ).2
-    have h1 := YoungDiagram.mem_iff_lt_colLen.mp hmem
-    rw [rowIndex_def]
-    exact lt_of_lt_of_le (lt_of_lt_of_le h1 (μ.colLen_anti 0 _ (Nat.zero_le _))) hn
-  set r : Fin μ.card → Fin n := fun ℓ => ⟨rowIndex t ℓ, hr ℓ⟩ with hrdef
+  set r : Fin μ.card → Fin n := fun ℓ => ⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ with hrdef
   set φ : (⨂[k]^μ.card (Fin n → k)) →ₗ[k] k :=
     PiTensorProduct.lift
       ((MultilinearMap.mkPiAlgebra k (Fin μ.card) k).compLinearMap fun ℓ => LinearMap.proj (r ℓ))
     with hφdef
   have hφ : ∀ s : Fin μ.card → Fin n,
       φ (PiTensorProduct.tprod k fun ℓ => Pi.single (s ℓ) (1 : k)) =
-        if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := by
-    intro s
-    rw [hφdef, PiTensorProduct.lift.tprod, MultilinearMap.compLinearMap_apply,
-      MultilinearMap.mkPiAlgebra_apply]
-    simp only [LinearMap.proj_apply, Pi.single_apply]
-    exact Finset.prod_boole.trans (by simp)
+        if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := fun s => by
+    rw [hφdef]; exact lift_proj_apply_tprod_single r s
   -- the row group is exactly the set of permutations surviving the evaluation
   set S : Finset (Equiv.Perm (Fin μ.card)) := {σ | σ ∈ rowSubgroup t} with hSdef
   have hmemS : ∀ σ : Equiv.Perm (Fin μ.card), σ ∈ S ↔ σ ∈ rowSubgroup t := by
     intro σ; rw [hSdef]; simp
   have hcond : ∀ σ : Equiv.Perm (Fin μ.card),
-      (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t := by
-    intro σ
-    rw [← inv_mem_iff (G := Equiv.Perm (Fin μ.card)), mem_rowSubgroup]
-    constructor
-    · intro h ℓ; exact (congrArg Fin.val (h ℓ)).symm
-    · intro h ℓ; exact Fin.ext (h ℓ).symm
-  -- evaluate the functional on the image of the standard pure tensor
-  set v : ⨂[k]^μ.card (Fin n → k) :=
-    PiTensorProduct.tprod k fun ℓ => Pi.single (r ℓ) (1 : k) with hvdef
-  have key : φ (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) v) = (S.card : k) := by
-    rw [hvdef, permTensorActionAlgHom_apply_tprod, map_finsuppSum]
+      (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t :=
+    forall_eq_comp_symm_iff_mem_rowSubgroup t r (fun _ => rfl)
+  have key : φ (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+      (PiTensorProduct.tprod k fun ℓ => Pi.single (r ℓ) (1 : k))) = (S.card : k) := by
+    rw [permTensorActionAlgHom_apply_tprod, map_finsuppSum]
     have hterm : ∀ σ : Equiv.Perm (Fin μ.card), ∀ x : k,
         φ (x • PiTensorProduct.tprod k fun i => Pi.single (r (σ.symm i)) (1 : k)) =
           if σ ∈ rowSubgroup t then x else 0 := by
@@ -276,19 +301,28 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
       exact ⟨fun h => h.2, fun h => ⟨hsub ((hmemS σ).mpr h), h⟩⟩
     rw [hfilter, Finset.sum_congr rfl fun σ hσ => hcoeff σ ((hmemS σ).mp hσ), Finset.sum_const,
       nsmul_eq_mul, mul_one]
+  rw [key]
+  refine Nat.cast_ne_zero.mpr (Finset.card_ne_zero_of_mem (a := 1) ?_)
+  exact (hmemS 1).mpr (one_mem _)
+
+/-- The Weyl module of a `μ`-tableau is nonzero as soon as `μ` has at most `n` rows.
+
+The image of the standard pure tensor `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}` under the symmetrizer, where
+`r ℓ` is the row of the label `ℓ`, is detected by the dual coordinate functional, so it is not
+zero and the module it generates is not `⊥`. -/
+theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0 ≤ n) :
+    weylModule k n t ≠ ⊥ := by
   intro hbot
   -- the submodule underlying the zero subrepresentation is `⊥`
   have hbot' : (weylModule k n t).toSubmodule = ⊥ := by rw [hbot]; rfl
-  have hmem : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t) v ∈
-      (weylModule k n t).toSubmodule := by
+  have hmem : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+      (PiTensorProduct.tprod k fun ℓ =>
+        (Pi.single (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n) (1 : k) :
+          Fin n → k)) ∈ (weylModule k n t).toSubmodule := by
     rw [weylModule_toSubmodule]
-    exact LinearMap.mem_range_self _ v
+    exact LinearMap.mem_range_self _ _
   rw [hbot', Submodule.mem_bot k] at hmem
-  rw [hmem, map_zero] at key
-  have hne : (S.card : k) ≠ 0 := by
-    refine Nat.cast_ne_zero.mpr (Finset.card_ne_zero_of_mem (a := 1) ?_)
-    exact (hmemS 1).mpr (one_mem _)
-  exact hne key.symm
+  exact lift_proj_symmetrizer_tprod_ne_zero t hn (by rw [hmem, map_zero])
 
 /-- The Weyl module of a `μ`-tableau vanishes as soon as `μ` has more than `n` rows.
 

--- a/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
+++ b/TauCeti/RepresentationTheory/ClassicalGroups/WeylModule.lean
@@ -7,7 +7,6 @@ module
 public import Mathlib.Algebra.Algebra.Rat
 public import Mathlib.Algebra.CharP.Algebra
 public import Mathlib.Data.Complex.Basic
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import TauCeti.Combinatorics.Young.StandardTableau.Reading
 public import TauCeti.RepresentationTheory.ClassicalGroups.TensorPower
 public import TauCeti.RepresentationTheory.Symmetric.Relabel
@@ -212,80 +211,43 @@ private theorem rowIndex_lt_of_colLen_le (t : YoungTableau μ) (hn : μ.colLen 0
   rw [rowIndex_def]
   exact lt_of_lt_of_le (lt_of_lt_of_le h1 (μ.colLen_anti 0 _ (Nat.zero_le _))) hn
 
-omit [Algebra ℚ k] in
-/-- **The coordinate functional dual to a multi-index detects exactly that multi-index.**
-Multiplying the `r ℓ`-th coordinates sends the pure tensor of standard basis vectors indexed by `s`
-to `1` when `s` agrees with `r`, and to `0` otherwise. -/
-private theorem lift_proj_apply_tprod_single {d : ℕ} (r s : Fin d → Fin n) :
-    PiTensorProduct.lift
-        ((MultilinearMap.mkPiAlgebra k (Fin d) k).compLinearMap fun ℓ => LinearMap.proj (r ℓ))
-        (PiTensorProduct.tprod k fun ℓ => (Pi.single (s ℓ) (1 : k) : Fin n → k))
-      = if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := by
-  rw [PiTensorProduct.lift.tprod, MultilinearMap.compLinearMap_apply,
-    MultilinearMap.mkPiAlgebra_apply]
-  simp only [LinearMap.proj_apply, Pi.single_apply]
-  exact Finset.prod_boole.trans (by simp)
-
-/-- **A permutation lies in the row group exactly when it preserves every row index.** Stated for
-any `r` that computes the row of a label, so that it applies to the basis-index function used to
-build the coordinate functional. -/
-private theorem forall_eq_comp_symm_iff_mem_rowSubgroup (t : YoungTableau μ)
-    (r : Fin μ.card → Fin n) (hrv : ∀ ℓ, (r ℓ : ℕ) = rowIndex t ℓ)
-    (σ : Equiv.Perm (Fin μ.card)) :
-    (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t := by
-  rw [← inv_mem_iff (G := Equiv.Perm (Fin μ.card)), mem_rowSubgroup]
-  constructor
-  · intro h ℓ
-    exact (hrv (σ.symm ℓ)).symm.trans ((congrArg Fin.val (h ℓ)).symm.trans (hrv ℓ))
-  · intro h ℓ
-    exact Fin.ext ((hrv ℓ).trans ((h ℓ).symm.trans (hrv (σ.symm ℓ)).symm))
-
-/-- **The symmetrizer does not annihilate the standard pure tensor of a tableau.** Write `r ℓ` for
-the row of the label `ℓ`, an index of the standard basis of `kⁿ`. Evaluating the coordinate
-functional dual to `e_{r(1)} ⊗ ⋯ ⊗ e_{r(d)}` on `c_t` applied to that same pure tensor leaves
-exactly the terms indexed by the row group of `t`, each with coefficient `1`; the value is the
-order of the row group, which is nonzero because the base ring has characteristic zero. -/
-private theorem lift_proj_symmetrizer_tprod_ne_zero [Nontrivial k] (t : YoungTableau μ)
+/-- **The symmetrizer does not annihilate the monomial basis vector of a tableau.** Write `r ℓ` for
+the row of the label `ℓ`. Reading the `r`-coordinate of `c_t • e_r` in the monomial basis leaves
+exactly the terms indexed by the row group of `t`, each with coefficient `1`; the value is the order
+of the row group, which is nonzero because the base ring has characteristic zero. -/
+private theorem repr_symmetrizer_tensorPowerBasis_ne_zero [Nontrivial k] (t : YoungTableau μ)
     (hn : μ.colLen 0 ≤ n) :
-    PiTensorProduct.lift
-        ((MultilinearMap.mkPiAlgebra k (Fin μ.card) k).compLinearMap fun ℓ =>
-          LinearMap.proj (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n))
+    (tensorPowerBasis k n μ.card).repr
         (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
-          (PiTensorProduct.tprod k fun ℓ =>
-            (Pi.single (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n) (1 : k) :
-              Fin n → k))) ≠ 0 := by
+          (tensorPowerBasis k n μ.card fun ℓ =>
+            (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n)))
+        (fun ℓ => (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n)) ≠ 0 := by
   classical
   have : CharZero k := charZero_of_injective_algebraMap (algebraMap ℚ k).injective
   set r : Fin μ.card → Fin n := fun ℓ => ⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ with hrdef
-  set φ : (⨂[k]^μ.card (Fin n → k)) →ₗ[k] k :=
-    PiTensorProduct.lift
-      ((MultilinearMap.mkPiAlgebra k (Fin μ.card) k).compLinearMap fun ℓ => LinearMap.proj (r ℓ))
-    with hφdef
-  have hφ : ∀ s : Fin μ.card → Fin n,
-      φ (PiTensorProduct.tprod k fun ℓ => Pi.single (s ℓ) (1 : k)) =
-        if ∀ ℓ, r ℓ = s ℓ then 1 else 0 := fun s => by
-    rw [hφdef]; exact lift_proj_apply_tprod_single r s
   -- the row group is exactly the set of permutations surviving the evaluation
   set S : Finset (Equiv.Perm (Fin μ.card)) := {σ | σ ∈ rowSubgroup t} with hSdef
   have hmemS : ∀ σ : Equiv.Perm (Fin μ.card), σ ∈ S ↔ σ ∈ rowSubgroup t := by
     intro σ; rw [hSdef]; simp
   have hcond : ∀ σ : Equiv.Perm (Fin μ.card),
-      (∀ ℓ, r ℓ = r (σ.symm ℓ)) ↔ σ ∈ rowSubgroup t :=
-    forall_eq_comp_symm_iff_mem_rowSubgroup t r (fun _ => rfl)
-  have key : φ (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
-      (PiTensorProduct.tprod k fun ℓ => Pi.single (r ℓ) (1 : k))) = (S.card : k) := by
-    rw [permTensorActionAlgHom_apply_tprod, map_finsuppSum]
-    have hterm : ∀ σ : Equiv.Perm (Fin μ.card), ∀ x : k,
-        φ (x • PiTensorProduct.tprod k fun i => Pi.single (r (σ.symm i)) (1 : k)) =
-          if σ ∈ rowSubgroup t then x else 0 := by
-      intro σ x
-      rw [map_smul, hφ (fun i => r (σ.symm i))]
-      by_cases h : σ ∈ rowSubgroup t
-      · rw [if_pos ((hcond σ).mpr h), if_pos h, smul_eq_mul, mul_one]
-      · rw [if_neg fun hc => h ((hcond σ).mp hc), if_neg h, smul_zero]
-    rw [Finsupp.sum_congr (g2 := fun σ x => if σ ∈ rowSubgroup t then x else 0)
-      fun σ _ => hterm σ _]
-    rw [Finsupp.sum]
+      (fun ℓ => r (σ.symm ℓ)) = r ↔ σ ∈ rowSubgroup t := by
+    intro σ
+    rw [← inv_mem_iff (G := Equiv.Perm (Fin μ.card)), mem_rowSubgroup]
+    exact ⟨fun h ℓ => congrArg Fin.val (congrFun h ℓ), fun h => funext fun ℓ => Fin.ext (h ℓ)⟩
+  have key : (tensorPowerBasis k n μ.card).repr
+      (permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
+        (tensorPowerBasis k n μ.card r)) r = (S.card : k) := by
+    rw [permTensorActionAlgHom_apply_tensorPowerBasis, map_sum, Finset.sum_apply']
+    have hterm : ∀ σ ∈ (youngSymmetrizerOver k t).coeff.support,
+        ((tensorPowerBasis k n μ.card).repr
+            ((youngSymmetrizerOver k t).coeff σ •
+              tensorPowerBasis k n μ.card fun i => r (σ.symm i))) r =
+          if σ ∈ rowSubgroup t then (youngSymmetrizerOver k t).coeff σ else 0 := by
+      intro σ _
+      rw [map_smul, Module.Basis.repr_self, Finsupp.smul_single, smul_eq_mul, mul_one,
+        Finsupp.single_apply]
+      exact if_congr (hcond σ) rfl rfl
+    rw [Finset.sum_congr rfl hterm]
     have hcoeff : ∀ σ ∈ rowSubgroup t, (youngSymmetrizerOver k t).coeff σ = 1 := by
       intro σ hσ
       rw [youngSymmetrizerOver_coeff, youngSymmetrizer_coeff_eq_one_of_mem_rowSubgroup t hσ,
@@ -316,13 +278,13 @@ theorem weylModule_ne_bot [Nontrivial k] (t : YoungTableau μ) (hn : μ.colLen 0
   -- the submodule underlying the zero subrepresentation is `⊥`
   have hbot' : (weylModule k n t).toSubmodule = ⊥ := by rw [hbot]; rfl
   have hmem : permTensorActionAlgHom k n μ.card (youngSymmetrizerOver k t)
-      (PiTensorProduct.tprod k fun ℓ =>
-        (Pi.single (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n) (1 : k) :
-          Fin n → k)) ∈ (weylModule k n t).toSubmodule := by
+      (tensorPowerBasis k n μ.card fun ℓ =>
+        (⟨rowIndex t ℓ, rowIndex_lt_of_colLen_le t hn ℓ⟩ : Fin n))
+      ∈ (weylModule k n t).toSubmodule := by
     rw [weylModule_toSubmodule]
     exact LinearMap.mem_range_self _ _
   rw [hbot', Submodule.mem_bot k] at hmem
-  exact lift_proj_symmetrizer_tprod_ne_zero t hn (by rw [hmem, map_zero])
+  exact repr_symmetrizer_tensorPowerBasis_ne_zero t hn (by rw [hmem, map_zero]; rfl)
 
 /-- The Weyl module of a `μ`-tableau vanishes as soon as `μ` has more than `n` rows.
 

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Basic.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basic
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import Mathlib.RepresentationTheory.Basic
 
 /-!
@@ -27,6 +27,8 @@ It reuses `PiTensorProduct.reindex`; the convention is
   and module.
 * `permTensorAction` specializes it to `(Fin n → R)^{⊗d}`.
 * `permTensorActionAlgHom` is its `Representation.asAlgebraHom` extension to `R[S_d]`.
+* `TauCeti.tensorPowerBasis` is the monomial basis of `(Rⁿ)^{⊗d}`, on which the action is a
+  reindexing.
 -/
 
 public section
@@ -145,5 +147,46 @@ theorem permTensorActionAlgHom_apply_tprod (a : MonoidAlgebra R (Equiv.Perm (Fin
       a.coeff.sum fun σ r => r • PiTensorProduct.tprod R fun i => m (σ.symm i) := by
   rw [permTensorActionAlgHom_def, permTensorAction_def]
   exact PiTensorProduct.reindexRepresentation_asAlgebraHom_apply_tprod R (Fin n → R) (Fin d) a m
+
+/-- The monomial basis of `(Rⁿ)^{⊗d}`: the basis vector at `f : Fin d → Fin n` is the pure tensor
+whose `i`-th factor is the `f i`-th standard basis vector of `Rⁿ`. -/
+noncomputable def tensorPowerBasis :
+    Module.Basis (Fin d → Fin n) R (⨂[R] _ : Fin d, Fin n → R) :=
+  Basis.piTensorProduct fun _ => Pi.basisFun R (Fin n)
+
+@[simp]
+theorem tensorPowerBasis_apply (f : Fin d → Fin n) :
+    tensorPowerBasis R n d f = PiTensorProduct.tprod R fun i => Pi.single (f i) (1 : R) := by
+  classical
+  rw [tensorPowerBasis, Basis.piTensorProduct_apply]
+  simp
+
+-- These two derived normal forms remain explicit rewrite lemmas: `simpNF` detects each as already
+-- provable from the underlying tensor-action rules, so adding them to the simp set is redundant.
+/-- A permutation acts on the monomial basis of `(Rⁿ)^{⊗d}` by precomposing the index function
+with its inverse. -/
+theorem permTensorAction_tensorPowerBasis (σ : Equiv.Perm (Fin d)) (f : Fin d → Fin n) :
+    permTensorAction R n d σ (tensorPowerBasis R n d f) =
+      tensorPowerBasis R n d fun i => f (σ.symm i) := by
+  simp
+
+/-- A group-algebra basis element acts on a monomial basis vector by precomposition and
+scaling. -/
+theorem permTensorActionAlgHom_single_tensorPowerBasis (ρ : Equiv.Perm (Fin d)) (r : R)
+    (f : Fin d → Fin n) :
+    permTensorActionAlgHom R n d (MonoidAlgebra.single ρ r) (tensorPowerBasis R n d f) =
+      r • tensorPowerBasis R n d fun i => f (ρ.symm i) := by
+  rw [permTensorActionAlgHom_def, Representation.asAlgebraHom_single, LinearMap.smul_apply,
+    permTensorAction_tensorPowerBasis]
+
+/-- The group-algebra action on a monomial basis vector is the coefficient-weighted sum of the
+precomposed monomial basis vectors. -/
+theorem permTensorActionAlgHom_apply_tensorPowerBasis
+    (a : MonoidAlgebra R (Equiv.Perm (Fin d))) (f : Fin d → Fin n) :
+    permTensorActionAlgHom R n d a (tensorPowerBasis R n d f) =
+      ∑ σ ∈ a.coeff.support,
+        a.coeff σ • tensorPowerBasis R n d fun i => f (σ.symm i) := by
+  rw [tensorPowerBasis_apply, permTensorActionAlgHom_apply_tprod, Finsupp.sum]
+  exact Finset.sum_congr rfl fun σ _ => by rw [tensorPowerBasis_apply]
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/TensorAction/Faithful.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/TensorAction/Faithful.lean
@@ -4,8 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Finsupp.Basic
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import TauCeti.RepresentationTheory.Symmetric.TensorAction.Basic
 
 /-!
@@ -28,10 +26,6 @@ independent coordinate directions with which to tell tensor slots apart, that is
 
 Both answers are read off the monomial basis `tensorPowerBasis` of `(Rⁿ)^{⊗d}`, indexed by the
 functions `Fin d → Fin n`, on which a permutation acts by precomposition with its inverse.
-
-## Main definitions
-
-* `TauCeti.tensorPowerBasis` is the monomial basis of `(Rⁿ)^{⊗d}`.
 
 ## Main results
 
@@ -61,47 +55,6 @@ namespace TauCeti
 section CommSemiring
 
 variable (R : Type u) (n d : ℕ) [CommSemiring R]
-
-/-- The monomial basis of `(Rⁿ)^{⊗d}`: the basis vector at `f : Fin d → Fin n` is the pure tensor
-whose `i`-th factor is the `f i`-th standard basis vector of `Rⁿ`. -/
-noncomputable def tensorPowerBasis :
-    Module.Basis (Fin d → Fin n) R (⨂[R] _ : Fin d, Fin n → R) :=
-  Basis.piTensorProduct fun _ => Pi.basisFun R (Fin n)
-
-@[simp]
-theorem tensorPowerBasis_apply (f : Fin d → Fin n) :
-    tensorPowerBasis R n d f = PiTensorProduct.tprod R fun i => Pi.single (f i) (1 : R) := by
-  classical
-  rw [tensorPowerBasis, Basis.piTensorProduct_apply]
-  simp
-
--- These two derived normal forms remain explicit rewrite lemmas: `simpNF` detects each as already
--- provable from the underlying tensor-action rules, so adding them to the simp set is redundant.
-/-- A permutation acts on the monomial basis of `(Rⁿ)^{⊗d}` by precomposing the index function
-with its inverse. -/
-theorem permTensorAction_tensorPowerBasis (σ : Equiv.Perm (Fin d)) (f : Fin d → Fin n) :
-    permTensorAction R n d σ (tensorPowerBasis R n d f) =
-      tensorPowerBasis R n d fun i => f (σ.symm i) := by
-  simp
-
-/-- A group-algebra basis element acts on a monomial basis vector by precomposition and
-scaling. -/
-theorem permTensorActionAlgHom_single_tensorPowerBasis (ρ : Equiv.Perm (Fin d)) (r : R)
-    (f : Fin d → Fin n) :
-    permTensorActionAlgHom R n d (MonoidAlgebra.single ρ r) (tensorPowerBasis R n d f) =
-      r • tensorPowerBasis R n d fun i => f (ρ.symm i) := by
-  rw [permTensorActionAlgHom_def, Representation.asAlgebraHom_single, LinearMap.smul_apply,
-    permTensorAction_tensorPowerBasis]
-
-/-- The group-algebra action on a monomial basis vector is the coefficient-weighted sum of the
-precomposed monomial basis vectors. -/
-theorem permTensorActionAlgHom_apply_tensorPowerBasis
-    (a : MonoidAlgebra R (Equiv.Perm (Fin d))) (f : Fin d → Fin n) :
-    permTensorActionAlgHom R n d a (tensorPowerBasis R n d f) =
-      ∑ σ ∈ a.coeff.support,
-        a.coeff σ • tensorPowerBasis R n d fun i => f (σ.symm i) := by
-  rw [tensorPowerBasis_apply, permTensorActionAlgHom_apply_tprod, Finsupp.sum]
-  exact Finset.sum_congr rfl fun σ _ => by rw [tensorPowerBasis_apply]
 
 variable {R n d}
 


### PR DESCRIPTION
`weylModule_ne_bot` had a **77-line body** — the largest on main outside
`DerivationBundle`. It did five things in one block: bound the row indices,
build a coordinate functional dual to the row multi-index, identify which
permutations survive its evaluation, compute the value on the symmetrized pure
tensor, and contradict `weylModule = ⊥`.

Two of those are statements in their own right:

| new private lemma | content | body |
|---|---|---|
| `rowIndex_lt_of_colLen_le` | a label's row is below `n` once `μ` has at most `n` rows | 4 |
| `repr_symmetrizer_tensorPowerBasis_ne_zero` | the symmetrizer does not annihilate the tableau's monomial basis vector | 44 |

**The evaluation goes through the existing monomial basis.** The original built
a `PiTensorProduct.lift`/`Pi.single` coordinate functional by hand; the value is
now read as a `Module.Basis.repr` coordinate using
`permTensorActionAlgHom_apply_tensorPowerBasis`, `Module.Basis.repr_self` and
`Finsupp.single_apply`.

**`tensorPowerBasis` and the generic action lemmas move from
`TensorAction/Faithful.lean` to `TensorAction/Basic.lean`.** They are basis
machinery and say nothing about faithfulness; leaving them where they were
would make `WeylModule` import the faithfulness theory just to reach them —
an inverted dependency. `Basic` is already on `WeylModule`'s path via
`ClassicalGroups/TensorPower`, so **no import is added anywhere**, and nothing
else imported `Faithful`. The `## Main definitions` bullet moves with them.

**The main helper concludes `≠ 0`, not `= |rowSubgroup t|`.** That is what the
caller consumes (it feeds a contradiction), and stating it this way keeps the
row-group `Finset` and its decidability out of the statement. Characteristic
zero is derived inside.

The row-group criterion is proved inline from `mem_rowSubgroup` rather than as
a separate helper: it is used once, and abstracting it over an arbitrary index
function bought no generality that anything needs.

Body: **77 → 11**, helpers 4 and 44. Both are `private`; the public signature
of `weylModule_ne_bot` is unchanged.

Gates run locally: `lake build` (6291 jobs), `lake exe axioms` (20848 decls in
allowlist), `lake exe module-system` (1146 modules), `scripts/lint-env.sh`
PASS.

Roadmap: RepresentationTheory