### PR TITLE
feat: the arccosine description of a cosine superlevel set

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean
@@ -7,6 +7,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.Basic
 import Mathlib.Geometry.Euclidean.Basic
+import TauCeti.Analysis.SpecialFunctions.Trigonometric.Arccos
 import TauCeti.Topology.Circle.Metric
 
 /-!
@@ -45,11 +46,18 @@ with its closure; they do not assert the continuous boundary extension itself.
 * `TauCeti.isPreconnected_ball_inter_sphere_inter_ball` — a ball centred at a point of the closed
   crosscut meets the crosscut in a subarc: a crosscut spans less than a half turn, so along it the
   chord distance to a fixed one of its points falls and then rises, and the angles it keeps below a
-  threshold form an interval. The chord length itself is measured by
-  `TauCeti.dist_circleMap_eq_two_mul_abs_sin`, in `TauCeti/Topology/Circle/Metric.lean`. This is the
+  threshold form an interval. That last step is
+  `TauCeti.ordConnected_inter_setOf_dist_circleMap_lt` and the chord length it runs on is measured
+  by `TauCeti.dist_circleMap_eq_two_mul_abs_sin`; both live in
+  `TauCeti/Topology/Circle/Metric.lean`, since neither mentions the disc. This is the
   local connectedness of a crosscut at its own endpoints,
   which `Conformal/Crosscut/Image.lean` spends to make the cluster set of a conformal map at an end
   of an image crosscut a continuum.
+
+The half-width `arccos (ρ / (2 * r))` is read off the cosine criterion of
+`TauCeti/Topology/Circle/Metric.lean` through `Real.lt_cos_iff_mem_Ioo` and
+`Real.le_cos_iff_mem_Icc`, the arccosine description of the angles at which the cosine exceeds a
+threshold, in `TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean`.
 
 ## Coordination with upstream Mathlib
 
@@ -75,40 +83,6 @@ open scoped Real
 variable {c ζ : ℂ} {r ρ : ℝ}
 
 /-! ## Metric and angular descriptions -/
-
-/-- **A ball centred at a point of an arc of angular width at most `π` meets it in an arc.** The
-chord distance to a fixed angle `θ₀` of the arc falls and then rises as the angle sweeps across the
-arc, so the angles it keeps below a threshold form an interval. -/
-private lemma ordConnected_Ioo_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : ℝ) {a b θ₀ δ : ℝ}
-    (hab : b - a ≤ π) (h₀ : θ₀ ∈ Icc a b) :
-    (Ioo a b ∩ {θ | dist (circleMap ζ ρ θ) (circleMap ζ ρ θ₀) < δ}).OrdConnected := by
-  have hdist : ∀ u ∈ Icc a b, dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀)
-      = 2 * |ρ| * Real.sin (|u - θ₀| / 2) := by
-    intro u hu
-    refine dist_circleMap_eq_two_mul_sin_abs ζ ρ ?_
-    rw [abs_le]
-    constructor <;> [linarith [hu.1, h₀.2, Real.pi_pos]; linarith [hu.2, h₀.1, Real.pi_pos]]
-  have hmono : ∀ u ∈ Icc a b, ∀ v ∈ Icc a b, |u - θ₀| ≤ |v - θ₀| →
-      dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀) ≤ dist (circleMap ζ ρ v) (circleMap ζ ρ θ₀) := by
-    intro u hu v hv huv
-    rw [hdist u hu, hdist v hv]
-    have hvπ : |v - θ₀| ≤ π := by
-      rw [abs_le]
-      constructor <;> [linarith [hv.1, h₀.2]; linarith [hv.2, h₀.1]]
-    have hsin : Real.sin (|u - θ₀| / 2) ≤ Real.sin (|v - θ₀| / 2) :=
-      Real.sin_le_sin_of_le_of_le_pi_div_two
-        (by linarith [abs_nonneg (u - θ₀), Real.pi_pos]) (by linarith) (by linarith)
-    exact mul_le_mul_of_nonneg_left hsin (by positivity)
-  refine ⟨fun x hx y hy z hz => ⟨(ordConnected_Ioo (a := a) (b := b)).out hx.1 hy.1 hz, ?_⟩⟩
-  have hzIcc : z ∈ Icc a b :=
-    Ioo_subset_Icc_self ((ordConnected_Ioo (a := a) (b := b)).out hx.1 hy.1 hz)
-  rcases le_total z θ₀ with hzθ | hzθ
-  · refine lt_of_le_of_lt (hmono z hzIcc x (Ioo_subset_Icc_self hx.1) ?_) hx.2
-    rw [abs_of_nonpos (by linarith), abs_of_nonpos (by linarith [hz.1])]
-    linarith [hz.1]
-  · refine lt_of_le_of_lt (hmono z hzIcc y (Ioo_subset_Icc_self hy.1) ?_) hy.2
-    rw [abs_of_nonneg (by linarith), abs_of_nonneg (by linarith [hz.2])]
-    linarith [hz.2]
 
 /-- A point of `sphere ζ ρ`, in angular coordinates, lies in `closedBall c r` exactly when its
 angle satisfies the weak cosine inequality complementary to
@@ -149,41 +123,6 @@ theorem dist_circleMap_eq_iff (hζ : dist ζ c = r) (hρ : 0 < ρ) (θ : ℝ) :
 
 /-! ## The open and closed arcs -/
 
-/-- On the principal period, comparison with the cosine of an arccosine is equivalent to lying
-strictly between the two symmetric angles. -/
-private theorem div_lt_cos_iff_mem_Ioo {x t : ℝ} (hx0 : 0 < x) (hx1 : x < 1)
-    (ht : t ∈ Icc (-π) π) :
-    x < Real.cos t ↔ t ∈ Ioo (-Real.arccos x) (Real.arccos x) := by
-  have hφ0 : 0 < Real.arccos x := Real.arccos_pos.mpr hx1
-  have hφπ : Real.arccos x < π := Real.arccos_lt_pi.mpr (by linarith)
-  have hat : |t| ∈ Icc (0 : ℝ) π := ⟨abs_nonneg _, (abs_le.mpr ht).trans' le_rfl⟩
-  have hφ : Real.arccos x ∈ Icc (0 : ℝ) π := ⟨hφ0.le, hφπ.le⟩
-  have hcos : Real.cos (Real.arccos x) = x := Real.cos_arccos (by linarith) hx1.le
-  constructor
-  · intro h
-    have h' : Real.cos (Real.arccos x) < Real.cos |t| := by simpa [hcos, Real.cos_abs] using h
-    exact abs_lt.mp ((Real.strictAntiOn_cos.lt_iff_gt hφ hat).mp h')
-  · intro h
-    have h' := (Real.strictAntiOn_cos.lt_iff_gt hφ hat).mpr (abs_lt.mpr h)
-    simpa [hcos, Real.cos_abs] using h'
-
-/-- The weak companion of `div_lt_cos_iff_mem_Ioo`. -/
-private theorem div_le_cos_iff_mem_Icc {x t : ℝ} (hx0 : 0 < x) (hx1 : x < 1)
-    (ht : t ∈ Icc (-π) π) :
-    x ≤ Real.cos t ↔ t ∈ Icc (-Real.arccos x) (Real.arccos x) := by
-  have hφ0 : 0 < Real.arccos x := Real.arccos_pos.mpr hx1
-  have hφπ : Real.arccos x < π := Real.arccos_lt_pi.mpr (by linarith)
-  have hat : |t| ∈ Icc (0 : ℝ) π := ⟨abs_nonneg _, (abs_le.mpr ht).trans' le_rfl⟩
-  have hφ : Real.arccos x ∈ Icc (0 : ℝ) π := ⟨hφ0.le, hφπ.le⟩
-  have hcos : Real.cos (Real.arccos x) = x := Real.cos_arccos (by linarith) hx1.le
-  constructor
-  · intro h
-    have h' : Real.cos (Real.arccos x) ≤ Real.cos |t| := by simpa [hcos, Real.cos_abs] using h
-    exact abs_le.mp ((Real.strictAntiOn_cos.le_iff_ge hφ hat).mp h')
-  · intro h
-    have h' := (Real.strictAntiOn_cos.le_iff_ge hφ hat).mpr (abs_le.mpr h)
-    simpa [hcos, Real.cos_abs] using h'
-
 /-- A genuine circular crosscut is exactly one open angular arc. -/
 theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 < ρ)
     (hρr : ρ < 2 * r) :
@@ -193,7 +132,6 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
         ((c - ζ).arg + Real.arccos (ρ / (2 * r))) := by
   have hr : 0 < r := by linarith
   have hx0 : 0 < ρ / (2 * r) := div_pos hρ (by positivity)
-  have hx1 : ρ / (2 * r) < 1 := (div_lt_one (by positivity)).mpr hρr
   ext z
   constructor
   · rintro ⟨hzball, hzsphere⟩
@@ -202,7 +140,7 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
     have hcos : ρ / (2 * r) < Real.cos t := by
       rw [div_lt_iff₀ (by positivity)]
       simpa only [add_sub_cancel_left, mul_comm] using hzball
-    have ht' := (div_lt_cos_iff_mem_Ioo hx0 hx1 ht).mp hcos
+    have ht' := (Real.lt_cos_iff_mem_Ioo (by linarith) ht).mp hcos
     exact ⟨(c - ζ).arg + t, by constructor <;> linarith [ht'.1, ht'.2], rfl⟩
   · rintro ⟨θ, hθ, rfl⟩
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
@@ -210,7 +148,7 @@ theorem ball_inter_sphere_eq_circleMap_image_Ioo (hζ : dist ζ c = r) (hρ : 0 
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
       have hφπ := Real.arccos_lt_pi.mpr (by linarith : -1 < ρ / (2 * r))
       constructor <;> linarith [hθ.1, hθ.2]
-    have hcos := (div_lt_cos_iff_mem_Ioo hx0 hx1 ht).mpr
+    have hcos := (Real.lt_cos_iff_mem_Ioo (by linarith) ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_lt_iff₀ (by positivity)).mp hcos)
 
@@ -234,7 +172,7 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
     have hcos : ρ / (2 * r) ≤ Real.cos t := by
       rw [div_le_iff₀ (by positivity)]
       simpa only [add_sub_cancel_left, mul_comm] using hzball
-    have ht' := (div_le_cos_iff_mem_Icc hx0 hx1 ht).mp hcos
+    have ht' := (Real.le_cos_iff_mem_Icc hx1.le ht).mp hcos
     exact ⟨(c - ζ).arg + t, by constructor <;> linarith [ht'.1, ht'.2], rfl⟩
   · rintro ⟨θ, hθ, rfl⟩
     refine ⟨?_, circleMap_mem_sphere ζ hρ.le θ⟩
@@ -242,7 +180,7 @@ theorem closedBall_inter_sphere_eq_circleMap_image_Icc (hζ : dist ζ c = r) (h�
     have ht : θ - (c - ζ).arg ∈ Icc (-π) π := by
       have hφπ := Real.arccos_lt_pi.mpr (by linarith : -1 < ρ / (2 * r))
       constructor <;> linarith [hθ.1, hθ.2]
-    have hcos := (div_le_cos_iff_mem_Icc hx0 hx1 ht).mpr
+    have hcos := (Real.le_cos_iff_mem_Icc hx1.le ht).mpr
       ⟨by linarith [hθ.1], by linarith [hθ.2]⟩
     simpa only [mul_comm] using ((div_le_iff₀ (by positivity)).mp hcos)
 
@@ -392,6 +330,8 @@ theorem isPreconnected_ball_inter_sphere_inter_ball (hζ : dist ζ c = r) (hρ :
     ext θ
     simp [Metric.mem_ball]
   rw [hpre]
-  exact (ordConnected_Ioo_inter_setOf_dist_circleMap_lt ζ ρ (by linarith) hθ₀).isPreconnected
+  refine (ordConnected_inter_setOf_dist_circleMap_lt ζ ρ ordConnected_Ioo ?_).isPreconnected
+  rintro u ⟨hu1, hu2⟩
+  exact ⟨by linarith [hθ₀.2], by linarith [hθ₀.1]⟩
 
 end TauCeti

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
@@ -24,10 +24,13 @@ sets of `Real.cos` on one period. Since `arccos` is antitone, the comparisons sw
 ## Main results
 
 * `Real.arccos_le_iff_cos_le`, `Real.le_arccos_iff_le_cos`, `Real.arccos_lt_iff_cos_lt` and
-  `Real.lt_arccos_iff_lt_cos` — the four comparisons, for an angle `y` in `[0, π]`. Nothing at all
-  is assumed of `x`: as with Mathlib's primed `arcsin` lemmas, the degenerate values `x < -1` and
-  `1 < x`, where `arccos` is constant, are covered by excluding the one endpoint of `[0, π]` at
-  which the comparison would fail.
+  `Real.lt_arccos_iff_lt_cos` — the four comparisons on the closed domain, for `x` in `[-1, 1]` and
+  an angle `y` in `[0, π]`.
+* `Real.arccos_le_iff_cos_le'`, `Real.le_arccos_iff_le_cos'`, `Real.arccos_lt_iff_cos_lt'` and
+  `Real.lt_arccos_iff_lt_cos'` — the same four with nothing at all assumed of `x`. Exactly as for
+  Mathlib's primed `arcsin` lemmas, the degenerate values `x < -1` and `1 < x`, where `arccos` is
+  constant, are covered at the price of excluding the one endpoint of `[0, π]` at which the
+  comparison would then fail.
 * `Real.abs_lt_arccos_iff_lt_cos` and `Real.abs_le_arccos_iff_le_cos` — since `cos` is even, an
   angle `t` of the full period `[-π, π]` may be compared through `|t|`; here the excluded endpoint
   is paid for by a one-sided bound on `x` instead.
@@ -40,10 +43,12 @@ sets of `Real.cos` on one period. Since `arccos` is antitone, the comparisons sw
 
 ## The argument
 
-Everything is `Real.arccos_eq_pi_div_two_sub_arcsin` fed into Mathlib's `arcsin` family, followed by
-`Real.sin_pi_div_two_sub`; the four comparisons come in two proofs and two negations, exactly as the
-`arcsin` family does. The `|t|` forms then split off the single degenerate angle that the
-half-period statement does not reach, and the interval forms are `abs_lt` and `abs_le`.
+The closed-domain family is `Real.arccos_eq_pi_div_two_sub_arcsin` fed into Mathlib's `arcsin`
+family, followed by `Real.sin_pi_div_two_sub`; each primed form is then its unprimed form together
+with the two degenerate ranges of `x`, and the strict comparisons are negations of the weak ones —
+exactly the shape, and the same order of derivation, that the `arcsin` family has. The `|t|` forms
+split off the single degenerate angle that the half-period statement does not reach, and the
+interval forms are `abs_lt` and `abs_le`.
 
 This is general real analysis, extracted from two places that had proved fragments of it privately:
 `TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean`, which described a circular crosscut of
@@ -62,41 +67,90 @@ open Set
 
 open scoped Real
 
-/-- **An arccosine is at most an angle exactly when the angle's cosine is at most the value.** The
-`Real.arccos` counterpart of Mathlib's `Real.le_arcsin_iff_sin_le'`, with the sides swapped because
-`Real.arccos` is antitone.
-
-The angle `y` is excluded from `π`, and in exchange nothing is assumed of `x`. At `y = π` the left
-side is automatic and the right side, `-1 ≤ x`, is not; at the other endpoint `y = 0` the statement
-is `Real.arccos_eq_zero`. -/
-theorem _root_.Real.arccos_le_iff_cos_le {x y : ℝ} (hy : y ∈ Ico 0 π) :
+/-- **An arccosine is at most an angle exactly when the angle's cosine is at most the value.** For
+`x ∈ [-1, 1]` and an angle `y ∈ [0, π]`, the two intervals on which `Real.arccos` and `Real.cos` are
+mutually inverse, `arccos x ≤ y ↔ cos y ≤ x`. The `Real.arccos` counterpart of Mathlib's
+`Real.le_arcsin_iff_sin_le`, with the sides swapped because `Real.arccos` is antitone. -/
+theorem _root_.Real.arccos_le_iff_cos_le {x y : ℝ} (hx : x ∈ Icc (-1 : ℝ) 1) (hy : y ∈ Icc 0 π) :
     Real.arccos x ≤ y ↔ Real.cos y ≤ x := by
   rw [Real.arccos_eq_pi_div_two_sub_arcsin, sub_le_comm,
-    Real.le_arcsin_iff_sin_le' ⟨by linarith [hy.2], by linarith [hy.1]⟩, Real.sin_pi_div_two_sub]
+    Real.le_arcsin_iff_sin_le ⟨by linarith [hy.2], by linarith [hy.1]⟩ hx, Real.sin_pi_div_two_sub]
 
-/-- **An angle is at most an arccosine exactly when the value is at most the angle's cosine.** The
-`Real.arccos` counterpart of Mathlib's `Real.arcsin_le_iff_le_sin'`.
+/-- **An arccosine is at most an angle exactly when the angle's cosine is at most the value**, with
+nothing assumed of `x`. The `Real.arccos` counterpart of Mathlib's `Real.le_arcsin_iff_sin_le'`.
 
-The angle `y` is excluded from `0`, and in exchange nothing is assumed of `x`. At `y = 0` the left
-side is automatic and the right side, `x ≤ 1`, is not; at the other endpoint `y = π` the statement
-is `Real.arccos_eq_pi`. -/
-theorem _root_.Real.le_arccos_iff_le_cos {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+The angle `y` is excluded from `π`, and in exchange the bounds on `x` are dropped: for `x < -1` and
+for `1 < x`, where `Real.arccos` is constant, both sides then agree. At `y = π` the left side is
+automatic while the right side, `-1 ≤ x`, is not; at the other endpoint `y = 0` the statement is
+`Real.arccos_eq_zero`. -/
+theorem _root_.Real.arccos_le_iff_cos_le' {x y : ℝ} (hy : y ∈ Ico 0 π) :
+    Real.arccos x ≤ y ↔ Real.cos y ≤ x := by
+  rcases le_total x (-1) with hx₁ | hx₁
+  · have hcos : Real.cos π < Real.cos y :=
+      Real.cos_lt_cos_of_nonneg_of_le_pi hy.1 le_rfl hy.2
+    rw [Real.cos_pi] at hcos
+    exact iff_of_false (by rw [Real.arccos_of_le_neg_one hx₁]; exact not_le.mpr hy.2)
+      (not_le.mpr (by linarith))
+  rcases le_total 1 x with hx₂ | hx₂
+  · exact iff_of_true (by rw [Real.arccos_of_one_le hx₂]; exact hy.1)
+      ((Real.cos_le_one y).trans hx₂)
+  exact Real.arccos_le_iff_cos_le ⟨hx₁, hx₂⟩ (mem_Icc_of_Ico hy)
+
+/-- **An angle is at most an arccosine exactly when the value is at most the angle's cosine.** For
+`x ∈ [-1, 1]` and an angle `y ∈ [0, π]`, `y ≤ arccos x ↔ x ≤ cos y`. The `Real.arccos` counterpart
+of Mathlib's `Real.arcsin_le_iff_le_sin`. -/
+theorem _root_.Real.le_arccos_iff_le_cos {x y : ℝ} (hx : x ∈ Icc (-1 : ℝ) 1) (hy : y ∈ Icc 0 π) :
     y ≤ Real.arccos x ↔ x ≤ Real.cos y := by
   rw [Real.arccos_eq_pi_div_two_sub_arcsin, le_sub_comm,
-    Real.arcsin_le_iff_le_sin' ⟨by linarith [hy.2], by linarith [hy.1]⟩, Real.sin_pi_div_two_sub]
+    Real.arcsin_le_iff_le_sin hx ⟨by linarith [hy.2], by linarith [hy.1]⟩, Real.sin_pi_div_two_sub]
 
-/-- The strict companion of `Real.le_arccos_iff_le_cos`, by negation. -/
-theorem _root_.Real.arccos_lt_iff_cos_lt {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+/-- **An angle is at most an arccosine exactly when the value is at most the angle's cosine**, with
+nothing assumed of `x`. The `Real.arccos` counterpart of Mathlib's `Real.arcsin_le_iff_le_sin'`.
+
+The angle `y` is excluded from `0`, and in exchange the bounds on `x` are dropped. At `y = 0` the
+left side is automatic while the right side, `x ≤ 1`, is not; at the other endpoint `y = π` the
+statement is `Real.arccos_eq_pi`. -/
+theorem _root_.Real.le_arccos_iff_le_cos' {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+    y ≤ Real.arccos x ↔ x ≤ Real.cos y := by
+  rcases le_total x (-1) with hx₁ | hx₁
+  · exact iff_of_true (by rw [Real.arccos_of_le_neg_one hx₁]; exact hy.2)
+      (hx₁.trans (Real.neg_one_le_cos y))
+  rcases le_total 1 x with hx₂ | hx₂
+  · have hcos : Real.cos y < Real.cos 0 :=
+      Real.cos_lt_cos_of_nonneg_of_le_pi le_rfl hy.2 hy.1
+    rw [Real.cos_zero] at hcos
+    exact iff_of_false (by rw [Real.arccos_of_one_le hx₂]; exact not_le.mpr hy.1)
+      (not_le.mpr (by linarith))
+  exact Real.le_arccos_iff_le_cos ⟨hx₁, hx₂⟩ (mem_Icc_of_Ioc hy)
+
+/-- **An arccosine is below an angle exactly when the angle's cosine is below the value.** The
+strict form of `Real.arccos_le_iff_cos_le`, for `x ∈ [-1, 1]` and an angle `y ∈ [0, π]`. -/
+theorem _root_.Real.arccos_lt_iff_cos_lt {x y : ℝ} (hx : x ∈ Icc (-1 : ℝ) 1) (hy : y ∈ Icc 0 π) :
     Real.arccos x < y ↔ Real.cos y < x :=
-  not_le.symm.trans <| (not_congr (Real.le_arccos_iff_le_cos hy)).trans not_le
+  not_le.symm.trans <| (not_congr (Real.le_arccos_iff_le_cos hx hy)).trans not_le
 
-/-- The strict companion of `Real.arccos_le_iff_cos_le`, by negation. -/
-theorem _root_.Real.lt_arccos_iff_lt_cos {x y : ℝ} (hy : y ∈ Ico 0 π) :
+/-- **An arccosine is below an angle exactly when the angle's cosine is below the value**, with
+nothing assumed of `x`. The strict form of `Real.arccos_le_iff_cos_le'`; as in
+`Real.le_arccos_iff_le_cos'`, whose negation it is, the angle `y` runs over `Ioc 0 π`. -/
+theorem _root_.Real.arccos_lt_iff_cos_lt' {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+    Real.arccos x < y ↔ Real.cos y < x :=
+  not_le.symm.trans <| (not_congr (Real.le_arccos_iff_le_cos' hy)).trans not_le
+
+/-- **An angle is below an arccosine exactly when the value is below the angle's cosine.** The
+strict form of `Real.le_arccos_iff_le_cos`, for `x ∈ [-1, 1]` and an angle `y ∈ [0, π]`. -/
+theorem _root_.Real.lt_arccos_iff_lt_cos {x y : ℝ} (hx : x ∈ Icc (-1 : ℝ) 1) (hy : y ∈ Icc 0 π) :
     y < Real.arccos x ↔ x < Real.cos y :=
-  not_le.symm.trans <| (not_congr (Real.arccos_le_iff_cos_le hy)).trans not_le
+  not_le.symm.trans <| (not_congr (Real.arccos_le_iff_cos_le hx hy)).trans not_le
+
+/-- **An angle is below an arccosine exactly when the value is below the angle's cosine**, with
+nothing assumed of `x`. The strict form of `Real.le_arccos_iff_le_cos'`; as in
+`Real.arccos_le_iff_cos_le'`, whose negation it is, the angle `y` runs over `Ico 0 π`. -/
+theorem _root_.Real.lt_arccos_iff_lt_cos' {x y : ℝ} (hy : y ∈ Ico 0 π) :
+    y < Real.arccos x ↔ x < Real.cos y :=
+  not_le.symm.trans <| (not_congr (Real.arccos_le_iff_cos_le' hy)).trans not_le
 
 /-- **On a full period, a strict lower bound on the cosine is a strict upper bound on the angle.**
-Because `Real.cos` is even, `Real.lt_arccos_iff_lt_cos` extends from `[0, π]` to `[-π, π]` read
+Because `Real.cos` is even, `Real.lt_arccos_iff_lt_cos'` extends from `[0, π]` to `[-π, π]` read
 through `|t|`. The angle is now allowed to reach `π`, at the cost of the hypothesis `-1 ≤ x`, which
 is what makes the two sides agree there: both are false. -/
 theorem _root_.Real.abs_lt_arccos_iff_lt_cos {x t : ℝ} (hx : -1 ≤ x) (ht : |t| ≤ π) :
@@ -109,7 +163,7 @@ theorem _root_.Real.abs_lt_arccos_iff_lt_cos {x t : ℝ} (hx : -1 ≤ x) (ht : |
     · rw [hcos]
       exact not_lt.mpr hx
   · rw [← Real.cos_abs t]
-    exact Real.lt_arccos_iff_lt_cos ⟨abs_nonneg t, hπ⟩
+    exact Real.lt_arccos_iff_lt_cos' ⟨abs_nonneg t, hπ⟩
 
 /-- **On a full period, a lower bound on the cosine is an upper bound on the angle.** The weak
 companion of `Real.abs_lt_arccos_iff_lt_cos`; here it is the angle `0` that the half-period
@@ -122,7 +176,7 @@ theorem _root_.Real.abs_le_arccos_iff_le_cos {x t : ℝ} (hx : x ≤ 1) (ht : |t
     rw [abs_zero, Real.cos_zero]
     exact iff_of_true (Real.arccos_nonneg x) hx
   · rw [← Real.cos_abs t]
-    exact Real.le_arccos_iff_le_cos ⟨h0, ht⟩
+    exact Real.le_arccos_iff_le_cos' ⟨h0, ht⟩
 
 /-- **The cosine exceeds a threshold on a symmetric interval.** On the period `[-π, π]` the angles
 at which `Real.cos` exceeds `x` are exactly those of `(-arccos x, arccos x)`. -/

--- a/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Trigonometric.Inverse
+
+/-!
+# Comparing an angle with an arccosine
+
+Mathlib's `Analysis/SpecialFunctions/Trigonometric/Inverse.lean` carries a complete comparison
+family for `Real.arcsin` — `Real.arcsin_le_iff_le_sin`, `Real.le_arcsin_iff_sin_le`,
+`Real.arcsin_lt_iff_lt_sin`, `Real.lt_arcsin_iff_sin_lt` and their primed variants — turning an
+inequality between an angle and an `arcsin` into one between a real number and a `sin`. It carries
+no counterpart for `Real.arccos`: the pinned Mathlib knows `Real.arccos_le_arccos`,
+`Real.arccos_lt_arccos` and `Real.cos_arccos`, but nothing that compares an *angle* with an
+arccosine.
+
+This file supplies that family, and reads it off as a description of the sublevel and superlevel
+sets of `Real.cos` on one period. Since `arccos` is antitone, the comparisons swap sides:
+`arccos x ≤ y ↔ cos y ≤ x` where the `arcsin` family has `arcsin x ≤ y ↔ x ≤ sin y`.
+
+## Main results
+
+* `Real.arccos_le_iff_cos_le`, `Real.le_arccos_iff_le_cos`, `Real.arccos_lt_iff_cos_lt` and
+  `Real.lt_arccos_iff_lt_cos` — the four comparisons, for an angle `y` in `[0, π]`. Nothing at all
+  is assumed of `x`: as with Mathlib's primed `arcsin` lemmas, the degenerate values `x < -1` and
+  `1 < x`, where `arccos` is constant, are covered by excluding the one endpoint of `[0, π]` at
+  which the comparison would fail.
+* `Real.abs_lt_arccos_iff_lt_cos` and `Real.abs_le_arccos_iff_le_cos` — since `cos` is even, an
+  angle `t` of the full period `[-π, π]` may be compared through `|t|`; here the excluded endpoint
+  is paid for by a one-sided bound on `x` instead.
+* `Real.lt_cos_iff_mem_Ioo` and `Real.le_cos_iff_mem_Icc` — the same statements read as
+  `{t ∈ [-π, π] | x < cos t} = (-arccos x, arccos x)` and its closed companion: on one period
+  centred at `0`, the angles at which `cos` exceeds a threshold form the symmetric interval of
+  half-width `arccos x`.
+* `Real.lt_cos_of_mem_Icc` — the unimodality corollary: `cos` has no interior minimum on `[-π, π]`,
+  so a strict lower bound holding at both ends of a subinterval holds throughout it.
+
+## The argument
+
+Everything is `Real.arccos_eq_pi_div_two_sub_arcsin` fed into Mathlib's `arcsin` family, followed by
+`Real.sin_pi_div_two_sub`; the four comparisons come in two proofs and two negations, exactly as the
+`arcsin` family does. The `|t|` forms then split off the single degenerate angle that the
+half-period statement does not reach, and the interval forms are `abs_lt` and `abs_le`.
+
+This is general real analysis, extracted from two places that had proved fragments of it privately:
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean`, which described a circular crosscut of
+a disc as an angular arc of half-width `arccos (ρ / (2 * r))`, and
+`TauCeti/Topology/Circle/Metric.lean`, which needed the unimodality corollary to see that a circle
+meets a disc in a connected set of angles. Both belong to layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of the Carathéodory boundary
+correspondence, but neither statement mentions a holomorphic map, a disc, or even the plane.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set
+
+open scoped Real
+
+/-- **An arccosine is at most an angle exactly when the angle's cosine is at most the value.** The
+`Real.arccos` counterpart of Mathlib's `Real.le_arcsin_iff_sin_le'`, with the sides swapped because
+`Real.arccos` is antitone.
+
+The angle `y` is excluded from `π`, and in exchange nothing is assumed of `x`. At `y = π` the left
+side is automatic and the right side, `-1 ≤ x`, is not; at the other endpoint `y = 0` the statement
+is `Real.arccos_eq_zero`. -/
+theorem _root_.Real.arccos_le_iff_cos_le {x y : ℝ} (hy : y ∈ Ico 0 π) :
+    Real.arccos x ≤ y ↔ Real.cos y ≤ x := by
+  rw [Real.arccos_eq_pi_div_two_sub_arcsin, sub_le_comm,
+    Real.le_arcsin_iff_sin_le' ⟨by linarith [hy.2], by linarith [hy.1]⟩, Real.sin_pi_div_two_sub]
+
+/-- **An angle is at most an arccosine exactly when the value is at most the angle's cosine.** The
+`Real.arccos` counterpart of Mathlib's `Real.arcsin_le_iff_le_sin'`.
+
+The angle `y` is excluded from `0`, and in exchange nothing is assumed of `x`. At `y = 0` the left
+side is automatic and the right side, `x ≤ 1`, is not; at the other endpoint `y = π` the statement
+is `Real.arccos_eq_pi`. -/
+theorem _root_.Real.le_arccos_iff_le_cos {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+    y ≤ Real.arccos x ↔ x ≤ Real.cos y := by
+  rw [Real.arccos_eq_pi_div_two_sub_arcsin, le_sub_comm,
+    Real.arcsin_le_iff_le_sin' ⟨by linarith [hy.2], by linarith [hy.1]⟩, Real.sin_pi_div_two_sub]
+
+/-- The strict companion of `Real.le_arccos_iff_le_cos`, by negation. -/
+theorem _root_.Real.arccos_lt_iff_cos_lt {x y : ℝ} (hy : y ∈ Ioc 0 π) :
+    Real.arccos x < y ↔ Real.cos y < x :=
+  not_le.symm.trans <| (not_congr (Real.le_arccos_iff_le_cos hy)).trans not_le
+
+/-- The strict companion of `Real.arccos_le_iff_cos_le`, by negation. -/
+theorem _root_.Real.lt_arccos_iff_lt_cos {x y : ℝ} (hy : y ∈ Ico 0 π) :
+    y < Real.arccos x ↔ x < Real.cos y :=
+  not_le.symm.trans <| (not_congr (Real.arccos_le_iff_cos_le hy)).trans not_le
+
+/-- **On a full period, a strict lower bound on the cosine is a strict upper bound on the angle.**
+Because `Real.cos` is even, `Real.lt_arccos_iff_lt_cos` extends from `[0, π]` to `[-π, π]` read
+through `|t|`. The angle is now allowed to reach `π`, at the cost of the hypothesis `-1 ≤ x`, which
+is what makes the two sides agree there: both are false. -/
+theorem _root_.Real.abs_lt_arccos_iff_lt_cos {x t : ℝ} (hx : -1 ≤ x) (ht : |t| ≤ π) :
+    |t| < Real.arccos x ↔ x < Real.cos t := by
+  rcases eq_or_lt_of_le ht with hπ | hπ
+  · have hcos : Real.cos t = -1 := by rw [← Real.cos_abs, hπ, Real.cos_pi]
+    refine iff_of_false ?_ ?_
+    · rw [hπ]
+      exact not_lt.mpr (Real.arccos_le_pi x)
+    · rw [hcos]
+      exact not_lt.mpr hx
+  · rw [← Real.cos_abs t]
+    exact Real.lt_arccos_iff_lt_cos ⟨abs_nonneg t, hπ⟩
+
+/-- **On a full period, a lower bound on the cosine is an upper bound on the angle.** The weak
+companion of `Real.abs_lt_arccos_iff_lt_cos`; here it is the angle `0` that the half-period
+statement does not reach, and the hypothesis `x ≤ 1` that makes both sides true there. -/
+theorem _root_.Real.abs_le_arccos_iff_le_cos {x t : ℝ} (hx : x ≤ 1) (ht : |t| ≤ π) :
+    |t| ≤ Real.arccos x ↔ x ≤ Real.cos t := by
+  rcases eq_or_lt_of_le (abs_nonneg t) with h0 | h0
+  · have ht0 : t = 0 := abs_eq_zero.mp h0.symm
+    subst ht0
+    rw [abs_zero, Real.cos_zero]
+    exact iff_of_true (Real.arccos_nonneg x) hx
+  · rw [← Real.cos_abs t]
+    exact Real.le_arccos_iff_le_cos ⟨h0, ht⟩
+
+/-- **The cosine exceeds a threshold on a symmetric interval.** On the period `[-π, π]` the angles
+at which `Real.cos` exceeds `x` are exactly those of `(-arccos x, arccos x)`. -/
+theorem _root_.Real.lt_cos_iff_mem_Ioo {x t : ℝ} (hx : -1 ≤ x) (ht : t ∈ Icc (-π) π) :
+    x < Real.cos t ↔ t ∈ Ioo (-Real.arccos x) (Real.arccos x) := by
+  rw [← Real.abs_lt_arccos_iff_lt_cos hx (abs_le.mpr ⟨ht.1, ht.2⟩), abs_lt, mem_Ioo]
+
+/-- **The cosine reaches a threshold on a symmetric closed interval.** The weak companion of
+`Real.lt_cos_iff_mem_Ioo`. -/
+theorem _root_.Real.le_cos_iff_mem_Icc {x t : ℝ} (hx : x ≤ 1) (ht : t ∈ Icc (-π) π) :
+    x ≤ Real.cos t ↔ t ∈ Icc (-Real.arccos x) (Real.arccos x) := by
+  rw [← Real.abs_le_arccos_iff_le_cos hx (abs_le.mpr ⟨ht.1, ht.2⟩), abs_le, mem_Icc]
+
+/-- **The cosine has no interior minimum on `[-π, π]`.** If `k < cos a` and `k < cos b`, with
+`-π ≤ a` and `b ≤ π`, then `k < cos θ` for every `θ ∈ [a, b]`.
+
+This is `Real.lt_cos_iff_mem_Ioo` read as unimodality: below `-1` the bound is vacuous, and above it
+the angles admitted form an interval symmetric about `0`, which therefore contains `[a, b]` as soon
+as it contains both endpoints. -/
+theorem _root_.Real.lt_cos_of_mem_Icc {k a b θ : ℝ} (ha : -π ≤ a) (hb : b ≤ π) (hθ : θ ∈ Icc a b)
+    (hka : k < Real.cos a) (hkb : k < Real.cos b) : k < Real.cos θ := by
+  rcases lt_or_ge k (-1) with hk | hk
+  · exact hk.trans_le (Real.neg_one_le_cos θ)
+  · have hab : a ≤ b := hθ.1.trans hθ.2
+    rw [← Real.abs_lt_arccos_iff_lt_cos hk (abs_le.mpr ⟨ha, hab.trans hb⟩)] at hka
+    rw [← Real.abs_lt_arccos_iff_lt_cos hk (abs_le.mpr ⟨ha.trans hab, hb⟩)] at hkb
+    rw [← Real.abs_lt_arccos_iff_lt_cos hk (abs_le.mpr ⟨ha.trans hθ.1, hθ.2.trans hb⟩)]
+    exact (abs_le_max_abs_abs hθ.1 hθ.2).trans_lt (max_lt hka hkb)
+
+end TauCeti

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Complex.Circle
 public import Mathlib.Analysis.SpecialFunctions.Complex.CircleMap
 import Mathlib.Analysis.SpecialFunctions.Trigonometric.Bounds
+import TauCeti.Analysis.SpecialFunctions.Trigonometric.Arccos
 
 /-!
 # The chord and the arc on a circle
@@ -31,6 +32,10 @@ circle.
   `2 * |ρ| * |sin ((θ - θ') / 2)|`, and
   `TauCeti.dist_circleMap_eq_two_mul_sin_abs`, the same formula with the sign of the angular
   difference cleared, valid for angles at most a full turn apart.
+* `TauCeti.dist_circleMap_le_dist_circleMap_of_abs_sub_le` — within half a turn that chord grows
+  with the angular gap, so the distance to a fixed point of the circle is unimodal along it, and
+  `TauCeti.ordConnected_inter_setOf_dist_circleMap_lt` — consequently a ball meets an arc of
+  angular width at most `π` in a set of angles that is order connected.
 * `TauCeti.dist_circleMap_sq` — the law of cosines: the point of `circleMap ζ ρ` at angle `θ` is at
   distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
   arbitrary point `c` of the plane.
@@ -125,6 +130,51 @@ theorem dist_circleMap_eq_two_mul_sin_abs (ζ : ℂ) (ρ : ℝ) {θ θ' : ℝ} (
   rw [dist_circleMap_eq_two_mul_abs_sin,
     Real.abs_sin_eq_sin_abs_of_abs_le_pi (by rw [habs]; linarith), habs]
 
+/-- **Within half a turn, the chord grows with the angular gap.** If the angle `u` is no further
+from `θ₀` than `v` is, and `v` is within half a turn of `θ₀`, then the point of `circleMap ζ ρ` at
+angle `u` is no further from the one at `θ₀` than the point at `v` is.
+
+Both chords are `TauCeti.dist_circleMap_eq_two_mul_sin_abs`, and the half-angles they feed to the
+sine stay in `[0, π / 2]`, where the sine is monotone. The restriction to half a turn is sharp:
+antipodal points are the furthest apart, and beyond them the chord shrinks again. -/
+theorem dist_circleMap_le_dist_circleMap_of_abs_sub_le (ζ : ℂ) (ρ : ℝ) {θ₀ u v : ℝ}
+    (huv : |u - θ₀| ≤ |v - θ₀|) (hv : |v - θ₀| ≤ π) :
+    dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀) ≤ dist (circleMap ζ ρ v) (circleMap ζ ρ θ₀) := by
+  have hu : |u - θ₀| ≤ π := huv.trans hv
+  have hdu : dist (circleMap ζ ρ u) (circleMap ζ ρ θ₀) = 2 * |ρ| * Real.sin (|u - θ₀| / 2) :=
+    dist_circleMap_eq_two_mul_sin_abs ζ ρ (by linarith [Real.pi_pos])
+  have hdv : dist (circleMap ζ ρ v) (circleMap ζ ρ θ₀) = 2 * |ρ| * Real.sin (|v - θ₀| / 2) :=
+    dist_circleMap_eq_two_mul_sin_abs ζ ρ (by linarith [Real.pi_pos])
+  rw [hdu, hdv]
+  have hsin : Real.sin (|u - θ₀| / 2) ≤ Real.sin (|v - θ₀| / 2) :=
+    Real.sin_le_sin_of_le_of_le_pi_div_two
+      (by linarith [abs_nonneg (u - θ₀), Real.pi_pos]) (by linarith) (by linarith)
+  exact mul_le_mul_of_nonneg_left hsin (by positivity)
+
+/-- **A ball centred on an arc of angular width at most `π` meets it in a subarc.** For a set `s` of
+angles contained in the half-turn `[θ₀ - π, θ₀ + π]`, the angles of `s` whose points lie within `δ`
+of the point at angle `θ₀` form an order-connected subset of `s`.
+
+The chord distance to `θ₀` falls and then rises as the angle sweeps across `s`
+(`TauCeti.dist_circleMap_le_dist_circleMap_of_abs_sub_le`), so an angle between two admitted ones is
+itself no further from `θ₀` than the admitted one on its side of `θ₀`. The angle `θ₀` need not lie
+in `s`, and the radius `δ` is arbitrary: for large `δ` the trace is all of `s`. -/
+theorem ordConnected_inter_setOf_dist_circleMap_lt (ζ : ℂ) (ρ : ℝ) {s : Set ℝ} {θ₀ δ : ℝ}
+    (hs : s.OrdConnected) (hsub : s ⊆ Icc (θ₀ - π) (θ₀ + π)) :
+    (s ∩ {θ | dist (circleMap ζ ρ θ) (circleMap ζ ρ θ₀) < δ}).OrdConnected := by
+  refine ⟨fun x hx y hy z hz => ⟨hs.out hx.1 hy.1 hz, ?_⟩⟩
+  rcases le_total z θ₀ with hzθ | hzθ
+  · refine lt_of_le_of_lt (dist_circleMap_le_dist_circleMap_of_abs_sub_le ζ ρ ?_ ?_) hx.2
+    · rw [abs_of_nonpos (by linarith), abs_of_nonpos (by linarith [hz.1])]
+      linarith [hz.1]
+    · rw [abs_le]
+      exact ⟨by linarith [(hsub hx.1).1], by linarith [(hsub hx.1).2]⟩
+  · refine lt_of_le_of_lt (dist_circleMap_le_dist_circleMap_of_abs_sub_le ζ ρ ?_ ?_) hy.2
+    · rw [abs_of_nonneg (by linarith), abs_of_nonneg (by linarith [hz.2])]
+      linarith [hz.2]
+    · rw [abs_le]
+      exact ⟨by linarith [(hsub hy.1).1], by linarith [(hsub hy.1).2]⟩
+
 /-- **The law of cosines for a point of a circle.** The point of `circleMap ζ ρ` at angle `θ` is at
 distance `ρ ^ 2 + dist ζ c ^ 2 - 2 * ρ * dist ζ c * cos (θ - arg (c - ζ))`, squared, from an
 arbitrary point `c`. For `ρ ≥ 0` this is the law of cosines as usually read: in the triangle with
@@ -214,26 +264,16 @@ theorem circleMap_mem_closedBall_iff_sq {c ζ : ℂ} {r : ℝ} (hr : 0 ≤ r) (�
   · intro h; linarith
   · intro h; linarith
 
-/-- **The cosine has no interior minimum on `[-π, π]`.** If `k < cos a` and `k < cos b`, with
-`-π ≤ a` and `b ≤ π`, then `k < cos θ` for every `θ ∈ [a, b]`: `cos` increases on `[-π, 0]` and
-decreases on `[0, π]`, so on `[a, b]` its minimum is attained at an endpoint. -/
-private theorem lt_cos_of_mem_Icc {k a b θ : ℝ} (ha : -π ≤ a) (hb : b ≤ π) (hθ : θ ∈ Icc a b)
-    (hka : k < Real.cos a) (hkb : k < Real.cos b) : k < Real.cos θ := by
-  rcases le_total θ 0 with hθ0 | hθ0
-  · refine hka.trans_le ?_
-    rw [← Real.cos_neg θ, ← Real.cos_neg a]
-    exact Real.cos_le_cos_of_nonneg_of_le_pi (by linarith) (by linarith) (by linarith [hθ.1])
-  · exact hkb.trans_le (Real.cos_le_cos_of_nonneg_of_le_pi hθ0 hb hθ.2)
-
 /-- **A circle meets a disc in a connected set of angles.** If the angles `a` and `b` both lie
 within `π` of the direction `arg (c - ζ)` from the centre `ζ` of the circle to the centre `c` of
 the disc, and both put the point of `sphere ζ ρ` they name inside `ball c r`, then so does every
 angle in `[a, b]`.
 
 This is `TauCeti.circleMap_mem_ball_iff_sq` read through the unimodality of `cos` on a period
-centred at `arg (c - ζ)`. Neither `0 < r` nor any relation between `ζ` and the disc is assumed: the
-first is forced by the hypotheses, and the second is not needed, so the conclusion covers a cutting
-circle centred anywhere and not only the circular crosscut at a boundary point `ζ` of the disc. Two
+centred at `arg (c - ζ)`, which is `Real.lt_cos_of_mem_Icc`. Neither `0 < r` nor any relation
+between `ζ` and the disc is assumed: the first is forced by the hypotheses, and the second is not
+needed, so the conclusion covers a cutting circle centred anywhere and not only the circular
+crosscut at a boundary point `ζ` of the disc. Two
 degenerate cases are covered as well, in both of which the criterion is independent of the angle: a
 circle centred at `c` itself, whose points are all at the same distance from `c`, and the circle of
 radius `ρ = 0`, which is the single point `ζ`. -/
@@ -255,7 +295,7 @@ theorem circleMap_mem_ball_of_mem_Icc {c ζ : ℂ} {r ρ : ℝ} (hρ : 0 ≤ ρ)
           < Real.cos (x - (c - ζ).arg) := fun x => by
       rw [div_lt_iff₀ hpos, mul_comm]
     rw [hkey] at hain hbin ⊢
-    exact lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
+    exact Real.lt_cos_of_mem_Icc ha hb ⟨by linarith [hθ.1], by linarith [hθ.2]⟩ hain hbin
 
 /-- **The chord is at most the arc**: `Circle.exp` is `1`-Lipschitz. -/
 theorem lipschitzWith_one_circleExp : LipschitzWith 1 Circle.exp :=

--- a/TauCeti/Topology/Circle/Metric.lean
+++ b/TauCeti/Topology/Circle/Metric.lean
@@ -151,9 +151,10 @@ theorem dist_circleMap_le_dist_circleMap_of_abs_sub_le (ζ : ℂ) (ρ : ℝ) {θ
       (by linarith [abs_nonneg (u - θ₀), Real.pi_pos]) (by linarith) (by linarith)
   exact mul_le_mul_of_nonneg_left hsin (by positivity)
 
-/-- **A ball centred on an arc of angular width at most `π` meets it in a subarc.** For a set `s` of
-angles contained in the half-turn `[θ₀ - π, θ₀ + π]`, the angles of `s` whose points lie within `δ`
-of the point at angle `θ₀` form an order-connected subset of `s`.
+/-- **An order-connected set of angles within half a turn of `θ₀` keeps that form when cut down by
+the distance to the point at `θ₀`.** For a set `s` of angles contained in the half-turn
+`[θ₀ - π, θ₀ + π]`, the angles of `s` whose points lie within `δ` of the point at angle `θ₀` form an
+order-connected subset of `s`.
 
 The chord distance to `θ₀` falls and then rises as the angle sweeps across `s`
 (`TauCeti.dist_circleMap_le_dist_circleMap_of_abs_sub_le`), so an angle between two admitted ones is


### PR DESCRIPTION
This PR extracts the general real-trigonometry and circle-geometry steps out of the L5 crosscut endpoint file into the places they belong, weakening their hypotheses to what the proofs actually use. No statement of the crosscut layer changes, and no declaration is renamed.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"arccos-cos-comparison-lemmas"}-->

The roadmap target is layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md` — "Carathéodory boundary correspondence … the Jordan-domain case" — whose source-side endpoint interface is `TauCeti/Analysis/Complex/Conformal/Crosscut/Endpoints.lean`. That file describes a circular crosscut of a disc as an angular arc of half-width `arccos (ρ / (2 * r))`, and it proved the trigonometry behind that description privately and inline. Nothing extracted here mentions a holomorphic map, a disc, or even the plane, so this is prior-art relocation under the improving-existing-code exemption rather than new mathematics; it follows the pattern of #2076 and #2089, which pulled the complex-analysis-free halves out of the neighbouring crosscut files.

Mathlib's `Analysis/SpecialFunctions/Trigonometric/Inverse.lean` carries a complete comparison family for `Real.arcsin` (`arcsin_le_iff_le_sin`, `le_arcsin_iff_sin_le`, `arcsin_lt_iff_lt_sin`, `lt_arcsin_iff_sin_lt`, plus primed variants) and none at all for `Real.arccos`: the pinned Mathlib knows `arccos_le_arccos`, `arccos_lt_arccos` and `cos_arccos`, but nothing comparing an *angle* with an arccosine. The new `TauCeti/Analysis/SpecialFunctions/Trigonometric/Arccos.lean` supplies that family, derived from Mathlib's `arcsin` lemmas through `Real.arccos_eq_pi_div_two_sub_arcsin` and `Real.sin_pi_div_two_sub` rather than reproved. It follows Mathlib's own split of that family: the unprimed `Real.arccos_le_iff_cos_le`, `Real.le_arccos_iff_le_cos` and their strict companions by negation state the closed-domain comparison, for `x ∈ [-1, 1]` and an angle in `[0, π]`; the primed `Real.arccos_le_iff_cos_le'`, `Real.le_arccos_iff_le_cos'` and companions assume nothing at all of `x`, each being its unprimed form together with the two degenerate ranges of `x`, at the price of excluding the one endpoint of `[0, π]` at which the comparison then fails. On top of that come `Real.abs_lt_arccos_iff_lt_cos` and `Real.abs_le_arccos_iff_le_cos`, which reach the full period `[-π, π]` through `|t|`; then `Real.lt_cos_iff_mem_Ioo` and `Real.le_cos_iff_mem_Icc`, reading the same statements as "on one period the angles at which the cosine exceeds a threshold form the symmetric interval of half-width `arccos x`"; and finally `Real.lt_cos_of_mem_Icc`, the unimodality corollary that the cosine has no interior minimum on `[-π, π]`. As with Mathlib's primed `arcsin` lemmas, the degenerate values `x < -1` and `1 < x`, where `arccos` is constant, are covered rather than excluded.

Two private fragments of that fact are deleted in favour of it. `Conformal/Crosscut/Endpoints.lean` had `div_lt_cos_iff_mem_Ioo` and `div_le_cos_iff_mem_Icc`, which assumed `0 < x` and `x < 1` where a single one-sided bound suffices, and `Topology/Circle/Metric.lean` had a `lt_cos_of_mem_Icc` proved directly from the monotonicity of the cosine on the two half-periods. Both call sites now go through the public lemmas.

The chord unimodality of a circle moves the other way. `Conformal/Crosscut/Endpoints.lean` also carried a private `ordConnected_Ioo_inter_setOf_dist_circleMap_lt`, which is about `circleMap` and not about the disc; it now sits in `TauCeti/Topology/Circle/Metric.lean` beside the chord formula it runs on, split into `TauCeti.dist_circleMap_le_dist_circleMap_of_abs_sub_le` — within half a turn the chord grows with the angular gap — and `TauCeti.ordConnected_inter_setOf_dist_circleMap_lt`. The latter is now stated for an arbitrary order-connected set of angles contained in a half turn of the base point, and that base point need no longer belong to it, replacing the previous `Ioo a b` with `b - a ≤ π` and `θ₀ ∈ Icc a b`.

No Mathlib source was vendored; the `arcsin` comparison lemmas, `Real.sin_le_sin_of_le_of_le_pi_div_two` and `abs_le_max_abs_abs` are consumed from Mathlib as they stand. Layer L5 is absent from [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress human-curated Riemann-mapping-theorem effort, so nothing here is shim material under the roadmap's coordination clause.

`lake build` and `lake exe axioms` are both green (24830 declarations audited, all within `propext`, `Classical.choice`, `Quot.sound`).

🤖 Prepared with Claude Code
