### PR TITLE
feat(LSeries): entire continuation of cusp-form L-series

### DIFF
--- a/TauCeti/NumberTheory/LSeries/EntireExtension.lean
+++ b/TauCeti/NumberTheory/LSeries/EntireExtension.lean
@@ -69,12 +69,13 @@ theorem of_extension {F : ℂ → ℂ} (h_finite : abscissaOfAbsConv a < ⊤)
   ⟨h_finite, F, hF, hFa⟩
 
 /-- Introduction from a smaller half-plane: an entire function agreeing with `LSeries a`
-on `Re s > c`, for any real `c` above the abscissa, extends it on the full
-absolute-convergence half-plane, by the identity theorem on connected half-planes. -/
-theorem of_extension_of_le {F : ℂ → ℂ} {c : ℝ} (hc : abscissaOfAbsConv a ≤ c)
+on `Re s > c`, for any real `c`, extends it on the full absolute-convergence half-plane
+(finite by hypothesis), by the identity theorem on connected half-planes: every real
+cutoff overlaps a finite convergence half-plane. -/
+theorem of_extension_of_le {F : ℂ → ℂ} {c : ℝ} (h_finite : abscissaOfAbsConv a < ⊤)
     (hF : Differentiable ℂ F) (hFa : ∀ {s : ℂ}, c < s.re → F s = LSeries a s) :
     HasEntireExtension a := by
-  refine ⟨lt_of_le_of_lt hc (EReal.coe_lt_top c), F, hF, fun {s} hs ↦ ?_⟩
+  refine ⟨h_finite, F, hF, fun {s} hs ↦ ?_⟩
   obtain ⟨σ, hσ_abs, hσ_s⟩ := EReal.exists_between_coe_real hs
   have hσ_s' : (σ : ℝ) < s.re := by exact_mod_cast hσ_s
   set W : Set ℂ := {z : ℂ | (σ : ℝ) < z.re} with hW_def

--- a/TauCeti/NumberTheory/LSeries/EntireExtension.lean
+++ b/TauCeti/NumberTheory/LSeries/EntireExtension.lean
@@ -81,13 +81,9 @@ theorem of_extension_of_eq_on_lt_re {F : ℂ → ℂ} {c : ℝ} (h_finite : absc
   obtain ⟨σ, hσ_abs, hσ_s⟩ := EReal.exists_between_coe_real hs
   have hσ_s' : (σ : ℝ) < s.re := by exact_mod_cast hσ_s
   set W : Set ℂ := {z : ℂ | (σ : ℝ) < z.re} with hW_def
-  have hW_open : IsOpen W := isOpen_lt continuous_const Complex.continuous_re
   have hW_sub : ∀ z ∈ W, abscissaOfAbsConv a < (z.re : EReal) := fun z hz ↦
     lt_of_lt_of_le hσ_abs (by exact_mod_cast (hz : (σ : ℝ) < z.re).le)
-  have hL : AnalyticOnNhd ℂ (LSeries a) W :=
-    DifferentiableOn.analyticOnNhd
-      (fun z hz ↦ ((LSeries_hasDerivAt (hW_sub z hz)).differentiableAt).differentiableWithinAt)
-      hW_open
+  have hL : AnalyticOnNhd ℂ (LSeries a) W := (LSeries_analyticOnNhd a).mono hW_sub
   have hFW : AnalyticOnNhd ℂ F W :=
     (Complex.analyticOnNhd_univ_iff_differentiable.mpr hF).mono (Set.subset_univ W)
   set z₀ : ℂ := ((max σ c + 1 : ℝ) : ℂ) with hz₀_def

--- a/TauCeti/NumberTheory/LSeries/EntireExtension.lean
+++ b/TauCeti/NumberTheory/LSeries/EntireExtension.lean
@@ -21,11 +21,14 @@ convergence is finite and some entire function agrees with `LSeries a` on the (n
 convergence half-plane. Such an extension is unique (`LSeries.HasEntireExtension.unique`)
 by analytic continuation.
 
-The predicate comes with an introduction lemma (`LSeries.HasEntireExtension.of_extension`)
-and elimination lemmas (`.abscissa_lt_top`, `.exists_extension`), so consumers never
-unfold the definition. It is exercised: every finitely supported coefficient sequence has
-an entire extension (`LSeries.hasEntireExtension_of_support_finite`, with the delta
-sequence `LSeries.hasEntireExtension_delta` as the basic instance), and
+The predicate comes with introduction lemmas — `LSeries.HasEntireExtension.of_extension`
+(agreement on the full convergence half-plane) and the principal
+`LSeries.HasEntireExtension.of_extension_of_le` (agreement only on `Re s > c` for some
+`c`, upgraded to the whole half-plane by analytic continuation) — and elimination lemmas
+(`.abscissa_lt_top`, `.exists_extension`), so consumers never unfold the definition.
+It is exercised: every finitely supported coefficient sequence has an entire extension
+(`LSeries.hasEntireExtension_of_support_finite`, with the delta sequence
+`LSeries.hasEntireExtension_delta` as the basic instance), and
 `LSeries.HasEntireExtension.existsUnique` pins down the unique extension.
 
 Ported from the AINTLIB `LeanModularForms` project

--- a/TauCeti/NumberTheory/LSeries/EntireExtension.lean
+++ b/TauCeti/NumberTheory/LSeries/EntireExtension.lean
@@ -23,8 +23,8 @@ by analytic continuation.
 
 The predicate comes with introduction lemmas — `LSeries.HasEntireExtension.of_extension`
 (agreement on the full convergence half-plane) and the principal
-`LSeries.HasEntireExtension.of_extension_of_le` (agreement only on `Re s > c` for some
-`c`, upgraded to the whole half-plane by analytic continuation) — and elimination lemmas
+`LSeries.HasEntireExtension.of_extension_of_eq_on_lt_re` (agreement on `Re s > c` for
+some real `c`) — and elimination lemmas
 (`.abscissa_lt_top`, `.exists_extension`), so consumers never unfold the definition.
 It is exercised: every finitely supported coefficient sequence has an entire extension
 (`LSeries.hasEntireExtension_of_support_finite`, with the delta sequence
@@ -71,11 +71,10 @@ theorem of_extension {F : ℂ → ℂ} (h_finite : abscissaOfAbsConv a < ⊤)
     HasEntireExtension a :=
   ⟨h_finite, F, hF, hFa⟩
 
-/-- Introduction from a smaller half-plane: an entire function agreeing with `LSeries a`
-on `Re s > c`, for any real `c`, extends it on the full absolute-convergence half-plane
-(finite by hypothesis), by the identity theorem on connected half-planes: every real
-cutoff overlaps a finite convergence half-plane. -/
-theorem of_extension_of_le {F : ℂ → ℂ} {c : ℝ} (h_finite : abscissaOfAbsConv a < ⊤)
+/-- Introduction from agreement on any real-cutoff half-plane: if an entire function
+agrees with `LSeries a` on `Re s > c` for some real `c`, and the abscissa of absolute
+convergence is finite, then `a` has an entire extension. -/
+theorem of_extension_of_eq_on_lt_re {F : ℂ → ℂ} {c : ℝ} (h_finite : abscissaOfAbsConv a < ⊤)
     (hF : Differentiable ℂ F) (hFa : ∀ {s : ℂ}, c < s.re → F s = LSeries a s) :
     HasEntireExtension a := by
   refine ⟨h_finite, F, hF, fun {s} hs ↦ ?_⟩

--- a/TauCeti/NumberTheory/LSeries/EntireExtension.lean
+++ b/TauCeti/NumberTheory/LSeries/EntireExtension.lean
@@ -8,6 +8,7 @@ module
 import Mathlib.Analysis.Analytic.Uniqueness
 public import Mathlib.Analysis.Calculus.FDeriv.Defs
 import Mathlib.Analysis.Complex.CauchyIntegral
+import Mathlib.Analysis.Complex.Convex
 import Mathlib.NumberTheory.LSeries.Deriv
 public import Mathlib.NumberTheory.LSeries.Convergence
 
@@ -66,6 +67,40 @@ theorem of_extension {F : ℂ → ℂ} (h_finite : abscissaOfAbsConv a < ⊤)
     (hFa : ∀ {s : ℂ}, abscissaOfAbsConv a < s.re → F s = LSeries a s) :
     HasEntireExtension a :=
   ⟨h_finite, F, hF, hFa⟩
+
+/-- Introduction from a smaller half-plane: an entire function agreeing with `LSeries a`
+on `Re s > c`, for any real `c` above the abscissa, extends it on the full
+absolute-convergence half-plane, by the identity theorem on connected half-planes. -/
+theorem of_extension_of_le {F : ℂ → ℂ} {c : ℝ} (hc : abscissaOfAbsConv a ≤ c)
+    (hF : Differentiable ℂ F) (hFa : ∀ {s : ℂ}, c < s.re → F s = LSeries a s) :
+    HasEntireExtension a := by
+  refine ⟨lt_of_le_of_lt hc (EReal.coe_lt_top c), F, hF, fun {s} hs ↦ ?_⟩
+  obtain ⟨σ, hσ_abs, hσ_s⟩ := EReal.exists_between_coe_real hs
+  have hσ_s' : (σ : ℝ) < s.re := by exact_mod_cast hσ_s
+  set W : Set ℂ := {z : ℂ | (σ : ℝ) < z.re} with hW_def
+  have hW_open : IsOpen W := isOpen_lt continuous_const Complex.continuous_re
+  have hW_sub : ∀ z ∈ W, abscissaOfAbsConv a < (z.re : EReal) := fun z hz ↦
+    lt_of_lt_of_le hσ_abs (by exact_mod_cast (hz : (σ : ℝ) < z.re).le)
+  have hL : AnalyticOnNhd ℂ (LSeries a) W :=
+    DifferentiableOn.analyticOnNhd
+      (fun z hz ↦ ((LSeries_hasDerivAt (hW_sub z hz)).differentiableAt).differentiableWithinAt)
+      hW_open
+  have hFW : AnalyticOnNhd ℂ F W :=
+    (Complex.analyticOnNhd_univ_iff_differentiable.mpr hF).mono (Set.subset_univ W)
+  set z₀ : ℂ := ((max σ c + 1 : ℝ) : ℂ) with hz₀_def
+  have hz₀W : z₀ ∈ W := by
+    simp only [hW_def, Set.mem_ofPred_eq, hz₀_def, Complex.ofReal_re]
+    have := le_max_left σ c
+    linarith
+  have hfg : F =ᶠ[nhds z₀] LSeries a := by
+    refine Filter.eventuallyEq_iff_exists_mem.mpr
+      ⟨{z : ℂ | (max σ c : ℝ) < z.re},
+        (isOpen_lt continuous_const Complex.continuous_re).mem_nhds ?_, fun z hz ↦ ?_⟩
+    · simp only [Set.mem_ofPred_eq, hz₀_def, Complex.ofReal_re]
+      linarith
+    · exact hFa (lt_of_le_of_lt (le_max_right σ c) hz)
+  have hconn : IsPreconnected W := (convex_halfSpace_re_gt σ).isPreconnected
+  exact hFW.eqOn_of_preconnected_of_eventuallyEq hL hconn hz₀W hfg hσ_s'
 
 /-- The abscissa of absolute convergence of a sequence with an entire extension is
 finite. -/

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -33,12 +33,14 @@ API and Mathlib's `LSeries` of the `q`-expansion coefficients:
 * `ModularForm.LSeries_qExpansion_coeff_eq`, `CuspForm.LSeries_qExpansion_coeff_eq`:
   on the respective half-planes, `LSeries` of the coefficients is
   `(Γ.strictWidthInfty : ℂ) ^ (-s) * L hk f s` for Mathlib's `ModularForm.L`.
+* `CuspForm.hasEntireExtension_qExpansion_coeff`: the coefficient series of a cusp form
+  of positive weight has an entire extension (the Layer-7 continuation milestone).
 
 The non-cuspidal abscissa bound `k + 1` is weaker than Diamond–Shurman Prop. 5.9.1
-(which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it, and the
-`LSeries.HasEntireExtension` corollary of `CuspForm.differentiable_L` (which needs the
-identification below the proven half-plane), are separate milestones of the roadmap's
-Layer 7.
+(which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it is a
+separate milestone of the roadmap's Layer 7. The entire continuation of the cusp-form
+series is `CuspForm.hasEntireExtension_qExpansion_coeff` below, through
+`CuspForm.differentiable_L` and `LSeries.HasEntireExtension.of_extension_of_le`.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/Modularforms/LFunction.lean`), rebuilt to consume Mathlib's
@@ -132,8 +134,10 @@ theorem hasEntireExtension_qExpansion_coeff (hk : 0 < k) [CuspFormClass F Γ k] 
     LSeries.HasEntireExtension (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) := by
   refine LSeries.HasEntireExtension.of_extension_of_le (c := (k : ℝ) / 2 + 1)
     ?_ ?_ (fun {s} hs ↦ (LSeries_qExpansion_coeff_eq hk f hs).symm)
-  · refine (abscissaOfAbsConv_qExpansion_coeff_le f).trans_eq ?_
-    rw [EReal.coe_add, EReal.coe_one]
+  · refine (abscissaOfAbsConv_qExpansion_coeff_le f).trans_lt ?_
+    rw [show (((k : ℝ) / 2 : ℝ) : EReal) + 1 = (((k : ℝ) / 2 + 1 : ℝ) : EReal) by
+      rw [EReal.coe_add, EReal.coe_one]]
+    exact EReal.coe_lt_top _
   · exact (Differentiable.const_cpow differentiable_neg
       (Or.inl (Complex.ofReal_ne_zero.mpr Γ.strictWidthInfty_pos.ne'))).mul
       (differentiable_L hk f)

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -5,7 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.NumberTheory.LSeries.Convergence
 public import Mathlib.NumberTheory.ModularForms.LFunction
 public import TauCeti.NumberTheory.LSeries.EntireExtension
 
@@ -39,8 +38,7 @@ API and Mathlib's `LSeries` of the `q`-expansion coefficients:
 The non-cuspidal abscissa bound `k + 1` is weaker than Diamond–Shurman Prop. 5.9.1
 (which gives convergence for `Re s > k` via `aₙ = O(n^{k-1})`); tightening it is a
 separate milestone of the roadmap's Layer 7. The entire continuation of the cusp-form
-series is `CuspForm.hasEntireExtension_qExpansion_coeff` below, through
-`CuspForm.differentiable_L` and `LSeries.HasEntireExtension.of_extension_of_le`.
+series is `CuspForm.hasEntireExtension_qExpansion_coeff` below.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/Modularforms/LFunction.lean`), rebuilt to consume Mathlib's
@@ -128,11 +126,11 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
 
 /-- **Entire continuation of the L-series of a cusp form** — the roadmap's Layer-7
 continuation milestone: the Dirichlet series of the `q`-expansion coefficients of a cusp
-form of positive weight has an entire extension, namely `s ↦ (h Γ)⁻ˢ · L hk f s`, through
-Mathlib's `CuspForm.differentiable_L` and the half-plane identification. -/
+form of positive weight has an entire extension, namely
+`s ↦ (Γ.strictWidthInfty : ℂ) ^ (-s) * L hk f s`. -/
 theorem hasEntireExtension_qExpansion_coeff (hk : 0 < k) [CuspFormClass F Γ k] (f : F) :
     LSeries.HasEntireExtension (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) := by
-  refine LSeries.HasEntireExtension.of_extension_of_le (c := (k : ℝ) / 2 + 1)
+  refine LSeries.HasEntireExtension.of_extension_of_eq_on_lt_re (c := (k : ℝ) / 2 + 1)
     ?_ ?_ (fun {s} hs ↦ (LSeries_qExpansion_coeff_eq hk f hs).symm)
   · refine (abscissaOfAbsConv_qExpansion_coeff_le f).trans_lt ?_
     rw [show (((k : ℝ) / 2 : ℝ) : EReal) + 1 = (((k : ℝ) / 2 + 1 : ℝ) : EReal) by

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.NumberTheory.LSeries.Convergence
 public import Mathlib.NumberTheory.ModularForms.LFunction
+public import TauCeti.NumberTheory.LSeries.EntireExtension
 
 /-!
 # Dirichlet series of modular forms
@@ -122,5 +123,19 @@ theorem LSeries_qExpansion_coeff_eq (hk : 0 < k) [CuspFormClass F Γ k] (f : F)
     have hk' : (0 : ℝ) < (k : ℝ) := mod_cast hk
     linarith
   exact LSeries_eq_of_hasSum hs0 (hasSum_L hk f hs)
+
+/-- **Entire continuation of the L-series of a cusp form** — the roadmap's Layer-7
+continuation milestone: the Dirichlet series of the `q`-expansion coefficients of a cusp
+form of positive weight has an entire extension, namely `s ↦ (h Γ)⁻ˢ · L hk f s`, through
+Mathlib's `CuspForm.differentiable_L` and the half-plane identification. -/
+theorem hasEntireExtension_qExpansion_coeff (hk : 0 < k) [CuspFormClass F Γ k] (f : F) :
+    LSeries.HasEntireExtension (fun n ↦ (qExpansion Γ.strictWidthInfty f).coeff n) := by
+  refine LSeries.HasEntireExtension.of_extension_of_le (c := (k : ℝ) / 2 + 1)
+    ?_ ?_ (fun {s} hs ↦ (LSeries_qExpansion_coeff_eq hk f hs).symm)
+  · refine (abscissaOfAbsConv_qExpansion_coeff_le f).trans_eq ?_
+    rw [EReal.coe_add, EReal.coe_one]
+  · exact (Differentiable.const_cpow differentiable_neg
+      (Or.inl (Complex.ofReal_ne_zero.mpr Γ.strictWidthInfty_pos.ne'))).mul
+      (differentiable_L hk f)
 
 end CuspForm

--- a/TauCeti/NumberTheory/ModularForms/LFunction.lean
+++ b/TauCeti/NumberTheory/ModularForms/LFunction.lean
@@ -133,8 +133,9 @@ theorem hasEntireExtension_qExpansion_coeff (hk : 0 < k) [CuspFormClass F Γ k] 
   refine LSeries.HasEntireExtension.of_extension_of_eq_on_lt_re (c := (k : ℝ) / 2 + 1)
     ?_ ?_ (fun {s} hs ↦ (LSeries_qExpansion_coeff_eq hk f hs).symm)
   · refine (abscissaOfAbsConv_qExpansion_coeff_le f).trans_lt ?_
-    rw [show (((k : ℝ) / 2 : ℝ) : EReal) + 1 = (((k : ℝ) / 2 + 1 : ℝ) : EReal) by
-      rw [EReal.coe_add, EReal.coe_one]]
+    have hcast : (((k : ℝ) / 2 : ℝ) : EReal) + 1 = (((k : ℝ) / 2 + 1 : ℝ) : EReal) := by
+      norm_cast
+    rw [hcast]
     exact EReal.coe_lt_top _
   · exact (Differentiable.const_cpow differentiable_neg
       (Or.inl (Complex.ofReal_ne_zero.mpr Γ.strictWidthInfty_pos.ne'))).mul


### PR DESCRIPTION
Stacked on #1987 (whose diff it includes until that merges; the new content is the last commit).

Two additions completing the analytic-continuation story begun in #1918 and #1987:

- `LSeries.HasEntireExtension.of_extension_of_le`: an entire function agreeing with `LSeries a` on `Re s > c`, for any real `c` above the abscissa of absolute convergence, witnesses `HasEntireExtension a` — the agreement transfers to the full convergence half-plane by the identity theorem (`AnalyticOnNhd.eqOn_of_preconnected_of_eventuallyEq` on the convex half-plane, with `LSeries` analytic there via `LSeries_hasDerivAt`).
- `CuspForm.hasEntireExtension_qExpansion_coeff`: for a cusp form of positive weight at arithmetic level, the Dirichlet series of its `q`-expansion coefficients has an entire extension, namely `s ↦ (h Γ)⁻ˢ · L hk f s` through Mathlib's `CuspForm.differentiable_L` and the half-plane identification of #1987. This is the roadmap's Layer-7 entire-continuation milestone (`lSeriesN_hasEntireExtension`), realized on Mathlib's `ModularForm.L` rather than a hand-rolled continuation.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5