### PR TITLE
feat(ModularForms): isolate the fundamental-domain zeros in an open neighbourhood

### DIFF
--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -47,18 +47,19 @@ any point of the upper half-plane. -/
 lemma not_accPt_zeros_comp_ofComplex {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
     {x : ℂ} (hx : 0 < x.im) :
     ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) := by
-  intro hacc
-  rw [accPt_iff_nhds] at hacc
-  refine hg0 (UpperHalfPlane.eq_zero_of_frequently hg (τ := ⟨x, hx⟩) ?_)
-  rw [Filter.frequently_iff]
-  intro V hV
-  obtain ⟨O, hO_open, hτO, hOV⟩ := mem_nhdsWithin.mp hV
-  obtain ⟨y, ⟨hyO, hyim, hyzero⟩, hyne⟩ :=
-    hacc _ ((UpperHalfPlane.isOpenEmbedding_coe.isOpenMap O hO_open).mem_nhds
-      (Set.mem_image_of_mem _ hτO))
-  obtain ⟨τ', hτ'O, rfl⟩ := hyO
-  refine ⟨τ', hOV ⟨hτ'O, fun hmem => hyne (congrArg UpperHalfPlane.coe hmem)⟩, ?_⟩
-  simpa [Function.comp, ofComplex_apply] using hyzero
+  have hall : AnalyticOnNhd ℂ (g ∘ ofComplex) {z : ℂ | 0 < z.im} := fun w hw =>
+    analyticAt_comp_ofComplex hg hw
+  obtain ⟨τ, hτ⟩ := Function.ne_iff.mp hg0
+  have hcod := hall.preimage_zero_mem_codiscreteWithin (x := (τ : ℂ))
+    (by simpa [Function.comp, ofComplex_apply] using hτ) τ.2
+    ⟨⟨Complex.I, by simp⟩, (convex_halfSpace_im_gt 0).isPreconnected⟩
+  have hne := mem_codiscreteWithin_accPt.mp hcod x hx
+  have hset : {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} =
+      {z : ℂ | 0 < z.im} \ (g ∘ ofComplex) ⁻¹' {0}ᶜ := by
+    ext z
+    simp only [Set.mem_ofPred_eq, Set.mem_sdiff, Set.mem_preimage, Set.mem_compl_iff,
+      Set.mem_singleton_iff, not_not]
+  rwa [hset]
 
 /-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
 containing no zeros of the function's complex extension beyond its own. -/
@@ -66,17 +67,9 @@ lemma exists_isOpen_zeros_inter {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
     {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
     ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
       {z ∈ U | (g ∘ ofComplex) z = 0} = {z ∈ K | (g ∘ ofComplex) z = 0} := by
-  have hnc : ∀ x ∈ K, x ∉ closure ({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) := by
-    intro x hx hxc
-    have hx_notin : x ∉ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K := fun h => h.2 hx
-    have hcl : ClusterPt x (Filter.principal
-        (({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) \ {x})) := by
-      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
-    exact not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
-      ((accPt_principal_iff_clusterPt.mpr hcl).mono
-        (Filter.principal_mono.mpr Set.sdiff_subset))
-  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_notMem_closure
-    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) isOpen_upperHalfPlaneSet hK hnc
+  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_not_accPt
+    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) isOpen_upperHalfPlaneSet hK
+    fun x hx => not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
   refine ⟨U, hUo, hKU, hUV, ?_⟩
   have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
       {z ∈ W | (g ∘ ofComplex) z = 0} =

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -6,7 +6,6 @@ module
 
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 
-import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
 import TauCeti.Topology.DiscreteSeparation
 
 /-!

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/Manifold.lean
@@ -6,6 +6,9 @@ module
 
 public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
 
+import Mathlib.Analysis.Complex.UpperHalfPlane.Topology
+import TauCeti.Topology.DiscreteSeparation
+
 /-!
 # Analyticity through `ofComplex`
 
@@ -15,6 +18,9 @@ analytic at every point of the open upper half-plane.
 ## Main declarations
 
 * `TauCeti.UpperHalfPlane.analyticAt_comp_ofComplex`.
+* `TauCeti.UpperHalfPlane.not_accPt_zeros_comp_ofComplex` and
+  `TauCeti.UpperHalfPlane.exists_isOpen_zeros_inter` — a subset's zeros isolate in an
+  open neighbourhood.
 
 ## References
 
@@ -36,6 +42,50 @@ lemma analyticAt_comp_ofComplex {f : ℍ → ℂ} (hf : MDiff f) {w : ℂ} (hw :
     AnalyticAt ℂ (f ∘ ofComplex) w :=
   (UpperHalfPlane.mdifferentiable_iff.mp hf).analyticAt
     (isOpen_upperHalfPlaneSet.mem_nhds hw)
+
+/-- The zeros of a nonzero holomorphic function's complex extension do not accumulate at
+any point of the upper half-plane. -/
+lemma not_accPt_zeros_comp_ofComplex {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
+    {x : ℂ} (hx : 0 < x.im) :
+    ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) := by
+  intro hacc
+  rw [accPt_iff_nhds] at hacc
+  refine hg0 (UpperHalfPlane.eq_zero_of_frequently hg (τ := ⟨x, hx⟩) ?_)
+  rw [Filter.frequently_iff]
+  intro V hV
+  obtain ⟨O, hO_open, hτO, hOV⟩ := mem_nhdsWithin.mp hV
+  obtain ⟨y, ⟨hyO, hyim, hyzero⟩, hyne⟩ :=
+    hacc _ ((UpperHalfPlane.isOpenEmbedding_coe.isOpenMap O hO_open).mem_nhds
+      (Set.mem_image_of_mem _ hτO))
+  obtain ⟨τ', hτ'O, rfl⟩ := hyO
+  refine ⟨τ', hOV ⟨hτ'O, fun hmem => hyne (congrArg UpperHalfPlane.coe hmem)⟩, ?_⟩
+  simpa [Function.comp, ofComplex_apply] using hyzero
+
+/-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
+containing no zeros of the function's complex extension beyond its own. -/
+lemma exists_isOpen_zeros_inter {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
+    {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
+    ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
+      {z ∈ U | (g ∘ ofComplex) z = 0} = {z ∈ K | (g ∘ ofComplex) z = 0} := by
+  have hnc : ∀ x ∈ K, x ∉ closure ({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) := by
+    intro x hx hxc
+    have hx_notin : x ∉ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K := fun h => h.2 hx
+    have hcl : ClusterPt x (Filter.principal
+        (({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) \ {x})) := by
+      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
+    exact not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
+      ((accPt_principal_iff_clusterPt.mpr hcl).mono
+        (Filter.principal_mono.mpr Set.sdiff_subset))
+  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_notMem_closure
+    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) isOpen_upperHalfPlaneSet hK hnc
+  refine ⟨U, hUo, hKU, hUV, ?_⟩
+  have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
+      {z ∈ W | (g ∘ ofComplex) z = 0} =
+        W ∩ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} := by
+    intro W hW
+    ext z
+    exact ⟨fun hz => ⟨hz.1, hW hz.1, hz.2⟩, fun hz => ⟨hz.1, hz.2.2⟩⟩
+  rw [hmassage hUV, hmassage hK, hUZ]
 
 end TauCeti.UpperHalfPlane
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -34,7 +34,7 @@ public noncomputable section
 
 open Complex Filter Metric Set UpperHalfPlane TauCeti.UpperHalfPlane
 
-open scoped Manifold ModularForm MatrixGroups Modular Topology
+open scoped ModularForm MatrixGroups Modular Topology
 
 namespace TauCeti
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -110,9 +110,17 @@ lemma exists_isOpen_zeros_inter {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
     {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
     ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
       {z ∈ U | (g ∘ ofComplex) z = 0} = {z ∈ K | (g ∘ ofComplex) z = 0} := by
-  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_not_accPt
-    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0})
-    isOpen_upperHalfPlaneSet hK fun x hx => not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
+  have hnc : ∀ x ∈ K, x ∉ closure ({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) := by
+    intro x hx hxc
+    have hx_notin : x ∉ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K := fun h => h.2 hx
+    have hcl : ClusterPt x (Filter.principal
+        (({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) \ {x})) := by
+      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
+    exact not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
+      ((accPt_principal_iff_clusterPt.mpr hcl).mono
+        (Filter.principal_mono.mpr Set.sdiff_subset))
+  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_notMem_closure
+    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) isOpen_upperHalfPlaneSet hK hnc
   refine ⟨U, hUo, hKU, hUV, ?_⟩
   have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
       {z ∈ W | (g ∘ ofComplex) z = 0} =

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -8,9 +8,6 @@ public import Mathlib.NumberTheory.Modular
 public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
 
-import Mathlib.Analysis.Analytic.Uniqueness
-import Mathlib.Analysis.Complex.Convex
-import TauCeti.Topology.DiscreteSeparation
 
 /-!
 # Finite zeros of a level-one modular form in the fundamental domain
@@ -26,10 +23,6 @@ finite-support input to the valence formula.
 * `TauCeti.ModularForm.exists_height_nonvanishing`: a nonzero form does not vanish at
   points of imaginary part above some height.
 * `TauCeti.ModularForm.finite_zeros_in_fd`: finiteness of the nonzero-order points in `𝒟`.
-* `TauCeti.ModularForm.not_accPt_zeros_comp_ofComplex`: the extension's zeros do not
-  accumulate in the upper half-plane.
-* `TauCeti.ModularForm.exists_isOpen_zeros_inter`: an open neighbourhood isolating a
-  subset's zeros.
 
 ## References
 
@@ -88,47 +81,6 @@ lemma finite_zeros_in_fd [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → �
     MeromorphicOn.divisor_apply h_mero hpK]
   intro h0
   exact hp_ord (by rwa [orderOfVanishingAt_def])
-
-/-- The zeros of a nonzero holomorphic function's complex extension do not accumulate at
-any point of the upper half-plane. -/
-lemma not_accPt_zeros_comp_ofComplex {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
-    {x : ℂ} (hx : 0 < x.im) :
-    ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) := by
-  intro hacc
-  have hall : AnalyticOnNhd ℂ (g ∘ ofComplex) {z : ℂ | 0 < z.im} := fun w hw =>
-    analyticAt_comp_ofComplex hg hw
-  rw [accPt_iff_frequently_nhdsNE] at hacc
-  have h0 := hall.eqOn_zero_of_preconnected_of_frequently_eq_zero
-    (convex_halfSpace_im_gt 0).isPreconnected hx (hacc.mono fun y hy => hy.2)
-  refine hg0 (funext fun p => ?_)
-  have := h0 (Set.mem_ofPred_eq ▸ p.2 : (p : ℂ) ∈ {z : ℂ | 0 < z.im})
-  simpa [Function.comp, ofComplex_apply] using this
-
-/-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
-containing no zeros of the form's complex extension beyond its own. -/
-lemma exists_isOpen_zeros_inter {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
-    {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
-    ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
-      {z ∈ U | (g ∘ ofComplex) z = 0} = {z ∈ K | (g ∘ ofComplex) z = 0} := by
-  have hnc : ∀ x ∈ K, x ∉ closure ({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) := by
-    intro x hx hxc
-    have hx_notin : x ∉ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K := fun h => h.2 hx
-    have hcl : ClusterPt x (Filter.principal
-        (({z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} \ K) \ {x})) := by
-      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
-    exact not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
-      ((accPt_principal_iff_clusterPt.mpr hcl).mono
-        (Filter.principal_mono.mpr Set.sdiff_subset))
-  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_notMem_closure
-    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) isOpen_upperHalfPlaneSet hK hnc
-  refine ⟨U, hUo, hKU, hUV, ?_⟩
-  have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
-      {z ∈ W | (g ∘ ofComplex) z = 0} =
-        W ∩ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} := by
-    intro W hW
-    ext z
-    exact ⟨fun hz => ⟨hz.1, hW hz.1, hz.2⟩, fun hz => ⟨hz.1, hz.2.2⟩⟩
-  rw [hmassage hUV, hmassage hK, hUZ]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -26,6 +26,10 @@ finite-support input to the valence formula.
 * `TauCeti.ModularForm.exists_height_nonvanishing`: a nonzero form does not vanish at
   points of imaginary part above some height.
 * `TauCeti.ModularForm.finite_zeros_in_fd`: finiteness of the nonzero-order points in `𝒟`.
+* `TauCeti.ModularForm.not_accPt_zeros_comp_ofComplex`: the extension's zeros do not
+  accumulate in the upper half-plane.
+* `TauCeti.ModularForm.exists_isOpen_zeros_inter`: an open neighbourhood isolating a
+  subset's zeros.
 
 ## References
 
@@ -87,7 +91,7 @@ lemma finite_zeros_in_fd [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → �
 
 /-- The zeros of a nonzero form's complex extension do not accumulate at any point of the
 upper half-plane. -/
-lemma not_accPt_zeros_comp_ofComplex [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+lemma not_accPt_zeros_comp_ofComplex [ModularFormClass F Γ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
     {x : ℂ} (hx : 0 < x.im) :
     ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0}) := by
   have han : AnalyticAt ℂ (⇑f ∘ ofComplex) x :=
@@ -100,18 +104,14 @@ lemma not_accPt_zeros_comp_ofComplex [ModularFormClass F 𝒮ℒ k] (hf : (⇑f 
       (convex_halfSpace_im_gt 0).isPreconnected hx hev
     have := h0 (Set.mem_ofPred_eq ▸ p.2 : (p : ℂ) ∈ {z : ℂ | 0 < z.im})
     simpa [Function.comp, ofComplex_apply] using this
-  · rw [accPt_iff_frequently]
+  · rw [accPt_iff_frequently_nhdsNE]
     intro hfreq
-    have hfreq' : ∃ᶠ y in nhdsWithin x {x}ᶜ,
-        y ∈ {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0} := by
-      rw [frequently_nhdsWithin_iff]
-      exact hfreq.mono fun y hy => ⟨hy.2, Set.mem_compl_singleton_iff.mpr hy.1⟩
-    obtain ⟨y, hymem, hyne⟩ := (hfreq'.and_eventually hev).exists
+    obtain ⟨y, hymem, hyne⟩ := (hfreq.and_eventually hev).exists
     exact hyne hymem.2
 
 /-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
 containing no zeros of the form's complex extension beyond its own. -/
-lemma exists_isOpen_zeros_inter [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+lemma exists_isOpen_zeros_inter [ModularFormClass F Γ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
     {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
     ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
       {z ∈ U | (⇑f ∘ ofComplex) z = 0} = {z ∈ K | (⇑f ∘ ofComplex) z = 0} := by

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -8,6 +8,10 @@ public import Mathlib.NumberTheory.Modular
 public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 public import TauCeti.NumberTheory.ModularForms.Order.OfVanishing
 
+import Mathlib.Analysis.Analytic.Uniqueness
+import Mathlib.Analysis.Complex.Convex
+import TauCeti.Topology.DiscreteSeparation
+
 /-!
 # Finite zeros of a level-one modular form in the fundamental domain
 
@@ -80,6 +84,48 @@ lemma finite_zeros_in_fd [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → �
     MeromorphicOn.divisor_apply h_mero hpK]
   intro h0
   exact hp_ord (by rwa [orderOfVanishingAt_def])
+
+/-- The zeros of a nonzero form's complex extension do not accumulate at any point of the
+upper half-plane. -/
+lemma not_accPt_zeros_comp_ofComplex [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+    {x : ℂ} (hx : 0 < x.im) :
+    ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0}) := by
+  have han : AnalyticAt ℂ (⇑f ∘ ofComplex) x :=
+    analyticAt_comp_ofComplex (ModularFormClass.holo f) hx
+  rcases han.eventually_eq_zero_or_eventually_ne_zero with hev | hev
+  · refine absurd (funext fun p => ?_) hf
+    have hall : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} := fun w hw =>
+      analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
+    have h0 := hall.eqOn_zero_of_preconnected_of_eventuallyEq_zero
+      (convex_halfSpace_im_gt 0).isPreconnected hx hev
+    have := h0 (Set.mem_ofPred_eq ▸ p.2 : (p : ℂ) ∈ {z : ℂ | 0 < z.im})
+    simpa [Function.comp, ofComplex_apply] using this
+  · rw [accPt_iff_frequently]
+    intro hfreq
+    have hfreq' : ∃ᶠ y in nhdsWithin x {x}ᶜ,
+        y ∈ {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0} := by
+      rw [frequently_nhdsWithin_iff]
+      exact hfreq.mono fun y hy => ⟨hy.2, Set.mem_compl_singleton_iff.mpr hy.1⟩
+    obtain ⟨y, hymem, hyne⟩ := (hfreq'.and_eventually hev).exists
+    exact hyne hymem.2
+
+/-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
+containing no zeros of the form's complex extension beyond its own. -/
+lemma exists_isOpen_zeros_inter [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+    {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
+    ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
+      {z ∈ U | (⇑f ∘ ofComplex) z = 0} = {z ∈ K | (⇑f ∘ ofComplex) z = 0} := by
+  obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_not_accPt
+    (Z := {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0})
+    isOpen_upperHalfPlaneSet hK fun x hx => not_accPt_zeros_comp_ofComplex hf (hK hx)
+  refine ⟨U, hUo, hKU, hUV, ?_⟩
+  have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
+      {z ∈ W | (⇑f ∘ ofComplex) z = 0} =
+        W ∩ {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0} := by
+    intro W hW
+    ext z
+    exact ⟨fun hz => ⟨hz.1, hW hz.1, hz.2⟩, fun hz => ⟨hz.1, hz.2.2⟩⟩
+  rw [hmassage hUV, hmassage hK, hUZ]
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
+++ b/TauCeti/NumberTheory/ModularForms/FiniteZeros.lean
@@ -41,7 +41,7 @@ public noncomputable section
 
 open Complex Filter Metric Set UpperHalfPlane TauCeti.UpperHalfPlane
 
-open scoped ModularForm MatrixGroups Modular Topology
+open scoped Manifold ModularForm MatrixGroups Modular Topology
 
 namespace TauCeti
 
@@ -89,39 +89,34 @@ lemma finite_zeros_in_fd [ModularFormClass F 𝒮ℒ k] (hf : (⇑f : ℍ → �
   intro h0
   exact hp_ord (by rwa [orderOfVanishingAt_def])
 
-/-- The zeros of a nonzero form's complex extension do not accumulate at any point of the
-upper half-plane. -/
-lemma not_accPt_zeros_comp_ofComplex [ModularFormClass F Γ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+/-- The zeros of a nonzero holomorphic function's complex extension do not accumulate at
+any point of the upper half-plane. -/
+lemma not_accPt_zeros_comp_ofComplex {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
     {x : ℂ} (hx : 0 < x.im) :
-    ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0}) := by
-  have han : AnalyticAt ℂ (⇑f ∘ ofComplex) x :=
-    analyticAt_comp_ofComplex (ModularFormClass.holo f) hx
-  rcases han.eventually_eq_zero_or_eventually_ne_zero with hev | hev
-  · refine absurd (funext fun p => ?_) hf
-    have hall : AnalyticOnNhd ℂ (⇑f ∘ ofComplex) {z : ℂ | 0 < z.im} := fun w hw =>
-      analyticAt_comp_ofComplex (ModularFormClass.holo f) hw
-    have h0 := hall.eqOn_zero_of_preconnected_of_eventuallyEq_zero
-      (convex_halfSpace_im_gt 0).isPreconnected hx hev
-    have := h0 (Set.mem_ofPred_eq ▸ p.2 : (p : ℂ) ∈ {z : ℂ | 0 < z.im})
-    simpa [Function.comp, ofComplex_apply] using this
-  · rw [accPt_iff_frequently_nhdsNE]
-    intro hfreq
-    obtain ⟨y, hymem, hyne⟩ := (hfreq.and_eventually hev).exists
-    exact hyne hymem.2
+    ¬AccPt x (Filter.principal {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0}) := by
+  intro hacc
+  have hall : AnalyticOnNhd ℂ (g ∘ ofComplex) {z : ℂ | 0 < z.im} := fun w hw =>
+    analyticAt_comp_ofComplex hg hw
+  rw [accPt_iff_frequently_nhdsNE] at hacc
+  have h0 := hall.eqOn_zero_of_preconnected_of_frequently_eq_zero
+    (convex_halfSpace_im_gt 0).isPreconnected hx (hacc.mono fun y hy => hy.2)
+  refine hg0 (funext fun p => ?_)
+  have := h0 (Set.mem_ofPred_eq ▸ p.2 : (p : ℂ) ∈ {z : ℂ | 0 < z.im})
+  simpa [Function.comp, ofComplex_apply] using this
 
 /-- Any subset of the upper half-plane has an open neighbourhood in the upper half-plane
 containing no zeros of the form's complex extension beyond its own. -/
-lemma exists_isOpen_zeros_inter [ModularFormClass F Γ k] (hf : (⇑f : ℍ → ℂ) ≠ 0)
+lemma exists_isOpen_zeros_inter {g : ℍ → ℂ} (hg : MDiff g) (hg0 : g ≠ 0)
     {K : Set ℂ} (hK : K ⊆ {z : ℂ | 0 < z.im}) :
     ∃ U : Set ℂ, IsOpen U ∧ K ⊆ U ∧ U ⊆ {z : ℂ | 0 < z.im} ∧
-      {z ∈ U | (⇑f ∘ ofComplex) z = 0} = {z ∈ K | (⇑f ∘ ofComplex) z = 0} := by
+      {z ∈ U | (g ∘ ofComplex) z = 0} = {z ∈ K | (g ∘ ofComplex) z = 0} := by
   obtain ⟨U, hUo, hKU, hUV, hUZ⟩ := TauCeti.exists_isOpen_inter_eq_of_not_accPt
-    (Z := {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0})
-    isOpen_upperHalfPlaneSet hK fun x hx => not_accPt_zeros_comp_ofComplex hf (hK hx)
+    (Z := {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0})
+    isOpen_upperHalfPlaneSet hK fun x hx => not_accPt_zeros_comp_ofComplex hg hg0 (hK hx)
   refine ⟨U, hUo, hKU, hUV, ?_⟩
   have hmassage : ∀ {W : Set ℂ}, W ⊆ {z : ℂ | 0 < z.im} →
-      {z ∈ W | (⇑f ∘ ofComplex) z = 0} =
-        W ∩ {z : ℂ | 0 < z.im ∧ (⇑f ∘ ofComplex) z = 0} := by
+      {z ∈ W | (g ∘ ofComplex) z = 0} =
+        W ∩ {z : ℂ | 0 < z.im ∧ (g ∘ ofComplex) z = 0} := by
     intro W hW
     ext z
     exact ⟨fun hz => ⟨hz.1, hW hz.1, hz.2⟩, fun hz => ⟨hz.1, hz.2.2⟩⟩

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -9,36 +9,29 @@ public import Mathlib.Topology.Separation.Basic
 /-!
 # Shrinking an open set to separate part of a non-accumulating set
 
-If no point of `K ⊆ V` is an accumulation point of `Z`, the open ambient set `V` shrinks
-to an open neighbourhood of `K` meeting `Z` in exactly `K ∩ Z`: remove the closure of the
-rest of `Z`. This is the localization step for residue computations — a contour region is
+If every point of `K ⊆ V` avoids the closure of `Z \ K`, the open ambient set `V`
+shrinks to an open neighbourhood of `K` meeting `Z` in exactly `K ∩ Z`. This is the
+localization step for residue computations — a contour region is
 shrunk until the only singularities it contains are the intended ones.
 
 ## Main declarations
 
-* `TauCeti.exists_isOpen_inter_eq_of_not_accPt`.
+* `TauCeti.exists_isOpen_inter_eq_of_notMem_closure`.
 -/
 
 public section
 
 namespace TauCeti
 
-/-- A set `K ⊆ V` at whose points `Z` does not accumulate shrinks the open ambient `V` to
-an open neighbourhood meeting `Z` exactly in `K ∩ Z`: remove the closure of the rest of
-`Z`. -/
-theorem exists_isOpen_inter_eq_of_not_accPt {X : Type*} [TopologicalSpace X] {V Z K : Set X}
-    (hV : IsOpen V) (hKV : K ⊆ V) (hacc : ∀ x ∈ K, ¬AccPt x (Filter.principal Z)) :
+/-- A set `K ⊆ V` whose points avoid the closure of `Z \ K` shrinks the open ambient `V`
+to an open neighbourhood meeting `Z` exactly in `K ∩ Z`: remove that closure. -/
+theorem exists_isOpen_inter_eq_of_notMem_closure {X : Type*} [TopologicalSpace X]
+    {V Z K : Set X} (hV : IsOpen V) (hKV : K ⊆ V)
+    (hK : ∀ x ∈ K, x ∉ closure (Z \ K)) :
     ∃ U : Set X, IsOpen U ∧ K ⊆ U ∧ U ⊆ V ∧ U ∩ Z = K ∩ Z := by
-  have hKU : K ⊆ V \ closure (Z \ K) := by
-    intro x hx
-    refine ⟨hKV hx, fun hxc => ?_⟩
-    have hx_notin : x ∉ Z \ K := fun h => h.2 hx
-    have hcl : ClusterPt x (Filter.principal ((Z \ K) \ {x})) := by
-      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
-    exact hacc x hx ((accPt_principal_iff_clusterPt.mpr hcl).mono
-      (Filter.principal_mono.mpr Set.sdiff_subset))
-  refine ⟨V \ closure (Z \ K), hV.sdiff isClosed_closure, hKU, Set.sdiff_subset, ?_⟩
-  refine Set.Subset.antisymm ?_ fun z hz => ⟨hKU hz.1, hz.2⟩
+  refine ⟨V \ closure (Z \ K), hV.sdiff isClosed_closure,
+    fun x hx => ⟨hKV hx, hK x hx⟩, Set.sdiff_subset, ?_⟩
+  refine Set.Subset.antisymm ?_ fun z hz => ⟨⟨hKV hz.1, hK z hz.1⟩, hz.2⟩
   rintro z ⟨⟨hzV, hznc⟩, hzZ⟩
   refine ⟨?_, hzZ⟩
   by_contra hzK

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Topology.Separation.Basic
+
+import Mathlib.Topology.Compactness.Compact
+
+/-!
+# Shrinking an open set to isolate the compact part of a discrete set
+
+A set that is closed and discrete inside an open ambient set meets a compact subset in
+finitely many points, and the ambient set shrinks to an open neighbourhood of the compact
+subset meeting the discrete set in exactly those points. This is the standard localization
+step for residue computations: a contour region is shrunk until the only singularities it
+contains are the finitely many inside the contour's compact hull.
+
+## Main declarations
+
+* `TauCeti.exists_isOpen_inter_eq_of_not_accPt`.
+-/
+
+public section
+
+namespace TauCeti
+
+/-- A set `K ⊆ V` at whose points `Z` does not accumulate shrinks the open ambient `V` to
+an open neighbourhood meeting `Z` exactly in `K ∩ Z`: remove the closure of the rest of
+`Z`. -/
+theorem exists_isOpen_inter_eq_of_not_accPt {X : Type*} [TopologicalSpace X] {V Z K : Set X}
+    (hV : IsOpen V) (hKV : K ⊆ V) (hacc : ∀ x ∈ K, ¬AccPt x (Filter.principal Z)) :
+    ∃ U : Set X, IsOpen U ∧ K ⊆ U ∧ U ⊆ V ∧ U ∩ Z = K ∩ Z := by
+  have hKU : K ⊆ V \ closure (Z \ K) := by
+    intro x hx
+    refine ⟨hKV hx, fun hxc => ?_⟩
+    have hx_notin : x ∉ Z \ K := fun h => h.2 hx
+    have hcl : ClusterPt x (Filter.principal ((Z \ K) \ {x})) := by
+      rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
+    exact hacc x hx ((accPt_principal_iff_clusterPt.mpr hcl).mono
+      (Filter.principal_mono.mpr Set.sdiff_subset))
+  refine ⟨V \ closure (Z \ K), hV.sdiff isClosed_closure, hKU, Set.sdiff_subset, ?_⟩
+  refine Set.Subset.antisymm ?_ fun z hz => ⟨hKU hz.1, hz.2⟩
+  rintro z ⟨⟨hzV, hznc⟩, hzZ⟩
+  refine ⟨?_, hzZ⟩
+  by_contra hzK
+  exact hznc (subset_closure ⟨hzZ, hzK⟩)
+
+end TauCeti
+
+end

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -6,16 +6,13 @@ module
 
 public import Mathlib.Topology.Separation.Basic
 
-import Mathlib.Topology.Compactness.Compact
-
 /-!
-# Shrinking an open set to isolate the compact part of a discrete set
+# Shrinking an open set to separate part of a non-accumulating set
 
-A set that is closed and discrete inside an open ambient set meets a compact subset in
-finitely many points, and the ambient set shrinks to an open neighbourhood of the compact
-subset meeting the discrete set in exactly those points. This is the standard localization
-step for residue computations: a contour region is shrunk until the only singularities it
-contains are the finitely many inside the contour's compact hull.
+If no point of `K ⊆ V` is an accumulation point of `Z`, the open ambient set `V` shrinks
+to an open neighbourhood of `K` meeting `Z` in exactly `K ∩ Z`: remove the closure of the
+rest of `Z`. This is the localization step for residue computations — a contour region is
+shrunk until the only singularities it contains are the intended ones.
 
 ## Main declarations
 

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -6,6 +6,8 @@ module
 
 public import Mathlib.Topology.Closure
 
+import Mathlib.Topology.ClusterPt
+
 /-!
 # Shrinking an open set to separate part of a non-accumulating set
 
@@ -16,7 +18,8 @@ shrunk until the only singularities it contains are the intended ones.
 
 ## Main declarations
 
-* `TauCeti.exists_isOpen_inter_eq_of_notMem_closure`.
+* `TauCeti.exists_isOpen_inter_eq_of_notMem_closure` (with the accumulation-hypothesis
+  corollary `TauCeti.exists_isOpen_inter_eq_of_not_accPt`).
 -/
 
 public section
@@ -36,6 +39,19 @@ theorem exists_isOpen_inter_eq_of_notMem_closure {X : Type*} [TopologicalSpace X
   refine ⟨?_, hzZ⟩
   by_contra hzK
   exact hznc (subset_closure ⟨hzZ, hzK⟩)
+
+/-- The separation under the stronger hypothesis that no point of `K` is an accumulation
+point of `Z` at all. -/
+theorem exists_isOpen_inter_eq_of_not_accPt {X : Type*} [TopologicalSpace X] {V Z K : Set X}
+    (hV : IsOpen V) (hKV : K ⊆ V)
+    (hacc : ∀ x ∈ K, ¬AccPt x (Filter.principal Z)) :
+    ∃ U : Set X, IsOpen U ∧ K ⊆ U ∧ U ⊆ V ∧ U ∩ Z = K ∩ Z := by
+  refine exists_isOpen_inter_eq_of_notMem_closure hV hKV fun x hx hxc => ?_
+  have hx_notin : x ∉ Z \ K := fun h => h.2 hx
+  have hcl : ClusterPt x (Filter.principal ((Z \ K) \ {x})) := by
+    rwa [Set.sdiff_singleton_eq_self hx_notin, ← mem_closure_iff_clusterPt]
+  exact hacc x hx ((accPt_principal_iff_clusterPt.mpr hcl).mono
+    (Filter.principal_mono.mpr Set.sdiff_subset))
 
 end TauCeti
 

--- a/TauCeti/Topology/DiscreteSeparation.lean
+++ b/TauCeti/Topology/DiscreteSeparation.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Topology.Separation.Basic
+public import Mathlib.Topology.Closure
 
 /-!
 # Shrinking an open set to separate part of a non-accumulating set


### PR DESCRIPTION
Isolates the fundamental-domain zeros of a nonzero modular form in an open neighbourhood, the localization step for the valence-formula residue count.

* `TauCeti/Topology/DiscreteSeparation.lean` — the general core `exists_isOpen_inter_eq_of_not_accPt`: a subset of an open ambient set at whose points `Z` does not accumulate has an open neighbourhood meeting `Z` in exactly its own points (`U := V \ closure (Z \ K)`). Candidate for upstreaming: Mathlib has no such shrinking lemma (compactness-free).
* `FiniteZeros.lean` gains `not_accPt_zeros_comp_ofComplex` (zeros of `⇑f ∘ ofComplex` do not accumulate in the upper half-plane — analytic dichotomy plus the identity principle on the convex half-plane) and `exists_isOpen_zeros_inter`, the instantiation.

Downstream: the open set feeds `PolarPartDecomposition.ofMeromorphic` for the residue sum along the boundary contour (#2040's follow-up, banked).

Roadmap: ModularForms

<!--tauceti-target:v1 {"focus":"valence formula: isolate the fundamental-domain zeros","id":"modular-valence-zero-nbhd"}-->
