### PR TITLE
refactor(Tangent): name the slotwise step of derivationComp_bracket

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -33,7 +33,13 @@ open Coalgebra TensorProduct WithConv
 section Bracket
 
 variable {R A A' B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring A'] [Bialgebra R A'] [CommRing B] [Algebra R B]
+  [CommSemiring A'] [Bialgebra R A']
+
+section Transport
+
+-- The transport step needs no more of `B` than `derivationComp` itself does; only the bracket
+-- below, being a commutator, asks for a ring.
+variable [Semiring B] [Algebra R B]
 
 /-- **Precomposing both slots by `φ` is multiplication of the transported derivations.** The two
 sides differ only by which counit coefficient algebra they are read in, and those are the same
@@ -61,6 +67,10 @@ private theorem mul'_comp_map_derivationComp (φ : A' →ₐc[R] A)
   -- The residual is print-identical across the two coefficient synonyms; both multiplications
   -- are definitionally `B`'s (the synonym is exposed), which is what this `rfl` uses.
   rfl
+
+end Transport
+
+variable [CommRing B] [Algebra R B]
 
 /-- The differential preserves the convolution commutator: a bialgebra morphism
 intertwines comultiplications, hence convolution products of derivations termwise. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -35,6 +35,33 @@ section Bracket
 variable {R A A' B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
   [CommSemiring A'] [Bialgebra R A'] [CommRing B] [Algebra R B]
 
+/-- **Precomposing both slots by `φ` is multiplication of the transported derivations.** The two
+sides differ only by which counit coefficient algebra they are read in, and those are the same
+`B`. -/
+private theorem mul'_comp_map_derivationComp (φ : A' →ₐc[R] A)
+    (e₁ e₂ : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    LinearMap.mul' R (Bialgebra.CounitAlgebra R A B) ∘ₗ
+        TensorProduct.map
+          ((↑e₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ
+            (φ : A' →ₐ[R] A).toLinearMap)
+          ((↑e₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ
+            (φ : A' →ₐ[R] A).toLinearMap) =
+      LinearMap.mul' R (Bialgebra.CounitAlgebra R A' B) ∘ₗ
+        TensorProduct.map
+          (↑(derivationComp (B := B) φ e₁) : A' →ₗ[R] Bialgebra.CounitAlgebra R A' B)
+          ↑(derivationComp (B := B) φ e₂) := by
+  -- An equality of linear maps on `A' ⊗ A'`, checked on pure tensors; `TensorProduct.ext'`
+  -- supplies the extensionality, so no induction is needed.
+  refine TensorProduct.ext' fun x y => ?_
+  -- Both composite applications unfold definitionally; restate them as values.
+  change (e₁ ((φ : A' →ₐ[R] A) x) * e₂ ((φ : A' →ₐ[R] A) y) :
+      Bialgebra.CounitAlgebra R A B) =
+    derivationComp (B := B) φ e₁ x * derivationComp (B := B) φ e₂ y
+  rw [derivationComp_apply, derivationComp_apply]
+  -- The residual is print-identical across the two coefficient synonyms; both multiplications
+  -- are definitionally `B`'s (the synonym is exposed), which is what this `rfl` uses.
+  rfl
+
 /-- The differential preserves the convolution commutator: a bialgebra morphism
 intertwines comultiplications, hence convolution products of derivations termwise. -/
 @[simp]
@@ -65,39 +92,13 @@ theorem derivationComp_bracket (φ : A' →ₐc[R] A)
         ((φ : A' →ₐc[R] A) : A' →ₗc[R] A)) a
     simp only [LinearMap.convMul_apply, LinearMap.coe_comp, Function.comp_apply] at h
     exact h
-  -- The two composites agree slotwise: an equality of linear maps on `A' ⊗ A'`
-  -- across the two coefficient synonyms (which are definitionally `B`), checked on
-  -- pure tensors by `derivationComp_apply`. `TensorProduct.ext'` supplies the
-  -- extensionality; no induction is needed.
-  have hslot : ∀ (e₁ e₂ : Derivation R A (Bialgebra.CounitAlgebra R A B)),
-      LinearMap.mul' R (Bialgebra.CounitAlgebra R A B) ∘ₗ
-        TensorProduct.map
-          ((↑e₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ
-            (φ : A' →ₐ[R] A).toLinearMap)
-          ((↑e₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ
-            (φ : A' →ₐ[R] A).toLinearMap) =
-      LinearMap.mul' R (Bialgebra.CounitAlgebra R A' B) ∘ₗ
-        TensorProduct.map
-          (↑(derivationComp (B := B) φ e₁) : A' →ₗ[R] Bialgebra.CounitAlgebra R A' B)
-          ↑(derivationComp (B := B) φ e₂) := by
-    intro e₁ e₂
-    refine TensorProduct.ext' fun x y => ?_
-    -- Both composite applications unfold definitionally; restate them as values.
-    change (e₁ ((φ : A' →ₐ[R] A) x) * e₂ ((φ : A' →ₐ[R] A) y) :
-        Bialgebra.CounitAlgebra R A B) =
-      derivationComp (B := B) φ e₁ x * derivationComp (B := B) φ e₂ y
-    rw [derivationComp_apply, derivationComp_apply]
-    -- The residual is print-identical across the two coefficient synonyms; both
-    -- multiplications are definitionally `B`'s (the synonym is exposed), which is
-    -- what this `rfl` uses.
-    rfl
-  have h1 := DFunLike.congr_fun (hslot d₁ d₂) (comul a)
-  have h2 := DFunLike.congr_fun (hslot d₂ d₁) (comul a)
+  have h1 := DFunLike.congr_fun (mul'_comp_map_derivationComp φ d₁ d₂) (comul a)
+  have h2 := DFunLike.congr_fun (mul'_comp_map_derivationComp φ d₂ d₁) (comul a)
   simp only [LinearMap.coe_comp, Function.comp_apply] at h1 h2
   rw [← AlgHom.toLinearMap_apply (φ : A' →ₐ[R] A) a, hconv, hconv, h1, h2]
   -- The closing `rfl` identifies the two sides through the exposed coefficient
-  -- synonyms once more: after the slotwise rewrites both are literally the same
-  -- `B`-valued expression.
+  -- synonyms: after the slotwise rewrites both are literally the same `B`-valued
+  -- expression.
   rfl
 
 end Bracket


### PR DESCRIPTION
`derivationComp_bracket` carried its whole argument in two `have`s inside the proof. Both were already universally quantified over the pair of derivations, so neither depended on the `d₁`, `d₂` of the enclosing statement.

This PR names the substantive one:

```lean
private theorem mul'_comp_map_derivationComp (φ : A' →ₐc[R] A)
    (e₁ e₂ : Derivation R A (Bialgebra.CounitAlgebra R A B)) : …
```

It says that precomposing both slots by `φ` is multiplication of the transported derivations — a genuine fact about `derivationComp`, proved on pure tensors via `TensorProduct.ext'`, whose two sides differ only by which counit coefficient algebra they are read in.

**Hypotheses are minimal by construction.** Because the `have` was already `∀`-quantified, what it states *is* its minimal hypothesis set: `φ` and the two derivations. Nothing from the enclosing proof is threaded through; the parent applies it at `(d₁, d₂)` and `(d₂, d₁)`.

**The convolution step deliberately stays inline.** A pre-submission review blocked an earlier revision of this PR that also extracted it, on the grounds that it would be a private restatement of Mathlib's `LinearMap.convMul_comp_coalgHom_distrib` specialised to `φ`'s underlying coalgebra morphism and evaluated at `a`. That is correct — the step is one application of that lemma plus `DFunLike.congr_fun` and the existing `simp only` normalisation — so it is left as a `have`, with the comment naming the Mathlib lemma it comes from.

Proof body: **57 → 31** lines, with a helper of 11. No signature changes; the helper is private.

Roadmap: none