### PR TITLE
feat: construct uniform local invariant flows

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -12,8 +12,8 @@ public import TauCeti.Geometry.Lie.Exponential.Basic
 This file begins the analytic parameter-dependence theory for the invariant integral curves that
 define the Lie-group exponential. In the identity chart, the tangent vector and group coordinate
 form an autonomous ODE on the product model space. Picard--Lindelöf then supplies a single local
-flow, continuous jointly in its initial condition and time, for all sufficiently small tangent
-vectors.
+solution family, continuous jointly in its initial condition and time, for all sufficiently small
+tangent vectors.
 
 ## Main results
 
@@ -21,13 +21,14 @@ vectors.
   generating tangent vector included as a parameter.
 * `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth at the
   zero vector and identity coordinate.
-* `exists_lipschitzOn_local_mulInvariantCoordinateFlow`: a local flow on a uniform closed
-  neighborhood of the zero vector and the identity coordinate, jointly continuous and uniformly
-  Lipschitz in its initial state.
-* `exists_eventually_hasDerivAt_mulInvariantCoordinateFlow`: a neighborhood form of the local flow
-  whose values remain inside the identity chart.
-* `exists_local_coordinate_representation_mulInvariantIntegralCurve`: the local flow represents the
-  canonical invariant integral curves uniformly for all sufficiently small generating vectors.
+* `exists_lipschitzOn_local_mulInvariantCoordinateFlow`: a local solution family on a uniform
+  closed neighborhood of the zero vector and the identity coordinate, jointly continuous and
+  uniformly Lipschitz in its initial state.
+* `exists_eventually_hasDerivAt_mulInvariantCoordinateFlow`: a neighborhood form of the local
+  solution family whose values remain inside the identity chart.
+* `exists_local_coordinate_representation_mulInvariantIntegralCurve`: the local solution family
+  represents the canonical invariant integral curves uniformly for all sufficiently small
+  generating vectors.
 * `continuousAt_mulInvariantExp_modelSpace_zero`: the tangent-space exponential is continuous at
   zero in model-space coordinates.
 
@@ -47,11 +48,10 @@ noncomputable section
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [IsManifold I 1 G] [IsManifold I 2 G]
 
-omit [Group G] [IsManifold I 2 G] in
+omit [Group G] in
 private theorem isMIntegralCurveAt_extChartAt_symm_of_eventually
-    [ContinuousSMul ℝ E]
+    [IsManifold I 1 G] [ContinuousSMul ℝ E]
     {x₀ : G} {f : ℝ → E} {t₀ : ℝ} {v : (x : G) → TangentSpace I x}
     (htarget : ∀ᶠ t in 𝓝 t₀, f t ∈ interior (extChartAt I x₀).target)
     (hderiv : ∀ᶠ t in 𝓝 t₀,
@@ -89,17 +89,31 @@ private theorem isMIntegralCurveAt_extChartAt_symm_of_eventually
   have hd' := hd.congr_deriv (tangentCoordChange_self hft2)
   simp only [writtenInExtChartAt, extChartAt_model_space_eq_id, PartialEquiv.refl_coe,
     PartialEquiv.refl_symm, modelWithCornersSelf_coe, Function.comp_def, id_eq, Set.range_id]
+  -- Restore the named chart preimage before comparing the ordinary and manifold derivatives.
   rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
   rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
-  with_unfolding_all
-    exact hd'.hasFDerivAt.hasFDerivWithinAt
+  -- In these charts, the source and target tangent spaces are definitionally their model spaces.
+  change HasFDerivWithinAt
+    (((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f))
+      (ContinuousLinearMap.toSpanSingleton ℝ (v xₜ)) Set.univ t
+  exact hd'.hasFDerivAt.hasFDerivWithinAt
 
 /-- The left-invariant vector field, expressed in the identity chart and parameterized by its
 generating tangent vector in the model space. -/
-noncomputable def mulInvariantCoordinateVectorField (p : E × E) : E :=
+noncomputable def mulInvariantCoordinateVectorField [IsManifold I 1 G] (p : E × E) : E :=
   let g := (extChartAt I (1 : G)).symm p.2
   tangentCoordChange I g (1 : G) g
     (mulInvariantVectorField (I := I) (G := G) p.1 g)
+
+/-- The parameterized coordinate field is the invariant vector field transported through the
+identity chart. -/
+theorem mulInvariantCoordinateVectorField_apply [IsManifold I 1 G] (v y : E) :
+    mulInvariantCoordinateVectorField (I := I) (G := G) (v, y) =
+      tangentCoordChange I ((extChartAt I (1 : G)).symm y) (1 : G)
+        ((extChartAt I (1 : G)).symm y)
+        (show E from mulInvariantVectorField (I := I) (G := G)
+          (v : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm y)) := by
+  rfl
 
 /-- The coordinate expression of the parameterized left-invariant vector field is smooth at the
 zero tangent vector and identity coordinate. -/
@@ -120,24 +134,29 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
   let w : E × E → E := fun x =>
     ((extChartAt I.tangent (V (0, 1)) ∘ V ∘
       (extChartAt (𝓘(ℝ, E).prod I) (0, 1)).symm) x).2
-  have hw : w = mulInvariantCoordinateVectorField (I := I) (G := G) := by
-    funext p
+  have hw_apply (p : E × E) :
+      w p = tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
+        ((extChartAt I (1 : G)).symm p.2)
+        (show E from mulInvariantVectorField (I := I) (G := G)
+          (p.1 : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm p.2)) := by
+    -- This is the second coordinate of the tangent-bundle extended chart at `(0, 1)`.
     change tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
       ((extChartAt I (1 : G)).symm p.2)
-        (mulInvariantVectorField
-          p.1
-          ((extChartAt I (1 : G)).symm p.2)) =
-      mulInvariantCoordinateVectorField (I := I) (G := G) p
+        (show E from mulInvariantVectorField (I := I) (G := G)
+          (p.1 : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm p.2)) = _
     rfl
+  have hw : w = mulInvariantCoordinateVectorField (I := I) (G := G) := by
+    funext p
+    rw [mulInvariantCoordinateVectorField_apply]
+    exact hw_apply p
   rw [← hw]
   simpa only [w, extChartAt_prod, extChartAt_self_apply, modelWithCornersSelf_coe,
     PartialEquiv.prod_coe, PartialEquiv.refl_coe, id_eq] using h.snd
 
-omit [IsManifold I 2 G] in
 /-- Near the zero tangent vector and the identity coordinate, the parameterized invariant ODE has
-a single flow that is continuous jointly in its initial condition and time and uniformly Lipschitz
-in its initial state. The tangent-vector coordinate is frozen by the ODE; the second coordinate
-follows the invariant vector field. -/
+a single solution family that is continuous jointly in its initial condition and time and
+uniformly Lipschitz in its initial state. The tangent-vector coordinate is frozen by the ODE; the
+second coordinate follows the invariant vector field. -/
 theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
     [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r L : NNReal), 0 < δ ∧ 0 < r ∧
@@ -197,6 +216,7 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
     have hβ : ∀ t ∈ Set.Icc (-δ) δ,
         HasDerivWithinAt β 0 (Set.Icc (-δ) δ) t := by
       intro t ht
+      -- `β` is definitionally the first continuous-linear projection of the solution family.
       change HasDerivWithinAt
         ((ContinuousLinearMap.fst ℝ E E) ∘ fun s => α' (x, s)) 0
           (Set.Icc (-δ) δ) t
@@ -209,14 +229,14 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
           (Set.Ico_subset_Icc_self ht)))
     intro t ht
     have hzero : (0 : ℝ) ∈ Set.Icc (-δ) δ := by constructor <;> linarith
+    -- Unfold the named first-coordinate path before applying its constancy theorem.
     change β t = x.1
     exact (hconst t ht).trans ((hconst 0 hzero).symm.trans
       (congrArg Prod.fst (hα' x hx').1))
 
-omit [IsManifold I 2 G] in
-/-- There is a coordinate flow near the zero tangent vector and time zero which is continuous at
-the center, solves the parameterized invariant ODE with an ordinary derivative, freezes the
-tangent-vector parameter, and remains in the target of the identity chart. -/
+/-- There is a coordinate solution family near the zero tangent vector and time zero which is
+continuous at the center, solves the parameterized invariant ODE with an ordinary derivative,
+freezes the tangent-vector parameter, and remains in the target of the identity chart. -/
 theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
     [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ∃ α : (E × E) × ℝ → E × E,
@@ -276,11 +296,10 @@ local instance lieGroupMinSmoothnessParameterDependence [LieGroup I ∞ G] :
     LieGroup I (minSmoothness ℝ 3) G := by
   simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
 
-omit [IsManifold I 2 G] in
-/-- A single coordinate flow represents the canonical invariant integral curves for every
-sufficiently small generating vector and every sufficiently small time. This is the bridge from
-Picard--Lindelöf's parameterized model-space flow to the canonical manifold-valued curves used to
-define `lieExp`. -/
+/-- A single coordinate solution family represents the canonical invariant integral curves for
+every sufficiently small generating vector and every sufficiently small time. This is the bridge
+from Picard--Lindelöf's parameterized model-space solutions to the canonical manifold-valued curves
+used to define `lieExp`. -/
 theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
     [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ∃ (α : (E × E) × ℝ → E × E) (U : Set E) (δ : ℝ),
@@ -347,6 +366,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
       have hsnd : HasDerivAt f
           (mulInvariantCoordinateVectorField (I := I) (G := G)
             (α (((v, extChartAt I (1 : G) (1 : G)), s)))) s := by
+        -- `f` is definitionally the second continuous-linear projection of the solution family.
         change HasDerivAt
           ((ContinuousLinearMap.snd ℝ E E) ∘ fun u =>
             α (((v, extChartAt I (1 : G) (1 : G)), u))) _ s
@@ -357,13 +377,14 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
         · exact (hlocal s hs).2.2.1
         · rfl
       rw [hpair] at hsnd
-      simpa only [mulInvariantCoordinateVectorField, f] using hsnd
+      simpa only [mulInvariantCoordinateVectorField_apply, f] using hsnd
   have hγOn : IsMIntegralCurveOn γ
       (mulInvariantVectorField (I := I) (G := G) (v : GroupLieAlgebra I G))
       (Set.Ioo (-δ) δ) := IsMIntegralCurveAt.isMIntegralCurveOn hγAt
   have hzero : (0 : ℝ) ∈ Set.Ioo (-δ) δ := ⟨by linarith, by linarith⟩
   have hγzero : γ 0 = 1 := by
     have hinit := (hlocal 0 hzero).2.1
+    -- Expand the named chart-valued path so the initial-value equality rewrites its coordinate.
     change (extChartAt I (1 : G)).symm
       (α (((v, extChartAt I (1 : G) (1 : G)), 0))).2 = 1
     rw [congrArg Prod.snd hinit]
@@ -382,10 +403,8 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
           (mulInvariantIntegralCurve_zero (I := I) (G := G)
             (v : GroupLieAlgebra I G) 1).symm)
 
-omit [IsManifold I 2 G] in
-/-- In model-space coordinates, the tangent-space exponential is continuous at the zero vector.
-The local parameterized flow only covers a short time interval; the scaling law for invariant
-integral curves transports that interval to time one. -/
+/-- The tangent-space exponential is continuous at zero when its domain uses the canonical
+model-space identification and its codomain remains the Lie group `G`. -/
 theorem continuousAt_mulInvariantExp_modelSpace_zero
     [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ContinuousAt

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -131,6 +131,8 @@ theorem contDiffAt_mulInvariantCoordinateVectorField {n : ℕ∞ω}
   have hV₀ := hV.contMDiffAt (x := ((0 : E), (1 : G)))
   rw [contMDiffAt_iff] at hV₀
   have h01 : (𝓘(ℝ, E).prod I).IsInteriorPoint ((0 : E), (1 : G)) := by
+    -- `ModelWithCorners.interior_prod` is stated for membership in `interior`; unfold
+    -- `IsInteriorPoint` to expose precisely that representation.
     change ((0 : E), (1 : G)) ∈ (𝓘(ℝ, E).prod I).interior (E × G)
     rw [ModelWithCorners.interior_prod]
     exact ⟨BoundarylessManifold.isInteriorPoint, h1⟩

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -99,8 +99,7 @@ generating tangent vector in the model space. -/
 noncomputable def mulInvariantCoordinateVectorField (p : E × E) : E :=
   let g := (extChartAt I (1 : G)).symm p.2
   tangentCoordChange I g (1 : G) g
-    (mulInvariantVectorField
-      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) g)
+    (mulInvariantVectorField (I := I) (G := G) p.1 g)
 
 /-- The coordinate expression of the parameterized left-invariant vector field is smooth at the
 zero tangent vector and identity coordinate. -/
@@ -111,8 +110,7 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
   let _ : ContMDiffMul I (∞ + 1) G := by
     simpa using (inferInstance : ContMDiffMul I ∞ G)
   let V : E × G → TangentBundle I G := fun p =>
-    ⟨p.2, mulInvariantVectorField
-      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2⟩
+    ⟨p.2, mulInvariantVectorField (I := I) (G := G) p.1 p.2⟩
   have hV : ContMDiff (𝓘(ℝ, E).prod I) I.tangent ∞ V :=
     contMDiff_mulInvariantVectorField_modelSpace (n := ∞)
   have hV₀ := hV.contMDiffAt (x := ((0 : E), (1 : G)))
@@ -127,7 +125,7 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
     change tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
       ((extChartAt I (1 : G)).symm p.2)
         (mulInvariantVectorField
-          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1)
+          p.1
           ((extChartAt I (1 : G)).symm p.2)) =
       mulInvariantCoordinateVectorField (I := I) (G := G) p
     rfl
@@ -296,8 +294,8 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
         Set.EqOn
           (fun t => (extChartAt I (1 : G)).symm
             (α (((v, extChartAt I (1 : G) (1 : G)), t))).2)
-          (mulInvariantIntegralCurve
-            ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1)
+          (mulInvariantIntegralCurve (I := I) (G := G)
+            (v : GroupLieAlgebra I G) 1)
           (Set.Ioo (-δ) δ) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   obtain ⟨α, hαcont, _, hαcontNear, hα⟩ :=
@@ -340,8 +338,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
     simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using (hsub hmem).2
   have hγAt : ∀ t ∈ Set.Ioo (-δ) δ,
       IsMIntegralCurveAt γ
-        (mulInvariantVectorField
-          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)) t := by
+        (mulInvariantVectorField (I := I) (G := G) (v : GroupLieAlgebra I G)) t := by
     intro t ht
     apply isMIntegralCurveAt_extChartAt_symm_of_eventually
     · filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
@@ -362,8 +359,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
       rw [hpair] at hsnd
       simpa only [mulInvariantCoordinateVectorField, f] using hsnd
   have hγOn : IsMIntegralCurveOn γ
-      (mulInvariantVectorField
-        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v))
+      (mulInvariantVectorField (I := I) (G := G) (v : GroupLieAlgebra I G))
       (Set.Ioo (-δ) δ) := IsMIntegralCurveAt.isMIntegralCurveOn hγAt
   have hzero : (0 : ℝ) ∈ Set.Ioo (-δ) δ := ⟨by linarith, by linarith⟩
   have hγzero : γ 0 = 1 := by
@@ -373,12 +369,18 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
     rw [congrArg Prod.snd hinit]
     exact (extChartAt I (1 : G)).left_inv (mem_extChartAt_source (I := I) (1 : G))
   exact isMIntegralCurveOn_Ioo_eqOn_of_contMDiff_boundaryless hzero
-    ((contMDiff_mulInvariantVectorField
-      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)).of_le (by simp))
+    ((contMDiff_mulInvariantVectorField (I := I) (G := G)
+      (v : GroupLieAlgebra I G)).of_le (by simp))
     hγOn
-    ((isMIntegralCurve_mulInvariantIntegralCurve
-      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1).isMIntegralCurveOn _)
-    (by simpa only [γ, f, Function.comp_apply, mulInvariantIntegralCurve_zero] using hγzero)
+    ((isMIntegralCurve_mulInvariantIntegralCurve (I := I) (G := G)
+      (v : GroupLieAlgebra I G) 1).isMIntegralCurveOn _)
+    (by
+      calc
+        γ 0 = 1 := hγzero
+        _ = mulInvariantIntegralCurve (I := I) (G := G)
+            (v : GroupLieAlgebra I G) 1 0 :=
+          (mulInvariantIntegralCurve_zero (I := I) (G := G)
+            (v : GroupLieAlgebra I G) 1).symm)
 
 omit [IsManifold I 2 G] in
 /-- In model-space coordinates, the tangent-space exponential is continuous at the zero vector.
@@ -387,8 +389,7 @@ integral curves transports that interval to time one. -/
 theorem continuousAt_mulInvariantExp_modelSpace_zero
     [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ContinuousAt
-      (fun v : E => mulInvariantExp
-        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)) 0 := by
+      (fun v : E => mulInvariantExp (I := I) (G := G) v) 0 := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   obtain ⟨α, U, δ, hU, hδ, _, hαlocal, hαeq⟩ :=
     exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
@@ -426,14 +427,13 @@ theorem continuousAt_mulInvariantExp_modelSpace_zero
   symm
   calc
     (extChartAt I (1 : G)).symm (α (q v)).2 =
-        mulInvariantIntegralCurve
-          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm (c⁻¹ • v)) 1 c := by
+        mulInvariantIntegralCurve (I := I) (G := G) (c⁻¹ • v) 1 c := by
       exact hαeq (c⁻¹ • v) hv hc
     _ = mulInvariantExp
-        (c • (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm (c⁻¹ • v)) := by
+        (c • (c⁻¹ • v)) := by
       exact (mulInvariantExp_smul _ c).symm
     _ = mulInvariantExp
-        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) := by
+        v := by
       congr 1
-      rw [← map_smul]
       simp only [smul_smul, mul_inv_cancel₀ hc0, one_smul]
+      rfl

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -19,8 +19,8 @@ vectors.
 
 * `mulInvariantCoordinateVectorField`: the invariant vector field in the identity chart, with its
   generating tangent vector included as a parameter.
-* `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth near the
-  zero vector and the identity.
+* `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth at the
+  zero vector and identity coordinate.
 * `exists_lipschitzOn_local_mulInvariantCoordinateFlow`: a local flow on a uniform closed
   neighborhood of the zero vector and the identity coordinate, jointly continuous and uniformly
   Lipschitz in its initial state.
@@ -102,8 +102,8 @@ noncomputable def mulInvariantCoordinateVectorField (p : E × E) : E :=
     (mulInvariantVectorField
       ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) g)
 
-/-- The coordinate expression of the parameterized left-invariant vector field is smooth near the
-zero tangent vector and the identity. -/
+/-- The coordinate expression of the parameterized left-invariant vector field is smooth at the
+zero tangent vector and identity coordinate. -/
 theorem contDiffAt_mulInvariantCoordinateVectorField
     [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ContDiffAt ℝ ∞ (mulInvariantCoordinateVectorField (I := I) (G := G))
@@ -164,7 +164,7 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
   have hF : ContDiffAt ℝ 1 F center := by
     exact contDiffAt_const.prodMk
       (contDiffAt_mulInvariantCoordinateVectorField.of_le (by norm_num))
-  obtain ⟨δ, hδ, a, r, L, K, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
+  obtain ⟨δ, hδ, _, r, _, _, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
   obtain ⟨α, hα, L', hαlip⟩ :=
     (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_lipschitzOnWith
   let α' : (E × E) × ℝ → E × E := fun xt => α xt.1 xt.2
@@ -300,7 +300,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
             ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1)
           (Set.Ioo (-δ) δ) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  obtain ⟨α, hαcont, hαcenter, hαcontNear, hα⟩ :=
+  obtain ⟨α, hαcont, _, hαcontNear, hα⟩ :=
     exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
   let embed : E × ℝ → (E × E) × ℝ := fun vt =>
     ((vt.1, extChartAt I (1 : G) (1 : G)), vt.2)
@@ -390,7 +390,7 @@ theorem continuousAt_mulInvariantExp_modelSpace_zero
       (fun v : E => mulInvariantExp
         ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)) 0 := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  obtain ⟨α, U, δ, hU, hδ, hαcenter, hαlocal, hαeq⟩ :=
+  obtain ⟨α, U, δ, hU, hδ, _, hαlocal, hαeq⟩ :=
     exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
   let c : ℝ := δ / 2
   have hc : c ∈ Set.Ioo (-δ) δ := by

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -118,7 +118,7 @@ theorem mulInvariantCoordinateVectorField_apply [IsManifold I 1 G] (v y : E) :
 /-- The coordinate expression of the parameterized left-invariant vector field is `C^n` at the
 zero tangent vector and identity coordinate when multiplication is `C^(n + 1)`. -/
 theorem contDiffAt_mulInvariantCoordinateVectorField {n : ℕ∞ω}
-    [ContMDiffMul I (n + 1) G] [BoundarylessManifold I G] :
+    [ContMDiffMul I (n + 1) G] (h1 : I.IsInteriorPoint (1 : G)) :
     let _ : IsManifold I 1 G := IsManifold.of_le (n := n + 1) le_add_self
     ContDiffAt ℝ n (mulInvariantCoordinateVectorField (I := I) (G := G))
       (0, extChartAt I (1 : G) (1 : G)) := by
@@ -130,8 +130,12 @@ theorem contDiffAt_mulInvariantCoordinateVectorField {n : ℕ∞ω}
     contMDiff_mulInvariantVectorField_modelSpace (n := n)
   have hV₀ := hV.contMDiffAt (x := ((0 : E), (1 : G)))
   rw [contMDiffAt_iff] at hV₀
+  have h01 : (𝓘(ℝ, E).prod I).IsInteriorPoint ((0 : E), (1 : G)) := by
+    change ((0 : E), (1 : G)) ∈ (𝓘(ℝ, E).prod I).interior (E × G)
+    rw [ModelWithCorners.interior_prod]
+    exact ⟨BoundarylessManifold.isInteriorPoint, h1⟩
   have h := hV₀.2.contDiffAt
-    (range_mem_nhds_isInteriorPoint BoundarylessManifold.isInteriorPoint)
+    (range_mem_nhds_isInteriorPoint h01)
   let w : E × E → E := fun x =>
     ((extChartAt I.tangent (V (0, 1)) ∘ V ∘
       (extChartAt (𝓘(ℝ, E).prod I) (0, 1)).symm) x).2
@@ -159,7 +163,7 @@ a single solution family that is continuous jointly in its initial condition and
 uniformly Lipschitz in its initial state. The tangent-vector coordinate is frozen by the ODE; the
 second coordinate follows the invariant vector field. -/
 theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
-    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] (h1 : I.IsInteriorPoint (1 : G)) :
     let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
     ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r L : NNReal), 0 < δ ∧ 0 < r ∧
       ContinuousOn α
@@ -183,7 +187,7 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
     (0, mulInvariantCoordinateVectorField (I := I) (G := G) p)
   have hF : ContDiffAt ℝ 1 F center := by
     exact contDiffAt_const.prodMk
-      (contDiffAt_mulInvariantCoordinateVectorField (n := 1))
+      (contDiffAt_mulInvariantCoordinateVectorField (n := 1) h1)
   obtain ⟨δ, hδ, _, r, _, _, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
   obtain ⟨α, hα, L', hαlip⟩ :=
     (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_lipschitzOnWith
@@ -241,7 +245,7 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
 continuous at the center, solves the parameterized invariant ODE with an ordinary derivative,
 freezes the tangent-vector parameter, and remains in the target of the identity chart. -/
 theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
-    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] (h1 : I.IsInteriorPoint (1 : G)) :
     let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
     ∃ α : (E × E) × ℝ → E × E,
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
@@ -260,7 +264,7 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
   dsimp only
   obtain ⟨α, δ, r, _, hδ, hr, hcont, _, hα⟩ :=
     exists_lipschitzOn_local_mulInvariantCoordinateFlow
-      (I := I) (G := G)
+      (I := I) (G := G) h1
   let center : E × E := (0, extChartAt I (1 : G) (1 : G))
   have hdomain :
       Metric.closedBall center r ×ˢ Set.Icc (-δ) δ ∈ 𝓝 (center, 0) := by
@@ -275,7 +279,7 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
   have hcenter : α (center, 0) = center := by
     exact (hα center (Metric.mem_closedBall_self hr.le)).1
   have htargetCenter : center.2 ∈ interior (extChartAt I (1 : G)).target := by
-    exact (I.isInteriorPoint_iff.mp BoundarylessManifold.isInteriorPoint)
+    exact I.isInteriorPoint_iff.mp h1
   have htarget :
       α ⁻¹' (Set.univ ×ˢ interior (extChartAt I (1 : G)).target) ∈ 𝓝 (center, 0) := by
     apply hcontAt.preimage_mem_nhds
@@ -324,6 +328,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
   let _ : IsManifold I 1 G := IsManifold.of_le (n := minSmoothness ℝ 3) (by norm_num)
   obtain ⟨α, hαcont, _, hαcontNear, hα⟩ :=
     exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
+      BoundarylessManifold.isInteriorPoint
   let embed : E × ℝ → (E × E) × ℝ := fun vt =>
     ((vt.1, extChartAt I (1 : G) (1 : G)), vt.2)
   have hembed : ContinuousAt embed ((0 : E), 0) := by fun_prop

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -25,6 +25,8 @@ vectors.
   closed neighborhood of the zero vector and the identity coordinate.
 * `exists_eventually_hasDerivAt_mulInvariantCoordinateFlow`: a neighborhood form of the local flow
   whose values remain inside the identity chart.
+* `exists_local_coordinate_representation_mulInvariantIntegralCurve`: the local flow represents the
+  canonical invariant integral curves uniformly for all sufficiently small generating vectors.
 
 ## References
 
@@ -43,6 +45,51 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [IsManifold I 1 G] [IsManifold I 2 G]
+
+omit [Group G] [IsManifold I 2 G] in
+private theorem isMIntegralCurveAt_extChartAt_symm_of_eventually
+    [ContinuousSMul ℝ E]
+    {x₀ : G} {f : ℝ → E} {t₀ : ℝ} {v : (x : G) → TangentSpace I x}
+    (htarget : ∀ᶠ t in 𝓝 t₀, f t ∈ interior (extChartAt I x₀).target)
+    (hderiv : ∀ᶠ t in 𝓝 t₀,
+      HasDerivAt f
+        (tangentCoordChange I ((extChartAt I x₀).symm (f t)) x₀
+          ((extChartAt I x₀).symm (f t)) (v ((extChartAt I x₀).symm (f t)))) t) :
+    IsMIntegralCurveAt ((extChartAt I x₀).symm ∘ f) v t₀ := by
+  obtain ⟨s, hs, haux⟩ := (hderiv.and htarget).exists_mem
+  rw [isMIntegralCurveAt_iff]
+  refine ⟨s, hs, ?_⟩
+  intro t ht
+  let xₜ : G := (extChartAt I x₀).symm (f t)
+  have h : HasDerivAt f
+      (tangentCoordChange I xₜ x₀ xₜ (v xₜ)) t := (haux t ht).1
+  have hf3 := Set.mem_of_mem_of_subset (haux t ht).2 interior_subset
+  have hft1 := Set.mem_preimage.mp <|
+    Set.mem_of_mem_of_subset hf3 (extChartAt I x₀).target_subset_preimage_source
+  have hft2 := mem_extChartAt_source (I := I) xₜ
+  have hft1' : xₜ ∈ (extChartAt I x₀).source := by simpa only [xₜ] using hft1
+  have hcharts :
+      xₜ ∈ (extChartAt I xₜ).source ∩ (extChartAt I x₀).source ∩
+        (extChartAt I xₜ).source := ⟨⟨hft2, hft1'⟩, hft2⟩
+  apply HasMFDerivAt.hasMFDerivWithinAt
+  refine ⟨(continuousAt_extChartAt_symm'' hf3).comp h.continuousAt, ?_⟩
+  have hcomp : HasDerivAt ((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f)
+      (tangentCoordChange I x₀ xₜ xₜ (tangentCoordChange I xₜ x₀ xₜ (v xₜ))) t := by
+    apply HasFDerivAt.comp_hasDerivAt _ _ h
+    apply HasFDerivWithinAt.hasFDerivAt (s := Set.range I) _ <|
+      mem_nhds_iff.mpr ⟨interior (extChartAt I x₀).target,
+        subset_trans interior_subset (extChartAt_target_subset_range ..),
+        isOpen_interior, (haux t ht).2⟩
+    rw [← (extChartAt I x₀).right_inv hf3]
+    exact hasFDerivWithinAt_tangentCoordChange ⟨hft1, hft2⟩
+  have hd := hcomp.congr_deriv (tangentCoordChange_comp hcharts)
+  have hd' := hd.congr_deriv (tangentCoordChange_self hft2)
+  simp only [writtenInExtChartAt, extChartAt_model_space_eq_id, PartialEquiv.refl_coe,
+    PartialEquiv.refl_symm, modelWithCornersSelf_coe, Function.comp_def, id_eq, Set.range_id]
+  rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
+  rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
+  with_unfolding_all
+    exact hd'.hasFDerivAt.hasFDerivWithinAt
 
 /-- The left-invariant vector field, expressed in the identity chart and parameterized by its
 generating tangent vector in the model space. -/
@@ -192,3 +239,98 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
   refine ⟨hderiv.hasDerivAt (Icc_mem_nhds hxt.2.1 hxt.2.2),
     (hα xt.1 hx).1, (hα xt.1 hx).2.2 xt.2 ht, ?_⟩
   exact (Set.mem_preimage.mp hxtTarget).2
+
+local instance lieGroupMinSmoothnessParameterDependence [LieGroup I ∞ G] :
+    LieGroup I (minSmoothness ℝ 3) G := by
+  simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
+
+/-- A single coordinate flow represents the canonical invariant integral curves for every
+sufficiently small generating vector and every sufficiently small time. This is the bridge from
+Picard--Lindelöf's parameterized model-space flow to the canonical manifold-valued curves used to
+define `lieExp`. -/
+theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
+    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    ∃ (α : (E × E) × ℝ → E × E) (U : Set E) (δ : ℝ),
+      U ∈ 𝓝 (0 : E) ∧ 0 < δ ∧
+      ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
+      ∀ v ∈ U,
+        Set.EqOn
+          (fun t => (extChartAt I (1 : G)).symm
+            (α (((v, extChartAt I (1 : G) (1 : G)), t))).2)
+          (mulInvariantIntegralCurve
+            ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1)
+          (Set.Ioo (-δ) δ) := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  obtain ⟨α, hαcont, hαcenter, hα⟩ :=
+    exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
+  let embed : E × ℝ → (E × E) × ℝ := fun vt =>
+    ((vt.1, extChartAt I (1 : G) (1 : G)), vt.2)
+  have hembed : ContinuousAt embed ((0 : E), 0) := by fun_prop
+  have hpull : ∀ᶠ vt in 𝓝 ((0 : E), 0),
+      HasDerivAt (fun t => α ((embed vt).1, t))
+          ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G) (α (embed vt))) vt.2 ∧
+        α ((embed vt).1, 0) = (embed vt).1 ∧
+        (α (embed vt)).1 = (embed vt).1.1 ∧
+        (α (embed vt)).2 ∈ interior (extChartAt I (1 : G)).target := by
+    exact hembed.eventually hα
+  rw [nhds_prod_eq] at hpull
+  obtain ⟨U, hU, T, hT, hsub⟩ := Filter.mem_prod_iff.mp hpull
+  obtain ⟨δ, hδ, hδT⟩ := Metric.mem_nhds_iff.mp hT
+  rw [Real.ball_eq_Ioo, zero_sub, zero_add] at hδT
+  refine ⟨α, U, δ, hU, hδ, hαcont, ?_⟩
+  intro v hv
+  let f : ℝ → E := fun t =>
+    (α (((v, extChartAt I (1 : G) (1 : G)), t))).2
+  let γ : ℝ → G := (extChartAt I (1 : G)).symm ∘ f
+  have hlocal (t : ℝ) (ht : t ∈ Set.Ioo (-δ) δ) :
+      HasDerivAt (fun s => α (((v, extChartAt I (1 : G) (1 : G)), s)))
+          ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G)
+            (α (((v, extChartAt I (1 : G) (1 : G)), t)))) t ∧
+        α (((v, extChartAt I (1 : G) (1 : G)), 0)) =
+          (v, extChartAt I (1 : G) (1 : G)) ∧
+        (α (((v, extChartAt I (1 : G) (1 : G)), t))).1 = v ∧
+        (α (((v, extChartAt I (1 : G) (1 : G)), t))).2 ∈
+          interior (extChartAt I (1 : G)).target := by
+    have hmem : (v, t) ∈ U ×ˢ T := ⟨hv, hδT ht⟩
+    simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using hsub hmem
+  have hγAt : ∀ t ∈ Set.Ioo (-δ) δ,
+      IsMIntegralCurveAt γ
+        (mulInvariantVectorField
+          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)) t := by
+    intro t ht
+    apply isMIntegralCurveAt_extChartAt_symm_of_eventually
+    · filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
+      exact (hlocal s hs).2.2.2
+    · filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
+      have hsnd : HasDerivAt f
+          (mulInvariantCoordinateVectorField (I := I) (G := G)
+            (α (((v, extChartAt I (1 : G) (1 : G)), s)))) s := by
+        change HasDerivAt
+          ((ContinuousLinearMap.snd ℝ E E) ∘ fun u =>
+            α (((v, extChartAt I (1 : G) (1 : G)), u))) _ s
+        simpa using (ContinuousLinearMap.snd ℝ E E).hasFDerivAt.comp_hasDerivAt s
+          (hlocal s hs).1
+      have hpair : α (((v, extChartAt I (1 : G) (1 : G)), s)) = (v, f s) := by
+        apply Prod.ext
+        · exact (hlocal s hs).2.2.1
+        · rfl
+      rw [hpair] at hsnd
+      simpa only [mulInvariantCoordinateVectorField, f] using hsnd
+  have hγOn : IsMIntegralCurveOn γ
+      (mulInvariantVectorField
+        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v))
+      (Set.Ioo (-δ) δ) := IsMIntegralCurveAt.isMIntegralCurveOn hγAt
+  have hzero : (0 : ℝ) ∈ Set.Ioo (-δ) δ := ⟨by linarith, by linarith⟩
+  have hγzero : γ 0 = 1 := by
+    have hinit := (hlocal 0 hzero).2.1
+    change (extChartAt I (1 : G)).symm
+      (α (((v, extChartAt I (1 : G) (1 : G)), 0))).2 = 1
+    rw [congrArg Prod.snd hinit]
+    exact (extChartAt I (1 : G)).left_inv (mem_extChartAt_source (I := I) (1 : G))
+  exact isMIntegralCurveOn_Ioo_eqOn_of_contMDiff_boundaryless hzero
+    ((contMDiff_mulInvariantVectorField
+      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)).of_le (by simp))
+    hγOn
+    ((isMIntegralCurve_mulInvariantIntegralCurve
+      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1).isMIntegralCurveOn _)
+    (by simpa only [γ, f, Function.comp_apply, mulInvariantIntegralCurve_zero] using hγzero)

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -27,6 +27,8 @@ vectors.
   whose values remain inside the identity chart.
 * `exists_local_coordinate_representation_mulInvariantIntegralCurve`: the local flow represents the
   canonical invariant integral curves uniformly for all sufficiently small generating vectors.
+* `continuousAt_mulInvariantExp_modelSpace_zero`: the tangent-space exponential is continuous at
+  zero in model-space coordinates.
 
 ## References
 
@@ -200,6 +202,8 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
       α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) =
         ((0 : E), extChartAt I (1 : G) (1 : G)) ∧
+      (∀ᶠ xt in 𝓝 (((0 : E), extChartAt I (1 : G) (1 : G)), 0),
+        ContinuousAt α xt) ∧
       ∀ᶠ xt in 𝓝 (((0 : E), extChartAt I (1 : G) (1 : G)), 0),
         HasDerivAt (fun t => α (xt.1, t))
           ((0 : E),
@@ -216,8 +220,8 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
     exact prod_mem_nhds (Metric.closedBall_mem_nhds center hr)
       (Icc_mem_nhds (by linarith) (by linarith))
   have hdomainOpen :
-      Metric.closedBall center r ×ˢ Set.Ioo (-δ) δ ∈ 𝓝 (center, 0) := by
-    exact prod_mem_nhds (Metric.closedBall_mem_nhds center hr)
+      Metric.ball center r ×ˢ Set.Ioo (-δ) δ ∈ 𝓝 (center, 0) := by
+    exact prod_mem_nhds (Metric.ball_mem_nhds center hr)
       (Ioo_mem_nhds (by linarith) (by linarith))
   have hcontAt : ContinuousAt α (center, 0) :=
     hcont.continuousAt hdomain
@@ -231,9 +235,16 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
     apply (isOpen_univ.prod isOpen_interior).mem_nhds
     rw [hcenter]
     exact ⟨Set.mem_univ _, htargetCenter⟩
-  refine ⟨α, by simpa only [center] using hcontAt, by simpa only [center] using hcenter, ?_⟩
+  have hcontNear : ∀ᶠ xt in 𝓝 (center, 0), ContinuousAt α xt := by
+    filter_upwards [hdomainOpen] with xt hxt
+    apply hcont.continuousAt
+    exact prod_mem_nhds
+      (Filter.mem_of_superset (Metric.isOpen_ball.mem_nhds hxt.1) Metric.ball_subset_closedBall)
+      (Filter.mem_of_superset (isOpen_Ioo.mem_nhds hxt.2) Set.Ioo_subset_Icc_self)
+  refine ⟨α, by simpa only [center] using hcontAt, by simpa only [center] using hcenter,
+    by simpa only [center] using hcontNear, ?_⟩
   filter_upwards [hdomainOpen, htarget] with xt hxt hxtTarget
-  have hx := hxt.1
+  have hx := Metric.ball_subset_closedBall hxt.1
   have ht : xt.2 ∈ Set.Icc (-δ) δ := Set.Ioo_subset_Icc_self hxt.2
   have hderiv := (hα xt.1 hx).2.1 xt.2 ht
   refine ⟨hderiv.hasDerivAt (Icc_mem_nhds hxt.2.1 hxt.2.2),
@@ -253,6 +264,10 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
     ∃ (α : (E × E) × ℝ → E × E) (U : Set E) (δ : ℝ),
       U ∈ 𝓝 (0 : E) ∧ 0 < δ ∧
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
+      (∀ v ∈ U, ∀ t ∈ Set.Ioo (-δ) δ,
+        ContinuousAt α ((v, extChartAt I (1 : G) (1 : G)), t) ∧
+          (α (((v, extChartAt I (1 : G) (1 : G)), t))).2 ∈
+            interior (extChartAt I (1 : G)).target) ∧
       ∀ v ∈ U,
         Set.EqOn
           (fun t => (extChartAt I (1 : G)).symm
@@ -261,23 +276,29 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
             ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1)
           (Set.Ioo (-δ) δ) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  obtain ⟨α, hαcont, hαcenter, hα⟩ :=
+  obtain ⟨α, hαcont, hαcenter, hαcontNear, hα⟩ :=
     exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
   let embed : E × ℝ → (E × E) × ℝ := fun vt =>
     ((vt.1, extChartAt I (1 : G) (1 : G)), vt.2)
   have hembed : ContinuousAt embed ((0 : E), 0) := by fun_prop
   have hpull : ∀ᶠ vt in 𝓝 ((0 : E), 0),
-      HasDerivAt (fun t => α ((embed vt).1, t))
+      ContinuousAt α (embed vt) ∧
+        HasDerivAt (fun t => α ((embed vt).1, t))
           ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G) (α (embed vt))) vt.2 ∧
         α ((embed vt).1, 0) = (embed vt).1 ∧
         (α (embed vt)).1 = (embed vt).1.1 ∧
         (α (embed vt)).2 ∈ interior (extChartAt I (1 : G)).target := by
-    exact hembed.eventually hα
+    exact hembed.eventually (hαcontNear.and hα)
   rw [nhds_prod_eq] at hpull
   obtain ⟨U, hU, T, hT, hsub⟩ := Filter.mem_prod_iff.mp hpull
   obtain ⟨δ, hδ, hδT⟩ := Metric.mem_nhds_iff.mp hT
   rw [Real.ball_eq_Ioo, zero_sub, zero_add] at hδT
-  refine ⟨α, U, δ, hU, hδ, hαcont, ?_⟩
+  refine ⟨α, U, δ, hU, hδ, hαcont, ?_, ?_⟩
+  · intro v hv t ht
+    have hmem : (v, t) ∈ U ×ˢ T := ⟨hv, hδT ht⟩
+    refine ⟨by simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using (hsub hmem).1,
+      ?_⟩
+    simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using (hsub hmem).2.2.2.2
   intro v hv
   let f : ℝ → E := fun t =>
     (α (((v, extChartAt I (1 : G) (1 : G)), t))).2
@@ -292,7 +313,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
         (α (((v, extChartAt I (1 : G) (1 : G)), t))).2 ∈
           interior (extChartAt I (1 : G)).target := by
     have hmem : (v, t) ∈ U ×ˢ T := ⟨hv, hδT ht⟩
-    simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using hsub hmem
+    simpa only [embed, Set.mem_ofPred_eq, Prod.fst, Prod.snd] using (hsub hmem).2
   have hγAt : ∀ t ∈ Set.Ioo (-δ) δ,
       IsMIntegralCurveAt γ
         (mulInvariantVectorField
@@ -334,3 +355,60 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
     ((isMIntegralCurve_mulInvariantIntegralCurve
       ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1).isMIntegralCurveOn _)
     (by simpa only [γ, f, Function.comp_apply, mulInvariantIntegralCurve_zero] using hγzero)
+
+/-- In model-space coordinates, the tangent-space exponential is continuous at the zero vector.
+The local parameterized flow only covers a short time interval; the scaling law for invariant
+integral curves transports that interval to time one. -/
+theorem continuousAt_mulInvariantExp_modelSpace_zero
+    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    ContinuousAt
+      (fun v : E => mulInvariantExp
+        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v)) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  obtain ⟨α, U, δ, hU, hδ, hαcenter, hαlocal, hαeq⟩ :=
+    exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
+  let c : ℝ := δ / 2
+  have hc : c ∈ Set.Ioo (-δ) δ := by
+    dsimp only [c]
+    constructor <;> linarith
+  have hc0 : c ≠ 0 := ne_of_gt (by dsimp only [c]; linarith)
+  have hzeroU : (0 : E) ∈ U := mem_of_mem_nhds hU
+  let q : E → (E × E) × ℝ := fun v =>
+    ((c⁻¹ • v, extChartAt I (1 : G) (1 : G)), c)
+  have hq : ContinuousAt q (0 : E) := by fun_prop
+  have hqzero : q (0 : E) = ((0, extChartAt I (1 : G) (1 : G)), c) := by
+    simp only [q, smul_zero]
+  have hαq : ContinuousAt (fun v : E => α (q v)) 0 := by
+    simpa only [Function.comp_def] using
+      (hαlocal 0 hzeroU c hc).1.comp_of_eq hq hqzero
+  have hsnd : ContinuousAt (fun v : E => (α (q v)).2) 0 :=
+    continuousAt_snd.comp' hαq
+  have htarget := Set.mem_of_mem_of_subset (hαlocal 0 hzeroU c hc).2 interior_subset
+  have hinv : ContinuousAt (extChartAt I (1 : G)).symm (α (q 0)).2 := by
+    rw [hqzero]
+    exact continuousAt_extChartAt_symm'' htarget
+  have hcontinuous : ContinuousAt
+      (fun v : E => (extChartAt I (1 : G)).symm (α (q v)).2) 0 :=
+    by
+      simpa only [Function.comp_def] using
+        (ContinuousAt.comp_of_eq (f := fun v : E => (α (q v)).2) hinv hsnd rfl)
+  apply hcontinuous.congr_of_eventuallyEq
+  have hrescale : ContinuousAt (fun v : E => c⁻¹ • v) 0 := by fun_prop
+  have hrescaleU : (fun v : E => c⁻¹ • v) ⁻¹' U ∈ 𝓝 0 := by
+    have hU' : U ∈ 𝓝 (c⁻¹ • (0 : E)) := by simpa only [smul_zero] using hU
+    exact hrescale.preimage_mem_nhds hU'
+  filter_upwards [hrescaleU] with v hv
+  symm
+  calc
+    (extChartAt I (1 : G)).symm (α (q v)).2 =
+        mulInvariantIntegralCurve
+          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm (c⁻¹ • v)) 1 c := by
+      exact hαeq (c⁻¹ • v) hv hc
+    _ = mulInvariantExp
+        (c • (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm (c⁻¹ • v)) := by
+      exact (mulInvariantExp_smul _ c).symm
+    _ = mulInvariantExp
+        ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) := by
+      congr 1
+      rw [← map_smul]
+      simp only [smul_smul, mul_inv_cancel₀ hc0, one_smul]

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -111,7 +111,7 @@ theorem mulInvariantCoordinateVectorField_apply [IsManifold I 1 G] (v y : E) :
     mulInvariantCoordinateVectorField (I := I) (G := G) (v, y) =
       tangentCoordChange I ((extChartAt I (1 : G)).symm y) (1 : G)
         ((extChartAt I (1 : G)).symm y)
-        (show E from mulInvariantVectorField (I := I) (G := G)
+        (mulInvariantVectorField (I := I) (G := G)
           (v : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm y)) := by
   rfl
 
@@ -144,12 +144,12 @@ theorem contDiffAt_mulInvariantCoordinateVectorField {n : ℕ∞ω}
   have hw_apply (p : E × E) :
       w p = tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
         ((extChartAt I (1 : G)).symm p.2)
-        (show E from mulInvariantVectorField (I := I) (G := G)
+        (mulInvariantVectorField (I := I) (G := G)
           (p.1 : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm p.2)) := by
     -- This is the second coordinate of the tangent-bundle extended chart at `(0, 1)`.
     change tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
       ((extChartAt I (1 : G)).symm p.2)
-        (show E from mulInvariantVectorField (I := I) (G := G)
+        (mulInvariantVectorField (I := I) (G := G)
           (p.1 : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm p.2)) = _
     rfl
   have hw : w = mulInvariantCoordinateVectorField (I := I) (G := G) := by

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -21,8 +21,9 @@ vectors.
   generating tangent vector included as a parameter.
 * `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth near the
   zero vector and the identity.
-* `exists_continuousOn_local_mulInvariantCoordinateFlow`: a continuous local flow on a uniform
-  closed neighborhood of the zero vector and the identity coordinate.
+* `exists_lipschitzOn_local_mulInvariantCoordinateFlow`: a local flow on a uniform closed
+  neighborhood of the zero vector and the identity coordinate, jointly continuous and uniformly
+  Lipschitz in its initial state.
 * `exists_eventually_hasDerivAt_mulInvariantCoordinateFlow`: a neighborhood form of the local flow
   whose values remain inside the identity chart.
 * `exists_local_coordinate_representation_mulInvariantIntegralCurve`: the local flow represents the
@@ -134,15 +135,20 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
   simpa only [w, extChartAt_prod, extChartAt_self_apply, modelWithCornersSelf_coe,
     PartialEquiv.prod_coe, PartialEquiv.refl_coe, id_eq] using h.snd
 
+omit [IsManifold I 2 G] in
 /-- Near the zero tangent vector and the identity coordinate, the parameterized invariant ODE has
-a single flow that is continuous jointly in its initial condition and time. The tangent-vector
-coordinate is frozen by the ODE; the second coordinate follows the invariant vector field. -/
-theorem exists_continuousOn_local_mulInvariantCoordinateFlow
+a single flow that is continuous jointly in its initial condition and time and uniformly Lipschitz
+in its initial state. The tangent-vector coordinate is frozen by the ODE; the second coordinate
+follows the invariant vector field. -/
+theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
     [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
-    ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r : NNReal), 0 < δ ∧ 0 < r ∧
+    ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r L : NNReal), 0 < δ ∧ 0 < r ∧
       ContinuousOn α
         (Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r ×ˢ
           Set.Icc (-δ) δ) ∧
+      (∀ t ∈ Set.Icc (-δ) δ,
+        LipschitzOnWith L (fun x => α (x, t))
+          (Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r)) ∧
       ∀ x ∈ Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r,
         α (x, 0) = x ∧
           (∀ t ∈ Set.Icc (-δ) δ,
@@ -159,26 +165,42 @@ theorem exists_continuousOn_local_mulInvariantCoordinateFlow
     exact contDiffAt_const.prodMk
       (contDiffAt_mulInvariantCoordinateVectorField.of_le (by norm_num))
   obtain ⟨δ, hδ, a, r, L, K, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
-  obtain ⟨α, hα, hαcont⟩ :=
-    (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_continuousOn
+  obtain ⟨α, hα, L', hαlip⟩ :=
+    (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_lipschitzOnWith
+  let α' : (E × E) × ℝ → E × E := fun xt => α xt.1 xt.2
+  have hαbase : ∀ x ∈ Metric.closedBall center r,
+      α x 0 = x ∧ ∀ t ∈ Set.Icc (-δ) δ,
+        HasDerivWithinAt (α x) (F (α x t)) (Set.Icc (-δ) δ) t := by
+    simpa only [zero_sub, zero_add] using hα
+  have hαlip' : ∀ t ∈ Set.Icc (-δ) δ,
+      LipschitzOnWith L' (fun x => α x t) (Metric.closedBall center r) := by
+    simpa only [zero_sub, zero_add] using hαlip
+  have hαcont : ContinuousOn α'
+      (Metric.closedBall center r ×ˢ Set.Icc (-δ) δ) := by
+    apply continuousOn_prod_of_continuousOn_lipschitzOnWith _ L'
+    · intro x hx
+      exact HasDerivWithinAt.continuousOn (hαbase x hx).2
+    · exact hαlip'
   have hα' : ∀ x ∈ Metric.closedBall center r,
-      α (x, 0) = x ∧ ∀ t ∈ Set.Icc (-δ) δ,
-        HasDerivWithinAt (fun s => α (x, s))
-          ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
+      α' (x, 0) = x ∧ ∀ t ∈ Set.Icc (-δ) δ,
+        HasDerivWithinAt (fun s => α' (x, s))
+          ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G) (α' (x, t)))
           (Set.Icc (-δ) δ) t := by
     intro x hx
-    simpa only [F, zero_sub, zero_add] using hα x hx
-  refine ⟨α, δ, r, hδ, hr, ?_, ?_⟩
+    simpa only [α', F] using hαbase x hx
+  refine ⟨α', δ, r, L', hδ, hr, ?_, ?_, ?_⟩
   · simpa only [center, zero_sub, zero_add] using hαcont
+  · intro t ht
+    simpa only [α'] using hαlip' t ht
   · intro x hx
     have hx' : x ∈ Metric.closedBall center r := by simpa only [center] using hx
     refine ⟨(hα' x hx').1, (hα' x hx').2, ?_⟩
-    let β : ℝ → E := fun t => (α (x, t)).1
+    let β : ℝ → E := fun t => (α' (x, t)).1
     have hβ : ∀ t ∈ Set.Icc (-δ) δ,
         HasDerivWithinAt β 0 (Set.Icc (-δ) δ) t := by
       intro t ht
       change HasDerivWithinAt
-        ((ContinuousLinearMap.fst ℝ E E) ∘ fun s => α (x, s)) 0
+        ((ContinuousLinearMap.fst ℝ E E) ∘ fun s => α' (x, s)) 0
           (Set.Icc (-δ) δ) t
       simpa using (ContinuousLinearMap.fst ℝ E E).hasFDerivAt.comp_hasDerivWithinAt t
         ((hα' x hx').2 t ht)
@@ -193,6 +215,7 @@ theorem exists_continuousOn_local_mulInvariantCoordinateFlow
     exact (hconst t ht).trans ((hconst 0 hzero).symm.trans
       (congrArg Prod.fst (hα' x hx').1))
 
+omit [IsManifold I 2 G] in
 /-- There is a coordinate flow near the zero tangent vector and time zero which is continuous at
 the center, solves the parameterized invariant ODE with an ordinary derivative, freezes the
 tangent-vector parameter, and remains in the target of the identity chart. -/
@@ -211,8 +234,8 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
         α (xt.1, 0) = xt.1 ∧
         (α xt).1 = xt.1.1 ∧
         (α xt).2 ∈ interior (extChartAt I (1 : G)).target := by
-  obtain ⟨α, δ, r, hδ, hr, hcont, hα⟩ :=
-    exists_continuousOn_local_mulInvariantCoordinateFlow
+  obtain ⟨α, δ, r, _, hδ, hr, hcont, _, hα⟩ :=
+    exists_lipschitzOn_local_mulInvariantCoordinateFlow
       (I := I) (G := G)
   let center : E × E := (0, extChartAt I (1 : G) (1 : G))
   have hdomain :
@@ -255,6 +278,7 @@ local instance lieGroupMinSmoothnessParameterDependence [LieGroup I ∞ G] :
     LieGroup I (minSmoothness ℝ 3) G := by
   simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
 
+omit [IsManifold I 2 G] in
 /-- A single coordinate flow represents the canonical invariant integral curves for every
 sufficiently small generating vector and every sufficiently small time. This is the bridge from
 Picard--Lindelöf's parameterized model-space flow to the canonical manifold-valued curves used to
@@ -356,6 +380,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
       ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v) 1).isMIntegralCurveOn _)
     (by simpa only [γ, f, Function.comp_apply, mulInvariantIntegralCurve_zero] using hγzero)
 
+omit [IsManifold I 2 G] in
 /-- In model-space coordinates, the tangent-space exponential is continuous at the zero vector.
 The local parameterized flow only covers a short time interval; the scaling law for invariant
 integral curves transports that interval to time one. -/

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Exponential.Basic
+
+/-!
+# Parameter dependence of invariant integral curves
+
+This file begins the analytic parameter-dependence theory for the invariant integral curves that
+define the Lie-group exponential. In the identity chart, the tangent vector and group coordinate
+form an autonomous ODE on the product model space. Picard--Lindelöf then supplies a single local
+flow, continuous jointly in its initial condition and time, for all sufficiently small tangent
+vectors.
+
+## Main results
+
+* `mulInvariantCoordinateVectorField`: the invariant vector field in the identity chart, with its
+  generating tangent vector included as a parameter.
+* `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth near the
+  zero vector and the identity.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The exponential map".
+-/
+
+public section
+
+open Bundle Function Manifold VectorField
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [IsManifold I 1 G] [IsManifold I 2 G]
+
+/-- The left-invariant vector field, expressed in the identity chart and parameterized by its
+generating tangent vector in the model space. -/
+noncomputable def mulInvariantCoordinateVectorField (p : E × E) : E :=
+  let g := (extChartAt I (1 : G)).symm p.2
+  tangentCoordChange I g (1 : G) g
+    (mulInvariantVectorField
+      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) g)
+
+/-- The coordinate expression of the parameterized left-invariant vector field is smooth near the
+zero tangent vector and the identity. -/
+theorem contDiffAt_mulInvariantCoordinateVectorField
+    [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    ContDiffAt ℝ ∞ (mulInvariantCoordinateVectorField (I := I) (G := G))
+      (0, extChartAt I (1 : G) (1 : G)) := by
+  letI : ContMDiffMul I (∞ + 1) G := by
+    simpa using (inferInstance : ContMDiffMul I ∞ G)
+  let V : E × G → TangentBundle I G := fun p =>
+    ⟨p.2, mulInvariantVectorField
+      ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2⟩
+  have hV : ContMDiff (𝓘(ℝ, E).prod I) I.tangent ∞ V :=
+    contMDiff_mulInvariantVectorField_modelSpace (n := ∞)
+  have hV₀ := hV.contMDiffAt (x := ((0 : E), (1 : G)))
+  rw [contMDiffAt_iff] at hV₀
+  have h := hV₀.2.contDiffAt
+    (range_mem_nhds_isInteriorPoint BoundarylessManifold.isInteriorPoint)
+  let w : E × E → E := fun x =>
+    ((extChartAt I.tangent (V (0, 1)) ∘ V ∘
+      (extChartAt (𝓘(ℝ, E).prod I) (0, 1)).symm) x).2
+  have hw : w = mulInvariantCoordinateVectorField (I := I) (G := G) := by
+    funext p
+    change tangentCoordChange I ((extChartAt I (1 : G)).symm p.2) (1 : G)
+      ((extChartAt I (1 : G)).symm p.2)
+        (mulInvariantVectorField
+          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1)
+          ((extChartAt I (1 : G)).symm p.2)) =
+      mulInvariantCoordinateVectorField (I := I) (G := G) p
+    rfl
+  rw [← hw]
+  simpa only [w, extChartAt_prod, extChartAt_self_apply, modelWithCornersSelf_coe,
+    PartialEquiv.prod_coe, PartialEquiv.refl_coe, id_eq] using h.snd

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -107,6 +107,7 @@ noncomputable def mulInvariantCoordinateVectorField [IsManifold I 1 G] (p : E ×
 
 /-- The parameterized coordinate field is the invariant vector field transported through the
 identity chart. -/
+@[simp]
 theorem mulInvariantCoordinateVectorField_apply [IsManifold I 1 G] (v y : E) :
     mulInvariantCoordinateVectorField (I := I) (G := G) (v, y) =
       tangentCoordChange I ((extChartAt I (1 : G)).symm y) (1 : G)

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -158,7 +158,7 @@ a single solution family that is continuous jointly in its initial condition and
 uniformly Lipschitz in its initial state. The tangent-vector coordinate is frozen by the ODE; the
 second coordinate follows the invariant vector field. -/
 theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
-    [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r L : NNReal), 0 < δ ∧ 0 < r ∧
       ContinuousOn α
         (Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r ×ˢ
@@ -174,7 +174,6 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
                 mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
               (Set.Icc (-δ) δ) t) ∧
           ∀ t ∈ Set.Icc (-δ) δ, (α (x, t)).1 = x.1 := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   let center : E × E := (0, extChartAt I (1 : G) (1 : G))
   let F : E × E → E × E := fun p =>
     (0, mulInvariantCoordinateVectorField (I := I) (G := G) p)
@@ -238,7 +237,7 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
 continuous at the center, solves the parameterized invariant ODE with an ordinary derivative,
 freezes the tangent-vector parameter, and remains in the target of the identity chart. -/
 theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
-    [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ∃ α : (E × E) × ℝ → E × E,
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
       α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) =
@@ -301,7 +300,7 @@ every sufficiently small generating vector and every sufficiently small time. Th
 from Picard--Lindelöf's parameterized model-space solutions to the canonical manifold-valued curves
 used to define `lieExp`. -/
 theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
-    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ∃ (α : (E × E) × ℝ → E × E) (U : Set E) (δ : ℝ),
       U ∈ 𝓝 (0 : E) ∧ 0 < δ ∧
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
@@ -316,7 +315,6 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
           (mulInvariantIntegralCurve (I := I) (G := G)
             (v : GroupLieAlgebra I G) 1)
           (Set.Ioo (-δ) δ) := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   obtain ⟨α, hαcont, _, hαcontNear, hα⟩ :=
     exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
   let embed : E × ℝ → (E × E) × ℝ := fun vt =>
@@ -406,10 +404,9 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
 /-- The tangent-space exponential is continuous at zero when its domain uses the canonical
 model-space identification and its codomain remains the Lie group `G`. -/
 theorem continuousAt_mulInvariantExp_modelSpace_zero
-    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ContinuousAt
       (fun v : E => mulInvariantExp (I := I) (G := G) v) 0 := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   obtain ⟨α, U, δ, hU, hδ, _, hαlocal, hαeq⟩ :=
     exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
   let c : ℝ := δ / 2

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -36,6 +36,8 @@ tangent vectors.
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 0, "The exponential map".
+* Winston Yin's Mathlib proof of `exists_isMIntegralCurveAt_of_contMDiffAt`, adapted by the private
+  chart-to-integral-curve bridge below to retain a shared parameter in the coordinate field.
 -/
 
 public section

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -21,6 +21,8 @@ vectors.
   generating tangent vector included as a parameter.
 * `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth near the
   zero vector and the identity.
+* `exists_continuousOn_local_mulInvariantCoordinateFlow`: a continuous local flow on a uniform
+  closed neighborhood of the zero vector and the identity coordinate.
 
 ## References
 
@@ -80,3 +82,62 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
   rw [← hw]
   simpa only [w, extChartAt_prod, extChartAt_self_apply, modelWithCornersSelf_coe,
     PartialEquiv.prod_coe, PartialEquiv.refl_coe, id_eq] using h.snd
+
+/-- Near the zero tangent vector and the identity coordinate, the parameterized invariant ODE has
+a single flow that is continuous jointly in its initial condition and time. The tangent-vector
+coordinate is frozen by the ODE; the second coordinate follows the invariant vector field. -/
+theorem exists_continuousOn_local_mulInvariantCoordinateFlow
+    [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r : NNReal), 0 < δ ∧ 0 < r ∧
+      ContinuousOn α
+        (Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r ×ˢ
+          Set.Icc (-δ) δ) ∧
+      ∀ x ∈ Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r,
+        α (x, 0) = x ∧
+          (∀ t ∈ Set.Icc (-δ) δ,
+            HasDerivWithinAt (fun s => α (x, s))
+              ((0 : E),
+                mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
+              (Set.Icc (-δ) δ) t) ∧
+          ∀ t ∈ Set.Icc (-δ) δ, (α (x, t)).1 = x.1 := by
+  letI : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let center : E × E := (0, extChartAt I (1 : G) (1 : G))
+  let F : E × E → E × E := fun p =>
+    (0, mulInvariantCoordinateVectorField (I := I) (G := G) p)
+  have hF : ContDiffAt ℝ 1 F center := by
+    exact contDiffAt_const.prodMk
+      (contDiffAt_mulInvariantCoordinateVectorField.of_le (by norm_num))
+  obtain ⟨δ, hδ, a, r, L, K, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
+  obtain ⟨α, hα, hαcont⟩ :=
+    (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_continuousOn
+  have hα' : ∀ x ∈ Metric.closedBall center r,
+      α (x, 0) = x ∧ ∀ t ∈ Set.Icc (-δ) δ,
+        HasDerivWithinAt (fun s => α (x, s))
+          ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
+          (Set.Icc (-δ) δ) t := by
+    intro x hx
+    simpa only [F, zero_sub, zero_add] using hα x hx
+  refine ⟨α, δ, r, hδ, hr, ?_, ?_⟩
+  · simpa only [center, zero_sub, zero_add] using hαcont
+  · intro x hx
+    have hx' : x ∈ Metric.closedBall center r := by simpa only [center] using hx
+    refine ⟨(hα' x hx').1, (hα' x hx').2, ?_⟩
+    let β : ℝ → E := fun t => (α (x, t)).1
+    have hβ : ∀ t ∈ Set.Icc (-δ) δ,
+        HasDerivWithinAt β 0 (Set.Icc (-δ) δ) t := by
+      intro t ht
+      change HasDerivWithinAt
+        ((ContinuousLinearMap.fst ℝ E E) ∘ fun s => α (x, s)) 0
+          (Set.Icc (-δ) δ) t
+      simpa using (ContinuousLinearMap.fst ℝ E E).hasFDerivAt.comp_hasDerivWithinAt t
+        ((hα' x hx').2 t ht)
+    have hconst := constant_of_derivWithin_zero
+      (fun t ht => (hβ t ht).differentiableWithinAt)
+      (fun t ht => (hβ t (Set.Ico_subset_Icc_self ht)).derivWithin
+        ((uniqueDiffOn_Icc (by linarith)).uniqueDiffWithinAt
+          (Set.Ico_subset_Icc_self ht)))
+    intro t ht
+    have hzero : (0 : ℝ) ∈ Set.Icc (-δ) δ := by constructor <;> linarith
+    change β t = x.1
+    exact (hconst t ht).trans ((hconst 0 hzero).symm.trans
+      (congrArg Prod.fst (hα' x hx').1))

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -19,8 +19,8 @@ tangent vectors.
 
 * `mulInvariantCoordinateVectorField`: the invariant vector field in the identity chart, with its
   generating tangent vector included as a parameter.
-* `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is smooth at the
-  zero vector and identity coordinate.
+* `contDiffAt_mulInvariantCoordinateVectorField`: this coordinate vector field is `C^n` at the
+  zero vector and identity coordinate when multiplication is `C^(n + 1)`.
 * `exists_lipschitzOn_local_mulInvariantCoordinateFlow`: a local solution family on a uniform
   closed neighborhood of the zero vector and the identity coordinate, jointly continuous and
   uniformly Lipschitz in its initial state.
@@ -115,18 +115,19 @@ theorem mulInvariantCoordinateVectorField_apply [IsManifold I 1 G] (v y : E) :
           (v : GroupLieAlgebra I G) ((extChartAt I (1 : G)).symm y)) := by
   rfl
 
-/-- The coordinate expression of the parameterized left-invariant vector field is smooth at the
-zero tangent vector and identity coordinate. -/
-theorem contDiffAt_mulInvariantCoordinateVectorField
-    [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
-    ContDiffAt ℝ ∞ (mulInvariantCoordinateVectorField (I := I) (G := G))
+/-- The coordinate expression of the parameterized left-invariant vector field is `C^n` at the
+zero tangent vector and identity coordinate when multiplication is `C^(n + 1)`. -/
+theorem contDiffAt_mulInvariantCoordinateVectorField {n : ℕ∞ω}
+    [ContMDiffMul I (n + 1) G] [BoundarylessManifold I G] :
+    let _ : IsManifold I 1 G := IsManifold.of_le (n := n + 1) le_add_self
+    ContDiffAt ℝ n (mulInvariantCoordinateVectorField (I := I) (G := G))
       (0, extChartAt I (1 : G) (1 : G)) := by
-  let _ : ContMDiffMul I (∞ + 1) G := by
-    simpa using (inferInstance : ContMDiffMul I ∞ G)
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := n + 1) le_add_self
+  dsimp only
   let V : E × G → TangentBundle I G := fun p =>
     ⟨p.2, mulInvariantVectorField (I := I) (G := G) p.1 p.2⟩
-  have hV : ContMDiff (𝓘(ℝ, E).prod I) I.tangent ∞ V :=
-    contMDiff_mulInvariantVectorField_modelSpace (n := ∞)
+  have hV : ContMDiff (𝓘(ℝ, E).prod I) I.tangent n V :=
+    contMDiff_mulInvariantVectorField_modelSpace (n := n)
   have hV₀ := hV.contMDiffAt (x := ((0 : E), (1 : G)))
   rw [contMDiffAt_iff] at hV₀
   have h := hV₀.2.contDiffAt
@@ -158,7 +159,8 @@ a single solution family that is continuous jointly in its initial condition and
 uniformly Lipschitz in its initial state. The tangent-vector coordinate is frozen by the ODE; the
 second coordinate follows the invariant vector field. -/
 theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
-    [CompleteSpace E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] [BoundarylessManifold I G] :
+    let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
     ∃ (α : (E × E) × ℝ → E × E) (δ : ℝ) (r L : NNReal), 0 < δ ∧ 0 < r ∧
       ContinuousOn α
         (Metric.closedBall ((0 : E), extChartAt I (1 : G) (1 : G)) r ×ˢ
@@ -174,12 +176,14 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
                 mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
               (Set.Icc (-δ) δ) t) ∧
           ∀ t ∈ Set.Icc (-δ) δ, (α (x, t)).1 = x.1 := by
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
+  dsimp only
   let center : E × E := (0, extChartAt I (1 : G) (1 : G))
   let F : E × E → E × E := fun p =>
     (0, mulInvariantCoordinateVectorField (I := I) (G := G) p)
   have hF : ContDiffAt ℝ 1 F center := by
     exact contDiffAt_const.prodMk
-      (contDiffAt_mulInvariantCoordinateVectorField.of_le (by norm_num))
+      (contDiffAt_mulInvariantCoordinateVectorField (n := 1))
   obtain ⟨δ, hδ, _, r, _, _, hr, hpl⟩ := IsPicardLindelof.of_contDiffAt_one hF
   obtain ⟨α, hα, L', hαlip⟩ :=
     (hpl (0 : ℝ)).exists_forall_mem_closedBall_eq_hasDerivWithinAt_lipschitzOnWith
@@ -237,7 +241,8 @@ theorem exists_lipschitzOn_local_mulInvariantCoordinateFlow
 continuous at the center, solves the parameterized invariant ODE with an ordinary derivative,
 freezes the tangent-vector parameter, and remains in the target of the identity chart. -/
 theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
-    [CompleteSpace E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [ContMDiffMul I (1 + 1) G] [BoundarylessManifold I G] :
+    let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
     ∃ α : (E × E) × ℝ → E × E,
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
       α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) =
@@ -251,6 +256,8 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
         α (xt.1, 0) = xt.1 ∧
         (α xt).1 = xt.1.1 ∧
         (α xt).2 ∈ interior (extChartAt I (1 : G)).target := by
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := 1 + 1) (by norm_num)
+  dsimp only
   obtain ⟨α, δ, r, _, hδ, hr, hcont, _, hα⟩ :=
     exists_lipschitzOn_local_mulInvariantCoordinateFlow
       (I := I) (G := G)
@@ -291,16 +298,13 @@ theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
     (hα xt.1 hx).1, (hα xt.1 hx).2.2 xt.2 ht, ?_⟩
   exact (Set.mem_preimage.mp hxtTarget).2
 
-local instance lieGroupMinSmoothnessParameterDependence [LieGroup I ∞ G] :
-    LieGroup I (minSmoothness ℝ 3) G := by
-  simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
-
 /-- A single coordinate solution family represents the canonical invariant integral curves for
 every sufficiently small generating vector and every sufficiently small time. This is the bridge
 from Picard--Lindelöf's parameterized model-space solutions to the canonical manifold-valued curves
 used to define `lieExp`. -/
 theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
-    [CompleteSpace E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [LieGroup I (minSmoothness ℝ 3) G]
+    [T2Space G] [BoundarylessManifold I G] :
     ∃ (α : (E × E) × ℝ → E × E) (U : Set E) (δ : ℝ),
       U ∈ 𝓝 (0 : E) ∧ 0 < δ ∧
       ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
@@ -315,6 +319,9 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
           (mulInvariantIntegralCurve (I := I) (G := G)
             (v : GroupLieAlgebra I G) 1)
           (Set.Ioo (-δ) δ) := by
+  let _ : ContMDiffMul I (1 + 1) G :=
+    ContMDiffMul.of_le (m := 1 + 1) (n := minSmoothness ℝ 3) (by norm_num)
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := minSmoothness ℝ 3) (by norm_num)
   obtain ⟨α, hαcont, _, hαcontNear, hα⟩ :=
     exists_eventually_hasDerivAt_mulInvariantCoordinateFlow (I := I) (G := G)
   let embed : E × ℝ → (E × E) × ℝ := fun vt =>
@@ -404,9 +411,13 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
 /-- The tangent-space exponential is continuous at zero when its domain uses the canonical
 model-space identification and its codomain remains the Lie group `G`. -/
 theorem continuousAt_mulInvariantExp_modelSpace_zero
-    [CompleteSpace E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    [CompleteSpace E] [LieGroup I (minSmoothness ℝ 3) G]
+    [T2Space G] [BoundarylessManifold I G] :
     ContinuousAt
       (fun v : E => mulInvariantExp (I := I) (G := G) v) 0 := by
+  let _ : ContMDiffMul I (1 + 1) G :=
+    ContMDiffMul.of_le (m := 1 + 1) (n := minSmoothness ℝ 3) (by norm_num)
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := minSmoothness ℝ 3) (by norm_num)
   obtain ⟨α, U, δ, hU, hδ, _, hαlocal, hαeq⟩ :=
     exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
   let c : ℝ := δ / 2

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -23,6 +23,8 @@ vectors.
   zero vector and the identity.
 * `exists_continuousOn_local_mulInvariantCoordinateFlow`: a continuous local flow on a uniform
   closed neighborhood of the zero vector and the identity coordinate.
+* `exists_eventually_hasDerivAt_mulInvariantCoordinateFlow`: a neighborhood form of the local flow
+  whose values remain inside the identity chart.
 
 ## References
 
@@ -141,3 +143,52 @@ theorem exists_continuousOn_local_mulInvariantCoordinateFlow
     change β t = x.1
     exact (hconst t ht).trans ((hconst 0 hzero).symm.trans
       (congrArg Prod.fst (hα' x hx').1))
+
+/-- There is a coordinate flow near the zero tangent vector and time zero which is continuous at
+the center, solves the parameterized invariant ODE with an ordinary derivative, freezes the
+tangent-vector parameter, and remains in the target of the identity chart. -/
+theorem exists_eventually_hasDerivAt_mulInvariantCoordinateFlow
+    [FiniteDimensional ℝ E] [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
+    ∃ α : (E × E) × ℝ → E × E,
+      ContinuousAt α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) ∧
+      α (((0 : E), extChartAt I (1 : G) (1 : G)), 0) =
+        ((0 : E), extChartAt I (1 : G) (1 : G)) ∧
+      ∀ᶠ xt in 𝓝 (((0 : E), extChartAt I (1 : G) (1 : G)), 0),
+        HasDerivAt (fun t => α (xt.1, t))
+          ((0 : E),
+            mulInvariantCoordinateVectorField (I := I) (G := G) (α xt)) xt.2 ∧
+        α (xt.1, 0) = xt.1 ∧
+        (α xt).1 = xt.1.1 ∧
+        (α xt).2 ∈ interior (extChartAt I (1 : G)).target := by
+  obtain ⟨α, δ, r, hδ, hr, hcont, hα⟩ :=
+    exists_continuousOn_local_mulInvariantCoordinateFlow
+      (I := I) (G := G)
+  let center : E × E := (0, extChartAt I (1 : G) (1 : G))
+  have hdomain :
+      Metric.closedBall center r ×ˢ Set.Icc (-δ) δ ∈ 𝓝 (center, 0) := by
+    exact prod_mem_nhds (Metric.closedBall_mem_nhds center hr)
+      (Icc_mem_nhds (by linarith) (by linarith))
+  have hdomainOpen :
+      Metric.closedBall center r ×ˢ Set.Ioo (-δ) δ ∈ 𝓝 (center, 0) := by
+    exact prod_mem_nhds (Metric.closedBall_mem_nhds center hr)
+      (Ioo_mem_nhds (by linarith) (by linarith))
+  have hcontAt : ContinuousAt α (center, 0) :=
+    hcont.continuousAt hdomain
+  have hcenter : α (center, 0) = center := by
+    exact (hα center (Metric.mem_closedBall_self hr.le)).1
+  have htargetCenter : center.2 ∈ interior (extChartAt I (1 : G)).target := by
+    exact (I.isInteriorPoint_iff.mp BoundarylessManifold.isInteriorPoint)
+  have htarget :
+      α ⁻¹' (Set.univ ×ˢ interior (extChartAt I (1 : G)).target) ∈ 𝓝 (center, 0) := by
+    apply hcontAt.preimage_mem_nhds
+    apply (isOpen_univ.prod isOpen_interior).mem_nhds
+    rw [hcenter]
+    exact ⟨Set.mem_univ _, htargetCenter⟩
+  refine ⟨α, by simpa only [center] using hcontAt, by simpa only [center] using hcenter, ?_⟩
+  filter_upwards [hdomainOpen, htarget] with xt hxt hxtTarget
+  have hx := hxt.1
+  have ht : xt.2 ∈ Set.Icc (-δ) δ := Set.Ioo_subset_Icc_self hxt.2
+  have hderiv := (hα xt.1 hx).2.1 xt.2 ht
+  refine ⟨hderiv.hasDerivAt (Icc_mem_nhds hxt.2.1 hxt.2.2),
+    (hα xt.1 hx).1, (hα xt.1 hx).2.2 xt.2 ht, ?_⟩
+  exact (Set.mem_preimage.mp hxtTarget).2

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -58,7 +58,7 @@ theorem contDiffAt_mulInvariantCoordinateVectorField
     [ContMDiffMul I ∞ G] [BoundarylessManifold I G] :
     ContDiffAt ℝ ∞ (mulInvariantCoordinateVectorField (I := I) (G := G))
       (0, extChartAt I (1 : G) (1 : G)) := by
-  letI : ContMDiffMul I (∞ + 1) G := by
+  let _ : ContMDiffMul I (∞ + 1) G := by
     simpa using (inferInstance : ContMDiffMul I ∞ G)
   let V : E × G → TangentBundle I G := fun p =>
     ⟨p.2, mulInvariantVectorField
@@ -102,7 +102,7 @@ theorem exists_continuousOn_local_mulInvariantCoordinateFlow
                 mulInvariantCoordinateVectorField (I := I) (G := G) (α (x, t)))
               (Set.Icc (-δ) δ) t) ∧
           ∀ t ∈ Set.Icc (-δ) δ, (α (x, t)).1 = x.1 := by
-  letI : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   let center : E × E := (0, extChartAt I (1 : G) (1 : G))
   let F : E × E → E × E := fun p =>
     (0, mulInvariantCoordinateVectorField (I := I) (G := G) p)

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -17,7 +17,6 @@ left-invariant-derivation model of a Lie algebra.
 
 ## Main results
 
-* `groupLieAlgebraEquivModelSpace`: the tangent Lie algebra is canonically the manifold model space.
 * `contMDiff_mulInvariantVectorField_infty`: a left-invariant vector field on a smooth Lie group is
   smooth.
 * `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly smooth in
@@ -40,25 +39,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-
-/-- The tangent Lie algebra of a Lie group is canonically linearly equivalent to the manifold
-model space. This makes explicit the identification implemented by Mathlib's `TangentSpace` type
-synonym. -/
-@[expose]
-noncomputable def groupLieAlgebraEquivModelSpace : GroupLieAlgebra I G ≃ₗ[𝕜] E :=
-  LinearEquiv.refl 𝕜 E
-
-/-- The tangent-to-model equivalence is the identity on underlying vectors. -/
-@[simp]
-theorem groupLieAlgebraEquivModelSpace_apply (v : GroupLieAlgebra I G) :
-    groupLieAlgebraEquivModelSpace v = v :=
-  rfl
-
-/-- The model-to-tangent equivalence is the identity on underlying vectors. -/
-@[simp]
-theorem groupLieAlgebraEquivModelSpace_symm_apply (v : E) :
-    (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v = v :=
-  rfl
 
 /-- A left-invariant vector field on a smooth Lie group is smooth. -/
 theorem contMDiff_mulInvariantVectorField_infty
@@ -95,9 +75,7 @@ theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
     [IsManifold I 2 G] [ContMDiffMul I (n + 1) G] :
     ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
       (fun p : E × G =>
-        (mulInvariantVectorField
-          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2 :
-            TangentBundle I G)) := by
+        (mulInvariantVectorField (I := I) (G := G) p.1 p.2 : TangentBundle I G)) := by
   let fg : E × G → TangentBundle I G := fun p => TotalSpace.mk' E p.2 0
   have sfg : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fg :=
     (contMDiff_zeroSection 𝕜 (TangentSpace I : G → Type _)).comp contMDiff_snd

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -19,8 +19,8 @@ left-invariant-derivation model of a Lie algebra.
 
 * `contMDiff_mulInvariantVectorField_infty`: a left-invariant vector field on a smooth Lie group is
   smooth.
-* `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly smooth in
-  its model-space generator and group argument.
+* `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly `C^n` in
+  its model-space generator and group argument when multiplication is `C^(n + 1)`.
 
 ## References
 

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -68,15 +68,14 @@ theorem contMDiff_mulInvariantVectorField_infty
     simp +instances [mulInvariantVectorField, equivTangentBundleProd]
     rfl
 /-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
-vector and the group point when multiplication is `C^(n + 1)`.
-
-The separate `IsManifold I 1 G` hypothesis supplies the differentiable tangent-bundle structure;
-it is independent of the regularity lost by differentiating multiplication. -/
+vector and the group point when multiplication is `C^(n + 1)`. -/
 theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
-    [IsManifold I 1 G] [ContMDiffMul I (n + 1) G] :
+    [ContMDiffMul I (n + 1) G] :
+    let _ : IsManifold I 1 G := IsManifold.of_le (n := n + 1) le_add_self
     ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
       (fun p : E × G =>
         (mulInvariantVectorField (I := I) (G := G) p.1 p.2 : TangentBundle I G)) := by
+  let _ : IsManifold I 1 G := IsManifold.of_le (n := n + 1) le_add_self
   let fg : E × G → TangentBundle I G := fun p => TotalSpace.mk' E p.2 0
   have sfg : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fg :=
     (contMDiff_zeroSection 𝕜 (TangentSpace I : G → Type _)).comp contMDiff_snd

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -41,32 +41,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
 
-/-- A left-invariant vector field on a smooth Lie group is smooth. -/
-theorem contMDiff_mulInvariantVectorField_infty
-    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G) :
-    ContMDiff I I.tangent ∞
-      (fun g : G ↦ (mulInvariantVectorField v g : TangentBundle I G)) := by
-  let fg : G → TangentBundle I G := fun g ↦ TotalSpace.mk' E g 0
-  have sfg : ContMDiff I I.tangent ∞ fg := contMDiff_zeroSection _ _
-  let fv : G → TangentBundle I G := fun _ ↦ TotalSpace.mk' E 1 v
-  have sfv : ContMDiff I I.tangent ∞ fv := contMDiff_const
-  let F₁ : G → TangentBundle I G × TangentBundle I G := fun g ↦ (fg g, fv g)
-  have S₁ : ContMDiff I (I.tangent.prod I.tangent) ∞ F₁ := sfg.prodMk sfv
-  let F₂ : TangentBundle I G × TangentBundle I G →
-      TangentBundle (I.prod I) (G × G) := (equivTangentBundleProd I G I G).symm
-  have S₂ : ContMDiff (I.tangent.prod I.tangent) (I.prod I).tangent ∞ F₂ :=
-    contMDiff_equivTangentBundleProd_symm
-  let F₃ : TangentBundle (I.prod I) (G × G) → TangentBundle I G :=
-    tangentMap% (fun p : G × G ↦ p.1 * p.2)
-  have S₃ : ContMDiff (I.prod I).tangent I.tangent ∞ F₃ :=
-    (contMDiff_mul I ∞).contMDiff_tangentMap (by simp)
-  let S := (S₃.comp S₂).comp S₁
-  convert! S with g
-  · simp [F₁, F₂, F₃, fg, fv]
-  · simp only [comp_apply, tangentMap, F₃, F₂, F₁, fg, fv]
-    rw [mfderiv_prod_eq_add_apply ((contMDiff_mul I ∞).mdifferentiableAt (by simp))]
-    simp +instances [mulInvariantVectorField, equivTangentBundleProd]
-    rfl
 /-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
 vector and the group point when multiplication is `C^(n + 1)`. -/
 theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
@@ -117,3 +91,13 @@ theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
       ((contMDiff_mul I (n + 1)).mdifferentiableAt (by simp))]
     simp +instances [mulInvariantVectorField, equivTangentBundleProd]
     rfl
+
+/-- A left-invariant vector field on a smooth Lie group is smooth. -/
+theorem contMDiff_mulInvariantVectorField_infty
+    [ContMDiffMul I ∞ G] (v : GroupLieAlgebra I G) :
+    ContMDiff I I.tangent ∞
+      (fun g : G ↦ (mulInvariantVectorField v g : TangentBundle I G)) := by
+  let _ : ContMDiffMul I (∞ + 1) G := by
+    simpa using (inferInstance : ContMDiffMul I ∞ G)
+  have h := contMDiff_mulInvariantVectorField_modelSpace (I := I) (G := G) (n := ∞)
+  exact h.comp (contMDiff_const.prodMk contMDiff_id)

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -17,8 +17,11 @@ left-invariant-derivation model of a Lie algebra.
 
 ## Main results
 
+* `groupLieAlgebraEquivModelSpace`: the tangent Lie algebra is canonically the manifold model space.
 * `contMDiff_mulInvariantVectorField_infty`: a left-invariant vector field on a smooth Lie group is
   smooth.
+* `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly smooth in
+  its model-space generator and group argument.
 
 ## References
 
@@ -37,6 +40,25 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+/-- The tangent Lie algebra of a Lie group is canonically linearly equivalent to the manifold
+model space. This makes explicit the identification implemented by Mathlib's `TangentSpace` type
+synonym. -/
+@[expose]
+noncomputable def groupLieAlgebraEquivModelSpace : GroupLieAlgebra I G ≃ₗ[𝕜] E :=
+  LinearEquiv.refl 𝕜 E
+
+/-- The tangent-to-model equivalence is the identity on underlying vectors. -/
+@[simp]
+theorem groupLieAlgebraEquivModelSpace_apply (v : GroupLieAlgebra I G) :
+    groupLieAlgebraEquivModelSpace v = v :=
+  rfl
+
+/-- The model-to-tangent equivalence is the identity on underlying vectors. -/
+@[simp]
+theorem groupLieAlgebraEquivModelSpace_symm_apply (v : E) :
+    (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v = v :=
+  rfl
 
 /-- A left-invariant vector field on a smooth Lie group is smooth. -/
 theorem contMDiff_mulInvariantVectorField_infty
@@ -62,5 +84,58 @@ theorem contMDiff_mulInvariantVectorField_infty
   · simp [F₁, F₂, F₃, fg, fv]
   · simp only [comp_apply, tangentMap, F₃, F₂, F₁, fg, fv]
     rw [mfderiv_prod_eq_add_apply ((contMDiff_mul I ∞).mdifferentiableAt (by simp))]
+    simp +instances [mulInvariantVectorField, equivTangentBundleProd]
+    rfl
+/-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
+vector and the group point when multiplication is `C^(n + 1)`.
+
+The separate `IsManifold I 2 G` hypothesis supplies the smooth tangent-bundle structure; it is
+independent of the regularity lost by differentiating multiplication. -/
+theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
+    [IsManifold I 2 G] [ContMDiffMul I (n + 1) G] :
+    ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
+      (fun p : E × G =>
+        (mulInvariantVectorField
+          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2 :
+            TangentBundle I G)) := by
+  let fg : E × G → TangentBundle I G := fun p => TotalSpace.mk' E p.2 0
+  have sfg : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fg :=
+    (contMDiff_zeroSection 𝕜 (TangentSpace I : G → Type _)).comp contMDiff_snd
+  let fv : E × G → TangentBundle I G := fun p => TotalSpace.mk' E 1 p.1
+  have sfv : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fv := by
+    intro p
+    rw [Bundle.contMDiffAt_totalSpace]
+    constructor
+    · simpa only [fv] using
+        (contMDiffAt_const : ContMDiffAt (𝓘(𝕜, E).prod I) I n
+          (fun _ : E × G => (1 : G)) p)
+    · have hone : (1 : G) ∈ (extChartAt I (1 : G)).source := mem_extChartAt_source _
+      have hfun :
+          (fun q : E × G =>
+            (trivializationAt E (TangentSpace I) ((fv p).proj) (fv q)).2) = fun q => q.1 := by
+        funext q
+        rw [TangentBundle.trivializationAt_apply]
+        -- Both fibers are over `1`, so their coordinate change is the identity on the model space.
+        change tangentCoordChange I (1 : G) (1 : G) (1 : G) q.1 = q.1
+        rw [tangentCoordChange_self hone]
+      rw [hfun]
+      exact contMDiffAt_fst
+  let F₁ : E × G → TangentBundle I G × TangentBundle I G := fun p => (fg p, fv p)
+  have S₁ : ContMDiff (𝓘(𝕜, E).prod I) (I.tangent.prod I.tangent) n F₁ :=
+    sfg.prodMk sfv
+  let F₂ : TangentBundle I G × TangentBundle I G → TangentBundle (I.prod I) (G × G) :=
+    (equivTangentBundleProd I G I G).symm
+  have S₂ : ContMDiff (I.tangent.prod I.tangent) (I.prod I).tangent n F₂ :=
+    contMDiff_equivTangentBundleProd_symm
+  let F₃ : TangentBundle (I.prod I) (G × G) → TangentBundle I G :=
+    tangentMap% (fun p : G × G => p.1 * p.2)
+  have S₃ : ContMDiff (I.prod I).tangent I.tangent n F₃ :=
+    (contMDiff_mul I (n + 1)).contMDiff_tangentMap le_rfl
+  let S := (S₃.comp S₂).comp S₁
+  convert! S with p
+  · simp [F₁, F₂, F₃, fg, fv]
+  · simp only [comp_apply, tangentMap, F₃, F₂, F₁, fg, fv]
+    rw [mfderiv_prod_eq_add_apply
+      ((contMDiff_mul I (n + 1)).mdifferentiableAt (by simp))]
     simp +instances [mulInvariantVectorField, equivTangentBundleProd]
     rfl

--- a/TauCeti/Geometry/Lie/InvariantVectorField.lean
+++ b/TauCeti/Geometry/Lie/InvariantVectorField.lean
@@ -26,8 +26,9 @@ left-invariant-derivation model of a Lie algebra.
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 0, "The Lie algebra and the tangent space at `1`".
-* The proof of `contMDiff_mulInvariantVectorField_infty` follows Sébastien Gouëzel's proof of
-  Mathlib's `contMDiff_mulInvariantVectorField`, specialized to infinite smoothness.
+* The proofs of `contMDiff_mulInvariantVectorField_modelSpace` and
+  `contMDiff_mulInvariantVectorField_infty` adapt Sébastien Gouëzel's proof of Mathlib's
+  `contMDiff_mulInvariantVectorField`.
 -/
 
 public section
@@ -69,10 +70,10 @@ theorem contMDiff_mulInvariantVectorField_infty
 /-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
 vector and the group point when multiplication is `C^(n + 1)`.
 
-The separate `IsManifold I 2 G` hypothesis supplies the smooth tangent-bundle structure; it is
-independent of the regularity lost by differentiating multiplication. -/
+The separate `IsManifold I 1 G` hypothesis supplies the differentiable tangent-bundle structure;
+it is independent of the regularity lost by differentiating multiplication. -/
 theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
-    [IsManifold I 2 G] [ContMDiffMul I (n + 1) G] :
+    [IsManifold I 1 G] [ContMDiffMul I (n + 1) G] :
     ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
       (fun p : E × G =>
         (mulInvariantVectorField (I := I) (G := G) p.1 p.2 : TangentBundle I G)) := by

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -22,6 +22,9 @@ The latter is the manifold model vector space, so this also determines the Lie a
 
 * `LeftInvariantDerivation.evalAt_one_injective`: identity evaluation is injective for monoids.
 * `LeftInvariantDerivation.evalAt_injective`: evaluation at any point is injective.
+* `groupLieAlgebraEquivModelSpace`: the tangent Lie algebra is canonically the manifold model space.
+* `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly smooth in
+  its model-space generator and group argument.
 * `tangentToLeftInvariantDerivation`: the left-invariant derivation associated to a tangent vector
   at the identity.
 * `leftInvariantDerivationEquivGroupLieAlgebra`: the canonical linear equivalence between
@@ -86,6 +89,79 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+/-- The tangent Lie algebra of a Lie group is canonically linearly equivalent to the manifold
+model space. This makes explicit the identification implemented by Mathlib's `TangentSpace` type
+synonym. -/
+@[expose]
+noncomputable def groupLieAlgebraEquivModelSpace : GroupLieAlgebra I G ≃ₗ[𝕜] E :=
+  LinearEquiv.refl 𝕜 E
+
+/-- The tangent-to-model equivalence is the identity on underlying vectors. -/
+@[simp]
+theorem groupLieAlgebraEquivModelSpace_apply (v : GroupLieAlgebra I G) :
+    groupLieAlgebraEquivModelSpace v = v :=
+  rfl
+
+/-- The model-to-tangent equivalence is the identity on underlying vectors. -/
+@[simp]
+theorem groupLieAlgebraEquivModelSpace_symm_apply (v : E) :
+    (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v = v :=
+  rfl
+
+/-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
+vector and the group point when multiplication is `C^(n + 1)`.
+
+The separate `IsManifold I 2 G` hypothesis supplies the smooth tangent-bundle structure; it is
+independent of the regularity lost by differentiating multiplication. -/
+theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
+    [IsManifold I 2 G] [ContMDiffMul I (n + 1) G] :
+    ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
+      (fun p : E × G =>
+        (mulInvariantVectorField
+          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2 :
+            TangentBundle I G)) := by
+  let fg : E × G → TangentBundle I G := fun p => TotalSpace.mk' E p.2 0
+  have sfg : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fg :=
+    (contMDiff_zeroSection 𝕜 (TangentSpace I : G → Type _)).comp contMDiff_snd
+  let fv : E × G → TangentBundle I G := fun p => TotalSpace.mk' E 1 p.1
+  have sfv : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fv := by
+    intro p
+    rw [Bundle.contMDiffAt_totalSpace]
+    constructor
+    · simpa only [fv] using
+        (contMDiffAt_const : ContMDiffAt (𝓘(𝕜, E).prod I) I n
+          (fun _ : E × G => (1 : G)) p)
+    · have hone : (1 : G) ∈ (extChartAt I (1 : G)).source := mem_extChartAt_source _
+      have hfun :
+          (fun q : E × G =>
+            (trivializationAt E (TangentSpace I) ((fv p).proj) (fv q)).2) = fun q => q.1 := by
+        funext q
+        rw [TangentBundle.trivializationAt_apply]
+        -- Both fibers are over `1`, so their coordinate change is the identity on the model space.
+        change tangentCoordChange I (1 : G) (1 : G) (1 : G) q.1 = q.1
+        rw [tangentCoordChange_self hone]
+      rw [hfun]
+      exact contMDiffAt_fst
+  let F₁ : E × G → TangentBundle I G × TangentBundle I G := fun p => (fg p, fv p)
+  have S₁ : ContMDiff (𝓘(𝕜, E).prod I) (I.tangent.prod I.tangent) n F₁ :=
+    sfg.prodMk sfv
+  let F₂ : TangentBundle I G × TangentBundle I G → TangentBundle (I.prod I) (G × G) :=
+    (equivTangentBundleProd I G I G).symm
+  have S₂ : ContMDiff (I.tangent.prod I.tangent) (I.prod I).tangent n F₂ :=
+    contMDiff_equivTangentBundleProd_symm
+  let F₃ : TangentBundle (I.prod I) (G × G) → TangentBundle I G :=
+    tangentMap% (fun p : G × G => p.1 * p.2)
+  have S₃ : ContMDiff (I.prod I).tangent I.tangent n F₃ :=
+    (contMDiff_mul I (n + 1)).contMDiff_tangentMap le_rfl
+  let S := (S₃.comp S₂).comp S₁
+  convert! S with p
+  · simp [F₁, F₂, F₃, fg, fv]
+  · simp only [comp_apply, tangentMap, F₃, F₂, F₁, fg, fv]
+    rw [mfderiv_prod_eq_add_apply
+      ((contMDiff_mul I (n + 1)).mdifferentiableAt (by simp))]
+    simp +instances [mulInvariantVectorField, equivTangentBundleProd]
+    rfl
 
 /-- Differentiating a smooth scalar function along a left-invariant vector field gives a smooth
 scalar function. -/

--- a/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LeftInvariantDerivation.lean
@@ -22,9 +22,6 @@ The latter is the manifold model vector space, so this also determines the Lie a
 
 * `LeftInvariantDerivation.evalAt_one_injective`: identity evaluation is injective for monoids.
 * `LeftInvariantDerivation.evalAt_injective`: evaluation at any point is injective.
-* `groupLieAlgebraEquivModelSpace`: the tangent Lie algebra is canonically the manifold model space.
-* `contMDiff_mulInvariantVectorField_modelSpace`: the invariant vector field is jointly smooth in
-  its model-space generator and group argument.
 * `tangentToLeftInvariantDerivation`: the left-invariant derivation associated to a tangent vector
   at the identity.
 * `leftInvariantDerivationEquivGroupLieAlgebra`: the canonical linear equivalence between
@@ -89,79 +86,6 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-
-/-- The tangent Lie algebra of a Lie group is canonically linearly equivalent to the manifold
-model space. This makes explicit the identification implemented by Mathlib's `TangentSpace` type
-synonym. -/
-@[expose]
-noncomputable def groupLieAlgebraEquivModelSpace : GroupLieAlgebra I G ≃ₗ[𝕜] E :=
-  LinearEquiv.refl 𝕜 E
-
-/-- The tangent-to-model equivalence is the identity on underlying vectors. -/
-@[simp]
-theorem groupLieAlgebraEquivModelSpace_apply (v : GroupLieAlgebra I G) :
-    groupLieAlgebraEquivModelSpace v = v :=
-  rfl
-
-/-- The model-to-tangent equivalence is the identity on underlying vectors. -/
-@[simp]
-theorem groupLieAlgebraEquivModelSpace_symm_apply (v : E) :
-    (groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm v = v :=
-  rfl
-
-/-- In model coordinates, the invariant vector field is jointly `C^n` in its generating tangent
-vector and the group point when multiplication is `C^(n + 1)`.
-
-The separate `IsManifold I 2 G` hypothesis supplies the smooth tangent-bundle structure; it is
-independent of the regularity lost by differentiating multiplication. -/
-theorem contMDiff_mulInvariantVectorField_modelSpace {n : ℕ∞ω}
-    [IsManifold I 2 G] [ContMDiffMul I (n + 1) G] :
-    ContMDiff (𝓘(𝕜, E).prod I) I.tangent n
-      (fun p : E × G =>
-        (mulInvariantVectorField
-          ((groupLieAlgebraEquivModelSpace (I := I) (G := G)).symm p.1) p.2 :
-            TangentBundle I G)) := by
-  let fg : E × G → TangentBundle I G := fun p => TotalSpace.mk' E p.2 0
-  have sfg : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fg :=
-    (contMDiff_zeroSection 𝕜 (TangentSpace I : G → Type _)).comp contMDiff_snd
-  let fv : E × G → TangentBundle I G := fun p => TotalSpace.mk' E 1 p.1
-  have sfv : ContMDiff (𝓘(𝕜, E).prod I) I.tangent n fv := by
-    intro p
-    rw [Bundle.contMDiffAt_totalSpace]
-    constructor
-    · simpa only [fv] using
-        (contMDiffAt_const : ContMDiffAt (𝓘(𝕜, E).prod I) I n
-          (fun _ : E × G => (1 : G)) p)
-    · have hone : (1 : G) ∈ (extChartAt I (1 : G)).source := mem_extChartAt_source _
-      have hfun :
-          (fun q : E × G =>
-            (trivializationAt E (TangentSpace I) ((fv p).proj) (fv q)).2) = fun q => q.1 := by
-        funext q
-        rw [TangentBundle.trivializationAt_apply]
-        -- Both fibers are over `1`, so their coordinate change is the identity on the model space.
-        change tangentCoordChange I (1 : G) (1 : G) (1 : G) q.1 = q.1
-        rw [tangentCoordChange_self hone]
-      rw [hfun]
-      exact contMDiffAt_fst
-  let F₁ : E × G → TangentBundle I G × TangentBundle I G := fun p => (fg p, fv p)
-  have S₁ : ContMDiff (𝓘(𝕜, E).prod I) (I.tangent.prod I.tangent) n F₁ :=
-    sfg.prodMk sfv
-  let F₂ : TangentBundle I G × TangentBundle I G → TangentBundle (I.prod I) (G × G) :=
-    (equivTangentBundleProd I G I G).symm
-  have S₂ : ContMDiff (I.tangent.prod I.tangent) (I.prod I).tangent n F₂ :=
-    contMDiff_equivTangentBundleProd_symm
-  let F₃ : TangentBundle (I.prod I) (G × G) → TangentBundle I G :=
-    tangentMap% (fun p : G × G => p.1 * p.2)
-  have S₃ : ContMDiff (I.prod I).tangent I.tangent n F₃ :=
-    (contMDiff_mul I (n + 1)).contMDiff_tangentMap le_rfl
-  let S := (S₃.comp S₂).comp S₁
-  convert! S with p
-  · simp [F₁, F₂, F₃, fg, fv]
-  · simp only [comp_apply, tangentMap, F₃, F₂, F₁, fg, fv]
-    rw [mfderiv_prod_eq_add_apply
-      ((contMDiff_mul I (n + 1)).mdifferentiableAt (by simp))]
-    simp +instances [mulInvariantVectorField, equivTangentBundleProd]
-    rfl
 
 /-- Differentiating a smooth scalar function along a left-invariant vector field gives a smooth
 scalar function. -/


### PR DESCRIPTION
## Goal

Advance `RepresentationTheory/LieGroups`, Deliverable A, Layer 0, by constructing one local coordinate flow for the left-invariant ODE that works uniformly for all sufficiently small Lie-algebra parameters. This supplies the parameter-dependent-flow and continuity foundation required to prove smoothness of `lieExp`. It advances TauCetiProject/TauCetiRoadmap#139.

## Argument

Continuity of the exponential in its generator requires solving one ODE whose state contains both the fixed generator and the evolving group coordinate. The invariant vector field is therefore expressed on that product space. Its coordinate form is proved `C^n` from `C^(n + 1)` multiplication; the Picard--Lindelöf application consequently uses only the `n = 1` case instead of imposing infinite smoothness.

That finite regularity supplies a solution on a common time interval and state neighborhood, jointly continuous in the initial condition and time and uniformly Lipschitz in the initial state. The vanishing derivative of the generator coordinate shows that this parameter remains fixed along every trajectory.

The coordinate solution is then kept inside the identity chart and identified with Mathlib's canonical invariant integral curve, uniformly for nearby generators. These exported bridge and continuity results require only `LieGroup I (minSmoothness ℝ 3) G`, exactly the finite regularity needed by the argument. Finally, the invariant-curve scaling law transports a short nonzero time to time one, proving continuity of the model-space exponential at zero without claiming the later smooth-dependence result.

## Verification

- `bash scripts/sandbox-build.sh`
  - `lake build --iofail`: 6,459 jobs completed.
  - `lake exe axioms`: 21,614 Tau Ceti declarations audited; only `propext`, `Classical.choice`, and `Quot.sound`.
  - `lake exe module-system`: all 1,190 Tau Ceti modules participate.
  - `bash scripts/lint-env.sh`: 1,769 declarations documented, 1,189 modules linted, and no new violations.

Roadmap: RepresentationTheory
