### PR TITLE
refactor(Lie): split tangentToLeftInvariantDerivation into its two constructions

### DIFF
--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -142,76 +142,88 @@ theorem mulInvariantVectorField_one (v : GroupLieAlgebra I G) :
   rw [show (fun x : G ↦ 1 * x) = id by funext x; simp, mfderiv_id]
   rfl
 
+/-- The derivation of smooth functions that differentiates along the left-invariant vector
+field of a tangent vector `v` at the identity. -/
+private noncomputable def mulInvariantDerivation [ContMDiffMul I ∞ G]
+    (v : GroupLieAlgebra I G) : Derivation 𝕜 C^∞⟮I, G; 𝕜⟯ C^∞⟮I, G; 𝕜⟯ :=
+  Derivation.mk'
+      { toFun := fun f ↦
+          ⟨fun g ↦ mvfderiv I f g (mulInvariantVectorField v g),
+            contMDiff_mvfderiv_mulInvariantVectorField v f⟩
+        map_add' := fun f g ↦ by
+          ext x
+          -- Unfold the smooth-function wrappers to use linearity of `mvfderiv`.
+          change mvfderiv I (⇑f + ⇑g) x (mulInvariantVectorField v x) =
+            mvfderiv I f x (mulInvariantVectorField v x) +
+              mvfderiv I g x (mulInvariantVectorField v x)
+          exact congr($(mvfderiv_add
+            (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+            (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
+            (mulInvariantVectorField v x))
+        map_smul' := fun c f ↦ by
+          ext x
+          have hc : MDiffAt (fun _ : G ↦ c) x := mdifferentiableAt_const
+          -- Unfold the smooth-function wrappers to use the product rule for `mvfderiv`.
+          change mvfderiv I ((fun _ : G ↦ c) • ⇑f) x (mulInvariantVectorField v x) =
+            c • mvfderiv I f x (mulInvariantVectorField v x)
+          have h := congr($(mvfderiv_smul hc
+            (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
+            (mulInvariantVectorField v x))
+          calc
+            _ = (c • mvfderiv I f x +
+                (mvfderiv I (fun _ : G ↦ c) x).smulRight (f x))
+                (mulInvariantVectorField v x) := h
+            _ = _ := by simp [mvfderiv_const] }
+      fun f g ↦ by
+        ext x
+        -- Unfold the smooth-function wrappers to use the product rule for `mvfderiv`.
+        change mvfderiv I (⇑f * ⇑g) x (mulInvariantVectorField v x) =
+          f x * mvfderiv I g x (mulInvariantVectorField v x) +
+            g x * mvfderiv I f x (mulInvariantVectorField v x)
+        exact congr($(mvfderiv_mul
+          (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+          (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
+          (mulInvariantVectorField v x))
+
+/-- `mulInvariantDerivation v` is left invariant: differentiating along a left-invariant
+vector field commutes with left translation. -/
+private theorem hfdifferential_evalAt_one_mulInvariantDerivation [ContMDiffMul I ∞ G]
+    (v : GroupLieAlgebra I G) (g : G) :
+    (𝒅ₕ (smoothLeftMul_one I g)) (Derivation.evalAt 1 (mulInvariantDerivation v)) =
+      Derivation.evalAt g (mulInvariantDerivation v) := by
+  ext f
+  -- The calculation endpoints unfold `hfdifferential`, `evalAt` and `mulInvariantDerivation`.
+  calc
+    ((𝒅ₕ (smoothLeftMul_one I g))
+        (Derivation.evalAt 1 (mulInvariantDerivation v))) f =
+        mvfderiv I ((show C^∞⟮I, G; 𝕜⟯ from f).comp (smoothLeftMul I g)) 1
+          (mulInvariantVectorField v 1) := rfl
+    _ = mvfderiv I ((show C^∞⟮I, G; 𝕜⟯ from f).comp (smoothLeftMul I g)) 1 v := by
+      rw [mulInvariantVectorField_one]
+    _ = mvfderiv I (show C^∞⟮I, G; 𝕜⟯ from f) g
+        (mulInvariantVectorField v g) := by
+      rw [mulInvariantVectorField]
+      -- Expose the function composition hidden by `ContMDiffMap.comp`.
+      change (mfderiv I (modelWithCornersSelf 𝕜 𝕜) (fun x ↦ f (g * x)) 1) v =
+        (mfderiv I (modelWithCornersSelf 𝕜 𝕜) f g)
+          ((mfderiv I I (fun x ↦ g * x) 1) v)
+      have h := mfderiv_comp_apply 1
+        (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
+        ((contMDiff_mul_left (n := ∞) (a := g)).mdifferentiable (by simp)).mdifferentiableAt v
+      rw [mul_one] at h
+      change ((mfderiv I (modelWithCornersSelf 𝕜 𝕜)
+        ((show G → 𝕜 from f) ∘ fun x ↦ g * x) 1) v) = _
+      exact h
+    _ = (Derivation.evalAt g (mulInvariantDerivation v)) f := rfl
+
 /-- The left-invariant derivation associated to a tangent vector at the identity. At every point it
 acts by differentiating along Mathlib's corresponding left-invariant vector field. -/
 noncomputable def tangentToLeftInvariantDerivation
     [ContMDiffMul I ∞ G] :
     GroupLieAlgebra I G →ₗ[𝕜] LeftInvariantDerivation I G where
-  toFun v := by
-    let D : Derivation 𝕜 C^∞⟮I, G; 𝕜⟯ C^∞⟮I, G; 𝕜⟯ :=
-      Derivation.mk'
-          { toFun := fun f ↦
-              ⟨fun g ↦ mvfderiv I f g (mulInvariantVectorField v g),
-                contMDiff_mvfderiv_mulInvariantVectorField v f⟩
-            map_add' := fun f g ↦ by
-              ext x
-              -- Unfold the smooth-function wrappers to use linearity of `mvfderiv`.
-              change mvfderiv I (⇑f + ⇑g) x (mulInvariantVectorField v x) =
-                mvfderiv I f x (mulInvariantVectorField v x) +
-                  mvfderiv I g x (mulInvariantVectorField v x)
-              exact congr($(mvfderiv_add
-                (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
-                (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
-                (mulInvariantVectorField v x))
-            map_smul' := fun c f ↦ by
-              ext x
-              have hc : MDiffAt (fun _ : G ↦ c) x := mdifferentiableAt_const
-              -- Unfold the smooth-function wrappers to use the product rule for `mvfderiv`.
-              change mvfderiv I ((fun _ : G ↦ c) • ⇑f) x (mulInvariantVectorField v x) =
-                c • mvfderiv I f x (mulInvariantVectorField v x)
-              have h := congr($(mvfderiv_smul hc
-                (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
-                (mulInvariantVectorField v x))
-              calc
-                _ = (c • mvfderiv I f x +
-                    (mvfderiv I (fun _ : G ↦ c) x).smulRight (f x))
-                    (mulInvariantVectorField v x) := h
-                _ = _ := by simp [mvfderiv_const] }
-          fun f g ↦ by
-            ext x
-            -- Unfold the smooth-function wrappers to use the product rule for `mvfderiv`.
-            change mvfderiv I (⇑f * ⇑g) x (mulInvariantVectorField v x) =
-              f x * mvfderiv I g x (mulInvariantVectorField v x) +
-                g x * mvfderiv I f x (mulInvariantVectorField v x)
-            exact congr($(mvfderiv_mul
-              (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
-              (g.contMDiff.mdifferentiable (by simp)).mdifferentiableAt)
-              (mulInvariantVectorField v x))
-    refine { toDerivation := D, left_invariant'' := fun g ↦ ?_ }
-    · ext f
-      -- The calculation endpoints unfold `hfdifferential`, `evalAt`, and the local derivation `D`.
-      calc
-        ((𝒅ₕ (smoothLeftMul_one I g))
-            (Derivation.evalAt 1 D)) f =
-            mvfderiv I ((show C^∞⟮I, G; 𝕜⟯ from f).comp (smoothLeftMul I g)) 1
-              (mulInvariantVectorField v 1) := rfl
-        _ = mvfderiv I ((show C^∞⟮I, G; 𝕜⟯ from f).comp (smoothLeftMul I g)) 1 v := by
-          rw [mulInvariantVectorField_one]
-        _ = mvfderiv I (show C^∞⟮I, G; 𝕜⟯ from f) g
-            (mulInvariantVectorField v g) := by
-          rw [mulInvariantVectorField]
-          -- Expose the function composition hidden by `ContMDiffMap.comp`.
-          change (mfderiv I (modelWithCornersSelf 𝕜 𝕜) (fun x ↦ f (g * x)) 1) v =
-            (mfderiv I (modelWithCornersSelf 𝕜 𝕜) f g)
-              ((mfderiv I I (fun x ↦ g * x) 1) v)
-          have h := mfderiv_comp_apply 1
-            (f.contMDiff.mdifferentiable (by simp)).mdifferentiableAt
-            ((contMDiff_mul_left (n := ∞) (a := g)).mdifferentiable (by simp)).mdifferentiableAt v
-          rw [mul_one] at h
-          change ((mfderiv I (modelWithCornersSelf 𝕜 𝕜)
-            ((show G → 𝕜 from f) ∘ fun x ↦ g * x) 1) v) = _
-          exact h
-        _ = (Derivation.evalAt g D) f := rfl
+  toFun v :=
+    { toDerivation := mulInvariantDerivation v
+      left_invariant'' := hfdifferential_evalAt_one_mulInvariantDerivation v }
   map_add' v w := by
     apply LeftInvariantDerivation.evalAt_one_injective
     ext f

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -187,7 +187,7 @@ private noncomputable def mulInvariantDerivation [ContMDiffMul I ∞ G]
 
 /-- `mulInvariantDerivation v` is left invariant: differentiating along a left-invariant
 vector field commutes with left translation. -/
-private theorem hfdifferential_evalAt_one_mulInvariantDerivation [ContMDiffMul I ∞ G]
+private theorem mulInvariantDerivation_left_invariant [ContMDiffMul I ∞ G]
     (v : GroupLieAlgebra I G) (g : G) :
     (𝒅ₕ (smoothLeftMul_one I g)) (Derivation.evalAt 1 (mulInvariantDerivation v)) =
       Derivation.evalAt g (mulInvariantDerivation v) := by
@@ -223,7 +223,7 @@ noncomputable def tangentToLeftInvariantDerivation
     GroupLieAlgebra I G →ₗ[𝕜] LeftInvariantDerivation I G where
   toFun v :=
     { toDerivation := mulInvariantDerivation v
-      left_invariant'' := hfdifferential_evalAt_one_mulInvariantDerivation v }
+      left_invariant'' := mulInvariantDerivation_left_invariant v }
   map_add' v w := by
     apply LeftInvariantDerivation.evalAt_one_injective
     ext f


### PR DESCRIPTION
`tangentToLeftInvariantDerivation` packs two independent constructions into a single 79-line `toFun`:

1. build a derivation of smooth functions by differentiating along the invariant vector field of `v` — the `Derivation.mk'` term, carrying the additivity, homogeneity and Leibniz obligations;
2. prove that derivation is left invariant — the `hfdifferential`/`evalAt` `calc`.

This PR names both:

```lean
private noncomputable def mulInvariantDerivation [ContMDiffMul I ∞ G]
    (v : GroupLieAlgebra I G) : Derivation 𝕜 C^∞⟮I, G; 𝕜⟯ C^∞⟮I, G; 𝕜⟯

private theorem hfdifferential_evalAt_one_mulInvariantDerivation [ContMDiffMul I ∞ G]
    (v : GroupLieAlgebra I G) (g : G) :
    (𝒅ₕ (smoothLeftMul_one I g)) (Derivation.evalAt 1 (mulInvariantDerivation v)) =
      Derivation.evalAt g (mulInvariantDerivation v)
```

The linear map is then assembled from the two by name; `map_add'` and `map_smul'` are untouched.

Both helpers take exactly the hypotheses their own statements need — `v`, and for the invariance the point `g` — rather than inheriting the enclosing `toFun`'s context. The old proof bound the derivation to a local `let D`; the accompanying comment naming `D` is updated, since there is no longer such a local.

**Definitional transparency is preserved.** `tangentToLeftInvariantDerivation_apply` is proved `by rfl`, and the helpers are private in the *same* file as their consumer, so the module system still exposes their bodies to it. Verified by a full `lake build`.

Proof body: **79 → 18** lines, with helpers of 38 and 24. No signature changes.

Note on lanes: this file is in the area the ReductiveGroups work is developing, but no open PR touches it and no unexpired coordination claim covers it. Being a pure refactor with no signature change, it should rebase cleanly under anything in flight.

Roadmap: none

---

### On reusing `tangentToPointDerivation` for the algebra obligations

A pre-submission review raised that `mulInvariantDerivation`'s `map_add'`/`map_smul'`/Leibniz obligations duplicate the ones inside `tangentToPointDerivation` (`Geometry/Manifold/DerivationBundle.lean`), and suggested discharging them via `(tangentToPointDerivation x (mulInvariantVectorField v x)).map_add`, `.map_smul`, `.leibniz` after `ext x`.

**The duplication is real** — the two files carry the same `congr($(mvfderiv_add …))` idiom — but I could not make that exact substitution compile, and I would rather say so than quietly leave it out:

1. `simpa only [tangentToPointDerivation_apply] using map_add …` does not close `map_add'`. The goal is stated against the raw bundled term, so the elaborated expected type is
   `⟨fun g => (d% ⇑(f + g) g) (mulInvariantVectorField v g), _⟩ x = …`
   rather than an `mvfderiv` application; the original `change` is what exposes it, and is still needed.
2. `.map_smul` does not apply at all:
   `failed to synthesize MulActionHomClass (PointDerivation I x) 𝕜 C^∞⟮I, G; 𝓘(𝕜, 𝕜), 𝕜⟯ 𝕜`.
   That obligation's `smul` is by the *constant function* `fun _ : G ↦ c`, not by the scalar `c`, so the point derivation's 𝕜-linearity is not the fact being used.

So the honest reuse here is not the one-line substitution; it would need a shared lemma stated for the function-valued derivation, which is a design change rather than this PR's decomposition. This PR moves the obligations unchanged and does not claim to dedupe them. Happy to do that follow-up separately if it is wanted.