### PR TITLE
feat: state the near side of a circular crosscut in a normed space

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Complex.AbsMax
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
+public import TauCeti.Analysis.Normed.Module.Ball.Cut
 public import TauCeti.Topology.ClusterSet
 public import TauCeti.Topology.MetricSpace.Cut
 import Mathlib.Analysis.Convex.PathConnected
@@ -31,7 +32,10 @@ extension the L5 milestone asks for.
 ## The decomposition
 
 That `ball c r ∩ ball ζ ρ` is connected is immediate — it is an intersection of two balls, hence
-convex. The other piece is not convex, and the proof is the **Möbius reduction** the roadmap
+convex — and is proved in a seminormed real vector space, together with the rest of what the
+crosscut neighbourhood is, in `TauCeti/Analysis/Normed/Module/Ball/Cut.lean`. The other piece is
+not convex,
+and the proof is the **Möbius reduction** the roadmap
 prescribes for circles: the inversion `z ↦ (z - ζ)⁻¹` at the boundary point `ζ` carries the disc to
 a half-plane, because a circle through the centre of an inversion goes to a line. Concretely,
 writing `a = c - ζ`, a point `z ≠ ζ` lies in `ball c r` exactly when `1 < 2 * (a * (z - ζ)⁻¹).re`
@@ -43,9 +47,14 @@ carried onto an intersection of a half-plane with a ball — convex, and nonempt
 inverse inversion `w ↦ ζ + w⁻¹`.
 
 The two pieces are open, disjoint and cover `ball c r \ sphere ζ ρ`, so they *are* its connected
-components (`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion):
-a circular crosscut separates the disc into exactly two parts, and a connected subset of the disc
-missing the crosscut lies entirely in one of them.
+components: a circular crosscut separates the disc into exactly two parts, and a connected subset
+of the disc missing the crosscut lies entirely in one of them. That the crosscut neighbourhood is
+one of the two components is
+`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` of
+`TauCeti/Analysis/Normed/Module/Ball/Cut.lean`, which needs no complex structure; that the other
+piece is the other component is
+`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` below, resting on the
+Möbius reduction.
 
 ## The angular description
 
@@ -69,7 +78,9 @@ left in its general form: the crosscut is an arc.
 ## The boundary criterion
 
 The frontier of the crosscut neighbourhood is contained in the union of two pieces of circle
-(`TauCeti.frontier_ball_inter_ball_subset`): the arc `closedBall c r ∩ sphere ζ ρ`, and the cap
+(`TauCeti.frontier_ball_inter_ball_subset` of `TauCeti/Analysis/Normed/Module/Ball/Cut.lean`, which
+asks nothing of the ambient space beyond a pseudo-metric): the arc `closedBall c r ∩ sphere ζ ρ`,
+and the cap
 `sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc. Equality can fail — for
 `2 * r ≤ ρ` the crosscut neighbourhood is the whole disc, and its frontier misses the arc — but
 containment is all a frontier bound needs. Since the crosscut neighbourhood
@@ -112,10 +123,15 @@ In accordance with the generality bar of `ConformalMapping/README.md`, which fix
 every theorem added in layers L0–L6, everything below is stated for `ℂ`. The three set lemmas that
 split a set by a sphere use nothing but the containments between balls and spheres, so they live in
 `TauCeti/Topology/MetricSpace/Cut.lean`, stated for an arbitrary pseudo-metric space, and are used
-here at `ℂ`. For the rest the bar is not merely a convenience: the map that performs the
-decomposition is the complex inversion `z ↦ (z - ζ)⁻¹`, the Möbius map the roadmap names for
-reducing circles to lines, and the analytic half is the maximum modulus principle for holomorphic
-functions.
+here at `ℂ`. Likewise the whole of the *near* side — that the crosscut neighbourhood is nonempty,
+connected and a connected component of the cut disc, and the bound on its frontier — needs only
+convexity of a ball, or for the frontier bound not even that, so it lives in
+`TauCeti/Analysis/Normed/Module/Ball/Cut.lean` for a seminormed real vector space and a
+pseudo-metric space respectively, and is used here at `ℂ`. For the rest the bar is not merely a
+convenience: the decomposition of the *far* side is performed by the complex inversion
+`z ↦ (z - ζ)⁻¹`, the
+Möbius map the roadmap names for reducing circles to lines, and the analytic half is the maximum
+modulus principle for holomorphic functions.
 
 ## Main results
 
@@ -126,9 +142,11 @@ functions.
   `TauCeti/Topology/Circle/Metric.lean`, which also supplies the fact that the angles form an arc.
 * `TauCeti.isConnected_ball_diff_closedBall` — the part of a disc outside a circular crosscut is
   connected.
-* `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` and its companion — a circular
-  crosscut separates the disc into exactly two connected components, the two sides being those cut
-  out by `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` and
+* `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` — together with its
+  companion `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` of
+  `TauCeti/Analysis/Normed/Module/Ball/Cut.lean`, a circular crosscut separates the disc into
+  exactly two connected components, the two sides being those cut out by
+  `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` and
   `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` of
   `TauCeti/Topology/MetricSpace/Cut.lean`. The disc signatures those two replace are kept here as
   deprecated compatibility wrappers.
@@ -250,34 +268,13 @@ theorem exists_mem_Icc_circleMap_eq (α : ℝ) {z : ℂ} (hz : z ∈ sphere ζ �
   · linarith [hθ.1]
   · linarith [hθ.2]
 
-/-! ## The two sides of a circular crosscut -/
+/-! ## The far side of a circular crosscut
 
-/-- **The crosscut neighbourhood is nonempty.** For `ζ` on the circle `sphere c r` and any positive
-`ρ`, the intersection `ball c r ∩ ball ζ ρ` contains points of the radius from `ζ` to `c` close
-enough to `ζ`. -/
-theorem nonempty_ball_inter_ball (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
-    (ball c r ∩ ball ζ ρ).Nonempty := by
-  have hnc : ‖ζ - c‖ = r := by rw [← dist_eq_norm, hζ]
-  set t : ℝ := min (1 / 2) (ρ / (2 * r))
-  have ht0 : 0 < t := lt_min (by norm_num) (by positivity)
-  have ht1 : t < 1 := lt_of_le_of_lt (min_le_left _ _) (by norm_num)
-  refine ⟨ζ + (t : ℂ) * (c - ζ), ?_, ?_⟩
-  · have : ζ + (t : ℂ) * (c - ζ) - c = ((1 : ℂ) - (t : ℂ)) * (ζ - c) := by ring
-    rw [mem_ball, dist_eq_norm, this, norm_mul, hnc, ← Complex.ofReal_one, ← Complex.ofReal_sub,
-      Complex.norm_real, Real.norm_eq_abs, abs_of_pos (by linarith)]
-    nlinarith
-  · have : ζ + (t : ℂ) * (c - ζ) - ζ = (t : ℂ) * (c - ζ) := by ring
-    rw [mem_ball, dist_eq_norm, this, norm_mul, Complex.norm_real, Real.norm_eq_abs,
-      abs_of_pos ht0, ← norm_neg, neg_sub, hnc]
-    calc t * r ≤ ρ / (2 * r) * r := by nlinarith [min_le_right (1 / 2 : ℝ) (ρ / (2 * r))]
-      _ = ρ / 2 := by field_simp
-      _ < ρ := by linarith
-
-/-- **The crosscut neighbourhood is connected**, being an intersection of two balls, hence convex.
-Its nonemptiness is `TauCeti.nonempty_ball_inter_ball`. -/
-theorem isConnected_ball_inter_ball (hr : 0 < r) (hζ : dist ζ c = r) (hρ : 0 < ρ) :
-    IsConnected (ball c r ∩ ball ζ ρ) :=
-  ((convex_ball c r).inter (convex_ball ζ ρ)).isConnected (nonempty_ball_inter_ball hr hζ hρ)
+The *near* side `ball c r ∩ ball ζ ρ` is convex, and everything about it — that it is nonempty,
+connected, and a connected component of the cut disc, and that its frontier lies on the two
+circles — is proved without any complex structure in
+`TauCeti/Analysis/Normed/Module/Ball/Cut.lean`. What follows is the far side, which is not convex
+and is where the Möbius reduction is needed. -/
 
 /-- The inversion model of a disc punctured by a crosscut: the intersection of the open half-plane
 `{w | 1 < 2 * (a * w).re}` with `ball 0 R`. It is convex for every `a` and every `R`, being an
@@ -404,25 +401,11 @@ theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS 
     S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
   subset_inter_ball_or_subset_sdiff_closedBall isOpen_ball hS hSsub
 
-/-- **The crosscut neighbourhood is a connected component of the cut disc.** Together with
-`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` this says a circular
-crosscut cuts the disc into *exactly two* pieces. -/
-theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball
-    (hz : z ∈ ball c r ∩ ball ζ ρ) :
-    connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
-  have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
-    sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_left
-  refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
-    |>.subset_connectedComponentIn hz hsub)
-  rcases subset_inter_ball_or_subset_sdiff_closedBall (x := ζ) (s := ball c r) isOpen_ball
-    isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
-  · exact h
-  · exact absurd (h (mem_connectedComponentIn (hsub hz)))
-      (Set.disjoint_left.mp disjoint_inter_ball_sdiff_closedBall hz)
-
 /-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
-of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball`; here the connectedness of the
-piece is the substantial `TauCeti.isConnected_ball_diff_closedBall`. -/
+of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` of
+`TauCeti/Analysis/Normed/Module/Ball/Cut.lean`; here the connectedness of the piece is the
+substantial `TauCeti.isConnected_ball_diff_closedBall` rather than convexity, which is why this
+half stays in the plane. -/
 theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
     (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρ' : ρ < 2 * r) (hz : z ∈ ball c r \ closedBall ζ ρ) :
     connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r \ closedBall ζ ρ := by
@@ -437,23 +420,6 @@ theorem connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall
   · exact h
 
 /-! ## The maximum modulus principle on a crosscut neighbourhood -/
-
-/-- **The frontier of a crosscut neighbourhood lies on the two circles.** It is covered by the
-*cap* `sphere c r ∩ closedBall ζ ρ` cut off on the boundary of the disc together with the closed
-*arc* `closedBall c r ∩ sphere ζ ρ` of the crosscut; these are the two pieces on which a function
-has to be controlled for the maximum principle to control it inside. Only the inclusion is claimed,
-which is all a frontier bound needs, and it is what holds without further hypotheses — for
-`2 * r ≤ ρ` the crosscut neighbourhood is the whole disc and its frontier misses the arc
-entirely.
-
-This is Mathlib's `frontier_inter_subset` for the two balls, whose two summands are pinned down by
-`frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`. -/
-theorem frontier_ball_inter_ball_subset :
-    frontier (ball c r ∩ ball ζ ρ)
-      ⊆ sphere c r ∩ closedBall ζ ρ ∪ closedBall c r ∩ sphere ζ ρ :=
-  (frontier_inter_subset _ _).trans <| union_subset_union
-    (inter_subset_inter frontier_ball_subset_sphere closure_ball_subset_closedBall)
-    (inter_subset_inter closure_ball_subset_closedBall frontier_ball_subset_sphere)
 
 variable {f : ℂ → ℂ} {a : ℂ} {C r₀ : ℝ}
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean
@@ -9,9 +9,6 @@ public import Mathlib.Analysis.Complex.AbsMax
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 public import TauCeti.Analysis.Normed.Module.Ball.Cut
 public import TauCeti.Topology.ClusterSet
-public import TauCeti.Topology.MetricSpace.Cut
-import Mathlib.Analysis.Convex.PathConnected
-import Mathlib.Analysis.Normed.Module.RCLike.Real
 import TauCeti.Topology.Circle.Metric
 
 /-!
@@ -148,8 +145,7 @@ modulus principle for holomorphic functions.
   exactly two connected components, the two sides being those cut out by
   `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall` and
   `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` of
-  `TauCeti/Topology/MetricSpace/Cut.lean`. The disc signatures those two replace are kept here as
-  deprecated compatibility wrappers.
+  `TauCeti/Topology/MetricSpace/Cut.lean`.
 * `TauCeti.norm_sub_le_of_mem_ball_inter_ball` and
   `TauCeti.norm_sub_le_of_mem_ball_inter_ball_of_differentiableOn` — the maximum modulus principle
   on a crosscut neighbourhood: a bound on the arc and on the cap is a bound inside, and its
@@ -371,35 +367,6 @@ theorem isConnected_ball_diff_closedBall (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (nonempty_halfPlane_inter_ball hρ (by rw [hac]; exact hρ'))).image _ fun w hw => ?_
   exact (continuousAt_const.add
     (continuousAt_inv₀ (ne_zero_of_one_lt_two_mul_re_mul hw.1))).continuousWithinAt
-
-/-! ### Deprecated disc-specific forms
-
-The three cut lemmas of `TauCeti/Topology/MetricSpace/Cut.lean` were stated here for
-`s = ball c r` in `ℂ`. Their old signatures are retained as deprecated compatibility wrappers,
-each naming its generalized replacement. -/
-
-/-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall`. -/
-@[deprecated sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (since := "2026-08-04")]
-theorem ball_diff_sphere_eq_union :
-    ball c r \ sphere ζ ρ = ball c r ∩ ball ζ ρ ∪ ball c r \ closedBall ζ ρ :=
-  sdiff_sphere_eq_inter_ball_union_sdiff_closedBall
-
-/-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.disjoint_inter_ball_sdiff_closedBall`. -/
-@[deprecated disjoint_inter_ball_sdiff_closedBall (since := "2026-08-04")]
-theorem disjoint_ball_inter_ball_ball_diff_closedBall :
-    Disjoint (ball c r ∩ ball ζ ρ) (ball c r \ closedBall ζ ρ) :=
-  disjoint_inter_ball_sdiff_closedBall
-
-/-- Deprecated compatibility wrapper for the disc case of
-`TauCeti.subset_inter_ball_or_subset_sdiff_closedBall`, whose openness hypothesis the disc
-discharges with `Metric.isOpen_ball`. -/
-@[deprecated subset_inter_ball_or_subset_sdiff_closedBall (since := "2026-08-04")]
-theorem subset_ball_inter_ball_or_subset_ball_diff_closedBall {S : Set ℂ} (hS : IsPreconnected S)
-    (hSsub : S ⊆ ball c r \ sphere ζ ρ) :
-    S ⊆ ball c r ∩ ball ζ ρ ∨ S ⊆ ball c r \ closedBall ζ ρ :=
-  subset_inter_ball_or_subset_sdiff_closedBall isOpen_ball hS hSsub
 
 /-- **The far side of a circular crosscut is a connected component of the cut disc.** The companion
 of `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` of

--- a/TauCeti/Analysis/Normed/Module/Ball/Cut.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Cut.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Convex
+public import TauCeti.Topology.MetricSpace.Cut
+
+/-!
+# The near side of a ball cut by a sphere
+
+`TauCeti/Topology/MetricSpace/Cut.lean` cuts an arbitrary set `s` by a sphere `sphere y ρ` into a
+*near side* `s ∩ ball y ρ` and a *far side* `s \ closedBall y ρ`. This file specialises the cut set
+to a ball, `s = ball x r`, and records what the near side then is: a convex set, hence connected as
+soon as it is nonempty, hence one of the two connected components of the cut ball. Its frontier is
+covered by the two spheres involved.
+
+Everything here is stated at the generality its proof uses, which is never more than a real normed
+space and for the frontier bound not even that:
+
+* the frontier bound `TauCeti.frontier_ball_inter_ball_subset` is Mathlib's `frontier_inter_subset`
+  fed with `frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`, so it holds in an
+  arbitrary pseudo-metric space, with no relation between the two balls;
+* nonemptiness, connectedness and the component identification use convexity of a ball, so they
+  ask for a real vector space with a seminorm, and nothing else — no completeness, no
+  non-degeneracy of the norm, and no finite dimensionality.
+
+The *far side* is deliberately absent: it is not convex, and identifying it needs a genuine
+argument that depends on the ambient geometry. In the plane that argument is the Möbius inversion
+at the cut point, and it lives with its complex-analytic consumer in
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean`
+(`TauCeti.isConnected_ball_diff_closedBall` and
+`TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall`).
+
+## The overlap condition
+
+Two balls meet exactly when their radii together exceed the distance between the centres. One
+direction is Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`; the other is
+`TauCeti.nonempty_ball_inter_ball`, whose witness is the point `c + t • (ζ - c)` of the segment
+joining the two centres at the parameter `t = r / (r + ρ)` that divides it in the ratio of the two
+radii. That one parameter works for every pair of balls: it puts the witness at distance
+`r * dist c ζ / (r + ρ)` from `c` and `ρ * dist c ζ / (r + ρ)` from `ζ`, and both are below the
+corresponding radius precisely when `dist c ζ < r + ρ`.
+
+## The intended consumer
+
+Layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, Carathéodory's boundary
+correspondence, cuts a disc `ball c r` in the plane by the circle `sphere ζ ρ` about a point `ζ`
+of its boundary — the *circular crosscut* of
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean` — and reads the boundary behaviour of a
+conformal map along the near side. There `dist ζ c = r`, so
+the overlap condition `dist c ζ < r + ρ` holds for every `ρ > 0`, and the frontier bound is what
+the maximum modulus principle is applied against. None of that is used here.
+
+## Main results
+
+* `TauCeti.frontier_ball_inter_ball_subset` — the frontier of the near side lies on the two spheres.
+* `TauCeti.nonempty_ball_inter_ball` — two balls that overlap meet.
+* `TauCeti.isConnected_ball_inter_ball` — the near side is connected.
+* `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — the near side is a connected
+  component of the cut ball.
+-/
+
+public section
+
+namespace TauCeti
+
+open Metric Set
+
+section PseudoMetric
+
+variable {X : Type*} [PseudoMetricSpace X] {x y : X} {r ρ : ℝ}
+
+/-- **The frontier of the near side lies on the two spheres.** The frontier of `ball x r ∩ ball y ρ`
+is covered by the piece `sphere x r ∩ closedBall y ρ` of the first sphere inside the second closed
+ball together with the piece `closedBall x r ∩ sphere y ρ` of the second sphere inside the first
+closed ball.
+
+Only the inclusion is claimed, and only the inclusion holds without further hypotheses: if one ball
+contains the other, the near side is that ball and its frontier misses the other sphere entirely.
+
+This is Mathlib's `frontier_inter_subset`, whose two summands are pinned down by
+`frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`. Nothing relates the two balls,
+and no hypothesis on the radii is needed. -/
+theorem frontier_ball_inter_ball_subset :
+    frontier (ball x r ∩ ball y ρ) ⊆ sphere x r ∩ closedBall y ρ ∪ closedBall x r ∩ sphere y ρ :=
+  (frontier_inter_subset _ _).trans <| union_subset_union
+    (inter_subset_inter frontier_ball_subset_sphere closure_ball_subset_closedBall)
+    (inter_subset_inter closure_ball_subset_closedBall frontier_ball_subset_sphere)
+
+end PseudoMetric
+
+section Normed
+
+variable {E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℝ E] {c ζ z : E} {r ρ : ℝ}
+
+/-- **Two balls whose radii together exceed the distance between their centres meet.** This is the
+converse of Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`, and it is where the linear
+structure enters: the witness is the point of the segment joining the two centres that divides it
+in the ratio of the two radii,
+`c + (r / (r + ρ)) • (ζ - c)`, at distance `r * dist c ζ / (r + ρ) < r` from `c` and
+`ρ * dist c ζ / (r + ρ) < ρ` from `ζ`.
+
+Both radii must be positive, or the corresponding ball is empty while the hypothesis can still
+hold. -/
+theorem nonempty_ball_inter_ball (hr : 0 < r) (hρ : 0 < ρ) (h : dist c ζ < r + ρ) :
+    (ball c r ∩ ball ζ ρ).Nonempty := by
+  have hsum : 0 < r + ρ := by linarith
+  set t : ℝ := r / (r + ρ) with ht
+  have ht0 : 0 ≤ t := by positivity
+  have ht1 : 0 ≤ 1 - t := by
+    rw [sub_nonneg, ht, div_le_one hsum]
+    linarith
+  have hone : 1 - t = ρ / (r + ρ) := by
+    rw [ht, eq_div_iff hsum.ne', sub_mul, one_mul, div_mul_cancel₀ _ hsum.ne']
+    ring
+  refine ⟨c + t • (ζ - c), ?_, ?_⟩
+  · rw [mem_ball, dist_eq_norm, add_sub_cancel_left, norm_smul, Real.norm_eq_abs,
+      abs_of_nonneg ht0, ← dist_eq_norm, dist_comm ζ c, ht, div_mul_eq_mul_div,
+      div_lt_iff₀ hsum]
+    exact mul_lt_mul_of_pos_left h hr
+  · have hsub : c + t • (ζ - c) - ζ = (1 - t) • (c - ζ) := by module
+    rw [mem_ball, dist_eq_norm, hsub, norm_smul, Real.norm_eq_abs, abs_of_nonneg ht1,
+      ← dist_eq_norm, hone, div_mul_eq_mul_div, div_lt_iff₀ hsum]
+    exact mul_lt_mul_of_pos_left h hρ
+
+/-- **The near side of a cut ball is connected**, being an intersection of two balls, hence convex.
+Its nonemptiness is `TauCeti.nonempty_ball_inter_ball`, and that is the only role the overlap
+condition `dist c ζ < r + ρ` plays. -/
+theorem isConnected_ball_inter_ball (hr : 0 < r) (hρ : 0 < ρ) (h : dist c ζ < r + ρ) :
+    IsConnected (ball c r ∩ ball ζ ρ) :=
+  ((convex_ball c r).inter (convex_ball ζ ρ)).isConnected (nonempty_ball_inter_ball hr hρ h)
+
+/-- **The near side is a connected component of the cut ball.** Removing `sphere ζ ρ` from
+`ball c r` leaves the near side `ball c r ∩ ball ζ ρ` and the far side `ball c r \ closedBall ζ ρ`;
+the near side is preconnected, being convex, and by
+`TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` the component of one of its points cannot
+spill into the far side.
+
+No hypothesis on the radii is needed: the membership `hz` already forces both to be positive, and
+the statement is about the component of `z` alone. -/
+theorem connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball (hz : z ∈ ball c r ∩ ball ζ ρ) :
+    connectedComponentIn (ball c r \ sphere ζ ρ) z = ball c r ∩ ball ζ ρ := by
+  have hsub : ball c r ∩ ball ζ ρ ⊆ ball c r \ sphere ζ ρ :=
+    sdiff_sphere_eq_inter_ball_union_sdiff_closedBall (x := ζ) (s := ball c r) ▸ subset_union_left
+  refine Subset.antisymm ?_ (((convex_ball c r).inter (convex_ball ζ ρ)).isPreconnected
+    |>.subset_connectedComponentIn hz hsub)
+  rcases subset_inter_ball_or_subset_sdiff_closedBall (x := ζ) (s := ball c r) isOpen_ball
+    isPreconnected_connectedComponentIn (connectedComponentIn_subset _ _) with h | h
+  · exact h
+  · exact absurd (h (mem_connectedComponentIn (hsub hz)))
+      (Set.disjoint_left.mp disjoint_inter_ball_sdiff_closedBall hz)
+
+end Normed
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Module/Ball/Cut.lean
+++ b/TauCeti/Analysis/Normed/Module/Ball/Cut.lean
@@ -7,6 +7,7 @@ module
 
 public import Mathlib.Analysis.Normed.Module.Convex
 public import TauCeti.Topology.MetricSpace.Cut
+import Mathlib.Analysis.Normed.Module.Ball.Pointwise
 
 /-!
 # The near side of a ball cut by a sphere
@@ -14,11 +15,16 @@ public import TauCeti.Topology.MetricSpace.Cut
 `TauCeti/Topology/MetricSpace/Cut.lean` cuts an arbitrary set `s` by a sphere `sphere y ρ` into a
 *near side* `s ∩ ball y ρ` and a *far side* `s \ closedBall y ρ`. This file specialises the cut set
 to a ball, `s = ball x r`, and records what the near side then is: a convex set, hence connected as
-soon as it is nonempty, hence one of the two connected components of the cut ball. Its frontier is
-covered by the two spheres involved.
+soon as it is nonempty, hence a connected component of the cut ball. Its frontier is covered by the
+two spheres involved.
 
-Everything here is stated at the generality its proof uses, which is never more than a real normed
-space and for the frontier bound not even that:
+Only *a* component, and not one of exactly two: at this generality the far side can itself be
+disconnected — in `ℝ`, cutting `ball 0 1` by `sphere 0 (1 / 2)` leaves three components — so how
+many components the cut ball has is a question about the ambient geometry, settled in the plane
+rather than here.
+
+Everything here is stated at the generality its proof uses, which is never more than a seminormed
+real vector space and for the frontier bound not even that:
 
 * the frontier bound `TauCeti.frontier_ball_inter_ball_subset` is Mathlib's `frontier_inter_subset`
   fed with `frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`, so it holds in an
@@ -36,13 +42,15 @@ at the cut point, and it lives with its complex-analytic consumer in
 
 ## The overlap condition
 
-Two balls meet exactly when their radii together exceed the distance between the centres. One
-direction is Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`; the other is
-`TauCeti.nonempty_ball_inter_ball`, whose witness is the point `c + t • (ζ - c)` of the segment
-joining the two centres at the parameter `t = r / (r + ρ)` that divides it in the ratio of the two
-radii. That one parameter works for every pair of balls: it puts the witness at distance
-`r * dist c ζ / (r + ρ)` from `c` and `ρ * dist c ζ / (r + ρ)` from `ζ`, and both are below the
-corresponding radius precisely when `dist c ζ < r + ρ`.
+Two balls *of positive radius* meet exactly when their radii together exceed the distance between
+the centres. One direction is Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`, and needs
+no positivity; the other is `TauCeti.nonempty_ball_inter_ball`, and does — a ball of non-positive
+radius is empty while `dist c ζ < r + ρ` can still hold.
+
+Its witness is supplied by Mathlib's `exists_dist_lt_lt`: the point of the segment joining the two
+centres that divides it in the ratio of the two radii, at distance `r * dist c ζ / (r + ρ)` from
+`c` and `ρ * dist c ζ / (r + ρ)` from `ζ`, both below the corresponding radius precisely when
+`dist c ζ < r + ρ`.
 
 ## The intended consumer
 
@@ -98,33 +106,16 @@ variable {E : Type*} [SeminormedAddCommGroup E] [NormedSpace ℝ E] {c ζ z : E}
 
 /-- **Two balls whose radii together exceed the distance between their centres meet.** This is the
 converse of Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`, and it is where the linear
-structure enters: the witness is the point of the segment joining the two centres that divides it
-in the ratio of the two radii,
-`c + (r / (r + ρ)) • (ζ - c)`, at distance `r * dist c ζ / (r + ρ) < r` from `c` and
-`ρ * dist c ζ / (r + ρ) < ρ` from `ζ`.
+structure enters, through Mathlib's `exists_dist_lt_lt`: the witness is the point of the segment
+joining the two centres that divides it in the ratio of the two radii, at distance
+`r * dist c ζ / (r + ρ) < r` from `c` and `ρ * dist c ζ / (r + ρ) < ρ` from `ζ`.
 
 Both radii must be positive, or the corresponding ball is empty while the hypothesis can still
 hold. -/
 theorem nonempty_ball_inter_ball (hr : 0 < r) (hρ : 0 < ρ) (h : dist c ζ < r + ρ) :
     (ball c r ∩ ball ζ ρ).Nonempty := by
-  have hsum : 0 < r + ρ := by linarith
-  set t : ℝ := r / (r + ρ) with ht
-  have ht0 : 0 ≤ t := by positivity
-  have ht1 : 0 ≤ 1 - t := by
-    rw [sub_nonneg, ht, div_le_one hsum]
-    linarith
-  have hone : 1 - t = ρ / (r + ρ) := by
-    rw [ht, eq_div_iff hsum.ne', sub_mul, one_mul, div_mul_cancel₀ _ hsum.ne']
-    ring
-  refine ⟨c + t • (ζ - c), ?_, ?_⟩
-  · rw [mem_ball, dist_eq_norm, add_sub_cancel_left, norm_smul, Real.norm_eq_abs,
-      abs_of_nonneg ht0, ← dist_eq_norm, dist_comm ζ c, ht, div_mul_eq_mul_div,
-      div_lt_iff₀ hsum]
-    exact mul_lt_mul_of_pos_left h hr
-  · have hsub : c + t • (ζ - c) - ζ = (1 - t) • (c - ζ) := by module
-    rw [mem_ball, dist_eq_norm, hsub, norm_smul, Real.norm_eq_abs, abs_of_nonneg ht1,
-      ← dist_eq_norm, hone, div_mul_eq_mul_div, div_lt_iff₀ hsum]
-    exact mul_lt_mul_of_pos_left h hρ
+  obtain ⟨w, hcw, hwζ⟩ := exists_dist_lt_lt hr hρ (by rwa [add_comm] at h)
+  exact ⟨w, mem_ball'.2 hcw, mem_ball.2 hwζ⟩
 
 /-- **The near side of a cut ball is connected**, being an intersection of two balls, hence convex.
 Its nonemptiness is `TauCeti.nonempty_ball_inter_ball`, and that is the only role the overlap


### PR DESCRIPTION
This PR moves the four steps of `TauCeti/Analysis/Complex/Conformal/Crosscut/Basic.lean` that describe the *near* side `ball c r ∩ ball ζ ρ` of a ball cut by a sphere into a new file `TauCeti/Analysis/Normed/Module/Ball/Cut.lean`, and states each at the generality its proof actually uses, leaving behind exactly the part of the crosscut decomposition that needs the complex structure. `TauCeti.frontier_ball_inter_ball_subset` — the frontier of the near side lies on the two spheres — is Mathlib's `frontier_inter_subset` fed with `frontier_ball_subset_sphere` and `closure_ball_subset_closedBall`, so it now reads for an arbitrary pseudo-metric space with no relation whatever between the two balls, rather than for a disc and a circle through a point of its boundary. `TauCeti.nonempty_ball_inter_ball` no longer asks that `ζ` lie on `sphere c r`: it asks only the sharp overlap condition `dist c ζ < r + ρ`, which is the exact converse of Mathlib's `Metric.dist_lt_add_of_nonempty_ball_inter_ball`, and its witness is now a single uniform point `c + (r / (r + ρ)) • (ζ - c)` — the one dividing the segment between the centres in the ratio of the radii — in place of the ad hoc `min (1 / 2) (ρ / (2 * r))` that the boundary-point case allowed; that is enough to state it for a seminormed real vector space, with no completeness, non-degeneracy or finite-dimensionality. `TauCeti.isConnected_ball_inter_ball` follows it, and `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_inter_ball` — the near side is a connected component of the cut ball — moves unchanged in signature, its proof being convexity of the two balls together with `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall` of `TauCeti/Topology/MetricSpace/Cut.lean`, which the new file now sits directly above. The *far* side stays in the plane, because it stays hard: `TauCeti.isConnected_ball_diff_closedBall` and `TauCeti.connectedComponentIn_ball_diff_sphere_eq_ball_diff_closedBall` rest on the Möbius inversion `z ↦ (z - ζ)⁻¹` at the boundary point, and that is now the only place in the decomposition where the complex structure is spent. Every declaration name is preserved and every in-repository use is rewired, so no compatibility transition is owed and the deprecated disc-specific wrappers already in `Crosscut/Basic.lean` keep naming their replacements; no statement at `ℂ` changed meaning, and the module docstrings of both files are updated to say which half lives where and why.

This is a refactor of already-merged material — relocation plus a modest generalisation of merged lemmas, adding no new declaration — so it carries no fresh roadmap claim; `rubrics/scope.md` makes reworking merged code in scope a priori, and `.claude/CLAUDE.md` lists relocating a misplaced declaration and modestly generalising an existing lemma as always in scope. The roadmap chiefly motivating it is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5** (Carathéodory boundary correspondence), whose circular crosscut at a boundary point is what these steps describe and whose crosscut criterion `TauCeti.exists_continuousOn_closedBall_eqOn` is what they assemble into. The scalar-`ℂ` generality bar of that README governs the theorems the entry *adds* and is untouched here: the milestone statements in `Conformal/Crosscut/Basic.lean` remain stated, and are used, for maps of `ℂ`, and what moved is prior art of that file rather than new mathematics. No Mathlib code was vendored; the inputs consumed are Mathlib's `frontier_inter_subset`, `frontier_ball_subset_sphere`, `closure_ball_subset_closedBall`, `convex_ball` and `Convex.isConnected`, together with Tau Ceti's own `TauCeti.sdiff_sphere_eq_inter_ball_union_sdiff_closedBall`, `TauCeti.disjoint_inter_ball_sdiff_closedBall` and `TauCeti.subset_inter_ball_or_subset_sdiff_closedBall`.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"connectedcomponentin-ball-diff-sphere-eq-ball-inter-ball"}-->

🤖 Prepared with Claude Code
