### PR TITLE
feat: the order of a q-expansion under period rescaling

### DIFF
--- a/TauCeti/Analysis/Analytic/Order.lean
+++ b/TauCeti/Analysis/Analytic/Order.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Analytic.Order
-public import Mathlib.Analysis.Analytic.Constructions
 
 /-!
 # The analytic order of products and power-compositions

--- a/TauCeti/Analysis/Analytic/Order.lean
+++ b/TauCeti/Analysis/Analytic/Order.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Analytic.Order
-public import Mathlib.Analysis.Meromorphic.NormalForm
+public import Mathlib.Analysis.Analytic.Constructions
 
 /-!
 # The analytic order of products and power-compositions
@@ -18,6 +18,11 @@ products, and composing with `q ↦ q ^ N` at `0` multiplies the order by `N`.
 * `TauCeti.analyticOrderAt_prod`: the order of `∏ i ∈ s, F i` is `∑ i ∈ s`, of the orders.
 * `TauCeti.analyticOrderAt_comp_pow_zero`: the order of `q ↦ f (q ^ N)` at `0` is `N` times
   the order of `f` at `0`.
+
+## References
+
+* [Mathlib PR #39083](https://github.com/leanprover-community/mathlib4/pull/39083)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
 -/
 
 public section
@@ -45,6 +50,8 @@ lemma analyticOrderAt_comp_pow_zero (hf : AnalyticAt 𝕜 f 0) {N : ℕ} (hN : 0
   set g : 𝕜 → 𝕜 := fun q ↦ q ^ N with hg_def
   have hzero : g 0 = 0 := zero_pow hN.ne'
   have h_sub_eq : (fun x : 𝕜 ↦ g x - 0) = (id : 𝕜 → 𝕜) ^ N := funext fun x ↦ by simp [hg_def]
+  -- The composite is definitionally the power lambda; `show … from rfl` records the
+  -- identification once so the composition rule applies.
   rw [show (fun q : 𝕜 ↦ f (q ^ N)) = f ∘ g from rfl,
     AnalyticAt.analyticOrderAt_comp (hzero.symm ▸ hf) (analyticAt_id.pow N), hzero, h_sub_eq,
     analyticOrderAt_pow analyticAt_id, analyticOrderAt_id]

--- a/TauCeti/Analysis/Analytic/Order.lean
+++ b/TauCeti/Analysis/Analytic/Order.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Analytic.Order
+public import Mathlib.Analysis.Meromorphic.NormalForm
+
+/-!
+# The analytic order of products and power-compositions
+
+Two extensions of Mathlib's `analyticOrderAt` calculus: the order is additive over finite
+products, and composing with `q ↦ q ^ N` at `0` multiplies the order by `N`.
+
+## Main declarations
+
+* `TauCeti.analyticOrderAt_prod`: the order of `∏ i ∈ s, F i` is `∑ i ∈ s`, of the orders.
+* `TauCeti.analyticOrderAt_comp_pow_zero`: the order of `q ↦ f (q ^ N)` at `0` is `N` times
+  the order of `f` at `0`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {f : 𝕜 → 𝕜} {z₀ : 𝕜}
+
+/-- The order is additive when taking a finite product of analytic functions. -/
+theorem analyticOrderAt_prod {ι : Type*} {s : Finset ι} {F : ι → 𝕜 → 𝕜}
+    (hF : ∀ i ∈ s, AnalyticAt 𝕜 (F i) z₀) :
+    analyticOrderAt (∏ i ∈ s, F i) z₀ = ∑ i ∈ s, analyticOrderAt (F i) z₀ := by
+  induction s using Finset.cons_induction with
+  | empty => simp [analyticOrderAt_eq_zero]
+  | cons a s ha ih =>
+    rw [Finset.prod_cons, Finset.sum_cons,
+      analyticOrderAt_mul (hF a (Finset.mem_cons_self a s))
+        (Finset.analyticAt_prod _ fun i hi ↦ hF i (Finset.mem_cons_of_mem hi)),
+      ih fun i hi ↦ hF i (Finset.mem_cons_of_mem hi)]
+
+/-- The analytic order of `q ↦ f (q ^ N)` at `0` is `N` times the analytic order of `f`
+at `0`. -/
+lemma analyticOrderAt_comp_pow_zero (hf : AnalyticAt 𝕜 f 0) {N : ℕ} (hN : 0 < N) :
+    analyticOrderAt (fun q : 𝕜 ↦ f (q ^ N)) 0 = analyticOrderAt f 0 * N := by
+  set g : 𝕜 → 𝕜 := fun q ↦ q ^ N with hg_def
+  have hzero : g 0 = 0 := zero_pow hN.ne'
+  have h_sub_eq : (fun x : 𝕜 ↦ g x - 0) = (id : 𝕜 → 𝕜) ^ N := funext fun x ↦ by simp [hg_def]
+  rw [show (fun q : 𝕜 ↦ f (q ^ N)) = f ∘ g from rfl,
+    AnalyticAt.analyticOrderAt_comp (hzero.symm ▸ hf) (analyticAt_id.pow N), hzero, h_sub_eq,
+    analyticOrderAt_pow analyticAt_id, analyticOrderAt_id]
+  simp
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Complex/Periodic.lean
+++ b/TauCeti/Analysis/Complex/Periodic.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.Periodic
+
+/-!
+# The local parameter under translation and period rescaling
+
+Two algebraic identities for the local parameter `𝕢 h z = exp (2 π I z / h)` at a cusp:
+translating the argument multiplies by an exponential, and the `m`-th power of the local
+parameter at period `m * h` is the local parameter at period `h`.
+
+## Main declarations
+
+* `TauCeti.Periodic.qParam_sub`: `𝕢 h (z - j) = 𝕢 h z * exp (-2 π I j / h)`.
+* `TauCeti.Periodic.qParam_nat_mul_pow`: `𝕢 (m * h) z ^ m = 𝕢 h z` for `m ≠ 0`.
+-/
+
+public section
+
+open Complex
+open scoped Real
+
+namespace TauCeti.Periodic
+
+open Function.Periodic
+
+local notation "𝕢" => Function.Periodic.qParam
+
+variable {h : ℝ}
+
+/-- Translation by `j` in the argument of `qParam` corresponds to multiplication by
+`exp (-2 π I j / h)`. -/
+theorem qParam_sub (z j : ℂ) : 𝕢 h (z - j) = 𝕢 h z * exp (-2 * π * I * j / h) := by
+  simp only [qParam, ← Complex.exp_add]
+  ring_nf
+
+/-- The `m`-th power of the local parameter at period `m * h` is the local parameter at
+period `h`. -/
+theorem qParam_nat_mul_pow {m : ℕ} (hm : m ≠ 0) (z : ℂ) : 𝕢 (m * h) z ^ m = 𝕢 h z := by
+  simp only [qParam, ← Complex.exp_nat_mul, ofReal_mul, ofReal_natCast]
+  rw [mul_div_assoc', mul_div_mul_left _ _ (Nat.cast_ne_zero.mpr hm)]
+
+end TauCeti.Periodic
+
+end

--- a/TauCeti/Analysis/Complex/Periodic.lean
+++ b/TauCeti/Analysis/Complex/Periodic.lean
@@ -17,6 +17,11 @@ parameter at period `m * h` is the local parameter at period `h`.
 
 * `TauCeti.Periodic.qParam_sub`: `𝕢 h (z - j) = 𝕢 h z * exp (-2 π I j / h)`.
 * `TauCeti.Periodic.qParam_nat_mul_pow`: `𝕢 (m * h) z ^ m = 𝕢 h z` for `m ≠ 0`.
+
+## References
+
+* [Mathlib PR #39083](https://github.com/leanprover-community/mathlib4/pull/39083)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
 -/
 
 public section

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -15,6 +15,11 @@ period exactly when the original function is invariant under the corresponding t
 ## Main declarations
 
 * `TauCeti.UpperHalfPlane.periodic_comp_ofComplex_iff`.
+
+## References
+
+* [Mathlib PR #39083](https://github.com/leanprover-community/mathlib4/pull/39083)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
 -/
 
 public section
@@ -31,6 +36,8 @@ lemma periodic_comp_ofComplex_iff {α : Type*} {f : ℍ → α} {c : ℝ} :
   · intro h τ
     have := h ↑τ
     simp only [Function.comp_apply] at this
+    -- Identify the translated coercion with the coercion of the translate, so both
+    -- `ofComplex` applications land back on `ℍ`.
     rwa [show (τ : ℂ) + ↑c = ↑(c +ᵥ τ) by rw [coe_vadd]; ring, ofComplex_apply,
       ofComplex_apply] at this
   · intro h w
@@ -38,6 +45,8 @@ lemma periodic_comp_ofComplex_iff {α : Type*} {f : ℍ → α} {c : ℝ} :
     · exact congrArg f (ofComplex_apply_eq_of_im_nonpos (by simpa using hw) hw)
     · have hw' : 0 < (w + ↑c).im := by simpa using hw
       simp only [Function.comp_apply]
+      -- Both points have positive imaginary part; identify the shifted point with the
+      -- vector translate so the hypothesis applies.
       rw [ofComplex_apply_of_im_pos hw', ofComplex_apply_of_im_pos hw,
         show (⟨w + ↑c, hw'⟩ : ℍ) = c +ᵥ (⟨w, hw⟩ : ℍ) from _root_.UpperHalfPlane.ext
           (by simp [add_comm])]

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
+
+/-!
+# Periodicity through `ofComplex`
+
+A function on the upper half-plane, extended to `ℂ` by `ofComplex`, is periodic with a real
+period exactly when the original function is invariant under the corresponding translation.
+
+## Main declarations
+
+* `TauCeti.UpperHalfPlane.periodic_comp_ofComplex_iff`.
+-/
+
+public section
+
+open UpperHalfPlane
+
+namespace TauCeti.UpperHalfPlane
+
+/-- A function `ℍ → α`, extended to `ℂ` via `ofComplex`, is periodic with real period `c` iff
+the original function is invariant under translation by `c`. -/
+lemma periodic_comp_ofComplex_iff {α : Type*} {f : ℍ → α} {c : ℝ} :
+    Function.Periodic (f ∘ ofComplex) c ↔ ∀ τ : ℍ, f (c +ᵥ τ) = f τ := by
+  constructor
+  · intro h τ
+    have := h ↑τ
+    simp only [Function.comp_apply] at this
+    rwa [show (τ : ℂ) + ↑c = ↑(c +ᵥ τ) by rw [coe_vadd]; ring, ofComplex_apply,
+      ofComplex_apply] at this
+  · intro h w
+    rcases le_or_gt w.im 0 with hw | hw
+    · exact congrArg f (ofComplex_apply_eq_of_im_nonpos (by simpa using hw) hw)
+    · have hw' : 0 < (w + ↑c).im := by simpa using hw
+      simp only [Function.comp_apply]
+      rw [ofComplex_apply_of_im_pos hw', ofComplex_apply_of_im_pos hw,
+        show (⟨w + ↑c, hw'⟩ : ℍ) = c +ᵥ (⟨w, hw⟩ : ℍ) from _root_.UpperHalfPlane.ext
+          (by simp [add_comm])]
+      exact h _
+
+end TauCeti.UpperHalfPlane
+
+end

--- a/TauCeti/NumberTheory/ModularForms/NormTrace.lean
+++ b/TauCeti/NumberTheory/ModularForms/NormTrace.lean
@@ -15,8 +15,13 @@ infinity.
 
 ## Main declarations
 
-* `TauCeti.SlashInvariantForm.quotientFunc_mdiff`.
-* `TauCeti.SlashInvariantForm.quotientFunc_isBoundedAtImInfty`.
+* `TauCeti.SlashInvariantForm.mdifferentiable_quotientFunc`.
+* `TauCeti.SlashInvariantForm.isBoundedAtImInfty_quotientFunc`.
+
+## References
+
+* [Mathlib PR #39083](https://github.com/leanprover-community/mathlib4/pull/39083)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
 -/
 
 public noncomputable section
@@ -33,12 +38,12 @@ local notation "𝒬" => ℋ ⧸ (𝒢.subgroupOf ℋ)
 namespace TauCeti.SlashInvariantForm
 
 /-- Each translate in the package `quotientFunc` of a modular form is holomorphic. -/
-lemma quotientFunc_mdiff (q : 𝒬) : MDiff (quotientFunc f q) :=
+lemma mdifferentiable_quotientFunc (q : 𝒬) : MDiff (quotientFunc f q) :=
   Quotient.inductionOn q fun r ↦ (ModularForm.translate f r.val⁻¹).holo'
 
 /-- Each translate in the package `quotientFunc` of a modular form is bounded at infinity,
 when `∞` is a cusp of `ℋ` and the relative index is finite. -/
-lemma quotientFunc_isBoundedAtImInfty [𝒢.IsFiniteRelIndex ℋ] [Fact (IsCusp OnePoint.infty ℋ)]
+lemma isBoundedAtImInfty_quotientFunc [𝒢.IsFiniteRelIndex ℋ] [Fact (IsCusp OnePoint.infty ℋ)]
     (q : 𝒬) : IsBoundedAtImInfty (quotientFunc f q) :=
   Quotient.inductionOn q fun ⟨_, hr⟩ ↦ OnePoint.isBoundedAt_infty_iff.mp <|
     (ModularForm.translate f _).bdd_at_cusps'

--- a/TauCeti/NumberTheory/ModularForms/NormTrace.lean
+++ b/TauCeti/NumberTheory/ModularForms/NormTrace.lean
@@ -1,0 +1,49 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.NormTrace
+
+/-!
+# Analytic properties of the translate package
+
+For a modular form `f`, each translate in the package `SlashInvariantForm.quotientFunc` is
+holomorphic, and — when the cusp `∞` is a cusp of `ℋ` of finite relative index — bounded at
+infinity.
+
+## Main declarations
+
+* `TauCeti.SlashInvariantForm.quotientFunc_mdiff`.
+* `TauCeti.SlashInvariantForm.quotientFunc_isBoundedAtImInfty`.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane SlashInvariantForm
+
+open scoped ModularForm Topology Filter Manifold
+
+variable {𝒢 ℋ : Subgroup (GL (Fin 2) ℝ)} {F : Type*} (f : F) [FunLike F ℍ ℂ] {k : ℤ}
+  [ModularFormClass F 𝒢 k]
+
+local notation "𝒬" => ℋ ⧸ (𝒢.subgroupOf ℋ)
+
+namespace TauCeti.SlashInvariantForm
+
+/-- Each translate in the package `quotientFunc` of a modular form is holomorphic. -/
+lemma quotientFunc_mdiff (q : 𝒬) : MDiff (quotientFunc f q) :=
+  Quotient.inductionOn q fun r ↦ (ModularForm.translate f r.val⁻¹).holo'
+
+/-- Each translate in the package `quotientFunc` of a modular form is bounded at infinity,
+when `∞` is a cusp of `ℋ` and the relative index is finite. -/
+lemma quotientFunc_isBoundedAtImInfty [𝒢.IsFiniteRelIndex ℋ] [Fact (IsCusp OnePoint.infty ℋ)]
+    (q : 𝒬) : IsBoundedAtImInfty (quotientFunc f q) :=
+  Quotient.inductionOn q fun ⟨_, hr⟩ ↦ OnePoint.isBoundedAt_infty_iff.mp <|
+    (ModularForm.translate f _).bdd_at_cusps'
+      ((Fact.out : IsCusp _ _).of_isFiniteRelIndex_conj hr)
+
+end TauCeti.SlashInvariantForm
+
+end

--- a/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
@@ -1,0 +1,113 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.LFunction
+public import Mathlib.RingTheory.PowerSeries.Order
+public import TauCeti.Analysis.Analytic.Order
+public import TauCeti.Analysis.Complex.Periodic
+
+/-!
+# The order of a `q`-expansion under period rescaling
+
+The order of the `q`-expansion of a periodic, bounded, holomorphic function on the upper
+half-plane equals the analytic order of its `cuspFunction` at `0`; consequently, passing
+from period `h` to period `m * h` multiplies the order by `m`. This is the vanishing-order
+bookkeeping feeding the finite-index Sturm bound.
+
+We also package the `q`-expansion as a `ℂ`-linear map on modular forms.
+
+## Main declarations
+
+* `TauCeti.qExpansion_order_eq_analyticOrderAt_cuspFunction`.
+* `TauCeti.qExpansion_nat_mul_order`: `(qExpansion (m * h) g).order = (qExpansion h g).order * m`.
+* `TauCeti.qExpansion_order_le_qExpansion_nat_mul_order`.
+* `TauCeti.ModularForm.qExpansionLinearMap`.
+
+## References
+
+* [Mathlib PR #39083](https://github.com/leanprover-community/mathlib4/pull/39083)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane Complex Function SlashInvariantForm Periodic
+
+open scoped ModularForm Topology Filter Manifold
+
+namespace TauCeti
+
+variable {h : ℝ}
+
+/-- The order of the `q`-expansion equals the analytic order of the `cuspFunction` at `0`. -/
+lemma qExpansion_order_eq_analyticOrderAt_cuspFunction {f : ℍ → ℂ}
+    (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    (qExpansion h f).order = analyticOrderAt (cuspFunction h f) 0 := by
+  refine ENat.eq_of_forall_natCast_le_iff fun n ↦ ?_
+  rw [natCast_le_analyticOrderAt_iff_iteratedDeriv_eq_zero hf]
+  refine ⟨fun H i hi ↦ ?_, fun H ↦ PowerSeries.nat_le_order _ _ fun i hi ↦ ?_⟩
+  · have hcoeff : (qExpansion h f).coeff i = 0 :=
+      PowerSeries.coeff_of_lt_order _ (lt_of_lt_of_le (mod_cast hi) H)
+    rw [qExpansion_coeff] at hcoeff
+    exact (mul_eq_zero.mp hcoeff).resolve_left (inv_ne_zero (mod_cast Nat.factorial_ne_zero i))
+  · rw [qExpansion_coeff, H i hi, mul_zero]
+
+/-- The cusp function at period `m * h` agrees near `0` with the cusp function at period `h`
+composed with the `m`-th power map. -/
+lemma cuspFunction_nat_mul_eventuallyEq {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
+    cuspFunction (m * h : ℝ) g =ᶠ[nhds 0] fun q : ℂ ↦ cuspFunction h g (q ^ m) := by
+  have hmh : (0 : ℝ) < m * h := by positivity
+  have hg_per_mh : Periodic (g ∘ ofComplex) (m * h : ℝ) := by simpa using hg_per.nat_mul m
+  have hpow_cts : ContinuousAt (fun q : ℂ ↦ cuspFunction h g (q ^ m)) 0 :=
+    (analyticAt_cuspFunction_zero hh hg_per hg_mdiff hg_bdd).continuousAt.comp_of_eq
+      (by fun_prop) (zero_pow hm.ne')
+  rw [← (analyticAt_cuspFunction_zero hmh hg_per_mh hg_mdiff
+      hg_bdd).continuousAt.eventuallyEq_nhds_iff_eventuallyEq_nhdsNE hpow_cts,
+    eventuallyEq_nhdsWithin_iff]
+  filter_upwards [Metric.ball_mem_nhds (0 : ℂ) zero_lt_one] with q hq_lt hq_ne
+  rw [mem_ball_zero_iff] at hq_lt
+  set τ : ℍ := ⟨Periodic.invQParam ((m : ℝ) * h) q,
+    Periodic.im_invQParam_pos_of_norm_lt_one hmh hq_lt hq_ne⟩
+  have hτq : Periodic.qParam ((m : ℝ) * h) τ = q := Periodic.qParam_right_inv hmh.ne' hq_ne
+  rw [← hτq, TauCeti.Periodic.qParam_nat_mul_pow hm.ne', eq_cuspFunction τ hmh.ne' hg_per_mh,
+    eq_cuspFunction τ hh.ne' hg_per]
+
+/-- The order of the `q`-expansion at period `m * h` is `m` times the order at period `h`. -/
+lemma qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
+    (qExpansion (m * h : ℝ) g).order = (qExpansion h g).order * m := by
+  have han : AnalyticAt ℂ (cuspFunction h g) 0 :=
+    analyticAt_cuspFunction_zero hh hg_per hg_mdiff hg_bdd
+  rw [qExpansion_order_eq_analyticOrderAt_cuspFunction han,
+    qExpansion_order_eq_analyticOrderAt_cuspFunction (analyticAt_cuspFunction_zero
+      (by positivity) (by simpa using hg_per.nat_mul m) hg_mdiff hg_bdd),
+    analyticOrderAt_congr (cuspFunction_nat_mul_eventuallyEq hh hm hg_per hg_bdd hg_mdiff),
+    TauCeti.analyticOrderAt_comp_pow_zero han hm]
+
+/-- The order of the `q`-expansion at period `h` is at most its order at period `m * h`. -/
+lemma qExpansion_order_le_qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
+    (qExpansion h g).order ≤ (qExpansion (m * h : ℝ) g).order :=
+  (ENat.self_le_mul_right _ (mod_cast hm.ne')).trans
+    (qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff).ge
+
+namespace ModularForm
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)}
+
+/-- The qExpansion map as a `ℂ`-linear map to power series over `ℂ`. -/
+def qExpansionLinearMap [Γ.HasDetOne] (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) :
+    ModularForm Γ k →ₗ[ℂ] PowerSeries ℂ where
+  toFun f := qExpansion h f
+  map_add' f g := _root_.ModularForm.qExpansion_add hh hΓ f g
+  map_smul' a f := _root_.ModularForm.qExpansion_smul hh hΓ a f
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.NumberTheory.ModularForms.LFunction
+public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import Mathlib.RingTheory.PowerSeries.Order
 public import TauCeti.Analysis.Analytic.Order
 public import TauCeti.Analysis.Complex.Periodic
@@ -17,14 +17,10 @@ half-plane equals the analytic order of its `cuspFunction` at `0`; consequently,
 from period `h` to period `m * h` multiplies the order by `m`. This is the vanishing-order
 bookkeeping feeding the finite-index Sturm bound.
 
-We also package the `q`-expansion as a `ℂ`-linear map on modular forms.
-
 ## Main declarations
 
 * `TauCeti.qExpansion_order_eq_analyticOrderAt_cuspFunction`.
 * `TauCeti.qExpansion_nat_mul_order`: `(qExpansion (m * h) g).order = (qExpansion h g).order * m`.
-* `TauCeti.qExpansion_order_le_qExpansion_nat_mul_order`.
-* `TauCeti.ModularForm.qExpansionLinearMap`.
 
 ## References
 
@@ -87,26 +83,6 @@ lemma qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 
       (by positivity) (by simpa using hg_per.nat_mul m) hg_mdiff hg_bdd),
     analyticOrderAt_congr (cuspFunction_nat_mul_eventuallyEq hh hm hg_per hg_bdd hg_mdiff),
     TauCeti.analyticOrderAt_comp_pow_zero han hm]
-
-/-- The order of the `q`-expansion at period `h` is at most its order at period `m * h`. -/
-lemma qExpansion_order_le_qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 < m)
-    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
-    (qExpansion h g).order ≤ (qExpansion (m * h : ℝ) g).order :=
-  (ENat.self_le_mul_right _ (mod_cast hm.ne')).trans
-    (qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff).ge
-
-namespace ModularForm
-
-variable {Γ : Subgroup (GL (Fin 2) ℝ)}
-
-/-- The qExpansion map as a `ℂ`-linear map to power series over `ℂ`. -/
-def qExpansionLinearMap [Γ.HasDetOne] (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) :
-    ModularForm Γ k →ₗ[ℂ] PowerSeries ℂ where
-  toFun f := qExpansion h f
-  map_add' f g := _root_.ModularForm.qExpansion_add hh hΓ f g
-  map_smul' a f := _root_.ModularForm.qExpansion_smul hh hΓ a f
-
-end ModularForm
 
 end TauCeti
 


### PR DESCRIPTION
The order of the `q`-expansion of a periodic, bounded, holomorphic function on the upper half-plane equals the analytic order of its `cuspFunction` at `0`; consequently passing from period `h` to period `m * h` multiplies the order by `m` (`TauCeti.qExpansion_nat_mul_order`). Supporting lemmas: the analytic order of finite products and of `q ↦ f (q ^ N)` at `0`, the local-parameter identities `𝕢 h (z − j) = 𝕢 h z · exp(−2πIj/h)` and `𝕢 (m·h) z ^ m = 𝕢 h z`, periodicity through `ofComplex`, and holomorphy and boundedness of the `quotientFunc` translate package.

First increment of the finite-index Sturm-bound stack: ports the stalled upstream draft leanprover-community/mathlib4#39083 (author: Chris Birkbeck) onto the current Mathlib pin. The roadmap consumes the Sturm stack from Mathlib with an explicit vendor-on-stall fallback; these are the preparations everything downstream (cusp widths, Galois products, the norm decomposition, the bound itself) builds on.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"sturm-prep-qexpansion-order"}-->
