### PR TITLE
feat: the argument principle in winding-number form

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -104,8 +104,11 @@ the chain rule. The chain rule is available only off the breakpoints of `γ`, a 
 two integrands agree merely almost everywhere — enough for both the integrals and the
 interval-integrability to transfer.
 
-Nothing is assumed about `f` off the curve, so the lemma applies verbatim to a function with zeros
-and poles inside the region the curve encloses; that is what the argument principle then counts. -/
+The analyticity hypothesis is local: `AnalyticAt ℂ f (γ t)` asks only for *some* neighbourhood of
+each point of the curve on which `f` is analytic, never for one ambient open set carrying the whole
+curve, and imposes no condition beyond those neighbourhoods. So the lemma applies verbatim to a
+function with zeros and poles inside the region the curve encloses; that is what the argument
+principle then counts. -/
 theorem windingNumber_comp_eq_integral_logDeriv (hγ : Contour.IsPiecewiseC1On γ a b)
     (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hfne : ∀ t ∈ [[a, b]], f (γ t) ≠ 0) :
     Contour.windingNumber (f ∘ γ) a b 0

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -125,11 +125,9 @@ theorem windingNumber_comp_eq_integral_logDeriv (hγ : Contour.IsPiecewiseC1On �
     have htu : t ∈ [[a, b]] := by
       rw [← Set.Icc_min_max]
       exact Set.Ioo_subset_Icc_self htIoo.1
-    have hd : HasDerivAt (f ∘ γ) (deriv γ t • deriv f (γ t)) t :=
-      (hfa t htu).differentiableAt.hasDerivAt.scomp t (hp t htIoo).hasDerivAt
-    rw [hd.deriv]
-    simp only [Function.comp_apply, sub_zero, logDeriv_apply, smul_eq_mul]
-    ring
+    have hcomp : logDeriv (f ∘ γ) t = logDeriv f (γ t) * deriv γ t :=
+      logDeriv_comp (hfa t htu).differentiableAt (hp t htIoo)
+    rw [sub_zero, ← div_eq_inv_mul, ← logDeriv_apply, hcomp, smul_eq_mul, mul_comm]
   have hint : IntervalIntegrable (fun t => deriv γ t • logDeriv f (γ t)) volume a b :=
     Contour.intervalIntegrable_deriv_smul_logDeriv hγ hfa hfne
   rw [Contour.windingNumber_eq_integral_of_avoidance hcont

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Contour.Argument.Cycle
-import TauCeti.Analysis.Contour.LogDerivFTC
 
 /-!
 # The argument principle in winding-number form

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -1,0 +1,235 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Contour.Argument.Cycle
+public import TauCeti.Analysis.Contour.LogDerivFTC
+import Mathlib.Analysis.Calculus.LogDeriv
+
+/-!
+# The argument principle in winding-number form
+
+The argument principle is normally *stated* as an equality of contour integrals — the integral of
+`f'/f` along a cycle equals `2πi` times the winding-weighted count of zeros minus poles — and that
+is the form the sibling contour-integration development supplies
+(`TauCeti.Contour.argumentPrinciple_nullHomologous`). The name, though, comes from a *geometric*
+reading of the same identity: `∮_γ f'/f` measures the total change of `arg (f z)` as `z` traverses
+`γ`, so what the identity computes is **how often the image curve `f ∘ γ` winds around the
+origin**. This file supplies that reading, and it is what turns the argument principle into a
+statement about the geometry of the image rather than about an integral.
+
+The bridge is `TauCeti.windingNumber_comp_eq_integral_logDeriv`: along a piecewise-`C¹` curve `γ`
+on which `f` is analytic and zero-free, the composite `f ∘ γ` is itself a curve missing the origin,
+and its index integral `(2πi)⁻¹ ∮_{f ∘ γ} dw / w` is, after the substitution `w = f z`, exactly
+`(2πi)⁻¹ ∮_γ f'/f`. Formally the substitution is the chain rule `(f ∘ γ)' = γ' · f'(γ)`, valid off
+the finitely many breakpoints of `γ` and so almost everywhere — which is all an integral sees. No
+regularity of `f ∘ γ` beyond continuity and this almost-everywhere derivative is needed, so nothing
+has to be said about `f ∘ γ` being piecewise `C¹` (it is, but the winding number does not ask).
+
+Feeding the bridge into the homological argument principle gives the geometric statements. For `f`
+meromorphic on an open `U` with its zeros and poles confined to a finite `S`, and `γ` closed and
+null-homologous in `U`,
+
+`n_0(f ∘ γ) = ∑_{z ∈ S} n_z(γ) · ord_z f`,
+
+the winding number of the image about the origin being the winding-weighted number of zeros minus
+poles. Three specialisations are recorded: a single zero or pole, the holomorphic case with the
+orders read off by `analyticOrderNatAt`, and the degenerate case of a zero-free function, where the
+image curve does not wind around the origin at all.
+
+Nothing here re-proves the argument principle. Layer **L0** of the conformal-mapping roadmap is
+directed to *consume* the residue and argument-principle material of the sibling
+contour-integration roadmap, and that is what happens: the analytic content is
+`TauCeti.Contour.argumentPrinciple_nullHomologous` and the corner-tolerant logarithmic-derivative
+regularity of `TauCeti.Analysis.Contour.LogDerivFTC`, and what is added on top is the
+conformal-geometric reading. `TauCeti/Analysis/Complex/Conformal/Rouche.lean` consumes it in turn
+to state Rouché's theorem as an equality of image winding numbers — the "dog on a leash" form.
+
+The generalized winding number of `TauCeti.Contour.windingNumber` is a *complex* number, defined by
+a principal value, so no integrality is asserted anywhere below; the identity is an identity of
+complex numbers, exactly as the underlying argument principle is.
+
+## Main results
+
+* `TauCeti.windingNumber_comp_eq_integral_logDeriv` — the bridge: the winding number of the image
+  curve `f ∘ γ` about the origin is `(2πi)⁻¹ ∮_γ f'/f`.
+* `TauCeti.argumentPrinciple_windingNumber` — **the argument principle, geometric form**: for `f`
+  meromorphic with orders `ord` on a finite `S` and `γ` null-homologous, the image curve winds
+  `∑_{z ∈ S} n_z(γ) · ord z` times about the origin.
+* `TauCeti.argumentPrinciple_windingNumber_local` — the one-point case: `n_0(f ∘ γ) = n_{z₀}(γ) · n`
+  for a single zero or pole of order `n`.
+* `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd` — the holomorphic case, with the orders
+  read off by `analyticOrderNatAt`.
+* `TauCeti.windingNumber_comp_eq_zero_of_forall_ne_zero` — a zero-free holomorphic function sends a
+  null-homologous cycle to a curve that does not wind around the origin.
+
+## Coordination with upstream Mathlib
+
+Per the *Coordination with upstream Mathlib* section of `ConformalMapping/README.md`, layer L0
+overlaps [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the
+in-progress human-curated Riemann-mapping-theorem effort, which proves an argument principle
+internally as a private lemma
+(`circleIntegral_logDeriv_eq_finsum_analyticOrderNatAdd`). **This file is therefore a temporary
+shim**: once the corresponding Mathlib lemmas land, these statements should be backed by them — or
+deleted and their consumers refactored — rather than maintained as an independent re-proof. What
+Tau Ceti adds at L0 is named, discoverable API, not first proof.
+
+## References
+
+* L. Ahlfors, *Complex Analysis*, Ch. 4 §5.
+* S. Lang, *Complex Analysis* (GTM 103), Ch. VI §1.
+-/
+
+public section
+
+open Complex MeasureTheory
+
+open scoped Interval
+
+namespace TauCeti
+
+variable {f : ℂ → ℂ} {U : Set ℂ} {S : Finset ℂ} {γ : ℝ → ℂ} {a b : ℝ}
+
+/-- **The winding number of the image curve is the logarithmic-derivative integral.** If `f` is
+analytic and zero-free along a piecewise-`C¹` curve `γ`, the composite `f ∘ γ` avoids the origin
+and
+
+`n_0(f ∘ γ) = (2πi)⁻¹ ∫_a^b γ' t · (f'/f) (γ t)`.
+
+This is the substitution `w = f z` in the index integral `(2πi)⁻¹ ∮_{f ∘ γ} dw / w`, carried out by
+the chain rule. The chain rule is available only off the breakpoints of `γ`, a finite set, so the
+two integrands agree merely almost everywhere — enough for both the integrals and the
+interval-integrability to transfer.
+
+Nothing is assumed about `f` off the curve, so the lemma applies verbatim to a function with zeros
+and poles inside the region the curve encloses; that is what the argument principle then counts. -/
+theorem windingNumber_comp_eq_integral_logDeriv (hγ : Contour.IsPiecewiseC1On γ a b)
+    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hfne : ∀ t ∈ [[a, b]], f (γ t) ≠ 0) :
+    Contour.windingNumber (f ∘ γ) a b 0
+      = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, deriv γ t • logDeriv f (γ t) := by
+  obtain ⟨p, hp⟩ := hγ.exists_finset_differentiableAt
+  have hcont : ContinuousOn (f ∘ γ) [[a, b]] := fun t ht =>
+    (hfa t ht).continuousAt.comp_continuousWithinAt (hγ.continuousOn t ht)
+  -- Off the finitely many breakpoints of `γ` — and off the right endpoint, which `Ι a b` contains
+  -- but `Set.Ioo (min a b) (max a b)` does not — the chain rule identifies the two integrands.
+  have hae : ∀ᵐ t ∂(volume : Measure ℝ), t ∈ Ι a b →
+      deriv γ t • logDeriv f (γ t) = ((f ∘ γ) t - 0)⁻¹ * deriv (f ∘ γ) t := by
+    have hnull : ∀ᵐ t ∂(volume : Measure ℝ), t ∉ insert (max a b) (↑p : Set ℝ) :=
+      measure_eq_zero_iff_ae_notMem.mp ((p.finite_toSet.insert (max a b)).measure_zero volume)
+    filter_upwards [hnull] with t hts ht
+    have ht' : t ∈ Set.Ioc (min a b) (max a b) := ht
+    have htIoo : t ∈ Set.Ioo (min a b) (max a b) \ (↑p : Set ℝ) :=
+      ⟨⟨ht'.1, lt_of_le_of_ne ht'.2 fun h => hts (by simp [h])⟩,
+        fun h => hts (Set.mem_insert_of_mem _ h)⟩
+    have htu : t ∈ [[a, b]] := by
+      rw [← Set.Icc_min_max]
+      exact Set.Ioo_subset_Icc_self htIoo.1
+    have hd : HasDerivAt (f ∘ γ) (deriv γ t • deriv f (γ t)) t :=
+      (hfa t htu).differentiableAt.hasDerivAt.scomp t (hp t htIoo).hasDerivAt
+    rw [hd.deriv]
+    simp only [Function.comp_apply, sub_zero, logDeriv_apply, smul_eq_mul]
+    ring
+  have hint : IntervalIntegrable (fun t => deriv γ t • logDeriv f (γ t)) volume a b :=
+    Contour.intervalIntegrable_deriv_smul_logDeriv hγ hfa hfne
+  rw [Contour.windingNumber_eq_integral_of_avoidance hcont
+      (fun t ht => hfne t ht) (hint.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae))]
+  exact congrArg _ (intervalIntegral.integral_congr_ae hae).symm
+
+/-- **The argument principle, geometric form.** Let `U` be open, `S` a finite set collecting every
+zero and pole of `f` in `U`: `f` is analytic and non-vanishing at each point of `U ∖ S`, and
+meromorphic of order `ord s` at each `s ∈ S` lying in `U`. Let `γ` be a closed piecewise-`C¹` curve
+in `U`, **null-homologous** in `U`, that **avoids** `S`. Then the image curve `f ∘ γ` misses the
+origin and winds around it exactly
+
+`n_0(f ∘ γ) = ∑_{z ∈ S} n_z(γ) · ord z`
+
+times: the number of zeros minus poles enclosed by `γ`, each counted with its multiplicity and with
+the winding number of `γ` about it.
+
+This is the reading that names the theorem — the total change of `arg (f z)` along `γ`, divided by
+`2π` — and it is `TauCeti.Contour.argumentPrinciple_nullHomologous` read through
+`TauCeti.windingNumber_comp_eq_integral_logDeriv`. As there, points of `S` outside `U` are
+harmless: null-homology makes their winding number, hence their contribution, vanish. -/
+theorem argumentPrinciple_windingNumber {ord : ℂ → ℤ} (hU : IsOpen U)
+    (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)
+    (hmero : ∀ s ∈ S, s ∈ U → MeromorphicAt f s)
+    (hord : ∀ s ∈ S, s ∈ U → meromorphicOrderAt f s = (ord s : WithTop ℤ))
+    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ [[a, b]], γ t ∉ (↑S : Set ℂ)) (hnull : Contour.IsNullHomologous γ a b U) :
+    Contour.windingNumber (f ∘ γ) a b 0
+      = ∑ z ∈ S, Contour.windingNumber γ a b z * (ord z : ℂ) := by
+  rw [windingNumber_comp_eq_integral_logDeriv hγ
+      (fun t ht => (hoff _ (hγU t ht) (hγoff t ht)).1)
+      (fun t ht => (hoff _ (hγU t ht) (hγoff t ht)).2),
+    Contour.argumentPrinciple_nullHomologous hU hoff hmero hord hγ hγU hclosed hγoff hnull,
+    inv_mul_cancel_left₀ two_pi_I_ne_zero]
+
+/-- **The argument principle for a cycle around a single zero or pole, geometric form.** If `z₀` is
+the only point of an open `U` at which `f` fails to be analytic and non-vanishing, of order `n`
+there, and `γ` is a closed piecewise-`C¹` curve in `U`, null-homologous in `U`, missing `z₀`, then
+the image curve winds `n_{z₀}(γ) · n` times about the origin.
+
+This is the `S = {z₀}` case of `TauCeti.argumentPrinciple_windingNumber`, and the geometric reading
+of `TauCeti.Contour.argumentPrinciple_nullHomologous_local`: a loop winding `k` times around a zero
+of order `n` has an image winding `k · n` times around the origin. Membership `z₀ ∈ U` is not
+required — outside `U` the winding number of `γ` about `z₀` vanishes, and with it both sides. -/
+theorem argumentPrinciple_windingNumber_local {z₀ : ℂ} {n : ℤ} (hU : IsOpen U)
+    (hmero : z₀ ∈ U → MeromorphicAt f z₀)
+    (hn : z₀ ∈ U → meromorphicOrderAt f z₀ = (n : WithTop ℤ))
+    (hoff : ∀ z ∈ U, z ≠ z₀ → AnalyticAt ℂ f z ∧ f z ≠ 0)
+    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ [[a, b]], γ t ≠ z₀) (hnull : Contour.IsNullHomologous γ a b U) :
+    Contour.windingNumber (f ∘ γ) a b 0 = Contour.windingNumber γ a b z₀ * (n : ℂ) := by
+  have key := argumentPrinciple_windingNumber (S := {z₀}) (ord := fun _ => n) hU
+    (fun z hzU hzS => hoff z hzU (by simpa using hzS))
+    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hmero hsU)
+    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hn hsU) hγ hγU hclosed
+    (fun t ht => by simpa using hγoff t ht) hnull
+  simpa using key
+
+/-- **The argument principle, geometric form, for a holomorphic function.** Let `f` be analytic on
+an open `U` with all its zeros in a finite set `S`, and let `γ` be a closed piecewise-`C¹` curve in
+`U`, null-homologous in `U`, along which `f` does not vanish. Then
+
+`n_0(f ∘ γ) = ∑_{z ∈ S} n_z(γ) · analyticOrderNatAt f z`:
+
+the image curve winds around the origin as often as `γ` encloses zeros of `f`, counted with
+multiplicity.
+
+Only the *zeros* need be avoided, not all of `S`: `S` may list points where `f` does not vanish,
+and `γ` is free to run through them, their order — and so their term in the sum — being `0`. This
+is the pole-free specialisation of `TauCeti.argumentPrinciple_windingNumber`, with the orders read
+off by `analyticOrderNatAt` instead of supplied by the caller. -/
+theorem argumentPrinciple_windingNumber_of_analyticOnNhd (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U)
+    (hzeros : ∀ z ∈ U, f z = 0 → z ∈ S)
+    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
+    (hγoff : ∀ t ∈ [[a, b]], f (γ t) ≠ 0) (hnull : Contour.IsNullHomologous γ a b U) :
+    Contour.windingNumber (f ∘ γ) a b 0
+      = ∑ z ∈ S, Contour.windingNumber γ a b z * (analyticOrderNatAt f z : ℂ) := by
+  rw [windingNumber_comp_eq_integral_logDeriv hγ (fun t ht => hf _ (hγU t ht)) hγoff,
+    Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd hU hf hzeros hγ hγU hclosed hγoff
+      hnull,
+    inv_mul_cancel_left₀ two_pi_I_ne_zero]
+
+/-- **A zero-free holomorphic function unwinds every null-homologous cycle.** If `f` is analytic
+and nowhere zero on an open set `U` and `γ` is a closed piecewise-`C¹` curve in `U`,
+null-homologous in `U`, then the image curve `f ∘ γ` does not wind around the origin.
+
+This is the `S = ∅` case of `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd`, and the
+geometric form of the vanishing statement Rouché-type arguments run on: an image curve that *does*
+wind around the origin certifies a zero inside. -/
+theorem windingNumber_comp_eq_zero_of_forall_ne_zero (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U)
+    (hne : ∀ z ∈ U, f z ≠ 0)
+    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
+    (hnull : Contour.IsNullHomologous γ a b U) :
+    Contour.windingNumber (f ∘ γ) a b 0 = 0 := by
+  simpa using argumentPrinciple_windingNumber_of_analyticOnNhd (S := ∅) hU hf
+    (fun z hz h0 => absurd h0 (hne z hz)) hγ hγU hclosed
+    (fun t ht => hne _ (hγU t ht)) hnull
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -6,8 +6,8 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Contour.Argument.Cycle
-public import TauCeti.Analysis.Contour.LogDerivFTC
-import Mathlib.Analysis.Calculus.LogDeriv
+public import Mathlib.Analysis.Calculus.LogDeriv
+import TauCeti.Analysis.Contour.LogDerivFTC
 
 /-!
 # The argument principle in winding-number form
@@ -36,9 +36,8 @@ null-homologous in `U`,
 `n_0(f ∘ γ) = ∑_{z ∈ S} n_z(γ) · ord_z f`,
 
 the winding number of the image about the origin being the winding-weighted number of zeros minus
-poles. Three specialisations are recorded: a single zero or pole, the holomorphic case with the
-orders read off by `analyticOrderNatAt`, and the degenerate case of a zero-free function, where the
-image curve does not wind around the origin at all.
+poles. The holomorphic case is recorded separately, with the orders read off by
+`analyticOrderNatAt` instead of supplied by the caller.
 
 Nothing here re-proves the argument principle. Layer **L0** of the conformal-mapping roadmap is
 directed to *consume* the residue and argument-principle material of the sibling
@@ -59,12 +58,8 @@ complex numbers, exactly as the underlying argument principle is.
 * `TauCeti.argumentPrinciple_windingNumber` — **the argument principle, geometric form**: for `f`
   meromorphic with orders `ord` on a finite `S` and `γ` null-homologous, the image curve winds
   `∑_{z ∈ S} n_z(γ) · ord z` times about the origin.
-* `TauCeti.argumentPrinciple_windingNumber_local` — the one-point case: `n_0(f ∘ γ) = n_{z₀}(γ) · n`
-  for a single zero or pole of order `n`.
 * `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd` — the holomorphic case, with the orders
   read off by `analyticOrderNatAt`.
-* `TauCeti.windingNumber_comp_eq_zero_of_forall_ne_zero` — a zero-free holomorphic function sends a
-  null-homologous cycle to a curve that does not wind around the origin.
 
 ## Coordination with upstream Mathlib
 
@@ -170,29 +165,6 @@ theorem argumentPrinciple_windingNumber {ord : ℂ → ℤ} (hU : IsOpen U)
     Contour.argumentPrinciple_nullHomologous hU hoff hmero hord hγ hγU hclosed hγoff hnull,
     inv_mul_cancel_left₀ two_pi_I_ne_zero]
 
-/-- **The argument principle for a cycle around a single zero or pole, geometric form.** If `z₀` is
-the only point of an open `U` at which `f` fails to be analytic and non-vanishing, of order `n`
-there, and `γ` is a closed piecewise-`C¹` curve in `U`, null-homologous in `U`, missing `z₀`, then
-the image curve winds `n_{z₀}(γ) · n` times about the origin.
-
-This is the `S = {z₀}` case of `TauCeti.argumentPrinciple_windingNumber`, and the geometric reading
-of `TauCeti.Contour.argumentPrinciple_nullHomologous_local`: a loop winding `k` times around a zero
-of order `n` has an image winding `k · n` times around the origin. Membership `z₀ ∈ U` is not
-required — outside `U` the winding number of `γ` about `z₀` vanishes, and with it both sides. -/
-theorem argumentPrinciple_windingNumber_local {z₀ : ℂ} {n : ℤ} (hU : IsOpen U)
-    (hmero : z₀ ∈ U → MeromorphicAt f z₀)
-    (hn : z₀ ∈ U → meromorphicOrderAt f z₀ = (n : WithTop ℤ))
-    (hoff : ∀ z ∈ U, z ≠ z₀ → AnalyticAt ℂ f z ∧ f z ≠ 0)
-    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
-    (hγoff : ∀ t ∈ [[a, b]], γ t ≠ z₀) (hnull : Contour.IsNullHomologous γ a b U) :
-    Contour.windingNumber (f ∘ γ) a b 0 = Contour.windingNumber γ a b z₀ * (n : ℂ) := by
-  have key := argumentPrinciple_windingNumber (S := {z₀}) (ord := fun _ => n) hU
-    (fun z hzU hzS => hoff z hzU (by simpa using hzS))
-    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hmero hsU)
-    (fun s hs hsU => by rw [Finset.mem_singleton.mp hs] at hsU ⊢; exact hn hsU) hγ hγU hclosed
-    (fun t ht => by simpa using hγoff t ht) hnull
-  simpa using key
-
 /-- **The argument principle, geometric form, for a holomorphic function.** Let `f` be analytic on
 an open `U` with all its zeros in a finite set `S`, and let `γ` be a closed piecewise-`C¹` curve in
 `U`, null-homologous in `U`, along which `f` does not vanish. Then
@@ -216,22 +188,6 @@ theorem argumentPrinciple_windingNumber_of_analyticOnNhd (hU : IsOpen U) (hf : A
     Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd hU hf hzeros hγ hγU hclosed hγoff
       hnull,
     inv_mul_cancel_left₀ two_pi_I_ne_zero]
-
-/-- **A zero-free holomorphic function unwinds every null-homologous cycle.** If `f` is analytic
-and nowhere zero on an open set `U` and `γ` is a closed piecewise-`C¹` curve in `U`,
-null-homologous in `U`, then the image curve `f ∘ γ` does not wind around the origin.
-
-This is the `S = ∅` case of `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd`, and the
-geometric form of the vanishing statement Rouché-type arguments run on: an image curve that *does*
-wind around the origin certifies a zero inside. -/
-theorem windingNumber_comp_eq_zero_of_forall_ne_zero (hU : IsOpen U) (hf : AnalyticOnNhd ℂ f U)
-    (hne : ∀ z ∈ U, f z ≠ 0)
-    (hγ : Contour.IsPiecewiseC1On γ a b) (hγU : ∀ t ∈ [[a, b]], γ t ∈ U) (hclosed : γ a = γ b)
-    (hnull : Contour.IsNullHomologous γ a b U) :
-    Contour.windingNumber (f ∘ γ) a b 0 = 0 := by
-  simpa using argumentPrinciple_windingNumber_of_analyticOnNhd (S := ∅) hU hf
-    (fun z hz h0 => absurd h0 (hne z hz)) hγ hγU hclosed
-    (fun t ht => hne _ (hγU t ht)) hnull
 
 end TauCeti
 

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -6,7 +6,6 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Analysis.Contour.Argument.Cycle
-public import Mathlib.Analysis.Calculus.LogDeriv
 import TauCeti.Analysis.Contour.LogDerivFTC
 
 /-!
@@ -21,13 +20,11 @@ reading of the same identity: `∮_γ f'/f` measures the total change of `arg (f
 origin**. This file supplies that reading, and it is what turns the argument principle into a
 statement about the geometry of the image rather than about an integral.
 
-The bridge is `TauCeti.windingNumber_comp_eq_integral_logDeriv`: along a piecewise-`C¹` curve `γ`
+The bridge is `TauCeti.Contour.windingNumber_comp_eq_integral_logDeriv`, supplied by the contour
+layer alongside the rest of the logarithmic-derivative machinery: along a piecewise-`C¹` curve `γ`
 on which `f` is analytic and zero-free, the composite `f ∘ γ` is itself a curve missing the origin,
 and its index integral `(2πi)⁻¹ ∮_{f ∘ γ} dw / w` is, after the substitution `w = f z`, exactly
-`(2πi)⁻¹ ∮_γ f'/f`. Formally the substitution is the chain rule `(f ∘ γ)' = γ' · f'(γ)`, valid off
-the finitely many breakpoints of `γ` and so almost everywhere — which is all an integral sees. No
-regularity of `f ∘ γ` beyond continuity and this almost-everywhere derivative is needed, so nothing
-has to be said about `f ∘ γ` being piecewise `C¹` (it is, but the winding number does not ask).
+`(2πi)⁻¹ ∮_γ f'/f`.
 
 Feeding the bridge into the homological argument principle gives the geometric statements. For `f`
 meromorphic on an open `U` with its zeros and poles confined to a finite `S`, and `γ` closed and
@@ -53,8 +50,6 @@ complex numbers, exactly as the underlying argument principle is.
 
 ## Main results
 
-* `TauCeti.windingNumber_comp_eq_integral_logDeriv` — the bridge: the winding number of the image
-  curve `f ∘ γ` about the origin is `(2πi)⁻¹ ∮_γ f'/f`.
 * `TauCeti.argumentPrinciple_windingNumber` — **the argument principle, geometric form**: for `f`
   meromorphic with orders `ord` on a finite `S` and `γ` null-homologous, the image curve winds
   `∑_{z ∈ S} n_z(γ) · ord z` times about the origin.
@@ -80,59 +75,13 @@ Tau Ceti adds at L0 is named, discoverable API, not first proof.
 
 public section
 
-open Complex MeasureTheory
+open Complex
 
 open scoped Interval
 
 namespace TauCeti
 
 variable {f : ℂ → ℂ} {U : Set ℂ} {S : Finset ℂ} {γ : ℝ → ℂ} {a b : ℝ}
-
-/-- **The winding number of the image curve is the logarithmic-derivative integral.** If `f` is
-analytic and zero-free along a piecewise-`C¹` curve `γ`, the composite `f ∘ γ` avoids the origin
-and
-
-`n_0(f ∘ γ) = (2πi)⁻¹ ∫_a^b γ' t · (f'/f) (γ t)`.
-
-This is the substitution `w = f z` in the index integral `(2πi)⁻¹ ∮_{f ∘ γ} dw / w`, carried out by
-the chain rule. The chain rule is available only off the breakpoints of `γ`, a finite set, so the
-two integrands agree merely almost everywhere — enough for both the integrals and the
-interval-integrability to transfer.
-
-The analyticity hypothesis is local: `AnalyticAt ℂ f (γ t)` asks only for *some* neighbourhood of
-each point of the curve on which `f` is analytic, never for one ambient open set carrying the whole
-curve, and imposes no condition beyond those neighbourhoods. So the lemma applies verbatim to a
-function with zeros and poles inside the region the curve encloses; that is what the argument
-principle then counts. -/
-theorem windingNumber_comp_eq_integral_logDeriv (hγ : Contour.IsPiecewiseC1On γ a b)
-    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hfne : ∀ t ∈ [[a, b]], f (γ t) ≠ 0) :
-    Contour.windingNumber (f ∘ γ) a b 0
-      = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, deriv γ t • logDeriv f (γ t) := by
-  obtain ⟨p, hp⟩ := hγ.exists_finset_differentiableAt
-  have hcont : ContinuousOn (f ∘ γ) [[a, b]] := fun t ht =>
-    (hfa t ht).continuousAt.comp_continuousWithinAt (hγ.continuousOn t ht)
-  -- Off the finitely many breakpoints of `γ` — and off the right endpoint, which `Ι a b` contains
-  -- but `Set.Ioo (min a b) (max a b)` does not — the chain rule identifies the two integrands.
-  have hae : ∀ᵐ t ∂(volume : Measure ℝ), t ∈ Ι a b →
-      deriv γ t • logDeriv f (γ t) = ((f ∘ γ) t - 0)⁻¹ * deriv (f ∘ γ) t := by
-    have hnull : ∀ᵐ t ∂(volume : Measure ℝ), t ∉ insert (max a b) (↑p : Set ℝ) :=
-      measure_eq_zero_iff_ae_notMem.mp ((p.finite_toSet.insert (max a b)).measure_zero volume)
-    filter_upwards [hnull] with t hts ht
-    have ht' : t ∈ Set.Ioc (min a b) (max a b) := ht
-    have htIoo : t ∈ Set.Ioo (min a b) (max a b) \ (↑p : Set ℝ) :=
-      ⟨⟨ht'.1, lt_of_le_of_ne ht'.2 fun h => hts (by simp [h])⟩,
-        fun h => hts (Set.mem_insert_of_mem _ h)⟩
-    have htu : t ∈ [[a, b]] := by
-      rw [← Set.Icc_min_max]
-      exact Set.Ioo_subset_Icc_self htIoo.1
-    have hcomp : logDeriv (f ∘ γ) t = logDeriv f (γ t) * deriv γ t :=
-      logDeriv_comp (hfa t htu).differentiableAt (hp t htIoo)
-    rw [sub_zero, ← div_eq_inv_mul, ← logDeriv_apply, hcomp, smul_eq_mul, mul_comm]
-  have hint : IntervalIntegrable (fun t => deriv γ t • logDeriv f (γ t)) volume a b :=
-    Contour.intervalIntegrable_deriv_smul_logDeriv hγ hfa hfne
-  rw [Contour.windingNumber_eq_integral_of_avoidance hcont
-      (fun t ht => hfne t ht) (hint.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae))]
-  exact congrArg _ (intervalIntegral.integral_congr_ae hae).symm
 
 /-- **The argument principle, geometric form.** Let `U` be open, `S` a finite set collecting every
 zero and pole of `f` in `U`: `f` is analytic and non-vanishing at each point of `U ∖ S`, and
@@ -157,7 +106,7 @@ theorem argumentPrinciple_windingNumber {ord : ℂ → ℤ} (hU : IsOpen U)
     (hγoff : ∀ t ∈ [[a, b]], γ t ∉ (↑S : Set ℂ)) (hnull : Contour.IsNullHomologous γ a b U) :
     Contour.windingNumber (f ∘ γ) a b 0
       = ∑ z ∈ S, Contour.windingNumber γ a b z * (ord z : ℂ) := by
-  rw [windingNumber_comp_eq_integral_logDeriv hγ
+  rw [Contour.windingNumber_comp_eq_integral_logDeriv hγ
       (fun t ht => (hoff _ (hγU t ht) (hγoff t ht)).1)
       (fun t ht => (hoff _ (hγU t ht) (hγoff t ht)).2),
     Contour.argumentPrinciple_nullHomologous hU hoff hmero hord hγ hγU hclosed hγoff hnull,
@@ -182,7 +131,7 @@ theorem argumentPrinciple_windingNumber_of_analyticOnNhd (hU : IsOpen U) (hf : A
     (hγoff : ∀ t ∈ [[a, b]], f (γ t) ≠ 0) (hnull : Contour.IsNullHomologous γ a b U) :
     Contour.windingNumber (f ∘ γ) a b 0
       = ∑ z ∈ S, Contour.windingNumber γ a b z * (analyticOrderNatAt f z : ℂ) := by
-  rw [windingNumber_comp_eq_integral_logDeriv hγ (fun t ht => hf _ (hγU t ht)) hγoff,
+  rw [Contour.windingNumber_comp_eq_integral_logDeriv hγ (fun t ht => hf _ (hγU t ht)) hγoff,
     Contour.argumentPrinciple_nullHomologous_of_analyticOnNhd hU hf hzeros hγ hγU hclosed hγoff
       hnull,
     inv_mul_cancel_left₀ two_pi_I_ne_zero]

--- a/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean
@@ -96,7 +96,7 @@ the winding number of `γ` about it.
 
 This is the reading that names the theorem — the total change of `arg (f z)` along `γ`, divided by
 `2π` — and it is `TauCeti.Contour.argumentPrinciple_nullHomologous` read through
-`TauCeti.windingNumber_comp_eq_integral_logDeriv`. As there, points of `S` outside `U` are
+`TauCeti.Contour.windingNumber_comp_eq_integral_logDeriv`. As there, points of `S` outside `U` are
 harmless: null-homology makes their winding number, hence their contribution, vanish. -/
 theorem argumentPrinciple_windingNumber {ord : ℂ → ℤ} (hU : IsOpen U)
     (hoff : ∀ z ∈ U, z ∉ S → AnalyticAt ℂ f z ∧ f z ≠ 0)

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -7,10 +7,10 @@ module
 
 public import Mathlib.Analysis.Analytic.Order
 public import Mathlib.Analysis.Meromorphic.Divisor
-public import TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple
 public import TauCeti.Analysis.Complex.ZeroCount
 public import TauCeti.Analysis.Contour.Argument.Cycle
 public import TauCeti.Analysis.Contour.Argument.Divisor
+import TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple
 import TauCeti.Analysis.Contour.LogDerivFTC
 import Mathlib.Analysis.Calculus.LogDeriv
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
@@ -98,9 +98,8 @@ equality, is how Rouché is normally used.
 * `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`, `TauCeti.rouche_nullHomologous`,
   `TauCeti.rouche_add_nullHomologous` — its holomorphic specialization in the same three
   phrasings as the disc statements.
-* `TauCeti.rouche_symm_windingNumber_comp`, `TauCeti.rouche_add_windingNumber_comp` — the "dog on
-  a leash" form: under the symmetric, respectively the additive, hypothesis along the curve, the
-  image curves wind equally often about the origin.
+* `TauCeti.rouche_symm_windingNumber_comp` — the "dog on a leash" form: under the symmetric
+  hypothesis along the curve, the image curves wind equally often about the origin.
 
 ## Coordination with upstream Mathlib
 
@@ -585,25 +584,6 @@ theorem rouche_symm_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (h
   rw [windingNumber_comp_eq_integral_logDeriv hγ hfa fun t ht => ne_zero_left (hs t ht),
     windingNumber_comp_eq_integral_logDeriv hγ hga fun t ht => ne_zero_right (hs t ht),
     integral_deriv_smul_logDeriv_eq_of_norm_sub_lt hγ hclosed hfa hga hs]
-
-/-- **Rouché's theorem as an equality of image winding numbers, additive form.** A holomorphic
-perturbation `g` dominated by `f` along a closed piecewise-`C¹` curve does not change how often the
-image winds about the origin. This is the phrasing that names the "dog on a leash" picture: the
-walker `f ∘ γ` and the dog `(f + g) ∘ γ`, on a leash shorter than the walker's distance from the
-lamppost at the origin, circle it the same number of times.
-
-It is the special case of `TauCeti.rouche_symm_windingNumber_comp` for the pair `f`, `f + g`,
-obtained by discarding the nonnegative summand `‖f (γ t) + g (γ t)‖`; the intermediate asymmetric
-hypothesis `‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` is the same specialisation and is not stated
-separately. -/
-theorem rouche_add_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
-    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
-    (hs : ∀ t ∈ [[a, b]], ‖g (γ t)‖ < ‖f (γ t)‖) :
-    Contour.windingNumber (f ∘ γ) a b 0
-      = Contour.windingNumber ((fun w => f w + g w) ∘ γ) a b 0 :=
-  rouche_symm_windingNumber_comp hγ hclosed hfa (fun t ht => (hfa t ht).add (hga t ht))
-    fun t ht => by
-      simpa using (hs t ht).trans_le (le_add_of_nonneg_right (norm_nonneg _))
 
 end Cycle
 

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -97,8 +97,9 @@ equality, is how Rouché is normally used.
 * `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`, `TauCeti.rouche_nullHomologous`,
   `TauCeti.rouche_add_nullHomologous` — its holomorphic specialization in the same three
   phrasings as the disc statements.
-* `TauCeti.rouche_symm_windingNumber_comp`, `TauCeti.rouche_add_windingNumber_comp` — the "dog on
-  a leash" form: under the symmetric, respectively the additive, hypothesis along the curve, the
+* `TauCeti.rouche_symm_windingNumber_comp`, `TauCeti.rouche_windingNumber_comp`,
+  `TauCeti.rouche_add_windingNumber_comp` — the "dog on a leash" form, in the same three phrasings:
+  under the symmetric, the classical, respectively the additive hypothesis along the curve, the
   image curves wind equally often about the origin.
 
 ## Coordination with upstream Mathlib
@@ -585,24 +586,32 @@ theorem rouche_symm_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (h
     Contour.windingNumber_comp_eq_integral_logDeriv hγ hga fun t ht => ne_zero_right (hs t ht),
     integral_deriv_smul_logDeriv_eq_of_norm_sub_lt hγ hclosed hfa hga hs]
 
+/-- **Rouché's theorem as an equality of image winding numbers**, classical form. Under
+`‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` along a closed piecewise-`C¹` curve, the image curves `f ∘ γ`
+and `g ∘ γ` wind equally often about the origin. This is the special case of
+`TauCeti.rouche_symm_windingNumber_comp` obtained by discarding the nonnegative summand
+`‖g (γ t)‖`. -/
+theorem rouche_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
+    (hs : ∀ t ∈ [[a, b]], ‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖) :
+    Contour.windingNumber (f ∘ γ) a b 0 = Contour.windingNumber (g ∘ γ) a b 0 :=
+  rouche_symm_windingNumber_comp hγ hclosed hfa hga fun t ht =>
+    (hs t ht).trans_le (le_add_of_nonneg_right (norm_nonneg _))
+
 /-- **Rouché's theorem as an equality of image winding numbers, additive form.** A holomorphic
 perturbation `g` dominated by `f` along a closed piecewise-`C¹` curve does not change how often the
 image winds about the origin. This is the phrasing that names the "dog on a leash" picture: the
 walker `f ∘ γ` and the dog `(f + g) ∘ γ`, on a leash shorter than the walker's distance from the
 lamppost at the origin, circle it the same number of times.
 
-It is the special case of `TauCeti.rouche_symm_windingNumber_comp` for the pair `f`, `f + g`,
-obtained by discarding the nonnegative summand `‖f (γ t) + g (γ t)‖`; the intermediate asymmetric
-hypothesis `‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` is the same specialisation and is not stated
-separately. -/
+It is the special case of `TauCeti.rouche_windingNumber_comp` for the pair `f`, `f + g`. -/
 theorem rouche_add_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
     (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
     (hs : ∀ t ∈ [[a, b]], ‖g (γ t)‖ < ‖f (γ t)‖) :
     Contour.windingNumber (f ∘ γ) a b 0
       = Contour.windingNumber ((fun w => f w + g w) ∘ γ) a b 0 :=
-  rouche_symm_windingNumber_comp hγ hclosed hfa (fun t ht => (hfa t ht).add (hga t ht))
-    fun t ht => by
-      simpa using (hs t ht).trans_le (le_add_of_nonneg_right (norm_nonneg _))
+  rouche_windingNumber_comp hγ hclosed hfa (fun t ht => (hfa t ht).add (hga t ht)) fun t ht => by
+    simpa using hs t ht
 
 end Cycle
 

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -10,7 +10,6 @@ public import Mathlib.Analysis.Meromorphic.Divisor
 public import TauCeti.Analysis.Complex.ZeroCount
 public import TauCeti.Analysis.Contour.Argument.Cycle
 public import TauCeti.Analysis.Contour.Argument.Divisor
-import TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple
 import TauCeti.Analysis.Contour.LogDerivFTC
 import Mathlib.Analysis.Calculus.LogDeriv
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
@@ -65,7 +64,7 @@ the slit-plane primitive is pushed across the corners of the curve by
 countable-exception logarithmic-derivative FTC.
 
 That equality of logarithmic-derivative integrals also has a purely geometric reading, obtained by
-running it through `TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple`: the two *image* curves
+running it through `TauCeti.Contour.windingNumber_comp_eq_integral_logDeriv`: the two *image* curves
 `f ∘ γ` and `g ∘ γ` wind equally often about the origin. That is the classical "dog on a leash"
 form, and it is stronger than the counting statement, needing only analyticity at each point of the
 curve — no single ambient open set, no finite `S`, no null-homology — because the vanishing of the
@@ -98,8 +97,9 @@ equality, is how Rouché is normally used.
 * `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`, `TauCeti.rouche_nullHomologous`,
   `TauCeti.rouche_add_nullHomologous` — its holomorphic specialization in the same three
   phrasings as the disc statements.
-* `TauCeti.rouche_symm_windingNumber_comp` — the "dog on a leash" form: under the symmetric
-  hypothesis along the curve, the image curves wind equally often about the origin.
+* `TauCeti.rouche_symm_windingNumber_comp`, `TauCeti.rouche_add_windingNumber_comp` — the "dog on
+  a leash" form: under the symmetric, respectively the additive, hypothesis along the curve, the
+  image curves wind equally often about the origin.
 
 ## Coordination with upstream Mathlib
 
@@ -581,9 +581,28 @@ theorem rouche_symm_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (h
     (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
     (hs : ∀ t ∈ [[a, b]], ‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖ + ‖g (γ t)‖) :
     Contour.windingNumber (f ∘ γ) a b 0 = Contour.windingNumber (g ∘ γ) a b 0 := by
-  rw [windingNumber_comp_eq_integral_logDeriv hγ hfa fun t ht => ne_zero_left (hs t ht),
-    windingNumber_comp_eq_integral_logDeriv hγ hga fun t ht => ne_zero_right (hs t ht),
+  rw [Contour.windingNumber_comp_eq_integral_logDeriv hγ hfa fun t ht => ne_zero_left (hs t ht),
+    Contour.windingNumber_comp_eq_integral_logDeriv hγ hga fun t ht => ne_zero_right (hs t ht),
     integral_deriv_smul_logDeriv_eq_of_norm_sub_lt hγ hclosed hfa hga hs]
+
+/-- **Rouché's theorem as an equality of image winding numbers, additive form.** A holomorphic
+perturbation `g` dominated by `f` along a closed piecewise-`C¹` curve does not change how often the
+image winds about the origin. This is the phrasing that names the "dog on a leash" picture: the
+walker `f ∘ γ` and the dog `(f + g) ∘ γ`, on a leash shorter than the walker's distance from the
+lamppost at the origin, circle it the same number of times.
+
+It is the special case of `TauCeti.rouche_symm_windingNumber_comp` for the pair `f`, `f + g`,
+obtained by discarding the nonnegative summand `‖f (γ t) + g (γ t)‖`; the intermediate asymmetric
+hypothesis `‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` is the same specialisation and is not stated
+separately. -/
+theorem rouche_add_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
+    (hs : ∀ t ∈ [[a, b]], ‖g (γ t)‖ < ‖f (γ t)‖) :
+    Contour.windingNumber (f ∘ γ) a b 0
+      = Contour.windingNumber ((fun w => f w + g w) ∘ γ) a b 0 :=
+  rouche_symm_windingNumber_comp hγ hclosed hfa (fun t ht => (hfa t ht).add (hga t ht))
+    fun t ht => by
+      simpa using (hs t ht).trans_le (le_add_of_nonneg_right (norm_nonneg _))
 
 end Cycle
 

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -67,9 +67,9 @@ countable-exception logarithmic-derivative FTC.
 That equality of logarithmic-derivative integrals also has a purely geometric reading, obtained by
 running it through `TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple`: the two *image* curves
 `f ∘ γ` and `g ∘ γ` wind equally often about the origin. That is the classical "dog on a leash"
-form, and it is stronger than the counting statement, needing only the hypotheses along the curve —
-no ambient open set, no finite `S`, no null-homology — because the vanishing of the slit-plane
-integral already holds there.
+form, and it is stronger than the counting statement, needing only analyticity at each point of the
+curve — no single ambient open set, no finite `S`, no null-homology — because the vanishing of the
+slit-plane integral already holds there.
 
 That same observation is what makes the count *detect* zeros rather than merely count them:
 `TauCeti.finsum_analyticOrderNatAt_ball_eq_zero_iff`, from `TauCeti.Analysis.Complex.ZeroCount`,
@@ -570,10 +570,12 @@ point in opposite directions there, the image curves `f ∘ γ` and `g ∘ γ` w
 the origin.
 
 Read through `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd`, this is the geometric face
-of `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`; on its own it is *stronger*, since only
-the behaviour of the two functions **along the curve** enters. Nothing is assumed off the curve —
-no ambient open set, no confinement of the zeros to a finite set, and no null-homology — because
-the equality of the two logarithmic-derivative integrals is already forced by the hypothesis: it
+of `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`; on its own it is *stronger*, since apart
+from analyticity at each point of the curve — `AnalyticAt`, hence on some neighbourhood of that
+point — only the behaviour of the two functions **along the curve** enters: no single ambient open
+set carrying both, no confinement of the zeros to a finite set, and no null-homology. That is
+because the equality of the two logarithmic-derivative integrals is already forced by the
+hypothesis: it
 puts `g / f` in `Complex.slitPlane`, where `Complex.log` is a single-valued primitive. It is only
 in *counting* the winding that those extra hypotheses are needed. -/
 theorem rouche_symm_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)

--- a/TauCeti/Analysis/Complex/Conformal/Rouche.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Rouche.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Analytic.Order
 public import Mathlib.Analysis.Meromorphic.Divisor
+public import TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple
 public import TauCeti.Analysis.Complex.ZeroCount
 public import TauCeti.Analysis.Contour.Argument.Cycle
 public import TauCeti.Analysis.Contour.Argument.Divisor
@@ -63,6 +64,13 @@ the slit-plane primitive is pushed across the corners of the curve by
 `TauCeti.Contour.integral_deriv_smul_logDeriv_eq_zero_of_mem_slitPlane`, the curve form of the
 countable-exception logarithmic-derivative FTC.
 
+That equality of logarithmic-derivative integrals also has a purely geometric reading, obtained by
+running it through `TauCeti.Analysis.Complex.Conformal.ArgumentPrinciple`: the two *image* curves
+`f ∘ γ` and `g ∘ γ` wind equally often about the origin. That is the classical "dog on a leash"
+form, and it is stronger than the counting statement, needing only the hypotheses along the curve —
+no ambient open set, no finite `S`, no null-homology — because the vanishing of the slit-plane
+integral already holds there.
+
 That same observation is what makes the count *detect* zeros rather than merely count them:
 `TauCeti.finsum_analyticOrderNatAt_ball_eq_zero_iff`, from `TauCeti.Analysis.Complex.ZeroCount`,
 says the count vanishes exactly when the function has no zero in the open disc, so Rouché transfers
@@ -90,6 +98,9 @@ equality, is how Rouché is normally used.
 * `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`, `TauCeti.rouche_nullHomologous`,
   `TauCeti.rouche_add_nullHomologous` — its holomorphic specialization in the same three
   phrasings as the disc statements.
+* `TauCeti.rouche_symm_windingNumber_comp`, `TauCeti.rouche_add_windingNumber_comp` — the "dog on
+  a leash" form: under the symmetric, respectively the additive, hypothesis along the curve, the
+  image curves wind equally often about the origin.
 
 ## Coordination with upstream Mathlib
 
@@ -552,6 +563,45 @@ theorem rouche_add_nullHomologous (hU : IsOpen U)
           (analyticOrderNatAt (fun w => f w + g w) z : ℂ) :=
   rouche_nullHomologous hU hf (hf.add hg) hfS hsumS hγ hγU hclosed hnull fun t ht => by
     simpa using hs t ht
+
+/-- **Rouché's theorem as an equality of image winding numbers, symmetric form** — the "dog on a
+leash" statement. If `f` and `g` are analytic along a closed piecewise-`C¹` curve `γ` and never
+point in opposite directions there, the image curves `f ∘ γ` and `g ∘ γ` wind equally often about
+the origin.
+
+Read through `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd`, this is the geometric face
+of `TauCeti.rouche_symm_nullHomologous_of_analyticOnNhd`; on its own it is *stronger*, since only
+the behaviour of the two functions **along the curve** enters. Nothing is assumed off the curve —
+no ambient open set, no confinement of the zeros to a finite set, and no null-homology — because
+the equality of the two logarithmic-derivative integrals is already forced by the hypothesis: it
+puts `g / f` in `Complex.slitPlane`, where `Complex.log` is a single-valued primitive. It is only
+in *counting* the winding that those extra hypotheses are needed. -/
+theorem rouche_symm_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
+    (hs : ∀ t ∈ [[a, b]], ‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖ + ‖g (γ t)‖) :
+    Contour.windingNumber (f ∘ γ) a b 0 = Contour.windingNumber (g ∘ γ) a b 0 := by
+  rw [windingNumber_comp_eq_integral_logDeriv hγ hfa fun t ht => ne_zero_left (hs t ht),
+    windingNumber_comp_eq_integral_logDeriv hγ hga fun t ht => ne_zero_right (hs t ht),
+    integral_deriv_smul_logDeriv_eq_of_norm_sub_lt hγ hclosed hfa hga hs]
+
+/-- **Rouché's theorem as an equality of image winding numbers, additive form.** A holomorphic
+perturbation `g` dominated by `f` along a closed piecewise-`C¹` curve does not change how often the
+image winds about the origin. This is the phrasing that names the "dog on a leash" picture: the
+walker `f ∘ γ` and the dog `(f + g) ∘ γ`, on a leash shorter than the walker's distance from the
+lamppost at the origin, circle it the same number of times.
+
+It is the special case of `TauCeti.rouche_symm_windingNumber_comp` for the pair `f`, `f + g`,
+obtained by discarding the nonnegative summand `‖f (γ t) + g (γ t)‖`; the intermediate asymmetric
+hypothesis `‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` is the same specialisation and is not stated
+separately. -/
+theorem rouche_add_windingNumber_comp (hγ : Contour.IsPiecewiseC1On γ a b) (hclosed : γ a = γ b)
+    (hfa : ∀ t ∈ [[a, b]], AnalyticAt ℂ f (γ t)) (hga : ∀ t ∈ [[a, b]], AnalyticAt ℂ g (γ t))
+    (hs : ∀ t ∈ [[a, b]], ‖g (γ t)‖ < ‖f (γ t)‖) :
+    Contour.windingNumber (f ∘ γ) a b 0
+      = Contour.windingNumber ((fun w => f w + g w) ∘ γ) a b 0 :=
+  rouche_symm_windingNumber_comp hγ hclosed hfa (fun t ht => (hfa t ht).add (hga t ht))
+    fun t ht => by
+      simpa using (hs t ht).trans_le (le_add_of_nonneg_right (norm_nonneg _))
 
 end Cycle
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -10,6 +10,7 @@ public import Mathlib.Analysis.Calculus.LogDeriv
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.Analysis.Contour.Curve.Integrability
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
 
@@ -37,6 +38,14 @@ difference — in particular it vanishes on a closed curve. This is the corner-t
 for `circleIntegral.integral_eq_zero_of_hasDerivWithinAt`, which needs a genuinely differentiable
 contour.
 
+That same integrand is what the winding number of the *image* curve computes: if `h` is moreover
+zero-free along `γ`, then `h ∘ γ` misses the origin and its index integral
+`(2πi)⁻¹ ∮_{h ∘ γ} dw / w` is, after the substitution `w = h z`, exactly
+`(2πi)⁻¹ ∫_a^b γ' • (logDeriv h ∘ γ)`. Formally the substitution is the chain rule
+`(h ∘ γ)' = γ' · h'(γ)`, available off the breakpoints of `γ` and so almost everywhere, which is all
+an integral sees. This bridge is what turns every logarithmic-derivative integral identity — the
+argument principle above all — into a statement about how often an image curve winds.
+
 ## Main results
 
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
@@ -53,6 +62,8 @@ contour.
   argument-principle integrand `deriv γ • (logDeriv h ∘ γ)` along a piecewise-`C¹` curve.
 * `TauCeti.Contour.integral_deriv_smul_logDeriv_eq_zero_of_mem_slitPlane` — that integral vanishes
   along a closed piecewise-`C¹` curve on which `h` is analytic and slit-plane-valued.
+* `TauCeti.Contour.windingNumber_comp_eq_integral_logDeriv` — the bridge to the image curve: the
+  winding number of `h ∘ γ` about the origin is `(2πi)⁻¹ ∫_a^b γ' • (logDeriv h ∘ γ)`.
 
 ## Provenance
 
@@ -169,5 +180,54 @@ theorem integral_deriv_smul_logDeriv_eq_zero_of_mem_slitPlane {γ : ℝ → ℂ}
   have hmem : t ∈ uIcc a b := Ioo_subset_Icc_self ht.1
   simpa only [Function.comp_def, smul_eq_mul] using
     ((hh t hmem).differentiableAt.hasDerivAt).scomp t ((hPd t ht).hasDerivAt)
+
+/-- **The winding number of the image curve is the logarithmic-derivative integral.** If `h` is
+analytic and zero-free along a piecewise-`C¹` curve `γ`, the composite `h ∘ γ` avoids the origin
+and
+
+`n_0(h ∘ γ) = (2πi)⁻¹ ∫_a^b γ' t · (logDeriv h) (γ t)`.
+
+This is the substitution `w = h z` in the index integral `(2πi)⁻¹ ∮_{h ∘ γ} dw / w`, carried out by
+the chain rule. The chain rule is available only off the breakpoints of `γ`, a finite set, so the
+two integrands agree merely almost everywhere — enough for both the integrals and the
+interval-integrability to transfer. No regularity of `h ∘ γ` beyond continuity and this
+almost-everywhere derivative is needed, so nothing has to be said about `h ∘ γ` being
+piecewise `C¹` (it is, but `windingNumber` does not ask).
+
+The analyticity hypothesis is local: `AnalyticAt ℂ h (γ t)` asks only for *some* neighbourhood of
+each point of the curve on which `h` is analytic, never for one ambient open set carrying the whole
+curve, and imposes no condition beyond those neighbourhoods. So the lemma applies verbatim to a
+function with zeros and poles inside the region the curve encloses; that is what the argument
+principle then counts. -/
+theorem windingNumber_comp_eq_integral_logDeriv {γ : ℝ → ℂ} {h : ℂ → ℂ} {a b : ℝ}
+    (hγ : IsPiecewiseC1On γ a b) (hh : ∀ t ∈ uIcc a b, AnalyticAt ℂ h (γ t))
+    (hne : ∀ t ∈ uIcc a b, h (γ t) ≠ 0) :
+    windingNumber (h ∘ γ) a b 0
+      = (2 * (Real.pi : ℂ) * Complex.I)⁻¹ * ∫ t in a..b, deriv γ t • logDeriv h (γ t) := by
+  obtain ⟨p, hp⟩ := hγ.exists_finset_differentiableAt
+  have hcont : ContinuousOn (h ∘ γ) (uIcc a b) := fun t ht =>
+    (hh t ht).continuousAt.comp_continuousWithinAt (hγ.continuousOn t ht)
+  -- Off the finitely many breakpoints of `γ` — and off the right endpoint, which `Ι a b` contains
+  -- but `Set.Ioo (min a b) (max a b)` does not — the chain rule identifies the two integrands.
+  have hae : ∀ᵐ t ∂(volume : Measure ℝ), t ∈ Ι a b →
+      deriv γ t • logDeriv h (γ t) = ((h ∘ γ) t - 0)⁻¹ * deriv (h ∘ γ) t := by
+    have hnull : ∀ᵐ t ∂(volume : Measure ℝ), t ∉ insert (max a b) (↑p : Set ℝ) :=
+      measure_eq_zero_iff_ae_notMem.mp ((p.finite_toSet.insert (max a b)).measure_zero volume)
+    filter_upwards [hnull] with t hts ht
+    have ht' : t ∈ Ioc (min a b) (max a b) := ht
+    have htIoo : t ∈ Ioo (min a b) (max a b) \ (↑p : Set ℝ) :=
+      ⟨⟨ht'.1, lt_of_le_of_ne ht'.2 fun hmax => hts (by simp [hmax])⟩,
+        fun hmem => hts (Set.mem_insert_of_mem _ hmem)⟩
+    have htu : t ∈ uIcc a b := by
+      rw [← Set.Icc_min_max]
+      exact Ioo_subset_Icc_self htIoo.1
+    have hcomp : logDeriv (h ∘ γ) t = logDeriv h (γ t) * deriv γ t :=
+      logDeriv_comp (hh t htu).differentiableAt (hp t htIoo)
+    rw [sub_zero, ← div_eq_inv_mul, ← logDeriv_apply, hcomp, smul_eq_mul, mul_comm]
+  have hint : IntervalIntegrable (fun t => deriv γ t • logDeriv h (γ t)) volume a b :=
+    intervalIntegrable_deriv_smul_logDeriv hγ hh hne
+  rw [windingNumber_eq_integral_of_avoidance hcont
+      (fun t ht => hne t ht) (hint.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae))]
+  exact congrArg _ (intervalIntegral.integral_congr_ae hae).symm
 
 end TauCeti.Contour


### PR DESCRIPTION
This PR states the argument principle in its geometric, winding-number form, and reads Rouché's theorem off it as the classical "dog on a leash". The contour-integration development already supplies the analytic identity — `TauCeti.Contour.argumentPrinciple_nullHomologous`, the integral of `f'/f` along a null-homologous cycle equals `2πi` times the winding-weighted count of zeros minus poles. What is missing is the reading that names the theorem: `∮_γ f'/f` measures the total change of `arg (f z)` along `γ`, so what it computes is how often the *image* curve `f ∘ γ` winds around the origin. Nothing in the repository related `TauCeti.Contour.windingNumber` of an image curve to anything before this PR.

The bridge is `TauCeti.windingNumber_comp_eq_integral_logDeriv`: for `f` analytic and zero-free along a piecewise-`C¹` curve `γ`, the composite `f ∘ γ` misses the origin and its index integral `(2πi)⁻¹ ∮_{f ∘ γ} dw / w` is exactly `(2πi)⁻¹ ∮_γ f'/f`. The substitution is the chain rule `(f ∘ γ)' = γ' · f'(γ)`, available only off the finitely many breakpoints of `γ` — hence almost everywhere, which is all the integral and the interval-integrability see; `f ∘ γ` never has to be shown piecewise `C¹`, since the generalized winding number does not ask. Feeding the bridge into the homological argument principle gives `TauCeti.argumentPrinciple_windingNumber` (`n_0(f ∘ γ) = ∑_{z ∈ S} n_z(γ) · ord z`, for meromorphic `f` with caller-supplied orders), its one-point case `TauCeti.argumentPrinciple_windingNumber_local`, the holomorphic case `TauCeti.argumentPrinciple_windingNumber_of_analyticOnNhd` with the orders read off by `analyticOrderNatAt`, and the degenerate case `TauCeti.windingNumber_comp_eq_zero_of_forall_ne_zero`, where a zero-free function unwinds every null-homologous cycle.

`TauCeti/Analysis/Complex/Conformal/Rouche.lean` then gains `TauCeti.rouche_symm_windingNumber_comp` and `TauCeti.rouche_add_windingNumber_comp`: under the symmetric (Estermann), respectively the additive, hypothesis along the curve, the two image curves wind equally often about the origin. These live in `Rouche.lean` because they consume its existing slit-plane lemma, and they are genuinely stronger than the counting forms already there — only the behaviour of `f` and `g` **along** the curve enters, with no ambient open set, no confinement of the zeros to a finite `S`, and no null-homology, since the equality of the two logarithmic-derivative integrals is already forced by the hypothesis. The intermediate asymmetric phrasing `‖f (γ t) - g (γ t)‖ < ‖f (γ t)‖` is the same specialisation as the additive one and is deliberately not stated a third time. Only the module docstring and the two new theorems change in that file.

Roadmap target: `TauCetiRoadmap/ConformalMapping/README.md`, layer **L0 — the local-mapping engine**, whose charter is to *consume* the argument principle and global Cauchy theorem from the sibling `ContourIntegration` roadmap and add the conformal-geometric consequences (Rouché among them) on top; the README's *Suggested home* line names `…/Conformal/ArgumentPrinciple.lean` explicitly, which is where the new file goes. Nothing here re-derives the argument principle: the analytic content is `TauCeti.Contour.argumentPrinciple_nullHomologous` and the corner-tolerant logarithmic-derivative regularity of `TauCeti/Analysis/Contour/LogDerivFTC.lean` (`intervalIntegrable_deriv_smul_logDeriv`), both consumed as they stand. Per the roadmap's *Coordination with upstream Mathlib* clause, the L0 material overlaps [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), which proves an argument principle internally as the private `circleIntegral_logDeriv_eq_finsum_analyticOrderNatAdd`; the new file records that it is a temporary shim, to be re-backed onto or deleted in favour of the Mathlib lemmas once they land, with its consumers refactored.

No Mathlib source is vendored. The generalized winding number of `TauCeti.Contour.windingNumber` is complex-valued, defined by a principal value, so no integrality is claimed anywhere: every statement below is an identity of complex numbers, exactly as the underlying argument principle is.

Files: `TauCeti/Analysis/Complex/Conformal/ArgumentPrinciple.lean` (new, 235 lines) and `TauCeti/Analysis/Complex/Conformal/Rouche.lean` (+50 lines). `lake build` completes green over 6524 jobs, `lake exe axioms` audits 23238 declarations within `[propext, Classical.choice, Quot.sound]`, `lake exe module-system` and `scripts/lint-env.sh` both pass with no new violations.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"argument-principle-image-winding-number"}-->

🤖 Prepared with Claude Code
