### PR TITLE
feat: add the symmetric- and exterior-square character formulas

### DIFF
--- a/TauCeti/LinearAlgebra/TensorSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorSquare.lean
@@ -42,7 +42,6 @@ open scoped TensorProduct
 universe v
 
 variable (R : Type) (M : Type v)
-variable [CommRing R] [Invertible (2 : R)] [AddCommGroup M] [Module R M]
 
 namespace TauCeti
 
@@ -71,18 +70,40 @@ theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :
         exact one_ne_zero (e.injective (h1'.trans h0'.symm))
       simpa using h1
 
-omit [Invertible (2 : R)] in
+section Swap
+
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+
 /-- The swap of the two factors of a tensor square, `x ⊗ₜ y ↦ y ⊗ₜ x`. -/
 noncomputable def tensorSwap : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
   PiTensorProduct.reindex R (fun _ : Fin 2 ↦ M) (Equiv.swap 0 1)
 
-omit [Invertible (2 : R)] in
 /-- The swap reads a pure tensor in the other order. -/
 @[simp]
 theorem tensorSwap_tprod (f : Fin 2 → M) :
     tensorSwap R M (PiTensorProduct.tprod R f) =
       PiTensorProduct.tprod R fun i ↦ f (Equiv.swap 0 1 i) := by
   rw [tensorSwap, PiTensorProduct.reindex_tprod, Equiv.symm_swap]
+
+/-- The swap is its own inverse. -/
+@[simp]
+theorem tensorSwap_symm : (tensorSwap R M).symm = tensorSwap R M := by
+  rw [tensorSwap, PiTensorProduct.reindex_symm, Equiv.symm_swap]
+
+/-- Swapping the two factors of an arbitrary tensor twice is the identity. -/
+@[simp]
+theorem tensorSwap_tensorSwap (x : ⨂[R]^2 M) :
+    tensorSwap R M (tensorSwap R M x) = x := by
+  have h := (tensorSwap R M).symm_apply_apply x
+  rwa [tensorSwap_symm] at h
+
+end Swap
+
+end TauCeti
+
+variable [CommRing R] [Invertible (2 : R)] [AddCommGroup M] [Module R M]
+
+namespace TauCeti
 
 private noncomputable def symmetricProjection : (⨂[R]^2 M) →ₗ[R] ⨂[R]^2 M :=
   (⅟ (2 : R)) • (LinearMap.id + (tensorSwap R M).toLinearMap)

--- a/TauCeti/LinearAlgebra/TensorSquare.lean
+++ b/TauCeti/LinearAlgebra/TensorSquare.lean
@@ -22,6 +22,8 @@ is needed.
 
 ## Main definitions
 
+* `TauCeti.tensorSwap` exchanges the two factors of a tensor square; it needs no hypothesis on
+  `2`, and is what the two orders on a tensor square are compared by.
 * `SymmetricPower.toTensorSquare` embeds a symmetric square by averaging the two orders.
 * `exteriorPower.toTensorSquare` embeds an exterior square by alternating the two orders.
 * `TauCeti.tensorSquareEquivSymmetricExterior` is the resulting direct-sum decomposition.
@@ -69,8 +71,18 @@ theorem perm_fin_two_eq_one_or_swap (e : Equiv.Perm (Fin 2)) :
         exact one_ne_zero (e.injective (h1'.trans h0'.symm))
       simpa using h1
 
-private noncomputable def tensorSwap : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
+omit [Invertible (2 : R)] in
+/-- The swap of the two factors of a tensor square, `x ⊗ₜ y ↦ y ⊗ₜ x`. -/
+noncomputable def tensorSwap : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
   PiTensorProduct.reindex R (fun _ : Fin 2 ↦ M) (Equiv.swap 0 1)
+
+omit [Invertible (2 : R)] in
+/-- The swap reads a pure tensor in the other order. -/
+@[simp]
+theorem tensorSwap_tprod (f : Fin 2 → M) :
+    tensorSwap R M (PiTensorProduct.tprod R f) =
+      PiTensorProduct.tprod R fun i ↦ f (Equiv.swap 0 1 i) := by
+  rw [tensorSwap, PiTensorProduct.reindex_tprod, Equiv.symm_swap]
 
 private noncomputable def symmetricProjection : (⨂[R]^2 M) →ₗ[R] ⨂[R]^2 M :=
   (⅟ (2 : R)) • (LinearMap.id + (tensorSwap R M).toLinearMap)

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -245,35 +245,28 @@ private theorem map_comp_toTensorPower {R : Type} {M : Type*}
   simp only [map_sub, PiTensorProduct.map_tprod, Function.comp_apply]
   congr 1
 
-/-- The swap of the two factors of a tensor square. -/
-private noncomputable def swapEquiv (R : Type) (M : Type*)
-    [CommRing R] [AddCommGroup M] [Module R M] : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
-  PiTensorProduct.reindex R (fun _ : Fin 2 ↦ M) (Equiv.swap 0 1)
-
 /-- The swap acts as `-1` on the alternating part: it exchanges the two pure tensors whose
 difference is the image of a wedge. -/
 private theorem swap_comp_toTensorPower {R : Type} {M : Type*}
     [CommRing R] [AddCommGroup M] [Module R M] :
-    (swapEquiv R M).toLinearMap.comp (exteriorPower.toTensorPower R M 2)
+    (tensorSwap R M).toLinearMap.comp (exteriorPower.toTensorPower R M 2)
       = -exteriorPower.toTensorPower R M 2 := by
   apply exteriorPower.linearMap_ext
   apply AlternatingMap.ext
   intro v
   simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply, LinearMap.neg_apply,
     LinearEquiv.coe_coe]
-  rw [toTensorPower_ιMulti_two, map_sub, swapEquiv, PiTensorProduct.reindex_tprod,
-    PiTensorProduct.reindex_tprod]
-  simp only [Equiv.symm_swap, Equiv.swap_apply_self, neg_sub]
+  rw [toTensorPower_ιMulti_two, map_sub, tensorSwap_tprod, tensorSwap_tprod]
+  simp only [Equiv.swap_apply_self, neg_sub]
 
 /-- The swap acts as `+1` on the symmetric part: that is exactly the relation defining `Sym²`. -/
 private theorem mk_comp_swap {R : Type} {M : Type*}
     [CommRing R] [AddCommGroup M] [Module R M] :
-    (SymmetricPower.mk R (Fin 2) M).comp (swapEquiv R M).toLinearMap
+    (SymmetricPower.mk R (Fin 2) M).comp (tensorSwap R M).toLinearMap
       = SymmetricPower.mk R (Fin 2) M := by
   apply LinearMap.ext_on (PiTensorProduct.span_tprod_eq_top (R := R))
   rintro _ ⟨v, rfl⟩
-  rw [LinearMap.comp_apply, LinearEquiv.coe_coe, swapEquiv, PiTensorProduct.reindex_tprod,
-    Equiv.symm_swap]
+  rw [LinearMap.comp_apply, LinearEquiv.coe_coe, tensorSwap_tprod]
   simpa only [SymmetricPower.tprod, LinearMap.compMultilinearMap_apply] using
     SymmetricPower.tprod_equiv (Equiv.swap (0 : Fin 2) 1) v
 
@@ -283,7 +276,7 @@ square of the matrix of `f`. -/
 private theorem trace_map_comp_swap {R : Type} {M : Type*}
     [Field R] [AddCommGroup M] [Module R M] [FiniteDimensional R M] (f : M →ₗ[R] M) :
     LinearMap.trace R (⨂[R]^2 M)
-        ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+        ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (tensorSwap R M).toLinearMap)
       = LinearMap.trace R M (f.comp f) := by
   classical
   set b := Module.finBasis R M
@@ -292,12 +285,12 @@ private theorem trace_map_comp_swap {R : Type} {M : Type*}
   have hdiag : ∀ p : Fin 2 → Fin (Module.finrank R M),
       LinearMap.toMatrix B B
           ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp
-            (swapEquiv R M).toLinearMap) p p
+            (tensorSwap R M).toLinearMap) p p
         = LinearMap.toMatrix b b f (p 0) (p 1) * LinearMap.toMatrix b b f (p 1) (p 0) := by
     intro p
     rw [LinearMap.toMatrix_apply, hB, Basis.piTensorProduct_apply, LinearMap.comp_apply,
-      LinearEquiv.coe_coe, swapEquiv, PiTensorProduct.reindex_tprod, Equiv.symm_swap,
-      PiTensorProduct.map_tprod, Basis.piTensorProduct_repr_tprod_apply, Fin.prod_univ_two]
+      LinearEquiv.coe_coe, tensorSwap_tprod, PiTensorProduct.map_tprod,
+      Basis.piTensorProduct_repr_tprod_apply, Fin.prod_univ_two]
     simp [LinearMap.toMatrix_apply]
   rw [LinearMap.trace_eq_matrix_trace R B, LinearMap.trace_eq_matrix_trace R b,
     LinearMap.toMatrix_comp b b b f f, Matrix.trace, Matrix.trace]
@@ -318,13 +311,13 @@ private theorem trace_symmetricPower_sub_trace_exteriorPower {R : Type} {M : Typ
   -- `-⋀²f` on the alternating part and `Sym²f` on the symmetric quotient.
   have hfi :
       ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp
-            (swapEquiv R M).toLinearMap).comp (exteriorPower.toTensorPower R M 2)
+            (tensorSwap R M).toLinearMap).comp (exteriorPower.toTensorPower R M 2)
         = (exteriorPower.toTensorPower R M 2).comp (-exteriorPower.map 2 f) := by
     rw [LinearMap.comp_assoc, swap_comp_toTensorPower, LinearMap.comp_neg, LinearMap.comp_neg,
       map_comp_toTensorPower]
   have hfq :
       (SymmetricPower.mk R (Fin 2) M).comp
-          ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+          ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (tensorSwap R M).toLinearMap)
         = (SymmetricPower.map (ι := Fin 2) f).comp (SymmetricPower.mk R (Fin 2) M) := by
     refine LinearMap.ext fun x ↦ ?_
     rw [LinearMap.comp_apply, LinearMap.comp_apply, ← SymmetricPower.map_mk,
@@ -335,7 +328,7 @@ private theorem trace_symmetricPower_sub_trace_exteriorPower {R : Type} {M : Typ
     (exteriorPower.toTensorPower R M 2)
     (SymmetricPower.mk R (Fin 2) M)
     (-exteriorPower.map 2 f)
-    ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+    ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (tensorSwap R M).toLinearMap)
     (SymmetricPower.map (ι := Fin 2) f)
     toTensorPower_injective
     (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -46,10 +46,10 @@ subtracting the two identities isolates each character, `2·χ_{Sym²}(g) = χ(g
 ## Implementation notes
 
 Both trace identities go through the same private helper, trace additivity along the exact
-sequence `⋀²M → M ⊗ M → Sym²M`, so the two intertwining squares that feed it are named once
-(`TauCeti.TensorSquare.map_comp_toTensorPower` and `TauCeti.TensorSquare.mk_comp_map`) and reused
-for both readings. The linear-algebra steps stay private, as the file's public interface is the
-character identities.
+sequence `⋀²M → M ⊗ M → Sym²M`, so its hypothesis on the alternating inclusion is named once
+(`TauCeti.TensorSquare.map_comp_toTensorPower`) and reused for both readings; the matching
+hypothesis on the symmetric quotient is `SymmetricPower.map_mk` read extensionally. The
+linear-algebra steps stay private, as the file's public interface is the character identities.
 
 ## References
 
@@ -243,28 +243,10 @@ private theorem map_comp_toTensorPower {R : Type} {M : Type*}
   simp only [map_sub, PiTensorProduct.map_tprod, Function.comp_apply]
   congr 1
 
-/-- The symmetric quotient `M ⊗ M → Sym²M` is natural in the endomorphism: it intertwines the
-diagonal action with the symmetric square. -/
-private theorem mk_comp_map {R : Type} {M : Type*}
-    [CommRing R] [AddCommGroup M] [Module R M] (f : M →ₗ[R] M) :
-    (SymmetricPower.mk R (Fin 2) M).comp (PiTensorProduct.map fun _ : Fin 2 ↦ f)
-      = (SymmetricPower.map (ι := Fin 2) f).comp (SymmetricPower.mk R (Fin 2) M) := by
-  apply LinearMap.ext_on (PiTensorProduct.span_tprod_eq_top (R := R))
-  rintro _ ⟨v, rfl⟩
-  simp
-
 /-- The swap of the two factors of a tensor square. -/
 private noncomputable def swapEquiv (R : Type) (M : Type*)
     [CommRing R] [AddCommGroup M] [Module R M] : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
   PiTensorProduct.reindex R (fun _ : Fin 2 ↦ M) (Equiv.swap 0 1)
-
-/-- The swap exchanges the two factors of a pure tensor. -/
-private theorem swapEquiv_tprod {R : Type} {M : Type*}
-    [CommRing R] [AddCommGroup M] [Module R M] (v : Fin 2 → M) :
-    swapEquiv R M (PiTensorProduct.tprod R v)
-      = PiTensorProduct.tprod R fun i ↦ v (Equiv.swap 0 1 i) := by
-  rw [swapEquiv, PiTensorProduct.reindex_tprod]
-  simp
 
 /-- The swap acts as `-1` on the alternating part: it exchanges the two pure tensors whose
 difference is the image of a wedge. -/
@@ -277,8 +259,9 @@ private theorem swap_comp_toTensorPower {R : Type} {M : Type*}
   intro v
   simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply, LinearMap.neg_apply,
     LinearEquiv.coe_coe]
-  rw [toTensorPower_ιMulti_two, map_sub, swapEquiv_tprod, swapEquiv_tprod]
-  simp only [Equiv.swap_apply_self, neg_sub]
+  rw [toTensorPower_ιMulti_two, map_sub, swapEquiv, PiTensorProduct.reindex_tprod,
+    PiTensorProduct.reindex_tprod]
+  simp only [Equiv.symm_swap, Equiv.swap_apply_self, neg_sub]
 
 /-- The swap acts as `+1` on the symmetric part: that is exactly the relation defining `Sym²`. -/
 private theorem mk_comp_swap {R : Type} {M : Type*}
@@ -287,7 +270,8 @@ private theorem mk_comp_swap {R : Type} {M : Type*}
       = SymmetricPower.mk R (Fin 2) M := by
   apply LinearMap.ext_on (PiTensorProduct.span_tprod_eq_top (R := R))
   rintro _ ⟨v, rfl⟩
-  rw [LinearMap.comp_apply, LinearEquiv.coe_coe, swapEquiv_tprod]
+  rw [LinearMap.comp_apply, LinearEquiv.coe_coe, swapEquiv, PiTensorProduct.reindex_tprod,
+    Equiv.symm_swap]
   simpa only [SymmetricPower.tprod, LinearMap.compMultilinearMap_apply] using
     SymmetricPower.tprod_equiv (Equiv.swap (0 : Fin 2) 1) v
 
@@ -310,8 +294,8 @@ private theorem trace_map_comp_swap {R : Type} {M : Type*}
         = LinearMap.toMatrix b b f (p 0) (p 1) * LinearMap.toMatrix b b f (p 1) (p 0) := by
     intro p
     rw [LinearMap.toMatrix_apply, hB, Basis.piTensorProduct_apply, LinearMap.comp_apply,
-      LinearEquiv.coe_coe, swapEquiv_tprod, PiTensorProduct.map_tprod,
-      Basis.piTensorProduct_repr_tprod_apply, Fin.prod_univ_two]
+      LinearEquiv.coe_coe, swapEquiv, PiTensorProduct.reindex_tprod, Equiv.symm_swap,
+      PiTensorProduct.map_tprod, Basis.piTensorProduct_repr_tprod_apply, Fin.prod_univ_two]
     simp [LinearMap.toMatrix_apply]
   rw [LinearMap.trace_eq_matrix_trace R B, LinearMap.trace_eq_matrix_trace R b,
     LinearMap.toMatrix_comp b b b f f, Matrix.trace, Matrix.trace]
@@ -340,7 +324,11 @@ private theorem trace_symmetricPower_sub_trace_exteriorPower {R : Type} {M : Typ
       (SymmetricPower.mk R (Fin 2) M).comp
           ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
         = (SymmetricPower.map (ι := Fin 2) f).comp (SymmetricPower.mk R (Fin 2) M) := by
-    rw [← LinearMap.comp_assoc, mk_comp_map, LinearMap.comp_assoc, mk_comp_swap]
+    refine LinearMap.ext fun x ↦ ?_
+    rw [LinearMap.comp_apply, LinearMap.comp_apply, ← SymmetricPower.map_mk,
+      LinearMap.comp_apply]
+    exact congrArg (SymmetricPower.map (ι := Fin 2) f)
+      (LinearMap.congr_fun mk_comp_swap x)
   have h := trace_eq_add_of_exact
     (exteriorPower.toTensorPower R M 2)
     (SymmetricPower.mk R (Fin 2) M)
@@ -423,7 +411,7 @@ theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g)
     (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))
     TauCeti.TensorSquare.range_toTensorPower_eq_ker_mk
     (TauCeti.TensorSquare.map_comp_toTensorPower (ρ g))
-    (TauCeti.TensorSquare.mk_comp_map (ρ g))
+    (LinearMap.ext fun x ↦ (SymmetricPower.map_mk (ρ g) x).symm)
   simpa only [add_comm] using h
 
 /-- **The difference of the two square characters is the character at the square.** Over any

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import TauCeti.LinearAlgebra.TensorSquare
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ExteriorPower
@@ -16,19 +17,48 @@ public import TauCeti.RepresentationTheory.Tensor.Power
 
 When `2` is invertible, the tensor square of a representation splits into its symmetric and
 exterior squares. This file lifts the natural linear decomposition to representations. It also
-proves the corresponding trace identity over every field, including characteristic two where the
-decomposition does not split.
+proves the two trace identities that this splitting is measured by, over every field, including
+characteristic two where the decomposition does not split.
+
+The two identities read the same exact sequence `⋀²M → M ⊗ M → Sym²M` twice. Reading it against
+`g` acting diagonally gives the sum `χ(g)² = χ_{Sym²}(g) + χ_{Λ²}(g)`. Reading it against that
+same diagonal action *composed with the swap of the two tensor factors* gives the difference:
+the swap is `-1` on the exterior square and `+1` on the symmetric square, while its composite
+with the diagonal action has trace `χ(g²)`. So `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`, and adding and
+subtracting the two identities isolates each character, `2·χ_{Sym²}(g) = χ(g)² + χ(g²)` and
+`2·χ_{Λ²}(g) = χ(g)² - χ(g²)`.
 
 ## Main definitions
 
 * `Representation.tensorSquareEquivSymmetricExterior` is the natural representation equivalence.
-* `Representation.char_tensorSquare` is the tensor-square character identity.
+
+## Main results
+
+* `Representation.char_tensorSquare` is the tensor-square character identity, the sum
+  `χ(g)² = χ_{Sym²}(g) + χ_{Λ²}(g)`.
+* `Representation.char_symmetricSquare_sub_char_exteriorSquare` is the companion difference
+  `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`.
+* `Representation.two_mul_char_symmetricSquare` and
+  `Representation.two_mul_char_exteriorSquare` isolate each character without dividing, and
+  `Representation.char_symmetricSquare` and `Representation.char_exteriorSquare` are the
+  familiar halved forms, away from characteristic two.
+
+## Implementation notes
+
+Both trace identities go through the same private helper, trace additivity along the exact
+sequence `⋀²M → M ⊗ M → Sym²M`, so the two intertwining squares that feed it are named once
+(`TauCeti.TensorSquare.map_comp_toTensorPower` and `TauCeti.TensorSquare.mk_comp_map`) and reused
+for both readings. The linear-algebra steps stay private, as the file's public interface is the
+character identities.
 
 ## References
 
 * [Classical groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/ClassicalGroups/README.md),
-  Layer 1, “The first decomposition”.
-* W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 6.
+  Layer 1, “The first decomposition”, for the splitting.
+* [Character-theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 7, “The symmetric and exterior squares”, for the character formulas.
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, Lecture 6 and Exercise 2.2.
+* J.-P. Serre, *Linear Representations of Finite Groups*, §2.1 and §13.2.
 * Mathlib's exterior-power universal-property, pairing, and basis APIs, by Sophie Morel,
   Joël Riou, and Daniel Morrison.
 -/
@@ -199,6 +229,134 @@ private theorem trace_eq_add_of_exact {K A B C : Type*} [Field K]
       (snd_comp_conj_eq_comp_snd e hsnd hfq),
     LinearMap.trace_prodMap_add_inl_comp_snd]
 
+/-- The alternating inclusion `⋀²M → M ⊗ M` is natural in the endomorphism: it intertwines the
+exterior square with the diagonal action. -/
+private theorem map_comp_toTensorPower {R : Type} {M : Type*}
+    [CommRing R] [AddCommGroup M] [Module R M] (f : M →ₗ[R] M) :
+    (PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (exteriorPower.toTensorPower R M 2)
+      = (exteriorPower.toTensorPower R M 2).comp (exteriorPower.map 2 f) := by
+  apply exteriorPower.linearMap_ext
+  apply AlternatingMap.ext
+  intro v
+  simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply]
+  rw [toTensorPower_ιMulti_two, exteriorPower.map_apply_ιMulti, toTensorPower_ιMulti_two]
+  simp only [map_sub, PiTensorProduct.map_tprod, Function.comp_apply]
+  congr 1
+
+/-- The symmetric quotient `M ⊗ M → Sym²M` is natural in the endomorphism: it intertwines the
+diagonal action with the symmetric square. -/
+private theorem mk_comp_map {R : Type} {M : Type*}
+    [CommRing R] [AddCommGroup M] [Module R M] (f : M →ₗ[R] M) :
+    (SymmetricPower.mk R (Fin 2) M).comp (PiTensorProduct.map fun _ : Fin 2 ↦ f)
+      = (SymmetricPower.map (ι := Fin 2) f).comp (SymmetricPower.mk R (Fin 2) M) := by
+  apply LinearMap.ext_on (PiTensorProduct.span_tprod_eq_top (R := R))
+  rintro _ ⟨v, rfl⟩
+  simp
+
+/-- The swap of the two factors of a tensor square. -/
+private noncomputable def swapEquiv (R : Type) (M : Type*)
+    [CommRing R] [AddCommGroup M] [Module R M] : (⨂[R]^2 M) ≃ₗ[R] ⨂[R]^2 M :=
+  PiTensorProduct.reindex R (fun _ : Fin 2 ↦ M) (Equiv.swap 0 1)
+
+/-- The swap exchanges the two factors of a pure tensor. -/
+private theorem swapEquiv_tprod {R : Type} {M : Type*}
+    [CommRing R] [AddCommGroup M] [Module R M] (v : Fin 2 → M) :
+    swapEquiv R M (PiTensorProduct.tprod R v)
+      = PiTensorProduct.tprod R fun i ↦ v (Equiv.swap 0 1 i) := by
+  rw [swapEquiv, PiTensorProduct.reindex_tprod]
+  simp
+
+/-- The swap acts as `-1` on the alternating part: it exchanges the two pure tensors whose
+difference is the image of a wedge. -/
+private theorem swap_comp_toTensorPower {R : Type} {M : Type*}
+    [CommRing R] [AddCommGroup M] [Module R M] :
+    (swapEquiv R M).toLinearMap.comp (exteriorPower.toTensorPower R M 2)
+      = -exteriorPower.toTensorPower R M 2 := by
+  apply exteriorPower.linearMap_ext
+  apply AlternatingMap.ext
+  intro v
+  simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply, LinearMap.neg_apply,
+    LinearEquiv.coe_coe]
+  rw [toTensorPower_ιMulti_two, map_sub, swapEquiv_tprod, swapEquiv_tprod]
+  simp only [Equiv.swap_apply_self, neg_sub]
+
+/-- The swap acts as `+1` on the symmetric part: that is exactly the relation defining `Sym²`. -/
+private theorem mk_comp_swap {R : Type} {M : Type*}
+    [CommRing R] [AddCommGroup M] [Module R M] :
+    (SymmetricPower.mk R (Fin 2) M).comp (swapEquiv R M).toLinearMap
+      = SymmetricPower.mk R (Fin 2) M := by
+  apply LinearMap.ext_on (PiTensorProduct.span_tprod_eq_top (R := R))
+  rintro _ ⟨v, rfl⟩
+  rw [LinearMap.comp_apply, LinearEquiv.coe_coe, swapEquiv_tprod]
+  simpa only [SymmetricPower.tprod, LinearMap.compMultilinearMap_apply] using
+    SymmetricPower.tprod_equiv (Equiv.swap (0 : Fin 2) 1) v
+
+/-- The trace of `f ⊗ f` composed with the swap of the two tensor factors is the trace of `f²`.
+On a basis the diagonal entry at `eᵢ ⊗ eⱼ` is `aᵢⱼ aⱼᵢ`, and summing those is the trace of the
+square of the matrix of `f`. -/
+private theorem trace_map_comp_swap {R : Type} {M : Type*}
+    [Field R] [AddCommGroup M] [Module R M] [FiniteDimensional R M] (f : M →ₗ[R] M) :
+    LinearMap.trace R (⨂[R]^2 M)
+        ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+      = LinearMap.trace R M (f.comp f) := by
+  classical
+  set b := Module.finBasis R M
+  -- The tensor square inherits the monomial basis, indexed by pairs of basis indices.
+  set B := Basis.piTensorProduct fun _ : Fin 2 ↦ b with hB
+  have hdiag : ∀ p : Fin 2 → Fin (Module.finrank R M),
+      LinearMap.toMatrix B B
+          ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp
+            (swapEquiv R M).toLinearMap) p p
+        = LinearMap.toMatrix b b f (p 0) (p 1) * LinearMap.toMatrix b b f (p 1) (p 0) := by
+    intro p
+    rw [LinearMap.toMatrix_apply, hB, Basis.piTensorProduct_apply, LinearMap.comp_apply,
+      LinearEquiv.coe_coe, swapEquiv_tprod, PiTensorProduct.map_tprod,
+      Basis.piTensorProduct_repr_tprod_apply, Fin.prod_univ_two]
+    simp [LinearMap.toMatrix_apply]
+  rw [LinearMap.trace_eq_matrix_trace R B, LinearMap.trace_eq_matrix_trace R b,
+    LinearMap.toMatrix_comp b b b f f, Matrix.trace, Matrix.trace]
+  simp only [Matrix.diag_apply, hdiag, Matrix.mul_apply]
+  refine Eq.trans (Fintype.sum_equiv (finTwoArrowEquiv _) _
+    (fun q ↦ LinearMap.toMatrix b b f q.1 q.2 * LinearMap.toMatrix b b f q.2 q.1)
+    fun p ↦ rfl) ?_
+  exact Fintype.sum_prod_type _
+
+/-- **The trace form of the two square characters.** Over any field, the traces of an
+endomorphism on the symmetric and exterior squares differ by the trace of its own square. -/
+private theorem trace_symmetricPower_sub_trace_exteriorPower {R : Type} {M : Type*}
+    [Field R] [AddCommGroup M] [Module R M] [FiniteDimensional R M] (f : M →ₗ[R] M) :
+    LinearMap.trace R (Sym[R]^2 M) (SymmetricPower.map (ι := Fin 2) f)
+        - LinearMap.trace R (⋀[R]^2 M) (exteriorPower.map 2 f)
+      = LinearMap.trace R M (f.comp f) := by
+  -- Read the exact sequence `⋀²M → M ⊗ M → Sym²M` against `(f ⊗ f) ∘ swap`, which covers
+  -- `-⋀²f` on the alternating part and `Sym²f` on the symmetric quotient.
+  have hfi :
+      ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp
+            (swapEquiv R M).toLinearMap).comp (exteriorPower.toTensorPower R M 2)
+        = (exteriorPower.toTensorPower R M 2).comp (-exteriorPower.map 2 f) := by
+    rw [LinearMap.comp_assoc, swap_comp_toTensorPower, LinearMap.comp_neg, LinearMap.comp_neg,
+      map_comp_toTensorPower]
+  have hfq :
+      (SymmetricPower.mk R (Fin 2) M).comp
+          ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+        = (SymmetricPower.map (ι := Fin 2) f).comp (SymmetricPower.mk R (Fin 2) M) := by
+    rw [← LinearMap.comp_assoc, mk_comp_map, LinearMap.comp_assoc, mk_comp_swap]
+  have h := trace_eq_add_of_exact
+    (exteriorPower.toTensorPower R M 2)
+    (SymmetricPower.mk R (Fin 2) M)
+    (-exteriorPower.map 2 f)
+    ((PiTensorProduct.map fun _ : Fin 2 ↦ f).comp (swapEquiv R M).toLinearMap)
+    (SymmetricPower.map (ι := Fin 2) f)
+    toTensorPower_injective
+    (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))
+    range_toTensorPower_eq_ker_mk hfi hfq
+  have hneg : LinearMap.trace R (⋀[R]^2 M) (-exteriorPower.map 2 f)
+      = -LinearMap.trace R (⋀[R]^2 M) (exteriorPower.map 2 f) :=
+    map_neg (LinearMap.trace R (⋀[R]^2 M)) (exteriorPower.map 2 f)
+  rw [trace_map_comp_swap, hneg] at h
+  rw [h]
+  ring
+
 end TauCeti.TensorSquare
 
 namespace Representation
@@ -254,29 +412,6 @@ theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g)
   rw [← char_tensorPower ρ 2 g]
   simp only [Representation.character, tensorPower_apply, symmetricPower_apply,
     exteriorPower_apply]
-  -- The alternating inclusion and symmetric quotient intertwine the three induced actions.
-  have hfi :
-      (PiTensorProduct.map fun _ : Fin 2 ↦ ρ g).comp
-          (exteriorPower.toTensorPower R M 2) =
-        (exteriorPower.toTensorPower R M 2).comp
-          (exteriorPower.map 2 (ρ g)) := by
-    apply exteriorPower.linearMap_ext
-    apply AlternatingMap.ext
-    intro f
-    simp only [LinearMap.compAlternatingMap_apply, LinearMap.comp_apply]
-    rw [TauCeti.TensorSquare.toTensorPower_ιMulti_two,
-      exteriorPower.map_apply_ιMulti,
-      TauCeti.TensorSquare.toTensorPower_ιMulti_two]
-    simp only [map_sub, PiTensorProduct.map_tprod, Function.comp_apply]
-    congr 1
-  have hfq :
-      (SymmetricPower.mk R (Fin 2) M).comp
-          (PiTensorProduct.map fun _ : Fin 2 ↦ ρ g) =
-        (SymmetricPower.map (ρ g)).comp
-          (SymmetricPower.mk R (Fin 2) M) := by
-    apply LinearMap.ext
-    intro x
-    simp
   -- Trace is additive along the exact sequence `⋀²M → M⊗M → Sym²M`.
   have h := TauCeti.TensorSquare.trace_eq_add_of_exact
     (exteriorPower.toTensorPower R M 2)
@@ -286,8 +421,44 @@ theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g)
     (SymmetricPower.map (ρ g))
     TauCeti.TensorSquare.toTensorPower_injective
     (LinearMap.range_eq_top.mp (SymmetricPower.range_mk R (Fin 2) M))
-    TauCeti.TensorSquare.range_toTensorPower_eq_ker_mk hfi hfq
+    TauCeti.TensorSquare.range_toTensorPower_eq_ker_mk
+    (TauCeti.TensorSquare.map_comp_toTensorPower (ρ g))
+    (TauCeti.TensorSquare.mk_comp_map (ρ g))
   simpa only [add_comm] using h
+
+/-- **The difference of the two square characters is the character at the square.** Over any
+field, including in characteristic two, `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`; this is the identity
+that, together with `Representation.char_tensorSquare`, pins each of the two characters. -/
+theorem char_symmetricSquare_sub_char_exteriorSquare (ρ : Representation R G M) (g : G) :
+    (ρ.symmetricPower 2).character g - (ρ.exteriorPower 2).character g
+      = ρ.character (g * g) := by
+  simpa only [Representation.character, symmetricPower_apply, exteriorPower_apply, map_mul,
+    Module.End.mul_eq_comp] using
+    TauCeti.TensorSquare.trace_symmetricPower_sub_trace_exteriorPower (ρ g)
+
+/-- **The symmetric-square character, without dividing**: `2·χ_{Sym²}(g) = χ(g)² + χ(g²)`. -/
+theorem two_mul_char_symmetricSquare (ρ : Representation R G M) (g : G) :
+    2 * (ρ.symmetricPower 2).character g = ρ.character g ^ 2 + ρ.character (g * g) := by
+  rw [char_tensorSquare ρ g, ← char_symmetricSquare_sub_char_exteriorSquare ρ g]
+  ring
+
+/-- **The exterior-square character, without dividing**: `2·χ_{Λ²}(g) = χ(g)² - χ(g²)`. -/
+theorem two_mul_char_exteriorSquare (ρ : Representation R G M) (g : G) :
+    2 * (ρ.exteriorPower 2).character g = ρ.character g ^ 2 - ρ.character (g * g) := by
+  rw [char_tensorSquare ρ g, ← char_symmetricSquare_sub_char_exteriorSquare ρ g]
+  ring
+
+/-- **The character of the symmetric square**, `χ_{Sym²}(g) = ½(χ(g)² + χ(g²))`, away from
+characteristic two. -/
+theorem char_symmetricSquare (ρ : Representation R G M) (g : G) (h2 : (2 : R) ≠ 0) :
+    (ρ.symmetricPower 2).character g = (ρ.character g ^ 2 + ρ.character (g * g)) / 2 :=
+  eq_div_of_mul_eq h2 (by rw [mul_comm]; exact two_mul_char_symmetricSquare ρ g)
+
+/-- **The character of the exterior square**, `χ_{Λ²}(g) = ½(χ(g)² - χ(g²))`, away from
+characteristic two. -/
+theorem char_exteriorSquare (ρ : Representation R G M) (g : G) (h2 : (2 : R) ≠ 0) :
+    (ρ.exteriorPower 2).character g = (ρ.character g ^ 2 - ρ.character (g * g)) / 2 :=
+  eq_div_of_mul_eq h2 (by rw [mul_comm]; exact two_mul_char_exteriorSquare ρ g)
 
 end Field
 

--- a/TauCeti/RepresentationTheory/Tensor/Square.lean
+++ b/TauCeti/RepresentationTheory/Tensor/Square.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.PiTensorProduct.Basis
+import Mathlib.LinearAlgebra.PiTensorProduct.Basis
 public import TauCeti.LinearAlgebra.TensorSquare
 public import TauCeti.LinearAlgebra.ExteriorPower
 public import TauCeti.RepresentationTheory.ExteriorPower
@@ -25,8 +25,10 @@ The two identities read the same exact sequence `⋀²M → M ⊗ M → Sym²M` 
 same diagonal action *composed with the swap of the two tensor factors* gives the difference:
 the swap is `-1` on the exterior square and `+1` on the symmetric square, while its composite
 with the diagonal action has trace `χ(g²)`. So `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`, and adding and
-subtracting the two identities isolates each character, `2·χ_{Sym²}(g) = χ(g)² + χ(g²)` and
-`2·χ_{Λ²}(g) = χ(g)² - χ(g²)`.
+subtracting the two identities gives the doubled formulas `2·χ_{Sym²}(g) = χ(g)² + χ(g²)` and
+`2·χ_{Λ²}(g) = χ(g)² - χ(g²)`. These hold over every field, but they pin down the two characters
+individually only away from characteristic two: in characteristic two their left sides vanish and
+the sum and difference identities coincide, so neither character is determined by them.
 
 ## Main definitions
 
@@ -39,9 +41,9 @@ subtracting the two identities isolates each character, `2·χ_{Sym²}(g) = χ(g
 * `Representation.char_symmetricSquare_sub_char_exteriorSquare` is the companion difference
   `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`.
 * `Representation.two_mul_char_symmetricSquare` and
-  `Representation.two_mul_char_exteriorSquare` isolate each character without dividing, and
+  `Representation.two_mul_char_exteriorSquare` are the doubled formulas, over every field, and
   `Representation.char_symmetricSquare` and `Representation.char_exteriorSquare` are the
-  familiar halved forms, away from characteristic two.
+  familiar halved forms that determine each character, away from characteristic two.
 
 ## Implementation notes
 
@@ -416,7 +418,8 @@ theorem char_tensorSquare (ρ : Representation R G M) (g : G) : (ρ.character g)
 
 /-- **The difference of the two square characters is the character at the square.** Over any
 field, including in characteristic two, `χ_{Sym²}(g) - χ_{Λ²}(g) = χ(g²)`; this is the identity
-that, together with `Representation.char_tensorSquare`, pins each of the two characters. -/
+that, together with `Representation.char_tensorSquare`, gives the doubled formulas for the two
+characters, which determine them individually away from characteristic two. -/
 theorem char_symmetricSquare_sub_char_exteriorSquare (ρ : Representation R G M) (g : G) :
     (ρ.symmetricPower 2).character g - (ρ.exteriorPower 2).character g
       = ρ.character (g * g) := by


### PR DESCRIPTION
This PR adds the character formulas of the symmetric and exterior squares of a representation: over any field, `χ_Sym²(g) - χ_Λ²(g) = χ(g²)`, and, combined with the tensor-square identity `χ(g)² = χ_Sym²(g) + χ_Λ²(g)` already in `TauCeti/RepresentationTheory/Tensor/Square.lean`, the division-free `2·χ_Sym²(g) = χ(g)² + χ(g²)` and `2·χ_Λ²(g) = χ(g)² - χ(g²)`, together with their familiar halved forms away from characteristic two.

The proof reads the characteristic-free exact sequence `⋀²M → M ⊗ M → Sym²M` a second time. The file already reads it against `g` acting diagonally, which makes trace additivity give the sum. Reading it against that same diagonal action composed with the swap of the two tensor factors gives the difference: the swap is `-1` on the alternating inclusion and `+1` on the symmetric quotient, while the trace of the diagonal action composed with the swap is `χ(g²)` — on a basis its diagonal entry at `eᵢ ⊗ eⱼ` is `aᵢⱼaⱼᵢ`, and those sum to the trace of the square of the matrix. So no diagonalisation, no algebraically closed field, and no invertibility of `2` is needed for the two primary identities; `(2 : R) ≠ 0` appears only in the two halved corollaries.

The intertwining square for the alternating inclusion that feeds trace additivity was previously inlined in the proof of `Representation.char_tensorSquare`; it is extracted as `TauCeti.TensorSquare.map_comp_toTensorPower` and now serves both readings, so that proof shrinks rather than being duplicated. The matching square for the symmetric quotient is the existing `SymmetricPower.map_mk` read extensionally, so it gets no helper of its own. The linear-algebra steps stay private, matching the file's existing shape, whose public interface is the character identities.

This advances the `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md` Layer 7 build item "The symmetric and exterior squares (a build target, not consumed)", which asks for the symmetric- and exterior-square representations and their character formulas `χ_Sym²(g) = ½(χ(g)² + χ(g²))` and `χ_Λ²(g) = ½(χ(g)² - χ(g²))`; the representations themselves are already in the tree, so only the character formulas were missing. They are the input the same layer's invariant-form and Frobenius–Schur milestones consume. Nothing here defines the Frobenius–Schur indicator or the invariant-form predicate; those remain separate targets.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"symmetric-exterior-square-characters"}-->

No Mathlib material is vendored, and no content is derived from any external source; `PiTensorProduct.reindex`, `Basis.piTensorProduct`, and the exterior-power basis and pairing APIs are consumed from the pinned Mathlib.

`lake build`, `lake exe axioms` (21382 declarations, allowlist only), `lake exe module-system`, and `scripts/lint-env.sh` all pass locally.

🤖 Prepared with Claude Code

