### PR TITLE
feat(ModularForms): the vanishing order at the cusp

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -41,7 +41,9 @@ namespace ModularForm
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F} {h : ℝ}
 
-private lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0 < h)
+/-- The cusp function of a nonzero modular form does not vanish identically near `0`:
+otherwise the identity theorem on the unit `q`-ball forces the form to vanish. -/
+lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
   intro h_ev
@@ -58,7 +60,9 @@ private lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0
     rw [mem_ball, dist_zero_right]
     exact_mod_cast Function.Periodic.norm_qParam_lt_one hh τ.im_pos)
 
-private lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
+/-- The cusp function of a nonzero modular form is nonvanishing on a punctured
+neighborhood of `0`. -/
+lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
   (ModularFormClass.analyticAt_cuspFunction_zero f hh

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.NumberTheory.Modular
-public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
 
 /-!
@@ -40,34 +40,6 @@ namespace TauCeti
 namespace ModularForm
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F} {h : ℝ}
-
-/-- The cusp function of a nonzero modular form does not vanish identically near `0`:
-otherwise the identity theorem on the unit `q`-ball forces the form to vanish. -/
-lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0 < h)
-    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
-  intro h_ev
-  have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) :=
-    have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
-    differentiableOn_cuspFunction_ball hh (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
-      (ModularFormClass.holo f) (ModularFormClass.bdd_at_infty f)
-  have h_eqOn : EqOn (cuspFunction h f) 0 (ball 0 1) :=
-    (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
-      (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev
-  refine hf (funext fun τ ↦ ?_)
-  rw [Pi.zero_apply, ← SlashInvariantFormClass.eq_cuspFunction f τ hΓ hh.ne']
-  exact h_eqOn (by
-    rw [mem_ball, dist_zero_right]
-    exact_mod_cast Function.Periodic.norm_qParam_lt_one hh τ.im_pos)
-
-/-- The cusp function of a nonzero modular form is nonvanishing on a punctured
-neighborhood of `0`. -/
-lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
-    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
-  (ModularFormClass.analyticAt_cuspFunction_zero f hh
-    hΓ).eventually_eq_zero_or_eventually_ne_zero.resolve_left
-    (cuspFunction_not_eventually_zero hh hΓ hf)
 
 /-- A nonzero modular form with a positive strict period does not vanish at points of
 sufficiently large imaginary part. -/

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.ENat.BigOperators
-public import TauCeti.NumberTheory.ModularForms.FiniteZeros
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 /-!
@@ -37,7 +36,7 @@ of them are supplied by the `ModularFormClass` machinery.
 
 public noncomputable section
 
-open UpperHalfPlane Complex Function SlashInvariantForm Periodic
+open UpperHalfPlane Complex Filter Function Metric Set SlashInvariantForm Periodic
 
 open scoped ModularForm Topology Filter Manifold
 
@@ -70,11 +69,16 @@ lemma orderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction h g) 0) 
     orderAtCusp h g = ((analyticOrderAt (cuspFunction h g) 0).toNat : ℤ) := by
   rw [orderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
 
-/-- A nonzero constant term at the cusp forces cusp order zero. -/
-lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero (hg : AnalyticAt ℂ (cuspFunction h g) 0)
-    (h0 : cuspFunction h g 0 ≠ 0) : orderAtCusp h g = 0 := by
-  rw [orderAtCusp_eq_analyticOrderAt hg, hg.analyticOrderAt_eq_zero.mpr h0]
-  rfl
+/-- A nonzero constant term at the cusp forces cusp order zero, with no analyticity
+hypothesis: the constant coefficient of the `q`-expansion is the value at `0`. -/
+lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero (h0 : cuspFunction h g 0 ≠ 0) :
+    orderAtCusp h g = 0 := by
+  rw [orderAtCusp_def, Int.natCast_eq_zero, ENat.toNat_eq_zero]
+  left
+  by_contra hne
+  exact h0 (by
+    simpa [← PowerSeries.coeff_zero_eq_constantCoeff, qExpansion_coeff, iteratedDeriv_zero]
+      using PowerSeries.order_ne_zero_iff_constCoeff_eq_zero.mp hne)
 
 /-- The cusp order rescales linearly in the width. For a modular form the periodicity,
 boundedness, and holomorphy are `SlashInvariantFormClass.periodic_comp_ofComplex`,
@@ -89,9 +93,8 @@ lemma orderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
 private lemma cuspFunction_mul_eventuallyEq (h : ℝ) (f g : ℍ → ℂ) :
     cuspFunction h (f * g) =ᶠ[𝓝[≠] (0 : ℂ)] cuspFunction h f * cuspFunction h g := by
   filter_upwards [self_mem_nhdsWithin] with q hq
-  simp only [UpperHalfPlane.cuspFunction, Pi.mul_apply,
+  simp only [UpperHalfPlane.cuspFunction, Pi.mul_apply, Function.comp_apply,
     Function.Periodic.cuspFunction_eq_of_nonzero _ _ hq]
-  rfl
 
 private lemma cuspFunction_mul_nhds {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
     (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
@@ -132,9 +135,7 @@ private lemma cuspFunction_one (h : ℝ) : cuspFunction h (1 : ℍ → ℂ) = 1 
 /-- The constant-one function has cusp order zero. -/
 @[simp]
 lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 :=
-  orderAtCusp_eq_zero_of_cuspFunction_ne_zero
-    (by rw [cuspFunction_one]; exact analyticAt_const)
-    (by rw [cuspFunction_one]; exact one_ne_zero)
+  orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by rw [cuspFunction_one]; exact one_ne_zero)
 
 private lemma cuspFunction_pow_nhds {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     ∀ n : ℕ, cuspFunction h (f ^ n) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n
@@ -191,6 +192,41 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
 section ModularFormClass
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
+
+private lemma cuspFunction_not_eventually_zero [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    ¬∀ᶠ q in 𝓝 (0 : ℂ), cuspFunction h f q = 0 := by
+  intro h_ev
+  have h_diff : DifferentiableOn ℂ (cuspFunction h f) (ball 0 1) :=
+    have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+    differentiableOn_cuspFunction_ball hh (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
+      (ModularFormClass.holo f) (ModularFormClass.bdd_at_infty f)
+  have h_eqOn : EqOn (cuspFunction h f) 0 (ball 0 1) :=
+    (h_diff.analyticOnNhd isOpen_ball).eqOn_zero_of_preconnected_of_eventuallyEq_zero
+      (convex_ball 0 1).isPreconnected (mem_ball_self one_pos) h_ev
+  refine hf (funext fun τ ↦ ?_)
+  rw [Pi.zero_apply, ← SlashInvariantFormClass.eq_cuspFunction f τ hΓ hh.ne']
+  exact h_eqOn (by
+    rw [mem_ball, dist_zero_right]
+    exact_mod_cast Function.Periodic.norm_qParam_lt_one hh τ.im_pos)
+
+/-- The cusp function of a nonzero modular form is nonvanishing on a punctured
+neighborhood of `0`. -/
+lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    ∀ᶠ q in 𝓝[≠] (0 : ℂ), cuspFunction h f q ≠ 0 :=
+  (ModularFormClass.analyticAt_cuspFunction_zero f hh
+    hΓ).eventually_eq_zero_or_eventually_ne_zero.resolve_left
+    (cuspFunction_not_eventually_zero hh hΓ hf)
+
+/-- The width rescaling for a modular form, with the periodicity, boundedness, and
+holomorphy supplied by the class machinery. -/
+lemma orderAtCusp_nat_mul_of_mem_strictPeriods [ModularFormClass F Γ k] {m : ℕ}
+    (hh : 0 < h) (hm : 0 < m) (hΓ : h ∈ Γ.strictPeriods) :
+    orderAtCusp (m * h) ⇑f = m * orderAtCusp h ⇑f :=
+  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+  orderAtCusp_nat_mul hh hm (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
+    (ModularFormClass.bdd_at_infty f) (ModularFormClass.holo f)
 
 /-- For a nonzero modular form the cusp function does not vanish identically near `0`,
 so its analytic order there is finite. -/

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -155,20 +155,28 @@ private lemma cuspFunction_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunct
       cuspFunction_mul (by rw [cuspFunction_pow hf n]; exact (hf.continuousAt.pow n))
         hf.continuousAt]
 
+private lemma qExpansion_one (h : ℝ) : qExpansion h (1 : ℍ → ℂ) = 1 := by
+  ext m
+  rw [qExpansion_coeff, cuspFunction_one]
+  rcases m with _ | m <;> simp [PowerSeries.coeff_one, Pi.one_def, iteratedDeriv_const]
+
+private lemma qExpansion_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    ∀ n : ℕ, qExpansion h (f ^ n) = qExpansion h f ^ n
+  | 0 => by rw [pow_zero, pow_zero, qExpansion_one]
+  | n + 1 => by
+    have h_an : AnalyticAt ℂ (cuspFunction h (f ^ n)) 0 := by
+      rw [cuspFunction_pow hf n]
+      exact hf.pow n
+    rw [pow_succ, pow_succ, qExpansion_mul h_an hf, qExpansion_pow hf n]
+
 /-- The cusp order multiplies under powers, with no finiteness hypothesis: for an
 identically vanishing expansion both sides take the junk value at positive exponents,
 and at exponent zero both sides are genuinely zero. -/
 lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
-  have h_an : AnalyticAt ℂ (cuspFunction h (f ^ n)) 0 := by
-    rw [cuspFunction_pow hf n]
-    exact hf.pow n
-  have h_nat := analyticOrderNatAt_pow hf n
-  simp only [analyticOrderNatAt, smul_eq_mul] at h_nat
-  rw [orderAtCusp_eq_analyticOrderAt h_an, orderAtCusp_eq_analyticOrderAt hf,
-    cuspFunction_pow hf n, h_nat]
-  push_cast
-  ring
+  rw [orderAtCusp_def, orderAtCusp_def, qExpansion_pow hf n, PowerSeries.order_pow,
+    nsmul_eq_mul, ENat.toNat_mul]
+  simp
 
 private lemma cuspFunction_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0) :
@@ -182,18 +190,31 @@ private lemma cuspFunction_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finse
         (by rw [h_prev]; exact (Finset.analyticAt_prod _ fun i hi ↦
           hf i (Finset.mem_cons_of_mem hi)).continuousAt)]
 
+private lemma qExpansion_prod {ι : Type*} (s : Finset ι) (f : ι → ℍ → ℂ)
+    (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0) :
+    qExpansion h (∏ i ∈ s, f i) = ∏ i ∈ s, qExpansion h (f i) := by
+  induction s using Finset.cons_induction with
+  | empty => simpa using qExpansion_one h
+  | cons a s ha ih =>
+    have h_an : AnalyticAt ℂ (cuspFunction h (∏ i ∈ s, f i)) 0 := by
+      rw [cuspFunction_prod s fun i hi ↦ hf i (Finset.mem_cons_of_mem hi)]
+      exact Finset.analyticAt_prod _ fun i hi ↦ hf i (Finset.mem_cons_of_mem hi)
+    rw [Finset.prod_cons, Finset.prod_cons,
+      qExpansion_mul (hf a (Finset.mem_cons_self a s)) h_an,
+      ih fun i hi ↦ hf i (Finset.mem_cons_of_mem hi)]
+
 /-- The cusp order is additive on finite products. The finiteness hypotheses exclude an
 identically vanishing factor, where the junk value `0` would break additivity. -/
 lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0)
     (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction h (f i)) 0 ≠ ⊤) :
     orderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCusp h (f i) := by
-  have h_an : AnalyticAt ℂ (cuspFunction h (∏ i ∈ s, f i)) 0 := by
-    rw [cuspFunction_prod s hf]
-    exact Finset.analyticAt_prod _ hf
-  rw [orderAtCusp_eq_analyticOrderAt h_an, cuspFunction_prod s hf,
-    TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf', Nat.cast_sum]
-  exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
+  have hf'' : ∀ i ∈ s, (qExpansion h (f i)).order ≠ ⊤ := fun i hi ↦ by
+    rw [qExpansion_order_eq_analyticOrderAt_cuspFunction (hf i hi)]
+    exact hf' i hi
+  rw [orderAtCusp_def, qExpansion_prod s f hf, PowerSeries.order_prod,
+    ENat.toNat_sum hf'', Nat.cast_sum]
+  exact Finset.sum_congr rfl fun i hi ↦ by rw [orderAtCusp_def]
 
 /-- The `ℚ`-valued cusp order: the width-`2h` exponent, halved. For an `h`-periodic
 function this is the integral order `orderAtCusp h` (`rationalOrderAtCusp_eq_orderAtCusp`);

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -18,23 +18,23 @@ width — the cusp term of the level-one valence formula. The lemmas take the ra
 periodicity, and boundedness hypotheses of the underlying `q`-expansion theorems; for a
 modular form all of them are supplied by the `ModularFormClass` machinery.
 
-`orderAtCusp` is the integral exponent of the width-`h` expansion, the correct primitive
-at every cusp; `rationalOrderAtCusp` supplies the width-normalized `ℚ`-valued convention
+`qExpansionOrderAtCusp` is the integral exponent of the width-`h` expansion, the correct primitive
+at every cusp; `orderAtCusp` supplies the width-normalized `ℚ`-valued convention
 on top of it — the doubled-width exponent halved, which is the integral order for an
 `h`-periodic function and the conventional half-integer at an irregular cusp of odd
 weight.
 
 ## Main declarations
 
-* `TauCeti.orderAtCusp`.
-* `TauCeti.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
-* `TauCeti.orderAtCusp_nat_mul`: linear rescaling in the width.
-* `TauCeti.rationalOrderAtCusp`: the `ℚ`-valued cusp order — the doubled-width exponent halved,
+* `TauCeti.qExpansionOrderAtCusp`.
+* `TauCeti.qExpansionOrderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
+* `TauCeti.qExpansionOrderAtCusp_nat_mul`: linear rescaling in the width.
+* `TauCeti.orderAtCusp`: the `ℚ`-valued cusp order — the doubled-width exponent halved,
   the conventional half-integral order at irregular cusps.
-* `TauCeti.ModularForm.orderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
+* `TauCeti.ModularForm.qExpansionOrderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
   is a nonzero constant term (the class-level interface lives in `TauCeti.ModularForm`).
-* `TauCeti.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow` and
-  `orderAtCusp_prod`).
+* `TauCeti.qExpansionOrderAtCusp_mul`: additivity on products (with `qExpansionOrderAtCusp_pow` and
+  `qExpansionOrderAtCusp_prod`).
 
 ## References
 
@@ -57,31 +57,31 @@ integer, with junk value `0` when the expansion vanishes identically — the `un
 convention of `orderOfVanishingAt`. This is the exponent of the width-`h` uniformizer;
 normalized orders at other widths (half-integral at irregular cusps) are conversion
 layers over this primitive. -/
-def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ := ((qExpansion h f).order.toNat : ℤ)
+def qExpansionOrderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ := ((qExpansion h f).order.toNat : ℤ)
 
-/-- `orderAtCusp` unfolded to the `q`-expansion order. The definition is sealed by the
+/-- `qExpansionOrderAtCusp` unfolded to the `q`-expansion order. The definition is sealed by the
 module system; this equation is the supported cross-module rewrite. -/
-lemma orderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
-    orderAtCusp h f = ((qExpansion h f).order.toNat : ℤ) := by
-  unfold orderAtCusp
+lemma qExpansionOrderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
+    qExpansionOrderAtCusp h f = ((qExpansion h f).order.toNat : ℤ) := by
+  unfold qExpansionOrderAtCusp
   rfl
 
 /-- The cusp order is nonnegative. -/
-lemma orderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCusp h f := by
-  rw [orderAtCusp_def]
+lemma qExpansionOrderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ qExpansionOrderAtCusp h f := by
+  rw [qExpansionOrderAtCusp_def]
   exact Int.natCast_nonneg _
 
 /-- The cusp order is the analytic order of the cusp function at `0`. For a modular form
 the analyticity is `ModularFormClass.analyticAt_cuspFunction_zero`. -/
-lemma orderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
-    orderAtCusp h g = ((analyticOrderAt (cuspFunction h g) 0).toNat : ℤ) := by
-  rw [orderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
+lemma qExpansionOrderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
+    qExpansionOrderAtCusp h g = ((analyticOrderAt (cuspFunction h g) 0).toNat : ℤ) := by
+  rw [qExpansionOrderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
 
 /-- A nonzero constant term at the cusp forces cusp order zero, with no analyticity
 hypothesis: the constant coefficient of the `q`-expansion is the value at `0`. -/
-lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero (h0 : cuspFunction h g 0 ≠ 0) :
-    orderAtCusp h g = 0 := by
-  rw [orderAtCusp_def, Int.natCast_eq_zero, ENat.toNat_eq_zero]
+lemma qExpansionOrderAtCusp_eq_zero_of_cuspFunction_ne_zero (h0 : cuspFunction h g 0 ≠ 0) :
+    qExpansionOrderAtCusp h g = 0 := by
+  rw [qExpansionOrderAtCusp_def, Int.natCast_eq_zero, ENat.toNat_eq_zero]
   left
   by_contra hne
   exact h0 (by
@@ -91,27 +91,27 @@ lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero (h0 : cuspFunction h g 0 ≠ 0
 /-- The cusp order rescales linearly in the width. For a modular form the periodicity,
 boundedness, and holomorphy are `SlashInvariantFormClass.periodic_comp_ofComplex`,
 `ModularFormClass.bdd_at_infty`, and `ModularFormClass.holo`. -/
-lemma orderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+lemma qExpansionOrderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
     (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g)
-    (hg_mdiff : MDiff g) : orderAtCusp (m * h) g = m * orderAtCusp h g := by
-  rw [orderAtCusp_def, orderAtCusp_def,
+    (hg_mdiff : MDiff g) : qExpansionOrderAtCusp (m * h) g = m * qExpansionOrderAtCusp h g := by
+  rw [qExpansionOrderAtCusp_def, qExpansionOrderAtCusp_def,
     qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff, ENat.toNat_mul]
   simp [mul_comm]
 
 /-- The cusp order is additive on products. The finiteness hypotheses exclude an
 identically vanishing factor, where the junk value `0` would break additivity. -/
-lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
+lemma qExpansionOrderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
     (hg : AnalyticAt ℂ (cuspFunction h g) 0)
     (hf' : analyticOrderAt (cuspFunction h f) 0 ≠ ⊤)
     (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
-    orderAtCusp h (f * g) = orderAtCusp h f + orderAtCusp h g := by
+    qExpansionOrderAtCusp h (f * g) = qExpansionOrderAtCusp h f + qExpansionOrderAtCusp h g := by
   have h_an : AnalyticAt ℂ (cuspFunction h (f * g)) 0 := by
     rw [cuspFunction_mul hf.continuousAt hg.continuousAt]
     exact hf.mul hg
   have h_nat := analyticOrderNatAt_mul hf hg hf' hg'
   simp only [analyticOrderNatAt] at h_nat
-  rw [orderAtCusp_eq_analyticOrderAt h_an, orderAtCusp_eq_analyticOrderAt hf,
-    orderAtCusp_eq_analyticOrderAt hg, cuspFunction_mul hf.continuousAt hg.continuousAt,
+  rw [qExpansionOrderAtCusp_eq_analyticOrderAt h_an, qExpansionOrderAtCusp_eq_analyticOrderAt hf,
+    qExpansionOrderAtCusp_eq_analyticOrderAt hg, cuspFunction_mul hf.continuousAt hg.continuousAt,
     h_nat]
   push_cast
   ring
@@ -130,22 +130,22 @@ private lemma cuspFunction_one (h : ℝ) : cuspFunction h (1 : ℍ → ℂ) = 1 
 /-- Every constant function has cusp order zero: a nonzero constant by the nonvanishing
 constant term, the zero function by the junk value. -/
 @[simp]
-lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
+lemma qExpansionOrderAtCusp_const (h : ℝ) (c : ℂ) : qExpansionOrderAtCusp h (fun _ ↦ c) = 0 := by
   rcases eq_or_ne c 0 with rfl | hc
   · -- `rw [qExpansion_zero]` cannot fire here: the goal spells the zero function as a
     -- lambda, which `rw`'s syntactic matching does not unify with `0`; the ascription
     -- applies the same lemma across the two spellings.
-    rw [orderAtCusp_def,
+    rw [qExpansionOrderAtCusp_def,
       show (qExpansion h fun _ ↦ (0 : ℂ)) = 0 from qExpansion_zero h, PowerSeries.order_zero]
     rfl
-  · exact orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by
+  · exact qExpansionOrderAtCusp_eq_zero_of_cuspFunction_ne_zero (by
       rw [cuspFunction_const]
       exact hc)
 
 /-- The constant-one function has cusp order zero. -/
 @[simp]
-lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 :=
-  orderAtCusp_const h 1
+lemma qExpansionOrderAtCusp_one (h : ℝ) : qExpansionOrderAtCusp h (1 : ℍ → ℂ) = 0 :=
+  qExpansionOrderAtCusp_const h 1
 
 private lemma cuspFunction_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     ∀ n : ℕ, cuspFunction h (f ^ n) = cuspFunction h f ^ n
@@ -172,10 +172,10 @@ private lemma qExpansion_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunctio
 /-- The cusp order multiplies under powers, with no finiteness hypothesis: for an
 identically vanishing expansion both sides take the junk value at positive exponents,
 and at exponent zero both sides are genuinely zero. -/
-lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
-    orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
-  rw [orderAtCusp_def, orderAtCusp_def, qExpansion_pow hf n, PowerSeries.order_pow,
-    nsmul_eq_mul, ENat.toNat_mul]
+lemma qExpansionOrderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    qExpansionOrderAtCusp h (f ^ n) = n * qExpansionOrderAtCusp h f := by
+  simp only [qExpansionOrderAtCusp_def]
+  rw [qExpansion_pow hf n, PowerSeries.order_pow, nsmul_eq_mul, ENat.toNat_mul]
   simp
 
 private lemma cuspFunction_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
@@ -205,91 +205,92 @@ private lemma qExpansion_prod {ι : Type*} (s : Finset ι) (f : ι → ℍ → �
 
 /-- The cusp order is additive on finite products. The finiteness hypotheses exclude an
 identically vanishing factor, where the junk value `0` would break additivity. -/
-lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+lemma qExpansionOrderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0)
     (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction h (f i)) 0 ≠ ⊤) :
-    orderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCusp h (f i) := by
+    qExpansionOrderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, qExpansionOrderAtCusp h (f i) := by
   have hf'' : ∀ i ∈ s, (qExpansion h (f i)).order ≠ ⊤ := fun i hi ↦ by
     rw [qExpansion_order_eq_analyticOrderAt_cuspFunction (hf i hi)]
     exact hf' i hi
-  rw [orderAtCusp_def, qExpansion_prod s f hf, PowerSeries.order_prod,
+  rw [qExpansionOrderAtCusp_def, qExpansion_prod s f hf, PowerSeries.order_prod,
     ENat.toNat_sum hf'', Nat.cast_sum]
-  exact Finset.sum_congr rfl fun i hi ↦ by rw [orderAtCusp_def]
+  exact Finset.sum_congr rfl fun i hi ↦ by rw [qExpansionOrderAtCusp_def]
 
 /-- The `ℚ`-valued cusp order: the width-`2h` exponent, halved. For an `h`-periodic
-function this is the integral order `orderAtCusp h` (`rationalOrderAtCusp_eq_orderAtCusp`);
+function this is the integral order at width `h`
+(`orderAtCusp_eq_qExpansionOrderAtCusp`);
 at an irregular cusp of odd weight, where the form is only `2h`-periodic, it is the
 conventional half-integral order. -/
-def rationalOrderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℚ := (orderAtCusp (2 * h) f : ℚ) / 2
+def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℚ := (qExpansionOrderAtCusp (2 * h) f : ℚ) / 2
 
-/-- `rationalOrderAtCusp` unfolded to the halved doubled-width exponent. -/
-lemma rationalOrderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
-    rationalOrderAtCusp h f = (orderAtCusp (2 * h) f : ℚ) / 2 := by
-  unfold rationalOrderAtCusp
+/-- `orderAtCusp` unfolded to the halved doubled-width exponent. -/
+lemma orderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
+    orderAtCusp h f = (qExpansionOrderAtCusp (2 * h) f : ℚ) / 2 := by
+  unfold orderAtCusp
   rfl
 
 /-- For an `h`-periodic bounded holomorphic function the `ℚ`-valued cusp order is the
 integral one: the doubled-width exponent doubles. -/
-lemma rationalOrderAtCusp_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofComplex) h)
+lemma orderAtCusp_eq_qExpansionOrderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofComplex) h)
     (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
-    rationalOrderAtCusp h g = (orderAtCusp h g : ℚ) := by
-  have h2 := orderAtCusp_nat_mul (g := g) (m := 2) hh (by norm_num) hg_per hg_bdd hg_mdiff
+    orderAtCusp h g = (qExpansionOrderAtCusp h g : ℚ) := by
+  have h2 := qExpansionOrderAtCusp_nat_mul (g := g) (m := 2) hh (by norm_num) hg_per hg_bdd hg_mdiff
   norm_num at h2
-  rw [rationalOrderAtCusp_def, h2]
+  rw [orderAtCusp_def, h2]
   push_cast
   ring
 
 /-- The rational cusp order is the halved doubled-width analytic order. -/
-lemma rationalOrderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0) :
-    rationalOrderAtCusp h g = ((analyticOrderAt (cuspFunction (2 * h) g) 0).toNat : ℚ) / 2 := by
-  rw [rationalOrderAtCusp_def, orderAtCusp_eq_analyticOrderAt hg]
+lemma orderAtCusp_eq_half_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0) :
+    orderAtCusp h g = ((analyticOrderAt (cuspFunction (2 * h) g) 0).toNat : ℚ) / 2 := by
+  rw [orderAtCusp_def, qExpansionOrderAtCusp_eq_analyticOrderAt hg]
   push_cast
   ring
 
 /-- The rational cusp order is nonnegative. -/
-lemma rationalOrderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ rationalOrderAtCusp h f := by
-  rw [rationalOrderAtCusp_def]
-  exact div_nonneg (by exact_mod_cast orderAtCusp_nonneg (2 * h) f) (by norm_num)
+lemma orderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCusp h f := by
+  rw [orderAtCusp_def]
+  exact div_nonneg (by exact_mod_cast qExpansionOrderAtCusp_nonneg (2 * h) f) (by norm_num)
 
 /-- Every constant function has rational cusp order zero. -/
 @[simp]
-lemma rationalOrderAtCusp_const (h : ℝ) (c : ℂ) : rationalOrderAtCusp h (fun _ ↦ c) = 0 := by
-  rw [rationalOrderAtCusp_def, orderAtCusp_const]
+lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
+  rw [orderAtCusp_def, qExpansionOrderAtCusp_const]
   norm_num
 
 /-- The constant-one function has rational cusp order zero. -/
 @[simp]
-lemma rationalOrderAtCusp_one (h : ℝ) : rationalOrderAtCusp h (1 : ℍ → ℂ) = 0 := by
-  rw [rationalOrderAtCusp_def, orderAtCusp_one]
+lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 := by
+  rw [orderAtCusp_def, qExpansionOrderAtCusp_one]
   norm_num
 
 /-- The rational cusp order is additive on products. -/
-lemma rationalOrderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
+lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
     (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0)
     (hf' : analyticOrderAt (cuspFunction (2 * h) f) 0 ≠ ⊤)
     (hg' : analyticOrderAt (cuspFunction (2 * h) g) 0 ≠ ⊤) :
-    rationalOrderAtCusp h (f * g) = rationalOrderAtCusp h f + rationalOrderAtCusp h g := by
-  simp only [rationalOrderAtCusp_def]
-  rw [orderAtCusp_mul hf hg hf' hg']
+    orderAtCusp h (f * g) = orderAtCusp h f + orderAtCusp h g := by
+  simp only [orderAtCusp_def]
+  rw [qExpansionOrderAtCusp_mul hf hg hf' hg']
   push_cast
   ring
 
 /-- The rational cusp order multiplies under powers. -/
-lemma rationalOrderAtCusp_pow {f : ℍ → ℂ} (n : ℕ)
+lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ)
     (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0) :
-    rationalOrderAtCusp h (f ^ n) = n * rationalOrderAtCusp h f := by
-  rw [rationalOrderAtCusp_def, rationalOrderAtCusp_def, orderAtCusp_pow n hf]
+    orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
+  rw [orderAtCusp_def, orderAtCusp_def, qExpansionOrderAtCusp_pow n hf]
   push_cast
   ring
 
 /-- The rational cusp order is additive on finite products. -/
-lemma rationalOrderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction (2 * h) (f i)) 0)
     (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction (2 * h) (f i)) 0 ≠ ⊤) :
-    rationalOrderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, rationalOrderAtCusp h (f i) := by
-  rw [rationalOrderAtCusp_def, orderAtCusp_prod s hf hf']
+    orderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCusp h (f i) := by
+  rw [orderAtCusp_def, qExpansionOrderAtCusp_prod s hf hf']
   push_cast
-  simp [rationalOrderAtCusp_def, Finset.sum_div]
+  simp [orderAtCusp_def, Finset.sum_div]
 
 namespace ModularForm
 
@@ -323,11 +324,11 @@ lemma cuspFunction_eventually_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
 
 /-- The width rescaling for a modular form, with the periodicity, boundedness, and
 holomorphy supplied by the class machinery. -/
-lemma orderAtCusp_nat_mul_of_mem_strictPeriods [ModularFormClass F Γ k] {m : ℕ}
+lemma qExpansionOrderAtCusp_nat_mul_of_mem_strictPeriods [ModularFormClass F Γ k] {m : ℕ}
     (hh : 0 < h) (hm : 0 < m) (hΓ : h ∈ Γ.strictPeriods) :
-    orderAtCusp (m * h) ⇑f = m * orderAtCusp h ⇑f :=
+    qExpansionOrderAtCusp (m * h) ⇑f = m * qExpansionOrderAtCusp h ⇑f :=
   have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
-  orderAtCusp_nat_mul hh hm (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
+  qExpansionOrderAtCusp_nat_mul hh hm (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
     (ModularFormClass.bdd_at_infty f) (ModularFormClass.holo f)
 
 /-- For a nonzero modular form the cusp function does not vanish identically near `0`,
@@ -338,46 +339,59 @@ lemma analyticOrderAt_cuspFunction_ne_top [ModularFormClass F Γ k] (hh : 0 < h)
   simp only [ne_eq, analyticOrderAt_eq_top]
   exact cuspFunction_not_eventually_zero hh hΓ hf
 
-/-- For a nonzero modular form the cusp order vanishes iff the constant term — the value
-of the cusp function at `0` — is nonzero. -/
-@[simp]
-lemma orderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
-    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    orderAtCusp h ⇑f = 0 ↔ cuspFunction h ⇑f 0 ≠ 0 := by
-  have h_an := ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ
-  rw [orderAtCusp_eq_analyticOrderAt h_an, Int.natCast_eq_zero, ENat.toNat_eq_zero,
-    or_iff_left (analyticOrderAt_cuspFunction_ne_top hh hΓ hf),
-    h_an.analyticOrderAt_eq_zero]
+/-- The exponent vanishes iff the constant term — the value of the cusp function at
+`0` — is nonzero, for any function whose cusp function is analytic with finite order. -/
+lemma qExpansionOrderAtCusp_eq_zero_iff' (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
+    qExpansionOrderAtCusp h g = 0 ↔ cuspFunction h g 0 ≠ 0 := by
+  rw [qExpansionOrderAtCusp_eq_analyticOrderAt hg, Int.natCast_eq_zero, ENat.toNat_eq_zero,
+    or_iff_left hg', hg.analyticOrderAt_eq_zero]
 
-/-- For a nonzero modular form the cusp order is positive iff the form vanishes at the
+/-- The exponent is positive iff the function vanishes at the cusp, for any function
+whose cusp function is analytic with finite order. -/
+lemma qExpansionOrderAtCusp_pos_iff' (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
+    0 < qExpansionOrderAtCusp h g ↔ cuspFunction h g 0 = 0 := by
+  rw [(qExpansionOrderAtCusp_nonneg h g).lt_iff_ne, ne_comm,
+    ← not_not (a := cuspFunction h g 0 = 0)]
+  exact not_congr (qExpansionOrderAtCusp_eq_zero_iff' hg hg')
+
+/-- For a nonzero modular form the exponent vanishes iff the constant term is nonzero. -/
+@[simp]
+lemma qExpansionOrderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    qExpansionOrderAtCusp h ⇑f = 0 ↔ cuspFunction h ⇑f 0 ≠ 0 :=
+  qExpansionOrderAtCusp_eq_zero_iff' (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
+    (analyticOrderAt_cuspFunction_ne_top hh hΓ hf)
+
+/-- For a nonzero modular form the exponent is positive iff the form vanishes at the
 cusp. -/
 @[simp]
-lemma orderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
+lemma qExpansionOrderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    0 < orderAtCusp h ⇑f ↔ cuspFunction h ⇑f 0 = 0 := by
-  rw [(orderAtCusp_nonneg h ⇑f).lt_iff_ne, ne_comm,
-    ← not_not (a := cuspFunction h ⇑f 0 = 0)]
-  exact not_congr (orderAtCusp_eq_zero_iff hh hΓ hf)
+    0 < qExpansionOrderAtCusp h ⇑f ↔ cuspFunction h ⇑f 0 = 0 :=
+  qExpansionOrderAtCusp_pos_iff' (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
+    (analyticOrderAt_cuspFunction_ne_top hh hΓ hf)
 
 /-- For a nonzero modular form the rational cusp order vanishes iff the doubled-width
 constant term is nonzero. -/
 @[simp]
-lemma rationalOrderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
+lemma orderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : 2 * h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    rationalOrderAtCusp h ⇑f = 0 ↔ cuspFunction (2 * h) ⇑f 0 ≠ 0 := by
-  rw [rationalOrderAtCusp_def, div_eq_zero_iff]
+    orderAtCusp h ⇑f = 0 ↔ cuspFunction (2 * h) ⇑f 0 ≠ 0 := by
+  rw [orderAtCusp_def, div_eq_zero_iff]
   simp only [OfNat.ofNat_ne_zero, or_false, Int.cast_eq_zero]
-  exact orderAtCusp_eq_zero_iff (by positivity) hΓ hf
+  exact qExpansionOrderAtCusp_eq_zero_iff (by positivity) hΓ hf
 
 /-- For a nonzero modular form the rational cusp order is positive iff the form vanishes
 at the cusp in the doubled-width reading. -/
 @[simp]
-lemma rationalOrderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
+lemma orderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : 2 * h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
-    0 < rationalOrderAtCusp h ⇑f ↔ cuspFunction (2 * h) ⇑f 0 = 0 := by
-  rw [rationalOrderAtCusp_def]
+    0 < orderAtCusp h ⇑f ↔ cuspFunction (2 * h) ⇑f 0 = 0 := by
+  rw [orderAtCusp_def]
   rw [div_pos_iff_of_pos_right (by norm_num : (0 : ℚ) < 2), Int.cast_pos]
-  exact orderAtCusp_pos_iff (by positivity) hΓ hf
+  exact qExpansionOrderAtCusp_pos_iff (by positivity) hΓ hf
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -29,6 +29,8 @@ not defined here.
 * `TauCeti.orderAtCusp`.
 * `TauCeti.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
 * `TauCeti.orderAtCusp_nat_mul`: linear rescaling in the width.
+* `TauCeti.orderAtCuspQ`: the `ℚ`-valued cusp order — the doubled-width exponent halved,
+  the conventional half-integral order at irregular cusps.
 * `TauCeti.ModularForm.orderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
   is a nonzero constant term (the class-level interface lives in `TauCeti.ModularForm`).
 * `TauCeti.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow` and
@@ -213,6 +215,29 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     analyticOrderAt_congr h_ev, TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf',
     Nat.cast_sum]
   exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
+
+/-- The `ℚ`-valued cusp order: the width-`2h` exponent, halved. For an `h`-periodic
+function this is the integral order `orderAtCusp h` (`orderAtCuspQ_eq_orderAtCusp`);
+at an irregular cusp of odd weight, where the form is only `2h`-periodic, it is the
+conventional half-integral order. -/
+def orderAtCuspQ (h : ℝ) (f : ℍ → ℂ) : ℚ := (orderAtCusp (2 * h) f : ℚ) / 2
+
+/-- `orderAtCuspQ` unfolded to the halved doubled-width exponent. -/
+lemma orderAtCuspQ_def (h : ℝ) (f : ℍ → ℂ) :
+    orderAtCuspQ h f = (orderAtCusp (2 * h) f : ℚ) / 2 := by
+  unfold orderAtCuspQ
+  rfl
+
+/-- For an `h`-periodic bounded holomorphic function the `ℚ`-valued cusp order is the
+integral one: the doubled-width exponent doubles. -/
+lemma orderAtCuspQ_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofComplex) h)
+    (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
+    orderAtCuspQ h g = (orderAtCusp h g : ℚ) := by
+  have h2 := orderAtCusp_nat_mul (g := g) (m := 2) hh (by norm_num) hg_per hg_bdd hg_mdiff
+  rw [orderAtCuspQ_def, show ((2 : ℕ) : ℝ) * h = 2 * h by norm_num] at *
+  rw [h2]
+  push_cast
+  ring
 
 namespace ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -130,8 +130,8 @@ constant term, the zero function by the junk value. -/
 @[simp]
 lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
   rcases eq_or_ne c 0 with rfl | hc
-  · have h0 : qExpansion h (fun _ ↦ (0 : ℂ)) = 0 := qExpansion_zero h
-    rw [orderAtCusp_def, h0, PowerSeries.order_zero]
+  · rw [orderAtCusp_def,
+      show (qExpansion h fun _ ↦ (0 : ℂ)) = 0 from qExpansion_zero h, PowerSeries.order_zero]
     rfl
   · exact orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by
       rw [cuspFunction_const]

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -20,13 +20,13 @@ of them are supplied by the `ModularFormClass` machinery.
 
 ## Main declarations
 
-* `TauCeti.ModularForm.orderAtCusp`.
-* `TauCeti.ModularForm.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
-* `TauCeti.ModularForm.orderAtCusp_nat_mul`: linear rescaling in the width.
+* `TauCeti.orderAtCusp`.
+* `TauCeti.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
+* `TauCeti.orderAtCusp_nat_mul`: linear rescaling in the width.
 * `TauCeti.ModularForm.orderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
-  is a nonzero constant term.
-* `TauCeti.ModularForm.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow`
-  and `orderAtCusp_prod`).
+  is a nonzero constant term (the class-level interface lives in `TauCeti.ModularForm`).
+* `TauCeti.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow` and
+  `orderAtCusp_prod`).
 
 ## References
 
@@ -41,8 +41,6 @@ open UpperHalfPlane Complex Filter Function Metric Set SlashInvariantForm Period
 open scoped ModularForm Topology Filter Manifold
 
 namespace TauCeti
-
-namespace ModularForm
 
 variable {h : ℝ} {g : ℍ → ℂ}
 
@@ -125,17 +123,36 @@ lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f
   push_cast
   ring
 
-private lemma cuspFunction_one (h : ℝ) : cuspFunction h (1 : ℍ → ℂ) = 1 := by
+private lemma cuspFunction_const (h : ℝ) (c : ℂ) :
+    UpperHalfPlane.cuspFunction h (fun _ ↦ c) = fun _ ↦ c := by
   have h_lim : Filter.limUnder (𝓝[≠] (0 : ℂ))
-      (((1 : ℍ → ℂ) ∘ ofComplex) ∘ Function.Periodic.invQParam h) = 1 :=
+      (((fun _ ↦ c : ℍ → ℂ) ∘ ofComplex) ∘ Function.Periodic.invQParam h) = c :=
     Filter.Tendsto.limUnder_eq tendsto_const_nhds
   rw [UpperHalfPlane.cuspFunction, Function.Periodic.cuspFunction, h_lim]
-  exact Function.update_eq_self 0 (1 : ℂ → ℂ)
+  exact Function.update_eq_self 0 (fun _ ↦ c)
+
+private lemma cuspFunction_one (h : ℝ) : cuspFunction h (1 : ℍ → ℂ) = 1 :=
+  cuspFunction_const h 1
+
+/-- Every constant function has cusp order zero: a nonzero constant by the nonvanishing
+constant term, the zero function by the junk value. -/
+@[simp]
+lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
+  rcases eq_or_ne c 0 with rfl | hc
+  · have h0 : qExpansion h (fun _ ↦ (0 : ℂ)) = 0 := by
+      ext m
+      rw [qExpansion_coeff, cuspFunction_const]
+      simp
+    rw [orderAtCusp_def, h0, PowerSeries.order_zero]
+    rfl
+  · exact orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by
+      rw [cuspFunction_const]
+      exact hc)
 
 /-- The constant-one function has cusp order zero. -/
 @[simp]
 lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 :=
-  orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by rw [cuspFunction_one]; exact one_ne_zero)
+  orderAtCusp_const h 1
 
 private lemma cuspFunction_pow_nhds {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     ∀ n : ℕ, cuspFunction h (f ^ n) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n
@@ -189,7 +206,7 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     Nat.cast_sum]
   exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
 
-section ModularFormClass
+namespace ModularForm
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
 
@@ -256,8 +273,6 @@ lemma orderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
   rw [(orderAtCusp_nonneg h ⇑f).lt_iff_ne, ne_comm,
     ← not_not (a := cuspFunction h ⇑f 0 = 0)]
   exact not_congr (orderAtCusp_eq_zero_iff hh hΓ hf)
-
-end ModularFormClass
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -287,6 +287,23 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
   push_cast
   simp [orderAtCusp_def, Finset.sum_div]
 
+/-- The exponent vanishes iff the constant term — the value of the cusp function at
+`0` — is nonzero, for any function whose cusp function is analytic with finite order. -/
+lemma qExpansionOrderAtCusp_eq_zero_iff (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
+    qExpansionOrderAtCusp h g = 0 ↔ cuspFunction h g 0 ≠ 0 := by
+  rw [qExpansionOrderAtCusp_eq_analyticOrderAt hg, Int.natCast_eq_zero, ENat.toNat_eq_zero,
+    or_iff_left hg', hg.analyticOrderAt_eq_zero]
+
+/-- The exponent is positive iff the function vanishes at the cusp, for any function
+whose cusp function is analytic with finite order. -/
+lemma qExpansionOrderAtCusp_pos_iff (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
+    0 < qExpansionOrderAtCusp h g ↔ cuspFunction h g 0 = 0 := by
+  rw [(qExpansionOrderAtCusp_nonneg h g).lt_iff_ne, ne_comm,
+    ← not_not (a := cuspFunction h g 0 = 0)]
+  exact not_congr (qExpansionOrderAtCusp_eq_zero_iff hg hg')
+
 namespace ModularForm
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
@@ -334,29 +351,13 @@ lemma analyticOrderAt_cuspFunction_ne_top [ModularFormClass F Γ k] (hh : 0 < h)
   simp only [ne_eq, analyticOrderAt_eq_top]
   exact cuspFunction_not_eventually_zero hh hΓ hf
 
-/-- The exponent vanishes iff the constant term — the value of the cusp function at
-`0` — is nonzero, for any function whose cusp function is analytic with finite order. -/
-lemma qExpansionOrderAtCusp_eq_zero_iff' (hg : AnalyticAt ℂ (cuspFunction h g) 0)
-    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
-    qExpansionOrderAtCusp h g = 0 ↔ cuspFunction h g 0 ≠ 0 := by
-  rw [qExpansionOrderAtCusp_eq_analyticOrderAt hg, Int.natCast_eq_zero, ENat.toNat_eq_zero,
-    or_iff_left hg', hg.analyticOrderAt_eq_zero]
-
-/-- The exponent is positive iff the function vanishes at the cusp, for any function
-whose cusp function is analytic with finite order. -/
-lemma qExpansionOrderAtCusp_pos_iff' (hg : AnalyticAt ℂ (cuspFunction h g) 0)
-    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
-    0 < qExpansionOrderAtCusp h g ↔ cuspFunction h g 0 = 0 := by
-  rw [(qExpansionOrderAtCusp_nonneg h g).lt_iff_ne, ne_comm,
-    ← not_not (a := cuspFunction h g 0 = 0)]
-  exact not_congr (qExpansionOrderAtCusp_eq_zero_iff' hg hg')
-
 /-- For a nonzero modular form the exponent vanishes iff the constant term is nonzero. -/
 @[simp]
 lemma qExpansionOrderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     qExpansionOrderAtCusp h ⇑f = 0 ↔ cuspFunction h ⇑f 0 ≠ 0 :=
-  qExpansionOrderAtCusp_eq_zero_iff' (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
+  TauCeti.qExpansionOrderAtCusp_eq_zero_iff
+    (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
     (analyticOrderAt_cuspFunction_ne_top hh hΓ hf)
 
 /-- For a nonzero modular form the exponent is positive iff the form vanishes at the
@@ -365,7 +366,8 @@ cusp. -/
 lemma qExpansionOrderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
     (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
     0 < qExpansionOrderAtCusp h ⇑f ↔ cuspFunction h ⇑f 0 = 0 :=
-  qExpansionOrderAtCusp_pos_iff' (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
+  TauCeti.qExpansionOrderAtCusp_pos_iff
+    (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)
     (analyticOrderAt_cuspFunction_ne_top hh hΓ hf)
 
 /-- For a nonzero modular form the rational cusp order vanishes iff the doubled-width

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -132,7 +132,10 @@ constant term, the zero function by the junk value. -/
 @[simp]
 lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
   rcases eq_or_ne c 0 with rfl | hc
-  · rw [orderAtCusp_def,
+  · -- `rw [qExpansion_zero]` cannot fire here: the goal spells the zero function as a
+    -- lambda, which `rw`'s syntactic matching does not unify with `0`; the ascription
+    -- applies the same lemma across the two spellings.
+    rw [orderAtCusp_def,
       show (qExpansion h fun _ ↦ (0 : ℂ)) = 0 from qExpansion_zero h, PowerSeries.order_zero]
     rfl
   · exact orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by
@@ -152,8 +155,9 @@ private lemma cuspFunction_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunct
       cuspFunction_mul (by rw [cuspFunction_pow hf n]; exact (hf.continuousAt.pow n))
         hf.continuousAt]
 
-/-- The cusp order multiplies under powers, with no finiteness hypothesis: at the
-identically vanishing expansion both sides take the junk value. -/
+/-- The cusp order multiplies under powers, with no finiteness hypothesis: for an
+identically vanishing expansion both sides take the junk value at positive exponents,
+and at exponent zero both sides are genuinely zero. -/
 lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
   have h_an : AnalyticAt ℂ (cuspFunction h (f ^ n)) 0 := by

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -14,9 +14,15 @@ The vanishing order of a modular form at the cusp is the order of its `q`-expans
 integer with junk value `0` at the identically vanishing expansion — the convention of the
 interior dictionary `orderOfVanishingAt`. It is computed by the analytic order of the cusp
 function at `0`, vanishes when the constant term is nonzero, and rescales linearly in the
-width — the cusp term of the valence formula. The lemmas take the raw analytic, periodicity,
-and boundedness hypotheses of the underlying `q`-expansion theorems; for a modular form all
-of them are supplied by the `ModularFormClass` machinery.
+width — the cusp term of the level-one valence formula. The lemmas take the raw analytic,
+periodicity, and boundedness hypotheses of the underlying `q`-expansion theorems; for a
+modular form all of them are supplied by the `ModularFormClass` machinery.
+
+This is the integral exponent of the width-`h` expansion, the correct primitive at every
+cusp: at an irregular cusp of odd weight the conventionally normalized order is the
+half-integer obtained by reading this exponent at the doubled width, a `ℚ`-valued
+convention layer that belongs with the cusp classification machinery and is deliberately
+not defined here.
 
 ## Main declarations
 
@@ -46,7 +52,9 @@ variable {h : ℝ} {g : ℍ → ℂ}
 
 /-- The vanishing order at the cusp: the order of the `q`-expansion at width `h`, as an
 integer, with junk value `0` when the expansion vanishes identically — the `untop₀`
-convention of `orderOfVanishingAt`. -/
+convention of `orderOfVanishingAt`. This is the exponent of the width-`h` uniformizer;
+normalized orders at other widths (half-integral at irregular cusps) are conversion
+layers over this primitive. -/
 def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ := ((qExpansion h f).order.toNat : ℤ)
 
 /-- `orderAtCusp` unfolded to the `q`-expansion order. The definition is sealed by the

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -239,6 +239,33 @@ lemma orderAtCuspQ_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofCompl
   push_cast
   ring
 
+/-- The rational cusp order is additive on products. -/
+lemma orderAtCuspQ_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
+    (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0)
+    (hf' : analyticOrderAt (cuspFunction (2 * h) f) 0 ≠ ⊤)
+    (hg' : analyticOrderAt (cuspFunction (2 * h) g) 0 ≠ ⊤) :
+    orderAtCuspQ h (f * g) = orderAtCuspQ h f + orderAtCuspQ h g := by
+  rw [orderAtCuspQ_def, orderAtCuspQ_def, orderAtCuspQ_def, orderAtCusp_mul hf hg hf' hg']
+  push_cast
+  ring
+
+/-- The rational cusp order multiplies under powers. -/
+lemma orderAtCuspQ_pow {f : ℍ → ℂ} (n : ℕ)
+    (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0) :
+    orderAtCuspQ h (f ^ n) = n * orderAtCuspQ h f := by
+  rw [orderAtCuspQ_def, orderAtCuspQ_def, orderAtCusp_pow n hf]
+  push_cast
+  ring
+
+/-- The rational cusp order is additive on finite products. -/
+lemma orderAtCuspQ_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+    (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction (2 * h) (f i)) 0)
+    (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction (2 * h) (f i)) 0 ≠ ⊤) :
+    orderAtCuspQ h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCuspQ h (f i) := by
+  rw [orderAtCuspQ_def, orderAtCusp_prod s hf hf']
+  push_cast
+  simp [orderAtCuspQ_def, Finset.sum_div]
+
 namespace ModularForm
 
 variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F}

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -239,6 +239,23 @@ lemma orderAtCuspQ_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofCompl
   push_cast
   ring
 
+/-- The rational cusp order is nonnegative. -/
+lemma orderAtCuspQ_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCuspQ h f := by
+  rw [orderAtCuspQ_def]
+  exact div_nonneg (by exact_mod_cast orderAtCusp_nonneg (2 * h) f) (by norm_num)
+
+/-- Every constant function has rational cusp order zero. -/
+@[simp]
+lemma orderAtCuspQ_const (h : ℝ) (c : ℂ) : orderAtCuspQ h (fun _ ↦ c) = 0 := by
+  rw [orderAtCuspQ_def, orderAtCusp_const]
+  norm_num
+
+/-- The constant-one function has rational cusp order zero. -/
+@[simp]
+lemma orderAtCuspQ_one (h : ℝ) : orderAtCuspQ h (1 : ℍ → ℂ) = 0 := by
+  rw [orderAtCuspQ_def, orderAtCusp_one]
+  norm_num
+
 /-- The rational cusp order is additive on products. -/
 lemma orderAtCuspQ_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
     (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0)

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -218,6 +218,13 @@ lemma rationalOrderAtCusp_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ 
   push_cast
   ring
 
+/-- The rational cusp order is the halved doubled-width analytic order. -/
+lemma rationalOrderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0) :
+    rationalOrderAtCusp h g = ((analyticOrderAt (cuspFunction (2 * h) g) 0).toNat : ℚ) / 2 := by
+  rw [rationalOrderAtCusp_def, orderAtCusp_eq_analyticOrderAt hg]
+  push_cast
+  ring
+
 /-- The rational cusp order is nonnegative. -/
 lemma rationalOrderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ rationalOrderAtCusp h f := by
   rw [rationalOrderAtCusp_def]
@@ -330,6 +337,26 @@ lemma orderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
   rw [(orderAtCusp_nonneg h ⇑f).lt_iff_ne, ne_comm,
     ← not_not (a := cuspFunction h ⇑f 0 = 0)]
   exact not_congr (orderAtCusp_eq_zero_iff hh hΓ hf)
+
+/-- For a nonzero modular form the rational cusp order vanishes iff the doubled-width
+constant term is nonzero. -/
+@[simp]
+lemma rationalOrderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : 2 * h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    rationalOrderAtCusp h ⇑f = 0 ↔ cuspFunction (2 * h) ⇑f 0 ≠ 0 := by
+  rw [rationalOrderAtCusp_def, div_eq_zero_iff]
+  simp only [OfNat.ofNat_ne_zero, or_false, Int.cast_eq_zero]
+  exact orderAtCusp_eq_zero_iff (by positivity) hΓ hf
+
+/-- For a nonzero modular form the rational cusp order is positive iff the form vanishes
+at the cusp in the doubled-width reading. -/
+@[simp]
+lemma rationalOrderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : 2 * h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    0 < rationalOrderAtCusp h ⇑f ↔ cuspFunction (2 * h) ⇑f 0 = 0 := by
+  rw [rationalOrderAtCusp_def]
+  rw [div_pos_iff_of_pos_right (by norm_num : (0 : ℚ) < 2), Int.cast_pos]
+  exact orderAtCusp_pos_iff (by positivity) hΓ hf
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -18,18 +18,18 @@ width — the cusp term of the level-one valence formula. The lemmas take the ra
 periodicity, and boundedness hypotheses of the underlying `q`-expansion theorems; for a
 modular form all of them are supplied by the `ModularFormClass` machinery.
 
-This is the integral exponent of the width-`h` expansion, the correct primitive at every
-cusp: at an irregular cusp of odd weight the conventionally normalized order is the
-half-integer obtained by reading this exponent at the doubled width, a `ℚ`-valued
-convention layer that belongs with the cusp classification machinery and is deliberately
-not defined here.
+`orderAtCusp` is the integral exponent of the width-`h` expansion, the correct primitive
+at every cusp; `rationalOrderAtCusp` supplies the width-normalized `ℚ`-valued convention
+on top of it — the doubled-width exponent halved, which is the integral order for an
+`h`-periodic function and the conventional half-integer at an irregular cusp of odd
+weight.
 
 ## Main declarations
 
 * `TauCeti.orderAtCusp`.
 * `TauCeti.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
 * `TauCeti.orderAtCusp_nat_mul`: linear rescaling in the width.
-* `TauCeti.orderAtCuspQ`: the `ℚ`-valued cusp order — the doubled-width exponent halved,
+* `TauCeti.rationalOrderAtCusp`: the `ℚ`-valued cusp order — the doubled-width exponent halved,
   the conventional half-integral order at irregular cusps.
 * `TauCeti.ModularForm.orderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
   is a nonzero constant term (the class-level interface lives in `TauCeti.ModularForm`).
@@ -98,27 +98,6 @@ lemma orderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
     qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff, ENat.toNat_mul]
   simp [mul_comm]
 
-private lemma cuspFunction_mul_eventuallyEq (h : ℝ) (f g : ℍ → ℂ) :
-    cuspFunction h (f * g) =ᶠ[𝓝[≠] (0 : ℂ)] cuspFunction h f * cuspFunction h g := by
-  filter_upwards [self_mem_nhdsWithin] with q hq
-  simp only [UpperHalfPlane.cuspFunction, Pi.mul_apply, Function.comp_apply,
-    Function.Periodic.cuspFunction_eq_of_nonzero _ _ hq]
-
-private lemma cuspFunction_mul_nhds {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
-    (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
-    cuspFunction h (f * g) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f * cuspFunction h g := by
-  have h_lim : Filter.Tendsto (cuspFunction h (f * g)) (𝓝[≠] 0)
-      (𝓝 (cuspFunction h f 0 * cuspFunction h g 0)) :=
-    (((hf.continuousAt.tendsto.mono_left nhdsWithin_le_nhds).mul
-      (hg.continuousAt.tendsto.mono_left nhdsWithin_le_nhds))).congr'
-      (cuspFunction_mul_eventuallyEq h f g).symm
-  have h_at : cuspFunction h (f * g) 0 = cuspFunction h f 0 * cuspFunction h g 0 := by
-    rw [UpperHalfPlane.cuspFunction, Function.Periodic.cuspFunction_zero_eq_limUnder_nhds_ne]
-    exact h_lim.limUnder_eq
-  rw [← nhdsNE_sup_pure (0 : ℂ)]
-  exact Filter.eventually_sup.mpr
-    ⟨cuspFunction_mul_eventuallyEq h f g, Filter.eventually_pure.mpr h_at⟩
-
 /-- The cusp order is additive on products. The finiteness hypotheses exclude an
 identically vanishing factor, where the junk value `0` would break additivity. -/
 lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
@@ -126,10 +105,12 @@ lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f
     (hf' : analyticOrderAt (cuspFunction h f) 0 ≠ ⊤)
     (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
     orderAtCusp h (f * g) = orderAtCusp h f + orderAtCusp h g := by
-  have h_full := cuspFunction_mul_nhds hf hg
-  rw [orderAtCusp_eq_analyticOrderAt ((hf.mul hg).congr h_full.symm),
-    orderAtCusp_eq_analyticOrderAt hf, orderAtCusp_eq_analyticOrderAt hg,
-    analyticOrderAt_congr h_full, analyticOrderAt_mul hf hg, ENat.toNat_add hf' hg']
+  have hf'' : (qExpansion h f).order ≠ ⊤ := by
+    rwa [qExpansion_order_eq_analyticOrderAt_cuspFunction hf]
+  have hg'' : (qExpansion h g).order ≠ ⊤ := by
+    rwa [qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
+  rw [orderAtCusp_def, orderAtCusp_def, orderAtCusp_def, qExpansion_mul hf hg,
+    PowerSeries.order_mul, ENat.toNat_add hf'' hg'']
   push_cast
   ring
 
@@ -164,45 +145,36 @@ lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 :=
 lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 :=
   orderAtCusp_const h 1
 
-private lemma cuspFunction_pow_nhds {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
-    ∀ n : ℕ, cuspFunction h (f ^ n) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n
-  | 0 => by simp [pow_zero, cuspFunction_one]
+private lemma cuspFunction_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    ∀ n : ℕ, cuspFunction h (f ^ n) = cuspFunction h f ^ n
+  | 0 => by rw [pow_zero, pow_zero]; exact cuspFunction_one h
   | n + 1 => by
-    have h_prev := cuspFunction_pow_nhds hf n
-    calc cuspFunction h (f ^ (n + 1))
-        =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f ^ n) * cuspFunction h f := by
-          rw [pow_succ]
-          exact cuspFunction_mul_nhds ((hf.pow n).congr h_prev.symm) hf
-      _ =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n * cuspFunction h f :=
-          h_prev.mul Filter.EventuallyEq.rfl
-      _ = cuspFunction h f ^ (n + 1) := (pow_succ _ _).symm
+    rw [pow_succ, pow_succ, ← cuspFunction_pow hf n,
+      cuspFunction_mul (by rw [cuspFunction_pow hf n]; exact (hf.continuousAt.pow n))
+        hf.continuousAt]
 
 /-- The cusp order multiplies under powers, with no finiteness hypothesis: at the
 identically vanishing expansion both sides take the junk value. -/
 lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
-  have h_ev := cuspFunction_pow_nhds hf n
-  rw [orderAtCusp_eq_analyticOrderAt ((hf.pow n).congr h_ev.symm),
-    orderAtCusp_eq_analyticOrderAt hf, analyticOrderAt_congr h_ev, analyticOrderAt_pow hf,
-    nsmul_eq_mul, ENat.toNat_mul]
+  have h_an : AnalyticAt ℂ (cuspFunction h (f ^ n)) 0 := by
+    rw [cuspFunction_pow hf n]
+    exact hf.pow n
+  rw [orderAtCusp_eq_analyticOrderAt h_an, orderAtCusp_eq_analyticOrderAt hf,
+    cuspFunction_pow hf n, analyticOrderAt_pow hf, nsmul_eq_mul, ENat.toNat_mul]
   simp
 
-private lemma cuspFunction_prod_nhds {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+private lemma cuspFunction_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0) :
-    cuspFunction h (∏ i ∈ s, f i) =ᶠ[𝓝 (0 : ℂ)] ∏ i ∈ s, cuspFunction h (f i) := by
+    cuspFunction h (∏ i ∈ s, f i) = ∏ i ∈ s, cuspFunction h (f i) := by
   induction s using Finset.cons_induction with
-  | empty => simp [cuspFunction_one]
+  | empty => simpa using cuspFunction_one h
   | cons a s ha ih =>
     have h_prev := ih fun i hi ↦ hf i (Finset.mem_cons_of_mem hi)
-    calc cuspFunction h (∏ i ∈ Finset.cons a s ha, f i)
-        =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f a) * cuspFunction h (∏ i ∈ s, f i) := by
-          rw [Finset.prod_cons]
-          exact cuspFunction_mul_nhds (hf a (Finset.mem_cons_self a s))
-            ((Finset.analyticAt_prod _ fun i hi ↦
-              hf i (Finset.mem_cons_of_mem hi)).congr h_prev.symm)
-      _ =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f a) * ∏ i ∈ s, cuspFunction h (f i) :=
-          Filter.EventuallyEq.rfl.mul h_prev
-      _ = ∏ i ∈ Finset.cons a s ha, cuspFunction h (f i) := by rw [Finset.prod_cons]
+    rw [Finset.prod_cons, Finset.prod_cons, ← h_prev,
+      cuspFunction_mul (hf a (Finset.mem_cons_self a s)).continuousAt
+        (by rw [h_prev]; exact (Finset.analyticAt_prod _ fun i hi ↦
+          hf i (Finset.mem_cons_of_mem hi)).continuousAt)]
 
 /-- The cusp order is additive on finite products. The finiteness hypotheses exclude an
 identically vanishing factor, where the junk value `0` would break additivity. -/
@@ -210,78 +182,80 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0)
     (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction h (f i)) 0 ≠ ⊤) :
     orderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCusp h (f i) := by
-  have h_ev := cuspFunction_prod_nhds s hf
-  rw [orderAtCusp_eq_analyticOrderAt ((Finset.analyticAt_prod _ hf).congr h_ev.symm),
-    analyticOrderAt_congr h_ev, TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf',
-    Nat.cast_sum]
+  have h_an : AnalyticAt ℂ (cuspFunction h (∏ i ∈ s, f i)) 0 := by
+    rw [cuspFunction_prod s hf]
+    exact Finset.analyticAt_prod _ hf
+  rw [orderAtCusp_eq_analyticOrderAt h_an, cuspFunction_prod s hf,
+    TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf', Nat.cast_sum]
   exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
 
 /-- The `ℚ`-valued cusp order: the width-`2h` exponent, halved. For an `h`-periodic
-function this is the integral order `orderAtCusp h` (`orderAtCuspQ_eq_orderAtCusp`);
+function this is the integral order `orderAtCusp h` (`rationalOrderAtCusp_eq_orderAtCusp`);
 at an irregular cusp of odd weight, where the form is only `2h`-periodic, it is the
 conventional half-integral order. -/
-def orderAtCuspQ (h : ℝ) (f : ℍ → ℂ) : ℚ := (orderAtCusp (2 * h) f : ℚ) / 2
+def rationalOrderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℚ := (orderAtCusp (2 * h) f : ℚ) / 2
 
-/-- `orderAtCuspQ` unfolded to the halved doubled-width exponent. -/
-lemma orderAtCuspQ_def (h : ℝ) (f : ℍ → ℂ) :
-    orderAtCuspQ h f = (orderAtCusp (2 * h) f : ℚ) / 2 := by
-  unfold orderAtCuspQ
+/-- `rationalOrderAtCusp` unfolded to the halved doubled-width exponent. -/
+lemma rationalOrderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
+    rationalOrderAtCusp h f = (orderAtCusp (2 * h) f : ℚ) / 2 := by
+  unfold rationalOrderAtCusp
   rfl
 
 /-- For an `h`-periodic bounded holomorphic function the `ℚ`-valued cusp order is the
 integral one: the doubled-width exponent doubles. -/
-lemma orderAtCuspQ_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofComplex) h)
+lemma rationalOrderAtCusp_eq_orderAtCusp (hh : 0 < h) (hg_per : Periodic (g ∘ ofComplex) h)
     (hg_bdd : IsBoundedAtImInfty g) (hg_mdiff : MDiff g) :
-    orderAtCuspQ h g = (orderAtCusp h g : ℚ) := by
+    rationalOrderAtCusp h g = (orderAtCusp h g : ℚ) := by
   have h2 := orderAtCusp_nat_mul (g := g) (m := 2) hh (by norm_num) hg_per hg_bdd hg_mdiff
-  rw [orderAtCuspQ_def, show ((2 : ℕ) : ℝ) * h = 2 * h by norm_num] at *
-  rw [h2]
+  norm_num at h2
+  rw [rationalOrderAtCusp_def, h2]
   push_cast
   ring
 
 /-- The rational cusp order is nonnegative. -/
-lemma orderAtCuspQ_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCuspQ h f := by
-  rw [orderAtCuspQ_def]
+lemma rationalOrderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ rationalOrderAtCusp h f := by
+  rw [rationalOrderAtCusp_def]
   exact div_nonneg (by exact_mod_cast orderAtCusp_nonneg (2 * h) f) (by norm_num)
 
 /-- Every constant function has rational cusp order zero. -/
 @[simp]
-lemma orderAtCuspQ_const (h : ℝ) (c : ℂ) : orderAtCuspQ h (fun _ ↦ c) = 0 := by
-  rw [orderAtCuspQ_def, orderAtCusp_const]
+lemma rationalOrderAtCusp_const (h : ℝ) (c : ℂ) : rationalOrderAtCusp h (fun _ ↦ c) = 0 := by
+  rw [rationalOrderAtCusp_def, orderAtCusp_const]
   norm_num
 
 /-- The constant-one function has rational cusp order zero. -/
 @[simp]
-lemma orderAtCuspQ_one (h : ℝ) : orderAtCuspQ h (1 : ℍ → ℂ) = 0 := by
-  rw [orderAtCuspQ_def, orderAtCusp_one]
+lemma rationalOrderAtCusp_one (h : ℝ) : rationalOrderAtCusp h (1 : ℍ → ℂ) = 0 := by
+  rw [rationalOrderAtCusp_def, orderAtCusp_one]
   norm_num
 
 /-- The rational cusp order is additive on products. -/
-lemma orderAtCuspQ_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
+lemma rationalOrderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0)
     (hg : AnalyticAt ℂ (cuspFunction (2 * h) g) 0)
     (hf' : analyticOrderAt (cuspFunction (2 * h) f) 0 ≠ ⊤)
     (hg' : analyticOrderAt (cuspFunction (2 * h) g) 0 ≠ ⊤) :
-    orderAtCuspQ h (f * g) = orderAtCuspQ h f + orderAtCuspQ h g := by
-  rw [orderAtCuspQ_def, orderAtCuspQ_def, orderAtCuspQ_def, orderAtCusp_mul hf hg hf' hg']
+    rationalOrderAtCusp h (f * g) = rationalOrderAtCusp h f + rationalOrderAtCusp h g := by
+  simp only [rationalOrderAtCusp_def]
+  rw [orderAtCusp_mul hf hg hf' hg']
   push_cast
   ring
 
 /-- The rational cusp order multiplies under powers. -/
-lemma orderAtCuspQ_pow {f : ℍ → ℂ} (n : ℕ)
+lemma rationalOrderAtCusp_pow {f : ℍ → ℂ} (n : ℕ)
     (hf : AnalyticAt ℂ (cuspFunction (2 * h) f) 0) :
-    orderAtCuspQ h (f ^ n) = n * orderAtCuspQ h f := by
-  rw [orderAtCuspQ_def, orderAtCuspQ_def, orderAtCusp_pow n hf]
+    rationalOrderAtCusp h (f ^ n) = n * rationalOrderAtCusp h f := by
+  rw [rationalOrderAtCusp_def, rationalOrderAtCusp_def, orderAtCusp_pow n hf]
   push_cast
   ring
 
 /-- The rational cusp order is additive on finite products. -/
-lemma orderAtCuspQ_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+lemma rationalOrderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction (2 * h) (f i)) 0)
     (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction (2 * h) (f i)) 0 ≠ ⊤) :
-    orderAtCuspQ h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCuspQ h (f i) := by
-  rw [orderAtCuspQ_def, orderAtCusp_prod s hf hf']
+    rationalOrderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, rationalOrderAtCusp h (f i) := by
+  rw [rationalOrderAtCusp_def, orderAtCusp_prod s hf hf']
   push_cast
-  simp [orderAtCuspQ_def, Finset.sum_div]
+  simp [rationalOrderAtCusp_def, Finset.sum_div]
 
 namespace ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -155,11 +155,6 @@ private lemma cuspFunction_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunct
       cuspFunction_mul (by rw [cuspFunction_pow hf n]; exact (hf.continuousAt.pow n))
         hf.continuousAt]
 
-private lemma qExpansion_one (h : ℝ) : qExpansion h (1 : ℍ → ℂ) = 1 := by
-  ext m
-  rw [qExpansion_coeff, cuspFunction_one]
-  rcases m with _ | m <;> simp [PowerSeries.coeff_one, Pi.one_def, iteratedDeriv_const]
-
 private lemma qExpansion_pow {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
     ∀ n : ℕ, qExpansion h (f ^ n) = qExpansion h f ^ n
   | 0 => by rw [pow_zero, pow_zero, qExpansion_one]

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Data.ENat.BigOperators
+public import TauCeti.NumberTheory.ModularForms.FiniteZeros
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 /-!
@@ -23,6 +24,8 @@ of them are supplied by the `ModularFormClass` machinery.
 * `TauCeti.ModularForm.orderAtCusp`.
 * `TauCeti.ModularForm.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
 * `TauCeti.ModularForm.orderAtCusp_nat_mul`: linear rescaling in the width.
+* `TauCeti.ModularForm.orderAtCusp_eq_zero_iff`: for a nonzero modular form, order zero
+  is a nonzero constant term.
 * `TauCeti.ModularForm.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow`
   and `orderAtCusp_prod`).
 
@@ -184,6 +187,41 @@ lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     analyticOrderAt_congr h_ev, TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf',
     Nat.cast_sum]
   exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
+
+section ModularFormClass
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F}
+
+/-- For a nonzero modular form the cusp function does not vanish identically near `0`,
+so its analytic order there is finite. -/
+lemma analyticOrderAt_cuspFunction_ne_top [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    analyticOrderAt (cuspFunction h ⇑f) 0 ≠ ⊤ := by
+  simp only [ne_eq, analyticOrderAt_eq_top]
+  exact cuspFunction_not_eventually_zero hh hΓ hf
+
+/-- For a nonzero modular form the cusp order vanishes iff the constant term — the value
+of the cusp function at `0` — is nonzero. -/
+@[simp]
+lemma orderAtCusp_eq_zero_iff [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    orderAtCusp h ⇑f = 0 ↔ cuspFunction h ⇑f 0 ≠ 0 := by
+  have h_an := ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ
+  rw [orderAtCusp_eq_analyticOrderAt h_an, Int.natCast_eq_zero, ENat.toNat_eq_zero,
+    or_iff_left (analyticOrderAt_cuspFunction_ne_top hh hΓ hf),
+    h_an.analyticOrderAt_eq_zero]
+
+/-- For a nonzero modular form the cusp order is positive iff the form vanishes at the
+cusp. -/
+@[simp]
+lemma orderAtCusp_pos_iff [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (hf : (⇑f : ℍ → ℂ) ≠ 0) :
+    0 < orderAtCusp h ⇑f ↔ cuspFunction h ⇑f 0 = 0 := by
+  rw [(orderAtCusp_nonneg h ⇑f).lt_iff_ne, ne_comm,
+    ← not_not (a := cuspFunction h ⇑f 0 = 0)]
+  exact not_congr (orderAtCusp_eq_zero_iff hh hΓ hf)
+
+end ModularFormClass
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -130,10 +130,7 @@ constant term, the zero function by the junk value. -/
 @[simp]
 lemma orderAtCusp_const (h : ℝ) (c : ℂ) : orderAtCusp h (fun _ ↦ c) = 0 := by
   rcases eq_or_ne c 0 with rfl | hc
-  · have h0 : qExpansion h (fun _ ↦ (0 : ℂ)) = 0 := by
-      ext m
-      rw [qExpansion_coeff, cuspFunction_const]
-      simp
+  · have h0 : qExpansion h (fun _ ↦ (0 : ℂ)) = 0 := qExpansion_zero h
     rw [orderAtCusp_def, h0, PowerSeries.order_zero]
     rfl
   · exact orderAtCusp_eq_zero_of_cuspFunction_ne_zero (by

--- a/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/Order/AtCusp.lean
@@ -105,12 +105,14 @@ lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f
     (hf' : analyticOrderAt (cuspFunction h f) 0 ≠ ⊤)
     (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
     orderAtCusp h (f * g) = orderAtCusp h f + orderAtCusp h g := by
-  have hf'' : (qExpansion h f).order ≠ ⊤ := by
-    rwa [qExpansion_order_eq_analyticOrderAt_cuspFunction hf]
-  have hg'' : (qExpansion h g).order ≠ ⊤ := by
-    rwa [qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
-  rw [orderAtCusp_def, orderAtCusp_def, orderAtCusp_def, qExpansion_mul hf hg,
-    PowerSeries.order_mul, ENat.toNat_add hf'' hg'']
+  have h_an : AnalyticAt ℂ (cuspFunction h (f * g)) 0 := by
+    rw [cuspFunction_mul hf.continuousAt hg.continuousAt]
+    exact hf.mul hg
+  have h_nat := analyticOrderNatAt_mul hf hg hf' hg'
+  simp only [analyticOrderNatAt] at h_nat
+  rw [orderAtCusp_eq_analyticOrderAt h_an, orderAtCusp_eq_analyticOrderAt hf,
+    orderAtCusp_eq_analyticOrderAt hg, cuspFunction_mul hf.continuousAt hg.continuousAt,
+    h_nat]
   push_cast
   ring
 
@@ -157,9 +159,12 @@ lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunc
   have h_an : AnalyticAt ℂ (cuspFunction h (f ^ n)) 0 := by
     rw [cuspFunction_pow hf n]
     exact hf.pow n
+  have h_nat := analyticOrderNatAt_pow hf n
+  simp only [analyticOrderNatAt, smul_eq_mul] at h_nat
   rw [orderAtCusp_eq_analyticOrderAt h_an, orderAtCusp_eq_analyticOrderAt hf,
-    cuspFunction_pow hf n, analyticOrderAt_pow hf, nsmul_eq_mul, ENat.toNat_mul]
-  simp
+    cuspFunction_pow hf n, h_nat]
+  push_cast
+  ring
 
 private lemma cuspFunction_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
     (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0) :

--- a/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 /-!
@@ -12,9 +11,11 @@ public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 The vanishing order of a modular form at the cusp is the order of its `q`-expansion, as an
 integer with junk value `0` at the identically vanishing expansion — the convention of the
-interior dictionary `orderOfVanishingAt`. For a modular form it is computed by the analytic
-order of the cusp function at `0`, vanishes when the constant term is nonzero, and rescales
-linearly in the width — the cusp term of the valence formula.
+interior dictionary `orderOfVanishingAt`. It is computed by the analytic order of the cusp
+function at `0`, vanishes when the constant term is nonzero, and rescales linearly in the
+width — the cusp term of the valence formula. The lemmas take the raw analytic, periodicity,
+and boundedness hypotheses of the underlying `q`-expansion theorems; for a modular form all
+of them are supplied by the `ModularFormClass` machinery.
 
 ## Main declarations
 
@@ -32,13 +33,13 @@ public noncomputable section
 
 open UpperHalfPlane Complex Function SlashInvariantForm Periodic
 
-open scoped ModularForm
+open scoped ModularForm Topology Filter Manifold
 
 namespace TauCeti
 
 namespace ModularForm
 
-variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F} {h : ℝ}
+variable {h : ℝ} {g : ℍ → ℂ}
 
 /-- The vanishing order at the cusp: the order of the `q`-expansion at width `h`, as an
 integer, with junk value `0` when the expansion vanishes identically — the `untop₀`
@@ -57,30 +58,26 @@ lemma orderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCusp h f := 
   rw [orderAtCusp_def]
   exact Int.natCast_nonneg _
 
-/-- The cusp order of a modular form is the analytic order of its cusp function at `0`. -/
-lemma orderAtCusp_eq_analyticOrderAt [ModularFormClass F Γ k] (hh : 0 < h)
-    (hΓ : h ∈ Γ.strictPeriods) :
-    orderAtCusp h f = ((analyticOrderAt (cuspFunction h f) 0).toNat : ℤ) := by
-  rw [orderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction
-    (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)]
+/-- The cusp order is the analytic order of the cusp function at `0`. For a modular form
+the analyticity is `ModularFormClass.analyticAt_cuspFunction_zero`. -/
+lemma orderAtCusp_eq_analyticOrderAt (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
+    orderAtCusp h g = ((analyticOrderAt (cuspFunction h g) 0).toNat : ℤ) := by
+  rw [orderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction hg]
 
-/-- A modular form whose constant term at the cusp is nonzero has cusp order zero. -/
-lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
-    (hΓ : h ∈ Γ.strictPeriods) (h0 : cuspFunction h f 0 ≠ 0) : orderAtCusp h f = 0 := by
-  rw [orderAtCusp_eq_analyticOrderAt hh hΓ,
-    (ModularFormClass.analyticAt_cuspFunction_zero f hh
-      hΓ).analyticOrderAt_eq_zero.mpr h0]
+/-- A nonzero constant term at the cusp forces cusp order zero. -/
+lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (h0 : cuspFunction h g 0 ≠ 0) : orderAtCusp h g = 0 := by
+  rw [orderAtCusp_eq_analyticOrderAt hg, hg.analyticOrderAt_eq_zero.mpr h0]
   rfl
 
-/-- The cusp order rescales linearly in the width. -/
-lemma orderAtCusp_nat_mul [ModularFormClass F Γ k] {m : ℕ} (hh : 0 < h) (hm : 0 < m)
-    (hΓ : h ∈ Γ.strictPeriods) :
-    orderAtCusp (m * h) f = m * orderAtCusp h f := by
-  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+/-- The cusp order rescales linearly in the width. For a modular form the periodicity,
+boundedness, and holomorphy are `SlashInvariantFormClass.periodic_comp_ofComplex`,
+`ModularFormClass.bdd_at_infty`, and `ModularFormClass.holo`. -/
+lemma orderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hg_per : Periodic (g ∘ ofComplex) h) (hg_bdd : IsBoundedAtImInfty g)
+    (hg_mdiff : MDiff g) : orderAtCusp (m * h) g = m * orderAtCusp h g := by
   rw [orderAtCusp_def, orderAtCusp_def,
-    qExpansion_nat_mul_order hh hm (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
-      (ModularFormClass.bdd_at_infty f) (ModularFormClass.holo f),
-    ENat.toNat_mul]
+    qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff, ENat.toNat_mul]
   simp [mul_comm]
 
 end ModularForm

--- a/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.ENat.BigOperators
 public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
 
 /-!
@@ -22,6 +23,8 @@ of them are supplied by the `ModularFormClass` machinery.
 * `TauCeti.ModularForm.orderAtCusp`.
 * `TauCeti.ModularForm.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
 * `TauCeti.ModularForm.orderAtCusp_nat_mul`: linear rescaling in the width.
+* `TauCeti.ModularForm.orderAtCusp_mul`: additivity on products (with `orderAtCusp_pow`
+  and `orderAtCusp_prod`).
 
 ## References
 
@@ -79,6 +82,108 @@ lemma orderAtCusp_nat_mul {m : ℕ} (hh : 0 < h) (hm : 0 < m)
   rw [orderAtCusp_def, orderAtCusp_def,
     qExpansion_nat_mul_order hh hm hg_per hg_bdd hg_mdiff, ENat.toNat_mul]
   simp [mul_comm]
+
+private lemma cuspFunction_mul_eventuallyEq (h : ℝ) (f g : ℍ → ℂ) :
+    cuspFunction h (f * g) =ᶠ[𝓝[≠] (0 : ℂ)] cuspFunction h f * cuspFunction h g := by
+  filter_upwards [self_mem_nhdsWithin] with q hq
+  simp only [UpperHalfPlane.cuspFunction, Pi.mul_apply,
+    Function.Periodic.cuspFunction_eq_of_nonzero _ _ hq]
+  rfl
+
+private lemma cuspFunction_mul_nhds {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
+    (hg : AnalyticAt ℂ (cuspFunction h g) 0) :
+    cuspFunction h (f * g) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f * cuspFunction h g := by
+  have h_lim : Filter.Tendsto (cuspFunction h (f * g)) (𝓝[≠] 0)
+      (𝓝 (cuspFunction h f 0 * cuspFunction h g 0)) :=
+    (((hf.continuousAt.tendsto.mono_left nhdsWithin_le_nhds).mul
+      (hg.continuousAt.tendsto.mono_left nhdsWithin_le_nhds))).congr'
+      (cuspFunction_mul_eventuallyEq h f g).symm
+  have h_at : cuspFunction h (f * g) 0 = cuspFunction h f 0 * cuspFunction h g 0 := by
+    rw [UpperHalfPlane.cuspFunction, Function.Periodic.cuspFunction_zero_eq_limUnder_nhds_ne]
+    exact h_lim.limUnder_eq
+  rw [← nhdsNE_sup_pure (0 : ℂ)]
+  exact Filter.eventually_sup.mpr
+    ⟨cuspFunction_mul_eventuallyEq h f g, Filter.eventually_pure.mpr h_at⟩
+
+/-- The cusp order is additive on products. The finiteness hypotheses exclude an
+identically vanishing factor, where the junk value `0` would break additivity. -/
+lemma orderAtCusp_mul {f g : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0)
+    (hg : AnalyticAt ℂ (cuspFunction h g) 0)
+    (hf' : analyticOrderAt (cuspFunction h f) 0 ≠ ⊤)
+    (hg' : analyticOrderAt (cuspFunction h g) 0 ≠ ⊤) :
+    orderAtCusp h (f * g) = orderAtCusp h f + orderAtCusp h g := by
+  have h_full := cuspFunction_mul_nhds hf hg
+  rw [orderAtCusp_eq_analyticOrderAt ((hf.mul hg).congr h_full.symm),
+    orderAtCusp_eq_analyticOrderAt hf, orderAtCusp_eq_analyticOrderAt hg,
+    analyticOrderAt_congr h_full, analyticOrderAt_mul hf hg, ENat.toNat_add hf' hg']
+  push_cast
+  ring
+
+private lemma cuspFunction_one (h : ℝ) : cuspFunction h (1 : ℍ → ℂ) = 1 := by
+  have h_lim : Filter.limUnder (𝓝[≠] (0 : ℂ))
+      (((1 : ℍ → ℂ) ∘ ofComplex) ∘ Function.Periodic.invQParam h) = 1 :=
+    Filter.Tendsto.limUnder_eq tendsto_const_nhds
+  rw [UpperHalfPlane.cuspFunction, Function.Periodic.cuspFunction, h_lim]
+  exact Function.update_eq_self 0 (1 : ℂ → ℂ)
+
+/-- The constant-one function has cusp order zero. -/
+@[simp]
+lemma orderAtCusp_one (h : ℝ) : orderAtCusp h (1 : ℍ → ℂ) = 0 :=
+  orderAtCusp_eq_zero_of_cuspFunction_ne_zero
+    (by rw [cuspFunction_one]; exact analyticAt_const)
+    (by rw [cuspFunction_one]; exact one_ne_zero)
+
+private lemma cuspFunction_pow_nhds {f : ℍ → ℂ} (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    ∀ n : ℕ, cuspFunction h (f ^ n) =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n
+  | 0 => by simp [pow_zero, cuspFunction_one]
+  | n + 1 => by
+    have h_prev := cuspFunction_pow_nhds hf n
+    calc cuspFunction h (f ^ (n + 1))
+        =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f ^ n) * cuspFunction h f := by
+          rw [pow_succ]
+          exact cuspFunction_mul_nhds ((hf.pow n).congr h_prev.symm) hf
+      _ =ᶠ[𝓝 (0 : ℂ)] cuspFunction h f ^ n * cuspFunction h f :=
+          h_prev.mul Filter.EventuallyEq.rfl
+      _ = cuspFunction h f ^ (n + 1) := (pow_succ _ _).symm
+
+/-- The cusp order multiplies under powers, with no finiteness hypothesis: at the
+identically vanishing expansion both sides take the junk value. -/
+lemma orderAtCusp_pow {f : ℍ → ℂ} (n : ℕ) (hf : AnalyticAt ℂ (cuspFunction h f) 0) :
+    orderAtCusp h (f ^ n) = n * orderAtCusp h f := by
+  have h_ev := cuspFunction_pow_nhds hf n
+  rw [orderAtCusp_eq_analyticOrderAt ((hf.pow n).congr h_ev.symm),
+    orderAtCusp_eq_analyticOrderAt hf, analyticOrderAt_congr h_ev, analyticOrderAt_pow hf,
+    nsmul_eq_mul, ENat.toNat_mul]
+  simp
+
+private lemma cuspFunction_prod_nhds {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+    (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0) :
+    cuspFunction h (∏ i ∈ s, f i) =ᶠ[𝓝 (0 : ℂ)] ∏ i ∈ s, cuspFunction h (f i) := by
+  induction s using Finset.cons_induction with
+  | empty => simp [cuspFunction_one]
+  | cons a s ha ih =>
+    have h_prev := ih fun i hi ↦ hf i (Finset.mem_cons_of_mem hi)
+    calc cuspFunction h (∏ i ∈ Finset.cons a s ha, f i)
+        =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f a) * cuspFunction h (∏ i ∈ s, f i) := by
+          rw [Finset.prod_cons]
+          exact cuspFunction_mul_nhds (hf a (Finset.mem_cons_self a s))
+            ((Finset.analyticAt_prod _ fun i hi ↦
+              hf i (Finset.mem_cons_of_mem hi)).congr h_prev.symm)
+      _ =ᶠ[𝓝 (0 : ℂ)] cuspFunction h (f a) * ∏ i ∈ s, cuspFunction h (f i) :=
+          Filter.EventuallyEq.rfl.mul h_prev
+      _ = ∏ i ∈ Finset.cons a s ha, cuspFunction h (f i) := by rw [Finset.prod_cons]
+
+/-- The cusp order is additive on finite products. The finiteness hypotheses exclude an
+identically vanishing factor, where the junk value `0` would break additivity. -/
+lemma orderAtCusp_prod {ι : Type*} {f : ι → ℍ → ℂ} (s : Finset ι)
+    (hf : ∀ i ∈ s, AnalyticAt ℂ (cuspFunction h (f i)) 0)
+    (hf' : ∀ i ∈ s, analyticOrderAt (cuspFunction h (f i)) 0 ≠ ⊤) :
+    orderAtCusp h (∏ i ∈ s, f i) = ∑ i ∈ s, orderAtCusp h (f i) := by
+  have h_ev := cuspFunction_prod_nhds s hf
+  rw [orderAtCusp_eq_analyticOrderAt ((Finset.analyticAt_prod _ hf).congr h_ev.symm),
+    analyticOrderAt_congr h_ev, TauCeti.analyticOrderAt_prod hf, ENat.toNat_sum hf',
+    Nat.cast_sum]
+  exact Finset.sum_congr rfl fun i hi ↦ (orderAtCusp_eq_analyticOrderAt (hf i hi)).symm
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
+++ b/TauCeti/NumberTheory/ModularForms/OrderAtCusp.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.ModularForms.QExpansion
+public import TauCeti.NumberTheory.ModularForms.QExpansion.Order
+
+/-!
+# The vanishing order at the cusp
+
+The vanishing order of a modular form at the cusp is the order of its `q`-expansion, as an
+integer with junk value `0` at the identically vanishing expansion — the convention of the
+interior dictionary `orderOfVanishingAt`. For a modular form it is computed by the analytic
+order of the cusp function at `0`, vanishes when the constant term is nonzero, and rescales
+linearly in the width — the cusp term of the valence formula.
+
+## Main declarations
+
+* `TauCeti.ModularForm.orderAtCusp`.
+* `TauCeti.ModularForm.orderAtCusp_eq_analyticOrderAt`: the analytic-order dictionary.
+* `TauCeti.ModularForm.orderAtCusp_nat_mul`: linear rescaling in the width.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development this file ports onto the current Mathlib pin.
+-/
+
+public noncomputable section
+
+open UpperHalfPlane Complex Function SlashInvariantForm Periodic
+
+open scoped ModularForm
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {Γ : Subgroup (GL (Fin 2) ℝ)} {k : ℤ} {F : Type*} [FunLike F ℍ ℂ] {f : F} {h : ℝ}
+
+/-- The vanishing order at the cusp: the order of the `q`-expansion at width `h`, as an
+integer, with junk value `0` when the expansion vanishes identically — the `untop₀`
+convention of `orderOfVanishingAt`. -/
+def orderAtCusp (h : ℝ) (f : ℍ → ℂ) : ℤ := ((qExpansion h f).order.toNat : ℤ)
+
+/-- `orderAtCusp` unfolded to the `q`-expansion order. The definition is sealed by the
+module system; this equation is the supported cross-module rewrite. -/
+lemma orderAtCusp_def (h : ℝ) (f : ℍ → ℂ) :
+    orderAtCusp h f = ((qExpansion h f).order.toNat : ℤ) := by
+  unfold orderAtCusp
+  rfl
+
+/-- The cusp order is nonnegative. -/
+lemma orderAtCusp_nonneg (h : ℝ) (f : ℍ → ℂ) : 0 ≤ orderAtCusp h f := by
+  rw [orderAtCusp_def]
+  exact Int.natCast_nonneg _
+
+/-- The cusp order of a modular form is the analytic order of its cusp function at `0`. -/
+lemma orderAtCusp_eq_analyticOrderAt [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) :
+    orderAtCusp h f = ((analyticOrderAt (cuspFunction h f) 0).toNat : ℤ) := by
+  rw [orderAtCusp_def, qExpansion_order_eq_analyticOrderAt_cuspFunction
+    (ModularFormClass.analyticAt_cuspFunction_zero f hh hΓ)]
+
+/-- A modular form whose constant term at the cusp is nonzero has cusp order zero. -/
+lemma orderAtCusp_eq_zero_of_cuspFunction_ne_zero [ModularFormClass F Γ k] (hh : 0 < h)
+    (hΓ : h ∈ Γ.strictPeriods) (h0 : cuspFunction h f 0 ≠ 0) : orderAtCusp h f = 0 := by
+  rw [orderAtCusp_eq_analyticOrderAt hh hΓ,
+    (ModularFormClass.analyticAt_cuspFunction_zero f hh
+      hΓ).analyticOrderAt_eq_zero.mpr h0]
+  rfl
+
+/-- The cusp order rescales linearly in the width. -/
+lemma orderAtCusp_nat_mul [ModularFormClass F Γ k] {m : ℕ} (hh : 0 < h) (hm : 0 < m)
+    (hΓ : h ∈ Γ.strictPeriods) :
+    orderAtCusp (m * h) f = m * orderAtCusp h f := by
+  have : Fact (IsCusp OnePoint.infty Γ) := ⟨Γ.isCusp_of_mem_strictPeriods hh hΓ⟩
+  rw [orderAtCusp_def, orderAtCusp_def,
+    qExpansion_nat_mul_order hh hm (SlashInvariantFormClass.periodic_comp_ofComplex f hΓ)
+      (ModularFormClass.bdd_at_infty f) (ModularFormClass.holo f),
+    ENat.toNat_mul]
+  simp [mul_comm]
+
+end ModularForm
+
+end TauCeti
+
+end


### PR DESCRIPTION
Defines the vanishing order of a modular form at the cusp — the cusp term of the valence formula — and its computation rules.

- `orderAtCusp h f : ℤ`: the `q`-expansion order at width `h`, junk value `0` at the identically vanishing expansion (the `untop₀` convention of the interior dictionary `orderOfVanishingAt`, #1974).
- `orderAtCusp_eq_analyticOrderAt`: for a modular form it is the analytic order of the cusp function at `0` (rides `qExpansion_order_eq_analyticOrderAt_cuspFunction`, #1968).
- `orderAtCusp_eq_zero_of_cuspFunction_ne_zero`: nonzero constant term forces order zero.
- `orderAtCusp_nat_mul`: linear rescaling in the width (rides `qExpansion_nat_mul_order`).

All lemmas at `ModularFormClass` interface generality over an arbitrary subgroup and strict period. Independent of the boundary-contour stack.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence-cusp-order","id":"mvco-1"}-->
