### PR TITLE
feat(DeFinetti/ViaKoopman): the invariant conditional law

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaKoopman/InvariantConditionalLaw.lean
+++ b/TauCeti/Probability/DeFinetti/ViaKoopman/InvariantConditionalLaw.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Kernel.ProbabilityMeasure
+public import TauCeti.Probability.Exchangeability.Basic
+public import Mathlib.MeasureTheory.MeasurableSpace.Invariants
+public import Mathlib.Probability.Kernel.CondDistrib
+
+/-!
+# The invariant conditional law
+
+On path space, the conditional law of the initial coordinate given the **shift-invariant**
+σ-algebra `MeasurableSpace.invariants (shift α)`, bundled as a random probability measure.
+
+It is named a *conditional law*, not a directing measure: this file does not prove that it directs
+the process, and Tau Ceti reserves "directing measure" for a witness of `ConditionallyIIDWith`.
+That name belongs with the theorem, not here. It is deliberately a separate object from
+`directingProbabilityMeasure`, which conditions on the process tail: the two σ-algebras are not
+interchangeable — `invariants_shift_le_pathTail` is one-sided, and `invariants_shift_lt_pathTail`
+shows the inclusion is strict over `Bool` — so sharing the underlying construction asserts nothing
+about the witnesses being equal. Whether they agree a.e. is a separate question, not settled here.
+
+## Main results
+
+* `invariantConditionalProbabilityMeasure` — the witness;
+* `invariantConditionalProbabilityMeasure_toMeasure` — its underlying measure, the abstraction
+  boundary that lets measure-level operations cross without unfolding the definition;
+* `measurable_invariants_invariantConditionalProbabilityMeasure` — measurability relative to the
+  invariant σ-algebra;
+* `measurable_invariantConditionalProbabilityMeasure` — the ambient corollary;
+* `invariantConditionalProbabilityMeasure_ae_eq_condExp` — the characteristic property: evaluated on
+  a measurable set, it is a version of the conditional expectation of that set's indicator at
+  coordinate `0`, given the invariant σ-algebra.
+
+Nothing here proves that this witness directs the process; that is the Koopman block
+factorization, which is not part of this file.
+
+Adapted from `DeFinetti/DirectingMeasure/Basic.lean`, which carries the attribution to
+`cameronfreer/exchangeability` (`DeFinetti/ViaMartingale/DirectingMeasure.lean`, pin
+`e0532e59ceff23edab44dda9ab0655debbc9cc22`). The specialization here is the conditioning
+σ-algebra: that file conditions on `tailProcess X`, this one on
+`MeasurableSpace.invariants (shift α)`, with the shared bundling factored through
+`Kernel.probabilityMeasure`.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory ProbabilityTheory
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α : Type*} [MeasurableSpace α] [StandardBorelSpace α] [Nonempty α]
+
+/-- The **invariant conditional law**: the conditional law of the initial coordinate `x 0` given
+the shift-invariant σ-algebra, bundled as a `ProbabilityMeasure`.
+
+The invariant σ-algebra is a *non-ambient* `MeasurableSpace` on `ℕ → α`, so it must be pinned at
+every layer — both on the bundling wrapper and on the `condDistrib` whose fibres it bundles. -/
+def invariantConditionalProbabilityMeasure (ρ : Measure (ℕ → α)) [IsFiniteMeasure ρ] :
+    (ℕ → α) → ProbabilityMeasure α :=
+  Kernel.probabilityMeasure (mβ := MeasurableSpace.invariants (shift α))
+    (@condDistrib (ℕ → α) (ℕ → α) α _ _ _ _ (MeasurableSpace.invariants (shift α))
+      (fun x => x 0) id ρ _)
+
+/-- The underlying measure is the invariant-indexed `condDistrib` fibre.
+
+This is the abstraction boundary: downstream measure-level reasoning goes through this lemma rather
+than unfolding the definition. -/
+@[simp]
+theorem invariantConditionalProbabilityMeasure_toMeasure {ρ : Measure (ℕ → α)} [IsFiniteMeasure ρ]
+    (x : ℕ → α) :
+    (invariantConditionalProbabilityMeasure ρ x : Measure α)
+      = (@condDistrib (ℕ → α) (ℕ → α) α _ _ _ _ (MeasurableSpace.invariants (shift α))
+          (fun x => x 0) id ρ _) x := by
+  simp only [invariantConditionalProbabilityMeasure, Kernel.probabilityMeasure_toMeasure]
+
+/-- The invariant conditional law is measurable with respect to the **invariant** σ-algebra. -/
+theorem measurable_invariants_invariantConditionalProbabilityMeasure {ρ : Measure (ℕ → α)}
+    [IsFiniteMeasure ρ] :
+    Measurable[MeasurableSpace.invariants (shift α)] (invariantConditionalProbabilityMeasure ρ) :=
+  Kernel.measurable_probabilityMeasure (mβ := MeasurableSpace.invariants (shift α))
+    (@condDistrib (ℕ → α) (ℕ → α) α _ _ _ _ (MeasurableSpace.invariants (shift α))
+      (fun x => x 0) id ρ _)
+
+/-- The ambient corollary, by monotonicity along `MeasurableSpace.invariants_le`. -/
+@[fun_prop]
+theorem measurable_invariantConditionalProbabilityMeasure {ρ : Measure (ℕ → α)}
+    [IsFiniteMeasure ρ] :
+    Measurable (invariantConditionalProbabilityMeasure ρ) :=
+  measurable_invariants_invariantConditionalProbabilityMeasure.mono
+    (MeasurableSpace.invariants_le _) le_rfl
+
+/-- **Characteristic property.** Evaluated on a measurable set `B`, the invariant conditional law
+is a version of the conditional expectation of `𝟙_B ∘ (· 0)` given the shift-invariant σ-algebra.
+
+This is what identifies the witness: everything the Koopman route needs to know about it is that
+its evaluations are these conditional expectations. -/
+theorem invariantConditionalProbabilityMeasure_ae_eq_condExp {ρ : Measure (ℕ → α)}
+    [IsFiniteMeasure ρ] {B : Set α} (hB : MeasurableSet B) :
+    (fun x => ((invariantConditionalProbabilityMeasure ρ x : Measure α)).real B)
+      =ᵐ[ρ] ρ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (fun x : ℕ → α => x 0) |
+        MeasurableSpace.invariants (shift α)] := by
+  have hid : @Measurable (ℕ → α) (ℕ → α) _ (MeasurableSpace.invariants (shift α)) id :=
+    measurable_id'' (MeasurableSpace.invariants_le (shift α))
+  have hcoord : Measurable fun x : ℕ → α => x 0 := measurable_pi_apply 0
+  have h := condDistrib_ae_eq_condExp (μ := ρ) (Y := fun x : ℕ → α => x 0)
+    (X := (id : (ℕ → α) → (ℕ → α))) hid hcoord hB
+  rw [MeasurableSpace.comap_id] at h
+  have hpre : ((fun x : ℕ → α => x 0) ⁻¹' B).indicator (fun _ => (1 : ℝ))
+      = Set.indicator B (fun _ => (1 : ℝ)) ∘ (fun x : ℕ → α => x 0) := by
+    funext y
+    exact Set.indicator_comp_right (g := fun _ => (1 : ℝ)) (fun x : ℕ → α => x 0)
+  rw [hpre] at h
+  simpa only [invariantConditionalProbabilityMeasure_toMeasure, id_eq] using h
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
Roadmap: Exchangeability

Roadmap file: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 5** (Koopman operators and
invariant σ-algebras). Intention `TauCetiProject/TauCetiRoadmap#133`, which stays open and claimed:
this is one step of it, not the whole route.

## What

```lean
def invariantConditionalProbabilityMeasure (ρ : Measure (ℕ → α)) [IsFiniteMeasure ρ] :
    (ℕ → α) → ProbabilityMeasure α
```

the conditional law of the initial coordinate given `MeasurableSpace.invariants (shift α)`, bundled
as a random probability measure, with invariant-relative measurability, the ambient corollary via
`MeasurableSpace.invariants_le`, and the characteristic property

```lean
(fun x => ((invariantConditionalProbabilityMeasure ρ x : Measure α)).real B)
  =ᵐ[ρ] ρ[Set.indicator B (fun _ => (1 : ℝ)) ∘ (fun x => x 0) | MeasurableSpace.invariants (shift α)]
```

## Why a second witness rather than reusing the tail one

`directingProbabilityMeasure` conditions on the process tail. These σ-algebras are **not**
interchangeable: `invariants_shift_le_pathTail` is one-sided, and `invariants_shift_lt_pathTail`
shows the inclusion is strict over `Bool`. So this is a genuinely different object, and sharing the
underlying `Kernel.probabilityMeasure` construction (TauCetiProject/TauCeti#1726) asserts nothing
about the two witnesses being equal.

Whether they agree a.e. is a later theorem, reached by proving each directs the process and applying
`conditionallyIID_ae_unique` — a consequence of two independent constructions rather than an
assumption that quietly imports the martingale route.

## Scope

Nothing here proves this witness directs the process; that is the block factorization, and it is not
in this PR. The module docstring says so rather than describing the route as if it existed.

## Import firewall

The Koopman subtree is meant not to depend on `DeFinetti.Theorem`, `TailFactorization`, the
reverse-martingale convergence theorem, `ViaL2`, or the unsuffixed `conditionallyIID_of_contractable`.
This module's direct imports are only `Probability.Kernel.ProbabilityMeasure`,
`Exchangeability.Basic`, and two Mathlib modules — no violation at the direct-import level. I have
not verified the transitive closure; a CI check enforcing that barrier would live in `.github/`,
which is human-owned, so I have not added one.

## A note on non-ambient σ-algebras

`MeasurableSpace.invariants (shift α)` is a second `MeasurableSpace (ℕ → α)` alongside the ambient
one, so elaboration needs help. Where the σ-algebra appears in the **definition's type** it is
pinned explicitly, on both the bundling wrapper and the `condDistrib` whose fibres it bundles;
underscores there silently resolve to the ambient instance. In the characteristic property it flows
from `hid` by unification instead, matching how the tail witness is proved.

## Verification

Full `lake build` green; `lake exe axioms` all 19514 declarations within
`propext, Classical.choice, Quot.sound`; `lake exe module-system` all 1066 modules opt in;
`scripts/lint-env.sh` PASS (54 grandfathered, 0 new). No `sorry`.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol



## Why this is a new PR

Replaces **#1731**, which I am closing. Content is that PR's final state after two review rounds,
byte-identical — all six findings it collected are applied:

* `naming` — the identifier said "directing measure" while the file explicitly does not prove the
  witness directs anything, so it is `invariantConditionalProbabilityMeasure` in
  `InvariantConditionalLaw.lean`; the directing-measure name waits for the theorem;
* `api-design` — `invariantConditionalProbabilityMeasure_toMeasure` (`@[simp]`) is the abstraction
  boundary, so measure-level reasoning need not unfold the definition;
* `reuse` — the indicator/preimage case split is replaced by `Set.indicator_comp_right`;
* `attribution` — carries forward `DirectingMeasure/Basic.lean`'s credit to
  `cameronfreer/exchangeability` (pin `e0532e5`), naming the specialization;
* `documentation` — two declaration docstrings still called it a directing measure after the rename;
* `proof-quality` — the characteristic property now goes through the boundary lemma instead of
  unfolding the definition.

#1731's review pipeline stopped responding. Its last scoreboard was 2026-08-02T12:12:59Z, two heads
old; rounds afterwards registered in the meta (`round=3` at `14:00:07Z` on the current head) but
posted no scoreboard, findings, or verdict. A `/review` from a human and a retrigger commit each
produced the same silence. CI was green on the current head throughout.

This branch is also cut from a much newer `main` — #1731's base had drifted roughly 35 PRs behind
while it sat unreviewed. Full gate on the new base: build 6302 jobs; `lake exe axioms` all 21031
declarations within `propext, Classical.choice, Quot.sound`; `lake exe module-system` all 1156
modules; `scripts/lint-env.sh` PASS (54 grandfathered, 0 new).

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
