### PR TITLE
feat: generalise the normal-families chain to Banach-valued families

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Montel/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel/Basic.lean
@@ -69,10 +69,12 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {Ω : Set ℂ} {
 `Ω ⊆ ℂ` into a proper complex normed space `E` is normal: every sequence from it has a subsequence
 converging locally uniformly on `Ω`, and the limit is holomorphic.
 
-The local boundedness hypothesis cannot be dropped: on any *nonempty* open `Ω`, and for any unit
-vector `v : E`, the holomorphic family `F n z = n • v` has no locally uniformly convergent
-subsequence. (On `Ω = ∅` the conclusion is vacuous, so nonemptiness is needed for the
-counterexample.) Properness of `E` cannot be dropped either — see
+The local boundedness hypothesis cannot be dropped once `E` is nontrivial: on any *nonempty* open
+`Ω`, and for a unit vector `v : E`, the holomorphic family `F n z = n • v` has no locally uniformly
+convergent subsequence. Both qualifications are needed for that counterexample: on `Ω = ∅` the
+conclusion is vacuous, and on the trivial `E = 0` there is no unit vector and every family
+converges, so local boundedness is genuinely dispensable in those two degenerate cases.
+Properness of `E` cannot be dropped either — see
 `TauCeti.isCompact_closure_range_of_isLocallyBoundedOn`, where it enters; for a normed space over
 `ℂ` it is exactly finite-dimensionality, and the scalar case `E = ℂ` is the one the Riemann
 mapping theorem uses. -/

--- a/TauCeti/Analysis/Complex/Conformal/Montel/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel/Basic.lean
@@ -11,21 +11,22 @@ import Mathlib.Analysis.Complex.LocallyUniformLimit
 /-!
 # Montel's selection theorem
 
-A locally bounded family of holomorphic functions on an open set `Ω ⊆ ℂ` is a normal family: every
-sequence drawn from it has a subsequence converging locally uniformly on `Ω`, and the limit is
-again holomorphic. This is the **Montel selection** component of layer **L1 (normal families /
-Montel)** of the conformal-mapping roadmap, and the compactness engine the Riemann mapping theorem
-runs on. The other component L1 lists, Vitali's theorem, is proved in `Conformal/Vitali.lean`,
-which applies the selection theorem below.
+A locally bounded family of holomorphic maps of an open set `Ω ⊆ ℂ` into a proper complex normed
+space is a normal family: every sequence drawn from it has a subsequence converging locally
+uniformly on `Ω`, and the limit is again holomorphic. This is the **Montel selection** component of
+layer **L1 (normal families / Montel)** of the conformal-mapping roadmap, and the compactness
+engine the Riemann mapping theorem runs on (there with the scalar target `E = ℂ`). The other
+component L1 lists, Vitali's theorem, is proved in `Conformal/Vitali.lean`, which applies the
+selection theorem below.
 
 The compactness this runs on is `Conformal/Montel/Precompact.lean`: the restricted family is
-relatively compact in `C(↥Ω, ℂ)` with its compact-open topology, and there it is *equivalent* to
+relatively compact in `C(↥Ω, E)` with its compact-open topology, and there it is *equivalent* to
 local boundedness. What is added here is the passage from that compactness to a convergent
 subsequence, and the identification of the limit.
 
 An open subset of `ℂ` is locally compact and second countable, hence σ-compact and so hemicompact —
 a countable cofinal family of compacts — which is what makes the compact-open topology on
-`C(↥Ω, ℂ)` first countable (local compactness alone would not suffice), and
+`C(↥Ω, E)` first countable (local compactness alone would not suffice), and
 `IsCompact.tendsto_subseq` extracts a convergent subsequence. Finally
 `ContinuousMap.tendsto_iff_tendstoLocallyUniformly` turns compact-open convergence into locally
 uniform convergence, and `TendstoLocallyUniformlyOn.differentiableOn` gives holomorphy of the limit.
@@ -35,8 +36,8 @@ in `Conformal/Montel/Precompact.lean`, subsumes both.
 
 ## Main results
 
-* `TauCeti.montel` — a locally bounded family of holomorphic functions on an open set has a
-  locally uniformly convergent subsequence, with holomorphic limit.
+* `TauCeti.montel` — a locally bounded family of holomorphic maps of an open set into a proper
+  complex normed space has a locally uniformly convergent subsequence, with holomorphic limit.
 
 ## Coordination with upstream Mathlib
 
@@ -62,22 +63,26 @@ open Complex Metric Filter Topology Set BoundedContinuousFunction
 
 namespace TauCeti
 
-variable {Ω : Set ℂ} {F : ℕ → ℂ → ℂ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {Ω : Set ℂ} {F : ℕ → ℂ → E}
 
-/-- **Montel's selection theorem.** A locally bounded family of holomorphic functions on an open
-set `Ω ⊆ ℂ` is normal: every sequence from it has a subsequence converging locally uniformly on
-`Ω`, and the limit is holomorphic.
+/-- **Montel's selection theorem.** A locally bounded family of holomorphic maps of an open set
+`Ω ⊆ ℂ` into a proper complex normed space `E` is normal: every sequence from it has a subsequence
+converging locally uniformly on `Ω`, and the limit is holomorphic.
 
-The local boundedness hypothesis cannot be dropped: on any *nonempty* open `Ω`, the holomorphic
-family `F n z = n` has no locally uniformly convergent subsequence. (On `Ω = ∅` the conclusion is
-vacuous, so nonemptiness is needed for the counterexample.) -/
-theorem montel (hΩ : IsOpen Ω) (hF : ∀ n, DifferentiableOn ℂ (F n) Ω)
+The local boundedness hypothesis cannot be dropped: on any *nonempty* open `Ω`, and for any unit
+vector `v : E`, the holomorphic family `F n z = n • v` has no locally uniformly convergent
+subsequence. (On `Ω = ∅` the conclusion is vacuous, so nonemptiness is needed for the
+counterexample.) Properness of `E` cannot be dropped either — see
+`TauCeti.isCompact_closure_range_of_isLocallyBoundedOn`, where it enters; for a normed space over
+`ℂ` it is exactly finite-dimensionality, and the scalar case `E = ℂ` is the one the Riemann
+mapping theorem uses. -/
+theorem montel [ProperSpace E] (hΩ : IsOpen Ω) (hF : ∀ n, DifferentiableOn ℂ (F n) Ω)
     (hb : IsLocallyBoundedOn F Ω) :
-    ∃ (φ : ℕ → ℕ) (g : ℂ → ℂ), StrictMono φ ∧ DifferentiableOn ℂ g Ω ∧
+    ∃ (φ : ℕ → ℕ) (g : ℂ → E), StrictMono φ ∧ DifferentiableOn ℂ g Ω ∧
       TendstoLocallyUniformlyOn (fun n => F (φ n)) g atTop Ω := by
   classical
   have : LocallyCompactSpace Ω := hΩ.locallyCompactSpace
-  set f : ℕ → C(Ω, ℂ) := fun n => ⟨Ω.domRestrict (F n), ((hF n).continuousOn).domRestrict⟩
+  set f : ℕ → C(Ω, E) := fun n => ⟨Ω.domRestrict (F n), ((hF n).continuousOn).domRestrict⟩
   -- The relative compactness of the restricted family, from `Conformal/Montel/Precompact.lean`.
   have hcpt : IsCompact (closure (Set.range f)) :=
     isCompact_closure_range_of_isLocallyBoundedOn hΩ hF hb fun _ => rfl

--- a/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
@@ -129,9 +129,11 @@ maps of an open set `Ω ⊆ ℂ` into a proper complex normed space `E` restrict
 compact family in the space `C(↥Ω, E)` of continuous maps with the compact-open topology.
 
 This is the precompactness the roadmap's L1 milestone asks for; `TauCeti.montel` is the sequential
-selection statement extracted from it. The local boundedness hypothesis cannot be dropped: on a
-nonempty open `Ω` the holomorphic family `F n z = n • v`, for a unit vector `v`, restricts to a
-closed discrete — hence non-relatively-compact — family. Properness of `E` cannot be dropped
+selection statement extracted from it. The local boundedness hypothesis cannot be dropped once `E`
+is nontrivial: on a nonempty open `Ω` the holomorphic family `F n z = n • v`, for a unit vector
+`v : E`, restricts to a closed discrete — hence non-relatively-compact — family. On `Ω = ∅`, or on
+the trivial `E = 0` where no unit vector exists, the conclusion holds regardless, so there is no
+counterexample in those two degenerate cases. Properness of `E` cannot be dropped
 either: it is what turns the pointwise norm bound into pointwise relative compactness, and for a
 normed space over `ℂ` it says exactly that `E` is finite-dimensional. -/
 theorem isCompact_closure_range_of_isLocallyBoundedOn [ProperSpace E] (hΩ : IsOpen Ω)

--- a/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
@@ -19,14 +19,14 @@ Layer **L1 (normal families / Montel)** of the conformal-mapping roadmap
 and `Conformal/Montel/Basic.lean` records the *selection* consequence: every sequence drawn from a
 locally bounded family of holomorphic functions has a locally uniformly convergent subsequence.
 This file isolates the compactness statement that selection consequence rests on, in the space
-where "precompact" literally means precompact — the space `C(↥Ω, ℂ)` of continuous maps on the
+where "precompact" literally means precompact — the space `C(↥Ω, E)` of continuous maps on the
 domain with its compact-open topology, whose convergence *is* locally uniform convergence — and
 shows that local boundedness is not merely sufficient for it but equivalent to it.
 
 ## The two directions
 
-A family `F : ι → ℂ → ℂ` of functions holomorphic on an open `Ω` restricts to a family
-`f : ι → C(↥Ω, ℂ)`; the theorems below take that restriction as a hypothesis
+A family `F : ι → ℂ → E` of functions holomorphic on an open `Ω` restricts to a family
+`f : ι → C(↥Ω, E)`; the theorems below take that restriction as a hypothesis
 `⇑(f i) = Ω.domRestrict (F i)` rather than fixing one bundling, so that a caller which already
 carries such an `f` may use them directly. The hypothesis constrains nothing: a caller holding
 `hF : ∀ i, ContinuousOn (F i) Ω` and no `f` of its own takes
@@ -41,21 +41,26 @@ family sits inside the uniform-on-compacts function space as a closed subspace
 compactness is local boundedness at a single point. This is the direction with analytic content —
 holomorphy enters only through the Cauchy estimate behind the equicontinuity.
 
+That pointwise step is also the only place the target matters: a norm bound confines the values to
+a closed ball, and for the ball to be compact `E` must be proper. So this direction is stated for
+a proper `E` — for a normed space over `ℂ` that is exactly finite-dimensionality — and the
+converse, which merely reads a bound off a compact set, for an arbitrary one.
+
 *Relatively compact ⇒ locally bounded* is a soft argument and needs no holomorphy at all, nor even
 openness of `Ω`: local compactness of the subtype `↥Ω` is all it uses. On a compact `K ⊆ Ω` the
 product `closure (range f) ×ˢ (Subtype.val ⁻¹' K)` is compact, local compactness of `↥Ω` makes
-evaluation `C(↥Ω, ℂ) × ↥Ω → ℂ` continuous in both variables at once, and a continuous real function
+evaluation `C(↥Ω, E) × ↥Ω → E` continuous in both variables at once, and a continuous real function
 on a compact set is bounded. The bound obtained is uniform in the index, which is exactly
 `TauCeti.IsLocallyBoundedOn`.
 
 Together they give `TauCeti.isCompact_closure_range_iff_isLocallyBoundedOn`: for a family of
-holomorphic functions on an open set, relative compactness in `C(↥Ω, ℂ)` and local boundedness are
-the same condition.
+holomorphic maps of an open set into a proper `E`, relative compactness in `C(↥Ω, E)` and local
+boundedness are the same condition.
 
 ## Main results
 
 * `TauCeti.isCompact_closure_range_of_isLocallyBoundedOn` — a locally bounded family of
-  holomorphic functions on an open set is relatively compact in `C(↥Ω, ℂ)`.
+  holomorphic maps of an open set into a proper `E` is relatively compact in `C(↥Ω, E)`.
 * `TauCeti.isLocallyBoundedOn_of_isCompact_closure_range` — the converse, for any family of
   maps on a set whose subtype is locally compact.
 * `TauCeti.isCompact_closure_range_iff_isLocallyBoundedOn` — the two are equivalent.
@@ -85,7 +90,8 @@ open Complex Metric Filter Topology Set
 
 namespace TauCeti
 
-variable {ι : Type*} {Ω : Set ℂ} {F : ι → ℂ → ℂ} {f : ι → C(Ω, ℂ)}
+variable {ι E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {Ω : Set ℂ} {F : ι → ℂ → E}
+  {f : ι → C(Ω, E)}
 
 -- `C(X, Y)` sits inside the uniform-on-compacts function space as a closed subspace: the
 -- coercion is a uniform embedding, and its range is the continuous maps, which is closed when
@@ -119,19 +125,21 @@ private theorem equicontinuous_subtype_val_range {X Y : Type*} [TopologicalSpace
   exact h.comp σ
 
 /-- **Montel's theorem, relative-compactness form.** A locally bounded family of holomorphic
-functions on an open set `Ω ⊆ ℂ` restricts to a relatively compact family in the space
-`C(↥Ω, ℂ)` of continuous maps with the compact-open topology.
+maps of an open set `Ω ⊆ ℂ` into a proper complex normed space `E` restricts to a relatively
+compact family in the space `C(↥Ω, E)` of continuous maps with the compact-open topology.
 
 This is the precompactness the roadmap's L1 milestone asks for; `TauCeti.montel` is the sequential
 selection statement extracted from it. The local boundedness hypothesis cannot be dropped: on a
-nonempty open `Ω` the holomorphic family `F n z = n` restricts to a closed discrete — hence
-non-relatively-compact — family. -/
-theorem isCompact_closure_range_of_isLocallyBoundedOn (hΩ : IsOpen Ω)
+nonempty open `Ω` the holomorphic family `F n z = n • v`, for a unit vector `v`, restricts to a
+closed discrete — hence non-relatively-compact — family. Properness of `E` cannot be dropped
+either: it is what turns the pointwise norm bound into pointwise relative compactness, and for a
+normed space over `ℂ` it says exactly that `E` is finite-dimensional. -/
+theorem isCompact_closure_range_of_isLocallyBoundedOn [ProperSpace E] (hΩ : IsOpen Ω)
     (hF : ∀ i, DifferentiableOn ℂ (F i) Ω) (hb : IsLocallyBoundedOn F Ω)
     (hf : ∀ i, ⇑(f i) = Ω.domRestrict (F i)) :
     IsCompact (closure (Set.range f)) := by
   have : LocallyCompactSpace Ω := hΩ.locallyCompactSpace
-  have heq : Equicontinuous fun i => (f i : Ω → ℂ) := by
+  have heq : Equicontinuous fun i => (f i : Ω → E) := by
     rw [funext hf]
     exact (equicontinuous_restrict_iff F).mpr (hb.equicontinuousOn hΩ hF)
   -- Arzelà–Ascoli in the compact-open topology: equicontinuity comes from Cauchy's estimate and
@@ -145,14 +153,15 @@ theorem isCompact_closure_range_of_isLocallyBoundedOn (hΩ : IsOpen Ω)
   obtain ⟨i, rfl⟩ := hg
   simpa [hf i, mem_closedBall, dist_zero_right] using hC i
 
-/-- **The converse of Montel's theorem.** A family of functions on a set `Ω ⊆ ℂ` with locally
-compact subtype whose restrictions are relatively compact in `C(↥Ω, ℂ)` is locally bounded on `Ω`.
+omit [NormedSpace ℂ E] in
+/-- **The converse of Montel's theorem.** A family of maps on a set `Ω ⊆ ℂ` with locally compact
+subtype whose restrictions are relatively compact in `C(↥Ω, E)` is locally bounded on `Ω`.
 
-No holomorphy is needed, nor even continuity beyond what the restrictions already carry:
-evaluation is continuous in the map and the point together as soon as `↥Ω` is locally compact
-(for an open `Ω` the instance is `IsOpen.locallyCompactSpace`), so a continuous real function on
-the compact product `closure (Set.range f) ×ˢ (Subtype.val ⁻¹' K)` is bounded — and its bound is
-uniform in the index, which is what local boundedness asserts. -/
+No holomorphy is needed, nor even continuity beyond what the restrictions already carry, and no
+properness of the target: evaluation is continuous in the map and the point together as soon as
+`↥Ω` is locally compact (for an open `Ω` the instance is `IsOpen.locallyCompactSpace`), so a
+continuous real function on the compact product `closure (Set.range f) ×ˢ (Subtype.val ⁻¹' K)` is
+bounded — and its bound is uniform in the index, which is what local boundedness asserts. -/
 theorem isLocallyBoundedOn_of_isCompact_closure_range [LocallyCompactSpace Ω]
     (hf : ∀ i, ⇑(f i) = Ω.domRestrict (F i)) (hcpt : IsCompact (closure (Set.range f))) :
     IsLocallyBoundedOn F Ω := by
@@ -160,19 +169,19 @@ theorem isLocallyBoundedOn_of_isCompact_closure_range [LocallyCompactSpace Ω]
   have hK' : IsCompact (Subtype.val ⁻¹' K : Set Ω) := by
     refine Topology.IsEmbedding.subtypeVal.isCompact_iff.2 ?_
     rwa [Subtype.image_preimage_val, inter_eq_self_of_subset_right hKΩ]
-  have hcont : Continuous fun p : C(Ω, ℂ) × Ω => ‖p.1 p.2‖ := continuous_eval.norm
+  have hcont : Continuous fun p : C(Ω, E) × Ω => ‖p.1 p.2‖ := continuous_eval.norm
   obtain ⟨C, hC⟩ := ((hcpt.prod hK').image hcont).bddAbove
   refine ⟨C, fun i z hz => ?_⟩
-  have hmem : ((f i, (⟨z, hKΩ hz⟩ : Ω)) : C(Ω, ℂ) × Ω) ∈
+  have hmem : ((f i, (⟨z, hKΩ hz⟩ : Ω)) : C(Ω, E) × Ω) ∈
       closure (Set.range f) ×ˢ (Subtype.val ⁻¹' K : Set Ω) :=
     ⟨subset_closure ⟨i, rfl⟩, hz⟩
   have hle : ‖(f i) (⟨z, hKΩ hz⟩ : Ω)‖ ≤ C := hC (mem_image_of_mem _ hmem)
   rwa [hf i] at hle
 
-/-- **Montel's theorem as an equivalence.** For a family of holomorphic functions on an open set
-`Ω ⊆ ℂ`, being locally bounded on `Ω` and being relatively compact in `C(↥Ω, ℂ)` are the same
-condition. -/
-theorem isCompact_closure_range_iff_isLocallyBoundedOn (hΩ : IsOpen Ω)
+/-- **Montel's theorem as an equivalence.** For a family of holomorphic maps of an open set
+`Ω ⊆ ℂ` into a proper complex normed space `E`, being locally bounded on `Ω` and being relatively
+compact in `C(↥Ω, E)` are the same condition. -/
+theorem isCompact_closure_range_iff_isLocallyBoundedOn [ProperSpace E] (hΩ : IsOpen Ω)
     (hF : ∀ i, DifferentiableOn ℂ (F i) Ω) (hf : ∀ i, ⇑(f i) = Ω.domRestrict (F i)) :
     IsCompact (closure (Set.range f)) ↔ IsLocallyBoundedOn F Ω :=
   haveI : LocallyCompactSpace Ω := hΩ.locallyCompactSpace

--- a/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Montel/Precompact.lean
@@ -47,7 +47,8 @@ a proper `E` — for a normed space over `ℂ` that is exactly finite-dimensiona
 converse, which merely reads a bound off a compact set, for an arbitrary one.
 
 *Relatively compact ⇒ locally bounded* is a soft argument and needs no holomorphy at all, nor even
-openness of `Ω`: local compactness of the subtype `↥Ω` is all it uses. On a compact `K ⊆ Ω` the
+openness of `Ω` or a complex domain: it is stated for a set `Ω` in an arbitrary topological space,
+because local compactness of the subtype `↥Ω` is all it uses. On a compact `K ⊆ Ω` the
 product `closure (range f) ×ˢ (Subtype.val ⁻¹' K)` is compact, local compactness of `↥Ω` makes
 evaluation `C(↥Ω, E) × ↥Ω → E` continuous in both variables at once, and a continuous real function
 on a compact set is bounded. The bound obtained is uniform in the index, which is exactly
@@ -62,7 +63,7 @@ boundedness are the same condition.
 * `TauCeti.isCompact_closure_range_of_isLocallyBoundedOn` — a locally bounded family of
   holomorphic maps of an open set into a proper `E` is relatively compact in `C(↥Ω, E)`.
 * `TauCeti.isLocallyBoundedOn_of_isCompact_closure_range` — the converse, for any family of
-  maps on a set whose subtype is locally compact.
+  maps on a set in a topological space whose subtype is locally compact.
 * `TauCeti.isCompact_closure_range_iff_isLocallyBoundedOn` — the two are equivalent.
 
 ## Coordination with upstream Mathlib
@@ -155,15 +156,22 @@ theorem isCompact_closure_range_of_isLocallyBoundedOn [ProperSpace E] (hΩ : IsO
   obtain ⟨i, rfl⟩ := hg
   simpa [hf i, mem_closedBall, dist_zero_right] using hC i
 
+section GeneralDomain
+
+-- The converse direction is pure topology: it never differentiates, so the domain need not be
+-- `ℂ`, only a topological space whose subtype `↥Ω` is locally compact.
+variable {X : Type*} [TopologicalSpace X] {Ω : Set X} {F : ι → X → E} {f : ι → C(Ω, E)}
+
 omit [NormedSpace ℂ E] in
-/-- **The converse of Montel's theorem.** A family of maps on a set `Ω ⊆ ℂ` with locally compact
+/-- **The converse of Montel's theorem.** A family of maps on a set `Ω` with locally compact
 subtype whose restrictions are relatively compact in `C(↥Ω, E)` is locally bounded on `Ω`.
 
-No holomorphy is needed, nor even continuity beyond what the restrictions already carry, and no
-properness of the target: evaluation is continuous in the map and the point together as soon as
-`↥Ω` is locally compact (for an open `Ω` the instance is `IsOpen.locallyCompactSpace`), so a
-continuous real function on the compact product `closure (Set.range f) ×ˢ (Subtype.val ⁻¹' K)` is
-bounded — and its bound is uniform in the index, which is what local boundedness asserts. -/
+No holomorphy is needed — not even a complex domain, nor continuity beyond what the restrictions
+already carry — and no properness of the target: evaluation is continuous in the map and the point
+together as soon as `↥Ω` is locally compact (for an open `Ω ⊆ ℂ` the instance is
+`IsOpen.locallyCompactSpace`), so a continuous real function on the compact product
+`closure (Set.range f) ×ˢ (Subtype.val ⁻¹' K)` is bounded — and its bound is uniform in the index,
+which is what local boundedness asserts. -/
 theorem isLocallyBoundedOn_of_isCompact_closure_range [LocallyCompactSpace Ω]
     (hf : ∀ i, ⇑(f i) = Ω.domRestrict (F i)) (hcpt : IsCompact (closure (Set.range f))) :
     IsLocallyBoundedOn F Ω := by
@@ -179,6 +187,8 @@ theorem isLocallyBoundedOn_of_isCompact_closure_range [LocallyCompactSpace Ω]
     ⟨subset_closure ⟨i, rfl⟩, hz⟩
   have hle : ‖(f i) (⟨z, hKΩ hz⟩ : Ω)‖ ≤ C := hC (mem_image_of_mem _ hmem)
   rwa [hf i] at hle
+
+end GeneralDomain
 
 /-- **Montel's theorem as an equivalence.** For a family of holomorphic maps of an open set
 `Ω ⊆ ℂ` into a proper complex normed space `E`, being locally bounded on `Ω` and being relatively

--- a/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
+++ b/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
@@ -21,14 +21,18 @@ bounded on every compact subset of `U` — is automatically equicontinuous on `U
 analytic heart of Montel's normal-families theorem: combined with Arzelà--Ascoli and an
 exhaustion/diagonal argument, it yields precompactness for local uniform convergence.
 
-Everything here is stated for maps `ℂ → E` into a complex normed space, because nothing in a
+The estimates here are stated for maps `ℂ → E` into a complex normed space, because nothing in a
 Cauchy estimate uses the multiplicative structure of the target: Mathlib's
 `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le`, which is the sole analytic input, is itself
 `E`-valued.  Only `TauCeti.IsLocallyBoundedOn.equicontinuousOn_deriv` needs `E` complete, and
-that is because it differentiates twice.  Local boundedness itself is a statement about `‖·‖`
-alone, so `TauCeti.IsLocallyBoundedOn` and its elementary API ask only for `[Norm E]`; the normed
-complex vector space structure enters with the Cauchy estimates.  Taking `E = ℂ` recovers the
-scalar statements.
+that is because it differentiates twice.  Taking `E = ℂ` recovers the scalar statements.
+
+Local boundedness itself is a statement about compact subsets of the domain and about `‖·‖`
+alone: it mentions neither holomorphy nor the complex structure of either side.  So
+`TauCeti.IsLocallyBoundedOn` and its elementary API are stated for a family of maps `X → E` from
+an arbitrary topological space into a type with a norm.  The domain specialises to `ℂ`, and the
+target acquires its normed complex vector space structure, exactly where holomorphy is first
+assumed: at the Cauchy estimates below.
 
 The mechanism is Cauchy's estimate for the first derivative.  Mathlib's
 `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le` bounds `‖deriv f c‖` at the *centre* of a
@@ -40,8 +44,8 @@ the family, which is exactly equicontinuity.
 
 ## Main definitions
 
-* `TauCeti.IsLocallyBoundedOn F s`: the family `F` is uniformly bounded on every compact subset
-  of `s`.
+* `TauCeti.IsLocallyBoundedOn F s`: the family `F` of maps out of a topological space is
+  uniformly bounded on every compact subset of `s`.
 * `TauCeti.IsLocallyBoundedOn.comp`: local boundedness passes to any reindexing of the family,
   in particular to a subsequence.
 
@@ -81,28 +85,30 @@ namespace TauCeti
 
 open Filter Metric Set Topology
 
-variable {ι E : Type*} {U : Set ℂ} {f : ℂ → E} {F : ι → ℂ → E}
+variable {ι E : Type*} {U : Set ℂ} {f : ℂ → E}
 
 section LocallyBounded
 
-variable [Norm E]
+variable {X : Type*} [TopologicalSpace X] [Norm E] {s t : Set X} {F : ι → X → E}
 
-/-- A family `F : ι → ℂ → E` is **locally bounded** on `s` if it is uniformly bounded — with a
-single constant, independent of the index — on every compact subset of `s`.
+/-- A family `F : ι → X → E` of maps from a topological space into a type with a norm is
+**locally bounded** on `s` if it is uniformly bounded — with a single constant, independent of
+the index — on every compact subset of `s`.
 
-This is the hypothesis of Montel's theorem, in the form fixed by the conformal-mapping roadmap. -/
-def IsLocallyBoundedOn (F : ι → ℂ → E) (s : Set ℂ) : Prop :=
+This is the hypothesis of Montel's theorem, in the form fixed by the conformal-mapping roadmap;
+there `X = ℂ` and `E` is a complex normed space. -/
+def IsLocallyBoundedOn (F : ι → X → E) (s : Set X) : Prop :=
   ∀ K ⊆ s, IsCompact K → ∃ C, ∀ i, ∀ z ∈ K, ‖F i z‖ ≤ C
 
 /-- The defining compact-set characterization of local boundedness. -/
 @[simp]
 theorem isLocallyBoundedOn_def :
-    IsLocallyBoundedOn F U ↔
-      ∀ K ⊆ U, IsCompact K → ∃ C, ∀ i, ∀ z ∈ K, ‖F i z‖ ≤ C :=
+    IsLocallyBoundedOn F s ↔
+      ∀ K ⊆ s, IsCompact K → ∃ C, ∀ i, ∀ z ∈ K, ‖F i z‖ ≤ C :=
   Iff.rfl
 
 /-- Local boundedness is inherited by subsets. -/
-theorem IsLocallyBoundedOn.mono {s t : Set ℂ} (hb : IsLocallyBoundedOn F s) (hts : t ⊆ s) :
+theorem IsLocallyBoundedOn.mono (hb : IsLocallyBoundedOn F s) (hts : t ⊆ s) :
     IsLocallyBoundedOn F t :=
   fun _K hKt hK => hb _ (hKt.trans hts) hK
 
@@ -111,7 +117,7 @@ uniform in the index, so it survives being restricted to a subfamily.
 
 The case `σ : ℕ → ℕ` is the one Montel-based arguments use, where passing to a subsequence must
 not lose the hypothesis. -/
-theorem IsLocallyBoundedOn.comp {κ : Type*} {s : Set ℂ} (hb : IsLocallyBoundedOn F s)
+theorem IsLocallyBoundedOn.comp {κ : Type*} (hb : IsLocallyBoundedOn F s)
     (σ : κ → ι) : IsLocallyBoundedOn (fun k => F (σ k)) s := by
   intro K hKs hK
   obtain ⟨C, hC⟩ := hb K hKs hK
@@ -121,13 +127,13 @@ theorem IsLocallyBoundedOn.comp {κ : Type*} {s : Set ℂ} (hb : IsLocallyBounde
 
 Together with `IsLocallyBoundedOn.equicontinuousOn`, this supplies the pointwise bounds used in
 an Arzelà--Ascoli exhaustion argument. -/
-theorem IsLocallyBoundedOn.exists_forall_norm_le {s : Set ℂ} (hb : IsLocallyBoundedOn F s) {z : ℂ}
+theorem IsLocallyBoundedOn.exists_forall_norm_le (hb : IsLocallyBoundedOn F s) {z : X}
     (hz : z ∈ s) : ∃ C, ∀ i, ‖F i z‖ ≤ C := by
   obtain ⟨C, hC⟩ := hb {z} (singleton_subset_iff.2 hz) isCompact_singleton
   exact ⟨C, fun i => hC i z (mem_singleton z)⟩
 
 /-- A family bounded by a single constant on all of `s` is locally bounded on `s`. -/
-theorem isLocallyBoundedOn_of_forall_norm_le {s : Set ℂ} {C : ℝ}
+theorem isLocallyBoundedOn_of_forall_norm_le {C : ℝ}
     (h : ∀ i, ∀ z ∈ s, ‖F i z‖ ≤ C) : IsLocallyBoundedOn F s :=
   fun _K hKs _hK => ⟨C, fun i z hz => h i z (hKs hz)⟩
 
@@ -148,7 +154,7 @@ private theorem exists_pos_closedBall_two_mul_subset (hU : IsOpen U) {z : ℂ} (
 
 section Estimates
 
-variable [NormedAddCommGroup E] [NormedSpace ℂ E]
+variable [NormedAddCommGroup E] [NormedSpace ℂ E] {F : ι → ℂ → E}
 
 /-- **Cauchy's estimate on a closed ball.** If `f` is holomorphic on an open set `U` containing
 `closedBall c r` and `‖f‖ ≤ M` on that closed ball, then `‖deriv f c‖ ≤ M / r`.

--- a/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
+++ b/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
@@ -25,7 +25,10 @@ Everything here is stated for maps `ℂ → E` into a complex normed space, beca
 Cauchy estimate uses the multiplicative structure of the target: Mathlib's
 `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le`, which is the sole analytic input, is itself
 `E`-valued.  Only `TauCeti.IsLocallyBoundedOn.equicontinuousOn_deriv` needs `E` complete, and
-that is because it differentiates twice.  Taking `E = ℂ` recovers the scalar statements.
+that is because it differentiates twice.  Local boundedness itself is a statement about `‖·‖`
+alone, so `TauCeti.IsLocallyBoundedOn` and its elementary API ask only for `[Norm E]`; the normed
+complex vector space structure enters with the Cauchy estimates.  Taking `E = ℂ` recovers the
+scalar statements.
 
 The mechanism is Cauchy's estimate for the first derivative.  Mathlib's
 `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le` bounds `‖deriv f c‖` at the *centre* of a
@@ -78,7 +81,11 @@ namespace TauCeti
 
 open Filter Metric Set Topology
 
-variable {ι E : Type*} [NormedAddCommGroup E] {U : Set ℂ} {f : ℂ → E} {F : ι → ℂ → E}
+variable {ι E : Type*} {U : Set ℂ} {f : ℂ → E} {F : ι → ℂ → E}
+
+section LocallyBounded
+
+variable [Norm E]
 
 /-- A family `F : ι → ℂ → E` is **locally bounded** on `s` if it is uniformly bounded — with a
 single constant, independent of the index — on every compact subset of `s`.
@@ -124,6 +131,8 @@ theorem isLocallyBoundedOn_of_forall_norm_le {s : Set ℂ} {C : ℝ}
     (h : ∀ i, ∀ z ∈ s, ‖F i z‖ ≤ C) : IsLocallyBoundedOn F s :=
   fun _K hKs _hK => ⟨C, fun i z hz => h i z (hKs hz)⟩
 
+end LocallyBounded
+
 /-- Every point of an open set admits a radius `r > 0` with `closedBall z (2 * r) ⊆ U`.
 
 The doubled radius is what lets the Cauchy estimate below be applied at every point of
@@ -139,7 +148,7 @@ private theorem exists_pos_closedBall_two_mul_subset (hU : IsOpen U) {z : ℂ} (
 
 section Estimates
 
-variable [NormedSpace ℂ E]
+variable [NormedAddCommGroup E] [NormedSpace ℂ E]
 
 /-- **Cauchy's estimate on a closed ball.** If `f` is holomorphic on an open set `U` containing
 `closedBall c r` and `‖f‖ ≤ M` on that closed ball, then `‖deriv f c‖ ≤ M / r`.

--- a/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
+++ b/TauCeti/Analysis/Complex/Conformal/NormalFamilies.lean
@@ -18,9 +18,14 @@ import Mathlib.Topology.MetricSpace.Thickening
 
 A family of holomorphic functions on an open set `U ⊆ ℂ` that is *locally bounded* — uniformly
 bounded on every compact subset of `U` — is automatically equicontinuous on `U`.  This is the
-analytic heart of Montel's normal-families theorem: for complex-valued functions, combined with
-Arzelà--Ascoli and an exhaustion/diagonal argument, it yields precompactness for local uniform
-convergence.
+analytic heart of Montel's normal-families theorem: combined with Arzelà--Ascoli and an
+exhaustion/diagonal argument, it yields precompactness for local uniform convergence.
+
+Everything here is stated for maps `ℂ → E` into a complex normed space, because nothing in a
+Cauchy estimate uses the multiplicative structure of the target: Mathlib's
+`Complex.norm_deriv_le_of_forall_mem_sphere_norm_le`, which is the sole analytic input, is itself
+`E`-valued.  Only `TauCeti.IsLocallyBoundedOn.equicontinuousOn_deriv` needs `E` complete, and
+that is because it differentiates twice.  Taking `E = ℂ` recovers the scalar statements.
 
 The mechanism is Cauchy's estimate for the first derivative.  Mathlib's
 `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le` bounds `‖deriv f c‖` at the *centre* of a
@@ -34,6 +39,8 @@ the family, which is exactly equicontinuity.
 
 * `TauCeti.IsLocallyBoundedOn F s`: the family `F` is uniformly bounded on every compact subset
   of `s`.
+* `TauCeti.IsLocallyBoundedOn.comp`: local boundedness passes to any reindexing of the family,
+  in particular to a subsequence.
 
 ## Main results
 
@@ -50,12 +57,15 @@ the family, which is exactly equicontinuity.
   derivatives of a locally bounded family of holomorphic functions are again locally bounded, hence
   also equicontinuous.
 
-This advances the L1 (normal families / Montel) layer of the conformal-mapping roadmap, whose
-generality bar requires scalar-valued functions `ℂ → ℂ` and fixes local boundedness as "bounded on
-each compact `K ⊆ Ω`".  As with the rest of the L0--L3 conformal-mapping material it is coordinated
-with the upstream Mathlib Riemann-mapping effort leanprover-community/mathlib4#33505, which proves a
-Montel equicontinuity statement internally as a private lemma; these declarations are a temporary
-shim, to be deleted and refactored to Mathlib's API once that human-curated work lands.
+This advances the L1 (normal families / Montel) layer of the conformal-mapping roadmap, which
+fixes local boundedness as "bounded on each compact `K ⊆ Ω`".  The roadmap's scalar generality bar
+governs the *conformal* statements it adds — Rouché, Hurwitz, the Riemann mapping theorem — whose
+hypotheses genuinely use `ℂ` as the target; the Cauchy estimates below are the inputs those
+statements consume, and are stated at the generality Mathlib already provides for them.  As with
+the rest of the L0--L3 conformal-mapping material it is coordinated with the upstream Mathlib
+Riemann-mapping effort leanprover-community/mathlib4#33505, which proves a Montel equicontinuity
+statement internally as a private lemma; these declarations are a temporary shim, to be deleted
+and refactored to Mathlib's API once that human-curated work lands.
 
 ## References
 
@@ -68,13 +78,13 @@ namespace TauCeti
 
 open Filter Metric Set Topology
 
-variable {ι : Type*} {U : Set ℂ} {f : ℂ → ℂ} {F : ι → ℂ → ℂ}
+variable {ι E : Type*} [NormedAddCommGroup E] {U : Set ℂ} {f : ℂ → E} {F : ι → ℂ → E}
 
-/-- A family `F : ι → ℂ → ℂ` is **locally bounded** on `s` if it is uniformly bounded — with a
+/-- A family `F : ι → ℂ → E` is **locally bounded** on `s` if it is uniformly bounded — with a
 single constant, independent of the index — on every compact subset of `s`.
 
 This is the hypothesis of Montel's theorem, in the form fixed by the conformal-mapping roadmap. -/
-def IsLocallyBoundedOn (F : ι → ℂ → ℂ) (s : Set ℂ) : Prop :=
+def IsLocallyBoundedOn (F : ι → ℂ → E) (s : Set ℂ) : Prop :=
   ∀ K ⊆ s, IsCompact K → ∃ C, ∀ i, ∀ z ∈ K, ‖F i z‖ ≤ C
 
 /-- The defining compact-set characterization of local boundedness. -/
@@ -88,6 +98,17 @@ theorem isLocallyBoundedOn_def :
 theorem IsLocallyBoundedOn.mono {s t : Set ℂ} (hb : IsLocallyBoundedOn F s) (hts : t ⊆ s) :
     IsLocallyBoundedOn F t :=
   fun _K hKt hK => hb _ (hKt.trans hts) hK
+
+/-- Local boundedness is inherited by any reindexing of the family: the bound on a compact set is
+uniform in the index, so it survives being restricted to a subfamily.
+
+The case `σ : ℕ → ℕ` is the one Montel-based arguments use, where passing to a subsequence must
+not lose the hypothesis. -/
+theorem IsLocallyBoundedOn.comp {κ : Type*} {s : Set ℂ} (hb : IsLocallyBoundedOn F s)
+    (σ : κ → ι) : IsLocallyBoundedOn (fun k => F (σ k)) s := by
+  intro K hKs hK
+  obtain ⟨C, hC⟩ := hb K hKs hK
+  exact ⟨C, fun k => hC (σ k)⟩
 
 /-- A locally bounded family is bounded at each point of the set, uniformly in the index.
 
@@ -117,6 +138,8 @@ private theorem exists_pos_closedBall_two_mul_subset (hU : IsOpen U) {z : ℂ} (
   exact (closedBall_subset_cthickening (mem_singleton z) δ).trans hδU
 
 section Estimates
+
+variable [NormedSpace ℂ E]
 
 /-- **Cauchy's estimate on a closed ball.** If `f` is holomorphic on an open set `U` containing
 `closedBall c r` and `‖f‖ ≤ M` on that closed ball, then `‖deriv f c‖ ≤ M / r`.
@@ -213,9 +236,12 @@ theorem IsLocallyBoundedOn.deriv (hb : IsLocallyBoundedOn F U) (hU : IsOpen U)
 /-- The derivatives of a locally bounded family of holomorphic functions are equicontinuous.
 
 The result follows by applying the preceding equicontinuity theorem to the locally bounded
-derivative family. -/
-theorem IsLocallyBoundedOn.equicontinuousOn_deriv (hb : IsLocallyBoundedOn F U) (hU : IsOpen U)
-    (hF : ∀ i, DifferentiableOn ℂ (F i) U) : EquicontinuousOn (fun i => _root_.deriv (F i)) U :=
+derivative family.  This is the one statement in this file that needs `E` complete, because
+that theorem asks the derivatives themselves to be holomorphic, and holomorphy of `deriv f`
+(`DifferentiableOn.deriv`) rests on the Cauchy integral formula. -/
+theorem IsLocallyBoundedOn.equicontinuousOn_deriv [CompleteSpace E]
+    (hb : IsLocallyBoundedOn F U) (hU : IsOpen U) (hF : ∀ i, DifferentiableOn ℂ (F i) U) :
+    EquicontinuousOn (fun i => _root_.deriv (F i)) U :=
   (hb.deriv hU hF).equicontinuousOn hU fun i => (hF i).deriv hU
 
 end Estimates

--- a/TauCeti/Analysis/Complex/Conformal/Vitali.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Vitali.lean
@@ -14,9 +14,8 @@ import Mathlib.Topology.UniformSpace.CompactConvergence
 # Vitali's convergence theorem
 
 Vitali's theorem upgrades pointwise convergence on a set with an accumulation point to locally
-uniform convergence for a locally bounded sequence of holomorphic maps into a proper complex
-normed space. This completes the Vitali component of layer **L1 (normal families / Montel)** of
-the conformal-mapping roadmap.
+uniform convergence for a locally bounded sequence of holomorphic functions. This completes the
+Vitali component of layer **L1 (normal families / Montel)** of the conformal-mapping roadmap.
 
 The proof applies `TauCeti.montel` twice. First choose one locally uniform subsequential limit `g`.
 For an arbitrary subsequence, Montel supplies a further locally uniform limit `q`. Both limits
@@ -28,11 +27,23 @@ each compact subset, gives locally uniform convergence of the original sequence.
 
 ## Main result
 
-* `TauCeti.vitali` — a locally bounded sequence of holomorphic maps which converges pointwise
+* `TauCeti.vitali` — a locally bounded sequence of holomorphic functions which converges pointwise
   on a set with an accumulation point in the domain converges locally uniformly to a holomorphic
-  map.
+  function.
 * `TauCeti.vitali_of_tendsto` — the same theorem with a prescribed pointwise limit on the
   convergence set.
+
+## The scalar target
+
+Unlike the estimates of `Conformal/NormalFamilies.lean` and the Montel results they feed, which
+are stated for a target complex normed space `E`, this file keeps the roadmap's scalar target
+`ℂ`. The reason is the proof: it runs `TauCeti.montel`, which is genuinely false for a target
+that is not proper, so an `E`-valued version of the argument below would prove only the
+finite-dimensional case. Vitali's theorem does hold for an arbitrary Banach target (Arendt and
+Nikolski, *Vector-valued holomorphic functions revisited*, Math. Z. **234** (2000), §2), but by a
+different argument — convergence of the Taylor coefficients at an accumulation point, and a
+clopen propagation — so that generality is a separate theorem rather than a weakening of this
+one.
 
 ## Coordination with upstream Mathlib
 
@@ -53,16 +64,15 @@ open Complex Filter Set Topology
 
 namespace TauCeti
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {Ω A : Set ℂ} {F : ℕ → ℂ → E}
+variable {Ω A : Set ℂ} {F : ℕ → ℂ → ℂ}
 
-omit [NormedSpace ℂ E] in
 /-- Two locally uniform subsequential limits agree on a set where the original sequence converges
 pointwise. -/
 private theorem eqOn_of_subseq_limits
     (hAΩ : A ⊆ Ω)
     (hpoint : ∀ z ∈ A, ∃ w, Tendsto (fun n => F n z) atTop (𝓝 w))
     {φ ψ : ℕ → ℕ} (hφ : Tendsto φ atTop atTop) (hψ : Tendsto ψ atTop atTop)
-    {g q : ℂ → E}
+    {g q : ℂ → ℂ}
     (hg : TendstoLocallyUniformlyOn (fun n => F (φ n)) g atTop Ω)
     (hq : TendstoLocallyUniformlyOn (fun n => F (ψ n)) q atTop Ω) :
     A.EqOn g q := by
@@ -73,19 +83,17 @@ private theorem eqOn_of_subseq_limits
   exact (tendsto_nhds_unique (hg.tendsto_at (hAΩ hz)) hgw).trans
     (tendsto_nhds_unique (hq.tendsto_at (hAΩ hz)) hqw).symm
 
-/-- **Vitali's convergence theorem.** Let `Ω` be an open preconnected subset of `ℂ` and `E` a
-proper complex normed space. A locally bounded sequence of holomorphic maps `Ω → E` which
-converges pointwise on a subset `A ⊆ Ω` having an accumulation point in `Ω` converges locally
-uniformly on `Ω` to a holomorphic map.
+/-- **Vitali's convergence theorem.** Let `Ω` be an open preconnected subset of `ℂ`. A locally
+bounded sequence of holomorphic functions on `Ω` which converges pointwise on a subset `A ⊆ Ω`
+having an accumulation point in `Ω` converges locally uniformly on `Ω` to a holomorphic function.
 
 The pointwise limit on `A` need not be supplied: its existence is enough to determine the
-holomorphic limit uniquely. Properness of `E` is inherited from `TauCeti.montel`, which the proof
-runs twice; for a normed space over `ℂ` it says exactly that `E` is finite-dimensional. -/
-theorem vitali [ProperSpace E] (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
+holomorphic limit uniquely. -/
+theorem vitali (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
     (hF : ∀ n, DifferentiableOn ℂ (F n) Ω) (hb : IsLocallyBoundedOn F Ω)
     (hAΩ : A ⊆ Ω) {z₀ : ℂ} (hz₀ : z₀ ∈ Ω) (hacc : AccPt z₀ (𝓟 A))
     (hpoint : ∀ z ∈ A, ∃ w, Tendsto (fun n => F n z) atTop (𝓝 w)) :
-    ∃ g : ℂ → E, DifferentiableOn ℂ g Ω ∧ TendstoLocallyUniformlyOn F g atTop Ω := by
+    ∃ g : ℂ → ℂ, DifferentiableOn ℂ g Ω ∧ TendstoLocallyUniformlyOn F g atTop Ω := by
   obtain ⟨φ, g, hφ, hg, hφconv⟩ := montel hΩ hF hb
   refine ⟨g, hg, (tendstoLocallyUniformlyOn_iff_forall_isCompact hΩ).2 ?_⟩
   intro K hKΩ hK
@@ -93,7 +101,7 @@ theorem vitali [ProperSpace E] (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
   have hrestr :
       Tendsto
         (fun n => ⟨K.domRestrict (F n), ((hF n).continuousOn.mono hKΩ).domRestrict⟩ :
-          ℕ → C(K, E))
+          ℕ → C(K, ℂ))
         atTop
         (𝓝 ⟨K.domRestrict g, (hg.continuousOn.mono hKΩ).domRestrict⟩) := by
     apply tendsto_of_subseq_tendsto
@@ -121,11 +129,11 @@ the sequence converges pointwise on `A` to a specified function `g`, its locally
 holomorphic limit agrees with `g` throughout `A`.
 
 No regularity of `g` away from `A` is assumed or concluded. -/
-theorem vitali_of_tendsto [ProperSpace E] (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
+theorem vitali_of_tendsto (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
     (hF : ∀ n, DifferentiableOn ℂ (F n) Ω) (hb : IsLocallyBoundedOn F Ω)
     (hAΩ : A ⊆ Ω) {z₀ : ℂ} (hz₀ : z₀ ∈ Ω) (hacc : AccPt z₀ (𝓟 A))
-    {g : ℂ → E} (hpoint : ∀ z ∈ A, Tendsto (fun n => F n z) atTop (𝓝 (g z))) :
-    ∃ q : ℂ → E, DifferentiableOn ℂ q Ω ∧ A.EqOn q g ∧
+    {g : ℂ → ℂ} (hpoint : ∀ z ∈ A, Tendsto (fun n => F n z) atTop (𝓝 (g z))) :
+    ∃ q : ℂ → ℂ, DifferentiableOn ℂ q Ω ∧ A.EqOn q g ∧
       TendstoLocallyUniformlyOn F q atTop Ω := by
   obtain ⟨q, hq, hconv⟩ :=
     vitali hΩ hconn hF hb hAΩ hz₀ hacc fun z hz => ⟨g z, hpoint z hz⟩

--- a/TauCeti/Analysis/Complex/Conformal/Vitali.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Vitali.lean
@@ -14,8 +14,9 @@ import Mathlib.Topology.UniformSpace.CompactConvergence
 # Vitali's convergence theorem
 
 Vitali's theorem upgrades pointwise convergence on a set with an accumulation point to locally
-uniform convergence for a locally bounded sequence of holomorphic functions. This completes the
-Vitali component of layer **L1 (normal families / Montel)** of the conformal-mapping roadmap.
+uniform convergence for a locally bounded sequence of holomorphic maps into a proper complex
+normed space. This completes the Vitali component of layer **L1 (normal families / Montel)** of
+the conformal-mapping roadmap.
 
 The proof applies `TauCeti.montel` twice. First choose one locally uniform subsequential limit `g`.
 For an arbitrary subsequence, Montel supplies a further locally uniform limit `q`. Both limits
@@ -27,9 +28,9 @@ each compact subset, gives locally uniform convergence of the original sequence.
 
 ## Main result
 
-* `TauCeti.vitali` — a locally bounded sequence of holomorphic functions which converges pointwise
+* `TauCeti.vitali` — a locally bounded sequence of holomorphic maps which converges pointwise
   on a set with an accumulation point in the domain converges locally uniformly to a holomorphic
-  function.
+  map.
 * `TauCeti.vitali_of_tendsto` — the same theorem with a prescribed pointwise limit on the
   convergence set.
 
@@ -52,15 +53,16 @@ open Complex Filter Set Topology
 
 namespace TauCeti
 
-variable {Ω A : Set ℂ} {F : ℕ → ℂ → ℂ}
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℂ E] {Ω A : Set ℂ} {F : ℕ → ℂ → E}
 
+omit [NormedSpace ℂ E] in
 /-- Two locally uniform subsequential limits agree on a set where the original sequence converges
 pointwise. -/
 private theorem eqOn_of_subseq_limits
     (hAΩ : A ⊆ Ω)
     (hpoint : ∀ z ∈ A, ∃ w, Tendsto (fun n => F n z) atTop (𝓝 w))
     {φ ψ : ℕ → ℕ} (hφ : Tendsto φ atTop atTop) (hψ : Tendsto ψ atTop atTop)
-    {g q : ℂ → ℂ}
+    {g q : ℂ → E}
     (hg : TendstoLocallyUniformlyOn (fun n => F (φ n)) g atTop Ω)
     (hq : TendstoLocallyUniformlyOn (fun n => F (ψ n)) q atTop Ω) :
     A.EqOn g q := by
@@ -71,17 +73,19 @@ private theorem eqOn_of_subseq_limits
   exact (tendsto_nhds_unique (hg.tendsto_at (hAΩ hz)) hgw).trans
     (tendsto_nhds_unique (hq.tendsto_at (hAΩ hz)) hqw).symm
 
-/-- **Vitali's convergence theorem.** Let `Ω` be an open preconnected subset of `ℂ`. A locally
-bounded sequence of holomorphic functions on `Ω` which converges pointwise on a subset `A ⊆ Ω`
-having an accumulation point in `Ω` converges locally uniformly on `Ω` to a holomorphic function.
+/-- **Vitali's convergence theorem.** Let `Ω` be an open preconnected subset of `ℂ` and `E` a
+proper complex normed space. A locally bounded sequence of holomorphic maps `Ω → E` which
+converges pointwise on a subset `A ⊆ Ω` having an accumulation point in `Ω` converges locally
+uniformly on `Ω` to a holomorphic map.
 
 The pointwise limit on `A` need not be supplied: its existence is enough to determine the
-holomorphic limit uniquely. -/
-theorem vitali (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
+holomorphic limit uniquely. Properness of `E` is inherited from `TauCeti.montel`, which the proof
+runs twice; for a normed space over `ℂ` it says exactly that `E` is finite-dimensional. -/
+theorem vitali [ProperSpace E] (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
     (hF : ∀ n, DifferentiableOn ℂ (F n) Ω) (hb : IsLocallyBoundedOn F Ω)
     (hAΩ : A ⊆ Ω) {z₀ : ℂ} (hz₀ : z₀ ∈ Ω) (hacc : AccPt z₀ (𝓟 A))
     (hpoint : ∀ z ∈ A, ∃ w, Tendsto (fun n => F n z) atTop (𝓝 w)) :
-    ∃ g : ℂ → ℂ, DifferentiableOn ℂ g Ω ∧ TendstoLocallyUniformlyOn F g atTop Ω := by
+    ∃ g : ℂ → E, DifferentiableOn ℂ g Ω ∧ TendstoLocallyUniformlyOn F g atTop Ω := by
   obtain ⟨φ, g, hφ, hg, hφconv⟩ := montel hΩ hF hb
   refine ⟨g, hg, (tendstoLocallyUniformlyOn_iff_forall_isCompact hΩ).2 ?_⟩
   intro K hKΩ hK
@@ -89,18 +93,13 @@ theorem vitali (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
   have hrestr :
       Tendsto
         (fun n => ⟨K.domRestrict (F n), ((hF n).continuousOn.mono hKΩ).domRestrict⟩ :
-          ℕ → C(K, ℂ))
+          ℕ → C(K, E))
         atTop
         (𝓝 ⟨K.domRestrict g, (hg.continuousOn.mono hKΩ).domRestrict⟩) := by
     apply tendsto_of_subseq_tendsto
     intro ψ hψ
-    have hbψ : IsLocallyBoundedOn (fun n => F (ψ n)) Ω := by
-      rw [isLocallyBoundedOn_def]
-      intro L hLΩ hL
-      obtain ⟨C, hC⟩ := isLocallyBoundedOn_def.mp hb L hLΩ hL
-      exact ⟨C, fun n => hC (ψ n)⟩
     obtain ⟨θ, q, hθ, hq, hθconv⟩ :=
-      montel hΩ (fun n => hF (ψ n)) hbψ
+      montel hΩ (fun n => hF (ψ n)) (hb.comp ψ)
     have hqgA : A.EqOn q g := eqOn_of_subseq_limits hAΩ hpoint
       (hψ.comp hθ.tendsto_atTop) hφ.tendsto_atTop hθconv hφconv
     have hqg : Ω.EqOn q g :=
@@ -122,11 +121,11 @@ the sequence converges pointwise on `A` to a specified function `g`, its locally
 holomorphic limit agrees with `g` throughout `A`.
 
 No regularity of `g` away from `A` is assumed or concluded. -/
-theorem vitali_of_tendsto (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
+theorem vitali_of_tendsto [ProperSpace E] (hΩ : IsOpen Ω) (hconn : IsPreconnected Ω)
     (hF : ∀ n, DifferentiableOn ℂ (F n) Ω) (hb : IsLocallyBoundedOn F Ω)
     (hAΩ : A ⊆ Ω) {z₀ : ℂ} (hz₀ : z₀ ∈ Ω) (hacc : AccPt z₀ (𝓟 A))
-    {g : ℂ → ℂ} (hpoint : ∀ z ∈ A, Tendsto (fun n => F n z) atTop (𝓝 (g z))) :
-    ∃ q : ℂ → ℂ, DifferentiableOn ℂ q Ω ∧ A.EqOn q g ∧
+    {g : ℂ → E} (hpoint : ∀ z ∈ A, Tendsto (fun n => F n z) atTop (𝓝 (g z))) :
+    ∃ q : ℂ → E, DifferentiableOn ℂ q Ω ∧ A.EqOn q g ∧
       TendstoLocallyUniformlyOn F q atTop Ω := by
   obtain ⟨q, hq, hconv⟩ :=
     vitali hΩ hconn hF hb hAΩ hz₀ hacc fun z hz => ⟨g z, hpoint z hz⟩


### PR DESCRIPTION
This PR generalises the L1 normal-families layer of the conformal-mapping roadmap from families of scalar functions `ℂ → ℂ` to families of maps `ℂ → E` into a complex normed space, and records for each step the hypothesis it actually needs. Nothing in a Cauchy estimate uses the multiplicative structure of the target, and the sole analytic input, Mathlib's `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le`, is itself `E`-valued and does not even require completeness — so `TauCeti.norm_deriv_le_of_forall_mem_closedBall_norm_le`, its uniform-on-a-ball and Lipschitz forms, `TauCeti.IsLocallyBoundedOn` with `mono` / `exists_forall_norm_le` / `equicontinuousOn` / `deriv`, and `TauCeti.isLocallyBoundedOn_of_isCompact_closure_range` now hold for an arbitrary `E`. Completeness enters at exactly one declaration, `TauCeti.IsLocallyBoundedOn.equicontinuousOn_deriv`, which differentiates twice and so needs `DifferentiableOn.deriv`. Properness of `E` — for a normed space over `ℂ`, exactly finite-dimensionality — enters at exactly one point, the step in `TauCeti.isCompact_closure_range_of_isLocallyBoundedOn` that has to turn a pointwise norm bound into pointwise relative compactness, and is therefore carried by that theorem, by `TauCeti.isCompact_closure_range_iff_isLocallyBoundedOn` and by `TauCeti.montel`. `TauCeti.vitali` and `TauCeti.vitali_of_tendsto` instead keep the roadmap's scalar target: their proof runs `montel`, which is genuinely false for a target that is not proper, so an `E`-valued form of that argument would publish only the finite-dimensional case. The Banach-valued Vitali theorem is true, but by a different proof (Arendt–Nikolski, *Vector-valued holomorphic functions revisited*, Math. Z. **234** (2000), §2); a `## The scalar target` section of `Conformal/Vitali.lean`'s module docstring records that, so the gap is documented rather than approximated. Taking `E = ℂ` recovers every previous statement verbatim, so no existing consumer changes; the Riemann mapping theorem continues to run on the scalar case.

Alongside the generalisation this adds `TauCeti.IsLocallyBoundedOn.comp`, the observation that local boundedness survives reindexing the family because the bound on a compact set is uniform in the index. `Conformal/Vitali.lean` was proving that inline in order to pass to a subsequence; it now consumes the named lemma instead. Local boundedness is also stated over its natural domain: it mentions neither holomorphy nor the complex structure of the domain, only compact subsets of it, so `TauCeti.IsLocallyBoundedOn` and its elementary API (`isLocallyBoundedOn_def`, `mono`, `comp`, `exists_forall_norm_le`, `isLocallyBoundedOn_of_forall_norm_le`) take a family `ι → X → E` out of an arbitrary topological space, and `X` specialises to `ℂ` at the Cauchy estimates, where holomorphy is first assumed.

This is a refactor of already-merged material — the roadmap attribution is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L1 — normal families / Montel (the analytic theorem, not `MontelSpace`)**, whose milestone "locally bounded ⇒ precompact for `TendstoLocallyUniformlyOn` … Vitali" is what the four touched files discharge. The README's generality bar fixes scalar `ℂ` for the theorems this area adds; that bar governs the conformal statements — Rouché, Hurwitz, Schwarz–Pick, the Riemann mapping theorem — whose hypotheses genuinely use `ℂ` as the target, and the estimates touched here are the analytic *inputs* those statements consume, which the same paragraph directs be taken at whatever generality Mathlib already provides. The bar is also unchanged where it bites: the milestone's own statements remain available, and are used, at `E = ℂ`. The files' existing shim notice under the README's *Coordination with upstream Mathlib* clause is untouched and still applies: L1 duplicates material [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505) proves internally as private lemmas, and these declarations are to be re-backed onto the human-curated Mathlib versions once they land.

No Mathlib source was vendored. The proofs are unchanged apart from the target type; `Complex.norm_deriv_le_of_forall_mem_sphere_norm_le`, `Convex.norm_image_sub_le_of_norm_deriv_le`, `DifferentiableOn.deriv` and the Arzelà–Ascoli framework are consumed from Mathlib as before. Three declarations pick up an `omit [NormedSpace ℂ E] in` because they use only the norm.

`lake build` and `lake exe axioms` are green (23816 declarations audited, allowlist `propext`, `Classical.choice`, `Quot.sound`).

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"islocallyboundedon-montel-banach-valued"}-->

🤖 Prepared with Claude Code

