### PR TITLE
feat(HeckeRing): the Hecke triple of Γ₁(N)

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -43,7 +43,7 @@ Chris Birkbeck).
 ## Main results
 
 * `HeckeRing.GL2.Gamma1Image_le_Delta0`: `Γ₁(N) ≤ Δ₀(N)`.
-* `HeckeRing.GL2.Gamma0Image_le_Delta0`: `Γ₀(N) ≤ Δ₀(N)`, so the diamond operators live in
+* `HeckeRing.GL2.Gamma0_map_le_Delta0`: `Γ₀(N) ≤ Δ₀(N)`, so the diamond operators live in
   the same Hecke ring.
 * `HeckeRing.GL2.Delta0_le_commensurator`: `Δ₀(N)` lies in the commensurator of `Γ₁(N)`.
 * the `IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N)` instance.
@@ -120,7 +120,7 @@ lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N := by
 /-- `Γ₀(N) ≤ Δ₀(N)`: an element of `Γ₀(N)` has `ad ≡ 1` modulo `N`, since `c ≡ 0` and the
 determinant is one, so its upper-left entry is a unit. This containment is what puts the
 diamond operators into the Hecke ring of `Γ₁(N)`. -/
-lemma Gamma0Image_le_Delta0 :
+lemma Gamma0_map_le_Delta0 :
     ((Gamma0 N).map (mapGL ℚ)).toSubmonoid ≤ Delta0 N := by
   intro g hg
   obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hg

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -11,8 +11,8 @@ public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 /-!
 # The Hecke triple of `Γ₁(N)`
 
-The submonoid `Δ₁(N) ⊆ GL₂(ℚ)` of integral matrices with positive determinant that are
-upper-triangular and unipotent modulo `N`, and the Hecke triple it forms with the image of
+The submonoid `Δ₁(N) ⊆ GL₂(ℚ)` of integral matrices with positive determinant whose first
+column is congruent to `(1, 0)` modulo `N`, and the Hecke triple it forms with the image of
 the congruence subgroup `Γ₁(N)`. This is the level-`N` counterpart of the arithmetic triple
 `(Δₙ, SL_n(ℤ))`, and the setting in which the Hecke operators on `M_k(Γ₁(N))` live.
 
@@ -23,13 +23,13 @@ Chris Birkbeck).
 ## Main definitions
 
 * `HeckeRing.GL2.Delta1`: the submonoid `Δ₁(N)`.
-* `HeckeRing.GL2.Gamma1Map`: the image of `Γ₁(N)` in `GL₂(ℚ)`.
+* `HeckeRing.GL2.Gamma1Image`: the image of `Γ₁(N)` in `GL₂(ℚ)`.
 
 ## Main results
 
-* `HeckeRing.GL2.Gamma1Map_le_Delta1`: `Γ₁(N) ≤ Δ₁(N)`.
+* `HeckeRing.GL2.Gamma1Image_le_Delta1`: `Γ₁(N) ≤ Δ₁(N)`.
 * `HeckeRing.GL2.Delta1_le_commensurator`: `Δ₁(N)` lies in the commensurator of `Γ₁(N)`.
-* the `IsHeckeTriple (Delta1 N) (Gamma1Map N) (Gamma1Map N)` instance.
+* the `IsHeckeTriple (Delta1 N) (Gamma1Image N) (Gamma1Image N)` instance.
 
 ## References
 
@@ -49,16 +49,17 @@ namespace HeckeRing.GL2
 variable (N : ℕ)
 
 /-- The image of `Γ₁(N)` in `GL₂(ℚ)`. -/
-noncomputable def Gamma1Map : Subgroup (GL (Fin 2) ℚ) :=
+noncomputable def Gamma1Image : Subgroup (GL (Fin 2) ℚ) :=
   (Gamma1 N).map (mapGL ℚ)
 
 /-- Membership in the image of `Γ₁(N)`, by an integral witness. -/
-lemma mem_Gamma1Map_iff {g : GL (Fin 2) ℚ} :
-    g ∈ Gamma1Map N ↔ ∃ σ ∈ Gamma1 N, mapGL ℚ σ = g := by
-  rw [Gamma1Map, Subgroup.mem_map]
+@[simp] lemma mem_Gamma1Image_iff {g : GL (Fin 2) ℚ} :
+    g ∈ Gamma1Image N ↔ ∃ σ ∈ Gamma1 N, mapGL ℚ σ = g := by
+  rw [Gamma1Image, Subgroup.mem_map]
 
-/-- `Δ₁(N)`: integral matrices of positive determinant that are unipotent upper-triangular
-modulo `N`, i.e. `a ≡ 1` and `c ≡ 0 (mod N)`. -/
+/-- `Δ₁(N)`: integral matrices of positive determinant whose first column is congruent to
+`(1, 0)` modulo `N`, i.e. `a ≡ 1` and `c ≡ 0 (mod N)`. Note this constrains only the first
+column: the lower-right entry is unrestricted. -/
 noncomputable def Delta1 : Submonoid (GL (Fin 2) ℚ) where
   carrier := {g | ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
     (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
@@ -76,7 +77,7 @@ noncomputable def Delta1 : Submonoid (GL (Fin 2) ℚ) where
         (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hBN]
 
 /-- Membership in `Δ₁(N)`, unfolded. -/
-lemma mem_Delta1_iff {g : GL (Fin 2) ℚ} :
+@[simp] lemma mem_Delta1_iff {g : GL (Fin 2) ℚ} :
     g ∈ Delta1 N ↔ ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
       (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
         0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧
@@ -84,9 +85,9 @@ lemma mem_Delta1_iff {g : GL (Fin 2) ℚ} :
   Iff.rfl
 
 /-- `Γ₁(N) ≤ Δ₁(N)`: the congruence subgroup embeds in the submonoid. -/
-lemma Gamma1Map_le_Delta1 : (Gamma1Map N).toSubmonoid ≤ Delta1 N := by
+lemma Gamma1Image_le_Delta1 : (Gamma1Image N).toSubmonoid ≤ Delta1 N := by
   intro g hg
-  obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Map_iff N).mp hg
+  obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Image_iff N).mp hg
   obtain ⟨ha, -, hc⟩ := (Gamma1_mem _ _).mp hσ
   refine (mem_Delta1_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha⟩
   · rw [mapGL_coe_matrix]
@@ -104,29 +105,29 @@ lemma Delta1_le_posDetInt : Delta1 N ≤ posDetInt 2 := by
 variable [NeZero N]
 
 /-- `Γ₁(N)` is commensurable with `SL₂(ℤ)`: it has finite index in it. -/
-lemma commensurable_Gamma1Map_SLnZ : Commensurable (Gamma1Map N) (SLnZ 2) := by
+lemma commensurable_Gamma1Image_SLnZ : Commensurable (Gamma1Image N) (SLnZ 2) := by
   have hSL : SLnZ 2 =
       Subgroup.map (mapGL ℚ : SpecialLinearGroup (Fin 2) ℤ →* GL (Fin 2) ℚ) ⊤ := by
     ext g
     simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
     exact (mem_SLnZ_iff 2).trans (by simp)
   constructor
-  · rw [Gamma1Map, hSL,
+  · rw [Gamma1Image, hSL,
       Subgroup.relIndex_map_map_of_injective _ _ mapGL_injective, Subgroup.relIndex_top_right]
     exact Subgroup.FiniteIndex.index_ne_zero
-  · rw [Gamma1Map, hSL,
+  · rw [Gamma1Image, hSL,
       Subgroup.relIndex_map_map_of_injective _ _ mapGL_injective, Subgroup.relIndex_top_left]
     exact one_ne_zero
 
 /-- `Δ₁(N)` lies in the commensurator of `Γ₁(N)`: it lies in that of `SL₂(ℤ)`, and the two
 groups are commensurable. -/
-lemma Delta1_le_commensurator : Delta1 N ≤ (commensurator (Gamma1Map N)).toSubmonoid := by
-  rw [Subgroup.Commensurable.eq (commensurable_Gamma1Map_SLnZ N)]
+lemma Delta1_le_commensurator : Delta1 N ≤ (commensurator (Gamma1Image N)).toSubmonoid := by
+  rw [Subgroup.Commensurable.eq (commensurable_Gamma1Image_SLnZ N)]
   exact (Delta1_le_posDetInt N).trans (posDetInt_le_commensurator 2)
 
 /-- **The Hecke triple of `Γ₁(N)`**: `Γ₁(N) ≤ Δ₁(N) ≤ commensurator(Γ₁(N))` inside
 `GL₂(ℚ)` — the setting of the Hecke operators on modular forms of level `N`. -/
-instance : IsHeckeTriple (Delta1 N) (Gamma1Map N) (Gamma1Map N) :=
-  IsHeckeTriple.of_diagonal (Gamma1Map_le_Delta1 N) (Delta1_le_commensurator N)
+instance : IsHeckeTriple (Delta1 N) (Gamma1Image N) (Gamma1Image N) :=
+  IsHeckeTriple.of_diagonal (Gamma1Image_le_Delta1 N) (Delta1_le_commensurator N)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -6,7 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GLn.Basic
-public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
+public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
 # The Hecke triple of `Γ₁(N)`
@@ -111,8 +111,7 @@ lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N := by
   obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Image_iff N).mp hg
   obtain ⟨ha, -, hc⟩ := (Gamma1_mem _ _).mp hσ
   refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha ▸ isUnit_one⟩
-  · rw [mapGL_coe_matrix]
-    rfl
+  · simp [mapGL_coe_matrix, algebraMap_int_eq]
   · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
     exact one_pos
   · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
@@ -124,27 +123,12 @@ lemma Gamma0_map_le_Delta0 :
     ((Gamma0 N).map (mapGL ℚ)).toSubmonoid ≤ Delta0 N := by
   intro g hg
   obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hg
-  have hc : ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ZMod N) = 0 := Gamma0_mem.mp hσ
-  have hdet : (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
-      (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = 1 := by
-    have := σ.prop
-    rwa [Matrix.det_fin_two] at this
-  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ?_⟩
-  · rw [mapGL_coe_matrix]
-    rfl
+  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_,
+    isUnit_coe_zero_zero_of_mem_Gamma0 hσ⟩
+  · simp [mapGL_coe_matrix, algebraMap_int_eq]
   · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
     exact one_pos
-  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
-  · refine IsUnit.of_mul_eq_one (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ZMod N)) ?_
-    have hcast : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 *
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 *
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 1 := by
-      rw [hdet]
-      exact Int.cast_one
-    push_cast at hcast
-    rw [hc, mul_zero, sub_zero] at hcast
-    exact hcast
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hσ)
 
 /-- `Δ₀(N)` consists of integral matrices with positive determinant. -/
 lemma Delta0_le_posDetInt : Delta0 N ≤ posDetInt 2 := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -11,10 +11,25 @@ public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 /-!
 # The Hecke triple of `Γ₁(N)`
 
-The submonoid `Δ₁(N) ⊆ GL₂(ℚ)` of integral matrices with positive determinant whose first
-column is congruent to `(1, 0)` modulo `N`, and the Hecke triple it forms with the image of
-the congruence subgroup `Γ₁(N)`. This is the level-`N` counterpart of the arithmetic triple
-`(Δₙ, SL_n(ℤ))`, and the setting in which the Hecke operators on `M_k(Γ₁(N))` live.
+The submonoid `Δ₀(N) ⊆ GL₂(ℚ)` of integral matrices with positive determinant that are
+upper-triangular modulo `N` with unit upper-left entry, and the Hecke triple it forms with
+the image of the congruence subgroup `Γ₁(N)`. This is the level-`N` counterpart of the
+arithmetic triple `(Δₙ, SL_n(ℤ))`, and the setting in which the Hecke operators on
+`M_k(Γ₁(N))` live.
+
+`Δ₀(N)` is the classical semigroup of Miyake, *Modular Forms*, §4.5: integral, of positive
+determinant, with `c ≡ 0` and `a` coprime to `N`, the coprimality spelled here as
+`IsUnit (a : ZMod N)`. Asking the upper-left entry to be a *unit* rather than `≡ 1` is what
+makes `Γ₀(N) ≤ Δ₀(N)`, so that the resulting Hecke ring carries the diamond operators
+alongside the `T_p`: an element of `Γ₀(N)` has `ad ≡ 1` modulo `N`, hence unit `a`, but
+`a ≡ 1` only for the elements of `Γ₁(N)` itself. The smaller classical semigroup `Δ₁(N)`,
+cut out by `a ≡ 1`, is the sub-semigroup carrying the `T_p` alone.
+
+Determinants divisible by `N` are deliberately admitted: `diag(1, p)` lies in `Δ₀(N)` even
+when `p ∣ N`, where it gives the bad-prime operator `U_p`. Because of this, the whole
+determinant-`n` part of `Δ₀(N)` is the full diamond orbit of the classical `T_n`, not `T_n`
+itself; an operator defined downstream must be cut out of the `a ≡ 1` part rather than taken
+as that entire fibre.
 
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`](https://github.com/CBirkbeck/AINTLIB),
@@ -22,14 +37,16 @@ Chris Birkbeck).
 
 ## Main definitions
 
-* `HeckeRing.GL2.Delta1`: the submonoid `Δ₁(N)`.
+* `HeckeRing.GL2.Delta0`: the submonoid `Δ₀(N)`.
 * `HeckeRing.GL2.Gamma1Image`: the image of `Γ₁(N)` in `GL₂(ℚ)`.
 
 ## Main results
 
-* `HeckeRing.GL2.Gamma1Image_le_Delta1`: `Γ₁(N) ≤ Δ₁(N)`.
-* `HeckeRing.GL2.Delta1_le_commensurator`: `Δ₁(N)` lies in the commensurator of `Γ₁(N)`.
-* the `IsHeckeTriple (Delta1 N) (Gamma1Image N) (Gamma1Image N)` instance.
+* `HeckeRing.GL2.Gamma1Image_le_Delta0`: `Γ₁(N) ≤ Δ₀(N)`.
+* `HeckeRing.GL2.Gamma0Image_le_Delta0`: `Γ₀(N) ≤ Δ₀(N)`, so the diamond operators live in
+  the same Hecke ring.
+* `HeckeRing.GL2.Delta0_le_commensurator`: `Δ₀(N)` lies in the commensurator of `Γ₁(N)`.
+* the `IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N)` instance.
 
 ## References
 
@@ -57,49 +74,82 @@ noncomputable def Gamma1Image : Subgroup (GL (Fin 2) ℚ) :=
     g ∈ Gamma1Image N ↔ ∃ σ ∈ Gamma1 N, mapGL ℚ σ = g := by
   rw [Gamma1Image, Subgroup.mem_map]
 
-/-- `Δ₁(N)`: integral matrices of positive determinant whose first column is congruent to
-`(1, 0)` modulo `N`, i.e. `a ≡ 1` and `c ≡ 0 (mod N)`. Note this constrains only the first
-column: the lower-right entry is unrestricted. -/
-noncomputable def Delta1 : Submonoid (GL (Fin 2) ℚ) where
+/-- `Δ₀(N)`: integral matrices of positive determinant that are upper-triangular modulo `N`
+with unit upper-left entry, i.e. `c ≡ 0 (mod N)` and `a` a unit in `ZMod N`. The unit
+condition (rather than `a ≡ 1`) is what makes `Γ₀(N) ≤ Δ₀(N)`. -/
+noncomputable def Delta0 : Submonoid (GL (Fin 2) ℚ) where
   carrier := {g | ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
     (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
-      0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧ (A 0 0 : ZMod N) = 1}
+      0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧ IsUnit (A 0 0 : ZMod N)}
   one_mem' := ⟨1, by simp, by simp, by simp, by simp⟩
   mul_mem' := by
-    rintro a b ⟨A, hA, hda, hAN, hAone⟩ ⟨B, hB, hdb, hBN, hBone⟩
+    rintro a b ⟨A, hA, hda, hAN, hAunit⟩ ⟨B, hB, hdb, hBN, hBunit⟩
     refine ⟨A * B, ?_, ?_, ?_, ?_⟩
     · ext i j
       simp [hA, hB, Matrix.mul_apply, Matrix.map_apply]
     · simpa [Matrix.det_mul] using mul_pos hda hdb
     · simp only [Matrix.mul_apply, Fin.sum_univ_two]
       exact dvd_add (dvd_mul_of_dvd_left hAN _) (dvd_mul_of_dvd_right hBN _)
-    · simp [Matrix.mul_apply, Fin.sum_univ_two, hAone, hBone,
-        (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hBN]
+    · -- the upper-left entry of the product is `a₁a₂` modulo `N`, since `c₂ ≡ 0`
+      have hentry : ((A * B) 0 0 : ZMod N) = (A 0 0 : ZMod N) * (B 0 0 : ZMod N) := by
+        simp [Matrix.mul_apply, Fin.sum_univ_two,
+          (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hBN]
+      rw [hentry]
+      exact hAunit.mul hBunit
 
-/-- Membership in `Δ₁(N)`, unfolded. -/
-@[simp] lemma mem_Delta1_iff {g : GL (Fin 2) ℚ} :
-    g ∈ Delta1 N ↔ ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
+/-- Membership in `Δ₀(N)`, unfolded. -/
+@[simp] lemma mem_Delta0_iff {g : GL (Fin 2) ℚ} :
+    g ∈ Delta0 N ↔ ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
       (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
         0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧
-          (A 0 0 : ZMod N) = 1 :=
+          IsUnit (A 0 0 : ZMod N) :=
   Iff.rfl
 
-/-- `Γ₁(N) ≤ Δ₁(N)`: the congruence subgroup embeds in the submonoid. -/
-lemma Gamma1Image_le_Delta1 : (Gamma1Image N).toSubmonoid ≤ Delta1 N := by
+/-- `Γ₁(N) ≤ Δ₀(N)`: the congruence subgroup embeds in the submonoid. -/
+lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N := by
   intro g hg
   obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Image_iff N).mp hg
   obtain ⟨ha, -, hc⟩ := (Gamma1_mem _ _).mp hσ
-  refine (mem_Delta1_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha⟩
+  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha ▸ isUnit_one⟩
   · rw [mapGL_coe_matrix]
     rfl
   · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
     exact one_pos
   · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
 
-/-- `Δ₁(N)` consists of integral matrices with positive determinant. -/
-lemma Delta1_le_posDetInt : Delta1 N ≤ posDetInt 2 := by
+/-- `Γ₀(N) ≤ Δ₀(N)`: an element of `Γ₀(N)` has `ad ≡ 1` modulo `N`, since `c ≡ 0` and the
+determinant is one, so its upper-left entry is a unit. This containment is what puts the
+diamond operators into the Hecke ring of `Γ₁(N)`. -/
+lemma Gamma0Image_le_Delta0 :
+    ((Gamma0 N).map (mapGL ℚ)).toSubmonoid ≤ Delta0 N := by
   intro g hg
-  obtain ⟨A, hA, hdet, -, -⟩ := (mem_Delta1_iff N).mp hg
+  obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hg
+  have hc : ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ZMod N) = 0 := Gamma0_mem.mp hσ
+  have hdet : (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
+      (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = 1 := by
+    have := σ.prop
+    rwa [Matrix.det_fin_two] at this
+  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ?_⟩
+  · rw [mapGL_coe_matrix]
+    rfl
+  · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
+    exact one_pos
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
+  · refine IsUnit.of_mul_eq_one (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ZMod N)) ?_
+    have hcast : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 *
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 *
+        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 1 := by
+      rw [hdet]
+      exact Int.cast_one
+    push_cast at hcast
+    rw [hc, mul_zero, sub_zero] at hcast
+    exact hcast
+
+/-- `Δ₀(N)` consists of integral matrices with positive determinant. -/
+lemma Delta0_le_posDetInt : Delta0 N ≤ posDetInt 2 := by
+  intro g hg
+  obtain ⟨A, hA, hdet, -, -⟩ := (mem_Delta0_iff N).mp hg
   exact (mem_posDetInt_iff 2).mpr ⟨(hasIntEntries_iff 2).mpr ⟨A, hA⟩, hdet⟩
 
 variable [NeZero N]
@@ -119,15 +169,15 @@ lemma commensurable_Gamma1Image_SLnZ : Commensurable (Gamma1Image N) (SLnZ 2) :=
       Subgroup.relIndex_map_map_of_injective _ _ mapGL_injective, Subgroup.relIndex_top_left]
     exact one_ne_zero
 
-/-- `Δ₁(N)` lies in the commensurator of `Γ₁(N)`: it lies in that of `SL₂(ℤ)`, and the two
+/-- `Δ₀(N)` lies in the commensurator of `Γ₁(N)`: it lies in that of `SL₂(ℤ)`, and the two
 groups are commensurable. -/
-lemma Delta1_le_commensurator : Delta1 N ≤ (commensurator (Gamma1Image N)).toSubmonoid := by
+lemma Delta0_le_commensurator : Delta0 N ≤ (commensurator (Gamma1Image N)).toSubmonoid := by
   rw [Subgroup.Commensurable.eq (commensurable_Gamma1Image_SLnZ N)]
-  exact (Delta1_le_posDetInt N).trans (posDetInt_le_commensurator 2)
+  exact (Delta0_le_posDetInt N).trans (posDetInt_le_commensurator 2)
 
-/-- **The Hecke triple of `Γ₁(N)`**: `Γ₁(N) ≤ Δ₁(N) ≤ commensurator(Γ₁(N))` inside
+/-- **The Hecke triple of `Γ₁(N)`**: `Γ₁(N) ≤ Δ₀(N) ≤ commensurator(Γ₁(N))` inside
 `GL₂(ℚ)` — the setting of the Hecke operators on modular forms of level `N`. -/
-instance : IsHeckeTriple (Delta1 N) (Gamma1Image N) (Gamma1Image N) :=
-  IsHeckeTriple.of_diagonal (Gamma1Image_le_Delta1 N) (Delta1_le_commensurator N)
+instance : IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N) :=
+  IsHeckeTriple.of_diagonal (Gamma1Image_le_Delta0 N) (Delta0_le_commensurator N)
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.Basic
+public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
+
+/-!
+# The Hecke triple of `Γ₁(N)`
+
+The submonoid `Δ₁(N) ⊆ GL₂(ℚ)` of integral matrices with positive determinant that are
+upper-triangular and unipotent modulo `N`, and the Hecke triple it forms with the image of
+the congruence subgroup `Γ₁(N)`. This is the level-`N` counterpart of the arithmetic triple
+`(Δₙ, SL_n(ℤ))`, and the setting in which the Hecke operators on `M_k(Γ₁(N))` live.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck).
+
+## Main definitions
+
+* `HeckeRing.GL2.Delta1`: the submonoid `Δ₁(N)`.
+* `HeckeRing.GL2.Gamma1Map`: the image of `Γ₁(N)` in `GL₂(ℚ)`.
+
+## Main results
+
+* `HeckeRing.GL2.Gamma1Map_le_Delta1`: `Γ₁(N) ≤ Δ₁(N)`.
+* `HeckeRing.GL2.Delta1_le_commensurator`: `Δ₁(N)` lies in the commensurator of `Γ₁(N)`.
+* the `IsHeckeTriple (Delta1 N) (Gamma1Map N) (Gamma1Map N)` instance.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Chapter 3.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup CongruenceSubgroup Subgroup
+  Subgroup.Commensurable HeckeRing.GLn
+
+open scoped Pointwise MatrixGroups
+
+namespace HeckeRing.GL2
+
+variable (N : ℕ)
+
+/-- The image of `Γ₁(N)` in `GL₂(ℚ)`. -/
+noncomputable def Gamma1Map : Subgroup (GL (Fin 2) ℚ) :=
+  (Gamma1 N).map (mapGL ℚ)
+
+/-- Membership in the image of `Γ₁(N)`, by an integral witness. -/
+lemma mem_Gamma1Map_iff {g : GL (Fin 2) ℚ} :
+    g ∈ Gamma1Map N ↔ ∃ σ ∈ Gamma1 N, mapGL ℚ σ = g := by
+  rw [Gamma1Map, Subgroup.mem_map]
+
+/-- `Δ₁(N)`: integral matrices of positive determinant that are unipotent upper-triangular
+modulo `N`, i.e. `a ≡ 1` and `c ≡ 0 (mod N)`. -/
+noncomputable def Delta1 : Submonoid (GL (Fin 2) ℚ) where
+  carrier := {g | ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
+    (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
+      0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧ (A 0 0 : ZMod N) = 1}
+  one_mem' := ⟨1, by simp, by simp, by simp, by simp⟩
+  mul_mem' := by
+    rintro a b ⟨A, hA, hda, hAN, hAone⟩ ⟨B, hB, hdb, hBN, hBone⟩
+    refine ⟨A * B, ?_, ?_, ?_, ?_⟩
+    · ext i j
+      simp [hA, hB, Matrix.mul_apply, Matrix.map_apply]
+    · simpa [Matrix.det_mul] using mul_pos hda hdb
+    · simp only [Matrix.mul_apply, Fin.sum_univ_two]
+      exact dvd_add (dvd_mul_of_dvd_left hAN _) (dvd_mul_of_dvd_right hBN _)
+    · simp [Matrix.mul_apply, Fin.sum_univ_two, hAone, hBone,
+        (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mpr hBN]
+
+/-- Membership in `Δ₁(N)`, unfolded. -/
+lemma mem_Delta1_iff {g : GL (Fin 2) ℚ} :
+    g ∈ Delta1 N ↔ ∃ A : Matrix (Fin 2) (Fin 2) ℤ,
+      (↑g : Matrix (Fin 2) (Fin 2) ℚ) = A.map (Int.cast : ℤ → ℚ) ∧
+        0 < (↑g : Matrix (Fin 2) (Fin 2) ℚ).det ∧ (N : ℤ) ∣ A 1 0 ∧
+          (A 0 0 : ZMod N) = 1 :=
+  Iff.rfl
+
+/-- `Γ₁(N) ≤ Δ₁(N)`: the congruence subgroup embeds in the submonoid. -/
+lemma Gamma1Map_le_Delta1 : (Gamma1Map N).toSubmonoid ≤ Delta1 N := by
+  intro g hg
+  obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Map_iff N).mp hg
+  obtain ⟨ha, -, hc⟩ := (Gamma1_mem _ _).mp hσ
+  refine (mem_Delta1_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha⟩
+  · rw [mapGL_coe_matrix]
+    rfl
+  · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
+    exact one_pos
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
+
+/-- `Δ₁(N)` consists of integral matrices with positive determinant. -/
+lemma Delta1_le_posDetInt : Delta1 N ≤ posDetInt 2 := by
+  intro g hg
+  obtain ⟨A, hA, hdet, -, -⟩ := (mem_Delta1_iff N).mp hg
+  exact (mem_posDetInt_iff 2).mpr ⟨(hasIntEntries_iff 2).mpr ⟨A, hA⟩, hdet⟩
+
+variable [NeZero N]
+
+/-- `Γ₁(N)` is commensurable with `SL₂(ℤ)`: it has finite index in it. -/
+lemma commensurable_Gamma1Map_SLnZ : Commensurable (Gamma1Map N) (SLnZ 2) := by
+  have hSL : SLnZ 2 =
+      Subgroup.map (mapGL ℚ : SpecialLinearGroup (Fin 2) ℤ →* GL (Fin 2) ℚ) ⊤ := by
+    ext g
+    simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
+    exact (mem_SLnZ_iff 2).trans (by simp)
+  constructor
+  · rw [Gamma1Map, hSL,
+      Subgroup.relIndex_map_map_of_injective _ _ mapGL_injective, Subgroup.relIndex_top_right]
+    exact Subgroup.FiniteIndex.index_ne_zero
+  · rw [Gamma1Map, hSL,
+      Subgroup.relIndex_map_map_of_injective _ _ mapGL_injective, Subgroup.relIndex_top_left]
+    exact one_ne_zero
+
+/-- `Δ₁(N)` lies in the commensurator of `Γ₁(N)`: it lies in that of `SL₂(ℤ)`, and the two
+groups are commensurable. -/
+lemma Delta1_le_commensurator : Delta1 N ≤ (commensurator (Gamma1Map N)).toSubmonoid := by
+  rw [Subgroup.Commensurable.eq (commensurable_Gamma1Map_SLnZ N)]
+  exact (Delta1_le_posDetInt N).trans (posDetInt_le_commensurator 2)
+
+/-- **The Hecke triple of `Γ₁(N)`**: `Γ₁(N) ≤ Δ₁(N) ≤ commensurator(Γ₁(N))` inside
+`GL₂(ℚ)` — the setting of the Hecke operators on modular forms of level `N`. -/
+instance : IsHeckeTriple (Delta1 N) (Gamma1Map N) (Gamma1Map N) :=
+  IsHeckeTriple.of_diagonal (Gamma1Map_le_Delta1 N) (Delta1_le_commensurator N)
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -32,6 +32,8 @@ infrastructure independent of the diamond operators.
 
 ## Main results
 
+* `CongruenceSubgroup.isUnit_coe_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has unit
+  upper-left entry modulo `N`.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
   `GL₂(ℝ)`.
@@ -58,6 +60,18 @@ open scoped MatrixGroups Pointwise
 variable {N : ℕ}
 
 namespace CongruenceSubgroup
+
+/-- The upper-left entry of a `Γ₀(N)` matrix is a unit modulo `N`: the determinant is one
+and the lower-left entry vanishes modulo `N`, so `ad ≡ 1`. -/
+theorem isUnit_coe_zero_zero_of_mem_Gamma0 {N : ℕ} {σ : SL(2, ℤ)} (hσ : σ ∈ Gamma0 N) :
+    IsUnit ((σ.1 0 0 : ℤ) : ZMod N) := by
+  have h10 : ((σ.1 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hσ
+  have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
+    Matrix.det_fin_two σ.1 ▸ σ.2
+  have hcast := congrArg (fun z : ℤ ↦ (z : ZMod N)) hdet
+  push_cast at hcast
+  rw [h10, mul_zero, sub_zero] at hcast
+  exact IsUnit.of_mul_eq_one _ hcast
 
 /-- Conjugation by a `Gamma0 N` element preserves `Gamma1 N`.
 This is the foundation for the diamond operator `⟨d⟩` on modular forms. -/
@@ -309,16 +323,10 @@ private lemma Gamma0_relindex_step_surj (k : ℕ) (hk : 0 < k) :
   obtain ⟨q, hq⟩ : (↑(p ^ k) : ℤ) ∣ σ.1 1 0 := by
     rwa [← ZMod.intCast_zmod_eq_zero_iff_dvd, ← Gamma0_mem]
   push_cast at hq
-  have h00_unit : IsUnit ((σ.1 0 0 : ℤ) : ZMod p) := by
-    have h10 : ((σ.1 1 0 : ℤ) : ZMod p) = 0 := by
+  have h00_unit : IsUnit ((σ.1 0 0 : ℤ) : ZMod p) :=
+    isUnit_coe_zero_zero_of_mem_Gamma0 (Gamma0_mem.mpr (by
       rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
-      exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q
-    have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
-      Matrix.det_fin_two σ.1 ▸ σ.2
-    have hcast := congrArg (fun z : ℤ ↦ (z : ZMod p)) hdet
-    push_cast at hcast
-    rw [h10, mul_zero, sub_zero] at hcast
-    exact IsUnit.of_mul_eq_one _ hcast
+      exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q))
   obtain ⟨c₀, hc₀⟩ := exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
   refine ⟨⟨c₀.val, ZMod.val_lt c₀⟩, ?_⟩
   rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]


### PR DESCRIPTION
The level-`N` counterpart of the arithmetic Hecke triple `(Δₙ, SL_n(ℤ))`: the setting in which the Hecke operators on `M_k(Γ₁(N))` live.

* `HeckeRing.GL2.Delta0 N`: the classical semigroup `Δ₀(N) ⊆ GL₂(ℚ)` (Miyake, *Modular Forms*, §4.5) of integral matrices with positive determinant that are upper-triangular modulo `N` (`c ≡ 0`) with `a` coprime to `N`, with its membership characterization.
* `HeckeRing.GL2.Gamma1Image N`: the image of `Γ₁(N)` in `GL₂(ℚ)`.
* `HeckeRing.GL2.Gamma1Image_le_Delta0`: the congruence subgroup embeds in the submonoid.
* `HeckeRing.GL2.Gamma0_map_le_Delta0`: so does `Γ₀(N)`, since `c ≡ 0` and `det = 1` force `ad ≡ 1 (mod N)`. This is what puts the diamond operators in the same Hecke ring as the `T_p`.
* `HeckeRing.GL2.commensurable_Gamma1Image_SLnZ`, `Delta0_le_commensurator`: `Γ₁(N)` is commensurable with `SL₂(ℤ)` (finite index), so `Δ₀(N)` — lying in the commensurator of `SL₂(ℤ)` by #2085's ambient theory — lies in that of `Γ₁(N)`.
* the resulting `IsHeckeTriple (Delta0 N) (Gamma1Image N) (Gamma1Image N)` instance.

**Why the unit condition, not `a ≡ 1`.** The first revision of this PR ported AINTLIB's `a ≡ 1` semigroup verbatim. That semigroup is too small to be the Hecke ring of `Γ₁(N)`: since elements of `Γ₁(N)` have unit diagonal and `c ≡ 0`, multiplying on either side preserves the residue of `a`, so a matrix with `a ≢ 1` — for instance `[[2,1],[5,3]] ∈ Γ₀(5)` — has no double-coset representative in it, and the resulting ring carries no nontrivial diamond operator. Asking for `a` to be a unit instead gives the classical `Δ₀(N)`, which contains `Γ₀(N)`; the `a ≡ 1` semigroup is classically `Δ₁(N)`, and the definition here is named to match. Determinants divisible by `N` remain admissible, which is what keeps the bad-prime `U_p` in range; correspondingly the determinant-`n` part of `Δ₀(N)` is the whole diamond orbit of `T_n` rather than `T_n` itself, which the module docstring records so a downstream `T_n` is cut from the `a ≡ 1` part.

Ported from the AINTLIB `LeanModularForms` project (`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`, Chris Birkbeck), whose bespoke `HeckePair` structure becomes the `IsHeckeTriple` typeclass used here and in Mathlib. That file's diamond-operator half is already in TauCeti via #1959; this PR supplies the Hecke-triple half.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/ModularForms/README.md), Layer 2: the `T_p` operators on modular forms of level `N` are defined as double-coset operators for exactly this triple, so it is the prerequisite for the `HeckeT_p` development.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
