### PR TITLE
test: probe the Lake cache fetch race on a runner

### DIFF
--- a/.github/workflows/cache-diagnostic.yml
+++ b/.github/workflows/cache-diagnostic.yml
@@ -74,10 +74,15 @@ jobs:
       - name: Collect artifact hashes to probe
         id: hashes
         run: |
-          if [ -z "$PUBLIC_ARTIFACT_ENDPOINT" ]; then
-            echo "::error::LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC is unset; nothing to probe"
-            exit 1
-          fi
+          # Fail closed on every path that would leave nothing to probe. A diagnostic
+          # that prints "NOT REPRODUCED" after zero verifications is worse than one that
+          # errors: it is a false negative in the instrument built to avoid them.
+          for v in PUBLIC_ARTIFACT_ENDPOINT PUBLIC_REVISION_ENDPOINT; do
+            if [ -z "${!v}" ]; then
+              echo "::error::$v is unset; cannot probe"
+              exit 1
+            fi
+          done
           # Take the revision manifest for a recent built commit and read the artifact
           # hashes out of it, so we probe exactly the objects a real fetch would.
           mkdir -p "$RUNNER_TEMP/diag"
@@ -89,14 +94,18 @@ jobs:
             fi
           done
           if [ -z "$found" ]; then
-            echo "::warning::no revision manifest found in the last 40 commits; falling back to none"
-            : > "$RUNNER_TEMP/diag/hashes.txt"
-          else
-            echo "using revision $found ($(wc -l < "$RUNNER_TEMP/diag/rev.jsonl") manifest lines)"
-            grep -oE '[0-9a-f]{16}' "$RUNNER_TEMP/diag/rev.jsonl" | sort -u \
-              | head -n "${{ inputs.artifacts }}" > "$RUNNER_TEMP/diag/hashes.txt"
+            echo "::error::no revision manifest found in the last 40 commits; aborting rather than probing nothing"
+            exit 1
           fi
-          echo "probing $(wc -l < "$RUNNER_TEMP/diag/hashes.txt") artifact hashes"
+          echo "using revision $found ($(wc -l < "$RUNNER_TEMP/diag/rev.jsonl") manifest lines)"
+          grep -oE '[0-9a-f]{16}' "$RUNNER_TEMP/diag/rev.jsonl" | sort -u \
+            | head -n "${{ inputs.artifacts }}" > "$RUNNER_TEMP/diag/hashes.txt"
+          n=$(wc -l < "$RUNNER_TEMP/diag/hashes.txt")
+          if [ "$n" -lt 50 ]; then
+            echo "::error::only $n artifact hashes extracted; too few for a meaningful probe"
+            exit 1
+          fi
+          echo "probing $n artifact hashes"
 
       - name: Phase A — probe alone (baseline)
         run: |

--- a/.github/workflows/cache-diagnostic.yml
+++ b/.github/workflows/cache-diagnostic.yml
@@ -1,0 +1,176 @@
+name: Cache fetch diagnostic
+
+# TEMPORARY. Delete this workflow once
+# https://github.com/TauCetiProject/TauCeti/issues/2062 is resolved.
+#
+# About a third of merge-group builds lose the Lake artifact cache entirely and rebuild
+# from scratch (22 to 28 min instead of 3 to 6). The failing runs show, on an artifact
+# Lake had just logged as downloaded, either
+#
+#   error: no such file or directory (error code: 4294967294)   # -2, ENOENT
+#   error: <path>.ltar: downloaded artifact hash mismatch, got <other-hash>
+#
+# and the exception aborts the entire fetch, because Lake/Config/Cache.lean's
+# monitorTransfer calls computeFileHash the instant curl's --write-out JSON reports
+# http_code 200, with no try/catch. The CDN has been ruled out (37 fetches of a failing
+# artifact returned identical bytes), as have missing uploads, disk space, leantar, and
+# duplicate requests. A local replication of Lake's verification logic over 2400 draws
+# saw zero failures, so the trigger is suspected to be environmental.
+#
+# This workflow tests it where it happens. It is dispatch-only and touches nothing:
+# read-only permissions, no secrets, anonymous GETs against the public read endpoint.
+#
+# Phase A  the probe alone, establishing a per-runner baseline.
+# Phase B  the same probe under synthetic disk and CPU load, since a real build writes
+#          multi-GB into the same filesystem while the fetch runs.
+# Phase C  a real `lake cache get`, the ground truth, repeated until it fails or the
+#          attempt budget runs out.
+
+on:
+  workflow_dispatch:
+    inputs:
+      artifacts:
+        description: "Artifacts per probe iteration"
+        type: string
+        default: "400"
+      iterations:
+        description: "Probe iterations per phase"
+        type: string
+        default: "6"
+      lake_attempts:
+        description: "Phase C: real `lake cache get` attempts"
+        type: string
+        default: "5"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cache-diagnostic
+  cancel-in-progress: false
+
+jobs:
+  diagnose:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 90
+    env:
+      PUBLIC_ARTIFACT_ENDPOINT: ${{ vars.LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC }}
+      PUBLIC_REVISION_ENDPOINT: ${{ vars.LAKE_CACHE_REVISION_ENDPOINT_PUBLIC }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Enough history for `lake cache get` to backtrack to a built revision.
+          fetch-depth: 200
+
+      - name: Environment (the suspected difference from a local run)
+        run: |
+          echo "curl:      $(curl --version | head -1)"
+          echo "nproc:     $(nproc)   # curl -Z parallelism scales with this"
+          echo "kernel:    $(uname -r)"
+          echo "runner fs: $(findmnt -no FSTYPE,OPTIONS --target "$PWD" || true)"
+          df -h "$PWD" | tail -1
+          echo "tmp fs:    $(findmnt -no FSTYPE,OPTIONS --target /tmp || true)"
+
+      - name: Collect artifact hashes to probe
+        id: hashes
+        run: |
+          if [ -z "$PUBLIC_ARTIFACT_ENDPOINT" ]; then
+            echo "::error::LAKE_CACHE_ARTIFACT_ENDPOINT_PUBLIC is unset; nothing to probe"
+            exit 1
+          fi
+          # Take the revision manifest for a recent built commit and read the artifact
+          # hashes out of it, so we probe exactly the objects a real fetch would.
+          mkdir -p "$RUNNER_TEMP/diag"
+          found=""
+          for sha in $(git log --format=%H -40 origin/main 2>/dev/null || git log --format=%H -40); do
+            url="$PUBLIC_REVISION_ENDPOINT/TauCetiProject/TauCeti/tc/$(cat lean-toolchain | tr '/:' '--')/$sha.jsonl"
+            if curl -fsS "$url" -o "$RUNNER_TEMP/diag/rev.jsonl" 2>/dev/null; then
+              found="$sha"; break
+            fi
+          done
+          if [ -z "$found" ]; then
+            echo "::warning::no revision manifest found in the last 40 commits; falling back to none"
+            : > "$RUNNER_TEMP/diag/hashes.txt"
+          else
+            echo "using revision $found ($(wc -l < "$RUNNER_TEMP/diag/rev.jsonl") manifest lines)"
+            grep -oE '[0-9a-f]{16}' "$RUNNER_TEMP/diag/rev.jsonl" | sort -u \
+              | head -n "${{ inputs.artifacts }}" > "$RUNNER_TEMP/diag/hashes.txt"
+          fi
+          echo "probing $(wc -l < "$RUNNER_TEMP/diag/hashes.txt") artifact hashes"
+
+      - name: Phase A — probe alone (baseline)
+        run: |
+          python3 scripts/diag/cache_fetch_probe.py \
+            "$RUNNER_TEMP/diag/hashes.txt" \
+            "$PUBLIC_ARTIFACT_ENDPOINT/TauCetiProject/TauCeti" \
+            "$RUNNER_TEMP/diag/outA" \
+            --iterations "${{ inputs.iterations }}"
+
+      - name: Phase B — probe under disk and CPU load
+        run: |
+          # A real build writes multi-GB into this filesystem while the fetch runs and
+          # saturates every core. Reproduce that pressure, then tear it down.
+          for i in $(seq 1 "$(nproc)"); do
+            ( while :; do dd if=/dev/zero of="$RUNNER_TEMP/diag/load.$i" bs=1M count=256 \
+                 oflag=direct 2>/dev/null || dd if=/dev/zero of="$RUNNER_TEMP/diag/load.$i" \
+                 bs=1M count=256 2>/dev/null; sync; done ) &
+            echo $! >> "$RUNNER_TEMP/diag/load.pids"
+          done
+          for i in $(seq 1 "$(nproc)"); do ( while :; do :; done ) & echo $! >> "$RUNNER_TEMP/diag/load.pids"; done
+          trap 'while read -r p; do kill "$p" 2>/dev/null || true; done < "$RUNNER_TEMP/diag/load.pids"' EXIT
+          sleep 5
+          python3 scripts/diag/cache_fetch_probe.py \
+            "$RUNNER_TEMP/diag/hashes.txt" \
+            "$PUBLIC_ARTIFACT_ENDPOINT/TauCetiProject/TauCeti" \
+            "$RUNNER_TEMP/diag/outB" \
+            --iterations "${{ inputs.iterations }}"
+          rm -f "$RUNNER_TEMP/diag"/load.* || true
+
+      - name: Install elan (for phase C)
+        run: |
+          curl -sSfL https://github.com/leanprover/elan/releases/download/v4.1.2/elan-x86_64-unknown-linux-gnu.tar.gz \
+            | tar xz
+          ./elan-init -y --default-toolchain "$(cat lean-toolchain)"
+          echo "$HOME/.elan/bin" >> "$GITHUB_PATH"
+
+      - name: Phase C — real `lake cache get`, the ground truth
+        run: |
+          CFG="$RUNNER_TEMP/lake-cache.toml"
+          cat > "$CFG" <<TOML
+          cache.defaultService = "tauceti-public"
+          [[cache.service]]
+          name = "tauceti-public"
+          kind = "s3"
+          artifactEndpoint = "$PUBLIC_ARTIFACT_ENDPOINT"
+          revisionEndpoint = "$PUBLIC_REVISION_ENDPOINT"
+          TOML
+          export LAKE_CACHE_DIR="$PWD/.lake/cache"
+          export LAKE_ARTIFACT_CACHE=true
+          export LAKE_RESTORE_ARTIFACTS=true
+          fails=0
+          for a in $(seq 1 "${{ inputs.lake_attempts }}"); do
+            rm -rf "$LAKE_CACHE_DIR"
+            LOG="$RUNNER_TEMP/diag/lake-$a.log"
+            rc=0
+            LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
+              --repo TauCetiProject/TauCeti > "$LOG" 2>&1 || rc=$?
+            enoent=$(grep -c "no such file or directory" "$LOG" || true)
+            mism=$(grep -c "downloaded artifact hash mismatch" "$LOG" || true)
+            dl=$(grep -c "downloaded artifact" "$LOG" || true)
+            echo "attempt $a: rc=$rc downloads=$dl ENOENT=$enoent hash_mismatch=$mism"
+            if [ "$enoent" != 0 ] || [ "$mism" != 0 ]; then
+              fails=$((fails+1))
+              echo "--- failing context ---"
+              grep -B 6 -E "no such file or directory|hash mismatch" "$LOG" | tail -20
+            fi
+          done
+          echo
+          echo "PHASE C: $fails of ${{ inputs.lake_attempts }} real fetches hit ENOENT or a hash mismatch"
+
+      - name: Upload logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cache-diagnostic-logs
+          path: ${{ runner.temp }}/diag/*.log
+          if-no-files-found: warn

--- a/.github/workflows/cache-diagnostic.yml
+++ b/.github/workflows/cache-diagnostic.yml
@@ -67,9 +67,18 @@ jobs:
           echo "curl:      $(curl --version | head -1)"
           echo "nproc:     $(nproc)   # curl -Z parallelism scales with this"
           echo "kernel:    $(uname -r)"
-          echo "runner fs: $(findmnt -no FSTYPE,OPTIONS --target "$PWD" || true)"
+          echo "workspace fs:   $(findmnt -no FSTYPE,OPTIONS --target "$PWD" || true)"
           df -h "$PWD" | tail -1
-          echo "tmp fs:    $(findmnt -no FSTYPE,OPTIONS --target /tmp || true)"
+          echo "RUNNER_TEMP fs: $(findmnt -no FSTYPE,OPTIONS --target "$RUNNER_TEMP" || true)"
+          echo "tmp fs:         $(findmnt -no FSTYPE,OPTIONS --target /tmp || true)"
+          # The probe MUST write where the real cache lives. pr-build.yml puts it at
+          # base/.lake/cache inside the workspace; if RUNNER_TEMP were a different
+          # filesystem, probing there would test the wrong one, and a negative result
+          # would say nothing about the filesystem the failure actually occurs on.
+          ws=$(findmnt -no SOURCE --target "$PWD" || echo unknown-ws)
+          rt=$(findmnt -no SOURCE --target "$RUNNER_TEMP" || echo unknown-rt)
+          echo "workspace device=$ws  RUNNER_TEMP device=$rt"
+          [ "$ws" = "$rt" ] || echo "::warning::workspace and RUNNER_TEMP are different filesystems; probes run on the workspace one"
 
       - name: Collect artifact hashes to probe
         id: hashes
@@ -112,16 +121,17 @@ jobs:
           python3 scripts/diag/cache_fetch_probe.py \
             "$RUNNER_TEMP/diag/hashes.txt" \
             "$PUBLIC_ARTIFACT_ENDPOINT/TauCetiProject/TauCeti" \
-            "$RUNNER_TEMP/diag/outA" \
+            "$GITHUB_WORKSPACE/base/.lake/cache/probeA" \
             --iterations "${{ inputs.iterations }}"
 
       - name: Phase B — probe under disk and CPU load
         run: |
+          mkdir -p "$GITHUB_WORKSPACE/base/.lake/cache"
           # A real build writes multi-GB into this filesystem while the fetch runs and
           # saturates every core. Reproduce that pressure, then tear it down.
           for i in $(seq 1 "$(nproc)"); do
-            ( while :; do dd if=/dev/zero of="$RUNNER_TEMP/diag/load.$i" bs=1M count=256 \
-                 oflag=direct 2>/dev/null || dd if=/dev/zero of="$RUNNER_TEMP/diag/load.$i" \
+            ( while :; do dd if=/dev/zero of="$GITHUB_WORKSPACE/base/.lake/cache/load.$i" bs=1M count=256 \
+                 oflag=direct 2>/dev/null || dd if=/dev/zero of="$GITHUB_WORKSPACE/base/.lake/cache/load.$i" \
                  bs=1M count=256 2>/dev/null; sync; done ) &
             echo $! >> "$RUNNER_TEMP/diag/load.pids"
           done
@@ -131,9 +141,9 @@ jobs:
           python3 scripts/diag/cache_fetch_probe.py \
             "$RUNNER_TEMP/diag/hashes.txt" \
             "$PUBLIC_ARTIFACT_ENDPOINT/TauCetiProject/TauCeti" \
-            "$RUNNER_TEMP/diag/outB" \
+            "$GITHUB_WORKSPACE/base/.lake/cache/probeB" \
             --iterations "${{ inputs.iterations }}"
-          rm -f "$RUNNER_TEMP/diag"/load.* || true
+          rm -f "$GITHUB_WORKSPACE/base/.lake/cache"/load.* || true
 
       - name: Install elan (for phase C)
         run: |

--- a/scripts/diag/cache_fetch_probe.py
+++ b/scripts/diag/cache_fetch_probe.py
@@ -34,7 +34,29 @@ import subprocess
 import sys
 
 
-def run_once(hashes, endpoint, outdir, tag):
+def build_references(hashes, endpoint, refdir):
+    """Fetch each artifact once, sequentially, and record its SHA-256.
+
+    Needed because the probe cannot check content against the artifact's own name:
+    Lake keys artifacts by `Lake.Hash`, a UInt64 rendered as 16 hex digits, which is
+    not a SHA-256 digest, and reimplementing Lake's 64-bit mix here would just be a
+    second thing to get wrong -- a bug in it would masquerade as the corruption we are
+    hunting. A locally-fetched reference gives an equivalent check with nothing to
+    reimplement. Sequential single fetches are the least-stressed path available, and
+    the CDN is already known to serve these bytes stably (37 fetches of a failing
+    artifact returned identical content), so a later mismatch localises to the runner.
+    """
+    os.makedirs(refdir, exist_ok=True)
+    refs = {}
+    for h in hashes:
+        path = os.path.join(refdir, h + ".ref")
+        subprocess.run(["curl", "-sSfL", "-o", path, f"{endpoint}/{h}.art"], check=True)
+        with open(path, "rb") as fh:
+            refs[h] = hashlib.sha256(fh.read()).hexdigest()
+    return refs
+
+
+def run_once(hashes, endpoint, outdir, tag, refs):
     """One curl -Z batch, verifying each file the instant curl reports it done."""
     os.makedirs(outdir, exist_ok=True)
     for name in os.listdir(outdir):
@@ -52,7 +74,7 @@ def run_once(hashes, endpoint, outdir, tag):
          "-s", "-w", "%{stderr}%{json}\n", "--config", cfg],
         stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
 
-    enoent, short, clean, non200, unparsed = [], [], 0, 0, 0
+    enoent, short, corrupt, clean, non200, unparsed = [], [], [], 0, 0, 0
     for line in proc.stderr:
         line = line.strip()
         if not line:
@@ -76,13 +98,22 @@ def run_once(hashes, endpoint, outdir, tag):
             continue
         if len(data) != want:
             short.append((os.path.basename(path), len(data), want))
+            continue
+        # Length alone is NOT enough. If the trigger is page-cache or overlay
+        # incoherence, the file presents with current metadata but stale data pages, and
+        # a read across an unwritten extent returns zeros at full length. Lake would
+        # raise `downloaded artifact hash mismatch` on exactly those bytes, so a
+        # length-only check reports "clean" for the very failures being hunted.
+        digest = hashlib.sha256(data).hexdigest()
+        expected = refs.get(os.path.basename(path).removesuffix(".ltar"))
+        if expected is not None and digest != expected:
+            corrupt.append((os.path.basename(path), len(data), digest[:16], expected[:16]))
         else:
             clean += 1
-            hashlib.sha256(data).digest()   # same read-and-hash cost as Lake
 
     proc.wait()
     proc.stdout.read()
-    return {"clean": clean, "enoent": enoent, "short": short,
+    return {"clean": clean, "enoent": enoent, "short": short, "corrupt": corrupt,
             "non200": non200, "unparsed": unparsed, "rc": proc.returncode}
 
 
@@ -99,26 +130,35 @@ def main(argv):
     print(f"probing {len(hashes)} artifacts x {args.iterations} iteration(s) "
           f"= {len(hashes) * args.iterations} verifications", flush=True)
 
-    tot_enoent = tot_short = tot_clean = 0
+    refdir = os.path.join(args.outdir, os.pardir, "reference")
+    refs = build_references(hashes, args.endpoint, refdir)
+    print(f"recorded {len(refs)} reference digests", flush=True)
+
+    tot_enoent = tot_short = tot_corrupt = tot_clean = 0
     for i in range(1, args.iterations + 1):
-        r = run_once(hashes, args.endpoint, args.outdir, i)
+        r = run_once(hashes, args.endpoint, args.outdir, i, refs)
         tot_enoent += len(r["enoent"])
         tot_short += len(r["short"])
+        tot_corrupt += len(r["corrupt"])
         tot_clean += r["clean"]
         print(f"  iter {i}: clean={r['clean']} enoent={len(r['enoent'])} "
-              f"short={len(r['short'])} non200={r['non200']} "
-              f"unparsed={r['unparsed']} curl_rc={r['rc']}", flush=True)
+              f"short={len(r['short'])} corrupt={len(r['corrupt'])} "
+              f"non200={r['non200']} unparsed={r['unparsed']} curl_rc={r['rc']}",
+              flush=True)
         for name in r["enoent"]:
-            print(f"    ENOENT {name}", flush=True)
+            print(f"    ENOENT  {name}", flush=True)
         for name, got, want in r["short"]:
-            print(f"    SHORT  {name} on-disk={got} curl-reported={want}", flush=True)
+            print(f"    SHORT   {name} on-disk={got} curl-reported={want}", flush=True)
+        for name, size, got, want in r["corrupt"]:
+            print(f"    CORRUPT {name} size={size} sha256={got}... "
+                  f"reference={want}...", flush=True)
 
-    total = tot_clean + tot_enoent + tot_short
+    total = tot_clean + tot_enoent + tot_short + tot_corrupt
     print(f"\nTOTAL verifications={total} clean={tot_clean} "
-          f"enoent={tot_enoent} short={tot_short}")
-    if tot_enoent or tot_short:
-        print("REPRODUCED: curl reported a completed 200 for a file that was absent "
-              "or short at verification time.")
+          f"enoent={tot_enoent} short={tot_short} corrupt={tot_corrupt}")
+    if tot_enoent or tot_short or tot_corrupt:
+        print("REPRODUCED: curl reported a completed 200 for a file that was absent, "
+              "short, or wrong at verification time.")
     else:
         print("NOT REPRODUCED in this configuration.")
     return 0

--- a/scripts/diag/cache_fetch_probe.py
+++ b/scripts/diag/cache_fetch_probe.py
@@ -87,8 +87,16 @@ def run_once(hashes, endpoint, outdir, tag, refs):
         if rec.get("http_code") not in (200, 201):
             non200 += 1
             continue
+        # Guard the fields before using them. A missing `filename_effective` would make
+        # open("") raise FileNotFoundError and be counted as ENOENT; a missing
+        # `size_download` would default to -1 and make every file look SHORT. Both would
+        # be false POSITIVES, which for a diagnostic is as bad as a false negative -- it
+        # would send the investigation after a phantom. Count them as anomalies instead.
         path = rec.get("filename_effective") or ""
-        want = rec.get("size_download", -1)
+        want = rec.get("size_download")
+        if not path or not isinstance(want, int):
+            unparsed += 1
+            continue
         # This is the moment Lake calls computeFileHash. Do exactly that.
         try:
             with open(path, "rb") as fh:
@@ -140,13 +148,14 @@ def main(argv):
     refs = build_references(hashes, args.endpoint, refdir)
     print(f"recorded {len(refs)} reference digests", flush=True)
 
-    tot_enoent = tot_short = tot_corrupt = tot_clean = 0
+    tot_enoent = tot_short = tot_corrupt = tot_clean = tot_unparsed = 0
     for i in range(1, args.iterations + 1):
         r = run_once(hashes, args.endpoint, args.outdir, i, refs)
         tot_enoent += len(r["enoent"])
         tot_short += len(r["short"])
         tot_corrupt += len(r["corrupt"])
         tot_clean += r["clean"]
+        tot_unparsed += r["unparsed"]
         print(f"  iter {i}: clean={r['clean']} enoent={len(r['enoent'])} "
               f"short={len(r['short'])} corrupt={len(r['corrupt'])} "
               f"non200={r['non200']} unparsed={r['unparsed']} curl_rc={r['rc']}",
@@ -167,6 +176,9 @@ def main(argv):
               "short, or wrong at verification time.")
     else:
         print("NOT REPRODUCED in this configuration.")
+    if tot_unparsed:
+        print(f"NOTE: {tot_unparsed} curl record(s) were unusable (missing fields or "
+              f"unparseable JSON) and were counted as neither clean nor failing.")
     return 0
 
 

--- a/scripts/diag/cache_fetch_probe.py
+++ b/scripts/diag/cache_fetch_probe.py
@@ -127,6 +127,12 @@ def main(argv):
 
     with open(args.hashes) as fh:
         hashes = [l.strip() for l in fh if l.strip()]
+    # Defence in depth against the worst outcome for a diagnostic: reporting a clean
+    # negative having verified nothing. The caller checks this too.
+    if len(hashes) < 50:
+        print(f"ERROR: only {len(hashes)} hashes supplied; refusing to report a "
+              f"negative result from too few draws", file=sys.stderr)
+        return 2
     print(f"probing {len(hashes)} artifacts x {args.iterations} iteration(s) "
           f"= {len(hashes) * args.iterations} verifications", flush=True)
 

--- a/scripts/diag/cache_fetch_probe.py
+++ b/scripts/diag/cache_fetch_probe.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Reproduce Lake's artifact-cache verification race on a CI runner.
+
+Investigating https://github.com/TauCetiProject/TauCeti/issues/2062: roughly a third
+of merge-group builds lose the Lake artifact cache entirely and rebuild from scratch,
+costing 22 to 28 minutes instead of 3 to 6. The failing runs show one of
+
+    error: no such file or directory (error code: 4294967294)   # -2, ENOENT
+    error: <path>.ltar: downloaded artifact hash mismatch, got <other-hash>
+
+on an artifact Lake had just logged as downloaded, and the exception aborts the whole
+fetch (Lake/Config/Cache.lean's monitorTransfer verifies with computeFileHash the
+instant curl's --write-out JSON reports http_code 200, with no try/catch).
+
+This probe replicates that verification logic exactly: drive curl in parallel mode
+with a config file, consume the per-transfer JSON from stderr, and the moment a 200 is
+reported, stat and hash the named output file. A local run over 2400 draws saw zero
+failures, so the trigger is suspected to be environmental (runner filesystem,
+concurrent build I/O, core count). This runs the same test where it actually happens.
+
+Usage:
+    cache_fetch_probe.py <hashes-file> <endpoint> <outdir> [--iterations N]
+
+Reports, per iteration, how many verifications hit ENOENT, how many saw a size other
+than curl's reported size_download, and how many were clean. Exit status is always 0:
+the finding is the report, not the run's success.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import subprocess
+import sys
+
+
+def run_once(hashes, endpoint, outdir, tag):
+    """One curl -Z batch, verifying each file the instant curl reports it done."""
+    os.makedirs(outdir, exist_ok=True)
+    for name in os.listdir(outdir):
+        os.remove(os.path.join(outdir, name))
+
+    cfg = os.path.join(outdir, os.pardir, f"curl-{tag}.cfg")
+    with open(cfg, "w") as fh:
+        for h in hashes:
+            fh.write(f'url = "{endpoint}/{h}.art"\n')
+            fh.write(f'-o "{os.path.join(outdir, h + ".ltar")}"\n')
+
+    # Mirrors Lake's own invocation: -Z (parallel), --retry 3, JSON to stderr.
+    proc = subprocess.Popen(
+        ["curl", "-Z", "-X", "GET", "-L", "--retry", "3",
+         "-s", "-w", "%{stderr}%{json}\n", "--config", cfg],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, bufsize=1)
+
+    enoent, short, clean, non200, unparsed = [], [], 0, 0, 0
+    for line in proc.stderr:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            unparsed += 1
+            continue
+        if rec.get("http_code") not in (200, 201):
+            non200 += 1
+            continue
+        path = rec.get("filename_effective") or ""
+        want = rec.get("size_download", -1)
+        # This is the moment Lake calls computeFileHash. Do exactly that.
+        try:
+            with open(path, "rb") as fh:
+                data = fh.read()
+        except FileNotFoundError:
+            enoent.append(os.path.basename(path))
+            continue
+        if len(data) != want:
+            short.append((os.path.basename(path), len(data), want))
+        else:
+            clean += 1
+            hashlib.sha256(data).digest()   # same read-and-hash cost as Lake
+
+    proc.wait()
+    proc.stdout.read()
+    return {"clean": clean, "enoent": enoent, "short": short,
+            "non200": non200, "unparsed": unparsed, "rc": proc.returncode}
+
+
+def main(argv):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("hashes")
+    ap.add_argument("endpoint")
+    ap.add_argument("outdir")
+    ap.add_argument("--iterations", type=int, default=1)
+    args = ap.parse_args(argv[1:])
+
+    with open(args.hashes) as fh:
+        hashes = [l.strip() for l in fh if l.strip()]
+    print(f"probing {len(hashes)} artifacts x {args.iterations} iteration(s) "
+          f"= {len(hashes) * args.iterations} verifications", flush=True)
+
+    tot_enoent = tot_short = tot_clean = 0
+    for i in range(1, args.iterations + 1):
+        r = run_once(hashes, args.endpoint, args.outdir, i)
+        tot_enoent += len(r["enoent"])
+        tot_short += len(r["short"])
+        tot_clean += r["clean"]
+        print(f"  iter {i}: clean={r['clean']} enoent={len(r['enoent'])} "
+              f"short={len(r['short'])} non200={r['non200']} "
+              f"unparsed={r['unparsed']} curl_rc={r['rc']}", flush=True)
+        for name in r["enoent"]:
+            print(f"    ENOENT {name}", flush=True)
+        for name, got, want in r["short"]:
+            print(f"    SHORT  {name} on-disk={got} curl-reported={want}", flush=True)
+
+    total = tot_clean + tot_enoent + tot_short
+    print(f"\nTOTAL verifications={total} clean={tot_clean} "
+          f"enoent={tot_enoent} short={tot_short}")
+    if tot_enoent or tot_short:
+        print("REPRODUCED: curl reported a completed 200 for a file that was absent "
+              "or short at verification time.")
+    else:
+        print("NOT REPRODUCED in this configuration.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
This PR adds a dispatch-only workflow that reproduces the Lake artifact-cache fetch failure on a runner, so the trigger can be identified rather than inferred.

Roughly a third of merge-group builds lose the artifact cache entirely and rebuild from scratch, taking 22 to 28 minutes instead of 3 to 6. That is 339 wasted minutes in a 10-hour window, and it holds throughput below demand. Details and measurements in https://github.com/TauCetiProject/TauCeti/issues/2062.

`Lake/Config/Cache.lean`'s `monitorTransfer` verifies each artifact with `computeFileHash` the moment curl's `--write-out` JSON reports `http_code: 200`, and there is no `try`/`catch`, so one unreadable file raises out of `transferArtifacts` and aborts the entire fetch. An absent file gives `no such file or directory (error code: 4294967294)` and a partially written one gives `downloaded artifact hash mismatch`; both appear in the failing logs, always on the last artifact logged, once per attempt.

Already ruled out: the CDN (37 fetches of a failing artifact returned identical bytes), missing uploads (every ENOENT artifact is present), artifact identity (a different one fails each attempt), duplicate requests, disk space, and leantar. Replicating the verification logic locally over 2400 draws produced zero failures, which is why an in-CI probe is needed: the trigger appears to be environmental.

Three phases. Phase A runs the probe alone for a per-runner baseline. Phase B repeats it under synthetic disk and CPU load, since a real build writes multi-GB into the same filesystem while the fetch runs and saturates every core. Phase C runs a real `lake cache get` repeatedly as ground truth, reporting ENOENT and hash-mismatch counts per attempt with surrounding context.

Read-only permissions, no secrets, anonymous GETs against the public read endpoint, and no trigger other than `workflow_dispatch`, so it cannot affect normal CI. It needs to be on the default branch before it can be dispatched at all.

Temporary: delete once #2062 is resolved.

🤖 Prepared with Claude Code