### PR TITLE
feat(HeckeRing): the module of left cosets and its faithful Hecke action

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Algebra.BigOperators.Finsupp.Basic
+public import Mathlib.Data.Finsupp.SMul
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
 
@@ -139,7 +140,7 @@ variable (R : Type*) [Zero R]
 for `Finsupp` itself, this is the type-correct way to produce elements of
 `HeckeCosetModule Δ H₁ H₂ R`. Only `[Zero R]` is assumed, so consumers with coefficient
 assumptions below `Semiring` (the left-coset scalar operations) can use it. -/
-@[expose] noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
+noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
     HeckeCosetModule Δ H₁ H₂ R :=
   Finsupp.single D b
 
@@ -155,5 +156,42 @@ lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
   Finsupp.single_apply
 
 end SingleWrapper
+
+section SingleAlgebra
+
+variable (R : Type*) [Semiring R]
+
+/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
+module structure to the wrapper type. -/
+noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
+  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
+
+lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
+  Finsupp.smul_single_one D b
+
+@[simp]
+lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
+  Finsupp.sum_single f
+
+/-- `Finsupp.single_zero`, as a wrapper-level equation. -/
+@[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
+  Finsupp.single_zero D
+
+/-- `Finsupp.single_add`, as a wrapper-level equation. -/
+lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
+    single R D (b + c) = single R D b + single R D c :=
+  Finsupp.single_add D b c
+
+/-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` in
+its basis vocabulary `single`, in the same way that `MonoidAlgebra.induction_linear` restates
+it for `MonoidAlgebra`: to prove a property of all elements, prove it for `0`, for sums, and
+for basis elements. -/
+lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
+    (f : HeckeCosetModule Δ H₁ H₂ R) (h0 : p 0)
+    (hadd : ∀ f g : HeckeCosetModule Δ H₁ H₂ R, p f → p g → p (f + g))
+    (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
+  Finsupp.induction_linear f h0 hadd hsingle
+
+end SingleAlgebra
 
 end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -5,6 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Finsupp.Basic
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
 
@@ -125,3 +126,34 @@ noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTripl
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
 end IsHeckeTriple
+
+namespace HeckeCosetModule
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+
+section SingleWrapper
+
+variable (R : Type*) [Zero R]
+
+/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
+for `Finsupp` itself, this is the type-correct way to produce elements of
+`HeckeCosetModule Δ H₁ H₂ R`. Only `[Zero R]` is assumed, so consumers with coefficient
+assumptions below `Semiring` (the left-coset scalar operations) can use it. -/
+@[expose] noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
+    HeckeCosetModule Δ H₁ H₂ R :=
+  Finsupp.single D b
+
+/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
+evaluates the summand at its point. -/
+lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
+    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
+  Finsupp.sum_single_index h
+
+@[grind =]
+lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
+    single R D b A = if D = A then b else 0 :=
+  Finsupp.single_apply
+
+end SingleWrapper
+
+end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -17,7 +17,11 @@ Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, foll
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite for a Hecke triple.
+define the Hecke product in later files and is finite for a Hecke triple. It also houses
+the basis-element API of the coset module: `HeckeCosetModule.single` with its evaluation,
+summation, and additivity laws, the `induction_linear` principle, and the transported
+`Module` instance — placed at this layer so every later file (convolution, one, and the
+coset actions) can build on one shared vocabulary.
 
 Vendored from the in-review mathlib4 PR
 [#41253](https://github.com/leanprover-community/mathlib4/pull/41253) (Chris Birkbeck), per the
@@ -30,6 +34,9 @@ stack merges.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
   in `Γ₁gΓ₂`; finite for a Hecke triple.
+* `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
+  `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
+  and the `Module R` instance `HeckeCosetModule.instModule`.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -116,6 +116,17 @@ abbrev DecompQuotient (Γ₁ Γ₂ : Subgroup G) (g : G) :=
 instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ₂ g) :=
   ⟨QuotientGroup.mk 1⟩
 
+/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
+`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
+lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
+  intro i j hij
+  simp only [QuotientGroup.eq] at hij
+  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
+    Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
+      ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
+  simpa [mul_assoc] using hij
+
 end DoubleCoset
 
 namespace IsHeckeTriple

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -161,7 +161,7 @@ lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H�
     {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
   Finsupp.sum_single_index h
 
-@[grind =]
+@[simp, grind =]
 lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
     single R D b A = if D = A then b else 0 :=
   Finsupp.single_apply

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -16,10 +16,11 @@ The scalar operations underlying the natural representation of the Hecke ring, f
 cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
 left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
-additive in both arguments and faithful. The action laws proper — compatibility with the
-convolution product and its identity, which upgrade these operations to a module structure —
-are Shimura's Proposition 3.2 and are established together with the degree homomorphism in
-the follow-up development.
+additive in both arguments and faithful. Since `HgH` sends `βH` to `Σᵢ βσᵢgH` by right
+multiplication, this is a **right** action, encoded as a left action of the opposite ring
+`(𝕋 Δ H R)ᵐᵒᵖ` per Mathlib convention: Shimura's compatibility law
+`(f * g) • m = g • (f • m)` (Proposition 3.2) is exactly `mul_smul` for the opposite ring,
+and is established together with the degree homomorphism in the follow-up development.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`HeckeRIngs/AbstractHeckeRing/Module.lean`,
@@ -34,14 +35,15 @@ Mathlib stack.
   the existing double-coset quotient serve as the left-coset quotient, with no new type.
 * `HeckeCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
   double coset representative.
-* the `SMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R)` instance.
+* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R)` instance — the right Hecke action in
+  its opposite-ring encoding.
 
 ## Main results
 
 * `HeckeCoset.smulOrbit_congr`, `HeckeCoset.smulOrbit_disjoint`: the orbit depends
   only on the left coset, and orbits of distinct double cosets are disjoint.
-* `HeckeLeftCosetModule.instFaithfulSMul`: the action of the Hecke ring on the module of
-  left cosets is faithful.
+* `HeckeLeftCosetModule.instFaithfulSMul`: the action of the (opposite) Hecke ring on the
+  module of left cosets is faithful.
 -/
 
 public section
@@ -268,21 +270,32 @@ open scoped HeckeCosetModule
 variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
 
 /-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
-a left coset by summing over its orbit, extended biadditively. -/
+a left coset by summing over its orbit, extended biadditively. Since `HgH` sends `βH` to
+the cosets `βσᵢH` by **right** multiplication, this is a right action — encoded, per
+Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`: Shimura's
+compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
+ring. -/
 noncomputable instance instSMulHeckeLeftCosetModule :
-    SMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
-  smul t m := t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+    SMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+  smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
     ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂)
+
+-- the defining formula for an opaque opposite-ring element; instance plumbing
+private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →₀ R) :
+    t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
+  (rfl)
 
 /-- The defining formula of the action. -/
 lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
-    t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+    MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
       ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
   (rfl)
 
 /-- The action of a basis element of the Hecke ring on a basis element of the module. -/
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
-    HeckeCosetModule.single R D a • (Finsupp.single q b : HeckeCoset Δ ⊥ H →₀ R) =
+    MulOpposite.op (HeckeCosetModule.single R D a) •
+        (Finsupp.single q b : HeckeCoset Δ ⊥ H →₀ R) =
       ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (a * b) := by
   classical
   rw [smul_eq_sum,
@@ -292,7 +305,7 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b 
 /-- The action is additive in the Hecke-ring argument. -/
 @[simp]
 lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
-    (t₁ + t₂) • m = t₁ • m + t₂ • m := by
+    MulOpposite.op (t₁ + t₂) • m = MulOpposite.op t₁ • m + MulOpposite.op t₂ • m := by
   classical
   simp only [smul_eq_sum]
   refine Finsupp.sum_add_index' (fun D ↦ ?_) fun D b₁ b₂ ↦ ?_
@@ -307,14 +320,15 @@ lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
 `DistribSMul` typeclass (the strongest action class available before the compatibility
 law with the convolution product); the generic `smul_zero`/`smul_add` supersede
 ad-hoc laws. -/
-noncomputable instance distribSMul : DistribSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
+noncomputable instance distribSMul :
+    DistribSMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
   smul_zero t := by
-    rw [smul_eq_sum]
+    rw [smul_def]
     simp only [Finsupp.sum_zero_index]
-    exact Finsupp.sum_fun_zero t
+    exact Finsupp.sum_fun_zero t.unop
   smul_add t m₁ m₂ := by
     classical
-    simp only [smul_eq_sum]
+    simp only [smul_def]
     refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
     refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
     · exact Finset.sum_eq_zero fun i _ ↦ by simp
@@ -322,10 +336,12 @@ noncomputable instance distribSMul : DistribSMul (𝕋 Δ H R) (HeckeCoset Δ �
       exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
 
 /-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
-noncomputable instance smulWithZero : SMulWithZero (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
+noncomputable instance smulWithZero :
+    SMulWithZero (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
   smul_zero := smul_zero
   zero_smul m := by
-    rw [smul_eq_sum]
+    rw [smul_def]
+    simp only [MulOpposite.unop_zero]
     exact Finsupp.sum_zero_index
 
 end HeckeLeftCosetModule
@@ -343,7 +359,7 @@ the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D
 private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
     {q : HeckeCoset Δ ⊥ H}
     (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :
-    (t • (Finsupp.single 1 1 : HeckeCoset Δ ⊥ H →₀ R)) q = t D := by
+    (MulOpposite.op t • (Finsupp.single 1 1 : HeckeCoset Δ ⊥ H →₀ R)) q = t D := by
   classical
   have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
       (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
@@ -380,17 +396,20 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
 
 /-- The action of the Hecke ring on the module of left cosets is faithful. -/
 lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
-    (h : ∀ m : HeckeCoset Δ ⊥ H →₀ R, t₁ • m = t₂ • m) : t₁ = t₂ := by
+    (h : ∀ m : HeckeCoset Δ ⊥ H →₀ R,
+      MulOpposite.op t₁ • m = MulOpposite.op t₂ • m) : t₁ = t₂ := by
   classical
   refine Finsupp.ext fun D ↦ ?_
   obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeCoset Δ ⊥ H).rep
   have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
   rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
 
-/-- The scalar operations of the Hecke ring on the left-coset module are faithful, as an
-instance. -/
+/-- The scalar operations of the opposite Hecke ring on the left-coset module are
+faithful, as an instance. -/
 noncomputable instance instFaithfulSMul :
-    FaithfulSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
-  eq_of_smul_eq_smul := eq_of_smul_eq_smul
+    FaithfulSMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+  eq_of_smul_eq_smul {a b} h :=
+    MulOpposite.unop_injective <| eq_of_smul_eq_smul fun m ↦ by
+      simpa only [MulOpposite.op_unop] using h m
 
 end HeckeLeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -64,7 +64,7 @@ variable (Δ) in
 /-- The identity left coset `1H = H` in the bottom-left specialization. -/
 instance instOneBot : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
 
-lemma bot_one_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
+lemma one_bot_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
 
 /-- In the bottom-left specialization two elements define the same class iff they differ by
 an element of `H` on the right: `⊥β₁H = ⊥β₂H ↔ β₁H = β₂H`. This is the entry point through
@@ -115,10 +115,10 @@ lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
   classical
   exact (Finset.univ_nonempty).image _
 
-/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
-element of the stabilizer conjugates into `H` under `g`. Used by every orbit argument that
-replaces a decomposition representative by its canonical `out`. -/
-lemma conj_mem_of_stabilizer (g : G)
+-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
+-- element of the stabilizer conjugates into `H` under `g`. Used by every orbit argument
+-- that replaces a decomposition representative by its canonical `out`.
+private lemma conj_mem_of_stabilizer (g : G)
     (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
   have hn := n.2
   rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -105,6 +105,15 @@ noncomputable def smulOrbit (H : Subgroup G) [IsHeckeTriple Δ H H] (g β : Δ) 
     mk ⊥ H ⟨(β : G) * i.out * g,
       Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩
 
+open Classical in
+/-- Membership in the orbit: the left cosets of the products `β · σᵢ · g` over the
+decomposition representatives. -/
+lemma mem_smulOrbit {g β : Δ} {x : HeckeCoset Δ ⊥ H} :
+    x ∈ smulOrbit H g β ↔ ∃ i : DecompQuotient H H (g : G),
+      mk ⊥ H ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ = x := by
+  simp [smulOrbit]
+
 lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
   classical
   exact (Finset.univ_nonempty).image _

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -13,7 +13,7 @@ import Mathlib.Tactic.Group
 # Hecke rings: the module of left cosets
 
 The scalar operations underlying the natural representation of the Hecke ring, following
-[Shimura][shimura1971], §3.1: on the free module `HeckeLeftCoset Δ H →₀ R` over the left
+[Shimura][shimura1971], §3.1: on the free module `HeckeCoset Δ ⊥ H →₀ R` over the left
 cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
 left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
@@ -30,15 +30,16 @@ Mathlib stack.
 
 ## Main definitions
 
-* `HeckeLeftCoset Δ H`: the left cosets of `H` with a representative in `Δ` (the quotient of
-  `Δ` by the left-coset relation of `H`).
-* `HeckeLeftCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
+* `HeckeCoset.mk_bot_eq_mk_bot`: the left cosets of `H` with a representative in `Δ` are
+  the bottom-left double cosets `HeckeCoset Δ ⊥ H` (`⊥βH = βH`); this characterization makes
+  the existing double-coset quotient serve as the left-coset quotient, with no new type.
+* `HeckeCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
   double coset representative.
-* the `SMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R)` instance.
+* the `SMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R)` instance.
 
 ## Main results
 
-* `HeckeLeftCoset.smulOrbit_congr`, `HeckeLeftCoset.smulOrbit_disjoint`: the orbit depends
+* `HeckeCoset.smulOrbit_congr`, `HeckeCoset.smulOrbit_disjoint`: the orbit depends
   only on the left coset, and orbits of distinct double cosets are disjoint.
 * `HeckeLeftCosetModule.instFaithfulSMul`: the action of the Hecke ring on the module of
   left cosets is faithful.
@@ -50,51 +51,44 @@ open DoubleCoset Subgroup
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G}
 
-/-- The setoid on `Δ` identifying elements in the same left coset of `H`, pulled back from
-`QuotientGroup.leftRel` along the inclusion `Δ ↪ G`. An `abbrev` for the same reason as
-`HeckeCoset.setoid`: `H` cannot be inferred from `Δ`, and a global instance would create a
-`Setoid` diamond on `↥Δ` with the double-coset setoid. -/
-abbrev HeckeLeftCoset.setoid (Δ : Submonoid G) (H : Subgroup G) : Setoid Δ :=
-  (QuotientGroup.leftRel H).comap Subtype.val
+/-!
+The left cosets `βH` of `Δ`-elements are the bottom-left specialization `HeckeCoset Δ ⊥ H`
+of the double cosets: `⊥βH = βH`. The type, constructor `HeckeCoset.mk ⊥ H`,
+representative `HeckeCoset.rep`, and induction principle are all reused from the
+double-coset API (they are built from the data alone); this section adds only the
+`⊥`-specialized characterizations.
+-/
 
-/-- A Hecke left coset: an equivalence class of `Δ`-elements under `βH = β'H`. This is the
-basis type for the free module `HeckeLeftCoset Δ H →₀ R`, on which the scalar operations
-of the Hecke ring `𝕋 Δ H R` are defined. -/
-def HeckeLeftCoset (Δ : Submonoid G) (H : Subgroup G) := Quotient (HeckeLeftCoset.setoid Δ H)
-
-namespace HeckeLeftCoset
-
-/-- The left coset `βH` of an element `β : Δ`. -/
-def mk (β : Δ) : HeckeLeftCoset Δ H := Quotient.mk (setoid Δ H) β
+namespace HeckeCoset
 
 variable (Δ) in
-instance : Inhabited (HeckeLeftCoset Δ H) := ⟨mk ⟨1, Δ.one_mem⟩⟩
+/-- The identity left coset `1H = H` in the bottom-left specialization. -/
+instance : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
 
-variable (Δ) in
-/-- The identity left coset `1H = H`. -/
-instance : One (HeckeLeftCoset Δ H) := ⟨mk ⟨1, Δ.one_mem⟩⟩
+lemma bot_one_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
 
-lemma one_def : (1 : HeckeLeftCoset Δ H) = mk ⟨1, Δ.one_mem⟩ := (rfl)
-
-/-- Two elements of `Δ` define the same left coset iff they differ by an element of `H` on
-the right. -/
-lemma mk_eq_mk {β₁ β₂ : Δ} : (mk β₁ : HeckeLeftCoset Δ H) = mk β₂ ↔
-    ((β₁ : G))⁻¹ * (β₂ : G) ∈ H :=
-  Quotient.eq''.trans QuotientGroup.leftRel_apply
-
-/-- A representative in `Δ` of a left coset (via `Quotient.out`). -/
-noncomputable def rep (q : HeckeLeftCoset Δ H) : Δ := Quotient.out q
-
-@[simp] lemma mk_rep (q : HeckeLeftCoset Δ H) : mk q.rep = q := Quotient.out_eq q
+/-- In the bottom-left specialization two elements define the same class iff they differ by
+an element of `H` on the right: `⊥β₁H = ⊥β₂H ↔ β₁H = β₂H`. This is the entry point through
+which the double-coset quotient serves as the left-coset quotient. -/
+lemma mk_bot_eq_mk_bot {β₁ β₂ : Δ} :
+    mk ⊥ H β₁ = mk ⊥ H β₂ ↔ ((β₁ : G))⁻¹ * (β₂ : G) ∈ H := by
+  rw [eq_iff]
+  constructor
+  · intro h
+    have hmem : (β₂ : G) ∈ doubleCoset (β₁ : G) ((⊥ : Subgroup G) : Set G) H :=
+      h ▸ mem_doubleCoset_self _ _ _
+    obtain ⟨h₁, hh₁, h₂, hh₂, heq⟩ := mem_doubleCoset.mp hmem
+    obtain rfl : h₁ = 1 := hh₁
+    rw [heq]
+    simpa using hh₂
+  · intro h
+    exact doubleCoset_eq_of_mem (mem_doubleCoset.mpr
+      ⟨1, Subgroup.mem_bot.mpr rfl, (β₂ : G)⁻¹ * (β₁ : G),
+        by simpa using H.inv_mem h, by group⟩)
 
 /-- The representative of the class of `β` differs from `β` by an element of `H`. -/
-lemma inv_rep_mul_mem (β : Δ) : (((mk β : HeckeLeftCoset Δ H).rep : G))⁻¹ * (β : G) ∈ H :=
-  mk_eq_mk.mp (mk_rep (mk β))
-
-/-- Induction: to prove something for all left cosets, prove it for `mk β`. -/
-protected lemma induction {motive : HeckeLeftCoset Δ H → Prop}
-    (h : ∀ β : Δ, motive (mk β)) : ∀ q, motive q :=
-  Quotient.ind h
+lemma inv_rep_mul_mem (β : Δ) : (((mk ⊥ H β : HeckeCoset Δ ⊥ H).rep : G))⁻¹ * (β : G) ∈ H :=
+  mk_bot_eq_mk_bot.mp (mk_rep (mk ⊥ H β))
 
 section Orbit
 
@@ -106,9 +100,9 @@ open Classical in
 /-- The orbit of a left coset representative `β` under a double coset representative `g`:
 the left cosets `βσᵢgH` over the decomposition `HgH = ⊔ᵢ σᵢgH`. -/
 noncomputable def smulOrbit (H : Subgroup G) [IsHeckeTriple Δ H H] (g β : Δ) :
-    Finset (HeckeLeftCoset Δ H) :=
+    Finset (HeckeCoset Δ ⊥ H) :=
   Finset.univ.image fun i : DecompQuotient H H (g : G) ↦
-    mk ⟨(β : G) * i.out * g,
+    mk ⊥ H ⟨(β : G) * i.out * g,
       Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩
 
 lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
@@ -139,7 +133,7 @@ private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
     simpa [Subgroup.coe_mul, mul_assoc] using congrArg (Subtype.val : H → G) hn
   refine ⟨j, ?_⟩
   rw [← hi]
-  refine mk_eq_mk.mpr ?_
+  refine mk_bot_eq_mk_bot.mpr ?_
   -- `mk_eq_mk` lands in the `leftRel`-comap relation of the setoid; its membership statement
   -- coincides with the displayed `H`-membership only through the definitional unfolding of
   -- `QuotientGroup.leftRel` and the `Δ`-subtype coercions, which no rewriting lemma states
@@ -152,9 +146,9 @@ private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
   simpa [mul_assoc] using H.inv_mem (conj_mem_of_stabilizer (g : G) n)
 
 /-- The orbit depends on `β` only through its left coset. -/
-lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : (mk β₁ : HeckeLeftCoset Δ H) = mk β₂) :
+lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : mk ⊥ H β₁ = mk ⊥ H β₂) :
     smulOrbit H g β₁ = smulOrbit H g β₂ := by
-  have hk := mk_eq_mk.mp h
+  have hk := mk_bot_eq_mk_bot.mp h
   refine Finset.Subset.antisymm
     (smulOrbit_subset hk (by group))
     (smulOrbit_subset (H.inv_mem hk) ?_)
@@ -164,12 +158,12 @@ lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : (mk β₁ : HeckeLeftCose
 open scoped Pointwise in
 private lemma smulOrbit_map_injective (g β : Δ) :
     Function.Injective fun i : DecompQuotient H H (g : G) ↦
-      (mk ⟨(β : G) * i.out * g,
+      (mk ⊥ H ⟨(β : G) * i.out * g,
         Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ :
-        HeckeLeftCoset Δ H) := by
+        HeckeCoset Δ ⊥ H) := by
   intro i₁ i₂ heq
   have hmem : ((β : G) * ((i₁.out : H) : G) * (g : G))⁻¹ *
-      ((β : G) * ((i₂.out : H) : G) * (g : G)) ∈ H := mk_eq_mk.mp heq
+      ((β : G) * ((i₂.out : H) : G) * (g : G)) ∈ H := mk_bot_eq_mk_bot.mp heq
   have hcoset : ((((i₁.out : H) : G) * (g : G) : G) : G ⧸ H) =
       ((((i₂.out : H) : G) * (g : G) : G) : G ⧸ H) := by
     rw [QuotientGroup.eq]
@@ -200,7 +194,7 @@ lemma smulOrbit_disjoint {g₁ g₂ : Δ} (β : Δ)
   obtain ⟨i₂, hi₂⟩ := hx₂
   have hmem : ((β : G) * ((i₁.out : H) : G) * (g₁ : G))⁻¹ *
       ((β : G) * ((i₂.out : H) : G) * (g₂ : G)) ∈ H :=
-    mk_eq_mk.mp (hi₁.trans hi₂.symm)
+    mk_bot_eq_mk_bot.mp (hi₁.trans hi₂.symm)
   refine hne (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
     ⟨((i₁.out : H) : G)⁻¹ * ((i₂.out : H) : G),
       H.mul_mem (H.inv_mem i₁.out.2) i₂.out.2,
@@ -210,11 +204,11 @@ lemma smulOrbit_disjoint {g₁ g₂ : Δ} (β : Δ)
 
 end Orbit
 
-end HeckeLeftCoset
+end HeckeCoset
 
 namespace HeckeLeftCosetModule
 
-open HeckeLeftCoset
+open HeckeCoset
 
 open scoped HeckeCosetModule
 
@@ -223,19 +217,19 @@ variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
 /-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
 a left coset by summing over its orbit, extended biadditively. -/
 noncomputable instance instSMulHeckeLeftCosetModule :
-    SMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R) where
+    SMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
   smul t m := t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
     ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂)
 
 /-- The defining formula of the action. -/
-lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
+lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
     t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
       ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
   (rfl)
 
 /-- The action of a basis element of the Hecke ring on a basis element of the module. -/
-lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeLeftCoset Δ H) (a b : R) :
-    HeckeCosetModule.single R D a • (Finsupp.single q b : HeckeLeftCoset Δ H →₀ R) =
+lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
+    HeckeCosetModule.single R D a • (Finsupp.single q b : HeckeCoset Δ ⊥ H →₀ R) =
       ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (a * b) := by
   classical
   rw [smul_eq_sum,
@@ -244,7 +238,7 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeLeftCoset Δ H) (a b 
 
 /-- The action is additive in the Hecke-ring argument. -/
 @[simp]
-lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
+lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
     (t₁ + t₂) • m = t₁ • m + t₂ • m := by
   classical
   simp only [smul_eq_sum]
@@ -258,7 +252,7 @@ lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
 
 /-- The action is additive in the module argument. -/
 @[simp]
-lemma smul_add (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
+lemma smul_add (t : 𝕋 Δ H R) (m₁ m₂ : HeckeCoset Δ ⊥ H →₀ R) :
     t • (m₁ + m₂) = t • m₁ + t • m₂ := by
   classical
   simp only [smul_eq_sum]
@@ -270,13 +264,13 @@ lemma smul_add (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
 
 /-- The zero element of the Hecke ring acts as zero. -/
 @[simp]
-lemma zero_smul (m : HeckeLeftCoset Δ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
+lemma zero_smul (m : HeckeCoset Δ ⊥ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
   rw [smul_eq_sum]
   exact Finsupp.sum_zero_index
 
 /-- Every Hecke-ring element acts as zero on zero. -/
 @[simp]
-lemma smul_zero (t : 𝕋 Δ H R) : t • (0 : HeckeLeftCoset Δ H →₀ R) = 0 := by
+lemma smul_zero (t : 𝕋 Δ H R) : t • (0 : HeckeCoset Δ ⊥ H →₀ R) = 0 := by
   rw [smul_eq_sum]
   simp only [Finsupp.sum_zero_index]
   exact Finsupp.sum_fun_zero t
@@ -285,7 +279,7 @@ end HeckeLeftCosetModule
 
 namespace HeckeLeftCosetModule
 
-open HeckeLeftCoset
+open HeckeCoset
 
 open scoped HeckeCosetModule
 
@@ -294,36 +288,36 @@ variable [IsHeckeTriple Δ H H] {R : Type*} [NonAssocSemiring R]
 /-- Reading off a coefficient of the action on the identity basis element: at any member of
 the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/
 private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
-    {q : HeckeLeftCoset Δ H}
-    (hq : q ∈ smulOrbit H D.rep (1 : HeckeLeftCoset Δ H).rep) :
-    (t • (Finsupp.single 1 1 : HeckeLeftCoset Δ H →₀ R)) q = t D := by
+    {q : HeckeCoset Δ ⊥ H}
+    (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :
+    (t • (Finsupp.single 1 1 : HeckeCoset Δ ⊥ H →₀ R)) q = t D := by
   classical
   have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
-      (Finsupp.single (1 : HeckeLeftCoset Δ H) (1 : R)).sum (fun q' b₂ ↦
+      (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
         ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
-      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep, Finsupp.single i b₁ := by
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ := by
     intro D' b₁
     rw [Finsupp.sum_single_index (by simp)]
     simp
   have hsum : (t.sum fun D' b₁ ↦
-        (Finsupp.single (1 : HeckeLeftCoset Δ H) (1 : R)).sum fun q' b₂ ↦
+        (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum fun q' b₂ ↦
           ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
       t.sum fun D' b₁ ↦
-        ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep, Finsupp.single i b₁ :=
+        ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ :=
     Finsupp.sum_congr fun D' _ ↦ hinner D' (t D')
   rw [smul_eq_sum, hsum]
   simp only [Finsupp.sum, Finsupp.finsetSum_apply]
   have hzero : ∀ D' ∈ t.support, D' ≠ D →
-      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep,
-        (Finsupp.single i (t D') : HeckeLeftCoset Δ H →₀ R) q = 0 := by
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep,
+        (Finsupp.single i (t D') : HeckeCoset Δ ⊥ H →₀ R) q = 0 := by
     intro D' _ hne
     refine Finset.sum_eq_zero fun i hi ↦ Finsupp.single_apply_eq_zero.mpr fun heq ↦ ?_
     have hne' : HeckeCoset.mk H H D'.rep ≠ HeckeCoset.mk H H D.rep := by
       simpa [HeckeCoset.mk_rep] using hne
     exact absurd hq (Finset.disjoint_left.mp (smulOrbit_disjoint _ hne') (heq ▸ hi))
   have hread : ∀ b : R,
-      ∑ i ∈ smulOrbit H D.rep (1 : HeckeLeftCoset Δ H).rep,
-        (Finsupp.single i b : HeckeLeftCoset Δ H →₀ R) q = b := by
+      ∑ i ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep,
+        (Finsupp.single i b : HeckeCoset Δ ⊥ H →₀ R) q = b := by
     intro b
     rw [Finset.sum_eq_single_of_mem q hq fun i _ hne ↦
       Finsupp.single_apply_eq_zero.mpr fun heq ↦ absurd heq.symm hne]
@@ -333,17 +327,17 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
 
 /-- The action of the Hecke ring on the module of left cosets is faithful. -/
 lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
-    (h : ∀ m : HeckeLeftCoset Δ H →₀ R, t₁ • m = t₂ • m) : t₁ = t₂ := by
+    (h : ∀ m : HeckeCoset Δ ⊥ H →₀ R, t₁ • m = t₂ • m) : t₁ = t₂ := by
   classical
   refine Finsupp.ext fun D ↦ ?_
-  obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeLeftCoset Δ H).rep
+  obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeCoset Δ ⊥ H).rep
   have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
   rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
 
 /-- The scalar operations of the Hecke ring on the left-coset module are faithful, as an
 instance. -/
 noncomputable instance instFaithfulSMul :
-    FaithfulSMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R) where
+    FaithfulSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
   eq_of_smul_eq_smul := eq_of_smul_eq_smul
 
 end HeckeLeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -155,6 +155,48 @@ lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : mk ⊥ H β₁ = mk ⊥ H
   rw [mul_inv_rev, inv_inv]
   group
 
+private lemma smulOrbit_subset_left {g₁ g₂ β : Δ}
+    (h : (g₂ : G) ∈ doubleCoset (g₁ : G) (H : Set G) H) :
+    smulOrbit H g₂ β ⊆ smulOrbit H g₁ β := by
+  classical
+  intro x hx
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx ⊢
+  obtain ⟨i, hi⟩ := hx
+  obtain ⟨h₁, hh₁, h₂, hh₂, hg₂⟩ := mem_doubleCoset.mp h
+  -- abstract the representative coercion: `i`'s type depends on `g₂`, so rewriting `g₂`
+  -- under `i.out` would produce a type-incorrect motive
+  set σ : G := ((i.out : H) : G) with hσ
+  set j : DecompQuotient H H (g₁ : G) :=
+    QuotientGroup.mk ((i.out : H) * ⟨h₁, hh₁⟩) with hj
+  obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (g₁ : G) • H).subgroupOf H) ((i.out : H) * ⟨h₁, hh₁⟩)
+  have hout : ((j.out : H) : G) = σ * h₁ * n := by
+    rw [hj, hσ]
+    simpa [Subgroup.coe_mul, mul_assoc] using congrArg (Subtype.val : H → G) hn
+  refine ⟨j, ?_⟩
+  rw [← hi]
+  refine mk_bot_eq_mk_bot.mpr ?_
+  -- as in `smulOrbit_subset`, `mk_bot_eq_mk_bot` unfolds to the double-coset setoid
+  -- through the `Δ`-subtype coercions, which no rewriting lemma states
+  change ((β : G) * ((j.out : H) : G) * (g₁ : G))⁻¹ * ((β : G) * σ * (g₂ : G)) ∈ H
+  have key : ((β : G) * ((j.out : H) : G) * (g₁ : G))⁻¹ * ((β : G) * σ * (g₂ : G)) =
+      ((g₁ : G)⁻¹ * (n : G)⁻¹ * g₁) * h₂ := by
+    rw [hout, hg₂]
+    group
+  rw [key]
+  exact H.mul_mem
+    (by simpa [mul_assoc] using H.inv_mem (conj_mem_of_stabilizer (g₁ : G) n)) hh₂
+
+/-- The orbit is invariant in the acting double-coset representative: representatives of
+the same double coset produce the same orbit. -/
+lemma smulOrbit_congr_left (β : Δ) {g₁ g₂ : Δ}
+    (h : HeckeCoset.mk H H g₁ = HeckeCoset.mk H H g₂) :
+    smulOrbit H g₁ β = smulOrbit H g₂ β := by
+  have hset := HeckeCoset.eq_iff.mp h
+  exact Finset.Subset.antisymm
+    (smulOrbit_subset_left (hset ▸ mem_doubleCoset_self H H (g₁ : G)))
+    (smulOrbit_subset_left (hset.symm ▸ mem_doubleCoset_self H H (g₂ : G)))
+
 open scoped Pointwise in
 private lemma smulOrbit_map_injective (g β : Δ) :
     Function.Injective fun i : DecompQuotient H H (g : G) ↦

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -302,12 +302,12 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b 
     HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
     Finsupp.sum_single_index (by simp)]
 
-/-- The action is additive in the Hecke-ring argument. -/
+/-- The action is additive in the (opposite) Hecke-ring argument. -/
 @[simp]
-lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
-    MulOpposite.op (t₁ + t₂) • m = MulOpposite.op t₁ • m + MulOpposite.op t₂ • m := by
+lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →₀ R) :
+    (t₁ + t₂) • m = t₁ • m + t₂ • m := by
   classical
-  simp only [smul_eq_sum]
+  simp only [smul_def, MulOpposite.unop_add]
   refine Finsupp.sum_add_index' (fun D ↦ ?_) fun D b₁ b₂ ↦ ?_
   · refine (Finsupp.sum_congr (g2 := fun _ _ ↦ 0) fun q _ ↦ ?_).trans
       (Finsupp.sum_fun_zero m)

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -337,6 +337,13 @@ lemma smul_zero (t : 𝕋 Δ H R) : t • (0 : HeckeCoset Δ ⊥ H →₀ R) = 0
   simp only [Finsupp.sum_zero_index]
   exact Finsupp.sum_fun_zero t
 
+/-- The scalar operations distribute over the module's addition, packaged as the
+`DistribSMul` typeclass (the strongest action class available before the compatibility
+law with the convolution product). -/
+noncomputable instance : DistribSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
+  smul_zero := smul_zero
+  smul_add := smul_add
+
 end HeckeLeftCosetModule
 
 namespace HeckeLeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Basic
+public import TauCeti.NumberTheory.HeckeRing.Basic
 import Mathlib.Tactic.Group
 
 /-!
@@ -71,19 +71,9 @@ an element of `H` on the right: `⊥β₁H = ⊥β₂H ↔ β₁H = β₂H`. Thi
 which the double-coset quotient serves as the left-coset quotient. -/
 lemma mk_bot_eq_mk_bot {β₁ β₂ : Δ} :
     mk ⊥ H β₁ = mk ⊥ H β₂ ↔ ((β₁ : G))⁻¹ * (β₂ : G) ∈ H := by
-  rw [eq_iff]
-  constructor
-  · intro h
-    have hmem : (β₂ : G) ∈ doubleCoset (β₁ : G) ((⊥ : Subgroup G) : Set G) H :=
-      h ▸ mem_doubleCoset_self _ _ _
-    obtain ⟨h₁, hh₁, h₂, hh₂, heq⟩ := mem_doubleCoset.mp hmem
-    obtain rfl : h₁ = 1 := hh₁
-    rw [heq]
-    simpa using hh₂
-  · intro h
-    exact doubleCoset_eq_of_mem (mem_doubleCoset.mpr
-      ⟨1, Subgroup.mem_bot.mpr rfl, (β₂ : G)⁻¹ * (β₁ : G),
-        by simpa using H.inv_mem h, by group⟩)
+  rw [eq_iff, ← QuotientGroup.leftRel_apply, ← DoubleCoset.bot_rel_eq_leftRel H]
+  exact (Setoid.ker_def
+    (f := fun x : G ↦ doubleCoset x (((⊥ : Subgroup G) : Set G)) ((H : Set G)))).symm
 
 /-- The representative of the class of `β` differs from `β` by an element of `H`. -/
 lemma inv_rep_mul_mem (β : Δ) : (((mk ⊥ H β : HeckeCoset Δ ⊥ H).rep : G))⁻¹ * (β : G) ∈ H :=

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -6,7 +6,6 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Basic
-import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Tactic.Group
 
 /-!

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -42,7 +42,7 @@ Mathlib stack.
 
 * `HeckeCoset.smulOrbit_congr`, `HeckeCoset.smulOrbit_disjoint`: the orbit depends
   only on the left coset, and orbits of distinct double cosets are disjoint.
-* `HeckeLeftCosetModule.instFaithfulSMul`: the action of the (opposite) Hecke ring on the
+* `LeftCosetModule.instFaithfulSMul`: the action of the (opposite) Hecke ring on the
   module of left cosets is faithful.
 -/
 
@@ -274,7 +274,7 @@ noncomputable abbrev LeftCosetModule.single {Δ : Submonoid G} {H : Subgroup G} 
     (q : HeckeCoset Δ ⊥ H) (b : R) : LeftCosetModule Δ H R :=
   Finsupp.single q b
 
-namespace HeckeLeftCosetModule
+namespace LeftCosetModule
 
 open HeckeCoset
 
@@ -288,7 +288,7 @@ the cosets `βσᵢgH` by **right** multiplication, this is a right action — e
 Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`: Shimura's
 compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
 ring. -/
-noncomputable instance instSMulHeckeLeftCosetModule :
+noncomputable instance instSMulLeftCosetModule :
     SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
     ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁)
@@ -359,9 +359,9 @@ noncomputable instance smulWithZero :
     simp only [MulOpposite.unop_zero]
     exact Finsupp.sum_zero_index
 
-end HeckeLeftCosetModule
+end LeftCosetModule
 
-namespace HeckeLeftCosetModule
+namespace LeftCosetModule
 
 open HeckeCoset
 
@@ -427,4 +427,4 @@ noncomputable instance instFaithfulSMul :
     MulOpposite.unop_injective <| eq_of_smul_eq_smul fun m ↦ by
       simpa only [MulOpposite.op_unop] using h m
 
-end HeckeLeftCosetModule
+end LeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -12,7 +12,7 @@ import Mathlib.Tactic.Group
 # Hecke rings: the module of left cosets
 
 The scalar operations underlying the natural representation of the Hecke ring, following
-[Shimura][shimura1971], §3.1: on the free module `HeckeCoset Δ ⊥ H →₀ R` over the left
+[Shimura][shimura1971], §3.1: on the free module `LeftCosetModule Δ H R` over the left
 cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
 left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
@@ -35,7 +35,7 @@ Mathlib stack.
   the existing double-coset quotient serve as the left-coset quotient, with no new type.
 * `HeckeCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
   double coset representative.
-* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R)` instance — the right Hecke action in
+* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R)` instance — the right Hecke action in
   its opposite-ring encoding.
 
 ## Main results
@@ -261,6 +261,19 @@ end Orbit
 
 end HeckeCoset
 
+/-- The left-coset module: the free `R`-module on the left cosets `Δ/H` (the bottom-left
+Hecke cosets), the carrier of the natural representation of the Hecke ring. An `abbrev`
+of the underlying `Finsupp`, so the full `Finsupp` API applies transparently at every
+coefficient class — the stable named interface for the action below. -/
+abbrev LeftCosetModule (Δ : Submonoid G) (H : Subgroup G) (R : Type*) [Zero R] :=
+  HeckeCoset Δ ⊥ H →₀ R
+
+/-- The basis element `b • [βH]` of the left-coset module. -/
+noncomputable abbrev LeftCosetModule.single {Δ : Submonoid G} {H : Subgroup G} {R : Type*}
+    [Zero R]
+    (q : HeckeCoset Δ ⊥ H) (b : R) : LeftCosetModule Δ H R :=
+  Finsupp.single q b
+
 namespace HeckeLeftCosetModule
 
 open HeckeCoset
@@ -276,27 +289,27 @@ Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒ�
 compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
 ring. -/
 noncomputable instance instSMulHeckeLeftCosetModule :
-    SMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+    SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
     ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁)
 
 -- the defining formula for an opaque opposite-ring element; instance plumbing
-private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →₀ R) :
+private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
     t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The defining formula of the action. -/
-lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
+lemma smul_eq_sum (t : 𝕋 Δ H R) (m : LeftCosetModule Δ H R) :
     MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The action of a basis element of the Hecke ring on a basis element of the module. -/
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
     MulOpposite.op (HeckeCosetModule.single R D a) •
-        (Finsupp.single q b : HeckeCoset Δ ⊥ H →₀ R) =
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b * a) := by
+        LeftCosetModule.single q b =
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b * a) := by
   classical
   rw [smul_eq_sum,
     HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
@@ -304,7 +317,7 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b 
 
 /-- The action is additive in the (opposite) Hecke-ring argument. -/
 @[simp]
-lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →₀ R) :
+lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
     (t₁ + t₂) • m = t₁ • m + t₂ • m := by
   classical
   simp only [smul_def, MulOpposite.unop_add]
@@ -314,14 +327,15 @@ lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →
     exact Finset.sum_eq_zero fun i _ ↦ by simp
   · refine ((Finsupp.sum_congr fun q _ ↦ ?_).trans Finsupp.sum_add)
     rw [← Finset.sum_add_distrib]
-    exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
+    exact Finset.sum_congr rfl fun i _ ↦ by
+      simp only [LeftCosetModule.single, mul_add, Finsupp.single_add]
 
 /-- The scalar operations distribute over the module's addition, packaged as the
 `DistribSMul` typeclass (the strongest action class available before the compatibility
 law with the convolution product); the generic `smul_zero`/`smul_add` supersede
 ad-hoc laws. -/
 noncomputable instance distribSMul :
-    DistribSMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+    DistribSMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul_zero t := by
     rw [smul_def]
     simp only [Finsupp.sum_zero_index]
@@ -333,11 +347,12 @@ noncomputable instance distribSMul :
     refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
     · exact Finset.sum_eq_zero fun i _ ↦ by simp
     · rw [← Finset.sum_add_distrib]
-      exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
+      exact Finset.sum_congr rfl fun i _ ↦ by
+        simp only [LeftCosetModule.single, add_mul, Finsupp.single_add]
 
 /-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
 noncomputable instance smulWithZero :
-    SMulWithZero (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+    SMulWithZero (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul_zero := smul_zero
   zero_smul m := by
     rw [smul_def]
@@ -359,7 +374,7 @@ the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D
 private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
     {q : HeckeCoset Δ ⊥ H}
     (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :
-    (MulOpposite.op t • (Finsupp.single 1 1 : HeckeCoset Δ ⊥ H →₀ R)) q = t D := by
+    (MulOpposite.op t • LeftCosetModule.single 1 1) q = t D := by
   classical
   have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
       (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
@@ -378,7 +393,7 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
   simp only [Finsupp.sum, Finsupp.finsetSum_apply]
   have hzero : ∀ D' ∈ t.support, D' ≠ D →
       ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep,
-        (Finsupp.single i (t D') : HeckeCoset Δ ⊥ H →₀ R) q = 0 := by
+        (Finsupp.single i (t D') : LeftCosetModule Δ H R) q = 0 := by
     intro D' _ hne
     refine Finset.sum_eq_zero fun i hi ↦ Finsupp.single_apply_eq_zero.mpr fun heq ↦ ?_
     have hne' : HeckeCoset.mk H H D'.rep ≠ HeckeCoset.mk H H D.rep := by
@@ -386,7 +401,7 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
     exact absurd hq (Finset.disjoint_left.mp (smulOrbit_disjoint _ hne') (heq ▸ hi))
   have hread : ∀ b : R,
       ∑ i ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep,
-        (Finsupp.single i b : HeckeCoset Δ ⊥ H →₀ R) q = b := by
+        (Finsupp.single i b : LeftCosetModule Δ H R) q = b := by
     intro b
     rw [Finset.sum_eq_single_of_mem q hq fun i _ hne ↦
       Finsupp.single_apply_eq_zero.mpr fun heq ↦ absurd heq.symm hne]
@@ -396,18 +411,18 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
 
 /-- The action of the Hecke ring on the module of left cosets is faithful. -/
 lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
-    (h : ∀ m : HeckeCoset Δ ⊥ H →₀ R,
+    (h : ∀ m : LeftCosetModule Δ H R,
       MulOpposite.op t₁ • m = MulOpposite.op t₂ • m) : t₁ = t₂ := by
   classical
   refine Finsupp.ext fun D ↦ ?_
   obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeCoset Δ ⊥ H).rep
-  have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
+  have h1 := congrArg (fun m ↦ m q) (h (LeftCosetModule.single 1 1))
   rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
 
 /-- The scalar operations of the opposite Hecke ring on the left-coset module are
 faithful, as an instance. -/
 noncomputable instance instFaithfulSMul :
-    FaithfulSMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
+    FaithfulSMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   eq_of_smul_eq_smul {a b} h :=
     MulOpposite.unop_injective <| eq_of_smul_eq_smul fun m ↦ by
       simpa only [MulOpposite.op_unop] using h m

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -302,37 +302,30 @@ lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
     rw [← Finset.sum_add_distrib]
     exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
 
-/-- The action is additive in the module argument. -/
-@[simp]
-lemma smul_add (t : 𝕋 Δ H R) (m₁ m₂ : HeckeCoset Δ ⊥ H →₀ R) :
-    t • (m₁ + m₂) = t • m₁ + t • m₂ := by
-  classical
-  simp only [smul_eq_sum]
-  refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
-  refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
-  · exact Finset.sum_eq_zero fun i _ ↦ by simp
-  · rw [← Finset.sum_add_distrib]
-    exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
-
-/-- The zero element of the Hecke ring acts as zero. -/
-@[simp]
-lemma zero_smul (m : HeckeCoset Δ ⊥ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
-  rw [smul_eq_sum]
-  exact Finsupp.sum_zero_index
-
-/-- Every Hecke-ring element acts as zero on zero. -/
-@[simp]
-lemma smul_zero (t : 𝕋 Δ H R) : t • (0 : HeckeCoset Δ ⊥ H →₀ R) = 0 := by
-  rw [smul_eq_sum]
-  simp only [Finsupp.sum_zero_index]
-  exact Finsupp.sum_fun_zero t
-
 /-- The scalar operations distribute over the module's addition, packaged as the
 `DistribSMul` typeclass (the strongest action class available before the compatibility
-law with the convolution product). -/
-noncomputable instance : DistribSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
+law with the convolution product); the generic `smul_zero`/`smul_add` supersede
+ad-hoc laws. -/
+noncomputable instance distribSMul : DistribSMul (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
+  smul_zero t := by
+    rw [smul_eq_sum]
+    simp only [Finsupp.sum_zero_index]
+    exact Finsupp.sum_fun_zero t
+  smul_add t m₁ m₂ := by
+    classical
+    simp only [smul_eq_sum]
+    refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
+    refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
+    · exact Finset.sum_eq_zero fun i _ ↦ by simp
+    · rw [← Finset.sum_add_distrib]
+      exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
+
+/-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
+noncomputable instance smulWithZero : SMulWithZero (𝕋 Δ H R) (HeckeCoset Δ ⊥ H →₀ R) where
   smul_zero := smul_zero
-  smul_add := smul_add
+  zero_smul m := by
+    rw [smul_eq_sum]
+    exact Finsupp.sum_zero_index
 
 end HeckeLeftCosetModule
 

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -105,6 +105,7 @@ lemma smulOrbit_eq_image (g β : Δ) :
 open Classical in
 /-- Membership in the orbit: the left cosets of the products `β · σᵢ · g` over the
 decomposition representatives. -/
+@[simp]
 lemma mem_smulOrbit {g β : Δ} {x : HeckeCoset Δ ⊥ H} :
     x ∈ smulOrbit H g β ↔ ∃ i : DecompQuotient H H (g : G),
       mk ⊥ H ⟨(β : G) * i.out * g,

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -155,6 +155,32 @@ lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : (mk β₁ : HeckeLeftCose
   rw [mul_inv_rev, inv_inv]
   group
 
+open scoped Pointwise in
+private lemma smulOrbit_map_injective (g β : Δ) :
+    Function.Injective fun i : DecompQuotient H H (g : G) ↦
+      (mk ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ :
+        HeckeLeftCoset Δ H) := by
+  intro i₁ i₂ heq
+  have hmem : ((β : G) * ((i₁.out : H) : G) * (g : G))⁻¹ *
+      ((β : G) * ((i₂.out : H) : G) * (g : G)) ∈ H := mk_eq_mk.mp heq
+  have hcoset : ((((i₁.out : H) : G) * (g : G) : G) : G ⧸ H) =
+      ((((i₂.out : H) : G) * (g : G) : G) : G ⧸ H) := by
+    rw [QuotientGroup.eq]
+    have hshape : ((β : G) * ((i₁.out : H) : G) * (g : G))⁻¹ *
+        ((β : G) * ((i₂.out : H) : G) * (g : G)) =
+        (((i₁.out : H) : G) * g)⁻¹ * (((i₂.out : H) : G) * g) := by group
+    exact hshape ▸ hmem
+  exact mk_out_mul_injective H H (g : G) hcoset
+
+/-- The orbit of a left coset under `g` has exactly as many elements as the decomposition
+`HgH = ⊔ᵢ σᵢgH`: the map `i ↦ βσᵢgH` is injective. -/
+lemma smulOrbit_card (g β : Δ) :
+    (smulOrbit H g β).card = Fintype.card (DecompQuotient H H (g : G)) := by
+  classical
+  rw [smulOrbit, Finset.card_image_of_injective _ (smulOrbit_map_injective g β),
+    Finset.card_univ]
+
 /-- Orbits of representatives of distinct double cosets on a common left coset are
 disjoint. -/
 lemma smulOrbit_disjoint {g₁ g₂ : Δ} (β : Δ)

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -14,7 +14,7 @@ import Mathlib.Tactic.Group
 
 The scalar operations underlying the natural representation of the Hecke ring, following
 [Shimura][shimura1971], §3.1: on the free module `HeckeLeftCoset Δ H →₀ R` over the left
-cosets `H\Δ`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
+cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
 left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
 additive in both arguments and faithful. The action laws proper — compatibility with the
@@ -74,7 +74,7 @@ variable (Δ) in
 /-- The identity left coset `1H = H`. -/
 instance : One (HeckeLeftCoset Δ H) := ⟨mk ⟨1, Δ.one_mem⟩⟩
 
-lemma one_def : (1 : HeckeLeftCoset Δ H) = mk ⟨1, Δ.one_mem⟩ := rfl
+lemma one_def : (1 : HeckeLeftCoset Δ H) = mk ⟨1, Δ.one_mem⟩ := (rfl)
 
 /-- Two elements of `Δ` define the same left coset iff they differ by an element of `H` on
 the right. -/
@@ -140,6 +140,9 @@ private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
   refine ⟨j, ?_⟩
   rw [← hi]
   refine mk_eq_mk.mpr ?_
+  -- `mk_eq_mk` lands in the `leftRel`-comap relation of the setoid; its membership statement
+  -- coincides with the displayed `H`-membership only through the definitional unfolding of
+  -- `QuotientGroup.leftRel` and the `Δ`-subtype coercions, which no rewriting lemma states
   change ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ * ((β₁ : G) * ((i.out : H) : G) * g) ∈ H
   have key : ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ *
       ((β₁ : G) * ((i.out : H) : G) * g) = (g : G)⁻¹ * (n : G)⁻¹ * g := by
@@ -215,7 +218,7 @@ open HeckeLeftCoset
 
 open scoped HeckeCosetModule
 
-variable [IsHeckeTriple Δ H H] {R : Type*} [Semiring R]
+variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
 
 /-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
 a left coset by summing over its orbit, extended biadditively. -/
@@ -240,7 +243,8 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeLeftCoset Δ H) (a b 
     Finsupp.sum_single_index (by simp)]
 
 /-- The action is additive in the Hecke-ring argument. -/
-lemma add_smul' (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
+@[simp]
+lemma add_smul (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
     (t₁ + t₂) • m = t₁ • m + t₂ • m := by
   classical
   simp only [smul_eq_sum]
@@ -253,7 +257,8 @@ lemma add_smul' (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
     exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
 
 /-- The action is additive in the module argument. -/
-lemma smul_add' (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
+@[simp]
+lemma smul_add (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
     t • (m₁ + m₂) = t • m₁ + t • m₂ := by
   classical
   simp only [smul_eq_sum]
@@ -264,15 +269,27 @@ lemma smul_add' (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
     exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
 
 /-- The zero element of the Hecke ring acts as zero. -/
-lemma zero_smul' (m : HeckeLeftCoset Δ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
+@[simp]
+lemma zero_smul (m : HeckeLeftCoset Δ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
   rw [smul_eq_sum]
   exact Finsupp.sum_zero_index
 
 /-- Every Hecke-ring element acts as zero on zero. -/
-lemma smul_zero' (t : 𝕋 Δ H R) : t • (0 : HeckeLeftCoset Δ H →₀ R) = 0 := by
+@[simp]
+lemma smul_zero (t : 𝕋 Δ H R) : t • (0 : HeckeLeftCoset Δ H →₀ R) = 0 := by
   rw [smul_eq_sum]
   simp only [Finsupp.sum_zero_index]
   exact Finsupp.sum_fun_zero t
+
+end HeckeLeftCosetModule
+
+namespace HeckeLeftCosetModule
+
+open HeckeLeftCoset
+
+open scoped HeckeCosetModule
+
+variable [IsHeckeTriple Δ H H] {R : Type*} [NonAssocSemiring R]
 
 /-- Reading off a coefficient of the action on the identity basis element: at any member of
 the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -63,7 +63,7 @@ namespace HeckeCoset
 
 variable (Δ) in
 /-- The identity left coset `1H = H` in the bottom-left specialization. -/
-instance : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
+instance instOneBot : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
 
 lemma bot_one_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
 

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -106,6 +106,14 @@ noncomputable def smulOrbit (H : Subgroup G) [IsHeckeTriple Δ H H] (g β : Δ) 
       Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩
 
 open Classical in
+/-- The orbit as an explicit image: the defining equation, exported for consumers that
+count over the enumeration. -/
+lemma smulOrbit_eq_image (g β : Δ) :
+    smulOrbit H g β = Finset.univ.image fun i : DecompQuotient H H (g : G) ↦
+      mk ⊥ H ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ := (rfl)
+
+open Classical in
 /-- Membership in the orbit: the left cosets of the products `β · σᵢ · g` over the
 decomposition representatives. -/
 lemma mem_smulOrbit {g β : Δ} {x : HeckeCoset Δ ⊥ H} :
@@ -209,7 +217,9 @@ lemma smulOrbit_congr_left (β : Δ) {g₁ g₂ : Δ}
     (smulOrbit_subset_left (hset.symm ▸ mem_doubleCoset_self H H (g₂ : G)))
 
 open scoped Pointwise in
-private lemma smulOrbit_map_injective (g β : Δ) :
+/-- The orbit enumeration is injective: distinct decomposition classes give distinct left
+cosets. -/
+lemma smulOrbit_map_injective (g β : Δ) :
     Function.Injective fun i : DecompQuotient H H (g : G) ↦
       (mk ⊥ H ⟨(β : G) * i.out * g,
         Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ :

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -118,8 +118,10 @@ lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
   classical
   exact (Finset.univ_nonempty).image _
 
-/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`. -/
-private lemma conj_mem_of_stabilizer (g : G)
+/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
+element of the stabilizer conjugates into `H` under `g`. Used by every orbit argument that
+replaces a decomposition representative by its canonical `out`. -/
+lemma conj_mem_of_stabilizer (g : G)
     (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
   have hn := n.2
   rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -15,7 +15,7 @@ The scalar operations underlying the natural representation of the Hecke ring, f
 [Shimura][shimura1971], §3.1: on the free module `LeftCosetModule Δ H R` over the left
 cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
-left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
+left-coset presentation, the orbit Finsets, and the scalar multiplication, and proves it is
 additive in both arguments and faithful. Since `HgH` sends `βH` to `Σᵢ βσᵢgH` by right
 multiplication, this is a **right** action, encoded as a left action of the opposite ring
 `(𝕋 Δ H R)ᵐᵒᵖ` per Mathlib convention: Shimura's compatibility law

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -12,12 +12,15 @@ import Mathlib.Tactic.Group
 /-!
 # Hecke rings: the module of left cosets
 
-The natural representation of the Hecke ring, following [Shimura][shimura1971], §3.1: the
-free module `HeckeLeftCoset Δ H →₀ R` on the left cosets `H\Δ` carries an action of
-`𝕋 Δ H R`, with a double coset `HgH = ⊔ᵢ σᵢgH` acting on a left coset `βH` by
-`βH ↦ Σᵢ βσᵢgH`. This file constructs the left-coset type, the orbit Finsets, the action,
-and proves the action is faithful — the input for the degree homomorphism of the following
-file.
+The scalar operations underlying the natural representation of the Hecke ring, following
+[Shimura][shimura1971], §3.1: on the free module `HeckeLeftCoset Δ H →₀ R` over the left
+cosets `H\Δ`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
+`HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
+left-coset type, the orbit Finsets, and the scalar multiplication, and proves it is
+additive in both arguments and faithful. The action laws proper — compatibility with the
+convolution product and its identity, which upgrade these operations to a module structure —
+are Shimura's Proposition 3.2 and are established together with the degree homomorphism in
+the follow-up development.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`HeckeRIngs/AbstractHeckeRing/Module.lean`,
@@ -55,8 +58,8 @@ abbrev HeckeLeftCoset.setoid (Δ : Submonoid G) (H : Subgroup G) : Setoid Δ :=
   (QuotientGroup.leftRel H).comap Subtype.val
 
 /-- A Hecke left coset: an equivalence class of `Δ`-elements under `βH = β'H`. This is the
-basis type for the natural representation of the Hecke ring `𝕋 Δ H R` on the free module
-`HeckeLeftCoset Δ H →₀ R`. -/
+basis type for the free module `HeckeLeftCoset Δ H →₀ R`, on which the scalar operations
+of the Hecke ring `𝕋 Δ H R` are defined. -/
 def HeckeLeftCoset (Δ : Submonoid G) (H : Subgroup G) := Quotient (HeckeLeftCoset.setoid Δ H)
 
 namespace HeckeLeftCoset
@@ -320,7 +323,8 @@ lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
   have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
   rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
 
-/-- The faithfulness of the natural representation, as an instance. -/
+/-- The scalar operations of the Hecke ring on the left-coset module are faithful, as an
+instance. -/
 noncomputable instance instFaithfulSMul :
     FaithfulSMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R) where
   eq_of_smul_eq_smul := eq_of_smul_eq_smul

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -1,0 +1,302 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Algebra.BigOperators.Finsupp.Basic
+public import TauCeti.NumberTheory.HeckeRing.Multiplication
+import Mathlib.Tactic.Group
+
+/-!
+# Hecke rings: the module of left cosets
+
+The natural representation of the Hecke ring, following [Shimura][shimura1971], §3.1: the
+free module `HeckeLeftCoset Δ H →₀ R` on the left cosets `H\Δ` carries an action of
+`𝕋 Δ H R`, with a double coset `HgH = ⊔ᵢ σᵢgH` acting on a left coset `βH` by
+`βH ↦ Σᵢ βσᵢgH`. This file constructs the left-coset type, the orbit Finsets, the action,
+and proves the action is faithful — the input for the degree homomorphism of the following
+file.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`HeckeRIngs/AbstractHeckeRing/Module.lean`,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), per the
+ModularForms roadmap's dependency policy, rebuilt on the left-coset quotient of the vendored
+Mathlib stack.
+
+## Main definitions
+
+* `HeckeLeftCoset Δ H`: the left cosets of `H` with a representative in `Δ` (the quotient of
+  `Δ` by the left-coset relation of `H`).
+* `HeckeLeftCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
+  double coset representative.
+* the `SMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R)` instance.
+
+## Main results
+
+* `HeckeLeftCoset.smulOrbit_congr`, `HeckeLeftCoset.smulOrbit_disjoint`: the orbit depends
+  only on the left coset, and orbits of distinct double cosets are disjoint.
+* `HeckeLeftCosetModule.instFaithfulSMul`: the action of the Hecke ring on the module of
+  left cosets is faithful.
+-/
+
+public section
+
+open DoubleCoset Subgroup
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G}
+
+/-- The setoid on `Δ` identifying elements in the same left coset of `H`, pulled back from
+`QuotientGroup.leftRel` along the inclusion `Δ ↪ G`. An `abbrev` for the same reason as
+`HeckeCoset.setoid`: `H` cannot be inferred from `Δ`, and a global instance would create a
+`Setoid` diamond on `↥Δ` with the double-coset setoid. -/
+abbrev HeckeLeftCoset.setoid (Δ : Submonoid G) (H : Subgroup G) : Setoid Δ :=
+  (QuotientGroup.leftRel H).comap Subtype.val
+
+/-- A Hecke left coset: an equivalence class of `Δ`-elements under `βH = β'H`. This is the
+basis type for the natural representation of the Hecke ring `𝕋 Δ H R` on the free module
+`HeckeLeftCoset Δ H →₀ R`. -/
+def HeckeLeftCoset (Δ : Submonoid G) (H : Subgroup G) := Quotient (HeckeLeftCoset.setoid Δ H)
+
+namespace HeckeLeftCoset
+
+/-- The left coset `βH` of an element `β : Δ`. -/
+def mk (β : Δ) : HeckeLeftCoset Δ H := Quotient.mk (setoid Δ H) β
+
+variable (Δ) in
+instance : Inhabited (HeckeLeftCoset Δ H) := ⟨mk ⟨1, Δ.one_mem⟩⟩
+
+variable (Δ) in
+/-- The identity left coset `1H = H`. -/
+instance : One (HeckeLeftCoset Δ H) := ⟨mk ⟨1, Δ.one_mem⟩⟩
+
+lemma one_def : (1 : HeckeLeftCoset Δ H) = mk ⟨1, Δ.one_mem⟩ := rfl
+
+/-- Two elements of `Δ` define the same left coset iff they differ by an element of `H` on
+the right. -/
+lemma mk_eq_mk {β₁ β₂ : Δ} : (mk β₁ : HeckeLeftCoset Δ H) = mk β₂ ↔
+    ((β₁ : G))⁻¹ * (β₂ : G) ∈ H :=
+  Quotient.eq''.trans QuotientGroup.leftRel_apply
+
+/-- A representative in `Δ` of a left coset (via `Quotient.out`). -/
+noncomputable def rep (q : HeckeLeftCoset Δ H) : Δ := Quotient.out q
+
+@[simp] lemma mk_rep (q : HeckeLeftCoset Δ H) : mk q.rep = q := Quotient.out_eq q
+
+/-- The representative of the class of `β` differs from `β` by an element of `H`. -/
+lemma inv_rep_mul_mem (β : Δ) : (((mk β : HeckeLeftCoset Δ H).rep : G))⁻¹ * (β : G) ∈ H :=
+  mk_eq_mk.mp (mk_rep (mk β))
+
+/-- Induction: to prove something for all left cosets, prove it for `mk β`. -/
+protected lemma induction {motive : HeckeLeftCoset Δ H → Prop}
+    (h : ∀ β : Δ, motive (mk β)) : ∀ q, motive q :=
+  Quotient.ind h
+
+section Orbit
+
+open scoped Pointwise
+
+variable [IsHeckeTriple Δ H H]
+
+open Classical in
+/-- The orbit of a left coset representative `β` under a double coset representative `g`:
+the left cosets `βσᵢgH` over the decomposition `HgH = ⊔ᵢ σᵢgH`. -/
+noncomputable def smulOrbit (H : Subgroup G) [IsHeckeTriple Δ H H] (g β : Δ) :
+    Finset (HeckeLeftCoset Δ H) :=
+  Finset.univ.image fun i : DecompQuotient H H (g : G) ↦
+    mk ⟨(β : G) * i.out * g,
+      Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩
+
+lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
+  classical
+  exact (Finset.univ_nonempty).image _
+
+/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`. -/
+private lemma conj_mem_of_stabilizer (g : G)
+    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
+  have hn := n.2
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def] at hn
+  simpa [ConjAct.ofConjAct_toConjAct] using hn
+
+private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
+    (hβ : (β₂ : G) = (β₁ : G) * k) : smulOrbit H g β₁ ⊆ smulOrbit H g β₂ := by
+  classical
+  intro x hx
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx ⊢
+  obtain ⟨i, hi⟩ := hx
+  set j : DecompQuotient H H (g : G) :=
+    QuotientGroup.mk ⟨k⁻¹ * i.out, H.mul_mem (H.inv_mem hk) i.out.2⟩ with hj
+  obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (g : G) • H).subgroupOf H)
+    (⟨k⁻¹ * i.out, H.mul_mem (H.inv_mem hk) i.out.2⟩ : H)
+  have hout : ((j.out : H) : G) = k⁻¹ * (i.out : G) * n := by
+    rw [hj]
+    simpa [Subgroup.coe_mul, mul_assoc] using congrArg (Subtype.val : H → G) hn
+  refine ⟨j, ?_⟩
+  rw [← hi]
+  refine mk_eq_mk.mpr ?_
+  change ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ * ((β₁ : G) * ((i.out : H) : G) * g) ∈ H
+  have key : ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ *
+      ((β₁ : G) * ((i.out : H) : G) * g) = (g : G)⁻¹ * (n : G)⁻¹ * g := by
+    rw [hout, hβ]
+    group
+  rw [key]
+  simpa [mul_assoc] using H.inv_mem (conj_mem_of_stabilizer (g : G) n)
+
+/-- The orbit depends on `β` only through its left coset. -/
+lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : (mk β₁ : HeckeLeftCoset Δ H) = mk β₂) :
+    smulOrbit H g β₁ = smulOrbit H g β₂ := by
+  have hk := mk_eq_mk.mp h
+  refine Finset.Subset.antisymm
+    (smulOrbit_subset hk (by group))
+    (smulOrbit_subset (H.inv_mem hk) ?_)
+  rw [mul_inv_rev, inv_inv]
+  group
+
+/-- Orbits of representatives of distinct double cosets on a common left coset are
+disjoint. -/
+lemma smulOrbit_disjoint {g₁ g₂ : Δ} (β : Δ)
+    (hne : HeckeCoset.mk H H g₁ ≠ HeckeCoset.mk H H g₂) :
+    Disjoint (smulOrbit H g₁ β) (smulOrbit H g₂ β) := by
+  classical
+  rw [Finset.disjoint_left]
+  intro x hx₁ hx₂
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx₁ hx₂
+  obtain ⟨i₁, hi₁⟩ := hx₁
+  obtain ⟨i₂, hi₂⟩ := hx₂
+  have hmem : ((β : G) * ((i₁.out : H) : G) * (g₁ : G))⁻¹ *
+      ((β : G) * ((i₂.out : H) : G) * (g₂ : G)) ∈ H :=
+    mk_eq_mk.mp (hi₁.trans hi₂.symm)
+  refine hne (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
+    ⟨((i₁.out : H) : G)⁻¹ * ((i₂.out : H) : G),
+      H.mul_mem (H.inv_mem i₁.out.2) i₂.out.2,
+      (((β : G) * ((i₁.out : H) : G) * (g₁ : G))⁻¹ *
+        ((β : G) * ((i₂.out : H) : G) * (g₂ : G)))⁻¹,
+      H.inv_mem hmem, by group⟩))
+
+end Orbit
+
+end HeckeLeftCoset
+
+namespace HeckeLeftCosetModule
+
+open HeckeLeftCoset
+
+open scoped HeckeCosetModule
+
+variable [IsHeckeTriple Δ H H] {R : Type*} [Semiring R]
+
+/-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
+a left coset by summing over its orbit, extended biadditively. -/
+noncomputable instance instSMulHeckeLeftCosetModule :
+    SMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R) where
+  smul t m := t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+    ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂)
+
+/-- The defining formula of the action. -/
+lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
+    t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
+  (rfl)
+
+/-- The action of a basis element of the Hecke ring on a basis element of the module. -/
+lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeLeftCoset Δ H) (a b : R) :
+    HeckeCosetModule.single R D a • (Finsupp.single q b : HeckeLeftCoset Δ H →₀ R) =
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (a * b) := by
+  classical
+  rw [smul_eq_sum,
+    HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
+    Finsupp.sum_single_index (by simp)]
+
+/-- The action is additive in the Hecke-ring argument. -/
+lemma add_smul' (t₁ t₂ : 𝕋 Δ H R) (m : HeckeLeftCoset Δ H →₀ R) :
+    (t₁ + t₂) • m = t₁ • m + t₂ • m := by
+  classical
+  simp only [smul_eq_sum]
+  refine Finsupp.sum_add_index' (fun D ↦ ?_) fun D b₁ b₂ ↦ ?_
+  · refine (Finsupp.sum_congr (g2 := fun _ _ ↦ 0) fun q _ ↦ ?_).trans
+      (Finsupp.sum_fun_zero m)
+    exact Finset.sum_eq_zero fun i _ ↦ by simp
+  · refine ((Finsupp.sum_congr fun q _ ↦ ?_).trans Finsupp.sum_add)
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
+
+/-- The action is additive in the module argument. -/
+lemma smul_add' (t : 𝕋 Δ H R) (m₁ m₂ : HeckeLeftCoset Δ H →₀ R) :
+    t • (m₁ + m₂) = t • m₁ + t • m₂ := by
+  classical
+  simp only [smul_eq_sum]
+  refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
+  refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
+  · exact Finset.sum_eq_zero fun i _ ↦ by simp
+  · rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
+
+/-- The zero element of the Hecke ring acts as zero. -/
+lemma zero_smul' (m : HeckeLeftCoset Δ H →₀ R) : (0 : 𝕋 Δ H R) • m = 0 := by
+  rw [smul_eq_sum]
+  exact Finsupp.sum_zero_index
+
+/-- Every Hecke-ring element acts as zero on zero. -/
+lemma smul_zero' (t : 𝕋 Δ H R) : t • (0 : HeckeLeftCoset Δ H →₀ R) = 0 := by
+  rw [smul_eq_sum]
+  simp only [Finsupp.sum_zero_index]
+  exact Finsupp.sum_fun_zero t
+
+/-- Reading off a coefficient of the action on the identity basis element: at any member of
+the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/
+private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
+    {q : HeckeLeftCoset Δ H}
+    (hq : q ∈ smulOrbit H D.rep (1 : HeckeLeftCoset Δ H).rep) :
+    (t • (Finsupp.single 1 1 : HeckeLeftCoset Δ H →₀ R)) q = t D := by
+  classical
+  have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
+      (Finsupp.single (1 : HeckeLeftCoset Δ H) (1 : R)).sum (fun q' b₂ ↦
+        ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep, Finsupp.single i b₁ := by
+    intro D' b₁
+    rw [Finsupp.sum_single_index (by simp)]
+    simp
+  have hsum : (t.sum fun D' b₁ ↦
+        (Finsupp.single (1 : HeckeLeftCoset Δ H) (1 : R)).sum fun q' b₂ ↦
+          ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
+      t.sum fun D' b₁ ↦
+        ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep, Finsupp.single i b₁ :=
+    Finsupp.sum_congr fun D' _ ↦ hinner D' (t D')
+  rw [smul_eq_sum, hsum]
+  simp only [Finsupp.sum, Finsupp.finsetSum_apply]
+  have hzero : ∀ D' ∈ t.support, D' ≠ D →
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeLeftCoset Δ H).rep,
+        (Finsupp.single i (t D') : HeckeLeftCoset Δ H →₀ R) q = 0 := by
+    intro D' _ hne
+    refine Finset.sum_eq_zero fun i hi ↦ Finsupp.single_apply_eq_zero.mpr fun heq ↦ ?_
+    have hne' : HeckeCoset.mk H H D'.rep ≠ HeckeCoset.mk H H D.rep := by
+      simpa [HeckeCoset.mk_rep] using hne
+    exact absurd hq (Finset.disjoint_left.mp (smulOrbit_disjoint _ hne') (heq ▸ hi))
+  have hread : ∀ b : R,
+      ∑ i ∈ smulOrbit H D.rep (1 : HeckeLeftCoset Δ H).rep,
+        (Finsupp.single i b : HeckeLeftCoset Δ H →₀ R) q = b := by
+    intro b
+    rw [Finset.sum_eq_single_of_mem q hq fun i _ hne ↦
+      Finsupp.single_apply_eq_zero.mpr fun heq ↦ absurd heq.symm hne]
+    simp
+  exact (Finset.sum_eq_single D hzero fun hD ↦
+    (hread (t D)).trans (Finsupp.notMem_support_iff.mp hD)).trans (hread (t D))
+
+/-- The action of the Hecke ring on the module of left cosets is faithful. -/
+lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
+    (h : ∀ m : HeckeLeftCoset Δ H →₀ R, t₁ • m = t₂ • m) : t₁ = t₂ := by
+  classical
+  refine Finsupp.ext fun D ↦ ?_
+  obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeLeftCoset Δ H).rep
+  have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
+  rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
+
+/-- The faithfulness of the natural representation, as an instance. -/
+noncomputable instance instFaithfulSMul :
+    FaithfulSMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R) where
+  eq_of_smul_eq_smul := eq_of_smul_eq_smul
+
+end HeckeLeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -5,8 +5,8 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Finsupp.Basic
-public import TauCeti.NumberTheory.HeckeRing.Multiplication
+public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Basic
+import Mathlib.Algebra.BigOperators.Finsupp.Basic
 import Mathlib.Tactic.Group
 
 /-!

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -271,7 +271,7 @@ variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
 
 /-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
 a left coset by summing over its orbit, extended biadditively. Since `HgH` sends `βH` to
-the cosets `βσᵢH` by **right** multiplication, this is a right action — encoded, per
+the cosets `βσᵢgH` by **right** multiplication, this is a right action — encoded, per
 Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`: Shimura's
 compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
 ring. -/

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -278,25 +278,25 @@ ring. -/
 noncomputable instance instSMulHeckeLeftCosetModule :
     SMul (𝕋 Δ H R)ᵐᵒᵖ (HeckeCoset Δ ⊥ H →₀ R) where
   smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-    ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂)
+    ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁)
 
 -- the defining formula for an opaque opposite-ring element; instance plumbing
 private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →₀ R) :
     t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The defining formula of the action. -/
 lemma smul_eq_sum (t : 𝕋 Δ H R) (m : HeckeCoset Δ ⊥ H →₀ R) :
     MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₁ * b₂) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The action of a basis element of the Hecke ring on a basis element of the module. -/
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
     MulOpposite.op (HeckeCosetModule.single R D a) •
         (Finsupp.single q b : HeckeCoset Δ ⊥ H →₀ R) =
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (a * b) := by
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b * a) := by
   classical
   rw [smul_eq_sum,
     HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
@@ -314,7 +314,7 @@ lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : HeckeCoset Δ ⊥ H →
     exact Finset.sum_eq_zero fun i _ ↦ by simp
   · refine ((Finsupp.sum_congr fun q _ ↦ ?_).trans Finsupp.sum_add)
     rw [← Finset.sum_add_distrib]
-    exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
+    exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
 
 /-- The scalar operations distribute over the module's addition, packaged as the
 `DistribSMul` typeclass (the strongest action class available before the compatibility
@@ -333,7 +333,7 @@ noncomputable instance distribSMul :
     refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
     · exact Finset.sum_eq_zero fun i _ ↦ by simp
     · rw [← Finset.sum_add_distrib]
-      exact Finset.sum_congr rfl fun i _ ↦ by rw [mul_add, Finsupp.single_add]
+      exact Finset.sum_congr rfl fun i _ ↦ by rw [add_mul, Finsupp.single_add]
 
 /-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
 noncomputable instance smulWithZero :
@@ -363,14 +363,14 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
   classical
   have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
       (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
-        ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
+        ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₂ * b₁)) =
       ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ := by
     intro D' b₁
     rw [Finsupp.sum_single_index (by simp)]
     simp
   have hsum : (t.sum fun D' b₁ ↦
         (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum fun q' b₂ ↦
-          ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₁ * b₂)) =
+          ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₂ * b₁)) =
       t.sum fun D' b₁ ↦
         ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ :=
     Finsupp.sum_congr fun D' _ ↦ hinner D' (t D')

--- a/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
@@ -46,26 +46,6 @@ namespace HeckeCosetModule
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
 
-section SingleWrapper
-
-variable (R : Type*) [Zero R]
-
-/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
-for `Finsupp` itself, this is the type-correct way to produce elements of
-`HeckeCosetModule Δ H₁ H₂ R`. Only `[Zero R]` is assumed, so consumers with coefficient
-assumptions below `Semiring` (the left-coset scalar operations) can use it. -/
-noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
-    HeckeCosetModule Δ H₁ H₂ R :=
-  Finsupp.single D b
-
-/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
-evaluates the summand at its point. -/
-lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
-    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
-  Finsupp.sum_single_index h
-
-end SingleWrapper
-
 variable (R : Type*) [Semiring R]
 
 open Classical in
@@ -117,11 +97,6 @@ noncomputable instance instMulHeckeRing {H : Subgroup G} [IsHeckeTriple Δ H H] 
 
 lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H R) :
     f * g = mul R f g := (rfl)
-
-@[grind =]
-lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
-    single R D b A = if D = A then b else 0 :=
-  Finsupp.single_apply
 
 lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
   Finsupp.smul_single_one D b

--- a/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
@@ -45,7 +45,28 @@ open scoped Pointwise
 namespace HeckeCosetModule
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
-  (R : Type*) [Semiring R]
+
+section SingleWrapper
+
+variable (R : Type*) [Zero R]
+
+/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
+for `Finsupp` itself, this is the type-correct way to produce elements of
+`HeckeCosetModule Δ H₁ H₂ R`. Only `[Zero R]` is assumed, so consumers with coefficient
+assumptions below `Semiring` (the left-coset scalar operations) can use it. -/
+noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
+    HeckeCosetModule Δ H₁ H₂ R :=
+  Finsupp.single D b
+
+/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
+evaluates the summand at its point. -/
+lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
+    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
+  Finsupp.sum_single_index h
+
+end SingleWrapper
+
+variable (R : Type*) [Semiring R]
 
 open Classical in
 /-- The structure constants of the Hecke product: `structureConstants H₁ H₂ H₃ R g₁ g₂` is the
@@ -97,13 +118,6 @@ noncomputable instance instMulHeckeRing {H : Subgroup G} [IsHeckeTriple Δ H H] 
 lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H R) :
     f * g = mul R f g := (rfl)
 
-/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
-for `Finsupp` itself, this is the type-correct way to produce elements of
-`HeckeCosetModule Δ H₁ H₂ R`. -/
-noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
-    HeckeCosetModule Δ H₁ H₂ R :=
-  Finsupp.single D b
-
 @[grind =]
 lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
     single R D b A = if D = A then b else 0 :=
@@ -123,12 +137,6 @@ lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
 lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
     single R D (b + c) = single R D b + single R D c :=
   Finsupp.single_add D b c
-
-/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
-evaluates the summand at its point. -/
-lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
-    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
-  Finsupp.sum_single_index h
 
 /-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` in
 its basis vocabulary `single`, in the same way that `MonoidAlgebra.induction_linear` restates

--- a/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
@@ -6,7 +6,6 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Algebra.BigOperators.Finsupp.Basic
-public import Mathlib.Data.Finsupp.SMul
 public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Support
 
 /-!
@@ -72,11 +71,6 @@ lemma support_structureConstants_subset [IsHeckeTriple Δ H₁ H₂]
       Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂) :=
   Finsupp.support_onFinset_subset
 
-/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
-module structure to the wrapper type. -/
-noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
-  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
-
 /-- The convolution product of Hecke coset modules, defined via the structure constants. The
 diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H R)` instance. -/
 noncomputable def mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
@@ -98,38 +92,14 @@ noncomputable instance instMulHeckeRing {H : Subgroup G} [IsHeckeTriple Δ H H] 
 lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H R) :
     f * g = mul R f g := (rfl)
 
-lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
-  Finsupp.smul_single_one D b
-
-@[simp]
-lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
-
-/-- `Finsupp.single_zero`, as a wrapper-level equation. -/
-@[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
-  Finsupp.single_zero D
-
-/-- `Finsupp.single_add`, as a wrapper-level equation. -/
-lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
-    single R D (b + c) = single R D b + single R D c :=
-  Finsupp.single_add D b c
-
-/-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` in
-its basis vocabulary `single`, in the same way that `MonoidAlgebra.induction_linear` restates
-it for `MonoidAlgebra`: to prove a property of all elements, prove it for `0`, for sums, and
-for basis elements. -/
-lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
-    (f : HeckeCosetModule Δ H₁ H₂ R) (h0 : p 0)
-    (hadd : ∀ f g : HeckeCosetModule Δ H₁ H₂ R, p f → p g → p (f + g))
-    (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
-  Finsupp.induction_linear f h0 hadd hsingle
-
 /-- The convolution product of two basis elements. -/
 lemma mul_single_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (D₁ : HeckeCoset Δ H₁ H₂) (D₂ : HeckeCoset Δ H₂ H₃) (a b : R) :
     mul R (single R D₁ a) (single R D₂ b) =
       a • b • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
-  rw [mul_eq_sum]
-  simp [single, Finsupp.sum_single_index]
+  rw [mul_eq_sum, sum_single_index, sum_single_index]
+  · simp
+  · rw [sum_single_index] <;> simp
 
 /-- The product of two basis elements of the Hecke ring. -/
 lemma single_mul_single {H : Subgroup G} [IsHeckeTriple Δ H H]

--- a/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Finsupp.Basic
 public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Support
 
 /-!

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
@@ -58,17 +58,6 @@ lemma subsingleton_decompQuotient_of_mem {Γ : Subgroup G} {g : G} (hg : g ∈ �
   subsingleton_decompQuotient
     (Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hg)).ge
 
-/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
-`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
-lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
-    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
-  intro i j hij
-  simp only [QuotientGroup.eq] at hij
-  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
-    Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
-      ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
-  simpa [mul_assoc] using hij
-
 /-- Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]): the number of pairs
 `(i, j)` of coset representatives such that `σᵢ g τⱼ h Γ₃ = d Γ₃`. The diagonal case
 `Γ₁ = Γ₂ = Γ₃` gives the structure constants of the Hecke ring.


### PR DESCRIPTION
The fourth tranche of the abstract Hecke-ring stack, on #1933's merged convolution semiring: **the natural representation** ([Shimura][shimura1971] §3.1). The left cosets `H\Δ` form the quotient type `HeckeLeftCoset Δ H` (mirroring `HeckeCoset`'s setoid-comap design, pulled back from `QuotientGroup.leftRel`), and the Hecke ring `𝕋 Δ H R` acts on the free module `HeckeLeftCoset Δ H →₀ R`: a double coset `HgH = ⊔ᵢ σᵢgH` sends a left coset `βH` to `Σᵢ βσᵢgH`.

* `HeckeLeftCoset Δ H` with `mk`/`rep`/`mk_eq_mk`/`one`/`induction`.
* `HeckeLeftCoset.smulOrbit H g β`: the orbit Finset, with `smulOrbit_congr` (the orbit depends only on the left coset — the out-representative wrinkle absorbed through the stabilizer conjugation) and `smulOrbit_disjoint` (orbits of distinct double cosets are disjoint, by translating a common member back to a double-coset equality).
* the `SMul (𝕋 Δ H R) (HeckeLeftCoset Δ H →₀ R)` instance with `smul_eq_sum`, `single_smul_single` (stated through #1933's `HeckeCosetModule.single` wrapper), biadditivity (`add_smul'`, `smul_add'`) and zero laws.
* **faithfulness** (`LeftCosetModule.instFaithfulSMul`): coefficients are recovered by evaluating the action on the identity basis element at any orbit member, using the orbit disjointness.

Ported from the AINTLIB `LeanModularForms` project (`HeckeRIngs/AbstractHeckeRing/Module.lean`), rebuilt on the left-coset quotient of the vendored Mathlib stack; there is no open mathlib4 PR for this layer (the open stack ends at mathlib4#41328), so the roadmap's AINTLIB fallback applies. Next tranche on this base: the degree homomorphism `deg : 𝕋 Δ H R →+* R` (Shimura Prop 3.3/3.4), whose multiplicativity is proved through this module.

### Roadmap target

**`TauCetiRoadmap/ModularForms/README.md`, § Layer 2** — the abstract Hecke-ring stack ("upstreamed from AINTLIB's `HeckeRIngs/AbstractHeckeRing/*`; Layer 2 consumes this"), continuing #1879 → #1933 → #1937.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
