### PR TITLE
feat: E₄ and E₆ freely generate the level-one modular forms

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -29,15 +29,17 @@ weight `k − 12` by Mathlib's `CuspForm.discriminantEquiv`, and `Δ = (E₄³ �
 * `TauCeti.ModularForm.evalE₄E₆_surjective`: the evaluation homomorphism is surjective.
 * `TauCeti.ModularForm.evalE₄E₆_injective`: the evaluation homomorphism is injective —
   `E₄` and `E₆` are algebraically independent.
-* `TauCeti.ModularForm.modularFormsEquivMvPolynomial`: the induced algebra isomorphism
+* `TauCeti.ModularForm.mvPolynomialEquivModularForms`: the induced algebra isomorphism
   `ℂ[X₀, X₁] ≃ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k`.
 * `TauCeti.ModularForm.E₄E₆_generate`: the two Eisenstein series generate the graded ring.
 
 ## References
 
 * [J.-P. Serre, *A Course in Arithmetic*][serre1973], VII.3.2.
-* [Mathlib PR #39258](https://github.com/leanprover-community/mathlib4/pull/39258)
-  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
+* [Mathlib PR #39258](https://github.com/leanprover-community/mathlib4/pull/39258) and
+  [Mathlib PR #38813](https://github.com/leanprover-community/mathlib4/pull/38813)
+  (Chris Birkbeck) — the upstream drafts (surjectivity, resp. freeness) this file ports
+  onto the current Mathlib pin.
 -/
 
 public noncomputable section
@@ -429,6 +431,8 @@ private lemma evalE₄E₆_discriminantPoly_mul_coeff_zero {n : ℕ} (hn12 : 12 
   rw [evalE₄E₆_discriminantPoly_mul_apply s hs hcast]
   set f := (CuspForm.discriminant : ModularForm 𝒮ℒ 12)
   set g := (evalE₄E₆ s) ((n - 12 : ℕ) : ℤ)
+  -- Transporting along the degree identity does not change pointwise values
+  -- (`cast_apply`); `show` states the function-level identification.
   rw [show ((hcast ▸ GradedMonoid.GMul.mul f g : ModularForm 𝒮ℒ ↑n) : ℍ → ℂ) =
       ((f.mul g : ModularForm 𝒮ℒ (12 + ((n - 12 : ℕ) : ℤ))) : ℍ → ℂ) from
         funext fun z ↦ cast_apply hcast _ z,
@@ -451,11 +455,12 @@ private lemma per_weight_injective_unique_monomial {n : ℕ} (p : MvPolynomial (
   · rw [hc, MvPolynomial.monomial_zero]
   · exact absurd hmz hmf_ne
 
-private lemma per_weight_injective_small {n : ℕ} (a b : ℕ) (ha : a < 3) (hn : n < 12)
+private lemma per_weight_injective_small {n : ℕ} (a b : ℕ) (hn : n < 12)
     (hab : 4 * a + 6 * b = n)
     (p : MvPolynomial (Fin 2) ℂ)
     (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
     (heval : (evalE₄E₆ p) (↑n : ℤ) = 0) : p = 0 := by
+  have ha : a < 3 := by lia
   obtain ⟨d₀, hd0a, hd0b⟩ : ∃ d : Fin 2 →₀ ℕ, d 0 = a ∧ d 1 = b :=
     ⟨Finsupp.equivFunOnFinite.invFun ![a, b], rfl, rfl⟩
   apply per_weight_injective_unique_monomial p hp heval d₀
@@ -482,6 +487,8 @@ private lemma per_weight_injective_zero
       ext i
       fin_cases i <;> simp <;> lia)
   rw [hpc, MvPolynomial.monomial_zero'] at heval ⊢
+  -- The degree-`0` component of the graded unit is the unit form; `show` states the
+  -- component extraction so `of_eq_same` can close it.
   rw [evalE₄E₆_C, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
     show (1 : DirectSum ℤ (ModularForm 𝒮ℒ)) (0 : ℤ) = (1 : ModularForm 𝒮ℒ 0) from by
       conv_lhs => rw [← DirectSum.of_zero_one (ModularForm 𝒮ℒ)]
@@ -490,7 +497,7 @@ private lemma per_weight_injective_zero
   · simp [hc]
   · exact absurd h1z one_ne_zero_modularForm
 
-private lemma discriminantPoly_piece_isWeightedHomogeneous {n : ℕ} (hn12 : 12 ≤ n)
+private lemma discriminantPoly_piece_isWeightedHomogeneous {n : ℕ}
     (d : Fin 2 →₀ ℕ) (hd_ge : 3 ≤ d 0) (hwd : d 0 * 4 + d 1 * 6 = n) (c : ℂ) :
     MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ)
       (MvPolynomial.C c * ((1728 : ℂ) • discriminantPoly *
@@ -541,7 +548,7 @@ private lemma support_degreeSum_lt_of_sub_discriminantPoly_piece (p : MvPolynomi
   simp [d', Finsupp.add_apply]
   lia
 
-private lemma weightedHomogeneous_poly_Delta_decomp_step {n : ℕ} (hn12 : 12 ≤ n)
+private lemma weightedHomogeneous_poly_Delta_decomp_step {n : ℕ}
     (p : MvPolynomial (Fin 2) ℂ)
     (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
     (hnotall : ¬ ∀ d ∈ p.support, d 0 < 3) :
@@ -564,13 +571,13 @@ private lemma weightedHomogeneous_poly_Delta_decomp_step {n : ℕ} (hn12 : 12 �
     simp only [δ_piece, q₁, MvPolynomial.smul_eq_C_mul, map_mul]
     ring
   refine ⟨p - δ_piece, q₁, hp.sub
-      (discriminantPoly_piece_isWeightedHomogeneous hn12 d hd_ge hwd c),
+      (discriminantPoly_piece_isWeightedHomogeneous d hd_ge hwd c),
     .C_mul (X0_pow_mul_X1_pow_isWeightedHomogeneous (d 0 - 3) (d 1) (n - 12) (by lia)) _, ?_,
     support_degreeSum_lt_of_sub_discriminantPoly_piece p hd_mem hd_ge⟩
   rw [← hδ_eq]
   ring
 
-private lemma weightedHomogeneous_poly_Delta_decomp {n : ℕ} (hn12 : 12 ≤ n)
+private lemma weightedHomogeneous_poly_Delta_decomp {n : ℕ}
     (p : MvPolynomial (Fin 2) ℂ)
     (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n) :
     ∃ r s : MvPolynomial (Fin 2) ℂ,
@@ -584,7 +591,7 @@ private lemma weightedHomogeneous_poly_Delta_decomp {n : ℕ} (hn12 : 12 ≤ n)
   · exact ⟨p, 0, hp, MvPolynomial.isWeightedHomogeneous_zero ℂ _ _,
       by simp only [mul_zero, add_zero], hall⟩
   obtain ⟨p', q₁, hp'_wh, hq₁_wh, hp_eq, hlt⟩ :=
-    weightedHomogeneous_poly_Delta_decomp_step hn12 p hp hall
+    weightedHomogeneous_poly_Delta_decomp_step p hp hall
   obtain ⟨r, s', hr_wh, hs'_wh, hp'_eq, hr_red⟩ :=
     ih _ (hM ▸ hlt) p' hp'_wh rfl
   refine ⟨r, s' + q₁, hr_wh, hs'_wh.add hq₁_wh, ?_, hr_red⟩
@@ -614,6 +621,8 @@ private lemma evalE₄E₆_monomial_qExpansion_coeff_zero {n : ℕ} {d₀ : Fin 
   rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply,
+    -- Scalar action commutes with the coercion to functions, definitionally; the
+    -- ascribed `show … from rfl` records it once at the right type.
     show (↑(c • ((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ))) : ℍ → ℂ) =
       c • (↑((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
@@ -644,6 +653,8 @@ private lemma reduced_part_eq_zero {n : ℕ} (hn12 : 12 ≤ n)
   have hQ : (Q ((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 +
       (Q ((evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ))).coeff 0 = 0 := by
     rw [← LinearMap.map_add, ← Q.map_add, heval, map_zero, map_zero]
+  -- Name the two constant coefficients through `Q`: the discriminant part vanishes,
+  -- the monomial part is the coefficient itself.
   rw [show (Q ((evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ))).coeff 0 = 0 from
       evalE₄E₆_discriminantPoly_mul_coeff_zero hn12 s hs, add_zero,
     show (Q ((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 = c from
@@ -670,7 +681,7 @@ private lemma per_weight_injective_inductive_step (n : ℕ)
     (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
     (heval : (evalE₄E₆ p) (↑n : ℤ) = 0)
     (hn12 : 12 ≤ n) : p = 0 := by
-  obtain ⟨r, s, hr_wh, hs_wh, hp_eq, hr_red⟩ := weightedHomogeneous_poly_Delta_decomp hn12 p hp
+  obtain ⟨r, s, hr_wh, hs_wh, hp_eq, hr_red⟩ := weightedHomogeneous_poly_Delta_decomp p hp
   have hr0 : r = 0 := reduced_part_eq_zero hn12 r s hr_wh hs_wh hr_red (hp_eq ▸ heval)
   rw [hp_eq, hr0, zero_add] at heval ⊢
   rw [ih (n - 12) (by lia) s hs_wh
@@ -686,10 +697,10 @@ private lemma per_weight_injective_at_small_weight {n : ℕ} (hn12 : n < 12) (hk
     lia
   · exact per_weight_injective_zero p hp heval
   · exact hp.eq_zero_of_no_monomials fun d h ↦ by rw [weight_eq_4a_6b] at h; lia
-  · exact per_weight_injective_small 1 0 (by lia) (by lia) rfl p hp heval
-  · exact per_weight_injective_small 0 1 (by lia) (by lia) rfl p hp heval
-  · exact per_weight_injective_small 2 0 (by lia) (by lia) rfl p hp heval
-  · exact per_weight_injective_small 1 1 (by lia) (by lia) rfl p hp heval
+  · exact per_weight_injective_small 1 0 (by lia) rfl p hp heval
+  · exact per_weight_injective_small 0 1 (by lia) rfl p hp heval
+  · exact per_weight_injective_small 2 0 (by lia) rfl p hp heval
+  · exact per_weight_injective_small 1 1 (by lia) rfl p hp heval
 
 private lemma per_weight_injective : ∀ (n : ℕ) (p : MvPolynomial (Fin 2) ℂ),
     MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n →
@@ -717,9 +728,17 @@ theorem evalE₄E₆_injective : Function.Injective evalE₄E₆ := by
 
 /-- The graded ring of level-1 modular forms is isomorphic to the polynomial ring
 `ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`. -/
-noncomputable def modularFormsEquivMvPolynomial :
+noncomputable def mvPolynomialEquivModularForms :
     MvPolynomial (Fin 2) ℂ ≃ₐ[ℂ] DirectSum ℤ (ModularForm 𝒮ℒ) :=
   AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩
+
+@[simp]
+lemma mvPolynomialEquivModularForms_apply (p : MvPolynomial (Fin 2) ℂ) :
+    mvPolynomialEquivModularForms p = evalE₄E₆ p := by
+  -- `mvPolynomialEquivModularForms` has no equation lemma to rewrite with; `change`
+  -- spells out its definitional unfolding once, explicitly.
+  change AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩ p = evalE₄E₆ p
+  rfl
 
 /-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
 `ℂ`-algebra. -/
@@ -727,6 +746,8 @@ theorem E₄E₆_generate :
     Algebra.adjoin ℂ ({DirectSum.of (ModularForm 𝒮ℒ) 4 E₄,
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆} :
       Set (DirectSum ℤ (ModularForm 𝒮ℒ))) = ⊤ := by
+  -- Rewrite the two-element set as the range of the evaluation vector, so the adjoin
+  -- becomes the range of `aeval`.
   rw [show ({DirectSum.of (ModularForm 𝒮ℒ) 4 E₄,
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆} : Set _) =
       Set.range (![DirectSum.of _ 4 E₄, DirectSum.of _ 6 E₆] : Fin 2 → _)
@@ -735,9 +756,9 @@ theorem E₄E₆_generate :
   exact (AlgHom.range_eq_top evalE₄E₆).mpr evalE₄E₆_surjective
 
 /-- The graded ring of level-1 modular forms is an integral domain, being isomorphic (via
-`modularFormsEquivMvPolynomial`) to the polynomial ring `ℂ[X₀, X₁]`. -/
+`mvPolynomialEquivModularForms`) to the polynomial ring `ℂ[X₀, X₁]`. -/
 instance : IsDomain (DirectSum ℤ (ModularForm 𝒮ℒ)) :=
-  modularFormsEquivMvPolynomial.symm.toMulEquiv.isDomain _
+  mvPolynomialEquivModularForms.symm.toMulEquiv.isDomain _
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -105,8 +105,7 @@ private lemma evalE₄E₆_C_mul_monomial (c : ℂ) (a b : ℕ) :
   -- `evalE₄E₆` is definitionally `aeval ![…]`, so `aeval_C` computes the constant once
   -- the equation is ascribed at that type; `rw` alone does not unfold the wrapper.
   rw [map_mul,
-    show evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c from
-      MvPolynomial.aeval_C _ c,
+    evalE₄E₆_C _,
     evalE₄E₆_monomial a b, Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul]
 
 private lemma exists_monomial_weight {k : ℕ} (hk : 4 ≤ k) (hkeven : Even k) :
@@ -126,8 +125,7 @@ private lemma surj_of_rank_one {k : ℤ}
   -- `evalE₄E₆` is definitionally `aeval ![…]`, so `aeval_C` computes the constant once
   -- the equation is ascribed at that type; `rw` alone does not unfold the wrapper.
   rw [map_mul,
-    show evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c from
-      MvPolynomial.aeval_C _ c,
+    evalE₄E₆_C _,
     hp, Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, ← DirectSum.of_smul]
 
 private lemma directSum_of_E₄_pow_mul_E₆_pow_apply {a b n : ℕ}
@@ -501,8 +499,7 @@ private lemma per_weight_injective_zero
   rw [hpc, MvPolynomial.monomial_zero'] at heval ⊢
   -- The degree-`0` component of the graded unit is the unit form; `show` states the
   -- component extraction so `of_eq_same` can close it.
-  rw [show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
-      MvPolynomial.aeval_C _ _, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
+  rw [evalE₄E₆_C _, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
     show (1 : DirectSum ℤ (ModularForm 𝒮ℒ)) (0 : ℤ) = (1 : ModularForm 𝒮ℒ 0) from by
       conv_lhs => rw [← DirectSum.of_zero_one (ModularForm 𝒮ℒ)]
       exact DirectSum.of_eq_same _ _] at heval

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -85,11 +85,11 @@ lemma evalE₄E₆_X_one :
     evalE₄E₆ (MvPolynomial.X 1) = DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ := by
   simp [evalE₄E₆]
 
-/-- Constants evaluate to scalars: `evalE₄E₆` is definitionally `aeval ![…]`, and this
-private restatement of `MvPolynomial.aeval_C` at the wrapper's type lets `rw` use the
-identity without a `show`-ascription at every site. -/
+/-- Constants evaluate to scalars. -/
 private lemma evalE₄E₆_C (c : ℂ) :
     evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c :=
+  -- `evalE₄E₆` is definitionally `aeval ![…]`; stating the identity once at the
+  -- wrapper's type lets `rw` use it without a `show`-ascription at every site.
   MvPolynomial.aeval_C _ c
 
 private lemma evalE₄E₆_monomial (a b : ℕ) :

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -6,9 +6,10 @@ module
 
 public import Mathlib.Algebra.MvPolynomial.Eval
 public import Mathlib.NumberTheory.ModularForms.LevelOne.GradedRing
+public import Mathlib.RingTheory.MvPolynomial.WeightedHomogeneous
 
 /-!
-# `E₄` and `E₆` generate the level-one modular forms
+# `E₄` and `E₆` freely generate the level-one modular forms
 
 This file defines the evaluation map `ℂ[X₀, X₁] →ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k` sending
 `X₀ ↦ E₄`, `X₁ ↦ E₆`, and proves it is surjective: every modular form of level one is a
@@ -26,6 +27,11 @@ weight `k − 12` by Mathlib's `CuspForm.discriminantEquiv`, and `Δ = (E₄³ �
 * `TauCeti.ModularForm.evalE₄E₆`: the evaluation homomorphism
   `ℂ[X₀, X₁] →ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k` sending `X₀ ↦ E₄`, `X₁ ↦ E₆`.
 * `TauCeti.ModularForm.evalE₄E₆_surjective`: the evaluation homomorphism is surjective.
+* `TauCeti.ModularForm.evalE₄E₆_injective`: the evaluation homomorphism is injective —
+  `E₄` and `E₆` are algebraically independent.
+* `TauCeti.ModularForm.modularFormsEquivMvPolynomial`: the induced algebra isomorphism
+  `ℂ[X₀, X₁] ≃ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k`.
+* `TauCeti.ModularForm.E₄E₆_generate`: the two Eisenstein series generate the graded ring.
 
 ## References
 
@@ -299,6 +305,439 @@ theorem evalE₄E₆_surjective : Function.Surjective evalE₄E₆ := by
   rw [show x = x.sum (fun i m ↦ DirectSum.of _ i m) from (DFinsupp.sum_single (f := x)).symm,
     ← AlgHom.mem_range]
   exact Subalgebra.sum_mem _ fun k _ ↦ surj_of_weight k (x k)
+
+
+private lemma evalE₄E₆_C (c : ℂ) :
+    evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c :=
+  MvPolynomial.aeval_C _ c
+
+private lemma discriminantPoly_smul_eq :
+    (1728 : ℂ) • discriminantPoly = MvPolynomial.X 0 ^ 3 - MvPolynomial.X 1 ^ 2 := by
+  rw [discriminantPoly, smul_smul]
+  norm_num
+
+/-- Transporting a modular form along an equality of weights does not change its
+pointwise values. -/
+private theorem cast_apply {Γ : Subgroup (GL (Fin 2) ℝ)} {k₁ k₂ : ℤ}
+    (heq : k₁ = k₂) (f : ModularForm Γ k₁) (z : ℍ) :
+    (heq ▸ f : ModularForm Γ k₂) z = f z := by
+  subst heq
+  rfl
+
+
+
+private lemma weight_eq_4a_6b (d : Fin 2 →₀ ℕ) :
+    Finsupp.weight (![4, 6] : Fin 2 → ℕ) d = d 0 * 4 + d 1 * 6 := by
+  simp [Finsupp.weight_eq_sum, Fin.sum_univ_two, mul_comm]
+
+private lemma no_weight_monomial_of_odd {n : ℕ} (hn : Odd n) (d : Fin 2 →₀ ℕ) :
+    Finsupp.weight (![4, 6] : Fin 2 → ℕ) d ≠ n := by
+  intro h
+  rw [weight_eq_4a_6b] at h
+  exact Nat.not_odd_iff_even.mpr ⟨d 0 * 2 + d 1 * 3, by lia⟩ hn
+
+private lemma unique_small_weight_solution {a₁ b₁ a₂ b₂ : ℕ}
+    (ha₁ : a₁ < 3) (ha₂ : a₂ < 3)
+    (h : a₁ * 4 + b₁ * 6 = a₂ * 4 + b₂ * 6) : a₁ = a₂ ∧ b₁ = b₂ :=
+  ⟨by interval_cases a₁ <;> lia, by lia⟩
+
+private lemma evalE₄E₆_X_pow_mul_apply_eq_zero_of_ne (a b : ℕ) (k : ℤ)
+    (hk : k ≠ (↑a * 4 + ↑b * 6 : ℤ)) :
+    (evalE₄E₆ (MvPolynomial.X 0 ^ a * MvPolynomial.X 1 ^ b)) k = 0 := by
+  rw [evalE₄E₆_monomial, DirectSum.ofPow, DirectSum.ofPow, DirectSum.of_mul_of]
+  refine DirectSum.of_eq_of_ne _ _ _ fun heq ↦ hk ?_
+  simpa using heq
+
+private lemma evalE₄E₆_monomial_apply_eq_zero_of_ne (d : Fin 2 →₀ ℕ) (c : ℂ) (k : ℤ)
+    (hk : k ≠ (↑(d 0) * 4 + ↑(d 1) * 6 : ℤ)) :
+    (evalE₄E₆ (MvPolynomial.monomial d c)) k = 0 := by
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+    Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, DirectSum.smul_apply,
+    evalE₄E₆_X_pow_mul_apply_eq_zero_of_ne (d 0) (d 1) k hk, smul_zero]
+
+private lemma evalE₄E₆_apply_eq_zero_of_ne {n : ℕ} (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (k : ℤ) (hk : k ≠ ↑n) :
+    (evalE₄E₆ p) k = 0 := by
+  rw [← MvPolynomial.support_sum_monomial_coeff p, map_sum, DirectSum.sum_apply]
+  refine Finset.sum_eq_zero fun d hd ↦
+    evalE₄E₆_monomial_apply_eq_zero_of_ne _ _ _ fun heq ↦ hk ?_
+  have hw := (weight_eq_4a_6b d).symm.trans (hp (MvPolynomial.mem_support_iff.mp hd))
+  rw [heq]
+  lia
+
+private lemma evalE₄E₆_eq_of_apply (n : ℕ) (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n) :
+    evalE₄E₆ p = DirectSum.of (ModularForm 𝒮ℒ) (↑n : ℤ) ((evalE₄E₆ p) ↑n) := by
+  refine DFinsupp.ext fun k : ℤ ↦ ?_
+  by_cases hk : k = (↑n : ℤ)
+  · subst hk
+    simp
+  · rw [DirectSum.of_eq_of_ne _ _ _ hk, evalE₄E₆_apply_eq_zero_of_ne p hp k hk]
+
+private lemma evalE₄E₆_component_eq (p : MvPolynomial (Fin 2) ℂ) (n : ℕ) :
+    (evalE₄E₆
+        (MvPolynomial.weightedHomogeneousComponent (![4, 6] : Fin 2 → ℕ) n p)) (↑n : ℤ) =
+      (evalE₄E₆ p) (↑n : ℤ) := by
+  set q := p - MvPolynomial.weightedHomogeneousComponent (![4, 6] : Fin 2 → ℕ) n p with hq_def
+  have hdecomp :
+      p = MvPolynomial.weightedHomogeneousComponent (![4, 6] : Fin 2 → ℕ) n p + q := by
+    simp [q]
+  conv_rhs => rw [hdecomp, map_add, DirectSum.add_apply]
+  suffices h : (evalE₄E₆ q) (↑n : ℤ) = 0 by rw [h, add_zero]
+  rw [← MvPolynomial.support_sum_monomial_coeff q, map_sum, DirectSum.sum_apply]
+  refine Finset.sum_eq_zero fun d hd ↦
+    evalE₄E₆_monomial_apply_eq_zero_of_ne _ _ _ fun heq ↦ MvPolynomial.mem_support_iff.mp hd ?_
+  rw [hq_def, MvPolynomial.coeff_sub, MvPolynomial.coeff_weightedHomogeneousComponent,
+    if_pos ?_, sub_self]
+  rw [weight_eq_4a_6b]
+  lia
+
+private lemma X0_pow_mul_X1_pow_isWeightedHomogeneous (a b n : ℕ) (hab : a * 4 + b * 6 = n) :
+    MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ)
+      (MvPolynomial.X (0 : Fin 2) ^ a * MvPolynomial.X (1 : Fin 2) ^ b :
+        MvPolynomial (Fin 2) ℂ) n := by
+  convert
+    ((MvPolynomial.isWeightedHomogeneous_X ℂ (![4, 6] : Fin 2 → ℕ) (0 : Fin 2)).pow a).mul
+      ((MvPolynomial.isWeightedHomogeneous_X ℂ (![4, 6] : Fin 2 → ℕ) (1 : Fin 2)).pow b)
+    using 1
+  simp only [Matrix.cons_val_zero, Matrix.cons_val_one, smul_eq_mul]
+  lia
+
+private lemma discriminantPoly_isWeightedHomogeneous :
+    MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) discriminantPoly 12 := by
+  rw [discriminantPoly, MvPolynomial.smul_eq_C_mul]
+  refine MvPolynomial.IsWeightedHomogeneous.C_mul (.sub ?_ ?_) _
+  · exact (MvPolynomial.isWeightedHomogeneous_X ℂ (![4, 6] : Fin 2 → ℕ) (0 : Fin 2)).pow 3
+  · exact (MvPolynomial.isWeightedHomogeneous_X ℂ (![4, 6] : Fin 2 → ℕ) (1 : Fin 2)).pow 2
+
+private lemma evalE₄E₆_discriminantPoly_mul_apply {n : ℕ}
+    (s : MvPolynomial (Fin 2) ℂ)
+    (hs : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) s (n - 12))
+    (hcast : (12 : ℤ) + ((n - 12 : ℕ) : ℤ) = (↑n : ℤ)) :
+    (evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ) =
+      hcast ▸ GradedMonoid.GMul.mul (CuspForm.discriminant : ModularForm 𝒮ℒ 12)
+        ((evalE₄E₆ s) ↑(n - 12)) := by
+  conv_lhs => rw [map_mul, evalE₄E₆_discriminantPoly, evalE₄E₆_eq_of_apply (n - 12) s hs,
+    DirectSum.of_mul_of, DirectSum.of_apply, dif_pos hcast]
+
+private lemma evalE₄E₆_discriminantPoly_mul_coeff_zero {n : ℕ} (hn12 : 12 ≤ n)
+    (s : MvPolynomial (Fin 2) ℂ)
+    (hs : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) s (n - 12)) :
+    (qExpansion 1 ↑((evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ))).coeff 0 = 0 := by
+  have hcast : (12 : ℤ) + ((n - 12 : ℕ) : ℤ) = (↑n : ℤ) := by lia
+  rw [evalE₄E₆_discriminantPoly_mul_apply s hs hcast]
+  set f := (CuspForm.discriminant : ModularForm 𝒮ℒ 12)
+  set g := (evalE₄E₆ s) ((n - 12 : ℕ) : ℤ)
+  rw [show ((hcast ▸ GradedMonoid.GMul.mul f g : ModularForm 𝒮ℒ ↑n) : ℍ → ℂ) =
+      ((f.mul g : ModularForm 𝒮ℒ (12 + ((n - 12 : ℕ) : ℤ))) : ℍ → ℂ) from
+        funext fun z ↦ cast_apply hcast _ z,
+    ModularForm.qExpansion_mul one_pos one_mem_strictPeriods_SL f g, PowerSeries.coeff_mul]
+  simp [(ModularForm.isCuspForm_iff_coeffZero_eq_zero f).mp ⟨CuspForm.discriminant, rfl⟩]
+
+private lemma per_weight_injective_unique_monomial {n : ℕ} (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (heval : (evalE₄E₆ p) (↑n : ℤ) = 0)
+    (d₀ : Fin 2 →₀ ℕ)
+    (huniq : ∀ d : Fin 2 →₀ ℕ, Finsupp.weight (![4, 6] : Fin 2 → ℕ) d = n → d = d₀)
+    (hmf_ne : (DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ) ≠ 0) : p = 0 := by
+  have hpc := hp.eq_monomial_of_unique_weight huniq
+  rw [hpc] at heval ⊢
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+    Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
+    DirectSum.smul_apply] at heval
+  rcases smul_eq_zero.mp heval with hc | hmz
+  · rw [hc, MvPolynomial.monomial_zero]
+  · exact absurd hmz hmf_ne
+
+private lemma per_weight_injective_small {n : ℕ} (a b : ℕ) (ha : a < 3) (hn : n < 12)
+    (hab : 4 * a + 6 * b = n)
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (heval : (evalE₄E₆ p) (↑n : ℤ) = 0) : p = 0 := by
+  obtain ⟨d₀, hd0a, hd0b⟩ : ∃ d : Fin 2 →₀ ℕ, d 0 = a ∧ d 1 = b :=
+    ⟨Finsupp.equivFunOnFinite.invFun ![a, b], rfl, rfl⟩
+  apply per_weight_injective_unique_monomial p hp heval d₀
+  · intro d hd
+    have h46 := weight_eq_4a_6b d
+    rw [hd] at h46
+    obtain ⟨hda, hdb⟩ := unique_small_weight_solution (by lia : d 0 < 3) ha
+      (show d 0 * 4 + d 1 * 6 = a * 4 + b * 6 by lia)
+    ext i
+    fin_cases i <;> [exact hda ▸ hd0a.symm; exact hdb ▸ hd0b.symm]
+  · rw [hd0a, hd0b]
+    intro habs
+    have hcz := monomial_qExpansion_coeff_zero_eq_one (n := n) (a := a) (b := b) (by lia)
+    rw [habs] at hcz
+    simp [UpperHalfPlane.qExpansion_zero] at hcz
+
+private lemma per_weight_injective_zero
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p 0)
+    (heval : (evalE₄E₆ p) (0 : ℤ) = 0) : p = 0 := by
+  have hpc : p = MvPolynomial.monomial (0 : Fin 2 →₀ ℕ) (MvPolynomial.coeff 0 p) :=
+    hp.eq_monomial_of_unique_weight (d₀ := 0) (fun d hd ↦ by
+      rw [weight_eq_4a_6b] at hd
+      ext i
+      fin_cases i <;> simp <;> lia)
+  rw [hpc, MvPolynomial.monomial_zero'] at heval ⊢
+  rw [evalE₄E₆_C, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
+    show (1 : DirectSum ℤ (ModularForm 𝒮ℒ)) (0 : ℤ) = (1 : ModularForm 𝒮ℒ 0) from by
+      conv_lhs => rw [← DirectSum.of_zero_one (ModularForm 𝒮ℒ)]
+      exact DirectSum.of_eq_same _ _] at heval
+  rcases smul_eq_zero.mp heval with hc | h1z
+  · simp [hc]
+  · exact absurd h1z one_ne_zero_modularForm
+
+private lemma discriminantPoly_piece_isWeightedHomogeneous {n : ℕ} (hn12 : 12 ≤ n)
+    (d : Fin 2 →₀ ℕ) (hd_ge : 3 ≤ d 0) (hwd : d 0 * 4 + d 1 * 6 = n) (c : ℂ) :
+    MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ)
+      (MvPolynomial.C c * ((1728 : ℂ) • discriminantPoly *
+        (MvPolynomial.X (0 : Fin 2) ^ (d 0 - 3) *
+          MvPolynomial.X (1 : Fin 2) ^ (d 1)))) n := by
+  apply MvPolynomial.IsWeightedHomogeneous.C_mul
+  rw [MvPolynomial.smul_eq_C_mul, mul_assoc]
+  apply MvPolynomial.IsWeightedHomogeneous.C_mul
+  convert discriminantPoly_isWeightedHomogeneous.mul
+    (X0_pow_mul_X1_pow_isWeightedHomogeneous (d 0 - 3) (d 1) (n - 12) (by lia))
+    using 1
+  lia
+
+private lemma discriminantPoly_piece_eq_monomial_sub
+    (d : Fin 2 →₀ ℕ) (hd_ge : 3 ≤ d 0) (c : ℂ) :
+    MvPolynomial.C c * ((1728 : ℂ) • discriminantPoly *
+        (MvPolynomial.X (0 : Fin 2) ^ (d 0 - 3) * MvPolynomial.X (1 : Fin 2) ^ d 1)) =
+    MvPolynomial.monomial d c - MvPolynomial.monomial
+      (Finsupp.single (0 : Fin 2) (d 0 - 3) + Finsupp.single (1 : Fin 2) (d 1 + 2)) c := by
+  have hX0 : (MvPolynomial.X (0 : Fin 2) : MvPolynomial (Fin 2) ℂ) ^ d 0 =
+      MvPolynomial.X 0 ^ 3 * MvPolynomial.X 0 ^ (d 0 - 3) := by
+    rw [← pow_add]
+    congr 1
+    lia
+  have h0 : (Finsupp.single (0 : Fin 2) (d 0 - 3) + Finsupp.single (1 : Fin 2) (d 1 + 2)) 0
+      = d 0 - 3 := by simp
+  have h1 : (Finsupp.single (0 : Fin 2) (d 0 - 3) + Finsupp.single (1 : Fin 2) (d 1 + 2)) 1
+      = d 1 + 2 := by simp
+  rw [discriminantPoly_smul_eq, MvPolynomial.monomial_fin_two, MvPolynomial.monomial_fin_two,
+    h0, h1, hX0, pow_add (MvPolynomial.X (1 : Fin 2)) (d 1) 2]
+  ring
+
+private lemma support_degreeSum_lt_of_sub_discriminantPoly_piece (p : MvPolynomial (Fin 2) ℂ)
+    {d : Fin 2 →₀ ℕ} (hd_mem : d ∈ p.support) (hd_ge : 3 ≤ d 0) :
+    ∑ d' ∈ (p - MvPolynomial.C (MvPolynomial.coeff d p) * ((1728 : ℂ) • discriminantPoly *
+          (MvPolynomial.X (0 : Fin 2) ^ (d 0 - 3) *
+            MvPolynomial.X (1 : Fin 2) ^ d 1))).support, d' 0 <
+      ∑ d' ∈ p.support, d' 0 := by
+  set d' := Finsupp.single (0 : Fin 2) (d 0 - 3) + Finsupp.single (1 : Fin 2) (d 1 + 2)
+  have hdd' : d ≠ d' := fun heq ↦ by
+    have h0 := Finsupp.ext_iff.mp heq (0 : Fin 2)
+    simp only [Fin.isValue, d', Finsupp.add_apply, Finsupp.single_eq_same,
+      ne_eq, zero_ne_one, not_false_eq_true, Finsupp.single_eq_of_ne, add_zero] at h0
+    lia
+  have hsupp := (discriminantPoly_piece_eq_monomial_sub d hd_ge _ : _ = _) ▸
+    MvPolynomial.support_sub_monomial_sub_monomial_subset p d d' _ hdd' rfl
+  refine Finset.sum_lt_sum_of_subset_erase_union_singleton hd_mem hsupp ?_
+  simp [d', Finsupp.add_apply]
+  lia
+
+private lemma weightedHomogeneous_poly_Delta_decomp_step {n : ℕ} (hn12 : 12 ≤ n)
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (hnotall : ¬ ∀ d ∈ p.support, d 0 < 3) :
+    ∃ p' q₁ : MvPolynomial (Fin 2) ℂ,
+      MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p' n ∧
+      MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) q₁ (n - 12) ∧
+      p = p' + discriminantPoly * q₁ ∧
+      ∑ d ∈ p'.support, d 0 < ∑ d ∈ p.support, d 0 := by
+  push Not at hnotall
+  obtain ⟨d, hd_mem, hd_ge⟩ := hnotall
+  have hwd : d 0 * 4 + d 1 * 6 = n := by
+    have := (weight_eq_4a_6b d).symm.trans <| hp <| MvPolynomial.mem_support_iff.mp hd_mem
+    lia
+  set c := MvPolynomial.coeff d p
+  set δ_piece := MvPolynomial.C c * ((1728 : ℂ) • discriminantPoly *
+    (MvPolynomial.X (0 : Fin 2) ^ (d 0 - 3) * MvPolynomial.X (1 : Fin 2) ^ d 1))
+  set q₁ := MvPolynomial.C (c * 1728) *
+    (MvPolynomial.X (0 : Fin 2) ^ (d 0 - 3) * MvPolynomial.X (1 : Fin 2) ^ d 1)
+  have hδ_eq : δ_piece = discriminantPoly * q₁ := by
+    simp only [δ_piece, q₁, MvPolynomial.smul_eq_C_mul, map_mul]
+    ring
+  refine ⟨p - δ_piece, q₁, hp.sub
+      (discriminantPoly_piece_isWeightedHomogeneous hn12 d hd_ge hwd c),
+    .C_mul (X0_pow_mul_X1_pow_isWeightedHomogeneous (d 0 - 3) (d 1) (n - 12) (by lia)) _, ?_,
+    support_degreeSum_lt_of_sub_discriminantPoly_piece p hd_mem hd_ge⟩
+  rw [← hδ_eq]
+  ring
+
+private lemma weightedHomogeneous_poly_Delta_decomp {n : ℕ} (hn12 : 12 ≤ n)
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n) :
+    ∃ r s : MvPolynomial (Fin 2) ℂ,
+      MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) r n ∧
+      MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) s (n - 12) ∧
+      p = r + discriminantPoly * s ∧
+      (∀ d ∈ r.support, d 0 < 3) := by
+  generalize hM : ∑ d ∈ p.support, d 0 = M
+  induction M using Nat.strong_induction_on generalizing p with | _ M ih => ?_
+  by_cases hall : ∀ d ∈ p.support, d 0 < 3
+  · exact ⟨p, 0, hp, MvPolynomial.isWeightedHomogeneous_zero ℂ _ _,
+      by simp only [mul_zero, add_zero], hall⟩
+  obtain ⟨p', q₁, hp'_wh, hq₁_wh, hp_eq, hlt⟩ :=
+    weightedHomogeneous_poly_Delta_decomp_step hn12 p hp hall
+  obtain ⟨r, s', hr_wh, hs'_wh, hp'_eq, hr_red⟩ :=
+    ih _ (hM ▸ hlt) p' hp'_wh rfl
+  refine ⟨r, s' + q₁, hr_wh, hs'_wh.add hq₁_wh, ?_, hr_red⟩
+  rw [hp_eq, hp'_eq, mul_add]
+  ring
+
+private lemma reduced_isWeightedHomogeneous_eq_monomial {n : ℕ}
+    (r : MvPolynomial (Fin 2) ℂ)
+    (hr : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) r n)
+    (hr_red : ∀ d ∈ r.support, d 0 < 3) {d₀ : Fin 2 →₀ ℕ} (hd₀ : d₀ ∈ r.support) :
+    r = MvPolynomial.monomial d₀ (MvPolynomial.coeff d₀ r) := by
+  ext d
+  rw [MvPolynomial.coeff_monomial]
+  by_cases hd : d = d₀
+  · simp [hd]
+  rw [if_neg (Ne.symm hd)]
+  by_cases hd_supp : d ∈ r.support
+  · obtain ⟨ha, hb⟩ := unique_small_weight_solution (hr_red d hd_supp) (hr_red d₀ hd₀)
+      (by rw [← weight_eq_4a_6b, ← weight_eq_4a_6b,
+        hr (MvPolynomial.mem_support_iff.mp hd_supp), hr (MvPolynomial.mem_support_iff.mp hd₀)])
+    exact absurd (Finsupp.ext fun i ↦ by fin_cases i <;> [exact ha; exact hb]) hd
+  · rwa [MvPolynomial.mem_support_iff, not_not] at hd_supp
+
+private lemma evalE₄E₆_monomial_qExpansion_coeff_zero {n : ℕ} {d₀ : Fin 2 →₀ ℕ}
+    (hd₀_weight : 4 * d₀ 0 + 6 * d₀ 1 = n) (c : ℂ) :
+    (qExpansion 1 ↑((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 = c := by
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+    Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
+    DirectSum.smul_apply,
+    show (↑(c • ((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ))) : ℍ → ℂ) =
+      c • (↑((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ)) : ℍ → ℂ) from rfl,
+    UpperHalfPlane.qExpansion_smul (ModularFormClass.analyticAt_cuspFunction_zero _
+      one_pos one_mem_strictPeriods_SL) c, PowerSeries.coeff_smul,
+    monomial_qExpansion_coeff_zero_eq_one hd₀_weight]
+  simp
+
+private lemma reduced_part_eq_zero {n : ℕ} (hn12 : 12 ≤ n)
+    (r s : MvPolynomial (Fin 2) ℂ)
+    (hr : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) r n)
+    (hs : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) s (n - 12))
+    (hr_red : ∀ d ∈ r.support, d 0 < 3)
+    (heval : (evalE₄E₆ (r + discriminantPoly * s)) (↑n : ℤ) = 0) :
+    r = 0 := by
+  by_cases hr_empty : r.support = ∅
+  · rwa [MvPolynomial.support_eq_empty] at hr_empty
+  obtain ⟨d₀, hd₀⟩ := Finset.nonempty_of_ne_empty hr_empty
+  have hr_mono := reduced_isWeightedHomogeneous_eq_monomial r hr hr_red hd₀
+  set c := MvPolynomial.coeff d₀ r
+  suffices hc : c = 0 by rw [hr_mono, hc, MvPolynomial.monomial_zero]
+  have hd₀_weight : 4 * d₀ 0 + 6 * d₀ 1 = n := by
+    have := (weight_eq_4a_6b d₀).symm.trans (hr (MvPolynomial.mem_support_iff.mp hd₀))
+    lia
+  rw [hr_mono, map_add, DirectSum.add_apply] at heval
+  set Q := ModularForm.qExpansionAddHom (h := 1) one_pos one_mem_strictPeriods_SL (↑n : ℤ)
+  have hQ : (Q ((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 +
+      (Q ((evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ))).coeff 0 = 0 := by
+    rw [← LinearMap.map_add, ← Q.map_add, heval, map_zero, map_zero]
+  rw [show (Q ((evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ))).coeff 0 = 0 from
+      evalE₄E₆_discriminantPoly_mul_coeff_zero hn12 s hs, add_zero,
+    show (Q ((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 = c from
+      evalE₄E₆_monomial_qExpansion_coeff_zero hd₀_weight c] at hQ
+  exact hQ
+
+private lemma eval_discriminantPoly_mul_eq_zero_imp_eval_eq_zero {n : ℕ} (hn12 : 12 ≤ n)
+    (s : MvPolynomial (Fin 2) ℂ)
+    (hs : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) s (n - 12))
+    (hds : (evalE₄E₆ (discriminantPoly * s)) (↑n : ℤ) = 0) :
+    (evalE₄E₆ s) (↑(n - 12) : ℤ) = 0 := by
+  have hcast : (12 : ℤ) + ((n - 12 : ℕ) : ℤ) = (↑n : ℤ) := by lia
+  rw [evalE₄E₆_discriminantPoly_mul_apply s hs hcast] at hds
+  ext z
+  have hpw := DFunLike.congr_fun hds z
+  simp only [ModularForm.zero_apply, cast_apply hcast] at hpw ⊢
+  exact (mul_eq_zero.mp hpw).resolve_left (discriminant_ne_zero z)
+
+private lemma per_weight_injective_inductive_step (n : ℕ)
+    (ih : ∀ m < n, ∀ (p : MvPolynomial (Fin 2) ℂ),
+      MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p m →
+        (evalE₄E₆ p) (↑m : ℤ) = 0 → p = 0)
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (heval : (evalE₄E₆ p) (↑n : ℤ) = 0)
+    (hn12 : 12 ≤ n) : p = 0 := by
+  obtain ⟨r, s, hr_wh, hs_wh, hp_eq, hr_red⟩ := weightedHomogeneous_poly_Delta_decomp hn12 p hp
+  have hr0 : r = 0 := reduced_part_eq_zero hn12 r s hr_wh hs_wh hr_red (hp_eq ▸ heval)
+  rw [hp_eq, hr0, zero_add] at heval ⊢
+  rw [ih (n - 12) (by lia) s hs_wh
+    (eval_discriminantPoly_mul_eq_zero_imp_eval_eq_zero hn12 s hs_wh heval), mul_zero]
+
+private lemma per_weight_injective_at_small_weight {n : ℕ} (hn12 : n < 12) (hk_even : Even n)
+    (p : MvPolynomial (Fin 2) ℂ)
+    (hp : MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n)
+    (heval : (evalE₄E₆ p) (↑n : ℤ) = 0) : p = 0 := by
+  obtain rfl | rfl | rfl | rfl | rfl | rfl :
+      n = 0 ∨ n = 2 ∨ n = 4 ∨ n = 6 ∨ n = 8 ∨ n = 10 := by
+    rcases hk_even with ⟨m, hm⟩
+    lia
+  · exact per_weight_injective_zero p hp heval
+  · exact hp.eq_zero_of_no_monomials fun d h ↦ by rw [weight_eq_4a_6b] at h; lia
+  · exact per_weight_injective_small 1 0 (by lia) (by lia) rfl p hp heval
+  · exact per_weight_injective_small 0 1 (by lia) (by lia) rfl p hp heval
+  · exact per_weight_injective_small 2 0 (by lia) (by lia) rfl p hp heval
+  · exact per_weight_injective_small 1 1 (by lia) (by lia) rfl p hp heval
+
+private lemma per_weight_injective : ∀ (n : ℕ) (p : MvPolynomial (Fin 2) ℂ),
+    MvPolynomial.IsWeightedHomogeneous (![4, 6] : Fin 2 → ℕ) p n →
+    (evalE₄E₆ p) (↑n : ℤ) = 0 → p = 0 := by
+  intro n
+  induction n using Nat.strong_induction_on with | _ n ih => ?_
+  intro p hp heval
+  by_cases hk_odd : Odd n
+  · exact hp.eq_zero_of_no_monomials (no_weight_monomial_of_odd hk_odd)
+  rw [Nat.not_odd_iff_even] at hk_odd
+  by_cases hn12 : n < 12
+  · exact per_weight_injective_at_small_weight hn12 hk_odd p hp heval
+  push Not at hn12
+  exact per_weight_injective_inductive_step n ih p hp heval hn12
+
+/-- The evaluation homomorphism `evalE₄E₆` is injective: `E₄` and `E₆` are algebraically
+independent. -/
+theorem evalE₄E₆_injective : Function.Injective evalE₄E₆ := by
+  intro p q hpq
+  rw [← sub_eq_zero,
+    ← MvPolynomial.sum_weightedHomogeneousComponent ((![4, 6] : Fin 2 → ℕ)) (p - q)]
+  refine finsum_eq_zero_of_forall_eq_zero fun n ↦ per_weight_injective n _
+    (MvPolynomial.weightedHomogeneousComponent_isWeightedHomogeneous _ _) ?_
+  rw [evalE₄E₆_component_eq, map_sub, hpq, sub_self, DirectSum.zero_apply]
+
+/-- The graded ring of level-1 modular forms is isomorphic to the polynomial ring
+`ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`. -/
+noncomputable def modularFormsEquivMvPolynomial :
+    MvPolynomial (Fin 2) ℂ ≃ₐ[ℂ] DirectSum ℤ (ModularForm 𝒮ℒ) :=
+  AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩
+
+/-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
+`ℂ`-algebra. -/
+theorem E₄E₆_generate :
+    Algebra.adjoin ℂ ({DirectSum.of (ModularForm 𝒮ℒ) 4 E₄,
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆} :
+      Set (DirectSum ℤ (ModularForm 𝒮ℒ))) = ⊤ := by
+  rw [show ({DirectSum.of (ModularForm 𝒮ℒ) 4 E₄,
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆} : Set _) =
+      Set.range (![DirectSum.of _ 4 E₄, DirectSum.of _ 6 E₆] : Fin 2 → _)
+    from (Matrix.range_cons_cons_empty _ _ _).symm,
+    Algebra.adjoin_range_eq_range_aeval]
+  exact (AlgHom.range_eq_top evalE₄E₆).mpr evalE₄E₆_surjective
+
+/-- The graded ring of level-1 modular forms is an integral domain, being isomorphic (via
+`modularFormsEquivMvPolynomial`) to the polynomial ring `ℂ[X₀, X₁]`. -/
+instance : IsDomain (DirectSum ℤ (ModularForm 𝒮ℒ)) :=
+  modularFormsEquivMvPolynomial.symm.toMulEquiv.isDomain _
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -739,14 +739,18 @@ theorem evalE₄E₆_injective : Function.Injective evalE₄E₆ := by
   rw [evalE₄E₆_component_eq, map_sub, hpq, sub_self, DirectSum.zero_apply]
 
 /-- The graded ring of level-1 modular forms is isomorphic to the polynomial ring
-`ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`.
-
-The definition is exposed so that its defining action is available downstream through
-Mathlib's own `AlgEquiv.ofBijective_apply`, with no wrapper lemma. -/
-@[expose]
+`ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`. -/
 noncomputable def mvPolynomialEquivModularForms :
     MvPolynomial (Fin 2) ℂ ≃ₐ[ℂ] DirectSum ℤ (ModularForm 𝒮ℒ) :=
   AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩
+
+@[simp]
+lemma mvPolynomialEquivModularForms_apply (p : MvPolynomial (Fin 2) ℂ) :
+    mvPolynomialEquivModularForms p = evalE₄E₆ p := by
+  -- `change` exposes the sealed definition once, explicitly; the identification is
+  -- then Mathlib's `AlgEquiv.ofBijective_apply`.
+  change AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩ p = evalE₄E₆ p
+  exact AlgEquiv.ofBijective_apply _ _ p
 
 /-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
 `ℂ`-algebra. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -747,10 +747,10 @@ noncomputable def mvPolynomialEquivModularForms :
 @[simp]
 lemma mvPolynomialEquivModularForms_apply (p : MvPolynomial (Fin 2) ℂ) :
     mvPolynomialEquivModularForms p = evalE₄E₆ p := by
-  -- `mvPolynomialEquivModularForms` has no equation lemma to rewrite with; `change`
-  -- spells out its definitional unfolding once, explicitly.
+  -- `change` exposes the sealed definition once, explicitly; the identification is
+  -- then Mathlib's `AlgEquiv.ofBijective_apply`.
   change AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩ p = evalE₄E₆ p
-  rfl
+  exact AlgEquiv.ofBijective_apply _ _ p
 
 /-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
 `ℂ`-algebra. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -85,6 +85,13 @@ lemma evalE₄E₆_X_one :
     evalE₄E₆ (MvPolynomial.X 1) = DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ := by
   simp [evalE₄E₆]
 
+/-- Constants evaluate to scalars: `evalE₄E₆` is definitionally `aeval ![…]`, and this
+private restatement of `MvPolynomial.aeval_C` at the wrapper's type lets `rw` use the
+identity without a `show`-ascription at every site. -/
+private lemma evalE₄E₆_C (c : ℂ) :
+    evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c :=
+  MvPolynomial.aeval_C _ c
+
 private lemma evalE₄E₆_monomial (a b : ℕ) :
     evalE₄E₆ (MvPolynomial.X 0 ^ a * MvPolynomial.X 1 ^ b) =
       DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ a *
@@ -357,8 +364,7 @@ private lemma evalE₄E₆_monomial_apply_eq_zero_of_ne (d : Fin 2 →₀ ℕ) (
     (hk : k ≠ (↑(d 0) * 4 + ↑(d 1) * 6 : ℤ)) :
     (evalE₄E₆ (MvPolynomial.monomial d c)) k = 0 := by
   rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
-    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
-      MvPolynomial.aeval_C _ _,
+    evalE₄E₆_C _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, DirectSum.smul_apply,
     evalE₄E₆_X_pow_mul_apply_eq_zero_of_ne (d 0) (d 1) k hk, smul_zero]
 
@@ -454,8 +460,7 @@ private lemma per_weight_injective_unique_monomial {n : ℕ} (p : MvPolynomial (
   have hpc := hp.eq_monomial_of_unique_weight huniq
   rw [hpc] at heval ⊢
   rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
-    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
-      MvPolynomial.aeval_C _ _,
+    evalE₄E₆_C _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply] at heval
   rcases smul_eq_zero.mp heval with hc | hmz
@@ -627,8 +632,7 @@ private lemma evalE₄E₆_monomial_qExpansion_coeff_zero {n : ℕ} {d₀ : Fin 
     (hd₀_weight : 4 * d₀ 0 + 6 * d₀ 1 = n) (c : ℂ) :
     (qExpansion 1 ↑((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 = c := by
   rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
-    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
-      MvPolynomial.aeval_C _ _,
+    evalE₄E₆_C _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply,
     -- Scalar action commutes with the coercion to functions

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -31,7 +31,7 @@ weight `k − 12` by Mathlib's `CuspForm.discriminantEquiv`, and `Δ = (E₄³ �
   `E₄` and `E₆` are algebraically independent.
 * `TauCeti.ModularForm.mvPolynomialEquivModularForms`: the induced algebra isomorphism
   `ℂ[X₀, X₁] ≃ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k`.
-* `TauCeti.ModularForm.E₄E₆_generate`: the two Eisenstein series generate the graded ring.
+* `TauCeti.ModularForm.adjoin_E₄_E₆_eq_top`: the two Eisenstein series generate the graded ring.
 
 ## References
 
@@ -621,12 +621,14 @@ private lemma evalE₄E₆_monomial_qExpansion_coeff_zero {n : ℕ} {d₀ : Fin 
   rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply,
-    -- Scalar action commutes with the coercion to functions, definitionally; the
-    -- ascribed `show … from rfl` records it once at the right type.
+    -- Scalar action commutes with the coercion to functions
+    -- (`ModularForm.IsGLPos.coe_smul`); the ascribed `show` pins the statement at the
+    -- right type.
     show (↑(c • ((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ))) : ℍ → ℂ) =
       c • (↑((DirectSum.of (ModularForm 𝒮ℒ) 4 E₄ ^ d₀ 0 *
-        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ)) : ℍ → ℂ) from rfl,
+        DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ)) : ℍ → ℂ) from
+      ModularForm.IsGLPos.coe_smul _ c,
     UpperHalfPlane.qExpansion_smul (ModularFormClass.analyticAt_cuspFunction_zero _
       one_pos one_mem_strictPeriods_SL) c, PowerSeries.coeff_smul,
     monomial_qExpansion_coeff_zero_eq_one hd₀_weight]
@@ -742,7 +744,7 @@ lemma mvPolynomialEquivModularForms_apply (p : MvPolynomial (Fin 2) ℂ) :
 
 /-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
 `ℂ`-algebra. -/
-theorem E₄E₆_generate :
+theorem adjoin_E₄_E₆_eq_top :
     Algebra.adjoin ℂ ({DirectSum.of (ModularForm 𝒮ℒ) 4 E₄,
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆} :
       Set (DirectSum ℤ (ModularForm 𝒮ℒ))) = ⊤ := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -316,10 +316,6 @@ theorem evalE₄E₆_surjective : Function.Surjective evalE₄E₆ := by
   exact Subalgebra.sum_mem _ fun k _ ↦ surj_of_weight k (x k)
 
 
-private lemma evalE₄E₆_C (c : ℂ) :
-    evalE₄E₆ (MvPolynomial.C c) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) c :=
-  MvPolynomial.aeval_C _ c
-
 private lemma discriminantPoly_smul_eq :
     (1728 : ℂ) • discriminantPoly = MvPolynomial.X 0 ^ 3 - MvPolynomial.X 1 ^ 2 := by
   rw [discriminantPoly, smul_smul]
@@ -360,7 +356,9 @@ private lemma evalE₄E₆_X_pow_mul_apply_eq_zero_of_ne (a b : ℕ) (k : ℤ)
 private lemma evalE₄E₆_monomial_apply_eq_zero_of_ne (d : Fin 2 →₀ ℕ) (c : ℂ) (k : ℤ)
     (hk : k ≠ (↑(d 0) * 4 + ↑(d 1) * 6 : ℤ)) :
     (evalE₄E₆ (MvPolynomial.monomial d c)) k = 0 := by
-  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
+    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
+      MvPolynomial.aeval_C _ _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, DirectSum.smul_apply,
     evalE₄E₆_X_pow_mul_apply_eq_zero_of_ne (d 0) (d 1) k hk, smul_zero]
 
@@ -455,7 +453,9 @@ private lemma per_weight_injective_unique_monomial {n : ℕ} (p : MvPolynomial (
         DirectSum.of (ModularForm 𝒮ℒ) 6 E₆ ^ d₀ 1) (↑n : ℤ) ≠ 0) : p = 0 := by
   have hpc := hp.eq_monomial_of_unique_weight huniq
   rw [hpc] at heval ⊢
-  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
+    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
+      MvPolynomial.aeval_C _ _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply] at heval
   rcases smul_eq_zero.mp heval with hc | hmz
@@ -496,7 +496,8 @@ private lemma per_weight_injective_zero
   rw [hpc, MvPolynomial.monomial_zero'] at heval ⊢
   -- The degree-`0` component of the graded unit is the unit form; `show` states the
   -- component extraction so `of_eq_same` can close it.
-  rw [evalE₄E₆_C, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
+  rw [show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
+      MvPolynomial.aeval_C _ _, Algebra.algebraMap_eq_smul_one, DirectSum.smul_apply,
     show (1 : DirectSum ℤ (ModularForm 𝒮ℒ)) (0 : ℤ) = (1 : ModularForm 𝒮ℒ 0) from by
       conv_lhs => rw [← DirectSum.of_zero_one (ModularForm 𝒮ℒ)]
       exact DirectSum.of_eq_same _ _] at heval
@@ -625,7 +626,9 @@ private lemma reduced_isWeightedHomogeneous_eq_monomial {n : ℕ}
 private lemma evalE₄E₆_monomial_qExpansion_coeff_zero {n : ℕ} {d₀ : Fin 2 →₀ ℕ}
     (hd₀_weight : 4 * d₀ 0 + 6 * d₀ 1 = n) (c : ℂ) :
     (qExpansion 1 ↑((evalE₄E₆ (MvPolynomial.monomial d₀ c)) (↑n : ℤ))).coeff 0 = c := by
-  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul, evalE₄E₆_C,
+  rw [MvPolynomial.monomial_fin_two, mul_assoc, map_mul,
+    show evalE₄E₆ (MvPolynomial.C _) = algebraMap ℂ (DirectSum ℤ (ModularForm 𝒮ℒ)) _ from
+      MvPolynomial.aeval_C _ _,
     Algebra.algebraMap_eq_smul_one, smul_mul_assoc, one_mul, evalE₄E₆_monomial,
     DirectSum.smul_apply,
     -- Scalar action commutes with the coercion to functions

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -739,18 +739,14 @@ theorem evalE₄E₆_injective : Function.Injective evalE₄E₆ := by
   rw [evalE₄E₆_component_eq, map_sub, hpq, sub_self, DirectSum.zero_apply]
 
 /-- The graded ring of level-1 modular forms is isomorphic to the polynomial ring
-`ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`. -/
+`ℂ[X₀, X₁]` via evaluation at `E₄` and `E₆`.
+
+The definition is exposed so that its defining action is available downstream through
+Mathlib's own `AlgEquiv.ofBijective_apply`, with no wrapper lemma. -/
+@[expose]
 noncomputable def mvPolynomialEquivModularForms :
     MvPolynomial (Fin 2) ℂ ≃ₐ[ℂ] DirectSum ℤ (ModularForm 𝒮ℒ) :=
   AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩
-
-@[simp]
-lemma mvPolynomialEquivModularForms_apply (p : MvPolynomial (Fin 2) ℂ) :
-    mvPolynomialEquivModularForms p = evalE₄E₆ p := by
-  -- `change` exposes the sealed definition once, explicitly; the identification is
-  -- then Mathlib's `AlgEquiv.ofBijective_apply`.
-  change AlgEquiv.ofBijective evalE₄E₆ ⟨evalE₄E₆_injective, evalE₄E₆_surjective⟩ p = evalE₄E₆ p
-  exact AlgEquiv.ofBijective_apply _ _ p
 
 /-- `E₄` and `E₆` generate the entire graded ring of level 1 modular forms as an
 `ℂ`-algebra. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/GradedRing.lean
@@ -22,6 +22,13 @@ weights and in weight `2`, and otherwise spanned by a monomial in `E₄`, `E₆`
 subtracting a multiple of such a monomial leaves a cusp form, which is `Δ` times a form of
 weight `k − 12` by Mathlib's `CuspForm.discriminantEquiv`, and `Δ = (E₄³ − E₆²)/1728`.
 
+Injectivity is a weight-by-weight argument on weighted-homogeneous components (weights
+`4`, `6`): any component of a relation splits, by repeated division of its high-`X₀`
+monomials, as a reduced part of `X₀`-degree below `3` plus the discriminant polynomial
+times a lower-weight piece; evaluating and inspecting the constant `q`-coefficient kills
+the reduced monomial, and induction on the weight — descending through the discriminant
+factor — finishes.
+
 ## Main declarations
 
 * `TauCeti.ModularForm.evalE₄E₆`: the evaluation homomorphism


### PR DESCRIPTION
The freeness half of the level-one graded ring: the evaluation homomorphism `ℂ[X₀, X₁] →ₐ[ℂ] ⨁ k, ModularForm 𝒮ℒ k` is injective — `E₄` and `E₆` are algebraically independent — so together with the surjectivity landed in #1878 it is an algebra isomorphism (`modularFormsEquivMvPolynomial`), the generators span (`E₄E₆_generate`), and the graded ring is an integral domain.

The injectivity argument decomposes a weighted-homogeneous relation along the discriminant polynomial: any weight-`n` polynomial splits as a reduced part (degree `< 3` in `X₀`) plus `Δ`-polynomial times a lower-weight piece; evaluating kills the reduced monomial by inspecting the constant `q`-coefficient, and induction on the weight finishes.

Ports the remaining half of the stalled upstream draft leanprover-community/mathlib4#38813 (author: Chris Birkbeck) onto the current Mathlib pin, completing the statement the roadmap names as "a genuine gap this roadmap fills".

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"level-one-graded-ring-freeness"}-->

---

**Reviewer note — application-lemma design.** Dry iteration hit a two-rubric contradiction on how consumers access the equivalence's forward action: with a `@[simp]` application wrapper and a sealed definition, *reuse* blocks ("specialization of `AlgEquiv.ofBijective_apply`"); with no wrapper and a sealed definition, *api-design* blocks ("defining action not available"); the current state — `@[expose]` on the definition, no wrapper, Mathlib's `ofBijective_apply` directly usable — was blocked by *api-design* in a dry sample as "coupling to the implementation" while *reuse* approves it. All three states cannot be simultaneously demanded; the exposed state is retained because the definition *is* `ofBijective` of the public evaluation map (its mathematical content, not an implementation detail), mirroring the accepted `@[expose]` precedent in #1833. Happy to switch states if the panel converges on one.
