### PR TITLE
refactor(Hyperbolic): make the direction vector total in exists_hyperbolicLength_eq_hyperbolicDist

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -751,19 +751,12 @@ theorem exists_hyperbolicLength_eq_hyperbolicDist (hz : ‖z‖ < 1) (hw : ‖w�
   set p : ℝ := pseudoHyperbolicExpr w z with hpdef
   set m : ℂ := (w - z) / (1 - (starRingEnd ℂ) z * w) with hmdef
   have hmnorm : ‖m‖ = p := by rw [hpdef, pseudoHyperbolicExpr_def, hmdef]
-  set u : ℂ := if p = 0 then 1 else m / (p : ℂ) with hudef
-  have hunorm : ‖u‖ = 1 := by
-    by_cases h : p = 0
-    · simp [hudef, h]
-    · rw [hudef, if_neg h, norm_div, hmnorm, Complex.norm_real, Real.norm_eq_abs,
-        abs_of_nonneg hp0, div_self h]
+  -- A unit vector pointing along `m`. `Complex.norm_mul_exp_arg_mul_I` supplies one for *every*
+  -- `m`, including `m = 0`, so the direction needs no case split on whether `p` vanishes.
+  set u : ℂ := Complex.exp ((m.arg : ℝ) * Complex.I) with hudef
+  have hunorm : ‖u‖ = 1 := Complex.norm_exp_ofReal_mul_I _
   have hup : u * (p : ℂ) = m := by
-    by_cases h : p = 0
-    · have hm0 : m = 0 := norm_eq_zero.mp (by rw [hmnorm, h])
-      rw [hudef, if_pos h, h, hm0]
-      simp
-    · rw [hudef, if_neg h, div_mul_cancel₀]
-      exact_mod_cast h
+    rw [hudef, ← hmnorm, mul_comm, Complex.norm_mul_exp_arg_mul_I]
   have hρderiv : ∀ t : ℝ, HasDerivAt (fun s : ℝ => u * (s : ℂ)) u t := fun t => by
     simpa using (Complex.ofRealCLM.hasDerivAt (x := t)).const_mul u
   have hρmem : ∀ t ∈ Icc (0 : ℝ) p, ‖u * (t : ℂ)‖ < 1 := fun t ht => by


### PR DESCRIPTION
The path realising `hyperbolicDist z w` is the Moebius image of the Euclidean radius `t ↦ u * t`, where `u` is a unit vector with `u * p = m` for `m` the Moebius image of `w` and `p = ‖m‖` the pseudo-hyperbolic distance.

Building `u` by hand as `if p = 0 then 1 else m / p` pushed that `if` into both of its properties: `hunorm : ‖u‖ = 1` and `hup : u * p = m` each opened a `by_cases` on `p = 0` and handled the vanishing case separately — thirteen lines between them.

Mathlib supplies the direction for **every** `m`, degenerate case included:

```lean
Complex.norm_mul_exp_arg_mul_I (x : ℂ) : ‖x‖ * exp (arg x * I) = x
```

Taking `u = exp (arg m * I)` gives `‖u‖ = 1` from `Complex.norm_exp_ofReal_mul_I` and `u * p = m` by one rewrite. At `m = 0` — that is, `z = w`, where `p = 0` — this is `exp 0 = 1` and `u * p = 0 = m` holds anyway, so the case split is simply unnecessary rather than being hidden somewhere else.

This is the same defect and the same fix as **#1857** in this file, which replaced the analogous hand-built `conj (γ b) / ‖γ b‖` in `artanh_norm_le_integral`; both halves of the least-length theorem constructed a unit vector by dividing by a norm that can vanish.

Proof body: **54 → 47** lines. No new declarations, no signature changes — the PR only deletes case analysis that Mathlib makes unnecessary.

Roadmap: none