### PR TITLE
feat(ModularForms): the boundary contour is a piecewise-C1 immersion

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -415,7 +415,7 @@ lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) 
 
 /-- A corner-free closed subinterval of `[0, 5]` lies inside one smooth piece — the
 classification certificate shared by the smoothness and immersion witnesses. -/
-theorem subset_piece_of_disjoint_corners_aux {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
     (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
       Icc c d ⊆ Icc (4 : ℝ) 5 := by
@@ -439,7 +439,7 @@ smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
-  rcases subset_piece_of_disjoint_corners_aux hcd hdis with h | h | h | h
+  rcases subset_piece_of_disjoint_corners hcd hdis with h | h | h | h
   · exact (fdBoundary_piece1 H).mono h
   · exact (fdBoundary_piece13 H).mono h
   · exact (fdBoundary_piece4 H).mono h

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -413,10 +413,8 @@ lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
 lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
   (continuous_fdBoundary H).continuousOn
 
-/-- Internal classification certificate for `contDiffOn_fdBoundary` and the immersion
-witness — a corner-free closed subinterval of `[0, 5]` lies inside one smooth piece. Not
-intended as standalone API. -/
-theorem subset_piece_of_disjoint_corners_aux {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+/-- A corner-free closed subinterval of `[0, 5]` lies inside one smooth piece. -/
+private theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
     (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
       Icc c d ⊆ Icc (4 : ℝ) 5 := by
@@ -440,7 +438,7 @@ smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
-  rcases subset_piece_of_disjoint_corners_aux hcd hdis with h | h | h | h
+  rcases subset_piece_of_disjoint_corners hcd hdis with h | h | h | h
   · exact (fdBoundary_piece1 H).mono h
   · exact (fdBoundary_piece13 H).mono h
   · exact (fdBoundary_piece4 H).mono h

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -413,8 +413,9 @@ lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
 lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
   (continuous_fdBoundary H).continuousOn
 
-/-- A corner-free closed subinterval of `[0, 5]` lies inside one smooth piece. -/
-private theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+/-- A corner-free closed subinterval of `[0, 5]` lies inside one smooth piece — the
+classification certificate shared by the smoothness and immersion witnesses. -/
+theorem subset_piece_of_disjoint_corners_aux {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
     (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
       Icc c d ⊆ Icc (4 : ℝ) 5 := by
@@ -438,7 +439,7 @@ smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
-  rcases subset_piece_of_disjoint_corners hcd hdis with h | h | h | h
+  rcases subset_piece_of_disjoint_corners_aux hcd hdis with h | h | h | h
   · exact (fdBoundary_piece1 H).mono h
   · exact (fdBoundary_piece13 H).mono h
   · exact (fdBoundary_piece4 H).mono h

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -415,7 +415,7 @@ lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) 
 
 /-- A closed subinterval of `[0, 5]` whose interior avoids the three genuine corners lies
 inside one of the four smooth pieces. -/
-theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+private theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
     (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
       Icc c d ⊆ Icc (4 : ℝ) 5 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -413,9 +413,10 @@ lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
 lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
   (continuous_fdBoundary H).continuousOn
 
-/-- A closed subinterval of `[0, 5]` whose interior avoids the three genuine corners lies
-inside one of the four smooth pieces. -/
-private theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+/-- Internal classification certificate for `contDiffOn_fdBoundary` and the immersion
+witness — a corner-free closed subinterval of `[0, 5]` lies inside one smooth piece. Not
+intended as standalone API. -/
+theorem subset_piece_of_disjoint_corners_aux {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
     (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
       Icc c d ⊆ Icc (4 : ℝ) 5 := by
@@ -439,7 +440,7 @@ smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
-  rcases subset_piece_of_disjoint_corners hcd hdis with h | h | h | h
+  rcases subset_piece_of_disjoint_corners_aux hcd hdis with h | h | h | h
   · exact (fdBoundary_piece1 H).mono h
   · exact (fdBoundary_piece13 H).mono h
   · exact (fdBoundary_piece4 H).mono h

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -413,6 +413,25 @@ lemma continuous_fdBoundary (H : ℝ) : Continuous (fdBoundary H) := by
 lemma continuousOn_fdBoundary (H : ℝ) : ContinuousOn (fdBoundary H) (Icc 0 5) :=
   (continuous_fdBoundary H).continuousOn
 
+/-- A closed subinterval of `[0, 5]` whose interior avoids the three genuine corners lies
+inside one of the four smooth pieces. -/
+theorem subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
+    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
+      Icc c d ⊆ Icc (4 : ℝ) 5 := by
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
+    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
+  rcases le_or_gt d 1 with hd1 | hd1
+  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
+  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
+    rcases le_or_gt d 3 with hd3 | hd3
+    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
+    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
+      rcases le_or_gt d 4 with hd4 | hd4
+      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
+      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
+        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
+
 /-- On every closed subinterval of `[0, 5]` whose interior avoids the three genuine
 corners, the contour is smooth at every order — the certificate that `fdBoundaryCorners`
 is a valid breakpoint witness for `isPiecewiseC1On_fdBoundary`. The two arcs continue one
@@ -420,18 +439,11 @@ smooth circle map through `t = 2`, so no hypothesis excludes it. -/
 lemma contDiffOn_fdBoundary (H : ℝ) {c d : ℝ}
     (hcd : Icc c d ⊆ Icc 0 5) (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
     ContDiffOn ℝ n (fdBoundary H) (Icc c d) := by
-  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
-    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
-  rcases le_or_gt d 1 with hd1 | hd1
-  · exact (fdBoundary_piece1 H).mono fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
-  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
-    rcases le_or_gt d 3 with hd3 | hd3
-    · exact (fdBoundary_piece13 H).mono fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩
-    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
-      rcases le_or_gt d 4 with hd4 | hd4
-      · exact (fdBoundary_piece4 H).mono fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩
-      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
-        exact (fdBoundary_piece5 H).mono fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩
+  rcases subset_piece_of_disjoint_corners hcd hdis with h | h | h | h
+  · exact (fdBoundary_piece1 H).mono h
+  · exact (fdBoundary_piece13 H).mono h
+  · exact (fdBoundary_piece4 H).mono h
+  · exact (fdBoundary_piece5 H).mono h
 
 /-- The right vertical has constant real part `1/2`. -/
 theorem re_fdBoundary_segment1 (H : ℝ) {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -158,17 +158,23 @@ lemma hasDerivAt_fdBoundary_of_lt_one (ht : t < 1) :
     filter_upwards [Iio_mem_nhds ht] with s hs
     exact fdBoundary_of_le_one hs.le
 
+/-- The unified-arc parameterization differentiates by the chain rule, at every real
+parameter. -/
+lemma hasDerivAt_fdBoundary_arcMap (t : ℝ) :
+    HasDerivAt (fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)))
+      ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
+  have hθ : HasDerivAt (fun s : ℝ ↦ (s + 1) * (Real.pi / 6)) (Real.pi / 6) t := by
+    simpa using ((hasDerivAt_id t).add_const 1).mul_const (Real.pi / 6)
+  exact HasDerivAt.scomp_of_eq (x := t)
+    (hg := hasDerivAt_circleMap 0 1 ((t + 1) * (Real.pi / 6))) (hh := hθ) (hy := rfl)
+
 /-- Strictly between the first and third breakpoints — across the smooth junction at
 `t = 2`, where the two arc segments continue the same circle parameterization — the
 contour differentiates like the unified arc of angle `(t + 1)·π/6`. -/
 lemma hasDerivAt_fdBoundary_of_mem_Ioo_one_three (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
     HasDerivAt (fdBoundary H)
       ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
-  have hθ : HasDerivAt (fun s : ℝ ↦ (s + 1) * (Real.pi / 6)) (Real.pi / 6) t := by
-    simpa using ((hasDerivAt_id t).add_const 1).mul_const (Real.pi / 6)
-  have h_arc := HasDerivAt.scomp_of_eq (x := t)
-    (hg := hasDerivAt_circleMap 0 1 ((t + 1) * (Real.pi / 6))) (hh := hθ) (hy := rfl)
-  refine h_arc.congr_of_eventuallyEq ?_
+  refine (hasDerivAt_fdBoundary_arcMap t).congr_of_eventuallyEq ?_
   filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
   exact eqOn_fdBoundary_arc H ⟨hs.1.le, hs.2.le⟩
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -160,7 +160,7 @@ lemma hasDerivAt_fdBoundary_of_lt_one (ht : t < 1) :
 
 /-- The unified-arc parameterization differentiates by the chain rule, at every real
 parameter. -/
-lemma hasDerivAt_fdBoundary_arcMap (t : ℝ) :
+private lemma hasDerivAt_arcMap (t : ℝ) :
     HasDerivAt (fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)))
       ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
   have hθ : HasDerivAt (fun s : ℝ ↦ (s + 1) * (Real.pi / 6)) (Real.pi / 6) t := by
@@ -168,13 +168,24 @@ lemma hasDerivAt_fdBoundary_arcMap (t : ℝ) :
   exact HasDerivAt.scomp_of_eq (x := t)
     (hg := hasDerivAt_circleMap 0 1 ((t + 1) * (Real.pi / 6))) (hh := hθ) (hy := rfl)
 
+/-- On any subinterval of the arc range, the contour's within-derivative is the arc
+speed, endpoints included. -/
+lemma hasDerivWithinAt_fdBoundary_arc {c d : ℝ} (hc : 1 ≤ c) (hd : d ≤ 3)
+    (ht : t ∈ Set.Icc c d) :
+    HasDerivWithinAt (fdBoundary H)
+      ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I))
+      (Set.Icc c d) t := by
+  refine (hasDerivAt_arcMap t).hasDerivWithinAt.congr (fun s hs ↦ ?_) ?_
+  · exact eqOn_fdBoundary_arc H ⟨hc.trans hs.1, hs.2.trans hd⟩
+  · exact eqOn_fdBoundary_arc H ⟨hc.trans ht.1, ht.2.trans hd⟩
+
 /-- Strictly between the first and third breakpoints — across the smooth junction at
 `t = 2`, where the two arc segments continue the same circle parameterization — the
 contour differentiates like the unified arc of angle `(t + 1)·π/6`. -/
 lemma hasDerivAt_fdBoundary_of_mem_Ioo_one_three (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
     HasDerivAt (fdBoundary H)
       ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
-  refine (hasDerivAt_fdBoundary_arcMap t).congr_of_eventuallyEq ?_
+  refine (hasDerivAt_arcMap t).congr_of_eventuallyEq ?_
   filter_upwards [Ioo_mem_nhds ht.1 ht.2] with s hs
   exact eqOn_fdBoundary_arc H ⟨hs.1.le, hs.2.le⟩
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -33,25 +33,6 @@ namespace ModularForm
 
 variable {H t c d : ℝ}
 
--- Duplicated from `Basic` deliberately: review guidance keeps the interval classification
--- private on both sides rather than public API.
-private lemma subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
-    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
-    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
-      Icc c d ⊆ Icc (4 : ℝ) 5 := by
-  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
-    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
-  rcases le_or_gt d 1 with hd1 | hd1
-  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
-  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
-    rcases le_or_gt d 3 with hd3 | hd3
-    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
-    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
-      rcases le_or_gt d 4 with hd4 | hd4
-      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
-      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
-        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
-
 /-- The vertical chords are nonzero exactly when the height differs from the corner row. -/
 private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
@@ -91,7 +72,7 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
       rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
     refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
     have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
-    rcases subset_piece_of_disjoint_corners hsub' hdis with h | h | h | h
+    rcases subset_piece_of_disjoint_corners_aux hsub' hdis with h | h | h | h
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -61,8 +61,8 @@ private lemma arc_deriv_ne_zero (t : ℝ) :
 with nonvanishing tangent. -/
 theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
     IsPwC1ImmersionOn (fdBoundary H) 0 5 := by
-  rw [isPwC1ImmersionOn_iff]
-  refine ⟨(continuous_fdBoundary H).continuousOn, fdBoundaryCorners, ?_, ?_⟩
+  refine IsPwC1ImmersionOn.of_breakpoints (continuous_fdBoundary H).continuousOn
+    fdBoundaryCorners ?_ ?_
   · intro x hx
     rw [Finset.mem_coe, mem_fdBoundaryCorners] at hx
     rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5), max_eq_right (by norm_num : (0 : ℝ) ≤ 5)]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -80,7 +80,7 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
       rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
     refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
     have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
-    rcases subset_piece_of_disjoint_corners_aux hsub' hdis with h | h | h | h
+    rcases subset_piece_of_disjoint_corners hsub' hdis with h | h | h | h
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -7,8 +7,6 @@ module
 public import TauCeti.Analysis.Contour.PwC1ImmersionOn
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
 
-import Mathlib.MeasureTheory.Integral.CircleIntegral
-
 /-!
 # The boundary contour is a piecewise-`C¹` immersion
 
@@ -34,6 +32,25 @@ namespace TauCeti
 namespace ModularForm
 
 variable {H t c d : ℝ}
+
+-- Duplicated from `Basic` deliberately: review guidance keeps the interval classification
+-- private on both sides rather than public API.
+private lemma subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
+    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
+      Icc c d ⊆ Icc (4 : ℝ) 5 := by
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
+    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
+  rcases le_or_gt d 1 with hd1 | hd1
+  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
+  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
+    rcases le_or_gt d 3 with hd3 | hd3
+    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
+    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
+      rcases le_or_gt d 4 with hd4 | hd4
+      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
+      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
+        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
 
 /-- The vertical chords are nonzero exactly when the height differs from the corner row. -/
 private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
@@ -79,9 +96,8 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]
       exact segment1_chord_ne_zero hH
-    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_arc H (h hs))
-        (eqOn_fdBoundary_arc H (h ht)),
-        (hasDerivAt_fdBoundary_arcMap t).hasDerivWithinAt.derivWithin h_uniq]
+    · rw [(hasDerivWithinAt_fdBoundary_arc (h ⟨le_rfl, hlt.le⟩).1
+        (h ⟨hlt.le, le_rfl⟩).2 ht).derivWithin h_uniq]
       exact arc_deriv_ne_zero t
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment4 H (h hs))
         (eqOn_fdBoundary_segment4 H (h ht)),

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -51,13 +51,6 @@ private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
   rw [h0, Complex.zero_im] at him
   linarith
 
-private lemma segment4_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
-    (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) ≠ 0 := by
-  have h : (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) =
-      -((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)) := by ring
-  rw [h]
-  exact neg_ne_zero.mpr (segment1_chord_ne_zero hH)
-
 private lemma arc_deriv_ne_zero (t : ℝ) :
     (Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I) ≠ 0 := by
   refine smul_ne_zero (by positivity) (mul_ne_zero ?_ Complex.I_ne_zero)
@@ -86,10 +79,12 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
     · rw [(hasDerivWithinAt_fdBoundary_arc (h ⟨le_rfl, hlt.le⟩).1
         (h ⟨hlt.le, le_rfl⟩).2 ht).derivWithin h_uniq]
       exact arc_deriv_ne_zero t
-    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment4 H (h hs))
+    · have hchord : (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) =
+          -((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)) := by ring
+      rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment4 H (h hs))
         (eqOn_fdBoundary_segment4 H (h ht)),
-        (hasDerivAt_fdBoundary_segment4 H t).hasDerivWithinAt.derivWithin h_uniq]
-      exact segment4_chord_ne_zero hH
+        (hasDerivAt_fdBoundary_segment4 H t).hasDerivWithinAt.derivWithin h_uniq, hchord]
+      exact neg_ne_zero.mpr (segment1_chord_ne_zero hH)
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment5 H (h hs))
         (eqOn_fdBoundary_segment5 H (h ht)),
         (hasDerivAt_fdBoundary_segment5 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -41,6 +41,26 @@ namespace ModularForm
 
 variable {H t c d : ℝ}
 
+-- Deliberately duplicated from `Basic`, where the same classification is private: the
+-- api-design adjudication on PR #2040 (review comment 3723294035) keeps the classifier
+-- out of the public API, and `private` declarations cannot be shared across modules.
+private lemma subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
+    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
+      Icc c d ⊆ Icc (4 : ℝ) 5 := by
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
+    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
+  rcases le_or_gt d 1 with hd1 | hd1
+  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
+  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
+    rcases le_or_gt d 3 with hd3 | hd3
+    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
+    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
+      rcases le_or_gt d 4 with hd4 | hd4
+      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
+      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
+        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
+
 /-- The segment-1 chord is nonzero when the height differs from the corner row. -/
 private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
@@ -80,7 +100,7 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
       rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
     refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
     have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
-    rcases subset_piece_of_disjoint_corners_aux hsub' hdis with h | h | h | h
+    rcases subset_piece_of_disjoint_corners hsub' hdis with h | h | h | h
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -53,12 +53,10 @@ private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
 
 private lemma segment4_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) ≠ 0 := by
-  intro h0
-  apply hH
-  have him : ((-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
-    simp [ρ]
-  rw [h0, Complex.zero_im] at him
-  linarith
+  have h : (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) =
+      -((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)) := by ring
+  rw [h]
+  exact neg_ne_zero.mpr (segment1_chord_ne_zero hH)
 
 private lemma arc_deriv_ne_zero (t : ℝ) :
     (Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I) ≠ 0 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -1,0 +1,124 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.PwC1ImmersionOn
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+import Mathlib.MeasureTheory.Integral.CircleIntegral
+
+/-!
+# The boundary contour is a piecewise-`C¹` immersion
+
+Away from the three genuine corners every piece of the boundary contour has a nonvanishing
+tangent: the verticals and the horizontal move with constant nonzero chords (the height
+clearing the corner row keeps the verticals nondegenerate), and the unified arc moves at
+constant speed `π/6`. This is the regularity that feeds the principal-value existence of
+the winding decomposition and the residue sum along the contour.
+
+## Main declarations
+
+* `TauCeti.ModularForm.isPwC1ImmersionOn_fdBoundary`.
+-/
+
+public noncomputable section
+
+open Complex Set UpperHalfPlane TauCeti.Contour
+
+open scoped Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H t c d : ℝ}
+
+private lemma exists_piece_superset (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
+    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
+    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
+      Icc c d ⊆ Icc (4 : ℝ) 5 := by
+  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
+    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
+  rcases le_or_gt d 1 with hd1 | hd1
+  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
+  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt1 ↦ hbp 1 (by simp) ⟨hlt1, hd1⟩
+    rcases le_or_gt d 3 with hd3 | hd3
+    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
+    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt3 ↦ hbp 3 (by simp) ⟨hlt3, hd3⟩
+      rcases le_or_gt d 4 with hd4 | hd4
+      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
+      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt4 ↦ hbp 4 (by simp) ⟨hlt4, hd4⟩
+        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
+
+/-- The vertical chords are nonzero once the height clears the corner row. -/
+private lemma segment1_chord_ne_zero (hH : 1 ≤ H) :
+    (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
+  have h32 : Real.sqrt 3 / 2 < 1 := by
+    rw [div_lt_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  intro h0
+  have := congrArg Complex.im h0
+  simp [ρ] at this
+  nlinarith [this]
+
+private lemma segment4_chord_ne_zero (hH : 1 ≤ H) :
+    (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) ≠ 0 := by
+  have h32 : Real.sqrt 3 / 2 < 1 := by
+    rw [div_lt_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  intro h0
+  have := congrArg Complex.im h0
+  simp [ρ] at this
+  nlinarith [this]
+
+private lemma arc_deriv_ne_zero (t : ℝ) :
+    (Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I) ≠ 0 := by
+  refine smul_ne_zero (by positivity) (mul_ne_zero ?_ Complex.I_ne_zero)
+  exact circleMap_ne_center one_ne_zero
+
+/-- The boundary contour is a piecewise-`C¹` immersion: every corner-free piece is `C¹`
+with nonvanishing tangent. -/
+theorem isPwC1ImmersionOn_fdBoundary (hH : 1 ≤ H) :
+    IsPwC1ImmersionOn (fdBoundary H) 0 5 := by
+  rw [isPwC1ImmersionOn_iff]
+  refine ⟨(continuous_fdBoundary H).continuousOn, fdBoundaryCorners, ?_, ?_⟩
+  · intro x hx
+    rw [Finset.mem_coe, mem_fdBoundaryCorners] at hx
+    rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5), max_eq_right (by norm_num : (0 : ℝ) ≤ 5)]
+    rcases hx with rfl | rfl | rfl <;> exact ⟨by norm_num, by norm_num⟩
+  · intro c d hlt hsub hdis
+    have hsub' : Icc c d ⊆ Icc (0 : ℝ) 5 := by
+      rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
+    refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
+    have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
+    rcases exists_piece_superset hsub' hdis with h | h | h | h
+    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
+        (eqOn_fdBoundary_segment1 H (h ht)),
+        (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]
+      exact segment1_chord_ne_zero hH
+    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_arc H (h hs))
+        (eqOn_fdBoundary_arc H (h ht))]
+      have h_arc : HasDerivAt (fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)))
+          ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
+        have hθ : HasDerivAt (fun s : ℝ ↦ (s + 1) * (Real.pi / 6)) (Real.pi / 6) t := by
+          simpa using ((hasDerivAt_id t).add_const 1).mul_const (Real.pi / 6)
+        exact HasDerivAt.scomp_of_eq (x := t)
+          (hg := hasDerivAt_circleMap 0 1 ((t + 1) * (Real.pi / 6))) (hh := hθ) (hy := rfl)
+      rw [h_arc.hasDerivWithinAt.derivWithin h_uniq]
+      exact arc_deriv_ne_zero t
+    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment4 H (h hs))
+        (eqOn_fdBoundary_segment4 H (h ht)),
+        (hasDerivAt_fdBoundary_segment4 H t).hasDerivWithinAt.derivWithin h_uniq]
+      exact segment4_chord_ne_zero hH
+    · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment5 H (h hs))
+        (eqOn_fdBoundary_segment5 H (h ht)),
+        (hasDerivAt_fdBoundary_segment5 H t).hasDerivWithinAt.derivWithin h_uniq]
+      exact one_ne_zero
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -19,6 +19,14 @@ the winding decomposition and the residue sum along the contour.
 ## Main declarations
 
 * `TauCeti.ModularForm.isPwC1ImmersionOn_fdBoundary`.
+
+## References
+
+The immersion condition is the regularity requirement of N. Hungerbühler and M. Wasem,
+*Non-integer valued winding numbers and a generalized Residue Theorem*, arXiv:1808.00997
+(2018); the truncated-contour strategy follows the fundamental-domain boundary development
+of AINTLIB's `LeanModularForms` (`ForMathlib/FDBoundary.lean`, `FDBoundaryH.lean`,
+`FDBoundaryPath.lean`).
 -/
 
 public noncomputable section

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -41,26 +41,6 @@ namespace ModularForm
 
 variable {H t c d : ℝ}
 
--- Deliberately duplicated from `Basic`, where the same classification is private: the
--- api-design adjudication on PR #2040 (review comment 3723294035) keeps the classifier
--- out of the public API, and `private` declarations cannot be shared across modules.
-private lemma subset_piece_of_disjoint_corners {c d : ℝ} (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
-    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
-    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
-      Icc c d ⊆ Icc (4 : ℝ) 5 := by
-  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
-    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
-  rcases le_or_gt d 1 with hd1 | hd1
-  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
-  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt ↦ hbp 1 (by simp) ⟨hlt, hd1⟩
-    rcases le_or_gt d 3 with hd3 | hd3
-    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
-    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt ↦ hbp 3 (by simp) ⟨hlt, hd3⟩
-      rcases le_or_gt d 4 with hd4 | hd4
-      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
-      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt ↦ hbp 4 (by simp) ⟨hlt, hd4⟩
-        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
-
 /-- The segment-1 chord is nonzero when the height differs from the corner row. -/
 private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
@@ -100,7 +80,7 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
       rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
     refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
     have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
-    rcases subset_piece_of_disjoint_corners hsub' hdis with h | h | h | h
+    rcases subset_piece_of_disjoint_corners_aux hsub' hdis with h | h | h | h
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -14,7 +14,7 @@ import Mathlib.MeasureTheory.Integral.CircleIntegral
 
 Away from the three genuine corners every piece of the boundary contour has a nonvanishing
 tangent: the verticals and the horizontal move with constant nonzero chords (the height
-clearing the corner row keeps the verticals nondegenerate), and the unified arc moves at
+differing from the corner row keeps the verticals nondegenerate), and the unified arc moves at
 constant speed `π/6`. This is the regularity that feeds the principal-value existence of
 the winding decomposition and the residue sum along the contour.
 
@@ -35,43 +35,24 @@ namespace ModularForm
 
 variable {H t c d : ℝ}
 
-private lemma exists_piece_superset (hcd : Icc c d ⊆ Icc (0 : ℝ) 5)
-    (hdis : Disjoint (fdBoundaryCorners : Set ℝ) (Ioo c d)) :
-    Icc c d ⊆ Icc (0 : ℝ) 1 ∨ Icc c d ⊆ Icc (1 : ℝ) 3 ∨ Icc c d ⊆ Icc (3 : ℝ) 4 ∨
-      Icc c d ⊆ Icc (4 : ℝ) 5 := by
-  have hbp : ∀ m : ℝ, m ∈ fdBoundaryCorners → m ∉ Ioo c d := fun m hm ↦
-    Set.disjoint_left.mp hdis (Finset.mem_coe.mpr hm)
-  rcases le_or_gt d 1 with hd1 | hd1
-  · exact Or.inl fun x hx ↦ ⟨(hcd hx).1, hx.2.trans hd1⟩
-  · have hc1 : 1 ≤ c := le_of_not_gt fun hlt1 ↦ hbp 1 (by simp) ⟨hlt1, hd1⟩
-    rcases le_or_gt d 3 with hd3 | hd3
-    · exact Or.inr (Or.inl fun x hx ↦ ⟨hc1.trans hx.1, hx.2.trans hd3⟩)
-    · have hc3 : 3 ≤ c := le_of_not_gt fun hlt3 ↦ hbp 3 (by simp) ⟨hlt3, hd3⟩
-      rcases le_or_gt d 4 with hd4 | hd4
-      · exact Or.inr (Or.inr (Or.inl fun x hx ↦ ⟨hc3.trans hx.1, hx.2.trans hd4⟩))
-      · have hc4 : 4 ≤ c := le_of_not_gt fun hlt4 ↦ hbp 4 (by simp) ⟨hlt4, hd4⟩
-        exact Or.inr (Or.inr (Or.inr fun x hx ↦ ⟨hc4.trans hx.1, (hcd hx).2⟩))
-
-/-- The vertical chords are nonzero once the height clears the corner row. -/
-private lemma segment1_chord_ne_zero (hH : 1 ≤ H) :
+/-- The vertical chords are nonzero exactly when the height differs from the corner row. -/
+private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
-  have h32 : Real.sqrt 3 / 2 < 1 := by
-    rw [div_lt_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
   intro h0
-  have := congrArg Complex.im h0
-  simp [ρ] at this
-  nlinarith [this]
+  apply hH
+  have him : ((ρ : ℂ) + 1 - (1 / 2 + H * Complex.I)).im = Real.sqrt 3 / 2 - H := by
+    simp [ρ]
+  rw [h0, Complex.zero_im] at him
+  linarith
 
-private lemma segment4_chord_ne_zero (hH : 1 ≤ H) :
+private lemma segment4_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ) ≠ 0 := by
-  have h32 : Real.sqrt 3 / 2 < 1 := by
-    rw [div_lt_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
   intro h0
-  have := congrArg Complex.im h0
-  simp [ρ] at this
-  nlinarith [this]
+  apply hH
+  have him : ((-1 / 2 : ℂ) + H * Complex.I - (ρ : ℂ)).im = H - Real.sqrt 3 / 2 := by
+    simp [ρ]
+  rw [h0, Complex.zero_im] at him
+  linarith
 
 private lemma arc_deriv_ne_zero (t : ℝ) :
     (Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I) ≠ 0 := by
@@ -80,7 +61,7 @@ private lemma arc_deriv_ne_zero (t : ℝ) :
 
 /-- The boundary contour is a piecewise-`C¹` immersion: every corner-free piece is `C¹`
 with nonvanishing tangent. -/
-theorem isPwC1ImmersionOn_fdBoundary (hH : 1 ≤ H) :
+theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
     IsPwC1ImmersionOn (fdBoundary H) 0 5 := by
   rw [isPwC1ImmersionOn_iff]
   refine ⟨(continuous_fdBoundary H).continuousOn, fdBoundaryCorners, ?_, ?_⟩
@@ -93,7 +74,7 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : 1 ≤ H) :
       rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
     refine ⟨contDiffOn_fdBoundary H hsub' hdis, fun t ht ↦ ?_⟩
     have h_uniq : UniqueDiffWithinAt ℝ (Icc c d) t := uniqueDiffOn_Icc hlt t ht
-    rcases exists_piece_superset hsub' hdis with h | h | h | h
+    rcases subset_piece_of_disjoint_corners hsub' hdis with h | h | h | h
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment1 H (h hs))
         (eqOn_fdBoundary_segment1 H (h ht)),
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -33,7 +33,7 @@ namespace ModularForm
 
 variable {H t c d : ℝ}
 
-/-- The vertical chords are nonzero exactly when the height differs from the corner row. -/
+/-- The segment-1 chord is nonzero when the height differs from the corner row. -/
 private lemma segment1_chord_ne_zero (hH : H ≠ Real.sqrt 3 / 2) :
     (ρ : ℂ) + 1 - (1 / 2 + H * Complex.I) ≠ 0 := by
   intro h0

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Immersion.lean
@@ -80,14 +80,8 @@ theorem isPwC1ImmersionOn_fdBoundary (hH : H ≠ Real.sqrt 3 / 2) :
         (hasDerivAt_fdBoundary_segment1 H t).hasDerivWithinAt.derivWithin h_uniq]
       exact segment1_chord_ne_zero hH
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_arc H (h hs))
-        (eqOn_fdBoundary_arc H (h ht))]
-      have h_arc : HasDerivAt (fun s : ℝ ↦ circleMap 0 1 ((s + 1) * (Real.pi / 6)))
-          ((Real.pi / 6) • (circleMap 0 1 ((t + 1) * (Real.pi / 6)) * Complex.I)) t := by
-        have hθ : HasDerivAt (fun s : ℝ ↦ (s + 1) * (Real.pi / 6)) (Real.pi / 6) t := by
-          simpa using ((hasDerivAt_id t).add_const 1).mul_const (Real.pi / 6)
-        exact HasDerivAt.scomp_of_eq (x := t)
-          (hg := hasDerivAt_circleMap 0 1 ((t + 1) * (Real.pi / 6))) (hh := hθ) (hy := rfl)
-      rw [h_arc.hasDerivWithinAt.derivWithin h_uniq]
+        (eqOn_fdBoundary_arc H (h ht)),
+        (hasDerivAt_fdBoundary_arcMap t).hasDerivWithinAt.derivWithin h_uniq]
       exact arc_deriv_ne_zero t
     · rw [derivWithin_congr (fun s hs ↦ eqOn_fdBoundary_segment4 H (h hs))
         (eqOn_fdBoundary_segment4 H (h ht)),


### PR DESCRIPTION
Adds `FundamentalDomainBoundary/Immersion.lean`: the boundary contour is a piecewise-`C¹` immersion (`isPwC1ImmersionOn_fdBoundary`, under the sharp hypothesis `H ≠ √3/2` — the verticals' chords must not collapse). This is the regularity input the Hungerbühler–Wasem residue sum takes for the valence-formula contour.

Also extracts, per review:
* `Deriv.lean`: the private chain-rule core and the characteristic `hasDerivWithinAt_fdBoundary_arc` (endpoints included).
* `Basic.lean`: the corner-free interval classification shared by the smoothness and immersion witnesses, as `subset_piece_of_disjoint_corners_aux`.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence formula: the boundary contour is a piecewise-C1 immersion","id":"modular-valence-fd-immersion"}-->
