### PR TITLE
feat: complete the centralizer theorem for a central simple subalgebra

### DIFF
--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -6,25 +6,33 @@ module
 
 -- Public: the types and classes occurring in the exported statements. `Subalgebra.centralizer` and
 -- `Subalgebra` come from `Mathlib.Algebra.Algebra.Subalgebra.Basic`, the module structure carrying
--- `Module.End (↥B ⊗[K] Aᵐᵒᵖ) (Bimodule B.val)` from `TauCeti.Algebra.CentralSimple.Bimodule`, and
--- the remaining three from the hypotheses `Algebra.IsCentral`, `IsSimpleRing`, `FiniteDimensional`.
+-- `Module.End (↥B ⊗[K] Aᵐᵒᵖ) (Bimodule B.val)` from `TauCeti.Algebra.CentralSimple.Bimodule`,
+-- `TauCeti.Algebra.deg` from `TauCeti.Algebra.CentralSimple.Degree`, and the remaining three from
+-- the hypotheses `Algebra.IsCentral`, `IsSimpleRing`, `FiniteDimensional`.
 public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.Algebra.Central.Defs
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.SimpleRing.Defs
 public import TauCeti.Algebra.CentralSimple.Bimodule
+public import TauCeti.Algebra.CentralSimple.Degree
 -- Non-public: used only inside proofs. Simplicity of the tensor product, the endomorphism algebra
 -- of a module over a simple Artinian ring, and finiteness of a tensor product supply the three
--- inputs of the two theorems, and no exported statement mentions any of them; the Artinian
+-- inputs of the first two theorems, and no exported statement mentions any of them; the Artinian
 -- hypothesis of the first is supplied by finite-dimensionality (`IsArtinianRing.of_finite`); the
 -- dimension of a tensor product and the finite-dimensionality of an opposite space are the
--- bookkeeping, and the complex numbers appear only in the worked example.
+-- bookkeeping, and the complex numbers appear only in the worked examples. Injectivity of a ring
+-- homomorphism out of a simple ring, the equality of injectivity and surjectivity in equal finite
+-- dimension, and the description of the center of a central algebra are the three further tools of
+-- the tensor decomposition and the double centralizer.
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
+import Mathlib.Algebra.Central.Basic
 import Mathlib.LinearAlgebra.Basis.MulOpposite
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
+import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 import Mathlib.RingTheory.Artinian.Module
+import Mathlib.RingTheory.SimpleRing.Basic
 import Mathlib.RingTheory.SimpleRing.Congr
 import Mathlib.RingTheory.TensorProduct.Finite
 import TauCeti.Algebra.CentralSimple.TensorProduct
@@ -41,6 +49,13 @@ Let `K` be a field, let `A` be a finite-dimensional **simple** `K`-algebra and l
 is again a simple `K`-algebra, and that its dimension is the complementary one:
 
   `finrank K B * finrank K C = finrank K A`.
+
+The dimension formula is sharpened here to a decomposition: multiplication `B ⊗[K] C → A` is an
+algebra isomorphism, because its source is simple, so that the map is injective, and the two sides
+have the same dimension. When `A` is moreover **central** simple, the decomposition forces `C` to be
+central as well, since an element of the center of `C` commutes with every `b * c`, hence with all
+of `A`; so `C` is central simple in turn, the centralizer theorem applies to it, and comparing the
+two dimension formulas gives the **double centralizer** `C_A(C) = B`.
 
 The proof is the module-theoretic one, and it reuses the bimodule of the Skolem-Noether theorem. The
 inclusion `B.val : B →ₐ[K] A` makes `A` a module over `R = B ⊗[K] Aᵐᵒᵖ`
@@ -64,6 +79,13 @@ is simple, and `finrank K (End_R A) * finrank K R = (finrank K A)²`. Since
 * `TauCeti.centralizer_isSimpleRing`: **the centralizer of a central simple subalgebra is simple.**
 * `TauCeti.finrank_mul_finrank_centralizer`: **the centralizer theorem**,
   `finrank K B * finrank K C_A(B) = finrank K A`.
+* `TauCeti.tensorCentralizerAlgEquiv`: **the tensor decomposition** `B ⊗[K] C_A(B) ≃ₐ[K] A`, by
+  multiplication.
+* `TauCeti.centralizer_isCentral`: **the centralizer of a central simple subalgebra of a central
+  simple algebra is central**, so that `C_A(B)` is central simple again.
+* `TauCeti.centralizer_centralizer`: **the double centralizer theorem**, `C_A(C_A(B)) = B`.
+* `TauCeti.deg_mul_deg_centralizer`: the degree form of the dimension formula,
+  `deg K B * deg K C_A(B) = deg K A`.
 
 ## Implementation notes
 
@@ -83,10 +105,20 @@ these statements cover. Centrality of `B` cannot be dropped: for `K = ℝ`, `A =
 centralizer is all of `ℂ`, so `finrank ℝ B * finrank ℝ C = 4 ≠ 2 = finrank ℝ A`; the worked example
 at the end of the file records this.
 
+Centrality of `A`, on the other hand, is asked only of the last three statements, and there it
+cannot be dropped either: for `K = ℝ`, `A = ℂ` and `B = ⊥`, which is central simple, the centralizer
+of `B` is all of `ℂ` and so is its centralizer in turn, which is not `⊥`. The second worked example
+records this.
+
+`TauCeti.deg_mul_deg_centralizer` is stated here rather than beside the other degree lemmas in
+`TauCeti/Algebra/CentralSimple/Degree.lean`, so that the degree file stays free of the centralizer
+machinery: it is a statement about a centralizer, whose only degree input is
+`TauCeti.Algebra.deg_tensorProduct`.
+
 ## References
 
-This implements the Layer 5 targets `centralizer_isSimpleRing` and `finrank_mul_finrank_centralizer`
-of the
+This implements the Layer 5 targets `centralizer_isSimpleRing`, `finrank_mul_finrank_centralizer`
+and `centralizer_centralizer` of the
 [semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md).
 See R. S. Pierce, *Associative Algebras*, GTM 88, Chapter 12, and P. Gille, T. Szamuely, *Central
 Simple Algebras and Galois Cohomology*, Chapter 2.
@@ -230,6 +262,31 @@ theorem centralizerAlgEquivEnd_symm_apply (φ : Module.End (↥B ⊗[K] Aᵐᵒ�
   conv_rhs => rw [← (centralizerAlgEquivEnd B).apply_symm_apply φ]
   rw [centralizerAlgEquivEnd_apply, LinearEquiv.symm_apply_apply, mul_one]
 
+/-- An element of a subalgebra commutes with an element of its centralizer; this is the hypothesis
+under which `Algebra.TensorProduct.lift` builds `TauCeti.tensorCentralizerAlgHom`. -/
+private theorem commute_val_centralizer (b : B) (c : Subalgebra.centralizer K (B : Set A)) :
+    Commute (B.val b) ((Subalgebra.centralizer K (B : Set A)).val c) :=
+  (Subalgebra.mem_centralizer_iff K).1 c.2 (b : A) b.2
+
+/-- **Multiplication `B ⊗[K] C_A(B) → A`**, as a `K`-algebra homomorphism.
+
+An element of the centralizer commutes with every element of `B` by definition, which is exactly the
+hypothesis under which the universal property of the tensor product of algebras turns the two
+inclusions into a single homomorphism out of the tensor product. Like
+`TauCeti.centralizerAlgEquivEnd` it asks nothing of `A` or `B`; it becomes an isomorphism under the
+hypotheses of the centralizer theorem (`TauCeti.tensorCentralizerAlgEquiv`). -/
+noncomputable def tensorCentralizerAlgHom :
+    ↥B ⊗[K] ↥(Subalgebra.centralizer K (B : Set A)) →ₐ[K] A :=
+  Algebra.TensorProduct.lift B.val (Subalgebra.centralizer K (B : Set A)).val
+    (commute_val_centralizer B)
+
+@[simp]
+theorem tensorCentralizerAlgHom_tmul (b : B) (c : Subalgebra.centralizer K (B : Set A)) :
+    tensorCentralizerAlgHom B (b ⊗ₜ c) = (b : A) * (c : A) := by
+  unfold tensorCentralizerAlgHom
+  rw [Algebra.TensorProduct.lift_tmul]
+  rfl
+
 end Identification
 
 section Centralizer
@@ -274,9 +331,129 @@ theorem finrank_mul_finrank_centralizer :
   rw [mul_comm (finrank K B), mul_assoc]
   exact key
 
+/-- **`B` and its centralizer generate `A`, freely**: multiplication
+`B ⊗[K] C_A(B) → A` is bijective.
+
+The source is a simple ring, being the tensor product of the central simple algebra `B` with the
+simple algebra `C_A(B)`, so the homomorphism is injective; the centralizer theorem says the two
+sides have the same dimension over `K`, so it is surjective as well. -/
+theorem tensorCentralizerAlgHom_bijective :
+    Function.Bijective (tensorCentralizerAlgHom B) := by
+  have := centralizer_isSimpleRing B
+  have hinj : Function.Injective (tensorCentralizerAlgHom B) :=
+    (tensorCentralizerAlgHom B : _ →ₐ[K] A).toRingHom.injective
+  refine ⟨hinj, ?_⟩
+  have hrank : finrank K (↥B ⊗[K] ↥(Subalgebra.centralizer K (B : Set A))) = finrank K A := by
+    rw [Module.finrank_tensorProduct]
+    exact finrank_mul_finrank_centralizer B
+  exact (LinearMap.injective_iff_surjective_of_finrank_eq_finrank hrank
+    (f := (tensorCentralizerAlgHom B).toLinearMap)).1 hinj
+
+/-- **The tensor decomposition along a central simple subalgebra**: for a central simple
+`K`-subalgebra `B` of a finite-dimensional simple `K`-algebra `A`,
+
+  `B ⊗[K] C_A(B) ≃ₐ[K] A`,
+
+by multiplication. It is `TauCeti.tensorCentralizerAlgHom`, which
+`TauCeti.tensorCentralizerAlgHom_bijective` shows to be bijective. -/
+noncomputable def tensorCentralizerAlgEquiv :
+    ↥B ⊗[K] ↥(Subalgebra.centralizer K (B : Set A)) ≃ₐ[K] A :=
+  AlgEquiv.ofBijective (tensorCentralizerAlgHom B) (tensorCentralizerAlgHom_bijective B)
+
+@[simp]
+theorem tensorCentralizerAlgEquiv_tmul (b : B) (c : Subalgebra.centralizer K (B : Set A)) :
+    tensorCentralizerAlgEquiv B (b ⊗ₜ c) = (b : A) * (c : A) := by
+  simp [tensorCentralizerAlgEquiv]
+
 end Centralizer
 
-/-! ### Worked example -/
+/-!
+### Centrality of the centralizer, and the double centralizer
+
+The three statements below need `A` itself to be **central** simple, and not merely simple. This is
+the first point in the file where that is so: the dimension formula and the tensor decomposition
+hold over the center of `A` for free, but `C_A(C_A(B)) = B` genuinely fails when `A` has a larger
+center, as the second worked example at the end of the file records.
+-/
+
+section DoubleCentralizer
+
+variable {K A : Type*} [Field K] [Ring A] [Algebra K A] [Algebra.IsCentral K A] [IsSimpleRing A]
+  [FiniteDimensional K A] (B : Subalgebra K A) [Algebra.IsCentral K B] [IsSimpleRing B]
+
+/-- **The centralizer of a central simple subalgebra of a central simple algebra is central.**
+Together with `TauCeti.centralizer_isSimpleRing` this says that `C_A(B)` is again central simple, so
+that the centralizer theorem may be applied to it in turn.
+
+The proof is the tensor decomposition `A ≃ₐ[K] B ⊗[K] C_A(B)` read as a statement about elements:
+every element of `A` is a sum of products `b * c` with `b ∈ B` and `c ∈ C_A(B)`. An element `z` of
+the center of `C_A(B)` commutes with each such `c` because it is central there, and with each such
+`b` because it lies in `C_A(B)`; so it commutes with all of `A`, and centrality of `A` puts it in
+`K`. -/
+theorem centralizer_isCentral :
+    Algebra.IsCentral K ↥(Subalgebra.centralizer K (B : Set A)) := by
+  refine ⟨fun z hz ↦ ?_⟩
+  -- `z` commutes with every element of `A`, checked on the image of a pure tensor.
+  have hzA : (z : A) ∈ Subalgebra.center K A := by
+    refine Subalgebra.mem_center_iff.2 fun a ↦ ?_
+    obtain ⟨t, rfl⟩ := (tensorCentralizerAlgHom_bijective B).surjective a
+    induction t using TensorProduct.induction_on with
+    | zero => simp
+    | tmul b c =>
+      -- `z` commutes with `b` because `z ∈ C_A(B)`, and with `c` because `z` is central there.
+      have hb : (b : A) * (z : A) = (z : A) * (b : A) :=
+        (Subalgebra.mem_centralizer_iff K).1 z.2 (b : A) b.2
+      have hc : (c : A) * (z : A) = (z : A) * (c : A) :=
+        congrArg Subtype.val (Subalgebra.mem_center_iff.1 hz c)
+      rw [tensorCentralizerAlgHom_tmul, mul_assoc, hc, ← mul_assoc, hb, mul_assoc]
+    | add x y hx hy => rw [map_add, add_mul, mul_add, hx, hy]
+  obtain ⟨k, hk⟩ := (Algebra.IsCentral.mem_center_iff K).1 hzA
+  refine Algebra.mem_bot.2 ⟨k, Subtype.ext ?_⟩
+  simpa using hk.symm
+
+/-- **The double centralizer theorem for a central simple subalgebra.** For a central simple
+`K`-subalgebra `B` of a finite-dimensional central simple `K`-algebra `A`,
+
+  `C_A(C_A(B)) = B`.
+
+One inclusion is formal. For the other, `C = C_A(B)` is itself central simple
+(`TauCeti.centralizer_isSimpleRing` and `TauCeti.centralizer_isCentral`), so the centralizer theorem
+applies to `C` as well and gives `finrank K C * finrank K C_A(C) = finrank K A`, while for `B` it
+gives `finrank K B * finrank K C = finrank K A`. Cancelling `finrank K C`, which is positive, leaves
+`finrank K C_A(C) = finrank K B`, and a subalgebra containing `B` with the dimension of `B` is `B`.
+-/
+theorem centralizer_centralizer :
+    Subalgebra.centralizer K (Subalgebra.centralizer K (B : Set A) : Set A) = B := by
+  have := centralizer_isSimpleRing B
+  have := centralizer_isCentral B
+  have hC : 0 < finrank K ↥(Subalgebra.centralizer K (B : Set A)) := Module.finrank_pos
+  have hdim : finrank K B
+      = finrank K ↥(Subalgebra.centralizer K
+        (Subalgebra.centralizer K (B : Set A) : Set A)) := by
+    refine Nat.eq_of_mul_eq_mul_left hC ?_
+    rw [finrank_mul_finrank_centralizer (Subalgebra.centralizer K (B : Set A)),
+      ← finrank_mul_finrank_centralizer B, mul_comm]
+  exact (Subalgebra.eq_of_le_of_finrank_eq (Subalgebra.le_centralizer_centralizer K) hdim).symm
+
+/-- **The degree is multiplicative along a central simple subalgebra**:
+`deg K B * deg K C_A(B) = deg K A`.
+
+This is the dimension formula divided by two, and it is the shape in which the centralizer theorem
+is usually quoted. It is a statement about the degree of `C_A(B)`, so it needs `C_A(B)` to be
+central simple, which is `TauCeti.centralizer_isCentral` together with
+`TauCeti.centralizer_isSimpleRing`; given that, it is the tensor decomposition read through
+`TauCeti.Algebra.deg_tensorProduct`. -/
+theorem deg_mul_deg_centralizer :
+    Algebra.deg K B * Algebra.deg K ↥(Subalgebra.centralizer K (B : Set A)) = Algebra.deg K A := by
+  have := centralizer_isSimpleRing B
+  have := centralizer_isCentral B
+  have h := Algebra.deg_eq_of_algEquiv (K := K) (tensorCentralizerAlgEquiv B)
+  rwa [Algebra.deg_tensorProduct (K := K) (A := ↥B)
+    ↥(Subalgebra.centralizer K (B : Set A))] at h
+
+end DoubleCentralizer
+
+/-! ### Worked examples -/
 
 section Example
 
@@ -297,6 +474,23 @@ example :
       Complex.finrank_real_complex]
   rw [centralizer_top_complex, htop, Complex.finrank_real_complex]
   norm_num
+
+/-- The centralizer of the trivial subalgebra `⊥` of `ℂ` is `ℂ`: scalars are central. -/
+private theorem centralizer_bot_complex :
+    Subalgebra.centralizer ℝ ((⊥ : Subalgebra ℝ ℂ) : Set ℂ) = ⊤ :=
+  eq_top_iff.2 fun z _ ↦ (Subalgebra.mem_centralizer_iff ℝ).2 fun w _ ↦ mul_comm w z
+
+/-- The negative control for `TauCeti.centralizer_centralizer`: centrality of the **ambient**
+algebra cannot be dropped. Take `K = ℝ` and `A = ℂ` again, and `B = ⊥`, which is central simple,
+being `ℝ` itself. Its centralizer is all of `ℂ`, and so is the centralizer of that, not `⊥`. -/
+example :
+    Subalgebra.centralizer ℝ
+        (Subalgebra.centralizer ℝ ((⊥ : Subalgebra ℝ ℂ) : Set ℂ) : Set ℂ)
+      ≠ (⊥ : Subalgebra ℝ ℂ) := by
+  rw [centralizer_bot_complex, centralizer_top_complex]
+  intro h
+  obtain ⟨r, hr⟩ := Algebra.mem_bot.1 (h ▸ (Algebra.mem_top : Complex.I ∈ (⊤ : Subalgebra ℝ ℂ)))
+  simpa using congrArg Complex.im hr
 
 end Example
 

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -8,25 +8,26 @@ module
 -- `Subalgebra` come from `Mathlib.Algebra.Algebra.Subalgebra.Basic`, the module structure carrying
 -- `Module.End (↥B ⊗[K] Aᵐᵒᵖ) (Bimodule B.val)` from `TauCeti.Algebra.CentralSimple.Bimodule`,
 -- `TauCeti.Algebra.deg` from `TauCeti.Algebra.CentralSimple.Degree`, and the remaining three from
--- the hypotheses `Algebra.IsCentral`, `IsSimpleRing`, `FiniteDimensional`.
+-- the hypotheses `Algebra.IsCentral`, `IsSimpleRing`, `FiniteDimensional`. The `Degree` import also
+-- re-exports `TauCeti.Algebra.CentralSimple.TensorProduct`, and with it
+-- `Mathlib.Algebra.Central.Basic` and `Mathlib.RingTheory.SimpleRing.Basic`, which is why none of
+-- those three is imported again here.
 public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.Algebra.Central.Defs
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 public import Mathlib.RingTheory.SimpleRing.Defs
 public import TauCeti.Algebra.CentralSimple.Bimodule
 public import TauCeti.Algebra.CentralSimple.Degree
--- Non-public: used only inside proofs. Simplicity of the tensor product, the endomorphism algebra
--- of a module over a simple Artinian ring, and finiteness of a tensor product supply the three
--- inputs of the first two theorems, and no exported statement mentions any of them; the Artinian
--- hypothesis of the first is supplied by finite-dimensionality (`IsArtinianRing.of_finite`); the
--- dimension of a tensor product and the finite-dimensionality of an opposite space are the
--- bookkeeping, and the complex numbers appear only in the worked examples. Injectivity of a ring
--- homomorphism out of a simple ring, the equality of injectivity and surjectivity in equal finite
--- dimension, the transport of centrality along an algebra isomorphism and the descent of centrality
--- from a tensor product to its factors are the four further tools of the tensor decomposition and
--- the double centralizer.
+-- Non-public: used only inside proofs. The endomorphism algebra of a module over a simple Artinian
+-- ring and finiteness of a tensor product supply two of the three inputs of the first two theorems
+-- (the third, simplicity of a tensor product, comes with the `Degree` import above), and no
+-- exported statement mentions any of them; the Artinian hypothesis of the first is supplied by
+-- finite-dimensionality (`IsArtinianRing.of_finite`); the dimension of a tensor product and the
+-- finite-dimensionality of an opposite space are the bookkeeping, and the complex numbers appear
+-- only in the worked examples. The equality of injectivity and surjectivity in equal finite
+-- dimension and the descent of centrality from a tensor product to its factors are the two further
+-- tools of the tensor decomposition and the double centralizer.
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
-import Mathlib.Algebra.Central.Basic
 import Mathlib.Algebra.Central.TensorProduct
 import Mathlib.LinearAlgebra.Basis.MulOpposite
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
@@ -34,10 +35,8 @@ import Mathlib.LinearAlgebra.Dimension.Constructions
 import Mathlib.LinearAlgebra.FiniteDimensional.Basic
 import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 import Mathlib.RingTheory.Artinian.Module
-import Mathlib.RingTheory.SimpleRing.Basic
 import Mathlib.RingTheory.SimpleRing.Congr
 import Mathlib.RingTheory.TensorProduct.Finite
-import TauCeti.Algebra.CentralSimple.TensorProduct
 import TauCeti.RingTheory.Semisimple.EndAlgebra
 
 /-!
@@ -470,11 +469,6 @@ example :
   rw [centralizer_top_complex, htop, Complex.finrank_real_complex]
   norm_num
 
-/-- The centralizer of the trivial subalgebra `⊥` of `ℂ` is `ℂ`: scalars are central. -/
-private theorem centralizer_bot_complex :
-    Subalgebra.centralizer ℝ ((⊥ : Subalgebra ℝ ℂ) : Set ℂ) = ⊤ :=
-  eq_top_iff.2 fun z _ ↦ (Subalgebra.mem_centralizer_iff ℝ).2 fun w _ ↦ mul_comm w z
-
 /-- The negative control for `TauCeti.centralizer_centralizer`: centrality of the **ambient**
 algebra cannot be dropped. Take `K = ℝ` and `A = ℂ` again, and `B = ⊥`, which is central simple,
 being `ℝ` itself. Its centralizer is all of `ℂ`, and so is the centralizer of that, not `⊥`. -/
@@ -482,7 +476,10 @@ example :
     Subalgebra.centralizer ℝ
         (Subalgebra.centralizer ℝ ((⊥ : Subalgebra ℝ ℂ) : Set ℂ) : Set ℂ)
       ≠ (⊥ : Subalgebra ℝ ℂ) := by
-  rw [centralizer_bot_complex, centralizer_top_complex]
+  -- `⊥` consists of scalars, so it lies in the center of `ℂ`, and its centralizer is everything.
+  have hbot : Subalgebra.centralizer ℝ ((⊥ : Subalgebra ℝ ℂ) : Set ℂ) = ⊤ :=
+    (Subalgebra.centralizer_eq_top_iff_subset ℝ).2 (by simp)
+  rw [hbot, centralizer_top_complex]
   intro h
   obtain ⟨r, hr⟩ := Algebra.mem_bot.1 (h ▸ (Algebra.mem_top : Complex.I ∈ (⊤ : Subalgebra ℝ ℂ)))
   simpa using congrArg Complex.im hr

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -421,9 +421,14 @@ One inclusion is formal. For the other, `C = C_A(B)` is itself central simple
 applies to `C` as well and gives `finrank K C * finrank K C_A(C) = finrank K A`, while for `B` it
 gives `finrank K B * finrank K C = finrank K A`. Cancelling `finrank K C`, which is positive, leaves
 `finrank K C_A(C) = finrank K B`, and a subalgebra containing `B` with the dimension of `B` is `B`.
--/
+
+The inner centralizer is written as the `Set.centralizer` of `↑B`, which is what
+`Subalgebra.coe_centralizer` (a `simp` lemma) turns the coerced subalgebra into, so that the
+left-hand side is in simp normal form; `Subalgebra.centralizer_centralizer_centralizer` is stated
+the same way. -/
+@[simp]
 theorem centralizer_centralizer :
-    Subalgebra.centralizer K (Subalgebra.centralizer K (B : Set A) : Set A) = B := by
+    Subalgebra.centralizer K (Set.centralizer (B : Set A)) = B := by
   have := centralizer_isSimpleRing B
   have := centralizer_isCentral B
   have hC : 0 < finrank K ↥(Subalgebra.centralizer K (B : Set A)) := Module.finrank_pos
@@ -438,8 +443,9 @@ theorem centralizer_centralizer :
 /-- **The degree is multiplicative along a central simple subalgebra**:
 `deg K B * deg K C_A(B) = deg K A`.
 
-This is the dimension formula divided by two, and it is the shape in which the centralizer theorem
-is usually quoted. It is a statement about the degree of `C_A(B)`, so it needs `C_A(B)` to be
+This is the dimension formula with square roots taken, the degree being the square root of the
+dimension (`TauCeti.Algebra.deg_sq`), and it is the shape in which the centralizer theorem is
+usually quoted. It is a statement about the degree of `C_A(B)`, so it needs `C_A(B)` to be
 central simple, which is `TauCeti.centralizer_isCentral` together with
 `TauCeti.centralizer_isSimpleRing`; given that, it is the tensor decomposition read through
 `TauCeti.Algebra.deg_tensorProduct`. -/

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -22,10 +22,12 @@ public import TauCeti.Algebra.CentralSimple.Degree
 -- dimension of a tensor product and the finite-dimensionality of an opposite space are the
 -- bookkeeping, and the complex numbers appear only in the worked examples. Injectivity of a ring
 -- homomorphism out of a simple ring, the equality of injectivity and surjectivity in equal finite
--- dimension, and the description of the center of a central algebra are the three further tools of
--- the tensor decomposition and the double centralizer.
+-- dimension, the transport of centrality along an algebra isomorphism and the descent of centrality
+-- from a tensor product to its factors are the four further tools of the tensor decomposition and
+-- the double centralizer.
 import Mathlib.Algebra.Algebra.Subalgebra.Lattice
 import Mathlib.Algebra.Central.Basic
+import Mathlib.Algebra.Central.TensorProduct
 import Mathlib.LinearAlgebra.Basis.MulOpposite
 import Mathlib.LinearAlgebra.Complex.FiniteDimensional
 import Mathlib.LinearAlgebra.Dimension.Constructions
@@ -53,9 +55,9 @@ is again a simple `K`-algebra, and that its dimension is the complementary one:
 The dimension formula is sharpened here to a decomposition: multiplication `B ⊗[K] C → A` is an
 algebra isomorphism, because its source is simple, so that the map is injective, and the two sides
 have the same dimension. When `A` is moreover **central** simple, the decomposition forces `C` to be
-central as well, since an element of the center of `C` commutes with every `b * c`, hence with all
-of `A`; so `C` is central simple in turn, the centralizer theorem applies to it, and comparing the
-two dimension formulas gives the **double centralizer** `C_A(C) = B`.
+central as well, since a tensor product of algebras over a field is central only if both factors
+are; so `C` is central simple in turn, the centralizer theorem applies to it, and comparing the two
+dimension formulas gives the **double centralizer** `C_A(C) = B`.
 
 The proof is the module-theoretic one, and it reuses the bimodule of the Skolem-Noether theorem. The
 inclusion `B.val : B →ₐ[K] A` makes `A` a module over `R = B ⊗[K] Aᵐᵒᵖ`
@@ -336,8 +338,10 @@ theorem finrank_mul_finrank_centralizer :
 
 The source is a simple ring, being the tensor product of the central simple algebra `B` with the
 simple algebra `C_A(B)`, so the homomorphism is injective; the centralizer theorem says the two
-sides have the same dimension over `K`, so it is surjective as well. -/
-theorem tensorCentralizerAlgHom_bijective :
+sides have the same dimension over `K`, so it is surjective as well.
+
+Only the isomorphism `TauCeti.tensorCentralizerAlgEquiv` assembled from this is exported. -/
+private theorem tensorCentralizerAlgHom_bijective :
     Function.Bijective (tensorCentralizerAlgHom B) := by
   have := centralizer_isSimpleRing B
   have hinj : Function.Injective (tensorCentralizerAlgHom B) :=
@@ -354,8 +358,9 @@ theorem tensorCentralizerAlgHom_bijective :
 
   `B ⊗[K] C_A(B) ≃ₐ[K] A`,
 
-by multiplication. It is `TauCeti.tensorCentralizerAlgHom`, which
-`TauCeti.tensorCentralizerAlgHom_bijective` shows to be bijective. -/
+by multiplication. It is `TauCeti.tensorCentralizerAlgHom`, which a private lemma of this file
+shows to be bijective: the source is simple, so the map is injective, and the centralizer theorem
+makes the two sides equidimensional, so it is surjective too. -/
 noncomputable def tensorCentralizerAlgEquiv :
     ↥B ⊗[K] ↥(Subalgebra.centralizer K (B : Set A)) ≃ₐ[K] A :=
   AlgEquiv.ofBijective (tensorCentralizerAlgHom B) (tensorCentralizerAlgHom_bijective B)
@@ -385,31 +390,15 @@ variable {K A : Type*} [Field K] [Ring A] [Algebra K A] [Algebra.IsCentral K A] 
 Together with `TauCeti.centralizer_isSimpleRing` this says that `C_A(B)` is again central simple, so
 that the centralizer theorem may be applied to it in turn.
 
-The proof is the tensor decomposition `A ≃ₐ[K] B ⊗[K] C_A(B)` read as a statement about elements:
-every element of `A` is a sum of products `b * c` with `b ∈ B` and `c ∈ C_A(B)`. An element `z` of
-the center of `C_A(B)` commutes with each such `c` because it is central there, and with each such
-`b` because it lies in `C_A(B)`; so it commutes with all of `A`, and centrality of `A` puts it in
-`K`. -/
+The proof is the tensor decomposition `B ⊗[K] C_A(B) ≃ₐ[K] A` transported: the tensor product is
+central because `A` is, and a tensor product of algebras over a field is central only if each factor
+is, provided the other one is nontrivial (`Algebra.IsCentral.right_of_tensor_of_field`); here `B` is
+nontrivial because it is simple. -/
 theorem centralizer_isCentral :
-    Algebra.IsCentral K ↥(Subalgebra.centralizer K (B : Set A)) := by
-  refine ⟨fun z hz ↦ ?_⟩
-  -- `z` commutes with every element of `A`, checked on the image of a pure tensor.
-  have hzA : (z : A) ∈ Subalgebra.center K A := by
-    refine Subalgebra.mem_center_iff.2 fun a ↦ ?_
-    obtain ⟨t, rfl⟩ := (tensorCentralizerAlgHom_bijective B).surjective a
-    induction t using TensorProduct.induction_on with
-    | zero => simp
-    | tmul b c =>
-      -- `z` commutes with `b` because `z ∈ C_A(B)`, and with `c` because `z` is central there.
-      have hb : (b : A) * (z : A) = (z : A) * (b : A) :=
-        (Subalgebra.mem_centralizer_iff K).1 z.2 (b : A) b.2
-      have hc : (c : A) * (z : A) = (z : A) * (c : A) :=
-        congrArg Subtype.val (Subalgebra.mem_center_iff.1 hz c)
-      rw [tensorCentralizerAlgHom_tmul, mul_assoc, hc, ← mul_assoc, hb, mul_assoc]
-    | add x y hx hy => rw [map_add, add_mul, mul_add, hx, hy]
-  obtain ⟨k, hk⟩ := (Algebra.IsCentral.mem_center_iff K).1 hzA
-  refine Algebra.mem_bot.2 ⟨k, Subtype.ext ?_⟩
-  simpa using hk.symm
+    Algebra.IsCentral K ↥(Subalgebra.centralizer K (B : Set A)) :=
+  have : Algebra.IsCentral K (↥B ⊗[K] ↥(Subalgebra.centralizer K (B : Set A))) :=
+    Algebra.IsCentral.of_algEquiv K A _ (tensorCentralizerAlgEquiv B).symm
+  Algebra.IsCentral.right_of_tensor_of_field K ↥B _
 
 /-- **The double centralizer theorem for a central simple subalgebra.** For a central simple
 `K`-subalgebra `B` of a finite-dimensional central simple `K`-algebra `A`,

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -377,8 +377,8 @@ end Centralizer
 
 The three statements below need `A` itself to be **central** simple, and not merely simple. This is
 the first point in the file where that is so: the dimension formula and the tensor decomposition
-hold over the center of `A` for free, but `C_A(C_A(B)) = B` genuinely fails when `A` has a larger
-center, as the second worked example at the end of the file records.
+hold over `K` without assuming that `A` is central, but `C_A(C_A(B)) = B` genuinely fails when `A`
+has a larger center, as the second worked example at the end of the file records.
 -/
 
 section DoubleCentralizer


### PR DESCRIPTION
This PR completes the centralizer theorem for a central simple subalgebra `B` of a
finite-dimensional simple `K`-algebra `A`, taking it from the dimension formula that already exists
in `TauCeti/Algebra/CentralSimple/Centralizer.lean` to the three statements that finish the layer:
multiplication `B ⊗[K] C_A(B) → A` is an algebra isomorphism (`tensorCentralizerAlgEquiv`); when `A`
is moreover central simple, the centralizer `C_A(B)` is itself central (`centralizer_isCentral`), so
that with `centralizer_isSimpleRing` it is central simple in turn; and the double centralizer
`C_A(C_A(B)) = B` (`centralizer_centralizer`). It also records the degree form
`deg K B * deg K C_A(B) = deg K A` (`deg_mul_deg_centralizer`), which is how the centralizer theorem
is usually quoted downstream.

The mathematics is the standard argument. The source of the multiplication map is simple, being the
tensor product of the central simple `B` with the simple `C_A(B)`, so the map is injective; the
existing dimension formula makes the two sides equidimensional, so it is bijective. Centrality of
`C_A(B)` is that decomposition read on elements: every element of `A` is a sum of products `b * c`,
an element of the center of `C_A(B)` commutes with each `c` because it is central there and with
each `b` because it lies in `C_A(B)`, hence with all of `A`, and `A` is central. The double
centralizer is then a dimension count: `C_A(B)` is central simple, so the centralizer theorem
applies to it too, and cancelling `finrank K C_A(B)` from the two dimension formulas shows
`C_A(C_A(B))` has the dimension of `B`, which it contains.

The milestone is Layer 5 of the semisimple-algebras roadmap, "Skolem-Noether and the centralizer
theorem". Skolem-Noether, the simplicity of the centralizer and the dimension formula have landed;
the roadmap's Layer 5 text also asks for the centralizer to be **central simple** and for
`C_A(C) = B`, which are exactly what this PR supplies. After this, Layer 5 is complete and the next
step on the critical path is Layer 6, the Brauer group and splitting fields, whose maximal-subfield
theory consumes the double centralizer directly.

Two additions are worth flagging for review. The new material lives in the existing
`Centralizer.lean` rather than a new module: it shares the hypotheses, the notation and the whole
proof idea with what is already there, and `centralizer_centralizer` is a second application of
`finrank_mul_finrank_centralizer` from the same file. `deg_mul_deg_centralizer` is stated there too
rather than in `Degree.lean`, so that the degree file does not acquire a dependency on the
centralizer machinery; the file docstring records the choice. A second worked example shows that
centrality of the **ambient** algebra cannot be dropped from the last three statements: over `ℝ` in
`ℂ`, the subalgebra `⊥` is central simple but its double centralizer is `ℂ`, not `⊥`. This sits
beside the existing negative control for centrality of the subalgebra.

Nothing was vendored from Mathlib, and no material was taken from the supplementary source snapshot.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"double-centralizer-central-simple-subalgebra"}-->

🤖 Prepared with Claude Code
