### PR TITLE
fix: discard the partial Lake cache before retrying a failed fetch

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -386,8 +386,13 @@ jobs:
       # Cloudflare rate-limits the public r2.dev host by design ("should only be used for
       # development purposes"), so throttled downloads (HTTP 429) make partial fetches routine.
       #
-      # Hence: retry, then fall back to no cache at all. Retries are cheap because an artifact
-      # already on disk is skipped, so each pass re-fetches only what is still missing.
+      # Hence: retry from an EMPTY cache each time, then fall back to no cache at all. Retrying
+      # over the dirty cache a failed attempt left behind does not work: Lake skips any artifact
+      # already on disk, so the retry re-fetches only what is still MISSING and never revisits
+      # what the failed attempt got wrong. It then reports clean and the corruption survives
+      # into the build. Discarding between attempts is what makes a clean verdict mean the
+      # cache is whole; it is affordable because a failing attempt aborts in seconds and a full
+      # refetch is ~30s.
       - name: Fetch TauCeti's own oleans from the Lake cache (network, no token; no PR code)
         if: ${{ env.INFRA != '1' && env.TAUCETI_CACHE_ENABLED == '1' }}
         env:
@@ -438,7 +443,11 @@ jobs:
             # `--retry 3`, so spacing the outer attempts keeps us from adding request rate to
             # an endpoint that is throttling us.
             if [ "$attempt" != 3 ]; then
-              echo "::notice::lake cache get attempt $attempt did not complete cleanly; retrying"
+              echo "::notice::lake cache get attempt $attempt did not complete cleanly; discarding the partial cache and retrying"
+              # Must precede the retry: see the step comment above. Without this, attempt N+1
+              # skips every artifact this attempt already wrote, including the broken ones, and
+              # a clean exit from it says nothing about the entries that made this attempt fail.
+              rm -rf base/.lake/cache
               sleep $(( attempt * 30 ))
             fi
           done


### PR DESCRIPTION
This PR discards the partially-populated Lake artifact cache before each `lake cache get` retry, so a clean retry verdict actually means the cache is whole.

A retry ran over the cache the failed attempt left behind. Lake skips any artifact already on disk, so the retry re-fetched only what was still *missing*, never revisited the entries that made the first attempt fail, and exited clean. The step then judged the cache whole, kept it, and the offline landrun build died unpacking a broken artifact:

```
error: no such file or directory (error code: 4294967294)
  file: .../base/.lake/cache/artifacts/0924436cc7dba396.ltar
...
✖ [4105/4163] Unpacking TauCeti.NumberTheory.Multiquadratic.CMField.Basic
error: external command '.../leantar' exited with code 1
error: build failed
```

The end-of-loop purge was written for exactly this case but could not be reached, because the laundered retry set `clean=1`. In the run above, attempt 1 failed in three seconds, the retry notice fired correctly, and attempt 2 was then judged clean with the poison still on disk.

This accounted for 16 of the last 20 merge-queue build failures. Each one evicted an otherwise-green PR from the merge queue, and since `merge-sweep` is the only thing that re-drives an evicted PR, recovery took one to three hours. #1986, #1964, #2002 and #1886 were all sitting green-and-unmerged because of it.

Retrying from an empty cache is affordable: a failing attempt aborts in seconds and a full refetch is about 30s.

🤖 Prepared with Claude Code