### PR TITLE
feat: generalise the length-area inequality to an arbitrary weight

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -7,52 +7,57 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import TauCeti.Analysis.Complex.Conformal.Area
+public import TauCeti.MeasureTheory.Integral.CircleLIntegral
 import Mathlib.Analysis.Complex.CauchyIntegral
-import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
-import Mathlib.Analysis.SpecialFunctions.PolarCoord
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
-import Mathlib.MeasureTheory.Integral.MeanInequalities
 import TauCeti.Analysis.Contour.ArcFTC
 
 /-!
-# The length–area inequality
+# The length–area inequality for a holomorphic map
 
 The **length–area method** converts the finiteness of the Dirichlet integral
 `∫⁻ z in s, ‖deriv f z‖ₑ ^ 2` — which `TauCeti/Analysis/Complex/Conformal/Area.lean` identifies
 with the area of `f '' s` — into a statement about *lengths*: among the circles `‖z - ζ‖ = ρ`
-with `r < ρ < R`, at least one has a short image. Quantitatively, writing `ℓ ρ` for the
-derivative-weighted angular integral `TauCeti.circleImageLength f s ζ ρ` — for measurable `s` and
-holomorphic `f`, the arc length of the parametrised curve `f ∘ circleMap ζ ρ` over the angles
-landing in `s` — Cauchy–Schwarz in the angular variable gives `ℓ ρ ^ 2 ≤ 2 π ρ ∫ ‖f'‖ ^ 2 ρ dθ`, and
-integrating `ℓ ρ ^ 2 / ρ` in `ρ` reassembles the right-hand side, in polar coordinates centred at
-`ζ`, into the whole Dirichlet integral:
+with `r < ρ < R`, at least one has a short image. This file is the holomorphic half of that
+method. The measure-theoretic half is
+`TauCeti/MeasureTheory/Integral/CircleLIntegral.lean`, which proves the length–area inequality and
+Wolff's lemma for an arbitrary measurable weight `g : ℂ → ℝ≥0∞` on the plane, out of
+Cauchy–Schwarz on each circle and polar Fubini. All this file does is instantiate that weight at
+the **length density of `f`**, namely `‖deriv f‖ₑ` cut off outside `s`, and identify what the two
+sides of the general estimates then mean:
 
-`∫⁻ ρ in Ioi 0, ℓ ρ ^ 2 / ρ ≤ 2 π ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2`.
+* the circle integral `TauCeti.circleLIntegral` of that weight is
+  `TauCeti.circleImageLength f s ζ ρ`, for measurable `s` and holomorphic `f` the arc length of the
+  parametrised curve `f ∘ circleMap ζ ρ` over the angles landing in `s`;
+* its plane integral of squares is the Dirichlet integral of `f` over `s`, hence by
+  `Conformal/Area.lean` the area of `f '' s`.
 
-Since `∫⁻ ρ in Ioo r R, ρ⁻¹ = log (R / r)` diverges as `r → 0`, a finite Dirichlet integral cannot
-keep `ℓ` away from `0`: on every annulus, and for every `c` strictly above the average
-`2 π A / log (R / r)`, there is a radius with `ℓ ρ ^ 2 < c` — a threshold that falls without
-limit as the annulus is made longer — and for a holomorphic `f` that bounds the chords of the
-image arc, by `TauCeti.ofReal_dist_le_circleImageLength`. That is Wolff's lemma, and it is the
-analytic engine of layer **L5** of the conformal-mapping roadmap (`ConformalMapping/README.md`),
-Carathéodory's boundary correspondence. Only that quantitative input is proved here: a radius whose
-circle has short image, and a bound on the chords of its arcs. The crosscuts of a Riemann map at a
-boundary point `ζ` are not constructed here, nor is the bound on their diameter that a later file
-is to draw from these estimates in order to force the cluster set at `ζ` to degenerate to a point.
+So the length–area inequality reads
+`∫⁻ ρ in Ioi 0, ℓ ρ ^ 2 / ρ ≤ 2 π * volume (f '' s)`, and Wolff's lemma reads: on every annulus,
+and for every `c` strictly above the average `2 π A / log (R / r)`, there is a radius with
+`ℓ ρ ^ 2 < c` — a threshold that falls without limit as the annulus is made longer.
+
+The genuinely holomorphic content added here is the **chord bound**
+`TauCeti.ofReal_dist_le_circleImageLength`, which is what makes `ℓ` a length: the fundamental
+theorem of calculus along the arc bounds the distance between the images of the endpoints of a
+sub-arc by `ℓ ρ`. That is the form in which Wolff's lemma is used, and it is the analytic engine of
+layer **L5** of the conformal-mapping roadmap (`ConformalMapping/README.md`), Carathéodory's
+boundary correspondence. Only that quantitative input is proved here: a radius whose circle has
+short image, and a bound on the chords of its arcs. The crosscuts of a Riemann map at a boundary
+point `ζ` are not constructed here, nor is the bound on their diameter that a later file is to draw
+from these estimates in order to force the cluster set at `ζ` to degenerate to a point.
 
 ## Main results
 
-* `TauCeti.circleImageLength` — the derivative-weighted angular integral
-  `∫⁻ θ in Ioo (-π) π, ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ` cut off outside `s`; for measurable `s`
-  and holomorphic `f` this is the arc length of `f ∘ circleMap ζ ρ` over the angles landing in `s`,
-  a length along the parametrisation, counted with multiplicity, rather than a measure of the image
-  set.
+* `TauCeti.circleImageLength` — the circle integral of the length density of `f` cut off outside
+  `s`; for measurable `s` and holomorphic `f` this is the arc length of `f ∘ circleMap ζ ρ` over the
+  angles landing in `s`, a length along the parametrisation, counted with multiplicity, rather than
+  a measure of the image set.
 * `TauCeti.ofReal_dist_le_circleImageLength` — the chord bound justifying the name, and the only
   claim made here about lengths that is actually proved: a sub-arc of angular width at most `2 * π`
   that stays in `s` and in a set on which `f` is holomorphic has the distance between the images of
   its endpoints bounded by that quantity.
-* `TauCeti.circleImageLength_eq_lintegral_Ioc` — the angular integral may be taken over any period
-  `Ioc t (t + 2 * π)`, so the branch cut chosen in the definition is immaterial.
+* `TauCeti.circleImageLength_eq_lintegral_Ioc` — the angular integral may be taken over any period,
+  so the branch cut chosen in the definition is immaterial.
 * `TauCeti.lintegral_circleImageLength_sq_div_le_lintegral_enorm_deriv_sq` — the **length–area
   inequality**, and `TauCeti.lintegral_circleImageLength_sq_div_le_volume_image` its form with the
   area of `f '' s` on the right, through the area formula of `Conformal/Area.lean`.
@@ -60,27 +65,18 @@ is to draw from these estimates in order to force the cluster set at `ζ` to deg
   `TauCeti.exists_circleImageLength_sq_lt_of_volume_image` — **Wolff's lemma**: a radius with
   `ℓ ρ ^ 2 < c` exists in every annulus `r < ρ < R` on which `2 π A < c * log (R / r)`.
 
-The length–area inequality itself needs no holomorphy: it is Cauchy–Schwarz followed by the
-polar-coordinate change of variables, and holds for the measurable function `deriv f` whatever it
-is. Holomorphy enters only through `Conformal/Area.lean`, to replace the Dirichlet integral by the
-area of the image, and in the chord bound, where the fundamental theorem of calculus along the arc
-is applied — and it is that chord bound, not the definition, that makes `ℓ` a length.
-
-The angular variable runs over `Ioo (-π) π`, one full period of Mathlib's `circleMap`
-parametrisation and the angular factor of `Complex.polarCoord.target`, which is what makes the
-polar-coordinate step a rewrite rather than a periodicity argument. Since the integrand is
-`2 * π`-periodic the choice of period is immaterial, and
-`TauCeti.circleImageLength_eq_lintegral_Ioc` moves it, so no statement here depends on the seam
-at `±π`.
+Holomorphy is used in exactly two places: through `Conformal/Area.lean`, to replace the Dirichlet
+integral by the area of the image, and in the chord bound, where the fundamental theorem of calculus
+along the arc is applied. The estimates themselves hold for the measurable function `deriv f`
+whatever it is, which is why they are proved for a general weight one file down.
 
 ## Coordination with upstream Mathlib
 
 Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505),
 the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem
 itself, and the pinned Mathlib has no length–area estimate; so this file is new Lean formalization
-rather than a temporary shim. Its Mathlib inputs — the polar-coordinate change of variables
-`Complex.lintegral_comp_polarCoord_symm`, Hölder's inequality
-`ENNReal.lintegral_mul_le_Lp_mul_Lq`, and the fundamental theorem of calculus along an arc through
+rather than a temporary shim. Its Mathlib inputs — the measurability of `deriv` and the fundamental
+theorem of calculus along an arc through
 `TauCeti.Contour.integral_comp_mul_eq_sub_of_hasDerivAt` — are consumed, not restated.
 
 ## References
@@ -99,8 +95,10 @@ open scoped ENNReal Real
 
 variable {U s t : Set ℂ} {f : ℂ → ℂ} {ζ : ℂ}
 
-/-- The **derivative-weighted angular integral** over a circle: the lower integral over the circle
-of centre `ζ` and radius `ρ` of the length density `‖deriv f‖` — the factor by which `f` stretches
+/-! ### The length density of a holomorphic map, and its circle integrals -/
+
+/-- The **derivative-weighted angular integral** over a circle: the circle integral
+`TauCeti.circleLIntegral` of the length density `‖deriv f‖` — the factor by which `f` stretches
 lengths, whose *square* is the area distortion — with the part of the circle outside `s` discarded
 by an indicator.
 
@@ -117,187 +115,84 @@ points covered several times are counted with multiplicity, and it is a length o
 only when `f` is in addition injective on that part of the circle; neither reading is formalised
 here. For a map with no complex derivative the reading fails outright, since `deriv` is then the
 junk value `0`: for `f = conj` the quantity is `0` while the image circle still has length
-`2 π ρ`.
-
-The angle runs over `Ioo (-π) π`, one full period of `circleMap ζ ρ`; by
-`TauCeti.circleImageLength_eq_lintegral_Ioc` any other period gives the same value. A negative
-radius, for which `circleMap` traverses the same circle backwards, gives the value `0`. -/
+`2 π ρ`. -/
 noncomputable def circleImageLength (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ) : ℝ≥0∞ :=
-  ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ)
+  circleLIntegral (s.indicator fun z => ‖deriv f z‖ₑ) ζ ρ
 
-/-- The defining angular integral. The body of `TauCeti.circleImageLength` is not `@[expose]`d, so
+/-- The defining circle integral. The body of `TauCeti.circleImageLength` is not `@[expose]`d, so
 this is the form in which downstream files — and the lemmas below — reach the definition; unfolding
-it directly fails outside this module with `Expected a definition with an exposed body`. -/
+it directly fails outside this module with `Expected a definition with an exposed body`. Through it
+the whole API of `TauCeti.circleLIntegral` applies to the length density of `f`. -/
 theorem circleImageLength_def (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
-    circleImageLength f s ζ ρ =
-      ENNReal.ofReal ρ *
-        ∫⁻ θ in Ioo (-π) π, s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
+    circleImageLength f s ζ ρ = circleLIntegral (s.indicator fun z => ‖deriv f z‖ₑ) ζ ρ := by
   rw [circleImageLength]
 
 /-- Enlarging the set can only increase the arc length measured inside it. -/
 theorem circleImageLength_mono (f : ℂ → ℂ) (ζ : ℂ) (ρ : ℝ) (hst : s ⊆ t) :
     circleImageLength f s ζ ρ ≤ circleImageLength f t ζ ρ := by
   rw [circleImageLength_def, circleImageLength_def]
-  gcongr with θ
+  refine circleLIntegral_mono (fun z => ?_) ζ ρ
+  by_cases hz : z ∈ s
+  · simp [Set.indicator_of_mem hz, Set.indicator_of_mem (hst hz)]
+  · simp [Set.indicator_of_notMem hz]
 
 /-- A circle of nonpositive radius contributes no length. -/
 @[simp]
 theorem circleImageLength_of_nonpos (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) {ρ : ℝ} (hρ : ρ ≤ 0) :
     circleImageLength f s ζ ρ = 0 := by
-  rw [circleImageLength_def, ENNReal.ofReal_of_nonpos hρ, zero_mul]
+  rw [circleImageLength_def]
+  exact circleLIntegral_of_nonpos _ ζ hρ
 
 /-- Measuring inside the empty set gives no length: the indicator kills the whole integrand. -/
 @[simp]
 theorem circleImageLength_empty (f : ℂ → ℂ) (ζ : ℂ) (ρ : ℝ) :
     circleImageLength f ∅ ζ ρ = 0 := by
-  simp [circleImageLength_def]
-
-/-- The angular integrand has period `2 * π`, because `circleMap ζ ρ` does. -/
-private theorem periodic_indicator_circleMap (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
-    Function.Periodic
-      (fun θ => s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ)) (2 * π) := fun θ =>
-  congrArg (s.indicator fun z => ‖deriv f z‖ₑ) (periodic_circleMap ζ ρ θ)
-
-/-- One period of the angular integral is as good as any other: `Ioc t (t + 2 * π)` is a
-fundamental domain for the translations by `2 * π`, which the integrand is invariant under. -/
-private theorem lintegral_Ioc_indicator_circleMap (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ)
-    (t u : ℝ) :
-    ∫⁻ θ in Ioc t (t + 2 * π), s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) =
-      ∫⁻ θ in Ioc u (u + 2 * π), s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) :=
-  (isAddFundamentalDomain_Ioc Real.two_pi_pos t).setLIntegral_eq
-    (isAddFundamentalDomain_Ioc Real.two_pi_pos u) _
-    fun g θ => (periodic_indicator_circleMap f s ζ ρ).map_vadd_zmultiples g θ
+  rw [circleImageLength_def, Set.indicator_empty]
+  exact circleLIntegral_zero ζ ρ
 
 /-- **The angular integral may be taken over any period.** The interval `Ioo (-π) π` fixed in the
-definition of `TauCeti.circleImageLength` can be replaced by any `Ioc t (t + 2 * π)`, so nothing
+definition of `TauCeti.circleLIntegral` can be replaced by any `Ioc t (t + 2 * π)`, so nothing
 about the quantity depends on the branch cut at `±π`; in particular an arc of the circle that
 crosses the seam is handled by choosing `t` beyond its far endpoint. -/
 theorem circleImageLength_eq_lintegral_Ioc (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ) (t : ℝ) :
     circleImageLength f s ζ ρ =
       ENNReal.ofReal ρ *
         ∫⁻ θ in Ioc t (t + 2 * π), s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
-  have hπ : -π + 2 * π = π := by ring
-  rw [circleImageLength_def, ← lintegral_Ioc_indicator_circleMap f s ζ ρ (-π) t, hπ]
-  exact congrArg _ (setLIntegral_congr Ioo_ae_eq_Ioc)
+  rw [circleImageLength_def]
+  exact circleLIntegral_eq_lintegral_Ioc _ ζ ρ t
 
-/-- The length density `‖deriv f‖ₑ` of `f`, cut off outside `s`; its square is the area distortion.
-This is the integrand on both sides of the length–area inequality: of the length directly, and,
-after squaring, of the Dirichlet integral. -/
-private noncomputable def enormDerivIndicator (f : ℂ → ℂ) (s : Set ℂ) : ℂ → ℝ≥0∞ :=
-  s.indicator fun z => ‖deriv f z‖ₑ
+/-! ### The length–area inequality and Wolff's lemma -/
 
-private theorem measurable_enormDerivIndicator (f : ℂ → ℂ) (hs : MeasurableSet s) :
-    Measurable (enormDerivIndicator f s) := by
-  rw [enormDerivIndicator]
-  exact (measurable_deriv f).enorm.indicator hs
+/-- The length density of `f` cut off outside a measurable set is measurable, so the estimates of
+`TauCeti/MeasureTheory/Integral/CircleLIntegral.lean` apply to it. -/
+private theorem measurable_indicator_enorm_deriv (f : ℂ → ℂ) (hs : MeasurableSet s) :
+    Measurable (s.indicator fun z => ‖deriv f z‖ₑ) :=
+  (measurable_deriv f).enorm.indicator hs
 
-private theorem circleImageLength_eq (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
-    circleImageLength f s ζ ρ =
-      ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, enormDerivIndicator f s (circleMap ζ ρ θ) := by
-  rw [circleImageLength_def, enormDerivIndicator]
-
-private theorem enormDerivIndicator_sq (f : ℂ → ℂ) (s : Set ℂ) (z : ℂ) :
-    enormDerivIndicator f s z ^ 2 = s.indicator (fun z => ‖deriv f z‖ₑ ^ 2) z := by
-  rw [enormDerivIndicator]
+/-- The plane integral of the square of the length density of `f` cut off outside `s` is the
+Dirichlet integral of `f` over `s`: the indicator commutes with squaring. -/
+private theorem lintegral_indicator_enorm_deriv_sq (f : ℂ → ℂ) (hs : MeasurableSet s) :
+    ∫⁻ z, s.indicator (fun z => ‖deriv f z‖ₑ) z ^ 2 = ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2 := by
+  rw [← lintegral_indicator hs]
+  refine lintegral_congr fun z => ?_
   by_cases hz : z ∈ s <;> simp [hz]
-
-/-- The polar-coordinate parametrisation of `ℂ` centred at `ζ` is `circleMap ζ`. -/
-private theorem add_polarCoord_symm_eq_circleMap (ζ : ℂ) (p : ℝ × ℝ) :
-    ζ + Complex.polarCoord.symm p = circleMap ζ p.1 p.2 := by
-  simp [circleMap, Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin]
-
-private theorem continuous_circleMap_uncurry (ζ : ℂ) :
-    Continuous fun p : ℝ × ℝ => circleMap ζ p.1 p.2 := by
-  simp only [circleMap]
-  fun_prop
-
-/-- **The Dirichlet integral in polar coordinates centred at `ζ`.** -/
-private theorem lintegral_enorm_deriv_sq_eq_polar (f : ℂ → ℂ) (hs : MeasurableSet s) (ζ : ℂ) :
-    ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2 =
-      ∫⁻ ρ in Ioi (0 : ℝ), ∫⁻ θ in Ioo (-π) π,
-        ENNReal.ofReal ρ * enormDerivIndicator f s (circleMap ζ ρ θ) ^ 2 := by
-  have hm : Measurable (enormDerivIndicator f s) := measurable_enormDerivIndicator f hs
-  have hjoint : Measurable fun p : ℝ × ℝ =>
-      ENNReal.ofReal p.1 * enormDerivIndicator f s (circleMap ζ p.1 p.2) ^ 2 :=
-    (ENNReal.measurable_ofReal.comp measurable_fst).mul
-      ((hm.comp (continuous_circleMap_uncurry ζ).measurable).pow_const 2)
-  calc ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2
-      = ∫⁻ z, enormDerivIndicator f s z ^ 2 := by
-        rw [← lintegral_indicator hs]
-        exact lintegral_congr fun z => (enormDerivIndicator_sq f s z).symm
-    _ = ∫⁻ z, enormDerivIndicator f s (ζ + z) ^ 2 :=
-        (lintegral_add_left_eq_self (fun z => enormDerivIndicator f s z ^ 2) ζ).symm
-    _ = ∫⁻ p in Ioi (0 : ℝ) ×ˢ Ioo (-π) π,
-          ENNReal.ofReal p.1 * enormDerivIndicator f s (circleMap ζ p.1 p.2) ^ 2 := by
-        rw [← Complex.lintegral_comp_polarCoord_symm
-          (fun z => enormDerivIndicator f s (ζ + z) ^ 2), _root_.polarCoord_target]
-        simp_rw [smul_eq_mul, add_polarCoord_symm_eq_circleMap]
-    _ = _ := by
-        rw [Measure.volume_eq_prod ℝ ℝ, setLIntegral_prod _ hjoint.aemeasurable]
-
-/-- **Cauchy–Schwarz.** The square of the integral of a function is at most the mass of the measure
-times the integral of its square. -/
-private theorem sq_lintegral_le_measure_univ_mul {α : Type*} [MeasurableSpace α] (μ : Measure α)
-    {u : α → ℝ≥0∞} (hu : AEMeasurable u μ) :
-    (∫⁻ x, u x ∂μ) ^ 2 ≤ μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
-  have h := ENNReal.lintegral_mul_le_Lp_mul_Lq μ Real.HolderConjugate.two_two hu
-    (aemeasurable_const (b := (1 : ℝ≥0∞)))
-  simp only [Pi.mul_apply, mul_one, ENNReal.one_rpow, lintegral_const, one_mul] at h
-  have hrp : ∀ x : ℝ≥0∞, (x ^ (1 / 2 : ℝ)) ^ 2 = x := by
-    intro x
-    rw [← ENNReal.rpow_natCast (x ^ (1 / 2 : ℝ)) 2, ← ENNReal.rpow_mul]
-    norm_num
-  calc (∫⁻ x, u x ∂μ) ^ 2
-      ≤ ((∫⁻ x, u x ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ) * (μ Set.univ) ^ (1 / 2 : ℝ)) ^ 2 :=
-        pow_le_pow_left' h 2
-    _ = (∫⁻ x, u x ^ (2 : ℝ) ∂μ) * μ Set.univ := by rw [mul_pow, hrp, hrp]
-    _ = μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
-        rw [mul_comm]
-        exact congrArg _ (lintegral_congr fun x => ENNReal.rpow_natCast (u x) 2)
-
-/-- Cauchy–Schwarz in the angular variable: the square of the angular integral of the length
-density is at most `2 π` times the angular integral of its square. -/
-private theorem sq_lintegral_angle_le (f : ℂ → ℂ) (hs : MeasurableSet s) (ζ : ℂ) (ρ : ℝ) :
-    (∫⁻ θ in Ioo (-π) π, enormDerivIndicator f s (circleMap ζ ρ θ)) ^ 2 ≤
-      ENNReal.ofReal (2 * π) *
-        ∫⁻ θ in Ioo (-π) π, enormDerivIndicator f s (circleMap ζ ρ θ) ^ 2 := by
-  have hvol : (volume.restrict (Ioo (-π) π)) Set.univ = ENNReal.ofReal (2 * π) := by
-    rw [Measure.restrict_apply_univ, Real.volume_Ioo]
-    ring_nf
-  have hum : AEMeasurable (fun θ => enormDerivIndicator f s (circleMap ζ ρ θ))
-      (volume.restrict (Ioo (-π) π)) :=
-    ((measurable_enormDerivIndicator f hs).comp (measurable_circleMap ζ ρ)).aemeasurable
-  simpa [hvol] using sq_lintegral_le_measure_univ_mul (volume.restrict (Ioo (-π) π)) hum
 
 /-- **The length–area inequality.** The integral of `ℓ ρ ^ 2 / ρ` over all radii, where `ℓ ρ` is
 `TauCeti.circleImageLength f s ζ ρ` — the derivative-weighted angular integral over the part inside
 `s` of the circle of radius `ρ` about `ζ`, an arc length counted with multiplicity when `f` is
 holomorphic there — is at most `2 π` times the Dirichlet integral of `f` over `s`.
 
-This is Cauchy–Schwarz in the angular variable — the source of the factor `2 π`, the length of the
-angular interval — followed by the polar-coordinate change of variables, which reassembles the
-angular integrals of `‖deriv f‖ₑ ^ 2` into the plane integral. Nothing is assumed of `f`; the
-holomorphic content of the method is the identification of the right-hand side with the area of
-`f '' s` in `TauCeti.lintegral_circleImageLength_sq_div_le_volume_image`. -/
+This is `TauCeti.lintegral_circleLIntegral_sq_div_le_lintegral_sq` at the weight `‖deriv f‖ₑ` cut
+off outside `s`. Nothing is assumed of `f`; the holomorphic content of the method is the
+identification of the right-hand side with the area of `f '' s` in
+`TauCeti.lintegral_circleImageLength_sq_div_le_volume_image`. -/
 theorem lintegral_circleImageLength_sq_div_le_lintegral_enorm_deriv_sq (f : ℂ → ℂ)
     (hs : MeasurableSet s) (ζ : ℂ) :
     ∫⁻ ρ in Ioi (0 : ℝ), circleImageLength f s ζ ρ ^ 2 / ENNReal.ofReal ρ ≤
       ENNReal.ofReal (2 * π) * ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2 := by
-  rw [lintegral_enorm_deriv_sq_eq_polar f hs ζ, ← lintegral_const_mul' _ _ ENNReal.ofReal_ne_top]
-  refine setLIntegral_mono' measurableSet_Ioi fun ρ hρ => ?_
-  have hρpos : (0 : ℝ) < ρ := hρ
-  have hρ0 : ENNReal.ofReal ρ ≠ 0 := (ENNReal.ofReal_pos.mpr hρpos).ne'
-  rw [circleImageLength_eq, lintegral_const_mul' _ _ ENNReal.ofReal_ne_top,
-    ENNReal.div_le_iff hρ0 ENNReal.ofReal_ne_top, mul_pow]
-  calc ENNReal.ofReal ρ ^ 2 *
-        (∫⁻ θ in Ioo (-π) π, enormDerivIndicator f s (circleMap ζ ρ θ)) ^ 2
-      ≤ ENNReal.ofReal ρ ^ 2 * (ENNReal.ofReal (2 * π) *
-          ∫⁻ θ in Ioo (-π) π, enormDerivIndicator f s (circleMap ζ ρ θ) ^ 2) := by
-        gcongr
-        exact sq_lintegral_angle_le f hs ζ ρ
-    _ = ENNReal.ofReal (2 * π) *
-          (ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π,
-            enormDerivIndicator f s (circleMap ζ ρ θ) ^ 2) * ENNReal.ofReal ρ := by ring
+  simp only [circleImageLength_def]
+  rw [← lintegral_indicator_enorm_deriv_sq f hs]
+  exact lintegral_circleLIntegral_sq_div_le_lintegral_sq (measurable_indicator_enorm_deriv f hs) ζ
 
 /-- **The length–area inequality, area form.** On a measurable subset `s` of the domain of
 holomorphy on which `f` is injective the Dirichlet integral is the area of `f '' s`, so the total
@@ -309,27 +204,6 @@ theorem lintegral_circleImageLength_sq_div_le_volume_image (hUo : IsOpen U)
       ENNReal.ofReal (2 * π) * volume (f '' s) := by
   rw [volume_image_eq_lintegral_enorm_deriv_sq hUo hf hs.nullMeasurableSet hsU hinj]
   exact lintegral_circleImageLength_sq_div_le_lintegral_enorm_deriv_sq f hs ζ
-
-/-- The logarithmic measure of an annulus: `∫⁻ ρ in Ioo r R, ρ⁻¹ = log (R / r)`. It is the
-divergence of this integral as `r → 0` that gives the length–area method its force. -/
-private theorem lintegral_inv_ofReal_Ioo {r R : ℝ} (hr : 0 < r) (hrR : r < R) :
-    ∫⁻ ρ in Ioo r R, (ENNReal.ofReal ρ)⁻¹ = ENNReal.ofReal (Real.log (R / r)) := by
-  have hR : 0 < R := hr.trans hrR
-  have hcont : ContinuousOn (fun x : ℝ => x⁻¹) (Set.uIcc r R) := by
-    refine ContinuousOn.inv₀ continuousOn_id fun x hx => ?_
-    rw [Set.uIcc_of_le hrR.le] at hx
-    exact ne_of_gt (lt_of_lt_of_le hr hx.1)
-  have hint : IntegrableOn (fun x : ℝ => x⁻¹) (Ioo r R) :=
-    (hcont.intervalIntegrable).1.mono_set Set.Ioo_subset_Ioc_self
-  have hnn : (0 : ℝ → ℝ) ≤ᵐ[volume.restrict (Ioo r R)] fun x : ℝ => x⁻¹ := by
-    filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
-    exact le_of_lt (inv_pos.mpr (hr.trans hx.1))
-  have hval : ∫ x in Ioo r R, x⁻¹ = Real.log (R / r) := by
-    rw [← MeasureTheory.integral_Ioc_eq_integral_Ioo, ← intervalIntegral.integral_of_le hrR.le]
-    exact integral_inv_of_pos hr hR
-  rw [← hval, MeasureTheory.ofReal_integral_eq_lintegral_ofReal hint hnn]
-  refine setLIntegral_congr_fun measurableSet_Ioo fun x hx => ?_
-  rw [ENNReal.ofReal_inv_of_pos (hr.trans hx.1)]
 
 /-- **Wolff's lemma.** If `2 π` times the Dirichlet integral of `f` over `s` is smaller than
 `c * log (R / r)`, then some circle of radius `ρ` between `r` and `R` has `ℓ ρ ^ 2 < c`.
@@ -343,28 +217,9 @@ theorem exists_circleImageLength_sq_lt (f : ℂ → ℂ) (hs : MeasurableSet s) 
     (hc : ENNReal.ofReal (2 * π) * (∫⁻ z in s, ‖deriv f z‖ₑ ^ 2) <
       c * ENNReal.ofReal (Real.log (R / r))) :
     ∃ ρ ∈ Ioo r R, circleImageLength f s ζ ρ ^ 2 < c := by
-  by_contra hcon
-  have hle : ∀ ρ ∈ Ioo r R, c ≤ circleImageLength f s ζ ρ ^ 2 := fun ρ hρ =>
-    not_lt.mp fun h => hcon ⟨ρ, hρ, h⟩
-  have hconst : ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ =
-      c * ENNReal.ofReal (Real.log (R / r)) := by
-    rw [lintegral_const_mul'' (f := fun ρ : ℝ => (ENNReal.ofReal ρ)⁻¹) c
-      ENNReal.measurable_ofReal.inv.aemeasurable, lintegral_inv_ofReal_Ioo hr hrR]
-  have hmono : ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ ≤
-      ∫⁻ ρ in Ioo r R, circleImageLength f s ζ ρ ^ 2 / ENNReal.ofReal ρ := by
-    refine setLIntegral_mono' measurableSet_Ioo fun ρ hρ => ?_
-    rw [div_eq_mul_inv]
-    gcongr
-    exact hle ρ hρ
-  have hsub : ∫⁻ ρ in Ioo r R, circleImageLength f s ζ ρ ^ 2 / ENNReal.ofReal ρ ≤
-      ∫⁻ ρ in Ioi (0 : ℝ), circleImageLength f s ζ ρ ^ 2 / ENNReal.ofReal ρ :=
-    lintegral_mono_set fun x hx => hr.trans hx.1
-  refine absurd (hc.trans_le ?_) (lt_irrefl _)
-  calc c * ENNReal.ofReal (Real.log (R / r))
-      = ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ := hconst.symm
-    _ ≤ ENNReal.ofReal (2 * π) * ∫⁻ z in s, ‖deriv f z‖ₑ ^ 2 :=
-        (hmono.trans hsub).trans
-          (lintegral_circleImageLength_sq_div_le_lintegral_enorm_deriv_sq f hs ζ)
+  simp only [circleImageLength_def]
+  refine exists_circleLIntegral_sq_lt (measurable_indicator_enorm_deriv f hs) ζ hr hrR ?_
+  rwa [lintegral_indicator_enorm_deriv_sq f hs]
 
 /-- **Wolff's lemma, area form.** On a measurable subset `s` of the domain of holomorphy on which
 `f` is injective the Dirichlet integral is the area of `f '' s`, so a radius with `ℓ ρ ^ 2 < c`
@@ -376,6 +231,9 @@ theorem exists_circleImageLength_sq_lt_of_volume_image (hUo : IsOpen U)
     ∃ ρ ∈ Ioo r R, circleImageLength f s ζ ρ ^ 2 < c := by
   refine exists_circleImageLength_sq_lt f hs ζ hr hrR ?_
   rwa [volume_image_eq_lintegral_enorm_deriv_sq hUo hf hs.nullMeasurableSet hsU hinj] at hc
+
+/-! ### The chord bound -/
+
 
 /-- **The fundamental theorem of calculus along a circular arc.** Integrating `deriv f` against the
 velocity of the parametrisation recovers the increment of `f` between the endpoints.

--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -131,7 +131,7 @@ theorem circleImageLength_def (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : �
 theorem circleImageLength_mono (f : ℂ → ℂ) (ζ : ℂ) (ρ : ℝ) (hst : s ⊆ t) :
     circleImageLength f s ζ ρ ≤ circleImageLength f t ζ ρ := by
   rw [circleImageLength_def, circleImageLength_def]
-  refine circleLIntegral_mono (fun z => ?_) ζ ρ
+  refine circleLIntegral_mono_on ζ ρ (fun z _ => ?_)
   by_cases hz : z ∈ s
   · simp [Set.indicator_of_mem hz, Set.indicator_of_mem (hst hz)]
   · simp [Set.indicator_of_notMem hz]

--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -26,8 +26,10 @@ the **length density of `f`**, namely `‖deriv f‖ₑ` cut off outside `s`, an
 sides of the general estimates then mean:
 
 * the circle integral `TauCeti.circleLIntegral` of that weight is
-  `TauCeti.circleImageLength f s ζ ρ`, for measurable `s` and holomorphic `f` the arc length of the
-  parametrised curve `f ∘ circleMap ζ ρ` over the angles landing in `s`;
+  `TauCeti.circleImageLength f s ζ ρ`, which for `ρ > 0`, measurable `s` and holomorphic `f` is the
+  arc length of the parametrised curve `f ∘ circleMap ζ ρ` over the angles landing in `s` (for
+  `ρ ≤ 0` it is `0` by the `ENNReal.ofReal ρ` convention of `TauCeti.circleLIntegral`, and carries
+  no geometric reading);
 * its plane integral of squares is the Dirichlet integral of `f` over `s`, hence by
   `Conformal/Area.lean` the area of `f '' s`.
 
@@ -49,9 +51,9 @@ from these estimates in order to force the cluster set at `ζ` to degenerate to 
 ## Main results
 
 * `TauCeti.circleImageLength` — the circle integral of the length density of `f` cut off outside
-  `s`; for measurable `s` and holomorphic `f` this is the arc length of `f ∘ circleMap ζ ρ` over the
-  angles landing in `s`, a length along the parametrisation, counted with multiplicity, rather than
-  a measure of the image set.
+  `s`; for `ρ > 0`, measurable `s` and holomorphic `f` this is the arc length of `f ∘ circleMap ζ ρ`
+  over the angles landing in `s`, a length along the parametrisation, counted with multiplicity,
+  rather than a measure of the image set.
 * `TauCeti.ofReal_dist_le_circleImageLength` — the chord bound justifying the name, and the only
   claim made here about lengths that is actually proved: a sub-arc of angular width at most `2 * π`
   that stays in `s` and in a set on which `f` is holomorphic has the distance between the images of
@@ -108,9 +110,11 @@ carries no geometric meaning. What is proved of it here is
 `TauCeti.ofReal_dist_le_circleImageLength`, which for `f` holomorphic bounds the chord across an
 arc of angles lying in `s` by this quantity, and that is what justifies the name.
 
-For measurable `s` and holomorphic `f` the informal reading is the arc length of the parametrised
-curve `f ∘ circleMap ζ ρ` restricted to the angles whose points lie in `s`, whose speed at angle
-`θ` is `ρ * ‖deriv f (circleMap ζ ρ θ)‖`. Even then it is length along the *parametrisation*, so
+For `0 < ρ`, measurable `s` and holomorphic `f` the informal reading is the arc length of the
+parametrised curve `f ∘ circleMap ζ ρ` restricted to the angles whose points lie in `s`, whose
+speed at angle `θ` is `ρ * ‖deriv f (circleMap ζ ρ θ)‖`. For `ρ ≤ 0` the quantity is `0` by the
+`ENNReal.ofReal ρ` convention of `TauCeti.circleLIntegral`, so no arc-length reading applies there.
+Even for `0 < ρ` it is length along the *parametrisation*, so
 points covered several times are counted with multiplicity, and it is a length of the image *set*
 only when `f` is in addition injective on that part of the circle; neither reading is formalised
 here. For a map with no complex derivative the reading fails outright, since `deriv` is then the
@@ -131,12 +135,13 @@ theorem circleImageLength_def (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) (ρ : �
 theorem circleImageLength_mono (f : ℂ → ℂ) (ζ : ℂ) (ρ : ℝ) (hst : s ⊆ t) :
     circleImageLength f s ζ ρ ≤ circleImageLength f t ζ ρ := by
   rw [circleImageLength_def, circleImageLength_def]
-  refine circleLIntegral_mono_on ζ ρ (fun z _ => ?_)
+  refine circleLIntegral_mono_on ζ ρ (fun _ z _ => ?_)
   by_cases hz : z ∈ s
   · simp [Set.indicator_of_mem hz, Set.indicator_of_mem (hst hz)]
   · simp [Set.indicator_of_notMem hz]
 
-/-- A circle of nonpositive radius contributes no length. -/
+/-- The quantity vanishes at a nonpositive radius, inheriting the `ENNReal.ofReal ρ` convention of
+`TauCeti.circleLIntegral`: it is that convention rather than a statement about lengths. -/
 @[simp]
 theorem circleImageLength_of_nonpos (f : ℂ → ℂ) (s : Set ℂ) (ζ : ℂ) {ρ : ℝ} (hρ : ρ ≤ 0) :
     circleImageLength f s ζ ρ = 0 := by

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -141,7 +141,8 @@ theorem circleLIntegral_const (a : ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
   rcases le_or_gt ρ 0 with hρ | _
   · rw [circleLIntegral_def, ENNReal.ofReal_of_nonpos hρ, zero_mul,
       ENNReal.ofReal_of_nonpos (mul_nonpos_of_nonneg_of_nonpos (by positivity) hρ), zero_mul]
-  · rw [circleLIntegral_def, setLIntegral_const, Real.volume_Ioo, show π - -π = 2 * π by ring,
+  · have hπ : π - -π = 2 * π := by ring
+    rw [circleLIntegral_def, setLIntegral_const, Real.volume_Ioo, hπ,
       ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ 2 * π)]
     ring
 
@@ -157,6 +158,26 @@ theorem circleLIntegral_of_nonpos (g : ℂ → ℝ≥0∞) (ζ : ℂ) (hρ : ρ 
 @[simp]
 theorem circleLIntegral_zero (ζ : ℂ) (ρ : ℝ) : circleLIntegral 0 ζ ρ = 0 := by
   simp [circleLIntegral_def]
+
+/-- **The circle integral is additive in the weight**, as soon as one summand has an a.e.
+measurable angular trace along the circle at hand; as in `TauCeti.circleLIntegral_sq_le`, nothing
+is assumed of either weight off that circle. Some such hypothesis is needed, a lower integral being
+only superadditive in general. It is the hypothesis of `MeasureTheory.lintegral_add_left'`, which
+is why — like that lemma, and unlike its `Measurable` counterpart — this is not a `simp` lemma. -/
+theorem circleLIntegral_add {h : ℂ → ℝ≥0∞} (ζ : ℂ) (ρ : ℝ)
+    (hg : AEMeasurable (fun θ => g (circleMap ζ ρ θ)) (volume.restrict (Ioo (-π) π))) :
+    circleLIntegral (fun z => g z + h z) ζ ρ =
+      circleLIntegral g ζ ρ + circleLIntegral h ζ ρ := by
+  rw [circleLIntegral_def, circleLIntegral_def, circleLIntegral_def, lintegral_add_left' hg,
+    mul_add]
+
+/-- **A finite constant comes out of the circle integral.** This is
+`MeasureTheory.lintegral_const_mul'`, whose finiteness hypothesis on the constant is what lets the
+weight stay arbitrary; as there, no measurability is needed. -/
+theorem circleLIntegral_const_mul (a : ℝ≥0∞) (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) (ha : a ≠ ∞) :
+    circleLIntegral (fun z => a * g z) ζ ρ = a * circleLIntegral g ζ ρ := by
+  rw [circleLIntegral_def, circleLIntegral_def, lintegral_const_mul' _ _ ha]
+  ring
 
 /-- The angular integrand has period `2 * π`, because `circleMap ζ ρ` does. -/
 private theorem periodic_comp_circleMap (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -1,0 +1,320 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
+public import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+import Mathlib.Analysis.SpecialFunctions.PolarCoord
+import Mathlib.MeasureTheory.Integral.CircleIntegral
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
+import Mathlib.MeasureTheory.Integral.MeanInequalities
+import Mathlib.MeasureTheory.Integral.Prod
+
+/-!
+# The lower integral of a weight over a circle, and the length–area inequality
+
+For a weight `g : ℂ → ℝ≥0∞` this file introduces `TauCeti.circleLIntegral g ζ ρ`, the lower
+integral of `g` over the circle of centre `ζ` and radius `ρ` with respect to arc length, computed
+through Mathlib's parametrisation `circleMap ζ ρ` whose speed is the constant `ρ`:
+
+`circleLIntegral g ζ ρ = ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)`.
+
+Two facts about it are proved, and they are the two halves of the classical **length–area method**.
+
+The first is **polar Fubini**: integrating the circle integrals over all radii recovers the plane
+integral,
+
+`∫⁻ ρ in Ioi 0, circleLIntegral g ζ ρ = ∫⁻ z, g z`
+
+(`TauCeti.lintegral_circleLIntegral_eq_lintegral`), for every measurable `g` and every centre `ζ`.
+This is Mathlib's `Complex.lintegral_comp_polarCoord_symm` recentred at `ζ` and unfolded into an
+iterated integral, the factor `ENNReal.ofReal ρ` in the definition being exactly the Jacobian
+`ρ dρ dθ` of polar coordinates.
+
+The second is **Cauchy–Schwarz on the circle**: the square of the circle integral of `g` is at most
+`2 π ρ` — the length of the circle — times the circle integral of `g ^ 2`
+(`TauCeti.circleLIntegral_sq_le`). Dividing by `ρ` and integrating in `ρ`, polar Fubini reassembles
+the right-hand side into the plane integral of `g ^ 2` and gives the **length–area inequality**
+
+`∫⁻ ρ in Ioi 0, circleLIntegral g ζ ρ ^ 2 / ρ ≤ 2 π ∫⁻ z, g z ^ 2`
+
+(`TauCeti.lintegral_circleLIntegral_sq_div_le_lintegral_sq`). Since the logarithmic measure
+`∫⁻ ρ in Ioo r R, ρ⁻¹ = log (R / r)` of an annulus diverges as `r → 0`, a finite right-hand side
+cannot keep `circleLIntegral g ζ ρ ^ 2` above a positive constant throughout a long annulus:
+**Wolff's lemma** `TauCeti.exists_circleLIntegral_sq_lt` produces a radius `ρ` between `r` and `R`
+with `circleLIntegral g ζ ρ ^ 2 < c` as soon as `2 π ∫⁻ z, g z ^ 2 < c * log (R / r)`.
+
+Nothing here is analytic: `g` is an arbitrary measurable weight, and the two inputs are the
+polar-coordinate change of variables and Hölder's inequality. The analytic use is
+`TauCeti/Analysis/Complex/Conformal/LengthArea.lean`, which takes `g` to be `‖deriv f‖ₑ` cut off
+outside a set `s`, so that `circleLIntegral g ζ ρ` becomes the arc length of the image of a circular
+arc under a holomorphic `f` and `∫⁻ z, g z ^ 2` its Dirichlet integral, hence the area of the image;
+that file is the layer **L5** input of `TauCetiRoadmap/ConformalMapping/README.md`. Stating the
+estimates for a weight keeps them available to any other length-versus-area argument — the plane
+integral on the right need not be an area and the circle integral on the left need not be a length.
+
+## Main definitions and results
+
+* `TauCeti.circleLIntegral` — the lower integral of a weight over a circle with respect to arc
+  length, through the parametrisation `circleMap`.
+* `TauCeti.circleLIntegral_eq_lintegral_Ioc` — the angular integral may be taken over any period,
+  so the branch cut at `±π` fixed in the definition is immaterial.
+* `TauCeti.lintegral_circleLIntegral_eq_lintegral` — **polar Fubini**: the circle integrals about
+  any centre integrate over the radii to the plane integral.
+* `TauCeti.circleLIntegral_sq_le` — **Cauchy–Schwarz on the circle**: the square of the circle
+  integral of `g` is at most the circumference times the circle integral of `g ^ 2`.
+* `TauCeti.lintegral_circleLIntegral_sq_div_le_lintegral_sq` — the **length–area inequality**.
+* `TauCeti.exists_circleLIntegral_sq_lt` — **Wolff's lemma**: a radius with small circle integral
+  exists in every annulus whose logarithmic measure is large enough.
+
+## References
+
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2 (the length–area method).
+* P. L. Duren, *Univalent Functions*, Ch. 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Set
+open scoped ENNReal Real
+
+variable {g : ℂ → ℝ≥0∞} {ζ : ℂ} {ρ : ℝ}
+
+/-! ### The circle integral of a weight -/
+
+/-- The **lower integral of the weight `g` over the circle** of centre `ζ` and radius `ρ`, taken
+with respect to arc length: the angular integral of `g ∘ circleMap ζ ρ` scaled by the speed `ρ` of
+that parametrisation.
+
+Nothing is assumed of `g`, so this is a lower integral of a possibly non-measurable integrand. The
+angle runs over `Ioo (-π) π`, one full period of `circleMap ζ ρ`; by
+`TauCeti.circleLIntegral_eq_lintegral_Ioc` any other period gives the same value. A negative radius,
+for which `circleMap` traverses the same circle backwards, gives the value `0`. -/
+noncomputable def circleLIntegral (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) : ℝ≥0∞ :=
+  ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)
+
+/-- The defining angular integral. The body of `TauCeti.circleLIntegral` is not `@[expose]`d, so
+this is the form in which other modules reach the definition. -/
+theorem circleLIntegral_def (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
+    circleLIntegral g ζ ρ = ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) := by
+  rw [circleLIntegral]
+
+/-- Increasing the weight increases its circle integral. -/
+theorem circleLIntegral_mono {h : ℂ → ℝ≥0∞} (hgh : ∀ z, g z ≤ h z) (ζ : ℂ) (ρ : ℝ) :
+    circleLIntegral g ζ ρ ≤ circleLIntegral h ζ ρ := by
+  rw [circleLIntegral_def, circleLIntegral_def]
+  gcongr with θ
+  exact hgh _
+
+/-- A circle of nonpositive radius carries no arc length. -/
+@[simp]
+theorem circleLIntegral_of_nonpos (g : ℂ → ℝ≥0∞) (ζ : ℂ) (hρ : ρ ≤ 0) :
+    circleLIntegral g ζ ρ = 0 := by
+  rw [circleLIntegral_def, ENNReal.ofReal_of_nonpos hρ, zero_mul]
+
+/-- The zero weight has zero circle integral. -/
+@[simp]
+theorem circleLIntegral_zero (ζ : ℂ) (ρ : ℝ) : circleLIntegral 0 ζ ρ = 0 := by
+  simp [circleLIntegral_def]
+
+/-- The angular integrand has period `2 * π`, because `circleMap ζ ρ` does. -/
+private theorem periodic_comp_circleMap (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
+    Function.Periodic (fun θ => g (circleMap ζ ρ θ)) (2 * π) := fun θ =>
+  congrArg g (periodic_circleMap ζ ρ θ)
+
+/-- One period of the angular integral is as good as any other: `Ioc t (t + 2 * π)` is a
+fundamental domain for the translations by `2 * π`, which the integrand is invariant under. -/
+private theorem lintegral_Ioc_comp_circleMap (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) (t u : ℝ) :
+    ∫⁻ θ in Ioc t (t + 2 * π), g (circleMap ζ ρ θ) =
+      ∫⁻ θ in Ioc u (u + 2 * π), g (circleMap ζ ρ θ) :=
+  (isAddFundamentalDomain_Ioc Real.two_pi_pos t).setLIntegral_eq
+    (isAddFundamentalDomain_Ioc Real.two_pi_pos u) _
+    fun v θ => (periodic_comp_circleMap g ζ ρ).map_vadd_zmultiples v θ
+
+/-- **The angular integral may be taken over any period.** The interval `Ioo (-π) π` fixed in the
+definition of `TauCeti.circleLIntegral` can be replaced by any `Ioc t (t + 2 * π)`, so nothing about
+the quantity depends on the branch cut at `±π`; in particular an arc of the circle that crosses the
+seam is handled by choosing `t` beyond its far endpoint. -/
+theorem circleLIntegral_eq_lintegral_Ioc (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) (t : ℝ) :
+    circleLIntegral g ζ ρ =
+      ENNReal.ofReal ρ * ∫⁻ θ in Ioc t (t + 2 * π), g (circleMap ζ ρ θ) := by
+  have hπ : -π + 2 * π = π := by ring
+  rw [circleLIntegral_def, ← lintegral_Ioc_comp_circleMap g ζ ρ (-π) t, hπ]
+  exact congrArg _ (setLIntegral_congr Ioo_ae_eq_Ioc)
+
+/-! ### Polar Fubini -/
+
+/-- The polar-coordinate parametrisation of `ℂ` centred at `ζ` is `circleMap ζ`. -/
+private theorem add_polarCoord_symm_eq_circleMap (ζ : ℂ) (p : ℝ × ℝ) :
+    ζ + Complex.polarCoord.symm p = circleMap ζ p.1 p.2 := by
+  simp [circleMap, Complex.exp_mul_I, ← Complex.ofReal_cos, ← Complex.ofReal_sin]
+
+private theorem continuous_circleMap_uncurry (ζ : ℂ) :
+    Continuous fun p : ℝ × ℝ => circleMap ζ p.1 p.2 := by
+  simp only [circleMap]
+  fun_prop
+
+/-- **Polar Fubini for the lower integral.** Integrating the circle integrals of a measurable
+weight over all radii recovers its plane integral, whatever centre the circles are taken about.
+
+This is the polar-coordinate change of variables `Complex.lintegral_comp_polarCoord_symm`,
+recentred at `ζ` by translation invariance of the plane measure and unfolded into an iterated
+integral over the radius and the angle; the factor `ENNReal.ofReal ρ` built into
+`TauCeti.circleLIntegral` is the Jacobian. -/
+theorem lintegral_circleLIntegral_eq_lintegral (hg : Measurable g) (ζ : ℂ) :
+    ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ = ∫⁻ z, g z := by
+  have hjoint : Measurable fun p : ℝ × ℝ =>
+      ENNReal.ofReal p.1 * g (circleMap ζ p.1 p.2) :=
+    (ENNReal.measurable_ofReal.comp measurable_fst).mul
+      (hg.comp (continuous_circleMap_uncurry ζ).measurable)
+  calc ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ
+      = ∫⁻ ρ in Ioi (0 : ℝ), ∫⁻ θ in Ioo (-π) π, ENNReal.ofReal ρ * g (circleMap ζ ρ θ) := by
+        refine setLIntegral_congr_fun measurableSet_Ioi fun ρ _ => ?_
+        rw [circleLIntegral_def, lintegral_const_mul' _ _ ENNReal.ofReal_ne_top]
+    _ = ∫⁻ p in Ioi (0 : ℝ) ×ˢ Ioo (-π) π, ENNReal.ofReal p.1 * g (circleMap ζ p.1 p.2) := by
+        rw [Measure.volume_eq_prod ℝ ℝ, setLIntegral_prod _ hjoint.aemeasurable]
+    _ = ∫⁻ z, g (ζ + z) := by
+        rw [← Complex.lintegral_comp_polarCoord_symm fun z => g (ζ + z), _root_.polarCoord_target]
+        simp_rw [smul_eq_mul, add_polarCoord_symm_eq_circleMap]
+    _ = ∫⁻ z, g z := lintegral_add_left_eq_self g ζ
+
+/-! ### Cauchy–Schwarz on a circle, and the length–area inequality -/
+
+/-- **Cauchy–Schwarz.** The square of the integral of a function is at most the mass of the measure
+times the integral of its square. -/
+private theorem sq_lintegral_le_measure_univ_mul {α : Type*} [MeasurableSpace α] (μ : Measure α)
+    {u : α → ℝ≥0∞} (hu : AEMeasurable u μ) :
+    (∫⁻ x, u x ∂μ) ^ 2 ≤ μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
+  have h := ENNReal.lintegral_mul_le_Lp_mul_Lq μ Real.HolderConjugate.two_two hu
+    (aemeasurable_const (b := (1 : ℝ≥0∞)))
+  simp only [Pi.mul_apply, mul_one, ENNReal.one_rpow, lintegral_const, one_mul] at h
+  have hrp : ∀ x : ℝ≥0∞, (x ^ (1 / 2 : ℝ)) ^ 2 = x := by
+    intro x
+    rw [← ENNReal.rpow_natCast (x ^ (1 / 2 : ℝ)) 2, ← ENNReal.rpow_mul]
+    norm_num
+  calc (∫⁻ x, u x ∂μ) ^ 2
+      ≤ ((∫⁻ x, u x ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ) * (μ Set.univ) ^ (1 / 2 : ℝ)) ^ 2 :=
+        pow_le_pow_left' h 2
+    _ = (∫⁻ x, u x ^ (2 : ℝ) ∂μ) * μ Set.univ := by rw [mul_pow, hrp, hrp]
+    _ = μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
+        rw [mul_comm]
+        exact congrArg _ (lintegral_congr fun x => ENNReal.rpow_natCast (u x) 2)
+
+/-- Cauchy–Schwarz in the angular variable: the square of the angular integral is at most `2 π`,
+the length of the angular interval, times the angular integral of the square. -/
+private theorem sq_lintegral_angle_le (hg : Measurable g) (ζ : ℂ) (ρ : ℝ) :
+    (∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)) ^ 2 ≤
+      ENNReal.ofReal (2 * π) * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2 := by
+  have hvol : (volume.restrict (Ioo (-π) π)) Set.univ = ENNReal.ofReal (2 * π) := by
+    rw [Measure.restrict_apply_univ, Real.volume_Ioo]
+    ring_nf
+  have hum : AEMeasurable (fun θ => g (circleMap ζ ρ θ)) (volume.restrict (Ioo (-π) π)) :=
+    (hg.comp (measurable_circleMap ζ ρ)).aemeasurable
+  simpa [hvol] using sq_lintegral_le_measure_univ_mul (volume.restrict (Ioo (-π) π)) hum
+
+/-- **Cauchy–Schwarz on a circle.** The square of the circle integral of `g` is at most the
+circumference `2 π ρ` times the circle integral of `g ^ 2`.
+
+Both sides vanish for a nonpositive radius, so no positivity is assumed. -/
+theorem circleLIntegral_sq_le (hg : Measurable g) (ζ : ℂ) (ρ : ℝ) :
+    circleLIntegral g ζ ρ ^ 2 ≤
+      ENNReal.ofReal (2 * π * ρ) * circleLIntegral (fun z => g z ^ 2) ζ ρ := by
+  rcases le_or_gt ρ 0 with hρ | hρ
+  · simp [circleLIntegral_of_nonpos _ _ hρ]
+  have h2π : (0 : ℝ) ≤ 2 * π := by positivity
+  rw [circleLIntegral_def, circleLIntegral_def, mul_pow, ENNReal.ofReal_mul h2π]
+  calc ENNReal.ofReal ρ ^ 2 * (∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)) ^ 2
+      ≤ ENNReal.ofReal ρ ^ 2 *
+          (ENNReal.ofReal (2 * π) * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2) := by
+        gcongr
+        exact sq_lintegral_angle_le hg ζ ρ
+    _ = ENNReal.ofReal (2 * π) * ENNReal.ofReal ρ *
+          (ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2) := by ring
+
+/-- **The length–area inequality.** For a measurable weight `g` and any centre `ζ`, the integral
+over all radii of `circleLIntegral g ζ ρ ^ 2 / ρ` is at most `2 π` times the plane integral of
+`g ^ 2`.
+
+This is Cauchy–Schwarz on each circle (`TauCeti.circleLIntegral_sq_le`) — the source of the factor
+`2 π` — followed by polar Fubini (`TauCeti.lintegral_circleLIntegral_eq_lintegral`) applied to the
+weight `g ^ 2`, which reassembles the circle integrals of `g ^ 2` into its plane integral. -/
+theorem lintegral_circleLIntegral_sq_div_le_lintegral_sq (hg : Measurable g) (ζ : ℂ) :
+    ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ ≤
+      ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 := by
+  have hstep : ∀ ρ ∈ Ioi (0 : ℝ), circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ ≤
+      ENNReal.ofReal (2 * π) * circleLIntegral (fun z => g z ^ 2) ζ ρ := by
+    intro ρ hρ
+    have hρpos : (0 : ℝ) < ρ := hρ
+    have hρ0 : ENNReal.ofReal ρ ≠ 0 := (ENNReal.ofReal_pos.mpr hρpos).ne'
+    rw [ENNReal.div_le_iff hρ0 ENNReal.ofReal_ne_top]
+    refine (circleLIntegral_sq_le hg ζ ρ).trans (le_of_eq ?_)
+    rw [ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ 2 * π)]
+    ring
+  calc ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ
+      ≤ ∫⁻ ρ in Ioi (0 : ℝ), ENNReal.ofReal (2 * π) * circleLIntegral (fun z => g z ^ 2) ζ ρ :=
+        setLIntegral_mono' measurableSet_Ioi hstep
+    _ = ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 := by
+        rw [lintegral_const_mul' _ _ ENNReal.ofReal_ne_top,
+          lintegral_circleLIntegral_eq_lintegral (hg.pow_const 2) ζ]
+
+/-- The logarithmic measure of an annulus: `∫⁻ ρ in Ioo r R, ρ⁻¹ = log (R / r)`. It is the
+divergence of this integral as `r → 0` that gives the length–area method its force. -/
+private theorem lintegral_inv_ofReal_Ioo {r R : ℝ} (hr : 0 < r) (hrR : r < R) :
+    ∫⁻ ρ in Ioo r R, (ENNReal.ofReal ρ)⁻¹ = ENNReal.ofReal (Real.log (R / r)) := by
+  have hR : 0 < R := hr.trans hrR
+  have hcont : ContinuousOn (fun x : ℝ => x⁻¹) (Set.uIcc r R) := by
+    refine ContinuousOn.inv₀ continuousOn_id fun x hx => ?_
+    rw [Set.uIcc_of_le hrR.le] at hx
+    exact ne_of_gt (lt_of_lt_of_le hr hx.1)
+  have hint : IntegrableOn (fun x : ℝ => x⁻¹) (Ioo r R) :=
+    (hcont.intervalIntegrable).1.mono_set Set.Ioo_subset_Ioc_self
+  have hnn : (0 : ℝ → ℝ) ≤ᵐ[volume.restrict (Ioo r R)] fun x : ℝ => x⁻¹ := by
+    filter_upwards [self_mem_ae_restrict measurableSet_Ioo] with x hx
+    exact le_of_lt (inv_pos.mpr (hr.trans hx.1))
+  have hval : ∫ x in Ioo r R, x⁻¹ = Real.log (R / r) := by
+    rw [← MeasureTheory.integral_Ioc_eq_integral_Ioo, ← intervalIntegral.integral_of_le hrR.le]
+    exact integral_inv_of_pos hr hR
+  rw [← hval, MeasureTheory.ofReal_integral_eq_lintegral_ofReal hint hnn]
+  refine setLIntegral_congr_fun measurableSet_Ioo fun x hx => ?_
+  rw [ENNReal.ofReal_inv_of_pos (hr.trans hx.1)]
+
+/-- **Wolff's lemma.** If `2 π` times the plane integral of `g ^ 2` is smaller than
+`c * log (R / r)`, then some circle of radius `ρ` strictly between `r` and `R` has
+`circleLIntegral g ζ ρ ^ 2 < c`.
+
+Since `log (R / r)` grows without bound as the annulus is made longer while the plane integral
+stays fixed, this makes the circle integral arbitrarily small at arbitrarily small radii: a weight
+of finite square integral cannot have a large circle integral on every circle about `ζ`. -/
+theorem exists_circleLIntegral_sq_lt (hg : Measurable g) (ζ : ℂ) {r R : ℝ} (hr : 0 < r)
+    (hrR : r < R) {c : ℝ≥0∞}
+    (hc : ENNReal.ofReal (2 * π) * (∫⁻ z, g z ^ 2) < c * ENNReal.ofReal (Real.log (R / r))) :
+    ∃ ρ ∈ Ioo r R, circleLIntegral g ζ ρ ^ 2 < c := by
+  by_contra hcon
+  have hle : ∀ ρ ∈ Ioo r R, c ≤ circleLIntegral g ζ ρ ^ 2 := fun ρ hρ =>
+    not_lt.mp fun h => hcon ⟨ρ, hρ, h⟩
+  have hconst : ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ =
+      c * ENNReal.ofReal (Real.log (R / r)) := by
+    rw [lintegral_const_mul'' (f := fun ρ : ℝ => (ENNReal.ofReal ρ)⁻¹) c
+      ENNReal.measurable_ofReal.inv.aemeasurable, lintegral_inv_ofReal_Ioo hr hrR]
+  have hmono : ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ ≤
+      ∫⁻ ρ in Ioo r R, circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ := by
+    refine setLIntegral_mono' measurableSet_Ioo fun ρ hρ => ?_
+    rw [div_eq_mul_inv]
+    gcongr
+    exact hle ρ hρ
+  have hsub : ∫⁻ ρ in Ioo r R, circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ ≤
+      ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ :=
+    lintegral_mono_set fun x hx => hr.trans hx.1
+  refine absurd (hc.trans_le ?_) (lt_irrefl _)
+  calc c * ENNReal.ofReal (Real.log (R / r))
+      = ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ := hconst.symm
+    _ ≤ ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 :=
+        (hmono.trans hsub).trans (lintegral_circleLIntegral_sq_div_le_lintegral_sq hg ζ)
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -112,20 +112,26 @@ theorem circleLIntegral_def (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
   rw [circleLIntegral]
 
 /-- Increasing the weight on the circle increases its circle integral: only the values on
-`Metric.sphere ζ |ρ|`, the circle the integral is taken over, matter. -/
+`Metric.sphere ζ ρ`, the circle the integral is taken over, matter.
+
+The comparison is asked for only at a positive radius, since at a nonpositive one both sides are
+`0` and nothing about `g` and `h` is needed. -/
 theorem circleLIntegral_mono_on {h : ℂ → ℝ≥0∞} (ζ : ℂ) (ρ : ℝ)
-    (hgh : ∀ z ∈ Metric.sphere ζ |ρ|, g z ≤ h z) :
+    (hgh : 0 < ρ → ∀ z ∈ Metric.sphere ζ ρ, g z ≤ h z) :
     circleLIntegral g ζ ρ ≤ circleLIntegral h ζ ρ := by
+  rcases le_or_gt ρ 0 with hρ | hρ
+  · rw [circleLIntegral_def, circleLIntegral_def, ENNReal.ofReal_of_nonpos hρ, zero_mul, zero_mul]
   rw [circleLIntegral_def, circleLIntegral_def]
   gcongr with θ
-  exact hgh _ (circleMap_mem_sphere' ζ ρ θ)
+  exact hgh hρ _ (circleMap_mem_sphere ζ hρ.le θ)
 
-/-- Weights agreeing on the circle have the same circle integral. -/
+/-- Weights agreeing on the circle have the same circle integral; as in
+`TauCeti.circleLIntegral_mono_on`, agreement is asked for only at a positive radius. -/
 theorem circleLIntegral_congr {h : ℂ → ℝ≥0∞} (ζ : ℂ) (ρ : ℝ)
-    (hgh : EqOn g h (Metric.sphere ζ |ρ|)) :
+    (hgh : 0 < ρ → EqOn g h (Metric.sphere ζ ρ)) :
     circleLIntegral g ζ ρ = circleLIntegral h ζ ρ :=
-  le_antisymm (circleLIntegral_mono_on ζ ρ fun _ hz => (hgh hz).le)
-    (circleLIntegral_mono_on ζ ρ fun _ hz => (hgh hz).ge)
+  le_antisymm (circleLIntegral_mono_on ζ ρ fun hρ _ hz => (hgh hρ hz).le)
+    (circleLIntegral_mono_on ζ ρ fun hρ _ hz => (hgh hρ hz).ge)
 
 /-- The circle integral of a constant weight is `2 π ρ` — for `ρ > 0` the circumference of the
 circle — times that constant; for `ρ ≤ 0` both sides are `0`. -/
@@ -139,7 +145,9 @@ theorem circleLIntegral_const (a : ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
       ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ 2 * π)]
     ring
 
-/-- A circle of nonpositive radius carries no arc length. -/
+/-- The circle integral vanishes at a nonpositive radius, by the factor `ENNReal.ofReal ρ` in the
+definition of `TauCeti.circleLIntegral`. This is that convention, not a geometric statement: for
+`ρ < 0` the parametrisation `circleMap ζ ρ` still runs once around the circle of radius `|ρ|`. -/
 @[simp]
 theorem circleLIntegral_of_nonpos (g : ℂ → ℝ≥0∞) (ζ : ℂ) (hρ : ρ ≤ 0) :
     circleLIntegral g ζ ρ = 0 := by

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -19,9 +19,13 @@ import Mathlib.MeasureTheory.Integral.Prod
 
 For a weight `g : ℂ → ℝ≥0∞` this file introduces `TauCeti.circleLIntegral g ζ ρ`, the lower
 integral of `g` over the circle of centre `ζ` and radius `ρ` with respect to arc length, computed
-through Mathlib's parametrisation `circleMap ζ ρ` whose speed is the constant `ρ`:
+through Mathlib's parametrisation `circleMap ζ ρ`, which for `ρ > 0` runs once around that circle
+at the constant speed `ρ`:
 
 `circleLIntegral g ζ ρ = ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)`.
+
+For `ρ ≤ 0` the factor `ENNReal.ofReal ρ` makes the value `0`, a convention rather than a reading
+of the parametrisation; the arc-length statements below are therefore statements about `ρ > 0`.
 
 Two facts about it are proved, and they are the two halves of the classical **length–area method**.
 
@@ -36,7 +40,7 @@ iterated integral, the factor `ENNReal.ofReal ρ` in the definition being exactl
 `ρ dρ dθ` of polar coordinates.
 
 The second is **Cauchy–Schwarz on the circle**: the square of the circle integral of `g` is at most
-`2 π ρ` — the length of the circle — times the circle integral of `g ^ 2`
+`2 π ρ` — for `ρ > 0` the length of the circle — times the circle integral of `g ^ 2`
 (`TauCeti.circleLIntegral_sq_le`). Dividing by `ρ` and integrating in `ρ`, polar Fubini reassembles
 the right-hand side into the plane integral of `g ^ 2` and gives the **length–area inequality**
 
@@ -89,13 +93,15 @@ variable {g : ℂ → ℝ≥0∞} {ζ : ℂ} {ρ : ℝ}
 /-! ### The circle integral of a weight -/
 
 /-- The **lower integral of the weight `g` over the circle** of centre `ζ` and radius `ρ`, taken
-with respect to arc length: the angular integral of `g ∘ circleMap ζ ρ` scaled by the speed `ρ` of
-that parametrisation.
+with respect to arc length: for `ρ > 0`, the angular integral of `g ∘ circleMap ζ ρ` scaled by the
+speed `ρ` of that parametrisation.
 
 Nothing is assumed of `g`, so this is a lower integral of a possibly non-measurable integrand. The
 angle runs over `Ioo (-π) π`, one full period of `circleMap ζ ρ`; by
-`TauCeti.circleLIntegral_eq_lintegral_Ioc` any other period gives the same value. A negative radius,
-for which `circleMap` traverses the same circle backwards, gives the value `0`. -/
+`TauCeti.circleLIntegral_eq_lintegral_Ioc` any other period gives the same value. A nonpositive
+radius gives the value `0`, by the factor `ENNReal.ofReal ρ`: that is a deliberate convention, not
+a property of the parametrisation, since for `ρ < 0` the map `circleMap ζ ρ` still runs once around
+the circle of radius `|ρ|`, at speed `|ρ|` and in the same direction, only rotated by `π`. -/
 noncomputable def circleLIntegral (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) : ℝ≥0∞ :=
   ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)
 
@@ -105,12 +111,33 @@ theorem circleLIntegral_def (g : ℂ → ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
     circleLIntegral g ζ ρ = ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) := by
   rw [circleLIntegral]
 
-/-- Increasing the weight increases its circle integral. -/
-theorem circleLIntegral_mono {h : ℂ → ℝ≥0∞} (hgh : ∀ z, g z ≤ h z) (ζ : ℂ) (ρ : ℝ) :
+/-- Increasing the weight on the circle increases its circle integral: only the values on
+`Metric.sphere ζ |ρ|`, the circle the integral is taken over, matter. -/
+theorem circleLIntegral_mono_on {h : ℂ → ℝ≥0∞} (ζ : ℂ) (ρ : ℝ)
+    (hgh : ∀ z ∈ Metric.sphere ζ |ρ|, g z ≤ h z) :
     circleLIntegral g ζ ρ ≤ circleLIntegral h ζ ρ := by
   rw [circleLIntegral_def, circleLIntegral_def]
   gcongr with θ
-  exact hgh _
+  exact hgh _ (circleMap_mem_sphere' ζ ρ θ)
+
+/-- Weights agreeing on the circle have the same circle integral. -/
+theorem circleLIntegral_congr {h : ℂ → ℝ≥0∞} (ζ : ℂ) (ρ : ℝ)
+    (hgh : EqOn g h (Metric.sphere ζ |ρ|)) :
+    circleLIntegral g ζ ρ = circleLIntegral h ζ ρ :=
+  le_antisymm (circleLIntegral_mono_on ζ ρ fun _ hz => (hgh hz).le)
+    (circleLIntegral_mono_on ζ ρ fun _ hz => (hgh hz).ge)
+
+/-- The circle integral of a constant weight is `2 π ρ` — for `ρ > 0` the circumference of the
+circle — times that constant; for `ρ ≤ 0` both sides are `0`. -/
+@[simp]
+theorem circleLIntegral_const (a : ℝ≥0∞) (ζ : ℂ) (ρ : ℝ) :
+    circleLIntegral (fun _ => a) ζ ρ = ENNReal.ofReal (2 * π * ρ) * a := by
+  rcases le_or_gt ρ 0 with hρ | _
+  · rw [circleLIntegral_def, ENNReal.ofReal_of_nonpos hρ, zero_mul,
+      ENNReal.ofReal_of_nonpos (mul_nonpos_of_nonneg_of_nonpos (by positivity) hρ), zero_mul]
+  · rw [circleLIntegral_def, setLIntegral_const, Real.volume_Ioo, show π - -π = 2 * π by ring,
+      ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ 2 * π)]
+    ring
 
 /-- A circle of nonpositive radius carries no arc length. -/
 @[simp]
@@ -208,21 +235,22 @@ private theorem sq_lintegral_le_measure_univ_mul {α : Type*} [MeasurableSpace �
 
 /-- Cauchy–Schwarz in the angular variable: the square of the angular integral is at most `2 π`,
 the length of the angular interval, times the angular integral of the square. -/
-private theorem sq_lintegral_angle_le (hg : Measurable g) (ζ : ℂ) (ρ : ℝ) :
+private theorem sq_lintegral_angle_le
+    (hg : AEMeasurable (fun θ => g (circleMap ζ ρ θ)) (volume.restrict (Ioo (-π) π))) :
     (∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ)) ^ 2 ≤
       ENNReal.ofReal (2 * π) * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2 := by
   have hvol : (volume.restrict (Ioo (-π) π)) Set.univ = ENNReal.ofReal (2 * π) := by
     rw [Measure.restrict_apply_univ, Real.volume_Ioo]
     ring_nf
-  have hum : AEMeasurable (fun θ => g (circleMap ζ ρ θ)) (volume.restrict (Ioo (-π) π)) :=
-    (hg.comp (measurable_circleMap ζ ρ)).aemeasurable
-  simpa [hvol] using sq_lintegral_le_measure_univ_mul (volume.restrict (Ioo (-π) π)) hum
+  simpa [hvol] using sq_lintegral_le_measure_univ_mul (volume.restrict (Ioo (-π) π)) hg
 
-/-- **Cauchy–Schwarz on a circle.** The square of the circle integral of `g` is at most the
-circumference `2 π ρ` times the circle integral of `g ^ 2`.
+/-- **Cauchy–Schwarz on a circle.** The square of the circle integral of `g` is at most
+`2 π ρ` — for `ρ > 0` the circumference of the circle — times the circle integral of `g ^ 2`.
 
-Both sides vanish for a nonpositive radius, so no positivity is assumed. -/
-theorem circleLIntegral_sq_le (hg : Measurable g) (ζ : ℂ) (ρ : ℝ) :
+Only the angular trace of `g` along the circle at hand need be measurable; nothing is assumed of
+`g` off that circle. Both sides vanish for a nonpositive radius, so no positivity is assumed. -/
+theorem circleLIntegral_sq_le (ζ : ℂ) (ρ : ℝ)
+    (hg : AEMeasurable (fun θ => g (circleMap ζ ρ θ)) (volume.restrict (Ioo (-π) π))) :
     circleLIntegral g ζ ρ ^ 2 ≤
       ENNReal.ofReal (2 * π * ρ) * circleLIntegral (fun z => g z ^ 2) ζ ρ := by
   rcases le_or_gt ρ 0 with hρ | hρ
@@ -233,7 +261,7 @@ theorem circleLIntegral_sq_le (hg : Measurable g) (ζ : ℂ) (ρ : ℝ) :
       ≤ ENNReal.ofReal ρ ^ 2 *
           (ENNReal.ofReal (2 * π) * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2) := by
         gcongr
-        exact sq_lintegral_angle_le hg ζ ρ
+        exact sq_lintegral_angle_le hg
     _ = ENNReal.ofReal (2 * π) * ENNReal.ofReal ρ *
           (ENNReal.ofReal ρ * ∫⁻ θ in Ioo (-π) π, g (circleMap ζ ρ θ) ^ 2) := by ring
 
@@ -253,7 +281,8 @@ theorem lintegral_circleLIntegral_sq_div_le_lintegral_sq (hg : Measurable g) (ζ
     have hρpos : (0 : ℝ) < ρ := hρ
     have hρ0 : ENNReal.ofReal ρ ≠ 0 := (ENNReal.ofReal_pos.mpr hρpos).ne'
     rw [ENNReal.div_le_iff hρ0 ENNReal.ofReal_ne_top]
-    refine (circleLIntegral_sq_le hg ζ ρ).trans (le_of_eq ?_)
+    refine (circleLIntegral_sq_le ζ ρ
+      (hg.comp (measurable_circleMap ζ ρ)).aemeasurable).trans (le_of_eq ?_)
     rw [ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ 2 * π)]
     ring
   calc ∫⁻ ρ in Ioi (0 : ℝ), circleLIntegral g ζ ρ ^ 2 / ENNReal.ofReal ρ


### PR DESCRIPTION
This PR generalises the length–area inequality and Wolff's lemma from the length density of a holomorphic map to an arbitrary measurable weight on the plane. `TauCeti/Analysis/Complex/Conformal/LengthArea.lean` on `main` proves both for `‖deriv f‖ₑ` cut off outside a set `s`, while saying of itself that "the length–area inequality itself needs no holomorphy: it is Cauchy–Schwarz followed by the polar-coordinate change of variables, and holds for the measurable function `deriv f` whatever it is". This is that self-identified specialisation lifted: a new `TauCeti/MeasureTheory/Integral/CircleLIntegral.lean` introduces `TauCeti.circleLIntegral g ζ ρ`, the lower integral of a weight `g : ℂ → ℝ≥0∞` over the circle of centre `ζ` and radius `ρ` with respect to arc length, and proves for it the polar Fubini identity `∫⁻ ρ in Ioi 0, circleLIntegral g ζ ρ = ∫⁻ z, g z`, Cauchy–Schwarz on a circle `circleLIntegral g ζ ρ ^ 2 ≤ 2 π ρ * circleLIntegral (g ^ 2) ζ ρ`, the length–area inequality `∫⁻ ρ in Ioi 0, circleLIntegral g ζ ρ ^ 2 / ρ ≤ 2 π ∫⁻ z, g z ^ 2`, and Wolff's lemma. `TauCeti.circleImageLength` becomes the circle integral of the length density of `f`, and every public statement of `Conformal/LengthArea.lean` keeps its name and its statement, so the two consumers `Conformal/ShortCrosscut.lean` and `Conformal/CutDiameter.lean` are untouched.

Two things improve besides the generality. The polar Fubini identity is new and reusable on its own: it recentres Mathlib's `Complex.lintegral_comp_polarCoord_symm` at an arbitrary point and unfolds it into an iterated integral over the radius and the angle, which is the form any radial argument on `ℂ` wants. And the length–area inequality's proof gets shorter, because Cauchy–Schwarz on a circle and polar Fubini now compose instead of being interleaved: the old proof had to carry the squared integrand through the polar rewrite by hand, whereas the new one applies the same Fubini identity to the weight `g ^ 2`. `Conformal/LengthArea.lean` loses 233 lines and gains 91, keeping only what is genuinely holomorphic — the identification of the Dirichlet integral with the area of `f '' s` through `Conformal/Area.lean`, and the chord bound `TauCeti.ofReal_dist_le_circleImageLength` that makes `TauCeti.circleImageLength` a length rather than an abstract integral.

This reworks material already on `main`, so it needs no fresh roadmap claim; the roadmap chiefly motivating it is `TauCetiRoadmap/ConformalMapping/README.md`, whose layer **L5** ("Carathéodory boundary correspondence", the Jordan-domain case) is what the length–area estimates are built for — the frontier step named there is "the length–area (Koebe–Wolff) estimate that shows the boundary cluster sets are singletons". Nothing about that step's status changes here; the mathematics moved and grew a variable. No new declaration duplicates the pinned Mathlib: `circleLIntegral` is free (Mathlib has `circleIntegral` and `circleAverage`, both `E`-valued Bochner integrals), and the pinned Mathlib has no length–area estimate, no Wolff lemma, and no `ℝ≥0∞`-valued circle integral. The Mathlib inputs — `Complex.lintegral_comp_polarCoord_symm` for the change of variables, `ENNReal.lintegral_mul_le_Lp_mul_Lq` for Hölder, `isAddFundamentalDomain_Ioc` for the period independence, `measurable_circleMap`, `measurable_deriv` — are consumed, not restated. No Mathlib source was vendored.

Module moves: none. New module `TauCeti.MeasureTheory.Integral.CircleLIntegral`, placed beside Mathlib's own `Mathlib/MeasureTheory/Integral/CircleAverage.lean` and `CircleIntegral.lean`; `TauCeti.Analysis.Complex.Conformal.LengthArea` now imports it.

`lake build` and `lake exe axioms` are green (`all within the allowlist [propext, Classical.choice, Quot.sound]`), and `scripts/lint-env.sh` reports no new violations.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"length-area-inequality-arbitrary-weight"}-->

🤖 Prepared with Claude Code
