### PR TITLE
feat: add homogeneous Clifford filtration multiplication

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -11,8 +11,8 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 /-!
 # Homogeneous multiplication for a Clifford filtration
 
-This file defines the successive quotient pieces of the Clifford degree filtration and lifts
-Clifford multiplication to a bilinear product between any two homogeneous pieces.
+This file lifts Clifford multiplication to a bilinear product between any two successive quotient
+pieces of the Clifford degree filtration.
 
 This is the multiplication prerequisite for the Layer 0 associated-graded comparison in the spin
 representations roadmap. It is generic in the quadratic form and does not yet package the direct
@@ -30,27 +30,6 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
-
-/-- The filtration step preceding degree `k`. At degree zero it is bottom, so the degree-zero
-piece remains the scalar filtration step rather than a zero quotient. -/
-def filtrationPrevious (Q : QuadraticForm R M) : ℕ → Submodule R (CliffordAlgebra Q)
-  | 0 => ⊥
-  | k + 1 => filtration Q k
-
--- Parenthesized `rfl` exports the intended reduction API without exposing the definition.
-@[simp]
-theorem filtrationPrevious_zero (Q : QuadraticForm R M) : filtrationPrevious Q 0 = ⊥ :=
-  (rfl)
-
-@[simp]
-theorem filtrationPrevious_succ (Q : QuadraticForm R M) (k : ℕ) :
-    filtrationPrevious Q (k + 1) = filtration Q k :=
-  (rfl)
-
-/-- The degree-`k` piece of the associated graded Clifford filtration. -/
-abbrev filtrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=
-  filtration Q k ⧸
-    Submodule.comap (filtration Q k).subtype (filtrationPrevious Q k)
 
 private theorem mul_mem_filtrationPrevious_left (Q : QuadraticForm R M) (i j : ℕ)
     {x y : CliffordAlgebra Q} (hx : x ∈ filtrationPrevious Q i) (hy : y ∈ filtration Q j) :
@@ -87,8 +66,17 @@ private noncomputable def filtrationMul (Q : QuadraticForm R M) (i j : ℕ) :
       Submodule.mulMap' (filtration Q i) (filtration Q j))
 
 private noncomputable def filtrationGradedPreMul (Q : QuadraticForm R M) (i j : ℕ) :
-    filtration Q i →ₗ[R] filtration Q j →ₗ[R] filtrationGradedPiece Q (i + j) :=
+    filtration Q i →ₗ[R] filtration Q j →ₗ[R] FiltrationGradedPiece Q (i + j) :=
   (filtrationMul Q i j).compr₂ (Submodule.mkQ _)
+
+private theorem filtrationGradedPreMul_apply (Q : QuadraticForm R M) (i j : ℕ)
+    (x : filtration Q i) (y : filtration Q j) :
+    filtrationGradedPreMul Q i j x y =
+      Submodule.Quotient.mk
+        (⟨(x : CliffordAlgebra Q) * y, by
+          rw [← filtration_mul Q i j]
+          exact Submodule.mul_mem_mul x.property y.property⟩ : filtration Q (i + j)) :=
+  rfl
 
 private theorem filtrationGradedPreMul_mem_ker_left (Q : QuadraticForm R M) (i j : ℕ) :
     Submodule.comap (filtration Q i).subtype (filtrationPrevious Q i) ≤
@@ -96,8 +84,7 @@ private theorem filtrationGradedPreMul_mem_ker_left (Q : QuadraticForm R M) (i j
   rintro ⟨x, hx⟩ hprevious
   rw [LinearMap.mem_ker]
   ext y
-  -- Expose the quotient representative before using its zero-class membership criterion.
-  change Submodule.Quotient.mk _ = 0
+  simp only [filtrationGradedPreMul_apply, LinearMap.zero_apply]
   rw [Submodule.Quotient.mk_eq_zero]
   -- The filtration product lemma is stated for ambient Clifford-algebra elements.
   change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
@@ -109,17 +96,16 @@ private theorem filtrationGradedPreMul_mem_ker_right (Q : QuadraticForm R M) (i 
   rintro ⟨y, hy⟩ hprevious
   rw [LinearMap.mem_ker]
   ext x
-  -- Expose the quotient representative before using its zero-class membership criterion.
-  change Submodule.Quotient.mk _ = 0
-  rw [Submodule.Quotient.mk_eq_zero]
+  simp only [LinearMap.flip_apply, LinearMap.zero_apply]
+  rw [filtrationGradedPreMul_apply, Submodule.Quotient.mk_eq_zero]
   -- The filtration product lemma is stated for ambient Clifford-algebra elements.
   change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
   exact mul_mem_filtrationPrevious_right Q i j x.property hprevious
 
 /-- Multiplication of two homogeneous pieces of the Clifford associated graded algebra. -/
 noncomputable def filtrationGradedMul (Q : QuadraticForm R M) (i j : ℕ) :
-    filtrationGradedPiece Q i →ₗ[R] filtrationGradedPiece Q j →ₗ[R]
-      filtrationGradedPiece Q (i + j) :=
+    FiltrationGradedPiece Q i →ₗ[R] FiltrationGradedPiece Q j →ₗ[R]
+      FiltrationGradedPiece Q (i + j) :=
   (filtrationGradedPreMul Q i j).liftQ₂ _ _
     (filtrationGradedPreMul_mem_ker_left Q i j)
     (filtrationGradedPreMul_mem_ker_right Q i j)
@@ -139,7 +125,7 @@ theorem filtrationGradedMul_apply_mk (Q : QuadraticForm R M) (i j : ℕ) (x : fi
 
 private theorem filtrationGradedPiece_cast_mk' (Q : QuadraticForm R M) {i j : ℕ}
     (h : i = j) (x : filtration Q i) :
-    cast (congrArg (filtrationGradedPiece Q) h) (Submodule.Quotient.mk x) =
+    cast (congrArg (FiltrationGradedPiece Q) h) (Submodule.Quotient.mk x) =
       Submodule.Quotient.mk (cast (congrArg (fun k => ↥(filtration Q k)) h) x) := by
   subst j
   rfl
@@ -152,9 +138,9 @@ private theorem filtration_subtype_cast (Q : QuadraticForm R M) {i j : ℕ}
 
 /-- Homogeneous Clifford filtration multiplication is associative after reindexing degrees. -/
 theorem filtrationGradedMul_assoc (Q : QuadraticForm R M) (i j k : ℕ)
-    (x : filtrationGradedPiece Q i) (y : filtrationGradedPiece Q j)
-    (z : filtrationGradedPiece Q k) :
-    cast (congrArg (filtrationGradedPiece Q) (Nat.add_assoc i j k))
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j)
+    (z : FiltrationGradedPiece Q k) :
+    cast (congrArg (FiltrationGradedPiece Q) (Nat.add_assoc i j k))
       (filtrationGradedMul Q (i + j) k (filtrationGradedMul Q i j x y) z) =
       filtrationGradedMul Q i (j + k) x (filtrationGradedMul Q j k y z) := by
   induction x using Submodule.Quotient.induction_on with
@@ -168,6 +154,7 @@ theorem filtrationGradedMul_assoc (Q : QuadraticForm R M) (i j k : ℕ)
               apply (Submodule.Quotient.eq _).mpr
               rw [Submodule.mem_comap, map_sub,
                 filtration_subtype_cast Q (Nat.add_assoc i j k)]
+              -- Compare the two representatives in the ambient Clifford algebra.
               change ((x : CliffordAlgebra Q) * y) * z - x * (y * z) ∈
                 filtrationPrevious Q (i + (j + k))
               rw [mul_assoc, sub_self]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -121,7 +121,7 @@ theorem filtrationGradedMul_apply_mk (Q : QuadraticForm R M) (i j : ℕ) (x : fi
           exact Submodule.mul_mem_mul x.property y.property⟩ : filtration Q (i + j)) :=
   by
   rw [filtrationGradedMul, LinearMap.liftQ₂_mk]
-  rfl
+  exact filtrationGradedPreMul_apply Q i j x y
 
 private theorem filtrationGradedPiece_cast_mk' (Q : QuadraticForm R M) {i j : ℕ}
     (h : i = j) (x : filtration Q i) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.LinearAlgebra.Quotient.Bilinear
+public import Mathlib.LinearAlgebra.TensorProduct.Submodule
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
+
+/-!
+# Homogeneous multiplication for a Clifford filtration
+
+This file defines the successive quotient pieces of the Clifford degree filtration and lifts
+Clifford multiplication to a bilinear product between any two homogeneous pieces.
+
+This is the multiplication prerequisite for the Layer 0 associated-graded comparison in the spin
+representations roadmap. It is generic in the quadratic form and does not yet package the direct
+sum as a graded algebra or identify it with the exterior algebra.
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- The filtration step preceding degree `k`. At degree zero it is bottom, so the degree-zero
+piece remains the scalar filtration step rather than a zero quotient. -/
+def filtrationPrevious (Q : QuadraticForm R M) : ℕ → Submodule R (CliffordAlgebra Q)
+  | 0 => ⊥
+  | k + 1 => filtration Q k
+
+-- Parenthesized `rfl` exports the intended reduction API without exposing the definition.
+@[simp]
+theorem filtrationPrevious_zero (Q : QuadraticForm R M) : filtrationPrevious Q 0 = ⊥ :=
+  (rfl)
+
+@[simp]
+theorem filtrationPrevious_succ (Q : QuadraticForm R M) (k : ℕ) :
+    filtrationPrevious Q (k + 1) = filtration Q k :=
+  (rfl)
+
+/-- The degree-`k` piece of the associated graded Clifford filtration. -/
+abbrev filtrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=
+  filtration Q k ⧸
+    Submodule.comap (filtration Q k).subtype (filtrationPrevious Q k)
+
+private theorem mul_mem_filtrationPrevious_left (Q : QuadraticForm R M) (i j : ℕ)
+    {x y : CliffordAlgebra Q} (hx : x ∈ filtrationPrevious Q i) (hy : y ∈ filtration Q j) :
+    x * y ∈ filtrationPrevious Q (i + j) := by
+  cases i with
+  | zero =>
+      rw [filtrationPrevious_zero] at hx
+      rw [Submodule.mem_bot] at hx
+      subst x
+      simp
+  | succ i =>
+      rw [filtrationPrevious_succ] at hx
+      rw [Nat.succ_add, filtrationPrevious_succ, ← filtration_mul]
+      exact Submodule.mul_mem_mul hx hy
+
+private theorem mul_mem_filtrationPrevious_right (Q : QuadraticForm R M) (i j : ℕ)
+    {x y : CliffordAlgebra Q} (hx : x ∈ filtration Q i) (hy : y ∈ filtrationPrevious Q j) :
+    x * y ∈ filtrationPrevious Q (i + j) := by
+  cases j with
+  | zero =>
+      rw [filtrationPrevious_zero] at hy
+      rw [Submodule.mem_bot] at hy
+      subst y
+      simp
+  | succ j =>
+      rw [filtrationPrevious_succ] at hy
+      rw [Nat.add_succ, filtrationPrevious_succ, ← filtration_mul]
+      exact Submodule.mul_mem_mul hx hy
+
+private noncomputable def filtrationMul (Q : QuadraticForm R M) (i j : ℕ) :
+    filtration Q i →ₗ[R] filtration Q j →ₗ[R] filtration Q (i + j) :=
+  TensorProduct.curry
+    ((LinearEquiv.ofEq _ _ (filtration_mul Q i j)).toLinearMap ∘ₗ
+      Submodule.mulMap' (filtration Q i) (filtration Q j))
+
+private noncomputable def filtrationGradedPreMul (Q : QuadraticForm R M) (i j : ℕ) :
+    filtration Q i →ₗ[R] filtration Q j →ₗ[R] filtrationGradedPiece Q (i + j) :=
+  (filtrationMul Q i j).compr₂ (Submodule.mkQ _)
+
+private theorem filtrationGradedPreMul_mem_ker_left (Q : QuadraticForm R M) (i j : ℕ) :
+    Submodule.comap (filtration Q i).subtype (filtrationPrevious Q i) ≤
+      (filtrationGradedPreMul Q i j).ker := by
+  rintro ⟨x, hx⟩ hprevious
+  rw [LinearMap.mem_ker]
+  ext y
+  -- Expose the quotient representative before using its zero-class membership criterion.
+  change Submodule.Quotient.mk _ = 0
+  rw [Submodule.Quotient.mk_eq_zero]
+  -- The filtration product lemma is stated for ambient Clifford-algebra elements.
+  change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
+  exact mul_mem_filtrationPrevious_left Q i j hprevious y.property
+
+private theorem filtrationGradedPreMul_mem_ker_right (Q : QuadraticForm R M) (i j : ℕ) :
+    Submodule.comap (filtration Q j).subtype (filtrationPrevious Q j) ≤
+      (filtrationGradedPreMul Q i j).flip.ker := by
+  rintro ⟨y, hy⟩ hprevious
+  rw [LinearMap.mem_ker]
+  ext x
+  -- Expose the quotient representative before using its zero-class membership criterion.
+  change Submodule.Quotient.mk _ = 0
+  rw [Submodule.Quotient.mk_eq_zero]
+  -- The filtration product lemma is stated for ambient Clifford-algebra elements.
+  change (x : CliffordAlgebra Q) * (y : CliffordAlgebra Q) ∈ filtrationPrevious Q (i + j)
+  exact mul_mem_filtrationPrevious_right Q i j x.property hprevious
+
+/-- Multiplication of two homogeneous pieces of the Clifford associated graded algebra. -/
+noncomputable def filtrationGradedMul (Q : QuadraticForm R M) (i j : ℕ) :
+    filtrationGradedPiece Q i →ₗ[R] filtrationGradedPiece Q j →ₗ[R]
+      filtrationGradedPiece Q (i + j) :=
+  (filtrationGradedPreMul Q i j).liftQ₂ _ _
+    (filtrationGradedPreMul_mem_ker_left Q i j)
+    (filtrationGradedPreMul_mem_ker_right Q i j)
+
+/-- On quotient representatives, the homogeneous product is induced by Clifford multiplication. -/
+@[simp]
+theorem filtrationGradedMul_apply_mk (Q : QuadraticForm R M) (i j : ℕ) (x : filtration Q i)
+    (y : filtration Q j) :
+    filtrationGradedMul Q i j (Submodule.Quotient.mk x) (Submodule.Quotient.mk y) =
+      Submodule.Quotient.mk
+        (⟨(x : CliffordAlgebra Q) * y, by
+          rw [← filtration_mul Q i j]
+          exact Submodule.mul_mem_mul x.property y.property⟩ : filtration Q (i + j)) :=
+  by
+  rw [filtrationGradedMul, LinearMap.liftQ₂_mk]
+  rfl
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -137,6 +137,42 @@ theorem filtrationGradedMul_apply_mk (Q : QuadraticForm R M) (i j : ℕ) (x : fi
   rw [filtrationGradedMul, LinearMap.liftQ₂_mk]
   rfl
 
+private theorem filtrationGradedPiece_cast_mk' (Q : QuadraticForm R M) {i j : ℕ}
+    (h : i = j) (x : filtration Q i) :
+    cast (congrArg (filtrationGradedPiece Q) h) (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk (cast (congrArg (fun k => ↥(filtration Q k)) h) x) := by
+  subst j
+  rfl
+
+private theorem filtration_subtype_cast (Q : QuadraticForm R M) {i j : ℕ}
+    (h : i = j) (x : filtration Q i) :
+    (filtration Q j).subtype (cast (congrArg (fun k => ↥(filtration Q k)) h) x) = x := by
+  subst j
+  rfl
+
+/-- Homogeneous Clifford filtration multiplication is associative after reindexing degrees. -/
+theorem filtrationGradedMul_assoc (Q : QuadraticForm R M) (i j k : ℕ)
+    (x : filtrationGradedPiece Q i) (y : filtrationGradedPiece Q j)
+    (z : filtrationGradedPiece Q k) :
+    cast (congrArg (filtrationGradedPiece Q) (Nat.add_assoc i j k))
+      (filtrationGradedMul Q (i + j) k (filtrationGradedMul Q i j x y) z) =
+      filtrationGradedMul Q i (j + k) x (filtrationGradedMul Q j k y z) := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ x =>
+      induction y using Submodule.Quotient.induction_on with
+      | _ y =>
+          induction z using Submodule.Quotient.induction_on with
+          | _ z =>
+              simp only [filtrationGradedMul_apply_mk]
+              rw [filtrationGradedPiece_cast_mk' Q (Nat.add_assoc i j k)]
+              apply (Submodule.Quotient.eq _).mpr
+              rw [Submodule.mem_comap, map_sub,
+                filtration_subtype_cast Q (Nat.add_assoc i j k)]
+              change ((x : CliffordAlgebra Q) * y) * z - x * (y * z) ∈
+                filtrationPrevious Q (i + (j + k))
+              rw [mul_assoc, sub_self]
+              exact Submodule.zero_mem (filtrationPrevious Q (i + (j + k)))
+
 end CliffordAlgebra
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -91,10 +91,17 @@ private theorem zero_form_filtration_succ_eq_exteriorPower_sup (k : ℕ) :
       ⋀[R]^(k + 1) M ⊔ filtration (0 : QuadraticForm R M) k := by
   rw [filtration_succ_eq_sup, sup_comm]
 
+private theorem zero_form_filtrationPrevious_succ_comap (k : ℕ) :
+    Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
+        (filtrationPrevious (0 : QuadraticForm R M) (k + 1)) =
+      Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
+        (filtration (0 : QuadraticForm R M) k) := by
+  rw [filtrationPrevious_succ]
+
 /-- The successive zero-form Clifford filtration quotient is the degree `k + 1` exterior power. -/
 noncomputable def zeroFormFiltrationQuotientEquivExteriorPower (k : ℕ) :
     FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
-  (Submodule.quotEquivOfEq _ _ (by rw [filtrationPrevious_succ])).trans
+  (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPrevious_succ_comap k)).trans
     (quotientEquivOfEqSup _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
       (exteriorPower_succ_disjoint_zero_form_filtration k))
 
@@ -109,7 +116,8 @@ theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
         exact Submodule.mem_sup_left x.property⟩ := by
   rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
     LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
-  rfl
+  apply (Submodule.quotEquivOfEq _ _ (zero_form_filtrationPrevious_succ_comap k)).injective
+  rw [LinearEquiv.apply_symm_apply, Submodule.quotEquivOfEq_mk]
 
 /-- The quotient equivalence sends the canonical class of a degree `k + 1` exterior element to
 that element. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/ExteriorFiltration.lean
@@ -93,11 +93,10 @@ private theorem zero_form_filtration_succ_eq_exteriorPower_sup (k : ℕ) :
 
 /-- The successive zero-form Clifford filtration quotient is the degree `k + 1` exterior power. -/
 noncomputable def zeroFormFiltrationQuotientEquivExteriorPower (k : ℕ) :
-    (filtration (0 : QuadraticForm R M) (k + 1) ⧸
-      Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
-        (filtration (0 : QuadraticForm R M) k)) ≃ₗ[R] ⋀[R]^(k + 1) M :=
-  quotientEquivOfEqSup _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
-    (exteriorPower_succ_disjoint_zero_form_filtration k)
+    FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
+  (Submodule.quotEquivOfEq _ _ (by rw [filtrationPrevious_succ])).trans
+    (quotientEquivOfEqSup _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
+      (exteriorPower_succ_disjoint_zero_form_filtration k))
 
 /-- The inverse quotient equivalence sends a degree `k + 1` exterior element to its canonical
 quotient class. -/
@@ -107,9 +106,10 @@ theorem zeroFormFiltrationQuotientEquivExteriorPower_symm_apply (k : ℕ)
     (zeroFormFiltrationQuotientEquivExteriorPower k).symm x =
       Submodule.Quotient.mk ⟨x, by
         rw [zero_form_filtration_succ_eq_exteriorPower_sup]
-        exact Submodule.mem_sup_left x.property⟩ :=
-  quotientEquivOfEqSup_symm_apply _ _ _ (zero_form_filtration_succ_eq_exteriorPower_sup k)
-    (exteriorPower_succ_disjoint_zero_form_filtration k) x
+        exact Submodule.mem_sup_left x.property⟩ := by
+  rw [zeroFormFiltrationQuotientEquivExteriorPower, LinearEquiv.trans_symm,
+    LinearEquiv.trans_apply, quotientEquivOfEqSup_symm_apply]
+  rfl
 
 /-- The quotient equivalence sends the canonical class of a degree `k + 1` exterior element to
 that element. -/

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Filtration.lean
@@ -36,6 +36,7 @@ supremum over the `i` of a fixed parity.
 ## Main definitions
 
 * `TauCeti.CliffordAlgebra.filtration Q k`: the span of the products of at most `k` generators.
+* `TauCeti.CliffordAlgebra.FiltrationGradedPiece Q k`: the degree-`k` successive quotient.
 
 ## Main results
 
@@ -97,6 +98,26 @@ This is deliberately not the submodule power `LinearMap.range (ι Q) ^ k`, which
 of exactly `k` generators; see `filtration_eq_iSup_pow` for the comparison. -/
 def filtration (Q : QuadraticForm R M) (k : ℕ) : Submodule R (CliffordAlgebra Q) :=
   Submodule.span R {x | ∃ l : List M, l.length ≤ k ∧ (l.map (ι Q)).prod = x}
+
+/-- The filtration step preceding degree `k`. At degree zero it is bottom, so the degree-zero
+piece remains the scalar filtration step rather than a zero quotient. -/
+def filtrationPrevious (Q : QuadraticForm R M) : ℕ → Submodule R (CliffordAlgebra Q)
+  | 0 => ⊥
+  | k + 1 => filtration Q k
+
+@[simp]
+theorem filtrationPrevious_zero (Q : QuadraticForm R M) : filtrationPrevious Q 0 = ⊥ :=
+  (rfl)
+
+@[simp]
+theorem filtrationPrevious_succ (Q : QuadraticForm R M) (k : ℕ) :
+    filtrationPrevious Q (k + 1) = filtration Q k :=
+  (rfl)
+
+/-- The degree-`k` piece of the associated graded Clifford filtration. -/
+abbrev FiltrationGradedPiece (Q : QuadraticForm R M) (k : ℕ) : Type max u v :=
+  filtration Q k ⧸
+    Submodule.comap (filtration Q k).subtype (filtrationPrevious Q k)
 
 variable (Q : QuadraticForm R M)
 
@@ -350,10 +371,10 @@ private theorem filtrationLeadingTermRaw_mem_previous (k : ℕ) (v : Fin (k + 1)
   simpa only [List.length_ofFn, Nat.add_sub_cancel] using
     prod_map_ι_mem_filtration_pred_of_not_nodup Q (List.ofFn v) hnot
 
-private noncomputable def filtrationLeadingTermAlternating (k : ℕ) : M [⋀^Fin (k + 1)]→ₗ[R]
-    (filtration Q (k + 1) ⧸ (filtration Q k).comap (filtration Q (k + 1)).subtype) :=
+private noncomputable def filtrationLeadingTermAlternating (k : ℕ) :
+    M [⋀^Fin (k + 1)]→ₗ[R] FiltrationGradedPiece Q (k + 1) :=
   let P : Submodule R (filtration Q (k + 1)) :=
-    (filtration Q k).comap (filtration Q (k + 1)).subtype
+    (filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype
   { toMultilinearMap :=
       P.mkQ.compMultilinearMap
         ((filtrationLeadingTermRaw Q k).codRestrict (filtration Q (k + 1))
@@ -363,7 +384,9 @@ private noncomputable def filtrationLeadingTermAlternating (k : ℕ) : M [⋀^Fi
       -- Expose the quotient/subtype wrapper so zero is membership in the lower filtration.
       change P.mkQ ⟨filtrationLeadingTermRaw Q k v, filtrationLeadingTermRaw_mem Q k v⟩ = 0
       rw [Submodule.mkQ_apply, Submodule.Quotient.mk_eq_zero]
-      exact filtrationLeadingTermRaw_mem_previous Q k v hij hijne }
+      change filtrationLeadingTermRaw Q k v ∈ filtrationPrevious Q (k + 1)
+      simpa only [filtrationPrevious_succ] using
+        filtrationLeadingTermRaw_mem_previous Q k v hij hijne }
 
 /-- The degree-`k + 1` leading-term map from the exterior power to the corresponding Clifford
 filtration quotient. A repeated generator becomes a lower-filtration term under the Clifford
@@ -372,7 +395,7 @@ relation, so the product descends to an alternating map.
 This is the surjectivity half of the Layer 0 `filtrationGradedEquiv` target in the
 [spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/Suggested.lean#L62-L68). -/
 noncomputable def filtrationLeadingTerm (k : ℕ) : ExteriorAlgebra.exteriorPower R (k + 1) M →ₗ[R]
-    (filtration Q (k + 1) ⧸ (filtration Q k).comap (filtration Q (k + 1)).subtype) :=
+    FiltrationGradedPiece Q (k + 1) :=
   exteriorPower.alternatingMapLinearEquiv (filtrationLeadingTermAlternating Q k)
 
 /-- The leading-term map sends an exterior product to the class of the corresponding product of
@@ -393,7 +416,7 @@ An element of `filtration Q (k + 1)` lies in its image under the inclusion exact
 modulo `filtration Q k` is a leading term. -/
 private noncomputable def leadingTermPreimage (k : ℕ) : Submodule R (filtration Q (k + 1)) :=
   (LinearMap.range (filtrationLeadingTerm Q k)).comap
-    ((filtration Q k).comap (filtration Q (k + 1)).subtype).mkQ
+    ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype).mkQ
 
 /-- **The lower filtration consists of leading terms, trivially.** An element of `filtration Q k`
 has zero class modulo `filtration Q k`, and zero is a leading term. -/
@@ -402,8 +425,12 @@ private theorem filtration_le_map_leadingTermPreimage (k : ℕ) :
   intro z hz
   have hz' : z ∈ filtration Q (k + 1) := filtration_mono Q (by omega) hz
   refine Submodule.mem_map.2 ⟨⟨z, hz'⟩, ?_, rfl⟩
-  have hzero : ((filtration Q k).comap (filtration Q (k + 1)).subtype).mkQ ⟨z, hz'⟩ = 0 :=
-    (Submodule.Quotient.mk_eq_zero _).mpr hz
+  have hzero :
+      ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype).mkQ
+        ⟨z, hz'⟩ = 0 :=
+    (Submodule.Quotient.mk_eq_zero _).mpr (by
+      rw [Submodule.mem_comap, filtrationPrevious_succ]
+      exact hz)
   simp [leadingTermPreimage, hzero]
 
 /-- **A product of `k + 1` generators is a leading term**, namely of the corresponding exterior
@@ -440,7 +467,8 @@ theorem filtrationLeadingTerm_surjective (k : ℕ) :
         (ι_range_pow_le_map_leadingTermPreimage Q k))
   intro z
   obtain ⟨x, rfl⟩ :=
-    Submodule.Quotient.mk_surjective ((filtration Q k).comap (filtration Q (k + 1)).subtype) z
+    Submodule.Quotient.mk_surjective
+      ((filtrationPrevious Q (k + 1)).comap (filtration Q (k + 1)).subtype) z
   obtain ⟨y, hy, hxy⟩ := Submodule.mem_map.1 (hle x.property)
   obtain rfl : y = x := Subtype.ext hxy
   simpa [leadingTermPreimage] using hy

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Graded.lean
@@ -81,18 +81,15 @@ private theorem equivExteriorFiltration_map_previous (Q : QuadraticForm R M) [In
 
 private noncomputable def equivExteriorFiltrationQuotient (Q : QuadraticForm R M)
     [Invertible (2 : R)] (k : ℕ) :
-    (filtration Q (k + 1) ⧸
-      Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)) ≃ₗ[R]
-      (filtration (0 : QuadraticForm R M) (k + 1) ⧸
-        Submodule.comap (filtration (0 : QuadraticForm R M) (k + 1)).subtype
-          (filtration (0 : QuadraticForm R M) k)) :=
+    FiltrationGradedPiece Q (k + 1) ≃ₗ[R]
+      FiltrationGradedPiece (0 : QuadraticForm R M) (k + 1) :=
   Submodule.Quotient.equiv _ _ (equivExteriorFiltration Q (k + 1))
-    (equivExteriorFiltration_map_previous Q k)
+    (by
+      simpa only [filtrationPrevious_succ] using equivExteriorFiltration_map_previous Q k)
 
 /-- The successive degree quotient of a Clifford algebra is the corresponding exterior power. -/
 noncomputable def filtrationGradedEquiv (Q : QuadraticForm R M) [Invertible (2 : R)] (k : ℕ) :
-    (filtration Q (k + 1) ⧸
-      Submodule.comap (filtration Q (k + 1)).subtype (filtration Q k)) ≃ₗ[R] ⋀[R]^(k + 1) M :=
+    FiltrationGradedPiece Q (k + 1) ≃ₗ[R] ⋀[R]^(k + 1) M :=
   (equivExteriorFiltrationQuotient Q k).trans (zeroFormFiltrationQuotientEquivExteriorPower k)
 
 /-- On quotient representatives, `filtrationGradedEquiv` first applies `equivExterior`. -/


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Adds homogeneous multiplication and degree-reindexed associativity for successive Clifford-filtration quotients.

- Defines each degree-`k` quotient, including degree zero.
- Moves the common graded-piece abbreviation and reduction API into `Filtration.lean`.
- Lifts Clifford multiplication from degrees `i` and `j` to degree `i + j`.
- Gives a simp equation for quotient representatives and an associativity equation.

## Roadmap target

Advances the Layer 0 associated-graded algebra milestone:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings

It leaves the direct-sum graded algebra and exterior comparison to later work.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#associated-graded-algebra"}-->

## Verification

`lake build TauCeti`, `lake build --iofail`, the axiom audit, module-system audit, `scripts/lint-env.sh`, whitespace, and a downstream bare-`simp` probe pass at `a17e08acd88a8be0da616a1bf1b3e0e58a3dfbca`. A fresh independent review approves this head.

## Scope

- **Consumes:** the Clifford filtration and successive quotient interfaces.
- **Provides:** homogeneous quotient multiplication, degree-reindexed associativity, and the shared graded-piece API.
- **Fits:** supplies the multiplication boundary consumed by the direct-sum associated-graded algebra.
- **Boundary:** direct-sum assembly and exterior comparison belong to downstream slices.

<sub>🤖 GPT-5.6 Terra max · rubrics @ [222eed0](https://github.com/TauCetiProject/TauCetiReview/commit/222eed046013fbee91239aea4a5186b12f086e65) · local review fixed: reuse (1), proof-quality (2)</sub>