### PR TITLE
feat: an image crosscut of finite length ends in two points

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -49,12 +49,16 @@ modulus as the Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exi
 included.
 
 The same chord bound, applied with the whole arc rather than a sub-arc, bounds the image
-(`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`), which is what turns a
-subsingleton cluster set into an honest limit.
+(`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`), which is what turns that
+subsingleton cluster set into an honest limit:
+`TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo`, with cluster-set form
+`TauCeti.exists_clusterSetOn_circleMap_image_Ioo_eq_singleton`. All of this is about an arc of
+angles and asks nothing of a crosscut.
 
 ## The crosscut
 
-The crosscut instances are the arc description of `Conformal/Crosscut/Endpoints.lean`:
+The crosscut statements are those arc statements at the arc description of
+`Conformal/Crosscut/Endpoints.lean`:
 `ball c r ∩ sphere ζ ρ` is the open arc of angles within `arccos (ρ / (2 * r))` of `arg (c - ζ)`,
 and `closedBall c r ∩ sphere ζ ρ` is the closed one, of angular width `2 * arccos (ρ / (2 * r))`,
 which is below `π` exactly because `ρ` is positive. Finiteness of the angular integral over the arc
@@ -77,11 +81,14 @@ joining them can be named.
 * `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` — at every point of an arc of angular
   width at most `π` and of finite image length, the cluster set of the map along the arc has at
   most one element.
-* `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere` and
-  `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` — the crosscut forms: a circular crosscut of
-  finite image length carries a limit at each point of its closure, its two endpoints included.
-* `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — that limit as a one-point cluster
-  set, the form `Conformal/Crosscut/Image.lean` indexes over.
+* `TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` and
+  `TauCeti.exists_clusterSetOn_circleMap_image_Ioo_eq_singleton` — hence such an arc carries a limit
+  at each point of its closure, its two endpoints included, and its cluster set there is a single
+  point.
+* `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere`,
+  `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` and
+  `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — the three arc statements at the arc
+  of a circular crosscut, the last of them the form `Conformal/Crosscut/Image.lean` indexes over.
 * `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` — hence the closure of an image
   crosscut of finite length is the image crosscut together with two points.
 
@@ -274,7 +281,59 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
   have hmη : m ≤ η / 2 := min_le_left _ _
   linarith
 
+/-- Every angle of the *closed* arc names a point of the closure of the open one: the closure of
+`Ioo a b` is `Icc a b`, and `circleMap ζ ρ` is continuous. -/
+private lemma circleMap_mem_closure_image_Ioo (ζ : ℂ) (ρ : ℝ) {a b θ₀ : ℝ} (hab : a < b)
+    (hθ₀ : θ₀ ∈ Icc a b) : circleMap ζ ρ θ₀ ∈ closure (circleMap ζ ρ '' Ioo a b) :=
+  mem_closure_image (continuous_circleMap ζ ρ).continuousAt (by rwa [closure_Ioo hab.ne])
+
+/-- **An arc of finite image length has a limit at each point of its closure.** The cluster set
+along the arc is a subsingleton by `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo`, and it
+is nonempty because the image of the arc is bounded,
+`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` — so the map is confined along the
+arc to a compact set, which is the hypothesis of
+`TauCeti.exists_tendsto_of_clusterSetOn_subsingleton`.
+
+The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content: there the arc is a curve with an
+honest end. -/
+theorem exists_tendsto_nhdsWithin_circleMap_image_Ioo (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
+    ∃ v, Tendsto f (𝓝[circleMap ζ ρ '' Ioo a b] (circleMap ζ ρ θ₀)) (𝓝 v) :=
+  exists_tendsto_of_clusterSetOn_subsingleton
+    (isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top hUo hf ζ hρ hmemU
+      hfin).isCompact_closure
+    (fun _ hw => subset_closure (mem_image_of_mem f hw))
+    (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀)
+    (subsingleton_clusterSetOn_circleMap_image_Ioo hUo hf ζ hρ hab habπ hθ₀ hmemU hfin)
+
+/-- **The cluster set of an arc of finite image length is a single point.** The limit of
+`TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` written as a cluster set, which is the form
+a boundary piece described as a union of cluster sets is indexed over. -/
+theorem exists_clusterSetOn_circleMap_image_Ioo_eq_singleton (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
+    ∃ v, clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀) = {v} := by
+  obtain ⟨v, hv⟩ :=
+    exists_tendsto_nhdsWithin_circleMap_image_Ioo hUo hf ζ hρ hab habπ hθ₀ hmemU hfin
+  exact ⟨v, clusterSetOn_eq_singleton_of_tendsto (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀) hv⟩
+
 /-! ## The two ends of a circular crosscut -/
+
+/-- Half the angular width of a genuine circular crosscut is positive. -/
+private lemma arccos_div_two_mul_pos (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    0 < Real.arccos (ρ / (2 * r)) :=
+  Real.arccos_pos.mpr ((div_lt_one (by linarith)).mpr hρr)
+
+/-- Half the angular width of a genuine circular crosscut is below `π / 2`: a crosscut spans less
+than half of its circle. -/
+private lemma arccos_div_two_mul_lt_pi_div_two (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    Real.arccos (ρ / (2 * r)) < π / 2 :=
+  Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by linarith))
 
 /-- The open arc of angles of a genuine circular crosscut lies in the disc: by
 `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` it parametrises the crosscut itself. -/
@@ -295,9 +354,7 @@ private lemma lintegral_enorm_deriv_circleMap_ne_top (hζ : dist ζ c = r) (hρ 
     (hρr : ρ < 2 * r) (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
     ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤ := by
-  have hr : 0 < r := by linarith
-  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 :=
-    Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by positivity))
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
   have hmem : ∀ θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r :=
     fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ
@@ -339,11 +396,8 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Subsingleton := by
-  have hr : 0 < r := by linarith
-  have hφ0 : 0 < Real.arccos (ρ / (2 * r)) :=
-    Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
-  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 :=
-    Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by positivity))
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
   obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
@@ -353,11 +407,9 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
-/-- **A circular crosscut of finite image length has a limit at each point of its closure.** The
-cluster set is a subsingleton by `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere`, and it is
-nonempty because the image of the crosscut is bounded — the arc form
-`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` at the crosscut's arc of angles —
-so the map is confined along the crosscut to a compact set.
+/-- **A circular crosscut of finite image length has a limit at each point of its closure.** This is
+`TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` at the arc description of
+`Conformal/Crosscut/Endpoints.lean`.
 
 At the two endpoints, where `e ∈ sphere c r ∩ sphere ζ ρ`, this is the statement that the image
 crosscut is a curve with two honest ends. -/
@@ -366,19 +418,20 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
-  have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
-    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-    exact isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top isOpen_ball hf ζ hρ
-      (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
-      (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
-  refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
-    (fun w hw => subset_closure (mem_image_of_mem f hw)) ?_
-    (subsingleton_clusterSetOn_ball_inter_sphere hζ hρ hρr hf hfin he)
-  rw [closure_ball_inter_sphere hζ hρ hρr]
-  exact he
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
+    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
+    exact he
+  rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+  exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
+    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
-/-- **The end of a circular crosscut of finite image length is a single point.** The cluster set of
-`TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` written as a singleton, which is the form
+/-- **The end of a circular crosscut of finite image length is a single point.** This is
+`TauCeti.exists_clusterSetOn_circleMap_image_Ioo_eq_singleton` at the arc description of
+`Conformal/Crosscut/Endpoints.lean`, and it is the form
 `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` of
 `Conformal/Crosscut/Image.lean` indexes the boundary piece over. -/
 theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r) (hρ : 0 < ρ)
@@ -386,10 +439,16 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     ∃ v, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {v} := by
-  obtain ⟨v, hv⟩ := exists_tendsto_nhdsWithin_ball_inter_sphere hζ hρ hρr hf hfin he
-  refine ⟨v, clusterSetOn_eq_singleton_of_tendsto ?_ hv⟩
-  rw [closure_ball_inter_sphere hζ hρ hρr]
-  exact he
+  have hφ0 := arccos_div_two_mul_pos hρ hρr
+  have hφπ2 := arccos_div_two_mul_lt_pi_div_two hρ hρr
+  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
+    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
+    exact he
+  rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+  exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ hρ (by linarith)
+    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The closure of an image crosscut of finite length is the image crosscut together with two
 points.** `Conformal/Crosscut/Image.lean` writes that closure as the image crosscut together with

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -33,7 +33,7 @@ the map on the disc is used, and none is proved.
 
 The engine is the chord bound of `Conformal/LengthArea.lean` in its primitive, set-free form
 `TauCeti.ofReal_dist_le_mul_lintegral_Ioc`: the images of the endpoints of an arc of angles are at
-distance at most `ρ` times the angular integral of `‖deriv f‖` over *that* arc. Applied to a
+distance at most `|ρ|` times the angular integral of `‖deriv f‖` over *that* arc. Applied to a
 sub-arc, it says that the oscillation of `f` along a piece of the circle is controlled by the length
 carried by that piece alone. Since the total length is finite, Mathlib's absolute continuity of the
 integral (`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`) makes the length carried by a
@@ -100,7 +100,10 @@ In accordance with the generality bar of `ConformalMapping/README.md`, which fix
 every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The arc statements
 ask nothing of the ambient disc — only that `f` be holomorphic on an open set containing the arc —
 so they apply to any circle in any domain, the crosscut being one instance; neither injectivity of
-`f` nor any hypothesis on its image is used anywhere in the file.
+`f` nor any hypothesis on its image is used anywhere in the file. They ask nothing of the sign of
+the radius either, a negative `ρ` tracing the same circle in the other sense and `ρ = 0` collapsing
+the arc to the point `ζ`, where the estimates are trivial. The crosscut statements do ask
+`0 < ρ < 2 * r`, which is what makes `ball c r ∩ sphere ζ ρ` a genuine crosscut.
 
 ## Coordination with upstream Mathlib
 
@@ -133,12 +136,12 @@ variable {U : Set ℂ} {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 /-- The chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` for two angles of an open arc on
 which `f` is holomorphic: the closed interval they span stays inside the open one. -/
 private lemma ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₁ θ₂ : ℝ}
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b θ₁ θ₂ : ℝ}
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U) (h₁ : θ₁ ∈ Ioo a b) (h₂ : θ₂ ∈ Ioo a b)
     (hle : θ₁ ≤ θ₂) :
     ENNReal.ofReal (dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂))) ≤
-      ENNReal.ofReal ρ * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
-  ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hρ hle fun _ hθ =>
+      ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+  ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hle fun _ hθ =>
     hmemU _ ⟨h₁.1.trans_le hθ.1, hθ.2.trans_lt h₂.2⟩
 
 /-- **A modulus of continuity along an arc of finite image length.** If `f` is holomorphic on an
@@ -154,15 +157,22 @@ bounds the distance between the images of its two ends.
 
 Uniform continuity in the angle is *not* uniform continuity of `f` on the arc as a subset of the
 plane, but on an arc of angular width below a full turn the two agree, which is what
-`TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` exploits. -/
+`TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` exploits.
+
+Nothing is assumed of the sign of the radius: a negative `ρ` traces the same circle in the other
+sense, and at `ρ = 0` the circle is the single point `ζ`, where there is nothing to estimate. -/
 theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ}
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b : ℝ}
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) {ε : ℝ} (hε : 0 < ε) :
     ∃ η > 0, ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, |θ₁ - θ₂| ≤ η →
       dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ ε := by
-  have hρ0 : ENNReal.ofReal ρ ≠ 0 := (ENNReal.ofReal_pos.mpr hρ).ne'
-  have hcne : ENNReal.ofReal (ε / ρ) ≠ 0 := (ENNReal.ofReal_pos.mpr (div_pos hε hρ)).ne'
+  -- a circle of radius `0` is the single point `ζ`, where every distance in sight vanishes
+  rcases eq_or_ne ρ 0 with rfl | hρ
+  · exact ⟨1, one_pos, fun _ _ _ _ _ => by simp [hε.le]⟩
+  have hρpos : 0 < |ρ| := abs_pos.mpr hρ
+  have hρ0 : ENNReal.ofReal |ρ| ≠ 0 := (ENNReal.ofReal_pos.mpr hρpos).ne'
+  have hcne : ENNReal.ofReal (ε / |ρ|) ≠ 0 := (ENNReal.ofReal_pos.mpr (div_pos hε hρpos)).ne'
   obtain ⟨δ, hδ, hδlt⟩ :=
     exists_pos_setLIntegral_lt_of_measure_lt (μ := volume.restrict (Ioo a b)) hfin hcne
   obtain ⟨d, hd0, hdδ⟩ := exists_between hδ
@@ -178,17 +188,17 @@ theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
       exact ENNReal.ofReal_le_ofReal hgap
     have hres : (volume.restrict (Ioo a b)).restrict (Ioc θ₁ θ₂) = volume.restrict (Ioc θ₁ θ₂) := by
       rw [Measure.restrict_restrict measurableSet_Ioc, inter_eq_self_of_subset_left hsub]
-    have hlt : ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ < ENNReal.ofReal (ε / ρ) := by
+    have hlt : ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ < ENNReal.ofReal (ε / |ρ|) := by
       have hbound := hδlt (Ioc θ₁ θ₂) hmeas
       rwa [hres] at hbound
-    have hmul : ENNReal.ofReal ρ * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ
+    have hmul : ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ
         < ENNReal.ofReal ε := by
       refine (ENNReal.mul_lt_mul_right hρ0 ENNReal.ofReal_ne_top hlt).trans_eq ?_
-      rw [← ENNReal.ofReal_mul hρ.le]
+      rw [← ENNReal.ofReal_mul (abs_nonneg ρ)]
       congr 1
       field_simp
     exact ((ENNReal.ofReal_lt_ofReal_iff hε).mp
-      ((ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hρ hmemU h₁ h₂ hle).trans_lt
+      ((ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hmemU h₁ h₂ hle).trans_lt
         hmul)).le
   refine ⟨d.toReal, ENNReal.toReal_pos hd0.ne' hdtop, fun θ₁ h₁ θ₂ h₂ habs => ?_⟩
   rcases le_total θ₁ θ₂ with hle | hle
@@ -200,16 +210,16 @@ theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
 
 /-- **An arc of finite image length has bounded image.** The chord bound applied to the whole arc
 rather than to a sub-arc: any two of its points have images at distance at most
-`ρ * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ`, a finite number.
+`|ρ| * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ`, a finite number.
 
 This is what makes a subsingleton cluster set along the arc an honest limit, the compactness input
 of `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton`. -/
 theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ}
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b : ℝ}
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     IsBounded (f '' (circleMap ζ ρ '' Ioo a b)) := by
-  set L : ℝ≥0∞ := ENNReal.ofReal ρ * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ with hL
+  set L : ℝ≥0∞ := ENNReal.ofReal |ρ| * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ with hL
   have hLtop : L ≠ ⊤ := by
     rw [hL]
     exact ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
@@ -217,7 +227,7 @@ theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
       dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ L.toReal := by
     intro θ₁ h₁ θ₂ h₂ hle
     refine (ENNReal.ofReal_le_iff_le_toReal hLtop).mp ?_
-    refine (ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hρ hmemU h₁ h₂ hle).trans ?_
+    refine (ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hmemU h₁ h₂ hle).trans ?_
     rw [hL]
     gcongr
     exact fun θ hθ => ⟨h₁.1.trans hθ.1, hθ.2.trans_lt h₂.2⟩
@@ -256,20 +266,28 @@ The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content; at an i
 statement is continuity. The angular width restriction is what makes closeness in the plane the same
 as closeness in angle, and it is exactly the requirement that the arc not wrap around the circle: by
 the chord formula `TauCeti.dist_circleMap_eq_two_mul_sin_abs` the chord is
-`2 * ρ * sin (|θ - θ₀| / 2)`, which over the angular gaps between `m` and the width `b - a` of the
+`2 * |ρ| * sin (|θ - θ₀| / 2)`, which over the angular gaps between `m` and the width `b - a` of the
 arc stays at least its value at one of those two ends, so a point of the arc within
-`2 * ρ * min (sin (m / 2)) (sin ((b - a) / 2))` of `circleMap ζ ρ θ₀` is within `m` of `θ₀` in
+`2 * |ρ| * min (sin (m / 2)) (sin ((b - a) / 2))` of `circleMap ζ ρ θ₀` is within `m` of `θ₀` in
 angle. Feeding that to the modulus `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` gives the
-Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists`. -/
+Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists`. A radius of either sign
+traces the same circle; at `ρ = 0` the arc is the single point `ζ` and the criterion is immediate,
+no angular control being needed. -/
 theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b θ₀ : ℝ} (hab : a < b)
     (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     (clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀)).Subsingleton := by
+  -- at radius `0` the arc is the single point `ζ`, so the criterion needs no angular control
+  rcases eq_or_ne ρ 0 with rfl | hρ
+  · refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ⟨1, one_pos, ?_⟩
+    rintro _ ⟨⟨θ₁, -, rfl⟩, -⟩ _ ⟨⟨θ₂, -, rfl⟩, -⟩
+    simp [hε.le]
+  have hρpos : 0 < |ρ| := abs_pos.mpr hρ
   refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
   obtain ⟨η, hη, hmod⟩ :=
-    exists_pos_forall_dist_le_of_lintegral_ne_top hUo hf ζ hρ hmemU hfin hε
+    exists_pos_forall_dist_le_of_lintegral_ne_top hUo hf ζ hmemU hfin hε
   -- the angular gap actually used: below half the modulus, and below the width of the arc
   set m : ℝ := min (η / 2) (b - a) with hm
   have hm0 : 0 < m := lt_min (by linarith) (by linarith)
@@ -279,11 +297,11 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
     Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
   have hsinw : 0 < Real.sin ((b - a) / 2) :=
     Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
-  refine ⟨2 * ρ * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)),
-    mul_pos (by positivity) (lt_min hsinm hsinw), ?_⟩
+  refine ⟨2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)),
+    mul_pos (by linarith) (lt_min hsinm hsinw), ?_⟩
   -- a point of the arc close to `circleMap ζ ρ θ₀` is close to `θ₀` in angle
   have hangle : ∀ x ∈ circleMap ζ ρ '' Ioo a b ∩
-      ball (circleMap ζ ρ θ₀) (2 * ρ * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2))),
+      ball (circleMap ζ ρ θ₀) (2 * |ρ| * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2))),
       ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
     rintro _ ⟨⟨θ, hθ, rfl⟩, hx⟩
     refine ⟨θ, hθ, rfl, ?_⟩
@@ -291,13 +309,13 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
       rw [abs_le]
       constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
     have hπ : |θ - θ₀| ≤ 2 * π := by linarith
-    rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ, abs_of_pos hρ] at hx
+    rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ] at hx
     rcases lt_or_ge |θ - θ₀| m with hlt | hcon
     · exact hlt
     · exfalso
       have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
         min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
-      nlinarith [hρ.le]
+      nlinarith [hρpos.le]
   rintro x hx y hy
   obtain ⟨θx, hθx, rfl, hdx⟩ := hangle x hx
   obtain ⟨θy, hθy, rfl, hdy⟩ := hangle y hy
@@ -323,29 +341,29 @@ arc to a compact set, which is the hypothesis of
 The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content: there the arc is a curve with an
 honest end. -/
 theorem exists_tendsto_nhdsWithin_circleMap_image_Ioo (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b θ₀ : ℝ} (hab : a < b)
     (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     ∃ v, Tendsto f (𝓝[circleMap ζ ρ '' Ioo a b] (circleMap ζ ρ θ₀)) (𝓝 v) :=
   exists_tendsto_of_clusterSetOn_subsingleton
-    (isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top hUo hf ζ hρ hmemU
+    (isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top hUo hf ζ hmemU
       hfin).isCompact_closure
     (fun _ hw => subset_closure (mem_image_of_mem f hw))
     (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀)
-    (subsingleton_clusterSetOn_circleMap_image_Ioo hUo hf ζ hρ hab hab2π hθ₀ hmemU hfin)
+    (subsingleton_clusterSetOn_circleMap_image_Ioo hUo hf ζ hab hab2π hθ₀ hmemU hfin)
 
 /-- **The cluster set of an arc of finite image length is a single point.** The limit of
 `TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` written as a cluster set, which is the form
 a boundary piece described as a union of cluster sets is indexed over. -/
 theorem exists_clusterSetOn_circleMap_image_Ioo_eq_singleton (hUo : IsOpen U)
-    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} {a b θ₀ : ℝ} (hab : a < b)
     (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     ∃ v, clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀) = {v} := by
   obtain ⟨v, hv⟩ :=
-    exists_tendsto_nhdsWithin_circleMap_image_Ioo hUo hf ζ hρ hab hab2π hθ₀ hmemU hfin
+    exists_tendsto_nhdsWithin_circleMap_image_Ioo hUo hf ζ hab hab2π hθ₀ hmemU hfin
   exact ⟨v, clusterSetOn_eq_singleton_of_tendsto (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀) hv⟩
 
 /-! ## The two ends of a circular crosscut -/
@@ -429,7 +447,7 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-  exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
+  exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
@@ -451,7 +469,7 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-  exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
+  exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
@@ -472,7 +490,7 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-  exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ hρ (by linarith)
+  exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ (by linarith)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -1,0 +1,421 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
+public import TauCeti.Analysis.Complex.Conformal.ShortCrosscut
+import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
+import TauCeti.Topology.Circle.Metric
+
+/-!
+# An image crosscut of finite length ends in two points
+
+`Conformal/Crosscut/Image.lean` identifies the boundary piece a circular crosscut clings to as the
+union of the *cluster sets* of the map at the crosscut's two endpoints, and shows each of them to be
+a continuum. Nothing there says those continua are single points; in its own words, the
+identification is "with a union of two cluster sets, not with a connected subset of `∂Ω` running
+between them". This file supplies the missing degeneration, from the one hypothesis that the
+length–area method already produces: **an image crosscut of finite length has an honest limit at
+each of its two ends**, so its closure is the crosscut together with two points.
+
+That this can be had at all, and without circularity, is the point. The end of an image crosscut is
+a boundary cluster set, and the boundary cluster sets of the map on the *disc* degenerating to
+points is exactly the layer-**L5** milestone of `TauCetiRoadmap/ConformalMapping/README.md` still
+open. The ends here degenerate for a different and much cheaper reason: the arc `ball c r ∩ sphere
+ζ ρ` is one-dimensional, and the length of its image is a *finite* number, so the images of its
+angles satisfy a Cauchy criterion as the angle runs to an end of the arc. No boundary behaviour of
+the map on the disc is used, and none is proved.
+
+## The estimate
+
+The engine is the chord bound of `Conformal/LengthArea.lean` in its primitive, set-free form
+`TauCeti.ofReal_dist_le_mul_lintegral_Ioc`: the images of the endpoints of an arc of angles are at
+distance at most `ρ` times the angular integral of `‖deriv f‖` over *that* arc. Applied to a
+sub-arc, it says that the oscillation of `f` along a piece of the circle is controlled by the length
+carried by that piece alone. Since the total length is finite, Mathlib's absolute continuity of the
+integral (`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`) makes the length carried by a
+short sub-arc uniformly small: that is `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top`, a
+modulus of continuity for `f` along the arc, in the angular parameter.
+
+Turning the angular modulus into a statement about the plane needs the chord formula
+`TauCeti.dist_circleMap_eq_two_mul_sin_abs`: on an arc of angular width at most `π` the chord
+`2 * |ρ| * sin (|θ - θ'| / 2)` grows with the angular gap, so points of the arc close in the plane
+are close in angle. With that, `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` reads the
+modulus as the Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists` of
+`Topology/ClusterSet.lean` and concludes at *every* point of the closed arc, its two endpoints
+included.
+
+The same chord bound, applied with the whole arc rather than a sub-arc, bounds the image
+(`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`), which is what turns a
+subsingleton cluster set into an honest limit.
+
+## The crosscut
+
+The crosscut instances are the arc description of `Conformal/Crosscut/Endpoints.lean`:
+`ball c r ∩ sphere ζ ρ` is the open arc of angles within `arccos (ρ / (2 * r))` of `arg (c - ζ)`,
+and `closedBall c r ∩ sphere ζ ρ` is the closed one, of angular width `2 * arccos (ρ / (2 * r))`,
+which is below `π` exactly because `ρ` is positive. Finiteness of the angular integral over the arc
+is finiteness of `TauCeti.circleImageLength f (ball c r) ζ ρ`, the quantity Wolff's lemma makes
+small: a crosscut short enough for the length–area estimates is in particular of finite length, so
+the hypothesis costs a consumer nothing it has not already paid for.
+
+The conclusion, `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert`, is that the closure of
+the image crosscut is the image crosscut together with two points. Which two points, and whether
+they are distinct, is not addressed: an image crosscut may well close up. What the L5 argument needs
+is only that the two ends are points on `∂Ω`, so that the small arc of a locally connected `∂Ω`
+joining them can be named.
+
+## Main results
+
+* `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` — a modulus of continuity along an arc of
+  finite image length, in the angular parameter.
+* `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` — an arc of finite image length
+  has bounded image.
+* `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` — at every point of an arc of angular
+  width at most `π` and of finite image length, the cluster set of the map along the arc has at
+  most one element.
+* `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere` and
+  `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` — the crosscut forms: a circular crosscut of
+  finite image length carries a limit at each point of its closure, its two endpoints included.
+* `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — that limit as a one-point cluster
+  set, the form `Conformal/Crosscut/Image.lean` indexes over.
+* `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` — hence the closure of an image
+  crosscut of finite length is the image crosscut together with two points.
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The arc statements
+ask nothing of the ambient disc — only that `f` be holomorphic on an open set containing the arc —
+so they apply to any circle in any domain, the crosscut being one instance; neither injectivity of
+`f` nor any hypothesis on its image is used anywhere in the file.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the
+pinned Mathlib has no boundary correspondence for conformal maps. So this file is new Lean
+formalization rather than a temporary shim, and it consumes no L0–L3 shim: its analytic input is the
+chord bound of `Conformal/LengthArea.lean`, which rests on the fundamental theorem of calculus along
+an arc.
+
+## References
+
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2 (crosscuts and the length–area
+  method).
+* J. B. Conway, *Functions of One Complex Variable I* (GTM 11), Ch. IX.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Complex Filter MeasureTheory Metric Set Topology
+open scoped ENNReal Real
+
+variable {U : Set ℂ} {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+
+/-! ## A modulus of continuity along an arc of finite image length -/
+
+/-- The chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` for two angles of an open arc on
+which `f` is holomorphic: the closed interval they span stays inside the open one. -/
+private lemma ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₁ θ₂ : ℝ}
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U) (h₁ : θ₁ ∈ Ioo a b) (h₂ : θ₂ ∈ Ioo a b)
+    (hle : θ₁ ≤ θ₂) :
+    ENNReal.ofReal (dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂))) ≤
+      ENNReal.ofReal ρ * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+  ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hρ hle fun _ hθ =>
+    hmemU _ ⟨h₁.1.trans_le hθ.1, hθ.2.trans_lt h₂.2⟩
+
+/-- **A modulus of continuity along an arc of finite image length.** If `f` is holomorphic on an
+open set containing the piece of the circle of radius `ρ` about `ζ` cut out by the angles `Ioo a b`,
+and the angular integral of `‖deriv f‖` over that arc is finite, then for every tolerance `ε > 0`
+there is an angular gap `η > 0` within which the images of two angles of the arc stay `ε` apart.
+
+The gap is uniform over the arc, and in particular does not shrink as an end of the arc is
+approached: that is the whole content, and it comes from the absolute continuity of the integral,
+`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`. A short sub-arc carries little length,
+and by the chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` the length a sub-arc carries
+bounds the distance between the images of its two ends.
+
+Uniform continuity in the angle is *not* uniform continuity of `f` on the arc as a subset of the
+plane, but on an arc of angular width at most `π` the two agree, which is what
+`TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` exploits. -/
+theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ}
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) {ε : ℝ} (hε : 0 < ε) :
+    ∃ η > 0, ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, |θ₁ - θ₂| ≤ η →
+      dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ ε := by
+  have hρ0 : ENNReal.ofReal ρ ≠ 0 := (ENNReal.ofReal_pos.mpr hρ).ne'
+  have hcne : ENNReal.ofReal (ε / ρ) ≠ 0 := (ENNReal.ofReal_pos.mpr (div_pos hε hρ)).ne'
+  obtain ⟨δ, hδ, hδlt⟩ :=
+    exists_pos_setLIntegral_lt_of_measure_lt (μ := volume.restrict (Ioo a b)) hfin hcne
+  obtain ⟨d, hd0, hdδ⟩ := exists_between hδ
+  have hdtop : d ≠ ⊤ := (hdδ.trans_le le_top).ne
+  -- the estimate for a pair of angles in increasing order
+  have key : ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, θ₁ ≤ θ₂ → θ₂ - θ₁ ≤ d.toReal →
+      dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ ε := by
+    intro θ₁ h₁ θ₂ h₂ hle hgap
+    have hsub : Ioc θ₁ θ₂ ⊆ Ioo a b := fun θ hθ => ⟨h₁.1.trans hθ.1, hθ.2.trans_lt h₂.2⟩
+    have hmeas : (volume.restrict (Ioo a b)) (Ioc θ₁ θ₂) < δ := by
+      refine lt_of_le_of_lt ((Measure.restrict_apply_le _ _).trans ?_) hdδ
+      rw [Real.volume_Ioc, ← ENNReal.ofReal_toReal hdtop]
+      exact ENNReal.ofReal_le_ofReal hgap
+    have hres : (volume.restrict (Ioo a b)).restrict (Ioc θ₁ θ₂) = volume.restrict (Ioc θ₁ θ₂) := by
+      rw [Measure.restrict_restrict measurableSet_Ioc, inter_eq_self_of_subset_left hsub]
+    have hlt : ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ < ENNReal.ofReal (ε / ρ) := by
+      have hbound := hδlt (Ioc θ₁ θ₂) hmeas
+      rwa [hres] at hbound
+    have hmul : ENNReal.ofReal ρ * ∫⁻ θ in Ioc θ₁ θ₂, ‖deriv f (circleMap ζ ρ θ)‖ₑ
+        < ENNReal.ofReal ε := by
+      refine (ENNReal.mul_lt_mul_right hρ0 ENNReal.ofReal_ne_top hlt).trans_eq ?_
+      rw [← ENNReal.ofReal_mul hρ.le]
+      congr 1
+      field_simp
+    exact ((ENNReal.ofReal_lt_ofReal_iff hε).mp
+      ((ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hρ hmemU h₁ h₂ hle).trans_lt
+        hmul)).le
+  refine ⟨d.toReal, ENNReal.toReal_pos hd0.ne' hdtop, fun θ₁ h₁ θ₂ h₂ habs => ?_⟩
+  rcases le_total θ₁ θ₂ with hle | hle
+  · rw [abs_sub_comm, abs_of_nonneg (sub_nonneg.mpr hle)] at habs
+    exact key θ₁ h₁ θ₂ h₂ hle habs
+  · rw [abs_of_nonneg (sub_nonneg.mpr hle)] at habs
+    rw [dist_comm]
+    exact key θ₂ h₂ θ₁ h₁ hle habs
+
+/-- **An arc of finite image length has bounded image.** The chord bound applied to the whole arc
+rather than to a sub-arc: any two of its points have images at distance at most
+`ρ * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ`, a finite number.
+
+This is what makes a subsingleton cluster set along the arc an honest limit, the compactness input
+of `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton`. -/
+theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ}
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
+    IsBounded (f '' (circleMap ζ ρ '' Ioo a b)) := by
+  set L : ℝ≥0∞ := ENNReal.ofReal ρ * ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ with hL
+  have hLtop : L ≠ ⊤ := by
+    rw [hL]
+    exact ENNReal.mul_ne_top ENNReal.ofReal_ne_top hfin
+  have key : ∀ θ₁ ∈ Ioo a b, ∀ θ₂ ∈ Ioo a b, θ₁ ≤ θ₂ →
+      dist (f (circleMap ζ ρ θ₁)) (f (circleMap ζ ρ θ₂)) ≤ L.toReal := by
+    intro θ₁ h₁ θ₂ h₂ hle
+    refine (ENNReal.ofReal_le_iff_le_toReal hLtop).mp ?_
+    refine (ofReal_dist_le_mul_lintegral_Ioc_of_mem_Ioo hUo hf ζ hρ hmemU h₁ h₂ hle).trans ?_
+    rw [hL]
+    gcongr
+    exact fun θ hθ => ⟨h₁.1.trans hθ.1, hθ.2.trans_lt h₂.2⟩
+  rw [image_image, Metric.isBounded_image_iff]
+  refine ⟨L.toReal, fun θ₁ h₁ θ₂ h₂ => ?_⟩
+  rcases le_total θ₁ θ₂ with hle | hle
+  · exact key θ₁ h₁ θ₂ h₂ hle
+  · rw [dist_comm]
+    exact key θ₂ h₂ θ₁ h₁ hle
+
+/-! ## The cluster sets of an arc of finite image length -/
+
+/-- **An arc of finite image length has at most one cluster value at each of its points.** For `f`
+holomorphic on an open set containing the open arc `circleMap ζ ρ '' Ioo a b`, of angular width at
+most `π` and of finite image length, and for any angle `θ₀` of the *closed* arc, `f` has at most one
+cluster value along the arc at the point `circleMap ζ ρ θ₀`.
+
+The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content; at an interior angle the
+statement is continuity. The angular width restriction is what makes closeness in the plane the same
+as closeness in angle: by the chord formula `TauCeti.dist_circleMap_eq_two_mul_sin_abs` the chord
+`2 * ρ * sin (|θ - θ₀| / 2)` is then an increasing function of the angular gap, so a point of the
+arc within `2 * ρ * sin (m / 2)` of `circleMap ζ ρ θ₀` is within `m` of `θ₀` in angle. Feeding that
+to the modulus `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` gives the Cauchy criterion
+`TauCeti.subsingleton_clusterSetOn_of_forall_exists`. -/
+theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
+    (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
+    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
+    (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
+    (clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀)).Subsingleton := by
+  refine subsingleton_clusterSetOn_of_forall_exists fun ε hε => ?_
+  obtain ⟨η, hη, hmod⟩ :=
+    exists_pos_forall_dist_le_of_lintegral_ne_top hUo hf ζ hρ hmemU hfin hε
+  -- the angular gap actually used: below half the modulus, and below the width of the arc
+  set m : ℝ := min (η / 2) (b - a) with hm
+  have hm0 : 0 < m := lt_min (by linarith) (by linarith)
+  have hmπ : m ≤ π := le_trans (min_le_right _ _) habπ
+  have hsinm : 0 < Real.sin (m / 2) :=
+    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith [Real.pi_pos])
+  refine ⟨2 * ρ * Real.sin (m / 2), by positivity, ?_⟩
+  -- a point of the arc close to `circleMap ζ ρ θ₀` is close to `θ₀` in angle
+  have hangle : ∀ x ∈ circleMap ζ ρ '' Ioo a b ∩ ball (circleMap ζ ρ θ₀) (2 * ρ * Real.sin (m / 2)),
+      ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
+    rintro _ ⟨⟨θ, hθ, rfl⟩, hx⟩
+    refine ⟨θ, hθ, rfl, ?_⟩
+    have hπ : |θ - θ₀| ≤ π := by
+      rw [abs_le]
+      constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
+    rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ, abs_of_pos hρ] at hx
+    rcases lt_or_ge |θ - θ₀| m with hlt | hcon
+    · exact hlt
+    · exfalso
+      have hmono : Real.sin (m / 2) ≤ Real.sin (|θ - θ₀| / 2) :=
+        Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
+          (by linarith)
+      nlinarith [hρ.le]
+  rintro x hx y hy
+  obtain ⟨θx, hθx, rfl, hdx⟩ := hangle x hx
+  obtain ⟨θy, hθy, rfl, hdy⟩ := hangle y hy
+  refine hmod θx hθx θy hθy ?_
+  have htri : |θx - θy| ≤ |θx - θ₀| + |θ₀ - θy| := abs_sub_le _ _ _
+  have hsymm : |θ₀ - θy| = |θy - θ₀| := abs_sub_comm _ _
+  have hmη : m ≤ η / 2 := min_le_left _ _
+  linarith
+
+/-! ## The two ends of a circular crosscut -/
+
+/-- The angular integral of the length density over the arc of a genuine circular crosscut is
+finite as soon as `TauCeti.circleImageLength f (ball c r) ζ ρ` is: the crosscut lies in `ball c r`,
+so the indicator in the definition of the latter is inert along it, and the crosscut spans less
+than a full period. -/
+private lemma lintegral_enorm_deriv_circleMap_ne_top (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤ := by
+  have hr : 0 < r := by linarith
+  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 :=
+    Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by positivity))
+  have hmem : ∀ θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r := by
+    intro θ hθ
+    have : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
+      rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+      exact ⟨θ, hθ, rfl⟩
+    exact this.1
+  have hle : ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+        ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≤
+      ∫⁻ θ in Ioc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+        ((c - ζ).arg - Real.arccos (ρ / (2 * r)) + 2 * π),
+          (ball c r).indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
+    calc ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+          ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ
+        = ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+            ((c - ζ).arg + Real.arccos (ρ / (2 * r))),
+              (ball c r).indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
+          refine setLIntegral_congr_fun measurableSet_Ioo fun θ hθ => ?_
+          rw [Set.indicator_of_mem (hmem θ hθ)]
+      _ ≤ _ := by
+          refine lintegral_mono_set (fun θ hθ => ?_)
+          exact ⟨hθ.1, by linarith [hθ.2, Real.pi_pos]⟩
+  intro htop
+  have hbig : ∫⁻ θ in Ioc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg - Real.arccos (ρ / (2 * r)) + 2 * π),
+        (ball c r).indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) = ⊤ :=
+    top_unique (by rw [← htop]; exact hle)
+  refine hfin ?_
+  rw [circleImageLength_eq_lintegral_Ioc f (ball c r) ζ ρ
+    ((c - ζ).arg - Real.arccos (ρ / (2 * r))), hbig,
+    ENNReal.mul_top (ENNReal.ofReal_pos.mpr hρ).ne']
+
+/-- **A circular crosscut of finite image length has at most one cluster value at each point of its
+closure.** This is `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` at the arc description of
+`Conformal/Crosscut/Endpoints.lean`: a genuine circular crosscut is the open arc of angles within
+`arccos (ρ / (2 * r))` of `arg (c - ζ)`, of angular width below `π`, and its closure adds exactly
+the two angles at the ends.
+
+The two endpoints, where `e ∈ sphere c r ∩ sphere ζ ρ`, are the case with content. Neither
+injectivity of `f` nor any hypothesis on its image is used. -/
+theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
+    (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
+    (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Subsingleton := by
+  have hr : 0 < r := by linarith
+  have hφ0 : 0 < Real.arccos (ρ / (2 * r)) :=
+    Real.arccos_pos.mpr ((div_lt_one (by positivity)).mpr hρr)
+  have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 :=
+    Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by positivity))
+  obtain ⟨θ₀, hθ₀, rfl⟩ : ∃ θ₀ ∈ Icc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ₀ = e := by
+    rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
+    exact he
+  rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+  refine subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
+    (by linarith) hθ₀ (fun θ hθ => ?_)
+    (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
+  have : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
+    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+    exact ⟨θ, hθ, rfl⟩
+  exact this.1
+
+/-- **A circular crosscut of finite image length has a limit at each point of its closure.** The
+cluster set is a subsingleton by `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere`, and it is
+nonempty because the image of the crosscut is bounded — the chord bound again — so the map is
+confined along the crosscut to a compact set.
+
+At the two endpoints, where `e ∈ sphere c r ∩ sphere ζ ρ`, this is the statement that the image
+crosscut is a curve with two honest ends. -/
+theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
+    (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
+    ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
+  have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
+    rw [Metric.isBounded_image_iff]
+    refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, fun z hz w hw => ?_⟩
+    exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
+      (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
+  refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
+    (fun w hw => subset_closure (mem_image_of_mem f hw)) ?_
+    (subsingleton_clusterSetOn_ball_inter_sphere hζ hρ hρr hf hfin he)
+  rw [closure_ball_inter_sphere hζ hρ hρr]
+  exact he
+
+/-- **The end of a circular crosscut of finite image length is a single point.** The cluster set of
+`TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` written as a singleton, which is the form
+`TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` of
+`Conformal/Crosscut/Image.lean` indexes the boundary piece over. -/
+theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) {e : ℂ}
+    (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
+    ∃ v, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {v} := by
+  obtain ⟨v, hv⟩ := exists_tendsto_nhdsWithin_ball_inter_sphere hζ hρ hρr hf hfin he
+  refine ⟨v, clusterSetOn_eq_singleton_of_tendsto ?_ hv⟩
+  rw [closure_ball_inter_sphere hζ hρ hρr]
+  exact he
+
+/-- **The closure of an image crosscut of finite length is the image crosscut together with two
+points.** `Conformal/Crosscut/Image.lean` writes that closure as the image crosscut together with
+the cluster sets at the two endpoints; finiteness of the length collapses each of those to a point.
+
+Nothing is claimed about the two points: they may coincide, an image crosscut being free to close
+up. What a boundary-correspondence argument needs of them is that they are points at all, so that
+the arc of a locally connected image boundary joining them can be named. -/
+theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    ∃ u v, closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      insert u (insert v (f '' (ball c r ∩ sphere ζ ρ))) := by
+  have hpair : sphere c r ∩ sphere ζ ρ =
+      {circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))),
+        circleMap ζ ρ ((c - ζ).arg + Real.arccos (ρ / (2 * r)))} :=
+    sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr
+  have hsub : ∀ e ∈ sphere c r ∩ sphere ζ ρ, e ∈ closedBall c r ∩ sphere ζ ρ :=
+    fun _ he => ⟨sphere_subset_closedBall he.1, he.2⟩
+  have hp : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))) ∈ sphere c r ∩ sphere ζ ρ := by
+    rw [hpair]; exact mem_insert _ _
+  have hq : circleMap ζ ρ ((c - ζ).arg + Real.arccos (ρ / (2 * r))) ∈ sphere c r ∩ sphere ζ ρ := by
+    rw [hpair]; exact mem_insert_of_mem _ rfl
+  obtain ⟨u, hu⟩ :=
+    exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hp)
+  obtain ⟨v, hv⟩ :=
+    exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hq)
+  refine ⟨u, v, ?_⟩
+  rw [closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hf.continuousOn.mono inter_subset_left) hζ hρ hρr, hpair, biUnion_pair, hu, hv,
+    union_comm, singleton_union, insert_union, singleton_union]
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -41,9 +41,10 @@ short sub-arc uniformly small: that is `TauCeti.exists_pos_forall_dist_le_of_lin
 modulus of continuity for `f` along the arc, in the angular parameter.
 
 Turning the angular modulus into a statement about the plane needs the chord formula
-`TauCeti.dist_circleMap_eq_two_mul_sin_abs`: on an arc of angular width at most `π` the chord
-`2 * |ρ| * sin (|θ - θ'| / 2)` grows with the angular gap, so points of the arc close in the plane
-are close in angle. With that, `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` reads the
+`TauCeti.dist_circleMap_eq_two_mul_sin_abs`: on an arc of angular width below a full turn the chord
+`2 * |ρ| * sin (|θ - θ'| / 2)` stays away from zero as long as the angular gap does, so points of
+the arc close in the plane are close in angle — this and nothing more is what the arc not wrapping
+around the circle buys. With that, `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` reads the
 modulus as the Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists` of
 `Topology/ClusterSet.lean` and concludes at *every* point of the closed arc, its two endpoints
 included.
@@ -61,7 +62,8 @@ The crosscut statements are those arc statements at the arc description of
 `Conformal/Crosscut/Endpoints.lean`:
 `ball c r ∩ sphere ζ ρ` is the open arc of angles within `arccos (ρ / (2 * r))` of `arg (c - ζ)`,
 and `closedBall c r ∩ sphere ζ ρ` is the closed one, of angular width `2 * arccos (ρ / (2 * r))`,
-which is below `π` exactly because `ρ` is positive. Finiteness of the angular integral over the arc
+which is below `π` — and so, with room to spare, below the full turn the arc statements ask for —
+exactly because `ρ` is positive. Finiteness of the angular integral over the arc
 is finiteness of `TauCeti.circleImageLength f (ball c r) ζ ρ`, the quantity Wolff's lemma makes
 small: a crosscut short enough for the length–area estimates is in particular of finite length, so
 the hypothesis costs a consumer nothing it has not already paid for.
@@ -79,8 +81,8 @@ joining them can be named.
 * `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` — an arc of finite image length
   has bounded image.
 * `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` — at every point of an arc of angular
-  width at most `π` and of finite image length, the cluster set of the map along the arc has at
-  most one element.
+  width below a full turn and of finite image length, the cluster set of the map along the arc has
+  at most one element.
 * `TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` and
   `TauCeti.exists_clusterSetOn_circleMap_image_Ioo_eq_singleton` — hence such an arc carries a limit
   at each point of its closure, its two endpoints included, and its cluster set there is a single
@@ -151,7 +153,7 @@ and by the chord bound `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` the length a s
 bounds the distance between the images of its two ends.
 
 Uniform continuity in the angle is *not* uniform continuity of `f` on the arc as a subset of the
-plane, but on an arc of angular width at most `π` the two agree, which is what
+plane, but on an arc of angular width below a full turn the two agree, which is what
 `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` exploits. -/
 theorem exists_pos_forall_dist_le_of_lintegral_ne_top (hUo : IsOpen U)
     (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ}
@@ -228,21 +230,40 @@ theorem isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top (hUo : IsOpen U)
 
 /-! ## The cluster sets of an arc of finite image length -/
 
+/-- **The sine of a half-angle is smallest at an end of the range of angles.** For
+`0 < m ≤ t ≤ w < 2 * π`, `sin (t / 2)` is at least `min (sin (m / 2)) (sin (w / 2))`, a positive
+number: the half-angle stays in `[0, π]`, where the sine rises to `π / 2` and falls back, so it is
+bounded below by its value at whichever end of `[m / 2, w / 2]` the half-angle has not passed.
+
+If `w ≤ π` the first of the two is the binding one and the second is slack; both are needed exactly
+because an arc of angular width beyond `π` is allowed. -/
+private lemma min_sin_div_two_le_sin_div_two {m t w : ℝ} (hm : 0 < m) (hmt : m ≤ t) (htw : t ≤ w)
+    (hw : w < 2 * π) : min (Real.sin (m / 2)) (Real.sin (w / 2)) ≤ Real.sin (t / 2) := by
+  rcases le_total (t / 2) (π / 2) with h | h
+  · exact (min_le_left _ _).trans
+      (Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) h (by linarith))
+  · refine (min_le_right _ _).trans ?_
+    rw [← Real.sin_pi_sub (w / 2), ← Real.sin_pi_sub (t / 2)]
+    exact Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
+      (by linarith)
+
 /-- **An arc of finite image length has at most one cluster value at each of its points.** For `f`
-holomorphic on an open set containing the open arc `circleMap ζ ρ '' Ioo a b`, of angular width at
-most `π` and of finite image length, and for any angle `θ₀` of the *closed* arc, `f` has at most one
-cluster value along the arc at the point `circleMap ζ ρ θ₀`.
+holomorphic on an open set containing the open arc `circleMap ζ ρ '' Ioo a b`, of angular width
+below a full turn and of finite image length, and for any angle `θ₀` of the *closed* arc, `f` has at
+most one cluster value along the arc at the point `circleMap ζ ρ θ₀`.
 
 The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content; at an interior angle the
 statement is continuity. The angular width restriction is what makes closeness in the plane the same
-as closeness in angle: by the chord formula `TauCeti.dist_circleMap_eq_two_mul_sin_abs` the chord
-`2 * ρ * sin (|θ - θ₀| / 2)` is then an increasing function of the angular gap, so a point of the
-arc within `2 * ρ * sin (m / 2)` of `circleMap ζ ρ θ₀` is within `m` of `θ₀` in angle. Feeding that
-to the modulus `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` gives the Cauchy criterion
-`TauCeti.subsingleton_clusterSetOn_of_forall_exists`. -/
+as closeness in angle, and it is exactly the requirement that the arc not wrap around the circle: by
+the chord formula `TauCeti.dist_circleMap_eq_two_mul_sin_abs` the chord is
+`2 * ρ * sin (|θ - θ₀| / 2)`, which over the angular gaps between `m` and the width `b - a` of the
+arc stays at least its value at one of those two ends, so a point of the arc within
+`2 * ρ * min (sin (m / 2)) (sin ((b - a) / 2))` of `circleMap ζ ρ θ₀` is within `m` of `θ₀` in
+angle. Feeding that to the modulus `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top` gives the
+Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists`. -/
 theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
     (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
-    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     (clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀)).Subsingleton := by
@@ -252,25 +273,30 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
   -- the angular gap actually used: below half the modulus, and below the width of the arc
   set m : ℝ := min (η / 2) (b - a) with hm
   have hm0 : 0 < m := lt_min (by linarith) (by linarith)
-  have hmπ : m ≤ π := le_trans (min_le_right _ _) habπ
+  have hmw : m ≤ b - a := min_le_right _ _
+  -- the arc not wrapping around the circle puts both half-angles in `(0, π)`
   have hsinm : 0 < Real.sin (m / 2) :=
-    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith [Real.pi_pos])
-  refine ⟨2 * ρ * Real.sin (m / 2), by positivity, ?_⟩
+    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
+  have hsinw : 0 < Real.sin ((b - a) / 2) :=
+    Real.sin_pos_of_pos_of_lt_pi (by linarith) (by linarith)
+  refine ⟨2 * ρ * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)),
+    mul_pos (by positivity) (lt_min hsinm hsinw), ?_⟩
   -- a point of the arc close to `circleMap ζ ρ θ₀` is close to `θ₀` in angle
-  have hangle : ∀ x ∈ circleMap ζ ρ '' Ioo a b ∩ ball (circleMap ζ ρ θ₀) (2 * ρ * Real.sin (m / 2)),
+  have hangle : ∀ x ∈ circleMap ζ ρ '' Ioo a b ∩
+      ball (circleMap ζ ρ θ₀) (2 * ρ * min (Real.sin (m / 2)) (Real.sin ((b - a) / 2))),
       ∃ θ ∈ Ioo a b, circleMap ζ ρ θ = x ∧ |θ - θ₀| < m := by
     rintro _ ⟨⟨θ, hθ, rfl⟩, hx⟩
     refine ⟨θ, hθ, rfl, ?_⟩
-    have hπ : |θ - θ₀| ≤ π := by
+    have hwidth : |θ - θ₀| ≤ b - a := by
       rw [abs_le]
       constructor <;> [linarith [hθ.1, hθ₀.2]; linarith [hθ.2, hθ₀.1]]
+    have hπ : |θ - θ₀| ≤ 2 * π := by linarith
     rw [mem_ball, dist_circleMap_eq_two_mul_sin_abs ζ ρ hπ, abs_of_pos hρ] at hx
     rcases lt_or_ge |θ - θ₀| m with hlt | hcon
     · exact hlt
     · exfalso
-      have hmono : Real.sin (m / 2) ≤ Real.sin (|θ - θ₀| / 2) :=
-        Real.sin_le_sin_of_le_of_le_pi_div_two (by linarith [Real.pi_pos]) (by linarith)
-          (by linarith)
+      have hmono : min (Real.sin (m / 2)) (Real.sin ((b - a) / 2)) ≤ Real.sin (|θ - θ₀| / 2) :=
+        min_sin_div_two_le_sin_div_two hm0 hcon hwidth hab2π
       nlinarith [hρ.le]
   rintro x hx y hy
   obtain ⟨θx, hθx, rfl, hdx⟩ := hangle x hx
@@ -298,7 +324,7 @@ The two endpoints `θ₀ = a` and `θ₀ = b` are the case with content: there t
 honest end. -/
 theorem exists_tendsto_nhdsWithin_circleMap_image_Ioo (hUo : IsOpen U)
     (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
-    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     ∃ v, Tendsto f (𝓝[circleMap ζ ρ '' Ioo a b] (circleMap ζ ρ θ₀)) (𝓝 v) :=
@@ -307,19 +333,19 @@ theorem exists_tendsto_nhdsWithin_circleMap_image_Ioo (hUo : IsOpen U)
       hfin).isCompact_closure
     (fun _ hw => subset_closure (mem_image_of_mem f hw))
     (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀)
-    (subsingleton_clusterSetOn_circleMap_image_Ioo hUo hf ζ hρ hab habπ hθ₀ hmemU hfin)
+    (subsingleton_clusterSetOn_circleMap_image_Ioo hUo hf ζ hρ hab hab2π hθ₀ hmemU hfin)
 
 /-- **The cluster set of an arc of finite image length is a single point.** The limit of
 `TauCeti.exists_tendsto_nhdsWithin_circleMap_image_Ioo` written as a cluster set, which is the form
 a boundary piece described as a union of cluster sets is indexed over. -/
 theorem exists_clusterSetOn_circleMap_image_Ioo_eq_singleton (hUo : IsOpen U)
     (hf : DifferentiableOn ℂ f U) (ζ : ℂ) {ρ : ℝ} (hρ : 0 < ρ) {a b θ₀ : ℝ} (hab : a < b)
-    (habπ : b - a ≤ π) (hθ₀ : θ₀ ∈ Icc a b)
+    (hab2π : b - a < 2 * π) (hθ₀ : θ₀ ∈ Icc a b)
     (hmemU : ∀ θ ∈ Ioo a b, circleMap ζ ρ θ ∈ U)
     (hfin : ∫⁻ θ in Ioo a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ ≠ ⊤) :
     ∃ v, clusterSetOn f (circleMap ζ ρ '' Ioo a b) (circleMap ζ ρ θ₀) = {v} := by
   obtain ⟨v, hv⟩ :=
-    exists_tendsto_nhdsWithin_circleMap_image_Ioo hUo hf ζ hρ hab habπ hθ₀ hmemU hfin
+    exists_tendsto_nhdsWithin_circleMap_image_Ioo hUo hf ζ hρ hab hab2π hθ₀ hmemU hfin
   exact ⟨v, clusterSetOn_eq_singleton_of_tendsto (circleMap_mem_closure_image_Ioo ζ ρ hab hθ₀) hv⟩
 
 /-! ## The two ends of a circular crosscut -/
@@ -404,7 +430,7 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
-    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **A circular crosscut of finite image length has a limit at each point of its closure.** This is
@@ -426,7 +452,7 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_tendsto_nhdsWithin_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
-    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The end of a circular crosscut of finite image length is a single point.** This is
@@ -447,7 +473,7 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
   exact exists_clusterSetOn_circleMap_image_Ioo_eq_singleton isOpen_ball hf ζ hρ (by linarith)
-    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+    (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The closure of an image crosscut of finite length is the image crosscut together with two

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -6,7 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Image
-public import TauCeti.Analysis.Complex.Conformal.ShortCrosscut
+public import TauCeti.Analysis.Complex.Conformal.LengthArea
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 import TauCeti.Topology.Circle.Metric
 
@@ -276,6 +276,17 @@ theorem subsingleton_clusterSetOn_circleMap_image_Ioo (hUo : IsOpen U)
 
 /-! ## The two ends of a circular crosscut -/
 
+/-- The open arc of angles of a genuine circular crosscut lies in the disc: by
+`TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo` it parametrises the crosscut itself. -/
+private lemma circleMap_mem_ball_of_mem_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    {θ : ℝ} (hθ : θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r)))) :
+    circleMap ζ ρ θ ∈ ball c r := by
+  have hmem : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
+    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+    exact ⟨θ, hθ, rfl⟩
+  exact hmem.1
+
 /-- The angular integral of the length density over the arc of a genuine circular crosscut is
 finite as soon as `TauCeti.circleImageLength f (ball c r) ζ ρ` is: the crosscut lies in `ball c r`,
 so the indicator in the definition of the latter is inert along it, and the crosscut spans less
@@ -288,12 +299,8 @@ private lemma lintegral_enorm_deriv_circleMap_ne_top (hζ : dist ζ c = r) (hρ 
   have hφπ2 : Real.arccos (ρ / (2 * r)) < π / 2 :=
     Real.arccos_lt_pi_div_two.mpr (div_pos hρ (by positivity))
   have hmem : ∀ θ ∈ Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r := by
-    intro θ hθ
-    have : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
-      rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-      exact ⟨θ, hθ, rfl⟩
-    exact this.1
+      ((c - ζ).arg + Real.arccos (ρ / (2 * r))), circleMap ζ ρ θ ∈ ball c r :=
+    fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ
   have hle : ∫⁻ θ in Ioo ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
         ((c - ζ).arg + Real.arccos (ρ / (2 * r))), ‖deriv f (circleMap ζ ρ θ)‖ₑ ≤
       ∫⁻ θ in Ioc ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
@@ -342,18 +349,15 @@ theorem subsingleton_clusterSetOn_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     rw [closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr] at he
     exact he
   rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-  refine subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
-    (by linarith) hθ₀ (fun θ hθ => ?_)
+  exact subsingleton_clusterSetOn_circleMap_image_Ioo isOpen_ball hf ζ hρ (by linarith)
+    (by linarith) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
-  have : circleMap ζ ρ θ ∈ ball c r ∩ sphere ζ ρ := by
-    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
-    exact ⟨θ, hθ, rfl⟩
-  exact this.1
 
 /-- **A circular crosscut of finite image length has a limit at each point of its closure.** The
 cluster set is a subsingleton by `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere`, and it is
-nonempty because the image of the crosscut is bounded — the chord bound again — so the map is
-confined along the crosscut to a compact set.
+nonempty because the image of the crosscut is bounded — the arc form
+`TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top` at the crosscut's arc of angles —
+so the map is confined along the crosscut to a compact set.
 
 At the two endpoints, where `e ∈ sphere c r ∩ sphere ζ ρ`, this is the statement that the image
 crosscut is a curve with two honest ends. -/
@@ -363,10 +367,10 @@ theorem exists_tendsto_nhdsWithin_ball_inter_sphere (hζ : dist ζ c = r) (hρ :
     (he : e ∈ closedBall c r ∩ sphere ζ ρ) :
     ∃ v, Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] e) (𝓝 v) := by
   have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
-    rw [Metric.isBounded_image_iff]
-    refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, fun z hz w hw => ?_⟩
-    exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
-      (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
+    rw [ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr]
+    exact isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top isOpen_ball hf ζ hρ
+      (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
+      (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
   refine exists_tendsto_of_clusterSetOn_subsingleton hb.isCompact_closure
     (fun w hw => subset_closure (mem_image_of_mem f hw)) ?_
     (subsingleton_clusterSetOn_ball_inter_sphere hζ hρ hρr hf hfin he)

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -116,23 +116,6 @@ private theorem dist_circleMap_sq (hζ : dist ζ c = r) (θ : ℝ) :
   rw [dist_eq_norm, ← Complex.normSq_eq_norm_sq, hsub, Complex.normSq_sub, hu, ha, hcross]
   ring
 
-/-- The chord length `TauCeti.dist_circleMap_eq_two_mul_abs_sin` with the sign of the angular
-difference cleared: for angles at most `π` apart the chord grows with the angular gap. -/
-private lemma dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ}
-    (h : |θ - θ'| ≤ π) :
-    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
-  rw [dist_circleMap_eq_two_mul_abs_sin]
-  congr 1
-  have hnn : 0 ≤ Real.sin (|θ - θ'| / 2) :=
-    Real.sin_nonneg_of_nonneg_of_le_pi (by positivity) (by linarith [Real.pi_pos])
-  rcases abs_cases (θ - θ') with ⟨hc, -⟩ | ⟨hc, -⟩
-  · rw [hc] at hnn ⊢
-    exact abs_of_nonneg hnn
-  · rw [hc] at hnn ⊢
-    rw [neg_div, Real.sin_neg]
-    rw [neg_div, Real.sin_neg] at hnn
-    exact abs_of_nonpos (by linarith)
-
 /-- **A ball centred at a point of an arc of angular width at most `π` meets it in an arc.** The
 chord distance to a fixed angle `θ₀` of the arc falls and then rises as the angle sweeps across the
 arc, so the angles it keeps below a threshold form an interval. -/

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -127,7 +127,7 @@ private lemma ordConnected_Ioo_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : �
     intro u hu
     refine dist_circleMap_eq_two_mul_sin_abs ζ ρ ?_
     rw [abs_le]
-    constructor <;> [linarith [hu.1, h₀.2]; linarith [hu.2, h₀.1]]
+    constructor <;> [linarith [hu.1, h₀.2, Real.pi_pos]; linarith [hu.2, h₀.1, Real.pi_pos]]
   have hmono : ∀ u ∈ Icc a b, ∀ v ∈ Icc a b, |u - θ₀| ≤ |v - θ₀| →
       dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀) ≤ dist (circleMap ζ ρ v) (circleMap ζ ρ θ₀) := by
     intro u hu v hv huv

--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import TauCeti.Analysis.Complex.Conformal.Area
 public import TauCeti.MeasureTheory.Integral.CircleLIntegral
 import Mathlib.Analysis.Complex.CauchyIntegral
-import TauCeti.Analysis.Contour.ArcFTC
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 
 /-!
 # The length–area inequality for a holomorphic map
@@ -90,9 +90,9 @@ whatever it is, which is why they are proved for a general weight one file down.
 Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505),
 the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem
 itself, and the pinned Mathlib has no length–area estimate; so this file is new Lean formalization
-rather than a temporary shim. Its Mathlib inputs — the measurability of `deriv` and the fundamental
-theorem of calculus along an arc through
-`TauCeti.Contour.integral_comp_mul_eq_sub_of_hasDerivAt` — are consumed, not restated.
+rather than a temporary shim. Its Mathlib inputs — the measurability of `deriv` and the increment
+bound `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` along an arc — are consumed,
+not restated.
 
 ## References
 
@@ -284,31 +284,6 @@ theorem liminf_circleImageLength_nhdsGT_eq_zero (f : ℂ → ℂ) (hs : Measurab
 /-! ### The chord bound -/
 
 
-/-- **The fundamental theorem of calculus along a circular arc.** Integrating `deriv f` against the
-velocity of the parametrisation recovers the increment of `f` between the endpoints.
-
-Arc-local, like the theorem below: only holomorphy on `U` and containment of the arc in `U` are
-used. The radius may have either sign, and the set `s` plays no part. Continuity of `deriv f` along
-the arc, needed for interval integrability, is derived here rather than assumed. -/
-private lemma integral_deriv_circleMap_mul_eq_sub (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U)
-    (ζ : ℂ) {ρ a b : ℝ} (hab : a ≤ b) (hmemU : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ U) :
-    ∫ θ in a..b, deriv f (circleMap ζ ρ θ) * (circleMap 0 ρ θ * I) =
-      f (circleMap ζ ρ b) - f (circleMap ζ ρ a) := by
-  have hcompCont : ContinuousOn (fun θ => deriv f (circleMap ζ ρ θ)) (Icc a b) :=
-    ((hf.analyticOnNhd hUo).deriv).continuousOn.comp
-      (continuous_circleMap ζ ρ).continuousOn hmemU
-  refine Contour.integral_comp_mul_eq_sub_of_hasDerivAt ?_
-    (fun θ _ => hasDerivAt_circleMap ζ ρ θ) (fun θ hθ => ?_) ?_
-  · rw [Set.uIcc_of_le hab]
-    exact hf.continuousOn.comp (continuous_circleMap ζ ρ).continuousOn hmemU
-  · have hθ' : θ ∈ Icc a b := by
-      rw [min_eq_left hab, max_eq_right hab] at hθ
-      exact Set.Ioo_subset_Icc_self hθ
-    exact ((hf _ (hmemU θ hθ')).differentiableAt (hUo.mem_nhds (hmemU θ hθ'))).hasDerivAt
-  · rw [intervalIntegrable_iff_integrableOn_Ioc_of_le hab]
-    refine (ContinuousOn.integrableOn_compact isCompact_Icc ?_).mono_set Set.Ioc_subset_Icc_self
-    exact hcompCont.mul ((continuous_circleMap 0 ρ).continuousOn.mul continuousOn_const)
-
 /-- **The chord bound over a sub-arc.** For `f` holomorphic on an open `U` containing the piece of
 the circle of radius `ρ` about `ζ` cut out by the angles `Icc a b`, the distance between the images
 of the two endpoints of that arc is at most `ρ` times the angular integral of `‖deriv f‖` over it.
@@ -318,41 +293,40 @@ chord bound: the right-hand side is the length of the image of *this* arc, with 
 any set `s` and no restriction on the angular width. Enlarging it to a whole period and inserting
 the indicator of `s` gives `TauCeti.ofReal_dist_le_circleImageLength`, which is the form the
 length–area estimates chain with; the form here is what a *local* estimate near one end of the arc
-needs, since there the arc is shrunk rather than the radius. -/
+needs, since there the arc is shrunk rather than the radius.
+
+The analytic step is Mathlib's `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc`,
+applied to `f ∘ circleMap ζ ρ`, which is `C¹` on the arc because `f` is analytic on `U` and
+`circleMap` is smooth. All that remains is the chain rule, which replaces the derivative of the
+composite by `deriv f (circleMap ζ ρ θ)` times the velocity `circleMap 0 ρ θ * I`, of norm `ρ`. -/
 theorem ofReal_dist_le_mul_lintegral_Ioc (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U) (ζ : ℂ)
     {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ} (hab : a ≤ b)
     (hmemU : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ U) :
     ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b))) ≤
       ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
-  have hderivCont : ContinuousOn (deriv f) U := ((hf.analyticOnNhd hUo).deriv).continuousOn
-  have hcompCont : ContinuousOn (fun θ => deriv f (circleMap ζ ρ θ)) (Icc a b) :=
-    hderivCont.comp (continuous_circleMap ζ ρ).continuousOn hmemU
-  have hFTC := integral_deriv_circleMap_mul_eq_sub hUo hf ζ hab hmemU
-  have hnorm : ‖f (circleMap ζ ρ b) - f (circleMap ζ ρ a)‖ ≤
-      ∫ θ in a..b, ρ * ‖deriv f (circleMap ζ ρ θ)‖ := by
-    rw [← hFTC]
-    refine (intervalIntegral.norm_integral_le_integral_norm hab).trans_eq ?_
-    refine intervalIntegral.integral_congr fun θ _ => ?_
-    rw [norm_mul, norm_mul, norm_circleMap_zero, Complex.norm_I, mul_one, abs_of_pos hρ, mul_comm]
-  have hintOn : IntegrableOn (fun θ => ρ * ‖deriv f (circleMap ζ ρ θ)‖) (Ioc a b) :=
-    (ContinuousOn.integrableOn_compact isCompact_Icc
-      (continuousOn_const.mul hcompCont.norm)).mono_set Set.Ioc_subset_Icc_self
-  have hnn : (0 : ℝ → ℝ) ≤ᵐ[volume.restrict (Ioc a b)]
-      fun θ => ρ * ‖deriv f (circleMap ζ ρ θ)‖ := by
-    filter_upwards with θ
-    simp only [Pi.zero_apply]
-    positivity
+  have hcd : ContDiffOn ℝ 1 (fun θ => f (circleMap ζ ρ θ)) (Icc a b) := fun θ hθ =>
+    (((hf.analyticAt (hUo.mem_nhds (hmemU θ hθ))).contDiffAt.restrict_scalars ℝ).comp θ
+      (contDiff_circleMap ζ ρ).contDiffAt).contDiffWithinAt
+  have hderiv : ∀ θ ∈ Ioc a b, ‖deriv (fun θ => f (circleMap ζ ρ θ)) θ‖ₑ =
+      ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+    intro θ hθ
+    have hmem := hmemU θ (Set.Ioc_subset_Icc_self hθ)
+    have h : HasDerivAt (fun θ => f (circleMap ζ ρ θ))
+        ((circleMap 0 ρ θ * I) • deriv f (circleMap ζ ρ θ)) θ :=
+      ((hf _ hmem).differentiableAt (hUo.mem_nhds hmem)).hasDerivAt.scomp θ
+        (hasDerivAt_circleMap ζ ρ θ)
+    rw [h.deriv, smul_eq_mul, enorm_mul]
+    congr 1
+    rw [← ofReal_norm, norm_mul, norm_circleMap_zero, Complex.norm_I, mul_one, abs_of_pos hρ]
   calc ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b)))
-      ≤ ENNReal.ofReal (∫ θ in a..b, ρ * ‖deriv f (circleMap ζ ρ θ)‖) := by
-        refine ENNReal.ofReal_le_ofReal ?_
-        rw [dist_eq_norm, ← norm_neg, neg_sub]
-        exact hnorm
-    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal (ρ * ‖deriv f (circleMap ζ ρ θ)‖) := by
-        rw [intervalIntegral.integral_of_le hab,
-          MeasureTheory.ofReal_integral_eq_lintegral_ofReal hintOn hnn]
-    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
-        refine setLIntegral_congr_fun measurableSet_Ioc fun θ _ => ?_
-        rw [ENNReal.ofReal_mul hρ.le, ofReal_norm]
+      = ‖f (circleMap ζ ρ b) - f (circleMap ζ ρ a)‖ₑ := by
+        rw [dist_comm, dist_eq_norm, ofReal_norm]
+    _ ≤ ∫⁻ θ in Icc a b, ‖deriv (fun θ => f (circleMap ζ ρ θ)) θ‖ₑ :=
+        enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc hcd hab
+    _ = ∫⁻ θ in Ioc a b, ‖deriv (fun θ => f (circleMap ζ ρ θ)) θ‖ₑ := by
+        rw [← restrict_Ioc_eq_restrict_Icc]
+    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+        setLIntegral_congr_fun measurableSet_Ioc hderiv
     _ = ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
         lintegral_const_mul' _ _ ENNReal.ofReal_ne_top
 

--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -60,8 +60,8 @@ from these estimates in order to force the cluster set at `ζ` to degenerate to 
   over the angles landing in `s`, a length along the parametrisation, counted with multiplicity,
   rather than a measure of the image set.
 * `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` — the chord bound in its primitive, set-free form:
-  the images of the endpoints of an arc of angles are at distance at most `ρ` times the angular
-  integral of `‖deriv f‖` over that arc.
+  the images of the endpoints of an arc of angles are at distance at most `|ρ|` times the angular
+  integral of `‖deriv f‖` over that arc, for a radius `ρ` of either sign.
 * `TauCeti.ofReal_dist_le_circleImageLength` — the chord bound justifying the name, and the only
   claim made here about lengths that is actually proved: a sub-arc of angular width at most `2 * π`
   that stays in `s` and in a set on which `f` is holomorphic has the distance between the images of
@@ -286,29 +286,32 @@ theorem liminf_circleImageLength_nhdsGT_eq_zero (f : ℂ → ℂ) (hs : Measurab
 
 /-- **The chord bound over a sub-arc.** For `f` holomorphic on an open `U` containing the piece of
 the circle of radius `ρ` about `ζ` cut out by the angles `Icc a b`, the distance between the images
-of the two endpoints of that arc is at most `ρ` times the angular integral of `‖deriv f‖` over it.
+of the two endpoints of that arc is at most `|ρ|` times the angular integral of `‖deriv f‖` over it.
 
 This is the fundamental theorem of calculus along the arc, and it is the primitive form of the
 chord bound: the right-hand side is the length of the image of *this* arc, with no reference to
-any set `s` and no restriction on the angular width. Enlarging it to a whole period and inserting
-the indicator of `s` gives `TauCeti.ofReal_dist_le_circleImageLength`, which is the form the
-length–area estimates chain with; the form here is what a *local* estimate near one end of the arc
-needs, since there the arc is shrunk rather than the radius.
+any set `s`, no restriction on the angular width and none on the sign of the radius — a negative
+`ρ` traces the same circle in the other sense, and `ρ = 0` makes both sides `0`. Enlarging the arc
+to a whole period and inserting the indicator of `s` gives
+`TauCeti.ofReal_dist_le_circleImageLength`, which is the form the length–area estimates chain with
+and which does need `0 < ρ`, since `TauCeti.circleImageLength` vanishes at a nonpositive radius;
+the form here is what a *local* estimate near one end of the arc needs, since there the arc is
+shrunk rather than the radius.
 
 The analytic step is Mathlib's `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc`,
 applied to `f ∘ circleMap ζ ρ`, which is `C¹` on the arc because `f` is analytic on `U` and
 `circleMap` is smooth. All that remains is the chain rule, which replaces the derivative of the
-composite by `deriv f (circleMap ζ ρ θ)` times the velocity `circleMap 0 ρ θ * I`, of norm `ρ`. -/
+composite by `deriv f (circleMap ζ ρ θ)` times the velocity `circleMap 0 ρ θ * I`, of norm `|ρ|`. -/
 theorem ofReal_dist_le_mul_lintegral_Ioc (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U) (ζ : ℂ)
-    {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ} (hab : a ≤ b)
+    {ρ : ℝ} {a b : ℝ} (hab : a ≤ b)
     (hmemU : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ U) :
     ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b))) ≤
-      ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+      ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
   have hcd : ContDiffOn ℝ 1 (fun θ => f (circleMap ζ ρ θ)) (Icc a b) := fun θ hθ =>
     (((hf.analyticAt (hUo.mem_nhds (hmemU θ hθ))).contDiffAt.restrict_scalars ℝ).comp θ
       (contDiff_circleMap ζ ρ).contDiffAt).contDiffWithinAt
   have hderiv : ∀ θ ∈ Ioc a b, ‖deriv (fun θ => f (circleMap ζ ρ θ)) θ‖ₑ =
-      ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+      ENNReal.ofReal |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
     intro θ hθ
     have hmem := hmemU θ (Set.Ioc_subset_Icc_self hθ)
     have h : HasDerivAt (fun θ => f (circleMap ζ ρ θ))
@@ -317,7 +320,7 @@ theorem ofReal_dist_le_mul_lintegral_Ioc (hUo : IsOpen U) (hf : DifferentiableOn
         (hasDerivAt_circleMap ζ ρ θ)
     rw [h.deriv, smul_eq_mul, enorm_mul]
     congr 1
-    rw [← ofReal_norm, norm_mul, norm_circleMap_zero, Complex.norm_I, mul_one, abs_of_pos hρ]
+    rw [← ofReal_norm, norm_mul, norm_circleMap_zero, Complex.norm_I, mul_one]
   calc ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b)))
       = ‖f (circleMap ζ ρ b) - f (circleMap ζ ρ a)‖ₑ := by
         rw [dist_comm, dist_eq_norm, ofReal_norm]
@@ -325,9 +328,9 @@ theorem ofReal_dist_le_mul_lintegral_Ioc (hUo : IsOpen U) (hf : DifferentiableOn
         enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc hcd hab
     _ = ∫⁻ θ in Ioc a b, ‖deriv (fun θ => f (circleMap ζ ρ θ)) θ‖ₑ := by
         rw [← restrict_Ioc_eq_restrict_Icc]
-    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal |ρ| * ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
         setLIntegral_congr_fun measurableSet_Ioc hderiv
-    _ = ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+    _ = ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
         lintegral_const_mul' _ _ ENNReal.ofReal_ne_top
 
 /-- **The chord bound.** If the closed arc of angles `Icc a b` has angular width at most `2 * π`
@@ -357,8 +360,10 @@ theorem ofReal_dist_le_circleImageLength (hUo : IsOpen U) (hf : DifferentiableOn
     ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b))) ≤
       circleImageLength f s ζ ρ := by
   calc ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b)))
-      ≤ ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
-        ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hρ hab hmemU
+      ≤ ENNReal.ofReal |ρ| * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+        ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hab hmemU
+    _ = ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+        rw [abs_of_pos hρ]
     _ = ENNReal.ofReal ρ *
           ∫⁻ θ in Ioc a b, s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
         congr 1

--- a/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
+++ b/TauCeti/Analysis/Complex/Conformal/LengthArea.lean
@@ -59,6 +59,9 @@ from these estimates in order to force the cluster set at `ζ` to degenerate to 
   `s`; for `ρ > 0`, measurable `s` and holomorphic `f` this is the arc length of `f ∘ circleMap ζ ρ`
   over the angles landing in `s`, a length along the parametrisation, counted with multiplicity,
   rather than a measure of the image set.
+* `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` — the chord bound in its primitive, set-free form:
+  the images of the endpoints of an arc of angles are at distance at most `ρ` times the angular
+  integral of `‖deriv f‖` over that arc.
 * `TauCeti.ofReal_dist_le_circleImageLength` — the chord bound justifying the name, and the only
   claim made here about lengths that is actually proved: a sub-arc of angular width at most `2 * π`
   that stays in `s` and in a set on which `f` is holomorphic has the distance between the images of
@@ -306,32 +309,21 @@ private lemma integral_deriv_circleMap_mul_eq_sub (hUo : IsOpen U) (hf : Differe
     refine (ContinuousOn.integrableOn_compact isCompact_Icc ?_).mono_set Set.Ioc_subset_Icc_self
     exact hcompCont.mul ((continuous_circleMap 0 ρ).continuousOn.mul continuousOn_const)
 
-/-- **The chord bound.** If the closed arc of angles `Icc a b` has angular width at most `2 * π`
-and the corresponding piece of the circle of radius `ρ` lies both in `s` and in an open set `U` on
-which `f` is holomorphic, then the distance between the images of its endpoints is at most
-`TauCeti.circleImageLength f s ζ ρ`.
+/-- **The chord bound over a sub-arc.** For `f` holomorphic on an open `U` containing the piece of
+the circle of radius `ρ` about `ζ` cut out by the angles `Icc a b`, the distance between the images
+of the two endpoints of that arc is at most `ρ` times the angular integral of `‖deriv f‖` over it.
 
-Both hypotheses are arc-local: `s` is constrained only along the arc, so the rest of it — the rest
-of the circle included — may lie outside the domain of holomorphy, and `U` need only be a
-neighbourhood of the arc rather than of `s`. That is what chains with
-`TauCeti.exists_circleImageLength_sq_lt`, whose conclusion is a bound on
-`TauCeti.circleImageLength f s ζ ρ` for a `s` chosen for the area estimate rather than for this
-arc; when `s ⊆ U` the containment along the arc is immediate from membership in `s`.
-
-The arc is unrestricted apart from its width: it may start anywhere and cross the branch cut at
-`±π` fixed in the definition, since by `TauCeti.circleImageLength_eq_lintegral_Ioc` the period of
-integration can be moved to `Ioc a (a + 2 * π)`.
-
-This is what makes `TauCeti.circleImageLength` a length rather than an abstract integral, and it is
-the form in which Wolff's lemma is used: a short image arc has small chords. Turning that into a
-crosscut of small diameter at a boundary point is left to the later file that constructs the
-crosscuts. -/
-theorem ofReal_dist_le_circleImageLength (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U) (ζ : ℂ)
-    {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ} (hab : a ≤ b) (hb : b ≤ a + 2 * π)
-    (hmem : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ s)
+This is the fundamental theorem of calculus along the arc, and it is the primitive form of the
+chord bound: the right-hand side is the length of the image of *this* arc, with no reference to
+any set `s` and no restriction on the angular width. Enlarging it to a whole period and inserting
+the indicator of `s` gives `TauCeti.ofReal_dist_le_circleImageLength`, which is the form the
+length–area estimates chain with; the form here is what a *local* estimate near one end of the arc
+needs, since there the arc is shrunk rather than the radius. -/
+theorem ofReal_dist_le_mul_lintegral_Ioc (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U) (ζ : ℂ)
+    {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ} (hab : a ≤ b)
     (hmemU : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ U) :
     ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b))) ≤
-      circleImageLength f s ζ ρ := by
+      ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
   have hderivCont : ContinuousOn (deriv f) U := ((hf.analyticOnNhd hUo).deriv).continuousOn
   have hcompCont : ContinuousOn (fun θ => deriv f (circleMap ζ ρ θ)) (Icc a b) :=
     hderivCont.comp (continuous_circleMap ζ ρ).continuousOn hmemU
@@ -358,16 +350,49 @@ theorem ofReal_dist_le_circleImageLength (hUo : IsOpen U) (hf : DifferentiableOn
     _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal (ρ * ‖deriv f (circleMap ζ ρ θ)‖) := by
         rw [intervalIntegral.integral_of_le hab,
           MeasureTheory.ofReal_integral_eq_lintegral_ofReal hintOn hnn]
-    _ = ∫⁻ θ in Ioc a b,
-          ENNReal.ofReal ρ * s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
+    _ = ∫⁻ θ in Ioc a b, ENNReal.ofReal ρ * ‖deriv f (circleMap ζ ρ θ)‖ₑ := by
+        refine setLIntegral_congr_fun measurableSet_Ioc fun θ _ => ?_
+        rw [ENNReal.ofReal_mul hρ.le, ofReal_norm]
+    _ = ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+        lintegral_const_mul' _ _ ENNReal.ofReal_ne_top
+
+/-- **The chord bound.** If the closed arc of angles `Icc a b` has angular width at most `2 * π`
+and the corresponding piece of the circle of radius `ρ` lies both in `s` and in an open set `U` on
+which `f` is holomorphic, then the distance between the images of its endpoints is at most
+`TauCeti.circleImageLength f s ζ ρ`.
+
+Both hypotheses are arc-local: `s` is constrained only along the arc, so the rest of it — the rest
+of the circle included — may lie outside the domain of holomorphy, and `U` need only be a
+neighbourhood of the arc rather than of `s`. That is what chains with
+`TauCeti.exists_circleImageLength_sq_lt`, whose conclusion is a bound on
+`TauCeti.circleImageLength f s ζ ρ` for a `s` chosen for the area estimate rather than for this
+arc; when `s ⊆ U` the containment along the arc is immediate from membership in `s`.
+
+The arc is unrestricted apart from its width: it may start anywhere and cross the branch cut at
+`±π` fixed in the definition, since by `TauCeti.circleImageLength_eq_lintegral_Ioc` the period of
+integration can be moved to `Ioc a (a + 2 * π)`.
+
+This is what makes `TauCeti.circleImageLength` a length rather than an abstract integral, and it is
+the form in which Wolff's lemma is used: a short image arc has small chords. Turning that into a
+crosscut of small diameter at a boundary point is left to the later file that constructs the
+crosscuts. -/
+theorem ofReal_dist_le_circleImageLength (hUo : IsOpen U) (hf : DifferentiableOn ℂ f U) (ζ : ℂ)
+    {ρ : ℝ} (hρ : 0 < ρ) {a b : ℝ} (hab : a ≤ b) (hb : b ≤ a + 2 * π)
+    (hmem : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ s)
+    (hmemU : ∀ θ ∈ Icc a b, circleMap ζ ρ θ ∈ U) :
+    ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b))) ≤
+      circleImageLength f s ζ ρ := by
+  calc ENNReal.ofReal (dist (f (circleMap ζ ρ a)) (f (circleMap ζ ρ b)))
+      ≤ ENNReal.ofReal ρ * ∫⁻ θ in Ioc a b, ‖deriv f (circleMap ζ ρ θ)‖ₑ :=
+        ofReal_dist_le_mul_lintegral_Ioc hUo hf ζ hρ hab hmemU
+    _ = ENNReal.ofReal ρ *
+          ∫⁻ θ in Ioc a b, s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) := by
+        congr 1
         refine setLIntegral_congr_fun measurableSet_Ioc fun θ hθ => ?_
-        rw [ENNReal.ofReal_mul hρ.le, ofReal_norm,
-          Set.indicator_of_mem (hmem θ (Set.Ioc_subset_Icc_self hθ))]
-    _ ≤ ∫⁻ θ in Ioc a (a + 2 * π),
-          ENNReal.ofReal ρ * s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) :=
-        lintegral_mono_set (Set.Ioc_subset_Ioc_right hb)
-    _ = circleImageLength f s ζ ρ := by
-        rw [circleImageLength_eq_lintegral_Ioc f s ζ ρ a,
-          lintegral_const_mul' _ _ ENNReal.ofReal_ne_top]
+        rw [Set.indicator_of_mem (hmem θ (Set.Ioc_subset_Icc_self hθ))]
+    _ ≤ ENNReal.ofReal ρ *
+          ∫⁻ θ in Ioc a (a + 2 * π), s.indicator (fun z => ‖deriv f z‖ₑ) (circleMap ζ ρ θ) :=
+        by gcongr
+    _ = circleImageLength f s ζ ρ := (circleImageLength_eq_lintegral_Ioc f s ζ ρ a).symm
 
 end TauCeti

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -108,17 +108,9 @@ angular gap, the half-angle then staying in `[0, π / 2]`; beyond `π` the formu
 chord shrinks again as the gap widens. -/
 theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (h : |θ - θ'| ≤ 2 * π) :
     dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
-  rw [dist_circleMap_eq_two_mul_abs_sin]
-  congr 1
-  have hnn : 0 ≤ Real.sin (|θ - θ'| / 2) :=
-    Real.sin_nonneg_of_nonneg_of_le_pi (by positivity) (by linarith [Real.pi_pos])
-  rcases abs_cases (θ - θ') with ⟨hc, -⟩ | ⟨hc, -⟩
-  · rw [hc] at hnn ⊢
-    exact abs_of_nonneg hnn
-  · rw [hc] at hnn ⊢
-    rw [neg_div, Real.sin_neg]
-    rw [neg_div, Real.sin_neg] at hnn
-    exact abs_of_nonpos (by linarith)
+  have habs : |(θ - θ') / 2| = |θ - θ'| / 2 := by rw [abs_div, abs_two]
+  rw [dist_circleMap_eq_two_mul_abs_sin,
+    Real.abs_sin_eq_sin_abs_of_abs_le_pi (by rw [habs]; linarith), habs]
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -26,7 +26,7 @@ translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ 
   centre and radius, where the chord between the angles `θ` and `θ'` has length
   `2 * |ρ| * |sin ((θ - θ') / 2)|`, and
   `TauCeti.dist_circleMap_eq_two_mul_sin_abs`, the same formula with the sign of the angular
-  difference cleared, valid for angles at most `π` apart.
+  difference cleared, valid for angles at most a full turn apart.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
   most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
@@ -97,14 +97,16 @@ theorem dist_circleMap_eq_two_mul_abs_sin (ζ : ℂ) (ρ θ θ' : ℝ) :
   rw [dist_eq_norm, hsub, norm_mul, Complex.norm_real, Real.norm_eq_abs, hchord]
   ring
 
-/-- **The chord with the sign of the angular difference cleared.** For angles at most `π` apart the
-chord `TauCeti.dist_circleMap_eq_two_mul_abs_sin` is `2 * |ρ| * sin (|θ - θ'| / 2)`, an increasing
-function of the angular gap: the absolute value moves from outside the sine to inside it.
+/-- **The chord with the sign of the angular difference cleared.** For angles at most a full turn
+apart the chord `TauCeti.dist_circleMap_eq_two_mul_abs_sin` is `2 * |ρ| * sin (|θ - θ'| / 2)`: the
+absolute value moves from outside the sine to inside it.
 
-The width restriction is what makes the two forms differ. Beyond `π` the half-angle leaves
-`[-π / 2, π / 2]`, where `|sin|` and `sin ∘ |·|` part company, and the chord stops growing with the
-gap. -/
-theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (h : |θ - θ'| ≤ π) :
+The width restriction is what makes the two forms differ: it puts the half-angle in `[0, π]`, where
+the sine is nonnegative, and past a full turn the half-angle leaves that interval and `|sin|` and
+`sin ∘ |·|` part company. Up to `π` the right-hand side is moreover an increasing function of the
+angular gap, the half-angle then staying in `[0, π / 2]`; beyond `π` the formula still holds but the
+chord shrinks again as the gap widens. -/
+theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (h : |θ - θ'| ≤ 2 * π) :
     dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
   rw [dist_circleMap_eq_two_mul_abs_sin]
   congr 1

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -24,7 +24,9 @@ translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ 
   unit circle has length `2 * |sin (θ / 2)|`.
 * `TauCeti.dist_circleMap_eq_two_mul_abs_sin` — its form for the circle `circleMap ζ ρ` of arbitrary
   centre and radius, where the chord between the angles `θ` and `θ'` has length
-  `2 * |ρ| * |sin ((θ - θ') / 2)|`.
+  `2 * |ρ| * |sin ((θ - θ') / 2)|`, and
+  `TauCeti.dist_circleMap_eq_two_mul_sin_abs`, the same formula with the sign of the angular
+  difference cleared, valid for angles at most `π` apart.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
   most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
@@ -94,6 +96,27 @@ theorem dist_circleMap_eq_two_mul_abs_sin (ζ : ℂ) (ρ θ θ' : ℝ) :
     exact (Subtype.dist_eq _ _).symm
   rw [dist_eq_norm, hsub, norm_mul, Complex.norm_real, Real.norm_eq_abs, hchord]
   ring
+
+/-- **The chord with the sign of the angular difference cleared.** For angles at most `π` apart the
+chord `TauCeti.dist_circleMap_eq_two_mul_abs_sin` is `2 * |ρ| * sin (|θ - θ'| / 2)`, an increasing
+function of the angular gap: the absolute value moves from outside the sine to inside it.
+
+The width restriction is what makes the two forms differ. Beyond `π` the half-angle leaves
+`[-π / 2, π / 2]`, where `|sin|` and `sin ∘ |·|` part company, and the chord stops growing with the
+gap. -/
+theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (h : |θ - θ'| ≤ π) :
+    dist (circleMap ζ ρ θ) (circleMap ζ ρ θ') = 2 * |ρ| * Real.sin (|θ - θ'| / 2) := by
+  rw [dist_circleMap_eq_two_mul_abs_sin]
+  congr 1
+  have hnn : 0 ≤ Real.sin (|θ - θ'| / 2) :=
+    Real.sin_nonneg_of_nonneg_of_le_pi (by positivity) (by linarith [Real.pi_pos])
+  rcases abs_cases (θ - θ') with ⟨hc, -⟩ | ⟨hc, -⟩
+  · rw [hc] at hnn ⊢
+    exact abs_of_nonneg hnn
+  · rw [hc] at hnn ⊢
+    rw [neg_div, Real.sin_neg]
+    rw [neg_div, Real.sin_neg] at hnn
+    exact abs_of_nonpos (by linarith)
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=


### PR DESCRIPTION
This PR shows that a circular crosscut whose image has finite length has an honest limit at each of its two ends, so that the closure of the image crosscut is the image crosscut together with two points. `TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean` already identifies the boundary piece a crosscut clings to as the union of the *cluster sets* of the map at the crosscut's two endpoints, and shows each of them to be a continuum, but says in its own words that the identification is "with a union of two cluster sets, not with a connected subset of `∂Ω` running between them"; nothing there degenerates those continua to points. The new `TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean` supplies that degeneration from the single hypothesis `TauCeti.circleImageLength f (Metric.ball c r) ζ ρ ≠ ⊤`, which the length–area method already produces — Wolff's lemma makes that quantity *small*, so a crosscut short enough for the existing estimates is in particular of finite length and the hypothesis costs a consumer nothing it has not already paid for.

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "**L5 — Carathéodory boundary correspondence.** The concrete L5 milestone is the **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of closures" — and within it the second of the two geometric inputs that `Conformal/CutDiameter.lean` names: "the length–area method makes the image crosscut short, and local connectedness of `∂Ω` supplies the small connected `E` joining its two ends". Naming that arc of `∂Ω` presupposes two *points* to join, and the library only knew of two cluster sets. That the degeneration is available at all, and without circularity, is the point of the file: the boundary cluster sets of the map on the *disc* degenerating to points is precisely the open L5 milestone, whereas the ends of a crosscut degenerate for a much cheaper reason — the arc `Metric.ball c r ∩ Metric.sphere ζ ρ` is one-dimensional and the length of its image is a finite number, so the images of its angles satisfy a Cauchy criterion as the angle runs to an end of the arc. No boundary behaviour of the map on the disc is used, and none is proved.

The engine is the chord bound of `Conformal/LengthArea.lean`, and it is first split into its primitive, set-free form. `TauCeti.ofReal_dist_le_mul_lintegral_Ioc` bounds the distance between the images of the two endpoints of an arc of angles by `ρ` times the angular integral of `‖deriv f‖` over *that* arc, with no reference to a set `s` and no restriction on the angular width; `TauCeti.ofReal_dist_le_circleImageLength` is now three calc steps on top of it — insert the indicator of `s`, enlarge the arc to a period — rather than an independent run of the fundamental theorem of calculus along the arc, so no proof is duplicated and no signature changes. Applied to a *sub*-arc it says the oscillation of `f` along a piece of the circle is controlled by the length that piece alone carries, and since the total is finite, Mathlib's absolute continuity of the integral (`MeasureTheory.exists_pos_setLIntegral_lt_of_measure_lt`, consumed rather than restated) makes the length carried by a short sub-arc uniformly small. That is `TauCeti.exists_pos_forall_dist_le_of_lintegral_ne_top`, a modulus of continuity for `f` along the arc in the angular parameter, uniform over the arc and in particular not shrinking as an end is approached. The same chord bound applied to the whole arc gives `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`.

Turning the angular modulus into a statement about the plane needs the chord formula with the sign of the angular difference cleared: on an arc of angular width at most `π` the chord is `2 * |ρ| * Real.sin (|θ - θ'| / 2)`, an increasing function of the angular gap, so points of the arc close in the plane are close in angle. That formula existed as a `private` helper in `Conformal/Crosscut/Endpoints.lean`; it is a fact about circles and nothing else, so it moves verbatim to `TauCeti/Topology/Circle/Metric.lean` beside the signed form it is proved from, and becomes `TauCeti.dist_circleMap_eq_two_mul_sin_abs`. No declaration is renamed and no proof changes; `Conformal/Crosscut/Endpoints.lean` keeps using it exactly as before, through the import it already had. With it, `TauCeti.subsingleton_clusterSetOn_circleMap_image_Ioo` reads the modulus as the Cauchy criterion `TauCeti.subsingleton_clusterSetOn_of_forall_exists` of `TauCeti/Topology/ClusterSet.lean` and concludes at every point of the closed arc, both endpoints included.

The crosscut instances are the arc description of `Conformal/Crosscut/Endpoints.lean` — `TauCeti.ball_inter_sphere_eq_circleMap_image_Ioo`, `TauCeti.closedBall_inter_sphere_eq_circleMap_image_Icc`, `TauCeti.closure_ball_inter_sphere` and `TauCeti.sphere_inter_sphere_eq_pair_circleMap` — a genuine circular crosscut having angular width `2 * Real.arccos (ρ / (2 * r))`, which is below `π` exactly because `ρ` is positive. They give `TauCeti.subsingleton_clusterSetOn_ball_inter_sphere`, then `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` once boundedness of the image supplies the compactness that `TauCeti.exists_tendsto_of_clusterSetOn_subsingleton` consumes, then the singleton form `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — the form the middle-piece identification `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` indexes over — and finally `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert`, the closure of an image crosscut as the image crosscut plus two points. Nothing is claimed about those two points: they may coincide, an image crosscut being free to close up, and the separation argument that would enclose the whole cut-off boundary piece is not attempted here. This is disjoint from the in-flight L5 threads, which generalise the cut-diameter criterion to an arbitrary domain and identify the middle piece as a union of two cluster sets; neither produces a limit along a crosscut, and both leave the ends as cluster sets.

Neither injectivity of `f` nor any hypothesis on its image is used anywhere, and in accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for layers L0–L6, everything is stated for maps of `ℂ`; the arc statements ask nothing of the ambient disc, only that `f` be holomorphic on an open set containing the arc, so they apply to any circle in any domain and the crosscut is one instance. No Mathlib infrastructure was vendored. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the pinned Mathlib has no boundary correspondence for conformal maps, so this is new Lean formalization rather than a temporary shim; it consumes no L0–L3 shim, its analytic input being the fundamental theorem of calculus along an arc through `Conformal/LengthArea.lean`.

`lake build` (6509 jobs) and `lake exe axioms` (22285 declarations, all within the allowlist `[propext, Classical.choice, Quot.sound]`) are green, as are `lake exe module-system` (1232 modules), `lake exe lint-style` and `scripts/lint-env.sh` (no new violations).

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"crosscut-endpoint-limit-of-finite-image-length"}-->

🤖 Prepared with Claude Code
