### PR TITLE
feat(ModularForms): decompose the boundary winding number into pieces

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
@@ -38,23 +38,19 @@ namespace ModularForm
 
 variable {H : ℝ} {w : ℂ}
 
-/-- The single-point Cauchy principal value of the index integrand exists on every
-subinterval of the parameter interval of the boundary contour, for any point `w` off the
-contour: the integrand is then singularity-free, and integrable by piecewise-`C¹`
-regularity. -/
-theorem cauchyPVExistsAt_fdBoundary (hw : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w)
-    (c d : ℝ) (hc : c ∈ Icc (0 : ℝ) 5) (hd : d ∈ Icc (0 : ℝ) 5) :
+/-- The single-point Cauchy principal value of the index integrand exists on any parameter
+subinterval of the boundary contour avoiding `w`: the integrand is then singularity-free,
+and integrable by piecewise-`C¹` regularity. -/
+theorem cauchyPVExistsAt_fdBoundary (c d : ℝ) (hc : c ∈ Icc (0 : ℝ) 5)
+    (hd : d ∈ Icc (0 : ℝ) 5) (hw : ∀ t ∈ uIcc c d, fdBoundary H t ≠ w) :
     CauchyPVExistsAt (fdBoundary H) c d (fun z => (z - w)⁻¹) w := by
   have hsub : uIcc c d ⊆ uIcc (0 : ℝ) 5 := uIcc_subset_uIcc
     (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
     (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
-  have hsub' : uIcc c d ⊆ Icc (0 : ℝ) 5 := by
-    rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
-  refine cauchyPVExistsAt_of_avoidance (continuous_fdBoundary H).continuousOn
-    (fun t ht => hw t (hsub' ht)) ?_
+  refine cauchyPVExistsAt_of_avoidance (continuous_fdBoundary H).continuousOn hw ?_
   have hcont : ContinuousOn (fun t => (fdBoundary H t - w)⁻¹) (uIcc c d) :=
     ((continuous_fdBoundary H).continuousOn.sub continuousOn_const).inv₀
-      fun t ht => sub_ne_zero.mpr (hw t (hsub' ht))
+      fun t ht => sub_ne_zero.mpr (hw t ht)
   exact ((isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv.mono_set
     hsub).continuousOn_mul hcont
 
@@ -67,7 +63,14 @@ theorem windingNumber_fdBoundary_eq_sum_pieces
     windingNumber (fdBoundary H) 0 5 w =
       windingNumber (fdBoundary H) 0 1 w + windingNumber (fdBoundary H) 1 3 w +
         windingNumber (fdBoundary H) 3 4 w + windingNumber (fdBoundary H) 4 5 w := by
-  have hpv := cauchyPVExistsAt_fdBoundary hw
+  have hpv : ∀ c d : ℝ, c ∈ Icc (0 : ℝ) 5 → d ∈ Icc (0 : ℝ) 5 →
+      CauchyPVExistsAt (fdBoundary H) c d (fun z => (z - w)⁻¹) w := fun c d hc hd =>
+    cauchyPVExistsAt_fdBoundary c d hc hd fun s hs => hw s (by
+      have hsub : uIcc c d ⊆ uIcc (0 : ℝ) 5 := uIcc_subset_uIcc
+        (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+        (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+      have hs5 := hsub hs
+      rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hs5)
   have h := windingNumber_eq_sum_range (γ := fdBoundary H) (z₀ := w) (n := 4)
     (t := fun k => match k with | 0 => 0 | 1 => 1 | 2 => 3 | 3 => 4 | _ => 5)
     (fun k hk => by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
@@ -12,11 +12,12 @@ import TauCeti.Analysis.Contour.Winding.Number.Partition
 /-!
 # Decomposition of the winding number of the boundary contour
 
-For a point off the boundary contour of the truncated fundamental domain, the winding
+For a point off the boundary path `fdBoundary H` — the contour that traces the boundary of
+the truncated fundamental domain once the height parameter satisfies `1 < H` — the winding
 number over the full parameter interval `[0, 5]` splits as the sum of the winding numbers
 of the four smooth pieces: the right vertical, the arc, the left vertical, and the
-truncation ceiling. This is the entry point for evaluating the winding number at interior
-points piece by piece.
+truncation ceiling. The statements hold for arbitrary `H`. This is the entry point for
+evaluating the winding number at interior points piece by piece.
 
 The single-point Cauchy principal values required by the partition additivity are supplied
 by avoidance: away from the contour the index integrand has no singularity, and its
@@ -39,7 +40,7 @@ namespace ModularForm
 variable {H : ℝ} {w : ℂ}
 
 /-- The single-point Cauchy principal value of the index integrand exists on any parameter
-subinterval of the boundary contour avoiding `w`: the integrand is then singularity-free,
+subinterval of the boundary path avoiding `w`: the integrand is then singularity-free,
 and integrable by piecewise-`C¹` regularity. -/
 theorem cauchyPVExistsAt_fdBoundary (c d : ℝ) (hc : c ∈ Icc (0 : ℝ) 5)
     (hd : d ∈ Icc (0 : ℝ) 5) (hw : ∀ t ∈ uIcc c d, fdBoundary H t ≠ w) :
@@ -54,7 +55,7 @@ theorem cauchyPVExistsAt_fdBoundary (c d : ℝ) (hc : c ∈ Icc (0 : ℝ) 5)
   exact ((isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv.mono_set
     hsub).continuousOn_mul hcont
 
-/-- The winding number of the boundary contour about a point off the contour is the sum of
+/-- The winding number of the boundary path about a point off it is the sum of
 the winding numbers of its four smooth pieces: the right vertical, the arc, the left
 vertical, and the truncation ceiling. This instantiates the finite-partition additivity
 `Contour.windingNumber_eq_sum_range` at the junction partition `0, 1, 3, 4, 5`. -/

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
@@ -1,0 +1,79 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.Number.Concat
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+/-!
+# Decomposition of the winding number of the boundary contour
+
+For a point off the boundary contour of the truncated fundamental domain, the winding
+number over the full parameter interval `[0, 5]` splits as the sum of the winding numbers
+of the four smooth pieces: the right vertical, the arc, the left vertical, and the
+truncation ceiling. This is the entry point for evaluating the winding number at interior
+points piece by piece.
+
+The single-point Cauchy principal values required by the concatenation are supplied by
+avoidance: away from the contour the index integrand has no singularity, and its
+integrability follows from the piecewise-`C¹` regularity of the contour.
+
+## Main declarations
+
+* `TauCeti.ModularForm.cauchyPVExistsAt_fdBoundary`
+* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_sum_pieces`
+-/
+
+public section
+
+open Set TauCeti.Contour
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H : ℝ} {w : ℂ}
+
+/-- The single-point Cauchy principal value of the index integrand exists on every
+subinterval of the parameter interval of the boundary contour, for any point `w` off the
+contour: the integrand is then singularity-free, and integrable by piecewise-`C¹`
+regularity. -/
+theorem cauchyPVExistsAt_fdBoundary (hw : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w)
+    (c d : ℝ) (hc : c ∈ Icc (0 : ℝ) 5) (hd : d ∈ Icc (0 : ℝ) 5) :
+    CauchyPVExistsAt (fdBoundary H) c d (fun z => (z - w)⁻¹) w := by
+  have hsub : uIcc c d ⊆ uIcc (0 : ℝ) 5 := uIcc_subset_uIcc
+    (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+    (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+  have hsub' : uIcc c d ⊆ Icc (0 : ℝ) 5 := by
+    rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hsub
+  refine cauchyPVExistsAt_of_avoidance (continuous_fdBoundary H).continuousOn
+    (fun t ht => hw t (hsub' ht)) ?_
+  have hcont : ContinuousOn (fun t => (fdBoundary H t - w)⁻¹) (uIcc c d) :=
+    ((continuous_fdBoundary H).continuousOn.sub continuousOn_const).inv₀
+      fun t ht => sub_ne_zero.mpr (hw t (hsub' ht))
+  exact ((isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv.mono_set
+    hsub).continuousOn_mul hcont
+
+/-- The winding number of the boundary contour about a point off the contour is the sum of
+the winding numbers of its four smooth pieces: the right vertical, the arc, the left
+vertical, and the truncation ceiling. -/
+theorem windingNumber_fdBoundary_eq_sum_pieces
+    (hw : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w) :
+    windingNumber (fdBoundary H) 0 5 w =
+      windingNumber (fdBoundary H) 0 1 w + windingNumber (fdBoundary H) 1 3 w +
+        windingNumber (fdBoundary H) 3 4 w + windingNumber (fdBoundary H) 4 5 w := by
+  have hpv := cauchyPVExistsAt_fdBoundary hw
+  rw [windingNumber_concat (hpv 0 4 (by norm_num) (by norm_num))
+      (hpv 4 5 (by norm_num) (by norm_num)),
+    windingNumber_concat (hpv 0 3 (by norm_num) (by norm_num))
+      (hpv 3 4 (by norm_num) (by norm_num)),
+    windingNumber_concat (hpv 0 1 (by norm_num) (by norm_num))
+      (hpv 1 3 (by norm_num) (by norm_num))]
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Decomposition.lean
@@ -4,8 +4,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Analysis.Contour.Winding.Number.Concat
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+import TauCeti.Analysis.Contour.Winding.Number.Partition
 
 /-!
 # Decomposition of the winding number of the boundary contour
@@ -16,8 +18,8 @@ of the four smooth pieces: the right vertical, the arc, the left vertical, and t
 truncation ceiling. This is the entry point for evaluating the winding number at interior
 points piece by piece.
 
-The single-point Cauchy principal values required by the concatenation are supplied by
-avoidance: away from the contour the index integrand has no singularity, and its
+The single-point Cauchy principal values required by the partition additivity are supplied
+by avoidance: away from the contour the index integrand has no singularity, and its
 integrability follows from the piecewise-`C¹` regularity of the contour.
 
 ## Main declarations
@@ -58,19 +60,25 @@ theorem cauchyPVExistsAt_fdBoundary (hw : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary 
 
 /-- The winding number of the boundary contour about a point off the contour is the sum of
 the winding numbers of its four smooth pieces: the right vertical, the arc, the left
-vertical, and the truncation ceiling. -/
+vertical, and the truncation ceiling. This instantiates the finite-partition additivity
+`Contour.windingNumber_eq_sum_range` at the junction partition `0, 1, 3, 4, 5`. -/
 theorem windingNumber_fdBoundary_eq_sum_pieces
     (hw : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w) :
     windingNumber (fdBoundary H) 0 5 w =
       windingNumber (fdBoundary H) 0 1 w + windingNumber (fdBoundary H) 1 3 w +
         windingNumber (fdBoundary H) 3 4 w + windingNumber (fdBoundary H) 4 5 w := by
   have hpv := cauchyPVExistsAt_fdBoundary hw
-  rw [windingNumber_concat (hpv 0 4 (by norm_num) (by norm_num))
-      (hpv 4 5 (by norm_num) (by norm_num)),
-    windingNumber_concat (hpv 0 3 (by norm_num) (by norm_num))
-      (hpv 3 4 (by norm_num) (by norm_num)),
-    windingNumber_concat (hpv 0 1 (by norm_num) (by norm_num))
-      (hpv 1 3 (by norm_num) (by norm_num))]
+  have h := windingNumber_eq_sum_range (γ := fdBoundary H) (z₀ := w) (n := 4)
+    (t := fun k => match k with | 0 => 0 | 1 => 1 | 2 => 3 | 3 => 4 | _ => 5)
+    (fun k hk => by
+      match k, hk with
+      | 0, _ => exact hpv 0 1 ⟨le_rfl, by norm_num⟩ ⟨by norm_num, by norm_num⟩
+      | 1, _ => exact hpv 1 3 ⟨by norm_num, by norm_num⟩ ⟨by norm_num, by norm_num⟩
+      | 2, _ => exact hpv 3 4 ⟨by norm_num, by norm_num⟩ ⟨by norm_num, by norm_num⟩
+      | 3, _ => exact hpv 4 5 ⟨by norm_num, by norm_num⟩ ⟨by norm_num, by norm_num⟩
+      | n + 4, hk => exact absurd hk (Nat.not_lt.mpr (Nat.le_add_left 4 n)))
+  refine h.trans ?_
+  simp [Finset.sum_range_succ]
 
 end ModularForm
 


### PR DESCRIPTION
Adds `FundamentalDomainBoundary/Decomposition.lean`: for a point off the boundary contour of the truncated fundamental domain, the winding number over `[0, 5]` splits as the sum of the winding numbers of the four smooth pieces (right vertical, arc, left vertical, ceiling).

* `cauchyPVExistsAt_fdBoundary` — the single-point Cauchy principal value of the index integrand exists on every subinterval of the parameter interval for any off-contour point: avoidance kills the singularity and piecewise-`C¹` regularity gives integrability (`cauchyPVExistsAt_of_avoidance` + `IsPiecewiseC1On.intervalIntegrable_deriv`).
* `windingNumber_fdBoundary_eq_sum_pieces` — three applications of `windingNumber_concat` at the junctions `t = 4, 3, 1`.

This is the entry point for evaluating the interior winding number piece by piece (the `−1` computation feeding the valence formula's contour argument).

**Stacked on #1998** (uses the `FundamentalDomainBoundary/Basic.lean` location); the diff collapses to the single new file once #1998 merges.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence formula: boundary winding decomposition into pieces","id":"modular-valence-winding-decomp"}-->
