### PR TITLE
feat: package the Clifford associated graded algebra

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -200,13 +200,6 @@ noncomputable def filtrationGradedAlgebraMap₀ (Q : QuadraticForm R M) :
   rw [map_one, sub_self]
   exact Submodule.zero_mem _
 
-private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
-    {a b : GradedMonoid (FiltrationGradedPiece Q)} (h : a.fst = b.fst)
-    (h2 : cast (congrArg (FiltrationGradedPiece Q) h) a.snd = b.snd) : a = b := by
-  obtain ⟨i, a⟩ := a
-  cases h
-  exact congrArg _ h2
-
 /-- The degree-zero homogeneous unit acts on the left. -/
 @[simp] theorem filtrationGradedOne_mul (Q : QuadraticForm R M) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
@@ -250,20 +243,24 @@ private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
       rw [mul_one, sub_self]
       exact Submodule.zero_mem (filtrationPrevious Q (k + 0))
 
+/-- The homogeneous degree-zero class supplies the `GOne` structure on filtration pieces. -/
 noncomputable instance filtrationGradedGOne {Q : QuadraticForm R M} :
     GradedMonoid.GOne (FiltrationGradedPiece Q) where
   one := filtrationGradedOne Q
 
+/-- Homogeneous filtration multiplication supplies the `GMul` structure on filtration pieces. -/
 noncomputable instance filtrationGradedGMul {Q : QuadraticForm R M} :
     GradedMonoid.GMul (FiltrationGradedPiece Q) where
   mul {i j} := fun x y => filtrationGradedMul Q i j x y
 
+/-- The homogeneous unit and multiplication form a graded monoid of filtration pieces. -/
 noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
     GradedMonoid.GMonoid (FiltrationGradedPiece Q) :=
   { filtrationGradedGMul (Q := Q), filtrationGradedGOne (Q := Q) with
     one_mul := fun x => by
       rcases x with ⟨k, x⟩
-      apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k)
+      apply Sigma.ext (Nat.zero_add k)
+      apply heq_of_cast_eq (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
       -- The sigma equality is now a homogeneous equality after exposing the GOne and GMul fields.
       change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
         (filtrationGradedMul Q 0 k (filtrationGradedOne Q) x) = x
@@ -271,7 +268,8 @@ noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
       simp
     mul_one := fun x => by
       rcases x with ⟨k, x⟩
-      apply filtrationGradedMonoid_eq_of_cast Q (Nat.add_zero k)
+      apply Sigma.ext (Nat.add_zero k)
+      apply heq_of_cast_eq (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k))
       -- The sigma equality is now a homogeneous equality after exposing the GOne and GMul fields.
       change cast (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k))
         (filtrationGradedMul Q k 0 x (filtrationGradedOne Q)) = x
@@ -281,9 +279,11 @@ noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
       rcases x with ⟨i, x⟩
       rcases y with ⟨j, y⟩
       rcases z with ⟨k, z⟩
-      apply filtrationGradedMonoid_eq_of_cast Q (Nat.add_assoc i j k)
+      apply Sigma.ext (Nat.add_assoc i j k)
+      apply heq_of_cast_eq (congrArg (FiltrationGradedPiece Q) (Nat.add_assoc i j k))
       exact filtrationGradedMul_assoc Q i j k x y z }
 
+/-- Bilinearity and scalar casts make the homogeneous pieces a direct-sum graded ring. -/
 noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
     DirectSum.GRing (FiltrationGradedPiece Q) where
   mul_zero := fun x => (filtrationGradedMul Q _ _ x).map_zero
@@ -390,11 +390,13 @@ theorem filtrationGradedAlgebraMap₀_commutes (Q : QuadraticForm R M) (r : R) (
   rw [← filtrationGradedAlgebraMap₀_commutes Q r k x]
   simpa only [cast_cast, cast_eq] using filtrationGradedAlgebraMap₀_mul Q r k x
 
+/-- The graded-ring structure supplies the semiring structure needed by the direct sum. -/
 noncomputable instance filtrationGradedGSemiring {Q : QuadraticForm R M} :
     DirectSum.GSemiring (FiltrationGradedPiece Q) := by
   exact @DirectSum.GRing.toGSemiring ℕ (FiltrationGradedPiece Q) _ _
     (filtrationGradedGRing (Q := Q))
 
+/-- Degree-zero scalar classes make the homogeneous pieces into a graded `R`-algebra. -/
 noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     DirectSum.GAlgebra R (FiltrationGradedPiece Q) where
   toFun := filtrationGradedAlgebraMap₀ Q
@@ -403,7 +405,8 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     change filtrationGradedAlgebraMap₀ Q 1 = filtrationGradedOne Q
     exact filtrationGradedAlgebraMap₀_one Q
   map_mul r s := by
-    apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add 0).symm
+    apply Sigma.ext (Nat.zero_add 0).symm
+    apply heq_of_cast_eq (congrArg (FiltrationGradedPiece Q) (Nat.zero_add 0).symm)
     -- The scalar product is a degree-zero homogeneous product after this reindexing.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add 0).symm)
       (filtrationGradedAlgebraMap₀ Q (r * s)) =
@@ -413,11 +416,14 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     simp
   commutes r x := by
     rcases x with ⟨k, x⟩
-    apply filtrationGradedMonoid_eq_of_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)
+    apply Sigma.ext ((Nat.zero_add k).trans (Nat.add_zero k).symm)
+    apply heq_of_cast_eq
+      (congrArg (FiltrationGradedPiece Q) ((Nat.zero_add k).trans (Nat.add_zero k).symm))
     exact filtrationGradedAlgebraMap₀_commutes Q r k x
   smul_def r x := by
     rcases x with ⟨k, x⟩
-    apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k).symm
+    apply Sigma.ext (Nat.zero_add k).symm
+    apply heq_of_cast_eq (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm)
     -- The sigma-level scalar law reduces to the degree-`k` homogeneous scalar equation.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) (r • x) =
       filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap₀ Q r) x
@@ -426,6 +432,8 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
       congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
         (filtrationGradedAlgebraMap₀_mul Q r k x)
 
+/-- The direct sum of homogeneous filtration pieces inherits its associated-graded
+ring structure. -/
 noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
     Ring (filtrationAssociatedGraded Q) := by
   letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -368,6 +368,8 @@ theorem filtrationGradedAlgebraMap₀_commutes (Q : QuadraticForm R M) (r : R) (
       filtrationGradedMul Q k 0 x (filtrationGradedAlgebraMap₀ Q r) := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
+      -- Quotient induction provides a representative. Expose the quotient classes so the
+      -- representative-product API applies on both sides of the commutation equation.
       change cast (congrArg (FiltrationGradedPiece Q)
         ((Nat.zero_add k).trans (Nat.add_zero k).symm))
         (filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
@@ -378,6 +380,8 @@ theorem filtrationGradedAlgebraMap₀_commutes (Q : QuadraticForm R M) (r : R) (
       apply (Submodule.Quotient.eq _).mpr
       rw [Submodule.mem_comap, map_sub,
         filtration_subtype_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
+      -- Quotient equality is ambient filtration membership; this exposes the coercions needed
+      -- for the Clifford algebra's scalar-commutation theorem.
       change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) -
           x * algebraMap R (CliffordAlgebra Q) r ∈ filtrationPrevious Q (k + 0)
       rw [Algebra.commutes, sub_self]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -248,10 +248,19 @@ noncomputable instance filtrationGradedGOne {Q : QuadraticForm R M} :
     GradedMonoid.GOne (FiltrationGradedPiece Q) where
   one := filtrationGradedOne Q
 
+/-- The `GOne` field is the named degree-zero filtration class. -/
+@[simp] theorem filtrationGradedGOne_one (Q : QuadraticForm R M) :
+    (GradedMonoid.GOne.one : FiltrationGradedPiece Q 0) = filtrationGradedOne Q := rfl
+
 /-- Homogeneous filtration multiplication supplies the `GMul` structure on filtration pieces. -/
 noncomputable instance filtrationGradedGMul {Q : QuadraticForm R M} :
     GradedMonoid.GMul (FiltrationGradedPiece Q) where
   mul {i j} := fun x y => filtrationGradedMul Q i j x y
+
+/-- The `GMul` field is the named homogeneous filtration product. -/
+@[simp] theorem filtrationGradedGMul_mul (Q : QuadraticForm R M) {i j : ℕ}
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
+    GradedMonoid.GMul.mul (A := FiltrationGradedPiece Q) x y = filtrationGradedMul Q i j x y := rfl
 
 /-- The homogeneous unit and multiplication form a graded monoid of filtration pieces. -/
 noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
@@ -436,12 +445,30 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
       congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
         (filtrationGradedAlgebraMap₀_mul Q r k x)
 
+/-- The `GAlgebra` field is the named degree-zero scalar map. -/
+@[simp] theorem filtrationGradedGAlgebra_toFun (Q : QuadraticForm R M) (r : R) :
+    DirectSum.GAlgebra.toFun (A := FiltrationGradedPiece Q)
+      (self := filtrationGradedGAlgebra (Q := Q)) r = filtrationGradedAlgebraMap₀ Q r := rfl
+
 /-- The direct sum of homogeneous filtration pieces inherits its associated-graded
 ring structure. -/
 noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
     Ring (filtrationAssociatedGraded Q) := by
   letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
   infer_instance
+
+/-- Multiplication of homogeneous direct-sum terms is the named filtration product. -/
+@[simp] theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) {i j : ℕ}
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
+    (DirectSum.of (FiltrationGradedPiece Q) i x : filtrationAssociatedGraded Q) *
+      DirectSum.of (FiltrationGradedPiece Q) j y =
+      DirectSum.of (FiltrationGradedPiece Q) (i + j) (filtrationGradedMul Q i j x y) := by
+  simp only [DirectSum.of_mul_of, filtrationGradedGMul_mul]
+
+/-- The associated-graded scalar map is the degree-zero named filtration map. -/
+@[simp] theorem filtrationAssociatedGraded_algebraMap (Q : QuadraticForm R M) (r : R) :
+    algebraMap R (filtrationAssociatedGraded Q) r =
+      DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r) := rfl
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -18,6 +18,9 @@ algebra with the exterior algebra.
 
 It advances the Layer 0 associated-graded-algebra target in the
 [Spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings).
+
+Its graded-algebra packaging adapts the pattern in Mathlib's
+[`TensorPower` construction](https://github.com/leanprover-community/mathlib4/blob/master/Mathlib/LinearAlgebra/TensorPower/Basic.lean).
 -/
 
 public section
@@ -185,11 +188,14 @@ noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
 /-- The degree-zero scalar map sends `1` to the homogeneous unit. -/
 @[simp] theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
     filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q := by
+  -- Expand the two degree-zero representatives to compare their quotient classes;
+  -- `map_one` is stated only in the ambient Clifford algebra.
   change Submodule.Quotient.mk
       (⟨algebraMap R (CliffordAlgebra Q) 1, algebraMap_mem_filtration Q 1 0⟩ : filtration Q 0) =
     Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0)
   apply (Submodule.Quotient.eq _).mpr
   rw [Submodule.mem_comap]
+  -- Quotient equality is ambient membership, the form in which `map_one` applies.
   change algebraMap R (CliffordAlgebra Q) 1 - 1 ∈ filtrationPrevious Q 0
   rw [map_one, sub_self]
   exact Submodule.zero_mem _
@@ -258,6 +264,7 @@ noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
     one_mul := fun x => by
       rcases x with ⟨k, x⟩
       apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k)
+      -- The sigma equality is now a homogeneous equality after exposing the GOne and GMul fields.
       change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
         (filtrationGradedMul Q 0 k (filtrationGradedOne Q) x) = x
       rw [filtrationGradedOne_mul]
@@ -265,6 +272,7 @@ noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
     mul_one := fun x => by
       rcases x with ⟨k, x⟩
       apply filtrationGradedMonoid_eq_of_cast Q (Nat.add_zero k)
+      -- The sigma equality is now a homogeneous equality after exposing the GOne and GMul fields.
       change cast (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k))
         (filtrationGradedMul Q k 0 x (filtrationGradedOne Q)) = x
       rw [filtrationGradedMul_one]
@@ -337,11 +345,14 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
 private theorem filtrationGradedAlgebraMap_mul_self (Q : QuadraticForm R M) (r s : R) :
     filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
       (filtrationGradedAlgebraMap Q s) = filtrationGradedAlgebraMap Q (r * s) := by
+  -- Both scalar classes are quotient representatives, so expose them for the
+  -- representative product.
   change filtrationGradedMul Q 0 0 (Submodule.Quotient.mk _)
     (Submodule.Quotient.mk _) = Submodule.Quotient.mk _
   rw [filtrationGradedMul_apply_mk]
   apply (Submodule.Quotient.eq _).mpr
   rw [Submodule.mem_comap]
+  -- Quotient equality is ambient membership, the form in which `map_mul` applies.
   change algebraMap R (CliffordAlgebra Q) r * algebraMap R (CliffordAlgebra Q) s -
       algebraMap R (CliffordAlgebra Q) (r * s) ∈ filtrationPrevious Q 0
   rw [← map_mul, sub_self]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -178,8 +178,6 @@ noncomputable def filtrationGradedOne (Q : QuadraticForm R M) :
 theorem filtrationGradedOne_def (Q : QuadraticForm R M) :
     filtrationGradedOne Q =
       Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0) := by
-  change Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0) =
-    Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0)
   rfl
 
 /-- The quotient class of the Clifford unit is the degree-zero homogeneous unit. -/
@@ -205,12 +203,6 @@ theorem filtrationGradedAlgebraMap₀_apply (Q : QuadraticForm R M) (r : R) :
       Submodule.Quotient.mk
         (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
           filtration Q 0) := by
-  change Submodule.Quotient.mk
-      (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
-        filtration Q 0) =
-    Submodule.Quotient.mk
-      (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
-        filtration Q 0)
   rfl
 
 /-- The quotient class of an ambient scalar is its degree-zero homogeneous class. -/
@@ -499,11 +491,6 @@ noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
       DirectSum.of (FiltrationGradedPiece Q) j y =
       DirectSum.of (FiltrationGradedPiece Q) (i + j) (filtrationGradedMul Q i j x y) := by
   simp only [DirectSum.of_mul_of, filtrationGradedGMul_def]
-
-/-- The associated-graded scalar map is the degree-zero named filtration map. -/
-@[simp] theorem filtrationAssociatedGraded_algebraMap (Q : QuadraticForm R M) (r : R) :
-    algebraMap R (filtrationAssociatedGraded Q) r =
-      DirectSum.of (FiltrationGradedPiece Q) 0 (filtrationGradedAlgebraMap₀ Q r) := rfl
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -385,11 +385,6 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     simpa using congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
       (filtrationGradedAlgebraMap_mul Q r k x)
 
-noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
-    Ring (filtrationAssociatedGraded Q) := by
-  letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
-  infer_instance
-
 /-- Multiplication of homogeneous elements in the associated graded Clifford algebra. -/
 @[simp]
 theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) (i j : ℕ)

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -6,22 +6,21 @@ module
 
 public import Mathlib.LinearAlgebra.Quotient.Bilinear
 public import Mathlib.LinearAlgebra.TensorProduct.Submodule
+public import Mathlib.Algebra.DirectSum.Algebra
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 
 /-!
 # Homogeneous multiplication for a Clifford filtration
 
-This file lifts Clifford multiplication to a bilinear product between any two successive quotient
-pieces of the Clifford degree filtration.
-
-This is the multiplication prerequisite for the Layer 0 associated-graded comparison in the spin
-representations roadmap. It is generic in the quadratic form and does not yet package the direct
-sum as a graded algebra or identify it with the exterior algebra.
+This file packages the homogeneous pieces of the Clifford degree filtration into a direct-sum
+associated-graded algebra. It is generic in the quadratic form and does not yet identify that
+algebra with the exterior algebra.
 -/
 
 public section
 
 open CliffordAlgebra
+open scoped DirectSum
 
 universe u v
 
@@ -30,6 +29,10 @@ namespace TauCeti
 namespace CliffordAlgebra
 
 variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+
+/-- The direct sum of the homogeneous pieces of the Clifford degree filtration. -/
+abbrev filtrationAssociatedGraded (Q : QuadraticForm R M) : Type max u v :=
+  ⨁ k : ℕ, FiltrationGradedPiece Q k
 
 private theorem mul_mem_filtrationPrevious_left (Q : QuadraticForm R M) (i j : ℕ)
     {x y : CliffordAlgebra Q} (hx : x ∈ filtrationPrevious Q i) (hy : y ∈ filtration Q j) :
@@ -159,6 +162,250 @@ theorem filtrationGradedMul_assoc (Q : QuadraticForm R M) (i j k : ℕ)
                 filtrationPrevious Q (i + (j + k))
               rw [mul_assoc, sub_self]
               exact Submodule.zero_mem (filtrationPrevious Q (i + (j + k)))
+
+/-- The degree-zero unit of the homogeneous Clifford filtration pieces. -/
+noncomputable def filtrationGradedOne (Q : QuadraticForm R M) :
+    FiltrationGradedPiece Q 0 :=
+  Submodule.Quotient.mk ⟨1, one_mem_filtration Q 0⟩
+
+/-- The degree-zero class of a scalar in the associated graded Clifford filtration. -/
+noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
+    R →+ FiltrationGradedPiece Q 0 where
+  toFun r := Submodule.Quotient.mk
+    ⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩
+  map_zero' := by simp
+  map_add' r s := by
+    rw [← Submodule.Quotient.mk_add]
+    apply congrArg Submodule.Quotient.mk
+    exact Subtype.ext (map_add (algebraMap R (CliffordAlgebra Q)) r s)
+
+@[simp] private theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
+    filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q :=
+  rfl
+
+private theorem filtrationGradedPiece_cast_mk (Q : QuadraticForm R M) {i j : ℕ}
+    (h : i = j) (x : filtration Q i) (hx : (x : CliffordAlgebra Q) ∈ filtration Q j) :
+    cast (congrArg (FiltrationGradedPiece Q) h) (Submodule.Quotient.mk x) =
+      Submodule.Quotient.mk ⟨x, hx⟩ := by
+  subst j
+  rfl
+
+private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
+    {a b : GradedMonoid (FiltrationGradedPiece Q)} (h : a.fst = b.fst)
+    (h2 : cast (congrArg (FiltrationGradedPiece Q) h) a.snd = b.snd) : a = b := by
+  obtain ⟨i, a⟩ := a
+  cases h
+  exact congrArg _ h2
+
+private theorem filtrationGradedOne_mul (Q : QuadraticForm R M) (k : ℕ)
+    (x : FiltrationGradedPiece Q k) :
+    filtrationGradedMul Q 0 k (filtrationGradedOne Q) x =
+      cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) x := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ x =>
+      change filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
+        (Submodule.Quotient.mk x) = _
+      rw [filtrationGradedMul_apply_mk]
+      rw [filtrationGradedPiece_cast_mk Q (Nat.zero_add k).symm x (by
+        rw [Nat.zero_add]
+        exact x.property)]
+      apply (Submodule.Quotient.eq _).mpr
+      change (1 : CliffordAlgebra Q) * (x : CliffordAlgebra Q) - x ∈
+        filtrationPrevious Q (0 + k)
+      rw [one_mul, sub_self]
+      exact Submodule.zero_mem (filtrationPrevious Q (0 + k))
+
+private theorem filtrationGradedMul_one (Q : QuadraticForm R M) (k : ℕ)
+    (x : FiltrationGradedPiece Q k) :
+    filtrationGradedMul Q k 0 x (filtrationGradedOne Q) =
+      cast (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k).symm) x := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ x =>
+      change filtrationGradedMul Q k 0 (Submodule.Quotient.mk x)
+        (Submodule.Quotient.mk _) = _
+      rw [filtrationGradedMul_apply_mk]
+      rw [filtrationGradedPiece_cast_mk Q (Nat.add_zero k).symm x (by
+        rw [Nat.add_zero]
+        exact x.property)]
+      apply (Submodule.Quotient.eq _).mpr
+      change (x : CliffordAlgebra Q) * 1 - x ∈ filtrationPrevious Q (k + 0)
+      rw [mul_one, sub_self]
+      exact Submodule.zero_mem (filtrationPrevious Q (k + 0))
+
+noncomputable instance filtrationGradedGOne {Q : QuadraticForm R M} :
+    GradedMonoid.GOne (FiltrationGradedPiece Q) where
+  one := filtrationGradedOne Q
+
+noncomputable instance filtrationGradedGMul {Q : QuadraticForm R M} :
+    GradedMonoid.GMul (FiltrationGradedPiece Q) where
+  mul {i j} := fun x y => filtrationGradedMul Q i j x y
+
+noncomputable instance filtrationGradedGMonoid {Q : QuadraticForm R M} :
+    GradedMonoid.GMonoid (FiltrationGradedPiece Q) :=
+  { filtrationGradedGMul (Q := Q), filtrationGradedGOne (Q := Q) with
+    one_mul := fun x => by
+      rcases x with ⟨k, x⟩
+      apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k)
+      change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
+        (filtrationGradedMul Q 0 k (filtrationGradedOne Q) x) = x
+      rw [filtrationGradedOne_mul]
+      simp
+    mul_one := fun x => by
+      rcases x with ⟨k, x⟩
+      apply filtrationGradedMonoid_eq_of_cast Q (Nat.add_zero k)
+      change cast (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k))
+        (filtrationGradedMul Q k 0 x (filtrationGradedOne Q)) = x
+      rw [filtrationGradedMul_one]
+      simp
+    mul_assoc := fun x y z => by
+      rcases x with ⟨i, x⟩
+      rcases y with ⟨j, y⟩
+      rcases z with ⟨k, z⟩
+      apply filtrationGradedMonoid_eq_of_cast Q (Nat.add_assoc i j k)
+      exact filtrationGradedMul_assoc Q i j k x y z }
+
+noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
+    DirectSum.GRing (FiltrationGradedPiece Q) where
+  mul_zero := fun x => (filtrationGradedMul Q _ _ x).map_zero
+  zero_mul := fun x => by
+    change filtrationGradedMul Q _ _ 0 x = 0
+    rw [LinearMap.map_zero]
+    rfl
+  mul_add := fun x y z => (filtrationGradedMul Q _ _ x).map_add y z
+  add_mul := fun x y z => by
+    change filtrationGradedMul Q _ _ (x + y) z =
+      filtrationGradedMul Q _ _ x z + filtrationGradedMul Q _ _ y z
+    rw [LinearMap.map_add]
+    rfl
+  natCast := fun n => filtrationGradedAlgebraMap Q n
+  natCast_zero := by
+    rw [Nat.cast_zero]
+    exact map_zero (filtrationGradedAlgebraMap Q)
+  natCast_succ := fun n => by
+    change filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R) =
+      filtrationGradedAlgebraMap Q (n : R) + filtrationGradedOne Q
+    rw [Nat.cast_succ, map_add]
+    rfl
+  intCast := fun z => filtrationGradedAlgebraMap Q z
+  intCast_ofNat := fun n => by
+    change filtrationGradedAlgebraMap Q ((n : ℤ) : R) = filtrationGradedAlgebraMap Q (n : R)
+    norm_cast
+  intCast_negSucc_ofNat := fun n => by
+    change filtrationGradedAlgebraMap Q ((Int.negSucc n : ℤ) : R) =
+      -filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R)
+    rw [Int.cast_negSucc, map_neg]
+
+private theorem filtrationGradedAlgebraMap_mul (Q : QuadraticForm R M) (r : R) (k : ℕ)
+    (x : FiltrationGradedPiece Q k) :
+    cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
+      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x) = r • x := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ x =>
+      change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
+        (filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
+          (Submodule.Quotient.mk x)) = r • Submodule.Quotient.mk x
+      rw [filtrationGradedMul_apply_mk, ← Submodule.Quotient.mk_smul]
+      rw [filtrationGradedPiece_cast_mk Q (Nat.zero_add k) _ (by
+        simpa using (show (algebraMap R (CliffordAlgebra Q) r) * x ∈ filtration Q (0 + k) by
+          rw [← filtration_mul Q 0 k]
+          exact Submodule.mul_mem_mul
+            (algebraMap_mem_filtration Q r 0) x.property))]
+      apply (Submodule.Quotient.eq _).mpr
+      rw [Submodule.mem_comap]
+      change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) - r • x ∈
+        filtrationPrevious Q k
+      rw [Algebra.smul_def, sub_self]
+      exact Submodule.zero_mem (filtrationPrevious Q k)
+
+private theorem filtrationGradedAlgebraMap_mul_self (Q : QuadraticForm R M) (r s : R) :
+    filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
+      (filtrationGradedAlgebraMap Q s) = filtrationGradedAlgebraMap Q (r * s) := by
+  change filtrationGradedMul Q 0 0 (Submodule.Quotient.mk _)
+    (Submodule.Quotient.mk _) = Submodule.Quotient.mk _
+  rw [filtrationGradedMul_apply_mk]
+  apply (Submodule.Quotient.eq _).mpr
+  rw [Submodule.mem_comap]
+  change algebraMap R (CliffordAlgebra Q) r * algebraMap R (CliffordAlgebra Q) s -
+      algebraMap R (CliffordAlgebra Q) (r * s) ∈ filtrationPrevious Q 0
+  rw [← map_mul, sub_self]
+  exact Submodule.zero_mem (filtrationPrevious Q 0)
+
+private theorem filtrationGradedAlgebraMap_commutes (Q : QuadraticForm R M) (r : R) (k : ℕ)
+    (x : FiltrationGradedPiece Q k) :
+    cast (congrArg (FiltrationGradedPiece Q)
+      ((Nat.zero_add k).trans (Nat.add_zero k).symm))
+      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x) =
+      filtrationGradedMul Q k 0 x (filtrationGradedAlgebraMap Q r) := by
+  induction x using Submodule.Quotient.induction_on with
+  | _ x =>
+      change cast (congrArg (FiltrationGradedPiece Q)
+        ((Nat.zero_add k).trans (Nat.add_zero k).symm))
+        (filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
+          (Submodule.Quotient.mk x)) =
+        filtrationGradedMul Q k 0 (Submodule.Quotient.mk x) (Submodule.Quotient.mk _)
+      rw [filtrationGradedMul_apply_mk, filtrationGradedMul_apply_mk]
+      rw [filtrationGradedPiece_cast_mk' Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
+      apply (Submodule.Quotient.eq _).mpr
+      rw [Submodule.mem_comap, map_sub,
+        filtration_subtype_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)]
+      change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) -
+          x * algebraMap R (CliffordAlgebra Q) r ∈ filtrationPrevious Q (k + 0)
+      rw [Algebra.commutes, sub_self]
+      exact Submodule.zero_mem (filtrationPrevious Q (k + 0))
+
+noncomputable instance filtrationGradedGSemiring {Q : QuadraticForm R M} :
+    DirectSum.GSemiring (FiltrationGradedPiece Q) := by
+  exact @DirectSum.GRing.toGSemiring ℕ (FiltrationGradedPiece Q) _ _
+    (filtrationGradedGRing (Q := Q))
+
+noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
+    DirectSum.GAlgebra R (FiltrationGradedPiece Q) where
+  toFun := filtrationGradedAlgebraMap Q
+  map_one := by
+    change filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q
+    exact filtrationGradedAlgebraMap_one Q
+  map_mul r s := by
+    apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add 0).symm
+    change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add 0).symm)
+      (filtrationGradedAlgebraMap Q (r * s)) =
+      filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
+        (filtrationGradedAlgebraMap Q s)
+    rw [filtrationGradedAlgebraMap_mul_self]
+    simp
+  commutes r x := by
+    rcases x with ⟨k, x⟩
+    apply filtrationGradedMonoid_eq_of_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)
+    exact filtrationGradedAlgebraMap_commutes Q r k x
+  smul_def r x := by
+    rcases x with ⟨k, x⟩
+    apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k).symm
+    change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) (r • x) =
+      filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x
+    symm
+    simpa using congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
+      (filtrationGradedAlgebraMap_mul Q r k x)
+
+noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
+    Ring (filtrationAssociatedGraded Q) := by
+  letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
+  infer_instance
+
+/-- Multiplication of homogeneous elements in the associated graded Clifford algebra. -/
+@[simp]
+theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) (i j : ℕ)
+    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
+    (DirectSum.of (fun k => FiltrationGradedPiece Q k) i x : filtrationAssociatedGraded Q) *
+      DirectSum.of (fun k => FiltrationGradedPiece Q k) j y =
+        DirectSum.of (fun k => FiltrationGradedPiece Q k) (i + j)
+          (filtrationGradedMul Q i j x y) :=
+  DirectSum.of_mul_of x y
+
+/-- The scalar map of the associated graded Clifford algebra lands in degree zero. -/
+@[simp]
+theorem filtrationAssociatedGraded_algebraMap_apply (Q : QuadraticForm R M) (r : R) :
+    algebraMap R (filtrationAssociatedGraded Q) r =
+      DirectSum.of (fun k => FiltrationGradedPiece Q k) 0 (filtrationGradedAlgebraMap Q r) :=
+  DirectSum.algebraMap_apply R (FiltrationGradedPiece Q) r
 
 end CliffordAlgebra
 

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -15,6 +15,9 @@ public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 This file packages the homogeneous pieces of the Clifford degree filtration into a direct-sum
 associated-graded algebra. It is generic in the quadratic form and does not yet identify that
 algebra with the exterior algebra.
+
+It advances the Layer 0 associated-graded-algebra target in the
+[Spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings).
 -/
 
 public section
@@ -179,9 +182,10 @@ noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
     apply congrArg Submodule.Quotient.mk
     exact Subtype.ext (map_add (algebraMap R (CliffordAlgebra Q)) r s)
 
-@[simp] private theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
+/-- The degree-zero scalar map sends `1` to the homogeneous unit. -/
+@[simp] theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
     filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q :=
-  rfl
+  (rfl)
 
 private theorem filtrationGradedPiece_cast_mk (Q : QuadraticForm R M) {i j : ℕ}
     (h : i = j) (x : filtration Q i) (hx : (x : CliffordAlgebra Q) ∈ filtration Q j) :
@@ -197,12 +201,15 @@ private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
   cases h
   exact congrArg _ h2
 
-private theorem filtrationGradedOne_mul (Q : QuadraticForm R M) (k : ℕ)
+/-- The degree-zero homogeneous unit acts on the left. -/
+@[simp] theorem filtrationGradedOne_mul (Q : QuadraticForm R M) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
     filtrationGradedMul Q 0 k (filtrationGradedOne Q) x =
       cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) x := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
+      -- Quotient induction supplies representatives, the only stable form to which the
+      -- public representative multiplication lemma applies.
       change filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
         (Submodule.Quotient.mk x) = _
       rw [filtrationGradedMul_apply_mk]
@@ -210,17 +217,21 @@ private theorem filtrationGradedOne_mul (Q : QuadraticForm R M) (k : ℕ)
         rw [Nat.zero_add]
         exact x.property)]
       apply (Submodule.Quotient.eq _).mpr
+      -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (1 : CliffordAlgebra Q) * (x : CliffordAlgebra Q) - x ∈
         filtrationPrevious Q (0 + k)
       rw [one_mul, sub_self]
       exact Submodule.zero_mem (filtrationPrevious Q (0 + k))
 
-private theorem filtrationGradedMul_one (Q : QuadraticForm R M) (k : ℕ)
+/-- The degree-zero homogeneous unit acts on the right. -/
+@[simp] theorem filtrationGradedMul_one (Q : QuadraticForm R M) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
     filtrationGradedMul Q k 0 x (filtrationGradedOne Q) =
       cast (congrArg (FiltrationGradedPiece Q) (Nat.add_zero k).symm) x := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
+      -- Quotient induction supplies representatives, the only stable form to which the
+      -- public representative multiplication lemma applies.
       change filtrationGradedMul Q k 0 (Submodule.Quotient.mk x)
         (Submodule.Quotient.mk _) = _
       rw [filtrationGradedMul_apply_mk]
@@ -228,6 +239,7 @@ private theorem filtrationGradedMul_one (Q : QuadraticForm R M) (k : ℕ)
         rw [Nat.add_zero]
         exact x.property)]
       apply (Submodule.Quotient.eq _).mpr
+      -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (x : CliffordAlgebra Q) * 1 - x ∈ filtrationPrevious Q (k + 0)
       rw [mul_one, sub_self]
       exact Submodule.zero_mem (filtrationPrevious Q (k + 0))
@@ -295,16 +307,20 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
       -filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R)
     rw [Int.cast_negSucc, map_neg]
 
-private theorem filtrationGradedAlgebraMap_mul (Q : QuadraticForm R M) (r : R) (k : ℕ)
+/-- Left multiplication by a degree-zero scalar class is scalar multiplication. -/
+@[simp] theorem filtrationGradedAlgebraMap_mul (Q : QuadraticForm R M) (r : R) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
     cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
       (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x) = r • x := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
+      -- Quotient induction supplies representatives, the only stable form to which the
+      -- public representative multiplication lemma applies.
       change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
         (filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
           (Submodule.Quotient.mk x)) = r • Submodule.Quotient.mk x
       rw [filtrationGradedMul_apply_mk, ← Submodule.Quotient.mk_smul]
+      -- The cast needs an ambient membership witness; `filtration_mul` supplies that witness.
       rw [filtrationGradedPiece_cast_mk Q (Nat.zero_add k) _ (by
         simpa using (show (algebraMap R (CliffordAlgebra Q) r) * x ∈ filtration Q (0 + k) by
           rw [← filtration_mul Q 0 k]
@@ -382,8 +398,9 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) (r • x) =
       filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x
     symm
-    simpa using congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
-      (filtrationGradedAlgebraMap_mul Q r k x)
+    simpa only [cast_cast, cast_eq] using
+      congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
+        (filtrationGradedAlgebraMap_mul Q r k x)
 
 noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
     Ring (filtrationAssociatedGraded Q) := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -484,14 +484,6 @@ noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
   letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
   infer_instance
 
-/-- Multiplication of homogeneous direct-sum terms is the named filtration product. -/
-@[simp] theorem filtrationAssociatedGraded_of_mul_of (Q : QuadraticForm R M) {i j : ℕ}
-    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
-    (DirectSum.of (FiltrationGradedPiece Q) i x : filtrationAssociatedGraded Q) *
-      DirectSum.of (FiltrationGradedPiece Q) j y =
-      DirectSum.of (FiltrationGradedPiece Q) (i + j) (filtrationGradedMul Q i j x y) := by
-  simp only [DirectSum.of_mul_of, filtrationGradedGMul_def]
-
 end CliffordAlgebra
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -175,7 +175,7 @@ noncomputable def filtrationGradedOne (Q : QuadraticForm R M) :
   Submodule.Quotient.mk ⟨1, one_mem_filtration Q 0⟩
 
 /-- The degree-zero class of a scalar in the associated graded Clifford filtration. -/
-noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
+noncomputable def filtrationGradedAlgebraMap₀ (Q : QuadraticForm R M) :
     R →+ FiltrationGradedPiece Q 0 where
   toFun r := Submodule.Quotient.mk
     ⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩
@@ -186,8 +186,8 @@ noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
     exact Subtype.ext (map_add (algebraMap R (CliffordAlgebra Q)) r s)
 
 /-- The degree-zero scalar map sends `1` to the homogeneous unit. -/
-@[simp] theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
-    filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q := by
+@[simp] theorem filtrationGradedAlgebraMap₀_one (Q : QuadraticForm R M) :
+    filtrationGradedAlgebraMap₀ Q 1 = filtrationGradedOne Q := by
   -- Expand the two degree-zero representatives to compare their quotient classes;
   -- `map_one` is stated only in the ambient Clifford algebra.
   change Submodule.Quotient.mk
@@ -299,32 +299,32 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
       filtrationGradedMul Q _ _ x z + filtrationGradedMul Q _ _ y z
     rw [LinearMap.map_add]
     rfl
-  natCast := fun n => filtrationGradedAlgebraMap Q n
+  natCast := fun n => filtrationGradedAlgebraMap₀ Q n
   natCast_zero := by
     rw [Nat.cast_zero]
-    exact map_zero (filtrationGradedAlgebraMap Q)
+    exact map_zero (filtrationGradedAlgebraMap₀ Q)
   natCast_succ := fun n => by
     -- The cast field is represented by the degree-zero scalar class chosen above.
-    change filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R) =
-      filtrationGradedAlgebraMap Q (n : R) + filtrationGradedOne Q
+    change filtrationGradedAlgebraMap₀ Q ((n + 1 : ℕ) : R) =
+      filtrationGradedAlgebraMap₀ Q (n : R) + filtrationGradedOne Q
     rw [Nat.cast_succ, map_add]
     rfl
-  intCast := fun z => filtrationGradedAlgebraMap Q z
+  intCast := fun z => filtrationGradedAlgebraMap₀ Q z
   intCast_ofNat := fun n => by
     -- Integer casts use the same chosen degree-zero scalar representative.
-    change filtrationGradedAlgebraMap Q ((n : ℤ) : R) = filtrationGradedAlgebraMap Q (n : R)
+    change filtrationGradedAlgebraMap₀ Q ((n : ℤ) : R) = filtrationGradedAlgebraMap₀ Q (n : R)
     norm_cast
   intCast_negSucc_ofNat := fun n => by
     -- Integer casts use the same chosen degree-zero scalar representative.
-    change filtrationGradedAlgebraMap Q ((Int.negSucc n : ℤ) : R) =
-      -filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R)
+    change filtrationGradedAlgebraMap₀ Q ((Int.negSucc n : ℤ) : R) =
+      -filtrationGradedAlgebraMap₀ Q ((n + 1 : ℕ) : R)
     rw [Int.cast_negSucc, map_neg]
 
 /-- Left multiplication by a degree-zero scalar class is scalar multiplication. -/
-@[simp] theorem filtrationGradedAlgebraMap_mul (Q : QuadraticForm R M) (r : R) (k : ℕ)
+@[simp] theorem filtrationGradedAlgebraMap₀_mul (Q : QuadraticForm R M) (r : R) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
     cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k))
-      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x) = r • x := by
+      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap₀ Q r) x) = r • x := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
       -- Quotient induction supplies representatives, the only stable form to which the
@@ -342,9 +342,10 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
       rw [Algebra.smul_def, sub_self]
       exact Submodule.zero_mem (filtrationPrevious Q k)
 
-private theorem filtrationGradedAlgebraMap_mul_self (Q : QuadraticForm R M) (r s : R) :
-    filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
-      (filtrationGradedAlgebraMap Q s) = filtrationGradedAlgebraMap Q (r * s) := by
+/-- Degree-zero scalar classes multiply by multiplying their scalars. -/
+@[simp 1100] theorem filtrationGradedAlgebraMap₀_mul_algebraMap₀ (Q : QuadraticForm R M) (r s : R) :
+    filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap₀ Q r)
+      (filtrationGradedAlgebraMap₀ Q s) = filtrationGradedAlgebraMap₀ Q (r * s) := by
   -- Both scalar classes are quotient representatives, so expose them for the
   -- representative product.
   change filtrationGradedMul Q 0 0 (Submodule.Quotient.mk _)
@@ -358,12 +359,13 @@ private theorem filtrationGradedAlgebraMap_mul_self (Q : QuadraticForm R M) (r s
   rw [← map_mul, sub_self]
   exact Submodule.zero_mem (filtrationPrevious Q 0)
 
-private theorem filtrationGradedAlgebraMap_commutes (Q : QuadraticForm R M) (r : R) (k : ℕ)
+/-- Degree-zero scalar classes commute with homogeneous products after reindexing degrees. -/
+theorem filtrationGradedAlgebraMap₀_commutes (Q : QuadraticForm R M) (r : R) (k : ℕ)
     (x : FiltrationGradedPiece Q k) :
     cast (congrArg (FiltrationGradedPiece Q)
       ((Nat.zero_add k).trans (Nat.add_zero k).symm))
-      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x) =
-      filtrationGradedMul Q k 0 x (filtrationGradedAlgebraMap Q r) := by
+      (filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap₀ Q r) x) =
+      filtrationGradedMul Q k 0 x (filtrationGradedAlgebraMap₀ Q r) := by
   induction x using Submodule.Quotient.induction_on with
   | _ x =>
       change cast (congrArg (FiltrationGradedPiece Q)
@@ -381,6 +383,13 @@ private theorem filtrationGradedAlgebraMap_commutes (Q : QuadraticForm R M) (r :
       rw [Algebra.commutes, sub_self]
       exact Submodule.zero_mem (filtrationPrevious Q (k + 0))
 
+/-- Right multiplication by a degree-zero scalar class is scalar multiplication. -/
+@[simp] theorem filtrationGradedMul_algebraMap₀ (Q : QuadraticForm R M) (r : R) (k : ℕ)
+    (x : FiltrationGradedPiece Q k) :
+    filtrationGradedMul Q k 0 x (filtrationGradedAlgebraMap₀ Q r) = r • x := by
+  rw [← filtrationGradedAlgebraMap₀_commutes Q r k x]
+  simpa only [cast_cast, cast_eq] using filtrationGradedAlgebraMap₀_mul Q r k x
+
 noncomputable instance filtrationGradedGSemiring {Q : QuadraticForm R M} :
     DirectSum.GSemiring (FiltrationGradedPiece Q) := by
   exact @DirectSum.GRing.toGSemiring ℕ (FiltrationGradedPiece Q) _ _
@@ -388,34 +397,34 @@ noncomputable instance filtrationGradedGSemiring {Q : QuadraticForm R M} :
 
 noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     DirectSum.GAlgebra R (FiltrationGradedPiece Q) where
-  toFun := filtrationGradedAlgebraMap Q
+  toFun := filtrationGradedAlgebraMap₀ Q
   map_one := by
     -- `DirectSum.GAlgebra.map_one` is phrased through the degree-zero `GOne` field.
-    change filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q
-    exact filtrationGradedAlgebraMap_one Q
+    change filtrationGradedAlgebraMap₀ Q 1 = filtrationGradedOne Q
+    exact filtrationGradedAlgebraMap₀_one Q
   map_mul r s := by
     apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add 0).symm
     -- The scalar product is a degree-zero homogeneous product after this reindexing.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add 0).symm)
-      (filtrationGradedAlgebraMap Q (r * s)) =
-      filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
-        (filtrationGradedAlgebraMap Q s)
-    rw [filtrationGradedAlgebraMap_mul_self]
+      (filtrationGradedAlgebraMap₀ Q (r * s)) =
+      filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap₀ Q r)
+        (filtrationGradedAlgebraMap₀ Q s)
+    rw [filtrationGradedAlgebraMap₀_mul_algebraMap₀]
     simp
   commutes r x := by
     rcases x with ⟨k, x⟩
     apply filtrationGradedMonoid_eq_of_cast Q ((Nat.zero_add k).trans (Nat.add_zero k).symm)
-    exact filtrationGradedAlgebraMap_commutes Q r k x
+    exact filtrationGradedAlgebraMap₀_commutes Q r k x
   smul_def r x := by
     rcases x with ⟨k, x⟩
     apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k).symm
     -- The sigma-level scalar law reduces to the degree-`k` homogeneous scalar equation.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) (r • x) =
-      filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x
+      filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap₀ Q r) x
     symm
     simpa only [cast_cast, cast_eq] using
       congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
-        (filtrationGradedAlgebraMap_mul Q r k x)
+        (filtrationGradedAlgebraMap₀_mul Q r k x)
 
 noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
     Ring (filtrationAssociatedGraded Q) := by

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -10,7 +10,7 @@ public import Mathlib.Algebra.DirectSum.Algebra
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Filtration
 
 /-!
-# Homogeneous multiplication for a Clifford filtration
+# Associated-graded algebra of a Clifford filtration
 
 This file packages the homogeneous pieces of the Clifford degree filtration into a direct-sum
 associated-graded algebra. It is generic in the quadratic form and does not yet identify that
@@ -174,6 +174,20 @@ noncomputable def filtrationGradedOne (Q : QuadraticForm R M) :
     FiltrationGradedPiece Q 0 :=
   Submodule.Quotient.mk ⟨1, one_mem_filtration Q 0⟩
 
+/-- The degree-zero unit is the quotient class of the Clifford unit. -/
+theorem filtrationGradedOne_def (Q : QuadraticForm R M) :
+    filtrationGradedOne Q =
+      Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0) := by
+  change Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0) =
+    Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0)
+  rfl
+
+/-- The quotient class of the Clifford unit is the degree-zero homogeneous unit. -/
+@[simp] theorem filtrationGradedOne_mk (Q : QuadraticForm R M) :
+    Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0) =
+      filtrationGradedOne Q :=
+  (filtrationGradedOne_def Q).symm
+
 /-- The degree-zero class of a scalar in the associated graded Clifford filtration. -/
 noncomputable def filtrationGradedAlgebraMap₀ (Q : QuadraticForm R M) :
     R →+ FiltrationGradedPiece Q 0 where
@@ -184,6 +198,27 @@ noncomputable def filtrationGradedAlgebraMap₀ (Q : QuadraticForm R M) :
     rw [← Submodule.Quotient.mk_add]
     apply congrArg Submodule.Quotient.mk
     exact Subtype.ext (map_add (algebraMap R (CliffordAlgebra Q)) r s)
+
+/-- The degree-zero scalar map is the quotient class of its ambient scalar. -/
+theorem filtrationGradedAlgebraMap₀_apply (Q : QuadraticForm R M) (r : R) :
+    filtrationGradedAlgebraMap₀ Q r =
+      Submodule.Quotient.mk
+        (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+          filtration Q 0) := by
+  change Submodule.Quotient.mk
+      (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+        filtration Q 0) =
+    Submodule.Quotient.mk
+      (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+        filtration Q 0)
+  rfl
+
+/-- The quotient class of an ambient scalar is its degree-zero homogeneous class. -/
+@[simp] theorem filtrationGradedAlgebraMap₀_mk (Q : QuadraticForm R M) (r : R) :
+    Submodule.Quotient.mk
+      (⟨algebraMap R (CliffordAlgebra Q) r, algebraMap_mem_filtration Q r 0⟩ :
+        filtration Q 0) = filtrationGradedAlgebraMap₀ Q r :=
+  (filtrationGradedAlgebraMap₀_apply Q r).symm
 
 /-- The degree-zero scalar map sends `1` to the homogeneous unit. -/
 @[simp] theorem filtrationGradedAlgebraMap₀_one (Q : QuadraticForm R M) :
@@ -249,7 +284,7 @@ noncomputable instance filtrationGradedGOne {Q : QuadraticForm R M} :
   one := filtrationGradedOne Q
 
 /-- The `GOne` field is the named degree-zero filtration class. -/
-@[simp] theorem filtrationGradedGOne_one (Q : QuadraticForm R M) :
+@[simp] theorem filtrationGradedGOne_def (Q : QuadraticForm R M) :
     (GradedMonoid.GOne.one : FiltrationGradedPiece Q 0) = filtrationGradedOne Q := rfl
 
 /-- Homogeneous filtration multiplication supplies the `GMul` structure on filtration pieces. -/
@@ -258,7 +293,7 @@ noncomputable instance filtrationGradedGMul {Q : QuadraticForm R M} :
   mul {i j} := fun x y => filtrationGradedMul Q i j x y
 
 /-- The `GMul` field is the named homogeneous filtration product. -/
-@[simp] theorem filtrationGradedGMul_mul (Q : QuadraticForm R M) {i j : ℕ}
+@[simp] theorem filtrationGradedGMul_def (Q : QuadraticForm R M) {i j : ℕ}
     (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
     GradedMonoid.GMul.mul (A := FiltrationGradedPiece Q) x y = filtrationGradedMul Q i j x y := rfl
 
@@ -446,7 +481,7 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
         (filtrationGradedAlgebraMap₀_mul Q r k x)
 
 /-- The `GAlgebra` field is the named degree-zero scalar map. -/
-@[simp] theorem filtrationGradedGAlgebra_toFun (Q : QuadraticForm R M) (r : R) :
+@[simp] theorem filtrationGradedGAlgebra_toFun_def (Q : QuadraticForm R M) (r : R) :
     DirectSum.GAlgebra.toFun (A := FiltrationGradedPiece Q)
       (self := filtrationGradedGAlgebra (Q := Q)) r = filtrationGradedAlgebraMap₀ Q r := rfl
 
@@ -458,12 +493,12 @@ noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
   infer_instance
 
 /-- Multiplication of homogeneous direct-sum terms is the named filtration product. -/
-@[simp] theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) {i j : ℕ}
+@[simp] theorem filtrationAssociatedGraded_of_mul_of (Q : QuadraticForm R M) {i j : ℕ}
     (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
     (DirectSum.of (FiltrationGradedPiece Q) i x : filtrationAssociatedGraded Q) *
       DirectSum.of (FiltrationGradedPiece Q) j y =
       DirectSum.of (FiltrationGradedPiece Q) (i + j) (filtrationGradedMul Q i j x y) := by
-  simp only [DirectSum.of_mul_of, filtrationGradedGMul_mul]
+  simp only [DirectSum.of_mul_of, filtrationGradedGMul_def]
 
 /-- The associated-graded scalar map is the degree-zero named filtration map. -/
 @[simp] theorem filtrationAssociatedGraded_algebraMap (Q : QuadraticForm R M) (r : R) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -390,23 +390,6 @@ noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
   letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
   infer_instance
 
-/-- Multiplication of homogeneous elements in the associated graded Clifford algebra. -/
-@[simp]
-theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) (i j : ℕ)
-    (x : FiltrationGradedPiece Q i) (y : FiltrationGradedPiece Q j) :
-    (DirectSum.of (fun k => FiltrationGradedPiece Q k) i x : filtrationAssociatedGraded Q) *
-      DirectSum.of (fun k => FiltrationGradedPiece Q k) j y =
-        DirectSum.of (fun k => FiltrationGradedPiece Q k) (i + j)
-          (filtrationGradedMul Q i j x y) :=
-  DirectSum.of_mul_of x y
-
-/-- The scalar map of the associated graded Clifford algebra lands in degree zero. -/
-@[simp]
-theorem filtrationAssociatedGraded_algebraMap_apply (Q : QuadraticForm R M) (r : R) :
-    algebraMap R (filtrationAssociatedGraded Q) r =
-      DirectSum.of (fun k => FiltrationGradedPiece Q k) 0 (filtrationGradedAlgebraMap Q r) :=
-  DirectSum.algebraMap_apply R (FiltrationGradedPiece Q) r
-
 end CliffordAlgebra
 
 end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -184,15 +184,15 @@ noncomputable def filtrationGradedAlgebraMap (Q : QuadraticForm R M) :
 
 /-- The degree-zero scalar map sends `1` to the homogeneous unit. -/
 @[simp] theorem filtrationGradedAlgebraMap_one (Q : QuadraticForm R M) :
-    filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q :=
-  (rfl)
-
-private theorem filtrationGradedPiece_cast_mk (Q : QuadraticForm R M) {i j : ℕ}
-    (h : i = j) (x : filtration Q i) (hx : (x : CliffordAlgebra Q) ∈ filtration Q j) :
-    cast (congrArg (FiltrationGradedPiece Q) h) (Submodule.Quotient.mk x) =
-      Submodule.Quotient.mk ⟨x, hx⟩ := by
-  subst j
-  rfl
+    filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q := by
+  change Submodule.Quotient.mk
+      (⟨algebraMap R (CliffordAlgebra Q) 1, algebraMap_mem_filtration Q 1 0⟩ : filtration Q 0) =
+    Submodule.Quotient.mk (⟨1, one_mem_filtration Q 0⟩ : filtration Q 0)
+  apply (Submodule.Quotient.eq _).mpr
+  rw [Submodule.mem_comap]
+  change algebraMap R (CliffordAlgebra Q) 1 - 1 ∈ filtrationPrevious Q 0
+  rw [map_one, sub_self]
+  exact Submodule.zero_mem _
 
 private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
     {a b : GradedMonoid (FiltrationGradedPiece Q)} (h : a.fst = b.fst)
@@ -213,10 +213,10 @@ private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
       change filtrationGradedMul Q 0 k (Submodule.Quotient.mk _)
         (Submodule.Quotient.mk x) = _
       rw [filtrationGradedMul_apply_mk]
-      rw [filtrationGradedPiece_cast_mk Q (Nat.zero_add k).symm x (by
-        rw [Nat.zero_add]
-        exact x.property)]
+      rw [filtrationGradedPiece_cast_mk' Q (Nat.zero_add k).symm]
       apply (Submodule.Quotient.eq _).mpr
+      rw [Submodule.mem_comap, map_sub,
+        filtration_subtype_cast Q (Nat.zero_add k).symm]
       -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (1 : CliffordAlgebra Q) * (x : CliffordAlgebra Q) - x ∈
         filtrationPrevious Q (0 + k)
@@ -235,10 +235,10 @@ private theorem filtrationGradedMonoid_eq_of_cast (Q : QuadraticForm R M)
       change filtrationGradedMul Q k 0 (Submodule.Quotient.mk x)
         (Submodule.Quotient.mk _) = _
       rw [filtrationGradedMul_apply_mk]
-      rw [filtrationGradedPiece_cast_mk Q (Nat.add_zero k).symm x (by
-        rw [Nat.add_zero]
-        exact x.property)]
+      rw [filtrationGradedPiece_cast_mk' Q (Nat.add_zero k).symm]
       apply (Submodule.Quotient.eq _).mpr
+      rw [Submodule.mem_comap, map_sub,
+        filtration_subtype_cast Q (Nat.add_zero k).symm]
       -- Quotient equality is now ambient membership, the form of the filtration product API.
       change (x : CliffordAlgebra Q) * 1 - x ∈ filtrationPrevious Q (k + 0)
       rw [mul_one, sub_self]
@@ -280,11 +280,13 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
     DirectSum.GRing (FiltrationGradedPiece Q) where
   mul_zero := fun x => (filtrationGradedMul Q _ _ x).map_zero
   zero_mul := fun x => by
+    -- `DirectSum.GRing` states this through `GMul`; expose its declared homogeneous product.
     change filtrationGradedMul Q _ _ 0 x = 0
     rw [LinearMap.map_zero]
     rfl
   mul_add := fun x y z => (filtrationGradedMul Q _ _ x).map_add y z
   add_mul := fun x y z => by
+    -- `DirectSum.GRing` states this through `GMul`; expose its declared homogeneous product.
     change filtrationGradedMul Q _ _ (x + y) z =
       filtrationGradedMul Q _ _ x z + filtrationGradedMul Q _ _ y z
     rw [LinearMap.map_add]
@@ -294,15 +296,18 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
     rw [Nat.cast_zero]
     exact map_zero (filtrationGradedAlgebraMap Q)
   natCast_succ := fun n => by
+    -- The cast field is represented by the degree-zero scalar class chosen above.
     change filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R) =
       filtrationGradedAlgebraMap Q (n : R) + filtrationGradedOne Q
     rw [Nat.cast_succ, map_add]
     rfl
   intCast := fun z => filtrationGradedAlgebraMap Q z
   intCast_ofNat := fun n => by
+    -- Integer casts use the same chosen degree-zero scalar representative.
     change filtrationGradedAlgebraMap Q ((n : ℤ) : R) = filtrationGradedAlgebraMap Q (n : R)
     norm_cast
   intCast_negSucc_ofNat := fun n => by
+    -- Integer casts use the same chosen degree-zero scalar representative.
     change filtrationGradedAlgebraMap Q ((Int.negSucc n : ℤ) : R) =
       -filtrationGradedAlgebraMap Q ((n + 1 : ℕ) : R)
     rw [Int.cast_negSucc, map_neg]
@@ -321,13 +326,9 @@ noncomputable instance filtrationGradedGRing {Q : QuadraticForm R M} :
           (Submodule.Quotient.mk x)) = r • Submodule.Quotient.mk x
       rw [filtrationGradedMul_apply_mk, ← Submodule.Quotient.mk_smul]
       -- The cast needs an ambient membership witness; `filtration_mul` supplies that witness.
-      rw [filtrationGradedPiece_cast_mk Q (Nat.zero_add k) _ (by
-        simpa using (show (algebraMap R (CliffordAlgebra Q) r) * x ∈ filtration Q (0 + k) by
-          rw [← filtration_mul Q 0 k]
-          exact Submodule.mul_mem_mul
-            (algebraMap_mem_filtration Q r 0) x.property))]
+      rw [filtrationGradedPiece_cast_mk' Q (Nat.zero_add k)]
       apply (Submodule.Quotient.eq _).mpr
-      rw [Submodule.mem_comap]
+      rw [Submodule.mem_comap, map_sub, filtration_subtype_cast Q (Nat.zero_add k)]
       change algebraMap R (CliffordAlgebra Q) r * (x : CliffordAlgebra Q) - r • x ∈
         filtrationPrevious Q k
       rw [Algebra.smul_def, sub_self]
@@ -378,10 +379,12 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     DirectSum.GAlgebra R (FiltrationGradedPiece Q) where
   toFun := filtrationGradedAlgebraMap Q
   map_one := by
+    -- `DirectSum.GAlgebra.map_one` is phrased through the degree-zero `GOne` field.
     change filtrationGradedAlgebraMap Q 1 = filtrationGradedOne Q
     exact filtrationGradedAlgebraMap_one Q
   map_mul r s := by
     apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add 0).symm
+    -- The scalar product is a degree-zero homogeneous product after this reindexing.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add 0).symm)
       (filtrationGradedAlgebraMap Q (r * s)) =
       filtrationGradedMul Q 0 0 (filtrationGradedAlgebraMap Q r)
@@ -395,6 +398,7 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
   smul_def r x := by
     rcases x with ⟨k, x⟩
     apply filtrationGradedMonoid_eq_of_cast Q (Nat.zero_add k).symm
+    -- The sigma-level scalar law reduces to the degree-`k` homogeneous scalar equation.
     change cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm) (r • x) =
       filtrationGradedMul Q 0 k (filtrationGradedAlgebraMap Q r) x
     symm

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/AssociatedGraded.lean
@@ -385,6 +385,11 @@ noncomputable instance filtrationGradedGAlgebra {Q : QuadraticForm R M} :
     simpa using congrArg (cast (congrArg (FiltrationGradedPiece Q) (Nat.zero_add k).symm))
       (filtrationGradedAlgebraMap_mul Q r k x)
 
+noncomputable instance filtrationAssociatedGradedRing {Q : QuadraticForm R M} :
+    Ring (filtrationAssociatedGraded Q) := by
+  letI : ∀ k, AddCommGroup (FiltrationGradedPiece Q k) := fun _ => inferInstance
+  infer_instance
+
 /-- Multiplication of homogeneous elements in the associated graded Clifford algebra. -/
 @[simp]
 theorem filtrationAssociatedGraded_of_mul (Q : QuadraticForm R M) (i j : ℕ)


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Summary

Packages homogeneous Clifford-filtration quotients into their direct-sum associated-graded algebra.

- Defines `filtrationAssociatedGraded` and its generic direct-sum ring and algebra structures.
- Exposes homogeneous multiplication and the degree-zero scalar-map equations.
- Reuses the merged quotient multiplication and Mathlib direct-sum interfaces.

## Roadmap target

Advances the Layer 0 associated-graded algebra milestone:

https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md#layer-0-the-clifford-algebra-its-universal-property-and-the-two-gradings

It leaves the exterior-algebra comparison and multiplicative PBW equivalence for later work.

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"SpinRepresentations/README.md#associated-graded-algebra"}-->

## Verification

`lake build TauCeti`, `lake build --iofail`, audits, `scripts/lint-env.sh`, whitespace, a bare-`simp` probe, proof golf, and independent review pass at `b80d3013946677800ee8c14d9d19b6aaf3e903e6`.

## Scope

- **Consumes:** homogeneous quotient multiplication and Mathlib direct-sum ring and algebra interfaces.
- **Provides:** the direct-sum Clifford associated-graded ring and algebra with homogeneous multiplication and scalar equations.
- **Fits:** assembles the Layer 0 algebra consumed by exterior and multiplicative PBW comparisons.
- **Boundary:** those comparison equivalences require additional compatibility proofs in later slices.

<sub>🤖 GPT-5.6 Terra max · rubrics @ [222eed0](https://github.com/TauCetiProject/TauCetiReview/commit/222eed046013fbee91239aea4a5186b12f086e65) · local review fixed: reuse (1), proof-quality (1)</sub>