### PR TITLE
refactor(Tangent): name the counit-coefficient identification in derivationCompAux

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -13,9 +13,9 @@ A morphism `φ : A' →ₐc[R] A` of bialgebras sends a counit-valued derivation
 one of `A'` by precomposition. The construction splits the transport into the two halves
 Mathlib provides: restricting the domain along `φ` (`Derivation.compAlgebraMap`, over
 local scalar-tower instances for `φ`), and moving the coefficients across the canonical
-identification of the two counit coefficient algebras, which is `A'`-linear precisely
-because bialgebra morphisms intertwine counits (`LinearEquiv.compDer`). The Leibniz rule
-therefore comes from those two facts and is not reproved here.
+identification of the two counit coefficient algebras (`counitAlgebraCongr`), which is
+`A'`-linear precisely because bialgebra morphisms intertwine counits (`LinearEquiv.compDer`).
+The Leibniz rule therefore comes from those two facts and is not reproved here.
 
 ## Main declarations
 
@@ -40,6 +40,30 @@ section DerivationMap
 variable {R A A' B : Type*} [CommSemiring R]
   [CommSemiring A] [Bialgebra R A] [CommSemiring A'] [Bialgebra R A']
   [Semiring B] [Algebra R B]
+
+/-- **The two counit coefficient algebras agree, `A'`-linearly.** `Bialgebra.CounitAlgebra R A B`
+and `Bialgebra.CounitAlgebra R A' B` are both copies of `B`, and the identification between them is
+`A'`-linear exactly because a bialgebra morphism intertwines the counits
+(`BialgHom.counitAlgHom_comp`). The `A'`-algebra structure on the `A`-side copy is not the global
+one, so it is taken as an instance argument together with `hmap`, which says its structure map
+factors through `φ` — the only property of it this construction uses. -/
+private noncomputable def counitAlgebraCongr (φ : A' →ₐc[R] A)
+    [Algebra A' (Bialgebra.CounitAlgebra R A B)]
+    (hmap : ∀ a : A', algebraMap A' (Bialgebra.CounitAlgebra R A B) a =
+      algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a)) :
+    Bialgebra.CounitAlgebra R A B ≃ₐ[A'] Bialgebra.CounitAlgebra R A' B :=
+  AlgEquiv.ofRingEquiv
+    (f := (Bialgebra.CounitAlgebra.algEquivSelf R A B).toRingEquiv.trans
+      (Bialgebra.CounitAlgebra.algEquivSelf R A' B).symm.toRingEquiv) (by
+    intro a
+    simp only [RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
+      Bialgebra.CounitAlgebra.algEquivSelf_apply]
+    rw [hmap a, Bialgebra.CounitAlgebra.algebraMap_apply R A B,
+      Bialgebra.CounitAlgebra.algebraMap_apply R A' B,
+      Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B]
+    exact congrArg (algebraMap R B)
+      (DFunLike.congr_fun (BialgHom.counitAlgHom_comp φ) a))
+
 
 /-- Implementation of the bundled `derivationComp`, which is the API. -/
 private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
@@ -78,34 +102,16 @@ private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
         IsScalarTower.coe_toAlgHom', ← IsScalarTower.algebraMap_apply]
   letI : IsScalarTower A' A (Bialgebra.CounitAlgebra R A B) :=
     IsScalarTower.of_algebraMap_eq' rfl
-  let eRing : Bialgebra.CounitAlgebra R A B ≃+* Bialgebra.CounitAlgebra R A' B :=
-    (Bialgebra.CounitAlgebra.algEquivSelf R A B).toRingEquiv.trans
-      (Bialgebra.CounitAlgebra.algEquivSelf R A' B).symm.toRingEquiv
-  let e : Bialgebra.CounitAlgebra R A B ≃ₐ[A'] Bialgebra.CounitAlgebra R A' B :=
-    AlgEquiv.ofRingEquiv (f := eRing) (by
-      intro a
-      -- The single mathematical obligation: the two `A'`-algebra maps agree because
-      -- `φ` intertwines the counits. The transports erase pointwise, the left algebra
-      -- map is `algebraMap A (CounitAlgebra R A B)` at `φ a` by the local instance, and
-      -- both sides then reduce through the counit.
-      simp only [eRing, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
-        Bialgebra.CounitAlgebra.algEquivSelf_apply]
-      -- The `A'`-algebra map on the left is the local `letI` instance, whose value
-      -- is definitionally `ρ a = algebraMap A _ (φ a)`; this holds by `rfl` only, as
-      -- no lemma describes an instance local to this construction.
-      rw [show (algebraMap A' (Bialgebra.CounitAlgebra R A B)) a =
-          algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a) from rfl,
-        Bialgebra.CounitAlgebra.algebraMap_apply R A B,
-        Bialgebra.CounitAlgebra.algebraMap_apply R A' B,
-        Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B]
-      exact congrArg (algebraMap R B)
-        (DFunLike.congr_fun (BialgHom.counitAlgHom_comp φ) a))
-  exact e.toLinearEquiv.compDer (d.compAlgebraMap A')
+  -- The `A'`-algebra structure just installed sends `a` to `ρ a = algebraMap A _ (φ a)`,
+  -- which is definitional, so `hmap` is discharged by `rfl`.
+  exact (counitAlgebraCongr φ (B := B) (fun _ => rfl)).toLinearEquiv.compDer
+    (d.compAlgebraMap A')
 
 private lemma derivationCompAux_apply (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
     derivationCompAux (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
-  simp only [derivationCompAux, Derivation.linearEquiv_coe_comp, LinearMap.coe_comp,
+  simp only [derivationCompAux, counitAlgebraCongr, Derivation.linearEquiv_coe_comp,
+    LinearMap.coe_comp,
     Function.comp_apply, LinearMap.restrictScalars_apply, AlgEquiv.toLinearMap_apply,
     AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
     Bialgebra.CounitAlgebra.algEquivSelf_apply]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -13,9 +13,9 @@ A morphism `φ : A' →ₐc[R] A` of bialgebras sends a counit-valued derivation
 one of `A'` by precomposition. The construction splits the transport into the two halves
 Mathlib provides: restricting the domain along `φ` (`Derivation.compAlgebraMap`, over
 local scalar-tower instances for `φ`), and moving the coefficients across the canonical
-identification of the two counit coefficient algebras (`counitAlgebraCongr`), which is
-`A'`-linear precisely because bialgebra morphisms intertwine counits (`LinearEquiv.compDer`).
-The Leibniz rule therefore comes from those two facts and is not reproved here.
+identification of the two counit coefficient algebras, which is `A'`-linear precisely
+because bialgebra morphisms intertwine counits (`LinearEquiv.compDer`). The Leibniz rule
+therefore comes from those two facts and is not reproved here.
 
 ## Main declarations
 
@@ -110,11 +110,13 @@ private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
 private lemma derivationCompAux_apply (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
     derivationCompAux (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
+  -- `counitAlgebraCongr` must be unfolded rather than applied through an `_apply` lemma: the
+  -- `Algebra A' (CounitAlgebra R A B)` instance it takes lives only inside `derivationCompAux`,
+  -- so no lemma stated outside that body can mention it. See the PR discussion.
   simp only [derivationCompAux, counitAlgebraCongr, Derivation.linearEquiv_coe_comp,
-    LinearMap.coe_comp,
-    Function.comp_apply, LinearMap.restrictScalars_apply, AlgEquiv.toLinearMap_apply,
-    AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply, AlgEquiv.coe_ringEquiv,
-    Bialgebra.CounitAlgebra.algEquivSelf_apply]
+    LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
+    AlgEquiv.toLinearMap_apply, AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply,
+    AlgEquiv.coe_ringEquiv, Bialgebra.CounitAlgebra.algEquivSelf_apply]
   -- The remaining transport erases at this value, and the precomposition is
   -- definitional in Mathlib's `compAlgebraMap`.
   exact (Bialgebra.CounitAlgebra.algEquivSelf_symm_apply R A' B _).trans rfl

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -110,9 +110,11 @@ private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
 private lemma derivationCompAux_apply (φ : A' →ₐc[R] A)
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A') :
     derivationCompAux (B := B) φ d a = d ((φ : A' →ₐ[R] A) a) := by
-  -- `counitAlgebraCongr` must be unfolded rather than applied through an `_apply` lemma: the
-  -- `Algebra A' (CounitAlgebra R A B)` instance it takes lives only inside `derivationCompAux`,
-  -- so no lemma stated outside that body can mention it. See the PR discussion.
+  -- `counitAlgebraCongr` is unfolded rather than applied through an `_apply` lemma. Its `hmap`
+  -- argument is supplied here as `fun _ => rfl`, elaborated under the `letI` algebra instance of
+  -- `derivationCompAux`, in which the two sides of `hmap` are the *same* term; the stored proof
+  -- therefore carries a reflexivity type. An `_apply` lemma, whose `hmap` has the general
+  -- non-reflexive type, does not match this occurrence, and `rw`/`simp only` find no pattern.
   simp only [derivationCompAux, counitAlgebraCongr, Derivation.linearEquiv_coe_comp,
     LinearMap.coe_comp, Function.comp_apply, LinearMap.restrictScalars_apply,
     AlgEquiv.toLinearMap_apply, AlgEquiv.ofRingEquiv_apply, RingEquiv.trans_apply,


### PR DESCRIPTION
`derivationCompAux` installs four local instances and then builds two things: the `A'`-linear identification of the two counit coefficient algebras, and the transported derivation. The identification is the construction's one piece of mathematical content — the module docstring already singles it out — but it sat inline as a 22-line `let eRing` / `let e` pair inside the definition.

This PR gives it a name:

```lean
private noncomputable def counitAlgebraCongr (φ : A' →ₐc[R] A)
    [Algebra A' (Bialgebra.CounitAlgebra R A B)]
    (hmap : ∀ a : A', algebraMap A' (Bialgebra.CounitAlgebra R A B) a =
      algebraMap A (Bialgebra.CounitAlgebra R A B) ((φ : A' →ₐ[R] A) a)) :
    Bialgebra.CounitAlgebra R A B ≃ₐ[A'] Bialgebra.CounitAlgebra R A' B
```

**The hypotheses are re-derived, not inherited.** The enclosing definition has four `letI` instances in scope; the identification needs exactly one of them, so `Algebra A' (Bialgebra.CounitAlgebra R A B)` becomes an instance argument. The inline proof then leaned on that instance being the specific local `ρ`, via a `rw [show … from rfl]`; stated for an arbitrary instance that `rfl` is not available, so the one property actually used — that the structure map factors through `φ` — becomes the explicit `hmap`. At the call site `hmap` is discharged by `fun _ => rfl`, exactly the step the inline proof was doing. The three scalar-tower instances are not needed by the identification and are not threaded through.

`derivationCompAux_apply` is rerouted onto the new definition rather than left to unfold the old `let`s: naming `counitAlgebraCongr` in its `simp only` restores the previous normal form. The module docstring, which already described this identification, now names it.

Proof body: **56 → 37** lines, with an 11-line helper. No signature changes; both declarations stay private.

Roadmap: none

---

### Why there is no `counitAlgebraCongr_apply`

A pre-submission review asked for a private `counitAlgebraCongr_apply` lemma so that `derivationCompAux_apply` could avoid unfolding the new definition. I tried it; **it cannot be stated**, and the reason is worth recording rather than leaving as an unexplained unfolding.

`counitAlgebraCongr` takes `[Algebra A' (Bialgebra.CounitAlgebra R A B)]`, and that instance exists **only inside `derivationCompAux`'s body**, where it is installed by `letI`. Outside it:

```
failed to synthesize instance of type class
  Algebra A' (Bialgebra.CounitAlgebra R A ?m.45)
```

Worse, the occurrence already in the goal cannot be rewritten either. At the call site `hmap` is discharged by `fun _ => rfl`, which is only valid because under the local instance the two sides are *definitionally identical* — so the stored proof has the reflexivity type, and outside that context it no longer fits `counitAlgebraCongr`'s signature:

```
Application type mismatch: The argument
  derivationCompAux._proof_8 φ
has type
  ∀ (x : A'), (algebraMap A' (CounitAlgebra R A B)) x = (algebraMap A' (CounitAlgebra R A B)) x
but is expected to have type
  ∀ (a : A'), (algebraMap A' (CounitAlgebra R A B)) a = (algebraMap A (CounitAlgebra R A B)) (↑φ a)
```

So `(counitAlgebraCongr φ ⋯) x` is not type-correct at `implicit` transparency, and `rw`/`simp only` both refuse: *"Did not find an occurrence of the pattern `(counitAlgebraCongr ?φ ?hmap) ?x`"*, *"simp made no progress"*.

Stating the apply lemma would mean re-installing all four `letI` instances in the lemma too — strictly more code than the unfolding it would replace, and it would re-introduce the coupling the extraction removes. The `simp only` therefore names `counitAlgebraCongr`, with a comment at that site explaining why.

The `api-design` finding from the same review **is** fixed: the private name has been removed from the public module docstring.