### PR TITLE
feat: prove the degree of an irreducible character divides the group order

### DIFF
--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -121,7 +121,7 @@ times the single value the class function takes there.
 
 This is the substitution that turns a sum over the group, such as the one pairing two characters,
 into a sum over the columns of a character table. -/
-theorem sum_eq_sum_conjClasses [Fintype G] [DecidableEq G] (f : ClassFunction k G) :
+theorem sum_eq_sum_conjClasses [Fintype G] [Fintype (ConjClasses G)] (f : ClassFunction k G) :
     ∑ g : G, f.1 g = ∑ C : ConjClasses G, (Nat.card C.carrier : k) * toConjClasses f C := by
   classical
   rw [← Fintype.sum_fiberwise (ConjClasses.mk (α := G)) fun g => f.1 g]

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -13,7 +13,8 @@ public import Mathlib.RepresentationTheory.Character
 
 This file defines functions on a group that are constant on conjugacy classes. It identifies
 their module with the module of functions on `ConjClasses G`, computes its dimension for finite
-groups, and shows that characters of representations are class functions.
+groups, shows that characters of representations are class functions, and evaluates a sum over a
+finite group one conjugacy class at a time.
 
 These are the indexing foundations for character tables.
 
@@ -113,6 +114,27 @@ theorem equivConjClasses_apply (f : ClassFunction k G) :
 theorem equivConjClasses_symm_apply (f : ConjClasses G → k) :
     equivConjClasses.symm f = ofConjClasses f :=
   (rfl)
+
+/-- **Summing a class function one conjugacy class at a time.** The conjugacy classes partition
+the group and a class function is constant on each of them, so each class contributes its size
+times the single value the class function takes there.
+
+This is the substitution that turns a sum over the group, such as the one pairing two characters,
+into a sum over the columns of a character table. -/
+theorem sum_eq_sum_conjClasses [Fintype G] [DecidableEq G] (f : ClassFunction k G) :
+    ∑ g : G, f.1 g = ∑ C : ConjClasses G, (Nat.card C.carrier : k) * toConjClasses f C := by
+  classical
+  rw [← Fintype.sum_fiberwise (ConjClasses.mk (α := G)) fun g => f.1 g]
+  refine Finset.sum_congr rfl fun C _ => ?_
+  have hconst : ∀ x : {g : G // ConjClasses.mk g = C}, f.1 x.1 = toConjClasses f C := by
+    rintro ⟨x, rfl⟩
+    exact (toConjClasses_mk f x).symm
+  have hcard : Nat.card C.carrier = Fintype.card {g : G // ConjClasses.mk g = C} :=
+    (Nat.card_congr
+      (Equiv.subtypeEquivRight fun _ => ConjClasses.mem_carrier_iff_mk_eq)).trans
+      (Nat.card_eq_fintype_card)
+  rw [Finset.sum_congr rfl fun x _ => hconst x, Finset.sum_const, Finset.card_univ, hcard,
+    nsmul_eq_mul]
 
 end ClassFunction
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -102,8 +102,7 @@ theorem finrank_mul_sum_centralCharacter_eq_card [Invertible (Nat.card G : k)] :
         ClassFunction.toConjClasses (ClassFunction.ofCharacter ρ.dual) C = Nat.card G := by
   classical
   -- First orthogonality for `ρ` against itself, with the normalising factor `|G|⁻¹` cleared.
-  have hself : Nonempty (_root_.Representation.Equiv ρ ρ) :=
-    ⟨_root_.Representation.Equiv.mk (LinearEquiv.refl k V) fun g => by ext v; simp⟩
+  have hself : Nonempty (_root_.Representation.Equiv ρ ρ) := ⟨.refl ρ⟩
   have horth : ∑ g : G, ρ.character g * ρ.character g⁻¹ = Nat.card G := by
     have h := _root_.Representation.char_orthonormal ρ ρ
     rw [if_pos hself,

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -27,8 +27,6 @@ rational algebraic integer is an integer, so `χ(1)` divides `|G|`.
 
 ## Main statements
 
-* `TauCeti.Representation.sum_character_mul_character_inv`: first orthogonality for a single
-  irreducible character, in the form `∑_g χ(g) χ(g⁻¹) = |G|`.
 * `TauCeti.Representation.finrank_mul_sum_centralCharacter_eq_card`: the division-free identity
   `χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`.
 * `TauCeti.Representation.finrank_dvd_card` and `TauCeti.FDRep.finrank_dvd_card`: the degree of an
@@ -70,7 +68,7 @@ private theorem dvd_of_isIntegral_of_natCast_mul_eq {k : Type*} [Field k] [CharZ
     (isIntegral_algebraMap_iff (algebraMap ℚ k).injective).mp (hz' ▸ hz)
   obtain ⟨y, hy⟩ := IsIntegrallyClosed.algebraMap_eq_of_integral hq
   have hyq : (y : ℚ) * (n : ℚ) = (m : ℚ) := by
-    rw [show ((y : ℤ) : ℚ) = algebraMap ℤ ℚ y from rfl, hy, div_mul_cancel₀]
+    rw [← eq_intCast (algebraMap ℤ ℚ) y, hy, div_mul_cancel₀]
     exact Nat.cast_ne_zero.mpr hn
   refine Int.natCast_dvd_natCast.mp ⟨y, ?_⟩
   exact_mod_cast (by linarith : (m : ℚ) = (n : ℚ) * (y : ℚ))
@@ -78,28 +76,6 @@ private theorem dvd_of_isIntegral_of_natCast_mul_eq {k : Type*} [Field k] [CharZ
 namespace Representation
 
 variable {k G V : Type*} [Field k] [Group G] [AddCommGroup V] [Module k V]
-
-section Orthogonality
-
-variable [Fintype G] [IsAlgClosed k] [FiniteDimensional k V] (ρ : Representation k G V)
-  [ρ.IsIrreducible]
-
-/-- **First orthogonality for a single irreducible character**, in division-free form:
-`∑_g χ(g) χ(g⁻¹) = |G|`.
-
-This is Mathlib's `Representation.char_orthonormal` for `ρ` against itself, with the normalising
-factor `|G|⁻¹` cleared. -/
-theorem sum_character_mul_character_inv [Invertible (Nat.card G : k)] :
-    ∑ g : G, ρ.character g * ρ.character g⁻¹ = Nat.card G := by
-  classical
-  have hself : Nonempty (_root_.Representation.Equiv ρ ρ) :=
-    ⟨_root_.Representation.Equiv.mk (LinearEquiv.refl k V) fun g => by ext v; simp⟩
-  have h := _root_.Representation.char_orthonormal ρ ρ
-  rw [if_pos hself,
-    inv_mul_eq_iff_eq_mul₀ (Invertible.ne_zero (a := (Nat.card G : k)))] at h
-  simpa using h
-
-end Orthogonality
 
 section Divisibility
 
@@ -125,7 +101,15 @@ theorem finrank_mul_sum_centralCharacter_eq_card [Invertible (Nat.card G : k)] :
     (finrank k V : k) * ∑ C : ConjClasses G, centralCharacter ρ (classSumCenter C) *
         ClassFunction.toConjClasses (ClassFunction.ofCharacter ρ.dual) C = Nat.card G := by
   classical
-  rw [Finset.mul_sum, ← sum_character_mul_character_inv ρ,
+  -- First orthogonality for `ρ` against itself, with the normalising factor `|G|⁻¹` cleared.
+  have hself : Nonempty (_root_.Representation.Equiv ρ ρ) :=
+    ⟨_root_.Representation.Equiv.mk (LinearEquiv.refl k V) fun g => by ext v; simp⟩
+  have horth : ∑ g : G, ρ.character g * ρ.character g⁻¹ = Nat.card G := by
+    have h := _root_.Representation.char_orthonormal ρ ρ
+    rw [if_pos hself,
+      inv_mul_eq_iff_eq_mul₀ (Invertible.ne_zero (a := (Nat.card G : k)))] at h
+    simpa using h
+  rw [Finset.mul_sum, ← horth,
     ClassFunction.sum_eq_sum_conjClasses
       (⟨_, character_mul_character_inv_mem_classFunction ρ⟩ : ClassFunction k G)]
   refine Finset.sum_congr rfl fun C _ => ?_

--- a/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Degree.lean
@@ -1,0 +1,184 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.CentralCharacter
+public import TauCeti.RepresentationTheory.CharacterTable.Values
+public import Mathlib.Algebra.GCDMonoid.IntegrallyClosed
+
+/-!
+# The degree of an irreducible character divides the group order
+
+For an irreducible representation `ρ` of a finite group `G` over an algebraically closed field of
+characteristic zero, the degree `χ(1) = dim V` divides `|G|`.
+
+The proof is the classical one. First orthogonality gives `∑_g χ(g) χ(g⁻¹) = |G|`. Collecting that
+sum one conjugacy class at a time and substituting the class-sum identity
+`ωᵪ(K_C) · χ(1) = |C| · χ(g_C)` for the central character turns it into
+
+`χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`.
+
+Every factor of the remaining sum is an algebraic integer -- the values of a central character on
+the class sums because the class sums are integral over `ℤ`, the character values because they are
+sums of roots of unity -- so `|G| / χ(1)` is an algebraic integer. It is also rational, and a
+rational algebraic integer is an integer, so `χ(1)` divides `|G|`.
+
+## Main statements
+
+* `TauCeti.Representation.sum_character_mul_character_inv`: first orthogonality for a single
+  irreducible character, in the form `∑_g χ(g) χ(g⁻¹) = |G|`.
+* `TauCeti.Representation.finrank_mul_sum_centralCharacter_eq_card`: the division-free identity
+  `χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`.
+* `TauCeti.Representation.finrank_dvd_card` and `TauCeti.FDRep.finrank_dvd_card`: the degree of an
+  irreducible representation divides the order of the group.
+
+## Implementation notes
+
+The character value at the inverse, `g ↦ χ(g⁻¹)`, is the character of the dual representation
+(`Representation.char_dual`), so the sum over conjugacy classes is indexed through
+`TauCeti.ClassFunction.toConjClasses` of that character rather than through a choice of class
+representatives. The corresponding representative form is
+`TauCeti.Representation.centralCharacter_classSumCenter_mul_character_one`.
+
+## References
+
+This proves the "degree divides the order" item of Layer 4 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md).
+See I. M. Isaacs, *Character Theory of Finite Groups*, Theorem 3.11, or J.-P. Serre, *Linear
+Representations of Finite Groups*, Section 6.5.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module (finrank)
+open scoped MonoidAlgebra
+
+/-- A rational algebraic integer is an integer, in the form used below: if `n · z = m` for natural
+numbers `m` and `n` with `n ≠ 0`, and `z` is integral over `ℤ` in a field of characteristic zero,
+then `n` divides `m`. -/
+private theorem dvd_of_isIntegral_of_natCast_mul_eq {k : Type*} [Field k] [CharZero k] {m n : ℕ}
+    {z : k} (hz : IsIntegral ℤ z) (h : (n : k) * z = m) (hn : n ≠ 0) : n ∣ m := by
+  have hnk : (n : k) ≠ 0 := Nat.cast_ne_zero.mpr hn
+  have hz' : algebraMap ℚ k ((m : ℚ) / (n : ℚ)) = z := by
+    rw [map_div₀, map_natCast, map_natCast, eq_comm, eq_div_iff hnk, mul_comm]
+    exact h
+  have hq : IsIntegral ℤ ((m : ℚ) / (n : ℚ)) :=
+    (isIntegral_algebraMap_iff (algebraMap ℚ k).injective).mp (hz' ▸ hz)
+  obtain ⟨y, hy⟩ := IsIntegrallyClosed.algebraMap_eq_of_integral hq
+  have hyq : (y : ℚ) * (n : ℚ) = (m : ℚ) := by
+    rw [show ((y : ℤ) : ℚ) = algebraMap ℤ ℚ y from rfl, hy, div_mul_cancel₀]
+    exact Nat.cast_ne_zero.mpr hn
+  refine Int.natCast_dvd_natCast.mp ⟨y, ?_⟩
+  exact_mod_cast (by linarith : (m : ℚ) = (n : ℚ) * (y : ℚ))
+
+namespace Representation
+
+variable {k G V : Type*} [Field k] [Group G] [AddCommGroup V] [Module k V]
+
+section Orthogonality
+
+variable [Fintype G] [IsAlgClosed k] [FiniteDimensional k V] (ρ : Representation k G V)
+  [ρ.IsIrreducible]
+
+/-- **First orthogonality for a single irreducible character**, in division-free form:
+`∑_g χ(g) χ(g⁻¹) = |G|`.
+
+This is Mathlib's `Representation.char_orthonormal` for `ρ` against itself, with the normalising
+factor `|G|⁻¹` cleared. -/
+theorem sum_character_mul_character_inv [Invertible (Nat.card G : k)] :
+    ∑ g : G, ρ.character g * ρ.character g⁻¹ = Nat.card G := by
+  classical
+  have hself : Nonempty (_root_.Representation.Equiv ρ ρ) :=
+    ⟨_root_.Representation.Equiv.mk (LinearEquiv.refl k V) fun g => by ext v; simp⟩
+  have h := _root_.Representation.char_orthonormal ρ ρ
+  rw [if_pos hself,
+    inv_mul_eq_iff_eq_mul₀ (Invertible.ne_zero (a := (Nat.card G : k)))] at h
+  simpa using h
+
+end Orthogonality
+
+section Divisibility
+
+/-- The pointwise product `g ↦ χ(g) χ(g⁻¹)` is a class function: conjugation acts on `g` and on
+`g⁻¹` simultaneously. -/
+private theorem character_mul_character_inv_mem_classFunction (ρ : Representation k G V) :
+    (fun g : G => ρ.character g * ρ.character g⁻¹) ∈ ClassFunction k G := by
+  refine ClassFunction.mem_iff.mpr fun g h => ?_
+  have hinv : (h * g * h⁻¹)⁻¹ = h * g⁻¹ * h⁻¹ := by group
+  rw [hinv, ρ.char_conj, ρ.char_conj]
+
+variable [Fintype G] [DecidableEq G] [IsAlgClosed k] [FiniteDimensional k V]
+  (ρ : Representation k G V) [ρ.IsIrreducible]
+
+/-- **The degree times an algebraic integer is the group order.**
+
+Collecting first orthogonality one conjugacy class at a time and substituting
+`ωᵪ(K_C) · χ(1) = |C| · χ(g_C)` gives `χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`, where `g_C` is any
+element of the class `C` and the value `χ(g_C⁻¹)` is read off the character of the dual
+representation. Both factors of each summand are algebraic integers, which is what makes this the
+divisibility statement `TauCeti.Representation.finrank_dvd_card`. -/
+theorem finrank_mul_sum_centralCharacter_eq_card [Invertible (Nat.card G : k)] :
+    (finrank k V : k) * ∑ C : ConjClasses G, centralCharacter ρ (classSumCenter C) *
+        ClassFunction.toConjClasses (ClassFunction.ofCharacter ρ.dual) C = Nat.card G := by
+  classical
+  rw [Finset.mul_sum, ← sum_character_mul_character_inv ρ,
+    ClassFunction.sum_eq_sum_conjClasses
+      (⟨_, character_mul_character_inv_mem_classFunction ρ⟩ : ClassFunction k G)]
+  refine Finset.sum_congr rfl fun C _ => ?_
+  obtain ⟨g, rfl⟩ := ConjClasses.exists_rep C
+  have hω := centralCharacter_classSumCenter_mul_character_one ρ (rfl : ConjClasses.mk g = _)
+  rw [ρ.char_one] at hω
+  have hdual : ClassFunction.toConjClasses (ClassFunction.ofCharacter ρ.dual)
+      (ConjClasses.mk g) = ρ.character g⁻¹ := by
+    rw [ClassFunction.toConjClasses_mk, ClassFunction.ofCharacter_apply, ρ.char_dual]
+  rw [hdual, ClassFunction.toConjClasses_mk, ← mul_assoc, mul_comm (finrank k V : k), hω,
+    mul_assoc]
+
+end Divisibility
+
+section Dvd
+
+variable [Finite G] [IsAlgClosed k] [CharZero k] [FiniteDimensional k V]
+  (ρ : Representation k G V) [ρ.IsIrreducible]
+
+include ρ in
+/-- **The degree of an irreducible character divides the order of the group.**
+
+Over an algebraically closed field of characteristic zero, the dimension of an irreducible
+representation of a finite group `G` divides `|G|`. -/
+theorem finrank_dvd_card : finrank k V ∣ Nat.card G := by
+  classical
+  let _ : Fintype G := Fintype.ofFinite G
+  have hcard : (Nat.card G : k) ≠ 0 := Nat.cast_ne_zero.mpr Nat.card_pos.ne'
+  have : Invertible (Nat.card G : k) := invertibleOfNonzero hcard
+  have : Nontrivial ρ.asModule := IsSimpleModule.nontrivial k[G] ρ.asModule
+  have : Nontrivial V := ρ.asModuleEquiv.symm.toEquiv.nontrivial
+  refine dvd_of_isIntegral_of_natCast_mul_eq (k := k) ?_
+    (finrank_mul_sum_centralCharacter_eq_card ρ) Module.finrank_pos.ne'
+  refine IsIntegral.sum _ fun C _ => IsIntegral.mul
+    (isIntegral_centralCharacter_classSumCenter ρ C) ?_
+  obtain ⟨g, rfl⟩ := ConjClasses.exists_rep C
+  rw [ClassFunction.toConjClasses_mk, ClassFunction.ofCharacter_apply]
+  exact isIntegral_char ρ.dual (isOfFinOrder_of_finite g).orderOf_pos.ne' (pow_orderOf_eq_one g)
+
+end Dvd
+
+end Representation
+
+namespace FDRep
+
+variable {k G : Type*} [Field k] [IsAlgClosed k] [CharZero k] [Group G] [Finite G]
+
+/-- **The degree of an irreducible character divides the order of the group**, for a bundled
+finite-dimensional representation. -/
+theorem finrank_dvd_card (X : FDRep k G) [_root_.Representation.IsIrreducible X.ρ] :
+    finrank k X ∣ Nat.card G :=
+  Representation.finrank_dvd_card X.ρ
+
+end FDRep
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the degree of an irreducible character divides the order of the group: over an algebraically closed field of characteristic zero, the dimension of an irreducible representation of a finite group `G` divides `|G|`. The proof is the classical one. First orthogonality, cleared of its normalising factor, gives `∑_g χ(g) χ(g⁻¹) = |G|`; collecting that sum one conjugacy class at a time and substituting the class-sum identity `ωᵪ(K_C) · χ(1) = |C| · χ(g_C)` for the central character turns it into the division-free identity `χ(1) · ∑_C ωᵪ(K_C) χ(g_C⁻¹) = |G|`. Every factor of the remaining sum is already known here to be an algebraic integer — the values of a central character on the class sums because the class sums are integral over `ℤ`, the character values because they are sums of roots of unity — so `|G| / χ(1)` is a rational algebraic integer, hence an integer.

`TauCeti/RepresentationTheory/CharacterTable/Degree.lean` is new and carries `finrank_mul_sum_centralCharacter_eq_card`, and `finrank_dvd_card` in both its `Representation` and its `FDRep` form. The cleared form of first orthogonality stays a local `have` inside the former: it is a one-step consequence of Mathlib's `Representation.char_orthonormal`, used once, and its `FDRep` counterpart is already Mathlib's `FDRep.simple_iff_char_is_norm_one`. The sum over classes is indexed through `ClassFunction.toConjClasses` of the character of the dual representation rather than through a choice of class representatives, so no representative appears in any statement.

The one prerequisite this needed is `ClassFunction.sum_eq_sum_conjClasses`, added to `TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean`: a sum of a class function over a finite group is the sum over conjugacy classes of the class size times the single value taken on that class. That is the general shape of the "sum over the group becomes a sum over the columns of the character table" step, and it belongs beside the rest of the class-function API rather than in the new file.

This advances the "degree divides the order" item of Layer 4, "the arithmetic of character values", of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`. It consumes, and does not duplicate, `Representation.isIntegral_char` from `CharacterTable/Values.lean` and `Representation.isIntegral_centralCharacter_classSumCenter` from `CharacterTable/CentralCharacter.lean`, both of which the roadmap listed in the same layer and which are already in the library. No Mathlib infrastructure was vendored, and no content is derived from any source repository.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"character-degree-divides-group-order"}-->

🤖 Prepared with Claude Code

