### PR TITLE
feat: prove smoothness of continuous-map superposition

### DIFF
--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -4,9 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Calculus.ContDiff.Basic
+public import Mathlib.Analysis.Calculus.ContDiff.Comp
+public import Mathlib.Analysis.Calculus.MeanValue
 public import Mathlib.Analysis.Normed.Operator.Bilinear
 public import Mathlib.Topology.ContinuousMap.Compact
+public import Mathlib.Topology.UniformSpace.HeineCantor
 
 /-!
 # Calculus on spaces of continuous maps
@@ -20,6 +22,9 @@ spaces of continuous functions over a compact domain.
   continuous linear maps, as a bounded bilinear operator.
 * `ContinuousMap.hasStrictFDerivAt_comp_const`: strict differentiability of pointwise
   postcomposition at a constant map.
+* `ContinuousMap.hasFDerivAt_comp`: the derivative of pointwise postcomposition by a `C¹` map.
+* `ContinuousMap.contDiff_comp_nat`: finite-order smoothness of pointwise postcomposition.
+* `ContinuousMap.contDiff_comp_infty`: smoothness of pointwise postcomposition.
 
 ## References
 
@@ -29,9 +34,11 @@ spaces of continuous functions over a compact domain.
 
 public section
 
-open scoped ContinuousMap
+open scoped ContinuousMap ContDiff
 
 noncomputable section
+
+universe u
 
 namespace ContinuousMap
 
@@ -107,5 +114,101 @@ theorem hasStrictFDerivAt_comp_const (f : C(E, F)) (f' : E →L[𝕜] F) (x : E)
         applyContinuousLinearMap_apply, ContinuousMap.sub_apply] using hbound _ hpt
     _ ≤ c * ‖p.1 - p.2‖ :=
       mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (p.1 - p.2) t) hc.le
+
+end ContinuousMap
+
+namespace ContinuousMap
+
+variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
+  {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {F : Type u} [NormedAddCommGroup F] [NormedSpace ℝ F]
+
+/-- The continuous family of derivatives of a `C¹` map along a continuous map. -/
+@[expose]
+noncomputable def fderivComp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
+    C(K, E →L[ℝ] F) :=
+  ⟨fun t ↦ fderiv ℝ f (g t), (hf.continuous_fderiv one_ne_zero).comp g.continuous⟩
+
+omit [CompactSpace K] in
+@[simp]
+theorem fderivComp_apply (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) (t : K) :
+    fderivComp f hf g t = fderiv ℝ f (g t) :=
+  by
+    rw [fderivComp]
+    rfl
+
+/-- Pointwise postcomposition by a `C¹` map is Fréchet differentiable. Its derivative applies
+the derivative of the original map pointwise along the input function. -/
+theorem hasFDerivAt_comp (f : C(E, F)) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
+    HasFDerivAt (fun h : C(K, E) ↦ f.comp h)
+      (applyContinuousLinearMap (fderivComp f hf g)) g := by
+  rw [hasFDerivAt_iff_isLittleO, Asymptotics.isLittleO_iff]
+  intro c hc
+  have hcompact : IsCompact (Set.range g) := isCompact_range g.continuous
+  have hdf_cont : Continuous (fderiv ℝ f) := hf.continuous_fderiv one_ne_zero
+  have huniform := hcompact.uniformContinuousAt_of_continuousAt
+    (fderiv ℝ f) (fun _ _ ↦ hdf_cont.continuousAt) (Metric.dist_mem_uniformity hc)
+  obtain ⟨δ, hδ, hderiv⟩ := Metric.mem_uniformity_dist.mp huniform
+  rw [Metric.eventually_nhds_iff_ball]
+  refine ⟨δ, hδ, fun h hh ↦ ?_⟩
+  apply (ContinuousMap.norm_le _ (mul_nonneg hc.le (norm_nonneg _))).2
+  intro t
+  have htg : g t ∈ Set.range g := ⟨t, rfl⟩
+  have hpoint : dist (h t) (g t) < δ :=
+    (ContinuousMap.dist_apply_le_dist t).trans_lt hh
+  have hbound : ∀ z ∈ segment ℝ (g t) (h t),
+      ‖fderiv ℝ f z - fderiv ℝ f (g t)‖ ≤ c := by
+    intro z hz
+    have hzg : dist (g t) z < δ := by
+      rw [dist_comm]
+      simpa only [dist_eq_norm] using
+        (norm_sub_le_of_mem_segment hz).trans_lt (by simpa only [dist_eq_norm] using hpoint)
+    have hd := hderiv hzg htg
+    change dist (fderiv ℝ f (g t)) (fderiv ℝ f z) < c at hd
+    simpa only [dist_eq_norm, norm_sub_rev] using hd.le
+  calc
+    ‖(f.comp h - f.comp g - applyContinuousLinearMap (fderivComp f hf g) (h - g)) t‖ ≤
+        c * ‖h t - g t‖ := by
+      simpa only [ContinuousMap.comp_apply, ContinuousMap.sub_apply,
+        applyContinuousLinearMap_apply, fderivComp_apply] using
+        (convex_segment (g t) (h t)).norm_image_sub_le_of_norm_fderiv_le'
+          (fun _ _ ↦ hf.differentiable one_ne_zero _) hbound
+          (left_mem_segment ℝ (g t) (h t)) (right_mem_segment ℝ (g t) (h t))
+    _ ≤ c * ‖h - g‖ :=
+      mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (h - g) t) hc.le
+
+/-- Pointwise postcomposition by a `C^n` map is `C^n` on a compact-domain continuous-map space,
+for every finite differentiability order `n`. -/
+theorem contDiff_comp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
+    ContDiff ℝ n (fun g : C(K, E) ↦ f.comp g) := by
+  induction n generalizing F with
+  | zero =>
+      change ContDiff ℝ (0 : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g)
+      rw [contDiff_zero]
+      exact f.continuous_postcomp
+  | succ n ih =>
+      have hf' : ContDiff ℝ ((n : ℕ∞ω) + 1) f := by simpa using hf
+      let hf₁ : ContDiff ℝ 1 f := hf'.one_of_succ
+      let df : C(E, E →L[ℝ] F) := ⟨fderiv ℝ f, hf₁.continuous_fderiv one_ne_zero⟩
+      have hdf : ContDiff ℝ n df := (contDiff_succ_iff_fderiv.mp hf').2.2
+      have hcomp : ContDiff ℝ n (fun g : C(K, E) ↦ df.comp g) := ih df hdf
+      change ContDiff ℝ ((n : ℕ∞ω) + 1) (fun g : C(K, E) ↦ f.comp g)
+      rw [contDiff_succ_iff_hasFDerivAt]
+      refine ⟨fun g ↦ applyContinuousLinearMap (df.comp g),
+        applyContinuousLinearMap.contDiff.fun_comp hcomp, fun g ↦ ?_⟩
+      have hderiv := hasFDerivAt_comp f hf₁ g
+      have hfamily : df.comp g = fderivComp f hf₁ g := by
+        ext t
+        rfl
+      change HasFDerivAt (fun h : C(K, E) ↦ f.comp h)
+        (applyContinuousLinearMap (df.comp g)) g
+      rw [hfamily]
+      exact hderiv
+
+/-- Pointwise postcomposition by a smooth map is smooth on a compact-domain continuous-map
+space. -/
+theorem contDiff_comp_infty (f : C(E, F)) (hf : ContDiff ℝ ∞ f) :
+    ContDiff ℝ ∞ (fun g : C(K, E) ↦ f.comp g) :=
+  contDiff_infty.2 fun n ↦ contDiff_comp_nat n f ((contDiff_infty.mp hf) n)
 
 end ContinuousMap

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.ContDiff.Basic
+public import Mathlib.Analysis.Normed.Operator.Bilinear
+public import Mathlib.Topology.ContinuousMap.Compact
+
+/-!
+# Calculus on spaces of continuous maps
+
+This file develops the bounded pointwise operations needed to differentiate superposition maps on
+spaces of continuous functions over a compact domain.
+
+## Main results
+
+* `ContinuousMap.applyContinuousLinearMap`: pointwise application of a continuous family of
+  continuous linear maps, as a bounded bilinear operator.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The exponential map".
+-/
+
+public section
+
+open scoped ContinuousMap
+
+noncomputable section
+
+namespace ContinuousMap
+
+variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
+
+/-- Pointwise application of a continuous family of continuous linear maps to a continuous map,
+as a bounded bilinear operator. -/
+noncomputable def applyContinuousLinearMap :
+    C(K, E →L[𝕜] F) →L[𝕜] C(K, E) →L[𝕜] C(K, F) := by
+  let app (A : C(K, E →L[𝕜] F)) : C(K, E) →L[𝕜] C(K, F) :=
+    LinearMap.mkContinuous
+      { toFun := fun f => ⟨fun x => A x (f x), by fun_prop⟩
+        map_add' := fun _ _ => by ext x; simp
+        map_smul' := fun _ _ => by ext x; simp }
+      ‖A‖ fun f => by
+      apply (ContinuousMap.norm_le _
+        (mul_nonneg (norm_nonneg A) (norm_nonneg f))).2
+      intro x
+      exact (ContinuousLinearMap.le_opNorm (A x) (f x)).trans <|
+        mul_le_mul (norm_coe_le_norm A x) (norm_coe_le_norm f x)
+          (norm_nonneg _) (norm_nonneg _)
+  let L : C(K, E →L[𝕜] F) →ₗ[𝕜] C(K, E) →L[𝕜] C(K, F) :=
+    { toFun := app
+      map_add' := fun _ _ => by ext f x; simp [app]
+      map_smul' := fun _ _ => by ext f x; simp [app] }
+  exact LinearMap.mkContinuous (𝕜₂ := 𝕜) L 1 fun
+      (A : C(K, E →L[𝕜] F)) => by
+    change ‖app A‖ ≤ 1 * ‖A‖
+    rw [one_mul]
+    apply ContinuousLinearMap.opNorm_le_bound (app A) (norm_nonneg A)
+    intro f
+    apply (ContinuousMap.norm_le _
+      (mul_nonneg (norm_nonneg A) (norm_nonneg f))).2
+    intro x
+    exact (ContinuousLinearMap.le_opNorm (A x) (f x)).trans <|
+      mul_le_mul (norm_coe_le_norm A x) (norm_coe_le_norm f x)
+        (norm_nonneg _) (norm_nonneg _)
+
+@[simp]
+theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) (x : K) :
+    applyContinuousLinearMap A f x = A x (f x) :=
+  by
+    rw [applyContinuousLinearMap]
+    rfl
+
+end ContinuousMap

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -18,6 +18,8 @@ spaces of continuous functions over a compact domain.
 
 * `ContinuousMap.applyContinuousLinearMap`: pointwise application of a continuous family of
   continuous linear maps, as a bounded bilinear operator.
+* `ContinuousMap.hasStrictFDerivAt_comp_const`: strict differentiability of pointwise
+  postcomposition at a constant map.
 
 ## References
 
@@ -77,5 +79,33 @@ theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) 
   by
     rw [applyContinuousLinearMap]
     rfl
+
+/-- Strict differentiability of a map lifts to strict differentiability of pointwise
+postcomposition at a constant continuous map. The derivative acts pointwise by the original
+derivative. -/
+theorem hasStrictFDerivAt_comp_const (f : C(E, F)) (f' : E →L[𝕜] F) (x : E)
+    (hf : HasStrictFDerivAt f f' x) :
+    HasStrictFDerivAt (fun g : C(K, E) ↦ f.comp g)
+      (applyContinuousLinearMap (ContinuousMap.const K f')) (ContinuousMap.const K x) := by
+  rw [hasStrictFDerivAt_iff_isLittleO, Asymptotics.isLittleO_iff] at hf ⊢
+  intro c hc
+  obtain ⟨r, hr, hbound⟩ := Metric.eventually_nhds_iff_ball.mp (hf hc)
+  rw [Metric.eventually_nhds_iff_ball]
+  refine ⟨r, hr, fun p hp ↦ ?_⟩
+  apply (ContinuousMap.norm_le _ (mul_nonneg hc.le (norm_nonneg _))).2
+  intro t
+  have hpt : (p.1 t, p.2 t) ∈ Metric.ball (x, x) r := by
+    rw [Metric.mem_ball, Prod.dist_eq, max_lt_iff]
+    rw [Metric.mem_ball, Prod.dist_eq, max_lt_iff] at hp
+    exact ⟨(ContinuousMap.dist_apply_le_dist t).trans_lt hp.1,
+      (ContinuousMap.dist_apply_le_dist t).trans_lt hp.2⟩
+  calc
+    ‖(f.comp p.1 - f.comp p.2 -
+        applyContinuousLinearMap (ContinuousMap.const K f') (p.1 - p.2)) t‖ ≤
+        c * ‖p.1 t - p.2 t‖ := by
+      simpa only [ContinuousMap.comp_apply, ContinuousMap.const_apply,
+        applyContinuousLinearMap_apply, ContinuousMap.sub_apply] using hbound _ hpt
+    _ ≤ c * ‖p.1 - p.2‖ :=
+      mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (p.1 - p.2) t) hc.le
 
 end ContinuousMap

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -20,11 +20,10 @@ spaces of continuous functions over a compact domain.
 
 * `ContinuousMap.applyContinuousLinearMap`: pointwise application of a continuous family of
   continuous linear maps, as a bounded bilinear operator.
-* `ContinuousMap.hasStrictFDerivAt_comp_const`: strict differentiability of pointwise
+* `ContinuousMap.hasStrictFDerivAt_postcomp_const`: strict differentiability of pointwise
   postcomposition at a constant map.
-* `ContinuousMap.hasFDerivAt_comp`: the derivative of pointwise postcomposition by a `C¹` map.
-* `ContinuousMap.contDiff_comp_nat`: finite-order smoothness of pointwise postcomposition.
-* `ContinuousMap.contDiff_comp_infty`: smoothness of pointwise postcomposition.
+* `ContinuousMap.hasFDerivAt_postcomp`: the derivative of pointwise postcomposition by a `C¹` map.
+* `ContinuousMap.contDiff_postcomp`: finite-order or smooth pointwise postcomposition.
 
 ## References
 
@@ -38,7 +37,7 @@ open scoped ContinuousMap ContDiff
 
 noncomputable section
 
-universe u
+universe u v
 
 namespace ContinuousMap
 
@@ -51,36 +50,24 @@ variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
 as a bounded bilinear operator. -/
 noncomputable def applyContinuousLinearMap :
     C(K, E →L[𝕜] F) →L[𝕜] C(K, E) →L[𝕜] C(K, F) := by
-  let app (A : C(K, E →L[𝕜] F)) : C(K, E) →L[𝕜] C(K, F) :=
-    LinearMap.mkContinuous
-      { toFun := fun f => ⟨fun x => A x (f x), by fun_prop⟩
-        map_add' := fun _ _ => by ext x; simp
-        map_smul' := fun _ _ => by ext x; simp }
-      ‖A‖ fun f => by
+  let L : C(K, E →L[𝕜] F) →ₗ[𝕜] C(K, E) →ₗ[𝕜] C(K, F) :=
+    { toFun := fun A =>
+        { toFun := fun f => ⟨fun x => A x (f x), by fun_prop⟩
+          map_add' := fun _ _ => by ext x; simp
+          map_smul' := fun _ _ => by ext x; simp }
+      map_add' := fun _ _ => by ext f x; simp
+      map_smul' := fun _ _ => by ext f x; simp }
+  exact LinearMap.mkContinuous₂ (𝕜 := 𝕜) (𝕜₂ := 𝕜) (𝕜₃ := 𝕜)
+    (σ₁₃ := RingHom.id 𝕜) (σ₂₃ := RingHom.id 𝕜) L 1 fun
+      (A : C(K, E →L[𝕜] F)) (f : C(K, E)) => by
+      rw [one_mul]
+      change ‖(⟨fun x => A x (f x), by fun_prop⟩ : C(K, F))‖ ≤ ‖A‖ * ‖f‖
       apply (ContinuousMap.norm_le _
         (mul_nonneg (norm_nonneg A) (norm_nonneg f))).2
       intro x
       exact (ContinuousLinearMap.le_opNorm (A x) (f x)).trans <|
         mul_le_mul (norm_coe_le_norm A x) (norm_coe_le_norm f x)
           (norm_nonneg _) (norm_nonneg _)
-  let L : C(K, E →L[𝕜] F) →ₗ[𝕜] C(K, E) →L[𝕜] C(K, F) :=
-    { toFun := app
-      map_add' := fun _ _ => by ext f x; simp [app]
-      map_smul' := fun _ _ => by ext f x; simp [app] }
-  exact LinearMap.mkContinuous (𝕜₂ := 𝕜) L 1 fun
-      (A : C(K, E →L[𝕜] F)) => by
-    have hL_apply : L A = app A := by
-      rfl
-    rw [hL_apply]
-    rw [one_mul]
-    apply ContinuousLinearMap.opNorm_le_bound (app A) (norm_nonneg A)
-    intro f
-    apply (ContinuousMap.norm_le _
-      (mul_nonneg (norm_nonneg A) (norm_nonneg f))).2
-    intro x
-    exact (ContinuousLinearMap.le_opNorm (A x) (f x)).trans <|
-      mul_le_mul (norm_coe_le_norm A x) (norm_coe_le_norm f x)
-        (norm_nonneg _) (norm_nonneg _)
 
 @[simp]
 theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) (x : K) :
@@ -92,7 +79,7 @@ theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) 
 /-- Strict differentiability of a map lifts to strict differentiability of pointwise
 postcomposition at a constant continuous map. The derivative acts pointwise by the original
 derivative. -/
-theorem hasStrictFDerivAt_comp_const (f : C(E, F)) (f' : E →L[𝕜] F) (x : E)
+theorem hasStrictFDerivAt_postcomp_const (f : C(E, F)) (f' : E →L[𝕜] F) (x : E)
     (hf : HasStrictFDerivAt f f' x) :
     HasStrictFDerivAt (fun g : C(K, E) ↦ f.comp g)
       (applyContinuousLinearMap (ContinuousMap.const K f')) (ContinuousMap.const K x) := by
@@ -123,7 +110,7 @@ namespace ContinuousMap
 
 variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
   {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {F : Type u} [NormedAddCommGroup F] [NormedSpace ℝ F]
+  {F : Type (max u v)} [NormedAddCommGroup F] [NormedSpace ℝ F]
 
 /-- The continuous family of derivatives of a `C¹` map along a continuous map. -/
 noncomputable def fderivComp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
@@ -140,8 +127,8 @@ theorem fderivComp_apply (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) (t 
 
 /-- Pointwise postcomposition by a `C¹` map is Fréchet differentiable. Its derivative applies
 the derivative of the original map pointwise along the input function. -/
-theorem hasFDerivAt_comp (f : C(E, F)) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
-    HasFDerivAt (fun h : C(K, E) ↦ f.comp h)
+theorem hasFDerivAt_postcomp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
+    HasFDerivAt (fun h : C(K, E) ↦ (⟨f, hf.continuous⟩ : C(E, F)).comp h)
       (applyContinuousLinearMap (fderivComp f hf g)) g := by
   rw [hasFDerivAt_iff_isLittleO, Asymptotics.isLittleO_iff]
   intro c hc
@@ -168,19 +155,20 @@ theorem hasFDerivAt_comp (f : C(E, F)) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
     have hd' : dist (fderiv ℝ f (g t)) (fderiv ℝ f z) < c := hd
     simpa only [dist_eq_norm, norm_sub_rev] using hd'.le
   calc
-    ‖(f.comp h - f.comp g - applyContinuousLinearMap (fderivComp f hf g) (h - g)) t‖ ≤
+    ‖((⟨f, hf.continuous⟩ : C(E, F)).comp h -
+        (⟨f, hf.continuous⟩ : C(E, F)).comp g -
+        applyContinuousLinearMap (fderivComp f hf g) (h - g)) t‖ ≤
         c * ‖h t - g t‖ := by
-      simpa only [ContinuousMap.comp_apply, ContinuousMap.sub_apply,
-        applyContinuousLinearMap_apply, fderivComp_apply] using
-        (convex_segment (g t) (h t)).norm_image_sub_le_of_norm_fderiv_le'
-          (fun _ _ ↦ hf.differentiable one_ne_zero _) hbound
-          (left_mem_segment ℝ (g t) (h t)) (right_mem_segment ℝ (g t) (h t))
+      rw [ContinuousMap.sub_apply, ContinuousMap.sub_apply,
+        ContinuousMap.comp_apply, ContinuousMap.comp_apply,
+        applyContinuousLinearMap_apply, fderivComp_apply]
+      exact (convex_segment (g t) (h t)).norm_image_sub_le_of_norm_fderiv_le'
+        (fun _ _ ↦ hf.differentiable one_ne_zero _) hbound
+        (left_mem_segment ℝ (g t) (h t)) (right_mem_segment ℝ (g t) (h t))
     _ ≤ c * ‖h - g‖ :=
       mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (h - g) t) hc.le
 
-/-- Pointwise postcomposition by a `C^n` map is `C^n` on a compact-domain continuous-map space,
-for every finite differentiability order `n`. -/
-theorem contDiff_comp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
+private theorem contDiff_postcomp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
     ContDiff ℝ n (fun g : C(K, E) ↦ f.comp g) := by
   induction n generalizing F with
   | zero =>
@@ -198,20 +186,35 @@ theorem contDiff_comp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
         rw [contDiff_succ_iff_hasFDerivAt]
         refine ⟨fun g ↦ applyContinuousLinearMap (df.comp g),
           applyContinuousLinearMap.contDiff.fun_comp hcomp, fun g ↦ ?_⟩
-        have hderiv := hasFDerivAt_comp f hf₁ g
+        have hderiv := hasFDerivAt_postcomp (f : E → F) hf₁ g
         have hfamily : df.comp g = fderivComp f hf₁ g := by
           apply ContinuousMap.ext
           intro t
           have hdf_apply : df (g t) = fderiv ℝ f (g t) := by
             rfl
           rw [ContinuousMap.comp_apply, hdf_apply, fderivComp_apply]
+        have hfc : (⟨(f : E → F), hf₁.continuous⟩ : C(E, F)) = f := by
+          ext x
+          rfl
+        rw [hfc] at hderiv
         simpa only [hfamily] using hderiv
       simpa using hsucc
 
-/-- Pointwise postcomposition by a smooth map is smooth on a compact-domain continuous-map
-space. -/
-theorem contDiff_comp_infty (f : C(E, F)) (hf : ContDiff ℝ ∞ f) :
-    ContDiff ℝ ∞ (fun g : C(K, E) ↦ f.comp g) :=
-  contDiff_infty.2 fun n ↦ contDiff_comp_nat n f ((contDiff_infty.mp hf) n)
+/-- Pointwise postcomposition by a `C^n` map is `C^n` on a compact-domain continuous-map space,
+for every finite or infinite differentiability order `n`. -/
+theorem contDiff_postcomp (n : ℕ∞) (f : E → F) (hf : ContDiff ℝ (n : ℕ∞ω) f) :
+    ContDiff ℝ (n : ℕ∞ω)
+      (fun g : C(K, E) ↦ (⟨f, hf.continuous⟩ : C(E, F)).comp g) := by
+  induction n using ENat.recTopCoe with
+  | top =>
+      have hfInf : ContDiff ℝ ∞ f := by simpa using hf
+      let fc : C(E, F) := ⟨f, hfInf.continuous⟩
+      change ContDiff ℝ ∞ (fun g : C(K, E) => fc.comp g)
+      exact contDiff_infty.2 fun m =>
+        contDiff_postcomp_nat m fc ((contDiff_infty.mp hfInf) m)
+  | coe n =>
+      let fc : C(E, F) := ⟨f, hf.continuous⟩
+      change ContDiff ℝ n (fun g : C(K, E) => fc.comp g)
+      exact contDiff_postcomp_nat n fc hf
 
 end ContinuousMap

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -69,7 +69,9 @@ noncomputable def applyContinuousLinearMap :
       map_smul' := fun _ _ => by ext f x; simp [app] }
   exact LinearMap.mkContinuous (𝕜₂ := 𝕜) L 1 fun
       (A : C(K, E →L[𝕜] F)) => by
-    change ‖app A‖ ≤ 1 * ‖A‖
+    have hL_apply : L A = app A := by
+      rfl
+    rw [hL_apply]
     rw [one_mul]
     apply ContinuousLinearMap.opNorm_le_bound (app A) (norm_nonneg A)
     intro f
@@ -124,7 +126,6 @@ variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
   {F : Type u} [NormedAddCommGroup F] [NormedSpace ℝ F]
 
 /-- The continuous family of derivatives of a `C¹` map along a continuous map. -/
-@[expose]
 noncomputable def fderivComp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
     C(K, E →L[ℝ] F) :=
   ⟨fun t ↦ fderiv ℝ f (g t), (hf.continuous_fderiv one_ne_zero).comp g.continuous⟩
@@ -164,8 +165,8 @@ theorem hasFDerivAt_comp (f : C(E, F)) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
       simpa only [dist_eq_norm] using
         (norm_sub_le_of_mem_segment hz).trans_lt (by simpa only [dist_eq_norm] using hpoint)
     have hd := hderiv hzg htg
-    change dist (fderiv ℝ f (g t)) (fderiv ℝ f z) < c at hd
-    simpa only [dist_eq_norm, norm_sub_rev] using hd.le
+    have hd' : dist (fderiv ℝ f (g t)) (fderiv ℝ f z) < c := hd
+    simpa only [dist_eq_norm, norm_sub_rev] using hd'.le
   calc
     ‖(f.comp h - f.comp g - applyContinuousLinearMap (fderivComp f hf g) (h - g)) t‖ ≤
         c * ‖h t - g t‖ := by
@@ -183,27 +184,29 @@ theorem contDiff_comp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
     ContDiff ℝ n (fun g : C(K, E) ↦ f.comp g) := by
   induction n generalizing F with
   | zero =>
-      change ContDiff ℝ (0 : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g)
-      rw [contDiff_zero]
-      exact f.continuous_postcomp
+      have hzero : ContDiff ℝ (0 : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g) := by
+        rw [contDiff_zero]
+        exact f.continuous_postcomp
+      simpa using hzero
   | succ n ih =>
       have hf' : ContDiff ℝ ((n : ℕ∞ω) + 1) f := by simpa using hf
       let hf₁ : ContDiff ℝ 1 f := hf'.one_of_succ
       let df : C(E, E →L[ℝ] F) := ⟨fderiv ℝ f, hf₁.continuous_fderiv one_ne_zero⟩
       have hdf : ContDiff ℝ n df := (contDiff_succ_iff_fderiv.mp hf').2.2
       have hcomp : ContDiff ℝ n (fun g : C(K, E) ↦ df.comp g) := ih df hdf
-      change ContDiff ℝ ((n : ℕ∞ω) + 1) (fun g : C(K, E) ↦ f.comp g)
-      rw [contDiff_succ_iff_hasFDerivAt]
-      refine ⟨fun g ↦ applyContinuousLinearMap (df.comp g),
-        applyContinuousLinearMap.contDiff.fun_comp hcomp, fun g ↦ ?_⟩
-      have hderiv := hasFDerivAt_comp f hf₁ g
-      have hfamily : df.comp g = fderivComp f hf₁ g := by
-        ext t
-        rfl
-      change HasFDerivAt (fun h : C(K, E) ↦ f.comp h)
-        (applyContinuousLinearMap (df.comp g)) g
-      rw [hfamily]
-      exact hderiv
+      have hsucc : ContDiff ℝ ((n : ℕ∞ω) + 1) (fun g : C(K, E) ↦ f.comp g) := by
+        rw [contDiff_succ_iff_hasFDerivAt]
+        refine ⟨fun g ↦ applyContinuousLinearMap (df.comp g),
+          applyContinuousLinearMap.contDiff.fun_comp hcomp, fun g ↦ ?_⟩
+        have hderiv := hasFDerivAt_comp f hf₁ g
+        have hfamily : df.comp g = fderivComp f hf₁ g := by
+          apply ContinuousMap.ext
+          intro t
+          have hdf_apply : df (g t) = fderiv ℝ f (g t) := by
+            rfl
+          rw [ContinuousMap.comp_apply, hdf_apply, fderivComp_apply]
+        simpa only [hfamily] using hderiv
+      simpa using hsucc
 
 /-- Pointwise postcomposition by a smooth map is smooth on a compact-domain continuous-map
 space. -/

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -20,8 +20,6 @@ spaces of continuous functions over a compact domain.
 
 * `ContinuousMap.applyContinuousLinearMap`: pointwise application of a continuous family of
   continuous linear maps, as a bounded bilinear operator.
-* `ContinuousMap.hasStrictFDerivAt_postcomp_const`: strict differentiability of pointwise
-  postcomposition at a constant map.
 * `ContinuousMap.hasFDerivAt_postcomp`: the derivative of pointwise postcomposition by a `C¹` map.
 * `ContinuousMap.contDiff_postcomp`: finite-order or smooth pointwise postcomposition.
 
@@ -61,7 +59,6 @@ noncomputable def applyContinuousLinearMap :
     (σ₁₃ := RingHom.id 𝕜) (σ₂₃ := RingHom.id 𝕜) L 1 fun
       (A : C(K, E →L[𝕜] F)) (f : C(K, E)) => by
       rw [one_mul]
-      change ‖(⟨fun x => A x (f x), by fun_prop⟩ : C(K, F))‖ ≤ ‖A‖ * ‖f‖
       apply (ContinuousMap.norm_le _
         (mul_nonneg (norm_nonneg A) (norm_nonneg f))).2
       intro x
@@ -72,70 +69,33 @@ noncomputable def applyContinuousLinearMap :
 @[simp]
 theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) (x : K) :
     applyContinuousLinearMap A f x = A x (f x) :=
-  by
-    rw [applyContinuousLinearMap]
-    rfl
-
-/-- Strict differentiability of a map lifts to strict differentiability of pointwise
-postcomposition at a constant continuous map. The derivative acts pointwise by the original
-derivative. -/
-theorem hasStrictFDerivAt_postcomp_const (f : C(E, F)) (f' : E →L[𝕜] F) (x : E)
-    (hf : HasStrictFDerivAt f f' x) :
-    HasStrictFDerivAt (fun g : C(K, E) ↦ f.comp g)
-      (applyContinuousLinearMap (ContinuousMap.const K f')) (ContinuousMap.const K x) := by
-  rw [hasStrictFDerivAt_iff_isLittleO, Asymptotics.isLittleO_iff] at hf ⊢
-  intro c hc
-  obtain ⟨r, hr, hbound⟩ := Metric.eventually_nhds_iff_ball.mp (hf hc)
-  rw [Metric.eventually_nhds_iff_ball]
-  refine ⟨r, hr, fun p hp ↦ ?_⟩
-  apply (ContinuousMap.norm_le _ (mul_nonneg hc.le (norm_nonneg _))).2
-  intro t
-  have hpt : (p.1 t, p.2 t) ∈ Metric.ball (x, x) r := by
-    rw [Metric.mem_ball, Prod.dist_eq, max_lt_iff]
-    rw [Metric.mem_ball, Prod.dist_eq, max_lt_iff] at hp
-    exact ⟨(ContinuousMap.dist_apply_le_dist t).trans_lt hp.1,
-      (ContinuousMap.dist_apply_le_dist t).trans_lt hp.2⟩
-  calc
-    ‖(f.comp p.1 - f.comp p.2 -
-        applyContinuousLinearMap (ContinuousMap.const K f') (p.1 - p.2)) t‖ ≤
-        c * ‖p.1 t - p.2 t‖ := by
-      simpa only [ContinuousMap.comp_apply, ContinuousMap.const_apply,
-        applyContinuousLinearMap_apply, ContinuousMap.sub_apply] using hbound _ hpt
-    _ ≤ c * ‖p.1 - p.2‖ :=
-      mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (p.1 - p.2) t) hc.le
+  by simp [applyContinuousLinearMap]
 
 end ContinuousMap
 
 namespace ContinuousMap
 
 variable {K : Type*} [TopologicalSpace K] [CompactSpace K]
-  {E : Type u} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {F : Type (max u v)} [NormedAddCommGroup F] [NormedSpace ℝ F]
-
-/-- The continuous family of derivatives of a `C¹` map along a continuous map. -/
-noncomputable def fderivComp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
-    C(K, E →L[ℝ] F) :=
-  ⟨fun t ↦ fderiv ℝ f (g t), (hf.continuous_fderiv one_ne_zero).comp g.continuous⟩
-
-omit [CompactSpace K] in
-@[simp]
-theorem fderivComp_apply (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) (t : K) :
-    fderivComp f hf g t = fderiv ℝ f (g t) :=
-  by
-    rw [fderivComp]
-    rfl
+  {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
+  {E : Type u} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  -- The induction replaces `F` by `E →L[𝕜] F`; cumulativity still lets callers instantiate this
+  -- with a codomain from any universe, while `max u v` keeps every derivative family in one level.
+  {F : Type (max u v)} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
 
 /-- Pointwise postcomposition by a `C¹` map is Fréchet differentiable. Its derivative applies
 the derivative of the original map pointwise along the input function. -/
-theorem hasFDerivAt_postcomp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E)) :
-    HasFDerivAt (fun h : C(K, E) ↦ (⟨f, hf.continuous⟩ : C(E, F)).comp h)
-      (applyContinuousLinearMap (fderivComp f hf g)) g := by
+theorem hasFDerivAt_postcomp (f : C(E, F)) (hf : ContDiff 𝕜 1 f) (g : C(K, E)) :
+    HasFDerivAt (fun h : C(K, E) ↦ f.comp h)
+      (applyContinuousLinearMap
+        ((⟨fderiv 𝕜 f, hf.continuous_fderiv one_ne_zero⟩ : C(E, E →L[𝕜] F)).comp g)) g := by
+  let : RCLike 𝕜 := IsRCLikeNormedField.rclike 𝕜
+  let _ : NormedSpace ℝ E := NormedSpace.restrictScalars ℝ 𝕜 E
   rw [hasFDerivAt_iff_isLittleO, Asymptotics.isLittleO_iff]
   intro c hc
   have hcompact : IsCompact (Set.range g) := isCompact_range g.continuous
-  have hdf_cont : Continuous (fderiv ℝ f) := hf.continuous_fderiv one_ne_zero
+  have hdf_cont : Continuous (fderiv 𝕜 f) := hf.continuous_fderiv one_ne_zero
   have huniform := hcompact.uniformContinuousAt_of_continuousAt
-    (fderiv ℝ f) (fun _ _ ↦ hdf_cont.continuousAt) (Metric.dist_mem_uniformity hc)
+    (fderiv 𝕜 f) (fun _ _ ↦ hdf_cont.continuousAt) (Metric.dist_mem_uniformity hc)
   obtain ⟨δ, hδ, hderiv⟩ := Metric.mem_uniformity_dist.mp huniform
   rw [Metric.eventually_nhds_iff_ball]
   refine ⟨δ, hδ, fun h hh ↦ ?_⟩
@@ -145,76 +105,61 @@ theorem hasFDerivAt_postcomp (f : E → F) (hf : ContDiff ℝ 1 f) (g : C(K, E))
   have hpoint : dist (h t) (g t) < δ :=
     (ContinuousMap.dist_apply_le_dist t).trans_lt hh
   have hbound : ∀ z ∈ segment ℝ (g t) (h t),
-      ‖fderiv ℝ f z - fderiv ℝ f (g t)‖ ≤ c := by
+      ‖fderiv 𝕜 f z - fderiv 𝕜 f (g t)‖ ≤ c := by
     intro z hz
     have hzg : dist (g t) z < δ := by
       rw [dist_comm]
       simpa only [dist_eq_norm] using
         (norm_sub_le_of_mem_segment hz).trans_lt (by simpa only [dist_eq_norm] using hpoint)
     have hd := hderiv hzg htg
-    have hd' : dist (fderiv ℝ f (g t)) (fderiv ℝ f z) < c := hd
+    have hd' : dist (fderiv 𝕜 f (g t)) (fderiv 𝕜 f z) < c := hd
     simpa only [dist_eq_norm, norm_sub_rev] using hd'.le
   calc
-    ‖((⟨f, hf.continuous⟩ : C(E, F)).comp h -
-        (⟨f, hf.continuous⟩ : C(E, F)).comp g -
-        applyContinuousLinearMap (fderivComp f hf g) (h - g)) t‖ ≤
+    ‖(f.comp h - f.comp g -
+        applyContinuousLinearMap
+          ((⟨fderiv 𝕜 f, hf.continuous_fderiv one_ne_zero⟩ : C(E, E →L[𝕜] F)).comp g)
+          (h - g)) t‖ ≤
         c * ‖h t - g t‖ := by
       rw [ContinuousMap.sub_apply, ContinuousMap.sub_apply,
         ContinuousMap.comp_apply, ContinuousMap.comp_apply,
-        applyContinuousLinearMap_apply, fderivComp_apply]
-      exact (convex_segment (g t) (h t)).norm_image_sub_le_of_norm_fderiv_le'
+        applyContinuousLinearMap_apply]
+      exact (convex_segment (𝕜 := ℝ) (g t) (h t)).norm_image_sub_le_of_norm_fderiv_le'
         (fun _ _ ↦ hf.differentiable one_ne_zero _) hbound
         (left_mem_segment ℝ (g t) (h t)) (right_mem_segment ℝ (g t) (h t))
     _ ≤ c * ‖h - g‖ :=
       mul_le_mul_of_nonneg_left (ContinuousMap.norm_coe_le_norm (h - g) t) hc.le
 
-private theorem contDiff_postcomp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff ℝ n f) :
-    ContDiff ℝ n (fun g : C(K, E) ↦ f.comp g) := by
+private theorem contDiff_postcomp_nat (n : ℕ) (f : C(E, F)) (hf : ContDiff 𝕜 n f) :
+    ContDiff 𝕜 n (fun g : C(K, E) ↦ f.comp g) := by
   induction n generalizing F with
   | zero =>
-      have hzero : ContDiff ℝ (0 : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g) := by
+      have hzero : ContDiff 𝕜 (0 : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g) := by
         rw [contDiff_zero]
         exact f.continuous_postcomp
       simpa using hzero
   | succ n ih =>
-      have hf' : ContDiff ℝ ((n : ℕ∞ω) + 1) f := by simpa using hf
-      let hf₁ : ContDiff ℝ 1 f := hf'.one_of_succ
-      let df : C(E, E →L[ℝ] F) := ⟨fderiv ℝ f, hf₁.continuous_fderiv one_ne_zero⟩
-      have hdf : ContDiff ℝ n df := (contDiff_succ_iff_fderiv.mp hf').2.2
-      have hcomp : ContDiff ℝ n (fun g : C(K, E) ↦ df.comp g) := ih df hdf
-      have hsucc : ContDiff ℝ ((n : ℕ∞ω) + 1) (fun g : C(K, E) ↦ f.comp g) := by
+      have hf' : ContDiff 𝕜 ((n : ℕ∞ω) + 1) f := by simpa using hf
+      let hf₁ : ContDiff 𝕜 1 f := hf'.one_of_succ
+      let df : C(E, E →L[𝕜] F) := ⟨fderiv 𝕜 f, hf₁.continuous_fderiv one_ne_zero⟩
+      have hdf : ContDiff 𝕜 n df := (contDiff_succ_iff_fderiv.mp hf').2.2
+      have hcomp : ContDiff 𝕜 n (fun g : C(K, E) ↦ df.comp g) := ih df hdf
+      have hsucc : ContDiff 𝕜 ((n : ℕ∞ω) + 1) (fun g : C(K, E) ↦ f.comp g) := by
         rw [contDiff_succ_iff_hasFDerivAt]
         refine ⟨fun g ↦ applyContinuousLinearMap (df.comp g),
           applyContinuousLinearMap.contDiff.fun_comp hcomp, fun g ↦ ?_⟩
-        have hderiv := hasFDerivAt_postcomp (f : E → F) hf₁ g
-        have hfamily : df.comp g = fderivComp f hf₁ g := by
-          apply ContinuousMap.ext
-          intro t
-          have hdf_apply : df (g t) = fderiv ℝ f (g t) := by
-            rfl
-          rw [ContinuousMap.comp_apply, hdf_apply, fderivComp_apply]
-        have hfc : (⟨(f : E → F), hf₁.continuous⟩ : C(E, F)) = f := by
-          ext x
-          rfl
-        rw [hfc] at hderiv
-        simpa only [hfamily] using hderiv
+        exact hasFDerivAt_postcomp f hf₁ g
       simpa using hsucc
 
 /-- Pointwise postcomposition by a `C^n` map is `C^n` on a compact-domain continuous-map space,
 for every finite or infinite differentiability order `n`. -/
-theorem contDiff_postcomp (n : ℕ∞) (f : E → F) (hf : ContDiff ℝ (n : ℕ∞ω) f) :
-    ContDiff ℝ (n : ℕ∞ω)
-      (fun g : C(K, E) ↦ (⟨f, hf.continuous⟩ : C(E, F)).comp g) := by
+theorem contDiff_postcomp (n : ℕ∞) (f : C(E, F)) (hf : ContDiff 𝕜 (n : ℕ∞ω) f) :
+    ContDiff 𝕜 (n : ℕ∞ω) (fun g : C(K, E) ↦ f.comp g) := by
   induction n using ENat.recTopCoe with
   | top =>
-      have hfInf : ContDiff ℝ ∞ f := by simpa using hf
-      let fc : C(E, F) := ⟨f, hfInf.continuous⟩
-      change ContDiff ℝ ∞ (fun g : C(K, E) => fc.comp g)
+      have hfInf : ContDiff 𝕜 ∞ f := by simpa using hf
       exact contDiff_infty.2 fun m =>
-        contDiff_postcomp_nat m fc ((contDiff_infty.mp hfInf) m)
+        contDiff_postcomp_nat m f ((contDiff_infty.mp hfInf) m)
   | coe n =>
-      let fc : C(E, F) := ⟨f, hf.continuous⟩
-      change ContDiff ℝ n (fun g : C(K, E) => fc.comp g)
-      exact contDiff_postcomp_nat n fc hf
+      exact contDiff_postcomp_nat n f hf
 
 end ContinuousMap


### PR DESCRIPTION
## Goal

Supply the function-space calculus required for smooth parameter dependence of invariant integral curves. The fixed-point construction lives on a Banach space of continuous paths, so finite-dimensional smoothness must lift to pointwise postcomposition on that path space.

## Argument

Pointwise application of a continuous family of derivatives first has to be a bounded bilinear operator on continuous-map spaces; `applyContinuousLinearMap` packages precisely that operation.

For a `C¹` continuous map, compactness makes its derivative uniformly continuous along each input path's compact range. The mean-value estimate then upgrades the pointwise remainder bound to a uniform-norm Fréchet derivative for postcomposition. This argument is valid over any RCLike normed field.

Finite-order smoothness follows by induction: the derivative is the bounded application operator composed with postcomposition by the continuous derivative family. Iterating that argument proves every finite order, and the infinite case follows by satisfying all finite orders. The public API consequently accepts the already-bundled continuous map directly and exposes no derivative-family wrapper of its own.

## Verification

- `bash scripts/sandbox-build.sh`
  - `lake build --iofail`: 6,459 jobs completed.
  - `lake exe axioms`: 21,636 Tau Ceti declarations audited; only `propext`, `Classical.choice`, and `Quot.sound`.
  - `lake exe module-system`: all 1,190 Tau Ceti modules participate.
  - `bash scripts/lint-env.sh`: 1,769 declarations documented, 1,189 modules linted, and no new violations.
- `git diff --check`

Advances [TauCetiRoadmap#139](https://github.com/TauCetiProject/TauCetiRoadmap/issues/139) and [`RepresentationTheory/LieGroups`, Deliverable A, Layer 0, “The exponential map”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md).

Roadmap: RepresentationTheory
