### PR TITLE
feat(ModularForms): the reflection identities of the boundary contour

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -494,12 +494,11 @@ itself, reversed, through the inversion `z ↦ -1/z`: the two halves of the arc 
 fundamental-domain boundary are identified by `S`. -/
 theorem fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
     fdBoundary H (4 - t) = -1 / fdBoundary H t := by
+  have hangle : (4 - t + 1) * (Real.pi / 6) + (t + 1) * (Real.pi / 6) = Real.pi := by ring
   rw [eqOn_fdBoundary_arc H ⟨by linarith [ht.2], by linarith [ht.1]⟩,
     eqOn_fdBoundary_arc H ht, eq_div_iff (circleMap_ne_center one_ne_zero)]
   simp only [circleMap, Complex.ofReal_one, one_mul, zero_add]
-  rw [← Complex.exp_add, ← add_mul, ← Complex.ofReal_add,
-    show (4 - t + 1) * (Real.pi / 6) + (t + 1) * (Real.pi / 6) = Real.pi by ring,
-    Complex.exp_pi_mul_I]
+  rw [← Complex.exp_add, ← add_mul, ← Complex.ofReal_add, hangle, Complex.exp_pi_mul_I]
 
 end Regularity
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -480,6 +480,7 @@ theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBounda
 /-- The reflection `t ↦ 4 - t` of the parameter interval carries the right vertical onto
 the left vertical through the translation `z ↦ z - 1`: the two verticals of the
 fundamental-domain boundary are identified by `T⁻¹`. -/
+@[simp]
 theorem fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :
     fdBoundary H (4 - t) = fdBoundary H t - 1 := by
   rw [eqOn_fdBoundary_segment4 H ⟨by linarith [ht.2], by linarith [ht.1]⟩,
@@ -492,13 +493,14 @@ theorem fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Icc (0 : �
 /-- The reflection `t ↦ 4 - t` of the parameter interval carries the unit-circle arc onto
 itself, reversed, through the inversion `z ↦ -1/z`: the two halves of the arc of the
 fundamental-domain boundary are identified by `S`. -/
+@[simp]
 theorem fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
     fdBoundary H (4 - t) = -1 / fdBoundary H t := by
   have hangle : (4 - t + 1) * (Real.pi / 6) + (t + 1) * (Real.pi / 6) = Real.pi := by ring
   rw [eqOn_fdBoundary_arc H ⟨by linarith [ht.2], by linarith [ht.1]⟩,
-    eqOn_fdBoundary_arc H ht, eq_div_iff (circleMap_ne_center one_ne_zero)]
-  simp only [circleMap, Complex.ofReal_one, one_mul, zero_add]
-  rw [← Complex.exp_add, ← add_mul, ← Complex.ofReal_add, hangle, Complex.exp_pi_mul_I]
+    eqOn_fdBoundary_arc H ht, eq_div_iff (circleMap_ne_center one_ne_zero),
+    circleMap_zero_mul, hangle]
+  simp [circleMap_zero, Complex.exp_pi_mul_I]
 
 end Regularity
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -33,6 +33,10 @@ anchors of the valence-formula contour.
 * `TauCeti.ModularForm.continuous_fdBoundary`: the contour is (globally) continuous.
 * `TauCeti.ModularForm.isPiecewiseC1On_fdBoundary`: the contour is piecewise `C¹`
   (`contDiffOn_fdBoundary` certifies `fdBoundaryCorners` as a breakpoint witness).
+* `TauCeti.ModularForm.fdBoundary_four_sub_vertical`, `…_four_sub_arc`: the reflection
+  `t ↦ 4 - t` identifies the verticals through `z ↦ z - 1` and the arc with its own
+  reversal through `z ↦ -1/z` — the boundary identifications driving the cancellations
+  in the valence-formula contour integral.
 
 ## References
 
@@ -472,6 +476,30 @@ theorem isPiecewiseC1On_fdBoundary (H : ℝ) : Contour.IsPiecewiseC1On (fdBounda
   · intro c d hcd hdis
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at hcd
     exact contDiffOn_fdBoundary H hcd hdis
+
+/-- The reflection `t ↦ 4 - t` of the parameter interval carries the right vertical onto
+the left vertical through the translation `z ↦ z - 1`: the two verticals of the
+fundamental-domain boundary are identified by `T⁻¹`. -/
+theorem fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Icc (0 : ℝ) 1) :
+    fdBoundary H (4 - t) = fdBoundary H t - 1 := by
+  rw [eqOn_fdBoundary_segment4 H ⟨by linarith [ht.2], by linarith [ht.1]⟩,
+    eqOn_fdBoundary_segment1 H ht, fdBoundary_segment4_apply, fdBoundary_segment1_apply,
+    AffineMap.lineMap_apply, AffineMap.lineMap_apply]
+  simp only [vsub_eq_sub, vadd_eq_add, Complex.real_smul]
+  push_cast
+  ring
+
+/-- The reflection `t ↦ 4 - t` of the parameter interval carries the unit-circle arc onto
+itself, reversed, through the inversion `z ↦ -1/z`: the two halves of the arc of the
+fundamental-domain boundary are identified by `S`. -/
+theorem fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
+    fdBoundary H (4 - t) = -1 / fdBoundary H t := by
+  rw [eqOn_fdBoundary_arc H ⟨by linarith [ht.2], by linarith [ht.1]⟩,
+    eqOn_fdBoundary_arc H ht, eq_div_iff (circleMap_ne_center one_ne_zero)]
+  simp only [circleMap, Complex.ofReal_one, one_mul, zero_add]
+  rw [← Complex.exp_add, ← add_mul, ← Complex.ofReal_add,
+    show (4 - t + 1) * (Real.pi / 6) + (t + 1) * (Real.pi / 6) = Real.pi by ring,
+    Complex.exp_pi_mul_I]
 
 end Regularity
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -224,6 +224,7 @@ section Reflection
 
 /-- Differentiating the vertical reflection identity: on the interiors of the verticals,
 the reflection `t ↦ 4 - t` negates the derivative. -/
+@[simp]
 lemma deriv_fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (0 : ℝ) 1) :
     deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t := by
   rw [deriv_fdBoundary_of_mem_Ioo_three_four ⟨by linarith [ht.2], by linarith [ht.1]⟩,
@@ -231,8 +232,10 @@ lemma deriv_fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo
   ring
 
 /-- Differentiating the arc reflection identity: on the interior of the arc, the
-reflection `t ↦ 4 - t` transforms the derivative by `w ↦ -w / z ^ 2`, the derivative of
-the inversion `z ↦ -1/z` along the curve. -/
+reflection `t ↦ 4 - t` transforms the derivative by `w ↦ -w / z ^ 2` — the inversion
+`z ↦ -1/z` contributes its derivative `w ↦ w / z ^ 2`, and the parameter reversal
+`t ↦ 4 - t` contributes the minus sign. -/
+@[simp]
 lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
     deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t / fdBoundary H t ^ 2 := by
   have hmem : (4 - t : ℝ) ∈ Set.Icc (1 : ℝ) 3 := ⟨by linarith [ht.2], by linarith [ht.1]⟩

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -25,6 +25,9 @@ active segment. These are the `γ'` factors of the valence-formula contour integ
 * `TauCeti.ModularForm.hasDerivAt_fdBoundary_of_lt_one` … `_of_gt_four`: the contour
   differentiates like its active segment between the breakpoints, with the two arcs
   unified across their smooth junction (`hasDerivAt_fdBoundary_of_mem_Ioo_one_three`).
+* `TauCeti.ModularForm.deriv_fdBoundary_four_sub_vertical`, `…_four_sub_arc`: the
+  derivative transforms of the reflection identities of `fdBoundary` — the `γ'` halves
+  of the vertical cancellation and the arc self-pairing.
 
 ## References
 
@@ -216,6 +219,37 @@ lemma deriv_fdBoundary_of_gt_four (ht : 4 < t) : deriv (fdBoundary H) t = 1 :=
   (hasDerivAt_fdBoundary_of_gt_four ht).deriv
 
 end DerivRewrites
+
+section Reflection
+
+/-- Differentiating the vertical reflection identity: on the interiors of the verticals,
+the reflection `t ↦ 4 - t` negates the derivative. -/
+lemma deriv_fdBoundary_four_sub_vertical (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (0 : ℝ) 1) :
+    deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t := by
+  rw [deriv_fdBoundary_of_mem_Ioo_three_four ⟨by linarith [ht.2], by linarith [ht.1]⟩,
+    deriv_fdBoundary_of_lt_one ht.2]
+  ring
+
+/-- Differentiating the arc reflection identity: on the interior of the arc, the
+reflection `t ↦ 4 - t` transforms the derivative by `w ↦ -w / z ^ 2`, the derivative of
+the inversion `z ↦ -1/z` along the curve. -/
+lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
+    deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t / fdBoundary H t ^ 2 := by
+  have hmem : (4 - t : ℝ) ∈ Set.Icc (1 : ℝ) 3 := ⟨by linarith [ht.2], by linarith [ht.1]⟩
+  have hval : circleMap 0 1 ((4 - t + 1) * (Real.pi / 6)) =
+      -1 / circleMap 0 1 ((t + 1) * (Real.pi / 6)) := by
+    have h := fdBoundary_four_sub_arc H ⟨ht.1.le, ht.2.le⟩
+    rwa [eqOn_fdBoundary_arc H hmem, eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩] at h
+  have hcurve : fdBoundary H t = circleMap 0 1 ((t + 1) * (Real.pi / 6)) :=
+    eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩
+  have hne : circleMap 0 1 ((t + 1) * (Real.pi / 6)) ≠ 0 := circleMap_ne_center one_ne_zero
+  rw [deriv_fdBoundary_of_mem_Ioo_one_three ⟨by linarith [ht.2], by linarith [ht.1]⟩,
+    deriv_fdBoundary_of_mem_Ioo_one_three ht, hcurve, hval, Complex.real_smul,
+    Complex.real_smul]
+  field_simp
+
+end Reflection
+
 
 
 end ModularForm


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The reflection `t ↦ 4 - t` of the parameter interval is the parameter-level realization of
the boundary identifications of the standard fundamental domain: it carries the right
vertical onto the left vertical through the translation `z ↦ z - 1` (the verticals are
identified by `T⁻¹`), and the unit-circle arc onto its own reversal through the inversion
`z ↦ -1/z` (the arc is identified with itself by `S`).

Two value identities in `FundamentalDomainBoundary/Basic.lean`, following the file's
established pointwise-on-`Icc` style:

- `fdBoundary_four_sub_vertical : t ∈ Icc 0 1 → fdBoundary H (4 - t) = fdBoundary H t - 1`
- `fdBoundary_four_sub_arc : t ∈ Icc 1 3 → fdBoundary H (4 - t) = -1 / fdBoundary H t`

and their derivative transforms on the piece interiors in
`FundamentalDomainBoundary/Deriv.lean`:

- `deriv_fdBoundary_four_sub_vertical : t ∈ Ioo 0 1 → deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t`
- `deriv_fdBoundary_four_sub_arc : t ∈ Ioo 1 3 → deriv (fdBoundary H) (4 - t) = -deriv (fdBoundary H) t / fdBoundary H t ^ 2`

Together these are the curve-level inputs to the integral-evaluation half of the
valence-formula contour argument: composed with the periodicity resp. weight-`k`
`S`-transformation law of a level-one form, the value identities transport the
logarithmic-derivative integrand across the reflection and the derivative identities
supply the `γ'` factor, making the two vertical integrals cancel and the two arc halves
combine into the `k/12` term.

Roadmap: ModularForms
