### PR TITLE
refactor(UniversalCover): name the fibre-projection step of the monodromy comparison

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -116,18 +116,8 @@ private theorem monodromy_mapOfEq_subgroupQuotientProj
     dsimp only [e]
     rw [SubgroupQuotient.basepointLift_coe]
   let e' := hq.isCoveringMap.monodromy g e
-  have he'_basepoint : subgroupQuotientMap x₀ H e' =
-      SubgroupQuotient.basepoint x₀ H := by
-    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e'.2
-  have he' : proj (e' : UniversalCover x₀) = x₀ := by
-    calc
-      proj (e' : UniversalCover x₀) =
-          subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e') := by
-            exact congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e' |>.symm
-      _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by
-            rw [he'_basepoint]
-      _ = x₀ := subgroupQuotientProj_basepoint x₀ H
-  let e'' : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} := ⟨e', he'⟩
+  let e'' : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} :=
+    ⟨e', proj_eq_of_mem_subgroupQuotientMap_fibre x₀ H e'⟩
   -- Lift `g` through the quotient map, then map that same lifted path through the descended
   -- endpoint map; the commuting triangle identifies it as the universal-cover lift.
   have hmon : (isCoveringMap x₀).monodromy

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -147,6 +147,20 @@ theorem subgroupQuotientProj_basepoint (H : Subgroup (FundamentalGroup X x₀)) 
     subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) = x₀ :=
   subgroupQuotientProj_mk x₀ H _
 
+/-- **A point over the distinguished point of the quotient lies over the basepoint.** The descended
+projection composed with the quotient covering map is the universal-cover projection, so any point
+of the fibre over `SubgroupQuotient.basepoint x₀ H` projects to `x₀`. -/
+theorem proj_eq_of_mem_subgroupQuotientMap_fibre (H : Subgroup (FundamentalGroup X x₀))
+    (y : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
+    proj (y : UniversalCover x₀) = x₀ := by
+  have hb : subgroupQuotientMap x₀ H y = SubgroupQuotient.basepoint x₀ H := by
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using y.2
+  calc
+    proj (y : UniversalCover x₀) = subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H y) :=
+      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) y |>.symm
+    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hb]
+    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
+
 /-- The descended endpoint projection is continuous. -/
 theorem continuous_subgroupQuotientProj (H : Subgroup (FundamentalGroup X x₀)) :
     Continuous (subgroupQuotientProj x₀ H) := by


### PR DESCRIPTION
`monodromy_mapOfEq_subgroupQuotientProj` had a **59-line body**, eleven lines of
which established that the monodromy point of the quotient cover projects to
`x₀` — all before the commuting-triangle argument the theorem is actually
about.

That is a statement about the fibre alone: the quotient projection composed
with the quotient covering map *is* the universal-cover projection, so any
point over the basepoint of `SubgroupQuotient x₀ H` lies over `x₀`. It is now:

```lean
omit [LocallyPathConnectedSpace X] [PathConnectedSpace X]
  [SemilocallySimplyConnectedSpace X] in
private theorem proj_eq_of_mem_subgroupQuotientMap_fibre
    (H : Subgroup (FundamentalGroup X x₀))
    (y : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
    proj (y : UniversalCover x₀) = x₀
```

Note the `omit`: the fact needs none of the file's ambient connectivity
instances. It is pure fibre bookkeeping, so it holds for any topological `X`.
Lean's unused-section-variable check is what surfaced that.

Body: **59 → 49**. The helper is 7 lines and `private`; the public signature is
unchanged.

Gates run locally: `lake build` (6307 jobs), `lake exe axioms` (21079 decls in
allowlist), `lake exe module-system` (1161 modules), `scripts/lint-env.sh`
PASS.

Roadmap: UniversalCovers