### PR TITLE
feat: the standard representation of the symmetric group is irreducible

### DIFF
--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -110,6 +110,7 @@ variable (k : Type*) [CommSemiring k] (G X : Type*) [Group G] [MulAction G X]
 
 /-- The augmentation is invariant: a group element permutes the standard basis, so it does not
 change the sum of the coefficients. -/
+@[simp]
 theorem sumCoords_basis_ofMulAction (g : G) (v : MonoidAlgebra k X) :
     (MonoidAlgebra.basis X k).sumCoords (Representation.ofMulAction k G X g v) =
       (MonoidAlgebra.basis X k).sumCoords v := by
@@ -173,7 +174,10 @@ theorem coeff_permutationSum (x : X) : (permutationSum k X).coeff x = 1 := by
   classical
   simp [permutationSum, MonoidAlgebra.coeff_single, Finsupp.single_apply, Finset.sum_ite_eq']
 
-/-- The augmentation of the sum of the standard basis is the cardinality of the index type. -/
+/-- The augmentation of the sum of the standard basis is the cardinality of the index type.
+
+Deliberately not `@[simp]`: `simp` already proves this from `TauCeti.coeff_permutationSum` and the
+generic basis API, so tagging it would be a `simpNF` violation. -/
 theorem sumCoords_basis_permutationSum :
     (MonoidAlgebra.basis X k).sumCoords (permutationSum k X) = Fintype.card X := by
   simp
@@ -217,6 +221,7 @@ theorem toSubmodule_invariantLine :
 
 /-- The invariant line carries the trivial representation: the sum of the standard basis, and
 hence every multiple of it, is fixed. -/
+@[simp]
 theorem toRepresentation_invariantLine :
     (invariantLine k G X).toRepresentation = Representation.trivial k G _ := by
   refine DFunLike.ext _ _ fun g => LinearMap.ext fun w => Subtype.ext ?_
@@ -325,6 +330,7 @@ theorem isCompl_invariantLine_augmentationSubrepresentation
 
 /-- The augmentation subrepresentation has dimension one less than the cardinality of `X`.  For an
 empty `X` both sides are zero, the subtraction being truncated. -/
+@[simp]
 theorem finrank_augmentationSubrepresentation :
     Module.finrank k (augmentationSubrepresentation k G X).toSubmodule = Fintype.card X - 1 := by
   rcases isEmpty_or_nonempty X with hX | hX

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -29,14 +29,16 @@ the symmetric group in `TauCeti.RepresentationTheory.Symmetric.Standard` is the 
 
 ## Main results
 
-* `TauCeti.sumCoords_basis_ofMulAction`: the augmentation is invariant, which is what makes both
-  subrepresentations subrepresentations.
+* `TauCeti.sumCoords_basis_ofMulAction`: the augmentation is invariant, which is what makes the
+  augmentation subrepresentation a subrepresentation.
+* `TauCeti.ofMulAction_permutationSum`: the sum of the standard basis is fixed, which is what makes
+  the invariant line one.
 * `TauCeti.toRepresentation_invariantLine`: the invariant line carries the trivial representation,
   and `TauCeti.finrank_invariantLine` says it is a line.
 * `TauCeti.ker_sumCoords_basis_eq_span`: the augmentation subrepresentation is spanned by the
   differences of the standard basis vectors from a fixed one.
-* `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`: when `|X|` is invertible in `k`
-  the two subrepresentations are complementary.
+* `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`: when `|X|` is invertible in `k`,
+  or `X` is empty, the two subrepresentations are complementary.
 * `TauCeti.finrank_augmentationSubrepresentation`: the augmentation subrepresentation has
   dimension `|X| - 1`.
 
@@ -54,7 +56,8 @@ Invertibility of `|X|` in `k`, rather than an ordered field or an averaging oper
 splitting needs, and for a nonempty `X` over a nontrivial `k` it is the sharp hypothesis: if
 `|X| = 0` in `k` then `permutationSum` is a nonzero element of the augmentation subrepresentation,
 so the invariant line meets it and the two are not complementary.  For an empty `X`, or a trivial
-`k`, every module in sight is zero and the two are complementary whatever `|X|` is in `k`.
+`k`, every module in sight is zero and the two are complementary whatever `|X|` is in `k`; the
+empty case is the first disjunct of `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`.
 
 ## References
 
@@ -230,6 +233,15 @@ theorem toRepresentation_invariantLine :
     LinearMap.coe_restrict_apply, Representation.trivial_apply]
   rw [← hc, map_smul, ofMulAction_permutationSum]
 
+variable {k G X}
+
+/-- The elements of the invariant line are exactly the multiples of the sum of the standard
+basis. -/
+@[simp]
+theorem mem_invariantLine_iff {v : MonoidAlgebra k X} :
+    v ∈ invariantLine k G X ↔ ∃ c : k, c • permutationSum k X = v :=
+  Submodule.mem_span_singleton
+
 end InvariantLine
 
 /-! ### The splitting -/
@@ -277,9 +289,19 @@ variable {k G X}
 
 /-- **The permutation representation splits.**  When the cardinality of `X` is invertible in `k`,
 the invariant line and the augmentation subrepresentation are complementary, so `k[X]` is the
-direct sum of a trivial representation and a representation of dimension `|X| - 1`. -/
-theorem isCompl_invariantLine_augmentationSubrepresentation (h : (Fintype.card X : k) ≠ 0) :
+direct sum of a trivial representation and a representation of dimension `|X| - 1`.  For an empty
+`X` the two are complementary as well, for the degenerate reason that `k[X]` is then the zero
+module. -/
+theorem isCompl_invariantLine_augmentationSubrepresentation
+    (h : IsEmpty X ∨ (Fintype.card X : k) ≠ 0) :
     IsCompl (invariantLine k G X) (augmentationSubrepresentation k G X) := by
+  rcases h with hX | h
+  · -- `k[X]` is the zero module, so it has only one subrepresentation
+    have : Subsingleton (MonoidAlgebra k X) :=
+      ⟨fun v w => MonoidAlgebra.coeff_inj.mp (Finsupp.ext fun x => hX.elim x)⟩
+    have : Subsingleton (Subrepresentation (Representation.ofMulAction k G X)) :=
+      Subrepresentation.toSubmodule_injective.subsingleton
+    exact ⟨disjoint_iff.mpr (Subsingleton.elim _ _), codisjoint_iff.mpr (Subsingleton.elim _ _)⟩
   have hsub : IsCompl (Submodule.span k {permutationSum k X})
       (LinearMap.ker (MonoidAlgebra.basis X k).sumCoords) := by
     constructor

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -24,20 +24,18 @@ the symmetric group in `TauCeti.RepresentationTheory.Symmetric.Standard` is the 
 
 ## Main definitions
 
-* `TauCeti.coeffSum`: the augmentation of `k[X]`, the linear map summing all coefficients.
 * `TauCeti.permutationSum`: the sum of the standard basis of `k[X]`, for a finite `X`.
 * `TauCeti.invariantLine`: the line spanned by `TauCeti.permutationSum`, as a subrepresentation.
-* `TauCeti.augmentationSubrepresentation`: the kernel of `TauCeti.coeffSum`, as a
-  subrepresentation.
+* `TauCeti.augmentationSubrepresentation`: the kernel of the augmentation, as a subrepresentation.
 
 ## Main results
 
-* `TauCeti.coeffSum_ofMulAction`: the augmentation is invariant, which is what makes both
+* `TauCeti.sumCoords_basis_ofMulAction`: the augmentation is invariant, which is what makes both
   subrepresentations subrepresentations.
 * `TauCeti.toRepresentation_invariantLine`: the invariant line carries the trivial representation,
   and `TauCeti.finrank_invariantLine` says it is a line.
-* `TauCeti.ker_coeffSum_eq_span`: the augmentation subrepresentation is spanned by the differences
-  of the standard basis vectors from a fixed one.
+* `TauCeti.ker_sumCoords_basis_eq_span`: the augmentation subrepresentation is spanned by the
+  differences of the standard basis vectors from a fixed one.
 * `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`: when `|X|` is invertible in `k`
   the two subrepresentations are complementary.
 * `TauCeti.finrank_augmentationSubrepresentation`: the augmentation subrepresentation has
@@ -45,9 +43,10 @@ the symmetric group in `TauCeti.RepresentationTheory.Symmetric.Standard` is the 
 
 ## Implementation notes
 
-The augmentation here is a `k`-linear map on the free module `k[X]` of an arbitrary index type `X`,
-because that is what a permutation representation acts on.  It is therefore *not* an instance of
-`TauCeti.MonoidAlgebra.augmentation` of `TauCeti.Algebra.MonoidAlgebra.Exactness`, which is the
+The augmentation used here is Mathlib's `Module.Basis.sumCoords` of the standard basis
+`MonoidAlgebra.basis X k`, a `k`-linear map on the free module `k[X]` of an arbitrary index type
+`X`, because that is what a permutation representation acts on.  It is therefore *not* an instance
+of `TauCeti.MonoidAlgebra.augmentation` of `TauCeti.Algebra.MonoidAlgebra.Exactness`, which is the
 ring homomorphism `k[M] →+* k` of a monoid algebra: a `G`-set carries no multiplication, so there
 is no ring structure on `k[X]` for a ring homomorphism to be defined on.  On the overlap, `X` a
 monoid, the two maps agree, both sending `single x a` to `a`.
@@ -73,33 +72,32 @@ namespace TauCeti
 
 section Augmentation
 
-variable (k : Type*) [CommSemiring k] (X : Type*)
+variable {k : Type*} [CommSemiring k] {X : Type*}
 
-/-- The **augmentation** of `k[X]`: the linear map sending an element to the sum of its
-coefficients.  Equivalently, it is the unique linear map sending every standard basis vector
-to `1`. -/
-noncomputable def coeffSum : MonoidAlgebra k X →ₗ[k] k :=
-  (Finsupp.lsum k fun _ : X => LinearMap.id) ∘ₗ (MonoidAlgebra.coeffLinearEquiv k).toLinearMap
+/-- The **augmentation** of `k[X]` is `Module.Basis.sumCoords` of the standard basis: the linear
+map sending an element to the sum of its coefficients.  It sums them over the support. -/
+theorem sumCoords_basis_apply (v : MonoidAlgebra k X) :
+    (MonoidAlgebra.basis X k).sumCoords v = v.coeff.sum fun _ a => a :=
+  rfl
 
-variable {k X}
+/-- The augmentation sends a standard basis vector to its coefficient.
 
-/-- The augmentation sums the coefficients over the support. -/
-theorem coeffSum_apply (v : MonoidAlgebra k X) : coeffSum k X v = v.coeff.sum fun _ a => a := by
-  simp [coeffSum, Finsupp.sum]
-
-/-- The augmentation sends a standard basis vector to its coefficient. -/
-@[simp]
-theorem coeffSum_single (x : X) (a : k) : coeffSum k X (MonoidAlgebra.single x a) = a := by
-  rw [coeffSum_apply, MonoidAlgebra.coeff_single, Finsupp.sum_single_index rfl]
+This is not a `simp` lemma: `Module.Basis.coe_sumCoords` already rewrites the left-hand side, so
+the statement is not in `simp` normal form.  The same applies to the other lemmas below whose
+left-hand side is an augmentation. -/
+theorem sumCoords_basis_single (x : X) (a : k) :
+    (MonoidAlgebra.basis X k).sumCoords (MonoidAlgebra.single x a) = a := by
+  rw [sumCoords_basis_apply, MonoidAlgebra.coeff_single, Finsupp.sum_single_index rfl]
 
 /-- Over a finite index type the augmentation is the sum of all the coefficients. -/
-theorem coeffSum_eq_sum [Fintype X] (v : MonoidAlgebra k X) :
-    coeffSum k X v = ∑ x : X, v.coeff x := by
-  rw [coeffSum_apply, Finsupp.sum_fintype _ _ fun _ => rfl]
+theorem sumCoords_basis_eq_sum [Fintype X] (v : MonoidAlgebra k X) :
+    (MonoidAlgebra.basis X k).sumCoords v = ∑ x : X, v.coeff x := by
+  rw [sumCoords_basis_apply, Finsupp.sum_fintype _ _ fun _ => rfl]
 
 /-- The augmentation is surjective as soon as there is a standard basis vector to hit `1`. -/
-theorem coeffSum_surjective [Nonempty X] : Function.Surjective (coeffSum k X) := fun a =>
-  ⟨MonoidAlgebra.single (Classical.arbitrary X) a, coeffSum_single _ _⟩
+theorem sumCoords_basis_surjective [Nonempty X] :
+    Function.Surjective (MonoidAlgebra.basis X k).sumCoords := fun a =>
+  ⟨MonoidAlgebra.single (Classical.arbitrary X) a, sumCoords_basis_single _ _⟩
 
 end Augmentation
 
@@ -111,26 +109,27 @@ variable (k : Type*) [CommSemiring k] (G X : Type*) [Group G] [MulAction G X]
 
 /-- The augmentation is invariant: a group element permutes the standard basis, so it does not
 change the sum of the coefficients. -/
-@[simp]
-theorem coeffSum_ofMulAction (g : G) (v : MonoidAlgebra k X) :
-    coeffSum k X (Representation.ofMulAction k G X g v) = coeffSum k X v := by
+theorem sumCoords_basis_ofMulAction (g : G) (v : MonoidAlgebra k X) :
+    (MonoidAlgebra.basis X k).sumCoords (Representation.ofMulAction k G X g v) =
+      (MonoidAlgebra.basis X k).sumCoords v := by
   have hcoeff : (Representation.ofMulAction k G X g v).coeff =
       Finsupp.mapDomain (g • ·) v.coeff := by
     simp [Representation.ofMulAction_def]
-  rw [coeffSum_apply, coeffSum_apply, hcoeff,
+  rw [sumCoords_basis_apply, sumCoords_basis_apply, hcoeff,
     Finsupp.sum_mapDomain_index_inj (MulAction.injective g)]
 
 /-- The **augmentation subrepresentation** of `k[X]`: the elements whose coefficients sum to
 zero. -/
 noncomputable def augmentationSubrepresentation :
     Subrepresentation (Representation.ofMulAction k G X) where
-  toSubmodule := LinearMap.ker (coeffSum k X)
+  toSubmodule := LinearMap.ker (MonoidAlgebra.basis X k).sumCoords
   apply_mem_toSubmodule g v hv := by
-    simpa only [LinearMap.mem_ker, coeffSum_ofMulAction] using hv
+    simpa only [LinearMap.mem_ker, sumCoords_basis_ofMulAction] using hv
 
 @[simp]
 theorem toSubmodule_augmentationSubrepresentation :
-    (augmentationSubrepresentation k G X).toSubmodule = LinearMap.ker (coeffSum k X) :=
+    (augmentationSubrepresentation k G X).toSubmodule =
+      LinearMap.ker (MonoidAlgebra.basis X k).sumCoords :=
   -- `(rfl)`, not `rfl`: the body of `augmentationSubrepresentation` is not `@[expose]`d, so this
   -- must not be inferred `@[defeq]`.
   (rfl)
@@ -139,7 +138,7 @@ variable {k G X}
 
 @[simp]
 theorem mem_augmentationSubrepresentation_iff {v : MonoidAlgebra k X} :
-    v ∈ augmentationSubrepresentation k G X ↔ coeffSum k X v = 0 :=
+    v ∈ augmentationSubrepresentation k G X ↔ (MonoidAlgebra.basis X k).sumCoords v = 0 :=
   Iff.rfl
 
 end Subrep
@@ -152,7 +151,8 @@ variable {k : Type*} [CommRing k] {G X : Type*} [Group G] [MulAction G X]
 theorem single_sub_single_mem_augmentationSubrepresentation (x y : X) :
     (MonoidAlgebra.single x 1 - MonoidAlgebra.single y 1 : MonoidAlgebra k X) ∈
       augmentationSubrepresentation k G X := by
-  simp
+  rw [mem_augmentationSubrepresentation_iff, map_sub, sumCoords_basis_single,
+    sumCoords_basis_single, sub_self]
 
 end SubrepRing
 
@@ -173,9 +173,9 @@ theorem coeff_permutationSum (x : X) : (permutationSum k X).coeff x = 1 := by
   simp [permutationSum, MonoidAlgebra.coeff_single, Finsupp.single_apply, Finset.sum_ite_eq']
 
 /-- The augmentation of the sum of the standard basis is the cardinality of the index type. -/
-@[simp]
-theorem coeffSum_permutationSum : coeffSum k X (permutationSum k X) = Fintype.card X := by
-  rw [coeffSum_eq_sum]
+theorem sumCoords_basis_permutationSum :
+    (MonoidAlgebra.basis X k).sumCoords (permutationSum k X) = Fintype.card X := by
+  rw [sumCoords_basis_eq_sum]
   simp
 
 /-- The sum of the standard basis is nonzero, since each of its coefficients is `1`. -/
@@ -236,13 +236,13 @@ variable (k : Type*) [Field k] (G X : Type*) [Group G] [MulAction G X]
 
 /-- The augmentation subrepresentation is spanned by the differences of the standard basis vectors
 from a fixed one. -/
-theorem ker_coeffSum_eq_span (x₀ : X) :
-    LinearMap.ker (coeffSum k X) =
+theorem ker_sumCoords_basis_eq_span (x₀ : X) :
+    LinearMap.ker (MonoidAlgebra.basis X k).sumCoords =
       Submodule.span k (Set.range fun x : X =>
         (MonoidAlgebra.single x 1 - MonoidAlgebra.single x₀ 1 : MonoidAlgebra k X)) := by
   classical
   refine le_antisymm (fun v hv => ?_) (Submodule.span_le.mpr ?_)
-  · rw [LinearMap.mem_ker, coeffSum_apply, Finsupp.sum] at hv
+  · rw [LinearMap.mem_ker, sumCoords_basis_apply, Finsupp.sum] at hv
     have hbasis : ∑ x ∈ v.coeff.support, MonoidAlgebra.single x (v.coeff x) = v :=
       MonoidAlgebra.sum_coeff_single v
     have key : ∑ x ∈ v.coeff.support, v.coeff x •
@@ -254,7 +254,7 @@ theorem ker_coeffSum_eq_span (x₀ : X) :
     exact Submodule.sum_mem _ fun x _ =>
       Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, rfl⟩)
   · rintro _ ⟨x, rfl⟩
-    simp
+    simp only [SetLike.mem_coe, LinearMap.mem_ker, map_sub, sumCoords_basis_single, sub_self]
 
 variable [Fintype X]
 
@@ -272,19 +272,22 @@ the invariant line and the augmentation subrepresentation are complementary, so 
 direct sum of a trivial representation and a representation of dimension `|X| - 1`. -/
 theorem isCompl_invariantLine_augmentationSubrepresentation (h : (Fintype.card X : k) ≠ 0) :
     IsCompl (invariantLine k G X) (augmentationSubrepresentation k G X) := by
-  have hsub : IsCompl (Submodule.span k {permutationSum k X}) (LinearMap.ker (coeffSum k X)) := by
+  have hsub : IsCompl (Submodule.span k {permutationSum k X})
+      (LinearMap.ker (MonoidAlgebra.basis X k).sumCoords) := by
     constructor
     · rw [Submodule.disjoint_def]
       rintro v hv hv'
       obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.mp hv
-      rw [LinearMap.mem_ker, map_smul, coeffSum_permutationSum, smul_eq_mul] at hv'
+      rw [LinearMap.mem_ker, map_smul, sumCoords_basis_permutationSum, smul_eq_mul] at hv'
       rw [(mul_eq_zero.mp hv').resolve_right h, zero_smul]
     · rw [codisjoint_iff, eq_top_iff]
       intro v _
-      refine Submodule.mem_sup.mpr ⟨(coeffSum k X v / Fintype.card X) • permutationSum k X,
+      refine Submodule.mem_sup.mpr
+        ⟨((MonoidAlgebra.basis X k).sumCoords v / Fintype.card X) • permutationSum k X,
         Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _),
-        v - (coeffSum k X v / Fintype.card X) • permutationSum k X, ?_, by abel⟩
-      rw [LinearMap.mem_ker, map_sub, map_smul, coeffSum_permutationSum, smul_eq_mul,
+        v - ((MonoidAlgebra.basis X k).sumCoords v / Fintype.card X) • permutationSum k X,
+        ?_, by abel⟩
+      rw [LinearMap.mem_ker, map_sub, map_smul, sumCoords_basis_permutationSum, smul_eq_mul,
         div_mul_cancel₀ _ h, sub_self]
   constructor
   · rw [disjoint_iff]
@@ -298,10 +301,10 @@ theorem finrank_augmentationSubrepresentation [Nonempty X] :
   have hcard : Module.finrank k (MonoidAlgebra k X) = Fintype.card X :=
     (Module.finrank_eq_card_basis (MonoidAlgebra.basis X k)).trans (by simp)
   have : Module.Finite k (MonoidAlgebra k X) := Module.Finite.of_basis (MonoidAlgebra.basis X k)
-  have hrange : Module.finrank k (LinearMap.range (coeffSum k X)) = 1 := by
-    rw [LinearMap.range_eq_top.mpr coeffSum_surjective]
+  have hrange : Module.finrank k (LinearMap.range (MonoidAlgebra.basis X k).sumCoords) = 1 := by
+    rw [LinearMap.range_eq_top.mpr sumCoords_basis_surjective]
     simp
-  have hsum := LinearMap.finrank_range_add_finrank_ker (coeffSum k X)
+  have hsum := LinearMap.finrank_range_add_finrank_ker (MonoidAlgebra.basis X k).sumCoords
   rw [hrange, hcard] at hsum
   rw [toSubmodule_augmentationSubrepresentation]
   omega

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -162,7 +162,7 @@ end SubrepRing
 
 section PermutationSum
 
-variable (k : Type*) [CommSemiring k] (X : Type*) [Fintype X]
+variable (k : Type*) [Semiring k] (X : Type*) [Fintype X]
 
 /-- The sum of the standard basis of `k[X]`, for a finite index type. -/
 noncomputable def permutationSum : MonoidAlgebra k X := ∑ x : X, MonoidAlgebra.single x (1 : k)
@@ -249,7 +249,7 @@ end InvariantLine
 
 section Span
 
-variable (k : Type*) [CommRing k] (X : Type*)
+variable (k : Type*) [Ring k] (X : Type*)
 
 /-- The augmentation subrepresentation is spanned by the differences of the standard basis vectors
 from a fixed one. -/

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.MonoidAlgebra.Module
-public import Mathlib.RepresentationTheory.Basic
 public import Mathlib.RepresentationTheory.Subrepresentation
 
 /-!
@@ -52,8 +51,10 @@ is no ring structure on `k[X]` for a ring homomorphism to be defined on.  On the
 monoid, the two maps agree, both sending `single x a` to `a`.
 
 Invertibility of `|X|` in `k`, rather than an ordered field or an averaging operator, is what the
-splitting needs, and it is the sharp hypothesis: if `|X| = 0` in `k` then `permutationSum` itself
-lies in the augmentation subrepresentation, and the two are not complementary.
+splitting needs, and for a nonempty `X` over a nontrivial `k` it is the sharp hypothesis: if
+`|X| = 0` in `k` then `permutationSum` is a nonzero element of the augmentation subrepresentation,
+so the invariant line meets it and the two are not complementary.  For an empty `X`, or a trivial
+`k`, every module in sight is zero and the two are complementary whatever `|X|` is in `k`.
 
 ## References
 
@@ -223,16 +224,19 @@ theorem toRepresentation_invariantLine :
   have hw : (w : MonoidAlgebra k X) ∈ Submodule.span k {permutationSum k X} := by
     rw [← toSubmodule_invariantLine k G X]; exact w.2
   obtain ⟨c, hc⟩ := Submodule.mem_span_singleton.mp hw
-  change Representation.ofMulAction k G X g (w : MonoidAlgebra k X) = (w : MonoidAlgebra k X)
+  -- both sides act on the underlying element of `k[X]`: `Subrepresentation.toRepresentation` is
+  -- the restriction of the ambient action, and the trivial representation is the identity
+  simp only [Subrepresentation.toRepresentation, MonoidHom.coe_mk, OneHom.coe_mk,
+    LinearMap.coe_restrict_apply, Representation.trivial_apply]
   rw [← hc, map_smul, ofMulAction_permutationSum]
 
 end InvariantLine
 
 /-! ### The splitting -/
 
-section Field
+section Span
 
-variable (k : Type*) [Field k] (G X : Type*) [Group G] [MulAction G X]
+variable (k : Type*) [CommRing k] (X : Type*)
 
 /-- The augmentation subrepresentation is spanned by the differences of the standard basis vectors
 from a fixed one. -/
@@ -256,7 +260,11 @@ theorem ker_sumCoords_basis_eq_span (x₀ : X) :
   · rintro _ ⟨x, rfl⟩
     simp only [SetLike.mem_coe, LinearMap.mem_ker, map_sub, sumCoords_basis_single, sub_self]
 
-variable [Fintype X]
+end Span
+
+section Field
+
+variable (k : Type*) [Field k] (G X : Type*) [Group G] [MulAction G X] [Fintype X]
 
 /-- The invariant line is a line. -/
 @[simp]
@@ -295,9 +303,15 @@ theorem isCompl_invariantLine_augmentationSubrepresentation (h : (Fintype.card X
   · rw [codisjoint_iff]
     exact Subrepresentation.toSubmodule_injective hsub.sup_eq_top
 
-/-- The augmentation subrepresentation has dimension one less than the cardinality of `X`. -/
-theorem finrank_augmentationSubrepresentation [Nonempty X] :
+/-- The augmentation subrepresentation has dimension one less than the cardinality of `X`.  For an
+empty `X` both sides are zero, the subtraction being truncated. -/
+theorem finrank_augmentationSubrepresentation :
     Module.finrank k (augmentationSubrepresentation k G X).toSubmodule = Fintype.card X - 1 := by
+  rcases isEmpty_or_nonempty X with hX | hX
+  · have hbot : (augmentationSubrepresentation k G X).toSubmodule = ⊥ :=
+      Submodule.eq_bot_iff _ |>.mpr fun v _ =>
+        MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun x => isEmptyElim x)
+    rw [hbot, finrank_bot, Fintype.card_eq_zero]
   have hcard : Module.finrank k (MonoidAlgebra k X) = Fintype.card X :=
     (Module.finrank_eq_card_basis (MonoidAlgebra.basis X k)).trans (by simp)
   have : Module.Finite k (MonoidAlgebra k X) := Module.Finite.of_basis (MonoidAlgebra.basis X k)

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -1,0 +1,311 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.MonoidAlgebra.Module
+public import Mathlib.RepresentationTheory.Basic
+public import Mathlib.RepresentationTheory.Subrepresentation
+
+/-!
+# The augmentation subrepresentation of a permutation representation
+
+A permutation representation `k[X]` of a group `G` on a `G`-set `X` always carries two canonical
+subrepresentations, visible before anything is known about `G`: the **invariant line** spanned by
+the sum of the standard basis, and the **augmentation subrepresentation** cut out by the vanishing
+of the sum of the coefficients.  Neither uses more than the fact that `G` permutes the standard
+basis, which leaves the coefficient sum unchanged.
+
+For a finite `X` whose cardinality is invertible in `k` the two are complementary, so `k[X]` splits
+as a line carrying the trivial representation plus a representation of dimension `|X| - 1`.  That
+is the source of the *deleted* permutation representations, of which the standard representation of
+the symmetric group in `TauCeti.RepresentationTheory.Symmetric.Standard` is the first example.
+
+## Main definitions
+
+* `TauCeti.coeffSum`: the augmentation of `k[X]`, the linear map summing all coefficients.
+* `TauCeti.permutationSum`: the sum of the standard basis of `k[X]`, for a finite `X`.
+* `TauCeti.invariantLine`: the line spanned by `TauCeti.permutationSum`, as a subrepresentation.
+* `TauCeti.augmentationSubrepresentation`: the kernel of `TauCeti.coeffSum`, as a
+  subrepresentation.
+
+## Main results
+
+* `TauCeti.coeffSum_ofMulAction`: the augmentation is invariant, which is what makes both
+  subrepresentations subrepresentations.
+* `TauCeti.toRepresentation_invariantLine`: the invariant line carries the trivial representation,
+  and `TauCeti.finrank_invariantLine` says it is a line.
+* `TauCeti.ker_coeffSum_eq_span`: the augmentation subrepresentation is spanned by the differences
+  of the standard basis vectors from a fixed one.
+* `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`: when `|X|` is invertible in `k`
+  the two subrepresentations are complementary.
+* `TauCeti.finrank_augmentationSubrepresentation`: the augmentation subrepresentation has
+  dimension `|X| - 1`.
+
+## Implementation notes
+
+The augmentation here is a `k`-linear map on the free module `k[X]` of an arbitrary index type `X`,
+because that is what a permutation representation acts on.  It is therefore *not* an instance of
+`TauCeti.MonoidAlgebra.augmentation` of `TauCeti.Algebra.MonoidAlgebra.Exactness`, which is the
+ring homomorphism `k[M] →+* k` of a monoid algebra: a `G`-set carries no multiplication, so there
+is no ring structure on `k[X]` for a ring homomorphism to be defined on.  On the overlap, `X` a
+monoid, the two maps agree, both sending `single x a` to `a`.
+
+Invertibility of `|X|` in `k`, rather than an ordered field or an averaging operator, is what the
+splitting needs, and it is the sharp hypothesis: if `|X| = 0` in `k` then `permutationSum` itself
+lies in the augmentation subrepresentation, and the two are not complementary.
+
+## References
+
+* J.-P. Serre, *Linear Representations of Finite Groups*, §2.3, where the permutation
+  representation of a group on a finite set is split into the invariant line and its complement.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "the named small irreducibles", which asks for the standard representation of the
+  symmetric group as the complement of the trivial one in a permutation module.
+-/
+
+public section
+
+namespace TauCeti
+
+/-! ### The augmentation -/
+
+section Augmentation
+
+variable (k : Type*) [CommSemiring k] (X : Type*)
+
+/-- The **augmentation** of `k[X]`: the linear map sending an element to the sum of its
+coefficients.  Equivalently, it is the unique linear map sending every standard basis vector
+to `1`. -/
+noncomputable def coeffSum : MonoidAlgebra k X →ₗ[k] k :=
+  (Finsupp.lsum k fun _ : X => LinearMap.id) ∘ₗ (MonoidAlgebra.coeffLinearEquiv k).toLinearMap
+
+variable {k X}
+
+/-- The augmentation sums the coefficients over the support. -/
+theorem coeffSum_apply (v : MonoidAlgebra k X) : coeffSum k X v = v.coeff.sum fun _ a => a := by
+  simp [coeffSum, Finsupp.sum]
+
+/-- The augmentation sends a standard basis vector to its coefficient. -/
+@[simp]
+theorem coeffSum_single (x : X) (a : k) : coeffSum k X (MonoidAlgebra.single x a) = a := by
+  rw [coeffSum_apply, MonoidAlgebra.coeff_single, Finsupp.sum_single_index rfl]
+
+/-- Over a finite index type the augmentation is the sum of all the coefficients. -/
+theorem coeffSum_eq_sum [Fintype X] (v : MonoidAlgebra k X) :
+    coeffSum k X v = ∑ x : X, v.coeff x := by
+  rw [coeffSum_apply, Finsupp.sum_fintype _ _ fun _ => rfl]
+
+/-- The augmentation is surjective as soon as there is a standard basis vector to hit `1`. -/
+theorem coeffSum_surjective [Nonempty X] : Function.Surjective (coeffSum k X) := fun a =>
+  ⟨MonoidAlgebra.single (Classical.arbitrary X) a, coeffSum_single _ _⟩
+
+end Augmentation
+
+/-! ### The augmentation subrepresentation -/
+
+section Subrep
+
+variable (k : Type*) [CommSemiring k] (G X : Type*) [Group G] [MulAction G X]
+
+/-- The augmentation is invariant: a group element permutes the standard basis, so it does not
+change the sum of the coefficients. -/
+@[simp]
+theorem coeffSum_ofMulAction (g : G) (v : MonoidAlgebra k X) :
+    coeffSum k X (Representation.ofMulAction k G X g v) = coeffSum k X v := by
+  have hcoeff : (Representation.ofMulAction k G X g v).coeff =
+      Finsupp.mapDomain (g • ·) v.coeff := by
+    simp [Representation.ofMulAction_def]
+  rw [coeffSum_apply, coeffSum_apply, hcoeff,
+    Finsupp.sum_mapDomain_index_inj (MulAction.injective g)]
+
+/-- The **augmentation subrepresentation** of `k[X]`: the elements whose coefficients sum to
+zero. -/
+noncomputable def augmentationSubrepresentation :
+    Subrepresentation (Representation.ofMulAction k G X) where
+  toSubmodule := LinearMap.ker (coeffSum k X)
+  apply_mem_toSubmodule g v hv := by
+    simpa only [LinearMap.mem_ker, coeffSum_ofMulAction] using hv
+
+@[simp]
+theorem toSubmodule_augmentationSubrepresentation :
+    (augmentationSubrepresentation k G X).toSubmodule = LinearMap.ker (coeffSum k X) :=
+  -- `(rfl)`, not `rfl`: the body of `augmentationSubrepresentation` is not `@[expose]`d, so this
+  -- must not be inferred `@[defeq]`.
+  (rfl)
+
+variable {k G X}
+
+@[simp]
+theorem mem_augmentationSubrepresentation_iff {v : MonoidAlgebra k X} :
+    v ∈ augmentationSubrepresentation k G X ↔ coeffSum k X v = 0 :=
+  Iff.rfl
+
+end Subrep
+
+section SubrepRing
+
+variable {k : Type*} [CommRing k] {G X : Type*} [Group G] [MulAction G X]
+
+/-- A difference of two standard basis vectors has vanishing augmentation. -/
+theorem single_sub_single_mem_augmentationSubrepresentation (x y : X) :
+    (MonoidAlgebra.single x 1 - MonoidAlgebra.single y 1 : MonoidAlgebra k X) ∈
+      augmentationSubrepresentation k G X := by
+  simp
+
+end SubrepRing
+
+/-! ### The invariant line -/
+
+section PermutationSum
+
+variable (k : Type*) [CommSemiring k] (X : Type*) [Fintype X]
+
+/-- The sum of the standard basis of `k[X]`, for a finite index type. -/
+noncomputable def permutationSum : MonoidAlgebra k X := ∑ x : X, MonoidAlgebra.single x (1 : k)
+
+variable {k X}
+
+@[simp]
+theorem coeff_permutationSum (x : X) : (permutationSum k X).coeff x = 1 := by
+  classical
+  simp [permutationSum, MonoidAlgebra.coeff_single, Finsupp.single_apply, Finset.sum_ite_eq']
+
+/-- The augmentation of the sum of the standard basis is the cardinality of the index type. -/
+@[simp]
+theorem coeffSum_permutationSum : coeffSum k X (permutationSum k X) = Fintype.card X := by
+  rw [coeffSum_eq_sum]
+  simp
+
+/-- The sum of the standard basis is nonzero, since each of its coefficients is `1`. -/
+theorem permutationSum_ne_zero [Nonempty X] [Nontrivial k] : permutationSum k X ≠ 0 := by
+  intro h
+  have hone := coeff_permutationSum (k := k) (Classical.arbitrary X)
+  rw [h] at hone
+  simp at hone
+
+end PermutationSum
+
+section InvariantLine
+
+variable (k : Type*) [CommSemiring k] (G X : Type*) [Group G] [MulAction G X] [Fintype X]
+
+/-- A group element fixes the sum of the standard basis, since it permutes the summands. -/
+@[simp]
+theorem ofMulAction_permutationSum (g : G) :
+    Representation.ofMulAction k G X g (permutationSum k X) = permutationSum k X := by
+  rw [permutationSum, map_sum]
+  simp only [Representation.ofMulAction_single]
+  exact Fintype.sum_equiv (MulAction.toPerm g) _ _ fun _ => rfl
+
+/-- The **invariant line** of `k[X]`: the line spanned by the sum of the standard basis, as a
+subrepresentation. -/
+noncomputable def invariantLine : Subrepresentation (Representation.ofMulAction k G X) where
+  toSubmodule := Submodule.span k {permutationSum k X}
+  apply_mem_toSubmodule g v hv := by
+    obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.mp hv
+    rw [map_smul, ofMulAction_permutationSum]
+    exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+
+@[simp]
+theorem toSubmodule_invariantLine :
+    (invariantLine k G X).toSubmodule = Submodule.span k {permutationSum k X} :=
+  -- `(rfl)`, not `rfl`: the body of `invariantLine` is not `@[expose]`d, so this must not be
+  -- inferred `@[defeq]`.
+  (rfl)
+
+/-- The invariant line carries the trivial representation: the sum of the standard basis, and
+hence every multiple of it, is fixed. -/
+theorem toRepresentation_invariantLine :
+    (invariantLine k G X).toRepresentation = Representation.trivial k G _ := by
+  refine DFunLike.ext _ _ fun g => LinearMap.ext fun w => Subtype.ext ?_
+  have hw : (w : MonoidAlgebra k X) ∈ Submodule.span k {permutationSum k X} := by
+    rw [← toSubmodule_invariantLine k G X]; exact w.2
+  obtain ⟨c, hc⟩ := Submodule.mem_span_singleton.mp hw
+  change Representation.ofMulAction k G X g (w : MonoidAlgebra k X) = (w : MonoidAlgebra k X)
+  rw [← hc, map_smul, ofMulAction_permutationSum]
+
+end InvariantLine
+
+/-! ### The splitting -/
+
+section Field
+
+variable (k : Type*) [Field k] (G X : Type*) [Group G] [MulAction G X]
+
+/-- The augmentation subrepresentation is spanned by the differences of the standard basis vectors
+from a fixed one. -/
+theorem ker_coeffSum_eq_span (x₀ : X) :
+    LinearMap.ker (coeffSum k X) =
+      Submodule.span k (Set.range fun x : X =>
+        (MonoidAlgebra.single x 1 - MonoidAlgebra.single x₀ 1 : MonoidAlgebra k X)) := by
+  classical
+  refine le_antisymm (fun v hv => ?_) (Submodule.span_le.mpr ?_)
+  · rw [LinearMap.mem_ker, coeffSum_apply, Finsupp.sum] at hv
+    have hbasis : ∑ x ∈ v.coeff.support, MonoidAlgebra.single x (v.coeff x) = v :=
+      MonoidAlgebra.sum_coeff_single v
+    have key : ∑ x ∈ v.coeff.support, v.coeff x •
+        (MonoidAlgebra.single x 1 - MonoidAlgebra.single x₀ 1 : MonoidAlgebra k X) = v := by
+      simp only [smul_sub, Finset.sum_sub_distrib, ← Finset.sum_smul, hv, zero_smul, sub_zero]
+      refine (Finset.sum_congr rfl fun x _ => ?_).trans hbasis
+      rw [MonoidAlgebra.smul_single', mul_one]
+    rw [← key]
+    exact Submodule.sum_mem _ fun x _ =>
+      Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, rfl⟩)
+  · rintro _ ⟨x, rfl⟩
+    simp
+
+variable [Fintype X]
+
+/-- The invariant line is a line. -/
+@[simp]
+theorem finrank_invariantLine [Nonempty X] :
+    Module.finrank k (invariantLine k G X).toSubmodule = 1 := by
+  rw [toSubmodule_invariantLine]
+  exact finrank_span_singleton permutationSum_ne_zero
+
+variable {k G X}
+
+/-- **The permutation representation splits.**  When the cardinality of `X` is invertible in `k`,
+the invariant line and the augmentation subrepresentation are complementary, so `k[X]` is the
+direct sum of a trivial representation and a representation of dimension `|X| - 1`. -/
+theorem isCompl_invariantLine_augmentationSubrepresentation (h : (Fintype.card X : k) ≠ 0) :
+    IsCompl (invariantLine k G X) (augmentationSubrepresentation k G X) := by
+  have hsub : IsCompl (Submodule.span k {permutationSum k X}) (LinearMap.ker (coeffSum k X)) := by
+    constructor
+    · rw [Submodule.disjoint_def]
+      rintro v hv hv'
+      obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.mp hv
+      rw [LinearMap.mem_ker, map_smul, coeffSum_permutationSum, smul_eq_mul] at hv'
+      rw [(mul_eq_zero.mp hv').resolve_right h, zero_smul]
+    · rw [codisjoint_iff, eq_top_iff]
+      intro v _
+      refine Submodule.mem_sup.mpr ⟨(coeffSum k X v / Fintype.card X) • permutationSum k X,
+        Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _),
+        v - (coeffSum k X v / Fintype.card X) • permutationSum k X, ?_, by abel⟩
+      rw [LinearMap.mem_ker, map_sub, map_smul, coeffSum_permutationSum, smul_eq_mul,
+        div_mul_cancel₀ _ h, sub_self]
+  constructor
+  · rw [disjoint_iff]
+    exact Subrepresentation.toSubmodule_injective hsub.inf_eq_bot
+  · rw [codisjoint_iff]
+    exact Subrepresentation.toSubmodule_injective hsub.sup_eq_top
+
+/-- The augmentation subrepresentation has dimension one less than the cardinality of `X`. -/
+theorem finrank_augmentationSubrepresentation [Nonempty X] :
+    Module.finrank k (augmentationSubrepresentation k G X).toSubmodule = Fintype.card X - 1 := by
+  have hcard : Module.finrank k (MonoidAlgebra k X) = Fintype.card X :=
+    (Module.finrank_eq_card_basis (MonoidAlgebra.basis X k)).trans (by simp)
+  have : Module.Finite k (MonoidAlgebra k X) := Module.Finite.of_basis (MonoidAlgebra.basis X k)
+  have hrange : Module.finrank k (LinearMap.range (coeffSum k X)) = 1 := by
+    rw [LinearMap.range_eq_top.mpr coeffSum_surjective]
+    simp
+  have hsum := LinearMap.finrank_range_add_finrank_ker (coeffSum k X)
+  rw [hrange, hcard] at hsum
+  rw [toSubmodule_augmentationSubrepresentation]
+  omega
+
+end Field
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Augmentation.lean
+++ b/TauCeti/RepresentationTheory/Augmentation.lean
@@ -46,7 +46,10 @@ the symmetric group in `TauCeti.RepresentationTheory.Symmetric.Standard` is the 
 
 The augmentation used here is Mathlib's `Module.Basis.sumCoords` of the standard basis
 `MonoidAlgebra.basis X k`, a `k`-linear map on the free module `k[X]` of an arbitrary index type
-`X`, because that is what a permutation representation acts on.  It is therefore *not* an instance
+`X`, because that is what a permutation representation acts on.  Nothing is restated about it: the
+one lemma this file adds, `TauCeti.MonoidAlgebra.basis_repr`, is the bridge from that basis to
+`MonoidAlgebra.coeff` that Mathlib does not record, and the generic `Module.Basis` API computes
+with the augmentation once it is available.  The augmentation is therefore *not* an instance
 of `TauCeti.MonoidAlgebra.augmentation` of `TauCeti.Algebra.MonoidAlgebra.Exactness`, which is the
 ring homomorphism `k[M] →+* k` of a monoid algebra: a `G`-set carries no multiplication, so there
 is no ring structure on `k[X]` for a ring homomorphism to be defined on.  On the overlap, `X` a
@@ -76,32 +79,26 @@ namespace TauCeti
 
 section Augmentation
 
-variable {k : Type*} [CommSemiring k] {X : Type*}
+variable {k : Type*} [Semiring k] {X : Type*}
 
-/-- The **augmentation** of `k[X]` is `Module.Basis.sumCoords` of the standard basis: the linear
-map sending an element to the sum of its coefficients.  It sums them over the support. -/
-theorem sumCoords_basis_apply (v : MonoidAlgebra k X) :
-    (MonoidAlgebra.basis X k).sumCoords v = v.coeff.sum fun _ a => a :=
+/-- The coordinates of `k[X]` in the standard basis are the coefficients.
+
+Mathlib defines `MonoidAlgebra.basis` by `repr := MonoidAlgebra.coeffLinearEquiv _` but records no
+lemma for the resulting `repr`.  This is that missing bridge, and it is all that is needed for the
+generic basis API -- `Module.Basis.coe_sumCoords`, `Module.Basis.coe_sumCoords_of_fintype`,
+`Module.Basis.sumCoords_self_apply` -- to compute the augmentation in terms of
+`MonoidAlgebra.coeff`. -/
+@[simp]
+theorem MonoidAlgebra.basis_repr (v : MonoidAlgebra k X) :
+    (MonoidAlgebra.basis X k).repr v = v.coeff :=
   rfl
 
-/-- The augmentation sends a standard basis vector to its coefficient.
-
-This is not a `simp` lemma: `Module.Basis.coe_sumCoords` already rewrites the left-hand side, so
-the statement is not in `simp` normal form.  The same applies to the other lemmas below whose
-left-hand side is an augmentation. -/
-theorem sumCoords_basis_single (x : X) (a : k) :
-    (MonoidAlgebra.basis X k).sumCoords (MonoidAlgebra.single x a) = a := by
-  rw [sumCoords_basis_apply, MonoidAlgebra.coeff_single, Finsupp.sum_single_index rfl]
-
-/-- Over a finite index type the augmentation is the sum of all the coefficients. -/
-theorem sumCoords_basis_eq_sum [Fintype X] (v : MonoidAlgebra k X) :
-    (MonoidAlgebra.basis X k).sumCoords v = ∑ x : X, v.coeff x := by
-  rw [sumCoords_basis_apply, Finsupp.sum_fintype _ _ fun _ => rfl]
-
-/-- The augmentation is surjective as soon as there is a standard basis vector to hit `1`. -/
+/-- The **augmentation** of `k[X]` is `Module.Basis.sumCoords` of the standard basis: the linear
+map sending an element to the sum of its coefficients.  It is surjective as soon as there is a
+standard basis vector to hit `1`. -/
 theorem sumCoords_basis_surjective [Nonempty X] :
     Function.Surjective (MonoidAlgebra.basis X k).sumCoords := fun a =>
-  ⟨MonoidAlgebra.single (Classical.arbitrary X) a, sumCoords_basis_single _ _⟩
+  ⟨MonoidAlgebra.single (Classical.arbitrary X) a, by simp⟩
 
 end Augmentation
 
@@ -119,8 +116,8 @@ theorem sumCoords_basis_ofMulAction (g : G) (v : MonoidAlgebra k X) :
   have hcoeff : (Representation.ofMulAction k G X g v).coeff =
       Finsupp.mapDomain (g • ·) v.coeff := by
     simp [Representation.ofMulAction_def]
-  rw [sumCoords_basis_apply, sumCoords_basis_apply, hcoeff,
-    Finsupp.sum_mapDomain_index_inj (MulAction.injective g)]
+  simp only [Module.Basis.coe_sumCoords, MonoidAlgebra.basis_repr, hcoeff]
+  exact Finsupp.sum_mapDomain_index_inj (MulAction.injective g)
 
 /-- The **augmentation subrepresentation** of `k[X]`: the elements whose coefficients sum to
 zero. -/
@@ -155,8 +152,8 @@ variable {k : Type*} [CommRing k] {G X : Type*} [Group G] [MulAction G X]
 theorem single_sub_single_mem_augmentationSubrepresentation (x y : X) :
     (MonoidAlgebra.single x 1 - MonoidAlgebra.single y 1 : MonoidAlgebra k X) ∈
       augmentationSubrepresentation k G X := by
-  rw [mem_augmentationSubrepresentation_iff, map_sub, sumCoords_basis_single,
-    sumCoords_basis_single, sub_self]
+  rw [mem_augmentationSubrepresentation_iff, map_sub]
+  simp
 
 end SubrepRing
 
@@ -179,7 +176,6 @@ theorem coeff_permutationSum (x : X) : (permutationSum k X).coeff x = 1 := by
 /-- The augmentation of the sum of the standard basis is the cardinality of the index type. -/
 theorem sumCoords_basis_permutationSum :
     (MonoidAlgebra.basis X k).sumCoords (permutationSum k X) = Fintype.card X := by
-  rw [sumCoords_basis_eq_sum]
   simp
 
 /-- The sum of the standard basis is nonzero, since each of its coefficients is `1`. -/
@@ -258,7 +254,8 @@ theorem ker_sumCoords_basis_eq_span (x₀ : X) :
         (MonoidAlgebra.single x 1 - MonoidAlgebra.single x₀ 1 : MonoidAlgebra k X)) := by
   classical
   refine le_antisymm (fun v hv => ?_) (Submodule.span_le.mpr ?_)
-  · rw [LinearMap.mem_ker, sumCoords_basis_apply, Finsupp.sum] at hv
+  · simp only [LinearMap.mem_ker, Module.Basis.coe_sumCoords, MonoidAlgebra.basis_repr,
+      Finsupp.sum, id_eq] at hv
     have hbasis : ∑ x ∈ v.coeff.support, MonoidAlgebra.single x (v.coeff x) = v :=
       MonoidAlgebra.sum_coeff_single v
     have key : ∑ x ∈ v.coeff.support, v.coeff x •
@@ -270,7 +267,8 @@ theorem ker_sumCoords_basis_eq_span (x₀ : X) :
     exact Submodule.sum_mem _ fun x _ =>
       Submodule.smul_mem _ _ (Submodule.subset_span ⟨x, rfl⟩)
   · rintro _ ⟨x, rfl⟩
-    simp only [SetLike.mem_coe, LinearMap.mem_ker, map_sub, sumCoords_basis_single, sub_self]
+    rw [SetLike.mem_coe, LinearMap.mem_ker, map_sub]
+    simp
 
 end Span
 

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -8,15 +8,33 @@ public import Mathlib.RepresentationTheory.Irreducible
 public import Mathlib.RingTheory.SimpleModule.Rank
 
 /-!
-# Irreducibility of a line
+# Two criteria for irreducibility
+
+This file collects the two ways of recognising an irreducible representation that need no
+information about the group.
 
 A representation on a one-dimensional vector space is irreducible, whatever the group and however
 it acts: a subrepresentation is in particular a subspace, and a line has only the two trivial
-subspaces.  Nontriviality, the other half of irreducibility, is the same dimension count.
+subspaces.  Nontriviality, the other half of irreducibility, is the same dimension count.  This is
+how the smallest representations of a group are recognised as irreducible without knowing anything
+about the group -- the trivial representation, a character, a sign -- and it is the criterion the
+one-row and one-column Specht modules are proved irreducible by.
 
-This is how the smallest representations of a group are recognised as irreducible without knowing
-anything about the group -- the trivial representation, a character, a sign -- and it is the
-criterion the one-row and one-column Specht modules are proved irreducible by.
+The second criterion turns a lattice-theoretic statement about a fixed ambient representation into
+a statement about a subrepresentation on its own: a subrepresentation that is an **atom** of the
+lattice of subrepresentations carries an irreducible representation.  Irreducibility of a
+subrepresentation `σ` of `ρ` is a statement about the subrepresentations of `σ.toRepresentation`,
+one level down from `ρ`, whereas minimality is a statement inside the lattice attached to `ρ`; the
+translation between them is the correspondence sending a subrepresentation of `σ.toRepresentation`
+to its image in `ρ` under the inclusion of `σ.toSubmodule`.  In practice the atom form is the one
+that gets proved -- one exhibits an invariant subspace of the ambient representation and shows it
+has no proper nonzero invariant subspace -- and the irreducibility form is the one that gets used.
+
+## Main results
+
+* `TauCeti.Representation.isIrreducible_of_finrank_eq_one`: a line is irreducible.
+* `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom`: an atom of the lattice of
+  subrepresentations carries an irreducible representation.
 
 ## References
 
@@ -49,6 +67,50 @@ theorem isIrreducible_of_finrank_eq_one (ρ : Representation k G V)
 /-- The trivial representation of a monoid on the base field is irreducible, being a line. -/
 instance isIrreducible_trivial_self : (_root_.Representation.trivial k G k).IsIrreducible :=
   isIrreducible_of_finrank_eq_one _ (Module.finrank_self k)
+
+/-- A subrepresentation that is an **atom** of the lattice of subrepresentations -- nonzero, with
+no subrepresentation strictly between it and zero -- carries an irreducible representation.  The
+translation is the correspondence between the subrepresentations of `σ.toRepresentation` and the
+subrepresentations of `ρ` contained in `σ`, given by pushing forward along the inclusion. -/
+theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
+    {σ : Subrepresentation ρ} (h : IsAtom σ) : σ.toRepresentation.IsIrreducible := by
+  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
+  have hσ : σ.toSubmodule ≠ ⊥ := fun hc =>
+    h.1 (Subrepresentation.toSubmodule_injective (hc.trans hbot.symm))
+  have : Nontrivial σ.toSubmodule := Submodule.nontrivial_iff_ne_bot.mpr hσ
+  -- the two extreme subrepresentations of `σ.toRepresentation` carry the two extreme subspaces
+  have hbot' : (⊥ : Subrepresentation σ.toRepresentation).toSubmodule = ⊥ := rfl
+  have htop' : (⊤ : Subrepresentation σ.toRepresentation).toSubmodule = ⊤ := rfl
+  have hne : (⊥ : Subrepresentation σ.toRepresentation) ≠ ⊤ := fun hc =>
+    bot_ne_top (α := Submodule k σ.toSubmodule) (by rw [← hbot', ← htop', hc])
+  have : Nontrivial (Subrepresentation σ.toRepresentation) := ⟨⊥, ⊤, hne⟩
+  refine ⟨fun τ => ?_⟩
+  -- push `τ` forward to a subrepresentation of `ρ` contained in `σ`
+  let τ' : Subrepresentation ρ :=
+    { toSubmodule := τ.toSubmodule.map σ.toSubmodule.subtype
+      apply_mem_toSubmodule := by
+        rintro g _ ⟨w, hw, rfl⟩
+        exact ⟨σ.toRepresentation g w, τ.apply_mem_toSubmodule g hw, rfl⟩ }
+  have hmap : τ'.toSubmodule = τ.toSubmodule.map σ.toSubmodule.subtype := rfl
+  have hle : τ' ≤ σ := Submodule.map_subtype_le _ _
+  rcases eq_or_ne τ' ⊥ with hτ | hτ
+  · refine Or.inl (Subrepresentation.toSubmodule_injective ?_)
+    have : τ.toSubmodule.map σ.toSubmodule.subtype =
+        (⊥ : Submodule k σ.toSubmodule).map σ.toSubmodule.subtype := by
+      rw [Submodule.map_bot]
+      exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule hτ)
+    exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
+      hbot'.symm
+  · refine Or.inr (Subrepresentation.toSubmodule_injective ?_)
+    have heq : τ' = σ := by
+      by_contra hne'
+      exact hτ (h.2 _ (lt_of_le_of_ne hle hne'))
+    have : τ.toSubmodule.map σ.toSubmodule.subtype =
+        (⊤ : Submodule k σ.toSubmodule).map σ.toSubmodule.subtype := by
+      rw [Submodule.map_subtype_top]
+      exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule heq)
+    exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
+      htop'.symm
 
 end Representation
 

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -104,23 +104,41 @@ end Swap
 
 /-! ### The standard representation -/
 
-section Standard
+section Defn
 
-variable (k : Type*) [Field k] (α : Type*) [Fintype α]
+variable (k : Type*) [CommSemiring k] (α : Type*)
 
 /-- The **standard representation** of the symmetric group on `α`: the action of `Equiv.Perm α` on
-the vectors of `k[α]` whose coefficients sum to zero.  No hypothesis on `k` is imposed here; when
-`(Fintype.card α : k) ≠ 0` it is a complement of the invariant line in the permutation
-representation `k[α]`, by `isCompl_invariantLine_augmentationSubrepresentation`, whereas when
-`(Fintype.card α : k) = 0` the invariant line lies inside it instead.  Identifying it with the
-Specht module of the shape `(|α|-1, 1)` is an aim for later: the polytabloid presentation needed to
-state that equivalence is not yet in the repository. -/
+the vectors of `k[α]` whose coefficients sum to zero.  No hypothesis on `k` or on `α` is imposed
+here; when `α` is finite and `(Fintype.card α : k) ≠ 0` it is a complement of the invariant line in
+the permutation representation `k[α]`, by
+`isCompl_invariantLine_augmentationSubrepresentation`, whereas when `(Fintype.card α : k) = 0` the
+invariant line lies inside it instead.  Identifying it with the Specht module of the shape
+`(|α|-1, 1)` is an aim for later: the polytabloid presentation needed to state that equivalence is
+not yet in the repository. -/
 noncomputable def standardRepresentation :
     Representation k (Equiv.Perm α)
       (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
   (augmentationSubrepresentation k (Equiv.Perm α) α).toRepresentation
 
 variable {k α}
+
+/-- The standard representation acts by permuting the standard basis: on underlying elements of
+`k[α]` it is the permutation representation. -/
+@[simp]
+theorem coe_standardRepresentation_apply (g : Equiv.Perm α)
+    (v : (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule) :
+    (standardRepresentation k α g v : MonoidAlgebra k α) =
+      Representation.ofMulAction k (Equiv.Perm α) α g v :=
+  -- `(rfl)`, not `rfl`: the body of `standardRepresentation` is not `@[expose]`d, so this must not
+  -- be inferred `@[defeq]`.
+  (rfl)
+
+end Defn
+
+section Standard
+
+variable {k : Type*} [Field k] {α : Type*} [Fintype α]
 
 /-- **The standard subrepresentation is minimal.**  A nonzero subrepresentation of the permutation
 representation contained in the standard one is the whole of it: from a nonzero vector with
@@ -176,11 +194,13 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
       intro z
       rcases eq_or_ne z x with rfl | hzx
       · simp
-      · have hmem := τ.apply_mem_toSubmodule (Equiv.swap y z) hdiff
+      · have hswapx : (Equiv.swap y z) • x = x := by
+          rw [Equiv.Perm.smul_def, Equiv.swap_apply_of_ne_of_ne hxy (Ne.symm hzx)]
+        have hswapy : (Equiv.swap y z) • y = z := by
+          rw [Equiv.Perm.smul_def, Equiv.swap_apply_left]
+        have hmem := τ.apply_mem_toSubmodule (Equiv.swap y z) hdiff
         rw [map_sub, Representation.ofMulAction_single, Representation.ofMulAction_single,
-          show (Equiv.swap y z) • x = x from
-            Equiv.swap_apply_of_ne_of_ne hxy (Ne.symm hzx),
-          show (Equiv.swap y z) • y = z from Equiv.swap_apply_left y z] at hmem
+          hswapx, hswapy] at hmem
         simpa using τ.toSubmodule.neg_mem hmem
     -- so `τ` contains the whole standard subrepresentation, contradicting strictness
     have hle : augmentationSubrepresentation k (Equiv.Perm α) α ≤ τ := by

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -16,11 +16,16 @@ trivial representation, and the **standard representation**, the complementary s
 dimension `|α| - 1` on which the coefficients sum to zero.  This file proves that the standard
 representation is irreducible whenever `|α| ≥ 2` and `|α|` is invertible in `k`.
 
-Both hypotheses are needed.  For `|α| ≤ 1` the standard representation is zero, and the zero
-representation is not irreducible.  If `|α| = 0` in `k` the sum of the standard basis itself has
-vanishing coefficient sum, so the invariant line lies *inside* the standard subrepresentation and
-the latter is reducible -- this is the first place the modular theory departs from the ordinary
-one, and it is excluded here rather than developed.
+The hypothesis `2 ≤ |α|` is needed: for `|α| ≤ 1` the standard representation is zero, and the zero
+representation is not irreducible.  The hypothesis `|α| ≠ 0` in `k` is a sufficient hypothesis
+uniform in `|α|` rather than a necessary one.  It cannot simply be dropped: as soon as `3 ≤ |α|`
+and `|α| = 0` in `k`, the sum of the standard basis itself has vanishing coefficient sum, so the
+invariant line lies *inside* the standard subrepresentation, and it is a proper subrepresentation
+because the standard one has dimension `|α| - 1 ≥ 2`, so the latter is reducible -- this is the
+first place the modular theory departs from the ordinary one, and it is excluded here rather than
+developed.  The remaining case is an exception: for `|α| = 2` in characteristic `2` the standard
+subrepresentation *is* the invariant line, a line and hence irreducible, so there the conclusion
+holds without `|α| ≠ 0` in `k`.
 
 The argument is elementary and uses only transpositions.  If `v` has vanishing coefficient sum and
 is nonzero, two of its coefficients differ, say at `x` and `y`; subtracting the transposition
@@ -140,7 +145,8 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
     have hτne : τ.toSubmodule ≠ ⊥ := fun hc =>
       hτbot (Subrepresentation.toSubmodule_injective hc)
     obtain ⟨v, hv, hv0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hτne
-    have hvker : coeffSum k α v = 0 := mem_augmentationSubrepresentation_iff.mp (hτ.le hv)
+    have hvker : (MonoidAlgebra.basis α k).sumCoords v = 0 :=
+      mem_augmentationSubrepresentation_iff.mp (hτ.le hv)
     -- two of its coefficients differ
     obtain ⟨x, y, hxy, hcoeff⟩ : ∃ x y : α, x ≠ y ∧ v.coeff x ≠ v.coeff y := by
       by_contra hcon
@@ -148,7 +154,7 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
       have hall : ∀ z : α, v.coeff z = v.coeff x₀ := fun z =>
         (eq_or_ne z x₀).elim (fun h => by rw [h]) fun h => hcon z x₀ h
       have hmul : (Fintype.card α : k) * v.coeff x₀ = 0 := by
-        rw [← hvker, coeffSum_eq_sum, Finset.sum_congr rfl fun z _ => hall z]
+        rw [← hvker, sumCoords_basis_eq_sum, Finset.sum_congr rfl fun z _ => hall z]
         simp
       have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
       exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))
@@ -174,8 +180,9 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
     -- so `τ` contains the whole standard subrepresentation, contradicting strictness
     have hle : augmentationSubrepresentation k (Equiv.Perm α) α ≤ τ := by
       intro w hw
-      have hw' : w ∈ LinearMap.ker (coeffSum k α) := mem_augmentationSubrepresentation_iff.mp hw
-      rw [ker_coeffSum_eq_span k α x] at hw'
+      have hw' : w ∈ LinearMap.ker (MonoidAlgebra.basis α k).sumCoords :=
+        mem_augmentationSubrepresentation_iff.mp hw
+      rw [ker_sumCoords_basis_eq_span k α x] at hw'
       exact Submodule.span_le.mpr (by rintro _ ⟨z, rfl⟩; exact hall z) hw'
     exact absurd (le_antisymm hτ.le hle) hτ.ne
 

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -1,0 +1,190 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Augmentation
+public import TauCeti.RepresentationTheory.Irreducible
+
+/-!
+# The standard representation of the symmetric group
+
+The symmetric group on a finite type `α` acts on `k[α]` by permuting the standard basis, and that
+permutation representation splits: the invariant line spanned by the sum of the basis, carrying the
+trivial representation, and the **standard representation**, the complementary subrepresentation of
+dimension `|α| - 1` on which the coefficients sum to zero.  This file proves that the standard
+representation is irreducible whenever `|α| ≥ 2` and `|α|` is invertible in `k`.
+
+Both hypotheses are needed.  For `|α| ≤ 1` the standard representation is zero, and the zero
+representation is not irreducible.  If `|α| = 0` in `k` the sum of the standard basis itself has
+vanishing coefficient sum, so the invariant line lies *inside* the standard subrepresentation and
+the latter is reducible -- this is the first place the modular theory departs from the ordinary
+one, and it is excluded here rather than developed.
+
+The argument is elementary and uses only transpositions.  If `v` has vanishing coefficient sum and
+is nonzero, two of its coefficients differ, say at `x` and `y`; subtracting the transposition
+`(x y)` applied to `v` from `v` leaves exactly `(v x - v y) • (x - y)`, so any nonzero invariant
+subspace contains one difference `x - y` of basis vectors.  Transposing `y` with an arbitrary `z`
+produces all the others, and those differences span.
+
+## Main definitions
+
+* `TauCeti.standardRepresentation`: the standard representation of `Equiv.Perm α` on the
+  augmentation subrepresentation of `k[α]`.
+
+## Main results
+
+* `TauCeti.sub_ofMulAction_swap`: applying a transposition to `v` and subtracting leaves a multiple
+  of a difference of two standard basis vectors.  This is the whole computational content.
+* `TauCeti.isAtom_augmentationSubrepresentation`: the standard subrepresentation is an atom of the
+  lattice of subrepresentations of `k[α]`, and
+  `TauCeti.isIrreducible_standardRepresentation`: hence it is irreducible.
+
+The two remaining halves of the picture hold for an arbitrary permutation representation and are
+proved there, in `TauCeti.RepresentationTheory.Augmentation`: that `k[α]` is the direct sum of the
+invariant line and the standard subrepresentation is
+`TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, and that the standard
+subrepresentation has dimension `|α| - 1` is `TauCeti.finrank_augmentationSubrepresentation`.
+
+## References
+
+* W. Fulton and J. Harris, *Representation Theory: A First Course*, §2.1, where the standard
+  representation of `Sₙ` is introduced as the complement of the trivial summand in the permutation
+  representation.
+* G. D. James, *The Representation Theory of the Symmetric Groups*, §4, for the same
+  representation as the Specht module of the shape `(n-1, 1)`.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 4, "the named small irreducibles", which asks for `M^{(n-1,1)} = triv ⊕ standard` with the
+  standard summand the `(n-1)`-dimensional irreducible.
+-/
+
+public section
+
+namespace TauCeti
+
+open MonoidAlgebra
+
+/-! ### Transpositions and differences of basis vectors -/
+
+section Swap
+
+variable {k : Type*} [CommRing k] {α : Type*} [DecidableEq α]
+
+/-- Subtracting from `v` the effect of the transposition `(x y)` leaves the difference of the two
+coefficients times the difference of the two standard basis vectors: a transposition changes only
+the two coefficients it swaps.  This is the step that produces a difference of basis vectors from
+an arbitrary vector, and it needs no hypothesis relating `x` and `y`. -/
+theorem sub_ofMulAction_swap (x y : α) (v : MonoidAlgebra k α) :
+    v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v =
+      (v.coeff x - v.coeff y) • (single x 1 - single y 1 : MonoidAlgebra k α) := by
+  rw [← MonoidAlgebra.coeff_inj]
+  ext z
+  simp only [MonoidAlgebra.coeff_sub, MonoidAlgebra.coeff_smul, Finsupp.sub_apply,
+    Finsupp.smul_apply, Representation.coeff_ofMulAction, MonoidAlgebra.coeff_single,
+    Finsupp.single_apply, smul_eq_mul, Equiv.Perm.smul_def, Equiv.swap_inv]
+  rcases eq_or_ne z x with rfl | hzx
+  · rcases eq_or_ne z y with rfl | hzy
+    · simp
+    · rw [Equiv.swap_apply_left]
+      simp [Ne.symm hzy]
+  · rcases eq_or_ne z y with rfl | hzy
+    · rw [Equiv.swap_apply_right]
+      simp [Ne.symm hzx]
+    · rw [Equiv.swap_apply_of_ne_of_ne hzx hzy]
+      simp [Ne.symm hzx, Ne.symm hzy]
+
+end Swap
+
+/-! ### The standard representation -/
+
+section Standard
+
+variable (k : Type*) [Field k] (α : Type*) [Fintype α]
+
+/-- The **standard representation** of the symmetric group on `α`: the action of `Equiv.Perm α` on
+the vectors of `k[α]` whose coefficients sum to zero.  It is the complement of the invariant line
+in the permutation representation `k[α]`, and it is the Specht module of the shape `(|α|-1, 1)`. -/
+noncomputable def standardRepresentation :
+    Representation k (Equiv.Perm α)
+      (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
+  (augmentationSubrepresentation k (Equiv.Perm α) α).toRepresentation
+
+variable {k α}
+
+/-- **The standard subrepresentation is minimal.**  A nonzero subrepresentation of the permutation
+representation contained in the standard one is the whole of it: from a nonzero vector with
+vanishing coefficient sum one produces, by transpositions, every difference of standard basis
+vectors, and those span. -/
+theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
+    (hchar : (Fintype.card α : k) ≠ 0) :
+    IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
+  classical
+  obtain ⟨x₀, y₀, hx₀y₀⟩ := Fintype.exists_pair_of_one_lt_card (α := α) (by omega)
+  have hne : ∀ x y : α, x ≠ y → (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
+    intro x y hxy hzero
+    have : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
+    simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at this
+  constructor
+  · -- the standard subrepresentation is nonzero
+    intro hbot
+    have hmem : (single x₀ 1 - single y₀ 1 : MonoidAlgebra k α) ∈
+        augmentationSubrepresentation k (Equiv.Perm α) α :=
+      single_sub_single_mem_augmentationSubrepresentation x₀ y₀
+    rw [hbot] at hmem
+    exact hne x₀ y₀ hx₀y₀ (Submodule.mem_bot k |>.mp hmem)
+  · -- every strictly smaller subrepresentation is zero
+    intro τ hτ
+    by_contra hτbot
+    -- a nonzero vector of `τ`
+    have hτne : τ.toSubmodule ≠ ⊥ := fun hc =>
+      hτbot (Subrepresentation.toSubmodule_injective hc)
+    obtain ⟨v, hv, hv0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hτne
+    have hvker : coeffSum k α v = 0 := mem_augmentationSubrepresentation_iff.mp (hτ.le hv)
+    -- two of its coefficients differ
+    obtain ⟨x, y, hxy, hcoeff⟩ : ∃ x y : α, x ≠ y ∧ v.coeff x ≠ v.coeff y := by
+      by_contra hcon
+      push Not at hcon
+      have hall : ∀ z : α, v.coeff z = v.coeff x₀ := fun z =>
+        (eq_or_ne z x₀).elim (fun h => by rw [h]) fun h => hcon z x₀ h
+      have hmul : (Fintype.card α : k) * v.coeff x₀ = 0 := by
+        rw [← hvker, coeffSum_eq_sum, Finset.sum_congr rfl fun z _ => hall z]
+        simp
+      have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
+      exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))
+    -- hence `τ` contains one difference of standard basis vectors
+    have hdiff : (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
+      have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
+          τ.toSubmodule :=
+        Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
+      rw [sub_ofMulAction_swap] at hsub
+      have := τ.toSubmodule.smul_mem (v.coeff x - v.coeff y)⁻¹ hsub
+      rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at this
+    -- transposing `y` with an arbitrary `z` produces all the others
+    have hall : ∀ z : α, (single z 1 - single x 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
+      intro z
+      rcases eq_or_ne z x with rfl | hzx
+      · simp
+      · have hmem := τ.apply_mem_toSubmodule (Equiv.swap y z) hdiff
+        rw [map_sub, Representation.ofMulAction_single, Representation.ofMulAction_single,
+          show (Equiv.swap y z) • x = x from
+            Equiv.swap_apply_of_ne_of_ne hxy (Ne.symm hzx),
+          show (Equiv.swap y z) • y = z from Equiv.swap_apply_left y z] at hmem
+        simpa using τ.toSubmodule.neg_mem hmem
+    -- so `τ` contains the whole standard subrepresentation, contradicting strictness
+    have hle : augmentationSubrepresentation k (Equiv.Perm α) α ≤ τ := by
+      intro w hw
+      have hw' : w ∈ LinearMap.ker (coeffSum k α) := mem_augmentationSubrepresentation_iff.mp hw
+      rw [ker_coeffSum_eq_span k α x] at hw'
+      exact Submodule.span_le.mpr (by rintro _ ⟨z, rfl⟩; exact hall z) hw'
+    exact absurd (le_antisymm hτ.le hle) hτ.ne
+
+/-- **The standard representation is irreducible.** -/
+theorem isIrreducible_standardRepresentation (h2 : 2 ≤ Fintype.card α)
+    (hchar : (Fintype.card α : k) ≠ 0) : (standardRepresentation k α).IsIrreducible :=
+  Representation.isIrreducible_toRepresentation_of_isAtom
+    (isAtom_augmentationSubrepresentation h2 hchar)
+
+end Standard
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -69,7 +69,8 @@ public section
 
 namespace TauCeti
 
-open MonoidAlgebra
+-- `_root_.`, since `TauCeti.MonoidAlgebra` is a namespace of its own
+open _root_.MonoidAlgebra
 
 /-! ### Transpositions and differences of basis vectors -/
 
@@ -176,8 +177,9 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
       push Not at hcon
       have hall : ∀ z : α, v.coeff z = v.coeff x₀ := fun z =>
         (eq_or_ne z x₀).elim (fun h => by rw [h]) fun h => hcon z x₀ h
+      have hsum : (MonoidAlgebra.basis α k).sumCoords v = ∑ z : α, v.coeff z := by simp
       have hmul : (Fintype.card α : k) * v.coeff x₀ = 0 := by
-        rw [← hvker, sumCoords_basis_eq_sum, Finset.sum_congr rfl fun z _ => hall z]
+        rw [← hvker, hsum, Finset.sum_congr rfl fun z _ => hall z]
         simp
       have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
       exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -144,11 +144,24 @@ variable {k : Type*} [Field k] {α : Type*} [Fintype α]
 /-- **The standard subrepresentation is minimal.**  A nonzero subrepresentation of the permutation
 representation contained in the standard one is the whole of it: from a nonzero vector with
 vanishing coefficient sum one produces, by transpositions, every difference of standard basis
-vectors, and those span. -/
+vectors, and those span.  For a two-element `α` the standard subrepresentation is a line, so it is
+minimal whatever the characteristic. -/
 theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
-    (hchar : (Fintype.card α : k) ≠ 0) :
+    (hchar : Fintype.card α = 2 ∨ (Fintype.card α : k) ≠ 0) :
     IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
   classical
+  rcases hchar with hcard | hchar
+  · -- a two-element `α` leaves a line, and a line is an atom of the lattice of subspaces; the
+    -- lattice of subrepresentations embeds in it, the bottom one carrying the zero subspace
+    have hbot :
+        (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
+      rfl
+    have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
+      Submodule.isAtom_iff_finrank_eq_one.mpr
+        (by rw [finrank_augmentationSubrepresentation, hcard])
+    refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
+      Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
+    exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
   obtain ⟨x₀, y₀, hx₀y₀⟩ := Fintype.exists_pair_of_one_lt_card (α := α) (by omega)
   have hne : ∀ x y : α, x ≠ y → (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
     intro x y hxy hzero
@@ -219,13 +232,9 @@ and for `3 ≤ |α|` with `|α| = 0` in `k` the invariant line is a proper nonze
 of it. -/
 theorem isIrreducible_standardRepresentation (h2 : 2 ≤ Fintype.card α)
     (hchar : Fintype.card α = 2 ∨ (Fintype.card α : k) ≠ 0) :
-    (standardRepresentation k α).IsIrreducible := by
-  rcases hchar with hcard | hchar
-  · -- a two-element `α` leaves a line, which is irreducible in every characteristic
-    exact Representation.isIrreducible_of_finrank_eq_one _
-      (by rw [finrank_augmentationSubrepresentation, hcard])
-  · exact Representation.isIrreducible_toRepresentation_of_isAtom
-      (isAtom_augmentationSubrepresentation h2 hchar)
+    (standardRepresentation k α).IsIrreducible :=
+  Representation.isIrreducible_toRepresentation_of_isAtom
+    (isAtom_augmentationSubrepresentation h2 hchar)
 
 end Standard
 

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -10,11 +10,12 @@ public import TauCeti.RepresentationTheory.Irreducible
 /-!
 # The standard representation of the symmetric group
 
-The symmetric group on a finite type `α` acts on `k[α]` by permuting the standard basis, and that
-permutation representation splits: the invariant line spanned by the sum of the basis, carrying the
-trivial representation, and the **standard representation**, the complementary subrepresentation of
-dimension `|α| - 1` on which the coefficients sum to zero.  This file proves that the standard
-representation is irreducible whenever `|α| ≥ 2` and `|α|` is invertible in `k`.
+The symmetric group on a finite type `α` acts on `k[α]` by permuting the standard basis.  Inside
+that permutation representation sit the invariant line spanned by the sum of the basis, carrying the
+trivial representation, and the **standard representation**, the subrepresentation of dimension
+`|α| - 1` on which the coefficients sum to zero; when `|α|` is invertible in `k` the two are
+complementary and the permutation representation splits as their direct sum.  This file proves that
+the standard representation is irreducible whenever `|α| ≥ 2` and `|α|` is invertible in `k`.
 
 The hypothesis `2 ≤ |α|` is needed: for `|α| ≤ 1` the standard representation is zero, and the zero
 representation is not irreducible.  The hypothesis `|α| ≠ 0` in `k` is a sufficient hypothesis
@@ -48,7 +49,7 @@ produces all the others, and those differences span.
 
 The two remaining halves of the picture hold for an arbitrary permutation representation and are
 proved there, in `TauCeti.RepresentationTheory.Augmentation`: that `k[α]` is the direct sum of the
-invariant line and the standard subrepresentation is
+invariant line and the standard subrepresentation, again under `|α| ≠ 0` in `k`, is
 `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, and that the standard
 subrepresentation has dimension `|α| - 1` is `TauCeti.finrank_augmentationSubrepresentation`.
 
@@ -108,8 +109,12 @@ section Standard
 variable (k : Type*) [Field k] (α : Type*) [Fintype α]
 
 /-- The **standard representation** of the symmetric group on `α`: the action of `Equiv.Perm α` on
-the vectors of `k[α]` whose coefficients sum to zero.  It is the complement of the invariant line
-in the permutation representation `k[α]`, and it is the Specht module of the shape `(|α|-1, 1)`. -/
+the vectors of `k[α]` whose coefficients sum to zero.  No hypothesis on `k` is imposed here; when
+`(Fintype.card α : k) ≠ 0` it is a complement of the invariant line in the permutation
+representation `k[α]`, by `isCompl_invariantLine_augmentationSubrepresentation`, whereas when
+`(Fintype.card α : k) = 0` the invariant line lies inside it instead.  Identifying it with the
+Specht module of the shape `(|α|-1, 1)` is an aim for later: the polytabloid presentation needed to
+state that equivalence is not yet in the repository. -/
 noncomputable def standardRepresentation :
     Representation k (Equiv.Perm α)
       (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -15,18 +15,18 @@ that permutation representation sit the invariant line spanned by the sum of the
 trivial representation, and the **standard representation**, the subrepresentation of dimension
 `|α| - 1` on which the coefficients sum to zero; when `|α|` is invertible in `k` the two are
 complementary and the permutation representation splits as their direct sum.  This file proves that
-the standard representation is irreducible whenever `|α| ≥ 2` and `|α|` is invertible in `k`.
+the standard representation is irreducible whenever `|α| ≥ 2` and either `|α| = 2` or `|α|` is
+invertible in `k`.
 
 The hypothesis `2 ≤ |α|` is needed: for `|α| ≤ 1` the standard representation is zero, and the zero
-representation is not irreducible.  The hypothesis `|α| ≠ 0` in `k` is a sufficient hypothesis
-uniform in `|α|` rather than a necessary one.  It cannot simply be dropped: as soon as `3 ≤ |α|`
-and `|α| = 0` in `k`, the sum of the standard basis itself has vanishing coefficient sum, so the
-invariant line lies *inside* the standard subrepresentation, and it is a proper subrepresentation
-because the standard one has dimension `|α| - 1 ≥ 2`, so the latter is reducible -- this is the
-first place the modular theory departs from the ordinary one, and it is excluded here rather than
-developed.  The remaining case is an exception: for `|α| = 2` in characteristic `2` the standard
-subrepresentation *is* the invariant line, a line and hence irreducible, so there the conclusion
-holds without `|α| ≠ 0` in `k`.
+representation is not irreducible.  Given `2 ≤ |α|`, the disjunction is sharp.  Invertibility of
+`|α|` cannot simply be dropped: as soon as `3 ≤ |α|` and `|α| = 0` in `k`, the sum of the standard
+basis itself has vanishing coefficient sum, so the invariant line lies *inside* the standard
+subrepresentation, and it is a proper subrepresentation because the standard one has dimension
+`|α| - 1 ≥ 2`, so the latter is reducible -- this is the first place the modular theory departs
+from the ordinary one, and it is excluded here rather than developed.  The remaining case is the
+first disjunct: for `|α| = 2` the standard subrepresentation is a line -- in characteristic `2` it
+*is* the invariant line -- and hence irreducible whatever the characteristic.
 
 The argument is elementary and uses only transpositions.  If `v` has vanishing coefficient sum and
 is nonzero, two of its coefficients differ, say at `x` and `y`; subtracting the transposition
@@ -49,7 +49,7 @@ produces all the others, and those differences span.
 
 The two remaining halves of the picture hold for an arbitrary permutation representation and are
 proved there, in `TauCeti.RepresentationTheory.Augmentation`: that `k[α]` is the direct sum of the
-invariant line and the standard subrepresentation, again under `|α| ≠ 0` in `k`, is
+invariant line and the standard subrepresentation, again under `|α| ≠ 0` in `k` (or `α` empty), is
 `TauCeti.isCompl_invariantLine_augmentationSubrepresentation`, and that the standard
 subrepresentation has dimension `|α| - 1` is `TauCeti.finrank_augmentationSubrepresentation`.
 
@@ -211,11 +211,19 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
       exact Submodule.span_le.mpr (by rintro _ ⟨z, rfl⟩; exact hall z) hw'
     exact absurd (le_antisymm hτ.le hle) hτ.ne
 
-/-- **The standard representation is irreducible.** -/
+/-- **The standard representation is irreducible.**  Given `2 ≤ |α|`, the hypothesis is sharp: for
+`|α| = 2` the standard representation is a line, hence irreducible whatever the characteristic,
+and for `3 ≤ |α|` with `|α| = 0` in `k` the invariant line is a proper nonzero subrepresentation
+of it. -/
 theorem isIrreducible_standardRepresentation (h2 : 2 ≤ Fintype.card α)
-    (hchar : (Fintype.card α : k) ≠ 0) : (standardRepresentation k α).IsIrreducible :=
-  Representation.isIrreducible_toRepresentation_of_isAtom
-    (isAtom_augmentationSubrepresentation h2 hchar)
+    (hchar : Fintype.card α = 2 ∨ (Fintype.card α : k) ≠ 0) :
+    (standardRepresentation k α).IsIrreducible := by
+  rcases hchar with hcard | hchar
+  · -- a two-element `α` leaves a line, which is irreducible in every characteristic
+    exact Representation.isIrreducible_of_finrank_eq_one _
+      (by rw [finrank_augmentationSubrepresentation, hcard])
+  · exact Representation.isIrreducible_toRepresentation_of_isAtom
+      (isAtom_augmentationSubrepresentation h2 hchar)
 
 end Standard
 


### PR DESCRIPTION
This PR splits the permutation representation `k[X]` of a group `G` on a finite `G`-set into its invariant line and its augmentation subrepresentation, and proves that for `G = Equiv.Perm α` the latter — the standard representation of the symmetric group — is irreducible as soon as `2 ≤ |α|` and `|α|` is invertible in `k`. It targets the item "the named small irreducibles" of Layer 4 of `TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md`, which asks for `M^{(n-1,1)} = triv ⊕ standard` with the standard summand the `(n-1)`-dimensional irreducible; the splitting and the dimension count are proved here at the generality of an arbitrary permutation representation, and the irreducibility for the symmetric group. The identification of this representation with the Specht module `S^{(n-1,1)}` needs the polytabloid presentation, which is not yet in the repository, so it is stated as an aim in the docstring rather than claimed.

`TauCeti/RepresentationTheory/Augmentation.lean` is new and general: `coeffSum`, the coefficient-sum augmentation of `k[X]` for a bare index type, is invariant under any permutation action, so its kernel `augmentationSubrepresentation` is a subrepresentation, as is the `invariantLine` spanned by `permutationSum = ∑ₓ x`. The line carries the trivial representation; the kernel is spanned by the differences `single x 1 - single x₀ 1` from a fixed base point (no finiteness needed); the two are complementary exactly under the sharp hypothesis `(Fintype.card X : k) ≠ 0`, rather than under an averaging or ordered-field hypothesis; and the kernel has dimension `|X| - 1`. The existing `TauCeti.MonoidAlgebra.augmentation` is the ring homomorphism of a monoid algebra and cannot be reused, since a `G`-set carries no multiplication; the implementation notes record the relation between the two.

`TauCeti/RepresentationTheory/Symmetric/Standard.lean` is new and defines `standardRepresentation` and proves it irreducible. The computational core is `sub_ofMulAction_swap`: for any `x`, `y` and any `v`, subtracting from `v` the transposition `(x y)` applied to it leaves exactly `(v x - v y) • (single x 1 - single y 1)`. From a nonzero vector of vanishing coefficient sum two coefficients must differ — this is where invertibility of `|α|` enters — so any nonzero invariant subspace of the standard subrepresentation contains one difference of basis vectors, and transposing produces the rest, which span. That gives `isAtom_augmentationSubrepresentation`, minimality inside the lattice of subrepresentations of `k[α]`.

`TauCeti/RepresentationTheory/Irreducible.lean` gains the bridge between the two formulations, `Representation.isIrreducible_toRepresentation_of_isAtom`: an atom of the lattice of subrepresentations of `ρ` carries an irreducible representation, proved by pushing a subrepresentation of `σ.toRepresentation` forward along the inclusion of `σ.toSubmodule`. The file already collected criteria for irreducibility that need no information about the group, so its module docstring is widened from "irreducibility of a line" to the two criteria it now holds; the existing declarations are untouched.

`lake build` and `lake exe axioms` are green (23284 declarations audited, all within `propext`, `Classical.choice`, `Quot.sound`). No Mathlib infrastructure was vendored.

Roadmap: SchurWeyl

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"standard-representation-symmetric-group"}-->

🤖 Prepared with Claude Code
