### PR TITLE
feat(ModularForms): the vertical integrals of a periodic integrand cancel

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -12,8 +12,8 @@ import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deri
 /-!
 # The vertical integrals of a periodic integrand cancel
 
-The reflection `t ↦ 4 - t` carries the left vertical of the boundary contour onto the
-right vertical through the translation `z ↦ z - 1`, reversing the orientation. For any
+The reflection `t ↦ 4 - t` carries the right vertical of the boundary contour onto the
+left vertical through the translation `z ↦ z - 1`, reversing the orientation. For any
 integrand `φ` of period `1` — the level-one situation, where `φ` is the logarithmic
 derivative of the extension of a modular form — the left vertical contour integral of
 `γ' • φ ∘ γ` is therefore the negative of the right one: the values are identified by
@@ -35,9 +35,9 @@ namespace TauCeti
 namespace ModularForm
 
 /-- The left vertical integral of a period-`1` integrand along the boundary contour is
-the negative of the right vertical integral: the reflection `t ↦ 4 - t` matches the
-verticals through the translation `z ↦ z - 1`, which the periodicity absorbs, and
-reverses the orientation. -/
+the negative of the right vertical integral: the reflection `t ↦ 4 - t` carries the
+right vertical onto the left through the translation `z ↦ z - 1`, which the periodicity
+absorbs, and reverses the orientation. -/
 theorem intervalIntegral_fdBoundary_segment4_eq_neg_segment1 {E : Type*}
     [NormedAddCommGroup E] [NormedSpace ℂ E] (H : ℝ) {φ : ℂ → E}
     (hφ : Function.Periodic φ 1) :

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+/-!
+# The vertical integrals of a periodic integrand cancel
+
+The reflection `t ↦ 4 - t` carries the left vertical of the boundary contour onto the
+right vertical through the translation `z ↦ z - 1`, reversing the orientation. For any
+integrand `φ` of period `1` — the level-one situation, where `φ` is the logarithmic
+derivative of the extension of a modular form — the left vertical contour integral of
+`γ' • φ ∘ γ` is therefore the negative of the right one: the values are identified by
+periodicity and the derivatives by the reflection, up to the orientation sign. The
+statement is unconditional: the substitution and the interior congruence need no
+integrability.
+
+## Main declarations
+
+* `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment4_eq_neg_segment1`.
+-/
+
+public section
+
+open MeasureTheory Set
+
+namespace TauCeti
+
+namespace ModularForm
+
+/-- The left vertical integral of a period-`1` integrand along the boundary contour is
+the negative of the right vertical integral: the reflection `t ↦ 4 - t` matches the
+verticals through the translation `z ↦ z - 1`, which the periodicity absorbs, and
+reverses the orientation. -/
+theorem intervalIntegral_fdBoundary_segment4_eq_neg_segment1 {E : Type*}
+    [NormedAddCommGroup E] [NormedSpace ℂ E] (H : ℝ) {φ : ℂ → E}
+    (hφ : Function.Periodic φ 1) :
+    ∫ t in (3 : ℝ)..4, deriv (fdBoundary H) t • φ (fdBoundary H t) =
+      -∫ t in (0 : ℝ)..1, deriv (fdBoundary H) t • φ (fdBoundary H t) := by
+  have hsub : (∫ t in (3 : ℝ)..4, deriv (fdBoundary H) t • φ (fdBoundary H t)) =
+      ∫ u in (0 : ℝ)..1, deriv (fdBoundary H) (4 - u) • φ (fdBoundary H (4 - u)) := by
+    have h := intervalIntegral.integral_comp_sub_left (a := 0) (b := 1)
+      (fun t ↦ deriv (fdBoundary H) t • φ (fdBoundary H t)) 4
+    norm_num at h
+    exact h.symm
+  rw [hsub, ← intervalIntegral.integral_neg]
+  refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun u hu ↦ ?_
+  rw [fdBoundary_four_sub_vertical H ⟨hu.1.le, hu.2.le⟩,
+    deriv_fdBoundary_four_sub_vertical H hu, hφ.sub_eq, neg_smul]
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -24,6 +24,12 @@ integrability.
 ## Main declarations
 
 * `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment4_eq_neg_segment1`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development (`ForMathlib/ValenceFormula/PVChain/Assembly.lean`, the vertical
+  cancellation) this file ports onto the current Mathlib pin.
 -/
 
 public section


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The reflection `t ↦ 4 - t` carries the left vertical of the boundary contour onto the
right vertical through the translation `z ↦ z - 1` (#2105), reversing the orientation.
For any integrand `φ` of period `1` into a complex normed space, the left vertical
contour integral of `γ' • φ ∘ γ` is therefore the negative of the right one:

- `intervalIntegral_fdBoundary_segment4_eq_neg_segment1 (hφ : Function.Periodic φ 1) :
  ∫ t in 3..4, deriv (fdBoundary H) t • φ (fdBoundary H t) =
  -∫ t in 0..1, deriv (fdBoundary H) t • φ (fdBoundary H t)`

The statement is unconditional — the substitution (`integral_comp_sub_left`) and the
interior congruence (`integral_congr_Ioo_of_le`) need no integrability — and the
integrand is in the contour-canonical `deriv • φ ∘ γ` shape.

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): with
`φ := logDeriv (⇑f ∘ ofComplex)` — periodic by `periodic_comp_ofComplex` transported
through `TauCeti.Function.Periodic.logDeriv` (#2107) — this is the cancellation of the
two vertical integrals in the valence-formula contour integral.

Roadmap: ModularForms
