### PR TITLE
feat: package smooth Lie group conjugation

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -43,7 +43,6 @@ theorem conjugationDiffeomorph_apply (g x : G) :
     conjugationDiffeomorph (I := I) g x = g * x * g⁻¹ :=
   rfl
 
-@[simp]
 theorem conjugationDiffeomorph_one (g : G) :
     conjugationDiffeomorph (I := I) g (1 : G) = 1 := by
   simp

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -44,6 +44,11 @@ theorem conjugationDiffeomorph_apply (g x : G) :
   rfl
 
 @[simp]
+theorem conjugationDiffeomorph_one (g : G) :
+    conjugationDiffeomorph (I := I) g (1 : G) = 1 := by
+  simp
+
+@[simp]
 theorem conjugationDiffeomorph_symm_apply (g x : G) :
     (conjugationDiffeomorph (I := I) g).symm x = g⁻¹ * x * g :=
   rfl

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -48,6 +48,8 @@ instance instChartedSpaceConjAct : ChartedSpace H (ConjAct G) := chartsG
 /-- Conjugation is a smooth action of the conjugation-action copy of a Lie group on the group. -/
 instance instContMDiffSMulConjAct : ContMDiffSMul I I n (ConjAct G) G where
   contMDiff_smul := by
+    -- The topology and charts above are definitionally those of `G`, while `ConjAct`'s scalar
+    -- action is definitionally conjugation. Unfolding both exposes the standard smooth operations.
     change CMDiff n (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹)
     exact (contMDiff_fst.mul contMDiff_snd).mul contMDiff_fst.inv
 

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import TauCeti.Geometry.Diffeomorphism.Group
+
+/-!
+# Smooth conjugation in a Lie group
+
+This file packages conjugation by an element of a Lie group as a smooth self-diffeomorphism.  The
+resulting map from the group to its group of smooth self-diffeomorphisms is a group homomorphism.
+Its differential at the identity is the group adjoint action developed in subsequent files.
+
+## Main definitions
+
+* `TauCeti.Lie.conjugationDiffeomorph`: conjugation by `g` as a smooth diffeomorphism.
+* `TauCeti.Lie.conjugation`: the conjugation homomorphism into smooth self-diffeomorphisms.
+-/
+
+public section
+
+namespace TauCeti.Lie
+
+open scoped Manifold ContDiff
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [LieGroup I ∞ G]
+
+/-- Conjugation by `g`, sending `x` to `g * x * g⁻¹`, as a smooth self-diffeomorphism. -/
+@[expose]
+def conjugationDiffeomorph (g : G) : G ≃ₘ⟮I, I⟯ G where
+  toEquiv := (MulAut.conj g).toEquiv
+  contMDiff_toFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const.inv
+  contMDiff_invFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const
+
+@[simp]
+theorem conjugationDiffeomorph_apply (g x : G) :
+    conjugationDiffeomorph (I := I) g x = g * x * g⁻¹ :=
+  rfl
+
+@[simp]
+theorem conjugationDiffeomorph_symm_apply (g x : G) :
+    (conjugationDiffeomorph (I := I) g).symm x = g⁻¹ * x * g :=
+  rfl
+
+/-- Smooth conjugation is a group homomorphism from `G` to its group of smooth
+self-diffeomorphisms. -/
+@[expose]
+def conjugation : G →* TauCeti.Diff I G ∞ where
+  toFun := conjugationDiffeomorph
+  map_one' := by
+    ext x
+    simp
+  map_mul' g h := by
+    ext x
+    simp only [TauCeti.Diffeomorph.mul_apply, conjugationDiffeomorph_apply]
+    group
+
+@[simp]
+theorem conjugation_apply (g : G) :
+    conjugation (I := I) g = conjugationDiffeomorph (I := I) g :=
+  rfl
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import Mathlib.Geometry.Manifold.Algebra.SMul
 public import TauCeti.Geometry.Diffeomorphism.Group
 
 /-!
@@ -35,24 +36,34 @@ open scoped Manifold ContDiff
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
-  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  {G : Type*} [topG : TopologicalSpace G] [chartsG : ChartedSpace H G] [Group G]
   {n : ℕ∞ω} [LieGroup I n G]
 
+/-- The conjugation-action copy of a Lie group carries the original topology. -/
+instance instTopologicalSpaceConjAct : TopologicalSpace (ConjAct G) := topG
+
+/-- The conjugation-action copy of a Lie group carries the original manifold charts. -/
+instance instChartedSpaceConjAct : ChartedSpace H (ConjAct G) := chartsG
+
+/-- Conjugation is a smooth action of the conjugation-action copy of a Lie group on the group. -/
+instance instContMDiffSMulConjAct : ContMDiffSMul I I n (ConjAct G) G where
+  contMDiff_smul := by
+    change CMDiff n (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹)
+    exact (contMDiff_fst.mul contMDiff_snd).mul contMDiff_fst.inv
+
 /-- Conjugation by `g`, sending `x` to `g * x * g⁻¹`, as a smooth self-diffeomorphism. -/
-def conjDiffeomorph (g : G) : G ≃ₘ^n⟮I, I⟯ G where
-  toEquiv := (MulAut.conj g).toEquiv
-  contMDiff_toFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const.inv
-  contMDiff_invFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const
+def conjDiffeomorph (g : G) : G ≃ₘ^n⟮I, I⟯ G :=
+  Diffeomorph.smul I I n (ConjAct.toConjAct g)
 
 @[simp]
 theorem conjDiffeomorph_apply (g x : G) :
     conjDiffeomorph (I := I) (n := n) g x = g * x * g⁻¹ :=
-  (rfl)
+  ConjAct.toConjAct_smul g x
 
 @[simp]
 theorem conjDiffeomorph_symm_apply (g x : G) :
     (conjDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
-  (rfl)
+  ConjAct.toConjAct_inv_smul g x
 
 /-- Smooth conjugation is a group homomorphism from `G` to its group of smooth
 self-diffeomorphisms. -/

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -17,8 +17,8 @@ developed in subsequent files.
 
 ## Main definitions
 
-* `TauCeti.Lie.conjugationDiffeomorph`: conjugation by `g` as a smooth diffeomorphism.
-* `TauCeti.Lie.conjugation`: the conjugation homomorphism into smooth self-diffeomorphisms.
+* `TauCeti.Lie.conjDiffeomorph`: conjugation by `g` as a smooth diffeomorphism.
+* `TauCeti.Lie.conj`: the conjugation homomorphism into smooth self-diffeomorphisms.
 
 ## References
 
@@ -39,36 +39,36 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {n : ℕ∞ω} [LieGroup I n G]
 
 /-- Conjugation by `g`, sending `x` to `g * x * g⁻¹`, as a smooth self-diffeomorphism. -/
-def conjugationDiffeomorph (g : G) : G ≃ₘ^n⟮I, I⟯ G where
+def conjDiffeomorph (g : G) : G ≃ₘ^n⟮I, I⟯ G where
   toEquiv := (MulAut.conj g).toEquiv
   contMDiff_toFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const.inv
   contMDiff_invFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const
 
 @[simp]
-theorem conjugationDiffeomorph_apply (g x : G) :
-    conjugationDiffeomorph (I := I) (n := n) g x = g * x * g⁻¹ :=
+theorem conjDiffeomorph_apply (g x : G) :
+    conjDiffeomorph (I := I) (n := n) g x = g * x * g⁻¹ :=
   (rfl)
 
 @[simp]
-theorem conjugationDiffeomorph_symm_apply (g x : G) :
-    (conjugationDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
+theorem conjDiffeomorph_symm_apply (g x : G) :
+    (conjDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
   (rfl)
 
 /-- Smooth conjugation is a group homomorphism from `G` to its group of smooth
 self-diffeomorphisms. -/
-def conjugation : G →* TauCeti.Diff I G n where
-  toFun := conjugationDiffeomorph
+def conj : G →* TauCeti.Diff I G n where
+  toFun := conjDiffeomorph
   map_one' := by
     ext x
     simp
   map_mul' g h := by
     ext x
-    simp only [TauCeti.Diffeomorph.mul_apply, conjugationDiffeomorph_apply]
+    simp only [TauCeti.Diffeomorph.mul_apply, conjDiffeomorph_apply]
     group
 
 @[simp]
-theorem conjugation_apply (g : G) :
-    conjugation (I := I) (n := n) g = conjugationDiffeomorph (I := I) (n := n) g :=
+theorem conj_apply (g : G) :
+    conj (I := I) (n := n) g = conjDiffeomorph (I := I) (n := n) g :=
   (rfl)
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -10,14 +10,20 @@ public import TauCeti.Geometry.Diffeomorphism.Group
 /-!
 # Smooth conjugation in a Lie group
 
-This file packages conjugation by an element of a Lie group as a smooth self-diffeomorphism.  The
+This file packages conjugation by an element of a Lie group as a smooth self-diffeomorphism. The
 resulting map from the group to its group of smooth self-diffeomorphisms is a group homomorphism.
-Its differential at the identity is the group adjoint action developed in subsequent files.
+Differentiating each conjugation diffeomorphism at the identity yields the group adjoint action
+developed in subsequent files.
 
 ## Main definitions
 
 * `TauCeti.Lie.conjugationDiffeomorph`: conjugation by `g` as a smooth diffeomorphism.
 * `TauCeti.Lie.conjugation`: the conjugation homomorphism into smooth self-diffeomorphisms.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
 -/
 
 public section
@@ -26,36 +32,31 @@ namespace TauCeti.Lie
 
 open scoped Manifold ContDiff
 
-variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
-  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [LieGroup I ∞ G]
+  {n : ℕ∞ω} [LieGroup I n G]
 
 /-- Conjugation by `g`, sending `x` to `g * x * g⁻¹`, as a smooth self-diffeomorphism. -/
-@[expose]
-def conjugationDiffeomorph (g : G) : G ≃ₘ⟮I, I⟯ G where
+def conjugationDiffeomorph (g : G) : G ≃ₘ^n⟮I, I⟯ G where
   toEquiv := (MulAut.conj g).toEquiv
   contMDiff_toFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const.inv
   contMDiff_invFun := (contMDiff_const.mul contMDiff_id).mul contMDiff_const
 
 @[simp]
 theorem conjugationDiffeomorph_apply (g x : G) :
-    conjugationDiffeomorph (I := I) g x = g * x * g⁻¹ :=
-  rfl
-
-theorem conjugationDiffeomorph_one (g : G) :
-    conjugationDiffeomorph (I := I) g (1 : G) = 1 := by
-  simp
+    conjugationDiffeomorph (I := I) (n := n) g x = g * x * g⁻¹ :=
+  (rfl)
 
 @[simp]
 theorem conjugationDiffeomorph_symm_apply (g x : G) :
-    (conjugationDiffeomorph (I := I) g).symm x = g⁻¹ * x * g :=
-  rfl
+    (conjugationDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
+  (rfl)
 
 /-- Smooth conjugation is a group homomorphism from `G` to its group of smooth
 self-diffeomorphisms. -/
-@[expose]
-def conjugation : G →* TauCeti.Diff I G ∞ where
+def conjugation : G →* TauCeti.Diff I G n where
   toFun := conjugationDiffeomorph
   map_one' := by
     ext x
@@ -67,7 +68,7 @@ def conjugation : G →* TauCeti.Diff I G ∞ where
 
 @[simp]
 theorem conjugation_apply (g : G) :
-    conjugation (I := I) g = conjugationDiffeomorph (I := I) g :=
-  rfl
+    conjugation (I := I) (n := n) g = conjugationDiffeomorph (I := I) (n := n) g :=
+  (rfl)
 
 end TauCeti.Lie


### PR DESCRIPTION
## Goal

Provide the smooth conjugation map whose differential at the identity defines the group adjoint action required by `RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 1.

## Argument

The adjoint action is defined intrinsically by differentiating conjugation. To make that construction canonical and reusable, conjugation by each group element must first be bundled as a smooth self-diffeomorphism. Its inverse is conjugation by the inverse element, and the group identity `c_(gh) = c_g ∘ c_h` then upgrades the family to a homomorphism into `Diff(G)`. These properties supply exactly the invertibility and composition laws needed by the subsequent differential construction.

This is the first atomic prerequisite in the campaign tracked by TauCetiRoadmap#162.

## Verification

- `lake build TauCeti.Geometry.Lie.Adjoint.Conjugation`
- 2,394 build jobs completed successfully
- policy audit against the repository `AGENTS.md`

Roadmap: RepresentationTheory