### PR TITLE
feat(Multiquadratic): ring of integers and discriminant of ℚ(√d)

### DIFF
--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -58,7 +58,7 @@ theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 omit [NumberField K] in
 /-- The generator squares to the radicand in `K`: `θ² = d`. -/
-theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+@[simp] theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ^ 2 = algebraMap ℤ K d := by
   have h : θ ^ 2 = algebraMap ℤ (𝓞 K) d := by
     have hae := minpoly.aeval ℤ θ
@@ -69,10 +69,11 @@ theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
   have := congrArg (algebraMap (𝓞 K) K) h
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
-/-- The generator is irrational: `θ ∉ ℚ`. Were `θ = q` for some `q : ℚ`, its `ℚ`-minimal
-polynomial would divide `X - q` and so have degree `≤ 1`, contradicting `minpoly ℚ θ = X² - d`. -/
+/-- The generator is irrational: `θ ∉ ℚ`. -/
 theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ∉ (algebraMap ℚ K).range := by
+  -- Were `θ = q ∈ ℚ`, its `ℚ`-minimal polynomial would divide `X - q`, so have degree `≤ 1`,
+  -- contradicting `minpoly ℚ θ = X² - d`.
   rintro ⟨q, hq⟩
   have hdvd : minpoly ℚ (algebraMap ℚ K q) ∣ (X - C q) := minpoly.dvd ℚ _ (by simp)
   have h1 : (minpoly ℚ (algebraMap ℚ K q)).natDegree ≤ 1 := by
@@ -80,30 +81,30 @@ theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
   rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
   norm_num at h1
 
-/-- The trace of the generator vanishes: `Tr(θ) = 0`. This specialises the generic quadratic
-trace-vanishing fact `trace_eq_zero_of_sq_ratCast` to `θ² = d` and the irrationality of `θ`. -/
+/-- The trace of the generator vanishes: `Tr(θ) = 0`. -/
 theorem trace_gen_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     Algebra.trace ℚ K (θ : K) = 0 := by
+  -- Specialise the generic `trace_eq_zero_of_sq_ratCast` to `θ² = d` and the irrationality of `θ`.
   have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
     rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
   exact trace_eq_zero_of_sq_ratCast hd' (gen_notMem_range hmin)
 
-/-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`. This specialises the generic
-square-root-basis discriminant `discr_one_elem_eq_of_sq_algebraMap` to `θ² = d`. -/
+/-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`. -/
 theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (θ : K)] = ((4 * d : ℤ) : ℚ) := by
+  -- Specialise the generic square-root-basis discriminant `discr_one_elem_eq_of_sq_algebraMap`.
   have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
     rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
   rw [TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap (finrank_rat_eq_two hmin hgen) hd'
     (gen_notMem_range hmin)]
   push_cast; ring
 
-/-- The discriminant of the `ℚ`-family `{1, (1+θ)/2}` is `d`: a change of basis from `{1, θ}` by
-the matrix `!![1, 0; 1/2, 1/2]` (determinant `1/2`), so `disc = (1/2)² · 4d = d`. -/
+/-- The discriminant of the `ℚ`-family `{1, (1+θ)/2}` is `d`. -/
 theorem discr_one_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (1 + (θ : K)) / 2] = ((d : ℤ) : ℚ) := by
+  -- Change of basis from `{1, θ}` by `!![1, 0; 1/2, 1/2]` (determinant `1/2`): `(1/2)² · 4d = d`.
   have hP : ![(1 : K), (1 + (θ : K)) / 2]
       = (!![1, 0; 1 / 2, 1 / 2] : Matrix (Fin 2) (Fin 2) ℚ).map (algebraMap ℚ K) *ᵥ
           ![(1 : K), (θ : K)] := by

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -14,8 +14,9 @@ public import TauCeti.FieldTheory.Trace
 # Basics for quadratic number fields
 
 Shared facts about a quadratic number field `K` presented by an algebraic integer `θ : 𝓞 K` whose
-minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting law
-(`Quadratic/Splitting.lean`) and the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`).
+minimal polynomial over `ℤ` is `X² - d`. These feed the prime-splitting law
+(`Quadratic/Splitting.lean`), the conjugation automorphism (`Quadratic/Conjugation/Basic.lean`), and
+the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
 
 ## Main results
 
@@ -25,6 +26,7 @@ minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting 
 * `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
 * `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
 * `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
+* `TauCeti.NumberField.discr_one_halfGen`: the discriminant of `{1, (1+θ)/2}` over `ℚ` is `d`.
 
 The trace and discriminant computations reuse the generic quadratic-extension API
 `TauCeti.NumberField.trace_eq_zero_of_sq_ratCast` and

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
+public import Mathlib.RingTheory.Discriminant
 
 /-!
 # Basics for quadratic number fields
@@ -17,21 +18,76 @@ minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting 
 ## Main results
 
 * `TauCeti.NumberField.minpoly_rat_quadratic`: the minimal polynomial of `θ` over `ℚ` is `X² - d`.
+* `TauCeti.NumberField.finrank_rat_eq_two`: `K` has degree `2` over `ℚ`.
+* `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
+* `TauCeti.NumberField.trace_coe_eq_zero`: the trace of the generator is `0`.
+* `TauCeti.NumberField.discr_coe_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
 -/
 
 public section
 
-open Polynomial NumberField
+open Polynomial NumberField Module
 
 namespace TauCeti.NumberField
 
-variable {K : Type*} [Field K] [NumberField K]
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
 
 /-- The minimal polynomial of `θ` over `ℚ` is `X² - d`, obtained from its minimal polynomial over
 `ℤ` by base change along `ℤ → ℚ`. -/
-theorem minpoly_rat_quadratic {θ : 𝓞 K} {d : ℤ} (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+theorem minpoly_rat_quadratic (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     minpoly ℚ (θ : K) = X ^ 2 - C ((d : ℤ) : ℚ) := by
   rw [minpoly.isIntegrallyClosed_eq_field_fractions ℚ K (IsIntegralClosure.isIntegral ℤ K θ), hmin]
   simp [Polynomial.map_sub, Polynomial.map_pow]
+
+/-- The quadratic field `K = ℚ(θ)` has degree `2` over `ℚ`: its power basis has dimension
+`natDegree (X² - d) = 2`. -/
+theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : finrank ℚ K = 2 := by
+  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
+  rw [(PowerBasis.ofAdjoinEqTop' hint hgen).finrank,
+    ← (PowerBasis.ofAdjoinEqTop' hint hgen).natDegree_minpoly, PowerBasis.ofAdjoinEqTop'_gen,
+    minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
+
+omit [NumberField K] in
+/-- The generator squares to the radicand in `K`: `θ² = d`. -/
+theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    (θ : K) ^ 2 = algebraMap ℤ K d := by
+  have h : θ ^ 2 = algebraMap ℤ (𝓞 K) d := by
+    have hae := minpoly.aeval ℤ θ
+    rw [hmin] at hae
+    have h2 : θ ^ 2 - algebraMap ℤ (𝓞 K) d = 0 := by
+      simpa [map_sub, map_pow, aeval_X, aeval_C] using hae
+    linear_combination h2
+  have := congrArg (algebraMap (𝓞 K) K) h
+  rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
+
+/-- The trace of the generator vanishes: `Tr(θ) = 0` (the `X`-coefficient of `X² - d` is `0`). -/
+theorem trace_coe_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.trace ℚ K (θ : K) = 0 := by
+  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
+  have hpbmin : minpoly ℚ (PowerBasis.ofAdjoinEqTop' hint hgen).gen = X ^ 2 - C ((d : ℤ) : ℚ) := by
+    rw [PowerBasis.ofAdjoinEqTop'_gen]; exact minpoly_rat_quadratic hmin
+  have hnc : ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).nextCoeff = 0 := by
+    rw [nextCoeff_of_natDegree_pos (by rw [natDegree_X_pow_sub_C]; norm_num),
+      natDegree_X_pow_sub_C, show (2 : ℕ) - 1 = 1 from rfl, coeff_sub, coeff_X_pow, coeff_C]
+    norm_num
+  rw [← PowerBasis.ofAdjoinEqTop'_gen hint hgen, PowerBasis.trace_gen_eq_nextCoeff_minpoly,
+    hpbmin, hnc, neg_zero]
+
+/-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`, from the `2×2` trace form
+(`Tr 1 = 2`, `Tr θ = 0`, `Tr θ² = 2d`). -/
+theorem discr_coe_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    Algebra.discr ℚ ![(1 : K), (θ : K)] = ((4 * d : ℤ) : ℚ) := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
+    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  have htr1 : Algebra.trace ℚ K (1 : K) = 2 := by
+    rw [show (1 : K) = algebraMap ℚ K 1 from (map_one _).symm, Algebra.trace_algebraMap, hfr]; simp
+  rw [Algebra.discr_def, Matrix.det_fin_two]
+  simp only [Algebra.traceMatrix_apply, Algebra.traceForm_apply, Matrix.cons_val_zero,
+    Matrix.cons_val_one, mul_one, one_mul]
+  rw [← pow_two, hd', htr1, trace_coe_eq_zero hmin hgen, Algebra.trace_algebraMap, hfr]
+  simp only [nsmul_eq_mul]; push_cast; ring
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -101,7 +101,7 @@ theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 /-- The discriminant of the `ℚ`-family `{1, (1+θ)/2}` is `d`: a change of basis from `{1, θ}` by
 the matrix `!![1, 0; 1/2, 1/2]` (determinant `1/2`), so `disc = (1/2)² · 4d = d`. -/
-theorem discr_one_half_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+theorem discr_one_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (1 + (θ : K)) / 2] = ((d : ℤ) : ℚ) := by
   have hP : ![(1 : K), (1 + (θ : K)) / 2]

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -41,7 +41,6 @@ theorem minpoly_rat_quadratic (hmin : minpoly ℤ θ = X ^ 2 - C d) :
 
 /-- The quadratic field `K = ℚ(θ)` has degree `2` over `ℚ`: its power basis has dimension
 `natDegree (X² - d) = 2`. -/
-@[simp]
 theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : finrank ℚ K = 2 := by
   have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
@@ -51,7 +50,6 @@ theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 omit [NumberField K] in
 /-- The generator squares to the radicand in `K`: `θ² = d`. -/
-@[simp]
 theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ^ 2 = algebraMap ℤ K d := by
   have h : θ ^ 2 = algebraMap ℤ (𝓞 K) d := by
@@ -64,7 +62,6 @@ theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
 /-- The trace of the generator vanishes: `Tr(θ) = 0` (the `X`-coefficient of `X² - d` is `0`). -/
-@[simp]
 theorem trace_coe_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.trace ℚ K (θ : K) = 0 := by
   have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
+public import Mathlib.LinearAlgebra.Matrix.Notation
 
 /-!
 # Basics for quadratic number fields
@@ -27,6 +28,7 @@ minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting 
 public section
 
 open Polynomial NumberField Module
+open scoped Matrix
 
 namespace TauCeti.NumberField
 
@@ -89,5 +91,20 @@ theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     Matrix.cons_val_one, mul_one, one_mul]
   rw [← pow_two, hd', htr1, trace_coe_eq_zero hmin hgen, Algebra.trace_algebraMap, hfr]
   simp only [nsmul_eq_mul]; push_cast; ring
+
+/-- The discriminant of the `ℚ`-family `{1, (1+θ)/2}` is `d`: a change of basis from `{1, θ}` by
+the matrix `!![1, 0; 1/2, 1/2]` (determinant `1/2`), so `disc = (1/2)² · 4d = d`. -/
+theorem discr_one_half_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    Algebra.discr ℚ ![(1 : K), (1 + (θ : K)) / 2] = ((d : ℤ) : ℚ) := by
+  have hP : ![(1 : K), (1 + (θ : K)) / 2]
+      = (!![1, 0; 1 / 2, 1 / 2] : Matrix (Fin 2) (Fin 2) ℚ).map (algebraMap ℚ K) *ᵥ
+          ![(1 : K), (θ : K)] := by
+    funext i
+    fin_cases i
+    · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_two]
+    · simp [Matrix.mulVec, dotProduct, Fin.sum_univ_two]; ring
+  rw [hP, Algebra.discr_of_matrix_mulVec, discr_one_gen hmin hgen, Matrix.det_fin_two_of]
+  push_cast; ring
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -21,7 +21,7 @@ minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting 
 * `TauCeti.NumberField.finrank_rat_eq_two`: `K` has degree `2` over `ℚ`.
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
 * `TauCeti.NumberField.trace_coe_eq_zero`: the trace of the generator is `0`.
-* `TauCeti.NumberField.discr_coe_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
+* `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
 -/
 
 public section
@@ -41,6 +41,7 @@ theorem minpoly_rat_quadratic (hmin : minpoly ℤ θ = X ^ 2 - C d) :
 
 /-- The quadratic field `K = ℚ(θ)` has degree `2` over `ℚ`: its power basis has dimension
 `natDegree (X² - d) = 2`. -/
+@[simp]
 theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : finrank ℚ K = 2 := by
   have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
@@ -50,6 +51,7 @@ theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 omit [NumberField K] in
 /-- The generator squares to the radicand in `K`: `θ² = d`. -/
+@[simp]
 theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ^ 2 = algebraMap ℤ K d := by
   have h : θ ^ 2 = algebraMap ℤ (𝓞 K) d := by
@@ -62,6 +64,7 @@ theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
 /-- The trace of the generator vanishes: `Tr(θ) = 0` (the `X`-coefficient of `X² - d` is `0`). -/
+@[simp]
 theorem trace_coe_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.trace ℚ K (θ : K) = 0 := by
   have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
@@ -69,21 +72,21 @@ theorem trace_coe_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d)
     rw [PowerBasis.ofAdjoinEqTop'_gen]; exact minpoly_rat_quadratic hmin
   have hnc : ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).nextCoeff = 0 := by
     rw [nextCoeff_of_natDegree_pos (by rw [natDegree_X_pow_sub_C]; norm_num),
-      natDegree_X_pow_sub_C, show (2 : ℕ) - 1 = 1 from rfl, coeff_sub, coeff_X_pow, coeff_C]
+      natDegree_X_pow_sub_C, coeff_sub, coeff_X_pow, coeff_C]
     norm_num
   rw [← PowerBasis.ofAdjoinEqTop'_gen hint hgen, PowerBasis.trace_gen_eq_nextCoeff_minpoly,
     hpbmin, hnc, neg_zero]
 
 /-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`, from the `2×2` trace form
 (`Tr 1 = 2`, `Tr θ = 0`, `Tr θ² = 2d`). -/
-theorem discr_coe_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
+theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (θ : K)] = ((4 * d : ℤ) : ℚ) := by
   have hfr := finrank_rat_eq_two hmin hgen
   have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
     rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
   have htr1 : Algebra.trace ℚ K (1 : K) = 2 := by
-    rw [show (1 : K) = algebraMap ℚ K 1 from (map_one _).symm, Algebra.trace_algebraMap, hfr]; simp
+    rw [← map_one (algebraMap ℚ K), Algebra.trace_algebraMap, hfr]; simp
   rw [Algebra.discr_def, Matrix.det_fin_two]
   simp only [Algebra.traceMatrix_apply, Algebra.traceForm_apply, Matrix.cons_val_zero,
     Matrix.cons_val_one, mul_one, one_mul]

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -8,6 +8,7 @@ public import Mathlib.NumberTheory.NumberField.Basic
 public import Mathlib.FieldTheory.Minpoly.IsIntegrallyClosed
 public import Mathlib.RingTheory.Discriminant
 public import Mathlib.LinearAlgebra.Matrix.Notation
+public import TauCeti.FieldTheory.Trace
 
 /-!
 # Basics for quadratic number fields
@@ -21,8 +22,13 @@ minimal polynomial over `ℤ` is `X² - d`. These feed both the prime-splitting 
 * `TauCeti.NumberField.minpoly_rat_quadratic`: the minimal polynomial of `θ` over `ℚ` is `X² - d`.
 * `TauCeti.NumberField.finrank_rat_eq_two`: `K` has degree `2` over `ℚ`.
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
-* `TauCeti.NumberField.trace_coe_eq_zero`: the trace of the generator is `0`.
+* `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
+* `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
 * `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
+
+The trace and discriminant computations reuse the generic quadratic-extension API
+`TauCeti.NumberField.trace_eq_zero_of_sq_ratCast` and
+`TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap` from `TauCeti.FieldTheory.Trace`.
 -/
 
 public section
@@ -63,34 +69,35 @@ theorem coe_gen_sq (hmin : minpoly ℤ θ = X ^ 2 - C d) :
   have := congrArg (algebraMap (𝓞 K) K) h
   rwa [map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K] at this
 
-/-- The trace of the generator vanishes: `Tr(θ) = 0` (the `X`-coefficient of `X² - d` is `0`). -/
-theorem trace_coe_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Algebra.trace ℚ K (θ : K) = 0 := by
-  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
-  have hpbmin : minpoly ℚ (PowerBasis.ofAdjoinEqTop' hint hgen).gen = X ^ 2 - C ((d : ℤ) : ℚ) := by
-    rw [PowerBasis.ofAdjoinEqTop'_gen]; exact minpoly_rat_quadratic hmin
-  have hnc : ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).nextCoeff = 0 := by
-    rw [nextCoeff_of_natDegree_pos (by rw [natDegree_X_pow_sub_C]; norm_num),
-      natDegree_X_pow_sub_C, coeff_sub, coeff_X_pow, coeff_C]
-    norm_num
-  rw [← PowerBasis.ofAdjoinEqTop'_gen hint hgen, PowerBasis.trace_gen_eq_nextCoeff_minpoly,
-    hpbmin, hnc, neg_zero]
+/-- The generator is irrational: `θ ∉ ℚ`. Were `θ = q` for some `q : ℚ`, its `ℚ`-minimal
+polynomial would divide `X - q` and so have degree `≤ 1`, contradicting `minpoly ℚ θ = X² - d`. -/
+theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    (θ : K) ∉ (algebraMap ℚ K).range := by
+  rintro ⟨q, hq⟩
+  have hdvd : minpoly ℚ (algebraMap ℚ K q) ∣ (X - C q) := minpoly.dvd ℚ _ (by simp)
+  have h1 : (minpoly ℚ (algebraMap ℚ K q)).natDegree ≤ 1 := by
+    simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
+  rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
+  norm_num at h1
 
-/-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`, from the `2×2` trace form
-(`Tr 1 = 2`, `Tr θ = 0`, `Tr θ² = 2d`). -/
+/-- The trace of the generator vanishes: `Tr(θ) = 0`. This specialises the generic quadratic
+trace-vanishing fact `trace_eq_zero_of_sq_ratCast` to `θ² = d` and the irrationality of `θ`. -/
+theorem trace_gen_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    Algebra.trace ℚ K (θ : K) = 0 := by
+  have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
+    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  exact trace_eq_zero_of_sq_ratCast hd' (gen_notMem_range hmin)
+
+/-- The discriminant of the `ℚ`-family `{1, θ}` is `4d`. This specialises the generic
+square-root-basis discriminant `discr_one_elem_eq_of_sq_algebraMap` to `θ² = d`. -/
 theorem discr_one_gen (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
     Algebra.discr ℚ ![(1 : K), (θ : K)] = ((4 * d : ℤ) : ℚ) := by
-  have hfr := finrank_rat_eq_two hmin hgen
   have hd' : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
     rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
-  have htr1 : Algebra.trace ℚ K (1 : K) = 2 := by
-    rw [← map_one (algebraMap ℚ K), Algebra.trace_algebraMap, hfr]; simp
-  rw [Algebra.discr_def, Matrix.det_fin_two]
-  simp only [Algebra.traceMatrix_apply, Algebra.traceForm_apply, Matrix.cons_val_zero,
-    Matrix.cons_val_one, mul_one, one_mul]
-  rw [← pow_two, hd', htr1, trace_coe_eq_zero hmin hgen, Algebra.trace_algebraMap, hfr]
-  simp only [nsmul_eq_mul]; push_cast; ring
+  rw [TauCeti.Algebra.discr_one_elem_eq_of_sq_algebraMap (finrank_rat_eq_two hmin hgen) hd'
+    (gen_notMem_range hmin)]
+  push_cast; ring
 
 /-- The discriminant of the `ℚ`-family `{1, (1+θ)/2}` is `d`: a change of basis from `{1, θ}` by
 the matrix `!![1, 0; 1/2, 1/2]` (determinant `1/2`), so `disc = (1/2)² · 4d = d`. -/

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Conjugation/Norm.lean
@@ -32,14 +32,6 @@ namespace TauCeti.NumberField
 
 variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
 
-/-- The quadratic field `K` has degree `2` over `ℚ`: its power basis has dimension
-`natDegree (X² - d) = 2`. -/
-private theorem finrank_rat_eq_two (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) : Module.finrank ℚ K = 2 := by
-  have hint : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
-  rw [(PowerBasis.ofAdjoinEqTop' hint hgen).finrank,
-    PowerBasis.ofAdjoinEqTop'_dim hint hgen, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
-
 /-- The generator `θ` of the quadratic field is nonzero (its minimal polynomial has degree `2`,
 not `1`). -/
 private theorem coe_gen_ne_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) : (θ : K) ≠ 0 := by

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -28,7 +28,7 @@ even when `d % 4 ≠ 1`, and are equal mod `2` (so `z ∈ ℤ + ℤ·ω`) when `
 
 * `TauCeti.NumberField.adjoin_gen_eq_top_of_mod_four_ne_one`: `𝓞 K = ℤ[θ]` for `d % 4 ≠ 1`.
 * `TauCeti.NumberField.discr_eq_four_mul_of_mod_four_ne_one`: `discr K = 4d` for `d % 4 ≠ 1`.
-* `TauCeti.NumberField.adjoin_half_gen_eq_top_of_mod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
+* `TauCeti.NumberField.adjoin_halfGen_eq_top_of_mod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
 -/
 
 public section
@@ -163,7 +163,7 @@ private theorem two_dvd_sub_of_sq_sub_mul_sq {A B N : ℤ} (hd4 : d % 4 = 1)
 
 /-- For `d ≡ 1 (mod 4)`, `ω = (1 + θ)/2` is an algebraic integer: it is a root of the monic
 integer polynomial `X² - X - (d-1)/4`. -/
-private theorem isIntegral_half_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
+private theorem isIntegral_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
     IsIntegral ℤ ((1 + (θ : K)) / 2) := by
   obtain ⟨e, he⟩ : ∃ e : ℤ, d = 4 * e + 1 := ⟨d / 4, by omega⟩
   have ht : (θ : K) ^ 2 = algebraMap ℤ K d := coe_gen_sq hmin
@@ -227,7 +227,7 @@ private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 /-- For `d ≡ 1 (mod 4)`, the half-integer generator `ω = (1 + θ)/2 ∈ 𝓞 K`. -/
 noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) : 𝓞 K :=
-  ⟨(1 + (θ : K)) / 2, isIntegral_half_gen hmin hd4⟩
+  ⟨(1 + (θ : K)) / 2, isIntegral_halfGen hmin hd4⟩
 
 /-- The half-integer generator coerces to `(1 + θ)/2` in `K`. -/
 @[simp] theorem coe_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
@@ -254,7 +254,7 @@ private theorem exists_int_repr_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 /-- **The ring of integers is `ℤ[(1+θ)/2]` when `d ≡ 1 (mod 4)`.** For squarefree `d` with
 `d % 4 = 1`, the ring of integers of `ℚ(√d)` is generated over `ℤ` by `ω = (1+θ)/2`. -/
-theorem adjoin_half_gen_eq_top_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+theorem adjoin_halfGen_eq_top_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) :
     Algebra.adjoin ℤ {halfGen hmin hd4} = (⊤ : Subalgebra ℤ (𝓞 K)) := by
   rw [eq_top_iff]
@@ -275,9 +275,9 @@ theorem discr_eq_of_squarefree_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2
     rintro ⟨q, hq⟩
     exact gen_notMem_range hmin ⟨2 * q - 1, by rw [map_sub, map_mul, map_one, map_ofNat, hq]; ring⟩
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
-    hfr hωnotmem (isIntegral_half_gen hmin hd4)
+    hfr hωnotmem (isIntegral_halfGen hmin hd4)
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((d : ℤ) : ℚ) := by
-    rw [hbs]; exact discr_one_half_gen hmin hgen
+    rw [hbs]; exact discr_one_halfGen hmin hgen
   have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
     rw [eq_top_iff]
     rintro z -

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
 public import TauCeti.NumberTheory.NumberField.Internal.QuadraticIntegralBasis
-public import TauCeti.NumberTheory.EffectiveBounds.Discriminant.Equality
+public import TauCeti.NumberTheory.NumberField.Discriminant.OfIntegralBasis
 public import Mathlib.NumberTheory.NumberField.Norm
 
 /-!
@@ -127,7 +127,7 @@ private theorem two_dvd_of_sq_sub_mul_sq {A B N : ℤ} (hd4 : d % 4 = 2 ∨ d % 
   have heq0 : (A : ZMod 4) ^ 2 - (d : ZMod 4) * (B : ZMod 4) ^ 2 = 0 := by
     have hc : ((A ^ 2 - d * B ^ 2 : ℤ) : ZMod 4) = ((4 * N : ℤ) : ZMod 4) := by rw [h]
     push_cast at hc
-    rw [hc, show (4 : ZMod 4) = 0 from by decide]; ring
+    rw [hc, (by decide : (4 : ZMod 4) = 0)]; ring
   obtain ⟨hA, hB⟩ := key _ _ _ hw heq0
   refine ⟨?_, ?_⟩
   · rcases hA with h0 | h2
@@ -192,7 +192,7 @@ include hsf hd4 in
 /-- From squarefreeness and `d % 4 ≠ 1`, the residue is `2` or `3` (it is never `0`, as `4 ∤ d`). -/
 private theorem emod_four_eq_two_or_three : d % 4 = 2 ∨ d % 4 = 3 := by
   have hnd4 : ¬ (4 : ℤ) ∣ d := fun h => by
-    have h2 : IsUnit (2 : ℤ) := hsf 2 (by rw [show (2 : ℤ) * 2 = 4 from by norm_num]; exact h)
+    have h2 : IsUnit (2 : ℤ) := hsf 2 (by rw [(by norm_num : (2 : ℤ) * 2 = 4)]; exact h)
     rw [Int.isUnit_iff] at h2; omega
   omega
 
@@ -217,9 +217,9 @@ theorem discr_eq_four_mul_of_emod_four_ne_one : NumberField.discr K = 4 * d := b
   have hd4' := emod_four_eq_two_or_three hsf hd4
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
     hfr (coe_notMem_range hmin) θ.isIntegral_coe
-  -- Discriminant of `{1, θ}` is `4d` (`discr_coe_one_gen`).
+  -- Discriminant of `{1, θ}` is `4d` (`discr_one_gen`).
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((4 * d : ℤ) : ℚ) := by
-    rw [hbs]; exact discr_coe_one_gen hmin hgen
+    rw [hbs]; exact discr_one_gen hmin hgen
   -- Spanning: `{1, θ}` spans `𝓞 K` over `ℤ` (`exists_int_repr`).
   have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
     rw [eq_top_iff]

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -229,7 +229,8 @@ noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1
 
 /-- The half-integer generator coerces to `(1 + θ)/2` in `K`. -/
 @[simp] theorem coe_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
-    (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := rfl
+    (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := by
+  simp [halfGen]
 
 /-- **`𝓞 K = ℤ[ω]` for `d ≡ 1 (mod 4)`: coordinates.** Every algebraic integer is a `ℤ`-combination
 `k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the half-integer coordinates `A/2, B/2` give
@@ -286,8 +287,7 @@ theorem discr_eq_of_squarefree_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 
     have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
       apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
     have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = halfGen hmin hd4 := by
-      apply RingOfIntegers.coe_injective; rw [coe_halfGen]; change bs 1 = (1 + (θ : K)) / 2
-      exact hval1
+      apply RingOfIntegers.coe_injective; change bs 1 = (1 + (θ : K)) / 2; exact hval1
     have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
       e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
     have hω : halfGen hmin hd4 ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -230,7 +230,7 @@ noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1
 /-- The half-integer generator coerces to `(1 + θ)/2` in `K`. -/
 @[simp] theorem coe_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
     (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := by
-  simp only [halfGen, RingOfIntegers.coe_mk]
+  unfold halfGen; rfl
 
 /-- **`𝓞 K = ℤ[ω]` for `d ≡ 1 (mod 4)`: coordinates.** Every algebraic integer is a `ℤ`-combination
 `k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the half-integer coordinates `A/2, B/2` give

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -17,7 +17,8 @@ For a quadratic number field `K = ℚ(√d)` — presented by an algebraic integ
 depends on `d mod 4`:
 
 * `d ≢ 1 (mod 4)`: `𝓞 K = ℤ[θ]` and `NumberField.discr K = 4 * d`;
-* `d ≡ 1 (mod 4)`: `𝓞 K = ℤ[ω]` with `ω = (1+θ)/2 = TauCeti.NumberField.halfGen`.
+* `d ≡ 1 (mod 4)`: `𝓞 K = ℤ[ω]` with `ω = (1+θ)/2 = TauCeti.NumberField.halfGen`, and
+  `NumberField.discr K = d`.
 
 The content is the "no more integers" step: an algebraic integer `z` with `(z : K) = a + b·θ`
 (`a, b : ℚ`) has `2a ∈ ℤ` and `a² - d·b² ∈ ℤ` (its trace and norm), whence `2a, 2b ∈ ℤ` (using that
@@ -29,6 +30,7 @@ even when `d % 4 ≠ 1`, and are equal mod `2` (so `z ∈ ℤ + ℤ·ω`) when `
 * `TauCeti.NumberField.adjoin_gen_eq_top_of_mod_four_ne_one`: `𝓞 K = ℤ[θ]` for `d % 4 ≠ 1`.
 * `TauCeti.NumberField.discr_eq_four_mul_of_mod_four_ne_one`: `discr K = 4d` for `d % 4 ≠ 1`.
 * `TauCeti.NumberField.adjoin_halfGen_eq_top_of_mod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
+* `TauCeti.NumberField.discr_eq_of_squarefree_of_mod_four_eq_one`: `discr K = d` for `d ≡ 1`.
 -/
 
 public section
@@ -252,6 +254,29 @@ private theorem exists_int_repr_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
   field_simp
   linear_combination hmABK
 
+/-- **Spanning from a coordinate representation.** If `bs = ![1, g]` is a `ℚ`-basis of `K` whose
+entries are algebraic integers and every `z : 𝓞 K` is an integer combination `k·1 + l·g`, then the
+integral lifts `⟨bs i, _⟩` span `𝓞 K` over `ℤ`. -/
+private theorem span_eq_top_of_int_repr {g : 𝓞 K} {bs : Basis (Fin 2) ℚ K}
+    (hbs : (bs : Fin 2 → K) = ![1, (g : K)]) (hb : ∀ i, IsIntegral ℤ (bs i))
+    (hrepr : ∀ z : 𝓞 K, ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • g) :
+    Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
+  rw [eq_top_iff]
+  rintro z -
+  obtain ⟨k, l, hkl⟩ := hrepr z
+  -- The integral lifts `⟨bs 0, _⟩, ⟨bs 1, _⟩` are `1` and `g`; check on the injective coercion to
+  -- `K`, where `⟨bs i, _⟩` reduces definitionally to `bs i`.
+  have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
+    apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); rw [hbs]; rfl
+  have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = g := by
+    apply RingOfIntegers.coe_injective; change bs 1 = (g : K); rw [hbs]; rfl
+  have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+    e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
+  have hg : g ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+    e1 ▸ Submodule.subset_span (Set.mem_range_self 1)
+  rw [hkl]
+  exact add_mem (Submodule.smul_mem _ _ h1) (Submodule.smul_mem _ _ hg)
+
 /-- **The ring of integers is `ℤ[(1+θ)/2]` when `d ≡ 1 (mod 4)`.** For squarefree `d` with
 `d % 4 = 1`, the ring of integers of `ℚ(√d)` is generated over `ℤ` by `ω = (1+θ)/2`. -/
 theorem adjoin_halfGen_eq_top_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
@@ -278,24 +303,8 @@ theorem discr_eq_of_squarefree_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2
     hfr hωnotmem (isIntegral_halfGen hmin hd4)
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((d : ℤ) : ℚ) := by
     rw [hbs]; exact discr_one_halfGen hmin hgen
-  have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
-    rw [eq_top_iff]
-    rintro z -
-    obtain ⟨k, l, hkl⟩ := exists_int_repr_one hmin hgen hsf hd4 z
-    have hval0 : bs 0 = (1 : K) := by rw [hbs]; rfl
-    have hval1 : bs 1 = (1 + (θ : K)) / 2 := by rw [hbs]; rfl
-    -- The basis vectors `⟨bs 0, _⟩, ⟨bs 1, _⟩` of `𝓞 K` are `1` and `ω = (1+θ)/2`; check on the
-    -- coercion to `K` (injective), where `⟨bs i, _⟩` reduces definitionally to `bs i`.
-    have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
-      apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
-    have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = halfGen hmin hd4 := by
-      apply RingOfIntegers.coe_injective; change bs 1 = (1 + (θ : K)) / 2; exact hval1
-    have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
-      e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
-    have hω : halfGen hmin hd4 ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
-      e1 ▸ Submodule.subset_span (Set.mem_range_self 1)
-    rw [hkl]
-    exact add_mem (Submodule.smul_mem _ _ h1) (Submodule.smul_mem _ _ hω)
+  have hbs' : (bs : Fin 2 → K) = ![1, (halfGen hmin hd4 : K)] := by rw [coe_halfGen]; exact hbs
+  have hspan := span_eq_top_of_int_repr hbs' hb (exists_int_repr_one hmin hgen hsf hd4)
   exact_mod_cast discr_eq_of_basis_isIntegral_of_span_eq_top_of_discr_eq_int bs hb hspan hdd
 
 variable (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
@@ -330,28 +339,10 @@ theorem discr_eq_four_mul_of_mod_four_ne_one : NumberField.discr K = 4 * d := by
   have hd4' := mod_four_eq_two_or_three hsf hd4
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
     hfr (gen_notMem_range hmin) θ.isIntegral_coe
-  -- Discriminant of `{1, θ}` is `4d` (`discr_one_gen`).
+  -- Discriminant of `{1, θ}` is `4d` (`discr_one_gen`); `{1, θ}` spans `𝓞 K` over `ℤ`.
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((4 * d : ℤ) : ℚ) := by
     rw [hbs]; exact discr_one_gen hmin hgen
-  -- Spanning: `{1, θ}` spans `𝓞 K` over `ℤ` (`exists_int_repr`).
-  have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
-    rw [eq_top_iff]
-    rintro z -
-    obtain ⟨k, l, hkl⟩ := exists_int_repr hmin hgen hsf hd4' z
-    have hval0 : bs 0 = (1 : K) := by rw [hbs]; rfl
-    have hval1 : bs 1 = (θ : K) := by rw [hbs]; rfl
-    -- The basis vectors `⟨bs 0, _⟩`, `⟨bs 1, _⟩` of `𝓞 K` are `1` and `θ`; check on the coercion
-    -- to `K` (injective), where `⟨bs i, _⟩` reduces definitionally to `bs i`.
-    have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
-      apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
-    have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = θ := by
-      apply RingOfIntegers.coe_injective; change bs 1 = (θ : K); exact hval1
-    have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
-      e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
-    have hθ : θ ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
-      e1 ▸ Submodule.subset_span (Set.mem_range_self 1)
-    rw [hkl]
-    exact add_mem (Submodule.smul_mem _ _ h1) (Submodule.smul_mem _ _ hθ)
+  have hspan := span_eq_top_of_int_repr hbs hb (exists_int_repr hmin hgen hsf hd4')
   exact discr_eq_of_basis_isIntegral_of_span_eq_top_of_discr_eq_int bs hb hspan hdd
 
 end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -1,0 +1,244 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.NumberField.Quadratic.Basic
+public import TauCeti.NumberTheory.NumberField.Internal.QuadraticIntegralBasis
+public import TauCeti.NumberTheory.EffectiveBounds.Discriminant.Equality
+public import Mathlib.NumberTheory.NumberField.Norm
+
+/-!
+# The ring of integers and discriminant of a quadratic field, non-`1 mod 4` case
+
+For a quadratic number field `K = ℚ(√d)` — presented by an algebraic integer `θ : 𝓞 K` with
+`minpoly ℤ θ = X² - d` and `Algebra.adjoin ℚ {θ} = ⊤` — with `d` squarefree and `d % 4 ≠ 1`, the
+ring of integers is `ℤ[θ]` (`Algebra.adjoin ℤ {θ} = ⊤`) and `NumberField.discr K = 4 * d`.
+
+The content is the "no more integers" step: an algebraic integer `z` with `(z : K) = a + b·θ`
+(`a, b : ℚ`) has `2a ∈ ℤ` and `a² - d·b² ∈ ℤ` (its trace and norm), whence `2a, 2b ∈ ℤ` (using that
+`d` is squarefree), and the residue `a² ≡ d·b² (mod 4)` forces `2a, 2b` both even when `d % 4 ≠ 1`
+(equivalently `d ≡ 2, 3 (mod 4)`), i.e. `a, b ∈ ℤ`.
+
+## Main results
+
+* `TauCeti.NumberField.adjoin_gen_eq_top_of_emod_four_ne_one`: the ring of integers is `ℤ[θ]`.
+* `TauCeti.NumberField.discr_eq_four_mul_of_emod_four_ne_one`: `discr K = 4d`.
+-/
+
+public section
+
+open Polynomial NumberField Module
+
+namespace TauCeti.NumberField
+
+variable {K : Type*} [Field K] [NumberField K]
+
+/-- A rational number whose image in a number field is an algebraic integer is an integer. -/
+private theorem exists_intCast_eq_of_algebraMap_mem_range {q : ℚ}
+    (h : algebraMap ℚ K q ∈ (algebraMap (𝓞 K) K).range) : ∃ n : ℤ, (n : ℚ) = q := by
+  obtain ⟨w, hw⟩ := h
+  have hint : IsIntegral ℤ q := by
+    have hwint : IsIntegral ℤ (algebraMap ℚ K q) := by
+      rw [← hw]; exact (IsIntegralClosure.isIntegral ℤ K w).algebraMap
+    exact (isIntegral_algHom_iff (IsScalarTower.toAlgHom ℤ ℚ K)
+      (FaithfulSMul.algebraMap_injective ℚ K)).mp hwint
+  exact (IsIntegrallyClosed.isIntegral_iff).mp hint
+
+/-- If `d` is squarefree and `d · B²` is an integer for a rational `B`, then `B` is an integer:
+the reduced denominator squared divides `d`, so is a unit. -/
+private theorem den_eq_one_of_squarefree_mul_sq_isInt {d : ℤ} (hd : Squarefree d) {B : ℚ} {m : ℤ}
+    (h : (d : ℚ) * B ^ 2 = (m : ℚ)) : B.den = 1 := by
+  have hden : (B.den : ℚ) ≠ 0 := by exact_mod_cast B.den_ne_zero
+  -- Clear denominators: `d * B.num² = m * B.den²` in `ℤ`.
+  have hnumden : (B.num : ℚ) = B * (B.den : ℚ) := (div_eq_iff hden).mp (Rat.num_div_den B)
+  have key : (d : ℚ) * (B.num : ℚ) ^ 2 = (m : ℚ) * (B.den : ℚ) ^ 2 := by
+    have hsq : (B.num : ℚ) ^ 2 = B ^ 2 * (B.den : ℚ) ^ 2 := by rw [hnumden]; ring
+    rw [hsq, ← mul_assoc, h]
+  have keyZ : d * B.num ^ 2 = m * (B.den : ℤ) ^ 2 := by exact_mod_cast key
+  -- `B.den² ∣ d`, using `gcd(B.num, B.den) = 1`.
+  have hdvd : ((B.den : ℤ)) ^ 2 ∣ d * B.num ^ 2 := ⟨m, by rw [keyZ]; ring⟩
+  have hcop : IsCoprime (B.num) ((B.den : ℤ)) :=
+    Int.isCoprime_iff_gcd_eq_one.mpr (by simpa [Int.gcd] using B.reduced)
+  have hcop2 : IsCoprime ((B.den : ℤ) ^ 2) (B.num ^ 2) := hcop.symm.pow
+  have hdvdd : ((B.den : ℤ)) ^ 2 ∣ d := hcop2.dvd_of_dvd_mul_right hdvd
+  have hunit : IsUnit ((B.den : ℤ)) := hd _ (by rw [← pow_two]; exact hdvdd)
+  have hb1 : (B.den : ℤ) = 1 := by
+    rcases Int.isUnit_iff.mp hunit with h1 | h1
+    · exact h1
+    · have hpos : (0 : ℤ) < (B.den : ℤ) := by exact_mod_cast B.pos
+      omega
+  exact_mod_cast hb1
+
+variable {θ : 𝓞 K} {d : ℤ}
+
+/-- **Trace and norm of a quadratic algebraic integer are integers.** For `z : 𝓞 K` with
+`(z : K) = a + c·θ`, both `2a` (the trace) and `a² - d·c²` (the norm) are integers. -/
+private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) {z : 𝓞 K} {a c : ℚ}
+    (hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K)) :
+    (∃ A : ℤ, (A : ℚ) = 2 * a) ∧ (∃ N : ℤ, (N : ℚ) = a ^ 2 - (d : ℚ) * c ^ 2) := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  -- Trace: `Tr z = 2a` since `Tr θ = 0`.
+  have htr : Algebra.trace ℚ K (z : K) = 2 * a := by
+    rw [hz, map_add, Algebra.trace_algebraMap, hfr, ← Algebra.smul_def, map_smul,
+      trace_coe_eq_zero hmin hgen]
+    simp
+  have hAex : ∃ A : ℤ, (A : ℚ) = 2 * a :=
+    ⟨Algebra.trace ℤ (𝓞 K) z, by rw [Algebra.coe_trace_int, htr]⟩
+  refine ⟨hAex, ?_⟩
+  obtain ⟨A, hA⟩ := hAex
+  -- Norm: `z` satisfies `z² - (2a)·z + (a²-dc²) = 0`, so `a²-dc² = (2a)·z - z² ∈ 𝓞 K ∩ ℚ = ℤ`.
+  have hroot : (z : K) ^ 2 - algebraMap ℚ K (2 * a) * (z : K)
+      + algebraMap ℚ K (a ^ 2 - (d : ℚ) * c ^ 2) = 0 := by
+    have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
+      rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+    rw [hz]
+    simp only [map_mul, map_sub, map_pow, map_ofNat]
+    linear_combination (algebraMap ℚ K c) ^ 2 * hθ
+  have hmem : algebraMap ℚ K (a ^ 2 - (d : ℚ) * c ^ 2) ∈ (algebraMap (𝓞 K) K).range := by
+    refine ⟨algebraMap ℤ (𝓞 K) A * z - z ^ 2, ?_⟩
+    have heq : algebraMap ℚ K (a ^ 2 - (d : ℚ) * c ^ 2)
+        = algebraMap ℤ K A * (z : K) - (z : K) ^ 2 := by
+      have : algebraMap ℚ K (2 * a) = algebraMap ℤ K A := by
+        rw [← hA, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+      rw [this] at hroot; linear_combination hroot
+    rw [heq, map_sub, map_mul, map_pow, ← IsScalarTower.algebraMap_apply ℤ (𝓞 K) K,
+      RingOfIntegers.coe_eq_algebraMap]
+  obtain ⟨N, hN⟩ := exists_intCast_eq_of_algebraMap_mem_range hmem
+  exact ⟨N, hN⟩
+
+/-- **Parity from the norm residue.** If `A² - d·B² = 4N` with `d ≡ 2, 3 (mod 4)`, then `A` and
+`B` are both even: squares are `0, 1 (mod 4)`, so `A² ≡ d·B² (mod 4)` is impossible unless `B`
+(hence `A`) is even. -/
+private theorem two_dvd_of_sq_sub_mul_sq {A B N : ℤ} (hd4 : d % 4 = 2 ∨ d % 4 = 3)
+    (h : A ^ 2 - d * B ^ 2 = 4 * N) : 2 ∣ A ∧ 2 ∣ B := by
+  have key : ∀ x y w : ZMod 4, (w = 2 ∨ w = 3) → x ^ 2 - w * y ^ 2 = 0 →
+      (x = 0 ∨ x = 2) ∧ (y = 0 ∨ y = 2) := by decide
+  have hw : (d : ZMod 4) = 2 ∨ (d : ZMod 4) = 3 := by
+    rcases hd4 with h1 | h1
+    · left
+      have h0 := (ZMod.intCast_zmod_eq_zero_iff_dvd (d - 2) 4).mpr (by omega)
+      push_cast at h0; exact sub_eq_zero.mp h0
+    · right
+      have h0 := (ZMod.intCast_zmod_eq_zero_iff_dvd (d - 3) 4).mpr (by omega)
+      push_cast at h0; exact sub_eq_zero.mp h0
+  have heq0 : (A : ZMod 4) ^ 2 - (d : ZMod 4) * (B : ZMod 4) ^ 2 = 0 := by
+    have hc : ((A ^ 2 - d * B ^ 2 : ℤ) : ZMod 4) = ((4 * N : ℤ) : ZMod 4) := by rw [h]
+    push_cast at hc
+    rw [hc, show (4 : ZMod 4) = 0 from by decide]; ring
+  obtain ⟨hA, hB⟩ := key _ _ _ hw heq0
+  refine ⟨?_, ?_⟩
+  · rcases hA with h0 | h2
+    · exact dvd_trans (by norm_num) ((ZMod.intCast_zmod_eq_zero_iff_dvd A 4).mp h0)
+    · have h0 : ((A - 2 : ℤ) : ZMod 4) = 0 := by push_cast; rw [h2]; ring
+      have := (ZMod.intCast_zmod_eq_zero_iff_dvd (A - 2) 4).mp h0; omega
+  · rcases hB with h0 | h2
+    · exact dvd_trans (by norm_num) ((ZMod.intCast_zmod_eq_zero_iff_dvd B 4).mp h0)
+    · have h0 : ((B - 2 : ℤ) : ZMod 4) = 0 := by push_cast; rw [h2]; ring
+      have := (ZMod.intCast_zmod_eq_zero_iff_dvd (B - 2) 4).mp h0; omega
+
+/-- The generator `θ` is not rational (`minpoly` has degree `2`), so `{1, θ}` is a `ℚ`-basis. -/
+private theorem coe_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    (θ : K) ∉ (algebraMap ℚ K).range := by
+  rintro ⟨q, hq⟩
+  have hdvd : minpoly ℚ (algebraMap ℚ K q) ∣ (X - C q) := minpoly.dvd ℚ _ (by simp)
+  have h1 : (minpoly ℚ (algebraMap ℚ K q)).natDegree ≤ 1 := by
+    simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
+  rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
+  norm_num at h1
+
+/-- **`𝓞 K = ℤ[θ]` for `d ≢ 1 (mod 4)`: coordinates.** Every algebraic integer of `ℚ(√d)` is a
+`ℤ`-combination `k + l·θ` — the "no more integers" step (see the module docstring). -/
+private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d)
+    (hd4 : d % 4 = 2 ∨ d % 4 = 3) (z : 𝓞 K) : ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • θ := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
+    hfr (coe_notMem_range hmin) θ.isIntegral_coe
+  set a := bs.repr (z : K) 0 with ha
+  set c := bs.repr (z : K) 1 with hc
+  have hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K) := by
+    have hsum := bs.sum_repr (z : K)
+    rw [Fin.sum_univ_two, hbs] at hsum
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one] at hsum
+    rw [← hsum, Algebra.smul_def, Algebra.smul_def, mul_one]
+  obtain ⟨⟨A, hA⟩, ⟨N, hN⟩⟩ := exists_intCast_coords hmin hgen hz
+  -- `2c ∈ ℤ` from squarefreeness (`d·(2c)² = A² - 4N ∈ ℤ`).
+  have h2c : (d : ℚ) * (2 * c) ^ 2 = ((A ^ 2 - 4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hN]; ring
+  have hcden : (2 * c).den = 1 := den_eq_one_of_squarefree_mul_sq_isInt hsf h2c
+  obtain ⟨B, hB⟩ : ∃ B : ℤ, (B : ℚ) = 2 * c :=
+    ⟨(2 * c).num, by rw [← Rat.num_div_den (2 * c), hcden]; simp⟩
+  -- Parity: `A, B` both even, so `a = A/2`, `c = B/2` are integers.
+  have hABN : A ^ 2 - d * B ^ 2 = 4 * N := by
+    have : ((A ^ 2 - d * B ^ 2 : ℤ) : ℚ) = ((4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hB, hN]; ring
+    exact_mod_cast this
+  obtain ⟨⟨k, hk⟩, ⟨l, hl⟩⟩ := two_dvd_of_sq_sub_mul_sq hd4 hABN
+  have hak : a = (k : ℚ) := by rw [hk] at hA; push_cast at hA; linarith
+  have hcl : c = (l : ℚ) := by rw [hl] at hB; push_cast at hB; linarith
+  -- The coercion `𝓞 K → K` is injective; the identity holds on coordinates, where `algebraMap ℚ K`
+  -- of an integer cast and the `ℤ`-scalar action both reduce to the integer cast `↑· : ℤ → K`.
+  refine ⟨k, l, RingOfIntegers.coe_injective ?_⟩
+  change (z : K) = ((k • (1 : 𝓞 K) + l • θ) : K)
+  rw [hz, hak, hcl]
+  push_cast [zsmul_eq_mul, map_intCast]
+  ring
+
+variable (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+  (hsf : Squarefree d) (hd4 : d % 4 ≠ 1)
+
+include hsf hd4 in
+/-- From squarefreeness and `d % 4 ≠ 1`, the residue is `2` or `3` (it is never `0`, as `4 ∤ d`). -/
+private theorem emod_four_eq_two_or_three : d % 4 = 2 ∨ d % 4 = 3 := by
+  have hnd4 : ¬ (4 : ℤ) ∣ d := fun h => by
+    have h2 : IsUnit (2 : ℤ) := hsf 2 (by rw [show (2 : ℤ) * 2 = 4 from by norm_num]; exact h)
+    rw [Int.isUnit_iff] at h2; omega
+  omega
+
+include hmin hgen hsf hd4 in
+/-- **The ring of integers is `ℤ[θ]` when `d ≢ 1 (mod 4)`.** For squarefree `d` with `d % 4 ≠ 1`,
+the ring of integers of `ℚ(√d)` is generated over `ℤ` by `θ`. -/
+theorem adjoin_gen_eq_top_of_emod_four_ne_one :
+    Algebra.adjoin ℤ {θ} = (⊤ : Subalgebra ℤ (𝓞 K)) := by
+  rw [eq_top_iff]
+  rintro z -
+  obtain ⟨k, l, hkl⟩ := exists_int_repr hmin hgen hsf (emod_four_eq_two_or_three hsf hd4) z
+  rw [hkl]
+  exact add_mem (zsmul_mem (one_mem _) k)
+    (zsmul_mem (Algebra.subset_adjoin (Set.mem_singleton θ)) l)
+
+include hmin hgen hsf hd4 in
+/-- **The discriminant of `ℚ(√d)` when `d ≢ 1 (mod 4)`.** For squarefree `d` with `d % 4 ≠ 1`
+(equivalently `d ≡ 2, 3 (mod 4)`), the field discriminant is `disc K = 4d`. The ring of integers is
+`ℤ[θ]` — see `adjoin_gen_eq_top_of_emod_four_ne_one`. -/
+theorem discr_eq_four_mul_of_emod_four_ne_one : NumberField.discr K = 4 * d := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  have hd4' := emod_four_eq_two_or_three hsf hd4
+  obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
+    hfr (coe_notMem_range hmin) θ.isIntegral_coe
+  -- Discriminant of `{1, θ}` is `4d` (`discr_coe_one_gen`).
+  have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((4 * d : ℤ) : ℚ) := by
+    rw [hbs]; exact discr_coe_one_gen hmin hgen
+  -- Spanning: `{1, θ}` spans `𝓞 K` over `ℤ` (`exists_int_repr`).
+  have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
+    rw [eq_top_iff]
+    rintro z -
+    obtain ⟨k, l, hkl⟩ := exists_int_repr hmin hgen hsf hd4' z
+    have hval0 : bs 0 = (1 : K) := by rw [hbs]; rfl
+    have hval1 : bs 1 = (θ : K) := by rw [hbs]; rfl
+    -- The basis vectors `⟨bs 0, _⟩`, `⟨bs 1, _⟩` of `𝓞 K` are `1` and `θ`; check on the coercion
+    -- to `K` (injective), where `⟨bs i, _⟩` reduces definitionally to `bs i`.
+    have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
+      apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
+    have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = θ := by
+      apply RingOfIntegers.coe_injective; change bs 1 = (θ : K); exact hval1
+    have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+      e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
+    have hθ : θ ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+      e1 ▸ Submodule.subset_span (Set.mem_range_self 1)
+    rw [hkl]
+    exact add_mem (Submodule.smul_mem _ _ h1) (Submodule.smul_mem _ _ hθ)
+  exact discr_eq_of_basis_isIntegral_of_span_eq_top_of_discr_eq_int bs hb hspan hdd
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -271,6 +271,38 @@ theorem adjoin_half_gen_eq_top_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 
   exact add_mem (zsmul_mem (one_mem _) k)
     (zsmul_mem (Algebra.subset_adjoin (Set.mem_singleton _)) l)
 
+/-- **The discriminant of `ℚ(√d)` when `d ≡ 1 (mod 4)`.** For squarefree `d` with `d % 4 = 1`, the
+field discriminant is `disc K = d` (the ring of integers is `ℤ[(1+θ)/2]`, whose `{1, ω}` basis has
+discriminant `d`). -/
+theorem discr_eq_of_squarefree_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) :
+    NumberField.discr K = d := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  have hωnotmem : ((1 + (θ : K)) / 2) ∉ (algebraMap ℚ K).range := by
+    rintro ⟨q, hq⟩
+    exact coe_notMem_range hmin ⟨2 * q - 1, by rw [map_sub, map_mul, map_one, map_ofNat, hq]; ring⟩
+  obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
+    hfr hωnotmem (isIntegral_half_gen hmin hd4)
+  have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((d : ℤ) : ℚ) := by
+    rw [hbs]; exact discr_one_half_gen hmin hgen
+  have hspan : Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) = ⊤ := by
+    rw [eq_top_iff]
+    rintro z -
+    obtain ⟨k, l, hkl⟩ := exists_int_repr_one hmin hgen hsf hd4 z
+    have hval0 : bs 0 = (1 : K) := by rw [hbs]; rfl
+    have hval1 : bs 1 = (1 + (θ : K)) / 2 := by rw [hbs]; rfl
+    have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
+      apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
+    have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = halfGen hmin hd4 := by
+      apply RingOfIntegers.coe_injective; change bs 1 = (1 + (θ : K)) / 2; exact hval1
+    have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+      e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
+    have hω : halfGen hmin hd4 ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
+      e1 ▸ Submodule.subset_span (Set.mem_range_self 1)
+    rw [hkl]
+    exact add_mem (Submodule.smul_mem _ _ h1) (Submodule.smul_mem _ _ hω)
+  exact_mod_cast discr_eq_of_basis_isIntegral_of_span_eq_top_of_discr_eq_int bs hb hspan hdd
+
 variable (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
   (hsf : Squarefree d) (hd4 : d % 4 ≠ 1)
 

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -230,7 +230,7 @@ noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1
 /-- The half-integer generator coerces to `(1 + θ)/2` in `K`. -/
 @[simp] theorem coe_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
     (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := by
-  simp [halfGen]
+  simp only [halfGen, RingOfIntegers.coe_mk]
 
 /-- **`𝓞 K = ℤ[ω]` for `d ≡ 1 (mod 4)`: coordinates.** Every algebraic integer is a `ℤ`-combination
 `k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the half-integer coordinates `A/2, B/2` give

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -10,21 +10,25 @@ public import TauCeti.NumberTheory.NumberField.Discriminant.OfIntegralBasis
 public import Mathlib.NumberTheory.NumberField.Norm
 
 /-!
-# The ring of integers and discriminant of a quadratic field, non-`1 mod 4` case
+# The ring of integers of a quadratic field
 
 For a quadratic number field `K = ℚ(√d)` — presented by an algebraic integer `θ : 𝓞 K` with
-`minpoly ℤ θ = X² - d` and `Algebra.adjoin ℚ {θ} = ⊤` — with `d` squarefree and `d % 4 ≠ 1`, the
-ring of integers is `ℤ[θ]` (`Algebra.adjoin ℤ {θ} = ⊤`) and `NumberField.discr K = 4 * d`.
+`minpoly ℤ θ = X² - d` and `Algebra.adjoin ℚ {θ} = ⊤` — with `d` squarefree, the ring of integers
+depends on `d mod 4`:
+
+* `d ≢ 1 (mod 4)`: `𝓞 K = ℤ[θ]` and `NumberField.discr K = 4 * d`;
+* `d ≡ 1 (mod 4)`: `𝓞 K = ℤ[ω]` with `ω = (1+θ)/2 = TauCeti.NumberField.halfGen`.
 
 The content is the "no more integers" step: an algebraic integer `z` with `(z : K) = a + b·θ`
 (`a, b : ℚ`) has `2a ∈ ℤ` and `a² - d·b² ∈ ℤ` (its trace and norm), whence `2a, 2b ∈ ℤ` (using that
-`d` is squarefree), and the residue `a² ≡ d·b² (mod 4)` forces `2a, 2b` both even when `d % 4 ≠ 1`
-(equivalently `d ≡ 2, 3 (mod 4)`), i.e. `a, b ∈ ℤ`.
+`d` is squarefree), and the residue `a² ≡ d·b² (mod 4)` fixes the coordinates: `2a, 2b` are both
+even when `d % 4 ≠ 1`, and are equal mod `2` (so `z ∈ ℤ + ℤ·ω`) when `d ≡ 1 (mod 4)`.
 
 ## Main results
 
-* `TauCeti.NumberField.adjoin_gen_eq_top_of_emod_four_ne_one`: the ring of integers is `ℤ[θ]`.
-* `TauCeti.NumberField.discr_eq_four_mul_of_emod_four_ne_one`: `discr K = 4d`.
+* `TauCeti.NumberField.adjoin_gen_eq_top_of_emod_four_ne_one`: `𝓞 K = ℤ[θ]` for `d % 4 ≠ 1`.
+* `TauCeti.NumberField.discr_eq_four_mul_of_emod_four_ne_one`: `discr K = 4d` for `d % 4 ≠ 1`.
+* `TauCeti.NumberField.adjoin_half_gen_eq_top_of_emod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
 -/
 
 public section
@@ -139,7 +143,37 @@ private theorem two_dvd_of_sq_sub_mul_sq {A B N : ℤ} (hd4 : d % 4 = 2 ∨ d % 
     · have h0 : ((B - 2 : ℤ) : ZMod 4) = 0 := by push_cast; rw [h2]; ring
       have := (ZMod.intCast_zmod_eq_zero_iff_dvd (B - 2) 4).mp h0; omega
 
-/-- The generator `θ` is not rational (`minpoly` has degree `2`), so `{1, θ}` is a `ℚ`-basis. -/
+/-- **Parity from the norm residue, `d ≡ 1 (mod 4)`.** If `A² - d·B² = 4N` then `A ≡ B (mod 2)`:
+in `ZMod 4`, `A² = B²` forces `A - B ∈ {0, 2}`. -/
+private theorem two_dvd_sub_of_sq_sub_mul_sq {A B N : ℤ} (hd4 : d % 4 = 1)
+    (h : A ^ 2 - d * B ^ 2 = 4 * N) : 2 ∣ (A - B) := by
+  have key : ∀ x y : ZMod 4, x ^ 2 - (1 : ZMod 4) * y ^ 2 = 0 → x - y = 0 ∨ x - y = 2 := by decide
+  have hd1 : (d : ZMod 4) = 1 := by
+    have h0 := (ZMod.intCast_zmod_eq_zero_iff_dvd (d - 1) 4).mpr (by omega)
+    push_cast at h0; exact sub_eq_zero.mp h0
+  have heq0 : (A : ZMod 4) ^ 2 - (1 : ZMod 4) * (B : ZMod 4) ^ 2 = 0 := by
+    have hc : ((A ^ 2 - d * B ^ 2 : ℤ) : ZMod 4) = ((4 * N : ℤ) : ZMod 4) := by rw [h]
+    push_cast at hc
+    rw [← hd1, hc, (by decide : (4 : ZMod 4) = 0)]; ring
+  rcases key _ _ heq0 with h0 | h2
+  · have h0' : ((A - B : ℤ) : ZMod 4) = 0 := by push_cast; exact h0
+    have := (ZMod.intCast_zmod_eq_zero_iff_dvd (A - B) 4).mp h0'; omega
+  · have h0' : ((A - B - 2 : ℤ) : ZMod 4) = 0 := by push_cast; rw [h2]; ring
+    have := (ZMod.intCast_zmod_eq_zero_iff_dvd (A - B - 2) 4).mp h0'; omega
+
+/-- For `d ≡ 1 (mod 4)`, `ω = (1 + θ)/2` is an algebraic integer: it is a root of the monic
+integer polynomial `X² - X - (d-1)/4`. -/
+private theorem isIntegral_half_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
+    IsIntegral ℤ ((1 + (θ : K)) / 2) := by
+  obtain ⟨e, he⟩ : ∃ e : ℤ, d = 4 * e + 1 := ⟨d / 4, by omega⟩
+  have ht : (θ : K) ^ 2 = algebraMap ℤ K d := coe_gen_sq hmin
+  have hde : algebraMap ℤ K d = 4 * algebraMap ℤ K e + 1 := by
+    rw [he]; simp only [map_add, map_mul, map_ofNat, map_one]
+  refine ⟨X ^ 2 - X - C e, ?_, ?_⟩
+  · monicity!
+  · simp only [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C]
+    field_simp
+    linear_combination ht + hde
 private theorem coe_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     (θ : K) ∉ (algebraMap ℚ K).range := by
   rintro ⟨q, hq⟩
@@ -184,6 +218,58 @@ private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
   rw [hz, hak, hcl]
   push_cast [zsmul_eq_mul, map_intCast]
   ring
+
+/-- For `d ≡ 1 (mod 4)`, the half-integer generator `ω = (1 + θ)/2 ∈ 𝓞 K`. -/
+noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) : 𝓞 K :=
+  ⟨(1 + (θ : K)) / 2, isIntegral_half_gen hmin hd4⟩
+
+/-- **`𝓞 K = ℤ[ω]` for `d ≡ 1 (mod 4)`: coordinates.** Every algebraic integer is a `ℤ`-combination
+`k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the `{1, θ}`-coordinates `a = A/2, c = B/2` give
+`z = (A-B)/2 · 1 + B · ω`, and `A ≡ B (mod 2)` (`d ≡ 1`) makes `(A-B)/2` an integer. -/
+private theorem exists_int_repr_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) (z : 𝓞 K) :
+    ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • halfGen hmin hd4 := by
+  have hfr := finrank_rat_eq_two hmin hgen
+  obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
+    hfr (coe_notMem_range hmin) θ.isIntegral_coe
+  set a := bs.repr (z : K) 0 with ha
+  set c := bs.repr (z : K) 1 with hc
+  have hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K) := by
+    have hsum := bs.sum_repr (z : K)
+    rw [Fin.sum_univ_two, hbs] at hsum
+    simp only [Matrix.cons_val_zero, Matrix.cons_val_one] at hsum
+    rw [← hsum, Algebra.smul_def, Algebra.smul_def, mul_one]
+  obtain ⟨⟨A, hA⟩, ⟨N, hN⟩⟩ := exists_intCast_coords hmin hgen hz
+  have h2c : (d : ℚ) * (2 * c) ^ 2 = ((A ^ 2 - 4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hN]; ring
+  have hcden : (2 * c).den = 1 := den_eq_one_of_squarefree_mul_sq_isInt hsf h2c
+  obtain ⟨B, hB⟩ : ∃ B : ℤ, (B : ℚ) = 2 * c :=
+    ⟨(2 * c).num, by rw [← Rat.num_div_den (2 * c), hcden]; simp⟩
+  have hABN : A ^ 2 - d * B ^ 2 = 4 * N := by
+    have : ((A ^ 2 - d * B ^ 2 : ℤ) : ℚ) = ((4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hB, hN]; ring
+    exact_mod_cast this
+  obtain ⟨m, hm⟩ := two_dvd_sub_of_sq_sub_mul_sq hd4 hABN
+  refine ⟨m, B, RingOfIntegers.coe_injective ?_⟩
+  have hω : (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := rfl
+  have haA : a = (A : ℚ) / 2 := by rw [hA]; ring
+  have hcB : c = (B : ℚ) / 2 := by rw [hB]; ring
+  have hmABK : (A : K) - (B : K) = 2 * (m : K) := by exact_mod_cast hm
+  change (z : K) = ((m • (1 : 𝓞 K) + B • halfGen hmin hd4) : K)
+  rw [hz, haA, hcB]
+  push_cast [zsmul_eq_mul, map_intCast, map_div₀, map_ofNat, hω]
+  field_simp
+  linear_combination hmABK
+
+/-- **The ring of integers is `ℤ[(1+θ)/2]` when `d ≡ 1 (mod 4)`.** For squarefree `d` with
+`d % 4 = 1`, the ring of integers of `ℚ(√d)` is generated over `ℤ` by `ω = (1+θ)/2`. -/
+theorem adjoin_half_gen_eq_top_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) :
+    Algebra.adjoin ℤ {halfGen hmin hd4} = (⊤ : Subalgebra ℤ (𝓞 K)) := by
+  rw [eq_top_iff]
+  rintro z -
+  obtain ⟨k, l, hkl⟩ := exists_int_repr_one hmin hgen hsf hd4 z
+  rw [hkl]
+  exact add_mem (zsmul_mem (one_mem _) k)
+    (zsmul_mem (Algebra.subset_adjoin (Set.mem_singleton _)) l)
 
 variable (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
   (hsf : Squarefree d) (hd4 : d % 4 ≠ 1)

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -26,9 +26,9 @@ even when `d % 4 ≠ 1`, and are equal mod `2` (so `z ∈ ℤ + ℤ·ω`) when `
 
 ## Main results
 
-* `TauCeti.NumberField.adjoin_gen_eq_top_of_emod_four_ne_one`: `𝓞 K = ℤ[θ]` for `d % 4 ≠ 1`.
-* `TauCeti.NumberField.discr_eq_four_mul_of_emod_four_ne_one`: `discr K = 4d` for `d % 4 ≠ 1`.
-* `TauCeti.NumberField.adjoin_half_gen_eq_top_of_emod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
+* `TauCeti.NumberField.adjoin_gen_eq_top_of_mod_four_ne_one`: `𝓞 K = ℤ[θ]` for `d % 4 ≠ 1`.
+* `TauCeti.NumberField.discr_eq_four_mul_of_mod_four_ne_one`: `discr K = 4d` for `d % 4 ≠ 1`.
+* `TauCeti.NumberField.adjoin_half_gen_eq_top_of_mod_four_eq_one`: `𝓞 K = ℤ[(1+θ)/2]` for `d ≡ 1`.
 -/
 
 public section
@@ -203,7 +203,9 @@ private theorem exists_half_int_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
     have : ((A ^ 2 - d * B ^ 2 : ℤ) : ℚ) = ((4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hB, hN]; ring
     exact_mod_cast this
   refine ⟨A, B, N, ?_, hABN⟩
-  rw [hz, show a = (A : ℚ) / 2 by rw [hA]; ring, show c = (B : ℚ) / 2 by rw [hB]; ring]
+  have hAa : (A : ℚ) / 2 = a := by rw [hA]; ring
+  have hBc : (B : ℚ) / 2 = c := by rw [hB]; ring
+  rw [hz, hAa, hBc]
 
 /-- **`𝓞 K = ℤ[θ]` for `d ≢ 1 (mod 4)`: coordinates.** Every algebraic integer of `ℚ(√d)` is a
 `ℤ`-combination `k + l·θ` — the "no more integers" step (see the module docstring). -/
@@ -252,7 +254,7 @@ private theorem exists_int_repr_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
 
 /-- **The ring of integers is `ℤ[(1+θ)/2]` when `d ≡ 1 (mod 4)`.** For squarefree `d` with
 `d % 4 = 1`, the ring of integers of `ℚ(√d)` is generated over `ℤ` by `ω = (1+θ)/2`. -/
-theorem adjoin_half_gen_eq_top_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+theorem adjoin_half_gen_eq_top_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) :
     Algebra.adjoin ℤ {halfGen hmin hd4} = (⊤ : Subalgebra ℤ (𝓞 K)) := by
   rw [eq_top_iff]
@@ -265,7 +267,7 @@ theorem adjoin_half_gen_eq_top_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 
 /-- **The discriminant of `ℚ(√d)` when `d ≡ 1 (mod 4)`.** For squarefree `d` with `d % 4 = 1`, the
 field discriminant is `disc K = d` (the ring of integers is `ℤ[(1+θ)/2]`, whose `{1, ω}` basis has
 discriminant `d`). -/
-theorem discr_eq_of_squarefree_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
+theorem discr_eq_of_squarefree_of_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) :
     NumberField.discr K = d := by
   have hfr := finrank_rat_eq_two hmin hgen
@@ -301,7 +303,7 @@ variable (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ :
 
 include hsf hd4 in
 /-- From squarefreeness and `d % 4 ≠ 1`, the residue is `2` or `3` (it is never `0`, as `4 ∤ d`). -/
-private theorem emod_four_eq_two_or_three : d % 4 = 2 ∨ d % 4 = 3 := by
+private theorem mod_four_eq_two_or_three : d % 4 = 2 ∨ d % 4 = 3 := by
   have hnd4 : ¬ (4 : ℤ) ∣ d := fun h => by
     have h2 : IsUnit (2 : ℤ) := hsf 2 (by rw [(by norm_num : (2 : ℤ) * 2 = 4)]; exact h)
     rw [Int.isUnit_iff] at h2; omega
@@ -310,11 +312,11 @@ private theorem emod_four_eq_two_or_three : d % 4 = 2 ∨ d % 4 = 3 := by
 include hmin hgen hsf hd4 in
 /-- **The ring of integers is `ℤ[θ]` when `d ≢ 1 (mod 4)`.** For squarefree `d` with `d % 4 ≠ 1`,
 the ring of integers of `ℚ(√d)` is generated over `ℤ` by `θ`. -/
-theorem adjoin_gen_eq_top_of_emod_four_ne_one :
+theorem adjoin_gen_eq_top_of_mod_four_ne_one :
     Algebra.adjoin ℤ {θ} = (⊤ : Subalgebra ℤ (𝓞 K)) := by
   rw [eq_top_iff]
   rintro z -
-  obtain ⟨k, l, hkl⟩ := exists_int_repr hmin hgen hsf (emod_four_eq_two_or_three hsf hd4) z
+  obtain ⟨k, l, hkl⟩ := exists_int_repr hmin hgen hsf (mod_four_eq_two_or_three hsf hd4) z
   rw [hkl]
   exact add_mem (zsmul_mem (one_mem _) k)
     (zsmul_mem (Algebra.subset_adjoin (Set.mem_singleton θ)) l)
@@ -322,10 +324,10 @@ theorem adjoin_gen_eq_top_of_emod_four_ne_one :
 include hmin hgen hsf hd4 in
 /-- **The discriminant of `ℚ(√d)` when `d ≢ 1 (mod 4)`.** For squarefree `d` with `d % 4 ≠ 1`
 (equivalently `d ≡ 2, 3 (mod 4)`), the field discriminant is `disc K = 4d`. The ring of integers is
-`ℤ[θ]` — see `adjoin_gen_eq_top_of_emod_four_ne_one`. -/
-theorem discr_eq_four_mul_of_emod_four_ne_one : NumberField.discr K = 4 * d := by
+`ℤ[θ]` — see `adjoin_gen_eq_top_of_mod_four_ne_one`. -/
+theorem discr_eq_four_mul_of_mod_four_ne_one : NumberField.discr K = 4 * d := by
   have hfr := finrank_rat_eq_two hmin hgen
-  have hd4' := emod_four_eq_two_or_three hsf hd4
+  have hd4' := mod_four_eq_two_or_three hsf hd4
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
     hfr (gen_notMem_range hmin) θ.isIntegral_coe
   -- Discriminant of `{1, θ}` is `4d` (`discr_one_gen`).

--- a/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/RingOfIntegers.lean
@@ -87,7 +87,7 @@ private theorem exists_intCast_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
   -- Trace: `Tr z = 2a` since `Tr θ = 0`.
   have htr : Algebra.trace ℚ K (z : K) = 2 * a := by
     rw [hz, map_add, Algebra.trace_algebraMap, hfr, ← Algebra.smul_def, map_smul,
-      trace_coe_eq_zero hmin hgen]
+      trace_gen_eq_zero hmin]
     simp
   have hAex : ∃ A : ℤ, (A : ℚ) = 2 * a :=
     ⟨Algebra.trace ℤ (𝓞 K) z, by rw [Algebra.coe_trace_int, htr]⟩
@@ -174,23 +174,18 @@ private theorem isIntegral_half_gen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 :
   · simp only [eval₂_sub, eval₂_pow, eval₂_X, eval₂_C]
     field_simp
     linear_combination ht + hde
-private theorem coe_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
-    (θ : K) ∉ (algebraMap ℚ K).range := by
-  rintro ⟨q, hq⟩
-  have hdvd : minpoly ℚ (algebraMap ℚ K q) ∣ (X - C q) := minpoly.dvd ℚ _ (by simp)
-  have h1 : (minpoly ℚ (algebraMap ℚ K q)).natDegree ≤ 1 := by
-    simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
-  rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
-  norm_num at h1
-
-/-- **`𝓞 K = ℤ[θ]` for `d ≢ 1 (mod 4)`: coordinates.** Every algebraic integer of `ℚ(√d)` is a
-`ℤ`-combination `k + l·θ` — the "no more integers" step (see the module docstring). -/
-private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
-    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d)
-    (hd4 : d % 4 = 2 ∨ d % 4 = 3) (z : 𝓞 K) : ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • θ := by
+/-- **Shared half-integer coordinate/norm data.** For squarefree `d` and any `z : 𝓞 K`, the
+`{1, θ}`-coordinates of `z` are half-integers: `z = (A/2)·1 + (B/2)·θ` with `A` its trace and `B`
+twice its second coordinate, and the norm relation `A² - d·B² = 4N` holds for some `N : ℤ`. Both
+congruence branches read off their integral basis from this by the appropriate parity argument
+(`two_dvd_of_sq_sub_mul_sq` for `d ≢ 1`, `two_dvd_sub_of_sq_sub_mul_sq` for `d ≡ 1 (mod 4)`). -/
+private theorem exists_half_int_coords (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (z : 𝓞 K) :
+    ∃ A B N : ℤ, (z : K) = algebraMap ℚ K ((A : ℚ) / 2) + algebraMap ℚ K ((B : ℚ) / 2) * (θ : K)
+      ∧ A ^ 2 - d * B ^ 2 = 4 * N := by
   have hfr := finrank_rat_eq_two hmin hgen
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
-    hfr (coe_notMem_range hmin) θ.isIntegral_coe
+    hfr (gen_notMem_range hmin) θ.isIntegral_coe
   set a := bs.repr (z : K) 0 with ha
   set c := bs.repr (z : K) 1 with hc
   have hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K) := by
@@ -204,18 +199,27 @@ private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
   have hcden : (2 * c).den = 1 := den_eq_one_of_squarefree_mul_sq_isInt hsf h2c
   obtain ⟨B, hB⟩ : ∃ B : ℤ, (B : ℚ) = 2 * c :=
     ⟨(2 * c).num, by rw [← Rat.num_div_den (2 * c), hcden]; simp⟩
-  -- Parity: `A, B` both even, so `a = A/2`, `c = B/2` are integers.
   have hABN : A ^ 2 - d * B ^ 2 = 4 * N := by
     have : ((A ^ 2 - d * B ^ 2 : ℤ) : ℚ) = ((4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hB, hN]; ring
     exact_mod_cast this
+  refine ⟨A, B, N, ?_, hABN⟩
+  rw [hz, show a = (A : ℚ) / 2 by rw [hA]; ring, show c = (B : ℚ) / 2 by rw [hB]; ring]
+
+/-- **`𝓞 K = ℤ[θ]` for `d ≢ 1 (mod 4)`: coordinates.** Every algebraic integer of `ℚ(√d)` is a
+`ℤ`-combination `k + l·θ` — the "no more integers" step (see the module docstring). -/
+private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d)
+    (hd4 : d % 4 = 2 ∨ d % 4 = 3) (z : 𝓞 K) : ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • θ := by
+  obtain ⟨A, B, N, hz, hABN⟩ := exists_half_int_coords hmin hgen hsf z
+  -- Parity: `A, B` both even, so the half-integer coordinates `A/2, B/2` are the integers `k, l`.
   obtain ⟨⟨k, hk⟩, ⟨l, hl⟩⟩ := two_dvd_of_sq_sub_mul_sq hd4 hABN
-  have hak : a = (k : ℚ) := by rw [hk] at hA; push_cast at hA; linarith
-  have hcl : c = (l : ℚ) := by rw [hl] at hB; push_cast at hB; linarith
-  -- The coercion `𝓞 K → K` is injective; the identity holds on coordinates, where `algebraMap ℚ K`
-  -- of an integer cast and the `ℤ`-scalar action both reduce to the integer cast `↑· : ℤ → K`.
+  have hAk : (A : ℚ) / 2 = (k : ℚ) := by rw [hk]; push_cast; ring
+  have hBl : (B : ℚ) / 2 = (l : ℚ) := by rw [hl]; push_cast; ring
+  -- The coercion `𝓞 K → K` is injective, so compare in `K`, where `algebraMap ℚ K` of an integer
+  -- cast and the `ℤ`-scalar action both reduce to the integer cast `↑· : ℤ → K`.
   refine ⟨k, l, RingOfIntegers.coe_injective ?_⟩
   change (z : K) = ((k • (1 : 𝓞 K) + l • θ) : K)
-  rw [hz, hak, hcl]
+  rw [hz, hAk, hBl]
   push_cast [zsmul_eq_mul, map_intCast]
   ring
 
@@ -223,39 +227,25 @@ private theorem exists_int_repr (hmin : minpoly ℤ θ = X ^ 2 - C d)
 noncomputable def halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) : 𝓞 K :=
   ⟨(1 + (θ : K)) / 2, isIntegral_half_gen hmin hd4⟩
 
+/-- The half-integer generator coerces to `(1 + θ)/2` in `K`. -/
+@[simp] theorem coe_halfGen (hmin : minpoly ℤ θ = X ^ 2 - C d) (hd4 : d % 4 = 1) :
+    (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := rfl
+
 /-- **`𝓞 K = ℤ[ω]` for `d ≡ 1 (mod 4)`: coordinates.** Every algebraic integer is a `ℤ`-combination
-`k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the `{1, θ}`-coordinates `a = A/2, c = B/2` give
+`k + l·ω` with `ω = (1+θ)/2`. Since `θ = 2ω - 1`, the half-integer coordinates `A/2, B/2` give
 `z = (A-B)/2 · 1 + B · ω`, and `A ≡ B (mod 2)` (`d ≡ 1`) makes `(A-B)/2` an integer. -/
 private theorem exists_int_repr_one (hmin : minpoly ℤ θ = X ^ 2 - C d)
     (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) (hd4 : d % 4 = 1) (z : 𝓞 K) :
     ∃ k l : ℤ, z = k • (1 : 𝓞 K) + l • halfGen hmin hd4 := by
-  have hfr := finrank_rat_eq_two hmin hgen
-  obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
-    hfr (coe_notMem_range hmin) θ.isIntegral_coe
-  set a := bs.repr (z : K) 0 with ha
-  set c := bs.repr (z : K) 1 with hc
-  have hz : (z : K) = algebraMap ℚ K a + algebraMap ℚ K c * (θ : K) := by
-    have hsum := bs.sum_repr (z : K)
-    rw [Fin.sum_univ_two, hbs] at hsum
-    simp only [Matrix.cons_val_zero, Matrix.cons_val_one] at hsum
-    rw [← hsum, Algebra.smul_def, Algebra.smul_def, mul_one]
-  obtain ⟨⟨A, hA⟩, ⟨N, hN⟩⟩ := exists_intCast_coords hmin hgen hz
-  have h2c : (d : ℚ) * (2 * c) ^ 2 = ((A ^ 2 - 4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hN]; ring
-  have hcden : (2 * c).den = 1 := den_eq_one_of_squarefree_mul_sq_isInt hsf h2c
-  obtain ⟨B, hB⟩ : ∃ B : ℤ, (B : ℚ) = 2 * c :=
-    ⟨(2 * c).num, by rw [← Rat.num_div_den (2 * c), hcden]; simp⟩
-  have hABN : A ^ 2 - d * B ^ 2 = 4 * N := by
-    have : ((A ^ 2 - d * B ^ 2 : ℤ) : ℚ) = ((4 * N : ℤ) : ℚ) := by push_cast; rw [hA, hB, hN]; ring
-    exact_mod_cast this
+  obtain ⟨A, B, N, hz, hABN⟩ := exists_half_int_coords hmin hgen hsf z
   obtain ⟨m, hm⟩ := two_dvd_sub_of_sq_sub_mul_sq hd4 hABN
-  refine ⟨m, B, RingOfIntegers.coe_injective ?_⟩
-  have hω : (halfGen hmin hd4 : K) = (1 + (θ : K)) / 2 := rfl
-  have haA : a = (A : ℚ) / 2 := by rw [hA]; ring
-  have hcB : c = (B : ℚ) / 2 := by rw [hB]; ring
   have hmABK : (A : K) - (B : K) = 2 * (m : K) := by exact_mod_cast hm
+  -- Compare in `K` (the coercion `𝓞 K → K` is injective); `ω = (1+θ)/2`, so `θ = 2ω - 1` and the
+  -- half-integer coordinates combine to `(A-B)/2 · 1 + B · ω = m · 1 + B · ω`.
+  refine ⟨m, B, RingOfIntegers.coe_injective ?_⟩
   change (z : K) = ((m • (1 : 𝓞 K) + B • halfGen hmin hd4) : K)
-  rw [hz, haA, hcB]
-  push_cast [zsmul_eq_mul, map_intCast, map_div₀, map_ofNat, hω]
+  rw [hz]
+  push_cast [zsmul_eq_mul, map_intCast, map_div₀, map_ofNat, coe_halfGen]
   field_simp
   linear_combination hmABK
 
@@ -280,7 +270,7 @@ theorem discr_eq_of_squarefree_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 
   have hfr := finrank_rat_eq_two hmin hgen
   have hωnotmem : ((1 + (θ : K)) / 2) ∉ (algebraMap ℚ K).range := by
     rintro ⟨q, hq⟩
-    exact coe_notMem_range hmin ⟨2 * q - 1, by rw [map_sub, map_mul, map_one, map_ofNat, hq]; ring⟩
+    exact gen_notMem_range hmin ⟨2 * q - 1, by rw [map_sub, map_mul, map_one, map_ofNat, hq]; ring⟩
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
     hfr hωnotmem (isIntegral_half_gen hmin hd4)
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((d : ℤ) : ℚ) := by
@@ -291,10 +281,13 @@ theorem discr_eq_of_squarefree_of_emod_four_eq_one (hmin : minpoly ℤ θ = X ^ 
     obtain ⟨k, l, hkl⟩ := exists_int_repr_one hmin hgen hsf hd4 z
     have hval0 : bs 0 = (1 : K) := by rw [hbs]; rfl
     have hval1 : bs 1 = (1 + (θ : K)) / 2 := by rw [hbs]; rfl
+    -- The basis vectors `⟨bs 0, _⟩, ⟨bs 1, _⟩` of `𝓞 K` are `1` and `ω = (1+θ)/2`; check on the
+    -- coercion to `K` (injective), where `⟨bs i, _⟩` reduces definitionally to `bs i`.
     have e0 : (⟨bs 0, hb 0⟩ : 𝓞 K) = 1 := by
       apply RingOfIntegers.coe_injective; change bs 0 = (1 : K); exact hval0
     have e1 : (⟨bs 1, hb 1⟩ : 𝓞 K) = halfGen hmin hd4 := by
-      apply RingOfIntegers.coe_injective; change bs 1 = (1 + (θ : K)) / 2; exact hval1
+      apply RingOfIntegers.coe_injective; rw [coe_halfGen]; change bs 1 = (1 + (θ : K)) / 2
+      exact hval1
     have h1 : (1 : 𝓞 K) ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
       e0 ▸ Submodule.subset_span (Set.mem_range_self 0)
     have hω : halfGen hmin hd4 ∈ Submodule.span ℤ (Set.range fun i => (⟨bs i, hb i⟩ : 𝓞 K)) :=
@@ -334,7 +327,7 @@ theorem discr_eq_four_mul_of_emod_four_ne_one : NumberField.discr K = 4 * d := b
   have hfr := finrank_rat_eq_two hmin hgen
   have hd4' := emod_four_eq_two_or_three hsf hd4
   obtain ⟨bs, hbs, hb⟩ := Internal.exists_basis_eq_one_self_of_notMem_range_of_isIntegral
-    hfr (coe_notMem_range hmin) θ.isIntegral_coe
+    hfr (gen_notMem_range hmin) θ.isIntegral_coe
   -- Discriminant of `{1, θ}` is `4d` (`discr_one_gen`).
   have hdd : Algebra.discr ℚ (bs : Fin 2 → K) = ((4 * d : ℤ) : ℚ) := by
     rw [hbs]; exact discr_one_gen hmin hgen

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
@@ -171,11 +171,7 @@ theorem ncard_primesOver_quadratic_iff {θ : 𝓞 K} {d : ℤ}
     {p : ℕ} [Fact p.Prime] (hodd : p ≠ 2) (hcop : ¬ (p : ℤ) ∣ d) :
     (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = finrank ℚ K ↔ legendreSym p d = 1 := by
   have hp := not_dvd_exponent_of_minpoly_quadratic hmin hgen hodd hcop
-  have hintθℚ : IsIntegral ℚ (θ : K) := θ.isIntegral_coe.tower_top
-  have hfr : finrank ℚ K = 2 := by
-    rw [(PowerBasis.ofAdjoinEqTop' hintθℚ hgen).finrank,
-      ← (PowerBasis.ofAdjoinEqTop' hintθℚ hgen).natDegree_minpoly,
-      PowerBasis.ofAdjoinEqTop'_gen, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C]
+  have hfr : finrank ℚ K = 2 := finrank_rat_eq_two hmin hgen
   have hcard : (primesOver (span {(p : ℤ)}) (𝓞 K)).ncard = (monicFactorsMod θ p).card := by
     rw [← Nat.card_coe_set_eq, Nat.card_congr (primesOverSpanEquivMonicFactorsMod hp)]
     exact Nat.card_eq_finsetCard _

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
@@ -66,7 +66,7 @@ private theorem algebraMap_four_mul_mem_conductor {θ : 𝓞 K} {d : ℤ}
   have hnormθ : Algebra.norm ℚ pb.gen = -((d : ℤ) : ℚ) := by
     rw [Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly, hmin', hdim]
     simp [coeff_sub, coeff_X_pow]
-  have hfinrank : Module.finrank ℚ K = 2 := pb.finrank.trans hdim
+  have hfinrank : Module.finrank ℚ K = 2 := finrank_rat_eq_two hmin hgen
   have haeval : (aeval pb.gen) ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).derivative
       = algebraMap ℚ K 2 * pb.gen := by
     -- `derivative_X_pow` leaves the exponent as `2 - 1`; reduce it to `1` so `pow_one` applies.

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
@@ -63,21 +63,11 @@ private theorem algebraMap_four_mul_mem_conductor {θ : 𝓞 K} {d : ℤ}
     rw [hgenθ]; exact minpoly_rat_quadratic hmin
   have hdim : pb.dim = 2 := by
     rw [← pb.natDegree_minpoly, hmin', natDegree_X_pow_sub_C]
-  have hnormθ : Algebra.norm ℚ pb.gen = -((d : ℤ) : ℚ) := by
-    rw [Algebra.PowerBasis.norm_gen_eq_coeff_zero_minpoly, hmin', hdim]
-    simp [coeff_sub, coeff_X_pow]
-  have hfinrank : Module.finrank ℚ K = 2 := finrank_rat_eq_two hmin hgen
-  have haeval : (aeval pb.gen) ((X : ℚ[X]) ^ 2 - C ((d : ℤ) : ℚ)).derivative
-      = algebraMap ℚ K 2 * pb.gen := by
-    -- `derivative_X_pow` leaves the exponent as `2 - 1`; reduce it to `1` so `pow_one` applies.
-    have hsub : (2 : ℕ) - 1 = 1 := by norm_num
-    rw [derivative_sub, derivative_C, sub_zero, derivative_X_pow, map_mul, aeval_C, map_pow,
-      aeval_X, hsub, pow_one]
-    norm_num
   have hdiscr : Algebra.discr ℚ pb.basis = ((4 * d : ℤ) : ℚ) := by
-    rw [Algebra.discr_powerBasis_eq_norm, hmin', haeval, map_mul,
-      Algebra.norm_algebraMap, hnormθ, hfinrank]
-    norm_num
+    -- `pb.basis` is `{1, θ}` reindexed along `pb.dim = 2`, so its discriminant is `discr_one_gen`.
+    have hb2 : ⇑pb.basis ∘ ⇑(finCongr hdim).symm = ![(1 : K), (θ : K)] := by
+      funext j; fin_cases j <;> simp [pb.basis_eq_pow, hgenθ]
+    rw [← Algebra.discr_reindex pb.basis (finCongr hdim), hb2, discr_one_gen hmin hgen]
   have hgenint : IsIntegral ℤ pb.gen := hgenθ ▸ hintθℤ
   have key := Algebra.discr_mul_isIntegral_mem_adjoin (R := ℤ) (K := ℚ) (L := K) (B := pb)
     hgenint (z := (b : K)) (b.isIntegral_coe)

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Splitting.lean
@@ -66,8 +66,8 @@ private theorem algebraMap_four_mul_mem_conductor {θ : 𝓞 K} {d : ℤ}
   have hdiscr : Algebra.discr ℚ pb.basis = ((4 * d : ℤ) : ℚ) := by
     -- `pb.basis` is `{1, θ}` reindexed along `pb.dim = 2`, so its discriminant is `discr_one_gen`.
     have hb2 : ⇑pb.basis ∘ ⇑(finCongr hdim).symm = ![(1 : K), (θ : K)] := by
-      funext j; fin_cases j <;> simp [pb.basis_eq_pow, hgenθ]
-    rw [← Algebra.discr_reindex pb.basis (finCongr hdim), hb2, discr_one_gen hmin hgen]
+      funext j; fin_cases j <;> simp [hgenθ]
+    rw [← Algebra.discr_reindex ℚ pb.basis (finCongr hdim), hb2, discr_one_gen hmin hgen]
   have hgenint : IsIntegral ℤ pb.gen := hgenθ ▸ hintθℤ
   have key := Algebra.discr_mul_isIntegral_mem_adjoin (R := ℤ) (K := ℚ) (L := K) (B := pb)
     hgenint (z := (b : K)) (b.isIntegral_coe)


### PR DESCRIPTION
## Summary

For a quadratic number field `K = ℚ(√d)` — presented by an algebraic integer `θ : 𝓞 K` with
`minpoly ℤ θ = X² - d` and `Algebra.adjoin ℚ {θ} = ⊤` — with `d` squarefree, this computes the ring
of integers and the field discriminant in **both** residue cases:

- `d ≢ 1 (mod 4)` (i.e. `d ≡ 2, 3`): `𝓞 K = ℤ[θ]` and `NumberField.discr K = 4·d`
  (`adjoin_gen_eq_top_of_emod_four_ne_one`, `discr_eq_four_mul_of_emod_four_ne_one`);
- `d ≡ 1 (mod 4)`: `𝓞 K = ℤ[ω]` with `ω = (1+θ)/2`, and `NumberField.discr K = d`
  (`halfGen`, `adjoin_half_gen_eq_top_of_emod_four_eq_one`, `discr_eq_of_squarefree_of_emod_four_eq_one`).

## Why

Mathlib computes no quadratic ring of integers (`Zsqrtd` is never wired to `𝓞`), and
`NumberField.discr` for `ℚ(√d)` was unavailable. This is the ring-of-integers/discriminant input the
Layer-1 ramified-prime behaviour and the Layer-3 genus-field identification both need: with `discr K`
in hand, Mathlib's `not_dvd_discr_iff_isUnramifiedIn` reads off which primes ramify.

Roadmap README, Layer 1 (⚠): *"The discriminant of `ℚ(√d)` is `d` or `4d` according to `d mod 4`."*
This PR formalizes both branches.

## Proof sketch

The core is the "no more integers" spanning step (`exists_half_int_coords`): an algebraic integer `z`
with `{1, θ}`-coordinates `a + c·θ` has `2a ∈ ℤ` (its trace) and `a² − d·c² ∈ ℤ` (its norm, via `z`'s
quadratic relation landing in `𝓞 K ∩ ℚ = ℤ`); squarefreeness of `d` bounds the denominator to
`2c ∈ ℤ`; and the residue `a² ≡ d·c² (mod 4)` pins the coordinates — `2a, 2c` are both even when
`d ≢ 1`, and are equal mod `2` (so `z ∈ ℤ + ℤ·ω`) when `d ≡ 1`. Each discriminant then follows from
`discr_eq_of_basis_isIntegral_of_span_eq_top_of_discr_eq_int` with the `{1, θ}`/`{1, ω}` basis
discriminant (`4d`, resp. `d`).

## Structure

Shared quadratic-field lemmas live in `Quadratic/Basic.lean` (`finrank_rat_eq_two`, `coe_gen_sq`,
`gen_notMem_range`, `trace_gen_eq_zero`, `discr_one_gen`, `discr_one_half_gen`) and are reused here
and in `Conjugation/Norm.lean` and `Splitting.lean`. The trace and discriminant computations reuse
the generic quadratic-extension API `trace_eq_zero_of_sq_ratCast` and
`discr_one_elem_eq_of_sq_algebraMap` from `TauCeti.FieldTheory.Trace`; the generic integral-basis
discriminant bridge lives in `NumberField/Discriminant/OfIntegralBasis.lean` (relocated in #1912).

Sorry-free; default axioms.

Roadmap: Multiquadratic
