### PR TITLE
feat: alert on the stuck states the watchdog could not see

### DIFF
--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -37,6 +37,16 @@ Detectors (each names the infra failure it implies):
   7. stale-fkb       An open first-known-bad issue (label `dependency-incompatibility`)
                      has been open past a grace window. A regression against TauCeti
                      nobody has landed the fix for.
+  8. eviction-loop   The merge queue has accepted and evicted the same green PR
+                     repeatedly. One eviction looks like nothing (merge-sweep just
+                     re-enqueues), so only the count reveals a broken merge-group
+                     build, e.g. a flaky cache.
+  9. missing-status  A concluded pr-build left an open PR's head with no `build`
+                     status. The PR is BLOCKED forever and its label is pinned at
+                     `awaiting-CI`; nothing re-runs pr-build without a push.
+ 10. diverged-head   A PR's recorded head is not its branch tip, so GitHub never
+                     recomputes mergeability and it sits at `mergeable: null`,
+                     invisible to every mergeability-gated path.
 
 Deliberately NOT alerted (normal backlog, not stuck automation -- alerting on
 these would cheapen the topic and train people to ignore it):
@@ -120,6 +130,12 @@ MARKER_RE = re.compile(r"<!--stuck:v1 (" + KEY_RE.pattern + r")-->\s*\Z")
 BUMP_STUCK_HOURS = 24
 PIN_STALE_DAYS = 4
 STRANDED_HOURS = 6
+# Evictions at the current head, within the window, before a bounce counts as a loop.
+EVICTION_LOOP_MIN = 2
+EVICTION_WINDOW_HOURS = 24
+# How long a concluded pr-build may leave its head without a `build` status before that is
+# a wedge rather than a race between the run finishing and the status landing.
+MISSING_STATUS_HOURS = 0.5
 FKB_STALE_DAYS = 3
 SCHEDULERS = {
     # workflow file            (human name,               max age hours)
@@ -267,6 +283,142 @@ def is_automerge_scope(files):
     return all(path.startswith("TauCeti/") or path in allowed_roots for path in files)
 
 
+def open_prs():
+    """Every open PR against main, with the fields the PR-shaped detectors below need."""
+    return gh_stream(
+        f"/repos/{REPO}/pulls?state=open&base=main&per_page=100",
+        jq='.[] | {number, head: .head.sha, draft, updated_at, '
+           'head_ref: .head.ref, head_repo: (.head.repo.full_name // ""), '
+           'author: .user.login, labels: [.labels[].name]}')
+
+
+def ready_label_applied_at(number):
+    """When the CURRENT `ready-to-merge` label was applied, or None if it is not applied now.
+
+    Reads the label events in order and keeps the last transition, so a label removed and
+    re-added reports the latest application. Merge-queue enqueue/eviction events do not touch
+    the label, which is what makes this a stable readiness anchor (see detect_stranded_prs).
+    """
+    events = gh_stream(
+        f"/repos/{REPO}/issues/{number}/timeline?per_page=100",
+        jq='.[] | select(.event == "labeled" or .event == "unlabeled")'
+           ' | select(.label.name == "ready-to-merge")'
+           ' | {event, at: (.created_at // "")}')
+    applied = None
+    for e in events:
+        applied = e.get("at") if e.get("event") == "labeled" else None
+    return applied or None
+
+
+def detect_eviction_loops():
+    """A PR the merge queue keeps accepting and then throwing back out.
+
+    A single eviction is invisible: the PR stays green, simply is not merged, and merge-sweep
+    re-enqueues it an hour or two later. Nothing about any one cycle looks wrong, so a PR can
+    bounce for days while every other detector reports healthy. Counting the evictions is the
+    only way to see it, and a repeated eviction always means something upstream is broken (a
+    flaky cache, a genuinely red merge-group build) rather than one PR needing a nudge.
+
+    Only PRs the pipeline currently calls ready can be in the queue, so that label bounds the
+    per-PR timeline reads to a handful.
+    """
+    out = []
+    for pr in open_prs():
+        if pr.get("draft") or "ready-to-merge" not in pr.get("labels", []):
+            continue
+        # An OPEN PR that left the queue never merged, so every removal here is an eviction.
+        removals = gh_stream(
+            f"/repos/{REPO}/issues/{pr['number']}/timeline?per_page=100",
+            jq='.[] | select(.event == "removed_from_merge_queue") | {at: (.created_at // "")}')
+        recent = [r for r in removals
+                  if r.get("at") and hours_since(r["at"]) < EVICTION_WINDOW_HOURS]
+        if len(recent) < EVICTION_LOOP_MIN:
+            continue
+        out.append({
+            "key": f"eviction-loop/{pr['number']}",
+            "title": "Merge queue keeps evicting a green PR",
+            "body": (
+                f"https://github.com/{REPO}/pull/{pr['number']} has been evicted from the merge "
+                f"queue {len(recent)} times in the last {EVICTION_WINDOW_HOURS}h without merging.\n\n"
+                f"**Fix:** the PR is not the problem — find why the merge-group build fails. "
+                f"Check the `merge_group` runs for its `gh-readonly-queue/main/pr-{pr['number']}-*` "
+                f"branches. A failure mode shared across several PRs (cache, toolchain, a red "
+                f"main) is infrastructure and must be fixed there, not by re-queuing."),
+        })
+    return out
+
+
+def detect_missing_required_status():
+    """An open PR whose head never received a `build` status although pr-build finished.
+
+    A MISSING required status is worse than a red one and cannot self-heal. GitHub holds the PR
+    at BLOCKED because the required check never arrives; core.derive sees no `build` status, so
+    labels.py takes its ci=None branch and pins the PR at `awaiting-CI` instead of moving it to
+    `awaiting-author`; and nothing re-runs pr-build without a push, so no event ever corrects
+    it. PR #1358 sat wedged this way for seven days, invisible to the author and review paths
+    alike, after a transient API error killed the status-reporting step mid-way.
+    """
+    out = []
+    for pr in open_prs():
+        if pr.get("draft"):
+            continue
+        head = pr["head"]
+        if newest_status(head, "build")[0] is not None:
+            continue
+        # Only a CONCLUDED pr-build proves a status should already be there; a build still
+        # running is the ordinary `awaiting-CI` state and must never alert.
+        finished = gh_scalar(
+            f"/repos/{REPO}/actions/workflows/pr-build.yml/runs"
+            f"?head_sha={head}&status=completed&per_page=1",
+            jq='.workflow_runs[0].updated_at // ""')
+        if not finished or hours_since(finished) < MISSING_STATUS_HOURS:
+            continue
+        out.append({
+            "key": f"missing-status/{pr['number']}",
+            "title": "Required `build` status was never posted",
+            "body": (
+                f"https://github.com/{REPO}/pull/{pr['number']} has a completed pr-build run for "
+                f"its head commit but no `build` commit status, so it is BLOCKED forever and its "
+                f"label is pinned at `awaiting-CI`.\n\n"
+                f"**Fix:** re-dispatch pr-build for the PR to post the missing status "
+                f"(`gh workflow run pr-build.yml -f pr={pr['number']}`), then fix whatever "
+                f"dropped it — the report step must post all three statuses even when one POST "
+                f"fails."),
+        })
+    return out
+
+
+def detect_diverged_head():
+    """A PR whose recorded head no longer matches the tip of the branch it was opened from.
+
+    GitHub cannot compute mergeability for a head ref that has moved on without the PR record
+    following, so `.mergeable` stays null forever and the PR is invisible to every
+    mergeability-gated path, including detect_stranded_prs. It also means review and CI are
+    judging a commit that is not the author's latest work. #1475 sat at `UNKNOWN` this way, one
+    commit behind its own branch.
+    """
+    out = []
+    for pr in open_prs():
+        repo, ref = pr.get("head_repo"), pr.get("head_ref")
+        if not repo or not ref:
+            continue  # head repo deleted; a different problem, and not one a retry fixes
+        tip = gh_scalar(f"/repos/{repo}/branches/{ref}", jq='.commit.sha // ""')
+        if not tip or tip == pr["head"]:
+            continue
+        out.append({
+            "key": f"diverged-head/{pr['number']}",
+            "title": "PR head has diverged from its branch tip",
+            "body": (
+                f"https://github.com/{REPO}/pull/{pr['number']} records head `{pr['head'][:8]}` "
+                f"but `{repo}@{ref}` is at `{tip[:8]}`. GitHub will not recompute mergeability "
+                f"for a stale head, so the PR can sit at `mergeable: null` indefinitely.\n\n"
+                f"**Fix:** push the branch again (merging main onto it is usually right, and "
+                f"also clears the staleness) so the PR head follows. Then find the worker that "
+                f"moved the branch without the PR following — that is the actual bug."),
+        })
+    return out
+
+
 def detect_stranded_prs():
     prs = gh_stream(
         f"/repos/{REPO}/pulls?state=open&base=main&per_page=100",
@@ -282,11 +434,23 @@ def detect_stranded_prs():
         state, updated = newest_status(head, "build")
         if state != "success" or not updated:
             continue
-        # Readiness clock: the LATER of the build going green and the PR's last
-        # activity. Starting only from the build time would fire instantly when a
-        # review approves a PR whose build passed yesterday (the merge path has had
-        # no chance yet); updated_at bumps on that approval/commit/label.
-        ready_since = min(hours_since(updated), hours_since(pr["updated_at"]))
+        # Readiness clock: the LATER of the build going green and the pipeline declaring the
+        # PR ready. Starting only from the build time would fire instantly when a review
+        # approves a PR whose build passed yesterday (the merge path has had no chance yet).
+        #
+        # This used to take `updated_at` as the second anchor, which made the detector
+        # structurally blind to the exact failure it exists to catch. Every enqueue and
+        # eviction bumps `updated_at`, so a PR the merge queue accepted and threw back out
+        # every couple of hours could never accumulate STRANDED_HOURS of readiness. Four green
+        # PRs (#1986, #1964, #2002, #1886) sat unmerged in an eviction loop while this
+        # reported nothing. The `ready-to-merge` label is the pipeline's own "ready" moment
+        # and, unlike `updated_at`, queue churn does not move it.
+        applied = ready_label_applied_at(pr["number"])
+        if not applied:
+            # Not (yet) declared ready by the label sink. Skip this run rather than guessing:
+            # a real strand persists and will be caught next hour.
+            continue
+        ready_since = min(hours_since(updated), hours_since(applied))
         if ready_since < STRANDED_HOURS:
             continue
         # NOTE: scoreboard_meta is the trusted scoreboard comment auto-merge reads
@@ -478,6 +642,9 @@ DETECTORS = [
     ("stuck-bump", detect_stuck_bump),
     ("stale-pin", detect_stale_pin),
     ("stranded-pr", detect_stranded_prs),
+    ("eviction-loop", detect_eviction_loops),
+    ("missing-status", detect_missing_required_status),
+    ("diverged-head", detect_diverged_head),
     ("review-stuck", detect_review_stuck),
     ("dead-scheduler", detect_dead_schedulers),
     ("main-red", detect_main_red),

--- a/scripts/pr_status/stuck_alerts.py
+++ b/scripts/pr_status/stuck_alerts.py
@@ -130,7 +130,7 @@ MARKER_RE = re.compile(r"<!--stuck:v1 (" + KEY_RE.pattern + r")-->\s*\Z")
 BUMP_STUCK_HOURS = 24
 PIN_STALE_DAYS = 4
 STRANDED_HOURS = 6
-# Evictions at the current head, within the window, before a bounce counts as a loop.
+# Evictions since the current readiness, within the window, before a bounce counts as a loop.
 EVICTION_LOOP_MIN = 2
 EVICTION_WINDOW_HOURS = 24
 # How long a concluded pr-build may leave its head without a `build` status before that is
@@ -326,12 +326,21 @@ def detect_eviction_loops():
     for pr in open_prs():
         if pr.get("draft") or "ready-to-merge" not in pr.get("labels", []):
             continue
+        # Count only the CURRENT readiness cycle. Evictions from an earlier cycle -- before the
+        # author pushed a fix, or before the label came back -- say nothing about whether this
+        # PR is bouncing now, and counting them would alert on a PR that has since settled.
+        # The label survives enqueue/eviction (see ready_label_applied_at), so a genuine loop
+        # accumulates its removals after this timestamp.
+        applied = ready_label_applied_at(pr["number"])
+        if not applied:
+            continue
         # An OPEN PR that left the queue never merged, so every removal here is an eviction.
         removals = gh_stream(
             f"/repos/{REPO}/issues/{pr['number']}/timeline?per_page=100",
             jq='.[] | select(.event == "removed_from_merge_queue") | {at: (.created_at // "")}')
         recent = [r for r in removals
-                  if r.get("at") and hours_since(r["at"]) < EVICTION_WINDOW_HOURS]
+                  if r.get("at") and hours_since(r["at"]) < EVICTION_WINDOW_HOURS
+                  and parse_ts(r["at"]) > parse_ts(applied)]
         if len(recent) < EVICTION_LOOP_MIN:
             continue
         out.append({
@@ -365,12 +374,20 @@ def detect_missing_required_status():
         head = pr["head"]
         if newest_status(head, "build")[0] is not None:
             continue
-        # Only a CONCLUDED pr-build proves a status should already be there; a build still
-        # running is the ordinary `awaiting-CI` state and must never alert.
-        finished = gh_scalar(
-            f"/repos/{REPO}/actions/workflows/pr-build.yml/runs"
-            f"?head_sha={head}&status=completed&per_page=1",
-            jq='.workflow_runs[0].updated_at // ""')
+        # Only a run that RAN TO A VERDICT proves a status should already be there. A build
+        # still queued or in progress is the ordinary `awaiting-CI` state, and a cancelled run
+        # (a concurrency cancellation when the head is re-dispatched, or a manual cancel) never
+        # reaches its reporting step by design -- neither is a wedge, and alerting on either
+        # would make this detector fire on routine CI churn.
+        runs = gh_stream(
+            f"/repos/{REPO}/actions/workflows/pr-build.yml/runs?head_sha={head}&per_page=20",
+            jq='.workflow_runs[] | {status: (.status // ""), conclusion: (.conclusion // ""), '
+               'updated_at: (.updated_at // "")}', paginate=False)
+        if any(r.get("status") != "completed" for r in runs):
+            continue
+        # Newest run first, so this is the latest run that actually reported a verdict.
+        finished = next((r["updated_at"] for r in runs
+                         if r.get("conclusion") not in ("", "cancelled", "skipped")), "")
         if not finished or hours_since(finished) < MISSING_STATUS_HOURS:
             continue
         out.append({

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -209,5 +209,137 @@ class MarkerSafetyTest(unittest.TestCase):
         self.assertEqual(got["main-red"]["id"], 1)
 
 
+
+
+# ----- blind spots the detectors used to have --------------------------------
+
+def _ago(hours):
+    """An ISO timestamp `hours` in the past, in the format the GitHub API returns."""
+    import datetime as _dt
+    t = sa.now_utc() - _dt.timedelta(hours=hours)
+    return t.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+class RoutedGh:
+    """Fakes core.gh_api by matching substrings of the request path, in order."""
+
+    def __init__(self, routes):
+        self.routes = routes
+
+    def __call__(self, path, jq=None, paginate=False):
+        for needle, payload in self.routes:
+            if needle in path:
+                return payload
+        return ""
+
+
+def _install(test, routes):
+    test.addCleanup(setattr, core, "gh_api", core.gh_api)
+    core.gh_api = RoutedGh(routes)
+
+
+class ReadyLabelClockTest(unittest.TestCase):
+    """The strand clock must not reset when the merge queue churns a PR."""
+
+    def _timeline(self, *events):
+        return "".join(__import__("json").dumps(e) + "\n" for e in events)
+
+    def test_reports_latest_application(self):
+        _install(self, [("/timeline", self._timeline(
+            {"event": "labeled", "at": "2026-08-01T00:00:00Z"},
+            {"event": "unlabeled", "at": "2026-08-02T00:00:00Z"},
+            {"event": "labeled", "at": "2026-08-03T00:00:00Z"}))])
+        self.assertEqual(sa.ready_label_applied_at(1), "2026-08-03T00:00:00Z")
+
+    def test_none_when_currently_removed(self):
+        _install(self, [("/timeline", self._timeline(
+            {"event": "labeled", "at": "2026-08-01T00:00:00Z"},
+            {"event": "unlabeled", "at": "2026-08-02T00:00:00Z"}))])
+        self.assertIsNone(sa.ready_label_applied_at(1))
+
+    def test_queue_churn_does_not_reset_the_clock(self):
+        # The regression this replaced: `updated_at` bumps on every enqueue/eviction, so a PR
+        # bouncing every couple of hours could never reach STRANDED_HOURS. The label is old
+        # even though the PR was "updated" minutes ago, so the strand must still be visible.
+        _install(self, [("/timeline", self._timeline(
+            {"event": "labeled", "at": _ago(30)}))])
+        applied = sa.ready_label_applied_at(99)
+        self.assertGreater(sa.hours_since(applied), sa.STRANDED_HOURS)
+
+
+class EvictionLoopTest(unittest.TestCase):
+    def _routes(self, removals, labels=("ready-to-merge",)):
+        import json as _j
+        prs = _j.dumps({"number": 7, "head": "abc", "draft": False,
+                        "updated_at": _ago(1), "head_ref": "b", "head_repo": "o/r",
+                        "author": "a", "labels": list(labels)}) + "\n"
+        tl = "".join(_j.dumps({"at": t}) + "\n" for t in removals)
+        return [("/pulls?state=open", prs), ("/timeline", tl)]
+
+    def test_two_recent_evictions_alert(self):
+        _install(self, self._routes([_ago(1), _ago(3)]))
+        got = sa.detect_eviction_loops()
+        self.assertEqual([a["key"] for a in got], ["eviction-loop/7"])
+
+    def test_single_eviction_is_not_a_loop(self):
+        _install(self, self._routes([_ago(1)]))
+        self.assertEqual(sa.detect_eviction_loops(), [])
+
+    def test_evictions_outside_the_window_do_not_count(self):
+        _install(self, self._routes([_ago(30), _ago(40)]))
+        self.assertEqual(sa.detect_eviction_loops(), [])
+
+    def test_pr_not_marked_ready_is_skipped(self):
+        _install(self, self._routes([_ago(1), _ago(2)], labels=("awaiting-author",)))
+        self.assertEqual(sa.detect_eviction_loops(), [])
+
+
+class MissingStatusTest(unittest.TestCase):
+    def _routes(self, build_status, run_finished):
+        import json as _j
+        prs = _j.dumps({"number": 8, "head": "def", "draft": False,
+                        "updated_at": _ago(1), "head_ref": "b", "head_repo": "o/r",
+                        "author": "a", "labels": []}) + "\n"
+        return [("/pulls?state=open", prs),
+                ("/statuses", build_status),
+                ("pr-build.yml/runs", run_finished)]
+
+    def test_alerts_when_run_finished_but_no_status(self):
+        _install(self, self._routes("", _ago(2)))
+        self.assertEqual([a["key"] for a in sa.detect_missing_required_status()],
+                         ["missing-status/8"])
+
+    def test_silent_while_the_build_is_still_running(self):
+        # No completed run yet: this is ordinary `awaiting-CI`, never an alert.
+        _install(self, self._routes("", ""))
+        self.assertEqual(sa.detect_missing_required_status(), [])
+
+    def test_silent_when_the_status_exists(self):
+        _install(self, self._routes(
+            '{"state": "failure", "updated_at": "2026-08-01T00:00:00Z"}', _ago(2)))
+        self.assertEqual(sa.detect_missing_required_status(), [])
+
+
+class DivergedHeadTest(unittest.TestCase):
+    def _routes(self, tip):
+        import json as _j
+        prs = _j.dumps({"number": 9, "head": "aaaaaaaa", "draft": False,
+                        "updated_at": _ago(1), "head_ref": "feat", "head_repo": "fork/TauCeti",
+                        "author": "a", "labels": []}) + "\n"
+        return [("/pulls?state=open", prs), ("/branches/", tip)]
+
+    def test_alerts_when_head_is_behind_the_branch_tip(self):
+        _install(self, self._routes("bbbbbbbb"))
+        self.assertEqual([a["key"] for a in sa.detect_diverged_head()], ["diverged-head/9"])
+
+    def test_silent_when_head_matches(self):
+        _install(self, self._routes("aaaaaaaa"))
+        self.assertEqual(sa.detect_diverged_head(), [])
+
+    def test_silent_when_branch_is_unreadable(self):
+        # A deleted head repo/branch is a different problem; do not cry wolf on an API miss.
+        _install(self, self._routes(""))
+        self.assertEqual(sa.detect_diverged_head(), [])
+
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/pr_status/test_stuck_alerts.py
+++ b/scripts/pr_status/test_stuck_alerts.py
@@ -221,14 +221,19 @@ def _ago(hours):
 
 
 class RoutedGh:
-    """Fakes core.gh_api by matching substrings of the request path, in order."""
+    """Fakes core.gh_api by matching substrings of the request (path, then jq), in order.
+
+    Two detectors read the same timeline path with different jq filters, so the jq is part
+    of what identifies a request.
+    """
 
     def __init__(self, routes):
         self.routes = routes
 
     def __call__(self, path, jq=None, paginate=False):
+        request = f"{path} {jq or ''}"
         for needle, payload in self.routes:
-            if needle in path:
+            if needle in request:
                 return payload
         return ""
 
@@ -268,13 +273,16 @@ class ReadyLabelClockTest(unittest.TestCase):
 
 
 class EvictionLoopTest(unittest.TestCase):
-    def _routes(self, removals, labels=("ready-to-merge",)):
+    def _routes(self, removals, labels=("ready-to-merge",), ready_at=None):
         import json as _j
         prs = _j.dumps({"number": 7, "head": "abc", "draft": False,
                         "updated_at": _ago(1), "head_ref": "b", "head_repo": "o/r",
                         "author": "a", "labels": list(labels)}) + "\n"
         tl = "".join(_j.dumps({"at": t}) + "\n" for t in removals)
-        return [("/pulls?state=open", prs), ("/timeline", tl)]
+        label_events = _j.dumps({"event": "labeled", "at": ready_at or _ago(48)}) + "\n"
+        return [("/pulls?state=open", prs),
+                ("ready-to-merge", label_events),
+                ("removed_from_merge_queue", tl)]
 
     def test_two_recent_evictions_alert(self):
         _install(self, self._routes([_ago(1), _ago(3)]))
@@ -289,34 +297,66 @@ class EvictionLoopTest(unittest.TestCase):
         _install(self, self._routes([_ago(30), _ago(40)]))
         self.assertEqual(sa.detect_eviction_loops(), [])
 
+    def test_evictions_before_the_current_readiness_do_not_count(self):
+        # The PR bounced twice, then the author pushed a fix and the label came back. Those
+        # evictions belong to the previous cycle and say nothing about the current head.
+        _install(self, self._routes([_ago(5), _ago(6)], ready_at=_ago(3)))
+        self.assertEqual(sa.detect_eviction_loops(), [])
+
     def test_pr_not_marked_ready_is_skipped(self):
         _install(self, self._routes([_ago(1), _ago(2)], labels=("awaiting-author",)))
         self.assertEqual(sa.detect_eviction_loops(), [])
 
 
 class MissingStatusTest(unittest.TestCase):
-    def _routes(self, build_status, run_finished):
+    def _routes(self, build_status, runs):
         import json as _j
         prs = _j.dumps({"number": 8, "head": "def", "draft": False,
                         "updated_at": _ago(1), "head_ref": "b", "head_repo": "o/r",
                         "author": "a", "labels": []}) + "\n"
+        # The API returns runs newest first; so does this list.
         return [("/pulls?state=open", prs),
                 ("/statuses", build_status),
-                ("pr-build.yml/runs", run_finished)]
+                ("pr-build.yml/runs", "".join(_j.dumps(r) + "\n" for r in runs))]
+
+    @staticmethod
+    def _run(hours_ago, conclusion="failure", status="completed"):
+        return {"status": status, "conclusion": conclusion, "updated_at": _ago(hours_ago)}
 
     def test_alerts_when_run_finished_but_no_status(self):
-        _install(self, self._routes("", _ago(2)))
+        _install(self, self._routes("", [self._run(2)]))
         self.assertEqual([a["key"] for a in sa.detect_missing_required_status()],
                          ["missing-status/8"])
 
     def test_silent_while_the_build_is_still_running(self):
-        # No completed run yet: this is ordinary `awaiting-CI`, never an alert.
-        _install(self, self._routes("", ""))
+        # No run at all yet: this is ordinary `awaiting-CI`, never an alert.
+        _install(self, self._routes("", []))
         self.assertEqual(sa.detect_missing_required_status(), [])
+
+    def test_silent_while_a_rerun_is_in_progress(self):
+        # An earlier run concluded, but the head is building again right now; the status it
+        # will post has simply not landed yet.
+        _install(self, self._routes(
+            "", [self._run(0.1, conclusion="", status="in_progress"), self._run(2)]))
+        self.assertEqual(sa.detect_missing_required_status(), [])
+
+    def test_cancelled_run_is_not_proof_of_a_missing_status(self):
+        # A cancelled run (concurrency or manual) never reaches its reporting step, so it
+        # posting no status is by design, not a wedge.
+        _install(self, self._routes("", [self._run(2, conclusion="cancelled")]))
+        self.assertEqual(sa.detect_missing_required_status(), [])
+
+    def test_older_concluded_run_still_alerts_behind_a_cancellation(self):
+        # The run that reported is the older one; a later cancellation does not excuse the
+        # status it never posted.
+        _install(self, self._routes(
+            "", [self._run(0.6, conclusion="cancelled"), self._run(2, conclusion="success")]))
+        self.assertEqual([a["key"] for a in sa.detect_missing_required_status()],
+                         ["missing-status/8"])
 
     def test_silent_when_the_status_exists(self):
         _install(self, self._routes(
-            '{"state": "failure", "updated_at": "2026-08-01T00:00:00Z"}', _ago(2)))
+            '{"state": "failure", "updated_at": "2026-08-01T00:00:00Z"}', [self._run(2)]))
         self.assertEqual(sa.detect_missing_required_status(), [])
 
 


### PR DESCRIPTION
This PR anchors the stranded-PR clock on a signal the merge queue cannot move, and adds three detectors for stuck states that nothing watched.

During a queue health check, four green PRs (#1986, #1964, #2002, #1886) were sitting unmerged in a merge-queue eviction loop, #1358 had been wedged for seven days with no `build` status on its head, and #1475 was at `mergeable: null` behind a stale head. `stuck_alerts.py --dry-run` reported zero alerts through all of it.

The stranded-PR clock was the reason for the first one. It took `min(hours_since(build_green), hours_since(updated_at))`, and every `added_to_merge_queue` and `removed_from_merge_queue` event bumps `updated_at`. A PR the queue accepted and threw back out every couple of hours could never accumulate `STRANDED_HOURS` of readiness, so the detector was structurally incapable of seeing the exact failure it exists to catch. The clock now uses the `ready-to-merge` label's application time, which is the pipeline's own "this is ready" moment and which queue churn does not touch. The original reason for the second anchor (do not fire the instant a review approves a PR whose build passed yesterday) is preserved.

The three new detectors:

- `eviction-loop`, a PR the queue has accepted and evicted repeatedly. One eviction looks like nothing, since merge-sweep just re-enqueues, so only the count reveals a broken merge-group build.
- `missing-status`, a concluded pr-build that left an open PR's head with no `build` status. That PR is BLOCKED forever and its label is pinned at `awaiting-CI`, and nothing re-runs pr-build without a push.
- `diverged-head`, a PR whose recorded head is not its branch tip, so GitHub never recomputes mergeability and it sits at `mergeable: null`, invisible to every mergeability-gated path including the stranded-PR detector itself.

Verified against the live repository: the three fire on #2002, #1358 and #1477 respectively, and #1475 no longer fires now that its head has been resynced. 13 new unit tests, 34 total, all passing.

🤖 Prepared with Claude Code