### PR TITLE
feat: relate the multi-index Gaussian Hermite basis to the dilated Hermite functions

### DIFF
--- a/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
@@ -34,6 +34,7 @@ namespace TauCeti
 /-- **Transporting an `Lp` element along an equality of measures does not move its
 representative.** The `cast` is along the equality of types `↥(Lp E p μ) = ↥(Lp E p ν)` induced by
 `μ = ν`, so it acts as the identity on functions. -/
+@[simp]
 theorem coeFn_cast_lp {α E : Type*} [MeasurableSpace α] [NormedAddCommGroup E] {p : ℝ≥0∞}
     {μ ν : Measure α} (h : μ = ν) (f : Lp E p μ) (x : α) :
     ((cast (congrArg (fun m : Measure α => (Lp E p m : Type _)) h) f : Lp E p ν) : α → E) x

--- a/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean
@@ -1,0 +1,44 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Function.LpSpace.Basic
+
+/-!
+# Transporting an `Lp` element along an equality of measures
+
+Equal measures give *equal* (not merely isomorphic) `Lp` types, so an element of `Lp E p μ` can be
+moved to `Lp E p ν` by `cast` whenever `μ = ν`. The cast is the identity on representatives, which
+is what `TauCeti.coeFn_cast_lp` records.
+
+This is the bookkeeping a statement needs when a space is *defined* with one description of its
+measure and *used* with another, for example a basis of `L²(γ)` fed to
+`TauCeti.weightL2Isometry`, whose domain is spelled `L²(volume.withDensity …)`.
+
+## Main statements
+
+* `TauCeti.coeFn_cast_lp`: the cast does not move representatives.
+-/
+
+public section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+/-- **Transporting an `Lp` element along an equality of measures does not move its
+representative.** The `cast` is along the equality of types `↥(Lp E p μ) = ↥(Lp E p ν)` induced by
+`μ = ν`, so it acts as the identity on functions. -/
+theorem coeFn_cast_lp {α E : Type*} [MeasurableSpace α] [NormedAddCommGroup E] {p : ℝ≥0∞}
+    {μ ν : Measure α} (h : μ = ν) (f : Lp E p μ) (x : α) :
+    ((cast (congrArg (fun m : Measure α => (Lp E p m : Type _)) h) f : Lp E p ν) : α → E) x
+      = (f : α → E) x := by
+  subst h
+  rfl
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -24,9 +24,8 @@ Mathlib's: reduce a `Fin (n + 1)`-indexed product to a binary product measure al
 
 ## Main statements
 
-* `TauCeti.lintegral_fintype_prod_eq_prod₀`: the product formula, for almost everywhere
-  measurable factors.
-* `TauCeti.lintegral_fintype_prod_eq_prod`: the same for measurable factors.
+* `TauCeti.lintegral_fintype_prod_eq_prod`: the product formula, for measurable factors.
+* `TauCeti.lintegral_fintype_prod_eq_prod₀`: the same for almost everywhere measurable factors.
 -/
 
 public section
@@ -69,10 +68,14 @@ private theorem lintegral_fin_nat_prod_eq_prod {n : ℕ} {α : Fin n → Type*}
         _ = ∏ i, ∫⁻ y, f i y ∂μ i :=
             (Fin.prod_univ_succAbove (fun i => ∫⁻ y, f i y ∂μ i) 0).symm
 
-/-- The product formula for measurable factors, from which the almost everywhere measurable
-statement `TauCeti.lintegral_fintype_prod_eq_prod₀` is obtained by passing to measurable
-representatives. -/
-private theorem lintegral_fintype_prod_eq_prod_of_measurable {ι : Type*} [Fintype ι]
+/-- **The product formula for lower integrals over a finite product measure.** The lower integral
+of `∏ i, f i (x i)` against `MeasureTheory.Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`.
+
+This is the `ℝ≥0∞` analogue of `MeasureTheory.integral_fintype_prod_eq_prod`; unlike the Bochner
+statement it needs no integrability of the factors. See
+`TauCeti.lintegral_fintype_prod_eq_prod₀` for the almost everywhere measurable version, which is
+obtained from this one by passing to measurable representatives. -/
+theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι]
     {α : ι → Type*} {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i))
     [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
     ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i := by
@@ -91,11 +94,9 @@ private theorem lintegral_fintype_prod_eq_prod_of_measurable {ι : Type*} [Finty
     _ = ∏ j, ∫⁻ z, f (e j) z ∂μ (e j) := lintegral_fin_nat_prod_eq_prod fun j => hf _
     _ = ∏ i, ∫⁻ y, f i y ∂μ i := e.prod_comp fun i => ∫⁻ y, f i y ∂μ i
 
-/-- **The product formula for lower integrals over a finite product measure.** The lower integral
-of `∏ i, f i (x i)` against `MeasureTheory.Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`.
-
-This is the `ℝ≥0∞` analogue of `MeasureTheory.integral_fintype_prod_eq_prod`; unlike the Bochner
-statement it needs only almost everywhere measurability of the factors, no integrability. -/
+/-- **The product formula for lower integrals over a finite product measure**, for almost
+everywhere measurable factors; see `TauCeti.lintegral_fintype_prod_eq_prod` for the measurable
+version. -/
 theorem lintegral_fintype_prod_eq_prod₀ {ι : Type*} [Fintype ι] {α : ι → Type*}
     {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
     {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, AEMeasurable (f i) (μ i)) :
@@ -105,16 +106,7 @@ theorem lintegral_fintype_prod_eq_prod₀ {ι : Type*} [Fintype ι] {α : ι →
   have hae : ∀ᵐ x : ∀ i, α i ∂Measure.pi μ, ∀ i, f i (x i) = (hf i).mk (f i) (x i) :=
     Filter.eventually_all.2 fun i => tendsto_eval_ae_ae.eventually (hf i).ae_eq_mk
   rw [lintegral_congr_ae (hae.mono fun x hx => Finset.prod_congr rfl fun i _ => hx i),
-    lintegral_fintype_prod_eq_prod_of_measurable μ fun i => (hf i).measurable_mk]
+    lintegral_fintype_prod_eq_prod μ fun i => (hf i).measurable_mk]
   exact Finset.prod_congr rfl fun i _ => (lintegral_congr_ae (hf i).ae_eq_mk).symm
-
-/-- **The product formula for lower integrals over a finite product measure**, for measurable
-factors; see `TauCeti.lintegral_fintype_prod_eq_prod₀` for the almost everywhere measurable
-version. -/
-theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι] {α : ι → Type*}
-    {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
-    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
-    ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i :=
-  lintegral_fintype_prod_eq_prod₀ μ fun i => (hf i).aemeasurable
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.Pi
+
+/-!
+# Lower integrals of coordinatewise products over a finite product measure
+
+The `ℝ≥0∞`-valued companion of Mathlib's `MeasureTheory.integral_fintype_prod_eq_prod`: over
+`MeasureTheory.Measure.pi`, the lower integral of a product `∏ i, f i (x i)` of functions each
+depending on a single coordinate is the product of the one-dimensional lower integrals.
+
+Mathlib proves the Bochner version (and the matching integrability statements) but not this one,
+even though the `ℝ≥0∞` version needs no integrability hypothesis at all, since every factor is
+automatically "integrable" in the lower-integral sense. The proof is the same induction as
+Mathlib's: reduce a `Fin (n + 1)`-indexed product to a binary product measure along
+`MeasureTheory.measurePreserving_piFinSuccAbove`, split it with
+`MeasureTheory.lintegral_prod_mul`, and transfer an arbitrary `Fintype` index to `Fin` along
+`MeasureTheory.measurePreserving_piCongrLeft`.
+
+## Main statements
+
+* `TauCeti.lintegral_fintype_prod_eq_prod`: the product formula.
+-/
+
+public section
+
+open MeasureTheory MeasureTheory.Measure
+
+open scoped ENNReal
+
+namespace TauCeti
+
+/-- The product formula for a `Fin n`-indexed product measure, by induction on `n`. -/
+private theorem lintegral_fin_nat_prod_eq_prod {n : ℕ} {α : Fin n → Type*}
+    {mα : ∀ i, MeasurableSpace (α i)} {μ : ∀ i, Measure (α i)} [∀ i, SigmaFinite (μ i)]
+    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
+    ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      -- Peel off the zeroth coordinate: `Measure.pi μ` becomes a binary product measure.
+      have hprodm : Measurable fun z : ∀ j : Fin n, α ((0 : Fin (n + 1)).succAbove j) =>
+          ∏ j, f ((0 : Fin (n + 1)).succAbove j) (z j) :=
+        Finset.measurable_prod _ fun j _ => (hf _).comp (measurable_pi_apply j)
+      calc ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ
+          = ∫⁻ x : ∀ i, α i, f 0 ((MeasurableEquiv.piFinSuccAbove α 0 x).1)
+              * ∏ j, f ((0 : Fin (n + 1)).succAbove j)
+                  ((MeasurableEquiv.piFinSuccAbove α 0 x).2 j) ∂Measure.pi μ :=
+            lintegral_congr fun x => Fin.prod_univ_succAbove (fun i => f i (x i)) 0
+        _ = ∫⁻ z, f 0 z.1 * ∏ j, f ((0 : Fin (n + 1)).succAbove j) (z.2 j)
+              ∂(μ 0).prod (Measure.pi fun j => μ ((0 : Fin (n + 1)).succAbove j)) :=
+            ((measurePreserving_piFinSuccAbove μ 0).lintegral_map_equiv
+              (fun z : α 0 × ∀ j : Fin n, α ((0 : Fin (n + 1)).succAbove j) =>
+                f 0 z.1 * ∏ j, f ((0 : Fin (n + 1)).succAbove j) (z.2 j))
+              (MeasurableEquiv.piFinSuccAbove α 0)).symm
+        _ = (∫⁻ y, f 0 y ∂μ 0)
+              * ∫⁻ z, ∏ j, f ((0 : Fin (n + 1)).succAbove j) (z j)
+                  ∂Measure.pi fun j => μ ((0 : Fin (n + 1)).succAbove j) :=
+            lintegral_prod_mul (hf 0).aemeasurable hprodm.aemeasurable
+        _ = (∫⁻ y, f 0 y ∂μ 0) * ∏ j, ∫⁻ y, f ((0 : Fin (n + 1)).succAbove j) y
+              ∂μ ((0 : Fin (n + 1)).succAbove j) := by rw [ih fun j => hf _]
+        _ = ∏ i, ∫⁻ y, f i y ∂μ i :=
+            (Fin.prod_univ_succAbove (fun i => ∫⁻ y, f i y ∂μ i) 0).symm
+
+/-- **The product formula for lower integrals over a finite product measure.** The lower integral
+of `∏ i, f i (x i)` against `MeasureTheory.Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`.
+
+This is the `ℝ≥0∞` analogue of `MeasureTheory.integral_fintype_prod_eq_prod`; unlike the Bochner
+statement it needs only measurability of the factors, no integrability. -/
+theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι] {α : ι → Type*}
+    {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
+    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
+    ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i := by
+  -- Transfer the index type to `Fin (card ι)` and apply the `Fin`-indexed statement.
+  let e := (Fintype.equivFin ι).symm
+  calc ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ
+      = ∫⁻ y : ∀ j, α (e j), ∏ i, f i (MeasurableEquiv.piCongrLeft α e y i)
+          ∂Measure.pi fun j => μ (e j) :=
+        (measurePreserving_piCongrLeft μ e).lintegral_map_equiv _
+          (MeasurableEquiv.piCongrLeft α e)
+    _ = ∫⁻ y : ∀ j, α (e j), ∏ j, f (e j) (y j) ∂Measure.pi fun j => μ (e j) := by
+        refine lintegral_congr fun y => ?_
+        rw [← e.prod_comp fun i => f i (MeasurableEquiv.piCongrLeft α e y i)]
+        exact Finset.prod_congr rfl fun j _ => by
+          simp [MeasurableEquiv.piCongrLeft_apply_apply]
+    _ = ∏ j, ∫⁻ z, f (e j) z ∂μ (e j) := lintegral_fin_nat_prod_eq_prod fun j => hf _
+    _ = ∏ i, ∫⁻ y, f i y ∂μ i := e.prod_comp fun i => ∫⁻ y, f i y ∂μ i
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Pi.lean
+++ b/TauCeti/MeasureTheory/Integral/Pi.lean
@@ -24,7 +24,9 @@ Mathlib's: reduce a `Fin (n + 1)`-indexed product to a binary product measure al
 
 ## Main statements
 
-* `TauCeti.lintegral_fintype_prod_eq_prod`: the product formula.
+* `TauCeti.lintegral_fintype_prod_eq_prod₀`: the product formula, for almost everywhere
+  measurable factors.
+* `TauCeti.lintegral_fintype_prod_eq_prod`: the same for measurable factors.
 -/
 
 public section
@@ -67,14 +69,12 @@ private theorem lintegral_fin_nat_prod_eq_prod {n : ℕ} {α : Fin n → Type*}
         _ = ∏ i, ∫⁻ y, f i y ∂μ i :=
             (Fin.prod_univ_succAbove (fun i => ∫⁻ y, f i y ∂μ i) 0).symm
 
-/-- **The product formula for lower integrals over a finite product measure.** The lower integral
-of `∏ i, f i (x i)` against `MeasureTheory.Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`.
-
-This is the `ℝ≥0∞` analogue of `MeasureTheory.integral_fintype_prod_eq_prod`; unlike the Bochner
-statement it needs only measurability of the factors, no integrability. -/
-theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι] {α : ι → Type*}
-    {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
-    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
+/-- The product formula for measurable factors, from which the almost everywhere measurable
+statement `TauCeti.lintegral_fintype_prod_eq_prod₀` is obtained by passing to measurable
+representatives. -/
+private theorem lintegral_fintype_prod_eq_prod_of_measurable {ι : Type*} [Fintype ι]
+    {α : ι → Type*} {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i))
+    [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
     ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i := by
   -- Transfer the index type to `Fin (card ι)` and apply the `Fin`-indexed statement.
   let e := (Fintype.equivFin ι).symm
@@ -90,5 +90,31 @@ theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι] {α : ι → Ty
           simp [MeasurableEquiv.piCongrLeft_apply_apply]
     _ = ∏ j, ∫⁻ z, f (e j) z ∂μ (e j) := lintegral_fin_nat_prod_eq_prod fun j => hf _
     _ = ∏ i, ∫⁻ y, f i y ∂μ i := e.prod_comp fun i => ∫⁻ y, f i y ∂μ i
+
+/-- **The product formula for lower integrals over a finite product measure.** The lower integral
+of `∏ i, f i (x i)` against `MeasureTheory.Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`.
+
+This is the `ℝ≥0∞` analogue of `MeasureTheory.integral_fintype_prod_eq_prod`; unlike the Bochner
+statement it needs only almost everywhere measurability of the factors, no integrability. -/
+theorem lintegral_fintype_prod_eq_prod₀ {ι : Type*} [Fintype ι] {α : ι → Type*}
+    {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
+    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, AEMeasurable (f i) (μ i)) :
+    ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i := by
+  -- Each factor may be replaced by a measurable representative: a `μ i`-null exceptional set
+  -- pulls back to a `Measure.pi μ`-null one along the `i`-th coordinate.
+  have hae : ∀ᵐ x : ∀ i, α i ∂Measure.pi μ, ∀ i, f i (x i) = (hf i).mk (f i) (x i) :=
+    Filter.eventually_all.2 fun i => tendsto_eval_ae_ae.eventually (hf i).ae_eq_mk
+  rw [lintegral_congr_ae (hae.mono fun x hx => Finset.prod_congr rfl fun i _ => hx i),
+    lintegral_fintype_prod_eq_prod_of_measurable μ fun i => (hf i).measurable_mk]
+  exact Finset.prod_congr rfl fun i _ => (lintegral_congr_ae (hf i).ae_eq_mk).symm
+
+/-- **The product formula for lower integrals over a finite product measure**, for measurable
+factors; see `TauCeti.lintegral_fintype_prod_eq_prod₀` for the almost everywhere measurable
+version. -/
+theorem lintegral_fintype_prod_eq_prod {ι : Type*} [Fintype ι] {α : ι → Type*}
+    {mα : ∀ i, MeasurableSpace (α i)} (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)]
+    {f : ∀ i, α i → ℝ≥0∞} (hf : ∀ i, Measurable (f i)) :
+    ∫⁻ x : ∀ i, α i, ∏ i, f i (x i) ∂Measure.pi μ = ∏ i, ∫⁻ y, f i y ∂μ i :=
+  lintegral_fintype_prod_eq_prod₀ μ fun i => (hf i).aemeasurable
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.MeasureTheory.Integral.Pi
+
+/-!
+# A finite product of weighted measures is the product measure with the product weight
+
+`MeasureTheory.Measure.pi (fun i => (μ i).withDensity (f i))` is
+`(MeasureTheory.Measure.pi μ).withDensity (fun x => ∏ i, f i (x i))`: putting a density on each
+factor of a finite product measure is the same as putting the product of the densities on the
+product measure.
+
+Mathlib has the two-factor version `MeasureTheory.Measure.prod_withDensity` but not the
+`MeasureTheory.Measure.pi` version, which is what a coordinatewise weight on `ℝ^ι` needs. The
+motivating instance is the multivariate Gaussian, whose product measure is Lebesgue measure on
+`ℝ^ι` weighted by the product of the one-dimensional Gaussian densities.
+
+The proof identifies the two measures on measurable boxes via `MeasureTheory.Measure.pi_eq`; the
+box computation is `TauCeti.lintegral_fintype_prod_eq_prod` applied to the
+indicator-truncated densities.
+
+## Main statements
+
+* `TauCeti.pi_withDensity`: the identification.
+-/
+
+public section
+
+open MeasureTheory MeasureTheory.Measure
+
+open scoped ENNReal
+
+namespace TauCeti
+
+variable {ι : Type*} [Fintype ι] {α : ι → Type*} {mα : ∀ i, MeasurableSpace (α i)}
+
+/-- **Coordinatewise densities multiply.** For a finite family of σ-finite measures `μ i` and
+measurable densities `f i`, the product of the weighted measures `(μ i).withDensity (f i)` is the
+product measure weighted by the product density `x ↦ ∏ i, f i (x i)`.
+
+The σ-finiteness assumption on the weighted factors is what `MeasureTheory.Measure.pi_eq` needs to
+recognize the left-hand side as *the* product measure; it is automatic when the weighted factors
+are finite (as for probability densities). -/
+theorem pi_withDensity (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞}
+    (hf : ∀ i, Measurable (f i)) [∀ i, SigmaFinite ((μ i).withDensity (f i))] :
+    Measure.pi (fun i => (μ i).withDensity (f i))
+      = (Measure.pi μ).withDensity fun x => ∏ i, f i (x i) := by
+  refine Measure.pi_eq fun s hs => ?_
+  -- On a measurable box the product density truncates coordinatewise.
+  have hbox : ∀ x : ∀ i, α i, (Set.pi Set.univ s).indicator (fun x => ∏ i, f i (x i)) x
+      = ∏ i, (s i).indicator (f i) (x i) := by
+    intro x
+    by_cases hx : x ∈ Set.pi Set.univ s
+    · rw [Set.indicator_of_mem hx]
+      exact Finset.prod_congr rfl fun i _ =>
+        (Set.indicator_of_mem (Set.mem_univ_pi.1 hx i) (f i)).symm
+    · rw [Set.indicator_of_notMem hx]
+      obtain ⟨i, hi⟩ := not_forall.1 fun h => hx (Set.mem_univ_pi.2 h)
+      exact (Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi (f i))).symm
+  rw [withDensity_apply _ (MeasurableSet.univ_pi hs), ← lintegral_indicator
+    (MeasurableSet.univ_pi hs), lintegral_congr hbox,
+    lintegral_fintype_prod_eq_prod μ fun i => (hf i).indicator (hs i)]
+  exact Finset.prod_congr rfl fun i _ => by
+    rw [withDensity_apply _ (hs i), ← lintegral_indicator (hs i)]
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
+++ b/TauCeti/MeasureTheory/Measure/PiWithDensity.lean
@@ -15,18 +15,20 @@ public import TauCeti.MeasureTheory.Integral.Pi
 factor of a finite product measure is the same as putting the product of the densities on the
 product measure.
 
-Mathlib has the two-factor version `MeasureTheory.Measure.prod_withDensity` but not the
-`MeasureTheory.Measure.pi` version, which is what a coordinatewise weight on `ℝ^ι` needs. The
-motivating instance is the multivariate Gaussian, whose product measure is Lebesgue measure on
-`ℝ^ι` weighted by the product of the one-dimensional Gaussian densities.
+Mathlib has the two-factor versions `MeasureTheory.Measure.prod_withDensity₀` and
+`MeasureTheory.Measure.prod_withDensity` but not the `MeasureTheory.Measure.pi` version, which is
+what a coordinatewise weight on `ℝ^ι` needs. The motivating instance is the multivariate Gaussian,
+whose product measure is Lebesgue measure on `ℝ^ι` weighted by the product of the one-dimensional
+Gaussian densities.
 
 The proof identifies the two measures on measurable boxes via `MeasureTheory.Measure.pi_eq`; the
-box computation is `TauCeti.lintegral_fintype_prod_eq_prod` applied to the
+box computation is `TauCeti.lintegral_fintype_prod_eq_prod₀` applied to the
 indicator-truncated densities.
 
 ## Main statements
 
-* `TauCeti.pi_withDensity`: the identification.
+* `TauCeti.pi_withDensity₀`: the identification, for almost everywhere measurable densities.
+* `TauCeti.pi_withDensity`: the same for measurable densities.
 -/
 
 public section
@@ -40,14 +42,15 @@ namespace TauCeti
 variable {ι : Type*} [Fintype ι] {α : ι → Type*} {mα : ∀ i, MeasurableSpace (α i)}
 
 /-- **Coordinatewise densities multiply.** For a finite family of σ-finite measures `μ i` and
-measurable densities `f i`, the product of the weighted measures `(μ i).withDensity (f i)` is the
-product measure weighted by the product density `x ↦ ∏ i, f i (x i)`.
+almost everywhere measurable densities `f i`, the product of the weighted measures
+`(μ i).withDensity (f i)` is the product measure weighted by the product density
+`x ↦ ∏ i, f i (x i)`.
 
 The σ-finiteness assumption on the weighted factors is what `MeasureTheory.Measure.pi_eq` needs to
 recognize the left-hand side as *the* product measure; it is automatic when the weighted factors
 are finite (as for probability densities). -/
-theorem pi_withDensity (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞}
-    (hf : ∀ i, Measurable (f i)) [∀ i, SigmaFinite ((μ i).withDensity (f i))] :
+theorem pi_withDensity₀ (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞}
+    (hf : ∀ i, AEMeasurable (f i) (μ i)) [∀ i, SigmaFinite ((μ i).withDensity (f i))] :
     Measure.pi (fun i => (μ i).withDensity (f i))
       = (Measure.pi μ).withDensity fun x => ∏ i, f i (x i) := by
   refine Measure.pi_eq fun s hs => ?_
@@ -64,8 +67,16 @@ theorem pi_withDensity (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] 
       exact (Finset.prod_eq_zero (Finset.mem_univ i) (Set.indicator_of_notMem hi (f i))).symm
   rw [withDensity_apply _ (MeasurableSet.univ_pi hs), ← lintegral_indicator
     (MeasurableSet.univ_pi hs), lintegral_congr hbox,
-    lintegral_fintype_prod_eq_prod μ fun i => (hf i).indicator (hs i)]
+    lintegral_fintype_prod_eq_prod₀ μ fun i => (hf i).indicator (hs i)]
   exact Finset.prod_congr rfl fun i _ => by
     rw [withDensity_apply _ (hs i), ← lintegral_indicator (hs i)]
+
+/-- **Coordinatewise densities multiply**, for measurable densities; see
+`TauCeti.pi_withDensity₀` for the almost everywhere measurable version. -/
+theorem pi_withDensity (μ : ∀ i, Measure (α i)) [∀ i, SigmaFinite (μ i)] {f : ∀ i, α i → ℝ≥0∞}
+    (hf : ∀ i, Measurable (f i)) [∀ i, SigmaFinite ((μ i).withDensity (f i))] :
+    Measure.pi (fun i => (μ i).withDensity (f i))
+      = (Measure.pi μ).withDensity fun x => ∏ i, f i (x i) :=
+  pi_withDensity₀ μ fun i => (hf i).aemeasurable
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Function.Basic
 public import TauCeti.Analysis.SpecialFunctions.Hermite.Orthogonality
+public import TauCeti.MeasureTheory.Function.Lp.CastMeasure
 public import TauCeti.Probability.Distributions.Gaussian.Basic
 public import TauCeti.RingTheory.Polynomial.Hermite.Real
 
@@ -127,14 +128,6 @@ private theorem coe_cast_hilbertBasis {μ ν : Measure ℝ} (h : μ = ν)
   subst h
   rw [cast_eq]
   exact hb
-
-/-- Transporting an `L²` element along an equality of measures does not move its representative:
-the `cast` is along `↥(Lp 𝕜 2 μ) = ↥(Lp 𝕜 2 ν)`, so it is the identity on functions. -/
-private theorem coeFn_cast_lp {μ ν : Measure ℝ} (h : μ = ν) (f : Lp 𝕜 2 μ) (x : ℝ) :
-    ((cast (congrArg (fun m : Measure ℝ => (Lp 𝕜 2 m : Type _)) h) f : Lp 𝕜 2 ν) : ℝ → 𝕜) x
-      = (f : ℝ → 𝕜) x := by
-  subst h
-  rfl
 
 /-- **Roadmap A3′: the Hermite polynomials are a Hilbert basis of `L²(γ)`.** Orthonormality comes
 from the orthogonality relation against the Gaussian density and completeness from moment
@@ -270,7 +263,7 @@ theorem weightL2Isometry_gaussianHermiteHilbertBasis (n : ℕ) :
     rw [gaussianReal_of_var_ne_zero 0 one_ne_zero, gaussianPDF_def]
   refine Filter.EventuallyEq.trans ?_ (sqrt_gaussianPDFReal_smul_gaussianHermiteHilbertBasis 𝕜 n)
   exact Filter.Eventually.of_forall fun x => by
-    simp only [coeFn_cast_lp 𝕜 hγ (gaussianHermiteHilbertBasis 𝕜 n) x]
+    simp only [coeFn_cast_lp hγ (gaussianHermiteHilbertBasis 𝕜 n) x]
 
 end Basis
 

--- a/TauCeti/Probability/Distributions/Gaussian/Hermite/PiBasis.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Hermite/PiBasis.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.InnerProductSpace.L2.Pi
 public import TauCeti.Probability.Distributions.Gaussian.Hermite.Basis
+public import TauCeti.Probability.Distributions.Gaussian.Pi
 
 /-!
 # The multi-index Hermite basis of a multivariate Gaussian `L²`
@@ -15,15 +16,27 @@ The `Fintype`-indexed product of the one-dimensional Gaussian Hermite basis: the
 `Ψ_a(x) = ∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)` is a Hilbert basis of `L²(γ^ι)`, the standard basis for
 multivariate Gaussian `L²` and for chaos expansions.
 
-Both inputs are already in place, so this file only combines them: `TauCeti.piHilbertBasis` builds
-a Hilbert basis of `L²(Measure.pi μ)` from coordinatewise bases, and
+Both inputs are already in place, so the basis itself is a combination: `TauCeti.piHilbertBasis`
+builds a Hilbert basis of `L²(Measure.pi μ)` from coordinatewise bases, and
 `TauCeti.gaussianHermiteHilbertBasis` is the one-dimensional factor.
+
+The file then relates this measure-side basis to the function-side multi-index Hermite-function
+basis `TauCeti.hermiteFunctionPiBasis` of `L²(volume^ι)`. As in one dimension
+(`TauCeti.weightL2Isometry_gaussianHermiteHilbertBasis`), the two are *not* interchanged by the
+weight-to-function isometry alone: because `ψₙ` is built on the rescaled argument `x√2`, the image
+of `Ψ_a` under `TauCeti.weightL2Isometry` for the joint Gaussian density is the **dilated** product
+`∏ᵢ 2^{-1/4} ψ_{aᵢ}(xᵢ/√2)`. The dilation and the `2^{-1/4}` appear once per coordinate, which is
+exactly the statement the roadmap asks for.
 
 ## Main statements
 
 * `TauCeti.gaussianHermitePiBasis` — the multi-index basis.
 * `TauCeti.coeFn_gaussianHermitePiBasis` — the anti-vacuity pin: the `a`-th vector really is the
   product `∏ᵢ H_{aᵢ}(xᵢ)/√(aᵢ!)`.
+* `TauCeti.sqrt_prod_gaussianPDFReal_smul_gaussianHermitePiBasis`: scaling the `a`-th vector by
+  the square root of the joint Gaussian density gives `∏ᵢ 2^{-1/4} ψ_{aᵢ}(xᵢ/√2)`.
+* `TauCeti.weightL2Isometry_gaussianHermitePiBasis`: the same identification at the
+  `TauCeti.weightL2Isometry` level.
 -/
 
 public section
@@ -61,5 +74,64 @@ theorem coeFn_gaussianHermitePiBasis (a : ι → ℕ) :
     ae_all_iff.2 hcoord] with x hx hall
   rw [hx]
   exact Finset.prod_congr rfl fun i _ => hall i
+
+/-- **The joint Gaussian envelope of a multi-index basis vector is a dilated Hermite-function
+product.** Scaling the `a`-th vector of `L²(γ^ι)` by the square root of the joint density gives
+`∏ᵢ 2^{-1/4} ψ_{aᵢ}(xᵢ/√2)`, with `2^{-1/4}` written as `(√√2)⁻¹` to stay inside `Real.sqrt`.
+
+Stated `volume^ι`-almost everywhere, the measure the envelope lives on; the move from `γ^ι`-almost
+everywhere is legitimate because the joint density never vanishes
+(`TauCeti.pi_volume_absolutelyContinuous_pi_gaussianReal`). Every coordinate contributes one factor
+of the one-dimensional identity `TauCeti.sqrt_gaussianPDFReal_mul_hermiteℝ_div_sqrt_factorial`, so
+the dilation `xᵢ ↦ xᵢ/√2` really is coordinatewise. -/
+theorem sqrt_prod_gaussianPDFReal_smul_gaussianHermitePiBasis (a : ι → ℕ) :
+    (fun x : ι → ℝ => Real.sqrt (∏ i, gaussianPDFReal 0 1 (x i))
+        • (gaussianHermitePiBasis 𝕜 ι a : (ι → ℝ) → 𝕜) x)
+      =ᵐ[Measure.pi fun _ : ι => (volume : Measure ℝ)]
+        fun x => ∏ i, (algebraMap ℝ 𝕜)
+          ((Real.sqrt (Real.sqrt 2))⁻¹ * hermiteFunction (a i) (x i / Real.sqrt 2)) := by
+  have hpt : ∀ x : ι → ℝ, Real.sqrt (∏ i, gaussianPDFReal 0 1 (x i))
+      * ∏ i, aeval (x i) (hermite (a i)) / Real.sqrt (((a i).factorial : ℝ))
+      = ∏ i, (Real.sqrt (Real.sqrt 2))⁻¹ * hermiteFunction (a i) (x i / Real.sqrt 2) := by
+    intro x
+    rw [Real.sqrt_prod _ fun i _ => (gaussianPDFReal_pos 0 1 (x i) one_ne_zero).le,
+      ← Finset.prod_mul_distrib]
+    refine Finset.prod_congr rfl fun i _ => ?_
+    rw [← eval_hermiteℝ]
+    exact sqrt_gaussianPDFReal_mul_hermiteℝ_div_sqrt_factorial (a i) (x i)
+  filter_upwards [(coeFn_gaussianHermitePiBasis 𝕜 ι a).filter_mono
+    (pi_volume_absolutelyContinuous_pi_gaussianReal ι).ae_le] with x hx
+  rw [hx, Algebra.smul_def, ← map_prod, ← map_mul, hpt x, map_prod]
+
+/-- **The `TauCeti.weightL2Isometry`-image of the multi-index Gaussian Hermite basis is the dilated
+multi-index Hermite-function family.** The `a`-th vector goes to
+`∏ᵢ 2^{-1/4} • ψ_{aᵢ}(xᵢ/√2)`, pinning the measure-side basis of `L²(γ^ι)` to the function-side
+`TauCeti.hermiteFunctionPiBasis` of `L²(volume^ι)` up to that coordinatewise dilation and
+normalization.
+
+`TauCeti.weightL2Isometry` has `L²((volume^ι).withDensity …)` as its domain, whereas
+`TauCeti.gaussianHermitePiBasis` lives in the propositionally equal `L²(γ^ι)`, so the basis vector
+is transported along `TauCeti.pi_gaussianReal_eq_withDensity` before the isometry is applied. The
+positivity and measurability of the joint density are supplied here rather than left to the caller;
+by proof irrelevance the statement still applies to `TauCeti.weightL2Isometry` built from any other
+proofs of those two side conditions. -/
+theorem weightL2Isometry_gaussianHermitePiBasis (a : ι → ℕ) :
+    weightL2Isometry (Measure.pi fun _ : ι => (volume : Measure ℝ))
+        (fun x : ι → ℝ => ∏ i, gaussianPDFReal 0 1 (x i))
+        (Filter.Eventually.of_forall (prod_gaussianPDFReal_pos ι))
+        (measurable_prod_gaussianPDFReal ι).aemeasurable
+        (cast (congrArg (fun m : Measure (ι → ℝ) => (Lp 𝕜 2 m : Type _))
+          (pi_gaussianReal_eq_withDensity ι)) (gaussianHermitePiBasis 𝕜 ι a))
+      =ᵐ[Measure.pi fun _ : ι => (volume : Measure ℝ)]
+        fun x => ∏ i, (algebraMap ℝ 𝕜)
+          ((Real.sqrt (Real.sqrt 2))⁻¹ * hermiteFunction (a i) (x i / Real.sqrt 2)) := by
+  -- The isometry is multiplication by `√w`, and the transport does not move representatives.
+  refine (weightL2Isometry_apply (𝕜 := 𝕜) (Measure.pi fun _ : ι => (volume : Measure ℝ))
+    (fun x : ι → ℝ => ∏ i, gaussianPDFReal 0 1 (x i)) _ _ _).trans ?_
+  refine Filter.EventuallyEq.trans ?_
+    (sqrt_prod_gaussianPDFReal_smul_gaussianHermitePiBasis 𝕜 ι a)
+  exact Filter.Eventually.of_forall fun x => by
+    simp only [coeFn_cast_lp (pi_gaussianReal_eq_withDensity ι)
+      (gaussianHermitePiBasis 𝕜 ι a) x]
 
 end TauCeti

--- a/TauCeti/Probability/Distributions/Gaussian/Pi.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Pi.lean
@@ -61,10 +61,10 @@ theorem pi_gaussianReal_eq_withDensity :
   have : IsProbabilityMeasure
       (volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) := by
     rw [hγ]; infer_instance
-  rw [show (fun _ : ι => (gaussianReal 0 1 : Measure ℝ))
-      = fun _ : ι => volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x) from
-    funext fun _ => hγ.symm,
-    pi_withDensity (fun _ : ι => (volume : Measure ℝ)) fun _ =>
+  have hfam : (fun _ : ι => (gaussianReal 0 1 : Measure ℝ))
+      = fun _ : ι => volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x) :=
+    funext fun _ => hγ.symm
+  rw [hfam, pi_withDensity (fun _ : ι => (volume : Measure ℝ)) fun _ =>
       (measurable_gaussianPDFReal 0 1).ennreal_ofReal]
   exact withDensity_congr_ae (Filter.Eventually.of_forall fun x =>
     (ENNReal.ofReal_prod_of_nonneg fun i _ =>

--- a/TauCeti/Probability/Distributions/Gaussian/Pi.lean
+++ b/TauCeti/Probability/Distributions/Gaussian/Pi.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.MeasureTheory.Measure.PiWithDensity
+public import Mathlib.Probability.Distributions.Gaussian.Real
+
+/-!
+# The standard Gaussian measure on a finite product
+
+The product measure `γ^ι = Measure.pi (fun _ : ι => gaussianReal 0 1)` is Lebesgue measure on
+`ℝ^ι` weighted by the joint density `x ↦ ∏ i, gaussianPDFReal 0 1 (x i)`. That identification is
+what lets a weight-in-the-measure statement about `γ^ι` be read as a weight-in-the-function
+statement about `volume^ι`, via `TauCeti.weightL2Isometry`.
+
+Like `TauCeti.gaussianPDFReal_zero_one`, these are statements about the Gaussian distribution
+alone (no orthogonal family appears), so they live here rather than with the multi-index Hermite
+basis that consumes them.
+
+## Main statements
+
+* `TauCeti.pi_gaussianReal_eq_withDensity`: `γ^ι = volume^ι` weighted by the joint density.
+* `TauCeti.pi_volume_absolutelyContinuous_pi_gaussianReal`: the joint density never vanishes, so
+  `volume^ι`-null sets are exactly `γ^ι`-null sets in the direction one needs to move an
+  almost-everywhere statement from `γ^ι` to `volume^ι`.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+variable (ι : Type*) [Fintype ι]
+
+/-- The joint standard Gaussian density on `ℝ^ι` is everywhere positive. -/
+theorem prod_gaussianPDFReal_pos (x : ι → ℝ) : 0 < ∏ i, gaussianPDFReal 0 1 (x i) :=
+  Finset.prod_pos fun i _ => gaussianPDFReal_pos 0 1 (x i) one_ne_zero
+
+/-- The joint standard Gaussian density on `ℝ^ι` is measurable. -/
+theorem measurable_prod_gaussianPDFReal :
+    Measurable fun x : ι → ℝ => ∏ i, gaussianPDFReal 0 1 (x i) :=
+  Finset.measurable_prod _ fun i _ =>
+    (measurable_gaussianPDFReal 0 1).comp (measurable_pi_apply i)
+
+/-- **The standard Gaussian on `ℝ^ι` is `volume^ι` weighted by the joint density.** Each factor is
+`volume` weighted by `gaussianPDFReal 0 1` (`ProbabilityTheory.gaussianReal_of_var_ne_zero`), and
+coordinatewise densities multiply (`TauCeti.pi_withDensity`). -/
+theorem pi_gaussianReal_eq_withDensity :
+    (Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ))
+      = (Measure.pi fun _ : ι => (volume : Measure ℝ)).withDensity
+        fun x => ENNReal.ofReal (∏ i, gaussianPDFReal 0 1 (x i)) := by
+  have hγ : (volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x))
+      = (gaussianReal 0 1 : Measure ℝ) := by
+    rw [gaussianReal_of_var_ne_zero 0 one_ne_zero, gaussianPDF_def]
+  have : IsProbabilityMeasure
+      (volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x)) := by
+    rw [hγ]; infer_instance
+  rw [show (fun _ : ι => (gaussianReal 0 1 : Measure ℝ))
+      = fun _ : ι => volume.withDensity fun x => ENNReal.ofReal (gaussianPDFReal 0 1 x) from
+    funext fun _ => hγ.symm,
+    pi_withDensity (fun _ : ι => (volume : Measure ℝ)) fun _ =>
+      (measurable_gaussianPDFReal 0 1).ennreal_ofReal]
+  exact withDensity_congr_ae (Filter.Eventually.of_forall fun x =>
+    (ENNReal.ofReal_prod_of_nonneg fun i _ =>
+      (gaussianPDFReal_pos 0 1 (x i) one_ne_zero).le).symm)
+
+/-- **`volume^ι` is absolutely continuous with respect to `γ^ι`.** The joint density is everywhere
+positive, so weighting by it kills no set of positive measure. This is what moves an
+almost-everywhere identification of a `L²(γ^ι)` representative to one holding `volume^ι`-almost
+everywhere, where the `√`-density envelope lives. -/
+theorem pi_volume_absolutelyContinuous_pi_gaussianReal :
+    (Measure.pi fun _ : ι => (volume : Measure ℝ))
+      ≪ Measure.pi fun _ : ι => (gaussianReal 0 1 : Measure ℝ) := by
+  rw [pi_gaussianReal_eq_withDensity]
+  exact withDensity_absolutelyContinuous'
+    (measurable_prod_gaussianPDFReal ι).ennreal_ofReal.aemeasurable
+    (Filter.Eventually.of_forall fun x =>
+      (ENNReal.ofReal_pos.2 (prod_gaussianPDFReal_pos ι x)).ne')
+
+end TauCeti


### PR DESCRIPTION
This PR closes the last stated relation of Part D of the `OrthogonalL2Bases` roadmap: it identifies the image of the multivariate Gaussian Hermite basis of `L²(γ^ι)` under the coordinatewise weight-to-function isometry as the multi-index Hermite-function family, dilated by `xᵢ ↦ xᵢ/√2` and rescaled by `2^{-1/4}` in each coordinate. Part D already had both multi-index bases (`gaussianHermitePiBasis` on `L²(γ^ι)` and `hermiteFunctionPiBasis` on `L²(volume^ι)`) together with their `coe_*` pins, but its closing sentence, that the two are "related to it by the **coordinatewise** `weightL2Isometry` + `u = xᵢ√2` dilation (same caveat as A3′, per coordinate), not by the isometry alone", was unformalized; that per-coordinate caveat is exactly what this PR proves. The one-dimensional statement it lifts is `weightL2Isometry_gaussianHermiteHilbertBasis` (A3′), whose shape the new lemmas mirror.

Roadmap: OrthogonalL2Bases

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"weightl2isometry-gaussianhermitepibasis"}-->

Getting there needs two facts Mathlib does not have, which this PR proves in general form rather than for the Gaussian alone. `TauCeti.lintegral_fintype_prod_eq_prod` is the `ℝ≥0∞` companion of Mathlib's `MeasureTheory.integral_fintype_prod_eq_prod`: the lower integral of `∏ i, f i (x i)` over `Measure.pi μ` is `∏ i, ∫⁻ y, f i y ∂μ i`, needing only measurability of the factors. `TauCeti.pi_withDensity` then says that coordinatewise densities multiply, `Measure.pi (fun i => (μ i).withDensity (f i)) = (Measure.pi μ).withDensity (fun x => ∏ i, f i (x i))`; Mathlib has only the two-factor `MeasureTheory.Measure.prod_withDensity`. Specialized to the standard Gaussian these give `pi_gaussianReal_eq_withDensity`, which exhibits `γ^ι` as `volume^ι` weighted by the joint density and so puts the multi-index basis inside the domain of `weightL2Isometry`.

The new `Lp` cast lemma `TauCeti.coeFn_cast_lp` is the general form of a private lemma that already existed in `TauCeti/Probability/Distributions/Gaussian/Hermite/Basis.lean` for `Measure ℝ`; that private copy is deleted and its use site now calls the shared lemma.

Files added:

* `TauCeti/MeasureTheory/Integral/Pi.lean` (94 lines)
* `TauCeti/MeasureTheory/Measure/PiWithDensity.lean` (71 lines)
* `TauCeti/MeasureTheory/Function/Lp/CastMeasure.lean` (44 lines)
* `TauCeti/Probability/Distributions/Gaussian/Pi.lean` (86 lines)

`TauCeti/Probability/Distributions/Gaussian/Hermite/PiBasis.lean` gains `sqrt_prod_gaussianPDFReal_smul_gaussianHermitePiBasis` (the envelope computed pointwise, `volume^ι`-almost everywhere) and `weightL2Isometry_gaussianHermitePiBasis` (the same fact at the isometry level). No declarations were renamed or moved.

With this, every target stated in the `OrthogonalL2Bases` README is formalized. What remains for a follow-up, and is not asked for by the roadmap text, is to state the relation as an equation between the two bundled `HilbertBasis` objects by composing `weightL2Isometry` with an `L²(ℝ^ι)` dilation isometry, rather than as an almost-everywhere identity of representatives; the one-dimensional A3′ statement stops at the same point.

🤖 Prepared with Claude Code
