### PR TITLE
doc: note when the Lake cache exit-status workaround can go

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -413,6 +413,12 @@ jobs:
           # (Lake/Config/Cache.lean, `if s.didError then failure`), so it can log
           # "failed to download some artifacts" and still exit 0. An attempt therefore counts
           # as clean only if it exits 0 AND logs no failure diagnostic.
+          # SIMPLIFY ON THE BUMP TO v4.34.0: that stale read is fixed by
+          # https://github.com/leanprover/lean4/pull/14651 ("fix: lake: gracefully handle curl
+          # and IO errors during transfer"), which missed v4.33.0-rc2 by hours and was not
+          # backported. From v4.34.0-rc1 on, drop FAIL_RE and trust `rc` alone.
+          # The purge below outlives that bump: it is for
+          # https://github.com/leanprover/lean4/issues/14670, still open.
           FAIL_RE='failed to download|output lookup failed|curl exited with code'
           # A revision with no cached build at all is deterministic: retrying cannot change it,
           # and there is nothing partial to discard.


### PR DESCRIPTION
This PR records, at the point of the workaround, that the log-grep half of the cache fetch check can be dropped once the toolchain reaches v4.34.0.

The stale `s.didError` read that makes `lake cache get`'s exit status untrustworthy is fixed by https://github.com/leanprover/lean4/pull/14651 ("fix: lake: gracefully handle curl and IO errors during transfer"). It merged about eight hours after `v4.33.0-rc2` and was not backported to `releases/v4.33.0`, so it first ships in v4.34.0. The comment also separates that from the purge fallback, which exists for https://github.com/leanprover/lean4/issues/14670 and is still needed.

Comment-only: the executable lines of the `run` block are byte-identical to main.

🤖 Prepared with Claude Code