### PR TITLE
feat: add Clifford filtration graded equivalence

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -112,6 +112,26 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
     (Submodule.Quotient.mk y))
   exact Subtype.ext (coe_equivExteriorFiltration_apply Q (k + 1) x)
 
+/-- The inverse graded equivalence sends an exterior element to the quotient class of its
+preimage under `equivExterior`. -/
+@[simp]
+theorem filtrationGradedEquiv_symm_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+    (x : ⋀[R]^(k + 1) M) :
+    (filtrationGradedEquiv Q k).symm x =
+      Submodule.Quotient.mk
+        (⟨(equivExterior Q).symm x, by
+          simpa only [coe_equivExteriorFiltration_symm_apply] using
+            ((equivExteriorFiltration Q (k + 1)).symm
+              (⟨x, ι_range_pow_le_filtration (0 : QuadraticForm R M) (k + 1) x.property⟩ :
+                filtration (0 : QuadraticForm R M) (k + 1))).property⟩ :
+          filtration Q (k + 1)) := by
+  rw [filtrationGradedEquiv, LinearEquiv.trans_symm, LinearEquiv.trans_apply,
+    zeroFormFiltrationQuotientEquivExteriorPower_symm_apply,
+    equivExteriorFiltrationQuotient, Submodule.Quotient.equiv_symm,
+    Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  apply congrArg Submodule.Quotient.mk
+  exact Subtype.ext (coe_equivExteriorFiltration_symm_apply Q (k + 1) _)
+
 end CliffordAlgebra
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -1,0 +1,104 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.LinearAlgebra.CliffordAlgebra.ExteriorFiltration
+
+/-!
+# The degree quotients of a Clifford filtration
+
+Mathlib's `CliffordAlgebra.equivExterior` identifies a Clifford algebra with its exterior-algebra
+model when `2` is invertible. This file proves that the equivalence respects the degree filtration,
+then transports the zero-form calculation of each successive quotient to an arbitrary quadratic
+form.
+
+This is the degree-quotient part of the Layer 0 `filtrationGradedEquiv` target in the
+[spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68).
+It does not construct the total associated-graded algebra or prove multiplication compatibility.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.equivExteriorFiltration`: `equivExterior` restricted to one filtration
+  step.
+* `TauCeti.CliffordAlgebra.filtrationGradedEquiv`: the corresponding degree-quotient equivalence
+  with the exterior power.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 0, "The degree filtration".
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- `equivExterior` maps every Clifford filtration step to the corresponding zero-form step. -/
+theorem equivExterior_map_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+    (filtration Q k).map (equivExterior Q).toLinearMap = filtration (0 : QuadraticForm R M) k :=
+  changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k
+
+/-- `equivExterior` restricted to a Clifford filtration step. -/
+noncomputable def equivExteriorFiltration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+    filtration Q k ≃ₗ[R] filtration (0 : QuadraticForm R M) k :=
+  (equivExterior Q).ofSubmodules _ _ (equivExterior_map_filtration Q k)
+
+/-- The restricted equivalence agrees with `equivExterior` after coercion from a filtration step. -/
+@[simp]
+theorem coe_equivExteriorFiltration_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+    (x : filtration Q k) :
+    (equivExteriorFiltration Q k x : CliffordAlgebra (0 : QuadraticForm R M)) = equivExterior Q x :=
+  LinearEquiv.ofSubmodules_apply (equivExterior Q) (equivExterior_map_filtration Q k) x
+
+private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (k : ℕ) :
+    (Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)).map
+        (equivExteriorFiltration Q (k + 1)).toLinearMap =
+      Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
+        (filtration (0 : QuadraticForm R M) k) := by
+  ext x
+  rw [Submodule.mem_map_equiv]
+  -- The two submodules are over filtration subtypes, so expose their ambient carrier predicates.
+  change (equivExterior Q).symm (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration Q k ↔
+    (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration (0 : QuadraticForm R M) k
+  rw [← equivExterior_map_filtration Q k, Submodule.mem_map_equiv]
+
+private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M)
+    [Invertible (2 : R)] (k : ℕ) :
+    (filtration Q (k + 1) ⧸
+      Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)) ≃ₗ[R]
+      (filtration (0 : QuadraticForm R M) (k + 1) ⧸
+        Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
+          (filtration (0 : QuadraticForm R M) k)) :=
+  Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
+    (equivExteriorFiltration_map_previous Q k)
+
+/-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
+noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
+    (filtration Q (k + 1) ⧸
+      Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)) ≃ₗ[R] ⋀[R]^(k + 1) M :=
+  (equivExteriorFiltrationQuotient Q k).trans (zeroFormFiltrationQuotientEquivExteriorPower k)
+
+/-- On quotient representatives, `filtrationGradedEquiv` first applies `equivExterior`. -/
+@[simp]
+theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+    (x : filtration Q (k + 1)) :
+    filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
+      zeroFormFiltrationQuotientEquivExteriorPower k
+        (Submodule.Quotient.mk (equivExteriorFiltration Q (k + 1) x)) := by
+  rw [filtrationGradedEquiv, equivExteriorFiltrationQuotient]
+  rfl
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -49,6 +49,21 @@ noncomputable def equivExteriorFiltration (Q : QuadraticForm R M) [Invertible (2
   (equivExterior Q).ofSubmodules _ _
     (changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k)
 
+/-- Coercing the restricted exterior equivalence is the ambient `equivExterior` map. -/
+@[simp]
+theorem coe_equivExteriorFiltration_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
+    (x : filtration Q k) :
+    (equivExteriorFiltration Q k x : CliffordAlgebra (0 : QuadraticForm R M)) =
+      equivExterior Q x := by
+  simp only [equivExteriorFiltration, equivExterior, LinearEquiv.ofSubmodules_apply]
+
+/-- Coercing the inverse restricted exterior equivalence is the ambient inverse map. -/
+@[simp]
+theorem coe_equivExteriorFiltration_symm_apply (Q : QuadraticForm R M) [Invertible (2 : R)]
+    (k : ℕ) (x : filtration (0 : QuadraticForm R M) k) :
+    ((equivExteriorFiltration Q k).symm x : CliffordAlgebra Q) = (equivExterior Q).symm x := by
+  simp only [equivExteriorFiltration, equivExterior, LinearEquiv.ofSubmodules_symm_apply]
+
 private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [Invertible (2 : R)]
     (k : ℕ) :
     (Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)).map
@@ -86,9 +101,16 @@ theorem filtrationGradedEquiv_apply_mk (Q : QuadraticForm R M) [Invertible (2 : 
     (x : filtration Q (k + 1)) :
     filtrationGradedEquiv Q k (Submodule.Quotient.mk x) =
       zeroFormFiltrationQuotientEquivExteriorPower k
-        (Submodule.Quotient.mk (equivExteriorFiltration Q (k + 1) x)) := by
-  rw [filtrationGradedEquiv, equivExteriorFiltrationQuotient]
-  rfl
+        (Submodule.Quotient.mk
+          (⟨equivExterior Q x, by
+            simpa only [coe_equivExteriorFiltration_apply] using
+              (equivExteriorFiltration Q (k + 1) x).property⟩ :
+            filtration (0 : QuadraticForm R M) (k + 1))) := by
+  rw [filtrationGradedEquiv, LinearEquiv.trans_apply, equivExteriorFiltrationQuotient,
+    Submodule.Quotient.equiv_apply, Submodule.mapQ_apply]
+  apply congrArg (fun y => zeroFormFiltrationQuotientEquivExteriorPower k
+    (Submodule.Quotient.mk y))
+  exact Subtype.ext (coe_equivExteriorFiltration_apply Q (k + 1) x)
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -43,22 +43,11 @@ namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
 
-/-- `equivExterior` maps every Clifford filtration step to the corresponding zero-form step. -/
-theorem equivExterior_map_filtration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
-    (filtration Q k).map (equivExterior Q).toLinearMap = filtration (0 : QuadraticForm R M) k :=
-  changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k
-
 /-- `equivExterior` restricted to a Clifford filtration step. -/
 noncomputable def equivExteriorFiltration (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
     filtration Q k ≃ₗ[R] filtration (0 : QuadraticForm R M) k :=
-  (equivExterior Q).ofSubmodules _ _ (equivExterior_map_filtration Q k)
-
-/-- The restricted equivalence agrees with `equivExterior` after coercion from a filtration step. -/
-@[simp]
-theorem coe_equivExteriorFiltration_apply (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ)
-    (x : filtration Q k) :
-    (equivExteriorFiltration Q k x : CliffordAlgebra (0 : QuadraticForm R M)) = equivExterior Q x :=
-  LinearEquiv.ofSubmodules_apply (equivExterior Q) (equivExterior_map_filtration Q k) x
+  (equivExterior Q).ofSubmodules _ _
+    (changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k)
 
 private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [Invertible (2 : R)]
     (k : ℕ) :
@@ -69,9 +58,11 @@ private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [In
   ext x
   rw [Submodule.mem_map_equiv]
   -- The two submodules are over filtration subtypes, so expose their ambient carrier predicates.
-  change (equivExterior Q).symm (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration Q k ↔
+  change (changeFormEquiv changeForm.associated_neg_proof).symm
+      (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration Q k ↔
     (x : CliffordAlgebra (0 : QuadraticForm R M)) ∈ filtration (0 : QuadraticForm R M) k
-  rw [← equivExterior_map_filtration Q k, Submodule.mem_map_equiv]
+  rw [← changeFormEquiv_map_filtration Q changeForm.associated_neg_proof k,
+    Submodule.mem_map_equiv]
 
 private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M)
     [Invertible (2 : R)] (k : ℕ) :


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds the generic equivalence from a successive Clifford-filtration quotient to its exterior power.

- Proves `equivExterior` preserves each filtration step.
- Restricts it to filtration submodules and transports the preceding step.
- Composes that transport with the zero-form quotient equivalence as `filtrationGradedEquiv`.

## Roadmap target

Advances the degree-quotient part of Layer 0 `filtrationGradedEquiv`:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68

This is the remaining Layer 0 dependency of the Layer 3 bivector-closure target. Total associated-graded multiplication remains out of scope.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/Suggested.lean#filtrationGradedEquiv"}-->

## Verification

`lake build TauCeti`, `lake build --iofail`, axiom and module-system audits, environment lint, whitespace, and a downstream API probe pass at `846187095ad93bcfebd4e758f577984526085af6`. A fresh independent exact-head rubric review approves it.

## Scope

- **Consumes:** change-of-form filtration transport and the zero-form exterior quotient equivalence.
- **Provides:** the arbitrary-form equivalence from each successive filtration quotient to its exterior power.
- **Fits:** supplies the degreewise comparison consumed by associated-graded multiplication and later bivector work.
- **Boundary:** multiplication compatibility and total associated-graded assembly require downstream constructions.

<sub>🤖 GPT-5.6 Terra max · rubrics @ [222eed0](https://github.com/TauCetiProject/TauCetiReview/commit/222eed046013fbee91239aea4a5186b12f086e65) · local review fixed: proof-quality (4)</sub>