### PR TITLE
feat: synchronize general linear scheme points

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean
@@ -126,6 +126,13 @@ noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
     (Opposite.op (coordinateHopfAlgebra R))
 
+private lemma groupScheme_eq_hopfSpec :
+    groupScheme R =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+        (Opposite.op (coordinateHopfAlgebra R)) := by
+  unfold groupScheme
+  rfl
+
 -- The generic `hopfSpec_obj_*` lemmas are stated for the literal functor object, whereas
 -- `groupScheme` is a `def` whose body is not exposed outside this module. Downstream the generic
 -- lemmas therefore cannot be applied to `(groupScheme R).X` at all, and `simp` cannot see through
@@ -278,7 +285,8 @@ noncomputable def groupSchemePointMulEquiv :
     WithConv (SymmetricAlgebra R R →ₐ[R] A) ≃*
       ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
         (groupScheme R).X) :=
-  AlgebraicGeometry.Spec.mapMulEquiv
+  CommHopfAlgCat.mapMulEquivOfPresentation
+    (coordinateHopfAlgebra R) A (groupScheme_eq_hopfSpec R)
 
 /-- The underlying map of the spectrum point associated to an algebra point. -/
 @[simp]
@@ -287,10 +295,10 @@ lemma groupSchemePointMulEquiv_apply_left
     (groupSchemePointMulEquiv A f).left =
       Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
         eqToHom (groupScheme_X_left R).symm := by
-  -- Postcomposition crosses the named presentation equality; on the raw spectrum boundary the
-  -- specialized wrapper and Mathlib's spectrum-points equivalence agree definitionally.
-  apply (cancel_mono (eqToHom (groupScheme_X_left R))).1
-  rfl
+  simpa only [groupSchemePointMulEquiv] using
+    CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
+      (coordinateHopfAlgebra R) A (groupScheme_eq_hopfSpec R)
+        (groupScheme_X_left R) f
 
 /-- The group of scheme-valued points of the additive group scheme is the additive group of the
 value algebra.
@@ -340,27 +348,15 @@ theorem schemePointsMulEquiv_mapValue (φ : A →ₐ[R] B)
         (φ (Multiplicative.toAdd (schemePointsMulEquiv A p))) := by
   let q : WithConv (SymmetricAlgebra R R →ₐ[R] A) :=
     (groupSchemePointMulEquiv A).symm p
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapValue
-    (coordinateHopfAlgebra R) (CommAlgCat.ofHom φ) q
-  have hp : groupSchemePointMulEquiv A q = p :=
-    (groupSchemePointMulEquiv A).apply_symm_apply p
   have hpre :
       (groupSchemePointMulEquiv B).symm
           ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
             (Spec (CommRingCat.of R)) ≫ p) =
         HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R)
           (CommAlgCat.ofHom φ) q := by
-    apply (groupSchemePointMulEquiv B).injective
-    rw [(groupSchemePointMulEquiv B).apply_symm_apply, ← hp]
-    apply Over.OverMorphism.ext
-    apply (cancel_mono (eqToHom (groupScheme_X_left R))).1
-    erw [Over.comp_left]
-    simp only [OverClass.asOverHom_left, groupSchemePointMulEquiv_apply_left]
-    have hmapLeft := congrArg Over.Hom.left hmap.symm
-    simp only [Over.comp_left, OverClass.asOverHom_left] at hmapLeft
-    -- On the raw spectrum boundary, `Spec.mapMulEquiv` exposes this left component
-    -- definitionally, so the generic naturality theorem has exactly the required map equality.
-    exact hmapLeft
+    simpa only [q, groupSchemePointMulEquiv] using
+      CommHopfAlgCat.mapMulEquivOfPresentation_mapValue
+        (coordinateHopfAlgebra R) φ (groupScheme_eq_hopfSpec R) p
   simp only [schemePointsMulEquiv, MulEquiv.trans_apply]
   rw [hpre, HopfAlgebra.mapPoints_apply, ← AlgHom.mapValue_apply]
   exact gaPointsMulEquiv_mapValue φ q

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -145,23 +145,25 @@ theorem mapMulEquivOfPresentation_mapValue
     congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hG
   let q : WithConv (H →ₐ[R] A) :=
     (mapMulEquivOfPresentation H A hG).symm p
-  change (mapMulEquivOfPresentation H B hG).symm
-      ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
-        (Spec (CommRingCat.of R)) ≫ p) =
-    HopfAlgebra.mapPoints (H := H) (CommAlgCat.ofHom φ) q
-  have hmap := mapMulEquiv_mapValue H (CommAlgCat.ofHom φ) q
-  have hp : mapMulEquivOfPresentation H A hG q = p :=
-    (mapMulEquivOfPresentation H A hG).apply_symm_apply p
-  apply (mapMulEquivOfPresentation H B hG).injective
-  rw [(mapMulEquivOfPresentation H B hG).apply_symm_apply, ← hp]
-  apply Over.OverMorphism.ext
-  apply (cancel_mono (eqToHom hX)).1
-  erw [Over.comp_left]
-  rw [Category.assoc, mapMulEquivOfPresentation_apply_left_comp H A hG hX,
-    mapMulEquivOfPresentation_apply_left_comp H B hG hX]
-  have hmapLeft := congrArg Over.Hom.left hmap.symm
-  simp only [Over.comp_left, OverClass.asOverHom_left, mapMulEquiv_left] at hmapLeft
-  exact hmapLeft
+  have hq :
+      (mapMulEquivOfPresentation H B hG).symm
+          ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
+            (Spec (CommRingCat.of R)) ≫ p) =
+        HopfAlgebra.mapPoints (H := H) (CommAlgCat.ofHom φ) q := by
+    have hmap := mapMulEquiv_mapValue H (CommAlgCat.ofHom φ) q
+    have hp : mapMulEquivOfPresentation H A hG q = p :=
+      (mapMulEquivOfPresentation H A hG).apply_symm_apply p
+    apply (mapMulEquivOfPresentation H B hG).injective
+    rw [(mapMulEquivOfPresentation H B hG).apply_symm_apply, ← hp]
+    apply Over.OverMorphism.ext
+    apply (cancel_mono (eqToHom hX)).1
+    erw [Over.comp_left]
+    rw [Category.assoc, mapMulEquivOfPresentation_apply_left_comp H A hG hX,
+      mapMulEquivOfPresentation_apply_left_comp H B hG hX]
+    have hmapLeft := congrArg Over.Hom.left hmap.symm
+    simp only [Over.comp_left, OverClass.asOverHom_left, mapMulEquiv_left] at hmapLeft
+    exact hmapLeft
+  simpa only [q] using hq
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
 Hopf algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to

--- a/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/CommHopfAlgCat/SchemePoints.lean
@@ -22,13 +22,20 @@ commutative. The target `(Spec H).asOver (Spec R)` below is definitionally the u
 object of `(AlgebraicGeometry.hopfSpec R).obj (Opposite.op H)`.
 
 The equivalence and its multiplicativity are Mathlib's
-`AlgebraicGeometry.Spec.mapMulEquiv`. This file proves its covariance in the value algebra
-and contravariance in the coordinate Hopf algebra.
+`AlgebraicGeometry.Spec.mapMulEquiv`. This file provides its transport across named scheme
+presentations and proves its covariance in the value algebra and contravariance in the coordinate
+Hopf algebra.
 
 ## Main declarations
 
+* `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation`: Mathlib's spectrum-points equivalence with
+  its target transported across a named presentation.
+* `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_apply_left`: the underlying spectrum map of
+  the transported equivalence.
 * `TauCeti.CommHopfAlgCat.mapMulEquiv_mapValue`: a value-algebra map becomes
   precomposition by the corresponding spectrum morphism.
+* `TauCeti.CommHopfAlgCat.mapMulEquivOfPresentation_mapValue`: the same covariance after
+  transport across a named presentation.
 * `TauCeti.CommHopfAlgCat.mapMulEquiv_mapDomain`: a coordinate Hopf morphism
   becomes postcomposition by its contravariant `hopfSpec` image.
 -/
@@ -61,6 +68,49 @@ private lemma hopfSpec_map_left
       Spec.map (CommRingCat.ofHom φ.hom.toAlgHom.toRingHom) :=
   rfl
 
+/-- Mathlib's spectrum-points equivalence with its target transported to an equal named scheme
+over `Spec R`.
+
+The equality records the complete presentation as a group object over `Spec R`, so both the
+structural morphism and the pointwise group law are preserved by the transport. -/
+noncomputable def mapMulEquivOfPresentation
+    (H : _root_.CommHopfAlgCat.{u} R) (A : Type u) [CommRing A] [Algebra R A]
+    {G : Grp (Over (Spec (CommRingCat.of R)))}
+    (hG : G = (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H)) :
+    WithConv (H →ₐ[R] A) ≃*
+      ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶ G.X) := by
+  subst G
+  exact AlgebraicGeometry.Spec.mapMulEquiv
+
+private theorem mapMulEquivOfPresentation_apply_left_comp
+    (H : _root_.CommHopfAlgCat.{u} R) (A : Type u) [CommRing A] [Algebra R A]
+    {G : Grp (Over (Spec (CommRingCat.of R)))}
+    (hG : G = (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H))
+    (hX : G.X.left = Spec (CommRingCat.of H))
+    (f : WithConv (H →ₐ[R] A)) :
+    (mapMulEquivOfPresentation H A hG f).left ≫
+        eqToHom hX =
+      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) := by
+  subst G
+  rfl
+
+/-- The underlying scheme map of the spectrum point transported across a named presentation.
+
+The second equality names the presentation of the wrapped group's underlying scheme as `Spec H`;
+it determines the `eqToHom` appearing in the formula. -/
+theorem mapMulEquivOfPresentation_apply_left
+    (H : _root_.CommHopfAlgCat.{u} R) (A : Type u) [CommRing A] [Algebra R A]
+    {G : Grp (Over (Spec (CommRingCat.of R)))}
+    (hG : G = (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H))
+    (hX : G.X.left = Spec (CommRingCat.of H))
+    (f : WithConv (H →ₐ[R] A)) :
+    (mapMulEquivOfPresentation H A hG f).left =
+      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+        eqToHom hX.symm := by
+  apply (cancel_mono (eqToHom hX)).1
+  subst G
+  rfl
+
 /-- Mathlib's spectrum-points equivalence is natural in the value algebra. Postcomposing
 an `A`-valued algebra point by `φ : A ⟶ B` corresponds on spectra to precomposing by
 `Spec B ⟶ Spec A`. -/
@@ -77,6 +127,41 @@ theorem mapMulEquiv_mapValue
   simp only [mapMulEquiv_left, OverClass.asOverHom_left]
   erw [← Spec.map_comp]
   rfl
+
+/-- Naturality in the value algebra for spectrum points whose target is transported across a
+named presentation. -/
+theorem mapMulEquivOfPresentation_mapValue
+    (H : _root_.CommHopfAlgCat.{u} R)
+    {A B : Type u} [CommRing A] [CommRing B] [Algebra R A] [Algebra R B]
+    (φ : A →ₐ[R] B) {G : Grp (Over (Spec (CommRingCat.of R)))}
+    (hG : G = (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj (Opposite.op H))
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶ G.X) :
+    (mapMulEquivOfPresentation H B hG).symm
+        ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
+          (Spec (CommRingCat.of R)) ≫ p) =
+      HopfAlgebra.mapPoints (H := H) (CommAlgCat.ofHom φ)
+        ((mapMulEquivOfPresentation H A hG).symm p) := by
+  let hX : G.X.left = Spec (CommRingCat.of H) :=
+    congrArg (fun K : Grp (Over (Spec (CommRingCat.of R))) ↦ K.X.left) hG
+  let q : WithConv (H →ₐ[R] A) :=
+    (mapMulEquivOfPresentation H A hG).symm p
+  change (mapMulEquivOfPresentation H B hG).symm
+      ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
+        (Spec (CommRingCat.of R)) ≫ p) =
+    HopfAlgebra.mapPoints (H := H) (CommAlgCat.ofHom φ) q
+  have hmap := mapMulEquiv_mapValue H (CommAlgCat.ofHom φ) q
+  have hp : mapMulEquivOfPresentation H A hG q = p :=
+    (mapMulEquivOfPresentation H A hG).apply_symm_apply p
+  apply (mapMulEquivOfPresentation H B hG).injective
+  rw [(mapMulEquivOfPresentation H B hG).apply_symm_apply, ← hp]
+  apply Over.OverMorphism.ext
+  apply (cancel_mono (eqToHom hX)).1
+  erw [Over.comp_left]
+  rw [Category.assoc, mapMulEquivOfPresentation_apply_left_comp H A hG hX,
+    mapMulEquivOfPresentation_apply_left_comp H B hG hX]
+  have hmapLeft := congrArg Over.Hom.left hmap.symm
+  simp only [Over.comp_left, OverClass.asOverHom_left, mapMulEquiv_left] at hmapLeft
+  exact hmapLeft
 
 /-- Mathlib's spectrum-points equivalence is contravariantly natural in the coordinate
 Hopf algebra. Precomposing a `K`-point by `φ : H ⟶ K` corresponds on spectra to

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -98,7 +98,7 @@ private lemma groupScheme_eq_hopfSpec :
 
 /-- The scheme underlying the general linear group scheme is the spectrum of its bundled
 coordinate Hopf algebra. -/
-lemma groupScheme_X_left_bundled :
+lemma groupScheme_X_left :
     (groupScheme R n).X.left =
       Spec (CommRingCat.of (coordinateHopfAlgebra R n)) := by
   simpa only [groupScheme] using
@@ -108,13 +108,13 @@ lemma groupScheme_X_left_bundled :
 spectrum of the determinant localization. -/
 noncomputable def groupSchemeSpecIso :
     (groupScheme R n).X.left ≅ Spec (CommRingCat.of (CoordinateRing R n)) :=
-  eqToIso (groupScheme_X_left_bundled R n) ≪≫
+  eqToIso (groupScheme_X_left R n) ≪≫
     Scheme.Spec.mapIso
       (coordinateHopfAlgebraAlgEquiv R n).toRingEquiv.toCommRingCatIso.op
 
 private lemma groupScheme_X_hom_bundled :
     (groupScheme R n).X.hom =
-      eqToHom (groupScheme_X_left_bundled R n) ≫
+      eqToHom (groupScheme_X_left R n) ≫
         Spec.map (CommRingCat.ofHom
           (algebraMap R (coordinateHopfAlgebra R n))) := by
   unfold groupScheme
@@ -129,7 +129,7 @@ lemma groupScheme_X_hom :
         Spec.map (CommRingCat.ofHom (algebraMap R (CoordinateRing R n))) := by
   calc
     (groupScheme R n).X.hom =
-        eqToHom (groupScheme_X_left_bundled R n) ≫
+        eqToHom (groupScheme_X_left R n) ≫
           Spec.map (CommRingCat.ofHom
             (algebraMap R (coordinateHopfAlgebra R n))) :=
       groupScheme_X_hom_bundled R n
@@ -205,7 +205,7 @@ private lemma groupScheme_one_left_bundled :
     η[(groupScheme R n).X].left =
       Spec.map (CommRingCat.ofHom
         (Bialgebra.counitAlgHom R (coordinateHopfAlgebra R n))) ≫
-      eqToHom (groupScheme_X_left_bundled R n).symm := by
+      eqToHom (groupScheme_X_left R n).symm := by
   unfold groupScheme
   convert hopfSpec_obj_one_left R (coordinateHopfAlgebra R n) using 1
 
@@ -216,16 +216,16 @@ private lemma groupScheme_mul_left_bundled :
           (coordinateHopfAlgebra R n)).hom ≫
         Spec.map (CommRingCat.ofHom
           (Bialgebra.comulAlgHom R (coordinateHopfAlgebra R n))) ≫
-        eqToHom (groupScheme_X_left_bundled R n).symm := by
+        eqToHom (groupScheme_X_left R n).symm := by
   unfold groupScheme
   convert hopfSpec_obj_mul_left R (coordinateHopfAlgebra R n) using 1
 
 private lemma groupScheme_inv_left_bundled :
     ι[(groupScheme R n).X].left =
-      eqToHom (groupScheme_X_left_bundled R n) ≫
+      eqToHom (groupScheme_X_left R n) ≫
         Spec.map (CommRingCat.ofHom
           (HopfAlgebra.antipodeAlgHom R (coordinateHopfAlgebra R n)).toRingHom) ≫
-        eqToHom (groupScheme_X_left_bundled R n).symm := by
+        eqToHom (groupScheme_X_left R n).symm := by
   unfold groupScheme
   convert hopfSpec_obj_inv_left R (coordinateHopfAlgebra R n) using 1
 
@@ -240,7 +240,7 @@ lemma groupScheme_one_left :
     Functor.mapIso_inv, Iso.op_inv, Scheme.Spec_map, Quiver.Hom.unop_op,
     RingEquiv.toCommRingCatIso_inv]
   rw [← Category.assoc]
-  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  apply (cancel_mono (eqToHom (groupScheme_X_left R n).symm)).2
   rw [← Spec.map_comp]
   rw [Spec.map_inj]
   rw [← CommRingCat.ofHom_comp]
@@ -266,7 +266,7 @@ lemma groupScheme_mul_left :
     (pullbackSpecIso R (coordinateHopfAlgebra R n)
       (coordinateHopfAlgebra R n)).hom).2
   simp only [← Category.assoc]
-  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  apply (cancel_mono (eqToHom (groupScheme_X_left R n).symm)).2
   rw [← Spec.map_comp, ← Spec.map_comp]
   rw [Spec.map_inj]
   rw [← CommRingCat.ofHom_comp, ← CommRingCat.ofHom_comp]
@@ -287,9 +287,9 @@ lemma groupScheme_inv_left :
     Scheme.Spec_map, Quiver.Hom.unop_op, RingEquiv.toCommRingCatIso_hom,
     Iso.trans_inv, eqToIso.inv, Functor.mapIso_inv, Iso.op_inv,
     RingEquiv.toCommRingCatIso_inv, Category.assoc]
-  apply (cancel_epi (eqToHom (groupScheme_X_left_bundled R n))).2
+  apply (cancel_epi (eqToHom (groupScheme_X_left R n))).2
   simp only [← Category.assoc]
-  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n).symm)).2
+  apply (cancel_mono (eqToHom (groupScheme_X_left R n).symm)).2
   rw [← Spec.map_comp, ← Spec.map_comp]
   rw [Spec.map_inj]
   rw [← CommRingCat.ofHom_comp, ← CommRingCat.ofHom_comp]
@@ -335,11 +335,11 @@ lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     (groupSchemePointMulEquiv n A f).left =
       Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
-        eqToHom (groupScheme_X_left_bundled R n).symm := by
+        eqToHom (groupScheme_X_left R n).symm := by
   simpa only [groupSchemePointMulEquiv] using
     CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
       (coordinateHopfAlgebra R n) A (groupScheme_eq_hopfSpec R n)
-        (groupScheme_X_left_bundled R n) f
+        (groupScheme_X_left R n) f
 
 /-- The group of scheme-valued points of the general linear group scheme is the ordinary general
 linear group over the value algebra.

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -89,11 +89,16 @@ noncomputable def groupScheme : Grp (Over (Spec (CommRingCat.of R))) :=
   (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
     (Opposite.op (coordinateHopfAlgebra R n))
 
--- The generic `hopfSpec_obj_*` lemmas are stated for the literal functor object, while the
--- equality proofs occurring in `eqToHom` below have the opaque wrapper `groupScheme` as source.
--- These private specializations unfold the wrapper once and use `convert` only to rebind those
--- proof-dependent morphism types; all spectrum and group-operation computations stay generic.
-private lemma groupScheme_X_left_bundled :
+private lemma groupScheme_eq_hopfSpec :
+    groupScheme R n =
+      (AlgebraicGeometry.hopfSpec (CommRingCat.of R)).obj
+        (Opposite.op (coordinateHopfAlgebra R n)) := by
+  unfold groupScheme
+  rfl
+
+/-- The scheme underlying the general linear group scheme is the spectrum of its bundled
+coordinate Hopf algebra. -/
+lemma groupScheme_X_left_bundled :
     (groupScheme R n).X.left =
       Spec (CommRingCat.of (coordinateHopfAlgebra R n)) := by
   simpa only [groupScheme] using
@@ -321,20 +326,20 @@ noncomputable def groupSchemePointMulEquiv :
     WithConv (coordinateHopfAlgebra R n →ₐ[R] A) ≃*
       ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
         (groupScheme R n).X) :=
-  AlgebraicGeometry.Spec.mapMulEquiv
+  CommHopfAlgCat.mapMulEquivOfPresentation
+    (coordinateHopfAlgebra R n) A (groupScheme_eq_hopfSpec R n)
 
--- This private boundary formula is used only to transfer the generic spectrum naturality theorem
--- across the opaque `groupScheme` wrapper; the public point computation is entrywise below.
+/-- The underlying map of the spectrum point associated to an algebra point. -/
 @[simp]
-private lemma groupSchemePointMulEquiv_apply_left
+lemma groupSchemePointMulEquiv_apply_left
     (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
     (groupSchemePointMulEquiv n A f).left =
       Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
         eqToHom (groupScheme_X_left_bundled R n).symm := by
-  -- Postcomposition crosses the named presentation equality; on the raw spectrum boundary the
-  -- specialized wrapper and Mathlib's spectrum-points equivalence agree definitionally.
-  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n))).1
-  rfl
+  simpa only [groupSchemePointMulEquiv] using
+    CommHopfAlgCat.mapMulEquivOfPresentation_apply_left
+      (coordinateHopfAlgebra R n) A (groupScheme_eq_hopfSpec R n)
+        (groupScheme_X_left_bundled R n) f
 
 /-- The group of scheme-valued points of the general linear group scheme is the ordinary general
 linear group over the value algebra.
@@ -383,27 +388,15 @@ theorem schemePointsMulEquiv_mapValue (φ : A →ₐ[R] B)
       Matrix.GeneralLinearGroup.map φ.toRingHom (schemePointsMulEquiv n A p) := by
   let q : WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
     (groupSchemePointMulEquiv n A).symm p
-  have hmap := CommHopfAlgCat.mapMulEquiv_mapValue
-    (coordinateHopfAlgebra R n) (CommAlgCat.ofHom φ) q
-  have hp : groupSchemePointMulEquiv n A q = p :=
-    (groupSchemePointMulEquiv n A).apply_symm_apply p
   have hpre :
       (groupSchemePointMulEquiv n B).symm
           ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
             (Spec (CommRingCat.of R)) ≫ p) =
         HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R n)
           (CommAlgCat.ofHom φ) q := by
-    apply (groupSchemePointMulEquiv n B).injective
-    rw [(groupSchemePointMulEquiv n B).apply_symm_apply, ← hp]
-    apply Over.OverMorphism.ext
-    apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n))).1
-    erw [Over.comp_left]
-    simp only [OverClass.asOverHom_left, groupSchemePointMulEquiv_apply_left]
-    have hmapLeft := congrArg Over.Hom.left hmap.symm
-    simp only [Over.comp_left, OverClass.asOverHom_left] at hmapLeft
-    -- On the raw spectrum boundary, `Spec.mapMulEquiv` exposes this left component
-    -- definitionally, so the generic naturality theorem has exactly the required map equality.
-    exact hmapLeft
+    simpa only [q, groupSchemePointMulEquiv] using
+      CommHopfAlgCat.mapMulEquivOfPresentation_mapValue
+        (coordinateHopfAlgebra R n) φ (groupScheme_eq_hopfSpec R n) p
   simp only [schemePointsMulEquiv, MulEquiv.trans_apply]
   rw [hpre, HopfAlgebra.mapPoints_apply, ← AlgHom.mapValue_apply]
   exact pointsMulEquiv_mapValue n φ q

--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Scheme.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.CoordinateHopfAlgebra
+public import TauCeti.Algebra.AlgebraicGroup.CommHopfAlgCat.SchemePoints
+public import TauCeti.Algebra.AlgebraicGroup.GeneralLinear.FunctorOfPoints
 public import TauCeti.AlgebraicGeometry.AffineGroupScheme.HopfSpec
 
 /-!
@@ -22,9 +23,14 @@ multiplication, and inversion are induced contravariantly by the algebra structu
 comultiplication, and antipode, respectively. The multiplication source is identified with the
 spectrum of the tensor square of the raw coordinate ring.
 
+For a same-universe commutative `R`-algebra `A`, Mathlib's spectrum-points equivalence followed by
+`GeneralLinear.pointsMulEquiv` identifies scheme-valued points with invertible matrices over `A`.
+The resulting identification computes entries by evaluation on the bundled matrix coordinates and
+is covariantly natural in `A`.
+
 The construction includes rank zero and the zero ring. Mathlib's current `hopfSpec` construction
-requires the base ring and Hopf-algebra carrier to lie in the same universe, so this file uses that
-same-universe setting.
+and spectrum-points equivalence require the base ring, Hopf-algebra carrier, and value algebra to
+lie in the same universe, so this file uses that same-universe setting.
 
 ## Main declarations
 
@@ -39,13 +45,25 @@ same-universe setting.
 * `TauCeti.GeneralLinear.isAffine_groupScheme` and
   `TauCeti.GeneralLinear.locallyOfFiniteType_groupScheme`: affineness and local finite type over
   the base.
+* `TauCeti.GeneralLinear.groupSchemePointMulEquiv`: the canonical passage between algebra points
+  and scheme-valued points.
+* `TauCeti.GeneralLinear.schemePointsMulEquiv` and
+  `TauCeti.GeneralLinear.schemePointsMulEquiv_apply`: scheme-valued points are invertible matrices
+  over the value algebra, with an entrywise coordinate formula.
+* `TauCeti.GeneralLinear.schemePointsMulEquiv_mapValue`: covariance in the value algebra.
 
 ## References
 
-* J. S. Milne, *Basic Theory of Affine Group Schemes*, Chapter IV, section 1.8.
+* J. S. Milne, *Basic Theory of Affine Group Schemes*, Chapter IV, section 1.8, and
+  *Algebraic Groups* (2017), sections 2.8 and 3.3--3.6.
 * The Stacks Project, Tags
-  [022W](https://stacks.math.columbia.edu/tag/022W) and
+  [022W](https://stacks.math.columbia.edu/tag/022W),
+  [022X](https://stacks.math.columbia.edu/tag/022X), and
   [00CM](https://stacks.math.columbia.edu/tag/00CM).
+
+The scheme-valued-points interface follows the spectrum-retyping and value-algebra naturality
+pattern in `TauCetiProject/TauCeti`, revision `1f55a87ca0ca0c64550c374d78dfe8e701a4ccfc`,
+`TauCeti/Algebra/AlgebraicGroup/AdditiveGroup/Scheme.lean` (Apache 2.0).
 -/
 
 public section
@@ -59,7 +77,7 @@ universe u
 
 namespace GeneralLinear
 
-open AlgebraicGeometry MonObj MonoidalCategory
+open AlgebraicGeometry MonObj MonoidalCategory WithConv
 
 variable (R : Type u) [CommRing R] (n : ℕ)
 
@@ -289,6 +307,108 @@ instance locallyOfFiniteType_groupScheme :
     rw [← AlgebraicGeometry.specOverSpec_over]
     infer_instance
   exact locallyOfFiniteType_comp _ _
+
+section SchemePoints
+
+variable {R} (A : Type u) [CommRing A] [Algebra R A]
+
+/-- Mathlib's spectrum-points equivalence, with its target presented as the underlying object of
+the general linear group scheme. It sends an algebra point to its contravariant spectrum morphism.
+
+The retyping makes the equivalence usable without unfolding the opaque definition of
+`groupScheme`. -/
+noncomputable def groupSchemePointMulEquiv :
+    WithConv (coordinateHopfAlgebra R n →ₐ[R] A) ≃*
+      ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+        (groupScheme R n).X) :=
+  AlgebraicGeometry.Spec.mapMulEquiv
+
+-- This private boundary formula is used only to transfer the generic spectrum naturality theorem
+-- across the opaque `groupScheme` wrapper; the public point computation is entrywise below.
+@[simp]
+private lemma groupSchemePointMulEquiv_apply_left
+    (f : WithConv (coordinateHopfAlgebra R n →ₐ[R] A)) :
+    (groupSchemePointMulEquiv n A f).left =
+      Spec.map (CommRingCat.ofHom f.ofConv.toRingHom) ≫
+        eqToHom (groupScheme_X_left_bundled R n).symm := by
+  -- Postcomposition crosses the named presentation equality; on the raw spectrum boundary the
+  -- specialized wrapper and Mathlib's spectrum-points equivalence agree definitionally.
+  apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n))).1
+  rfl
+
+/-- The group of scheme-valued points of the general linear group scheme is the ordinary general
+linear group over the value algebra.
+
+The source consists of morphisms over `Spec R` from `Spec A` to the underlying object of
+`groupScheme R n`; its multiplication is the pointwise group law induced by that group object. -/
+noncomputable def schemePointsMulEquiv :
+    ((Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+      (groupScheme R n).X) ≃* Matrix.GeneralLinearGroup (Fin n) A :=
+  (groupSchemePointMulEquiv n A).symm.trans
+    (pointsMulEquiv (R := R) n)
+
+/-- A scheme-valued point corresponds entrywise to evaluation of its canonical algebra point on
+the bundled matrix coordinates. -/
+@[simp]
+lemma schemePointsMulEquiv_apply
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+      (groupScheme R n).X) (i j : Fin n) :
+    schemePointsMulEquiv n A p i j =
+      ((groupSchemePointMulEquiv n A).symm p).ofConv
+        (coordinateHopfAlgebraAlgEquiv R n
+          (coordinateRingMap R n (MvPolynomial.X (i, j)))) := by
+  rw [schemePointsMulEquiv, MulEquiv.trans_apply, pointsMulEquiv_apply,
+    pointToGeneralLinear_apply]
+
+/-- The inverse scheme-points equivalence sends an invertible matrix to the spectrum map induced
+by its canonical coordinate-algebra point. -/
+@[simp]
+lemma schemePointsMulEquiv_symm_apply (g : Matrix.GeneralLinearGroup (Fin n) A) :
+    (schemePointsMulEquiv n A).symm g =
+      groupSchemePointMulEquiv n A
+        ((pointsMulEquiv (R := R) (A := A) n).symm g) := by
+  rfl
+
+variable {B : Type u} [CommRing B] [Algebra R B]
+
+/-- The scheme-valued point identification is covariantly natural in the value algebra. An
+`R`-algebra map `A → B` becomes precomposition by the reversed spectrum map and acts entrywise on
+the corresponding invertible matrix. -/
+theorem schemePointsMulEquiv_mapValue (φ : A →ₐ[R] B)
+    (p : (Spec (CommRingCat.of A)).asOver (Spec (CommRingCat.of R)) ⟶
+      (groupScheme R n).X) :
+    schemePointsMulEquiv n B
+        ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
+            (Spec (CommRingCat.of R)) ≫ p) =
+      Matrix.GeneralLinearGroup.map φ.toRingHom (schemePointsMulEquiv n A p) := by
+  let q : WithConv (coordinateHopfAlgebra R n →ₐ[R] A) :=
+    (groupSchemePointMulEquiv n A).symm p
+  have hmap := CommHopfAlgCat.mapMulEquiv_mapValue
+    (coordinateHopfAlgebra R n) (CommAlgCat.ofHom φ) q
+  have hp : groupSchemePointMulEquiv n A q = p :=
+    (groupSchemePointMulEquiv n A).apply_symm_apply p
+  have hpre :
+      (groupSchemePointMulEquiv n B).symm
+          ((Spec.map (CommRingCat.ofHom φ.toRingHom)).asOver
+            (Spec (CommRingCat.of R)) ≫ p) =
+        HopfAlgebra.mapPoints (H := coordinateHopfAlgebra R n)
+          (CommAlgCat.ofHom φ) q := by
+    apply (groupSchemePointMulEquiv n B).injective
+    rw [(groupSchemePointMulEquiv n B).apply_symm_apply, ← hp]
+    apply Over.OverMorphism.ext
+    apply (cancel_mono (eqToHom (groupScheme_X_left_bundled R n))).1
+    erw [Over.comp_left]
+    simp only [OverClass.asOverHom_left, groupSchemePointMulEquiv_apply_left]
+    have hmapLeft := congrArg Over.Hom.left hmap.symm
+    simp only [Over.comp_left, OverClass.asOverHom_left] at hmapLeft
+    -- On the raw spectrum boundary, `Spec.mapMulEquiv` exposes this left component
+    -- definitionally, so the generic naturality theorem has exactly the required map equality.
+    exact hmapLeft
+  simp only [schemePointsMulEquiv, MulEquiv.trans_apply]
+  rw [hpre, HopfAlgebra.mapPoints_apply, ← AlgHom.mapValue_apply]
+  exact pointsMulEquiv_mapValue n φ q
+
+end SchemePoints
 
 end GeneralLinear
 


### PR DESCRIPTION
This PR synchronizes the existing general linear group scheme with its matrix-valued functor of points. It gives a multiplicative equivalence between same-universe scheme points over `Spec R` and invertible matrices, exposes coordinate-entry and inverse formulas, and proves covariance under maps of value algebras.

It advances `TauCetiRoadmap/TauCetiRoadmap/ReductiveGroups/README.md`, Layer 0 lines 31–44 and 94–120 on synchronizing Hopf-algebra, group-scheme, and functor-of-points models, together with the `GL_n` worked example at lines 228–236 and the explicit-equivalence design requirement at lines 246–247.

Roadmap: ReductiveGroups

<!--tauceti-target:v1 {"focus":"ReductiveGroups","id":"general-linear-scheme-points"}-->

🤖 Prepared with Codex
