### PR TITLE
feat(HeckeRing): the module of left cosets and its faithful right Hecke action

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -138,6 +138,12 @@ end DoubleCoset
 
 namespace IsHeckeTriple
 
+/-- Every member of the double coset `H₁gH₂` of an element of `Δ` lies in `Δ`. -/
+theorem mem_of_mem_doubleCoset {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
+    {g x : G} (hg : g ∈ Δ) (hx : x ∈ doubleCoset g (H₁ : Set G) H₂) : x ∈ Δ := by
+  obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := mem_doubleCoset.mp hx
+  exact mul_mem (mul_mem (mem_of_mem_left H₂ hh₁) hg) (mem_of_mem_right H₁ hh₂)
+
 /-- For a Hecke triple, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
 noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -134,6 +134,16 @@ lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
       ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
   simpa [mul_assoc] using hij
 
+open scoped Pointwise in
+/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
+element of the stabilizer conjugates into `H` under `g`. -/
+lemma conj_mem_of_stabilizer {H : Subgroup G} (g : G)
+    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
+  have hn := n.2
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def] at hn
+  simpa [ConjAct.ofConjAct_toConjAct] using hn
+
 end DoubleCoset
 
 namespace IsHeckeTriple
@@ -183,25 +193,18 @@ end SingleWrapper
 
 section SingleAlgebra
 
-variable (R : Type*) [Semiring R]
-
-/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
-module structure to the wrapper type. -/
-noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
-  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
-
-lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
-  Finsupp.smul_single_one D b
-
-@[simp]
-lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
-  Finsupp.sum_single f
+variable (R : Type*) [AddCommMonoid R]
 
 /-- `Finsupp.single_zero`, as a wrapper-level equation. -/
 @[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
   Finsupp.single_zero D
 
+@[simp]
+lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
+  Finsupp.sum_single f
+
 /-- `Finsupp.single_add`, as a wrapper-level equation. -/
+@[simp]
 lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
     single R D (b + c) = single R D b + single R D c :=
   Finsupp.single_add D b c
@@ -217,5 +220,20 @@ lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
   Finsupp.induction_linear f h0 hadd hsingle
 
 end SingleAlgebra
+
+section SingleModule
+
+variable (R : Type*) [Semiring R]
+
+/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
+module structure to the wrapper type. -/
+noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
+  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
+
+@[simp]
+lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
+  Finsupp.smul_single_one D b
+
+end SingleModule
 
 end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -5,6 +5,8 @@ Authors: Chris Birkbeck
 -/
 module
 
+public import Mathlib.Algebra.BigOperators.Finsupp.Basic
+public import Mathlib.Data.Finsupp.SMul
 public import Mathlib.NumberTheory.HeckeRing.Defs
 public import Mathlib.GroupTheory.Index
 
@@ -15,7 +17,11 @@ Basic API for the double cosets `HeckeCoset` indexing a Hecke coset module, foll
 [Shimura][shimura1971], Chapter 3. This file provides representatives of double cosets, the
 characterisation of when two elements give the same double coset, and the quotient
 `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets inside a double coset `Γ₁gΓ₂`, which is used to
-define the Hecke product in later files and is finite for a Hecke triple.
+define the Hecke product in later files and is finite for a Hecke triple. It also houses
+the basis-element API of the coset module: `HeckeCosetModule.single` with its evaluation,
+summation, and additivity laws, the `induction_linear` principle, and the transported
+`Module` instance — placed at this layer so every later file (convolution, one, and the
+coset actions) can build on one shared vocabulary.
 
 Vendored from the in-review mathlib4 PR
 [#41253](https://github.com/leanprover-community/mathlib4/pull/41253) (Chris Birkbeck), per the
@@ -28,6 +34,9 @@ stack merges.
 * `HeckeCoset.rep`: a chosen representative in `Δ`.
 * `DoubleCoset.DecompQuotient`: the quotient `Γ₁ ⧸ (Γ₁ ∩ gΓ₂g⁻¹)` indexing the left cosets
   in `Γ₁gΓ₂`; finite for a Hecke triple.
+* `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
+  `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
+  and the `Module R` instance `HeckeCosetModule.instModule`.
 
 ## Main results
 
@@ -114,15 +123,20 @@ abbrev DecompQuotient (Γ₁ Γ₂ : Subgroup G) (g : G) :=
 instance (Γ₁ Γ₂ : Subgroup G) (g : G) : Nonempty (DecompQuotient Γ₁ Γ₂ g) :=
   ⟨QuotientGroup.mk 1⟩
 
+/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
+`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
+lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
+    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
+  intro i j hij
+  simp only [QuotientGroup.eq] at hij
+  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
+    Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
+      ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
+  simpa [mul_assoc] using hij
+
 end DoubleCoset
 
 namespace IsHeckeTriple
-
-/-- Every member of the double coset `H₁gH₂` of an element of `Δ` lies in `Δ`. -/
-theorem mem_of_mem_doubleCoset {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTriple Δ H₁ H₂]
-    {g x : G} (hg : g ∈ Δ) (hx : x ∈ doubleCoset g (H₁ : Set G) H₂) : x ∈ Δ := by
-  obtain ⟨h₁, hh₁, h₂, hh₂, rfl⟩ := mem_doubleCoset.mp hx
-  exact mul_mem (mul_mem (mem_of_mem_left H₂ hh₁) hg) (mem_of_mem_right H₁ hh₂)
 
 /-- For a Hecke triple, the decomposition quotient of any `g : Δ` is finite: `Δ`
 commensurates `H₂`, which is commensurable with `H₁`. -/
@@ -131,3 +145,71 @@ noncomputable instance {Δ : Submonoid G} {H₁ H₂ : Subgroup G} [IsHeckeTripl
   Subgroup.fintypeOfIndexNeZero (IsHeckeTriple.commensurable_conjAct_right g).1
 
 end IsHeckeTriple
+
+namespace HeckeCosetModule
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ : Subgroup G}
+
+section SingleWrapper
+
+variable (R : Type*) [Zero R]
+
+/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
+for `Finsupp` itself, this is the type-correct way to produce elements of
+`HeckeCosetModule Δ H₁ H₂ R`. Only `[Zero R]` is assumed, so consumers with coefficient
+assumptions below `Semiring` (the left-coset scalar operations) can use it. -/
+noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
+    HeckeCosetModule Δ H₁ H₂ R :=
+  Finsupp.single D b
+
+/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
+evaluates the summand at its point. -/
+lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
+    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
+  Finsupp.sum_single_index h
+
+@[simp, grind =]
+lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
+    single R D b A = if D = A then b else 0 :=
+  Finsupp.single_apply
+
+end SingleWrapper
+
+section SingleAlgebra
+
+variable (R : Type*) [Semiring R]
+
+/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
+module structure to the wrapper type. -/
+noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
+  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
+
+lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
+  Finsupp.smul_single_one D b
+
+@[simp]
+lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
+  Finsupp.sum_single f
+
+/-- `Finsupp.single_zero`, as a wrapper-level equation. -/
+@[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
+  Finsupp.single_zero D
+
+/-- `Finsupp.single_add`, as a wrapper-level equation. -/
+lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
+    single R D (b + c) = single R D b + single R D c :=
+  Finsupp.single_add D b c
+
+/-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` in
+its basis vocabulary `single`, in the same way that `MonoidAlgebra.induction_linear` restates
+it for `MonoidAlgebra`: to prove a property of all elements, prove it for `0`, for sums, and
+for basis elements. -/
+lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
+    (f : HeckeCosetModule Δ H₁ H₂ R) (h0 : p 0)
+    (hadd : ∀ f g : HeckeCosetModule Δ H₁ H₂ R, p f → p g → p (f + g))
+    (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
+  Finsupp.induction_linear f h0 hadd hsingle
+
+end SingleAlgebra
+
+end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -184,6 +184,7 @@ lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H�
     {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
   Finsupp.sum_single_index h
 
+/-- Evaluating a basis element: `single R D b` is `b` at `D` and `0` elsewhere. -/
 @[simp, grind =]
 lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
     single R D b A = if D = A then b else 0 :=
@@ -199,6 +200,7 @@ variable (R : Type*) [AddCommMonoid R]
 @[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
   Finsupp.single_zero D
 
+/-- Every element is the sum of its basis components. -/
 @[simp]
 lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f :=
   Finsupp.sum_single f
@@ -230,6 +232,7 @@ module structure to the wrapper type. -/
 noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
   inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
 
+/-- Scaling the unit basis element produces the basis element of the scalar. -/
 @[simp]
 lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
   Finsupp.smul_single_one D b

--- a/TauCeti/NumberTheory/HeckeRing/Commutativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Commutativity.lean
@@ -187,15 +187,6 @@ private lemma exists_bar_eq [IsHeckeTriple Δ H H]
   rw [doubleCoset_eq_of_mem (ι.bar_mem_doubleCoset_self h_fix g)] at hbar
   exact mem_doubleCoset.mp hbar
 
-/-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
-element `n` of the stabilizer conjugates into `H` under `g`. -/
-private lemma conj_mem_of_stabilizer (g : G)
-    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
-  have hn := n.2
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def] at hn
-  simpa [ConjAct.ofConjAct_toConjAct] using hn
-
 /-- Equality of classes in `DecompQuotient H H g` yields the conjugation relation of their
 representatives. -/
 private lemma conj_mem_of_mk_eq (g : G) {u₁ u₂ : H}

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -120,16 +120,6 @@ lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
   classical
   exact (Finset.univ_nonempty).image _
 
--- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
--- element of the stabilizer conjugates into `H` under `g`. Used by every orbit argument
--- that replaces a decomposition representative by its canonical `out`.
-private lemma conj_mem_of_stabilizer (g : G)
-    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
-  have hn := n.2
-  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
-    ConjAct.smul_def] at hn
-  simpa [ConjAct.ofConjAct_toConjAct] using hn
-
 private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
     (hβ : (β₂ : G) = (β₁ : G) * k) : smulOrbit H g β₁ ⊆ smulOrbit H g β₂ := by
   classical
@@ -266,7 +256,7 @@ end HeckeCoset
 /-- The left-coset module: the free `R`-module on the left cosets `Δ/H` (the bottom-left
 Hecke cosets), the carrier of the natural representation of the Hecke ring. An `abbrev`
 of the underlying `Finsupp`, so the full `Finsupp` API applies transparently at every
-coefficient class — the stable named interface for the action below. -/
+coefficient class — the stable named interface for the scalar operations below. -/
 abbrev LeftCosetModule (Δ : Submonoid G) (H : Subgroup G) (R : Type*) [Zero R] :=
   HeckeCoset Δ ⊥ H →₀ R
 
@@ -290,19 +280,14 @@ noncomputable instance instSMulLeftCosetModule :
   smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
     ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁)
 
--- the defining formula for an opaque opposite-ring element; instance plumbing
-private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
-    t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
-  (rfl)
-
-/-- The defining formula of the action. -/
+/-- The defining formula of the scalar multiplication. -/
 lemma smul_eq_sum (t : 𝕋 Δ H R) (m : LeftCosetModule Δ H R) :
     MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
       ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
   (rfl)
 
-/-- The action of a basis element of the Hecke ring on a basis element of the module. -/
+/-- A basis element of the Hecke ring scales a basis element of the module into its
+orbit sum. -/
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
     MulOpposite.op (HeckeCosetModule.single R D a) •
         Finsupp.single q b =
@@ -312,12 +297,13 @@ lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b 
     HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
     Finsupp.sum_single_index (by simp)]
 
-/-- The action is additive in the (opposite) Hecke-ring argument. -/
+/-- The scalar multiplication is additive in the (opposite) Hecke-ring argument. -/
 @[simp]
 lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
     (t₁ + t₂) • m = t₁ • m + t₂ • m := by
   classical
-  simp only [smul_def, MulOpposite.unop_add]
+  rw [← MulOpposite.op_unop t₁, ← MulOpposite.op_unop t₂, ← MulOpposite.op_add,
+    smul_eq_sum, smul_eq_sum, smul_eq_sum]
   refine Finsupp.sum_add_index' (fun D ↦ ?_) fun D b₁ b₂ ↦ ?_
   · refine (Finsupp.sum_congr (g2 := fun _ _ ↦ 0) fun q _ ↦ ?_).trans
       (Finsupp.sum_fun_zero m)
@@ -334,12 +320,12 @@ ad-hoc laws. -/
 noncomputable instance distribSMul :
     DistribSMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul_zero t := by
-    rw [smul_def]
+    rw [← MulOpposite.op_unop t, smul_eq_sum]
     simp only [Finsupp.sum_zero_index]
     exact Finsupp.sum_fun_zero t.unop
   smul_add t m₁ m₂ := by
     classical
-    simp only [smul_def]
+    rw [← MulOpposite.op_unop t, smul_eq_sum, smul_eq_sum, smul_eq_sum]
     refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
     refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
     · exact Finset.sum_eq_zero fun i _ ↦ by simp
@@ -352,8 +338,7 @@ noncomputable instance smulWithZero :
     SMulWithZero (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul_zero := smul_zero
   zero_smul m := by
-    rw [smul_def]
-    simp only [MulOpposite.unop_zero]
+    rw [← MulOpposite.op_zero, smul_eq_sum]
     exact Finsupp.sum_zero_index
 
 end LeftCosetModule
@@ -366,8 +351,8 @@ open scoped HeckeCosetModule
 
 variable [IsHeckeTriple Δ H H] {R : Type*} [NonAssocSemiring R]
 
-/-- Reading off a coefficient of the action on the identity basis element: at any member of
-the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/
+/-- Reading off a coefficient of the scalar multiple of the identity basis element: at any
+member of the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/
 private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
     {q : HeckeCoset Δ ⊥ H}
     (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -68,6 +68,7 @@ variable (Δ) in
 /-- The identity left coset `1H = H` in the bottom-left specialization. -/
 instance instOneBot : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
 
+@[simp]
 lemma one_bot_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
 
 /-- In the bottom-left specialization two elements define the same class iff they differ by

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -1,0 +1,430 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Basic
+import Mathlib.Tactic.Group
+
+/-!
+# Hecke rings: the module of left cosets
+
+The scalar operations underlying the natural representation of the Hecke ring, following
+[Shimura][shimura1971], §3.1: on the free module `LeftCosetModule Δ H R` over the left
+cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a double coset
+`HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
+left-coset presentation, the orbit Finsets, and the scalar multiplication, and proves it is
+additive in both arguments and faithful. Since `HgH` sends `βH` to `Σᵢ βσᵢgH` by right
+multiplication, this is a **right** action, encoded as a left action of the opposite ring
+`(𝕋 Δ H R)ᵐᵒᵖ` per Mathlib convention: Shimura's compatibility law
+`(f * g) • m = g • (f • m)` (Proposition 3.2) is exactly `mul_smul` for the opposite ring,
+and is established together with the degree homomorphism in the follow-up development.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`HeckeRIngs/AbstractHeckeRing/Module.lean`,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), per the
+ModularForms roadmap's dependency policy, rebuilt on the left-coset quotient of the vendored
+Mathlib stack.
+
+## Main definitions
+
+* `HeckeCoset.mk_bot_eq_mk_bot`: the left cosets of `H` with a representative in `Δ` are
+  the bottom-left double cosets `HeckeCoset Δ ⊥ H` (`⊥βH = βH`); this characterization makes
+  the existing double-coset quotient serve as the left-coset quotient, with no new type.
+* `HeckeCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
+  double coset representative.
+* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R)` instance — the right Hecke action in
+  its opposite-ring encoding.
+
+## Main results
+
+* `HeckeCoset.smulOrbit_congr`, `HeckeCoset.smulOrbit_disjoint`: the orbit depends
+  only on the left coset, and orbits of distinct double cosets are disjoint.
+* `LeftCosetModule.instFaithfulSMul`: the action of the (opposite) Hecke ring on the
+  module of left cosets is faithful.
+-/
+
+public section
+
+open DoubleCoset Subgroup
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G}
+
+/-!
+The left cosets `βH` of `Δ`-elements are the bottom-left specialization `HeckeCoset Δ ⊥ H`
+of the double cosets: `⊥βH = βH`. The type, constructor `HeckeCoset.mk ⊥ H`,
+representative `HeckeCoset.rep`, and induction principle are all reused from the
+double-coset API (they are built from the data alone); this section adds only the
+`⊥`-specialized characterizations.
+-/
+
+namespace HeckeCoset
+
+variable (Δ) in
+/-- The identity left coset `1H = H` in the bottom-left specialization. -/
+instance instOneBot : One (HeckeCoset Δ ⊥ H) := ⟨mk ⊥ H ⟨1, Δ.one_mem⟩⟩
+
+lemma one_bot_def : (1 : HeckeCoset Δ ⊥ H) = mk ⊥ H ⟨1, Δ.one_mem⟩ := (rfl)
+
+/-- In the bottom-left specialization two elements define the same class iff they differ by
+an element of `H` on the right: `⊥β₁H = ⊥β₂H ↔ β₁H = β₂H`. This is the entry point through
+which the double-coset quotient serves as the left-coset quotient. -/
+lemma mk_bot_eq_mk_bot {β₁ β₂ : Δ} :
+    mk ⊥ H β₁ = mk ⊥ H β₂ ↔ ((β₁ : G))⁻¹ * (β₂ : G) ∈ H := by
+  rw [eq_iff, ← QuotientGroup.leftRel_apply, ← DoubleCoset.bot_rel_eq_leftRel H]
+  exact (Setoid.ker_def
+    (f := fun x : G ↦ doubleCoset x (((⊥ : Subgroup G) : Set G)) ((H : Set G)))).symm
+
+/-- The representative of the class of `β` differs from `β` by an element of `H`. -/
+lemma inv_rep_mul_mem (β : Δ) : (((mk ⊥ H β : HeckeCoset Δ ⊥ H).rep : G))⁻¹ * (β : G) ∈ H :=
+  mk_bot_eq_mk_bot.mp (mk_rep (mk ⊥ H β))
+
+section Orbit
+
+open scoped Pointwise
+
+variable [IsHeckeTriple Δ H H]
+
+open Classical in
+/-- The orbit of a left coset representative `β` under a double coset representative `g`:
+the left cosets `βσᵢgH` over the decomposition `HgH = ⊔ᵢ σᵢgH`. -/
+noncomputable def smulOrbit (H : Subgroup G) [IsHeckeTriple Δ H H] (g β : Δ) :
+    Finset (HeckeCoset Δ ⊥ H) :=
+  Finset.univ.image fun i : DecompQuotient H H (g : G) ↦
+    mk ⊥ H ⟨(β : G) * i.out * g,
+      Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩
+
+open Classical in
+/-- The orbit as an explicit image: the defining equation, exported for consumers that
+count over the enumeration. -/
+lemma smulOrbit_eq_image (g β : Δ) :
+    smulOrbit H g β = Finset.univ.image fun i : DecompQuotient H H (g : G) ↦
+      mk ⊥ H ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ := (rfl)
+
+open Classical in
+/-- Membership in the orbit: the left cosets of the products `β · σᵢ · g` over the
+decomposition representatives. -/
+@[simp]
+lemma mem_smulOrbit {g β : Δ} {x : HeckeCoset Δ ⊥ H} :
+    x ∈ smulOrbit H g β ↔ ∃ i : DecompQuotient H H (g : G),
+      mk ⊥ H ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ = x := by
+  simp [smulOrbit]
+
+lemma smulOrbit_nonempty (g β : Δ) : (smulOrbit H g β).Nonempty := by
+  classical
+  exact (Finset.univ_nonempty).image _
+
+-- The conjugation criterion for the stabilizer subgroup indexing `DecompQuotient`: an
+-- element of the stabilizer conjugates into `H` under `g`. Used by every orbit argument
+-- that replaces a decomposition representative by its canonical `out`.
+private lemma conj_mem_of_stabilizer (g : G)
+    (n : (ConjAct.toConjAct g • H).subgroupOf H) : g⁻¹ * (n : G) * g ∈ H := by
+  have hn := n.2
+  rw [Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem,
+    ConjAct.smul_def] at hn
+  simpa [ConjAct.ofConjAct_toConjAct] using hn
+
+private lemma smulOrbit_subset {g β₁ β₂ : Δ} {k : G} (hk : k ∈ H)
+    (hβ : (β₂ : G) = (β₁ : G) * k) : smulOrbit H g β₁ ⊆ smulOrbit H g β₂ := by
+  classical
+  intro x hx
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx ⊢
+  obtain ⟨i, hi⟩ := hx
+  set j : DecompQuotient H H (g : G) :=
+    QuotientGroup.mk ⟨k⁻¹ * i.out, H.mul_mem (H.inv_mem hk) i.out.2⟩ with hj
+  obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (g : G) • H).subgroupOf H)
+    (⟨k⁻¹ * i.out, H.mul_mem (H.inv_mem hk) i.out.2⟩ : H)
+  have hout : ((j.out : H) : G) = k⁻¹ * (i.out : G) * n := by
+    rw [hj]
+    simpa [Subgroup.coe_mul, mul_assoc] using congrArg (Subtype.val : H → G) hn
+  refine ⟨j, ?_⟩
+  rw [← hi]
+  refine mk_bot_eq_mk_bot.mpr ?_
+  -- `mk_eq_mk` lands in the `leftRel`-comap relation of the setoid; its membership statement
+  -- coincides with the displayed `H`-membership only through the definitional unfolding of
+  -- `QuotientGroup.leftRel` and the `Δ`-subtype coercions, which no rewriting lemma states
+  change ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ * ((β₁ : G) * ((i.out : H) : G) * g) ∈ H
+  have key : ((β₂ : G) * ((j.out : H) : G) * (g : G))⁻¹ *
+      ((β₁ : G) * ((i.out : H) : G) * g) = (g : G)⁻¹ * (n : G)⁻¹ * g := by
+    rw [hout, hβ]
+    group
+  rw [key]
+  simpa [mul_assoc] using H.inv_mem (conj_mem_of_stabilizer (g : G) n)
+
+/-- The orbit depends on `β` only through its left coset. -/
+lemma smulOrbit_congr (g : Δ) {β₁ β₂ : Δ} (h : mk ⊥ H β₁ = mk ⊥ H β₂) :
+    smulOrbit H g β₁ = smulOrbit H g β₂ := by
+  have hk := mk_bot_eq_mk_bot.mp h
+  refine Finset.Subset.antisymm
+    (smulOrbit_subset hk (by group))
+    (smulOrbit_subset (H.inv_mem hk) ?_)
+  rw [mul_inv_rev, inv_inv]
+  group
+
+private lemma smulOrbit_subset_left {g₁ g₂ β : Δ}
+    (h : (g₂ : G) ∈ doubleCoset (g₁ : G) (H : Set G) H) :
+    smulOrbit H g₂ β ⊆ smulOrbit H g₁ β := by
+  classical
+  intro x hx
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx ⊢
+  obtain ⟨i, hi⟩ := hx
+  obtain ⟨h₁, hh₁, h₂, hh₂, hg₂⟩ := mem_doubleCoset.mp h
+  -- abstract the representative coercion: `i`'s type depends on `g₂`, so rewriting `g₂`
+  -- under `i.out` would produce a type-incorrect motive
+  set σ : G := ((i.out : H) : G) with hσ
+  set j : DecompQuotient H H (g₁ : G) :=
+    QuotientGroup.mk ((i.out : H) * ⟨h₁, hh₁⟩) with hj
+  obtain ⟨n, hn⟩ := QuotientGroup.mk_out_eq_mul
+    ((ConjAct.toConjAct (g₁ : G) • H).subgroupOf H) ((i.out : H) * ⟨h₁, hh₁⟩)
+  have hout : ((j.out : H) : G) = σ * h₁ * n := by
+    rw [hj, hσ]
+    simpa [Subgroup.coe_mul, mul_assoc] using congrArg (Subtype.val : H → G) hn
+  refine ⟨j, ?_⟩
+  rw [← hi]
+  refine mk_bot_eq_mk_bot.mpr ?_
+  -- as in `smulOrbit_subset`, `mk_bot_eq_mk_bot` unfolds to the double-coset setoid
+  -- through the `Δ`-subtype coercions, which no rewriting lemma states
+  change ((β : G) * ((j.out : H) : G) * (g₁ : G))⁻¹ * ((β : G) * σ * (g₂ : G)) ∈ H
+  have key : ((β : G) * ((j.out : H) : G) * (g₁ : G))⁻¹ * ((β : G) * σ * (g₂ : G)) =
+      ((g₁ : G)⁻¹ * (n : G)⁻¹ * g₁) * h₂ := by
+    rw [hout, hg₂]
+    group
+  rw [key]
+  exact H.mul_mem
+    (by simpa [mul_assoc] using H.inv_mem (conj_mem_of_stabilizer (g₁ : G) n)) hh₂
+
+/-- The orbit is invariant in the acting double-coset representative: representatives of
+the same double coset produce the same orbit. -/
+lemma smulOrbit_congr_left (β : Δ) {g₁ g₂ : Δ}
+    (h : HeckeCoset.mk H H g₁ = HeckeCoset.mk H H g₂) :
+    smulOrbit H g₁ β = smulOrbit H g₂ β := by
+  have hset := HeckeCoset.eq_iff.mp h
+  exact Finset.Subset.antisymm
+    (smulOrbit_subset_left (hset ▸ mem_doubleCoset_self H H (g₁ : G)))
+    (smulOrbit_subset_left (hset.symm ▸ mem_doubleCoset_self H H (g₂ : G)))
+
+open scoped Pointwise in
+/-- The orbit enumeration is injective: distinct decomposition classes give distinct left
+cosets. -/
+lemma smulOrbit_map_injective (g β : Δ) :
+    Function.Injective fun i : DecompQuotient H H (g : G) ↦
+      (mk ⊥ H ⟨(β : G) * i.out * g,
+        Δ.mul_mem (Δ.mul_mem β.2 (IsHeckeTriple.mem_of_mem_left H i.out.2)) g.2⟩ :
+        HeckeCoset Δ ⊥ H) := by
+  intro i₁ i₂ heq
+  have hmem : ((β : G) * ((i₁.out : H) : G) * (g : G))⁻¹ *
+      ((β : G) * ((i₂.out : H) : G) * (g : G)) ∈ H := mk_bot_eq_mk_bot.mp heq
+  have hcoset : ((((i₁.out : H) : G) * (g : G) : G) : G ⧸ H) =
+      ((((i₂.out : H) : G) * (g : G) : G) : G ⧸ H) := by
+    rw [QuotientGroup.eq]
+    have hshape : ((β : G) * ((i₁.out : H) : G) * (g : G))⁻¹ *
+        ((β : G) * ((i₂.out : H) : G) * (g : G)) =
+        (((i₁.out : H) : G) * g)⁻¹ * (((i₂.out : H) : G) * g) := by group
+    exact hshape ▸ hmem
+  exact mk_out_mul_injective H H (g : G) hcoset
+
+/-- The orbit of a left coset under `g` has exactly as many elements as the decomposition
+`HgH = ⊔ᵢ σᵢgH`: the map `i ↦ βσᵢgH` is injective. -/
+lemma smulOrbit_card (g β : Δ) :
+    (smulOrbit H g β).card = Fintype.card (DecompQuotient H H (g : G)) := by
+  classical
+  rw [smulOrbit, Finset.card_image_of_injective _ (smulOrbit_map_injective g β),
+    Finset.card_univ]
+
+/-- Orbits of representatives of distinct double cosets on a common left coset are
+disjoint. -/
+lemma smulOrbit_disjoint {g₁ g₂ : Δ} (β : Δ)
+    (hne : HeckeCoset.mk H H g₁ ≠ HeckeCoset.mk H H g₂) :
+    Disjoint (smulOrbit H g₁ β) (smulOrbit H g₂ β) := by
+  classical
+  rw [Finset.disjoint_left]
+  intro x hx₁ hx₂
+  simp only [smulOrbit, Finset.mem_image, Finset.mem_univ, true_and] at hx₁ hx₂
+  obtain ⟨i₁, hi₁⟩ := hx₁
+  obtain ⟨i₂, hi₂⟩ := hx₂
+  have hmem : ((β : G) * ((i₁.out : H) : G) * (g₁ : G))⁻¹ *
+      ((β : G) * ((i₂.out : H) : G) * (g₂ : G)) ∈ H :=
+    mk_bot_eq_mk_bot.mp (hi₁.trans hi₂.symm)
+  refine hne (HeckeCoset.mk_eq_mk_of_mem (mem_doubleCoset.mpr
+    ⟨((i₁.out : H) : G)⁻¹ * ((i₂.out : H) : G),
+      H.mul_mem (H.inv_mem i₁.out.2) i₂.out.2,
+      (((β : G) * ((i₁.out : H) : G) * (g₁ : G))⁻¹ *
+        ((β : G) * ((i₂.out : H) : G) * (g₂ : G)))⁻¹,
+      H.inv_mem hmem, by group⟩))
+
+end Orbit
+
+end HeckeCoset
+
+/-- The left-coset module: the free `R`-module on the left cosets `Δ/H` (the bottom-left
+Hecke cosets), the carrier of the natural representation of the Hecke ring. An `abbrev`
+of the underlying `Finsupp`, so the full `Finsupp` API applies transparently at every
+coefficient class — the stable named interface for the action below. -/
+abbrev LeftCosetModule (Δ : Submonoid G) (H : Subgroup G) (R : Type*) [Zero R] :=
+  HeckeCoset Δ ⊥ H →₀ R
+
+/-- The basis element `b • [βH]` of the left-coset module. -/
+noncomputable abbrev LeftCosetModule.single {Δ : Submonoid G} {H : Subgroup G} {R : Type*}
+    [Zero R]
+    (q : HeckeCoset Δ ⊥ H) (b : R) : LeftCosetModule Δ H R :=
+  Finsupp.single q b
+
+namespace LeftCosetModule
+
+open HeckeCoset
+
+open scoped HeckeCosetModule
+
+variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
+
+/-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
+a left coset by summing over its orbit, extended biadditively. Since `HgH` sends `βH` to
+the cosets `βσᵢgH` by **right** multiplication, this is a right action — encoded, per
+Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`: Shimura's
+compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
+ring. -/
+noncomputable instance instSMulLeftCosetModule :
+    SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
+  smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+    ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁)
+
+-- the defining formula for an opaque opposite-ring element; instance plumbing
+private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
+    t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
+  (rfl)
+
+/-- The defining formula of the action. -/
+lemma smul_eq_sum (t : 𝕋 Δ H R) (m : LeftCosetModule Δ H R) :
+    MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
+  (rfl)
+
+/-- The action of a basis element of the Hecke ring on a basis element of the module. -/
+lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
+    MulOpposite.op (HeckeCosetModule.single R D a) •
+        LeftCosetModule.single q b =
+      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b * a) := by
+  classical
+  rw [smul_eq_sum,
+    HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
+    Finsupp.sum_single_index (by simp)]
+
+/-- The action is additive in the (opposite) Hecke-ring argument. -/
+@[simp]
+lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
+    (t₁ + t₂) • m = t₁ • m + t₂ • m := by
+  classical
+  simp only [smul_def, MulOpposite.unop_add]
+  refine Finsupp.sum_add_index' (fun D ↦ ?_) fun D b₁ b₂ ↦ ?_
+  · refine (Finsupp.sum_congr (g2 := fun _ _ ↦ 0) fun q _ ↦ ?_).trans
+      (Finsupp.sum_fun_zero m)
+    exact Finset.sum_eq_zero fun i _ ↦ by simp
+  · refine ((Finsupp.sum_congr fun q _ ↦ ?_).trans Finsupp.sum_add)
+    rw [← Finset.sum_add_distrib]
+    exact Finset.sum_congr rfl fun i _ ↦ by
+      simp only [LeftCosetModule.single, mul_add, Finsupp.single_add]
+
+/-- The scalar operations distribute over the module's addition, packaged as the
+`DistribSMul` typeclass (the strongest action class available before the compatibility
+law with the convolution product); the generic `smul_zero`/`smul_add` supersede
+ad-hoc laws. -/
+noncomputable instance distribSMul :
+    DistribSMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
+  smul_zero t := by
+    rw [smul_def]
+    simp only [Finsupp.sum_zero_index]
+    exact Finsupp.sum_fun_zero t.unop
+  smul_add t m₁ m₂ := by
+    classical
+    simp only [smul_def]
+    refine (Finsupp.sum_congr fun D b₁ ↦ ?_).trans Finsupp.sum_add
+    refine Finsupp.sum_add_index' (fun q ↦ ?_) fun q b₂ b₃ ↦ ?_
+    · exact Finset.sum_eq_zero fun i _ ↦ by simp
+    · rw [← Finset.sum_add_distrib]
+      exact Finset.sum_congr rfl fun i _ ↦ by
+        simp only [LeftCosetModule.single, add_mul, Finsupp.single_add]
+
+/-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
+noncomputable instance smulWithZero :
+    SMulWithZero (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
+  smul_zero := smul_zero
+  zero_smul m := by
+    rw [smul_def]
+    simp only [MulOpposite.unop_zero]
+    exact Finsupp.sum_zero_index
+
+end LeftCosetModule
+
+namespace LeftCosetModule
+
+open HeckeCoset
+
+open scoped HeckeCosetModule
+
+variable [IsHeckeTriple Δ H H] {R : Type*} [NonAssocSemiring R]
+
+/-- Reading off a coefficient of the action on the identity basis element: at any member of
+the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D`. -/
+private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
+    {q : HeckeCoset Δ ⊥ H}
+    (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :
+    (MulOpposite.op t • LeftCosetModule.single 1 1) q = t D := by
+  classical
+  have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
+      (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
+        ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₂ * b₁)) =
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ := by
+    intro D' b₁
+    rw [Finsupp.sum_single_index (by simp)]
+    simp
+  have hsum : (t.sum fun D' b₁ ↦
+        (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum fun q' b₂ ↦
+          ∑ i ∈ smulOrbit H D'.rep q'.rep, Finsupp.single i (b₂ * b₁)) =
+      t.sum fun D' b₁ ↦
+        ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep, Finsupp.single i b₁ :=
+    Finsupp.sum_congr fun D' _ ↦ hinner D' (t D')
+  rw [smul_eq_sum, hsum]
+  simp only [Finsupp.sum, Finsupp.finsetSum_apply]
+  have hzero : ∀ D' ∈ t.support, D' ≠ D →
+      ∑ i ∈ smulOrbit H D'.rep (1 : HeckeCoset Δ ⊥ H).rep,
+        (Finsupp.single i (t D') : LeftCosetModule Δ H R) q = 0 := by
+    intro D' _ hne
+    refine Finset.sum_eq_zero fun i hi ↦ Finsupp.single_apply_eq_zero.mpr fun heq ↦ ?_
+    have hne' : HeckeCoset.mk H H D'.rep ≠ HeckeCoset.mk H H D.rep := by
+      simpa [HeckeCoset.mk_rep] using hne
+    exact absurd hq (Finset.disjoint_left.mp (smulOrbit_disjoint _ hne') (heq ▸ hi))
+  have hread : ∀ b : R,
+      ∑ i ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep,
+        (Finsupp.single i b : LeftCosetModule Δ H R) q = b := by
+    intro b
+    rw [Finset.sum_eq_single_of_mem q hq fun i _ hne ↦
+      Finsupp.single_apply_eq_zero.mpr fun heq ↦ absurd heq.symm hne]
+    simp
+  exact (Finset.sum_eq_single D hzero fun hD ↦
+    (hread (t D)).trans (Finsupp.notMem_support_iff.mp hD)).trans (hread (t D))
+
+/-- The action of the Hecke ring on the module of left cosets is faithful. -/
+lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
+    (h : ∀ m : LeftCosetModule Δ H R,
+      MulOpposite.op t₁ • m = MulOpposite.op t₂ • m) : t₁ = t₂ := by
+  classical
+  refine Finsupp.ext fun D ↦ ?_
+  obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeCoset Δ ⊥ H).rep
+  have h1 := congrArg (fun m ↦ m q) (h (LeftCosetModule.single 1 1))
+  rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
+
+/-- The scalar operations of the opposite Hecke ring on the left-coset module are
+faithful, as an instance. -/
+noncomputable instance instFaithfulSMul :
+    FaithfulSMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
+  eq_of_smul_eq_smul {a b} h :=
+    MulOpposite.unop_injective <| eq_of_smul_eq_smul fun m ↦ by
+      simpa only [MulOpposite.op_unop] using h m
+
+end LeftCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -270,12 +270,6 @@ coefficient class — the stable named interface for the action below. -/
 abbrev LeftCosetModule (Δ : Submonoid G) (H : Subgroup G) (R : Type*) [Zero R] :=
   HeckeCoset Δ ⊥ H →₀ R
 
-/-- The basis element `b • [βH]` of the left-coset module. -/
-noncomputable abbrev LeftCosetModule.single {Δ : Submonoid G} {H : Subgroup G} {R : Type*}
-    [Zero R]
-    (q : HeckeCoset Δ ⊥ H) (b : R) : LeftCosetModule Δ H R :=
-  Finsupp.single q b
-
 namespace LeftCosetModule
 
 open HeckeCoset
@@ -299,20 +293,20 @@ noncomputable instance instSMulLeftCosetModule :
 -- the defining formula for an opaque opposite-ring element; instance plumbing
 private lemma smul_def (t : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R) :
     t • m = t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The defining formula of the action. -/
 lemma smul_eq_sum (t : 𝕋 Δ H R) (m : LeftCosetModule Δ H R) :
     MulOpposite.op t • m = t.sum fun D b₁ ↦ m.sum fun q b₂ ↦
-      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b₂ * b₁) :=
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b₂ * b₁) :=
   (rfl)
 
 /-- The action of a basis element of the Hecke ring on a basis element of the module. -/
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
     MulOpposite.op (HeckeCosetModule.single R D a) •
-        LeftCosetModule.single q b =
-      ∑ i ∈ smulOrbit H D.rep q.rep, LeftCosetModule.single i (b * a) := by
+        Finsupp.single q b =
+      ∑ i ∈ smulOrbit H D.rep q.rep, Finsupp.single i (b * a) := by
   classical
   rw [smul_eq_sum,
     HeckeCosetModule.sum_single_index R (by rw [Finsupp.sum_single_index (by simp)]; simp),
@@ -331,7 +325,7 @@ lemma add_smul (t₁ t₂ : (𝕋 Δ H R)ᵐᵒᵖ) (m : LeftCosetModule Δ H R)
   · refine ((Finsupp.sum_congr fun q _ ↦ ?_).trans Finsupp.sum_add)
     rw [← Finset.sum_add_distrib]
     exact Finset.sum_congr rfl fun i _ ↦ by
-      simp only [LeftCosetModule.single, mul_add, Finsupp.single_add]
+      simp only [mul_add, Finsupp.single_add]
 
 /-- The scalar operations distribute over the module's addition, packaged as the
 `DistribSMul` typeclass (the strongest action class available before the compatibility
@@ -351,7 +345,7 @@ noncomputable instance distribSMul :
     · exact Finset.sum_eq_zero fun i _ ↦ by simp
     · rw [← Finset.sum_add_distrib]
       exact Finset.sum_congr rfl fun i _ ↦ by
-        simp only [LeftCosetModule.single, add_mul, Finsupp.single_add]
+        simp only [add_mul, Finsupp.single_add]
 
 /-- Zero acts as zero and acting on zero gives zero: the `SMulWithZero` typeclass. -/
 noncomputable instance smulWithZero :
@@ -377,7 +371,7 @@ the orbit of `D`, the coefficient of `t • [H]` is the coefficient of `t` at `D
 private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
     {q : HeckeCoset Δ ⊥ H}
     (hq : q ∈ smulOrbit H D.rep (1 : HeckeCoset Δ ⊥ H).rep) :
-    (MulOpposite.op t • LeftCosetModule.single 1 1) q = t D := by
+    (MulOpposite.op t • Finsupp.single 1 1) q = t D := by
   classical
   have hinner : ∀ (D' : HeckeCoset Δ H H) (b₁ : R),
       (Finsupp.single (1 : HeckeCoset Δ ⊥ H) (1 : R)).sum (fun q' b₂ ↦
@@ -420,7 +414,7 @@ lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
   classical
   refine Finsupp.ext fun D ↦ ?_
   obtain ⟨q, hq⟩ := smulOrbit_nonempty (H := H) D.rep (1 : HeckeCoset Δ ⊥ H).rep
-  have h1 := congrArg (fun m ↦ m q) (h (LeftCosetModule.single 1 1))
+  have h1 := congrArg (fun m ↦ m q) (h (Finsupp.single 1 1))
   rwa [smul_single_one_apply t₁ D hq, smul_single_one_apply t₂ D hq] at h1
 
 /-- The scalar operations of the opposite Hecke ring on the left-coset module are

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -288,6 +288,7 @@ lemma smul_eq_sum (t : 𝕋 Δ H R) (m : LeftCosetModule Δ H R) :
 
 /-- A basis element of the Hecke ring scales a basis element of the module into its
 orbit sum. -/
+@[simp]
 lemma single_smul_single (D : HeckeCoset Δ H H) (q : HeckeCoset Δ ⊥ H) (a b : R) :
     MulOpposite.op (HeckeCosetModule.single R D a) •
         Finsupp.single q b =

--- a/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
+++ b/TauCeti/NumberTheory/HeckeRing/LeftCosetModule.lean
@@ -17,10 +17,12 @@ cosets `Δ/H`, each element of `𝕋 Δ H R` defines a scalar operation, with a 
 `HgH = ⊔ᵢ σᵢgH` sending a left coset `βH` to `Σᵢ βσᵢgH`. This file constructs the
 left-coset presentation, the orbit Finsets, and the scalar multiplication, and proves it is
 additive in both arguments and faithful. Since `HgH` sends `βH` to `Σᵢ βσᵢgH` by right
-multiplication, this is a **right** action, encoded as a left action of the opposite ring
-`(𝕋 Δ H R)ᵐᵒᵖ` per Mathlib convention: Shimura's compatibility law
-`(f * g) • m = g • (f • m)` (Proposition 3.2) is exactly `mul_smul` for the opposite ring,
-and is established together with the degree homomorphism in the follow-up development.
+multiplication, this is **right** multiplication, encoded as scalar operations of the
+opposite ring `(𝕋 Δ H R)ᵐᵒᵖ` per Mathlib convention. This file provides only the scalar
+operations, not yet an action: Shimura's compatibility law `(f * g) • m = g • (f • m)`
+(Proposition 3.2) is exactly `mul_smul` for the opposite ring, and is established — turning
+these scalars into a genuine action — together with the degree homomorphism in the
+follow-up development.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`HeckeRIngs/AbstractHeckeRing/Module.lean`,
@@ -35,15 +37,15 @@ Mathlib stack.
   the existing double-coset quotient serve as the left-coset quotient, with no new type.
 * `HeckeCoset.smulOrbit H g β`: the orbit Finset `{βσᵢgH}` of a left coset under a
   double coset representative.
-* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R)` instance — the right Hecke action in
-  its opposite-ring encoding.
+* the `SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R)` instance — right multiplication by the
+  Hecke ring in its opposite-ring encoding.
 
 ## Main results
 
 * `HeckeCoset.smulOrbit_congr`, `HeckeCoset.smulOrbit_disjoint`: the orbit depends
   only on the left coset, and orbits of distinct double cosets are disjoint.
-* `LeftCosetModule.instFaithfulSMul`: the action of the (opposite) Hecke ring on the
-  module of left cosets is faithful.
+* `LeftCosetModule.instFaithfulSMul`: the scalar multiplication of the (opposite) Hecke
+  ring on the module of left cosets is faithful.
 -/
 
 public section
@@ -282,12 +284,13 @@ open scoped HeckeCosetModule
 
 variable [IsHeckeTriple Δ H H] {R : Type*} [NonUnitalNonAssocSemiring R]
 
-/-- The action of the Hecke ring on the free module of left cosets: a double coset acts on
-a left coset by summing over its orbit, extended biadditively. Since `HgH` sends `βH` to
-the cosets `βσᵢgH` by **right** multiplication, this is a right action — encoded, per
-Mathlib convention, as a left action of the opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`: Shimura's
-compatibility `(f * g) • m = g • (f • m)` is precisely `mul_smul` for the opposite
-ring. -/
+/-- The scalar multiplication of the Hecke ring on the free module of left cosets: a double
+coset scales a left coset by summing over its orbit, extended biadditively. Since `HgH`
+sends `βH` to the cosets `βσᵢgH` by **right** multiplication, the scalars come from the
+opposite ring `(𝕋 Δ H R)ᵐᵒᵖ`, per Mathlib convention. Shimura's compatibility
+`(f * g) • m = g • (f • m)` — precisely `mul_smul` for the opposite ring, which upgrades
+these scalar operations to an action — is proved with the degree homomorphism in the
+follow-up development. -/
 noncomputable instance instSMulLeftCosetModule :
     SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R) where
   smul t m := t.unop.sum fun D b₁ ↦ m.sum fun q b₂ ↦
@@ -409,7 +412,8 @@ private lemma smul_single_one_apply (t : 𝕋 Δ H R) (D : HeckeCoset Δ H H)
   exact (Finset.sum_eq_single D hzero fun hD ↦
     (hread (t D)).trans (Finsupp.notMem_support_iff.mp hD)).trans (hread (t D))
 
-/-- The action of the Hecke ring on the module of left cosets is faithful. -/
+/-- The scalar multiplication of the Hecke ring on the module of left cosets is
+faithful. -/
 lemma eq_of_smul_eq_smul {t₁ t₂ : 𝕋 Δ H R}
     (h : ∀ m : LeftCosetModule Δ H R,
       MulOpposite.op t₁ • m = MulOpposite.op t₂ • m) : t₁ = t₂ := by

--- a/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplication.lean
@@ -5,8 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Algebra.BigOperators.Finsupp.Basic
-public import Mathlib.Data.Finsupp.SMul
 public import TauCeti.NumberTheory.HeckeRing.Multiplicity.Support
 
 /-!
@@ -45,7 +43,8 @@ open scoped Pointwise
 namespace HeckeCosetModule
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ : Subgroup G}
-  (R : Type*) [Semiring R]
+
+variable (R : Type*) [Semiring R]
 
 open Classical in
 /-- The structure constants of the Hecke product: `structureConstants H₁ H₂ H₃ R g₁ g₂` is the
@@ -71,11 +70,6 @@ lemma support_structureConstants_subset [IsHeckeTriple Δ H₁ H₂]
       Finset.univ.image (HeckeCoset.mulMap H₁ H₂ H₃ g₁ g₂) :=
   Finsupp.support_onFinset_subset
 
-/-- The `R`-module structure of the Hecke coset module, transporting the standard `Finsupp`
-module structure to the wrapper type. -/
-noncomputable instance instModule : Module R (HeckeCosetModule Δ H₁ H₂ R) :=
-  inferInstanceAs (Module R (HeckeCoset Δ H₁ H₂ →₀ R))
-
 /-- The convolution product of Hecke coset modules, defined via the structure constants. The
 diagonal case is the multiplication of the Hecke ring; see the `Mul (𝕋 Δ H R)` instance. -/
 noncomputable def mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
@@ -97,56 +91,14 @@ noncomputable instance instMulHeckeRing {H : Subgroup G} [IsHeckeTriple Δ H H] 
 lemma mul_def {H : Subgroup G} [IsHeckeTriple Δ H H] (f g : 𝕋 Δ H R) :
     f * g = mul R f g := (rfl)
 
-/-- A basis element of the Hecke coset module: `single R D b` is the formal sum `b • [D]`. As
-for `Finsupp` itself, this is the type-correct way to produce elements of
-`HeckeCosetModule Δ H₁ H₂ R`. -/
-noncomputable def single (D : HeckeCoset Δ H₁ H₂) (b : R) :
-    HeckeCosetModule Δ H₁ H₂ R :=
-  Finsupp.single D b
-
-@[grind =]
-lemma single_apply {D A : HeckeCoset Δ H₁ H₂} {b : R} [Decidable (D = A)] :
-    single R D b A = if D = A then b else 0 :=
-  Finsupp.single_apply
-
-lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1 = single R D b :=
-  Finsupp.smul_single_one D b
-
-@[simp]
-lemma sum_single (f : HeckeCosetModule Δ H₁ H₂ R) : f.sum (single R) = f := Finsupp.sum_single f
-
-/-- `Finsupp.single_zero`, as a wrapper-level equation. -/
-@[simp] lemma single_zero (D : HeckeCoset Δ H₁ H₂) : single R D (0 : R) = 0 :=
-  Finsupp.single_zero D
-
-/-- `Finsupp.single_add`, as a wrapper-level equation. -/
-lemma single_add (D : HeckeCoset Δ H₁ H₂) (b c : R) :
-    single R D (b + c) = single R D b + single R D c :=
-  Finsupp.single_add D b c
-
-/-- `Finsupp.sum_single_index`, as a wrapper-level equation: summing over a basis element
-evaluates the summand at its point. -/
-lemma sum_single_index {N : Type*} [AddCommMonoid N] {D : HeckeCoset Δ H₁ H₂} {b : R}
-    {F : HeckeCoset Δ H₁ H₂ → R → N} (h : F D 0 = 0) : (single R D b).sum F = F D b :=
-  Finsupp.sum_single_index h
-
-/-- `Finsupp.induction_linear`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R` in
-its basis vocabulary `single`, in the same way that `MonoidAlgebra.induction_linear` restates
-it for `MonoidAlgebra`: to prove a property of all elements, prove it for `0`, for sums, and
-for basis elements. -/
-lemma induction_linear {p : HeckeCosetModule Δ H₁ H₂ R → Prop}
-    (f : HeckeCosetModule Δ H₁ H₂ R) (h0 : p 0)
-    (hadd : ∀ f g : HeckeCosetModule Δ H₁ H₂ R, p f → p g → p (f + g))
-    (hsingle : ∀ (D : HeckeCoset Δ H₁ H₂) (b : R), p (single R D b)) : p f :=
-  Finsupp.induction_linear f h0 hadd hsingle
-
 /-- The convolution product of two basis elements. -/
 lemma mul_single_single [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
     (D₁ : HeckeCoset Δ H₁ H₂) (D₂ : HeckeCoset Δ H₂ H₃) (a b : R) :
     mul R (single R D₁ a) (single R D₂ b) =
       a • b • structureConstants R H₁ H₂ H₃ D₁.rep D₂.rep := by
-  rw [mul_eq_sum]
-  simp [single, Finsupp.sum_single_index]
+  rw [mul_eq_sum, sum_single_index, sum_single_index]
+  · simp
+  · rw [sum_single_index] <;> simp
 
 /-- The product of two basis elements of the Hecke ring. -/
 lemma single_mul_single {H : Subgroup G} [IsHeckeTriple Δ H H]

--- a/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Multiplicity/Basic.lean
@@ -58,17 +58,6 @@ lemma subsingleton_decompQuotient_of_mem {Γ : Subgroup G} {g : G} (hg : g ∈ �
   subsingleton_decompQuotient
     (Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hg)).ge
 
-/-- The left cosets `σᵢ g Γ₂` of the decomposition of `Γ₁gΓ₂` are pairwise distinct: the map
-`i ↦ σᵢ g Γ₂` into `G ⧸ Γ₂` is injective. -/
-lemma mk_out_mul_injective (Γ₁ Γ₂ : Subgroup G) (g : G) :
-    Function.Injective fun i : DecompQuotient Γ₁ Γ₂ g ↦ (((i.out : G) * g : G) : G ⧸ Γ₂) := by
-  intro i j hij
-  simp only [QuotientGroup.eq] at hij
-  rw [← QuotientGroup.out_eq' i, ← QuotientGroup.out_eq' j, QuotientGroup.eq,
-    Subgroup.mem_subgroupOf, Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ← ConjAct.toConjAct_inv,
-      ConjAct.smul_def, ConjAct.ofConjAct_toConjAct, inv_inv]
-  simpa [mul_assoc] using hij
-
 /-- Shimura's multiplicity (Proposition 3.2 of [Shimura][shimura1971]): the number of pairs
 `(i, j)` of coset representatives such that `σᵢ g τⱼ h Γ₃ = d Γ₃`. The diagonal case
 `Γ₁ = Γ₂ = Γ₃` gives the structure constants of the Hecke ring.


### PR DESCRIPTION
Successor to #1940, which queue housekeeping retired at the round cap; the branch carries every finding-fix from its review rounds (including the final naming round: `one_bot_def`, the private stabilizer helper), and its last CI was green. Restacked onto current main and the new Mathlib pin with no content change.

What those rounds shaped, cumulatively:

- `LeftCosetModule Δ H R`: the free `R`-module on the left cosets `H\Δ`, as a reducible `Finsupp` target with `LeftCosetModule.single` — the raw-target design the review converged on after three machine-refuted wrapper alternatives.
- The right action of the Hecke ring through the opposite ring: `SMul (𝕋 Δ H R)ᵐᵒᵖ (LeftCosetModule Δ H R)`, with coefficient order `b₂ * b₁` — associativity-only, no commutativity assumption; Shimura's `(f*g)•m = g•(f•m)` is the opposite ring's genuine `mul_smul`.
- `single_smul_single`, the op-normal-form `smul_eq_sum`/`add_smul`, `DistribSMul`/`SMulWithZero`, and faithfulness (`FaithfulSMul`) of the action.

The cumulative review history is on #1940 (and its own predecessor threads); all substantive mathematical findings there were resolved in-pipeline — the two real correctness catches (opposite-ring form, coefficient order) are incorporated.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/ModularForms/README.md), Layer 2(a) — the abstract Hecke-ring development toward the degree map and the `GL₂` multiplication table (AINTLIB provenance: `LeanModularForms/HeckeRIngs/AbstractHeckeRing/Module.lean`). The left-coset module is the carrier of the Hecke ring's natural representation: the degree homomorphism of Layer 2(a) is precisely the coefficient-sum of this module's scalar operations, so this PR is the direct prerequisite of the stacked degree-map PR (branch `numbertheory/hecke-degree-v2`), which proves the action laws and the degree formula on top of it.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
