### PR TITLE
feat(ModularForms): the Sturm bound for finite relative index

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
+++ b/TauCeti/NumberTheory/ModularForms/GaloisProd.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Complex.UpperHalfPlane.Topology
-public import TauCeti.NumberTheory.ModularForms.QExpansionOrder
+public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 /-!
 # The Galois product of a periodic function

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Basic.lean
@@ -1,0 +1,50 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.QExpansion
+
+/-!
+# The `q`-expansion as a linear map
+
+The `q`-expansion of modular forms for a determinant-one subgroup of `GL(2, ℝ)`, bundled as
+a `ℂ`-linear map into power series, refining Mathlib's additive `ModularForm.qExpansionAddHom`.
+
+## Main declarations
+
+* `TauCeti.ModularForm.qExpansionLinearMap`.
+
+## References
+
+* [Mathlib PR #39000](https://github.com/leanprover-community/mathlib4/pull/39000)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane
+
+namespace TauCeti
+
+variable {h : ℝ}
+
+/-- The `q`-expansion map as a `ℂ`-linear map to power series over `ℂ`, refining the additive
+`ModularForm.qExpansionAddHom`. -/
+def ModularForm.qExpansionLinearMap {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
+    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) :
+    ModularForm Γ k →ₗ[ℂ] PowerSeries ℂ where
+  toAddHom := (_root_.ModularForm.qExpansionAddHom hh hΓ k).toAddHom
+  map_smul' a f := _root_.ModularForm.qExpansion_smul hh hΓ a f
+
+@[simp]
+lemma ModularForm.qExpansionLinearMap_apply {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
+    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {k : ℤ} (f : ModularForm Γ k) :
+    ModularForm.qExpansionLinearMap hh hΓ k f = qExpansion h f := by
+  unfold ModularForm.qExpansionLinearMap
+  rfl
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/QExpansion/Order.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansion/Order.lean
@@ -21,7 +21,6 @@ bookkeeping feeding the finite-index Sturm bound.
 
 * `TauCeti.qExpansion_order_eq_analyticOrderAt_cuspFunction`.
 * `TauCeti.qExpansion_nat_mul_order`: `(qExpansion (m * h) g).order = (qExpansion h g).order * m`.
-* `TauCeti.ModularForm.qExpansionLinearMap`: the `q`-expansion as a `ℂ`-linear map.
 
 ## References
 
@@ -91,20 +90,6 @@ lemma qExpansion_order_le_qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (
     (qExpansion h g).order ≤ (qExpansion (m * h : ℝ) g).order :=
   (ENat.self_le_mul_right _ (mod_cast hm.ne')).trans
     (qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff).ge
-
-/-- The `q`-expansion map as a `ℂ`-linear map to power series over `ℂ`. -/
-@[expose]
-def ModularForm.qExpansionLinearMap {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
-    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) :
-    ModularForm Γ k →ₗ[ℂ] PowerSeries ℂ where
-  toFun f := qExpansion h f
-  map_add' f g := _root_.ModularForm.qExpansion_add hh hΓ f g
-  map_smul' a f := _root_.ModularForm.qExpansion_smul hh hΓ a f
-
-@[simp]
-lemma ModularForm.qExpansionLinearMap_apply {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
-    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {k : ℤ} (f : ModularForm Γ k) :
-    ModularForm.qExpansionLinearMap hh hΓ k f = qExpansion h f := rfl
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
+++ b/TauCeti/NumberTheory/ModularForms/QExpansionOrder.lean
@@ -21,6 +21,7 @@ bookkeeping feeding the finite-index Sturm bound.
 
 * `TauCeti.qExpansion_order_eq_analyticOrderAt_cuspFunction`.
 * `TauCeti.qExpansion_nat_mul_order`: `(qExpansion (m * h) g).order = (qExpansion h g).order * m`.
+* `TauCeti.ModularForm.qExpansionLinearMap`: the `q`-expansion as a `ℂ`-linear map.
 
 ## References
 
@@ -83,6 +84,27 @@ lemma qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 
       (by positivity) (by simpa using hg_per.nat_mul m) hg_mdiff hg_bdd),
     analyticOrderAt_congr (cuspFunction_nat_mul_eventuallyEq hh hm hg_per hg_bdd hg_mdiff),
     TauCeti.analyticOrderAt_comp_pow_zero han hm]
+
+/-- The order of the `q`-expansion at period `h` is at most its order at period `m * h`. -/
+lemma qExpansion_order_le_qExpansion_nat_mul_order {g : ℍ → ℂ} {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
+    (qExpansion h g).order ≤ (qExpansion (m * h : ℝ) g).order :=
+  (ENat.self_le_mul_right _ (mod_cast hm.ne')).trans
+    (qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff).ge
+
+/-- The `q`-expansion map as a `ℂ`-linear map to power series over `ℂ`. -/
+@[expose]
+def ModularForm.qExpansionLinearMap {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
+    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (k : ℤ) :
+    ModularForm Γ k →ₗ[ℂ] PowerSeries ℂ where
+  toFun f := qExpansion h f
+  map_add' f g := _root_.ModularForm.qExpansion_add hh hΓ f g
+  map_smul' a f := _root_.ModularForm.qExpansion_smul hh hΓ a f
+
+@[simp]
+lemma ModularForm.qExpansionLinearMap_apply {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.HasDetOne]
+    (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) {k : ℤ} (f : ModularForm Γ k) :
+    ModularForm.qExpansionLinearMap hh hΓ k f = qExpansion h f := rfl
 
 end TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -47,6 +47,15 @@ namespace ModularForm
 
 variable {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.IsFiniteRelIndex 𝒮ℒ] {k : ℤ} (f : ModularForm 𝒢 k)
 
+private lemma strictWidthInfty_pos_of_finiteRelIndex {𝒢 : Subgroup (GL (Fin 2) ℝ)}
+    [𝒢.IsFiniteRelIndex 𝒮ℒ] [DiscreteTopology 𝒢.strictPeriods] : 0 < 𝒢.strictWidthInfty := by
+  obtain ⟨m', hm'_pos, hnRw⟩ :=
+    Subgroup.exists_pos_nat_integerCuspWidth_eq_mul_strictWidthInfty (𝒢 := 𝒢)
+  refine 𝒢.strictWidthInfty_nonneg.lt_of_ne fun heq ↦ ?_
+  rw [← heq, mul_zero] at hnRw
+  exact (by exact_mod_cast Subgroup.integerCuspWidth_pos (𝒢 := 𝒢) : (0 : ℝ) <
+    Subgroup.integerCuspWidth 𝒢).ne' hnRw
+
 private lemma qExpansion_order_le_qExpansion_norm_order [DiscreteTopology 𝒢.strictPeriods] :
     (qExpansion 𝒢.strictWidthInfty f).order ≤
       (qExpansion 1 (_root_.ModularForm.norm 𝒮ℒ f)).order := by
@@ -77,11 +86,8 @@ private lemma qExpansion_order_le_qExpansion_norm_order [DiscreteTopology 𝒢.s
     qExpansion_one_galoisProd_order_eq hn_pos hf_n_per hf_bdd f.holo']
   refine le_trans ?_ le_self_add
   rw [hnRw]
-  exact qExpansion_order_le_qExpansion_nat_mul_order
-    (𝒢.strictWidthInfty_nonneg.lt_of_ne fun heq ↦ by
-      rw [← heq, mul_zero] at hnRw
-      exact hnR_pos.ne' hnRw)
-    hm'_pos hf_w_per hf_bdd f.holo'
+  exact qExpansion_order_le_qExpansion_nat_mul_order strictWidthInfty_pos_of_finiteRelIndex hm'_pos
+    hf_w_per hf_bdd f.holo'
 
 /-- **Sturm bound for subgroups of `GL(2, ℝ)` of finite relative index in `SL(2, ℤ)`.** A
 modular form of weight `k` whose `q`-expansion at the cusp `∞` has order strictly greater
@@ -107,15 +113,9 @@ theorem sturm_bound_finiteIndex_SL2Z {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex]
       Subgroup.relIndex_top_right]
   exact sturm_bound_finiteIndex f (h_index ▸ h)
 
-private lemma strictWidthInfty_pos {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne]
-    [𝒢.IsFiniteRelIndex 𝒮ℒ] [DiscreteTopology 𝒢.strictPeriods] : 0 < 𝒢.strictWidthInfty :=
-  𝒢.strictWidthInfty_pos_iff.mpr <| Subgroup.isCusp_of_mem_strictPeriods
-    (by exact_mod_cast Subgroup.integerCuspWidth_pos (𝒢 := 𝒢))
-    Subgroup.integerCuspWidth_mem_strictPeriods
-
 /-- **Modular forms agreeing up to the Sturm bound are equal**: two weight-`k` forms whose
 `q`-expansions at `∞` agree in every coefficient up to `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` coincide. -/
-theorem eq_of_sturm_bound [𝒢.HasDetOne] [DiscreteTopology 𝒢.strictPeriods]
+theorem eq_of_sturm_bound [DiscreteTopology 𝒢.strictPeriods]
     (g : ModularForm 𝒢 k)
     (h : ∀ i ≤ (k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12,
       PowerSeries.coeff i (qExpansion 𝒢.strictWidthInfty f) =
@@ -123,8 +123,9 @@ theorem eq_of_sturm_bound [𝒢.HasDetOne] [DiscreteTopology 𝒢.strictPeriods]
   rw [← sub_eq_zero]
   refine sturm_bound_finiteIndex (f - g) (lt_of_lt_of_le
     (by exact_mod_cast Nat.lt_succ_self _) (PowerSeries.nat_le_order _ _ fun i hi ↦ ?_))
-  rw [_root_.ModularForm.coe_sub, _root_.ModularForm.qExpansion_sub strictWidthInfty_pos
-    𝒢.strictWidthInfty_mem_strictPeriods, map_sub, sub_eq_zero]
+  rw [_root_.ModularForm.coe_sub, _root_.ModularForm.qExpansion_sub
+    strictWidthInfty_pos_of_finiteRelIndex 𝒢.strictWidthInfty_mem_strictPeriods,
+    map_sub, sub_eq_zero]
   exact h i (Nat.lt_succ_iff.mp hi)
 
 /-- **Finite-dimensionality of modular forms.** As a corollary of the Sturm bound, the space
@@ -138,8 +139,8 @@ instance finiteDimensional_modularForm_finiteIndex
   have hfin : Module.Finite ℂ (Polynomial.degreeLT ℂ N) :=
     Module.Finite.equiv (Polynomial.degreeLTEquiv ℂ N).symm
   refine Module.Finite.of_injective
-    (((PowerSeries.trunc N).comp (ModularForm.qExpansionLinearMap strictWidthInfty_pos
-        𝒢.strictWidthInfty_mem_strictPeriods k)).codRestrict
+    (((PowerSeries.trunc N).comp (ModularForm.qExpansionLinearMap
+        strictWidthInfty_pos_of_finiteRelIndex 𝒢.strictWidthInfty_mem_strictPeriods k)).codRestrict
       (Polynomial.degreeLT ℂ N) fun f ↦
         Polynomial.mem_degreeLT.mpr (PowerSeries.degree_trunc_lt _ _))
     ((injective_iff_map_eq_zero _).mpr fun f hf ↦ ?_)

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -1,0 +1,136 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.LevelOne.DimensionFormula
+public import TauCeti.NumberTheory.ModularForms.NormTrace
+public import TauCeti.NumberTheory.ModularForms.QExpansionOrder
+
+/-!
+# The Sturm bound for finite-index subgroups of `SL(2, ℤ)`
+
+For `𝒢 ≤ GL(2, ℝ)` of finite relative index in `𝒮ℒ` and `f : ModularForm 𝒢 k`, if the
+`q`-expansion of `f` at the cusp `∞` (with cusp width `𝒢.strictWidthInfty`) has order
+strictly greater than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12`, then `f = 0`.
+
+The proof lifts the level-one bound `ModularForm.sturm_bound_levelOne` through the norm map:
+the norm of `f` vanishes exactly when `f` does, and by the decomposition
+`TauCeti.ModularForm.exists_norm_decomposition` sufficient vanishing of `f` at `∞`
+propagates to the norm.
+
+## Main declarations
+
+* `TauCeti.ModularForm.sturm_bound_finiteIndex`: the Sturm bound for finite relative index.
+* `TauCeti.ModularForm.sturm_bound_finiteIndex_SL2Z`: the classical form for finite-index
+  subgroups of `SL(2, ℤ)`.
+* `TauCeti.ModularForm.finiteDimensional_modularForm_finiteIndex`: `ModularForm 𝒢 k` is
+  finite-dimensional over `ℂ`.
+
+## References
+
+* [Mathlib PR #39000](https://github.com/leanprover-community/mathlib4/pull/39000)
+  (Chris Birkbeck) — the upstream draft this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane Complex Function SlashInvariantForm Periodic Subgroup
+
+open scoped ModularForm Topology Filter Manifold MatrixGroups
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.IsFiniteRelIndex 𝒮ℒ] {k : ℤ} (f : ModularForm 𝒢 k)
+
+private lemma qExpansion_order_le_qExpansion_norm_order [DiscreteTopology 𝒢.strictPeriods] :
+    (qExpansion 𝒢.strictWidthInfty f).order ≤
+      (qExpansion 1 (_root_.ModularForm.norm 𝒮ℒ f)).order := by
+  obtain ⟨m', hm'_pos, hnRw⟩ :=
+    Subgroup.exists_pos_nat_integerCuspWidth_eq_mul_strictWidthInfty (𝒢 := 𝒢)
+  have hn_pos : 0 < Subgroup.integerCuspWidth 𝒢 := Subgroup.integerCuspWidth_pos
+  have hnR_pos : (0 : ℝ) < Subgroup.integerCuspWidth 𝒢 := by exact_mod_cast hn_pos
+  have hf_w_per : Function.Periodic (⇑f ∘ ofComplex) 𝒢.strictWidthInfty :=
+    SlashInvariantFormClass.periodic_comp_ofComplex f 𝒢.strictWidthInfty_mem_strictPeriods
+  have hf_bdd : IsBoundedAtImInfty f := OnePoint.isBoundedAt_infty_iff.mp <|
+    f.bdd_at_cusps' <|
+      Subgroup.isCusp_of_mem_strictPeriods hnR_pos Subgroup.integerCuspWidth_mem_strictPeriods
+  have hf_n_per : Function.Periodic (⇑f ∘ ofComplex)
+      ((Subgroup.integerCuspWidth 𝒢 : ℕ) : ℝ) := by
+    rw [hnRw]
+    exact_mod_cast hf_w_per.nat_mul m'
+  obtain ⟨rest, _, h_rest_an, h_decomp⟩ := exists_norm_decomposition f
+  rw [show qExpansion 1 (_root_.ModularForm.norm 𝒮ℒ f) =
+        qExpansion 1 (galoisProd (Subgroup.integerCuspWidth 𝒢) ⇑f) * qExpansion 1 rest by
+      rw [funext h_decomp]
+      exact qExpansion_mul (analyticAt_cuspFunction_zero one_pos
+        (galoisProd_periodic_one hf_n_per) (mdifferentiable_galoisProd f.holo')
+        (isBoundedAtImInfty_galoisProd hf_bdd)) h_rest_an,
+    PowerSeries.order_mul,
+    qExpansion_one_galoisProd_order_eq hn_pos hf_n_per hf_bdd f.holo']
+  refine le_trans ?_ le_self_add
+  rw [hnRw]
+  exact qExpansion_order_le_qExpansion_nat_mul_order
+    (𝒢.strictWidthInfty_nonneg.lt_of_ne fun heq ↦ by
+      rw [← heq, mul_zero] at hnRw
+      exact hnR_pos.ne' hnRw)
+    hm'_pos hf_w_per hf_bdd f.holo'
+
+/-- **Sturm bound for subgroups of `GL(2, ℝ)` of finite relative index in `SL(2, ℤ)`.** A
+modular form of weight `k` whose `q`-expansion at the cusp `∞` has order strictly greater
+than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` is identically zero. -/
+theorem sturm_bound_finiteIndex [DiscreteTopology 𝒢.strictPeriods]
+    (h : (↑((k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12) : ℕ∞) <
+      (qExpansion 𝒢.strictWidthInfty f).order) : f = 0 := by
+  rw [← _root_.ModularForm.coe_eq_zero_iff, ← _root_.ModularForm.norm_eq_zero_iff (ℋ := 𝒮ℒ)]
+  exact _root_.ModularForm.sturm_bound_levelOne <|
+    h.trans_le (qExpansion_order_le_qExpansion_norm_order f)
+
+/-- **Classical Sturm bound for finite-index subgroups of `SL(2, ℤ)`.** -/
+theorem sturm_bound_finiteIndex_SL2Z {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex]
+    {k : ℤ} (f : ModularForm (Γ.map (Matrix.SpecialLinearGroup.mapGL ℝ)) k)
+    (h : (↑((k * Γ.index).toNat / 12) : ℕ∞) <
+      (qExpansion (Γ.map (Matrix.SpecialLinearGroup.mapGL ℝ)).strictWidthInfty f).order) :
+    f = 0 := by
+  have h_index :
+      Nat.card (𝒮ℒ ⧸ (Γ.map (Matrix.SpecialLinearGroup.mapGL ℝ)).subgroupOf 𝒮ℒ) = Γ.index := by
+    rw [← Subgroup.index_eq_card, ← Subgroup.relIndex,
+      MonoidHom.range_eq_map (Matrix.SpecialLinearGroup.mapGL ℝ), ← Subgroup.relIndex_comap,
+      Subgroup.comap_map_eq_self_of_injective Matrix.SpecialLinearGroup.mapGL_injective,
+      Subgroup.relIndex_top_right]
+  exact sturm_bound_finiteIndex f (h_index ▸ h)
+
+/-- The `ℂ`-linear map sending a weight-`k` modular form for `𝒢` to the vector of the first
+`N` coefficients of its `q`-expansion at the cusp `∞` (cusp width `𝒢.strictWidthInfty`). -/
+def qExpansionCoeffLinearMap {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] {k : ℤ} (N : ℕ)
+    (hh : 0 < 𝒢.strictWidthInfty) (hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods) :
+    ModularForm 𝒢 k →ₗ[ℂ] (Fin N → ℂ) :=
+  LinearMap.pi fun i ↦ (PowerSeries.coeff (i : ℕ)).comp (ModularForm.qExpansionLinearMap hh hΓ k)
+
+/-- **Finite-dimensionality of modular forms.** As a corollary of the Sturm bound, the space
+`ModularForm 𝒢 k` is finite-dimensional over `ℂ` for any subgroup `𝒢 ≤ GL(2, ℝ)` of finite
+relative index in `𝒮ℒ` with determinant-one elements and discrete strict periods. -/
+instance finiteDimensional_modularForm_finiteIndex
+    {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] [𝒢.IsFiniteRelIndex 𝒮ℒ]
+    [DiscreteTopology 𝒢.strictPeriods] {k : ℤ} :
+    Module.Finite ℂ (ModularForm 𝒢 k) := by
+  set N : ℕ := (k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12 + 1
+  have hh : 0 < 𝒢.strictWidthInfty :=
+    𝒢.strictWidthInfty_pos_iff.mpr <| Subgroup.isCusp_of_mem_strictPeriods
+      (by exact_mod_cast Subgroup.integerCuspWidth_pos (𝒢 := 𝒢))
+      Subgroup.integerCuspWidth_mem_strictPeriods
+  have hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods := 𝒢.strictWidthInfty_mem_strictPeriods
+  refine Module.Finite.of_injective (qExpansionCoeffLinearMap N hh hΓ)
+    ((injective_iff_map_eq_zero _).mpr fun f hf ↦ ?_)
+  exact sturm_bound_finiteIndex f <| lt_of_lt_of_le (by exact_mod_cast Nat.lt_succ_self _) <|
+    PowerSeries.nat_le_order _ _ fun i hi ↦ by
+      simpa [qExpansionCoeffLinearMap] using congr_fun hf ⟨i, hi⟩
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.NumberTheory.ModularForms.LevelOne.DimensionFormula
 public import TauCeti.NumberTheory.ModularForms.NormTrace
-public import TauCeti.NumberTheory.ModularForms.QExpansionOrder
+public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
 
 /-!
 # The Sturm bound for finite-index subgroups of `SL(2, ℤ)`
@@ -63,13 +63,16 @@ private lemma qExpansion_order_le_qExpansion_norm_order [DiscreteTopology 𝒢.s
     rw [hnRw]
     exact_mod_cast hf_w_per.nat_mul m'
   obtain ⟨rest, _, h_rest_an, h_decomp⟩ := exists_norm_decomposition f
-  rw [show qExpansion 1 (_root_.ModularForm.norm 𝒮ℒ f) =
-        qExpansion 1 (galoisProd (Subgroup.integerCuspWidth 𝒢) ⇑f) * qExpansion 1 rest by
-      rw [funext h_decomp]
-      exact qExpansion_mul (analyticAt_cuspFunction_zero one_pos
-        (galoisProd_periodic_one hf_n_per) (mdifferentiable_galoisProd f.holo')
-        (isBoundedAtImInfty_galoisProd hf_bdd)) h_rest_an,
-    PowerSeries.order_mul,
+  -- `h_decomp` is a pointwise identity; `funext` converts it to an equality of functions so
+  -- the `q`-expansion of the norm literally becomes that of the product, and `qExpansion_mul`
+  -- (with both cusp functions analytic at `0`) splits it.
+  have h_qexp : qExpansion 1 (_root_.ModularForm.norm 𝒮ℒ f) =
+      qExpansion 1 (galoisProd (Subgroup.integerCuspWidth 𝒢) ⇑f) * qExpansion 1 rest := by
+    rw [funext h_decomp]
+    exact qExpansion_mul (analyticAt_cuspFunction_zero one_pos
+      (galoisProd_periodic_one hf_n_per) (mdifferentiable_galoisProd f.holo')
+      (isBoundedAtImInfty_galoisProd hf_bdd)) h_rest_an
+  rw [h_qexp, PowerSeries.order_mul,
     qExpansion_one_galoisProd_order_eq hn_pos hf_n_per hf_bdd f.holo']
   refine le_trans ?_ le_self_add
   rw [hnRw]
@@ -110,6 +113,14 @@ def qExpansionCoeffLinearMap {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne]
     ModularForm 𝒢 k →ₗ[ℂ] (Fin N → ℂ) :=
   LinearMap.pi fun i ↦ (PowerSeries.coeff (i : ℕ)).comp (ModularForm.qExpansionLinearMap hh hΓ k)
 
+@[simp]
+lemma qExpansionCoeffLinearMap_apply {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] {k : ℤ}
+    (N : ℕ) (hh : 0 < 𝒢.strictWidthInfty) (hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods)
+    (f : ModularForm 𝒢 k) (i : Fin N) :
+    qExpansionCoeffLinearMap N hh hΓ f i =
+      PowerSeries.coeff (i : ℕ) (qExpansion 𝒢.strictWidthInfty f) := by
+  simp [qExpansionCoeffLinearMap]
+
 /-- **Finite-dimensionality of modular forms.** As a corollary of the Sturm bound, the space
 `ModularForm 𝒢 k` is finite-dimensional over `ℂ` for any subgroup `𝒢 ≤ GL(2, ℝ)` of finite
 relative index in `𝒮ℒ` with determinant-one elements and discrete strict periods. -/
@@ -127,7 +138,7 @@ instance finiteDimensional_modularForm_finiteIndex
     ((injective_iff_map_eq_zero _).mpr fun f hf ↦ ?_)
   exact sturm_bound_finiteIndex f <| lt_of_lt_of_le (by exact_mod_cast Nat.lt_succ_self _) <|
     PowerSeries.nat_le_order _ _ fun i hi ↦ by
-      simpa [qExpansionCoeffLinearMap] using congr_fun hf ⟨i, hi⟩
+      simpa using congr_fun hf ⟨i, hi⟩
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -5,15 +5,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.ModularForms.LevelOne.DimensionFormula
+public import Mathlib.RingTheory.Polynomial.DegreeLT
 public import TauCeti.NumberTheory.ModularForms.NormTrace
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Basic
 
 /-!
 # The Sturm bound for finite-index subgroups of `SL(2, ℤ)`
 
-For `𝒢 ≤ GL(2, ℝ)` of finite relative index in `𝒮ℒ` and `f : ModularForm 𝒢 k`, if the
-`q`-expansion of `f` at the cusp `∞` (with cusp width `𝒢.strictWidthInfty`) has order
-strictly greater than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12`, then `f = 0`.
+For `𝒢 ≤ GL(2, ℝ)` of finite relative index in `𝒮ℒ` with discrete strict periods and
+`f : ModularForm 𝒢 k`, if the `q`-expansion of `f` at the cusp `∞` (with cusp width
+`𝒢.strictWidthInfty`) has order strictly greater than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12`, then
+`f = 0`.
 
 The proof lifts the level-one bound `ModularForm.sturm_bound_levelOne` through the norm map:
 the norm of `f` vanishes exactly when `f` does, and by the decomposition
@@ -89,9 +91,9 @@ private lemma qExpansion_order_le_qExpansion_norm_order [DiscreteTopology 𝒢.s
   exact qExpansion_order_le_qExpansion_nat_mul_order strictWidthInfty_pos_of_finiteRelIndex hm'_pos
     hf_w_per hf_bdd f.holo'
 
-/-- **Sturm bound for subgroups of `GL(2, ℝ)` of finite relative index in `SL(2, ℤ)`.** A
-modular form of weight `k` whose `q`-expansion at the cusp `∞` has order strictly greater
-than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` is identically zero. -/
+/-- **Sturm bound for subgroups of `GL(2, ℝ)` of finite relative index in `SL(2, ℤ)`** with
+discrete strict periods. A modular form of weight `k` whose `q`-expansion at the cusp `∞`
+has order strictly greater than `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` is identically zero. -/
 theorem sturm_bound_finiteIndex [DiscreteTopology 𝒢.strictPeriods]
     (h : (↑((k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12) : ℕ∞) <
       (qExpansion 𝒢.strictWidthInfty f).order) : f = 0 := by
@@ -136,8 +138,6 @@ instance finiteDimensional_modularForm_finiteIndex
     [DiscreteTopology 𝒢.strictPeriods] {k : ℤ} :
     Module.Finite ℂ (ModularForm 𝒢 k) := by
   set N : ℕ := (k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12 + 1
-  have hfin : Module.Finite ℂ (Polynomial.degreeLT ℂ N) :=
-    Module.Finite.equiv (Polynomial.degreeLTEquiv ℂ N).symm
   refine Module.Finite.of_injective
     (((PowerSeries.trunc N).comp (ModularForm.qExpansionLinearMap
         strictWidthInfty_pos_of_finiteRelIndex 𝒢.strictWidthInfty_mem_strictPeriods k)).codRestrict

--- a/TauCeti/NumberTheory/ModularForms/SturmBound.lean
+++ b/TauCeti/NumberTheory/ModularForms/SturmBound.lean
@@ -25,6 +25,7 @@ propagates to the norm.
 * `TauCeti.ModularForm.sturm_bound_finiteIndex`: the Sturm bound for finite relative index.
 * `TauCeti.ModularForm.sturm_bound_finiteIndex_SL2Z`: the classical form for finite-index
   subgroups of `SL(2, ℤ)`.
+* `TauCeti.ModularForm.eq_of_sturm_bound`: forms agreeing up to the bound are equal.
 * `TauCeti.ModularForm.finiteDimensional_modularForm_finiteIndex`: `ModularForm 𝒢 k` is
   finite-dimensional over `ℂ`.
 
@@ -106,20 +107,25 @@ theorem sturm_bound_finiteIndex_SL2Z {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex]
       Subgroup.relIndex_top_right]
   exact sturm_bound_finiteIndex f (h_index ▸ h)
 
-/-- The `ℂ`-linear map sending a weight-`k` modular form for `𝒢` to the vector of the first
-`N` coefficients of its `q`-expansion at the cusp `∞` (cusp width `𝒢.strictWidthInfty`). -/
-def qExpansionCoeffLinearMap {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] {k : ℤ} (N : ℕ)
-    (hh : 0 < 𝒢.strictWidthInfty) (hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods) :
-    ModularForm 𝒢 k →ₗ[ℂ] (Fin N → ℂ) :=
-  LinearMap.pi fun i ↦ (PowerSeries.coeff (i : ℕ)).comp (ModularForm.qExpansionLinearMap hh hΓ k)
+private lemma strictWidthInfty_pos {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne]
+    [𝒢.IsFiniteRelIndex 𝒮ℒ] [DiscreteTopology 𝒢.strictPeriods] : 0 < 𝒢.strictWidthInfty :=
+  𝒢.strictWidthInfty_pos_iff.mpr <| Subgroup.isCusp_of_mem_strictPeriods
+    (by exact_mod_cast Subgroup.integerCuspWidth_pos (𝒢 := 𝒢))
+    Subgroup.integerCuspWidth_mem_strictPeriods
 
-@[simp]
-lemma qExpansionCoeffLinearMap_apply {𝒢 : Subgroup (GL (Fin 2) ℝ)} [𝒢.HasDetOne] {k : ℤ}
-    (N : ℕ) (hh : 0 < 𝒢.strictWidthInfty) (hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods)
-    (f : ModularForm 𝒢 k) (i : Fin N) :
-    qExpansionCoeffLinearMap N hh hΓ f i =
-      PowerSeries.coeff (i : ℕ) (qExpansion 𝒢.strictWidthInfty f) := by
-  simp [qExpansionCoeffLinearMap]
+/-- **Modular forms agreeing up to the Sturm bound are equal**: two weight-`k` forms whose
+`q`-expansions at `∞` agree in every coefficient up to `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` coincide. -/
+theorem eq_of_sturm_bound [𝒢.HasDetOne] [DiscreteTopology 𝒢.strictPeriods]
+    (g : ModularForm 𝒢 k)
+    (h : ∀ i ≤ (k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12,
+      PowerSeries.coeff i (qExpansion 𝒢.strictWidthInfty f) =
+        PowerSeries.coeff i (qExpansion 𝒢.strictWidthInfty g)) : f = g := by
+  rw [← sub_eq_zero]
+  refine sturm_bound_finiteIndex (f - g) (lt_of_lt_of_le
+    (by exact_mod_cast Nat.lt_succ_self _) (PowerSeries.nat_le_order _ _ fun i hi ↦ ?_))
+  rw [_root_.ModularForm.coe_sub, _root_.ModularForm.qExpansion_sub strictWidthInfty_pos
+    𝒢.strictWidthInfty_mem_strictPeriods, map_sub, sub_eq_zero]
+  exact h i (Nat.lt_succ_iff.mp hi)
 
 /-- **Finite-dimensionality of modular forms.** As a corollary of the Sturm bound, the space
 `ModularForm 𝒢 k` is finite-dimensional over `ℂ` for any subgroup `𝒢 ≤ GL(2, ℝ)` of finite
@@ -129,16 +135,20 @@ instance finiteDimensional_modularForm_finiteIndex
     [DiscreteTopology 𝒢.strictPeriods] {k : ℤ} :
     Module.Finite ℂ (ModularForm 𝒢 k) := by
   set N : ℕ := (k * Nat.card (𝒮ℒ ⧸ 𝒢.subgroupOf 𝒮ℒ)).toNat / 12 + 1
-  have hh : 0 < 𝒢.strictWidthInfty :=
-    𝒢.strictWidthInfty_pos_iff.mpr <| Subgroup.isCusp_of_mem_strictPeriods
-      (by exact_mod_cast Subgroup.integerCuspWidth_pos (𝒢 := 𝒢))
-      Subgroup.integerCuspWidth_mem_strictPeriods
-  have hΓ : 𝒢.strictWidthInfty ∈ 𝒢.strictPeriods := 𝒢.strictWidthInfty_mem_strictPeriods
-  refine Module.Finite.of_injective (qExpansionCoeffLinearMap N hh hΓ)
+  have hfin : Module.Finite ℂ (Polynomial.degreeLT ℂ N) :=
+    Module.Finite.equiv (Polynomial.degreeLTEquiv ℂ N).symm
+  refine Module.Finite.of_injective
+    (((PowerSeries.trunc N).comp (ModularForm.qExpansionLinearMap strictWidthInfty_pos
+        𝒢.strictWidthInfty_mem_strictPeriods k)).codRestrict
+      (Polynomial.degreeLT ℂ N) fun f ↦
+        Polynomial.mem_degreeLT.mpr (PowerSeries.degree_trunc_lt _ _))
     ((injective_iff_map_eq_zero _).mpr fun f hf ↦ ?_)
-  exact sturm_bound_finiteIndex f <| lt_of_lt_of_le (by exact_mod_cast Nat.lt_succ_self _) <|
-    PowerSeries.nat_le_order _ _ fun i hi ↦ by
-      simpa using congr_fun hf ⟨i, hi⟩
+  refine sturm_bound_finiteIndex f (lt_of_lt_of_le (by exact_mod_cast Nat.lt_succ_self _)
+    (PowerSeries.nat_le_order _ _ fun i hi ↦ ?_))
+  have hval : PowerSeries.trunc N (qExpansion 𝒢.strictWidthInfty f) = 0 := by
+    simpa using congrArg Subtype.val hf
+  have hcoeff := congrArg (fun p ↦ Polynomial.coeff p i) hval
+  rwa [PowerSeries.coeff_trunc, if_pos hi, Polynomial.coeff_zero] at hcoeff
 
 end ModularForm
 


### PR DESCRIPTION
The Sturm-bound summit (chain step 5 of 5): for `𝒢 ≤ GL(2, ℝ)` of finite relative index in `𝒮ℒ` with discrete strict periods, a weight-`k` modular form whose `q`-expansion at `∞` has order exceeding `k · [𝒮ℒ : 𝒢 ⊓ 𝒮ℒ] / 12` vanishes (`TauCeti.ModularForm.sturm_bound_finiteIndex`), by lifting Mathlib's `sturm_bound_levelOne` through the norm map via the decomposition `exists_norm_decomposition` (#1965). The classical statement for finite-index `Γ ≤ SL(2, ℤ)` and finite-dimensionality of `ModularForm 𝒢 k` (via the coefficient linear map) follow as corollaries.

`QExpansionOrder.lean` gains the two generic prerequisites: the order-monotonicity corollary `qExpansion_order_le_qExpansion_nat_mul_order` and the `ℂ`-linear `qExpansionLinearMap` with its apply lemma.

Ports the `SturmBound.lean` increment of [mathlib4#39000](https://github.com/leanprover-community/mathlib4/pull/39000) onto the current pin.

<!--tauceti-target:v1 {"focus":"ModularForms","id":"sturm-bound-summit"}-->
Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
