### PR TITLE
feat: expose the local Lie logarithm

### DIFF
--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -22,9 +22,9 @@ tangent-space exponential.
 * `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
 * `eventually_mulInvariantLog_exp`: logarithm followed after exponential is locally the identity.
 * `isLocalDiffeomorphAt_lieExp_zero`: the canonical Lie-group exponential is a local
-  diffeomorphism of every finite differentiability order at zero.
+  `C∞` local diffeomorphism at zero.
 * `isLocalDiffeomorphAt_mulInvariantExpChart_zero`: the fully charted exponential is a local
-  diffeomorphism of every finite differentiability order at zero.
+  `C∞` local diffeomorphism at zero.
 * `exists_injOn_mulInvariantExp_modelSpace`: exponential is injective near zero.
 
 ## References
@@ -422,198 +422,230 @@ theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGr
   rw [mulInvariantExpOpenPartialHomeomorph_apply, mulInvariantExpOpenPartialHomeomorph_apply]
   exact congrArg (extChartAt I (1 : G)) hxy
 
-/-- The fully charted exponential is a local diffeomorphism of every finite differentiability
-order at zero. Together with `contMDiff_mulInvariantExp` and
-`contDiffAt_mulInvariantLogChart_one`, this packages the smooth inverse-function-theorem
-conclusion available from Mathlib's finite-order local-neighborhood API. -/
-theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensional ℝ E]
-    [LieGroup I ∞ G]
-    [T2Space G] [BoundarylessManifold I G] :
-    IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) (n : ℕ∞ω)
-      (mulInvariantExpChart (I := I) (G := G)) 0 := by
+/-- A smooth partial diffeomorphism for the fully charted exponential, whose source stays inside
+the identity chart. -/
+private theorem exists_mulInvariantExpChartPartialDiffeomorph [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    ∃ d : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E ∞,
+      0 ∈ d.source ∧
+      d.source ⊆ (fun v : E =>
+        mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) ⁻¹'
+          (extChartAt I (1 : G)).source ∧
+      mulInvariantExpChart (I := I) (G := G) = d := by
+  let f : E → G := fun v =>
+    mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)
+  let F : E → E := mulInvariantExpChart (I := I) (G := G)
+  let S := f ⁻¹' (extChartAt I (1 : G)).source
+  have hf : ContMDiff 𝓘(ℝ, E) I ∞ f := by
+    simpa only [f] using contMDiff_mulInvariantExp (I := I) (G := G)
+  have hSopen : IsOpen S := hf.continuous.isOpen_preimage _
+    (isOpen_extChartAt_source (I := I) (1 : G))
+  have hzeroS : (0 : E) ∈ S := by
+    change f 0 ∈ (extChartAt I (1 : G)).source
+    rw [show f 0 = (1 : G) by exact mulInvariantExp_zero]
+    exact mem_extChartAt_source (I := I) (1 : G)
+  -- Global smoothness of the exponential gives smoothness of its identity-chart expression on
+  -- the fixed open set where that chart is valid.
+  have hF : ContDiffOn ℝ ∞ F S := by
+    have hcoord := (contMDiff_iff_target.mp hf).2 (1 : G)
+    rw [contMDiffOn_iff_contDiffOn] at hcoord
+    simpa only [F, S, f, mulInvariantExpChart_eq, Function.comp_def] using hcoord
+  have hDF : ContinuousOn (fderiv ℝ F) S :=
+    hF.continuousOn_fderiv_of_isOpen hSopen (by simp)
+  -- Invertible continuous linear endomorphisms form an open set. Shrinking to its derivative
+  -- preimage makes the derivative invertible at every point of one common source neighborhood.
+  let U := S ∩ (fderiv ℝ F) ⁻¹' {A : E →L[ℝ] E | IsUnit A}
+  have hUopen : IsOpen U := hDF.isOpen_inter_preimage hSopen Units.isOpen
+  have hzeroU : (0 : E) ∈ U := by
+    refine ⟨hzeroS, ?_⟩
+    change IsUnit (fderiv ℝ F 0)
+    rw [show fderiv ℝ F 0 = ContinuousLinearMap.id ℝ E by
+      simpa only [F] using
+        (hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G)).fderiv]
+    exact (ContinuousLinearEquiv.toUnit (ContinuousLinearEquiv.refl ℝ E)).isUnit
   let φ := mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)
-  -- Choose neighborhoods on which the exponential and logarithm are both `C^n`.
-  obtain ⟨U, hUopen, hzeroU, hFU⟩ :=
-    (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).contDiffOn'
-      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
-  obtain ⟨V, hVopen, hyV, hLV⟩ :=
-    (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).contDiffOn'
-      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
-  have hFU' : ContDiffOn ℝ n (mulInvariantExpChart (I := I) (G := G)) U := by
-    simpa using hFU
-  have hLV' : ContDiffOn ℝ n (mulInvariantLogChart (I := I) (G := G)) V := by
-    simpa using hLV
-  -- Restrict the inverse-function-theorem homeomorphism to those two neighborhoods.
-  let ψ : OpenPartialHomeomorph E E :=
-    (φ.restrOpen U hUopen).trans (OpenPartialHomeomorph.ofSet V hVopen)
-  have hψ_apply (x : E) : ψ x = mulInvariantExpChart (I := I) (G := G) x := by
+  let ψ := φ.restrOpen U hUopen
+  have hψ_apply (x : E) : ψ x = F x := by
     exact mulInvariantExpOpenPartialHomeomorph_apply (I := I) (G := G) x
-  have hφzeroV : φ 0 ∈ V := by
-    rw [mulInvariantExpOpenPartialHomeomorph_apply, mulInvariantExpChart_zero]
-    exact hyV
   have hzeroψ : (0 : E) ∈ ψ.source := by
-    rw [OpenPartialHomeomorph.trans_source]
-    refine ⟨?_, ?_⟩
-    · rw [OpenPartialHomeomorph.restrOpen_source]
-      exact ⟨zero_mem_mulInvariantExpOpenPartialHomeomorph_source (I := I) (G := G), hzeroU⟩
-    · exact hφzeroV
-  -- Give the restricted homeomorphism the public coordinate exponential as its forward map.
-  let ψe : PartialEquiv E E := {
-    toFun := mulInvariantExpChart (I := I) (G := G)
-    invFun := ψ.symm
-    source := ψ.source
-    target := ψ.target
-    map_source' := by
-      intro x hx
-      exact ψ.map_source hx
-    map_target' := by
-      intro x hx
-      exact ψ.map_target hx
-    left_inv' := by
-      intro x hx
-      rw [← hψ_apply]
-      exact ψ.left_inv hx
-    right_inv' := by
-      intro x hx
-      rw [← hψ_apply]
-      exact ψ.right_inv hx
-  }
-  -- Attach the two finite-order smoothness proofs to obtain the partial diffeomorphism.
-  let ψd : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E n := {
-    toPartialEquiv := ψe
+    rw [OpenPartialHomeomorph.restrOpen_source]
+    exact ⟨zero_mem_mulInvariantExpOpenPartialHomeomorph_source (I := I) (G := G), hzeroU⟩
+  have hψsmooth : ContDiffOn ℝ ∞ ψ ψ.source := by
+    rw [show (ψ : E → E) = F by funext x; exact hψ_apply x]
+    apply hF.mono
+    intro x hx
+    rw [OpenPartialHomeomorph.restrOpen_source] at hx
+    exact hx.2.1
+  -- At every target point the derivative is invertible, so smoothness of the global forward map
+  -- bootstraps the homeomorphism's inverse to `C∞` on the entire fixed target neighborhood.
+  have hψsymmSmooth : ContDiffOn ℝ ∞ ψ.symm ψ.target := by
+    intro y hy
+    have hxy := ψ.map_target hy
+    have hxyU : ψ.symm y ∈ U := by
+      rw [OpenPartialHomeomorph.restrOpen_source] at hxy
+      exact hxy.2
+    have hxyS : ψ.symm y ∈ S := hxyU.1
+    have hFxy : ContDiffAt ℝ ∞ F (ψ.symm y) :=
+      (hF (ψ.symm y) hxyS).contDiffAt (hSopen.mem_nhds hxyS)
+    obtain ⟨A, hA⟩ := hxyU.2
+    apply (ψ.contDiffAt_symm hy (f₀' := ContinuousLinearEquiv.ofUnit A) ?_ ?_).contDiffWithinAt
+    · rw [show (ψ : E → E) = F by funext x; exact hψ_apply x]
+      rw [show ((ContinuousLinearEquiv.ofUnit A : E ≃L[ℝ] E) : E →L[ℝ] E) =
+          fderiv ℝ F (ψ.symm y) by exact hA]
+      exact (hFxy.differentiableAt (by simp)).hasFDerivAt
+    · rw [show (ψ : E → E) = F by funext x; exact hψ_apply x]
+      exact hFxy
+  let d : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E ∞ := {
+    toPartialEquiv := ψ.toPartialEquiv
     open_source := ψ.open_source
     open_target := ψ.open_target
     contMDiffOn_toFun := by
       rw [contMDiffOn_iff_contDiffOn]
-      apply hFU'.mono
-      intro v hv
-      rw [OpenPartialHomeomorph.trans_source] at hv
-      exact hv.1.2
+      exact hψsmooth
     contMDiffOn_invFun := by
       rw [contMDiffOn_iff_contDiffOn]
-      apply hLV'.mono
-      intro y hy
-      rw [OpenPartialHomeomorph.trans_target] at hy
-      exact hy.1
+      exact hψsymmSmooth
   }
-  exact ψd.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) n hzeroψ
+  refine ⟨d, hzeroψ, ?_, ?_⟩
+  · intro x hx
+    change x ∈ ψ.source at hx
+    rw [OpenPartialHomeomorph.restrOpen_source] at hx
+    exact hx.2.1
+  · funext x
+    exact (hψ_apply x).symm
 
-/-- The canonical Lie-group exponential is a local diffeomorphism of every finite
-differentiability order at zero. -/
-theorem isLocalDiffeomorphAt_lieExp_zero (n : ℕ) [FiniteDimensional ℝ E]
+/-- The fully charted exponential is a smooth local diffeomorphism at zero. -/
+theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
-    IsLocalDiffeomorphAt
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I (n : ℕ∞ω)
-      (lieExp (I := I) (G := G)) 0 := by
-  let f : LeftInvariantDerivation I G → G := lieExp (I := I) (G := G)
-  let g : G → LeftInvariantDerivation I G := lieLog (I := I) (G := G)
-  -- First choose neighborhoods on which the two germ-level inverse laws hold pointwise.
-  have hgf : ∀ᶠ X in 𝓝 (0 : LeftInvariantDerivation I G), g (f X) = X := by
-    simpa only [f, g] using eventually_lieLog_lieExp (I := I) (G := G)
-  have hfg : ∀ᶠ y in 𝓝 (1 : G), f (g y) = y := by
-    simpa only [f, g] using eventually_lieExp_lieLog (I := I) (G := G)
-  obtain ⟨U₀, hU₀sub, hU₀open, hzeroU₀⟩ := mem_nhds_iff.mp hgf
-  obtain ⟨V₀, hV₀sub, hV₀open, honeV₀⟩ := mem_nhds_iff.mp hfg
-  -- Independently choose a neighborhood on which the local logarithm is `C^n`.
-  obtain ⟨W, hWopen, honeW, hgW⟩ :=
-    (contMDiffAt_lieLog_one (I := I) (G := G)).contMDiffOn'
-      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
-  have hgW' : ContMDiffOn I
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n g W := by
-    simpa [g] using hgW
-  have hf : ContMDiff
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I ∞ f := by
-    simpa only [f] using contMDiff_lieExp (I := I) (G := G)
-  -- Shrink the target to the common inverse-law and smoothness neighborhood. Then shrink the
-  -- source and target once more so each map lands in the other's domain; this turns the two
-  -- eventual inverse laws into the exact source/target laws required by `PartialEquiv`.
-  let Vb := V₀ ∩ W
-  have hVbopen : IsOpen Vb := hV₀open.inter hWopen
-  have honeVb : (1 : G) ∈ Vb := ⟨honeV₀, honeW⟩
-  have hgVb : ContMDiffOn I
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n g Vb :=
-    hgW'.mono Set.inter_subset_right
-  let U := U₀ ∩ f ⁻¹' Vb
-  have hUopen : IsOpen U :=
-    hU₀open.inter (hf.continuous.isOpen_preimage _ hVbopen)
-  have hzeroU : (0 : LeftInvariantDerivation I G) ∈ U := by
-    refine ⟨hzeroU₀, ?_⟩
-    change f 0 ∈ Vb
-    rw [show f 0 = (1 : G) by exact lieExp_zero]
-    exact honeVb
-  let V := Vb ∩ g ⁻¹' U
-  have hVopen : IsOpen V :=
-    hgVb.continuousOn.isOpen_inter_preimage hVbopen hUopen
-  have honeV : (1 : G) ∈ V := by
-    refine ⟨honeVb, ?_⟩
-    change g 1 ∈ U
-    rw [show g 1 = (0 : LeftInvariantDerivation I G) by exact lieLog_one]
-    exact hzeroU
-  -- Package the restricted inverse pair, followed by its finite-order smoothness data.
-  let e : PartialEquiv (LeftInvariantDerivation I G) G := {
-    toFun := f
-    invFun := g
-    source := U
+    IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) ∞
+      (mulInvariantExpChart (I := I) (G := G)) 0 := by
+  obtain ⟨d, hzero, _, hd⟩ :=
+    exists_mulInvariantExpChartPartialDiffeomorph (I := I) (G := G)
+  rw [hd]
+  exact d.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) ∞ hzero
+
+/-- The tangent-space exponential, viewed as a group-valued map on model coordinates, is a smooth
+local diffeomorphism at zero. -/
+theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    IsLocalDiffeomorphAt 𝓘(ℝ, E) I ∞
+      (fun v : E => mulInvariantExp (I := I) (G := G)
+        (v : GroupLieAlgebra I G)) 0 := by
+  let f : E → G := fun v =>
+    mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)
+  obtain ⟨d, hzero, hdsource, hd⟩ :=
+    exists_mulInvariantExpChartPartialDiffeomorph (I := I) (G := G)
+  let chart := extChartAt I (1 : G)
+  let V := interior chart.target
+  have hVopen : IsOpen V := isOpen_interior
+  have honeV : extChartAt I (1 : G) (1 : G) ∈ V := by
+    exact (ModelWithCorners.isInteriorPoint_iff (I := I)).mp
+      BoundarylessManifold.isInteriorPoint
+  have hsourceOpen : IsOpen (chart.source ∩ chart ⁻¹' V) :=
+    (continuousOn_extChartAt (I := I) (1 : G)).isOpen_inter_preimage
+      (isOpen_extChartAt_source (I := I) (1 : G)) hVopen
+  let ce : PartialEquiv G E := {
+    toFun := chart
+    invFun := chart.symm
+    source := chart.source ∩ chart ⁻¹' V
     target := V
-    map_source' := by
-      intro X hX
-      refine ⟨hX.2, ?_⟩
-      change g (f X) ∈ U
-      rw [hU₀sub hX.1]
-      exact hX
+    map_source' := fun _ hx => hx.2
     map_target' := by
       intro y hy
-      exact hy.2
+      refine ⟨chart.map_target (interior_subset hy), ?_⟩
+      change chart (chart.symm y) ∈ V
+      rw [chart.right_inv (interior_subset hy)]
+      exact hy
+    left_inv' := fun _ hx => chart.left_inv hx.1
+    right_inv' := fun _ hy => chart.right_inv (interior_subset hy)
+  }
+  let c : PartialDiffeomorph I 𝓘(ℝ, E) G E ∞ := {
+    toPartialEquiv := ce
+    open_source := hsourceOpen
+    open_target := hVopen
+    contMDiffOn_toFun := by
+      apply (contMDiffOn_extChartAt (I := I) (n := ∞) (x := (1 : G))).mono
+      intro x hx
+      change x ∈ chart.source ∩ chart ⁻¹' V at hx
+      simpa only [chart, extChartAt_source] using hx.1
+    contMDiffOn_invFun :=
+      (contMDiffOn_extChartAt_symm (I := I) (1 : G)).mono interior_subset
+  }
+  let q := d.trans c.symm
+  have hzeroq : (0 : E) ∈ q.source := by
+    change 0 ∈ d.source ∩ d ⁻¹' c.symm.source
+    refine ⟨hzero, ?_⟩
+    change d 0 ∈ c.target
+    rw [← hd, mulInvariantExpChart_zero]
+    exact honeV
+  have hq (x : E) (hx : x ∈ q.source) : f x = q x := by
+    change x ∈ d.source ∩ d ⁻¹' c.symm.source at hx
+    change f x = (extChartAt I (1 : G)).symm (d x)
+    rw [← hd]
+    change f x = (extChartAt I (1 : G)).symm
+      (extChartAt I (1 : G) (f x))
+    exact ((extChartAt I (1 : G)).left_inv (hdsource hx.1)).symm
+  let e : PartialEquiv E G := {
+    toFun := f
+    invFun := q.symm
+    source := q.source
+    target := q.target
+    map_source' := by
+      intro x hx
+      rw [hq x hx]
+      exact q.map_source hx
+    map_target' := by
+      intro y hy
+      exact q.map_target hy
     left_inv' := by
-      intro X hX
-      exact hU₀sub hX.1
+      intro x hx
+      rw [hq x hx]
+      exact q.left_inv hx
     right_inv' := by
       intro y hy
-      exact hV₀sub hy.1.1
+      rw [hq (q.symm y) (q.map_target hy)]
+      exact q.right_inv hy
   }
-  let d : PartialDiffeomorph
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I
-      (LeftInvariantDerivation I G) G n := {
+  let p : PartialDiffeomorph 𝓘(ℝ, E) I E G ∞ := {
     toPartialEquiv := e
-    open_source := hUopen
-    open_target := hVopen
-    contMDiffOn_toFun := hf.contMDiffOn.of_le (by exact_mod_cast le_top)
-    contMDiffOn_invFun := hgVb.mono Set.inter_subset_left
+    open_source := q.open_source
+    open_target := q.open_target
+    contMDiffOn_toFun := by
+      simpa only [f] using
+        (contMDiff_mulInvariantExp (I := I) (G := G)).contMDiffOn
+    contMDiffOn_invFun := q.contMDiffOn_invFun
   }
-  exact d.isLocalDiffeomorphAt _ _ n hzeroU
+  change IsLocalDiffeomorphAt 𝓘(ℝ, E) I ∞ f 0
+  exact p.isLocalDiffeomorphAt 𝓘(ℝ, E) I ∞ hzeroq
 
-/-- The tangent-space exponential, viewed as a group-valued map on model coordinates, is a local
-diffeomorphism of every finite differentiability order at zero. -/
-theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero (n : ℕ)
-    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
-    [BoundarylessManifold I G] :
-    IsLocalDiffeomorphAt 𝓘(ℝ, E) I (n : ℕ∞ω)
-      (fun v : E => mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) 0 := by
+/-- The canonical Lie-group exponential is a smooth local diffeomorphism at zero. -/
+theorem isLocalDiffeomorphAt_lieExp_zero [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    IsLocalDiffeomorphAt
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I ∞
+      (lieExp (I := I) (G := G)) 0 := by
   let L := leftInvariantDerivationLinearIsometryEquivModelVectorSpace
     (I := I) (G := G)
-  let d : E ≃ₘ^n⟮𝓘(ℝ, E),
-      modelWithCornersSelf ℝ (LeftInvariantDerivation I G)⟯
-      LeftInvariantDerivation I G := {
-    toEquiv := L.symm.toEquiv
-    contMDiff_toFun :=
-      L.toContinuousLinearEquiv.symm.contDiff.contMDiff.of_le (by exact_mod_cast le_top)
-    contMDiff_invFun :=
-      L.toContinuousLinearEquiv.contDiff.contMDiff.of_le (by exact_mod_cast le_top)
+  let d : LeftInvariantDerivation I G ≃ₘ^∞⟮
+      modelWithCornersSelf ℝ (LeftInvariantDerivation I G), 𝓘(ℝ, E)⟯ E := {
+    toEquiv := L.toEquiv
+    contMDiff_toFun := L.toContinuousLinearEquiv.contDiff.contMDiff
+    contMDiff_invFun := L.toContinuousLinearEquiv.symm.contDiff.contMDiff
   }
-  have hL : IsLocalDiffeomorphAt 𝓘(ℝ, E)
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n L.symm 0 :=
+  have hL : IsLocalDiffeomorphAt
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) 𝓘(ℝ, E) ∞ L 0 :=
     d.isLocalDiffeomorph 0
-  have hgroup : IsLocalDiffeomorphAt
-      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I n
-      (lieExp (I := I) (G := G)) (L.symm 0) := by
-    rw [show L.symm (0 : E) = (0 : LeftInvariantDerivation I G) by
+  have hmodel : IsLocalDiffeomorphAt 𝓘(ℝ, E) I ∞
+      (fun v : E => mulInvariantExp (I := I) (G := G)
+        (v : GroupLieAlgebra I G)) (L 0) := by
+    rw [show L (0 : LeftInvariantDerivation I G) = (0 : E) by
       exact LinearEquiv.map_zero _]
-    exact isLocalDiffeomorphAt_lieExp_zero (I := I) (G := G) n
-  have hcomp := hL.comp I G hgroup
-  rw [show (fun v : E => mulInvariantExp (I := I) (G := G)
-      (v : GroupLieAlgebra I G)) = lieExp (I := I) (G := G) ∘ L.symm by
-    funext v
+    exact isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero (I := I) (G := G)
+  have hcomp := hL.comp I G hmodel
+  rw [show lieExp (I := I) (G := G) =
+      (fun v : E => mulInvariantExp (I := I) (G := G)
+        (v : GroupLieAlgebra I G)) ∘ L by
+    funext X
     rw [Function.comp_apply, lieExp_eq_mulInvariantExp,
-      ← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
-      L.apply_symm_apply]]
+      leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply]]
   exact hcomp

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -176,10 +176,7 @@ theorem mulInvariantLogChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 theorem mulInvariantLogChart_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantLogChart (I := I) (G := G)
-      (I (chartAt H (1 : G) (1 : G))) = 0 := by
-  have hcoord := congrFun (extChartAt_coe (I := I) (1 : G)) (1 : G)
-  simp only [Function.comp_apply] at hcoord
-  rw [← hcoord]
+      (extChartAt I (1 : G) (1 : G)) = 0 := by
   rw [← mulInvariantExpChart_zero (I := I) (G := G)]
   exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).left_inv
     zero_mem_mulInvariantExpOpenPartialHomeomorph_source
@@ -363,8 +360,7 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
     (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).continuousAt.comp
       (continuousAt_extChartAt (I := I) (1 : G))
   have hlogOne : L (extChartAt I (1 : G) (1 : G)) = 0 := by
-    simpa only [L, extChartAt_coe, Function.comp_apply] using
-      mulInvariantLogChart_one (I := I) (G := G)
+    exact mulInvariantLogChart_one (I := I) (G := G)
   have hexpCont : ContinuousAt
       (fun g : G => mulInvariantExp (I := I) (G := G)
         (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G)) 1 :=
@@ -544,6 +540,8 @@ theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero [FiniteDimensional 
   have hsourceOpen : IsOpen (chart.source ∩ chart ⁻¹' V) :=
     (continuousOn_extChartAt (I := I) (1 : G)).isOpen_inter_preimage
       (isOpen_extChartAt_source (I := I) (1 : G)) hVopen
+  -- Boundarylessness puts the identity coordinate in the interior of the chart target. Restricting
+  -- the chart to that interior gives an honest smooth partial diffeomorphism in both directions.
   let ce : PartialEquiv G E := {
     toFun := chart
     invFun := chart.symm
@@ -571,6 +569,8 @@ theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero [FiniteDimensional 
     contMDiffOn_invFun :=
       (contMDiffOn_extChartAt_symm (I := I) (1 : G)).mono interior_subset
   }
+  -- Transport the charted local diffeomorphism `d : E ↔ E` back through the restricted identity
+  -- chart. The resulting `q : E ↔ G` has the desired source, target, and smooth inverse.
   let q := d.trans c.symm
   have hzeroq : (0 : E) ∈ q.source := by
     change 0 ∈ d.source ∩ d ⁻¹' c.symm.source
@@ -585,6 +585,9 @@ theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero [FiniteDimensional 
     change f x = (extChartAt I (1 : G)).symm
       (extChartAt I (1 : G) (f x))
     exact ((extChartAt I (1 : G)).left_inv (hdsource hx.1)).symm
+  -- Although `q` agrees with `f` on its source, its total forward function retains the composed
+  -- chart implementation. Re-wrap its partial equivalence using literally `f` so the final local
+  -- diffeomorphism theorem has the canonical exponential as its function.
   let e : PartialEquiv E G := {
     toFun := f
     invFun := q.symm

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -10,16 +10,19 @@ public import Mathlib.Geometry.Manifold.LocalDiffeomorph
 # Local inverse of the Lie-group exponential
 
 The smooth coordinate exponential has derivative the identity at zero, so the inverse function
-theorem supplies a smooth local logarithm in model-space identity coordinates.
+theorem supplies a chosen smooth local logarithm in model-space identity coordinates.
 
 Transporting that logarithm through the identity chart gives a group-level local inverse for the
 tangent-space exponential.
 
 ## Main results
 
-* `mulInvariantLog`: the canonical local logarithm from the group to its tangent Lie algebra.
+* `mulInvariantLog`: a local logarithm from the group to its tangent Lie algebra.
+* `lieLog`: the same chosen local logarithm, valued in left-invariant derivations.
 * `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
 * `eventually_mulInvariantLog_exp`: logarithm followed after exponential is locally the identity.
+* `isLocalDiffeomorphAt_lieExp_zero`: the canonical Lie-group exponential is a local
+  diffeomorphism of every finite differentiability order at zero.
 * `isLocalDiffeomorphAt_mulInvariantExpChart_zero`: the fully charted exponential is a local
   diffeomorphism of every finite differentiability order at zero.
 * `exists_injOn_mulInvariantExp_modelSpace`: exponential is injective near zero.
@@ -30,7 +33,7 @@ tangent-space exponential.
   Deliverable A, Layer 0, "The exponential map".
 -/
 public section
-open Function Manifold
+open Filter Function Manifold
 open scoped ContDiff Manifold Topology
 noncomputable section
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
@@ -119,7 +122,7 @@ private theorem hasFDerivAt_mulInvariantExpChart_zero_equiv [FiniteDimensional �
       ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
   simpa using hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G)
 
-/-- The fully charted exponential on the canonical neighborhoods selected by the inverse function
+/-- The fully charted exponential on the neighborhoods selected by the inverse function
 theorem. -/
 noncomputable def mulInvariantExpOpenPartialHomeomorph [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : OpenPartialHomeomorph E E := by
@@ -146,7 +149,7 @@ theorem zero_mem_mulInvariantExpOpenPartialHomeomorph_source [FiniteDimensional 
       (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
 
 /-- The identity coordinate belongs to the target of the local coordinate exponential. -/
-theorem identity_mem_mulInvariantExpOpenPartialHomeomorph_target [FiniteDimensional ℝ E]
+theorem one_mem_mulInvariantExpOpenPartialHomeomorph_target [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     extChartAt I (1 : G) (1 : G) ∈
       (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).target := by
@@ -154,38 +157,23 @@ theorem identity_mem_mulInvariantExpOpenPartialHomeomorph_target [FiniteDimensio
   exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).map_source
     zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
-/-- The canonical local logarithm with both domain and codomain in identity-chart coordinates. -/
+/-- The logarithm selected by the inverse function theorem, with domain and codomain in
+identity-chart coordinates. Its values outside the selected target neighborhood carry no
+logarithmic meaning. -/
 noncomputable def mulInvariantLogChart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : E → E :=
   (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).symm
 
-/-- The fully charted logarithm is the inverse of the canonical local homeomorphism. -/
+/-- The fully charted logarithm is the inverse of the chosen local homeomorphism. -/
 theorem mulInvariantLogChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (y : E) :
     mulInvariantLogChart (I := I) (G := G) y =
       (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).symm y := by
   rfl
 
-/- This private wrapper gives a stable name to Mathlib's inverse-function-theorem local inverse. -/
-private noncomputable def mulInvariantLogLocalInverse [FiniteDimensional ℝ E] [LieGroup I ∞ G]
-    [T2Space G] [BoundarylessManifold I G] : E → E := by
-  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).localInverse
-    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
-
-/- The logarithm chosen through the local homeomorphism is exactly Mathlib's named local inverse.
-The `rfl` proof relies on the definitional identity between `ContDiffAt.localInverse` and the
-inverse of `ContDiffAt.toOpenPartialHomeomorph`; Mathlib currently has no public lemma for this
-bridge. -/
-private theorem mulInvariantLogChart_eq_localInverse [FiniteDimensional ℝ E] [LieGroup I ∞ G]
-    [T2Space G] [BoundarylessManifold I G] :
-    mulInvariantLogChart (I := I) (G := G) =
-      mulInvariantLogLocalInverse (I := I) (G := G) := by
-  rfl
-
 /-- The coordinate logarithm sends the identity coordinate to zero. -/
 @[simp]
-theorem mulInvariantLogChart_identity [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem mulInvariantLogChart_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantLogChart (I := I) (G := G)
       (I (chartAt H (1 : G) (1 : G))) = 0 := by
@@ -216,19 +204,26 @@ theorem eventually_mulInvariantExpChart_log [FiniteDimensional ℝ E] [LieGroup 
     zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
 /-- The coordinate logarithm is smooth at the identity coordinate. -/
-theorem contDiffAt_mulInvariantLogChart_identity [FiniteDimensional ℝ E]
+theorem contDiffAt_mulInvariantLogChart_one [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     ContDiffAt ℝ ∞ (mulInvariantLogChart (I := I) (G := G))
       (extChartAt I (1 : G) (1 : G)) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  let hf := contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)
-  rw [mulInvariantLogChart_eq_localInverse]
-  unfold mulInvariantLogLocalInverse
-  simpa only [mulInvariantExpChart_zero] using hf.to_localInverse
-    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
+  let φ := mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)
+  have hφ : (φ : E → E) = mulInvariantExpChart (I := I) (G := G) := by
+    funext v
+    exact mulInvariantExpOpenPartialHomeomorph_apply (I := I) (G := G) v
+  have hlog : φ.symm (extChartAt I (1 : G) (1 : G)) = 0 :=
+    mulInvariantLogChart_one (I := I) (G := G)
+  apply φ.contDiffAt_symm one_mem_mulInvariantExpOpenPartialHomeomorph_target
+  · rw [hlog, hφ]
+    exact hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)
+  · rw [hlog, hφ]
+    exact contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)
 
 /-- The local logarithm of a group element, valued in the tangent Lie algebra at the identity. It
-is the coordinate logarithm transported back from the manifold model space. -/
+is the coordinate logarithm transported back from the manifold model space. Its values outside
+the selected identity neighborhood carry no logarithmic meaning. -/
 noncomputable def mulInvariantLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (g : G) : GroupLieAlgebra I G := by
   -- `GroupLieAlgebra I G` is definitionally the model space `E`.
@@ -242,6 +237,51 @@ theorem mulInvariantLog_eq_chart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     (show E from mulInvariantLog (I := I) (G := G) g) =
       mulInvariantLogChart (I := I) (G := G) (extChartAt I (1 : G) g) := by
   rfl
+
+/-- The tangent-valued local logarithm is smooth at the group identity. -/
+theorem contMDiffAt_mulInvariantLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ContMDiffAt I 𝓘(ℝ, E) ∞
+      (fun g : G => (show E from mulInvariantLog (I := I) (G := G) g)) (1 : G) := by
+  rw [show (fun g : G => (show E from mulInvariantLog (I := I) (G := G) g)) = fun g : G =>
+      mulInvariantLogChart (I := I) (G := G) (extChartAt I (1 : G) g) by
+    funext g
+    exact mulInvariantLog_eq_chart (I := I) (G := G) g]
+  exact (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).contMDiffAt.comp
+    (1 : G) (contMDiffAt_extChartAt (I := I) (x := (1 : G)))
+
+/-- The local Lie logarithm, valued in the canonical Lie algebra of left-invariant derivations.
+Its values outside the identity neighborhood selected by the inverse function theorem carry no
+logarithmic meaning. -/
+noncomputable def lieLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (g : G) : LeftInvariantDerivation I G :=
+  (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)).symm (mulInvariantLog (I := I) (G := G) g)
+
+/-- The derivation-valued local Lie logarithm is the tangent-valued logarithm transported through
+the derivation–tangent equivalence. -/
+theorem lieLog_eq [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (g : G) :
+    lieLog (I := I) (G := G) g =
+      (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+        (I := I) (G := G)).symm (mulInvariantLog (I := I) (G := G) g) := by
+  rfl
+
+/-- The derivation-valued local Lie logarithm is smooth at the group identity. -/
+theorem contMDiffAt_lieLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ContMDiffAt I (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) ∞
+      (lieLog (I := I) (G := G)) (1 : G) := by
+  let L := leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)
+  have hL : ContMDiff (modelWithCornersSelf ℝ E)
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) ∞ L.symm :=
+    L.toContinuousLinearEquiv.symm.contDiff.contMDiff
+  rw [show lieLog (I := I) (G := G) = fun g : G =>
+      L.symm (mulInvariantLog (I := I) (G := G) g) by
+    funext g
+    exact lieLog_eq (I := I) (G := G) g]
+  exact hL.contMDiffAt.comp (1 : G) (contMDiffAt_mulInvariantLog_one (I := I) (G := G))
 
 /-- Locally around zero, taking the local logarithm after exponentiating recovers the original
 tangent vector. -/
@@ -264,7 +304,42 @@ theorem mulInvariantLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
   -- performs the substantive rewrite.
   change (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0
   rw [mulInvariantLog_eq_chart]
-  exact mulInvariantLogChart_identity (I := I) (G := G)
+  exact mulInvariantLogChart_one (I := I) (G := G)
+
+/-- The derivation-valued local Lie logarithm sends the group identity to the zero derivation. -/
+@[simp]
+theorem lieLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    lieLog (I := I) (G := G) (1 : G) = 0 := by
+  rw [lieLog_eq]
+  change (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)).symm
+      (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0
+  have hlog : (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0 := by
+    change mulInvariantLog (I := I) (G := G) (1 : G) =
+      (0 : GroupLieAlgebra I G)
+    exact mulInvariantLog_one (I := I) (G := G)
+  rw [hlog]
+  exact LinearEquiv.map_zero _
+
+/-- Locally around zero, the derivation-valued Lie logarithm is a left inverse to `lieExp`. -/
+theorem eventually_lieLog_lieExp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ X in 𝓝 (0 : LeftInvariantDerivation I G),
+      lieLog (I := I) (G := G) (lieExp X) = X := by
+  let L := leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)
+  have hL : Tendsto L (𝓝 (0 : LeftInvariantDerivation I G)) (𝓝 (0 : E)) := by
+    have h : ContinuousAt L (0 : LeftInvariantDerivation I G) := L.continuousAt
+    exact (show L (0 : LeftInvariantDerivation I G) = (0 : E) by
+      exact LinearEquiv.map_zero _) ▸ h
+  have h := hL.eventually (eventually_mulInvariantLog_exp (I := I) (G := G))
+  filter_upwards [h] with X hX
+  rw [lieLog_eq, lieExp_eq_mulInvariantExp]
+  rw [← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply]
+  change L.symm (show E from mulInvariantLog (I := I) (G := G)
+    (mulInvariantExp (I := I) (G := G) (L X : GroupLieAlgebra I G))) = X
+  rw [hX, L.symm_apply_apply]
 
 /-- Locally around the identity, exponentiating the local logarithm recovers the original group
 element. -/
@@ -280,11 +355,11 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
       extChartAt I (1 : G) g :=
     (continuousAt_extChartAt (I := I) (1 : G)).tendsto.eventually hFL
   have hlogCont : ContinuousAt (fun g : G => L (extChartAt I (1 : G) g)) 1 :=
-    (contDiffAt_mulInvariantLogChart_identity (I := I) (G := G)).continuousAt.comp
+    (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).continuousAt.comp
       (continuousAt_extChartAt (I := I) (1 : G))
   have hlogOne : L (extChartAt I (1 : G) (1 : G)) = 0 := by
     simpa only [L, extChartAt_coe, Function.comp_apply] using
-      mulInvariantLogChart_identity (I := I) (G := G)
+      mulInvariantLogChart_one (I := I) (G := G)
   have hexpCont : ContinuousAt
       (fun g : G => mulInvariantExp (I := I) (G := G)
         (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G)) 1 :=
@@ -310,6 +385,23 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
   apply (extChartAt I (1 : G)).injOn (by simpa only [L] using hexp) hg
   simpa only [F, L, mulInvariantExpChart_apply] using hcoord
 
+/-- Locally around the identity, `lieExp` is a left inverse to the derivation-valued Lie
+logarithm. -/
+theorem eventually_lieExp_lieLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ g in 𝓝 (1 : G), lieExp (lieLog (I := I) (G := G) g) = g := by
+  let L := leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)
+  refine (eventually_mulInvariantExp_log (I := I) (G := G)).mono ?_
+  intro g hg
+  rw [lieLog_eq, lieExp_eq_mulInvariantExp]
+  rw [← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply]
+  change mulInvariantExp (I := I) (G := G)
+    (L (L.symm (show E from mulInvariantLog (I := I) (G := G) g)) :
+      GroupLieAlgebra I G) = g
+  rw [L.apply_symm_apply]
+  exact hg
+
 /-- In model-space coordinates, the tangent-space exponential is injective on a neighborhood of
 zero. -/
 theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
@@ -326,7 +418,7 @@ theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGr
 
 /-- The fully charted exponential is a local diffeomorphism of every finite differentiability
 order at zero. Together with `contMDiff_mulInvariantExp` and
-`contDiffAt_mulInvariantLogChart_identity`, this packages the smooth inverse-function-theorem
+`contDiffAt_mulInvariantLogChart_one`, this packages the smooth inverse-function-theorem
 conclusion available from Mathlib's finite-order local-neighborhood API. -/
 theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensional ℝ E]
     [LieGroup I ∞ G]
@@ -339,7 +431,7 @@ theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensio
     (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).contDiffOn'
       (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
   obtain ⟨V, hVopen, hyV, hLV⟩ :=
-    (contDiffAt_mulInvariantLogChart_identity (I := I) (G := G)).contDiffOn'
+    (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).contDiffOn'
       (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
   have hFU' : ContDiffOn ℝ n (mulInvariantExpChart (I := I) (G := G)) U := by
     simpa using hFU
@@ -399,3 +491,117 @@ theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensio
       exact hy.1
   }
   exact ψd.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) n hzeroψ
+
+/-- The canonical Lie-group exponential is a local diffeomorphism of every finite
+differentiability order at zero. -/
+theorem isLocalDiffeomorphAt_lieExp_zero (n : ℕ) [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    IsLocalDiffeomorphAt
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I (n : ℕ∞ω)
+      (lieExp (I := I) (G := G)) 0 := by
+  let f : LeftInvariantDerivation I G → G := lieExp (I := I) (G := G)
+  let g : G → LeftInvariantDerivation I G := lieLog (I := I) (G := G)
+  have hgf : ∀ᶠ X in 𝓝 (0 : LeftInvariantDerivation I G), g (f X) = X := by
+    simpa only [f, g] using eventually_lieLog_lieExp (I := I) (G := G)
+  have hfg : ∀ᶠ y in 𝓝 (1 : G), f (g y) = y := by
+    simpa only [f, g] using eventually_lieExp_lieLog (I := I) (G := G)
+  obtain ⟨U₀, hU₀sub, hU₀open, hzeroU₀⟩ := mem_nhds_iff.mp hgf
+  obtain ⟨V₀, hV₀sub, hV₀open, honeV₀⟩ := mem_nhds_iff.mp hfg
+  obtain ⟨W, hWopen, honeW, hgW⟩ :=
+    (contMDiffAt_lieLog_one (I := I) (G := G)).contMDiffOn'
+      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
+  have hgW' : ContMDiffOn I
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n g W := by
+    simpa [g] using hgW
+  have hf : ContMDiff
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I ∞ f := by
+    simpa only [f] using contMDiff_lieExp (I := I) (G := G)
+  let Vb := V₀ ∩ W
+  have hVbopen : IsOpen Vb := hV₀open.inter hWopen
+  have honeVb : (1 : G) ∈ Vb := ⟨honeV₀, honeW⟩
+  have hgVb : ContMDiffOn I
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n g Vb :=
+    hgW'.mono Set.inter_subset_right
+  let U := U₀ ∩ f ⁻¹' Vb
+  have hUopen : IsOpen U :=
+    hU₀open.inter (hf.continuous.isOpen_preimage _ hVbopen)
+  have hzeroU : (0 : LeftInvariantDerivation I G) ∈ U := by
+    refine ⟨hzeroU₀, ?_⟩
+    change f 0 ∈ Vb
+    rw [show f 0 = (1 : G) by exact lieExp_zero]
+    exact honeVb
+  let V := Vb ∩ g ⁻¹' U
+  have hVopen : IsOpen V :=
+    hgVb.continuousOn.isOpen_inter_preimage hVbopen hUopen
+  have honeV : (1 : G) ∈ V := by
+    refine ⟨honeVb, ?_⟩
+    change g 1 ∈ U
+    rw [show g 1 = (0 : LeftInvariantDerivation I G) by exact lieLog_one]
+    exact hzeroU
+  let e : PartialEquiv (LeftInvariantDerivation I G) G := {
+    toFun := f
+    invFun := g
+    source := U
+    target := V
+    map_source' := by
+      intro X hX
+      refine ⟨hX.2, ?_⟩
+      change g (f X) ∈ U
+      rw [hU₀sub hX.1]
+      exact hX
+    map_target' := by
+      intro y hy
+      exact hy.2
+    left_inv' := by
+      intro X hX
+      exact hU₀sub hX.1
+    right_inv' := by
+      intro y hy
+      exact hV₀sub hy.1.1
+  }
+  let d : PartialDiffeomorph
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I
+      (LeftInvariantDerivation I G) G n := {
+    toPartialEquiv := e
+    open_source := hUopen
+    open_target := hVopen
+    contMDiffOn_toFun := hf.contMDiffOn.of_le (by exact_mod_cast le_top)
+    contMDiffOn_invFun := hgVb.mono Set.inter_subset_left
+  }
+  exact d.isLocalDiffeomorphAt _ _ n hzeroU
+
+/-- The tangent-space exponential, viewed as a group-valued map on model coordinates, is a local
+diffeomorphism of every finite differentiability order at zero. -/
+theorem isLocalDiffeomorphAt_mulInvariantExp_modelSpace_zero (n : ℕ)
+    [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+    [BoundarylessManifold I G] :
+    IsLocalDiffeomorphAt 𝓘(ℝ, E) I (n : ℕ∞ω)
+      (fun v : E => mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) 0 := by
+  let L := leftInvariantDerivationLinearIsometryEquivModelVectorSpace
+    (I := I) (G := G)
+  let d : E ≃ₘ^n⟮𝓘(ℝ, E),
+      modelWithCornersSelf ℝ (LeftInvariantDerivation I G)⟯
+      LeftInvariantDerivation I G := {
+    toEquiv := L.symm.toEquiv
+    contMDiff_toFun :=
+      L.toContinuousLinearEquiv.symm.contDiff.contMDiff.of_le (by exact_mod_cast le_top)
+    contMDiff_invFun :=
+      L.toContinuousLinearEquiv.contDiff.contMDiff.of_le (by exact_mod_cast le_top)
+  }
+  have hL : IsLocalDiffeomorphAt 𝓘(ℝ, E)
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) n L.symm 0 :=
+    d.isLocalDiffeomorph 0
+  have hgroup : IsLocalDiffeomorphAt
+      (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I n
+      (lieExp (I := I) (G := G)) (L.symm 0) := by
+    rw [show L.symm (0 : E) = (0 : LeftInvariantDerivation I G) by
+      exact LinearEquiv.map_zero _]
+    exact isLocalDiffeomorphAt_lieExp_zero (I := I) (G := G) n
+  have hcomp := hL.comp I G hgroup
+  rw [show (fun v : E => mulInvariantExp (I := I) (G := G)
+      (v : GroupLieAlgebra I G)) = lieExp (I := I) (G := G) ∘ L.symm by
+    funext v
+    rw [Function.comp_apply, lieExp_eq_mulInvariantExp,
+      ← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply,
+      L.apply_symm_apply]]
+  exact hcomp

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -174,7 +174,10 @@ private noncomputable def mulInvariantLogLocalInverse [FiniteDimensional ℝ E] 
   exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).localInverse
     (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
 
-/- The logarithm chosen through the local homeomorphism is exactly Mathlib's named local inverse. -/
+/- The logarithm chosen through the local homeomorphism is exactly Mathlib's named local inverse.
+The `rfl` proof relies on the definitional identity between `ContDiffAt.localInverse` and the
+inverse of `ContDiffAt.toOpenPartialHomeomorph`; Mathlib currently has no public lemma for this
+bridge. -/
 private theorem mulInvariantLogChart_eq_localInverse [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantLogChart (I := I) (G := G) =

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -176,7 +176,10 @@ theorem mulInvariantLogChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 theorem mulInvariantLogChart_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantLogChart (I := I) (G := G)
-      (extChartAt I (1 : G) (1 : G)) = 0 := by
+      (I (chartAt H (1 : G) (1 : G))) = 0 := by
+  have hcoord := congrFun (extChartAt_coe (I := I) (1 : G)) (1 : G)
+  simp only [Function.comp_apply] at hcoord
+  rw [← hcoord]
   rw [← mulInvariantExpChart_zero (I := I) (G := G)]
   exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).left_inv
     zero_mem_mulInvariantExpOpenPartialHomeomorph_source
@@ -360,7 +363,8 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
     (contDiffAt_mulInvariantLogChart_one (I := I) (G := G)).continuousAt.comp
       (continuousAt_extChartAt (I := I) (1 : G))
   have hlogOne : L (extChartAt I (1 : G) (1 : G)) = 0 := by
-    exact mulInvariantLogChart_one (I := I) (G := G)
+    simpa only [L, extChartAt_coe, Function.comp_apply] using
+      mulInvariantLogChart_one (I := I) (G := G)
   have hexpCont : ContinuousAt
       (fun g : G => mulInvariantExp (I := I) (G := G)
         (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G)) 1 :=

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -312,10 +312,13 @@ theorem lieLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     lieLog (I := I) (G := G) (1 : G) = 0 := by
   rw [lieLog_eq]
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`, so the linear equivalence can
+  -- consume the model-space presentation of `mulInvariantLog`.
   change (leftInvariantDerivationLinearIsometryEquivModelVectorSpace
     (I := I) (G := G)).symm
       (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0
   have hlog : (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0 := by
+    -- Return across the same definitional identification to reuse the group-valued zero theorem.
     change mulInvariantLog (I := I) (G := G) (1 : G) =
       (0 : GroupLieAlgebra I G)
     exact mulInvariantLog_one (I := I) (G := G)
@@ -337,6 +340,8 @@ theorem eventually_lieLog_lieExp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
   filter_upwards [h] with X hX
   rw [lieLog_eq, lieExp_eq_mulInvariantExp]
   rw [← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply]
+  -- `GroupLieAlgebra I G` is definitionally `E`; expose that identification around the two
+  -- mutually inverse linear equivalences.
   change L.symm (show E from mulInvariantLog (I := I) (G := G)
     (mulInvariantExp (I := I) (G := G) (L X : GroupLieAlgebra I G))) = X
   rw [hX, L.symm_apply_apply]
@@ -396,6 +401,7 @@ theorem eventually_lieExp_lieLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
   intro g hg
   rw [lieLog_eq, lieExp_eq_mulInvariantExp]
   rw [← leftInvariantDerivationLinearIsometryEquivModelVectorSpace_apply]
+  -- `GroupLieAlgebra I G` is definitionally `E`; expose it so `L.apply_symm_apply` applies.
   change mulInvariantExp (I := I) (G := G)
     (L (L.symm (show E from mulInvariantLog (I := I) (G := G) g)) :
       GroupLieAlgebra I G) = g
@@ -501,12 +507,14 @@ theorem isLocalDiffeomorphAt_lieExp_zero (n : ℕ) [FiniteDimensional ℝ E]
       (lieExp (I := I) (G := G)) 0 := by
   let f : LeftInvariantDerivation I G → G := lieExp (I := I) (G := G)
   let g : G → LeftInvariantDerivation I G := lieLog (I := I) (G := G)
+  -- First choose neighborhoods on which the two germ-level inverse laws hold pointwise.
   have hgf : ∀ᶠ X in 𝓝 (0 : LeftInvariantDerivation I G), g (f X) = X := by
     simpa only [f, g] using eventually_lieLog_lieExp (I := I) (G := G)
   have hfg : ∀ᶠ y in 𝓝 (1 : G), f (g y) = y := by
     simpa only [f, g] using eventually_lieExp_lieLog (I := I) (G := G)
   obtain ⟨U₀, hU₀sub, hU₀open, hzeroU₀⟩ := mem_nhds_iff.mp hgf
   obtain ⟨V₀, hV₀sub, hV₀open, honeV₀⟩ := mem_nhds_iff.mp hfg
+  -- Independently choose a neighborhood on which the local logarithm is `C^n`.
   obtain ⟨W, hWopen, honeW, hgW⟩ :=
     (contMDiffAt_lieLog_one (I := I) (G := G)).contMDiffOn'
       (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
@@ -516,6 +524,9 @@ theorem isLocalDiffeomorphAt_lieExp_zero (n : ℕ) [FiniteDimensional ℝ E]
   have hf : ContMDiff
       (modelWithCornersSelf ℝ (LeftInvariantDerivation I G)) I ∞ f := by
     simpa only [f] using contMDiff_lieExp (I := I) (G := G)
+  -- Shrink the target to the common inverse-law and smoothness neighborhood. Then shrink the
+  -- source and target once more so each map lands in the other's domain; this turns the two
+  -- eventual inverse laws into the exact source/target laws required by `PartialEquiv`.
   let Vb := V₀ ∩ W
   have hVbopen : IsOpen Vb := hV₀open.inter hWopen
   have honeVb : (1 : G) ∈ Vb := ⟨honeV₀, honeW⟩
@@ -538,6 +549,7 @@ theorem isLocalDiffeomorphAt_lieExp_zero (n : ℕ) [FiniteDimensional ℝ E]
     change g 1 ∈ U
     rw [show g 1 = (0 : LeftInvariantDerivation I G) by exact lieLog_one]
     exact hzeroU
+  -- Package the restricted inverse pair, followed by its finite-order smoothness data.
   let e : PartialEquiv (LeftInvariantDerivation I G) G := {
     toFun := f
     invFun := g

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -1,0 +1,174 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+public import TauCeti.Geometry.Lie.Exponential.Derivative
+public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
+/-!
+# Local inverse of the Lie-group exponential
+
+The smooth coordinate exponential has derivative the identity at zero, so the inverse function
+theorem supplies a smooth local logarithm in model-space identity coordinates.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 0, "The exponential map".
+-/
+public section
+open Function Manifold
+open scoped ContDiff Manifold Topology
+noncomputable section
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [IsManifold I 1 G]
+local instance lieGroupMinSmoothnessLocalInverse [LieGroup I ∞ G] :
+    LieGroup I (minSmoothness ℝ 3) G := by
+  simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
+/-- The tangent-space exponential expressed in model-space identity coordinates. -/
+@[expose]
+noncomputable def mulInvariantExpModelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (v : E) : E := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  exact extChartAt I (1 : G)
+    (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))
+/-- The coordinate exponential sends zero to the identity coordinate. -/
+@[simp]
+theorem mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    mulInvariantExpModelSpace (I := I) (G := G) 0 =
+      extChartAt I (1 : G) (1 : G) := by
+  change extChartAt I (1 : G)
+    (mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G)) = _
+  rw [mulInvariantExp_zero]
+/-- The coordinate exponential is smooth at zero. -/
+theorem contDiffAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ContDiffAt ℝ ∞ (mulInvariantExpModelSpace (I := I) (G := G)) 0 := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let f : E → G := fun v =>
+    mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)
+  have hfzero : f 0 = 1 := by
+    exact mulInvariantExp_zero (I := I) (G := G)
+  have hsource : f 0 ∈ (chartAt H (1 : G)).source := by
+    rw [hfzero]
+    exact mem_chart_source H (1 : G)
+  have hsmooth := contMDiffAt_mulInvariantExp_modelSpace_zero (I := I) (G := G)
+  have hcoord :=
+    (contMDiffAt_iff_target_of_mem_source (f := f) (y := (1 : G)) hsource).mp hsmooth
+  rw [contMDiffAt_iff_contDiffAt] at hcoord
+  rw [show mulInvariantExpModelSpace (I := I) (G := G) =
+      (extChartAt I (1 : G)) ∘ f by
+    funext v
+    rw [mulInvariantExpModelSpace]
+    rfl]
+  exact hcoord.2
+/-- The coordinate exponential has derivative the identity at zero. -/
+theorem hasFDerivAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
+      (ContinuousLinearMap.id ℝ E) 0 := by
+  rw [show mulInvariantExpModelSpace (I := I) (G := G) =
+      fun v : E => extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) by
+    funext v
+    rw [mulInvariantExpModelSpace]]
+  exact hasFDerivAt_extChartAt_mulInvariantExp_zero (I := I) (G := G)
+/-- The coordinate exponential on the canonical neighborhoods selected by the inverse function
+theorem. -/
+@[expose]
+noncomputable def mulInvariantExpLocalHomeomorph [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] : OpenPartialHomeomorph E E := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let h' : HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
+      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
+    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
+  exact (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G))
+    |>.toOpenPartialHomeomorph _ h' (by simp)
+/-- The local homeomorphism agrees with the coordinate exponential. -/
+@[simp]
+theorem mulInvariantExpLocalHomeomorph_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (v : E) :
+    mulInvariantExpLocalHomeomorph (I := I) (G := G) v =
+      mulInvariantExpModelSpace (I := I) (G := G) v := by
+  unfold mulInvariantExpLocalHomeomorph
+  rfl
+
+/-- Zero belongs to the source of the local coordinate exponential. -/
+theorem zero_mem_mulInvariantExpLocalHomeomorph_source [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    0 ∈ (mulInvariantExpLocalHomeomorph (I := I) (G := G)).source := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let h' : HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
+      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
+    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
+  exact (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G))
+    |>.mem_toOpenPartialHomeomorph_source h' (by simp)
+
+/-- The identity coordinate belongs to the target of the local coordinate exponential. -/
+theorem identity_mem_mulInvariantExpLocalHomeomorph_target [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    extChartAt I (1 : G) (1 : G) ∈
+      (mulInvariantExpLocalHomeomorph (I := I) (G := G)).target := by
+  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).map_source
+    zero_mem_mulInvariantExpLocalHomeomorph_source
+
+/-- The canonical local logarithm in model-space identity coordinates. -/
+@[expose]
+noncomputable def mulInvariantLogModelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] : E → E :=
+  (mulInvariantExpLocalHomeomorph (I := I) (G := G)).symm
+
+/-- The coordinate logarithm sends the identity coordinate to zero. -/
+@[simp]
+theorem mulInvariantLogModelSpace_identity [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    mulInvariantLogModelSpace (I := I) (G := G)
+      (I (chartAt H (1 : G) (1 : G))) = 0 := by
+  change mulInvariantLogModelSpace (I := I) (G := G)
+    (extChartAt I (1 : G) (1 : G)) = 0
+  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).left_inv
+    zero_mem_mulInvariantExpLocalHomeomorph_source
+
+/-- Locally around zero, logarithm is a left inverse to the coordinate exponential. -/
+theorem eventually_mulInvariantLogModelSpace_exp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ v in 𝓝 (0 : E),
+      mulInvariantLogModelSpace (I := I) (G := G)
+        (mulInvariantExpModelSpace (I := I) (G := G) v) = v :=
+  (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_left_inverse
+    zero_mem_mulInvariantExpLocalHomeomorph_source
+
+/-- Locally around the identity coordinate, exponential is a left inverse to logarithm. -/
+theorem eventually_mulInvariantExpModelSpace_log [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ y in 𝓝 (extChartAt I (1 : G) (1 : G)),
+      mulInvariantExpModelSpace (I := I) (G := G)
+        (mulInvariantLogModelSpace (I := I) (G := G) y) = y := by
+  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_right_inverse'
+    zero_mem_mulInvariantExpLocalHomeomorph_source
+
+/-- The coordinate logarithm is smooth at the identity coordinate. -/
+theorem contDiffAt_mulInvariantLogModelSpace_identity [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
+    ContDiffAt ℝ ∞ (mulInvariantLogModelSpace (I := I) (G := G))
+      (extChartAt I (1 : G) (1 : G)) := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  change ContDiffAt ℝ ∞ φ.symm (extChartAt I (1 : G) (1 : G))
+  have hpre : φ.symm (extChartAt I (1 : G) (1 : G)) = 0 := by
+    exact mulInvariantLogModelSpace_identity (I := I) (G := G)
+  have hφ : (φ : E → E) = mulInvariantExpModelSpace (I := I) (G := G) := by
+    funext v
+    exact mulInvariantExpLocalHomeomorph_apply (I := I) (G := G) v
+  apply φ.contDiffAt_symm (f₀' := ContinuousLinearEquiv.refl ℝ E)
+    identity_mem_mulInvariantExpLocalHomeomorph_target
+  · rw [hpre, hφ]
+    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
+  · rw [hpre, hφ]
+    exact contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G)

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -19,8 +19,8 @@ tangent-space exponential.
 
 * `mulInvariantLog`: the canonical local logarithm from the group to its tangent Lie algebra.
 * `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
-* `isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero`: the coordinate exponential is a local
-  diffeomorphism at zero.
+* `isLocalDiffeomorphAt_mulInvariantExpChart_zero`: the fully charted exponential is a local
+  diffeomorphism of every finite differentiability order at zero.
 * `exists_injOn_mulInvariantExp_modelSpace`: exponential is injective near zero.
 
 ## References
@@ -39,26 +39,49 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 local instance lieGroupMinSmoothnessLocalInverse [LieGroup I ∞ G] :
     LieGroup I (minSmoothness ℝ 3) G := by
   simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
-/-- The tangent-space exponential expressed in model-space identity coordinates. -/
-@[expose]
-noncomputable def mulInvariantExpModelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+/-- The tangent-space exponential with both domain and codomain expressed in identity-chart
+coordinates. -/
+noncomputable def mulInvariantExpChart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (v : E) : E := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   exact extChartAt I (1 : G)
     (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))
+
+/-- The fully charted exponential is the identity chart applied to the tangent-space
+exponential. -/
+theorem mulInvariantExpChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (v : E) :
+    mulInvariantExpChart (I := I) (G := G) v =
+      extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) := by
+  rfl
+
+/-- The fully charted exponential as a composition, for rewriting under higher-order
+predicates. -/
+theorem mulInvariantExpChart_eq [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    mulInvariantExpChart (I := I) (G := G) = fun v : E =>
+      extChartAt I (1 : G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) := by
+  funext v
+  exact mulInvariantExpChart_apply (I := I) (G := G) v
+
 /-- The coordinate exponential sends zero to the identity coordinate. -/
 @[simp]
-theorem mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem mulInvariantExpChart_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
-    mulInvariantExpModelSpace (I := I) (G := G) 0 =
+    mulInvariantExpChart (I := I) (G := G) 0 =
       extChartAt I (1 : G) (1 : G) := by
+  rw [mulInvariantExpChart_apply]
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`.
   change extChartAt I (1 : G)
     (mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G)) = _
   rw [mulInvariantExp_zero]
+
 /-- The coordinate exponential is smooth at zero. -/
-theorem contDiffAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem contDiffAt_mulInvariantExpChart_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
-    ContDiffAt ℝ ∞ (mulInvariantExpModelSpace (I := I) (G := G)) 0 := by
+    ContDiffAt ℝ ∞ (mulInvariantExpChart (I := I) (G := G)) 0 := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   let f : E → G := fun v =>
     mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)
@@ -71,40 +94,40 @@ theorem contDiffAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [Lie
   have hcoord :=
     (contMDiffAt_iff_target_of_mem_source (f := f) (y := (1 : G)) hsource).mp hsmooth
   rw [contMDiffAt_iff_contDiffAt] at hcoord
-  rw [show mulInvariantExpModelSpace (I := I) (G := G) =
-      (extChartAt I (1 : G)) ∘ f by
-    funext v
-    rw [mulInvariantExpModelSpace]
-    rfl]
+  rw [mulInvariantExpChart_eq]
   exact hcoord.2
+
 /-- The coordinate exponential has derivative the identity at zero. -/
-theorem hasFDerivAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem hasFDerivAt_mulInvariantExpChart_zero [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
-    HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
+    HasFDerivAt (mulInvariantExpChart (I := I) (G := G))
       (ContinuousLinearMap.id ℝ E) 0 := by
-  rw [show mulInvariantExpModelSpace (I := I) (G := G) =
-      fun v : E => extChartAt I (1 : G)
-        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) by
-    funext v
-    rw [mulInvariantExpModelSpace]]
+  rw [mulInvariantExpChart_eq]
   exact hasFDerivAt_extChartAt_mulInvariantExp_zero (I := I) (G := G)
-/-- The coordinate exponential on the canonical neighborhoods selected by the inverse function
+
+/-- The derivative of the fully charted exponential at zero, packaged as a continuous linear
+equivalence for the inverse function theorem. -/
+theorem hasFDerivAt_mulInvariantExpChart_zero_equiv [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    HasFDerivAt (mulInvariantExpChart (I := I) (G := G))
+      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
+  simpa using hasFDerivAt_mulInvariantExpChart_zero (I := I) (G := G)
+
+/-- The fully charted exponential on the canonical neighborhoods selected by the inverse function
 theorem. -/
-@[expose]
 noncomputable def mulInvariantExpLocalHomeomorph [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : OpenPartialHomeomorph E E := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  let h' : HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
-      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
-    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
-  exact (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G))
-    |>.toOpenPartialHomeomorph _ h' (by simp)
+  exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G))
+    |>.toOpenPartialHomeomorph _
+      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp)
+
 /-- The local homeomorphism agrees with the coordinate exponential. -/
 @[simp]
 theorem mulInvariantExpLocalHomeomorph_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (v : E) :
     mulInvariantExpLocalHomeomorph (I := I) (G := G) v =
-      mulInvariantExpModelSpace (I := I) (G := G) v := by
+      mulInvariantExpChart (I := I) (G := G) v := by
   unfold mulInvariantExpLocalHomeomorph
   rfl
 
@@ -113,91 +136,90 @@ theorem zero_mem_mulInvariantExpLocalHomeomorph_source [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     0 ∈ (mulInvariantExpLocalHomeomorph (I := I) (G := G)).source := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  let h' : HasFDerivAt (mulInvariantExpModelSpace (I := I) (G := G))
-      ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
-    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
-  exact (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G))
-    |>.mem_toOpenPartialHomeomorph_source h' (by simp)
+  exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G))
+    |>.mem_toOpenPartialHomeomorph_source
+      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp)
 
 /-- The identity coordinate belongs to the target of the local coordinate exponential. -/
 theorem identity_mem_mulInvariantExpLocalHomeomorph_target [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     extChartAt I (1 : G) (1 : G) ∈
       (mulInvariantExpLocalHomeomorph (I := I) (G := G)).target := by
-  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+  rw [← mulInvariantExpChart_zero (I := I) (G := G)]
   exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).map_source
     zero_mem_mulInvariantExpLocalHomeomorph_source
 
-/-- The canonical local logarithm in model-space identity coordinates. -/
-@[expose]
-noncomputable def mulInvariantLogModelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+/-- The canonical local logarithm with both domain and codomain in identity-chart coordinates. -/
+noncomputable def mulInvariantLogChart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : E → E :=
   (mulInvariantExpLocalHomeomorph (I := I) (G := G)).symm
 
+/-- The fully charted logarithm is the inverse of the canonical local homeomorphism. -/
+theorem mulInvariantLogChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (y : E) :
+    mulInvariantLogChart (I := I) (G := G) y =
+      (mulInvariantExpLocalHomeomorph (I := I) (G := G)).symm y := by
+  rfl
+
 /-- The coordinate logarithm sends the identity coordinate to zero. -/
 @[simp]
-theorem mulInvariantLogModelSpace_identity [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem mulInvariantLogChart_identity [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
-    mulInvariantLogModelSpace (I := I) (G := G)
+    mulInvariantLogChart (I := I) (G := G)
       (I (chartAt H (1 : G) (1 : G))) = 0 := by
-  change mulInvariantLogModelSpace (I := I) (G := G)
-    (extChartAt I (1 : G) (1 : G)) = 0
-  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+  have hcoord := congrFun (extChartAt_coe (I := I) (1 : G)) (1 : G)
+  simp only [Function.comp_apply] at hcoord
+  rw [← hcoord]
+  rw [← mulInvariantExpChart_zero (I := I) (G := G)]
   exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).left_inv
     zero_mem_mulInvariantExpLocalHomeomorph_source
 
 /-- Locally around zero, logarithm is a left inverse to the coordinate exponential. -/
-theorem eventually_mulInvariantLogModelSpace_exp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem eventually_mulInvariantLogChart_exp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     ∀ᶠ v in 𝓝 (0 : E),
-      mulInvariantLogModelSpace (I := I) (G := G)
-        (mulInvariantExpModelSpace (I := I) (G := G) v) = v :=
+      mulInvariantLogChart (I := I) (G := G)
+        (mulInvariantExpChart (I := I) (G := G) v) = v :=
   (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_left_inverse
     zero_mem_mulInvariantExpLocalHomeomorph_source
 
 /-- Locally around the identity coordinate, exponential is a left inverse to logarithm. -/
-theorem eventually_mulInvariantExpModelSpace_log [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem eventually_mulInvariantExpChart_log [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     ∀ᶠ y in 𝓝 (extChartAt I (1 : G) (1 : G)),
-      mulInvariantExpModelSpace (I := I) (G := G)
-        (mulInvariantLogModelSpace (I := I) (G := G) y) = y := by
-  rw [← mulInvariantExpModelSpace_zero (I := I) (G := G)]
+      mulInvariantExpChart (I := I) (G := G)
+        (mulInvariantLogChart (I := I) (G := G) y) = y := by
+  rw [← mulInvariantExpChart_zero (I := I) (G := G)]
   exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_right_inverse'
     zero_mem_mulInvariantExpLocalHomeomorph_source
 
 /-- The coordinate logarithm is smooth at the identity coordinate. -/
-theorem contDiffAt_mulInvariantLogModelSpace_identity [FiniteDimensional ℝ E]
+theorem contDiffAt_mulInvariantLogChart_identity [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
-    ContDiffAt ℝ ∞ (mulInvariantLogModelSpace (I := I) (G := G))
+    ContDiffAt ℝ ∞ (mulInvariantLogChart (I := I) (G := G))
       (extChartAt I (1 : G) (1 : G)) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
-  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
-  change ContDiffAt ℝ ∞ φ.symm (extChartAt I (1 : G) (1 : G))
-  have hpre : φ.symm (extChartAt I (1 : G) (1 : G)) = 0 := by
-    exact mulInvariantLogModelSpace_identity (I := I) (G := G)
-  have hφ : (φ : E → E) = mulInvariantExpModelSpace (I := I) (G := G) := by
-    funext v
-    exact mulInvariantExpLocalHomeomorph_apply (I := I) (G := G) v
-  apply φ.contDiffAt_symm (f₀' := ContinuousLinearEquiv.refl ℝ E)
-    identity_mem_mulInvariantExpLocalHomeomorph_target
-  · rw [hpre, hφ]
-    simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
-  · rw [hpre, hφ]
-    exact contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
+  let hf := contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)
+  unfold mulInvariantLogChart mulInvariantExpLocalHomeomorph
+  convert hf.to_localInverse
+    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp) using 1 <;>
+    simp only [ContDiffAt.localInverse, ContDiffAt.toOpenPartialHomeomorph,
+      HasStrictFDerivAt.localInverse, mulInvariantExpChart_zero]
 
 /-- The local logarithm of a group element, valued in the tangent Lie algebra at the identity. It
 is the coordinate logarithm transported back from the manifold model space. -/
 noncomputable def mulInvariantLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (g : G) : GroupLieAlgebra I G := by
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`.
   change E
-  exact mulInvariantLogModelSpace (I := I) (G := G) (extChartAt I (1 : G) g)
+  exact mulInvariantLogChart (I := I) (G := G) (extChartAt I (1 : G) g)
 
 /-- The group-level local logarithm is the coordinate logarithm after applying the identity
 chart. -/
-theorem mulInvariantLog_eq_modelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem mulInvariantLog_eq_chart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (g : G) :
     (show E from mulInvariantLog (I := I) (G := G) g) =
-      mulInvariantLogModelSpace (I := I) (G := G) (extChartAt I (1 : G) g) := by
+      mulInvariantLogChart (I := I) (G := G) (extChartAt I (1 : G) g) := by
   rfl
 
 /-- The local logarithm sends the group identity to the zero tangent vector. -/
@@ -205,11 +227,11 @@ theorem mulInvariantLog_eq_modelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ 
 theorem mulInvariantLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantLog (I := I) (G := G) (1 : G) = 0 := by
+  -- `GroupLieAlgebra I G` is definitionally the model space `E`; the bridge lemma below then
+  -- performs the substantive rewrite.
   change (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0
-  rw [mulInvariantLog_eq_modelSpace]
-  change mulInvariantLogModelSpace (I := I) (G := G)
-    (I (chartAt H (1 : G) (1 : G))) = 0
-  exact mulInvariantLogModelSpace_identity (I := I) (G := G)
+  rw [mulInvariantLog_eq_chart]
+  exact mulInvariantLogChart_identity (I := I) (G := G)
 
 /-- Locally around the identity, exponentiating the local logarithm recovers the original group
 element. -/
@@ -217,20 +239,19 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
     [T2Space G] [BoundarylessManifold I G] :
     ∀ᶠ g in 𝓝 (1 : G),
       mulInvariantExp (I := I) (G := G) (mulInvariantLog (I := I) (G := G) g) = g := by
-  let F : E → E := mulInvariantExpModelSpace (I := I) (G := G)
-  let L : E → E := mulInvariantLogModelSpace (I := I) (G := G)
+  let F : E → E := mulInvariantExpChart (I := I) (G := G)
+  let L : E → E := mulInvariantLogChart (I := I) (G := G)
   have hFL : ∀ᶠ y in 𝓝 (extChartAt I (1 : G) (1 : G)), F (L y) = y := by
-    simpa only [F, L] using eventually_mulInvariantExpModelSpace_log (I := I) (G := G)
+    simpa only [F, L] using eventually_mulInvariantExpChart_log (I := I) (G := G)
   have hchartFL : ∀ᶠ g in 𝓝 (1 : G), F (L (extChartAt I (1 : G) g)) =
       extChartAt I (1 : G) g :=
     (continuousAt_extChartAt (I := I) (1 : G)).tendsto.eventually hFL
   have hlogCont : ContinuousAt (fun g : G => L (extChartAt I (1 : G) g)) 1 :=
-    (contDiffAt_mulInvariantLogModelSpace_identity (I := I) (G := G)).continuousAt.comp
+    (contDiffAt_mulInvariantLogChart_identity (I := I) (G := G)).continuousAt.comp
       (continuousAt_extChartAt (I := I) (1 : G))
   have hlogOne : L (extChartAt I (1 : G) (1 : G)) = 0 := by
-    change mulInvariantLogModelSpace (I := I) (G := G)
-      (I (chartAt H (1 : G) (1 : G))) = 0
-    exact mulInvariantLogModelSpace_identity (I := I) (G := G)
+    simpa only [L, extChartAt_coe, Function.comp_apply] using
+      mulInvariantLogChart_identity (I := I) (G := G)
   have hexpCont : ContinuousAt
       (fun g : G => mulInvariantExp (I := I) (G := G)
         (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G)) 1 :=
@@ -240,7 +261,6 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
       mulInvariantExp (I := I) (G := G)
         (L (extChartAt I (1 : G) (1 : G)) : GroupLieAlgebra I G) = (1 : G) := by
     rw [hlogOne]
-    change mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G) = 1
     exact mulInvariantExp_zero (I := I) (G := G)
   have hexpSource : ∀ᶠ g in 𝓝 (1 : G),
       mulInvariantExp (I := I) (G := G)
@@ -250,11 +270,12 @@ theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞
       (by simpa only [hexpOne] using extChartAt_source_mem_nhds (I := I) (1 : G))
   filter_upwards [hchartFL, hexpSource,
     extChartAt_source_mem_nhds (I := I) (1 : G)] with g hcoord hexp hg
-  rw [mulInvariantLog]
+  -- Pass through the named group-to-chart bridge before comparing identity-chart coordinates.
   change mulInvariantExp (I := I) (G := G)
-    (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G) = g
-  apply (extChartAt I (1 : G)).injOn hexp hg
-  simpa only [F, mulInvariantExpModelSpace] using hcoord
+    (show E from mulInvariantLog (I := I) (G := G) g) = g
+  rw [mulInvariantLog_eq_chart]
+  apply (extChartAt I (1 : G)).injOn (by simpa only [L] using hexp) hg
+  simpa only [F, L, mulInvariantExpChart_apply] using hcoord
 
 /-- In model-space coordinates, the tangent-space exponential is injective on a neighborhood of
 zero. -/
@@ -270,38 +291,44 @@ theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGr
   rw [mulInvariantExpLocalHomeomorph_apply, mulInvariantExpLocalHomeomorph_apply]
   exact congrArg (extChartAt I (1 : G)) hxy
 
-/-- The coordinate exponential is a `C¹` local diffeomorphism at zero. Together with
-`contMDiff_mulInvariantExp` and `contDiffAt_mulInvariantLogModelSpace_identity`, this packages the
-local-diffeomorphism conclusion of the inverse function theorem for the smooth exponential. -/
-theorem isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E]
+/-- The fully charted exponential is a local diffeomorphism of every finite differentiability
+order at zero. Together with `contMDiff_mulInvariantExp` and
+`contDiffAt_mulInvariantLogChart_identity`, this packages the smooth inverse-function-theorem
+conclusion available from Mathlib's finite-order local-neighborhood API. -/
+theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensional ℝ E]
     [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
-    IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) 1
-      (mulInvariantExpModelSpace (I := I) (G := G)) 0 := by
+    IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) (n : ℕ∞ω)
+      (mulInvariantExpChart (I := I) (G := G)) 0 := by
   let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  -- Choose neighborhoods on which the exponential and logarithm are both `C^n`.
   obtain ⟨U, hUopen, hzeroU, hFU⟩ :=
-    (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G)).contDiffOn'
-      (m := (1 : ℕ∞ω)) (by simp) (by simp)
+    (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).contDiffOn'
+      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
   obtain ⟨V, hVopen, hyV, hLV⟩ :=
-    (contDiffAt_mulInvariantLogModelSpace_identity (I := I) (G := G)).contDiffOn'
-      (m := (1 : ℕ∞ω)) (by simp) (by simp)
-  have hFU' : ContDiffOn ℝ 1 (mulInvariantExpModelSpace (I := I) (G := G)) U := by
+    (contDiffAt_mulInvariantLogChart_identity (I := I) (G := G)).contDiffOn'
+      (m := (n : ℕ∞ω)) (by exact_mod_cast le_top) (by simp)
+  have hFU' : ContDiffOn ℝ n (mulInvariantExpChart (I := I) (G := G)) U := by
     simpa using hFU
-  have hLV' : ContDiffOn ℝ 1 (mulInvariantLogModelSpace (I := I) (G := G)) V := by
+  have hLV' : ContDiffOn ℝ n (mulInvariantLogChart (I := I) (G := G)) V := by
     simpa using hLV
+  -- Restrict the inverse-function-theorem homeomorphism to those two neighborhoods.
   let ψ : OpenPartialHomeomorph E E :=
     (φ.restrOpen U hUopen).trans (OpenPartialHomeomorph.ofSet V hVopen)
+  have hψ_apply (x : E) : ψ x = mulInvariantExpChart (I := I) (G := G) x := by
+    exact mulInvariantExpLocalHomeomorph_apply (I := I) (G := G) x
+  have hφzeroV : φ 0 ∈ V := by
+    rw [mulInvariantExpLocalHomeomorph_apply, mulInvariantExpChart_zero]
+    exact hyV
   have hzeroψ : (0 : E) ∈ ψ.source := by
     rw [OpenPartialHomeomorph.trans_source]
     refine ⟨?_, ?_⟩
     · rw [OpenPartialHomeomorph.restrOpen_source]
       exact ⟨zero_mem_mulInvariantExpLocalHomeomorph_source (I := I) (G := G), hzeroU⟩
-    · change φ 0 ∈ V
-      rw [mulInvariantExpLocalHomeomorph_apply,
-        mulInvariantExpModelSpace_zero]
-      exact hyV
+    · exact hφzeroV
+  -- Give the restricted homeomorphism the public coordinate exponential as its forward map.
   let ψe : PartialEquiv E E := {
-    toFun := mulInvariantExpModelSpace (I := I) (G := G)
+    toFun := mulInvariantExpChart (I := I) (G := G)
     invFun := ψ.symm
     source := ψ.source
     target := ψ.target
@@ -313,14 +340,15 @@ theorem isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero [FiniteDimensional �
       exact ψ.map_target hx
     left_inv' := by
       intro x hx
-      change ψ.symm (ψ x) = x
+      rw [← hψ_apply]
       exact ψ.left_inv hx
     right_inv' := by
       intro x hx
-      change ψ (ψ.symm x) = x
+      rw [← hψ_apply]
       exact ψ.right_inv hx
   }
-  let ψd : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E 1 := {
+  -- Attach the two finite-order smoothness proofs to obtain the partial diffeomorphism.
+  let ψd : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E n := {
     toPartialEquiv := ψe
     open_source := ψ.open_source
     open_target := ψ.open_target
@@ -337,4 +365,4 @@ theorem isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero [FiniteDimensional �
       rw [OpenPartialHomeomorph.trans_target] at hy
       exact hy.1
   }
-  exact ψd.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) 1 hzeroψ
+  exact ψd.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) n hzeroψ

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -5,11 +5,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 public import TauCeti.Geometry.Lie.Exponential.Derivative
 public import Mathlib.Analysis.Calculus.InverseFunctionTheorem.ContDiff
+public import Mathlib.Geometry.Manifold.LocalDiffeomorph
 /-!
 # Local inverse of the Lie-group exponential
 
 The smooth coordinate exponential has derivative the identity at zero, so the inverse function
 theorem supplies a smooth local logarithm in model-space identity coordinates.
+
+Transporting that logarithm through the identity chart gives a group-level local inverse for the
+tangent-space exponential.
+
+## Main results
+
+* `mulInvariantLog`: the canonical local logarithm from the group to its tangent Lie algebra.
+* `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
+* `isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero`: the coordinate exponential is a local
+  diffeomorphism at zero.
+* `exists_injOn_mulInvariantExp_modelSpace`: exponential is injective near zero.
 
 ## References
 
@@ -172,3 +184,157 @@ theorem contDiffAt_mulInvariantLogModelSpace_identity [FiniteDimensional ℝ E]
     simpa using hasFDerivAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
   · rw [hpre, hφ]
     exact contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G)
+
+/-- The local logarithm of a group element, valued in the tangent Lie algebra at the identity. It
+is the coordinate logarithm transported back from the manifold model space. -/
+noncomputable def mulInvariantLog [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (g : G) : GroupLieAlgebra I G := by
+  change E
+  exact mulInvariantLogModelSpace (I := I) (G := G) (extChartAt I (1 : G) g)
+
+/-- The group-level local logarithm is the coordinate logarithm after applying the identity
+chart. -/
+theorem mulInvariantLog_eq_modelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] (g : G) :
+    (show E from mulInvariantLog (I := I) (G := G) g) =
+      mulInvariantLogModelSpace (I := I) (G := G) (extChartAt I (1 : G) g) := by
+  rfl
+
+/-- The local logarithm sends the group identity to the zero tangent vector. -/
+@[simp]
+theorem mulInvariantLog_one [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    mulInvariantLog (I := I) (G := G) (1 : G) = 0 := by
+  change (show E from mulInvariantLog (I := I) (G := G) (1 : G)) = 0
+  rw [mulInvariantLog_eq_modelSpace]
+  change mulInvariantLogModelSpace (I := I) (G := G)
+    (I (chartAt H (1 : G) (1 : G))) = 0
+  exact mulInvariantLogModelSpace_identity (I := I) (G := G)
+
+/-- Locally around the identity, exponentiating the local logarithm recovers the original group
+element. -/
+theorem eventually_mulInvariantExp_log [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ g in 𝓝 (1 : G),
+      mulInvariantExp (I := I) (G := G) (mulInvariantLog (I := I) (G := G) g) = g := by
+  let F : E → E := mulInvariantExpModelSpace (I := I) (G := G)
+  let L : E → E := mulInvariantLogModelSpace (I := I) (G := G)
+  have hFL : ∀ᶠ y in 𝓝 (extChartAt I (1 : G) (1 : G)), F (L y) = y := by
+    simpa only [F, L] using eventually_mulInvariantExpModelSpace_log (I := I) (G := G)
+  have hchartFL : ∀ᶠ g in 𝓝 (1 : G), F (L (extChartAt I (1 : G) g)) =
+      extChartAt I (1 : G) g :=
+    (continuousAt_extChartAt (I := I) (1 : G)).tendsto.eventually hFL
+  have hlogCont : ContinuousAt (fun g : G => L (extChartAt I (1 : G) g)) 1 :=
+    (contDiffAt_mulInvariantLogModelSpace_identity (I := I) (G := G)).continuousAt.comp
+      (continuousAt_extChartAt (I := I) (1 : G))
+  have hlogOne : L (extChartAt I (1 : G) (1 : G)) = 0 := by
+    change mulInvariantLogModelSpace (I := I) (G := G)
+      (I (chartAt H (1 : G) (1 : G))) = 0
+    exact mulInvariantLogModelSpace_identity (I := I) (G := G)
+  have hexpCont : ContinuousAt
+      (fun g : G => mulInvariantExp (I := I) (G := G)
+        (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G)) 1 :=
+    (continuousAt_mulInvariantExp_modelSpace_zero (I := I) (G := G)).comp_of_eq
+      hlogCont hlogOne
+  have hexpOne :
+      mulInvariantExp (I := I) (G := G)
+        (L (extChartAt I (1 : G) (1 : G)) : GroupLieAlgebra I G) = (1 : G) := by
+    rw [hlogOne]
+    change mulInvariantExp (I := I) (G := G) (0 : GroupLieAlgebra I G) = 1
+    exact mulInvariantExp_zero (I := I) (G := G)
+  have hexpSource : ∀ᶠ g in 𝓝 (1 : G),
+      mulInvariantExp (I := I) (G := G)
+          (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G) ∈
+        (extChartAt I (1 : G)).source :=
+    hexpCont.preimage_mem_nhds
+      (by simpa only [hexpOne] using extChartAt_source_mem_nhds (I := I) (1 : G))
+  filter_upwards [hchartFL, hexpSource,
+    extChartAt_source_mem_nhds (I := I) (1 : G)] with g hcoord hexp hg
+  rw [mulInvariantLog]
+  change mulInvariantExp (I := I) (G := G)
+    (L (extChartAt I (1 : G) g) : GroupLieAlgebra I G) = g
+  apply (extChartAt I (1 : G)).injOn hexp hg
+  simpa only [F, mulInvariantExpModelSpace] using hcoord
+
+/-- In model-space coordinates, the tangent-space exponential is injective on a neighborhood of
+zero. -/
+theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∃ U ∈ 𝓝 (0 : E), Set.InjOn
+      (fun v : E => mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) U := by
+  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  refine ⟨φ.source, φ.open_source.mem_nhds
+    zero_mem_mulInvariantExpLocalHomeomorph_source, ?_⟩
+  intro x hx y hy hxy
+  apply φ.injOn hx hy
+  rw [mulInvariantExpLocalHomeomorph_apply, mulInvariantExpLocalHomeomorph_apply]
+  exact congrArg (extChartAt I (1 : G)) hxy
+
+/-- The coordinate exponential is a `C¹` local diffeomorphism at zero. Together with
+`contMDiff_mulInvariantExp` and `contDiffAt_mulInvariantLogModelSpace_identity`, this packages the
+local-diffeomorphism conclusion of the inverse function theorem for the smooth exponential. -/
+theorem isLocalDiffeomorphAt_mulInvariantExpModelSpace_zero [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) 1
+      (mulInvariantExpModelSpace (I := I) (G := G)) 0 := by
+  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  obtain ⟨U, hUopen, hzeroU, hFU⟩ :=
+    (contDiffAt_mulInvariantExpModelSpace_zero (I := I) (G := G)).contDiffOn'
+      (m := (1 : ℕ∞ω)) (by simp) (by simp)
+  obtain ⟨V, hVopen, hyV, hLV⟩ :=
+    (contDiffAt_mulInvariantLogModelSpace_identity (I := I) (G := G)).contDiffOn'
+      (m := (1 : ℕ∞ω)) (by simp) (by simp)
+  have hFU' : ContDiffOn ℝ 1 (mulInvariantExpModelSpace (I := I) (G := G)) U := by
+    simpa using hFU
+  have hLV' : ContDiffOn ℝ 1 (mulInvariantLogModelSpace (I := I) (G := G)) V := by
+    simpa using hLV
+  let ψ : OpenPartialHomeomorph E E :=
+    (φ.restrOpen U hUopen).trans (OpenPartialHomeomorph.ofSet V hVopen)
+  have hzeroψ : (0 : E) ∈ ψ.source := by
+    rw [OpenPartialHomeomorph.trans_source]
+    refine ⟨?_, ?_⟩
+    · rw [OpenPartialHomeomorph.restrOpen_source]
+      exact ⟨zero_mem_mulInvariantExpLocalHomeomorph_source (I := I) (G := G), hzeroU⟩
+    · change φ 0 ∈ V
+      rw [mulInvariantExpLocalHomeomorph_apply,
+        mulInvariantExpModelSpace_zero]
+      exact hyV
+  let ψe : PartialEquiv E E := {
+    toFun := mulInvariantExpModelSpace (I := I) (G := G)
+    invFun := ψ.symm
+    source := ψ.source
+    target := ψ.target
+    map_source' := by
+      intro x hx
+      exact ψ.map_source hx
+    map_target' := by
+      intro x hx
+      exact ψ.map_target hx
+    left_inv' := by
+      intro x hx
+      change ψ.symm (ψ x) = x
+      exact ψ.left_inv hx
+    right_inv' := by
+      intro x hx
+      change ψ (ψ.symm x) = x
+      exact ψ.right_inv hx
+  }
+  let ψd : PartialDiffeomorph 𝓘(ℝ, E) 𝓘(ℝ, E) E E 1 := {
+    toPartialEquiv := ψe
+    open_source := ψ.open_source
+    open_target := ψ.open_target
+    contMDiffOn_toFun := by
+      rw [contMDiffOn_iff_contDiffOn]
+      apply hFU'.mono
+      intro v hv
+      rw [OpenPartialHomeomorph.trans_source] at hv
+      exact hv.1.2
+    contMDiffOn_invFun := by
+      rw [contMDiffOn_iff_contDiffOn]
+      apply hLV'.mono
+      intro y hy
+      rw [OpenPartialHomeomorph.trans_target] at hy
+      exact hy.1
+  }
+  exact ψd.isLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) 1 hzeroψ

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -19,6 +19,7 @@ tangent-space exponential.
 
 * `mulInvariantLog`: the canonical local logarithm from the group to its tangent Lie algebra.
 * `eventually_mulInvariantExp_log`: exponential followed after logarithm is locally the identity.
+* `eventually_mulInvariantLog_exp`: logarithm followed after exponential is locally the identity.
 * `isLocalDiffeomorphAt_mulInvariantExpChart_zero`: the fully charted exponential is a local
   diffeomorphism of every finite differentiability order at zero.
 * `exists_injOn_mulInvariantExp_modelSpace`: exponential is injective near zero.
@@ -39,6 +40,10 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 local instance lieGroupMinSmoothnessLocalInverse [LieGroup I ∞ G] :
     LieGroup I (minSmoothness ℝ 3) G := by
   simpa using (inferInstance : LieGroup I (3 : ℕ∞ω) G)
+
+private theorem smoothOrder_ne_zero : (∞ : ℕ∞ω) ≠ 0 := by
+  simp
+
 /-- The tangent-space exponential with both domain and codomain expressed in identity-chart
 coordinates. -/
 noncomputable def mulInvariantExpChart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
@@ -58,7 +63,7 @@ theorem mulInvariantExpChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
 /-- The fully charted exponential as a composition, for rewriting under higher-order
 predicates. -/
-theorem mulInvariantExpChart_eq [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+private theorem mulInvariantExpChart_eq [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     mulInvariantExpChart (I := I) (G := G) = fun v : E =>
       extChartAt I (1 : G)
@@ -107,7 +112,8 @@ theorem hasFDerivAt_mulInvariantExpChart_zero [FiniteDimensional ℝ E] [LieGrou
 
 /-- The derivative of the fully charted exponential at zero, packaged as a continuous linear
 equivalence for the inverse function theorem. -/
-theorem hasFDerivAt_mulInvariantExpChart_zero_equiv [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+private theorem hasFDerivAt_mulInvariantExpChart_zero_equiv [FiniteDimensional ℝ E]
+    [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] :
     HasFDerivAt (mulInvariantExpChart (I := I) (G := G))
       ((ContinuousLinearEquiv.refl ℝ E : E ≃L[ℝ] E) : E →L[ℝ] E) 0 := by
@@ -115,50 +121,64 @@ theorem hasFDerivAt_mulInvariantExpChart_zero_equiv [FiniteDimensional ℝ E] [L
 
 /-- The fully charted exponential on the canonical neighborhoods selected by the inverse function
 theorem. -/
-noncomputable def mulInvariantExpLocalHomeomorph [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+noncomputable def mulInvariantExpOpenPartialHomeomorph [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : OpenPartialHomeomorph E E := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G))
     |>.toOpenPartialHomeomorph _
-      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp)
+      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
 
 /-- The local homeomorphism agrees with the coordinate exponential. -/
 @[simp]
-theorem mulInvariantExpLocalHomeomorph_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+theorem mulInvariantExpOpenPartialHomeomorph_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (v : E) :
-    mulInvariantExpLocalHomeomorph (I := I) (G := G) v =
+    mulInvariantExpOpenPartialHomeomorph (I := I) (G := G) v =
       mulInvariantExpChart (I := I) (G := G) v := by
-  unfold mulInvariantExpLocalHomeomorph
+  unfold mulInvariantExpOpenPartialHomeomorph
   rfl
 
 /-- Zero belongs to the source of the local coordinate exponential. -/
-theorem zero_mem_mulInvariantExpLocalHomeomorph_source [FiniteDimensional ℝ E]
+theorem zero_mem_mulInvariantExpOpenPartialHomeomorph_source [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
-    0 ∈ (mulInvariantExpLocalHomeomorph (I := I) (G := G)).source := by
+    0 ∈ (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).source := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G))
     |>.mem_toOpenPartialHomeomorph_source
-      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp)
+      (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
 
 /-- The identity coordinate belongs to the target of the local coordinate exponential. -/
-theorem identity_mem_mulInvariantExpLocalHomeomorph_target [FiniteDimensional ℝ E]
+theorem identity_mem_mulInvariantExpOpenPartialHomeomorph_target [FiniteDimensional ℝ E]
     [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G] :
     extChartAt I (1 : G) (1 : G) ∈
-      (mulInvariantExpLocalHomeomorph (I := I) (G := G)).target := by
+      (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).target := by
   rw [← mulInvariantExpChart_zero (I := I) (G := G)]
-  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).map_source
-    zero_mem_mulInvariantExpLocalHomeomorph_source
+  exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).map_source
+    zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
 /-- The canonical local logarithm with both domain and codomain in identity-chart coordinates. -/
 noncomputable def mulInvariantLogChart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] : E → E :=
-  (mulInvariantExpLocalHomeomorph (I := I) (G := G)).symm
+  (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).symm
 
 /-- The fully charted logarithm is the inverse of the canonical local homeomorphism. -/
 theorem mulInvariantLogChart_apply [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     [T2Space G] [BoundarylessManifold I G] (y : E) :
     mulInvariantLogChart (I := I) (G := G) y =
-      (mulInvariantExpLocalHomeomorph (I := I) (G := G)).symm y := by
+      (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).symm y := by
+  rfl
+
+/- This private wrapper gives a stable name to Mathlib's inverse-function-theorem local inverse. -/
+private noncomputable def mulInvariantLogLocalInverse [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] : E → E := by
+  let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
+  exact (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).localInverse
+    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
+
+/- The logarithm chosen through the local homeomorphism is exactly Mathlib's named local inverse. -/
+private theorem mulInvariantLogChart_eq_localInverse [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    mulInvariantLogChart (I := I) (G := G) =
+      mulInvariantLogLocalInverse (I := I) (G := G) := by
   rfl
 
 /-- The coordinate logarithm sends the identity coordinate to zero. -/
@@ -171,8 +191,8 @@ theorem mulInvariantLogChart_identity [FiniteDimensional ℝ E] [LieGroup I ∞ 
   simp only [Function.comp_apply] at hcoord
   rw [← hcoord]
   rw [← mulInvariantExpChart_zero (I := I) (G := G)]
-  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).left_inv
-    zero_mem_mulInvariantExpLocalHomeomorph_source
+  exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).left_inv
+    zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
 /-- Locally around zero, logarithm is a left inverse to the coordinate exponential. -/
 theorem eventually_mulInvariantLogChart_exp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
@@ -180,8 +200,8 @@ theorem eventually_mulInvariantLogChart_exp [FiniteDimensional ℝ E] [LieGroup 
     ∀ᶠ v in 𝓝 (0 : E),
       mulInvariantLogChart (I := I) (G := G)
         (mulInvariantExpChart (I := I) (G := G) v) = v :=
-  (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_left_inverse
-    zero_mem_mulInvariantExpLocalHomeomorph_source
+  (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).eventually_left_inverse
+    zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
 /-- Locally around the identity coordinate, exponential is a left inverse to logarithm. -/
 theorem eventually_mulInvariantExpChart_log [FiniteDimensional ℝ E] [LieGroup I ∞ G]
@@ -190,8 +210,8 @@ theorem eventually_mulInvariantExpChart_log [FiniteDimensional ℝ E] [LieGroup 
       mulInvariantExpChart (I := I) (G := G)
         (mulInvariantLogChart (I := I) (G := G) y) = y := by
   rw [← mulInvariantExpChart_zero (I := I) (G := G)]
-  exact (mulInvariantExpLocalHomeomorph (I := I) (G := G)).eventually_right_inverse'
-    zero_mem_mulInvariantExpLocalHomeomorph_source
+  exact (mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)).eventually_right_inverse'
+    zero_mem_mulInvariantExpOpenPartialHomeomorph_source
 
 /-- The coordinate logarithm is smooth at the identity coordinate. -/
 theorem contDiffAt_mulInvariantLogChart_identity [FiniteDimensional ℝ E]
@@ -200,11 +220,10 @@ theorem contDiffAt_mulInvariantLogChart_identity [FiniteDimensional ℝ E]
       (extChartAt I (1 : G) (1 : G)) := by
   let _ : CompleteSpace E := FiniteDimensional.complete ℝ E
   let hf := contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)
-  unfold mulInvariantLogChart mulInvariantExpLocalHomeomorph
-  convert hf.to_localInverse
-    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) (by simp) using 1 <;>
-    simp only [ContDiffAt.localInverse, ContDiffAt.toOpenPartialHomeomorph,
-      HasStrictFDerivAt.localInverse, mulInvariantExpChart_zero]
+  rw [mulInvariantLogChart_eq_localInverse]
+  unfold mulInvariantLogLocalInverse
+  simpa only [mulInvariantExpChart_zero] using hf.to_localInverse
+    (hasFDerivAt_mulInvariantExpChart_zero_equiv (I := I) (G := G)) smoothOrder_ne_zero
 
 /-- The local logarithm of a group element, valued in the tangent Lie algebra at the identity. It
 is the coordinate logarithm transported back from the manifold model space. -/
@@ -221,6 +240,18 @@ theorem mulInvariantLog_eq_chart [FiniteDimensional ℝ E] [LieGroup I ∞ G]
     (show E from mulInvariantLog (I := I) (G := G) g) =
       mulInvariantLogChart (I := I) (G := G) (extChartAt I (1 : G) g) := by
   rfl
+
+/-- Locally around zero, taking the local logarithm after exponentiating recovers the original
+tangent vector. -/
+theorem eventually_mulInvariantLog_exp [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+    [T2Space G] [BoundarylessManifold I G] :
+    ∀ᶠ v in 𝓝 (0 : E),
+      (show E from mulInvariantLog (I := I) (G := G)
+        (mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G))) = v := by
+  refine (eventually_mulInvariantLogChart_exp (I := I) (G := G)).mono ?_
+  intro v hv
+  rw [mulInvariantLog_eq_chart]
+  exact hv
 
 /-- The local logarithm sends the group identity to the zero tangent vector. -/
 @[simp]
@@ -283,12 +314,12 @@ theorem exists_injOn_mulInvariantExp_modelSpace [FiniteDimensional ℝ E] [LieGr
     [T2Space G] [BoundarylessManifold I G] :
     ∃ U ∈ 𝓝 (0 : E), Set.InjOn
       (fun v : E => mulInvariantExp (I := I) (G := G) (v : GroupLieAlgebra I G)) U := by
-  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  let φ := mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)
   refine ⟨φ.source, φ.open_source.mem_nhds
-    zero_mem_mulInvariantExpLocalHomeomorph_source, ?_⟩
+    zero_mem_mulInvariantExpOpenPartialHomeomorph_source, ?_⟩
   intro x hx y hy hxy
   apply φ.injOn hx hy
-  rw [mulInvariantExpLocalHomeomorph_apply, mulInvariantExpLocalHomeomorph_apply]
+  rw [mulInvariantExpOpenPartialHomeomorph_apply, mulInvariantExpOpenPartialHomeomorph_apply]
   exact congrArg (extChartAt I (1 : G)) hxy
 
 /-- The fully charted exponential is a local diffeomorphism of every finite differentiability
@@ -300,7 +331,7 @@ theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensio
     [T2Space G] [BoundarylessManifold I G] :
     IsLocalDiffeomorphAt 𝓘(ℝ, E) 𝓘(ℝ, E) (n : ℕ∞ω)
       (mulInvariantExpChart (I := I) (G := G)) 0 := by
-  let φ := mulInvariantExpLocalHomeomorph (I := I) (G := G)
+  let φ := mulInvariantExpOpenPartialHomeomorph (I := I) (G := G)
   -- Choose neighborhoods on which the exponential and logarithm are both `C^n`.
   obtain ⟨U, hUopen, hzeroU, hFU⟩ :=
     (contDiffAt_mulInvariantExpChart_zero (I := I) (G := G)).contDiffOn'
@@ -316,15 +347,15 @@ theorem isLocalDiffeomorphAt_mulInvariantExpChart_zero (n : ℕ) [FiniteDimensio
   let ψ : OpenPartialHomeomorph E E :=
     (φ.restrOpen U hUopen).trans (OpenPartialHomeomorph.ofSet V hVopen)
   have hψ_apply (x : E) : ψ x = mulInvariantExpChart (I := I) (G := G) x := by
-    exact mulInvariantExpLocalHomeomorph_apply (I := I) (G := G) x
+    exact mulInvariantExpOpenPartialHomeomorph_apply (I := I) (G := G) x
   have hφzeroV : φ 0 ∈ V := by
-    rw [mulInvariantExpLocalHomeomorph_apply, mulInvariantExpChart_zero]
+    rw [mulInvariantExpOpenPartialHomeomorph_apply, mulInvariantExpChart_zero]
     exact hyV
   have hzeroψ : (0 : E) ∈ ψ.source := by
     rw [OpenPartialHomeomorph.trans_source]
     refine ⟨?_, ?_⟩
     · rw [OpenPartialHomeomorph.restrOpen_source]
-      exact ⟨zero_mem_mulInvariantExpLocalHomeomorph_source (I := I) (G := G), hzeroU⟩
+      exact ⟨zero_mem_mulInvariantExpOpenPartialHomeomorph_source (I := I) (G := G), hzeroU⟩
     · exact hφzeroV
   -- Give the restricted homeomorphism the public coordinate exponential as its forward map.
   let ψe : PartialEquiv E E := {

--- a/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
+++ b/TauCeti/Geometry/Lie/Exponential/LocalInverse.lean
@@ -134,8 +134,7 @@ theorem mulInvariantExpOpenPartialHomeomorph_apply [FiniteDimensional ℝ E] [Li
     [T2Space G] [BoundarylessManifold I G] (v : E) :
     mulInvariantExpOpenPartialHomeomorph (I := I) (G := G) v =
       mulInvariantExpChart (I := I) (G := G) v := by
-  unfold mulInvariantExpOpenPartialHomeomorph
-  rfl
+  simp [mulInvariantExpOpenPartialHomeomorph]
 
 /-- Zero belongs to the source of the local coordinate exponential. -/
 theorem zero_mem_mulInvariantExpOpenPartialHomeomorph_source [FiniteDimensional ℝ E]


### PR DESCRIPTION
## Goal

Make the Lie-group exponential locally invertible at zero, supplying the local logarithm required by Deliverable A, Layer 0 and by the continuous one-parameter subgroup classification that follows.

## Why this establishes the goal

1. The already-merged smoothness and derivative results identify the identity-coordinate exponential as a smooth map with derivative `id` at zero. The inverse function theorem therefore supplies chosen source and target neighborhoods on which it is an open partial homeomorphism.
2. Taking that local inverse gives a smooth coordinate logarithm at the identity coordinate. Transport through the identity chart yields both a model-space presentation and the canonical `lieLog : G → LeftInvariantDerivation I G`, together with both neighborhood-filter inverse laws for `lieExp`. Values of these total logarithm functions outside the selected target neighborhood carry no logarithmic meaning.
3. Global smoothness makes the coordinate exponential's derivative continuous. Shrinking the inverse-function neighborhood to the open locus where that derivative is invertible lets the inverse-smoothness theorem apply at every point of one fixed target neighborhood, producing a genuine `C∞` partial diffeomorphism. Transport through the identity chart and the canonical Lie-algebra equivalence gives smooth local-diffeomorphism results for the charted exponential, the group-valued model-space exponential, and `lieExp` itself.

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 0 — The exponential map](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-0-the-exponential-map-and-one-parameter-subgroups) under [intention #139](https://github.com/TauCetiProject/TauCetiRoadmap/issues/139).

## Validation

- `lake build TauCeti.Geometry.Lie.Exponential.LocalInverse`
- `bash scripts/sandbox-build.sh` (6,524 build jobs; 23,243 declarations axiom-audited; 1,237 modules; 1,883/1,883 documented; no new linter violations)

Roadmap: RepresentationTheory