### PR TITLE
ci: pin crash-safe review publication

### DIFF
--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -79,11 +79,11 @@ jobs:
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
     # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
-    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@722074ab0dabc99b68a2f4d789c3f78894392761
+    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@5da9c0cc8ba80ed125f9e9ddb3c5448c820b2c52
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}
-      review_ref: 722074ab0dabc99b68a2f4d789c3f78894392761
+      review_ref: 5da9c0cc8ba80ed125f9e9ddb3c5448c820b2c52
       # Merging is handled by auto-merge.yml (the single merge path), so generation never merges.
       enable_automerge: false
     secrets: inherit

--- a/.github/workflows/review.yml
+++ b/.github/workflows/review.yml
@@ -79,11 +79,11 @@ jobs:
     if: ${{ vars.CI_REVIEW_ENABLED == 'true' && needs.resolve.outputs.pr != '' }}
     # Pinned to a TauCetiReview commit; bump deliberately (an unpinned @main lets an upstream change
     # break every contributor's review at once, and this workflow inherits TauCeti's secrets).
-    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@eeed9637d7e2af319a04de8120b35f0c52318f0d
+    uses: TauCetiProject/TauCetiReview/.github/workflows/review.yml@722074ab0dabc99b68a2f4d789c3f78894392761
     with:
       pr: ${{ needs.resolve.outputs.pr }}
       trigger: ${{ github.event_name }}
-      review_ref: eeed9637d7e2af319a04de8120b35f0c52318f0d
+      review_ref: 722074ab0dabc99b68a2f4d789c3f78894392761
       # Merging is handled by auto-merge.yml (the single merge path), so generation never merges.
       enable_automerge: false
     secrets: inherit


### PR DESCRIPTION
Pins the reusable review workflow and review_ref to TauCetiReview main commit 5da9c0cc8ba80ed125f9e9ddb3c5448c820b2c52.

That merged engine change makes blocker-thread publication transactional and crash-safe, fixing the failure mode exposed by #1943. Implemented and merged in TauCetiProject/TauCetiReview#110.