### PR TITLE
refactor(LFunction): build the modular-form L-function interface on Mathlib's ModularForm.L

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -6,42 +6,42 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.NumberTheory.LSeries.Convergence
-public import Mathlib.NumberTheory.ModularForms.Bounds
+public import Mathlib.NumberTheory.ModularForms.LFunction
 
 /-!
-# L-functions of modular forms
+# Dirichlet series of modular forms
 
-For a weight-`k` modular form `f` with `q`-expansion `f(τ) = Σ_{n≥0} aₙ qⁿ`, the
-**L-function** is the Dirichlet series `L(s, f) = Σ_{n ≥ 1} aₙ · n^{-s}`, built on
-Mathlib's `LSeries` infrastructure applied to the coefficient sequence of
-`UpperHalfPlane.qExpansion` at the strict width of the level at `∞`.
+Mathlib's `Mathlib/NumberTheory/ModularForms/LFunction.lean` defines the completed
+L-function `ModularForm.Λ` and the L-function `ModularForm.L` of a modular form for an
+arithmetic level, with the Dirichlet-series identities `ModularForm.hasSum_L` and
+`CuspForm.hasSum_L` on their convergence half-planes, and — for cusp forms — entire
+continuation (`CuspForm.differentiable_L`). This file supplies the interface between that
+API and Mathlib's `LSeries` of the `q`-expansion coefficients:
 
-## Main definitions
-
-* `ModularForm.lCoeff f`: the coefficient sequence `n ↦ aₙ(f)`, as `ℕ → ℂ`.
-* `ModularForm.lSeries f`: the L-function `s ↦ LSeries (lCoeff f) s`.
-* `ModularForm.imAxis f`: `f` along the positive imaginary axis (`0` off it). For a
-  *cusp form* `f`, whose decay makes the integral converge, the Mellin transform of this
-  restriction is the completed L-function; for general modular forms that reading needs
-  the constant term subtracted first.
+* Hecke's abscissa-of-absolute-convergence bounds for the coefficient series, and
+* the identification of `LSeries` of the coefficients with `ModularForm.L` on the
+  convergence half-plane, in both the modular and the cuspidal ranges.
 
 ## Main results
 
-Hecke's convergence bounds, from Mathlib's `q`-expansion coefficient growth:
-
-* `ModularForm.abscissaOfAbsConv_lCoeff_le`: for a modular form of weight `k ≥ 0`,
-  the abscissa of absolute convergence is at most `k + 1` (from `aₙ = O(nᵏ)`).
-* `ModularForm.abscissaOfAbsConv_lCoeff_le_cuspForm`: for a cusp form, at most
-  `k/2 + 1` (from Hecke's `aₙ = O(n^{k/2})`).
+* `ModularForm.abscissaOfAbsConv_qExpansion_coeff_le`: for a modular form of weight
+  `k ≥ 0`, the abscissa of absolute convergence of the coefficient series is at most
+  `k + 1` (from `aₙ = O(nᵏ)`).
+* `CuspForm.abscissaOfAbsConv_qExpansion_coeff_le`: for a cusp form, at most `k/2 + 1`
+  (from Hecke's `aₙ = O(n^{k/2})`).
+* `ModularForm.LSeries_qExpansion_coeff_eq`, `CuspForm.LSeries_qExpansion_coeff_eq`:
+  on the respective half-planes, `LSeries` of the coefficients is
+  `(h Γ)⁻ˢ · L hk f s` for Mathlib's `ModularForm.L`.
 
 The non-cuspidal abscissa bound `k + 1` is weaker than Diamond–Shurman Prop. 5.9.1
-(which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it is a
-separate milestone of the roadmap's Layer 7.
+(which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it, and the
+`LSeries.HasEntireExtension` corollary of `CuspForm.differentiable_L` (which needs the
+identification below the proven half-plane), are separate milestones of the roadmap's
+Layer 7.
 
 Ported from the AINTLIB `LeanModularForms` project
-(`LeanModularForms/Modularforms/LFunction.lean`), with the abscissa bounds — advertised
-but not present there — supplied from Mathlib's `ModularFormClass.qExpansion_isBigO` and
-`CuspFormClass.qExpansion_isBigO`.
+(`LeanModularForms/Modularforms/LFunction.lean`), rebuilt to consume Mathlib's
+`ModularForm.L` rather than defining a parallel Dirichlet series.
 
 ## References
 
@@ -58,70 +58,73 @@ noncomputable section
 
 open Filter LSeries UpperHalfPlane
 
+variable {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic]
+variable {F : Type*} [FunLike F ℍ ℂ] {s : ℂ}
+
 namespace ModularForm
 
-variable {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)}
-variable {F : Type*} [FunLike F ℍ ℂ]
-
-/-- The coefficient sequence `n ↦ aₙ(f)` of the `q`-expansion of `f` at the strict width
-at `∞` of its level, viewed as `ℕ → ℂ` — the natural input to Mathlib's `LSeries`. -/
-def lCoeff [ModularFormClass F Γ k] (f : F) : ℕ → ℂ :=
-  fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n
-
-@[simp]
-lemma lCoeff_apply [ModularFormClass F Γ k] (f : F) (n : ℕ) :
-    lCoeff f n = (qExpansion Γ.strictWidthInfty f).coeff n := (rfl)
-
-/-- The **L-function** of a modular form: the Dirichlet series
-`L(s, f) = Σ_{n ≥ 1} aₙ(f) · n^{-s}` of its `q`-expansion coefficients. -/
-def lSeries [ModularFormClass F Γ k] (f : F) (s : ℂ) : ℂ :=
-  LSeries (lCoeff f) s
-
-@[simp]
-lemma lSeries_apply [ModularFormClass F Γ k] (f : F) (s : ℂ) :
-    lSeries f s = LSeries (lCoeff f) s := (rfl)
-
-
-/-- **A function on `ℍ` along the positive imaginary axis**: `t > 0` maps to `f(i·t)`,
-and `t ≤ 0` to `0`. For a cusp form `f`, whose decay makes the integral converge, the
-Mellin transform of this restriction is the completed L-function. -/
-def imAxis (f : ℍ → ℂ) (t : ℝ) : ℂ :=
-  if h : 0 < t then
-    f ⟨Complex.I * (t : ℂ), by simpa only [Complex.I_mul_im, Complex.ofReal_re] using h⟩
-  else 0
-
-@[simp]
-lemma imAxis_apply_of_pos (f : ℍ → ℂ) {t : ℝ} (ht : 0 < t) :
-    imAxis f t =
-      f ⟨Complex.I * (t : ℂ), by simpa only [Complex.I_mul_im, Complex.ofReal_re] using ht⟩ := by
-  rw [imAxis, dif_pos ht]
-
-@[simp]
-lemma imAxis_apply_of_nonpos (f : ℍ → ℂ) {t : ℝ} (ht : ¬ 0 < t) :
-    imAxis f t = 0 := by
-  rw [imAxis, dif_neg ht]
-
-variable [Γ.IsArithmetic]
-
-/-- **Hecke's abscissa bound for modular forms**: for weight `k ≥ 0`, the L-series of a
-modular form converges absolutely for `Re s > k + 1` (from `aₙ = O(nᵏ)`). -/
-theorem abscissaOfAbsConv_lCoeff_le (hk : 0 ≤ k) [ModularFormClass F Γ k] (f : F) :
-    abscissaOfAbsConv (lCoeff f) ≤ ((k : ℝ) : EReal) + 1 := by
+/-- **Hecke's abscissa bound for modular forms**: for weight `k ≥ 0`, the Dirichlet series
+of the `q`-expansion coefficients converges absolutely for `Re s > k + 1`
+(from `aₙ = O(nᵏ)`). -/
+theorem abscissaOfAbsConv_qExpansion_coeff_le (hk : 0 ≤ k) [ModularFormClass F Γ k]
+    (f : F) :
+    abscissaOfAbsConv (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) ≤
+      ((k : ℝ) : EReal) + 1 := by
   refine LSeries.abscissaOfAbsConv_le_of_isBigO_rpow ?_
-  have h := ModularFormClass.qExpansion_isBigO hk f
-  have h_lCoeff : lCoeff f = fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n :=
-    funext (lCoeff_apply f)
-  rw [h_lCoeff]
-  refine h.congr' EventuallyEq.rfl (Eventually.of_forall fun n ↦ ?_)
+  refine (ModularFormClass.qExpansion_isBigO hk f).congr' EventuallyEq.rfl
+    (Eventually.of_forall fun n ↦ ?_)
   simp only [Real.rpow_intCast]
 
-/-- **Hecke's abscissa bound for cusp forms**: the L-series of a cusp form converges
-absolutely for `Re s > k/2 + 1` (from Hecke's `aₙ = O(n^{k/2})`). -/
-theorem abscissaOfAbsConv_lCoeff_le_cuspForm [CuspFormClass F Γ k] (f : F) :
-    abscissaOfAbsConv (lCoeff f) ≤ (((k : ℝ) / 2 : ℝ) : EReal) + 1 := by
-  have h_lCoeff : lCoeff f = fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n :=
-    funext (lCoeff_apply f)
-  rw [h_lCoeff]
-  exact LSeries.abscissaOfAbsConv_le_of_isBigO_rpow (CuspFormClass.qExpansion_isBigO f)
+/-- On the half-plane `Re s > k + 1`, the Dirichlet series of the `q`-expansion
+coefficients is Mathlib's `ModularForm.L`, up to the width factor. -/
+theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [ModularFormClass F Γ k] (f : F)
+    (hs : k + 1 < s.re) :
+    LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
+      (Γ.strictWidthInfty : ℂ) ^ (-s) * L hk f s := by
+  have hs0 : s ≠ 0 := by
+    rintro rfl
+    simp only [Complex.zero_re] at hs
+    linarith [show (0 : ℝ) ≤ k from mod_cast hk.le]
+  have hfun : LSeries.term (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
+      fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n / (n : ℂ) ^ s := by
+    funext n
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp [Complex.zero_cpow hs0]
+    · simp [hn]
+  have h := hasSum_L hk f hs
+  rw [← hfun] at h
+  exact LSeriesHasSum.LSeries_eq h
 
 end ModularForm
+
+namespace CuspForm
+
+/-- **Hecke's abscissa bound for cusp forms**: the Dirichlet series of the `q`-expansion
+coefficients converges absolutely for `Re s > k/2 + 1` (from Hecke's
+`aₙ = O(n^{k/2})`). -/
+theorem abscissaOfAbsConv_qExpansion_coeff_le [CuspFormClass F Γ k] (f : F) :
+    abscissaOfAbsConv (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) ≤
+      (((k : ℝ) / 2 : ℝ) : EReal) + 1 :=
+  LSeries.abscissaOfAbsConv_le_of_isBigO_rpow (CuspFormClass.qExpansion_isBigO f)
+
+/-- On the half-plane `Re s > k/2 + 1`, the Dirichlet series of the `q`-expansion
+coefficients of a cusp form is Mathlib's `ModularForm.L`, up to the width factor. -/
+theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
+    (hs : k / 2 + 1 < s.re) :
+    LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
+      (Γ.strictWidthInfty : ℂ) ^ (-s) * ModularForm.L hk f s := by
+  have hs0 : s ≠ 0 := by
+    rintro rfl
+    simp only [Complex.zero_re] at hs
+    linarith [show (0 : ℝ) < (k : ℝ) from mod_cast hk]
+  have hfun : LSeries.term (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
+      fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n / (n : ℂ) ^ s := by
+    funext n
+    rcases eq_or_ne n 0 with rfl | hn
+    · simp [Complex.zero_cpow hs0]
+    · simp [hn]
+  have h := hasSum_L hk f hs
+  rw [← hfun] at h
+  exact LSeriesHasSum.LSeries_eq h
+
+end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -31,7 +31,7 @@ API and Mathlib's `LSeries` of the `q`-expansion coefficients:
   (from Hecke's `aₙ = O(n^{k/2})`).
 * `ModularForm.LSeries_qExpansion_coeff_eq`, `CuspForm.LSeries_qExpansion_coeff_eq`:
   on the respective half-planes, `LSeries` of the coefficients is
-  `(h Γ)⁻ˢ · L hk f s` for Mathlib's `ModularForm.L`.
+  `(Γ.strictWidthInfty : ℂ) ^ (-s) * L hk f s` for Mathlib's `ModularForm.L`.
 
 The non-cuspidal abscissa bound `k + 1` is weaker than Diamond–Shurman Prop. 5.9.1
 (which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it, and the
@@ -85,14 +85,8 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [ModularFormClass F Γ k] (f : 
     rintro rfl
     simp only [Complex.zero_re] at hs
     linarith [show (0 : ℝ) ≤ k from mod_cast hk.le]
-  have hfun : LSeries.term (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
-      fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n / (n : ℂ) ^ s := by
-    funext n
-    rcases eq_or_ne n 0 with rfl | hn
-    · simp [Complex.zero_cpow hs0]
-    · simp [hn]
   have h := hasSum_L hk f hs
-  rw [← hfun] at h
+  rw [← funext (LSeries.term_of_ne_zero' hs0 _)] at h
   exact LSeriesHasSum.LSeries_eq h
 
 end ModularForm
@@ -117,14 +111,8 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
     rintro rfl
     simp only [Complex.zero_re] at hs
     linarith [show (0 : ℝ) < (k : ℝ) from mod_cast hk]
-  have hfun : LSeries.term (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
-      fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n / (n : ℂ) ^ s := by
-    funext n
-    rcases eq_or_ne n 0 with rfl | hn
-    · simp [Complex.zero_cpow hs0]
-    · simp [hn]
   have h := hasSum_L hk f hs
-  rw [← hfun] at h
+  rw [← funext (LSeries.term_of_ne_zero' hs0 _)] at h
   exact LSeriesHasSum.LSeries_eq h
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -61,6 +61,13 @@ open Filter LSeries UpperHalfPlane
 variable {k : ℤ} {Γ : Subgroup (GL (Fin 2) ℝ)} [Γ.IsArithmetic]
 variable {F : Type*} [FunLike F ℍ ℂ] {s : ℂ}
 
+/-- The `HasSum`-to-`LSeries` boundary shared by the identification theorems below:
+plain Dirichlet sums at `s ≠ 0` converging to `v` identify `LSeries a s` with `v`. -/
+private lemma LSeries_eq_of_hasSum {a : ℕ → ℂ} {v : ℂ} (hs0 : s ≠ 0)
+    (h : HasSum (fun n : ℕ ↦ a n / (n : ℂ) ^ s) v) : LSeries a s = v := by
+  rw [← funext (LSeries.term_of_ne_zero' hs0 a)] at h
+  exact LSeriesHasSum.LSeries_eq h
+
 namespace ModularForm
 
 /-- **Hecke's abscissa bound for modular forms**: for weight `k ≥ 0`, the Dirichlet series
@@ -77,6 +84,7 @@ theorem abscissaOfAbsConv_qExpansion_coeff_le (hk : 0 ≤ k) [ModularFormClass F
 
 /-- On the half-plane `Re s > k + 1`, the Dirichlet series of the `q`-expansion
 coefficients is Mathlib's `ModularForm.L`, up to the width factor. -/
+@[simp]
 theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [ModularFormClass F Γ k] (f : F)
     (hs : k + 1 < s.re) :
     LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
@@ -84,10 +92,9 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [ModularFormClass F Γ k] (f : 
   have hs0 : s ≠ 0 := by
     rintro rfl
     simp only [Complex.zero_re] at hs
-    linarith [show (0 : ℝ) ≤ k from mod_cast hk.le]
-  have h := hasSum_L hk f hs
-  rw [← funext (LSeries.term_of_ne_zero' hs0 _)] at h
-  exact LSeriesHasSum.LSeries_eq h
+    have hk' : (0 : ℝ) ≤ (k : ℝ) := mod_cast hk.le
+    linarith
+  exact LSeries_eq_of_hasSum hs0 (hasSum_L hk f hs)
 
 end ModularForm
 
@@ -103,6 +110,7 @@ theorem abscissaOfAbsConv_qExpansion_coeff_le [CuspFormClass F Γ k] (f : F) :
 
 /-- On the half-plane `Re s > k/2 + 1`, the Dirichlet series of the `q`-expansion
 coefficients of a cusp form is Mathlib's `ModularForm.L`, up to the width factor. -/
+@[simp]
 theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
     (hs : k / 2 + 1 < s.re) :
     LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
@@ -110,9 +118,8 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
   have hs0 : s ≠ 0 := by
     rintro rfl
     simp only [Complex.zero_re] at hs
-    linarith [show (0 : ℝ) < (k : ℝ) from mod_cast hk]
-  have h := hasSum_L hk f hs
-  rw [← funext (LSeries.term_of_ne_zero' hs0 _)] at h
-  exact LSeriesHasSum.LSeries_eq h
+    have hk' : (0 : ℝ) < (k : ℝ) := mod_cast hk
+    linarith
+  exact LSeries_eq_of_hasSum hs0 (hasSum_L hk f hs)
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -83,8 +83,9 @@ theorem abscissaOfAbsConv_qExpansion_coeff_le (hk : 0 ≤ k) [ModularFormClass F
   simp only [Real.rpow_intCast]
 
 /-- On the half-plane `Re s > k + 1`, the Dirichlet series of the `q`-expansion
-coefficients is Mathlib's `ModularForm.L`, up to the width factor. -/
-@[simp]
+coefficients is Mathlib's `ModularForm.L`, up to the width factor. Not `@[simp]`: the
+positivity witness `hk` occurs in the right-hand side `L hk f s`, so the rewrite cannot
+fire from the left-hand side alone (simpNF rejects it). -/
 theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [ModularFormClass F Γ k] (f : F)
     (hs : k + 1 < s.re) :
     LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =
@@ -109,8 +110,8 @@ theorem abscissaOfAbsConv_qExpansion_coeff_le [CuspFormClass F Γ k] (f : F) :
   LSeries.abscissaOfAbsConv_le_of_isBigO_rpow (CuspFormClass.qExpansion_isBigO f)
 
 /-- On the half-plane `Re s > k/2 + 1`, the Dirichlet series of the `q`-expansion
-coefficients of a cusp form is Mathlib's `ModularForm.L`, up to the width factor. -/
-@[simp]
+coefficients of a cusp form is Mathlib's `ModularForm.L`, up to the width factor.
+Not `@[simp]`: as with the modular-form version, `hk` occurs in the right-hand side. -/
 theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
     (hs : k / 2 + 1 < s.re) :
     LSeries (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) s =


### PR DESCRIPTION
Mathlib's `Mathlib/NumberTheory/ModularForms/LFunction.lean` (D. Loeffler) now provides the L-function of a modular form of arithmetic level: the completed `ModularForm.Λ`, the L-function `ModularForm.L`, the Dirichlet-series identities `ModularForm.hasSum_L`/`CuspForm.hasSum_L` on the convergence half-planes, and — for cusp forms — entire continuation (`CuspForm.differentiable_Λ`/`differentiable_L`).

Per the repo's defer-to-Mathlib rule, this PR deletes the parallel definitions in `TauCeti/NumberTheory/ModularForms/LFunction.lean` (`lCoeff`, `lSeries`, `imAxis` and their apply lemmas — no compatibility aliases) and rebuilds the file as the interface between Mathlib's `ModularForm.L` and Mathlib's `LSeries`:

- `ModularForm.abscissaOfAbsConv_qExpansion_coeff_le` and `CuspForm.abscissaOfAbsConv_qExpansion_coeff_le`: Hecke's convergence bounds (`k + 1`, resp. `k/2 + 1`) for the coefficient series, stated over the raw `qExpansion` coefficient spelling.
- `ModularForm.LSeries_qExpansion_coeff_eq` and `CuspForm.LSeries_qExpansion_coeff_eq`: on the respective half-planes, `LSeries` of the coefficients equals `(Γ.strictWidthInfty)^(-s) * ModularForm.L hk f s`.

The `LSeries.HasEntireExtension` corollary of `CuspForm.differentiable_L` — the roadmap's `lSeriesN_hasEntireExtension` milestone — needs the identification below the proven half-plane (an identity-theorem transfer along the lines of `HasEntireExtension.unique`) and is deliberately left as the next Layer-7 step; this PR keeps one topic.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5