### PR TITLE
feat(Algebra/Order): telescoping bound for products in the unit ball

### DIFF
--- a/TauCeti/Algebra/Order/BigOperators/ProdSubProd.lean
+++ b/TauCeti/Algebra/Order/BigOperators/ProdSubProd.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Field.Basic
+public import Mathlib.Algebra.Order.BigOperators.Ring.Finset
+
+/-!
+# Comparing two products of elements of the unit ball
+
+For families taking values in the closed unit ball of a seminormed commutative ring, the difference
+of the products is controlled by the sum of the pointwise differences:
+
+```text
+‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ ≤ ∑ i ∈ s, ‖a i - b i‖
+```
+
+Only `‖a i‖ ≤ 1` and `‖b i‖ ≤ 1` are needed; the argument uses subadditivity and submultiplicativity
+of the norm and nothing else, so it holds over `ℂ` as well as `ℝ`, and norm definiteness is never
+used — hence `SeminormedCommRing` rather than `NormedCommRing`. The unit-ball bound is what makes
+the constant `1`; the same telescoping argument with a uniform bound `C` gives `C ^ (s.card - 1)`
+and is not needed here.
+
+`abs_prod_sub_prod_le_sum_abs_sub` is the real-valued corollary, phrased with `|·|`, which is the
+form the probability consumers use.
+
+This is the elementary step that turns coordinatewise convergence of finitely many bounded
+observables into convergence of their product, without Hölder or dominated-convergence machinery.
+It is motivated by `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** (the L² averaging library
+and the standard-Borel de Finetti route): both that route and the Layer 5 Koopman route reduce a
+block factorization to convergence of a product of finitely many block averages.
+-/
+
+public section
+
+namespace TauCeti
+
+open Finset
+
+/-- **A finite product of unit-ball elements lies in the unit ball.** Mathlib's
+`Finset.norm_prod_le` gives this over a `NormedCommRing`, but only submultiplicativity of the norm
+and `‖1‖ = 1` are used, so it holds over a seminormed ring. -/
+theorem norm_prod_le_one {ι R : Type*} [SeminormedCommRing R] [NormOneClass R] {s : Finset ι}
+    {b : ι → R} (hb : ∀ i ∈ s, ‖b i‖ ≤ 1) : ‖∏ i ∈ s, b i‖ ≤ 1 := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert j s hj ih =>
+      rw [Finset.prod_insert hj]
+      exact (norm_mul_le _ _).trans (mul_le_one₀ (hb j (Finset.mem_insert_self j s))
+        (norm_nonneg _) (ih fun i hi => hb i (Finset.mem_insert_of_mem hi)))
+
+/-- **Telescoping bound for a product of unit-ball elements.** If `‖a i‖ ≤ 1` and `‖b i‖ ≤ 1` for
+every `i ∈ s`, then the difference of the products is at most the sum of the pointwise
+differences. -/
+theorem norm_prod_sub_prod_le_sum_norm_sub {ι R : Type*} [SeminormedCommRing R]
+    [NormOneClass R]
+    (s : Finset ι) {a b : ι → R}
+    (ha : ∀ i ∈ s, ‖a i‖ ≤ 1) (hb : ∀ i ∈ s, ‖b i‖ ≤ 1) :
+    ‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ ≤ ∑ i ∈ s, ‖a i - b i‖ := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp
+  | insert j s hj ih =>
+      have hmem : ∀ i ∈ s, i ∈ insert j s := fun i hi => Finset.mem_insert_of_mem hi
+      have hjs : j ∈ insert j s := Finset.mem_insert_self j s
+      have ihs := ih (fun i hi => ha i (hmem i hi)) (fun i hi => hb i (hmem i hi))
+      have hprodb : ‖∏ i ∈ s, b i‖ ≤ 1 := norm_prod_le_one fun i hi => hb i (hmem i hi)
+      rw [Finset.prod_insert hj, Finset.prod_insert hj, Finset.sum_insert hj]
+      have hsplit : a j * ∏ i ∈ s, a i - b j * ∏ i ∈ s, b i
+          = a j * (∏ i ∈ s, a i - ∏ i ∈ s, b i) + (a j - b j) * ∏ i ∈ s, b i := by ring
+      rw [hsplit]
+      refine (norm_add_le _ _).trans ?_
+      have h1 : ‖a j * (∏ i ∈ s, a i - ∏ i ∈ s, b i)‖ ≤ ∑ i ∈ s, ‖a i - b i‖ :=
+        calc ‖a j * (∏ i ∈ s, a i - ∏ i ∈ s, b i)‖
+            ≤ ‖a j‖ * ‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ := norm_mul_le _ _
+          _ ≤ 1 * ‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ := by gcongr; exact ha j hjs
+          _ = ‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ := one_mul _
+          _ ≤ ∑ i ∈ s, ‖a i - b i‖ := ihs
+      have h2 : ‖(a j - b j) * ∏ i ∈ s, b i‖ ≤ ‖a j - b j‖ :=
+        calc ‖(a j - b j) * ∏ i ∈ s, b i‖ ≤ ‖a j - b j‖ * ‖∏ i ∈ s, b i‖ := norm_mul_le _ _
+          _ ≤ ‖a j - b j‖ * 1 := by gcongr
+          _ = ‖a j - b j‖ := mul_one _
+      linarith
+
+/-- **Real-valued form**, phrased with `|·|`: the shape the probability consumers use, where the
+factors are block averages and conditional expectations of indicators, all in `[0, 1]`. -/
+theorem abs_prod_sub_prod_le_sum_abs_sub {ι : Type*} (s : Finset ι) {a b : ι → ℝ}
+    (ha : ∀ i ∈ s, |a i| ≤ 1) (hb : ∀ i ∈ s, |b i| ≤ 1) :
+    |∏ i ∈ s, a i - ∏ i ∈ s, b i| ≤ ∑ i ∈ s, |a i - b i| := by
+  simpa only [Real.norm_eq_abs] using
+    norm_prod_sub_prod_le_sum_norm_sub s (a := a) (b := b)
+      (fun i hi => by simpa only [Real.norm_eq_abs] using ha i hi)
+      (fun i hi => by simpa only [Real.norm_eq_abs] using hb i hi)
+
+end TauCeti


### PR DESCRIPTION
Content replay of #1976 after review automation stopped responding on the fully built current head,
including after `/review`. The mathematical change is unchanged apart from rebasing onto current
main. Prior review history and the outstanding `attribution` contest are preserved at
https://github.com/TauCetiProject/TauCeti/pull/1976#discussion_r3720710904

The old PR's last scoreboard is from 2026-08-04T23:54 on a superseded head; the current head built
green with the full gate and no further review ran in the following ~25 hours, while comparable PRs
completed two and three rounds in that window.

Roadmap: Exchangeability

## What

```lean
theorem norm_prod_sub_prod_le_sum_norm_sub {ι R : Type*} [SeminormedCommRing R]
    [NormOneClass R] (s : Finset ι) {a b : ι → R}
    (ha : ∀ i ∈ s, ‖a i‖ ≤ 1) (hb : ∀ i ∈ s, ‖b i‖ ≤ 1) :
    ‖∏ i ∈ s, a i - ∏ i ∈ s, b i‖ ≤ ∑ i ∈ s, ‖a i - b i‖
```

Telescoping induction: `a j * ∏ a - b j * ∏ b = a j * (∏ a - ∏ b) + (a j - b j) * ∏ b`, then the
unit-ball bounds make both coefficients at most `1`. `abs_prod_sub_prod_le_sum_abs_sub` is the
real-valued corollary phrased with `|·|`, which is the form the probability consumers use.

Norm definiteness is never used, so the hypothesis is `SeminormedCommRing`, not `NormedCommRing`.
Mathlib's `Finset.norm_prod_le` is stated only for `NormedCommRing`, so the fact actually needed —
a finite product of unit-ball elements lies in the unit ball — is proved here as
`norm_prod_le_one`, by induction from `norm_mul_le` and `mul_le_one₀`.

## Why

For indicator observables both the block averages and their conditional expectations lie in
`[0, 1]`, hence in the unit ball, so this converts a bound on each factor into a bound on the
product — no Hölder or dominated-convergence machinery. It is the step from "each window average
converges in `L¹`" to "the product of finitely many window averages converges in `L¹`".

Motivated by `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** (the L² averaging library and
the standard-Borel de Finetti route). The dependency chain is: this lemma → the product-`L¹`
convergence lemma → the disjoint-window block factorization. Layer 5's Koopman route needs the same
two steps against a different conditioning σ-algebra, which is why this is neutral infrastructure
rather than living inside either route.

## Carried-over contest

The `attribution` rubric asked for a citation to `TauCetiRoadmap/Exchangeability/README.md`, Layer 3
"near this motivation". That citation was already present in the module docstring on the reviewed
head, inside the motivation paragraph itself:

```
$ git show 39899c3e:TauCeti/Algebra/Order/BigOperators/ProdSubProd.lean | grep -n TauCetiRoadmap
30:It is motivated by `TauCetiRoadmap/Exchangeability/README.md`, **Layer 3** (the L² averaging library
```

It is unchanged in this replay. If the intended request is more specific than a path-and-layer
citation — a named Layer 3 milestone, say — please say which and I will add it.

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol