### PR TITLE
refactor(ModularForms): factor the Γ₀ unit-entry fact out of two proofs

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Gamma1.lean
@@ -8,6 +8,9 @@ module
 public import TauCeti.NumberTheory.HeckeRing.GLn.Basic
 public import Mathlib.NumberTheory.ModularForms.CongruenceSubgroups
 
+-- only the Γ₀ unit-entry lemma is needed, and only inside a proof
+import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+
 /-!
 # The Hecke triple of `Γ₁(N)`
 
@@ -111,8 +114,7 @@ lemma Gamma1Image_le_Delta0 : (Gamma1Image N).toSubmonoid ≤ Delta0 N := by
   obtain ⟨σ, hσ, rfl⟩ := (mem_Gamma1Image_iff N).mp hg
   obtain ⟨ha, -, hc⟩ := (Gamma1_mem _ _).mp hσ
   refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ha ▸ isUnit_one⟩
-  · rw [mapGL_coe_matrix]
-    rfl
+  · simp [mapGL_coe_matrix, algebraMap_int_eq]
   · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
     exact one_pos
   · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
@@ -124,27 +126,12 @@ lemma Gamma0_map_le_Delta0 :
     ((Gamma0 N).map (mapGL ℚ)).toSubmonoid ≤ Delta0 N := by
   intro g hg
   obtain ⟨σ, hσ, rfl⟩ := Subgroup.mem_map.mp hg
-  have hc : ((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ZMod N) = 0 := Gamma0_mem.mp hσ
-  have hdet : (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
-      (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 * (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 = 1 := by
-    have := σ.prop
-    rwa [Matrix.det_fin_two] at this
-  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_, ?_⟩
-  · rw [mapGL_coe_matrix]
-    rfl
+  refine (mem_Delta0_iff N).mpr ⟨(σ : Matrix (Fin 2) (Fin 2) ℤ), ?_, ?_, ?_,
+    isUnit_intCast_apply_zero_zero_of_mem_Gamma0 hσ⟩
+  · simp [mapGL_coe_matrix, algebraMap_int_eq]
   · rw [mapGL_coe_matrix, (SpecialLinearGroup.map (algebraMap ℤ ℚ) σ).prop]
     exact one_pos
-  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp hc
-  · refine IsUnit.of_mul_eq_one (((σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 : ZMod N)) ?_
-    have hcast : (((σ : Matrix (Fin 2) (Fin 2) ℤ) 0 0 *
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 1 -
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 0 1 *
-        (σ : Matrix (Fin 2) (Fin 2) ℤ) 1 0 : ℤ) : ZMod N) = 1 := by
-      rw [hdet]
-      exact Int.cast_one
-    push_cast at hcast
-    rw [hc, mul_zero, sub_zero] at hcast
-    exact hcast
+  · exact (ZMod.intCast_zmod_eq_zero_iff_dvd _ _).mp (Gamma0_mem.mp hσ)
 
 /-- `Δ₀(N)` consists of integral matrices with positive determinant. -/
 lemma Delta0_le_posDetInt : Delta0 N ≤ posDetInt 2 := by

--- a/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
+++ b/TauCeti/NumberTheory/ModularForms/CongruenceSubgroups.lean
@@ -35,6 +35,8 @@ infrastructure independent of the diamond operators.
 
 * `CongruenceSubgroup.Gamma1_le_Gamma1_of_dvd`, `CongruenceSubgroup.Gamma0_le_Gamma0_of_dvd`:
   both families are antitone in the level, `Γ(N) ≤ Γ(M)` whenever `M ∣ N`.
+* `CongruenceSubgroup.isUnit_intCast_apply_zero_zero_of_mem_Gamma0`: a `Γ₀(N)` matrix has
+  unit upper-left entry modulo `N`.
 * `CongruenceSubgroup.Gamma0_normalizes_Gamma1`: conjugation by `Γ₀(N)` preserves `Γ₁(N)`.
 * `CongruenceSubgroup.Gamma1_map_le_Gamma0_map`: the inclusion `Γ₁(N) ≤ Γ₀(N)` after mapping to
   `GL₂(ℝ)`.
@@ -76,6 +78,18 @@ theorem Gamma0_le_Gamma0_of_dvd {M N : ℕ} (h : M ∣ N) : Gamma0 N ≤ Gamma0 
   intro A hA
   rw [Gamma0_mem] at hA ⊢
   simpa [map_intCast, map_one, map_zero] using congr_arg (ZMod.castHom h (ZMod M)) hA
+
+/-- The upper-left entry of a `Γ₀(N)` matrix is a unit modulo `N`: the determinant is one
+and the lower-left entry vanishes modulo `N`, so `ad ≡ 1`. -/
+theorem isUnit_intCast_apply_zero_zero_of_mem_Gamma0 {N : ℕ} {σ : SL(2, ℤ)} (hσ : σ ∈ Gamma0 N) :
+    IsUnit ((σ.1 0 0 : ℤ) : ZMod N) := by
+  have h10 : ((σ.1 1 0 : ℤ) : ZMod N) = 0 := Gamma0_mem.mp hσ
+  have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
+    Matrix.det_fin_two σ.1 ▸ σ.2
+  have hcast := congrArg (fun z : ℤ ↦ (z : ZMod N)) hdet
+  push_cast at hcast
+  rw [h10, mul_zero, sub_zero] at hcast
+  exact IsUnit.of_mul_eq_one _ hcast
 
 /-- Conjugation by a `Gamma0 N` element preserves `Gamma1 N`.
 This is the foundation for the diamond operator `⟨d⟩` on modular forms. -/
@@ -327,16 +341,10 @@ private lemma Gamma0_relindex_step_surj (k : ℕ) (hk : 0 < k) :
   obtain ⟨q, hq⟩ : (↑(p ^ k) : ℤ) ∣ σ.1 1 0 := by
     rwa [← ZMod.intCast_zmod_eq_zero_iff_dvd, ← Gamma0_mem]
   push_cast at hq
-  have h00_unit : IsUnit ((σ.1 0 0 : ℤ) : ZMod p) := by
-    have h10 : ((σ.1 1 0 : ℤ) : ZMod p) = 0 := by
+  have h00_unit : IsUnit ((σ.1 0 0 : ℤ) : ZMod p) :=
+    isUnit_intCast_apply_zero_zero_of_mem_Gamma0 (Gamma0_mem.mpr (by
       rw [ZMod.intCast_zmod_eq_zero_iff_dvd]
-      exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q
-    have hdet : σ.1 0 0 * σ.1 1 1 - σ.1 0 1 * σ.1 1 0 = 1 :=
-      Matrix.det_fin_two σ.1 ▸ σ.2
-    have hcast := congrArg (fun z : ℤ ↦ (z : ZMod p)) hdet
-    push_cast at hcast
-    rw [h10, mul_zero, sub_zero] at hcast
-    exact IsUnit.of_mul_eq_one _ hcast
+      exact hq ▸ dvd_mul_of_dvd_left (dvd_pow_self _ hk.ne') q))
   obtain ⟨c₀, hc₀⟩ := exists_dvd_sub_val_mul p q (σ.1 0 0) h00_unit
   refine ⟨⟨c₀.val, ZMod.val_lt c₀⟩, ?_⟩
   rw [QuotientGroup.eq, Subgroup.mem_subgroupOf]


### PR DESCRIPTION
Two review findings on #2108 arrived after the merge queue had already enqueued its snapshot, so they did not ride along with that merge. Both are improvements to code now in `main`.

* **The Γ₀ unit-entry argument was proved twice.** `Gamma0_map_le_Delta0` derived "an element of `Γ₀(N)` has unit upper-left entry modulo `N`" from `det = 1` and `c ≡ 0`, which is exactly the `h00_unit` block inside `Gamma0_relindex_step_surj` in `CongruenceSubgroups.lean`. It is now the public `CongruenceSubgroup.isUnit_coe_zero_zero_of_mem_Gamma0`, used at both sites.
* **Two integral-witness goals leaned on a definitional equality.** They were closed by `rfl` after rewriting `mapGL_coe_matrix`, relying on `algebraMap ℤ ℚ` being defeq to `Int.cast`. They now use `simp [mapGL_coe_matrix, algebraMap_int_eq]`, matching how `hasIntEntries_of_mem_SLnZ` states the same step.

`Gamma1.lean` consequently imports TauCeti's `ModularForms.CongruenceSubgroups` rather than Mathlib's, which is where the shared lemma lives.

No new mathematics: this is a reuse/proof-quality cleanup of merged code, which the contributing guide places in scope without a fresh roadmap claim. The roadmap chiefly motivating the code being cleaned is ModularForms (Layer 2, the Γ₁(N) Hecke triple of #2108).

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
