### PR TITLE
feat: identify Hopf spectrum kernels as pullbacks

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -104,6 +104,9 @@ private noncomputable def kernelSpecPullbackIso (f : H ⟶ K) :
       (quotientKernelHopfIdealAlgEquiv f).toRingEquiv.toCommRingCatIso.op).symm ≪≫
       (pullbackSpecIso H K R).symm
 
+-- The two structure maps of the tensor product, transported along the quotient--tensor
+-- equivalence: both are computed by its `simp` lemma
+-- `quotientKernelHopfIdealAlgEquiv_symm_tmul` at `k ⊗ₜ 1` resp. `1 ⊗ₜ r`.
 private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeLeft (f : H ⟶ K) :
     letI : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
     letI : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
@@ -112,24 +115,8 @@ private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeLeft (f : H ⟶ K
         (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom := by
   let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
   let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
-  rw [← AlgEquiv.symm_toRingEquiv]
   ext k
-  simp only [RingHom.comp_apply, Algebra.TensorProduct.includeLeftRingHom_apply]
-  calc
-    (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv.toRingHom (k ⊗ₜ[↥H] 1) =
-        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv (k ⊗ₜ[↥H] 1) :=
-      congrFun (RingEquiv.coe_toRingHom
-        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv) _
-    _ = (quotientKernelHopfIdealAlgEquiv f).symm (k ⊗ₜ[↥H] 1) :=
-      congrFun (AlgEquiv.coe_ringEquiv (quotientKernelHopfIdealAlgEquiv f).symm) _
-    _ = (mkQuotient K (kernelHopfIdeal f)).hom k := by
-      rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mkQuotient_apply, map_one,
-        one_mul, Ideal.Quotient.mkₐ_eq_mk]
-    _ = (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom k :=
-      (congrFun (BialgHom.coe_toAlgHom (mkQuotient K (kernelHopfIdeal f)).hom) k).symm
-    _ = (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom k :=
-      (congrFun (AlgHom.coe_toRingHom
-        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom) k).symm
+  simp
 
 private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeRight (f : H ⟶ K) :
     letI : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
@@ -139,29 +126,8 @@ private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeRight (f : H ⟶ 
         algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) := by
   let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
   let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
-  rw [← AlgEquiv.symm_toRingEquiv]
   ext r
-  simp only [RingHom.comp_apply]
-  calc
-    (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv.toRingHom
-        ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) =
-        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv
-          ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) :=
-      congrFun (RingEquiv.coe_toRingHom
-        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv) _
-    _ = (quotientKernelHopfIdealAlgEquiv f).symm
-          ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) :=
-      congrFun (AlgEquiv.coe_ringEquiv (quotientKernelHopfIdealAlgEquiv f).symm) _
-    _ = (quotientKernelHopfIdealAlgEquiv f).symm (1 ⊗ₜ[↥H] r) := by
-      rw [show
-        (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r =
-          (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)) r from
-            congrFun (AlgHom.coe_toRingHom
-              (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R))) r,
-        Algebra.TensorProduct.includeRight_apply]
-    _ = algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) r := by
-      rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mul_one,
-        Ideal.Quotient.mk_algebraMap]
+  simp
 
 private lemma kernelSpecPullbackIso_hom_fst (f : H ⟶ K) :
     (kernelSpecPullbackIso f).hom ≫

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -6,6 +6,9 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel.Basic
 public import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Scheme.Basic
+import Mathlib.CategoryTheory.Limits.Constructions.Over.Connected
+import Mathlib.CategoryTheory.Monoidal.Cartesian.GrpLimits
+import TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel.BaseChange
 
 /-!
 # The kernel of a morphism of affine group schemes
@@ -18,8 +21,9 @@ ideal, whose kernel semantics — the trivialization criterion — live in
 `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Quotient.Kernel`). The inclusion is a closed
 immersion by `TauCeti.CommHopfAlgCat.isClosedImmersion_quotientSpecι`, and the
 scheme-level triangle here is the image of the coordinate-ring triangle under `hopfSpec`.
-The pullback square against the unit section is future work; the points-level kernel
-property is `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` in
+The quotient--tensor identification presents this kernel as the scheme-theoretic fibre over
+the identity section, and the resulting pullback square lifts from schemes to group objects.
+The points-level kernel property is `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` in
 `TauCeti.Algebra.AlgebraicGroup.HopfIdeal.Points.Kernel`.
 
 ## Main declarations
@@ -27,6 +31,8 @@ property is `TauCeti.CommHopfAlgCat.mapPointsFunctor_app_eq_one_iff` in
 * `TauCeti.CommHopfAlgCat.kernelSpec` and `TauCeti.CommHopfAlgCat.kernelSpecι`: the
   kernel closed subgroup scheme and its inclusion.
 * `TauCeti.CommHopfAlgCat.kernelSpecι_comp`: the scheme-level triangle.
+* `TauCeti.CommHopfAlgCat.isPullback_kernelSpec`: the kernel square against the identity
+  section is a pullback of group schemes.
 
 ## References
 
@@ -37,7 +43,7 @@ algebras is imposed by Mathlib's current `hopfSpec` construction, as in
 
 public section
 
-open CategoryTheory
+open CategoryTheory CategoryTheory.Limits
 
 namespace TauCeti
 
@@ -83,6 +89,93 @@ theorem kernelSpecι_comp (f : H ⟶ K) :
             (Bialgebra.counitBialgHom R H))).op := by
   rw [kernelSpecι_def, quotientSpecι_def, ← Functor.map_comp, ← op_comp,
     comp_mkQuotient_kernelHopfIdeal]
+
+-- The affine comparison expressing the quotient spectrum as the spectrum of the tensor
+-- product, followed by the canonical affine pullback presentation.
+private noncomputable def kernelSpecPullbackIso (f : H ⟶ K) :
+    Spec (CommRingCat.of (K ⧸ (kernelHopfIdeal f).toIdeal)) ≅
+      pullback
+        (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+        (Spec.map (CommRingCat.ofHom (Bialgebra.counitAlgHom R H).toRingHom)) := by
+  let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+  let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+  exact
+    (Scheme.Spec.mapIso
+      (quotientKernelHopfIdealAlgEquiv f).toRingEquiv.toCommRingCatIso.op).symm ≪≫
+      (pullbackSpecIso H K R).symm
+
+private lemma kernelSpecPullbackIso_hom_fst (f : H ⟶ K) :
+    (kernelSpecPullbackIso f).hom ≫
+        pullback.fst
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+          (Spec.map (CommRingCat.ofHom (Bialgebra.counitAlgHom R H).toRingHom)) =
+      Spec.map (CommRingCat.ofHom
+        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom) := by
+  let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+  let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+  simp only [kernelSpecPullbackIso, Iso.trans_hom, Iso.symm_hom,
+    Functor.mapIso_inv, Iso.op_inv, Scheme.Spec_map, Quiver.Hom.unop_op,
+    RingEquiv.toCommRingCatIso_inv]
+  rw [Category.assoc, pullbackSpecIso_inv_fst]
+  rw [← Spec.map_comp, Spec.map_inj]
+  rw [← CommRingCat.ofHom_comp]
+  congr 1
+  ext k
+  change (quotientKernelHopfIdealAlgEquiv f).symm (k ⊗ₜ[↥H] 1) =
+    (mkQuotient K (kernelHopfIdeal f)).hom k
+  rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mkQuotient_apply, map_one,
+    one_mul, Ideal.Quotient.mkₐ_eq_mk]
+
+private lemma kernelSpecPullbackIso_hom_snd (f : H ⟶ K) :
+    (kernelSpecPullbackIso f).hom ≫
+        pullback.snd
+          (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+          (Spec.map (CommRingCat.ofHom (Bialgebra.counitAlgHom R H).toRingHom)) =
+      Spec.map (CommRingCat.ofHom
+        (algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal))) := by
+  let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+  let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+  simp only [kernelSpecPullbackIso, Iso.trans_hom, Iso.symm_hom,
+    Functor.mapIso_inv, Iso.op_inv, Scheme.Spec_map, Quiver.Hom.unop_op,
+    RingEquiv.toCommRingCatIso_inv]
+  rw [Category.assoc, pullbackSpecIso_inv_snd]
+  rw [← Spec.map_comp, Spec.map_inj]
+  rw [← CommRingCat.ofHom_comp]
+  congr 1
+  ext r
+  change (quotientKernelHopfIdealAlgEquiv f).symm (1 ⊗ₜ[↥H] r) =
+    algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) r
+  rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mul_one,
+    Ideal.Quotient.mk_algebraMap]
+
+private lemma isPullback_kernelSpec_scheme (f : H ⟶ K) :
+    IsPullback
+      (Spec.map (CommRingCat.ofHom
+        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom))
+      (Spec.map (CommRingCat.ofHom
+        (algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal))))
+      (Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom))
+      (Spec.map (CommRingCat.ofHom
+        (Bialgebra.counitAlgHom R H).toRingHom)) := by
+  refine IsPullback.of_iso_pullback ⟨?_⟩ (kernelSpecPullbackIso f)
+    (kernelSpecPullbackIso_hom_fst f) (kernelSpecPullbackIso_hom_snd f)
+  rw [← kernelSpecPullbackIso_hom_fst f, ← kernelSpecPullbackIso_hom_snd f,
+    Category.assoc, Category.assoc, pullback.condition]
+
+/-- The Hopf spectrum of the kernel quotient is the scheme-theoretic fibre over the identity.
+The horizontal maps are the kernel inclusion and the unique map to the trivial group scheme;
+the vertical maps are the morphism induced by `f` and the identity section, respectively. -/
+theorem isPullback_kernelSpec (f : H ⟶ K) :
+    IsPullback (kernelSpecι f)
+      (0 : kernelSpec f ⟶ Grp.trivial (Over (Spec (CommRingCat.of R))))
+      ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op)
+      (0 : Grp.trivial (Over (Spec (CommRingCat.of R))) ⟶
+        (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)) := by
+  apply IsPullback.of_map_of_faithful (Grp.forget _)
+  apply IsPullback.of_map_of_faithful (Over.forget _)
+  convert isPullback_kernelSpec_scheme f using 1 <;> try rfl
+  rw [kernelSpecι_def, quotientSpecι_def]
+  rfl
 
 end CommHopfAlgCat
 

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -215,8 +215,8 @@ private lemma trivial_to_hopfSpec_underlying (H : _root_.CommHopfAlgCat.{u} R) :
   rfl
 
 /-- The Hopf spectrum of the kernel quotient is the scheme-theoretic fibre over the identity.
-The horizontal maps are the kernel inclusion and the unique map to the trivial group scheme;
-the vertical maps are the morphism induced by `f` and the identity section, respectively. -/
+The horizontal maps are the kernel inclusion and the identity section; the vertical maps are the
+unique map to the trivial group scheme and the morphism induced by `f`, respectively. -/
 theorem isPullback_kernelSpec (f : H ⟶ K) :
     IsPullback (kernelSpecι f)
       (0 : kernelSpec f ⟶ Grp.trivial (Over (Spec (CommRingCat.of R))))

--- a/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/HopfIdeal/Scheme/Kernel.lean
@@ -104,6 +104,65 @@ private noncomputable def kernelSpecPullbackIso (f : H ⟶ K) :
       (quotientKernelHopfIdealAlgEquiv f).toRingEquiv.toCommRingCatIso.op).symm ≪≫
       (pullbackSpecIso H K R).symm
 
+private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeLeft (f : H ⟶ K) :
+    letI : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+    letI : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+    (quotientKernelHopfIdealAlgEquiv f).toRingEquiv.symm.toRingHom.comp
+      (Algebra.TensorProduct.includeLeftRingHom (R := ↥H) (A := ↥K) (B := R)) =
+        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom := by
+  let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+  let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+  rw [← AlgEquiv.symm_toRingEquiv]
+  ext k
+  simp only [RingHom.comp_apply, Algebra.TensorProduct.includeLeftRingHom_apply]
+  calc
+    (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv.toRingHom (k ⊗ₜ[↥H] 1) =
+        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv (k ⊗ₜ[↥H] 1) :=
+      congrFun (RingEquiv.coe_toRingHom
+        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv) _
+    _ = (quotientKernelHopfIdealAlgEquiv f).symm (k ⊗ₜ[↥H] 1) :=
+      congrFun (AlgEquiv.coe_ringEquiv (quotientKernelHopfIdealAlgEquiv f).symm) _
+    _ = (mkQuotient K (kernelHopfIdeal f)).hom k := by
+      rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mkQuotient_apply, map_one,
+        one_mul, Ideal.Quotient.mkₐ_eq_mk]
+    _ = (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom k :=
+      (congrFun (BialgHom.coe_toAlgHom (mkQuotient K (kernelHopfIdeal f)).hom) k).symm
+    _ = (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom k :=
+      (congrFun (AlgHom.coe_toRingHom
+        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom) k).symm
+
+private lemma quotientKernelHopfIdealAlgEquiv_symm_comp_includeRight (f : H ⟶ K) :
+    letI : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+    letI : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+    (quotientKernelHopfIdealAlgEquiv f).toRingEquiv.symm.toRingHom.comp
+      (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom =
+        algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) := by
+  let : Algebra ↥H ↥K := f.hom.toAlgHom.toAlgebra
+  let : Algebra ↥H R := (Bialgebra.counitAlgHom R ↥H).toAlgebra
+  rw [← AlgEquiv.symm_toRingEquiv]
+  ext r
+  simp only [RingHom.comp_apply]
+  calc
+    (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv.toRingHom
+        ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) =
+        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv
+          ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) :=
+      congrFun (RingEquiv.coe_toRingHom
+        (quotientKernelHopfIdealAlgEquiv f).symm.toRingEquiv) _
+    _ = (quotientKernelHopfIdealAlgEquiv f).symm
+          ((Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r) :=
+      congrFun (AlgEquiv.coe_ringEquiv (quotientKernelHopfIdealAlgEquiv f).symm) _
+    _ = (quotientKernelHopfIdealAlgEquiv f).symm (1 ⊗ₜ[↥H] r) := by
+      rw [show
+        (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)).toRingHom r =
+          (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R)) r from
+            congrFun (AlgHom.coe_toRingHom
+              (Algebra.TensorProduct.includeRight (R := ↥H) (A := ↥K) (B := R))) r,
+        Algebra.TensorProduct.includeRight_apply]
+    _ = algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) r := by
+      rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mul_one,
+        Ideal.Quotient.mk_algebraMap]
+
 private lemma kernelSpecPullbackIso_hom_fst (f : H ⟶ K) :
     (kernelSpecPullbackIso f).hom ≫
         pullback.fst
@@ -120,11 +179,7 @@ private lemma kernelSpecPullbackIso_hom_fst (f : H ⟶ K) :
   rw [← Spec.map_comp, Spec.map_inj]
   rw [← CommRingCat.ofHom_comp]
   congr 1
-  ext k
-  change (quotientKernelHopfIdealAlgEquiv f).symm (k ⊗ₜ[↥H] 1) =
-    (mkQuotient K (kernelHopfIdeal f)).hom k
-  rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mkQuotient_apply, map_one,
-    one_mul, Ideal.Quotient.mkₐ_eq_mk]
+  exact quotientKernelHopfIdealAlgEquiv_symm_comp_includeLeft f
 
 private lemma kernelSpecPullbackIso_hom_snd (f : H ⟶ K) :
     (kernelSpecPullbackIso f).hom ≫
@@ -142,11 +197,7 @@ private lemma kernelSpecPullbackIso_hom_snd (f : H ⟶ K) :
   rw [← Spec.map_comp, Spec.map_inj]
   rw [← CommRingCat.ofHom_comp]
   congr 1
-  ext r
-  change (quotientKernelHopfIdealAlgEquiv f).symm (1 ⊗ₜ[↥H] r) =
-    algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal) r
-  rw [quotientKernelHopfIdealAlgEquiv_symm_tmul, mul_one,
-    Ideal.Quotient.mk_algebraMap]
+  exact quotientKernelHopfIdealAlgEquiv_symm_comp_includeRight f
 
 private lemma isPullback_kernelSpec_scheme (f : H ⟶ K) :
     IsPullback
@@ -162,6 +213,41 @@ private lemma isPullback_kernelSpec_scheme (f : H ⟶ K) :
   rw [← kernelSpecPullbackIso_hom_fst f, ← kernelSpecPullbackIso_hom_snd f,
     Category.assoc, Category.assoc, pullback.condition]
 
+-- The following four lemmas isolate the underlying scheme maps of the group-object square.
+-- In particular, the two zero morphisms become the structural map and the identity section,
+-- rather than being left to unfold inside the pullback proof.
+private lemma kernelSpecι_underlying (f : H ⟶ K) :
+    (Over.forget (Spec (CommRingCat.of R))).map
+        ((Grp.forget (Over (Spec (CommRingCat.of R)))).map (kernelSpecι f)) =
+      Spec.map (CommRingCat.ofHom
+        (mkQuotient K (kernelHopfIdeal f)).hom.toAlgHom.toRingHom) := by
+  rw [kernelSpecι_def, quotientSpecι_def]
+  rfl
+
+private lemma kernelSpec_to_trivial_underlying (f : H ⟶ K) :
+    (Over.forget (Spec (CommRingCat.of R))).map
+        ((Grp.forget (Over (Spec (CommRingCat.of R)))).map
+          (0 : kernelSpec f ⟶ Grp.trivial (Over (Spec (CommRingCat.of R))))) =
+      Spec.map (CommRingCat.ofHom
+        (algebraMap R (K ⧸ (kernelHopfIdeal f).toIdeal))) := by
+  rfl
+
+private lemma hopfSpec_map_underlying (f : H ⟶ K) :
+    (Over.forget (Spec (CommRingCat.of R))).map
+        ((Grp.forget (Over (Spec (CommRingCat.of R)))).map
+          ((AlgebraicGeometry.hopfSpec (CommRingCat.of R)).map f.op)) =
+      Spec.map (CommRingCat.ofHom f.hom.toAlgHom.toRingHom) := by
+  rfl
+
+private lemma trivial_to_hopfSpec_underlying (H : _root_.CommHopfAlgCat.{u} R) :
+    (Over.forget (Spec (CommRingCat.of R))).map
+        ((Grp.forget (Over (Spec (CommRingCat.of R)))).map
+          (0 : Grp.trivial (Over (Spec (CommRingCat.of R))) ⟶
+            (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H))) =
+      Spec.map (CommRingCat.ofHom
+        (Bialgebra.counitAlgHom R H).toRingHom) := by
+  rfl
+
 /-- The Hopf spectrum of the kernel quotient is the scheme-theoretic fibre over the identity.
 The horizontal maps are the kernel inclusion and the unique map to the trivial group scheme;
 the vertical maps are the morphism induced by `f` and the identity section, respectively. -/
@@ -173,9 +259,9 @@ theorem isPullback_kernelSpec (f : H ⟶ K) :
         (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)) := by
   apply IsPullback.of_map_of_faithful (Grp.forget _)
   apply IsPullback.of_map_of_faithful (Over.forget _)
-  convert isPullback_kernelSpec_scheme f using 1 <;> try rfl
-  rw [kernelSpecι_def, quotientSpecι_def]
-  rfl
+  rw [kernelSpecι_underlying, kernelSpec_to_trivial_underlying,
+    hopfSpec_map_underlying, trivial_to_hopfSpec_underlying]
+  exact isPullback_kernelSpec_scheme f
 
 end CommHopfAlgCat
 


### PR DESCRIPTION
This PR identifies the existing Hopf-spectrum kernel as the scheme-theoretic fibre over the identity section. It proves that the square formed by `kernelSpecι`, the induced Hopf-spectrum morphism, and the two trivial-group maps is a pullback in group schemes over `Spec R`, reusing the quotient–tensor equivalence and Mathlib's affine pullback and limit-reflection infrastructure.

It advances the Layer 3 passage “Hopf ideals ↔ closed subgroup schemes …; the anti-equivalence; kernels” in `TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md` by supplying the categorical universal property of the represented kernel.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"hopf-spec-kernel-pullback"}-->

🤖 Prepared with Codex
