### PR TITLE
feat: the Petersson inner product over the invariant measure on ℍ

### DIFF
--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Measure.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Measure.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Measure
+
+/-!
+# The invariant measure on `ℍ` and the Lebesgue measure on `ℂ`
+
+Comparison of Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`) with the
+pullback of the Lebesgue measure along the embedding `ℍ ↪ ℂ`: the two are mutually
+absolutely continuous, since the density `(Im τ)⁻²` is everywhere positive. Consequently
+the invariant measure is positive on nonempty open sets, and preimages of Lebesgue-null
+subsets of `ℂ` are null in `ℍ`.
+
+## Main results
+
+* `UpperHalfPlane.volume_eq_withDensity_ofReal`: the invariant measure as a density over
+  the pullback of the Lebesgue measure.
+* `UpperHalfPlane.volume_absolutelyContinuous_comap`,
+  `UpperHalfPlane.comap_absolutelyContinuous_volume`: mutual absolute continuity.
+* the `IsOpenPosMeasure` instance for `volume : Measure ℍ`.
+* `UpperHalfPlane.volume_preimage_coe_null`: preimages of Lebesgue-null sets are null.
+
+Split out of the Petersson inner-product development ported from the AINTLIB
+`LeanModularForms` project
+(<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>,
+`Modularforms/PeterssonInnerProduct.lean`, Chris Birkbeck).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Measure Set
+
+namespace UpperHalfPlane
+
+/-- Mathlib's invariant measure on `ℍ`, respelled with the density `(Im τ)⁻²` in
+`ENNReal.ofReal` form. -/
+theorem volume_eq_withDensity_ofReal :
+    (volume : Measure ℍ) = (Measure.comap UpperHalfPlane.coe volume).withDensity
+      (fun τ ↦ ENNReal.ofReal (τ.im ^ (-2 : ℤ))) := by
+  rw [volume_def]
+  congr 1
+  funext τ
+  rw [← ENNReal.ofReal_coe_nnreal]
+  congr 1
+  push_cast [NNReal.coe_mk]
+  rw [one_div, inv_pow, zpow_neg]
+  norm_num
+
+/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is positive on nonempty open sets. -/
+instance : IsOpenPosMeasure (Measure.comap UpperHalfPlane.coe (volume : Measure ℂ)) :=
+  IsOpenPosMeasure.comap volume isOpenEmbedding_coe
+
+/-- The invariant measure is absolutely continuous w.r.t. the pullback of the Lebesgue
+measure along `ℍ ↪ ℂ`. -/
+theorem volume_absolutelyContinuous_comap :
+    (volume : Measure ℍ) ≪ Measure.comap UpperHalfPlane.coe volume := by
+  rw [volume_eq_withDensity_ofReal]
+  exact withDensity_absolutelyContinuous _ _
+
+/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is absolutely continuous w.r.t. the
+invariant measure, since the density `(Im τ)⁻²` is everywhere positive on `ℍ`. -/
+theorem comap_absolutelyContinuous_volume :
+    Measure.comap UpperHalfPlane.coe (volume : Measure ℂ) ≪ (volume : Measure ℍ) := by
+  rw [volume_eq_withDensity_ofReal]
+  exact withDensity_absolutelyContinuous'
+    ((continuous_im.zpow₀ _ fun τ ↦ Or.inl τ.im_pos.ne').measurable.ennreal_ofReal.aemeasurable)
+    (ae_of_all _ fun τ ↦ by
+      simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
+      exact zpow_pos τ.im_pos _)
+
+/-- The invariant measure gives positive mass to nonempty open sets. -/
+instance : IsOpenPosMeasure (volume : Measure ℍ) :=
+  comap_absolutelyContinuous_volume.isOpenPosMeasure
+
+/-- If a subset of `ℂ` has zero Lebesgue measure, its preimage in `ℍ` has zero invariant
+measure. -/
+theorem volume_preimage_coe_null {S : Set ℂ} (hS : volume S = 0) :
+    (volume : Measure ℍ) (UpperHalfPlane.coe ⁻¹' S) = 0 := by
+  refine volume_absolutelyContinuous_comap ?_
+  rw [isOpenEmbedding_coe.measurableEmbedding.comap_apply]
+  exact measure_mono_null (image_preimage_subset _ _) hS
+
+end UpperHalfPlane

--- a/TauCeti/NumberTheory/Modular.lean
+++ b/TauCeti/NumberTheory/Modular.lean
@@ -1,0 +1,167 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.NumberTheory.Modular
+public import TauCeti.Analysis.Complex.UpperHalfPlane.Measure
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+
+/-!
+# Measure theory of the standard fundamental domain
+
+The measure theory of the standard fundamental domain `𝒟 = ModularGroup.fd` for `SL₂(ℤ)`,
+complementing its topology from `Mathlib/NumberTheory/Modular.lean`: `𝒟` has finite
+invariant measure, its frontier is null, and therefore integrals over `𝒟` and its interior
+`𝒟ᵒ` agree.
+
+## Main results
+
+* `ModularGroup.volume_fd_lt_top`: the standard fundamental domain has finite invariant
+  measure.
+* `ModularGroup.volume_frontier_fd`: the frontier of `𝒟` has zero invariant measure.
+* `ModularGroup.fd_ae_eq_fdo`, `ModularGroup.setIntegral_fd_eq_fdo`: `𝒟` and `𝒟ᵒ` agree
+  almost everywhere, so their set integrals coincide.
+
+Split out of the Petersson inner-product development ported from the AINTLIB
+`LeanModularForms` project
+(<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>,
+`Modularforms/PeterssonInnerProduct.lean`, Chris Birkbeck).
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Measure UpperHalfPlane Complex Set ENNReal
+
+open scoped NNReal
+
+namespace ModularGroup
+
+private theorem integrableOn_zpow_neg_two_Ioi {c : ℝ} (hc : 0 < c) :
+    IntegrableOn (· ^ (-2 : ℤ)) (Ioi c) (volume : Measure ℝ) := by
+  have h := integrableOn_Ioi_rpow_of_lt (by norm_num : (-2 : ℝ) < -1) hc
+  have h_eq : (· ^ (-2 : ℝ) : ℝ → ℝ) = (· ^ (-2 : ℤ)) := by
+    funext x
+    rw [← Real.rpow_intCast]
+    norm_num
+  rwa [h_eq] at h
+
+private theorem strip_lintegral_lt_top {c : ℝ} (hc : 0 < c) :
+    ∫⁻ p in Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi c,
+      ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂(volume : Measure (ℝ × ℝ)) < ⊤ := by
+  rw [volume_eq_prod ℝ ℝ, setLIntegral_prod_symm _ (by fun_prop)]
+  simp_rw [setLIntegral_const]
+  calc ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) *
+        volume (Icc (-1/2 : ℝ) (1/2)) ∂volume
+      ≤ ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) * 1 ∂volume := by
+        gcongr with y; rw [Real.volume_Icc]; norm_num
+    _ = _ := by simp
+    _ < ⊤ := lt_of_le_of_lt (setLIntegral_mono' measurableSet_Ioi
+        fun y _ ↦ Real.ofReal_le_enorm _)
+        (integrableOn_zpow_neg_two_Ioi hc).hasFiniteIntegral
+
+private theorem setLIntegral_im_eq_prod (g : ℝ → ENNReal) (T : Set (ℝ × ℝ)) :
+    ∫⁻ z in measurableEquivRealProd ⁻¹' T, g z.im ∂(volume : Measure ℂ) =
+      ∫⁻ p in T, g p.2 ∂(volume : Measure (ℝ × ℝ)) := by
+  have h := volume_preserving_equiv_real_prod.setLIntegral_comp_emb
+      measurableEquivRealProd.measurableEmbedding (fun p : ℝ × ℝ ↦ g p.2)
+      (measurableEquivRealProd ⁻¹' T)
+  rw [MeasurableEquiv.image_preimage] at h
+  simpa only [measurableEquivRealProd_apply] using h
+
+/-- The invariant measure of the standard fundamental domain is finite. -/
+theorem volume_fd_lt_top : (volume : Measure ℍ) fd < ⊤ := by
+  rw [volume_eq_lintegral]
+  set T := Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi (Real.sqrt 3 / 4)
+  calc ∫⁻ z in UpperHalfPlane.coe '' fd, ↑((1 / ‖z.im‖₊) ^ 2 : ℝ≥0)
+      = ∫⁻ z in UpperHalfPlane.coe '' fd, ENNReal.ofReal (z.im ^ (-2 : ℤ)) := by
+        refine setLIntegral_congr_fun
+          (isOpenEmbedding_coe.measurableEmbedding.measurableSet_image.mpr
+            isClosed_fd.measurableSet) fun z hz ↦ ?_
+        obtain ⟨τ, -, rfl⟩ := hz
+        rw [← ENNReal.ofReal_coe_nnreal]
+        congr 1
+        push_cast [Real.nnnorm_of_nonneg τ.im_pos.le]
+        rw [one_div, inv_pow, zpow_neg]
+        norm_num
+    _ ≤ ∫⁻ z in measurableEquivRealProd ⁻¹' T, ENNReal.ofReal (z.im ^ (-2 : ℤ)) :=
+        lintegral_mono_set fun z ↦ by
+          rintro ⟨τ, hτ, rfl⟩
+          simp only [mem_preimage, measurableEquivRealProd_apply, coe_re, coe_im]
+          refine ⟨⟨by linarith [(abs_le.mp hτ.2).1], (abs_le.mp hτ.2).2⟩,
+            mem_Ioi.mpr ?_⟩
+          have h := three_le_four_mul_im_sq_of_mem_fd hτ
+          have h_sq : (4 : ℝ) * τ.im ^ 2 = (2 * τ.im) ^ 2 := by ring
+          rw [h_sq] at h
+          have h2 := Real.sqrt_le_sqrt h
+          rw [Real.sqrt_sq (by linarith [τ.im_pos])] at h2
+          nlinarith [Real.sqrt_pos_of_pos (by norm_num : (0 : ℝ) < 3)]
+    _ = ∫⁻ p in T, ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂volume :=
+        setLIntegral_im_eq_prod (fun y ↦ ENNReal.ofReal (y ^ (-2 : ℤ))) T
+    _ < ⊤ := strip_lintegral_lt_top (by positivity)
+
+private theorem volume_complex_re_eq (c : ℝ) : volume {z : ℂ | z.re = c} = 0 := by
+  have h_eq : {z : ℂ | z.re = c} = measurableEquivRealProd ⁻¹' ({c} ×ˢ univ) := by
+    ext z
+    simp [measurableEquivRealProd_apply]
+  rw [h_eq, volume_preserving_equiv_real_prod.measure_preimage
+    ((measurableSet_singleton c).prod MeasurableSet.univ).nullMeasurableSet,
+    volume_eq_prod, Measure.prod_prod, Real.volume_singleton, zero_mul]
+
+private theorem volume_complex_normSq_eq (c : ℝ) :
+    volume {z : ℂ | Complex.normSq z = c} = 0 := by
+  rcases le_or_gt 0 c with hc | hc
+  · have h_eq : {z : ℂ | Complex.normSq z = c} = Metric.sphere (0 : ℂ) (Real.sqrt c) := by
+      ext z
+      simp only [mem_ofPred_eq, Complex.normSq_eq_norm_sq, mem_sphere_zero_iff_norm]
+      constructor
+      · intro h
+        rw [← h, Real.sqrt_sq (norm_nonneg z)]
+      · intro h
+        rw [h, Real.sq_sqrt hc]
+    rw [h_eq]
+    exact Measure.addHaar_sphere volume 0 _
+  · have h_empty : {z : ℂ | Complex.normSq z = c} = ∅ :=
+      eq_empty_iff_forall_notMem.mpr fun z hz ↦ not_le.mpr hc (hz ▸ Complex.normSq_nonneg z)
+    rw [h_empty]
+    exact measure_empty
+
+/-- **The frontier of the standard fundamental domain has zero invariant measure.**
+
+`frontier 𝒟 = 𝒟 \ 𝒟ᵒ ⊆ {normSq = 1} ∪ {Re = 1/2} ∪ {Re = −1/2}`, each of which has
+zero Lebesgue measure in `ℂ`. -/
+theorem volume_frontier_fd : (volume : Measure ℍ) (frontier (fd : Set ℍ)) = 0 := by
+  rw [frontier, isClosed_fd.closure_eq, ← fdo_eq_interior_fd]
+  apply measure_mono_null _ (volume_preimage_coe_null
+    (measure_union_null
+      (measure_union_null (volume_complex_normSq_eq 1) (volume_complex_re_eq (1/2)))
+      (volume_complex_re_eq (-1/2))))
+  intro τ ⟨hfd, hfdo⟩
+  simp only [fd, fdo, mem_ofPred_eq, not_and, not_lt] at hfd hfdo
+  obtain ⟨h1, h2⟩ := hfd
+  simp only [mem_preimage, mem_union, mem_ofPred_eq]
+  by_cases h : Complex.normSq (τ : ℂ) = 1
+  · left; left; exact h
+  · have hns : 1 < Complex.normSq (τ : ℂ) := lt_of_le_of_ne h1 (Ne.symm h)
+    have habs : |τ.re| = 1 / 2 := le_antisymm h2 (hfdo hns)
+    by_cases hre : 0 ≤ τ.re
+    · left; right; rw [coe_re]; rwa [abs_of_nonneg hre] at habs
+    · push Not at hre; right
+      rw [coe_re]; rw [abs_of_neg hre] at habs; linarith
+
+/-- `fd` and `fdo` are a.e. equal w.r.t. the invariant measure. -/
+theorem fd_ae_eq_fdo : (fd : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fdo :=
+  ((fdo_eq_interior_fd.symm ▸ interior_ae_eq_of_null_frontier volume_frontier_fd :
+    (fdo : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fd)).symm
+
+/-- Integrals over `fd` and `fdo` agree against the invariant measure. -/
+theorem setIntegral_fd_eq_fdo {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (f : ℍ → E) : ∫ τ in fd, f τ = ∫ τ in fdo, f τ :=
+  setIntegral_congr_set fd_ae_eq_fdo
+
+end ModularGroup

--- a/TauCeti/NumberTheory/Modular.lean
+++ b/TauCeti/NumberTheory/Modular.lean
@@ -23,8 +23,8 @@ invariant measure, its frontier is null, and therefore integrals over `𝒟` and
 * `ModularGroup.volume_fd_lt_top`: the standard fundamental domain has finite invariant
   measure.
 * `ModularGroup.volume_frontier_fd`: the frontier of `𝒟` has zero invariant measure.
-* `ModularGroup.fd_ae_eq_fdo`, `ModularGroup.setIntegral_fd_eq_fdo`: `𝒟` and `𝒟ᵒ` agree
-  almost everywhere, so their set integrals coincide.
+* `ModularGroup.fd_ae_eq_fdo`: `𝒟` and `𝒟ᵒ` agree almost everywhere (so set integrals
+  over them coincide, via `MeasureTheory.setIntegral_congr_set`).
 
 Split out of the Petersson inner-product development ported from the AINTLIB
 `LeanModularForms` project
@@ -158,10 +158,5 @@ theorem volume_frontier_fd : (volume : Measure ℍ) (frontier (fd : Set ℍ)) = 
 theorem fd_ae_eq_fdo : (fd : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fdo :=
   ((fdo_eq_interior_fd.symm ▸ interior_ae_eq_of_null_frontier volume_frontier_fd :
     (fdo : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fd)).symm
-
-/-- Integrals over `fd` and `fdo` agree against the invariant measure. -/
-theorem setIntegral_fd_eq_fdo {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    (f : ℍ → E) : ∫ τ in fd, f τ = ∫ τ in fdo, f τ :=
-  setIntegral_congr_set fd_ae_eq_fdo
 
 end ModularGroup

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -48,10 +48,17 @@ union of `n` translates. The topology of `𝒟`/`𝒟ᵒ` (`ModularGroup.isClose
 `ModularGroup.isOpen_fdo`, `ModularGroup.fd_eq_closure_fdo`) comes from
 `Mathlib/NumberTheory/Modular.lean`; this file adds their measure theory.
 
+Ported from the AINTLIB `LeanModularForms` project's
+`LeanModularForms/Modularforms/PeterssonInnerProduct.lean` (Chris Birkbeck), rewritten to
+consume Mathlib's `MeasureSpace ℍ` instance instead of constructing the hyperbolic measure.
+
 ## References
 
 * Diamond–Shurman, *A first course in modular forms*, §5.4
 * Miyake, *Modular forms*, §2.5
+* The AINTLIB `LeanModularForms` project,
+  <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>
+  (`Modularforms/PeterssonInnerProduct.lean`)
 -/
 
 public section

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -1,0 +1,396 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Measure
+public import Mathlib.NumberTheory.Modular
+public import Mathlib.NumberTheory.ModularForms.Bounds
+public import Mathlib.NumberTheory.ModularForms.Petersson
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+
+/-!
+# The Petersson inner product
+
+The **Petersson inner product**
+$$\langle f, g \rangle = \int_D \overline{f(\tau)} \, g(\tau) \, (\operatorname{Im}\tau)^k
+\, d\mu(\tau)$$
+of two functions on the upper half-plane, integrated over a fundamental domain `D` against
+Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
+`Mathlib/Analysis/Complex/UpperHalfPlane/Measure.lean`), with the integrand
+`petersson k f g` from `Mathlib/NumberTheory/ModularForms/Petersson.lean`.
+
+## Main definitions
+
+* `UpperHalfPlane.peterssonInner`: the Petersson inner product, parameterized by weight `k`
+  and fundamental domain `D`.
+* `CuspForm.pet`: the inner product of two cusp forms over the standard fundamental domain.
+
+## Main results
+
+* `ModularGroup.volume_fd_lt_top`: the standard fundamental domain has finite invariant
+  measure.
+* `UpperHalfPlane.peterssonInner_conj_symm`: Hermitian symmetry.
+* `UpperHalfPlane.peterssonInner_integrableOn_left`: integrability of the Petersson integrand of a
+  cusp form against a modular form over the standard fundamental domain.
+* `ModularGroup.volume_frontier_fd`, `ModularGroup.setIntegral_fd_eq_fdo`: the frontier of
+  the fundamental domain is null, so integrals over `𝒟` and `𝒟ᵒ` agree.
+* `UpperHalfPlane.eq_zero_on_fd_of_peterssonInner_self_eq_zero`: definiteness on the
+  fundamental domain.
+
+The inner product is parameterized by a fundamental domain `D : Set ℍ` rather than fixing a
+subgroup; for `SL₂(ℤ)` use `D = ModularGroup.fd`, and for a congruence subgroup of index `n` a
+union of `n` translates. The topology of `𝒟`/`𝒟ᵒ` (`ModularGroup.isClosed_fd`,
+`ModularGroup.isOpen_fdo`, `ModularGroup.fd_eq_closure_fdo`) comes from
+`Mathlib/NumberTheory/Modular.lean`; this file adds their measure theory.
+
+## References
+
+* Diamond–Shurman, *A first course in modular forms*, §5.4
+* Miyake, *Modular forms*, §2.5
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Measure UpperHalfPlane ModularGroup Complex Set ENNReal
+
+open scoped ComplexConjugate MatrixGroups NNReal Pointwise
+
+namespace UpperHalfPlane
+
+/-- Mathlib's invariant measure on `ℍ`, respelled with the density `(Im τ)⁻²` in
+`ENNReal.ofReal` form. -/
+theorem volume_eq_withDensity_ofReal :
+    (volume : Measure ℍ) = (Measure.comap UpperHalfPlane.coe volume).withDensity
+      (fun τ ↦ ENNReal.ofReal (τ.im ^ (-2 : ℤ))) := by
+  rw [volume_def]
+  congr 1
+  funext τ
+  rw [← ENNReal.ofReal_coe_nnreal]
+  congr 1
+  push_cast [NNReal.coe_mk]
+  rw [one_div, inv_pow, zpow_neg]
+  norm_num
+
+/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is positive on nonempty open sets. -/
+instance : IsOpenPosMeasure (Measure.comap UpperHalfPlane.coe (volume : Measure ℂ)) :=
+  IsOpenPosMeasure.comap volume isOpenEmbedding_coe
+
+/-- The invariant measure is absolutely continuous w.r.t. the pullback of the Lebesgue
+measure along `ℍ ↪ ℂ`. -/
+theorem volume_absolutelyContinuous_comap :
+    (volume : Measure ℍ) ≪ Measure.comap UpperHalfPlane.coe volume := by
+  rw [volume_eq_withDensity_ofReal]
+  exact withDensity_absolutelyContinuous _ _
+
+/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is absolutely continuous w.r.t. the
+invariant measure, since the density `(Im τ)⁻²` is everywhere positive on `ℍ`. -/
+theorem comap_absolutelyContinuous_volume :
+    Measure.comap UpperHalfPlane.coe (volume : Measure ℂ) ≪ (volume : Measure ℍ) := by
+  rw [volume_eq_withDensity_ofReal]
+  exact withDensity_absolutelyContinuous'
+    ((continuous_im.zpow₀ _ fun τ ↦ Or.inl τ.im_pos.ne').measurable.ennreal_ofReal.aemeasurable)
+    (ae_of_all _ fun τ ↦ by
+      simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
+      exact zpow_pos τ.im_pos _)
+
+/-- The invariant measure gives positive mass to nonempty open sets. -/
+instance : IsOpenPosMeasure (volume : Measure ℍ) :=
+  comap_absolutelyContinuous_volume.isOpenPosMeasure
+
+/-- If a subset of `ℂ` has zero Lebesgue measure, its preimage in `ℍ` has zero invariant
+measure. -/
+theorem volume_preimage_coe_null {S : Set ℂ} (hS : volume S = 0) :
+    (volume : Measure ℍ) (UpperHalfPlane.coe ⁻¹' S) = 0 := by
+  refine volume_absolutelyContinuous_comap ?_
+  rw [isOpenEmbedding_coe.measurableEmbedding.comap_apply]
+  exact measure_mono_null (image_preimage_subset _ _) hS
+
+end UpperHalfPlane
+
+namespace ModularGroup
+
+private theorem integrableOn_zpow_neg_two_Ioi {c : ℝ} (hc : 0 < c) :
+    IntegrableOn (· ^ (-2 : ℤ)) (Ioi c) (volume : Measure ℝ) := by
+  have h := integrableOn_Ioi_rpow_of_lt (show (-2 : ℝ) < -1 by norm_num) hc
+  rwa [show (· ^ (-2 : ℝ) : ℝ → ℝ) = (· ^ (-2 : ℤ)) from funext fun _ ↦ by
+    rw [show (-2 : ℝ) = ((-2 : ℤ) : ℝ) by norm_cast, Real.rpow_intCast]] at h
+
+private theorem strip_lintegral_lt_top {c : ℝ} (hc : 0 < c) :
+    ∫⁻ p in Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi c,
+      ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂(volume : Measure (ℝ × ℝ)) < ⊤ := by
+  rw [volume_eq_prod ℝ ℝ, setLIntegral_prod_symm _ (by fun_prop)]
+  simp_rw [setLIntegral_const]
+  calc ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) *
+        volume (Icc (-1/2 : ℝ) (1/2)) ∂volume
+      ≤ ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) * 1 ∂volume := by
+        gcongr with y; rw [Real.volume_Icc]; norm_num
+    _ = _ := by simp
+    _ < ⊤ := lt_of_le_of_lt (setLIntegral_mono' measurableSet_Ioi
+        fun y _ ↦ Real.ofReal_le_enorm _)
+        (integrableOn_zpow_neg_two_Ioi hc).hasFiniteIntegral
+
+private theorem setLIntegral_im_eq_prod (g : ℝ → ENNReal) (T : Set (ℝ × ℝ)) :
+    ∫⁻ z in equivRealProd ⁻¹' T, g z.im ∂(volume : Measure ℂ) =
+      ∫⁻ p in T, g p.2 ∂(volume : Measure (ℝ × ℝ)) := by
+  rw [show (⇑equivRealProd : ℂ → ℝ × ℝ) = ⇑measurableEquivRealProd from rfl]
+  have h := volume_preserving_equiv_real_prod.setLIntegral_comp_emb
+      measurableEquivRealProd.measurableEmbedding (fun p : ℝ × ℝ ↦ g p.2)
+      (measurableEquivRealProd ⁻¹' T)
+  rw [MeasurableEquiv.image_preimage] at h
+  simpa only [measurableEquivRealProd_apply] using h
+
+/-- The invariant measure of the standard fundamental domain is finite. -/
+theorem volume_fd_lt_top : (volume : Measure ℍ) fd < ⊤ := by
+  rw [volume_eq_lintegral]
+  set T := Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi (Real.sqrt 3 / 4)
+  calc ∫⁻ z in UpperHalfPlane.coe '' fd, ↑((1 / ‖z.im‖₊) ^ 2 : ℝ≥0)
+      = ∫⁻ z in UpperHalfPlane.coe '' fd, ENNReal.ofReal (z.im ^ (-2 : ℤ)) := by
+        refine setLIntegral_congr_fun
+          (isOpenEmbedding_coe.measurableEmbedding.measurableSet_image.mpr
+            isClosed_fd.measurableSet) fun z hz ↦ ?_
+        obtain ⟨τ, -, rfl⟩ := hz
+        rw [← ENNReal.ofReal_coe_nnreal]
+        congr 1
+        push_cast [Real.nnnorm_of_nonneg τ.im_pos.le]
+        rw [one_div, inv_pow, zpow_neg]
+        norm_num
+    _ ≤ ∫⁻ z in equivRealProd ⁻¹' T, ENNReal.ofReal (z.im ^ (-2 : ℤ)) :=
+        lintegral_mono_set fun z ↦ by
+          rintro ⟨τ, hτ, rfl⟩
+          simp only [mem_preimage, equivRealProd_apply, coe_re, coe_im]
+          refine ⟨⟨by linarith [(abs_le.mp hτ.2).1], (abs_le.mp hτ.2).2⟩,
+            mem_Ioi.mpr ?_⟩
+          have h := three_le_four_mul_im_sq_of_mem_fd hτ
+          rw [show (4 : ℝ) * τ.im ^ 2 = (2 * τ.im) ^ 2 from by ring] at h
+          have h2 := Real.sqrt_le_sqrt h
+          rw [Real.sqrt_sq (by linarith [τ.im_pos])] at h2
+          nlinarith [Real.sqrt_pos_of_pos (show (3 : ℝ) > 0 by norm_num)]
+    _ = ∫⁻ p in T, ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂volume :=
+        setLIntegral_im_eq_prod (fun y ↦ ENNReal.ofReal (y ^ (-2 : ℤ))) T
+    _ < ⊤ := strip_lintegral_lt_top (by positivity)
+
+private theorem volume_complex_re_eq (c : ℝ) : volume {z : ℂ | z.re = c} = 0 := by
+  rw [show {z : ℂ | z.re = c} = measurableEquivRealProd ⁻¹' ({c} ×ˢ univ) from by
+    ext z; simp [measurableEquivRealProd]]
+  rw [volume_preserving_equiv_real_prod.measure_preimage
+    ((measurableSet_singleton c).prod MeasurableSet.univ).nullMeasurableSet,
+    volume_eq_prod, Measure.prod_prod, Real.volume_singleton, zero_mul]
+
+private theorem volume_complex_normSq_eq (c : ℝ) :
+    volume {z : ℂ | Complex.normSq z = c} = 0 := by
+  rcases le_or_gt 0 c with hc | hc
+  · rw [show {z : ℂ | Complex.normSq z = c} = Metric.sphere (0 : ℂ) (Real.sqrt c) from by
+      ext z
+      simp only [mem_ofPred_eq, Complex.normSq_eq_norm_sq, mem_sphere_zero_iff_norm]
+      constructor
+      · intro h
+        rw [← h, Real.sqrt_sq (norm_nonneg z)]
+      · intro h
+        rw [h, Real.sq_sqrt hc]]
+    exact Measure.addHaar_sphere volume 0 _
+  · rw [show {z : ℂ | Complex.normSq z = c} = ∅ from eq_empty_iff_forall_notMem.mpr
+      fun z hz ↦ not_le.mpr hc (hz ▸ Complex.normSq_nonneg z)]
+    exact measure_empty
+
+/-- **The frontier of the standard fundamental domain has zero invariant measure.**
+
+`frontier 𝒟 = 𝒟 \ 𝒟ᵒ ⊆ {normSq = 1} ∪ {Re = 1/2} ∪ {Re = −1/2}`, each of which has
+zero Lebesgue measure in `ℂ`. -/
+theorem volume_frontier_fd : (volume : Measure ℍ) (frontier (fd : Set ℍ)) = 0 := by
+  rw [frontier, isClosed_fd.closure_eq, ← fdo_eq_interior_fd]
+  apply measure_mono_null _ (volume_preimage_coe_null
+    (measure_union_null
+      (measure_union_null (volume_complex_normSq_eq 1) (volume_complex_re_eq (1/2)))
+      (volume_complex_re_eq (-1/2))))
+  intro τ ⟨hfd, hfdo⟩
+  simp only [fd, fdo, mem_ofPred_eq, not_and, not_lt] at hfd hfdo
+  obtain ⟨h1, h2⟩ := hfd
+  simp only [mem_preimage, mem_union, mem_ofPred_eq]
+  by_cases h : Complex.normSq (τ : ℂ) = 1
+  · left; left; exact h
+  · have hns : 1 < Complex.normSq (τ : ℂ) := lt_of_le_of_ne h1 (Ne.symm h)
+    have habs : |τ.re| = 1 / 2 := le_antisymm h2 (hfdo hns)
+    by_cases hre : 0 ≤ τ.re
+    · left; right; rw [coe_re]; rwa [abs_of_nonneg hre] at habs
+    · push Not at hre; right
+      rw [coe_re]; rw [abs_of_neg hre] at habs; linarith
+
+/-- `fd` and `fdo` are a.e. equal w.r.t. the invariant measure. -/
+theorem fd_ae_eq_fdo : (fd : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fdo :=
+  ((fdo_eq_interior_fd.symm ▸ interior_ae_eq_of_null_frontier volume_frontier_fd :
+    (fdo : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fd)).symm
+
+/-- Integrals over `fd` and `fdo` agree against the invariant measure. -/
+theorem setIntegral_fd_eq_fdo {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (f : ℍ → E) : ∫ τ in fd, f τ = ∫ τ in fdo, f τ :=
+  setIntegral_congr_set fd_ae_eq_fdo
+
+end ModularGroup
+
+namespace UpperHalfPlane
+
+/-- The Petersson inner product of two functions `f, g : ℍ → ℂ` of weight `k`,
+integrated over a fundamental domain `D` with respect to the invariant measure.
+
+The integrand is `conj(f(τ)) · g(τ) · (Im τ)^k`, which equals
+`petersson k f g τ` from `Mathlib.NumberTheory.ModularForms.Petersson`. -/
+def peterssonInner (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) : ℂ :=
+  ∫ τ in D, petersson k f g τ
+
+/-- Hermitian symmetry: `conj ⟨g, f⟩ = ⟨f, g⟩`. -/
+theorem peterssonInner_conj_symm (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
+    conj (peterssonInner k D g f) = peterssonInner k D f g := by
+  simp only [peterssonInner, ← integral_conj, petersson_symm k g f]
+
+/-- The pairing with zero on the right vanishes. -/
+theorem peterssonInner_zero_right (k : ℤ) (D : Set ℍ) (f : ℍ → ℂ) :
+    peterssonInner k D f 0 = 0 := by
+  simp [peterssonInner, petersson]
+
+/-- The pairing with zero on the left vanishes. -/
+theorem peterssonInner_zero_left (k : ℤ) (D : Set ℍ) (g : ℍ → ℂ) :
+    peterssonInner k D 0 g = 0 := by
+  simp [peterssonInner, petersson]
+
+/-- Negation in the right argument. -/
+theorem peterssonInner_neg_right (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
+    peterssonInner k D f (-g) = -peterssonInner k D f g := by
+  simp only [peterssonInner, petersson, Pi.neg_apply, mul_neg, neg_mul, integral_neg]
+
+/-- Negation in the left argument. -/
+theorem peterssonInner_neg_left (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
+    peterssonInner k D (-f) g = -peterssonInner k D f g := by
+  simp only [peterssonInner, petersson, Pi.neg_apply, map_neg, neg_mul, integral_neg]
+
+/-- The Petersson integrand of a cusp form against a modular form is integrable over the
+standard fundamental domain. -/
+theorem peterssonInner_integrableOn_left {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
+    (k : ℤ) (Γ : Subgroup (GL (Fin 2) ℝ)) [Γ.IsArithmetic]
+    [CuspFormClass F Γ k] [ModularFormClass F' Γ k]
+    (f : F) (f' : F') :
+    IntegrableOn (fun τ ↦ petersson k f f' τ) fd (volume : Measure ℍ) := by
+  obtain ⟨C, hC⟩ := CuspFormClass.petersson_bounded_left k Γ f f'
+  exact IntegrableOn.of_bound ModularGroup.volume_fd_lt_top
+    ((petersson_continuous k (ModularFormClass.continuous f)
+      (ModularFormClass.continuous f')).aestronglyMeasurable.restrict) C
+    (ae_of_all _ fun τ ↦ hC τ)
+
+/-- The Petersson integrand of a modular form against a cusp form is integrable over the
+standard fundamental domain. -/
+theorem peterssonInner_integrableOn_right {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
+    (k : ℤ) (Γ : Subgroup (GL (Fin 2) ℝ)) [Γ.IsArithmetic]
+    [ModularFormClass F Γ k] [CuspFormClass F' Γ k]
+    (f : F) (f' : F') :
+    IntegrableOn (fun τ ↦ petersson k f f' τ) fd (volume : Measure ℍ) := by
+  obtain ⟨C, hC⟩ := CuspFormClass.petersson_bounded_right k Γ f f'
+  exact IntegrableOn.of_bound ModularGroup.volume_fd_lt_top
+    ((petersson_continuous k (ModularFormClass.continuous f)
+      (ModularFormClass.continuous f')).aestronglyMeasurable.restrict) C
+    (ae_of_all _ fun τ ↦ hC τ)
+
+/-- Additivity in the second argument. -/
+theorem peterssonInner_add_right (k : ℤ) (D : Set ℍ) (f g₁ g₂ : ℍ → ℂ)
+    (hg₁ : IntegrableOn (fun τ ↦ petersson k f g₁ τ) D (volume : Measure ℍ))
+    (hg₂ : IntegrableOn (fun τ ↦ petersson k f g₂ τ) D (volume : Measure ℍ)) :
+    peterssonInner k D f (g₁ + g₂) = peterssonInner k D f g₁ + peterssonInner k D f g₂ := by
+  rw [show peterssonInner k D f (g₁ + g₂) =
+      ∫ τ in D, (petersson k f g₁ τ + petersson k f g₂ τ) from by
+    simp only [peterssonInner, petersson, Pi.add_apply]; congr 1; ext τ; ring]
+  exact integral_add hg₁ hg₂
+
+/-- Additivity in the first argument, given integrability of both summands. -/
+theorem peterssonInner_add_left (k : ℤ) (D : Set ℍ) (f₁ f₂ g : ℍ → ℂ)
+    (hf₁ : IntegrableOn (fun τ ↦ petersson k f₁ g τ) D (volume : Measure ℍ))
+    (hf₂ : IntegrableOn (fun τ ↦ petersson k f₂ g τ) D (volume : Measure ℍ)) :
+    peterssonInner k D (f₁ + f₂) g = peterssonInner k D f₁ g + peterssonInner k D f₂ g := by
+  rw [show peterssonInner k D (f₁ + f₂) g =
+      ∫ τ in D, (petersson k f₁ g τ + petersson k f₂ g τ) from by
+    simp only [peterssonInner, petersson, Pi.add_apply, map_add]; congr 1; ext τ; ring]
+  exact integral_add hf₁ hf₂
+
+/-- Scalar multiplication in the second argument. -/
+theorem peterssonInner_smul_right (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
+    peterssonInner k D f (c • g) = c * peterssonInner k D f g := by
+  rw [show peterssonInner k D f (c • g) = ∫ τ in D, c * petersson k f g τ from by
+    simp only [peterssonInner, petersson, Pi.smul_apply, smul_eq_mul]
+    congr 1; ext τ; ring]
+  exact integral_const_mul c _
+
+/-- Conjugate-scalar multiplication in the left argument. -/
+theorem peterssonInner_conj_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
+    peterssonInner k D (c • f) g = conj c * peterssonInner k D f g := by
+  rw [show peterssonInner k D (c • f) g = ∫ τ in D, conj c * petersson k f g τ from by
+    simp only [peterssonInner, petersson, Pi.smul_apply, smul_eq_mul, map_mul]
+    congr 1; ext τ; ring]
+  exact integral_const_mul (conj c) _
+
+private lemma petersson_self_re_eq (z : ℂ) (y : ℝ) (k : ℤ) :
+    (starRingEnd ℂ z * z * (↑y : ℂ) ^ k).re = Complex.normSq z * y ^ k := by
+  rw [show starRingEnd ℂ z * z = ↑(Complex.normSq z) from Complex.normSq_eq_conj_mul_self.symm,
+    ← Complex.ofReal_zpow, ← Complex.ofReal_mul, Complex.ofReal_re]
+
+/-- **Definiteness of the Petersson pairing on the fundamental domain**: a cusp form whose
+Petersson self-pairing over `𝒟` vanishes is zero everywhere on `𝒟`.
+
+The nonnegative continuous integrand `normSq (f τ) · (Im τ)^k` is a.e. zero, hence zero on
+the open domain `𝒟ᵒ`, hence zero on `𝒟 = closure 𝒟ᵒ` by continuity. -/
+theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {F : Type*} [FunLike F ℍ ℂ]
+    {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic]
+    [CuspFormClass F Γ k]
+    (f : F) (hpet : peterssonInner k fd (fun τ ↦ f τ) (fun τ ↦ f τ) = 0)
+    {τ : ℍ} (hτ : τ ∈ fd) : f τ = 0 := by
+  set g : ℍ → ℝ := fun z ↦ (petersson k (⇑f) (⇑f) z).re
+  have hint := peterssonInner_integrableOn_left k Γ f f
+  have hg_zero : ∫ z in fd, g z = 0 := by
+    trans RCLike.re (∫ z in fd, petersson k (⇑f) (⇑f) z)
+    · exact integral_re hint
+    · simp only [peterssonInner] at hpet; rw [hpet]; simp
+  have hg_ae : g =ᶠ[ae ((volume : Measure ℍ).restrict fd)] 0 := by
+    rwa [← integral_eq_zero_iff_of_nonneg_ae
+      (ae_of_all _ fun z ↦ show 0 ≤ g z from by
+        simp only [g, petersson]
+        exact (petersson_self_re_eq (f z) z.im k).symm ▸
+          mul_nonneg (Complex.normSq_nonneg _) (zpow_nonneg z.im_pos.le _)) hint.re]
+  have hg_cont : Continuous g :=
+    Complex.continuous_re.comp (petersson_continuous k (ModularFormClass.continuous f)
+      (ModularFormClass.continuous f))
+  have hg_fdo : EqOn g 0 fdo :=
+    Measure.eqOn_open_of_ae_eq
+      (hg_ae.filter_mono (ae_mono (restrict_mono fdo_subset_fd le_rfl)))
+      isOpen_fdo hg_cont.continuousOn continuousOn_const
+  have hgτ : g τ = 0 :=
+    (EqOn.of_subset_closure hg_fdo hg_cont.continuousOn continuousOn_const
+      fdo_subset_fd fd_eq_closure_fdo.subset) hτ
+  simp only [g, petersson] at hgτ
+  rw [petersson_self_re_eq] at hgτ
+  exact Complex.normSq_eq_zero.mp ((mul_eq_zero.mp hgτ).elim id
+    (fun h ↦ absurd h (ne_of_gt (zpow_pos τ.im_pos k))))
+
+end UpperHalfPlane
+
+namespace CuspForm
+
+open UpperHalfPlane
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ}
+
+/-- The Petersson pairing of two cusp forms, integrated over the standard fundamental
+domain `𝒟` for `SL₂(ℤ)`.
+
+This is the level-one-domain pairing, **not** the `Γ \ ℍ`-normalized Petersson inner
+product: for `Γ ≤ SL₂(ℤ)` of index `n`, the latter integrates over `n` translates of `𝒟`.
+The two differ by that positive factor, so `pet` is nonetheless Hermitian-sesquilinear and
+positive definite for cusp forms of any arithmetic level (`CuspForm.pet_definite`). -/
+def pet (f g : CuspForm Γ k) : ℂ :=
+  peterssonInner k ModularGroup.fd f g
+
+@[simp]
+theorem pet_def (f g : CuspForm Γ k) : pet f g = peterssonInner k ModularGroup.fd f g := (rfl)
+
+end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -26,10 +26,10 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 
 ## Main definitions
 
-* `UpperHalfPlane.peterssonInner`: the Petersson pairing — the set integral of the
-  Petersson integrand over an arbitrary `D : Set ℍ`. It is a pairing for every `D`;
-  positive definiteness is a separate result of the level-one-domain specialization
-  (`CuspForm.peterssonInnerFd_definite`).
+* `UpperHalfPlane.peterssonInner`: the set integral of the Petersson integrand over an
+  arbitrary `D : Set ℍ` — a sesquilinear pairing on classes of functions whose integrands
+  are integrable over `D`; positive definiteness is a separate result of the
+  level-one-domain specialization (`CuspForm.peterssonInnerFd_definite`).
 * `CuspForm.peterssonInnerFd`: the level-one-domain pairing of two cusp forms (over `𝒟`,
   whatever the level).
 
@@ -416,9 +416,11 @@ standard fundamental domain `𝒟` for `SL₂(ℤ)`, whatever the level `Γ` —
 name marks that the integration domain is `𝒟`, not a `Γ`-fundamental domain.
 
 This is **not** the `Γ \ ℍ`-normalized Petersson inner product, which integrates over a
-`Γ`-fundamental domain. It is nonetheless Hermitian-sesquilinear
-(`peterssonInnerFd_add_left`/`_right`, `peterssonInnerFd_smul_left`/`_right`) and positive
-definite for cusp forms of any arithmetic level (`peterssonInnerFd_definite`, below). -/
+`Γ`-fundamental domain. Its structure accrues by hypothesis: Hermitian symmetry and the
+zero/negation laws, reality, and nonnegativity of the self-pairing are unconditional,
+the scalar laws (`peterssonInnerFd_smul_left`/`_right`) require `[Γ.HasDetOne]`, and
+additivity (`peterssonInnerFd_add_left`/`_right`) and positive definiteness
+(`peterssonInnerFd_definite`) require `[Γ.IsArithmetic]`. -/
 def peterssonInnerFd (f g : CuspForm Γ k) : ℂ :=
   UpperHalfPlane.peterssonInner k ModularGroup.fd f g
 
@@ -430,6 +432,26 @@ theorem peterssonInnerFd_conj_symm (f g : CuspForm Γ k) :
     conj (peterssonInnerFd g f) = peterssonInnerFd f g := by
   simp only [peterssonInnerFd_def]
   exact UpperHalfPlane.peterssonInner_conj_symm k ModularGroup.fd f g
+
+/-- The self-pairing is real: its imaginary part vanishes, by Hermitian symmetry. -/
+@[simp]
+theorem peterssonInnerFd_self_im (f : CuspForm Γ k) : (peterssonInnerFd f f).im = 0 :=
+  Complex.conj_eq_iff_im.mp (peterssonInnerFd_conj_symm f f)
+
+/-- The self-pairing is nonnegative: its real part is the integral of
+`|f τ|² (Im τ)ᵏ ≥ 0` over the fundamental domain. -/
+theorem peterssonInnerFd_self_re_nonneg (f : CuspForm Γ k) :
+    0 ≤ (peterssonInnerFd f f).re := by
+  rw [peterssonInnerFd_def, UpperHalfPlane.peterssonInner_def]
+  have hpt : ∀ τ : ℍ, UpperHalfPlane.petersson k (⇑f) (⇑f) τ =
+      ((‖f τ‖ ^ 2 * τ.im ^ k : ℝ) : ℂ) := fun τ ↦ by
+    simp [UpperHalfPlane.petersson, Complex.conj_mul', Complex.ofReal_mul,
+      Complex.ofReal_zpow]
+  simp only [hpt, integral_complex_ofReal, Complex.ofReal_re]
+  refine MeasureTheory.setIntegral_nonneg ModularGroup.isClosed_fd.measurableSet
+    fun τ _ ↦ ?_
+  have him : (0 : ℝ) < τ.im := τ.im_pos
+  positivity
 
 @[simp]
 theorem peterssonInnerFd_zero_right (f : CuspForm Γ k) : peterssonInnerFd f 0 = 0 := by
@@ -512,6 +534,13 @@ theorem peterssonInnerFd_definite (f : CuspForm Γ k) (hpet : peterssonInnerFd f
     (hev.filter_mono nhdsWithin_le_nhds).frequently
   ext τ
   exact congr_fun h τ
+
+/-- The self-pairing vanishes exactly on the zero form: nondegeneracy packaged with the
+zero law. -/
+@[simp]
+theorem peterssonInnerFd_self_eq_zero_iff (f : CuspForm Γ k) :
+    peterssonInnerFd f f = 0 ↔ f = 0 :=
+  ⟨peterssonInnerFd_definite f, fun h ↦ by rw [h]; exact peterssonInnerFd_zero_left 0⟩
 
 end IsArithmetic
 

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -117,9 +117,12 @@ namespace ModularGroup
 
 private theorem integrableOn_zpow_neg_two_Ioi {c : ℝ} (hc : 0 < c) :
     IntegrableOn (· ^ (-2 : ℤ)) (Ioi c) (volume : Measure ℝ) := by
-  have h := integrableOn_Ioi_rpow_of_lt (show (-2 : ℝ) < -1 by norm_num) hc
-  rwa [show (· ^ (-2 : ℝ) : ℝ → ℝ) = (· ^ (-2 : ℤ)) from funext fun _ ↦ by
-    rw [show (-2 : ℝ) = ((-2 : ℤ) : ℝ) by norm_cast, Real.rpow_intCast]] at h
+  have h := integrableOn_Ioi_rpow_of_lt (by norm_num : (-2 : ℝ) < -1) hc
+  have h_eq : (· ^ (-2 : ℝ) : ℝ → ℝ) = (· ^ (-2 : ℤ)) := by
+    funext x
+    rw [← Real.rpow_intCast]
+    norm_num
+  rwa [h_eq] at h
 
 private theorem strip_lintegral_lt_top {c : ℝ} (hc : 0 < c) :
     ∫⁻ p in Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi c,
@@ -136,9 +139,8 @@ private theorem strip_lintegral_lt_top {c : ℝ} (hc : 0 < c) :
         (integrableOn_zpow_neg_two_Ioi hc).hasFiniteIntegral
 
 private theorem setLIntegral_im_eq_prod (g : ℝ → ENNReal) (T : Set (ℝ × ℝ)) :
-    ∫⁻ z in equivRealProd ⁻¹' T, g z.im ∂(volume : Measure ℂ) =
+    ∫⁻ z in measurableEquivRealProd ⁻¹' T, g z.im ∂(volume : Measure ℂ) =
       ∫⁻ p in T, g p.2 ∂(volume : Measure (ℝ × ℝ)) := by
-  rw [show (⇑equivRealProd : ℂ → ℝ × ℝ) = ⇑measurableEquivRealProd from rfl]
   have h := volume_preserving_equiv_real_prod.setLIntegral_comp_emb
       measurableEquivRealProd.measurableEmbedding (fun p : ℝ × ℝ ↦ g p.2)
       (measurableEquivRealProd ⁻¹' T)
@@ -160,42 +162,46 @@ theorem volume_fd_lt_top : (volume : Measure ℍ) fd < ⊤ := by
         push_cast [Real.nnnorm_of_nonneg τ.im_pos.le]
         rw [one_div, inv_pow, zpow_neg]
         norm_num
-    _ ≤ ∫⁻ z in equivRealProd ⁻¹' T, ENNReal.ofReal (z.im ^ (-2 : ℤ)) :=
+    _ ≤ ∫⁻ z in measurableEquivRealProd ⁻¹' T, ENNReal.ofReal (z.im ^ (-2 : ℤ)) :=
         lintegral_mono_set fun z ↦ by
           rintro ⟨τ, hτ, rfl⟩
-          simp only [mem_preimage, equivRealProd_apply, coe_re, coe_im]
+          simp only [mem_preimage, measurableEquivRealProd_apply, coe_re, coe_im]
           refine ⟨⟨by linarith [(abs_le.mp hτ.2).1], (abs_le.mp hτ.2).2⟩,
             mem_Ioi.mpr ?_⟩
           have h := three_le_four_mul_im_sq_of_mem_fd hτ
-          rw [show (4 : ℝ) * τ.im ^ 2 = (2 * τ.im) ^ 2 from by ring] at h
+          have h_sq : (4 : ℝ) * τ.im ^ 2 = (2 * τ.im) ^ 2 := by ring
+          rw [h_sq] at h
           have h2 := Real.sqrt_le_sqrt h
           rw [Real.sqrt_sq (by linarith [τ.im_pos])] at h2
-          nlinarith [Real.sqrt_pos_of_pos (show (3 : ℝ) > 0 by norm_num)]
+          nlinarith [Real.sqrt_pos_of_pos (by norm_num : (0 : ℝ) < 3)]
     _ = ∫⁻ p in T, ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂volume :=
         setLIntegral_im_eq_prod (fun y ↦ ENNReal.ofReal (y ^ (-2 : ℤ))) T
     _ < ⊤ := strip_lintegral_lt_top (by positivity)
 
 private theorem volume_complex_re_eq (c : ℝ) : volume {z : ℂ | z.re = c} = 0 := by
-  rw [show {z : ℂ | z.re = c} = measurableEquivRealProd ⁻¹' ({c} ×ˢ univ) from by
-    ext z; simp [measurableEquivRealProd]]
-  rw [volume_preserving_equiv_real_prod.measure_preimage
+  have h_eq : {z : ℂ | z.re = c} = measurableEquivRealProd ⁻¹' ({c} ×ˢ univ) := by
+    ext z
+    simp [measurableEquivRealProd_apply]
+  rw [h_eq, volume_preserving_equiv_real_prod.measure_preimage
     ((measurableSet_singleton c).prod MeasurableSet.univ).nullMeasurableSet,
     volume_eq_prod, Measure.prod_prod, Real.volume_singleton, zero_mul]
 
 private theorem volume_complex_normSq_eq (c : ℝ) :
     volume {z : ℂ | Complex.normSq z = c} = 0 := by
   rcases le_or_gt 0 c with hc | hc
-  · rw [show {z : ℂ | Complex.normSq z = c} = Metric.sphere (0 : ℂ) (Real.sqrt c) from by
+  · have h_eq : {z : ℂ | Complex.normSq z = c} = Metric.sphere (0 : ℂ) (Real.sqrt c) := by
       ext z
       simp only [mem_ofPred_eq, Complex.normSq_eq_norm_sq, mem_sphere_zero_iff_norm]
       constructor
       · intro h
         rw [← h, Real.sqrt_sq (norm_nonneg z)]
       · intro h
-        rw [h, Real.sq_sqrt hc]]
+        rw [h, Real.sq_sqrt hc]
+    rw [h_eq]
     exact Measure.addHaar_sphere volume 0 _
-  · rw [show {z : ℂ | Complex.normSq z = c} = ∅ from eq_empty_iff_forall_notMem.mpr
-      fun z hz ↦ not_le.mpr hc (hz ▸ Complex.normSq_nonneg z)]
+  · have h_empty : {z : ℂ | Complex.normSq z = c} = ∅ :=
+      eq_empty_iff_forall_notMem.mpr fun z hz ↦ not_le.mpr hc (hz ▸ Complex.normSq_nonneg z)
+    rw [h_empty]
     exact measure_empty
 
 /-- **The frontier of the standard fundamental domain has zero invariant measure.**
@@ -299,41 +305,45 @@ theorem peterssonInner_add_right (k : ℤ) (D : Set ℍ) (f g₁ g₂ : ℍ → 
     (hg₁ : IntegrableOn (fun τ ↦ petersson k f g₁ τ) D (volume : Measure ℍ))
     (hg₂ : IntegrableOn (fun τ ↦ petersson k f g₂ τ) D (volume : Measure ℍ)) :
     peterssonInner k D f (g₁ + g₂) = peterssonInner k D f g₁ + peterssonInner k D f g₂ := by
-  rw [show peterssonInner k D f (g₁ + g₂) =
-      ∫ τ in D, (petersson k f g₁ τ + petersson k f g₂ τ) from by
-    simp only [peterssonInner, petersson, Pi.add_apply]; congr 1; ext τ; ring]
-  exact integral_add hg₁ hg₂
+  simp only [peterssonInner]
+  rw [← integral_add hg₁ hg₂]
+  exact integral_congr_ae (ae_of_all _ fun τ ↦ by
+    simp only [petersson, Pi.add_apply]
+    ring)
 
 /-- Additivity in the first argument, given integrability of both summands. -/
 theorem peterssonInner_add_left (k : ℤ) (D : Set ℍ) (f₁ f₂ g : ℍ → ℂ)
     (hf₁ : IntegrableOn (fun τ ↦ petersson k f₁ g τ) D (volume : Measure ℍ))
     (hf₂ : IntegrableOn (fun τ ↦ petersson k f₂ g τ) D (volume : Measure ℍ)) :
     peterssonInner k D (f₁ + f₂) g = peterssonInner k D f₁ g + peterssonInner k D f₂ g := by
-  rw [show peterssonInner k D (f₁ + f₂) g =
-      ∫ τ in D, (petersson k f₁ g τ + petersson k f₂ g τ) from by
-    simp only [peterssonInner, petersson, Pi.add_apply, map_add]; congr 1; ext τ; ring]
-  exact integral_add hf₁ hf₂
+  simp only [peterssonInner]
+  rw [← integral_add hf₁ hf₂]
+  exact integral_congr_ae (ae_of_all _ fun τ ↦ by
+    simp only [petersson, Pi.add_apply, map_add]
+    ring)
 
 /-- Scalar multiplication in the second argument. -/
 theorem peterssonInner_smul_right (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
     peterssonInner k D f (c • g) = c * peterssonInner k D f g := by
-  rw [show peterssonInner k D f (c • g) = ∫ τ in D, c * petersson k f g τ from by
-    simp only [peterssonInner, petersson, Pi.smul_apply, smul_eq_mul]
-    congr 1; ext τ; ring]
-  exact integral_const_mul c _
+  simp only [peterssonInner]
+  rw [← integral_const_mul]
+  exact integral_congr_ae (ae_of_all _ fun τ ↦ by
+    simp only [petersson, Pi.smul_apply, smul_eq_mul]
+    ring)
 
 /-- Conjugate-scalar multiplication in the left argument. -/
 theorem peterssonInner_conj_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
     peterssonInner k D (c • f) g = conj c * peterssonInner k D f g := by
-  rw [show peterssonInner k D (c • f) g = ∫ τ in D, conj c * petersson k f g τ from by
-    simp only [peterssonInner, petersson, Pi.smul_apply, smul_eq_mul, map_mul]
-    congr 1; ext τ; ring]
-  exact integral_const_mul (conj c) _
+  simp only [peterssonInner]
+  rw [← integral_const_mul]
+  exact integral_congr_ae (ae_of_all _ fun τ ↦ by
+    simp only [petersson, Pi.smul_apply, smul_eq_mul, map_mul]
+    ring)
 
 private lemma petersson_self_re_eq (z : ℂ) (y : ℝ) (k : ℤ) :
     (starRingEnd ℂ z * z * (↑y : ℂ) ^ k).re = Complex.normSq z * y ^ k := by
-  rw [show starRingEnd ℂ z * z = ↑(Complex.normSq z) from Complex.normSq_eq_conj_mul_self.symm,
-    ← Complex.ofReal_zpow, ← Complex.ofReal_mul, Complex.ofReal_re]
+  rw [← Complex.normSq_eq_conj_mul_self, ← Complex.ofReal_zpow, ← Complex.ofReal_mul,
+    Complex.ofReal_re]
 
 /-- **Definiteness of the Petersson pairing on the fundamental domain**: a cusp form whose
 Petersson self-pairing over `𝒟` vanishes is zero everywhere on `𝒟`.
@@ -351,12 +361,12 @@ theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {F : Type*} [FunLike F ℍ 
     trans RCLike.re (∫ z in fd, petersson k (⇑f) (⇑f) z)
     · exact integral_re hint
     · simp only [peterssonInner] at hpet; rw [hpet]; simp
+  have hg_nonneg : ∀ z, 0 ≤ g z := fun z ↦ by
+    simp only [g, petersson]
+    exact (petersson_self_re_eq (f z) z.im k).symm ▸
+      mul_nonneg (Complex.normSq_nonneg _) (zpow_nonneg z.im_pos.le _)
   have hg_ae : g =ᶠ[ae ((volume : Measure ℍ).restrict fd)] 0 := by
-    rwa [← integral_eq_zero_iff_of_nonneg_ae
-      (ae_of_all _ fun z ↦ show 0 ≤ g z from by
-        simp only [g, petersson]
-        exact (petersson_self_re_eq (f z) z.im k).symm ▸
-          mul_nonneg (Complex.normSq_nonneg _) (zpow_nonneg z.im_pos.le _)) hint.re]
+    rwa [← integral_eq_zero_iff_of_nonneg_ae (ae_of_all _ hg_nonneg) hint.re]
   have hg_cont : Continuous g :=
     Complex.continuous_re.comp (petersson_continuous k (ModularFormClass.continuous f)
       (ModularFormClass.continuous f))

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -18,7 +18,8 @@ import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 The **Petersson inner product**
 $$\langle f, g \rangle = \int_D \overline{f(\tau)} \, g(\tau) \, (\operatorname{Im}\tau)^k
 \, d\mu(\tau)$$
-of two functions on the upper half-plane, integrated over a fundamental domain `D` against
+of two functions on the upper half-plane, integrated over a set `D` — in applications a
+fundamental domain — against
 Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 `Mathlib/Analysis/Complex/UpperHalfPlane/Measure.lean`), with the integrand
 `petersson k f g` from `Mathlib/NumberTheory/ModularForms/Petersson.lean`.
@@ -42,9 +43,9 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 * `UpperHalfPlane.eq_zero_on_fd_of_peterssonInner_self_eq_zero`: definiteness on the
   fundamental domain.
 
-The inner product is parameterized by a fundamental domain `D : Set ℍ` rather than fixing a
-subgroup; for `SL₂(ℤ)` use `D = ModularGroup.fd`, and for a congruence subgroup of index `n` a
-union of `n` translates. The topology of `𝒟`/`𝒟ᵒ` (`ModularGroup.isClosed_fd`,
+The pairing is parameterized by an arbitrary `D : Set ℍ` rather than fixing a subgroup;
+for `SL₂(ℤ)` use `D = ModularGroup.fd`, and for a congruence subgroup a union of
+translates of `𝒟`. The topology of `𝒟`/`𝒟ᵒ` (`ModularGroup.isClosed_fd`,
 `ModularGroup.isOpen_fdo`, `ModularGroup.fd_eq_closure_fdo`) comes from
 `Mathlib/NumberTheory/Modular.lean`; this file adds their measure theory.
 
@@ -249,8 +250,9 @@ end ModularGroup
 
 namespace UpperHalfPlane
 
-/-- The Petersson inner product of two functions `f, g : ℍ → ℂ` of weight `k`,
-integrated over a fundamental domain `D` with respect to the invariant measure.
+/-- The Petersson pairing of two functions `f, g : ℍ → ℂ` of weight `k`, integrated over
+an arbitrary set `D` (in applications, a fundamental domain) with respect to the
+invariant measure.
 
 The integrand is `conj(f(τ)) · g(τ) · (Im τ)^k`, which equals
 `petersson k f g τ` from `Mathlib.NumberTheory.ModularForms.Petersson`. -/
@@ -266,21 +268,25 @@ theorem peterssonInner_conj_symm (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
   simp only [peterssonInner, ← integral_conj, petersson_symm k g f]
 
 /-- The pairing with zero on the right vanishes. -/
+@[simp]
 theorem peterssonInner_zero_right (k : ℤ) (D : Set ℍ) (f : ℍ → ℂ) :
     peterssonInner k D f 0 = 0 := by
   simp [peterssonInner, petersson]
 
 /-- The pairing with zero on the left vanishes. -/
+@[simp]
 theorem peterssonInner_zero_left (k : ℤ) (D : Set ℍ) (g : ℍ → ℂ) :
     peterssonInner k D 0 g = 0 := by
   simp [peterssonInner, petersson]
 
 /-- Negation in the right argument. -/
+@[simp]
 theorem peterssonInner_neg_right (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     peterssonInner k D f (-g) = -peterssonInner k D f g := by
   simp only [peterssonInner, petersson, Pi.neg_apply, mul_neg, neg_mul, integral_neg]
 
 /-- Negation in the left argument. -/
+@[simp]
 theorem peterssonInner_neg_left (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     peterssonInner k D (-f) g = -peterssonInner k D f g := by
   simp only [peterssonInner, petersson, Pi.neg_apply, map_neg, neg_mul, integral_neg]
@@ -405,15 +411,28 @@ variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ}
 standard fundamental domain `𝒟` for `SL₂(ℤ)`, whatever the level `Γ` — the `Fd` in the
 name marks that the integration domain is `𝒟`, not a `Γ`-fundamental domain.
 
-This is **not** the `Γ \ ℍ`-normalized Petersson inner product: for `Γ ≤ SL₂(ℤ)` of
-index `n`, the latter integrates over `n` translates of `𝒟`. The two differ by that
-positive factor, so this pairing is nonetheless Hermitian-sesquilinear and positive
-definite for cusp forms of any arithmetic level (`CuspForm.peterssonInnerFd_definite`),
-which is exactly how the level-`N` pairing's definiteness is reduced to level one. -/
+This is **not** the `Γ \ ℍ`-normalized Petersson inner product, which integrates over a
+`Γ`-fundamental domain. It is nonetheless Hermitian-sesquilinear and positive definite
+for cusp forms of any arithmetic level (`CuspForm.peterssonInnerFd_definite`), which is
+exactly how the level-`N` pairing's definiteness is reduced to level one. -/
 def peterssonInnerFd (f g : CuspForm Γ k) : ℂ :=
   UpperHalfPlane.peterssonInner k ModularGroup.fd f g
 
 theorem peterssonInnerFd_def (f g : CuspForm Γ k) :
     peterssonInnerFd f g = UpperHalfPlane.peterssonInner k ModularGroup.fd f g := (rfl)
+
+/-- Hermitian symmetry of the level-one-domain pairing. -/
+theorem peterssonInnerFd_conj_symm (f g : CuspForm Γ k) :
+    conj (peterssonInnerFd g f) = peterssonInnerFd f g := by
+  simp only [peterssonInnerFd_def]
+  exact UpperHalfPlane.peterssonInner_conj_symm k ModularGroup.fd f g
+
+@[simp]
+theorem peterssonInnerFd_zero_right (f : CuspForm Γ k) : peterssonInnerFd f 0 = 0 := by
+  simp [peterssonInnerFd_def]
+
+@[simp]
+theorem peterssonInnerFd_zero_left (g : CuspForm Γ k) : peterssonInnerFd 0 g = 0 := by
+  simp [peterssonInnerFd_def]
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -27,14 +27,15 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 
 * `UpperHalfPlane.peterssonInner`: the Petersson inner product, parameterized by weight `k`
   and fundamental domain `D`.
-* `CuspForm.pet`: the inner product of two cusp forms over the standard fundamental domain.
+* `CuspForm.peterssonInner`: the inner product of two cusp forms over the standard
+  fundamental domain.
 
 ## Main results
 
 * `ModularGroup.volume_fd_lt_top`: the standard fundamental domain has finite invariant
   measure.
 * `UpperHalfPlane.peterssonInner_conj_symm`: Hermitian symmetry.
-* `UpperHalfPlane.peterssonInner_integrableOn_left`: integrability of the Petersson integrand of a
+* `UpperHalfPlane.integrableOn_petersson_fd_left`: integrability of the Petersson integrand of a
   cusp form against a modular form over the standard fundamental domain.
 * `ModularGroup.volume_frontier_fd`, `ModularGroup.setIntegral_fd_eq_fdo`: the frontier of
   the fundamental domain is null, so integrals over `𝒟` and `𝒟ᵒ` agree.
@@ -279,7 +280,7 @@ theorem peterssonInner_neg_left (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
 
 /-- The Petersson integrand of a cusp form against a modular form is integrable over the
 standard fundamental domain. -/
-theorem peterssonInner_integrableOn_left {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
+theorem integrableOn_petersson_fd_left {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
     (k : ℤ) (Γ : Subgroup (GL (Fin 2) ℝ)) [Γ.IsArithmetic]
     [CuspFormClass F Γ k] [ModularFormClass F' Γ k]
     (f : F) (f' : F') :
@@ -292,7 +293,7 @@ theorem peterssonInner_integrableOn_left {F F' : Type*} [FunLike F ℍ ℂ] [Fun
 
 /-- The Petersson integrand of a modular form against a cusp form is integrable over the
 standard fundamental domain. -/
-theorem peterssonInner_integrableOn_right {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
+theorem integrableOn_petersson_fd_right {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
     (k : ℤ) (Γ : Subgroup (GL (Fin 2) ℝ)) [Γ.IsArithmetic]
     [ModularFormClass F Γ k] [CuspFormClass F' Γ k]
     (f : F) (f' : F') :
@@ -335,7 +336,7 @@ theorem peterssonInner_smul_right (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ �
     ring)
 
 /-- Conjugate-scalar multiplication in the left argument. -/
-theorem peterssonInner_conj_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
+theorem peterssonInner_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
     peterssonInner k D (c • f) g = conj c * peterssonInner k D f g := by
   simp only [peterssonInner]
   rw [← integral_const_mul]
@@ -359,7 +360,7 @@ theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {F : Type*} [FunLike F ℍ 
     (f : F) (hpet : peterssonInner k fd (fun τ ↦ f τ) (fun τ ↦ f τ) = 0)
     {τ : ℍ} (hτ : τ ∈ fd) : f τ = 0 := by
   set g : ℍ → ℝ := fun z ↦ (petersson k (⇑f) (⇑f) z).re
-  have hint := peterssonInner_integrableOn_left k Γ f f
+  have hint := integrableOn_petersson_fd_left k Γ f f
   have hg_zero : ∫ z in fd, g z = 0 := by
     trans RCLike.re (∫ z in fd, petersson k (⇑f) (⇑f) z)
     · exact integral_re hint
@@ -393,16 +394,18 @@ open UpperHalfPlane
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ}
 
-/-- The Petersson pairing of two cusp forms, integrated over the standard fundamental
-domain `𝒟` for `SL₂(ℤ)`.
+/-- The Petersson inner product of two cusp forms, integrated over the standard
+fundamental domain `𝒟` for `SL₂(ℤ)`.
 
 This is the level-one-domain pairing, **not** the `Γ \ ℍ`-normalized Petersson inner
 product: for `Γ ≤ SL₂(ℤ)` of index `n`, the latter integrates over `n` translates of `𝒟`.
-The two differ by that positive factor, so `pet` is nonetheless Hermitian-sesquilinear and
-positive definite for cusp forms of any arithmetic level (`CuspForm.pet_definite`). -/
-def pet (f g : CuspForm Γ k) : ℂ :=
-  peterssonInner k ModularGroup.fd f g
+The two differ by that positive factor, so this pairing is nonetheless
+Hermitian-sesquilinear and positive definite for cusp forms of any arithmetic level
+(`CuspForm.peterssonInner_definite`). -/
+def peterssonInner (f g : CuspForm Γ k) : ℂ :=
+  UpperHalfPlane.peterssonInner k ModularGroup.fd f g
 
-theorem pet_def (f g : CuspForm Γ k) : pet f g = peterssonInner k ModularGroup.fd f g := (rfl)
+theorem peterssonInner_def (f g : CuspForm Γ k) :
+    peterssonInner f g = UpperHalfPlane.peterssonInner k ModularGroup.fd f g := (rfl)
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -27,8 +27,9 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 ## Main definitions
 
 * `UpperHalfPlane.peterssonInner`: the Petersson pairing — the set integral of the
-  Petersson integrand over an arbitrary `D : Set ℍ`; it is an inner product only once a
-  domain and integrability are supplied.
+  Petersson integrand over an arbitrary `D : Set ℍ`. It is a pairing for every `D`;
+  positive definiteness is a separate result of the level-one-domain specialization
+  (`CuspForm.peterssonInnerFd_definite`).
 * `CuspForm.peterssonInnerFd`: the level-one-domain pairing of two cusp forms (over `𝒟`,
   whatever the level).
 
@@ -438,17 +439,31 @@ theorem peterssonInnerFd_zero_right (f : CuspForm Γ k) : peterssonInnerFd f 0 =
 theorem peterssonInnerFd_zero_left (g : CuspForm Γ k) : peterssonInnerFd 0 g = 0 := by
   simp [peterssonInnerFd_def]
 
+@[simp]
+theorem peterssonInnerFd_neg_right (f g : CuspForm Γ k) :
+    peterssonInnerFd f (-g) = -peterssonInnerFd f g := by
+  simp only [peterssonInnerFd_def, coe_neg]
+  exact UpperHalfPlane.peterssonInner_neg_right k ModularGroup.fd f g
+
+@[simp]
+theorem peterssonInnerFd_neg_left (f g : CuspForm Γ k) :
+    peterssonInnerFd (-f) g = -peterssonInnerFd f g := by
+  simp only [peterssonInnerFd_def, coe_neg]
+  exact UpperHalfPlane.peterssonInner_neg_left k ModularGroup.fd f g
+
 section HasDetOne
 
 variable [Γ.HasDetOne]
 
 /-- The level-one-domain pairing is ℂ-linear in the second argument. -/
+@[simp]
 theorem peterssonInnerFd_smul_right (c : ℂ) (f g : CuspForm Γ k) :
     peterssonInnerFd f (c • g) = c * peterssonInnerFd f g := by
   simp only [peterssonInnerFd_def, IsGLPos.coe_smul]
   exact UpperHalfPlane.peterssonInner_smul_right k ModularGroup.fd c f g
 
 /-- The level-one-domain pairing is conjugate-linear in the first argument. -/
+@[simp]
 theorem peterssonInnerFd_smul_left (c : ℂ) (f g : CuspForm Γ k) :
     peterssonInnerFd (c • f) g = conj c * peterssonInnerFd f g := by
   simp only [peterssonInnerFd_def, IsGLPos.coe_smul]
@@ -461,6 +476,7 @@ section IsArithmetic
 variable [Γ.IsArithmetic]
 
 /-- Additivity of the level-one-domain pairing in the second argument. -/
+@[simp]
 theorem peterssonInnerFd_add_right (f g₁ g₂ : CuspForm Γ k) :
     peterssonInnerFd f (g₁ + g₂) = peterssonInnerFd f g₁ + peterssonInnerFd f g₂ := by
   simp only [peterssonInnerFd_def, coe_add]
@@ -468,6 +484,7 @@ theorem peterssonInnerFd_add_right (f g₁ g₂ : CuspForm Γ k) :
     (integrableOn_petersson_fd_left k Γ f g₁) (integrableOn_petersson_fd_left k Γ f g₂)
 
 /-- Additivity of the level-one-domain pairing in the first argument. -/
+@[simp]
 theorem peterssonInnerFd_add_left (f₁ f₂ g : CuspForm Γ k) :
     peterssonInnerFd (f₁ + f₂) g = peterssonInnerFd f₁ g + peterssonInnerFd f₂ g := by
   rw [← peterssonInnerFd_conj_symm, peterssonInnerFd_add_right, map_add,

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -26,8 +26,9 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 
 ## Main definitions
 
-* `UpperHalfPlane.peterssonInner`: the Petersson inner product, parameterized by weight `k`
-  and fundamental domain `D`.
+* `UpperHalfPlane.peterssonInner`: the Petersson pairing — the set integral of the
+  Petersson integrand over an arbitrary `D : Set ℍ`; it is an inner product only once a
+  domain and integrability are supplied.
 * `CuspForm.peterssonInnerFd`: the level-one-domain pairing of two cusp forms (over `𝒟`,
   whatever the level).
 
@@ -340,6 +341,7 @@ theorem peterssonInner_add_left (k : ℤ) (D : Set ℍ) (f₁ f₂ g : ℍ → �
     ring)
 
 /-- Scalar multiplication in the second argument. -/
+@[simp]
 theorem peterssonInner_smul_right (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
     peterssonInner k D f (c • g) = c * peterssonInner k D f g := by
   simp only [peterssonInner]
@@ -349,6 +351,7 @@ theorem peterssonInner_smul_right (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ �
     ring)
 
 /-- Conjugate-scalar multiplication in the left argument. -/
+@[simp]
 theorem peterssonInner_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ → ℂ) :
     peterssonInner k D (c • f) g = conj c * peterssonInner k D f g := by
   simp only [peterssonInner]
@@ -412,9 +415,9 @@ standard fundamental domain `𝒟` for `SL₂(ℤ)`, whatever the level `Γ` —
 name marks that the integration domain is `𝒟`, not a `Γ`-fundamental domain.
 
 This is **not** the `Γ \ ℍ`-normalized Petersson inner product, which integrates over a
-`Γ`-fundamental domain. It is nonetheless Hermitian-sesquilinear and positive definite
-for cusp forms of any arithmetic level (`CuspForm.peterssonInnerFd_definite`), which is
-exactly how the level-`N` pairing's definiteness is reduced to level one. -/
+`Γ`-fundamental domain. It is nonetheless Hermitian-sesquilinear
+(`peterssonInnerFd_add_left`/`_right`, `peterssonInnerFd_smul_left`/`_right`) and positive
+definite for cusp forms of any arithmetic level (`peterssonInnerFd_definite`, below). -/
 def peterssonInnerFd (f g : CuspForm Γ k) : ℂ :=
   UpperHalfPlane.peterssonInner k ModularGroup.fd f g
 
@@ -434,5 +437,65 @@ theorem peterssonInnerFd_zero_right (f : CuspForm Γ k) : peterssonInnerFd f 0 =
 @[simp]
 theorem peterssonInnerFd_zero_left (g : CuspForm Γ k) : peterssonInnerFd 0 g = 0 := by
   simp [peterssonInnerFd_def]
+
+section HasDetOne
+
+variable [Γ.HasDetOne]
+
+/-- The level-one-domain pairing is ℂ-linear in the second argument. -/
+theorem peterssonInnerFd_smul_right (c : ℂ) (f g : CuspForm Γ k) :
+    peterssonInnerFd f (c • g) = c * peterssonInnerFd f g := by
+  simp only [peterssonInnerFd_def, IsGLPos.coe_smul]
+  exact UpperHalfPlane.peterssonInner_smul_right k ModularGroup.fd c f g
+
+/-- The level-one-domain pairing is conjugate-linear in the first argument. -/
+theorem peterssonInnerFd_smul_left (c : ℂ) (f g : CuspForm Γ k) :
+    peterssonInnerFd (c • f) g = conj c * peterssonInnerFd f g := by
+  simp only [peterssonInnerFd_def, IsGLPos.coe_smul]
+  exact UpperHalfPlane.peterssonInner_smul_left k ModularGroup.fd c f g
+
+end HasDetOne
+
+section IsArithmetic
+
+variable [Γ.IsArithmetic]
+
+/-- Additivity of the level-one-domain pairing in the second argument. -/
+theorem peterssonInnerFd_add_right (f g₁ g₂ : CuspForm Γ k) :
+    peterssonInnerFd f (g₁ + g₂) = peterssonInnerFd f g₁ + peterssonInnerFd f g₂ := by
+  simp only [peterssonInnerFd_def, coe_add]
+  exact UpperHalfPlane.peterssonInner_add_right k ModularGroup.fd f g₁ g₂
+    (integrableOn_petersson_fd_left k Γ f g₁) (integrableOn_petersson_fd_left k Γ f g₂)
+
+/-- Additivity of the level-one-domain pairing in the first argument. -/
+theorem peterssonInnerFd_add_left (f₁ f₂ g : CuspForm Γ k) :
+    peterssonInnerFd (f₁ + f₂) g = peterssonInnerFd f₁ g + peterssonInnerFd f₂ g := by
+  rw [← peterssonInnerFd_conj_symm, peterssonInnerFd_add_right, map_add,
+    peterssonInnerFd_conj_symm, peterssonInnerFd_conj_symm]
+
+/-- **Positive definiteness of the level-one-domain pairing**: a cusp form of any
+arithmetic level with vanishing self-pairing is zero.
+
+The self-pairing vanishing forces `f = 0` on the open fundamental domain `𝒟ᵒ`
+(`eq_zero_on_fd_of_peterssonInner_self_eq_zero`), and a holomorphic function on `ℍ`
+vanishing on a nonempty open set vanishes identically
+(`UpperHalfPlane.eq_zero_of_frequently`). -/
+theorem peterssonInnerFd_definite (f : CuspForm Γ k) (hpet : peterssonInnerFd f f = 0) :
+    f = 0 := by
+  rw [peterssonInnerFd_def] at hpet
+  have hfdo : ∀ τ ∈ ModularGroup.fdo, f τ = 0 := fun τ hτ ↦
+    eq_zero_on_fd_of_peterssonInner_self_eq_zero f hpet (ModularGroup.fdo_subset_fd hτ)
+  set τ₀ : ℍ := ⟨⟨0, 2⟩, by norm_num⟩ with hτ₀_def
+  have hτ₀ : τ₀ ∈ ModularGroup.fdo := by
+    constructor
+    · norm_num [hτ₀_def, Complex.normSq_apply]
+    · norm_num [hτ₀_def]
+  have hev := Filter.eventually_of_mem (ModularGroup.isOpen_fdo.mem_nhds hτ₀) hfdo
+  have h := UpperHalfPlane.eq_zero_of_frequently (CuspFormClass.holo f)
+    (hev.filter_mono nhdsWithin_le_nhds).frequently
+  ext τ
+  exact congr_fun h τ
+
+end IsArithmetic
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -27,8 +27,8 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 
 * `UpperHalfPlane.peterssonInner`: the Petersson inner product, parameterized by weight `k`
   and fundamental domain `D`.
-* `CuspForm.peterssonInner`: the inner product of two cusp forms over the standard
-  fundamental domain.
+* `CuspForm.peterssonInnerFd`: the level-one-domain pairing of two cusp forms (over `𝒟`,
+  whatever the level).
 
 ## Main results
 
@@ -401,18 +401,19 @@ open UpperHalfPlane
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ}
 
-/-- The Petersson inner product of two cusp forms, integrated over the standard
-fundamental domain `𝒟` for `SL₂(ℤ)`.
+/-- The **level-one-domain Petersson pairing** of two cusp forms: the integral over the
+standard fundamental domain `𝒟` for `SL₂(ℤ)`, whatever the level `Γ` — the `Fd` in the
+name marks that the integration domain is `𝒟`, not a `Γ`-fundamental domain.
 
-This is the level-one-domain pairing, **not** the `Γ \ ℍ`-normalized Petersson inner
-product: for `Γ ≤ SL₂(ℤ)` of index `n`, the latter integrates over `n` translates of `𝒟`.
-The two differ by that positive factor, so this pairing is nonetheless
-Hermitian-sesquilinear and positive definite for cusp forms of any arithmetic level
-(`CuspForm.peterssonInner_definite`). -/
-def peterssonInner (f g : CuspForm Γ k) : ℂ :=
+This is **not** the `Γ \ ℍ`-normalized Petersson inner product: for `Γ ≤ SL₂(ℤ)` of
+index `n`, the latter integrates over `n` translates of `𝒟`. The two differ by that
+positive factor, so this pairing is nonetheless Hermitian-sesquilinear and positive
+definite for cusp forms of any arithmetic level (`CuspForm.peterssonInnerFd_definite`),
+which is exactly how the level-`N` pairing's definiteness is reduced to level one. -/
+def peterssonInnerFd (f g : CuspForm Γ k) : ℂ :=
   UpperHalfPlane.peterssonInner k ModularGroup.fd f g
 
-theorem peterssonInner_def (f g : CuspForm Γ k) :
-    peterssonInner f g = UpperHalfPlane.peterssonInner k ModularGroup.fd f g := (rfl)
+theorem peterssonInnerFd_def (f g : CuspForm Γ k) :
+    peterssonInnerFd f g = UpperHalfPlane.peterssonInner k ModularGroup.fd f g := (rfl)
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -249,6 +249,9 @@ The integrand is `conj(f(τ)) · g(τ) · (Im τ)^k`, which equals
 def peterssonInner (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) : ℂ :=
   ∫ τ in D, petersson k f g τ
 
+theorem peterssonInner_def (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
+    peterssonInner k D f g = ∫ τ in D, petersson k f g τ := (rfl)
+
 /-- Hermitian symmetry: `conj ⟨g, f⟩ = ⟨f, g⟩`. -/
 theorem peterssonInner_conj_symm (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     conj (peterssonInner k D g f) = peterssonInner k D f g := by
@@ -400,7 +403,6 @@ positive definite for cusp forms of any arithmetic level (`CuspForm.pet_definite
 def pet (f g : CuspForm Γ k) : ℂ :=
   peterssonInner k ModularGroup.fd f g
 
-@[simp]
 theorem pet_def (f g : CuspForm Γ k) : pet f g = peterssonInner k ModularGroup.fd f g := (rfl)
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -80,6 +80,7 @@ theorem peterssonInner_def (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     peterssonInner k D f g = ∫ τ in D, petersson k f g τ := (rfl)
 
 /-- Hermitian symmetry: `conj ⟨g, f⟩ = ⟨f, g⟩`. -/
+@[simp]
 theorem peterssonInner_conj_symm (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     conj (peterssonInner k D g f) = peterssonInner k D f g := by
   simp only [peterssonInner, ← integral_conj, petersson_symm k g f]
@@ -240,6 +241,7 @@ theorem peterssonInnerFd_def (f g : CuspForm Γ k) :
     peterssonInnerFd f g = UpperHalfPlane.peterssonInner k ModularGroup.fd f g := (rfl)
 
 /-- Hermitian symmetry of the level-one-domain pairing. -/
+@[simp]
 theorem peterssonInnerFd_conj_symm (f g : CuspForm Γ k) :
     conj (peterssonInnerFd g f) = peterssonInnerFd f g := by
   simp only [peterssonInnerFd_def]
@@ -351,7 +353,7 @@ theorem peterssonInnerFd_definite (f : CuspForm Γ k) (hpet : peterssonInnerFd f
 /-- The self-pairing vanishes exactly on the zero form: nondegeneracy packaged with the
 zero law. -/
 @[simp]
-theorem peterssonInnerFd_self_eq_zero_iff (f : CuspForm Γ k) :
+theorem peterssonInnerFd_self_eq_zero (f : CuspForm Γ k) :
     peterssonInnerFd f f = 0 ↔ f = 0 :=
   ⟨peterssonInnerFd_definite f, fun h ↦ by rw [h]; exact peterssonInnerFd_zero_left 0⟩
 

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -76,6 +76,17 @@ The integrand is `conj(f(τ)) · g(τ) · (Im τ)^k`, which equals
 def peterssonInner (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) : ℂ :=
   ∫ τ in D, petersson k f g τ
 
+/-- The pairing depends on the domain only up to null sets: congruent domains give equal
+pairings, with no unfolding to the underlying set integral. -/
+theorem peterssonInner_congr_set {k : ℤ} {D D' : Set ℍ} (h : D =ᶠ[MeasureTheory.ae volume] D')
+    (f g : ℍ → ℂ) : peterssonInner k D f g = peterssonInner k D' f g :=
+  MeasureTheory.setIntegral_congr_set h
+
+/-- Over the standard fundamental domain the pairing may be computed on its interior. -/
+theorem peterssonInner_fd_eq_fdo (k : ℤ) (f g : ℍ → ℂ) :
+    peterssonInner k ModularGroup.fd f g = peterssonInner k ModularGroup.fdo f g :=
+  peterssonInner_congr_set ModularGroup.fd_ae_eq_fdo f g
+
 theorem peterssonInner_def (k : ℤ) (D : Set ℍ) (f g : ℍ → ℂ) :
     peterssonInner k D f g = ∫ τ in D, petersson k f g τ := (rfl)
 

--- a/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
+++ b/TauCeti/NumberTheory/ModularForms/PeterssonInner.lean
@@ -5,12 +5,9 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Measure
-public import Mathlib.NumberTheory.Modular
 public import Mathlib.NumberTheory.ModularForms.Bounds
 public import Mathlib.NumberTheory.ModularForms.Petersson
-import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
-import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
+public import TauCeti.NumberTheory.Modular
 
 /-!
 # The Petersson inner product
@@ -35,21 +32,17 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 
 ## Main results
 
-* `ModularGroup.volume_fd_lt_top`: the standard fundamental domain has finite invariant
-  measure.
 * `UpperHalfPlane.peterssonInner_conj_symm`: Hermitian symmetry.
 * `UpperHalfPlane.integrableOn_petersson_fd_left`: integrability of the Petersson integrand of a
   cusp form against a modular form over the standard fundamental domain.
-* `ModularGroup.volume_frontier_fd`, `ModularGroup.setIntegral_fd_eq_fdo`: the frontier of
-  the fundamental domain is null, so integrals over `𝒟` and `𝒟ᵒ` agree.
 * `UpperHalfPlane.eq_zero_on_fd_of_peterssonInner_self_eq_zero`: definiteness on the
-  fundamental domain.
+  fundamental domain, for any continuous function with integrable self-integrand.
 
 The pairing is parameterized by an arbitrary `D : Set ℍ` rather than fixing a subgroup;
 for `SL₂(ℤ)` use `D = ModularGroup.fd`, and for a congruence subgroup a union of
-translates of `𝒟`. The topology of `𝒟`/`𝒟ᵒ` (`ModularGroup.isClosed_fd`,
-`ModularGroup.isOpen_fdo`, `ModularGroup.fd_eq_closure_fdo`) comes from
-`Mathlib/NumberTheory/Modular.lean`; this file adds their measure theory.
+translates of `𝒟`. The topology of `𝒟`/`𝒟ᵒ` comes from
+`Mathlib/NumberTheory/Modular.lean`, and its measure theory (finite volume, null frontier,
+`𝒟`-vs-`𝒟ᵒ` integration) from `TauCeti/NumberTheory/Modular.lean`.
 
 Ported from the AINTLIB `LeanModularForms` project's
 `LeanModularForms/Modularforms/PeterssonInnerProduct.lean` (Chris Birkbeck), rewritten to
@@ -71,184 +64,6 @@ noncomputable section
 open MeasureTheory Measure UpperHalfPlane ModularGroup Complex Set ENNReal
 
 open scoped ComplexConjugate MatrixGroups NNReal Pointwise
-
-namespace UpperHalfPlane
-
-/-- Mathlib's invariant measure on `ℍ`, respelled with the density `(Im τ)⁻²` in
-`ENNReal.ofReal` form. -/
-theorem volume_eq_withDensity_ofReal :
-    (volume : Measure ℍ) = (Measure.comap UpperHalfPlane.coe volume).withDensity
-      (fun τ ↦ ENNReal.ofReal (τ.im ^ (-2 : ℤ))) := by
-  rw [volume_def]
-  congr 1
-  funext τ
-  rw [← ENNReal.ofReal_coe_nnreal]
-  congr 1
-  push_cast [NNReal.coe_mk]
-  rw [one_div, inv_pow, zpow_neg]
-  norm_num
-
-/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is positive on nonempty open sets. -/
-instance : IsOpenPosMeasure (Measure.comap UpperHalfPlane.coe (volume : Measure ℂ)) :=
-  IsOpenPosMeasure.comap volume isOpenEmbedding_coe
-
-/-- The invariant measure is absolutely continuous w.r.t. the pullback of the Lebesgue
-measure along `ℍ ↪ ℂ`. -/
-theorem volume_absolutelyContinuous_comap :
-    (volume : Measure ℍ) ≪ Measure.comap UpperHalfPlane.coe volume := by
-  rw [volume_eq_withDensity_ofReal]
-  exact withDensity_absolutelyContinuous _ _
-
-/-- The pullback of the Lebesgue measure along `ℍ ↪ ℂ` is absolutely continuous w.r.t. the
-invariant measure, since the density `(Im τ)⁻²` is everywhere positive on `ℍ`. -/
-theorem comap_absolutelyContinuous_volume :
-    Measure.comap UpperHalfPlane.coe (volume : Measure ℂ) ≪ (volume : Measure ℍ) := by
-  rw [volume_eq_withDensity_ofReal]
-  exact withDensity_absolutelyContinuous'
-    ((continuous_im.zpow₀ _ fun τ ↦ Or.inl τ.im_pos.ne').measurable.ennreal_ofReal.aemeasurable)
-    (ae_of_all _ fun τ ↦ by
-      simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
-      exact zpow_pos τ.im_pos _)
-
-/-- The invariant measure gives positive mass to nonempty open sets. -/
-instance : IsOpenPosMeasure (volume : Measure ℍ) :=
-  comap_absolutelyContinuous_volume.isOpenPosMeasure
-
-/-- If a subset of `ℂ` has zero Lebesgue measure, its preimage in `ℍ` has zero invariant
-measure. -/
-theorem volume_preimage_coe_null {S : Set ℂ} (hS : volume S = 0) :
-    (volume : Measure ℍ) (UpperHalfPlane.coe ⁻¹' S) = 0 := by
-  refine volume_absolutelyContinuous_comap ?_
-  rw [isOpenEmbedding_coe.measurableEmbedding.comap_apply]
-  exact measure_mono_null (image_preimage_subset _ _) hS
-
-end UpperHalfPlane
-
-namespace ModularGroup
-
-private theorem integrableOn_zpow_neg_two_Ioi {c : ℝ} (hc : 0 < c) :
-    IntegrableOn (· ^ (-2 : ℤ)) (Ioi c) (volume : Measure ℝ) := by
-  have h := integrableOn_Ioi_rpow_of_lt (by norm_num : (-2 : ℝ) < -1) hc
-  have h_eq : (· ^ (-2 : ℝ) : ℝ → ℝ) = (· ^ (-2 : ℤ)) := by
-    funext x
-    rw [← Real.rpow_intCast]
-    norm_num
-  rwa [h_eq] at h
-
-private theorem strip_lintegral_lt_top {c : ℝ} (hc : 0 < c) :
-    ∫⁻ p in Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi c,
-      ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂(volume : Measure (ℝ × ℝ)) < ⊤ := by
-  rw [volume_eq_prod ℝ ℝ, setLIntegral_prod_symm _ (by fun_prop)]
-  simp_rw [setLIntegral_const]
-  calc ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) *
-        volume (Icc (-1/2 : ℝ) (1/2)) ∂volume
-      ≤ ∫⁻ y in Ioi c, ENNReal.ofReal (y ^ (-2 : ℤ)) * 1 ∂volume := by
-        gcongr with y; rw [Real.volume_Icc]; norm_num
-    _ = _ := by simp
-    _ < ⊤ := lt_of_le_of_lt (setLIntegral_mono' measurableSet_Ioi
-        fun y _ ↦ Real.ofReal_le_enorm _)
-        (integrableOn_zpow_neg_two_Ioi hc).hasFiniteIntegral
-
-private theorem setLIntegral_im_eq_prod (g : ℝ → ENNReal) (T : Set (ℝ × ℝ)) :
-    ∫⁻ z in measurableEquivRealProd ⁻¹' T, g z.im ∂(volume : Measure ℂ) =
-      ∫⁻ p in T, g p.2 ∂(volume : Measure (ℝ × ℝ)) := by
-  have h := volume_preserving_equiv_real_prod.setLIntegral_comp_emb
-      measurableEquivRealProd.measurableEmbedding (fun p : ℝ × ℝ ↦ g p.2)
-      (measurableEquivRealProd ⁻¹' T)
-  rw [MeasurableEquiv.image_preimage] at h
-  simpa only [measurableEquivRealProd_apply] using h
-
-/-- The invariant measure of the standard fundamental domain is finite. -/
-theorem volume_fd_lt_top : (volume : Measure ℍ) fd < ⊤ := by
-  rw [volume_eq_lintegral]
-  set T := Icc (-1/2 : ℝ) (1/2) ×ˢ Ioi (Real.sqrt 3 / 4)
-  calc ∫⁻ z in UpperHalfPlane.coe '' fd, ↑((1 / ‖z.im‖₊) ^ 2 : ℝ≥0)
-      = ∫⁻ z in UpperHalfPlane.coe '' fd, ENNReal.ofReal (z.im ^ (-2 : ℤ)) := by
-        refine setLIntegral_congr_fun
-          (isOpenEmbedding_coe.measurableEmbedding.measurableSet_image.mpr
-            isClosed_fd.measurableSet) fun z hz ↦ ?_
-        obtain ⟨τ, -, rfl⟩ := hz
-        rw [← ENNReal.ofReal_coe_nnreal]
-        congr 1
-        push_cast [Real.nnnorm_of_nonneg τ.im_pos.le]
-        rw [one_div, inv_pow, zpow_neg]
-        norm_num
-    _ ≤ ∫⁻ z in measurableEquivRealProd ⁻¹' T, ENNReal.ofReal (z.im ^ (-2 : ℤ)) :=
-        lintegral_mono_set fun z ↦ by
-          rintro ⟨τ, hτ, rfl⟩
-          simp only [mem_preimage, measurableEquivRealProd_apply, coe_re, coe_im]
-          refine ⟨⟨by linarith [(abs_le.mp hτ.2).1], (abs_le.mp hτ.2).2⟩,
-            mem_Ioi.mpr ?_⟩
-          have h := three_le_four_mul_im_sq_of_mem_fd hτ
-          have h_sq : (4 : ℝ) * τ.im ^ 2 = (2 * τ.im) ^ 2 := by ring
-          rw [h_sq] at h
-          have h2 := Real.sqrt_le_sqrt h
-          rw [Real.sqrt_sq (by linarith [τ.im_pos])] at h2
-          nlinarith [Real.sqrt_pos_of_pos (by norm_num : (0 : ℝ) < 3)]
-    _ = ∫⁻ p in T, ENNReal.ofReal (p.2 ^ (-2 : ℤ)) ∂volume :=
-        setLIntegral_im_eq_prod (fun y ↦ ENNReal.ofReal (y ^ (-2 : ℤ))) T
-    _ < ⊤ := strip_lintegral_lt_top (by positivity)
-
-private theorem volume_complex_re_eq (c : ℝ) : volume {z : ℂ | z.re = c} = 0 := by
-  have h_eq : {z : ℂ | z.re = c} = measurableEquivRealProd ⁻¹' ({c} ×ˢ univ) := by
-    ext z
-    simp [measurableEquivRealProd_apply]
-  rw [h_eq, volume_preserving_equiv_real_prod.measure_preimage
-    ((measurableSet_singleton c).prod MeasurableSet.univ).nullMeasurableSet,
-    volume_eq_prod, Measure.prod_prod, Real.volume_singleton, zero_mul]
-
-private theorem volume_complex_normSq_eq (c : ℝ) :
-    volume {z : ℂ | Complex.normSq z = c} = 0 := by
-  rcases le_or_gt 0 c with hc | hc
-  · have h_eq : {z : ℂ | Complex.normSq z = c} = Metric.sphere (0 : ℂ) (Real.sqrt c) := by
-      ext z
-      simp only [mem_ofPred_eq, Complex.normSq_eq_norm_sq, mem_sphere_zero_iff_norm]
-      constructor
-      · intro h
-        rw [← h, Real.sqrt_sq (norm_nonneg z)]
-      · intro h
-        rw [h, Real.sq_sqrt hc]
-    rw [h_eq]
-    exact Measure.addHaar_sphere volume 0 _
-  · have h_empty : {z : ℂ | Complex.normSq z = c} = ∅ :=
-      eq_empty_iff_forall_notMem.mpr fun z hz ↦ not_le.mpr hc (hz ▸ Complex.normSq_nonneg z)
-    rw [h_empty]
-    exact measure_empty
-
-/-- **The frontier of the standard fundamental domain has zero invariant measure.**
-
-`frontier 𝒟 = 𝒟 \ 𝒟ᵒ ⊆ {normSq = 1} ∪ {Re = 1/2} ∪ {Re = −1/2}`, each of which has
-zero Lebesgue measure in `ℂ`. -/
-theorem volume_frontier_fd : (volume : Measure ℍ) (frontier (fd : Set ℍ)) = 0 := by
-  rw [frontier, isClosed_fd.closure_eq, ← fdo_eq_interior_fd]
-  apply measure_mono_null _ (volume_preimage_coe_null
-    (measure_union_null
-      (measure_union_null (volume_complex_normSq_eq 1) (volume_complex_re_eq (1/2)))
-      (volume_complex_re_eq (-1/2))))
-  intro τ ⟨hfd, hfdo⟩
-  simp only [fd, fdo, mem_ofPred_eq, not_and, not_lt] at hfd hfdo
-  obtain ⟨h1, h2⟩ := hfd
-  simp only [mem_preimage, mem_union, mem_ofPred_eq]
-  by_cases h : Complex.normSq (τ : ℂ) = 1
-  · left; left; exact h
-  · have hns : 1 < Complex.normSq (τ : ℂ) := lt_of_le_of_ne h1 (Ne.symm h)
-    have habs : |τ.re| = 1 / 2 := le_antisymm h2 (hfdo hns)
-    by_cases hre : 0 ≤ τ.re
-    · left; right; rw [coe_re]; rwa [abs_of_nonneg hre] at habs
-    · push Not at hre; right
-      rw [coe_re]; rw [abs_of_neg hre] at habs; linarith
-
-/-- `fd` and `fdo` are a.e. equal w.r.t. the invariant measure. -/
-theorem fd_ae_eq_fdo : (fd : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fdo :=
-  ((fdo_eq_interior_fd.symm ▸ interior_ae_eq_of_null_frontier volume_frontier_fd :
-    (fdo : Set ℍ) =ᶠ[ae (volume : Measure ℍ)] fd)).symm
-
-/-- Integrals over `fd` and `fdo` agree against the invariant measure. -/
-theorem setIntegral_fd_eq_fdo {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    (f : ℍ → E) : ∫ τ in fd, f τ = ∫ τ in fdo, f τ :=
-  setIntegral_congr_set fd_ae_eq_fdo
-
-end ModularGroup
 
 namespace UpperHalfPlane
 
@@ -366,20 +181,18 @@ private lemma petersson_self_re_eq (z : ℂ) (y : ℝ) (k : ℤ) :
   rw [← Complex.normSq_eq_conj_mul_self, ← Complex.ofReal_zpow, ← Complex.ofReal_mul,
     Complex.ofReal_re]
 
-/-- **Definiteness of the Petersson pairing on the fundamental domain**: a cusp form whose
-Petersson self-pairing over `𝒟` vanishes is zero everywhere on `𝒟`.
+/-- **Definiteness of the Petersson pairing on the fundamental domain**: a continuous
+function whose Petersson self-integrand is integrable on `𝒟` and whose self-pairing over
+`𝒟` vanishes is zero everywhere on `𝒟`.
 
 The nonnegative continuous integrand `normSq (f τ) · (Im τ)^k` is a.e. zero, hence zero on
 the open domain `𝒟ᵒ`, hence zero on `𝒟 = closure 𝒟ᵒ` by continuity. -/
-theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {F : Type*} [FunLike F ℍ ℂ]
-    {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic]
-    [CuspFormClass F Γ k]
-    (f : F) (hpet : peterssonInner k fd (fun τ ↦ f τ) (fun τ ↦ f τ) = 0)
-    {τ : ℍ} (hτ : τ ∈ fd) : f τ = 0 := by
-  set g : ℍ → ℝ := fun z ↦ (petersson k (⇑f) (⇑f) z).re
-  have hint := integrableOn_petersson_fd_left k Γ f f
+theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {k : ℤ} {f : ℍ → ℂ}
+    (hf : Continuous f) (hint : IntegrableOn (petersson k f f) fd volume)
+    (hpet : peterssonInner k fd f f = 0) {τ : ℍ} (hτ : τ ∈ fd) : f τ = 0 := by
+  set g : ℍ → ℝ := fun z ↦ (petersson k f f z).re
   have hg_zero : ∫ z in fd, g z = 0 := by
-    trans RCLike.re (∫ z in fd, petersson k (⇑f) (⇑f) z)
+    trans RCLike.re (∫ z in fd, petersson k f f z)
     · exact integral_re hint
     · simp only [peterssonInner] at hpet; rw [hpet]; simp
   have hg_nonneg : ∀ z, 0 ≤ g z := fun z ↦ by
@@ -389,8 +202,7 @@ theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {F : Type*} [FunLike F ℍ 
   have hg_ae : g =ᶠ[ae ((volume : Measure ℍ).restrict fd)] 0 := by
     rwa [← integral_eq_zero_iff_of_nonneg_ae (ae_of_all _ hg_nonneg) hint.re]
   have hg_cont : Continuous g :=
-    Complex.continuous_re.comp (petersson_continuous k (ModularFormClass.continuous f)
-      (ModularFormClass.continuous f))
+    Complex.continuous_re.comp (petersson_continuous k hf hf)
   have hg_fdo : EqOn g 0 fdo :=
     Measure.eqOn_open_of_ae_eq
       (hg_ae.filter_mono (ae_mono (restrict_mono fdo_subset_fd le_rfl)))
@@ -523,7 +335,8 @@ theorem peterssonInnerFd_definite (f : CuspForm Γ k) (hpet : peterssonInnerFd f
     f = 0 := by
   rw [peterssonInnerFd_def] at hpet
   have hfdo : ∀ τ ∈ ModularGroup.fdo, f τ = 0 := fun τ hτ ↦
-    eq_zero_on_fd_of_peterssonInner_self_eq_zero f hpet (ModularGroup.fdo_subset_fd hτ)
+    eq_zero_on_fd_of_peterssonInner_self_eq_zero (ModularFormClass.continuous f)
+      (integrableOn_petersson_fd_left k Γ f f) hpet (ModularGroup.fdo_subset_fd hτ)
   set τ₀ : ℍ := ⟨⟨0, 2⟩, by norm_num⟩ with hτ₀_def
   have hτ₀ : τ₀ ∈ ModularGroup.fdo := by
     constructor


### PR DESCRIPTION
Ports the Petersson inner product from the AINTLIB `LeanModularForms` project (`Modularforms/PeterssonInnerProduct.lean`), rewritten to **consume** mathlib's invariant measure `volume : Measure ℍ` (`Mathlib/Analysis/Complex/UpperHalfPlane/Measure.lean`, = `dx dy / y²`) rather than constructing the hyperbolic measure — the AINTLIB measure-construction half (borel instances, `μ_hyp`, its FMOC/locally-finite/open-pos instances) is dropped as duplicating mathlib.

### What's here

**`UpperHalfPlane`**
- `volume_eq_withDensity_ofReal`: mathlib's `volume_def` density respelled in `ENNReal.ofReal (im ^ (-2 : ℤ))` form, the shape the lintegral computations consume.
- `IsOpenPosMeasure` instances for `volume : Measure ℍ` and the comap of Lebesgue along `ℍ ↪ ℂ` (the pin has finiteness-on-compacts but not open-positivity).
- `volume_preimage_coe_null`: null sets of ℂ pull back to null sets of ℍ.
- `peterssonInner k D f g = ∫ τ in D, petersson k f g τ` with Hermitian symmetry (`peterssonInner_conj_symm`), `zero`/`neg`/`add`/`smul` lemmas (sesquilinear: `conj_smul_left`), integrability for cusp-form × modular-form pairs over `𝒟` (`peterssonInner_integrableOn`, via `CuspFormClass.petersson_bounded_left`), and definiteness on `𝒟` (`eq_zero_on_fd_of_peterssonInner_self_eq_zero`).

**`ModularGroup`** (beside mathlib's `fd`/`fdo` topology)
- `volume_fd_lt_top`: the standard fundamental domain has finite invariant measure (strip bound `Icc (-1/2) (1/2) ×ˢ Ioi (√3/4)` + `∫ y⁻² dy < ∞`).
- `volume_fd_boundary`, `fd_ae_eq_fdo`, `setIntegral_fd_eq_fdo`: the boundary `𝒟 \ 𝒟ᵒ` is null (circle + two vertical lines), so `𝒟`/`𝒟ᵒ` integrals agree.

**`CuspForm.pet`**: the inner product of two cusp forms over `𝒟`.

### Reuse notes

- `𝒟`/`𝒟ᵒ` topology (`isClosed_fd`, `isOpen_fdo`, `fd_eq_closure_fdo`, `fdo_subset_fd`) comes from mathlib's `Modular.lean` — the AINTLIB copies of those (including a 40-line closure argument) are **not** ported.
- The circle-measure argument reuses `Measure.addHaar_sphere`; vertical lines via `volume_preserving_equiv_real_prod`.
- `peterssonInner` is parameterized by the domain `D : Set ℍ`, not a subgroup, so level-`Γ` inner products can later integrate over unions of translates without new definitions.

### Roadmap target

**`TauCetiRoadmap/ModularForms/README.md`, § Layer 3: the Petersson inner product** — the roadmap breaks the pairing's "migrated construction" into its own milestone list ("rather than one verb *integrate*"): *the invariant measure `dx dy/y²`*, *the effective `PSL₂` quotient*, *a measurable finite-volume fundamental domain for every finite-index subgroup*, *convergence from decay at every cusp*, and *positive-definiteness (`∫ = 0 ⟹ f = 0`)*. This PR lands the first and last of those milestones at level one (invariant-measure consumption, `vol 𝒟 < ∞`, integrability from `CuspFormClass` decay, definiteness on `𝒟`), plus the null-boundary lemma the fundamental-domain milestone consumes. The `PSL₂`-quotient and finite-index-tiling milestones are the two follow-on PRs already in flight (#1911 general coset tiling; PSL action port on branch `modforms/psl2-action`).

This layer-3 slice depends only on Mathlib (measure on `ℍ`, `petersson`, `CuspFormClass` bounds) — the roadmap's Layers 0/2 (nebentypus, Hecke action) enter Layer 3 only at the **adjoint** `Tₙ* = ⟨n⟩⁻¹Tₙ` and old/new milestones, which are not part of this PR; the level-`N` pairing `petN` will consume Layer 0 when it lands. (Layer-0 work is in flight separately: diamond operators are staged on #1882's branch stack, and the Hecke lane is #1879/#1886.)

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
