### PR TITLE
feat(ModularForms): finite zeros in the fundamental domain

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -45,9 +45,10 @@ private lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
   intro h_ev
-  have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) := fun q hq ↦
-    (ModularFormClass.differentiableAt_cuspFunction f hh hΓ
-      (by rwa [mem_ball, dist_zero_right] at hq)).differentiableWithinAt
+  have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) :=
+    have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+    differentiableOn_cuspFunction_ball hh (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
+      (ModularFormClass.holo f) (ModularFormClass.bdd_at_infty f)
   have h_eqOn : EqOn (cuspFunction h f) 0 (ball 0 1) :=
     (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
       (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -11,11 +11,11 @@ public import TauCeti.NumberTheory.ModularForms.OrderOfVanishing
 /-!
 # Finite zeros of a level-one modular form in the fundamental domain
 
-A nonzero level-one modular form does not vanish above some height (its cusp function is
-nonvanishing on a punctured `q`-ball), and its zeros in any bounded strip are finite by
-the identity theorem; consequently the set of points of the standard fundamental domain
-`𝒟` at which its vanishing order is nonzero is finite — the finite-support input to the
-valence formula.
+A nonzero level-one modular form does not vanish above some height, since its cusp
+function is nonvanishing on a punctured `q`-ball; its remaining nonzero-order points in
+the standard fundamental domain lie in a truncated fundamental domain, which is compact,
+so by the accumulation-point argument and the identity theorem they are finite — the
+finite-support input to the valence formula.
 
 ## Main declarations
 
@@ -68,84 +68,57 @@ private lemma cuspFunction_eventually_ne_zero (hf : f ≠ 0) :
 /-- A nonzero level-one modular form does not vanish at points of sufficiently large
 imaginary part. -/
 lemma exists_height_nonvanishing (hf : f ≠ 0) :
-    ∃ H : ℝ, Real.sqrt 3 / 2 < H ∧ ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
+    ∃ H : ℝ, ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
   obtain ⟨s, hs_prop, hs_open, hs_zero⟩ := _root_.eventually_nhds_iff.mp
     (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hf))
   obtain ⟨r, hr_pos, hr_ball⟩ := Metric.isOpen_iff.mp hs_open 0 hs_zero
-  refine ⟨max (-Real.log (r / 2) / (2 * Real.pi)) (Real.sqrt 3 / 2 + 1),
-    lt_of_lt_of_le (by linarith) (le_max_right _ _), fun p hp hfp ↦ ?_⟩
+  refine ⟨-Real.log (r / 2) / (2 * Real.pi), fun p hp hfp ↦ ?_⟩
   have h_qmem : Function.Periodic.qParam (1 : ℝ) (p : ℂ) ∈ ball (0 : ℂ) r := by
     rw [mem_ball, dist_zero_right, Function.Periodic.norm_qParam, div_one]
+    have h_exp : -2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi)) = Real.log (r / 2) := by
+      field_simp
     calc Real.exp (-2 * Real.pi * (p : ℂ).im)
         ≤ Real.exp (-2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi))) := by
           refine Real.exp_le_exp.mpr ?_
-          nlinarith [Real.pi_pos, le_trans (le_max_left _ _) hp]
-      _ = r / 2 := by
-          rw [show -2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi)) = Real.log (r / 2) by
-            field_simp]
-          exact Real.exp_log (by linarith)
+          nlinarith [Real.pi_pos]
+      _ = r / 2 := by rw [h_exp]; exact Real.exp_log (by linarith)
       _ < r := by linarith
   refine hs_prop _ (hr_ball h_qmem) (mem_compl_singleton_iff.mpr (Complex.exp_ne_zero _)) ?_
   rw [← SlashInvariantFormClass.eq_cuspFunction f p one_mem_strictPeriods one_ne_zero] at hfp
   exact hfp
 
-private lemma finite_zeros_in_strip (hf : f ≠ 0) {M : ℝ} (hM : (1 : ℝ) / 2 < M) :
-    Set.Finite {z : ℂ | (-1 < z.re ∧ z.re < 1 ∧ (1 : ℝ) / 2 < z.im ∧ z.im < M) ∧
-      (⇑f ∘ ofComplex) z = 0} := by
-  by_contra h_inf
-  have hBdd : Bornology.IsBounded
-      {z : ℂ | -1 < z.re ∧ z.re < 1 ∧ (1 : ℝ) / 2 < z.im ∧ z.im < M} :=
-    isBounded_iff_forall_norm_le.mpr ⟨1 + M, fun z hz ↦
-      (Complex.norm_le_abs_re_add_abs_im z).trans (by
-        have h1 : |z.re| < 1 := abs_lt.mpr ⟨by linarith [hz.1], hz.2.1⟩
-        have h2 : |z.im| ≤ M := abs_le.mpr ⟨by linarith [hz.2.2.1], hz.2.2.2.le⟩
-        linarith)⟩
-  obtain ⟨z₀, hz₀K, hz₀_acc⟩ :=
-    (show Set.Infinite _ from h_inf).exists_accPt_of_subset_isCompact
-      hBdd.isCompact_closure (fun z hz ↦ subset_closure hz.1)
-  have hz₀_pos : 0 < z₀.im := by
-    have h_half : (1 : ℝ) / 2 ≤ z₀.im := closure_minimal (fun z hz ↦ hz.2.2.1.le)
-      (isClosed_le continuous_const Complex.continuous_im) hz₀K
-    linarith
-  have h_freq : ∃ᶠ y in 𝓝[≠] z₀, (⇑f ∘ ofComplex) y = 0 :=
-    (accPt_iff_frequently_nhdsNE.mp hz₀_acc).mono fun y hy ↦ hy.2
-  have h_analOn : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} :=
-    fun w hw ↦ analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
-  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
-  have h_zero := h_analOn.eqOn_zero_of_preconnected_of_frequently_eq_zero
-    (Convex.isPreconnected (convex_halfSpace_im_gt 0)) hz₀_pos h_freq τ.im_pos
-  simpa [Function.comp_apply, ofComplex_apply] using h_zero
-
-/-- A point of the standard fundamental domain has imaginary part above `1/2`. -/
-lemma fd_im_gt_half {p : ℍ} (hp : p ∈ 𝒟) : (1 : ℝ) / 2 < (p : ℂ).im := by
-  by_contra! h_le
-  obtain ⟨hnormSq, habs_re⟩ := hp
-  have hre := abs_le.mp habs_re
-  nlinarith [normSq_apply (p : ℂ), p.im_pos, mul_self_nonneg (p : ℂ).re,
-    show UpperHalfPlane.re p = (p : ℂ).re from rfl, show p.im = (p : ℂ).im from rfl]
-
 /-- The set of points of the fundamental domain at which the vanishing order of a nonzero
 level-one modular form is nonzero is finite. -/
 lemma finite_zeros_in_fd (hf : f ≠ 0) :
     Set.Finite {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} := by
-  obtain ⟨H₀, hH₀_gt, hH₀_no⟩ := exists_height_nonvanishing hf
-  have hM : (1 : ℝ) / 2 < H₀ + 1 := by nlinarith [Real.sqrt_nonneg 3]
-  refine ((finite_zeros_in_strip hf hM).preimage
-    ((UpperHalfPlane.coe_injective).injOn)).subset fun p ⟨hp_fd, hp_ord⟩ ↦ ?_
-  have hfp : f p = 0 := by
+  obtain ⟨H₀, hH₀_no⟩ := exists_height_nonvanishing hf
+  by_contra h_inf
+  have h_zero : ∀ p : ℍ, orderOfVanishingAt (⇑f) p ≠ 0 → f p = 0 := fun p hp ↦ by
     by_contra hne
-    exact hp_ord (orderOfVanishingAt_eq_zero_of_ne_zero
+    exact hp (orderOfVanishingAt_eq_zero_of_ne_zero
       (analyticAt_comp_ofComplex (ModularFormClass.holo f) p.im_pos).meromorphicNFAt hne)
-  have hre := abs_le.mp hp_fd.2
-  have him_lt : (p : ℂ).im < H₀ + 1 := by
-    by_contra! h_ge
-    exact hH₀_no p (by linarith) hfp
-  refine ⟨⟨?_, ?_, fd_im_gt_half hp_fd, him_lt⟩, ?_⟩
-  · have : UpperHalfPlane.re p = (p : ℂ).re := rfl
-    linarith [hre.1]
-  · have : UpperHalfPlane.re p = (p : ℂ).re := rfl
-    linarith [hre.2]
-  · simpa [Function.comp_apply, ofComplex_apply] using hfp
+  have h_sub : {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} ⊆
+      ModularGroup.truncatedFundamentalDomain H₀ := fun p ⟨hp_fd, hp_ord⟩ ↦ by
+    refine ⟨hp_fd, ?_⟩
+    by_contra! h_gt
+    exact hH₀_no p h_gt.le (h_zero p hp_ord)
+  have hK : IsCompact (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀) :=
+    (ModularGroup.isCompact_truncatedFundamentalDomain H₀).image continuous_coe
+  obtain ⟨z₀, hz₀K, hz₀_acc⟩ :=
+    ((show Set.Infinite _ from h_inf).image
+      UpperHalfPlane.coe_injective.injOn).exists_accPt_of_subset_isCompact hK
+      (Set.image_mono h_sub |>.trans (Set.image_subset_iff.mpr fun p hp ↦ ⟨p, hp, rfl⟩))
+  obtain ⟨q₀, -, rfl⟩ := hz₀K
+  have h_freq : ∃ᶠ w in 𝓝[≠] (q₀ : ℂ), (⇑f ∘ ofComplex) w = 0 := by
+    refine (accPt_iff_frequently_nhdsNE.mp hz₀_acc).mono ?_
+    rintro w ⟨p, ⟨-, hp_ord⟩, rfl⟩
+    simpa [Function.comp_apply, ofComplex_apply] using h_zero p hp_ord
+  have h_analOn : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} :=
+    fun w hw ↦ analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
+  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
+  have h_zero' := h_analOn.eqOn_zero_of_preconnected_of_frequently_eq_zero
+    (Convex.isPreconnected (convex_halfSpace_im_gt 0)) q₀.im_pos h_freq τ.im_pos
+  simpa [Function.comp_apply, ofComplex_apply] using h_zero'
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -69,25 +69,11 @@ sufficiently large imaginary part. -/
 lemma exists_height_nonvanishing [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     ∃ H : ℝ, ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
-  obtain ⟨s, hs_prop, hs_open, hs_zero⟩ := _root_.eventually_nhds_iff.mp
-    (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hh hΓ hf))
-  obtain ⟨r, hr_pos, hr_ball⟩ := Metric.isOpen_iff.mp hs_open 0 hs_zero
-  refine ⟨-h * Real.log (r / 2) / (2 * Real.pi), fun p hp hfp ↦ ?_⟩
-  have h_qmem : Function.Periodic.qParam h (p : ℂ) ∈ ball (0 : ℂ) r := by
-    rw [mem_ball, dist_zero_right, Function.Periodic.norm_qParam]
-    have h_exp : -2 * Real.pi * ((-h * Real.log (r / 2) / (2 * Real.pi)) / h) =
-        Real.log (r / 2) := by
-      field_simp
-    calc Real.exp (-2 * Real.pi * (p : ℂ).im / h)
-        ≤ Real.exp (-2 * Real.pi * ((-h * Real.log (r / 2) / (2 * Real.pi)) / h)) := by
-          refine Real.exp_le_exp.mpr ?_
-          rw [← mul_div_assoc]
-          refine (div_le_div_iff_of_pos_right hh).mpr ?_
-          have := mul_le_mul_of_nonneg_left hp (by positivity : (0 : ℝ) ≤ 2 * Real.pi)
-          linarith
-      _ = r / 2 := by rw [h_exp]; exact Real.exp_log (by linarith)
-      _ < r := by linarith
-  refine hs_prop _ (hr_ball h_qmem) (mem_compl_singleton_iff.mpr (Complex.exp_ne_zero _)) ?_
+  have h_ev : ∀ᶠ p : ℍ in atImInfty, cuspFunction h f (Function.Periodic.qParam h ↑p) ≠ 0 :=
+    ((Function.Periodic.qParam_tendsto hh).comp tendsto_coe_atImInfty).eventually
+      (cuspFunction_eventually_ne_zero hh hΓ hf)
+  obtain ⟨H, hH⟩ := (atImInfty_mem _).mp h_ev
+  refine ⟨H, fun p hp hfp ↦ hH p (by rwa [UpperHalfPlane.coe_im] at hp) ?_⟩
   rw [← SlashInvariantFormClass.eq_cuspFunction f p hΓ hh.ne'] at hfp
   exact hfp
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -31,7 +31,7 @@ valence formula.
 
 public noncomputable section
 
-open Complex Filter Metric Set UpperHalfPlane
+open Complex Filter Metric Set UpperHalfPlane TauCeti.UpperHalfPlane
 
 open scoped ModularForm MatrixGroups Modular Topology
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -39,86 +39,83 @@ namespace TauCeti
 
 namespace ModularForm
 
-variable {k : ℤ} {f : ModularForm 𝒮ℒ k}
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {f : ModularForm Γ k} {h : ℝ}
 
-private lemma one_mem_strictPeriods : (1 : ℝ) ∈ (𝒮ℒ).strictPeriods := by simp
-
-private lemma cuspFunction_not_eventually_zero (hf : f ≠ 0) :
-    ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction 1 f q = 0 := by
+private lemma cuspFunction_not_eventually_zero (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
+    (hf : f ≠ 0) : ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
   intro h_ev
-  have h_diff : DifferentiableOn ℂ (cuspFunction 1 f) (ball 0 1) := fun q hq ↦
-    (ModularFormClass.differentiableAt_cuspFunction f one_pos one_mem_strictPeriods
+  have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) := fun q hq ↦
+    (ModularFormClass.differentiableAt_cuspFunction f hh hΓ
       (by rwa [mem_ball, dist_zero_right] at hq)).differentiableWithinAt
-  have h_eqOn : EqOn (cuspFunction 1 f) 0 (ball 0 1) :=
+  have h_eqOn : EqOn (cuspFunction h f) 0 (ball 0 1) :=
     (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
       (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev
   refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
   rw [ModularForm.coe_zero, Pi.zero_apply,
-    ← SlashInvariantFormClass.eq_cuspFunction f τ one_mem_strictPeriods one_ne_zero]
+    ← SlashInvariantFormClass.eq_cuspFunction f τ hΓ hh.ne']
   exact h_eqOn (by
     rw [mem_ball, dist_zero_right]
-    exact_mod_cast norm_qParam_lt_one 1 τ)
+    exact_mod_cast Function.Periodic.norm_qParam_lt_one hh τ.im_pos)
 
-private lemma cuspFunction_eventually_ne_zero (hf : f ≠ 0) :
-    ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction 1 f q ≠ 0 :=
-  (ModularFormClass.analyticAt_cuspFunction_zero f one_pos
-    one_mem_strictPeriods).eventually_eq_zero_or_eventually_ne_zero.resolve_left
-    (cuspFunction_not_eventually_zero hf)
+private lemma cuspFunction_eventually_ne_zero (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
+    (hf : f ≠ 0) : ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
+  (ModularFormClass.analyticAt_cuspFunction_zero f hh
+    hΓ).eventually_eq_zero_or_eventually_ne_zero.resolve_left
+    (cuspFunction_not_eventually_zero hh hΓ hf)
 
-/-- A nonzero level-one modular form does not vanish at points of sufficiently large
-imaginary part. -/
-lemma exists_height_nonvanishing (hf : f ≠ 0) :
+/-- A nonzero modular form with a positive strict period does not vanish at points of
+sufficiently large imaginary part. -/
+lemma exists_height_nonvanishing (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (hf : f ≠ 0) :
     ∃ H : ℝ, ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
   obtain ⟨s, hs_prop, hs_open, hs_zero⟩ := _root_.eventually_nhds_iff.mp
-    (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hf))
+    (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hh hΓ hf))
   obtain ⟨r, hr_pos, hr_ball⟩ := Metric.isOpen_iff.mp hs_open 0 hs_zero
-  refine ⟨-Real.log (r / 2) / (2 * Real.pi), fun p hp hfp ↦ ?_⟩
-  have h_qmem : Function.Periodic.qParam (1 : ℝ) (p : ℂ) ∈ ball (0 : ℂ) r := by
-    rw [mem_ball, dist_zero_right, Function.Periodic.norm_qParam, div_one]
-    have h_exp : -2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi)) = Real.log (r / 2) := by
+  refine ⟨-h * Real.log (r / 2) / (2 * Real.pi), fun p hp hfp ↦ ?_⟩
+  have h_qmem : Function.Periodic.qParam h (p : ℂ) ∈ ball (0 : ℂ) r := by
+    rw [mem_ball, dist_zero_right, Function.Periodic.norm_qParam]
+    have h_exp : -2 * Real.pi * ((-h * Real.log (r / 2) / (2 * Real.pi)) / h) =
+        Real.log (r / 2) := by
       field_simp
-    calc Real.exp (-2 * Real.pi * (p : ℂ).im)
-        ≤ Real.exp (-2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi))) := by
+    calc Real.exp (-2 * Real.pi * (p : ℂ).im / h)
+        ≤ Real.exp (-2 * Real.pi * ((-h * Real.log (r / 2) / (2 * Real.pi)) / h)) := by
           refine Real.exp_le_exp.mpr ?_
-          nlinarith [Real.pi_pos]
+          rw [← mul_div_assoc]
+          refine (div_le_div_iff_of_pos_right hh).mpr ?_
+          have := mul_le_mul_of_nonneg_left hp (by positivity : (0 : ℝ) ≤ 2 * Real.pi)
+          linarith
       _ = r / 2 := by rw [h_exp]; exact Real.exp_log (by linarith)
       _ < r := by linarith
   refine hs_prop _ (hr_ball h_qmem) (mem_compl_singleton_iff.mpr (Complex.exp_ne_zero _)) ?_
-  rw [← SlashInvariantFormClass.eq_cuspFunction f p one_mem_strictPeriods one_ne_zero] at hfp
+  rw [← SlashInvariantFormClass.eq_cuspFunction f p hΓ hh.ne'] at hfp
   exact hfp
 
 /-- The set of points of the fundamental domain at which the vanishing order of a nonzero
 level-one modular form is nonzero is finite. -/
-lemma finite_zeros_in_fd (hf : f ≠ 0) :
+lemma finite_zeros_in_fd {f : ModularForm 𝒮ℒ k} (hf : f ≠ 0) :
     Set.Finite {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} := by
-  obtain ⟨H₀, hH₀_no⟩ := exists_height_nonvanishing hf
-  by_contra h_inf
-  have h_zero : ∀ p : ℍ, orderOfVanishingAt (⇑f) p ≠ 0 → f p = 0 := fun p hp ↦ by
-    by_contra hne
-    exact hp (orderOfVanishingAt_eq_zero_of_ne_zero
-      (analyticAt_comp_ofComplex (ModularFormClass.holo f) p.im_pos).meromorphicNFAt hne)
-  have h_sub : {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} ⊆
-      ModularGroup.truncatedFundamentalDomain H₀ := fun p ⟨hp_fd, hp_ord⟩ ↦ by
-    refine ⟨hp_fd, ?_⟩
-    by_contra! h_gt
-    exact hH₀_no p h_gt.le (h_zero p hp_ord)
+  obtain ⟨H₀, hH₀_no⟩ := exists_height_nonvanishing one_pos (by simp) hf
+  have hne : (⇑f : ℍ → ℂ) ≠ 0 := (ModularForm.coe_eq_zero_iff f).not.mpr hf
   have hK : IsCompact (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀) :=
     (ModularGroup.isCompact_truncatedFundamentalDomain H₀).image continuous_coe
-  obtain ⟨z₀, hz₀K, hz₀_acc⟩ :=
-    ((show Set.Infinite _ from h_inf).image
-      UpperHalfPlane.coe_injective.injOn).exists_accPt_of_subset_isCompact hK
-      (Set.image_mono h_sub |>.trans (Set.image_subset_iff.mpr fun p hp ↦ ⟨p, hp, rfl⟩))
-  obtain ⟨q₀, -, rfl⟩ := hz₀K
-  have h_freq : ∃ᶠ w in 𝓝[≠] (q₀ : ℂ), (⇑f ∘ ofComplex) w = 0 := by
-    refine (accPt_iff_frequently_nhdsNE.mp hz₀_acc).mono ?_
-    rintro w ⟨p, ⟨-, hp_ord⟩, rfl⟩
-    simpa [Function.comp_apply, ofComplex_apply] using h_zero p hp_ord
-  have h_analOn : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} :=
-    fun w hw ↦ analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
-  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
-  have h_zero' := h_analOn.eqOn_zero_of_preconnected_of_frequently_eq_zero
-    (Convex.isPreconnected (convex_halfSpace_im_gt 0)) q₀.im_pos h_freq τ.im_pos
-  simpa [Function.comp_apply, ofComplex_apply] using h_zero'
+  have hK_im : ∀ z ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀,
+      0 < z.im := by
+    rintro _ ⟨q, -, rfl⟩
+    exact q.im_pos
+  have h_mero : MeromorphicOn (⇑f ∘ ofComplex)
+      (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀) := fun z hz ↦
+    (analyticAt_comp_ofComplex (ModularFormClass.holo f) (hK_im z hz)).meromorphicAt
+  have h_fin := MeromorphicOn.divisor_support_finite_of_subset h_mero hK subset_rfl
+  refine (h_fin.preimage UpperHalfPlane.coe_injective.injOn).subset ?_
+  rintro p ⟨hp_fd, hp_ord⟩
+  have h_zero : f p = 0 := by
+    by_contra hne'
+    exact hp_ord ((orderOfVanishingAt_eq_zero_iff (ModularFormClass.holo f) hne).mpr hne')
+  have hpK : (p : ℂ) ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀ :=
+    ⟨p, ⟨hp_fd, by by_contra! h_gt; exact hH₀_no p h_gt.le h_zero⟩, rfl⟩
+  rw [Set.mem_preimage, Function.mem_support, ne_eq,
+    MeromorphicOn.divisor_apply h_mero hpK]
+  intro h0
+  exact hp_ord (by rwa [orderOfVanishingAt_def])
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -39,10 +39,11 @@ namespace TauCeti
 
 namespace ModularForm
 
-variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {f : ModularForm Γ k} {h : ℝ}
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F} {h : ℝ}
 
-private lemma cuspFunction_not_eventually_zero (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
-    (hf : f ≠ 0) : ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
+private lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
   intro h_ev
   have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) := fun q hq ↦
     (ModularFormClass.differentiableAt_cuspFunction f hh hΓ
@@ -50,22 +51,23 @@ private lemma cuspFunction_not_eventually_zero (hh : 0 < h) (hΓ : h ∈ Γ.stri
   have h_eqOn : EqOn (cuspFunction h f) 0 (ball 0 1) :=
     (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
       (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev
-  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
-  rw [ModularForm.coe_zero, Pi.zero_apply,
-    ← SlashInvariantFormClass.eq_cuspFunction f τ hΓ hh.ne']
+  refine hf (funext fun τ ↦ ?_)
+  rw [Pi.zero_apply, ← SlashInvariantFormClass.eq_cuspFunction f τ hΓ hh.ne']
   exact h_eqOn (by
     rw [mem_ball, dist_zero_right]
     exact_mod_cast Function.Periodic.norm_qParam_lt_one hh τ.im_pos)
 
-private lemma cuspFunction_eventually_ne_zero (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods)
-    (hf : f ≠ 0) : ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
+private lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
   (ModularFormClass.analyticAt_cuspFunction_zero f hh
     hΓ).eventually_eq_zero_or_eventually_ne_zero.resolve_left
     (cuspFunction_not_eventually_zero hh hΓ hf)
 
 /-- A nonzero modular form with a positive strict period does not vanish at points of
 sufficiently large imaginary part. -/
-lemma exists_height_nonvanishing (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (hf : f ≠ 0) :
+lemma exists_height_nonvanishing [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     ∃ H : ℝ, ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
   obtain ⟨s, hs_prop, hs_open, hs_zero⟩ := _root_.eventually_nhds_iff.mp
     (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hh hΓ hf))
@@ -91,10 +93,9 @@ lemma exists_height_nonvanishing (hh : 0 < h) (hΓ : h ∈ Γ.strictPeriods) (hf
 
 /-- The set of points of the fundamental domain at which the vanishing order of a nonzero
 level-one modular form is nonzero is finite. -/
-lemma finite_zeros_in_fd {f : ModularForm 𝒮ℒ k} (hf : f ≠ 0) :
+lemma finite_zeros_in_fd [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     Set.Finite {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} := by
   obtain ⟨H₀, hH₀_no⟩ := exists_height_nonvanishing one_pos (by simp) hf
-  have hne : (⇑f : ℍ → ℂ) ≠ 0 := (ModularForm.coe_eq_zero_iff f).not.mpr hf
   have hK : IsCompact (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀) :=
     (ModularGroup.isCompact_truncatedFundamentalDomain H₀).image continuous_coe
   have hK_im : ∀ z ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀,
@@ -109,7 +110,7 @@ lemma finite_zeros_in_fd {f : ModularForm 𝒮ℒ k} (hf : f ≠ 0) :
   rintro p ⟨hp_fd, hp_ord⟩
   have h_zero : f p = 0 := by
     by_contra hne'
-    exact hp_ord ((orderOfVanishingAt_eq_zero_iff (ModularFormClass.holo f) hne).mpr hne')
+    exact hp_ord ((orderOfVanishingAt_eq_zero_iff (ModularFormClass.holo f) hf).mpr hne')
   have hpK : (p : ℂ) ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H₀ :=
     ⟨p, ⟨hp_fd, by by_contra! h_gt; exact hH₀_no p h_gt.le h_zero⟩, rfl⟩
   rw [Set.mem_preimage, Function.mem_support, ne_eq,

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.Modular
+public import TauCeti.NumberTheory.ModularForms.OrderOfVanishing
+
+/-!
+# Finite zeros of a level-one modular form in the fundamental domain
+
+A nonzero level-one modular form does not vanish above some height (its cusp function is
+nonvanishing on a punctured `q`-ball), and its zeros in any bounded strip are finite by
+the identity theorem; consequently the set of points of the standard fundamental domain
+`𝒟` at which its vanishing order is nonzero is finite — the finite-support input to the
+valence formula.
+
+## Main declarations
+
+* `TauCeti.ModularForm.exists_height_nonvanishing`: a nonzero form does not vanish at
+  points of imaginary part above some height.
+* `TauCeti.ModularForm.finite_zeros_in_fd`: finiteness of the nonzero-order points in `𝒟`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open Complex Filter Metric Set UpperHalfPlane
+
+open scoped ModularForm MatrixGroups Modular Topology
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {k : ℤ} {f : ModularForm 𝒮ℒ k}
+
+private lemma one_mem_strictPeriods : (1 : ℝ) ∈ (𝒮ℒ).strictPeriods := by simp
+
+private lemma cuspFunction_not_eventually_zero (hf : f ≠ 0) :
+    ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction 1 f q = 0 := by
+  intro h_ev
+  have h_diff : DifferentiableOn ℂ (cuspFunction 1 f) (ball 0 1) := fun q hq ↦
+    (ModularFormClass.differentiableAt_cuspFunction f one_pos one_mem_strictPeriods
+      (by rwa [mem_ball, dist_zero_right] at hq)).differentiableWithinAt
+  have h_eqOn : EqOn (cuspFunction 1 f) 0 (ball 0 1) :=
+    (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
+      (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev
+  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
+  rw [ModularForm.coe_zero, Pi.zero_apply,
+    ← SlashInvariantFormClass.eq_cuspFunction f τ one_mem_strictPeriods one_ne_zero]
+  exact h_eqOn (by
+    rw [mem_ball, dist_zero_right]
+    exact_mod_cast norm_qParam_lt_one 1 τ)
+
+private lemma cuspFunction_eventually_ne_zero (hf : f ≠ 0) :
+    ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction 1 f q ≠ 0 :=
+  (ModularFormClass.analyticAt_cuspFunction_zero f one_pos
+    one_mem_strictPeriods).eventually_eq_zero_or_eventually_ne_zero.resolve_left
+    (cuspFunction_not_eventually_zero hf)
+
+/-- A nonzero level-one modular form does not vanish at points of sufficiently large
+imaginary part. -/
+lemma exists_height_nonvanishing (hf : f ≠ 0) :
+    ∃ H : ℝ, Real.sqrt 3 / 2 < H ∧ ∀ p : ℍ, H ≤ (p : ℂ).im → f p ≠ 0 := by
+  obtain ⟨s, hs_prop, hs_open, hs_zero⟩ := _root_.eventually_nhds_iff.mp
+    (eventually_nhdsWithin_iff.mp (cuspFunction_eventually_ne_zero hf))
+  obtain ⟨r, hr_pos, hr_ball⟩ := Metric.isOpen_iff.mp hs_open 0 hs_zero
+  refine ⟨max (-Real.log (r / 2) / (2 * Real.pi)) (Real.sqrt 3 / 2 + 1),
+    lt_of_lt_of_le (by linarith) (le_max_right _ _), fun p hp hfp ↦ ?_⟩
+  have h_qmem : Function.Periodic.qParam (1 : ℝ) (p : ℂ) ∈ ball (0 : ℂ) r := by
+    rw [mem_ball, dist_zero_right, Function.Periodic.norm_qParam, div_one]
+    calc Real.exp (-2 * Real.pi * (p : ℂ).im)
+        ≤ Real.exp (-2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi))) := by
+          refine Real.exp_le_exp.mpr ?_
+          nlinarith [Real.pi_pos, le_trans (le_max_left _ _) hp]
+      _ = r / 2 := by
+          rw [show -2 * Real.pi * (-Real.log (r / 2) / (2 * Real.pi)) = Real.log (r / 2) by
+            field_simp]
+          exact Real.exp_log (by linarith)
+      _ < r := by linarith
+  refine hs_prop _ (hr_ball h_qmem) (mem_compl_singleton_iff.mpr (Complex.exp_ne_zero _)) ?_
+  rw [← SlashInvariantFormClass.eq_cuspFunction f p one_mem_strictPeriods one_ne_zero] at hfp
+  exact hfp
+
+private lemma finite_zeros_in_strip (hf : f ≠ 0) {M : ℝ} (hM : (1 : ℝ) / 2 < M) :
+    Set.Finite {z : ℂ | (-1 < z.re ∧ z.re < 1 ∧ (1 : ℝ) / 2 < z.im ∧ z.im < M) ∧
+      (⇑f ∘ ofComplex) z = 0} := by
+  by_contra h_inf
+  have hBdd : Bornology.IsBounded
+      {z : ℂ | -1 < z.re ∧ z.re < 1 ∧ (1 : ℝ) / 2 < z.im ∧ z.im < M} :=
+    isBounded_iff_forall_norm_le.mpr ⟨1 + M, fun z hz ↦
+      (Complex.norm_le_abs_re_add_abs_im z).trans (by
+        have h1 : |z.re| < 1 := abs_lt.mpr ⟨by linarith [hz.1], hz.2.1⟩
+        have h2 : |z.im| ≤ M := abs_le.mpr ⟨by linarith [hz.2.2.1], hz.2.2.2.le⟩
+        linarith)⟩
+  obtain ⟨z₀, hz₀K, hz₀_acc⟩ :=
+    (show Set.Infinite _ from h_inf).exists_accPt_of_subset_isCompact
+      hBdd.isCompact_closure (fun z hz ↦ subset_closure hz.1)
+  have hz₀_pos : 0 < z₀.im := by
+    have h_half : (1 : ℝ) / 2 ≤ z₀.im := closure_minimal (fun z hz ↦ hz.2.2.1.le)
+      (isClosed_le continuous_const Complex.continuous_im) hz₀K
+    linarith
+  have h_freq : ∃ᶠ y in 𝓝[≠] z₀, (⇑f ∘ ofComplex) y = 0 :=
+    (accPt_iff_frequently_nhdsNE.mp hz₀_acc).mono fun y hy ↦ hy.2
+  have h_analOn : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} :=
+    fun w hw ↦ analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
+  refine hf (DFunLike.coe_injective (funext fun τ ↦ ?_))
+  have h_zero := h_analOn.eqOn_zero_of_preconnected_of_frequently_eq_zero
+    (Convex.isPreconnected (convex_halfSpace_im_gt 0)) hz₀_pos h_freq τ.im_pos
+  simpa [Function.comp_apply, ofComplex_apply] using h_zero
+
+/-- A point of the standard fundamental domain has imaginary part above `1/2`. -/
+lemma fd_im_gt_half {p : ℍ} (hp : p ∈ 𝒟) : (1 : ℝ) / 2 < (p : ℂ).im := by
+  by_contra! h_le
+  obtain ⟨hnormSq, habs_re⟩ := hp
+  have hre := abs_le.mp habs_re
+  nlinarith [normSq_apply (p : ℂ), p.im_pos, mul_self_nonneg (p : ℂ).re,
+    show UpperHalfPlane.re p = (p : ℂ).re from rfl, show p.im = (p : ℂ).im from rfl]
+
+/-- The set of points of the fundamental domain at which the vanishing order of a nonzero
+level-one modular form is nonzero is finite. -/
+lemma finite_zeros_in_fd (hf : f ≠ 0) :
+    Set.Finite {p : ℍ | p ∈ 𝒟 ∧ orderOfVanishingAt f p ≠ 0} := by
+  obtain ⟨H₀, hH₀_gt, hH₀_no⟩ := exists_height_nonvanishing hf
+  have hM : (1 : ℝ) / 2 < H₀ + 1 := by nlinarith [Real.sqrt_nonneg 3]
+  refine ((finite_zeros_in_strip hf hM).preimage
+    ((UpperHalfPlane.coe_injective).injOn)).subset fun p ⟨hp_fd, hp_ord⟩ ↦ ?_
+  have hfp : f p = 0 := by
+    by_contra hne
+    exact hp_ord (orderOfVanishingAt_eq_zero_of_ne_zero
+      (analyticAt_comp_ofComplex (ModularFormClass.holo f) p.im_pos).meromorphicNFAt hne)
+  have hre := abs_le.mp hp_fd.2
+  have him_lt : (p : ℂ).im < H₀ + 1 := by
+    by_contra! h_ge
+    exact hH₀_no p (by linarith) hfp
+  refine ⟨⟨?_, ?_, fd_im_gt_half hp_fd, him_lt⟩, ?_⟩
+  · have : UpperHalfPlane.re p = (p : ℂ).re := rfl
+    linarith [hre.1]
+  · have : UpperHalfPlane.re p = (p : ℂ).re := rfl
+    linarith [hre.2]
+  · simpa [Function.comp_apply, ofComplex_apply] using hfp
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.Modular
+public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import TauCeti.NumberTheory.ModularForms.OrderOfVanishing
 
 /-!


### PR DESCRIPTION
Second step of the valence-formula layer: a nonzero level-one modular form has finitely many nonzero-order points in the standard fundamental domain (`TauCeti.ModularForm.finite_zeros_in_fd`). The route: the cusp function of a nonzero form is nonvanishing on a punctured `q`-ball (isolated zeros), giving nonvanishing of the form above some height (`exists_height_nonvanishing`); zeros in the remaining bounded strip are finite by the accumulation-point argument and the identity theorem on the connected half-plane; and `𝒟`-membership pins the imaginary part above `1/2` (`fd_im_gt_half`).

Stacked on #1974 (consumes `orderOfVanishingAt` and its dictionary); will rebase onto main when that merges and stay draft until then.

<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-finite-zeros"}-->
Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
