### PR TITLE
feat: the parity lemma for nebentypus character spaces

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup.lean
@@ -6,17 +6,19 @@ Authors: Chris Birkbeck
 module
 
 public import Mathlib.Data.ZMod.Basic
+public import Mathlib.LinearAlgebra.Matrix.GeneralLinearGroup.Defs
 public import Mathlib.LinearAlgebra.Matrix.SpecialLinearGroup
 import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 
 /-!
-# Surjectivity of the reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)`
+# Special linear groups: surjectivity of reduction, and the image of `-I`
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
-`SL₂`; Shimura §1.6, Serre Ch. VII).
+`SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
+`-I` to `-I`.
 
-Ported from the AINTLIB `LeanModularForms` project
+The surjectivity is ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/SL2Surjection.lean`, Chris Birkbeck). Prerequisite for the
 diamond operators of the ModularForms roadmap (Layer 0), where it realizes every unit of
 `ZMod N` as the lower-right entry of a matrix in `Γ₀(N)`.
@@ -24,6 +26,7 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 ## Main results
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
+* `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
 
 ## References
 
@@ -38,6 +41,14 @@ open Matrix
 variable {d : ℕ}
 
 namespace Matrix.SpecialLinearGroup
+
+/-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
+@[simp]
+lemma mapGL_neg_one {n R S : Type*} [Fintype n] [DecidableEq n] [CommRing R] [CommRing S]
+    [Algebra R S] [Fact (Even (Fintype.card n))] :
+    mapGL S (-1 : SpecialLinearGroup n R) = -1 := by
+  ext i j
+  rcases eq_or_ne i j with h | h <;> simp [mapGL, h]
 
 variable {R : Type*} [CommRing R]
 

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -11,9 +11,10 @@ public import Mathlib.NumberTheory.ModularForms.Basic
 # Modular-forms basics: extensions of Mathlib's API
 
 Small generic lemmas extending `Mathlib/NumberTheory/ModularForms/Basic.lean` and its slash
-actions: the conjugation `σ` is trivial on `SL(2, ℤ)`-matrices, and the `CuspForm`
+actions: the conjugation `σ` is trivial on `SL(2, ℤ)`-matrices, the `CuspForm`
 translation equations Mathlib does not yet provide (`CuspForm.mcast_apply` and the
-`GL(2, ℝ)`-level `CuspForm.coe_translate_gl`).
+`GL(2, ℝ)`-level `CuspForm.coe_translate_gl`), and the weight-`k` slash action of `-I`
+(`ModularForm.slash_neg_one`).
 
 Split out of the diamond-operator development ported from the AINTLIB `LeanModularForms`
 project (<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>).
@@ -43,4 +44,29 @@ lemma _root_.CuspForm.mcast_apply {a b : ℤ} {Γ Γ' : Subgroup (GL (Fin 2) ℝ
 lemma _root_.CuspForm.coe_translate_gl {F : Type*} [FunLike F UpperHalfPlane ℂ] {k : ℤ}
     {Γ : Subgroup (GL (Fin 2) ℝ)} [CuspFormClass F Γ k] (f : F) (g : GL (Fin 2) ℝ) :
     ⇑(CuspForm.translate f g) = ⇑f ∣[k] g := (rfl)
+
+/-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
+@[simp]
+lemma _root_.Matrix.SpecialLinearGroup.mapGL_neg_one {n R S : Type*} [Fintype n] [DecidableEq n]
+    [CommRing R] [CommRing S] [Algebra R S] [Fact (Even (Fintype.card n))] :
+    mapGL S (-1 : SpecialLinearGroup n R) = -1 := by
+  ext i j
+  rcases eq_or_ne i j with h | h <;> simp [mapGL, h]
+
+/-- The weight-`k` slash action of `-I` is multiplication by `(-1) ^ k`: `-I` acts trivially
+on `ℍ` and has determinant `1`, so the only surviving factor is its automorphy factor
+`denom (-I) z ^ (-k) = (-1) ^ (-k) = (-1) ^ k`.
+
+This is the source of every parity constraint on weights and nebentypus characters. -/
+theorem _root_.ModularForm.slash_neg_one (k : ℤ) (f : ℍ → ℂ) :
+    f ∣[k] (-1 : GL (Fin 2) ℝ) = (-1 : ℂ) ^ k • f := by
+  have hzpow : (-1 : ℂ) ^ (-k) = (-1 : ℂ) ^ k := by
+    rw [zpow_neg, ← inv_zpow]
+    norm_num
+  have hdet : (-1 : GL (Fin 2) ℝ).det = 1 := by
+    ext
+    simp [Matrix.det_neg]
+  funext z
+  rw [ModularForm.slash_apply]
+  simp [UpperHalfPlane.σ, hzpow, hdet, mul_comm]
 

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -14,7 +14,8 @@ Small generic lemmas extending `Mathlib/NumberTheory/ModularForms/Basic.lean` an
 actions: the conjugation `σ` is trivial on `SL(2, ℤ)`-matrices, the `CuspForm`
 translation equations Mathlib does not yet provide (`CuspForm.mcast_apply` and the
 `GL(2, ℝ)`-level `CuspForm.coe_translate_gl`), and the weight-`k` slash action of `-I`
-(`ModularForm.slash_neg_one`).
+(`ModularForm.slash_neg_one`), the source of every parity constraint on weights and
+nebentypus characters.
 
 Split out of the diamond-operator development ported from the AINTLIB `LeanModularForms`
 project (<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>).
@@ -45,19 +46,12 @@ lemma _root_.CuspForm.coe_translate_gl {F : Type*} [FunLike F UpperHalfPlane ℂ
     {Γ : Subgroup (GL (Fin 2) ℝ)} [CuspFormClass F Γ k] (f : F) (g : GL (Fin 2) ℝ) :
     ⇑(CuspForm.translate f g) = ⇑f ∣[k] g := (rfl)
 
-/-- `-I` maps to `-I` under `SL(n, R) → GL(n, S)`. -/
-@[simp]
-lemma _root_.Matrix.SpecialLinearGroup.mapGL_neg_one {n R S : Type*} [Fintype n] [DecidableEq n]
-    [CommRing R] [CommRing S] [Algebra R S] [Fact (Even (Fintype.card n))] :
-    mapGL S (-1 : SpecialLinearGroup n R) = -1 := by
-  ext i j
-  rcases eq_or_ne i j with h | h <;> simp [mapGL, h]
-
 /-- The weight-`k` slash action of `-I` is multiplication by `(-1) ^ k`: `-I` acts trivially
 on `ℍ` and has determinant `1`, so the only surviving factor is its automorphy factor
 `denom (-I) z ^ (-k) = (-1) ^ (-k) = (-1) ^ k`.
 
 This is the source of every parity constraint on weights and nebentypus characters. -/
+@[simp]
 theorem _root_.ModularForm.slash_neg_one (k : ℤ) (f : ℍ → ℂ) :
     f ∣[k] (-1 : GL (Fin 2) ℝ) = (-1 : ℂ) ^ k • f := by
   have hzpow : (-1 : ℂ) ^ (-k) = (-1 : ℂ) ^ k := by

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -113,15 +113,15 @@ theorem neg_one_mem_Gamma0 : (-1 : SL(2, ℤ)) ∈ Gamma0 N := by
 
 /-- `-I ∈ Γ₀(N)`, packaged as an element of the subgroup. It is the representative through
 which the diamond operator at `-1` is computed. -/
-@[expose] def Gamma0.negOne (N : ℕ) : ↥(Gamma0 N) := ⟨-1, neg_one_mem_Gamma0⟩
+def Gamma0.negOne (N : ℕ) : ↥(Gamma0 N) := ⟨-1, neg_one_mem_Gamma0⟩
 
 @[simp]
-lemma Gamma0.coe_negOne (N : ℕ) : (Gamma0.negOne N : SL(2, ℤ)) = -1 := rfl
+lemma Gamma0.coe_negOne (N : ℕ) : (Gamma0.negOne N : SL(2, ℤ)) = -1 := (rfl)
 
 /-- The lower-right entry of `-I ∈ Γ₀(N)` is `-1`. -/
 @[simp]
 theorem Gamma0Map_negOne : Gamma0Map N (Gamma0.negOne N) = -1 := by
-  simp [Gamma0Map, Gamma0.negOne]
+  simp [Gamma0Map, Gamma0.coe_negOne]
 
 /-- The unit-valued lower-right entry of `-I ∈ Γ₀(N)` is the unit `-1`. -/
 @[simp]
@@ -133,8 +133,8 @@ theorem Gamma0Map_toHomUnits_negOne :
 range in which `Γ₁(N)` contains `-I`, so that all odd-weight forms for it vanish. -/
 theorem neg_one_mem_Gamma1_iff : (-1 : SL(2, ℤ)) ∈ Gamma1 N ↔ N ∣ 2 := by
   have h : (-1 : ZMod N) = 1 ↔ N ∣ 2 := by
-    rw [neg_eq_iff_add_eq_zero, show (1 : ZMod N) + 1 = ((2 : ℕ) : ZMod N) by push_cast; ring,
-      ZMod.natCast_eq_zero_iff]
+    rw [neg_eq_iff_add_eq_zero, ← ZMod.natCast_eq_zero_iff 2 N]
+    norm_num
   simp [Gamma1_mem, h]
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -14,7 +14,9 @@ public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup
 Foundational results about the pair `Γ₁(N) ≤ Γ₀(N)` beyond Mathlib's
 `Mathlib.NumberTheory.ModularForms.CongruenceSubgroups`: `Γ₀(N)` normalizes `Γ₁(N)` (also
 after mapping to `GL₂(ℝ)`), the ratio of two `Γ₀(N)`-elements with equal lower-right entry
-lies in `Γ₁(N)`, and the lower-right-entry map `Γ₀(N) →* (ZMod N)ˣ` is surjective.
+lies in `Γ₁(N)`, the lower-right-entry map `Γ₀(N) →* (ZMod N)ˣ` is surjective, and the
+location of `-I`: it always lies in `Γ₀(N)`, with lower-right entry the unit `-1`, and it
+lies in `Γ₁(N)` exactly when `N ∣ 2`.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`, Chris Birkbeck,
@@ -29,6 +31,9 @@ infrastructure independent of the diamond operators.
   under conjugation by `Γ₀(N)` elements in `GL₂(ℝ)`.
 * `CongruenceSubgroup.Gamma0Map_toHomUnits_surjective`: every unit of `ZMod N` is the
   lower-right entry of a matrix in `Γ₀(N)` (via strong approximation for `SL₂`).
+* `CongruenceSubgroup.neg_one_mem_Gamma0` and
+  `CongruenceSubgroup.Gamma0Map_toHomUnits_negOne`: `-I ∈ Γ₀(N)`, with lower-right entry the
+  unit `-1`; `CongruenceSubgroup.neg_one_mem_Gamma1_iff`: `-I ∈ Γ₁(N) ↔ N ∣ 2`.
 -/
 
 public section
@@ -101,5 +106,35 @@ theorem Gamma0Map_toHomUnits_surjective [NeZero N] :
   have h10 : ((g 1 0 : ℤ) : ZMod N) = 0 := by rw [hentry]; simp
   have h11 : ((g 1 1 : ℤ) : ZMod N) = u := by rw [hentry]; simp
   exact ⟨⟨g, Gamma0_mem.mpr h10⟩, Units.ext (by simpa [Gamma0Map] using h11)⟩
+
+/-- `-I` lies in `Γ₀(N)`: its lower-left entry is `0`. -/
+theorem neg_one_mem_Gamma0 : (-1 : SL(2, ℤ)) ∈ Gamma0 N := by
+  simp
+
+/-- `-I ∈ Γ₀(N)`, packaged as an element of the subgroup. It is the representative through
+which the diamond operator at `-1` is computed. -/
+@[expose] def Gamma0.negOne (N : ℕ) : ↥(Gamma0 N) := ⟨-1, neg_one_mem_Gamma0⟩
+
+@[simp]
+lemma Gamma0.coe_negOne (N : ℕ) : (Gamma0.negOne N : SL(2, ℤ)) = -1 := rfl
+
+/-- The lower-right entry of `-I ∈ Γ₀(N)` is `-1`. -/
+@[simp]
+theorem Gamma0Map_negOne : Gamma0Map N (Gamma0.negOne N) = -1 := by
+  simp [Gamma0Map, Gamma0.negOne]
+
+/-- The unit-valued lower-right entry of `-I ∈ Γ₀(N)` is the unit `-1`. -/
+@[simp]
+theorem Gamma0Map_toHomUnits_negOne :
+    (Gamma0Map N).toHomUnits (Gamma0.negOne N) = -1 :=
+  Units.ext (by simp)
+
+/-- `-I` lies in `Γ₁(N)` exactly when `N ∣ 2`, i.e. for `N ∈ {1, 2}`. This is the degenerate
+range in which `Γ₁(N)` contains `-I`, so that all odd-weight forms for it vanish. -/
+theorem neg_one_mem_Gamma1_iff : (-1 : SL(2, ℤ)) ∈ Gamma1 N ↔ N ∣ 2 := by
+  have h : (-1 : ZMod N) = 1 ↔ N ∣ 2 := by
+    rw [neg_eq_iff_add_eq_zero, show (1 : ZMod N) + 1 = ((2 : ℕ) : ZMod N) by push_cast; ring,
+      ZMod.natCast_eq_zero_iff]
+  simp [Gamma1_mem, h]
 
 end CongruenceSubgroup

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -1,0 +1,173 @@
+/-
+Copyright (c) 2026 TauCeti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.DiamondOperators
+
+/-!
+# The parity lemma for nebentypus character spaces
+
+The weight and the nebentypus of a nonzero modular form determine each other's parity:
+`M_k(Γ₁(N), χ) ≠ 0` forces `χ(-1) = (-1)^k`. This is the emptiness criterion that odd
+weights and Eisenstein constructions consume, and the ModularForms roadmap pins it at
+Layer 0, alongside the diamond operators and character spaces of
+`TauCeti.NumberTheory.ModularForms.DiamondOperators` on which it is stated.
+
+The mechanism is `-I`. It lies in `Γ₀(N)` at every level, and its lower-right entry is the
+unit `-1`, so it represents the diamond operator `⟨-1⟩`. On the other hand `-I` acts
+trivially on `ℍ` and has determinant `1`, so slashing by it is multiplication by the scalar
+`(-1)^k` (`ModularForm.slash_neg_one`). Comparing the two readings gives
+`⟨-1⟩ = (-1)^k` as an operator (`diamondOp_neg_one`), and hence `χ(-1) = (-1)^k` on any
+nonzero element of the `χ`-eigenspace.
+
+The criterion is one-directional: matching parities do not make the space nonzero, and
+nothing here claims they do. At the degenerate levels `N ∣ 2`, where `-I` lies in `Γ₁(N)`
+itself (`CongruenceSubgroup.neg_one_mem_Gamma1_iff`), the same computation kills the whole of
+`M_k(Γ₁(N))` in odd weight (`ModularForm.eq_zero_of_odd_of_dvd_two`, deduced from Mathlib's
+`ModularForm.eq_zero_of_neg_one_mem`). That is consistent with the parity lemma rather than
+additional to it: there `-1 = 1` in `(ZMod N)ˣ`, so every `χ` has `χ(-1) = 1 ≠ -1 = (-1)^k`.
+
+## Main results
+
+* `diamondOp_neg_one`, `diamondOpCusp_neg_one`: the diamond operator `⟨-1⟩` is the scalar
+  `(-1)^k`.
+* `char_neg_one_of_mem_modFormCharSpace`, `char_neg_one_of_mem_cuspFormCharSpace`: the parity
+  lemma, `χ(-1) = (-1)^k` for a nonzero form in the `χ`-eigenspace.
+* `modFormCharSpace_eq_bot_of_char_neg_one_ne`, `cuspFormCharSpace_eq_bot_of_char_neg_one_ne`:
+  its contrapositive, the emptiness criterion; `char_neg_one_of_modFormCharSpace_ne_bot` and
+  `char_neg_one_of_cuspFormCharSpace_ne_bot` restate the lemma on the space itself.
+* `modFormCharSpace_one_eq_bot_of_odd`: there are no odd-weight forms with trivial nebentypus,
+  the classical `M_k(Γ₀(N)) = 0` for odd `k`.
+* `ModularForm.eq_zero_of_odd_of_dvd_two`: at the levels `N ∣ 2` all of `M_k(Γ₁(N))` vanishes
+  in odd weight.
+
+## References
+
+* Diamond–Shurman, *A first course in modular forms*, §5.1 (the remark following the
+  definition of `M_k(N, χ)`)
+* Miyake, *Modular forms*, §4.3
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup UpperHalfPlane CongruenceSubgroup
+
+open scoped MatrixGroups ModularForm
+
+namespace TauCeti
+
+variable {N : ℕ} [NeZero N] {k : ℤ} {χ : (ZMod N)ˣ →* ℂˣ}
+
+/-! ### The diamond operator at `-1` -/
+
+/-- The diamond operator `⟨-1⟩` acts on `M_k(Γ₁(N))` as the scalar `(-1)^k`: it is
+represented by `-I ∈ Γ₀(N)`, and slashing by `-I` is multiplication by `(-1)^k`. -/
+theorem coe_diamondOp_neg_one (k : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(diamondOp k (-1 : (ZMod N)ˣ) f) = (-1 : ℂ) ^ k • ⇑f := by
+  rw [coe_diamondOp k (-1 : (ZMod N)ˣ) (Gamma0.negOne N) Gamma0Map_toHomUnits_negOne f,
+    Gamma0.coe_negOne, mapGL_neg_one, ModularForm.slash_neg_one]
+
+/-- The diamond operator `⟨-1⟩` on `M_k(Γ₁(N))` is the scalar `(-1)^k`. -/
+theorem diamondOp_neg_one (k : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    diamondOp k (-1 : (ZMod N)ˣ) f = ((-1 : ℂ) ^ k) • f :=
+  ModularForm.ext fun z ↦ congr_fun (coe_diamondOp_neg_one k f) z
+
+/-- The diamond operator `⟨-1⟩` acts on `S_k(Γ₁(N))` as the scalar `(-1)^k`. -/
+theorem coe_diamondOpCusp_neg_one (k : ℤ) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    ⇑(diamondOpCusp k (-1 : (ZMod N)ˣ) f) = (-1 : ℂ) ^ k • ⇑f := by
+  rw [coe_diamondOpCusp k (-1 : (ZMod N)ˣ) (Gamma0.negOne N) Gamma0Map_toHomUnits_negOne f,
+    Gamma0.coe_negOne, mapGL_neg_one, ModularForm.slash_neg_one]
+
+/-- The diamond operator `⟨-1⟩` on `S_k(Γ₁(N))` is the scalar `(-1)^k`. -/
+theorem diamondOpCusp_neg_one (k : ℤ) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
+    diamondOpCusp k (-1 : (ZMod N)ˣ) f = ((-1 : ℂ) ^ k) • f :=
+  CuspForm.ext fun z ↦ congr_fun (coe_diamondOpCusp_neg_one k f) z
+
+/-! ### The parity lemma -/
+
+/-- **The parity lemma.** If `M_k(Γ₁(N), χ)` contains a nonzero form then `χ(-1) = (-1)^k`.
+
+Equivalently: the nebentypus of a nonzero modular form has the parity of its weight. The
+proof compares the two descriptions of `-I`, as the representative of the diamond operator
+`⟨-1⟩` (which acts by `χ(-1)` on the `χ`-eigenspace) and as a scalar matrix (which slashes
+by `(-1)^k`). -/
+theorem char_neg_one_of_mem_modFormCharSpace {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ modFormCharSpace k χ) (hf0 : f ≠ 0) : (χ (-1) : ℂ) = (-1 : ℂ) ^ k := by
+  have hne : (⇑f : ℍ → ℂ) ≠ 0 := fun h ↦ hf0 (DFunLike.coe_injective (by simpa using h))
+  have h : ((-1 : ℂ) ^ k) • (⇑f : ℍ → ℂ) = (χ (-1) : ℂ) • (⇑f : ℍ → ℂ) := by
+    rw [← coe_diamondOp_neg_one k f, diamondOp_apply_of_mem_modFormCharSpace k χ (-1) hf]
+    simp
+  exact ((smul_left_inj hne).mp h).symm
+
+/-- **The parity lemma for cusp forms.** If `S_k(Γ₁(N), χ)` contains a nonzero form then
+`χ(-1) = (-1)^k`. -/
+theorem char_neg_one_of_mem_cuspFormCharSpace {f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ cuspFormCharSpace k χ) (hf0 : f ≠ 0) : (χ (-1) : ℂ) = (-1 : ℂ) ^ k := by
+  have hne : (⇑f : ℍ → ℂ) ≠ 0 := fun h ↦ hf0 (DFunLike.coe_injective (by simpa using h))
+  have h : ((-1 : ℂ) ^ k) • (⇑f : ℍ → ℂ) = (χ (-1) : ℂ) • (⇑f : ℍ → ℂ) := by
+    rw [← coe_diamondOpCusp_neg_one k f,
+      diamondOpCusp_apply_of_mem_cuspFormCharSpace k χ (-1) hf]
+    simp
+  exact ((smul_left_inj hne).mp h).symm
+
+/-! ### The emptiness criterion -/
+
+/-- If the parities of `χ` and `k` disagree, `M_k(Γ₁(N), χ)` is zero. -/
+theorem modFormCharSpace_eq_bot_of_char_neg_one_ne (h : (χ (-1) : ℂ) ≠ (-1 : ℂ) ^ k) :
+    modFormCharSpace (N := N) k χ = ⊥ :=
+  Submodule.eq_bot_iff _ |>.mpr fun _f hf ↦
+    not_not.mp fun hf0 ↦ h (char_neg_one_of_mem_modFormCharSpace hf hf0)
+
+/-- If the parities of `χ` and `k` disagree, `S_k(Γ₁(N), χ)` is zero. -/
+theorem cuspFormCharSpace_eq_bot_of_char_neg_one_ne (h : (χ (-1) : ℂ) ≠ (-1 : ℂ) ^ k) :
+    cuspFormCharSpace (N := N) k χ = ⊥ :=
+  Submodule.eq_bot_iff _ |>.mpr fun _f hf ↦
+    not_not.mp fun hf0 ↦ h (char_neg_one_of_mem_cuspFormCharSpace hf hf0)
+
+/-- **The parity lemma**, in the form the roadmap states it: if `M_k(Γ₁(N), χ)` is nonzero
+then `χ(-1) = (-1)^k`. -/
+theorem char_neg_one_of_modFormCharSpace_ne_bot (h : modFormCharSpace (N := N) k χ ≠ ⊥) :
+    (χ (-1) : ℂ) = (-1 : ℂ) ^ k :=
+  not_not.mp fun hne ↦ h (modFormCharSpace_eq_bot_of_char_neg_one_ne hne)
+
+/-- **The parity lemma for cusp forms**, in the form the roadmap states it. -/
+theorem char_neg_one_of_cuspFormCharSpace_ne_bot (h : cuspFormCharSpace (N := N) k χ ≠ ⊥) :
+    (χ (-1) : ℂ) = (-1 : ℂ) ^ k :=
+  not_not.mp fun hne ↦ h (cuspFormCharSpace_eq_bot_of_char_neg_one_ne hne)
+
+/-- An even weight admits only even nebentypus: `χ(-1) = 1`. -/
+theorem char_neg_one_eq_one_of_even {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ modFormCharSpace k χ) (hf0 : f ≠ 0) (hk : Even k) : (χ (-1) : ℂ) = 1 := by
+  rw [char_neg_one_of_mem_modFormCharSpace hf hf0, hk.neg_one_zpow]
+
+/-- An odd weight admits only odd nebentypus: `χ(-1) = -1`. -/
+theorem char_neg_one_eq_neg_one_of_odd {f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k}
+    (hf : f ∈ modFormCharSpace k χ) (hf0 : f ≠ 0) (hk : Odd k) : (χ (-1) : ℂ) = -1 := by
+  rw [char_neg_one_of_mem_modFormCharSpace hf hf0, hk.neg_one_zpow]
+
+/-- There are no nonzero odd-weight forms with trivial nebentypus: `M_k(N, 1) = 0` for `k`
+odd. This is the classical statement that `M_k(Γ₀(N))` vanishes in odd weight, since
+`-I ∈ Γ₀(N)` acts on it by `(-1)^k = -1`. -/
+theorem modFormCharSpace_one_eq_bot_of_odd (hk : Odd k) :
+    modFormCharSpace (N := N) k 1 = ⊥ :=
+  modFormCharSpace_eq_bot_of_char_neg_one_ne (by norm_num [hk.neg_one_zpow])
+
+/-- There are no nonzero odd-weight cusp forms with trivial nebentypus. -/
+theorem cuspFormCharSpace_one_eq_bot_of_odd (hk : Odd k) :
+    cuspFormCharSpace (N := N) k 1 = ⊥ :=
+  cuspFormCharSpace_eq_bot_of_char_neg_one_ne (by norm_num [hk.neg_one_zpow])
+
+/-! ### The degenerate levels `N ∣ 2` -/
+
+omit [NeZero N] in
+/-- At the levels `N ∣ 2`, exactly those with `-I ∈ Γ₁(N)`, every odd-weight modular form for
+`Γ₁(N)` vanishes. -/
+theorem ModularForm.eq_zero_of_odd_of_dvd_two (hN : N ∣ 2) (hk : Odd k)
+    (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) : f = 0 :=
+  _root_.ModularForm.eq_zero_of_neg_one_mem
+    (Subgroup.mem_map.mpr ⟨-1, neg_one_mem_Gamma1_iff.mpr hN, mapGL_neg_one⟩) hk f
+
+end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/Parity.lean
+++ b/TauCeti/NumberTheory/ModularForms/Parity.lean
@@ -71,6 +71,7 @@ theorem coe_diamondOp_neg_one (k : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL 
     Gamma0.coe_negOne, mapGL_neg_one, ModularForm.slash_neg_one]
 
 /-- The diamond operator `⟨-1⟩` on `M_k(Γ₁(N))` is the scalar `(-1)^k`. -/
+@[simp]
 theorem diamondOp_neg_one (k : ℤ) (f : ModularForm ((Gamma1 N).map (mapGL ℝ)) k) :
     diamondOp k (-1 : (ZMod N)ˣ) f = ((-1 : ℂ) ^ k) • f :=
   ModularForm.ext fun z ↦ congr_fun (coe_diamondOp_neg_one k f) z
@@ -82,6 +83,7 @@ theorem coe_diamondOpCusp_neg_one (k : ℤ) (f : CuspForm ((Gamma1 N).map (mapGL
     Gamma0.coe_negOne, mapGL_neg_one, ModularForm.slash_neg_one]
 
 /-- The diamond operator `⟨-1⟩` on `S_k(Γ₁(N))` is the scalar `(-1)^k`. -/
+@[simp]
 theorem diamondOpCusp_neg_one (k : ℤ) (f : CuspForm ((Gamma1 N).map (mapGL ℝ)) k) :
     diamondOpCusp k (-1 : (ZMod N)ˣ) f = ((-1 : ℂ) ^ k) • f :=
   CuspForm.ext fun z ↦ congr_fun (coe_diamondOpCusp_neg_one k f) z


### PR DESCRIPTION
This PR records the parity lemma of the ModularForms roadmap: a nonzero form in the nebentypus character space `M_k(Γ₁(N), χ)` forces `χ(-1) = (-1)^k`, so the space is zero whenever the parities of the character and the weight disagree. This is the target named in `TauCetiRoadmap/ModularForms/README.md`, *Standing hypotheses and conventions*, second bullet ("Record at Layer 0 the **parity lemma**: `M_k(N, χ) ≠ 0 → χ(−1) = (−1)^k` (slash by `−I ∈ Γ₀(N)`) — the emptiness criterion that odd weights and Eisenstein constructions consume"). It builds directly on the Layer-0 diamond operators and character spaces merged in #1959 and is disjoint from the character decomposition in flight in #2004.

The mechanism is `-I`, read two ways. It lies in `Γ₀(N)` at every level with lower-right entry the unit `-1`, so it represents the diamond operator `⟨-1⟩`; and it acts trivially on `ℍ` with determinant `1`, so slashing by it is multiplication by the scalar `(-1)^k`. Comparing the readings gives `⟨-1⟩ = (-1)^k` as an operator on `M_k(Γ₁(N))` and on `S_k(Γ₁(N))`, and hence `χ(-1) = (-1)^k` on any nonzero element of the `χ`-eigenspace.

`TauCeti/NumberTheory/ModularForms/Parity.lean` (new) carries `diamondOp_neg_one` and `diamondOpCusp_neg_one`, the parity lemma in its element form (`char_neg_one_of_mem_modFormCharSpace`) and its space form (`char_neg_one_of_modFormCharSpace_ne_bot`), the emptiness criterion `modFormCharSpace_eq_bot_of_char_neg_one_ne`, the even/odd specializations, and the corollary `modFormCharSpace_one_eq_bot_of_odd` that trivial nebentypus supports no odd weight, the classical vanishing of `M_k(Γ₀(N))` in odd weight. Cusp-form analogues run alongside throughout. At the degenerate levels `N ∣ 2`, where `-I` lies in `Γ₁(N)` itself, `ModularForm.eq_zero_of_odd_of_dvd_two` kills all of `M_k(Γ₁(N))` in odd weight; that is deduced from Mathlib's `ModularForm.eq_zero_of_neg_one_mem` rather than reproved, and it is consistent with the parity lemma rather than additional to it, since `-1 = 1` in `(ZMod N)ˣ` there.

The two supporting facts go where they belong rather than into the new file. `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean` gains the location of `-I`: `neg_one_mem_Gamma0`, the packaged representative `Gamma0.negOne`, its lower-right entry `Gamma0Map_toHomUnits_negOne`, and `neg_one_mem_Gamma1_iff : (-1 : SL(2, ℤ)) ∈ Γ₁(N) ↔ N ∣ 2`. `TauCeti/NumberTheory/ModularForms/Basic.lean`, whose stated remit is generic extensions of Mathlib's slash actions, gains `ModularForm.slash_neg_one : f ∣[k] (-1) = (-1)^k • f`. The dimension- and ring-generic `Matrix.SpecialLinearGroup.mapGL_neg_one` goes to `TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup.lean` instead, reaching `Parity.lean` through `CongruenceSubgroups.lean`.

Nothing is vendored from AINTLIB here; the scalar cancellation is Mathlib's `smul_left_inj`, and the odd-weight vanishing is Mathlib's `ModularForm.eq_zero_of_neg_one_mem`.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"ModularForms","id":"parity-lemma-nebentypus"}-->

🤖 Prepared with Claude Code

