### PR TITLE
feat: prove the invariant exponential smooth at zero

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -97,18 +97,24 @@ private theorem continuousMap_terminal_eq_of_ode_unique
       HasDerivWithinAt a (F (p, a t)) (Set.Ici t) t)
     (haS : ∀ t ∈ Set.Ico (0 : ℝ) 1, a t ∈ S) (haZero : a 0 = center) :
     γ ⟨1, zero_le_one, le_rfl⟩ = a 1 := by
-  let g : ℝ → E := fun t => γ (Set.projIcc 0 1 zero_le_one t)
+  let g : C(ℝ, E) := ContinuousMap.IccExtendCM γ
   have hgCont : ContinuousOn g (Set.Icc (0 : ℝ) 1) :=
-    (γ.continuous.comp continuous_projIcc).continuousOn
-  have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := fun t _ =>
-    hγS (Set.projIcc 0 1 zero_le_one t)
+    g.continuous.continuousOn
+  have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := by
+    intro t ht
+    rw [ContinuousMap.IccExtendCM_of_mem ⟨ht.1, ht.2.le⟩]
+    exact hγS ⟨t, ht.1, ht.2.le⟩
   have hgaZero : g 0 = a 0 := by
-    simpa only [g, Set.projIcc_left] using hγzero.trans haZero.symm
+    rw [ContinuousMap.IccExtendCM_of_mem
+      (show (0 : ℝ) ∈ Set.Icc 0 1 from ⟨le_rfl, zero_le_one⟩)]
+    exact hγzero.trans haZero.symm
   have hunique := ODE_solution_unique_of_mem_Icc_right
     (v := fun _ y => F (p, y)) (s := fun _ => S)
     (fun _ _ => hfixed) hgCont hγderiv hgS haCont haDeriv haS hgaZero
   have hone := hunique (⟨zero_le_one, le_rfl⟩ : (1 : ℝ) ∈ Set.Icc 0 1)
-  simpa only [g, Set.projIcc_right] using hone
+  rw [ContinuousMap.IccExtendCM_of_mem
+    (show (1 : ℝ) ∈ Set.Icc 0 1 from ⟨zero_le_one, le_rfl⟩)] at hone
+  exact hone
 
 /-- The tangent-space exponential of a finite-dimensional smooth Lie group is smooth at zero. -/
 theorem contMDiffAt_mulInvariantExp_modelSpace_zero

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -69,8 +69,8 @@ theorem contMDiffAt_mulInvariantExp_zero
         ((contDiffAt_mulInvariantCoordinateVectorField (I := I) (G := G) (n := ∞)
           BoundarylessManifold.isInteriorPoint).of_le
           (by exact_mod_cast le_top))
-    have hFzero : ∀ y, F (0, y) = 0 := by
-      intro y
+    have hFzero : ∀ᶠ y in 𝓝 center, F (0, y) = 0 := by
+      filter_upwards [] with y
       simp only [F, mulInvariantCoordinateVectorField_zero, smul_zero]
     obtain ⟨γ, hγsmooth, hγzero, hγode⟩ :=
       ODE.exists_contDiffAt_picard_solution n F (0 : E) center hF hFzero

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.ODE.SmoothParameter
+public import TauCeti.Geometry.Lie.Exponential.ParameterDependence
+
+/-!
+# Smoothness of the Lie-group exponential
+
+This file upgrades the continuous local invariant flow to smooth parameter dependence and uses it
+to prove that the Lie-group exponential is smooth at the zero vector.
+
+## Main results
+
+* `contMDiffAt_mulInvariantExp_zero`: the tangent-space exponential is smooth at zero.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The exponential map".
+-/
+
+public section
+
+open Bundle Function Manifold VectorField
+open scoped ContDiff Manifold Topology
+
+noncomputable section
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [IsManifold I 1 G] [IsManifold I 2 G]
+
+local instance lieGroupMinSmoothnessSmoothness [LieGroup I ∞ G] :
+    LieGroup I (minSmoothness ℝ 3) G := by
+  simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
+
+omit [IsManifold I 2 G] in
+/-- The tangent-space exponential of a finite-dimensional smooth Lie group is smooth at zero. -/
+theorem contMDiffAt_mulInvariantExp_zero
+    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    ContMDiffAt 𝓘(ℝ, E) I ∞
+      (fun v : E => mulInvariantExp (I := I) (G := G)
+        (v : GroupLieAlgebra I G)) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let _ : ContMDiffMul I (∞ + 1) G := by
+    simpa using (inferInstance : ContMDiffMul I ∞ G)
+  let center : E := extChartAt I (1 : G) (1 : G)
+  obtain ⟨α, U, δ, hU, hδ, hαlocal, hαeq⟩ :=
+    exists_local_coordinate_representation_mulInvariantIntegralCurve (I := I) (G := G)
+  let c : ℝ := δ / 2
+  have hc : 0 < c := by dsimp only [c]; linarith
+  have hcδ : c < δ := by dsimp only [c]; linarith
+  have hc0 : c ≠ 0 := ne_of_gt hc
+  have hzeroU : (0 : E) ∈ U := mem_of_mem_nhds hU
+  rw [contMDiffAt_infty]
+  intro n
+  have hcoord : ContDiffAt ℝ n
+      (fun v : E => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))) 0 := by
+    let F : E × E → E := fun p => c •
+      mulInvariantCoordinateVectorField (I := I) (G := G) p
+    have hF : ContDiffAt ℝ (n + 1) F ((0 : E), center) := by
+      exact contDiffAt_const.smul
+        ((contDiffAt_mulInvariantCoordinateVectorField (I := I) (G := G) (n := ∞)
+          BoundarylessManifold.isInteriorPoint).of_le
+          (by exact_mod_cast le_top))
+    have hFzero : ∀ y, F (0, y) = 0 := by
+      intro y
+      simp only [F, mulInvariantCoordinateVectorField_zero, smul_zero]
+    obtain ⟨γ, hγsmooth, hγzero, hγode⟩ :=
+      ODE.exists_contDiffAt_picard_solution n F (0 : E) center hF hFzero
+    have hFone : ContDiffAt ℝ 1 F ((0 : E), center) :=
+      hF.of_le (by exact_mod_cast Nat.succ_le_succ (Nat.zero_le n))
+    obtain ⟨K, W, hW, hFlip⟩ := hFone.exists_lipschitzOnWith
+    rw [nhds_prod_eq] at hW
+    obtain ⟨P, hP, S, hS, hPS⟩ := Filter.mem_prod_iff.mp hW
+    have hfixed (p : E) (hp : p ∈ P) : LipschitzOnWith K (fun y => F (p, y)) S := by
+      intro y hy z hz
+      have h := hFlip (x := (p, y)) (y := (p, z))
+        (hPS ⟨hp, hy⟩) (hPS ⟨hp, hz⟩)
+      simpa only [Prod.edist_eq, edist_self, zero_max] using h
+    obtain ⟨ε, hε, hεS⟩ := Metric.mem_nhds_iff.mp hS
+    have hγS : ∀ᶠ p in 𝓝 (0 : E), ∀ t : Set.Icc (0 : ℝ) 1, γ p t ∈ S := by
+      have hnear := hγsmooth.continuousAt
+        (show Metric.ball (ContinuousMap.const _ center) ε ∈ 𝓝 (γ 0) by
+          rw [hγzero]
+          exact Metric.ball_mem_nhds _ hε)
+      filter_upwards [hnear] with p hp
+      intro t
+      apply hεS
+      rw [Metric.mem_ball]
+      simpa only [hγzero, ContinuousMap.const_apply] using
+        (ContinuousMap.dist_apply_le_dist (f := γ p)
+          (g := ContinuousMap.const _ center) t).trans_lt hp
+    have hexpCoord : ContinuousAt
+        (fun v : E => extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))) 0 := by
+      have hexp : ContinuousAt
+          (fun v : E => mulInvariantExp (I := I) (G := G)
+            (v : GroupLieAlgebra I G)) 0 :=
+        continuousAt_mulInvariantExp_modelSpace_zero (I := I) (G := G)
+      have hzero : mulInvariantExp (I := I) (G := G)
+          (0 : GroupLieAlgebra I G) = 1 := mulInvariantExp_zero
+      exact (continuousAt_extChartAt (I := I) (1 : G)).comp_of_eq hexp hzero
+    have hcoordS : (fun v : E => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))) ⁻¹' S ∈ 𝓝 (0 : E) :=
+      by
+        have hzero : mulInvariantExp (I := I) (G := G)
+            (0 : GroupLieAlgebra I G) = 1 := mulInvariantExp_zero
+        apply hexpCoord.preimage_mem_nhds
+        change S ∈ 𝓝 (extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G)))
+        rw [hzero]
+        exact hS
+    obtain ⟨η, hη, hηS⟩ := Metric.mem_nhds_iff.mp hcoordS
+    have hradius : 0 < η / (c + 1) := div_pos hη (by linarith)
+    have hcanonicalS : ∀ᶠ p : E in 𝓝 (0 : E), ∀ t ∈ Set.Icc (0 : ℝ) 1,
+        extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G)
+            ((c * t) • (p : GroupLieAlgebra I G))) ∈ S := by
+      filter_upwards [Metric.ball_mem_nhds (0 : E) hradius] with p hp
+      intro t ht
+      apply hηS
+      rw [Metric.mem_ball, dist_zero_right] at hp ⊢
+      rw [norm_smul, Real.norm_eq_abs, abs_of_nonneg (mul_nonneg hc.le ht.1)]
+      have hct : c * t ≤ c := mul_le_of_le_one_right hc.le ht.2
+      have hmul : c * ‖p‖ < c * (η / (c + 1)) :=
+        mul_lt_mul_of_pos_left hp hc
+      calc
+        c * t * ‖p‖ ≤ c * ‖p‖ := mul_le_mul_of_nonneg_right hct (norm_nonneg p)
+        _ < c * (η / (c + 1)) := hmul
+        _ < η := by
+          have hcfrac : c / (c + 1) < 1 := (div_lt_one (by linarith)).2 (by linarith)
+          calc
+            c * (η / (c + 1)) = (c / (c + 1)) * η := by ring
+            _ < 1 * η := mul_lt_mul_of_pos_right hcfrac hη
+            _ = η := one_mul η
+    have hEq : ∀ᶠ p in 𝓝 (0 : E),
+        γ p ⟨1, zero_le_one, le_rfl⟩ =
+          extChartAt I (1 : G)
+            (mulInvariantExp (I := I) (G := G)
+              (c • (p : GroupLieAlgebra I G))) := by
+      filter_upwards [hγode, hγS, hcanonicalS, hP, hU] with p hpODE hpγS hpCanonicalS hpP hpU
+      let g : ℝ → E := fun t => γ p (Set.projIcc 0 1 zero_le_one t)
+      let a : ℝ → E := fun t =>
+        (α (((p, center), c * t))).2
+      have htime (t : ℝ) (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+          c * t ∈ Set.Ioo (-δ) δ := by
+        constructor
+        · nlinarith [mul_nonneg hc.le ht.1]
+        · exact (mul_le_of_le_one_right hc.le ht.2).trans_lt hcδ
+      have haCoord (t : ℝ) (ht : t ∈ Set.Icc (0 : ℝ) 1) :
+          a t = extChartAt I (1 : G)
+            (mulInvariantExp (I := I) (G := G)
+              ((c * t) • (p : GroupLieAlgebra I G))) := by
+        have hlocal := hαlocal p hpU (c * t) (htime t ht)
+        have htarget := hlocal.2.2.2.2
+        have htarget' : a t ∈ (extChartAt I (1 : G)).target := by
+          exact interior_subset (by simpa only [a, center] using htarget)
+        calc
+          a t = extChartAt I (1 : G) ((extChartAt I (1 : G)).symm (a t)) :=
+            ((extChartAt I (1 : G)).right_inv htarget').symm
+          _ = extChartAt I (1 : G)
+              (mulInvariantIntegralCurve (I := I) (G := G)
+                (p : GroupLieAlgebra I G) 1 (c * t)) := by
+            congr 1
+            exact hαeq p hpU (htime t ht)
+          _ = extChartAt I (1 : G)
+              (mulInvariantExp (I := I) (G := G)
+                ((c * t) • (p : GroupLieAlgebra I G))) := by
+            exact congrArg (extChartAt I (1 : G))
+              (mulInvariantExp_smul (I := I) (G := G)
+                (p : GroupLieAlgebra I G) (c * t)).symm
+      have haCont : ContinuousOn a (Set.Icc (0 : ℝ) 1) := by
+        intro t ht
+        have hlocal := hαlocal p hpU (c * t) (htime t ht)
+        have hinner : ContinuousAt
+            (fun s : ℝ => ((p, extChartAt I (1 : G) (1 : G)), c * s)) t := by fun_prop
+        have hαcomp : ContinuousAt
+            (fun s : ℝ => α ((p, extChartAt I (1 : G) (1 : G)), c * s)) t :=
+          hlocal.1.comp_of_eq hinner rfl
+        simpa only [a, center] using (continuousAt_snd.comp' hαcomp).continuousWithinAt
+      have haDeriv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
+          HasDerivWithinAt a (F (p, a t)) (Set.Ici t) t := by
+        intro t ht
+        have ht' : t ∈ Set.Icc (0 : ℝ) 1 := ⟨ht.1, ht.2.le⟩
+        have hlocal := hαlocal p hpU (c * t) (htime t ht')
+        have hcomp : HasDerivAt
+            (fun s : ℝ => α ((p, extChartAt I (1 : G) (1 : G)), c * s))
+            (c • ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G)
+              (α ((p, extChartAt I (1 : G) (1 : G)), c * t)))) t :=
+          HasDerivAt.scomp t hlocal.2.1 (hasDerivAt_const_mul c)
+        have hsnd := (ContinuousLinearMap.snd ℝ E E).hasFDerivAt.comp_hasDerivAt t hcomp
+        apply hsnd.hasDerivWithinAt.congr_deriv
+        have hpair : α (((p, center), c * t)) = (p, a t) := by
+          apply Prod.ext
+          · exact hlocal.2.2.2.1
+          · rfl
+        have hpair' : α (((p, extChartAt I (1 : G) (1 : G)), c * t)) = (p, a t) := by
+          simpa only [center] using hpair
+        simp only [F, map_smul]
+        rw [hpair']
+        rfl
+      have hgCont : ContinuousOn g (Set.Icc (0 : ℝ) 1) :=
+        ((γ p).continuous.comp continuous_projIcc).continuousOn
+      have hgDeriv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
+          HasDerivWithinAt g (F (p, g t)) (Set.Ici t) t := hpODE.2.2
+      have haS : ∀ t ∈ Set.Ico (0 : ℝ) 1, a t ∈ S := by
+        intro t ht
+        rw [haCoord t ⟨ht.1, ht.2.le⟩]
+        exact hpCanonicalS t ⟨ht.1, ht.2.le⟩
+      have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := by
+        intro t ht
+        exact hpγS (Set.projIcc 0 1 zero_le_one t)
+      have hga0 : g 0 = a 0 := by
+        have hg0 := hpODE.1 ⟨0, le_rfl, zero_le_one⟩
+        have ha0 := (hαlocal p hpU 0 (by simpa using htime 0 ⟨le_rfl, zero_le_one⟩)).2.2.1
+        have hg0' : g 0 = center := by
+          change γ p (Set.projIcc 0 1 zero_le_one 0) = center
+          rw [show Set.projIcc 0 1 zero_le_one 0 =
+            (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) by ext; simp]
+          simpa using hg0
+        have ha0' : a 0 = center := by
+          change (α (((p, center), c * 0))).2 = center
+          rw [mul_zero]
+          simpa only [center] using congrArg Prod.snd ha0
+        exact hg0'.trans ha0'.symm
+      have hunique := ODE_solution_unique_of_mem_Icc_right
+        (v := fun _ y => F (p, y)) (s := fun _ => S)
+        (fun _ _ => hfixed p hpP) hgCont hgDeriv hgS haCont haDeriv haS hga0
+      have hone := hunique (show (1 : ℝ) ∈ Set.Icc 0 1 by exact ⟨zero_le_one, le_rfl⟩)
+      have hone' := hone.trans (haCoord 1 ⟨zero_le_one, le_rfl⟩)
+      change γ p ⟨1, zero_le_one, le_rfl⟩ = _
+      rw [← show Set.projIcc 0 1 zero_le_one 1 =
+        (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) by ext; simp]
+      simpa only [g, mul_one] using hone'
+    have heval : ContDiffAt ℝ (n + 1)
+        (fun p => γ p ⟨1, zero_le_one, le_rfl⟩) 0 :=
+      by
+        simpa only [Function.comp_def, ContinuousMap.evalCLM_apply] using
+          hγsmooth.continuousLinearMap_comp
+            (ContinuousMap.evalCLM ℝ ⟨1, zero_le_one, le_rfl⟩)
+    have hscaled : ContDiffAt ℝ (n + 1)
+        (fun p : E => extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G)
+            (c • (p : GroupLieAlgebra I G)))) 0 :=
+      by
+        apply heval.congr_of_eventuallyEq
+        filter_upwards [hEq] with p hp
+        exact hp.symm
+    have hrescale : ContDiffAt ℝ (n + 1) (fun p : E => c⁻¹ • p) 0 := by fun_prop
+    have hscaled' : ContDiffAt ℝ (n + 1)
+        (fun p : E => extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G)
+            (c • (p : GroupLieAlgebra I G)))) (c⁻¹ • (0 : E)) := by
+      simpa only [smul_zero] using hscaled
+    have hcomp := hscaled'.comp 0 hrescale
+    apply (hcomp.congr_of_eventuallyEq (Filter.Eventually.of_forall fun p => ?_)).of_le
+      (by exact_mod_cast Nat.le_succ n)
+    have harg : c • ((c⁻¹ • p : E) : GroupLieAlgebra I G) =
+        (p : GroupLieAlgebra I G) := by
+      rw [smul_smul, mul_inv_cancel₀ hc0, one_smul]
+    change extChartAt I (1 : G)
+      (mulInvariantExp (I := I) (G := G) (p : GroupLieAlgebra I G)) =
+        extChartAt I (1 : G)
+          (mulInvariantExp (I := I) (G := G)
+            (c • ((c⁻¹ • p : E) : GroupLieAlgebra I G)))
+    rw [harg]
+  have hzero : mulInvariantExp (I := I) (G := G)
+      (0 : GroupLieAlgebra I G) = 1 := mulInvariantExp_zero
+  rw [contMDiffAt_iff_target_of_mem_source (y := (1 : G)) (by
+    convert mem_chart_source H (1 : G) using 1
+    exact hzero)]
+  refine ⟨continuousAt_mulInvariantExp_modelSpace_zero (I := I) (G := G), ?_⟩
+  have hcoordM := hcoord.contMDiffAt
+  simpa only [Function.comp_def] using hcoordM

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -102,21 +102,13 @@ private theorem continuousMap_terminal_eq_of_ode_unique
     (γ.continuous.comp continuous_projIcc).continuousOn
   have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := fun t _ =>
     hγS (Set.projIcc 0 1 zero_le_one t)
-  have hprojZero : Set.projIcc 0 1 zero_le_one 0 =
-      (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) := by
-    ext
-    simp
   have hgaZero : g 0 = a 0 := by
-    simpa only [g, hprojZero] using hγzero.trans haZero.symm
+    simpa only [g, Set.projIcc_left] using hγzero.trans haZero.symm
   have hunique := ODE_solution_unique_of_mem_Icc_right
     (v := fun _ y => F (p, y)) (s := fun _ => S)
     (fun _ _ => hfixed) hgCont hγderiv hgS haCont haDeriv haS hgaZero
   have hone := hunique (⟨zero_le_one, le_rfl⟩ : (1 : ℝ) ∈ Set.Icc 0 1)
-  have hprojOne : Set.projIcc 0 1 zero_le_one 1 =
-      (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) := by
-    ext
-    simp
-  simpa only [g, hprojOne] using hone
+  simpa only [g, Set.projIcc_right] using hone
 
 /-- The tangent-space exponential of a finite-dimensional smooth Lie group is smooth at zero. -/
 theorem contMDiffAt_mulInvariantExp_modelSpace_zero

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -15,7 +15,7 @@ to prove that the Lie-group exponential is smooth at the zero vector.
 
 ## Main results
 
-* `contMDiffAt_mulInvariantExp_zero`: the tangent-space exponential is smooth at zero.
+* `contMDiffAt_mulInvariantExp_modelSpace_zero`: the tangent-space exponential is smooth at zero.
 
 ## References
 
@@ -33,15 +33,93 @@ noncomputable section
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [IsManifold I 1 G] [IsManifold I 2 G]
 
-local instance lieGroupMinSmoothnessSmoothness [LieGroup I ∞ G] :
-    LieGroup I (minSmoothness ℝ 3) G := by
+local instance [LieGroup I ∞ G] : LieGroup I (minSmoothness ℝ 3) G := by
   simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
 
-omit [IsManifold I 2 G] in
+/-- Continuity, the rescaled ODE, and the initial value for the second coordinate of a product
+flow. This packages the chain-rule calculation used to compare a canonical coordinate path with a
+Picard path. -/
+private theorem rescaledSecondCoordinate_data
+    {α : (E × E) × ℝ → E × E} {V : E × E → E} (p center : E) (c : ℝ)
+    (hα : ∀ t ∈ Set.Icc (0 : ℝ) 1,
+      ContinuousAt α ((p, center), c * t) ∧
+        HasDerivAt (fun s : ℝ => α ((p, center), s))
+          ((0 : E), V (α ((p, center), c * t))) (c * t) ∧
+        α ((p, center), 0) = (p, center) ∧
+        (α ((p, center), c * t)).1 = p) :
+    ContinuousOn (fun t : ℝ => (α ((p, center), c * t)).2) (Set.Icc 0 1) ∧
+      (∀ t ∈ Set.Ico (0 : ℝ) 1,
+        HasDerivWithinAt (fun s : ℝ => (α ((p, center), c * s)).2)
+          (c • V (p, (α ((p, center), c * t)).2)) (Set.Ici t) t) ∧
+      (α ((p, center), c * 0)).2 = center := by
+  have hcont : ContinuousOn (fun t : ℝ => (α ((p, center), c * t)).2)
+      (Set.Icc 0 1) := by
+    intro t ht
+    have hinner : ContinuousAt (fun s : ℝ => ((p, center), c * s)) t := by fun_prop
+    exact (continuousAt_snd.comp'
+      ((hα t ht).1.comp_of_eq hinner rfl)).continuousWithinAt
+  have hderiv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
+      HasDerivWithinAt (fun s : ℝ => (α ((p, center), c * s)).2)
+        (c • V (p, (α ((p, center), c * t)).2)) (Set.Ici t) t := by
+    intro t ht
+    have ht' : t ∈ Set.Icc (0 : ℝ) 1 := ⟨ht.1, ht.2.le⟩
+    have hcomp : HasDerivAt (fun s : ℝ => α ((p, center), c * s))
+        (c • ((0 : E), V (α ((p, center), c * t)))) t :=
+      HasDerivAt.scomp t (hα t ht').2.1 (hasDerivAt_const_mul c)
+    have hsnd := (ContinuousLinearMap.snd ℝ E E).hasFDerivAt.comp_hasDerivAt t hcomp
+    apply hsnd.hasDerivWithinAt.congr_deriv
+    have hpair : α ((p, center), c * t) =
+        (p, (α ((p, center), c * t)).2) := by
+      apply Prod.ext
+      · exact (hα t ht').2.2.2
+      · rfl
+    simp only [map_smul]
+    rw [hpair]
+    rfl
+  refine ⟨hcont, hderiv, ?_⟩
+  simpa only [mul_zero] using congrArg Prod.snd
+    ((hα 0 ⟨le_rfl, zero_le_one⟩).2.2.1)
+
+/-- Two paths in one Lipschitz set with the same right-hand ODE and initial value agree at the
+terminal time. The first path is bundled on `Icc`; the second is an ordinary real path. -/
+private theorem continuousMap_terminal_eq_of_ode_unique
+    {F : E × E → E} {p center : E} {S : Set E} {K : NNReal}
+    (γ : C(Set.Icc (0 : ℝ) 1, E)) (a : ℝ → E)
+    (hfixed : LipschitzOnWith K (fun y => F (p, y)) S)
+    (hγzero : γ ⟨0, le_rfl, zero_le_one⟩ = center)
+    (hγderiv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
+      HasDerivWithinAt (fun s => γ (Set.projIcc 0 1 zero_le_one s))
+        (F (p, γ (Set.projIcc 0 1 zero_le_one t))) (Set.Ici t) t)
+    (hγS : ∀ t : Set.Icc (0 : ℝ) 1, γ t ∈ S)
+    (haCont : ContinuousOn a (Set.Icc (0 : ℝ) 1))
+    (haDeriv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
+      HasDerivWithinAt a (F (p, a t)) (Set.Ici t) t)
+    (haS : ∀ t ∈ Set.Ico (0 : ℝ) 1, a t ∈ S) (haZero : a 0 = center) :
+    γ ⟨1, zero_le_one, le_rfl⟩ = a 1 := by
+  let g : ℝ → E := fun t => γ (Set.projIcc 0 1 zero_le_one t)
+  have hgCont : ContinuousOn g (Set.Icc (0 : ℝ) 1) :=
+    (γ.continuous.comp continuous_projIcc).continuousOn
+  have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := fun t _ =>
+    hγS (Set.projIcc 0 1 zero_le_one t)
+  have hprojZero : Set.projIcc 0 1 zero_le_one 0 =
+      (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) := by
+    ext
+    simp
+  have hgaZero : g 0 = a 0 := by
+    simpa only [g, hprojZero] using hγzero.trans haZero.symm
+  have hunique := ODE_solution_unique_of_mem_Icc_right
+    (v := fun _ y => F (p, y)) (s := fun _ => S)
+    (fun _ _ => hfixed) hgCont hγderiv hgS haCont haDeriv haS hgaZero
+  have hone := hunique (⟨zero_le_one, le_rfl⟩ : (1 : ℝ) ∈ Set.Icc 0 1)
+  have hprojOne : Set.projIcc 0 1 zero_le_one 1 =
+      (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) := by
+    ext
+    simp
+  simpa only [g, hprojOne] using hone
+
 /-- The tangent-space exponential of a finite-dimensional smooth Lie group is smooth at zero. -/
-theorem contMDiffAt_mulInvariantExp_zero
+theorem contMDiffAt_mulInvariantExp_modelSpace_zero
     [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ContMDiffAt 𝓘(ℝ, E) I ∞
       (fun v : E => mulInvariantExp (I := I) (G := G)
@@ -153,7 +231,6 @@ theorem contMDiffAt_mulInvariantExp_zero
             (mulInvariantExp (I := I) (G := G)
               (c • (p : GroupLieAlgebra I G))) := by
       filter_upwards [hγode, hγS, hcanonicalS, hP, hU] with p hpODE hpγS hpCanonicalS hpP hpU
-      let g : ℝ → E := fun t => γ p (Set.projIcc 0 1 zero_le_one t)
       let a : ℝ → E := fun t =>
         (α (((p, center), c * t))).2
       have htime (t : ℝ) (ht : t ∈ Set.Icc (0 : ℝ) 1) :
@@ -183,77 +260,33 @@ theorem contMDiffAt_mulInvariantExp_zero
             exact congrArg (extChartAt I (1 : G))
               (mulInvariantExp_smul (I := I) (G := G)
                 (p : GroupLieAlgebra I G) (c * t)).symm
+      have hpath := rescaledSecondCoordinate_data
+        (α := α) (V := mulInvariantCoordinateVectorField (I := I) (G := G)) p center c (by
+          intro t ht
+          have hlocal := hαlocal p hpU (c * t) (htime t ht)
+          refine ⟨?_, ?_, ?_, ?_⟩
+          · simpa only [center] using hlocal.1
+          · simpa only [center] using hlocal.2.1
+          · simpa only [center] using hlocal.2.2.1
+          · simpa only [center] using hlocal.2.2.2.1)
       have haCont : ContinuousOn a (Set.Icc (0 : ℝ) 1) := by
-        intro t ht
-        have hlocal := hαlocal p hpU (c * t) (htime t ht)
-        have hinner : ContinuousAt
-            (fun s : ℝ => ((p, extChartAt I (1 : G) (1 : G)), c * s)) t := by fun_prop
-        have hαcomp : ContinuousAt
-            (fun s : ℝ => α ((p, extChartAt I (1 : G) (1 : G)), c * s)) t :=
-          hlocal.1.comp_of_eq hinner rfl
-        simpa only [a, center] using (continuousAt_snd.comp' hαcomp).continuousWithinAt
+        simpa only [a] using hpath.1
       have haDeriv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
           HasDerivWithinAt a (F (p, a t)) (Set.Ici t) t := by
         intro t ht
-        have ht' : t ∈ Set.Icc (0 : ℝ) 1 := ⟨ht.1, ht.2.le⟩
-        have hlocal := hαlocal p hpU (c * t) (htime t ht')
-        have hcomp : HasDerivAt
-            (fun s : ℝ => α ((p, extChartAt I (1 : G) (1 : G)), c * s))
-            (c • ((0 : E), mulInvariantCoordinateVectorField (I := I) (G := G)
-              (α ((p, extChartAt I (1 : G) (1 : G)), c * t)))) t :=
-          HasDerivAt.scomp t hlocal.2.1 (hasDerivAt_const_mul c)
-        have hsnd := (ContinuousLinearMap.snd ℝ E E).hasFDerivAt.comp_hasDerivAt t hcomp
-        apply hsnd.hasDerivWithinAt.congr_deriv
-        have hpair : α (((p, center), c * t)) = (p, a t) := by
-          apply Prod.ext
-          · exact hlocal.2.2.2.1
-          · rfl
-        have hpair' : α (((p, extChartAt I (1 : G) (1 : G)), c * t)) = (p, a t) := by
-          simpa only [center] using hpair
-        simp only [F, map_smul]
-        rw [hpair']
-        rfl
-      have hgCont : ContinuousOn g (Set.Icc (0 : ℝ) 1) :=
-        ((γ p).continuous.comp continuous_projIcc).continuousOn
-      have hgDeriv : ∀ t ∈ Set.Ico (0 : ℝ) 1,
-          HasDerivWithinAt g (F (p, g t)) (Set.Ici t) t := hpODE.2.2
+        simpa only [a, F] using hpath.2.1 t ht
       have haS : ∀ t ∈ Set.Ico (0 : ℝ) 1, a t ∈ S := by
         intro t ht
         rw [haCoord t ⟨ht.1, ht.2.le⟩]
         exact hpCanonicalS t ⟨ht.1, ht.2.le⟩
-      have hgS : ∀ t ∈ Set.Ico (0 : ℝ) 1, g t ∈ S := by
-        intro t ht
-        exact hpγS (Set.projIcc 0 1 zero_le_one t)
-      have hga0 : g 0 = a 0 := by
-        have hg0 := hpODE.1 ⟨0, le_rfl, zero_le_one⟩
-        have ha0 := (hαlocal p hpU 0 (by simpa using htime 0 ⟨le_rfl, zero_le_one⟩)).2.2.1
-        have hprojZero : Set.projIcc 0 1 zero_le_one 0 =
-            (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) := by
-          ext
-          simp
-        have hg0' : g 0 = center := by
-          -- Expose the definition of `g` only at the initial time.
-          change γ p (Set.projIcc 0 1 zero_le_one 0) = center
-          rw [hprojZero]
-          simpa using hg0
-        have ha0' : a 0 = center := by
-          -- Expose the definition of `a` only at the initial time.
-          change (α (((p, center), c * 0))).2 = center
-          rw [mul_zero]
-          simpa only [center] using congrArg Prod.snd ha0
-        exact hg0'.trans ha0'.symm
-      have hunique := ODE_solution_unique_of_mem_Icc_right
-        (v := fun _ y => F (p, y)) (s := fun _ => S)
-        (fun _ _ => hfixed p hpP) hgCont hgDeriv hgS haCont haDeriv haS hga0
-      have hone := hunique (show (1 : ℝ) ∈ Set.Icc 0 1 by exact ⟨zero_le_one, le_rfl⟩)
-      have hone' := hone.trans (haCoord 1 ⟨zero_le_one, le_rfl⟩)
-      have hprojOne : Set.projIcc 0 1 zero_le_one 1 =
-          (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) := by
-        ext
-        simp
-      change γ p ⟨1, zero_le_one, le_rfl⟩ = _
-      rw [← hprojOne]
-      simpa only [g, mul_one] using hone'
+      have haZero : a 0 = center := by simpa only [a] using hpath.2.2
+      have hγzero : γ p ⟨0, le_rfl, zero_le_one⟩ = center := by
+        simpa using hpODE.1 ⟨0, le_rfl, zero_le_one⟩
+      have hterminal := continuousMap_terminal_eq_of_ode_unique
+        (F := F) (p := p) (center := center) (S := S) (K := K) (γ p) a
+        (hfixed p hpP) hγzero hpODE.2.2 hpγS haCont haDeriv haS haZero
+      exact hterminal.trans (by
+        simpa only [mul_one] using haCoord 1 ⟨zero_le_one, le_rfl⟩)
     -- Phase 4: evaluate the smooth Picard germ at the terminal time, transfer smoothness through
     -- the comparison, and undo the time rescaling.
     have heval : ContDiffAt ℝ (n + 1)

--- a/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Smoothness.lean
@@ -62,6 +62,7 @@ theorem contMDiffAt_mulInvariantExp_zero
   have hcoord : ContDiffAt ℝ n
       (fun v : E => extChartAt I (1 : G)
         (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))) 0 := by
+    -- Phase 1: construct a smooth Picard germ for the time-rescaled coordinate field.
     let F : E × E → E := fun p => c •
       mulInvariantCoordinateVectorField (I := I) (G := G) p
     have hF : ContDiffAt ℝ (n + 1) F ((0 : E), center) := by
@@ -74,6 +75,8 @@ theorem contMDiffAt_mulInvariantExp_zero
       simp only [F, mulInvariantCoordinateVectorField_zero, smul_zero]
     obtain ⟨γ, hγsmooth, hγzero, hγode⟩ :=
       ODE.exists_contDiffAt_picard_solution n F (0 : E) center hF hFzero
+    -- Phase 2: choose one Lipschitz neighborhood containing both the Picard paths and the
+    -- canonical exponential paths for all sufficiently small parameters.
     have hFone : ContDiffAt ℝ 1 F ((0 : E), center) :=
       hF.of_le (by exact_mod_cast Nat.succ_le_succ (Nat.zero_le n))
     obtain ⟨K, W, hW, hFlip⟩ := hFone.exists_lipschitzOnWith
@@ -87,6 +90,7 @@ theorem contMDiffAt_mulInvariantExp_zero
     obtain ⟨ε, hε, hεS⟩ := Metric.mem_nhds_iff.mp hS
     have hγS : ∀ᶠ p in 𝓝 (0 : E), ∀ t : Set.Icc (0 : ℝ) 1, γ p t ∈ S := by
       have hnear := hγsmooth.continuousAt
+        -- The path-space neighborhood is the sup-norm ball around the constant center path.
         (show Metric.ball (ContinuousMap.const _ center) ε ∈ 𝓝 (γ 0) by
           rw [hγzero]
           exact Metric.ball_mem_nhds _ hε)
@@ -113,6 +117,7 @@ theorem contMDiffAt_mulInvariantExp_zero
         have hzero : mulInvariantExp (I := I) (G := G)
             (0 : GroupLieAlgebra I G) = 1 := mulInvariantExp_zero
         apply hexpCoord.preimage_mem_nhds
+        -- Expose the value of the preimage map at zero so that `hS` has the required center.
         change S ∈ 𝓝 (extChartAt I (1 : G)
           (mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G)))
         rw [hzero]
@@ -140,6 +145,8 @@ theorem contMDiffAt_mulInvariantExp_zero
             c * (η / (c + 1)) = (c / (c + 1)) * η := by ring
             _ < 1 * η := mul_lt_mul_of_pos_right hcfrac hη
             _ = η := one_mul η
+    -- Phase 3: compare the smooth Picard path with the canonical invariant path by ODE
+    -- uniqueness inside their common Lipschitz neighborhood.
     have hEq : ∀ᶠ p in 𝓝 (0 : E),
         γ p ⟨1, zero_le_one, le_rfl⟩ =
           extChartAt I (1 : G)
@@ -220,12 +227,17 @@ theorem contMDiffAt_mulInvariantExp_zero
       have hga0 : g 0 = a 0 := by
         have hg0 := hpODE.1 ⟨0, le_rfl, zero_le_one⟩
         have ha0 := (hαlocal p hpU 0 (by simpa using htime 0 ⟨le_rfl, zero_le_one⟩)).2.2.1
+        have hprojZero : Set.projIcc 0 1 zero_le_one 0 =
+            (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) := by
+          ext
+          simp
         have hg0' : g 0 = center := by
+          -- Expose the definition of `g` only at the initial time.
           change γ p (Set.projIcc 0 1 zero_le_one 0) = center
-          rw [show Set.projIcc 0 1 zero_le_one 0 =
-            (⟨0, le_rfl, zero_le_one⟩ : Set.Icc (0 : ℝ) 1) by ext; simp]
+          rw [hprojZero]
           simpa using hg0
         have ha0' : a 0 = center := by
+          -- Expose the definition of `a` only at the initial time.
           change (α (((p, center), c * 0))).2 = center
           rw [mul_zero]
           simpa only [center] using congrArg Prod.snd ha0
@@ -235,10 +247,15 @@ theorem contMDiffAt_mulInvariantExp_zero
         (fun _ _ => hfixed p hpP) hgCont hgDeriv hgS haCont haDeriv haS hga0
       have hone := hunique (show (1 : ℝ) ∈ Set.Icc 0 1 by exact ⟨zero_le_one, le_rfl⟩)
       have hone' := hone.trans (haCoord 1 ⟨zero_le_one, le_rfl⟩)
+      have hprojOne : Set.projIcc 0 1 zero_le_one 1 =
+          (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) := by
+        ext
+        simp
       change γ p ⟨1, zero_le_one, le_rfl⟩ = _
-      rw [← show Set.projIcc 0 1 zero_le_one 1 =
-        (⟨1, zero_le_one, le_rfl⟩ : Set.Icc (0 : ℝ) 1) by ext; simp]
+      rw [← hprojOne]
       simpa only [g, mul_one] using hone'
+    -- Phase 4: evaluate the smooth Picard germ at the terminal time, transfer smoothness through
+    -- the comparison, and undo the time rescaling.
     have heval : ContDiffAt ℝ (n + 1)
         (fun p => γ p ⟨1, zero_le_one, le_rfl⟩) 0 :=
       by
@@ -265,12 +282,14 @@ theorem contMDiffAt_mulInvariantExp_zero
     have harg : c • ((c⁻¹ • p : E) : GroupLieAlgebra I G) =
         (p : GroupLieAlgebra I G) := by
       rw [smul_smul, mul_inv_cancel₀ hc0, one_smul]
+    -- State the rescaled composite in the model-space presentation used by `harg`.
     change extChartAt I (1 : G)
       (mulInvariantExp (I := I) (G := G) (p : GroupLieAlgebra I G)) =
         extChartAt I (1 : G)
           (mulInvariantExp (I := I) (G := G)
             (c • ((c⁻¹ • p : E) : GroupLieAlgebra I G)))
     rw [harg]
+  -- Phase 5: convert smoothness of the identity-chart expression back to manifold smoothness.
   have hzero : mulInvariantExp (I := I) (G := G)
       (0 : GroupLieAlgebra I G) = 1 := mulInvariantExp_zero
   rw [contMDiffAt_iff_target_of_mem_source (y := (1 : G)) (by


### PR DESCRIPTION
## Goal

Prove that the tangent-space Lie-group exponential is infinitely smooth at the zero vector, closing the analytic core of exponential-map smoothness.

## Proof structure

1. Choose a positive time `c` inside the uniform canonical coordinate-flow interval and rescale the invariant coordinate field so a unit Picard interval corresponds to canonical time `c`.
2. For each finite order `n`, the generic smooth-parameter ODE theorem from #1881 supplies a `C^(n+1)` path-valued Picard germ at the zero generator. The zero-generator coordinate field vanishes, so its implicit residual has identity path derivative.
3. Joint `C¹` regularity gives a uniform local Lipschitz set. Sup-norm continuity keeps the Picard paths in it; continuity of the already-constructed exponential at zero keeps the canonical coordinate paths there as well.
4. The coordinate-flow equation exposed by #1890 supplies the canonical path's right derivative and initial value. Mathlib's right-interval ODE uniqueness theorem therefore identifies it with the Picard path through the terminal time.
5. Evaluation at time one is continuous linear, so the canonical coordinate exponential at scale `c` inherits `C^(n+1)` regularity. Rescaling by `c⁻¹` gives `C^n` regularity of the original exponential coordinate germ.
6. Since this works for every finite `n`, the manifold-valued tangent exponential is `C∞` at zero.

## Scope and reuse

The new file contains the comparison and assembly argument only. It reuses Mathlib ODE uniqueness, #1877/#1880/#1881 for smooth Picard families, and #1876/#1883/#1890 for the canonical invariant coordinate flow.

## Validation

- Full sandbox build — 6,531 jobs
- `lake exe axioms` — 22,611 declarations, only the allowed axioms
- `lake exe module-system` — all 1,248 modules valid
- `bash scripts/lint-env.sh` — 1,835 public declarations documented; 1,247 modules linted with no new violations
- Focused elaboration of the new smoothness module
- `git diff --check`

## Dependencies

Depends on #1876, #1877, #1880, #1881, #1883, and #1890. All dependencies are merged. The semantic change is one new 331-line module proving smoothness at zero, organized as six commits.

Advances [TauCetiRoadmap#139](https://github.com/TauCetiProject/TauCetiRoadmap/issues/139) and [`RepresentationTheory/LieGroups`, Deliverable A, Layer 0, “The exponential map”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md). The immediate follow-up globalizes this germ by the power identity `exp(v) = exp(v/N)^N` and transports it to `lieExp`.

Roadmap: RepresentationTheory



