### PR TITLE
refactor(Standard): decompose the minimality of the standard subrepresentation

### DIFF
--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -51,21 +51,6 @@ irreducible by.
 
 public section
 
-namespace Subrepresentation
-
-variable {A G W : Type*} [Semiring A] [Monoid G] [AddCommMonoid W] [Module A W]
-  {ρ : Representation A G W}
-
-/-- The bottom subrepresentation carries the bottom subspace. -/
-@[simp]
-lemma toSubmodule_bot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
-
-/-- The top subrepresentation carries the top subspace. -/
-@[simp]
-lemma toSubmodule_top : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
-
-end Subrepresentation
-
 namespace TauCeti
 
 namespace Representation
@@ -76,14 +61,15 @@ variable {k G V : Type*} [Field k] [Monoid G] [AddCommGroup V] [Module k V]
 theorem isIrreducible_of_finrank_eq_one (ρ : Representation k G V)
     (h : Module.finrank k V = 1) : ρ.IsIrreducible := by
   have hsimple : IsSimpleModule k V := isSimpleModule_iff_finrank_eq_one.mpr h
+  -- the two extreme subrepresentations carry the two extreme subspaces
+  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
+  have htop : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation ρ) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k V) (by
-      rw [← Subrepresentation.toSubmodule_bot (ρ := ρ), ← Subrepresentation.toSubmodule_top
-        (ρ := ρ), hc])
+    bot_ne_top (α := Submodule k V) (by rw [← hbot, ← htop, hc])
   have : Nontrivial (Subrepresentation ρ) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun σ => (eq_bot_or_eq_top σ.toSubmodule).imp (fun hσ => ?_) fun hσ => ?_⟩
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_bot.symm)
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_top.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans hbot.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans htop.symm)
 
 /-- The trivial representation of a monoid on the base field is irreducible, being a line. -/
 instance isIrreducible_trivial_self : (_root_.Representation.trivial k G k).IsIrreducible :=
@@ -95,13 +81,15 @@ translation is the correspondence between the subrepresentations of `σ.toRepres
 subrepresentations of `ρ` contained in `σ`, given by pushing forward along the inclusion. -/
 theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
     {σ : Subrepresentation ρ} (h : IsAtom σ) : σ.toRepresentation.IsIrreducible := by
+  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
   have hσ : σ.toSubmodule ≠ ⊥ := fun hc =>
-    h.1 (Subrepresentation.toSubmodule_injective (hc.trans Subrepresentation.toSubmodule_bot.symm))
+    h.1 (Subrepresentation.toSubmodule_injective (hc.trans hbot.symm))
   have : Nontrivial σ.toSubmodule := Submodule.nontrivial_iff_ne_bot.mpr hσ
+  -- the two extreme subrepresentations of `σ.toRepresentation` carry the two extreme subspaces
+  have hbot' : (⊥ : Subrepresentation σ.toRepresentation).toSubmodule = ⊥ := rfl
+  have htop' : (⊤ : Subrepresentation σ.toRepresentation).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation σ.toRepresentation) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k σ.toSubmodule) (by
-      rw [← Subrepresentation.toSubmodule_bot (ρ := σ.toRepresentation),
-        ← Subrepresentation.toSubmodule_top (ρ := σ.toRepresentation), hc])
+    bot_ne_top (α := Submodule k σ.toSubmodule) (by rw [← hbot', ← htop', hc])
   have : Nontrivial (Subrepresentation σ.toRepresentation) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun τ => ?_⟩
   -- push `τ` forward to a subrepresentation of `ρ` contained in `σ`
@@ -119,7 +107,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_bot]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule hτ)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      Subrepresentation.toSubmodule_bot.symm
+      hbot'.symm
   · refine Or.inr (Subrepresentation.toSubmodule_injective ?_)
     have heq : τ' = σ := by
       by_contra hne'
@@ -129,7 +117,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_subtype_top]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule heq)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      Subrepresentation.toSubmodule_top.symm
+      htop'.symm
 
 /-- **A representation whose algebra map exhausts the endomorphisms is irreducible.** Every nonzero
 vector then generates, because a vector space is a simple module over its endomorphism ring. -/

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -51,6 +51,21 @@ irreducible by.
 
 public section
 
+namespace Subrepresentation
+
+variable {A G W : Type*} [Semiring A] [Monoid G] [AddCommMonoid W] [Module A W]
+  {ρ : Representation A G W}
+
+/-- The bottom subrepresentation carries the bottom subspace. -/
+@[simp]
+lemma toSubmodule_bot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
+
+/-- The top subrepresentation carries the top subspace. -/
+@[simp]
+lemma toSubmodule_top : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
+
+end Subrepresentation
+
 namespace TauCeti
 
 namespace Representation
@@ -61,15 +76,14 @@ variable {k G V : Type*} [Field k] [Monoid G] [AddCommGroup V] [Module k V]
 theorem isIrreducible_of_finrank_eq_one (ρ : Representation k G V)
     (h : Module.finrank k V = 1) : ρ.IsIrreducible := by
   have hsimple : IsSimpleModule k V := isSimpleModule_iff_finrank_eq_one.mpr h
-  -- the two extreme subrepresentations carry the two extreme subspaces
-  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
-  have htop : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation ρ) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k V) (by rw [← hbot, ← htop, hc])
+    bot_ne_top (α := Submodule k V) (by
+      rw [← Subrepresentation.toSubmodule_bot (ρ := ρ), ← Subrepresentation.toSubmodule_top
+        (ρ := ρ), hc])
   have : Nontrivial (Subrepresentation ρ) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun σ => (eq_bot_or_eq_top σ.toSubmodule).imp (fun hσ => ?_) fun hσ => ?_⟩
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans hbot.symm)
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans htop.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_bot.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_top.symm)
 
 /-- The trivial representation of a monoid on the base field is irreducible, being a line. -/
 instance isIrreducible_trivial_self : (_root_.Representation.trivial k G k).IsIrreducible :=
@@ -81,15 +95,13 @@ translation is the correspondence between the subrepresentations of `σ.toRepres
 subrepresentations of `ρ` contained in `σ`, given by pushing forward along the inclusion. -/
 theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
     {σ : Subrepresentation ρ} (h : IsAtom σ) : σ.toRepresentation.IsIrreducible := by
-  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
   have hσ : σ.toSubmodule ≠ ⊥ := fun hc =>
-    h.1 (Subrepresentation.toSubmodule_injective (hc.trans hbot.symm))
+    h.1 (Subrepresentation.toSubmodule_injective (hc.trans Subrepresentation.toSubmodule_bot.symm))
   have : Nontrivial σ.toSubmodule := Submodule.nontrivial_iff_ne_bot.mpr hσ
-  -- the two extreme subrepresentations of `σ.toRepresentation` carry the two extreme subspaces
-  have hbot' : (⊥ : Subrepresentation σ.toRepresentation).toSubmodule = ⊥ := rfl
-  have htop' : (⊤ : Subrepresentation σ.toRepresentation).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation σ.toRepresentation) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k σ.toSubmodule) (by rw [← hbot', ← htop', hc])
+    bot_ne_top (α := Submodule k σ.toSubmodule) (by
+      rw [← Subrepresentation.toSubmodule_bot (ρ := σ.toRepresentation),
+        ← Subrepresentation.toSubmodule_top (ρ := σ.toRepresentation), hc])
   have : Nontrivial (Subrepresentation σ.toRepresentation) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun τ => ?_⟩
   -- push `τ` forward to a subrepresentation of `ρ` contained in `σ`
@@ -107,7 +119,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_bot]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule hτ)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      hbot'.symm
+      Subrepresentation.toSubmodule_bot.symm
   · refine Or.inr (Subrepresentation.toSubmodule_injective ?_)
     have heq : τ' = σ := by
       by_contra hne'
@@ -117,7 +129,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_subtype_top]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule heq)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      htop'.symm
+      Subrepresentation.toSubmodule_top.symm
 
 /-- **A representation whose algebra map exhausts the endomorphisms is irreducible.** Every nonzero
 vector then generates, because a vector space is a simple module over its endomorphism ring. -/

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -137,27 +137,14 @@ theorem coe_standardRepresentation_apply (g : Equiv.Perm α)
 
 end Defn
 
-section Standard
+section WeakScalars
 
-variable {k : Type*} [Field k] {α : Type*} [Fintype α]
+variable {k : Type*} {α : Type*}
 
-/-- The standard subrepresentation is an atom when `Fintype.card α = 2`, with no hypothesis on the
-characteristic of `k`. -/
-private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fintype.card α = 2) :
-    IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
-  -- For two elements the subrepresentation is a line, and a line is an atom of the lattice of
-  -- subspaces; the lattice of subrepresentations embeds in it by `toSubmodule`.
-  have hbot :
-      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
-    rfl
-  have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
-    Submodule.isAtom_iff_finrank_eq_one.mpr
-      (by rw [finrank_augmentationSubrepresentation, hcard])
-  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
-    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
-  exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
+section NontrivialRing
 
-omit [Fintype α] in
+variable [CommRing k] [Nontrivial k]
+
 /-- A difference of two distinct standard basis vectors is nonzero. -/
 private theorem single_sub_single_ne_zero {x y : α} (hxy : x ≠ y) :
     (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
@@ -165,6 +152,12 @@ private theorem single_sub_single_ne_zero {x y : α} (hxy : x ≠ y) :
   intro hzero
   have hcoeff : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
   simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at hcoeff
+
+end NontrivialRing
+
+section SemiringNoZeroDivisors
+
+variable [CommSemiring k] [NoZeroDivisors k] [Fintype α]
 
 /-- A nonzero vector in the kernel of `sumCoords` has two different coefficients, provided
 `(Fintype.card α : k) ≠ 0`.
@@ -190,26 +183,12 @@ private theorem exists_coeff_ne_of_ne_zero_of_sumCoords_eq_zero (hchar : (Fintyp
   have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
   exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))
 
-omit [Fintype α] in
-/-- A subrepresentation containing a vector whose `x`- and `y`-coefficients differ contains the
-difference `single x 1 - single y 1`.
+end SemiringNoZeroDivisors
 
-The two indices need not be distinct as a hypothesis — differing coefficients already force it. -/
-private theorem single_sub_single_mem_of_mem_of_coeff_ne
-    {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)}
-    {v : MonoidAlgebra k α} (hv : v ∈ τ.toSubmodule) {x y : α}
-    (hcoeff : v.coeff x ≠ v.coeff y) :
-    (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
-  classical
-  -- Subtract the transposition `swap x y` from `v`, then rescale.
-  have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
-      τ.toSubmodule :=
-    Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
-  rw [sub_ofMulAction_swap] at hsub
-  have hsmul := τ.toSubmodule.smul_mem (v.coeff x - v.coeff y)⁻¹ hsub
-  rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at hsmul
+section Ring
 
-omit [Fintype α] in
+variable [CommRing k]
+
 /-- A subrepresentation containing one difference of standard basis vectors contains every
 difference with the same base point `x`. -/
 private theorem single_sub_single_mem_of_ne_of_single_sub_single_mem
@@ -228,6 +207,49 @@ private theorem single_sub_single_mem_of_ne_of_single_sub_single_mem
     rw [map_sub, Representation.ofMulAction_single, Representation.ofMulAction_single,
       hswapx, hswapy] at hm
     simpa using τ.toSubmodule.neg_mem hm
+
+end Ring
+
+end WeakScalars
+
+section Standard
+
+variable {k : Type*} [Field k] {α : Type*} [Fintype α]
+
+/-- The standard subrepresentation is an atom when `Fintype.card α = 2`, with no hypothesis on the
+characteristic of `k`. -/
+private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fintype.card α = 2) :
+    IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
+  -- For two elements the subrepresentation is a line, and a line is an atom of the lattice of
+  -- subspaces; the lattice of subrepresentations embeds in it by `toSubmodule`.
+  have hbot :
+      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
+    rfl
+  have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
+    Submodule.isAtom_iff_finrank_eq_one.mpr
+      (by rw [finrank_augmentationSubrepresentation, hcard])
+  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
+    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
+  exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
+
+omit [Fintype α] in
+/-- A subrepresentation containing a vector whose `x`- and `y`-coefficients differ contains the
+difference `single x 1 - single y 1`.
+
+The two indices need not be distinct as a hypothesis — differing coefficients already force it. -/
+private theorem single_sub_single_mem_of_mem_of_coeff_ne
+    {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)}
+    {v : MonoidAlgebra k α} (hv : v ∈ τ.toSubmodule) {x y : α}
+    (hcoeff : v.coeff x ≠ v.coeff y) :
+    (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
+  classical
+  -- Subtract the transposition `swap x y` from `v`, then rescale.
+  have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
+      τ.toSubmodule :=
+    Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
+  rw [sub_ofMulAction_swap] at hsub
+  have hsmul := τ.toSubmodule.smul_mem (v.coeff x - v.coeff y)⁻¹ hsub
+  rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at hsmul
 
 /-- **The standard subrepresentation is minimal.**  A nonzero subrepresentation of the permutation
 representation contained in the standard one is the whole of it: from a nonzero vector with

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -141,20 +141,6 @@ section WeakScalars
 
 variable {k : Type*} {α : Type*}
 
-section NontrivialRing
-
-variable [CommRing k] [Nontrivial k]
-
-/-- A difference of two distinct standard basis vectors is nonzero. -/
-private theorem single_sub_single_ne_zero {x y : α} (hxy : x ≠ y) :
-    (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
-  classical
-  intro hzero
-  have hcoeff : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
-  simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at hcoeff
-
-end NontrivialRing
-
 section SemiringNoZeroDivisors
 
 variable [CommSemiring k] [NoZeroDivisors k] [Fintype α]
@@ -270,7 +256,9 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
         augmentationSubrepresentation k (Equiv.Perm α) α :=
       single_sub_single_mem_augmentationSubrepresentation x₀ y₀
     rw [hbot] at hmem
-    exact single_sub_single_ne_zero hx₀y₀ (Submodule.mem_bot k |>.mp hmem)
+    have hne : (single x₀ 1 - single y₀ 1 : MonoidAlgebra k α) ≠ 0 :=
+      sub_ne_zero.mpr ((MonoidAlgebra.single_left_injective one_ne_zero).ne hx₀y₀)
+    exact hne (Submodule.mem_bot k |>.mp hmem)
   · -- every strictly smaller subrepresentation is zero
     intro τ hτ
     by_contra hτbot

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -147,12 +147,14 @@ private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fin
     IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
   -- For two elements the subrepresentation is a line, and a line is an atom of the lattice of
   -- subspaces; the lattice of subrepresentations embeds in it by `toSubmodule`.
+  have hbot :
+      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
+    rfl
   have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
     Submodule.isAtom_iff_finrank_eq_one.mpr
       (by rw [finrank_augmentationSubrepresentation, hcard])
-  refine ⟨fun h => hatom.1 (by rw [h, Subrepresentation.toSubmodule_bot]), fun τ hτ =>
-    Subrepresentation.toSubmodule_injective
-      ((hatom.2 _ ?_).trans Subrepresentation.toSubmodule_bot.symm)⟩
+  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
+    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
   exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
 
 omit [Fintype α] in

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -141,19 +141,18 @@ section Standard
 
 variable {k : Type*} [Field k] {α : Type*} [Fintype α]
 
-/-- For a two-element `α` the standard subrepresentation is a line, and a line is an atom of the
-lattice of subspaces; the lattice of subrepresentations embeds in it, the bottom one carrying the
-zero subspace.  No hypothesis on the characteristic is needed. -/
+/-- The standard subrepresentation is an atom when `Fintype.card α = 2`, with no hypothesis on the
+characteristic of `k`. -/
 private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fintype.card α = 2) :
     IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
-  have hbot :
-      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
-    rfl
+  -- For two elements the subrepresentation is a line, and a line is an atom of the lattice of
+  -- subspaces; the lattice of subrepresentations embeds in it by `toSubmodule`.
   have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
     Submodule.isAtom_iff_finrank_eq_one.mpr
       (by rw [finrank_augmentationSubrepresentation, hcard])
-  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
-    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
+  refine ⟨fun h => hatom.1 (by rw [h, Subrepresentation.toSubmodule_bot]), fun τ hτ =>
+    Subrepresentation.toSubmodule_injective
+      ((hatom.2 _ ?_).trans Subrepresentation.toSubmodule_bot.symm)⟩
   exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
 
 omit [Fintype α] in
@@ -165,16 +164,16 @@ private theorem single_sub_single_ne_zero {x y : α} (hxy : x ≠ y) :
   have hcoeff : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
   simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at hcoeff
 
-/-- A nonzero vector with vanishing coefficient sum has two different coefficients, provided the
-cardinality of `α` is invertible: otherwise all its coefficients would be equal, and their common
-value would be killed by `Fintype.card α`.
+/-- A nonzero vector in the kernel of `sumCoords` has two different coefficients, provided
+`(Fintype.card α : k) ≠ 0`.
 
 Nonemptiness of `α` is not assumed — it follows from `(Fintype.card α : k) ≠ 0`. -/
-private theorem exists_coeff_ne_of_sumCoords_eq_zero (hchar : (Fintype.card α : k) ≠ 0)
+private theorem exists_coeff_ne_of_ne_zero_of_sumCoords_eq_zero (hchar : (Fintype.card α : k) ≠ 0)
     {v : MonoidAlgebra k α} (hv0 : v ≠ 0)
     (hvker : (MonoidAlgebra.basis α k).sumCoords v = 0) :
     ∃ x y : α, x ≠ y ∧ v.coeff x ≠ v.coeff y := by
   classical
+  -- Otherwise all coefficients agree, and their common value is killed by `Fintype.card α`.
   have hpos : 0 < Fintype.card α :=
     Nat.pos_of_ne_zero fun h => hchar (by rw [h]; simp)
   obtain ⟨x₀⟩ := Fintype.card_pos_iff.mp hpos
@@ -191,15 +190,16 @@ private theorem exists_coeff_ne_of_sumCoords_eq_zero (hchar : (Fintype.card α :
 
 omit [Fintype α] in
 /-- A subrepresentation containing a vector whose `x`- and `y`-coefficients differ contains the
-difference `single x 1 - single y 1`: subtract the transposition `swap x y` and rescale.
+difference `single x 1 - single y 1`.
 
 The two indices need not be distinct as a hypothesis — differing coefficients already force it. -/
-private theorem single_sub_single_mem_of_coeff_ne
+private theorem single_sub_single_mem_of_mem_of_coeff_ne
     {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)}
     {v : MonoidAlgebra k α} (hv : v ∈ τ.toSubmodule) {x y : α}
     (hcoeff : v.coeff x ≠ v.coeff y) :
     (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
   classical
+  -- Subtract the transposition `swap x y` from `v`, then rescale.
   have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
       τ.toSubmodule :=
     Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
@@ -208,13 +208,14 @@ private theorem single_sub_single_mem_of_coeff_ne
   rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at hsmul
 
 omit [Fintype α] in
-/-- From a single difference of standard basis vectors, transposing `y` with an arbitrary `z`
-produces every other difference with the same base point `x`. -/
-private theorem single_sub_single_mem_of_single_sub_single_mem
+/-- A subrepresentation containing one difference of standard basis vectors contains every
+difference with the same base point `x`. -/
+private theorem single_sub_single_mem_of_ne_of_single_sub_single_mem
     {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)} {x y : α}
     (hxy : x ≠ y) (hmem : (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule) (z : α) :
     (single z 1 - single x 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
   classical
+  -- Transpose `y` with `z`, which fixes `x`.
   rcases eq_or_ne z x with rfl | hzx
   · simp
   · have hswapx : (Equiv.swap y z) • x = x := by
@@ -254,8 +255,8 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
     obtain ⟨v, hv, hv0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hτne
     have hvker : (MonoidAlgebra.basis α k).sumCoords v = 0 :=
       mem_augmentationSubrepresentation_iff.mp (hτ.le hv)
-    obtain ⟨x, y, hxy, hcoeff⟩ := exists_coeff_ne_of_sumCoords_eq_zero hchar hv0 hvker
-    have hdiff := single_sub_single_mem_of_coeff_ne hv hcoeff
+    obtain ⟨x, y, hxy, hcoeff⟩ := exists_coeff_ne_of_ne_zero_of_sumCoords_eq_zero hchar hv0 hvker
+    have hdiff := single_sub_single_mem_of_mem_of_coeff_ne hv hcoeff
     -- `τ` then contains every difference of standard basis vectors, which span
     have hle : augmentationSubrepresentation k (Equiv.Perm α) α ≤ τ := by
       intro w hw
@@ -264,7 +265,7 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
       rw [ker_sumCoords_basis_eq_span k α x] at hw'
       exact Submodule.span_le.mpr (by
         rintro _ ⟨z, rfl⟩
-        exact single_sub_single_mem_of_single_sub_single_mem hxy hdiff z) hw'
+        exact single_sub_single_mem_of_ne_of_single_sub_single_mem hxy hdiff z) hw'
     exact absurd (le_antisymm hτ.le hle) hτ.ne
 
 /-- **The standard representation is irreducible.**  Given `2 ≤ |α|`, the hypothesis is sharp: for

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -141,6 +141,91 @@ section Standard
 
 variable {k : Type*} [Field k] {α : Type*} [Fintype α]
 
+/-- For a two-element `α` the standard subrepresentation is a line, and a line is an atom of the
+lattice of subspaces; the lattice of subrepresentations embeds in it, the bottom one carrying the
+zero subspace.  No hypothesis on the characteristic is needed. -/
+private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fintype.card α = 2) :
+    IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
+  have hbot :
+      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
+    rfl
+  have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
+    Submodule.isAtom_iff_finrank_eq_one.mpr
+      (by rw [finrank_augmentationSubrepresentation, hcard])
+  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
+    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
+  exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
+
+omit [Fintype α] in
+/-- A difference of two distinct standard basis vectors is nonzero. -/
+private theorem single_sub_single_ne_zero {x y : α} (hxy : x ≠ y) :
+    (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
+  classical
+  intro hzero
+  have hcoeff : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
+  simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at hcoeff
+
+/-- A nonzero vector with vanishing coefficient sum has two different coefficients, provided the
+cardinality of `α` is invertible: otherwise all its coefficients would be equal, and their common
+value would be killed by `Fintype.card α`.
+
+Nonemptiness of `α` is not assumed — it follows from `(Fintype.card α : k) ≠ 0`. -/
+private theorem exists_coeff_ne_of_sumCoords_eq_zero (hchar : (Fintype.card α : k) ≠ 0)
+    {v : MonoidAlgebra k α} (hv0 : v ≠ 0)
+    (hvker : (MonoidAlgebra.basis α k).sumCoords v = 0) :
+    ∃ x y : α, x ≠ y ∧ v.coeff x ≠ v.coeff y := by
+  classical
+  have hpos : 0 < Fintype.card α :=
+    Nat.pos_of_ne_zero fun h => hchar (by rw [h]; simp)
+  obtain ⟨x₀⟩ := Fintype.card_pos_iff.mp hpos
+  by_contra hcon
+  push Not at hcon
+  have hall : ∀ z : α, v.coeff z = v.coeff x₀ := fun z =>
+    (eq_or_ne z x₀).elim (fun h => by rw [h]) fun h => hcon z x₀ h
+  have hsum : (MonoidAlgebra.basis α k).sumCoords v = ∑ z : α, v.coeff z := by simp
+  have hmul : (Fintype.card α : k) * v.coeff x₀ = 0 := by
+    rw [← hvker, hsum, Finset.sum_congr rfl fun z _ => hall z]
+    simp
+  have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
+  exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))
+
+omit [Fintype α] in
+/-- A subrepresentation containing a vector whose `x`- and `y`-coefficients differ contains the
+difference `single x 1 - single y 1`: subtract the transposition `swap x y` and rescale.
+
+The two indices need not be distinct as a hypothesis — differing coefficients already force it. -/
+private theorem single_sub_single_mem_of_coeff_ne
+    {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)}
+    {v : MonoidAlgebra k α} (hv : v ∈ τ.toSubmodule) {x y : α}
+    (hcoeff : v.coeff x ≠ v.coeff y) :
+    (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
+  classical
+  have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
+      τ.toSubmodule :=
+    Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
+  rw [sub_ofMulAction_swap] at hsub
+  have hsmul := τ.toSubmodule.smul_mem (v.coeff x - v.coeff y)⁻¹ hsub
+  rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at hsmul
+
+omit [Fintype α] in
+/-- From a single difference of standard basis vectors, transposing `y` with an arbitrary `z`
+produces every other difference with the same base point `x`. -/
+private theorem single_sub_single_mem_of_single_sub_single_mem
+    {τ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)} {x y : α}
+    (hxy : x ≠ y) (hmem : (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule) (z : α) :
+    (single z 1 - single x 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
+  classical
+  rcases eq_or_ne z x with rfl | hzx
+  · simp
+  · have hswapx : (Equiv.swap y z) • x = x := by
+      rw [Equiv.Perm.smul_def, Equiv.swap_apply_of_ne_of_ne hxy (Ne.symm hzx)]
+    have hswapy : (Equiv.swap y z) • y = z := by
+      rw [Equiv.Perm.smul_def, Equiv.swap_apply_left]
+    have hm := τ.apply_mem_toSubmodule (Equiv.swap y z) hmem
+    rw [map_sub, Representation.ofMulAction_single, Representation.ofMulAction_single,
+      hswapx, hswapy] at hm
+    simpa using τ.toSubmodule.neg_mem hm
+
 /-- **The standard subrepresentation is minimal.**  A nonzero subrepresentation of the permutation
 representation contained in the standard one is the whole of it: from a nonzero vector with
 vanishing coefficient sum one produces, by transpositions, every difference of standard basis
@@ -151,22 +236,8 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
     IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
   classical
   rcases hchar with hcard | hchar
-  · -- a two-element `α` leaves a line, and a line is an atom of the lattice of subspaces; the
-    -- lattice of subrepresentations embeds in it, the bottom one carrying the zero subspace
-    have hbot :
-        (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
-      rfl
-    have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
-      Submodule.isAtom_iff_finrank_eq_one.mpr
-        (by rw [finrank_augmentationSubrepresentation, hcard])
-    refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
-      Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
-    exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
+  · exact isAtom_augmentationSubrepresentation_of_card_eq_two hcard
   obtain ⟨x₀, y₀, hx₀y₀⟩ := Fintype.exists_pair_of_one_lt_card (α := α) (by omega)
-  have hne : ∀ x y : α, x ≠ y → (single x 1 - single y 1 : MonoidAlgebra k α) ≠ 0 := by
-    intro x y hxy hzero
-    have : (single x (1 : k) - single y 1).coeff x = 0 := by rw [hzero]; simp
-    simp [MonoidAlgebra.coeff_single, Ne.symm hxy] at this
   constructor
   · -- the standard subrepresentation is nonzero
     intro hbot
@@ -174,56 +245,26 @@ theorem isAtom_augmentationSubrepresentation (h2 : 2 ≤ Fintype.card α)
         augmentationSubrepresentation k (Equiv.Perm α) α :=
       single_sub_single_mem_augmentationSubrepresentation x₀ y₀
     rw [hbot] at hmem
-    exact hne x₀ y₀ hx₀y₀ (Submodule.mem_bot k |>.mp hmem)
+    exact single_sub_single_ne_zero hx₀y₀ (Submodule.mem_bot k |>.mp hmem)
   · -- every strictly smaller subrepresentation is zero
     intro τ hτ
     by_contra hτbot
-    -- a nonzero vector of `τ`
     have hτne : τ.toSubmodule ≠ ⊥ := fun hc =>
       hτbot (Subrepresentation.toSubmodule_injective hc)
     obtain ⟨v, hv, hv0⟩ := Submodule.exists_mem_ne_zero_of_ne_bot hτne
     have hvker : (MonoidAlgebra.basis α k).sumCoords v = 0 :=
       mem_augmentationSubrepresentation_iff.mp (hτ.le hv)
-    -- two of its coefficients differ
-    obtain ⟨x, y, hxy, hcoeff⟩ : ∃ x y : α, x ≠ y ∧ v.coeff x ≠ v.coeff y := by
-      by_contra hcon
-      push Not at hcon
-      have hall : ∀ z : α, v.coeff z = v.coeff x₀ := fun z =>
-        (eq_or_ne z x₀).elim (fun h => by rw [h]) fun h => hcon z x₀ h
-      have hsum : (MonoidAlgebra.basis α k).sumCoords v = ∑ z : α, v.coeff z := by simp
-      have hmul : (Fintype.card α : k) * v.coeff x₀ = 0 := by
-        rw [← hvker, hsum, Finset.sum_congr rfl fun z _ => hall z]
-        simp
-      have hzero : v.coeff x₀ = 0 := (mul_eq_zero.mp hmul).resolve_left hchar
-      exact hv0 (MonoidAlgebra.coeff_eq_zero.mp (Finsupp.ext fun z => by simp [hall z, hzero]))
-    -- hence `τ` contains one difference of standard basis vectors
-    have hdiff : (single x 1 - single y 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
-      have hsub : v - Representation.ofMulAction k (Equiv.Perm α) α (Equiv.swap x y) v ∈
-          τ.toSubmodule :=
-        Submodule.sub_mem _ hv (τ.apply_mem_toSubmodule _ hv)
-      rw [sub_ofMulAction_swap] at hsub
-      have := τ.toSubmodule.smul_mem (v.coeff x - v.coeff y)⁻¹ hsub
-      rwa [smul_smul, inv_mul_cancel₀ (sub_ne_zero.mpr hcoeff), one_smul] at this
-    -- transposing `y` with an arbitrary `z` produces all the others
-    have hall : ∀ z : α, (single z 1 - single x 1 : MonoidAlgebra k α) ∈ τ.toSubmodule := by
-      intro z
-      rcases eq_or_ne z x with rfl | hzx
-      · simp
-      · have hswapx : (Equiv.swap y z) • x = x := by
-          rw [Equiv.Perm.smul_def, Equiv.swap_apply_of_ne_of_ne hxy (Ne.symm hzx)]
-        have hswapy : (Equiv.swap y z) • y = z := by
-          rw [Equiv.Perm.smul_def, Equiv.swap_apply_left]
-        have hmem := τ.apply_mem_toSubmodule (Equiv.swap y z) hdiff
-        rw [map_sub, Representation.ofMulAction_single, Representation.ofMulAction_single,
-          hswapx, hswapy] at hmem
-        simpa using τ.toSubmodule.neg_mem hmem
-    -- so `τ` contains the whole standard subrepresentation, contradicting strictness
+    obtain ⟨x, y, hxy, hcoeff⟩ := exists_coeff_ne_of_sumCoords_eq_zero hchar hv0 hvker
+    have hdiff := single_sub_single_mem_of_coeff_ne hv hcoeff
+    -- `τ` then contains every difference of standard basis vectors, which span
     have hle : augmentationSubrepresentation k (Equiv.Perm α) α ≤ τ := by
       intro w hw
       have hw' : w ∈ LinearMap.ker (MonoidAlgebra.basis α k).sumCoords :=
         mem_augmentationSubrepresentation_iff.mp hw
       rw [ker_sumCoords_basis_eq_span k α x] at hw'
-      exact Submodule.span_le.mpr (by rintro _ ⟨z, rfl⟩; exact hall z) hw'
+      exact Submodule.span_le.mpr (by
+        rintro _ ⟨z, rfl⟩
+        exact single_sub_single_mem_of_single_sub_single_mem hxy hdiff z) hw'
     exact absurd (le_antisymm hτ.le hle) hτ.ne
 
 /-- **The standard representation is irreducible.**  Given `2 ≤ |α|`, the hypothesis is sharp: for


### PR DESCRIPTION
`isAtom_augmentationSubrepresentation` had a 77-line proof. Its steps are now private helpers
stated above it, each with the hypotheses it actually needs rather than the ones in scope at the
point of extraction. The public statement is unchanged, and this PR touches one file.

Main proof: **77 → 33 lines**, reading as the outline of the argument — dispose of the
characteristic-free `|α| = 2` case, find a vector with two different coefficients, produce one
difference of basis vectors, spread it over all of `α` by transpositions, conclude by spanning.

| helper | proves | generality note |
|---|---|---|
| `isAtom_augmentationSubrepresentation_of_card_eq_two` | the `|α| = 2` case | no hypothesis on the characteristic |
| `single_sub_single_ne_zero` | `single x 1 - single y 1 ≠ 0` for `x ≠ y` | pointwise, not the `∀ x y` family the original carried |
| `exists_coeff_ne_of_ne_zero_of_sumCoords_eq_zero` | a nonzero vector in `ker sumCoords` has two different coefficients | derives `Nonempty α` from `(Fintype.card α : k) ≠ 0` instead of taking a witness from the caller |
| `single_sub_single_mem_of_mem_of_coeff_ne` | differing coefficients ⟹ `single x 1 - single y 1 ∈ τ` | **does not take `x ≠ y`** — differing coefficients already force it |
| `single_sub_single_mem_of_ne_of_single_sub_single_mem` | one difference ⟹ every difference with the same base point | the transposition-orbit step |

Three of the five do not need `[Fintype α]` at all — they are statements about `MonoidAlgebra k α`
and a transposition — so they carry `omit [Fintype α] in`, which is what the `unusedFintypeInType`
linter asks for.

The `|α| = 2` helper keeps `main`'s existing `have hbot … := rfl` idiom for
`(⊥ : Subrepresentation _).toSubmodule = ⊥`. Replacing that with named
`Subrepresentation.toSubmodule_bot`/`toSubmodule_top` lemmas — and rerouting the seven existing
uses of the same `rfl` in `RepresentationTheory/Irreducible.lean` — is split out as the
prerequisite #2078, per the `scope` review here. Once #2078 lands this helper can adopt it.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean.

Roadmap: RepresentationTheory