### PR TITLE
feat: integrate continuous paths linearly

### DIFF
--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -10,13 +10,14 @@ public import Mathlib.Analysis.Normed.Operator.Bilinear
 public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Topology.ContinuousMap.Compact
+public import Mathlib.Topology.ContinuousMap.Interval
 public import Mathlib.Topology.UniformSpace.HeineCantor
 
 /-!
 # Calculus on spaces of continuous maps
 
-This file develops the bounded pointwise operations needed to differentiate superposition maps on
-spaces of continuous functions over a compact domain.
+This file develops bounded pointwise operations for differentiating superposition maps, together
+with bounded integration operators on continuous paths for constructing Picard residuals.
 
 ## Main results
 
@@ -85,48 +86,54 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E
 
 /-- The primitive of a continuous path on a compact real interval, using constant extension before
 integration. -/
-private noncomputable def intervalPrimitive (a b : ℝ) (hab : a ≤ b)
+private noncomputable def intervalPrimitive (a b : ℝ) [Fact (a ≤ b)]
     (f : C(Set.Icc a b, E)) : C(Set.Icc a b, E) :=
-  ⟨fun t ↦ ∫ s in a..t, f (Set.projIcc a b hab s),
+  ⟨fun t ↦ ∫ s in a..t, IccExtendCM f s,
     (intervalIntegral.continuous_primitive
-      (fun x y ↦ (f.continuous.comp continuous_projIcc).intervalIntegrable x y) a).comp
+      (fun x y ↦ (IccExtendCM f).continuous.intervalIntegrable x y) a).comp
         continuous_subtype_val⟩
 
 omit [CompleteSpace E] in
-private theorem intervalPrimitive_apply (a b : ℝ) (hab : a ≤ b)
+private theorem intervalPrimitive_apply (a b : ℝ) [Fact (a ≤ b)]
     (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
-    intervalPrimitive a b hab f t = ∫ s in a..t, f (Set.projIcc a b hab s) := rfl
+    intervalPrimitive a b f t = ∫ s in a..t, IccExtendCM f s := rfl
 
 /-- Volterra integration as a continuous linear operator on continuous paths over an arbitrary
 compact real interval. The input is extended constantly outside the interval before integration. -/
 noncomputable def intervalIntegralOperator (a b : ℝ) (hab : a ≤ b) :
     C(Set.Icc a b, E) →L[ℝ] C(Set.Icc a b, E) := by
+  let _ : Fact (a ≤ b) := ⟨hab⟩
   let L : C(Set.Icc a b, E) →ₗ[ℝ] C(Set.Icc a b, E) :=
-    { toFun := intervalPrimitive a b hab
+    { toFun := intervalPrimitive a b
       map_add' := fun f g ↦ by
         ext t
         rw [intervalPrimitive_apply, ContinuousMap.add_apply, intervalPrimitive_apply,
           intervalPrimitive_apply]
+        rw [show IccExtendCM (f + g) = IccExtendCM f + IccExtendCM g by
+          ext s
+          rfl]
         exact intervalIntegral.integral_add
-          ((f.continuous.comp continuous_projIcc).intervalIntegrable _ _)
-          ((g.continuous.comp continuous_projIcc).intervalIntegrable _ _)
+          ((IccExtendCM f).continuous.intervalIntegrable _ _)
+          ((IccExtendCM g).continuous.intervalIntegrable _ _)
       map_smul' := fun c f ↦ by
         ext t
         rw [intervalPrimitive_apply, ContinuousMap.smul_apply, intervalPrimitive_apply]
+        rw [show IccExtendCM (c • f) = c • IccExtendCM f by
+          ext s
+          rfl]
         simpa only [ContinuousMap.smul_apply, RingHom.id_apply] using
-          intervalIntegral.integral_smul c
-            (fun s ↦ f (Set.projIcc a b hab s)) }
+          intervalIntegral.integral_smul c (IccExtendCM f) }
   have L_apply (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
-      L f t = intervalPrimitive a b hab f t := rfl
+      L f t = intervalPrimitive a b f t := rfl
   exact LinearMap.mkContinuous L (b - a) fun f ↦ by
     apply (ContinuousMap.norm_le _
       (mul_nonneg (sub_nonneg.mpr hab) (norm_nonneg f))).2
     intro t
     rw [L_apply, intervalPrimitive_apply]
     calc
-      ‖∫ s in a..(t : ℝ), f (Set.projIcc a b hab s)‖ ≤ ‖f‖ * |(t : ℝ) - a| :=
+      ‖∫ s in a..(t : ℝ), IccExtendCM f s‖ ≤ ‖f‖ * |(t : ℝ) - a| :=
         intervalIntegral.norm_integral_le_of_norm_le_const fun s _ ↦
-          ContinuousMap.norm_coe_le_norm f (Set.projIcc a b hab s)
+          ContinuousMap.norm_coe_le_norm f (projIccCM s)
       _ ≤ (b - a) * ‖f‖ := by
         rw [abs_of_nonneg (sub_nonneg.mpr t.2.1), mul_comm (b - a)]
         exact mul_le_mul_of_nonneg_left (sub_le_sub_right t.2.2 a) (norm_nonneg f)
@@ -146,8 +153,9 @@ theorem intervalIntegralOperator_apply (a b : ℝ) (hab : a ≤ b)
     (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
     intervalIntegralOperator a b hab f t =
       ∫ s in a..t, f (Set.projIcc a b hab s) := by
+  let _ : Fact (a ≤ b) := ⟨hab⟩
   rw [intervalIntegralOperator]
-  exact intervalPrimitive_apply a b hab f t
+  exact intervalPrimitive_apply a b f t
 
 /-- Volterra integration on the unit interval, obtained from the general compact-interval
 operator. -/

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -84,19 +84,30 @@ open MeasureTheory
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
+/-- Constant extension from a compact interval, bundled as a continuous linear map. -/
+private noncomputable def intervalExtension (a b : ℝ) [Fact (a ≤ b)] :
+    C(Set.Icc a b, E) →L[ℝ] C(ℝ, E) :=
+  (projIccCM (α := ℝ) (a := a) (b := b)).compCLM ℝ E
+
+omit [CompleteSpace E] in
+@[simp]
+private theorem intervalExtension_apply (a b : ℝ) [Fact (a ≤ b)]
+    (f : C(Set.Icc a b, E)) (t : ℝ) :
+    intervalExtension a b f t = IccExtendCM f t := rfl
+
 /-- The primitive of a continuous path on a compact real interval, using constant extension before
 integration. -/
 private noncomputable def intervalPrimitive (a b : ℝ) [Fact (a ≤ b)]
     (f : C(Set.Icc a b, E)) : C(Set.Icc a b, E) :=
-  ⟨fun t ↦ ∫ s in a..t, IccExtendCM f s,
+  ⟨fun t ↦ ∫ s in a..t, intervalExtension a b f s,
     (intervalIntegral.continuous_primitive
-      (fun x y ↦ (IccExtendCM f).continuous.intervalIntegrable x y) a).comp
+      (fun x y ↦ (intervalExtension a b f).continuous.intervalIntegrable x y) a).comp
         continuous_subtype_val⟩
 
 omit [CompleteSpace E] in
 private theorem intervalPrimitive_apply (a b : ℝ) [Fact (a ≤ b)]
     (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
-    intervalPrimitive a b f t = ∫ s in a..t, IccExtendCM f s := rfl
+    intervalPrimitive a b f t = ∫ s in a..t, intervalExtension a b f s := rfl
 
 /-- Volterra integration as a continuous linear operator on continuous paths over an arbitrary
 compact real interval. The input is extended constantly outside the interval before integration. -/
@@ -109,20 +120,16 @@ noncomputable def intervalIntegralOperator (a b : ℝ) (hab : a ≤ b) :
         ext t
         rw [intervalPrimitive_apply, ContinuousMap.add_apply, intervalPrimitive_apply,
           intervalPrimitive_apply]
-        rw [show IccExtendCM (f + g) = IccExtendCM f + IccExtendCM g by
-          ext s
-          rfl]
+        rw [map_add]
         exact intervalIntegral.integral_add
-          ((IccExtendCM f).continuous.intervalIntegrable _ _)
-          ((IccExtendCM g).continuous.intervalIntegrable _ _)
+          ((intervalExtension a b f).continuous.intervalIntegrable _ _)
+          ((intervalExtension a b g).continuous.intervalIntegrable _ _)
       map_smul' := fun c f ↦ by
         ext t
         rw [intervalPrimitive_apply, ContinuousMap.smul_apply, intervalPrimitive_apply]
-        rw [show IccExtendCM (c • f) = c • IccExtendCM f by
-          ext s
-          rfl]
+        rw [map_smul]
         simpa only [ContinuousMap.smul_apply, RingHom.id_apply] using
-          intervalIntegral.integral_smul c (IccExtendCM f) }
+          intervalIntegral.integral_smul c (intervalExtension a b f) }
   have L_apply (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
       L f t = intervalPrimitive a b f t := rfl
   exact LinearMap.mkContinuous L (b - a) fun f ↦ by
@@ -131,7 +138,7 @@ noncomputable def intervalIntegralOperator (a b : ℝ) (hab : a ≤ b) :
     intro t
     rw [L_apply, intervalPrimitive_apply]
     calc
-      ‖∫ s in a..(t : ℝ), IccExtendCM f s‖ ≤ ‖f‖ * |(t : ℝ) - a| :=
+      ‖∫ s in a..(t : ℝ), intervalExtension a b f s‖ ≤ ‖f‖ * |(t : ℝ) - a| :=
         intervalIntegral.norm_integral_le_of_norm_le_const fun s _ ↦
           ContinuousMap.norm_coe_le_norm f (projIccCM s)
       _ ≤ (b - a) * ‖f‖ := by
@@ -155,7 +162,9 @@ theorem intervalIntegralOperator_apply (a b : ℝ) (hab : a ≤ b)
       ∫ s in a..t, f (Set.projIcc a b hab s) := by
   let _ : Fact (a ≤ b) := ⟨hab⟩
   rw [intervalIntegralOperator]
-  exact intervalPrimitive_apply a b f t
+  change intervalPrimitive a b f t = _
+  rw [intervalPrimitive_apply]
+  simp [intervalExtension_apply, IccExtendCM, projIccCM]
 
 /-- Volterra integration on the unit interval, obtained from the general compact-interval
 operator. -/

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -153,6 +153,15 @@ theorem norm_intervalIntegralOperator_le (a b : ℝ) (hab : a ≤ b) :
   exact LinearMap.mkContinuous_norm_le _ (sub_nonneg.mpr hab) _
 
 omit [CompleteSpace E] in
+/-- The bundled operator evaluates to its primitive construction. -/
+private theorem intervalIntegralOperator_apply_intervalPrimitive (a b : ℝ) (hab : a ≤ b)
+    [Fact (a ≤ b)]
+    (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
+    intervalIntegralOperator a b hab f t = intervalPrimitive a b f t := by
+  rw [intervalIntegralOperator]
+  rfl
+
+omit [CompleteSpace E] in
 /-- Evaluating the Volterra operator at `t` integrates the input's constant extension from the left
 endpoint to `t`. -/
 @[simp]
@@ -161,9 +170,7 @@ theorem intervalIntegralOperator_apply (a b : ℝ) (hab : a ≤ b)
     intervalIntegralOperator a b hab f t =
       ∫ s in a..t, f (Set.projIcc a b hab s) := by
   let _ : Fact (a ≤ b) := ⟨hab⟩
-  rw [intervalIntegralOperator]
-  change intervalPrimitive a b f t = _
-  rw [intervalPrimitive_apply]
+  rw [intervalIntegralOperator_apply_intervalPrimitive, intervalPrimitive_apply]
   simp [intervalExtension_apply, IccExtendCM, projIccCM]
 
 /-- Volterra integration on the unit interval, obtained from the general compact-interval

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -92,6 +92,10 @@ noncomputable def unitIntervalIntegral :
       (intervalIntegral.continuous_primitive
         (fun a b ↦ (f.continuous.comp continuous_projIcc).intervalIntegrable a b) 0).comp
           continuous_subtype_val⟩
+  have primitive_apply (f : C(Set.Icc (0 : ℝ) 1, E)) (t : Set.Icc (0 : ℝ) 1) :
+      primitive f t =
+        ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s) :=
+    rfl
   let L : C(Set.Icc (0 : ℝ) 1, E) →ₗ[ℝ] C(Set.Icc (0 : ℝ) 1, E) :=
     { toFun := primitive
       map_add' := fun f g ↦ by
@@ -101,11 +105,8 @@ noncomputable def unitIntervalIntegral :
           ((g.continuous.comp continuous_projIcc).intervalIntegrable _ _)
       map_smul' := fun c f ↦ by
         ext t
-        change (∫ s in (0 : ℝ)..(t : ℝ),
-          c • f (Set.projIcc 0 1 zero_le_one s)) =
-            c • ∫ s in (0 : ℝ)..(t : ℝ),
-              f (Set.projIcc 0 1 zero_le_one s)
-        simpa only [ContinuousMap.smul_apply] using
+        rw [primitive_apply, ContinuousMap.smul_apply, primitive_apply]
+        simpa only [ContinuousMap.smul_apply, RingHom.id_apply] using
           intervalIntegral.integral_smul c
             (fun s ↦ f (Set.projIcc 0 1 zero_le_one s)) }
   exact LinearMap.mkContinuous L 1 fun f ↦ by
@@ -121,6 +122,15 @@ noncomputable def unitIntervalIntegral :
         exact mul_le_of_le_one_right (norm_nonneg f) t.2.2
 
 omit [CompleteSpace E] in
+/-- The Volterra integral operator on the unit interval has operator norm at most one. -/
+theorem norm_unitIntervalIntegral_le :
+    ‖unitIntervalIntegral (E := E)‖ ≤ 1 := by
+  rw [unitIntervalIntegral]
+  exact LinearMap.mkContinuous_norm_le _ zero_le_one _
+
+omit [CompleteSpace E] in
+/-- Evaluating the Volterra operator at `t` integrates the input's constant extension from zero
+to `t`. -/
 @[simp]
 theorem unitIntervalIntegral_apply (f : C(Set.Icc (0 : ℝ) 1, E))
     (t : Set.Icc (0 : ℝ) 1) :

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -83,50 +83,84 @@ open MeasureTheory
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
 
-/-- Volterra integration as a continuous linear operator on continuous paths over the unit
-interval. The input is extended constantly outside the interval before integration. -/
-noncomputable def unitIntervalIntegral :
-    C(Set.Icc (0 : ℝ) 1, E) →L[ℝ] C(Set.Icc (0 : ℝ) 1, E) := by
-  let primitive (f : C(Set.Icc (0 : ℝ) 1, E)) : C(Set.Icc (0 : ℝ) 1, E) :=
-    ⟨fun t ↦ ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s),
-      (intervalIntegral.continuous_primitive
-        (fun a b ↦ (f.continuous.comp continuous_projIcc).intervalIntegrable a b) 0).comp
-          continuous_subtype_val⟩
-  have primitive_apply (f : C(Set.Icc (0 : ℝ) 1, E)) (t : Set.Icc (0 : ℝ) 1) :
-      primitive f t =
-        ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s) :=
-    rfl
-  let L : C(Set.Icc (0 : ℝ) 1, E) →ₗ[ℝ] C(Set.Icc (0 : ℝ) 1, E) :=
-    { toFun := primitive
+/-- The primitive of a continuous path on a compact real interval, using constant extension before
+integration. -/
+private noncomputable def intervalPrimitive (a b : ℝ) (hab : a ≤ b)
+    (f : C(Set.Icc a b, E)) : C(Set.Icc a b, E) :=
+  ⟨fun t ↦ ∫ s in a..t, f (Set.projIcc a b hab s),
+    (intervalIntegral.continuous_primitive
+      (fun x y ↦ (f.continuous.comp continuous_projIcc).intervalIntegrable x y) a).comp
+        continuous_subtype_val⟩
+
+omit [CompleteSpace E] in
+private theorem intervalPrimitive_apply (a b : ℝ) (hab : a ≤ b)
+    (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
+    intervalPrimitive a b hab f t = ∫ s in a..t, f (Set.projIcc a b hab s) := rfl
+
+/-- Volterra integration as a continuous linear operator on continuous paths over an arbitrary
+compact real interval. The input is extended constantly outside the interval before integration. -/
+noncomputable def intervalIntegralOperator (a b : ℝ) (hab : a ≤ b) :
+    C(Set.Icc a b, E) →L[ℝ] C(Set.Icc a b, E) := by
+  let L : C(Set.Icc a b, E) →ₗ[ℝ] C(Set.Icc a b, E) :=
+    { toFun := intervalPrimitive a b hab
       map_add' := fun f g ↦ by
         ext t
+        rw [intervalPrimitive_apply, ContinuousMap.add_apply, intervalPrimitive_apply,
+          intervalPrimitive_apply]
         exact intervalIntegral.integral_add
           ((f.continuous.comp continuous_projIcc).intervalIntegrable _ _)
           ((g.continuous.comp continuous_projIcc).intervalIntegrable _ _)
       map_smul' := fun c f ↦ by
         ext t
-        rw [primitive_apply, ContinuousMap.smul_apply, primitive_apply]
+        rw [intervalPrimitive_apply, ContinuousMap.smul_apply, intervalPrimitive_apply]
         simpa only [ContinuousMap.smul_apply, RingHom.id_apply] using
           intervalIntegral.integral_smul c
-            (fun s ↦ f (Set.projIcc 0 1 zero_le_one s)) }
-  exact LinearMap.mkContinuous L 1 fun f ↦ by
-    rw [one_mul]
-    apply (ContinuousMap.norm_le _ (norm_nonneg f)).2
+            (fun s ↦ f (Set.projIcc a b hab s)) }
+  have L_apply (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
+      L f t = intervalPrimitive a b hab f t := rfl
+  exact LinearMap.mkContinuous L (b - a) fun f ↦ by
+    apply (ContinuousMap.norm_le _
+      (mul_nonneg (sub_nonneg.mpr hab) (norm_nonneg f))).2
     intro t
+    rw [L_apply, intervalPrimitive_apply]
     calc
-      ‖primitive f t‖ ≤ ‖f‖ * |(t : ℝ) - 0| :=
+      ‖∫ s in a..(t : ℝ), f (Set.projIcc a b hab s)‖ ≤ ‖f‖ * |(t : ℝ) - a| :=
         intervalIntegral.norm_integral_le_of_norm_le_const fun s _ ↦
-          ContinuousMap.norm_coe_le_norm f (Set.projIcc 0 1 zero_le_one s)
-      _ ≤ ‖f‖ := by
-        rw [sub_zero, abs_of_nonneg t.2.1]
-        exact mul_le_of_le_one_right (norm_nonneg f) t.2.2
+          ContinuousMap.norm_coe_le_norm f (Set.projIcc a b hab s)
+      _ ≤ (b - a) * ‖f‖ := by
+        rw [abs_of_nonneg (sub_nonneg.mpr t.2.1), mul_comm (b - a)]
+        exact mul_le_mul_of_nonneg_left (sub_le_sub_right t.2.2 a) (norm_nonneg f)
+
+omit [CompleteSpace E] in
+/-- The Volterra integral operator on `[a, b]` has operator norm at most the interval length. -/
+theorem norm_intervalIntegralOperator_le (a b : ℝ) (hab : a ≤ b) :
+    ‖intervalIntegralOperator (E := E) a b hab‖ ≤ b - a := by
+  rw [intervalIntegralOperator]
+  exact LinearMap.mkContinuous_norm_le _ (sub_nonneg.mpr hab) _
+
+omit [CompleteSpace E] in
+/-- Evaluating the Volterra operator at `t` integrates the input's constant extension from the left
+endpoint to `t`. -/
+@[simp]
+theorem intervalIntegralOperator_apply (a b : ℝ) (hab : a ≤ b)
+    (f : C(Set.Icc a b, E)) (t : Set.Icc a b) :
+    intervalIntegralOperator a b hab f t =
+      ∫ s in a..t, f (Set.projIcc a b hab s) := by
+  rw [intervalIntegralOperator]
+  exact intervalPrimitive_apply a b hab f t
+
+/-- Volterra integration on the unit interval, obtained from the general compact-interval
+operator. -/
+noncomputable def unitIntervalIntegral :
+    C(Set.Icc (0 : ℝ) 1, E) →L[ℝ] C(Set.Icc (0 : ℝ) 1, E) :=
+  intervalIntegralOperator 0 1 zero_le_one
 
 omit [CompleteSpace E] in
 /-- The Volterra integral operator on the unit interval has operator norm at most one. -/
 theorem norm_unitIntervalIntegral_le :
     ‖unitIntervalIntegral (E := E)‖ ≤ 1 := by
-  rw [unitIntervalIntegral]
-  exact LinearMap.mkContinuous_norm_le _ zero_le_one _
+  simpa only [unitIntervalIntegral, sub_zero] using
+    norm_intervalIntegralOperator_le (E := E) 0 1 zero_le_one
 
 omit [CompleteSpace E] in
 /-- Evaluating the Volterra operator at `t` integrates the input's constant extension from zero
@@ -136,8 +170,7 @@ theorem unitIntervalIntegral_apply (f : C(Set.Icc (0 : ℝ) 1, E))
     (t : Set.Icc (0 : ℝ) 1) :
     unitIntervalIntegral f t =
       ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s) := by
-  rw [unitIntervalIntegral]
-  rfl
+  exact intervalIntegralOperator_apply 0 1 zero_le_one f t
 
 end ContinuousMap
 

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -93,7 +93,7 @@ omit [CompleteSpace E] in
 @[simp]
 private theorem intervalExtension_apply (a b : ℝ) [Fact (a ≤ b)]
     (f : C(Set.Icc a b, E)) (t : ℝ) :
-    intervalExtension a b f t = IccExtendCM f t := rfl
+    intervalExtension a b f t = f (Set.projIcc a b Fact.out t) := rfl
 
 /-- The primitive of a continuous path on a compact real interval, using constant extension before
 integration. -/
@@ -171,7 +171,7 @@ theorem intervalIntegralOperator_apply (a b : ℝ) (hab : a ≤ b)
       ∫ s in a..t, f (Set.projIcc a b hab s) := by
   let _ : Fact (a ≤ b) := ⟨hab⟩
   rw [intervalIntegralOperator_apply_intervalPrimitive, intervalPrimitive_apply]
-  simp [intervalExtension_apply, IccExtendCM, projIccCM]
+  simp only [intervalExtension_apply]
 
 /-- Volterra integration on the unit interval, obtained from the general compact-interval
 operator. -/
@@ -194,7 +194,7 @@ theorem unitIntervalIntegral_apply (f : C(Set.Icc (0 : ℝ) 1, E))
     (t : Set.Icc (0 : ℝ) 1) :
     unitIntervalIntegral f t =
       ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s) := by
-  exact intervalIntegralOperator_apply 0 1 zero_le_one f t
+  simpa only [unitIntervalIntegral] using intervalIntegralOperator_apply 0 1 zero_le_one f t
 
 end ContinuousMap
 

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -7,6 +7,8 @@ module
 public import Mathlib.Analysis.Calculus.ContDiff.Comp
 public import Mathlib.Analysis.Calculus.MeanValue
 public import Mathlib.Analysis.Normed.Operator.Bilinear
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import Mathlib.Topology.ContinuousMap.Compact
 public import Mathlib.Topology.UniformSpace.HeineCantor
 
@@ -22,6 +24,8 @@ spaces of continuous functions over a compact domain.
   continuous linear maps, as a bounded bilinear operator.
 * `ContinuousMap.hasFDerivAt_postcomp`: the derivative of pointwise postcomposition by a `C¹` map.
 * `ContinuousMap.contDiff_postcomp`: finite-order or smooth pointwise postcomposition.
+* `ContinuousMap.unitIntervalIntegral`: the Volterra integral operator on continuous paths over
+  the unit interval.
 
 ## References
 
@@ -70,6 +74,60 @@ noncomputable def applyContinuousLinearMap :
 theorem applyContinuousLinearMap_apply (A : C(K, E →L[𝕜] F)) (f : C(K, E)) (x : K) :
     applyContinuousLinearMap A f x = A x (f x) :=
   by simp [applyContinuousLinearMap]
+
+end ContinuousMap
+
+namespace ContinuousMap
+
+open MeasureTheory
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+
+/-- Volterra integration as a continuous linear operator on continuous paths over the unit
+interval. The input is extended constantly outside the interval before integration. -/
+noncomputable def unitIntervalIntegral :
+    C(Set.Icc (0 : ℝ) 1, E) →L[ℝ] C(Set.Icc (0 : ℝ) 1, E) := by
+  let primitive (f : C(Set.Icc (0 : ℝ) 1, E)) : C(Set.Icc (0 : ℝ) 1, E) :=
+    ⟨fun t ↦ ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s),
+      (intervalIntegral.continuous_primitive
+        (fun a b ↦ (f.continuous.comp continuous_projIcc).intervalIntegrable a b) 0).comp
+          continuous_subtype_val⟩
+  let L : C(Set.Icc (0 : ℝ) 1, E) →ₗ[ℝ] C(Set.Icc (0 : ℝ) 1, E) :=
+    { toFun := primitive
+      map_add' := fun f g ↦ by
+        ext t
+        exact intervalIntegral.integral_add
+          ((f.continuous.comp continuous_projIcc).intervalIntegrable _ _)
+          ((g.continuous.comp continuous_projIcc).intervalIntegrable _ _)
+      map_smul' := fun c f ↦ by
+        ext t
+        change (∫ s in (0 : ℝ)..(t : ℝ),
+          c • f (Set.projIcc 0 1 zero_le_one s)) =
+            c • ∫ s in (0 : ℝ)..(t : ℝ),
+              f (Set.projIcc 0 1 zero_le_one s)
+        simpa only [ContinuousMap.smul_apply] using
+          intervalIntegral.integral_smul c
+            (fun s ↦ f (Set.projIcc 0 1 zero_le_one s)) }
+  exact LinearMap.mkContinuous L 1 fun f ↦ by
+    rw [one_mul]
+    apply (ContinuousMap.norm_le _ (norm_nonneg f)).2
+    intro t
+    calc
+      ‖primitive f t‖ ≤ ‖f‖ * |(t : ℝ) - 0| :=
+        intervalIntegral.norm_integral_le_of_norm_le_const fun s _ ↦
+          ContinuousMap.norm_coe_le_norm f (Set.projIcc 0 1 zero_le_one s)
+      _ ≤ ‖f‖ := by
+        rw [sub_zero, abs_of_nonneg t.2.1]
+        exact mul_le_of_le_one_right (norm_nonneg f) t.2.2
+
+omit [CompleteSpace E] in
+@[simp]
+theorem unitIntervalIntegral_apply (f : C(Set.Icc (0 : ℝ) 1, E))
+    (t : Set.Icc (0 : ℝ) 1) :
+    unitIntervalIntegral f t =
+      ∫ s in (0 : ℝ)..t, f (Set.projIcc 0 1 zero_le_one s) := by
+  rw [unitIntervalIntegral]
+  rfl
 
 end ContinuousMap
 

--- a/TauCeti/Analysis/Calculus/ContinuousMap.lean
+++ b/TauCeti/Analysis/Calculus/ContinuousMap.lean
@@ -181,7 +181,7 @@ noncomputable def unitIntervalIntegral :
 
 omit [CompleteSpace E] in
 /-- The Volterra integral operator on the unit interval has operator norm at most one. -/
-theorem norm_unitIntervalIntegral_le :
+theorem norm_unitIntervalIntegral_le_one :
     ‖unitIntervalIntegral (E := E)‖ ≤ 1 := by
   simpa only [unitIntervalIntegral, sub_zero] using
     norm_intervalIntegralOperator_le (E := E) 0 1 zero_le_one


### PR DESCRIPTION
## Goal

Package Volterra integration on unit-interval continuous paths as a continuous linear operator. This is the linear integration component required to express the parameter-dependent Picard equation as a smooth Banach-space residual.

## Argument

Smooth parameter dependence will be proved by applying the implicit-function theorem to a Picard residual on a continuous-path space. That residual composes #1877's nonlinear superposition map with a bounded linear primitive operator, so interval integration needs a reusable continuous-linear-map interface.

The operator integrates the constant extension of each path from zero to the requested unit-interval time. Linearity follows from interval-integral additivity and scalar compatibility. The uniform estimate `‖∫₀ᵗ f‖ ≤ ‖f‖ · t ≤ ‖f‖` proves continuity and bounds the operator norm by one. The application and norm-bound theorems expose exactly the facts used by the downstream Picard construction.

## Verification

- `bash scripts/sandbox-build.sh`
  - `lake build --iofail`: 6,459 jobs completed.
  - `lake exe axioms`: 21,650 Tau Ceti declarations audited; only `propext`, `Classical.choice`, and `Quot.sound`.
  - `lake exe module-system`: all 1,190 Tau Ceti modules participate.
  - `bash scripts/lint-env.sh`: 1,770 declarations documented, 1,189 modules linted, and no new violations.
- `git diff --check`

## Dependency

Depends on #1877, which supplies the continuous-map superposition calculus in the same module. The semantic diff over #1877 is one 68-line operator/API change, split into its construction and reviewed API refinement commits.

Advances [TauCetiRoadmap#139](https://github.com/TauCetiProject/TauCetiRoadmap/issues/139), `RepresentationTheory/LieGroups`, Deliverable A, Layer 0, by supplying the integration operator used in smooth parameter dependence for invariant integral curves.

Roadmap: RepresentationTheory
