### PR TITLE
fix: opt in to fork PR checkout in pr-profile

### DIFF
--- a/.github/workflows/pr-profile.yml
+++ b/.github/workflows/pr-profile.yml
@@ -148,6 +148,11 @@ jobs:
           ref: ${{ steps.pr.outputs.sha }}
           path: pr
           persist-credentials: false
+          # actions/checkout refuses to fetch fork PR code under
+          # pull_request_target unless this opt-in is set. Safe here for the
+          # same reasons as pr-build.yml: no credentials in the checkout, and
+          # the fork's code runs only under landrun below (offline, no token).
+          allow-unsafe-pr-checkout: true
 
       - name: Overlay PR TauCeti/ and root TauCeti.lean onto the trusted base (reject symlinks)
         if: ${{ steps.files.outputs.none != '1' }}


### PR DESCRIPTION
This PR sets `allow-unsafe-pr-checkout: true` on the untrusted PR-head checkout in `pr-profile.yml`, which GitHub's hardened `actions/checkout` now requires under `pull_request_target`. Without it the profile job aborts at the checkout step on every fork PR, so the advisory heartbeat comment has silently stopped appearing: of today's 54 `pull_request_target` runs, 53 failed, and the one success was a same-repo bot branch, where the guard does not fire.

The opt-in is safe here for the same reasons it is safe in `pr-build.yml` (https://github.com/TauCetiProject/TauCeti/pull/1075, "fix: opt in to fork PR checkout under the hardened actions/checkout"): the checkout carries no credentials (`persist-credentials: false`), the trusted `scripts/` never come from the PR, and the fork's sources are elaborated only under landrun, offline and with no token in reach.

This is a cherry-pick of `bf735f42`, written at the time `pr-build.yml` was fixed but stranded on `origin/heartbeat-profile` after that branch's feature commit was squash-merged as https://github.com/TauCetiProject/TauCeti/pull/1035 ("feat: advisory heartbeat profile comment for PRs").

🤖 Prepared with Claude Code
