### PR TITLE
refactor(Plumbing): drop the unused codimension-two face restatements

### DIFF
--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -209,6 +209,15 @@ theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.dir
     simpa [vertices_def, upperFace_base, upperFace_directions] using
       PlumbingGraph.cubeVertices_upperFace_subset (x := C.base) hv
 
+/-- The vertices of a bundled cube split as the union of the vertices of its lower and upper faces
+in any present direction. -/
+theorem vertices_eq_union_faces (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    C.vertices = (C.lowerFace v hv).vertices ∪ (C.upperFace v hv).vertices :=
+  by
+    simpa [vertices_def, lowerFace_base, lowerFace_directions, upperFace_base,
+      upperFace_directions] using
+      PlumbingGraph.cubeVertices_eq_union_erase hv C.base
+
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
 @[simp]
@@ -324,6 +333,32 @@ theorem characteristicWeight_eraseDirection_le [Fintype V] (P : PlumbingGraph V)
   by
     simpa [characteristicWeight_def, eraseDirection_base, eraseDirection_directions] using
       P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
+
+/-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
+theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
+  by simpa [lowerFace_def] using characteristicWeight_eraseDirection_le P k C v
+
+/-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
+theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k (C.upperFace v hv) ≤ characteristicWeight P k C :=
+  by
+    simpa [characteristicWeight_def, upperFace_base, upperFace_directions] using
+      P.characteristicUpperFaceWeight_le (x := C.base) k hv
+
+/-- In any present direction, the characteristic weight of a cube is the maximum of the weights
+of its lower and upper faces. -/
+theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
+    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
+    characteristicWeight P k C =
+      max (characteristicWeight P k (C.lowerFace v hv))
+        (characteristicWeight P k (C.upperFace v hv)) :=
+  by
+    simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions, upperFace_base,
+      upperFace_directions] using
+      P.characteristicCubeWeight_eq_max_erase k C.base hv
 
 /-! ### Codimension-two faces
 

--- a/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
+++ b/TauCeti/LowDimTopology/Plumbing/Cube/Generator.lean
@@ -17,13 +17,21 @@ upper face `(x + E_v, S.erase v)`.
 Taking faces in two distinct present directions `v ≠ w` produces a codimension-two face, and the
 order of the two directions does not matter: `PlumbingCube.lowerFace_lowerFace_comm`,
 `PlumbingCube.upperFace_upperFace_comm`, `PlumbingCube.lowerFace_upperFace_comm`, and
-`PlumbingCube.upperFace_lowerFace_comm` identify the two ways of reaching each corner. These
-commuting squares are the geometric skeleton of the lattice-homology differential's `∂² = 0`: the
-boundary of the boundary revisits each codimension-two face along the two edges of a square, and
-the squares identify those two contributions as the *same* generator (before the `U`-power
-bookkeeping, which lives in the weight files). All four corners share the direction set
-`(S.erase v).erase w`, drop the cubical dimension by two, and have vertices among those of the
-ambient cube.
+`PlumbingCube.upperFace_lowerFace_comm` identify the two ways of reaching each corner. These four
+commuting squares are the codimension-two interface this file exports, and they are the geometric
+skeleton of the lattice-homology differential's `∂² = 0`: the boundary of the boundary revisits each
+codimension-two face along the two edges of a square, and the squares identify those two
+contributions as the *same* generator (before the `U`-power bookkeeping, which lives in the weight
+files).
+
+The remaining codimension-two bookkeeping — that all four corners carry the direction set
+`(S.erase v).erase w`, sit two below the ambient cubical dimension, and have vertices among the
+ambient cube's — is not restated per corner. Each is the corresponding codimension-one fact applied
+twice, and the codimension-one lemmas (`lowerFace_directions` / `upperFace_directions`,
+`lowerFace_base` / `upperFace_base`, `dimension_lowerFace_of_mem` / `dimension_upperFace_of_mem`,
+`vertices_lowerFace_subset` / `vertices_upperFace_subset`) are the intended public interface for it.
+The first two families are `@[simp]`, so `simp` discharges the composite direction and base goals
+directly; the dimension and vertex composites follow by `rw`/`.trans` on the codimension-one pair.
 
 The earlier plumbing files define vertices, characteristic cube weights, and the lower/upper
 face exponents as functions of `(x, S)`. This file provides the bundled generator API that the
@@ -201,15 +209,6 @@ theorem vertices_upperFace_subset (C : PlumbingCube V) {v : V} (hv : v ∈ C.dir
     simpa [vertices_def, upperFace_base, upperFace_directions] using
       PlumbingGraph.cubeVertices_upperFace_subset (x := C.base) hv
 
-/-- The vertices of a bundled cube split as the union of the vertices of its lower and upper faces
-in any present direction. -/
-theorem vertices_eq_union_faces (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    C.vertices = (C.lowerFace v hv).vertices ∪ (C.upperFace v hv).vertices :=
-  by
-    simpa [vertices_def, lowerFace_base, lowerFace_directions, upperFace_base,
-      upperFace_directions] using
-      PlumbingGraph.cubeVertices_eq_union_erase hv C.base
-
 omit [DecidableEq (V → ℤ)] in
 /-- Removing a present direction drops the cubical dimension by one for the lower face. -/
 @[simp]
@@ -326,40 +325,17 @@ theorem characteristicWeight_eraseDirection_le [Fintype V] (P : PlumbingGraph V)
     simpa [characteristicWeight_def, eraseDirection_base, eraseDirection_directions] using
       P.characteristicCubeWeight_mono k (Finset.erase_subset v C.directions) C.base
 
-/-- The lower face's characteristic weight is bounded by the ambient cube weight. -/
-theorem characteristicWeight_lowerFace_le [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicWeight P k (C.lowerFace v hv) ≤ characteristicWeight P k C :=
-  by simpa [lowerFace_def] using characteristicWeight_eraseDirection_le P k C v
-
-/-- The upper face's characteristic weight is bounded by the ambient cube weight. -/
-theorem characteristicWeight_upperFace_le [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicWeight P k (C.upperFace v hv) ≤ characteristicWeight P k C :=
-  by
-    simpa [characteristicWeight_def, upperFace_base, upperFace_directions] using
-      P.characteristicUpperFaceWeight_le (x := C.base) k hv
-
-/-- In any present direction, the characteristic weight of a cube is the maximum of the weights
-of its lower and upper faces. -/
-theorem characteristicWeight_eq_max_faces [Fintype V] (P : PlumbingGraph V)
-    (k : P.characteristicVectors) (C : PlumbingCube V) {v : V} (hv : v ∈ C.directions) :
-    characteristicWeight P k C =
-      max (characteristicWeight P k (C.lowerFace v hv))
-        (characteristicWeight P k (C.upperFace v hv)) :=
-  by
-    simpa [characteristicWeight_def, lowerFace_base, lowerFace_directions, upperFace_base,
-      upperFace_directions] using
-      P.characteristicCubeWeight_eq_max_erase k C.base hv
-
 /-! ### Codimension-two faces
 
 Taking a face in two distinct present directions `v ≠ w` gives a codimension-two face. The four
 corners (one per choice of lower/upper in each direction) are independent of the order in which the
-directions are removed, so each corner is well defined; they share the direction set
-`(C.directions.erase v).erase w`, drop the cubical dimension by two, and have vertices among those
-of the ambient cube. These commuting squares are the standard cubical-boundary squares underlying
-`∂² = 0` in Némethi's lattice homology, [arXiv:0709.0841](https://arxiv.org/abs/0709.0841). -/
+directions are removed, so each corner is well defined. These commuting squares are the standard
+cubical-boundary squares underlying `∂² = 0` in Némethi's lattice homology,
+[arXiv:0709.0841](https://arxiv.org/abs/0709.0841).
+
+The direction set, base point, dimension and vertices of each corner are read off by applying the
+codimension-one lemmas above twice, rather than by a per-corner restatement; see the module
+docstring. -/
 
 variable (C : PlumbingCube V) {v w : V}
 
@@ -418,111 +394,7 @@ theorem upperFace_lowerFace_comm (hv : v ∈ C.directions) (hw : w ∈ C.directi
   · simp only [upperFace_directions, lowerFace_directions]
     exact Finset.erase_right_comm
 
-/-- The direction set of the lower-lower codimension-two face is the ambient direction set with the
-two chosen directions removed. -/
-theorem lowerFace_lowerFace_directions (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).lowerFace w hwv).directions = (C.directions.erase v).erase w := by
-  simp
-
-/-- The direction set of the upper-upper codimension-two face is the ambient direction set with the
-two chosen directions removed. -/
-theorem upperFace_upperFace_directions (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).upperFace w hwv).directions = (C.directions.erase v).erase w := by
-  simp
-
-/-- The direction set of the lower-upper codimension-two face is the ambient direction set with the
-two chosen directions removed. -/
-theorem lowerFace_upperFace_directions (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).upperFace w hwv).directions = (C.directions.erase v).erase w := by
-  simp
-
-/-- The direction set of the upper-lower codimension-two face is the ambient direction set with the
-two chosen directions removed. -/
-theorem upperFace_lowerFace_directions (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).lowerFace w hwv).directions = (C.directions.erase v).erase w := by
-  simp
-
-/-- The lower-lower codimension-two face keeps the ambient base point. -/
-theorem lowerFace_lowerFace_base (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).lowerFace w hwv).base = C.base := by
-  simp
-
-/-- The upper-upper codimension-two face sits at the far corner `C.base + E_v + E_w`. -/
-theorem upperFace_upperFace_base (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).upperFace w hwv).base = C.base + Pi.single v (1 : ℤ) + Pi.single w 1 := by
-  simp
-
-/-- The lower-upper codimension-two face sits at the mixed corner `C.base + E_w`. -/
-theorem lowerFace_upperFace_base (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).upperFace w hwv).base = C.base + Pi.single w (1 : ℤ) := by
-  simp
-
-/-- The upper-lower codimension-two face sits at the mixed corner `C.base + E_v`. -/
-theorem upperFace_lowerFace_base (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).lowerFace w hwv).base = C.base + Pi.single v (1 : ℤ) := by
-  simp
-
-/-- The lower-lower codimension-two face has cubical dimension two less than the ambient cube. -/
-theorem dimension_lowerFace_lowerFace (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).lowerFace w hwv).dimension = C.dimension - 2 := by
-  rw [dimension_lowerFace_of_mem, dimension_lowerFace_of_mem]
-  omega
-
-/-- The upper-upper codimension-two face has cubical dimension two less than the ambient cube. -/
-theorem dimension_upperFace_upperFace (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).upperFace w hwv).dimension = C.dimension - 2 := by
-  rw [dimension_upperFace_of_mem, dimension_upperFace_of_mem]
-  omega
-
-/-- The lower-upper codimension-two face has cubical dimension two less than the ambient cube. -/
-theorem dimension_lowerFace_upperFace (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).upperFace w hwv).dimension = C.dimension - 2 := by
-  rw [dimension_upperFace_of_mem, dimension_lowerFace_of_mem]
-  omega
-
-/-- The upper-lower codimension-two face has cubical dimension two less than the ambient cube. -/
-theorem dimension_upperFace_lowerFace (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).lowerFace w hwv).dimension = C.dimension - 2 := by
-  rw [dimension_lowerFace_of_mem, dimension_upperFace_of_mem]
-  omega
-
 end
-
-/-- The vertices of the lower-lower codimension-two face are vertices of the ambient cube. -/
-theorem vertices_lowerFace_lowerFace_subset (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).lowerFace w hwv).vertices ⊆ C.vertices :=
-  ((C.lowerFace v hv).vertices_lowerFace_subset hwv).trans (C.vertices_lowerFace_subset hv)
-
-/-- The vertices of the upper-upper codimension-two face are vertices of the ambient cube. -/
-theorem vertices_upperFace_upperFace_subset (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).upperFace w hwv).vertices ⊆ C.vertices :=
-  ((C.upperFace v hv).vertices_upperFace_subset hwv).trans (C.vertices_upperFace_subset hv)
-
-/-- The vertices of the lower-upper codimension-two face are vertices of the ambient cube. -/
-theorem vertices_lowerFace_upperFace_subset (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.lowerFace v hv).directions) :
-    ((C.lowerFace v hv).upperFace w hwv).vertices ⊆ C.vertices :=
-  ((C.lowerFace v hv).vertices_upperFace_subset hwv).trans (C.vertices_lowerFace_subset hv)
-
-/-- The vertices of the upper-lower codimension-two face are vertices of the ambient cube. -/
-theorem vertices_upperFace_lowerFace_subset (hv : v ∈ C.directions)
-    (hwv : w ∈ (C.upperFace v hv).directions) :
-    ((C.upperFace v hv).lowerFace w hwv).vertices ⊆ C.vertices :=
-  ((C.upperFace v hv).vertices_lowerFace_subset hwv).trans (C.vertices_upperFace_subset hv)
 
 end PlumbingCube
 


### PR DESCRIPTION
This PR removes sixteen codimension-two restatements from the plumbing-cube generator API. Composing `lowerFace` and `upperFace` in two distinct directions gives four corners, and the direction-set, base-point, dimension and vertex-subset facts were written out once per corner. Each is the corresponding codimension-one fact applied twice, the codimension-one lemmas that discharge them are already public, and the direction and base families are `simp`, so `simp` closes the composite goals directly. None of the sixteen is referenced anywhere and none carries `@[simp]`.

The four commuting squares (`lowerFace_lowerFace_comm` and friends) stay. They carry the actual content — the cubical-boundary squares underlying `∂² = 0` — and `Differential.lean` and `Cube/Face/Exponent.lean` consume all four between them.

Both the module docstring and the codimension-two section docstring promised the deleted results by name, so this PR rewrites them to establish the codimension-one lemmas together with the four commuting squares as the intended codimension-two interface, rather than leaving prose describing an API that no longer exists.

Verified against `b318e921`: `lake build --iofail` clean with no new warnings, `lake exe axioms` and `lake exe module-system` pass, and `scripts/lint-env.sh` reports no new violations.

🤖 Prepared with Claude Code