### PR TITLE
feat(Analysis): periodicity of the derivative and the logarithmic derivative

### DIFF
--- a/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
+++ b/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Ring.Periodic
+public import Mathlib.Analysis.Calculus.LogDeriv
+
+import Mathlib.Analysis.Calculus.Deriv.Shift
+
+/-!
+# Periodicity of the derivative and the logarithmic derivative
+
+Differentiation commutes with translation of the domain, so the derivative of a periodic
+function is periodic with the same period, and hence so is its logarithmic derivative.
+Both statements are unconditional: `deriv` (and with it `logDeriv`) takes its junk value
+at non-differentiable points, and the translation identity holds there too.
+
+## Main declarations
+
+* `TauCeti.Function.Periodic.deriv`: the derivative of a periodic function is periodic.
+* `TauCeti.Function.Periodic.logDeriv`: the logarithmic derivative of a periodic function
+  is periodic.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace Function
+
+namespace Periodic
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {c : 𝕜}
+
+/-- The derivative of a periodic function is periodic. -/
+theorem deriv {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : 𝕜 → F}
+    (hf : _root_.Function.Periodic f c) :
+    _root_.Function.Periodic (_root_.deriv f) c := fun x ↦ by
+  rw [← deriv_comp_add_const]
+  exact congrFun (congrArg _root_.deriv (funext hf)) x
+
+/-- The logarithmic derivative of a periodic function is periodic. -/
+theorem logDeriv {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
+    {f : 𝕜 → 𝕜'} (hf : _root_.Function.Periodic f c) :
+    _root_.Function.Periodic (_root_.logDeriv f) c :=
+  fun x ↦ by rw [logDeriv_apply, logDeriv_apply, deriv hf x, hf x]
+
+end Periodic
+
+end Function
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
+++ b/TauCeti/Analysis/Calculus/PeriodicDeriv.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Algebra.Ring.Periodic
+public import Mathlib.Analysis.Calculus.FDeriv.Add
 public import Mathlib.Analysis.Calculus.LogDeriv
 
 import Mathlib.Analysis.Calculus.Deriv.Shift
@@ -12,16 +13,19 @@ import Mathlib.Analysis.Calculus.Deriv.Shift
 /-!
 # Periodicity of the derivative and the logarithmic derivative
 
-Differentiation commutes with translation of the domain, so the derivative of a periodic
-function is periodic with the same period, and hence so is its logarithmic derivative.
-Both statements are unconditional: `deriv` (and with it `logDeriv`) takes its junk value
-at non-differentiable points, and the translation identity holds there too.
+Differentiation commutes with translation of the domain, so the Fréchet and the
+one-variable derivative of a periodic function are periodic with the same period, and
+hence so is the logarithmic derivative. All three statements are unconditional:
+`fderiv`, `deriv`, and with them `logDeriv` take their junk values at non-differentiable
+points, and the translation identities hold there too.
 
 ## Main declarations
 
+* `TauCeti.Function.Periodic.fderiv`: the Fréchet derivative of a periodic function is
+  periodic.
 * `TauCeti.Function.Periodic.deriv`: the derivative of a periodic function is periodic.
-* `TauCeti.Function.Periodic.logDeriv`: the logarithmic derivative of a periodic function
-  is periodic.
+* `TauCeti.Function.Periodic.logDeriv`: the logarithmic derivative of a periodic
+  function is periodic.
 -/
 
 public section
@@ -32,20 +36,26 @@ namespace Function
 
 namespace Periodic
 
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {c : 𝕜}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+
+/-- The Fréchet derivative of a periodic function is periodic. -/
+protected theorem fderiv {E F : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+    [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : E → F} {c : E}
+    (hf : _root_.Function.Periodic f c) :
+    _root_.Function.Periodic (fderiv 𝕜 f) c := fun x ↦ by
+  rw [← fderiv_comp_add_right, hf.funext]
 
 /-- The derivative of a periodic function is periodic. -/
-theorem deriv {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : 𝕜 → F}
-    (hf : _root_.Function.Periodic f c) :
+protected theorem deriv {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F] {f : 𝕜 → F}
+    {c : 𝕜} (hf : _root_.Function.Periodic f c) :
     _root_.Function.Periodic (_root_.deriv f) c := fun x ↦ by
-  rw [← deriv_comp_add_const]
-  exact congrFun (congrArg _root_.deriv (funext hf)) x
+  rw [← deriv_comp_add_const, hf.funext]
 
 /-- The logarithmic derivative of a periodic function is periodic. -/
-theorem logDeriv {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
-    {f : 𝕜 → 𝕜'} (hf : _root_.Function.Periodic f c) :
+protected theorem logDeriv {𝕜' : Type*} [NontriviallyNormedField 𝕜'] [NormedAlgebra 𝕜 𝕜']
+    {f : 𝕜 → 𝕜'} {c : 𝕜} (hf : _root_.Function.Periodic f c) :
     _root_.Function.Periodic (_root_.logDeriv f) c :=
-  fun x ↦ by rw [logDeriv_apply, logDeriv_apply, deriv hf x, hf x]
+  (Periodic.deriv hf).div hf
 
 end Periodic
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

Differentiation commutes with translation of the domain, so the Fréchet and one-variable
derivatives of a periodic function are periodic with the same period, and hence so is the
logarithmic derivative:

- `TauCeti.Function.Periodic.fderiv : Periodic f c → Periodic (fderiv 𝕜 f) c`
- `TauCeti.Function.Periodic.deriv : Periodic f c → Periodic (deriv f) c`
- `TauCeti.Function.Periodic.logDeriv : Periodic f c → Periodic (logDeriv f) c`

All three are unconditional — the derivatives take their junk values at
non-differentiable points and Mathlib's translation identities (`fderiv_comp_add_right`,
`deriv_comp_add_const`) hold there too — and each sits at Mathlib's own generality for
the operation it transports.

Roadmap: this is a prerequisite of the **ModularForms** roadmap's Layer 1 (the valence
formula, `TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula") —
the proof route there is the contour integral of `f'/f` around the fundamental-domain
boundary, and the vertical-cancellation step transports the `T`-periodicity of a
level-one form (`SlashInvariantFormClass.periodic_comp_ofComplex`, giving
`Periodic (⇑f ∘ ofComplex) 1`) to its logarithmic derivative through exactly these
lemmas.

Mathlib note: no `Periodic`/calculus interaction exists in Mathlib at all; natural
upstream homes would be `Analysis/Calculus/Deriv/Shift.lean` (or a new
`Deriv/Periodic.lean`) for the derivative statements and
`Analysis/Calculus/LogDeriv.lean` for the logarithmic one.

Roadmap: ModularForms
