### PR TITLE
feat: cut the image of an arbitrary domain, not only a disc, by a circular crosscut

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -521,9 +521,12 @@ theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (
   obtain ⟨v, hv⟩ :=
     exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hq)
   have hr : 0 < r := by linarith
+  have hends : ⋃ e ∈ frontier (ball c r) ∩ sphere ζ ρ,
+      clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {u, v} := by
+    rw [frontier_ball c hr.ne', hpair, biUnion_pair, hu, hv, singleton_union]
   refine ⟨u, v, ?_⟩
   rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hf.continuousOn.mono inter_subset_left) hρ, frontier_ball c hr.ne', hpair, biUnion_pair,
-    hu, hv, union_comm, singleton_union, insert_union, singleton_union]
+    (hf.continuousOn.mono inter_subset_left), hends]
+  simp
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -16,7 +16,7 @@ import TauCeti.Topology.Circle.Metric
 `Conformal/Crosscut/Image.lean` identifies the boundary piece a circular crosscut clings to as the
 union of the *cluster sets* of the map at the crosscut's two endpoints, and shows each of them to be
 a continuum. Nothing there says those continua are single points; in its own words, the
-identification is "with a union of two cluster sets, not with a connected subset of `∂Ω` running
+identification is "with a union of cluster sets, not with a connected subset of `∂Ω` running
 between them". This file supplies the missing degeneration, from the one hypothesis that the
 length–area method already produces: **an image crosscut of finite length has an honest limit at
 each of its two ends**, so its closure is the crosscut together with two points.
@@ -520,9 +520,10 @@ theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (
     exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hp)
   obtain ⟨v, hv⟩ :=
     exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hq)
+  have hr : 0 < r := by linarith
   refine ⟨u, v, ?_⟩
-  rw [closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hf.continuousOn.mono inter_subset_left) hζ hρ hρr, hpair, biUnion_pair, hu, hv,
-    union_comm, singleton_union, insert_union, singleton_union]
+  rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hf.continuousOn.mono inter_subset_left) hρ, frontier_ball c hr.ne', hpair, biUnion_pair,
+    hu, hv, union_comm, singleton_union, insert_union, singleton_union]
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -39,7 +39,9 @@ with its closure; they do not assert the continuous boundary extension itself.
   arcs.
 * `TauCeti.sphere_inter_sphere_eq_pair_circleMap` identifies their two distinct endpoints.
 * `TauCeti.isPathConnected_ball_inter_sphere` and
-  `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging.
+  `TauCeti.closure_ball_inter_sphere` give the corresponding topological packaging, and
+  `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere` records that a crosscut reaches
+  the frontier of the disc.
 * `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` — a ball centred at a point of the closed
   crosscut meets the crosscut in a subarc: a crosscut spans less than a half turn, so along it the
   chord distance to a fixed one of its points falls and then rises, and the angles it keeps below a
@@ -392,6 +394,27 @@ theorem closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : �
   · rintro z ⟨θ, hθ, rfl⟩
     exact mem_closure_image (continuous_circleMap ζ ρ).continuousAt
       (by rwa [closure_Ioo hab.ne])
+
+/-- **A circular crosscut of a disc reaches the boundary of the disc.** A crosscut spanning less
+than a half turn has two endpoints (`TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and either of
+them lies on `sphere c r`, the frontier of the disc, and in the closure of the crosscut
+(`TauCeti.closure_ball_inter_sphere`).
+
+This is the form in which `Conformal/Crosscut/Image.lean`, whose statements are about an arbitrary
+domain, asks a cut to leave the domain at all. -/
+theorem nonempty_frontier_ball_inter_closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) :
+    (frontier (ball c r) ∩ closure (ball c r ∩ sphere ζ ρ)).Nonempty := by
+  have hr : 0 < r := by linarith
+  have hmem : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+      ∈ sphere c r ∩ sphere ζ ρ := by
+    rw [sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr]
+    exact Or.inl rfl
+  refine ⟨circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))), ?_, ?_⟩
+  · rw [frontier_ball c hr.ne']
+    exact hmem.1
+  · rw [closure_ball_inter_sphere hζ hρ hρr]
+    exact ⟨sphere_subset_closedBall hmem.1, hmem.2⟩
 
 /-- **A ball centred at a point of the closed crosscut meets the crosscut in a subarc.** A genuine
 circular crosscut spans an angle `2 * arccos (ρ / (2 * r)) < π`, so along it the chord distance to

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -51,7 +51,7 @@ crosscut arc (`TauCeti.sphere_inter_sphere_eq_pair_circleMap`); for a general do
 whole trace of `frontier U` on the cutting circle, which is where the crosscut can run out of the
 domain, and the cluster sets at points of it not adherent to the crosscut are empty. The equality
 itself allows all of those cluster sets to be empty; as soon as the image crosscut `γ` is bounded
-each end carries one (`TauCeti.nonempty_clusterSetOn_inter_sphere`), and for a disc each is in
+each end carries one (`TauCeti.clusterSetOn_nonempty`), and for a disc each is in
 fact a continuum (`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to
 the boundary of the image at *each* of its ends and the middle piece is where those ends sit.
 
@@ -113,10 +113,9 @@ pseudometric space.
   the image into two pieces and a middle piece adherent to the image crosscut.
 * `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of an image
   crosscut is the image crosscut together with the cluster sets at its ends.
-* `TauCeti.nonempty_clusterSetOn_inter_sphere` and
-  `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — an end cluster set is nonempty once the
-  image of the crosscut is bounded, and, for a disc, connected once `f` is in addition continuous
-  along the crosscut.
+* `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — for a disc an end cluster set is a
+  continuum once `f` is continuous along the crosscut with bounded image; its nonemptiness for a
+  general domain is the generic `TauCeti.clusterSetOn_nonempty`, applied to the crosscut.
 * `TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` — the middle
   piece is *exactly* the union of the end cluster sets, its one-sided inclusion being
   `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`.
@@ -270,16 +269,6 @@ theorem clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (hUo : IsO
       (clusterSetOn_mono inter_subset_left hv))
     fun _ hv => clusterSetOn_subset_closure_image hv
 
-/-- **Each end of a circular crosscut carries a cluster value.** At a point adherent to the
-crosscut, `f` is confined along it to the compact `closure (f '' (U ∩ sphere ζ ρ))`, so the cluster
-set there is nonempty; only the image of the crosscut need be bounded, and no holomorphy is
-needed. -/
-theorem nonempty_clusterSetOn_inter_sphere (hb : IsBounded (f '' (U ∩ sphere ζ ρ)))
-    (he : e ∈ closure (U ∩ sphere ζ ρ)) :
-    (clusterSetOn f (U ∩ sphere ζ ρ) e).Nonempty :=
-  clusterSetOn_nonempty hb.isCompact_closure
-    (fun _ hz => subset_closure (mem_image_of_mem f hz)) he
-
 /-- **Each end of an image crosscut of a disc is a continuum.** For `f` continuous along a genuine
 circular crosscut of a disc and with bounded image *of the crosscut*, the cluster set at either
 endpoint is nonempty and connected; it is compact by
@@ -314,7 +303,7 @@ the index set being, for a disc, the two endpoints of the crosscut
 crosscut clings to is not merely small: it is the union of the cluster sets at its ends. The
 image of the crosscut is not assumed bounded here, so the equality by itself leaves those cluster
 sets possibly empty; add that boundedness and each end adherent to the crosscut carries one by
-`TauCeti.nonempty_clusterSetOn_inter_sphere`, which is what a small connected boundary set
+`TauCeti.clusterSetOn_nonempty`, which is what a small connected boundary set
 enclosing the middle piece — `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — has to
 *join*.
 
@@ -359,8 +348,9 @@ theorem nonempty_frontier_inter_closure_image_inter_sphere (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
     (he : e ∈ frontier U ∩ closure (U ∩ sphere ζ ρ)) :
     (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))).Nonempty := by
-  obtain ⟨v, hv⟩ :=
-    nonempty_clusterSetOn_inter_sphere (hb.subset (image_mono inter_subset_left)) he.2
+  have harc : IsBounded (f '' (U ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
+  obtain ⟨v, hv⟩ := clusterSetOn_nonempty harc.isCompact_closure
+    (fun _ hz => subset_closure (mem_image_of_mem f hz)) he.2
   exact ⟨v, clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1 hv⟩
 
 /-- **A circular crosscut of a disc has an end.** The disc discharges the hypothesis that the
@@ -480,14 +470,14 @@ theorem clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image
   clusterSetOn_inter_sphere_subset_frontier_inter_closure_image isOpen_ball hd hinj
     (by rw [frontier_ball c hr.ne']; exact he.1)
 
-/-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.nonempty_clusterSetOn_inter_sphere`, which asks only that the end be adherent to the
-crosscut. -/
-@[deprecated nonempty_clusterSetOn_inter_sphere (since := "2026-08-04")]
+/-- Deprecated compatibility wrapper for the disc case of `TauCeti.clusterSetOn_nonempty`, which
+asks only that the end be adherent to the crosscut. -/
+@[deprecated clusterSetOn_nonempty (since := "2026-08-04")]
 theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
     (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Nonempty := by
-  refine nonempty_clusterSetOn_inter_sphere hb ?_
+  refine clusterSetOn_nonempty hb.isCompact_closure
+    (fun _ hz => subset_closure (mem_image_of_mem f hz)) ?_
   rw [closure_ball_inter_sphere hζ hρ hρr]
   exact ⟨sphere_subset_closedBall he.1, he.2⟩
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -11,68 +11,78 @@ import TauCeti.Analysis.Complex.Conformal.ClusterSet
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 
 /-!
-# How a circular crosscut splits the image of a domain, and its boundary
+# How a circle splits the image of a domain, and its boundary
 
 `Conformal/Crosscut/Basic.lean` cuts a disc `ball c r` at a boundary point `ζ` by the circle
 `sphere ζ ρ` and proves that the two sides `ball c r ∩ ball ζ ρ` and `ball c r \ closedBall ζ ρ`
-are the two connected components of what is left. `Conformal/CutDiameter.lean` transports the
-two sides of such a cut of an *arbitrary* open `U` to a conformal image and bounds their width by
-the width of the image crosscut together with the boundary piece cut off. This file completes that
-picture on the image side: it splits `frontier (f '' U)`, identifies the middle piece of that
-splitting as the ends of the image crosscut, and supplies — from local connectedness of that
+are the two connected components of what is left; for `0 < ρ < 2 * r` the piece
+`ball c r ∩ sphere ζ ρ` left over is then a genuine *crosscut*, the single arc that
+`Conformal/Crosscut/Endpoints.lean` describes. `Conformal/CutDiameter.lean` transports such a cut
+of an *arbitrary* open `U` to a conformal image and bounds the width of the two sides by the width
+of the image of the cut together with the boundary piece cut off. This file completes that picture
+on the image side: it splits `frontier (f '' U)`, identifies the middle piece of that splitting as
+a union of cluster sets of `f` along the cut, and supplies — from local connectedness of that
 frontier — a small connected boundary set enclosing that middle piece.
+
+Nothing below assumes that `U ∩ sphere ζ ρ` *is* a crosscut. For an arbitrary `U` it may be empty,
+disconnected, or the whole circle, and it need not separate `U`; the statements are about that
+intersection as it stands, and the words *crosscut*, *arc* and *endpoint* are used only where a
+hypothesis puts them there — for a disc, in `TauCeti.isConnected_clusterSetOn_ball_inter_sphere`
+and in the deprecated disc forms of the final section.
 
 ## The decomposition
 
 Write `Ω = f '' U`, `A = f '' (U ∩ ball ζ ρ)`, `B = f '' (U \ closedBall ζ ρ)` for the images of
-the two sides, and `γ = f '' (U ∩ sphere ζ ρ)` for the image crosscut, `f` being holomorphic and
-injective on the open set `U`. Then `Ω = A ∪ γ ∪ B`
-(`TauCeti.image_eq_union_image_crosscut`), and the frontier of a union is covered by the
+the parts of `U` inside and outside the circle, and `γ = f '' (U ∩ sphere ζ ρ)` for the image of the
+part on it, `f` being holomorphic and injective on the open set `U`. Then `Ω = A ∪ γ ∪ B`
+(`TauCeti.image_eq_union_image_inter_sphere`), and the frontier of a union is covered by the
 frontiers of its parts, so a frontier point of `Ω` is a frontier point of `A`, a frontier point of
 `B`, or an adherent point of `γ`:
 
 > `frontier Ω = frontier Ω ∩ frontier A ∪ frontier Ω ∩ closure γ ∪ frontier Ω ∩ frontier B`
 
-(`TauCeti.frontier_image_eq_union_closure_image_inter_sphere`). This is the sense in which a
-crosscut *cuts the image boundary in two*: the two boundary pieces `frontier Ω ∩ frontier A` and
-`frontier Ω ∩ frontier B` cover `frontier Ω` apart from a middle piece no wider than the image
-crosscut itself (`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`), which by the
-length–area estimate of `Conformal/ShortCrosscut.lean` can be made as small as desired.
+(`TauCeti.frontier_image_eq_union_closure_image_inter_sphere`). This is the sense in which the
+circle *cuts the image boundary in two*: the two boundary pieces `frontier Ω ∩ frontier A` and
+`frontier Ω ∩ frontier B` cover `frontier Ω` apart from a middle piece no wider than `γ` itself
+(`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`), which by the length–area estimate of
+`Conformal/ShortCrosscut.lean` can be made as small as desired.
 
 ## The middle piece, and the connected boundary set enclosing it
 
-The middle piece is not merely small, it is *exactly the ends of the image crosscut*
+The middle piece is not merely small, it is *exactly the values `f` clusters at along the cut, at
+the points of `frontier U` on the circle*
 (`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn`):
 
 > `frontier Ω ∩ closure γ = ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f S e`
 
-for `S = U ∩ sphere ζ ρ` the crosscut itself. For a disc the index set is the two endpoints of the
-crosscut arc (`TauCeti.sphere_inter_sphere_eq_pair_circleMap`); for a general domain it is the
-whole trace of `frontier U` on the cutting circle, which is where the crosscut can run out of the
-domain, and the cluster sets at points of it not adherent to the crosscut are empty. The equality
-itself allows all of those cluster sets to be empty; as soon as the image crosscut `γ` is bounded
-each end carries one (`TauCeti.clusterSetOn_nonempty`), and for a disc each is in
-fact a continuum (`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to
-the boundary of the image at *each* of its ends and the middle piece is where those ends sit.
+for `S = U ∩ sphere ζ ρ` the cut itself. For a crosscut of a disc the index set is the two
+endpoints of the crosscut arc (`TauCeti.sphere_inter_sphere_eq_pair_circleMap`); for a general
+domain it is the whole trace of `frontier U` on the cutting circle, which is where `S` can run out
+of the domain, and the cluster sets at points of it not adherent to `S` are empty. The equality
+itself allows all of those cluster sets to be empty; as soon as `γ` is bounded, each point of the
+index set adherent to `S` carries one (`TauCeti.clusterSetOn_nonempty`), and for a crosscut of a
+disc each is in fact a continuum (`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so `γ`
+clings to the boundary of the image wherever the cut leaves the domain, and the middle piece is
+where it does so.
 
-Both inclusions come from the same source. The closure of an image crosscut is the image crosscut
-together with its end cluster sets
-(`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`), because closing the arc
-`U ∩ sphere ζ ρ` adds only points of `frontier U` on the circle — the arc has empty interior, so
-its frontier is its whole closure — and a continuous `f` contributes only its own values over the
-arc itself. A value taken *on* the crosscut lies in the open set `Ω`, which is disjoint from
-`frontier Ω`, so the middle piece can only consist of end cluster values; conversely each end
+Both inclusions come from the same source. The closure of `γ` is `γ` together with those cluster
+sets (`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`), because closing
+`U ∩ sphere ζ ρ` adds only points of `frontier U` on the circle — that intersection has empty
+interior in the plane, so its frontier is its whole closure — and a continuous `f` contributes only
+its own values over the cut itself. A value taken *on* the cut lies in the open set `Ω`, which is
+disjoint from `frontier Ω`, so the middle piece can only consist of cluster values; conversely each
 cluster value lies on `frontier Ω`, since a conformal map is proper
 (`TauCeti.clusterSetOn_subset_frontier_image`), and is adherent to `γ` by construction.
 
-What this does *not* say is that the two ends are joined: the identification is of the middle piece
-with a union of cluster sets, not with a connected subset of `frontier Ω` running between them.
+What this does *not* say is that those cluster sets are joined to one another: the identification is
+of the middle piece with a union of cluster sets, not with a connected subset of `frontier Ω`
+running between them.
 
 That nonemptiness is what the enclosure theorem consumes. If `frontier Ω` is uniformly locally
 connected — which by `TauCeti.IsCompact.isUniformlyLocallyConnected` is exactly local
 connectedness, `frontier Ω` being compact — then for every `ε > 0` there is a single `δ > 0`,
-independent of the boundary point `ζ` and of the crosscut radius `ρ`, such that an image crosscut of
-diameter less than `δ` has its whole middle piece enclosed in a *connected* subset of `frontier Ω`
+independent of the centre `ζ` and the radius `ρ` of the cutting circle, such that a `γ` of diameter
+less than `δ` has its whole middle piece enclosed in a *connected* subset of `frontier Ω`
 of diameter at most `ε` (`TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt`), the general
 enclosure statement `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_superset` applied to the
 middle piece. This is where the local connectedness of `∂Ω` that `Conformal/CutDiameter.lean` names
@@ -80,9 +90,9 @@ as one of its two geometric inputs enters, the other being the length–area est
 
 What is **not** proved here, and is what still separates layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md` from its milestone, is that the resulting connected set
-encloses the boundary piece: that `frontier Ω ∩ frontier A` is contained in it together with the
-image crosscut. Classically that is a separation argument about the closed curve formed by the image
-crosscut and the boundary set, and no part of it is claimed below.
+encloses the boundary piece: that `frontier Ω ∩ frontier A` is contained in it together with `γ`.
+Classically that is a separation argument about the closed curve formed by the image of the cut and
+the boundary set, and no part of it is claimed below.
 
 ## Generality
 
@@ -92,11 +102,12 @@ The domain `U` is an arbitrary open set rather than a disc, matching
 disc-shaped input cannot be handed to a criterion stated for a general domain without first
 specialising the criterion, and the Carathéodory correspondence is a statement about a Jordan
 domain and the disc it is mapped from at once, so both directions of it are served only by the
-general form. Nothing below uses the shape of `U`; the two ends of the crosscut become the trace
-of `frontier U` on the cutting circle, and the disc hypothesis `ρ < 2 * r`, which said that the
-crosscut spans less than a half turn, disappears. The one statement that does use the disc is the
-continuum theorem `TauCeti.isConnected_clusterSetOn_ball_inter_sphere`, whose input is that small
-balls meet the crosscut in a subarc.
+general form. Nothing below uses the shape of `U`; the two endpoints of a crosscut of a disc become
+the trace of `frontier U` on the cutting circle, and the disc hypotheses `dist ζ c = r` and
+`ρ < 2 * r`, which made the cut a crosscut spanning less than a half turn, disappear. The one
+statement that does use the disc is the continuum theorem
+`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`, whose input is that small balls meet the
+crosscut in a subarc.
 
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, everything here is stated for maps of `ℂ`. The two inputs that
@@ -106,27 +117,28 @@ pseudometric space.
 
 ## Main results
 
-* `TauCeti.image_eq_union_image_crosscut` — the image of the domain is the union of the images
-  of the two sides of a crosscut and of the crosscut itself.
+* `TauCeti.image_eq_union_image_inter_sphere` — the image of the domain is the union of the images
+  of the parts of it inside, on, and outside the circle.
 * `TauCeti.frontier_image_subset_union_closure_image_inter_sphere` and
-  `TauCeti.frontier_image_eq_union_closure_image_inter_sphere` — a crosscut cuts the boundary of
-  the image into two pieces and a middle piece adherent to the image crosscut.
-* `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of an image
-  crosscut is the image crosscut together with the cluster sets at its ends.
-* `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — for a disc an end cluster set is a
-  continuum once `f` is continuous along the crosscut with bounded image; its nonemptiness for a
-  general domain is the generic `TauCeti.clusterSetOn_nonempty`, applied to the crosscut.
+  `TauCeti.frontier_image_eq_union_closure_image_inter_sphere` — the circle cuts the boundary of
+  the image into two pieces and a middle piece adherent to the image of the cut.
+* `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of the image of
+  the cut is that image together with the cluster sets of `f` along it.
+* `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — at an endpoint of a crosscut of a disc a
+  cluster set is a continuum once `f` is continuous along the crosscut with bounded image; its
+  nonemptiness for a general domain is the generic `TauCeti.clusterSetOn_nonempty`, applied to the
+  cut.
 * `TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` — the middle
-  piece is *exactly* the union of the end cluster sets, its one-sided inclusion being
+  piece is *exactly* the union of those cluster sets, its one-sided inclusion being
   `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`.
 * `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` and
   `TauCeti.nonempty_frontier_inter_closure_image_inter_sphere` — the middle piece is nonempty
-  and no wider than the image crosscut.
-* `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere` — for a disc the nonemptiness
-  hypothesis of the last two is discharged by an endpoint of the crosscut.
-* `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — a uniformly locally
-  connected image boundary encloses the middle piece of every short image crosscut in a small
-  connected boundary set, at a rate independent of the boundary point and the crosscut radius.
+  and no wider than the image of the cut. For a disc,
+  `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere` in
+  `Conformal/Crosscut/Endpoints.lean` discharges the nonemptiness hypothesis of the second.
+* `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — a uniformly locally connected
+  image boundary encloses the middle piece of every small cut in a small connected boundary set, at
+  a rate independent of the centre and radius of the cutting circle.
 
 The disc signatures these replace are kept as deprecated compatibility wrappers in a final section,
 each naming its generalized replacement.
@@ -157,25 +169,25 @@ variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
 
 /-! ## The three pieces of the image -/
 
-/-- **A circular crosscut splits the image of a domain into three pieces**: the images of the two
-sides and the image crosscut. This is `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` —
-the corresponding identity in the domain — pushed forward, and needs nothing of `f` and nothing of
-`U`. -/
-theorem image_eq_union_image_crosscut (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
+/-- **A circle splits the image of a domain into three pieces**: the images of the parts of the
+domain inside, on, and outside it. This is
+`TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` — the corresponding identity in the
+domain — pushed forward, and needs nothing of `f` and nothing of `U`. -/
+theorem image_eq_union_image_inter_sphere (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
     f '' U =
       f '' (U ∩ ball ζ ρ) ∪ f '' (U ∩ sphere ζ ρ) ∪ f '' (U \ closedBall ζ ρ) := by
   rw [← image_union, ← image_union]
   congr 1
   rw [union_right_comm, ← sdiff_sphere_eq_inter_ball_union_sdiff_closedBall, sdiff_union_inter]
 
-/-! ## The crosscut cuts the boundary of the image in two -/
+/-! ## The circle cuts the boundary of the image in two -/
 
-/-- **The boundary of the image of a domain is covered by the boundaries of the two sides of a
-crosscut together with the closure of the image crosscut.**
+/-- **The boundary of the image of a domain is covered by the boundaries of the images of the parts
+inside and outside the circle together with the closure of the image of the part on it.**
 
 Like the decomposition itself this needs nothing of `f`: the image of the domain is the union of
-the three pieces by `TauCeti.image_eq_union_image_crosscut`, the frontier of a union is covered by
-the frontiers of the two parts by `frontier_union_subset`, and the frontier of the image crosscut
+the three pieces by `TauCeti.image_eq_union_image_inter_sphere`, the frontier of a union is covered
+by the frontiers of the two parts by `frontier_union_subset`, and the frontier of the middle image
 lies in its closure. -/
 theorem frontier_image_subset_union_closure_image_inter_sphere (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ)
     (ρ : ℝ) :
@@ -184,16 +196,16 @@ theorem frontier_image_subset_union_closure_image_inter_sphere (f : ℂ → ℂ)
         frontier (f '' (U \ closedBall ζ ρ)) := by
   have hunion : ∀ s t : Set ℂ, frontier (s ∪ t) ⊆ frontier s ∪ frontier t := fun s t =>
     (frontier_union_subset s t).trans (union_subset_union inter_subset_left inter_subset_right)
-  rw [image_eq_union_image_crosscut f U ζ ρ]
+  rw [image_eq_union_image_inter_sphere f U ζ ρ]
   exact (hunion _ _).trans (union_subset_union
     ((hunion _ _).trans (union_subset_union subset_rfl frontier_subset_closure)) subset_rfl)
 
-/-- **A circular crosscut cuts the boundary of the image into two pieces and a middle piece.** The
-equality form of `TauCeti.frontier_image_subset_union_closure_image_inter_sphere`:
-`frontier (f '' U)` is the union of the two *boundary pieces* the crosscut determines — its
-intersections with the frontiers of the images of the two sides — and of the part of it adherent to
-the image crosscut, which `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` shows to be no
-wider than the image crosscut itself. -/
+/-- **A circle cuts the boundary of the image into two pieces and a middle piece.** The equality
+form of `TauCeti.frontier_image_subset_union_closure_image_inter_sphere`: `frontier (f '' U)` is the
+union of the two *boundary pieces* the circle determines — its intersections with the frontiers of
+the images of the parts of `U` inside and outside the circle — and of the part of it adherent to
+`f '' (U ∩ sphere ζ ρ)`, which `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` shows to
+be no wider than that image itself. -/
 theorem frontier_image_eq_union_closure_image_inter_sphere (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
     frontier (f '' U) =
       frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ)) ∪
@@ -203,39 +215,37 @@ theorem frontier_image_eq_union_closure_image_inter_sphere (f : ℂ → ℂ) (U 
   exact (inter_eq_left.mpr
     (frontier_image_subset_union_closure_image_inter_sphere f U ζ ρ)).symm
 
-/-! ## The ends of the image crosscut -/
+/-! ## Where the cut leaves the domain -/
 
-/-- The frontier of a crosscut arc of an open set consists of the arc itself and of points of the
-frontier of the set on the cutting circle: the arc has empty interior in the plane, so its frontier
-is its whole closure, which sits inside the circle and inside the closure of the domain.
+/-- The frontier of the intersection of a set with a circle is contained in that intersection
+together with the points of the frontier of the set lying on the circle. This is
+`frontier_inter_subset` with the circle's own frontier and closure — both the circle itself —
+filled in, and `closure U` split as `U ∪ frontier U`.
 
 Kept private: it is the elementary topological step of
 `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`, phrased for the one shape of
 cut this file uses. -/
-private lemma frontier_inter_sphere_subset (hρ : 0 < ρ) :
+private lemma frontier_inter_sphere_subset (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
     frontier (U ∩ sphere ζ ρ) ⊆ U ∩ sphere ζ ρ ∪ frontier U ∩ sphere ζ ρ := by
-  have hint : interior (U ∩ sphere ζ ρ) = ∅ := by
-    rw [← subset_empty_iff, ← interior_sphere ζ hρ.ne']
-    exact interior_mono inter_subset_right
-  rw [← closure_sdiff_interior, hint, sdiff_empty]
-  intro z hz
-  have hzs : z ∈ sphere ζ ρ := closure_minimal inter_subset_right isClosed_sphere hz
-  have hzU : z ∈ closure U := closure_mono inter_subset_left hz
-  rw [closure_eq_self_union_frontier] at hzU
-  exact hzU.imp (fun h => ⟨h, hzs⟩) fun h => ⟨h, hzs⟩
+  refine (frontier_inter_subset U (sphere ζ ρ)).trans ?_
+  rw [isClosed_sphere.closure_eq, frontier_sphere' ζ ρ, closure_eq_self_union_frontier,
+    union_inter_distrib_right]
+  exact union_subset subset_union_right subset_rfl
 
-/-- **The closure of an image crosscut is the image crosscut together with its end cluster
-sets.** The crosscut `U ∩ sphere ζ ρ` is an arc whose frontier is its whole closure, and closing it
-adds only points of `frontier U` lying on the cutting circle; a continuous `f` contributes nothing
-new over the arc itself, so all of `closure (f '' arc)` beyond `f '' arc` is cluster values at the
-ends. The cluster-set content is `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`,
-applied to the arc, whose closure is compact because the circle is.
+/-- **The closure of the image of `U ∩ sphere ζ ρ` is that image together with the cluster sets of
+`f` at the points of `frontier U` on the circle.** The set `U ∩ sphere ζ ρ` has empty interior in
+the plane, so its frontier is its whole closure, and closing it adds only points of `frontier U`
+lying on the circle; a continuous `f` contributes nothing new over `U ∩ sphere ζ ρ` itself, so all
+of `closure (f '' (U ∩ sphere ζ ρ))` beyond `f '' (U ∩ sphere ζ ρ)` is cluster values there. The
+cluster-set content is `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`, applied to
+`U ∩ sphere ζ ρ`, whose closure is compact because the circle is.
 
-Only continuity of `f` along the arc is used; `f` need be neither holomorphic nor injective, `U`
-need not be open, and the image need not be bounded. Ends of the circle that the crosscut does not
-reach contribute an empty cluster set, so nothing is claimed about how many ends there are. -/
+Only continuity of `f` on `U ∩ sphere ζ ρ` is used; `f` need be neither holomorphic nor injective,
+`U` need not be open, the image need not be bounded, and the radius is unrestricted. Points of the
+index set not adherent to `U ∩ sphere ζ ρ` contribute an empty cluster set, so nothing is claimed
+about how many of them are met. -/
 theorem closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hfc : ContinuousOn f (U ∩ sphere ζ ρ)) (hρ : 0 < ρ) :
+    (hfc : ContinuousOn f (U ∩ sphere ζ ρ)) :
     closure (f '' (U ∩ sphere ζ ρ)) =
       f '' (U ∩ sphere ζ ρ) ∪
         ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e := by
@@ -247,19 +257,20 @@ theorem closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
       (iUnion₂_subset fun _ _ => clusterSetOn_subset_closure_image))
   rw [closure_image_eq_image_union_biUnion_clusterSetOn hcomp hfc]
   refine union_subset subset_union_left (iUnion₂_subset fun w hw => ?_)
-  rcases frontier_inter_sphere_subset hρ hw with hwarc | hwend
-  · rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwarc (hfc w hwarc)]
-    exact singleton_subset_iff.mpr (subset_union_left (mem_image_of_mem f hwarc))
+  rcases frontier_inter_sphere_subset U ζ ρ hw with hwcut | hwend
+  · rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwcut (hfc w hwcut)]
+    exact singleton_subset_iff.mpr (subset_union_left (mem_image_of_mem f hwcut))
   · exact subset_union_right.trans' (subset_biUnion_of_mem hwend)
 
-/-- **An end cluster set of an image crosscut lies in the middle piece.** For `f` holomorphic and
-injective on an open `U` and a point `e` of `frontier U`, every value `f` clusters at along the
-crosscut as `e` is approached is a boundary value of the image adherent to the image crosscut.
+/-- **A cluster set along `U ∩ sphere ζ ρ` lies in the middle piece.** For `f` holomorphic and
+injective on an open `U` and a point `e` of `frontier U`, every value `f` clusters at along
+`U ∩ sphere ζ ρ` as `e` is approached is a boundary value of the image adherent to
+`f '' (U ∩ sphere ζ ρ)`.
 
-Both halves are already available: the cluster set along the crosscut is contained in the cluster
-set along the whole domain, which `TauCeti.clusterSetOn_subset_frontier_image` — properness of a
-conformal map — puts on `frontier (f '' U)`; and cluster values are adherent to the image of the
-approach set by `TauCeti.clusterSetOn_subset_closure_image`. -/
+Both halves are already available: the cluster set along `U ∩ sphere ζ ρ` is contained in the
+cluster set along the whole domain, which `TauCeti.clusterSetOn_subset_frontier_image` — properness
+of a conformal map — puts on `frontier (f '' U)`; and cluster values are adherent to the image of
+the approach set by `TauCeti.clusterSetOn_subset_closure_image`. -/
 theorem clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (hUo : IsOpen U)
     (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (he : e ∈ frontier U) :
     clusterSetOn f (U ∩ sphere ζ ρ) e ⊆
@@ -277,8 +288,8 @@ endpoint is nonempty and connected; it is compact by
 of the endpoint meet the crosscut in a preconnected set — is exactly
 `TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half turn and
 so meeting each ball centred on it in a subarc. That input is what keeps this statement about a
-disc while its neighbours above are about an arbitrary domain: a general crosscut may meet a small
-ball in many subarcs. -/
+disc while its neighbours above are about an arbitrary domain: a general `U ∩ sphere ζ ρ` may meet
+a small ball in many pieces. -/
 theorem isConnected_clusterSetOn_ball_inter_sphere
     (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
@@ -292,95 +303,75 @@ theorem isConnected_clusterSetOn_ball_inter_sphere
 
 /-! ## The middle piece -/
 
-/-- **The middle piece is exactly the end cluster sets of the image crosscut.** For `f` holomorphic
-and injective on an open `U` and a circle of positive radius,
+/-- **The middle piece is exactly the cluster sets along `U ∩ sphere ζ ρ`.** For `f` holomorphic
+and injective on an open `U`,
 
 > `frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))`
 > `= ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e`,
 
-the index set being, for a disc, the two endpoints of the crosscut
-(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). So the part of the image boundary that the
-crosscut clings to is not merely small: it is the union of the cluster sets at its ends. The
-image of the crosscut is not assumed bounded here, so the equality by itself leaves those cluster
-sets possibly empty; add that boundedness and each end adherent to the crosscut carries one by
-`TauCeti.clusterSetOn_nonempty`, which is what a small connected boundary set
-enclosing the middle piece — `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — has to
-*join*.
+the index set being, for a crosscut of a disc, the two endpoints of the crosscut arc
+(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). So the part of the image boundary that
+`f '' (U ∩ sphere ζ ρ)` clings to is not merely small: it is the union of those cluster sets. That
+image is not assumed bounded here, so the equality by itself leaves the cluster sets possibly
+empty; add that boundedness and every point of the index set adherent to `U ∩ sphere ζ ρ` carries
+one by `TauCeti.clusterSetOn_nonempty`, which is what a small connected boundary set enclosing the
+middle piece — `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — has to *join*.
 
-One inclusion is `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`. For
-the other, `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` splits a point
-of the closure of the image crosscut into a value on the crosscut and a cluster value at an end,
-and a value on the crosscut lies in the *open* image `f '' U`, which is disjoint from its own
-frontier. -/
+One inclusion is `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`. For the
+other, `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` splits a point of
+`closure (f '' (U ∩ sphere ζ ρ))` into a value taken on `U ∩ sphere ζ ρ` and a cluster value, and a
+value taken there lies in the *open* image `f '' U`, which is disjoint from its own frontier. -/
 theorem frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hρ : 0 < ρ) :
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) :
     frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) =
       ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e := by
   refine subset_antisymm ?_ (iUnion₂_subset fun e he =>
     clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1)
   rintro v ⟨hvfr, hvcl⟩
   rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hd.continuousOn.mono inter_subset_left) hρ] at hvcl
+    (hd.continuousOn.mono inter_subset_left)] at hvcl
   refine hvcl.resolve_left fun hv => ?_
   have hopen : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
   exact (hopen.frontier_eq ▸ hvfr).2 (image_mono inter_subset_left hv)
 
-/-- **The middle piece is no wider than the image crosscut.** It is contained in the closure of the
-image crosscut, and closing a set does not change its diameter. -/
-theorem diam_frontier_inter_closure_image_inter_sphere_le (hb : IsBounded (f '' U)) (ζ : ℂ)
-    (ρ : ℝ) :
+/-- **The middle piece is no wider than the image of `U ∩ sphere ζ ρ`.** It is contained in the
+closure of that image, and closing a set does not change its diameter. Only that image is asked to
+be bounded; the image of `U` itself need not be. -/
+theorem diam_frontier_inter_closure_image_inter_sphere_le
+    (hb : IsBounded (f '' (U ∩ sphere ζ ρ))) :
     diam (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
-      ≤ diam (f '' (U ∩ sphere ζ ρ)) := by
-  have harc : IsBounded (f '' (U ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
+      ≤ diam (f '' (U ∩ sphere ζ ρ)) :=
   calc diam (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
-      ≤ diam (closure (f '' (U ∩ sphere ζ ρ))) := diam_mono inter_subset_right harc.closure
+      ≤ diam (closure (f '' (U ∩ sphere ζ ρ))) := diam_mono inter_subset_right hb.closure
     _ = diam (f '' (U ∩ sphere ζ ρ)) := diam_closure _
 
-/-- **The middle piece is nonempty**: for `f` holomorphic and injective on an open `U` with bounded
-image, and a crosscut with an end `e` — a point of `frontier U` adherent to the crosscut — the set
-`frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))` has a point. So the image crosscut does cling
-to the boundary of the image, and — by
+/-- **The middle piece is nonempty**: for `f` holomorphic and injective on an open `U`, a bounded
+image of `U ∩ sphere ζ ρ` and a point `e` of `frontier U` adherent to `U ∩ sphere ζ ρ`, the set
+`frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))` has a point. So the image of `U ∩ sphere ζ ρ`
+does cling to the boundary of the image, and — by
 `TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` — it does so at each
-such end.
+such `e`.
 
-The cluster set of `f` along the crosscut at `e` is nonempty and contained in the middle piece. -/
+The cluster set of `f` along `U ∩ sphere ζ ρ` at `e` is nonempty and contained in the middle
+piece. As for the diameter bound, only the image of `U ∩ sphere ζ ρ` is asked to be bounded. -/
 theorem nonempty_frontier_inter_closure_image_inter_sphere (hUo : IsOpen U)
-    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' (U ∩ sphere ζ ρ)))
     (he : e ∈ frontier U ∩ closure (U ∩ sphere ζ ρ)) :
     (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))).Nonempty := by
-  have harc : IsBounded (f '' (U ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
-  obtain ⟨v, hv⟩ := clusterSetOn_nonempty harc.isCompact_closure
+  obtain ⟨v, hv⟩ := clusterSetOn_nonempty hb.isCompact_closure
     (fun _ hz => subset_closure (mem_image_of_mem f hz)) he.2
   exact ⟨v, clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1 hv⟩
 
-/-- **A circular crosscut of a disc has an end.** The disc discharges the hypothesis that the
-crosscut reaches `frontier U`: a crosscut spanning less than a half turn has two endpoints
-(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and either of them lies on `sphere c r`, the
-frontier of the disc, and in the closure of the crosscut
-(`TauCeti.closure_ball_inter_sphere`). -/
-theorem nonempty_frontier_ball_inter_closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
-    (hρr : ρ < 2 * r) :
-    (frontier (ball c r) ∩ closure (ball c r ∩ sphere ζ ρ)).Nonempty := by
-  have hr : 0 < r := by linarith
-  have hmem : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
-      ∈ sphere c r ∩ sphere ζ ρ := by
-    rw [sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr]
-    exact Or.inl rfl
-  refine ⟨circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))), ?_, ?_⟩
-  · rw [frontier_ball c hr.ne']
-    exact hmem.1
-  · rw [closure_ball_inter_sphere hζ hρ hρr]
-    exact ⟨sphere_subset_closedBall hmem.1, hmem.2⟩
-
 /-! ## The small connected set enclosing the middle piece -/
 
-/-- **A uniformly locally connected image boundary encloses the middle piece of every short image
-crosscut in a small connected boundary set.** For `f` holomorphic and injective on an open `U` with
-bounded image and `frontier (f '' U)` uniformly locally connected, every `ε > 0` admits a single
-`δ > 0` — independent of the boundary point `ζ` and of the crosscut radius `ρ` — such that an image
-crosscut of diameter less than `δ` has its middle piece contained in a connected subset of
-`frontier (f '' U)` of diameter at most `ε`. The crosscut is asked to have an end, which for a disc
-is `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`; a cut missing `frontier U`
+/-- **A uniformly locally connected image boundary encloses the middle piece of every small cut in
+a small connected boundary set.** For `f` holomorphic and injective on an open `U` with bounded
+image and `frontier (f '' U)` uniformly locally connected, every `ε > 0` admits a single `δ > 0` —
+independent of the centre `ζ` and the radius `ρ` of the cutting circle — such that whenever
+`f '' (U ∩ sphere ζ ρ)` has diameter less than `δ`, the middle piece is contained in a connected
+subset of `frontier (f '' U)` of diameter at most `ε`. The cut is asked to reach `frontier U`,
+which for a circular crosscut of a disc is
+`TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`; a cut missing `frontier U`
 altogether has an empty middle piece and nothing to enclose.
 
 This is where the local connectedness of `∂Ω` that
@@ -404,27 +395,32 @@ theorem exists_isConnected_subset_frontier_image_of_diam_lt (hUo : IsOpen U)
           frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) ⊆ S ∧ diam S ≤ ε := by
   obtain ⟨δ, hδ, hencl⟩ := hulc.exists_isConnected_superset hε
   refine ⟨δ, hδ, fun ζ ρ ⟨w, hw⟩ hdiam => ?_⟩
-  refine hencl _ inter_subset_left
-    (((hb.subset (image_mono inter_subset_left)).closure).subset inter_subset_right)
-    (nonempty_frontier_inter_closure_image_inter_sphere hUo hd hinj hb hw) ?_
-  exact lt_of_le_of_lt (diam_frontier_inter_closure_image_inter_sphere_le hb ζ ρ) hdiam
+  have hcut : IsBounded (f '' (U ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
+  exact hencl _ inter_subset_left (hcut.closure.subset inter_subset_right)
+    (nonempty_frontier_inter_closure_image_inter_sphere hUo hd hinj hcut hw)
+    (lt_of_le_of_lt (diam_frontier_inter_closure_image_inter_sphere_le hcut) hdiam)
 
 /-! ## Deprecated disc-specific forms
 
-Everything above was stated for `U = ball c r`. The old signatures are retained here as deprecated
-compatibility wrappers, each naming its generalized replacement; the openness hypothesis is
-discharged by `Metric.isOpen_ball`, `Metric.frontier_ball` turns `frontier U` back into
-`sphere c r`, and `TauCeti.closure_ball_inter_sphere` turns the closure of the crosscut back into
-`closedBall c r ∩ sphere ζ ρ`. -/
+The statements above used to be made only for `U = ball c r`. Their old signatures are retained here
+as deprecated compatibility wrappers, each naming its generalized replacement; the openness
+hypothesis is discharged by `Metric.isOpen_ball`, `Metric.frontier_ball` turns `frontier U` back
+into `sphere c r`, and `TauCeti.closure_ball_inter_sphere` turns the closure of the crosscut back
+into `closedBall c r ∩ sphere ζ ρ`.
+
+Hypotheses that the generalization no longer needs are kept, in their old positions, so that every
+former application still elaborates; they are named `_hζ` because the unused-variable linter rejects
+a referenced-nowhere binder name, and a positional or `_`-prefixed named argument reaches them
+either way. -/
 
 /-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.image_eq_union_image_crosscut`. -/
-@[deprecated image_eq_union_image_crosscut (since := "2026-08-04")]
+`TauCeti.image_eq_union_image_inter_sphere`. -/
+@[deprecated image_eq_union_image_inter_sphere (since := "2026-08-04")]
 theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
     f '' ball c r =
       f '' (ball c r ∩ ball ζ ρ) ∪ f '' (ball c r ∩ sphere ζ ρ) ∪
         f '' (ball c r \ closedBall ζ ρ) :=
-  image_eq_union_image_crosscut f (ball c r) ζ ρ
+  image_eq_union_image_inter_sphere f (ball c r) ζ ρ
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.frontier_image_subset_union_closure_image_inter_sphere`. -/
@@ -450,13 +446,14 @@ theorem frontier_image_ball_eq_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ)
 `dist ζ c = r` nor `ρ < 2 * r`. -/
 @[deprecated closure_image_inter_sphere_eq_union_biUnion_clusterSetOn (since := "2026-08-04")]
 theorem closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (_hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) :
     closure (f '' (ball c r ∩ sphere ζ ρ)) =
       f '' (ball c r ∩ sphere ζ ρ) ∪
         ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
   have hr : 0 < r := by linarith
   rw [← frontier_ball c hr.ne']
-  exact closure_image_inter_sphere_eq_union_biUnion_clusterSetOn hfc hρ
+  exact closure_image_inter_sphere_eq_union_biUnion_clusterSetOn hfc
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`, which asks only that the
@@ -487,13 +484,13 @@ theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' (ball c r 
 @[deprecated frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn
   (since := "2026-08-04")]
 theorem frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hρ : 0 < ρ)
-    (hρr : ρ < 2 * r) :
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (_hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
     frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) =
       ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
   have hr : 0 < r := by linarith
   rw [← frontier_ball c hr.ne']
-  exact frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn isOpen_ball hd hinj hρ
+  exact frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn isOpen_ball hd hinj
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`. -/
@@ -502,7 +499,7 @@ theorem diam_frontier_inter_closure_image_ball_inter_sphere_le (hb : IsBounded (
     (ζ : ℂ) (ρ : ℝ) :
     diam (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)))
       ≤ diam (f '' (ball c r ∩ sphere ζ ρ)) :=
-  diam_frontier_inter_closure_image_inter_sphere_le hb ζ ρ
+  diam_frontier_inter_closure_image_inter_sphere_le (hb.subset (image_mono inter_subset_left))
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.nonempty_frontier_inter_closure_image_inter_sphere`, whose end the disc supplies through
@@ -513,7 +510,8 @@ theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
     (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
     (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Nonempty :=
   let ⟨_, he⟩ := nonempty_frontier_ball_inter_closure_ball_inter_sphere hζ hρ hρr
-  nonempty_frontier_inter_closure_image_inter_sphere isOpen_ball hd hinj hb he
+  nonempty_frontier_inter_closure_image_inter_sphere isOpen_ball hd hinj
+    (hb.subset (image_mono inter_subset_left)) he
 
 /-- Deprecated compatibility wrapper for the disc case of
 `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt`, whose end the disc supplies through

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean
@@ -11,72 +11,72 @@ import TauCeti.Analysis.Complex.Conformal.ClusterSet
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 
 /-!
-# How a circular crosscut splits the image of a disc, and its boundary
+# How a circular crosscut splits the image of a domain, and its boundary
 
 `Conformal/Crosscut/Basic.lean` cuts a disc `ball c r` at a boundary point `ζ` by the circle
 `sphere ζ ρ` and proves that the two sides `ball c r ∩ ball ζ ρ` and `ball c r \ closedBall ζ ρ`
 are the two connected components of what is left. `Conformal/CutDiameter.lean` transports the
-two sides to a conformal image and bounds their width by the width of the image crosscut together
-with the boundary piece cut off. This file completes that picture on the image side: it splits
-`frontier (f '' ball c r)`, identifies the middle piece of that splitting as the two ends of the
-image crosscut, and supplies — from local connectedness of that frontier — a small connected
-boundary set enclosing that middle piece.
+two sides of such a cut of an *arbitrary* open `U` to a conformal image and bounds their width by
+the width of the image crosscut together with the boundary piece cut off. This file completes that
+picture on the image side: it splits `frontier (f '' U)`, identifies the middle piece of that
+splitting as the ends of the image crosscut, and supplies — from local connectedness of that
+frontier — a small connected boundary set enclosing that middle piece.
 
 ## The decomposition
 
-Write `Ω = f '' ball c r`, `A = f '' (ball c r ∩ ball ζ ρ)`, `B = f '' (ball c r \ closedBall ζ ρ)`
-for the images of the two sides, and `γ = f '' (ball c r ∩ sphere ζ ρ)` for the image crosscut, `f`
-being holomorphic and injective on the disc. Then `Ω = A ∪ γ ∪ B`
-(`TauCeti.image_ball_eq_union_image_crosscut`), and the frontier of a union is covered by the
+Write `Ω = f '' U`, `A = f '' (U ∩ ball ζ ρ)`, `B = f '' (U \ closedBall ζ ρ)` for the images of
+the two sides, and `γ = f '' (U ∩ sphere ζ ρ)` for the image crosscut, `f` being holomorphic and
+injective on the open set `U`. Then `Ω = A ∪ γ ∪ B`
+(`TauCeti.image_eq_union_image_crosscut`), and the frontier of a union is covered by the
 frontiers of its parts, so a frontier point of `Ω` is a frontier point of `A`, a frontier point of
 `B`, or an adherent point of `γ`:
 
 > `frontier Ω = frontier Ω ∩ frontier A ∪ frontier Ω ∩ closure γ ∪ frontier Ω ∩ frontier B`
 
-(`TauCeti.frontier_image_ball_eq_union`). This is the sense in which a crosscut *cuts the image
-boundary in two*: the two boundary pieces `frontier Ω ∩ frontier A` and `frontier Ω ∩ frontier B`
-cover `frontier Ω` apart from a middle piece no wider than the image crosscut itself
-(`TauCeti.diam_frontier_inter_closure_image_ball_inter_sphere_le`), which by the length–area
-estimate of `Conformal/ShortCrosscut.lean` can be made as small as desired.
+(`TauCeti.frontier_image_eq_union_closure_image_inter_sphere`). This is the sense in which a
+crosscut *cuts the image boundary in two*: the two boundary pieces `frontier Ω ∩ frontier A` and
+`frontier Ω ∩ frontier B` cover `frontier Ω` apart from a middle piece no wider than the image
+crosscut itself (`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`), which by the
+length–area estimate of `Conformal/ShortCrosscut.lean` can be made as small as desired.
 
 ## The middle piece, and the connected boundary set enclosing it
 
-The middle piece is not merely small, it is *exactly the two ends of the image crosscut*
-(`TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn`):
+The middle piece is not merely small, it is *exactly the ends of the image crosscut*
+(`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn`):
 
-> `frontier Ω ∩ closure γ = ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f S e`
+> `frontier Ω ∩ closure γ = ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f S e`
 
-for `S = ball c r ∩ sphere ζ ρ` the crosscut itself, the index set being its two endpoints
-(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). The equality itself allows the two cluster sets
-to be empty; as soon as the image crosscut `γ` is bounded each of them is nonempty
-(`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`) and in fact a continuum
-(`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), and then the crosscut clings to the boundary
-of the image at *each* of its ends and the middle piece is where those two ends sit.
+for `S = U ∩ sphere ζ ρ` the crosscut itself. For a disc the index set is the two endpoints of the
+crosscut arc (`TauCeti.sphere_inter_sphere_eq_pair_circleMap`); for a general domain it is the
+whole trace of `frontier U` on the cutting circle, which is where the crosscut can run out of the
+domain, and the cluster sets at points of it not adherent to the crosscut are empty. The equality
+itself allows all of those cluster sets to be empty; as soon as the image crosscut `γ` is bounded
+each end carries one (`TauCeti.nonempty_clusterSetOn_inter_sphere`), and for a disc each is in
+fact a continuum (`TauCeti.isConnected_clusterSetOn_ball_inter_sphere`), so the crosscut clings to
+the boundary of the image at *each* of its ends and the middle piece is where those ends sit.
 
 Both inclusions come from the same source. The closure of an image crosscut is the image crosscut
-together with its two end cluster sets
-(`TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn`), because closing the open
-arc `ball c r ∩ sphere ζ ρ` adds exactly the two points of `sphere c r ∩ sphere ζ ρ` and a
-continuous `f` contributes only its own values over the arc itself. A value taken *on* the crosscut
-lies in the open set `Ω`, which is disjoint from `frontier Ω`, so the middle piece can only consist
-of end cluster values; conversely each end cluster value lies on `frontier Ω`, since a conformal
-map is proper (`TauCeti.clusterSetOn_subset_frontier_image`), and is adherent to `γ` by
-construction.
+together with its end cluster sets
+(`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`), because closing the arc
+`U ∩ sphere ζ ρ` adds only points of `frontier U` on the circle — the arc has empty interior, so
+its frontier is its whole closure — and a continuous `f` contributes only its own values over the
+arc itself. A value taken *on* the crosscut lies in the open set `Ω`, which is disjoint from
+`frontier Ω`, so the middle piece can only consist of end cluster values; conversely each end
+cluster value lies on `frontier Ω`, since a conformal map is proper
+(`TauCeti.clusterSetOn_subset_frontier_image`), and is adherent to `γ` by construction.
 
 What this does *not* say is that the two ends are joined: the identification is of the middle piece
-with the union of two cluster sets, not with a connected subset of `frontier Ω` running between
-them.
+with a union of cluster sets, not with a connected subset of `frontier Ω` running between them.
 
 That nonemptiness is what the enclosure theorem consumes. If `frontier Ω` is uniformly locally
 connected — which by `TauCeti.IsCompact.isUniformlyLocallyConnected` is exactly local
 connectedness, `frontier Ω` being compact — then for every `ε > 0` there is a single `δ > 0`,
-independent of the
-boundary point `ζ` and of the crosscut radius `ρ`, such that an image crosscut of diameter less than
-`δ` has its whole middle piece enclosed in a *connected* subset of `frontier Ω` of diameter at most
-`ε` (`TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt`), the general enclosure
-statement `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_superset` applied to the middle
-piece. This is where the local connectedness of `∂Ω` that `Conformal/CutDiameter.lean` names as one
-of its two geometric inputs enters, the other being the length–area estimate.
+independent of the boundary point `ζ` and of the crosscut radius `ρ`, such that an image crosscut of
+diameter less than `δ` has its whole middle piece enclosed in a *connected* subset of `frontier Ω`
+of diameter at most `ε` (`TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt`), the general
+enclosure statement `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_superset` applied to the
+middle piece. This is where the local connectedness of `∂Ω` that `Conformal/CutDiameter.lean` names
+as one of its two geometric inputs enters, the other being the length–area estimate.
 
 What is **not** proved here, and is what still separates layer **L5** of
 `TauCetiRoadmap/ConformalMapping/README.md` from its milestone, is that the resulting connected set
@@ -86,6 +86,18 @@ crosscut and the boundary set, and no part of it is claimed below.
 
 ## Generality
 
+The domain `U` is an arbitrary open set rather than a disc, matching
+`Conformal/CutDiameter.lean`, whose criterion
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` these results feed: a
+disc-shaped input cannot be handed to a criterion stated for a general domain without first
+specialising the criterion, and the Carathéodory correspondence is a statement about a Jordan
+domain and the disc it is mapped from at once, so both directions of it are served only by the
+general form. Nothing below uses the shape of `U`; the two ends of the crosscut become the trace
+of `frontier U` on the cutting circle, and the disc hypothesis `ρ < 2 * r`, which said that the
+crosscut spans less than a half turn, disappears. The one statement that does use the disc is the
+continuum theorem `TauCeti.isConnected_clusterSetOn_ball_inter_sphere`, whose input is that small
+balls meet the crosscut in a subarc.
+
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, everything here is stated for maps of `ℂ`. The two inputs that
 are not about conformality are stated at their own generality elsewhere: `TauCeti.diam_frontier`
@@ -94,26 +106,31 @@ pseudometric space.
 
 ## Main results
 
-* `TauCeti.image_ball_eq_union_image_crosscut` — the image of the disc is the union of the images
+* `TauCeti.image_eq_union_image_crosscut` — the image of the domain is the union of the images
   of the two sides of a crosscut and of the crosscut itself.
-* `TauCeti.frontier_image_ball_subset_union` and `TauCeti.frontier_image_ball_eq_union` — a
-  crosscut cuts the boundary of the image into two pieces and a middle piece adherent to the image
-  crosscut.
-* `TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of an image
-  crosscut is the image crosscut together with the cluster sets at its two endpoints.
-* `TauCeti.nonempty_clusterSetOn_ball_inter_sphere` and
-  `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — each of those two end cluster sets is
-  nonempty once the image of the crosscut is bounded, and connected once `f` is in addition
-  continuous along the crosscut.
-* `TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` — the middle
-  piece is *exactly* the union of the two end cluster sets, its one-sided inclusion being
-  `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`.
-* `TauCeti.diam_frontier_inter_closure_image_ball_inter_sphere_le` and
-  `TauCeti.nonempty_frontier_inter_closure_image_ball_inter_sphere` — the middle piece is nonempty
+* `TauCeti.frontier_image_subset_union_closure_image_inter_sphere` and
+  `TauCeti.frontier_image_eq_union_closure_image_inter_sphere` — a crosscut cuts the boundary of
+  the image into two pieces and a middle piece adherent to the image crosscut.
+* `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` — the closure of an image
+  crosscut is the image crosscut together with the cluster sets at its ends.
+* `TauCeti.nonempty_clusterSetOn_inter_sphere` and
+  `TauCeti.isConnected_clusterSetOn_ball_inter_sphere` — an end cluster set is nonempty once the
+  image of the crosscut is bounded, and, for a disc, connected once `f` is in addition continuous
+  along the crosscut.
+* `TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` — the middle
+  piece is *exactly* the union of the end cluster sets, its one-sided inclusion being
+  `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`.
+* `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` and
+  `TauCeti.nonempty_frontier_inter_closure_image_inter_sphere` — the middle piece is nonempty
   and no wider than the image crosscut.
-* `TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` — a uniformly locally
+* `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere` — for a disc the nonemptiness
+  hypothesis of the last two is discharged by an endpoint of the crosscut.
+* `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — a uniformly locally
   connected image boundary encloses the middle piece of every short image crosscut in a small
   connected boundary set, at a rate independent of the boundary point and the crosscut radius.
+
+The disc signatures these replace are kept as deprecated compatibility wrappers in a final section,
+each naming its generalized replacement.
 
 ## Coordination with upstream Mathlib
 
@@ -137,133 +154,142 @@ namespace TauCeti
 
 open Bornology Complex Filter Metric Set Topology
 
-variable {f : ℂ → ℂ} {c ζ e : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ e : ℂ} {r ρ : ℝ}
 
 /-! ## The three pieces of the image -/
 
-/-- **A circular crosscut splits the image of a disc into three pieces**: the images of the two
+/-- **A circular crosscut splits the image of a domain into three pieces**: the images of the two
 sides and the image crosscut. This is `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` —
-the corresponding identity in the disc — pushed forward, and needs nothing of `f`. -/
-theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
-    f '' ball c r =
-      f '' (ball c r ∩ ball ζ ρ) ∪ f '' (ball c r ∩ sphere ζ ρ) ∪
-        f '' (ball c r \ closedBall ζ ρ) := by
+the corresponding identity in the domain — pushed forward, and needs nothing of `f` and nothing of
+`U`. -/
+theorem image_eq_union_image_crosscut (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
+    f '' U =
+      f '' (U ∩ ball ζ ρ) ∪ f '' (U ∩ sphere ζ ρ) ∪ f '' (U \ closedBall ζ ρ) := by
   rw [← image_union, ← image_union]
   congr 1
   rw [union_right_comm, ← sdiff_sphere_eq_inter_ball_union_sdiff_closedBall, sdiff_union_inter]
 
 /-! ## The crosscut cuts the boundary of the image in two -/
 
-/-- **The boundary of the image of a disc is covered by the boundaries of the two sides of a
+/-- **The boundary of the image of a domain is covered by the boundaries of the two sides of a
 crosscut together with the closure of the image crosscut.**
 
-Like the decomposition itself this needs nothing of `f`: the image of the disc is the union of the
-three pieces by `TauCeti.image_ball_eq_union_image_crosscut`, the frontier of a union is covered by
+Like the decomposition itself this needs nothing of `f`: the image of the domain is the union of
+the three pieces by `TauCeti.image_eq_union_image_crosscut`, the frontier of a union is covered by
 the frontiers of the two parts by `frontier_union_subset`, and the frontier of the image crosscut
 lies in its closure. -/
-theorem frontier_image_ball_subset_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
-    frontier (f '' ball c r) ⊆
-      frontier (f '' (ball c r ∩ ball ζ ρ)) ∪ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪
-        frontier (f '' (ball c r \ closedBall ζ ρ)) := by
+theorem frontier_image_subset_union_closure_image_inter_sphere (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ)
+    (ρ : ℝ) :
+    frontier (f '' U) ⊆
+      frontier (f '' (U ∩ ball ζ ρ)) ∪ closure (f '' (U ∩ sphere ζ ρ)) ∪
+        frontier (f '' (U \ closedBall ζ ρ)) := by
   have hunion : ∀ s t : Set ℂ, frontier (s ∪ t) ⊆ frontier s ∪ frontier t := fun s t =>
     (frontier_union_subset s t).trans (union_subset_union inter_subset_left inter_subset_right)
-  rw [image_ball_eq_union_image_crosscut f c ζ r ρ]
+  rw [image_eq_union_image_crosscut f U ζ ρ]
   exact (hunion _ _).trans (union_subset_union
     ((hunion _ _).trans (union_subset_union subset_rfl frontier_subset_closure)) subset_rfl)
 
 /-- **A circular crosscut cuts the boundary of the image into two pieces and a middle piece.** The
-equality form of `TauCeti.frontier_image_ball_subset_union`: `frontier (f '' ball c r)` is the union
-of the two *boundary pieces* the crosscut determines — its intersections with the frontiers of the
-images of the two sides — and of the part of it adherent to the image crosscut, which
-`TauCeti.diam_frontier_inter_closure_image_ball_inter_sphere_le` shows to be no wider than the
-image crosscut itself. -/
-theorem frontier_image_ball_eq_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
-    frontier (f '' ball c r) =
-      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ∪
-        frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪
-        frontier (f '' ball c r) ∩ frontier (f '' (ball c r \ closedBall ζ ρ)) := by
+equality form of `TauCeti.frontier_image_subset_union_closure_image_inter_sphere`:
+`frontier (f '' U)` is the union of the two *boundary pieces* the crosscut determines — its
+intersections with the frontiers of the images of the two sides — and of the part of it adherent to
+the image crosscut, which `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` shows to be no
+wider than the image crosscut itself. -/
+theorem frontier_image_eq_union_closure_image_inter_sphere (f : ℂ → ℂ) (U : Set ℂ) (ζ : ℂ) (ρ : ℝ) :
+    frontier (f '' U) =
+      frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ)) ∪
+        frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) ∪
+        frontier (f '' U) ∩ frontier (f '' (U \ closedBall ζ ρ)) := by
   rw [← inter_union_distrib_left, ← inter_union_distrib_left]
-  exact (inter_eq_left.mpr (frontier_image_ball_subset_union f c ζ r ρ)).symm
+  exact (inter_eq_left.mpr
+    (frontier_image_subset_union_closure_image_inter_sphere f U ζ ρ)).symm
 
-/-! ## The two ends of the image crosscut -/
+/-! ## The ends of the image crosscut -/
 
-/-- **The closure of an image crosscut is the image crosscut together with its two end cluster
-sets.** The crosscut `ball c r ∩ sphere ζ ρ` is an open arc whose closure adds exactly the two
-points of `sphere c r ∩ sphere ζ ρ`
-(`TauCeti.closure_ball_inter_sphere`, `TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and a
-continuous `f` contributes nothing new over the arc itself, so all of `closure (f '' arc)` beyond
-`f '' arc` is cluster values at the two ends. The cluster-set content is
-`TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`, applied to the arc, whose frontier is
-its whole closure because an arc has empty interior in the plane.
+/-- The frontier of a crosscut arc of an open set consists of the arc itself and of points of the
+frontier of the set on the cutting circle: the arc has empty interior in the plane, so its frontier
+is its whole closure, which sits inside the circle and inside the closure of the domain.
 
-Only continuity along the arc is used; `f` need be neither holomorphic nor injective, and the
-image need not be bounded. -/
-theorem closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hζ : dist ζ c = r) (hρ : 0 < ρ)
-    (hρr : ρ < 2 * r) :
-    closure (f '' (ball c r ∩ sphere ζ ρ)) =
-      f '' (ball c r ∩ sphere ζ ρ) ∪
-        ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
-  have hcl : closure (ball c r ∩ sphere ζ ρ) = closedBall c r ∩ sphere ζ ρ :=
-    closure_ball_inter_sphere hζ hρ hρr
-  have hcomp : IsCompact (closure (ball c r ∩ sphere ζ ρ)) := by
-    rw [hcl]
-    exact (isCompact_closedBall c r).inter_right isClosed_sphere
-  -- the crosscut is an arc, so it has empty interior and its frontier is its whole closure
-  have hint : interior (ball c r ∩ sphere ζ ρ) = ∅ := by
+Kept private: it is the elementary topological step of
+`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`, phrased for the one shape of
+cut this file uses. -/
+private lemma frontier_inter_sphere_subset (hρ : 0 < ρ) :
+    frontier (U ∩ sphere ζ ρ) ⊆ U ∩ sphere ζ ρ ∪ frontier U ∩ sphere ζ ρ := by
+  have hint : interior (U ∩ sphere ζ ρ) = ∅ := by
     rw [← subset_empty_iff, ← interior_sphere ζ hρ.ne']
     exact interior_mono inter_subset_right
-  have hfr : frontier (ball c r ∩ sphere ζ ρ) =
-      (ball c r ∩ sphere ζ ρ) ∪ (sphere c r ∩ sphere ζ ρ) := by
-    rw [← closure_sdiff_interior, hint, sdiff_empty, hcl, ← ball_union_sphere,
-      union_inter_distrib_right]
-  have harc : ⋃ w ∈ ball c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) w
-      ⊆ f '' (ball c r ∩ sphere ζ ρ) := by
-    refine iUnion₂_subset fun w hw => ?_
-    rw [clusterSetOn_eq_singleton_of_continuousWithinAt hw (hfc w hw)]
-    exact singleton_subset_iff.mpr (mem_image_of_mem f hw)
-  rw [closure_image_eq_image_union_biUnion_clusterSetOn hcomp hfc, hfr, biUnion_union,
-    ← union_assoc, union_eq_self_of_subset_right harc]
+  rw [← closure_sdiff_interior, hint, sdiff_empty]
+  intro z hz
+  have hzs : z ∈ sphere ζ ρ := closure_minimal inter_subset_right isClosed_sphere hz
+  have hzU : z ∈ closure U := closure_mono inter_subset_left hz
+  rw [closure_eq_self_union_frontier] at hzU
+  exact hzU.imp (fun h => ⟨h, hzs⟩) fun h => ⟨h, hzs⟩
+
+/-- **The closure of an image crosscut is the image crosscut together with its end cluster
+sets.** The crosscut `U ∩ sphere ζ ρ` is an arc whose frontier is its whole closure, and closing it
+adds only points of `frontier U` lying on the cutting circle; a continuous `f` contributes nothing
+new over the arc itself, so all of `closure (f '' arc)` beyond `f '' arc` is cluster values at the
+ends. The cluster-set content is `TauCeti.closure_image_eq_image_union_biUnion_clusterSetOn`,
+applied to the arc, whose closure is compact because the circle is.
+
+Only continuity of `f` along the arc is used; `f` need be neither holomorphic nor injective, `U`
+need not be open, and the image need not be bounded. Ends of the circle that the crosscut does not
+reach contribute an empty cluster set, so nothing is claimed about how many ends there are. -/
+theorem closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hfc : ContinuousOn f (U ∩ sphere ζ ρ)) (hρ : 0 < ρ) :
+    closure (f '' (U ∩ sphere ζ ρ)) =
+      f '' (U ∩ sphere ζ ρ) ∪
+        ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e := by
+  have hcomp : IsCompact (closure (U ∩ sphere ζ ρ)) :=
+    (isCompact_sphere ζ ρ).of_isClosed_subset isClosed_closure
+      (closure_minimal inter_subset_right isClosed_sphere)
+  refine subset_antisymm ?_
+    (union_subset subset_closure
+      (iUnion₂_subset fun _ _ => clusterSetOn_subset_closure_image))
+  rw [closure_image_eq_image_union_biUnion_clusterSetOn hcomp hfc]
+  refine union_subset subset_union_left (iUnion₂_subset fun w hw => ?_)
+  rcases frontier_inter_sphere_subset hρ hw with hwarc | hwend
+  · rw [clusterSetOn_eq_singleton_of_continuousWithinAt hwarc (hfc w hwarc)]
+    exact singleton_subset_iff.mpr (subset_union_left (mem_image_of_mem f hwarc))
+  · exact subset_union_right.trans' (subset_biUnion_of_mem hwend)
 
 /-- **An end cluster set of an image crosscut lies in the middle piece.** For `f` holomorphic and
-injective on `ball c r` and an endpoint `e` of a circular crosscut, every value `f` clusters at
-along the crosscut as `e` is approached is a boundary value of the image adherent to the image
-crosscut.
+injective on an open `U` and a point `e` of `frontier U`, every value `f` clusters at along the
+crosscut as `e` is approached is a boundary value of the image adherent to the image crosscut.
 
 Both halves are already available: the cluster set along the crosscut is contained in the cluster
-set along the whole disc, which `TauCeti.clusterSetOn_subset_frontier_image` — properness of a
-conformal map — puts on `frontier (f '' ball c r)`; and cluster values are adherent to the image
-of the approach set by `TauCeti.clusterSetOn_subset_closure_image`. -/
-theorem clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hr : 0 < r)
-    (he : e ∈ sphere c r ∩ sphere ζ ρ) :
-    clusterSetOn f (ball c r ∩ sphere ζ ρ) e ⊆
-      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
-  refine subset_inter (fun v hv => ?_) fun v hv => clusterSetOn_subset_closure_image hv
-  refine clusterSetOn_subset_frontier_image isOpen_ball hd hinj ?_
-    (clusterSetOn_mono inter_subset_left hv)
-  rw [frontier_ball c hr.ne']
-  exact he.1
+set along the whole domain, which `TauCeti.clusterSetOn_subset_frontier_image` — properness of a
+conformal map — puts on `frontier (f '' U)`; and cluster values are adherent to the image of the
+approach set by `TauCeti.clusterSetOn_subset_closure_image`. -/
+theorem clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (he : e ∈ frontier U) :
+    clusterSetOn f (U ∩ sphere ζ ρ) e ⊆
+      frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) :=
+  subset_inter
+    (fun _ hv => clusterSetOn_subset_frontier_image hUo hd hinj he
+      (clusterSetOn_mono inter_subset_left hv))
+    fun _ hv => clusterSetOn_subset_closure_image hv
 
-/-- **Each end of a circular crosscut carries a cluster value.** The crosscut is adherent to each
-of its two endpoints and `f` is confined along it to the compact
-`closure (f '' (ball c r ∩ sphere ζ ρ))`, so the cluster set there is nonempty; only the image of
-the crosscut need be bounded, and no holomorphy is needed. -/
-theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
-    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
-    (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Nonempty := by
-  refine clusterSetOn_nonempty hb.isCompact_closure
-    (fun z hz => subset_closure (mem_image_of_mem f hz)) ?_
-  rw [closure_ball_inter_sphere hζ hρ hρr]
-  exact ⟨sphere_subset_closedBall he.1, he.2⟩
+/-- **Each end of a circular crosscut carries a cluster value.** At a point adherent to the
+crosscut, `f` is confined along it to the compact `closure (f '' (U ∩ sphere ζ ρ))`, so the cluster
+set there is nonempty; only the image of the crosscut need be bounded, and no holomorphy is
+needed. -/
+theorem nonempty_clusterSetOn_inter_sphere (hb : IsBounded (f '' (U ∩ sphere ζ ρ)))
+    (he : e ∈ closure (U ∩ sphere ζ ρ)) :
+    (clusterSetOn f (U ∩ sphere ζ ρ) e).Nonempty :=
+  clusterSetOn_nonempty hb.isCompact_closure
+    (fun _ hz => subset_closure (mem_image_of_mem f hz)) he
 
-/-- **Each end of an image crosscut is a continuum.** For `f` continuous along a genuine circular
-crosscut and with bounded image *of the crosscut*, the cluster set at either endpoint is nonempty
-and connected; it is compact by `TauCeti.isCompact_clusterSetOn_of_isBounded`. This is the
-Collingwood–Lohwater continuum theorem `TauCeti.isConnected_clusterSetOn`, whose local hypothesis —
-that arbitrarily small neighbourhoods of the endpoint meet the crosscut in a preconnected set — is
-exactly `TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half
-turn and so meeting each ball centred on it in a subarc. -/
+/-- **Each end of an image crosscut of a disc is a continuum.** For `f` continuous along a genuine
+circular crosscut of a disc and with bounded image *of the crosscut*, the cluster set at either
+endpoint is nonempty and connected; it is compact by
+`TauCeti.isCompact_clusterSetOn_of_isBounded`. This is the Collingwood–Lohwater continuum theorem
+`TauCeti.isConnected_clusterSetOn`, whose local hypothesis — that arbitrarily small neighbourhoods
+of the endpoint meet the crosscut in a preconnected set — is exactly
+`TauCeti.isPreconnected_ball_inter_sphere_inter_ball`, a crosscut spanning less than a half turn and
+so meeting each ball centred on it in a subarc. That input is what keeps this statement about a
+disc while its neighbours above are about an arbitrary domain: a general crosscut may meet a small
+ball in many subarcs. -/
 theorem isConnected_clusterSetOn_ball_inter_sphere
     (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
@@ -277,99 +303,232 @@ theorem isConnected_clusterSetOn_ball_inter_sphere
 
 /-! ## The middle piece -/
 
-/-- **The middle piece is exactly the two end cluster sets of the image crosscut.** For `f`
-holomorphic and injective on `ball c r` and a genuine circular crosscut at a boundary point `ζ`,
+/-- **The middle piece is exactly the end cluster sets of the image crosscut.** For `f` holomorphic
+and injective on an open `U` and a circle of positive radius,
 
-> `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))`
-> `= ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e`,
+> `frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))`
+> `= ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e`,
 
-the index set being the two endpoints of the crosscut by
-`TauCeti.sphere_inter_sphere_eq_pair_circleMap`. So the part of the image boundary that the
-crosscut clings to is not merely small: it is the union of the cluster sets at the two ends. The
-image of the crosscut is not assumed bounded here, so the equality by itself leaves those two
-cluster sets possibly empty; add that boundedness and each of them is nonempty by
-`TauCeti.nonempty_clusterSetOn_ball_inter_sphere`, which is what a small connected boundary set
-enclosing the middle piece —
-`TauCeti.exists_isConnected_subset_frontier_image_ball_of_diam_lt` — has to *join*.
+the index set being, for a disc, the two endpoints of the crosscut
+(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`). So the part of the image boundary that the
+crosscut clings to is not merely small: it is the union of the cluster sets at its ends. The
+image of the crosscut is not assumed bounded here, so the equality by itself leaves those cluster
+sets possibly empty; add that boundedness and each end adherent to the crosscut carries one by
+`TauCeti.nonempty_clusterSetOn_inter_sphere`, which is what a small connected boundary set
+enclosing the middle piece — `TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt` — has to
+*join*.
 
-One inclusion is `TauCeti.clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image`. For
-the other, `TauCeti.closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` splits a point
+One inclusion is `TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`. For
+the other, `TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` splits a point
 of the closure of the image crosscut into a value on the crosscut and a cluster value at an end,
-and a value on the crosscut lies in the *open* image `f '' ball c r`, which is disjoint from its
-own frontier. -/
-theorem frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hζ : dist ζ c = r)
-    (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
-    frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) =
-      ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
-  have hr : 0 < r := by linarith
+and a value on the crosscut lies in the *open* image `f '' U`, which is disjoint from its own
+frontier. -/
+theorem frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hρ : 0 < ρ) :
+    frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) =
+      ⋃ e ∈ frontier U ∩ sphere ζ ρ, clusterSetOn f (U ∩ sphere ζ ρ) e := by
   refine subset_antisymm ?_ (iUnion₂_subset fun e he =>
-    clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image hd hinj hr he)
+    clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1)
   rintro v ⟨hvfr, hvcl⟩
-  rw [closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hd.continuousOn.mono inter_subset_left) hζ hρ hρr] at hvcl
+  rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hd.continuousOn.mono inter_subset_left) hρ] at hvcl
   refine hvcl.resolve_left fun hv => ?_
-  have hopen : IsOpen (f '' ball c r) :=
-    isOpen_image_of_differentiableOn_of_injOn isOpen_ball hd hinj
+  have hopen : IsOpen (f '' U) := isOpen_image_of_differentiableOn_of_injOn hUo hd hinj
   exact (hopen.frontier_eq ▸ hvfr).2 (image_mono inter_subset_left hv)
 
 /-- **The middle piece is no wider than the image crosscut.** It is contained in the closure of the
 image crosscut, and closing a set does not change its diameter. -/
-theorem diam_frontier_inter_closure_image_ball_inter_sphere_le (hb : IsBounded (f '' ball c r))
-    (ζ : ℂ) (ρ : ℝ) :
-    diam (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)))
-      ≤ diam (f '' (ball c r ∩ sphere ζ ρ)) := by
-  have harc : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
-  calc diam (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)))
-      ≤ diam (closure (f '' (ball c r ∩ sphere ζ ρ))) := diam_mono inter_subset_right harc.closure
-    _ = diam (f '' (ball c r ∩ sphere ζ ρ)) := diam_closure _
+theorem diam_frontier_inter_closure_image_inter_sphere_le (hb : IsBounded (f '' U)) (ζ : ℂ)
+    (ρ : ℝ) :
+    diam (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
+      ≤ diam (f '' (U ∩ sphere ζ ρ)) := by
+  have harc : IsBounded (f '' (U ∩ sphere ζ ρ)) := hb.subset (image_mono inter_subset_left)
+  calc diam (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
+      ≤ diam (closure (f '' (U ∩ sphere ζ ρ))) := diam_mono inter_subset_right harc.closure
+    _ = diam (f '' (U ∩ sphere ζ ρ)) := diam_closure _
 
-/-- **The middle piece is nonempty**: for `f` holomorphic and injective on `ball c r` with bounded
-image, and a genuine circular crosscut at a boundary point `ζ`, the set
-`frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))` has a point. So the image
-crosscut does cling to the boundary of the image, and — by
-`TauCeti.frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` and
-`TauCeti.nonempty_clusterSetOn_ball_inter_sphere` — at *each* of its two ends.
+/-- **The middle piece is nonempty**: for `f` holomorphic and injective on an open `U` with bounded
+image, and a crosscut with an end `e` — a point of `frontier U` adherent to the crosscut — the set
+`frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))` has a point. So the image crosscut does cling
+to the boundary of the image, and — by
+`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` — it does so at each
+such end.
 
-The crosscut has an endpoint on `sphere c r`, and the cluster set of `f` along the crosscut there
-is nonempty and contained in the middle piece. -/
-theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
-    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
-    (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Nonempty := by
+The cluster set of `f` along the crosscut at `e` is nonempty and contained in the middle piece. -/
+theorem nonempty_frontier_inter_closure_image_inter_sphere (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
+    (he : e ∈ frontier U ∩ closure (U ∩ sphere ζ ρ)) :
+    (frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))).Nonempty := by
+  obtain ⟨v, hv⟩ :=
+    nonempty_clusterSetOn_inter_sphere (hb.subset (image_mono inter_subset_left)) he.2
+  exact ⟨v, clusterSetOn_inter_sphere_subset_frontier_inter_closure_image hUo hd hinj he.1 hv⟩
+
+/-- **A circular crosscut of a disc has an end.** The disc discharges the hypothesis that the
+crosscut reaches `frontier U`: a crosscut spanning less than a half turn has two endpoints
+(`TauCeti.sphere_inter_sphere_eq_pair_circleMap`), and either of them lies on `sphere c r`, the
+frontier of the disc, and in the closure of the crosscut
+(`TauCeti.closure_ball_inter_sphere`). -/
+theorem nonempty_frontier_ball_inter_closure_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) :
+    (frontier (ball c r) ∩ closure (ball c r ∩ sphere ζ ρ)).Nonempty := by
   have hr : 0 < r := by linarith
-  -- one of the two endpoints of the crosscut
-  have hemem : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
+  have hmem : circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r)))
       ∈ sphere c r ∩ sphere ζ ρ := by
     rw [sphere_inter_sphere_eq_pair_circleMap hζ hρ hρr]
     exact Or.inl rfl
-  obtain ⟨v, hv⟩ :=
-    nonempty_clusterSetOn_ball_inter_sphere (hb.subset (image_mono inter_subset_left))
-      hζ hρ hρr hemem
-  exact ⟨v, clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image hd hinj hr hemem hv⟩
+  refine ⟨circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))), ?_, ?_⟩
+  · rw [frontier_ball c hr.ne']
+    exact hmem.1
+  · rw [closure_ball_inter_sphere hζ hρ hρr]
+    exact ⟨sphere_subset_closedBall hmem.1, hmem.2⟩
 
 /-! ## The small connected set enclosing the middle piece -/
 
 /-- **A uniformly locally connected image boundary encloses the middle piece of every short image
-crosscut in a small connected boundary set.** For `f` holomorphic and injective on `ball c r` with
-bounded image and `frontier (f '' ball c r)` uniformly locally connected, every `ε > 0` admits a
-single `δ > 0` — independent of the boundary point `ζ` and of the crosscut radius `ρ` — such that
-an image crosscut of diameter less than `δ` has its middle piece contained in a connected subset of
-`frontier (f '' ball c r)` of diameter at most `ε`.
+crosscut in a small connected boundary set.** For `f` holomorphic and injective on an open `U` with
+bounded image and `frontier (f '' U)` uniformly locally connected, every `ε > 0` admits a single
+`δ > 0` — independent of the boundary point `ζ` and of the crosscut radius `ρ` — such that an image
+crosscut of diameter less than `δ` has its middle piece contained in a connected subset of
+`frontier (f '' U)` of diameter at most `ε`. The crosscut is asked to have an end, which for a disc
+is `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`; a cut missing `frontier U`
+altogether has an empty middle piece and nothing to enclose.
 
 This is where the local connectedness of `∂Ω` that
 `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` needs enters, the other
 of its two geometric inputs being the length–area estimate
 `TauCeti.exists_diam_image_ball_inter_sphere_le`. It does not by itself discharge that criterion,
 whose enclosing set has to contain the whole boundary piece
-`frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ))` and not only the middle piece.
+`frontier (f '' U) ∩ frontier (f '' (U ∩ ball ζ ρ))` and not only the middle piece.
 
 Everything topological is in `TauCeti.IsUniformlyLocallyConnected.exists_isConnected_superset`, the
 statement that a uniformly locally connected set encloses each of its small subsets in a small
-connected subset. What remains is that the middle piece is a subset of `frontier (f '' ball c r)`
-that is bounded, nonempty by
-`TauCeti.nonempty_frontier_inter_closure_image_ball_inter_sphere`, and of diameter less than `δ` by
-`TauCeti.diam_frontier_inter_closure_image_ball_inter_sphere_le`. -/
+connected subset. What remains is that the middle piece is a subset of `frontier (f '' U)` that is
+bounded, nonempty by `TauCeti.nonempty_frontier_inter_closure_image_inter_sphere`, and of diameter
+less than `δ` by `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`. -/
+theorem exists_isConnected_subset_frontier_image_of_diam_lt (hUo : IsOpen U)
+    (hd : DifferentiableOn ℂ f U) (hinj : InjOn f U) (hb : IsBounded (f '' U))
+    (hulc : IsUniformlyLocallyConnected (frontier (f '' U))) {ε : ℝ} (hε : 0 < ε) :
+    ∃ δ > 0, ∀ ζ : ℂ, ∀ ρ : ℝ, (frontier U ∩ closure (U ∩ sphere ζ ρ)).Nonempty →
+      diam (f '' (U ∩ sphere ζ ρ)) < δ →
+        ∃ S ⊆ frontier (f '' U), IsConnected S ∧
+          frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)) ⊆ S ∧ diam S ≤ ε := by
+  obtain ⟨δ, hδ, hencl⟩ := hulc.exists_isConnected_superset hε
+  refine ⟨δ, hδ, fun ζ ρ ⟨w, hw⟩ hdiam => ?_⟩
+  refine hencl _ inter_subset_left
+    (((hb.subset (image_mono inter_subset_left)).closure).subset inter_subset_right)
+    (nonempty_frontier_inter_closure_image_inter_sphere hUo hd hinj hb hw) ?_
+  exact lt_of_le_of_lt (diam_frontier_inter_closure_image_inter_sphere_le hb ζ ρ) hdiam
+
+/-! ## Deprecated disc-specific forms
+
+Everything above was stated for `U = ball c r`. The old signatures are retained here as deprecated
+compatibility wrappers, each naming its generalized replacement; the openness hypothesis is
+discharged by `Metric.isOpen_ball`, `Metric.frontier_ball` turns `frontier U` back into
+`sphere c r`, and `TauCeti.closure_ball_inter_sphere` turns the closure of the crosscut back into
+`closedBall c r ∩ sphere ζ ρ`. -/
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.image_eq_union_image_crosscut`. -/
+@[deprecated image_eq_union_image_crosscut (since := "2026-08-04")]
+theorem image_ball_eq_union_image_crosscut (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
+    f '' ball c r =
+      f '' (ball c r ∩ ball ζ ρ) ∪ f '' (ball c r ∩ sphere ζ ρ) ∪
+        f '' (ball c r \ closedBall ζ ρ) :=
+  image_eq_union_image_crosscut f (ball c r) ζ ρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_image_subset_union_closure_image_inter_sphere`. -/
+@[deprecated frontier_image_subset_union_closure_image_inter_sphere (since := "2026-08-04")]
+theorem frontier_image_ball_subset_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
+    frontier (f '' ball c r) ⊆
+      frontier (f '' (ball c r ∩ ball ζ ρ)) ∪ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪
+        frontier (f '' (ball c r \ closedBall ζ ρ)) :=
+  frontier_image_subset_union_closure_image_inter_sphere f (ball c r) ζ ρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_image_eq_union_closure_image_inter_sphere`. -/
+@[deprecated frontier_image_eq_union_closure_image_inter_sphere (since := "2026-08-04")]
+theorem frontier_image_ball_eq_union (f : ℂ → ℂ) (c ζ : ℂ) (r ρ : ℝ) :
+    frontier (f '' ball c r) =
+      frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ)) ∪
+        frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) ∪
+        frontier (f '' ball c r) ∩ frontier (f '' (ball c r \ closedBall ζ ρ)) :=
+  frontier_image_eq_union_closure_image_inter_sphere f (ball c r) ζ ρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.closure_image_inter_sphere_eq_union_biUnion_clusterSetOn`, which needs neither
+`dist ζ c = r` nor `ρ < 2 * r`. -/
+@[deprecated closure_image_inter_sphere_eq_union_biUnion_clusterSetOn (since := "2026-08-04")]
+theorem closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn
+    (hfc : ContinuousOn f (ball c r ∩ sphere ζ ρ)) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      f '' (ball c r ∩ sphere ζ ρ) ∪
+        ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
+  have hr : 0 < r := by linarith
+  rw [← frontier_ball c hr.ne']
+  exact closure_image_inter_sphere_eq_union_biUnion_clusterSetOn hfc hρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.clusterSetOn_inter_sphere_subset_frontier_inter_closure_image`, which asks only that the
+end lie on `frontier U`. -/
+@[deprecated clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (since := "2026-08-04")]
+theorem clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hr : 0 < r)
+    (he : e ∈ sphere c r ∩ sphere ζ ρ) :
+    clusterSetOn f (ball c r ∩ sphere ζ ρ) e ⊆
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) :=
+  clusterSetOn_inter_sphere_subset_frontier_inter_closure_image isOpen_ball hd hinj
+    (by rw [frontier_ball c hr.ne']; exact he.1)
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.nonempty_clusterSetOn_inter_sphere`, which asks only that the end be adherent to the
+crosscut. -/
+@[deprecated nonempty_clusterSetOn_inter_sphere (since := "2026-08-04")]
+theorem nonempty_clusterSetOn_ball_inter_sphere (hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)))
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) (he : e ∈ sphere c r ∩ sphere ζ ρ) :
+    (clusterSetOn f (ball c r ∩ sphere ζ ρ) e).Nonempty := by
+  refine nonempty_clusterSetOn_inter_sphere hb ?_
+  rw [closure_ball_inter_sphere hζ hρ hρr]
+  exact ⟨sphere_subset_closedBall he.1, he.2⟩
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn`, which needs neither
+`dist ζ c = r` nor `ρ < 2 * r`. -/
+@[deprecated frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn
+  (since := "2026-08-04")]
+theorem frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r)) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) :
+    frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e := by
+  have hr : 0 < r := by linarith
+  rw [← frontier_ball c hr.ne']
+  exact frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn isOpen_ball hd hinj hρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le`. -/
+@[deprecated diam_frontier_inter_closure_image_inter_sphere_le (since := "2026-08-04")]
+theorem diam_frontier_inter_closure_image_ball_inter_sphere_le (hb : IsBounded (f '' ball c r))
+    (ζ : ℂ) (ρ : ℝ) :
+    diam (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)))
+      ≤ diam (f '' (ball c r ∩ sphere ζ ρ)) :=
+  diam_frontier_inter_closure_image_inter_sphere_le hb ζ ρ
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.nonempty_frontier_inter_closure_image_inter_sphere`, whose end the disc supplies through
+`TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`. -/
+@[deprecated nonempty_frontier_inter_closure_image_inter_sphere (since := "2026-08-04")]
+theorem nonempty_frontier_inter_closure_image_ball_inter_sphere
+    (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r)) (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r) :
+    (frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))).Nonempty :=
+  let ⟨_, he⟩ := nonempty_frontier_ball_inter_closure_ball_inter_sphere hζ hρ hρr
+  nonempty_frontier_inter_closure_image_inter_sphere isOpen_ball hd hinj hb he
+
+/-- Deprecated compatibility wrapper for the disc case of
+`TauCeti.exists_isConnected_subset_frontier_image_of_diam_lt`, whose end the disc supplies through
+`TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`. -/
+@[deprecated exists_isConnected_subset_frontier_image_of_diam_lt (since := "2026-08-04")]
 theorem exists_isConnected_subset_frontier_image_ball_of_diam_lt
     (hd : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r))
@@ -378,11 +537,9 @@ theorem exists_isConnected_subset_frontier_image_ball_of_diam_lt
       diam (f '' (ball c r ∩ sphere ζ ρ)) < δ →
         ∃ S ⊆ frontier (f '' ball c r), IsConnected S ∧
           frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) ⊆ S ∧ diam S ≤ ε := by
-  obtain ⟨δ, hδ, hencl⟩ := hulc.exists_isConnected_superset hε
-  refine ⟨δ, hδ, fun ζ hζ ρ hρ hρr hdiam => ?_⟩
-  refine hencl _ inter_subset_left
-    (((hb.subset (image_mono inter_subset_left)).closure).subset inter_subset_right)
-    (nonempty_frontier_inter_closure_image_ball_inter_sphere hd hinj hb hζ hρ hρr) ?_
-  exact lt_of_le_of_lt (diam_frontier_inter_closure_image_ball_inter_sphere_le hb ζ ρ) hdiam
+  obtain ⟨δ, hδ, hencl⟩ :=
+    exists_isConnected_subset_frontier_image_of_diam_lt isOpen_ball hd hinj hb hulc hε
+  exact ⟨δ, hδ, fun ζ hζ ρ hρ hρr hdiam =>
+    hencl ζ ρ (nonempty_frontier_ball_inter_closure_ball_inter_sphere hζ hρ hρr) hdiam⟩
 
 end TauCeti


### PR DESCRIPTION
This PR generalises `TauCeti/Analysis/Complex/Conformal/Crosscut/Image.lean` — how a circular crosscut splits the image of a domain and its boundary — from a disc `ball c r` to an arbitrary open `U`, and retires the disc signatures as deprecated compatibility wrappers. It is a refactor of already-merged material: every statement below existed on `main`, up to the widening of its domain hypothesis, and no new mathematics is claimed.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"crosscut-image-arbitrary-domain"}-->

Roadmap: ConformalMapping

The motivating target is layer **L5, the Carathéodory boundary correspondence**, of `TauCetiRoadmap/ConformalMapping/README.md` ("**L5 — Carathéodory boundary correspondence.** The concrete L5 milestone is the **Jordan-domain case**: the RMT map of a Jordan domain extends to a homeomorphism of closures"). The results generalised here are the inputs of `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`, the criterion in `Conformal/CutDiameter.lean` that turns a small cut-off piece into a continuous extension to the closure. That criterion was itself generalised to an arbitrary open `U` in TauCeti#1966; its inputs had stayed disc-shaped, so they could not be handed to it without first re-specialising the criterion. `Conformal/CutDiameter.lean` already records why the general form is the one wanted: the Carathéodory correspondence is a statement about a Jordan domain and the disc it is mapped from at once, so both directions of it are served only by the general form.

Nothing in the argument used the shape of the domain. The two endpoints of a crosscut become the trace `frontier U ∩ sphere ζ ρ` of the domain boundary on the cutting circle; the disc hypotheses `dist ζ c = r` and `ρ < 2 * r`, which said that the crosscut spans less than a half turn, disappear from every statement that does not need them; and `closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` loses even the openness of `U`, since `closure U = U ∪ frontier U` holds regardless. The proof of the middle-piece identification is unchanged apart from the elementary topological step that replaces the disc's explicit arc closure: the crosscut arc has empty interior in the plane, so its frontier is its whole closure, and closing `U ∩ sphere ζ ρ` can only add points of `frontier U` on the circle.

Old to new:

| deprecated disc form | generalised replacement |
| --- | --- |
| `image_ball_eq_union_image_crosscut` | `image_eq_union_image_inter_sphere` |
| `frontier_image_ball_subset_union` | `frontier_image_subset_union_closure_image_inter_sphere` |
| `frontier_image_ball_eq_union` | `frontier_image_eq_union_closure_image_inter_sphere` |
| `closure_image_ball_inter_sphere_eq_union_biUnion_clusterSetOn` | `closure_image_inter_sphere_eq_union_biUnion_clusterSetOn` |
| `clusterSetOn_ball_inter_sphere_subset_frontier_inter_closure_image` | `clusterSetOn_inter_sphere_subset_frontier_inter_closure_image` |
| `nonempty_clusterSetOn_ball_inter_sphere` | `TauCeti.clusterSetOn_nonempty` (the generic cluster-set lemma, applied directly) |
| `frontier_inter_closure_image_ball_inter_sphere_eq_biUnion_clusterSetOn` | `frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` |
| `diam_frontier_inter_closure_image_ball_inter_sphere_le` | `diam_frontier_inter_closure_image_inter_sphere_le` |
| `nonempty_frontier_inter_closure_image_ball_inter_sphere` | `nonempty_frontier_inter_closure_image_inter_sphere` |
| `exists_isConnected_subset_frontier_image_ball_of_diam_lt` | `exists_isConnected_subset_frontier_image_of_diam_lt` |

Two statements are not de-specialised. `TauCeti.isConnected_clusterSetOn_ball_inter_sphere`, the Collingwood–Lohwater continuum theorem at an end, keeps the disc: its local input is that small balls meet the crosscut in a single subarc, which a general crosscut may fail. And the last two theorems now ask, in place of the disc's endpoint, that the crosscut have an end at all — a point of `frontier U` adherent to it; the new `TauCeti.nonempty_frontier_ball_inter_closure_ball_inter_sphere`, in `Conformal/Crosscut/Endpoints.lean`, discharges that for a disc, so the disc case loses nothing and the deprecated wrappers reproduce the old signatures exactly.

The one internal consumer, `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` in `Conformal/Crosscut/EndpointLimit.lean`, is migrated to the general form.

No Mathlib infrastructure is vendored. Layer L5 is absent from the in-progress upstream Riemann-mapping effort ([mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505)), and the pinned Mathlib has no boundary correspondence for conformal maps, so this file remains new Lean formalization rather than a temporary shim.

`lake build` and `lake exe axioms` are green: 6514 jobs built, 22423 declarations audited, all within `[propext, Classical.choice, Quot.sound]`.

🤖 Prepared with Claude Code



---

**Round 2 update.** The reviewed statements moved as follows: the two cluster-set identities no
longer ask `0 < ρ`; the diameter bound and the nonemptiness of the middle piece ask only that
`f '' (U ∩ sphere ζ ρ)` be bounded; `nonempty_frontier_ball_inter_closure_ball_inter_sphere` now
lives in `Conformal/Crosscut/Endpoints.lean`; and the two wrappers that had dropped `dist ζ c = r`
take it again in its old position (underscored, since the unused-variable linter is fatal here).
