### PR TITLE
feat: the ends of an image crosscut are two boundary points

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -132,10 +132,9 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair (hζ : dis
 /-- **A holomorphic injection of finite Dirichlet integral has, at every boundary point, crosscuts
 of arbitrarily small radius whose image is narrow and whose two ends are close together on the
 image boundary.** For `f` holomorphic and injective on `ball c r` with
-`∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤`, every tolerance `ε > 0` and every bound `R` with
-`0 < R ≤ 2 * r` admit a radius `ρ < R` at which the image of `ball c r ∩ sphere ζ ρ` has diameter
-at most `ε` and the closed image crosscut meets `frontier (f '' ball c r)` in two points at
-distance at most `ε`.
+`∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤`, every tolerance `ε > 0` and every bound `R > 0` admit a
+radius `ρ < R` at which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε` and the
+closed image crosscut meets `frontier (f '' ball c r)` in two points at distance at most `ε`.
 
 The radius comes from the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top`
 of Wolff's lemma, which makes `TauCeti.circleImageLength f (ball c r) ζ ρ` smaller than
@@ -145,31 +144,32 @@ points; `TauCeti.diam_image_ball_inter_sphere_le` turns the same bound into the 
 `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` passes it on to the two ends, which lie
 in the boundary piece and so are no further apart than the image crosscut is wide.
 
-The bound `R ≤ 2 * r` is what makes `ball c r ∩ sphere ζ ρ` a genuine circular crosscut rather than
-the empty set; it forces `0 < r`, so no separate hypothesis on the radius of the disc is needed. -/
+Only `0 < r` is asked of the disc, and only `0 < R` of the prescribed bound: the radius is searched
+for below `min R (2 * r)` instead of below `R`, which is what makes `ball c r ∩ sphere ζ ρ` a
+genuine circular crosscut rather than the empty set. -/
 theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
-    (hζ : dist ζ c = r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R)
-    (hRr : R ≤ 2 * r) :
+    (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ}
+    (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, ∃ u v,
       frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
         dist u v ≤ ε ∧ diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
   obtain ⟨ρ, hρmem, hlen⟩ :=
     exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
-      (ENNReal.ofReal_pos.mpr hε).ne' hR
+      (ENNReal.ofReal_pos.mpr hε).ne' (R := min R (2 * r)) (lt_min hR (by linarith))
   have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
     (hlen.trans ENNReal.ofReal_lt_top).ne
   have hdiam : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
     diam_image_ball_inter_sphere_le hζ hρmem.1 hf hε.le hlen.le
   obtain ⟨u, v, hpair⟩ := exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair hζ hρmem.1
-    (hρmem.2.trans_le hRr) hf hinj hfin'
+    (hρmem.2.trans_le (min_le_right _ _)) hf hinj hfin'
   have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert _ _
   have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert_of_mem _ rfl
   have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
     isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρmem.1 hf hfin'
-  exact ⟨ρ, hρmem, u, v, hpair,
+  exact ⟨ρ, ⟨hρmem.1, hρmem.2.trans_le (min_le_left _ _)⟩, u, v, hpair,
     (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
       ((diam_frontier_inter_closure_image_inter_sphere_le hb).trans hdiam), hdiam⟩
 
@@ -185,13 +185,14 @@ on `frontier (f '' ball c r)`, which for a Jordan domain is a Jordan curve, and 
 of each other, so `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` cuts a small closed arc
 off that curve between them — once `u ≠ v` is known, which nothing here supplies. -/
 theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded
-    (hζ : dist ζ c = r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
-    (hb : IsBounded (f '' ball c r)) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) (hRr : R ≤ 2 * r) :
+    (hζ : dist ζ c = r) (hr : 0 < r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hb : IsBounded (f '' ball c r)) {ε : ℝ} (hε : 0 < ε) {R : ℝ}
+    (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, ∃ u v,
       frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
         dist u v ≤ ε ∧ diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
-  exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le hζ hf
+  exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le hζ hr hf
     hinj (lintegral_enorm_deriv_sq_ne_top_of_isBounded isOpen_ball hf
-      measurableSet_ball.nullMeasurableSet subset_rfl hinj hb) hε hR hRr
+      measurableSet_ball.nullMeasurableSet subset_rfl hinj hb) hε hR
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -53,10 +53,6 @@ domain rather than of the crosscut, and is untouched here.
 
 ## Main results
 
-* `TauCeti.isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top` — an image crosscut of
-  finite length is bounded, so its diameter is a genuine bound on the distances inside it.
-* `TauCeti.dist_le_diam_image_inter_sphere` — two points of the boundary piece are no further apart
-  than the image crosscut is wide; this holds over an arbitrary domain, no disc being involved.
 * `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` — the closed image
   crosscut of finite length meets the boundary of the image domain in a pair of points.
 * `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le`
@@ -71,8 +67,7 @@ domain rather than of the crosscut, and is untouched here.
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The disc is a
 general `ball c r` rather than the unit disc, the boundary point entering only through
-`dist ζ c = r`; `TauCeti.dist_le_diam_image_inter_sphere` asks for no disc at all, the boundary
-piece being defined over any domain.
+`dist ζ c = r`.
 
 ## Coordination with upstream Mathlib
 
@@ -100,42 +95,9 @@ namespace TauCeti
 
 open Bornology Complex MeasureTheory Metric Set
 
-variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ u v : ℂ} {r ρ : ℝ}
+variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 
 /-! ## The boundary piece of an image crosscut is a pair -/
-
-/-- **An image crosscut of finite length is bounded.** The chord bound
-`TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
-`f '' (ball c r ∩ sphere ζ ρ)` within the finite number
-`(TauCeti.circleImageLength f (ball c r) ζ ρ).toReal` of each other.
-
-This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on the distances inside the
-image crosscut rather than the junk value `0` that an unbounded set carries; it is the disc
-counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
-the crosscut rather than against an arc of angles. -/
-theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top (hζ : dist ζ c = r)
-    (hρ : 0 < ρ) (hf : DifferentiableOn ℂ f (ball c r))
-    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
-    IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
-  rw [isBounded_iff]
-  refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, ?_⟩
-  rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
-  exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
-    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
-
-/-- **The boundary piece is no wider than the image crosscut.** Two points of
-`frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))` are at distance at most
-`Metric.diam (f '' (U ∩ sphere ζ ρ))`.
-
-This is `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` read pointwise, and asks
-nothing of `U` beyond boundedness of the image of the cut: the boundary piece sits inside the
-closure of the image cut, whose diameter is that of the image cut. -/
-theorem dist_le_diam_image_inter_sphere (hb : IsBounded (f '' (U ∩ sphere ζ ρ)))
-    (hu : u ∈ frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
-    (hv : v ∈ frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))) :
-    dist u v ≤ diam (f '' (U ∩ sphere ζ ρ)) :=
-  (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
-    (diam_frontier_inter_closure_image_inter_sphere_le hb)
 
 /-- **A closed image crosscut of finite length meets the boundary of the image domain in a pair
 of points.** For `f` holomorphic and injective on `ball c r`, and a genuine circular crosscut
@@ -180,7 +142,8 @@ of Wolff's lemma, which makes `TauCeti.circleImageLength f (ball c r) ζ ρ` sma
 `ENNReal.ofReal ε` — in particular finite, which is what
 `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` needs, so the ends are two
 points; `TauCeti.diam_image_ball_inter_sphere_le` turns the same bound into the diameter bound, and
-`TauCeti.dist_le_diam_image_inter_sphere` passes it on to the two ends.
+`TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` passes it on to the two ends, which lie
+in the boundary piece and so are no further apart than the image crosscut is wide.
 
 The bound `R ≤ 2 * r` is what makes `ball c r ∩ sphere ζ ρ` a genuine circular crosscut rather than
 the empty set; it forces `0 < r`, so no separate hypothesis on the radius of the disc is needed. -/
@@ -204,9 +167,11 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
     rw [hpair]; exact mem_insert _ _
   have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert_of_mem _ rfl
-  exact ⟨ρ, hρmem, u, v, hpair, (dist_le_diam_image_inter_sphere
-    (isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρmem.1 hf hfin') hu hv).trans
-    hdiam, hdiam⟩
+  have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρmem.1 hf hfin'
+  exact ⟨ρ, hρmem, u, v, hpair,
+    (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
+      ((diam_frontier_inter_closure_image_inter_sphere_le hb).trans hdiam), hdiam⟩
 
 /-- **A conformal map of a disc has, at every boundary point, crosscuts of arbitrarily small radius
 whose image is narrow and whose two ends are close together on the image boundary.** This is the

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -1,0 +1,232 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.EndpointLimit
+import TauCeti.Analysis.Complex.Conformal.ShortCrosscut
+
+/-!
+# The ends of an image crosscut are two boundary points
+
+A circular crosscut `ball c r ∩ sphere ζ ρ` at a boundary point `ζ` of a disc is carried by a
+conformal map `f` to a curve inside the image domain `f '' ball c r`, and that curve reaches the
+boundary of the image domain only in the limit. Two files describe what it reaches:
+
+* `Conformal/Crosscut/Image.lean` identifies the *boundary piece* the image crosscut clings to,
+  `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))`, with the union of the cluster
+  sets of `f` at the two endpoints of the crosscut, and shows each of those cluster sets to be a
+  continuum;
+* `Conformal/Crosscut/EndpointLimit.lean` collapses each continuum to a point as soon as the image
+  crosscut has finite length, so that union is a pair
+  (`TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair`).
+
+Putting the two together is what this file does: for an *injective* holomorphic `f`, the closed
+image crosscut meets the boundary of the image domain in a pair of points,
+
+> `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v}`,
+
+and those two points are no further apart than the image crosscut is wide. Feeding that width
+bound the length–area estimate of `Conformal/ShortCrosscut.lean` then gives the statement layer
+**L5** of `TauCetiRoadmap/ConformalMapping/README.md` — Carathéodory's boundary correspondence —
+consumes: at every boundary point of the disc, and below every prescribed radius, there is a
+crosscut whose image is narrow *and* whose two ends are two points of the image boundary within
+`ε` of each other.
+
+That is precisely the hypothesis `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` of
+`TauCeti/Topology/JordanCurve/SmallArc.lean` runs on: two nearby points of a Jordan curve cut a
+small closed arc off it. Until now nothing connected the analytic side of L5 — the length–area
+method, which produces short image crosscuts — to the topological side, which turns two nearby
+boundary points into a small boundary arc; the pair `{u, v}` produced here is the connection.
+
+## What is not claimed
+
+The two ends may coincide: an image crosscut is free to close up, and no hypothesis available here
+excludes it. So `{u, v}` is a pair only in the sense of `Set.instInsert`, possibly a singleton, and
+the small-arc theorem — which asks `p ≠ q` — still has to rule that out from properties of the
+image domain. Nor is the *piece* of the boundary cut off between the two ends identified: bounding
+`frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ))`, the second geometric input of
+`TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`, is a matter of the image
+domain rather than of the crosscut, and is untouched here.
+
+## Main results
+
+* `TauCeti.isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top` — an image crosscut of
+  finite length is bounded, so its diameter is a genuine bound on the distances inside it.
+* `TauCeti.dist_le_diam_image_inter_sphere` — two points of the boundary piece are no further apart
+  than the image crosscut is wide; this holds over an arbitrary domain, no disc being involved.
+* `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` — the closed image
+  crosscut of finite length meets the boundary of the image domain in a pair of points.
+* `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le`
+  — the conclusion, from Wolff's lemma: a holomorphic injection of a disc with finite Dirichlet
+  integral has, at every boundary point and below every positive radius, a crosscut whose image has
+  diameter at most `ε` and whose two ends lie within `ε` of each other on the image boundary.
+* `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded`
+  — its corollary for an injection with bounded image, the case a Riemann map falls under.
+
+## Generality
+
+In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
+every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The disc is a
+general `ball c r` rather than the unit disc, the boundary point entering only through
+`dist ζ c = r`; `TauCeti.dist_le_diam_image_inter_sphere` asks for no disc at all, the boundary
+piece being defined over any domain.
+
+## Coordination with upstream Mathlib
+
+Layer L5 is absent from
+[mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
+human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself, and the
+pinned Mathlib has no boundary correspondence for conformal maps. So this file is new Lean
+formalization rather than a temporary shim. Through
+`Conformal/Crosscut/Image.lean` it consumes the L0–L3 shim
+`TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib's open mapping
+API once the upstream work lands.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2–2.3 (crosscuts and the length–area
+  method).
+* P. L. Duren, *Univalent Functions*, Ch. 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Bornology Complex MeasureTheory Metric Set
+
+variable {f : ℂ → ℂ} {U : Set ℂ} {c ζ u v : ℂ} {r ρ : ℝ}
+
+/-! ## The boundary piece of an image crosscut is a pair -/
+
+/-- **An image crosscut of finite length is bounded.** The chord bound
+`TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
+`f '' (ball c r ∩ sphere ζ ρ)` within the finite number
+`(TauCeti.circleImageLength f (ball c r) ζ ρ).toReal` of each other.
+
+This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on the distances inside the
+image crosscut rather than the junk value `0` that an unbounded set carries; it is the disc
+counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
+the crosscut rather than against an arc of angles. -/
+theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top (hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
+  rw [isBounded_iff]
+  refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, ?_⟩
+  rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
+  exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
+    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
+
+/-- **The boundary piece is no wider than the image crosscut.** Two points of
+`frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))` are at distance at most
+`Metric.diam (f '' (U ∩ sphere ζ ρ))`.
+
+This is `TauCeti.diam_frontier_inter_closure_image_inter_sphere_le` read pointwise, and asks
+nothing of `U` beyond boundedness of the image of the cut: the boundary piece sits inside the
+closure of the image cut, whose diameter is that of the image cut. -/
+theorem dist_le_diam_image_inter_sphere (hb : IsBounded (f '' (U ∩ sphere ζ ρ)))
+    (hu : u ∈ frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ)))
+    (hv : v ∈ frontier (f '' U) ∩ closure (f '' (U ∩ sphere ζ ρ))) :
+    dist u v ≤ diam (f '' (U ∩ sphere ζ ρ)) :=
+  (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
+    (diam_frontier_inter_closure_image_inter_sphere_le hb)
+
+/-- **A closed image crosscut of finite length meets the boundary of the image domain in a pair
+of points.** For `f` holomorphic and injective on `ball c r`, and a genuine circular crosscut
+`ball c r ∩ sphere ζ ρ` at a boundary point `ζ` whose image has finite length,
+
+> `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v}`.
+
+The two ingredients are already in place and only have to be matched up:
+`TauCeti.frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn` writes the left-hand
+side as the union of the cluster sets of `f` over `frontier (ball c r) ∩ sphere ζ ρ`, which is
+`sphere c r ∩ sphere ζ ρ` since `0 < r`, and
+`TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair` evaluates that union to a pair.
+
+Injectivity enters only through the first of the two, where it makes `f '' ball c r` open and so
+disjoint from its own frontier; that is what excludes the image crosscut itself from the boundary
+piece. The two points may coincide.
+
+Membership of the two ends in `frontier (f '' ball c r)` is read off the statement: `u` and `v` lie
+in `{u, v}`, hence in the left-hand side, hence in `frontier (f '' ball c r)`. -/
+theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair (hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hinj : InjOn f (ball c r)) (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    ∃ u v, frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} := by
+  obtain ⟨u, v, hends⟩ := exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair hζ hρ hρr hf hfin
+  have hr : 0 < r := by linarith
+  refine ⟨u, v, ?_⟩
+  rw [frontier_inter_closure_image_inter_sphere_eq_biUnion_clusterSetOn isOpen_ball hf hinj,
+    frontier_ball c hr.ne', hends]
+
+/-! ## Crosscuts with a short image and close ends -/
+
+/-- **A holomorphic injection of finite Dirichlet integral has, at every boundary point, crosscuts
+of arbitrarily small radius whose image is narrow and whose two ends are close together on the
+image boundary.** For `f` holomorphic and injective on `ball c r` with
+`∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤`, every tolerance `ε > 0` and every bound `R` with
+`0 < R ≤ 2 * r` admit a radius `ρ < R` at which the image of `ball c r ∩ sphere ζ ρ` has diameter
+at most `ε` and the closed image crosscut meets `frontier (f '' ball c r)` in two points at
+distance at most `ε`.
+
+The radius comes from the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top`
+of Wolff's lemma, which makes `TauCeti.circleImageLength f (ball c r) ζ ρ` smaller than
+`ENNReal.ofReal ε` — in particular finite, which is what
+`TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` needs, so the ends are two
+points; `TauCeti.diam_image_ball_inter_sphere_le` turns the same bound into the diameter bound, and
+`TauCeti.dist_le_diam_image_inter_sphere` passes it on to the two ends.
+
+The bound `R ≤ 2 * r` is what makes `ball c r ∩ sphere ζ ρ` a genuine circular crosscut rather than
+the empty set; it forces `0 < r`, so no separate hypothesis on the radius of the disc is needed. -/
+theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
+    (hζ : dist ζ c = r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R)
+    (hRr : R ≤ 2 * r) :
+    ∃ ρ ∈ Ioo 0 R, ∃ u v,
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
+        dist u v ≤ ε ∧ diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
+  obtain ⟨ρ, hρmem, hlen⟩ :=
+    exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
+      (ENNReal.ofReal_pos.mpr hε).ne' hR
+  have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
+    (hlen.trans ENNReal.ofReal_lt_top).ne
+  have hdiam : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
+    diam_image_ball_inter_sphere_le hζ hρmem.1 hf hε.le hlen.le
+  obtain ⟨u, v, hpair⟩ := exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair hζ hρmem.1
+    (hρmem.2.trans_le hRr) hf hinj hfin'
+  have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+    rw [hpair]; exact mem_insert _ _
+  have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+    rw [hpair]; exact mem_insert_of_mem _ rfl
+  exact ⟨ρ, hρmem, u, v, hpair, (dist_le_diam_image_inter_sphere
+    (isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρmem.1 hf hfin') hu hv).trans
+    hdiam, hdiam⟩
+
+/-- **A conformal map of a disc has, at every boundary point, crosscuts of arbitrarily small radius
+whose image is narrow and whose two ends are close together on the image boundary.** This is the
+case of `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le`
+that a Riemann map falls under: for `f` injective on `ball c r` with bounded image the Dirichlet
+integral is the area of that image, hence finite by
+`TauCeti.lintegral_enorm_deriv_sq_ne_top_of_isBounded`.
+
+This is the form the Jordan-domain boundary correspondence consumes. Its two ends `u` and `v` lie
+on `frontier (f '' ball c r)`, which for a Jordan domain is a Jordan curve, and they are within `ε`
+of each other, so `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` cuts a small closed arc
+off that curve between them — once `u ≠ v` is known, which nothing here supplies. -/
+theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le_of_isBounded
+    (hζ : dist ζ c = r) (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hb : IsBounded (f '' ball c r)) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) (hRr : R ≤ 2 * r) :
+    ∃ ρ ∈ Ioo 0 R, ∃ u v,
+      frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v} ∧
+        dist u v ≤ ε ∧ diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
+  exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le hζ hf
+    hinj (lintegral_enorm_deriv_sq_ne_top_of_isBounded isOpen_ball hf
+      measurableSet_ball.nullMeasurableSet subset_rfl hinj hb) hε hR hRr
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -92,9 +92,9 @@ joining them can be named.
   `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — the three arc statements at the arc
   of a circular crosscut, the last of them the form `Conformal/Crosscut/Image.lean` indexes over.
 * `TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair` — hence the union of the cluster
-  sets at the two endpoints, which `Conformal/Crosscut/Image.lean` identifies with the part of the
-  closed image crosscut outside the image crosscut, is a pair of points. (That file also identifies
-  the union with the boundary piece the image crosscut clings to, but only for injective `f`.)
+  sets at the two endpoints, the term `Conformal/Crosscut/Image.lean` adjoins to the image crosscut
+  to close it, is a pair of points. (That file also identifies the union with the boundary piece the
+  image crosscut clings to, but only for injective `f`.)
 * `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` — hence the closure of an image
   crosscut of finite length is the image crosscut together with two points.
 
@@ -499,13 +499,15 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The two ends of a circular crosscut of finite image length are two points.** The union of the
-cluster sets of `f` at the two endpoints of the crosscut is a pair. So, therefore, is the part of
-`closure (f '' (ball c r ∩ sphere ζ ρ))` outside the image crosscut, which
-`Conformal/Crosscut/Image.lean` identifies with that union under exactly the hypotheses assumed
-here. The other description of the union in that file, as the piece of `frontier (f '' ball c r)`
-the image crosscut clings to, is *not* available here: it asks `f` to be injective on `ball c r`,
-which makes `f '' ball c r` open and hence disjoint from its own frontier. Adding that hypothesis
-is `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` of
+cluster sets of `f` at the two endpoints of the crosscut is a pair. That union is the term
+`Conformal/Crosscut/Image.lean` adjoins to the image crosscut to write
+`closure (f '' (ball c r ∩ sphere ζ ρ))`, under exactly the hypotheses assumed here; that
+decomposition is a union, not a disjoint one, so nothing here says the pair misses the image
+crosscut. The other description of the union in that file, as the piece of
+`frontier (f '' ball c r)` the image crosscut clings to, is *not* available here: it asks `f` to be
+injective on `ball c r`, which makes `f '' ball c r` open and hence disjoint from its own
+frontier. Adding that hypothesis is
+`TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` of
 `Conformal/Crosscut/BoundaryEnds.lean`.
 
 Nothing is claimed about the two points: they may coincide, an image crosscut being free to close

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -92,9 +92,9 @@ joining them can be named.
   `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — the three arc statements at the arc
   of a circular crosscut, the last of them the form `Conformal/Crosscut/Image.lean` indexes over.
 * `TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair` — hence the union of the cluster
-  sets at the two endpoints, which `Conformal/Crosscut/Image.lean` identifies both with the part of
-  the closed image crosscut outside the image crosscut and with the boundary piece it clings to, is
-  a pair of points.
+  sets at the two endpoints, which `Conformal/Crosscut/Image.lean` identifies with the part of the
+  closed image crosscut outside the image crosscut, is a pair of points. (That file also identifies
+  the union with the boundary piece the image crosscut clings to, but only for injective `f`.)
 * `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` — hence the closure of an image
   crosscut of finite length is the image crosscut together with two points.
 
@@ -499,10 +499,14 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
 /-- **The two ends of a circular crosscut of finite image length are two points.** The union of the
-cluster sets of `f` at the two endpoints of the crosscut is a pair. Both descriptions of that union
-in `Conformal/Crosscut/Image.lean` — as the part of `closure (f '' (ball c r ∩ sphere ζ ρ))` outside
-the image crosscut, and as the piece of `frontier (f '' ball c r)` the image crosscut clings to —
-therefore name a pair of points once the length is finite.
+cluster sets of `f` at the two endpoints of the crosscut is a pair. So, therefore, is the part of
+`closure (f '' (ball c r ∩ sphere ζ ρ))` outside the image crosscut, which
+`Conformal/Crosscut/Image.lean` identifies with that union under exactly the hypotheses assumed
+here. The other description of the union in that file, as the piece of `frontier (f '' ball c r)`
+the image crosscut clings to, is *not* available here: it asks `f` to be injective on `ball c r`,
+which makes `f '' ball c r` open and hence disjoint from its own frontier. Adding that hypothesis
+is `TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` of
+`Conformal/Crosscut/BoundaryEnds.lean`.
 
 Nothing is claimed about the two points: they may coincide, an image crosscut being free to close
 up. What a boundary-correspondence argument needs of them is that they are points at all, so that

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/EndpointLimit.lean
@@ -91,6 +91,10 @@ joining them can be named.
   `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere` and
   `TauCeti.exists_clusterSetOn_ball_inter_sphere_eq_singleton` — the three arc statements at the arc
   of a circular crosscut, the last of them the form `Conformal/Crosscut/Image.lean` indexes over.
+* `TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair` — hence the union of the cluster
+  sets at the two endpoints, which `Conformal/Crosscut/Image.lean` identifies both with the part of
+  the closed image crosscut outside the image crosscut and with the boundary piece it clings to, is
+  a pair of points.
 * `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert` — hence the closure of an image
   crosscut of finite length is the image crosscut together with two points.
 
@@ -494,18 +498,19 @@ theorem exists_clusterSetOn_ball_inter_sphere_eq_singleton (hζ : dist ζ c = r)
     (by linarith [Real.pi_pos]) hθ₀ (fun _ hθ => circleMap_mem_ball_of_mem_Ioo hζ hρ hρr hθ)
     (lintegral_enorm_deriv_circleMap_ne_top hζ hρ hρr hfin)
 
-/-- **The closure of an image crosscut of finite length is the image crosscut together with two
-points.** `Conformal/Crosscut/Image.lean` writes that closure as the image crosscut together with
-the cluster sets at the two endpoints; finiteness of the length collapses each of those to a point.
+/-- **The two ends of a circular crosscut of finite image length are two points.** The union of the
+cluster sets of `f` at the two endpoints of the crosscut is a pair. Both descriptions of that union
+in `Conformal/Crosscut/Image.lean` — as the part of `closure (f '' (ball c r ∩ sphere ζ ρ))` outside
+the image crosscut, and as the piece of `frontier (f '' ball c r)` the image crosscut clings to —
+therefore name a pair of points once the length is finite.
 
 Nothing is claimed about the two points: they may coincide, an image crosscut being free to close
 up. What a boundary-correspondence argument needs of them is that they are points at all, so that
 the arc of a locally connected image boundary joining them can be named. -/
-theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (hρ : 0 < ρ)
+theorem exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
-    ∃ u v, closure (f '' (ball c r ∩ sphere ζ ρ)) =
-      insert u (insert v (f '' (ball c r ∩ sphere ζ ρ))) := by
+    ∃ u v, ⋃ e ∈ sphere c r ∩ sphere ζ ρ, clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {u, v} := by
   have hpair : sphere c r ∩ sphere ζ ρ =
       {circleMap ζ ρ ((c - ζ).arg - Real.arccos (ρ / (2 * r))),
         circleMap ζ ρ ((c - ζ).arg + Real.arccos (ρ / (2 * r)))} :=
@@ -520,13 +525,27 @@ theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (
     exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hp)
   obtain ⟨v, hv⟩ :=
     exists_clusterSetOn_ball_inter_sphere_eq_singleton hζ hρ hρr hf hfin (hsub _ hq)
+  exact ⟨u, v, by rw [hpair, biUnion_pair, hu, hv, singleton_union]⟩
+
+/-- **The closure of an image crosscut of finite length is the image crosscut together with two
+points.** `Conformal/Crosscut/Image.lean` writes that closure as the image crosscut together with
+the cluster sets at the two endpoints, and
+`TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair` collapses those to a pair.
+
+Which two points they are is not recorded here; the sharper statement that they are exactly the
+points where the closed image crosscut meets `frontier (f '' ball c r)` is
+`TauCeti.exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair` in
+`Conformal/Crosscut/BoundaryEnds.lean`, which asks injectivity of `f` in addition. -/
+theorem exists_closure_image_ball_inter_sphere_eq_insert (hζ : dist ζ c = r) (hρ : 0 < ρ)
+    (hρr : ρ < 2 * r) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    ∃ u v, closure (f '' (ball c r ∩ sphere ζ ρ)) =
+      insert u (insert v (f '' (ball c r ∩ sphere ζ ρ))) := by
+  obtain ⟨u, v, hends⟩ := exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair hζ hρ hρr hf hfin
   have hr : 0 < r := by linarith
-  have hends : ⋃ e ∈ frontier (ball c r) ∩ sphere ζ ρ,
-      clusterSetOn f (ball c r ∩ sphere ζ ρ) e = {u, v} := by
-    rw [frontier_ball c hr.ne', hpair, biUnion_pair, hu, hv, singleton_union]
   refine ⟨u, v, ?_⟩
   rw [closure_image_inter_sphere_eq_union_biUnion_clusterSetOn
-    (hf.continuousOn.mono inter_subset_left), hends]
+    (hf.continuousOn.mono inter_subset_left), frontier_ball c hr.ne', hends]
   simp
 
 end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -49,6 +49,8 @@ bound applies.
   `TauCeti.circleImageLength f (ball c r) ζ ρ`.
 * `TauCeti.diam_image_ball_inter_sphere_le` — hence the image of `ball c r ∩ sphere ζ ρ` is no
   wider than that quantity.
+* `TauCeti.isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top` — and when that quantity
+  is finite the image is bounded, so its diameter is a genuine bound on the distances inside it.
 * `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` — the conclusion, from
   Wolff's lemma: a holomorphic map of a disc with finite Dirichlet integral has, at every boundary
   point and below every positive radius, a radius `ρ` at which `f '' (ball c r ∩ sphere ζ ρ)` has
@@ -134,6 +136,25 @@ theorem diam_image_ball_inter_sphere_le (hζ : dist ζ c = r) (hρ : 0 < ρ)
   rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
   exact (ENNReal.ofReal_le_ofReal_iff hε).mp
     ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw).trans hlen)
+
+/-- **An image crosscut of finite length is bounded.** The chord bound
+`TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
+`f '' (ball c r ∩ sphere ζ ρ)` within the finite number
+`(TauCeti.circleImageLength f (ball c r) ζ ρ).toReal` of each other.
+
+This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on the distances inside the
+image crosscut rather than the junk value `0` that an unbounded set carries; it is the disc
+counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
+the crosscut rather than against an arc of angles. -/
+theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top (hζ : dist ζ c = r)
+    (hρ : 0 < ρ) (hf : DifferentiableOn ℂ f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
+    IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
+  rw [isBounded_iff]
+  refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, ?_⟩
+  rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
+  exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
+    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
 
 /-! ## Crosscuts with a short image -/
 


### PR DESCRIPTION
This PR identifies the piece of the image boundary that an image crosscut clings to as a pair of points, and hands the length–area method's output to the Jordan-curve side of layer L5. `Conformal/Crosscut/Image.lean` writes `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))` as the union of the cluster sets of `f` at the two endpoints of the crosscut, and `Conformal/Crosscut/EndpointLimit.lean` collapses each of those continua to a point once the image crosscut has finite length. Matching the two up — which needs injectivity of `f`, to make `f '' ball c r` open and hence disjoint from its own frontier — gives `frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) = {u, v}`. Feeding that the Wolff estimate of `Conformal/ShortCrosscut.lean` then yields the statement the boundary correspondence consumes: at every boundary point of the disc, and below every prescribed radius, a conformal map has a crosscut whose image has diameter at most `ε` and whose two ends are two points of `frontier (f '' ball c r)` at distance at most `ε`.

That is exactly the input `TauCeti.IsJordanCurve.exists_pos_forall_exists_diam_le` of `TauCeti/Topology/JordanCurve/SmallArc.lean` runs on — two nearby points of a Jordan curve cut a small closed arc off it. Until now nothing joined the analytic side of L5, which produces short image crosscuts, to the topological side, which turns two nearby boundary points into a small boundary arc; the pair `{u, v}` produced here is that join. What is deliberately not claimed: the two ends may coincide, no hypothesis available at this stage excluding it, and the boundary piece the crosscut cuts off — `frontier (f '' ball c r) ∩ frontier (f '' (ball c r ∩ ball ζ ρ))`, the second geometric input of `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` — is untouched, being a matter of the image domain rather than of the crosscut.

The roadmap target is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5 — Carathéodory boundary correspondence** ("The concrete L5 milestone is the Jordan-domain case: the RMT map of a Jordan domain extends to a homeomorphism of closures"), on the route its `STATUS.md` frontier names: "the length–area (Koebe–Wolff) estimate that shows the boundary cluster sets are singletons", continuing the line of #1970 (an image crosscut ends in two points), #1981 and #1966 (crosscuts of an arbitrary domain) and #1884/#1950 (the length–area inequality and Wolff's lemma). L4 and the L5 prerequisites the file consumes — the crosscut decomposition, the cluster-set identification, the chord bound and Wolff's lemma — are all on `main`. As the roadmap requires of L5, this is new Lean formalization rather than a temporary shim: layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, and the pinned Mathlib has no boundary correspondence for conformal maps; the file does consume, transitively through `Conformal/Crosscut/Image.lean`, the L0–L3 shim `TauCeti.isOpen_image_of_differentiableOn_of_injOn`, to be refactored onto Mathlib's open mapping API once the upstream work lands. Everything is stated for scalar `ℂ`, per the roadmap's generality bar, over a general `ball c r` rather than the unit disc; `TauCeti.dist_le_diam_image_inter_sphere` needs no disc at all and is stated over an arbitrary domain. No Mathlib infrastructure was vendored.

The new module is `TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean` (232 lines). One existing file changes: `Conformal/Crosscut/EndpointLimit.lean` gains the named theorem `TauCeti.exists_biUnion_clusterSetOn_ball_inter_sphere_eq_pair`, extracted verbatim from the anonymous `have` inside the proof of `TauCeti.exists_closure_image_ball_inter_sphere_eq_insert`, which is then reproved from it; that extraction is what the new file consumes, so no proof step is duplicated. `lake build` and `lake exe axioms` are green (22439 declarations audited, all within `propext`, `Classical.choice`, `Quot.sound`).

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"image-crosscut-ends-on-frontier"}-->

🤖 Prepared with Claude Code
