### PR TITLE
feat(HeckeRing): the GL_n Hecke ring is commutative

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
@@ -27,8 +27,9 @@ integral Hecke ring of `GL_n` is commutative.
 
 * `HeckeRing.GLn.transposeAntiInvolution_onHeckeCoset_eq_self`: transposition fixes every
   double coset.
-* `HeckeRing.GLn.commSemiringIntegralHeckeRing`: **Shimura's Proposition 3.8 for `GL_n`** —
-  the integral Hecke ring is commutative.
+* `HeckeRing.GLn.commSemiringHeckeRing`: **Shimura's Proposition 3.8 for `GL_n`** — the
+  Hecke ring is commutative over any commutative semiring of coefficients, with
+  `HeckeRing.GLn.commSemiringIntegralHeckeRing` the integral case.
 
 ## References
 
@@ -120,11 +121,18 @@ transposition fixes diagonal matrices. -/
   exact congrArg (HeckeCoset.mk (SLnZ n) (SLnZ n))
     (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGL_natDiagGL n a)))
 
-/-- **Shimura's Proposition 3.8 for `GL_n`**: the integral Hecke ring of `GL_n` is
-commutative, transposition being an anti-involution that fixes every double coset. -/
+/-- **Shimura's Proposition 3.8 for `GL_n`**: the Hecke ring of `GL_n` over any commutative
+semiring is commutative, transposition being an anti-involution that fixes every double
+coset. -/
+@[instance_reducible]
+noncomputable def commSemiringHeckeRing (R : Type*) [CommSemiring R] :
+    CommSemiring (𝕋 (posDetInt n) (SLnZ n) R) :=
+  commSemiringOfAntiInvolution R (transposeAntiInvolution n)
+    (transposeAntiInvolution_onHeckeCoset_eq_self n)
+
+/-- The integral Hecke ring of `GL_n` is commutative. -/
 @[instance_reducible]
 noncomputable def commSemiringIntegralHeckeRing : CommSemiring (IntegralHeckeRing n) :=
-  commSemiringOfAntiInvolution ℤ (transposeAntiInvolution n)
-    (transposeAntiInvolution_onHeckeCoset_eq_self n)
+  commSemiringHeckeRing n ℤ
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
@@ -50,7 +50,7 @@ variable (n : ℕ)
 
 /-- Transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`: it reverses products, so it
 lands in the opposite group. -/
-noncomputable def transposeGL : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
+def transposeGL : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
   (Units.mapEquiv (Matrix.transposeRingEquiv (Fin n) ℚ).toMulEquiv).trans Units.opEquiv
 
 /-- Transposition acts on the underlying matrix as `Matrix.transpose`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
@@ -25,8 +25,8 @@ integral Hecke ring of `GL_n` is commutative.
 
 ## Main results
 
-* `HeckeRing.GLn.transposeAntiInvolution_onHeckeCoset`: transposition fixes every double
-  coset.
+* `HeckeRing.GLn.transposeAntiInvolution_onHeckeCoset_eq_self`: transposition fixes every
+  double coset.
 * `HeckeRing.GLn.commSemiringIntegralHeckeRing`: **Shimura's Proposition 3.8 for `GL_n`** —
   the integral Hecke ring is commutative.
 
@@ -34,6 +34,10 @@ integral Hecke ring of `GL_n` is commutative.
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
   Proposition 3.8.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GLn/TransposeAntiInvolution.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck).
 -/
 
 public section
@@ -49,15 +53,24 @@ lands in the opposite group. -/
 noncomputable def transposeGL : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
   (Units.mapEquiv (Matrix.transposeRingEquiv (Fin n) ℚ).toMulEquiv).trans Units.opEquiv
 
+/-- Transposition acts on the underlying matrix as `Matrix.transpose`. -/
 @[simp] lemma transposeGL_coe (g : GL (Fin n) ℚ) :
     ((transposeGL n g).unop : Matrix (Fin n) (Fin n) ℚ) =
       (↑g : Matrix (Fin n) (Fin n) ℚ)ᵀ := by
   simp [transposeGL, Units.opEquiv, Units.mapEquiv, Matrix.transposeRingEquiv]
 
-lemma transposeGL_involutive (g : GL (Fin n) ℚ) :
+/-- Transposing twice is the identity. -/
+@[simp] lemma transposeGL_transposeGL (g : GL (Fin n) ℚ) :
     (transposeGL n (transposeGL n g).unop).unop = g :=
   Units.ext (by ext i j; simp)
 
+/-- Transposition is an involution of `GL_n(ℚ)`. -/
+lemma transposeGL_involutive :
+    Function.Involutive (fun g : GL (Fin n) ℚ ↦ (transposeGL n g).unop) :=
+  transposeGL_transposeGL n
+
+/-- Transposition preserves `SL_n(ℤ)`: the transpose of an integral matrix of determinant
+one again has determinant one. -/
 lemma transposeGL_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
     (transposeGL n g).unop ∈ SLnZ n := by
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
@@ -65,6 +78,8 @@ lemma transposeGL_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
   ext i j
   simp [mapGL_coe_matrix, algebraMap_int_eq, SpecialLinearGroup.coe_transpose]
 
+/-- Transposition preserves `Δ`: it transposes the integral witness and leaves the
+determinant unchanged. -/
 lemma transposeGL_mem_posDetInt {g : GL (Fin n) ℚ} (hg : g ∈ posDetInt n) :
     (transposeGL n g).unop ∈ posDetInt n := by
   obtain ⟨hint, hdet⟩ := (mem_posDetInt_iff n).mp hg
@@ -73,15 +88,19 @@ lemma transposeGL_mem_posDetInt {g : GL (Fin n) ℚ} (hg : g ∈ posDetInt n) :
   · rw [transposeGL_coe, hA, Matrix.transpose_map]
   · rwa [transposeGL_coe, Matrix.det_transpose]
 
-/-- Transposition fixes a diagonal matrix. -/
-@[simp] lemma transposeGL_natDiagGL (a : Fin n → ℕ) (ha : ∀ i, 0 < a i) :
-    (transposeGL n (natDiagGL n a)).unop = natDiagGL n a :=
-  Units.ext (by simp [natDiagGL_coe n a ha])
+/-- Transposition fixes every diagonal matrix, including the junk value `1` taken when
+some entry vanishes. -/
+@[simp] lemma transposeGL_natDiagGL (a : Fin n → ℕ) :
+    (transposeGL n (natDiagGL n a)).unop = natDiagGL n a := by
+  by_cases ha : ∀ i, 0 < a i
+  · exact Units.ext (by simp [natDiagGL_coe n a ha])
+  · rw [natDiagGL_of_not_pos n ha]
+    exact Units.ext (by simp)
 
 /-- Transposition as an anti-involution of the arithmetic Hecke datum `(Δ, SL_n(ℤ))`. -/
 noncomputable def transposeAntiInvolution :
     HeckeAntiInvolution (posDetInt n) (SLnZ n) :=
-  HeckeAntiInvolution.ofAmbient (transposeGL n).toMonoidHom (transposeGL_involutive n)
+  HeckeAntiInvolution.ofAmbient (transposeGL n).toMonoidHom (transposeGL_transposeGL n)
     (fun _ hg ↦ transposeGL_mem_SLnZ n hg) (fun _ hg ↦ transposeGL_mem_posDetInt n hg)
 
 /-- The anti-involution acts as transposition, unfolding the sealed definition. -/
@@ -93,19 +112,19 @@ variable [NeZero n]
 
 /-- Transposition fixes every double coset: each one has a diagonal representative, and
 transposition fixes diagonal matrices. -/
-lemma transposeAntiInvolution_onHeckeCoset
+@[simp] lemma transposeAntiInvolution_onHeckeCoset_eq_self
     (D : HeckeCoset (posDetInt n) (SLnZ n) (SLnZ n)) :
     (transposeAntiInvolution n).onHeckeCoset D = D := by
-  obtain ⟨a, ha, -, rfl⟩ := exists_diagonal_representative D
+  obtain ⟨a, -, -, rfl⟩ := exists_diagonal_representative D
   rw [diagCoset_def, (transposeAntiInvolution n).onHeckeCoset_mk]
   exact congrArg (HeckeCoset.mk (SLnZ n) (SLnZ n))
-    (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGL_natDiagGL n a ha)))
+    (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGL_natDiagGL n a)))
 
 /-- **Shimura's Proposition 3.8 for `GL_n`**: the integral Hecke ring of `GL_n` is
 commutative, transposition being an anti-involution that fixes every double coset. -/
 @[instance_reducible]
 noncomputable def commSemiringIntegralHeckeRing : CommSemiring (IntegralHeckeRing n) :=
   commSemiringOfAntiInvolution ℤ (transposeAntiInvolution n)
-    (transposeAntiInvolution_onHeckeCoset n)
+    (transposeAntiInvolution_onHeckeCoset_eq_self n)
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
@@ -1,0 +1,111 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Commutativity
+public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+
+/-!
+# Commutativity of the `GL_n` Hecke ring
+
+Transposition `ξ ↦ ᵗξ` is an anti-automorphism of `GL_n(ℚ)` preserving both `SL_n(ℤ)` and
+the submonoid `Δ` of integral matrices of positive determinant, so it restricts to a
+`HeckeAntiInvolution` of the arithmetic Hecke datum. Every double coset has a diagonal
+representative and transposition fixes a diagonal matrix, so the involution it induces on
+`SL_n(ℤ) \ Δ / SL_n(ℤ)` is the identity. Shimura's Proposition 3.8 then applies: the
+integral Hecke ring of `GL_n` is commutative.
+
+## Main definitions
+
+* `HeckeRing.GLn.transposeGL`: transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`.
+* `HeckeRing.GLn.transposeAntiInvolution`: the induced `HeckeAntiInvolution` of `(Δ, SL_n(ℤ))`.
+
+## Main results
+
+* `HeckeRing.GLn.transposeAntiInvolution_onHeckeCoset`: transposition fixes every double
+  coset.
+* `HeckeRing.GLn.commSemiringIntegralHeckeRing`: **Shimura's Proposition 3.8 for `GL_n`** —
+  the integral Hecke ring is commutative.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Proposition 3.8.
+-/
+
+public section
+
+open Matrix Matrix.SpecialLinearGroup HeckeRing HeckeCosetModule
+
+namespace HeckeRing.GLn
+
+variable (n : ℕ)
+
+/-- Transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`: it reverses products, so it
+lands in the opposite group. -/
+noncomputable def transposeGL : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
+  (Units.mapEquiv (Matrix.transposeRingEquiv (Fin n) ℚ).toMulEquiv).trans Units.opEquiv
+
+@[simp] lemma transposeGL_coe (g : GL (Fin n) ℚ) :
+    ((transposeGL n g).unop : Matrix (Fin n) (Fin n) ℚ) =
+      (↑g : Matrix (Fin n) (Fin n) ℚ)ᵀ := by
+  simp [transposeGL, Units.opEquiv, Units.mapEquiv, Matrix.transposeRingEquiv]
+
+lemma transposeGL_involutive (g : GL (Fin n) ℚ) :
+    (transposeGL n (transposeGL n g).unop).unop = g :=
+  Units.ext (by ext i j; simp)
+
+lemma transposeGL_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
+    (transposeGL n g).unop ∈ SLnZ n := by
+  obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
+  refine (mem_SLnZ_iff n).mpr ⟨σ.transpose, Units.ext ?_⟩
+  ext i j
+  simp [mapGL_coe_matrix, algebraMap_int_eq, SpecialLinearGroup.coe_transpose]
+
+lemma transposeGL_mem_posDetInt {g : GL (Fin n) ℚ} (hg : g ∈ posDetInt n) :
+    (transposeGL n g).unop ∈ posDetInt n := by
+  obtain ⟨hint, hdet⟩ := (mem_posDetInt_iff n).mp hg
+  obtain ⟨A, hA⟩ := (hasIntEntries_iff n).mp hint
+  refine (mem_posDetInt_iff n).mpr ⟨(hasIntEntries_iff n).mpr ⟨Aᵀ, ?_⟩, ?_⟩
+  · rw [transposeGL_coe, hA, Matrix.transpose_map]
+  · rwa [transposeGL_coe, Matrix.det_transpose]
+
+/-- Transposition fixes a diagonal matrix. -/
+@[simp] lemma transposeGL_natDiagGL (a : Fin n → ℕ) (ha : ∀ i, 0 < a i) :
+    (transposeGL n (natDiagGL n a)).unop = natDiagGL n a :=
+  Units.ext (by simp [natDiagGL_coe n a ha])
+
+/-- Transposition as an anti-involution of the arithmetic Hecke datum `(Δ, SL_n(ℤ))`. -/
+noncomputable def transposeAntiInvolution :
+    HeckeAntiInvolution (posDetInt n) (SLnZ n) :=
+  HeckeAntiInvolution.ofAmbient (transposeGL n).toMonoidHom (transposeGL_involutive n)
+    (fun _ hg ↦ transposeGL_mem_SLnZ n hg) (fun _ hg ↦ transposeGL_mem_posDetInt n hg)
+
+/-- The anti-involution acts as transposition, unfolding the sealed definition. -/
+@[simp] lemma transposeAntiInvolution_bar {x : GL (Fin n) ℚ} (hx : x ∈ posDetInt n) :
+    (transposeAntiInvolution n).bar x hx = (transposeGL n x).unop :=
+  HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
+
+variable [NeZero n]
+
+/-- Transposition fixes every double coset: each one has a diagonal representative, and
+transposition fixes diagonal matrices. -/
+lemma transposeAntiInvolution_onHeckeCoset
+    (D : HeckeCoset (posDetInt n) (SLnZ n) (SLnZ n)) :
+    (transposeAntiInvolution n).onHeckeCoset D = D := by
+  obtain ⟨a, ha, -, rfl⟩ := exists_diagonal_representative D
+  rw [diagCoset_def, (transposeAntiInvolution n).onHeckeCoset_mk]
+  exact congrArg (HeckeCoset.mk (SLnZ n) (SLnZ n))
+    (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGL_natDiagGL n a ha)))
+
+/-- **Shimura's Proposition 3.8 for `GL_n`**: the integral Hecke ring of `GL_n` is
+commutative, transposition being an anti-involution that fixes every double coset. -/
+@[instance_reducible]
+noncomputable def commSemiringIntegralHeckeRing : CommSemiring (IntegralHeckeRing n) :=
+  commSemiringOfAntiInvolution ℤ (transposeAntiInvolution n)
+    (transposeAntiInvolution_onHeckeCoset n)
+
+end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/TransposeAntiInvolution.lean
@@ -20,7 +20,7 @@ integral Hecke ring of `GL_n` is commutative.
 
 ## Main definitions
 
-* `HeckeRing.GLn.transposeGL`: transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`.
+* `HeckeRing.GLn.transposeGLEquiv`: transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`.
 * `HeckeRing.GLn.transposeAntiInvolution`: the induced `HeckeAntiInvolution` of `(Δ, SL_n(ℤ))`.
 
 ## Main results
@@ -51,29 +51,24 @@ variable (n : ℕ)
 
 /-- Transposition as an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`: it reverses products, so it
 lands in the opposite group. -/
-def transposeGL : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
+def transposeGLEquiv : GL (Fin n) ℚ ≃* (GL (Fin n) ℚ)ᵐᵒᵖ :=
   (Units.mapEquiv (Matrix.transposeRingEquiv (Fin n) ℚ).toMulEquiv).trans Units.opEquiv
 
 /-- Transposition acts on the underlying matrix as `Matrix.transpose`. -/
-@[simp] lemma transposeGL_coe (g : GL (Fin n) ℚ) :
-    ((transposeGL n g).unop : Matrix (Fin n) (Fin n) ℚ) =
+@[simp] lemma transposeGLEquiv_coe (g : GL (Fin n) ℚ) :
+    ((transposeGLEquiv n g).unop : Matrix (Fin n) (Fin n) ℚ) =
       (↑g : Matrix (Fin n) (Fin n) ℚ)ᵀ := by
-  simp [transposeGL, Units.opEquiv, Units.mapEquiv, Matrix.transposeRingEquiv]
+  simp [transposeGLEquiv, Units.opEquiv, Units.mapEquiv, Matrix.transposeRingEquiv]
 
 /-- Transposing twice is the identity. -/
-@[simp] lemma transposeGL_transposeGL (g : GL (Fin n) ℚ) :
-    (transposeGL n (transposeGL n g).unop).unop = g :=
+@[simp] lemma transposeGLEquiv_transposeGLEquiv (g : GL (Fin n) ℚ) :
+    (transposeGLEquiv n (transposeGLEquiv n g).unop).unop = g :=
   Units.ext (by ext i j; simp)
-
-/-- Transposition is an involution of `GL_n(ℚ)`. -/
-lemma transposeGL_involutive :
-    Function.Involutive (fun g : GL (Fin n) ℚ ↦ (transposeGL n g).unop) :=
-  transposeGL_transposeGL n
 
 /-- Transposition preserves `SL_n(ℤ)`: the transpose of an integral matrix of determinant
 one again has determinant one. -/
-lemma transposeGL_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
-    (transposeGL n g).unop ∈ SLnZ n := by
+lemma transposeGLEquiv_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
+    (transposeGLEquiv n g).unop ∈ SLnZ n := by
   obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff n).mp hg
   refine (mem_SLnZ_iff n).mpr ⟨σ.transpose, Units.ext ?_⟩
   ext i j
@@ -81,18 +76,18 @@ lemma transposeGL_mem_SLnZ {g : GL (Fin n) ℚ} (hg : g ∈ SLnZ n) :
 
 /-- Transposition preserves `Δ`: it transposes the integral witness and leaves the
 determinant unchanged. -/
-lemma transposeGL_mem_posDetInt {g : GL (Fin n) ℚ} (hg : g ∈ posDetInt n) :
-    (transposeGL n g).unop ∈ posDetInt n := by
+lemma transposeGLEquiv_mem_posDetInt {g : GL (Fin n) ℚ} (hg : g ∈ posDetInt n) :
+    (transposeGLEquiv n g).unop ∈ posDetInt n := by
   obtain ⟨hint, hdet⟩ := (mem_posDetInt_iff n).mp hg
   obtain ⟨A, hA⟩ := (hasIntEntries_iff n).mp hint
   refine (mem_posDetInt_iff n).mpr ⟨(hasIntEntries_iff n).mpr ⟨Aᵀ, ?_⟩, ?_⟩
-  · rw [transposeGL_coe, hA, Matrix.transpose_map]
-  · rwa [transposeGL_coe, Matrix.det_transpose]
+  · rw [transposeGLEquiv_coe, hA, Matrix.transpose_map]
+  · rwa [transposeGLEquiv_coe, Matrix.det_transpose]
 
 /-- Transposition fixes every diagonal matrix, including the junk value `1` taken when
 some entry vanishes. -/
-@[simp] lemma transposeGL_natDiagGL (a : Fin n → ℕ) :
-    (transposeGL n (natDiagGL n a)).unop = natDiagGL n a := by
+@[simp] lemma transposeGLEquiv_natDiagGL (a : Fin n → ℕ) :
+    (transposeGLEquiv n (natDiagGL n a)).unop = natDiagGL n a := by
   by_cases ha : ∀ i, 0 < a i
   · exact Units.ext (by simp [natDiagGL_coe n a ha])
   · rw [natDiagGL_of_not_pos n ha]
@@ -101,12 +96,14 @@ some entry vanishes. -/
 /-- Transposition as an anti-involution of the arithmetic Hecke datum `(Δ, SL_n(ℤ))`. -/
 noncomputable def transposeAntiInvolution :
     HeckeAntiInvolution (posDetInt n) (SLnZ n) :=
-  HeckeAntiInvolution.ofAmbient (transposeGL n).toMonoidHom (transposeGL_transposeGL n)
-    (fun _ hg ↦ transposeGL_mem_SLnZ n hg) (fun _ hg ↦ transposeGL_mem_posDetInt n hg)
+  HeckeAntiInvolution.ofAmbient (transposeGLEquiv n).toMonoidHom
+    (transposeGLEquiv_transposeGLEquiv n)
+    (fun _ hg ↦ transposeGLEquiv_mem_SLnZ n hg)
+    (fun _ hg ↦ transposeGLEquiv_mem_posDetInt n hg)
 
 /-- The anti-involution acts as transposition, unfolding the sealed definition. -/
 @[simp] lemma transposeAntiInvolution_bar {x : GL (Fin n) ℚ} (hx : x ∈ posDetInt n) :
-    (transposeAntiInvolution n).bar x hx = (transposeGL n x).unop :=
+    (transposeAntiInvolution n).bar x hx = (transposeGLEquiv n x).unop :=
   HeckeAntiInvolution.ofAmbient_bar _ _ _ _ x hx
 
 variable [NeZero n]
@@ -119,7 +116,7 @@ transposition fixes diagonal matrices. -/
   obtain ⟨a, -, -, rfl⟩ := exists_diagonal_representative D
   rw [diagCoset_def, (transposeAntiInvolution n).onHeckeCoset_mk]
   exact congrArg (HeckeCoset.mk (SLnZ n) (SLnZ n))
-    (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGL_natDiagGL n a)))
+    (Subtype.ext ((transposeAntiInvolution_bar n _).trans (transposeGLEquiv_natDiagGL n a)))
 
 /-- **Shimura's Proposition 3.8 for `GL_n`**: the Hecke ring of `GL_n` over any commutative
 semiring is commutative, transposition being an anti-involution that fixes every double


### PR DESCRIPTION
Transposition `ξ ↦ ᵗξ` reverses products, so it is an isomorphism `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`. It preserves `SL_n(ℤ)` (the transpose of an integral matrix of determinant one is one) and the submonoid `Δ` of integral matrices of positive determinant (`det ᵗA = det A`), so `HeckeAntiInvolution.ofAmbient` turns it into an anti-involution of the arithmetic Hecke datum `(Δ, SL_n(ℤ))`.

Every double coset has a diagonal representative (`exists_diagonal_representative`, #2085) and transposition fixes a diagonal matrix, so the involution induced on `SL_n(ℤ) \ Δ / SL_n(ℤ)` is the identity. That is exactly the hypothesis of Shimura's Proposition 3.8, already in the repository as `HeckeCosetModule.commSemiringOfAntiInvolution` (#1937), so the integral Hecke ring of `GL_n` is commutative.

* `HeckeRing.GLn.transposeGL`: transposition as `GL_n(ℚ) ≃* GL_n(ℚ)ᵐᵒᵖ`, with `transposeGL_coe` characterizing it entrywise, `transposeGL_involutive`, and `transposeGL_mem_SLnZ` / `transposeGL_mem_posDetInt` for the two preservation facts.
* `HeckeRing.GLn.transposeAntiInvolution`: the resulting `HeckeAntiInvolution (posDetInt n) (SLnZ n)`, with `transposeAntiInvolution_bar` unfolding the sealed definition.
* `HeckeRing.GLn.transposeAntiInvolution_onHeckeCoset`: transposition fixes every double coset.
* `HeckeRing.GLn.commSemiringIntegralHeckeRing`: **Shimura's Proposition 3.8 for `GL_n`** — `CommSemiring (IntegralHeckeRing n)`.

The conclusion is stated as `CommSemiring` because that is what the merged criterion produces; upgrading it to `CommRing` needs the `Ring` instance that rides with the degree stack, and belongs with it rather than here.

Ported from the AINTLIB `LeanModularForms` project (`LeanModularForms/HeckeRIngs/GLn/TransposeAntiInvolution.lean`, Chris Birkbeck). Depends only on merged material (#1937 for the abstract criterion, #2085 for the diagonal representatives), so it is independent of the open degree stack.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/ModularForms/README.md), Layer 2: the concrete `GL_n` Hecke-ring theory underlying the `T_p` operators. Commutativity of the Hecke ring is the structural fact that makes the `T_n` a commuting family, which is what the eigenform theory downstream rests on.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
