### PR TITLE
fix: stabilize review contributor trust

### DIFF
--- a/scripts/pr_stats_graphs.md
+++ b/scripts/pr_stats_graphs.md
@@ -36,9 +36,9 @@ It requires an authenticated `gh` CLI. In GitHub Actions, set `GH_TOKEN` to
   the engine started stamping that block; `pr-stats.json` records how many marker comments
   were rejected and why.
   This is a count of posted scoreboards, not reconstructed review rounds; scoreboards
-  edited in place remain one comment. As in the status pipeline, attribution accepts
-  only comments whose author association is `OWNER`, `MEMBER`, or `COLLABORATOR`; an
-  external account cannot forge review credit with a pasted marker and metadata block.
+  edited in place remain one comment. Attribution accepts only comments posted by a
+  current repository collaborator, read from GitHub's collaborators endpoint; an external
+  account cannot forge review credit with a pasted marker and metadata block.
 - Seven-day metrics use complete UTC calendar days. Merge latency is PR creation to
   merge time among PRs merged in that trailing window. Cumulative contributor histories
   include events through the snapshot time, including the current partial UTC day.

--- a/scripts/pr_stats_graphs.py
+++ b/scripts/pr_stats_graphs.py
@@ -53,7 +53,6 @@ SCOREBOARD_MARKER = "<!--tauceti-scoreboard-->"
 # marker or paste another PR's scoreboard.  scripts/pr_status/core.py parses the same block
 # when it derives a single PR's review state.
 SCOREBOARD_META_KIND = "scoreboard"
-TRUSTED_ASSOCIATIONS = {"OWNER", "MEMBER", "COLLABORATOR"}
 STATE_REVIEW = {"awaiting-review", "review-in-progress"}
 STATE_LABELS = {"awaiting-author", *STATE_REVIEW}
 # States in which the PR has left the review queue: the author owns it, or CI is judging a
@@ -288,15 +287,42 @@ def names_scoreboard_for(metas: Iterable[str], pr_number: int) -> bool:
     return False
 
 
-def fetch_scoreboards(repo: str, pr_numbers: set[int]) -> tuple[list[dict], Counter]:
+def fetch_trusted_collaborators(repo: str) -> set[str]:
+    """Current repository collaborators, using the token-independent trust endpoint.
+
+    ``author_association`` on issue comments is requester-dependent: a GitHub Actions
+    installation token can see an organization member as ``CONTRIBUTOR`` even when a member's
+    user token sees ``MEMBER``.  The collaborators endpoint instead answers the question the
+    chart needs directly and is available to installation tokens with metadata read access.
+    """
+    raw = run_gh([
+        "api", "--paginate",
+        f"repos/{repo}/collaborators?affiliation=all&per_page=100",
+        "--jq", ".[].login",
+    ])
+    collaborators = {line.strip() for line in raw.splitlines() if line.strip()}
+    if not collaborators:
+        raise ValueError(
+            "GitHub returned no repository collaborators; refusing an empty review chart"
+        )
+    return collaborators
+
+
+def fetch_scoreboards(
+    repo: str,
+    pr_numbers: set[int],
+    trusted_logins: set[str] | None = None,
+) -> tuple[list[dict], Counter]:
     """Canonical review scoreboards posted on this repository's pull requests.
 
     The repository issue-comments endpoint also serves ordinary issues and accepts comments
     from anyone. A comment counts only when its issue number is one of the fetched pull
-    requests, its author is repository-associated, and its parsed engine metadata declares
-    a scoreboard for that same PR. Parsing runs at gh/jq, so only compact fields reach Python
-    rather than memory growing with review prose. Rejections are published by reason.
+    requests, its author is a current repository collaborator, and its parsed engine metadata
+    declares a scoreboard for that same PR. Parsing runs at gh/jq, so only compact fields reach
+    Python rather than memory growing with review prose. Rejections are published by reason.
     """
+    if trusted_logins is None:
+        trusted_logins = fetch_trusted_collaborators(repo)
     marker = json.dumps(SCOREBOARD_MARKER)
     raw = run_gh([
         "api", "--paginate",
@@ -306,8 +332,9 @@ def fetch_scoreboards(repo: str, pr_numbers: set[int]) -> tuple[list[dict], Coun
                 ' | ([try ($comment.body | capture("<!--tauceti-meta:v1\\\\s+'
                 '(?<json>\\\\{[\\\\s\\\\S]*\\\\})\\\\s*-->").json'
                 ' | fromjson) catch null][0] // null) as $meta'
-                ' | {number: $number, created_at, updated_at, user: .user.login,'
-                '    author_association, canonical: (($meta | type == "object")'
+                ' | {number: $number, created_at: $comment.created_at,'
+                '    updated_at: $comment.updated_at, user: $comment.user.login,'
+                '    canonical: (($meta | type == "object")'
                 '      and $meta.kind == "scoreboard"'
                 '      and (($meta.pr | type) == "number")'
                 '      and (($meta.pr | floor) == $meta.pr)'
@@ -325,7 +352,7 @@ def fetch_scoreboards(repo: str, pr_numbers: set[int]) -> tuple[list[dict], Coun
         if pr_number not in pr_numbers:
             rejected["not_a_pull_request"] += 1
             continue
-        if comment.get("author_association") not in TRUSTED_ASSOCIATIONS:
+        if comment.get("user") not in trusted_logins:
             rejected["untrusted_author"] += 1
             continue
         if not comment.get("canonical"):
@@ -833,7 +860,7 @@ def generate(
         "last_full_day": last_full_day.isoformat(),
         "definitions": {
             "review_cycle": cycles["definition"],
-            "review": "one canonical <!--tauceti-scoreboard--> comment on a pull request of this repository, identified by the tauceti-meta:v1 block naming that PR, attributed to the posting account",
+            "review": "one canonical <!--tauceti-scoreboard--> comment on a pull request of this repository, identified by the tauceti-meta:v1 block naming that PR, attributed to a current repository collaborator",
             "active_author": "distinct PR author opening a PR in the trailing seven-day window",
             "merge_latency": "PR creation timestamp to merge timestamp",
         },

--- a/scripts/test_pr_stats_graphs.py
+++ b/scripts/test_pr_stats_graphs.py
@@ -231,14 +231,18 @@ class MetricsTest(unittest.TestCase):
             })
 
         raw = "\n".join([
-            comment(7, "reviewer-a"),
+            # GitHub Actions may project a real collaborator as CONTRIBUTOR here.
+            comment(7, "reviewer-a", association="CONTRIBUTOR"),
             comment(8, "issue-commenter"),       # an ordinary issue, not a PR
             comment(9, "marker-quoter", False),  # the public marker without engine meta
             comment(7, "forger", association="NONE"),
             comment(7, "reviewer-b"),
         ])
         with patch.object(stats, "run_gh", return_value=raw):
-            scoreboards, rejected = stats.fetch_scoreboards("example/project", {7, 9})
+            scoreboards, rejected = stats.fetch_scoreboards(
+                "example/project", {7, 9},
+                {"reviewer-a", "reviewer-b", "marker-quoter"},
+            )
         self.assertEqual(
             [(item["pr"], item["user"]) for item in scoreboards],
             [(7, "reviewer-a"), (7, "reviewer-b")],
@@ -272,7 +276,7 @@ class MetricsTest(unittest.TestCase):
             }
 
         comments = [
-            fixture(7, "trusted", "MEMBER",
+            fixture(7, "trusted", "CONTRIBUTOR",
                     {"kind": "scoreboard", "pr": 7, "states": {"api": "green"}}),
             fixture(7, "wrong-pr", "MEMBER", {"kind": "scoreboard", "pr": 8}),
             fixture(7, "string-pr", "MEMBER", {"kind": "scoreboard", "pr": "7"}),
@@ -285,7 +289,7 @@ class MetricsTest(unittest.TestCase):
             },
         ]
         with patch.object(stats, "run_gh", return_value="") as run:
-            stats.fetch_scoreboards("example/project", {7})
+            stats.fetch_scoreboards("example/project", {7}, {"trusted"})
         query = run.call_args.args[0][-1]
         result = subprocess.run(
             ["jq", "-c", query], input=json.dumps(comments), text=True,
@@ -295,7 +299,25 @@ class MetricsTest(unittest.TestCase):
         self.assertEqual(
             [row["canonical"] for row in rows], [True, False, False, False, False],
         )
-        self.assertTrue(all(row["author_association"] == "MEMBER" for row in rows))
+        self.assertEqual(rows[0]["user"], "trusted")
+
+    def test_trusted_collaborators_use_repository_metadata_endpoint(self):
+        with patch.object(stats, "run_gh", return_value="reviewer-a\nreviewer-b\n") as run:
+            self.assertEqual(
+                stats.fetch_trusted_collaborators("example/project"),
+                {"reviewer-a", "reviewer-b"},
+            )
+        self.assertEqual(
+            run.call_args.args[0],
+            ["api", "--paginate",
+             "repos/example/project/collaborators?affiliation=all&per_page=100",
+             "--jq", ".[].login"],
+        )
+
+    def test_empty_collaborator_response_refuses_empty_review_chart(self):
+        with patch.object(stats, "run_gh", return_value=""):
+            with self.assertRaisesRegex(ValueError, "no repository collaborators"):
+                stats.fetch_trusted_collaborators("example/project")
 
     def test_thousands_of_contributors_are_bounded(self):
         start = datetime(2026, 1, 1, tzinfo=UTC)

--- a/web/Site/Stats.lean
+++ b/web/Site/Stats.lean
@@ -78,7 +78,7 @@ private def prGraphs : Html := {{
       <img class="loc-graph" src="static/cumulative-reviews-by-contributor.svg"
            alt="Cumulative trusted v1 review scoreboards by contributor"
            loading="lazy"/>
-      <figcaption>"Cumulative canonical v1 review scoreboards posted by repository-associated accounts; external accounts and edits to existing scoreboards do not add counts."</figcaption>
+      <figcaption>"Cumulative canonical v1 review scoreboards posted by current repository collaborators; external accounts and edits to existing scoreboards do not add counts."</figcaption>
     </figure>
   </div>
 }}
@@ -124,8 +124,8 @@ include the current partial UTC day through the snapshot time. The contributor S
 show every contributor while that remains legible, then cap themselves at 24 named
 lines and combine the remaining long tail. Exact totals for every login remain available in
 the generated [`pr-stats.json`](static/pr-stats.json). Review attribution follows the
-status pipeline's trust boundary: only canonical v1 scoreboards from repository owners,
-members, or collaborators are included.
+status pipeline's trust boundary: only canonical v1 scoreboards from current repository
+collaborators are included.
 
 :::blob prGraphs
 :::


### PR DESCRIPTION
This PR makes review-contributor attribution independent of the requesting GitHub token by reading current trusted logins from the repository collaborators endpoint. GitHub Actions otherwise projects member-authored issue comments as `CONTRIBUTOR`, causing the deployed review history to reject every scoreboard; the new endpoint restores the 1,701 canonical trusted scoreboards and refuses to silently publish an empty chart when collaborator discovery fails.

The script test suite passes (42 tests). The current-main local website build reaches an existing Verso/toolchain incompatibility (`Lean.Doc.PostponedCheck`), while the merged statistics deployment's own 252-job website build passed.

:robot: Prepared with OpenAI Codex
