### PR TITLE
feat: locally flat embeddings and their structural API

### DIFF
--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -41,7 +41,7 @@ closure properties: restriction to an open subset of the domain, locality, invar
 homeomorphisms and open embeddings on either side, invariance under a change of model space, and
 products. Those are proved here, together with two results that pin the notion down: in codimension
 zero local flatness is exactly openness of the embedding, and a locally flat embedding has locally
-closed image as soon as the complementary model is `T1`.
+closed image as soon as the origin of the complementary model is closed.
 
 This is layer 2 of the geometric-topology roadmap, the substrate for topologically locally flat
 discs (topological sliceness) and for stating the annulus conjecture.
@@ -56,17 +56,18 @@ discs (topological sliceness) and for stating the annulus conjecture.
 
 * `TauCeti.isSliceChart_iff`: a chart is a slice chart iff, on its source, membership in the set is
   read off as membership of the coordinates in the slice.
-* `TauCeti.IsLocallyFlat.restrict` and `TauCeti.isLocallyFlat_iff_forall_exists_isOpen`: local
+* `TauCeti.IsLocallyFlat.restrict` and `TauCeti.IsLocallyFlat.of_forall_exists_isOpen`: local
   flatness is a local property of the domain.
-* `TauCeti.IsLocallyFlat.comp_isOpenEmbedding`, `TauCeti.IsLocallyFlat.of_comp_isOpenEmbedding`,
+* `TauCeti.IsLocallyFlat.isOpenEmbedding_comp`, `TauCeti.IsLocallyFlat.of_isOpenEmbedding_comp`,
   `TauCeti.IsLocallyFlat.codRestrict`, `TauCeti.IsLocallyFlat.homeomorph_comp`,
-  `TauCeti.IsLocallyFlat.comp_homeomorph`: invariance under open embeddings and homeomorphisms of
-  the ambient space and of the domain.
+  `TauCeti.IsLocallyFlat.comp_isOpenEmbedding`, `TauCeti.IsLocallyFlat.comp_homeomorph`: invariance
+  under open embeddings and homeomorphisms of the ambient space and of the domain.
 * `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
   space.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
 * `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
-* `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed.
+* `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed, as soon as
+  the origin of the complementary model is closed.
 * `TauCeti.isLocallyFlat_prodMkLeft`: the standard model `x ↦ (x, 0)` is locally flat.
 
 ## Implementation notes
@@ -101,7 +102,7 @@ structure and is not formalised here.
 Composing two locally flat embeddings `N ↪ M ↪ P` is deliberately absent: it is not a formal
 consequence of the definition, because the two flattening charts have to be made compatible before
 they can be combined. Only the codimension-zero ambient case is proved here, as
-`TauCeti.IsLocallyFlat.comp_isOpenEmbedding` and its converse.
+`TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
 
 ## References
 
@@ -274,10 +275,18 @@ theorem comp_homeomorph (h : IsSliceEmbedding S f) (e : N' ≃ₜ N) : IsSliceEm
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart (e x)
   exact ⟨φ, hφx, by rwa [range_comp, e.surjective.range_eq, image_univ]⟩
 
+/-- Being a slice embedding is invariant under precomposition with an open embedding of the domain:
+such a precomposition is a restriction to an open subset, read through the homeomorphism onto its
+range. -/
+theorem comp_isOpenEmbedding {e : N' → N} (h : IsSliceEmbedding S f) (he : IsOpenEmbedding e) :
+    IsSliceEmbedding S (f ∘ e) := by
+  have h' := (h.restrict he.isOpen_range).comp_homeomorph he.isEmbedding.toHomeomorph
+  simpa [Function.comp_def] using h'
+
 /-- Pushing a slice embedding forward along an open embedding of the ambient space keeps it a slice
 embedding. Taking `g` the inclusion of an open subset, this is the statement that a slice embedding
 into an open subset is one into the whole space. -/
-theorem comp_isOpenEmbedding {g : M → P} (h : IsSliceEmbedding S f) (hg : IsOpenEmbedding g) :
+theorem isOpenEmbedding_comp {g : M → P} (h : IsSliceEmbedding S f) (hg : IsOpenEmbedding g) :
     IsSliceEmbedding S (g ∘ f) := by
   refine ⟨hg.isEmbedding.comp h.isEmbedding, fun x => ?_⟩
   have : Nonempty M := ⟨f x⟩
@@ -302,7 +311,7 @@ theorem comp_isOpenEmbedding {g : M → P} (h : IsSliceEmbedding S f) (hg : IsOp
 /-- Conversely, an embedding that becomes a slice embedding after an open embedding of the ambient
 space was already one. Taking `g` the inclusion of an open subset, this corestricts a slice
 embedding to an open neighbourhood of its image. -/
-theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
+theorem of_isOpenEmbedding_comp {g : M → P} (hg : IsOpenEmbedding g)
     (h : IsSliceEmbedding S (g ∘ f)) : IsSliceEmbedding S f := by
   refine ⟨hg.isEmbedding.of_comp_iff.1 h.isEmbedding, fun x => ?_⟩
   have : Nonempty M := ⟨f x⟩
@@ -324,11 +333,11 @@ theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
 a slice embedding as a map into `V`. -/
 theorem codRestrict (h : IsSliceEmbedding S f) {V : Set M} (hV : IsOpen V) (hf : ∀ x, f x ∈ V) :
     IsSliceEmbedding S (fun x => (⟨f x, hf x⟩ : V)) :=
-  of_comp_isOpenEmbedding hV.isOpenEmbedding_subtypeVal h
+  of_isOpenEmbedding_comp hV.isOpenEmbedding_subtypeVal h
 
 /-- Being a slice embedding is invariant under a homeomorphism of the ambient space. -/
 theorem homeomorph_comp (h : IsSliceEmbedding S f) (e : M ≃ₜ P) : IsSliceEmbedding S (e ∘ f) :=
-  h.comp_isOpenEmbedding e.isOpenEmbedding
+  h.isOpenEmbedding_comp e.isOpenEmbedding
 
 /-- Being a slice embedding only depends on the model space up to homeomorphism, the slice being
 transported along. -/
@@ -368,21 +377,13 @@ theorem isLocallyClosed_range (h : IsSliceEmbedding S f) (hS : IsClosed S) :
   rintro _ ⟨x, rfl⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
   refine ⟨φ.source, φ.open_source.mem_nhds hφx, ?_⟩
-  have hpre : ((Subtype.val : φ.source → M) ⁻¹' range f) = (fun y : φ.source => φ ↑y) ⁻¹' S := by
-    ext y
-    exact hφ.mem_iff y.2
-  change IsClosed ((Subtype.val : φ.source → M) ⁻¹' range f)
+  -- `U ↓∩ s` is notation for `Subtype.val ⁻¹' s`, so the goal is literally about that preimage.
+  have hpre : ((Subtype.val : φ.source → M) ⁻¹' range f) = (fun y : φ.source => φ ↑y) ⁻¹' S :=
+    Set.ext fun y => hφ.mem_iff y.2
   rw [hpre]
   exact hS.preimage φ.continuousOn.domRestrict
 
 end IsSliceEmbedding
-
-/-- Being a slice embedding is exactly a local property of the domain. -/
-theorem isSliceEmbedding_iff_forall_exists_isOpen :
-    IsSliceEmbedding S f ↔ IsEmbedding f ∧
-      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsSliceEmbedding S (f ∘ ((↑) : U → N)) :=
-  ⟨fun h => ⟨h.isEmbedding, fun x => ⟨univ, isOpen_univ, mem_univ x, h.restrict isOpen_univ⟩⟩,
-    fun h => .of_forall_exists_isOpen h.1 h.2⟩
 
 /-- An open embedding into a space charted on `F` is a slice embedding for the full model space. -/
 theorem isSliceEmbedding_univ_of_isOpenEmbedding [ChartedSpace F M] (h : IsOpenEmbedding f) :
@@ -401,12 +402,6 @@ theorem isSliceEmbedding_univ_iff [ChartedSpace F M] :
 section StandardSlice
 
 variable [Zero F']
-
-/-- Local flatness unfolded: it is the slice-embedding condition for the standard slice. All the
-transport lemmas are inherited through this. -/
-theorem isLocallyFlat_iff_isSliceEmbedding :
-    IsLocallyFlat F F' f ↔ IsSliceEmbedding ((univ : Set F) ×ˢ ({0} : Set F')) f :=
-  Iff.rfl
 
 namespace IsLocallyFlat
 
@@ -435,18 +430,23 @@ theorem of_forall_exists_isOpen (hf : IsEmbedding f)
 theorem comp_homeomorph (h : IsLocallyFlat F F' f) (e : N' ≃ₜ N) : IsLocallyFlat F F' (f ∘ e) :=
   IsSliceEmbedding.comp_homeomorph h e
 
+/-- Local flatness is invariant under precomposition with an open embedding of the domain. -/
+theorem comp_isOpenEmbedding {e : N' → N} (h : IsLocallyFlat F F' f) (he : IsOpenEmbedding e) :
+    IsLocallyFlat F F' (f ∘ e) :=
+  IsSliceEmbedding.comp_isOpenEmbedding h he
+
 /-- Pushing a locally flat embedding forward along an open embedding of the ambient space keeps it
 locally flat. Taking `g` the inclusion of an open subset, this is the statement that a locally flat
 embedding into an open subset is locally flat into the whole space. -/
-theorem comp_isOpenEmbedding {g : M → P} (h : IsLocallyFlat F F' f) (hg : IsOpenEmbedding g) :
+theorem isOpenEmbedding_comp {g : M → P} (h : IsLocallyFlat F F' f) (hg : IsOpenEmbedding g) :
     IsLocallyFlat F F' (g ∘ f) :=
-  IsSliceEmbedding.comp_isOpenEmbedding h hg
+  IsSliceEmbedding.isOpenEmbedding_comp h hg
 
 /-- Conversely, an embedding that becomes locally flat after an open embedding of the ambient space
 was already locally flat. -/
-theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
+theorem of_isOpenEmbedding_comp {g : M → P} (hg : IsOpenEmbedding g)
     (h : IsLocallyFlat F F' (g ∘ f)) : IsLocallyFlat F F' f :=
-  IsSliceEmbedding.of_comp_isOpenEmbedding hg h
+  IsSliceEmbedding.of_isOpenEmbedding_comp hg h
 
 /-- Corestriction: a locally flat embedding whose image lies in an open subset `V` of the ambient
 space is locally flat as a map into `V`. -/
@@ -475,19 +475,14 @@ theorem prodMap {G G' : Type*} [TopologicalSpace G] [TopologicalSpace G'] [Zero 
   rw [himage] at hprod
   exact hprod
 
-/-- The image of a locally flat embedding is locally closed, the standard slice being closed. This
-is where the definition has teeth: the image of a wild embedding need not be locally closed. -/
-theorem isLocallyClosed_range [T1Space F'] (h : IsLocallyFlat F F' f) :
+/-- The image of a locally flat embedding is locally closed as soon as the origin of the
+complementary model is closed, the standard slice then being closed. This is where the definition
+has teeth: the image of a wild embedding need not be locally closed. -/
+theorem isLocallyClosed_range (h : IsLocallyFlat F F' f) (h0 : IsClosed ({0} : Set F')) :
     IsLocallyClosed (range f) :=
-  IsSliceEmbedding.isLocallyClosed_range h (isClosed_univ.prod isClosed_singleton)
+  IsSliceEmbedding.isLocallyClosed_range h (isClosed_univ.prod h0)
 
 end IsLocallyFlat
-
-/-- Local flatness is exactly a local property of the domain. -/
-theorem isLocallyFlat_iff_forall_exists_isOpen :
-    IsLocallyFlat F F' f ↔ IsEmbedding f ∧
-      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat F F' (f ∘ ((↑) : U → N)) :=
-  isSliceEmbedding_iff_forall_exists_isOpen
 
 /-- Codimension zero: with a trivial complementary model, over a space charted on `F × F'`, locally
 flat is exactly open embedding. In particular local flatness is strictly stronger than embedding:
@@ -497,7 +492,7 @@ theorem isLocallyFlat_iff_isOpenEmbedding [Subsingleton F'] [ChartedSpace (F × 
   have h0 : ((univ : Set F) ×ˢ ({0} : Set F')) = (univ : Set (F × F')) := by
     rw [show ({0} : Set F') = univ from eq_univ_of_forall fun x => Subsingleton.elim x 0,
       univ_prod_univ]
-  rw [isLocallyFlat_iff_isSliceEmbedding, h0]
+  rw [IsLocallyFlat, h0]
   exact isSliceEmbedding_univ_iff
 
 /-- The standard local model: the inclusion of `F` as the slice `F × {0}` of `F × F'` is locally

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -208,6 +208,7 @@ end IsSliceChart
 
 /-- A chart is a slice chart for the full model space exactly when everything it sees lies in the
 set: this is the codimension-zero case. -/
+@[simp]
 theorem isSliceChart_univ_iff : IsSliceChart φ (univ : Set F) A ↔ φ.source ⊆ A := by
   simp [isSliceChart_iff, subset_def]
 
@@ -521,9 +522,9 @@ flat is exactly open embedding. In particular local flatness is strictly stronge
 not every embedding is locally flat. -/
 theorem isLocallyFlat_iff_isOpenEmbedding [Subsingleton F'] [ChartedSpace (F × F') M] :
     IsLocallyFlat F F' f ↔ IsOpenEmbedding f := by
+  have hzero : ({0} : Set F') = univ := eq_univ_of_forall fun x => Subsingleton.elim x 0
   have h0 : ((univ : Set F) ×ˢ ({0} : Set F')) = (univ : Set (F × F')) := by
-    rw [show ({0} : Set F') = univ from eq_univ_of_forall fun x => Subsingleton.elim x 0,
-      univ_prod_univ]
+    rw [hzero, univ_prod_univ]
   rw [IsLocallyFlat, h0]
   exact isSliceEmbedding_univ_iff
 

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -1,0 +1,379 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.ChartedSpace
+public import Mathlib.Topology.LocallyClosed
+
+/-!
+# Locally flat embeddings
+
+Topological manifolds admit embeddings that no smooth embedding can imitate: the Alexander horned
+sphere is a topologically embedded `2`-sphere in `S³` bounding a non-simply-connected region, and a
+wild arc in `ℝ³` is knotted although its domain is an interval. Theorems about topological
+manifolds therefore quantify over *locally flat* embeddings, those that in suitable ambient charts
+look like a fixed slice of the model space.
+
+This file introduces that notion and the structural API it is used through. The definition is split
+into two layers.
+
+* `TauCeti.IsSliceChart φ S A` says that a single chart `φ` of the ambient space flattens the set
+  `A` onto the model slice `S`, in the sense that `φ '' (φ.source ∩ A) = φ.target ∩ S`.
+* `TauCeti.IsLocallyFlat S f` says that `f` is a topological embedding admitting a slice chart for
+  `Set.range f` around every point of its image.
+
+Local flatness is a local condition, so the load-bearing content is not the definition but its
+closure properties: restriction to an open subset of the domain, locality, invariance under
+homeomorphisms and open embeddings on either side, invariance under a change of model space, and
+products. Those are proved here, together with two results that pin the notion down: in codimension
+zero (`S = Set.univ`) local flatness is exactly openness of the embedding, and a locally flat
+embedding with a closed model slice has locally closed image.
+
+The slice `S` is a parameter rather than a fixed coordinate subspace, deliberately: codimension `0`
+(open embeddings), codimension `1` (where collaring lives) and codimension `2` (where knotting
+lives) behave very differently, and keeping one predicate for all of them is the point.
+`TauCeti.isLocallyFlat_prodMkLeft` records the standard model, the inclusion `X → X × Y`,
+`x ↦ (x, c)`, whose slice is `Set.univ ×ˢ {c}`; taking `X = ℝⁿ` and `Y = ℝᵏ` gives the usual
+`ℝⁿ ⊆ ℝⁿ⁺ᵏ` picture.
+
+This is layer 2 of the geometric-topology roadmap, the substrate for topologically locally flat
+discs (topological sliceness) and for stating the annulus conjecture.
+
+## Main definitions
+
+* `TauCeti.IsSliceChart`: an ambient chart flattening a set onto a model slice.
+* `TauCeti.IsLocallyFlat`: a topological embedding that is flat in ambient charts.
+
+## Main results
+
+* `TauCeti.isSliceChart_iff`: a chart is a slice chart iff, on its source, membership in the set is
+  read off as membership of the coordinates in the slice.
+* `TauCeti.IsLocallyFlat.restrict` and `TauCeti.isLocallyFlat_iff_forall_exists_isOpen`: local
+  flatness is a local property of the domain.
+* `TauCeti.IsLocallyFlat.comp_isOpenEmbedding`, `TauCeti.IsLocallyFlat.of_comp_isOpenEmbedding`,
+  `TauCeti.IsLocallyFlat.codRestrict`, `TauCeti.IsLocallyFlat.homeomorph_comp`,
+  `TauCeti.IsLocallyFlat.comp_homeomorph`: invariance under open embeddings and homeomorphisms of
+  the ambient space and of the domain.
+* `TauCeti.IsLocallyFlat.transHomeomorph`: invariance under a homeomorphic change of model space.
+* `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
+* `TauCeti.isLocallyFlat_univ_iff`: in codimension zero, locally flat means open.
+* `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a closed slice forces a locally closed image.
+
+## Implementation notes
+
+No membership in a prescribed atlas is required of the flattening chart: an
+`OpenPartialHomeomorph M F` is automatically a chart of the maximal topological atlas of a
+topological manifold `M` modelled on `F`, so demanding atlas membership would be redundant there
+and would needlessly restrict the definition on ambient spaces that are not manifolds.
+
+A slice chart is only asked to flatten the set *relative to its own target*, that is
+`φ '' (φ.source ∩ A) = φ.target ∩ S` rather than `φ.target = F` together with
+`φ '' (φ.source ∩ A) = S`. The relative form is the one that is genuinely local, hence the one
+closed under restriction; the textbook form is not, since shrinking the source shrinks the target.
+For the standard model, a chart in the relative sense can be shrunk to a ball around the point and
+rescaled onto `(ℝᵐ, ℝⁿ)`, recovering the textbook form, but that comparison needs the linear
+structure and is not formalised here.
+
+Codimension is not baked into the definition; see the module docstring above.
+
+Composing two locally flat embeddings `N ↪ M ↪ P` is deliberately absent: it is not a formal
+consequence of the definition, because the two flattening charts have to be made compatible before
+they can be combined. Only the codimension-zero ambient case is proved here, as
+`TauCeti.IsLocallyFlat.comp_isOpenEmbedding` and its converse.
+
+## References
+
+* R. Daverman and G. Venema, *Embeddings in Manifolds*, AMS Graduate Studies in Mathematics 106
+  (2009), Chapter 1, for local flatness and wild embeddings.
+* M. Brown, *Locally flat imbeddings of topological manifolds*, Annals of Mathematics 75 (1962),
+  331–341, for the collaring theorem that local flatness was isolated to prove.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set Topology
+
+variable {M N N' P F F' : Type*} [TopologicalSpace M] [TopologicalSpace N] [TopologicalSpace N']
+  [TopologicalSpace P] [TopologicalSpace F] [TopologicalSpace F']
+
+/-- `IsSliceChart φ S A` says that the ambient chart `φ` flattens the set `A` onto the model slice
+`S`: the chart carries the part of `A` it sees exactly onto the part of `S` in its target. -/
+def IsSliceChart (φ : OpenPartialHomeomorph M F) (S : Set F) (A : Set M) : Prop :=
+  φ '' (φ.source ∩ A) = φ.target ∩ S
+
+variable {φ : OpenPartialHomeomorph M F} {S : Set F} {A : Set M}
+
+/-- A chart is a slice chart for `A` exactly when, on its source, membership in `A` can be read off
+as membership of the coordinates in the slice. This pointwise form is how the predicate is used. -/
+theorem isSliceChart_iff :
+    IsSliceChart φ S A ↔ ∀ y ∈ φ.source, (y ∈ A ↔ φ y ∈ S) := by
+  constructor
+  · intro h y hy
+    constructor
+    · intro hyA
+      exact (h ▸ mem_image_of_mem _ ⟨hy, hyA⟩ : φ y ∈ φ.target ∩ S).2
+    · intro hyS
+      have hmem : φ y ∈ φ.target ∩ S := ⟨φ.map_source hy, hyS⟩
+      rw [← h] at hmem
+      obtain ⟨z, hz, hzy⟩ := hmem
+      exact φ.injOn hz.1 hy hzy ▸ hz.2
+  · intro h
+    refine Subset.antisymm ?_ ?_
+    · rintro _ ⟨y, ⟨hy, hyA⟩, rfl⟩
+      exact ⟨φ.map_source hy, (h y hy).1 hyA⟩
+    · rintro z ⟨hz, hzS⟩
+      refine ⟨φ.symm z, ⟨φ.map_target hz, ?_⟩, φ.right_inv hz⟩
+      rw [h _ (φ.map_target hz), φ.right_inv hz]
+      exact hzS
+
+namespace IsSliceChart
+
+theorem mem_iff (h : IsSliceChart φ S A) {y : M} (hy : y ∈ φ.source) : y ∈ A ↔ φ y ∈ S :=
+  isSliceChart_iff.1 h y hy
+
+/-- On the source of a slice chart, the flattened set is cut out by the slice. -/
+theorem source_inter_eq (h : IsSliceChart φ S A) : φ.source ∩ A = φ.source ∩ φ ⁻¹' S :=
+  Set.ext fun _ => and_congr_right fun hy => h.mem_iff hy
+
+/-- Restricting a slice chart to an open set restricts the flattened set to the same open set. -/
+theorem restrOpen (h : IsSliceChart φ S A) {V : Set M} (hV : IsOpen V) :
+    IsSliceChart (φ.restrOpen V hV) S (A ∩ V) := by
+  refine isSliceChart_iff.2 fun y hy => ?_
+  rw [OpenPartialHomeomorph.restrOpen_source] at hy
+  simp only [OpenPartialHomeomorph.coe_restrOpen, mem_inter_iff, hy.2, and_true]
+  exact h.mem_iff hy.1
+
+/-- Conversely, a chart flattening `A ∩ V` for an open `V` restricts to a chart flattening `A`. -/
+theorem of_inter {V : Set M} (h : IsSliceChart φ S (A ∩ V)) (hV : IsOpen V) :
+    IsSliceChart (φ.restrOpen V hV) S A := by
+  refine isSliceChart_iff.2 fun y hy => ?_
+  rw [OpenPartialHomeomorph.restrOpen_source] at hy
+  simp only [OpenPartialHomeomorph.coe_restrOpen]
+  rw [← h.mem_iff hy.1, mem_inter_iff, and_iff_left hy.2]
+
+/-- Slice charts pull back along any chart of a second ambient space. This is the single
+transport lemma behind invariance under open embeddings and homeomorphisms. -/
+theorem comp (h : IsSliceChart φ S A) (e : OpenPartialHomeomorph P M) :
+    IsSliceChart (e.trans φ) S (e.source ∩ e ⁻¹' A) := by
+  refine isSliceChart_iff.2 fun p hp => ?_
+  rw [OpenPartialHomeomorph.trans_source] at hp
+  rw [OpenPartialHomeomorph.trans_apply, ← h.mem_iff hp.2, mem_inter_iff, mem_preimage,
+    and_iff_right hp.1]
+
+/-- Composing a slice chart with a homeomorphism of the model space transports the slice. -/
+theorem transHomeomorph (h : IsSliceChart φ S A) (e : F ≃ₜ F') :
+    IsSliceChart (φ.trans e.toOpenPartialHomeomorph) (e '' S) A := by
+  refine isSliceChart_iff.2 fun y hy => ?_
+  rw [OpenPartialHomeomorph.trans_source] at hy
+  rw [OpenPartialHomeomorph.trans_apply, h.mem_iff hy.1]
+  simp
+
+/-- The product of two slice charts is a slice chart for the product slice. -/
+theorem prod {ψ : OpenPartialHomeomorph N F'} {S' : Set F'} {B : Set N}
+    (h : IsSliceChart φ S A) (h' : IsSliceChart ψ S' B) :
+    IsSliceChart (φ.prod ψ) (S ×ˢ S') (A ×ˢ B) := by
+  refine isSliceChart_iff.2 fun p hp => ?_
+  rw [OpenPartialHomeomorph.prod_source] at hp
+  rw [OpenPartialHomeomorph.prod_apply, mem_prod, mem_prod, h.mem_iff hp.1, h'.mem_iff hp.2]
+
+end IsSliceChart
+
+/-- A chart is a slice chart for the full model space exactly when everything it sees lies in the
+set: this is the codimension-zero case. -/
+theorem isSliceChart_univ_iff : IsSliceChart φ (univ : Set F) A ↔ φ.source ⊆ A := by
+  simp [isSliceChart_iff, subset_def]
+
+/-- A topological embedding `f : N → M` is *locally flat* with model slice `S ⊆ F` if around every
+point of its image there is a chart of `M` with values in the model space `F` carrying the image of
+`f` onto `S`. For a topological manifold `M` modelled on `F` and a locally flat embedding of an
+`n`-manifold in codimension `k`, `S` is a coordinate `ℝⁿ ⊆ ℝⁿ⁺ᵏ`. -/
+structure IsLocallyFlat (S : Set F) (f : N → M) : Prop where
+  /-- A locally flat map is in particular a topological embedding. -/
+  isEmbedding : IsEmbedding f
+  /-- Around every point of the image there is a chart flattening the image onto the slice. -/
+  exists_isSliceChart : ∀ x : N, ∃ φ : OpenPartialHomeomorph M F,
+    f x ∈ φ.source ∧ IsSliceChart φ S (range f)
+
+variable {f : N → M}
+
+namespace IsLocallyFlat
+
+theorem continuous (h : IsLocallyFlat S f) : Continuous f :=
+  h.isEmbedding.continuous
+
+theorem injective (h : IsLocallyFlat S f) : Function.Injective f :=
+  h.isEmbedding.injective
+
+/-- Local flatness is inherited by the restriction to an open subset of the domain. -/
+theorem restrict (h : IsLocallyFlat S f) {U : Set N} (hU : IsOpen U) :
+    IsLocallyFlat S (f ∘ ((↑) : U → N)) := by
+  obtain ⟨V, hV, rfl⟩ := h.isEmbedding.isInducing.isOpen_iff.1 hU
+  have hrange : range (f ∘ ((↑) : (f ⁻¹' V) → N)) = range f ∩ V := by
+    rw [range_comp, Subtype.range_coe, image_preimage_eq_inter_range, inter_comm]
+  refine ⟨h.isEmbedding.comp IsEmbedding.subtypeVal, fun x => ?_⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
+  refine ⟨φ.restrOpen V hV, ?_, ?_⟩
+  · exact ⟨hφx, x.2⟩
+  · rw [hrange]
+    exact hφ.restrOpen hV
+
+/-- Local flatness is a local property of the domain: if every point of `N` has an open
+neighbourhood on which the restriction of `f` is locally flat, then `f` is locally flat. -/
+theorem of_forall_exists_isOpen (hf : IsEmbedding f)
+    (h : ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat S (f ∘ ((↑) : U → N))) :
+    IsLocallyFlat S f := by
+  refine ⟨hf, fun x => ?_⟩
+  obtain ⟨U, hU, hxU, hflat⟩ := h x
+  obtain ⟨V, hV, rfl⟩ := hf.isInducing.isOpen_iff.1 hU
+  obtain ⟨φ, hφx, hφ⟩ := hflat.exists_isSliceChart ⟨x, hxU⟩
+  rw [range_comp, Subtype.range_coe, image_preimage_eq_inter_range, inter_comm] at hφ
+  exact ⟨φ.restrOpen V hV, ⟨hφx, hxU⟩, hφ.of_inter hV⟩
+
+/-- Local flatness is invariant under precomposition with a homeomorphism of the domain. -/
+theorem comp_homeomorph (h : IsLocallyFlat S f) (e : N' ≃ₜ N) : IsLocallyFlat S (f ∘ e) := by
+  refine ⟨h.isEmbedding.comp e.isEmbedding, fun x => ?_⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart (e x)
+  exact ⟨φ, hφx, by rwa [range_comp, e.surjective.range_eq, image_univ]⟩
+
+/-- Pushing a locally flat embedding forward along an open embedding of the ambient space keeps it
+locally flat. Taking `g` the inclusion of an open subset, this is the statement that a locally flat
+embedding into an open subset is locally flat into the whole space. -/
+theorem comp_isOpenEmbedding {g : M → P} (h : IsLocallyFlat S f) (hg : IsOpenEmbedding g) :
+    IsLocallyFlat S (g ∘ f) := by
+  refine ⟨hg.isEmbedding.comp h.isEmbedding, fun x => ?_⟩
+  have : Nonempty M := ⟨f x⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
+  set e := (hg.toOpenPartialHomeomorph g).symm with he
+  have hsource : e.source = range g := by simp [he]
+  have hsymm : ∀ y : M, e (g y) = y := fun y => hg.toOpenPartialHomeomorph_left_inv g
+  have hset : e.source ∩ e ⁻¹' range f = range (g ∘ f) := by
+    ext p
+    simp only [hsource, mem_inter_iff, mem_preimage, range_comp]
+    constructor
+    · rintro ⟨⟨y, rfl⟩, hy⟩
+      exact mem_image_of_mem g (by rwa [hsymm] at hy)
+    · rintro ⟨y, hy, rfl⟩
+      exact ⟨mem_range_self y, by rwa [hsymm]⟩
+  refine ⟨e.trans φ, ?_, ?_⟩
+  · rw [OpenPartialHomeomorph.trans_source]
+    exact ⟨hsource ▸ mem_range_self (f x),
+      by simpa only [mem_preimage, Function.comp_apply, hsymm] using hφx⟩
+  · simpa only [hset] using hφ.comp e
+
+/-- Conversely, an embedding that becomes locally flat after an open embedding of the ambient space
+was already locally flat. Taking `g` the inclusion of an open subset, this corestricts a locally
+flat embedding to an open neighbourhood of its image. -/
+theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
+    (h : IsLocallyFlat S (g ∘ f)) : IsLocallyFlat S f := by
+  refine ⟨hg.isEmbedding.of_comp_iff.1 h.isEmbedding, fun x => ?_⟩
+  have : Nonempty M := ⟨f x⟩
+  obtain ⟨ψ, hψx, hψ⟩ := h.exists_isSliceChart x
+  set e := hg.toOpenPartialHomeomorph g with he
+  have hsource : e.source = univ := by simp [he]
+  have happly : ∀ y : M, e y = g y := fun y => congrFun (hg.toOpenPartialHomeomorph_apply g) y
+  have hset : e.source ∩ e ⁻¹' range (g ∘ f) = range f := by
+    ext y
+    simp only [hsource, univ_inter, mem_preimage, happly, range_comp,
+      hg.injective.mem_set_image]
+  refine ⟨e.trans ψ, ?_, ?_⟩
+  · rw [OpenPartialHomeomorph.trans_source]
+    exact ⟨hsource ▸ mem_univ _,
+      by simpa only [mem_preimage, happly, Function.comp_apply] using hψx⟩
+  · simpa only [hset] using hψ.comp e
+
+/-- Corestriction: a locally flat embedding whose image lies in an open subset `V` of the ambient
+space is locally flat as a map into `V`. -/
+theorem codRestrict (h : IsLocallyFlat S f) {V : Set M} (hV : IsOpen V) (hf : ∀ x, f x ∈ V) :
+    IsLocallyFlat S (fun x => (⟨f x, hf x⟩ : V)) :=
+  of_comp_isOpenEmbedding hV.isOpenEmbedding_subtypeVal h
+
+/-- Local flatness is invariant under a homeomorphism of the ambient space. -/
+theorem homeomorph_comp (h : IsLocallyFlat S f) (e : M ≃ₜ P) : IsLocallyFlat S (e ∘ f) :=
+  h.comp_isOpenEmbedding e.isOpenEmbedding
+
+/-- Local flatness only depends on the model space up to homeomorphism, the slice being transported
+along. -/
+theorem transHomeomorph (h : IsLocallyFlat S f) (e : F ≃ₜ F') : IsLocallyFlat (e '' S) f := by
+  refine ⟨h.isEmbedding, fun x => ?_⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
+  refine ⟨φ.trans e.toOpenPartialHomeomorph, ?_, hφ.transHomeomorph e⟩
+  rw [OpenPartialHomeomorph.trans_source]
+  simpa using hφx
+
+/-- A product of locally flat embeddings is locally flat, with the product slice: a product of
+slice charts is a slice chart. -/
+theorem prodMap {S' : Set F'} {g : N' → P} (h : IsLocallyFlat S f) (h' : IsLocallyFlat S' g) :
+    IsLocallyFlat (S ×ˢ S') (Prod.map f g) := by
+  refine ⟨h.isEmbedding.prodMap h'.isEmbedding, fun x => ?_⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x.1
+  obtain ⟨ψ, hψx, hψ⟩ := h'.exists_isSliceChart x.2
+  refine ⟨φ.prod ψ, ?_, ?_⟩
+  · rw [OpenPartialHomeomorph.prod_source]
+    exact ⟨hφx, hψx⟩
+  · rw [range_prodMap]
+    exact hφ.prod hψ
+
+/-- A locally flat embedding in codimension zero is an open embedding. -/
+theorem isOpenEmbedding (h : IsLocallyFlat (univ : Set F) f) : IsOpenEmbedding f := by
+  refine ⟨h.isEmbedding, isOpen_iff_mem_nhds.2 ?_⟩
+  rintro _ ⟨x, rfl⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
+  exact Filter.mem_of_superset (φ.open_source.mem_nhds hφx) (isSliceChart_univ_iff.1 hφ)
+
+/-- The image of a locally flat embedding is locally closed as soon as the model slice is closed.
+This is where the definition has teeth: the image of a wild embedding need not be locally closed in
+any chart in this way. -/
+theorem isLocallyClosed_range (h : IsLocallyFlat S f) (hS : IsClosed S) :
+    IsLocallyClosed (range f) := by
+  refine ((isLocallyClosed_tfae (range f)).out 2 0).1 ?_
+  rintro _ ⟨x, rfl⟩
+  obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
+  refine ⟨φ.source, φ.open_source.mem_nhds hφx, ?_⟩
+  have hpre : ((Subtype.val : φ.source → M) ⁻¹' range f) = (fun y : φ.source => φ ↑y) ⁻¹' S := by
+    ext y
+    exact hφ.mem_iff y.2
+  change IsClosed ((Subtype.val : φ.source → M) ⁻¹' range f)
+  rw [hpre]
+  exact hS.preimage φ.continuousOn.domRestrict
+
+end IsLocallyFlat
+
+/-- Local flatness is exactly a local property of the domain. -/
+theorem isLocallyFlat_iff_forall_exists_isOpen :
+    IsLocallyFlat S f ↔ IsEmbedding f ∧
+      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat S (f ∘ ((↑) : U → N)) :=
+  ⟨fun h => ⟨h.isEmbedding, fun x => ⟨univ, isOpen_univ, mem_univ x, h.restrict isOpen_univ⟩⟩,
+    fun h => .of_forall_exists_isOpen h.1 h.2⟩
+
+/-- An open embedding into a space charted on `F` is locally flat with the full model space as
+slice. -/
+theorem isLocallyFlat_univ_of_isOpenEmbedding [ChartedSpace F M] (h : IsOpenEmbedding f) :
+    IsLocallyFlat (univ : Set F) f := by
+  refine ⟨h.isEmbedding, fun x => ?_⟩
+  refine ⟨(chartAt F (f x)).restrOpen (range f) h.isOpen_range,
+    ⟨mem_chart_source F (f x), mem_range_self x⟩, ?_⟩
+  exact isSliceChart_univ_iff.2 fun _ hy => hy.2
+
+/-- Codimension zero: a map into a space charted on `F` is locally flat with slice the whole model
+space exactly when it is an open embedding. -/
+theorem isLocallyFlat_univ_iff [ChartedSpace F M] :
+    IsLocallyFlat (univ : Set F) f ↔ IsOpenEmbedding f :=
+  ⟨IsLocallyFlat.isOpenEmbedding, isLocallyFlat_univ_of_isOpenEmbedding⟩
+
+/-- The standard local model: the inclusion of `F` as the slice `F × {c}` of `F × F'` is locally
+flat. With `F = ℝⁿ` and `F' = ℝᵏ` this is the coordinate slice `ℝⁿ ⊆ ℝⁿ⁺ᵏ` that local flatness
+is modelled on. -/
+theorem isLocallyFlat_prodMkLeft (c : F') :
+    IsLocallyFlat ((univ : Set F) ×ˢ ({c} : Set F')) (fun x : F => (x, c)) := by
+  have hrange : (range fun x : F => (x, c)) = (univ : Set F) ×ˢ ({c} : Set F') := by
+    ext p
+    simp [Prod.ext_iff, eq_comm]
+  refine ⟨isEmbedding_prodMkLeft c, fun x => ⟨OpenPartialHomeomorph.refl (F × F'), mem_univ _, ?_⟩⟩
+  rw [hrange]
+  exact isSliceChart_iff.2 fun y _ => Iff.rfl
+
+end TauCeti

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -67,6 +67,8 @@ discs (topological sliceness) and for stating the annulus conjecture.
   under open embeddings and homeomorphisms of the ambient space and of the domain.
 * `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
   space.
+* `TauCeti.IsLocallyFlat.comp`: a composite of locally flat embeddings is locally flat, under an
+  explicit hypothesis that their flattening charts are chosen compatibly.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
 * `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
 * `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed, as soon as
@@ -102,10 +104,15 @@ For the standard model, a chart in the relative sense can be shrunk to a ball ar
 rescaled onto `(ℝᵐ, ℝⁿ)`, recovering the textbook form, but that comparison needs the linear
 structure and is not formalised here.
 
-Composing two locally flat embeddings `N ↪ M ↪ P` is deliberately absent: it is not a formal
-consequence of the definition, because the two flattening charts have to be made compatible before
-they can be combined. Only the codimension-zero ambient case is proved here, as
-`TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
+Composing two locally flat embeddings `N ↪ M ↪ P` is not a formal consequence of the definition:
+the chart of `M` flattening the inner embedding and the chart of `P` flattening the outer one are
+chosen independently, and nothing makes them agree. `TauCeti.IsLocallyFlat.comp` therefore carries
+that agreement as an explicit hypothesis — the outer chart reads the intermediate coordinates off
+the inner one along `g` — rather than assuming the conclusion; the outer chart then flattens the
+composite, and the complementary models multiply. It is stated only for the standard slice, since
+the compatibility condition refers to the splitting `F × F'` of the intermediate model, which the
+relative layer does not have. The ambient codimension-zero case needs no such hypothesis and is
+kept separate, as `TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
 
 ## References
 
@@ -156,6 +163,9 @@ theorem isSliceChart_iff :
 
 namespace IsSliceChart
 
+/-- On the source of a slice chart, membership in the flattened set is membership of the
+coordinates in the model slice. This is the pointwise form of `TauCeti.isSliceChart_iff` in the
+shape proofs use it, as an elimination rule at a single point. -/
 theorem mem_iff (h : IsSliceChart φ S A) {y : M} (hy : y ∈ φ.source) : y ∈ A ↔ φ y ∈ S :=
   isSliceChart_iff.1 h y hy
 
@@ -475,6 +485,51 @@ theorem codRestrict (h : IsLocallyFlat F F' f) {V : Set M} (hV : IsOpen V) (hf :
 /-- Local flatness is invariant under a homeomorphism of the ambient space. -/
 theorem homeomorph_comp (h : IsLocallyFlat F F' f) (e : M ≃ₜ P) : IsLocallyFlat F F' (e ∘ f) :=
   IsSliceEmbedding.homeomorph_comp h e
+
+/-- **Composition of locally flat embeddings**, under an explicit compatibility hypothesis on
+their flattening charts. Local flatness of `f : N → M` and of `g : M → P` does not by itself make
+`g ∘ f` locally flat, because the chart of `M` flattening `f` and the chart of `P` flattening `g`
+need not have anything to do with each other; `hcompat` is the hypothesis that they can be chosen
+coherently around each point of the domain. It asks for a flattening chart `φ` of `M` at `f x` and
+a flattening chart `ψ` of `P` at `g (f x)` such that `ψ` reads the intermediate coordinates off
+`φ` along `g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, and such that `ψ` sees no
+more of `range g` than `φ` charts. That same `ψ` then flattens `g ∘ f`, whose complementary model
+is the product of the two complementary models. -/
+theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
+    (hg : IsLocallyFlat (F × F') G' g) (hf : IsLocallyFlat F F' f)
+    (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
+      ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧ f x ∈ φ.source ∧
+        IsSliceChart ψ ((univ : Set (F × F')) ×ˢ ({0} : Set G')) (range g) ∧
+        IsSliceChart φ ((univ : Set F) ×ˢ ({0} : Set F')) (range f) ∧
+        ψ.source ∩ range g ⊆ g '' φ.source ∧ ∀ y ∈ φ.source, ψ (g y) = (φ y, 0)) :
+    IsLocallyFlat F (F' × G') (g ∘ f) := by
+  -- In the model `(F × F') × G'` of `P` the composite is flattened onto the iterated slice; the
+  -- standard slice of `F × (F' × G')` is that one after reassociating the coordinates.
+  have key : IsSliceEmbedding (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ({0} : Set G')) (g ∘ f) := by
+    refine ⟨hg.isEmbedding.comp hf.isEmbedding, fun x => ?_⟩
+    obtain ⟨ψ, φ, hψx, hφx, hψ, hφ, hsub, hagree⟩ := hcompat x
+    refine ⟨ψ, hψx, isSliceChart_iff.2 fun p hp => ?_⟩
+    constructor
+    · intro hpf
+      obtain ⟨y, hy, rfl⟩ := hsub ⟨hp, range_comp_subset_range f g hpf⟩
+      obtain ⟨x', hx'⟩ := hpf
+      rw [Function.comp_apply] at hx'
+      rw [hagree y hy]
+      exact ⟨(hφ.mem_iff hy).1 ⟨x', hg.injective hx'⟩, rfl⟩
+    · intro hps
+      obtain ⟨y, hy, rfl⟩ := hsub ⟨hp, (hψ.mem_iff hp).2 ⟨mem_univ _, hps.2⟩⟩
+      rw [hagree y hy] at hps
+      obtain ⟨x', hx'⟩ := (hφ.mem_iff hy).2 hps.1
+      exact ⟨x', by rw [Function.comp_apply, hx']⟩
+  have himage : Homeomorph.prodAssoc F F' G' ''
+      (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ({0} : Set G')) =
+      (univ : Set F) ×ˢ ({0} : Set (F' × G')) := by
+    rw [Homeomorph.image_eq_preimage_symm]
+    ext ⟨a, b, c⟩
+    simp [Homeomorph.prodAssoc, Prod.ext_iff]
+  have hcomp := key.transHomeomorph (Homeomorph.prodAssoc F F' G')
+  rw [himage] at hcomp
+  exact hcomp
 
 /-- A product of locally flat embeddings is locally flat, the models multiplying: the product of
 two standard slices is the standard slice of the product, after the permutation of coordinates

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -67,8 +67,10 @@ discs (topological sliceness) and for stating the annulus conjecture.
   under open embeddings and homeomorphisms of the ambient space and of the domain.
 * `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
   space.
-* `TauCeti.IsLocallyFlat.comp`: a composite embedding is locally flat, under an explicit
-  hypothesis supplying flattening charts for the two factors that are chosen compatibly.
+* `TauCeti.IsLocallyFlat.comp`: a composite of locally flat embeddings is locally flat, under an
+  explicit hypothesis that their flattening charts can be chosen compatibly, and
+  `TauCeti.IsLocallyFlat.of_compatible_isSliceChart`, the form of it that assumes only the
+  compatible pair of charts.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
 * `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
 * `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed, as soon as
@@ -107,17 +109,21 @@ structure and is not formalised here.
 Composing two locally flat embeddings `N ↪ M ↪ P` is not a formal consequence of the definition:
 the chart of `M` flattening the inner embedding and the chart of `P` flattening the outer one are
 chosen independently, and nothing makes them agree. `TauCeti.IsLocallyFlat.comp` therefore carries
-that agreement as an explicit hypothesis — the outer chart reads the intermediate coordinates off
-the inner one along `g` — rather than assuming the conclusion; the outer chart then flattens the
-composite, and the complementary models multiply. That hypothesis already produces the flattening
-charts around each point of the domain, so nothing beyond the embedding content of the conclusion
-itself is assumed: that the composite is an embedding, and that the outer map is injective. The
-compatibility hypothesis is kept down to the part that is not already implied by the rest of it:
-the outer chart is only asked to detect `range g` in one direction, the other direction and the
-fact that the inner chart is a chart around `f x` both following from the agreement of the two
-charts together with injectivity of the outer map. It is
-stated only for the standard slice, since the compatibility condition refers to the splitting
-`F × F'` of the intermediate model, which the relative layer does not have. The ambient
+that agreement as an explicit hypothesis on charts witnessing the local flatness of the two
+factors — the outer chart reads the intermediate coordinates off the inner one along `g` — rather
+than assuming the conclusion; the outer chart then flattens the composite, and the complementary
+models multiply. Composition comes in two levels, because a witnessing chart can only be referred
+to by exhibiting it, so the compatibility hypothesis necessarily re-exhibits the two charts and
+thereby already carries the flattening content of the two factors. `TauCeti.IsLocallyFlat.comp` is
+the statement in the shape it is used and read, with both factors locally flat;
+`TauCeti.IsLocallyFlat.of_compatible_isSliceChart` is what its proof actually consumes, a
+compatible pair of charts around each point together with the embedding content of the conclusion
+itself, and `comp` is a two-line consequence of it. There the compatibility hypothesis is kept down
+to the part not already implied by the rest of it: the outer chart is only asked to detect
+`range g` in one direction, the other direction and the fact that the inner chart is a chart around
+`f x` both following from the agreement of the two charts together with injectivity of the outer
+map. Both are stated only for the standard slice, since the compatibility condition refers to the
+splitting `F × F'` of the intermediate model, which the relative layer does not have. The ambient
 codimension-zero case needs no such hypothesis and is kept separate, as
 `TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
 
@@ -493,21 +499,19 @@ theorem codRestrict (h : IsLocallyFlat F F' f) {V : Set M} (hV : IsOpen V) (hf :
 theorem homeomorph_comp (h : IsLocallyFlat F F' f) (e : M ≃ₜ P) : IsLocallyFlat F F' (e ∘ f) :=
   IsSliceEmbedding.homeomorph_comp h e
 
-/-- **Composition of locally flat embeddings**, under an explicit compatibility hypothesis on
-their flattening charts. Local flatness of `f : N → M` and of `g : M → P` does not by itself make
-`g ∘ f` locally flat, because the chart of `M` flattening `f` and the chart of `P` flattening `g`
-need not have anything to do with each other; `hcompat` is the hypothesis that they can be chosen
-coherently around each point of the domain. It asks for a chart `ψ` of `P` at `g (f x)` and a
-flattening chart `φ` of `M` for `f` such that `ψ` reads the intermediate coordinates off `φ` along
-`g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, such that `ψ` sees no more of
-`range g` than `φ` charts, and such that on its source `ψ` detects `range g` from the vanishing of
-the outer coordinate. That same `ψ` then flattens `g ∘ f`, whose complementary model is the product
-of the two complementary models. Since `hcompat` already supplies every flattening chart the
-conclusion needs, the only embedding content assumed is what the conclusion itself carries, that
-`g ∘ f` is an embedding, together with injectivity of `g`. Only the stated half of the flattening
-of `range g` by `ψ` is assumed, the other half being forced by `hagree` and `hsub`; likewise
-`f x ∈ φ.source` is not assumed, since `hsub` and injectivity of `g` already give it. -/
-theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
+/-- The general form of `TauCeti.IsLocallyFlat.comp`: what makes a composite locally flat is a
+compatible pair of charts around each point of the domain, and nothing else. It asks for a chart
+`ψ` of `P` at `g (f x)` and a flattening chart `φ` of `M` for `f` such that `ψ` reads the
+intermediate coordinates off `φ` along `g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`,
+such that `ψ` sees no more of `range g` than `φ` charts, and such that on its source `ψ` detects
+`range g` from the vanishing of the outer coordinate. That same `ψ` then flattens `g ∘ f`, whose
+complementary model is the product of the two complementary models. Since `hcompat` already
+supplies every flattening chart the conclusion needs, the only embedding content assumed is what
+the conclusion itself carries, that `g ∘ f` is an embedding, together with injectivity of `g`. Only
+the stated half of the flattening of `range g` by `ψ` is assumed, the other half being forced by
+`hagree` and `hsub`; likewise `f x ∈ φ.source` is not assumed, since `hsub` and injectivity of `g`
+already give it. -/
+theorem of_compatible_isSliceChart {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
     (hgf : IsEmbedding (g ∘ f)) (hg : Function.Injective g)
     (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
       ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧
@@ -542,6 +546,32 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
   have hcomp := key.transHomeomorph (Homeomorph.prodAssoc F F' G')
   rw [himage] at hcomp
   exact hcomp
+
+/-- **Composition of locally flat embeddings**, under an explicit compatibility hypothesis on
+their flattening charts. Local flatness of `f : N → M` and of `g : M → P` does not by itself make
+`g ∘ f` locally flat, because the chart of `M` flattening `f` and the chart of `P` flattening `g`
+are chosen independently and nothing makes them agree; `hcompat` is the hypothesis that charts
+witnessing `hf` and `hg` can be chosen coherently around each point of the domain, namely so that
+the outer chart reads the intermediate coordinates off the inner one along `g`, in the sense
+`ψ (g y) = (φ y, 0)` on the source of `φ`, and sees no more of `range g` than the inner one charts.
+The outer chart then flattens the composite, whose complementary model is the product of the two
+complementary models.
+
+Only the compatible pair of charts is used, not the two local flatness hypotheses in full; that
+sharper form is `TauCeti.IsLocallyFlat.of_compatible_isSliceChart`, from which this is derived. -/
+theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
+    (hg : IsLocallyFlat (F × F') G' g) (hf : IsLocallyFlat F F' f)
+    (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
+      ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧ f x ∈ φ.source ∧
+        IsSliceChart ψ ((univ : Set (F × F')) ×ˢ ({0} : Set G')) (range g) ∧
+        IsSliceChart φ ((univ : Set F) ×ˢ ({0} : Set F')) (range f) ∧
+        ψ.source ∩ range g ⊆ g '' φ.source ∧ ∀ y ∈ φ.source, ψ (g y) = (φ y, 0)) :
+    IsLocallyFlat F (F' × G') (g ∘ f) :=
+  of_compatible_isSliceChart (hg.isEmbedding.comp hf.isEmbedding) hg.injective fun x => by
+    obtain ⟨ψ, φ, hψx, -, hψ, hφ, hsub, hagree⟩ := hcompat x
+    -- The flattening of `range g` by `ψ` gives in particular the one direction of it that
+    -- `of_compatible_isSliceChart` asks for.
+    exact ⟨ψ, φ, hψx, fun p hp hp2 => (hψ.mem_iff hp).2 ⟨mem_univ _, hp2⟩, hφ, hsub, hagree⟩
 
 /-- A product of locally flat embeddings is locally flat, the models multiplying: the product of
 two standard slices is the standard slice of the product, after the permutation of coordinates

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -111,7 +111,11 @@ that agreement as an explicit hypothesis — the outer chart reads the intermedi
 the inner one along `g` — rather than assuming the conclusion; the outer chart then flattens the
 composite, and the complementary models multiply. That hypothesis already produces the flattening
 charts around each point of the domain, so nothing beyond the embedding content of the conclusion
-itself is assumed: that the composite is an embedding, and that the outer map is injective. It is
+itself is assumed: that the composite is an embedding, and that the outer map is injective. The
+compatibility hypothesis is kept down to the part that is not already implied by the rest of it:
+the outer chart is only asked to detect `range g` in one direction, the other direction and the
+fact that the inner chart is a chart around `f x` both following from the agreement of the two
+charts together with injectivity of the outer map. It is
 stated only for the standard slice, since the compatibility condition refers to the splitting
 `F × F'` of the intermediate model, which the relative layer does not have. The ambient
 codimension-zero case needs no such hypothesis and is kept separate, as
@@ -493,18 +497,21 @@ theorem homeomorph_comp (h : IsLocallyFlat F F' f) (e : M ≃ₜ P) : IsLocallyF
 their flattening charts. Local flatness of `f : N → M` and of `g : M → P` does not by itself make
 `g ∘ f` locally flat, because the chart of `M` flattening `f` and the chart of `P` flattening `g`
 need not have anything to do with each other; `hcompat` is the hypothesis that they can be chosen
-coherently around each point of the domain. It asks for a flattening chart `φ` of `M` at `f x` and
-a flattening chart `ψ` of `P` at `g (f x)` such that `ψ` reads the intermediate coordinates off
-`φ` along `g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, and such that `ψ` sees no
-more of `range g` than `φ` charts. That same `ψ` then flattens `g ∘ f`, whose complementary model
-is the product of the two complementary models. Since `hcompat` already supplies every flattening
-chart the conclusion needs, the only embedding content assumed is what the conclusion itself
-carries, that `g ∘ f` is an embedding, together with injectivity of `g`. -/
+coherently around each point of the domain. It asks for a chart `ψ` of `P` at `g (f x)` and a
+flattening chart `φ` of `M` for `f` such that `ψ` reads the intermediate coordinates off `φ` along
+`g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, such that `ψ` sees no more of
+`range g` than `φ` charts, and such that on its source `ψ` detects `range g` from the vanishing of
+the outer coordinate. That same `ψ` then flattens `g ∘ f`, whose complementary model is the product
+of the two complementary models. Since `hcompat` already supplies every flattening chart the
+conclusion needs, the only embedding content assumed is what the conclusion itself carries, that
+`g ∘ f` is an embedding, together with injectivity of `g`. Only the stated half of the flattening
+of `range g` by `ψ` is assumed, the other half being forced by `hagree` and `hsub`; likewise
+`f x ∈ φ.source` is not assumed, since `hsub` and injectivity of `g` already give it. -/
 theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
     (hgf : IsEmbedding (g ∘ f)) (hg : Function.Injective g)
     (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
-      ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧ f x ∈ φ.source ∧
-        IsSliceChart ψ ((univ : Set (F × F')) ×ˢ ({0} : Set G')) (range g) ∧
+      ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧
+        (∀ p ∈ ψ.source, (ψ p).2 = 0 → p ∈ range g) ∧
         IsSliceChart φ ((univ : Set F) ×ˢ ({0} : Set F')) (range f) ∧
         ψ.source ∩ range g ⊆ g '' φ.source ∧ ∀ y ∈ φ.source, ψ (g y) = (φ y, 0)) :
     IsLocallyFlat F (F' × G') (g ∘ f) := by
@@ -512,7 +519,7 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
   -- standard slice of `F × (F' × G')` is that one after reassociating the coordinates.
   have key : IsSliceEmbedding (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ({0} : Set G')) (g ∘ f) := by
     refine ⟨hgf, fun x => ?_⟩
-    obtain ⟨ψ, φ, hψx, hφx, hψ, hφ, hsub, hagree⟩ := hcompat x
+    obtain ⟨ψ, φ, hψx, hψ, hφ, hsub, hagree⟩ := hcompat x
     refine ⟨ψ, hψx, isSliceChart_iff.2 fun p hp => ?_⟩
     constructor
     · intro hpf
@@ -522,7 +529,7 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
       rw [hagree y hy]
       exact ⟨(hφ.mem_iff hy).1 ⟨x', hg hx'⟩, rfl⟩
     · intro hps
-      obtain ⟨y, hy, rfl⟩ := hsub ⟨hp, (hψ.mem_iff hp).2 ⟨mem_univ _, hps.2⟩⟩
+      obtain ⟨y, hy, rfl⟩ := hsub ⟨hp, hψ p hp hps.2⟩
       rw [hagree y hy] at hps
       obtain ⟨x', hx'⟩ := (hφ.mem_iff hy).2 hps.1
       exact ⟨x', by rw [Function.comp_apply, hx']⟩

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Algebra.Group.Prod
 public import Mathlib.Geometry.Manifold.ChartedSpace
 public import Mathlib.Topology.LocallyClosed
 
@@ -14,29 +15,33 @@ Topological manifolds admit embeddings that no smooth embedding can imitate: the
 sphere is a topologically embedded `2`-sphere in `S³` bounding a non-simply-connected region, and a
 wild arc in `ℝ³` is knotted although its domain is an interval. Theorems about topological
 manifolds therefore quantify over *locally flat* embeddings, those that in suitable ambient charts
-look like a fixed slice of the model space.
+look like the standard coordinate slice.
 
-This file introduces that notion and the structural API it is used through. The definition is split
-into two layers.
+This file introduces that notion and the structural API it is used through. The definition is built
+in three layers.
 
 * `TauCeti.IsSliceChart φ S A` says that a single chart `φ` of the ambient space flattens the set
   `A` onto the model slice `S`, in the sense that `φ '' (φ.source ∩ A) = φ.target ∩ S`.
-* `TauCeti.IsLocallyFlat S f` says that `f` is a topological embedding admitting a slice chart for
-  `Set.range f` around every point of its image.
+* `TauCeti.IsSliceEmbedding S f` says that `f` is a topological embedding admitting a slice chart
+  for `Set.range f` around every point of its image. Here `S` is an arbitrary subset of an
+  arbitrary model space, so this is *not* local flatness; it is the transport layer on which the
+  closure properties are proved, and it is stated relatively so that they can be.
+* `TauCeti.IsLocallyFlat F F' f` is local flatness proper: it is `IsSliceEmbedding` for the
+  *standard coordinate slice* `F × {0}` of the model space `F × F'`, so ambient charts take values
+  in `F × F'` and carry the image of `f` exactly onto the vanishing locus of the last `F'`
+  coordinates. With `F = ℝⁿ` and `F' = ℝᵏ` this is the textbook `ℝⁿ × {0} ⊆ ℝⁿ⁺ᵏ`.
+
+Codimension is not baked in: it is the choice of the complementary model `F'`, so codimension `0`
+(`F'` a subsingleton, where local flatness is openness of the embedding), codimension `1` (where
+collaring lives) and codimension `2` (where knotting lives) are all instances of the one predicate,
+which is the point.
 
 Local flatness is a local condition, so the load-bearing content is not the definition but its
 closure properties: restriction to an open subset of the domain, locality, invariance under
 homeomorphisms and open embeddings on either side, invariance under a change of model space, and
 products. Those are proved here, together with two results that pin the notion down: in codimension
-zero (`S = Set.univ`) local flatness is exactly openness of the embedding, and a locally flat
-embedding with a closed model slice has locally closed image.
-
-The slice `S` is a parameter rather than a fixed coordinate subspace, deliberately: codimension `0`
-(open embeddings), codimension `1` (where collaring lives) and codimension `2` (where knotting
-lives) behave very differently, and keeping one predicate for all of them is the point.
-`TauCeti.isLocallyFlat_prodMkLeft` records the standard model, the inclusion `X → X × Y`,
-`x ↦ (x, c)`, whose slice is `Set.univ ×ˢ {c}`; taking `X = ℝⁿ` and `Y = ℝᵏ` gives the usual
-`ℝⁿ ⊆ ℝⁿ⁺ᵏ` picture.
+zero local flatness is exactly openness of the embedding, and a locally flat embedding has locally
+closed image as soon as the complementary model is `T1`.
 
 This is layer 2 of the geometric-topology roadmap, the substrate for topologically locally flat
 discs (topological sliceness) and for stating the annulus conjecture.
@@ -44,7 +49,8 @@ discs (topological sliceness) and for stating the annulus conjecture.
 ## Main definitions
 
 * `TauCeti.IsSliceChart`: an ambient chart flattening a set onto a model slice.
-* `TauCeti.IsLocallyFlat`: a topological embedding that is flat in ambient charts.
+* `TauCeti.IsSliceEmbedding`: an embedding flattened onto a given model slice by ambient charts.
+* `TauCeti.IsLocallyFlat`: a locally flat embedding, the case of the standard coordinate slice.
 
 ## Main results
 
@@ -56,17 +62,33 @@ discs (topological sliceness) and for stating the annulus conjecture.
   `TauCeti.IsLocallyFlat.codRestrict`, `TauCeti.IsLocallyFlat.homeomorph_comp`,
   `TauCeti.IsLocallyFlat.comp_homeomorph`: invariance under open embeddings and homeomorphisms of
   the ambient space and of the domain.
-* `TauCeti.IsLocallyFlat.transHomeomorph`: invariance under a homeomorphic change of model space.
+* `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
+  space.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
-* `TauCeti.isLocallyFlat_univ_iff`: in codimension zero, locally flat means open.
-* `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a closed slice forces a locally closed image.
+* `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
+* `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed.
+* `TauCeti.isLocallyFlat_prodMkLeft`: the standard model `x ↦ (x, 0)` is locally flat.
 
 ## Implementation notes
 
+The relative predicate `IsSliceEmbedding` is deliberately *not* the definition of local flatness,
+and is not a substitute for it: its slice is an arbitrary subset of an arbitrary space, so taking
+the model space to be `M` itself, the slice to be `Set.range f` and the chart to be
+`OpenPartialHomeomorph.refl M` makes every embedding, wild ones included, a slice embedding. It is
+the layer on which transport is proved, because the closure properties genuinely need a slice that
+varies (a product of standard slices is a standard slice only after a permutation of coordinates,
+which is where `IsSliceEmbedding.transHomeomorph` is used). Local flatness is
+`IsLocallyFlat F F' f`, which fixes the slice to be the standard one, and that predicate does have
+teeth: `TauCeti.isLocallyFlat_iff_isOpenEmbedding` shows that in codimension zero it is equivalent
+to openness of the embedding, and `TauCeti.IsLocallyFlat.isLocallyClosed_range` rules out an image
+that is not locally closed, which the horned sphere's complement-side wildness aside is already
+enough to exclude embeddings no chart can flatten.
+
 No membership in a prescribed atlas is required of the flattening chart: an
-`OpenPartialHomeomorph M F` is automatically a chart of the maximal topological atlas of a
-topological manifold `M` modelled on `F`, so demanding atlas membership would be redundant there
-and would needlessly restrict the definition on ambient spaces that are not manifolds.
+`OpenPartialHomeomorph M (F × F')` is automatically a chart of the maximal topological atlas of a
+topological manifold `M` modelled on `F × F'`, so demanding atlas membership would be redundant
+there and would needlessly restrict the definition on ambient spaces that are not manifolds. The
+model-space data enters exactly as it does for `ChartedSpace`, through the codomain of the charts.
 
 A slice chart is only asked to flatten the set *relative to its own target*, that is
 `φ '' (φ.source ∩ A) = φ.target ∩ S` rather than `φ.target = F` together with
@@ -75,20 +97,6 @@ closed under restriction; the textbook form is not, since shrinking the source s
 For the standard model, a chart in the relative sense can be shrunk to a ball around the point and
 rescaled onto `(ℝᵐ, ℝⁿ)`, recovering the textbook form, but that comparison needs the linear
 structure and is not formalised here.
-
-Codimension is not baked into the definition; see the module docstring above.
-
-The pair `(F, S)` is the *local model*, and it is an argument of the predicate rather than
-something `IsLocallyFlat` picks: `IsLocallyFlat S f` asserts flatness against the model the caller
-names, so a statement about locally flat embeddings fixes that model, as
-`TauCeti.isLocallyFlat_prodMkLeft` fixes the standard slice `Set.univ ×ˢ {c}`. Degenerate models
-are cheap, as they are for `ChartedSpace`: Mathlib's `chartedSpaceSelf` charts every space on itself
-through the identity, and in the same way `F = M`, `S = Set.range f` and
-`OpenPartialHomeomorph.refl M` flatten any embedding at all. As with `ChartedSpace`, the content
-is in the model being the standard one, and the predicate has teeth once it is fixed:
-`TauCeti.isLocallyFlat_univ_iff` says that for `S = Set.univ` exactly the open embeddings are
-flat, and `TauCeti.IsLocallyFlat.isLocallyClosed_range` rules out an image that is not locally
-closed whenever `S` is closed.
 
 Composing two locally flat embeddings `N ↪ M ↪ P` is deliberately absent: it is not a formal
 consequence of the definition, because the two flattening charts have to be made compatible before
@@ -199,30 +207,44 @@ set: this is the codimension-zero case. -/
 theorem isSliceChart_univ_iff : IsSliceChart φ (univ : Set F) A ↔ φ.source ⊆ A := by
   simp [isSliceChart_iff, subset_def]
 
-/-- A topological embedding `f : N → M` is *locally flat* with model slice `S ⊆ F` if around every
-point of its image there is a chart of `M` with values in the model space `F` carrying the image of
-`f` onto `S`. For a topological manifold `M` modelled on `F` and a locally flat embedding of an
-`n`-manifold in codimension `k`, `S` is a coordinate `ℝⁿ ⊆ ℝⁿ⁺ᵏ`. -/
-structure IsLocallyFlat (S : Set F) (f : N → M) : Prop where
-  /-- A locally flat map is in particular a topological embedding. -/
+/-- A topological embedding `f : N → M` is a *slice embedding* for the model slice `S ⊆ F` if
+around every point of its image there is a chart of `M` with values in the model space `F` carrying
+the image of `f` onto `S`.
+
+This is a relative notion: `S` is arbitrary, so it is not local flatness, which is the case of the
+standard slice, `TauCeti.IsLocallyFlat`. It is the layer the transport lemmas are proved on, since
+they move the slice around. -/
+structure IsSliceEmbedding (S : Set F) (f : N → M) : Prop where
+  /-- A slice embedding is in particular a topological embedding. -/
   isEmbedding : IsEmbedding f
   /-- Around every point of the image there is a chart flattening the image onto the slice. -/
   exists_isSliceChart : ∀ x : N, ∃ φ : OpenPartialHomeomorph M F,
     f x ∈ φ.source ∧ IsSliceChart φ S (range f)
 
+variable (F F') in
+/-- A topological embedding `f : N → M` is *locally flat* with model `F × F'` if around every point
+of its image there is a chart of `M` with values in `F × F'` carrying the image of `f` onto the
+standard coordinate slice `F × {0}`.
+
+For `M` a topological manifold modelled on `F × F'` and `N` one modelled on `F` this is the usual
+condition that `f` looks like `ℝⁿ × {0} ⊆ ℝⁿ⁺ᵏ` in ambient charts; the codimension is the choice of
+the complementary model `F'`, and is not otherwise constrained. -/
+def IsLocallyFlat [Zero F'] (f : N → M) : Prop :=
+  IsSliceEmbedding ((univ : Set F) ×ˢ ({0} : Set F')) f
+
 variable {f : N → M}
 
-namespace IsLocallyFlat
+namespace IsSliceEmbedding
 
-theorem continuous (h : IsLocallyFlat S f) : Continuous f :=
+theorem continuous (h : IsSliceEmbedding S f) : Continuous f :=
   h.isEmbedding.continuous
 
-theorem injective (h : IsLocallyFlat S f) : Function.Injective f :=
+theorem injective (h : IsSliceEmbedding S f) : Function.Injective f :=
   h.isEmbedding.injective
 
-/-- Local flatness is inherited by the restriction to an open subset of the domain. -/
-theorem restrict (h : IsLocallyFlat S f) {U : Set N} (hU : IsOpen U) :
-    IsLocallyFlat S (f ∘ ((↑) : U → N)) := by
+/-- Being a slice embedding is inherited by the restriction to an open subset of the domain. -/
+theorem restrict (h : IsSliceEmbedding S f) {U : Set N} (hU : IsOpen U) :
+    IsSliceEmbedding S (f ∘ ((↑) : U → N)) := by
   obtain ⟨V, hV, rfl⟩ := h.isEmbedding.isInducing.isOpen_iff.1 hU
   have hrange : range (f ∘ ((↑) : (f ⁻¹' V) → N)) = range f ∩ V := by
     rw [range_comp, Subtype.range_coe, image_preimage_eq_inter_range, inter_comm]
@@ -233,11 +255,11 @@ theorem restrict (h : IsLocallyFlat S f) {U : Set N} (hU : IsOpen U) :
   · rw [hrange]
     exact hφ.restrOpen hV
 
-/-- Local flatness is a local property of the domain: if every point of `N` has an open
-neighbourhood on which the restriction of `f` is locally flat, then `f` is locally flat. -/
+/-- Being a slice embedding is a local property of the domain: if every point of `N` has an open
+neighbourhood on which the restriction of `f` is a slice embedding, then `f` is one. -/
 theorem of_forall_exists_isOpen (hf : IsEmbedding f)
-    (h : ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat S (f ∘ ((↑) : U → N))) :
-    IsLocallyFlat S f := by
+    (h : ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsSliceEmbedding S (f ∘ ((↑) : U → N))) :
+    IsSliceEmbedding S f := by
   refine ⟨hf, fun x => ?_⟩
   obtain ⟨U, hU, hxU, hflat⟩ := h x
   obtain ⟨V, hV, rfl⟩ := hf.isInducing.isOpen_iff.1 hU
@@ -245,17 +267,18 @@ theorem of_forall_exists_isOpen (hf : IsEmbedding f)
   rw [range_comp, Subtype.range_coe, image_preimage_eq_inter_range, inter_comm] at hφ
   exact ⟨φ.restrOpen V hV, ⟨hφx, hxU⟩, hφ.of_inter hV⟩
 
-/-- Local flatness is invariant under precomposition with a homeomorphism of the domain. -/
-theorem comp_homeomorph (h : IsLocallyFlat S f) (e : N' ≃ₜ N) : IsLocallyFlat S (f ∘ e) := by
+/-- Being a slice embedding is invariant under precomposition with a homeomorphism of the
+domain. -/
+theorem comp_homeomorph (h : IsSliceEmbedding S f) (e : N' ≃ₜ N) : IsSliceEmbedding S (f ∘ e) := by
   refine ⟨h.isEmbedding.comp e.isEmbedding, fun x => ?_⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart (e x)
   exact ⟨φ, hφx, by rwa [range_comp, e.surjective.range_eq, image_univ]⟩
 
-/-- Pushing a locally flat embedding forward along an open embedding of the ambient space keeps it
-locally flat. Taking `g` the inclusion of an open subset, this is the statement that a locally flat
-embedding into an open subset is locally flat into the whole space. -/
-theorem comp_isOpenEmbedding {g : M → P} (h : IsLocallyFlat S f) (hg : IsOpenEmbedding g) :
-    IsLocallyFlat S (g ∘ f) := by
+/-- Pushing a slice embedding forward along an open embedding of the ambient space keeps it a slice
+embedding. Taking `g` the inclusion of an open subset, this is the statement that a slice embedding
+into an open subset is one into the whole space. -/
+theorem comp_isOpenEmbedding {g : M → P} (h : IsSliceEmbedding S f) (hg : IsOpenEmbedding g) :
+    IsSliceEmbedding S (g ∘ f) := by
   refine ⟨hg.isEmbedding.comp h.isEmbedding, fun x => ?_⟩
   have : Nonempty M := ⟨f x⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
@@ -276,11 +299,11 @@ theorem comp_isOpenEmbedding {g : M → P} (h : IsLocallyFlat S f) (hg : IsOpenE
       by simpa only [mem_preimage, Function.comp_apply, hsymm] using hφx⟩
   · simpa only [hset] using hφ.comp e
 
-/-- Conversely, an embedding that becomes locally flat after an open embedding of the ambient space
-was already locally flat. Taking `g` the inclusion of an open subset, this corestricts a locally
-flat embedding to an open neighbourhood of its image. -/
+/-- Conversely, an embedding that becomes a slice embedding after an open embedding of the ambient
+space was already one. Taking `g` the inclusion of an open subset, this corestricts a slice
+embedding to an open neighbourhood of its image. -/
 theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
-    (h : IsLocallyFlat S (g ∘ f)) : IsLocallyFlat S f := by
+    (h : IsSliceEmbedding S (g ∘ f)) : IsSliceEmbedding S f := by
   refine ⟨hg.isEmbedding.of_comp_iff.1 h.isEmbedding, fun x => ?_⟩
   have : Nonempty M := ⟨f x⟩
   obtain ⟨ψ, hψx, hψ⟩ := h.exists_isSliceChart x
@@ -297,29 +320,29 @@ theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
       by simpa only [mem_preimage, happly, Function.comp_apply] using hψx⟩
   · simpa only [hset] using hψ.comp e
 
-/-- Corestriction: a locally flat embedding whose image lies in an open subset `V` of the ambient
-space is locally flat as a map into `V`. -/
-theorem codRestrict (h : IsLocallyFlat S f) {V : Set M} (hV : IsOpen V) (hf : ∀ x, f x ∈ V) :
-    IsLocallyFlat S (fun x => (⟨f x, hf x⟩ : V)) :=
+/-- Corestriction: a slice embedding whose image lies in an open subset `V` of the ambient space is
+a slice embedding as a map into `V`. -/
+theorem codRestrict (h : IsSliceEmbedding S f) {V : Set M} (hV : IsOpen V) (hf : ∀ x, f x ∈ V) :
+    IsSliceEmbedding S (fun x => (⟨f x, hf x⟩ : V)) :=
   of_comp_isOpenEmbedding hV.isOpenEmbedding_subtypeVal h
 
-/-- Local flatness is invariant under a homeomorphism of the ambient space. -/
-theorem homeomorph_comp (h : IsLocallyFlat S f) (e : M ≃ₜ P) : IsLocallyFlat S (e ∘ f) :=
+/-- Being a slice embedding is invariant under a homeomorphism of the ambient space. -/
+theorem homeomorph_comp (h : IsSliceEmbedding S f) (e : M ≃ₜ P) : IsSliceEmbedding S (e ∘ f) :=
   h.comp_isOpenEmbedding e.isOpenEmbedding
 
-/-- Local flatness only depends on the model space up to homeomorphism, the slice being transported
-along. -/
-theorem transHomeomorph (h : IsLocallyFlat S f) (e : F ≃ₜ F') : IsLocallyFlat (e '' S) f := by
+/-- Being a slice embedding only depends on the model space up to homeomorphism, the slice being
+transported along. -/
+theorem transHomeomorph (h : IsSliceEmbedding S f) (e : F ≃ₜ F') : IsSliceEmbedding (e '' S) f := by
   refine ⟨h.isEmbedding, fun x => ?_⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
   refine ⟨φ.trans e.toOpenPartialHomeomorph, ?_, hφ.transHomeomorph e⟩
   rw [OpenPartialHomeomorph.trans_source]
   simpa using hφx
 
-/-- A product of locally flat embeddings is locally flat, with the product slice: a product of
-slice charts is a slice chart. -/
-theorem prodMap {S' : Set F'} {g : N' → P} (h : IsLocallyFlat S f) (h' : IsLocallyFlat S' g) :
-    IsLocallyFlat (S ×ˢ S') (Prod.map f g) := by
+/-- A product of slice embeddings is a slice embedding for the product slice: a product of slice
+charts is a slice chart. -/
+theorem prodMap {S' : Set F'} {g : N' → P} (h : IsSliceEmbedding S f) (h' : IsSliceEmbedding S' g) :
+    IsSliceEmbedding (S ×ˢ S') (Prod.map f g) := by
   refine ⟨h.isEmbedding.prodMap h'.isEmbedding, fun x => ?_⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x.1
   obtain ⟨ψ, hψx, hψ⟩ := h'.exists_isSliceChart x.2
@@ -329,17 +352,17 @@ theorem prodMap {S' : Set F'} {g : N' → P} (h : IsLocallyFlat S f) (h' : IsLoc
   · rw [range_prodMap]
     exact hφ.prod hψ
 
-/-- A locally flat embedding in codimension zero is an open embedding. -/
-theorem isOpenEmbedding (h : IsLocallyFlat (univ : Set F) f) : IsOpenEmbedding f := by
+/-- A slice embedding for the full model space is an open embedding. -/
+theorem isOpenEmbedding (h : IsSliceEmbedding (univ : Set F) f) : IsOpenEmbedding f := by
   refine ⟨h.isEmbedding, isOpen_iff_mem_nhds.2 ?_⟩
   rintro _ ⟨x, rfl⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
   exact Filter.mem_of_superset (φ.open_source.mem_nhds hφx) (isSliceChart_univ_iff.1 hφ)
 
-/-- The image of a locally flat embedding is locally closed as soon as the model slice is closed.
-This is where the definition has teeth: the image of a wild embedding need not be locally closed in
-any chart in this way. -/
-theorem isLocallyClosed_range (h : IsLocallyFlat S f) (hS : IsClosed S) :
+/-- The image of a slice embedding is locally closed as soon as the model slice is closed. This is
+where the definition has teeth: the image of a wild embedding need not be locally closed in any
+chart in this way. -/
+theorem isLocallyClosed_range (h : IsSliceEmbedding S f) (hS : IsClosed S) :
     IsLocallyClosed (range f) := by
   refine ((isLocallyClosed_tfae (range f)).out 2 0).1 ?_
   rintro _ ⟨x, rfl⟩
@@ -352,40 +375,142 @@ theorem isLocallyClosed_range (h : IsLocallyFlat S f) (hS : IsClosed S) :
   rw [hpre]
   exact hS.preimage φ.continuousOn.domRestrict
 
-end IsLocallyFlat
+end IsSliceEmbedding
 
-/-- Local flatness is exactly a local property of the domain. -/
-theorem isLocallyFlat_iff_forall_exists_isOpen :
-    IsLocallyFlat S f ↔ IsEmbedding f ∧
-      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat S (f ∘ ((↑) : U → N)) :=
+/-- Being a slice embedding is exactly a local property of the domain. -/
+theorem isSliceEmbedding_iff_forall_exists_isOpen :
+    IsSliceEmbedding S f ↔ IsEmbedding f ∧
+      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsSliceEmbedding S (f ∘ ((↑) : U → N)) :=
   ⟨fun h => ⟨h.isEmbedding, fun x => ⟨univ, isOpen_univ, mem_univ x, h.restrict isOpen_univ⟩⟩,
     fun h => .of_forall_exists_isOpen h.1 h.2⟩
 
-/-- An open embedding into a space charted on `F` is locally flat with the full model space as
-slice. -/
-theorem isLocallyFlat_univ_of_isOpenEmbedding [ChartedSpace F M] (h : IsOpenEmbedding f) :
-    IsLocallyFlat (univ : Set F) f := by
+/-- An open embedding into a space charted on `F` is a slice embedding for the full model space. -/
+theorem isSliceEmbedding_univ_of_isOpenEmbedding [ChartedSpace F M] (h : IsOpenEmbedding f) :
+    IsSliceEmbedding (univ : Set F) f := by
   refine ⟨h.isEmbedding, fun x => ?_⟩
   refine ⟨(chartAt F (f x)).restrOpen (range f) h.isOpen_range,
     ⟨mem_chart_source F (f x), mem_range_self x⟩, ?_⟩
   exact isSliceChart_univ_iff.2 fun _ hy => hy.2
 
-/-- Codimension zero: a map into a space charted on `F` is locally flat with slice the whole model
+/-- Codimension zero: a map into a space charted on `F` is a slice embedding for the whole model
 space exactly when it is an open embedding. -/
-theorem isLocallyFlat_univ_iff [ChartedSpace F M] :
-    IsLocallyFlat (univ : Set F) f ↔ IsOpenEmbedding f :=
-  ⟨IsLocallyFlat.isOpenEmbedding, isLocallyFlat_univ_of_isOpenEmbedding⟩
+theorem isSliceEmbedding_univ_iff [ChartedSpace F M] :
+    IsSliceEmbedding (univ : Set F) f ↔ IsOpenEmbedding f :=
+  ⟨IsSliceEmbedding.isOpenEmbedding, isSliceEmbedding_univ_of_isOpenEmbedding⟩
 
-/-- The standard local model: the inclusion of `F` as the slice `F × {c}` of `F × F'` is locally
-flat. With `F = ℝⁿ` and `F' = ℝᵏ` this is the coordinate slice `ℝⁿ ⊆ ℝⁿ⁺ᵏ` that local flatness
-is modelled on. -/
-theorem isLocallyFlat_prodMkLeft (c : F') :
-    IsLocallyFlat ((univ : Set F) ×ˢ ({c} : Set F')) (fun x : F => (x, c)) := by
-  have hrange : (range fun x : F => (x, c)) = (univ : Set F) ×ˢ ({c} : Set F') := by
+section StandardSlice
+
+variable [Zero F']
+
+/-- Local flatness unfolded: it is the slice-embedding condition for the standard slice. All the
+transport lemmas are inherited through this. -/
+theorem isLocallyFlat_iff_isSliceEmbedding :
+    IsLocallyFlat F F' f ↔ IsSliceEmbedding ((univ : Set F) ×ˢ ({0} : Set F')) f :=
+  Iff.rfl
+
+namespace IsLocallyFlat
+
+theorem isEmbedding (h : IsLocallyFlat F F' f) : IsEmbedding f :=
+  IsSliceEmbedding.isEmbedding h
+
+theorem continuous (h : IsLocallyFlat F F' f) : Continuous f :=
+  h.isEmbedding.continuous
+
+theorem injective (h : IsLocallyFlat F F' f) : Function.Injective f :=
+  h.isEmbedding.injective
+
+/-- Local flatness is inherited by the restriction to an open subset of the domain. -/
+theorem restrict (h : IsLocallyFlat F F' f) {U : Set N} (hU : IsOpen U) :
+    IsLocallyFlat F F' (f ∘ ((↑) : U → N)) :=
+  IsSliceEmbedding.restrict h hU
+
+/-- Local flatness is a local property of the domain: if every point of `N` has an open
+neighbourhood on which the restriction of `f` is locally flat, then `f` is locally flat. -/
+theorem of_forall_exists_isOpen (hf : IsEmbedding f)
+    (h : ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat F F' (f ∘ ((↑) : U → N))) :
+    IsLocallyFlat F F' f :=
+  IsSliceEmbedding.of_forall_exists_isOpen hf h
+
+/-- Local flatness is invariant under precomposition with a homeomorphism of the domain. -/
+theorem comp_homeomorph (h : IsLocallyFlat F F' f) (e : N' ≃ₜ N) : IsLocallyFlat F F' (f ∘ e) :=
+  IsSliceEmbedding.comp_homeomorph h e
+
+/-- Pushing a locally flat embedding forward along an open embedding of the ambient space keeps it
+locally flat. Taking `g` the inclusion of an open subset, this is the statement that a locally flat
+embedding into an open subset is locally flat into the whole space. -/
+theorem comp_isOpenEmbedding {g : M → P} (h : IsLocallyFlat F F' f) (hg : IsOpenEmbedding g) :
+    IsLocallyFlat F F' (g ∘ f) :=
+  IsSliceEmbedding.comp_isOpenEmbedding h hg
+
+/-- Conversely, an embedding that becomes locally flat after an open embedding of the ambient space
+was already locally flat. -/
+theorem of_comp_isOpenEmbedding {g : M → P} (hg : IsOpenEmbedding g)
+    (h : IsLocallyFlat F F' (g ∘ f)) : IsLocallyFlat F F' f :=
+  IsSliceEmbedding.of_comp_isOpenEmbedding hg h
+
+/-- Corestriction: a locally flat embedding whose image lies in an open subset `V` of the ambient
+space is locally flat as a map into `V`. -/
+theorem codRestrict (h : IsLocallyFlat F F' f) {V : Set M} (hV : IsOpen V) (hf : ∀ x, f x ∈ V) :
+    IsLocallyFlat F F' (fun x => (⟨f x, hf x⟩ : V)) :=
+  IsSliceEmbedding.codRestrict h hV hf
+
+/-- Local flatness is invariant under a homeomorphism of the ambient space. -/
+theorem homeomorph_comp (h : IsLocallyFlat F F' f) (e : M ≃ₜ P) : IsLocallyFlat F F' (e ∘ f) :=
+  IsSliceEmbedding.homeomorph_comp h e
+
+/-- A product of locally flat embeddings is locally flat, the models multiplying: the product of
+two standard slices is the standard slice of the product, after the permutation of coordinates
+exchanging the two middle factors. -/
+theorem prodMap {G G' : Type*} [TopologicalSpace G] [TopologicalSpace G'] [Zero G'] {g : N' → P}
+    (h : IsLocallyFlat F F' f) (h' : IsLocallyFlat G G' g) :
+    IsLocallyFlat (F × G) (F' × G') (Prod.map f g) := by
+  have himage : Homeomorph.prodProdProdComm F F' G G' ''
+      (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ((univ : Set G) ×ˢ ({0} : Set G'))) =
+      (univ : Set (F × G)) ×ˢ ({0} : Set (F' × G')) := by
+    rw [Homeomorph.image_eq_preimage_symm]
+    ext ⟨⟨a, c⟩, b, d⟩
+    simp [Homeomorph.prodProdProdComm, Prod.ext_iff]
+  have hprod := (IsSliceEmbedding.prodMap h h').transHomeomorph
+    (Homeomorph.prodProdProdComm F F' G G')
+  rw [himage] at hprod
+  exact hprod
+
+/-- The image of a locally flat embedding is locally closed, the standard slice being closed. This
+is where the definition has teeth: the image of a wild embedding need not be locally closed. -/
+theorem isLocallyClosed_range [T1Space F'] (h : IsLocallyFlat F F' f) :
+    IsLocallyClosed (range f) :=
+  IsSliceEmbedding.isLocallyClosed_range h (isClosed_univ.prod isClosed_singleton)
+
+end IsLocallyFlat
+
+/-- Local flatness is exactly a local property of the domain. -/
+theorem isLocallyFlat_iff_forall_exists_isOpen :
+    IsLocallyFlat F F' f ↔ IsEmbedding f ∧
+      ∀ x : N, ∃ U : Set N, IsOpen U ∧ x ∈ U ∧ IsLocallyFlat F F' (f ∘ ((↑) : U → N)) :=
+  isSliceEmbedding_iff_forall_exists_isOpen
+
+/-- Codimension zero: with a trivial complementary model, over a space charted on `F × F'`, locally
+flat is exactly open embedding. In particular local flatness is strictly stronger than embedding:
+not every embedding is locally flat. -/
+theorem isLocallyFlat_iff_isOpenEmbedding [Subsingleton F'] [ChartedSpace (F × F') M] :
+    IsLocallyFlat F F' f ↔ IsOpenEmbedding f := by
+  have h0 : ((univ : Set F) ×ˢ ({0} : Set F')) = (univ : Set (F × F')) := by
+    rw [show ({0} : Set F') = univ from eq_univ_of_forall fun x => Subsingleton.elim x 0,
+      univ_prod_univ]
+  rw [isLocallyFlat_iff_isSliceEmbedding, h0]
+  exact isSliceEmbedding_univ_iff
+
+/-- The standard local model: the inclusion of `F` as the slice `F × {0}` of `F × F'` is locally
+flat. With `F = ℝⁿ` and `F' = ℝᵏ` this is the coordinate slice `ℝⁿ × {0} ⊆ ℝⁿ⁺ᵏ` that local
+flatness is modelled on. -/
+theorem isLocallyFlat_prodMkLeft : IsLocallyFlat F F' (fun x : F => (x, (0 : F'))) := by
+  have hrange : (range fun x : F => (x, (0 : F'))) = (univ : Set F) ×ˢ ({0} : Set F') := by
     ext p
     simp [Prod.ext_iff, eq_comm]
-  refine ⟨isEmbedding_prodMkLeft c, fun x => ⟨OpenPartialHomeomorph.refl (F × F'), mem_univ _, ?_⟩⟩
+  refine ⟨isEmbedding_prodMkLeft 0, fun x => ⟨OpenPartialHomeomorph.refl (F × F'), mem_univ _, ?_⟩⟩
   rw [hrange]
   exact isSliceChart_iff.2 fun y _ => Iff.rfl
+
+end StandardSlice
 
 end TauCeti

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -41,7 +41,8 @@ closure properties: restriction to an open subset of the domain, locality, invar
 homeomorphisms and open embeddings on either side, invariance under a change of model space, and
 products. Those are proved here, together with two results that pin the notion down: in codimension
 zero local flatness is exactly openness of the embedding, and a locally flat embedding has locally
-closed image as soon as the origin of the complementary model is closed.
+closed image as soon as the origin of the complementary model is closed (on the relative layer, as
+soon as the model slice is locally closed).
 
 This is layer 2 of the geometric-topology roadmap, the substrate for topologically locally flat
 discs (topological sliceness) and for stating the annulus conjecture.
@@ -56,6 +57,8 @@ discs (topological sliceness) and for stating the annulus conjecture.
 
 * `TauCeti.isSliceChart_iff`: a chart is a slice chart iff, on its source, membership in the set is
   read off as membership of the coordinates in the slice.
+* `TauCeti.isLocallyFlat_iff` and `TauCeti.IsLocallyFlat.exists_isSliceChart`: the defining
+  flattening charts, in pointwise form and as an eliminator.
 * `TauCeti.IsLocallyFlat.restrict` and `TauCeti.IsLocallyFlat.of_forall_exists_isOpen`: local
   flatness is a local property of the domain.
 * `TauCeti.IsLocallyFlat.isOpenEmbedding_comp`, `TauCeti.IsLocallyFlat.of_isOpenEmbedding_comp`,
@@ -368,20 +371,26 @@ theorem isOpenEmbedding (h : IsSliceEmbedding (univ : Set F) f) : IsOpenEmbeddin
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
   exact Filter.mem_of_superset (φ.open_source.mem_nhds hφx) (isSliceChart_univ_iff.1 hφ)
 
-/-- The image of a slice embedding is locally closed as soon as the model slice is closed. This is
-where the definition has teeth: the image of a wild embedding need not be locally closed in any
-chart in this way. -/
-theorem isLocallyClosed_range (h : IsSliceEmbedding S f) (hS : IsClosed S) :
+/-- The image of a slice embedding is locally closed as soon as the model slice is. This is where
+the definition has teeth: the image of a wild embedding need not be locally closed in any chart in
+this way. -/
+theorem isLocallyClosed_range (h : IsSliceEmbedding S f) (hS : IsLocallyClosed S) :
     IsLocallyClosed (range f) := by
+  obtain ⟨U, Z, hU, hZ, rfl⟩ := hS
   refine ((isLocallyClosed_tfae (range f)).out 2 0).1 ?_
   rintro _ ⟨x, rfl⟩
   obtain ⟨φ, hφx, hφ⟩ := h.exists_isSliceChart x
-  refine ⟨φ.source, φ.open_source.mem_nhds hφx, ?_⟩
+  -- Shrink the chart to the part of its source where the open half of the slice already holds;
+  -- there the image is cut out by the closed half alone.
+  set W := φ.source ∩ φ ⁻¹' U
+  have hW : IsOpen W := φ.isOpen_inter_preimage hU
+  have hxW : f x ∈ W := ⟨hφx, ((hφ.mem_iff hφx).1 (mem_range_self x)).1⟩
+  refine ⟨W, hW.mem_nhds hxW, ?_⟩
   -- `U ↓∩ s` is notation for `Subtype.val ⁻¹' s`, so the goal is literally about that preimage.
-  have hpre : ((Subtype.val : φ.source → M) ⁻¹' range f) = (fun y : φ.source => φ ↑y) ⁻¹' S :=
-    Set.ext fun y => hφ.mem_iff y.2
+  have hpre : ((Subtype.val : W → M) ⁻¹' range f) = (fun y : W => φ ↑y) ⁻¹' Z :=
+    Set.ext fun y => (hφ.mem_iff y.2.1).trans (and_iff_right y.2.2)
   rw [hpre]
-  exact hS.preimage φ.continuousOn.domRestrict
+  exact hZ.preimage (φ.continuousOn.mono inter_subset_left).domRestrict
 
 end IsSliceEmbedding
 
@@ -407,6 +416,14 @@ namespace IsLocallyFlat
 
 theorem isEmbedding (h : IsLocallyFlat F F' f) : IsEmbedding f :=
   IsSliceEmbedding.isEmbedding h
+
+/-- The defining charts of a locally flat embedding: around every point of the image there is a
+chart of the ambient space, with values in `F × F'`, carrying the image onto the standard
+coordinate slice. This is the eliminator consumers use to get hold of a flattening chart. -/
+theorem exists_isSliceChart (h : IsLocallyFlat F F' f) (x : N) :
+    ∃ φ : OpenPartialHomeomorph M (F × F'), f x ∈ φ.source ∧
+      IsSliceChart φ ((univ : Set F) ×ˢ ({0} : Set F')) (range f) :=
+  IsSliceEmbedding.exists_isSliceChart h x
 
 theorem continuous (h : IsLocallyFlat F F' f) : Continuous f :=
   h.isEmbedding.continuous
@@ -480,9 +497,24 @@ complementary model is closed, the standard slice then being closed. This is whe
 has teeth: the image of a wild embedding need not be locally closed. -/
 theorem isLocallyClosed_range (h : IsLocallyFlat F F' f) (h0 : IsClosed ({0} : Set F')) :
     IsLocallyClosed (range f) :=
-  IsSliceEmbedding.isLocallyClosed_range h (isClosed_univ.prod h0)
+  IsSliceEmbedding.isLocallyClosed_range h (isClosed_univ.prod h0).isLocallyClosed
 
 end IsLocallyFlat
+
+/-- Local flatness spelled out pointwise: `f` is a topological embedding, and around every point of
+its image there is an ambient chart in which the image is exactly the vanishing locus of the
+complementary coordinates. -/
+theorem isLocallyFlat_iff :
+    IsLocallyFlat F F' f ↔ IsEmbedding f ∧ ∀ x : N, ∃ φ : OpenPartialHomeomorph M (F × F'),
+      f x ∈ φ.source ∧ ∀ y ∈ φ.source, y ∈ range f ↔ (φ y).2 = 0 := by
+  have key : ∀ φ : OpenPartialHomeomorph M (F × F'),
+      IsSliceChart φ ((univ : Set F) ×ˢ ({0} : Set F')) (range f) ↔
+        ∀ y ∈ φ.source, y ∈ range f ↔ (φ y).2 = 0 := fun φ => by
+    rw [isSliceChart_iff]
+    simp
+  exact ⟨fun h => ⟨h.isEmbedding,
+      fun x => (h.exists_isSliceChart x).imp fun φ hφ => ⟨hφ.1, (key φ).1 hφ.2⟩⟩,
+    fun h => ⟨h.1, fun x => (h.2 x).imp fun φ hφ => ⟨hφ.1, (key φ).2 hφ.2⟩⟩⟩
 
 /-- Codimension zero: with a trivial complementary model, over a space charted on `F × F'`, locally
 flat is exactly open embedding. In particular local flatness is strictly stronger than embedding:

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -67,8 +67,8 @@ discs (topological sliceness) and for stating the annulus conjecture.
   under open embeddings and homeomorphisms of the ambient space and of the domain.
 * `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
   space.
-* `TauCeti.IsLocallyFlat.comp`: a composite of locally flat embeddings is locally flat, under an
-  explicit hypothesis that their flattening charts are chosen compatibly.
+* `TauCeti.IsLocallyFlat.comp`: a composite of embeddings is locally flat, under an explicit
+  hypothesis supplying flattening charts for the two that are chosen compatibly.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
 * `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
 * `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed, as soon as
@@ -109,10 +109,12 @@ the chart of `M` flattening the inner embedding and the chart of `P` flattening 
 chosen independently, and nothing makes them agree. `TauCeti.IsLocallyFlat.comp` therefore carries
 that agreement as an explicit hypothesis — the outer chart reads the intermediate coordinates off
 the inner one along `g` — rather than assuming the conclusion; the outer chart then flattens the
-composite, and the complementary models multiply. It is stated only for the standard slice, since
-the compatibility condition refers to the splitting `F × F'` of the intermediate model, which the
-relative layer does not have. The ambient codimension-zero case needs no such hypothesis and is
-kept separate, as `TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
+composite, and the complementary models multiply. That hypothesis already produces the flattening
+charts around each point of the domain, so the two maps are assumed to be embeddings only. It is
+stated only for the standard slice, since the compatibility condition refers to the splitting
+`F × F'` of the intermediate model, which the relative layer does not have. The ambient
+codimension-zero case needs no such hypothesis and is kept separate, as
+`TauCeti.IsLocallyFlat.isOpenEmbedding_comp` and its converse.
 
 ## References
 
@@ -494,9 +496,10 @@ coherently around each point of the domain. It asks for a flattening chart `φ` 
 a flattening chart `ψ` of `P` at `g (f x)` such that `ψ` reads the intermediate coordinates off
 `φ` along `g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, and such that `ψ` sees no
 more of `range g` than `φ` charts. That same `ψ` then flattens `g ∘ f`, whose complementary model
-is the product of the two complementary models. -/
+is the product of the two complementary models. Since `hcompat` already supplies every flattening
+chart the conclusion needs, `f` and `g` themselves are only assumed to be embeddings. -/
 theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
-    (hg : IsLocallyFlat (F × F') G' g) (hf : IsLocallyFlat F F' f)
+    (hg : IsEmbedding g) (hf : IsEmbedding f)
     (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
       ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧ f x ∈ φ.source ∧
         IsSliceChart ψ ((univ : Set (F × F')) ×ˢ ({0} : Set G')) (range g) ∧
@@ -506,7 +509,7 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
   -- In the model `(F × F') × G'` of `P` the composite is flattened onto the iterated slice; the
   -- standard slice of `F × (F' × G')` is that one after reassociating the coordinates.
   have key : IsSliceEmbedding (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ({0} : Set G')) (g ∘ f) := by
-    refine ⟨hg.isEmbedding.comp hf.isEmbedding, fun x => ?_⟩
+    refine ⟨hg.comp hf, fun x => ?_⟩
     obtain ⟨ψ, φ, hψx, hφx, hψ, hφ, hsub, hagree⟩ := hcompat x
     refine ⟨ψ, hψx, isSliceChart_iff.2 fun p hp => ?_⟩
     constructor

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -78,6 +78,18 @@ structure and is not formalised here.
 
 Codimension is not baked into the definition; see the module docstring above.
 
+The pair `(F, S)` is the *local model*, and it is an argument of the predicate rather than
+something `IsLocallyFlat` picks: `IsLocallyFlat S f` asserts flatness against the model the caller
+names, so a statement about locally flat embeddings fixes that model, as
+`TauCeti.isLocallyFlat_prodMkLeft` fixes the standard slice `Set.univ ×ˢ {c}`. Degenerate models
+are cheap, as they are for `ChartedSpace`: Mathlib's `chartedSpaceSelf` charts every space on itself
+through the identity, and in the same way `F = M`, `S = Set.range f` and
+`OpenPartialHomeomorph.refl M` flatten any embedding at all. As with `ChartedSpace`, the content
+is in the model being the standard one, and the predicate has teeth once it is fixed:
+`TauCeti.isLocallyFlat_univ_iff` says that for `S = Set.univ` exactly the open embeddings are
+flat, and `TauCeti.IsLocallyFlat.isLocallyClosed_range` rules out an image that is not locally
+closed whenever `S` is closed.
+
 Composing two locally flat embeddings `N ↪ M ↪ P` is deliberately absent: it is not a formal
 consequence of the definition, because the two flattening charts have to be made compatible before
 they can be combined. Only the codimension-zero ambient case is proved here, as

--- a/TauCeti/Geometry/Manifold/LocallyFlat.lean
+++ b/TauCeti/Geometry/Manifold/LocallyFlat.lean
@@ -67,8 +67,8 @@ discs (topological sliceness) and for stating the annulus conjecture.
   under open embeddings and homeomorphisms of the ambient space and of the domain.
 * `TauCeti.IsSliceEmbedding.transHomeomorph`: invariance under a homeomorphic change of model
   space.
-* `TauCeti.IsLocallyFlat.comp`: a composite of embeddings is locally flat, under an explicit
-  hypothesis supplying flattening charts for the two that are chosen compatibly.
+* `TauCeti.IsLocallyFlat.comp`: a composite embedding is locally flat, under an explicit
+  hypothesis supplying flattening charts for the two factors that are chosen compatibly.
 * `TauCeti.IsLocallyFlat.prodMap`: a product of locally flat embeddings is locally flat.
 * `TauCeti.isLocallyFlat_iff_isOpenEmbedding`: in codimension zero, locally flat means open.
 * `TauCeti.IsLocallyFlat.isLocallyClosed_range`: a locally flat image is locally closed, as soon as
@@ -110,7 +110,8 @@ chosen independently, and nothing makes them agree. `TauCeti.IsLocallyFlat.comp`
 that agreement as an explicit hypothesis — the outer chart reads the intermediate coordinates off
 the inner one along `g` — rather than assuming the conclusion; the outer chart then flattens the
 composite, and the complementary models multiply. That hypothesis already produces the flattening
-charts around each point of the domain, so the two maps are assumed to be embeddings only. It is
+charts around each point of the domain, so nothing beyond the embedding content of the conclusion
+itself is assumed: that the composite is an embedding, and that the outer map is injective. It is
 stated only for the standard slice, since the compatibility condition refers to the splitting
 `F × F'` of the intermediate model, which the relative layer does not have. The ambient
 codimension-zero case needs no such hypothesis and is kept separate, as
@@ -497,9 +498,10 @@ a flattening chart `ψ` of `P` at `g (f x)` such that `ψ` reads the intermediat
 `φ` along `g`, in the sense `ψ (g y) = (φ y, 0)` on the source of `φ`, and such that `ψ` sees no
 more of `range g` than `φ` charts. That same `ψ` then flattens `g ∘ f`, whose complementary model
 is the product of the two complementary models. Since `hcompat` already supplies every flattening
-chart the conclusion needs, `f` and `g` themselves are only assumed to be embeddings. -/
+chart the conclusion needs, the only embedding content assumed is what the conclusion itself
+carries, that `g ∘ f` is an embedding, together with injectivity of `g`. -/
 theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
-    (hg : IsEmbedding g) (hf : IsEmbedding f)
+    (hgf : IsEmbedding (g ∘ f)) (hg : Function.Injective g)
     (hcompat : ∀ x : N, ∃ ψ : OpenPartialHomeomorph P ((F × F') × G'),
       ∃ φ : OpenPartialHomeomorph M (F × F'), g (f x) ∈ ψ.source ∧ f x ∈ φ.source ∧
         IsSliceChart ψ ((univ : Set (F × F')) ×ˢ ({0} : Set G')) (range g) ∧
@@ -509,7 +511,7 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
   -- In the model `(F × F') × G'` of `P` the composite is flattened onto the iterated slice; the
   -- standard slice of `F × (F' × G')` is that one after reassociating the coordinates.
   have key : IsSliceEmbedding (((univ : Set F) ×ˢ ({0} : Set F')) ×ˢ ({0} : Set G')) (g ∘ f) := by
-    refine ⟨hg.comp hf, fun x => ?_⟩
+    refine ⟨hgf, fun x => ?_⟩
     obtain ⟨ψ, φ, hψx, hφx, hψ, hφ, hsub, hagree⟩ := hcompat x
     refine ⟨ψ, hψx, isSliceChart_iff.2 fun p hp => ?_⟩
     constructor
@@ -518,7 +520,7 @@ theorem comp {G' : Type*} [TopologicalSpace G'] [Zero G'] {g : M → P}
       obtain ⟨x', hx'⟩ := hpf
       rw [Function.comp_apply] at hx'
       rw [hagree y hy]
-      exact ⟨(hφ.mem_iff hy).1 ⟨x', hg.injective hx'⟩, rfl⟩
+      exact ⟨(hφ.mem_iff hy).1 ⟨x', hg hx'⟩, rfl⟩
     · intro hps
       obtain ⟨y, hy, rfl⟩ := hsub ⟨hp, (hψ.mem_iff hp).2 ⟨mem_univ _, hps.2⟩⟩
       rw [hagree y hy] at hps


### PR DESCRIPTION
This PR builds the entry point to layer 2 of the geometric-topology roadmap, locally flat embeddings in general dimension, which is one of the three layers the roadmap says "can start immediately and independently against current Mathlib" and the only one with no code in the repository yet. The roadmap's layer-2 target is the predicate `IsLocallyFlat f` for a topological embedding of topological manifolds ("a slice chart `ℝⁿ ⊆ ℝᵐ` exists at every image point") together with "the structural API, which is most of the work and what every later use depends on": restriction, homeomorphism invariance, and products. That structural API is what this PR delivers, sorry-free.

The definition is built in three layers. `TauCeti.IsSliceChart φ S A` says a single ambient chart `φ` flattens a set `A` onto a model slice `S`, in the sense `φ '' (φ.source ∩ A) = φ.target ∩ S`, and `TauCeti.isSliceChart_iff` reduces it to the pointwise form "on `φ.source`, membership in `A` is membership of the coordinates in `S`", which is what every proof below runs on. `TauCeti.IsSliceEmbedding S f` then bundles `IsEmbedding f` with the existence of a slice chart for `Set.range f` around each point of the image; its slice is arbitrary, so it is *not* local flatness — it is the transport layer, stated relatively precisely so that the closure properties can be proved on it. Local flatness proper is

```lean
def IsLocallyFlat [Zero F'] (f : N → M) : Prop :=
  IsSliceEmbedding ((univ : Set F) ×ˢ ({0} : Set F')) f
```

that is, ambient charts take values in `F × F'` and carry the image exactly onto the standard coordinate slice `F × {0}`, the vanishing locus of the complementary coordinates; with `F = ℝⁿ` and `F' = ℝᵏ` this is the textbook `ℝⁿ × {0} ⊆ ℝⁿ⁺ᵏ`. Following the roadmap's design note, codimension is deliberately not baked in: it is the choice of the complementary model `F'`, so codimension `0` (`F'` a subsingleton), `1`, and `2` all live in the one predicate, and `TauCeti.isLocallyFlat_prodMkLeft` records the standard model `x ↦ (x, 0)`.

The closure properties are the deliverable, and are stated for `IsLocallyFlat` itself. `IsLocallyFlat.restrict` restricts to an open subset of the domain and `IsLocallyFlat.of_forall_exists_isOpen` goes back: local flatness really is a local property. `IsLocallyFlat.isOpenEmbedding_comp` and `IsLocallyFlat.of_isOpenEmbedding_comp` are invariance under an open embedding of the ambient space in both directions, with `IsLocallyFlat.codRestrict` (corestrict to an open neighbourhood of the image) and `IsLocallyFlat.homeomorph_comp` as corollaries; `IsLocallyFlat.comp_homeomorph` and `IsLocallyFlat.comp_isOpenEmbedding` handle the domain side. `IsLocallyFlat.prodMap` is the product, the building block the roadmap wants for product regions; it is where the relative layer earns its keep, since the product of two standard slices is a standard slice only after the coordinate permutation `Homeomorph.prodProdProdComm`, applied through `IsSliceEmbedding.transHomeomorph`. All of these factor through a single transport lemma, `IsSliceChart.comp`, which pulls a slice chart back along an arbitrary chart of a second ambient space.

Two results pin the notion down rather than merely restating it. `isLocallyFlat_iff_isOpenEmbedding` shows that in codimension zero, over a space charted on `F × F'`, locally flat is exactly open embedding, so the predicate is strictly stronger than `IsEmbedding`. `IsLocallyFlat.isLocallyClosed_range` shows the image is locally closed as soon as `{0}` is closed in `F'`, which is the first place local flatness does real work against wildness.

Composition is stated the way the roadmap asks for it, "with explicit hypotheses rather than assuming it": `IsLocallyFlat.comp` composes `N ↪ M ↪ P` given that the two flattening charts can be chosen compatibly around each point — a chart `φ` of `M` flattening `f`, a chart `ψ` of `P` flattening `g`, with `ψ (g y) = (φ y, 0)` on `φ.source` and `ψ.source ∩ range g ⊆ g '' φ.source`. Neither clause mentions `range (g ∘ f)`, so the conclusion is not smuggled into the hypothesis; the content is that `ψ` then flattens the composite, whose complementary model is `F' × G'` after `Homeomorph.prodAssoc`. The ambient codimension-zero case needs no such hypothesis and stays separate. One thing is deliberately absent and recorded as such in the implementation notes rather than approximated: nothing is asserted about smooth or PL embeddings being locally flat; that needs a local normal form for immersions and is a separate target. The notes also justify the "relative to the chart's target" form of the flattening condition (`φ.target ∩ S` rather than a chart onto all of the model), which is the form that is genuinely local and hence closed under restriction.

The milestone this serves is layer 2 of the geometric-topology roadmap, whose unlock is the statement of the annulus conjecture and whose consumers are layer 4's `IsTopologicallySlice` and layer 6's topological concordance. What remains for that milestone after this PR: the locally flat sphere and its bicollaring (Brown), the theorem that smooth and PL embeddings are locally flat, and then the annulus-conjecture statement itself.

No Mathlib source was vendored; the file consumes `OpenPartialHomeomorph`, `ChartedSpace`, `Topology.IsOpenEmbedding.toOpenPartialHomeomorph`, `Topology.isEmbedding_prodMkLeft`, `Homeomorph.prodProdProdComm`, and `isLocallyClosed_tfae` as they stand upstream.

New file: `TauCeti/Geometry/Manifold/LocallyFlat.lean`. No existing module is renamed or moved.

Roadmap: GeometricTopology

<!--tauceti-target:v1 {"focus":"GeometricTopology","id":"islocallyflat"}-->

🤖 Prepared with Claude Code


