### PR TITLE
feat: the Wedderburn dimension count

### DIFF
--- a/TauCeti/Algebra/Matrix/Pi.lean
+++ b/TauCeti/Algebra/Matrix/Pi.lean
@@ -7,18 +7,50 @@ module
 public import TauCeti.Algebra.Subalgebra.Center
 public import Mathlib.Algebra.Central.Matrix
 public import Mathlib.LinearAlgebra.Dimension.Constructions
+-- `FiniteDimensional` is a hypothesis of, and a conclusion of, the presentation results below.
+public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
+-- Non-public: `Matrix.entryLinearMap` is used only inside a proof, to exhibit a coefficient algebra
+-- as a linear quotient of its matrix block, and `Module.finrank_pos` only to bound the dimension of
+-- a nontrivial coefficient algebra from below.
+import Mathlib.Data.Matrix.Basic
+import Mathlib.LinearAlgebra.Dimension.Finite
 
 /-!
 # Finite products of matrix algebras
 
 The dimension and the center of a product `Π i, Matₙᵢ(k)` of matrix algebras over a field, both
-read off the sizes `nᵢ` alone. Such a product is what a structure theorem of Artin--Wedderburn type
-presents an algebra as, and these are the invariants such a presentation transports.
+read off the sizes `nᵢ` alone, together with the dimensions that an algebra equivalence
+`A ≃ₐ[k] ∏ᵢ Matₙᵢ(Dᵢ)` onto such a product — over an arbitrary family of coefficient algebras
+`Dᵢ` — transports back to the algebra `A` presented. Such a product is what a structure theorem of
+Artin--Wedderburn type presents an algebra as, and these are the invariants such a presentation
+transports; nothing here needs the presentation to come from Artin--Wedderburn, nor the
+coefficients to be division algebras.
 
 * `TauCeti.finrank_pi_matrix`: the dimension of the product is `∑ᵢ nᵢ²`;
 * `TauCeti.centerPiMatrixAlgEquiv`: when every size is nonzero the center consists of the tuples of
   scalar matrices, so it is the algebra `ι → k` of functions on the index, whose dimension is the
-  number of factors (`TauCeti.finrank_center_pi_matrix`).
+  number of factors (`TauCeti.finrank_center_pi_matrix`);
+* `TauCeti.finiteDimensional_of_algEquiv_pi_matrix`: the coefficient algebra of a block of *nonzero*
+  size in a presentation of a finite-dimensional algebra is itself finite-dimensional. A block of
+  size `0` is the zero ring whatever its coefficients are, so it constrains them not at all: the
+  positivity hypothesis is essential rather than an artefact of the proof;
+* `TauCeti.finrank_eq_sum_sq_finrank`: **the dimension count** `finrank k A = ∑ᵢ nᵢ² · finrank k Dᵢ`
+  for an algebra presented as `∏ᵢ Matₙᵢ(Dᵢ)`, of which
+  `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split form
+  `finrank k A = ∑ᵢ nᵢ²`. The count itself needs no positivity: a block of size `0` contributes `0`
+  to both sides;
+* `TauCeti.sq_le_finrank_of_algEquiv_pi_matrix` and `TauCeti.card_le_finrank_of_algEquiv_pi_matrix`:
+  the bounds `nᵢ² ≤ finrank k A` on a single block degree and, when every block is nonzero,
+  `Nat.card ι ≤ finrank k A` on the number of blocks.
+
+## References
+
+The dimension count implements the Layer 2 target "the dimension count" of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
+pinned there as `finrank_eq_sum_sq_finrank`; its algebraically closed form lives in
+`TauCeti/RingTheory/Semisimple/DimensionCount.lean`. See C. W. Curtis and I. Reiner,
+*Representation Theory of Finite Groups and Associative Algebras*, §25, or T. Y. Lam, *A First
+Course in Noncommutative Rings*, §3.
 -/
 
 public section
@@ -54,6 +86,8 @@ theorem centerPiMatrixAlgEquiv_symm_apply_coe [∀ i, NeZero (d i)] (f : ι → 
       algebraMap k (Matrix (Fin (d i)) (Fin (d i)) k) (f i) := by
   simp [centerPiMatrixAlgEquiv]
 
+section FiniteIndex
+
 variable [Fintype ι]
 
 /-- The dimension of a finite product of matrix algebras is the sum of the squares of the sizes. -/
@@ -70,5 +104,121 @@ theorem finrank_center_pi_matrix [∀ i, NeZero (d i)] :
     Module.finrank k (Subalgebra.center k (Π i, Matrix (Fin (d i)) (Fin (d i)) k)) =
       Fintype.card ι := by
   rw [(centerPiMatrixAlgEquiv k d).toLinearEquiv.finrank_eq, Module.finrank_pi]
+
+end FiniteIndex
+
+/-! ### Dimensions read off a presentation -/
+
+section Presentation
+
+variable {d : ι → ℕ} {A : Type*} [Ring A] [Algebra k A] {D : ι → Type*} [∀ i, Ring (D i)]
+  [∀ i, Algebra k (D i)]
+
+section Blocks
+
+variable [FiniteDimensional k A] (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
+
+include e
+
+/-- A matrix block of a presentation of a finite-dimensional algebra as a product of matrix algebras
+is finite-dimensional: it is a direct factor, hence a linear quotient, of the algebra. -/
+private theorem finiteDimensional_matrix_of_algEquiv_pi_matrix (i : ι) :
+    FiniteDimensional k (Matrix (Fin (d i)) (Fin (d i)) (D i)) := by
+  classical
+  have : Module.Finite k (Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
+    Module.Finite.equiv e.toLinearEquiv
+  exact Module.Finite.of_surjective
+    (LinearMap.proj (R := k) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
+    fun x => ⟨Pi.single i x, by simp⟩
+
+/-- The coefficient algebra of a block of nonzero size in a presentation of a finite-dimensional
+algebra as a product of matrix algebras is itself finite-dimensional, so no such presentation can
+smuggle an infinite-dimensional coefficient algebra into a nonzero block.
+
+The positivity hypothesis `NeZero (d i)` is essential and not an artefact of the proof: a block of
+size `0` is the zero ring whatever its coefficients are, so it constrains `D i` not at all. Every
+Artin--Wedderburn presentation supplies that positivity. -/
+theorem finiteDimensional_of_algEquiv_pi_matrix (i : ι) [NeZero (d i)] :
+    FiniteDimensional k (D i) := by
+  have := finiteDimensional_matrix_of_algEquiv_pi_matrix k e i
+  obtain ⟨j⟩ : Nonempty (Fin (d i)) :=
+    Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
+  exact Module.Finite.of_surjective (Matrix.entryLinearMap k (D i) j j)
+    fun x => ⟨Matrix.of fun _ _ => x, rfl⟩
+
+end Blocks
+
+section Count
+
+variable [Fintype ι] [FiniteDimensional k A]
+
+/-- **The Wedderburn dimension count.** If a finite-dimensional `k`-algebra `A` is presented as a
+finite product `∏ᵢ Matₙᵢ(Dᵢ)` of matrix algebras, then `finrank k A = ∑ᵢ nᵢ² · finrank k Dᵢ`.
+
+No positivity is needed: a block of size `0` contributes `0` to both sides, whatever its
+coefficients are. Only the presentation is used: `A` is not assumed semisimple, although by
+`RingEquiv.isSemisimpleRing` it is one as soon as the coefficients `Dᵢ` are division algebras. -/
+theorem finrank_eq_sum_sq_finrank (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
+    Module.finrank k A = ∑ i, d i ^ 2 * Module.finrank k (D i) := by
+  have : ∀ i, Module.Finite k (Matrix (Fin (d i)) (Fin (d i)) (D i)) := fun i =>
+    finiteDimensional_matrix_of_algEquiv_pi_matrix k e i
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_pi_fintype]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Module.finrank_matrix, Fintype.card_fin, sq]
+
+omit [FiniteDimensional k A] in
+/-- **The dimension count for an already split presentation**: if `A` is presented as a product of
+matrix algebras over the base field itself, then `finrank k A = ∑ᵢ nᵢ²`.
+
+No hypothesis on `k` is needed here; algebraic closedness enters
+`TauCeti.finrank_eq_sum_sq_of_isAlgClosed` only to identify the coefficients of the nonzero blocks
+of a presentation with the base field, and here every coefficient already is the base field. -/
+theorem finrank_eq_sum_sq_of_algEquiv_pi_matrix
+    (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
+    Module.finrank k A = ∑ i, d i ^ 2 :=
+  e.toLinearEquiv.finrank_eq.trans (finrank_pi_matrix k d)
+
+end Count
+
+section Bounds
+
+variable [Finite ι] [FiniteDimensional k A] [∀ i, Nontrivial (D i)]
+  (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
+
+include e
+
+/-- **The degree of a block is bounded by the dimension**: `nᵢ² ≤ finrank k A` for every block of a
+presentation of a finite-dimensional algebra by matrix algebras over nontrivial coefficients. -/
+theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) : d i ^ 2 ≤ Module.finrank k A := by
+  have : Fintype ι := Fintype.ofFinite ι
+  rcases eq_or_ne (d i) 0 with h | h
+  · simp [h]
+  · have : NeZero (d i) := ⟨h⟩
+    have := finiteDimensional_of_algEquiv_pi_matrix k e i
+    calc d i ^ 2 ≤ d i ^ 2 * Module.finrank k (D i) :=
+          Nat.le_mul_of_pos_right _ (Module.finrank_pos (R := k) (M := D i))
+      _ ≤ ∑ j, d j ^ 2 * Module.finrank k (D j) :=
+          Finset.single_le_sum (f := fun j => d j ^ 2 * Module.finrank k (D j))
+            (fun _ _ => Nat.zero_le _) (Finset.mem_univ i)
+      _ = Module.finrank k A := (finrank_eq_sum_sq_finrank k e).symm
+
+/-- **The number of blocks is bounded by the dimension**: a finite-dimensional algebra presented by
+nonzero matrix blocks over nontrivial coefficients has at most `finrank k A` of them.
+
+For the group algebra of a finite group over a splitting field this bounds the number of irreducible
+representations by the order of the group. -/
+theorem card_le_finrank_of_algEquiv_pi_matrix [∀ i, NeZero (d i)] :
+    Nat.card ι ≤ Module.finrank k A := by
+  have : Fintype ι := Fintype.ofFinite ι
+  rw [finrank_eq_sum_sq_finrank k e, Nat.card_eq_fintype_card, ← Finset.card_univ,
+    Finset.card_eq_sum_ones]
+  refine Finset.sum_le_sum fun i _ => ?_
+  have := finiteDimensional_of_algEquiv_pi_matrix k e i
+  exact Nat.one_le_iff_ne_zero.mpr <| Nat.mul_ne_zero (pow_ne_zero 2 (NeZero.ne (d i)))
+    (Module.finrank_pos (R := k) (M := D i)).ne'
+
+end Bounds
+
+end Presentation
 
 end TauCeti

--- a/TauCeti/Algebra/Matrix/Pi.lean
+++ b/TauCeti/Algebra/Matrix/Pi.lean
@@ -10,8 +10,9 @@ public import Mathlib.LinearAlgebra.Dimension.Constructions
 -- `FiniteDimensional` is a hypothesis of, and a conclusion of, the presentation results below.
 public import Mathlib.LinearAlgebra.FiniteDimensional.Defs
 -- Non-public: `Matrix.entryLinearMap` is used only inside a proof, to exhibit a coefficient algebra
--- as a linear quotient of its matrix block, and `Module.finrank_pos` only to bound the dimension of
--- a nontrivial coefficient algebra from below.
+-- as a linear quotient of its matrix block, and `Module.finrank_pos` together with
+-- `LinearMap.finrank_le_finrank_of_surjective` only to bound a block from below by the dimension of
+-- its coefficients and from above by that of the algebra presented.
 import Mathlib.Data.Matrix.Basic
 import Mathlib.LinearAlgebra.Dimension.Finite
 
@@ -35,13 +36,12 @@ coefficients to be division algebras.
   size `0` is the zero ring whatever its coefficients are, so it constrains them not at all: the
   positivity hypothesis is essential rather than an artefact of the proof;
 * `TauCeti.finrank_eq_sum_sq_finrank`: **the dimension count** `finrank k A = ∑ᵢ nᵢ² · finrank k Dᵢ`
-  for an algebra presented as `∏ᵢ Matₙᵢ(Dᵢ)`, of which
-  `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split form
-  `finrank k A = ∑ᵢ nᵢ²`. The count itself needs no positivity: a block of size `0` contributes `0`
-  to both sides;
+  for an algebra presented as `∏ᵢ Matₙᵢ(Dᵢ)`. The count itself needs no positivity: a block of size
+  `0` contributes `0` to both sides;
 * `TauCeti.sq_le_finrank_of_algEquiv_pi_matrix` and `TauCeti.card_le_finrank_of_algEquiv_pi_matrix`:
-  the bounds `nᵢ² ≤ finrank k A` on a single block degree and, when every block is nonzero,
-  `Nat.card ι ≤ finrank k A` on the number of blocks.
+  the bounds `nᵢ² ≤ finrank k A` on the degree of a single block with nontrivial coefficients — no
+  other block plays any part, so the index need not even be finite — and, when every block is
+  nonzero over nontrivial coefficients, `Nat.card ι ≤ finrank k A` on the number of blocks.
 
 ## References
 
@@ -166,49 +166,43 @@ theorem finrank_eq_sum_sq_finrank (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin
   refine Finset.sum_congr rfl fun i _ => ?_
   rw [Module.finrank_matrix, Fintype.card_fin, sq]
 
-omit [FiniteDimensional k A] in
-/-- **The dimension count for an already split presentation**: if `A` is presented as a product of
-matrix algebras over the base field itself, then `finrank k A = ∑ᵢ nᵢ²`.
-
-No hypothesis on `k` is needed here; algebraic closedness enters
-`TauCeti.finrank_eq_sum_sq_of_isAlgClosed` only to identify the coefficients of the nonzero blocks
-of a presentation with the base field, and here every coefficient already is the base field. -/
-theorem finrank_eq_sum_sq_of_algEquiv_pi_matrix
-    (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) k) :
-    Module.finrank k A = ∑ i, d i ^ 2 :=
-  e.toLinearEquiv.finrank_eq.trans (finrank_pi_matrix k d)
-
 end Count
 
 section Bounds
 
-variable [Finite ι] [FiniteDimensional k A] [∀ i, Nontrivial (D i)]
-  (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
+variable [FiniteDimensional k A] (e : A ≃ₐ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
 
 include e
 
-/-- **The degree of a block is bounded by the dimension**: `nᵢ² ≤ finrank k A` for every block of a
-presentation of a finite-dimensional algebra by matrix algebras over nontrivial coefficients. -/
-theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) : d i ^ 2 ≤ Module.finrank k A := by
-  have : Fintype ι := Fintype.ofFinite ι
+/-- **The degree of a block is bounded by the dimension**: `nᵢ² ≤ finrank k A` for a block with
+nontrivial coefficients in a presentation of a finite-dimensional algebra by matrix algebras.
+
+Only the block `i` takes part: the bound reads off the surjection of `A` onto that block alone, so
+neither the other coefficient algebras nor the finiteness of the index are assumed. -/
+theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) [Nontrivial (D i)] :
+    d i ^ 2 ≤ Module.finrank k A := by
+  classical
   rcases eq_or_ne (d i) 0 with h | h
   · simp [h]
   · have : NeZero (d i) := ⟨h⟩
     have := finiteDimensional_of_algEquiv_pi_matrix k e i
     calc d i ^ 2 ≤ d i ^ 2 * Module.finrank k (D i) :=
           Nat.le_mul_of_pos_right _ (Module.finrank_pos (R := k) (M := D i))
-      _ ≤ ∑ j, d j ^ 2 * Module.finrank k (D j) :=
-          Finset.single_le_sum (f := fun j => d j ^ 2 * Module.finrank k (D j))
-            (fun _ _ => Nat.zero_le _) (Finset.mem_univ i)
-      _ = Module.finrank k A := (finrank_eq_sum_sq_finrank k e).symm
+      _ = Module.finrank k (Matrix (Fin (d i)) (Fin (d i)) (D i)) := by
+          rw [Module.finrank_matrix, Fintype.card_fin, sq]
+      _ ≤ Module.finrank k A :=
+          LinearMap.finrank_le_finrank_of_surjective
+            (f := (LinearMap.proj (R := k) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
+              ∘ₗ (e.toLinearEquiv : A →ₗ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)))
+            fun x => ⟨e.symm (Pi.single i x), by simp⟩
 
 /-- **The number of blocks is bounded by the dimension**: a finite-dimensional algebra presented by
 nonzero matrix blocks over nontrivial coefficients has at most `finrank k A` of them.
 
 For the group algebra of a finite group over a splitting field this bounds the number of irreducible
 representations by the order of the group. -/
-theorem card_le_finrank_of_algEquiv_pi_matrix [∀ i, NeZero (d i)] :
-    Nat.card ι ≤ Module.finrank k A := by
+theorem card_le_finrank_of_algEquiv_pi_matrix [Finite ι] [∀ i, NeZero (d i)]
+    [∀ i, Nontrivial (D i)] : Nat.card ι ≤ Module.finrank k A := by
   have : Fintype ι := Fintype.ofFinite ι
   rw [finrank_eq_sum_sq_finrank k e, Nat.card_eq_fintype_card, ← Finset.card_univ,
     Finset.card_eq_sum_ones]

--- a/TauCeti/Algebra/Matrix/Pi.lean
+++ b/TauCeti/Algebra/Matrix/Pi.lean
@@ -124,12 +124,10 @@ include e
 is finite-dimensional: it is a direct factor, hence a linear quotient, of the algebra. -/
 private theorem finiteDimensional_matrix_of_algEquiv_pi_matrix (i : ι) :
     FiniteDimensional k (Matrix (Fin (d i)) (Fin (d i)) (D i)) := by
-  classical
   have : Module.Finite k (Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
     Module.Finite.equiv e.toLinearEquiv
-  exact Module.Finite.of_surjective
-    (LinearMap.proj (R := k) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
-    fun x => ⟨Pi.single i x, by simp⟩
+  exact Module.Finite.of_surjective _ (LinearMap.proj_surjective (R := k)
+    (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
 
 /-- The coefficient algebra of a block of nonzero size in a presentation of a finite-dimensional
 algebra as a product of matrix algebras is itself finite-dimensional, so no such presentation can
@@ -181,7 +179,6 @@ Only the block `i` takes part: the bound reads off the surjection of `A` onto th
 neither the other coefficient algebras nor the finiteness of the index are assumed. -/
 theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) [Nontrivial (D i)] :
     d i ^ 2 ≤ Module.finrank k A := by
-  classical
   rcases eq_or_ne (d i) 0 with h | h
   · simp [h]
   · have : NeZero (d i) := ⟨h⟩
@@ -194,7 +191,9 @@ theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) [Nontrivial (D i)] :
           LinearMap.finrank_le_finrank_of_surjective
             (f := (LinearMap.proj (R := k) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
               ∘ₗ (e.toLinearEquiv : A →ₗ[k] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)))
-            fun x => ⟨e.symm (Pi.single i x), by simp⟩
+            ((LinearMap.proj_surjective (R := k)
+              (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i).comp
+              e.toLinearEquiv.surjective)
 
 /-- **The number of blocks is bounded by the dimension**: a finite-dimensional algebra presented by
 nonzero matrix blocks over nontrivial coefficients has at most `finrank k A` of them.

--- a/TauCeti/RingTheory/Semisimple/DimensionCount.lean
+++ b/TauCeti/RingTheory/Semisimple/DimensionCount.lean
@@ -4,76 +4,54 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
--- `TauCeti.Algebra.Matrix.Pi` is imported publicly: it supplies `TauCeti.finrank_pi_matrix`, the
--- already split case of the count proved below, and it re-exports
--- `Mathlib.LinearAlgebra.Dimension.Constructions`, hence `Module.finrank` and the dimension
--- formulas `Module.finrank_pi_fintype` and `Module.finrank_matrix` that the proofs run on, as well
--- as the `Matrix` occurring in every statement here.
+-- `TauCeti.Algebra.Matrix.Pi` is imported publicly: it supplies the dimension count
+-- `TauCeti.finrank_eq_sum_sq_finrank` specialized below and the finite-dimensionality
+-- `TauCeti.finiteDimensional_of_algEquiv_pi_matrix` of the coefficients, and it re-exports
+-- `Module.finrank` as well as the `Matrix` and the `FiniteDimensional` occurring in the statement.
 public import TauCeti.Algebra.Matrix.Pi
--- `IsSemisimpleRing` and Artin--Wedderburn appear in the existence statements below.
-public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
--- `IsAlgClosed` appears in the hypotheses of the split forms below.
+-- `IsAlgClosed` appears in the hypotheses below.
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
 -- Non-public: `TauCeti.nonempty_algEquiv_self_of_finiteDimensional_divisionRing` (the collapse of a
--- finite-dimensional division algebra over an algebraically closed field) and Mathlib's
--- algebraically closed form of Artin--Wedderburn are used only inside proofs, and
--- `Matrix.entryLinearMap` only to exhibit a coefficient algebra as a quotient of its matrix block,
--- so downstream importers do not pay for any of them.
-import Mathlib.Data.Matrix.Basic
-import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+-- finite-dimensional division algebra over an algebraically closed field) is used only inside the
+-- proof, so downstream importers do not pay for it.
 import TauCeti.RingTheory.Semisimple.Schur
 
 /-!
-# The Wedderburn dimension count
+# The Wedderburn dimension count over an algebraically closed field
 
 Artin--Wedderburn presents a finite-dimensional semisimple algebra `A` over a field `K` as a finite
-product of matrix algebras `∏ᵢ Matₙᵢ(Dᵢ)` over division algebras. This file reads the dimension of
-`A` off such a presentation,
+product of matrix algebras `∏ᵢ Matₙᵢ(Dᵢ)` over division algebras, and
+`TauCeti.finrank_eq_sum_sq_finrank` reads
 
-`finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`,
+`finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`
 
-which over an algebraically closed field, where every `Dᵢ` collapses to the base field, becomes the
-classical `finrank k A = ∑ᵢ nᵢ²`. Applied to a group algebra that last identity is the relation
-`∑ᵢ nᵢ² = |G|` between the degrees of the irreducible representations of a finite group and its
-order; `TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean` derives that special case from
-`TauCeti.finrank_pi_matrix`, which this file generalizes away from the split case.
+off such a presentation, for coefficients `Dᵢ` of any kind. This file specializes that count to an
+algebraically closed base field, where a coefficient division algebra of a block of nonzero size —
+finite-dimensional by `TauCeti.finiteDimensional_of_algEquiv_pi_matrix` — is the base field itself,
+so the count becomes the classical `finrank k A = ∑ᵢ nᵢ²`. A block of size `0` leaves its
+coefficients unconstrained, but contributes `0` to both sides and so needs no such collapse.
+
+Applied to a group algebra that last identity is the relation `∑ᵢ nᵢ² = |G|` between the degrees of
+the irreducible representations of a finite group and its order;
+`TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean` derives that special case from
+`TauCeti.finrank_pi_matrix`, which the count generalizes away from the split case.
 
 Nothing here needs the presentation to come from Artin--Wedderburn: an algebra equivalence
-`A ≃ₐ[K] Π i, Matₙᵢ(Dᵢ)` onto *any* product of matrix algebras is enough, and the coefficients `Dᵢ`
-need not be division algebras except where that is said. What finite-dimensionality of `A` buys is
-that the blocks are then finite-dimensional too, which is
-`TauCeti.finiteDimensional_of_algEquiv_pi_matrix`: no presentation can smuggle in an
-infinite-dimensional coefficient algebra. A block of size `0` is the zero ring whatever its
-coefficients are, so that statement is exactly where the positivity hypothesis `NeZero (d i)` — the
-one Artin--Wedderburn always supplies — is needed.
-
-Two counting consequences close the file: a single block satisfies `nᵢ² ≤ finrank K A`, and, when
-every block is nonzero, there are at most `finrank K A` of them. For a group algebra over a
-splitting field the latter bounds the number of irreducible representations by `|G|`.
+`A ≃ₐ[K] Π i, Matₙᵢ(Dᵢ)` onto *any* product of matrix algebras over division algebras is enough.
 
 ## Main results
 
-* `TauCeti.finiteDimensional_of_algEquiv_pi_matrix`: the coefficient algebras of a presentation of a
-  finite-dimensional algebra are finite-dimensional.
-* `TauCeti.finrank_eq_sum_sq_finrank`: **the dimension count**,
-  `finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`.
 * `TauCeti.finrank_eq_sum_sq_of_isAlgClosed`: over an algebraically closed field the count reads
-  `finrank k A = ∑ᵢ nᵢ²`, because every finite-dimensional division algebra there is the base field;
-  `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split form, which needs no
-  hypothesis on the field.
-* `TauCeti.exists_algEquiv_pi_matrix_divisionRing_finrank` and
-  `TauCeti.exists_algEquiv_pi_matrix_of_isAlgClosed_finrank`: Artin--Wedderburn packaged together
-  with the count.
-* `TauCeti.sq_le_finrank_of_algEquiv_pi_matrix` and
-  `TauCeti.card_le_finrank_of_algEquiv_pi_matrix`: the resulting bounds on a block degree and on the
-  number of blocks.
+  `finrank k A = ∑ᵢ nᵢ²`. `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split
+  form, which needs no hypothesis on the field.
 
 ## References
 
 This implements the Layer 2 target "the dimension count" of the
 [semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
-pinned there as `finrank_eq_sum_sq_finrank` and `finrank_eq_sum_sq_of_isAlgClosed`. See C. W. Curtis
-and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §25, or T. Y. Lam,
+pinned there as `finrank_eq_sum_sq_of_isAlgClosed`; its companion `finrank_eq_sum_sq_finrank`, which
+assumes nothing of the coefficients, is in `TauCeti/Algebra/Matrix/Pi.lean`. See C. W. Curtis and
+I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §25, or T. Y. Lam,
 *A First Course in Noncommutative Rings*, §3.
 -/
 
@@ -81,93 +59,20 @@ public section
 
 namespace TauCeti
 
-universe u v w
-
 open Module (finrank)
 
-variable (K : Type u) [Field K] {ι : Type v} {d : ι → ℕ} {A : Type*} [Ring A] [Algebra K A]
+variable (K : Type*) [Field K] {ι : Type*} [Fintype ι] {d : ι → ℕ} {A : Type*} [Ring A]
+  [Algebra K A] [FiniteDimensional K A]
 
-/-! ### Finite-dimensionality of the blocks -/
-
-section Blocks
-
-variable {D : ι → Type w} [∀ i, Ring (D i)] [∀ i, Algebra K (D i)] [FiniteDimensional K A]
-  (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
-
-include e
-
-/-- A matrix block of a presentation of a finite-dimensional algebra as a product of matrix algebras
-is finite-dimensional: it is a direct factor, hence a linear quotient, of the algebra. -/
-theorem finiteDimensional_matrix_of_algEquiv_pi_matrix (i : ι) :
-    FiniteDimensional K (Matrix (Fin (d i)) (Fin (d i)) (D i)) := by
-  classical
-  have : Module.Finite K (Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
-    Module.Finite.equiv e.toLinearEquiv
-  exact Module.Finite.of_surjective
-    (LinearMap.proj (R := K) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
-    fun x => ⟨Pi.single i x, by simp⟩
-
-/-- The coefficient algebras of a presentation of a finite-dimensional algebra as a product of
-matrix algebras are themselves finite-dimensional, so no such presentation can involve an
-infinite-dimensional division algebra.
-
-The positivity hypothesis `NeZero (d i)` is essential and not an artefact of the proof: a block of
-size `0` is the zero ring whatever its coefficients are, so it constrains `D i` not at all. Every
-Artin--Wedderburn presentation supplies that positivity. -/
-theorem finiteDimensional_of_algEquiv_pi_matrix (i : ι) [NeZero (d i)] :
-    FiniteDimensional K (D i) := by
-  have := finiteDimensional_matrix_of_algEquiv_pi_matrix K e i
-  obtain ⟨j⟩ : Nonempty (Fin (d i)) :=
-    Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
-  exact Module.Finite.of_surjective (Matrix.entryLinearMap K (D i) j j)
-    fun x => ⟨Matrix.of fun _ _ => x, rfl⟩
-
-end Blocks
-
-/-! ### The dimension count -/
-
-section Count
-
-variable [Fintype ι] [FiniteDimensional K A]
-
-section Coefficients
-
-variable {D : ι → Type w} [∀ i, Ring (D i)] [∀ i, Algebra K (D i)]
-
-/-- **The Wedderburn dimension count.** If a finite-dimensional `K`-algebra `A` is presented as a
-finite product `∏ᵢ Matₙᵢ(Dᵢ)` of matrix algebras, then `finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`.
-
-Only the presentation is used: `A` is not assumed semisimple, although by
-`RingEquiv.isSemisimpleRing` it is one as soon as the coefficients `Dᵢ` are division algebras. -/
-theorem finrank_eq_sum_sq_finrank (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
-    finrank K A = ∑ i, d i ^ 2 * finrank K (D i) := by
-  have : ∀ i, Module.Finite K (Matrix (Fin (d i)) (Fin (d i)) (D i)) := fun i =>
-    finiteDimensional_matrix_of_algEquiv_pi_matrix K e i
-  rw [e.toLinearEquiv.finrank_eq, Module.finrank_pi_fintype]
-  refine Finset.sum_congr rfl fun i _ => ?_
-  rw [Module.finrank_matrix, Fintype.card_fin, sq]
-
-end Coefficients
-
-omit [FiniteDimensional K A] in
-/-- **The dimension count for an already split presentation**: if `A` is presented as a product of
-matrix algebras over the base field itself, then `finrank K A = ∑ᵢ nᵢ²`.
-
-No hypothesis on `K` is needed here; algebraic closedness enters
-`TauCeti.finrank_eq_sum_sq_of_isAlgClosed` only to force the coefficients of a presentation to be
-the base field, and here they already are. -/
-theorem finrank_eq_sum_sq_of_algEquiv_pi_matrix
-    (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) K) :
-    finrank K A = ∑ i, d i ^ 2 :=
-  e.toLinearEquiv.finrank_eq.trans (finrank_pi_matrix K d)
-
-/-- **The dimension count over an algebraically closed field.** Every finite-dimensional division
-algebra over an algebraically closed field is the field itself, so the coefficient dimensions in
-`TauCeti.finrank_eq_sum_sq_finrank` all equal `1` and the count reads `finrank k A = ∑ᵢ nᵢ²`.
+/-- **The dimension count over an algebraically closed field.** A finite-dimensional division
+algebra over an algebraically closed field is the field itself, so each block of nonzero size in a
+presentation `A ≃ₐ[K] ∏ᵢ Matₙᵢ(Dᵢ)` has `finrank K Dᵢ = 1` and the count
+`TauCeti.finrank_eq_sum_sq_finrank` reads `finrank k A = ∑ᵢ nᵢ²`. A block of size `0` need not have
+finite-dimensional, let alone split, coefficients, but contributes `0` to both sides.
 
 This is the identity that becomes `∑ᵢ nᵢ² = |G|` for the group algebra of a finite group over a
 splitting field. -/
-theorem finrank_eq_sum_sq_of_isAlgClosed [IsAlgClosed K] {D : ι → Type w}
+theorem finrank_eq_sum_sq_of_isAlgClosed [IsAlgClosed K] {D : ι → Type*}
     [∀ i, DivisionRing (D i)] [∀ i, Algebra K (D i)]
     (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
     finrank K A = ∑ i, d i ^ 2 := by
@@ -179,80 +84,5 @@ theorem finrank_eq_sum_sq_of_isAlgClosed [IsAlgClosed K] {D : ι → Type w}
     have := finiteDimensional_of_algEquiv_pi_matrix K e i
     obtain ⟨f⟩ := nonempty_algEquiv_self_of_finiteDimensional_divisionRing (k := K) (D := D i)
     rw [f.toLinearEquiv.finrank_eq, Module.finrank_self, mul_one]
-
-end Count
-
-/-! ### Artin--Wedderburn with the count -/
-
-section Existence
-
-variable (A : Type u) [Ring A] [Algebra K A] [IsSemisimpleRing A] [FiniteDimensional K A]
-
-/-- **Artin--Wedderburn with the dimension count.** A finite-dimensional semisimple `K`-algebra is a
-finite product of matrix algebras of positive size over finite-dimensional division `K`-algebras,
-and its dimension is `∑ᵢ nᵢ² · finrank K Dᵢ`. -/
-theorem exists_algEquiv_pi_matrix_divisionRing_finrank :
-    ∃ (n : ℕ) (D : Fin n → Type u) (d : Fin n → ℕ) (_ : ∀ i, DivisionRing (D i))
-      (_ : ∀ i, Algebra K (D i)) (_ : ∀ i, FiniteDimensional K (D i)), (∀ i, NeZero (d i)) ∧
-      Nonempty (A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) ∧
-      finrank K A = ∑ i, d i ^ 2 * finrank K (D i) := by
-  obtain ⟨n, D, d, _, _, _, hd, ⟨e⟩⟩ :=
-    IsSemisimpleRing.exists_algEquiv_pi_matrix_divisionRing_finite K A
-  exact ⟨n, D, d, inferInstance, inferInstance, inferInstance, hd, ⟨e⟩,
-    finrank_eq_sum_sq_finrank K e⟩
-
-/-- **Artin--Wedderburn with the dimension count, over an algebraically closed field.** A
-finite-dimensional semisimple algebra over an algebraically closed field is a finite product of
-matrix algebras of positive size over that field, and its dimension is `∑ᵢ nᵢ²`. -/
-theorem exists_algEquiv_pi_matrix_of_isAlgClosed_finrank [IsAlgClosed K] :
-    ∃ (n : ℕ) (d : Fin n → ℕ), (∀ i, NeZero (d i)) ∧
-      Nonempty (A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) K) ∧
-      finrank K A = ∑ i, d i ^ 2 := by
-  obtain ⟨n, d, hd, ⟨e⟩⟩ := IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed K A
-  exact ⟨n, d, hd, ⟨e⟩, finrank_eq_sum_sq_of_algEquiv_pi_matrix K e⟩
-
-end Existence
-
-/-! ### Bounds read off the count -/
-
-section Bounds
-
-variable [Finite ι] [FiniteDimensional K A] {D : ι → Type w} [∀ i, Ring (D i)]
-  [∀ i, Algebra K (D i)] [∀ i, Nontrivial (D i)]
-  (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
-
-include e
-
-/-- **The degree of a block is bounded by the dimension**: `nᵢ² ≤ finrank K A` for every block of a
-presentation of a finite-dimensional algebra by matrix algebras over nontrivial coefficients. -/
-theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) : d i ^ 2 ≤ finrank K A := by
-  have : Fintype ι := Fintype.ofFinite ι
-  rcases eq_or_ne (d i) 0 with h | h
-  · simp [h]
-  · have : NeZero (d i) := ⟨h⟩
-    have := finiteDimensional_of_algEquiv_pi_matrix K e i
-    calc d i ^ 2 ≤ d i ^ 2 * finrank K (D i) :=
-          Nat.le_mul_of_pos_right _ (Module.finrank_pos (R := K) (M := D i))
-      _ ≤ ∑ j, d j ^ 2 * finrank K (D j) :=
-          Finset.single_le_sum (f := fun j => d j ^ 2 * finrank K (D j))
-            (fun _ _ => Nat.zero_le _) (Finset.mem_univ i)
-      _ = finrank K A := (finrank_eq_sum_sq_finrank K e).symm
-
-/-- **The number of blocks is bounded by the dimension**: a finite-dimensional algebra presented by
-nonzero matrix blocks over nontrivial coefficients has at most `finrank K A` of them.
-
-For the group algebra of a finite group over a splitting field this bounds the number of irreducible
-representations by the order of the group. -/
-theorem card_le_finrank_of_algEquiv_pi_matrix [∀ i, NeZero (d i)] :
-    Nat.card ι ≤ finrank K A := by
-  have : Fintype ι := Fintype.ofFinite ι
-  rw [finrank_eq_sum_sq_finrank K e, Nat.card_eq_fintype_card, ← Finset.card_univ,
-    Finset.card_eq_sum_ones]
-  refine Finset.sum_le_sum fun i _ => ?_
-  have := finiteDimensional_of_algEquiv_pi_matrix K e i
-  exact Nat.one_le_iff_ne_zero.mpr <| Nat.mul_ne_zero (pow_ne_zero 2 (NeZero.ne (d i)))
-    (Module.finrank_pos (R := K) (M := D i)).ne'
-
-end Bounds
 
 end TauCeti

--- a/TauCeti/RingTheory/Semisimple/DimensionCount.lean
+++ b/TauCeti/RingTheory/Semisimple/DimensionCount.lean
@@ -42,8 +42,7 @@ Nothing here needs the presentation to come from Artin--Wedderburn: an algebra e
 ## Main results
 
 * `TauCeti.finrank_eq_sum_sq_of_isAlgClosed`: over an algebraically closed field the count reads
-  `finrank k A = ∑ᵢ nᵢ²`. `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split
-  form, which needs no hypothesis on the field.
+  `finrank k A = ∑ᵢ nᵢ²`.
 
 ## References
 

--- a/TauCeti/RingTheory/Semisimple/DimensionCount.lean
+++ b/TauCeti/RingTheory/Semisimple/DimensionCount.lean
@@ -1,0 +1,258 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- `TauCeti.Algebra.Matrix.Pi` is imported publicly: it supplies `TauCeti.finrank_pi_matrix`, the
+-- already split case of the count proved below, and it re-exports
+-- `Mathlib.LinearAlgebra.Dimension.Constructions`, hence `Module.finrank` and the dimension
+-- formulas `Module.finrank_pi_fintype` and `Module.finrank_matrix` that the proofs run on, as well
+-- as the `Matrix` occurring in every statement here.
+public import TauCeti.Algebra.Matrix.Pi
+-- `IsSemisimpleRing` and Artin--Wedderburn appear in the existence statements below.
+public import Mathlib.RingTheory.SimpleModule.WedderburnArtin
+-- `IsAlgClosed` appears in the hypotheses of the split forms below.
+public import Mathlib.FieldTheory.IsAlgClosed.Basic
+-- Non-public: `TauCeti.nonempty_algEquiv_self_of_finiteDimensional_divisionRing` (the collapse of a
+-- finite-dimensional division algebra over an algebraically closed field) and Mathlib's
+-- algebraically closed form of Artin--Wedderburn are used only inside proofs, and
+-- `Matrix.entryLinearMap` only to exhibit a coefficient algebra as a quotient of its matrix block,
+-- so downstream importers do not pay for any of them.
+import Mathlib.Data.Matrix.Basic
+import Mathlib.RingTheory.SimpleModule.IsAlgClosed
+import TauCeti.RingTheory.Semisimple.Schur
+
+/-!
+# The Wedderburn dimension count
+
+Artin--Wedderburn presents a finite-dimensional semisimple algebra `A` over a field `K` as a finite
+product of matrix algebras `∏ᵢ Matₙᵢ(Dᵢ)` over division algebras. This file reads the dimension of
+`A` off such a presentation,
+
+`finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`,
+
+which over an algebraically closed field, where every `Dᵢ` collapses to the base field, becomes the
+classical `finrank k A = ∑ᵢ nᵢ²`. Applied to a group algebra that last identity is the relation
+`∑ᵢ nᵢ² = |G|` between the degrees of the irreducible representations of a finite group and its
+order; `TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean` derives that special case from
+`TauCeti.finrank_pi_matrix`, which this file generalizes away from the split case.
+
+Nothing here needs the presentation to come from Artin--Wedderburn: an algebra equivalence
+`A ≃ₐ[K] Π i, Matₙᵢ(Dᵢ)` onto *any* product of matrix algebras is enough, and the coefficients `Dᵢ`
+need not be division algebras except where that is said. What finite-dimensionality of `A` buys is
+that the blocks are then finite-dimensional too, which is
+`TauCeti.finiteDimensional_of_algEquiv_pi_matrix`: no presentation can smuggle in an
+infinite-dimensional coefficient algebra. A block of size `0` is the zero ring whatever its
+coefficients are, so that statement is exactly where the positivity hypothesis `NeZero (d i)` — the
+one Artin--Wedderburn always supplies — is needed.
+
+Two counting consequences close the file: a single block satisfies `nᵢ² ≤ finrank K A`, and, when
+every block is nonzero, there are at most `finrank K A` of them. For a group algebra over a
+splitting field the latter bounds the number of irreducible representations by `|G|`.
+
+## Main results
+
+* `TauCeti.finiteDimensional_of_algEquiv_pi_matrix`: the coefficient algebras of a presentation of a
+  finite-dimensional algebra are finite-dimensional.
+* `TauCeti.finrank_eq_sum_sq_finrank`: **the dimension count**,
+  `finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`.
+* `TauCeti.finrank_eq_sum_sq_of_isAlgClosed`: over an algebraically closed field the count reads
+  `finrank k A = ∑ᵢ nᵢ²`, because every finite-dimensional division algebra there is the base field;
+  `TauCeti.finrank_eq_sum_sq_of_algEquiv_pi_matrix` is the already split form, which needs no
+  hypothesis on the field.
+* `TauCeti.exists_algEquiv_pi_matrix_divisionRing_finrank` and
+  `TauCeti.exists_algEquiv_pi_matrix_of_isAlgClosed_finrank`: Artin--Wedderburn packaged together
+  with the count.
+* `TauCeti.sq_le_finrank_of_algEquiv_pi_matrix` and
+  `TauCeti.card_le_finrank_of_algEquiv_pi_matrix`: the resulting bounds on a block degree and on the
+  number of blocks.
+
+## References
+
+This implements the Layer 2 target "the dimension count" of the
+[semisimple algebras roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md),
+pinned there as `finrank_eq_sum_sq_finrank` and `finrank_eq_sum_sq_of_isAlgClosed`. See C. W. Curtis
+and I. Reiner, *Representation Theory of Finite Groups and Associative Algebras*, §25, or T. Y. Lam,
+*A First Course in Noncommutative Rings*, §3.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v w
+
+open Module (finrank)
+
+variable (K : Type u) [Field K] {ι : Type v} {d : ι → ℕ} {A : Type*} [Ring A] [Algebra K A]
+
+/-! ### Finite-dimensionality of the blocks -/
+
+section Blocks
+
+variable {D : ι → Type w} [∀ i, Ring (D i)] [∀ i, Algebra K (D i)] [FiniteDimensional K A]
+  (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
+
+include e
+
+/-- A matrix block of a presentation of a finite-dimensional algebra as a product of matrix algebras
+is finite-dimensional: it is a direct factor, hence a linear quotient, of the algebra. -/
+theorem finiteDimensional_matrix_of_algEquiv_pi_matrix (i : ι) :
+    FiniteDimensional K (Matrix (Fin (d i)) (Fin (d i)) (D i)) := by
+  classical
+  have : Module.Finite K (Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :=
+    Module.Finite.equiv e.toLinearEquiv
+  exact Module.Finite.of_surjective
+    (LinearMap.proj (R := K) (φ := fun j => Matrix (Fin (d j)) (Fin (d j)) (D j)) i)
+    fun x => ⟨Pi.single i x, by simp⟩
+
+/-- The coefficient algebras of a presentation of a finite-dimensional algebra as a product of
+matrix algebras are themselves finite-dimensional, so no such presentation can involve an
+infinite-dimensional division algebra.
+
+The positivity hypothesis `NeZero (d i)` is essential and not an artefact of the proof: a block of
+size `0` is the zero ring whatever its coefficients are, so it constrains `D i` not at all. Every
+Artin--Wedderburn presentation supplies that positivity. -/
+theorem finiteDimensional_of_algEquiv_pi_matrix (i : ι) [NeZero (d i)] :
+    FiniteDimensional K (D i) := by
+  have := finiteDimensional_matrix_of_algEquiv_pi_matrix K e i
+  obtain ⟨j⟩ : Nonempty (Fin (d i)) :=
+    Fin.pos_iff_nonempty.mp (Nat.pos_of_ne_zero (NeZero.ne (d i)))
+  exact Module.Finite.of_surjective (Matrix.entryLinearMap K (D i) j j)
+    fun x => ⟨Matrix.of fun _ _ => x, rfl⟩
+
+end Blocks
+
+/-! ### The dimension count -/
+
+section Count
+
+variable [Fintype ι] [FiniteDimensional K A]
+
+section Coefficients
+
+variable {D : ι → Type w} [∀ i, Ring (D i)] [∀ i, Algebra K (D i)]
+
+/-- **The Wedderburn dimension count.** If a finite-dimensional `K`-algebra `A` is presented as a
+finite product `∏ᵢ Matₙᵢ(Dᵢ)` of matrix algebras, then `finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`.
+
+Only the presentation is used: `A` is not assumed semisimple, although by
+`RingEquiv.isSemisimpleRing` it is one as soon as the coefficients `Dᵢ` are division algebras. -/
+theorem finrank_eq_sum_sq_finrank (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
+    finrank K A = ∑ i, d i ^ 2 * finrank K (D i) := by
+  have : ∀ i, Module.Finite K (Matrix (Fin (d i)) (Fin (d i)) (D i)) := fun i =>
+    finiteDimensional_matrix_of_algEquiv_pi_matrix K e i
+  rw [e.toLinearEquiv.finrank_eq, Module.finrank_pi_fintype]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rw [Module.finrank_matrix, Fintype.card_fin, sq]
+
+end Coefficients
+
+omit [FiniteDimensional K A] in
+/-- **The dimension count for an already split presentation**: if `A` is presented as a product of
+matrix algebras over the base field itself, then `finrank K A = ∑ᵢ nᵢ²`.
+
+No hypothesis on `K` is needed here; algebraic closedness enters
+`TauCeti.finrank_eq_sum_sq_of_isAlgClosed` only to force the coefficients of a presentation to be
+the base field, and here they already are. -/
+theorem finrank_eq_sum_sq_of_algEquiv_pi_matrix
+    (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) K) :
+    finrank K A = ∑ i, d i ^ 2 :=
+  e.toLinearEquiv.finrank_eq.trans (finrank_pi_matrix K d)
+
+/-- **The dimension count over an algebraically closed field.** Every finite-dimensional division
+algebra over an algebraically closed field is the field itself, so the coefficient dimensions in
+`TauCeti.finrank_eq_sum_sq_finrank` all equal `1` and the count reads `finrank k A = ∑ᵢ nᵢ²`.
+
+This is the identity that becomes `∑ᵢ nᵢ² = |G|` for the group algebra of a finite group over a
+splitting field. -/
+theorem finrank_eq_sum_sq_of_isAlgClosed [IsAlgClosed K] {D : ι → Type w}
+    [∀ i, DivisionRing (D i)] [∀ i, Algebra K (D i)]
+    (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) :
+    finrank K A = ∑ i, d i ^ 2 := by
+  rw [finrank_eq_sum_sq_finrank K e]
+  refine Finset.sum_congr rfl fun i _ => ?_
+  rcases eq_or_ne (d i) 0 with h | h
+  · simp [h]
+  · have : NeZero (d i) := ⟨h⟩
+    have := finiteDimensional_of_algEquiv_pi_matrix K e i
+    obtain ⟨f⟩ := nonempty_algEquiv_self_of_finiteDimensional_divisionRing (k := K) (D := D i)
+    rw [f.toLinearEquiv.finrank_eq, Module.finrank_self, mul_one]
+
+end Count
+
+/-! ### Artin--Wedderburn with the count -/
+
+section Existence
+
+variable (A : Type u) [Ring A] [Algebra K A] [IsSemisimpleRing A] [FiniteDimensional K A]
+
+/-- **Artin--Wedderburn with the dimension count.** A finite-dimensional semisimple `K`-algebra is a
+finite product of matrix algebras of positive size over finite-dimensional division `K`-algebras,
+and its dimension is `∑ᵢ nᵢ² · finrank K Dᵢ`. -/
+theorem exists_algEquiv_pi_matrix_divisionRing_finrank :
+    ∃ (n : ℕ) (D : Fin n → Type u) (d : Fin n → ℕ) (_ : ∀ i, DivisionRing (D i))
+      (_ : ∀ i, Algebra K (D i)) (_ : ∀ i, FiniteDimensional K (D i)), (∀ i, NeZero (d i)) ∧
+      Nonempty (A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i)) ∧
+      finrank K A = ∑ i, d i ^ 2 * finrank K (D i) := by
+  obtain ⟨n, D, d, _, _, _, hd, ⟨e⟩⟩ :=
+    IsSemisimpleRing.exists_algEquiv_pi_matrix_divisionRing_finite K A
+  exact ⟨n, D, d, inferInstance, inferInstance, inferInstance, hd, ⟨e⟩,
+    finrank_eq_sum_sq_finrank K e⟩
+
+/-- **Artin--Wedderburn with the dimension count, over an algebraically closed field.** A
+finite-dimensional semisimple algebra over an algebraically closed field is a finite product of
+matrix algebras of positive size over that field, and its dimension is `∑ᵢ nᵢ²`. -/
+theorem exists_algEquiv_pi_matrix_of_isAlgClosed_finrank [IsAlgClosed K] :
+    ∃ (n : ℕ) (d : Fin n → ℕ), (∀ i, NeZero (d i)) ∧
+      Nonempty (A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) K) ∧
+      finrank K A = ∑ i, d i ^ 2 := by
+  obtain ⟨n, d, hd, ⟨e⟩⟩ := IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed K A
+  exact ⟨n, d, hd, ⟨e⟩, finrank_eq_sum_sq_of_algEquiv_pi_matrix K e⟩
+
+end Existence
+
+/-! ### Bounds read off the count -/
+
+section Bounds
+
+variable [Finite ι] [FiniteDimensional K A] {D : ι → Type w} [∀ i, Ring (D i)]
+  [∀ i, Algebra K (D i)] [∀ i, Nontrivial (D i)]
+  (e : A ≃ₐ[K] Π i, Matrix (Fin (d i)) (Fin (d i)) (D i))
+
+include e
+
+/-- **The degree of a block is bounded by the dimension**: `nᵢ² ≤ finrank K A` for every block of a
+presentation of a finite-dimensional algebra by matrix algebras over nontrivial coefficients. -/
+theorem sq_le_finrank_of_algEquiv_pi_matrix (i : ι) : d i ^ 2 ≤ finrank K A := by
+  have : Fintype ι := Fintype.ofFinite ι
+  rcases eq_or_ne (d i) 0 with h | h
+  · simp [h]
+  · have : NeZero (d i) := ⟨h⟩
+    have := finiteDimensional_of_algEquiv_pi_matrix K e i
+    calc d i ^ 2 ≤ d i ^ 2 * finrank K (D i) :=
+          Nat.le_mul_of_pos_right _ (Module.finrank_pos (R := K) (M := D i))
+      _ ≤ ∑ j, d j ^ 2 * finrank K (D j) :=
+          Finset.single_le_sum (f := fun j => d j ^ 2 * finrank K (D j))
+            (fun _ _ => Nat.zero_le _) (Finset.mem_univ i)
+      _ = finrank K A := (finrank_eq_sum_sq_finrank K e).symm
+
+/-- **The number of blocks is bounded by the dimension**: a finite-dimensional algebra presented by
+nonzero matrix blocks over nontrivial coefficients has at most `finrank K A` of them.
+
+For the group algebra of a finite group over a splitting field this bounds the number of irreducible
+representations by the order of the group. -/
+theorem card_le_finrank_of_algEquiv_pi_matrix [∀ i, NeZero (d i)] :
+    Nat.card ι ≤ finrank K A := by
+  have : Fintype ι := Fintype.ofFinite ι
+  rw [finrank_eq_sum_sq_finrank K e, Nat.card_eq_fintype_card, ← Finset.card_univ,
+    Finset.card_eq_sum_ones]
+  refine Finset.sum_le_sum fun i _ => ?_
+  have := finiteDimensional_of_algEquiv_pi_matrix K e i
+  exact Nat.one_le_iff_ne_zero.mpr <| Nat.mul_ne_zero (pow_ne_zero 2 (NeZero.ne (d i)))
+    (Module.finrank_pos (R := K) (M := D i)).ne'
+
+end Bounds
+
+end TauCeti


### PR DESCRIPTION
This PR proves the Wedderburn dimension count. If a finite-dimensional algebra `A` over a field `K`
is presented as a finite product of matrix algebras `∏ᵢ Matₙᵢ(Dᵢ)`, then
`finrank K A = ∑ᵢ nᵢ² · finrank K Dᵢ`; over an algebraically closed field, where every
finite-dimensional division algebra collapses to the base field, this reads `finrank k A = ∑ᵢ nᵢ²`.
That last identity is the one a group algebra turns into `∑ᵢ nᵢ² = |G|`.

The target is the Layer 2 bullet "The dimension count" of
`TauCetiRoadmap/RepresentationTheory/SemisimpleAlgebras/README.md` ("State this for the **algebra**
Wedderburn presentation, where each `Dᵢ` carries a compatible `K`-algebra structure (and is
finite-dimensional over `K`, forced by `FiniteDimensional K A`) ... `finrank K A = ∑ᵢ (nᵢ)² ·
finrank K Dᵢ`, and over `[IsAlgClosed k]` ... `finrank k A = ∑ᵢ (nᵢ)²`"), pinned in that roadmap's
`Suggested.lean` as `finrank_eq_sum_sq_finrank` and `finrank_eq_sum_sq_of_isAlgClosed`. It was the
last unbuilt piece of the numerical half of Layer 2: the split case over the base field is already in
the repo as `TauCeti.finrank_pi_matrix` (`TauCeti/Algebra/Matrix/Pi.lean`), which
`TauCeti/RepresentationTheory/CharacterTable/Wedderburn.lean` uses for `∑ᵢ nᵢ² = |G|`, but nothing
covered coefficients other than `K` itself.

Nothing in the count needs semisimplicity, division-algebra coefficients, or Artin--Wedderburn
itself: an algebra equivalence onto *any* finite product of matrix algebras is enough. So the
general half joins the existing product-of-matrix-algebras material in `TauCeti/Algebra/Matrix/Pi.lean`,
and only the algebraically closed specialization needs a new file,
`TauCeti/RingTheory/Semisimple/DimensionCount.lean` (87 lines).

Added to `TauCeti/Algebra/Matrix/Pi.lean`:

* `TauCeti.finiteDimensional_of_algEquiv_pi_matrix` — the finite-dimensionality the README puts in
  parentheses and which the count needs but no existing declaration states: the coefficient algebra
  of a block is finite-dimensional, obtained by exhibiting the block as a linear quotient of `A` and
  `Dᵢ` as a linear quotient of the block through an entry map, so no presentation can smuggle in an
  infinite-dimensional division algebra. Its `NeZero (d i)` is essential rather than incidental — a
  block of size `0` is the zero ring whatever its coefficients are, so it constrains `Dᵢ` not at all.
* `TauCeti.finrank_eq_sum_sq_finrank` — the count itself, which by contrast needs no positivity,
  because a zero-size block contributes `0` to both sides.
* `TauCeti.sq_le_finrank_of_algEquiv_pi_matrix` — the bound `nᵢ² ≤ finrank K A` on a single block
  degree, read off the surjection of `A` onto that block alone, so neither the other coefficients nor
  finiteness of the index take part.
* `TauCeti.card_le_finrank_of_algEquiv_pi_matrix` — the bound `Nat.card ι ≤ finrank K A` on the
  number of blocks; for a group algebra over a splitting field, the number of irreducible
  representations by `|G|`.

Added in `TauCeti/RingTheory/Semisimple/DimensionCount.lean`:

* `TauCeti.finrank_eq_sum_sq_of_isAlgClosed` — the algebraically closed form, which consumes the
  existing `TauCeti.nonempty_algEquiv_self_of_finiteDimensional_divisionRing` of
  `TauCeti/RingTheory/Semisimple/Schur.lean` to see each `finrank K Dᵢ = 1`.

Two of the signatures are deliberately more general than the pinned ones. `finrank_eq_sum_sq_finrank`
drops `[IsSemisimpleRing A]`, which the proof never uses (semisimplicity is a consequence of having
division-algebra coefficients, not a hypothesis of the arithmetic), indexes the product by an
arbitrary `Fintype` rather than `Fin n`, and allows arbitrary coefficient rings `Dᵢ`.
`finrank_eq_sum_sq_of_isAlgClosed` is stated for division-algebra coefficients, which is what makes
algebraic closedness do work.

The PR adds no packaging of Mathlib's Artin--Wedderburn existence theorems together with the count:
such a conjunction carries no content beyond destructing
`IsSemisimpleRing.exists_algEquiv_pi_matrix_divisionRing_finite` (or
`IsSemisimpleRing.exists_algEquiv_pi_matrix_of_isAlgClosed`) and applying the count to the resulting
equivalence, so consumers do that directly.

Mathlib supplies `Module.finrank_pi_fintype`, `Module.finrank_matrix`, `Matrix.entryLinearMap`,
`LinearMap.proj_surjective`, `Module.Finite.of_surjective`, and
`LinearMap.finrank_le_finrank_of_surjective`; all are consumed, none is reproved. No Mathlib source
was vendored into this repository and no declaration was copied.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finrank-eq-sum-sq-finrank"}-->

🤖 Prepared with Claude Code
