### PR TITLE
feat: recover the matrix exponential from lieExp

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/Matrix/Compatibility.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Matrix/Compatibility.lean
@@ -5,14 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Normed.Algebra.MatrixExponential
-public import TauCeti.Geometry.Lie.Exponential.UnitsCompatibility
+public import TauCeti.Geometry.Lie.Exponential.Units.Compatibility
 
 /-!
 # Compatibility with the matrix exponential
 
 The abstract Lie-group exponential on the general linear group is the usual matrix exponential.
 The remaining results show that the transported abstract exponential inherits Mathlib's diagonal,
-transpose, and conjugation formulas.
+transpose, and conjugation formulas. The statements use Mathlib's scoped `L∞` operator norm on
+matrices; in finite dimension this choice does not change the underlying topology or exponential
+series, but consumers using another scoped matrix norm must transport across the instance choice.
 
 ## Main results
 
@@ -20,7 +22,7 @@ transpose, and conjugation formulas.
   `GL(n, ℝ)` to matrices, is `NormedSpace.exp`.
 * `lieExp_generalLinearGroup_diagonal`: the abstract exponential of a diagonal matrix is diagonal.
 * `lieExp_generalLinearGroup_transpose`: the abstract exponential commutes with transpose.
-* `lieExp_generalLinearGroup_conj`: the abstract exponential respects conjugation.
+* `lieExp_generalLinearGroup_units_conj`: the abstract exponential respects conjugation by a unit.
 
 ## References
 
@@ -44,6 +46,8 @@ theorem lieExp_generalLinearGroup_coe (A : Matrix n n ℝ) :
         ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm A) :
           Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) = exp A := by
   rw [lieExp_eq_expUnit, LinearEquiv.apply_symm_apply, TauCeti.expUnit_coe]
+  -- Both sides now use the same matrix exponential series. The remaining reduction only removes
+  -- the locally selected L∞ operator-norm and normed-algebra instance wrappers.
   rfl
 
 /-- The abstract exponential on `GL(n, ℝ)` sends diagonal matrices to the diagonal of the scalar
@@ -66,8 +70,9 @@ theorem lieExp_generalLinearGroup_transpose (A : Matrix n n ℝ) :
             Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ)).transpose := by
   rw [lieExp_generalLinearGroup_coe, lieExp_generalLinearGroup_coe, Matrix.exp_transpose]
 
-/-- The abstract exponential on `GL(n, ℝ)`, expressed in matrices, respects conjugation. -/
-theorem lieExp_generalLinearGroup_conj
+/-- The abstract exponential on `GL(n, ℝ)`, expressed in matrices, respects conjugation by a
+unit. -/
+theorem lieExp_generalLinearGroup_units_conj
     (U : Matrix.GeneralLinearGroup n ℝ) (A : Matrix n n ℝ) :
     ((lieExp
         ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm (U * A * U⁻¹)) :

--- a/TauCeti/Geometry/Lie/Exponential/MatrixCompatibility.lean
+++ b/TauCeti/Geometry/Lie/Exponential/MatrixCompatibility.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Algebra.MatrixExponential
+public import TauCeti.Geometry.Lie.Exponential.UnitsCompatibility
+
+/-!
+# Compatibility with the matrix exponential
+
+The abstract Lie-group exponential on the general linear group is the usual matrix exponential.
+The remaining results show that the transported abstract exponential inherits Mathlib's diagonal,
+transpose, and conjugation formulas.
+
+## Main results
+
+* `lieExp_generalLinearGroup_coe`: the abstract exponential, transported from the Lie algebra of
+  `GL(n, ℝ)` to matrices, is `NormedSpace.exp`.
+* `lieExp_generalLinearGroup_diagonal`: the abstract exponential of a diagonal matrix is diagonal.
+* `lieExp_generalLinearGroup_transpose`: the abstract exponential commutes with transpose.
+* `lieExp_generalLinearGroup_conj`: the abstract exponential respects conjugation.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The matrix and circle shadows".
+-/
+
+public section
+
+open Manifold NormedSpace
+open scoped ContDiff Manifold Matrix Matrix.Norms.Operator
+
+noncomputable section
+
+variable {n : Type*} [Fintype n] [DecidableEq n]
+
+/-- Coercing the abstract exponential on `GL(n, ℝ)` to matrices gives the matrix exponential. -/
+@[simp]
+theorem lieExp_generalLinearGroup_coe (A : Matrix n n ℝ) :
+    ((lieExp
+        ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm A) :
+          Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) = exp A := by
+  rw [lieExp_eq_expUnit, LinearEquiv.apply_symm_apply, TauCeti.expUnit_coe]
+  rfl
+
+/-- The abstract exponential on `GL(n, ℝ)` sends diagonal matrices to the diagonal of the scalar
+exponentials. -/
+theorem lieExp_generalLinearGroup_diagonal (v : n → ℝ) :
+    ((lieExp
+        ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm (Matrix.diagonal v)) :
+          Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) =
+      Matrix.diagonal (fun i => exp (v i)) := by
+  rw [lieExp_generalLinearGroup_coe, Matrix.exp_diagonal]
+  rw [Pi.exp_def]
+
+/-- The abstract exponential on `GL(n, ℝ)`, expressed in matrices, commutes with transpose. -/
+theorem lieExp_generalLinearGroup_transpose (A : Matrix n n ℝ) :
+    ((lieExp
+        ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm A.transpose) :
+          Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) =
+      (((lieExp
+          ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm A) :
+            Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ)).transpose := by
+  rw [lieExp_generalLinearGroup_coe, lieExp_generalLinearGroup_coe, Matrix.exp_transpose]
+
+/-- The abstract exponential on `GL(n, ℝ)`, expressed in matrices, respects conjugation. -/
+theorem lieExp_generalLinearGroup_conj
+    (U : Matrix.GeneralLinearGroup n ℝ) (A : Matrix n n ℝ) :
+    ((lieExp
+        ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm (U * A * U⁻¹)) :
+          Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) =
+      U *
+        ((lieExp
+          ((unitsLieAlgebraEquiv (R := Matrix n n ℝ)).symm A) :
+            Matrix.GeneralLinearGroup n ℝ) : Matrix n n ℝ) * U⁻¹ := by
+  rw [lieExp_generalLinearGroup_coe, lieExp_generalLinearGroup_coe, Matrix.exp_units_conj]


### PR DESCRIPTION
## Goal

Establish the matrix part of the Layer 0 acceptance criterion: the abstract Lie-group exponential on `GL(n, ℝ)` recovers the usual matrix exponential and its standard computational formulas.

## Argument

PR #1899 identifies `lieExp` on units with `TauCeti.expUnit`. Specializing that bridge to square real matrices and applying the inverse Lie-algebra equivalence reduces the generator to the original matrix; coercing `expUnit` then yields `NormedSpace.exp`. The diagonal, transpose, and unit-conjugation results are transported directly from the corresponding Mathlib matrix-exponential theorems, so this PR introduces no replacement exponential.

The declarations use Mathlib scoped L∞ operator norm. In finite dimension that instance choice does not alter the topology or exponential series, but the module documents the formal instance boundary for consumers using a different scoped matrix norm.

## Changes

- Add `TauCeti.Geometry.Lie.Exponential.Matrix.Compatibility`.
- Prove coercion, diagonal, transpose, and unit-conjugation compatibility.
- Group the module under the canonical `Exponential/Matrix/` prefix.
- Document the final definitional reduction across the local normed-algebra instance wrappers.

## Verification

- `bash scripts/sandbox-build.sh`
  - 6,518 jobs built.
  - 22,451 Tau Ceti declarations passed the axiom audit.
  - All 1,240 Tau Ceti modules participate in the module system.
  - 1,829 declarations passed the docstring scan; 1,239 modules passed lint with no new violations.
- `git diff --check`

Depends on merged #1899 and advances `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 0, “The matrix and circle shadows.”

Roadmap: RepresentationTheory