### PR TITLE
feat(ModularForms): the congruence subgroups are antitone in the level

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -24,8 +24,9 @@ prime-power levels — the degree count of Shimura, Theorem 3.24 — which lives
 is congruence-subgroup arithmetic consumed by, but independent of, the Hecke-ring layer.
 
 Ported from the AINTLIB `LeanModularForms` project
-(`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean` and, for the index section,
-`LeanModularForms/HeckeRIngs/GL2/CongruenceIndex.lean`, Chris Birkbeck,
+(`LeanModularForms/HeckeRIngs/GL2/Gamma1Pair.lean`, for the index section
+`LeanModularForms/HeckeRIngs/GL2/CongruenceIndex.lean`, and for the level-antitonicity
+lemmas `LeanModularForms/HeckeRIngs/GL2/LevelEmbed.lean`, all Chris Birkbeck,
 <https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), extracted from
 `TauCeti/NumberTheory/ModularForms/DiamondOperators.lean` as congruence-subgroup
 infrastructure independent of the diamond operators.
@@ -360,10 +361,8 @@ theorem Gamma0_prime_power_index (p : ℕ) (hp : Nat.Prime p) (k : ℕ) (hk : 0 
   induction k, hk using Nat.le_induction with
   | base => simpa using Gamma0_prime_index p hp
   | succ m hm ih =>
-    have h_le : Gamma0 (p ^ (m + 1)) ≤ Gamma0 (p ^ m) := fun σ hσ ↦ by
-      rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd] at hσ ⊢
-      exact (Int.natCast_dvd_natCast.mpr (pow_dvd_pow p m.le_succ)).trans hσ
-    rw [Nat.add_sub_cancel, ← Subgroup.relIndex_mul_index h_le,
+    rw [Nat.add_sub_cancel,
+      ← Subgroup.relIndex_mul_index (Gamma0_le_Gamma0_of_dvd (pow_dvd_pow p m.le_succ)),
       Gamma0_relIndex_pow_succ p hp.pos m hm, ih, ← mul_assoc, ← pow_succ',
       Nat.sub_add_cancel hm]
 

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -32,6 +32,8 @@ infrastructure independent of the diamond operators.
 
 ## Main results
 
+* `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`, `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`:
+  both families are antitone in the level, `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
   `GL₂(ℝ)`.
@@ -58,6 +60,21 @@ open scoped MatrixGroups Pointwise
 variable {N : ℕ}
 
 namespace CongruenceSubgroup
+
+/-- `Γ₁` is antitone in the level: if `M ∣ N` then `Γ₁(N) ≤ Γ₁(M)`, since reducing the
+congruences `a ≡ d ≡ 1`, `c ≡ 0` modulo `N` along `ZMod N → ZMod M` gives them modulo `M`. -/
+theorem Gamma1_le_Gamma1_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma1 N ≤ Gamma1 M := by
+  intro A hA
+  rw [Gamma1_mem] at hA ⊢
+  exact ⟨by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.1,
+    by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.2.1,
+    by simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA.2.2⟩
+
+/-- `Γ₀` is antitone in the level: if `M ∣ N` then `Γ₀(N) ≤ Γ₀(M)`. -/
+theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 M := by
+  intro A hA
+  rw [Gamma0_mem] at hA ⊢
+  simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA
 
 /-- Conjugation by a `Gamma0 N` element preserves `Gamma1 N`.
 This is the foundation for the diamond operator `⟨d⟩` on modular forms. -/


### PR DESCRIPTION
The congruence subgroups are antitone in the level: `Γ₁(N) ≤ Γ₁(M)` and `Γ₀(N) ≤ Γ₀(M)` whenever `M ∣ N`. Both defining conditions are congruences in `ZMod N` — `a ≡ d ≡ 1`, `c ≡ 0` for `Γ₁`, and `c ≡ 0` for `Γ₀` — so applying `ZMod.castHom` along `M ∣ N` transports each of them to level `M`.

* `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`
* `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`

Placed in the existing `TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean` beside the rest of the `Γ₁(N) ≤ Γ₀(N)` infrastructure; neither Mathlib nor TauCeti had these. Mathlib's `Gamma1_in_Gamma0` already supplies the same-level inclusion, so this PR does not restate it.

Ported from the AINTLIB `LeanModularForms` project (`LeanModularForms/HeckeRIngs/GL2/LevelEmbed.lean`, Chris Birkbeck). That file's third lemma is a bare alias for Mathlib's `Gamma1_in_Gamma0` and is deliberately not carried over.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/TauCetiRoadmap/ModularForms/README.md).

These are not speculative: `Gamma0_prime_power_index`, already in `main` in this very file, needs `Γ₀(p^(m+1)) ≤ Γ₀(p^m)` and proved that containment inline. It now calls `Gamma0_le_Gamma0_of_dvd`, so the `Γ₀` case removes a duplicated argument from merged code rather than anticipating future work.

Looking forward, the same pair is the definition-level prerequisite for the Layer 3 degeneracy maps — the old subspace `S_k(N)^old` is spanned by the level-raising images of forms of proper divisor level, and the layer calls for "the level- and character-transport lemmas ... part of the degeneracy-map API". That consumer is not yet built, which is why the justification above rests on the present one.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
