### PR TITLE
feat(ModularForms): the boundary contour winds zero outside the truncated domain

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -88,6 +88,97 @@ lemma sqrt_three_div_two_le_im_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : �
         rw [him, smul_eq_mul, mul_zero]
         nlinarith [hH, h32]
 
+
+/-- The contour's real part stays within the fundamental strip. -/
+lemma abs_re_fdBoundary_le_half (ht : t ∈ Icc (0 : ℝ) 5) :
+    |(fdBoundary H t).re| ≤ 1 / 2 := by
+  obtain ⟨ht0, ht5⟩ := ht
+  rw [abs_le]
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+    have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
+      simp [ρ]
+      norm_num
+    rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero]
+    have : (1 / 2 + H * Complex.I : ℂ).re = 1 / 2 := by simp
+    rw [this]
+    norm_num
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_re, one_mul]
+      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
+          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
+        constructor <;> nlinarith [Real.pi_pos]
+      constructor
+      · calc (-(1 / 2) : ℝ) = Real.cos (2 * Real.pi / 3) := by
+              rw [show (2 * Real.pi / 3 : ℝ) = Real.pi - Real.pi / 3 by ring,
+                Real.cos_pi_sub, Real.cos_pi_div_three]
+          _ ≤ Real.cos ((t + 1) * (Real.pi / 6)) :=
+              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
+                (by linarith [Real.pi_pos]) harc.2
+      · calc Real.cos ((t + 1) * (Real.pi / 6)) ≤ Real.cos (Real.pi / 3) :=
+              Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
+                (by linarith [Real.pi_pos]) harc.1
+          _ = 1 / 2 := Real.cos_pi_div_three
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
+          AffineMap.lineMap_apply_module']
+        have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).re = 0 := by
+          simp [ρ]
+        rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero]
+        have : (ρ : ℂ).re = -(1 / 2) := by
+          simp [ρ]
+          norm_num
+        rw [this]
+        norm_num
+      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
+          AffineMap.lineMap_apply_module']
+        have hchord : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).re = 1 := by
+          simp
+          norm_num
+        rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_one]
+        have : (-1 / 2 + H * Complex.I : ℂ).re = -(1 / 2) := by
+          simp
+          norm_num
+        rw [this]
+        constructor <;> nlinarith
+
+/-- The contour stays at or below its height parameter. -/
+lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+    (fdBoundary H t).im ≤ H := by
+  obtain ⟨ht0, ht5⟩ := ht
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+    have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
+      simp [ρ]
+    rw [Complex.add_im, Complex.smul_im, hchord, smul_eq_mul]
+    have : (1 / 2 + H * Complex.I : ℂ).im = H := by simp
+    rw [this]
+    nlinarith [mul_nonneg ht0 (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
+      exact (Real.sin_le_one _).trans hH
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
+          AffineMap.lineMap_apply_module']
+        have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
+          simp [ρ]
+        rw [Complex.add_im, Complex.smul_im, hchord, smul_eq_mul]
+        have : (ρ : ℂ).im = Real.sqrt 3 / 2 := by simp [ρ]
+        rw [this]
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
+          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2),
+          mul_nonneg (by linarith : (0 : ℝ) ≤ 4 - t)
+          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
+          AffineMap.lineMap_apply_module']
+        have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
+          simp
+        rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero]
+        simp
+
 /-- Winding transport through an unbounded convex region avoiding the contour: the
 region lies in one connected component of the complement, which reaches points far away
 where the winding number vanishes. -/
@@ -133,6 +224,57 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
         Complex.norm_real, Real.norm_of_nonneg (by positivity)]
     rw [hnorm]
     linarith [le_max_left R 0]
+
+/-- Every point strictly right of the fundamental strip winds zero. -/
+theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
+    (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_re_gt _)
+    ?_ (fun R ↦ ⟨((max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
+  · rintro z hz ⟨t, ht, rfl⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht)).2
+    rw [Set.mem_ofPred_eq] at hz
+    linarith
+  · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
+    nlinarith [le_max_right R 0]
+  · rw [Complex.norm_real, Real.norm_of_nonneg (by positivity)]
+    linarith [le_max_left R 0]
+
+/-- Every point strictly left of the fundamental strip winds zero. -/
+theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
+    (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_re_lt _)
+    ?_ (fun R ↦ ⟨(-(max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
+  · rintro z hz ⟨t, ht, rfl⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht)).1
+    rw [Set.mem_ofPred_eq] at hz
+    linarith
+  · rw [Set.mem_ofPred_eq]
+    have : ((-(max R 0 + 1 : ℝ) : ℝ) : ℂ).re = -(max R 0 + 1) := Complex.ofReal_re _
+    rw [show (-(max R 0 + 1 : ℝ) : ℂ) = ((-(max R 0 + 1) : ℝ) : ℂ) by push_cast; ring, this]
+    nlinarith [le_max_right R 0]
+  · rw [show (-(max R 0 + 1 : ℝ) : ℂ) = ((-(max R 0 + 1) : ℝ) : ℂ) by push_cast; ring,
+      Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
+    nlinarith [le_max_left R 0]
+
+/-- Every point strictly above the contour's height winds zero. -/
+theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
+    (hw : H < w.im) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_im_gt _)
+    ?_ (fun R ↦ ⟨((H + max R 0 + 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩) hw
+  · rintro z hz ⟨t, ht, rfl⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    have := im_fdBoundary_le hH ht
+    rw [Set.mem_ofPred_eq] at hz
+    linarith
+  · rw [Set.mem_ofPred_eq]
+    have : (((H + max R 0 + 1 : ℝ) : ℂ) * Complex.I).im = H + max R 0 + 1 := by simp
+    rw [this]
+    nlinarith [le_max_right R 0]
+  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+      Real.norm_of_nonneg (by nlinarith [le_max_right R 0])]
+    nlinarith [le_max_left R 0]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.NumberTheory.Modular
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
-public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 
 import Mathlib.Analysis.Complex.Convex
 import TauCeti.Analysis.Contour.Winding.UnboundedComponent
@@ -49,14 +49,17 @@ namespace ModularForm
 
 variable {H t : ℝ}
 
+/-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
+private lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
+  rw [div_le_one (by norm_num)]
+  nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+
 /-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
 height parameter clears the corner row. -/
 lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
   obtain ⟨ht0, ht5⟩ := ht
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rcases le_or_gt t 1 with h1 | h1
   · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
     have : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
@@ -158,9 +161,7 @@ lemma abs_re_fdBoundary_le_half (ht : t ∈ Icc (0 : ℝ) 5) :
 lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     (fdBoundary H t).im ≤ H := by
   obtain ⟨ht0, ht5⟩ := ht
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rcases le_or_gt t 1 with h1 | h1
   · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
     have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
@@ -192,6 +193,7 @@ lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
         simp
 
 /-- The right vertical has constant real part `1/2`. -/
+@[simp]
 lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
   rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
   have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
@@ -201,6 +203,7 @@ lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
   simp
 
 /-- The left vertical has constant real part `-1/2`. -/
+@[simp]
 lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
     (fdBoundary H t).re = -(1 / 2) := by
   rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
@@ -211,6 +214,7 @@ lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
   norm_num
 
 /-- The truncation ceiling has constant height `H`. -/
+@[simp]
 lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
   rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
   have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
@@ -219,6 +223,7 @@ lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
   simp
 
 /-- The arc lies on the unit circle. -/
+@[simp]
 lemma norm_fdBoundary_arc (h1 : 1 ≤ t) (h3 : t ≤ 3) : ‖fdBoundary H t‖ = 1 := by
   rw [eqOn_fdBoundary_arc H ⟨h1, h3⟩, norm_circleMap_zero, abs_one]
 
@@ -228,9 +233,7 @@ lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     1 ≤ ‖fdBoundary H t‖ := by
   obtain ⟨ht0, ht5⟩ := ht
   have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   have him := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ⟨ht0, ht5⟩
   have hnn := norm_nonneg (fdBoundary H t)
   rcases le_or_gt t 1 with h1 | h1
@@ -268,6 +271,7 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
   linarith
 
 /-- Every point strictly below the contour's height winds zero. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {w : ℂ}
     (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -283,6 +287,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
     nlinarith [le_max_left R 0]
 
 /-- Every point strictly right of the fundamental strip winds zero. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -299,6 +304,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     linarith [le_max_left R 0]
 
 /-- Every point strictly left of the fundamental strip winds zero. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -315,6 +321,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     nlinarith [le_max_left R 0]
 
 /-- Every point strictly above the contour's height winds zero. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
     (hw : H < w.im) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -337,6 +344,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
 contour's complement, and connects through the origin to the region below the corner
 height. Together with the four half-plane determinations this covers every point off the
 closed truncated fundamental domain. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
     (hw : ‖w‖ < 1) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   have hconn : IsPreconnected
@@ -345,9 +353,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
       (convex_ball 0 1).isPreconnected (convex_halfSpace_im_lt _).isPreconnected
     rw [Set.mem_ofPred_eq, Complex.zero_im]
     positivity
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
     (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, Or.inr ?_, ?_⟩)
     (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
@@ -368,9 +374,7 @@ winding number vanishes. -/
 theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
     IsNullHomologous (fdBoundary H) 0 5
       (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H) := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rw [isNullHomologous_iff]
   intro z hz
   rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq, not_and_or, not_and_or,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -253,11 +253,11 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
       Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
     nlinarith [le_max_left R 0]
 
--- `simpNF` rejects `simp` annotations here and on the left companion: `simp` normalizes
--- the hypothesis `1 / 2 < w.re` to `2⁻¹ < w.re`, so the stated forms never fire.
-/-- Every point strictly right of the fundamental strip winds zero. -/
+/-- Every point strictly right of the fundamental strip winds zero. The bound is stated
+in simp-normal form so the lemma can participate in simplification. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
-    (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+    (hw : 2⁻¹ < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_gt _).isPreconnected
     ?_ (fun R ↦ ⟨((max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
@@ -272,8 +272,9 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     linarith [le_max_left R 0]
 
 /-- Every point strictly left of the fundamental strip winds zero. -/
+@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
-    (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+    (hw : w.re < -2⁻¹) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_lt _).isPreconnected
     ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ), ?_, ?_⟩) hw
@@ -351,8 +352,10 @@ theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
       (him.trans_le (by positivity))
   · exact windingNumber_fdBoundary_eq_zero_of_lt_im hH hzH
   · rcases lt_abs.mp hre with h | h
-    · exact windingNumber_fdBoundary_eq_zero_of_half_lt_re h
-    · exact windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half (by linarith)
+    · exact windingNumber_fdBoundary_eq_zero_of_half_lt_re (by simpa using h)
+    · refine windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half ?_
+      rw [show (-2⁻¹ : ℝ) = -(1 / 2) by norm_num]
+      linarith
   · exact windingNumber_fdBoundary_eq_zero_of_norm_lt_one hH hnorm
 
 end ModularForm

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -179,11 +179,67 @@ lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
         rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero]
         simp
 
-/-- Winding transport through an unbounded convex region avoiding the contour: the
+/-- The right vertical has constant real part `1/2`. -/
+lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
+  rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
+    simp [ρ]
+    norm_num
+  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
+  simp
+
+/-- The left vertical has constant real part `-1/2`. -/
+lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
+    (fdBoundary H t).re = -(1 / 2) := by
+  rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).re = 0 := by
+    simp [ρ]
+  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
+  simp [ρ]
+  norm_num
+
+/-- The truncation ceiling has constant height `H`. -/
+lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
+  rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
+  have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
+    simp
+  rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero, zero_add]
+  simp
+
+/-- The arc lies on the unit circle. -/
+lemma norm_fdBoundary_arc (h1 : 1 ≤ t) (h3 : t ≤ 3) : ‖fdBoundary H t‖ = 1 := by
+  rw [eqOn_fdBoundary_arc H ⟨h1, h3⟩, norm_circleMap_zero, abs_one]
+
+/-- The boundary contour stays outside the open unit disc: the verticals and the ceiling
+clear it by height and offset, and the arc lies on the unit circle. -/
+lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+    1 ≤ ‖fdBoundary H t‖ := by
+  obtain ⟨ht0, ht5⟩ := ht
+  have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
+  have him := sqrt_three_div_two_le_im_fdBoundary hH ⟨ht0, ht5⟩
+  have hnn := norm_nonneg (fdBoundary H t)
+  rcases le_or_gt t 1 with h1 | h1
+  · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
+      rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_one h1]
+      nlinarith [Real.sqrt_nonneg 3]
+    nlinarith
+  · rcases le_or_gt t 3 with h3 | h3
+    · exact (norm_fdBoundary_arc h1.le h3).ge
+    · rcases le_or_gt t 4 with h4 | h4
+      · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
+          rw [Complex.sq_norm, Complex.normSq_apply, re_fdBoundary_of_le_four h3 h4]
+          nlinarith [Real.sqrt_nonneg 3]
+        nlinarith
+      · calc (1 : ℝ) ≤ H := hH
+          _ = (fdBoundary H t).im := (im_fdBoundary_of_gt_four h4).symm
+          _ ≤ |(fdBoundary H t).im| := le_abs_self _
+          _ ≤ ‖fdBoundary H t‖ := Complex.abs_im_le_norm _
+
+/-- Winding transport through an unbounded preconnected region avoiding the contour: the
 region lies in one connected component of the complement, which reaches points far away
 where the winding number vanishes. -/
-private lemma windingNumber_fdBoundary_eq_zero_of_mem_convex {S : Set ℂ}
-    (hconv : Convex ℝ S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
+private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
+    (hconn : IsPreconnected S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
     (hunb : ∀ R : ℝ, ∃ z ∈ S, R < ‖z‖) {w : ℂ} (hw : w ∈ S) :
     windingNumber (fdBoundary H) 0 5 w = 0 := by
   obtain ⟨p, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_finset_differentiableAt
@@ -203,14 +259,15 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_convex {S : Set ℂ}
     linarith
   have hw₀_zero : windingNumber (fdBoundary H) 0 5 w₀ = 0 := (hKsub hw₀_notK).2
   have h_sub : S ⊆ connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w₀ :=
-    hconv.isPreconnected.subset_connectedComponentIn hw₀S hdisj
+    hconn.subset_connectedComponentIn hw₀S hdisj
   rw [windingNumber_eq_of_mem_connectedComponentIn hclosed hP hcont hdiff hint (h_sub hw)]
   exact hw₀_zero
 
 /-- Every point strictly below the contour's height winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
     (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
-  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_im_lt _)
+  refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
+    (convex_halfSpace_im_lt _).isPreconnected
     ?_ (fun R ↦ ⟨-(max R 0 + 1) * Complex.I, ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -228,7 +285,8 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
 /-- Every point strictly right of the fundamental strip winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
-  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_re_gt _)
+  refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
+    (convex_halfSpace_re_gt _).isPreconnected
     ?_ (fun R ↦ ⟨((max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -243,7 +301,8 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
 /-- Every point strictly left of the fundamental strip winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
-  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_re_lt _)
+  refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
+    (convex_halfSpace_re_lt _).isPreconnected
     ?_ (fun R ↦ ⟨(-(max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -261,7 +320,8 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
 /-- Every point strictly above the contour's height winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
     (hw : H < w.im) : windingNumber (fdBoundary H) 0 5 w = 0 := by
-  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_im_gt _)
+  refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
+    (convex_halfSpace_im_gt _).isPreconnected
     ?_ (fun R ↦ ⟨((H + max R 0 + 1 : ℝ) : ℂ) * Complex.I, ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
@@ -275,6 +335,36 @@ theorem windingNumber_fdBoundary_eq_zero_of_lt_im (hH : 1 ≤ H) {w : ℂ}
   · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
       Real.norm_of_nonneg (by nlinarith [le_max_right R 0])]
     nlinarith [le_max_left R 0]
+
+/-- Every point of the open unit disc winds zero: the disc sits under the arc, inside the
+contour's complement, and connects through the origin to the region below the corner
+height. Together with the four half-plane determinations this covers every point off the
+closed truncated fundamental domain. -/
+theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
+    (hw : ‖w‖ < 1) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  have hconn : IsPreconnected
+      (Metric.ball (0 : ℂ) 1 ∪ {z : ℂ | z.im < Real.sqrt 3 / 2}) := by
+    refine IsPreconnected.union 0 (Metric.mem_ball_self one_pos) ?_
+      (convex_ball 0 1).isPreconnected (convex_halfSpace_im_lt _).isPreconnected
+    rw [Set.mem_ofPred_eq, Complex.zero_im]
+    positivity
+  refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
+    (fun R ↦ ⟨-(max R 0 + 1) * Complex.I, Or.inr ?_, ?_⟩)
+    (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
+  · rintro z (hz | hz) ⟨t, ht, rfl⟩ <;>
+      rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    · rw [Metric.mem_ball, dist_zero_right] at hz
+      exact absurd hz (not_lt.mpr (one_le_norm_fdBoundary hH ht))
+    · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
+  · have him : (-(max R 0 + 1) * Complex.I).im = -(max R 0 + 1) := by simp
+    rw [Set.mem_ofPred_eq, him]
+    nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
+  · rw [norm_mul, Complex.norm_I, mul_one, norm_neg]
+    have hnorm : ‖((max R 0 : ℝ) : ℂ) + 1‖ = max R 0 + 1 := by
+      rw [show ((max R 0 : ℝ) : ℂ) + 1 = ((max R 0 + 1 : ℝ) : ℂ) by push_cast; ring,
+        Complex.norm_real, Real.norm_of_nonneg (by positivity)]
+    rw [hnorm]
+    linarith [le_max_left R 0]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -354,7 +354,7 @@ theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
   · rcases lt_abs.mp hre with h | h
     · exact windingNumber_fdBoundary_eq_zero_of_half_lt_re (by simpa using h)
     · refine windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half ?_
-      rw [show (-2⁻¹ : ℝ) = -(1 / 2) by norm_num]
+      norm_num at h ⊢
       linarith
   · exact windingNumber_fdBoundary_eq_zero_of_norm_lt_one hH hnorm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -21,7 +21,8 @@ count.
 
 * `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`: the image height bound.
 * `TauCeti.ModularForm.windingNumber_fdBoundary_eq_zero_of_im_lt`: points below the
-  contour wind zero.
+  contour wind zero, with the analogous determinations on the other three sides
+  (`_of_half_lt_re`, `_of_re_lt_neg_half`, `_of_lt_im`).
 -/
 
 public noncomputable section
@@ -87,45 +88,51 @@ lemma sqrt_three_div_two_le_im_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : �
         rw [him, smul_eq_mul, mul_zero]
         nlinarith [hH, h32]
 
-/-- Every point strictly below the contour's height winds zero: it lies in the convex —
-hence connected — half-plane inside the complement, along which the winding number is
-constant, and vanishes at points far below. -/
-theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
-    (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+/-- Winding transport through an unbounded convex region avoiding the contour: the
+region lies in one connected component of the complement, which reaches points far away
+where the winding number vanishes. -/
+private lemma windingNumber_fdBoundary_eq_zero_of_mem_convex {S : Set ℂ}
+    (hconv : Convex ℝ S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
+    (hunb : ∀ R : ℝ, ∃ z ∈ S, R < ‖z‖) {w : ℂ} (hw : w ∈ S) :
+    windingNumber (fdBoundary H) 0 5 w = 0 := by
   obtain ⟨p, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_finset_differentiableAt
   have hclosed := (fdBoundary_closed H).symm
   have hP : ((p : Set ℝ)).Countable := p.finite_toSet.countable
   have hcont : ContinuousOn (fdBoundary H) (uIcc 0 5) :=
     (continuous_fdBoundary H).continuousOn
   have hint := (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv
-  have h_lower : {z : ℂ | z.im < Real.sqrt 3 / 2} ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ := by
-    rintro z hz ⟨t, ht, rfl⟩
-    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
-    exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
   have h_ev := windingNumber_eventually_zero_cocompact hclosed hP hcont hdiff hint
   rw [Filter.eventually_iff, Filter.mem_cocompact] at h_ev
   obtain ⟨K, hK, hKsub⟩ := h_ev
   obtain ⟨r, hr⟩ := hK.isBounded.subset_closedBall 0
-  set w₀ : ℂ := -((max r 0 + 1 : ℝ) : ℂ) * Complex.I with hw₀_def
-  have hw₀_norm : ‖w₀‖ = max r 0 + 1 := by
-    rw [hw₀_def, norm_mul, Complex.norm_I, mul_one, norm_neg, Complex.norm_real]
-    exact abs_of_nonneg (by positivity)
+  obtain ⟨w₀, hw₀S, hw₀far⟩ := hunb r
   have hw₀_notK : w₀ ∉ K := fun hmem ↦ by
     have := hr hmem
-    rw [Metric.mem_closedBall, dist_zero_right, hw₀_norm] at this
-    nlinarith [le_max_left r 0]
+    rw [Metric.mem_closedBall, dist_zero_right] at this
+    linarith
   have hw₀_zero : windingNumber (fdBoundary H) 0 5 w₀ = 0 := (hKsub hw₀_notK).2
-  have hw₀_S : w₀ ∈ {z : ℂ | z.im < Real.sqrt 3 / 2} := by
-    have : w₀.im = -(max r 0 + 1) := by
-      rw [hw₀_def]
-      simp
-    rw [Set.mem_ofPred_eq, this]
-    nlinarith [le_max_right r 0, Real.sqrt_nonneg 3]
-  have h_sub : {z : ℂ | z.im < Real.sqrt 3 / 2} ⊆
-      connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w₀ :=
-    (convex_halfSpace_im_lt _).isPreconnected.subset_connectedComponentIn hw₀_S h_lower
+  have h_sub : S ⊆ connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w₀ :=
+    hconv.isPreconnected.subset_connectedComponentIn hw₀S hdisj
   rw [windingNumber_eq_of_mem_connectedComponentIn hclosed hP hcont hdiff hint (h_sub hw)]
   exact hw₀_zero
+
+/-- Every point strictly below the contour's height winds zero. -/
+theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
+    (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  refine windingNumber_fdBoundary_eq_zero_of_mem_convex (convex_halfSpace_im_lt _)
+    ?_ (fun R ↦ ⟨-(max R 0 + 1) * Complex.I, ?_, ?_⟩) hw
+  · rintro z hz ⟨t, ht, rfl⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
+  · have : (-(max R 0 + 1) * Complex.I).im = -(max R 0 + 1) := by simp
+    rw [Set.mem_ofPred_eq, this]
+    nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
+  · rw [norm_mul, Complex.norm_I, mul_one, norm_neg]
+    have hnorm : ‖((max R 0 : ℝ) : ℂ) + 1‖ = max R 0 + 1 := by
+      rw [show ((max R 0 : ℝ) : ℂ) + 1 = ((max R 0 + 1 : ℝ) : ℂ) by push_cast; ring,
+        Complex.norm_real, Real.norm_of_nonneg (by positivity)]
+    rw [hnorm]
+    linarith [le_max_left R 0]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.Convex
+public import TauCeti.Analysis.Contour.Winding.Vanishing
+public import TauCeti.Analysis.Contour.Winding.LocallyConstant
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+/-!
+# Winding of the fundamental-domain boundary: the exterior
+
+The boundary contour lies in the half-plane `im ≥ √3/2`, so every point strictly below
+that height sits in the unbounded connected component of the complement, where the
+winding number vanishes: the exterior determination feeding the valence-formula residue
+count.
+
+## Main declarations
+
+* `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`: the image height bound.
+* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_zero_of_im_lt`: points below the
+  contour wind zero.
+-/
+
+public noncomputable section
+
+open Complex Set UpperHalfPlane TauCeti.Contour
+
+open scoped Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H t : ℝ}
+
+/-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
+height parameter clears the corner row. -/
+lemma sqrt_three_div_two_le_im_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+    Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
+  obtain ⟨ht0, ht5⟩ := ht
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  rcases le_or_gt t 1 with h1 | h1
+  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+    have : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
+      simp [ρ]
+    rw [Complex.add_im, Complex.smul_im, this]
+    have him : (1 / 2 + H * Complex.I : ℂ).im = H := by simp
+    rw [him, smul_eq_mul]
+    nlinarith [mul_nonneg (by linarith [ht0] : (0 : ℝ) ≤ t)
+      (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2), h1, h32, hH,
+      mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t)
+      (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+  · rcases le_or_gt t 3 with h3 | h3
+    · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
+      have harc : Real.pi / 3 ≤ (t + 1) * (Real.pi / 6) ∧
+          (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
+        constructor <;> nlinarith [Real.pi_pos, h1, h3]
+      calc Real.sqrt 3 / 2 = Real.sin (Real.pi / 3) := (Real.sin_pi_div_three).symm
+        _ ≤ Real.sin ((t + 1) * (Real.pi / 6)) := by
+            rcases le_or_gt ((t + 1) * (Real.pi / 6)) (Real.pi / 2) with hle | hgt
+            · exact Real.sin_le_sin_of_le_of_le_pi_div_two
+                (by linarith [Real.pi_pos]) hle harc.1
+            · nth_rewrite 2 [← Real.sin_pi_sub]
+              refine Real.sin_le_sin_of_le_of_le_pi_div_two
+                (by linarith [Real.pi_pos]) ?_ ?_ <;> linarith [Real.pi_pos, harc.2, hgt]
+    · rcases le_or_gt t 4 with h4 | h4
+      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
+          AffineMap.lineMap_apply_module']
+        have : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
+          simp [ρ]
+        rw [Complex.add_im, Complex.smul_im, this]
+        have hρ : (ρ : ℂ).im = Real.sqrt 3 / 2 := by simp [ρ]
+        rw [hρ, smul_eq_mul]
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
+          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
+      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
+          AffineMap.lineMap_apply_module']
+        have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
+          simp
+        rw [Complex.add_im, Complex.smul_im, h5]
+        have him : (-1 / 2 + H * Complex.I : ℂ).im = H := by simp
+        rw [him, smul_eq_mul, mul_zero]
+        nlinarith [hH, h32]
+
+/-- Every point strictly below the contour's height winds zero: it lies in the convex —
+hence connected — half-plane inside the complement, along which the winding number is
+constant, and vanishes at points far below. -/
+theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
+    (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
+  obtain ⟨p, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_finset_differentiableAt
+  have hclosed := (fdBoundary_closed H).symm
+  have hP : ((p : Set ℝ)).Countable := p.finite_toSet.countable
+  have hcont : ContinuousOn (fdBoundary H) (uIcc 0 5) :=
+    (continuous_fdBoundary H).continuousOn
+  have hint := (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv
+  have h_lower : {z : ℂ | z.im < Real.sqrt 3 / 2} ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ := by
+    rintro z hz ⟨t, ht, rfl⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
+  have h_ev := windingNumber_eventually_zero_cocompact hclosed hP hcont hdiff hint
+  rw [Filter.eventually_iff, Filter.mem_cocompact] at h_ev
+  obtain ⟨K, hK, hKsub⟩ := h_ev
+  obtain ⟨r, hr⟩ := hK.isBounded.subset_closedBall 0
+  set w₀ : ℂ := -((max r 0 + 1 : ℝ) : ℂ) * Complex.I with hw₀_def
+  have hw₀_norm : ‖w₀‖ = max r 0 + 1 := by
+    rw [hw₀_def, norm_mul, Complex.norm_I, mul_one, norm_neg, Complex.norm_real]
+    exact abs_of_nonneg (by positivity)
+  have hw₀_notK : w₀ ∉ K := fun hmem ↦ by
+    have := hr hmem
+    rw [Metric.mem_closedBall, dist_zero_right, hw₀_norm] at this
+    nlinarith [le_max_left r 0]
+  have hw₀_zero : windingNumber (fdBoundary H) 0 5 w₀ = 0 := (hKsub hw₀_notK).2
+  have hw₀_S : w₀ ∈ {z : ℂ | z.im < Real.sqrt 3 / 2} := by
+    have : w₀.im = -(max r 0 + 1) := by
+      rw [hw₀_def]
+      simp
+    rw [Set.mem_ofPred_eq, this]
+    nlinarith [le_max_right r 0, Real.sqrt_nonneg 3]
+  have h_sub : {z : ℂ | z.im < Real.sqrt 3 / 2} ⊆
+      connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w₀ :=
+    (convex_halfSpace_im_lt _).isPreconnected.subset_connectedComponentIn hw₀_S h_lower
+  rw [windingNumber_eq_of_mem_connectedComponentIn hclosed hP hcont hdiff hint (h_sub hw)]
+  exact hw₀_zero
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -4,25 +4,37 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Complex.Convex
-public import TauCeti.Analysis.Contour.Winding.Vanishing
-public import TauCeti.Analysis.Contour.Winding.LocallyConstant
+public import Mathlib.NumberTheory.Modular
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+import Mathlib.Analysis.Complex.Convex
+import TauCeti.Analysis.Contour.Winding.UnboundedComponent
 
 /-!
 # Winding of the fundamental-domain boundary: the exterior
 
-The boundary contour lies in the half-plane `im ≥ √3/2`, so every point strictly below
-that height sits in the unbounded connected component of the complement, where the
-winding number vanishes: the exterior determination feeding the valence-formula residue
-count.
+Every point off the closed truncated fundamental domain lies in one of five regions —
+below the corner height, right or left of the fundamental strip, above the ceiling, or in
+the open unit disc under the arc — and each region sits in the unbounded connected
+component of the contour's complement, where the winding number vanishes. Together the
+five determinations package as null-homology of the boundary contour in the truncated
+fundamental domain, the exterior input to the valence-formula residue count.
 
 ## Main declarations
 
 * `TauCeti.ModularForm.sqrt_three_div_two_le_im_fdBoundary`: the image height bound.
 * `TauCeti.ModularForm.windingNumber_fdBoundary_eq_zero_of_im_lt`: points below the
-  contour wind zero, with the analogous determinations on the other three sides
-  (`_of_half_lt_re`, `_of_re_lt_neg_half`, `_of_lt_im`).
+  corner height wind zero, with the analogous determinations on the other sides
+  (`_of_half_lt_re`, `_of_re_lt_neg_half`, `_of_lt_im`) and in the unit disc
+  (`_of_norm_lt_one`).
+* `TauCeti.ModularForm.isNullHomologous_fdBoundary`: the packaged null-homology.
+
+## References
+
+The truncated-contour strategy follows the fundamental-domain boundary development of
+AINTLIB's `LeanModularForms` (`ForMathlib/FDBoundary.lean`, `FDBoundaryH.lean`,
+`FDBoundaryPath.lean`); the winding transport is Tau Ceti's Hungerbühler–Wasem machinery.
 -/
 
 public noncomputable section
@@ -39,7 +51,7 @@ variable {H t : ℝ}
 
 /-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
 height parameter clears the corner row. -/
-lemma sqrt_three_div_two_le_im_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
+lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
   obtain ⟨ht0, ht5⟩ := ht
   have h32 : Real.sqrt 3 / 2 ≤ 1 := by
@@ -109,9 +121,9 @@ lemma abs_re_fdBoundary_le_half (ht : t ∈ Icc (0 : ℝ) 5) :
           (t + 1) * (Real.pi / 6) ≤ 2 * Real.pi / 3 := by
         constructor <;> nlinarith [Real.pi_pos]
       constructor
-      · calc (-(1 / 2) : ℝ) = Real.cos (2 * Real.pi / 3) := by
-              rw [show (2 * Real.pi / 3 : ℝ) = Real.pi - Real.pi / 3 by ring,
-                Real.cos_pi_sub, Real.cos_pi_div_three]
+      · have h23 : (2 * Real.pi / 3 : ℝ) = Real.pi - Real.pi / 3 := by ring
+        calc (-(1 / 2) : ℝ) = Real.cos (2 * Real.pi / 3) := by
+              rw [h23, Real.cos_pi_sub, Real.cos_pi_div_three]
           _ ≤ Real.cos ((t + 1) * (Real.pi / 6)) :=
               Real.cos_le_cos_of_nonneg_of_le_pi (by positivity)
                 (by linarith [Real.pi_pos]) harc.2
@@ -216,7 +228,10 @@ lemma one_le_norm_fdBoundary (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
     1 ≤ ‖fdBoundary H t‖ := by
   obtain ⟨ht0, ht5⟩ := ht
   have hsq : Real.sqrt 3 ^ 2 = 3 := Real.sq_sqrt (by norm_num)
-  have him := sqrt_three_div_two_le_im_fdBoundary hH ⟨ht0, ht5⟩
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sqrt_nonneg 3]
+  have him := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ⟨ht0, ht5⟩
   have hnn := norm_nonneg (fdBoundary H t)
   rcases le_or_gt t 1 with h1 | h1
   · have h1' : 1 ≤ ‖fdBoundary H t‖ ^ 2 := by
@@ -242,45 +257,30 @@ private lemma windingNumber_fdBoundary_eq_zero_of_mem_preconnected {S : Set ℂ}
     (hconn : IsPreconnected S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
     (hunb : ∀ R : ℝ, ∃ z ∈ S, R < ‖z‖) {w : ℂ} (hw : w ∈ S) :
     windingNumber (fdBoundary H) 0 5 w = 0 := by
-  obtain ⟨p, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_finset_differentiableAt
-  have hclosed := (fdBoundary_closed H).symm
-  have hP : ((p : Set ℝ)).Countable := p.finite_toSet.countable
-  have hcont : ContinuousOn (fdBoundary H) (uIcc 0 5) :=
-    (continuous_fdBoundary H).continuousOn
-  have hint := (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv
-  have h_ev := windingNumber_eventually_zero_cocompact hclosed hP hcont hdiff hint
-  rw [Filter.eventually_iff, Filter.mem_cocompact] at h_ev
-  obtain ⟨K, hK, hKsub⟩ := h_ev
-  obtain ⟨r, hr⟩ := hK.isBounded.subset_closedBall 0
-  obtain ⟨w₀, hw₀S, hw₀far⟩ := hunb r
-  have hw₀_notK : w₀ ∉ K := fun hmem ↦ by
-    have := hr hmem
-    rw [Metric.mem_closedBall, dist_zero_right] at this
-    linarith
-  have hw₀_zero : windingNumber (fdBoundary H) 0 5 w₀ = 0 := (hKsub hw₀_notK).2
-  have h_sub : S ⊆ connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w₀ :=
-    hconn.subset_connectedComponentIn hw₀S hdisj
-  rw [windingNumber_eq_of_mem_connectedComponentIn hclosed hP hcont hdiff hint (h_sub hw)]
-  exact hw₀_zero
+  refine (isPiecewiseC1On_fdBoundary H).windingNumber_eq_zero_of_unbounded_component
+    (fdBoundary_closed H).symm fun hbdd => ?_
+  obtain ⟨r, hr⟩ := hbdd.subset_closedBall 0
+  obtain ⟨z, hzS, hzr⟩ := hunb r
+  have hz_comp : z ∈ connectedComponentIn ((fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ) w :=
+    hconn.subset_connectedComponentIn hw hdisj hzS
+  have := hr hz_comp
+  rw [Metric.mem_closedBall, dist_zero_right] at this
+  linarith
 
 /-- Every point strictly below the contour's height winds zero. -/
-theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : 1 ≤ H) {w : ℂ}
+theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {w : ℂ}
     (hw : w.im < Real.sqrt 3 / 2) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_im_lt _).isPreconnected
-    ?_ (fun R ↦ ⟨-(max R 0 + 1) * Complex.I, ?_, ?_⟩) hw
+    ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
-  · have : (-(max R 0 + 1) * Complex.I).im = -(max R 0 + 1) := by simp
-    rw [Set.mem_ofPred_eq, this]
+  · rw [Set.mem_ofPred_eq, Complex.mul_I_im, Complex.ofReal_re]
     nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
-  · rw [norm_mul, Complex.norm_I, mul_one, norm_neg]
-    have hnorm : ‖((max R 0 : ℝ) : ℂ) + 1‖ = max R 0 + 1 := by
-      rw [show ((max R 0 : ℝ) : ℂ) + 1 = ((max R 0 + 1 : ℝ) : ℂ) by push_cast; ring,
-        Complex.norm_real, Real.norm_of_nonneg (by positivity)]
-    rw [hnorm]
-    linarith [le_max_left R 0]
+  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+      Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
+    nlinarith [le_max_left R 0]
 
 /-- Every point strictly right of the fundamental strip winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
@@ -303,18 +303,15 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
     (convex_halfSpace_re_lt _).isPreconnected
-    ?_ (fun R ↦ ⟨(-(max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
+    ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ), ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht)).1
     rw [Set.mem_ofPred_eq] at hz
     linarith
-  · rw [Set.mem_ofPred_eq]
-    have : ((-(max R 0 + 1 : ℝ) : ℝ) : ℂ).re = -(max R 0 + 1) := Complex.ofReal_re _
-    rw [show (-(max R 0 + 1 : ℝ) : ℂ) = ((-(max R 0 + 1) : ℝ) : ℂ) by push_cast; ring, this]
+  · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
     nlinarith [le_max_right R 0]
-  · rw [show (-(max R 0 + 1 : ℝ) : ℂ) = ((-(max R 0 + 1) : ℝ) : ℂ) by push_cast; ring,
-      Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
+  · rw [Complex.norm_real, Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
     nlinarith [le_max_left R 0]
 
 /-- Every point strictly above the contour's height winds zero. -/
@@ -348,23 +345,44 @@ theorem windingNumber_fdBoundary_eq_zero_of_norm_lt_one (hH : 1 ≤ H) {w : ℂ}
       (convex_ball 0 1).isPreconnected (convex_halfSpace_im_lt _).isPreconnected
     rw [Set.mem_ofPred_eq, Complex.zero_im]
     positivity
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected hconn ?_
-    (fun R ↦ ⟨-(max R 0 + 1) * Complex.I, Or.inr ?_, ?_⟩)
+    (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ) * Complex.I, Or.inr ?_, ?_⟩)
     (Or.inl (by rwa [Metric.mem_ball, dist_zero_right]))
   · rintro z (hz | hz) ⟨t, ht, rfl⟩ <;>
       rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     · rw [Metric.mem_ball, dist_zero_right] at hz
       exact absurd hz (not_lt.mpr (one_le_norm_fdBoundary hH ht))
-    · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary hH ht))
-  · have him : (-(max R 0 + 1) * Complex.I).im = -(max R 0 + 1) := by simp
-    rw [Set.mem_ofPred_eq, him]
+    · exact absurd hz (not_lt.mpr (sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht))
+  · rw [Set.mem_ofPred_eq, Complex.mul_I_im, Complex.ofReal_re]
     nlinarith [le_max_right R 0, Real.sqrt_nonneg 3]
-  · rw [norm_mul, Complex.norm_I, mul_one, norm_neg]
-    have hnorm : ‖((max R 0 : ℝ) : ℂ) + 1‖ = max R 0 + 1 := by
-      rw [show ((max R 0 : ℝ) : ℂ) + 1 = ((max R 0 + 1 : ℝ) : ℂ) by push_cast; ring,
-        Complex.norm_real, Real.norm_of_nonneg (by positivity)]
-    rw [hnorm]
-    linarith [le_max_left R 0]
+  · rw [norm_mul, Complex.norm_I, mul_one, Complex.norm_real,
+      Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
+    nlinarith [le_max_left R 0]
+
+/-- The boundary contour is null-homologous in the truncated fundamental domain: every
+point off the closed truncated domain lies in one of the five exterior regions, where the
+winding number vanishes. -/
+theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
+    IsNullHomologous (fdBoundary H) 0 5
+      (UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H) := by
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  rw [isNullHomologous_iff]
+  intro z hz
+  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq, not_and_or, not_and_or,
+    not_and_or, not_le, not_le, not_le, not_le] at hz
+  rcases hz with him | hzH | hre | hnorm
+  · exact windingNumber_fdBoundary_eq_zero_of_im_lt (h32.trans hH)
+      (him.trans_le (by positivity))
+  · exact windingNumber_fdBoundary_eq_zero_of_lt_im hH hzH
+  · rcases lt_abs.mp hre with h | h
+    · exact windingNumber_fdBoundary_eq_zero_of_half_lt_re h
+    · exact windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half (by linarith)
+  · exact windingNumber_fdBoundary_eq_zero_of_norm_lt_one hH hnorm
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -192,7 +192,11 @@ lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
         rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero]
         simp
 
-/-- The right vertical has constant real part `1/2`. -/
+/-- The right vertical has constant real part `1/2`.
+
+`simpNF` rejects a `simp` annotation here: the `@[simp]` branch selectors already rewrite
+`fdBoundary` applications to the segment functions, so this left-hand side is not in simp
+normal form; the same applies to the other coordinate rewrites below. -/
 lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
   rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
   have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
@@ -283,7 +287,10 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
       Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
     nlinarith [le_max_left R 0]
 
-/-- Every point strictly right of the fundamental strip winds zero. -/
+/-- Every point strictly right of the fundamental strip winds zero.
+
+`simpNF` rejects a `simp` annotation here and on the left companion: `simp` normalizes the
+hypothesis `1 / 2 < w.re` to `2⁻¹ < w.re`, so the stated form never fires as a simp lemma. -/
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -54,22 +54,80 @@ private lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
   rw [div_le_one (by norm_num)]
   nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 
+-- `simpNF` rejects `simp` annotations on the affine coordinate rewrites below: the
+-- `@[simp]` branch selectors already rewrite `fdBoundary` applications to the segment
+-- functions, so these left-hand sides are not in simp normal form.
+
+/-- The right vertical has constant real part `1/2`. -/
+lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
+  rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
+    simp [ρ]
+    norm_num
+  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
+  simp
+
+/-- The right vertical descends affinely from the ceiling to the corner row. -/
+lemma im_fdBoundary_of_le_one (h1 : t ≤ 1) :
+    (fdBoundary H t).im = H + t * (Real.sqrt 3 / 2 - H) := by
+  rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
+    simp [ρ]
+  have him : (1 / 2 + H * Complex.I : ℂ).im = H := by simp
+  rw [Complex.add_im, Complex.smul_im, hchord, him, smul_eq_mul, add_comm]
+
+/-- The left vertical has constant real part `-1/2`. -/
+lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
+    (fdBoundary H t).re = -(1 / 2) := by
+  rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).re = 0 := by
+    simp [ρ]
+  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
+  simp [ρ]
+  norm_num
+
+/-- The left vertical ascends affinely from the corner row to the ceiling. -/
+lemma im_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
+    (fdBoundary H t).im = Real.sqrt 3 / 2 + (t - 3) * (H - Real.sqrt 3 / 2) := by
+  rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
+    simp [ρ]
+  have hρ : (ρ : ℂ).im = Real.sqrt 3 / 2 := by simp [ρ]
+  rw [Complex.add_im, Complex.smul_im, hchord, hρ, smul_eq_mul, add_comm]
+
+/-- The truncation ceiling runs affinely from the left corner to the right. -/
+lemma re_fdBoundary_of_gt_four (h4 : 4 < t) :
+    (fdBoundary H t).re = -(1 / 2) + (t - 4) := by
+  rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
+  have hchord : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).re = 1 := by
+    simp
+    norm_num
+  have hre : (-1 / 2 + H * Complex.I : ℂ).re = -(1 / 2) := by
+    simp
+    norm_num
+  rw [Complex.add_re, Complex.smul_re, hchord, hre, smul_eq_mul, mul_one, add_comm]
+
+/-- The truncation ceiling has constant height `H`. -/
+lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
+  rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
+  have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
+    simp
+  rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero, zero_add]
+  simp
+
+/-- The arc lies on the unit circle. -/
+@[simp]
+lemma norm_fdBoundary_arc (h1 : 1 ≤ t) (h3 : t ≤ 3) : ‖fdBoundary H t‖ = 1 := by
+  rw [eqOn_fdBoundary_arc H ⟨h1, h3⟩, norm_circleMap_zero, abs_one]
+
 /-- Every point of the boundary contour has imaginary part at least `√3/2`, provided the
 height parameter clears the corner row. -/
-lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
-    Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
+lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H)
+    (ht : t ∈ Icc (0 : ℝ) 5) : Real.sqrt 3 / 2 ≤ (fdBoundary H t).im := by
   obtain ⟨ht0, ht5⟩ := ht
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rcases le_or_gt t 1 with h1 | h1
-  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
-    have : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
-      simp [ρ]
-    rw [Complex.add_im, Complex.smul_im, this]
-    have him : (1 / 2 + H * Complex.I : ℂ).im = H := by simp
-    rw [him, smul_eq_mul]
-    nlinarith [mul_nonneg (by linarith [ht0] : (0 : ℝ) ≤ t)
-      (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2), h1, h32, hH,
-      mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t)
+  · rw [im_fdBoundary_of_le_one h1]
+    nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 1 - t)
       (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
   · rcases le_or_gt t 3 with h3 | h3
     · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
@@ -85,38 +143,17 @@ lemma sqrt_three_div_two_le_im_fdBoundary (hH : Real.sqrt 3 / 2 ≤ H) (ht : t �
               refine Real.sin_le_sin_of_le_of_le_pi_div_two
                 (by linarith [Real.pi_pos]) ?_ ?_ <;> linarith [Real.pi_pos, harc.2, hgt]
     · rcases le_or_gt t 4 with h4 | h4
-      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
-          AffineMap.lineMap_apply_module']
-        have : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
-          simp [ρ]
-        rw [Complex.add_im, Complex.smul_im, this]
-        have hρ : (ρ : ℂ).im = Real.sqrt 3 / 2 := by simp [ρ]
-        rw [hρ, smul_eq_mul]
+      · rw [im_fdBoundary_of_le_four h3 h4]
         nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
           (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
-          AffineMap.lineMap_apply_module']
-        have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
-          simp
-        rw [Complex.add_im, Complex.smul_im, h5]
-        have him : (-1 / 2 + H * Complex.I : ℂ).im = H := by simp
-        rw [him, smul_eq_mul, mul_zero]
-        nlinarith [hH, h32]
-
+      · rw [im_fdBoundary_of_gt_four h4]
+        exact hH
 
 /-- The contour's real part stays within the fundamental strip. -/
-lemma abs_re_fdBoundary_le_half (ht : t ∈ Icc (0 : ℝ) 5) :
-    |(fdBoundary H t).re| ≤ 1 / 2 := by
-  obtain ⟨ht0, ht5⟩ := ht
+lemma abs_re_fdBoundary_le_half (ht : t ≤ 5) : |(fdBoundary H t).re| ≤ 1 / 2 := by
   rw [abs_le]
   rcases le_or_gt t 1 with h1 | h1
-  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
-    have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
-      simp [ρ]
-      norm_num
-    rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero]
-    have : (1 / 2 + H * Complex.I : ℂ).re = 1 / 2 := by simp
-    rw [this]
+  · rw [re_fdBoundary_of_le_one h1]
     norm_num
   · rcases le_or_gt t 3 with h3 | h3
     · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_re, one_mul]
@@ -135,26 +172,9 @@ lemma abs_re_fdBoundary_le_half (ht : t ∈ Icc (0 : ℝ) 5) :
                 (by linarith [Real.pi_pos]) harc.1
           _ = 1 / 2 := Real.cos_pi_div_three
     · rcases le_or_gt t 4 with h4 | h4
-      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
-          AffineMap.lineMap_apply_module']
-        have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).re = 0 := by
-          simp [ρ]
-        rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero]
-        have : (ρ : ℂ).re = -(1 / 2) := by
-          simp [ρ]
-          norm_num
-        rw [this]
+      · rw [re_fdBoundary_of_le_four h3 h4]
         norm_num
-      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
-          AffineMap.lineMap_apply_module']
-        have hchord : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).re = 1 := by
-          simp
-          norm_num
-        rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_one]
-        have : (-1 / 2 + H * Complex.I : ℂ).re = -(1 / 2) := by
-          simp
-          norm_num
-        rw [this]
+      · rw [re_fdBoundary_of_gt_four h4]
         constructor <;> nlinarith
 
 /-- The contour stays at or below its height parameter. -/
@@ -163,70 +183,16 @@ lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
   obtain ⟨ht0, ht5⟩ := ht
   have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rcases le_or_gt t 1 with h1 | h1
-  · rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
-    have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
-      simp [ρ]
-    rw [Complex.add_im, Complex.smul_im, hchord, smul_eq_mul]
-    have : (1 / 2 + H * Complex.I : ℂ).im = H := by simp
-    rw [this]
+  · rw [im_fdBoundary_of_le_one h1]
     nlinarith [mul_nonneg ht0 (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
   · rcases le_or_gt t 3 with h3 | h3
     · rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, circleMap_zero_im, one_mul]
       exact (Real.sin_le_one _).trans hH
     · rcases le_or_gt t 4 with h4 | h4
-      · rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply,
-          AffineMap.lineMap_apply_module']
-        have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
-          simp [ρ]
-        rw [Complex.add_im, Complex.smul_im, hchord, smul_eq_mul]
-        have : (ρ : ℂ).im = Real.sqrt 3 / 2 := by simp [ρ]
-        rw [this]
-        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ t - 3)
-          (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2),
-          mul_nonneg (by linarith : (0 : ℝ) ≤ 4 - t)
+      · rw [im_fdBoundary_of_le_four h3 h4]
+        nlinarith [mul_nonneg (by linarith : (0 : ℝ) ≤ 4 - t)
           (by linarith : (0 : ℝ) ≤ H - Real.sqrt 3 / 2)]
-      · rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply,
-          AffineMap.lineMap_apply_module']
-        have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
-          simp
-        rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero]
-        simp
-
-/-- The right vertical has constant real part `1/2`.
-
-`simpNF` rejects a `simp` annotation here: the `@[simp]` branch selectors already rewrite
-`fdBoundary` applications to the segment functions, so this left-hand side is not in simp
-normal form; the same applies to the other coordinate rewrites below. -/
-lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
-  rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
-  have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
-    simp [ρ]
-    norm_num
-  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
-  simp
-
-/-- The left vertical has constant real part `-1/2`. -/
-lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
-    (fdBoundary H t).re = -(1 / 2) := by
-  rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
-  have hchord : ((-1 / 2 + H * Complex.I : ℂ) - (ρ : ℂ)).re = 0 := by
-    simp [ρ]
-  rw [Complex.add_re, Complex.smul_re, hchord, smul_eq_mul, mul_zero, zero_add]
-  simp [ρ]
-  norm_num
-
-/-- The truncation ceiling has constant height `H`. -/
-lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
-  rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
-  have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
-    simp
-  rw [Complex.add_im, Complex.smul_im, h5, smul_eq_mul, mul_zero, zero_add]
-  simp
-
-/-- The arc lies on the unit circle. -/
-@[simp]
-lemma norm_fdBoundary_arc (h1 : 1 ≤ t) (h3 : t ≤ 3) : ‖fdBoundary H t‖ = 1 := by
-  rw [eqOn_fdBoundary_arc H ⟨h1, h3⟩, norm_circleMap_zero, abs_one]
+      · rw [im_fdBoundary_of_gt_four h4]
 
 /-- The boundary contour stays outside the open unit disc: the verticals and the ceiling
 clear it by height and offset, and the arc lies on the unit circle. -/
@@ -287,10 +253,9 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
       Real.norm_of_nonpos (by nlinarith [le_max_right R 0])]
     nlinarith [le_max_left R 0]
 
-/-- Every point strictly right of the fundamental strip winds zero.
-
-`simpNF` rejects a `simp` annotation here and on the left companion: `simp` normalizes the
-hypothesis `1 / 2 < w.re` to `2⁻¹ < w.re`, so the stated form never fires as a simp lemma. -/
+-- `simpNF` rejects `simp` annotations here and on the left companion: `simp` normalizes
+-- the hypothesis `1 / 2 < w.re` to `2⁻¹ < w.re`, so the stated forms never fire.
+/-- Every point strictly right of the fundamental strip winds zero. -/
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -298,7 +263,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     ?_ (fun R ↦ ⟨((max R 0 + 1 : ℝ) : ℂ), ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
-    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht)).2
+    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht.2)).2
     rw [Set.mem_ofPred_eq] at hz
     linarith
   · rw [Set.mem_ofPred_eq, Complex.ofReal_re]
@@ -314,7 +279,7 @@ theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     ?_ (fun R ↦ ⟨((-(max R 0 + 1) : ℝ) : ℂ), ?_, ?_⟩) hw
   · rintro z hz ⟨t, ht, rfl⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
-    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht)).1
+    have := (abs_le.mp (abs_re_fdBoundary_le_half (H := H) ht.2)).1
     rw [Set.mem_ofPred_eq] at hz
     linarith
   · rw [Set.mem_ofPred_eq, Complex.ofReal_re]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -193,7 +193,6 @@ lemma im_fdBoundary_le (hH : 1 ≤ H) (ht : t ∈ Icc (0 : ℝ) 5) :
         simp
 
 /-- The right vertical has constant real part `1/2`. -/
-@[simp]
 lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
   rw [fdBoundary_of_le_one h1, fdBoundary_segment1_apply, AffineMap.lineMap_apply_module']
   have hchord : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).re = 0 := by
@@ -203,7 +202,6 @@ lemma re_fdBoundary_of_le_one (h1 : t ≤ 1) : (fdBoundary H t).re = 1 / 2 := by
   simp
 
 /-- The left vertical has constant real part `-1/2`. -/
-@[simp]
 lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
     (fdBoundary H t).re = -(1 / 2) := by
   rw [fdBoundary_of_le_four h3 h4, fdBoundary_segment4_apply, AffineMap.lineMap_apply_module']
@@ -214,7 +212,6 @@ lemma re_fdBoundary_of_le_four (h3 : 3 < t) (h4 : t ≤ 4) :
   norm_num
 
 /-- The truncation ceiling has constant height `H`. -/
-@[simp]
 lemma im_fdBoundary_of_gt_four (h4 : 4 < t) : (fdBoundary H t).im = H := by
   rw [fdBoundary_of_gt_four h4, fdBoundary_segment5_apply, AffineMap.lineMap_apply_module']
   have h5 : ((1 / 2 + H * Complex.I : ℂ) - (-1 / 2 + H * Complex.I)).im = 0 := by
@@ -287,7 +284,6 @@ theorem windingNumber_fdBoundary_eq_zero_of_im_lt (hH : Real.sqrt 3 / 2 ≤ H) {
     nlinarith [le_max_left R 0]
 
 /-- Every point strictly right of the fundamental strip winds zero. -/
-@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     (hw : 1 / 2 < w.re) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected
@@ -304,7 +300,6 @@ theorem windingNumber_fdBoundary_eq_zero_of_half_lt_re {w : ℂ}
     linarith [le_max_left R 0]
 
 /-- Every point strictly left of the fundamental strip winds zero. -/
-@[simp]
 theorem windingNumber_fdBoundary_eq_zero_of_re_lt_neg_half {w : ℂ}
     (hw : w.re < -(1 / 2)) : windingNumber (fdBoundary H) 0 5 w = 0 := by
   refine windingNumber_fdBoundary_eq_zero_of_mem_preconnected


### PR DESCRIPTION
The complete exterior determination of the boundary contour's winding number — the `IsNullHomologous` input of the valence-formula residue count.

**Stacked on #1998** (and transitively the merged boundary/regularity layer); the content is `FundamentalDomainBoundary/Winding.lean`:

- `sqrt_three_div_two_le_im_fdBoundary`, `abs_re_fdBoundary_le_half`, `im_fdBoundary_le`: the contour's image lies in the box `|Re| ≤ 1/2`, `√3/2 ≤ Im ≤ H` (per-segment bounds; the arc cases by sine/cosine monotonicity).
- A factored transport: an unbounded convex region avoiding the contour lies in one connected component of the complement, where the winding number is constant and vanishes far away (`windingNumber_eq_of_mem_connectedComponentIn` + `windingNumber_eventually_zero_cocompact`).
- The four exterior determinations: `windingNumber_fdBoundary_eq_zero_of_im_lt` / `_of_half_lt_re` / `_of_re_lt_neg_half` / `_of_lt_im` — every point outside the closed truncated domain winds zero.

The interior value (`= -1`, the contour being negatively oriented) follows in the next slice via `windingNumber_concat` over the five segments.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence-fd-winding","id":"mvfw-1"}-->
