### PR TITLE
fix: post every commit status even when one POST fails

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -488,6 +488,37 @@ jobs:
         if: always()
         env: { GH_TOKEN: "${{ github.token }}" }
         run: |
+          # Posting the three statuses is deliberately NOT all-or-nothing. These are three
+          # sequential API calls under `set -e`: a single transient error on an early one used to
+          # abort the step and leave the commit with a partial set. A MISSING required status is
+          # worse than a red one. `build` never appears, so GitHub holds the PR at BLOCKED
+          # forever; core.derive reads no `build` status, so labels.py pins the PR at
+          # `awaiting-CI` (its ci=None branch) rather than `awaiting-author`; and nothing re-runs
+          # pr-build without a push, so no event ever corrects it. That wedged PR #1358 for seven
+          # days, invisible to both the author path and the review path.
+          #
+          # So: retry each POST, always attempt all three whatever the others did, and surface a
+          # persistent failure loudly at the end rather than silently dropping a status.
+          post_fail=0
+          post_status() {
+            local ctx="$1" st="$2" dsc="$3" attempt
+            for attempt in 1 2 3; do
+              if gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
+                   -f state="$st" -f context="$ctx" -f description="$dsc" \
+                   -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"; then
+                echo "posted $ctx=$st ($dsc) to ${{ steps.pr.outputs.status_sha }}"
+                return 0
+              fi
+              echo "::warning::posting the $ctx status failed (attempt $attempt/3)"
+              if [ "$attempt" != 3 ]; then sleep $(( attempt * 5 )); fi
+            done
+            # Never propagate the failure as a return code: that would abort this step under
+            # `set -e` and skip the statuses not yet posted, which is the bug being fixed.
+            echo "::error::could not post the $ctx status to ${{ steps.pr.outputs.status_sha }} after 3 attempts"
+            post_fail=1
+            return 0
+          }
+
           # bump-guard: this job already ran the trusted base scripts/check-bump.sh inline
           # (the "Validate the Lake-pin bump" step), so we post the required `bump-guard`
           # status from its result here rather than from a separate workflow. BUMP_BAD is set
@@ -501,10 +532,7 @@ jobs:
           else
             bg_state=success; bg_desc="validated forward Lake pin bump (or no pin change)"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
-            -f state="$bg_state" -f context="bump-guard" -f description="$bg_desc" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "posted bump-guard=$bg_state ($bg_desc) to ${{ steps.pr.outputs.status_sha }}"
+          post_status bump-guard "$bg_state" "$bg_desc"
 
           # build: the real sandboxed-build result ONLY — never a policy verdict. The build now runs even
           # for an out-of-scope PR (its TauCeti/ is overlaid onto the trusted base and built), so a red
@@ -521,10 +549,7 @@ jobs:
           else
             state=failure; desc="sandboxed build, audit, or simp-NF lint failed"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
-            -f state="$state" -f context="build" -f description="$desc" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "posted build=$state ($desc) to ${{ steps.pr.outputs.status_sha }}"
+          post_status build "$state" "$desc"
 
           # scope: the merge-policy verdict, posted as its OWN status so a policy issue never hides the
           # build result (the bug this split fixes — an out-of-scope PR used to post its "human review"
@@ -549,8 +574,12 @@ jobs:
           else
             sc_state=success; sc_desc="changes are in scope (TauCeti/ and the allowed root files only)"
           fi
-          gh api -X POST "repos/${{ github.repository }}/statuses/${{ steps.pr.outputs.status_sha }}" \
-            -f state="$sc_state" -f context="scope" -f description="$sc_desc" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          echo "posted scope=$sc_state ($sc_desc) to ${{ steps.pr.outputs.status_sha }}"
+          post_status scope "$sc_state" "$sc_desc"
+
+          # A status we could not post leaves the commit in the wedged state described above, so
+          # fail the job loudly. This runs only after all three have been attempted.
+          if [ "$post_fail" = 1 ]; then
+            echo "::error::one or more commit statuses are missing; re-run pr-build for this commit"
+            exit 1
+          fi
           [ "$state" = "success" ]


### PR DESCRIPTION
This PR retries each commit-status POST and always attempts all three, so a transient API error can no longer leave a PR head with a partial status set.

`bump-guard`, `build` and `scope` were three sequential `gh api` calls in a single `set -e` block with no retry. One failure aborted the step and dropped every status after it.

PR #1358 hit exactly that. From its run log:

```
06:59:00.57  posted bump-guard=success ... to d9681380...
06:59:01.56  ##[error]Process completed with exit code 1.
```

One second apart, and no `posted build=` line ever appears. Its head commit carries `bump-guard` and nothing else, seven days later.

A missing required status is worse than a red one. GitHub holds the PR at `BLOCKED` because `build` never arrives; `core.derive` reads no `build` status, so `labels.py` takes its `ci=None` branch and pins the PR at `awaiting-CI` rather than moving it to `awaiting-author`; and nothing re-runs pr-build without a push, so no event ever corrects it. The PR was invisible to both the author path and the review path for a week.

The three statuses are now posted through a helper that retries three times with backoff, never propagates its failure as a return code (which is what skipped the later statuses), and records a flag. The step fails loudly at the end if any status is still missing, after all three have been attempted.

Verified by extracting the step and running it against a mocked `gh`: with the `build` POST failing permanently, `scope` is still posted and the step exits 1 with an explicit error; with all POSTs succeeding, a green build exits 0, a red build exits 1, and an out-of-scope PR posts `build=success` alongside `scope=failure` as before.

🤖 Prepared with Claude Code