### PR TITLE
feat: cut an arbitrary domain, not only a disc, by a circular crosscut

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -121,8 +121,8 @@ functions.
   connected.
 * `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion — a circular
   crosscut separates the disc into exactly two connected components, the two sides being those cut
-  out by `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` and
-  `TauCeti.subset_inter_ball_or_subset_diff_closedBall` of
+  out by `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` and
+  `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` of
   `TauCeti/Topology/MetricSpace/Cut.lean`. The disc signatures those two replace are kept here as
   deprecated compatibility wrappers.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
@@ -434,27 +434,27 @@ The three cut lemmas of `TauCeti/Topology/MetricSpace/Cut.lean` were stated here
 each naming its generalized replacement. -/
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`. -/
-@[deprecated diff_sphere_eq_inter_ball_union_diff_closedBall (since := "2026-08-04")]
+`TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall`. -/
+@[deprecated sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (since := "2026-08-04")]
 theorem ball_diff_sphere_eq_union :
     ball c r \ sphere ζ ρ = ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ :=
-  diff_sphere_eq_inter_ball_union_diff_closedBall
+  sdiff_sphere_eq_inter_ball_union_sdiff_closedBall
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.disjoint_inter_ball_diff_closedBall`. -/
-@[deprecated disjoint_inter_ball_diff_closedBall (since := "2026-08-04")]
+`TauCeti.disjoint_inter_ball_sdiff_closedBall`. -/
+@[deprecated disjoint_inter_ball_sdiff_closedBall (since := "2026-08-04")]
 theorem disjoint_ball_inter_ball_ball_diff_closedBall :
     Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) :=
-  disjoint_inter_ball_diff_closedBall
+  disjoint_inter_ball_sdiff_closedBall
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.subset_inter_ball_or_subset_diff_closedBall`, whose openness hypothesis the disc
+`TauCeti.subset_inter_ball_or_subset_sdiff_closedBall`, whose openness hypothesis the disc
 discharges with `Metric.isOpen_ball`. -/
-@[deprecated subset_inter_ball_or_subset_diff_closedBall (since := "2026-08-04")]
+@[deprecated subset_inter_ball_or_subset_sdiff_closedBall (since := "2026-08-04")]
 theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS : IsPreconnected S)
     (hSsub : S ⊆ ball c r \ sphere ζ ρ) :
     S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
-  subset_inter_ball_or_subset_diff_closedBall isOpen_ball hS hSsub
+  subset_inter_ball_or_subset_sdiff_closedBall isOpen_ball hS hSsub
 
 /-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
 `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular
@@ -463,14 +463,14 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
     (hz : z ∈ ball c r ∩ ball ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
   have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    diff_sphere_eq_inter_ball_union_diff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_left
+    sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_left
   refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_inter_ball_or_subset_diff_closedBall (x := ζ) (s := ball c r) isOpen_ball
+  rcases subset_inter_ball_or_subset_sdiff_closedBall (x := ζ) (s := ball c r) isOpen_ball
     isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
   · exact h
   · exact absurd (h (mem_connectedComponentIn (hsub hz)))
-      (Set.disjoint_left.mp disjoint_inter_ball_diff_closedBall hz)
+      (Set.disjoint_left.mp disjoint_inter_ball_sdiff_closedBall hz)
 
 /-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
 of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball`; here the connectedness of the
@@ -479,12 +479,12 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
   have hsub : ball c r \ closedBall ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    diff_sphere_eq_inter_ball_union_diff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_right
+    sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_right
   refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hζ hρ hρ').isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_inter_ball_or_subset_diff_closedBall (x := ζ) (s := ball c r) isOpen_ball
+  rcases subset_inter_ball_or_subset_sdiff_closedBall (x := ζ) (s := ball c r) isOpen_ball
     isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
-  · exact absurd hz (Set.disjoint_left.mp disjoint_inter_ball_diff_closedBall
+  · exact absurd hz (Set.disjoint_left.mp disjoint_inter_ball_sdiff_closedBall
       (h (mem_connectedComponentIn (hsub hz))))
   · exact h
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -121,7 +121,8 @@ lines, and the analytic half is the maximum modulus principle for holomorphic fu
   `TauCeti.subset_inter_ball_or_subset_diff_closedBall` and
   `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
   separates the disc into exactly two connected components. The first two need nothing of the
-  disc, nor of the plane, and are stated for an arbitrary cut set in a pseudo-metric space.
+  disc, nor of the plane, and are stated for an arbitrary cut set in a pseudo-metric space; the
+  disc signatures they replace are kept as deprecated compatibility wrappers beside them.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
   `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
   on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
@@ -469,6 +470,34 @@ theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set X} (hs : IsOpen s
     (diff_sphere_eq_inter_ball_union_diff_closedBall (x := x) (s := s) ▸ hSsub)
 
 end Cut
+
+/-! ### Deprecated disc-specific forms
+
+The three lemmas above were stated for `s = ball c r` in `ℂ`. Their old signatures are retained
+here as deprecated compatibility wrappers, each naming its generalized replacement. -/
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`. -/
+@[deprecated diff_sphere_eq_inter_ball_union_diff_closedBall (since := "2026-08-04")]
+theorem ball_diff_sphere_eq_union :
+    ball c r \ sphere ζ ρ = ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ :=
+  diff_sphere_eq_inter_ball_union_diff_closedBall
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.disjoint_inter_ball_diff_closedBall`. -/
+@[deprecated disjoint_inter_ball_diff_closedBall (since := "2026-08-04")]
+theorem disjoint_ball_inter_ball_ball_diff_closedBall :
+    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) :=
+  disjoint_inter_ball_diff_closedBall
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.subset_inter_ball_or_subset_diff_closedBall`, whose openness hypothesis the disc
+discharges with `Metric.isOpen_ball`. -/
+@[deprecated subset_inter_ball_or_subset_diff_closedBall (since := "2026-08-04")]
+theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS : IsPreconnected S)
+    (hSsub : S ⊆ ball c r \ sphere ζ ρ) :
+    S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
+  subset_inter_ball_or_subset_diff_closedBall isOpen_ball hS hSsub
 
 /-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
 `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.Complex.AbsMax
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import TauCeti.Topology.ClusterSet
+public import TauCeti.Topology.MetricSpace.Cut
 import Mathlib.Analysis.Convex.PathConnected
 import Mathlib.Analysis.Normed.Module.RCLike.Real
 
@@ -102,12 +103,13 @@ on the collar is where local connectedness of the image boundary enters.
 ## Generality
 
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
-every theorem added in layers L0–L6, everything below is stated for `ℂ`, except the three set
-lemmas that split a set by a sphere: their statements and proofs use nothing but the containments
-between balls and spheres, so they are stated for an arbitrary pseudo-metric space and used here
-at `ℂ`. For the rest the bar is not merely a convenience: the map that performs the decomposition
-is the complex inversion `z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for reducing circles to
-lines, and the analytic half is the maximum modulus principle for holomorphic functions.
+every theorem added in layers L0–L6, everything below is stated for `ℂ`. The three set lemmas that
+split a set by a sphere use nothing but the containments between balls and spheres, so they live in
+`TauCeti/Topology/MetricSpace/Cut.lean`, stated for an arbitrary pseudo-metric space, and are used
+here at `ℂ`. For the rest the bar is not merely a convenience: the map that performs the
+decomposition is the complex inversion `z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for
+reducing circles to lines, and the analytic half is the maximum modulus principle for holomorphic
+functions.
 
 ## Main results
 
@@ -117,12 +119,12 @@ lines, and the analytic half is the maximum modulus principle for holomorphic fu
   description of a circular crosscut, and the fact that it is an arc of angles.
 * `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
   connected.
-* `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`,
-  `TauCeti.subset_inter_ball_or_subset_diff_closedBall` and
-  `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
-  separates the disc into exactly two connected components. The first two need nothing of the
-  disc, nor of the plane, and are stated for an arbitrary cut set in a pseudo-metric space; the
-  disc signatures they replace are kept as deprecated compatibility wrappers beside them.
+* `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion — a circular
+  crosscut separates the disc into exactly two connected components, the two sides being those cut
+  out by `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` and
+  `TauCeti.subset_inter_ball_or_subset_diff_closedBall` of
+  `TauCeti/Topology/MetricSpace/Cut.lean`. The disc signatures those two replace are kept here as
+  deprecated compatibility wrappers.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
   `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
   on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
@@ -425,56 +427,11 @@ theorem isConnected_ball_diff_closedBall (hζ : dist ζ c = r) (hρ : 0 < ρ)
   exact (continuousAt_const.add
     (continuousAt_inv₀ (ne_zero_of_one_lt_two_mul_re_mul hw.1))).continuousWithinAt
 
-section Cut
-
-variable {X : Type*} [PseudoMetricSpace X] {x : X}
-
-/-- **A circular cut splits a set into a near side and a far side.** The set identity underlying
-the crosscut decomposition: removing the sphere `sphere x ρ` from a set `s` leaves the points of
-`s` at distance less than `ρ` from `x` together with those at distance more than `ρ`.
-
-Neither the disc nor the plane plays any role — `s` is an arbitrary set in an arbitrary
-pseudo-metric space — and the crosscut instance is `X = ℂ`, `s = ball c r`. The general form is
-what `Conformal/CutDiameter.lean` cuts an arbitrary domain with. -/
-theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set X} :
-    s \ sphere x ρ = s ∩ ball x ρ ∪ s \ closedBall x ρ := by
-  ext y
-  constructor
-  · rintro ⟨hy, hne⟩
-    rw [Metric.mem_sphere] at hne
-    rcases lt_or_gt_of_ne hne with h | h
-    · exact Or.inl ⟨hy, Metric.mem_ball.mpr h⟩
-    · exact Or.inr ⟨hy, fun hc => absurd (Metric.mem_closedBall.mp hc) (not_le.mpr h)⟩
-  · rintro (⟨hy, h⟩ | ⟨hy, h⟩)
-    · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
-    · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
-
-/-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall x ρ` and
-the far side outside it. As in `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` the cut
-set, and the ambient pseudo-metric space, are arbitrary. -/
-theorem disjoint_inter_ball_diff_closedBall {s : Set X} :
-    Disjoint (s ∩ ball x ρ) (s \ closedBall x ρ) :=
-  Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
-
-/-- **A connected subset of an open set missing a circular cut lies on one side of it.** This is
-the separation statement the decomposition exists for: the two sides are open and disjoint, so a
-preconnected subset of their union cannot meet both.
-
-Only openness of the cut set is used, so the disc is again not needed; the crosscut instance is
-`X = ℂ`, `s = ball c r`, supplied with `isOpen_ball`. -/
-theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set X} (hs : IsOpen s)
-    (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere x ρ) :
-    S ⊆ s ∩ ball x ρ ∨ S ⊆ s \ closedBall x ρ :=
-  hS.subset_or_subset (hs.inter isOpen_ball) (hs.sdiff isClosed_closedBall)
-    disjoint_inter_ball_diff_closedBall
-    (diff_sphere_eq_inter_ball_union_diff_closedBall (x := x) (s := s) ▸ hSsub)
-
-end Cut
-
 /-! ### Deprecated disc-specific forms
 
-The three lemmas above were stated for `s = ball c r` in `ℂ`. Their old signatures are retained
-here as deprecated compatibility wrappers, each naming its generalized replacement. -/
+The three cut lemmas of `TauCeti/Topology/MetricSpace/Cut.lean` were stated here for
+`s = ball c r` in `ℂ`. Their old signatures are retained as deprecated compatibility wrappers,
+each naming its generalized replacement. -/
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`. -/

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -115,10 +115,11 @@ half is the maximum modulus principle for holomorphic functions.
   description of a circular crosscut, and the fact that it is an arc of angles.
 * `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
   connected.
-* `TauCeti.ball_diff_sphere_eq_union`,
-  `TauCeti.subset_ball_inter_ball_or_subset_ball_diff_closedBall` and
+* `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`,
+  `TauCeti.subset_inter_ball_or_subset_diff_closedBall` and
   `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
-  separates the disc into exactly two connected components.
+  separates the disc into exactly two connected components. The first two need nothing of the
+  disc and are stated for an arbitrary cut set.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
   `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
   on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
@@ -421,11 +422,14 @@ theorem isConnected_ball_diff_closedBall (hζ : dist ζ c = r) (hρ : 0 < ρ)
   exact (continuousAt_const.add
     (continuousAt_inv₀ (ne_zero_of_one_lt_two_mul_re_mul hw.1))).continuousWithinAt
 
-/-- **A circular crosscut splits the disc into the crosscut neighbourhood and the rest.** The
-underlying set identity: removing the crosscut `sphere ζ ρ` from `ball c r` leaves the points at
-distance less than `ρ` from `ζ` together with those at distance more than `ρ`. -/
-theorem ball_diff_sphere_eq_union :
-    ball c r \ sphere ζ ρ = ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ := by
+/-- **A circular cut splits a set into a near side and a far side.** The set identity underlying
+the crosscut decomposition: removing the circle `sphere ζ ρ` from a set `s` leaves the points of
+`s` at distance less than `ρ` from `ζ` together with those at distance more than `ρ`.
+
+The disc plays no role — `s` is arbitrary — and the crosscut instance is `s = ball c r`. The
+general form is what `Conformal/CutDiameter.lean` cuts an arbitrary domain with. -/
+theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set ℂ} :
+    s \ sphere ζ ρ = s ∩ ball ζ ρ ∪ s \ closedBall ζ ρ := by
   ext y
   constructor
   · rintro ⟨hy, hne⟩
@@ -437,20 +441,24 @@ theorem ball_diff_sphere_eq_union :
     · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
     · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
 
-/-- The two sides of a circular crosscut are disjoint, the near side lying inside `closedBall ζ ρ`
-and the far side outside it. -/
-theorem disjoint_ball_inter_ball_ball_diff_closedBall :
-    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) :=
+/-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall ζ ρ` and
+the far side outside it. As in `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` the cut
+set is arbitrary. -/
+theorem disjoint_inter_ball_diff_closedBall {s : Set ℂ} :
+    Disjoint (s ∩ ball ζ ρ) (s \ closedBall ζ ρ) :=
   Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
 
-/-- **A connected set in the disc missing a circular crosscut lies on one side of it.** This is the
-separation statement the decomposition exists for: the two sides are open and disjoint, so a
-preconnected subset of their union cannot meet both. -/
-theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS : IsPreconnected S)
-    (hSsub : S ⊆ ball c r \ sphere ζ ρ) :
-    S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
-  hS.subset_or_subset (isOpen_ball.inter isOpen_ball) (isOpen_ball.sdiff isClosed_closedBall)
-    disjoint_ball_inter_ball_ball_diff_closedBall (ball_diff_sphere_eq_union ▸ hSsub)
+/-- **A connected subset of an open set missing a circular cut lies on one side of it.** This is
+the separation statement the decomposition exists for: the two sides are open and disjoint, so a
+preconnected subset of their union cannot meet both.
+
+Only openness of the cut set is used, so the disc is again not needed; the crosscut instance is
+`s = ball c r`, supplied with `isOpen_ball`. -/
+theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set ℂ} (hs : IsOpen s)
+    (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere ζ ρ) :
+    S ⊆ s ∩ ball ζ ρ ∨ S ⊆ s \ closedBall ζ ρ :=
+  hS.subset_or_subset (hs.inter isOpen_ball) (hs.sdiff isClosed_closedBall)
+    disjoint_inter_ball_diff_closedBall (diff_sphere_eq_inter_ball_union_diff_closedBall ▸ hSsub)
 
 /-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
 `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular
@@ -459,14 +467,14 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
     (hz : z ∈ ball c r ∩ ball ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
   have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    ball_diff_sphere_eq_union ▸ subset_union_left
+    diff_sphere_eq_inter_ball_union_diff_closedBall ▸ subset_union_left
   refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_ball_inter_ball_or_subset_ball_diff_closedBall isPreconnected_connectedComponentIn
-    (connectedComponentIn_subset _ _) with h | h
+  rcases subset_inter_ball_or_subset_diff_closedBall isOpen_ball
+    isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
   · exact h
   · exact absurd (h (mem_connectedComponentIn (hsub hz)))
-      (Set.disjoint_left.mp disjoint_ball_inter_ball_ball_diff_closedBall hz)
+      (Set.disjoint_left.mp disjoint_inter_ball_diff_closedBall hz)
 
 /-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
 of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball`; here the connectedness of the
@@ -475,12 +483,12 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
   have hsub : ball c r \ closedBall ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    ball_diff_sphere_eq_union ▸ subset_union_right
+    diff_sphere_eq_inter_ball_union_diff_closedBall ▸ subset_union_right
   refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hζ hρ hρ').isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_ball_inter_ball_or_subset_ball_diff_closedBall isPreconnected_connectedComponentIn
-    (connectedComponentIn_subset _ _) with h | h
-  · exact absurd hz (Set.disjoint_left.mp disjoint_ball_inter_ball_ball_diff_closedBall
+  rcases subset_inter_ball_or_subset_diff_closedBall isOpen_ball
+    isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
+  · exact absurd hz (Set.disjoint_left.mp disjoint_inter_ball_diff_closedBall
       (h (mem_connectedComponentIn (hsub hz))))
   · exact h
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -102,10 +102,12 @@ on the collar is where local connectedness of the image boundary enters.
 ## Generality
 
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
-every theorem added in layers L0–L6, everything below is stated for `ℂ`. The geometric half is not
-merely a convenience of that bar: the map that performs the decomposition is the complex inversion
-`z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for reducing circles to lines, and the analytic
-half is the maximum modulus principle for holomorphic functions.
+every theorem added in layers L0–L6, everything below is stated for `ℂ`, except the three set
+lemmas that split a set by a sphere: their statements and proofs use nothing but the containments
+between balls and spheres, so they are stated for an arbitrary pseudo-metric space and used here
+at `ℂ`. For the rest the bar is not merely a convenience: the map that performs the decomposition
+is the complex inversion `z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for reducing circles to
+lines, and the analytic half is the maximum modulus principle for holomorphic functions.
 
 ## Main results
 
@@ -119,7 +121,7 @@ half is the maximum modulus principle for holomorphic functions.
   `TauCeti.subset_inter_ball_or_subset_diff_closedBall` and
   `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — a circular crosscut
   separates the disc into exactly two connected components. The first two need nothing of the
-  disc and are stated for an arbitrary cut set.
+  disc, nor of the plane, and are stated for an arbitrary cut set in a pseudo-metric space.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
   `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
   on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
@@ -422,14 +424,19 @@ theorem isConnected_ball_diff_closedBall (hζ : dist ζ c = r) (hρ : 0 < ρ)
   exact (continuousAt_const.add
     (continuousAt_inv₀ (ne_zero_of_one_lt_two_mul_re_mul hw.1))).continuousWithinAt
 
-/-- **A circular cut splits a set into a near side and a far side.** The set identity underlying
-the crosscut decomposition: removing the circle `sphere ζ ρ` from a set `s` leaves the points of
-`s` at distance less than `ρ` from `ζ` together with those at distance more than `ρ`.
+section Cut
 
-The disc plays no role — `s` is arbitrary — and the crosscut instance is `s = ball c r`. The
-general form is what `Conformal/CutDiameter.lean` cuts an arbitrary domain with. -/
-theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set ℂ} :
-    s \ sphere ζ ρ = s ∩ ball ζ ρ ∪ s \ closedBall ζ ρ := by
+variable {X : Type*} [PseudoMetricSpace X] {x : X}
+
+/-- **A circular cut splits a set into a near side and a far side.** The set identity underlying
+the crosscut decomposition: removing the sphere `sphere x ρ` from a set `s` leaves the points of
+`s` at distance less than `ρ` from `x` together with those at distance more than `ρ`.
+
+Neither the disc nor the plane plays any role — `s` is an arbitrary set in an arbitrary
+pseudo-metric space — and the crosscut instance is `X = ℂ`, `s = ball c r`. The general form is
+what `Conformal/CutDiameter.lean` cuts an arbitrary domain with. -/
+theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set X} :
+    s \ sphere x ρ = s ∩ ball x ρ ∪ s \ closedBall x ρ := by
   ext y
   constructor
   · rintro ⟨hy, hne⟩
@@ -441,11 +448,11 @@ theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set ℂ} :
     · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
     · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
 
-/-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall ζ ρ` and
+/-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall x ρ` and
 the far side outside it. As in `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` the cut
-set is arbitrary. -/
-theorem disjoint_inter_ball_diff_closedBall {s : Set ℂ} :
-    Disjoint (s ∩ ball ζ ρ) (s \ closedBall ζ ρ) :=
+set, and the ambient pseudo-metric space, are arbitrary. -/
+theorem disjoint_inter_ball_diff_closedBall {s : Set X} :
+    Disjoint (s ∩ ball x ρ) (s \ closedBall x ρ) :=
   Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
 
 /-- **A connected subset of an open set missing a circular cut lies on one side of it.** This is
@@ -453,12 +460,15 @@ the separation statement the decomposition exists for: the two sides are open an
 preconnected subset of their union cannot meet both.
 
 Only openness of the cut set is used, so the disc is again not needed; the crosscut instance is
-`s = ball c r`, supplied with `isOpen_ball`. -/
-theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set ℂ} (hs : IsOpen s)
-    (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere ζ ρ) :
-    S ⊆ s ∩ ball ζ ρ ∨ S ⊆ s \ closedBall ζ ρ :=
+`X = ℂ`, `s = ball c r`, supplied with `isOpen_ball`. -/
+theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set X} (hs : IsOpen s)
+    (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere x ρ) :
+    S ⊆ s ∩ ball x ρ ∨ S ⊆ s \ closedBall x ρ :=
   hS.subset_or_subset (hs.inter isOpen_ball) (hs.sdiff isClosed_closedBall)
-    disjoint_inter_ball_diff_closedBall (diff_sphere_eq_inter_ball_union_diff_closedBall ▸ hSsub)
+    disjoint_inter_ball_diff_closedBall
+    (diff_sphere_eq_inter_ball_union_diff_closedBall (x := x) (s := s) ▸ hSsub)
+
+end Cut
 
 /-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
 `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular
@@ -467,10 +477,10 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
     (hz : z ∈ ball c r ∩ ball ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
   have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    diff_sphere_eq_inter_ball_union_diff_closedBall ▸ subset_union_left
+    diff_sphere_eq_inter_ball_union_diff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_left
   refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_inter_ball_or_subset_diff_closedBall isOpen_ball
+  rcases subset_inter_ball_or_subset_diff_closedBall (x := ζ) (s := ball c r) isOpen_ball
     isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
   · exact h
   · exact absurd (h (mem_connectedComponentIn (hsub hz)))
@@ -483,10 +493,10 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
   have hsub : ball c r \ closedBall ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    diff_sphere_eq_inter_ball_union_diff_closedBall ▸ subset_union_right
+    diff_sphere_eq_inter_ball_union_diff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_right
   refine Subset.antisymm ?_ ((isConnected_ball_diff_closedBall hζ hρ hρ').isPreconnected
     |>.subset_connectedComponentIn hz hsub)
-  rcases subset_inter_ball_or_subset_diff_closedBall isOpen_ball
+  rcases subset_inter_ball_or_subset_diff_closedBall (x := ζ) (s := ball c r) isOpen_ball
     isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
   · exact absurd hz (Set.disjoint_left.mp disjoint_inter_ball_diff_closedBall
       (h (mem_connectedComponentIn (hsub hz))))

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -112,15 +112,15 @@ variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 /-! ## The three pieces of the image -/
 
 /-- **A circular crosscut splits the image of a disc into three pieces**: the images of the two
-sides and the image crosscut. This is `TauCeti.ball_diff_sphere_eq_union` — the corresponding
-identity in the disc — pushed forward, and needs nothing of `f`. -/
+sides and the image crosscut. This is `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` —
+the corresponding identity in the disc — pushed forward, and needs nothing of `f`. -/
 theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
     f '' ball c r =
       f '' (ball c r ∩ ball ζ ρ) ∪ f '' (ball c r ∩ sphere ζ ρ) ∪
         f '' (ball c r \ closedBall ζ ρ) := by
   rw [← image_union, ← image_union]
   congr 1
-  rw [union_right_comm, ← ball_diff_sphere_eq_union, sdiff_union_inter]
+  rw [union_right_comm, ← diff_sphere_eq_inter_ball_union_diff_closedBall, sdiff_union_inter]
 
 /-! ## The crosscut cuts the boundary of the image in two -/
 
@@ -212,7 +212,7 @@ an image crosscut of diameter less than `δ` has its middle piece contained in a
 `frontier (f '' ball c r)` of diameter at most `ε`.
 
 This is where the local connectedness of `∂Ω` that
-`TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le` needs enters, the other
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` needs enters, the other
 of its two geometric inputs being the length–area estimate
 `TauCeti.exists_diam_image_ball_inter_sphere_le`. It does not by itself discharge that criterion,
 whose enclosing set has to contain the whole boundary piece

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -112,7 +112,7 @@ variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 /-! ## The three pieces of the image -/
 
 /-- **A circular crosscut splits the image of a disc into three pieces**: the images of the two
-sides and the image crosscut. This is `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` —
+sides and the image crosscut. This is `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` —
 the corresponding identity in the disc — pushed forward, and needs nothing of `f`. -/
 theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
     f '' ball c r =
@@ -120,7 +120,7 @@ theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ 
         f '' (ball c r \ closedBall ζ ρ) := by
   rw [← image_union, ← image_union]
   congr 1
-  rw [union_right_comm, ← diff_sphere_eq_inter_ball_union_diff_closedBall, sdiff_union_inter]
+  rw [union_right_comm, ← sdiff_sphere_eq_inter_ball_union_sdiff_closedBall, sdiff_union_inter]
 
 /-! ## The crosscut cuts the boundary of the image in two -/
 

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -13,39 +13,38 @@ import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 /-!
 # The piece a crosscut cuts off, measured by its boundary
 
-`Conformal/Crosscut/Basic.lean` cuts a disc `ball c r` at a boundary point `ζ` by the circle
-`sphere ζ ρ`, leaving the *crosscut neighbourhood* `ball c r ∩ ball ζ ρ` of `ζ`, and turns an
-oscillation bound on that neighbourhood into a boundary limit. This file supplies such a bound for a
-*conformal* map, in the geometric form that layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory boundary correspondence — produces
-it: the image of the crosscut neighbourhood is no wider than the image of the crosscut arc together
-with the piece of `∂Ω` that arc cuts off.
+`Conformal/Crosscut/Basic.lean` cuts a domain at a boundary point `ζ` by the circle `sphere ζ ρ`,
+leaving the *crosscut neighbourhood* `U ∩ ball ζ ρ` of `ζ`, and turns an oscillation bound on that
+neighbourhood into a boundary limit. This file supplies such a bound for a *conformal* map, in the
+geometric form that layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory
+boundary correspondence — produces it: the image of the crosscut neighbourhood is no wider than the
+image of the crosscut arc together with the piece of `∂Ω` that arc cuts off.
 
 ## The boundary of the image of a crosscut neighbourhood
 
-Write `Ω = f '' ball c r` for the image domain and `A = f '' (ball c r ∩ ball ζ ρ)` for the image of
-the crosscut neighbourhood, `f` being holomorphic and injective on the disc. Then
-(`TauCeti.frontier_image_ball_inter_ball_subset`)
+Write `Ω = f '' U` for the image domain and `A = f '' (U ∩ ball ζ ρ)` for the image of the crosscut
+neighbourhood, `f` being holomorphic and injective on the open set `U`. Then
+(`TauCeti.frontier_image_inter_ball_subset`)
 
-> `frontier A ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier Ω`:
+> `frontier A ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier Ω`:
 
 the boundary of `A` consists of the *image crosscut* and of boundary points of `Ω`, and nothing
 else.
 
 Nothing in that statement distinguishes the two sides of the crosscut, so it is proved once for an
-arbitrary splitting of the disc into two disjoint open pieces `s`, `t` and a remainder `u`
-(`TauCeti.frontier_image_subset_image_union_frontier_image_ball`), by the open mapping theorem
-applied three times: a point `p` of `frontier (f '' s)` lies in `closure Ω = Ω ∪ frontier Ω`, so if
-it is not on `frontier Ω` it is `f w` for a unique `w` in the disc, and `w ∈ s` would put `p` in the
-open set `f '' s`, which is disjoint from its own frontier, while `w ∈ t` would put `p` in the
-*open* set `f '' t`, which injectivity makes disjoint from `f '' s`, contradicting
-`p ∈ closure (f '' s)`. So `w ∈ u`. Simple connectivity of the disc plays no role, and neither does
-the geometry of `Ω`.
+arbitrary splitting of the domain into two disjoint open pieces `s`, `t` and a remainder `u`
+(`TauCeti.frontier_image_subset_image_union_frontier_image`), by the open mapping theorem applied
+twice: a point `p` of `frontier (f '' s)` lies in `closure Ω = Ω ∪ frontier Ω`, so if it is not on
+`frontier Ω` it is `f w` for a unique `w` in `U`, and `w ∈ s` would put `p` in the open set
+`f '' s`, which is disjoint from its own frontier, while `w ∈ t` would put `p` in the *open* set
+`f '' t`, which injectivity makes disjoint from `f '' s`, contradicting `p ∈ closure (f '' s)`.
+So `w ∈ u`. Simple connectivity plays no role, and neither does the geometry of `Ω` — nor even
+openness of `U`, which enters only when the splitting is produced.
 
-Instantiating it at the near side and at the far side `ball c r \ closedBall ζ ρ`, which by
-`TauCeti.ball_diff_sphere_eq_union` are disjoint and open and leave exactly the crosscut arc, gives
-`TauCeti.frontier_image_ball_inter_ball_subset` and
-`TauCeti.frontier_image_ball_diff_closedBall_subset`: a consumer may bound either side.
+Instantiating it at the near side and at the far side `U \ closedBall ζ ρ`, which by
+`TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` are disjoint and open and leave exactly
+the crosscut arc, gives `TauCeti.frontier_image_inter_ball_subset` and
+`TauCeti.frontier_image_diff_closedBall_subset`: a consumer may bound either side.
 
 ## From the boundary to the piece
 
@@ -54,15 +53,15 @@ A bounded set in a normed space is exactly as wide as its frontier
 above is already a diameter bound: for any `E` containing the boundary points of `Ω` that lie on
 `frontier A`,
 
-> `diam A ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E)`
+> `diam A ≤ diam (f '' (U ∩ sphere ζ ρ) ∪ E)`
 
-(`TauCeti.diam_image_ball_inter_ball_le`), and likewise for the far side
-(`TauCeti.diam_image_ball_diff_closedBall_le`), both through the same
+(`TauCeti.diam_image_inter_ball_le`), and likewise for the far side
+(`TauCeti.diam_image_diff_closedBall_le`), both through the same
 `TauCeti.diam_image_le_diam_image_union`. Feeding those bounds, one for each tolerance, to the
 Cauchy criterion of `Topology/ClusterSet.lean` gives the boundary limit
-`TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` and, if the bounds are
-available at every point of the boundary circle, the continuous extension to the closed disc
-`TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le`.
+`TauCeti.exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le` and, if the bounds are available
+at every point of `frontier U`, the continuous extension to `closure U`,
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`.
 
 This is the **geometric** counterpart of the analytic criterion
 `TauCeti.exists_continuousOn_closedBall_eqOn` of `Conformal/Crosscut/Basic.lean`. That one asks for
@@ -73,13 +72,20 @@ a small set `E`. That is the shape in which the two remaining L5 inputs arrive: 
 method makes the image crosscut short, and local connectedness of `∂Ω` supplies the small
 connected `E`
 joining its two ends. Neither is proved here; what is proved here is that those two data suffice,
-with no maximum principle and no estimate on `f` inside the disc.
+with no maximum principle and no estimate on `f` inside the domain.
 
-Nothing below assumes that `ζ` lies on the boundary circle, that `ρ` is smaller than `2 * r`, or
-that `Ω` is anything but bounded, so the hypotheses stay checkable; only the final two theorems,
-which produce a limit, ask `ζ` to be a boundary point.
+Nothing below assumes that `ζ` lies on `frontier U`, or that `Ω` is anything but bounded, so the
+hypotheses stay checkable; only the final two theorems, which produce a limit, ask `ζ` to be
+adherent to `U`.
 
 ## Generality
+
+The domain `U` is an arbitrary open set rather than a disc. The disc is where the *inputs* live —
+`Conformal/ShortCrosscut.lean` makes an image crosscut of a disc short — but nothing in the
+argument below uses the shape of `U`, and the Carathéodory correspondence is a statement about
+both a Jordan domain and the disc it is mapped from, so both directions of it are served only by
+the general form. The cut itself is still a circle `sphere ζ ρ`, which is what makes the crosscut
+neighbourhoods a neighbourhood basis of `ζ`.
 
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The two ingredients
@@ -88,21 +94,20 @@ space, and `TauCeti.IsPreconnected.inter_frontier_nonempty` for an arbitrary top
 
 ## Main results
 
-* `TauCeti.frontier_image_subset_image_union_frontier_image_ball` and
+* `TauCeti.frontier_image_subset_image_union_frontier_image` and
   `TauCeti.diam_image_le_diam_image_union` — the boundary inclusion and the diameter bound for one
-  side of an arbitrary splitting of the disc into two disjoint open pieces and a remainder.
-* `TauCeti.frontier_image_ball_inter_ball_subset` and
-  `TauCeti.frontier_image_ball_diff_closedBall_subset` — the boundary of the image of either side of
-  a crosscut is covered by the image crosscut and the boundary of the image domain.
-* `TauCeti.diam_image_ball_inter_ball_le` and `TauCeti.diam_image_ball_diff_closedBall_le` — either
-  side of a crosscut has image no wider than the image crosscut together with the boundary piece it
-  cuts off.
-* `TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_le` and
-  `TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le` — small cut-off pieces
-  make the boundary cluster set a subsingleton.
-* `TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` and
-  `TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le` — the resulting
-  boundary limit and continuous extension to the closed disc.
+  side of an arbitrary splitting of the domain into two disjoint open pieces and a remainder.
+* `TauCeti.frontier_image_inter_ball_subset` and `TauCeti.frontier_image_diff_closedBall_subset` —
+  the boundary of the image of either side of a crosscut is covered by the image crosscut and the
+  boundary of the image domain.
+* `TauCeti.diam_image_inter_ball_le` and `TauCeti.diam_image_diff_closedBall_le` — either side of a
+  crosscut has image no wider than the image crosscut together with the boundary piece it cuts off.
+* `TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_le` and
+  `TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_union_le` — small cut-off pieces make
+  the boundary cluster set a subsingleton.
+* `TauCeti.exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le` and
+  `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` — the resulting
+  boundary limit and continuous extension to the closure.
 
 ## Coordination with upstream Mathlib
 
@@ -128,36 +133,36 @@ namespace TauCeti
 
 open Bornology Complex Filter Metric Set Topology
 
-variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {U : Set ℂ} {ζ : ℂ} {ρ : ℝ}
 
 /-! ## The boundary of the image of one side -/
 
-/-- **The boundary of the image of one open side of a splitting of a disc lies on the image of the
-splitting set and on the boundary of the image of the disc.** If the disc `ball c r` is covered by
-two disjoint open subsets `s` and `t` of it together with a third set `u`, and `f` is holomorphic
-and injective on the disc, then `frontier (f '' s) ⊆ f '' u ∪ frontier (f '' ball c r)`.
+/-- **The boundary of the image of one open side of a splitting of a domain lies on the image of
+the splitting set and on the boundary of the image of the domain.** If `U` is covered by two
+disjoint open subsets `s` and `t` of it together with a third set `u`, and `f` is holomorphic and
+injective on `U`, then `frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U)`.
 
 The two sides enter symmetrically, so the lemma bounds either of them; the crosscut instances are
-`TauCeti.frontier_image_ball_inter_ball_subset` and
-`TauCeti.frontier_image_ball_diff_closedBall_subset`.
+`TauCeti.frontier_image_inter_ball_subset` and
+`TauCeti.frontier_image_diff_closedBall_subset`.
 
-The sets `f '' s`, `f '' t` and `f '' ball c r` are open by the open mapping theorem, and
-injectivity makes the first two disjoint. A frontier point of `f '' s` lies in
-`closure (f '' ball c r)`, so if it is not a frontier point of `f '' ball c r` it is a value `f w`
-with `w` in one of the three covering sets: `w ∈ s` would place it inside an open set disjoint from
-its own frontier, and `w ∈ t` inside an open set disjoint from a set it is in the closure of, so
-`w ∈ u`. -/
-theorem frontier_image_subset_image_union_frontier_image_ball
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) {s t u : Set ℂ}
-    (hs : IsOpen s) (ht : IsOpen t) (hsr : s ⊆ ball c r) (htr : t ⊆ ball c r)
-    (hst : Disjoint s t) (hcov : ball c r ⊆ s ∪ t ∪ u) :
-    frontier (f '' s) ⊆ f '' u ∪ frontier (f '' ball c r) := by
+The sets `f '' s` and `f '' t` are open by the open mapping theorem, and injectivity makes them
+disjoint. A frontier point of `f '' s` lies in `closure (f '' U)`, so if it is not a frontier point
+of `f '' U` it is a value `f w` with `w` in one of the three covering sets: `w ∈ s` would place it
+inside an open set disjoint from its own frontier, and `w ∈ t` inside an open set disjoint from a
+set it is in the closure of, so `w ∈ u`. Openness of `U` is not used: only the two named sides need
+to be open. -/
+theorem frontier_image_subset_image_union_frontier_image
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) {s t u : Set ℂ}
+    (hs : IsOpen s) (ht : IsOpen t) (hsU : s ⊆ U) (htU : t ⊆ U)
+    (hst : Disjoint s t) (hcov : U ⊆ s ∪ t ∪ u) :
+    frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U) := by
   have hsopen : IsOpen (f '' s) :=
-    isOpen_image_of_differentiableOn_of_injOn hs (hd.mono hsr) (hinj.mono hsr)
+    isOpen_image_of_differentiableOn_of_injOn hs (hd.mono hsU) (hinj.mono hsU)
   have htopen : IsOpen (f '' t) :=
-    isOpen_image_of_differentiableOn_of_injOn ht (hd.mono htr) (hinj.mono htr)
+    isOpen_image_of_differentiableOn_of_injOn ht (hd.mono htU) (hinj.mono htU)
   intro p hp
-  have hpΩ : p ∈ closure (f '' ball c r) := closure_mono (image_mono hsr) hp.1
+  have hpΩ : p ∈ closure (f '' U) := closure_mono (image_mono hsU) hp.1
   rw [closure_eq_self_union_frontier] at hpΩ
   rcases hpΩ with hpin | hpfr
   · obtain ⟨w, hw, rfl⟩ := hpin
@@ -166,106 +171,102 @@ theorem frontier_image_subset_image_union_frontier_image_ball
         (eq_empty_iff_forall_notMem.mp hsopen.inter_frontier_eq (f w))
     · obtain ⟨q, ⟨v, hv, hfv⟩, ⟨x, hx, hfx⟩⟩ :=
         mem_closure_iff.mp hp.1 _ htopen (mem_image_of_mem f hwt)
-      exact absurd (hinj (htr hv) (hsr hx) (hfv.trans hfx.symm) ▸ hv)
+      exact absurd (hinj (htU hv) (hsU hx) (hfv.trans hfx.symm) ▸ hv)
         (Set.disjoint_left.mp hst hx)
     · exact Or.inl (mem_image_of_mem f hwu)
   · exact Or.inr hpfr
 
 /-- **The boundary of the image of a crosscut neighbourhood lies on the image crosscut and on the
-boundary of the image domain.** For `f` holomorphic and injective on `ball c r`, the frontier of the
-image `f '' (ball c r ∩ ball ζ ρ)` of the crosscut neighbourhood is covered by the image
-`f '' (ball c r ∩ sphere ζ ρ)` of the crosscut arc together with `frontier (f '' ball c r)`.
+boundary of the image domain.** For `f` holomorphic and injective on an open `U`, the frontier of
+the image `f '' (U ∩ ball ζ ρ)` of the crosscut neighbourhood is covered by the image
+`f '' (U ∩ sphere ζ ρ)` of the crosscut arc together with `frontier (f '' U)`.
 
-This is `TauCeti.frontier_image_subset_image_union_frontier_image_ball` for the near side of the
-crosscut, the two sides of which are disjoint and open and cover the disc apart from the crosscut
-arc by `TauCeti.ball_diff_sphere_eq_union`. -/
-theorem frontier_image_ball_inter_ball_subset (hd : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) :
-    frontier (f '' (ball c r ∩ ball ζ ρ))
-      ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) := by
-  have hcov : ball c r =
-      ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ ∪ ball c r ∩ sphere ζ ρ := by
-    rw [← ball_diff_sphere_eq_union, sdiff_union_inter]
-  exact frontier_image_subset_image_union_frontier_image_ball hd hinj
-    (isOpen_ball.inter isOpen_ball) (isOpen_ball.sdiff isClosed_closedBall) inter_subset_left
-    sdiff_subset disjoint_ball_inter_ball_ball_diff_closedBall hcov.subset
+This is `TauCeti.frontier_image_subset_image_union_frontier_image` for the near side of the
+crosscut, the two sides of which are disjoint and open and cover the domain apart from the crosscut
+arc by `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`. -/
+theorem frontier_image_inter_ball_subset (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) :
+    frontier (f '' (U ∩ ball ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
+  have hcov : U = U ∩ ball ζ ρ ∪ U \ closedBall ζ ρ ∪ U ∩ sphere ζ ρ := by
+    rw [← diff_sphere_eq_inter_ball_union_diff_closedBall, sdiff_union_inter]
+  exact frontier_image_subset_image_union_frontier_image hd hinj
+    (hUo.inter isOpen_ball) (hUo.sdiff isClosed_closedBall) inter_subset_left
+    sdiff_subset disjoint_inter_ball_diff_closedBall hcov.subset
 
 /-- **The boundary of the image of the far side of a crosscut lies on the image crosscut and on the
-boundary of the image domain.** The mirror of `TauCeti.frontier_image_ball_inter_ball_subset`: it is
-`TauCeti.frontier_image_subset_image_union_frontier_image_ball` read across the crosscut, the two
-sides entering that lemma symmetrically. -/
-theorem frontier_image_ball_diff_closedBall_subset (hd : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) :
-    frontier (f '' (ball c r \ closedBall ζ ρ))
-      ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) := by
-  have hcov : ball c r =
-      ball c r \ closedBall ζ ρ ∪ ball c r ∩ ball ζ ρ ∪ ball c r ∩ sphere ζ ρ := by
-    rw [union_comm (ball c r \ closedBall ζ ρ), ← ball_diff_sphere_eq_union, sdiff_union_inter]
-  exact frontier_image_subset_image_union_frontier_image_ball hd hinj
-    (isOpen_ball.sdiff isClosed_closedBall) (isOpen_ball.inter isOpen_ball) sdiff_subset
-    inter_subset_left disjoint_ball_inter_ball_ball_diff_closedBall.symm hcov.subset
+boundary of the image domain.** The mirror of `TauCeti.frontier_image_inter_ball_subset`: it is
+`TauCeti.frontier_image_subset_image_union_frontier_image` read across the crosscut, the two sides
+entering that lemma symmetrically. -/
+theorem frontier_image_diff_closedBall_subset (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) :
+    frontier (f '' (U \ closedBall ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
+  have hcov : U = U \ closedBall ζ ρ ∪ U ∩ ball ζ ρ ∪ U ∩ sphere ζ ρ := by
+    rw [union_comm (U \ closedBall ζ ρ), ← diff_sphere_eq_inter_ball_union_diff_closedBall,
+      sdiff_union_inter]
+  exact frontier_image_subset_image_union_frontier_image hd hinj
+    (hUo.sdiff isClosed_closedBall) (hUo.inter isOpen_ball) sdiff_subset
+    inter_subset_left disjoint_inter_ball_diff_closedBall.symm hcov.subset
 
 /-! ## The diameter of the cut-off piece -/
 
-/-- **A piece of the disc whose image has its boundary on the image of a set and on the boundary of
-the image domain is no wider than the two together.** For `s` and `u` inside `ball c r` with
-`frontier (f '' s) ⊆ f '' u ∪ frontier (f '' ball c r)`, and a bounded `E` containing the boundary
-points of the image domain that lie on `frontier (f '' s)`, the image `f '' s` has diameter at most
-that of `f '' u ∪ E`.
+/-- **A piece of the domain whose image has its boundary on the image of a set and on the boundary
+of the image domain is no wider than the two together.** For `s` and `u` inside `U` with
+`frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U)`, and a bounded `E` containing the boundary points
+of the image domain that lie on `frontier (f '' s)`, the image `f '' s` has diameter at most that of
+`f '' u ∪ E`.
 
 This is `TauCeti.diam_frontier` — a bounded set has exactly the diameter of its frontier — applied
 to a boundary inclusion; no estimate on `f` is used, the width of the piece being entirely
 determined by the width of what bounds it. -/
-theorem diam_image_le_diam_image_union (hb : IsBounded (f '' ball c r)) {s u : Set ℂ}
-    (hsr : s ⊆ ball c r) (hur : u ⊆ ball c r)
-    (hfr : frontier (f '' s) ⊆ f '' u ∪ frontier (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
-    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' s) ⊆ E) :
+theorem diam_image_le_diam_image_union (hb : IsBounded (f '' U)) {s u : Set ℂ}
+    (hsU : s ⊆ U) (huU : u ⊆ U)
+    (hfr : frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' U) ∩ frontier (f '' s) ⊆ E) :
     diam (f '' s) ≤ diam (f '' u ∪ E) := by
-  rw [← diam_frontier (hb.subset (image_mono hsr))]
-  refine diam_mono (fun p hp => ?_) ((hb.subset (image_mono hur)).union hE)
+  rw [← diam_frontier (hb.subset (image_mono hsU))]
+  refine diam_mono (fun p hp => ?_) ((hb.subset (image_mono huU)).union hE)
   rcases hfr hp with h | h
   · exact Or.inl h
   · exact Or.inr (hEsub ⟨h, hp⟩)
 
 /-- **The image of a crosscut neighbourhood is no wider than the image crosscut together with the
-boundary piece it cuts off.** If every boundary point of the image domain `f '' ball c r` that lies
-on the frontier of `f '' (ball c r ∩ ball ζ ρ)` belongs to a bounded set `E`, then the diameter of
-that image is at most the diameter of `f '' (ball c r ∩ sphere ζ ρ) ∪ E`.
+boundary piece it cuts off.** If every boundary point of the image domain `f '' U` that lies on the
+frontier of `f '' (U ∩ ball ζ ρ)` belongs to a bounded set `E`, then the diameter of that image is
+at most the diameter of `f '' (U ∩ sphere ζ ρ) ∪ E`.
 
-This is `TauCeti.frontier_image_ball_inter_ball_subset` read through
+This is `TauCeti.frontier_image_inter_ball_subset` read through
 `TauCeti.diam_image_le_diam_image_union`. -/
-theorem diam_image_ball_inter_ball_le (hd : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
-    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E) :
-    diam (f '' (ball c r ∩ ball ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) :=
+theorem diam_image_inter_ball_le (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) (hb : IsBounded (f '' U)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ)) ⊆ E) :
+    diam (f '' (U ∩ ball ζ ρ)) ≤ diam (f '' (U ∩ sphere ζ ρ) ∪ E) :=
   diam_image_le_diam_image_union hb inter_subset_left inter_subset_left
-    (frontier_image_ball_inter_ball_subset hd hinj) hE hEsub
+    (frontier_image_inter_ball_subset hUo hd hinj) hE hEsub
 
 /-- **The image of the far side of a crosscut is no wider than the image crosscut together with the
-boundary piece it cuts off.** The mirror of `TauCeti.diam_image_ball_inter_ball_le`: whichever of
-the two sides a boundary piece is supplied for, that side is the one bounded. -/
-theorem diam_image_ball_diff_closedBall_le (hd : DifferentiableOn ℂ f (ball c r))
-    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
-    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r \ closedBall ζ ρ)) ⊆ E) :
-    diam (f '' (ball c r \ closedBall ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) :=
+boundary piece it cuts off.** The mirror of `TauCeti.diam_image_inter_ball_le`: whichever of the two
+sides a boundary piece is supplied for, that side is the one bounded. -/
+theorem diam_image_diff_closedBall_le (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+    (hinj : InjOn f U) (hb : IsBounded (f '' U)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' U) ∩ frontier (f '' (U \ closedBall ζ ρ)) ⊆ E) :
+    diam (f '' (U \ closedBall ζ ρ)) ≤ diam (f '' (U ∩ sphere ζ ρ) ∪ E) :=
   diam_image_le_diam_image_union hb sdiff_subset inter_subset_left
-    (frontier_image_ball_diff_closedBall_subset hd hinj) hE hEsub
+    (frontier_image_diff_closedBall_subset hUo hd hinj) hE hEsub
 
 /-! ## The boundary limit -/
 
 /-- **Small cut-off pieces make the boundary cluster set a subsingleton.** If for every `ε > 0`
-there is a radius `ρ > 0` at which the image `f '' (ball c r ∩ ball ζ ρ)` of the crosscut
-neighbourhood has diameter at most `ε`, then `f` has at most one cluster value at `ζ` along the
-disc.
+there is a radius `ρ > 0` at which the image `f '' (U ∩ ball ζ ρ)` of the crosscut neighbourhood has
+diameter at most `ε`, then `f` has at most one cluster value at `ζ` along `U`.
 
 Only boundedness of the image is assumed — no holomorphy, no injectivity — because the diameter
 hypothesis *is* the Cauchy criterion of `TauCeti.subsingleton_clusterSetOn_of_forall_exists`: the
-crosscut neighbourhoods are exactly the traces on the disc of the balls around `ζ`. Boundedness is
-needed only because `Metric.diam` vanishes on unbounded sets, so a diameter bound is otherwise no
-bound at all. -/
-theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_le (hb : IsBounded (f '' ball c r))
-    (h : ∀ ε > 0, ∃ ρ > 0, diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε) :
-    (clusterSetOn f (ball c r) ζ).Subsingleton := by
+crosscut neighbourhoods are exactly the traces on `U` of the balls around `ζ`. Boundedness is needed
+only because `Metric.diam` vanishes on unbounded sets, so a diameter bound is otherwise no bound at
+all. -/
+theorem subsingleton_clusterSetOn_of_forall_exists_diam_le (hb : IsBounded (f '' U))
+    (h : ∀ ε > 0, ∃ ρ > 0, diam (f '' (U ∩ ball ζ ρ)) ≤ ε) :
+    (clusterSetOn f U ζ).Subsingleton := by
   refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
   obtain ⟨ρ, hρ, hdiam⟩ := h ε hε
   refine ⟨ρ, hρ, fun x hx y hy => le_trans ?_ hdiam⟩
@@ -275,61 +276,56 @@ theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_le (hb : IsBounded 
 /-- **The crosscut criterion in geometric form, cluster-set version.** If for every `ε > 0` there
 is a crosscut radius `ρ > 0` and a bounded set `E` enclosing the boundary points of the image domain
 that cling to the cut-off piece, such that the image crosscut together with `E` has diameter at most
-`ε`, then `f` has at most one cluster value at `ζ` along the disc.
+`ε`, then `f` has at most one cluster value at `ζ` along `U`.
 
-This is `TauCeti.diam_image_ball_inter_ball_le` fed to
-`TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_le`. -/
-theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r))
+This is `TauCeti.diam_image_inter_ball_le` fed to
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_le`. -/
+theorem subsingleton_clusterSetOn_of_forall_exists_diam_union_le (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
     (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
-      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
-      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
-    (clusterSetOn f (ball c r) ζ).Subsingleton := by
-  refine subsingleton_clusterSetOn_ball_of_forall_exists_diam_le hb fun ε hε => ?_
+      frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (U ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    (clusterSetOn f U ζ).Subsingleton := by
+  refine subsingleton_clusterSetOn_of_forall_exists_diam_le hb fun ε hε => ?_
   obtain ⟨ρ, hρ, E, hEb, hEsub, hEdiam⟩ := h ε hε
-  exact ⟨ρ, hρ, (diam_image_ball_inter_ball_le hd hinj hb hEb hEsub).trans hEdiam⟩
+  exact ⟨ρ, hρ, (diam_image_inter_ball_le hUo hd hinj hb hEb hEsub).trans hEdiam⟩
 
-/-- **The crosscut criterion in geometric form, boundary-limit version.** A conformal map of a disc
-with bounded image has a limit at a boundary point `ζ`, along the disc, as soon as the pieces it
-cuts off at `ζ` can be made small in the sense of
-`TauCeti.subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le`.
+/-- **The crosscut criterion in geometric form, boundary-limit version.** A conformal map of a
+domain with bounded image has a limit at a point `ζ` of its closure, along the domain, as soon as
+the pieces it cuts off at `ζ` can be made small in the sense of
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_union_le`.
 
-The cluster set is a subsingleton by that theorem, and it is nonempty because `f` maps the disc into
-the compact closure of its bounded image, which is what
+The cluster set is a subsingleton by that theorem, and it is nonempty because `f` maps the domain
+into the compact closure of its bounded image, which is what
 `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` needs. -/
-theorem exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le (hr : 0 < r)
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r)
+theorem exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
+    (hζ : ζ ∈ closure U)
     (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
-      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
-      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
-    ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) := by
-  refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
-    (fun w hw => subset_closure ⟨w, hw, rfl⟩) ?_
-    (subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le hd hinj hb h)
-  rw [closure_ball c hr.ne']
-  exact mem_closedBall.mpr hζ.le
+      frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (U ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    ∃ v, Tendsto f (𝓝[U] ζ) (𝓝 v) :=
+  exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
+    (fun w hw => subset_closure ⟨w, hw, rfl⟩) hζ
+    (subsingleton_clusterSetOn_of_forall_exists_diam_union_le hUo hd hinj hb h)
 
 /-- **The crosscut criterion in geometric form, continuous-extension version.** If the hypothesis of
-`TauCeti.exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` holds at *every* point
-of the boundary circle, the conformal map `f` extends continuously to `closedBall c r`.
+`TauCeti.exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le` holds at *every* boundary point
+of the domain, the conformal map `f` extends continuously to `closure U`.
 
 This is the shape the Carathéodory boundary correspondence is proved in once the two geometric
 inputs are available: the length–area method makes the image crosscut short at some radius, and
 local connectedness of the image boundary supplies the small set `E` joining its ends. Nothing here
-asserts that the extension is injective, which is an independent matter. -/
-theorem exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le (hr : 0 < r)
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r))
-    (h : ∀ w ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
-      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball w ρ)) ⊆ E ∧
-      diam (f '' (ball c r ∩ sphere w ρ) ∪ E) ≤ ε) :
-    ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
-  obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_isBounded isOpen_ball
-    hd.continuousOn hb fun w hw => by
-      refine subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le hd hinj hb (h w ?_)
-      rwa [frontier_ball c hr.ne'] at hw
-  exact ⟨F, closure_ball c hr.ne' ▸ hFc, hFe⟩
+asserts that the extension is injective, which is an independent matter. For a disc,
+`Metric.frontier_ball` and `Metric.closure_ball` turn the hypothesis and the conclusion into
+statements about `sphere c r` and `closedBall c r`. -/
+theorem exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
+    (h : ∀ w ∈ frontier U, ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' U) ∩ frontier (f '' (U ∩ ball w ρ)) ⊆ E ∧
+      diam (f '' (U ∩ sphere w ρ) ∪ E) ≤ ε) :
+    ∃ F : ℂ → ℂ, ContinuousOn F (closure U) ∧ EqOn F f U :=
+  exists_continuousOn_closure_eqOn_of_isBounded hUo hd.continuousOn hb fun w hw =>
+    subsingleton_clusterSetOn_of_forall_exists_diam_union_le hUo hd hinj hb (h w hw)
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -8,19 +8,19 @@ module
 public import TauCeti.Analysis.Complex.Conformal.ImageSimplyConnected
 public import TauCeti.Analysis.Normed.Module.DiamFrontier
 public import TauCeti.Topology.ClusterSet
-import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
+import TauCeti.Topology.MetricSpace.Cut
 
 /-!
 # The piece a crosscut cuts off, measured by its boundary
 
-`Conformal/Crosscut/Basic.lean` supplies the set-splitting lemmas that cut a set at a point `ζ` by
-the circle `sphere ζ ρ`, leaving the *crosscut neighbourhood* `U ∩ ball ζ ρ` of `ζ`, and turns an
-oscillation bound on that neighbourhood into a boundary limit for a *disc* `U`, by the maximum
-modulus principle. This file carries that criterion to an arbitrary open `U`, and supplies the
-oscillation bound for a *conformal* map, in the geometric form that layer **L5** of
-`TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory boundary correspondence — produces
-it: the image of the crosscut neighbourhood is no wider than the image of the crosscut arc together
-with the piece of `∂Ω` that arc cuts off.
+`Topology/MetricSpace/Cut.lean` supplies the set-splitting lemmas that cut a set at a point `ζ` by
+the circle `sphere ζ ρ`, leaving the *crosscut neighbourhood* `U ∩ ball ζ ρ` of `ζ`, and
+`Conformal/Crosscut/Basic.lean` turns an oscillation bound on that neighbourhood into a boundary
+limit for a *disc* `U`, by the maximum modulus principle. This file carries that criterion to an
+arbitrary open `U`, and supplies the oscillation bound for a *conformal* map, in the geometric form
+that layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory boundary
+correspondence — produces it: the image of the crosscut neighbourhood is no wider than the image of
+the crosscut arc together with the piece of `∂Ω` that arc cuts off.
 
 ## The boundary of the image of a crosscut neighbourhood
 

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -46,9 +46,9 @@ openness of `U`, which enters only when the splitting is produced; holomorphy an
 frontier the conclusion names.
 
 Instantiating it at the near side and at the far side `U \ closedBall ζ ρ`, which by
-`TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` are disjoint and open and leave exactly
+`TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` are disjoint and open and leave exactly
 the crosscut arc, gives `TauCeti.frontier_image_inter_ball_subset` and
-`TauCeti.frontier_image_diff_closedBall_subset`: a consumer may bound either side.
+`TauCeti.frontier_image_sdiff_closedBall_subset`: a consumer may bound either side.
 
 ## From the boundary to the piece
 
@@ -60,7 +60,7 @@ above is already a diameter bound: for any `E` containing the boundary points of
 > `diam A ≤ diam (f '' (U ∩ sphere ζ ρ) ∪ E)`
 
 (`TauCeti.diam_image_inter_ball_le`), and likewise for the far side
-(`TauCeti.diam_image_diff_closedBall_le`), both through the same
+(`TauCeti.diam_image_sdiff_closedBall_le`), both through the same
 `TauCeti.diam_image_le_diam_image_union`. Feeding those bounds, one for each tolerance, to the
 Cauchy criterion of `Topology/ClusterSet.lean` gives the boundary limit
 `TauCeti.exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le` and, if the bounds are available
@@ -101,10 +101,10 @@ space, and `TauCeti.IsPreconnected.inter_frontier_nonempty` for an arbitrary top
 * `TauCeti.frontier_image_subset_image_union_frontier_image` and
   `TauCeti.diam_image_le_diam_image_union` — the boundary inclusion and the diameter bound for one
   side of an arbitrary splitting of the domain into two disjoint open pieces and a remainder.
-* `TauCeti.frontier_image_inter_ball_subset` and `TauCeti.frontier_image_diff_closedBall_subset` —
+* `TauCeti.frontier_image_inter_ball_subset` and `TauCeti.frontier_image_sdiff_closedBall_subset` —
   the boundary of the image of either side of a crosscut is covered by the image crosscut and the
   boundary of the image domain.
-* `TauCeti.diam_image_inter_ball_le` and `TauCeti.diam_image_diff_closedBall_le` — either side of a
+* `TauCeti.diam_image_inter_ball_le` and `TauCeti.diam_image_sdiff_closedBall_le` — either side of a
   crosscut has image no wider than the image crosscut together with the boundary piece it cuts off.
 * `TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_le` and
   `TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_union_le` — small cut-off pieces make
@@ -151,7 +151,7 @@ holomorphic and injective on `s ∪ t`, then `frontier (f '' s) ⊆ f '' u ∪ f
 
 The two sides enter symmetrically, so the lemma bounds either of them; the crosscut instances are
 `TauCeti.frontier_image_inter_ball_subset` and
-`TauCeti.frontier_image_diff_closedBall_subset`.
+`TauCeti.frontier_image_sdiff_closedBall_subset`.
 
 The sets `f '' s` and `f '' t` are open by the open mapping theorem, and injectivity makes them
 disjoint. A frontier point of `f '' s` lies in `closure (f '' U)`, so if it is not a frontier point
@@ -193,31 +193,31 @@ the image `f '' (U ∩ ball ζ ρ)` of the crosscut neighbourhood is covered by 
 
 This is `TauCeti.frontier_image_subset_image_union_frontier_image` for the near side of the
 crosscut, the two sides of which are disjoint and open and cover the domain apart from the crosscut
-arc by `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall`. -/
+arc by `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall`. -/
 theorem frontier_image_inter_ball_subset (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
     (hinj : InjOn f U) :
     frontier (f '' (U ∩ ball ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
   have hcov : U = U ∩ ball ζ ρ ∪ U \ closedBall ζ ρ ∪ U ∩ sphere ζ ρ := by
-    rw [← diff_sphere_eq_inter_ball_union_diff_closedBall, sdiff_union_inter]
+    rw [← sdiff_sphere_eq_inter_ball_union_sdiff_closedBall, sdiff_union_inter]
   have hsub : U ∩ ball ζ ρ ∪ U \ closedBall ζ ρ ⊆ U := union_subset inter_subset_left sdiff_subset
   exact frontier_image_subset_image_union_frontier_image (hd.mono hsub) (hinj.mono hsub)
     (hUo.inter isOpen_ball) (hUo.sdiff isClosed_closedBall) inter_subset_left
-    disjoint_inter_ball_diff_closedBall hcov.subset
+    disjoint_inter_ball_sdiff_closedBall hcov.subset
 
 /-- **The boundary of the image of the far side of a crosscut lies on the image crosscut and on the
 boundary of the image domain.** The mirror of `TauCeti.frontier_image_inter_ball_subset`: it is
 `TauCeti.frontier_image_subset_image_union_frontier_image` read across the crosscut, the two sides
 entering that lemma symmetrically. -/
-theorem frontier_image_diff_closedBall_subset (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+theorem frontier_image_sdiff_closedBall_subset (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
     (hinj : InjOn f U) :
     frontier (f '' (U \ closedBall ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
   have hcov : U = U \ closedBall ζ ρ ∪ U ∩ ball ζ ρ ∪ U ∩ sphere ζ ρ := by
-    rw [union_comm (U \ closedBall ζ ρ), ← diff_sphere_eq_inter_ball_union_diff_closedBall,
+    rw [union_comm (U \ closedBall ζ ρ), ← sdiff_sphere_eq_inter_ball_union_sdiff_closedBall,
       sdiff_union_inter]
   have hsub : U \ closedBall ζ ρ ∪ U ∩ ball ζ ρ ⊆ U := union_subset sdiff_subset inter_subset_left
   exact frontier_image_subset_image_union_frontier_image (hd.mono hsub) (hinj.mono hsub)
     (hUo.sdiff isClosed_closedBall) (hUo.inter isOpen_ball) sdiff_subset
-    disjoint_inter_ball_diff_closedBall.symm hcov.subset
+    disjoint_inter_ball_sdiff_closedBall.symm hcov.subset
 
 /-! ## The diameter of the cut-off piece -/
 
@@ -258,12 +258,12 @@ theorem diam_image_inter_ball_le (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U
 /-- **The image of the far side of a crosscut is no wider than the image crosscut together with the
 boundary piece it cuts off.** The mirror of `TauCeti.diam_image_inter_ball_le`: whichever of the two
 sides a boundary piece is supplied for, that side is the one bounded. -/
-theorem diam_image_diff_closedBall_le (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
+theorem diam_image_sdiff_closedBall_le (hUo : IsOpen U) (hd : DifferentiableOn ℂ f U)
     (hinj : InjOn f U) (hb : IsBounded (f '' U)) {E : Set ℂ} (hE : IsBounded E)
     (hEsub : frontier (f '' U) ∩ frontier (f '' (U \ closedBall ζ ρ)) ⊆ E) :
     diam (f '' (U \ closedBall ζ ρ)) ≤ diam (f '' (U ∩ sphere ζ ρ) ∪ E) :=
   diam_image_le_diam_image_union hb sdiff_subset inter_subset_left
-    (frontier_image_diff_closedBall_subset hUo hd hinj) hE hEsub
+    (frontier_image_sdiff_closedBall_subset hUo hd hinj) hE hEsub
 
 /-! ## The boundary limit -/
 
@@ -371,13 +371,13 @@ theorem frontier_image_ball_inter_ball_subset (hd : DifferentiableOn ℂ f (ball
   frontier_image_inter_ball_subset isOpen_ball hd hinj
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.frontier_image_diff_closedBall_subset`. -/
-@[deprecated frontier_image_diff_closedBall_subset (since := "2026-08-04")]
+`TauCeti.frontier_image_sdiff_closedBall_subset`. -/
+@[deprecated frontier_image_sdiff_closedBall_subset (since := "2026-08-04")]
 theorem frontier_image_ball_diff_closedBall_subset (hd : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) :
     frontier (f '' (ball c r \ closedBall ζ ρ))
       ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) :=
-  frontier_image_diff_closedBall_subset isOpen_ball hd hinj
+  frontier_image_sdiff_closedBall_subset isOpen_ball hd hinj
 
 /-- Deprecated compatibility wrapper for the disc case of `TauCeti.diam_image_inter_ball_le`. -/
 @[deprecated diam_image_inter_ball_le (since := "2026-08-04")]
@@ -388,13 +388,13 @@ theorem diam_image_ball_inter_ball_le (hd : DifferentiableOn ℂ f (ball c r))
   diam_image_inter_ball_le isOpen_ball hd hinj hb hE hEsub
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.diam_image_diff_closedBall_le`. -/
-@[deprecated diam_image_diff_closedBall_le (since := "2026-08-04")]
+`TauCeti.diam_image_sdiff_closedBall_le`. -/
+@[deprecated diam_image_sdiff_closedBall_le (since := "2026-08-04")]
 theorem diam_image_ball_diff_closedBall_le (hd : DifferentiableOn ℂ f (ball c r))
     (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
     (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r \ closedBall ζ ρ)) ⊆ E) :
     diam (f '' (ball c r \ closedBall ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) :=
-  diam_image_diff_closedBall_le isOpen_ball hd hinj hb hE hEsub
+  diam_image_sdiff_closedBall_le isOpen_ball hd hinj hb hE hEsub
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_le`. -/

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -113,6 +113,9 @@ space, and `TauCeti.IsPreconnected.inter_frontier_nonempty` for an arbitrary top
   `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` — the resulting
   boundary limit and continuous extension to the closure.
 
+The disc signatures these replace are kept as deprecated compatibility wrappers in a final section,
+each naming its generalized replacement.
+
 ## Coordination with upstream Mathlib
 
 Layer L5 is absent from
@@ -336,5 +339,111 @@ theorem exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le (hUo : I
     ∃ F : ℂ → ℂ, ContinuousOn F (closure U) ∧ EqOn F f U :=
   exists_continuousOn_closure_eqOn_of_isBounded hUo hd.continuousOn hb fun w hw =>
     subsingleton_clusterSetOn_of_forall_exists_diam_union_le hUo hd hinj hb (h w hw)
+
+/-! ## Deprecated disc-specific forms
+
+Everything above was stated for `U = ball c r`. The old signatures are retained here as deprecated
+compatibility wrappers, each naming its generalized replacement; the openness hypothesis is
+discharged by `Metric.isOpen_ball`, and `Metric.frontier_ball` and `Metric.closure_ball` turn
+`frontier U` and `closure U` back into `sphere c r` and `closedBall c r`. -/
+
+variable {c : ℂ} {r : ℝ}
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_image_subset_image_union_frontier_image`, which asks holomorphy and injectivity
+on `s ∪ t` only, and does not need `t ⊆ U`. -/
+@[deprecated frontier_image_subset_image_union_frontier_image (since := "2026-08-04")]
+theorem frontier_image_subset_image_union_frontier_image_ball
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) {s t u : Set ℂ}
+    (hs : IsOpen s) (ht : IsOpen t) (hsr : s ⊆ ball c r) (htr : t ⊆ ball c r)
+    (hst : Disjoint s t) (hcov : ball c r ⊆ s ∪ t ∪ u) :
+    frontier (f '' s) ⊆ f '' u ∪ frontier (f '' ball c r) :=
+  frontier_image_subset_image_union_frontier_image (hd.mono (union_subset hsr htr))
+    (hinj.mono (union_subset hsr htr)) hs ht hsr hst hcov
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_image_inter_ball_subset`. -/
+@[deprecated frontier_image_inter_ball_subset (since := "2026-08-04")]
+theorem frontier_image_ball_inter_ball_subset (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) :
+    frontier (f '' (ball c r ∩ ball ζ ρ))
+      ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) :=
+  frontier_image_inter_ball_subset isOpen_ball hd hinj
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_image_diff_closedBall_subset`. -/
+@[deprecated frontier_image_diff_closedBall_subset (since := "2026-08-04")]
+theorem frontier_image_ball_diff_closedBall_subset (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) :
+    frontier (f '' (ball c r \ closedBall ζ ρ))
+      ⊆ f '' (ball c r ∩ sphere ζ ρ) ∪ frontier (f '' ball c r) :=
+  frontier_image_diff_closedBall_subset isOpen_ball hd hinj
+
+/-- Deprecated compatibility wrapper for the disc case of `TauCeti.diam_image_inter_ball_le`. -/
+@[deprecated diam_image_inter_ball_le (since := "2026-08-04")]
+theorem diam_image_ball_inter_ball_le (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E) :
+    diam (f '' (ball c r ∩ ball ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) :=
+  diam_image_inter_ball_le isOpen_ball hd hinj hb hE hEsub
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.diam_image_diff_closedBall_le`. -/
+@[deprecated diam_image_diff_closedBall_le (since := "2026-08-04")]
+theorem diam_image_ball_diff_closedBall_le (hd : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {E : Set ℂ} (hE : IsBounded E)
+    (hEsub : frontier (f '' ball c r) ∩ frontier (f '' (ball c r \ closedBall ζ ρ)) ⊆ E) :
+    diam (f '' (ball c r \ closedBall ζ ρ)) ≤ diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) :=
+  diam_image_diff_closedBall_le isOpen_ball hd hinj hb hE hEsub
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_le`. -/
+@[deprecated subsingleton_clusterSetOn_of_forall_exists_diam_le (since := "2026-08-04")]
+theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_le (hb : IsBounded (f '' ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, diam (f '' (ball c r ∩ ball ζ ρ)) ≤ ε) :
+    (clusterSetOn f (ball c r) ζ).Subsingleton :=
+  subsingleton_clusterSetOn_of_forall_exists_diam_le hb h
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists_diam_union_le`. -/
+@[deprecated subsingleton_clusterSetOn_of_forall_exists_diam_union_le (since := "2026-08-04")]
+theorem subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r))
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    (clusterSetOn f (ball c r) ζ).Subsingleton :=
+  subsingleton_clusterSetOn_of_forall_exists_diam_union_le isOpen_ball hd hinj hb h
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le`, whose hypothesis
+`ζ ∈ closure U` the disc discharges from `dist ζ c = r` through `Metric.closure_ball`. -/
+@[deprecated exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le (since := "2026-08-04")]
+theorem exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le (hr : 0 < r)
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r)
+    (h : ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere ζ ρ) ∪ E) ≤ ε) :
+    ∃ v, Tendsto f (𝓝[ball c r] ζ) (𝓝 v) :=
+  exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le isOpen_ball hd hinj hb
+    (closure_ball c hr.ne' ▸ mem_closedBall.mpr hζ.le) h
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`, whose `frontier U` and
+`closure U` the disc turns into `sphere c r` and `closedBall c r`. -/
+@[deprecated exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le
+  (since := "2026-08-04")]
+theorem exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le (hr : 0 < r)
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r))
+    (h : ∀ w ∈ sphere c r, ∀ ε > 0, ∃ ρ > 0, ∃ E : Set ℂ, IsBounded E ∧
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball w ρ)) ⊆ E ∧
+      diam (f '' (ball c r ∩ sphere w ρ) ∪ E) ≤ ε) :
+    ∃ F : ℂ → ℂ, ContinuousOn F (closedBall c r) ∧ EqOn F f (ball c r) := by
+  obtain ⟨F, hFc, hFe⟩ := exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le
+    isOpen_ball hd hinj hb (frontier_ball c hr.ne' ▸ h)
+  exact ⟨F, closure_ball c hr.ne' ▸ hFc, hFe⟩
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
+++ b/TauCeti/Analysis/Complex/Conformal/CutDiameter.lean
@@ -13,12 +13,14 @@ import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 /-!
 # The piece a crosscut cuts off, measured by its boundary
 
-`Conformal/Crosscut/Basic.lean` cuts a domain at a boundary point `ζ` by the circle `sphere ζ ρ`,
-leaving the *crosscut neighbourhood* `U ∩ ball ζ ρ` of `ζ`, and turns an oscillation bound on that
-neighbourhood into a boundary limit. This file supplies such a bound for a *conformal* map, in the
-geometric form that layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory
-boundary correspondence — produces it: the image of the crosscut neighbourhood is no wider than the
-image of the crosscut arc together with the piece of `∂Ω` that arc cuts off.
+`Conformal/Crosscut/Basic.lean` supplies the set-splitting lemmas that cut a set at a point `ζ` by
+the circle `sphere ζ ρ`, leaving the *crosscut neighbourhood* `U ∩ ball ζ ρ` of `ζ`, and turns an
+oscillation bound on that neighbourhood into a boundary limit for a *disc* `U`, by the maximum
+modulus principle. This file carries that criterion to an arbitrary open `U`, and supplies the
+oscillation bound for a *conformal* map, in the geometric form that layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md` — the Carathéodory boundary correspondence — produces
+it: the image of the crosscut neighbourhood is no wider than the image of the crosscut arc together
+with the piece of `∂Ω` that arc cuts off.
 
 ## The boundary of the image of a crosscut neighbourhood
 
@@ -39,7 +41,9 @@ twice: a point `p` of `frontier (f '' s)` lies in `closure Ω = Ω ∪ frontier 
 `f '' s`, which is disjoint from its own frontier, while `w ∈ t` would put `p` in the *open* set
 `f '' t`, which injectivity makes disjoint from `f '' s`, contradicting `p ∈ closure (f '' s)`.
 So `w ∈ u`. Simple connectivity plays no role, and neither does the geometry of `Ω` — nor even
-openness of `U`, which enters only when the splitting is produced.
+openness of `U`, which enters only when the splitting is produced; holomorphy and injectivity of
+`f` are asked for on `s ∪ t` alone, the rest of `U` entering only through the set `f '' U` whose
+frontier the conclusion names.
 
 Instantiating it at the near side and at the far side `U \ closedBall ζ ρ`, which by
 `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` are disjoint and open and leave exactly
@@ -139,8 +143,8 @@ variable {f : ℂ → ℂ} {U : Set ℂ} {ζ : ℂ} {ρ : ℝ}
 
 /-- **The boundary of the image of one open side of a splitting of a domain lies on the image of
 the splitting set and on the boundary of the image of the domain.** If `U` is covered by two
-disjoint open subsets `s` and `t` of it together with a third set `u`, and `f` is holomorphic and
-injective on `U`, then `frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U)`.
+disjoint open sets `s`, `t` together with a third set `u`, the side `s` lies in `U`, and `f` is
+holomorphic and injective on `s ∪ t`, then `frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U)`.
 
 The two sides enter symmetrically, so the lemma bounds either of them; the crosscut instances are
 `TauCeti.frontier_image_inter_ball_subset` and
@@ -150,17 +154,20 @@ The sets `f '' s` and `f '' t` are open by the open mapping theorem, and injecti
 disjoint. A frontier point of `f '' s` lies in `closure (f '' U)`, so if it is not a frontier point
 of `f '' U` it is a value `f w` with `w` in one of the three covering sets: `w ∈ s` would place it
 inside an open set disjoint from its own frontier, and `w ∈ t` inside an open set disjoint from a
-set it is in the closure of, so `w ∈ u`. Openness of `U` is not used: only the two named sides need
-to be open. -/
-theorem frontier_image_subset_image_union_frontier_image
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) {s t u : Set ℂ}
-    (hs : IsOpen s) (ht : IsOpen t) (hsU : s ⊆ U) (htU : t ⊆ U)
+set it is in the closure of, so `w ∈ u`. Openness of `U` is not used, and neither is any analytic
+hypothesis away from the two named sides: only they need to be open, and only on their union is
+`f` asked to be holomorphic and injective. -/
+theorem frontier_image_subset_image_union_frontier_image {s t u : Set ℂ}
+    (hd : DifferentiableOn ℂ f (s ∪ t)) (hinj : InjOn f (s ∪ t))
+    (hs : IsOpen s) (ht : IsOpen t) (hsU : s ⊆ U)
     (hst : Disjoint s t) (hcov : U ⊆ s ∪ t ∪ u) :
     frontier (f '' s) ⊆ f '' u ∪ frontier (f '' U) := by
   have hsopen : IsOpen (f '' s) :=
-    isOpen_image_of_differentiableOn_of_injOn hs (hd.mono hsU) (hinj.mono hsU)
+    isOpen_image_of_differentiableOn_of_injOn hs (hd.mono subset_union_left)
+      (hinj.mono subset_union_left)
   have htopen : IsOpen (f '' t) :=
-    isOpen_image_of_differentiableOn_of_injOn ht (hd.mono htU) (hinj.mono htU)
+    isOpen_image_of_differentiableOn_of_injOn ht (hd.mono subset_union_right)
+      (hinj.mono subset_union_right)
   intro p hp
   have hpΩ : p ∈ closure (f '' U) := closure_mono (image_mono hsU) hp.1
   rw [closure_eq_self_union_frontier] at hpΩ
@@ -171,8 +178,8 @@ theorem frontier_image_subset_image_union_frontier_image
         (eq_empty_iff_forall_notMem.mp hsopen.inter_frontier_eq (f w))
     · obtain ⟨q, ⟨v, hv, hfv⟩, ⟨x, hx, hfx⟩⟩ :=
         mem_closure_iff.mp hp.1 _ htopen (mem_image_of_mem f hwt)
-      exact absurd (hinj (htU hv) (hsU hx) (hfv.trans hfx.symm) ▸ hv)
-        (Set.disjoint_left.mp hst hx)
+      exact absurd (hinj (subset_union_right hv) (subset_union_left hx)
+        (hfv.trans hfx.symm) ▸ hv) (Set.disjoint_left.mp hst hx)
     · exact Or.inl (mem_image_of_mem f hwu)
   · exact Or.inr hpfr
 
@@ -189,9 +196,10 @@ theorem frontier_image_inter_ball_subset (hUo : IsOpen U) (hd : DifferentiableOn
     frontier (f '' (U ∩ ball ζ ρ)) ⊆ f '' (U ∩ sphere ζ ρ) ∪ frontier (f '' U) := by
   have hcov : U = U ∩ ball ζ ρ ∪ U \ closedBall ζ ρ ∪ U ∩ sphere ζ ρ := by
     rw [← diff_sphere_eq_inter_ball_union_diff_closedBall, sdiff_union_inter]
-  exact frontier_image_subset_image_union_frontier_image hd hinj
+  have hsub : U ∩ ball ζ ρ ∪ U \ closedBall ζ ρ ⊆ U := union_subset inter_subset_left sdiff_subset
+  exact frontier_image_subset_image_union_frontier_image (hd.mono hsub) (hinj.mono hsub)
     (hUo.inter isOpen_ball) (hUo.sdiff isClosed_closedBall) inter_subset_left
-    sdiff_subset disjoint_inter_ball_diff_closedBall hcov.subset
+    disjoint_inter_ball_diff_closedBall hcov.subset
 
 /-- **The boundary of the image of the far side of a crosscut lies on the image crosscut and on the
 boundary of the image domain.** The mirror of `TauCeti.frontier_image_inter_ball_subset`: it is
@@ -203,9 +211,10 @@ theorem frontier_image_diff_closedBall_subset (hUo : IsOpen U) (hd : Differentia
   have hcov : U = U \ closedBall ζ ρ ∪ U ∩ ball ζ ρ ∪ U ∩ sphere ζ ρ := by
     rw [union_comm (U \ closedBall ζ ρ), ← diff_sphere_eq_inter_ball_union_diff_closedBall,
       sdiff_union_inter]
-  exact frontier_image_subset_image_union_frontier_image hd hinj
+  have hsub : U \ closedBall ζ ρ ∪ U ∩ ball ζ ρ ⊆ U := union_subset sdiff_subset inter_subset_left
+  exact frontier_image_subset_image_union_frontier_image (hd.mono hsub) (hinj.mono hsub)
     (hUo.sdiff isClosed_closedBall) (hUo.inter isOpen_ball) sdiff_subset
-    inter_subset_left disjoint_inter_ball_diff_closedBall.symm hcov.subset
+    disjoint_inter_ball_diff_closedBall.symm hcov.subset
 
 /-! ## The diameter of the cut-off piece -/
 

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -22,7 +22,7 @@ angles, and concludes that its image under a conformal map has small diameter at
 `ρ`.
 
 That is the first of the two geometric inputs
-`TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le` of
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` of
 `Conformal/CutDiameter.lean` runs on, and hence of layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's boundary correspondence. The second —
 a small set `E` enclosing the boundary points of the image domain that cling to the piece the
@@ -153,7 +153,7 @@ when `ρ < 2 * r`, being empty otherwise; since `R` is arbitrary, a caller wanti
 the theorem with `R ≤ 2 * r`.
 
 This is the first of the two geometric inputs of
-`TauCeti.exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le`; nothing here bounds
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`; nothing here bounds
 the boundary piece the crosscut cuts off, which is a matter of the image domain rather than of the
 map. -/
 theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top (hζ : dist ζ c = r)

--- a/TauCeti/Topology/MetricSpace/Cut.lean
+++ b/TauCeti/Topology/MetricSpace/Cut.lean
@@ -30,9 +30,9 @@ use, and Mathlib has no form of the decomposition.
 
 ## Main results
 
-* `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` — the two sides cover the cut set.
-* `TauCeti.disjoint_inter_ball_diff_closedBall` — the two sides are disjoint.
-* `TauCeti.subset_inter_ball_or_subset_diff_closedBall` — a preconnected subset of an open cut set
+* `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` — the two sides cover the cut set.
+* `TauCeti.disjoint_inter_ball_sdiff_closedBall` — the two sides are disjoint.
+* `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` — a preconnected subset of an open cut set
   missing the sphere lies on one side of it.
 -/
 
@@ -47,7 +47,7 @@ variable {X : Type*} [PseudoMetricSpace X] {x : X} {ρ : ℝ}
 /-- **A circular cut splits a set into a near side and a far side.** Removing the sphere
 `sphere x ρ` from a set `s` leaves the points of `s` at distance less than `ρ` from `x` together
 with those at distance more than `ρ`. -/
-theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set X} :
+theorem sdiff_sphere_eq_inter_ball_union_sdiff_closedBall {s : Set X} :
     s \ sphere x ρ = s ∩ ball x ρ ∪ s \ closedBall x ρ := by
   ext y
   constructor
@@ -62,18 +62,18 @@ theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set X} :
 
 /-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall x ρ` and
 the far side outside it. -/
-theorem disjoint_inter_ball_diff_closedBall {s : Set X} :
+theorem disjoint_inter_ball_sdiff_closedBall {s : Set X} :
     Disjoint (s ∩ ball x ρ) (s \ closedBall x ρ) :=
   Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
 
 /-- **A connected subset of an open set missing a circular cut lies on one side of it.** This is
 the separation statement the decomposition exists for: the two sides are open and disjoint, so a
 preconnected subset of their union cannot meet both. Only openness of the cut set is used. -/
-theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set X} (hs : IsOpen s)
+theorem subset_inter_ball_or_subset_sdiff_closedBall {s S : Set X} (hs : IsOpen s)
     (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere x ρ) :
     S ⊆ s ∩ ball x ρ ∨ S ⊆ s \ closedBall x ρ :=
   hS.subset_or_subset (hs.inter isOpen_ball) (hs.sdiff isClosed_closedBall)
-    disjoint_inter_ball_diff_closedBall
-    (diff_sphere_eq_inter_ball_union_diff_closedBall (x := x) (s := s) ▸ hSsub)
+    disjoint_inter_ball_sdiff_closedBall
+    (sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (x := x) (s := s) ▸ hSsub)
 
 end TauCeti

--- a/TauCeti/Topology/MetricSpace/Cut.lean
+++ b/TauCeti/Topology/MetricSpace/Cut.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Topology.Connected.Basic
+public import Mathlib.Topology.MetricSpace.Pseudo.Lemmas
+
+/-!
+# Cutting a set by a sphere
+
+Removing the sphere `sphere x ρ` from a set `s` leaves two pieces: the *near side*
+`s ∩ ball x ρ`, of the points of `s` closer to `x` than `ρ`, and the *far side*
+`s \ closedBall x ρ`, of those further away. This file records that they cover `s \ sphere x ρ`,
+that they are disjoint, and — when `s` is open, so that both sides are open — that a preconnected
+subset of `s` missing the sphere lies entirely in one of them.
+
+Nothing beyond the containments `ball x ρ ⊆ closedBall x ρ` and `sphere x ρ ⊆ closedBall x ρ`, and
+the openness of a ball against the closedness of a closed ball, is used, so `s` is an arbitrary set
+in an arbitrary pseudo-metric space.
+
+The intended consumer is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's
+boundary correspondence, through `TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean` and
+`TauCeti/Analysis/Complex/Conformal/CutDiameter.lean`: there `X = ℂ` and the sphere is the
+*circular crosscut* of a plane domain at a boundary point, whose near side is the approach region
+along which the boundary behaviour of a conformal map is read off. Nothing here is specific to that
+use, and Mathlib has no form of the decomposition.
+
+## Main results
+
+* `TauCeti.diff_sphere_eq_inter_ball_union_diff_closedBall` — the two sides cover the cut set.
+* `TauCeti.disjoint_inter_ball_diff_closedBall` — the two sides are disjoint.
+* `TauCeti.subset_inter_ball_or_subset_diff_closedBall` — a preconnected subset of an open cut set
+  missing the sphere lies on one side of it.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric Set
+
+variable {X : Type*} [PseudoMetricSpace X] {x : X} {ρ : ℝ}
+
+/-- **A circular cut splits a set into a near side and a far side.** Removing the sphere
+`sphere x ρ` from a set `s` leaves the points of `s` at distance less than `ρ` from `x` together
+with those at distance more than `ρ`. -/
+theorem diff_sphere_eq_inter_ball_union_diff_closedBall {s : Set X} :
+    s \ sphere x ρ = s ∩ ball x ρ ∪ s \ closedBall x ρ := by
+  ext y
+  constructor
+  · rintro ⟨hy, hne⟩
+    rw [Metric.mem_sphere] at hne
+    rcases lt_or_gt_of_ne hne with h | h
+    · exact Or.inl ⟨hy, Metric.mem_ball.mpr h⟩
+    · exact Or.inr ⟨hy, fun hc => absurd (Metric.mem_closedBall.mp hc) (not_le.mpr h)⟩
+  · rintro (⟨hy, h⟩ | ⟨hy, h⟩)
+    · exact ⟨hy, fun hc => (Metric.mem_ball.mp h).ne (Metric.mem_sphere.mp hc)⟩
+    · exact ⟨hy, fun hc => h (Metric.sphere_subset_closedBall hc)⟩
+
+/-- The two sides of a circular cut are disjoint, the near side lying inside `closedBall x ρ` and
+the far side outside it. -/
+theorem disjoint_inter_ball_diff_closedBall {s : Set X} :
+    Disjoint (s ∩ ball x ρ) (s \ closedBall x ρ) :=
+  Set.disjoint_sdiff_right.mono_left (inter_subset_right.trans ball_subset_closedBall)
+
+/-- **A connected subset of an open set missing a circular cut lies on one side of it.** This is
+the separation statement the decomposition exists for: the two sides are open and disjoint, so a
+preconnected subset of their union cannot meet both. Only openness of the cut set is used. -/
+theorem subset_inter_ball_or_subset_diff_closedBall {s S : Set X} (hs : IsOpen s)
+    (hS : IsPreconnected S) (hSsub : S ⊆ s \ sphere x ρ) :
+    S ⊆ s ∩ ball x ρ ∨ S ⊆ s \ closedBall x ρ :=
+  hS.subset_or_subset (hs.inter isOpen_ball) (hs.sdiff isClosed_closedBall)
+    disjoint_inter_ball_diff_closedBall
+    (diff_sphere_eq_inter_ball_union_diff_closedBall (x := x) (s := s) ▸ hSsub)
+
+end TauCeti


### PR DESCRIPTION
This PR generalises the crosscut cut-diameter criterion of `TauCeti/Analysis/Complex/Conformal/CutDiameter.lean` from the disc `Metric.ball c r` to an arbitrary open `U ⊆ ℂ`, and with it the two set-theoretic lemmas of `TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean` that produce the cut. Nothing in the argument used the shape of the disc: the criterion says that if a conformal map's image of the crosscut neighbourhood `U ∩ Metric.ball ζ ρ` can be made small — bounded by the image crosscut `f '' (U ∩ Metric.sphere ζ ρ)` together with a small set enclosing the boundary points of `f '' U` that cling to the cut-off piece — then `f` has a boundary limit at `ζ`, and, if that holds at every point of `frontier U`, a continuous extension to `closure U`. Only the two named sides of the splitting have to be open; the splitting lemma `TauCeti.frontier_image_subset_image_union_frontier_image` needs nothing of the ambient set, which is now visible in its signature.

This is a refactor of already-merged material, so it carries no fresh roadmap claim; the roadmap chiefly motivating it is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5 — Carathéodory boundary correspondence** ("the RMT map of a Jordan domain extends to a homeomorphism of closures"), whose two remaining geometric inputs are exactly what `CutDiameter.lean` is stated to consume. The generality matters there because the L5 milestone relates *two* domains — a Jordan domain and the disc it is mapped from — and the correspondence is a statement about both, while the surrounding L5 material (`Conformal/BoundaryCorrespondence.lean`, `Conformal/LocallyConnectedBoundary.lean`, `Conformal/ClusterSet.lean`, `Topology/ClusterSet.lean`) is already stated for an arbitrary bounded open set. The disc-shaped inputs in `Conformal/ShortCrosscut.lean` are unaffected and instantiate the general form at `U := Metric.ball c r`, where `Metric.frontier_ball` and `Metric.closure_ball` recover the previous `sphere c r` / `closedBall c r` statements.

Old to new names. In `Conformal/Crosscut/Basic.lean` the cut set becomes an arbitrary `s : Set ℂ` (and, for the separation lemma, an arbitrary open `s`, whose openness is now an explicit hypothesis): `ball_diff_sphere_eq_union` to `sdiff_sphere_eq_inter_ball_union_sdiff_closedBall`, `disjoint_ball_inter_ball_ball_diff_closedBall` to `disjoint_inter_ball_sdiff_closedBall`, `subset_ball_inter_ball_or_subset_ball_diff_closedBall` to `subset_inter_ball_or_subset_sdiff_closedBall`. In `Conformal/CutDiameter.lean` the domain becomes an arbitrary open `U`: `frontier_image_subset_image_union_frontier_image_ball` to `frontier_image_subset_image_union_frontier_image`, `frontier_image_ball_inter_ball_subset` to `frontier_image_inter_ball_subset`, `frontier_image_ball_diff_closedBall_subset` to `frontier_image_sdiff_closedBall_subset`, `diam_image_ball_inter_ball_le` to `diam_image_inter_ball_le`, `diam_image_ball_diff_closedBall_le` to `diam_image_sdiff_closedBall_le`, `subsingleton_clusterSetOn_ball_of_forall_exists_diam_le` to `subsingleton_clusterSetOn_of_forall_exists_diam_le`, `subsingleton_clusterSetOn_ball_of_forall_exists_diam_union_le` to `subsingleton_clusterSetOn_of_forall_exists_diam_union_le`, `exists_tendsto_nhdsWithin_ball_of_forall_exists_diam_union_le` to `exists_tendsto_nhdsWithin_of_forall_exists_diam_union_le` (with `dist ζ c = r` replaced by `ζ ∈ closure U`), and `exists_continuousOn_closedBall_eqOn_of_forall_exists_diam_union_le` to `exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`. No declaration is dropped without a strictly more general replacement, and no specialization is left behind: the only code consumer of any renamed lemma is `Conformal/Crosscut/Image.lean`, updated here, alongside docstring references in `Conformal/ShortCrosscut.lean`. `Conformal/Crosscut/Basic.lean`'s own disc-specific results — the Möbius inversion model, the angular description of the crosscut, the connectedness of the two sides and their identification as the connected components of the cut disc — are untouched and continue to use the general lemmas at `s := ball c r`.

The three cut lemmas are stated over an arbitrary pseudo-metric space and use nothing of the plane, so they live in a new lightweight module, `TauCeti/Topology/MetricSpace/Cut.lean`, which imports only `Mathlib.Topology.Connected.Basic` and `Mathlib.Topology.MetricSpace.Pseudo.Lemmas`; `Conformal/Crosscut/Basic.lean` imports it and keeps the deprecated disc signatures, and `Conformal/CutDiameter.lean`, whose only dependency on `Conformal/Crosscut/Basic.lean` was those three lemmas, imports it directly.

No mathematics is added and no Mathlib infrastructure is vendored; the statements consume `TauCeti.diam_frontier`, `TauCeti.isOpen_image_of_differentiableOn_of_injOn` and the cluster-set criteria of `TauCeti/Topology/ClusterSet.lean` exactly as before. Per the roadmap's coordination clause, L5 is absent from the in-progress upstream Riemann-mapping effort [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), so this material is not shim material; the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn` that it consumes remains marked as such in the module docstring.

`lake build` and `lake exe axioms` are green, as are `scripts/lint-env.sh` and `lake exe module-system`.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"cut-diameter-criterion-arbitrary-domain"}-->

🤖 Prepared with Claude Code


