### PR TITLE
feat: identify the middle piece of a crosscut as its two ends

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -40,12 +40,12 @@ with its closure; they do not assert the continuous boundary extension itself.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
   `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging.
-* `TauCeti.dist_circleMap_eq_two_mul_abs_sin` is the chord length `2 * |ρ| * |sin ((θ - θ') / 2)|`
-  between two angles of a circle.
 * `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` — a ball centred at a point of the closed
   crosscut meets the crosscut in a subarc: a crosscut spans less than a half turn, so along it the
   chord distance to a fixed one of its points falls and then rises, and the angles it keeps below a
-  threshold form an interval. This is the local connectedness of a crosscut at its own endpoints,
+  threshold form an interval. The chord length itself is measured by
+  `TauCeti.dist_circleMap_eq_two_mul_abs_sin`, in `TauCeti/Topology/Circle/Metric.lean`. This is the
+  local connectedness of a crosscut at its own endpoints,
   which `Conformal/Crosscut/Image.lean` spends to make the cluster set of a conformal map at an end
   of an image crosscut a continuum.
 
@@ -116,27 +116,7 @@ private theorem dist_circleMap_sq (hζ : dist ζ c = r) (θ : ℝ) :
   rw [dist_eq_norm, ← Complex.normSq_eq_norm_sq, hsub, Complex.normSq_sub, hu, ha, hcross]
   ring
 
-/-- **The chord of a circle.** The two points of `circleMap ζ ρ` at angles `θ` and `θ'` are at
-distance `2 * |ρ| * |sin ((θ - θ') / 2)|`; nothing is assumed of the radius, a negative `ρ`
-tracing the same circle in the other sense.
-
-This is the unit-circle chord formula `TauCeti.dist_circleExp_eq_two_mul_abs_sin` — itself Mathlib's
-`Complex.norm_exp_I_mul_ofReal_sub_one : ‖exp (I * x) - 1‖ = ‖2 * sin (x / 2)‖` — transported along
-the translation and real scaling that carry `Circle.exp` to `circleMap ζ ρ`, which is how the
-angular descriptions in this file measure distances along a crosscut. -/
-theorem dist_circleMap_eq_two_mul_abs_sin (ζ : ℂ) (ρ θ θ' : ℝ) :
-    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * |Real.sin ((θ - θ') / 2)| := by
-  have hsub : circleMap ζ ρ θ - circleMap ζ ρ θ' =
-      (ρ : ℂ) * ((Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)) := by
-    simp only [circleMap, Circle.coe_exp]
-    ring
-  have hchord : ‖(Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)‖ = 2 * |Real.sin ((θ - θ') / 2)| := by
-    rw [← dist_circleExp_eq_two_mul_abs_sin, ← Complex.dist_eq]
-    exact (Subtype.dist_eq _ _).symm
-  rw [dist_eq_norm, hsub, norm_mul, Complex.norm_real, Real.norm_eq_abs, hchord]
-  ring
-
-/-- The chord length of `TauCeti.dist_circleMap_eq_two_mul_abs_sin` with the sign of the angular
+/-- The chord length `TauCeti.dist_circleMap_eq_two_mul_abs_sin` with the sign of the angular
 difference cleared: for angles at most `π` apart the chord grows with the angular gap. -/
 private lemma dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ}
     (h : |θ - θ'| ≤ π) :

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -19,7 +19,10 @@ companion, and its two endpoints exactly. If
 * `φ = arccos (ρ / (2 * r))` is the half-angle of the crosscut,
 
 then the open and closed arcs are the images under `circleMap ζ ρ` of `(α - φ, α + φ)` and
-`[α - φ, α + φ]`, while the two bounding circles meet at the images of the endpoints.
+`[α - φ, α + φ]`, while the two bounding circles meet at the images of the endpoints. Since
+`φ < π / 2`, a crosscut spans less than a half turn, and the chord length along it is therefore
+unimodal about any one of its points; that is what makes a crosscut *locally connected at its own
+endpoints*, the last statement below.
 
 This is the source-side endpoint interface needed by layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of Carathéodory boundary
@@ -36,6 +39,14 @@ with its closure; they do not assert the continuous boundary extension itself.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
   `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging.
+* `TauCeti.dist_circleMap_circleMap` is the chord length `2 * |ρ| * |sin ((θ - θ') / 2)|` between
+  two angles of a circle.
+* `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` — a ball centred at a point of the closed
+  crosscut meets the crosscut in a subarc: a crosscut spans less than a half turn, so along it the
+  chord distance to a fixed one of its points falls and then rises, and the angles it keeps below a
+  threshold form an interval. This is the local connectedness of a crosscut at its own endpoints,
+  which `Conformal/Crosscut/Image.lean` spends to make the cluster set of a conformal map at an end
+  of an image crosscut a continuum.
 
 ## Coordination with upstream Mathlib
 
@@ -103,6 +114,83 @@ private theorem dist_circleMap_sq (hζ : dist ζ c = r) (θ : ℝ) :
         ring
   rw [dist_eq_norm, ← Complex.normSq_eq_norm_sq, hsub, Complex.normSq_sub, hu, ha, hcross]
   ring
+
+/-- **The chord of a circle.** The two points of `circleMap ζ ρ` at angles `θ` and `θ'` are at
+distance `2 * |ρ| * |sin ((θ - θ') / 2)|`; nothing is assumed of the radius, a negative `ρ`
+tracing the same circle in the other sense.
+
+Mathlib has the unit-circle case in the form
+`Complex.norm_exp_I_mul_ofReal_sub_one : ‖exp (I * x) - 1‖ = ‖2 * sin (x / 2)‖`; this is that
+statement transported to `circleMap`, which is how the angular descriptions in this file measure
+distances along a crosscut. -/
+theorem dist_circleMap_circleMap (ζ : ℂ) (ρ θ θ' : ℝ) :
+    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * |Real.sin ((θ - θ') / 2)| := by
+  have hsub : circleMap ζ ρ θ - circleMap ζ ρ θ' =
+      (ρ : ℂ) * exp ((θ' : ℂ) * I) * (exp (I * ((θ - θ' : ℝ) : ℂ)) - 1) := by
+    have hmul : exp ((θ' : ℂ) * I) * exp (I * ((θ - θ' : ℝ) : ℂ)) = exp ((θ : ℂ) * I) := by
+      rw [← Complex.exp_add]
+      congr 1
+      push_cast
+      ring
+    simp only [circleMap]
+    rw [mul_sub, mul_one, mul_assoc, hmul]
+    ring
+  rw [dist_eq_norm, hsub, norm_mul, norm_mul, Complex.norm_real, Real.norm_eq_abs,
+    Complex.norm_exp_ofReal_mul_I, mul_one, Complex.norm_exp_I_mul_ofReal_sub_one,
+    Real.norm_eq_abs, abs_mul]
+  norm_num
+  ring
+
+/-- The chord length of `TauCeti.dist_circleMap_circleMap` with the sign of the angular difference
+cleared: for angles at most `π` apart the chord grows with the angular gap. -/
+private lemma dist_circleMap_circleMap_eq_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ}
+    (h : |θ - θ'| ≤ π) :
+    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
+  rw [dist_circleMap_circleMap]
+  congr 1
+  have hnn : 0 ≤ Real.sin (|θ - θ'| / 2) :=
+    Real.sin_nonneg_of_nonneg_of_le_pi (by positivity) (by linarith [Real.pi_pos])
+  rcases abs_cases (θ - θ') with ⟨hc, -⟩ | ⟨hc, -⟩
+  · rw [hc] at hnn ⊢
+    exact abs_of_nonneg hnn
+  · rw [hc] at hnn ⊢
+    rw [neg_div, Real.sin_neg]
+    rw [neg_div, Real.sin_neg] at hnn
+    exact abs_of_nonpos (by linarith)
+
+/-- **A ball centred at a point of an arc of angular width at most `π` meets it in an arc.** The
+chord distance to a fixed angle `θ₀` of the arc falls and then rises as the angle sweeps across the
+arc, so the angles it keeps below a threshold form an interval. -/
+private lemma ordConnected_Ioo_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : ℝ) {a b θ₀ δ : ℝ}
+    (hab : b - a ≤ π) (h₀ : θ₀ ∈ Icc a b) :
+    (Ioo a b ∩ {θ | dist (circleMap ζ ρ θ) (circleMap ζ ρ θ₀) < δ}).OrdConnected := by
+  have hdist : ∀ u ∈ Icc a b, dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀)
+      = 2 * |ρ| * Real.sin (|u - θ₀| / 2) := by
+    intro u hu
+    refine dist_circleMap_circleMap_eq_sin_abs ζ ρ ?_
+    rw [abs_le]
+    constructor <;> [linarith [hu.1, h₀.2]; linarith [hu.2, h₀.1]]
+  have hmono : ∀ u ∈ Icc a b, ∀ v ∈ Icc a b, |u - θ₀| ≤ |v - θ₀| →
+      dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀) ≤ dist (circleMap ζ ρ v) (circleMap ζ ρ θ₀) := by
+    intro u hu v hv huv
+    rw [hdist u hu, hdist v hv]
+    have hvπ : |v - θ₀| ≤ π := by
+      rw [abs_le]
+      constructor <;> [linarith [hv.1, h₀.2]; linarith [hv.2, h₀.1]]
+    have hsin : Real.sin (|u - θ₀| / 2) ≤ Real.sin (|v - θ₀| / 2) :=
+      Real.sin_le_sin_of_le_of_le_pi_div_two
+        (by linarith [abs_nonneg (u - θ₀), Real.pi_pos]) (by linarith) (by linarith)
+    exact mul_le_mul_of_nonneg_left hsin (by positivity)
+  refine ⟨fun x hx y hy z hz => ⟨(ordConnected_Ioo (a := a) (b := b)).out hx.1 hy.1 hz, ?_⟩⟩
+  have hzIcc : z ∈ Icc a b :=
+    Ioo_subset_Icc_self ((ordConnected_Ioo (a := a) (b := b)).out hx.1 hy.1 hz)
+  rcases le_total z θ₀ with hzθ | hzθ
+  · refine lt_of_le_of_lt (hmono z hzIcc x (Ioo_subset_Icc_self hx.1) ?_) hx.2
+    rw [abs_of_nonpos (by linarith), abs_of_nonpos (by linarith [hz.1])]
+    linarith [hz.1]
+  · refine lt_of_le_of_lt (hmono z hzIcc y (Ioo_subset_Icc_self hy.1) ?_) hy.2
+    rw [abs_of_nonneg (by linarith), abs_of_nonneg (by linarith [hz.2])]
+    linarith [hz.2]
 
 /-- A point of `sphere ζ ρ`, in angular coordinates, lies in `closedBall c r` exactly when its
 angle satisfies the weak cosine inequality complementary to
@@ -346,5 +434,33 @@ theorem closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : �
   · rintro z ⟨θ, hθ, rfl⟩
     exact mem_closure_image (continuous_circleMap ζ ρ).continuousAt
       (by rwa [closure_Ioo hab.ne])
+
+/-- **A ball centred at a point of the closed crosscut meets the crosscut in a subarc.** A genuine
+circular crosscut spans an angle `2 * arccos (ρ / (2 * r)) < π`, so along it the chord distance to
+a fixed one of its points is unimodal; the part of the crosscut inside any ball centred at such a
+point is therefore the image of an interval of angles, and in particular preconnected.
+
+This is the local connectedness of a crosscut *at its own endpoints*, which is what the cluster set
+of a map along a crosscut needs in order to be a continuum
+(`TauCeti.isConnected_clusterSetOn`). The radius `δ` is arbitrary: for large `δ` the trace is the
+whole crosscut. -/
+theorem isPreconnected_ball_inter_sphere_inter_ball (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) {e : ℂ} (he : e ∈ closedBall c r ∩ sphere ζ ρ) (δ : ℝ) :
+    IsPreconnected (ball c r ∩ sphere ζ ρ ∩ ball e δ) := by
+  have hr : 0 < r := by linarith
+  have hx0 : 0 < ρ / (2 * r) := div_pos hρ (by positivity)
+  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 := Real.arccos_lt_pi_div_two.mpr hx0
+  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
+    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
+    exact he
+  rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr, ← image_inter_preimage]
+  refine IsPreconnected.image ?_ _ (continuous_circleMap ζ ρ).continuousOn
+  have hpre : circleMap ζ ρ ⁻¹' ball (circleMap ζ ρ θ₀) δ
+      = {θ | dist (circleMap ζ ρ θ) (circleMap ζ ρ θ₀) < δ} := by
+    ext θ
+    simp [Metric.mem_ball]
+  rw [hpre]
+  exact (ordConnected_Ioo_inter_setOf_dist_circleMap_lt ζ ρ (by linarith) hθ₀).isPreconnected
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 import Mathlib.Geometry.Euclidean.Basic
+import TauCeti.Topology.Circle.Metric
 
 /-!
 # The endpoints of a circular crosscut
@@ -39,8 +40,8 @@ with its closure; they do not assert the continuous boundary extension itself.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
   `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging.
-* `TauCeti.dist_circleMap_circleMap` is the chord length `2 * |ρ| * |sin ((θ - θ') / 2)|` between
-  two angles of a circle.
+* `TauCeti.dist_circleMap_eq_two_mul_abs_sin` is the chord length `2 * |ρ| * |sin ((θ - θ') / 2)|`
+  between two angles of a circle.
 * `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` — a ball centred at a point of the closed
   crosscut meets the crosscut in a subarc: a crosscut spans less than a half turn, so along it the
   chord distance to a fixed one of its points falls and then rises, and the angles it keeps below a
@@ -119,34 +120,28 @@ private theorem dist_circleMap_sq (hζ : dist ζ c = r) (θ : ℝ) :
 distance `2 * |ρ| * |sin ((θ - θ') / 2)|`; nothing is assumed of the radius, a negative `ρ`
 tracing the same circle in the other sense.
 
-Mathlib has the unit-circle case in the form
-`Complex.norm_exp_I_mul_ofReal_sub_one : ‖exp (I * x) - 1‖ = ‖2 * sin (x / 2)‖`; this is that
-statement transported to `circleMap`, which is how the angular descriptions in this file measure
-distances along a crosscut. -/
-theorem dist_circleMap_circleMap (ζ : ℂ) (ρ θ θ' : ℝ) :
+This is the unit-circle chord formula `TauCeti.dist_circleExp_eq_two_mul_abs_sin` — itself Mathlib's
+`Complex.norm_exp_I_mul_ofReal_sub_one : ‖exp (I * x) - 1‖ = ‖2 * sin (x / 2)‖` — transported along
+the translation and real scaling that carry `Circle.exp` to `circleMap ζ ρ`, which is how the
+angular descriptions in this file measure distances along a crosscut. -/
+theorem dist_circleMap_eq_two_mul_abs_sin (ζ : ℂ) (ρ θ θ' : ℝ) :
     dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * |Real.sin ((θ - θ') / 2)| := by
   have hsub : circleMap ζ ρ θ - circleMap ζ ρ θ' =
-      (ρ : ℂ) * exp ((θ' : ℂ) * I) * (exp (I * ((θ - θ' : ℝ) : ℂ)) - 1) := by
-    have hmul : exp ((θ' : ℂ) * I) * exp (I * ((θ - θ' : ℝ) : ℂ)) = exp ((θ : ℂ) * I) := by
-      rw [← Complex.exp_add]
-      congr 1
-      push_cast
-      ring
-    simp only [circleMap]
-    rw [mul_sub, mul_one, mul_assoc, hmul]
+      (ρ : ℂ) * ((Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)) := by
+    simp only [circleMap, Circle.coe_exp]
     ring
-  rw [dist_eq_norm, hsub, norm_mul, norm_mul, Complex.norm_real, Real.norm_eq_abs,
-    Complex.norm_exp_ofReal_mul_I, mul_one, Complex.norm_exp_I_mul_ofReal_sub_one,
-    Real.norm_eq_abs, abs_mul]
-  norm_num
+  have hchord : ‖(Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)‖ = 2 * |Real.sin ((θ - θ') / 2)| := by
+    rw [← dist_circleExp_eq_two_mul_abs_sin, ← Complex.dist_eq]
+    exact (Subtype.dist_eq _ _).symm
+  rw [dist_eq_norm, hsub, norm_mul, Complex.norm_real, Real.norm_eq_abs, hchord]
   ring
 
-/-- The chord length of `TauCeti.dist_circleMap_circleMap` with the sign of the angular difference
-cleared: for angles at most `π` apart the chord grows with the angular gap. -/
-private lemma dist_circleMap_circleMap_eq_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ}
+/-- The chord length of `TauCeti.dist_circleMap_eq_two_mul_abs_sin` with the sign of the angular
+difference cleared: for angles at most `π` apart the chord grows with the angular gap. -/
+private lemma dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ}
     (h : |θ - θ'| ≤ π) :
     dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
-  rw [dist_circleMap_circleMap]
+  rw [dist_circleMap_eq_two_mul_abs_sin]
   congr 1
   have hnn : 0 ≤ Real.sin (|θ - θ'| / 2) :=
     Real.sin_nonneg_of_nonneg_of_le_pi (by positivity) (by linarith [Real.pi_pos])
@@ -167,7 +162,7 @@ private lemma ordConnected_Ioo_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : �
   have hdist : ∀ u ∈ Icc a b, dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀)
       = 2 * |ρ| * Real.sin (|u - θ₀| / 2) := by
     intro u hu
-    refine dist_circleMap_circleMap_eq_sin_abs ζ ρ ?_
+    refine dist_circleMap_eq_two_mul_sin_abs ζ ρ ?_
     rw [abs_le]
     constructor <;> [linarith [hu.1, h₀.2]; linarith [hu.2, h₀.1]]
   have hmono : ∀ u ∈ Icc a b, ∀ v ∈ Icc a b, |u - θ₀| ≤ |v - θ₀| →

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -47,10 +47,11 @@ The middle piece is not merely small, it is *exactly the two ends of the image c
 > `frontier Ω ∩ closure γ = ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f S e`
 
 for `S = ball c r ∩ sphere ζ ρ` the crosscut itself, the index set being its two endpoints
-(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). Each of those two cluster sets is nonempty
+(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). The equality itself allows the two cluster sets
+to be empty; as soon as the image crosscut `γ` is bounded each of them is nonempty
 (`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`) and in fact a continuum
-(`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to the boundary of
-the image at *each* of its ends and the middle piece is where those two ends sit.
+(`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), and then the crosscut clings to the boundary
+of the image at *each* of its ends and the middle piece is where those two ends sit.
 
 Both inclusions come from the same source. The closure of an image crosscut is the image crosscut
 together with its two end cluster sets
@@ -102,7 +103,8 @@ pseudometric space.
   crosscut is the image crosscut together with the cluster sets at its two endpoints.
 * `TauCeti.nonempty_clusterSetOn_ball_inter_sphere` and
   `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — each of those two end cluster sets is
-  nonempty, and connected as soon as `f` is continuous along the crosscut.
+  nonempty once the image of the crosscut is bounded, and connected once `f` is in addition
+  continuous along the crosscut.
 * `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` — the middle
   piece is *exactly* the union of the two end cluster sets, its one-sided inclusion being
   `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`.
@@ -283,9 +285,11 @@ holomorphic and injective on `ball c r` and a genuine circular crosscut at a bou
 
 the index set being the two endpoints of the crosscut by
 `TauCeti.sphere_inter_sphere_eq_pair_circleMap`. So the part of the image boundary that the
-crosscut clings to is not merely small and nonempty: it is the union of the cluster sets at the two
-ends, each of them nonempty by `TauCeti.nonempty_clusterSetOn_ball_inter_sphere`. This is what a
-small connected boundary set enclosing the middle piece —
+crosscut clings to is not merely small: it is the union of the cluster sets at the two ends. The
+image of the crosscut is not assumed bounded here, so the equality by itself leaves those two
+cluster sets possibly empty; add that boundedness and each of them is nonempty by
+`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`, which is what a small connected boundary set
+enclosing the middle piece —
 `TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` — has to *join*.
 
 One inclusion is `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`. For

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -18,8 +18,9 @@ import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 are the two connected components of what is left. `Conformal/CutDiameter.lean` transports the
 two sides to a conformal image and bounds their width by the width of the image crosscut together
 with the boundary piece cut off. This file completes that picture on the image side: it splits
-`frontier (f '' ball c r)`, and it supplies — from local connectedness of that frontier — a small
-connected boundary set enclosing the part of that frontier which clings to the image crosscut.
+`frontier (f '' ball c r)`, identifies the middle piece of that splitting as the two ends of the
+image crosscut, and supplies — from local connectedness of that frontier — a small connected
+boundary set enclosing that middle piece.
 
 ## The decomposition
 
@@ -40,16 +41,35 @@ estimate of `Conformal/ShortCrosscut.lean` can be made as small as desired.
 
 ## The middle piece, and the connected boundary set enclosing it
 
-The middle piece is not merely small, it is *nonempty*
-(`TauCeti.nonempty_frontier_inter_closure_image_ball_inter_sphere`): the crosscut has an endpoint on
-`sphere c r`, and along that endpoint `f` has a cluster value, which is adherent to `γ` and — a
-conformal map being proper — is not attained, hence lies on `frontier Ω`. That is a statement about
-the *one* endpoint the proof selects, and all that is claimed: nothing below says where the other
-end goes, nor that the two ends are joined.
+The middle piece is not merely small, it is *exactly the two ends of the image crosscut*
+(`TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn`):
 
-That nonemptiness is what the last theorem consumes. If `frontier Ω` is uniformly locally connected
-— which by `TauCeti.IsCompact.isUniformlyLocallyConnected` is exactly local connectedness,
-`frontier Ω` being compact — then for every `ε > 0` there is a single `δ > 0`, independent of the
+> `frontier Ω ∩ closure γ = ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f S e`
+
+for `S = ball c r ∩ sphere ζ ρ` the crosscut itself, the index set being its two endpoints
+(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). Each of those two cluster sets is nonempty
+(`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`) and in fact a continuum
+(`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to the boundary of
+the image at *each* of its ends and the middle piece is where those two ends sit.
+
+Both inclusions come from the same source. The closure of an image crosscut is the image crosscut
+together with its two end cluster sets
+(`TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn`), because closing the open
+arc `ball c r ∩ sphere ζ ρ` adds exactly the two points of `sphere c r ∩ sphere ζ ρ` and a
+continuous `f` contributes only its own values over the arc itself. A value taken *on* the crosscut
+lies in the open set `Ω`, which is disjoint from `frontier Ω`, so the middle piece can only consist
+of end cluster values; conversely each end cluster value lies on `frontier Ω`, since a conformal
+map is proper (`TauCeti.clusterSetOn_subset_frontier_image`), and is adherent to `γ` by
+construction.
+
+What this does *not* say is that the two ends are joined: the identification is of the middle piece
+with the union of two cluster sets, not with a connected subset of `frontier Ω` running between
+them.
+
+That nonemptiness is what the enclosure theorem consumes. If `frontier Ω` is uniformly locally
+connected — which by `TauCeti.IsCompact.isUniformlyLocallyConnected` is exactly local
+connectedness, `frontier Ω` being compact — then for every `ε > 0` there is a single `δ > 0`,
+independent of the
 boundary point `ζ` and of the crosscut radius `ρ`, such that an image crosscut of diameter less than
 `δ` has its whole middle piece enclosed in a *connected* subset of `frontier Ω` of diameter at most
 `ε` (`TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt`), the general enclosure
@@ -78,6 +98,14 @@ pseudometric space.
 * `TauCeti.frontier_image_ball_subset_union` and `TauCeti.frontier_image_ball_eq_union` — a
   crosscut cuts the boundary of the image into two pieces and a middle piece adherent to the image
   crosscut.
+* `TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of an image
+  crosscut is the image crosscut together with the cluster sets at its two endpoints.
+* `TauCeti.nonempty_clusterSetOn_ball_inter_sphere` and
+  `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — each of those two end cluster sets is
+  nonempty, and connected as soon as `f` is continuous along the crosscut.
+* `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` — the middle
+  piece is *exactly* the union of the two end cluster sets, its one-sided inclusion being
+  `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`.
 * `TauCeti.diam_frontier_inter_closure_image_ball_inter_sphere_le` and
   `TauCeti.nonempty_frontier_inter_closure_image_ball_inter_sphere` — the middle piece is nonempty
   and no wider than the image crosscut.
@@ -107,7 +135,7 @@ namespace TauCeti
 
 open Bornology Complex Filter Metric Set Topology
 
-variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {c ζ e : ℂ} {r ρ : ℝ}
 
 /-! ## The three pieces of the image -/
 
@@ -155,7 +183,128 @@ theorem frontier_image_ball_eq_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ)
   rw [← inter_union_distrib_left, ← inter_union_distrib_left]
   exact (inter_eq_left.mpr (frontier_image_ball_subset_union f c ζ r ρ)).symm
 
+/-! ## The two ends of the image crosscut -/
+
+/-- **The closure of an image crosscut is the image crosscut together with its two end cluster
+sets.** The crosscut `ball c r ∩ sphere ζ ρ` is an open arc whose closure adds exactly the two
+points of `sphere c r ∩ sphere ζ ρ`
+(`TauCeti.closure_ball_inter_sphere`, `TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and a
+continuous `f` contributes nothing new over the arc itself, so all of `closure (f '' arc)` beyond
+`f '' arc` is cluster values at the two ends.
+
+Only continuity along the arc is used; `f` need be neither holomorphic nor injective, and the
+image need not be bounded. -/
+theorem closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) :
+    closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      f '' (ball c r ∩ sphere ζ ρ) ∪
+        ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
+  have hcl : closure (ball c r ∩ sphere ζ ρ) = closedBall c r ∩ sphere ζ ρ :=
+    closure_ball_inter_sphere hζ hρ hρr
+  have hcomp : IsCompact (closure (ball c r ∩ sphere ζ ρ)) := by
+    rw [hcl]
+    exact (isCompact_closedBall c r).inter_right isClosed_sphere
+  have hsplit : closure (ball c r ∩ sphere ζ ρ) =
+      (ball c r ∩ sphere ζ ρ) ∪ (sphere c r ∩ sphere ζ ρ) := by
+    rw [hcl, ← ball_union_sphere, union_inter_distrib_right]
+  have harc : ⋃ w ∈ ball c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) w
+      = f '' (ball c r ∩ sphere ζ ρ) := by
+    ext v
+    simp only [mem_iUnion₂, mem_image]
+    constructor
+    · rintro ⟨w, hw, hv⟩
+      rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw), mem_singleton_iff] at hv
+      exact ⟨w, hw, hv.symm⟩
+    · rintro ⟨w, hw, rfl⟩
+      exact ⟨w, hw, by
+        rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw)]; rfl⟩
+  rw [closure_image_eq_biUnion_clusterSetOn hcomp, hsplit, biUnion_union, harc]
+
+/-- **An end cluster set of an image crosscut lies in the middle piece.** For `f` holomorphic and
+injective on `ball c r` and an endpoint `e` of a circular crosscut, every value `f` clusters at
+along the crosscut as `e` is approached is a boundary value of the image adherent to the image
+crosscut.
+
+Both halves are already available: the cluster set along the crosscut is contained in the cluster
+set along the whole disc, which `TauCeti.clusterSetOn_subset_frontier_image` — properness of a
+conformal map — puts on `frontier (f '' ball c r)`; and cluster values are adherent to the image
+of the approach set by `TauCeti.clusterSetOn_subset_closure_image`. -/
+theorem clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hr : 0 < r)
+    (he : e ∈ sphere c r ∩ sphere ζ ρ) :
+    clusterSetOn f (ball c r ∩ sphere ζ ρ) e ⊆
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+  refine subset_inter (fun v hv => ?_) fun v hv => clusterSetOn_subset_closure_image hv
+  refine clusterSetOn_subset_frontier_image isOpen_ball hd hinj ?_
+    (clusterSetOn_mono inter_subset_left hv)
+  rw [frontier_ball c hr.ne']
+  exact he.1
+
+/-- **Each end of a circular crosscut carries a cluster value.** The crosscut is adherent to each
+of its two endpoints and `f` is confined to the compact `closure (f '' ball c r)`, so the cluster
+set there is nonempty; no holomorphy is needed. -/
+theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' ball c r))
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
+    (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Nonempty := by
+  refine clusterSetOn_nonempty hb.isCompact_closure
+    (fun z hz => subset_closure (mem_image_of_mem f (inter_subset_left hz))) ?_
+  rw [closure_ball_inter_sphere hζ hρ hρr]
+  exact ⟨sphere_subset_closedBall he.1, he.2⟩
+
+/-- **Each end of an image crosscut is a continuum.** For `f` continuous along a genuine circular
+crosscut and with bounded image, the cluster set at either endpoint is nonempty and connected; it
+is compact by `TauCeti.isCompact_clusterSetOn_of_isBounded`. This is the Collingwood–Lohwater
+continuum theorem `TauCeti.isConnected_clusterSetOn`, whose local hypothesis — that arbitrarily
+small neighbourhoods of the endpoint meet the crosscut in a preconnected set — is exactly
+`TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half turn
+and so meeting each ball centred on it in a subarc. -/
+theorem isConnected_clusterSetOn_ball_inter_sphere
+    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hb : IsBounded (f '' ball c r))
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
+    IsConnected (clusterSetOn f (ball c r ∩ sphere ζ ρ) e) := by
+  have hecl : e ∈ closedBall c r ∩ sphere ζ ρ := ⟨sphere_subset_closedBall he.1, he.2⟩
+  refine isConnected_clusterSetOn_of_isBounded hfc (hb.subset (image_mono inter_subset_left))
+    (by rw [closure_ball_inter_sphere hζ hρ hρr]; exact hecl) fun s hs => ?_
+  obtain ⟨δ, hδ, hball⟩ := Metric.mem_nhds_iff.mp hs
+  exact ⟨ball e δ, ball_mem_nhds e hδ, hball,
+    isPreconnected_ball_inter_sphere_inter_ball hζ hρ hρr hecl δ⟩
+
 /-! ## The middle piece -/
+
+/-- **The middle piece is exactly the two end cluster sets of the image crosscut.** For `f`
+holomorphic and injective on `ball c r` and a genuine circular crosscut at a boundary point `ζ`,
+
+> `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))`
+> `= ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e`,
+
+the index set being the two endpoints of the crosscut by
+`TauCeti.sphere_inter_sphere_eq_pair_circleMap`. So the part of the image boundary that the
+crosscut clings to is not merely small and nonempty: it is the union of the cluster sets at the two
+ends, each of them nonempty by `TauCeti.nonempty_clusterSetOn_ball_inter_sphere`. This is what a
+small connected boundary set enclosing the middle piece —
+`TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` — has to *join*.
+
+One inclusion is `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`. For
+the other, `TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` splits a point
+of the closure of the image crosscut into a value on the crosscut and a cluster value at an end,
+and a value on the crosscut lies in the *open* image `f '' ball c r`, which is disjoint from its
+own frontier. -/
+theorem frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
+  have hr : 0 < r := by linarith
+  refine subset_antisymm ?_ (iUnion₂_subset fun e he =>
+    clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image hd hinj hr he)
+  rintro v ⟨hvfr, hvcl⟩
+  rw [closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hd.continuousOn.mono inter_subset_left) hζ hρ hρr] at hvcl
+  refine hvcl.resolve_left fun hv => ?_
+  have hopen : IsOpen (f '' ball c r) :=
+    isOpen_image_of_differentiableOn_of_injOn isOpen_ball hd hinj
+  exact (hopen.frontier_eq ▸ hvfr).2 (image_mono inter_subset_left hv)
 
 /-- **The middle piece is no wider than the image crosscut.** It is contained in the closure of the
 image crosscut, and closing a set does not change its diameter. -/
@@ -171,14 +320,12 @@ theorem diam_frontier_inter_closure_image_ball_inter_sphere_le (hb : IsBounded (
 /-- **The middle piece is nonempty**: for `f` holomorphic and injective on `ball c r` with bounded
 image, and a genuine circular crosscut at a boundary point `ζ`, the set
 `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))` has a point. So the image
-crosscut does cling to the boundary of the image — at the one endpoint the proof selects; where the
-other end of the crosscut goes is not asserted.
+crosscut does cling to the boundary of the image, and — by
+`TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` and
+`TauCeti.nonempty_clusterSetOn_ball_inter_sphere` — at *each* of its two ends.
 
-The crosscut has an endpoint `e` on `sphere c r`, adherent to it by
-`TauCeti.closure_ball_inter_sphere`. Along `e` the map has a cluster value, the image being confined
-to the compact `closure (f '' ball c r)`; that value is adherent to the image crosscut by
-construction, and by `TauCeti.clusterSetOn_subset_frontier_image` — properness of a conformal map —
-it is a boundary value of the image rather than one of its points. -/
+The crosscut has an endpoint on `sphere c r`, and the cluster set of `f` along the crosscut there
+is nonempty and contained in the middle piece. -/
 theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
     (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
@@ -189,18 +336,8 @@ theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
       ∈ sphere c r ∩ sphere ζ ρ := by
     rw [sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr]
     exact Or.inl rfl
-  have hecl : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ∈ closure (ball c r ∩ sphere ζ ρ) := by
-    rw [closure_ball_inter_sphere hζ hρ hρr]
-    exact ⟨sphere_subset_closedBall hemem.1, hemem.2⟩
-  have hefr : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))) ∈ frontier (ball c r) := by
-    rw [frontier_ball c hr.ne']
-    exact hemem.1
-  -- a cluster value of `f` along the crosscut at that endpoint
-  obtain ⟨v, hv⟩ := clusterSetOn_nonempty hb.isCompact_closure
-    (fun z hz => subset_closure (mem_image_of_mem f (inter_subset_left hz))) hecl
-  exact ⟨v, clusterSetOn_subset_frontier_image isOpen_ball hd hinj hefr
-    (clusterSetOn_mono inter_subset_left hv), clusterSetOn_subset_closure_image hv⟩
+  obtain ⟨v, hv⟩ := nonempty_clusterSetOn_ball_inter_sphere hb hζ hρ hρr hemem
+  exact ⟨v, clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image hd hinj hr hemem hv⟩
 
 /-! ## The small connected set enclosing the middle piece -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -190,7 +190,9 @@ sets.** The crosscut `ball c r ∩ sphere ζ ρ` is an open arc whose closure ad
 points of `sphere c r ∩ sphere ζ ρ`
 (`TauCeti.closure_ball_inter_sphere`, `TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and a
 continuous `f` contributes nothing new over the arc itself, so all of `closure (f '' arc)` beyond
-`f '' arc` is cluster values at the two ends.
+`f '' arc` is cluster values at the two ends. The cluster-set content is
+`TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`, applied to the arc, whose frontier is
+its whole closure because an arc has empty interior in the plane.
 
 Only continuity along the arc is used; `f` need be neither holomorphic nor injective, and the
 image need not be bounded. -/
@@ -205,21 +207,21 @@ theorem closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
   have hcomp : IsCompact (closure (ball c r ∩ sphere ζ ρ)) := by
     rw [hcl]
     exact (isCompact_closedBall c r).inter_right isClosed_sphere
-  have hsplit : closure (ball c r ∩ sphere ζ ρ) =
+  -- the crosscut is an arc, so it has empty interior and its frontier is its whole closure
+  have hint : interior (ball c r ∩ sphere ζ ρ) = ∅ := by
+    rw [← subset_empty_iff, ← interior_sphere ζ hρ.ne']
+    exact interior_mono inter_subset_right
+  have hfr : frontier (ball c r ∩ sphere ζ ρ) =
       (ball c r ∩ sphere ζ ρ) ∪ (sphere c r ∩ sphere ζ ρ) := by
-    rw [hcl, ← ball_union_sphere, union_inter_distrib_right]
+    rw [← closure_sdiff_interior, hint, sdiff_empty, hcl, ← ball_union_sphere,
+      union_inter_distrib_right]
   have harc : ⋃ w ∈ ball c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) w
-      = f '' (ball c r ∩ sphere ζ ρ) := by
-    ext v
-    simp only [mem_iUnion₂, mem_image]
-    constructor
-    · rintro ⟨w, hw, hv⟩
-      rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw), mem_singleton_iff] at hv
-      exact ⟨w, hw, hv.symm⟩
-    · rintro ⟨w, hw, rfl⟩
-      exact ⟨w, hw, by
-        rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw)]; rfl⟩
-  rw [closure_image_eq_biUnion_clusterSetOn hcomp, hsplit, biUnion_union, harc]
+      ⊆ f '' (ball c r ∩ sphere ζ ρ) := by
+    refine iUnion₂_subset fun w hw => ?_
+    rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw)]
+    exact singleton_subset_iff.mpr (mem_image_of_mem f hw)
+  rw [closure_image_eq_image_union_biUnion_clusterSetOn hcomp hfc, hfr, biUnion_union,
+    ← union_assoc, union_eq_self_of_subset_right harc]
 
 /-- **An end cluster set of an image crosscut lies in the middle piece.** For `f` holomorphic and
 injective on `ball c r` and an endpoint `e` of a circular crosscut, every value `f` clusters at
@@ -242,29 +244,30 @@ theorem clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image
   exact he.1
 
 /-- **Each end of a circular crosscut carries a cluster value.** The crosscut is adherent to each
-of its two endpoints and `f` is confined to the compact `closure (f '' ball c r)`, so the cluster
-set there is nonempty; no holomorphy is needed. -/
-theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' ball c r))
+of its two endpoints and `f` is confined along it to the compact
+`closure (f '' (ball c r ∩ sphere ζ ρ))`, so the cluster set there is nonempty; only the image of
+the crosscut need be bounded, and no holomorphy is needed. -/
+theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Nonempty := by
   refine clusterSetOn_nonempty hb.isCompact_closure
-    (fun z hz => subset_closure (mem_image_of_mem f (inter_subset_left hz))) ?_
+    (fun z hz => subset_closure (mem_image_of_mem f hz)) ?_
   rw [closure_ball_inter_sphere hζ hρ hρr]
   exact ⟨sphere_subset_closedBall he.1, he.2⟩
 
 /-- **Each end of an image crosscut is a continuum.** For `f` continuous along a genuine circular
-crosscut and with bounded image, the cluster set at either endpoint is nonempty and connected; it
-is compact by `TauCeti.isCompact_clusterSetOn_of_isBounded`. This is the Collingwood–Lohwater
-continuum theorem `TauCeti.isConnected_clusterSetOn`, whose local hypothesis — that arbitrarily
-small neighbourhoods of the endpoint meet the crosscut in a preconnected set — is exactly
-`TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half turn
-and so meeting each ball centred on it in a subarc. -/
+crosscut and with bounded image *of the crosscut*, the cluster set at either endpoint is nonempty
+and connected; it is compact by `TauCeti.isCompact_clusterSetOn_of_isBounded`. This is the
+Collingwood–Lohwater continuum theorem `TauCeti.isConnected_clusterSetOn`, whose local hypothesis —
+that arbitrarily small neighbourhoods of the endpoint meet the crosscut in a preconnected set — is
+exactly `TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half
+turn and so meeting each ball centred on it in a subarc. -/
 theorem isConnected_clusterSetOn_ball_inter_sphere
-    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hb : IsBounded (f '' ball c r))
+    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
     IsConnected (clusterSetOn f (ball c r ∩ sphere ζ ρ) e) := by
   have hecl : e ∈ closedBall c r ∩ sphere ζ ρ := ⟨sphere_subset_closedBall he.1, he.2⟩
-  refine isConnected_clusterSetOn_of_isBounded hfc (hb.subset (image_mono inter_subset_left))
+  refine isConnected_clusterSetOn_of_isBounded hfc hb
     (by rw [closure_ball_inter_sphere hζ hρ hρr]; exact hecl) fun s hs => ?_
   obtain ⟨δ, hδ, hball⟩ := Metric.mem_nhds_iff.mp hs
   exact ⟨ball e δ, ball_mem_nhds e hδ, hball,
@@ -336,7 +339,9 @@ theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
       ∈ sphere c r ∩ sphere ζ ρ := by
     rw [sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr]
     exact Or.inl rfl
-  obtain ⟨v, hv⟩ := nonempty_clusterSetOn_ball_inter_sphere hb hζ hρ hρr hemem
+  obtain ⟨v, hv⟩ :=
+    nonempty_clusterSetOn_ball_inter_sphere (hb.subset (image_mono inter_subset_left))
+      hζ hρ hρr hemem
   exact ⟨v, clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image hd hinj hr hemem hv⟩
 
 /-! ## The small connected set enclosing the middle piece -/

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -6,20 +6,25 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
+public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
 
 /-!
-# The chord and the arc on the unit circle
+# The chord and the arc on a circle
 
 Mathlib's `Circle` carries both a metric, from the inclusion into `ℂ`, and an arc-length API:
 `Circle.exp` parametrizes it by angles and `Circle.angleDiff x y` is the length of the arc running
 counterclockwise from `x` to `y`. This file relates the two, comparing the *chord* `dist x y` with
-the *arc* separating `x` from `y` in both directions.
+the *arc* separating `x` from `y` in both directions, and transports the chord formula along the
+translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ ρ`.
 
 ## Main results
 
 * `TauCeti.dist_circleExp_eq_two_mul_abs_sin` — the chord subtended by an arc of angle `θ` of the
   unit circle has length `2 * |sin (θ / 2)|`.
+* `TauCeti.dist_circleMap_eq_two_mul_abs_sin` — its form for the circle `circleMap ζ ρ` of arbitrary
+  centre and radius, where the chord between the angles `θ` and `θ'` has length
+  `2 * |ρ| * |sin ((θ - θ') / 2)|`.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
   most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
@@ -71,6 +76,24 @@ theorem dist_circleExp_eq_two_mul_abs_sin (a b : ℝ) :
   rw [dist_circleExp_eq_norm_exp_sub_one, Complex.norm_exp_I_mul_ofReal_sub_one,
     Real.norm_eq_abs, abs_mul]
   norm_num
+
+/-- **The chord of a circle of arbitrary centre and radius.** The two points of `circleMap ζ ρ` at
+angles `θ` and `θ'` are at distance `2 * |ρ| * |sin ((θ - θ') / 2)|`; nothing is assumed of the
+radius, a negative `ρ` tracing the same circle in the other sense.
+
+This is the unit-circle formula `TauCeti.dist_circleExp_eq_two_mul_abs_sin` transported along the
+translation and real scaling that carry `Circle.exp` to `circleMap ζ ρ`. -/
+theorem dist_circleMap_eq_two_mul_abs_sin (ζ : ℂ) (ρ θ θ' : ℝ) :
+    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * |Real.sin ((θ - θ') / 2)| := by
+  have hsub : circleMap ζ ρ θ - circleMap ζ ρ θ' =
+      (ρ : ℂ) * ((Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)) := by
+    simp only [circleMap, Circle.coe_exp]
+    ring
+  have hchord : ‖(Circle.exp θ : ℂ) - (Circle.exp θ' : ℂ)‖ = 2 * |Real.sin ((θ - θ') / 2)| := by
+    rw [← dist_circleExp_eq_two_mul_abs_sin, ← Complex.dist_eq]
+    exact (Subtype.dist_eq _ _).symm
+  rw [dist_eq_norm, hsub, norm_mul, Complex.norm_real, Real.norm_eq_abs, hchord]
+  ring
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=


### PR DESCRIPTION
This PR identifies the boundary piece a circular crosscut clings to as exactly the two ends of the image crosscut, and shows each end to be a continuum. `TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean` already splits `frontier Ω` for `Ω = f '' Metric.ball c r` into two boundary pieces and a *middle piece* `frontier Ω ∩ closure (f '' (ball c r ∩ Metric.sphere ζ ρ))`, and proved that middle piece nonempty — but, in the file's own words, "that is a statement about the *one* endpoint the proof selects, and all that is claimed: nothing below says where the other end goes, nor that the two ends are joined". `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` closes the first of those two gaps with an equality: for `f` holomorphic and injective on the disc and `0 < ρ < 2 * r`, the middle piece is `⋃ e ∈ sphere c r ∩ sphere ζ ρ, TauCeti.clusterSetOn f (ball c r ∩ sphere ζ ρ) e`, the index set being the crosscut's two endpoints by the existing `TauCeti.sphere_inter_sphere_eq_pair_circleMap`. Each of those two cluster sets is nonempty (`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`) and connected (`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to `∂Ω` at *each* of its ends and the middle piece is precisely where those two ends sit. The old one-endpoint statement `TauCeti.nonempty_frontier_inter_closure_image_ball_inter_sphere` is kept, since `TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` consumes it, but is now a three-line corollary of the two new facts rather than an independent argument.

Both inclusions rest on one new decomposition. `TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` says the closure of an image crosscut is the image crosscut together with its two end cluster sets: closing the open arc adds exactly the two points of `sphere c r ∩ sphere ζ ρ` (`TauCeti.closure_ball_inter_sphere` and `Metric.ball_union_sphere`), and over the arc itself a continuous `f` contributes only its own values, by `TauCeti.clusterSetOn_eq_singleton_of_continuousWithinAt`; it asks neither holomorphy, injectivity nor boundedness. A value taken *on* the crosscut lies in the open set `Ω`, disjoint from `frontier Ω`, so the middle piece consists of end cluster values only; conversely each end cluster value lies on `frontier Ω` because a conformal map is proper (`TauCeti.clusterSetOn_subset_frontier_image`) and is adherent to the image crosscut by construction — that direction is `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`. What is deliberately *not* claimed is that the two ends are joined: the identification is with a union of two cluster sets, not with a connected subset of `∂Ω` running between them, and the module docstring says so.

The continuum statement needs one piece of plane geometry that `Conformal/Crosscut/Endpoints.lean` did not have, and it is added there beside the other metric and angular descriptions of a crosscut. `TauCeti.dist_circleMap_circleMap` is the chord length `dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * |Real.sin ((θ - θ') / 2)|`, transported from Mathlib's unit-circle form `Complex.norm_exp_I_mul_ofReal_sub_one` rather than reproved; the pinned Mathlib has no `circleMap` chord lemma. Since a crosscut spans `2 * Real.arccos (ρ / (2 * r)) < π`, the chord distance along it to a fixed one of its points falls and then rises, so the angles it keeps below a threshold are order-connected and `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` gets a ball centred at a point of the closed crosscut meeting the crosscut in a subarc. That is the local hypothesis of the Collingwood–Lohwater continuum theorem `TauCeti.isConnected_clusterSetOn` in `TauCeti/Topology/ClusterSet.lean`, which is consumed rather than restated, as are `TauCeti.closure_image_eq_biUnion_clusterSetOn` and `TauCeti.isConnected_clusterSetOn_of_isBounded` beside it.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "**L5 — Carathéodory boundary correspondence.** The concrete L5 milestone is the **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of closures" — and within it the second of the two geometric inputs `Conformal/CutDiameter.lean` names: "the length–area method makes the image crosscut short, and local connectedness of `∂Ω` supplies the small connected `E` **joining its two ends**". That clause presupposes two ends; before this PR the library knew of one, and knew the middle piece only up to an inclusion. Naming both ends and pinning the middle piece to them is what lets the enclosure statement `TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` be read as joining them: the connected set it produces contains the middle piece, hence both end cluster sets. This PR does not supply the separation argument that would show `E` together with the image crosscut encloses `frontier Ω ∩ frontier (f '' (ball c r ∩ ball ζ ρ))`, and so does not discharge the milestone; it is disjoint from the in-flight L5 threads, which generalise the cut-diameter criterion to an arbitrary domain and study the cluster sets over the cut-off arc of the *source* boundary circle, neither of which describes the closure of an image crosscut or its ends.

No Mathlib infrastructure was vendored. In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for layers L0–L6, the conformal statements are for maps of `ℂ`; the two new geometric statements ask nothing of `f` at all, and the closure decomposition asks only continuity along the crosscut. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the pinned Mathlib has no boundary correspondence for conformal maps, so this is new Lean formalization rather than a temporary shim; it consumes the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn` through `TauCeti.clusterSetOn_subset_frontier_image`, to be refactored onto Mathlib's open mapping API once the upstream work lands.

`lake build` (6508 jobs) and `lake exe axioms` (22277 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`) are green, as are `lake exe module-system` (1231 modules), `lake exe lint-style` and `scripts/lint-env.sh` (no new violations).

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"crosscut-endpoint-cluster-sets"}-->

🤖 Prepared with Claude Code
