### PR TITLE
feat(DeFinetti/ViaL2): Cesàro averages of an indicator converge to the directing measure

### DIFF
--- a/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
@@ -49,16 +49,17 @@ theorem Contractable.tendsto_integral_abs_blockAverage_indicator_sub_directingMe
       atTop (𝓝 0) := by
   have hf : Measurable (Set.indicator B (fun _ => (1 : ℝ))) :=
     (measurable_const.indicator hB)
-  have hf_bdd : ∃ C, ∀ x, ‖Set.indicator B (fun _ => (1 : ℝ)) x‖ ≤ C := by
-    refine ⟨1, fun x => ?_⟩
-    by_cases hx : x ∈ B <;> simp [Set.indicator_of_mem, Set.indicator_of_notMem, hx]
+  have hf_bdd : ∃ C, ∀ x, ‖Set.indicator B (fun _ => (1 : ℝ)) x‖ ≤ C :=
+    ⟨1, fun x => by simpa only [norm_one] using norm_indicator_le_norm_self (fun _ => (1 : ℝ)) x⟩
   have hlim := hX.tendsto_integral_abs_blockAverage_sub_condExp hX_meas hf hf_bdd r
-  have hdir := directingMeasure_ae_eq_condExp (μ := μ) (X := X)
-    (tailProcess_le_ambient 0 fun k _ => hX_meas k) (hX_meas 0) hB
+  -- Normalise the composition wrapper so the rewrite matches without relying on defeq.
+  have hdir : (fun ω => (directingMeasure μ X ω).real B)
+      =ᵐ[μ] μ[fun ω => Set.indicator B (fun _ => (1 : ℝ)) (X 0 ω) | tailProcess X] := by
+    simpa only [Function.comp_def] using directingMeasure_ae_eq_condExp (μ := μ) (X := X)
+      (tailProcess_le_ambient 0 fun k _ => hX_meas k) (hX_meas 0) hB
   refine hlim.congr fun m => integral_congr_ae ?_
   filter_upwards [hdir] with ω hω
   rw [hω]
-  rfl
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
+++ b/TauCeti/Probability/DeFinetti/ViaL2/EmpiricalToDirecting.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.Exchangeability.L2.Cesaro.ToCondExp
+public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
+
+/-!
+# Cesàro averages of an indicator converge to the directing measure
+
+`Contractable.tendsto_integral_abs_blockAverage_sub_condExp` identifies the `L¹` limit of the
+fixed-start Cesàro windows of an observable with `μ[f ∘ X 0 | tailProcess X]`, and
+`directingMeasure_ae_eq_condExp` identifies `ω ↦ (directingMeasure μ X ω).real B` with the same
+conditional expectation when the observable is the indicator `𝟙_B`. Composing the two gives the
+statement in the form the `L²` route consumes: the empirical averages of `𝟙_B ∘ X` converge in
+`L¹` to the directing measure's evaluation at `B`.
+
+The point is that no directing measure is *constructed* here. `directingMeasure` is Mathlib's
+`condDistrib` conditioned on `tailProcess X`, which the martingale route also uses but does not
+own; this file only observes that the `L²` averaging limit lands on it.
+-/
+
+public section
+
+noncomputable section
+
+open Filter MeasureTheory
+open scoped Topology
+
+namespace TauCeti
+
+namespace Probability
+
+variable {Ω α : Type*} [MeasurableSpace Ω] [MeasurableSpace α]
+
+/-- **The Cesàro averages of an indicator converge to the directing measure.** For a contractable
+process on a standard Borel state space and a measurable set `B`, the fixed-start Cesàro windows of
+`𝟙_B ∘ X` converge in `L¹` to `ω ↦ (directingMeasure μ X ω).real B`. -/
+theorem Contractable.tendsto_integral_abs_blockAverage_indicator_sub_directingMeasure
+    [StandardBorelSpace α] [Nonempty α] {μ : Measure Ω} [IsFiniteMeasure μ] {X : ℕ → Ω → α}
+    (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i)) {B : Set α} (hB : MeasurableSet B)
+    (r : ℕ) :
+    Tendsto
+      (fun m => ∫ ω, |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω))
+          (fun j : Fin (m + 1) => r + j) ω
+        - (directingMeasure μ X ω).real B| ∂μ)
+      atTop (𝓝 0) := by
+  have hf : Measurable (Set.indicator B (fun _ => (1 : ℝ))) :=
+    (measurable_const.indicator hB)
+  have hf_bdd : ∃ C, ∀ x, ‖Set.indicator B (fun _ => (1 : ℝ)) x‖ ≤ C := by
+    refine ⟨1, fun x => ?_⟩
+    by_cases hx : x ∈ B <;> simp [Set.indicator_of_mem, Set.indicator_of_notMem, hx]
+  have hlim := hX.tendsto_integral_abs_blockAverage_sub_condExp hX_meas hf hf_bdd r
+  have hdir := directingMeasure_ae_eq_condExp (μ := μ) (X := X)
+    (tailProcess_le_ambient 0 fun k _ => hX_meas k) (hX_meas 0) hB
+  refine hlim.congr fun m => integral_congr_ae ?_
+  filter_upwards [hdir] with ω hω
+  rw [hω]
+  rfl
+
+end Probability
+
+end TauCeti


### PR DESCRIPTION
Roadmap: Exchangeability

Roadmap file: `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** (L² averaging library and the
standard-Borel de Finetti route). Intention `TauCetiProject/TauCetiRoadmap#131`, which **stays open**
— see Scope below.

## What

```lean
theorem Contractable.tendsto_integral_abs_blockAverage_indicator_sub_directingMeasure
    [StandardBorelSpace α] [Nonempty α] [IsFiniteMeasure μ]
    (hX : Contractable μ X) (hX_meas : ∀ i, Measurable (X i))
    {B : Set α} (hB : MeasurableSet B) (r : ℕ) :
    Tendsto (fun m => ∫ ω, |blockAverage (fun i ω => Set.indicator B (fun _ => (1 : ℝ)) (X i ω))
        (fun j : Fin (m + 1) => r + j) ω - (directingMeasure μ X ω).real B| ∂μ) atTop (𝓝 0)
```

It composes two identifications that already exist:

* `Contractable.tendsto_integral_abs_blockAverage_sub_condExp` (from
  TauCetiProject/TauCeti#1826) — the `L¹` limit of the fixed-start Cesàro windows is
  `μ[f ∘ X 0 | tailProcess X]`;
* `directingMeasure_ae_eq_condExp` — for `f = 𝟙_B`, that conditional expectation *is*
  `ω ↦ (directingMeasure μ X ω).real B`.

The proof is a `congr` over the first and an `=ᵐ` rewrite through the second.

## Why it is small, and why that is the point

An earlier reading of Layer 3 had this step as
`realObservables_determine_directing_measure`: reconstruct a directing random measure from a
countable determining class of bounded real observables. That was the right architecture before a
canonical directing measure existed. It now does — `directingMeasure` is Mathlib's `condDistrib`
conditioned on `tailProcess X` — so there is nothing to reconstruct, and the `L²` route simply
lands on it.

Nothing is constructed here, and in particular the martingale route is not imported: `condDistrib`
is neutral, used by that route but not owned by it. The reverse-martingale convergence theorem
plays no part.

## Scope

This does **not** close intention #131. What remains on the route is untouched:

* simultaneous finite-block averaging over disjoint windows;
* convergence of the product to the product of directing-measure evaluations;
* the conditional block factorization;
* the call to `conditionallyIIDWith_of_measure_inter_blockCylinder_eq_setLIntegral`;
* `conditionallyIID_of_contractable_viaL2` and the `deFinetti_viaL2` wrappers.

## Verification

Full `lake build` green; `lake exe axioms` all 21542 declarations within
`propext, Classical.choice, Quot.sound`; `lake exe module-system` all 1187 modules;
`scripts/lint-env.sh` PASS (54 grandfathered, 0 new). No `sorry`.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol
