### PR TITLE
refactor: cut a disc by a circle centred anywhere

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -11,6 +11,7 @@ public import TauCeti.Topology.ClusterSet
 public import TauCeti.Topology.MetricSpace.Cut
 import Mathlib.Analysis.Convex.PathConnected
 import Mathlib.Analysis.Normed.Module.RCLike.Real
+import TauCeti.Topology.Circle.Metric
 
 /-!
 # The circular crosscut of a disc at a boundary point
@@ -48,18 +49,19 @@ missing the crosscut lies entirely in one of them.
 
 ## The angular description
 
-Which *angles* the crosscut occupies is the law of cosines, `TauCeti.dist_circleMap_sq`: writing
-`α = arg (c - ζ)` for the direction from `ζ` to the centre and `d = dist ζ c`, the point of
-`sphere ζ ρ` at angle `θ` is at distance `ρ ^ 2 + d ^ 2 - 2 * ρ * d * cos (θ - α)`, squared, from
-`c`, so it lies in the disc exactly when `ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`
-(`TauCeti.circleMap_mem_ball_iff_sq`). Nothing there ties `ζ` to the disc; at a *boundary* point,
-`d = r`, the two squared radii cancel and the condition becomes `ρ < 2 * r * cos (θ - α)`
-(`TauCeti.circleMap_mem_ball_iff`, with the `simp`-normal form `TauCeti.dist_circleMap_lt_iff`
-beside it), so for `0 < ρ < 2 * r` the crosscut consists of the angles *strictly* within
-`arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no angle satisfies the condition and
-`sphere ζ ρ` misses the disc altogether. Rather than name that half-width, the file records only
-that `cos` has no interior minimum on a period centred at `α`, so the condition holds throughout an
-interval of angles as soon as it holds at both ends
+Which *angles* the crosscut occupies is the law of cosines `TauCeti.dist_circleMap_sq` of
+`TauCeti/Topology/Circle/Metric.lean`: writing `α = arg (c - ζ)` for the direction from `ζ` to the
+centre and `d = dist ζ c`, the point of `sphere ζ ρ` at angle `θ` is at distance
+`ρ ^ 2 + d ^ 2 - 2 * ρ * d * cos (θ - α)`, squared, from `c`, so it lies in the disc exactly when
+`ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)` (`TauCeti.circleMap_mem_ball_iff_sq`, with
+`TauCeti.circleMap_mem_closedBall_iff_sq` and the `simp`-normal distance forms of both beside it).
+Nothing there ties `ζ` to the disc; at a *boundary* point, `d = r`, the two squared radii cancel
+and the condition becomes `ρ < 2 * r * cos (θ - α)` (`TauCeti.circleMap_mem_ball_iff`, with the
+`simp`-normal form `TauCeti.dist_circleMap_lt_iff` beside it), so for `0 < ρ < 2 * r` the crosscut
+consists of the angles *strictly* within `arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no
+angle satisfies the condition and `sphere ζ ρ` misses the disc altogether. Rather than name that
+half-width, the file records only that `cos` has no interior minimum on a period centred at `α`, so
+the condition holds throughout an interval of angles as soon as it holds at both ends
 (`TauCeti.circleMap_mem_ball_of_mem_Icc`, for a cutting circle centred anywhere): the crosscut is
 an arc.
 
@@ -118,8 +120,8 @@ functions.
 
 * `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` — the inversion at a boundary point carries a
   disc to a half-plane.
-* `TauCeti.dist_circleMap_sq` — the law of cosines for a point of a circle, from which
-  `TauCeti.circleMap_mem_ball_iff_sq` reads off when that point lies in a disc.
+* `TauCeti.circleMap_mem_ball_iff_sq` and `TauCeti.circleMap_mem_closedBall_iff_sq` — when a point
+  of a circle centred anywhere lies in a disc, read off the law of cosines.
 * `TauCeti.circleMap_mem_ball_iff` and `TauCeti.circleMap_mem_ball_of_mem_Icc` — the angular
   description of a circular crosscut, and the fact that it is an arc of angles; the latter holds
   for a cutting circle centred anywhere, not only at a boundary point of the disc.
@@ -206,47 +208,6 @@ theorem mem_ball_iff_one_lt_two_mul_re_mul_inv (hζ : dist ζ c = r) (hz : z ≠
 
 /-! ## The angular description of a circular crosscut -/
 
-/-- **The law of cosines for a point of a circle.** The point of `sphere ζ ρ` at angle `θ` is at
-distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
-arbitrary point `c`: in the triangle with vertices `ζ`, `circleMap ζ ρ θ` and `c`, the angle at `ζ`
-between the two sides of lengths `ρ` and `dist ζ c` is `θ - arg (c - ζ)`.
-
-Nothing is assumed. For `ρ < 0` the point `circleMap ζ ρ θ` is the one at angle `θ + π` on the
-circle of radius `-ρ`, and the identity still holds because only `ρ ^ 2` and `ρ * cos` occur; for
-`c = ζ` both terms carrying `dist ζ c` vanish, so the junk value `arg 0 = 0` does no harm and the
-identity reads `dist (circleMap ζ ρ θ) ζ ^ 2 = ρ ^ 2`. -/
-theorem dist_circleMap_sq (ζ c : ℂ) (ρ θ : ℝ) :
-    dist (circleMap ζ ρ θ) c ^ 2
-      = ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
-  have hdist : dist ζ c = ‖c - ζ‖ := by rw [dist_eq_norm, norm_sub_rev]
-  have hsub : circleMap ζ ρ θ - c = (ρ : ℂ) * exp ((θ : ℂ) * I) - (c - ζ) := by
-    simp only [circleMap]; ring
-  -- the conjugate of `c - ζ` in polar form, valid at `c = ζ` as well
-  have hconj : (starRingEnd ℂ) (c - ζ)
-      = ((‖c - ζ‖ : ℝ) : ℂ) * exp (((-(c - ζ).arg : ℝ) : ℂ) * I) := by
-    conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I (c - ζ)]
-    rw [map_mul, Complex.conj_ofReal, ← Complex.exp_conj]
-    congr 2
-    push_cast
-    rw [map_mul, Complex.conj_ofReal, Complex.conj_I]
-    ring
-  -- the cross term is the cosine of the angle at `ζ`
-  have hre : ((ρ : ℂ) * exp ((θ : ℂ) * I) * (starRingEnd ℂ) (c - ζ)).re
-      = ρ * ‖c - ζ‖ * Real.cos (θ - (c - ζ).arg) := by
-    have hmul : (ρ : ℂ) * exp ((θ : ℂ) * I) * (starRingEnd ℂ) (c - ζ)
-        = ((ρ * ‖c - ζ‖ : ℝ) : ℂ) * exp (((θ - (c - ζ).arg : ℝ) : ℂ) * I) := by
-      rw [hconj, mul_mul_mul_comm, ← Complex.exp_add]
-      push_cast
-      ring_nf
-    rw [hmul, Complex.re_ofReal_mul, Complex.exp_ofReal_mul_I_re]
-  have hunit : normSq ((ρ : ℂ) * exp ((θ : ℂ) * I)) = ρ ^ 2 := by
-    rw [Complex.normSq_mul, Complex.normSq_ofReal, Complex.normSq_eq_norm_sq,
-      Complex.norm_exp_ofReal_mul_I]
-    ring
-  rw [dist_eq_norm, Complex.sq_norm, hsub, Complex.normSq_sub, hunit, hre,
-    Complex.normSq_eq_norm_sq, hdist]
-  ring
-
 /-- **A circle meets a disc in an arc of angles around the direction of the centre.** For `r ≥ 0`
 and an arbitrary centre `ζ`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly when
 `ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
@@ -263,6 +224,39 @@ theorem circleMap_mem_ball_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
   constructor
   · intro h; linarith
   · intro h; linarith
+
+/-- **A circle meets a disc in an arc of angles around the direction of the centre**, stated in
+`simp` normal form. This is `TauCeti.circleMap_mem_ball_iff_sq` with the membership in `ball c r`
+already unfolded by `Metric.mem_ball`, which is the form a `simp` call leaves the goal in. -/
+@[simp]
+theorem dist_circleMap_lt_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
+    dist (circleMap ζ ρ θ) c < r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) :=
+  circleMap_mem_ball_iff_sq hr ρ θ
+
+/-- **A circle meets a closed disc in a closed arc of angles around the direction of the centre.**
+The weak companion of `TauCeti.circleMap_mem_ball_iff_sq`: for `r ≥ 0` and an arbitrary centre `ζ`,
+the point of `sphere ζ ρ` at angle `θ` lies in `closedBall c r` exactly when
+`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
+
+The boundary-point case `dist ζ c = r`, where the condition collapses to
+`ρ ≤ 2 * r * cos (θ - arg (c - ζ))`, is `TauCeti.circleMap_mem_closedBall_iff`. -/
+theorem circleMap_mem_closedBall_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
+    circleMap ζ ρ θ ∈ closedBall c r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  rw [mem_closedBall, ← sq_le_sq₀ dist_nonneg hr, dist_circleMap_sq]
+  constructor
+  · intro h; linarith
+  · intro h; linarith
+
+/-- **A circle meets a closed disc in a closed arc of angles around the direction of the centre**,
+stated in `simp` normal form. This is `TauCeti.circleMap_mem_closedBall_iff_sq` with the membership
+in `closedBall c r` already unfolded by `Metric.mem_closedBall`. -/
+@[simp]
+theorem dist_circleMap_le_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
+    dist (circleMap ζ ρ θ) c ≤ r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) :=
+  circleMap_mem_closedBall_iff_sq hr ρ θ
 
 /-- **A circular crosscut is an arc of angles around the direction of the centre.** For `ζ` on the
 circle `sphere c r` and `ρ > 0`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -48,17 +48,20 @@ missing the crosscut lies entirely in one of them.
 
 ## The angular description
 
-The same inversion, read in polar coordinates around `ζ`, says which *angles* the crosscut
-occupies. Writing `α = arg (c - ζ)` for the direction from `ζ` to the centre, the point of
-`sphere ζ ρ` at angle `θ` lies in the disc exactly when `ρ < 2 * r * cos (θ - α)`
-(`TauCeti.circleMap_mem_ball_iff`, with the `simp`-normal form
-`TauCeti.dist_circleMap_lt_iff` beside it): for `0 < ρ < 2 * r` the crosscut consists of the angles
-*strictly* within `arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no angle satisfies the
-condition and `sphere ζ ρ` misses the disc altogether. Rather than name that half-width,
-the file records only
+Which *angles* the crosscut occupies is the law of cosines, `TauCeti.dist_circleMap_sq`: writing
+`α = arg (c - ζ)` for the direction from `ζ` to the centre and `d = dist ζ c`, the point of
+`sphere ζ ρ` at angle `θ` is at distance `ρ ^ 2 + d ^ 2 - 2 * ρ * d * cos (θ - α)`, squared, from
+`c`, so it lies in the disc exactly when `ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`
+(`TauCeti.circleMap_mem_ball_iff_sq`). Nothing there ties `ζ` to the disc; at a *boundary* point,
+`d = r`, the two squared radii cancel and the condition becomes `ρ < 2 * r * cos (θ - α)`
+(`TauCeti.circleMap_mem_ball_iff`, with the `simp`-normal form `TauCeti.dist_circleMap_lt_iff`
+beside it), so for `0 < ρ < 2 * r` the crosscut consists of the angles *strictly* within
+`arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no angle satisfies the condition and
+`sphere ζ ρ` misses the disc altogether. Rather than name that half-width, the file records only
 that `cos` has no interior minimum on a period centred at `α`, so the condition holds throughout an
 interval of angles as soon as it holds at both ends
-(`TauCeti.circleMap_mem_ball_of_mem_Icc`): the crosscut is an arc.
+(`TauCeti.circleMap_mem_ball_of_mem_Icc`, for a cutting circle centred anywhere): the crosscut is
+an arc.
 
 ## The boundary criterion
 
@@ -115,8 +118,11 @@ functions.
 
 * `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` — the inversion at a boundary point carries a
   disc to a half-plane.
+* `TauCeti.dist_circleMap_sq` — the law of cosines for a point of a circle, from which
+  `TauCeti.circleMap_mem_ball_iff_sq` reads off when that point lies in a disc.
 * `TauCeti.circleMap_mem_ball_iff` and `TauCeti.circleMap_mem_ball_of_mem_Icc` — the angular
-  description of a circular crosscut, and the fact that it is an arc of angles.
+  description of a circular crosscut, and the fact that it is an arc of angles; the latter holds
+  for a cutting circle centred anywhere, not only at a boundary point of the disc.
 * `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
   connected.
 * `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion — a circular
@@ -200,14 +206,71 @@ theorem mem_ball_iff_one_lt_two_mul_re_mul_inv (hζ : dist ζ c = r) (hz : z ≠
 
 /-! ## The angular description of a circular crosscut -/
 
+/-- **The law of cosines for a point of a circle.** The point of `sphere ζ ρ` at angle `θ` is at
+distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
+arbitrary point `c`: in the triangle with vertices `ζ`, `circleMap ζ ρ θ` and `c`, the angle at `ζ`
+between the two sides of lengths `ρ` and `dist ζ c` is `θ - arg (c - ζ)`.
+
+Nothing is assumed. For `ρ < 0` the point `circleMap ζ ρ θ` is the one at angle `θ + π` on the
+circle of radius `-ρ`, and the identity still holds because only `ρ ^ 2` and `ρ * cos` occur; for
+`c = ζ` both terms carrying `dist ζ c` vanish, so the junk value `arg 0 = 0` does no harm and the
+identity reads `dist (circleMap ζ ρ θ) ζ ^ 2 = ρ ^ 2`. -/
+theorem dist_circleMap_sq (ζ c : ℂ) (ρ θ : ℝ) :
+    dist (circleMap ζ ρ θ) c ^ 2
+      = ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  have hdist : dist ζ c = ‖c - ζ‖ := by rw [dist_eq_norm, norm_sub_rev]
+  have hsub : circleMap ζ ρ θ - c = (ρ : ℂ) * exp ((θ : ℂ) * I) - (c - ζ) := by
+    simp only [circleMap]; ring
+  -- the conjugate of `c - ζ` in polar form, valid at `c = ζ` as well
+  have hconj : (starRingEnd ℂ) (c - ζ)
+      = ((‖c - ζ‖ : ℝ) : ℂ) * exp (((-(c - ζ).arg : ℝ) : ℂ) * I) := by
+    conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I (c - ζ)]
+    rw [map_mul, Complex.conj_ofReal, ← Complex.exp_conj]
+    congr 2
+    push_cast
+    rw [map_mul, Complex.conj_ofReal, Complex.conj_I]
+    ring
+  -- the cross term is the cosine of the angle at `ζ`
+  have hre : ((ρ : ℂ) * exp ((θ : ℂ) * I) * (starRingEnd ℂ) (c - ζ)).re
+      = ρ * ‖c - ζ‖ * Real.cos (θ - (c - ζ).arg) := by
+    have hmul : (ρ : ℂ) * exp ((θ : ℂ) * I) * (starRingEnd ℂ) (c - ζ)
+        = ((ρ * ‖c - ζ‖ : ℝ) : ℂ) * exp (((θ - (c - ζ).arg : ℝ) : ℂ) * I) := by
+      rw [hconj, mul_mul_mul_comm, ← Complex.exp_add]
+      push_cast
+      ring_nf
+    rw [hmul, Complex.re_ofReal_mul, Complex.exp_ofReal_mul_I_re]
+  have hunit : normSq ((ρ : ℂ) * exp ((θ : ℂ) * I)) = ρ ^ 2 := by
+    rw [Complex.normSq_mul, Complex.normSq_ofReal, Complex.normSq_eq_norm_sq,
+      Complex.norm_exp_ofReal_mul_I]
+    ring
+  rw [dist_eq_norm, Complex.sq_norm, hsub, Complex.normSq_sub, hunit, hre,
+    Complex.normSq_eq_norm_sq, hdist]
+  ring
+
+/-- **A circle meets a disc in an arc of angles around the direction of the centre.** For `r ≥ 0`
+and an arbitrary centre `ζ`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly when
+`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
+
+This is `TauCeti.dist_circleMap_sq` compared with `r ^ 2`, both sides of `dist … < r` being
+nonnegative. The right-hand side depends on `θ` only through `cos (θ - arg (c - ζ))`, which is what
+makes the intersection an arc (`TauCeti.circleMap_mem_ball_of_mem_Icc`); the boundary-point case
+`dist ζ c = r`, where the condition collapses to `ρ < 2 * r * cos (θ - arg (c - ζ))`, is
+`TauCeti.circleMap_mem_ball_iff`. -/
+theorem circleMap_mem_ball_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
+    circleMap ζ ρ θ ∈ ball c r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  rw [mem_ball, ← sq_lt_sq₀ dist_nonneg hr, dist_circleMap_sq]
+  constructor
+  · intro h; linarith
+  · intro h; linarith
+
 /-- **A circular crosscut is an arc of angles around the direction of the centre.** For `ζ` on the
 circle `sphere c r` and `ρ > 0`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly
 when `ρ < 2 * r * cos (θ - arg (c - ζ))`.
 
-This is the inversion identity `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` written in polar
-form: with `c - ζ = r * exp (arg (c - ζ) * I)`, the inverted point
-`(c - ζ) * (circleMap ζ ρ θ - ζ)⁻¹` is `(r / ρ) * exp ((arg (c - ζ) - θ) * I)`, whose real part is
-`(r / ρ) * cos (θ - arg (c - ζ))`.
+This is the general criterion `TauCeti.circleMap_mem_ball_iff_sq` at `dist ζ c = r`, where the two
+squared radii cancel and the surviving condition `ρ ^ 2 < 2 * ρ * r * cos (θ - arg (c - ζ))` may be
+divided by `ρ > 0`.
 
 Nothing is assumed of `r` beyond what `dist ζ c = r` forces; for `r = 0` both sides are false.
 
@@ -217,35 +280,10 @@ linter rejects the attribute. The `simp`-normal companion is
 `TauCeti.dist_circleMap_lt_iff`. -/
 theorem circleMap_mem_ball_iff (hζ : dist ζ c = r) (hρ : 0 < ρ) (θ : ℝ) :
     circleMap ζ ρ θ ∈ ball c r ↔ ρ < 2 * r * Real.cos (θ - (c - ζ).arg) := by
-  have hnorm : ‖c - ζ‖ = r := by rw [← dist_eq_norm, dist_comm, hζ]
-  have hpolar : c - ζ = (r : ℂ) * exp (((c - ζ).arg : ℂ) * I) := by
-    conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I (c - ζ)]
-    rw [hnorm]
-  have hsphere : circleMap ζ ρ θ ∈ sphere ζ ρ := circleMap_mem_sphere ζ hρ.le θ
-  have hne : circleMap ζ ρ θ ≠ ζ := by
-    intro h
-    rw [mem_sphere, h, dist_self] at hsphere
-    exact hρ.ne hsphere
-  have hsub : circleMap ζ ρ θ - ζ = (ρ : ℂ) * exp ((θ : ℂ) * I) := by
-    rw [circleMap_sub_center, circleMap_zero]
-  have hexp : exp (((c - ζ).arg : ℂ) * I) * (exp ((θ : ℂ) * I))⁻¹
-      = exp ((((c - ζ).arg - θ : ℝ) : ℂ) * I) := by
-    rw [← Complex.exp_neg, ← Complex.exp_add]
-    push_cast
-    ring_nf
-  have hprod : (c - ζ) * (circleMap ζ ρ θ - ζ)⁻¹
-      = ((r * ρ⁻¹ : ℝ) : ℂ) * exp ((((c - ζ).arg - θ : ℝ) : ℂ) * I) := by
-    rw [hsub, mul_inv, ← hexp]
-    conv_lhs => rw [hpolar]
-    push_cast
-    ring
-  -- the half-plane condition, cleared of the inversion
-  have hre : 2 * ((c - ζ) * (circleMap ζ ρ θ - ζ)⁻¹).re
-      = 2 * r * Real.cos (θ - (c - ζ).arg) / ρ := by
-    rw [hprod, Complex.re_ofReal_mul, Complex.exp_ofReal_mul_I_re, ← Real.cos_neg, neg_sub,
-      eq_div_iff hρ.ne']
-    field_simp
-  rw [mem_ball_iff_one_lt_two_mul_re_mul_inv hζ hne, hre, lt_div_iff₀ hρ, one_mul]
+  rw [circleMap_mem_ball_iff_sq (hζ ▸ dist_nonneg) ρ θ, hζ]
+  constructor
+  · intro h; nlinarith
+  · intro h; nlinarith
 
 /-- **A circular crosscut is an arc of angles around the direction of the centre**, stated in
 `simp` normal form. This is `TauCeti.circleMap_mem_ball_iff` with the membership in `ball c r`
@@ -280,27 +318,36 @@ private theorem lt_cos_of_mem_Icc {k a b θ : ℝ} (ha : -π ≤ a) (hb : b ≤ 
     exact Real.cos_le_cos_of_nonneg_of_le_pi (by linarith) (by linarith) (by linarith [hθ.1])
   · exact hkb.trans_le (Real.cos_le_cos_of_nonneg_of_le_pi hθ0 hb hθ.2)
 
-/-- **A circular crosscut is connected as a set of angles.** If the angles `a` and `b` both lie
-within `π` of the direction `arg (c - ζ)` of the centre and both put the point of `sphere ζ ρ` they
-name inside `ball c r`, then so does every angle in `[a, b]`.
+/-- **A circle meets a disc in a connected set of angles.** If the angles `a` and `b` both lie
+within `π` of the direction `arg (c - ζ)` from the centre `ζ` of the circle to the centre `c` of
+the disc, and both put the point of `sphere ζ ρ` they name inside `ball c r`, then so does every
+angle in `[a, b]`.
 
-This is `TauCeti.circleMap_mem_ball_iff` read through the unimodality of `cos` on a period centred
-at `arg (c - ζ)`; positivity of `r` is not assumed, being forced by the hypotheses. -/
-theorem circleMap_mem_ball_of_mem_Icc (hζ : dist ζ c = r) (hρ : 0 < ρ) {a b θ : ℝ}
+This is `TauCeti.circleMap_mem_ball_iff_sq` read through the unimodality of `cos` on a period
+centred at `arg (c - ζ)`. Neither `0 < r` nor any relation between `ζ` and the disc is assumed: the
+first is forced by the hypotheses, and the second is not needed, so the conclusion covers a cutting
+circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. A
+circle centred at `c` itself is the degenerate case, its points being all at the same distance from
+`c`; the criterion is then independent of the angle. -/
+theorem circleMap_mem_ball_of_mem_Icc (hρ : 0 < ρ) {a b θ : ℝ}
     (ha : -π ≤ a - (c - ζ).arg) (hb : b - (c - ζ).arg ≤ π) (hθ : θ ∈ Icc a b)
     (hain : circleMap ζ ρ a ∈ ball c r) (hbin : circleMap ζ ρ b ∈ ball c r) :
     circleMap ζ ρ θ ∈ ball c r := by
-  rw [circleMap_mem_ball_iff hζ hρ] at hain hbin ⊢
-  have hr : 0 < r := by
-    rcases (hζ ▸ dist_nonneg : (0 : ℝ) ≤ r).eq_or_lt with h | h
-    · rw [← h, mul_zero, zero_mul] at hain
-      linarith
-    · exact h
-  have hkey : ∀ x : ℝ, (ρ < 2 * r * Real.cos (x - (c - ζ).arg))
-      ↔ ρ / (2 * r) < Real.cos (x - (c - ζ).arg) := fun x => by
-    rw [div_lt_iff₀ (by linarith), mul_comm]
-  rw [hkey] at hain hbin ⊢
-  exact lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
+  have hr : 0 < r := dist_nonneg.trans_lt (mem_ball.mp hain)
+  rw [circleMap_mem_ball_iff_sq hr.le] at hain hbin ⊢
+  rcases (dist_nonneg : (0 : ℝ) ≤ dist ζ c).eq_or_lt with hd | hd
+  · -- a circle centred at `c`: the criterion does not see the angle at all
+    rw [← hd] at hain ⊢
+    linarith
+  · -- otherwise divide by `2 * ρ * dist ζ c` and use that `cos` has no interior minimum
+    have hpos : 0 < 2 * ρ * dist ζ c := by positivity
+    have hkey : ∀ x : ℝ, (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2
+          < 2 * ρ * dist ζ c * Real.cos (x - (c - ζ).arg))
+        ↔ (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2) / (2 * ρ * dist ζ c)
+          < Real.cos (x - (c - ζ).arg) := fun x => by
+      rw [div_lt_iff₀ hpos, mul_comm]
+    rw [hkey] at hain hbin ⊢
+    exact lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
 
 /-! ## The two sides of a circular crosscut -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -49,21 +49,22 @@ missing the crosscut lies entirely in one of them.
 
 ## The angular description
 
-Which *angles* the crosscut occupies is the law of cosines `TauCeti.dist_circleMap_sq` of
-`TauCeti/Topology/Circle/Metric.lean`: writing `α = arg (c - ζ)` for the direction from `ζ` to the
-centre and `d = dist ζ c`, the point of `sphere ζ ρ` at angle `θ` is at distance
-`ρ ^ 2 + d ^ 2 - 2 * ρ * d * cos (θ - α)`, squared, from `c`, so it lies in the disc exactly when
-`ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)` (`TauCeti.circleMap_mem_ball_iff_sq`, with
-`TauCeti.circleMap_mem_closedBall_iff_sq` and the `simp`-normal distance forms of both beside it).
-Nothing there ties `ζ` to the disc; at a *boundary* point, `d = r`, the two squared radii cancel
-and the condition becomes `ρ < 2 * r * cos (θ - α)` (`TauCeti.circleMap_mem_ball_iff`, with the
-`simp`-normal form `TauCeti.dist_circleMap_lt_iff` beside it), so for `0 < ρ < 2 * r` the crosscut
-consists of the angles *strictly* within `arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no
-angle satisfies the condition and `sphere ζ ρ` misses the disc altogether. Rather than name that
-half-width, the file records only that `cos` has no interior minimum on a period centred at `α`, so
-the condition holds throughout an interval of angles as soon as it holds at both ends
-(`TauCeti.circleMap_mem_ball_of_mem_Icc`, for a cutting circle centred anywhere): the crosscut is
-an arc.
+Which *angles* the crosscut occupies is settled in `TauCeti/Topology/Circle/Metric.lean`, where
+nothing ties the cutting circle to the disc: writing `α = arg (c - ζ)` for the direction from `ζ`
+to the centre and `d = dist ζ c`, the law of cosines `TauCeti.dist_circleMap_sq` puts the point of
+`sphere ζ ρ` at angle `θ` at distance `ρ ^ 2 + d ^ 2 - 2 * ρ * d * cos (θ - α)`, squared, from `c`,
+so it lies in the disc exactly when `ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`
+(`TauCeti.circleMap_mem_ball_iff_sq`, with `TauCeti.circleMap_mem_closedBall_iff_sq` beside it),
+and that condition holds throughout an interval of angles inside a period centred at `α` as soon
+as it holds at both ends (`TauCeti.circleMap_mem_ball_of_mem_Icc`).
+
+What this file adds is the *boundary-point* reading of that criterion, where `d = r`: the two
+squared radii cancel and the condition becomes `ρ < 2 * r * cos (θ - α)`
+(`TauCeti.circleMap_mem_ball_iff`, with the `simp`-normal form `TauCeti.dist_circleMap_lt_iff`
+beside it), so for `0 < ρ < 2 * r` the crosscut consists of the angles *strictly* within
+`arccos (ρ / (2 * r))` of `α`, while for `2 * r ≤ ρ` no angle satisfies the condition and
+`sphere ζ ρ` misses the disc altogether. Rather than name that half-width, the arc statement is
+left in its general form: the crosscut is an arc.
 
 ## The boundary criterion
 
@@ -120,11 +121,9 @@ functions.
 
 * `TauCeti.mem_ball_iff_one_lt_two_mul_re_mul_inv` — the inversion at a boundary point carries a
   disc to a half-plane.
-* `TauCeti.circleMap_mem_ball_iff_sq` and `TauCeti.circleMap_mem_closedBall_iff_sq` — when a point
-  of a circle centred anywhere lies in a disc, read off the law of cosines.
-* `TauCeti.circleMap_mem_ball_iff` and `TauCeti.circleMap_mem_ball_of_mem_Icc` — the angular
-  description of a circular crosscut, and the fact that it is an arc of angles; the latter holds
-  for a cutting circle centred anywhere, not only at a boundary point of the disc.
+* `TauCeti.circleMap_mem_ball_iff` — the angular description of a circular crosscut, the
+  boundary-point case of the criterion `TauCeti.circleMap_mem_ball_iff_sq` of
+  `TauCeti/Topology/Circle/Metric.lean`, which also supplies the fact that the angles form an arc.
 * `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
   connected.
 * `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion — a circular
@@ -208,63 +207,13 @@ theorem mem_ball_iff_one_lt_two_mul_re_mul_inv (hζ : dist ζ c = r) (hz : z ≠
 
 /-! ## The angular description of a circular crosscut -/
 
-/-- **A circle meets a disc in an arc of angles around the direction of the centre.** For `r ≥ 0`
-and an arbitrary centre `ζ`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly when
-`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
-
-This is `TauCeti.dist_circleMap_sq` compared with `r ^ 2`, both sides of `dist … < r` being
-nonnegative. The right-hand side depends on `θ` only through `cos (θ - arg (c - ζ))`, which is what
-makes the intersection an arc (`TauCeti.circleMap_mem_ball_of_mem_Icc`); the boundary-point case
-`dist ζ c = r`, where the condition collapses to `ρ < 2 * r * cos (θ - arg (c - ζ))`, is
-`TauCeti.circleMap_mem_ball_iff`. -/
-theorem circleMap_mem_ball_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
-    circleMap ζ ρ θ ∈ ball c r ↔
-      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
-  rw [mem_ball, ← sq_lt_sq₀ dist_nonneg hr, dist_circleMap_sq]
-  constructor
-  · intro h; linarith
-  · intro h; linarith
-
-/-- **A circle meets a disc in an arc of angles around the direction of the centre**, stated in
-`simp` normal form. This is `TauCeti.circleMap_mem_ball_iff_sq` with the membership in `ball c r`
-already unfolded by `Metric.mem_ball`, which is the form a `simp` call leaves the goal in. -/
-@[simp]
-theorem dist_circleMap_lt_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
-    dist (circleMap ζ ρ θ) c < r ↔
-      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) :=
-  circleMap_mem_ball_iff_sq hr ρ θ
-
-/-- **A circle meets a closed disc in a closed arc of angles around the direction of the centre.**
-The weak companion of `TauCeti.circleMap_mem_ball_iff_sq`: for `r ≥ 0` and an arbitrary centre `ζ`,
-the point of `sphere ζ ρ` at angle `θ` lies in `closedBall c r` exactly when
-`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
-
-The boundary-point case `dist ζ c = r`, where the condition collapses to
-`ρ ≤ 2 * r * cos (θ - arg (c - ζ))`, is `TauCeti.circleMap_mem_closedBall_iff`. -/
-theorem circleMap_mem_closedBall_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
-    circleMap ζ ρ θ ∈ closedBall c r ↔
-      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
-  rw [mem_closedBall, ← sq_le_sq₀ dist_nonneg hr, dist_circleMap_sq]
-  constructor
-  · intro h; linarith
-  · intro h; linarith
-
-/-- **A circle meets a closed disc in a closed arc of angles around the direction of the centre**,
-stated in `simp` normal form. This is `TauCeti.circleMap_mem_closedBall_iff_sq` with the membership
-in `closedBall c r` already unfolded by `Metric.mem_closedBall`. -/
-@[simp]
-theorem dist_circleMap_le_iff_sq (hr : 0 ≤ r) (ρ θ : ℝ) :
-    dist (circleMap ζ ρ θ) c ≤ r ↔
-      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) :=
-  circleMap_mem_closedBall_iff_sq hr ρ θ
-
 /-- **A circular crosscut is an arc of angles around the direction of the centre.** For `ζ` on the
 circle `sphere c r` and `ρ > 0`, the point of `sphere ζ ρ` at angle `θ` lies in `ball c r` exactly
 when `ρ < 2 * r * cos (θ - arg (c - ζ))`.
 
-This is the general criterion `TauCeti.circleMap_mem_ball_iff_sq` at `dist ζ c = r`, where the two
-squared radii cancel and the surviving condition `ρ ^ 2 < 2 * ρ * r * cos (θ - arg (c - ζ))` may be
-divided by `ρ > 0`.
+This is the general criterion `TauCeti.circleMap_mem_ball_iff_sq` of
+`TauCeti/Topology/Circle/Metric.lean` at `dist ζ c = r`, where the two squared radii cancel and the
+surviving condition `ρ ^ 2 < 2 * ρ * r * cos (θ - arg (c - ζ))` may be divided by `ρ > 0`.
 
 Nothing is assumed of `r` beyond what `dist ζ c = r` forces; for `r = 0` both sides are false.
 
@@ -300,48 +249,6 @@ theorem exists_mem_Icc_circleMap_eq (α : ℝ) {z : ℂ} (hz : z ∈ sphere ζ �
   constructor
   · linarith [hθ.1]
   · linarith [hθ.2]
-
-/-- **The cosine has no interior minimum on `[-π, π]`.** If `k < cos a` and `k < cos b`, with
-`-π ≤ a` and `b ≤ π`, then `k < cos θ` for every `θ ∈ [a, b]`: `cos` increases on `[-π, 0]` and
-decreases on `[0, π]`, so on `[a, b]` its minimum is attained at an endpoint. -/
-private theorem lt_cos_of_mem_Icc {k a b θ : ℝ} (ha : -π ≤ a) (hb : b ≤ π) (hθ : θ ∈ Icc a b)
-    (hka : k < Real.cos a) (hkb : k < Real.cos b) : k < Real.cos θ := by
-  rcases le_total θ 0 with hθ0 | hθ0
-  · refine hka.trans_le ?_
-    rw [← Real.cos_neg θ, ← Real.cos_neg a]
-    exact Real.cos_le_cos_of_nonneg_of_le_pi (by linarith) (by linarith) (by linarith [hθ.1])
-  · exact hkb.trans_le (Real.cos_le_cos_of_nonneg_of_le_pi hθ0 hb hθ.2)
-
-/-- **A circle meets a disc in a connected set of angles.** If the angles `a` and `b` both lie
-within `π` of the direction `arg (c - ζ)` from the centre `ζ` of the circle to the centre `c` of
-the disc, and both put the point of `sphere ζ ρ` they name inside `ball c r`, then so does every
-angle in `[a, b]`.
-
-This is `TauCeti.circleMap_mem_ball_iff_sq` read through the unimodality of `cos` on a period
-centred at `arg (c - ζ)`. Neither `0 < r` nor any relation between `ζ` and the disc is assumed: the
-first is forced by the hypotheses, and the second is not needed, so the conclusion covers a cutting
-circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. A
-circle centred at `c` itself is the degenerate case, its points being all at the same distance from
-`c`; the criterion is then independent of the angle. -/
-theorem circleMap_mem_ball_of_mem_Icc (hρ : 0 < ρ) {a b θ : ℝ}
-    (ha : -π ≤ a - (c - ζ).arg) (hb : b - (c - ζ).arg ≤ π) (hθ : θ ∈ Icc a b)
-    (hain : circleMap ζ ρ a ∈ ball c r) (hbin : circleMap ζ ρ b ∈ ball c r) :
-    circleMap ζ ρ θ ∈ ball c r := by
-  have hr : 0 < r := dist_nonneg.trans_lt (mem_ball.mp hain)
-  rw [circleMap_mem_ball_iff_sq hr.le] at hain hbin ⊢
-  rcases (dist_nonneg : (0 : ℝ) ≤ dist ζ c).eq_or_lt with hd | hd
-  · -- a circle centred at `c`: the criterion does not see the angle at all
-    rw [← hd] at hain ⊢
-    linarith
-  · -- otherwise divide by `2 * ρ * dist ζ c` and use that `cos` has no interior minimum
-    have hpos : 0 < 2 * ρ * dist ζ c := by positivity
-    have hkey : ∀ x : ℝ, (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2
-          < 2 * ρ * dist ζ c * Real.cos (x - (c - ζ).arg))
-        ↔ (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2) / (2 * ρ * dist ζ c)
-          < Real.cos (x - (c - ζ).arg) := fun x => by
-      rw [div_lt_iff₀ hpos, mul_comm]
-    rw [hkey] at hain hbin ⊢
-    exact lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
 
 /-! ## The two sides of a circular crosscut -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -160,7 +160,7 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
   have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
     (hlen.trans ENNReal.ofReal_lt_top).ne
   have hdiam : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
-    diam_image_ball_inter_sphere_le hρmem.1 hf hε.le hlen.le
+    diam_image_ball_inter_sphere_le hf hε.le hlen.le
   obtain ⟨u, v, hpair⟩ := exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair hζ hρmem.1
     (hρmem.2.trans_le (min_le_right _ _)) hf hinj hfin'
   have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
@@ -168,7 +168,7 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
   have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert_of_mem _ rfl
   have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
-    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hρmem.1 hf hfin'
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hfin'
   exact ⟨ρ, ⟨hρmem.1, hρmem.2.trans_le (min_le_left _ _)⟩, u, v, hpair,
     (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
       ((diam_frontier_inter_closure_image_inter_sphere_le hb).trans hdiam), hdiam⟩

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/BoundaryEnds.lean
@@ -160,7 +160,7 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
   have hfin' : circleImageLength f (ball c r) ζ ρ ≠ ⊤ :=
     (hlen.trans ENNReal.ofReal_lt_top).ne
   have hdiam : diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
-    diam_image_ball_inter_sphere_le hζ hρmem.1 hf hε.le hlen.le
+    diam_image_ball_inter_sphere_le hρmem.1 hf hε.le hlen.le
   obtain ⟨u, v, hpair⟩ := exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair hζ hρmem.1
     (hρmem.2.trans_le (min_le_right _ _)) hf hinj hfin'
   have hu : u ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
@@ -168,7 +168,7 @@ theorem exists_frontier_inter_closure_image_ball_inter_sphere_eq_pair_dist_le
   have hv : v ∈ frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ)) := by
     rw [hpair]; exact mem_insert_of_mem _ rfl
   have hb : IsBounded (f '' (ball c r ∩ sphere ζ ρ)) :=
-    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρmem.1 hf hfin'
+    isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hρmem.1 hf hfin'
   exact ⟨ρ, ⟨hρmem.1, hρmem.2.trans_le (min_le_left _ _)⟩, u, v, hpair,
     (dist_le_diam_of_mem (hb.closure.subset inter_subset_right) hu hv).trans
       ((diam_frontier_inter_closure_image_inter_sphere_le hb).trans hdiam), hdiam⟩

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -112,28 +112,18 @@ private lemma ordConnected_Ioo_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : �
 
 /-- A point of `sphere ζ ρ`, in angular coordinates, lies in `closedBall c r` exactly when its
 angle satisfies the weak cosine inequality complementary to
-`TauCeti.circleMap_mem_ball_iff`. -/
+`TauCeti.circleMap_mem_ball_iff`.
+
+This is the general criterion `TauCeti.circleMap_mem_closedBall_iff_sq` at `dist ζ c = r`, where
+the two squared radii cancel and the surviving condition
+`ρ ^ 2 ≤ 2 * ρ * r * cos (θ - arg (c - ζ))` may be divided by `ρ > 0`. -/
 theorem circleMap_mem_closedBall_iff (hζ : dist ζ c = r) (hρ : 0 < ρ) (θ : ℝ) :
     circleMap ζ ρ θ ∈ closedBall c r ↔
       ρ ≤ 2 * r * Real.cos (θ - (c - ζ).arg) := by
-  rw [mem_closedBall]
-  have hr : 0 ≤ r := hζ ▸ dist_nonneg
-  have hd : dist (circleMap ζ ρ θ) c ^ 2
-      = ρ ^ 2 + r ^ 2 - 2 * ρ * r * Real.cos (θ - (c - ζ).arg) := by
-    rw [dist_circleMap_sq, hζ]
+  rw [circleMap_mem_closedBall_iff_sq (hζ ▸ dist_nonneg) ρ θ, hζ]
   constructor
-  · intro h
-    have hsq : dist (circleMap ζ ρ θ) c ^ 2 ≤ r ^ 2 := by
-      nlinarith [dist_nonneg (x := circleMap ζ ρ θ) (y := c)]
-    have hprod : ρ * (ρ - 2 * r * Real.cos (θ - (c - ζ).arg)) ≤ 0 := by
-      nlinarith
-    apply le_of_sub_nonpos
-    by_contra hnot
-    exact (not_lt_of_ge hprod) (mul_pos hρ (lt_of_not_ge hnot))
-  · intro h
-    have hprod : ρ * (ρ - 2 * r * Real.cos (θ - (c - ζ).arg)) ≤ 0 :=
-      mul_nonpos_of_nonneg_of_nonpos hρ.le (sub_nonpos.mpr h)
-    nlinarith [dist_nonneg (x := circleMap ζ ρ θ) (y := c)]
+  · intro h; nlinarith
+  · intro h; nlinarith
 
 /-- The `simp`-normal form of `TauCeti.circleMap_mem_closedBall_iff`. -/
 @[simp]

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -76,48 +76,6 @@ variable {c ζ : ℂ} {r ρ : ℝ}
 
 /-! ## Metric and angular descriptions -/
 
-/-- The squared distance from a point on `sphere ζ ρ` to `c`, in angular coordinates based at the
-direction from `ζ` to `c`. This is the cosine rule in the form underlying circular crosscuts. -/
-private theorem dist_circleMap_sq (hζ : dist ζ c = r) (θ : ℝ) :
-    dist (circleMap ζ ρ θ) c ^ 2 =
-      ρ ^ 2 + r ^ 2 - 2 * ρ * r * Real.cos (θ - (c - ζ).arg) := by
-  have hnorm : ‖c - ζ‖ = r := by rw [← dist_eq_norm, dist_comm, hζ]
-  have hpolar : c - ζ = (r : ℂ) * exp (((c - ζ).arg : ℂ) * I) := by
-    conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I (c - ζ)]
-    rw [hnorm]
-  have hsub : circleMap ζ ρ θ - c =
-      (ρ : ℂ) * exp ((θ : ℂ) * I) - (c - ζ) := by
-    simp only [circleMap]
-    ring
-  have hu : normSq ((ρ : ℂ) * exp ((θ : ℂ) * I)) = ρ ^ 2 := by
-    rw [Complex.normSq_eq_norm_sq, Complex.norm_mul, Complex.norm_exp_ofReal_mul_I, mul_one,
-      norm_real, Real.norm_eq_abs, sq_abs]
-  have ha : normSq (c - ζ) = r ^ 2 := by
-    rw [Complex.normSq_eq_norm_sq, hnorm]
-  have hare : (c - ζ).re = r * Real.cos (c - ζ).arg := by
-    calc
-      (c - ζ).re = ((r : ℂ) * exp (((c - ζ).arg : ℂ) * I)).re :=
-        congrArg Complex.re hpolar
-      _ = r * Real.cos (c - ζ).arg := by simp [Complex.mul_re]
-  have haim : (c - ζ).im = r * Real.sin (c - ζ).arg := by
-    calc
-      (c - ζ).im = ((r : ℂ) * exp (((c - ζ).arg : ℂ) * I)).im :=
-        congrArg Complex.im hpolar
-      _ = r * Real.sin (c - ζ).arg := by simp [Complex.mul_im]
-  have hcross :
-      (((ρ : ℂ) * exp ((θ : ℂ) * I)) * (starRingEnd ℂ) (c - ζ)).re =
-        ρ * r * Real.cos (θ - (c - ζ).arg) := by
-    calc
-      (((ρ : ℂ) * exp ((θ : ℂ) * I)) * (starRingEnd ℂ) (c - ζ)).re =
-          (ρ * Real.cos θ) * (c - ζ).re + (ρ * Real.sin θ) * (c - ζ).im := by
-            simp [Complex.mul_re, Complex.mul_im]
-            ring
-      _ = ρ * r * Real.cos (θ - (c - ζ).arg) := by
-        rw [hare, haim, Real.cos_sub]
-        ring
-  rw [dist_eq_norm, ← Complex.normSq_eq_norm_sq, hsub, Complex.normSq_sub, hu, ha, hcross]
-  ring
-
 /-- **A ball centred at a point of an arc of angular width at most `π` meets it in an arc.** The
 chord distance to a fixed angle `θ₀` of the arc falls and then rises as the angle sweeps across the
 arc, so the angles it keeps below a threshold form an interval. -/
@@ -160,7 +118,9 @@ theorem circleMap_mem_closedBall_iff (hζ : dist ζ c = r) (hρ : 0 < ρ) (θ : 
       ρ ≤ 2 * r * Real.cos (θ - (c - ζ).arg) := by
   rw [mem_closedBall]
   have hr : 0 ≤ r := hζ ▸ dist_nonneg
-  have hd := dist_circleMap_sq (ρ := ρ) hζ θ
+  have hd : dist (circleMap ζ ρ θ) c ^ 2
+      = ρ ^ 2 + r ^ 2 - 2 * ρ * r * Real.cos (θ - (c - ζ).arg) := by
+    rw [dist_circleMap_sq, hζ]
   constructor
   · intro h
     have hsq : dist (circleMap ζ ρ θ) c ^ 2 ≤ r ^ 2 := by

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -145,7 +145,7 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere (hζ : dist ζ c = 
       (hf.continuousOn _ (hmaps hθ)).comp
         (continuous_circleMap ζ ρ).continuousAt.continuousWithinAt hmaps
   have hgb : IsBounded (g '' Ioo a b) := by
-    have hb := isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hζ hρ hf hfin
+    have hb := isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hρ hf hfin
     rw [hcrosscut, image_image] at hb
     simpa only [g, Function.comp_def] using hb
   have hglim : ∀ θ ∈ frontier (Ioo a b), ∃ v,

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -145,7 +145,7 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere (hζ : dist ζ c = 
       (hf.continuousOn _ (hmaps hθ)).comp
         (continuous_circleMap ζ ρ).continuousAt.continuousWithinAt hmaps
   have hgb : IsBounded (g '' Ioo a b) := by
-    have hb := isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hρ hf hfin
+    have hb := isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top hf hfin
     rw [hcrosscut, image_image] at hb
     simpa only [g, Function.comp_def] using hb
   have hglim : ∀ θ ∈ frontier (Ioo a b), ∃ v,

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -16,10 +16,10 @@ public import TauCeti.Analysis.Complex.Conformal.LengthArea
 `TauCeti.ofReal_dist_le_circleImageLength`, which controls the distance between the images of the
 two endpoints of an *arc of angles*. It leaves open, in its own words, the step of "turning that
 into a crosscut of small diameter at a boundary point". This file takes that step: it reads the
-intersection `ball c r ∩ sphere ζ ρ` of the circle `sphere ζ ρ` with the disc — the **circular
-crosscut** of `Conformal/Crosscut/Basic.lean` when `ρ < 2 * r`, and empty otherwise — as an arc of
-angles, and concludes that its image under a conformal map has small diameter at suitable radii
-`ρ`.
+intersection `ball c r ∩ sphere ζ ρ` of the circle `sphere ζ ρ` with the disc — at a boundary
+point, `dist ζ c = r`, the **circular crosscut** of `Conformal/Crosscut/Basic.lean` when
+`ρ < 2 * r`, and empty otherwise — as an arc of angles, and concludes that its image under a
+conformal map has small diameter at suitable radii `ρ`.
 
 That is the first of the two geometric inputs
 `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le` of
@@ -32,7 +32,8 @@ crosscut cuts off — is a matter of local connectedness of that boundary and is
 
 Everything rests on the angular description of the intersection proved in
 `Conformal/Crosscut/Basic.lean`. Writing `α = arg (c - ζ)` for the direction from `ζ` to the centre
-of the disc and `d = dist ζ c`, the law of cosines `TauCeti.dist_circleMap_sq` says that
+of the disc and `d = dist ζ c`, the criterion `TauCeti.circleMap_mem_ball_iff_sq` read off the law
+of cosines says that
 
 > `circleMap ζ ρ θ ∈ ball c r ↔ ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`,
 
@@ -169,11 +170,11 @@ theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
 
 /-! ## Crosscuts with a short image -/
 
-/-- **A holomorphic map of finite Dirichlet integral has short image crosscuts at every boundary
-point.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤` and an
-arbitrary `ζ`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
-which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory
-correspondence uses is `ζ` on the circle `sphere c r`, where the intersection is a crosscut.
+/-- **A holomorphic map of finite Dirichlet integral has short image crosscuts.** For `f`
+holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤` and an arbitrary `ζ`, every
+tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at which the image of
+`ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory correspondence uses is
+`ζ` on the circle `sphere c r`, where the intersection is a crosscut.
 
 This is the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` of Wolff's
 lemma fed to `TauCeti.diam_image_ball_inter_sphere_le`. The annulus in which the good `ρ` is sought
@@ -182,8 +183,11 @@ average of `circleImageLength f (ball c r) ζ ρ ^ 2` over it falls below the th
 shrunk against `R` so that the radius produced lies in `Ioo 0 R`.
 
 The bound is on the intersection `ball c r ∩ sphere ζ ρ`, which is a genuine circular crosscut only
-when `ρ < 2 * r`, being empty otherwise; since `R` is arbitrary, a caller wanting a crosscut applies
-the theorem with `R ≤ 2 * r`.
+at a boundary point, `dist ζ c = r`, and there only when `ρ < 2 * r`, the intersection being empty
+otherwise; since `R` is arbitrary, a caller wanting a crosscut applies the theorem at such a `ζ`
+with `R ≤ 2 * r`. Neither restriction is imposed here, and away from the boundary circle neither
+holds: a cutting circle centred at `c` itself meets the disc in the whole of `sphere c ρ` for
+`ρ < r`, and one centred far outside meets it at radii `ρ` far above `2 * r`.
 
 This is the first of the two geometric inputs of
 `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`; nothing here bounds
@@ -204,9 +208,10 @@ theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top
 for `f` injective on `ball c r` with bounded image the Dirichlet integral is the area of that image,
 hence finite by `TauCeti.lintegral_enorm_deriv_sq_ne_top_of_isBounded`.
 
-As there, the intersection bounded is a genuine circular crosscut only when `ρ < 2 * r`, being
-empty otherwise — in particular when `r = 0`, which the hypotheses allow; a caller wanting a
-crosscut applies the theorem with `R ≤ 2 * r`. -/
+As there, the intersection bounded is a genuine circular crosscut only at a boundary point,
+`dist ζ c = r`, and there only when `ρ < 2 * r`, the intersection being empty otherwise — in
+particular empty when `r = 0`, which the hypotheses allow; a caller wanting a crosscut applies the
+theorem at such a `ζ` with `R ≤ 2 * r`. -/
 theorem exists_diam_image_ball_inter_sphere_le
     (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 public import TauCeti.Analysis.Complex.Conformal.LengthArea
+import TauCeti.Topology.Circle.Metric
 
 /-!
 # A circular crosscut with a short image
@@ -31,9 +32,9 @@ crosscut cuts off — is a matter of local connectedness of that boundary and is
 ## The intersection is an arc
 
 Everything rests on the angular description of the intersection proved in
-`Conformal/Crosscut/Basic.lean`. Writing `α = arg (c - ζ)` for the direction from `ζ` to the centre
-of the disc and `d = dist ζ c`, the criterion `TauCeti.circleMap_mem_ball_iff_sq` read off the law
-of cosines says that
+`TauCeti/Topology/Circle/Metric.lean`. Writing `α = arg (c - ζ)` for the direction from `ζ` to the
+centre of the disc and `d = dist ζ c`, the criterion `TauCeti.circleMap_mem_ball_iff_sq` read off
+the law of cosines says that
 
 > `circleMap ζ ρ θ ∈ ball c r ↔ ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`,
 

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -46,9 +46,9 @@ bound applies.
 
 Nothing in that description relates `ζ` to the disc, so the estimates below are stated for an
 arbitrary centre `ζ` of the cutting circle. The Carathéodory correspondence spends them at a
-boundary point, `dist ζ c = r`, which is where `ball c r ∩ sphere ζ ρ` is a circular crosscut in
-the sense of `Conformal/Crosscut/Basic.lean`; that hypothesis is nowhere needed for the estimates
-themselves.
+boundary point, `dist ζ c = r`, which together with `ρ < 2 * r` is where `ball c r ∩ sphere ζ ρ`
+is a circular crosscut in the sense of `Conformal/Crosscut/Basic.lean`; neither hypothesis is
+needed for the estimates themselves, whose statements cover every centre and radius.
 
 ## Main results
 
@@ -101,10 +101,10 @@ open scoped ENNReal Real
 
 variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 
-/-! ## The chord bound on a circular crosscut -/
+/-! ## The chord bound on the intersection `ball c r ∩ sphere ζ ρ` -/
 
-/-- **The chord bound for a circular crosscut.** For `f` holomorphic on `ball c r` and an arbitrary
-centre `ζ`, any two points of `ball c r ∩ sphere ζ ρ` have images at distance at most
+/-- **The chord bound on `ball c r ∩ sphere ζ ρ`.** For `f` holomorphic on `ball c r` and an
+arbitrary centre `ζ`, any two points of `ball c r ∩ sphere ζ ρ` have images at distance at most
 `TauCeti.circleImageLength f (ball c r) ζ ρ`.
 
 The two points are `circleMap ζ ρ (α + t₁)` and `circleMap ζ ρ (α + t₂)` for angles
@@ -146,7 +146,7 @@ theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere
   exact ofReal_dist_le_circleImageLength isOpen_ball hf ζ hρ (by linarith)
     (by linarith [ht₁.1, ht₂.2, Real.pi_pos]) harc harc
 
-/-- **The image of a circular crosscut is no wider than its length.** A bound `ε` on
+/-- **The image of `ball c r ∩ sphere ζ ρ` is no wider than its length.** A bound `ε` on
 `TauCeti.circleImageLength f (ball c r) ζ ρ` bounds the diameter of the image of
 `ball c r ∩ sphere ζ ρ`, by the chord bound
 `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere`, from which it inherits its
@@ -160,15 +160,15 @@ theorem diam_image_ball_inter_sphere_le
   exact (ENNReal.ofReal_le_ofReal_iff hε).mp
     ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hf hz hw).trans hlen)
 
-/-- **An image crosscut of finite length is bounded.** The chord bound
+/-- **An image of finite length is bounded.** The chord bound
 `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
 `f '' (ball c r ∩ sphere ζ ρ)` within the finite number
 `(TauCeti.circleImageLength f (ball c r) ζ ρ).toReal` of each other.
 
-This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on the distances inside the
-image crosscut rather than the junk value `0` that an unbounded set carries; it is the disc
-counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
-the crosscut rather than against an arc of angles. -/
+This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on the distances inside
+that image rather than the junk value `0` that an unbounded set carries; it is the disc counterpart
+of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against the
+intersection rather than against an arc of angles. -/
 theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
     (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
@@ -179,13 +179,14 @@ theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
   exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
     (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hf hz hw)
 
-/-! ## Crosscuts with a short image -/
+/-! ## Circle intersections with a short image -/
 
-/-- **A holomorphic map of finite Dirichlet integral has short image crosscuts.** For `f`
-holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤` and an arbitrary `ζ`, every
-tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at which the image of
-`ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory correspondence uses is
-`ζ` on the circle `sphere c r`, where the intersection is a crosscut.
+/-- **A holomorphic map of finite Dirichlet integral has short images of small circle
+intersections.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤`
+and an arbitrary `ζ`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
+which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory
+correspondence uses is `ζ` on the circle `sphere c r` and `ρ < 2 * r`, where the intersection is a
+circular crosscut.
 
 This is the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` of Wolff's
 lemma fed to `TauCeti.diam_image_ball_inter_sphere_le`. The annulus in which the good `ρ` is sought

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -31,16 +31,22 @@ crosscut cuts off — is a matter of local connectedness of that boundary and is
 ## The intersection is an arc
 
 Everything rests on the angular description of the intersection proved in
-`Conformal/Crosscut/Basic.lean`. Writing `α = arg (c - ζ)` for the direction from the boundary
-point `ζ` to the centre, `TauCeti.circleMap_mem_ball_iff` says that
+`Conformal/Crosscut/Basic.lean`. Writing `α = arg (c - ζ)` for the direction from `ζ` to the centre
+of the disc and `d = dist ζ c`, the law of cosines `TauCeti.dist_circleMap_sq` says that
 
-> `circleMap ζ ρ θ ∈ ball c r ↔ ρ < 2 * r * cos (θ - α)`,
+> `circleMap ζ ρ θ ∈ ball c r ↔ ρ ^ 2 + d ^ 2 - r ^ 2 < 2 * ρ * d * cos (θ - α)`,
 
 and `TauCeti.circleMap_mem_ball_of_mem_Icc` deduces that the condition holds throughout an interval
 of angles inside the period centred at `α` as soon as it holds at both ends. Every point of the
 circle `sphere ζ ρ` is `circleMap ζ ρ (α + t)` for some `t ∈ [-π, π]`, so any two points of the
 intersection are the endpoints of such an interval, of width at most `2 * π`, along which the chord
 bound applies.
+
+Nothing in that description relates `ζ` to the disc, so the estimates below are stated for an
+arbitrary centre `ζ` of the cutting circle. The Carathéodory correspondence spends them at a
+boundary point, `dist ζ c = r`, which is where `ball c r ∩ sphere ζ ρ` is a circular crosscut in
+the sense of `Conformal/Crosscut/Basic.lean`; that hypothesis is nowhere needed for the estimates
+themselves.
 
 ## Main results
 
@@ -52,8 +58,8 @@ bound applies.
 * `TauCeti.isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top` — and when that quantity
   is finite the image is bounded, so its diameter is a genuine bound on the distances inside it.
 * `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` — the conclusion, from
-  Wolff's lemma: a holomorphic map of a disc with finite Dirichlet integral has, at every boundary
-  point and below every positive radius, a radius `ρ` at which `f '' (ball c r ∩ sphere ζ ρ)` has
+  Wolff's lemma: a holomorphic map of a disc with finite Dirichlet integral has, at every centre
+  `ζ` and below every positive radius, a radius `ρ` at which `f '' (ball c r ∩ sphere ζ ρ)` has
   diameter at most `ε`.
 * `TauCeti.exists_diam_image_ball_inter_sphere_le` — its corollary for an injective map with
   bounded image, the case a Riemann map falls under.
@@ -63,7 +69,8 @@ bound applies.
 In accordance with the generality bar of `ConformalMapping/README.md`, which fixes scalar `ℂ` for
 every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The disc is a
 general `ball c r` rather than the unit disc, since nothing is cheaper in the normalised case, and
-the boundary point enters only through `dist ζ c = r`.
+the centre `ζ` of the cutting circle is unrestricted, since the arc description that carries the
+chord bound never uses `dist ζ c = r`.
 
 ## Coordination with upstream Mathlib
 
@@ -92,16 +99,20 @@ variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
 
 /-! ## The chord bound on a circular crosscut -/
 
-/-- **The chord bound for a circular crosscut.** For `f` holomorphic on `ball c r` and `ζ` on the
-circle `sphere c r`, any two points of `ball c r ∩ sphere ζ ρ` have images at distance at most
+/-- **The chord bound for a circular crosscut.** For `f` holomorphic on `ball c r` and an arbitrary
+centre `ζ`, any two points of `ball c r ∩ sphere ζ ρ` have images at distance at most
 `TauCeti.circleImageLength f (ball c r) ζ ρ`.
 
 The two points are `circleMap ζ ρ (α + t₁)` and `circleMap ζ ρ (α + t₂)` for angles
-`t₁, t₂ ∈ [-π, π]` off the direction `α = arg (c - ζ)` of the centre; the arc of angles between
-them has width at most `2 * π` and stays in the disc by
+`t₁, t₂ ∈ [-π, π]` off the direction `α = arg (c - ζ)` of the centre of the disc; the arc of angles
+between them has width at most `2 * π` and stays in the disc by
 `TauCeti.circleMap_mem_ball_of_mem_Icc`, so `TauCeti.ofReal_dist_le_circleImageLength` applies to
-it with `s = U = ball c r`. -/
-theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hζ : dist ζ c = r) (hρ : 0 < ρ)
+it with `s = U = ball c r`.
+
+The centre `ζ` of the cutting circle is unrestricted: `ball c r ∩ sphere ζ ρ` is an arc of angles
+wherever `ζ` lies, so the bound is not confined to the circular crosscuts at a boundary point
+`ζ ∈ sphere c r` that the Carathéodory correspondence cuts with. -/
+theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hρ : 0 < ρ)
     (hf : DifferentiableOn ℂ f (ball c r)) {z w : ℂ} (hz : z ∈ ball c r ∩ sphere ζ ρ)
     (hw : w ∈ ball c r ∩ sphere ζ ρ) :
     ENNReal.ofReal (dist (f z) (f w)) ≤ circleImageLength f (ball c r) ζ ρ := by
@@ -119,7 +130,7 @@ theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hζ : dist ζ
   rintro z' w' hz' hw' t₁ ht₁ t₂ ht₂ hle rfl rfl
   have harc : ∀ θ ∈ Icc ((c - ζ).arg + t₁) ((c - ζ).arg + t₂), circleMap ζ ρ θ ∈ ball c r :=
     fun θ hθ =>
-      circleMap_mem_ball_of_mem_Icc hζ hρ (by rw [add_sub_cancel_left]; exact ht₁.1)
+      circleMap_mem_ball_of_mem_Icc hρ (by rw [add_sub_cancel_left]; exact ht₁.1)
         (by rw [add_sub_cancel_left]; exact ht₂.2) hθ hz'.1 hw'.1
   exact ofReal_dist_le_circleImageLength isOpen_ball hf ζ hρ (by linarith)
     (by linarith [ht₁.1, ht₂.2, Real.pi_pos]) harc harc
@@ -128,14 +139,14 @@ theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hζ : dist ζ
 `TauCeti.circleImageLength f (ball c r) ζ ρ` bounds the diameter of the image of
 `ball c r ∩ sphere ζ ρ`, by the chord bound
 `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere`. -/
-theorem diam_image_ball_inter_sphere_le (hζ : dist ζ c = r) (hρ : 0 < ρ)
+theorem diam_image_ball_inter_sphere_le (hρ : 0 < ρ)
     (hf : DifferentiableOn ℂ f (ball c r)) {ε : ℝ} (hε : 0 ≤ ε)
     (hlen : circleImageLength f (ball c r) ζ ρ ≤ ENNReal.ofReal ε) :
     diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
   refine diam_le_of_forall_dist_le hε ?_
   rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
   exact (ENNReal.ofReal_le_ofReal_iff hε).mp
-    ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw).trans hlen)
+    ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hρ hf hz hw).trans hlen)
 
 /-- **An image crosscut of finite length is bounded.** The chord bound
 `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
@@ -146,7 +157,7 @@ This is what makes `Metric.diam (f '' (ball c r ∩ sphere ζ ρ))` a bound on t
 image crosscut rather than the junk value `0` that an unbounded set carries; it is the disc
 counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
 the crosscut rather than against an arc of angles. -/
-theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top (hζ : dist ζ c = r)
+theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
     (hρ : 0 < ρ) (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
     IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
@@ -154,14 +165,15 @@ theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top (hζ : dis
   refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, ?_⟩
   rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
   exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
-    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hζ hρ hf hz hw)
+    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hρ hf hz hw)
 
 /-! ## Crosscuts with a short image -/
 
 /-- **A holomorphic map of finite Dirichlet integral has short image crosscuts at every boundary
-point.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤` and `ζ` on
-the circle `sphere c r`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
-which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`.
+point.** For `f` holomorphic on `ball c r` with `∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤` and an
+arbitrary `ζ`, every tolerance `ε > 0` and every bound `R > 0` admit a radius `ρ < R` at
+which the image of `ball c r ∩ sphere ζ ρ` has diameter at most `ε`. The case the Carathéodory
+correspondence uses is `ζ` on the circle `sphere c r`, where the intersection is a crosscut.
 
 This is the limiting form `TauCeti.exists_circleImageLength_lt_of_lintegral_ne_top` of Wolff's
 lemma fed to `TauCeti.diam_image_ball_inter_sphere_le`. The annulus in which the good `ρ` is sought
@@ -177,17 +189,17 @@ This is the first of the two geometric inputs of
 `TauCeti.exists_continuousOn_closure_eqOn_of_forall_exists_diam_union_le`; nothing here bounds
 the boundary piece the crosscut cuts off, which is a matter of the image domain rather than of the
 map. -/
-theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top (hζ : dist ζ c = r)
+theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top
     (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : ∫⁻ z in ball c r, ‖deriv f z‖ₑ ^ 2 ≠ ⊤) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
   obtain ⟨ρ, hρmem, hlen⟩ :=
     exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
       (ENNReal.ofReal_pos.mpr hε).ne' hR
-  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hζ hρmem.1 hf hε.le hlen.le⟩
+  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hρmem.1 hf hε.le hlen.le⟩
 
 /-- **A conformal map of a disc has arbitrarily small images of the circle intersections
-`ball c r ∩ sphere ζ ρ` at every boundary point.** This is the case of
+`ball c r ∩ sphere ζ ρ` at every centre `ζ`.** This is the case of
 `TauCeti.exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top` that a Riemann map falls under:
 for `f` injective on `ball c r` with bounded image the Dirichlet integral is the area of that image,
 hence finite by `TauCeti.lintegral_enorm_deriv_sq_ne_top_of_isBounded`.
@@ -195,11 +207,11 @@ hence finite by `TauCeti.lintegral_enorm_deriv_sq_ne_top_of_isBounded`.
 As there, the intersection bounded is a genuine circular crosscut only when `ρ < 2 * r`, being
 empty otherwise — in particular when `r = 0`, which the hypotheses allow; a caller wanting a
 crosscut applies the theorem with `R ≤ 2 * r`. -/
-theorem exists_diam_image_ball_inter_sphere_le (hζ : dist ζ c = r)
+theorem exists_diam_image_ball_inter_sphere_le
     (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
     (hb : IsBounded (f '' ball c r)) {ε : ℝ} (hε : 0 < ε) {R : ℝ} (hR : 0 < R) :
     ∃ ρ ∈ Ioo 0 R, diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε :=
-  exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top hζ hf
+  exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top hf
     (lintegral_enorm_deriv_sq_ne_top_of_isBounded isOpen_ball hf
       measurableSet_ball.nullMeasurableSet subset_rfl hinj hb) hε hR
 

--- a/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
+++ b/TauCeti/Analysis/Complex/Conformal/ShortCrosscut.lean
@@ -72,7 +72,9 @@ In accordance with the generality bar of `ConformalMapping/README.md`, which fix
 every theorem added in layers L0–L6, everything below is stated for maps of `ℂ`. The disc is a
 general `ball c r` rather than the unit disc, since nothing is cheaper in the normalised case, and
 the centre `ζ` of the cutting circle is unrestricted, since the arc description that carries the
-chord bound never uses `dist ζ c = r`.
+chord bound never uses `dist ζ c = r`. The radius `ρ` of that circle is unrestricted as well, the
+three estimates on `ball c r ∩ sphere ζ ρ` asking nothing of it: `sphere ζ ρ` is empty for `ρ < 0`
+and the single point `ζ` for `ρ = 0`, so both degenerate cases hold for want of a second point.
 
 ## Coordination with upstream Mathlib
 
@@ -113,11 +115,18 @@ it with `s = U = ball c r`.
 
 The centre `ζ` of the cutting circle is unrestricted: `ball c r ∩ sphere ζ ρ` is an arc of angles
 wherever `ζ` lies, so the bound is not confined to the circular crosscuts at a boundary point
-`ζ ∈ sphere c r` that the Carathéodory correspondence cuts with. -/
-theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hρ : 0 < ρ)
+`ζ ∈ sphere c r` that the Carathéodory correspondence cuts with. The radius `ρ` is unrestricted
+too, the hypotheses forcing `0 ≤ ρ`: a negative radius leaves `sphere ζ ρ` empty, and `ρ = 0`
+leaves it the single point `ζ`, so in both degenerate cases `z = w` and the chord is `0`. -/
+theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere
     (hf : DifferentiableOn ℂ f (ball c r)) {z w : ℂ} (hz : z ∈ ball c r ∩ sphere ζ ρ)
     (hw : w ∈ ball c r ∩ sphere ζ ρ) :
     ENNReal.ofReal (dist (f z) (f w)) ≤ circleImageLength f (ball c r) ζ ρ := by
+  rcases (nonneg_of_mem_sphere hz.2).eq_or_lt with hρ | hρ
+  · -- a circle of radius zero: both points are its centre
+    have hzζ : z = ζ := by simpa [← hρ] using hz.2
+    have hwζ : w = ζ := by simpa [← hρ] using hw.2
+    simp [hzζ, hwζ]
   -- it suffices to treat a pair of angles in increasing order
   suffices h : ∀ z' w' : ℂ, z' ∈ ball c r ∩ sphere ζ ρ → w' ∈ ball c r ∩ sphere ζ ρ →
       ∀ t₁ ∈ Icc (-π) π, ∀ t₂ ∈ Icc (-π) π, t₁ ≤ t₂ →
@@ -132,7 +141,7 @@ theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hρ : 0 < ρ)
   rintro z' w' hz' hw' t₁ ht₁ t₂ ht₂ hle rfl rfl
   have harc : ∀ θ ∈ Icc ((c - ζ).arg + t₁) ((c - ζ).arg + t₂), circleMap ζ ρ θ ∈ ball c r :=
     fun θ hθ =>
-      circleMap_mem_ball_of_mem_Icc hρ (by rw [add_sub_cancel_left]; exact ht₁.1)
+      circleMap_mem_ball_of_mem_Icc hρ.le (by rw [add_sub_cancel_left]; exact ht₁.1)
         (by rw [add_sub_cancel_left]; exact ht₂.2) hθ hz'.1 hw'.1
   exact ofReal_dist_le_circleImageLength isOpen_ball hf ζ hρ (by linarith)
     (by linarith [ht₁.1, ht₂.2, Real.pi_pos]) harc harc
@@ -140,15 +149,16 @@ theorem ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere (hρ : 0 < ρ)
 /-- **The image of a circular crosscut is no wider than its length.** A bound `ε` on
 `TauCeti.circleImageLength f (ball c r) ζ ρ` bounds the diameter of the image of
 `ball c r ∩ sphere ζ ρ`, by the chord bound
-`TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere`. -/
-theorem diam_image_ball_inter_sphere_le (hρ : 0 < ρ)
+`TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere`, from which it inherits its
+indifference to the centre and the radius of the cutting circle. -/
+theorem diam_image_ball_inter_sphere_le
     (hf : DifferentiableOn ℂ f (ball c r)) {ε : ℝ} (hε : 0 ≤ ε)
     (hlen : circleImageLength f (ball c r) ζ ρ ≤ ENNReal.ofReal ε) :
     diam (f '' (ball c r ∩ sphere ζ ρ)) ≤ ε := by
   refine diam_le_of_forall_dist_le hε ?_
   rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
   exact (ENNReal.ofReal_le_ofReal_iff hε).mp
-    ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hρ hf hz hw).trans hlen)
+    ((ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hf hz hw).trans hlen)
 
 /-- **An image crosscut of finite length is bounded.** The chord bound
 `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` keeps every pair of points of
@@ -160,14 +170,14 @@ image crosscut rather than the junk value `0` that an unbounded set carries; it 
 counterpart of `TauCeti.isBounded_image_circleMap_image_Ioo_of_lintegral_ne_top`, stated against
 the crosscut rather than against an arc of angles. -/
 theorem isBounded_image_ball_inter_sphere_of_circleImageLength_ne_top
-    (hρ : 0 < ρ) (hf : DifferentiableOn ℂ f (ball c r))
+    (hf : DifferentiableOn ℂ f (ball c r))
     (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤) :
     IsBounded (f '' (ball c r ∩ sphere ζ ρ)) := by
   rw [isBounded_iff]
   refine ⟨(circleImageLength f (ball c r) ζ ρ).toReal, ?_⟩
   rintro _ ⟨z, hz, rfl⟩ _ ⟨w, hw, rfl⟩
   exact (ENNReal.ofReal_le_iff_le_toReal hfin).mp
-    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hρ hf hz hw)
+    (ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere hf hz hw)
 
 /-! ## Crosscuts with a short image -/
 
@@ -201,7 +211,7 @@ theorem exists_diam_image_ball_inter_sphere_le_of_lintegral_ne_top
   obtain ⟨ρ, hρmem, hlen⟩ :=
     exists_circleImageLength_lt_of_lintegral_ne_top (s := ball c r) f measurableSet_ball ζ hfin
       (ENNReal.ofReal_pos.mpr hε).ne' hR
-  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hρmem.1 hf hε.le hlen.le⟩
+  exact ⟨ρ, hρmem, diam_image_ball_inter_sphere_le hf hε.le hlen.le⟩
 
 /-- **A conformal map of a disc has arbitrarily small images of the circle intersections
 `ball c r ∩ sphere ζ ρ` at every centre `ζ`.** This is the case of

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -233,21 +233,22 @@ angle in `[a, b]`.
 This is `TauCeti.circleMap_mem_ball_iff_sq` read through the unimodality of `cos` on a period
 centred at `arg (c - ζ)`. Neither `0 < r` nor any relation between `ζ` and the disc is assumed: the
 first is forced by the hypotheses, and the second is not needed, so the conclusion covers a cutting
-circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. A
-circle centred at `c` itself is the degenerate case, its points being all at the same distance from
-`c`; the criterion is then independent of the angle. -/
-theorem circleMap_mem_ball_of_mem_Icc {c ζ : ℂ} {r ρ : ℝ} (hρ : 0 < ρ) {a b θ : ℝ}
+circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. Two
+degenerate cases are covered as well, in both of which the criterion is independent of the angle: a
+circle centred at `c` itself, whose points are all at the same distance from `c`, and the circle of
+radius `ρ = 0`, which is the single point `ζ`. -/
+theorem circleMap_mem_ball_of_mem_Icc {c ζ : ℂ} {r ρ : ℝ} (hρ : 0 ≤ ρ) {a b θ : ℝ}
     (ha : -π ≤ a - (c - ζ).arg) (hb : b - (c - ζ).arg ≤ π) (hθ : θ ∈ Icc a b)
     (hain : circleMap ζ ρ a ∈ ball c r) (hbin : circleMap ζ ρ b ∈ ball c r) :
     circleMap ζ ρ θ ∈ ball c r := by
   have hr : 0 < r := dist_nonneg.trans_lt (mem_ball.mp hain)
   rw [circleMap_mem_ball_iff_sq hr.le] at hain hbin ⊢
-  rcases (dist_nonneg : (0 : ℝ) ≤ dist ζ c).eq_or_lt with hd | hd
-  · -- a circle centred at `c`: the criterion does not see the angle at all
+  have hnn : (0 : ℝ) ≤ 2 * ρ * dist ζ c := mul_nonneg (by linarith) dist_nonneg
+  rcases hnn.eq_or_lt with hd | hpos
+  · -- a circle centred at `c`, or one of radius zero: the criterion does not see the angle at all
     rw [← hd] at hain ⊢
     linarith
   · -- otherwise divide by `2 * ρ * dist ζ c` and use that `cos` has no interior minimum
-    have hpos : 0 < 2 * ρ * dist ζ c := by positivity
     have hkey : ∀ x : ℝ, (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2
           < 2 * ρ * dist ζ c * Real.cos (x - (c - ζ).arg))
         ↔ (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2) / (2 * ρ * dist ζ c)

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -18,7 +18,9 @@ counterclockwise from `x` to `y`. This file relates the two, comparing the *chor
 the *arc* separating `x` from `y` in both directions, and transports the chord formula along the
 translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ ρ`. It also records
 the chord with one endpoint allowed *off* the circle — the distance from a point of `circleMap ζ ρ`
-to an arbitrary point of the plane, which is the law of cosines.
+to an arbitrary point of the plane, which is the law of cosines — and reads off from that law when
+such a point lies in a disc `ball c r`, whose centre `c` is unrelated to the centre `ζ` of the
+circle.
 
 ## Main results
 
@@ -32,6 +34,12 @@ to an arbitrary point of the plane, which is the law of cosines.
 * `TauCeti.dist_circleMap_sq` — the law of cosines: the point of `circleMap ζ ρ` at angle `θ` is at
   distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
   arbitrary point `c` of the plane.
+* `TauCeti.circleMap_mem_ball_iff_sq` and `TauCeti.circleMap_mem_closedBall_iff_sq` — that law
+  compared with `r ^ 2`: when the point at angle `θ` lies in the disc `ball c r`, respectively in
+  `closedBall c r`.
+* `TauCeti.circleMap_mem_ball_of_mem_Icc` — since the criterion sees the angle only through
+  `cos (θ - arg (c - ζ))`, the angles it admits form an arc: it holds throughout an interval of
+  angles inside a period centred at `arg (c - ζ)` as soon as it holds at both ends.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
   most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
@@ -119,14 +127,17 @@ theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (
 
 /-- **The law of cosines for a point of a circle.** The point of `circleMap ζ ρ` at angle `θ` is at
 distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
-arbitrary point `c`: in the triangle with vertices `ζ`, `circleMap ζ ρ θ` and `c`, the angle at `ζ`
-between the two sides of lengths `ρ` and `dist ζ c` is `θ - arg (c - ζ)`. It is the chord formula
+arbitrary point `c`. For `ρ ≥ 0` this is the law of cosines as usually read: in the triangle with
+vertices `ζ`, `circleMap ζ ρ θ` and `c`, the angle at `ζ` between the two sides of lengths `ρ` and
+`dist ζ c` is `θ - arg (c - ζ)`. It is the chord formula
 `TauCeti.dist_circleMap_eq_two_mul_abs_sin` with one endpoint allowed off the circle.
 
-Nothing is assumed. For `ρ < 0` the point `circleMap ζ ρ θ` is the one at angle `θ + π` on the
-circle of radius `-ρ`, and the identity still holds because only `ρ ^ 2` and `ρ * cos` occur; for
-`c = ζ` both terms carrying `dist ζ c` vanish, so the junk value `arg 0 = 0` does no harm and the
-identity reads `dist (circleMap ζ ρ θ) ζ ^ 2 = ρ ^ 2`. -/
+Nothing is assumed, and the identity is the signed-radius extension of that reading. For `ρ < 0`
+the point `circleMap ζ ρ θ` is the one at angle `θ + π` on the circle of radius `-ρ`, so the side
+at `ζ` has length `-ρ` and points in the direction `θ + π`; the identity still holds as stated
+because only `ρ ^ 2` and `ρ * cos` occur, and the two sign changes cancel. For `c = ζ` both terms
+carrying `dist ζ c` vanish, so the junk value `arg 0 = 0` does no harm and the identity reads
+`dist (circleMap ζ ρ θ) ζ ^ 2 = ρ ^ 2`. -/
 theorem dist_circleMap_sq (ζ c : ℂ) (ρ θ : ℝ) :
     dist (circleMap ζ ρ θ) c ^ 2
       = ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
@@ -160,6 +171,90 @@ theorem dist_circleMap_sq (ζ c : ℂ) (ρ θ : ℝ) :
   rw [dist_eq_norm, Complex.sq_norm, hsub, Complex.normSq_sub, hunit, hre,
     Complex.normSq_eq_norm_sq, hdist]
   ring
+
+/-- **When a point of a circle lies in a disc**, read off the law of cosines. For `r ≥ 0` and a
+disc `ball c r` whose centre is unrelated to the centre `ζ` of the circle, the point
+`circleMap ζ ρ θ` lies in `ball c r` exactly when
+`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`.
+
+This is `TauCeti.dist_circleMap_sq` compared with `r ^ 2`, both sides of `dist … < r` being
+nonnegative. Nothing is assumed of `ρ`: for `ρ > 0` the point described is the point of
+`sphere ζ ρ` at angle `θ`, and for `ρ < 0` it is the point of `sphere ζ (-ρ)` at angle `θ + π`,
+the criterion following it as the law of cosines does. Since the right-hand side depends on `θ`
+only through `cos (θ - arg (c - ζ))`, the angles it admits form an arc
+(`TauCeti.circleMap_mem_ball_of_mem_Icc`).
+
+At a point `ζ` of the boundary circle `sphere c r` the two squared radii cancel and, for `ρ > 0`,
+the surviving condition `ρ ^ 2 < 2 * ρ * r * cos (θ - arg (c - ζ))` may be divided by `ρ`; that
+case is `TauCeti.circleMap_mem_ball_iff` of
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean`. -/
+theorem circleMap_mem_ball_iff_sq {c ζ : ℂ} {r : ℝ} (hr : 0 ≤ r) (ρ θ : ℝ) :
+    circleMap ζ ρ θ ∈ ball c r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 < 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  rw [mem_ball, ← sq_lt_sq₀ dist_nonneg hr, dist_circleMap_sq]
+  constructor
+  · intro h; linarith
+  · intro h; linarith
+
+/-- **When a point of a circle lies in a closed disc.** The weak companion of
+`TauCeti.circleMap_mem_ball_iff_sq`: for `r ≥ 0` and an arbitrary centre `ζ`, the point
+`circleMap ζ ρ θ` lies in `closedBall c r` exactly when
+`ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`. Nothing is assumed of
+`ρ`, whose sign is read as it is there.
+
+At a point `ζ` of the boundary circle `sphere c r` the two squared radii cancel and, for `ρ > 0`,
+the surviving condition may be divided by `ρ`; that case is
+`TauCeti.circleMap_mem_closedBall_iff` of
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean`. -/
+theorem circleMap_mem_closedBall_iff_sq {c ζ : ℂ} {r : ℝ} (hr : 0 ≤ r) (ρ θ : ℝ) :
+    circleMap ζ ρ θ ∈ closedBall c r ↔
+      ρ ^ 2 + dist ζ c ^ 2 - r ^ 2 ≤ 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  rw [mem_closedBall, ← sq_le_sq₀ dist_nonneg hr, dist_circleMap_sq]
+  constructor
+  · intro h; linarith
+  · intro h; linarith
+
+/-- **The cosine has no interior minimum on `[-π, π]`.** If `k < cos a` and `k < cos b`, with
+`-π ≤ a` and `b ≤ π`, then `k < cos θ` for every `θ ∈ [a, b]`: `cos` increases on `[-π, 0]` and
+decreases on `[0, π]`, so on `[a, b]` its minimum is attained at an endpoint. -/
+private theorem lt_cos_of_mem_Icc {k a b θ : ℝ} (ha : -π ≤ a) (hb : b ≤ π) (hθ : θ ∈ Icc a b)
+    (hka : k < Real.cos a) (hkb : k < Real.cos b) : k < Real.cos θ := by
+  rcases le_total θ 0 with hθ0 | hθ0
+  · refine hka.trans_le ?_
+    rw [← Real.cos_neg θ, ← Real.cos_neg a]
+    exact Real.cos_le_cos_of_nonneg_of_le_pi (by linarith) (by linarith) (by linarith [hθ.1])
+  · exact hkb.trans_le (Real.cos_le_cos_of_nonneg_of_le_pi hθ0 hb hθ.2)
+
+/-- **A circle meets a disc in a connected set of angles.** If the angles `a` and `b` both lie
+within `π` of the direction `arg (c - ζ)` from the centre `ζ` of the circle to the centre `c` of
+the disc, and both put the point of `sphere ζ ρ` they name inside `ball c r`, then so does every
+angle in `[a, b]`.
+
+This is `TauCeti.circleMap_mem_ball_iff_sq` read through the unimodality of `cos` on a period
+centred at `arg (c - ζ)`. Neither `0 < r` nor any relation between `ζ` and the disc is assumed: the
+first is forced by the hypotheses, and the second is not needed, so the conclusion covers a cutting
+circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. A
+circle centred at `c` itself is the degenerate case, its points being all at the same distance from
+`c`; the criterion is then independent of the angle. -/
+theorem circleMap_mem_ball_of_mem_Icc {c ζ : ℂ} {r ρ : ℝ} (hρ : 0 < ρ) {a b θ : ℝ}
+    (ha : -π ≤ a - (c - ζ).arg) (hb : b - (c - ζ).arg ≤ π) (hθ : θ ∈ Icc a b)
+    (hain : circleMap ζ ρ a ∈ ball c r) (hbin : circleMap ζ ρ b ∈ ball c r) :
+    circleMap ζ ρ θ ∈ ball c r := by
+  have hr : 0 < r := dist_nonneg.trans_lt (mem_ball.mp hain)
+  rw [circleMap_mem_ball_iff_sq hr.le] at hain hbin ⊢
+  rcases (dist_nonneg : (0 : ℝ) ≤ dist ζ c).eq_or_lt with hd | hd
+  · -- a circle centred at `c`: the criterion does not see the angle at all
+    rw [← hd] at hain ⊢
+    linarith
+  · -- otherwise divide by `2 * ρ * dist ζ c` and use that `cos` has no interior minimum
+    have hpos : 0 < 2 * ρ * dist ζ c := by positivity
+    have hkey : ∀ x : ℝ, (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2
+          < 2 * ρ * dist ζ c * Real.cos (x - (c - ζ).arg))
+        ↔ (ρ ^ 2 + dist ζ c ^ 2 - r ^ 2) / (2 * ρ * dist ζ c)
+          < Real.cos (x - (c - ζ).arg) := fun x => by
+      rw [div_lt_iff₀ hpos, mul_comm]
+    rw [hkey] at hain hbin ⊢
+    exact lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -16,7 +16,9 @@ Mathlib's `Circle` carries both a metric, from the inclusion into `ℂ`, and an 
 `Circle.exp` parametrizes it by angles and `Circle.angleDiff x y` is the length of the arc running
 counterclockwise from `x` to `y`. This file relates the two, comparing the *chord* `dist x y` with
 the *arc* separating `x` from `y` in both directions, and transports the chord formula along the
-translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ ρ`.
+translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ ρ`. It also records
+the chord with one endpoint allowed *off* the circle — the distance from a point of `circleMap ζ ρ`
+to an arbitrary point of the plane, which is the law of cosines.
 
 ## Main results
 
@@ -27,6 +29,9 @@ translation and real scaling that carry `Circle.exp` to Mathlib's `circleMap ζ 
   `2 * |ρ| * |sin ((θ - θ') / 2)|`, and
   `TauCeti.dist_circleMap_eq_two_mul_sin_abs`, the same formula with the sign of the angular
   difference cleared, valid for angles at most a full turn apart.
+* `TauCeti.dist_circleMap_sq` — the law of cosines: the point of `circleMap ζ ρ` at angle `θ` is at
+  distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
+  arbitrary point `c` of the plane.
 * `TauCeti.lipschitzWith_one_circleExp` and `TauCeti.diam_circleExp_image_Icc_le` — the chord is at
   most the arc, so an arc of angles of length `b - a` has image of diameter at most `b - a`.
 * `TauCeti.min_angleDiff_le_pi_div_two_mul_dist` — the shorter of the two arcs joining two points of
@@ -111,6 +116,50 @@ theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (
   have habs : |(θ - θ') / 2| = |θ - θ'| / 2 := by rw [abs_div, abs_two]
   rw [dist_circleMap_eq_two_mul_abs_sin,
     Real.abs_sin_eq_sin_abs_of_abs_le_pi (by rw [habs]; linarith), habs]
+
+/-- **The law of cosines for a point of a circle.** The point of `circleMap ζ ρ` at angle `θ` is at
+distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
+arbitrary point `c`: in the triangle with vertices `ζ`, `circleMap ζ ρ θ` and `c`, the angle at `ζ`
+between the two sides of lengths `ρ` and `dist ζ c` is `θ - arg (c - ζ)`. It is the chord formula
+`TauCeti.dist_circleMap_eq_two_mul_abs_sin` with one endpoint allowed off the circle.
+
+Nothing is assumed. For `ρ < 0` the point `circleMap ζ ρ θ` is the one at angle `θ + π` on the
+circle of radius `-ρ`, and the identity still holds because only `ρ ^ 2` and `ρ * cos` occur; for
+`c = ζ` both terms carrying `dist ζ c` vanish, so the junk value `arg 0 = 0` does no harm and the
+identity reads `dist (circleMap ζ ρ θ) ζ ^ 2 = ρ ^ 2`. -/
+theorem dist_circleMap_sq (ζ c : ℂ) (ρ θ : ℝ) :
+    dist (circleMap ζ ρ θ) c ^ 2
+      = ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * Real.cos (θ - (c - ζ).arg) := by
+  have hdist : dist ζ c = ‖c - ζ‖ := by rw [dist_eq_norm, norm_sub_rev]
+  have hsub : circleMap ζ ρ θ - c
+      = (ρ : ℂ) * Complex.exp ((θ : ℂ) * Complex.I) - (c - ζ) := by
+    simp only [circleMap]; ring
+  -- the conjugate of `c - ζ` in polar form, valid at `c = ζ` as well
+  have hconj : (starRingEnd ℂ) (c - ζ)
+      = ((‖c - ζ‖ : ℝ) : ℂ) * Complex.exp (((-(c - ζ).arg : ℝ) : ℂ) * Complex.I) := by
+    conv_lhs => rw [← Complex.norm_mul_exp_arg_mul_I (c - ζ)]
+    rw [map_mul, Complex.conj_ofReal, ← Complex.exp_conj]
+    congr 2
+    push_cast
+    rw [map_mul, Complex.conj_ofReal, Complex.conj_I]
+    ring
+  -- the cross term is the cosine of the angle at `ζ`
+  have hre : ((ρ : ℂ) * Complex.exp ((θ : ℂ) * Complex.I) * (starRingEnd ℂ) (c - ζ)).re
+      = ρ * ‖c - ζ‖ * Real.cos (θ - (c - ζ).arg) := by
+    have hmul : (ρ : ℂ) * Complex.exp ((θ : ℂ) * Complex.I) * (starRingEnd ℂ) (c - ζ)
+        = ((ρ * ‖c - ζ‖ : ℝ) : ℂ)
+            * Complex.exp (((θ - (c - ζ).arg : ℝ) : ℂ) * Complex.I) := by
+      rw [hconj, mul_mul_mul_comm, ← Complex.exp_add]
+      push_cast
+      ring_nf
+    rw [hmul, Complex.re_ofReal_mul, Complex.exp_ofReal_mul_I_re]
+  have hunit : Complex.normSq ((ρ : ℂ) * Complex.exp ((θ : ℂ) * Complex.I)) = ρ ^ 2 := by
+    rw [Complex.normSq_mul, Complex.normSq_ofReal, Complex.normSq_eq_norm_sq,
+      Complex.norm_exp_ofReal_mul_I]
+    ring
+  rw [dist_eq_norm, Complex.sq_norm, hsub, Complex.normSq_sub, hunit, hre,
+    Complex.normSq_eq_norm_sq, hdist]
+  ring
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=


### PR DESCRIPTION
This PR removes the hypothesis `dist ζ c = r` from the circular-crosscut estimates, so that a disc may be cut by a circle centred anywhere, and names the geometric identity those estimates rest on. `TauCeti.dist_circleMap_sq` is the law of cosines for a point of a circle — `dist (circleMap ζ ρ θ) c ^ 2 = ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, with no hypotheses at all, the degenerate cases `ρ < 0` and `c = ζ` included — and `TauCeti.circleMap_mem_ball_iff_sq` reads off from it when that point lies in `ball c r`. Since the resulting condition depends on the angle only through `cos (θ - arg (c - ζ))`, the intersection `ball c r ∩ sphere ζ ρ` is an arc of angles for every centre `ζ`, and `TauCeti.circleMap_mem_ball_of_mem_Icc` loses `dist ζ c = r` with it; positivity of `r` is forced by the hypotheses rather than assumed, and a cutting circle concentric with the disc is handled as the case in which the criterion does not see the angle. Downstream, the chord bound `TauCeti.ofReal_dist_le_circleImageLength_of_mem_ball_inter_sphere` of `Conformal/ShortCrosscut.lean` and the four diameter and boundedness estimates built on it — through to `TauCeti.exists_diam_image_ball_inter_sphere_le`, the length–area input the Carathéodory correspondence spends — drop the same hypothesis. The boundary-point form `TauCeti.circleMap_mem_ball_iff` keeps its statement, but is now derived from the general criterion in three lines rather than proved separately through the inversion identity, and the private `dist_circleMap_sq` of `Conformal/Crosscut/Endpoints.lean`, which proved the law of cosines again in its `dist ζ c = r` special case, is deleted in favour of the public one. Nothing new is claimed about crosscuts: the boundary-point case, where `ball c r ∩ sphere ζ ρ` is a circular crosscut, is exactly the old content, and the docstrings say so at each generalized statement.

This is improvement of code that already exists — the modest generalisation of existing lemmas and the removal of a duplicated private proof — so it makes no new mathematical claim and needs no roadmap target of its own. The machinery it improves serves the L5 milestone of `TauCetiRoadmap/ConformalMapping/README.md`, "Carathéodory boundary correspondence … the Jordan-domain case", whose length–area half is `TauCeti.exists_diam_image_ball_inter_sphere_le`; per that roadmap's coordination clause, L5 is outside the shim-deletion obligation attaching to L0–L3, being absent from the in-progress upstream Riemann-mapping effort [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505).

No Mathlib source is vendored. The law of cosines is proved from Mathlib's `Complex.normSq_sub`, `Complex.norm_mul_exp_arg_mul_I` and `Complex.exp_ofReal_mul_I_re` rather than restated, and the arc argument keeps the existing private `lt_cos_of_mem_Icc`.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"circular-crosscut-arbitrary-centre"}-->

🤖 Prepared with Claude Code
