### PR TITLE
feat(ModularForms): the boundary contour winds -1 on the whole interior

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -7,8 +7,8 @@ module
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 
-import TauCeti.Analysis.Contour.Winding.Integer
 import Mathlib.Analysis.Complex.Convex
+import TauCeti.Analysis.Contour.Winding.Integer
 import TauCeti.Analysis.Contour.Winding.LocallyConstant
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Decomposition
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.PieceLog
@@ -202,8 +202,7 @@ private lemma interior_avoiding_facts (hH : 1 < H) {w : ℂ} (hnorm : 1 < ‖w�
       hz.2.2⟩
 
 /-- **The boundary contour winds `-1` about every point of the open truncated fundamental
-domain**: interior points connect vertically into the strip above the corner row, where
-the value is pinned by `windingNumber_fdBoundary_eq_neg_one_of_one_lt_im`. -/
+domain**: the region `1 < ‖w‖`, `|re w| < 1/2`, `0 < im w < H`. -/
 theorem windingNumber_fdBoundary_eq_neg_one_of_interior (hH : 1 < H) {w : ℂ}
     (hnorm : 1 < ‖w‖) (hre : |w.re| < 1 / 2) (hpos : 0 < w.im) (him : w.im < H) :
     windingNumber (fdBoundary H) 0 5 w = -1 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -11,7 +11,6 @@ import TauCeti.Analysis.Contour.Winding.Integer
 import Mathlib.Analysis.Complex.Convex
 import TauCeti.Analysis.Contour.Winding.LocallyConstant
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Decomposition
-import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
 import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.PieceLog
 
 /-!

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -29,9 +29,7 @@ open strip box, is one preconnected region avoiding the contour, so the value tr
 
 ## Main declarations
 
-* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_one_lt_im` — the strip value.
-* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_interior` — every interior
-  point.
+* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_interior`.
 
 ## References
 
@@ -83,7 +81,7 @@ private lemma arg_div_neg {z₁ z₂ : ℂ} (hz₁ : z₁ ≠ 0)
 
 /-- The winding number of the boundary contour is `-1` on the open strip above the corner
 row: the region `|re w| < 1/2`, `1 < im w < H`. -/
-theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
+private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
     (hy1 : 1 < w.im) (hyH : w.im < H) : windingNumber (fdBoundary H) 0 5 w = -1 := by
   obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hx
   have h32 : Real.sqrt 3 / 2 ≤ 1 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -74,27 +74,6 @@ private lemma fdBoundary_ne_of_interior (hre : |w.re| < 1 / 2) (hnorm : 1 < ‖w
         rw [h_eq] at this
         linarith
 
-/-- Differentiability of the contour away from its corner parameters. -/
-private lemma differentiableAt_fdBoundary_off_corners :
-    ∀ t ∈ Ioo (min (0 : ℝ) 5) (max (0 : ℝ) 5) \ (fdBoundaryCorners : Set ℝ),
-      DifferentiableAt ℝ (fdBoundary H) t := by
-  intro t ht
-  rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5),
-    max_eq_right (by norm_num : (0 : ℝ) ≤ 5)] at ht
-  obtain ⟨ht', htc⟩ := ht
-  rw [Finset.mem_coe, mem_fdBoundaryCorners] at htc
-  push Not at htc
-  rcases lt_trichotomy t 1 with h1 | h1 | h1
-  · exact (hasDerivAt_fdBoundary_of_lt_one h1).differentiableAt
-  · exact absurd h1 htc.1
-  · rcases lt_trichotomy t 3 with h3 | h3 | h3
-    · exact (hasDerivAt_fdBoundary_of_mem_Ioo_one_three ⟨h1, h3⟩).differentiableAt
-    · exact absurd h3 htc.2.1
-    · rcases lt_trichotomy t 4 with h4 | h4 | h4
-      · exact (hasDerivAt_fdBoundary_of_mem_Ioo_three_four ⟨h3, h4⟩).differentiableAt
-      · exact absurd h4 htc.2.2
-      · exact (hasDerivAt_fdBoundary_of_gt_four h4).differentiableAt
-
 /-- The endpoint ratio of a piece has negative argument when its junction chord turns
 clockwise as seen from `w`; the four instances below feed the pinning argument. -/
 private lemma arg_div_neg {z₁ z₂ : ℂ} (hz₁ : z₁ ≠ 0)
@@ -155,9 +134,9 @@ theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
       windingNumber_fdBoundary_segment5_eq_log hyH]
     ring
   -- integrality
-  obtain ⟨n, hn⟩ := exists_int_windingNumber_of_closed (P := (fdBoundaryCorners : Set ℝ))
-    (fdBoundary_closed H).symm fdBoundaryCorners.finite_toSet.countable
-    (continuous_fdBoundary H).continuousOn differentiableAt_fdBoundary_off_corners
+  obtain ⟨P, hP, hdiff⟩ := (isPiecewiseC1On_fdBoundary H).exists_countable_differentiableAt
+  obtain ⟨n, hn⟩ := exists_int_windingNumber_of_closed (P := P)
+    (fdBoundary_closed H).symm hP (continuous_fdBoundary H).continuousOn hdiff
     (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
     (intervalIntegrable_inv_sub_mul_deriv (continuous_fdBoundary H).continuousOn
       (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -32,6 +32,13 @@ open strip box, is one preconnected region avoiding the contour, so the value tr
 * `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_one_lt_im` — the strip value.
 * `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_interior` — every interior
   point.
+
+## References
+
+The interior determination follows the fundamental-domain boundary development of AINTLIB's
+`LeanModularForms` (`ForMathlib/FDBoundary.lean`, `FDBoundaryH.lean`, `FDBoundaryPath.lean`),
+adapted to the raw-path winding machinery: the piece decomposition and logarithm values are
+summed and pinned by integrality rather than evaluated termwise.
 -/
 
 public section
@@ -87,17 +94,6 @@ private lemma differentiableAt_fdBoundary_off_corners :
       · exact (hasDerivAt_fdBoundary_of_mem_Ioo_three_four ⟨h3, h4⟩).differentiableAt
       · exact absurd h4 htc.2.2
       · exact (hasDerivAt_fdBoundary_of_gt_four h4).differentiableAt
-
-/-- Winding transport between two points of a preconnected region avoiding the contour. -/
-private lemma windingNumber_fdBoundary_eq_of_preconnected {S : Set ℂ}
-    (hconn : IsPreconnected S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
-    {w w' : ℂ} (hw : w ∈ S) (hw' : w' ∈ S) :
-    windingNumber (fdBoundary H) 0 5 w = windingNumber (fdBoundary H) 0 5 w' :=
-  windingNumber_eq_of_mem_connectedComponentIn (fdBoundary_closed H).symm
-    fdBoundaryCorners.finite_toSet.countable (continuous_fdBoundary H).continuousOn
-    differentiableAt_fdBoundary_off_corners
-    (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv
-    (hconn.subset_connectedComponentIn hw' hdisj hw)
 
 /-- The endpoint ratio of a piece has negative argument when its junction chord turns
 clockwise as seen from `w`; the four instances below feed the pinning argument. -/
@@ -173,10 +169,8 @@ theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
         ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w)).arg +
         (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w)).arg +
         (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w)).arg := by
-    have h2πI : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 := by
-      simp [Complex.ext_iff, Real.pi_ne_zero]
     have := hsum.symm.trans hn
-    rw [inv_mul_eq_iff_eq_mul₀ h2πI] at this
+    rw [inv_mul_eq_iff_eq_mul₀ Complex.two_pi_I_ne_zero] at this
     have hIm' := congrArg Complex.im this.symm
     simpa [Complex.log_im, Complex.add_im, Complex.mul_im] using hIm'
   have hb₁ := Complex.neg_pi_lt_arg (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w))
@@ -269,8 +263,10 @@ theorem windingNumber_fdBoundary_eq_neg_one_of_interior (hH : 1 < H) {w : ℂ}
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     obtain ⟨hz_re, hz_norm, hz_im⟩ := interior_avoiding_facts hH hnorm hre him hpos hz
     exact fdBoundary_ne_of_interior hz_re hz_norm hz_im t ht h_eq
-  rw [windingNumber_fdBoundary_eq_of_preconnected hconn hdisj
-      (Or.inl (left_mem_segment ℝ w _)) (Or.inr htop_mem_box),
+  rw [(isPiecewiseC1On_fdBoundary H).windingNumber_eq_of_mem_connectedComponentIn
+      (fdBoundary_closed H).symm
+      (hconn.subset_connectedComponentIn (Or.inr htop_mem_box) hdisj
+        (Or.inl (left_mem_segment ℝ w _))),
     windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (by simpa using hre)
       (by simpa using hy1) (by simpa using hyH)]
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -1,0 +1,281 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.Contour.Winding.Number.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+import TauCeti.Analysis.Contour.Winding.Integer
+import Mathlib.Analysis.Complex.Convex
+import TauCeti.Analysis.Contour.Winding.LocallyConstant
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Decomposition
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.PieceLog
+
+/-!
+# The boundary contour winds `-1` above the corner row
+
+For a point of the open strip `|re| < 1/2` strictly between height `1` and the ceiling
+height `H`, the boundary contour winds exactly `-1`: the contour is traversed clockwise
+around its interior. The four piece values are principal logarithms whose arguments each
+lie in `(-π, 0)`, so their sum lies in `(-4π, 0)`; integrality of the winding number then
+pins the value to `-1`.
+
+Points of the truncated fundamental domain below height `1` are reached from this strip by
+winding transport: the vertical lift of an interior point into the strip, together with the
+open strip box, is one preconnected region avoiding the contour, so the value transports.
+
+## Main declarations
+
+* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_one_lt_im` — the strip value.
+* `TauCeti.ModularForm.windingNumber_fdBoundary_eq_neg_one_of_interior` — every interior
+  point.
+-/
+
+public section
+
+open Set TauCeti.Contour UpperHalfPlane
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H : ℝ} {w : ℂ}
+
+/-- Off-curve avoidance for interior points: each piece is separated from `w` in one
+coordinate, the arc by the norm. -/
+private lemma fdBoundary_ne_of_interior (hre : |w.re| < 1 / 2) (hnorm : 1 < ‖w‖)
+    (him : w.im < H) : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w := by
+  obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hre
+  intro t ht h_eq
+  rcases le_or_gt t 1 with h1 | h1
+  · have := re_fdBoundary_segment1 H ⟨ht.1, h1⟩
+    rw [h_eq] at this
+    linarith
+  · rcases le_or_gt t 3 with h3 | h3
+    · have : ‖fdBoundary H t‖ = 1 := by
+        rw [eqOn_fdBoundary_arc H ⟨h1.le, h3⟩, norm_circleMap_zero, abs_one]
+      rw [h_eq] at this
+      linarith
+    · rcases le_or_gt t 4 with h4 | h4
+      · have := re_fdBoundary_segment4 H ⟨h3.le, h4⟩
+        rw [h_eq] at this
+        linarith
+      · have := im_fdBoundary_segment5 H ⟨h4.le, ht.2⟩
+        rw [h_eq] at this
+        linarith
+
+/-- Differentiability of the contour away from its corner parameters. -/
+private lemma differentiableAt_fdBoundary_off_corners :
+    ∀ t ∈ Ioo (min (0 : ℝ) 5) (max (0 : ℝ) 5) \ (fdBoundaryCorners : Set ℝ),
+      DifferentiableAt ℝ (fdBoundary H) t := by
+  intro t ht
+  rw [min_eq_left (by norm_num : (0 : ℝ) ≤ 5),
+    max_eq_right (by norm_num : (0 : ℝ) ≤ 5)] at ht
+  obtain ⟨ht', htc⟩ := ht
+  rw [Finset.mem_coe, mem_fdBoundaryCorners] at htc
+  push Not at htc
+  rcases lt_trichotomy t 1 with h1 | h1 | h1
+  · exact (hasDerivAt_fdBoundary_of_lt_one h1).differentiableAt
+  · exact absurd h1 htc.1
+  · rcases lt_trichotomy t 3 with h3 | h3 | h3
+    · exact (hasDerivAt_fdBoundary_of_mem_Ioo_one_three ⟨h1, h3⟩).differentiableAt
+    · exact absurd h3 htc.2.1
+    · rcases lt_trichotomy t 4 with h4 | h4 | h4
+      · exact (hasDerivAt_fdBoundary_of_mem_Ioo_three_four ⟨h3, h4⟩).differentiableAt
+      · exact absurd h4 htc.2.2
+      · exact (hasDerivAt_fdBoundary_of_gt_four h4).differentiableAt
+
+/-- Winding transport between two points of a preconnected region avoiding the contour. -/
+private lemma windingNumber_fdBoundary_eq_of_preconnected {S : Set ℂ}
+    (hconn : IsPreconnected S) (hdisj : S ⊆ (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ)
+    {w w' : ℂ} (hw : w ∈ S) (hw' : w' ∈ S) :
+    windingNumber (fdBoundary H) 0 5 w = windingNumber (fdBoundary H) 0 5 w' :=
+  windingNumber_eq_of_mem_connectedComponentIn (fdBoundary_closed H).symm
+    fdBoundaryCorners.finite_toSet.countable (continuous_fdBoundary H).continuousOn
+    differentiableAt_fdBoundary_off_corners
+    (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv
+    (hconn.subset_connectedComponentIn hw' hdisj hw)
+
+/-- The endpoint ratio of a piece has negative argument when its junction chord turns
+clockwise as seen from `w`; the four instances below feed the pinning argument. -/
+private lemma arg_div_neg {z₁ z₂ : ℂ} (hz₁ : z₁ ≠ 0)
+    (hnum : z₂.im * z₁.re - z₂.re * z₁.im < 0) : (z₂ / z₁).arg < 0 := by
+  rw [Complex.arg_neg_iff, Complex.div_im, div_sub_div_same]
+  exact div_neg_of_neg_of_pos hnum (Complex.normSq_pos.mpr hz₁)
+
+/-- The winding number of the boundary contour is `-1` on the open strip above the corner
+row: the region `|re w| < 1/2`, `1 < im w < H`. -/
+theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 1 / 2)
+    (hy1 : 1 < w.im) (hyH : w.im < H) : windingNumber (fdBoundary H) 0 5 w = -1 := by
+  obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hx
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have hnorm : 1 < ‖w‖ :=
+    hy1.trans_le ((le_abs_self _).trans (Complex.abs_im_le_norm w))
+  have hw := fdBoundary_ne_of_interior hx hnorm hyH
+  -- the four endpoint differences, their coordinates, and their nonvanishing
+  have hz₀ : (1 / 2 + H * Complex.I - w).re = 1 / 2 - w.re ∧
+      (1 / 2 + H * Complex.I - w).im = H - w.im := by constructor <;> simp
+  have hz₁ : ((ρ : ℂ) + 1 - w).re = 1 / 2 - w.re ∧
+      ((ρ : ℂ) + 1 - w).im = Real.sqrt 3 / 2 - w.im := by
+    constructor <;> simp [ρ]; norm_num
+  have hz₃ : ((ρ : ℂ) - w).re = -(1 / 2) - w.re ∧
+      ((ρ : ℂ) - w).im = Real.sqrt 3 / 2 - w.im := by
+    constructor <;> simp [ρ]; norm_num
+  have hz₄ : (-1 / 2 + H * Complex.I - w).re = -(1 / 2) - w.re ∧
+      (-1 / 2 + H * Complex.I - w).im = H - w.im := by constructor <;> simp; norm_num
+  have hne₀ : (1 / 2 + H * Complex.I - w) ≠ 0 := fun h0 => by
+    have := congrArg Complex.re h0; rw [hz₀.1] at this; simp at this; linarith
+  have hne₁ : ((ρ : ℂ) + 1 - w) ≠ 0 := fun h0 => by
+    have := congrArg Complex.re h0; rw [hz₁.1] at this; simp at this; linarith
+  have hne₃ : ((ρ : ℂ) - w) ≠ 0 := fun h0 => by
+    have := congrArg Complex.re h0; rw [hz₃.1] at this; simp at this; linarith
+  have hne₄ : (-1 / 2 + H * Complex.I - w) ≠ 0 := fun h0 => by
+    have := congrArg Complex.re h0; rw [hz₄.1] at this; simp at this; linarith
+  -- the four piece arguments are strictly negative
+  have ha₁ : ((((ρ : ℂ) + 1 - w)) / (1 / 2 + H * Complex.I - w)).arg < 0 :=
+    arg_div_neg hne₀ (by rw [hz₀.1, hz₀.2, hz₁.1, hz₁.2]; nlinarith)
+  have ha₂ : ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w)).arg < 0 :=
+    arg_div_neg hne₁ (by rw [hz₁.1, hz₁.2, hz₃.1, hz₃.2]; nlinarith)
+  have ha₃ : (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w)).arg < 0 :=
+    arg_div_neg hne₃ (by rw [hz₃.1, hz₃.2, hz₄.1, hz₄.2]; nlinarith)
+  have ha₄ : (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w)).arg < 0 :=
+    arg_div_neg hne₄ (by rw [hz₄.1, hz₄.2, hz₀.1, hz₀.2]; nlinarith)
+  -- the winding number is the normalized sum of the four principal logarithms
+  have hsum : windingNumber (fdBoundary H) 0 5 w =
+      (2 * (Real.pi : ℂ) * Complex.I)⁻¹ *
+        (Complex.log (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w)) +
+          Complex.log (((ρ : ℂ) - w) / ((ρ : ℂ) + 1 - w)) +
+          Complex.log ((-1 / 2 + H * Complex.I - w) / ((ρ : ℂ) - w)) +
+          Complex.log ((1 / 2 + H * Complex.I - w) / (-1 / 2 + H * Complex.I - w))) := by
+    rw [windingNumber_fdBoundary_eq_sum_pieces hw,
+      windingNumber_fdBoundary_segment1_eq_log hx₂,
+      windingNumber_fdBoundary_arc_eq_log hy1,
+      windingNumber_fdBoundary_segment4_eq_log hx₁,
+      windingNumber_fdBoundary_segment5_eq_log hyH]
+    ring
+  -- integrality
+  obtain ⟨n, hn⟩ := exists_int_windingNumber_of_closed (P := (fdBoundaryCorners : Set ℝ))
+    (fdBoundary_closed H).symm fdBoundaryCorners.finite_toSet.countable
+    (continuous_fdBoundary H).continuousOn differentiableAt_fdBoundary_off_corners
+    (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+    (intervalIntegrable_inv_sub_mul_deriv (continuous_fdBoundary H).continuousOn
+      (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)])
+      (isPiecewiseC1On_fdBoundary H).intervalIntegrable_deriv)
+  -- extract the argument sum and pin the integer
+  have hπ : (0 : ℝ) < Real.pi := Real.pi_pos
+  have hIm : 2 * Real.pi * (n : ℝ) =
+      (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w)).arg +
+        ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w)).arg +
+        (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w)).arg +
+        (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w)).arg := by
+    have h2πI : (2 * (Real.pi : ℂ) * Complex.I) ≠ 0 := by
+      simp [Complex.ext_iff, Real.pi_ne_zero]
+    have := hsum.symm.trans hn
+    rw [inv_mul_eq_iff_eq_mul₀ h2πI] at this
+    have hIm' := congrArg Complex.im this.symm
+    simpa [Complex.log_im, Complex.add_im, Complex.mul_im] using hIm'
+  have hb₁ := Complex.neg_pi_lt_arg (((ρ : ℂ) + 1 - w) / (1 / 2 + H * Complex.I - w))
+  have hb₂ := Complex.neg_pi_lt_arg ((((ρ : ℂ) - w)) / ((ρ : ℂ) + 1 - w))
+  have hb₃ := Complex.neg_pi_lt_arg (((-1 / 2 + H * Complex.I - w)) / ((ρ : ℂ) - w))
+  have hb₄ := Complex.neg_pi_lt_arg (((1 / 2 + H * Complex.I - w)) / (-1 / 2 + H * Complex.I - w))
+  have hn2 : (-2 : ℤ) < n := by
+    have : (-2 : ℝ) < (n : ℝ) := by nlinarith
+    exact_mod_cast this
+  have hn0 : n < 0 := by
+    have : ((n : ℝ)) < 0 := by nlinarith
+    exact_mod_cast this
+  have : n = -1 := by omega
+  rw [hn, this]
+  norm_num
+
+/-- Points of the lifted segment and of the strip box satisfy the interior avoidance
+facts: strip-bounded real part, norm above the circle, height below the ceiling. -/
+private lemma interior_avoiding_facts (hH : 1 < H) {w : ℂ} (hnorm : 1 < ‖w‖)
+    (hre : |w.re| < 1 / 2) (him : w.im < H) (hpos : 0 < w.im) {z : ℂ}
+    (hz : z ∈ segment ℝ w ((w.re : ℂ) + (((max w.im 1 + H) / 2 : ℝ) : ℂ) * Complex.I) ∪
+      {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H}) :
+    |z.re| < 1 / 2 ∧ 1 < ‖z‖ ∧ z.im < H := by
+  set y : ℝ := (max w.im 1 + H) / 2 with hy_def
+  have htop_re : ((w.re : ℂ) + (y : ℝ) * Complex.I).re = w.re := by simp
+  have htop_im : ((w.re : ℂ) + (y : ℝ) * Complex.I).im = y := by simp
+  have hyw : w.im ≤ y := by
+    rw [hy_def]
+    nlinarith [le_max_left w.im 1, him]
+  have hyH : y < H := by
+    rw [hy_def]
+    rcases max_cases w.im 1 with ⟨heq, -⟩ | ⟨heq, -⟩ <;> rw [heq] <;> nlinarith
+  rcases hz with hz | hz
+  · obtain ⟨a, b, ha, hb, hab, rfl⟩ := hz
+    have hre' : (a • w + b • ((w.re : ℂ) + (y : ℝ) * Complex.I)).re = w.re := by
+      rw [Complex.add_re, Complex.smul_re, Complex.smul_re, htop_re]
+      linear_combination w.re * hab
+    have him' : (a • w + b • ((w.re : ℂ) + (y : ℝ) * Complex.I)).im = a * w.im + b * y := by
+      rw [Complex.add_im, Complex.smul_im, Complex.smul_im, htop_im, smul_eq_mul, smul_eq_mul]
+    have hs_lb : w.im ≤ a * w.im + b * y := by nlinarith [mul_nonneg hb (sub_nonneg.mpr hyw)]
+    refine ⟨by rw [hre']; exact hre, ?_, by rw [him']; nlinarith⟩
+    have hw2 : 1 < w.re * w.re + w.im * w.im := by
+      have hsq := Complex.sq_norm w
+      rw [Complex.normSq_apply] at hsq
+      nlinarith [norm_nonneg w]
+    have himsq : w.im * w.im ≤ (a * w.im + b * y) * (a * w.im + b * y) :=
+      mul_self_le_mul_self hpos.le hs_lb
+    have hzsq : 1 < ‖a • w + b • ((w.re : ℂ) + (y : ℝ) * Complex.I)‖ ^ 2 := by
+      rw [Complex.sq_norm, Complex.normSq_apply, hre', him']
+      nlinarith
+    nlinarith [norm_nonneg (a • w + b • ((w.re : ℂ) + (y : ℝ) * Complex.I))]
+  · exact ⟨hz.1, lt_of_lt_of_le hz.2.1 ((le_abs_self _).trans (Complex.abs_im_le_norm z)),
+      hz.2.2⟩
+
+/-- **The boundary contour winds `-1` about every point of the open truncated fundamental
+domain**: interior points connect vertically into the strip above the corner row, where
+the value is pinned by `windingNumber_fdBoundary_eq_neg_one_of_one_lt_im`. -/
+theorem windingNumber_fdBoundary_eq_neg_one_of_interior (hH : 1 < H) {w : ℂ}
+    (hnorm : 1 < ‖w‖) (hre : |w.re| < 1 / 2) (hpos : 0 < w.im) (him : w.im < H) :
+    windingNumber (fdBoundary H) 0 5 w = -1 := by
+  set y : ℝ := (max w.im 1 + H) / 2 with hy_def
+  have hy1 : 1 < y := by
+    rw [hy_def]
+    nlinarith [le_max_right w.im 1]
+  have hyH : y < H := by
+    rw [hy_def]
+    rcases max_cases w.im 1 with ⟨heq, -⟩ | ⟨heq, -⟩ <;> rw [heq] <;> nlinarith
+  have htop_mem_box : ((w.re : ℂ) + (y : ℝ) * Complex.I) ∈
+      {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H} :=
+    ⟨by simpa using hre, by simpa using hy1, by simpa using hyH⟩
+  have hbox_convex : Convex ℝ {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H} := by
+    have hset : {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H} =
+        ({z : ℂ | z.re < 1 / 2} ∩ {z : ℂ | -(1 / 2) < z.re}) ∩
+          ({z : ℂ | 1 < z.im} ∩ {z : ℂ | z.im < H}) := by
+      ext z
+      simp only [Set.mem_ofPred_eq, Set.mem_inter_iff, abs_lt]
+      tauto
+    rw [hset]
+    exact ((convex_halfSpace_re_lt _).inter (convex_halfSpace_re_gt _)).inter
+      ((convex_halfSpace_im_gt _).inter (convex_halfSpace_im_lt _))
+  have hconn : IsPreconnected (segment ℝ w ((w.re : ℂ) + (y : ℝ) * Complex.I) ∪
+      {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H}) :=
+    IsPreconnected.union ((w.re : ℂ) + (y : ℝ) * Complex.I)
+      (right_mem_segment ℝ w _) htop_mem_box
+      (convex_segment w _).isPreconnected hbox_convex.isPreconnected
+  have hdisj : (segment ℝ w ((w.re : ℂ) + (y : ℝ) * Complex.I) ∪
+      {z : ℂ | |z.re| < 1 / 2 ∧ 1 < z.im ∧ z.im < H}) ⊆
+        (fdBoundary H '' uIcc (0 : ℝ) 5)ᶜ := by
+    rintro z hz ⟨t, ht, h_eq⟩
+    rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
+    obtain ⟨hz_re, hz_norm, hz_im⟩ := interior_avoiding_facts hH hnorm hre him hpos hz
+    exact fdBoundary_ne_of_interior hz_re hz_norm hz_im t ht h_eq
+  rw [windingNumber_fdBoundary_eq_of_preconnected hconn hdisj
+      (Or.inl (left_mem_segment ℝ w _)) (Or.inr htop_mem_box),
+    windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (by simpa using hre)
+      (by simpa using hy1) (by simpa using hyH)]
+
+end ModularForm
+
+end TauCeti
+
+end


### PR DESCRIPTION
Adds `FundamentalDomainBoundary/Interior.lean`: the boundary contour winds exactly `-1` about every point of the open truncated fundamental domain.

* `windingNumber_fdBoundary_eq_neg_one_of_one_lt_im` — on the open strip above the corner row, the four piece logarithms (#2058) sum over the decomposition (#2045); each argument lies in `(-π, 0)`, so the sum lies in `(-4π, 0)`, and integrality (`Contour.exists_int_windingNumber_of_closed`) pins the value to `-1`.
* `windingNumber_fdBoundary_eq_neg_one_of_interior` — every interior point: the vertical lift into the strip together with the open strip box is one preconnected region avoiding the contour, and the value transports (`Contour.windingNumber_eq_of_mem_connectedComponentIn`).

With the exterior null-homology (#2020) this completes the winding determination of the contour; the valence-formula residue count consumes both.

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence formula: the interior winding number is -1","id":"modular-valence-interior"}-->
