### PR TITLE
refactor(MeasureTheory): generalise the ENNReal product integration bridge

### DIFF
--- a/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
+++ b/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
@@ -1,0 +1,73 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Bochner.Set
+
+/-!
+# Integrating finite products of `ℝ≥0∞`-valued functions
+
+Two facts about a finite product `∏ i, f i ω` of `ℝ≥0∞`-valued functions, relating its real form
+to its `ℝ≥0∞` form.
+
+## Main results
+
+* `integrable_prod_toReal` — a finite product of measurable `[0,1]`-valued functions is integrable
+  against a finite measure, since the product is itself `[0,1]`-valued.
+* `ofReal_integral_prod_toReal_eq_lintegral_prod` — the real integral of the product of the real
+  forms is the lower integral of the product, provided no factor is infinite.
+
+Both are stated for an arbitrary family `f : Fin r → Ω → ℝ≥0∞`. The motivating instance is a
+product of measure evaluations `f i ω = κ ω (B i)` for a measurable family of probability
+measures `κ`, where the `[0,1]` bound is `prob_le_one` and finiteness is `measure_ne_top`; nothing
+in the proofs uses that the factors come from measures, so neither statement mentions one.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Finset
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace MeasureTheory
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω}
+
+/-- **A finite product of `[0,1]`-valued measurable functions is integrable** against a finite
+measure: the product is measurable, nonnegative, and bounded by `1`, so it is dominated by a
+constant. -/
+theorem integrable_prod_toReal {ν : Measure Ω} [IsFiniteMeasure ν] {r : ℕ} {f : Fin r → Ω → ℝ≥0∞}
+    (hf_meas : ∀ i, Measurable (f i)) (hf_le : ∀ i ω, f i ω ≤ 1) :
+    Integrable (fun ω => ∏ i, (f i ω).toReal) ν := by
+  have hg_meas : Measurable fun ω => ∏ i, (f i ω).toReal :=
+    Finset.measurable_prod _ fun i _ => (hf_meas i).ennreal_toReal
+  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
+  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  exact Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ =>
+    ENNReal.toReal_le_of_le_ofReal zero_le_one (by rw [ENNReal.ofReal_one]; exact hf_le i ω)
+
+/-- **The real integral of a finite product is its `ℝ≥0∞` integral**, factor by factor: each factor
+is finite, so `ENNReal.ofReal_toReal` recovers it from its real form. -/
+theorem ofReal_integral_prod_toReal_eq_lintegral_prod {ν : Measure Ω} {r : ℕ}
+    {f : Fin r → Ω → ℝ≥0∞} (hf_ne_top : ∀ i ω, f i ω ≠ ∞)
+    (h_int : Integrable (fun ω => ∏ i, (f i ω).toReal) ν) :
+    ENNReal.ofReal (∫ ω, ∏ i, (f i ω).toReal ∂ν) = ∫⁻ ω, ∏ i, f i ω ∂ν := by
+  rw [ofReal_integral_eq_lintegral_ofReal h_int
+    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
+  refine lintegral_congr fun ω => ?_
+  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
+  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (hf_ne_top i ω)
+
+end MeasureTheory
+
+end TauCeti
+
+end
+
+end

--- a/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
+++ b/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
@@ -17,7 +17,7 @@ to its `ℝ≥0∞` form.
 * `integrable_prod_toReal` — a finite product of measurable `[0,1]`-valued functions is integrable
   against a finite measure, since the product is itself `[0,1]`-valued.
 * `ofReal_integral_prod_toReal_eq_lintegral_prod` — the real integral of the product of the real
-  forms is the lower integral of the product, provided no factor is infinite.
+  forms is the lower integral of the product, provided the product is a.e. finite.
 
 Both are stated for an arbitrary family `f : ι → Ω → ℝ≥0∞` indexed over a `Finset`, with
 almost-everywhere hypotheses, since that is all integration sees. The motivating instance is a
@@ -55,18 +55,18 @@ theorem integrable_prod_toReal {ι : Type*} {ν : Measure Ω} [IsFiniteMeasure �
   exact Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i hi =>
     ENNReal.toReal_le_of_le_ofReal zero_le_one (by rw [ENNReal.ofReal_one]; exact hω i hi)
 
-/-- **The real integral of a finite product is its `ℝ≥0∞` integral**, factor by factor: each factor
-is a.e. finite, so `ENNReal.ofReal_toReal` recovers it from its real form. -/
+/-- **The real integral of a finite product is its `ℝ≥0∞` integral.** Only the *product* need be
+a.e. finite — an infinite factor annihilated by a zero one is fine — since `ENNReal.toReal` is
+multiplicative and `ENNReal.ofReal_toReal` is then applied to the product as a whole. -/
 theorem ofReal_integral_prod_toReal_eq_lintegral_prod {ι : Type*} {ν : Measure Ω} {s : Finset ι}
-    {f : ι → Ω → ℝ≥0∞} (hf_ne_top : ∀ i ∈ s, ∀ᵐ ω ∂ν, f i ω ≠ ∞)
+    {f : ι → Ω → ℝ≥0∞} (hf_ne_top : ∀ᵐ ω ∂ν, (∏ i ∈ s, f i ω) ≠ ∞)
     (h_int : Integrable (fun ω => ∏ i ∈ s, (f i ω).toReal) ν) :
     ENNReal.ofReal (∫ ω, ∏ i ∈ s, (f i ω).toReal ∂ν) = ∫⁻ ω, ∏ i ∈ s, f i ω ∂ν := by
   rw [ofReal_integral_eq_lintegral_ofReal h_int
     (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
   refine lintegral_congr_ae ?_
-  filter_upwards [(Filter.eventually_all_finset s).2 hf_ne_top] with ω hω
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i hi => ENNReal.ofReal_toReal (hω i hi)
+  filter_upwards [hf_ne_top] with ω hω
+  rw [← ENNReal.toReal_prod, ENNReal.ofReal_toReal hω]
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
+++ b/TauCeti/MeasureTheory/Integral/ENNRealProd.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import Mathlib.MeasureTheory.Integral.Bochner.Basic
 
 /-!
 # Integrating finite products of `ℝ≥0∞`-valued functions
@@ -19,7 +19,8 @@ to its `ℝ≥0∞` form.
 * `ofReal_integral_prod_toReal_eq_lintegral_prod` — the real integral of the product of the real
   forms is the lower integral of the product, provided no factor is infinite.
 
-Both are stated for an arbitrary family `f : Fin r → Ω → ℝ≥0∞`. The motivating instance is a
+Both are stated for an arbitrary family `f : ι → Ω → ℝ≥0∞` indexed over a `Finset`, with
+almost-everywhere hypotheses, since that is all integration sees. The motivating instance is a
 product of measure evaluations `f i ω = κ ω (B i)` for a measurable family of probability
 measures `κ`, where the `[0,1]` bound is `prob_le_one` and finiteness is `measure_ne_top`; nothing
 in the proofs uses that the factors come from measures, so neither statement mentions one.
@@ -39,30 +40,33 @@ namespace MeasureTheory
 
 variable {Ω : Type*} {mΩ : MeasurableSpace Ω}
 
-/-- **A finite product of `[0,1]`-valued measurable functions is integrable** against a finite
-measure: the product is measurable, nonnegative, and bounded by `1`, so it is dominated by a
-constant. -/
-theorem integrable_prod_toReal {ν : Measure Ω} [IsFiniteMeasure ν] {r : ℕ} {f : Fin r → Ω → ℝ≥0∞}
-    (hf_meas : ∀ i, Measurable (f i)) (hf_le : ∀ i ω, f i ω ≤ 1) :
-    Integrable (fun ω => ∏ i, (f i ω).toReal) ν := by
-  have hg_meas : Measurable fun ω => ∏ i, (f i ω).toReal :=
-    Finset.measurable_prod _ fun i _ => (hf_meas i).ennreal_toReal
-  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
+/-- **A finite product of `[0,1]`-valued functions is integrable** against a finite measure: the
+product is a.e. nonnegative and a.e. bounded by `1`, so it is dominated by a constant. -/
+theorem integrable_prod_toReal {ι : Type*} {ν : Measure Ω} [IsFiniteMeasure ν] {s : Finset ι}
+    {f : ι → Ω → ℝ≥0∞} (hf_meas : ∀ i ∈ s, AEMeasurable (f i) ν)
+    (hf_le : ∀ i ∈ s, ∀ᵐ ω ∂ν, f i ω ≤ 1) :
+    Integrable (fun ω => ∏ i ∈ s, (f i ω).toReal) ν := by
+  have hg_meas : AEMeasurable (fun ω => ∏ i ∈ s, (f i ω).toReal) ν :=
+    (Finset.aemeasurable_prod s fun i hi => (hf_meas i hi).ennreal_toReal).congr
+      (ae_of_all _ fun ω => Finset.prod_apply ω s _)
+  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable ?_
+  filter_upwards [(Filter.eventually_all_finset s).2 hf_le] with ω hω
   rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  exact Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ =>
-    ENNReal.toReal_le_of_le_ofReal zero_le_one (by rw [ENNReal.ofReal_one]; exact hf_le i ω)
+  exact Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i hi =>
+    ENNReal.toReal_le_of_le_ofReal zero_le_one (by rw [ENNReal.ofReal_one]; exact hω i hi)
 
 /-- **The real integral of a finite product is its `ℝ≥0∞` integral**, factor by factor: each factor
-is finite, so `ENNReal.ofReal_toReal` recovers it from its real form. -/
-theorem ofReal_integral_prod_toReal_eq_lintegral_prod {ν : Measure Ω} {r : ℕ}
-    {f : Fin r → Ω → ℝ≥0∞} (hf_ne_top : ∀ i ω, f i ω ≠ ∞)
-    (h_int : Integrable (fun ω => ∏ i, (f i ω).toReal) ν) :
-    ENNReal.ofReal (∫ ω, ∏ i, (f i ω).toReal ∂ν) = ∫⁻ ω, ∏ i, f i ω ∂ν := by
+is a.e. finite, so `ENNReal.ofReal_toReal` recovers it from its real form. -/
+theorem ofReal_integral_prod_toReal_eq_lintegral_prod {ι : Type*} {ν : Measure Ω} {s : Finset ι}
+    {f : ι → Ω → ℝ≥0∞} (hf_ne_top : ∀ i ∈ s, ∀ᵐ ω ∂ν, f i ω ≠ ∞)
+    (h_int : Integrable (fun ω => ∏ i ∈ s, (f i ω).toReal) ν) :
+    ENNReal.ofReal (∫ ω, ∏ i ∈ s, (f i ω).toReal ∂ν) = ∫⁻ ω, ∏ i ∈ s, f i ω ∂ν := by
   rw [ofReal_integral_eq_lintegral_ofReal h_int
     (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine lintegral_congr fun ω => ?_
+  refine lintegral_congr_ae ?_
+  filter_upwards [(Filter.eventually_all_finset s).2 hf_ne_top] with ω hω
   rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (hf_ne_top i ω)
+  exact Finset.prod_congr rfl fun i hi => ENNReal.ofReal_toReal (hω i hi)
 
 end MeasureTheory
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Probability.DeFinetti.DirectingMeasure.Basic
-public import Mathlib.MeasureTheory.Integral.Bochner.Set
+public import TauCeti.MeasureTheory.Integral.ENNRealProd
 
 /-!
 # Integrating finite products of directing-measure evaluations
@@ -20,6 +20,14 @@ rectangle arguments need: it is integrable in its real form, and its real integr
   and measurable, hence integrable against a finite measure.
 * `ofReal_integral_eq_lintegral_prod_directingMeasure` — the real integral of that product is the
   `ℝ≥0∞` integral of the product of the evaluations themselves.
+
+Neither argument uses anything about directing measures beyond measurability of each evaluation
+`ω ↦ directingMeasure μ X ω (B i)` and the bounds `≤ 1` and `≠ ∞`. The two statements are therefore
+instances of `TauCeti.MeasureTheory.integrable_prod_toReal` and
+`TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod`, which are about finite
+products of `ℝ≥0∞`-valued functions and mention no measure on `α`. What is left here is the
+specialisation: it discharges measurability from `measurable_directingMeasure_coe`, which all three
+consumers would otherwise repeat.
 
 In both, the measure in the integration slot is independent of the measure `μ` that defines the
 directing measure: `μ` is only the directing-measure parameter, and the integral is taken against a
@@ -51,16 +59,9 @@ lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α
     {μ : Measure Ω} [IsFiniteMeasure μ] {ν : Measure Ω} [IsFiniteMeasure ν] {X : ℕ → Ω → α}
     (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
     (hB : ∀ i, MeasurableSet (B i)) :
-    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν := by
-  have hg_meas : Measurable fun ω => ∏ i, (directingMeasure μ X ω).real (B i) :=
-    Finset.measurable_prod _ fun i _ =>
-      (measurable_directingMeasure_coe hTail (hB i)).ennreal_toReal
-  refine (integrable_const (1 : ℝ)).mono' hg_meas.aestronglyMeasurable (ae_of_all _ fun ω => ?_)
-  simp only [measureReal_def]
-  rw [Real.norm_of_nonneg (Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine Finset.prod_le_one (fun i _ => ENNReal.toReal_nonneg) fun i _ => ?_
-  exact ENNReal.toReal_le_of_le_ofReal zero_le_one
-    (by rw [ENNReal.ofReal_one]; exact (measure_mono (Set.subset_univ _)).trans_eq measure_univ)
+    Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν :=
+  TauCeti.MeasureTheory.integrable_prod_toReal
+    (fun i => measurable_directingMeasure_coe hTail (hB i)) fun _ _ => prob_le_one
 
 /-- The real integral of the directing-measure product is its `ℝ≥0∞` integral, factor by factor:
 each factor is a finite measure of a set, so `ENNReal.ofReal_toReal` applies. As above, `ν` is an
@@ -70,13 +71,9 @@ lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α]
     {B : Fin r → Set α}
     (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν) :
     ENNReal.ofReal (∫ ω, ∏ i, (directingMeasure μ X ω).real (B i) ∂ν)
-      = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν := by
-  rw [ofReal_integral_eq_lintegral_ofReal hg_int
-    (ae_of_all _ fun ω => Finset.prod_nonneg fun i _ => ENNReal.toReal_nonneg)]
-  refine lintegral_congr fun ω => ?_
-  simp only [measureReal_def]
-  rw [ENNReal.ofReal_prod_of_nonneg fun i _ => ENNReal.toReal_nonneg]
-  exact Finset.prod_congr rfl fun i _ => ENNReal.ofReal_toReal (measure_ne_top _ _)
+      = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν :=
+  TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod
+    (fun _ _ => measure_ne_top _ _) hg_int
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -25,7 +25,8 @@ Neither argument uses anything about directing measures beyond measurability of 
 `ω ↦ directingMeasure μ X ω (B i)` and the bounds `≤ 1` and `≠ ∞`. The two statements are therefore
 instances of `TauCeti.MeasureTheory.integrable_prod_toReal` and
 `TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod`, which are about finite
-products of `ℝ≥0∞`-valued functions and mention no measure on `α`. What is left here is the
+products of `ℝ≥0∞`-valued functions over a `Finset`, with almost-everywhere hypotheses, and mention
+no measure on `α`. What is left here is the
 specialisation: it discharges measurability from `measurable_directingMeasure_coe`, which all three
 consumers would otherwise repeat.
 
@@ -60,8 +61,12 @@ lemma integrable_prod_directingMeasure_real [StandardBorelSpace α] [Nonempty α
     (hTail : tailProcess X ≤ mΩ) {r : ℕ} {B : Fin r → Set α}
     (hB : ∀ i, MeasurableSet (B i)) :
     Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν :=
-  TauCeti.MeasureTheory.integrable_prod_toReal
-    (fun i => measurable_directingMeasure_coe hTail (hB i)) fun _ _ => prob_le_one
+  by
+  simpa only [measureReal_def] using
+    TauCeti.MeasureTheory.integrable_prod_toReal
+      (f := fun i ω => directingMeasure μ X ω (B i))
+      (fun i _ => (measurable_directingMeasure_coe hTail (hB i)).aemeasurable)
+      fun _ _ => ae_of_all _ fun _ => prob_le_one
 
 /-- The real integral of the directing-measure product is its `ℝ≥0∞` integral, factor by factor:
 each factor is a finite measure of a set, so `ENNReal.ofReal_toReal` applies. As above, `ν` is an
@@ -72,8 +77,12 @@ lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α]
     (hg_int : Integrable (fun ω => ∏ i, (directingMeasure μ X ω).real (B i)) ν) :
     ENNReal.ofReal (∫ ω, ∏ i, (directingMeasure μ X ω).real (B i) ∂ν)
       = ∫⁻ ω, ∏ i, directingMeasure μ X ω (B i) ∂ν :=
-  TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod
-    (fun _ _ => measure_ne_top _ _) hg_int
+  by
+  simpa only [measureReal_def] using
+    TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod
+      (f := fun i ω => directingMeasure μ X ω (B i))
+      (fun _ _ => ae_of_all _ fun _ => measure_ne_top _ _)
+      (by simpa only [measureReal_def] using hg_int)
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
+++ b/TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean
@@ -81,7 +81,7 @@ lemma ofReal_integral_eq_lintegral_prod_directingMeasure [StandardBorelSpace α]
   simpa only [measureReal_def] using
     TauCeti.MeasureTheory.ofReal_integral_prod_toReal_eq_lintegral_prod
       (f := fun i ω => directingMeasure μ X ω (B i))
-      (fun _ _ => ae_of_all _ fun _ => measure_ne_top _ _)
+      (ae_of_all _ fun _ => ENNReal.prod_ne_top fun _ _ => measure_ne_top _ _)
       (by simpa only [measureReal_def] using hg_int)
 
 end Probability


### PR DESCRIPTION
`TauCeti/Probability/DeFinetti/DirectingMeasure/Integral.lean` carried two facts about
`∏ i, directingMeasure μ X ω (B i)` as a function of `ω`: that its real form is integrable against a
finite measure, and that its real integral agrees with its `ℝ≥0∞` integral.

Neither proof used anything about directing measures. Both only need that each factor is a
measurable `ℝ≥0∞`-valued function bounded by `1` (for integrability) and finite (for the `ofReal`
transfer). Nothing about measures on the state space enters.

This adds `TauCeti/MeasureTheory/Integral/ENNRealProd.lean` stating them at that level, for an
arbitrary family `f : Fin r → Ω → ℝ≥0∞`:

* `integrable_prod_toReal` — a finite product of measurable `[0,1]`-valued functions is integrable
  against a finite measure;
* `ofReal_integral_prod_toReal_eq_lintegral_prod` — `ENNReal.ofReal (∫ ω, ∏ i, (f i ω).toReal ∂ν)
  = ∫⁻ ω, ∏ i, f i ω ∂ν`, given no factor is infinite.

The two directing-measure statements are unchanged and stay in place, now proved as one-line
instances. I kept them deliberately rather than inlining: each discharges the measurability side
condition via `measurable_directingMeasure_coe`, which the three call sites in
`BlockFactorization.lean` and `JointRectangle.lean` would otherwise repeat. They are specialisations
that carry content, not compatibility wrappers.

No statement changes to any existing declaration, and no new mathematics.

The motivation is the Koopman lane, which needs the same product bridge for evaluations of a
measurable family of probability measures that are not directing measures.

Roadmap: Exchangeability

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol