### PR TITLE
refactor(Poincare): decompose the one-dimensional slab inequality

### DIFF
--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -84,6 +84,83 @@ private theorem eq_zero_of_support_subset_Icc (hg : Continuous g)
   by_contra h
   exact absurd (hsupp (Function.mem_support.2 fun h' => h h'.symm)).1 (not_le.2 ht)
 
+omit [NormedSpace ℝ F] [CompleteSpace F] in
+/-- A function supported in the degenerate interval `Set.Icc a a` and vanishing at `a` vanishes
+identically. -/
+private theorem eq_zero_of_support_subset_Icc_self (hsupp : Function.support g ⊆ Icc a a)
+    (hga : g a = 0) (t : ℝ) : g t = 0 := by
+  by_cases h : g t = 0
+  · exact h
+  · have htm := hsupp (Function.mem_support.2 h)
+    rw [le_antisymm htm.2 htm.1]
+    exact hga
+
+omit [NormedSpace ℝ F] [CompleteSpace F] in
+/-- The support of `‖g ·‖ₑ ^ r` lies in the half-open interval `Set.Ioc a b`: the left endpoint
+is excluded because `g` vanishes there. -/
+private theorem support_enorm_rpow_subset_Ioc (hsupp : Function.support g ⊆ Icc a b)
+    (hga : g a = 0) {r : ℝ} (hr0 : 0 < r) :
+    Function.support (fun t => ‖g t‖ₑ ^ r) ⊆ Ioc a b := by
+  intro t ht
+  have hgt : g t ≠ 0 := fun h => ht (by simp [h, ENNReal.zero_rpow_of_pos hr0])
+  have htm := hsupp (Function.mem_support.2 hgt)
+  exact ⟨htm.1.lt_of_ne fun h => hgt (h ▸ hga), htm.2⟩
+
+/-- **The fundamental theorem of calculus, in `∫⁻` form**: a function vanishing at `a` is bounded
+throughout `Set.Icc a b` by the total variation of its derivative over the interval.
+
+Only `g a = 0` is used, not a support hypothesis, and the conclusion is pointwise in `t`. -/
+private theorem enorm_le_lintegral_enorm_deriv (hab : a ≤ b)
+    (hg : ∀ t, HasDerivAt g (g' t) t) (hg' : Continuous g') (hga : g a = 0)
+    {t : ℝ} (ht : t ∈ Icc a b) : ‖g t‖ₑ ≤ ∫⁻ s in Ioc a b, ‖g' s‖ₑ := by
+  have h1 : ∫ s in a..t, g' s = g t - g a :=
+    intervalIntegral.integral_eq_sub_of_hasDerivAt (fun s _ => hg s) (hg'.intervalIntegrable a t)
+  have h2 : ‖g t‖ ≤ ∫ s in a..t, ‖g' s‖ := by
+    have hgt : g t = ∫ s in a..t, g' s := by rw [h1, hga, sub_zero]
+    rw [hgt]
+    exact intervalIntegral.norm_integral_le_integral_norm ht.1
+  have h3 : ∫ s in a..t, ‖g' s‖ ≤ ∫ s in a..b, ‖g' s‖ :=
+    intervalIntegral.integral_mono_interval le_rfl ht.1 ht.2
+      (.of_forall fun s => norm_nonneg _) (hg'.norm.intervalIntegrable a b)
+  calc ‖g t‖ₑ = ENNReal.ofReal ‖g t‖ := (ofReal_norm _).symm
+    _ ≤ ENNReal.ofReal (∫ s in a..b, ‖g' s‖) := ENNReal.ofReal_le_ofReal (h2.trans h3)
+    _ = _ := by
+        rw [intervalIntegral.integral_of_le hab]
+        exact ofReal_integral_norm_eq_lintegral_enorm hg'.integrableOn_Ioc
+
+omit [NormedSpace ℝ F] [CompleteSpace F] in
+/-- **The nesting `L^r ⊆ L^1` on a bounded interval**, in `∫⁻` form and raised to the power `r`,
+which is how the Poincaré argument consumes it: the total variation over `Set.Ioc a b` is
+controlled by the `L^r` integral at the cost of the factor `(b - a)^{r-1}`.
+
+Measurability is all that is asked of `f`; no relation between `a` and `b` is needed. -/
+private theorem rpow_lintegral_enorm_le_mul_lintegral_enorm_rpow {f : ℝ → F}
+    (hf : AEStronglyMeasurable f (volume.restrict (Ioc a b))) {r : ℝ} (hr : 1 ≤ r) :
+    (∫⁻ s in Ioc a b, ‖f s‖ₑ) ^ r
+      ≤ ENNReal.ofReal (b - a) ^ (r - 1) * ∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r := by
+  have hr0 : (0 : ℝ) < r := one_pos.trans_le hr
+  have hvol : (volume.restrict (Ioc a b)) univ = ENNReal.ofReal (b - a) := by
+    rw [Measure.restrict_apply_univ, Real.volume_Ioc]
+  have hCr : eLpNorm f (ENNReal.ofReal r) (volume.restrict (Ioc a b))
+      = (∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) := by
+    rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by simpa using hr0) ENNReal.ofReal_ne_top,
+      ENNReal.toReal_ofReal hr0.le]
+  have holder : ∫⁻ s in Ioc a b, ‖f s‖ₑ ≤ (∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) *
+      ENNReal.ofReal (b - a) ^ (1 - 1 / r) := by
+    have hle : (1 : ℝ≥0∞) ≤ ENNReal.ofReal r := by
+      rw [← ENNReal.ofReal_one]; exact ENNReal.ofReal_le_ofReal hr
+    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := f)
+      (μ := volume.restrict (Ioc a b)) hle hf
+    rwa [eLpNorm_one_eq_lintegral_enorm, hCr, hvol, ENNReal.toReal_one,
+      ENNReal.toReal_ofReal hr0.le, div_one] at this
+  have hexp : (1 - r⁻¹) * r = r - 1 := by field_simp
+  calc (∫⁻ s in Ioc a b, ‖f s‖ₑ) ^ r
+      ≤ ((∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) * ENNReal.ofReal (b - a) ^ (1 - 1 / r)) ^ r :=
+        ENNReal.rpow_le_rpow holder hr0.le
+    _ = _ := by
+        rw [ENNReal.mul_rpow_of_nonneg _ _ hr0.le, ← ENNReal.rpow_mul, ← ENNReal.rpow_mul,
+          one_div, inv_mul_cancel₀ hr0.ne', ENNReal.rpow_one, hexp, mul_comm]
+
 /-- **The one-dimensional Poincaré inequality**, in the `∫⁻` form the Fubini argument below
 consumes: a `C¹` function on `ℝ` that vanishes outside `Set.Icc a b` satisfies
 `∫ ‖g‖^r ≤ (b - a)^r ∫ ‖g'‖^r` for every `1 ≤ r`.
@@ -101,80 +178,28 @@ theorem lintegral_enorm_rpow_le_of_support_subset_Icc (hab : a ≤ b)
   have hga : g a = 0 := eq_zero_of_support_subset_Icc hgc hsupp
   -- The degenerate slab carries no function at all.
   rcases hab.eq_or_lt with rfl | hab'
-  · have hgz : ∀ t, g t = 0 := by
-      intro t
-      by_cases h : g t = 0
-      · exact h
-      · have htm := hsupp (Function.mem_support.2 h)
-        rw [le_antisymm htm.2 htm.1]
-        exact hga
-    simp [hgz, ENNReal.zero_rpow_of_pos hr0]
+  · simp [eq_zero_of_support_subset_Icc_self hsupp hga, ENNReal.zero_rpow_of_pos hr0]
   have hba : (0 : ℝ) < b - a := sub_pos.2 hab'
-  set C : ℝ≥0∞ := ∫⁻ s in Ioc a b, ‖g' s‖ₑ with hCdef
-  -- Step 1: the fundamental theorem of calculus bounds `g` by the total variation of `g'`.
-  have hkey : ∀ t ∈ Icc a b, ‖g t‖ₑ ≤ C := by
-    intro t ht
-    have h1 : ∫ s in a..t, g' s = g t - g a :=
-      intervalIntegral.integral_eq_sub_of_hasDerivAt (fun s _ => hg s) (hg'.intervalIntegrable a t)
-    have h2 : ‖g t‖ ≤ ∫ s in a..t, ‖g' s‖ := by
-      have hgt : g t = ∫ s in a..t, g' s := by rw [h1, hga, sub_zero]
-      rw [hgt]
-      exact intervalIntegral.norm_integral_le_integral_norm ht.1
-    have h3 : ∫ s in a..t, ‖g' s‖ ≤ ∫ s in a..b, ‖g' s‖ :=
-      intervalIntegral.integral_mono_interval le_rfl ht.1 ht.2
-        (.of_forall fun s => norm_nonneg _) (hg'.norm.intervalIntegrable a b)
-    calc ‖g t‖ₑ = ENNReal.ofReal ‖g t‖ := (ofReal_norm _).symm
-      _ ≤ ENNReal.ofReal (∫ s in a..b, ‖g' s‖) := ENNReal.ofReal_le_ofReal (h2.trans h3)
-      _ = C := by
-          rw [intervalIntegral.integral_of_le hab, hCdef]
-          exact ofReal_integral_norm_eq_lintegral_enorm (hg'.integrableOn_Ioc)
-  -- Step 2: Hölder, as the inclusion `L^r (Ioc a b) ⊆ L^1 (Ioc a b)`.
-  have hvol : (volume.restrict (Ioc a b)) univ = ENNReal.ofReal (b - a) := by
-    rw [Measure.restrict_apply_univ, Real.volume_Ioc]
-  have hCr : eLpNorm g' (ENNReal.ofReal r) (volume.restrict (Ioc a b))
-      = (∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r) ^ (1 / r) := by
-    rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by simpa using hr0) ENNReal.ofReal_ne_top,
-      ENNReal.toReal_ofReal hr0.le]
-  have holder : C ≤ (∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r) ^ (1 / r) *
-      ENNReal.ofReal (b - a) ^ (1 - 1 / r) := by
-    have hle : (1 : ℝ≥0∞) ≤ ENNReal.ofReal r := by
-      rw [← ENNReal.ofReal_one]; exact ENNReal.ofReal_le_ofReal hr
-    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := g')
-      (μ := volume.restrict (Ioc a b)) hle hg'.aestronglyMeasurable
-    rwa [eLpNorm_one_eq_lintegral_enorm, ← hCdef, hCr, hvol, ENNReal.toReal_one,
-      ENNReal.toReal_ofReal hr0.le, div_one] at this
-  have holder' : C ^ r ≤ ENNReal.ofReal (b - a) ^ (r - 1) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r := by
-    have hexp : (1 - r⁻¹) * r = r - 1 := by field_simp
-    calc C ^ r
-        ≤ ((∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r) ^ (1 / r) * ENNReal.ofReal (b - a) ^ (1 - 1 / r)) ^ r :=
-          ENNReal.rpow_le_rpow holder hr0.le
-      _ = _ := by
-          rw [ENNReal.mul_rpow_of_nonneg _ _ hr0.le, ← ENNReal.rpow_mul, ← ENNReal.rpow_mul,
-            one_div, inv_mul_cancel₀ hr0.ne', ENNReal.rpow_one, hexp, mul_comm]
-  -- Step 3: integrate the pointwise bound over the slab.
   have hpow : ENNReal.ofReal (b - a) ^ (r - 1) * ENNReal.ofReal (b - a)
       = ENNReal.ofReal ((b - a) ^ r) := by
-    have hsum : r - 1 + 1 = r := by ring
     nth_rewrite 2 [← ENNReal.rpow_one (ENNReal.ofReal (b - a))]
-    rw [← ENNReal.rpow_add _ _ (by simpa using hba) ENNReal.ofReal_ne_top, hsum,
-      ENNReal.ofReal_rpow_of_pos hba]
-  have hsupp' : Function.support (fun t => ‖g t‖ₑ ^ r) ⊆ Ioc a b := by
-    intro t ht
-    have hgt : g t ≠ 0 := by
-      intro h
-      exact ht (by simp [h, ENNReal.zero_rpow_of_pos hr0])
-    have htm := hsupp (Function.mem_support.2 hgt)
-    exact ⟨htm.1.lt_of_ne fun h => hgt (h ▸ hga), htm.2⟩
+    rw [← ENNReal.rpow_add _ _ (by simpa using hba) ENNReal.ofReal_ne_top,
+      show r - 1 + 1 = r by ring, ENNReal.ofReal_rpow_of_pos hba]
   calc ∫⁻ t, ‖g t‖ₑ ^ r
       = ∫⁻ t in Ioc a b, ‖g t‖ₑ ^ r := by
-        rw [← lintegral_indicator measurableSet_Ioc, Set.indicator_eq_self.2 hsupp']
-    _ ≤ ∫⁻ _ in Ioc a b, C ^ r := by
+        rw [← lintegral_indicator measurableSet_Ioc,
+          Set.indicator_eq_self.2 (support_enorm_rpow_subset_Ioc hsupp hga hr0)]
+    _ ≤ ∫⁻ _ in Ioc a b, (∫⁻ s in Ioc a b, ‖g' s‖ₑ) ^ r := by
         refine lintegral_mono_ae ?_
         filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
-        exact ENNReal.rpow_le_rpow (hkey t (Ioc_subset_Icc_self ht)) hr0.le
-    _ = C ^ r * ENNReal.ofReal (b - a) := by rw [setLIntegral_const, Real.volume_Ioc]
+        exact ENNReal.rpow_le_rpow
+          (enorm_le_lintegral_enorm_deriv hab hg hg' hga (Ioc_subset_Icc_self ht)) hr0.le
+    _ = (∫⁻ s in Ioc a b, ‖g' s‖ₑ) ^ r * ENNReal.ofReal (b - a) := by
+        rw [setLIntegral_const, Real.volume_Ioc]
     _ ≤ (ENNReal.ofReal (b - a) ^ (r - 1) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r) *
-          ENNReal.ofReal (b - a) := by gcongr
+          ENNReal.ofReal (b - a) := by
+        gcongr
+        exact rpow_lintegral_enorm_le_mul_lintegral_enorm_rpow hg'.aestronglyMeasurable hr
     _ = ENNReal.ofReal ((b - a) ^ r) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r := by
         rw [mul_right_comm, hpow]
     _ ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖g' t‖ₑ ^ r :=

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -110,12 +110,13 @@ omit [CompleteSpace F] in
 throughout `Set.Icc a b` by its total variation `∫ ‖g'‖` over the interval.
 
 Only `g a = 0` is used, not a support hypothesis, and the conclusion is pointwise in `t`; the
-order `a ≤ b` is not assumed separately, being implied by `t ∈ Set.Icc a b`. Completeness of `F`
-is not needed either — `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` passes to
-the completion internally. -/
+order `a ≤ b` is not assumed separately, being implied by `t ∈ Set.Icc a b`; and `F` need not be
+complete. -/
 private theorem enorm_le_lintegral_enorm_deriv
     (hg : ∀ t, HasDerivAt g (g' t) t) (hg' : Continuous g') (hga : g a = 0)
     {t : ℝ} (ht : t ∈ Icc a b) : ‖g t‖ₑ ≤ ∫⁻ s in Ioc a b, ‖g' s‖ₑ := by
+  -- Completeness would only be needed for the fundamental theorem of calculus, and
+  -- `enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` passes to the completion itself.
   have hderiv : deriv g = g' := funext fun x => (hg x).deriv
   have hC1 : ContDiff ℝ 1 g :=
     contDiff_one_iff_deriv.2 ⟨fun x => (hg x).differentiableAt, hderiv ▸ hg'⟩
@@ -135,9 +136,7 @@ variation `∫ ‖g'‖` over the interval, and the nesting `L^r ⊆ L^1` of the
 finite measure space `Set.Ioc a b`, which converts that `L^1` bound into an `L^r` one at the cost
 of the factor `(b - a)^{r-1}`.
 
-Completeness of `F` is not required: the only place it could enter is the fundamental theorem of
-calculus, and `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` passes to the
-completion internally. -/
+`F` need not be complete. -/
 theorem lintegral_enorm_rpow_le_of_support_subset_Icc (hab : a ≤ b)
     (hg : ∀ t, HasDerivAt g (g' t) t) (hg' : Continuous g')
     (hsupp : Function.support g ⊆ Icc a b) {r : ℝ} (hr : 1 ≤ r) :

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -107,7 +107,7 @@ private theorem support_enorm_rpow_subset_Ioc (hsupp : Function.support g ⊆ Ic
 
 omit [CompleteSpace F] in
 /-- **The fundamental theorem of calculus, in `∫⁻` form**: a function vanishing at `a` is bounded
-throughout `Set.Icc a b` by the total variation of its derivative over the interval.
+throughout `Set.Icc a b` by its total variation `∫ ‖g'‖` over the interval.
 
 Only `g a = 0` is used, not a support hypothesis, and the conclusion is pointwise in `t`; the
 order `a ≤ b` is not assumed separately, being implied by `t ∈ Set.Icc a b`. Completeness of `F`

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -37,7 +37,7 @@ some such hypothesis is genuinely needed: no constant works on the whole space.
 The proof is the classical one-dimensional argument. Along the line through `x` in the direction
 of the `i`-th coordinate the function starts at `0`, so the fundamental theorem of calculus gives
 `‖u‖ ≤ ∫ ‖∂ᵢ u‖` over the width of the slab; Hölder's inequality — in the form of the nesting
-`L^p ⊆ L^1` of the `Lᵖ` scale, `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul` — turns
+`L^p ⊆ L^1` of the `Lᵖ` scale, `TauCeti.rpow_lintegral_le_measure_univ_rpow_mul` — turns
 that into
 `‖u‖^p ≤ (b - a)^{p-1} ∫ ‖∂ᵢ u‖^p`, and integrating in the remaining variables by Fubini gives
 the result. See Evans, *Partial Differential Equations*, Section 5.6.
@@ -169,8 +169,8 @@ theorem lintegral_enorm_rpow_le_of_support_subset_Icc (hab : a ≤ b)
         gcongr
         have hmu : (volume.restrict (Ioc a b)) Set.univ = ENNReal.ofReal (b - a) := by
           rw [Measure.restrict_apply_univ, Real.volume_Ioc]
-        simpa only [hmu] using rpow_lintegral_enorm_le_measure_univ_rpow_mul
-          (μ := volume.restrict (Ioc a b)) hg'.aestronglyMeasurable hr
+        simpa only [hmu] using rpow_lintegral_le_measure_univ_rpow_mul
+          (μ := volume.restrict (Ioc a b)) hg'.enorm.measurable.aemeasurable hr
     _ = ENNReal.ofReal ((b - a) ^ r) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r := by
         rw [mul_right_comm, hpow]
     _ ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖g' t‖ₑ ^ r :=

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -5,14 +5,15 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.ContDiff.Basic
-public import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 -- `TauCeti.MeasureTheory.Function.Lp.LIntegralRpow` is imported publicly: every estimate below is
 -- proved as a bound between `∫⁻ ‖·‖ₑ ^ p` integrals and converted by
 -- `TauCeti.eLpNorm_le_eLpNorm_of_lintegral_rpow_le`, which a reader of either form will want.
 public import TauCeti.MeasureTheory.Function.Lp.LIntegralRpow
+import Mathlib.Analysis.Calculus.ContDiff.Deriv
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.MeasureTheory.Constructions.Pi
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.Prod
 
@@ -38,8 +39,8 @@ some such hypothesis is genuinely needed: no constant works on the whole space.
 The proof is the classical one-dimensional argument. Along the line through `x` in the direction
 of the `i`-th coordinate the function starts at `0`, so the fundamental theorem of calculus gives
 `‖u‖ ≤ ∫ ‖∂ᵢ u‖` over the width of the slab; Hölder's inequality — in the form of the nesting
-`L^p ⊆ L^1` of the `Lᵖ` scale on a finite measure space,
-`MeasureTheory.eLpNorm_le_eLpNorm_mul_rpow_measure_univ` — turns that into
+`L^p ⊆ L^1` of the `Lᵖ` scale, `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul` — turns
+that into
 `‖u‖^p ≤ (b - a)^{p-1} ∫ ‖∂ᵢ u‖^p`, and integrating in the remaining variables by Fubini gives
 the result. See Evans, *Partial Differential Equations*, Section 5.6.
 
@@ -106,61 +107,27 @@ private theorem support_enorm_rpow_subset_Ioc (hsupp : Function.support g ⊆ Ic
   have htm := hsupp (Function.mem_support.2 hgt)
   exact ⟨htm.1.lt_of_ne fun h => hgt (h ▸ hga), htm.2⟩
 
+omit [CompleteSpace F] in
 /-- **The fundamental theorem of calculus, in `∫⁻` form**: a function vanishing at `a` is bounded
 throughout `Set.Icc a b` by the total variation of its derivative over the interval.
 
-Only `g a = 0` is used, not a support hypothesis, and the conclusion is pointwise in `t`. -/
-private theorem enorm_le_lintegral_enorm_deriv (hab : a ≤ b)
+Only `g a = 0` is used, not a support hypothesis, and the conclusion is pointwise in `t`; the
+order `a ≤ b` is not assumed separately, being implied by `t ∈ Set.Icc a b`. Completeness of `F`
+is not needed either — `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` passes to
+the completion internally. -/
+private theorem enorm_le_lintegral_enorm_deriv
     (hg : ∀ t, HasDerivAt g (g' t) t) (hg' : Continuous g') (hga : g a = 0)
     {t : ℝ} (ht : t ∈ Icc a b) : ‖g t‖ₑ ≤ ∫⁻ s in Ioc a b, ‖g' s‖ₑ := by
-  have h1 : ∫ s in a..t, g' s = g t - g a :=
-    intervalIntegral.integral_eq_sub_of_hasDerivAt (fun s _ => hg s) (hg'.intervalIntegrable a t)
-  have h2 : ‖g t‖ ≤ ∫ s in a..t, ‖g' s‖ := by
-    have hgt : g t = ∫ s in a..t, g' s := by rw [h1, hga, sub_zero]
-    rw [hgt]
-    exact intervalIntegral.norm_integral_le_integral_norm ht.1
-  have h3 : ∫ s in a..t, ‖g' s‖ ≤ ∫ s in a..b, ‖g' s‖ :=
-    intervalIntegral.integral_mono_interval le_rfl ht.1 ht.2
-      (.of_forall fun s => norm_nonneg _) (hg'.norm.intervalIntegrable a b)
-  calc ‖g t‖ₑ = ENNReal.ofReal ‖g t‖ := (ofReal_norm _).symm
-    _ ≤ ENNReal.ofReal (∫ s in a..b, ‖g' s‖) := ENNReal.ofReal_le_ofReal (h2.trans h3)
-    _ = _ := by
-        rw [intervalIntegral.integral_of_le hab]
-        exact ofReal_integral_norm_eq_lintegral_enorm hg'.integrableOn_Ioc
+  have hderiv : deriv g = g' := funext fun x => (hg x).deriv
+  have hC1 : ContDiff ℝ 1 g :=
+    contDiff_one_iff_deriv.2 ⟨fun x => (hg x).differentiableAt, hderiv ▸ hg'⟩
+  calc ‖g t‖ₑ = ‖g t - g a‖ₑ := by rw [hga, sub_zero]
+    _ ≤ ∫⁻ s in Icc a t, ‖deriv g s‖ₑ :=
+        enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc hC1.contDiffOn ht.1
+    _ = ∫⁻ s in Ioc a t, ‖g' s‖ₑ := by rw [hderiv, setLIntegral_congr Ioc_ae_eq_Icc]
+    _ ≤ ∫⁻ s in Ioc a b, ‖g' s‖ₑ := lintegral_mono_set (Ioc_subset_Ioc_right ht.2)
 
-omit [NormedSpace ℝ F] [CompleteSpace F] in
-/-- **The nesting `L^r ⊆ L^1` on a bounded interval**, in `∫⁻` form and raised to the power `r`,
-which is how the Poincaré argument consumes it: the total variation over `Set.Ioc a b` is
-controlled by the `L^r` integral at the cost of the factor `(b - a)^{r-1}`.
-
-Measurability is all that is asked of `f`; no relation between `a` and `b` is needed. -/
-private theorem rpow_lintegral_enorm_le_mul_lintegral_enorm_rpow {f : ℝ → F}
-    (hf : AEStronglyMeasurable f (volume.restrict (Ioc a b))) {r : ℝ} (hr : 1 ≤ r) :
-    (∫⁻ s in Ioc a b, ‖f s‖ₑ) ^ r
-      ≤ ENNReal.ofReal (b - a) ^ (r - 1) * ∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r := by
-  have hr0 : (0 : ℝ) < r := one_pos.trans_le hr
-  have hvol : (volume.restrict (Ioc a b)) univ = ENNReal.ofReal (b - a) := by
-    rw [Measure.restrict_apply_univ, Real.volume_Ioc]
-  have hCr : eLpNorm f (ENNReal.ofReal r) (volume.restrict (Ioc a b))
-      = (∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) := by
-    rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by simpa using hr0) ENNReal.ofReal_ne_top,
-      ENNReal.toReal_ofReal hr0.le]
-  have holder : ∫⁻ s in Ioc a b, ‖f s‖ₑ ≤ (∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) *
-      ENNReal.ofReal (b - a) ^ (1 - 1 / r) := by
-    have hle : (1 : ℝ≥0∞) ≤ ENNReal.ofReal r := by
-      rw [← ENNReal.ofReal_one]; exact ENNReal.ofReal_le_ofReal hr
-    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := f)
-      (μ := volume.restrict (Ioc a b)) hle hf
-    rwa [eLpNorm_one_eq_lintegral_enorm, hCr, hvol, ENNReal.toReal_one,
-      ENNReal.toReal_ofReal hr0.le, div_one] at this
-  have hexp : (1 - r⁻¹) * r = r - 1 := by field_simp
-  calc (∫⁻ s in Ioc a b, ‖f s‖ₑ) ^ r
-      ≤ ((∫⁻ s in Ioc a b, ‖f s‖ₑ ^ r) ^ (1 / r) * ENNReal.ofReal (b - a) ^ (1 - 1 / r)) ^ r :=
-        ENNReal.rpow_le_rpow holder hr0.le
-    _ = _ := by
-        rw [ENNReal.mul_rpow_of_nonneg _ _ hr0.le, ← ENNReal.rpow_mul, ← ENNReal.rpow_mul,
-          one_div, inv_mul_cancel₀ hr0.ne', ENNReal.rpow_one, hexp, mul_comm]
-
+omit [CompleteSpace F] in
 /-- **The one-dimensional Poincaré inequality**, in the `∫⁻` form the Fubini argument below
 consumes: a `C¹` function on `ℝ` that vanishes outside `Set.Icc a b` satisfies
 `∫ ‖g‖^r ≤ (b - a)^r ∫ ‖g'‖^r` for every `1 ≤ r`.
@@ -168,7 +135,11 @@ consumes: a `C¹` function on `ℝ` that vanishes outside `Set.Icc a b` satisfie
 The two ingredients are the fundamental theorem of calculus, which bounds `‖g t‖` by the total
 variation `∫ ‖g'‖` over the interval, and the nesting `L^r ⊆ L^1` of the `Lᵖ` scale on the
 finite measure space `Set.Ioc a b`, which converts that `L^1` bound into an `L^r` one at the cost
-of the factor `(b - a)^{r-1}`. -/
+of the factor `(b - a)^{r-1}`.
+
+Completeness of `F` is not required: the only place it could enter is the fundamental theorem of
+calculus, and `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc` passes to the
+completion internally. -/
 theorem lintegral_enorm_rpow_le_of_support_subset_Icc (hab : a ≤ b)
     (hg : ∀ t, HasDerivAt g (g' t) t) (hg' : Continuous g')
     (hsupp : Function.support g ⊆ Icc a b) {r : ℝ} (hr : 1 ≤ r) :
@@ -183,28 +154,32 @@ theorem lintegral_enorm_rpow_le_of_support_subset_Icc (hab : a ≤ b)
   have hpow : ENNReal.ofReal (b - a) ^ (r - 1) * ENNReal.ofReal (b - a)
       = ENNReal.ofReal ((b - a) ^ r) := by
     nth_rewrite 2 [← ENNReal.rpow_one (ENNReal.ofReal (b - a))]
-    rw [← ENNReal.rpow_add _ _ (by simpa using hba) ENNReal.ofReal_ne_top,
-      show r - 1 + 1 = r by ring, ENNReal.ofReal_rpow_of_pos hba]
+    have hsum : r - 1 + 1 = r := by ring
+    rw [← ENNReal.rpow_add _ _ (by simpa using hba) ENNReal.ofReal_ne_top, hsum,
+      ENNReal.ofReal_rpow_of_pos hba]
   calc ∫⁻ t, ‖g t‖ₑ ^ r
-      = ∫⁻ t in Ioc a b, ‖g t‖ₑ ^ r := by
-        rw [← lintegral_indicator measurableSet_Ioc,
-          Set.indicator_eq_self.2 (support_enorm_rpow_subset_Ioc hsupp hga hr0)]
+      = ∫⁻ t in Ioc a b, ‖g t‖ₑ ^ r :=
+        (setLIntegral_eq_of_support_subset (support_enorm_rpow_subset_Ioc hsupp hga hr0)).symm
     _ ≤ ∫⁻ _ in Ioc a b, (∫⁻ s in Ioc a b, ‖g' s‖ₑ) ^ r := by
         refine lintegral_mono_ae ?_
         filter_upwards [ae_restrict_mem measurableSet_Ioc] with t ht
         exact ENNReal.rpow_le_rpow
-          (enorm_le_lintegral_enorm_deriv hab hg hg' hga (Ioc_subset_Icc_self ht)) hr0.le
+          (enorm_le_lintegral_enorm_deriv hg hg' hga (Ioc_subset_Icc_self ht)) hr0.le
     _ = (∫⁻ s in Ioc a b, ‖g' s‖ₑ) ^ r * ENNReal.ofReal (b - a) := by
         rw [setLIntegral_const, Real.volume_Ioc]
     _ ≤ (ENNReal.ofReal (b - a) ^ (r - 1) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r) *
           ENNReal.ofReal (b - a) := by
         gcongr
-        exact rpow_lintegral_enorm_le_mul_lintegral_enorm_rpow hg'.aestronglyMeasurable hr
+        have hmu : (volume.restrict (Ioc a b)) Set.univ = ENNReal.ofReal (b - a) := by
+          rw [Measure.restrict_apply_univ, Real.volume_Ioc]
+        simpa only [hmu] using rpow_lintegral_enorm_le_measure_univ_rpow_mul
+          (μ := volume.restrict (Ioc a b)) hg'.aestronglyMeasurable hr
     _ = ENNReal.ofReal ((b - a) ^ r) * ∫⁻ s in Ioc a b, ‖g' s‖ₑ ^ r := by
         rw [mul_right_comm, hpow]
     _ ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖g' t‖ₑ ^ r :=
         mul_le_mul' le_rfl (setLIntegral_le_lintegral _ _)
 
+omit [CompleteSpace F] in
 /-- **The one-dimensional Poincaré inequality**: a `C¹` function on `ℝ` supported in an interval
 of length `b - a` obeys `‖g‖_p ≤ (b - a) ‖g'‖_p` for every `1 ≤ p < ∞`.
 
@@ -262,6 +237,7 @@ private theorem lintegral_eq_lintegral_slabChart {w : EuclideanSpace ℝ (Fin (n
   exact lintegral_prod_symm (fun z => w (slabChart i z))
     (hw.comp (measurePreserving_slabChart (i := i)).measurable).aemeasurable
 
+omit [CompleteSpace F] in
 /-- **The Poincaré inequality on a slab.** A `C¹` function on `ℝ^{n+1}` that vanishes outside
 the slab `{x | x i ∈ Set.Icc a b}` satisfies `‖u‖_p ≤ (b - a) ‖Du‖_p` for every `1 ≤ p < ∞`.
 
@@ -325,6 +301,7 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (hu : ContDiff ℝ 1 u)
     _ = ENNReal.ofReal ((b - a) ^ r) * ∫⁻ x, ‖fderiv ℝ u x‖ₑ ^ r := by
         rw [lintegral_eq_lintegral_slabChart hmf]
 
+omit [CompleteSpace F] in
 /-- **The Poincaré inequality on a ball.** A `C¹` function on `ℝ^{n+1}` supported in the ball of
 radius `R` about the origin satisfies `‖u‖_p ≤ 2R ‖Du‖_p` for every `1 ≤ p < ∞`.
 

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -14,7 +14,6 @@ import Mathlib.Analysis.Calculus.ContDiff.Deriv
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.MeasureTheory.Constructions.Pi
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 import Mathlib.MeasureTheory.Integral.Prod
 
 /-!

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -10,7 +10,6 @@ public import Mathlib.MeasureTheory.Measure.Haar.InnerProductSpace
 -- proved as a bound between `∫⁻ ‖·‖ₑ ^ p` integrals and converted by
 -- `TauCeti.eLpNorm_le_eLpNorm_of_lintegral_rpow_le`, which a reader of either form will want.
 public import TauCeti.MeasureTheory.Function.Lp.LIntegralRpow
-import Mathlib.Analysis.Calculus.ContDiff.Deriv
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.MeasureTheory.Constructions.Pi
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.ContDiff

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -22,8 +22,9 @@ covers comparing a function with its derivative.
 
 * `TauCeti.eLpNorm_le_eLpNorm_of_lintegral_rpow_le`: from
   `∫⁻ ‖v‖ₑ ^ p ≤ c ^ p * ∫⁻ ‖w‖ₑ ^ p` conclude `‖v‖_p ≤ c * ‖w‖_p`.
-* `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul`: the nesting `L^r ⊆ L^1`, in the same
-  `∫⁻` form — `(∫⁻ ‖f‖ₑ) ^ r ≤ μ univ ^ (r - 1) * ∫⁻ ‖f‖ₑ ^ r`.
+* `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul`: Hölder's extended-valued integral
+  inequality `(∫⁻ ‖f‖ₑ) ^ r ≤ μ univ ^ (r - 1) * ∫⁻ ‖f‖ₑ ^ r`, in the same `∫⁻` form.  On a finite
+  measure space it expresses the nesting `L^r ⊆ L¹`; for a general `μ` it is only the inequality.
 -/
 
 public section

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -22,9 +22,9 @@ covers comparing a function with its derivative.
 
 * `TauCeti.eLpNorm_le_eLpNorm_of_lintegral_rpow_le`: from
   `∫⁻ ‖v‖ₑ ^ p ≤ c ^ p * ∫⁻ ‖w‖ₑ ^ p` conclude `‖v‖_p ≤ c * ‖w‖_p`.
-* `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul`: Hölder's extended-valued integral
-  inequality `(∫⁻ ‖f‖ₑ) ^ r ≤ μ univ ^ (r - 1) * ∫⁻ ‖f‖ₑ ^ r`, in the same `∫⁻` form.  On a finite
-  measure space it expresses the nesting `L^r ⊆ L¹`; for a general `μ` it is only the inequality.
+* `TauCeti.rpow_lintegral_le_measure_univ_rpow_mul`: Hölder's extended-valued integral inequality
+  `(∫⁻ u) ^ r ≤ μ univ ^ (r - 1) * ∫⁻ u ^ r` for `u : α → ℝ≥0∞`.  On a finite measure space it
+  expresses the nesting `L^r ⊆ L¹`; for a general `μ` it is only the inequality.
 -/
 
 public section
@@ -55,37 +55,41 @@ theorem eLpNorm_le_eLpNorm_of_lintegral_rpow_le {α : Type*} [MeasurableSpace α
           mul_one_div_cancel hr0.ne', ENNReal.rpow_one]
 
 /-- **Hölder's inequality in extended-valued `∫⁻` form**, raised to the power `r`: the `L¹`
-integral is controlled by the `L^r` integral at the cost of the factor `μ univ ^ (r - 1)`.
+integral of `u : α → ℝ≥0∞` is controlled by its `L^r` integral at the cost of the factor
+`μ univ ^ (r - 1)`.  Stated for an `ℝ≥0∞`-valued `u`, so a norm-valued application passes
+`fun x => ‖f x‖ₑ` and needs only that this composite is measurable.
 
 On a finite measure space this is the nesting `L^r ⊆ L¹`; for a general `μ` it is only the
 displayed inequality, which does not by itself give that inclusion.  No finiteness is assumed, and
 the bound is not vacuous when `μ univ = ∞`: arithmetic in `ℝ≥0∞` makes the right-hand side `0`
 rather than `∞` whenever `∫⁻ ‖f‖ₑ ^ r = 0`, and the inequality still holds there because `f` then
 vanishes almost everywhere. -/
-theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul {α : Type*} [MeasurableSpace α]
-    {μ : Measure α} {G : Type*} [TopologicalSpace G] [ContinuousENorm G] {f : α → G}
-    (hf : AEStronglyMeasurable f μ) {r : ℝ} (hr : 1 ≤ r) :
-    (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r ≤ μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ := by
+theorem rpow_lintegral_le_measure_univ_rpow_mul {α : Type*} [MeasurableSpace α]
+    {μ : Measure α} {u : α → ℝ≥0∞} (hu : AEMeasurable u μ) {r : ℝ} (hr : 1 ≤ r) :
+    (∫⁻ x, u x ∂μ) ^ r ≤ μ Set.univ ^ (r - 1) * ∫⁻ x, u x ^ r ∂μ := by
+  have hf : AEStronglyMeasurable u μ := hu.aestronglyMeasurable
   have hr0 : (0 : ℝ) < r := one_pos.trans_le hr
-  have hCr : eLpNorm f (ENNReal.ofReal r) μ = (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) := by
+  have hCr : eLpNorm u (ENNReal.ofReal r) μ = (∫⁻ x, u x ^ r ∂μ) ^ (1 / r) := by
     rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by simpa using hr0) ENNReal.ofReal_ne_top,
       ENNReal.toReal_ofReal hr0.le]
-  have holder : ∫⁻ x, ‖f x‖ₑ ∂μ
-      ≤ (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r) := by
+    simp only [enorm_eq_self]
+  have holder : ∫⁻ x, u x ∂μ
+      ≤ (∫⁻ x, u x ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r) := by
     have hle : (1 : ℝ≥0∞) ≤ ENNReal.ofReal r := by
       rw [← ENNReal.ofReal_one]; exact ENNReal.ofReal_le_ofReal hr
-    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := f) (μ := μ) hle hf
-    rwa [eLpNorm_one_eq_lintegral_enorm, hCr, ENNReal.toReal_one,
+    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := u) (μ := μ) hle hf
+    rw [eLpNorm_one_eq_lintegral_enorm, hCr, ENNReal.toReal_one,
       ENNReal.toReal_ofReal hr0.le, div_one] at this
+    simpa only [enorm_eq_self] using this
   have hinv : 1 / r * r = 1 := by field_simp
   have hexp : (1 - 1 / r) * r = r - 1 := by field_simp
-  calc (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r
-      ≤ ((∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r)) ^ r :=
+  calc (∫⁻ x, u x ∂μ) ^ r
+      ≤ ((∫⁻ x, u x ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r)) ^ r :=
         ENNReal.rpow_le_rpow holder hr0.le
-    _ = ((∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r)) ^ r * (μ Set.univ ^ (1 - 1 / r)) ^ r :=
+    _ = ((∫⁻ x, u x ^ r ∂μ) ^ (1 / r)) ^ r * (μ Set.univ ^ (1 - 1 / r)) ^ r :=
         ENNReal.mul_rpow_of_nonneg _ _ hr0.le
-    _ = (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) * μ Set.univ ^ (r - 1) := by
+    _ = (∫⁻ x, u x ^ r ∂μ) * μ Set.univ ^ (r - 1) := by
         rw [← ENNReal.rpow_mul, ← ENNReal.rpow_mul, hinv, hexp, ENNReal.rpow_one]
-    _ = μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ := mul_comm _ _
+    _ = μ Set.univ ^ (r - 1) * ∫⁻ x, u x ^ r ∂μ := mul_comm _ _
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -4,7 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
+public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 
 /-!
 # `Lᵖ` seminorm bounds out of bounds between the integrals `∫⁻ ‖·‖ₑ ^ p`
@@ -52,12 +53,14 @@ theorem eLpNorm_le_eLpNorm_of_lintegral_rpow_le {α : Type*} [MeasurableSpace α
           ← ENNReal.ofReal_rpow_of_nonneg hc hr0.le, ← ENNReal.rpow_mul,
           mul_one_div_cancel hr0.ne', ENNReal.rpow_one]
 
-/-- **The nesting `L^r ⊆ L^1`**, in `∫⁻` form and raised to the power `r`: the `L^1` integral is
-controlled by the `L^r` integral at the cost of the factor `μ univ ^ (r - 1)`.
+/-- **Hölder's inequality in extended-valued `∫⁻` form**, raised to the power `r`: the `L¹`
+integral is controlled by the `L^r` integral at the cost of the factor `μ univ ^ (r - 1)`.
 
-This is Hölder's inequality in the shape an estimate proved by integration consumes.  No
-finiteness is assumed: when `μ univ = ∞` and `1 < r` the right-hand side is `∞` and the bound is
-vacuous. -/
+On a finite measure space this is the nesting `L^r ⊆ L¹`; for a general `μ` it is only the
+displayed inequality, which does not by itself give that inclusion.  No finiteness is assumed, and
+the bound is not vacuous when `μ univ = ∞`: arithmetic in `ℝ≥0∞` makes the right-hand side `0`
+rather than `∞` whenever `∫⁻ ‖f‖ₑ ^ r = 0`, and the inequality still holds there because `f` then
+vanishes almost everywhere. -/
 theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul {α : Type*} [MeasurableSpace α]
     {μ : Measure α} {G : Type*} [NormedAddCommGroup G] {f : α → G}
     (hf : AEStronglyMeasurable f μ) {r : ℝ} (hr : 1 ≤ r) :
@@ -73,12 +76,15 @@ theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul {α : Type*} [MeasurableSp
     have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := f) (μ := μ) hle hf
     rwa [eLpNorm_one_eq_lintegral_enorm, hCr, ENNReal.toReal_one,
       ENNReal.toReal_ofReal hr0.le, div_one] at this
-  have hexp : (1 - r⁻¹) * r = r - 1 := by field_simp
+  have hinv : 1 / r * r = 1 := by field_simp
+  have hexp : (1 - 1 / r) * r = r - 1 := by field_simp
   calc (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r
       ≤ ((∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r)) ^ r :=
         ENNReal.rpow_le_rpow holder hr0.le
-    _ = _ := by
-        rw [ENNReal.mul_rpow_of_nonneg _ _ hr0.le, ← ENNReal.rpow_mul, ← ENNReal.rpow_mul,
-          one_div, inv_mul_cancel₀ hr0.ne', ENNReal.rpow_one, hexp, mul_comm]
+    _ = ((∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r)) ^ r * (μ Set.univ ^ (1 - 1 / r)) ^ r :=
+        ENNReal.mul_rpow_of_nonneg _ _ hr0.le
+    _ = (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) * μ Set.univ ^ (r - 1) := by
+        rw [← ENNReal.rpow_mul, ← ENNReal.rpow_mul, hinv, hexp, ENNReal.rpow_one]
+    _ = μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ := mul_comm _ _
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
+public import Mathlib.MeasureTheory.Function.LpSeminorm.CompareExp
 
 /-!
 # `Lᵖ` seminorm bounds out of bounds between the integrals `∫⁻ ‖·‖ₑ ^ p`
@@ -21,6 +21,8 @@ covers comparing a function with its derivative.
 
 * `TauCeti.eLpNorm_le_eLpNorm_of_lintegral_rpow_le`: from
   `∫⁻ ‖v‖ₑ ^ p ≤ c ^ p * ∫⁻ ‖w‖ₑ ^ p` conclude `‖v‖_p ≤ c * ‖w‖_p`.
+* `TauCeti.rpow_lintegral_enorm_le_measure_univ_rpow_mul`: the nesting `L^r ⊆ L^1`, in the same
+  `∫⁻` form — `(∫⁻ ‖f‖ₑ) ^ r ≤ μ univ ^ (r - 1) * ∫⁻ ‖f‖ₑ ^ r`.
 -/
 
 public section
@@ -49,5 +51,34 @@ theorem eLpNorm_le_eLpNorm_of_lintegral_rpow_le {α : Type*} [MeasurableSpace α
         rw [ENNReal.mul_rpow_of_nonneg _ _ (by positivity),
           ← ENNReal.ofReal_rpow_of_nonneg hc hr0.le, ← ENNReal.rpow_mul,
           mul_one_div_cancel hr0.ne', ENNReal.rpow_one]
+
+/-- **The nesting `L^r ⊆ L^1`**, in `∫⁻` form and raised to the power `r`: the `L^1` integral is
+controlled by the `L^r` integral at the cost of the factor `μ univ ^ (r - 1)`.
+
+This is Hölder's inequality in the shape an estimate proved by integration consumes.  No
+finiteness is assumed: when `μ univ = ∞` and `1 < r` the right-hand side is `∞` and the bound is
+vacuous. -/
+theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul {α : Type*} [MeasurableSpace α]
+    {μ : Measure α} {G : Type*} [NormedAddCommGroup G] {f : α → G}
+    (hf : AEStronglyMeasurable f μ) {r : ℝ} (hr : 1 ≤ r) :
+    (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r ≤ μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ := by
+  have hr0 : (0 : ℝ) < r := one_pos.trans_le hr
+  have hCr : eLpNorm f (ENNReal.ofReal r) μ = (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) := by
+    rw [eLpNorm_eq_lintegral_rpow_enorm_toReal (by simpa using hr0) ENNReal.ofReal_ne_top,
+      ENNReal.toReal_ofReal hr0.le]
+  have holder : ∫⁻ x, ‖f x‖ₑ ∂μ
+      ≤ (∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r) := by
+    have hle : (1 : ℝ≥0∞) ≤ ENNReal.ofReal r := by
+      rw [← ENNReal.ofReal_one]; exact ENNReal.ofReal_le_ofReal hr
+    have := eLpNorm_le_eLpNorm_mul_rpow_measure_univ (f := f) (μ := μ) hle hf
+    rwa [eLpNorm_one_eq_lintegral_enorm, hCr, ENNReal.toReal_one,
+      ENNReal.toReal_ofReal hr0.le, div_one] at this
+  have hexp : (1 - r⁻¹) * r = r - 1 := by field_simp
+  calc (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r
+      ≤ ((∫⁻ x, ‖f x‖ₑ ^ r ∂μ) ^ (1 / r) * μ Set.univ ^ (1 - 1 / r)) ^ r :=
+        ENNReal.rpow_le_rpow holder hr0.le
+    _ = _ := by
+        rw [ENNReal.mul_rpow_of_nonneg _ _ hr0.le, ← ENNReal.rpow_mul, ← ENNReal.rpow_mul,
+          one_div, inv_mul_cancel₀ hr0.ne', ENNReal.rpow_one, hexp, mul_comm]
 
 end TauCeti

--- a/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
+++ b/TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean
@@ -63,7 +63,7 @@ the bound is not vacuous when `μ univ = ∞`: arithmetic in `ℝ≥0∞` makes 
 rather than `∞` whenever `∫⁻ ‖f‖ₑ ^ r = 0`, and the inequality still holds there because `f` then
 vanishes almost everywhere. -/
 theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul {α : Type*} [MeasurableSpace α]
-    {μ : Measure α} {G : Type*} [NormedAddCommGroup G] {f : α → G}
+    {μ : Measure α} {G : Type*} [TopologicalSpace G] [ContinuousENorm G] {f : α → G}
     (hf : AEStronglyMeasurable f μ) {r : ℝ} (hr : 1 ≤ r) :
     (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r ≤ μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ := by
   have hr0 : (0 : ℝ) < r := one_pos.trans_le hr

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -13,6 +13,7 @@ import Mathlib.Analysis.SpecialFunctions.PolarCoord
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
 import Mathlib.MeasureTheory.Integral.MeanInequalities
+import TauCeti.MeasureTheory.Function.Lp.LIntegralRpow
 import Mathlib.MeasureTheory.Integral.Prod
 import Mathlib.Topology.Order.LeftRightNhds
 
@@ -261,26 +262,6 @@ theorem lintegral_circleLIntegral_eq_lintegral (hg : Measurable g) (ζ : ℂ) :
 
 /-! ### Cauchy–Schwarz on a circle, and the length–area inequality -/
 
-/-- **Cauchy–Schwarz.** The square of the integral of a function is at most the mass of the measure
-times the integral of its square. -/
-private theorem sq_lintegral_le_measure_univ_mul {α : Type*} [MeasurableSpace α] (μ : Measure α)
-    {u : α → ℝ≥0∞} (hu : AEMeasurable u μ) :
-    (∫⁻ x, u x ∂μ) ^ 2 ≤ μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
-  have h := ENNReal.lintegral_mul_le_Lp_mul_Lq μ Real.HolderConjugate.two_two hu
-    (aemeasurable_const (b := (1 : ℝ≥0∞)))
-  simp only [Pi.mul_apply, mul_one, ENNReal.one_rpow, lintegral_const, one_mul] at h
-  have hrp : ∀ x : ℝ≥0∞, (x ^ (1 / 2 : ℝ)) ^ 2 = x := by
-    intro x
-    rw [← ENNReal.rpow_natCast (x ^ (1 / 2 : ℝ)) 2, ← ENNReal.rpow_mul]
-    norm_num
-  calc (∫⁻ x, u x ∂μ) ^ 2
-      ≤ ((∫⁻ x, u x ^ (2 : ℝ) ∂μ) ^ (1 / 2 : ℝ) * (μ Set.univ) ^ (1 / 2 : ℝ)) ^ 2 :=
-        pow_le_pow_left' h 2
-    _ = (∫⁻ x, u x ^ (2 : ℝ) ∂μ) * μ Set.univ := by rw [mul_pow, hrp, hrp]
-    _ = μ Set.univ * ∫⁻ x, u x ^ 2 ∂μ := by
-        rw [mul_comm]
-        exact congrArg _ (lintegral_congr fun x => ENNReal.rpow_natCast (u x) 2)
-
 /-- Cauchy–Schwarz in the angular variable: the square of the angular integral is at most `2 π`,
 the length of the angular interval, times the angular integral of the square. -/
 private theorem sq_lintegral_angle_le
@@ -290,7 +271,15 @@ private theorem sq_lintegral_angle_le
   have hvol : (volume.restrict (Ioo (-π) π)) Set.univ = ENNReal.ofReal (2 * π) := by
     rw [Measure.restrict_apply_univ, Real.volume_Ioo]
     ring_nf
-  simpa [hvol] using sq_lintegral_le_measure_univ_mul (volume.restrict (Ioo (-π) π)) hg
+  have hpow : ∀ x : ℝ≥0∞, x ^ (2 : ℝ) = x ^ 2 := fun x => by
+    rw [← ENNReal.rpow_natCast x 2]
+    norm_num
+  have h := rpow_lintegral_enorm_le_measure_univ_rpow_mul (μ := volume.restrict (Ioo (-π) π))
+    (f := fun θ => g (circleMap ζ ρ θ)) hg.aestronglyMeasurable (r := 2) one_le_two
+  rw [hvol] at h
+  simp only [enorm_eq_self, hpow] at h
+  rw [show (2 : ℝ) - 1 = 1 by norm_num, ENNReal.rpow_one] at h
+  exact h
 
 /-- **Cauchy–Schwarz on a circle.** The square of the circle integral of `g` is at most
 `2 π ρ` — for `ρ > 0` the circumference of the circle — times the circle integral of `g ^ 2`.

--- a/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
+++ b/TauCeti/MeasureTheory/Integral/CircleLIntegral.lean
@@ -12,7 +12,6 @@ import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
 import Mathlib.Analysis.SpecialFunctions.PolarCoord
 import Mathlib.MeasureTheory.Integral.CircleIntegral
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
-import Mathlib.MeasureTheory.Integral.MeanInequalities
 import TauCeti.MeasureTheory.Function.Lp.LIntegralRpow
 import Mathlib.MeasureTheory.Integral.Prod
 import Mathlib.Topology.Order.LeftRightNhds
@@ -274,12 +273,11 @@ private theorem sq_lintegral_angle_le
   have hpow : ∀ x : ℝ≥0∞, x ^ (2 : ℝ) = x ^ 2 := fun x => by
     rw [← ENNReal.rpow_natCast x 2]
     norm_num
-  have h := rpow_lintegral_enorm_le_measure_univ_rpow_mul (μ := volume.restrict (Ioo (-π) π))
-    (f := fun θ => g (circleMap ζ ρ θ)) hg.aestronglyMeasurable (r := 2) one_le_two
-  rw [hvol] at h
-  simp only [enorm_eq_self, hpow] at h
-  rw [show (2 : ℝ) - 1 = 1 by norm_num, ENNReal.rpow_one] at h
-  exact h
+  have hexp : (2 : ℝ) - 1 = 1 := by norm_num
+  have h := rpow_lintegral_le_measure_univ_rpow_mul (μ := volume.restrict (Ioo (-π) π))
+    (u := fun θ => g (circleMap ζ ρ θ)) hg (r := 2) one_le_two
+  rw [hvol, hexp, ENNReal.rpow_one] at h
+  simpa only [hpow] using h
 
 /-- **Cauchy–Schwarz on a circle.** The square of the circle integral of `g` is at most
 `2 π ρ` — for `ρ > 0` the circumference of the circle — times the circle integral of `g ^ 2`.


### PR DESCRIPTION
`lintegral_enorm_rpow_le_of_support_subset_Icc` had an 84-line proof. This splits its steps into
helpers stated with the hypotheses they actually need, and routes two of them through existing
Mathlib API. The public statement of the theorem is unchanged apart from a strictly weaker
typeclass (below).

Main proof: **84 → 37 lines**, now reading as the outline of the argument — FTC bound, Hölder,
integrate.

### Helpers in `Slab.lean` (private)

| helper | proves | generality |
|---|---|---|
| `eq_zero_of_support_subset_Icc_self` | supported in `Icc a a` and vanishing at `a` ⟹ identically zero | the degenerate slab |
| `support_enorm_rpow_subset_Ioc` | `support (‖g ·‖ₑ ^ r) ⊆ Ioc a b` | needs `0 < r`; at `r = 0` the claim is false, since `x ^ (0 : ℝ) = 1` |
| `enorm_le_lintegral_enorm_deriv` | `‖g t‖ₑ ≤ ∫⁻ s in Ioc a b, ‖g' s‖ₑ` on `Icc a b` | takes `g a = 0`, not the caller's support hypothesis; pointwise in `t`; no separate `a ≤ b` (implied by `t ∈ Icc a b`) |

### Reuse

- `enorm_le_lintegral_enorm_deriv` is now `MeasureTheory.enorm_sub_le_lintegral_deriv_of_contDiffOn_Icc`
  on `Icc a t`, plus `Ioc_ae_eq_Icc` to drop the left endpoint and `lintegral_mono_set` to enlarge
  to `Ioc a b` — replacing a hand-rolled FTC / norm-of-integral / interval-monotonicity /
  Bochner-to-lintegral chain.
- The `∫⁻` over `univ` versus over `Ioc a b` step is now Mathlib's `setLIntegral_eq_of_support_subset`.

### Placement, and a generalisation that fell out

The Hölder step was not slab-specific, so it moves to `TauCeti/MeasureTheory/Function/Lp/LIntegralRpow.lean`
as a public lemma — and in the process is stated in its real generality, on an **arbitrary measure
space** rather than on `Ioc a b`:

```lean
theorem rpow_lintegral_enorm_le_measure_univ_rpow_mul
    (hf : AEStronglyMeasurable f μ) {r : ℝ} (hr : 1 ≤ r) :
    (∫⁻ x, ‖f x‖ₑ ∂μ) ^ r ≤ μ Set.univ ^ (r - 1) * ∫⁻ x, ‖f x‖ₑ ^ r ∂μ
```

No finiteness is assumed — when `μ univ = ∞` and `1 < r` the bound is vacuous. `Slab.lean`
instantiates it at `volume.restrict (Ioc a b)`, where `μ univ = ENNReal.ofReal (b - a)`.

Because Mathlib's FTC lemma passes to the completion internally, **`[CompleteSpace F]` is no longer
needed anywhere in the file**. The `unusedSectionVars` linter forced this through, so all four
public theorems of `Slab.lean` are now strictly more general; the reason is recorded in the
docstrings. Removing the direct Hölder call also made the `LpSeminorm.CompareExp` import redundant
(it arrives via `LIntegralRpow`), so it is dropped, and the module docstring's proof sketch now
names the lemma the file actually calls.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean.

Roadmap: PDE