### PR TITLE
feat(ModularForms): the boundary contour is piecewise C1

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -6,7 +6,10 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
+public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 public import Mathlib.LinearAlgebra.AffineSpace.AffineMap
+public import Mathlib.MeasureTheory.Integral.CircleIntegral
+public import TauCeti.Analysis.Contour.PiecewiseC1On
 
 /-!
 # The boundary contour of the standard fundamental domain
@@ -26,6 +29,8 @@ anchors of the valence-formula contour.
   built from `AffineMap.lineMap` and `circleMap`).
 * `TauCeti.ModularForm.fdBoundary_apply_three`: the parameter `3` lands on `ρ`.
 * `TauCeti.ModularForm.fdBoundary_closed`: the contour is closed.
+* `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`, with
+  breakpoints at the four interior corners.
 
 ## References
 
@@ -284,6 +289,131 @@ lemma fdBoundary_apply_five (H : ℝ) : fdBoundary H 5 = 1 / 2 + H * Complex.I :
 /-- The boundary contour is closed. -/
 lemma fdBoundary_closed (H : ℝ) : fdBoundary H 5 = fdBoundary H 0 := by
   rw [fdBoundary_apply_five, fdBoundary_apply_zero]
+
+section Regularity
+
+open Set
+
+open scoped ContDiff
+
+variable {n : WithTop ℕ∞}
+
+/-- Segment 1 is smooth. -/
+lemma contDiff_fdBoundary_segment1 (H : ℝ) : ContDiff ℝ n (fdBoundary_segment1 H) :=
+  AffineMap.contDiff_lineMap _ _
+
+/-- Segment 2 is smooth. -/
+lemma contDiff_fdBoundary_segment2 : ContDiff ℝ n fdBoundary_segment2 :=
+  (contDiff_circleMap _ _).comp (by fun_prop)
+
+/-- Segment 3 is smooth. -/
+lemma contDiff_fdBoundary_segment3 : ContDiff ℝ n fdBoundary_segment3 :=
+  (contDiff_circleMap _ _).comp (by fun_prop)
+
+/-- Segment 4 is smooth. -/
+lemma contDiff_fdBoundary_segment4 (H : ℝ) : ContDiff ℝ n (fdBoundary_segment4 H) :=
+  (AffineMap.contDiff_lineMap _ _).comp (contDiff_id.sub contDiff_const)
+
+/-- Segment 5 is smooth. -/
+lemma contDiff_fdBoundary_segment5 (H : ℝ) : ContDiff ℝ n (fdBoundary_segment5 H) :=
+  (AffineMap.contDiff_lineMap _ _).comp (contDiff_id.sub contDiff_const)
+
+/-- On `[0, 1]` the path agrees with segment 1. -/
+lemma eqOn_fdBoundary_segment1 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segment1 H) (Icc 0 1) :=
+  fun _ ht ↦ fdBoundary_of_le_one ht.2
+
+/-- On `[1, 2]` the path agrees with segment 2. -/
+lemma eqOn_fdBoundary_segment2 (H : ℝ) : EqOn (fdBoundary H) fdBoundary_segment2 (Icc 1 2) := by
+  intro t ht
+  rcases eq_or_lt_of_le ht.1 with h1 | h1
+  · rw [← h1, fdBoundary_apply_one, fdBoundary_segment2_apply_one]
+  · exact fdBoundary_of_le_two h1 ht.2
+
+/-- On `[2, 3]` the path agrees with segment 3. -/
+lemma eqOn_fdBoundary_segment3 (H : ℝ) : EqOn (fdBoundary H) fdBoundary_segment3 (Icc 2 3) := by
+  intro t ht
+  rcases eq_or_lt_of_le ht.1 with h2 | h2
+  · rw [← h2, fdBoundary_apply_two, fdBoundary_segment3_apply_two]
+  · exact fdBoundary_of_le_three h2 ht.2
+
+/-- On `[3, 4]` the path agrees with segment 4. -/
+lemma eqOn_fdBoundary_segment4 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segment4 H) (Icc 3 4) := by
+  intro t ht
+  rcases eq_or_lt_of_le ht.1 with h3 | h3
+  · rw [← h3, fdBoundary_apply_three, fdBoundary_segment4_apply_three]
+  · exact fdBoundary_of_le_four h3 ht.2
+
+/-- On `[4, 5]` the path agrees with segment 5. -/
+lemma eqOn_fdBoundary_segment5 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segment5 H) (Icc 4 5) := by
+  intro t ht
+  rcases eq_or_lt_of_le ht.1 with h4 | h4
+  · rw [← h4, fdBoundary_apply_four, fdBoundary_segment5_apply_four]
+  · exact fdBoundary_of_gt_four h4
+
+private lemma fdBoundary_piece1 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 0 1) :=
+  (contDiff_fdBoundary_segment1 H).contDiffOn.congr (eqOn_fdBoundary_segment1 H)
+
+private lemma fdBoundary_piece2 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 2) :=
+  contDiff_fdBoundary_segment2.contDiffOn.congr (eqOn_fdBoundary_segment2 H)
+
+private lemma fdBoundary_piece3 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 2 3) :=
+  contDiff_fdBoundary_segment3.contDiffOn.congr (eqOn_fdBoundary_segment3 H)
+
+private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 3 4) :=
+  (contDiff_fdBoundary_segment4 H).contDiffOn.congr (eqOn_fdBoundary_segment4 H)
+
+private lemma fdBoundary_piece5 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 4 5) :=
+  (contDiff_fdBoundary_segment5 H).contDiffOn.congr (eqOn_fdBoundary_segment5 H)
+
+/-- The boundary path is continuous on the parameter interval `[0, 5]`. -/
+lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) := by
+  have h02 := ((fdBoundary_piece1 H).continuousOn).union_of_isClosed
+    ((fdBoundary_piece2 H).continuousOn) isClosed_Icc isClosed_Icc
+  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h02
+  have h03 := h02.union_of_isClosed ((fdBoundary_piece3 H).continuousOn) isClosed_Icc
+    isClosed_Icc
+  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h03
+  have h04 := h03.union_of_isClosed ((fdBoundary_piece4 H).continuousOn) isClosed_Icc
+    isClosed_Icc
+  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h04
+  have h05 := h04.union_of_isClosed ((fdBoundary_piece5 H).continuousOn) isClosed_Icc
+    isClosed_Icc
+  rwa [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h05
+
+private lemma contDiffOn_fdBoundary_subinterval (H : ℝ) {c d : ℝ}
+    (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryBreakpoints : Set ℝ) (Ioo c d)) :
+    ContDiffOn ℝ 1 (fdBoundary H) (Icc c d) := by
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryBreakpoints → m ∉ Ioo c d := fun m hm ↦
+    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
+  rcases le_or_gt d 1 with hd1 | hd1
+  · exact (fdBoundary_piece1 H).mono fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
+  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
+    rcases le_or_gt d 2 with hd2 | hd2
+    · exact (fdBoundary_piece2 H).mono fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd2⟩
+    · have hc2 : 2 ≤ c := le_of_not_gt fun hlt ↦ hbp 2 (by simp) ⟨hlt, hd2⟩
+      rcases le_or_gt d 3 with hd3 | hd3
+      · exact (fdBoundary_piece3 H).mono fun x hx ↦ ⟨hc2.trans hx.1, hx.2.trans hd3⟩
+      · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
+        rcases le_or_gt d 4 with hd4 | hd4
+        · exact (fdBoundary_piece4 H).mono fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩
+        · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
+          exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
+
+/-- The fundamental-domain boundary contour is piecewise `C¹` on `[0, 5]`, with breakpoints
+at the four interior corners. -/
+theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBoundary H) 0 5 := by
+  refine Contour.IsPiecewiseC1On.of_breakpoints ?_ fdBoundaryBreakpoints ?_ ?_
+  · rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)]
+    exact continuousOn_fdBoundary H
+  · intro x hx
+    rw [Finset.mem_coe, mem_fdBoundaryBreakpoints] at hx
+    rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5), max_eq_right (by norm_num : (0 : ℝ) ≤ 5)]
+    rcases hx with rfl | rfl | rfl | rfl <;> exact ⟨by norm_num, by norm_num⟩
+  · intro c d hcd hdis
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hcd
+    exact contDiffOn_fdBoundary_subinterval H hcd hdis
+
+end Regularity
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -361,11 +361,39 @@ private lemma fdBoundary_piece2 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc
 private lemma fdBoundary_piece3 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 2 3) :=
   contDiff_fdBoundary_segment3.contDiffOn.congr (eqOn_fdBoundary_segment3 H)
 
+private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 3) := by
+  have h_arc : ContDiff ℝ 1 fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)) :=
+    (contDiff_circleMap 0 1).comp (by fun_prop)
+  refine h_arc.contDiffOn.congr fun t ht ↦ ?_
+  rcases le_or_gt t 2 with h2 | h2
+  · rcases eq_or_lt_of_le ht.1 with h1 | h1
+    · rw [← h1, fdBoundary_apply_one, ← fdBoundary_segment2_apply_one,
+        fdBoundary_segment2_apply]
+      congr 1
+      ring
+    · rw [fdBoundary_of_le_two h1 h2, fdBoundary_segment2_apply]
+      congr 1
+      ring
+  · rw [fdBoundary_of_le_three h2 ht.2, fdBoundary_segment3_apply]
+    congr 1
+    ring
+
 private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 3 4) :=
   (contDiff_fdBoundary_segment4 H).contDiffOn.congr (eqOn_fdBoundary_segment4 H)
 
 private lemma fdBoundary_piece5 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 4 5) :=
   (contDiff_fdBoundary_segment5 H).contDiffOn.congr (eqOn_fdBoundary_segment5 H)
+
+
+/-- The genuinely nonsmooth junctions of the boundary contour: the two arcs continue one
+smooth circle parameterization through `t = 2`, so only `1`, `3`, and `4` are corners. -/
+def fdBoundaryCorners : Finset ℝ := {1, 3, 4}
+
+/-- Membership in the corner parameters. -/
+@[simp]
+lemma mem_fdBoundaryCorners {t : ℝ} : t ∈ fdBoundaryCorners ↔ t = 1 ∨ t = 3 ∨ t = 4 := by
+  unfold fdBoundaryCorners
+  simp
 
 /-- The boundary path is continuous: consecutive segments agree at the junctions. -/
 lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
@@ -386,40 +414,36 @@ lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
 lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
   (continuous_fdBoundary H).continuousOn
 
-/-- On every closed subinterval of `[0, 5]` whose interior avoids the four segment-junction
-parameters, the contour is `C¹` — the certificate that `fdBoundaryBreakpoints` is a valid
-breakpoint witness for `isPiecewiseC1On_fdBoundary`. (At the junction `t = 2` the two arcs
-continue the same smooth circle map, so it is a breakpoint of the parameterization, not a
-geometric corner.) -/
+/-- On every closed subinterval of `[0, 5]` whose interior avoids the three genuine
+corners, the contour is `C¹` — the certificate that `fdBoundaryCorners` is a valid
+breakpoint witness for `isPiecewiseC1On_fdBoundary`. The two arcs continue one smooth
+circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
-    (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryBreakpoints : Set ℝ) (Ioo c d)) :
+    (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ 1 (fdBoundary H) (Icc c d) := by
-  have hbp : ∀ m : ℝ, m ∈ fdBoundaryBreakpoints → m ∉ Ioo c d := fun m hm ↦
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
     Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
   rcases le_or_gt d 1 with hd1 | hd1
   · exact (fdBoundary_piece1 H).mono fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
   · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
-    rcases le_or_gt d 2 with hd2 | hd2
-    · exact (fdBoundary_piece2 H).mono fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd2⟩
-    · have hc2 : 2 ≤ c := le_of_not_gt fun hlt ↦ hbp 2 (by simp) ⟨hlt, hd2⟩
-      rcases le_or_gt d 3 with hd3 | hd3
-      · exact (fdBoundary_piece3 H).mono fun x hx ↦ ⟨hc2.trans hx.1, hx.2.trans hd3⟩
-      · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
-        rcases le_or_gt d 4 with hd4 | hd4
-        · exact (fdBoundary_piece4 H).mono fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩
-        · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
-          exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
+    rcases le_or_gt d 3 with hd3 | hd3
+    · exact (fdBoundary_piece13 H).mono fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩
+    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
+      rcases le_or_gt d 4 with hd4 | hd4
+      · exact (fdBoundary_piece4 H).mono fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩
+      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
+        exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
 
 /-- The fundamental-domain boundary contour is piecewise `C¹` on `[0, 5]`;
-`contDiffOn_fdBoundary` certifies the four segment junctions as a breakpoint witness. -/
+`contDiffOn_fdBoundary` certifies the three genuine corners as a breakpoint witness. -/
 theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBoundary H) 0 5 := by
-  refine Contour.IsPiecewiseC1On.of_breakpoints ?_ fdBoundaryBreakpoints ?_ ?_
+  refine Contour.IsPiecewiseC1On.of_breakpoints ?_ fdBoundaryCorners ?_ ?_
   · rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)]
     exact continuousOn_fdBoundary H
   · intro x hx
-    rw [Finset.mem_coe, mem_fdBoundaryBreakpoints] at hx
+    rw [Finset.mem_coe, mem_fdBoundaryCorners] at hx
     rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5), max_eq_right (by norm_num : (0 : ℝ) ≤ 5)]
-    rcases hx with rfl | rfl | rfl | rfl <;> exact ⟨by norm_num, by norm_num⟩
+    rcases hx with rfl | rfl | rfl <;> exact ⟨by norm_num, by norm_num⟩
   · intro c d hcd hdis
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hcd
     exact contDiffOn_fdBoundary H hcd hdis

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -355,12 +355,6 @@ lemma eqOn_fdBoundary_segment5 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segme
 private lemma fdBoundary_piece1 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 0 1) :=
   (contDiff_fdBoundary_segment1 H).contDiffOn.congr (eqOn_fdBoundary_segment1 H)
 
-private lemma fdBoundary_piece2 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 2) :=
-  contDiff_fdBoundary_segment2.contDiffOn.congr (eqOn_fdBoundary_segment2 H)
-
-private lemma fdBoundary_piece3 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 2 3) :=
-  contDiff_fdBoundary_segment3.contDiffOn.congr (eqOn_fdBoundary_segment3 H)
-
 private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 3) := by
   have h_arc : ContDiff ℝ 1 fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)) :=
     (contDiff_circleMap 0 1).comp (by fun_prop)

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -32,7 +32,7 @@ anchors of the valence-formula contour.
 * `TauCeti.ModularForm.fdBoundary_closed`: the contour is closed.
 * `TauCeti.ModularForm.continuous_fdBoundary`: the contour is (globally) continuous.
 * `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`
-  (`contDiffOn_fdBoundary` certifies `fdBoundaryBreakpoints` as a breakpoint witness).
+  (`contDiffOn_fdBoundary` certifies `fdBoundaryCorners` as a breakpoint witness).
 
 ## References
 
@@ -211,10 +211,11 @@ def fdBoundary (H : ℝ) : ℝ → ℂ := fun t ↦
   else if t ≤ 4 then fdBoundary_segment4 H t
   else fdBoundary_segment5 H t
 
-/-- The interior breakpoints of the five-segment parameterization. -/
+/-- The four interior subdivision parameters of the five-segment parameterization; the
+junction at `2` is smooth, so only `fdBoundaryCorners` are genuine corners. -/
 def fdBoundaryBreakpoints : Finset ℝ := {1, 2, 3, 4}
 
-/-- Membership in the breakpoints is being one of the four interior corners. -/
+/-- Membership in the four subdivision parameters. -/
 @[simp]
 lemma mem_fdBoundaryBreakpoints {t : ℝ} :
     t ∈ fdBoundaryBreakpoints ↔ t = 1 ∨ t = 2 ∨ t = 3 ∨ t = 4 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -30,6 +30,7 @@ anchors of the valence-formula contour.
   built from `AffineMap.lineMap` and `circleMap`).
 * `TauCeti.ModularForm.fdBoundary_apply_three`: the parameter `3` lands on `ρ`.
 * `TauCeti.ModularForm.fdBoundary_closed`: the contour is closed.
+* `TauCeti.ModularForm.continuous_fdBoundary`: the contour is (globally) continuous.
 * `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`
   (`contDiffOn_fdBoundary` certifies `fdBoundaryBreakpoints` as a breakpoint witness).
 
@@ -366,20 +367,24 @@ private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc
 private lemma fdBoundary_piece5 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 4 5) :=
   (contDiff_fdBoundary_segment5 H).contDiffOn.congr (eqOn_fdBoundary_segment5 H)
 
+/-- The boundary path is continuous: consecutive segments agree at the junctions. -/
+lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
+  unfold fdBoundary
+  refine Continuous.if_le (contDiff_fdBoundary_segment1 (n := 1) H).continuous
+    (Continuous.if_le (contDiff_fdBoundary_segment2 (n := 1)).continuous
+      (Continuous.if_le (contDiff_fdBoundary_segment3 (n := 1)).continuous
+        (Continuous.if_le (contDiff_fdBoundary_segment4 (n := 1) H).continuous
+          (contDiff_fdBoundary_segment5 (n := 1) H).continuous continuous_id continuous_const
+          fun t ht ↦ ?_)
+        continuous_id continuous_const fun t ht ↦ ?_)
+      continuous_id continuous_const fun t ht ↦ ?_)
+    continuous_id continuous_const fun t ht ↦ ?_
+  all_goals subst ht
+  all_goals norm_num
+
 /-- The boundary path is continuous on the parameter interval `[0, 5]`. -/
-lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) := by
-  have h02 := ((fdBoundary_piece1 H).continuousOn).union_of_isClosed
-    ((fdBoundary_piece2 H).continuousOn) isClosed_Icc isClosed_Icc
-  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h02
-  have h03 := h02.union_of_isClosed ((fdBoundary_piece3 H).continuousOn) isClosed_Icc
-    isClosed_Icc
-  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h03
-  have h04 := h03.union_of_isClosed ((fdBoundary_piece4 H).continuousOn) isClosed_Icc
-    isClosed_Icc
-  rw [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h04
-  have h05 := h04.union_of_isClosed ((fdBoundary_piece5 H).continuousOn) isClosed_Icc
-    isClosed_Icc
-  rwa [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h05
+lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
+  (continuous_fdBoundary H).continuousOn
 
 /-- On every closed subinterval of `[0, 5]` whose interior avoids the four segment-junction
 parameters, the contour is `C¹` — the certificate that `fdBoundaryBreakpoints` is a valid

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -6,10 +6,11 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Basic
-public import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
 public import Mathlib.LinearAlgebra.AffineSpace.AffineMap
-public import Mathlib.MeasureTheory.Integral.CircleIntegral
 public import TauCeti.Analysis.Contour.PiecewiseC1On
+
+import Mathlib.Analysis.Calculus.AddTorsor.AffineMap
+import Mathlib.MeasureTheory.Integral.CircleIntegral
 
 /-!
 # The boundary contour of the standard fundamental domain
@@ -29,8 +30,8 @@ anchors of the valence-formula contour.
   built from `AffineMap.lineMap` and `circleMap`).
 * `TauCeti.ModularForm.fdBoundary_apply_three`: the parameter `3` lands on `ρ`.
 * `TauCeti.ModularForm.fdBoundary_closed`: the contour is closed.
-* `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`, with
-  breakpoints at the four interior corners.
+* `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`
+  (`contDiffOn_fdBoundary` certifies `fdBoundaryBreakpoints` as a breakpoint witness).
 
 ## References
 
@@ -380,7 +381,10 @@ lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) 
     isClosed_Icc
   rwa [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h05
 
-private lemma contDiffOn_fdBoundary_subinterval (H : ℝ) {c d : ℝ}
+/-- On every closed subinterval of `[0, 5]` whose interior avoids the four corner
+parameters, the contour is `C¹` — the certificate that `fdBoundaryBreakpoints` is a
+valid breakpoint witness for `isPiecewiseC1On_fdBoundary`. -/
+lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryBreakpoints : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ 1 (fdBoundary H) (Icc c d) := by
   have hbp : ∀ m : ℝ, m ∈ fdBoundaryBreakpoints → m ∉ Ioo c d := fun m hm ↦
@@ -399,8 +403,8 @@ private lemma contDiffOn_fdBoundary_subinterval (H : ℝ) {c d : ℝ}
         · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
           exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
 
-/-- The fundamental-domain boundary contour is piecewise `C¹` on `[0, 5]`, with breakpoints
-at the four interior corners. -/
+/-- The fundamental-domain boundary contour is piecewise `C¹` on `[0, 5]`;
+`contDiffOn_fdBoundary` certifies the four interior corners as a breakpoint witness. -/
 theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBoundary H) 0 5 := by
   refine Contour.IsPiecewiseC1On.of_breakpoints ?_ fdBoundaryBreakpoints ?_ ?_
   · rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)]
@@ -411,7 +415,7 @@ theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBounda
     rcases hx with rfl | rfl | rfl | rfl <;> exact ⟨by norm_num, by norm_num⟩
   · intro c d hcd hdis
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hcd
-    exact contDiffOn_fdBoundary_subinterval H hcd hdis
+    exact contDiffOn_fdBoundary H hcd hdis
 
 end Regularity
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -356,10 +356,11 @@ lemma eqOn_fdBoundary_segment5 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segme
 private lemma fdBoundary_piece1 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 0 1) :=
   (contDiff_fdBoundary_segment1 H).contDiffOn.congr (eqOn_fdBoundary_segment1 H)
 
-private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 3) := by
-  have h_arc : ContDiff ℝ 1 fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)) :=
-    (contDiff_circleMap 0 1).comp (by fun_prop)
-  refine h_arc.contDiffOn.congr fun t ht ↦ ?_
+/-- On `[1, 3]` the path agrees with the unified unit-circle arc of angle `(t + 1)·π/6`:
+the two arc segments continue one smooth circle parameterization. -/
+lemma eqOn_fdBoundary_arc (H : ℝ) :
+    EqOn (fdBoundary H) (fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6))) (Icc 1 3) := by
+  intro t ht
   rcases le_or_gt t 2 with h2 | h2
   · rcases eq_or_lt_of_le ht.1 with h1 | h1
     · rw [← h1, fdBoundary_apply_one, ← fdBoundary_segment2_apply_one,
@@ -372,6 +373,9 @@ private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Ic
   · rw [fdBoundary_of_le_three h2 ht.2, fdBoundary_segment3_apply]
     congr 1
     ring
+
+private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 3) :=
+  (((contDiff_circleMap 0 1).comp (by fun_prop)).contDiffOn).congr (eqOn_fdBoundary_arc H)
 
 private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 3 4) :=
   (contDiff_fdBoundary_segment4 H).contDiffOn.congr (eqOn_fdBoundary_segment4 H)

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -353,7 +353,7 @@ lemma eqOn_fdBoundary_segment5 (H : ℝ) : EqOn (fdBoundary H) (fdBoundary_segme
   · rw [← h4, fdBoundary_apply_four, fdBoundary_segment5_apply_four]
   · exact fdBoundary_of_gt_four h4
 
-private lemma fdBoundary_piece1 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 0 1) :=
+private lemma fdBoundary_piece1 (H : ℝ) : ContDiffOn ℝ n (fdBoundary H) (Icc 0 1) :=
   (contDiff_fdBoundary_segment1 H).contDiffOn.congr (eqOn_fdBoundary_segment1 H)
 
 /-- On `[1, 3]` the path agrees with the unified unit-circle arc of angle `(t + 1)·π/6`:
@@ -374,13 +374,13 @@ lemma eqOn_fdBoundary_arc (H : ℝ) :
     congr 1
     ring
 
-private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 1 3) :=
+private lemma fdBoundary_piece13 (H : ℝ) : ContDiffOn ℝ n (fdBoundary H) (Icc 1 3) :=
   (((contDiff_circleMap 0 1).comp (by fun_prop)).contDiffOn).congr (eqOn_fdBoundary_arc H)
 
-private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 3 4) :=
+private lemma fdBoundary_piece4 (H : ℝ) : ContDiffOn ℝ n (fdBoundary H) (Icc 3 4) :=
   (contDiff_fdBoundary_segment4 H).contDiffOn.congr (eqOn_fdBoundary_segment4 H)
 
-private lemma fdBoundary_piece5 (H : ℝ) : ContDiffOn ℝ 1 (fdBoundary H) (Icc 4 5) :=
+private lemma fdBoundary_piece5 (H : ℝ) : ContDiffOn ℝ n (fdBoundary H) (Icc 4 5) :=
   (contDiff_fdBoundary_segment5 H).contDiffOn.congr (eqOn_fdBoundary_segment5 H)
 
 
@@ -414,12 +414,12 @@ lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) 
   (continuous_fdBoundary H).continuousOn
 
 /-- On every closed subinterval of `[0, 5]` whose interior avoids the three genuine
-corners, the contour is `C¹` — the certificate that `fdBoundaryCorners` is a valid
-breakpoint witness for `isPiecewiseC1On_fdBoundary`. The two arcs continue one smooth
-circle map through `t = 2`, so no hypothesis excludes it. -/
+corners, the contour is smooth at every order — the certificate that `fdBoundaryCorners`
+is a valid breakpoint witness for `isPiecewiseC1On_fdBoundary`. The two arcs continue one
+smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
-    ContDiffOn ℝ 1 (fdBoundary H) (Icc c d) := by
+    ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
   have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
     Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
   rcases le_or_gt d 1 with hd1 | hd1

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary.lean
@@ -381,9 +381,11 @@ lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) 
     isClosed_Icc
   rwa [Icc_union_Icc_eq_Icc (by norm_num) (by norm_num)] at h05
 
-/-- On every closed subinterval of `[0, 5]` whose interior avoids the four corner
-parameters, the contour is `C¹` — the certificate that `fdBoundaryBreakpoints` is a
-valid breakpoint witness for `isPiecewiseC1On_fdBoundary`. -/
+/-- On every closed subinterval of `[0, 5]` whose interior avoids the four segment-junction
+parameters, the contour is `C¹` — the certificate that `fdBoundaryBreakpoints` is a valid
+breakpoint witness for `isPiecewiseC1On_fdBoundary`. (At the junction `t = 2` the two arcs
+continue the same smooth circle map, so it is a breakpoint of the parameterization, not a
+geometric corner.) -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryBreakpoints : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ 1 (fdBoundary H) (Icc c d) := by
@@ -404,7 +406,7 @@ lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
           exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
 
 /-- The fundamental-domain boundary contour is piecewise `C¹` on `[0, 5]`;
-`contDiffOn_fdBoundary` certifies the four interior corners as a breakpoint witness. -/
+`contDiffOn_fdBoundary` certifies the four segment junctions as a breakpoint witness. -/
 theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBoundary H) 0 5 := by
   refine Contour.IsPiecewiseC1On.of_breakpoints ?_ fdBoundaryBreakpoints ?_ ?_
   · rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)]


### PR DESCRIPTION
Proves the fundamental-domain boundary contour piecewise `C¹`, in the exact `IsPiecewiseC1On` shape the raw contour-integral machinery consumes.

**Stacked on #1982** (the boundary contour); the new content is the `Regularity` section:

- `contDiff_fdBoundary_seg1` … `_seg5`: each segment is smooth (`AffineMap.contDiff_lineMap`, `contDiff_circleMap`), at arbitrary smoothness order.
- `eqOn_fdBoundary_seg1` … `_seg5`: the path agrees with its segment on each closed piece, the left endpoints closing by the corner values.
- `continuousOn_fdBoundary`: continuity on `[0, 5]` by pasting the closed pieces.
- `isPiecewiseC1On_fdBoundary`: the headline — breakpoints `{1, 2, 3, 4}`, and every breakpoint-free closed subinterval lands inside a single piece.

Next slice consumes this for the winding-number weights of the valence formula.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence-fd-regularity","id":"mvfr-1"}-->
