### PR TITLE
feat(ModularForms): the arc self-pairing of the logDeriv integrand

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 public import TauCeti.NumberTheory.ModularForms.STransform
 
@@ -18,8 +17,8 @@ own reversal through the inversion `S`. Composed with the `S`-transformation law
 logarithmic derivative of a weight-`k` form, the reflected integrand
 `logDeriv g (γ (4 - t)) · γ' (4 - t)` pairs with the direct one up to the weight term
 `-k · γ' / γ` — so the two halves of the arc integral collapse to the integral of
-`γ' / γ`, which is the constant `π/6 · i` producing the `k/12` term of the valence
-formula.
+`γ' / γ`, whose integrand is `π/6 · i` on the open arc and hence almost everywhere,
+producing the `k/12` term of the valence formula.
 
 ## Main declarations
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -25,8 +25,12 @@ formula.
 
 * `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_pairing`: the direct and
   reflected arc contour integrands sum to the weight term.
-* `TauCeti.ModularForm.integral_deriv_div_fdBoundary_arc`: the arc integral of `γ' / γ`
-  is `(b - a) · π/6 · i`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development (`ForMathlib/ValenceFormula/PVChain/ArcContribution.lean`) this file ports
+  onto the current Mathlib pin.
 -/
 
 public section
@@ -40,14 +44,6 @@ namespace TauCeti
 namespace ModularForm
 
 variable {F : Type*} [FunLike F ℍ ℂ] {Γ : Subgroup SL(2, ℤ)} {k : ℤ}
-
-/-- The positivity of the imaginary part along the arc. -/
-lemma im_fdBoundary_arc_pos (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
-    0 < (fdBoundary H t).im := by
-  rw [eqOn_fdBoundary_arc H ht, circleMap_zero_im, one_mul]
-  exact Real.sin_pos_of_pos_of_lt_pi
-    (mul_pos (by linarith [ht.1]) (by positivity))
-    (by nlinarith [mul_pos Real.pi_pos (show (0 : ℝ) < 5 - t by linarith [ht.2])])
 
 /-- On the open arc, the direct and reflected logarithmic-derivative contour integrands
 sum to the weight term `-k · γ' / γ`. -/
@@ -64,34 +60,6 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_pairing [SlashInvariantFormClass 
     smul_eq_mul, smul_eq_mul, logDeriv_comp_ofComplex_S_transform f hS him hd hne]
   field_simp
   ring
-
-/-- The arc integral of `γ' / γ` over any subinterval of the arc, in either orientation:
-the integrand is the constant `π/6 · i`. -/
-theorem integral_deriv_div_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Icc (1 : ℝ) 3)
-    (hb : b ∈ Icc (1 : ℝ) 3) :
-    ∫ t in a..b, deriv (fdBoundary H) t / fdBoundary H t =
-      (b - a) * ((π / 6 : ℝ) * Complex.I) := by
-  have key : ∀ c d : ℝ, c ∈ Icc (1 : ℝ) 3 → d ∈ Icc (1 : ℝ) 3 → c ≤ d →
-      ∫ t in c..d, deriv (fdBoundary H) t / fdBoundary H t =
-        (d - c) * ((π / 6 : ℝ) * Complex.I) := by
-    intro c d hc hd hcd
-    have hcongr : ∀ t ∈ Ioo c d, deriv (fdBoundary H) t / fdBoundary H t =
-        ((π / 6 : ℝ) : ℂ) * Complex.I := fun t ht ↦ by
-      have ht' : t ∈ Ioo (1 : ℝ) 3 :=
-        ⟨lt_of_le_of_lt hc.1 ht.1, lt_of_lt_of_le ht.2 hd.2⟩
-      rw [deriv_fdBoundary_of_mem_Ioo_one_three ht',
-        eqOn_fdBoundary_arc H ⟨ht'.1.le, ht'.2.le⟩, Complex.real_smul,
-        mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I, mul_div_assoc,
-        mul_div_assoc, div_self (circleMap_ne_center one_ne_zero), mul_one]
-    rw [intervalIntegral.integral_congr_Ioo_of_le hcd hcongr,
-      intervalIntegral.integral_const, Complex.real_smul]
-    push_cast
-    ring
-  rcases le_total a b with hab | hab
-  · exact key a b ha hb hab
-  · rw [intervalIntegral.integral_symm, key b a hb ha hab]
-    push_cast
-    ring
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -1,0 +1,116 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+public import TauCeti.NumberTheory.ModularForms.STransform
+
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+/-!
+# The arc self-pairing of the logarithmic-derivative integrand
+
+The reflection `t ↦ 4 - t` carries the unit-circle arc of the boundary contour to its
+own reversal through the inversion `S`. Composed with the `S`-transformation law of the
+logarithmic derivative of a weight-`k` form, the reflected integrand
+`logDeriv g (γ (4 - t)) · γ' (4 - t)` pairs with the direct one up to the weight term
+`-k · γ' / γ` — so the two halves of the arc integral collapse to the integral of
+`γ' / γ`, which is the constant `π/6 · i` producing the `k/12` term of the valence
+formula.
+
+## Main declarations
+
+* `TauCeti.ModularForm.logDeriv_comp_ofComplex_S_transform_reflected`: the
+  denominator-free reflected form of the `S`-transformation law.
+* `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_pairing`: the direct and
+  reflected arc contour integrands sum to the weight term.
+* `TauCeti.ModularForm.integral_deriv_div_fdBoundary_arc`: the arc integral of `γ' / γ`
+  is `(b - a) · π/6 · i`.
+-/
+
+public section
+
+open Complex MeasureTheory Set UpperHalfPlane
+
+open scoped MatrixGroups Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {F : Type*} [FunLike F ℍ ℂ] {Γ : Subgroup SL(2, ℤ)} {k : ℤ}
+
+/-- The reflected, denominator-free form of the `S`-transformation law of the
+logarithmic derivative. -/
+theorem logDeriv_comp_ofComplex_S_transform_reflected [SlashInvariantFormClass F Γ k]
+    (f : F) (hS : ModularGroup.S ∈ Γ) {w : ℂ} (hw : 0 < w.im)
+    (hd : DifferentiableAt ℂ (⇑f ∘ ofComplex) w) (hfw : (⇑f ∘ ofComplex) w ≠ 0) :
+    logDeriv (⇑f ∘ ofComplex) (-1 / w) =
+      w ^ 2 * logDeriv (⇑f ∘ ofComplex) w + k * w := by
+  have hw0 : w ≠ 0 := fun h ↦ absurd hw (by simp [h])
+  have h := logDeriv_comp_ofComplex_S_transform f hS hw hd hfw
+  rw [neg_div]
+  field_simp at h
+  linear_combination -h
+
+/-- The positivity of the imaginary part along the arc. -/
+lemma im_fdBoundary_arc_pos (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
+    0 < (fdBoundary H t).im := by
+  rw [eqOn_fdBoundary_arc H ht, circleMap_zero_im, one_mul]
+  exact Real.sin_pos_of_pos_of_lt_pi
+    (mul_pos (by linarith [ht.1]) (by positivity))
+    (by nlinarith [mul_pos Real.pi_pos (show (0 : ℝ) < 5 - t by linarith [ht.2])])
+
+/-- On the open arc, the direct and reflected logarithmic-derivative contour integrands
+sum to the weight term `-k · γ' / γ`. -/
+theorem logDeriv_comp_ofComplex_fdBoundary_arc_pairing [SlashInvariantFormClass F Γ k]
+    (f : F) (hS : ModularGroup.S ∈ Γ) {H t : ℝ} (ht : t ∈ Ioo (1 : ℝ) 3)
+    (hd : DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
+    (hne : (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0) :
+    deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t) +
+      deriv (fdBoundary H) (4 - t) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - t)) =
+      -(k * (deriv (fdBoundary H) t / fdBoundary H t)) := by
+  have him := im_fdBoundary_arc_pos H ⟨ht.1.le, ht.2.le⟩
+  have h0 : fdBoundary H t ≠ 0 := fun h ↦ absurd him (by simp [h])
+  rw [fdBoundary_four_sub_arc H ⟨ht.1.le, ht.2.le⟩, deriv_fdBoundary_four_sub_arc H ht,
+    logDeriv_comp_ofComplex_S_transform_reflected f hS him hd hne, smul_eq_mul,
+    smul_eq_mul]
+  field_simp
+  ring
+
+/-- The arc integral of `γ' / γ` over any subinterval of the arc, in either orientation:
+the integrand is the constant `π/6 · i`. -/
+theorem integral_deriv_div_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Icc (1 : ℝ) 3)
+    (hb : b ∈ Icc (1 : ℝ) 3) :
+    ∫ t in a..b, deriv (fdBoundary H) t / fdBoundary H t =
+      (b - a) * ((π / 6 : ℝ) * Complex.I) := by
+  have key : ∀ c d : ℝ, c ∈ Icc (1 : ℝ) 3 → d ∈ Icc (1 : ℝ) 3 → c ≤ d →
+      ∫ t in c..d, deriv (fdBoundary H) t / fdBoundary H t =
+        (d - c) * ((π / 6 : ℝ) * Complex.I) := by
+    intro c d hc hd hcd
+    have hcongr : ∀ t ∈ Ioo c d, deriv (fdBoundary H) t / fdBoundary H t =
+        ((π / 6 : ℝ) : ℂ) * Complex.I := fun t ht ↦ by
+      have ht' : t ∈ Ioo (1 : ℝ) 3 :=
+        ⟨lt_of_le_of_lt hc.1 ht.1, lt_of_lt_of_le ht.2 hd.2⟩
+      rw [deriv_fdBoundary_of_mem_Ioo_one_three ht',
+        eqOn_fdBoundary_arc H ⟨ht'.1.le, ht'.2.le⟩, Complex.real_smul,
+        mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I, mul_div_assoc,
+        mul_div_assoc, div_self (circleMap_ne_center one_ne_zero), mul_one]
+    rw [intervalIntegral.integral_congr_Ioo_of_le hcd hcongr,
+      intervalIntegral.integral_const, Complex.real_smul]
+    push_cast
+    ring
+  rcases le_total a b with hab | hab
+  · exact key a b ha hb hab
+  · rw [intervalIntegral.integral_symm, key b a hb ha hab]
+    push_cast
+    ring
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -23,8 +23,6 @@ formula.
 
 ## Main declarations
 
-* `TauCeti.ModularForm.logDeriv_comp_ofComplex_S_transform_reflected`: the
-  denominator-free reflected form of the `S`-transformation law.
 * `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_pairing`: the direct and
   reflected arc contour integrands sum to the weight term.
 * `TauCeti.ModularForm.integral_deriv_div_fdBoundary_arc`: the arc integral of `γ' / γ`
@@ -42,19 +40,6 @@ namespace TauCeti
 namespace ModularForm
 
 variable {F : Type*} [FunLike F ℍ ℂ] {Γ : Subgroup SL(2, ℤ)} {k : ℤ}
-
-/-- The reflected, denominator-free form of the `S`-transformation law of the
-logarithmic derivative. -/
-theorem logDeriv_comp_ofComplex_S_transform_reflected [SlashInvariantFormClass F Γ k]
-    (f : F) (hS : ModularGroup.S ∈ Γ) {w : ℂ} (hw : 0 < w.im)
-    (hd : DifferentiableAt ℂ (⇑f ∘ ofComplex) w) (hfw : (⇑f ∘ ofComplex) w ≠ 0) :
-    logDeriv (⇑f ∘ ofComplex) (-1 / w) =
-      w ^ 2 * logDeriv (⇑f ∘ ofComplex) w + k * w := by
-  have hw0 : w ≠ 0 := fun h ↦ absurd hw (by simp [h])
-  have h := logDeriv_comp_ofComplex_S_transform f hS hw hd hfw
-  rw [neg_div]
-  field_simp at h
-  linear_combination -h
 
 /-- The positivity of the imaginary part along the arc. -/
 lemma im_fdBoundary_arc_pos (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
@@ -76,8 +61,7 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_pairing [SlashInvariantFormClass 
   have him := im_fdBoundary_arc_pos H ⟨ht.1.le, ht.2.le⟩
   have h0 : fdBoundary H t ≠ 0 := fun h ↦ absurd him (by simp [h])
   rw [fdBoundary_four_sub_arc H ⟨ht.1.le, ht.2.le⟩, deriv_fdBoundary_four_sub_arc H ht,
-    logDeriv_comp_ofComplex_S_transform_reflected f hS him hd hne, smul_eq_mul,
-    smul_eq_mul]
+    smul_eq_mul, smul_eq_mul, logDeriv_comp_ofComplex_S_transform f hS him hd hne]
   field_simp
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -16,14 +16,15 @@ The reflection `t ↦ 4 - t` carries the unit-circle arc of the boundary contour
 own reversal through the inversion `S`. Composed with the `S`-transformation law of the
 logarithmic derivative of a weight-`k` form, the reflected integrand
 `logDeriv g (γ (4 - t)) · γ' (4 - t)` pairs with the direct one up to the weight term
-`-k · γ' / γ` — so the two halves of the arc integral collapse to the integral of
-`γ' / γ`, whose integrand is `π/6 · i` on the open arc and hence almost everywhere,
-producing the `k/12` term of the valence formula.
+`-k · γ' / γ` — so the two halves of the arc integral collapse to `-k` times the
+integral of `γ' / γ`, whose integrand is `π/6 · i` on the open arc and hence almost
+everywhere: the arc contributes `-k/12` to the `(2πi)⁻¹`-normalized valence contour,
+the term that lands as `k/12` on the divisor side of the valence formula.
 
 ## Main declarations
 
-* `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_pairing`: the direct and
-  reflected arc contour integrands sum to the weight term.
+* `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg`: the
+  direct and reflected arc contour integrands sum to the negated weight term.
 
 ## References
 
@@ -45,18 +46,20 @@ namespace ModularForm
 variable {F : Type*} [FunLike F ℍ ℂ] {Γ : Subgroup SL(2, ℤ)} {k : ℤ}
 
 /-- On the open arc, the direct and reflected logarithmic-derivative contour integrands
-sum to the weight term `-k · γ' / γ`. -/
-theorem logDeriv_comp_ofComplex_fdBoundary_arc_pairing [SlashInvariantFormClass F Γ k]
+sum to the negated weight term `-k · logDeriv γ`. -/
+theorem logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
+    [SlashInvariantFormClass F Γ k]
     (f : F) (hS : ModularGroup.S ∈ Γ) {H t : ℝ} (ht : t ∈ Ioo (1 : ℝ) 3)
     (hd : DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
     (hne : (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0) :
     deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t) +
       deriv (fdBoundary H) (4 - t) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - t)) =
-      -(k * (deriv (fdBoundary H) t / fdBoundary H t)) := by
+      -(k * logDeriv (fdBoundary H) t) := by
   have him := im_fdBoundary_arc_pos H ⟨ht.1.le, ht.2.le⟩
   have h0 : fdBoundary H t ≠ 0 := fun h ↦ absurd him (by simp [h])
   rw [fdBoundary_four_sub_arc H ⟨ht.1.le, ht.2.le⟩, deriv_fdBoundary_four_sub_arc H ht,
-    smul_eq_mul, smul_eq_mul, logDeriv_comp_ofComplex_S_transform f hS him hd hne]
+    smul_eq_mul, smul_eq_mul, logDeriv_comp_ofComplex_S_transform f hS him hd hne,
+    logDeriv_apply (fdBoundary H) t]
   field_simp
   ring
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -454,9 +454,9 @@ theorem im_fdBoundary_arc_le (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
 theorem im_fdBoundary_arc_pos (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
     0 < (fdBoundary H t).im := by
   rw [eqOn_fdBoundary_arc H ht, circleMap_zero_im, one_mul]
-  exact Real.sin_pos_of_pos_of_lt_pi
-    (mul_pos (by linarith [ht.1]) (by positivity))
-    (by nlinarith [mul_pos Real.pi_pos (show (0 : ℝ) < 5 - t by linarith [ht.2])])
+  have h5 : (0 : ℝ) < 5 - t := by linarith [ht.2]
+  exact Real.sin_pos_of_pos_of_lt_pi (mul_pos (by linarith [ht.1]) (by positivity))
+    (by nlinarith [mul_pos Real.pi_pos h5])
 
 /-- The left vertical has constant real part `-1/2`. -/
 theorem re_fdBoundary_segment4 (H : ℝ) {t : ℝ} (ht : t ∈ Icc (3 : ℝ) 4) :

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Basic.lean
@@ -450,6 +450,14 @@ theorem im_fdBoundary_arc_le (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
   rw [eqOn_fdBoundary_arc H ht, circleMap_zero_im]
   simpa using Real.sin_le_one ((t + 1) * (Real.pi / 6))
 
+/-- The arc stays in the open upper half-plane. -/
+theorem im_fdBoundary_arc_pos (H : ℝ) {t : ℝ} (ht : t ∈ Icc (1 : ℝ) 3) :
+    0 < (fdBoundary H t).im := by
+  rw [eqOn_fdBoundary_arc H ht, circleMap_zero_im, one_mul]
+  exact Real.sin_pos_of_pos_of_lt_pi
+    (mul_pos (by linarith [ht.1]) (by positivity))
+    (by nlinarith [mul_pos Real.pi_pos (show (0 : ℝ) < 5 - t by linarith [ht.2])])
+
 /-- The left vertical has constant real part `-1/2`. -/
 theorem re_fdBoundary_segment4 (H : ℝ) {t : ℝ} (ht : t ∈ Icc (3 : ℝ) 4) :
     (fdBoundary H t).re = -(1 / 2) := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -255,6 +255,7 @@ lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 :
 /-- On the open arc the contour's logarithmic derivative — its logarithmic speed
 `γ' / γ` — is the constant `π/6 · i`: the arc traverses the unit circle at angular speed
 `π/6`. -/
+@[simp]
 theorem logDeriv_fdBoundary_arc {H t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
     logDeriv (fdBoundary H) t = (Real.pi / 6 : ℝ) * Complex.I := by
   have hne : circleMap 0 1 ((t + 1) * (Real.pi / 6)) ≠ 0 := circleMap_ne_center one_ne_zero

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -257,10 +257,10 @@ lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 :
 `π/6`. -/
 theorem logDeriv_fdBoundary_arc {H t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
     logDeriv (fdBoundary H) t = (Real.pi / 6 : ℝ) * Complex.I := by
+  have hne : circleMap 0 1 ((t + 1) * (Real.pi / 6)) ≠ 0 := circleMap_ne_center one_ne_zero
   rw [logDeriv_apply, deriv_fdBoundary_of_mem_Ioo_one_three ht,
-    eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩, Complex.real_smul,
-    mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I,
-    mul_div_assoc, mul_div_assoc, div_self (circleMap_ne_center one_ne_zero), mul_one]
+    eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩, Complex.real_smul]
+  field_simp
 
 /-- The arc integral of the contour's logarithmic derivative over any subinterval of the
 arc, in either orientation: the integrand is `π/6 · i` on the open arc
@@ -269,22 +269,14 @@ theorem integral_logDeriv_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Set.I
     (hb : b ∈ Set.Icc (1 : ℝ) 3) :
     ∫ t in a..b, logDeriv (fdBoundary H) t =
       (b - a) * ((Real.pi / 6 : ℝ) * Complex.I) := by
-  have key : ∀ c d : ℝ, c ∈ Set.Icc (1 : ℝ) 3 → d ∈ Set.Icc (1 : ℝ) 3 → c ≤ d →
-      ∫ t in c..d, logDeriv (fdBoundary H) t =
-        (d - c) * ((Real.pi / 6 : ℝ) * Complex.I) := by
-    intro c d hc hd hcd
-    rw [intervalIntegral.integral_congr_Ioo_of_le hcd
-        (g := fun _ ↦ ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)
-        (fun t ht ↦ logDeriv_fdBoundary_arc
-          ⟨lt_of_le_of_lt hc.1 ht.1, lt_of_lt_of_le ht.2 hd.2⟩),
-      intervalIntegral.integral_const, Complex.real_smul]
-    push_cast
-    ring
-  rcases le_total a b with hab | hab
-  · exact key a b ha hb hab
-  · rw [intervalIntegral.integral_symm, key b a hb ha hab]
-    push_cast
-    ring
+  rw [intervalIntegral.integral_congr_uIoo
+      (g := fun _ ↦ ((Real.pi / 6 : ℝ) : ℂ) * Complex.I) fun t ht ↦
+        logDeriv_fdBoundary_arc
+          ⟨lt_of_le_of_lt (le_min ha.1 hb.1) ht.1,
+            lt_of_lt_of_le ht.2 (max_le ha.2 hb.2)⟩,
+    intervalIntegral.integral_const, Complex.real_smul]
+  push_cast
+  ring
 
 end Reflection
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -251,6 +251,38 @@ lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 :
     Complex.real_smul]
   field_simp
 
+/-- On the open arc the contour's logarithmic speed `γ' / γ` is the constant `π/6 · i`:
+the arc traverses the unit circle at angular speed `π/6`. -/
+theorem deriv_div_fdBoundary_arc {H t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
+    deriv (fdBoundary H) t / fdBoundary H t = (Real.pi / 6 : ℝ) * Complex.I := by
+  rw [deriv_fdBoundary_of_mem_Ioo_one_three ht, eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩,
+    Complex.real_smul, mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I,
+    mul_div_assoc, mul_div_assoc, div_self (circleMap_ne_center one_ne_zero), mul_one]
+
+/-- The arc integral of `γ' / γ` over any subinterval of the arc, in either orientation:
+the integrand is `π/6 · i` on the open arc (`deriv_div_fdBoundary_arc`), hence almost
+everywhere for these interval integrals. -/
+theorem integral_deriv_div_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Set.Icc (1 : ℝ) 3)
+    (hb : b ∈ Set.Icc (1 : ℝ) 3) :
+    ∫ t in a..b, deriv (fdBoundary H) t / fdBoundary H t =
+      (b - a) * ((Real.pi / 6 : ℝ) * Complex.I) := by
+  have key : ∀ c d : ℝ, c ∈ Set.Icc (1 : ℝ) 3 → d ∈ Set.Icc (1 : ℝ) 3 → c ≤ d →
+      ∫ t in c..d, deriv (fdBoundary H) t / fdBoundary H t =
+        (d - c) * ((Real.pi / 6 : ℝ) * Complex.I) := by
+    intro c d hc hd hcd
+    rw [intervalIntegral.integral_congr_Ioo_of_le hcd
+        (g := fun _ ↦ ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)
+        (fun t ht ↦ deriv_div_fdBoundary_arc
+          ⟨lt_of_le_of_lt hc.1 ht.1, lt_of_lt_of_le ht.2 hd.2⟩),
+      intervalIntegral.integral_const, Complex.real_smul]
+    push_cast
+    ring
+  rcases le_total a b with hab | hab
+  · exact key a b ha hb hab
+  · rw [intervalIntegral.integral_symm, key b a hb ha hab]
+    push_cast
+    ring
+
 end Reflection
 
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Basic
+public import Mathlib.Analysis.Calculus.LogDeriv
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 
 import Mathlib.Analysis.Calculus.Deriv.AffineMap
@@ -251,28 +252,30 @@ lemma deriv_fdBoundary_four_sub_arc (H : ℝ) {t : ℝ} (ht : t ∈ Set.Ioo (1 :
     Complex.real_smul]
   field_simp
 
-/-- On the open arc the contour's logarithmic speed `γ' / γ` is the constant `π/6 · i`:
-the arc traverses the unit circle at angular speed `π/6`. -/
-theorem deriv_div_fdBoundary_arc {H t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
-    deriv (fdBoundary H) t / fdBoundary H t = (Real.pi / 6 : ℝ) * Complex.I := by
-  rw [deriv_fdBoundary_of_mem_Ioo_one_three ht, eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩,
-    Complex.real_smul, mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I,
+/-- On the open arc the contour's logarithmic derivative — its logarithmic speed
+`γ' / γ` — is the constant `π/6 · i`: the arc traverses the unit circle at angular speed
+`π/6`. -/
+theorem logDeriv_fdBoundary_arc {H t : ℝ} (ht : t ∈ Set.Ioo (1 : ℝ) 3) :
+    logDeriv (fdBoundary H) t = (Real.pi / 6 : ℝ) * Complex.I := by
+  rw [logDeriv_apply, deriv_fdBoundary_of_mem_Ioo_one_three ht,
+    eqOn_fdBoundary_arc H ⟨ht.1.le, ht.2.le⟩, Complex.real_smul,
+    mul_comm (circleMap 0 1 ((t + 1) * (Real.pi / 6))) Complex.I,
     mul_div_assoc, mul_div_assoc, div_self (circleMap_ne_center one_ne_zero), mul_one]
 
-/-- The arc integral of `γ' / γ` over any subinterval of the arc, in either orientation:
-the integrand is `π/6 · i` on the open arc (`deriv_div_fdBoundary_arc`), hence almost
-everywhere for these interval integrals. -/
-theorem integral_deriv_div_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Set.Icc (1 : ℝ) 3)
+/-- The arc integral of the contour's logarithmic derivative over any subinterval of the
+arc, in either orientation: the integrand is `π/6 · i` on the open arc
+(`logDeriv_fdBoundary_arc`), hence almost everywhere for these interval integrals. -/
+theorem integral_logDeriv_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Set.Icc (1 : ℝ) 3)
     (hb : b ∈ Set.Icc (1 : ℝ) 3) :
-    ∫ t in a..b, deriv (fdBoundary H) t / fdBoundary H t =
+    ∫ t in a..b, logDeriv (fdBoundary H) t =
       (b - a) * ((Real.pi / 6 : ℝ) * Complex.I) := by
   have key : ∀ c d : ℝ, c ∈ Set.Icc (1 : ℝ) 3 → d ∈ Set.Icc (1 : ℝ) 3 → c ≤ d →
-      ∫ t in c..d, deriv (fdBoundary H) t / fdBoundary H t =
+      ∫ t in c..d, logDeriv (fdBoundary H) t =
         (d - c) * ((Real.pi / 6 : ℝ) * Complex.I) := by
     intro c d hc hd hcd
     rw [intervalIntegral.integral_congr_Ioo_of_le hcd
         (g := fun _ ↦ ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)
-        (fun t ht ↦ deriv_div_fdBoundary_arc
+        (fun t ht ↦ logDeriv_fdBoundary_arc
           ⟨lt_of_le_of_lt hc.1 ht.1, lt_of_lt_of_le ht.2 hd.2⟩),
       intervalIntegral.integral_const, Complex.real_smul]
     push_cast


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The reflection `t ↦ 4 - t` carries the unit-circle arc of the boundary contour to its
own reversal through the inversion `S` (#2105). Composed with the `S`-transformation law
of the logarithmic derivative (#2109), the direct and reflected contour integrands sum
to the weight term:

- `im_fdBoundary_arc_pos` — the arc stays in the open upper half-plane
- `logDeriv_comp_ofComplex_fdBoundary_arc_pairing :
  γ'(t) • logDeriv g (γ t) + γ'(4-t) • logDeriv g (γ (4-t)) = -(k * (γ'(t) / γ t))`
  on the open arc (pointwise hypotheses: differentiability and nonvanishing at `γ t`)
- `integral_deriv_div_fdBoundary_arc : ∫ t in a..b, γ'/γ = (b - a) * (π/6 * I)` for
  `a, b ∈ Icc 1 3`, either orientation

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): the two arc
halves of the contour integral of `f'/f` collapse through this pairing to
`-k · (π/6) · i`, which under the `(2πi)⁻¹` normalization is exactly the `-k/12` term of
the valence formula. This is the last pointwise ingredient of the integral-evaluation
side; the vertical side is #2117.

Roadmap: ModularForms
