### PR TITLE
feat(ModularForms): the interior vanishing-order dictionary

### DIFF
--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
+
+/-!
+# Analyticity through `ofComplex`
+
+A function holomorphic on the upper half-plane, extended to `ℂ` by `ofComplex`, is
+analytic at every point of the open upper half-plane.
+
+## Main declarations
+
+* `TauCeti.UpperHalfPlane.analyticAt_comp_ofComplex`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development this file ports onto the current Mathlib pin.
+-/
+
+public section
+
+open UpperHalfPlane
+
+open scoped Manifold
+
+namespace TauCeti.UpperHalfPlane
+
+/-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
+every point of the open upper half-plane. -/
+lemma analyticAt_comp_ofComplex {f : ℍ → ℂ} (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
+    AnalyticAt ℂ (f ∘ ofComplex) w :=
+  (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
+    (isOpen_upperHalfPlaneSet.mem_nhds hw)
+
+end TauCeti.UpperHalfPlane
+
+end

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -4,19 +4,17 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 
 /-!
-# Periodicity and analyticity through `ofComplex`
+# Periodicity through `ofComplex`
 
 A function on the upper half-plane, extended to `ℂ` by `ofComplex`, is periodic with a real
-period exactly when the original function is invariant under the corresponding translation,
-and is analytic on the open upper half-plane when the original function is holomorphic.
+period exactly when the original function is invariant under the corresponding translation.
 
 ## Main declarations
 
 * `TauCeti.UpperHalfPlane.periodic_comp_ofComplex_iff`.
-* `TauCeti.UpperHalfPlane.analyticAt_comp_ofComplex`.
 
 ## References
 
@@ -29,14 +27,6 @@ public section
 open UpperHalfPlane
 
 namespace TauCeti.UpperHalfPlane
-
-open scoped Manifold in
-/-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
-every point of the open upper half-plane. -/
-lemma analyticAt_comp_ofComplex {f : ℍ → ℂ} (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
-    AnalyticAt ℂ (f ∘ ofComplex) w :=
-  (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
-    (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
 /-- A function `ℍ → α`, extended to `ℂ` via `ofComplex`, is periodic with real period `c` iff
 the original function is invariant under translation by `c`. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 
 /-!
 # Periodicity and analyticity through `ofComplex`

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Topology.lean
@@ -4,17 +4,20 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 
 /-!
-# Periodicity through `ofComplex`
+# Periodicity and analyticity through `ofComplex`
 
 A function on the upper half-plane, extended to `ℂ` by `ofComplex`, is periodic with a real
-period exactly when the original function is invariant under the corresponding translation.
+period exactly when the original function is invariant under the corresponding translation,
+and is analytic on the open upper half-plane when the original function is holomorphic.
 
 ## Main declarations
 
 * `TauCeti.UpperHalfPlane.periodic_comp_ofComplex_iff`.
+* `TauCeti.UpperHalfPlane.analyticAt_comp_ofComplex`.
 
 ## References
 
@@ -27,6 +30,14 @@ public section
 open UpperHalfPlane
 
 namespace TauCeti.UpperHalfPlane
+
+open scoped Manifold in
+/-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
+every point of the open upper half-plane. -/
+lemma analyticAt_comp_ofComplex {f : ℍ → ℂ} (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
+    AnalyticAt ℂ (f ∘ ofComplex) w :=
+  (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
+    (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
 /-- A function `ℍ → α`, extended to `ℂ` via `ofComplex`, is periodic with real period `c` iff
 the original function is invariant under translation by `c`. -/

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -47,8 +47,8 @@ def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
   (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
 
 -- The definition is sealed by the module system, so this restatement is the supported
--- cross-module rewrite for it.
-@[simp]
+-- cross-module rewrite for it. Not a `simp` lemma: unfolding the definition is not a
+-- normal form, and `simpNF` rejects it against the dictionary lemmas below.
 lemma orderOfVanishingAt_def (f : ℍ → ℂ) (z : ℍ) :
     orderOfVanishingAt f z = (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀ := by
   unfold orderOfVanishingAt
@@ -105,7 +105,8 @@ lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
 /-- The vanishing order of a slash-invariant form is constant along the group action. -/
-@[simp]
+-- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects
+-- the annotation (`simp` could never instantiate it from the left-hand side).
 lemma orderOfVanishingAt_smul [Γ.HasDetOne] [SlashInvariantFormClass F Γ k] (f : F) {γ}
     (hγ : γ ∈ Γ) (z : ℍ) : orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
   have hdet : 0 < γ.val.det := by

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -4,9 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 public import Mathlib.Analysis.Meromorphic.NormalForm
-public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import Mathlib.NumberTheory.ModularForms.Basic
 
 /-!
 # The vanishing order of a modular form
@@ -132,21 +131,22 @@ private lemma untop₀_sum {ι : Type*} {s : Finset ι} {g : ι → WithTop ℤ}
 lemma orderOfVanishingAt_prod {ι : Type*} {s : Finset ι} {F : ι → ℍ → ℂ}
     (hF : ∀ i ∈ s, MDiff (F i)) (hFne : ∀ i ∈ s, F i ≠ 0) (z : ℍ) :
     orderOfVanishingAt (∏ i ∈ s, F i) z = ∑ i ∈ s, orderOfVanishingAt (F i) z := by
-  have hcomp : (∏ i ∈ s, F i) ∘ ofComplex = ∏ i ∈ s, (F i ∘ ofComplex) := by
-    ext w
-    simp [Finset.prod_apply]
   simp only [orderOfVanishingAt_def]
-  rw [hcomp, meromorphicOrderAt_prod
-    (fun i hi ↦ (analyticAt_comp_ofComplex (hF i hi) z.im_pos).meromorphicAt)]
+  rw [show (∏ i ∈ s, F i) ∘ ofComplex = fun w ↦ ∏ i ∈ s, (F i ∘ ofComplex) w from
+      funext fun w ↦ Finset.prod_apply .. ,
+    meromorphicOrderAt_fun_prod
+      (fun i hi ↦ (analyticAt_comp_ofComplex (hF i hi) z.im_pos).meromorphicAt)]
   exact untop₀_sum fun i hi ↦
     meromorphicOrderAt_comp_ofComplex_ne_top (hF i hi) (hFne i hi) z
 
-/-- Vanishing orders scale under powers of a nonzero holomorphic function. -/
-lemma orderOfVanishingAt_pow (hf : MDiff f) (hfne : f ≠ 0) (n : ℕ) (z : ℍ) :
+/-- Vanishing orders scale under powers of a holomorphic function. -/
+lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
     orderOfVanishingAt (f ^ n) z = n * orderOfVanishingAt f z := by
-  have hpow : f ^ n = ∏ _i ∈ Finset.range n, f := by simp
-  rw [hpow, orderOfVanishingAt_prod (fun _ _ ↦ hf) (fun _ _ ↦ hfne),
-    Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+  have hcomp : (f ^ n) ∘ ofComplex = (f ∘ ofComplex) ^ n := rfl
+  rw [orderOfVanishingAt_def, orderOfVanishingAt_def, hcomp,
+    meromorphicOrderAt_pow (analyticAt_comp_ofComplex hf z.im_pos).meromorphicAt,
+    WithTop.untop₀_mul]
+  simp
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -23,7 +23,8 @@ irregular cusps in odd weight) belongs to the general-level layer and is not def
 * `TauCeti.orderOfVanishingAt`.
 * `TauCeti.orderOfVanishingAt_eq_zero_iff`: for a nonzero holomorphic function, the order
   at `z` vanishes exactly when the function does not vanish at `z`.
-* `TauCeti.orderOfVanishingAt_mul`: orders add under multiplication.
+* `TauCeti.orderOfVanishingAt_mul`: orders add under multiplication, with the
+  `Finset.prod` and power versions.
 * `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
 
 ## References
@@ -115,6 +116,37 @@ lemma orderOfVanishingAt_mul {g : ℍ → ℂ} (hf : MDiff f) (hg : MDiff g)
       (analyticAt_comp_ofComplex hg z.im_pos).meromorphicAt]
   exact WithTop.untop₀_add (meromorphicOrderAt_comp_ofComplex_ne_top hf hfne z)
     (meromorphicOrderAt_comp_ofComplex_ne_top hg hgne z)
+
+private lemma untop₀_sum {ι : Type*} {s : Finset ι} {g : ι → WithTop ℤ}
+    (hg : ∀ i ∈ s, g i ≠ ⊤) :
+    (∑ i ∈ s, g i).untop₀ = ∑ i ∈ s, (g i).untop₀ := by
+  induction s using Finset.cons_induction with
+  | empty => simp
+  | cons i s his ih =>
+    rw [Finset.sum_cons, Finset.sum_cons,
+      WithTop.untop₀_add (hg i (Finset.mem_cons_self i s))
+        (WithTop.sum_ne_top.mpr fun j hj ↦ hg j (Finset.mem_cons_of_mem hj)),
+      ih fun j hj ↦ hg j (Finset.mem_cons_of_mem hj)]
+
+/-- Vanishing orders sum over finite products of nonzero holomorphic functions. -/
+lemma orderOfVanishingAt_prod {ι : Type*} {s : Finset ι} {F : ι → ℍ → ℂ}
+    (hF : ∀ i ∈ s, MDiff (F i)) (hFne : ∀ i ∈ s, F i ≠ 0) (z : ℍ) :
+    orderOfVanishingAt (∏ i ∈ s, F i) z = ∑ i ∈ s, orderOfVanishingAt (F i) z := by
+  have hcomp : (∏ i ∈ s, F i) ∘ ofComplex = ∏ i ∈ s, (F i ∘ ofComplex) := by
+    ext w
+    simp [Finset.prod_apply]
+  simp only [orderOfVanishingAt_def]
+  rw [hcomp, meromorphicOrderAt_prod
+    (fun i hi ↦ (analyticAt_comp_ofComplex (hF i hi) z.im_pos).meromorphicAt)]
+  exact untop₀_sum fun i hi ↦
+    meromorphicOrderAt_comp_ofComplex_ne_top (hF i hi) (hFne i hi) z
+
+/-- Vanishing orders scale under powers of a nonzero holomorphic function. -/
+lemma orderOfVanishingAt_pow (hf : MDiff f) (hfne : f ≠ 0) (n : ℕ) (z : ℍ) :
+    orderOfVanishingAt (f ^ n) z = n * orderOfVanishingAt f z := by
+  have hpow : f ^ n = ∏ _i ∈ Finset.range n, f := by simp
+  rw [hpow, orderOfVanishingAt_prod (fun _ _ ↦ hf) (fun _ _ ↦ hfne),
+    Finset.sum_const, Finset.card_range, nsmul_eq_mul]
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -13,17 +13,18 @@ public import Mathlib.NumberTheory.ModularForms.QExpansion
 
 `TauCeti.orderOfVanishingAt f z` is the order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`, read
 as the meromorphic order of `f ∘ ofComplex` at `z`; `TauCeti.orderAtCusp` is the order at
-the cusp `∞` of a level-one form, read in its `q`-expansion. For a holomorphic modular
-form the interior order is detected by vanishing (`orderOfVanishingAt_eq_zero_iff` under
-nonvanishing of the form), and it is constant along the group action
-(`orderOfVanishingAt_smul`) — the order dictionary feeding the valence formula.
+the cusp `∞` with respect to a width parameter, read in the `q`-expansion. For a nonzero
+holomorphic function the interior order detects vanishing
+(`orderOfVanishingAt_eq_zero_iff`), and for a slash-invariant form it is constant along
+the group action (`orderOfVanishingAt_smul`) — the order dictionary feeding the valence
+formula.
 
 ## Main declarations
 
 * `TauCeti.orderOfVanishingAt`, `TauCeti.orderAtCusp`.
+* `TauCeti.orderOfVanishingAt_eq_zero_iff`: for a nonzero holomorphic function, the order
+  at `z` vanishes exactly when the function does not vanish at `z`.
 * `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
-* `TauCeti.orderOfVanishingAt_ne_zero_of_eq_zero`: a zero of a nonzero form has
-  nonzero order.
 
 ## References
 
@@ -35,7 +36,7 @@ public noncomputable section
 
 open UpperHalfPlane Complex
 
-open scoped ModularForm MatrixGroups
+open scoped ModularForm MatrixGroups Manifold
 
 namespace TauCeti
 
@@ -46,54 +47,64 @@ order `0`. -/
 def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
   (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
 
-/-- The order of vanishing at the cusp `∞` of a level-one modular form, read in its
-`q`-expansion, with the convention that the zero form gets order `0`. -/
-def orderAtCusp {k : ℤ} (f : ModularForm 𝒮ℒ k) : ℤ :=
-  (qExpansion 1 f).order.toNat
+/-- The order of vanishing of `f : ℍ → ℂ` at the cusp `∞` with respect to the width
+parameter `h`, read in the `q`-expansion, with the convention that the zero function gets
+order `0`. -/
+def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ :=
+  (qExpansion h f).order.toNat
 
-variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
+/-- Restatement of `orderAtCusp` through the `q`-expansion order. -/
+lemma orderAtCusp_eq (h : ℝ) (f : ℍ → ℂ) :
+    orderAtCusp h f = (qExpansion h f).order.toNat := by
+  unfold orderAtCusp
+  rfl
 
-private lemma analyticAt_comp_ofComplex [ModularFormClass F Γ k] (f : F) {w : ℂ}
-    (hw : 0 < w.im) : AnalyticAt ℂ (⇑f ∘ ofComplex) w :=
-  (UpperHalfPlane.mdifferentiable_iff.mp (ModularFormClass.holo f)).analyticAt
+variable {f : ℍ → ℂ}
+
+private lemma analyticAt_comp_ofComplex (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
+    AnalyticAt ℂ (f ∘ ofComplex) w :=
+  (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
     (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
-/-- At a point where a holomorphic modular form does not vanish, its order is zero. -/
-lemma orderOfVanishingAt_eq_zero_of_ne_zero [ModularFormClass F Γ k] (f : F) {z : ℍ}
-    (hz : f z ≠ 0) : orderOfVanishingAt f z = 0 := by
-  have h_nf : MeromorphicNFAt (⇑f ∘ ofComplex) (z : ℂ) :=
-    (analyticAt_comp_ofComplex f z.im_pos).meromorphicNFAt
-  have : (⇑f ∘ ofComplex) (z : ℂ) ≠ 0 := by
+/-- At a point where a holomorphic function on `ℍ` does not vanish, its order is zero. -/
+lemma orderOfVanishingAt_eq_zero_of_ne_zero (hf : MDiff f) {z : ℍ} (hz : f z ≠ 0) :
+    orderOfVanishingAt f z = 0 := by
+  have h_nf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ) :=
+    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt
+  have : (f ∘ ofComplex) (z : ℂ) ≠ 0 := by
     simpa [Function.comp_apply, ofComplex_apply] using hz
   rw [orderOfVanishingAt, h_nf.meromorphicOrderAt_eq_zero_iff.mpr this]
   rfl
 
-/-- A nonzero holomorphic modular form has finite vanishing order at every point of `ℍ`. -/
-lemma meromorphicOrderAt_comp_ofComplex_ne_top [ModularFormClass F Γ k] {f : F}
-    (hf : (⇑f : ℍ → ℂ) ≠ 0) (z : ℍ) : meromorphicOrderAt (⇑f ∘ ofComplex) (z : ℂ) ≠ ⊤ := by
-  intro htop
-  refine hf (funext fun τ ↦ ?_)
-  have h_eqOn : Set.EqOn (⇑f ∘ ofComplex) 0 upperHalfPlaneSet := by
-    have h_top : analyticOrderAt (⇑f ∘ ofComplex) (z : ℂ) = ⊤ := by
-      have := (analyticAt_comp_ofComplex f z.im_pos).meromorphicOrderAt_eq
-      rw [htop] at this
-      simpa using this.symm
-    exact AnalyticOnNhd.eqOn_zero_of_preconnected_of_eventuallyEq_zero
-      (fun w hw ↦ analyticAt_comp_ofComplex f hw)
-      (Convex.isPreconnected (convex_halfSpace_im_gt 0)) z.im_pos
-      (analyticOrderAt_eq_top.mp h_top)
-  simpa [Function.comp_apply, ofComplex_apply] using h_eqOn (τ.im_pos : (τ : ℂ) ∈ _)
+private lemma meromorphicOrderAt_comp_ofComplex_ne_top (hf : MDiff f) (hne : f ≠ 0)
+    (z : ℍ) : meromorphicOrderAt (f ∘ ofComplex) (z : ℂ) ≠ ⊤ := by
+  obtain ⟨τ, hτ⟩ := Function.ne_iff.mp hne
+  refine MeromorphicOn.meromorphicOrderAt_ne_top_of_isPreconnected
+    (fun w hw ↦ (analyticAt_comp_ofComplex hf hw).meromorphicAt)
+    (Convex.isPreconnected (convex_halfSpace_im_gt 0)) τ.im_pos z.im_pos ?_
+  rw [((analyticAt_comp_ofComplex hf τ.im_pos).meromorphicNFAt).meromorphicOrderAt_eq_zero_iff.mpr
+    (by simpa [Function.comp_apply, ofComplex_apply] using hτ)]
+  exact WithTop.zero_ne_top
 
-/-- A zero of a nonzero holomorphic modular form has nonzero vanishing order. -/
-lemma orderOfVanishingAt_ne_zero_of_eq_zero [ModularFormClass F Γ k] {f : F}
-    (hf : (⇑f : ℍ → ℂ) ≠ 0) {z : ℍ} (hz : f z = 0) : orderOfVanishingAt f z ≠ 0 := by
-  have h_nf : MeromorphicNFAt (⇑f ∘ ofComplex) (z : ℂ) :=
-    (analyticAt_comp_ofComplex f z.im_pos).meromorphicNFAt
-  have h_ne : meromorphicOrderAt (⇑f ∘ ofComplex) (z : ℂ) ≠ 0 := fun h0 ↦
+/-- A zero of a nonzero holomorphic function on `ℍ` has nonzero vanishing order. -/
+lemma orderOfVanishingAt_ne_zero_of_eq_zero (hf : MDiff f) (hne : f ≠ 0) {z : ℍ}
+    (hz : f z = 0) : orderOfVanishingAt f z ≠ 0 := by
+  have h_nf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ) :=
+    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt
+  have h_ne : meromorphicOrderAt (f ∘ ofComplex) (z : ℂ) ≠ 0 := fun h0 ↦
     h_nf.meromorphicOrderAt_eq_zero_iff.mp h0 (by simp [ofComplex_apply, hz])
   rw [orderOfVanishingAt]
   exact fun h ↦ h_ne (((WithTop.untop₀_eq_zero).mp h).resolve_right
-    (meromorphicOrderAt_comp_ofComplex_ne_top hf z))
+    (meromorphicOrderAt_comp_ofComplex_ne_top hf hne z))
+
+/-- For a nonzero holomorphic function on `ℍ`, the vanishing order at `z` is zero exactly
+when the function does not vanish at `z`. -/
+lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
+    orderOfVanishingAt f z = 0 ↔ f z ≠ 0 :=
+  ⟨fun h hz ↦ orderOfVanishingAt_ne_zero_of_eq_zero hf hne hz h,
+    orderOfVanishingAt_eq_zero_of_ne_zero hf⟩
+
+variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
 /-- The vanishing order of a slash-invariant form is constant along the group action. -/
 lemma orderOfVanishingAt_smul [Γ.HasDetOne] [SlashInvariantFormClass F Γ k] (f : F) {γ}

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -23,6 +23,7 @@ irregular cusps in odd weight) belongs to the general-level layer and is not def
 * `TauCeti.orderOfVanishingAt`.
 * `TauCeti.orderOfVanishingAt_eq_zero_iff`: for a nonzero holomorphic function, the order
   at `z` vanishes exactly when the function does not vanish at `z`.
+* `TauCeti.orderOfVanishingAt_mul`: orders add under multiplication.
 * `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
 
 ## References
@@ -46,9 +47,10 @@ order `0`. -/
 def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
   (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
 
--- The definition is sealed by the module system, so this restatement is the supported
--- cross-module rewrite for it. Not a `simp` lemma: unfolding the definition is not a
--- normal form, and `simpNF` rejects it against the dictionary lemmas below.
+/-- The defining equality of `orderOfVanishingAt`: the definition is sealed by the module
+system, so this restatement is the supported cross-module rewrite for it. -/
+-- Not a `simp` lemma: unfolding the definition is not a normal form, and `simpNF` rejects
+-- it against the dictionary lemmas below.
 lemma orderOfVanishingAt_def (f : ℍ → ℂ) (z : ℍ) :
     orderOfVanishingAt f z = (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀ := by
   unfold orderOfVanishingAt
@@ -102,6 +104,17 @@ lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
   ⟨fun h hz ↦ orderOfVanishingAt_ne_zero_of_eq_zero hf hne hz h,
     orderOfVanishingAt_eq_zero_of_ne_zero
       (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt⟩
+
+/-- Vanishing orders add under multiplication of nonzero holomorphic functions. -/
+lemma orderOfVanishingAt_mul {g : ℍ → ℂ} (hf : MDiff f) (hg : MDiff g)
+    (hfne : f ≠ 0) (hgne : g ≠ 0) (z : ℍ) :
+    orderOfVanishingAt (f * g) z = orderOfVanishingAt f z + orderOfVanishingAt g z := by
+  have hmul : (f * g) ∘ ofComplex = (f ∘ ofComplex) * (g ∘ ofComplex) := rfl
+  rw [orderOfVanishingAt_def, orderOfVanishingAt_def, orderOfVanishingAt_def, hmul,
+    meromorphicOrderAt_mul (analyticAt_comp_ofComplex hf z.im_pos).meromorphicAt
+      (analyticAt_comp_ofComplex hg z.im_pos).meromorphicAt]
+  exact WithTop.untop₀_add (meromorphicOrderAt_comp_ofComplex_ne_top hf hfne z)
+    (meromorphicOrderAt_comp_ofComplex_ne_top hg hgne z)
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -12,16 +12,15 @@ public import Mathlib.NumberTheory.ModularForms.QExpansion
 # The vanishing order of a modular form
 
 `TauCeti.orderOfVanishingAt f z` is the order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`, read
-as the meromorphic order of `f ∘ ofComplex` at `z`; `TauCeti.orderAtCusp` is the order at
-the cusp `∞` with respect to a width parameter, read in the `q`-expansion. For a nonzero
-holomorphic function the interior order detects vanishing
-(`orderOfVanishingAt_eq_zero_iff`), and for a slash-invariant form it is constant along
-the group action (`orderOfVanishingAt_smul`) — the order dictionary feeding the valence
-formula.
+as the meromorphic order of `f ∘ ofComplex` at `z`. For a nonzero holomorphic function it
+detects vanishing (`orderOfVanishingAt_eq_zero_iff`), and for a slash-invariant form it is
+constant along the group action (`orderOfVanishingAt_smul`) — the interior half of the
+order dictionary feeding the valence formula. The order at the cusps (`ℚ`-normalized at
+irregular cusps in odd weight) belongs to the general-level layer and is not defined here.
 
 ## Main declarations
 
-* `TauCeti.orderOfVanishingAt`, `TauCeti.orderAtCusp`.
+* `TauCeti.orderOfVanishingAt`.
 * `TauCeti.orderOfVanishingAt_eq_zero_iff`: for a nonzero holomorphic function, the order
   at `z` vanishes exactly when the function does not vanish at `z`.
 * `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
@@ -47,30 +46,20 @@ order `0`. -/
 def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
   (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
 
-/-- The order of vanishing of `f : ℍ → ℂ` at the cusp `∞` with respect to the width
-parameter `h`, read in the `q`-expansion, with the convention that the zero function gets
-order `0`. -/
-def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ :=
-  (qExpansion h f).order.toNat
-
-/-- Restatement of `orderAtCusp` through the `q`-expansion order. -/
-lemma orderAtCusp_eq (h : ℝ) (f : ℍ → ℂ) :
-    orderAtCusp h f = (qExpansion h f).order.toNat := by
-  unfold orderAtCusp
-  rfl
-
 variable {f : ℍ → ℂ}
 
-private lemma analyticAt_comp_ofComplex (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
+/-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
+every point of the open upper half-plane. -/
+lemma analyticAt_comp_ofComplex (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
     AnalyticAt ℂ (f ∘ ofComplex) w :=
   (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
     (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
-/-- At a point where a holomorphic function on `ℍ` does not vanish, its order is zero. -/
-lemma orderOfVanishingAt_eq_zero_of_ne_zero (hf : MDiff f) {z : ℍ} (hz : f z ≠ 0) :
+/-- At a point where a function analytic near `z` does not vanish, its order is zero. -/
+lemma orderOfVanishingAt_eq_zero_of_ne_zero {z : ℍ}
+    (hf : AnalyticAt ℂ (f ∘ ofComplex) (z : ℂ)) (hz : f z ≠ 0) :
     orderOfVanishingAt f z = 0 := by
-  have h_nf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ) :=
-    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt
+  have h_nf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ) := hf.meromorphicNFAt
   have : (f ∘ ofComplex) (z : ℂ) ≠ 0 := by
     simpa [Function.comp_apply, ofComplex_apply] using hz
   rw [orderOfVanishingAt, h_nf.meromorphicOrderAt_eq_zero_iff.mpr this]
@@ -99,10 +88,11 @@ lemma orderOfVanishingAt_ne_zero_of_eq_zero (hf : MDiff f) (hne : f ≠ 0) {z : 
 
 /-- For a nonzero holomorphic function on `ℍ`, the vanishing order at `z` is zero exactly
 when the function does not vanish at `z`. -/
+@[simp]
 lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
     orderOfVanishingAt f z = 0 ↔ f z ≠ 0 :=
   ⟨fun h hz ↦ orderOfVanishingAt_ne_zero_of_eq_zero hf hne hz h,
-    orderOfVanishingAt_eq_zero_of_ne_zero hf⟩
+    orderOfVanishingAt_eq_zero_of_ne_zero (analyticAt_comp_ofComplex hf z.im_pos)⟩
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -46,6 +46,14 @@ order `0`. -/
 def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
   (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
 
+-- The definition is sealed by the module system, so this restatement is the supported
+-- cross-module rewrite for it.
+@[simp]
+lemma orderOfVanishingAt_def (f : ℍ → ℂ) (z : ℍ) :
+    orderOfVanishingAt f z = (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀ := by
+  unfold orderOfVanishingAt
+  rfl
+
 variable {f : ℍ → ℂ}
 
 /-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
@@ -97,6 +105,7 @@ lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
 /-- The vanishing order of a slash-invariant form is constant along the group action. -/
+@[simp]
 lemma orderOfVanishingAt_smul [Γ.HasDetOne] [SlashInvariantFormClass F Γ k] (f : F) {γ}
     (hγ : γ ∈ Γ) (z : ℍ) : orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
   have hdet : 0 < γ.val.det := by

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -63,14 +63,14 @@ lemma analyticAt_comp_ofComplex (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
   (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
     (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
-/-- At a point where a function analytic near `z` does not vanish, its order is zero. -/
+/-- At a point where a function in meromorphic normal form does not vanish, its order is
+zero. -/
 lemma orderOfVanishingAt_eq_zero_of_ne_zero {z : ℍ}
-    (hf : AnalyticAt ℂ (f ∘ ofComplex) (z : ℂ)) (hz : f z ≠ 0) :
+    (hf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ)) (hz : f z ≠ 0) :
     orderOfVanishingAt f z = 0 := by
-  have h_nf : MeromorphicNFAt (f ∘ ofComplex) (z : ℂ) := hf.meromorphicNFAt
   have : (f ∘ ofComplex) (z : ℂ) ≠ 0 := by
     simpa [Function.comp_apply, ofComplex_apply] using hz
-  rw [orderOfVanishingAt, h_nf.meromorphicOrderAt_eq_zero_iff.mpr this]
+  rw [orderOfVanishingAt, hf.meromorphicOrderAt_eq_zero_iff.mpr this]
   rfl
 
 private lemma meromorphicOrderAt_comp_ofComplex_ne_top (hf : MDiff f) (hne : f ≠ 0)
@@ -100,7 +100,8 @@ when the function does not vanish at `z`. -/
 lemma orderOfVanishingAt_eq_zero_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
     orderOfVanishingAt f z = 0 ↔ f z ≠ 0 :=
   ⟨fun h hz ↦ orderOfVanishingAt_ne_zero_of_eq_zero hf hne hz h,
-    orderOfVanishingAt_eq_zero_of_ne_zero (analyticAt_comp_ofComplex hf z.im_pos)⟩
+    orderOfVanishingAt_eq_zero_of_ne_zero
+      (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt⟩
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -6,6 +6,7 @@ module
 
 public import Mathlib.Analysis.Meromorphic.NormalForm
 public import Mathlib.NumberTheory.ModularForms.Basic
+public import TauCeti.Analysis.Complex.UpperHalfPlane.Topology
 
 /-!
 # The vanishing order of a modular form
@@ -36,7 +37,7 @@ irregular cusps in odd weight) belongs to the general-level layer and is not def
 
 public noncomputable section
 
-open UpperHalfPlane Complex
+open UpperHalfPlane Complex TauCeti.UpperHalfPlane
 
 open scoped ModularForm MatrixGroups Manifold
 
@@ -59,13 +60,6 @@ lemma orderOfVanishingAt_def (f : ℍ → ℂ) (z : ℍ) :
   rfl
 
 variable {f : ℍ → ℂ}
-
-/-- A function holomorphic on `ℍ` composes with `ofComplex` to a function analytic at
-every point of the open upper half-plane. -/
-lemma analyticAt_comp_ofComplex (hf : MDiff f) {w : ℂ} (hw : 0 < w.im) :
-    AnalyticAt ℂ (f ∘ ofComplex) w :=
-  (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
-    (isOpen_upperHalfPlaneSet.mem_nhds hw)
 
 /-- At a point where a function in meromorphic normal form does not vanish, its order is
 zero. -/

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -135,8 +135,10 @@ by the order-zero convention). -/
 lemma orderOfVanishingAt_const (c : ℂ) (z : ℍ) :
     orderOfVanishingAt (fun _ ↦ c) z = 0 := by
   classical
-  rw [orderOfVanishingAt_def,
-    show (fun _ : ℍ ↦ c) ∘ ofComplex = fun _ ↦ c from rfl, meromorphicOrderAt_const]
+  -- Composition with a constant is definitionally constant; the composition equality is by
+  -- `rfl` since no `ofComplex` value is consumed.
+  have hcomp : (fun _ : ℍ ↦ c) ∘ ofComplex = fun _ ↦ c := rfl
+  rw [orderOfVanishingAt_def, hcomp, meromorphicOrderAt_const]
   split_ifs <;> rfl
 
 /-- The vanishing order of a holomorphic function is nonnegative. -/
@@ -186,23 +188,46 @@ lemma orderOfVanishingAt_pow (hf : MDiff f) (n : ℕ) (z : ℍ) :
 
 variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
 
-/-- The vanishing order of a slash-invariant form is constant along the group action. -/
+/-- The vanishing order of a slash-invariant form is constant along the action of any
+positive-determinant element of the group. -/
 -- Not a `simp` lemma: the subgroup `Γ` occurs only in the hypotheses, so `simpNF` rejects
 -- the annotation (`simp` could never instantiate it from the left-hand side).
-lemma orderOfVanishingAt_smul [Γ.HasDetOne] [SlashInvariantFormClass F Γ k] (f : F) {γ}
-    (hγ : γ ∈ Γ) (z : ℍ) : orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
-  have hdet : 0 < γ.val.det := by
-    simp [← Matrix.GeneralLinearGroup.val_det_apply, Subgroup.HasDetOne.det_eq hγ]
+lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
+    (hγ : γ ∈ Γ) (hdet : 0 < γ.val.det) (z : ℍ) :
+    orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
+  have hdet_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ≠ 0 := by
+    exact_mod_cast (abs_pos.mpr (γ.det : ℝˣ).ne_zero).ne'
+  have hpt : ∀ τ : ℍ, f (γ • τ) =
+      ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) * denom γ (τ : ℂ) ^ k * f τ := by
+    intro τ
+    have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
+    rw [ModularForm.slash_def] at h
+    have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by
+      rw [σ, if_pos (show (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) from by
+        rwa [Matrix.GeneralLinearGroup.val_det_apply])]
+    rw [hσ] at h
+    have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
+    have h2 : f (γ • τ) =
+        f τ * (((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (k - 1))⁻¹ * (denom γ (τ : ℂ) ^ (-k))⁻¹ := by
+      rw [← h]
+      field_simp
+      rfl
+    rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, show -(k - 1) = 1 - k by ring]
+    ring
   have hcongr : (fun w : ℂ ↦ f (γ • ofComplex w)) =ᶠ[nhds (z : ℂ)]
-      (fun w : ℂ ↦ ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
+      (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
+        ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
     filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
     rw [Pi.mul_apply, Function.comp_apply, ofComplex_apply_of_im_pos hw]
-    simpa using SlashInvariantForm.slash_action_eqn' f hγ ⟨w, hw⟩
-  have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
-    refine AnalyticAt.zpow (by fun_prop) ?_
+    simpa [denom, mul_assoc] using hpt ⟨w, hw⟩
+  have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
+      ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
+    refine AnalyticAt.mul analyticAt_const (AnalyticAt.zpow (by fun_prop) ?_)
     simpa [denom] using denom_ne_zero γ z
-  have h_ne : ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ k ≠ 0 :=
-    zpow_ne_zero _ (by simpa [denom] using denom_ne_zero γ z)
+  have h_ne : ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *
+      ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ k ≠ 0 :=
+    mul_ne_zero (zpow_ne_zero _ hdet_ne)
+      (zpow_ne_zero _ (by simpa [denom] using denom_ne_zero γ z))
   unfold orderOfVanishingAt
   conv_lhs => rw [Function.comp_def]
   rw [← meromorphicOrderAt_comp_smul hdet,

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.Analysis.Meromorphic.NormalForm
 public import Mathlib.NumberTheory.ModularForms.Basic
-public import TauCeti.Analysis.Complex.UpperHalfPlane.Topology
+public import TauCeti.Analysis.Complex.UpperHalfPlane.Manifold
 
 /-!
 # The vanishing order of a modular form

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -1,0 +1,121 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
+public import Mathlib.Analysis.Meromorphic.NormalForm
+public import Mathlib.NumberTheory.ModularForms.QExpansion
+
+/-!
+# The vanishing order of a modular form
+
+`TauCeti.orderOfVanishingAt f z` is the order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`, read
+as the meromorphic order of `f ∘ ofComplex` at `z`; `TauCeti.orderAtCusp` is the order at
+the cusp `∞` of a level-one form, read in its `q`-expansion. For a holomorphic modular
+form the interior order is detected by vanishing (`orderOfVanishingAt_eq_zero_iff` under
+nonvanishing of the form), and it is constant along the group action
+(`orderOfVanishingAt_smul`) — the order dictionary feeding the valence formula.
+
+## Main declarations
+
+* `TauCeti.orderOfVanishingAt`, `TauCeti.orderAtCusp`.
+* `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
+* `TauCeti.orderOfVanishingAt_ne_zero_of_eq_zero`: a zero of a nonzero form has
+  nonzero order.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane Complex
+
+open scoped ModularForm MatrixGroups
+
+namespace TauCeti
+
+/-- The order of vanishing of `f : ℍ → ℂ` at `z ∈ ℍ`: the meromorphic order of
+`f ∘ ofComplex` at `z`, with the conventions that a function vanishing in a neighborhood
+of `z` (in particular the zero function) and a function not meromorphic at `z` both get
+order `0`. -/
+def orderOfVanishingAt (f : ℍ → ℂ) (z : ℍ) : ℤ :=
+  (meromorphicOrderAt (f ∘ ofComplex) (z : ℂ)).untop₀
+
+/-- The order of vanishing at the cusp `∞` of a level-one modular form, read in its
+`q`-expansion, with the convention that the zero form gets order `0`. -/
+def orderAtCusp {k : ℤ} (f : ModularForm 𝒮ℒ k) : ℤ :=
+  (qExpansion 1 f).order.toNat
+
+variable {F : Type*} {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} [FunLike F ℍ ℂ]
+
+private lemma analyticAt_comp_ofComplex [ModularFormClass F Γ k] (f : F) {w : ℂ}
+    (hw : 0 < w.im) : AnalyticAt ℂ (⇑f ∘ ofComplex) w :=
+  (UpperHalfPlane.mdifferentiable_iff.mp (ModularFormClass.holo f)).analyticAt
+    (isOpen_upperHalfPlaneSet.mem_nhds hw)
+
+/-- At a point where a holomorphic modular form does not vanish, its order is zero. -/
+lemma orderOfVanishingAt_eq_zero_of_ne_zero [ModularFormClass F Γ k] (f : F) {z : ℍ}
+    (hz : f z ≠ 0) : orderOfVanishingAt f z = 0 := by
+  have h_nf : MeromorphicNFAt (⇑f ∘ ofComplex) (z : ℂ) :=
+    (analyticAt_comp_ofComplex f z.im_pos).meromorphicNFAt
+  have : (⇑f ∘ ofComplex) (z : ℂ) ≠ 0 := by
+    simpa [Function.comp_apply, ofComplex_apply] using hz
+  rw [orderOfVanishingAt, h_nf.meromorphicOrderAt_eq_zero_iff.mpr this]
+  rfl
+
+/-- A nonzero holomorphic modular form has finite vanishing order at every point of `ℍ`. -/
+lemma meromorphicOrderAt_comp_ofComplex_ne_top [ModularFormClass F Γ k] {f : F}
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) (z : ℍ) : meromorphicOrderAt (⇑f ∘ ofComplex) (z : ℂ) ≠ ⊤ := by
+  intro htop
+  refine hf (funext fun τ ↦ ?_)
+  have h_eqOn : Set.EqOn (⇑f ∘ ofComplex) 0 upperHalfPlaneSet := by
+    have h_top : analyticOrderAt (⇑f ∘ ofComplex) (z : ℂ) = ⊤ := by
+      have := (analyticAt_comp_ofComplex f z.im_pos).meromorphicOrderAt_eq
+      rw [htop] at this
+      simpa using this.symm
+    exact AnalyticOnNhd.eqOn_zero_of_preconnected_of_eventuallyEq_zero
+      (fun w hw ↦ analyticAt_comp_ofComplex f hw)
+      (Convex.isPreconnected (convex_halfSpace_im_gt 0)) z.im_pos
+      (analyticOrderAt_eq_top.mp h_top)
+  simpa [Function.comp_apply, ofComplex_apply] using h_eqOn (τ.im_pos : (τ : ℂ) ∈ _)
+
+/-- A zero of a nonzero holomorphic modular form has nonzero vanishing order. -/
+lemma orderOfVanishingAt_ne_zero_of_eq_zero [ModularFormClass F Γ k] {f : F}
+    (hf : (⇑f : ℍ → ℂ) ≠ 0) {z : ℍ} (hz : f z = 0) : orderOfVanishingAt f z ≠ 0 := by
+  have h_nf : MeromorphicNFAt (⇑f ∘ ofComplex) (z : ℂ) :=
+    (analyticAt_comp_ofComplex f z.im_pos).meromorphicNFAt
+  have h_ne : meromorphicOrderAt (⇑f ∘ ofComplex) (z : ℂ) ≠ 0 := fun h0 ↦
+    h_nf.meromorphicOrderAt_eq_zero_iff.mp h0 (by simp [ofComplex_apply, hz])
+  rw [orderOfVanishingAt]
+  exact fun h ↦ h_ne (((WithTop.untop₀_eq_zero).mp h).resolve_right
+    (meromorphicOrderAt_comp_ofComplex_ne_top hf z))
+
+/-- The vanishing order of a slash-invariant form is constant along the group action. -/
+lemma orderOfVanishingAt_smul [Γ.HasDetOne] [SlashInvariantFormClass F Γ k] (f : F) {γ}
+    (hγ : γ ∈ Γ) (z : ℍ) : orderOfVanishingAt f (γ • z) = orderOfVanishingAt f z := by
+  have hdet : 0 < γ.val.det := by
+    simp [← Matrix.GeneralLinearGroup.val_det_apply, Subgroup.HasDetOne.det_eq hγ]
+  have hcongr : (fun w : ℂ ↦ f (γ • ofComplex w)) =ᶠ[nhds (z : ℂ)]
+      (fun w : ℂ ↦ ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) * (⇑f ∘ ofComplex) := by
+    filter_upwards [isOpen_upperHalfPlaneSet.mem_nhds z.im_pos] with w hw
+    rw [Pi.mul_apply, Function.comp_apply, ofComplex_apply_of_im_pos hw]
+    simpa using SlashInvariantForm.slash_action_eqn' f hγ ⟨w, hw⟩
+  have h_an : AnalyticAt ℂ (fun w : ℂ ↦ ((γ 1 0 : ℂ) * w + (γ 1 1 : ℂ)) ^ k) (z : ℂ) := by
+    refine AnalyticAt.zpow (by fun_prop) ?_
+    simpa [denom] using denom_ne_zero γ z
+  have h_ne : ((γ 1 0 : ℂ) * (z : ℂ) + (γ 1 1 : ℂ)) ^ k ≠ 0 :=
+    zpow_ne_zero _ (by simpa [denom] using denom_ne_zero γ z)
+  unfold orderOfVanishingAt
+  conv_lhs => rw [Function.comp_def]
+  rw [← meromorphicOrderAt_comp_smul hdet,
+    meromorphicOrderAt_congr (hcongr.filter_mono nhdsWithin_le_nhds),
+    meromorphicOrderAt_mul_of_ne_zero h_an h_ne]
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -24,6 +24,8 @@ irregular cusps in odd weight) belongs to the general-level layer and is not def
   at `z` vanishes exactly when the function does not vanish at `z`.
 * `TauCeti.orderOfVanishingAt_mul`: orders add under multiplication, with the
   `Finset.prod` and power versions.
+* `TauCeti.orderOfVanishingAt_pos_iff`: for a nonzero holomorphic function, positive
+  order characterizes the zeros.
 * `TauCeti.orderOfVanishingAt_smul`: invariance along the action of the group.
 
 ## References
@@ -127,15 +129,49 @@ private lemma untop₀_sum {ι : Type*} {s : Finset ι} {g : ι → WithTop ℤ}
         (WithTop.sum_ne_top.mpr fun j hj ↦ hg j (Finset.mem_cons_of_mem hj)),
       ih fun j hj ↦ hg j (Finset.mem_cons_of_mem hj)]
 
+/-- Constant functions have vanishing order zero everywhere (including the zero function,
+by the order-zero convention). -/
+@[simp]
+lemma orderOfVanishingAt_const (c : ℂ) (z : ℍ) :
+    orderOfVanishingAt (fun _ ↦ c) z = 0 := by
+  classical
+  rw [orderOfVanishingAt_def,
+    show (fun _ : ℍ ↦ c) ∘ ofComplex = fun _ ↦ c from rfl, meromorphicOrderAt_const]
+  split_ifs <;> rfl
+
+/-- The vanishing order of a holomorphic function is nonnegative. -/
+lemma orderOfVanishingAt_nonneg (hf : MDiff f) (z : ℍ) : 0 ≤ orderOfVanishingAt f z := by
+  rw [orderOfVanishingAt_def,
+    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicOrderAt_eq]
+  induction analyticOrderAt (f ∘ ofComplex) (z : ℂ) using ENat.recTopCoe with
+  | top => simp
+  | coe n =>
+    simp only [ENat.map_natCast, WithTop.untop₀_coe]
+    exact Int.natCast_nonneg n
+
+/-- For a nonzero holomorphic function, the vanishing order at `z` is positive exactly
+when the function vanishes at `z`. -/
+@[simp]
+lemma orderOfVanishingAt_pos_iff (hf : MDiff f) (hne : f ≠ 0) {z : ℍ} :
+    0 < orderOfVanishingAt f z ↔ f z = 0 := by
+  constructor
+  · intro h
+    by_contra hz
+    rw [orderOfVanishingAt_eq_zero_of_ne_zero
+      (analyticAt_comp_ofComplex hf z.im_pos).meromorphicNFAt hz] at h
+    exact lt_irrefl 0 h
+  · exact fun hz ↦ lt_of_le_of_ne (orderOfVanishingAt_nonneg hf z)
+      (Ne.symm (orderOfVanishingAt_ne_zero_of_eq_zero hf hne hz))
+
 /-- Vanishing orders sum over finite products of nonzero holomorphic functions. -/
 lemma orderOfVanishingAt_prod {ι : Type*} {s : Finset ι} {F : ι → ℍ → ℂ}
     (hF : ∀ i ∈ s, MDiff (F i)) (hFne : ∀ i ∈ s, F i ≠ 0) (z : ℍ) :
     orderOfVanishingAt (∏ i ∈ s, F i) z = ∑ i ∈ s, orderOfVanishingAt (F i) z := by
+  have hcomp : (∏ i ∈ s, F i) ∘ ofComplex = fun w ↦ ∏ i ∈ s, (F i ∘ ofComplex) w :=
+    funext fun w ↦ Finset.prod_apply ..
   simp only [orderOfVanishingAt_def]
-  rw [show (∏ i ∈ s, F i) ∘ ofComplex = fun w ↦ ∏ i ∈ s, (F i ∘ ofComplex) w from
-      funext fun w ↦ Finset.prod_apply .. ,
-    meromorphicOrderAt_fun_prod
-      (fun i hi ↦ (analyticAt_comp_ofComplex (hF i hi) z.im_pos).meromorphicAt)]
+  rw [hcomp, meromorphicOrderAt_fun_prod
+    (fun i hi ↦ (analyticAt_comp_ofComplex (hF i hi) z.im_pos).meromorphicAt)]
   exact untop₀_sum fun i hi ↦
     meromorphicOrderAt_comp_ofComplex_ne_top (hF i hi) (hFne i hi) z
 

--- a/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderOfVanishing.lean
@@ -143,13 +143,9 @@ lemma orderOfVanishingAt_const (c : ℂ) (z : ℍ) :
 
 /-- The vanishing order of a holomorphic function is nonnegative. -/
 lemma orderOfVanishingAt_nonneg (hf : MDiff f) (z : ℍ) : 0 ≤ orderOfVanishingAt f z := by
-  rw [orderOfVanishingAt_def,
-    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicOrderAt_eq]
-  induction analyticOrderAt (f ∘ ofComplex) (z : ℂ) using ENat.recTopCoe with
-  | top => simp
-  | coe n =>
-    simp only [ENat.map_natCast, WithTop.untop₀_coe]
-    exact Int.natCast_nonneg n
+  rw [orderOfVanishingAt_def]
+  exact WithTop.untop₀_nonneg.mpr
+    (analyticAt_comp_ofComplex hf z.im_pos).meromorphicOrderAt_nonneg
 
 /-- For a nonzero holomorphic function, the vanishing order at `z` is positive exactly
 when the function vanishes at `z`. -/
@@ -202,9 +198,9 @@ lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
     intro τ
     have h := congr_fun (SlashInvariantForm.slash_action_eqn f γ hγ) τ
     rw [ModularForm.slash_def] at h
-    have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by
-      rw [σ, if_pos (show (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) from by
-        rwa [Matrix.GeneralLinearGroup.val_det_apply])]
+    have hdet' : (0 : ℝ) < ↑(Matrix.GeneralLinearGroup.det γ) := by
+      rwa [Matrix.GeneralLinearGroup.val_det_apply]
+    have hσ : σ γ = ContinuousAlgEquiv.refl ℝ ℂ := by rw [σ, if_pos hdet']
     rw [hσ] at h
     have hden : denom γ (τ : ℂ) ≠ 0 := denom_ne_zero γ τ
     have h2 : f (γ • τ) =
@@ -212,7 +208,8 @@ lemma orderOfVanishingAt_smul [SlashInvariantFormClass F Γ k] (f : F) {γ}
       rw [← h]
       field_simp
       rfl
-    rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, show -(k - 1) = 1 - k by ring]
+    have hexp : -(k - 1) = 1 - k := by ring
+    rw [h2, ← zpow_neg, ← zpow_neg, neg_neg, hexp]
     ring
   have hcongr : (fun w : ℂ ↦ f (γ • ofComplex w)) =ᶠ[nhds (z : ℂ)]
       (fun w : ℂ ↦ ((|(γ.det : ℝ)| : ℝ) : ℂ) ^ (1 - k) *


### PR DESCRIPTION
Opens the valence-formula layer (ModularForms roadmap, Layer 1) with the interior half of its order dictionary: `TauCeti.orderOfVanishingAt`, the vanishing order of `f : ℍ → ℂ` at a point of `ℍ` via the meromorphic order of `f ∘ ofComplex`, together with the facts the layer consumes — the supported restatement (`orderOfVanishingAt_def`), the characteristic detection of zeros for nonzero holomorphic functions (`orderOfVanishingAt_eq_zero_iff`, with the one-way lemmas at meromorphic-normal-form and function generality), additivity under multiplication (`orderOfVanishingAt_mul`), and constancy along the group action at determinant-one levels (`orderOfVanishingAt_smul`).

The order at the cusps is deliberately not defined here: it is `ℚ`-normalized at irregular cusps in odd weight, and ships with the general-level layer where that width machinery lives.

Ports the corresponding definitions of AINTLIB's proved valence development onto the current pin, with the upstream private meromorphic-transport layer and its `S`/`T` generator induction replaced by Mathlib's `meromorphicOrderAt_comp_smul`, and the invariance stated for any determinant-one subgroup element.

<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-order-dictionary"}-->
Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
