### PR TITLE
feat: relate dual point actions by evaluation

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Basic.lean
@@ -36,6 +36,8 @@ any finiteness, freeness, projectivity, flatness, or nontriviality hypothesis.
 
 * `HopfAlgebra.PointRepresentation`: a natural action on the scalar extensions of `V`.
 * `HopfAlgebra.PointRepresentation.ofComodule`: the point representation induced by a coaction.
+* `HopfAlgebra.PointRepresentation.ofComodule_action_val_eq_endOfPoint`: identification of the
+  induced representation action with the underlying comodule point action.
 * `HopfAlgebra.PointRepresentation.toComodule`: recovery of a coaction from the universal point.
 * `HopfAlgebra.pointRepresentationEquivComodule`: the fixed-object representation--comodule
   correspondence.
@@ -239,6 +241,14 @@ theorem ofComodule_action_tmul (rho : Comodule R H V)
   let : Comodule R H V := rho
   simpa only [LinearMap.lTensor_def] using
     (Comodule.endOfPoint_tmul (R := R) (H := H) V x.ofConv a v)
+
+/-- The underlying linear map of the action induced by a coaction is the corresponding
+comodule point-action endomorphism. -/
+theorem ofComodule_action_val_eq_endOfPoint (rho : Comodule R H V)
+    (A : CommAlgCat.{max u v w} R) (x : points (H := H) A) :
+    ((ofComodule rho).action A x).val = Comodule.endOfPoint V x.ofConv := by
+  refine TensorProduct.AlgebraTensorModule.ext fun a v ↦ ?_
+  rw [ofComodule_action_tmul, Comodule.endOfPoint_tmul, LinearMap.lTensor_def]
 
 /-- At the universal point, the action induced by a coaction is the flipped coaction. -/
 @[simp]

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
@@ -61,7 +61,7 @@ left-hand side first, so the simp-normal-form linter rejects the specialized ori
 theorem ofComodule_dual_action_evaluation_tmul
     (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
     (a b : A) (φ : Module.Dual R M) (m : M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (((ofComodule (Comodule.dual R H M)).action A g).val (a ⊗ₜ[R] φ))
         (b ⊗ₜ[R] m) =
       a * b * (g⁻¹).ofConv (Comodule.matrixCoefficient (R := R) (C := H) φ m) := by
@@ -74,9 +74,9 @@ dual comodule is adjoint under evaluation to the original action at the inverse 
 theorem ofComodule_dual_action_evaluation
     (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (((ofComodule (Comodule.dual R H M)).action A g).val ξ) z =
-      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
+      TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
         (((ofComodule rho).action A g⁻¹).val z) := by
   rw [ofComodule_action_val_eq_endOfPoint, ofComodule_action_val_eq_endOfPoint]
   exact Comodule.baseChangeEvaluation_dual_endOfPoint g ξ z
@@ -89,10 +89,10 @@ left-hand side first, so the simp-normal-form linter rejects the specialized ori
 theorem ofComodule_dual_action_evaluation_invariant
     (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (((ofComodule (Comodule.dual R H M)).action A g).val ξ)
         (((ofComodule rho).action A g).val z) =
-      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
+      TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
   rw [ofComodule_action_val_eq_endOfPoint, ofComodule_action_val_eq_endOfPoint]
   exact Comodule.baseChangeEvaluation_dual_endOfPoint_invariant g ξ z
 

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/Comodule/Dual.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Comodule.Basic
+public import TauCeti.Algebra.Coalgebra.Comodule.Evaluation
+
+/-!
+# Dual comodules and point representations
+
+For a finite-projective right comodule over a commutative Hopf algebra, this file expresses the
+evaluation identities for dual comodule point actions through the fixed-object
+representation--comodule dictionary. The point action on the dual is adjoint to the original
+action at the inverse point, and acting by the same point on both inputs preserves evaluation.
+
+The underlying action-level results hold at semiring generality in
+`TauCeti.Algebra.Coalgebra.Comodule.Evaluation`; the corollaries here use the dictionary's current
+commutative-ring and commutative-Hopf-algebra interface.
+
+## Main declarations
+
+* `TauCeti.HopfAlgebra.PointRepresentation.ofComodule_dual_action_evaluation_tmul`: evaluation of
+  a dual-action generator.
+* `TauCeti.HopfAlgebra.PointRepresentation.ofComodule_dual_action_evaluation`: adjointness in the
+  fixed-object dictionary.
+* `TauCeti.HopfAlgebra.PointRepresentation.ofComodule_dual_action_evaluation_invariant`:
+  same-point invariance of evaluation.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 4(a) and the contragredient formula on
+  p. 471.
+* J. E. Humphreys, *Linear Algebraic Groups*, p. 60.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+open scoped TensorProduct
+
+namespace TauCeti.HopfAlgebra.PointRepresentation
+
+universe u v w
+
+variable {R : Type u} {H : Type v} {M : Type w}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [rho : Comodule R H M]
+variable [Module.Finite R M] [Module.Projective R M]
+
+noncomputable section
+
+attribute [local instance] Comodule.dual
+
+/-- For the point action supplied by the representation--comodule dictionary, evaluation of a
+dual-action generator is inverse-point evaluation of the original matrix coefficient.
+
+This is not a simp lemma because `ofComodule_dual_action_evaluation` and `map_inv` simplify its
+left-hand side first, so the simp-normal-form linter rejects the specialized orientation. -/
+theorem ofComodule_dual_action_evaluation_tmul
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (a b : A) (φ : Module.Dual R M) (m : M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val (a ⊗ₜ[R] φ))
+        (b ⊗ₜ[R] m) =
+      a * b * (g⁻¹).ofConv (Comodule.matrixCoefficient (R := R) (C := H) φ m) := by
+  rw [ofComodule_action_val_eq_endOfPoint]
+  exact Comodule.baseChangeEvaluation_dual_endOfPoint_tmul (g := g) a b φ m
+
+/-- In the fixed-object representation--comodule dictionary, the point action induced on the
+dual comodule is adjoint under evaluation to the original action at the inverse point. -/
+@[simp↓]
+theorem ofComodule_dual_action_evaluation
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val ξ) z =
+      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
+        (((ofComodule rho).action A g⁻¹).val z) := by
+  rw [ofComodule_action_val_eq_endOfPoint, ofComodule_action_val_eq_endOfPoint]
+  exact Comodule.baseChangeEvaluation_dual_endOfPoint g ξ z
+
+/-- In the fixed-object representation--comodule dictionary, applying the same point to a
+finite-projective comodule and its dual preserves scalar-extended evaluation.
+
+This is not a simp lemma because `ofComodule_dual_action_evaluation` and `map_inv` simplify its
+left-hand side first, so the simp-normal-form linter rejects the specialized orientation. -/
+theorem ofComodule_dual_action_evaluation_invariant
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val ξ)
+        (((ofComodule rho).action A g).val z) =
+      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
+  rw [ofComodule_action_val_eq_endOfPoint, ofComodule_action_val_eq_endOfPoint]
+  exact Comodule.baseChangeEvaluation_dual_endOfPoint_invariant g ξ z
+
+end
+
+end TauCeti.HopfAlgebra.PointRepresentation

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/ComoduleDual.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/ComoduleDual.lean
@@ -1,0 +1,270 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dual.BaseChange
+public import TauCeti.Algebra.AlgebraicGroup.Representation.Comodule
+public import TauCeti.Algebra.Coalgebra.Comodule.Dual
+
+/-!
+# Dual comodules and point actions
+
+For a finite-projective right comodule `M` over a Hopf algebra, this file relates the point
+action on its antipode-twisted dual comodule to the original point action. The canonical
+`A`-valued pairing between `A ⊗[R] Module.Dual R M` and `A ⊗[R] M` satisfies
+
+```text
+⟨g · ξ, z⟩ = ⟨ξ, g⁻¹ · z⟩.
+```
+
+Equivalently, acting by the same point on both inputs preserves evaluation. On pure tensors,
+both sides are the inverse point evaluated at the existing matrix coefficient, multiplied by
+the two scalar factors. The basis-free proof uses the characteristic equation for
+`Comodule.dualCoact`; it does not identify the scalar extension of the dual with the full dual
+of the scalar extension.
+
+The action-level results first hold for a possibly noncommutative Hopf algebra over a
+commutative semiring. Their `PointRepresentation.ofComodule` corollaries use the dictionary's
+current commutative-ring and commutative-Hopf-algebra interface.
+
+## Main declarations
+
+* `TauCeti.Comodule.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
+* `TauCeti.Comodule.baseChangeEvaluation_dual_endOfPoint`: adjointness of the dual point action
+  and the inverse original point action.
+* `TauCeti.Comodule.baseChangeEvaluation_dual_endOfPoint_invariant`: same-point invariance of
+  evaluation.
+* `TauCeti.HopfAlgebra.PointRepresentation.ofComodule_dual_action_evaluation`: the corresponding
+  fixed-object dictionary statement.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), Chapter 4(a) and the contragredient formula on
+  p. 471.
+* J. E. Humphreys, *Linear Algebraic Groups*, p. 60.
+-/
+
+public section
+
+open CategoryTheory TensorProduct WithConv
+open scoped TensorProduct
+
+namespace TauCeti
+
+namespace Comodule
+
+universe u v w x
+
+section Evaluation
+
+variable {R : Type u} {M : Type w} {A : Type x}
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring A] [Algebra R A]
+
+/-- The canonical pairing of scalar extensions, as the map sending a scalar-extended
+`R`-linear functional to an `A`-linear functional on the scalar extension of its domain.
+
+This map requires no finiteness hypothesis and is not asserted to be an equivalence. -/
+def baseChangeEvaluation :
+    A ⊗[R] Module.Dual R M →ₗ[A] Module.Dual A (A ⊗[R] M) :=
+  (Module.Dual.baseChange A).liftBaseChange A
+
+/-- On pure tensors, scalar-extended evaluation is
+`⟨a ⊗ φ, b ⊗ m⟩ = a * b * algebraMap R A (φ m)`. -/
+@[simp]
+theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
+      a * b * algebraMap R A (φ m) := by
+  simp only [baseChangeEvaluation, LinearMap.liftBaseChange_tmul, LinearMap.smul_apply,
+    Module.Dual.baseChange_apply_tmul, Algebra.smul_def]
+  rw [Algebra.algebraMap_self_apply]
+  ac_rfl
+
+end Evaluation
+
+section Coalgebra
+
+variable {R : Type u} {H : Type v} {M : Type w} {A : Type x}
+variable [CommSemiring R] [Semiring H] [Algebra R H] [Coalgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+variable [CommSemiring A] [Algebra R A]
+
+/-- Pairing a scalar-extended functional with a point acting on a pure tensor evaluates the
+point at the corresponding matrix coefficient. -/
+theorem baseChangeEvaluation_endOfPoint_tmul (g : H →ₐ[R] A)
+    (a b : A) (φ : Module.Dual R M) (m : M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ)
+        (endOfPoint M g (b ⊗ₜ[R] m)) =
+      a * b * g (matrixCoefficient (R := R) (C := H) φ m) := by
+  rw [endOfPoint_tmul, matrixCoefficient_def]
+  generalize coact (R := R) (C := H) (M := M) m = t
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add s t hs ht => simp [hs, ht, mul_add]
+  | tmul n h =>
+      simp only [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, TensorProduct.comm_tmul,
+        map_smul, baseChangeEvaluation_tmul, smul_eq_mul, TensorProduct.map_tmul,
+        LinearMap.id_coe, id_eq, TensorProduct.lid_tmul, Algebra.smul_def, map_mul,
+        AlgHom.commutes]
+      rw [mul_comm (algebraMap R A (φ n)) (g h)]
+      ac_rfl
+
+end Coalgebra
+
+section Hopf
+
+variable {R : Type u} {H : Type v} {M : Type w} {A : Type x}
+variable [CommSemiring R] [Semiring H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [Comodule R H M]
+variable [Module.Finite R M] [Module.Projective R M]
+variable [CommSemiring A] [Algebra R A]
+
+noncomputable section
+
+attribute [local instance] dual
+
+omit [Comodule R H M] [Module.Finite R M] [Module.Projective R M] in
+private theorem baseChangeEvaluation_comm_lTensor (g : H →ₐ[R] A)
+    (t : Module.Dual R M ⊗[R] H) (b : A) (m : M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A)
+        (TensorProduct.comm R (Module.Dual R M) A
+          (LinearMap.lTensor (Module.Dual R M) g.toLinearMap t)) (b ⊗ₜ[R] m) =
+      b * g (dualTensorHom R M H t m) := by
+  induction t using TensorProduct.induction_on with
+  | zero => simp
+  | add s t hs ht => simp [hs, ht, mul_add]
+  | tmul φ h =>
+      simp only [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, TensorProduct.comm_tmul,
+        baseChangeEvaluation_tmul, dualTensorHom_apply, Algebra.smul_def, map_mul,
+        AlgHom.commutes]
+      rw [mul_comm (algebraMap R A (φ m)) (g h)]
+      ac_rfl
+
+/-- On pure tensors, acting on the dual leg and then evaluating gives the inverse point applied
+to the original matrix coefficient, together with the two scalar factors. -/
+theorem baseChangeEvaluation_dual_endOfPoint_tmul (g : WithConv (H →ₐ[R] A))
+    (a b : A) (φ : Module.Dual R M) (m : M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A)
+        (endOfPoint (Module.Dual R M) g.ofConv (a ⊗ₜ[R] φ)) (b ⊗ₜ[R] m) =
+      a * b * (g⁻¹).ofConv (matrixCoefficient (R := R) (C := H) φ m) := by
+  rw [endOfPoint_tmul]
+  rw [dual_coact (R := R) (H := H) (M := M)]
+  simp only [map_smul, LinearMap.smul_apply, baseChangeEvaluation_comm_lTensor]
+  rw [dualTensorHom_dualCoact_apply, AlgHom.convInv_apply]
+  simp only [smul_eq_mul]
+  ac_rfl
+
+/-- The point action on the antipode-twisted dual comodule is adjoint, under canonical
+scalar-extended evaluation, to the original point action at the inverse point. -/
+theorem baseChangeEvaluation_dual_endOfPoint (g : WithConv (H →ₐ[R] A))
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A)
+        (endOfPoint (Module.Dual R M) g.ofConv ξ) z =
+      baseChangeEvaluation (R := R) (M := M) (A := A) ξ
+        (endOfPoint M (g⁻¹).ofConv z) := by
+  induction ξ using TensorProduct.induction_on with
+  | zero => simp
+  | add ξ η hξ hη => simp only [map_add, LinearMap.add_apply, hξ, hη]
+  | tmul a φ =>
+      induction z using TensorProduct.induction_on with
+      | zero => simp
+      | add z w hz hw => simp only [map_add, hz, hw]
+      | tmul b m =>
+          rw [baseChangeEvaluation_dual_endOfPoint_tmul,
+            baseChangeEvaluation_endOfPoint_tmul]
+
+/-- Acting by the same point on a finite-projective comodule and its antipode-twisted dual
+preserves the canonical scalar-extended evaluation pairing. -/
+theorem baseChangeEvaluation_dual_endOfPoint_invariant (g : WithConv (H →ₐ[R] A))
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A)
+        (endOfPoint (Module.Dual R M) g.ofConv ξ) (endOfPoint M g.ofConv z) =
+      baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
+  rw [baseChangeEvaluation_dual_endOfPoint]
+  congr 1
+  have h := LinearMap.congr_fun (endOfPoint_convMul M g⁻¹ g) z
+  simpa using h.symm
+
+end
+
+end Hopf
+
+end Comodule
+
+namespace HopfAlgebra.PointRepresentation
+
+universe u v w
+
+variable {R : Type u} {H : Type v} {M : Type w}
+variable [CommRing R] [CommRing H] [HopfAlgebra R H]
+variable [AddCommMonoid M] [Module R M] [rho : Comodule R H M]
+variable [Module.Finite R M] [Module.Projective R M]
+
+noncomputable section
+
+attribute [local instance] Comodule.dual
+
+/-- For the point action supplied by the representation--comodule dictionary, evaluation of a
+dual-action generator is inverse-point evaluation of the original matrix coefficient. -/
+theorem ofComodule_dual_action_evaluation_tmul
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (a b : A) (φ : Module.Dual R M) (m : M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val (a ⊗ₜ[R] φ))
+        (b ⊗ₜ[R] m) =
+      a * b * (g⁻¹).ofConv (Comodule.matrixCoefficient (R := R) (C := H) φ m) := by
+  rw [ofComodule_action_tmul]
+  rw [Comodule.dual_coact (R := R) (H := H) (M := M)]
+  simpa only [Comodule.endOfPoint_tmul, Comodule.dual_coact, LinearMap.lTensor_def]
+    using Comodule.baseChangeEvaluation_dual_endOfPoint_tmul (g := g) a b φ m
+
+/-- In the fixed-object representation--comodule dictionary, the point action induced on the
+dual comodule is adjoint under evaluation to the original action at the inverse point. -/
+theorem ofComodule_dual_action_evaluation
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val ξ) z =
+      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
+        (((ofComodule rho).action A g⁻¹).val z) := by
+  have hdual :
+      ((ofComodule (Comodule.dual R H M)).action A g).val =
+        Comodule.endOfPoint (Module.Dual R M) g.ofConv := by
+    refine TensorProduct.AlgebraTensorModule.ext fun a φ ↦ ?_
+    rw [ofComodule_action_tmul (rho := Comodule.dual R H M),
+      Comodule.endOfPoint_tmul, LinearMap.lTensor_def]
+  have horiginal :
+      ((ofComodule rho).action A g⁻¹).val =
+        Comodule.endOfPoint M (g⁻¹).ofConv := by
+    refine TensorProduct.AlgebraTensorModule.ext fun a m ↦ ?_
+    rw [ofComodule_action_tmul (rho := rho), Comodule.endOfPoint_tmul,
+      LinearMap.lTensor_def]
+  rw [hdual, horiginal]
+  exact Comodule.baseChangeEvaluation_dual_endOfPoint g ξ z
+
+/-- In the fixed-object representation--comodule dictionary, applying the same point to a
+finite-projective comodule and its dual preserves scalar-extended evaluation. -/
+theorem ofComodule_dual_action_evaluation_invariant
+    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
+    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
+    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
+        (((ofComodule (Comodule.dual R H M)).action A g).val ξ)
+        (((ofComodule rho).action A g).val z) =
+      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
+  rw [ofComodule_dual_action_evaluation]
+  congr 1
+  calc
+    ((ofComodule rho).action A g⁻¹).val (((ofComodule rho).action A g).val z) =
+        (((ofComodule rho).action A g⁻¹) * ((ofComodule rho).action A g)).val z := by
+      rw [Units.val_mul, Module.End.mul_apply]
+    _ = ((ofComodule rho).action A (g⁻¹ * g)).val z := by
+      rw [((ofComodule rho).action A).hom.map_mul]
+    _ = z := by simp
+
+end
+
+end HopfAlgebra.PointRepresentation
+
+end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
@@ -4,12 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.Dual.BaseChange
-public import TauCeti.Algebra.AlgebraicGroup.Representation.Comodule
+public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.Algebra.Coalgebra.Comodule.Dual
+public import TauCeti.Algebra.Coalgebra.Comodule.PointsAction
+public import TauCeti.LinearAlgebra.Dual.BaseChange
 
 /-!
-# Dual comodules and point actions
+# Evaluation and dual point actions
 
 For a finite-projective right comodule `M` over a Hopf algebra, this file relates the point
 action on its antipode-twisted dual comodule to the original point action. The canonical
@@ -25,19 +26,17 @@ the two scalar factors. The basis-free proof uses the characteristic equation fo
 `Comodule.dualCoact`; it does not identify the scalar extension of the dual with the full dual
 of the scalar extension.
 
-The action-level results first hold for a possibly noncommutative Hopf algebra over a
-commutative semiring. Their `PointRepresentation.ofComodule` corollaries use the dictionary's
-current commutative-ring and commutative-Hopf-algebra interface.
+The action-level results hold for a possibly noncommutative Hopf algebra over a commutative
+semiring.
 
 ## Main declarations
 
-* `TauCeti.Comodule.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
+* `TauCeti.Comodule.baseChangeEvaluation_endOfPoint_tmul`: evaluation after a point acts on a
+  pure tensor.
 * `TauCeti.Comodule.baseChangeEvaluation_dual_endOfPoint`: adjointness of the dual point action
   and the inverse original point action.
 * `TauCeti.Comodule.baseChangeEvaluation_dual_endOfPoint_invariant`: same-point invariance of
   evaluation.
-* `TauCeti.HopfAlgebra.PointRepresentation.ofComodule_dual_action_evaluation`: the corresponding
-  fixed-object dictionary statement.
 
 ## References
 
@@ -48,41 +47,12 @@ current commutative-ring and commutative-Hopf-algebra interface.
 
 public section
 
-open CategoryTheory TensorProduct WithConv
+open TensorProduct WithConv
 open scoped TensorProduct
 
-namespace TauCeti
-
-namespace Comodule
+namespace TauCeti.Comodule
 
 universe u v w x
-
-section Evaluation
-
-variable {R : Type u} {M : Type w} {A : Type x}
-variable [CommSemiring R] [AddCommMonoid M] [Module R M]
-variable [CommSemiring A] [Algebra R A]
-
-/-- The canonical pairing of scalar extensions, as the map sending a scalar-extended
-`R`-linear functional to an `A`-linear functional on the scalar extension of its domain.
-
-This map requires no finiteness hypothesis and is not asserted to be an equivalence. -/
-def baseChangeEvaluation :
-    A ⊗[R] Module.Dual R M →ₗ[A] Module.Dual A (A ⊗[R] M) :=
-  (Module.Dual.baseChange A).liftBaseChange A
-
-/-- On pure tensors, scalar-extended evaluation is
-`⟨a ⊗ φ, b ⊗ m⟩ = a * b * algebraMap R A (φ m)`. -/
-@[simp]
-theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
-      a * b * algebraMap R A (φ m) := by
-  simp only [baseChangeEvaluation, LinearMap.liftBaseChange_tmul, LinearMap.smul_apply,
-    Module.Dual.baseChange_apply_tmul, Algebra.smul_def]
-  rw [Algebra.algebraMap_self_apply]
-  ac_rfl
-
-end Evaluation
 
 section Coalgebra
 
@@ -93,6 +63,8 @@ variable [CommSemiring A] [Algebra R A]
 
 /-- Pairing a scalar-extended functional with a point acting on a pure tensor evaluates the
 point at the corresponding matrix coefficient. -/
+-- Prefer the characteristic evaluation formula before `endOfPoint_tmul` expands the inner action.
+@[simp↓]
 theorem baseChangeEvaluation_endOfPoint_tmul (g : H →ₐ[R] A)
     (a b : A) (φ : Module.Dual R M) (m : M) :
     baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ)
@@ -144,6 +116,8 @@ private theorem baseChangeEvaluation_comm_lTensor (g : H →ₐ[R] A)
 
 /-- On pure tensors, acting on the dual leg and then evaluating gives the inverse point applied
 to the original matrix coefficient, together with the two scalar factors. -/
+-- Prefer the characteristic evaluation formula before the dual action itself is simplified.
+@[simp↓]
 theorem baseChangeEvaluation_dual_endOfPoint_tmul (g : WithConv (H →ₐ[R] A))
     (a b : A) (φ : Module.Dual R M) (m : M) :
     baseChangeEvaluation (R := R) (M := M) (A := A)
@@ -158,6 +132,7 @@ theorem baseChangeEvaluation_dual_endOfPoint_tmul (g : WithConv (H →ₐ[R] A))
 
 /-- The point action on the antipode-twisted dual comodule is adjoint, under canonical
 scalar-extended evaluation, to the original point action at the inverse point. -/
+@[simp]
 theorem baseChangeEvaluation_dual_endOfPoint (g : WithConv (H →ₐ[R] A))
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
     baseChangeEvaluation (R := R) (M := M) (A := A)
@@ -177,6 +152,8 @@ theorem baseChangeEvaluation_dual_endOfPoint (g : WithConv (H →ₐ[R] A))
 
 /-- Acting by the same point on a finite-projective comodule and its antipode-twisted dual
 preserves the canonical scalar-extended evaluation pairing. -/
+-- Prefer invariance before adjointness simplifies the first action.
+@[simp↓]
 theorem baseChangeEvaluation_dual_endOfPoint_invariant (g : WithConv (H →ₐ[R] A))
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
     baseChangeEvaluation (R := R) (M := M) (A := A)
@@ -191,80 +168,4 @@ end
 
 end Hopf
 
-end Comodule
-
-namespace HopfAlgebra.PointRepresentation
-
-universe u v w
-
-variable {R : Type u} {H : Type v} {M : Type w}
-variable [CommRing R] [CommRing H] [HopfAlgebra R H]
-variable [AddCommMonoid M] [Module R M] [rho : Comodule R H M]
-variable [Module.Finite R M] [Module.Projective R M]
-
-noncomputable section
-
-attribute [local instance] Comodule.dual
-
-/-- For the point action supplied by the representation--comodule dictionary, evaluation of a
-dual-action generator is inverse-point evaluation of the original matrix coefficient. -/
-theorem ofComodule_dual_action_evaluation_tmul
-    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
-    (a b : A) (φ : Module.Dual R M) (m : M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
-        (((ofComodule (Comodule.dual R H M)).action A g).val (a ⊗ₜ[R] φ))
-        (b ⊗ₜ[R] m) =
-      a * b * (g⁻¹).ofConv (Comodule.matrixCoefficient (R := R) (C := H) φ m) := by
-  rw [ofComodule_action_tmul]
-  rw [Comodule.dual_coact (R := R) (H := H) (M := M)]
-  simpa only [Comodule.endOfPoint_tmul, Comodule.dual_coact, LinearMap.lTensor_def]
-    using Comodule.baseChangeEvaluation_dual_endOfPoint_tmul (g := g) a b φ m
-
-/-- In the fixed-object representation--comodule dictionary, the point action induced on the
-dual comodule is adjoint under evaluation to the original action at the inverse point. -/
-theorem ofComodule_dual_action_evaluation
-    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
-    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
-        (((ofComodule (Comodule.dual R H M)).action A g).val ξ) z =
-      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
-        (((ofComodule rho).action A g⁻¹).val z) := by
-  have hdual :
-      ((ofComodule (Comodule.dual R H M)).action A g).val =
-        Comodule.endOfPoint (Module.Dual R M) g.ofConv := by
-    refine TensorProduct.AlgebraTensorModule.ext fun a φ ↦ ?_
-    rw [ofComodule_action_tmul (rho := Comodule.dual R H M),
-      Comodule.endOfPoint_tmul, LinearMap.lTensor_def]
-  have horiginal :
-      ((ofComodule rho).action A g⁻¹).val =
-        Comodule.endOfPoint M (g⁻¹).ofConv := by
-    refine TensorProduct.AlgebraTensorModule.ext fun a m ↦ ?_
-    rw [ofComodule_action_tmul (rho := rho), Comodule.endOfPoint_tmul,
-      LinearMap.lTensor_def]
-  rw [hdual, horiginal]
-  exact Comodule.baseChangeEvaluation_dual_endOfPoint g ξ z
-
-/-- In the fixed-object representation--comodule dictionary, applying the same point to a
-finite-projective comodule and its dual preserves scalar-extended evaluation. -/
-theorem ofComodule_dual_action_evaluation_invariant
-    (A : CommAlgCat.{max u v w} R) (g : points (H := H) A)
-    (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    Comodule.baseChangeEvaluation (R := R) (M := M) (A := A)
-        (((ofComodule (Comodule.dual R H M)).action A g).val ξ)
-        (((ofComodule rho).action A g).val z) =
-      Comodule.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
-  rw [ofComodule_dual_action_evaluation]
-  congr 1
-  calc
-    ((ofComodule rho).action A g⁻¹).val (((ofComodule rho).action A g).val z) =
-        (((ofComodule rho).action A g⁻¹) * ((ofComodule rho).action A g)).val z := by
-      rw [Units.val_mul, Module.End.mul_apply]
-    _ = ((ofComodule rho).action A (g⁻¹ * g)).val z := by
-      rw [((ofComodule rho).action A).hom.map_mul]
-    _ = z := by simp
-
-end
-
-end HopfAlgebra.PointRepresentation
-
-end TauCeti
+end TauCeti.Comodule

--- a/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
+++ b/TauCeti/Algebra/Coalgebra/Comodule/Evaluation.lean
@@ -67,7 +67,7 @@ point at the corresponding matrix coefficient. -/
 @[simp↓]
 theorem baseChangeEvaluation_endOfPoint_tmul (g : H →ₐ[R] A)
     (a b : A) (φ : Module.Dual R M) (m : M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ)
         (endOfPoint M g (b ⊗ₜ[R] m)) =
       a * b * g (matrixCoefficient (R := R) (C := H) φ m) := by
   rw [endOfPoint_tmul, matrixCoefficient_def]
@@ -77,7 +77,8 @@ theorem baseChangeEvaluation_endOfPoint_tmul (g : H →ₐ[R] A)
   | add s t hs ht => simp [hs, ht, mul_add]
   | tmul n h =>
       simp only [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, TensorProduct.comm_tmul,
-        map_smul, baseChangeEvaluation_tmul, smul_eq_mul, TensorProduct.map_tmul,
+        map_smul, TauCeti.Module.Dual.baseChangeEvaluation_tmul, smul_eq_mul,
+        TensorProduct.map_tmul,
         LinearMap.id_coe, id_eq, TensorProduct.lid_tmul, Algebra.smul_def, map_mul,
         AlgHom.commutes]
       rw [mul_comm (algebraMap R A (φ n)) (g h)]
@@ -100,7 +101,7 @@ attribute [local instance] dual
 omit [Comodule R H M] [Module.Finite R M] [Module.Projective R M] in
 private theorem baseChangeEvaluation_comm_lTensor (g : H →ₐ[R] A)
     (t : Module.Dual R M ⊗[R] H) (b : A) (m : M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (TensorProduct.comm R (Module.Dual R M) A
           (LinearMap.lTensor (Module.Dual R M) g.toLinearMap t)) (b ⊗ₜ[R] m) =
       b * g (dualTensorHom R M H t m) := by
@@ -109,7 +110,8 @@ private theorem baseChangeEvaluation_comm_lTensor (g : H →ₐ[R] A)
   | add s t hs ht => simp [hs, ht, mul_add]
   | tmul φ h =>
       simp only [LinearMap.lTensor_tmul, AlgHom.toLinearMap_apply, TensorProduct.comm_tmul,
-        baseChangeEvaluation_tmul, dualTensorHom_apply, Algebra.smul_def, map_mul,
+        TauCeti.Module.Dual.baseChangeEvaluation_tmul, dualTensorHom_apply, Algebra.smul_def,
+        map_mul,
         AlgHom.commutes]
       rw [mul_comm (algebraMap R A (φ m)) (g h)]
       ac_rfl
@@ -120,7 +122,7 @@ to the original matrix coefficient, together with the two scalar factors. -/
 @[simp↓]
 theorem baseChangeEvaluation_dual_endOfPoint_tmul (g : WithConv (H →ₐ[R] A))
     (a b : A) (φ : Module.Dual R M) (m : M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (endOfPoint (Module.Dual R M) g.ofConv (a ⊗ₜ[R] φ)) (b ⊗ₜ[R] m) =
       a * b * (g⁻¹).ofConv (matrixCoefficient (R := R) (C := H) φ m) := by
   rw [endOfPoint_tmul]
@@ -135,9 +137,9 @@ scalar-extended evaluation, to the original point action at the inverse point. -
 @[simp]
 theorem baseChangeEvaluation_dual_endOfPoint (g : WithConv (H →ₐ[R] A))
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (endOfPoint (Module.Dual R M) g.ofConv ξ) z =
-      baseChangeEvaluation (R := R) (M := M) (A := A) ξ
+      TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A) ξ
         (endOfPoint M (g⁻¹).ofConv z) := by
   induction ξ using TensorProduct.induction_on with
   | zero => simp
@@ -156,9 +158,9 @@ preserves the canonical scalar-extended evaluation pairing. -/
 @[simp↓]
 theorem baseChangeEvaluation_dual_endOfPoint_invariant (g : WithConv (H →ₐ[R] A))
     (ξ : A ⊗[R] Module.Dual R M) (z : A ⊗[R] M) :
-    baseChangeEvaluation (R := R) (M := M) (A := A)
+    TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A)
         (endOfPoint (Module.Dual R M) g.ofConv ξ) (endOfPoint M g.ofConv z) =
-      baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
+      TauCeti.Module.Dual.baseChangeEvaluation (R := R) (M := M) (A := A) ξ z := by
   rw [baseChangeEvaluation_dual_endOfPoint]
   congr 1
   have h := LinearMap.congr_fun (endOfPoint_convMul M g⁻¹ g) z

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -17,15 +17,15 @@ extension.
 
 ## Main declarations
 
-* `TauCeti.Comodule.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
-* `TauCeti.Comodule.baseChangeEvaluation_tmul`: its value on two pure tensors.
+* `TauCeti.Module.Dual.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
+* `TauCeti.Module.Dual.baseChangeEvaluation_tmul`: its value on two pure tensors.
 -/
 
 public section
 
 open scoped TensorProduct
 
-namespace TauCeti.Comodule
+namespace TauCeti.Module.Dual
 
 universe u w x
 
@@ -52,4 +52,4 @@ theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
   rw [Algebra.algebraMap_self_apply]
   ac_rfl
 
-end TauCeti.Comodule
+end TauCeti.Module.Dual

--- a/TauCeti/LinearAlgebra/Dual/BaseChange.lean
+++ b/TauCeti/LinearAlgebra/Dual/BaseChange.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Dual.BaseChange
+
+/-!
+# Evaluation after scalar extension
+
+This file defines the canonical pairing between the scalar extensions of a module and its linear
+dual. It sends an `R`-linear functional extended to `A` to the corresponding `A`-linear functional
+on the scalar extension of its domain. No finiteness hypothesis is required, and the construction
+is not asserted to identify the scalar extension of the dual with the full dual of the scalar
+extension.
+
+## Main declarations
+
+* `TauCeti.Comodule.baseChangeEvaluation`: the canonical scalar-extended evaluation map.
+* `TauCeti.Comodule.baseChangeEvaluation_tmul`: its value on two pure tensors.
+-/
+
+public section
+
+open scoped TensorProduct
+
+namespace TauCeti.Comodule
+
+universe u w x
+
+variable {R : Type u} {M : Type w} {A : Type x}
+variable [CommSemiring R] [AddCommMonoid M] [Module R M]
+variable [CommSemiring A] [Algebra R A]
+
+/-- The canonical pairing of scalar extensions, as the map sending a scalar-extended
+`R`-linear functional to an `A`-linear functional on the scalar extension of its domain.
+
+This map requires no finiteness hypothesis and is not asserted to be an equivalence. -/
+def baseChangeEvaluation :
+    A ⊗[R] Module.Dual R M →ₗ[A] Module.Dual A (A ⊗[R] M) :=
+  (Module.Dual.baseChange A).liftBaseChange A
+
+/-- On pure tensors, scalar-extended evaluation is
+`⟨a ⊗ φ, b ⊗ m⟩ = a * b * algebraMap R A (φ m)`. -/
+@[simp]
+theorem baseChangeEvaluation_tmul (a b : A) (φ : Module.Dual R M) (m : M) :
+    baseChangeEvaluation (R := R) (M := M) (A := A) (a ⊗ₜ[R] φ) (b ⊗ₜ[R] m) =
+      a * b * algebraMap R A (φ m) := by
+  simp only [baseChangeEvaluation, LinearMap.liftBaseChange_tmul, LinearMap.smul_apply,
+    Module.Dual.baseChange_apply_tmul, Algebra.smul_def]
+  rw [Algebra.algebraMap_self_apply]
+  ac_rfl
+
+end TauCeti.Comodule


### PR DESCRIPTION
This PR proves that the point action induced by the antipode-twisted dual comodule is contragredient to the original point action: under the canonical scalar-extended evaluation pairing, the dual action at a point is adjoint to the original action at the inverse point, and the two same-point actions preserve evaluation. It exposes the basis-free finite-projective identity at the semiring/Hopf boundary, its matrix-coefficient generator formulas, and fixed-object representation–comodule corollaries over commutative rings.

This advances `TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md`, Layer 1, lines 125–132, which calls for finite-dimensional comodules, duals, rigidity, and the representation–comodule dictionary, together with the synchronization requirement at lines 240 and 246–247. The implementation reuses Mathlib's `Module.Dual.baseChange` and `LinearMap.liftBaseChange` and Tau Ceti's existing dual-coaction and point-action APIs without copying their implementations.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"dual-point-action-pairing"}-->

🤖 Prepared with Codex
