### PR TITLE
feat(ModularForms): the index of Γ₀(pᵏ) in SL₂(ℤ)

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -12,11 +12,13 @@ import Mathlib.Tactic.LinearCombination
 import TauCeti.Data.ZMod.Units
 
 /-!
-# Special linear groups: surjectivity of reduction, and the image of `-I`
+# Special linear groups: reduction surjectivity, `-I`, and `SL₂` inverse coordinates
 
 The natural reduction map `SL₂(ℤ) → SL₂(ℤ/dℤ)` is surjective (strong approximation for
-`SL₂`; Shimura §1.6, Serre Ch. VII), and the base-change map `SL(n, R) → GL(n, S)` sends
-`-I` to `-I`.
+`SL₂`; Shimura §1.6, Serre Ch. VII), the base-change map `SL(n, R) → GL(n, S)` sends
+`-I` to `-I`, and the four entries of an `SL₂` inverse are given by the explicit
+adjugate formulas `inv_apply_zero_zero` … `inv_apply_one_one` — exported with `@[simp]`
+so coordinate computations with congruence subgroups normalize automatically.
 
 The surjectivity is ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/HeckeRIngs/GLn/SL2Surjection.lean`, Chris Birkbeck). Prerequisite for the
@@ -27,6 +29,8 @@ diamond operators of the ModularForms roadmap (Layer 0), where it realizes every
 
 * `Matrix.SpecialLinearGroup.map_intCast_zmod_surjective`: strong approximation for `SL₂`.
 * `Matrix.SpecialLinearGroup.mapGL_neg_one`: `mapGL S (-1) = -1`.
+* `Matrix.SpecialLinearGroup.inv_apply_zero_zero` (and its three siblings): the
+  coordinates of an `SL₂` inverse, as `@[simp]` lemmas.
 
 ## References
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -53,30 +53,34 @@ lemma mapGL_neg_one {n R S : Type*} [Fintype n] [DecidableEq n] [CommRing R] [Co
 variable {R : Type*} [CommRing R]
 
 /-- The `(1,0)` coordinate of the inverse of an `SL₂` element, from `SL2_inv_expl`. -/
-private lemma inv_apply_one_zero (M : SpecialLinearGroup (Fin 2) R) :
+@[simp]
+lemma inv_apply_one_zero (M : SpecialLinearGroup (Fin 2) R) :
     (M⁻¹ : SpecialLinearGroup (Fin 2) R) 1 0 = -(M 1 0) := by
   rw [SL2_inv_expl]
   rfl
 
 /-- The `(1,1)` coordinate of the inverse of an `SL₂` element, from `SL2_inv_expl`. -/
-private lemma inv_apply_one_one (M : SpecialLinearGroup (Fin 2) R) :
+@[simp]
+lemma inv_apply_one_one (M : SpecialLinearGroup (Fin 2) R) :
     (M⁻¹ : SpecialLinearGroup (Fin 2) R) 1 1 = M 0 0 := by
   rw [SL2_inv_expl]
   rfl
 
 /-- The `(0,0)` coordinate of the inverse of an `SL₂` element, from `SL2_inv_expl`. -/
-private lemma inv_apply_zero_zero (M : SpecialLinearGroup (Fin 2) R) :
+@[simp]
+lemma inv_apply_zero_zero (M : SpecialLinearGroup (Fin 2) R) :
     (M⁻¹ : SpecialLinearGroup (Fin 2) R) 0 0 = M 1 1 := by
   rw [SL2_inv_expl]
   rfl
 
 /-- The `(0,1)` coordinate of the inverse of an `SL₂` element, from `SL2_inv_expl`. -/
-private lemma inv_apply_zero_one (M : SpecialLinearGroup (Fin 2) R) :
+@[simp]
+lemma inv_apply_zero_one (M : SpecialLinearGroup (Fin 2) R) :
     (M⁻¹ : SpecialLinearGroup (Fin 2) R) 0 1 = -(M 0 1) := by
   rw [SL2_inv_expl]
   rfl
 
-private lemma mul_apply_one_zero (M g : SpecialLinearGroup (Fin 2) R) :
+lemma mul_apply_one_zero (M g : SpecialLinearGroup (Fin 2) R) :
     (M * g) 1 0 = M 1 0 * g 0 0 + M 1 1 * g 1 0 := by
   simp [coe_mul, mul_apply, Fin.sum_univ_two]
 

--- a/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SpecialLinearGroup/Basic.lean
@@ -80,7 +80,7 @@ lemma inv_apply_zero_one (M : SpecialLinearGroup (Fin 2) R) :
   rw [SL2_inv_expl]
   rfl
 
-lemma mul_apply_one_zero (M g : SpecialLinearGroup (Fin 2) R) :
+private lemma mul_apply_one_zero (M g : SpecialLinearGroup (Fin 2) R) :
     (M * g) 1 0 = M 1 0 * g 0 0 + M 1 1 * g 1 0 := by
   simp [coe_mul, mul_apply, Fin.sum_univ_two]
 

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -184,13 +184,10 @@ private lemma TjS_inv_11 (j : ℤ) : ((T ^ j * S)⁻¹).1 1 1 = j := by
   rw [inv_apply_one_one, TjS_00]
 
 
-private lemma mul_apply_one_zero (M g : SL(2, ℤ)) :
-    (M * g) 1 0 = M 1 0 * g 0 0 + M 1 1 * g 1 0 := by
-  simp [Matrix.SpecialLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two]
-
 private lemma TjS_inv_mul_10 (j : ℤ) (σ : SL(2, ℤ)) :
     ((T ^ j * S)⁻¹ * σ).1 1 0 = j * σ.1 1 0 - σ.1 0 0 := by
-  rw [mul_apply_one_zero, TjS_inv_10, TjS_inv_11]
+  simp only [Matrix.SpecialLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two]
+  rw [TjS_inv_10, TjS_inv_11]
   ring
 
 private lemma rep_diff_10 (i j : ℤ) :
@@ -264,13 +261,15 @@ private lemma lowerTriRep_mem_Gamma0 (k : ℕ) (c : Fin p) :
 private lemma lowerTriRep_diff_entry (k : ℕ) (c₁ c₂ : Fin p) :
     ((lowerTriRep p k c₁)⁻¹ * lowerTriRep p k c₂).1 1 0 =
     ((c₂ : ℤ) - (c₁ : ℤ)) * (p : ℤ) ^ k := by
-  rw [mul_apply_one_zero, inv_apply_one_zero, inv_apply_one_one]
+  simp only [Matrix.SpecialLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two]
+  rw [inv_apply_one_zero, inv_apply_one_one]
   simp [lowerTriRep]
   ring
 
 private lemma lowerTriRep_inv_mul_10 (k : ℕ) (c : Fin p) (σ : SL(2, ℤ)) :
     ((lowerTriRep p k c)⁻¹ * σ).1 1 0 = σ.1 1 0 - (c : ℤ) * (p : ℤ) ^ k * σ.1 0 0 := by
-  rw [mul_apply_one_zero, inv_apply_one_zero, inv_apply_one_one]
+  simp only [Matrix.SpecialLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two]
+  rw [inv_apply_one_zero, inv_apply_one_one]
   simp [lowerTriRep]
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -183,6 +183,11 @@ private lemma TjS_inv_10 (j : ℤ) : ((T ^ j * S)⁻¹).1 1 0 = -1 := by
 private lemma TjS_inv_11 (j : ℤ) : ((T ^ j * S)⁻¹).1 1 1 = j := by
   rw [inv_apply_one_one, TjS_00]
 
+
+private lemma mul_apply_one_zero (M g : SL(2, ℤ)) :
+    (M * g) 1 0 = M 1 0 * g 0 0 + M 1 1 * g 1 0 := by
+  simp [Matrix.SpecialLinearGroup.coe_mul, Matrix.mul_apply, Fin.sum_univ_two]
+
 private lemma TjS_inv_mul_10 (j : ℤ) (σ : SL(2, ℤ)) :
     ((T ^ j * S)⁻¹ * σ).1 1 0 = j * σ.1 1 0 - σ.1 0 0 := by
   rw [mul_apply_one_zero, TjS_inv_10, TjS_inv_11]
@@ -272,9 +277,6 @@ private lemma lowerTriRep_inv_mul_10 (k : ℕ) (c : Fin p) (σ : SL(2, ℤ)) :
 private def relindexRep (k : ℕ) (c : Fin p) : ↥(Gamma0 (p ^ k)) :=
   ⟨lowerTriRep p k c, lowerTriRep_mem_Gamma0 p k c⟩
 
-private lemma relindexRep_coe (k : ℕ) (c : Fin p) :
-    (relindexRep p k c : SL(2, ℤ)) = lowerTriRep p k c := (rfl)
-
 variable (hp : 0 < p)
 include hp
 
@@ -284,7 +286,7 @@ private lemma Gamma0_relindex_step_inj (k : ℕ) :
         ↥(Gamma0 (p ^ k)) ⧸ (Gamma0 (p ^ (k + 1))).subgroupOf (Gamma0 (p ^ k)))) := by
   intro ⟨c₁, hc₁⟩ ⟨c₂, hc₂⟩ hf
   rw [QuotientGroup.eq, Subgroup.mem_subgroupOf, Gamma0_mem] at hf
-  simp only [InvMemClass.coe_inv, MulMemClass.coe_mul, relindexRep_coe] at hf
+  simp only [relindexRep, InvMemClass.coe_inv, MulMemClass.coe_mul] at hf
   rw [lowerTriRep_diff_entry p, ZMod.intCast_zmod_eq_zero_iff_dvd, Nat.cast_pow, pow_succ,
     mul_comm ((↑c₂ : ℤ) - ↑c₁) ((p : ℤ) ^ k),
     mul_dvd_mul_iff_left (pow_ne_zero k (Int.natCast_ne_zero.mpr hp.ne'))] at hf
@@ -314,7 +316,7 @@ private lemma Gamma0_relindex_step_surj (k : ℕ) (hk : 0 < k) :
   obtain ⟨c₀, hc₀⟩ := exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
   refine ⟨⟨c₀.val, ZMod.val_lt c₀⟩, ?_⟩
   rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
-  simp only [InvMemClass.coe_inv, MulMemClass.coe_mul, relindexRep_coe]
+  simp only [relindexRep, InvMemClass.coe_inv, MulMemClass.coe_mul]
   rw [Gamma0_mem, lowerTriRep_inv_mul_10, hq, ZMod.intCast_zmod_eq_zero_iff_dvd, pow_succ]
   push_cast
   calc (p : ℤ) ^ k * (p : ℤ)

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -5,21 +5,27 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.GroupTheory.Index
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
 
+import Mathlib.Algebra.Field.ZMod
+
 /-!
-# Congruence subgroup infrastructure for `Γ₁(N) ⊴ Γ₀(N)`
+# Congruence subgroup infrastructure: the pair `Γ₁(N) ⊴ Γ₀(N)` and the index of `Γ₀(pᵏ)`
 
 Foundational results about the pair `Γ₁(N) ≤ Γ₀(N)` beyond Mathlib's
 `Mathlib.NumberTheory.ModularForms.CongruenceSubgroups`: `Γ₀(N)` normalizes `Γ₁(N)` (also
 after mapping to `GL₂(ℝ)`), the ratio of two `Γ₀(N)`-elements with equal lower-right entry
 lies in `Γ₁(N)`, the lower-right-entry map `Γ₀(N) →* (ZMod N)ˣ` is surjective, and the
 location of `-I`: it always lies in `Γ₀(N)`, with lower-right entry the unit `-1`, and it
-lies in `Γ₁(N)` exactly when `N ∣ 2`.
+lies in `Γ₁(N)` exactly when `N ∣ 2`.  The file then computes the index of `Γ₀` at
+prime-power levels — the degree count of Shimura, Theorem 3.24 — which lives here because it
+is congruence-subgroup arithmetic consumed by, but independent of, the Hecke-ring layer.
 
 Ported from the AINTLIB `LeanModularForms` project
-(`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`, Chris Birkbeck,
+(`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean` and, for the index section,
+`LeanModularForms/HeckeRIngs/GL2/CongruenceIndex.lean`, Chris Birkbeck,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), extracted from
 `TauCeti/NumberTheory/ModularForms/DiamondOperators.lean` as congruence-subgroup
 infrastructure independent of the diamond operators.
@@ -34,6 +40,11 @@ infrastructure independent of the diamond operators.
 * `CongruenceSubgroup.neg_one_mem_Gamma0` and
   `CongruenceSubgroup.Gamma0Map_toHomUnits_negOne`: `-I ∈ Γ₀(N)`, with lower-right entry the
   unit `-1`; `CongruenceSubgroup.neg_one_mem_Gamma1_iff`: `-I ∈ Γ₁(N) ↔ N ∣ 2`.
+* `CongruenceSubgroup.Gamma0_prime_index`: `[SL₂(ℤ) : Γ₀(p)] = p + 1` for prime `p`.
+* `CongruenceSubgroup.Gamma0_relIndex_pow_succ`: `[Γ₀(pᵏ) : Γ₀(p^(k+1))] = p` for `0 < p`
+  and `0 < k`.
+* `CongruenceSubgroup.Gamma0_prime_power_index`: `[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1) * (p + 1)` for
+  prime `p` and `k ≥ 1`.
 -/
 
 public section
@@ -136,5 +147,199 @@ theorem neg_one_mem_Gamma1_iff : (-1 : SL(2, ℤ)) ∈ Gamma1 N ↔ N ∣ 2 := b
     rw [neg_eq_iff_add_eq_zero, ← ZMod.natCast_eq_zero_iff 2 N]
     norm_num
   simp [Gamma1_mem, h]
+
+/-! ## The index of `Γ₀(pᵏ)`
+
+The coset representatives of `Γ₀(p)` in `SL₂(ℤ)` are `TʲS` for `0 ≤ j < p` together with the
+identity, giving `[SL₂(ℤ) : Γ₀(p)] = p + 1`; the relative index of `Γ₀(p^(k+1))` in `Γ₀(pᵏ)`
+is `p` via lower-unitriangular representatives, and the tower multiplies to
+`[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1)(p + 1)` for prime `p` and `k ≥ 1` — the degree count of
+Shimura, Theorem 3.24. -/
+
+private lemma exists_dvd_sub_val_mul (p : ℕ) [NeZero p] (a b : ℤ)
+    (hb : IsUnit ((b : ℤ) : ZMod p)) : ∃ j : ZMod p, (p : ℤ) ∣ a - (j.val : ℤ) * b := by
+  obtain ⟨u, hu⟩ := hb
+  refine ⟨(a : ZMod p) * ↑u⁻¹, ?_⟩
+  rw [← ZMod.intCast_zmod_eq_zero_iff_dvd]
+  push_cast
+  rw [ZMod.natCast_zmod_val, mul_assoc]
+  -- the coerced product collapses: `↑b = ↑u` by `hu`, and `u⁻¹ * u = 1` in the units
+  have hunit : (↑u⁻¹ * ((b : ℤ) : ZMod p) : ZMod p) = 1 := by rw [← hu, Units.inv_mul]
+  rw [hunit, mul_one, sub_self]
+
+section BaseCase
+
+open ModularGroup
+
+private lemma TjS_00 (j : ℤ) : (T ^ j * S).1 0 0 = j := by
+  simp [coe_T_zpow, coe_S]
+
+private lemma TjS_10 (j : ℤ) : (T ^ j * S).1 1 0 = 1 := by
+  simp [coe_S]
+
+private lemma TjS_inv_10 (j : ℤ) : ((T ^ j * S)⁻¹).1 1 0 = -1 := by
+  rw [inv_apply_one_zero, TjS_10]
+
+private lemma TjS_inv_11 (j : ℤ) : ((T ^ j * S)⁻¹).1 1 1 = j := by
+  rw [inv_apply_one_one, TjS_00]
+
+private lemma TjS_inv_mul_10 (j : ℤ) (σ : SL(2, ℤ)) :
+    ((T ^ j * S)⁻¹ * σ).1 1 0 = j * σ.1 1 0 - σ.1 0 0 := by
+  rw [mul_apply_one_zero, TjS_inv_10, TjS_inv_11]
+  ring
+
+private lemma rep_diff_10 (i j : ℤ) :
+    ((T ^ j * S)⁻¹ * (T ^ i * S)).1 1 0 = j - i := by
+  rw [TjS_inv_mul_10, TjS_10, TjS_00]
+  ring
+
+variable (p : ℕ) (hp : Nat.Prime p)
+include hp
+
+private def Gamma0Rep (j : Fin (p + 1)) : SL(2, ℤ) :=
+  if j.val < p then T ^ (j.val : ℤ) * S else 1
+
+private lemma Gamma0_prime_index_inj :
+    Function.Injective (fun j : Fin (p + 1) ↦ QuotientGroup.mk (Gamma0Rep p j) :
+      Fin (p + 1) → SL(2, ℤ) ⧸ (Gamma0 p)) := by
+  have : Fact (Nat.Prime p) := ⟨hp⟩
+  intro ⟨j₁, hj₁⟩ ⟨j₂, hj₂⟩ hf
+  rw [QuotientGroup.eq, Gamma0_mem] at hf
+  simp only [Gamma0Rep] at hf
+  split_ifs at hf with h1 h2
+  · rw [rep_diff_10, ZMod.intCast_zmod_eq_zero_iff_dvd] at hf
+    have := Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hf (by omega)
+    exact Fin.mk_eq_mk.mpr (by omega)
+  · rw [mul_one, TjS_inv_10] at hf
+    exact absurd hf (by norm_num)
+  · rw [inv_one, one_mul, TjS_10] at hf
+    exact absurd hf (by norm_num)
+  · exact Fin.mk_eq_mk.mpr (by omega)
+
+private lemma Gamma0_prime_index_surj :
+    Function.Surjective (fun j : Fin (p + 1) ↦ QuotientGroup.mk (Gamma0Rep p j) :
+      Fin (p + 1) → SL(2, ℤ) ⧸ (Gamma0 p)) := by
+  have : Fact (Nat.Prime p) := ⟨hp⟩
+  intro x
+  obtain ⟨σ, rfl⟩ := QuotientGroup.mk_surjective x
+  by_cases h : ((σ.1 1 0 : ℤ) : ZMod p) = 0
+  · refine ⟨⟨p, p.lt_succ_self⟩, ?_⟩
+    rw [QuotientGroup.eq, Gamma0_mem]
+    simpa [Gamma0Rep] using h
+  · have hunit : IsUnit ((σ.1 1 0 : ℤ) : ZMod p) := by
+      have : Fact (Nat.Prime p) := ⟨hp⟩
+      obtain ⟨j, hj⟩ : ∃ j : ZMod p, j * ((σ.1 1 0 : ℤ) : ZMod p) = 1 :=
+        Finite.surjective_of_injective (mul_left_injective₀ h) 1
+      exact IsUnit.of_mul_eq_one _ (by rwa [mul_comm] at hj)
+    obtain ⟨j₀, hj₀⟩ := exists_dvd_sub_val_mul p (σ.1 0 0) (σ.1 1 0) hunit
+    refine ⟨⟨j₀.val, Nat.lt_succ_of_lt (ZMod.val_lt j₀)⟩, ?_⟩
+    rw [QuotientGroup.eq, Gamma0_mem]
+    simp only [Gamma0Rep, ZMod.val_lt j₀, ite_true]
+    rwa [TjS_inv_mul_10, ZMod.intCast_zmod_eq_zero_iff_dvd, dvd_sub_comm]
+
+/-- `[SL₂(ℤ) : Γ₀(p)] = p + 1` for prime `p`. -/
+theorem Gamma0_prime_index : (Gamma0 p).index = p + 1 :=
+  Nat.card_eq_of_equiv_fin (Equiv.ofBijective _
+    ⟨Gamma0_prime_index_inj p hp, Gamma0_prime_index_surj p hp⟩).symm
+
+end BaseCase
+
+section InductiveStep
+
+variable (p : ℕ)
+
+private def lowerTriRep (k : ℕ) (c : Fin p) : SL(2, ℤ) :=
+  ⟨!![1, 0; (c : ℤ) * (p : ℤ) ^ k, 1], by simp [det_fin_two_of]⟩
+
+private lemma lowerTriRep_mem_Gamma0 (k : ℕ) (c : Fin p) :
+    lowerTriRep p k c ∈ Gamma0 (p ^ k) := by
+  rw [Gamma0_mem]
+  simp [lowerTriRep, ← Nat.cast_pow, -Int.natCast_pow]
+
+private lemma lowerTriRep_diff_entry (k : ℕ) (c₁ c₂ : Fin p) :
+    ((lowerTriRep p k c₁)⁻¹ * lowerTriRep p k c₂).1 1 0 =
+    ((c₂ : ℤ) - (c₁ : ℤ)) * (p : ℤ) ^ k := by
+  rw [mul_apply_one_zero, inv_apply_one_zero, inv_apply_one_one]
+  simp [lowerTriRep]
+  ring
+
+private lemma lowerTriRep_inv_mul_10 (k : ℕ) (c : Fin p) (σ : SL(2, ℤ)) :
+    ((lowerTriRep p k c)⁻¹ * σ).1 1 0 = σ.1 1 0 - (c : ℤ) * (p : ℤ) ^ k * σ.1 0 0 := by
+  rw [mul_apply_one_zero, inv_apply_one_zero, inv_apply_one_one]
+  simp [lowerTriRep]
+  ring
+
+private def relindexRep (k : ℕ) (c : Fin p) : ↥(Gamma0 (p ^ k)) :=
+  ⟨lowerTriRep p k c, lowerTriRep_mem_Gamma0 p k c⟩
+
+private lemma relindexRep_coe (k : ℕ) (c : Fin p) :
+    (relindexRep p k c : SL(2, ℤ)) = lowerTriRep p k c := (rfl)
+
+variable (hp : 0 < p)
+include hp
+
+private lemma Gamma0_relindex_step_inj (k : ℕ) :
+    Function.Injective (fun c : Fin p ↦
+      (QuotientGroup.mk (relindexRep p k c) :
+        ↥(Gamma0 (p ^ k)) ⧸ (Gamma0 (p ^ (k + 1))).subgroupOf (Gamma0 (p ^ k)))) := by
+  intro ⟨c₁, hc₁⟩ ⟨c₂, hc₂⟩ hf
+  rw [QuotientGroup.eq, Subgroup.mem_subgroupOf, Gamma0_mem] at hf
+  simp only [InvMemClass.coe_inv, MulMemClass.coe_mul, relindexRep_coe] at hf
+  rw [lowerTriRep_diff_entry p, ZMod.intCast_zmod_eq_zero_iff_dvd, Nat.cast_pow, pow_succ,
+    mul_comm ((↑c₂ : ℤ) - ↑c₁) ((p : ℤ) ^ k),
+    mul_dvd_mul_iff_left (pow_ne_zero k (Int.natCast_ne_zero.mpr hp.ne'))] at hf
+  have := Int.eq_zero_of_dvd_of_natAbs_lt_natAbs hf (by omega)
+  exact Fin.mk_eq_mk.mpr (by omega)
+
+private lemma Gamma0_relindex_step_surj (k : ℕ) (hk : 0 < k) :
+    Function.Surjective (fun c : Fin p ↦
+      (QuotientGroup.mk (relindexRep p k c) :
+        ↥(Gamma0 (p ^ k)) ⧸ (Gamma0 (p ^ (k + 1))).subgroupOf (Gamma0 (p ^ k)))) := by
+  have : NeZero p := ⟨hp.ne'⟩
+  intro x
+  obtain ⟨⟨σ, hσ_K⟩, rfl⟩ := QuotientGroup.mk_surjective x
+  obtain ⟨q, hq⟩ : (↑(p ^ k) : ℤ) ∣ σ.1 1 0 := by
+    rwa [← ZMod.intCast_zmod_eq_zero_iff_dvd, ← Gamma0_mem]
+  push_cast at hq
+  have h00_unit : IsUnit ((σ.1 0 0 : ℤ) : ZMod p) := by
+    have h10 : ((σ.1 1 0 : ℤ) : ZMod p) = 0 := by
+      rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
+      exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q
+    have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
+      Matrix.det_fin_two σ.1 ▸ σ.2
+    have hcast := congrArg (fun z : ℤ ↦ (z : ZMod p)) hdet
+    push_cast at hcast
+    rw [h10, mul_zero, sub_zero] at hcast
+    exact IsUnit.of_mul_eq_one _ hcast
+  obtain ⟨c₀, hc₀⟩ := exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
+  refine ⟨⟨c₀.val, ZMod.val_lt c₀⟩, ?_⟩
+  rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]
+  simp only [InvMemClass.coe_inv, MulMemClass.coe_mul, relindexRep_coe]
+  rw [Gamma0_mem, lowerTriRep_inv_mul_10, hq, ZMod.intCast_zmod_eq_zero_iff_dvd, pow_succ]
+  push_cast
+  calc (p : ℤ) ^ k * (p : ℤ)
+      ∣ (p : ℤ) ^ k * (q - ↑c₀.val * σ.1 0 0) := mul_dvd_mul_left _ hc₀
+    _ = (p : ℤ) ^ k * q - ↑c₀.val * (p : ℤ) ^ k * σ.1 0 0 := by ring
+
+/-- `[Γ₀(pᵏ) : Γ₀(p^(k+1))] = p` for any positive base `p` and `k ≥ 1`. -/
+theorem Gamma0_relIndex_pow_succ (k : ℕ) (hk : 0 < k) :
+    (Gamma0 (p ^ (k + 1))).relIndex (Gamma0 (p ^ k)) = p :=
+  Nat.card_eq_of_equiv_fin (Equiv.ofBijective _
+    ⟨Gamma0_relindex_step_inj p hp k, Gamma0_relindex_step_surj p hp k hk⟩).symm
+
+end InductiveStep
+
+/-- `[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1) * (p + 1)` for prime `p` and `k ≥ 1`. -/
+theorem Gamma0_prime_power_index (p : ℕ) (hp : Nat.Prime p) (k : ℕ) (hk : 0 < k) :
+    (Gamma0 (p ^ k)).index = p ^ (k - 1) * (p + 1) := by
+  induction k, hk using Nat.le_induction with
+  | base => simpa using Gamma0_prime_index p hp
+  | succ m hm ih =>
+    have h_le : Gamma0 (p ^ (m + 1)) ≤ Gamma0 (p ^ m) := fun σ hσ ↦ by
+      rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at hσ ⊢
+      exact (Int.natCast_dvd_natCast.mpr (pow_dvd_pow p m.le_succ)).trans hσ
+    rw [Nat.add_sub_cancel, ← Subgroup.relIndex_mul_index h_le,
+      Gamma0_relIndex_pow_succ p hp.pos m hm, ih, ← mul_assoc, ← pow_succ',
+      Nat.sub_add_cancel hm]
 
 end CongruenceSubgroup


### PR DESCRIPTION
Extends `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean` with the index computation for prime-power levels:

- `CongruenceSubgroup.Gamma0_prime_index`: `[SL₂(ℤ) : Γ₀(p)] = p + 1`, via the coset representatives `TʲS` (`0 ≤ j < p`) and the identity.
- `CongruenceSubgroup.Gamma0_relindex_step`: `[Γ₀(pᵏ) : Γ₀(p^(k+1))] = p` for `k ≥ 1`, via lower-unitriangular representatives.
- `CongruenceSubgroup.Gamma0_prime_power_index`: `[SL₂(ℤ) : Γ₀(pᵏ)] = p^(k-1)(p + 1)` for `k ≥ 1`, multiplying the tower.

Neither Mathlib nor TauCeti has any Γ₀ index formula (Mathlib's congruence-subgroup file has only the commensurability relIndex machinery). This is the degree count of Shimura, Theorem 3.24, consumed by the `GL₂` Hecke-operator degree formulas next in the Layer-2 chain.

Ported from AINTLIB `LeanModularForms/HeckeRIngs/GL2/CongruenceIndex.lean` into the existing congruence-subgroup infrastructure file (same topic, no new file). The coprime-solvability step is reformulated inverse-free (cancellation plus finiteness of `ZMod p`) since the ZMod field-inverse route no longer unifies smoothly under the module system.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5