### PR TITLE
feat: name the limiting form of Wolff's lemma

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -36,7 +36,12 @@ sides of the general estimates then mean:
 So the length–area inequality reads
 `∫⁻ ρ in Ioi 0, ℓ ρ ^ 2 / ρ ≤ 2 π * volume (f '' s)`, and Wolff's lemma reads: on every annulus,
 and for every `c` strictly above the average `2 π A / log (R / r)`, there is a radius with
-`ℓ ρ ^ 2 < c` — a threshold that falls without limit as the annulus is made longer.
+`ℓ ρ ^ 2 < c` — a threshold that falls without limit as the annulus is made longer. Letting it fall
+below an arbitrary `c ≠ 0`, which a finite Dirichlet integral allows, gives the form the crosscut
+estimates consume: `ℓ ρ < c` at some radius below every prescribed bound
+(`TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top`), equivalently `ℓ` has lower limit `0` at
+the centre (`TauCeti.liminf_circleImageLength_nhdsGT_eq_zero`). A *limit* is not available and is
+false in general; only some arbitrarily small radii carry a short circle.
 
 The genuinely holomorphic content added here is the **chord bound**
 `TauCeti.ofReal_dist_le_circleImageLength`, which is what makes `ℓ` a length: the fundamental
@@ -66,6 +71,11 @@ from these estimates in order to force the cluster set at `ζ` to degenerate to 
 * `TauCeti.exists_circleImageLength_sq_lt` and
   `TauCeti.exists_circleImageLength_sq_lt_of_volume_image` — **Wolff's lemma**: a radius with
   `ℓ ρ ^ 2 < c` exists in every annulus `r < ρ < R` on which `2 π A < c * log (R / r)`.
+* `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` — its limiting form, the one a crosscut
+  estimate consumes: for a finite Dirichlet integral, below every bound `R` there is a radius at
+  which `ℓ ρ` is smaller than any prescribed `c ≠ 0`.
+* `TauCeti.liminf_circleImageLength_nhdsGT_eq_zero` — the same statement as a lower limit at the
+  centre, which is the exact sense in which the method makes arcs short.
 
 Holomorphy is used in exactly two places: through `Conformal/Area.lean`, to replace the Dirichlet
 integral by the area of the image, and in the chord bound, where the fundamental theorem of calculus
@@ -92,7 +102,7 @@ public section
 
 namespace TauCeti
 
-open Complex MeasureTheory Metric Set
+open Complex MeasureTheory Metric Set Topology
 open scoped ENNReal Real
 
 variable {U s t : Set ℂ} {f : ℂ → ℂ} {ζ : ℂ}
@@ -236,6 +246,37 @@ theorem exists_circleImageLength_sq_lt_of_volume_image (hUo : IsOpen U)
     ∃ ρ ∈ Ioo r R, circleImageLength f s ζ ρ ^ 2 < c := by
   refine exists_circleImageLength_sq_lt f hs ζ hr hrR ?_
   rwa [volume_image_eq_lintegral_enorm_deriv_sq hUo hf hs.nullMeasurableSet hsU hinj] at hc
+
+/-! ### Short circles at arbitrarily small radii -/
+
+/-- **A finite Dirichlet integral makes the circles about any point short at arbitrarily small
+radii.** If `∫⁻ z in s, ‖deriv f z‖ₑ ^ 2` is finite, then below every bound `R > 0` there is a
+radius `ρ` at which `TauCeti.circleImageLength f s ζ ρ` is smaller than any prescribed `c ≠ 0`.
+
+This is the limiting form `TauCeti.exists_circleLIntegral_lt_of_lintegral_sq_ne_top` of Wolff's
+lemma at the length density of `f`: the annulus in which
+`TauCeti.exists_circleImageLength_sq_lt` is applied is chosen there, logarithmically long enough
+that its average is beaten, and shrunk against `R`. It is the statement the crosscut estimate of
+`Conformal/ShortCrosscut.lean` runs on, the bound `R` being what confines the radius to a genuine
+crosscut. -/
+theorem exists_circleImageLength_lt_of_lintegral_ne_top (f : ℂ → ℂ) (hs : MeasurableSet s) (ζ : ℂ)
+    (hfin : (∫⁻ z in s, ‖deriv f z‖ₑ ^ 2) ≠ ⊤) {c : ℝ≥0∞} (hc : c ≠ 0) {R : ℝ} (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, circleImageLength f s ζ ρ < c := by
+  simp only [circleImageLength_def]
+  refine exists_circleLIntegral_lt_of_lintegral_sq_ne_top
+    (measurable_indicator_enorm_deriv f hs) ?_ ζ hc hR
+  rwa [lintegral_indicator_enorm_deriv_sq f hs]
+
+/-- **The circles about any point have lower limit `0` in length.** The sharp form of
+`TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top`, and the exact sense in which the
+length–area method makes arcs short: only *some* arbitrarily small radii carry a short circle, not
+all of them. -/
+theorem liminf_circleImageLength_nhdsGT_eq_zero (f : ℂ → ℂ) (hs : MeasurableSet s) (ζ : ℂ)
+    (hfin : (∫⁻ z in s, ‖deriv f z‖ₑ ^ 2) ≠ ⊤) :
+    Filter.liminf (fun ρ => circleImageLength f s ζ ρ) (𝓝[>] (0 : ℝ)) = 0 := by
+  simp only [circleImageLength_def]
+  refine liminf_circleLIntegral_nhdsGT_eq_zero (measurable_indicator_enorm_deriv f hs) ?_ ζ
+  rwa [lintegral_indicator_enorm_deriv_sq f hs]
 
 /-! ### The chord bound -/
 

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -7,7 +7,6 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 public import TauCeti.Analysis.Complex.Conformal.LengthArea
-import Mathlib.MeasureTheory.Integral.CircleIntegral
 
 /-!
 # A circular crosscut with a short image
@@ -143,11 +142,11 @@ point.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv 
 the circle `sphere c r`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
 which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`.
 
-This is Wolff's lemma `TauCeti.exists_circleImageLength_sq_lt` fed to
-`TauCeti.diam_image_ball_inter_sphere_le`. The inner radius of the annulus in which the good `ρ` is
-sought is `R * exp (-(A + 1) / ε ^ 2)`, where `A` is `2 * π` times the Dirichlet integral: the
-annulus is made logarithmically long enough that the average of
-`circleImageLength f (ball c r) ζ ρ ^ 2` over it falls below `ε ^ 2`.
+This is the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` of Wolff's
+lemma fed to `TauCeti.diam_image_ball_inter_sphere_le`. The annulus in which the good `ρ` is sought
+is chosen there rather than here: it is made logarithmically long enough that the length–area
+average of `circleImageLength f (ball c r) ζ ρ ^ 2` over it falls below the threshold, and is
+shrunk against `R` so that the radius produced lies in `Ioo 0 R`.
 
 The bound is on the intersection `ball c r ∩ sphere ζ ρ`, which is a genuine circular crosscut only
 when `ρ < 2 * r`, being empty otherwise; since `R` is arbitrary, a caller wanting a crosscut applies
@@ -161,41 +160,10 @@ theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top (hζ : dist �
     (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
-  -- `A` is `2 * π` times the Dirichlet integral, a finite real number
-  have hfin' : ENNReal.ofReal (2 * π) * ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤ :=
-    ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
-  set A : ℝ := (ENNReal.ofReal (2 * π) * ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2).toReal with hA
-  have hA0 : 0 ≤ A := ENNReal.toReal_nonneg
-  -- the annulus `Ioo r' R`, of logarithmic length `L`
-  have hε2 : ε ^ 2 ≠ 0 := by positivity
-  set L : ℝ := (A + 1) / ε ^ 2 with hL
-  have hLpos : 0 < L := div_pos (by linarith) (by positivity)
-  have hεL : ε ^ 2 * L = A + 1 := by rw [hL]; field_simp
-  set r' : ℝ := R * Real.exp (-L) with hr'
-  have hr'pos : 0 < r' := mul_pos hR (Real.exp_pos _)
-  have hr'R : r' < R := by
-    have : Real.exp (-L) < 1 := Real.exp_lt_one_iff.mpr (by linarith)
-    nlinarith
-  have hlog : Real.log (R / r') = L := by
-    rw [hr', Real.log_div hR.ne' hr'pos.ne', Real.log_mul hR.ne' (Real.exp_ne_zero _),
-      Real.log_exp]
-    ring
-  -- Wolff's lemma on that annulus, with threshold `ε ^ 2`
-  have hc : ENNReal.ofReal (2 * π) * ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2
-      < ENNReal.ofReal (ε ^ 2) * ENNReal.ofReal (Real.log (R / r')) := by
-    have hAeq : ENNReal.ofReal (2 * π) * ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 = ENNReal.ofReal A :=
-      (ENNReal.ofReal_toReal hfin').symm
-    rw [hAeq, hlog, ← ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ ε ^ 2), hεL]
-    exact (ENNReal.ofReal_lt_ofReal_iff (by linarith)).mpr (by linarith)
-  obtain ⟨ρ, hρmem, hρlt⟩ :=
-    exists_circleImageLength_sq_lt (s := ball c r) f measurableSet_ball ζ hr'pos hr'R hc
-  -- undo the square
-  have hlen : circleImageLength f (ball c r) ζ ρ ≤ ENNReal.ofReal ε := by
-    rw [ENNReal.ofReal_pow hε.le] at hρlt
-    by_contra hcon
-    exact absurd (pow_le_pow_left' (not_le.mp hcon).le 2) (not_le.mpr hρlt)
-  exact ⟨ρ, ⟨hr'pos.trans hρmem.1, hρmem.2⟩,
-    diam_image_ball_inter_sphere_le hζ (hr'pos.trans hρmem.1) hf hε.le hlen⟩
+  obtain ⟨ρ, hρmem, hlen⟩ :=
+    exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
+      (ENNReal.ofReal_pos.mpr hε).ne' hR
+  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hζ hρmem.1 hf hε.le hlen.le⟩
 
 /-- **A conformal map of a disc has arbitrarily small images of the circle intersections
 `ball c r ∩ sphere ζ ρ` at every boundary point.** This is the case of

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -7,12 +7,14 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.MeasureTheory.Measure.Lebesgue.Complex
+public import Mathlib.Order.LiminfLimsup
 import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 import Mathlib.Analysis.SpecialFunctions.PolarCoord
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
 import Mathlib.MeasureTheory.Integral.MeanInequalities
 import Mathlib.MeasureTheory.Integral.Prod
+import Mathlib.Topology.Order.LeftRightNhds
 
 /-!
 # The lower integral of a weight over a circle, and the length–area inequality
@@ -52,6 +54,18 @@ cannot keep `circleLIntegral g ζ ρ ^ 2` above a positive constant throughout a
 **Wolff's lemma** `TauCeti.exists_circleLIntegral_sq_lt` produces a radius `ρ` between `r` and `R`
 with `circleLIntegral g ζ ρ ^ 2 < c` as soon as `2 π ∫⁻ z, g z ^ 2 < c * log (R / r)`.
 
+The threshold `2 π ∫⁻ z, g z ^ 2 / log (R / r)` that lemma asks to be beaten falls to `0` as the
+annulus is made longer, so for a weight of *finite* square integral it is beaten by every positive
+`c` once the annulus is long enough. Shrinking the annulus onto the centre — take the outer radius
+`R` as given and the inner one `R * exp (-L)` with `L` large — that is
+`TauCeti.exists_circleLIntegral_lt_of_lintegral_sq_ne_top`: below every bound `R` there is a radius
+`ρ` with `circleLIntegral g ζ ρ` smaller than any prescribed `c ≠ 0`. Equivalently, and sharply,
+the circle integral has **lower limit zero at the centre**,
+`TauCeti.liminf_circleLIntegral_nhdsGT_eq_zero`. Only a *lower* limit is available, and that is not
+a defect of the proof: the weight `‖z - ζ‖⁻¹ / (2 π)` cut down to a sequence of thin annuli
+`Ioo aₙ (aₙ * (1 + εₙ))` with `∑ εₙ` finite has finite square integral yet circle integral `1` at
+every radius in those annuli, so `circleLIntegral g ζ ρ` need not tend to `0` as `ρ → 0`.
+
 Nothing here is analytic: `g` is an arbitrary measurable weight, and the two inputs are the
 polar-coordinate change of variables and Hölder's inequality. The analytic use is
 `TauCeti/Analysis/Complex/Conformal/LengthArea.lean`, which takes `g` to be `‖deriv f‖ₑ` cut off
@@ -74,6 +88,11 @@ integral on the right need not be an area and the circle integral on the left ne
 * `TauCeti.lintegral_circleLIntegral_sq_div_le_lintegral_sq` — the **length–area inequality**.
 * `TauCeti.exists_circleLIntegral_sq_lt` — **Wolff's lemma**: a radius with small circle integral
   exists in every annulus whose logarithmic measure is large enough.
+* `TauCeti.exists_circleLIntegral_lt_of_lintegral_sq_ne_top` — its limiting form for a weight of
+  finite square integral: below every positive bound there is a radius at which the circle integral
+  is smaller than any prescribed `c ≠ 0`.
+* `TauCeti.liminf_circleLIntegral_nhdsGT_eq_zero` — the same statement as a lower limit: the circle
+  integrals of a weight of finite square integral have lower limit `0` at the centre.
 
 ## References
 
@@ -85,7 +104,7 @@ public section
 
 namespace TauCeti
 
-open MeasureTheory Set
+open MeasureTheory Set Topology
 open scoped ENNReal Real
 
 variable {g : ℂ → ℝ≥0∞} {ζ : ℂ} {ρ : ℝ}
@@ -374,5 +393,89 @@ theorem exists_circleLIntegral_sq_lt (hg : Measurable g) (ζ : ℂ) {r R : ℝ} 
       = ∫⁻ ρ in Ioo r R, c * (ENNReal.ofReal ρ)⁻¹ := hconst.symm
     _ ≤ ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 :=
         (hmono.trans hsub).trans (lintegral_circleLIntegral_sq_div_le_lintegral_sq hg ζ)
+
+/-! ### Small circle integrals at arbitrarily small radii -/
+
+/-- **An annulus of prescribed logarithmic length inside a prescribed disc.** Shrinking the inner
+radius of the annulus `Ioo r R` towards `0` sends `Real.log (R / r)` to `+∞`, so every target
+length `L` is met by the inner radius `R * Real.exp (-L)`, which for `0 < L` is smaller than `R`.
+This is how the outer radius is kept below a prescribed bound while Wolff's lemma is given as long
+an annulus as it needs. -/
+private theorem log_div_mul_exp_neg {R : ℝ} (hR : 0 < R) (L : ℝ) :
+    Real.log (R / (R * Real.exp (-L))) = L := by
+  have h : R / (R * Real.exp (-L)) = Real.exp L := by
+    rw [Real.exp_neg]
+    field_simp
+  rw [h, Real.log_exp]
+
+/-- **Wolff's lemma in the limit: a weight of finite square integral has small circle integrals at
+arbitrarily small radii.** If `∫⁻ z, g z ^ 2` is finite then for every threshold `c ≠ 0` and every
+bound `R > 0` there is a radius `ρ` below `R` with `circleLIntegral g ζ ρ < c`.
+
+The threshold that `TauCeti.exists_circleLIntegral_sq_lt` asks to be beaten is
+`2 π ∫⁻ z, g z ^ 2 / log (R / r)`, which for a finite square integral falls to `0` as the annulus
+`Ioo r R` is made logarithmically longer; here the outer radius is the prescribed bound `R` and the
+inner one `R * exp (-L)` is pushed towards `0`, which is what confines the radius produced to
+`Ioo 0 R`. The reduction to a finite threshold is the passage to `min c 1`, and the square is undone
+by monotonicity of squaring on `ℝ≥0∞`.
+
+There is no companion statement for a *fixed* small radius: see
+`TauCeti.liminf_circleLIntegral_nhdsGT_eq_zero` for the sharp form, a lower limit rather than a
+limit. -/
+theorem exists_circleLIntegral_lt_of_lintegral_sq_ne_top (hg : Measurable g)
+    (hfin : (∫⁻ z, g z ^ 2) ≠ ∞) (ζ : ℂ) {c : ℝ≥0∞} (hc : c ≠ 0) {R : ℝ} (hR : 0 < R) :
+    ∃ ρ ∈ Ioo 0 R, circleLIntegral g ζ ρ < c := by
+  -- it is enough to treat a finite threshold, since `min c 1` is one and is at most `c`
+  suffices h : ∀ b : ℝ≥0∞, b ≠ 0 → b ≠ ∞ → ∃ ρ ∈ Ioo 0 R, circleLIntegral g ζ ρ < b by
+    obtain ⟨ρ, hρ, hlt⟩ := h (min c 1) (by simp [hc]) (by simp)
+    exact ⟨ρ, hρ, hlt.trans_le (min_le_left c 1)⟩
+  intro b hb0 hbtop
+  -- `A` is `2 π` times the square integral, a finite real number, and `br` is the threshold
+  have hAtop : ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 ≠ ∞ :=
+    ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
+  set A : ℝ := (ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2).toReal
+  have hA0 : 0 ≤ A := ENNReal.toReal_nonneg
+  set br : ℝ := b.toReal
+  have hbr0 : 0 < br := ENNReal.toReal_pos hb0 hbtop
+  -- the annulus `Ioo r R`, chosen of logarithmic length `L` so that `br ^ 2 * L` beats `A`
+  set L : ℝ := (A + 1) / br ^ 2 with hL
+  have hLpos : 0 < L := div_pos (by linarith) (by positivity)
+  have hbrL : br ^ 2 * L = A + 1 := by rw [hL]; field_simp
+  set r : ℝ := R * Real.exp (-L) with hr
+  have hrpos : 0 < r := mul_pos hR (Real.exp_pos _)
+  have hrR : r < R := by
+    have hexp : Real.exp (-L) < 1 := Real.exp_lt_one_iff.mpr (by linarith)
+    nlinarith
+  have hlog : Real.log (R / r) = L := by rw [hr, log_div_mul_exp_neg hR]
+  -- Wolff's lemma on that annulus, at the squared threshold
+  have hlt : ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 <
+      b ^ 2 * ENNReal.ofReal (Real.log (R / r)) := by
+    have hAeq : ENNReal.ofReal (2 * π) * ∫⁻ z, g z ^ 2 = ENNReal.ofReal A :=
+      (ENNReal.ofReal_toReal hAtop).symm
+    have hbeq : b = ENNReal.ofReal br := (ENNReal.ofReal_toReal hbtop).symm
+    rw [hAeq, hbeq, hlog, ← ENNReal.ofReal_pow hbr0.le,
+      ← ENNReal.ofReal_mul (by positivity : (0 : ℝ) ≤ br ^ 2), hbrL]
+    exact (ENNReal.ofReal_lt_ofReal_iff (by linarith)).mpr (by linarith)
+  obtain ⟨ρ, hρmem, hρlt⟩ := exists_circleLIntegral_sq_lt hg ζ hrpos hrR hlt
+  refine ⟨ρ, ⟨hrpos.trans hρmem.1, hρmem.2⟩, ?_⟩
+  by_contra hcon
+  exact absurd (pow_le_pow_left' (not_lt.mp hcon) 2) (not_le.mpr hρlt)
+
+/-- **The circle integrals of a weight of finite square integral have lower limit `0` at the
+centre.** This is the sharp form of `TauCeti.exists_circleLIntegral_lt_of_lintegral_sq_ne_top`,
+which says exactly that every positive threshold is undercut on every interval `Ioo 0 R` of radii,
+and those intervals are a basis of `𝓝[>] 0`.
+
+The limit itself does not exist in general: the circle integral is only *frequently* small, as the
+thin-annulus weight described in the module docstring shows. -/
+theorem liminf_circleLIntegral_nhdsGT_eq_zero (hg : Measurable g) (hfin : (∫⁻ z, g z ^ 2) ≠ ∞)
+    (ζ : ℂ) : Filter.liminf (fun ρ => circleLIntegral g ζ ρ) (𝓝[>] (0 : ℝ)) = 0 := by
+  refine le_antisymm ?_ zero_le
+  by_contra hcon
+  obtain ⟨b, hb0, hbl⟩ := exists_between (not_le.mp hcon)
+  refine absurd (Filter.liminf_le_of_frequently_le' ?_) (not_le.mpr hbl)
+  refine (nhdsGT_basis (0 : ℝ)).frequently_iff.mpr fun R hR => ?_
+  obtain ⟨ρ, hρ, hlt⟩ := exists_circleLIntegral_lt_of_lintegral_sq_ne_top hg hfin ζ hb0.ne' hR
+  exact ⟨ρ, hρ, hlt.le⟩
 
 end TauCeti


### PR DESCRIPTION
This PR names the limiting form of Wolff's lemma and refactors the crosscut estimate onto it. Both `TauCeti/MeasureTheory/Integral/CircleLIntegral.lean` and `TauCeti/Analysis/Complex/Conformal/LengthArea.lean` already assert in prose that a finite square integral makes the circle integral "arbitrarily small at arbitrarily small radii", but neither proves it: what is proved there is Wolff's lemma on a *given* annulus, `∃ ρ ∈ Ioo r R, circleLIntegral g ζ ρ ^ 2 < c` under `2 π ∫⁻ z, g z ^ 2 < c * log (R / r)`, which still leaves the annulus to be chosen. That choice was made inline, once, inside the proof of `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` in `Conformal/ShortCrosscut.lean`. This PR lifts it out to the weight level where it belongs, states it as a lower limit as well, instantiates it at the length density of a holomorphic map, and deletes the inline computation.

At the weight level, `TauCeti.exists_circleLIntegral_lt_of_lintegral_sq_ne_top` says that for a measurable `g` with `∫⁻ z, g z ^ 2` finite, every threshold `c ≠ 0` and every bound `R > 0` admit a radius `ρ ∈ Ioo 0 R` with `circleLIntegral g ζ ρ < c`: the annulus is `Ioo (R * exp (-L)) R`, whose logarithmic length is exactly `L`, and `L` is taken large enough that the average the earlier lemma asks to be beaten falls below the threshold; the reduction to a finite threshold is the passage to `min c 1`, and the square comes off by monotonicity of squaring on `ℝ≥0∞`. Its sharp restatement is `TauCeti.liminf_circleLIntegral_nhdsGT_eq_zero`, that `Filter.liminf (fun ρ => circleLIntegral g ζ ρ) (𝓝[>] 0) = 0`, the intervals `Ioo 0 R` being a basis of `𝓝[>] 0`. Only a lower limit holds, and the module docstring now records why rather than leaving the reader to wonder: the weight `‖z - ζ‖⁻¹ / (2 π)` cut down to thin annuli `Ioo aₙ (aₙ * (1 + εₙ))` with `∑ εₙ` finite has finite square integral yet circle integral `1` at every radius in those annuli.

`Conformal/LengthArea.lean` instantiates both at the length density `‖deriv f‖ₑ` cut off outside `s`, as `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` and `TauCeti.liminf_circleImageLength_nhdsGT_eq_zero`, through the two private measurability and squaring lemmas already in that file; `Conformal/ShortCrosscut.lean` then proves its short-crosscut theorem in three lines instead of thirty-five, with no change to any statement, and drops an import that the deleted computation was the only user of. Nothing is generalised or restricted: the refactored theorem keeps its hypotheses and conclusion verbatim, and no Mathlib infrastructure is vendored.

The motivating target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's boundary correspondence in the Jordan-domain case, whose analytic engine is the length–area method; `TauCetiRoadmap/ConformalMapping/STATUS.md` names under "The frontier" the length–area (Koebe–Wolff) estimate showing the boundary cluster sets are singletons as the one missing step, and this is the form in which that estimate is consumed downstream. The bulk of the change is a refactor of already-merged code, which the `scope` rubric admits without a fresh roadmap claim; the L5 attribution is the one roadmap chiefly motivating it. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505) and the pinned Mathlib has no length–area estimate, so, like the files it extends, none of this is shim material under the roadmap's coordination clause.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"liminf-circlelintegral-nhdsgt-eq-zero"}-->

🤖 Prepared with Claude Code
