### PR TITLE
refactor: expose the coordinate integral-curve bridge

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -51,55 +51,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
 
-omit [Group G] in
-private theorem isMIntegralCurveAt_extChartAt_symm_of_eventually
-    [IsManifold I 1 G] [ContinuousSMul ℝ E]
-    {x₀ : G} {f : ℝ → E} {t₀ : ℝ} {v : (x : G) → TangentSpace I x}
-    (htarget : ∀ᶠ t in 𝓝 t₀, f t ∈ interior (extChartAt I x₀).target)
-    (hderiv : ∀ᶠ t in 𝓝 t₀,
-      HasDerivAt f
-        (tangentCoordChange I ((extChartAt I x₀).symm (f t)) x₀
-          ((extChartAt I x₀).symm (f t)) (v ((extChartAt I x₀).symm (f t)))) t) :
-    IsMIntegralCurveAt ((extChartAt I x₀).symm ∘ f) v t₀ := by
-  obtain ⟨s, hs, haux⟩ := (hderiv.and htarget).exists_mem
-  rw [isMIntegralCurveAt_iff]
-  refine ⟨s, hs, ?_⟩
-  intro t ht
-  let xₜ : G := (extChartAt I x₀).symm (f t)
-  have h : HasDerivAt f
-      (tangentCoordChange I xₜ x₀ xₜ (v xₜ)) t := (haux t ht).1
-  have hf3 := Set.mem_of_mem_of_subset (haux t ht).2 interior_subset
-  have hft1 := Set.mem_preimage.mp <|
-    Set.mem_of_mem_of_subset hf3 (extChartAt I x₀).target_subset_preimage_source
-  have hft2 := mem_extChartAt_source (I := I) xₜ
-  have hft1' : xₜ ∈ (extChartAt I x₀).source := by simpa only [xₜ] using hft1
-  have hcharts :
-      xₜ ∈ (extChartAt I xₜ).source ∩ (extChartAt I x₀).source ∩
-        (extChartAt I xₜ).source := ⟨⟨hft2, hft1'⟩, hft2⟩
-  apply HasMFDerivAt.hasMFDerivWithinAt
-  refine ⟨(continuousAt_extChartAt_symm'' hf3).comp h.continuousAt, ?_⟩
-  have hcomp : HasDerivAt ((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f)
-      (tangentCoordChange I x₀ xₜ xₜ (tangentCoordChange I xₜ x₀ xₜ (v xₜ))) t := by
-    apply HasFDerivAt.comp_hasDerivAt _ _ h
-    apply HasFDerivWithinAt.hasFDerivAt (s := Set.range I) _ <|
-      mem_nhds_iff.mpr ⟨interior (extChartAt I x₀).target,
-        subset_trans interior_subset (extChartAt_target_subset_range ..),
-        isOpen_interior, (haux t ht).2⟩
-    rw [← (extChartAt I x₀).right_inv hf3]
-    exact hasFDerivWithinAt_tangentCoordChange ⟨hft1, hft2⟩
-  have hd := hcomp.congr_deriv (tangentCoordChange_comp hcharts)
-  have hd' := hd.congr_deriv (tangentCoordChange_self hft2)
-  simp only [writtenInExtChartAt, extChartAt_model_space_eq_id, PartialEquiv.refl_coe,
-    PartialEquiv.refl_symm, modelWithCornersSelf_coe, Function.comp_def, id_eq, Set.range_id]
-  -- Restore the named chart preimage before comparing the ordinary and manifold derivatives.
-  rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
-  rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
-  -- In these charts, the source and target tangent spaces are definitionally their model spaces.
-  change HasFDerivWithinAt
-    (((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f))
-      (ContinuousLinearMap.toSpanSingleton ℝ (v xₜ)) Set.univ t
-  exact hd'.hasFDerivAt.hasFDerivWithinAt
-
 /-- The left-invariant vector field, expressed in the identity chart and parameterized by its
 generating tangent vector in the model space. -/
 noncomputable def mulInvariantCoordinateVectorField [IsManifold I 1 G] (p : E × E) : E :=
@@ -374,7 +325,7 @@ theorem exists_local_coordinate_representation_mulInvariantIntegralCurve
       IsMIntegralCurveAt γ
         (mulInvariantVectorField (I := I) (G := G) (v : GroupLieAlgebra I G)) t := by
     intro t ht
-    apply isMIntegralCurveAt_extChartAt_symm_of_eventually
+    apply IsMIntegralCurveAt.of_extChartAt_symm
     · filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
       exact (hlocal s hs).2.2.2
     · filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs

--- a/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
+++ b/TauCeti/Geometry/Lie/Exponential/ParameterDependence.lean
@@ -36,8 +36,8 @@ tangent vectors.
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 0, "The exponential map".
-* Winston Yin's Mathlib proof of `exists_isMIntegralCurveAt_of_contMDiffAt`, adapted by the private
-  chart-to-integral-curve bridge below to retain a shared parameter in the coordinate field.
+* Winston Yin's Mathlib proof of `exists_isMIntegralCurveAt_of_contMDiffAt_boundaryless`, whose
+  chart calculation is exposed by `IsMIntegralCurveAt.of_extChartAt_symm` and invoked below.
 -/
 
 public section

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -18,6 +18,7 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 
 * `IsMIntegralCurve.contMDiff_succ`: an integral curve of a `C^n` vector field is `C^(n + 1)`.
 * `IsMIntegralCurve.contMDiff`: an integral curve of a smooth vector field is smooth.
+* `IsMIntegralCurveAt.of_extChartAt_symm`: a coordinate solution gives a manifold integral curve.
 
 ## References
 
@@ -27,11 +28,59 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 
 public section
 
-open Function Manifold Set
+open Bundle Function Manifold Set
 open scoped ContDiff Manifold Topology
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+
+/-- A coordinate curve whose values stay in an extended-chart target and whose derivative is the
+coordinate expression of a vector field gives a manifold integral curve after applying the inverse
+chart. -/
+theorem IsMIntegralCurveAt.of_extChartAt_symm
+    [ContinuousSMul ℝ E]
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
+    {x₀ : M} {f : ℝ → E} {t₀ : ℝ} {v : (x : M) → TangentSpace I x}
+    (htarget : ∀ᶠ t in nhds t₀, f t ∈ interior (extChartAt I x₀).target)
+    (hderiv : ∀ᶠ t in nhds t₀,
+      HasDerivAt f
+        (tangentCoordChange I ((extChartAt I x₀).symm (f t)) x₀
+          ((extChartAt I x₀).symm (f t)) (v ((extChartAt I x₀).symm (f t)))) t) :
+    IsMIntegralCurveAt ((extChartAt I x₀).symm ∘ f) v t₀ := by
+  obtain ⟨s, hs, haux⟩ := (hderiv.and htarget).exists_mem
+  rw [isMIntegralCurveAt_iff]
+  refine ⟨s, hs, ?_⟩
+  intro t ht
+  let xₜ : M := (extChartAt I x₀).symm (f t)
+  have h : HasDerivAt f
+      (tangentCoordChange I xₜ x₀ xₜ (v xₜ)) t := (haux t ht).1
+  have hf3 := mem_of_mem_of_subset (haux t ht).2 interior_subset
+  have hft1 := mem_preimage.mp <|
+    mem_of_mem_of_subset hf3 (extChartAt I x₀).target_subset_preimage_source
+  have hft2 := mem_extChartAt_source (I := I) xₜ
+  have hft1' : xₜ ∈ (extChartAt I x₀).source := by simpa only [xₜ] using hft1
+  have hcharts :
+      xₜ ∈ (extChartAt I xₜ).source ∩ (extChartAt I x₀).source ∩
+        (extChartAt I xₜ).source := ⟨⟨hft2, hft1'⟩, hft2⟩
+  apply HasMFDerivAt.hasMFDerivWithinAt
+  refine ⟨(continuousAt_extChartAt_symm'' hf3).comp h.continuousAt, ?_⟩
+  have hcomp : HasDerivAt ((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f)
+      (tangentCoordChange I x₀ xₜ xₜ (tangentCoordChange I xₜ x₀ xₜ (v xₜ))) t := by
+    apply HasFDerivAt.comp_hasDerivAt _ _ h
+    apply HasFDerivWithinAt.hasFDerivAt (s := range I) _ <|
+      mem_nhds_iff.mpr ⟨interior (extChartAt I x₀).target,
+        subset_trans interior_subset (extChartAt_target_subset_range ..),
+        isOpen_interior, (haux t ht).2⟩
+    rw [← (extChartAt I x₀).right_inv hf3]
+    exact hasFDerivWithinAt_tangentCoordChange ⟨hft1, hft2⟩
+  have hd := hcomp.congr_deriv (tangentCoordChange_comp hcharts)
+  have hd' := hd.congr_deriv (tangentCoordChange_self hft2)
+  simp only [writtenInExtChartAt, extChartAt_model_space_eq_id, PartialEquiv.refl_coe,
+    PartialEquiv.refl_symm, modelWithCornersSelf_coe, Function.comp_def, id_eq, range_id]
+  rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
+  rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
+  with_unfolding_all
+    exact hd'.hasFDerivAt.hasFDerivWithinAt
 
 private theorem contDiffOn_succ_of_hasDerivAt_comp {F : Type*} [NormedAddCommGroup F]
     [NormedSpace ℝ F] {n : ℕ} {f : ℝ → F} {v : F → F} {s : Set ℝ} {u : Set F}

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -79,10 +79,14 @@ theorem IsMIntegralCurveAt.of_extChartAt_symm
   have hd' := hd.congr_deriv (tangentCoordChange_self hft2)
   simp only [writtenInExtChartAt, extChartAt_model_space_eq_id, PartialEquiv.refl_coe,
     PartialEquiv.refl_symm, modelWithCornersSelf_coe, Function.comp_def, id_eq, range_id]
+  -- Restore the named chart preimage before comparing the ordinary and manifold derivatives.
   rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
   rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
-  with_unfolding_all
-    exact hd'.hasFDerivAt.hasFDerivWithinAt
+  -- In these charts, the source and target tangent spaces are definitionally their model spaces.
+  change HasFDerivWithinAt
+    (((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f))
+      (ContinuousLinearMap.toSpanSingleton ℝ (v xₜ)) Set.univ t
+  exact hd'.hasFDerivAt.hasFDerivWithinAt
 
 private theorem contDiffOn_succ_of_hasDerivAt_comp {F : Type*} [NormedAddCommGroup F]
     [NormedSpace ℝ F] {n : ℕ} {f : ℝ → F} {v : F → F} {s : Set ℝ} {u : Set F}

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -36,6 +36,20 @@ open scoped ContDiff Manifold Topology
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
 
+/-- Convert an ordinary derivative into the model-space derivative expected inside a manifold
+derivative. This is the single boundary where the tangent spaces of the self model on `ℝ` and of
+`I` are identified with their model vector spaces `ℝ` and `E`. -/
+private theorem hasFDerivWithinAt_model_tangent_spaces
+    {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+    {x : M} {φ : ℝ → E} {t : ℝ} {v : TangentSpace I x}
+    (hφ : HasDerivAt φ v t) :
+    HasFDerivWithinAt φ
+      (ContinuousLinearMap.toSpanSingleton ℝ v :
+        TangentSpace 𝓘(ℝ, ℝ) t →L[ℝ] TangentSpace I x)
+      Set.univ t := by
+  change HasFDerivWithinAt φ (ContinuousLinearMap.toSpanSingleton ℝ v) Set.univ t
+  exact hφ.hasFDerivAt.hasFDerivWithinAt
+
 /-- A coordinate curve whose values stay in an extended-chart target and whose derivative is the
 coordinate expression of a vector field gives a manifold integral curve after applying the inverse
 chart. -/
@@ -81,8 +95,7 @@ theorem IsMIntegralCurveAt.of_extChartAt_symm
   -- Restore the named chart preimage before comparing the ordinary and manifold derivatives.
   rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
   rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
-  convert (hd'.hasFDerivAt.hasFDerivWithinAt (s := Set.univ)) using 1
-  all_goals rfl
+  exact hasFDerivWithinAt_model_tangent_spaces hd'
 
 private theorem contDiffOn_succ_of_hasDerivAt_comp {F : Type*} [NormedAddCommGroup F]
     [NormedSpace ℝ F] {n : ℕ} {f : ℝ → F} {v : F → F} {s : Set ℝ} {u : Set F}

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -40,7 +40,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 coordinate expression of a vector field gives a manifold integral curve after applying the inverse
 chart. -/
 theorem IsMIntegralCurveAt.of_extChartAt_symm
-    [ContinuousSMul ℝ E]
     {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 1 M]
     {x₀ : M} {f : ℝ → E} {t₀ : ℝ} {v : (x : M) → TangentSpace I x}
     (htarget : ∀ᶠ t in nhds t₀, f t ∈ interior (extChartAt I x₀).target)
@@ -82,11 +81,8 @@ theorem IsMIntegralCurveAt.of_extChartAt_symm
   -- Restore the named chart preimage before comparing the ordinary and manifold derivatives.
   rw [show (extChartAt I x₀).symm (f t) = xₜ from rfl]
   rw [ContinuousLinearMap.smulRight_one_eq_toSpanSingleton]
-  -- In these charts, the source and target tangent spaces are definitionally their model spaces.
-  change HasFDerivWithinAt
-    (((extChartAt I xₜ ∘ (extChartAt I x₀).symm) ∘ f))
-      (ContinuousLinearMap.toSpanSingleton ℝ (v xₜ)) Set.univ t
-  exact hd'.hasFDerivAt.hasFDerivWithinAt
+  convert (hd'.hasFDerivAt.hasFDerivWithinAt (s := Set.univ)) using 1
+  all_goals rfl
 
 private theorem contDiffOn_succ_of_hasDerivAt_comp {F : Type*} [NormedAddCommGroup F]
     [NormedSpace ℝ F] {n : ℕ} {f : ℝ → F} {v : F → F} {s : Set ℝ} {u : Set F}

--- a/TauCeti/Geometry/Manifold/IntegralCurve.lean
+++ b/TauCeti/Geometry/Manifold/IntegralCurve.lean
@@ -22,6 +22,8 @@ smooth vector fields on boundaryless smooth manifolds are smooth.
 
 ## References
 
+* Mathlib's proof of `exists_isMIntegralCurveAt_of_contMDiffAt_boundaryless`, whose extended-chart
+  calculation is adapted by `IsMIntegralCurveAt.of_extChartAt_symm` in the reverse direction.
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 0, "The exponential map".
 -/


### PR DESCRIPTION
## Goal

Make the existing coordinate-to-manifold integral-curve conversion reusable by the smooth parameter-dependence construction, without duplicating its chart-calculus proof.

## Argument

The uniform Picard–Lindelöf flow already converts an extended-chart coordinate solution into a manifold integral curve using a private theorem. The smooth path-valued Picard construction in #1881 must perform exactly the same conversion before uniqueness can identify its paths with the canonical invariant curves.

That conversion depends only on manifold charts and tangent-coordinate change—not on groups or exponentials—so its public home is the general manifold integral-curve module. The proof is moved unchanged in substance and generalized only by dropping the accidental ambient `Group` assumptions. The existing Lie-flow application then invokes `IsMIntegralCurveAt.of_extChartAt_symm` with the same hypotheses and conclusion, preserving the established flow theorem while exposing the bridge for its next consumer.

## Verification

- `bash scripts/sandbox-build.sh`
  - `lake build --iofail`: 6,459 jobs completed.
  - `lake exe axioms`: 21,614 Tau Ceti declarations audited; only `propext`, `Classical.choice`, and `Quot.sound`.
  - `lake exe module-system`: all 1,190 Tau Ceti modules participate.
  - `bash scripts/lint-env.sh`: 1,769 declarations documented, 1,189 modules linted, and no new violations.
- `git diff --check`

## Dependency

Depends on #1876, where the private bridge and its current caller are introduced. The semantic diff over #1876 moves the 51-line proof into the general module, removes the private copy, preserves the explicit chart-derivative proof, and records the Mathlib attribution.

This prerequisite directly supports [TauCetiRoadmap#139](https://github.com/TauCetiProject/TauCetiRoadmap/issues/139), `RepresentationTheory/LieGroups`, Deliverable A, Layer 0, smooth parameter dependence for the exponential map.

Roadmap: RepresentationTheory
