### PR TITLE
refactor(UniversalCover): name the fibre computation behind the monodromy comparison

### DIFF
--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -93,6 +93,23 @@ theorem SubgroupQuotient.fundamentalGroupEquiv_unop_smul
   exact
     (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
 
+/-- **A universal-cover point sitting over the distinguished quotient point sits over `x₀`.**
+The descended endpoint projection factors the universal-cover projection through the quotient
+map, and it sends the distinguished quotient point to `x₀`; chaining the two computes `proj` on
+this fibre. -/
+private theorem proj_eq_of_mem_fiber_subgroupQuotientMap
+    (H : Subgroup (FundamentalGroup X x₀))
+    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
+    proj (e : UniversalCover x₀) = x₀ := by
+  have hbase : subgroupQuotientMap x₀ H e = SubgroupQuotient.basepoint x₀ H := by
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
+  calc
+    proj (e : UniversalCover x₀) =
+        subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
+      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
+    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hbase]
+    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
+
 variable [LocallyPathConnectedSpace X] [PathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X]
 
@@ -116,18 +133,8 @@ private theorem monodromy_mapOfEq_subgroupQuotientProj
     dsimp only [e]
     rw [SubgroupQuotient.basepointLift_coe]
   let e' := hq.isCoveringMap.monodromy g e
-  have he'_basepoint : subgroupQuotientMap x₀ H e' =
-      SubgroupQuotient.basepoint x₀ H := by
-    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e'.2
-  have he' : proj (e' : UniversalCover x₀) = x₀ := by
-    calc
-      proj (e' : UniversalCover x₀) =
-          subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e') := by
-            exact congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e' |>.symm
-      _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by
-            rw [he'_basepoint]
-      _ = x₀ := subgroupQuotientProj_basepoint x₀ H
-  let e'' : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} := ⟨e', he'⟩
+  let e'' : (proj : UniversalCover x₀ → X) ⁻¹' {x₀} :=
+    ⟨e', proj_eq_of_mem_fiber_subgroupQuotientMap x₀ H e'⟩
   -- Lift `g` through the quotient map, then map that same lifted path through the descended
   -- endpoint map; the commuting triangle identifies it as the universal-cover lift.
   have hmon : (isCoveringMap x₀).monodromy

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -93,23 +93,6 @@ theorem SubgroupQuotient.fundamentalGroupEquiv_unop_smul
   exact
     (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
 
-/-- **A universal-cover point sitting over the distinguished quotient point sits over `x₀`.**
-The descended endpoint projection factors the universal-cover projection through the quotient
-map, and it sends the distinguished quotient point to `x₀`; chaining the two computes `proj` on
-this fibre. -/
-private theorem proj_eq_of_mem_fiber_subgroupQuotientMap
-    (H : Subgroup (FundamentalGroup X x₀))
-    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
-    proj (e : UniversalCover x₀) = x₀ := by
-  have hbase : subgroupQuotientMap x₀ H e = SubgroupQuotient.basepoint x₀ H := by
-    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
-  calc
-    proj (e : UniversalCover x₀) =
-        subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
-      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
-    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hbase]
-    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
-
 variable [LocallyPathConnectedSpace X] [PathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X]
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean
@@ -93,6 +93,21 @@ theorem SubgroupQuotient.fundamentalGroupEquiv_unop_smul
   exact
     (isQuotientCoveringMap_subgroupQuotientMap x₀ H).unop_fundamentalGroupToMulOpposite_smul
 
+/-- **The fibre of `subgroupQuotientMap` over the distinguished quotient point lies inside the
+fibre of `proj` over `x₀`.** -/
+private theorem proj_eq_of_mem_fiber_subgroupQuotientMap
+    (H : Subgroup (FundamentalGroup X x₀))
+    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
+    proj (e : UniversalCover x₀) = x₀ := by
+  have hbase : subgroupQuotientMap x₀ H e = SubgroupQuotient.basepoint x₀ H := by
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
+  calc
+    proj (e : UniversalCover x₀) =
+        subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
+      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
+    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hbase]
+    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
+
 variable [LocallyPathConnectedSpace X] [PathConnectedSpace X]
   [SemilocallySimplyConnectedSpace X]
 

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -147,21 +147,6 @@ theorem subgroupQuotientProj_basepoint (H : Subgroup (FundamentalGroup X x₀)) 
     subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) = x₀ :=
   subgroupQuotientProj_mk x₀ H _
 
-/-- **A universal-cover point sitting over the distinguished quotient point sits over `x₀`.**
-The two preceding lemmas combine: the descended endpoint projection factors `proj` through the
-quotient map, and it sends the distinguished quotient point to `x₀`. -/
-theorem proj_eq_of_mem_fiber_subgroupQuotientMap (H : Subgroup (FundamentalGroup X x₀))
-    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
-    proj (e : UniversalCover x₀) = x₀ := by
-  have hbase : subgroupQuotientMap x₀ H e = SubgroupQuotient.basepoint x₀ H := by
-    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
-  calc
-    proj (e : UniversalCover x₀) =
-        subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
-      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
-    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hbase]
-    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
-
 /-- The descended endpoint projection is continuous. -/
 theorem continuous_subgroupQuotientProj (H : Subgroup (FundamentalGroup X x₀)) :
     Continuous (subgroupQuotientProj x₀ H) := by

--- a/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
+++ b/TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean
@@ -147,6 +147,21 @@ theorem subgroupQuotientProj_basepoint (H : Subgroup (FundamentalGroup X x₀)) 
     subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) = x₀ :=
   subgroupQuotientProj_mk x₀ H _
 
+/-- **A universal-cover point sitting over the distinguished quotient point sits over `x₀`.**
+The two preceding lemmas combine: the descended endpoint projection factors `proj` through the
+quotient map, and it sends the distinguished quotient point to `x₀`. -/
+theorem proj_eq_of_mem_fiber_subgroupQuotientMap (H : Subgroup (FundamentalGroup X x₀))
+    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
+    proj (e : UniversalCover x₀) = x₀ := by
+  have hbase : subgroupQuotientMap x₀ H e = SubgroupQuotient.basepoint x₀ H := by
+    simpa only [Set.mem_preimage, Set.mem_singleton_iff] using e.2
+  calc
+    proj (e : UniversalCover x₀) =
+        subgroupQuotientProj x₀ H (subgroupQuotientMap x₀ H e) :=
+      congrFun (subgroupQuotientProj_comp_subgroupQuotientMap x₀ H) e |>.symm
+    _ = subgroupQuotientProj x₀ H (SubgroupQuotient.basepoint x₀ H) := by rw [hbase]
+    _ = x₀ := subgroupQuotientProj_basepoint x₀ H
+
 /-- The descended endpoint projection is continuous. -/
 theorem continuous_subgroupQuotientProj (H : Subgroup (FundamentalGroup X x₀)) :
     Continuous (subgroupQuotientProj x₀ H) := by


### PR DESCRIPTION
`monodromy_mapOfEq_subgroupQuotientProj` opened with twelve lines establishing that the monodromy endpoint of the quotient covering lies over `x₀`, before reaching the dependent-cast argument the theorem exists for.

That opening never mentions `g` or monodromy. It holds of **any** point of the fibre of `subgroupQuotientMap` over the distinguished quotient point, because the descended endpoint projection factors `proj` through the quotient map (`subgroupQuotientProj_comp_subgroupQuotientMap`) and sends that point to `x₀` (`subgroupQuotientProj_basepoint`). Named as such:

```lean
private theorem proj_eq_of_mem_fiber_subgroupQuotientMap
    (H : Subgroup (FundamentalGroup X x₀))
    (e : (subgroupQuotientMap x₀ H) ⁻¹' {SubgroupQuotient.basepoint x₀ H}) :
    proj (e : UniversalCover x₀) = x₀
```

and applied at the point where the fibre element is built.

| declaration | body before | body after |
|---|---|---|
| `monodromy_mapOfEq_subgroupQuotientProj` | 59 | 49 |
| longest proof in the file | 59 | 49 |

That clears the fifty-line limit. What remains is the reconciliation of the dependent endpoint casts — the four `convert … using 2` side goals — which does not decompose further into anything with independent mathematical content; the remaining candidate cuts would all be one-line wrappers around `congrFun`.

The helper is stated **above** the `LocallyPathConnectedSpace` / `PathConnectedSpace` / `SemilocallySimplyConnectedSpace` variable block, since it needs none of the three.

No public declaration changes — the addition is `private`, and `monodromy_mapOfEq_subgroupQuotientProj` keeps its signature, so its two call sites are untouched.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh` — all green.

---

## Contesting the `placement` finding: it and `api-design` cannot both be satisfied

`placement` and `api-design` have each requested the negation of the other, on the same declaration. Quoting both verbatim:

> **`placement` — request_changes** (round 1, head `1a680a22`)
> `TauCeti/AlgebraicTopology/UniversalCover/Classification/RecoveredSubgroup.lean:100` — `proj_eq_of_mem_fiber_subgroupQuotientMap` is placed in `RecoveredSubgroup`, but its statement and proof only concern `subgroupQuotientMap`, `SubgroupQuotient.basepoint`, and `subgroupQuotientProj`; it is not specific to subgroup recovery or monodromy. _Fix:_ **Move this lemma to `TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean`** near `subgroupQuotientProj_comp_subgroupQuotientMap` / `subgroupQuotientProj_basepoint`, then import/use it from `RecoveredSubgroup`.

I complied at head `66e4cbd8`, which moved the lemma to `SubgroupQuotient.lean`. That drew:

> **`api-design` — request_changes** (round 2, head `66e4cbd8`)
> `TauCeti/AlgebraicTopology/UniversalCover/Classification/SubgroupQuotient.lean:153` — `proj_eq_of_mem_fiber_subgroupQuotientMap` is a public theorem for an implementation-only fibre computation used only inside the private proof in `RecoveredSubgroup.lean`. _Fix:_ **Keep this helper private by moving it to `RecoveredSubgroup.lean`** near its only use, or inline it; **do not add it to `SubgroupQuotient.lean`'s public API.**

**Why both cannot hold.** `private` in Lean is file-scoped. `RecoveredSubgroup.lean` is the consumer, so a lemma living in `SubgroupQuotient.lean` and visible to it is necessarily **public**. So:

- private, in `RecoveredSubgroup.lean` → `placement` blocks (round 1);
- public, in `SubgroupQuotient.lean` → `api-design` blocks (round 2);

and there is no third state. The only remaining option `api-design` names is "or inline it", which restores the 59-line body and makes this PR a no-op.

**I have complied with `api-design`** (head `0c6de4d7` reverts the move; the diff is again one file, and the public API is unchanged) **and contest `placement`**, for three reasons:

1. **`api-design` is right on the merits.** The lemma has exactly one use, inside a `private` proof. Publishing it commits the project to an API surface nothing consumes — the cost `api-design` exists to prevent — whereas the cost `placement` names is that a private eight-line helper sits one file away from its thematic home, which no downstream file can observe.
2. **`placement` has repeatedly approved this exact shape.** Private decompose helpers placed directly above their single consumer were approved by `placement` on #1948, #1961 and #1996 — the last of them this same day, on the same reviewer model, with the identical justification recorded in its description.
3. **The stated `placement` reason does not distinguish this case.** "Its statement only concerns `subgroupQuotientMap` / `SubgroupQuotient.basepoint` / `subgroupQuotientProj`" is true of essentially every extracted proof step: a decomposition names the sub-fact a proof already used, so the sub-fact is *always* more elementary than its parent. If that alone forced relocation-and-publication, no proof could be decomposed without growing the public API — which is the outcome `api-design` blocks.

If `placement` is nonetheless sustained, the consistent resolution is to publish the lemma in `SubgroupQuotient.lean` and have `api-design` waived for it; I cannot satisfy both, and I would rather not oscillate the diff between two rejected states.

Roadmap: UniversalCovers