### PR TITLE
refactor(Subrepresentation): name the extreme-subspace lemmas

### DIFF
--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RepresentationTheory.Irreducible
+public import TauCeti.RepresentationTheory.Subrepresentation
 public import Mathlib.RingTheory.SimpleModule.Rank
 
 /-!
@@ -61,15 +62,14 @@ variable {k G V : Type*} [Field k] [Monoid G] [AddCommGroup V] [Module k V]
 theorem isIrreducible_of_finrank_eq_one (ρ : Representation k G V)
     (h : Module.finrank k V = 1) : ρ.IsIrreducible := by
   have hsimple : IsSimpleModule k V := isSimpleModule_iff_finrank_eq_one.mpr h
-  -- the two extreme subrepresentations carry the two extreme subspaces
-  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
-  have htop : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation ρ) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k V) (by rw [← hbot, ← htop, hc])
+    bot_ne_top (α := Submodule k V) (by
+      rw [← Subrepresentation.toSubmodule_bot (ρ := ρ), ← Subrepresentation.toSubmodule_top
+        (ρ := ρ), hc])
   have : Nontrivial (Subrepresentation ρ) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun σ => (eq_bot_or_eq_top σ.toSubmodule).imp (fun hσ => ?_) fun hσ => ?_⟩
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans hbot.symm)
-  · exact Subrepresentation.toSubmodule_injective (hσ.trans htop.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_bot.symm)
+  · exact Subrepresentation.toSubmodule_injective (hσ.trans Subrepresentation.toSubmodule_top.symm)
 
 /-- The trivial representation of a monoid on the base field is irreducible, being a line. -/
 instance isIrreducible_trivial_self : (_root_.Representation.trivial k G k).IsIrreducible :=
@@ -81,15 +81,13 @@ translation is the correspondence between the subrepresentations of `σ.toRepres
 subrepresentations of `ρ` contained in `σ`, given by pushing forward along the inclusion. -/
 theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
     {σ : Subrepresentation ρ} (h : IsAtom σ) : σ.toRepresentation.IsIrreducible := by
-  have hbot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
   have hσ : σ.toSubmodule ≠ ⊥ := fun hc =>
-    h.1 (Subrepresentation.toSubmodule_injective (hc.trans hbot.symm))
+    h.1 (Subrepresentation.toSubmodule_injective (hc.trans Subrepresentation.toSubmodule_bot.symm))
   have : Nontrivial σ.toSubmodule := Submodule.nontrivial_iff_ne_bot.mpr hσ
-  -- the two extreme subrepresentations of `σ.toRepresentation` carry the two extreme subspaces
-  have hbot' : (⊥ : Subrepresentation σ.toRepresentation).toSubmodule = ⊥ := rfl
-  have htop' : (⊤ : Subrepresentation σ.toRepresentation).toSubmodule = ⊤ := rfl
   have hne : (⊥ : Subrepresentation σ.toRepresentation) ≠ ⊤ := fun hc =>
-    bot_ne_top (α := Submodule k σ.toSubmodule) (by rw [← hbot', ← htop', hc])
+    bot_ne_top (α := Submodule k σ.toSubmodule) (by
+      rw [← Subrepresentation.toSubmodule_bot (ρ := σ.toRepresentation),
+        ← Subrepresentation.toSubmodule_top (ρ := σ.toRepresentation), hc])
   have : Nontrivial (Subrepresentation σ.toRepresentation) := ⟨⊥, ⊤, hne⟩
   refine ⟨fun τ => ?_⟩
   -- push `τ` forward to a subrepresentation of `ρ` contained in `σ`
@@ -107,7 +105,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_bot]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule hτ)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      hbot'.symm
+      Subrepresentation.toSubmodule_bot.symm
   · refine Or.inr (Subrepresentation.toSubmodule_injective ?_)
     have heq : τ' = σ := by
       by_contra hne'
@@ -117,7 +115,7 @@ theorem isIrreducible_toRepresentation_of_isAtom {ρ : Representation k G V}
       rw [Submodule.map_subtype_top]
       exact hmap.symm.trans (congrArg Subrepresentation.toSubmodule heq)
     exact (Submodule.map_injective_of_injective σ.toSubmodule.subtype_injective this).trans
-      htop'.symm
+      Subrepresentation.toSubmodule_top.symm
 
 /-- **A representation whose algebra map exhausts the endomorphisms is irreducible.** Every nonzero
 vector then generates, because a vector space is a simple module over its endomorphism ring. -/

--- a/TauCeti/RepresentationTheory/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Subrepresentation.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RepresentationTheory.Subrepresentation
+
+/-!
+# The extreme subrepresentations carry the extreme subspaces
+
+Mathlib's `Subrepresentation` API records how `toSubmodule` interacts with the lattice
+operations — `Subrepresentation.toSubmodule_sup` and `Subrepresentation.toSubmodule_inf`, both
+`@[simp]` and both true by `rfl` — but not how it interacts with the bounded-lattice structure.
+This file adds the two missing counterparts, in the same shape.
+
+They are stated at the typeclasses `Subrepresentation` itself asks for, so they apply wherever
+the abstraction does, and they let proofs about `⊥` and `⊤` subrepresentations avoid asserting
+the definitional unfolding of the `BoundedOrder` instance by hand.
+
+## Main results
+
+* `Subrepresentation.toSubmodule_bot`
+* `Subrepresentation.toSubmodule_top`
+-/
+
+public section
+
+namespace Subrepresentation
+
+variable {A G W : Type*} [Semiring A] [Monoid G] [AddCommMonoid W] [Module A W]
+  {ρ : Representation A G W}
+
+/-- The bottom subrepresentation carries the bottom subspace. -/
+@[simp]
+lemma toSubmodule_bot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
+
+/-- The top subrepresentation carries the top subspace. -/
+@[simp]
+lemma toSubmodule_top : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
+
+end Subrepresentation

--- a/TauCeti/RepresentationTheory/Symmetric/Standard.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Standard.lean
@@ -208,14 +208,12 @@ private theorem isAtom_augmentationSubrepresentation_of_card_eq_two (hcard : Fin
     IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α) := by
   -- For two elements the subrepresentation is a line, and a line is an atom of the lattice of
   -- subspaces; the lattice of subrepresentations embeds in it by `toSubmodule`.
-  have hbot :
-      (⊥ : Subrepresentation (Representation.ofMulAction k (Equiv.Perm α) α)).toSubmodule = ⊥ :=
-    rfl
   have hatom : IsAtom (augmentationSubrepresentation k (Equiv.Perm α) α).toSubmodule :=
     Submodule.isAtom_iff_finrank_eq_one.mpr
       (by rw [finrank_augmentationSubrepresentation, hcard])
-  refine ⟨fun h => hatom.1 (by rw [h, hbot]), fun τ hτ =>
-    Subrepresentation.toSubmodule_injective ((hatom.2 _ ?_).trans hbot.symm)⟩
+  refine ⟨fun h => hatom.1 (by rw [h, Subrepresentation.toSubmodule_bot]), fun τ hτ =>
+    Subrepresentation.toSubmodule_injective
+      ((hatom.2 _ ?_).trans Subrepresentation.toSubmodule_bot.symm)⟩
   exact lt_of_le_of_ne hτ.le fun hc => hτ.ne (Subrepresentation.toSubmodule_injective hc)
 
 omit [Fintype α] in


### PR DESCRIPTION
Mathlib's `Subrepresentation` API records how `toSubmodule` interacts with the lattice operations
— `toSubmodule_sup` and `toSubmodule_inf`, both `@[simp]` and both true by `rfl` — but not how it
interacts with the *bounded*-lattice structure. `TauCeti/RepresentationTheory/Irreducible.lean`
was filling that gap inline: the same two `rfl`s appear as local `have`s in **seven** places
across its two main proofs.

This adds the missing counterparts in a new `TauCeti/RepresentationTheory/Subrepresentation.lean`,
in Mathlib's own shape:

```lean
@[simp] lemma Subrepresentation.toSubmodule_bot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
@[simp] lemma Subrepresentation.toSubmodule_top : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
```

and reroutes every use, so the dependence on the `BoundedOrder` instance's definitional
unfolding is asserted once rather than per proof: seven local `have`s in `Irreducible.lean`, plus
the one remaining in `Symmetric/Standard.lean`, which the `reuse` review here asked for.

They are stated at the typeclasses `Subrepresentation` itself asks for — `[Semiring A] [Monoid G]
[AddCommMonoid W] [Module A W]` — not at the `[Field k] [AddCommGroup V]` of the section that
happened to need them, so they apply wherever the abstraction does.

The dedicated module (rather than parking them in `Irreducible.lean`) is at the request of the
`api-design` and `placement` reviews here: this is foundational lattice API, and a consumer should
not have to import irreducibility and rank theory to get it.

No statement changes: `isIrreducible_of_finrank_eq_one` and
`isIrreducible_toRepresentation_of_isAtom` keep their signatures, and each loses two to three
lines of boilerplate.

This is the prerequisite half of #2075, split out at the request of that PR's `scope` review;
#2075 now covers only the proof decomposition in `Symmetric/Standard.lean` and will adopt these
lemmas once this lands.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean.

Roadmap: RepresentationTheory
