### PR TITLE
feat: the adjoint action on the tangent space

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Basic.lean
@@ -73,7 +73,7 @@ is from Mathlib.
 
 public section
 
-open Coalgebra HopfAlgebra SymmetricAlgebra WithConv
+open _root_.Coalgebra HopfAlgebra SymmetricAlgebra WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Kernel.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveFrobeniusKernel/Kernel.lean
@@ -63,7 +63,7 @@ functor of points, the additive companion of `TauCeti.Algebra.AlgebraicGroup.Roo
 
 public section
 
-open Coalgebra HopfAlgebra SymmetricAlgebra WithConv
+open _root_.Coalgebra HopfAlgebra SymmetricAlgebra WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Basic.lean
@@ -39,7 +39,7 @@ bialgebra and convolution monoid APIs.
 
 public section
 
-open Coalgebra HopfAlgebra SymmetricAlgebra WithConv
+open _root_.Coalgebra HopfAlgebra SymmetricAlgebra WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Frobenius.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Frobenius.lean
@@ -52,7 +52,7 @@ constructor `BialgHom.ofAlgHom` are Mathlib's.
 
 public section
 
-open Coalgebra HopfAlgebra SymmetricAlgebra WithConv
+open _root_.Coalgebra HopfAlgebra SymmetricAlgebra WithConv
 open scoped TensorProduct
 
 namespace TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/BaseChange/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/BaseChange/Basic.lean
@@ -39,7 +39,7 @@ used here are from Mathlib, respectively `Mathlib.RingTheory.Bialgebra.TensorPro
 
 public section
 
-open Coalgebra HopfAlgebra TensorProduct WithConv
+open _root_.Coalgebra HopfAlgebra TensorProduct WithConv
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -53,7 +53,7 @@ Yaël Dillies, Michał Mrugała and Yunzhou Xie in Mathlib.
 
 public section
 
-open Coalgebra HopfAlgebra TensorProduct WithConv
+open _root_.Coalgebra HopfAlgebra TensorProduct WithConv
 
 namespace TauCeti
 

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -127,6 +127,7 @@ noncomputable instance instGroup : Group (WithConv (H →ₐ[R] A)) where
 /-- The linear images of a point and of its convolution inverse multiply to the
 convolution unit: the group law of the points, transferred to the linear
 convolution monoid. -/
+@[simp]
 lemma toConv_toLinearMap_mul_inv (g : WithConv (H →ₐ[R] A)) :
     toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
       (1 : WithConv (H →ₗ[R] A)) := by

--- a/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/FunctorOfPoints.lean
@@ -124,6 +124,16 @@ noncomputable instance instGroup : Group (WithConv (H →ₐ[R] A)) where
     ext h
     exact f.ofConv.commutes (counit h)
 
+/-- The linear images of a point and of its convolution inverse multiply to the
+convolution unit: the group law of the points, transferred to the linear
+convolution monoid. -/
+lemma toConv_toLinearMap_mul_inv (g : WithConv (H →ₐ[R] A)) :
+    toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
+      (1 : WithConv (H →ₗ[R] A)) := by
+  have h := congrArg (fun ψ : WithConv (H →ₐ[R] A) =>
+    toConv ψ.ofConv.toLinearMap) (mul_inv_cancel g)
+  rwa [AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convOne] at h
+
 end Hopf
 
 section Bialgebra

--- a/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Representation/PointsAction.lean
@@ -31,7 +31,7 @@ namespace TauCeti
 
 namespace Comodule
 
-open Coalgebra WithConv TensorProduct
+open _root_.Coalgebra WithConv TensorProduct
 
 variable {R H V A : Type*} [CommSemiring R] [Semiring H] [HopfAlgebra R H]
   [AddCommMonoid V] [Module R V] [Comodule R H V]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.DerivationMap
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Map
+
+/-!
+# The tangent space at the identity
+
+Aggregator for the tangent-level theory: the counit-valued derivations
+(`Tangent.Basic`), functoriality in the bialgebra (`Tangent.DerivationMap`,
+`Tangent.Map`), and the adjoint action of the points (`Tangent.Adjoint`).
+The Lie-algebra structure lives in the `Tangent.Lie` aggregator.
+-/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
@@ -50,7 +50,7 @@ namespace TauCeti
 
 namespace Derivation
 
-open Coalgebra WithConv TensorProduct
+open _root_.Coalgebra WithConv TensorProduct
 
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
   [CommSemiring B] [Algebra R B]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
@@ -182,8 +182,8 @@ noncomputable def adRepresentation :
     ext d a
     simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.one_apply]
     rw [adDerivation_apply, AlgHom.toLinearMap_convOne, inv_one,
-      AlgHom.toLinearMap_convOne, one_mul, mul_one]
-    rfl
+      AlgHom.toLinearMap_convOne, one_mul, mul_one, ofConv_toConv,
+      Derivation.coeFn_coe]
   map_mul' g h := by
     ext d a
     simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.mul_apply]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Adjoint.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
 public import Mathlib.RepresentationTheory.Basic
 
 /-!
@@ -21,7 +21,7 @@ the `B`-points on the `B`-valued tangent vectors (`adRepresentation`). For commu
 affine group scheme on its Lie functor; their compatibility as `B` varies
 (postcomposition naturality) is later infrastructure, not packaged here.
 
-Closure is composition-level, by the exterior-product calculus of `Lie.Basic`: an
+Closure is composition-level, by the exterior-product calculus of `Tangent.Basic`: an
 algebra-map point satisfies `g ∘ mul = g ⊠ g`, a derivation satisfies
 `d ∘ mul = e ⊠ d + d ⊠ e` for the convolution unit `e`, and the conjugates collapse
 by `g ⋆ e ⋆ g⁻¹ = e`, leaving the Leibniz form for `g ⋆ d ⋆ g⁻¹`. No antipode
@@ -61,10 +61,10 @@ private lemma conj_comp_mul'
     toConv ((toConv g.ofConv.toLinearMap *
         toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
         toConv ((g⁻¹).ofConv.toLinearMap)).ofConv ∘ₗ LinearMap.mul' R A) =
-      mulTensor 1 (toConv g.ofConv.toLinearMap *
+      LinearMap.mulTensor 1 (toConv g.ofConv.toLinearMap *
           toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
           toConv ((g⁻¹).ofConv.toLinearMap)) +
-        mulTensor (toConv g.ofConv.toLinearMap *
+        LinearMap.mulTensor (toConv g.ofConv.toLinearMap *
           toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
           toConv ((g⁻¹).ofConv.toLinearMap)) 1 := by
   have h := LinearMap.convMul_comp_coalgHom_distrib
@@ -79,15 +79,11 @@ private lemma conj_comp_mul'
   rw [show (_root_.Bialgebra.mulCoalgHom R A).toLinearMap = LinearMap.mul' R A from rfl] at h h2
   rw [h, toConv_ofConv]
   rw [h2, toConv_ofConv]
-  rw [toConv_algHom_comp_mul' g.ofConv, toConv_coe_comp_mul' d,
-    toConv_algHom_comp_mul' (g⁻¹).ofConv]
-  rw [mul_add, add_mul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul,
-    mulTensor_convMul, mul_one, AlgHom.toConv_toLinearMap_mul_inv]
-
-omit [CommSemiring A] [HopfAlgebra R A] in
-/-- The base algebra maps of the coefficient synonym and of `B` agree. -/
-private lemma algebraMap_counitAlgebra (r : R) :
-    algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
+  rw [AlgHom.toConv_toLinearMap_comp_mul' g.ofConv, toConv_coe_comp_mul' d,
+    AlgHom.toConv_toLinearMap_comp_mul' (g⁻¹).ofConv]
+  rw [mul_add, add_mul, LinearMap.mulTensor_convMul, LinearMap.mulTensor_convMul,
+    LinearMap.mulTensor_convMul, LinearMap.mulTensor_convMul, mul_one,
+    AlgHom.toConv_toLinearMap_mul_inv]
 
 /-- The Leibniz rule for a conjugated derivation, in scalar-action form. -/
 private lemma conj_ofConv_mul
@@ -104,8 +100,8 @@ private lemma conj_ofConv_mul
           toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := by
   have h := congrArg (fun F => F.ofConv (a ⊗ₜ[R] b)) (conj_comp_mul' g d)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mul'_apply,
-    ofConv_add, LinearMap.add_apply, mulTensor_apply_tmul,
-    LinearMap.convOne_apply, algebraMap_counitAlgebra] at h
+    ofConv_add, LinearMap.add_apply, LinearMap.mulTensor_apply_tmul,
+    LinearMap.convOne_apply, Bialgebra.CounitAlgebra.algebraMap_base] at h
   rw [h, ← Bialgebra.CounitAlgebra.algebraMap_apply R A B a,
     ← Bialgebra.CounitAlgebra.algebraMap_apply R A B b, ← Algebra.commutes,
     ← Algebra.smul_def, ← Algebra.smul_def]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -35,6 +35,20 @@ of the kernel says nothing about the Lie bracket, which appears at second order.
 The synonym `CounitAlgebra` is a fresh scope for the point-induced algebra structure,
 as the dictionary requires; it does not install instances on `B` itself, and
 `Bialgebra.CounitAlgebra.algEquivSelf` transports back to `B` as an `R`-algebra.
+
+## The exterior convolution product
+
+The file also provides the exterior convolution product `LinearMap.mulTensor`: two
+convolution linear maps applied legwise on `A ⊗[R] A` and multiplied in the
+coefficients, with its normalization rules (zero, addition, scalars) and its
+multiplicativity for convolution. Composing with the multiplication of `A` lands in
+this product's image: an algebra-map point satisfies `g ∘ mul = g ⊠ g`
+(`AlgHom.toConv_toLinearMap_comp_mul'`), and a counit-valued derivation satisfies the
+Leibniz rule `d ∘ mul = 1 ⊠ d + d ⊠ 1` (`Derivation.toConv_coe_comp_mul'`). This
+calculus lives here, at the tangent level, because every later structure on the tangent
+space — the Lie bracket and the adjoint action alike — is a composition-level
+consequence of these three identities.
+
 -/
 
 public section

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -480,24 +480,28 @@ lemma mulTensor_zero_right (s : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R 
   simp
 
 /-- The exterior product is additive in the left factor. -/
+@[simp]
 lemma mulTensor_add_left (s₁ s₂ t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     mulTensor (s₁ + s₂) t = mulTensor s₁ t + mulTensor s₂ t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp [add_mul]
 
 /-- The exterior product is additive in the right factor. -/
+@[simp]
 lemma mulTensor_add_right (s t₁ t₂ : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     mulTensor s (t₁ + t₂) = mulTensor s t₁ + mulTensor s t₂ := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp [mul_add]
 
 /-- Scalars pull out of the left factor of the exterior product. -/
+@[simp]
 lemma mulTensor_smul_left (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     mulTensor (r • s) t = r • mulTensor s t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp
 
 /-- Scalars pull out of the right factor of the exterior product. -/
+@[simp]
 lemma mulTensor_smul_right (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     mulTensor s (r • t) = r • mulTensor s t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -6,6 +6,7 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.RingTheory.Derivation.DualNumber
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 
 /-!
 # The tangent space at the identity point
@@ -130,10 +131,14 @@ noncomputable instance : IsScalarTower R A (CounitAlgebra R A B) :=
       ((Algebra.ofId R B).comp (counitAlgHom R A)) (algebraMap R A r)
     simp
 
+/-- The coefficient synonym is a module over the coefficients, inherited from `B`. -/
 instance : Module B (CounitAlgebra R A B) := inferInstanceAs (Module B B)
 
+/-- Base and coefficient scalars commute on the synonym, inherited from `B`. -/
 instance : SMulCommClass R B (CounitAlgebra R A B) := inferInstanceAs (SMulCommClass R B B)
 
+/-- Coefficient scalars associate with the synonym's multiplication, inherited from
+`B`. -/
 instance : IsScalarTower B (CounitAlgebra R A B) (CounitAlgebra R A B) :=
   inferInstanceAs (IsScalarTower B B B)
 
@@ -145,6 +150,13 @@ instance : SMulCommClass B A (CounitAlgebra R A B) where
     -- with the `B`-action: move the central factor across the product.
     rw [Algebra.smul_def, Algebra.smul_def, Algebra.commutes a (b • x), smul_mul_assoc,
       Algebra.commutes a x]
+
+omit [CommSemiring A] [Bialgebra R A] in
+/-- The base `R`-algebra map of the coefficient synonym agrees with that of `B` itself:
+the synonym changes only the `A`-algebra structure. -/
+@[simp]
+lemma algebraMap_base (r : R) :
+    algebraMap R (CounitAlgebra R A B) r = algebraMap R B r := rfl
 
 @[simp]
 lemma algebraMap_apply (a : A) :
@@ -405,5 +417,130 @@ noncomputable instance : CommGroup (tangentKer R A B) :=
       rw [map_mul, map_mul, mul_comm] }
 
 end Hopf
+
+
+section ExteriorProduct
+
+open WithConv TensorProduct
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B]
+
+namespace LinearMap
+
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B]
+
+/-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
+leg and multiply the results in the coefficients. It underlies the Leibniz-rule
+manipulations for counit-valued derivations: composing with the multiplication of the
+bialgebra lands in this product's image. -/
+def mulTensor (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    WithConv (A ⊗[R] A →ₗ[R] Bialgebra.CounitAlgebra R A B) :=
+  toConv ((Algebra.TensorProduct.lmul' R
+    (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
+
+/-- The exterior product evaluates a pure tensor legwise and multiplies the results
+in the coefficients. -/
+@[simp]
+lemma mulTensor_apply_tmul
+    (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) (x y : A) :
+    (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
+  simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
+
+/-- The exterior product is multiplicative for convolution: products interleave
+legwise. -/
+lemma mulTensor_convMul
+    (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
+  have h := LinearMap.algHom_comp_convMul_distrib
+    (Algebra.TensorProduct.lmul' R (S := Bialgebra.CounitAlgebra R A B))
+    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
+  rw [map_convMul_map] at h
+  calc mulTensor s t * mulTensor u v
+      = toConv ((Algebra.TensorProduct.lmul' R
+            (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ
+          map (s * u).ofConv (t * v).ofConv) := by
+        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
+    _ = mulTensor (s * u) (t * v) := rfl
+
+/-- The exterior product vanishes when the left factor is zero. -/
+@[simp]
+lemma mulTensor_zero_left (t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor 0 t = 0 := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- The exterior product vanishes when the right factor is zero. -/
+@[simp]
+lemma mulTensor_zero_right (s : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor s 0 = 0 := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- The exterior product is additive in the left factor. -/
+lemma mulTensor_add_left (s₁ s₂ t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor (s₁ + s₂) t = mulTensor s₁ t + mulTensor s₂ t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [add_mul]
+
+/-- The exterior product is additive in the right factor. -/
+lemma mulTensor_add_right (s t₁ t₂ : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor s (t₁ + t₂) = mulTensor s t₁ + mulTensor s t₂ := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [mul_add]
+
+/-- Scalars pull out of the left factor of the exterior product. -/
+lemma mulTensor_smul_left (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor (r • s) t = r • mulTensor s t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- Scalars pull out of the right factor of the exterior product. -/
+lemma mulTensor_smul_right (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor s (r • t) = r • mulTensor s t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+end LinearMap
+
+namespace AlgHom
+
+open TauCeti.LinearMap in
+/-- An algebra-map point composed with multiplication is its own exterior square:
+the multiplicativity of the point, in convolution form. -/
+lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
+    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
+      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [map_mul]
+
+end AlgHom
+
+namespace Derivation
+
+open TauCeti.LinearMap
+
+/-- The Leibniz rule in convolution form: composing a counit-valued derivation with
+the multiplication of `A` is the exterior product against the convolution unit, on
+either side. -/
+lemma toConv_coe_comp_mul'
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    toConv ((d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ LinearMap.mul' R A) =
+      mulTensor 1 (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) +
+        mulTensor (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) 1 := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp only [ofConv_add, LinearMap.add_apply, LinearMap.coe_comp,
+    Function.comp_apply, LinearMap.mul'_apply, mulTensor_apply_tmul,
+    Derivation.coeFn_coe, LinearMap.convOne_apply, Bialgebra.CounitAlgebra.algebraMap_base]
+  rw [← Bialgebra.CounitAlgebra.algebraMap_apply R A B x,
+    ← Bialgebra.CounitAlgebra.algebraMap_apply R A B y, ← Algebra.commutes,
+    ← Algebra.smul_def, ← Algebra.smul_def]
+  exact d.leibniz x y
+
+end Derivation
+
+end ExteriorProduct
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -507,12 +507,12 @@ end LinearMap
 
 namespace AlgHom
 
-variable {A B : Type*} [Semiring A] [Algebra R A] [CommSemiring B] [Algebra R B]
+variable {A : Type*} [Semiring A] [Algebra R A]
 
 open TauCeti.LinearMap in
 /-- An algebra-map point composed with multiplication is its own exterior square:
 the multiplicativity of the point, in convolution form. -/
-lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
+lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] S) :
     toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
       mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
@@ -526,23 +526,22 @@ section ExteriorConvolution
 
 open WithConv TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B]
+variable {R A S : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
+  [CommSemiring S] [Algebra R S]
 
 namespace LinearMap
 
 /-- The exterior product is multiplicative for convolution: products interleave
 legwise. -/
 lemma mulTensor_convMul
-    (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    (s t u v : WithConv (A →ₗ[R] S)) :
     mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
   have h := LinearMap.algHom_comp_convMul_distrib
-    (Algebra.TensorProduct.lmul' R (S := Bialgebra.CounitAlgebra R A B))
+    (Algebra.TensorProduct.lmul' R (S := S))
     (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
   rw [map_convMul_map] at h
   calc mulTensor s t * mulTensor u v
-      = toConv ((Algebra.TensorProduct.lmul' R
-            (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ
+      = toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ
           map (s * u).ofConv (t * v).ofConv) := by
         rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
     _ = mulTensor (s * u) (t * v) := rfl

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.RingTheory.Derivation.DualNumber
-public import Mathlib.RingTheory.Bialgebra.TensorProduct
 public import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -130,6 +130,22 @@ noncomputable instance : IsScalarTower R A (CounitAlgebra R A B) :=
       ((Algebra.ofId R B).comp (counitAlgHom R A)) (algebraMap R A r)
     simp
 
+instance : Module B (CounitAlgebra R A B) := inferInstanceAs (Module B B)
+
+instance : SMulCommClass R B (CounitAlgebra R A B) := inferInstanceAs (SMulCommClass R B B)
+
+instance : IsScalarTower B (CounitAlgebra R A B) (CounitAlgebra R A B) :=
+  inferInstanceAs (IsScalarTower B B B)
+
+/-- Scalars of the coefficient algebra commute with the bialgebra scalar action, because
+the latter multiplies by a central element — the image of the counit in `B`. -/
+instance : SMulCommClass B A (CounitAlgebra R A B) where
+  smul_comm b a x := by
+    -- The bialgebra scalar action multiplies by a central element, so it commutes
+    -- with the `B`-action: move the central factor across the product.
+    rw [Algebra.smul_def, Algebra.smul_def, Algebra.commutes a (b • x), smul_mul_assoc,
+      Algebra.commutes a x]
+
 @[simp]
 lemma algebraMap_apply (a : A) :
     algebraMap A (CounitAlgebra R A B) a = algebraMap R B (counit a) := by
@@ -141,6 +157,17 @@ lemma algebraMap_apply (a : A) :
 end Bialgebra.CounitAlgebra
 
 end BialgebraPointScalar
+
+section CommPointScalar
+
+variable (R A B : Type*) [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B]
+
+/-- Coefficient scalars commute with multiplication in the coefficient synonym. -/
+instance : SMulCommClass B (Bialgebra.CounitAlgebra R A B) (Bialgebra.CounitAlgebra R A B) :=
+  inferInstanceAs (SMulCommClass B B B)
+
+end CommPointScalar
 
 section BialgebraCommTarget
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -7,6 +7,7 @@ module
 public import TauCeti.Algebra.AlgebraicGroup.FunctorOfPoints
 public import TauCeti.RingTheory.Derivation.DualNumber
 public import Mathlib.RingTheory.Bialgebra.TensorProduct
+public import TauCeti.Algebra.Coalgebra.Convolution
 
 /-!
 # The tangent space at the identity point
@@ -55,7 +56,7 @@ public section
 
 namespace TauCeti
 
-open Bialgebra Coalgebra WithConv
+open Bialgebra _root_.Coalgebra WithConv
 
 section BialgebraPoint
 
@@ -102,7 +103,6 @@ lemma algEquivSelf_symm_apply (b : B) : (algEquivSelf R A B).symm b = b := by
   change (AlgEquiv.refl (R := R) (A₁ := B)).symm b = b
   simp only [AlgEquiv.refl_symm, AlgEquiv.coe_refl]
   rfl
-
 
 end Bialgebra.CounitAlgebra
 
@@ -431,124 +431,6 @@ noncomputable instance : CommGroup (tangentKer R A B) :=
       rw [map_mul, map_mul, mul_comm] }
 
 end Hopf
-
-
-section ExteriorProduct
-
-open WithConv TensorProduct
-
-variable {R M S : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-  [CommSemiring S] [Algebra R S]
-
-namespace LinearMap
-
-
-
-/-- The exterior convolution product on `M ⊗[R] M`: apply one factor on each tensor
-leg and multiply the results in the coefficients. It underlies the Leibniz-rule
-manipulations for counit-valued derivations: composing with the multiplication of the
-bialgebra lands in this product's image. -/
-def mulTensor (s t : WithConv (M →ₗ[R] S)) :
-    WithConv (M ⊗[R] M →ₗ[R] S) :=
-  toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
-
-/-- The exterior product evaluates a pure tensor legwise and multiplies the results
-in the coefficients. -/
-@[simp]
-lemma mulTensor_apply_tmul
-    (s t : WithConv (M →ₗ[R] S)) (x y : M) :
-    (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
-  simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
-
-
-/-- The exterior product vanishes when the left factor is zero. -/
-@[simp]
-lemma mulTensor_zero_left (t : WithConv (M →ₗ[R] S)) :
-    mulTensor 0 t = 0 := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp
-
-/-- The exterior product vanishes when the right factor is zero. -/
-@[simp]
-lemma mulTensor_zero_right (s : WithConv (M →ₗ[R] S)) :
-    mulTensor s 0 = 0 := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp
-
-/-- The exterior product is additive in the left factor. -/
-@[simp]
-lemma mulTensor_add_left (s₁ s₂ t : WithConv (M →ₗ[R] S)) :
-    mulTensor (s₁ + s₂) t = mulTensor s₁ t + mulTensor s₂ t := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [add_mul]
-
-/-- The exterior product is additive in the right factor. -/
-@[simp]
-lemma mulTensor_add_right (s t₁ t₂ : WithConv (M →ₗ[R] S)) :
-    mulTensor s (t₁ + t₂) = mulTensor s t₁ + mulTensor s t₂ := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [mul_add]
-
-/-- Scalars pull out of the left factor of the exterior product. -/
-@[simp]
-lemma mulTensor_smul_left (r : R) (s t : WithConv (M →ₗ[R] S)) :
-    mulTensor (r • s) t = r • mulTensor s t := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp
-
-/-- Scalars pull out of the right factor of the exterior product. -/
-@[simp]
-lemma mulTensor_smul_right (r : R) (s t : WithConv (M →ₗ[R] S)) :
-    mulTensor s (r • t) = r • mulTensor s t := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp
-
-end LinearMap
-
-namespace AlgHom
-
-variable {A : Type*} [Semiring A] [Algebra R A]
-
-open TauCeti.LinearMap in
-/-- An algebra-map point composed with multiplication is its own exterior square:
-the multiplicativity of the point, in convolution form. -/
-lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] S) :
-    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
-      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [map_mul]
-
-end AlgHom
-
-end ExteriorProduct
-
-section ExteriorConvolution
-
-open WithConv TensorProduct
-
-variable {R A S : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
-  [CommSemiring S] [Algebra R S]
-
-namespace LinearMap
-
-/-- The exterior product is multiplicative for convolution: products interleave
-legwise. -/
-lemma mulTensor_convMul
-    (s t u v : WithConv (A →ₗ[R] S)) :
-    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
-  have h := LinearMap.algHom_comp_convMul_distrib
-    (Algebra.TensorProduct.lmul' R (S := S))
-    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
-  rw [map_convMul_map] at h
-  calc mulTensor s t * mulTensor u v
-      = toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ
-          map (s * u).ofConv (t * v).ofConv) := by
-        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
-    _ = mulTensor (s * u) (t * v) := rfl
-
-end LinearMap
-
-end ExteriorConvolution
 
 section DerivationLeibniz
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -423,7 +423,7 @@ section ExteriorProduct
 
 open WithConv TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
   [CommSemiring B] [Algebra R B]
 
 namespace LinearMap
@@ -447,21 +447,6 @@ lemma mulTensor_apply_tmul
     (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
   simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
 
-/-- The exterior product is multiplicative for convolution: products interleave
-legwise. -/
-lemma mulTensor_convMul
-    (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
-    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
-  have h := LinearMap.algHom_comp_convMul_distrib
-    (Algebra.TensorProduct.lmul' R (S := Bialgebra.CounitAlgebra R A B))
-    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
-  rw [map_convMul_map] at h
-  calc mulTensor s t * mulTensor u v
-      = toConv ((Algebra.TensorProduct.lmul' R
-            (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ
-          map (s * u).ofConv (t * v).ofConv) := by
-        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
-    _ = mulTensor (s * u) (t * v) := rfl
 
 /-- The exterior product vanishes when the left factor is zero. -/
 @[simp]
@@ -521,6 +506,35 @@ lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A 
 end AlgHom
 
 end ExteriorProduct
+
+section ExteriorConvolution
+
+open WithConv TensorProduct
+
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B]
+
+namespace LinearMap
+
+/-- The exterior product is multiplicative for convolution: products interleave
+legwise. -/
+lemma mulTensor_convMul
+    (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
+  have h := LinearMap.algHom_comp_convMul_distrib
+    (Algebra.TensorProduct.lmul' R (S := Bialgebra.CounitAlgebra R A B))
+    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
+  rw [map_convMul_map] at h
+  calc mulTensor s t * mulTensor u v
+      = toConv ((Algebra.TensorProduct.lmul' R
+            (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ
+          map (s * u).ofConv (t * v).ofConv) := by
+        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
+    _ = mulTensor (s * u) (t * v) := rfl
+
+end LinearMap
+
+end ExteriorConvolution
 
 section DerivationLeibniz
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -423,14 +423,12 @@ section ExteriorProduct
 
 open WithConv TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+variable {R A B : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
   [CommSemiring B] [Algebra R B]
 
 namespace LinearMap
 
 
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B]
 
 /-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
 leg and multiply the results in the coefficients. It underlies the Leibniz-rule
@@ -522,6 +520,15 @@ lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A 
 
 end AlgHom
 
+end ExteriorProduct
+
+section DerivationLeibniz
+
+open WithConv TensorProduct
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommSemiring B] [Algebra R B]
+
 namespace Derivation
 
 open TauCeti.LinearMap
@@ -545,6 +552,6 @@ lemma toConv_coe_comp_mul'
 
 end Derivation
 
-end ExteriorProduct
+end DerivationLeibniz
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Basic.lean
@@ -437,69 +437,68 @@ section ExteriorProduct
 
 open WithConv TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [Semiring A] [Algebra R A]
-  [CommSemiring B] [Algebra R B]
+variable {R M S : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [CommSemiring S] [Algebra R S]
 
 namespace LinearMap
 
 
 
-/-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
+/-- The exterior convolution product on `M ⊗[R] M`: apply one factor on each tensor
 leg and multiply the results in the coefficients. It underlies the Leibniz-rule
 manipulations for counit-valued derivations: composing with the multiplication of the
 bialgebra lands in this product's image. -/
-def mulTensor (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
-    WithConv (A ⊗[R] A →ₗ[R] Bialgebra.CounitAlgebra R A B) :=
-  toConv ((Algebra.TensorProduct.lmul' R
-    (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
+def mulTensor (s t : WithConv (M →ₗ[R] S)) :
+    WithConv (M ⊗[R] M →ₗ[R] S) :=
+  toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
 
 /-- The exterior product evaluates a pure tensor legwise and multiplies the results
 in the coefficients. -/
 @[simp]
 lemma mulTensor_apply_tmul
-    (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) (x y : A) :
+    (s t : WithConv (M →ₗ[R] S)) (x y : M) :
     (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
   simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
 
 
 /-- The exterior product vanishes when the left factor is zero. -/
 @[simp]
-lemma mulTensor_zero_left (t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_zero_left (t : WithConv (M →ₗ[R] S)) :
     mulTensor 0 t = 0 := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp
 
 /-- The exterior product vanishes when the right factor is zero. -/
 @[simp]
-lemma mulTensor_zero_right (s : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_zero_right (s : WithConv (M →ₗ[R] S)) :
     mulTensor s 0 = 0 := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp
 
 /-- The exterior product is additive in the left factor. -/
 @[simp]
-lemma mulTensor_add_left (s₁ s₂ t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_add_left (s₁ s₂ t : WithConv (M →ₗ[R] S)) :
     mulTensor (s₁ + s₂) t = mulTensor s₁ t + mulTensor s₂ t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp [add_mul]
 
 /-- The exterior product is additive in the right factor. -/
 @[simp]
-lemma mulTensor_add_right (s t₁ t₂ : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_add_right (s t₁ t₂ : WithConv (M →ₗ[R] S)) :
     mulTensor s (t₁ + t₂) = mulTensor s t₁ + mulTensor s t₂ := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp [mul_add]
 
 /-- Scalars pull out of the left factor of the exterior product. -/
 @[simp]
-lemma mulTensor_smul_left (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_smul_left (r : R) (s t : WithConv (M →ₗ[R] S)) :
     mulTensor (r • s) t = r • mulTensor s t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp
 
 /-- Scalars pull out of the right factor of the exterior product. -/
 @[simp]
-lemma mulTensor_smul_right (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+lemma mulTensor_smul_right (r : R) (s t : WithConv (M →ₗ[R] S)) :
     mulTensor s (r • t) = r • mulTensor s t := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp
@@ -507,6 +506,8 @@ lemma mulTensor_smul_right (r : R) (s t : WithConv (A →ₗ[R] Bialgebra.Counit
 end LinearMap
 
 namespace AlgHom
+
+variable {A B : Type*} [Semiring A] [Algebra R A] [CommSemiring B] [Algebra R B]
 
 open TauCeti.LinearMap in
 /-- An algebra-map point composed with multiplication is its own exterior square:

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -33,7 +33,7 @@ public section
 
 namespace TauCeti
 
-open Coalgebra
+open _root_.Coalgebra
 
 section DerivationMap
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/DerivationMap.lean
@@ -74,7 +74,8 @@ private noncomputable def derivationCompAux (φ : A' →ₐc[R] A)
       -- step explicitly.
       rw [show ρ (algebraMap R A' r) =
           (IsScalarTower.toAlgHom R A (Bialgebra.CounitAlgebra R A B))
-            (algebraMap R A r) from by simp [ρ, AlgHomClass.commutes],
+            (algebraMap R A r) from by
+          simp [ρ, AlgHomClass.commutes, -Bialgebra.CounitAlgebra.algebraMap_base],
         IsScalarTower.coe_toAlgHom', ← IsScalarTower.algebraMap_apply]
   letI : IsScalarTower A' A (Bialgebra.CounitAlgebra R A B) :=
     IsScalarTower.of_algebraMap_eq' rfl

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
@@ -12,6 +13,6 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
 Directory aggregator: the Lie algebra structure on counit-valued derivations
 (`Lie.Basic`), the differential as a Lie algebra morphism (`Lie.Map`), and the
-adjoint action (`Lie.Adjoint`). Importing
+adjoint action (`Tangent.Adjoint`). Importing
 `TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides all three.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -12,5 +12,5 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
 Directory aggregator: the Lie algebra structure on counit-valued derivations
 (`Lie.Basic`), the differential as a Lie algebra morphism (`Lie.Map`), and the
-`TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides all three.
+`TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides both.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
@@ -11,6 +12,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 # The Lie algebra of the tangent space
 
 Directory aggregator: the Lie algebra structure on counit-valued derivations
-(`Lie.Basic`) and the differential as a Lie algebra morphism (`Lie.Map`). Importing
-`TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` continues to provide both.
+(`Lie.Basic`), the differential as a Lie algebra morphism (`Lie.Map`), and the
+adjoint action (`Lie.Adjoint`). Importing
+`TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides all three.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -10,7 +10,7 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 /-!
 # The Lie algebra of the tangent space
 
-Directory aggregator: the Lie algebra structure on counit-valued derivations
-(`Lie.Basic`), the differential as a Lie algebra morphism (`Lie.Map`), and the
-`TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides both.
+Directory aggregator: importing this module provides both the Lie algebra structure
+on counit-valued derivations (`Lie.Basic`) and the differential as a Lie algebra
+morphism (`Lie.Map`).
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.Tangent.Adjoint
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
@@ -13,6 +12,5 @@ public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Map
 
 Directory aggregator: the Lie algebra structure on counit-valued derivations
 (`Lie.Basic`), the differential as a Lie algebra morphism (`Lie.Map`), and the
-adjoint action (`Tangent.Adjoint`). Importing
 `TauCeti.Algebra.AlgebraicGroup.Tangent.Lie` provides all three.
 -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -163,10 +163,11 @@ private lemma toConv_coe_adDerivation
 
 variable (B) in
 /-- The adjoint action of the group of points on the tangent space, as a
-representation: conjugation is a semiring automorphism of the convolution semiring, and it
-restricts to the derivations. -/
+`B`-linear representation: conjugation is a semiring automorphism of the convolution
+semiring, it restricts to the derivations, and scalars of the coefficient algebra pass
+through the conjugation because `B` is commutative. -/
 noncomputable def adRepresentation :
-    Representation R (WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    Representation B (WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
       (Derivation R A (Bialgebra.CounitAlgebra R A B)) where
   toFun g :=
     { toFun := adDerivation B g
@@ -175,7 +176,7 @@ noncomputable def adRepresentation :
         rw [adDerivation_apply, adDerivation_apply, adDerivation_apply,
           Derivation.coe_add_linearMap, toConv_add, mul_add, add_mul,
           ofConv_add, LinearMap.add_apply]
-      map_smul' := fun r d => Derivation.ext fun a => by
+      map_smul' := fun b d => Derivation.ext fun a => by
         simp only [Derivation.smul_apply, RingHom.id_apply]
         rw [adDerivation_apply, adDerivation_apply, Derivation.coe_smul_linearMap,
           toConv_smul, mul_smul_comm, smul_mul_assoc, ofConv_smul,

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -101,6 +101,123 @@ private lemma conj_comp_mul'
   rw [mul_add, add_mul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul,
     mulTensor_convMul, mul_one, toConv_toLinearMap_mul_inv]
 
+omit [CommRing A] [HopfAlgebra R A] in
+/-- The base algebra maps of the coefficient synonym and of `B` agree. -/
+private lemma algebraMap_counitAlgebra (r : R) :
+    algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
+
+/-- The Leibniz rule for a conjugated derivation, in scalar-action form. -/
+private lemma conj_ofConv_mul
+    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a b : A) :
+    (toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv (a * b) =
+      a • (toConv g.ofConv.toLinearMap *
+          toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((g⁻¹).ofConv.toLinearMap)).ofConv b +
+        b • (toConv g.ofConv.toLinearMap *
+          toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := by
+  have h := congrArg (fun F => F.ofConv (a ⊗ₜ[R] b)) (conj_comp_mul' g d)
+  simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mul'_apply,
+    ofConv_add, LinearMap.add_apply, mulTensor_ofConv_tmul,
+    LinearMap.convOne_apply, algebraMap_counitAlgebra] at h
+  rw [h, ← Bialgebra.CounitAlgebra.algebraMap_apply R A B a,
+    ← Bialgebra.CounitAlgebra.algebraMap_apply R A B b, ← Algebra.commutes,
+    ← Algebra.smul_def, ← Algebra.smul_def]
+
+variable (B) in
+/-- The conjugate of a tangent vector by a point: the adjoint action
+`Ad g d = g ⋆ d ⋆ g⁻¹`, the differential of conjugation on the group of points. -/
+noncomputable def adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    Derivation R A (Bialgebra.CounitAlgebra R A B) :=
+  Derivation.mk'
+    ((toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv)
+    fun a b => conj_ofConv_mul g d a b
+
+/-- The adjoint action is the convolution conjugate, on underlying linear maps. -/
+theorem coe_adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    ↑(adDerivation B g d) =
+      (toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv :=
+  Derivation.coe_mk'_linearMap _ _
+
+private lemma toConv_coe_adDerivation
+    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    toConv (↑(adDerivation B g d) : A →ₗ[R] Bialgebra.CounitAlgebra R A B) =
+      toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap) := by
+  rw [coe_adDerivation, toConv_ofConv]
+
+variable (B) in
+/-- The adjoint action of the group of points on the tangent space, as a
+representation: conjugation is a ring automorphism of the convolution ring, and it
+restricts to the derivations. -/
+noncomputable def adRepresentation :
+    Representation R (WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+      (Derivation R A (Bialgebra.CounitAlgebra R A B)) where
+  toFun g :=
+    { toFun := adDerivation B g
+      map_add' := fun d₁ d₂ => Derivation.ext fun a => by
+        simp only [Derivation.add_apply]
+        have h : ∀ e : Derivation R A (Bialgebra.CounitAlgebra R A B),
+            adDerivation B g e a = (toConv g.ofConv.toLinearMap *
+              toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+              toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := fun e => by
+          have := DFunLike.congr_fun (coe_adDerivation g e) a
+          simpa only [Derivation.coeFn_coe] using this
+        rw [h, h, h, Derivation.coe_add_linearMap, toConv_add, mul_add, add_mul,
+          ofConv_add, LinearMap.add_apply]
+      map_smul' := fun r d => Derivation.ext fun a => by
+        simp only [Derivation.smul_apply, RingHom.id_apply]
+        have h : ∀ e : Derivation R A (Bialgebra.CounitAlgebra R A B),
+            adDerivation B g e a = (toConv g.ofConv.toLinearMap *
+              toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+              toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := fun e => by
+          have := DFunLike.congr_fun (coe_adDerivation g e) a
+          simpa only [Derivation.coeFn_coe] using this
+        rw [h, h, Derivation.coe_smul_linearMap, toConv_smul, mul_smul_comm,
+          smul_mul_assoc, ofConv_smul, LinearMap.smul_apply] }
+  map_one' := by
+    ext d a
+    simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.one_apply]
+    have h := DFunLike.congr_fun (coe_adDerivation (B := B)
+      (1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) d) a
+    simp only [Derivation.coeFn_coe] at h
+    rw [h, show toConv ((1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)).ofConv.toLinearMap) =
+        (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) from
+        AlgHom.toLinearMap_convOne, inv_one,
+      show toConv ((1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)).ofConv.toLinearMap) =
+        (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) from
+        AlgHom.toLinearMap_convOne, one_mul, mul_one]
+    rfl
+  map_mul' g h := by
+    ext d a
+    simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.mul_apply]
+    have hc : ∀ (k : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+        (e : Derivation R A (Bialgebra.CounitAlgebra R A B)),
+        adDerivation B k e a = (toConv k.ofConv.toLinearMap *
+          toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((k⁻¹).ofConv.toLinearMap)).ofConv a := fun k e => by
+      have := DFunLike.congr_fun (coe_adDerivation k e) a
+      simpa only [Derivation.coeFn_coe] using this
+    rw [hc, hc, toConv_coe_adDerivation, mul_inv_rev,
+      show toConv ((g * h).ofConv.toLinearMap) =
+        toConv (g.ofConv.toLinearMap) * toConv (h.ofConv.toLinearMap) from
+        AlgHom.toLinearMap_convMul g h,
+      show toConv ((h⁻¹ * g⁻¹).ofConv.toLinearMap) =
+        toConv ((h⁻¹).ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) from
+        AlgHom.toLinearMap_convMul h⁻¹ g⁻¹]
+    exact DFunLike.congr_fun (congrArg ofConv (by simp [mul_assoc])) a
+
 end Derivation
 
 end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -15,9 +15,11 @@ vectors at the identity — by convolution conjugation: `Ad g d = g ⋆ d ⋆ g�
 convolution semiring of linear maps, the differential of the conjugation
 `c_g x = g ⋆ x ⋆ g⁻¹` of the group of points. Conjugation is a semiring automorphism of
 the whole convolution semiring; this file shows it restricts to the derivations, and
-packages the restriction as a representation of the group of points on the tangent
-space (`adRepresentation`). This is the adjoint action of the corresponding affine
-group scheme on its Lie functor, for commutative `A`.
+packages the restriction, one coefficient algebra `B` at a time, as a representation of
+the `B`-points on the `B`-valued tangent vectors (`adRepresentation`). For commutative
+`A` these are the coefficientwise layers of the adjoint action of the corresponding
+affine group scheme on its Lie functor; their compatibility as `B` varies
+(postcomposition naturality) is later infrastructure, not packaged here.
 
 Closure is composition-level, by the exterior-product calculus of `Lie.Basic`: an
 algebra-map point satisfies `g ∘ mul = g ⊠ g`, a derivation satisfies

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Algebra.AlgebraicGroup.Tangent.Lie.Basic
+public import Mathlib.RepresentationTheory.Basic
+
+/-!
+# The adjoint action on the tangent space
+
+The points of a Hopf algebra act on the counit-valued derivations — the tangent
+vectors at the identity — by convolution conjugation: `Ad g d = g ⋆ d ⋆ g⁻¹` in the
+convolution ring of linear maps, the differential of the conjugation
+`c_g x = g ⋆ x ⋆ g⁻¹` of the group of points. Conjugation is a ring automorphism of
+the whole convolution ring; this file shows it restricts to the derivations, and
+packages the restriction as a representation of the group of points on the tangent
+space (`adRepresentation`). This is the adjoint action of the corresponding affine
+group scheme on its Lie functor, for commutative `A`.
+
+Closure is composition-level, by the exterior-product calculus of `Lie.Basic`: an
+algebra-map point satisfies `g ∘ mul = g ⊠ g`, a derivation satisfies
+`d ∘ mul = e ⊠ d + d ⊠ e` for the convolution unit `e`, and the conjugates collapse
+by `g ⋆ e ⋆ g⁻¹ = e`, leaving the Leibniz form for `g ⋆ d ⋆ g⁻¹`. No antipode
+computation appears; inverses come from the group of points.
+
+## Main declarations
+
+* `TauCeti.Derivation.adDerivation`: the conjugate of a tangent vector by a point.
+* `TauCeti.Derivation.adRepresentation`: the adjoint action, as a representation of
+  the convolution group of points on the tangent space.
+
+The action stays on the Lie functor `B ↦ Derivation R A (CounitAlgebra R A B)`;
+presenting it as `G → GL(Lie G)` on a fixed module needs a finite-projectivity
+hypothesis on the conormal module and is not attempted here.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Derivation
+
+open Coalgebra WithConv TensorProduct
+
+variable {R A B : Type*} [CommRing R] [CommRing A] [HopfAlgebra R A]
+  [CommRing B] [Algebra R B]
+
+/-- An algebra-map point composed with multiplication is its own exterior square:
+the multiplicativity of the point, in convolution form. -/
+lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
+    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
+      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [mulTensor_ofConv_tmul]
+
+/-- The linear images of a point and of its convolution inverse multiply to the
+convolution unit. -/
+lemma toConv_toLinearMap_mul_inv (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) :
+    toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
+      (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) := by
+  have h := congrArg (fun ψ : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B) =>
+    toConv ψ.ofConv.toLinearMap) (mul_inv_cancel g)
+  rwa [AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convOne] at h
+
+private lemma conj_comp_mul'
+    (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    toConv ((toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv ∘ₗ LinearMap.mul' R A) =
+      mulTensor 1 (toConv g.ofConv.toLinearMap *
+          toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((g⁻¹).ofConv.toLinearMap)) +
+        mulTensor (toConv g.ofConv.toLinearMap *
+          toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+          toConv ((g⁻¹).ofConv.toLinearMap)) 1 := by
+  have h := LinearMap.convMul_comp_coalgHom_distrib
+    (toConv g.ofConv.toLinearMap * toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
+    (toConv ((g⁻¹).ofConv.toLinearMap)) (_root_.Bialgebra.mulCoalgHom R A)
+  have h2 := LinearMap.convMul_comp_coalgHom_distrib
+    (toConv g.ofConv.toLinearMap) (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
+    (_root_.Bialgebra.mulCoalgHom R A)
+  rw [show (_root_.Bialgebra.mulCoalgHom R A).toLinearMap = LinearMap.mul' R A from rfl] at h h2
+  rw [h, toConv_ofConv]
+  rw [show (toConv g.ofConv.toLinearMap *
+      toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)).ofConv ∘ₗ
+      LinearMap.mul' R A = ((toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)).ofConv).comp
+        (LinearMap.mul' R A) from rfl, h2, toConv_ofConv]
+  rw [show g.ofConv.toLinearMap ∘ₗ LinearMap.mul' R A =
+      (g.ofConv.toLinearMap).comp (LinearMap.mul' R A) from rfl]
+  rw [show toConv (g.ofConv.toLinearMap.comp (LinearMap.mul' R A)) =
+      mulTensor (toConv g.ofConv.toLinearMap) (toConv g.ofConv.toLinearMap) from
+      toConv_algHom_comp_mul' g.ofConv,
+    toConv_coe_comp_mul' d,
+    show toConv (((g⁻¹).ofConv.toLinearMap).comp (LinearMap.mul' R A)) =
+      mulTensor (toConv (g⁻¹).ofConv.toLinearMap) (toConv (g⁻¹).ofConv.toLinearMap) from
+      toConv_algHom_comp_mul' (g⁻¹).ofConv]
+  rw [mul_add, add_mul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul,
+    mulTensor_convMul, mul_one, toConv_toLinearMap_mul_inv]
+
+end Derivation
+
+end TauCeti

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -50,7 +50,9 @@ namespace Derivation
 
 open Coalgebra WithConv TensorProduct
 
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+section Square
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
   [CommSemiring B] [Algebra R B]
 
 /-- An algebra-map point composed with multiplication is its own exterior square:
@@ -60,6 +62,11 @@ lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
       mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp [map_mul]
+
+end Square
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+  [CommSemiring B] [Algebra R B]
 
 /-- The linear images of a point and of its convolution inverse multiply to the
 convolution unit. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -80,7 +80,7 @@ private lemma conj_comp_mul'
   rw [toConv_algHom_comp_mul' g.ofConv, toConv_coe_comp_mul' d,
     toConv_algHom_comp_mul' (g⁻¹).ofConv]
   rw [mul_add, add_mul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul,
-    mulTensor_convMul, mul_one, toConv_toLinearMap_mul_inv]
+    mulTensor_convMul, mul_one, AlgHom.toConv_toLinearMap_mul_inv]
 
 omit [CommSemiring A] [HopfAlgebra R A] in
 /-- The base algebra maps of the coefficient synonym and of `B` agree. -/

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -31,9 +31,15 @@ computation appears; inverses come from the group of points.
 * `TauCeti.Derivation.adRepresentation`: the adjoint action, as a representation of
   the convolution group of points on the tangent space.
 
-The action stays on the Lie functor `B ↦ Derivation R A (CounitAlgebra R A B)`;
-presenting it as `G → GL(Lie G)` on a fixed module needs a finite-projectivity
-hypothesis on the conormal module and is not attempted here.
+The action stays on the Lie functor `B ↦ Derivation R A (CounitAlgebra R A B)`; at
+each `B` it is a genuine representation. Identifying the functor's value at `B` with
+`B ⊗ Lie(G)(R)` — the classical fixed-module `G → GL(Lie G)` — needs a
+finite-projectivity hypothesis on the conormal module and is not attempted here.
+
+## References
+
+* J. S. Milne, *Algebraic Groups* (2017), §14 (the adjoint representation).
+* J. C. Jantzen, *Representations of Algebraic Groups*, I.7.18.
 -/
 
 public section
@@ -44,8 +50,8 @@ namespace Derivation
 
 open Coalgebra WithConv TensorProduct
 
-variable {R A B : Type*} [CommRing R] [CommRing A] [HopfAlgebra R A]
-  [CommRing B] [Algebra R B]
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+  [CommSemiring B] [Algebra R B]
 
 /-- An algebra-map point composed with multiplication is its own exterior square:
 the multiplicativity of the point, in convolution form. -/
@@ -53,7 +59,7 @@ lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
     toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
       mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [mulTensor_ofConv_tmul]
+  simp [map_mul]
 
 /-- The linear images of a point and of its convolution inverse multiply to the
 convolution unit. -/
@@ -82,26 +88,18 @@ private lemma conj_comp_mul'
   have h2 := LinearMap.convMul_comp_coalgHom_distrib
     (toConv g.ofConv.toLinearMap) (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
     (_root_.Bialgebra.mulCoalgHom R A)
+  -- The `toLinearMap` field of `mulCoalgHom` is definitionally `mul'`; the library
+  -- states this only for the coercion, whose pattern does not match the field
+  -- projection, so the identification is by `rfl`.
   rw [show (_root_.Bialgebra.mulCoalgHom R A).toLinearMap = LinearMap.mul' R A from rfl] at h h2
   rw [h, toConv_ofConv]
-  rw [show (toConv g.ofConv.toLinearMap *
-      toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)).ofConv ∘ₗ
-      LinearMap.mul' R A = ((toConv g.ofConv.toLinearMap *
-        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)).ofConv).comp
-        (LinearMap.mul' R A) from rfl, h2, toConv_ofConv]
-  rw [show g.ofConv.toLinearMap ∘ₗ LinearMap.mul' R A =
-      (g.ofConv.toLinearMap).comp (LinearMap.mul' R A) from rfl]
-  rw [show toConv (g.ofConv.toLinearMap.comp (LinearMap.mul' R A)) =
-      mulTensor (toConv g.ofConv.toLinearMap) (toConv g.ofConv.toLinearMap) from
-      toConv_algHom_comp_mul' g.ofConv,
-    toConv_coe_comp_mul' d,
-    show toConv (((g⁻¹).ofConv.toLinearMap).comp (LinearMap.mul' R A)) =
-      mulTensor (toConv (g⁻¹).ofConv.toLinearMap) (toConv (g⁻¹).ofConv.toLinearMap) from
-      toConv_algHom_comp_mul' (g⁻¹).ofConv]
+  rw [h2, toConv_ofConv]
+  rw [toConv_algHom_comp_mul' g.ofConv, toConv_coe_comp_mul' d,
+    toConv_algHom_comp_mul' (g⁻¹).ofConv]
   rw [mul_add, add_mul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul,
     mulTensor_convMul, mul_one, toConv_toLinearMap_mul_inv]
 
-omit [CommRing A] [HopfAlgebra R A] in
+omit [CommSemiring A] [HopfAlgebra R A] in
 /-- The base algebra maps of the coefficient synonym and of `B` agree. -/
 private lemma algebraMap_counitAlgebra (r : R) :
     algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
@@ -121,7 +119,7 @@ private lemma conj_ofConv_mul
           toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := by
   have h := congrArg (fun F => F.ofConv (a ⊗ₜ[R] b)) (conj_comp_mul' g d)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mul'_apply,
-    ofConv_add, LinearMap.add_apply, mulTensor_ofConv_tmul,
+    ofConv_add, LinearMap.add_apply, mulTensor_apply_tmul,
     LinearMap.convOne_apply, algebraMap_counitAlgebra] at h
   rw [h, ← Bialgebra.CounitAlgebra.algebraMap_apply R A B a,
     ← Bialgebra.CounitAlgebra.algebraMap_apply R A B b, ← Algebra.commutes,
@@ -132,21 +130,42 @@ variable (B) in
 `Ad g d = g ⋆ d ⋆ g⁻¹`, the differential of conjugation on the group of points. -/
 noncomputable def adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    Derivation R A (Bialgebra.CounitAlgebra R A B) :=
-  Derivation.mk'
-    ((toConv g.ofConv.toLinearMap *
+    Derivation R A (Bialgebra.CounitAlgebra R A B) where
+  toLinearMap :=
+    (toConv g.ofConv.toLinearMap *
         toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
-        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv)
-    fun a b => conj_ofConv_mul g d a b
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv
+  map_one_eq_zero' := by
+    -- The middle factor kills `1`: `d 1 = 0`, and both convolution products
+    -- evaluate at `1` factorwise since `comul 1 = 1 ⊗ 1`.
+    simp [Algebra.TensorProduct.one_def, Derivation.coeFn_coe]
+  leibniz' a b := conj_ofConv_mul g d a b
 
 /-- The adjoint action is the convolution conjugate, on underlying linear maps. -/
+@[simp]
 theorem coe_adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     ↑(adDerivation B g d) =
       (toConv g.ofConv.toLinearMap *
         toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
-        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv :=
-  Derivation.coe_mk'_linearMap _ _
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv := by
+  -- `adDerivation` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change (toConv g.ofConv.toLinearMap *
+      toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+      toConv ((g⁻¹).ofConv.toLinearMap)).ofConv = _
+  rfl
+
+/-- The adjoint action, valuewise: the conjugate evaluated at a point of the
+bialgebra. -/
+theorem adDerivation_apply (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
+    adDerivation B g d a =
+      (toConv g.ofConv.toLinearMap *
+        toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := by
+  have h := DFunLike.congr_fun (coe_adDerivation g d) a
+  simpa only [Derivation.coeFn_coe] using h
 
 private lemma toConv_coe_adDerivation
     (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
@@ -168,55 +187,35 @@ noncomputable def adRepresentation :
     { toFun := adDerivation B g
       map_add' := fun d₁ d₂ => Derivation.ext fun a => by
         simp only [Derivation.add_apply]
-        have h : ∀ e : Derivation R A (Bialgebra.CounitAlgebra R A B),
-            adDerivation B g e a = (toConv g.ofConv.toLinearMap *
-              toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
-              toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := fun e => by
-          have := DFunLike.congr_fun (coe_adDerivation g e) a
-          simpa only [Derivation.coeFn_coe] using this
-        rw [h, h, h, Derivation.coe_add_linearMap, toConv_add, mul_add, add_mul,
+        rw [adDerivation_apply, adDerivation_apply, adDerivation_apply,
+          Derivation.coe_add_linearMap, toConv_add, mul_add, add_mul,
           ofConv_add, LinearMap.add_apply]
       map_smul' := fun r d => Derivation.ext fun a => by
         simp only [Derivation.smul_apply, RingHom.id_apply]
-        have h : ∀ e : Derivation R A (Bialgebra.CounitAlgebra R A B),
-            adDerivation B g e a = (toConv g.ofConv.toLinearMap *
-              toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
-              toConv ((g⁻¹).ofConv.toLinearMap)).ofConv a := fun e => by
-          have := DFunLike.congr_fun (coe_adDerivation g e) a
-          simpa only [Derivation.coeFn_coe] using this
-        rw [h, h, Derivation.coe_smul_linearMap, toConv_smul, mul_smul_comm,
-          smul_mul_assoc, ofConv_smul, LinearMap.smul_apply] }
+        rw [adDerivation_apply, adDerivation_apply, Derivation.coe_smul_linearMap,
+          toConv_smul, mul_smul_comm, smul_mul_assoc, ofConv_smul,
+          LinearMap.smul_apply] }
   map_one' := by
     ext d a
     simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.one_apply]
-    have h := DFunLike.congr_fun (coe_adDerivation (B := B)
-      (1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) d) a
-    simp only [Derivation.coeFn_coe] at h
-    rw [h, show toConv ((1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)).ofConv.toLinearMap) =
-        (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) from
-        AlgHom.toLinearMap_convOne, inv_one,
-      show toConv ((1 : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)).ofConv.toLinearMap) =
-        (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) from
-        AlgHom.toLinearMap_convOne, one_mul, mul_one]
+    rw [adDerivation_apply, AlgHom.toLinearMap_convOne, inv_one,
+      AlgHom.toLinearMap_convOne, one_mul, mul_one]
     rfl
   map_mul' g h := by
     ext d a
     simp only [LinearMap.coe_mk, AddHom.coe_mk, Module.End.mul_apply]
-    have hc : ∀ (k : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
-        (e : Derivation R A (Bialgebra.CounitAlgebra R A B)),
-        adDerivation B k e a = (toConv k.ofConv.toLinearMap *
-          toConv (↑e : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
-          toConv ((k⁻¹).ofConv.toLinearMap)).ofConv a := fun k e => by
-      have := DFunLike.congr_fun (coe_adDerivation k e) a
-      simpa only [Derivation.coeFn_coe] using this
-    rw [hc, hc, toConv_coe_adDerivation, mul_inv_rev,
-      show toConv ((g * h).ofConv.toLinearMap) =
-        toConv (g.ofConv.toLinearMap) * toConv (h.ofConv.toLinearMap) from
-        AlgHom.toLinearMap_convMul g h,
-      show toConv ((h⁻¹ * g⁻¹).ofConv.toLinearMap) =
-        toConv ((h⁻¹).ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) from
-        AlgHom.toLinearMap_convMul h⁻¹ g⁻¹]
+    rw [adDerivation_apply, adDerivation_apply, toConv_coe_adDerivation, mul_inv_rev,
+      AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convMul]
     exact DFunLike.congr_fun (congrArg ofConv (by simp [mul_assoc])) a
+
+@[simp]
+lemma adRepresentation_apply (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
+    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
+    adRepresentation B g d = adDerivation B g d := by
+  -- `adRepresentation` has no equation lemma to rewrite with; `change` spells out its
+  -- definitional unfolding once, explicitly.
+  change adDerivation B g d = _
+  rfl
 
 end Derivation
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -12,9 +12,9 @@ public import Mathlib.RepresentationTheory.Basic
 
 The points of a Hopf algebra act on the counit-valued derivations — the tangent
 vectors at the identity — by convolution conjugation: `Ad g d = g ⋆ d ⋆ g⁻¹` in the
-convolution ring of linear maps, the differential of the conjugation
-`c_g x = g ⋆ x ⋆ g⁻¹` of the group of points. Conjugation is a ring automorphism of
-the whole convolution ring; this file shows it restricts to the derivations, and
+convolution semiring of linear maps, the differential of the conjugation
+`c_g x = g ⋆ x ⋆ g⁻¹` of the group of points. Conjugation is a semiring automorphism of
+the whole convolution semiring; this file shows it restricts to the derivations, and
 packages the restriction as a representation of the group of points on the tangent
 space (`adRepresentation`). This is the adjoint action of the corresponding affine
 group scheme on its Lie functor, for commutative `A`.
@@ -50,32 +50,8 @@ namespace Derivation
 
 open Coalgebra WithConv TensorProduct
 
-section Square
-
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B]
-
-/-- An algebra-map point composed with multiplication is its own exterior square:
-the multiplicativity of the point, in convolution form. -/
-lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
-    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
-      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [map_mul]
-
-end Square
-
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
   [CommSemiring B] [Algebra R B]
-
-/-- The linear images of a point and of its convolution inverse multiply to the
-convolution unit. -/
-lemma toConv_toLinearMap_mul_inv (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) :
-    toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
-      (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) := by
-  have h := congrArg (fun ψ : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B) =>
-    toConv ψ.ofConv.toLinearMap) (mul_inv_cancel g)
-  rwa [AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convOne] at h
 
 private lemma conj_comp_mul'
     (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
@@ -163,7 +139,7 @@ theorem coe_adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A 
       toConv ((g⁻¹).ofConv.toLinearMap)).ofConv = _
   rfl
 
-/-- The adjoint action, valuewise: the conjugate evaluated at a point of the
+/-- The adjoint action, valuewise: the conjugate evaluated at an element of the
 bialgebra. -/
 theorem adDerivation_apply (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
@@ -185,7 +161,7 @@ private lemma toConv_coe_adDerivation
 
 variable (B) in
 /-- The adjoint action of the group of points on the tangent space, as a
-representation: conjugation is a ring automorphism of the convolution ring, and it
+representation: conjugation is a semiring automorphism of the convolution semiring, and it
 restricts to the derivations. -/
 noncomputable def adRepresentation :
     Representation R (WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Adjoint.lean
@@ -143,6 +143,7 @@ theorem coe_adDerivation (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A 
 
 /-- The adjoint action, valuewise: the conjugate evaluated at an element of the
 bialgebra. -/
+@[simp]
 theorem adDerivation_apply (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B))
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) (a : A) :
     adDerivation B g d a =

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -129,22 +129,6 @@ lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
 
 end ExteriorProduct
 
-section HopfPoints
-
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
-  [CommSemiring B] [Algebra R B]
-
-/-- The linear images of a point and of its convolution inverse multiply to the
-convolution unit. -/
-lemma toConv_toLinearMap_mul_inv (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) :
-    toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
-      (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) := by
-  have h := congrArg (fun ψ : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B) =>
-    toConv ψ.ofConv.toLinearMap) (mul_inv_cancel g)
-  rwa [AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convOne] at h
-
-end HopfPoints
-
 section Bracket
 
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -58,77 +58,6 @@ open Coalgebra WithConv TensorProduct
 
 namespace Derivation
 
-section ExteriorProduct
-
-variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommSemiring B] [Algebra R B]
-
-/-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
-leg and multiply the results in the coefficients. It underlies the Leibniz-rule
-manipulations for counit-valued derivations: composing with the multiplication of the
-bialgebra lands in this product's image. -/
-def mulTensor (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
-    WithConv (A ⊗[R] A →ₗ[R] Bialgebra.CounitAlgebra R A B) :=
-  toConv ((Algebra.TensorProduct.lmul' R
-    (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
-
-omit [CommSemiring A] [Bialgebra R A] in
-/-- The base algebra maps of the coefficient synonym and of `B` agree. -/
-private lemma algebraMap_counitAlgebra (r : R) :
-    algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
-
-/-- The exterior product evaluates a pure tensor legwise and multiplies the results
-in the coefficients. -/
-@[simp]
-lemma mulTensor_apply_tmul
-    (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) (x y : A) :
-    (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
-  simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
-
-/-- The exterior product is multiplicative for convolution: products interleave
-legwise. Push `TensorProduct.map_convMul_map` through the multiplication of the
-commutative coefficient algebra. -/
-lemma mulTensor_convMul
-    (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
-    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
-  have h := LinearMap.algHom_comp_convMul_distrib
-    (Algebra.TensorProduct.lmul' R (S := Bialgebra.CounitAlgebra R A B))
-    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
-  rw [map_convMul_map] at h
-  calc mulTensor s t * mulTensor u v
-      = toConv ((Algebra.TensorProduct.lmul' R
-            (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ
-          map (s * u).ofConv (t * v).ofConv) := by
-        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
-    _ = mulTensor (s * u) (t * v) := rfl
-
-/-- The Leibniz rule in convolution form: composing a counit-valued derivation with
-the multiplication of `A` is the exterior product against the convolution unit, on
-either side. -/
-lemma toConv_coe_comp_mul'
-    (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
-    toConv ((d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ LinearMap.mul' R A) =
-      mulTensor 1 (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) +
-        mulTensor (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) 1 := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp only [ofConv_add, LinearMap.add_apply, LinearMap.coe_comp,
-    Function.comp_apply, LinearMap.mul'_apply, mulTensor_apply_tmul,
-    Derivation.coeFn_coe, LinearMap.convOne_apply, algebraMap_counitAlgebra]
-  rw [← Bialgebra.CounitAlgebra.algebraMap_apply R A B x,
-    ← Bialgebra.CounitAlgebra.algebraMap_apply R A B y, ← Algebra.commutes,
-    ← Algebra.smul_def, ← Algebra.smul_def]
-  exact d.leibniz x y
-
-/-- An algebra-map point composed with multiplication is its own exterior square:
-the multiplicativity of the point, in convolution form. -/
-lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
-    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
-      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
-  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
-  simp [map_mul]
-
-end ExteriorProduct
-
 section Bracket
 
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
@@ -142,13 +71,13 @@ private lemma convMul_comp_mul'
     toConv ((toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
         toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)).ofConv ∘ₗ
           LinearMap.mul' R A) =
-      mulTensor 1 (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+      LinearMap.mulTensor 1 (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
           toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) +
-        mulTensor (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
+        LinearMap.mulTensor (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B) *
           toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) 1 +
-        (mulTensor (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
+        (LinearMap.mulTensor (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
             (toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) +
-          mulTensor (toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
+          LinearMap.mulTensor (toConv (↑d₂ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
             (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))) := by
   have h := LinearMap.convMul_comp_coalgHom_distrib
     (toConv (↑d₁ : A →ₗ[R] Bialgebra.CounitAlgebra R A B))
@@ -160,7 +89,8 @@ private lemma convMul_comp_mul'
   rw [show (_root_.Bialgebra.mulCoalgHom R A).toLinearMap = LinearMap.mul' R A from rfl,
     ofConv_toConv, ofConv_toConv] at h
   rw [h, toConv_ofConv, toConv_coe_comp_mul', toConv_coe_comp_mul', add_mul, mul_add,
-    mul_add, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul, mulTensor_convMul]
+    mul_add, LinearMap.mulTensor_convMul, LinearMap.mulTensor_convMul,
+    LinearMap.mulTensor_convMul, LinearMap.mulTensor_convMul]
   simp only [one_mul, mul_one]
   abel
 
@@ -178,8 +108,8 @@ private lemma convMul_ofConv_mul (d₁ d₂ : Derivation R A (Bialgebra.CounitAl
         (d₁ a * d₂ b + d₂ a * d₁ b) := by
   have h := congrArg (fun F => F.ofConv (a ⊗ₜ[R] b)) (convMul_comp_mul' d₁ d₂)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mul'_apply,
-    ofConv_add, LinearMap.add_apply, mulTensor_apply_tmul, LinearMap.convOne_apply,
-    algebraMap_counitAlgebra, Derivation.coeFn_coe] at h
+    ofConv_add, LinearMap.add_apply, LinearMap.mulTensor_apply_tmul, LinearMap.convOne_apply,
+    Bialgebra.CounitAlgebra.algebraMap_base, Derivation.coeFn_coe] at h
   rw [h, ← Bialgebra.CounitAlgebra.algebraMap_apply R A B a,
     ← Bialgebra.CounitAlgebra.algebraMap_apply R A B b, ← Algebra.commutes,
     ← Algebra.smul_def, ← Algebra.smul_def]

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -58,10 +58,10 @@ open Coalgebra WithConv TensorProduct
 
 namespace Derivation
 
-section Bracket
+section ExteriorProduct
 
 variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
-  [CommRing B] [Algebra R B]
+  [CommSemiring B] [Algebra R B]
 
 /-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
 leg and multiply the results in the coefficients. It underlies the Leibniz-rule
@@ -77,7 +77,10 @@ omit [CommSemiring A] [Bialgebra R A] in
 private lemma algebraMap_counitAlgebra (r : R) :
     algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
 
-lemma mulTensor_ofConv_tmul
+/-- The exterior product evaluates a pure tensor legwise and multiplies the results
+in the coefficients. -/
+@[simp]
+lemma mulTensor_apply_tmul
     (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) (x y : A) :
     (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
   simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
@@ -109,12 +112,19 @@ lemma toConv_coe_comp_mul'
         mulTensor (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) 1 := by
   refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
   simp only [ofConv_add, LinearMap.add_apply, LinearMap.coe_comp,
-    Function.comp_apply, LinearMap.mul'_apply, mulTensor_ofConv_tmul,
+    Function.comp_apply, LinearMap.mul'_apply, mulTensor_apply_tmul,
     Derivation.coeFn_coe, LinearMap.convOne_apply, algebraMap_counitAlgebra]
   rw [← Bialgebra.CounitAlgebra.algebraMap_apply R A B x,
     ← Bialgebra.CounitAlgebra.algebraMap_apply R A B y, ← Algebra.commutes,
     ← Algebra.smul_def, ← Algebra.smul_def]
   exact d.leibniz x y
+
+end ExteriorProduct
+
+section Bracket
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
+  [CommRing B] [Algebra R B]
 
 /-- The convolution square of the Leibniz rule: composing a convolution product of two
 derivations with the multiplication of `A` expands into exterior products, with the
@@ -160,7 +170,7 @@ private lemma convMul_ofConv_mul (d₁ d₂ : Derivation R A (Bialgebra.CounitAl
         (d₁ a * d₂ b + d₂ a * d₁ b) := by
   have h := congrArg (fun F => F.ofConv (a ⊗ₜ[R] b)) (convMul_comp_mul' d₁ d₂)
   simp only [LinearMap.coe_comp, Function.comp_apply, LinearMap.mul'_apply,
-    ofConv_add, LinearMap.add_apply, mulTensor_ofConv_tmul, LinearMap.convOne_apply,
+    ofConv_add, LinearMap.add_apply, mulTensor_apply_tmul, LinearMap.convOne_apply,
     algebraMap_counitAlgebra, Derivation.coeFn_coe] at h
   rw [h, ← Bialgebra.CounitAlgebra.algebraMap_apply R A B a,
     ← Bialgebra.CounitAlgebra.algebraMap_apply R A B b, ← Algebra.commutes,

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -119,7 +119,31 @@ lemma toConv_coe_comp_mul'
     ← Algebra.smul_def, ← Algebra.smul_def]
   exact d.leibniz x y
 
+/-- An algebra-map point composed with multiplication is its own exterior square:
+the multiplicativity of the point, in convolution form. -/
+lemma toConv_algHom_comp_mul' (g : A →ₐ[R] Bialgebra.CounitAlgebra R A B) :
+    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
+      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [map_mul]
+
 end ExteriorProduct
+
+section HopfPoints
+
+variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [HopfAlgebra R A]
+  [CommSemiring B] [Algebra R B]
+
+/-- The linear images of a point and of its convolution inverse multiply to the
+convolution unit. -/
+lemma toConv_toLinearMap_mul_inv (g : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B)) :
+    toConv (g.ofConv.toLinearMap) * toConv ((g⁻¹).ofConv.toLinearMap) =
+      (1 : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) := by
+  have h := congrArg (fun ψ : WithConv (A →ₐ[R] Bialgebra.CounitAlgebra R A B) =>
+    toConv ψ.ofConv.toLinearMap) (mul_inv_cancel g)
+  rwa [AlgHom.toLinearMap_convMul, AlgHom.toLinearMap_convOne] at h
+
+end HopfPoints
 
 section Bracket
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -53,7 +53,7 @@ public section
 
 namespace TauCeti
 
-open Coalgebra WithConv TensorProduct
+open _root_.Coalgebra WithConv TensorProduct
 
 namespace Derivation
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -6,7 +6,6 @@ module
 
 public import TauCeti.Algebra.AlgebraicGroup.Tangent.Basic
 public import Mathlib.Algebra.Lie.OfAssociative
-public import Mathlib.RingTheory.Bialgebra.TensorProduct
 
 /-!
 # The Lie algebra of the tangent space at the identity

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Basic.lean
@@ -64,8 +64,10 @@ variable {R A B : Type*} [CommSemiring R] [CommSemiring A] [Bialgebra R A]
   [CommRing B] [Algebra R B]
 
 /-- The exterior convolution product on `A ⊗[R] A`: apply one factor on each tensor
-leg and multiply the results in the coefficients. -/
-private def mulTensor (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
+leg and multiply the results in the coefficients. It underlies the Leibniz-rule
+manipulations for counit-valued derivations: composing with the multiplication of the
+bialgebra lands in this product's image. -/
+def mulTensor (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     WithConv (A ⊗[R] A →ₗ[R] Bialgebra.CounitAlgebra R A B) :=
   toConv ((Algebra.TensorProduct.lmul' R
     (S := Bialgebra.CounitAlgebra R A B)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
@@ -75,7 +77,7 @@ omit [CommSemiring A] [Bialgebra R A] in
 private lemma algebraMap_counitAlgebra (r : R) :
     algebraMap R (Bialgebra.CounitAlgebra R A B) r = algebraMap R B r := rfl
 
-private lemma mulTensor_ofConv_tmul
+lemma mulTensor_ofConv_tmul
     (s t : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) (x y : A) :
     (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
   simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
@@ -83,7 +85,7 @@ private lemma mulTensor_ofConv_tmul
 /-- The exterior product is multiplicative for convolution: products interleave
 legwise. Push `TensorProduct.map_convMul_map` through the multiplication of the
 commutative coefficient algebra. -/
-private lemma mulTensor_convMul
+lemma mulTensor_convMul
     (s t u v : WithConv (A →ₗ[R] Bialgebra.CounitAlgebra R A B)) :
     mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
   have h := LinearMap.algHom_comp_convMul_distrib
@@ -100,7 +102,7 @@ private lemma mulTensor_convMul
 /-- The Leibniz rule in convolution form: composing a counit-valued derivation with
 the multiplication of `A` is the exterior product against the convolution unit, on
 either side. -/
-private lemma toConv_coe_comp_mul'
+lemma toConv_coe_comp_mul'
     (d : Derivation R A (Bialgebra.CounitAlgebra R A B)) :
     toConv ((d : A →ₗ[R] Bialgebra.CounitAlgebra R A B) ∘ₗ LinearMap.mul' R A) =
       mulTensor 1 (toConv (↑d : A →ₗ[R] Bialgebra.CounitAlgebra R A B)) +

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Lie/Map.lean
@@ -28,7 +28,7 @@ public section
 
 namespace TauCeti
 
-open Coalgebra TensorProduct WithConv
+open _root_.Coalgebra TensorProduct WithConv
 
 section Bracket
 

--- a/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/Tangent/Map.lean
@@ -33,7 +33,7 @@ public section
 
 namespace TauCeti
 
-open Coalgebra WithConv TrivSqZeroExt
+open _root_.Coalgebra WithConv TrivSqZeroExt
 
 section Differential
 

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -14,10 +14,21 @@ Let `C` be an `R`-algebra carrying a comultiplication. This file records that, i
 monoid of linear maps `C →ₗ[R] C ⊗[R] C`, comultiplication is the convolution product of the two
 canonical inclusions `c ↦ c ⊗ₜ 1` and `c ↦ 1 ⊗ₜ c` of `C` into its tensor square.
 
+The file also provides the exterior convolution product `LinearMap.mulTensor`: two
+linear maps out of a module `M`, valued in an algebra, applied legwise on `M ⊗[R] M`
+and multiplied in the codomain. Its normalization rules (zero, addition, scalars) and
+its multiplicativity for the convolution product make it the engine for
+composition-level convolution calculations: composing a map with a multiplication
+lands in the image of `mulTensor`, and convolution products interleave legwise.
+
 ## Main declarations
 
 * `TauCeti.Coalgebra.comul_eq_convMul_includeLeft_includeRight`: comultiplication as the
   convolution product of the two tensor inclusions.
+* `TauCeti.LinearMap.mulTensor`: the exterior convolution product, with its
+  normalization rules and `TauCeti.LinearMap.mulTensor_convMul`.
+* `TauCeti.AlgHom.toConv_toLinearMap_comp_mul'`: an algebra map composed with
+  multiplication is its own exterior square.
 -/
 
 public section

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Coalgebra.Convolution
+public import Mathlib.RingTheory.Bialgebra.TensorProduct
 
 /-!
 # Comultiplication as a convolution product
@@ -57,5 +58,123 @@ theorem comul_eq_convMul_includeLeft_includeRight :
   simp
 
 end Coalgebra
+
+
+section ExteriorProduct
+
+open WithConv TensorProduct
+
+variable {R M S : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
+  [CommSemiring S] [Algebra R S]
+
+namespace LinearMap
+
+
+
+/-- The exterior convolution product on `M ⊗[R] M`: apply one factor on each tensor
+leg and multiply the results in the coefficients. It underlies the Leibniz-rule
+manipulations for counit-valued derivations: composing with the multiplication of the
+bialgebra lands in this product's image. -/
+def mulTensor (s t : WithConv (M →ₗ[R] S)) :
+    WithConv (M ⊗[R] M →ₗ[R] S) :=
+  toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
+
+/-- The exterior product evaluates a pure tensor legwise and multiplies the results
+in the coefficients. -/
+@[simp]
+lemma mulTensor_apply_tmul
+    (s t : WithConv (M →ₗ[R] S)) (x y : M) :
+    (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
+  simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
+
+
+/-- The exterior product vanishes when the left factor is zero. -/
+@[simp]
+lemma mulTensor_zero_left (t : WithConv (M →ₗ[R] S)) :
+    mulTensor 0 t = 0 := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- The exterior product vanishes when the right factor is zero. -/
+@[simp]
+lemma mulTensor_zero_right (s : WithConv (M →ₗ[R] S)) :
+    mulTensor s 0 = 0 := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- The exterior product is additive in the left factor. -/
+@[simp]
+lemma mulTensor_add_left (s₁ s₂ t : WithConv (M →ₗ[R] S)) :
+    mulTensor (s₁ + s₂) t = mulTensor s₁ t + mulTensor s₂ t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [add_mul]
+
+/-- The exterior product is additive in the right factor. -/
+@[simp]
+lemma mulTensor_add_right (s t₁ t₂ : WithConv (M →ₗ[R] S)) :
+    mulTensor s (t₁ + t₂) = mulTensor s t₁ + mulTensor s t₂ := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [mul_add]
+
+/-- Scalars pull out of the left factor of the exterior product. -/
+@[simp]
+lemma mulTensor_smul_left (r : R) (s t : WithConv (M →ₗ[R] S)) :
+    mulTensor (r • s) t = r • mulTensor s t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+/-- Scalars pull out of the right factor of the exterior product. -/
+@[simp]
+lemma mulTensor_smul_right (r : R) (s t : WithConv (M →ₗ[R] S)) :
+    mulTensor s (r • t) = r • mulTensor s t := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp
+
+end LinearMap
+
+namespace AlgHom
+
+variable {A : Type*} [Semiring A] [Algebra R A]
+
+open TauCeti.LinearMap in
+/-- An algebra-map point composed with multiplication is its own exterior square:
+the multiplicativity of the point, in convolution form. -/
+lemma toConv_toLinearMap_comp_mul' (g : A →ₐ[R] S) :
+    toConv (g.toLinearMap ∘ₗ LinearMap.mul' R A) =
+      mulTensor (toConv g.toLinearMap) (toConv g.toLinearMap) := by
+  refine ofConv_injective (TensorProduct.ext' fun x y => ?_)
+  simp [map_mul]
+
+end AlgHom
+
+end ExteriorProduct
+
+section ExteriorConvolution
+
+open WithConv TensorProduct
+
+variable {R A S : Type*} [CommSemiring R] [Semiring A] [Bialgebra R A]
+  [CommSemiring S] [Algebra R S]
+
+namespace LinearMap
+
+/-- The exterior product is multiplicative for convolution: products interleave
+legwise. -/
+lemma mulTensor_convMul
+    (s t u v : WithConv (A →ₗ[R] S)) :
+    mulTensor s t * mulTensor u v = mulTensor (s * u) (t * v) := by
+  have h := LinearMap.algHom_comp_convMul_distrib
+    (Algebra.TensorProduct.lmul' R (S := S))
+    (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
+  rw [map_convMul_map] at h
+  calc mulTensor s t * mulTensor u v
+      = toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ
+          map (s * u).ofConv (t * v).ofConv) := by
+        rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
+    _ = mulTensor (s * u) (t * v) := rfl
+
+end LinearMap
+
+end ExteriorConvolution
 
 end TauCeti

--- a/TauCeti/Algebra/Coalgebra/Convolution.lean
+++ b/TauCeti/Algebra/Coalgebra/Convolution.lean
@@ -65,7 +65,7 @@ section ExteriorProduct
 open WithConv TensorProduct
 
 variable {R M S : Type*} [CommSemiring R] [AddCommMonoid M] [Module R M]
-  [CommSemiring S] [Algebra R S]
+  [Semiring S] [Algebra R S]
 
 namespace LinearMap
 
@@ -77,7 +77,7 @@ manipulations for counit-valued derivations: composing with the multiplication o
 bialgebra lands in this product's image. -/
 def mulTensor (s t : WithConv (M →ₗ[R] S)) :
     WithConv (M ⊗[R] M →ₗ[R] S) :=
-  toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ map s.ofConv t.ofConv)
+  toConv (LinearMap.mul' R S ∘ₗ map s.ofConv t.ofConv)
 
 /-- The exterior product evaluates a pure tensor legwise and multiplies the results
 in the coefficients. -/
@@ -85,7 +85,7 @@ in the coefficients. -/
 lemma mulTensor_apply_tmul
     (s t : WithConv (M →ₗ[R] S)) (x y : M) :
     (mulTensor s t).ofConv (x ⊗ₜ[R] y) = s.ofConv x * t.ofConv y := by
-  simp [mulTensor, Algebra.TensorProduct.lmul'_apply_tmul]
+  simp [mulTensor]
 
 
 /-- The exterior product vanishes when the left factor is zero. -/
@@ -167,9 +167,11 @@ lemma mulTensor_convMul
     (Algebra.TensorProduct.lmul' R (S := S))
     (toConv (map s.ofConv t.ofConv)) (toConv (map u.ofConv v.ofConv))
   rw [map_convMul_map] at h
+  -- The commutative multiplication algebra map and the plain multiplication linear map
+  -- agree; restate `h` in the linear form used by `mulTensor`.
+  rw [Algebra.TensorProduct.lmul'_toLinearMap] at h
   calc mulTensor s t * mulTensor u v
-      = toConv ((Algebra.TensorProduct.lmul' R (S := S)).toLinearMap ∘ₗ
-          map (s * u).ofConv (t * v).ofConv) := by
+      = toConv (LinearMap.mul' R S ∘ₗ map (s * u).ofConv (t * v).ofConv) := by
         rw [mulTensor, mulTensor, ← toConv_ofConv (toConv _ * toConv _), ← h]
     _ = mulTensor (s * u) (t * v) := rfl
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"adjoint-action"}-->

The points of a Hopf algebra act on the tangent space at the identity by convolution conjugation: `Ad g d = g ⋆ d ⋆ g⁻¹`, the differential of the conjugation of the group of points (ReductiveGroups roadmap, Layer 2, "the adjoint action"). Conjugation is a ring automorphism of the whole convolution ring of linear maps; this PR shows it restricts to the counit-valued derivations (`adDerivation`) and packages the restriction as a representation of the convolution group of points on the tangent space (`adRepresentation`).

Closure is composition-level in the exterior-product calculus of `Tangent/Lie/Basic.lean`, whose `mulTensor` API this PR promotes from private to public (the promotion is the API-need arising, per the calculus's original design): an algebra-map point satisfies `g ∘ mul = g ⊠ g`, a derivation satisfies `d ∘ mul = e ⊠ d + d ⊠ e`, and the conjugates collapse by `g ⋆ e ⋆ g⁻¹ = e`, leaving the Leibniz form. No antipode computation appears — inverses come from the group of points, and the group-law transfers to the linear convolution ring through `AlgHom.toLinearMap_convMul`/`convOne`.

Convention (adversarially verified, gpt-5.6-sol): `g ⋆ d ⋆ g⁻¹` is the standard left adjoint action — the dual-number computation `g ⋆ (e + τ d) ⋆ g⁻¹ = e + τ (g ⋆ d ⋆ g⁻¹)` witnesses it as the differential of `c_g x = g x g⁻¹` — matching Milne §14 and Jantzen §7.18. The action stays on the Lie functor `B ↦ Derivation R A (CounitAlgebra R A B)`; presenting it as `G → GL(Lie G)` on a fixed module needs a finite-projectivity hypothesis on the conormal module and is deliberately not claimed. Bracket-preservation (the Lie-automorphism upgrade) is the next PR.

Roadmap: ReductiveGroups