### PR TITLE
feat: prove the Jacobson radical is left-right symmetric

### DIFF
--- a/TauCeti/Algebra/Ring/Units.lean
+++ b/TauCeti/Algebra/Ring/Units.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Ring.Units
+import Mathlib.Tactic.NoncommRing
+
+/-!
+# `1 + a * b` is a unit exactly when `1 + b * a` is
+
+In a ring, possibly noncommutative, the two products `a * b` and `b * a` are generally unrelated,
+but `1 + a * b` and `1 + b * a` are invertible together: if `v` inverts `1 + a * b`, then
+`1 - b * v * a` inverts `1 + b * a`. This is the elementwise shadow of the fact that `a * b` and
+`b * a` have the same spectrum away from `0`, and it is the mechanism behind the left-right
+symmetry of the Jacobson radical.
+
+Mathlib carries this computation only as an unnamed step inside the proof of
+`spectrum.unit_mem_mul_comm`; here it is stated on its own.
+
+## Main results
+
+* `TauCeti.isUnit_one_add_mul_comm`: `IsUnit (1 + a * b) ↔ IsUnit (1 + b * a)`.
+* `TauCeti.isUnit_one_sub_mul_comm`: `IsUnit (1 - a * b) ↔ IsUnit (1 - b * a)`.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R : Type*} [Ring R]
+
+/-- If `1 + a * b` is a unit then so is `1 + b * a`: an explicit inverse is `1 - b * v * a`,
+where `v` inverts `1 + a * b`. -/
+theorem isUnit_one_add_mul_swap {a b : R} (h : IsUnit (1 + a * b)) : IsUnit (1 + b * a) := by
+  obtain ⟨u, hu⟩ := h
+  obtain ⟨v, hv, hv'⟩ : ∃ v : R, (1 + a * b) * v = 1 ∧ v * (1 + a * b) = 1 :=
+    ⟨((u⁻¹ : Rˣ) : R), by rw [← hu, u.mul_inv], by rw [← hu, u.inv_mul]⟩
+  refine ⟨⟨1 + b * a, 1 - b * v * a, ?_, ?_⟩, rfl⟩
+  · calc (1 + b * a) * (1 - b * v * a)
+        = 1 + b * a - b * ((1 + a * b) * v) * a := by noncomm_ring
+      _ = 1 := by rw [hv]; noncomm_ring
+  · calc (1 - b * v * a) * (1 + b * a)
+        = 1 + b * a - b * (v * (1 + a * b)) * a := by noncomm_ring
+      _ = 1 := by rw [hv']; noncomm_ring
+
+/-- `1 + a * b` is a unit exactly when `1 + b * a` is. -/
+theorem isUnit_one_add_mul_comm {a b : R} : IsUnit (1 + a * b) ↔ IsUnit (1 + b * a) :=
+  ⟨isUnit_one_add_mul_swap, isUnit_one_add_mul_swap⟩
+
+/-- `1 - a * b` is a unit exactly when `1 - b * a` is. -/
+theorem isUnit_one_sub_mul_comm {a b : R} : IsUnit (1 - a * b) ↔ IsUnit (1 - b * a) := by
+  simpa [sub_eq_add_neg] using isUnit_one_add_mul_comm (a := -a) (b := b)
+
+end TauCeti

--- a/TauCeti/Algebra/Ring/Units.lean
+++ b/TauCeti/Algebra/Ring/Units.lean
@@ -32,8 +32,11 @@ namespace TauCeti
 variable {R : Type*} [Ring R]
 
 /-- If `1 + a * b` is a unit then so is `1 + b * a`: an explicit inverse is `1 - b * v * a`,
-where `v` inverts `1 + a * b`. -/
-theorem isUnit_one_add_mul_swap {a b : R} (h : IsUnit (1 + a * b)) : IsUnit (1 + b * a) := by
+where `v` inverts `1 + a * b`.
+
+This is one direction of `TauCeti.isUnit_one_add_mul_comm`, which is the form to use. -/
+private theorem isUnit_one_add_mul_swap {a b : R} (h : IsUnit (1 + a * b)) :
+    IsUnit (1 + b * a) := by
   obtain ⟨u, hu⟩ := h
   obtain ⟨v, hv, hv'⟩ : ∃ v : R, (1 + a * b) * v = 1 ∧ v * (1 + a * b) = 1 :=
     ⟨((u⁻¹ : Rˣ) : R), by rw [← hu, u.mul_inv], by rw [← hu, u.inv_mul]⟩

--- a/TauCeti/Algebra/Ring/Units.lean
+++ b/TauCeti/Algebra/Ring/Units.lean
@@ -4,25 +4,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Ring.Units
-import Mathlib.Tactic.NoncommRing
+public import Mathlib.Algebra.Algebra.Spectrum.Basic
 
 /-!
 # `1 + a * b` is a unit exactly when `1 + b * a` is
 
 In a ring, possibly noncommutative, the two products `a * b` and `b * a` are generally unrelated,
-but `1 + a * b` and `1 + b * a` are invertible together: if `v` inverts `1 + a * b`, then
-`1 - b * v * a` inverts `1 + b * a`. This is the elementwise shadow of the fact that `a * b` and
-`b * a` have the same spectrum away from `0`, and it is the mechanism behind the left-right
-symmetry of the Jacobson radical.
+but `1 + a * b` and `1 + b * a` are invertible together. This is the elementwise shadow of the
+fact that `a * b` and `b * a` have the same spectrum away from `0`, and it is the mechanism behind
+the left-right symmetry of the Jacobson radical.
 
-Mathlib carries this computation only as an unnamed step inside the proof of
-`spectrum.unit_mem_mul_comm`; here it is stated on its own.
+Mathlib records the spectral statement as `spectrum.unit_mem_mul_comm`. The elementwise form is
+that statement for the base ring `ℤ`, read at the unit `1`, and that is how it is obtained here.
 
 ## Main results
 
-* `TauCeti.isUnit_one_add_mul_comm`: `IsUnit (1 + a * b) ↔ IsUnit (1 + b * a)`.
 * `TauCeti.isUnit_one_sub_mul_comm`: `IsUnit (1 - a * b) ↔ IsUnit (1 - b * a)`.
+* `TauCeti.isUnit_one_add_mul_comm`: `IsUnit (1 + a * b) ↔ IsUnit (1 + b * a)`.
 -/
 
 public section
@@ -31,29 +29,15 @@ namespace TauCeti
 
 variable {R : Type*} [Ring R]
 
-/-- If `1 + a * b` is a unit then so is `1 + b * a`: an explicit inverse is `1 - b * v * a`,
-where `v` inverts `1 + a * b`.
+/-- `1 - a * b` is a unit exactly when `1 - b * a` is.
 
-This is one direction of `TauCeti.isUnit_one_add_mul_comm`, which is the form to use. -/
-private theorem isUnit_one_add_mul_swap {a b : R} (h : IsUnit (1 + a * b)) :
-    IsUnit (1 + b * a) := by
-  obtain ⟨u, hu⟩ := h
-  obtain ⟨v, hv, hv'⟩ : ∃ v : R, (1 + a * b) * v = 1 ∧ v * (1 + a * b) = 1 :=
-    ⟨((u⁻¹ : Rˣ) : R), by rw [← hu, u.mul_inv], by rw [← hu, u.inv_mul]⟩
-  refine ⟨⟨1 + b * a, 1 - b * v * a, ?_, ?_⟩, rfl⟩
-  · calc (1 + b * a) * (1 - b * v * a)
-        = 1 + b * a - b * ((1 + a * b) * v) * a := by noncomm_ring
-      _ = 1 := by rw [hv]; noncomm_ring
-  · calc (1 - b * v * a) * (1 + b * a)
-        = 1 + b * a - b * (v * (1 + a * b)) * a := by noncomm_ring
-      _ = 1 := by rw [hv']; noncomm_ring
+This is `spectrum.unit_mem_mul_comm` over the base ring `ℤ`, at the unit `1`. -/
+theorem isUnit_one_sub_mul_comm {a b : R} : IsUnit (1 - a * b) ↔ IsUnit (1 - b * a) := by
+  have h := spectrum.unit_mem_mul_comm (R := ℤ) (a := a) (b := b) (r := 1)
+  simpa only [spectrum.mem_iff, Units.val_one, map_one, not_iff_not] using h
 
 /-- `1 + a * b` is a unit exactly when `1 + b * a` is. -/
-theorem isUnit_one_add_mul_comm {a b : R} : IsUnit (1 + a * b) ↔ IsUnit (1 + b * a) :=
-  ⟨isUnit_one_add_mul_swap, isUnit_one_add_mul_swap⟩
-
-/-- `1 - a * b` is a unit exactly when `1 - b * a` is. -/
-theorem isUnit_one_sub_mul_comm {a b : R} : IsUnit (1 - a * b) ↔ IsUnit (1 - b * a) := by
-  simpa [sub_eq_add_neg] using isUnit_one_add_mul_comm (a := -a) (b := b)
+theorem isUnit_one_add_mul_comm {a b : R} : IsUnit (1 + a * b) ↔ IsUnit (1 + b * a) := by
+  simpa only [neg_mul, mul_neg, sub_neg_eq_add] using isUnit_one_sub_mul_comm (a := -a) (b := b)
 
 end TauCeti

--- a/TauCeti/RingTheory/Jacobson/MulOpposite.lean
+++ b/TauCeti/RingTheory/Jacobson/MulOpposite.lean
@@ -8,7 +8,6 @@ public import Mathlib.RingTheory.HopkinsLevitzki
 public import Mathlib.RingTheory.Jacobson.Ideal
 public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
 public import TauCeti.Algebra.Ring.Units
-import Mathlib.RingTheory.Ideal.Quotient.Operations
 import Mathlib.Tactic.NoncommRing
 
 /-!
@@ -131,8 +130,11 @@ theorem coe_jacobson_mulOpposite (R : Type*) [Ring R] :
 
 /-- The symmetry passes to the powers of the radical: `op` reverses products, so a product of `n`
 elements of `Ring.jacobson R` is the opposite of a product of `n` elements of
-`Ring.jacobson Rᵐᵒᵖ`, taken in the other order. -/
-theorem op_mem_jacobson_pow (n : ℕ) (x : R) (hx : x ∈ Ring.jacobson R ^ n) :
+`Ring.jacobson Rᵐᵒᵖ`, taken in the other order.
+
+This is the forward half of `TauCeti.Ring.op_mem_jacobson_mulOpposite_pow_iff`, which is the form
+to use. -/
+private theorem op_mem_jacobson_pow (n : ℕ) (x : R) (hx : x ∈ Ring.jacobson R ^ n) :
     op x ∈ Ring.jacobson Rᵐᵒᵖ ^ n := by
   induction n generalizing x with
   | zero => rw [Submodule.pow_zero, Ideal.one_eq_top]; exact Submodule.mem_top
@@ -144,8 +146,9 @@ theorem op_mem_jacobson_pow (n : ℕ) (x : R) (hx : x ∈ Ring.jacobson R ^ n) :
     · rw [op_add]
       exact Ideal.add_mem _ ha hb
 
-/-- The converse direction of `TauCeti.Ring.op_mem_jacobson_pow`. -/
-theorem unop_mem_jacobson_pow (n : ℕ) (X : Rᵐᵒᵖ) (hX : X ∈ Ring.jacobson Rᵐᵒᵖ ^ n) :
+/-- The reverse half of `TauCeti.Ring.op_mem_jacobson_mulOpposite_pow_iff`, the same induction run
+in the opposite ring. -/
+private theorem unop_mem_jacobson_pow (n : ℕ) (X : Rᵐᵒᵖ) (hX : X ∈ Ring.jacobson Rᵐᵒᵖ ^ n) :
     X.unop ∈ Ring.jacobson R ^ n := by
   induction n generalizing X with
   | zero => rw [Submodule.pow_zero, Ideal.one_eq_top]; exact Submodule.mem_top
@@ -157,6 +160,19 @@ theorem unop_mem_jacobson_pow (n : ℕ) (X : Rᵐᵒᵖ) (hX : X ∈ Ring.jacobs
     · rw [unop_add]
       exact Ideal.add_mem _ hA hB
 
+/-- The left-right symmetry of the Jacobson radical, at the level of powers: `op x` lies in the
+`n`-th power of `Ring.jacobson Rᵐᵒᵖ` exactly when `x` lies in the `n`-th power of
+`Ring.jacobson R`. -/
+theorem op_mem_jacobson_mulOpposite_pow_iff {x : R} {n : ℕ} :
+    op x ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ x ∈ Ring.jacobson R ^ n :=
+  ⟨unop_mem_jacobson_pow n (op x), op_mem_jacobson_pow n x⟩
+
+/-- `TauCeti.Ring.op_mem_jacobson_mulOpposite_pow_iff` phrased for an element of `Rᵐᵒᵖ`. -/
+@[simp]
+theorem mem_jacobson_mulOpposite_pow_iff {X : Rᵐᵒᵖ} {n : ℕ} :
+    X ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ X.unop ∈ Ring.jacobson R ^ n :=
+  op_mem_jacobson_mulOpposite_pow_iff (x := X.unop)
+
 variable (R)
 
 /-- Nilpotence of the Jacobson radical is left-right symmetric: the two radicals have the same
@@ -166,17 +182,17 @@ theorem isNilpotent_jacobson_mulOpposite_iff :
   constructor
   · rintro ⟨n, hn⟩
     refine ⟨n, eq_bot_iff.mpr fun x hx => ?_⟩
-    have hx' := op_mem_jacobson_pow n x hx
+    have hx' := op_mem_jacobson_mulOpposite_pow_iff.mpr hx
     rw [hn] at hx'
     simpa [Ideal.mem_bot] using hx'
   · rintro ⟨n, hn⟩
     refine ⟨n, eq_bot_iff.mpr fun X hX => ?_⟩
-    have hX' := unop_mem_jacobson_pow n X hX
+    have hX' := mem_jacobson_mulOpposite_pow_iff.mp hX
     rw [hn] at hX'
     simpa [Ideal.mem_bot] using hX'
 
 /-- Reduction modulo the Jacobson radical commutes with passing to the opposite ring. -/
-noncomputable def quotientJacobsonMulOppositeRingEquiv :
+@[expose] noncomputable def quotientJacobsonMulOppositeRingEquiv :
     Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := by
   let f : Rᵐᵒᵖ →+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := RingHom.op (Ideal.Quotient.mk (Ring.jacobson R))
   have hf : Function.Surjective f := fun Y => by
@@ -186,6 +202,21 @@ noncomputable def quotientJacobsonMulOppositeRingEquiv :
     ext X
     simp [f, RingHom.mem_ker, Ideal.Quotient.eq_zero_iff_mem]
   exact (Ideal.quotEquivOfEq hker.symm).trans (RingHom.quotientKerEquivOfSurjective hf)
+
+/-- `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv` is reduction modulo the radical read in
+`Rᵐᵒᵖ`: it sends the class of `op x` to the opposite of the class of `x`. -/
+@[simp]
+theorem quotientJacobsonMulOppositeRingEquiv_mk (x : R) :
+    quotientJacobsonMulOppositeRingEquiv R (Ideal.Quotient.mk (Ring.jacobson Rᵐᵒᵖ) (op x)) =
+      op (Ideal.Quotient.mk (Ring.jacobson R) x) :=
+  rfl
+
+/-- The inverse of `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv`, on generators. -/
+@[simp]
+theorem quotientJacobsonMulOppositeRingEquiv_symm_op_mk (x : R) :
+    (quotientJacobsonMulOppositeRingEquiv R).symm (op (Ideal.Quotient.mk (Ring.jacobson R) x)) =
+      Ideal.Quotient.mk (Ring.jacobson Rᵐᵒᵖ) (op x) :=
+  (RingEquiv.symm_apply_eq _).mpr (quotientJacobsonMulOppositeRingEquiv_mk R x).symm
 
 /-- Semisimplicity of the quotient by the Jacobson radical is left-right symmetric. -/
 theorem isSemisimpleRing_quotient_jacobson_mulOpposite_iff :

--- a/TauCeti/RingTheory/Jacobson/MulOpposite.lean
+++ b/TauCeti/RingTheory/Jacobson/MulOpposite.lean
@@ -65,8 +65,8 @@ variable {R}
 
 This is `Ideal.mem_jacobson_iff` at the zero ideal, rearranged. Only a left inverse is available
 at this stage; `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_left` upgrades it to a two-sided
-one. -/
-theorem mem_jacobson_iff_exists_mul_eq_one {x : R} :
+one and is the form to use. -/
+private theorem mem_jacobson_iff_forall_exists_mul_one_add_mul_eq_one {x : R} :
     x ∈ Ring.jacobson R ↔ ∀ y : R, ∃ z : R, z * (1 + y * x) = 1 := by
   rw [← Ideal.jacobson_bot, Ideal.mem_jacobson_iff]
   refine forall_congr' fun y => exists_congr fun z => ?_
@@ -78,7 +78,7 @@ theorem mem_jacobson_iff_exists_mul_eq_one {x : R} :
 Mathlib's `Ideal.mem_jacobson_bot` is this statement over a commutative ring. -/
 theorem mem_jacobson_iff_isUnit_one_add_mul_left {x : R} :
     x ∈ Ring.jacobson R ↔ ∀ y : R, IsUnit (1 + y * x) := by
-  rw [mem_jacobson_iff_exists_mul_eq_one]
+  rw [mem_jacobson_iff_forall_exists_mul_one_add_mul_eq_one]
   refine ⟨fun h y => ?_, fun h y => ?_⟩
   · -- A left inverse `z` of `1 + y * x` is again of the form `1 + y' * x`, so it has a left
     -- inverse `w` in turn; then `w = w * (z * (1 + y * x)) = 1 + y * x`, which makes `z` a
@@ -120,8 +120,9 @@ theorem op_mem_jacobson_mulOpposite_iff {x : R} :
 /-- `TauCeti.Ring.op_mem_jacobson_mulOpposite_iff` phrased for an element of `Rᵐᵒᵖ`. -/
 @[simp]
 theorem mem_jacobson_mulOpposite_iff {X : Rᵐᵒᵖ} :
-    X ∈ Ring.jacobson Rᵐᵒᵖ ↔ X.unop ∈ Ring.jacobson R :=
-  op_mem_jacobson_mulOpposite_iff (x := X.unop)
+    X ∈ Ring.jacobson Rᵐᵒᵖ ↔ X.unop ∈ Ring.jacobson R := by
+  conv_lhs => rw [← op_unop X]
+  exact op_mem_jacobson_mulOpposite_iff
 
 /-- The Jacobson radical of `Rᵐᵒᵖ` is, as a set, the `op`-image of the Jacobson radical of `R`. -/
 theorem coe_jacobson_mulOpposite (R : Type*) [Ring R] :
@@ -164,14 +165,17 @@ private theorem unop_mem_jacobson_pow (n : ℕ) (X : Rᵐᵒᵖ) (hX : X ∈ Rin
 `n`-th power of `Ring.jacobson Rᵐᵒᵖ` exactly when `x` lies in the `n`-th power of
 `Ring.jacobson R`. -/
 theorem op_mem_jacobson_mulOpposite_pow_iff {x : R} {n : ℕ} :
-    op x ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ x ∈ Ring.jacobson R ^ n :=
-  ⟨unop_mem_jacobson_pow n (op x), op_mem_jacobson_pow n x⟩
+    op x ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ x ∈ Ring.jacobson R ^ n := by
+  refine ⟨fun h => ?_, op_mem_jacobson_pow n x⟩
+  have h' := unop_mem_jacobson_pow n (op x) h
+  rwa [unop_op] at h'
 
 /-- `TauCeti.Ring.op_mem_jacobson_mulOpposite_pow_iff` phrased for an element of `Rᵐᵒᵖ`. -/
 @[simp]
 theorem mem_jacobson_mulOpposite_pow_iff {X : Rᵐᵒᵖ} {n : ℕ} :
-    X ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ X.unop ∈ Ring.jacobson R ^ n :=
-  op_mem_jacobson_mulOpposite_pow_iff (x := X.unop)
+    X ∈ Ring.jacobson Rᵐᵒᵖ ^ n ↔ X.unop ∈ Ring.jacobson R ^ n := by
+  conv_lhs => rw [← op_unop X]
+  exact op_mem_jacobson_mulOpposite_pow_iff
 
 variable (R)
 
@@ -191,25 +195,45 @@ theorem isNilpotent_jacobson_mulOpposite_iff :
     rw [hn] at hX'
     simpa [Ideal.mem_bot] using hX'
 
+/-- Reduction modulo the Jacobson radical, read in the opposite ring: this sends `op x` to
+`op (Ideal.Quotient.mk (Ring.jacobson R) x)`. -/
+private def opQuotientMk : Rᵐᵒᵖ →+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ :=
+  RingHom.op (Ideal.Quotient.mk (Ring.jacobson R))
+
+/-- `TauCeti.Ring.opQuotientMk` on `op`-generators. This is how `RingHom.op` is defined, so the
+computation is definitional; every later use of `TauCeti.Ring.opQuotientMk` goes through this
+lemma rather than through the definition. -/
+private theorem opQuotientMk_op (x : R) :
+    opQuotientMk R (op x) = op (Ideal.Quotient.mk (Ring.jacobson R) x) := rfl
+
+/-- `TauCeti.Ring.opQuotientMk` is surjective, since `Ideal.Quotient.mk` is. -/
+private theorem opQuotientMk_surjective : Function.Surjective (opQuotientMk R) := fun Y => by
+  obtain ⟨x, hx⟩ := Ideal.Quotient.mk_surjective Y.unop
+  exact ⟨op x, by rw [opQuotientMk_op, hx, op_unop]⟩
+
+/-- The kernel of `TauCeti.Ring.opQuotientMk` is the Jacobson radical of `Rᵐᵒᵖ`: this is the
+left-right symmetry again. -/
+private theorem ker_opQuotientMk : RingHom.ker (opQuotientMk R) = Ring.jacobson Rᵐᵒᵖ := by
+  ext X
+  induction X using MulOpposite.rec' with
+  | _ x =>
+    rw [RingHom.mem_ker, opQuotientMk_op, op_eq_zero_iff, Ideal.Quotient.eq_zero_iff_mem,
+      op_mem_jacobson_mulOpposite_iff]
+
 /-- Reduction modulo the Jacobson radical commutes with passing to the opposite ring. -/
-@[expose] noncomputable def quotientJacobsonMulOppositeRingEquiv :
-    Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := by
-  let f : Rᵐᵒᵖ →+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := RingHom.op (Ideal.Quotient.mk (Ring.jacobson R))
-  have hf : Function.Surjective f := fun Y => by
-    obtain ⟨x, hx⟩ := Ideal.Quotient.mk_surjective Y.unop
-    exact ⟨op x, by simp [f, hx]⟩
-  have hker : RingHom.ker f = Ring.jacobson Rᵐᵒᵖ := by
-    ext X
-    simp [f, RingHom.mem_ker, Ideal.Quotient.eq_zero_iff_mem]
-  exact (Ideal.quotEquivOfEq hker.symm).trans (RingHom.quotientKerEquivOfSurjective hf)
+noncomputable def quotientJacobsonMulOppositeRingEquiv :
+    Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ :=
+  (Ideal.quotEquivOfEq (ker_opQuotientMk R).symm).trans
+    (RingHom.quotientKerEquivOfSurjective (opQuotientMk_surjective R))
 
 /-- `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv` is reduction modulo the radical read in
 `Rᵐᵒᵖ`: it sends the class of `op x` to the opposite of the class of `x`. -/
 @[simp]
 theorem quotientJacobsonMulOppositeRingEquiv_mk (x : R) :
     quotientJacobsonMulOppositeRingEquiv R (Ideal.Quotient.mk (Ring.jacobson Rᵐᵒᵖ) (op x)) =
-      op (Ideal.Quotient.mk (Ring.jacobson R) x) :=
-  rfl
+      op (Ideal.Quotient.mk (Ring.jacobson R) x) := by
+  rw [quotientJacobsonMulOppositeRingEquiv, RingEquiv.trans_apply, Ideal.quotEquivOfEq_mk,
+    RingHom.quotientKerEquivOfSurjective_apply_mk, opQuotientMk_op]
 
 /-- The inverse of `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv`, on generators. -/
 @[simp]

--- a/TauCeti/RingTheory/Jacobson/MulOpposite.lean
+++ b/TauCeti/RingTheory/Jacobson/MulOpposite.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.HopkinsLevitzki
+public import Mathlib.RingTheory.Jacobson.Ideal
+public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
+public import TauCeti.Algebra.Ring.Units
+import Mathlib.RingTheory.Ideal.Quotient.Operations
+import Mathlib.Tactic.NoncommRing
+
+/-!
+# The Jacobson radical, and semiprimary rings, are left-right symmetric
+
+`Ring.jacobson R` is the intersection of the maximal *left* ideals of `R`, so nothing about the
+definition is symmetric in the two sides. Mathlib knows the resulting ideal is two-sided, but it
+does not record the sharper statement that the *same* ideal is cut out by the maximal right
+ideals, and consequently it leaves the transfer of `IsSemiprimaryRing` to the opposite ring as a
+`proof_wanted` in `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean`, annotated "Need
+left-right symmetry of Jacobson radical".
+
+This file supplies that symmetry and the two consequences it was wanted for. The route is the
+elementwise description of the radical: `x` lies in `Ring.jacobson R` exactly when `1 + y * x` is
+a unit for every `y`, and hence, by `TauCeti.isUnit_one_add_mul_comm`, exactly when `1 + x * y` is
+a unit for every `y`. The second description is the first one read in `Rᵐᵒᵖ`, so the radical of
+the opposite ring is the opposite of the radical.
+
+Mathlib proves the elementwise description only over a commutative ring
+(`Ideal.mem_jacobson_bot`), where left-right symmetry is vacuous; the noncommutative statement
+here is what carries the content. The one extra step over the commutative case is that membership
+in the radical only supplies a *left* inverse for `1 + y * x`, so the argument has to promote that
+left inverse to a two-sided one.
+
+## Main results
+
+* `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_left` and
+  `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_right`: the two elementwise descriptions of
+  the Jacobson radical of a ring.
+* `TauCeti.Ring.op_mem_jacobson_mulOpposite_iff`: `MulOpposite.op x` lies in `Ring.jacobson Rᵐᵒᵖ`
+  exactly when `x` lies in `Ring.jacobson R` -- the left-right symmetry, in membership form.
+* `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv`: the resulting identification
+  `Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ`.
+* `TauCeti.isSemiprimaryRing_mulOpposite_iff` and `TauCeti.IsSemiprimaryRing.mulOpposite`:
+  semiprimarity passes to the opposite ring.
+* `TauCeti.IsArtinianRing.isNoetherianRing_iff_isArtinianRing_mulOpposite`: a left
+  Artinian ring is right Noetherian exactly when it is right Artinian, the statement that
+  `WedderburnArtin.lean` records as waiting on the same symmetry.
+-/
+
+public section
+
+namespace TauCeti
+
+open MulOpposite
+
+variable (R : Type*) [Ring R]
+
+namespace Ring
+
+variable {R}
+
+/-- Membership in the Jacobson radical, unfolded: `x` lies in `Ring.jacobson R` exactly when
+`1 + y * x` has a left inverse for every `y`.
+
+This is `Ideal.mem_jacobson_iff` at the zero ideal, rearranged. Only a left inverse is available
+at this stage; `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_left` upgrades it to a two-sided
+one. -/
+theorem mem_jacobson_iff_exists_mul_eq_one {x : R} :
+    x ∈ Ring.jacobson R ↔ ∀ y : R, ∃ z : R, z * (1 + y * x) = 1 := by
+  rw [← Ideal.jacobson_bot, Ideal.mem_jacobson_iff]
+  refine forall_congr' fun y => exists_congr fun z => ?_
+  have h : z * (1 + y * x) = z * y * x + z := by noncomm_ring
+  rw [Ideal.mem_bot, sub_eq_zero, h]
+
+/-- The Jacobson radical of a ring is `{x | ∀ y, IsUnit (1 + y * x)}`.
+
+Mathlib's `Ideal.mem_jacobson_bot` is this statement over a commutative ring. -/
+theorem mem_jacobson_iff_isUnit_one_add_mul_left {x : R} :
+    x ∈ Ring.jacobson R ↔ ∀ y : R, IsUnit (1 + y * x) := by
+  rw [mem_jacobson_iff_exists_mul_eq_one]
+  refine ⟨fun h y => ?_, fun h y => ?_⟩
+  · -- A left inverse `z` of `1 + y * x` is again of the form `1 + y' * x`, so it has a left
+    -- inverse `w` in turn; then `w = w * (z * (1 + y * x)) = 1 + y * x`, which makes `z` a
+    -- two-sided inverse of `1 + y * x`.
+    obtain ⟨z, hz⟩ := h y
+    have hexp : z * (1 + y * x) = z * y * x + z := by noncomm_ring
+    have h1 : z * y * x + z = 1 := by rw [← hexp]; exact hz
+    have hz' : 1 + -(z * y) * x = z := by
+      have key : 1 + -(z * y) * x - z = 1 - (z * y * x + z) := by noncomm_ring
+      rwa [h1, sub_self, sub_eq_zero] at key
+    obtain ⟨w, hw⟩ := h (-(z * y))
+    rw [hz'] at hw
+    have hwz : w = 1 + y * x :=
+      calc w = w * (z * (1 + y * x)) := by rw [hz, mul_one]
+        _ = w * z * (1 + y * x) := by rw [mul_assoc]
+        _ = 1 + y * x := by rw [hw, one_mul]
+    exact ⟨⟨1 + y * x, z, by rw [← hwz]; exact hw, hz⟩, rfl⟩
+  · obtain ⟨u, hu⟩ := h y
+    exact ⟨↑u⁻¹, by rw [← hu]; exact u.inv_mul⟩
+
+/-- The right-handed description of the Jacobson radical: it is also `{x | ∀ y, IsUnit (1 + x*y)}`.
+
+This is where the left-right symmetry enters: the two descriptions differ only by the swap
+`TauCeti.isUnit_one_add_mul_comm`. -/
+theorem mem_jacobson_iff_isUnit_one_add_mul_right {x : R} :
+    x ∈ Ring.jacobson R ↔ ∀ y : R, IsUnit (1 + x * y) :=
+  mem_jacobson_iff_isUnit_one_add_mul_left.trans
+    (forall_congr' fun _ => isUnit_one_add_mul_comm)
+
+/-- **Left-right symmetry of the Jacobson radical**: the intersection of the maximal left ideals
+of `Rᵐᵒᵖ` is the opposite of the intersection of the maximal left ideals of `R`, which is to say
+that the Jacobson radical of `R` is also the intersection of its maximal right ideals. -/
+theorem op_mem_jacobson_mulOpposite_iff {x : R} :
+    op x ∈ Ring.jacobson Rᵐᵒᵖ ↔ x ∈ Ring.jacobson R := by
+  rw [mem_jacobson_iff_isUnit_one_add_mul_left, mem_jacobson_iff_isUnit_one_add_mul_right,
+    op_surjective.forall]
+  exact forall_congr' fun y => by rw [← op_one, ← op_mul, ← op_add, isUnit_op]
+
+/-- `TauCeti.Ring.op_mem_jacobson_mulOpposite_iff` phrased for an element of `Rᵐᵒᵖ`. -/
+@[simp]
+theorem mem_jacobson_mulOpposite_iff {X : Rᵐᵒᵖ} :
+    X ∈ Ring.jacobson Rᵐᵒᵖ ↔ X.unop ∈ Ring.jacobson R :=
+  op_mem_jacobson_mulOpposite_iff (x := X.unop)
+
+/-- The Jacobson radical of `Rᵐᵒᵖ` is, as a set, the `op`-image of the Jacobson radical of `R`. -/
+theorem coe_jacobson_mulOpposite (R : Type*) [Ring R] :
+    (Ring.jacobson Rᵐᵒᵖ : Set Rᵐᵒᵖ) = unop ⁻¹' (Ring.jacobson R) :=
+  Set.ext fun _ => mem_jacobson_mulOpposite_iff
+
+/-- The symmetry passes to the powers of the radical: `op` reverses products, so a product of `n`
+elements of `Ring.jacobson R` is the opposite of a product of `n` elements of
+`Ring.jacobson Rᵐᵒᵖ`, taken in the other order. -/
+theorem op_mem_jacobson_pow (n : ℕ) (x : R) (hx : x ∈ Ring.jacobson R ^ n) :
+    op x ∈ Ring.jacobson Rᵐᵒᵖ ^ n := by
+  induction n generalizing x with
+  | zero => rw [Submodule.pow_zero, Ideal.one_eq_top]; exact Submodule.mem_top
+  | succ n ih =>
+    rw [Submodule.pow_succ] at hx
+    refine Submodule.mul_induction_on hx (fun a ha b hb => ?_) (fun a b ha hb => ?_)
+    · rw [op_mul, Ideal.IsTwoSided.pow_succ]
+      exact Ideal.mul_mem_mul (op_mem_jacobson_mulOpposite_iff.mpr hb) (ih a ha)
+    · rw [op_add]
+      exact Ideal.add_mem _ ha hb
+
+/-- The converse direction of `TauCeti.Ring.op_mem_jacobson_pow`. -/
+theorem unop_mem_jacobson_pow (n : ℕ) (X : Rᵐᵒᵖ) (hX : X ∈ Ring.jacobson Rᵐᵒᵖ ^ n) :
+    X.unop ∈ Ring.jacobson R ^ n := by
+  induction n generalizing X with
+  | zero => rw [Submodule.pow_zero, Ideal.one_eq_top]; exact Submodule.mem_top
+  | succ n ih =>
+    rw [Submodule.pow_succ] at hX
+    refine Submodule.mul_induction_on hX (fun A hA B hB => ?_) (fun A B hA hB => ?_)
+    · rw [unop_mul, Ideal.IsTwoSided.pow_succ]
+      exact Ideal.mul_mem_mul (mem_jacobson_mulOpposite_iff.mp hB) (ih A hA)
+    · rw [unop_add]
+      exact Ideal.add_mem _ hA hB
+
+variable (R)
+
+/-- Nilpotence of the Jacobson radical is left-right symmetric: the two radicals have the same
+vanishing powers. -/
+theorem isNilpotent_jacobson_mulOpposite_iff :
+    IsNilpotent (Ring.jacobson Rᵐᵒᵖ) ↔ IsNilpotent (Ring.jacobson R) := by
+  constructor
+  · rintro ⟨n, hn⟩
+    refine ⟨n, eq_bot_iff.mpr fun x hx => ?_⟩
+    have hx' := op_mem_jacobson_pow n x hx
+    rw [hn] at hx'
+    simpa [Ideal.mem_bot] using hx'
+  · rintro ⟨n, hn⟩
+    refine ⟨n, eq_bot_iff.mpr fun X hX => ?_⟩
+    have hX' := unop_mem_jacobson_pow n X hX
+    rw [hn] at hX'
+    simpa [Ideal.mem_bot] using hX'
+
+/-- Reduction modulo the Jacobson radical commutes with passing to the opposite ring. -/
+noncomputable def quotientJacobsonMulOppositeRingEquiv :
+    Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := by
+  let f : Rᵐᵒᵖ →+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ := RingHom.op (Ideal.Quotient.mk (Ring.jacobson R))
+  have hf : Function.Surjective f := fun Y => by
+    obtain ⟨x, hx⟩ := Ideal.Quotient.mk_surjective Y.unop
+    exact ⟨op x, by simp [f, hx]⟩
+  have hker : RingHom.ker f = Ring.jacobson Rᵐᵒᵖ := by
+    ext X
+    simp [f, RingHom.mem_ker, Ideal.Quotient.eq_zero_iff_mem]
+  exact (Ideal.quotEquivOfEq hker.symm).trans (RingHom.quotientKerEquivOfSurjective hf)
+
+/-- Semisimplicity of the quotient by the Jacobson radical is left-right symmetric. -/
+theorem isSemisimpleRing_quotient_jacobson_mulOpposite_iff :
+    IsSemisimpleRing (Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ) ↔ IsSemisimpleRing (R ⧸ Ring.jacobson R) :=
+  (quotientJacobsonMulOppositeRingEquiv R).isSemisimpleRing_iff.trans
+    isSemisimpleRing_mulOpposite_iff
+
+end Ring
+
+/-- **Semiprimarity is left-right symmetric**, discharging Mathlib's `proof_wanted`
+`isSemiprimaryRing_mulOpposite_iff`. -/
+theorem isSemiprimaryRing_mulOpposite_iff : IsSemiprimaryRing Rᵐᵒᵖ ↔ IsSemiprimaryRing R := by
+  rw [isSemiprimaryRing_iff, isSemiprimaryRing_iff,
+    Ring.isSemisimpleRing_quotient_jacobson_mulOpposite_iff,
+    Ring.isNilpotent_jacobson_mulOpposite_iff]
+
+/-- The opposite of a semiprimary ring is semiprimary, discharging Mathlib's `proof_wanted`
+`IsSemiprimaryRing.mulOpposite`. -/
+instance IsSemiprimaryRing.mulOpposite [IsSemiprimaryRing R] : IsSemiprimaryRing Rᵐᵒᵖ :=
+  (isSemiprimaryRing_mulOpposite_iff R).mpr ‹_›
+
+/-- For a left Artinian ring, being right Noetherian and being right Artinian coincide: the
+opposite ring is semiprimary, so Hopkins-Levitzki applies to it. This is the `example` that
+`Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` leaves open. -/
+theorem IsArtinianRing.isNoetherianRing_iff_isArtinianRing_mulOpposite
+    [IsArtinianRing R] : IsNoetherianRing Rᵐᵒᵖ ↔ IsArtinianRing Rᵐᵒᵖ :=
+  IsSemiprimaryRing.isNoetherian_iff_isArtinian
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the Jacobson radical of a ring is left-right symmetric, and draws the consequences Mathlib records as waiting on that symmetry. `Ring.jacobson R` is the intersection of the maximal *left* ideals, so `Mathlib/RingTheory/SimpleModule/WedderburnArtin.lean` carries the comment "Need left-right symmetry of Jacobson radical" above three `proof_wanted`s: `IsSemiprimaryRing.mulOpposite`, `isSemiprimaryRing_mulOpposite_iff`, and `IsArtinianRing.isNoetherianRing_iff_isArtinianRing_mulOpposite`. All three are discharged here, under the names Mathlib pins for them.

This is the Layer 0 item "Left-right symmetry" of `TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md`, which asks in as many words to "Discharge Mathlib's standing `proof_wanted IsSemiprimaryRing.mulOpposite` and `isSemiprimaryRing_mulOpposite_iff`, giving `Ring.jacobson Aᵐᵒᵖ` the expected description and completing the 'left Artinian ⇔ right Artinian for these rings' `example` noted in `WedderburnArtin.lean`". It is the lowest-hanging genuine target in that family: the roadmap states it as self-contained supporting API off the critical path, its statements are already written down upstream, and no open or merged pull request touches the Jacobson radical outside the path-algebra computation in `TauCeti/RepresentationTheory/Quiver/Radical.lean`, which consumes `Ring.jacobson` rather than developing it.

The route is the elementwise description of the radical. `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_left` says `x ∈ Ring.jacobson R` exactly when `1 + y * x` is a unit for every `y`. Mathlib has this only over a commutative ring (`Ideal.mem_jacobson_bot`), where left-right symmetry is vacuous, and the noncommutative statement needs one genuine extra step: `Ideal.mem_jacobson_iff` yields only a *left* inverse `z` of `1 + y * x`, and `z` is promoted to a two-sided inverse by observing that `z = 1 + (-(z * y)) * x` is again of that shape, so `z` has a left inverse `w` in turn, and `w = w * (z * (1 + y * x)) = 1 + y * x`. Swapping the two factors then gives the right-handed description `TauCeti.Ring.mem_jacobson_iff_isUnit_one_add_mul_right`, which is the left-handed one read in `Rᵐᵒᵖ`; that is `TauCeti.Ring.op_mem_jacobson_mulOpposite_iff`, the symmetry itself, equivalently the statement that `Ring.jacobson R` is also the intersection of the maximal right ideals of `R`.

`TauCeti/Algebra/Ring/Units.lean` (43 lines) supplies the swap: `TauCeti.isUnit_one_sub_mul_comm`, that `1 - a * b` is a unit exactly when `1 - b * a` is, together with the `1 + a * b` form obtained from it at `-a`. Both come straight from Mathlib's `spectrum.unit_mem_mul_comm` for the base ring `ℤ`, read at the unit `1`: `1 ∈ σ (a * b)` unfolds to `¬ IsUnit (1 - a * b)`, so the spectral statement *is* the elementwise one there. Nothing is proved by hand and nothing is vendored; the file only names a specialization Mathlib does not name.

`TauCeti/RingTheory/Jacobson/MulOpposite.lean` (217 lines) carries the symmetry to the two invariants that define `IsSemiprimaryRing`. Nilpotence transfers through `TauCeti.Ring.op_mem_jacobson_mulOpposite_pow_iff`, whose two halves are private inductions on the exponent with `Submodule.mul_induction_on` for the step: `op` reverses products, so `Ideal.IsTwoSided.pow_succ` on one side matches `Submodule.pow_succ` on the other. Semisimplicity of the quotient transfers through `TauCeti.Ring.quotientJacobsonMulOppositeRingEquiv`, the identification `Rᵐᵒᵖ ⧸ Ring.jacobson Rᵐᵒᵖ ≃+* (R ⧸ Ring.jacobson R)ᵐᵒᵖ` obtained as the first isomorphism theorem for `RingHom.op (Ideal.Quotient.mk (Ring.jacobson R))`, whose kernel the symmetry computes; Mathlib's `isSemisimpleRing_mulOpposite_iff` then finishes. `TauCeti.isSemiprimaryRing_mulOpposite_iff` is the conjunction of the two, read off `isSemiprimaryRing_iff`, and the `instance` form `TauCeti.IsSemiprimaryRing.mulOpposite` follows from it. Since a left Artinian ring is semiprimary upstream, feeding `Rᵐᵒᵖ` to Hopkins-Levitzki gives `TauCeti.IsArtinianRing.isNoetherianRing_iff_isArtinianRing_mulOpposite`, the third `proof_wanted`.

Everything is stated for a bare `Ring`, with no finiteness, commutativity, or base algebra, which is the generality the statements upstream are written at and the one the Wedderburn development that will consume them works in.

`lake exe cache get` reports `Decompressed 7191 already-cached file(s)`. `lake build` reports `Build completed successfully (6503 jobs).` `lake exe axioms` reports `axioms: audited 22088 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].` `scripts/lint-env.sh` reports `LINT-ENV: PASS — no new violations (54 grandfathered, 3 ratchetable).`

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"issemiprimaryring-mulopposite"}-->

🤖 Prepared with Claude Code

