### PR TITLE
refactor(AlgebraicGroup): transport the generator statement through the image directly

### DIFF
--- a/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
+++ b/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/CoordinateHopfAlgebra.lean
@@ -599,58 +599,25 @@ theorem adjoin_coordinateHopfAlgebra_X_union_antipode_X :
             (coordinateHopfAlgebraAlgEquiv R n
               (coordinateRingMap R n (MvPolynomial.X ij))))) =
       ⊤ := by
-  let rawGenerators : Set (CoordinateRing R n) :=
-    Set.range (fun ij : Fin n × Fin n =>
-      coordinateRingMap R n (MvPolynomial.X ij)) ∪
-    Set.range (fun ij : Fin n × Fin n =>
-      antipode R n (coordinateRingMap R n (MvPolynomial.X ij)))
-  let bundledGenerators : Set (coordinateHopfAlgebra R n) :=
-    Set.range (fun ij : Fin n × Fin n =>
-      coordinateHopfAlgebraAlgEquiv R n
-        (coordinateRingMap R n (MvPolynomial.X ij))) ∪
-    Set.range (fun ij : Fin n × Fin n =>
-      HopfAlgebra.antipode R (A := coordinateHopfAlgebra R n)
-        (coordinateHopfAlgebraAlgEquiv R n
-          (coordinateRingMap R n (MvPolynomial.X ij))))
+  -- The bundled generators are the image of the raw ones: the stored antipode acts through the
+  -- transport equivalence, so each range is the equivalence's image of the corresponding raw range.
   have himage :
-      (coordinateHopfAlgebraAlgEquiv R n) '' rawGenerators = bundledGenerators := by
-    ext x
-    constructor
-    · rintro ⟨y, hy, rfl⟩
-      rcases hy with ⟨ij, rfl⟩ | ⟨ij, rfl⟩
-      · exact Set.mem_union_left _ ⟨ij, rfl⟩
-      · exact Set.mem_union_right _ ⟨ij,
-          (coordinateHopfAlgebra_antipode_apply R n _).symm⟩
-    · intro hx
-      rcases hx with ⟨ij, rfl⟩ | ⟨ij, rfl⟩
-      · exact ⟨_, Set.mem_union_left _ ⟨ij, rfl⟩, rfl⟩
-      · exact ⟨_, Set.mem_union_right _ ⟨ij, rfl⟩,
-          coordinateHopfAlgebra_antipode_apply R n _⟩
-  have hbundledAdjoin :
-      Algebra.adjoin R
+      Set.range (fun ij : Fin n × Fin n =>
+          coordinateHopfAlgebraAlgEquiv R n
+            (coordinateRingMap R n (MvPolynomial.X ij))) ∪
+        Set.range (fun ij : Fin n × Fin n =>
+          HopfAlgebra.antipode R (A := coordinateHopfAlgebra R n)
+            (coordinateHopfAlgebraAlgEquiv R n
+              (coordinateRingMap R n (MvPolynomial.X ij)))) =
+        (coordinateHopfAlgebraAlgEquiv R n).toAlgHom ''
           (Set.range (fun ij : Fin n × Fin n =>
-            coordinateHopfAlgebraAlgEquiv R n
-              (coordinateRingMap R n (MvPolynomial.X ij))) ∪
+            coordinateRingMap R n (MvPolynomial.X ij)) ∪
           Set.range (fun ij : Fin n × Fin n =>
-            HopfAlgebra.antipode R (A := coordinateHopfAlgebra R n)
-              (coordinateHopfAlgebraAlgEquiv R n
-                (coordinateRingMap R n (MvPolynomial.X ij))))) =
-        Algebra.adjoin R bundledGenerators := by
-    simp only [bundledGenerators]
-  have hrawAdjoin : Algebra.adjoin R rawGenerators = ⊤ := by
-    simpa only [rawGenerators] using adjoin_X_union_antipode_X R n
-  calc
-    _ = Algebra.adjoin R bundledGenerators := hbundledAdjoin
-    _ =
-        Algebra.adjoin R ((coordinateHopfAlgebraAlgEquiv R n) '' rawGenerators) := by
-      rw [himage]
-    _ = (Algebra.adjoin R rawGenerators).map
-        (coordinateHopfAlgebraAlgEquiv R n).toAlgHom := by
-      simpa using Algebra.adjoin_image R
-        (coordinateHopfAlgebraAlgEquiv R n).toAlgHom rawGenerators
-    _ = ⊤ := by
-      rw [hrawAdjoin, Algebra.map_top]
-      exact (AlgHom.range_eq_top _).mpr (coordinateHopfAlgebraAlgEquiv R n).surjective
+            antipode R n (coordinateRingMap R n (MvPolynomial.X ij)))) := by
+    simp only [Set.image_union, ← Set.range_comp, Function.comp_def, AlgEquiv.coe_toAlgHom,
+      coordinateHopfAlgebra_antipode_apply]
+  rw [himage, Algebra.adjoin_image, adjoin_X_union_antipode_X, Algebra.map_top]
+  exact (AlgHom.range_eq_top _).mpr (coordinateHopfAlgebraAlgEquiv R n).surjective
 
 /-- The general linear coordinate Hopf algebra bundled with its finite-type algebra property. -/
 noncomputable def finiteTypeCoordinateHopfAlgebra : FiniteTypeCommHopfAlgCat R :=


### PR DESCRIPTION
`adjoin_coordinateHopfAlgebra_X_union_antipode_X` already reused its raw counterpart
`adjoin_X_union_antipode_X`; the length was bookkeeping around that reuse. It named the two
generator sets with `let`s, then spent ten lines on `hbundledAdjoin`, whose entire content was
unfolding one of those `let`s, and proved the set-image identity by a four-case `ext`.

Both are avoidable. The bundled generators are the image of the raw ones under the transport
equivalence, and that is what `Set.image_union`, `Set.range_comp` and the existing
`coordinateHopfAlgebra_antipode_apply` say -- so the image identity is a `simp only`, stated
against the goal's own sets rather than against `let`-bound copies. The conclusion then follows
by rewriting with `Algebra.adjoin_image` and the raw result.

Proof body 52 -> 19 lines; the file drops 670 -> 637. The statement is unchanged.

Roadmap: ReductiveGroups


