### PR TITLE
doc: agents never file roadmap changes themselves

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,10 @@ the three repos fit together; this file only adds the contract for agents workin
 [TauCetiRoadmap](https://github.com/TauCetiProject/TauCetiRoadmap) repo. The roadmap gates
 *new* mathematics: only add a new mathematical declaration (definition, theorem, instance,
 notation) or file when it advances a specific roadmap target, or supplies a prerequisite that a
-specific target needs. If a human asks you to build something new that is not on the roadmap,
-say so and ask them to add it to the roadmap first, rather than building it here.
+specific target needs. If something you want to build is not on the roadmap — whether a human
+asked for it or you found the gap yourself — say so and leave it to a human to add, rather than
+building it here. Never open a PR or an issue in TauCetiRoadmap yourself; reviewing a roadmap
+change needs human attention.
 
 Improving code that already exists is **always in scope** and needs no roadmap entry:
 refactoring, simplifying proofs, fixing or modestly generalising an existing lemma (without


### PR DESCRIPTION
This PR closes the reading of `AGENTS.md` that let autonomous workers file roadmap issues. The "ask them to add it to the roadmap first" sentence assumed a human was in the loop to ask; an agent running unattended generalised it into opening an issue on TauCetiRoadmap, citing this file for the authority. It now covers the unattended case explicitly and says never to open a PR or an issue there.

Roadmap: none

See https://github.com/TauCetiProject/TauCetiRoadmap/issues/111 and https://github.com/TauCetiProject/TauCetiRoadmap/issues/112 for the two that landed. The matching prompt-side rule is https://github.com/kim-em/TauCetiWorker/pull/167.

🤖 Prepared with Claude Code