### PR TITLE
feat: the Chebyshev envelope functions as a Hilbert basis of L²((-1,1])

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
+++ b/TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean
@@ -49,6 +49,8 @@ re-derive.
 * `TauCeti.orthonormal_bareNormalizedLp` — orthonormality from the orthogonality relation.
 * `TauCeti.coe_hilbertBasisOfWeightedMeasure`, `TauCeti.coe_hilbertBasisOfOrthogonalSystem` — the
   element-level characterizations (anti-vacuity pins).
+* `TauCeti.coeFn_hilbertBasisOfOrthogonalSystem` — the envelope basis vector as the explicit
+  function `fₙ·√w/√cₙ`, the form a family instance identifies with its own envelope family.
 -/
 
 public section
@@ -210,5 +212,34 @@ theorem coe_hilbertBasisOfOrthogonalSystem {μ : Measure α}
   rw [hilbertBasisOfOrthogonalSystem, HilbertBasis.mapₗᵢ_apply,
     coe_hilbertBasisOfWeightedMeasure f w c (hwpos.mono fun _ hx => hx.le) hwm hc horth hmem
       hcomplete]
+
+/-- **The envelope basis vectors are the functions `fₙ·√w/√cₙ`.** Where
+`TauCeti.coe_hilbertBasisOfOrthogonalSystem` names the `n`-th vector as a `weightL2Isometry`
+image, this multiplies that image out, so a family instance can identify the vector with its own
+envelope family by pointwise algebra alone.
+
+Positivity of `w` is what makes the statement `μ`-almost-everywhere rather than merely
+`w·μ`-almost-everywhere: it makes `μ` absolutely continuous with respect to `w·μ`, so the
+representative of the weighted-measure basis vector may be read on `μ` as well. -/
+theorem coeFn_hilbertBasisOfOrthogonalSystem {μ : Measure α}
+    (hwpos : ∀ᵐ x ∂μ, 0 < w x) (hwm : AEMeasurable w μ) (hc : ∀ n, 0 < c n)
+    (horth : ∀ m n, (∫ x, f m x * f n x * w x ∂μ) = if m = n then c n else 0)
+    (hmem : ∀ n, MemLp (fun x => (algebraMap ℝ 𝕜) (f n x / Real.sqrt (c n))) 2
+      (μ.withDensity (fun x => ENNReal.ofReal (w x)))) (hcomplete :
+      (Submodule.span 𝕜 (Set.range (bareNormalizedLp (𝕜 := 𝕜) f w c hmem)))ᗮ = ⊥) (n : ℕ) :
+    ⇑(hilbertBasisOfOrthogonalSystem f w c hwpos hwm hc horth hmem hcomplete n)
+      =ᵐ[μ] fun x => (algebraMap ℝ 𝕜) (f n x * Real.sqrt (w x) / Real.sqrt (c n)) := by
+  have hac : μ ≪ μ.withDensity fun x => ENNReal.ofReal (w x) :=
+    withDensity_absolutelyContinuous' hwm.ennreal_ofReal <| by
+      filter_upwards [hwpos] with x hx
+      simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
+      exact hx
+  rw [coe_hilbertBasisOfOrthogonalSystem f w c hwpos hwm hc horth hmem hcomplete n]
+  filter_upwards [weightL2Isometry_apply (𝕜 := 𝕜) μ w hwpos hwm
+      (bareNormalizedLp (𝕜 := 𝕜) f w c hmem n),
+    (coeFn_bareNormalizedLp (𝕜 := 𝕜) f w c hmem n).filter_mono hac.ae_le] with x hx hbare
+  rw [hx, hbare, Algebra.smul_def, ← map_mul]
+  congr 1
+  ring
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean
@@ -139,27 +139,11 @@ exhibit *some* Hilbert basis; here the `√w`-envelope of `Hₙ(x√2)/√cₙ` 
 @[simp]
 theorem coe_hermiteHilbertBasis : ⇑(hermiteHilbertBasis 𝕜) = hermiteFunctionLp 𝕜 := by
   funext n
-  have hwpos : ∀ᵐ x ∂(volume : Measure ℝ), 0 < Real.exp (-x ^ 2) :=
-    Filter.Eventually.of_forall fun x => Real.exp_pos _
-  have hwm : AEMeasurable (fun x : ℝ => Real.exp (-x ^ 2)) volume := by fun_prop
-  -- `w > 0` makes `μ` absolutely continuous with respect to `w·μ`, so the `w·μ`-a.e.
-  -- representative of the normalized family is also a `volume`-a.e. one.
-  have hac : (volume : Measure ℝ)
-      ≪ volume.withDensity fun x => ENNReal.ofReal (Real.exp (-x ^ 2)) :=
-    withDensity_absolutelyContinuous' hwm.ennreal_ofReal
-      (Filter.Eventually.of_forall fun x => by
-        simp only [ne_eq, ENNReal.ofReal_eq_zero, not_le]
-        exact Real.exp_pos _)
-  rw [hermiteHilbertBasis, coe_hilbertBasisOfOrthogonalSystem]
-  refine Lp.ext ?_
-  filter_upwards [weightL2Isometry_apply (𝕜 := 𝕜) volume (fun x => Real.exp (-x ^ 2)) hwpos hwm
-      (bareNormalizedLp (𝕜 := 𝕜) (fun n x => (hermiteDilated n).eval x)
-        (fun x => Real.exp (-x ^ 2)) (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi)
-        (memLp_hermiteDilated_normalized 𝕜) n),
-    (coeFn_bareNormalizedLp (𝕜 := 𝕜) (fun n x => (hermiteDilated n).eval x)
-      (fun x => Real.exp (-x ^ 2)) (fun n => (n.factorial : ℝ) * Real.sqrt Real.pi)
-      (memLp_hermiteDilated_normalized 𝕜) n).filter_mono hac.ae_le,
-    coeFn_hermiteFunctionLp (𝕜 := 𝕜) n] with x h1 h2 h3
+  rw [hermiteHilbertBasis]
+  -- The bridge already presents the `n`-th vector as `Hₙ(x√2)·√w/√cₙ`, so nothing about the
+  -- weighted measure is left to do here.
+  refine Lp.ext ((coeFn_hilbertBasisOfOrthogonalSystem _ _ _ _ _ _ _ _ _ n).trans ?_)
+  filter_upwards [coeFn_hermiteFunctionLp (𝕜 := 𝕜) n] with x hx
   -- `√w` is the Hermite envelope: `√(e^{-x²}) = e^{-x²/2}`. `Real.sqrt_mul_self` wants the
   -- radicand presented as a literal product, so the exponent is split first and `Real.exp_add`
   -- turns the sum into that product; the split is stated as its own equality rather than being
@@ -168,9 +152,7 @@ theorem coe_hermiteHilbertBasis : ⇑(hermiteHilbertBasis 𝕜) = hermiteFunctio
   have hs : Real.sqrt (Real.exp (-x ^ 2)) = Real.exp (-(x ^ 2 / 2)) := by
     rw [hsplit, Real.exp_add]
     exact Real.sqrt_mul_self (Real.exp_pos _).le
-  rw [h1, h2, h3, hermiteFunction_def, eval_hermiteDilated, Algebra.smul_def, ← map_mul, hs]
-  congr 1
-  ring
+  rw [hx, hermiteFunction_def, eval_hermiteDilated, hs]
 
 end Basis
 

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
@@ -1,0 +1,239 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
+public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+
+/-!
+# The Chebyshev envelope functions as a Hilbert basis of `L²((-1, 1])`
+
+`TauCeti.chebyshevTHilbertBasis` carries the Chebyshev weight `(1-x²)^{-1/2}` in the *measure*: the
+bare normalized polynomials `Tₙ/√cₙ` are an orthonormal basis of `L²(measureT)`. This file supplies
+the other normalization, with the weight in the *function*: the envelope functions
+
+`τₙ(x) = Tₙ(x)·(1-x²)^{-1/4}/√cₙ`,  `c₀ = π`, `cₙ = π/2` for `n ≠ 0`,
+
+are an orthonormal basis of `L²((-1, 1]; dx)` for plain Lebesgue measure on the Chebyshev interval.
+That is the basis a Chebyshev expansion taken in an *unweighted* `L²` runs against.
+
+Both normalizations come out of the same family-agnostic bridge. The basis here is
+`TauCeti.hilbertBasisOfOrthogonalSystem` at `μ = volume.restrict (Set.Ioc (-1) 1)`,
+`w x = (1-x²)^{-1/2}`, `f n = (T ℝ n).eval` and `c = TauCeti.chebyshevTNormSq`, so it exercises that
+bridge on a compact weighted measure rather than on the Gaussian. Its orthogonality input is
+Mathlib's, read off `measureT` through `Polynomial.Chebyshev.integral_measureT`; its completeness
+input is `TauCeti.orthogonal_span_range_bareNormalizedLp_eq_bot`, whose one analytic hypothesis — a
+finite exponential moment — is free on a bounded interval.
+
+The reference measure is `volume.restrict (Set.Ioc (-1) 1)` rather than Mathlib's `measureT`
+itself. The two are related by `measureT = w · (volume.restrict (Set.Ioc (-1) 1))`, but `measureT`
+does not expose its body outside the module that defines it, so that identity is not available
+here; the orthogonality relation is transported instead through the public integral formula, which
+is all the bridge needs.
+
+## Main statements
+
+* `TauCeti.integral_eval_T_real_mul_eval_T_real_mul_chebyshevWeight` — the Chebyshev orthogonality
+  relation re-keyed to Lebesgue measure on `(-1, 1]`, with the weight in the integrand.
+* `TauCeti.integrable_exp_mul_abs_chebyshevWeight` — the weighted measure has every exponential
+  moment finite, the hypothesis the completeness theorem needs.
+* `TauCeti.integral_chebyshevTEnvelope_mul_chebyshevTEnvelope` — the envelope functions are
+  orthonormal for `dx` on `(-1, 1]`.
+* `TauCeti.chebyshevTEnvelopeHilbertBasis` — the basis itself.
+* `TauCeti.coeFn_chebyshevTEnvelopeHilbertBasis`, `TauCeti.coe_chebyshevTEnvelopeHilbertBasis` —
+  the anti-vacuity pins: the `n`-th basis vector really is `τₙ`, pointwise and as an `Lp` vector.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Polynomial Polynomial.Chebyshev
+
+/-! ## The weight and its moments -/
+
+/-- The Chebyshev weight `(1-x²)^{-1/2}` is measurable. -/
+theorem measurable_chebyshevWeight : Measurable fun x : ℝ => √(1 - x ^ 2)⁻¹ := by
+  fun_prop
+
+/-- The Chebyshev weight is almost everywhere positive on `(-1, 1]`: the endpoint `1`, where
+`1 - x²` vanishes, is a Lebesgue null set, so the interior bound `x² < 1` holds almost
+everywhere. -/
+theorem ae_zero_lt_chebyshevWeight :
+    ∀ᵐ x ∂(volume.restrict (Set.Ioc (-1 : ℝ) 1)), 0 < √(1 - x ^ 2)⁻¹ := by
+  rw [← Measure.restrict_congr_set (Ioo_ae_eq_Ioc (a := (-1 : ℝ)) (b := 1))]
+  filter_upwards [ae_restrict_mem measurableSet_Ioo] with x hx
+  refine Real.sqrt_pos.mpr (inv_pos.mpr ?_)
+  nlinarith [hx.1, hx.2]
+
+/-- **Finite exponential moments of the Chebyshev weight.** For every rate `a` the function
+`e^{a|x|}` is integrable against the weighted measure `w·(volume|_{(-1,1]})`. On a bounded interval
+`e^{a|x|} ≤ e^{|a|}`, so the statement reduces to integrability of the weight itself, which is
+Mathlib's `Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`.
+
+This is the single analytic hypothesis behind both the `L²` membership of the polynomials and the
+completeness of the family. -/
+theorem integrable_exp_mul_abs_chebyshevWeight (a : ℝ) :
+    Integrable (fun x : ℝ => Real.exp (a * |x|))
+      ((volume.restrict (Set.Ioc (-1 : ℝ) 1)).withDensity
+        fun x => ENNReal.ofReal (√(1 - x ^ 2)⁻¹)) := by
+  rw [integrable_withDensity_iff_integrable_smul' measurable_chebyshevWeight.ennreal_ofReal
+    (Filter.Eventually.of_forall fun _ => ENNReal.ofReal_lt_top)]
+  simp only [ENNReal.toReal_ofReal (Real.sqrt_nonneg _), smul_eq_mul]
+  have hw : Integrable (fun x : ℝ => √(1 - x ^ 2)⁻¹) (volume.restrict (Set.Ioc (-1 : ℝ) 1)) :=
+    intervalIntegrable_sqrt_one_sub_sq_inv.1
+  refine Integrable.mono' (hw.const_mul (Real.exp |a|)) (by fun_prop) ?_
+  filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+  have hx1 : |x| ≤ 1 := abs_le.mpr ⟨hx.1.le, hx.2⟩
+  have hexp : Real.exp (a * |x|) ≤ Real.exp |a| :=
+    Real.exp_le_exp.mpr <| by nlinarith [le_abs_self a, abs_nonneg a, abs_nonneg x]
+  rw [Real.norm_eq_abs, abs_of_nonneg (by positivity), mul_comm (Real.exp |a|)]
+  exact mul_le_mul_of_nonneg_left hexp (Real.sqrt_nonneg _)
+
+/-- **The Chebyshev orthogonality relation on Lebesgue measure.** Mathlib's relation is stated
+against `measureT`; `Polynomial.Chebyshev.integral_measureT` rewrites it as an interval integral,
+which is exactly an integral against `volume.restrict (Set.Ioc (-1) 1)` with the weight moved into
+the integrand — the shape `TauCeti.hilbertBasisOfOrthogonalSystem` consumes. -/
+theorem integral_eval_T_real_mul_eval_T_real_mul_chebyshevWeight (m n : ℕ) :
+    (∫ x, (T ℝ m).eval x * (T ℝ n).eval x * √(1 - x ^ 2)⁻¹
+        ∂(volume.restrict (Set.Ioc (-1 : ℝ) 1)))
+      = if m = n then chebyshevTNormSq n else 0 := by
+  rw [← integral_eval_T_real_mul_eval_T_real_measureT_eq_ite m n,
+    integral_measureT fun x => (T ℝ m).eval x * (T ℝ n).eval x,
+    intervalIntegral.integral_of_le (by norm_num : (-1 : ℝ) ≤ 1)]
+
+/-! ## The envelope functions -/
+
+/-- The `n`-th **Chebyshev envelope function** `τₙ(x) = Tₙ(x)·(1-x²)^{-1/4}/√cₙ`: the normalized
+Chebyshev mode `TauCeti.normalizedChebyshevT` multiplied by the square root of the Chebyshev
+weight, which is the weight-in-the-function counterpart of that mode. -/
+noncomputable def chebyshevTEnvelope (n : ℕ) (x : ℝ) : ℝ :=
+  normalizedChebyshevT n x * √(√(1 - x ^ 2)⁻¹)
+
+/-- The defining equation for the Chebyshev envelope function. -/
+@[simp]
+theorem chebyshevTEnvelope_def (n : ℕ) (x : ℝ) :
+    chebyshevTEnvelope n x = normalizedChebyshevT n x * √(√(1 - x ^ 2)⁻¹) :=
+  chebyshevTEnvelope.eq_1 n x
+
+/-- The zeroth envelope function is the bare square root of the weight, normalized by `√π`. -/
+theorem chebyshevTEnvelope_zero (x : ℝ) :
+    chebyshevTEnvelope 0 x = √(√(1 - x ^ 2)⁻¹) / √Real.pi := by
+  have h0 : (T ℝ (0 : ℕ)).eval x = 1 := by simp
+  rw [chebyshevTEnvelope_def, normalizedChebyshevT_def, chebyshevTNormSq_zero, h0]
+  ring
+
+/-- **The envelope functions are orthonormal for Lebesgue measure on `(-1, 1]`.** Multiplying two
+envelope functions restores the full weight, `√w·√w = w`, which returns the integral to the
+weighted orthogonality relation. -/
+theorem integral_chebyshevTEnvelope_mul_chebyshevTEnvelope (m n : ℕ) :
+    (∫ x, chebyshevTEnvelope m x * chebyshevTEnvelope n x
+        ∂(volume.restrict (Set.Ioc (-1 : ℝ) 1)))
+      = if m = n then 1 else 0 := by
+  have hm := chebyshevTNormSq_pos m
+  have hkey : (∫ x, chebyshevTEnvelope m x * chebyshevTEnvelope n x
+      ∂(volume.restrict (Set.Ioc (-1 : ℝ) 1)))
+      = (√(chebyshevTNormSq m) * √(chebyshevTNormSq n))⁻¹ *
+        ∫ x, (T ℝ m).eval x * (T ℝ n).eval x * √(1 - x ^ 2)⁻¹
+          ∂(volume.restrict (Set.Ioc (-1 : ℝ) 1)) := by
+    rw [← integral_const_mul]
+    refine integral_congr_ae (Filter.Eventually.of_forall fun x => ?_)
+    have hsq : √(√(1 - x ^ 2)⁻¹) * √(√(1 - x ^ 2)⁻¹) = √(1 - x ^ 2)⁻¹ :=
+      Real.mul_self_sqrt (Real.sqrt_nonneg _)
+    simp only [chebyshevTEnvelope_def, normalizedChebyshevT_def]
+    linear_combination ((√(chebyshevTNormSq m) * √(chebyshevTNormSq n))⁻¹ *
+      ((T ℝ m).eval x * (T ℝ n).eval x)) * hsq
+  rw [hkey, integral_eval_T_real_mul_eval_T_real_mul_chebyshevWeight]
+  by_cases hmn : m = n
+  · subst hmn
+    rw [if_pos rfl, if_pos rfl, Real.mul_self_sqrt hm.le, inv_mul_cancel₀ hm.ne']
+  · rw [if_neg hmn, if_neg hmn, mul_zero]
+
+/-! ## The Hilbert basis -/
+
+section Basis
+
+variable (𝕜 : Type*) [RCLike 𝕜]
+
+/-- The `MemLp` obligation for the Chebyshev family against its weight: the generic
+`TauCeti.memLp_two_bareNormalized` at `p n = Tₙ`, `c = TauCeti.chebyshevTNormSq`. -/
+private theorem memLp_normalizedChebyshevT_weighted (n : ℕ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜)
+        ((T ℝ n).eval x / √(chebyshevTNormSq n))) 2
+      ((volume.restrict (Set.Ioc (-1 : ℝ) 1)).withDensity
+        fun x => ENNReal.ofReal (√(1 - x ^ 2)⁻¹)) :=
+  memLp_two_bareNormalized (𝕜 := 𝕜) ⟨1, one_pos, integrable_exp_mul_abs_chebyshevWeight 1⟩
+    (fun n => T ℝ n) chebyshevTNormSq n
+
+/-- **The Chebyshev envelope functions are a Hilbert basis of `L²((-1, 1]; dx)`.** The
+weight-in-the-function normalization of Part C of the `OrthogonalL2Bases` roadmap, assembled from
+the same bridge as the weight-in-the-measure basis `TauCeti.chebyshevTHilbertBasis`: orthonormality
+from the Chebyshev orthogonality relation, completeness from moment determinacy applied to the
+exact-degree family `Tₙ`. -/
+noncomputable def chebyshevTEnvelopeHilbertBasis :
+    HilbertBasis ℕ 𝕜 (Lp 𝕜 2 (volume.restrict (Set.Ioc (-1 : ℝ) 1))) :=
+  hilbertBasisOfOrthogonalSystem (𝕜 := 𝕜) (fun n x => (T ℝ n).eval x)
+    (fun x => √(1 - x ^ 2)⁻¹) chebyshevTNormSq
+    ae_zero_lt_chebyshevWeight measurable_chebyshevWeight.aemeasurable chebyshevTNormSq_pos
+    integral_eval_T_real_mul_eval_T_real_mul_chebyshevWeight
+    (memLp_normalizedChebyshevT_weighted 𝕜)
+    (orthogonal_span_range_bareNormalizedLp_eq_bot (𝕜 := 𝕜) (fun n => T ℝ n)
+      (fun x => √(1 - x ^ 2)⁻¹) chebyshevTNormSq (fun n => by simp [degree_T])
+      chebyshevTNormSq_pos ⟨1, one_pos, integrable_exp_mul_abs_chebyshevWeight 1⟩
+      (memLp_normalizedChebyshevT_weighted 𝕜))
+
+/-- **The basis vectors are the envelope functions.** Without this the construction would only
+exhibit *some* Hilbert basis of `L²((-1, 1])`; here each vector is pinned to `τₙ`. -/
+theorem coeFn_chebyshevTEnvelopeHilbertBasis (n : ℕ) :
+    ⇑(chebyshevTEnvelopeHilbertBasis 𝕜 n)
+      =ᵐ[volume.restrict (Set.Ioc (-1 : ℝ) 1)]
+        fun x => (algebraMap ℝ 𝕜) (chebyshevTEnvelope n x) := by
+  rw [chebyshevTEnvelopeHilbertBasis]
+  filter_upwards [coeFn_hilbertBasisOfOrthogonalSystem (𝕜 := 𝕜) _ _ _ _ _ _ _ _ _ n] with x hx
+  rw [hx, chebyshevTEnvelope_def, normalizedChebyshevT_def]
+  congr 1
+  ring
+
+/-- Each envelope function lies in `L²((-1, 1]; dx)`. It is the representative of a basis vector,
+so this is read off the basis rather than re-proved: the `L²` membership is exactly what the
+weighted `MemLp` obligation of the bridge already established, transported by
+`TauCeti.coeFn_chebyshevTEnvelopeHilbertBasis`. -/
+theorem memLp_two_algebraMap_chebyshevTEnvelope (n : ℕ) :
+    MemLp (fun x : ℝ => (algebraMap ℝ 𝕜) (chebyshevTEnvelope n x)) 2
+      (volume.restrict (Set.Ioc (-1 : ℝ) 1)) :=
+  MemLp.ae_eq (coeFn_chebyshevTEnvelopeHilbertBasis 𝕜 n)
+    (Lp.memLp (chebyshevTEnvelopeHilbertBasis 𝕜 n))
+
+/-- The `n`-th envelope function as a vector of `L²((-1, 1]; dx)`. -/
+noncomputable def chebyshevTEnvelopeLp (n : ℕ) :
+    Lp 𝕜 2 (volume.restrict (Set.Ioc (-1 : ℝ) 1)) :=
+  (memLp_two_algebraMap_chebyshevTEnvelope 𝕜 n).toLp _
+
+/-- The `Lp` representative of `TauCeti.chebyshevTEnvelopeLp` is the expected scalar-cast envelope
+function. -/
+theorem coeFn_chebyshevTEnvelopeLp (n : ℕ) :
+    ⇑(chebyshevTEnvelopeLp 𝕜 n) =ᵐ[volume.restrict (Set.Ioc (-1 : ℝ) 1)]
+      fun x => (algebraMap ℝ 𝕜) (chebyshevTEnvelope n x) :=
+  MemLp.coeFn_toLp _
+
+/-- **The basis is the envelope family, as an equality of `ℕ`-indexed families of `L²` vectors.**
+This is the shape the roadmap's element-level export asks for; it upgrades the almost-everywhere
+`TauCeti.coeFn_chebyshevTEnvelopeHilbertBasis` to an identity of `Lp` vectors. -/
+@[simp]
+theorem coe_chebyshevTEnvelopeHilbertBasis :
+    ⇑(chebyshevTEnvelopeHilbertBasis 𝕜) = chebyshevTEnvelopeLp 𝕜 := by
+  funext n
+  exact Lp.ext ((coeFn_chebyshevTEnvelopeHilbertBasis 𝕜 n).trans
+    (coeFn_chebyshevTEnvelopeLp 𝕜 n).symm)
+
+/-- The envelope functions are orthonormal in `L²((-1, 1]; dx)`. -/
+theorem orthonormal_chebyshevTEnvelopeLp : Orthonormal 𝕜 (chebyshevTEnvelopeLp 𝕜) := by
+  rw [← coe_chebyshevTEnvelopeHilbertBasis]
+  exact (chebyshevTEnvelopeHilbertBasis 𝕜).orthonormal
+
+end Basis
+
+end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.InnerProductSpace.PolynomialCompleteness
 public import TauCeti.Analysis.SpecialFunctions.Trigonometric.Chebyshev.Measure
+import TauCeti.MeasureTheory.Function.BoundedSupportExponential
 
 /-!
 # The Chebyshev envelope functions as a Hilbert basis of `L²((-1, 1])`
@@ -71,9 +72,10 @@ theorem ae_zero_lt_chebyshevWeight :
   nlinarith [hx.1, hx.2]
 
 /-- **Finite exponential moments of the Chebyshev weight.** For every rate `a` the function
-`e^{a|x|}` is integrable against the weighted measure `w·(volume|_{(-1,1]})`. On a bounded interval
-`e^{a|x|} ≤ e^{|a|}`, so the statement reduces to integrability of the weight itself, which is
-Mathlib's `Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`.
+`e^{a|x|}` is integrable against the weighted measure `w·(volume|_{(-1,1]})`. The measure lives on a
+bounded interval, so this is the bounded-support principle
+`TauCeti.Integrable.exp_abs_smul_of_ae_abs_le` applied to integrability of the weight itself, which
+is Mathlib's `Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`.
 
 This is the single analytic hypothesis behind both the `L²` membership of the polynomials and the
 completeness of the family. -/
@@ -83,16 +85,12 @@ theorem integrable_exp_mul_abs_chebyshevWeight (a : ℝ) :
         fun x => ENNReal.ofReal (√(1 - x ^ 2)⁻¹)) := by
   rw [integrable_withDensity_iff_integrable_smul' measurable_chebyshevWeight.ennreal_ofReal
     (Filter.Eventually.of_forall fun _ => ENNReal.ofReal_lt_top)]
-  simp only [ENNReal.toReal_ofReal (Real.sqrt_nonneg _), smul_eq_mul]
   have hw : Integrable (fun x : ℝ => √(1 - x ^ 2)⁻¹) (volume.restrict (Set.Ioc (-1 : ℝ) 1)) :=
     intervalIntegrable_sqrt_one_sub_sq_inv.1
-  refine Integrable.mono' (hw.const_mul (Real.exp |a|)) (by fun_prop) ?_
-  filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
-  have hx1 : |x| ≤ 1 := abs_le.mpr ⟨hx.1.le, hx.2⟩
-  have hexp : Real.exp (a * |x|) ≤ Real.exp |a| :=
-    Real.exp_le_exp.mpr <| by nlinarith [le_abs_self a, abs_nonneg a, abs_nonneg x]
-  rw [Real.norm_eq_abs, abs_of_nonneg (by positivity), mul_comm (Real.exp |a|)]
-  exact mul_le_mul_of_nonneg_left hexp (Real.sqrt_nonneg _)
+  have := Integrable.exp_abs_smul_of_ae_abs_le (𝕜 := ℝ) hw a 1 (by
+    filter_upwards [ae_restrict_mem measurableSet_Ioc] with x hx
+    exact abs_le.mpr ⟨hx.1.le, hx.2⟩)
+  simpa [ENNReal.toReal_ofReal (Real.sqrt_nonneg _), smul_eq_mul, mul_comm] using this
 
 /-- **The Chebyshev orthogonality relation on Lebesgue measure.** Mathlib's relation is stated
 against `measureT`; `Polynomial.Chebyshev.integral_measureT` rewrites it as an interval integral,

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean
@@ -44,7 +44,8 @@ is all the bridge needs.
   orthonormal for `dx` on `(-1, 1]`.
 * `TauCeti.chebyshevTEnvelopeHilbertBasis` — the basis itself.
 * `TauCeti.coeFn_chebyshevTEnvelopeHilbertBasis`, `TauCeti.coe_chebyshevTEnvelopeHilbertBasis` —
-  the anti-vacuity pins: the `n`-th basis vector really is `τₙ`, pointwise and as an `Lp` vector.
+  the anti-vacuity pins: the `n`-th basis vector really is `τₙ`, almost everywhere and as an `Lp`
+  vector.
 -/
 
 public section


### PR DESCRIPTION
This PR delivers the Chebyshev family in its second, weight-in-the-function normalization: the envelope functions `τₙ(x) = Tₙ(x)·(1-x²)^{-1/4}/√cₙ` (with `c₀ = π`, `cₙ = π/2`) are exhibited as a Hilbert basis of `L²((-1, 1]; dx)` — plain Lebesgue measure on the Chebyshev interval — for every `[RCLike 𝕜]`, together with the element-level pins that make the bundled basis usable. It serves Part C of the `OrthogonalL2Bases` roadmap, whose overview requires that "each family's basis is available in both normalizations — the bare polynomials as an ONB of the weighted measure `L²(w·μ)`, and their `√w`-envelope functions as an ONB of `L²(μ)` — from one construction". Part C's weighted-measure half is already merged as `TauCeti.chebyshevTHilbertBasis` (`HilbertBasis ℕ 𝕜 (Lp 𝕜 2 measureT)`, PR #1297) and its cosine transfer as `TauCeti.chebyshevCosineHilbertBasis` (#1474); the `L²(μ)` half was the piece still missing, and it is the instance that exercises B2's `√w`-envelope output — until now used only by Hermite — on a compact weighted measure rather than the Gaussian. After this PR, Part C's stated targets are complete.

The basis is assembled entirely from the family-agnostic spine, at `μ = volume.restrict (Set.Ioc (-1) 1)`, `w x = (1-x²)^{-1/2}`, `f n = (T ℝ n).eval` and `c = TauCeti.chebyshevTNormSq`: orthonormality from `TauCeti.hilbertBasisOfOrthogonalSystem` (B2), completeness from `TauCeti.orthogonal_span_range_bareNormalizedLp_eq_bot` (B1) applied to the exact-degree family `Tₙ` (`Polynomial.Chebyshev.degree_T`). The orthogonality relation is Mathlib's, re-keyed from `measureT` to an integral against Lebesgue measure with the weight in the integrand through the public `Polynomial.Chebyshev.integral_measureT`; the single analytic hypothesis behind both `L²` membership and completeness is a finite exponential moment, which on a bounded interval reduces to integrability of the weight itself (`Polynomial.Chebyshev.intervalIntegrable_sqrt_one_sub_sq_inv`). The reference measure is spelled `volume.restrict (Set.Ioc (-1) 1)` rather than `measureT`: the two are equal, but Mathlib's `measureT` does not expose its body outside its defining module, so the transport goes through the public integral formula instead — which is all the bridge needs. No Mathlib source was vendored.

Enabling the instance, the B2 bridge gains the element-level export the roadmap names for it: `TauCeti.coeFn_hilbertBasisOfOrthogonalSystem` states that the `n`-th vector of the envelope basis is almost everywhere `fₙ·√w/√cₙ`, where the existing `coe_hilbertBasisOfOrthogonalSystem` only named it as a `weightL2Isometry` image. The Hermite instance now obtains `coe_hermiteHilbertBasis` by specializing that lemma instead of repeating the absolute-continuity and `√w`-multiplication bookkeeping inline, which is what the roadmap asks of the export ("so the Hermite (A3) and Chebyshev (Part C) instances obtain their `coe_*` by specialization, not re-derivation"); its proof shrinks by about a dozen lines and no statement changes.

Files: one new module, `TauCeti/Analysis/SpecialFunctions/Trigonometric/Chebyshev/Envelope.lean` (239 lines), placed alongside the existing `Chebyshev/Measure.lean` and `Chebyshev/HilbertBasis.lean`; plus 31 added lines in `TauCeti/Analysis/InnerProductSpace/WeightedOrthogonalBasis.lean` and a net 12 fewer in `TauCeti/Analysis/SpecialFunctions/Hermite/Function/HilbertBasis.lean`.

Roadmap: OrthogonalL2Bases

<!--tauceti-target:v1 {"focus":"OrthogonalL2Bases","id":"chebyshev-envelope-hilbert-basis"}-->

🤖 Prepared with Claude Code
