### PR TITLE
feat: decompose a unitary representation into orthogonal irreducibles

### DIFF
--- a/TauCeti/RepresentationTheory/Continuous/InvariantComplement.lean
+++ b/TauCeti/RepresentationTheory/Continuous/InvariantComplement.lean
@@ -4,10 +4,11 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.InnerProductSpace.Projection.Basic
+public import Mathlib.Analysis.InnerProductSpace.Projection.Submodule
 public import Mathlib.RepresentationTheory.Semisimple
 public import Mathlib.RepresentationTheory.Submodule
 public import TauCeti.RepresentationTheory.Continuous.Unitary
+public import TauCeti.RepresentationTheory.Subrepresentation
 
 /-!
 # Invariant complements of unitary continuous representations
@@ -36,6 +37,8 @@ complemented.
   `TauCeti.ContRepresentation.IsUnitary.apply_mem_orthogonal`.
 * `TauCeti.ContRepresentation.IsUnitary.isCompl_orthogonalSubrepresentation`: a subrepresentation
   admitting an orthogonal projection is complemented by its orthogonal complement.
+* `TauCeti.ContRepresentation.IsUnitary.sup_orthogonalSubrepresentation_inf`: a subrepresentation
+  together with its orthogonal complement inside a larger one recovers the larger one.
 * `TauCeti.ContRepresentation.IsUnitary.starProjection_apply_comm`: the orthogonal projection onto
   an invariant subspace commutes with the action.
 * `TauCeti.ContRepresentation.IsUnitary.isSemisimpleRepresentation` and
@@ -167,6 +170,21 @@ theorem isCompl_orthogonalSubrepresentation (hπ : IsUnitary π)
     exact Subrepresentation.toSubmodule_injective h.inf_eq_bot
   · rw [codisjoint_iff]
     exact Subrepresentation.toSubmodule_injective h.sup_eq_top
+
+/-- A subrepresentation, together with its orthogonal complement taken inside a larger
+subrepresentation, recovers that larger subrepresentation. This is
+`Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection` read in the lattice of
+subrepresentations, which is legitimate because unitarity makes the orthogonal complement
+invariant. -/
+theorem sup_orthogonalSubrepresentation_inf (hπ : IsUnitary π)
+    {σ τ : Subrepresentation π.toRepresentation} (h : σ ≤ τ)
+    [σ.toSubmodule.HasOrthogonalProjection] :
+    σ ⊔ hπ.orthogonalSubrepresentation σ ⊓ τ = τ := by
+  refine Subrepresentation.toSubmodule_injective ?_
+  rw [Subrepresentation.toSubmodule_sup, Subrepresentation.toSubmodule_inf,
+    toSubmodule_orthogonalSubrepresentation]
+  exact Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection
+    (Subrepresentation.toSubmodule_le_toSubmodule.mpr h)
 
 /-! ### Complete reducibility in finite dimensions -/
 

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -32,7 +32,7 @@ unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` is there 
 
 ## Main results
 
-* `TauCeti.ContRepresentation.IsUnitary.sup_inf_orthogonalSubrepresentation`: a subrepresentation
+* `TauCeti.ContRepresentation.IsUnitary.sup_orthogonalSubrepresentation_inf`: a subrepresentation
   together with its orthogonal complement inside a larger one recovers the larger one.
 * `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition`: complete
   reducibility in orthogonal internal form, with the dimension count that goes with it.
@@ -83,7 +83,7 @@ subrepresentation, recovers that larger subrepresentation. This is
 `Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection` read in the lattice of
 subrepresentations, which is legitimate because unitarity makes the orthogonal complement
 invariant. -/
-theorem sup_inf_orthogonalSubrepresentation (hπ : IsUnitary π)
+theorem sup_orthogonalSubrepresentation_inf (hπ : IsUnitary π)
     {σ τ : Subrepresentation π.toRepresentation} (h : σ ≤ τ)
     [σ.toSubmodule.HasOrthogonalProjection] :
     σ ⊔ hπ.orthogonalSubrepresentation σ ⊓ τ = τ := by
@@ -126,7 +126,7 @@ private theorem exists_atom_family_aux (hπ : IsUnitary π) :
     set ω : Subrepresentation π.toRepresentation := hπ.orthogonalSubrepresentation τ ⊓ σ with hω
     have hωsub : ω.toSubmodule = τ.toSubmoduleᗮ ⊓ σ.toSubmodule := by
       rw [hω, Subrepresentation.toSubmodule_inf, toSubmodule_orthogonalSubrepresentation]
-    have hsup : τ ⊔ ω = σ := hπ.sup_inf_orthogonalSubrepresentation hτσ
+    have hsup : τ ⊔ ω = σ := hπ.sup_orthogonalSubrepresentation_inf hτσ
     have hωlt : ω.toSubmodule < σ.toSubmodule := by
       refine lt_of_le_of_ne (hωsub ▸ inf_le_right) fun heq ↦ hτbot (le_bot_iff.mp ?_)
       refine Submodule.orthogonal_disjoint τ.toSubmodule le_rfl ?_

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -32,8 +32,6 @@ unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` is there 
 
 ## Main results
 
-* `TauCeti.ContRepresentation.IsUnitary.sup_orthogonalSubrepresentation_inf`: a subrepresentation
-  together with its orthogonal complement inside a larger one recovers the larger one.
 * `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition`: complete
   reducibility in orthogonal internal form, with the dimension count that goes with it.
 
@@ -77,21 +75,6 @@ namespace IsUnitary
 
 variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
   {π : ContRepresentation 𝕜 G V}
-
-/-- A subrepresentation, together with its orthogonal complement taken inside a larger
-subrepresentation, recovers that larger subrepresentation. This is
-`Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection` read in the lattice of
-subrepresentations, which is legitimate because unitarity makes the orthogonal complement
-invariant. -/
-theorem sup_orthogonalSubrepresentation_inf (hπ : IsUnitary π)
-    {σ τ : Subrepresentation π.toRepresentation} (h : σ ≤ τ)
-    [σ.toSubmodule.HasOrthogonalProjection] :
-    σ ⊔ hπ.orthogonalSubrepresentation σ ⊓ τ = τ := by
-  refine Subrepresentation.toSubmodule_injective ?_
-  rw [Subrepresentation.toSubmodule_sup, Subrepresentation.toSubmodule_inf,
-    toSubmodule_orthogonalSubrepresentation]
-  exact Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection
-    (Subrepresentation.toSubmodule_le_toSubmodule.mpr h)
 
 section FiniteDimensional
 

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -166,8 +166,10 @@ irreducible subrepresentations, and its dimension is the sum of theirs.
 
 The four conclusions say, in order: each block is irreducible; distinct blocks are orthogonal;
 the blocks decompose the space as an internal direct sum; and the dimensions add up. Unitarity is
-essential — over a general representation the blocks exist only after choosing complements, and
-they need not be orthogonal for the given inner product. -/
+essential: a general finite-dimensional representation need not decompose into irreducible
+subrepresentations at all, since an invariant subspace need not have an invariant complement.
+Unitarity supplies one, and supplies it orthogonally, which is what makes the descent go through
+and the resulting family orthogonal. -/
 theorem exists_orthogonal_irreducible_decomposition (hπ : IsUnitary π) :
     ∃ (n : ℕ) (U : Fin n → Subrepresentation π.toRepresentation),
       (∀ i, (U i).toRepresentation.IsIrreducible) ∧

--- a/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
+++ b/TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean
@@ -1,0 +1,199 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.Projection.FiniteDimensional
+public import TauCeti.RepresentationTheory.Continuous.InvariantComplement
+public import TauCeti.RepresentationTheory.Irreducible
+
+/-!
+# The orthogonal decomposition of a unitary representation into irreducibles
+
+A finite-dimensional unitary continuous representation of a group is an **orthogonal internal
+direct sum of irreducible subrepresentations**. This is the geometric — as opposed to
+lattice-theoretic — form of complete reducibility: not merely that every subrepresentation has a
+complement, but that the whole space is cut into finitely many mutually orthogonal irreducible
+blocks.
+
+The proof is the classical descent. A nonzero subrepresentation of a finite-dimensional
+representation contains an atom of the lattice of subrepresentations
+(`TauCeti.Representation.exists_isAtom_le`), and an atom carries an irreducible representation
+(`TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom`). Unitarity enters exactly
+once, to split off that atom orthogonally: the orthogonal complement of an invariant subspace is
+again invariant (`TauCeti.ContRepresentation.IsUnitary.orthogonal_mem_invtSubmodule`), so the
+remainder is a strictly smaller subrepresentation and the descent recurses on it.
+
+No measure, no compactness, and no continuity of the representation are used: the argument runs on
+a `ContRepresentation` only because that is where `TauCeti.ContRepresentation.IsUnitary` lives, and
+the acting group may be arbitrary. For a compact group the unitarity hypothesis is what Weyl's
+unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` is there to supply.
+
+## Main results
+
+* `TauCeti.ContRepresentation.IsUnitary.sup_inf_orthogonalSubrepresentation`: a subrepresentation
+  together with its orthogonal complement inside a larger one recovers the larger one.
+* `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition`: complete
+  reducibility in orthogonal internal form, with the dimension count that goes with it.
+
+## Implementation notes
+
+Invariant subspaces are carried as `Subrepresentation π.toRepresentation` rather than as bare
+submodules with an invariance side condition: the lattice operations, the atoms, and the
+`toRepresentation` needed to say "irreducible" are then all Mathlib's, and the translation to
+submodules is `Subrepresentation.toSubmodule_le_toSubmodule` and its relatives.
+
+Orthogonality of the resulting family is stated as Mathlib's `OrthogonalFamily`, which unfolds to
+the pairwise vanishing of inner products between distinct blocks and is the form the orthogonal
+projection API consumes; `DirectSum.IsInternal` is then read off it through
+`OrthogonalFamily.isInternal_iff`.
+
+## References
+
+This is the target `exists_orthogonal_irreducible_decomposition` of Layer 2 of the
+[compact-groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md).
+The mathematical development follows Daniel Bump, *Lie Groups*, second edition, Chapter 2.
+-/
+
+public section
+
+open scoped InnerProductSpace
+
+namespace TauCeti
+
+/-- Splitting the supremum of a family indexed by `Fin (n + 1)` off its first member. -/
+private theorem iSup_fin_succ {α : Type*} [CompleteLattice α] {n : ℕ} (f : Fin (n + 1) → α) :
+    ⨆ i, f i = f 0 ⊔ ⨆ i : Fin n, f i.succ := by
+  refine le_antisymm (iSup_le fun i ↦ ?_)
+    (sup_le (le_iSup f 0) (iSup_le fun j ↦ le_iSup f j.succ))
+  rcases Fin.eq_zero_or_eq_succ i with rfl | ⟨j, rfl⟩
+  · exact le_sup_left
+  · exact le_sup_of_le_right (le_iSup (fun j : Fin n ↦ f j.succ) j)
+
+namespace ContRepresentation
+
+namespace IsUnitary
+
+variable {𝕜 G V : Type*} [RCLike 𝕜] [Group G] [NormedAddCommGroup V] [InnerProductSpace 𝕜 V]
+  {π : ContRepresentation 𝕜 G V}
+
+/-- A subrepresentation, together with its orthogonal complement taken inside a larger
+subrepresentation, recovers that larger subrepresentation. This is
+`Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection` read in the lattice of
+subrepresentations, which is legitimate because unitarity makes the orthogonal complement
+invariant. -/
+theorem sup_inf_orthogonalSubrepresentation (hπ : IsUnitary π)
+    {σ τ : Subrepresentation π.toRepresentation} (h : σ ≤ τ)
+    [σ.toSubmodule.HasOrthogonalProjection] :
+    σ ⊔ hπ.orthogonalSubrepresentation σ ⊓ τ = τ := by
+  refine Subrepresentation.toSubmodule_injective ?_
+  rw [Subrepresentation.toSubmodule_sup, Subrepresentation.toSubmodule_inf,
+    toSubmodule_orthogonalSubrepresentation]
+  exact Submodule.sup_orthogonal_inf_of_hasOrthogonalProjection
+    (Subrepresentation.toSubmodule_le_toSubmodule.mpr h)
+
+section FiniteDimensional
+
+variable [FiniteDimensional 𝕜 V]
+
+/-- The descent behind `exists_orthogonal_irreducible_decomposition`: every subrepresentation of a
+finite-dimensional unitary representation is the supremum of a finite, pairwise orthogonal family
+of atoms. The extra numeral `m` is a bound on the dimension, giving the induction something to
+decrease. -/
+private theorem exists_atom_family_aux (hπ : IsUnitary π) :
+    ∀ (m : ℕ) (σ : Subrepresentation π.toRepresentation),
+      Module.finrank 𝕜 σ.toSubmodule ≤ m →
+      ∃ (n : ℕ) (U : Fin n → Subrepresentation π.toRepresentation),
+        (∀ i, IsAtom (U i)) ∧ ⨆ i, (U i).toSubmodule = σ.toSubmodule ∧
+          Pairwise fun i j ↦
+            ∀ v ∈ (U i).toSubmodule, ∀ w ∈ (U j).toSubmodule, ⟪v, w⟫_𝕜 = 0 := by
+  intro m
+  induction m with
+  | zero =>
+    intro σ hle
+    refine ⟨0, Fin.elim0, fun i ↦ i.elim0, ?_, fun i ↦ i.elim0⟩
+    rw [iSup_of_empty, Submodule.finrank_eq_zero.mp (Nat.le_zero.mp hle)]
+  | succ m ih =>
+    intro σ hle
+    rcases eq_or_ne σ ⊥ with rfl | hσ
+    · exact ⟨0, Fin.elim0, fun i ↦ i.elim0, by rw [iSup_of_empty,
+        Subrepresentation.toSubmodule_bot], fun i ↦ i.elim0⟩
+    obtain ⟨τ, hτσ, hτ⟩ := Representation.exists_isAtom_le hσ
+    have hτbot : τ.toSubmodule ≠ ⊥ := fun hc ↦ hτ.1 (Subrepresentation.toSubmodule_injective
+      (hc.trans Subrepresentation.toSubmodule_bot.symm))
+    -- the orthogonal complement of the atom inside `σ`
+    set ω : Subrepresentation π.toRepresentation := hπ.orthogonalSubrepresentation τ ⊓ σ with hω
+    have hωsub : ω.toSubmodule = τ.toSubmoduleᗮ ⊓ σ.toSubmodule := by
+      rw [hω, Subrepresentation.toSubmodule_inf, toSubmodule_orthogonalSubrepresentation]
+    have hsup : τ ⊔ ω = σ := hπ.sup_inf_orthogonalSubrepresentation hτσ
+    have hωlt : ω.toSubmodule < σ.toSubmodule := by
+      refine lt_of_le_of_ne (hωsub ▸ inf_le_right) fun heq ↦ hτbot (le_bot_iff.mp ?_)
+      refine Submodule.orthogonal_disjoint τ.toSubmodule le_rfl ?_
+      calc τ.toSubmodule ≤ σ.toSubmodule := Subrepresentation.toSubmodule_le_toSubmodule.mpr hτσ
+        _ = ω.toSubmodule := heq.symm
+        _ ≤ τ.toSubmoduleᗮ := hωsub ▸ inf_le_left
+    have hωle : Module.finrank 𝕜 ω.toSubmodule ≤ m := by
+      have := Submodule.finrank_lt_finrank_of_lt hωlt
+      omega
+    obtain ⟨n, U, hatom, hiSup, horth⟩ := ih ω hωle
+    -- every block of the recursive decomposition lands in the orthogonal complement of the atom
+    have hUorth : ∀ j : Fin n, (U j).toSubmodule ≤ τ.toSubmoduleᗮ := fun j ↦
+      le_trans (hiSup ▸ le_iSup (fun i ↦ (U i).toSubmodule) j) (hωsub ▸ inf_le_left)
+    have hmix : ∀ (j : Fin n), ∀ v ∈ τ.toSubmodule, ∀ w ∈ (U j).toSubmodule, ⟪v, w⟫_𝕜 = 0 :=
+      fun j v hv w hw ↦ (Submodule.mem_orthogonal _ w).mp (hUorth j hw) v hv
+    refine ⟨n + 1, Fin.cons τ U, ?_, ?_, ?_⟩
+    · intro i
+      rcases Fin.eq_zero_or_eq_succ i with rfl | ⟨j, rfl⟩
+      · simpa using hτ
+      · simpa using hatom j
+    · rw [iSup_fin_succ]
+      simp only [Fin.cons_zero, Fin.cons_succ]
+      rw [hiSup, ← Subrepresentation.toSubmodule_sup, hsup]
+    · intro i j hij
+      rcases Fin.eq_zero_or_eq_succ i with rfl | ⟨i', rfl⟩ <;>
+        rcases Fin.eq_zero_or_eq_succ j with rfl | ⟨j', rfl⟩
+      · exact absurd rfl hij
+      · simpa using hmix j'
+      · intro v hv w hw
+        simp only [Fin.cons_succ, Fin.cons_zero] at hv hw
+        exact inner_eq_zero_symm.mp (hmix i' w hw v hv)
+      · simpa using horth fun hc ↦ hij (by rw [hc])
+
+/-- **Complete reducibility, orthogonal internal form.** A finite-dimensional unitary continuous
+representation of a group decomposes as an orthogonal internal direct sum of finitely many
+irreducible subrepresentations, and its dimension is the sum of theirs.
+
+The four conclusions say, in order: each block is irreducible; distinct blocks are orthogonal;
+the blocks decompose the space as an internal direct sum; and the dimensions add up. Unitarity is
+essential — over a general representation the blocks exist only after choosing complements, and
+they need not be orthogonal for the given inner product. -/
+theorem exists_orthogonal_irreducible_decomposition (hπ : IsUnitary π) :
+    ∃ (n : ℕ) (U : Fin n → Subrepresentation π.toRepresentation),
+      (∀ i, (U i).toRepresentation.IsIrreducible) ∧
+      OrthogonalFamily 𝕜 (fun i ↦ (U i).toSubmodule) (fun i ↦ ((U i).toSubmodule).subtypeₗᵢ) ∧
+      DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) ∧
+      Module.finrank 𝕜 V = ∑ i, Module.finrank 𝕜 (U i).toSubmodule := by
+  classical
+  obtain ⟨n, U, hatom, hiSup, horth⟩ :=
+    hπ.exists_atom_family_aux (Module.finrank 𝕜 V) ⊤
+      (le_of_eq (by rw [Subrepresentation.toSubmodule_top, finrank_top]))
+  have hfamily :
+      OrthogonalFamily 𝕜 (fun i ↦ (U i).toSubmodule) (fun i ↦ ((U i).toSubmodule).subtypeₗᵢ) :=
+    fun i j hij v w ↦ horth hij v v.2 w w.2
+  have htop : ⨆ i, (U i).toSubmodule = ⊤ := by
+    rw [hiSup, Subrepresentation.toSubmodule_top]
+  have hinternal : DirectSum.IsInternal (fun i ↦ (U i).toSubmodule) :=
+    hfamily.isInternal_iff.mpr (by rw [htop, Submodule.top_orthogonal_eq_bot])
+  refine ⟨n, U, fun i ↦ Representation.isIrreducible_toRepresentation_of_isAtom (hatom i),
+    hfamily, hinternal, ?_⟩
+  rw [← (LinearEquiv.ofBijective (DirectSum.coeLinearMap fun i ↦ (U i).toSubmodule)
+    hinternal).finrank_eq, Module.finrank_directSum]
+
+end FiniteDimensional
+
+end IsUnitary
+
+end ContRepresentation
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -43,7 +43,7 @@ irreducible by.
   subrepresentations carries an irreducible representation.
 * `TauCeti.Representation.isIrreducible_of_asAlgebraHom_surjective`: a representation whose
   algebra map exhausts the endomorphisms is irreducible.
-* `TauCeti.Representation.exists_isAtom_le`: in finite dimensions every nonzero subrepresentation
+* `TauCeti.Representation.exists_isAtom_le`: every nonzero finite-dimensional subrepresentation
   contains an atom, so the atom criterion always has something to apply to.
 * `TauCeti.Representation.exists_isIrreducible_subrepresentation`: consequently every nonzero
   finite-dimensional representation contains an irreducible subrepresentation.
@@ -140,39 +140,46 @@ theorem isIrreducible_of_asAlgebraHom_surjective [Nontrivial V] (ρ : Representa
 /-- The engine behind `TauCeti.Representation.exists_isAtom_le`: descend from a nonzero
 subrepresentation to a smaller nonzero one until the descent stops, which it must, because the
 subspace carried by a subrepresentation drops dimension at every step. -/
-private theorem exists_isAtom_le_aux [FiniteDimensional k V] {ρ : Representation k G V} :
-    ∀ n : ℕ, ∀ σ : Subrepresentation ρ, Module.finrank k σ.toSubmodule ≤ n → σ ≠ ⊥ →
+private theorem exists_isAtom_le_aux {ρ : Representation k G V} :
+    ∀ n : ℕ, ∀ σ : Subrepresentation ρ, FiniteDimensional k σ.toSubmodule →
+      Module.finrank k σ.toSubmodule ≤ n → σ ≠ ⊥ →
       ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ := by
   intro n
   induction n with
   | zero =>
-    intro σ hle hne
+    intro σ hfin hle hne
+    have := hfin
     exact absurd (Subrepresentation.toSubmodule_injective
       ((Submodule.finrank_eq_zero.mp (Nat.le_zero.mp hle)).trans
         Subrepresentation.toSubmodule_bot.symm)) hne
   | succ n ih =>
-    intro σ hle hne
+    intro σ hfin hle hne
+    have := hfin
     by_cases hatom : IsAtom σ
     · exact ⟨σ, le_rfl, hatom⟩
     · obtain ⟨υ, hυσ, hυ⟩ : ∃ υ : Subrepresentation ρ, υ < σ ∧ υ ≠ ⊥ := by
         by_contra hcon
         push Not at hcon
         exact hatom ⟨hne, fun υ hυ => hcon υ hυ⟩
+      have hltsub : υ.toSubmodule < σ.toSubmodule :=
+        Subrepresentation.toSubmodule_lt_toSubmodule.mpr hυσ
       have hlt : Module.finrank k υ.toSubmodule < Module.finrank k σ.toSubmodule :=
-        Submodule.finrank_lt_finrank_of_lt (Subrepresentation.toSubmodule_lt_toSubmodule.mpr hυσ)
-      obtain ⟨τ, hτυ, hτ⟩ := ih υ (by omega) hυ
+        Submodule.finrank_lt_finrank_of_lt hltsub
+      obtain ⟨τ, hτυ, hτ⟩ := ih υ (Submodule.finiteDimensional_of_le hltsub.le) (by omega) hυ
       exact ⟨τ, hτυ.trans hυσ.le, hτ⟩
 
-/-- **Atoms exist.** In a finite-dimensional representation every nonzero subrepresentation
-contains an atom of the lattice of subrepresentations.
+/-- **Atoms exist.** Every nonzero finite-dimensional subrepresentation contains an atom of the
+lattice of subrepresentations.
 
-Finite-dimensionality is what makes the descent to a minimal nonzero subrepresentation terminate;
-it is a hypothesis on the ambient representation, not on the acting monoid, which stays arbitrary.
-Combined with `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` it exhibits an
-irreducible subrepresentation inside any nonzero one. -/
-theorem exists_isAtom_le [FiniteDimensional k V] {ρ : Representation k G V}
-    {σ : Subrepresentation ρ} (hσ : σ ≠ ⊥) : ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ :=
-  exists_isAtom_le_aux (Module.finrank k σ.toSubmodule) σ le_rfl hσ
+Finite-dimensionality is what makes the descent to a minimal nonzero subrepresentation terminate,
+and only the subrepresentation being descended through has to be finite-dimensional: the ambient
+representation may be infinite-dimensional, and the acting monoid stays arbitrary.  Combined with
+`TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` it exhibits an irreducible
+subrepresentation inside any nonzero one. -/
+theorem exists_isAtom_le {ρ : Representation k G V} {σ : Subrepresentation ρ}
+    [FiniteDimensional k σ.toSubmodule] (hσ : σ ≠ ⊥) :
+    ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ :=
+  exists_isAtom_le_aux (Module.finrank k σ.toSubmodule) σ inferInstance le_rfl hσ
 
 /-- **Every nonzero finite-dimensional representation contains an irreducible subrepresentation.**
 Finite-dimensionality alone suffices; no semisimplicity is assumed.  This produces a single

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.RepresentationTheory.Subrepresentation
 public import Mathlib.RingTheory.SimpleModule.Rank
@@ -169,14 +168,16 @@ contains an atom of the lattice of subrepresentations.
 
 Finite-dimensionality is what makes the descent to a minimal nonzero subrepresentation terminate;
 it is a hypothesis on the ambient representation, not on the acting monoid, which stays arbitrary.
-Combined with `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` this is the
-statement that a finite-dimensional representation is built from irreducible pieces. -/
+Combined with `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` it exhibits an
+irreducible subrepresentation inside any nonzero one. -/
 theorem exists_isAtom_le [FiniteDimensional k V] {ρ : Representation k G V}
     {σ : Subrepresentation ρ} (hσ : σ ≠ ⊥) : ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ :=
   exists_isAtom_le_aux (Module.finrank k σ.toSubmodule) σ le_rfl hσ
 
-/-- **Every nonzero finite-dimensional representation contains an irreducible.** This is the
-existence half of complete reducibility, available with no semisimplicity hypothesis at all. -/
+/-- **Every nonzero finite-dimensional representation contains an irreducible subrepresentation.**
+Finite-dimensionality alone suffices; no semisimplicity is assumed.  This produces a single
+irreducible subrepresentation, not a decomposition: a representation that is not semisimple need
+not be the sum of its irreducible subrepresentations. -/
 theorem exists_isIrreducible_subrepresentation [FiniteDimensional k V] [Nontrivial V]
     (ρ : Representation k G V) :
     ∃ σ : Subrepresentation ρ, σ ≠ ⊥ ∧ σ.toRepresentation.IsIrreducible := by

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.LinearAlgebra.FiniteDimensional.Lemmas
 public import Mathlib.RepresentationTheory.Irreducible
 public import TauCeti.RepresentationTheory.Subrepresentation
 public import Mathlib.RingTheory.SimpleModule.Rank
@@ -12,7 +13,8 @@ public import Mathlib.RingTheory.SimpleModule.Rank
 # Criteria for irreducibility
 
 This file collects three ways of recognising an irreducible representation from outside, without
-inspecting its subrepresentations one by one.
+inspecting its subrepresentations one by one, and the finite-dimensional existence statement that
+makes the second of them usable.
 
 A representation on a one-dimensional vector space is irreducible, whatever the group and however
 it acts: a subrepresentation is in particular a subspace, and a line has only the two trivial
@@ -42,6 +44,10 @@ irreducible by.
   subrepresentations carries an irreducible representation.
 * `TauCeti.Representation.isIrreducible_of_asAlgebraHom_surjective`: a representation whose
   algebra map exhausts the endomorphisms is irreducible.
+* `TauCeti.Representation.exists_isAtom_le`: in finite dimensions every nonzero subrepresentation
+  contains an atom, so the atom criterion always has something to apply to.
+* `TauCeti.Representation.exists_isIrreducible_subrepresentation`: consequently every nonzero
+  finite-dimensional representation contains an irreducible subrepresentation.
 
 ## References
 
@@ -129,6 +135,57 @@ theorem isIrreducible_of_asAlgebraHom_surjective [Nontrivial V] (ρ : Representa
   obtain ⟨r, rfl⟩ := h T
   refine ⟨r, ρ.asModuleEquiv.injective ?_⟩
   rw [LinearMap.toSpanSingleton_apply, _root_.Representation.asModuleEquiv_map_smul, hT]
+
+/-! ### Atoms exist in finite dimensions -/
+
+/-- The engine behind `TauCeti.Representation.exists_isAtom_le`: descend from a nonzero
+subrepresentation to a smaller nonzero one until the descent stops, which it must, because the
+subspace carried by a subrepresentation drops dimension at every step. -/
+private theorem exists_isAtom_le_aux [FiniteDimensional k V] {ρ : Representation k G V} :
+    ∀ n : ℕ, ∀ σ : Subrepresentation ρ, Module.finrank k σ.toSubmodule ≤ n → σ ≠ ⊥ →
+      ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ := by
+  intro n
+  induction n with
+  | zero =>
+    intro σ hle hne
+    exact absurd (Subrepresentation.toSubmodule_injective
+      ((Submodule.finrank_eq_zero.mp (Nat.le_zero.mp hle)).trans
+        Subrepresentation.toSubmodule_bot.symm)) hne
+  | succ n ih =>
+    intro σ hle hne
+    by_cases hatom : IsAtom σ
+    · exact ⟨σ, le_rfl, hatom⟩
+    · obtain ⟨υ, hυσ, hυ⟩ : ∃ υ : Subrepresentation ρ, υ < σ ∧ υ ≠ ⊥ := by
+        by_contra hcon
+        push Not at hcon
+        exact hatom ⟨hne, fun υ hυ => hcon υ hυ⟩
+      have hlt : Module.finrank k υ.toSubmodule < Module.finrank k σ.toSubmodule :=
+        Submodule.finrank_lt_finrank_of_lt (Subrepresentation.toSubmodule_lt_toSubmodule.mpr hυσ)
+      obtain ⟨τ, hτυ, hτ⟩ := ih υ (by omega) hυ
+      exact ⟨τ, hτυ.trans hυσ.le, hτ⟩
+
+/-- **Atoms exist.** In a finite-dimensional representation every nonzero subrepresentation
+contains an atom of the lattice of subrepresentations.
+
+Finite-dimensionality is what makes the descent to a minimal nonzero subrepresentation terminate;
+it is a hypothesis on the ambient representation, not on the acting monoid, which stays arbitrary.
+Combined with `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` this is the
+statement that a finite-dimensional representation is built from irreducible pieces. -/
+theorem exists_isAtom_le [FiniteDimensional k V] {ρ : Representation k G V}
+    {σ : Subrepresentation ρ} (hσ : σ ≠ ⊥) : ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ :=
+  exists_isAtom_le_aux (Module.finrank k σ.toSubmodule) σ le_rfl hσ
+
+/-- **Every nonzero finite-dimensional representation contains an irreducible.** This is the
+existence half of complete reducibility, available with no semisimplicity hypothesis at all. -/
+theorem exists_isIrreducible_subrepresentation [FiniteDimensional k V] [Nontrivial V]
+    (ρ : Representation k G V) :
+    ∃ σ : Subrepresentation ρ, σ ≠ ⊥ ∧ σ.toRepresentation.IsIrreducible := by
+  have htop : (⊤ : Subrepresentation ρ) ≠ ⊥ := fun hc =>
+    top_ne_bot (α := Submodule k V) (by
+      rw [← Subrepresentation.toSubmodule_top (ρ := ρ), ← Subrepresentation.toSubmodule_bot
+        (ρ := ρ), hc])
+  obtain ⟨σ, -, hσ⟩ := exists_isAtom_le htop
+  exact ⟨σ, hσ.1, isIrreducible_toRepresentation_of_isAtom hσ⟩
 
 end Representation
 

--- a/TauCeti/RepresentationTheory/Irreducible.lean
+++ b/TauCeti/RepresentationTheory/Irreducible.lean
@@ -137,49 +137,32 @@ theorem isIrreducible_of_asAlgebraHom_surjective [Nontrivial V] (ρ : Representa
 
 /-! ### Atoms exist in finite dimensions -/
 
-/-- The engine behind `TauCeti.Representation.exists_isAtom_le`: descend from a nonzero
-subrepresentation to a smaller nonzero one until the descent stops, which it must, because the
-subspace carried by a subrepresentation drops dimension at every step. -/
-private theorem exists_isAtom_le_aux {ρ : Representation k G V} :
-    ∀ n : ℕ, ∀ σ : Subrepresentation ρ, FiniteDimensional k σ.toSubmodule →
-      Module.finrank k σ.toSubmodule ≤ n → σ ≠ ⊥ →
-      ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ := by
-  intro n
-  induction n with
-  | zero =>
-    intro σ hfin hle hne
-    have := hfin
-    exact absurd (Subrepresentation.toSubmodule_injective
-      ((Submodule.finrank_eq_zero.mp (Nat.le_zero.mp hle)).trans
-        Subrepresentation.toSubmodule_bot.symm)) hne
-  | succ n ih =>
-    intro σ hfin hle hne
-    have := hfin
-    by_cases hatom : IsAtom σ
-    · exact ⟨σ, le_rfl, hatom⟩
-    · obtain ⟨υ, hυσ, hυ⟩ : ∃ υ : Subrepresentation ρ, υ < σ ∧ υ ≠ ⊥ := by
-        by_contra hcon
-        push Not at hcon
-        exact hatom ⟨hne, fun υ hυ => hcon υ hυ⟩
-      have hltsub : υ.toSubmodule < σ.toSubmodule :=
-        Subrepresentation.toSubmodule_lt_toSubmodule.mpr hυσ
-      have hlt : Module.finrank k υ.toSubmodule < Module.finrank k σ.toSubmodule :=
-        Submodule.finrank_lt_finrank_of_lt hltsub
-      obtain ⟨τ, hτυ, hτ⟩ := ih υ (Submodule.finiteDimensional_of_le hltsub.le) (by omega) hυ
-      exact ⟨τ, hτυ.trans hυσ.le, hτ⟩
-
 /-- **Atoms exist.** Every nonzero finite-dimensional subrepresentation contains an atom of the
 lattice of subrepresentations.
 
-Finite-dimensionality is what makes the descent to a minimal nonzero subrepresentation terminate,
-and only the subrepresentation being descended through has to be finite-dimensional: the ambient
-representation may be infinite-dimensional, and the acting monoid stays arbitrary.  Combined with
+Finite-dimensionality is what makes a minimal nonzero subrepresentation exist, and only the
+subrepresentation being minimised inside has to be finite-dimensional: the ambient representation
+may be infinite-dimensional, and the acting monoid stays arbitrary.  Combined with
 `TauCeti.Representation.isIrreducible_toRepresentation_of_isAtom` it exhibits an irreducible
 subrepresentation inside any nonzero one. -/
 theorem exists_isAtom_le {ρ : Representation k G V} {σ : Subrepresentation ρ}
     [FiniteDimensional k σ.toSubmodule] (hσ : σ ≠ ⊥) :
-    ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ :=
-  exists_isAtom_le_aux (Module.finrank k σ.toSubmodule) σ inferInstance le_rfl hσ
+    ∃ τ : Subrepresentation ρ, τ ≤ σ ∧ IsAtom τ := by
+  -- Among the nonzero subrepresentations contained in `σ`, pick one whose subspace has least
+  -- dimension; the dimensions are natural numbers, so such a one exists.
+  obtain ⟨τ, hmin⟩ :=
+    exists_minimalFor_of_wellFoundedLT (fun τ : Subrepresentation ρ => τ ≠ ⊥ ∧ τ ≤ σ)
+      (fun τ => Module.finrank k τ.toSubmodule) ⟨σ, hσ, le_rfl⟩
+  obtain ⟨hτ, hτσ⟩ := hmin.1
+  have : FiniteDimensional k τ.toSubmodule :=
+    Submodule.finiteDimensional_of_le (Subrepresentation.toSubmodule_le_toSubmodule.mpr hτσ)
+  -- Anything strictly inside `τ` is again inside `σ` and of strictly smaller dimension, so
+  -- minimality forces it to be zero.
+  refine ⟨τ, hτσ, hτ, fun υ hυ => ?_⟩
+  by_contra hυ0
+  exact hmin.not_prop_of_lt
+    (Submodule.finrank_lt_finrank_of_lt (Subrepresentation.toSubmodule_lt_toSubmodule.mpr hυ))
+    ⟨hυ0, hυ.le.trans hτσ⟩
 
 /-- **Every nonzero finite-dimensional representation contains an irreducible subrepresentation.**
 Finite-dimensionality alone suffices; no semisimplicity is assumed.  This produces a single

--- a/TauCeti/RepresentationTheory/Subrepresentation.lean
+++ b/TauCeti/RepresentationTheory/Subrepresentation.lean
@@ -7,21 +7,27 @@ module
 public import Mathlib.RepresentationTheory.Subrepresentation
 
 /-!
-# The extreme subrepresentations carry the extreme subspaces
+# `toSubmodule` against the order on subrepresentations
 
 Mathlib's `Subrepresentation` API records how `toSubmodule` interacts with the lattice
 operations — `Subrepresentation.toSubmodule_sup` and `Subrepresentation.toSubmodule_inf`, both
-`@[simp]` and both true by `rfl` — but not how it interacts with the bounded-lattice structure.
-This file adds the two missing counterparts, in the same shape.
+`@[simp]` and both true by `rfl` — but not how it interacts with the bounded-lattice structure,
+nor how it interacts with the order relations themselves. This file adds the four missing
+counterparts, in the same shape.
 
 They are stated at the typeclasses `Subrepresentation` itself asks for, so they apply wherever
-the abstraction does, and they let proofs about `⊥` and `⊤` subrepresentations avoid asserting
-the definitional unfolding of the `BoundedOrder` instance by hand.
+the abstraction does. The `⊥` and `⊤` lemmas let proofs about extreme subrepresentations avoid
+asserting the definitional unfolding of the `BoundedOrder` instance by hand; the `≤` and `<`
+lemmas move an order statement between the two lattices, which is what lets a submodule-level
+argument — a dimension count, say, or an orthogonal complement — settle a question about
+subrepresentations.
 
 ## Main results
 
 * `Subrepresentation.toSubmodule_bot`
 * `Subrepresentation.toSubmodule_top`
+* `Subrepresentation.toSubmodule_le_toSubmodule`
+* `Subrepresentation.toSubmodule_lt_toSubmodule`
 -/
 
 public section
@@ -38,5 +44,17 @@ lemma toSubmodule_bot : (⊥ : Subrepresentation ρ).toSubmodule = ⊥ := rfl
 /-- The top subrepresentation carries the top subspace. -/
 @[simp]
 lemma toSubmodule_top : (⊤ : Subrepresentation ρ).toSubmodule = ⊤ := rfl
+
+/-- One subrepresentation is contained in another exactly when the subspace it carries is. -/
+@[simp]
+lemma toSubmodule_le_toSubmodule {ρ₁ ρ₂ : Subrepresentation ρ} :
+    ρ₁.toSubmodule ≤ ρ₂.toSubmodule ↔ ρ₁ ≤ ρ₂ := Iff.rfl
+
+/-- One subrepresentation is strictly contained in another exactly when the subspace it carries
+is. -/
+@[simp]
+lemma toSubmodule_lt_toSubmodule {ρ₁ ρ₂ : Subrepresentation ρ} :
+    ρ₁.toSubmodule < ρ₂.toSubmodule ↔ ρ₁ < ρ₂ := by
+  simp only [lt_iff_le_not_ge, toSubmodule_le_toSubmodule]
 
 end Subrepresentation


### PR DESCRIPTION
This PR proves complete reducibility in its geometric, internal form: a finite-dimensional unitary continuous representation of a group decomposes as an orthogonal internal direct sum of finitely many irreducible subrepresentations, together with the dimension count that goes with it. The new `TauCeti/RepresentationTheory/Continuous/OrthogonalDecomposition.lean` states it as `TauCeti.ContRepresentation.IsUnitary.exists_orthogonal_irreducible_decomposition`, the target of that name pinned in `TauCetiRoadmap/RepresentationTheory/CompactGroups/Suggested.lean` for the "Complete reducibility, primary (internal) form" milestone of Layer 2 ("Complete reducibility") of `TauCetiRoadmap/RepresentationTheory/CompactGroups/README.md`. What already existed was the lattice-theoretic shadow — `TauCeti.ContRepresentation.IsUnitary.isSemisimpleRepresentation`, that every subrepresentation has a complement; what was missing is the statement that the whole space is actually cut into mutually orthogonal irreducible blocks, which is what the matrix-coefficient and Schur-orthogonality layers above it consume.

The proof is the classical descent, and it is stated at the generality the argument really has: no measure, no compactness, and no continuity of the representation are used, so the hypotheses are `[RCLike 𝕜]`, an arbitrary group `G`, a finite-dimensional inner product space, and `IsUnitary π`. For a compact group that last hypothesis is what Weyl's unitarian trick in `TauCeti.RepresentationTheory.Compact.Unitarizable` exists to supply. Unitarity enters exactly once, to split an atom off orthogonally via the already-proved `IsUnitary.orthogonal_mem_invtSubmodule`; everything else is dimension induction. Orthogonality of the resulting family is stated as Mathlib's `OrthogonalFamily`, from which `DirectSum.IsInternal` is read off through `OrthogonalFamily.isInternal_iff`, and the blocks are carried as `Subrepresentation π.toRepresentation` so that "irreducible" is Mathlib's `Representation.IsIrreducible` applied to Mathlib's `toRepresentation`, with no new predicate introduced.

Two prerequisites the descent needs are added where they belong rather than inlined. `TauCeti/RepresentationTheory/Subrepresentation.lean`, which already records how `toSubmodule` meets `⊥` and `⊤`, gains the two order counterparts `Subrepresentation.toSubmodule_le_toSubmodule` and `Subrepresentation.toSubmodule_lt_toSubmodule`, which are what let a submodule-level dimension count settle a question about subrepresentations. `TauCeti/RepresentationTheory/Irreducible.lean`, which already proves that an atom of the subrepresentation lattice carries an irreducible representation, gains the existence half that makes that criterion applicable: `TauCeti.Representation.exists_isAtom_le`, every nonzero subrepresentation of a finite-dimensional representation contains an atom, and the immediate corollary `TauCeti.Representation.exists_isIrreducible_subrepresentation`. Both are about plain `Representation`s over a field with an arbitrary acting monoid, so they carry none of the analytic context.

No Mathlib source is vendored. `lake build` and `lake exe axioms` are green (all 25045 audited declarations within `[propext, Classical.choice, Quot.sound]`), as is the environment-linter set on the touched modules.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"exists-orthogonal-irreducible-decomposition"}-->

🤖 Prepared with Claude Code
