### PR TITLE
feat: the Galois action on character values

### DIFF
--- a/TauCeti/LinearAlgebra/End/FiniteOrder.lean
+++ b/TauCeti/LinearAlgebra/End/FiniteOrder.lean
@@ -23,10 +23,14 @@ is then squarefree.
 
 Over an algebraically closed field semisimplicity is diagonalizability, so the eigenspaces of such
 an `f` decompose the space. Every power of `f` acts on the `μ`-eigenspace as the scalar `μ ^ m`,
-which turns the trace of `f ^ m` into the sum `∑ μ, dim(V_μ) * μ ^ m` over the eigenvalues. Over `ℂ`
-the eigenvalues are roots of unity, so complex conjugation sends `μ` to `μ⁻¹ = μ ^ (n - 1)` and the
-trace of `f` is conjugated by passing to `f ^ (n - 1)`, that is, to the inverse of `f`. That last
-statement is the source of `conj (χ g) = χ g⁻¹` for characters of complex representations.
+which turns the trace of `f ^ m` into the sum `∑ μ, dim(V_μ) * μ ^ m` over the eigenvalues.
+
+That sum is what makes the trace transform predictably under a ring endomorphism `σ` of the
+coefficient field: the dimensions are natural numbers and so are fixed by `σ`, so if `σ` raises
+every `n`-th root of unity to the `j`-th power then `σ (tr f) = tr (f ^ j)`. Over `ℂ` complex
+conjugation is such a `σ`, with `j = n - 1`, since it sends a root of unity `μ` to
+`μ⁻¹ = μ ^ (n - 1)`; that instance is the source of `conj (χ g) = χ g⁻¹` for characters of complex
+representations.
 
 All the results are stated of `Module.End`, so they sit in the `End` namespace under `open Module`.
 
@@ -39,6 +43,9 @@ All the results are stated of `Module.End`, so they sit in the `End` namespace u
 * `TauCeti.End.trace_pow_eq_sum_eigenvalue_pow`: over an algebraically closed field, the trace of
   `f ^ m` is the sum of the `m`-th powers of the eigenvalues of `f`, weighted by the dimensions of
   the eigenspaces.
+* `TauCeti.End.map_trace_eq_trace_pow`: a ring endomorphism raising every `n`-th root of unity to
+  the `j`-th power sends the trace of an endomorphism of finite order `n` to the trace of its
+  `j`-th power.
 * `TauCeti.End.conj_trace_eq_trace_pow_sub_one`: over `ℂ`, the conjugate of the trace of an
   endomorphism of finite order `n` is the trace of its inverse `f ^ (n - 1)`.
 -/
@@ -127,6 +134,20 @@ theorem trace_pow_eq_sum_eigenvalue_pow (hn : (n : k) ≠ 0) (hf : f ^ n = 1) (m
     (End.finite_hasEigenvalue f) (mapsTo_pow_eigenspace f · m)]
   exact Finset.sum_congr rfl fun μ _ => trace_restrict_eigenspace f μ m
 
+/-- **A ring endomorphism raising the roots of unity to the `j`-th power raises an endomorphism of
+finite order to the `j`-th power, as far as the trace can see**: if `f ^ n = 1` and `σ μ = μ ^ j`
+for every `n`-th root of unity `μ`, then `σ (tr f) = tr (f ^ j)`. Both sides are the sum
+`∑ μ, dim(V_μ) · μ ^ j` over the eigenvalues, since a ring homomorphism fixes the dimensions,
+which enter as natural numbers. -/
+theorem map_trace_eq_trace_pow {j : ℕ} (hn : (n : k) ≠ 0) (hf : f ^ n = 1) (σ : k →+* k)
+    (hσ : ∀ μ : k, μ ^ n = 1 → σ μ = μ ^ j) :
+    σ (LinearMap.trace k V f) = LinearMap.trace k V (f ^ j) := by
+  conv_lhs => rw [← pow_one f]
+  rw [trace_pow_eq_sum_eigenvalue_pow hn hf 1, trace_pow_eq_sum_eigenvalue_pow hn hf j, map_sum]
+  refine Finset.sum_congr rfl fun μ hμ => ?_
+  rw [map_mul, map_natCast, pow_one,
+    hσ μ (pow_eq_one_of_hasEigenvalue hf ((End.finite_hasEigenvalue f).mem_toFinset.1 hμ))]
+
 end Eigenspace
 
 section Complex
@@ -137,19 +158,11 @@ variable {V : Type w} [AddCommGroup V] [Module ℂ V] [FiniteDimensional ℂ V]
 the conjugate of the trace of `f` is the trace of its inverse `f ^ (n - 1)`: the eigenvalues of `f`
 are `n`-th roots of unity, and conjugation inverts those. -/
 theorem conj_trace_eq_trace_pow_sub_one {f : End ℂ V} {n : ℕ} (hn : n ≠ 0) (hf : f ^ n = 1) :
-    (starRingEnd ℂ) (LinearMap.trace ℂ V f) = LinearMap.trace ℂ V (f ^ (n - 1)) := by
-  have hn' : ((n : ℕ) : ℂ) ≠ 0 := Nat.cast_ne_zero.2 hn
-  conv_lhs => rw [← pow_one f]
-  rw [trace_pow_eq_sum_eigenvalue_pow hn' hf 1, trace_pow_eq_sum_eigenvalue_pow hn' hf (n - 1),
-    map_sum]
-  refine Finset.sum_congr rfl fun μ hμ => ?_
-  have hroot : μ ^ n = 1 :=
-    pow_eq_one_of_hasEigenvalue hf ((End.finite_hasEigenvalue f).mem_toFinset.1 hμ)
-  have hinv : (starRingEnd ℂ) μ = μ ^ (n - 1) := by
-    rw [← Complex.inv_eq_conj (Complex.norm_eq_one_of_pow_eq_one hroot hn)]
-    refine inv_eq_of_mul_eq_one_right ?_
-    rw [← pow_succ', Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.2 hn), hroot]
-  rw [map_mul, pow_one, hinv, Complex.conj_natCast]
+    (starRingEnd ℂ) (LinearMap.trace ℂ V f) = LinearMap.trace ℂ V (f ^ (n - 1)) :=
+  map_trace_eq_trace_pow (Nat.cast_ne_zero.2 hn) hf (starRingEnd ℂ) fun μ hμ => by
+    rw [← Complex.inv_eq_conj (Complex.norm_eq_one_of_pow_eq_one hμ hn)]
+    exact inv_eq_of_mul_eq_one_right
+      (by rw [← pow_succ', Nat.sub_add_cancel (Nat.one_le_iff_ne_zero.2 hn), hμ])
 
 end Complex
 

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -13,9 +13,9 @@ public import Mathlib.RepresentationTheory.Character
 
 This file defines functions on a group that are constant on conjugacy classes. It identifies
 their module with the module of functions on `ConjClasses G`, computes its dimension for finite
-groups, pulls class functions back along a group homomorphism, shows that characters of
-representations are class functions, and evaluates a sum over a finite group one conjugacy class
-at a time.
+groups, pulls class functions back along a group homomorphism, twists them by a power map of the
+group element, shows that characters of representations are class functions, and evaluates a sum
+over a finite group one conjugacy class at a time.
 
 The indicator function of a conjugacy class, `TauCeti.ClassFunction.classIndicator`, is the class
 function pulled back from the indicator of a single point of `ConjClasses G`; pairing a class
@@ -132,6 +132,20 @@ each factor in turn. -/
 @[simp]
 theorem comap_comp {H : Type w} {J : Type w'} [Group H] [Group J] (φ : H →* G) (ψ : J →* H) :
     comap (k := k) (φ.comp ψ) = (comap ψ).comp (comap φ) :=
+  (rfl)
+
+/-- Twist a class function by a power map of the group element, `f ↦ (g ↦ f (g ^ j))`.  This is
+again a class function because a power of a conjugate is the conjugate of that power, and it
+depends linearly on `f`.  The Galois action on character values is by these twists. -/
+def powMap (j : ℕ) : ClassFunction k G →ₗ[k] ClassFunction k G where
+  toFun f := ⟨fun g => f.1 (g ^ j), fun g h => by simpa only [conj_pow] using f.2 (g ^ j) h⟩
+  map_add' _ _ := rfl
+  map_smul' _ _ := rfl
+
+/-- The power-map twist evaluates the class function at the power of the group element. -/
+@[simp]
+theorem powMap_apply (j : ℕ) (f : ClassFunction k G) (g : G) :
+    (powMap j f).1 g = f.1 (g ^ j) :=
   (rfl)
 
 /-- Class functions on `G` are linearly equivalent to functions on its conjugacy classes. -/

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassFunction.lean
@@ -148,6 +148,20 @@ theorem powMap_apply (j : ℕ) (f : ClassFunction k G) (g : G) :
     (powMap j f).1 g = f.1 (g ^ j) :=
   (rfl)
 
+/-- Twisting by the first power changes nothing. -/
+@[simp]
+theorem powMap_one : powMap 1 = LinearMap.id (R := k) (M := ClassFunction k G) := by
+  ext f g
+  simp
+
+/-- The power maps compose: twisting by `j` and then by `i` is twisting by `i * j`.  This is what
+makes the twists an action of the multiplicative monoid of exponents. -/
+@[simp]
+theorem powMap_mul (i j : ℕ) :
+    powMap (k := k) (G := G) (i * j) = (powMap i).comp (powMap j) := by
+  ext f g
+  simp [pow_mul]
+
 /-- Class functions on `G` are linearly equivalent to functions on its conjugacy classes. -/
 noncomputable def equivConjClasses : ClassFunction k G ≃ₗ[k] (ConjClasses G → k) where
   toFun := toConjClasses

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -6,8 +6,8 @@ module
 
 public import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
 public import TauCeti.RepresentationTheory.CharacterTable.Values
+public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 public import Mathlib.FieldTheory.Minpoly.IsConjRoot
-public import Mathlib.NumberTheory.Cyclotomic.CyclotomicCharacter
 
 /-!
 # The Galois action on character values
@@ -21,11 +21,10 @@ action on character values is by power maps of the group element**.
 
 This file proves that identity, first for an arbitrary ring endomorphism of an algebraically closed
 field and then, over `ℂ`, in the form the character-theory roadmap asks for, with the exponent `j`
-supplied by Mathlib's cyclotomic character. Two packagings of that exponent are given, because
-Mathlib supplies two: `IsPrimitiveRoot.autToPow` reads it off a chosen primitive root of unity and
-an algebra automorphism, while `modularCyclotomicCharacter` reads it off a ring automorphism with
-no base ring in sight. Over `ℂ` the two settings agree: every ring homomorphism `ℂ →+* ℂ` is
-automatically `ℚ`-linear, so `ℂ ≃ₐ[ℚ] ℂ` is the group of field automorphisms of `ℂ`.
+supplied by Mathlib's cyclotomic character `IsPrimitiveRoot.autToPow`, which reads it off a chosen
+primitive root of unity and an algebra automorphism. Every ring homomorphism `ℂ →+* ℂ` is
+automatically `ℚ`-linear, so `ℂ ≃ₐ[ℚ] ℂ` is the group of field automorphisms of `ℂ` and no
+generality is lost.
 
 Complex conjugation is the instance `j = n - 1` of all this, and gives back
 `TauCeti.Representation.conj_char_eq_char_inv`, `conj (χ g) = χ g⁻¹`.
@@ -45,15 +44,13 @@ consumes once such a `σ` is in hand.
 * `TauCeti.Representation.map_character_eq_character_pow`: if `σ` raises every `n`-th root of unity
   to the `j`-th power and `g ^ n = 1`, then `σ (χ(g)) = χ(g ^ j)`. The variant
   `TauCeti.Representation.map_character_eq_character_pow_of_isPrimitiveRoot` witnesses the power on
-  a single primitive root of unity, and `TauCeti.Representation.map_comp_character` states the
-  identity as an equality of functions on the group.
-* `TauCeti.Representation.character_comp_pow_mem_classFunction`: the twisted function
-  `g ↦ χ(g ^ j)` is again a class function, so the Galois twist stays in `ClassFunction k G`.
+  a single primitive root of unity.
+* `TauCeti.Representation.map_ofCharacter_eq_powMap`: on a group of exponent dividing `n` the
+  Galois twist `σ ∘ χ` is the power-map twist `TauCeti.ClassFunction.powMap j` of the class
+  function of `χ`, so the twist is an operation on `ClassFunction k G`.
 * `TauCeti.FDRep.algEquiv_character_eq_character_pow`: over `ℂ`, a field automorphism `f` of `ℂ`
   sends `χ(g)` to `χ(g ^ j)`, with `j` the cyclotomic exponent `IsPrimitiveRoot.autToPow` attaches
   to `f`.
-* `TauCeti.FDRep.ringEquiv_character_eq_character_pow`: the same statement with the exponent read
-  off `modularCyclotomicCharacter` instead.
 * `TauCeti.FDRep.isConjRoot_character_pow`: `χ(g)` and `χ(g ^ j)` are conjugate over `ℚ`.
 * `TauCeti.FDRep.character_pow_eq_character_of_mem_range`: a rational character value is unchanged
   by the power maps that automorphisms of `ℂ` realize.
@@ -73,20 +70,6 @@ namespace TauCeti
 open Module Polynomial
 
 universe u v w
-
-section RootsOfUnity
-
-variable {R : Type u} [CommRing R] [IsDomain R]
-
-/-- A ring homomorphism that raises one primitive `n`-th root of unity to the `j`-th power raises
-every `n`-th root of unity to the `j`-th power, since the `n`-th roots of unity are exactly the
-powers of a primitive one. -/
-theorem IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrimitiveRoot ζ n)
-    (σ : R →+* R) (hσ : σ ζ = ζ ^ j) {μ : R} (hμ : μ ^ n = 1) : σ μ = μ ^ j := by
-  obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one hμ
-  rw [map_pow, hσ, ← pow_mul, ← pow_mul, Nat.mul_comm]
-
-end RootsOfUnity
 
 namespace Representation
 
@@ -113,28 +96,24 @@ theorem map_character_eq_character_pow_of_isPrimitiveRoot (ρ : Representation k
   Representation.map_character_eq_character_pow ρ hn hg σ
     fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ σ hσ hμ
 
-/-- **The Galois twist of a character is its twist by a power map**, as functions on a group of
-exponent dividing `n`: `σ ∘ χ = χ ∘ (· ^ j)`. -/
-theorem map_comp_character (ρ : Representation k G V) {n j : ℕ} (hn : (n : k) ≠ 0)
-    (hG : ∀ g : G, g ^ n = 1) (σ : k →+* k) (hσ : ∀ μ : k, μ ^ n = 1 → σ μ = μ ^ j) :
-    σ ∘ ρ.character = fun g => ρ.character (g ^ j) :=
-  funext fun g => Representation.map_character_eq_character_pow ρ hn (hG g) σ hσ
-
 end Representation
 
 section ClassFunction
 
-variable {k : Type u} {G : Type v} {V : Type w} [Field k] [Group G] [AddCommGroup V] [Module k V]
+variable {k : Type u} {G : Type v} {V : Type w} [Field k] [IsAlgClosed k] [Group G]
+  [AddCommGroup V] [Module k V] [FiniteDimensional k V]
 
-/-- **The power-map twist of a character is again a class function**, because a power of a
-conjugate is the conjugate of that power. Together with
-`TauCeti.Representation.map_comp_character` this places the Galois twist `σ ∘ χ` of a character in
-`ClassFunction k G`, where the character itself lives. -/
-theorem Representation.character_comp_pow_mem_classFunction (ρ : Representation k G V) (j : ℕ) :
-    (fun g => ρ.character (g ^ j)) ∈ ClassFunction k G :=
-  ClassFunction.mem_iff.mpr fun g h => by
-    show ρ.character ((h * g * h⁻¹) ^ j) = ρ.character (g ^ j)
-    rw [conj_pow, _root_.Representation.char_conj]
+/-- **The Galois twist of a character is the power-map twist of its class function.** On a group
+of exponent dividing `n`, the composite `σ ∘ χ` is `TauCeti.ClassFunction.powMap j` applied to the
+class function of `χ`. This is the form in which a Galois group acts on `ClassFunction k G`. -/
+theorem Representation.map_ofCharacter_eq_powMap (ρ : Representation k G V) {n j : ℕ}
+    (hn : (n : k) ≠ 0) (hG : ∀ g : G, g ^ n = 1) (σ : k →+* k)
+    (hσ : ∀ μ : k, μ ^ n = 1 → σ μ = μ ^ j) :
+    σ ∘ (ClassFunction.ofCharacter ρ).1 =
+      (ClassFunction.powMap j (ClassFunction.ofCharacter ρ)).1 := by
+  funext g
+  simpa only [Function.comp_apply, ClassFunction.powMap_apply, ClassFunction.ofCharacter_apply]
+    using Representation.map_character_eq_character_pow ρ hn (hG g) σ hσ
 
 end ClassFunction
 
@@ -159,18 +138,6 @@ theorem algEquiv_character_eq_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero 
     f (X.character g) = X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) :=
   FDRep.map_character_eq_character_pow X (NeZero.ne n) hg f.toAlgHom.toRingHom
     fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ _ (hζ.autToPow_spec ℚ f).symm hμ
-
-/-- **The Galois action on complex character values is by power maps**, with the power supplied by
-`modularCyclotomicCharacter`, which reads the action of a ring automorphism of `ℂ` on the `n`-th
-roots of unity directly, with no base ring. -/
-theorem ringEquiv_character_eq_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
-    (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (σ : ℂ ≃+* ℂ) :
-    σ (X.character g) =
-      X.character (g ^ ((modularCyclotomicCharacter ℂ hζ.card_rootsOfUnity σ : ZMod n).val)) := by
-  have hζ' := modularCyclotomicCharacter.spec ℂ hζ.card_rootsOfUnity σ hζ.toRootsOfUnity.2
-  rw [hζ.val_toRootsOfUnity_coe] at hζ'
-  exact FDRep.map_character_eq_character_pow X (NeZero.ne n) hg σ.toRingHom
-    fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ _ hζ' hμ
 
 /-- **A character value and its power-map twist are conjugate algebraic numbers**: `χ(g)` and
 `χ(g ^ j)` have the same minimal polynomial over `ℚ`, being images of one another under a field

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.LinearAlgebra.End.FiniteOrder
 public import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
-public import TauCeti.RepresentationTheory.CharacterTable.Values
 public import TauCeti.RingTheory.RootsOfUnity.PrimitiveRoots
 public import Mathlib.FieldTheory.Minpoly.IsConjRoot
 
@@ -22,9 +22,10 @@ action on character values is by power maps of the group element**.
 This file proves that identity, first for an arbitrary ring endomorphism of an algebraically closed
 field and then, over `ℂ`, in the form the character-theory roadmap asks for, with the exponent `j`
 supplied by Mathlib's cyclotomic character `IsPrimitiveRoot.autToPow`, which reads it off a chosen
-primitive root of unity and an algebra automorphism. Every ring homomorphism `ℂ →+* ℂ` is
-automatically `ℚ`-linear, so `ℂ ≃ₐ[ℚ] ℂ` is the group of field automorphisms of `ℂ` and no
-generality is lost.
+primitive root of unity and an algebra automorphism. A field automorphism of `ℂ` is automatically
+`ℚ`-linear, so `ℂ ≃ₐ[ℚ] ℂ` is the group of field automorphisms of `ℂ`; the endomorphism statement
+above is the more general one, since a `ℚ`-linear ring homomorphism `ℂ →+* ℂ` is an embedding but
+need not be surjective.
 
 Complex conjugation is the instance `j = n - 1` of all this, and gives back
 `TauCeti.Representation.conj_char_eq_char_inv`, `conj (χ g) = χ g⁻¹`.
@@ -48,9 +49,9 @@ consumes once such a `σ` is in hand.
 * `TauCeti.Representation.map_ofCharacter_eq_powMap`: on a group of exponent dividing `n` the
   Galois twist `σ ∘ χ` is the power-map twist `TauCeti.ClassFunction.powMap j` of the class
   function of `χ`, so the twist is an operation on `ClassFunction k G`.
-* `TauCeti.FDRep.algEquiv_character_eq_character_pow`: over `ℂ`, a field automorphism `f` of `ℂ`
-  sends `χ(g)` to `χ(g ^ j)`, with `j` the cyclotomic exponent `IsPrimitiveRoot.autToPow` attaches
-  to `f`.
+* `TauCeti.FDRep.map_character_eq_character_pow_of_isPrimitiveRoot`: over `ℂ`, a field
+  automorphism `f` of `ℂ` sends `χ(g)` to `χ(g ^ j)`, with `j` the cyclotomic exponent
+  `IsPrimitiveRoot.autToPow` attaches to `f`.
 * `TauCeti.FDRep.isConjRoot_character_pow`: `χ(g)` and `χ(g ^ j)` are conjugate over `ℚ`.
 * `TauCeti.FDRep.character_pow_eq_character_of_mem_range`: a rational character value is unchanged
   by the power maps that automorphisms of `ℂ` realize.
@@ -90,9 +91,10 @@ theorem map_character_eq_character_pow (ρ : Representation k G V) {g : G} {n j 
 witnessed on a single primitive `n`-th root of unity: if `σ ζ = ζ ^ j` for a primitive `n`-th root
 of unity `ζ` and `g ^ n = 1`, then `σ (χ(g)) = χ(g ^ j)`. -/
 theorem map_character_eq_character_pow_of_isPrimitiveRoot (ρ : Representation k G V) {g : G}
-    {n j : ℕ} [NeZero n] {ζ : k} (hζ : IsPrimitiveRoot ζ n) (hn : (n : k) ≠ 0) (hg : g ^ n = 1)
+    {n j : ℕ} {ζ : k} (hζ : IsPrimitiveRoot ζ n) (hn : (n : k) ≠ 0) (hg : g ^ n = 1)
     (σ : k →+* k) (hσ : σ ζ = ζ ^ j) :
     σ (ρ.character g) = ρ.character (g ^ j) :=
+  have : NeZero n := ⟨fun h => hn (by rw [h, Nat.cast_zero])⟩
   Representation.map_character_eq_character_pow ρ hn hg σ
     fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ σ hσ hμ
 
@@ -133,7 +135,7 @@ theorem map_character_eq_character_pow (X : FDRep ℂ G) {g : G} {n j : ℕ} (hn
 the cyclotomic character `IsPrimitiveRoot.autToPow`: a field automorphism `f` of `ℂ`, which is the
 same thing as a `ℚ`-algebra automorphism, acts on the roots of unity of order dividing `n` as
 `ζ ↦ ζ ^ j` for a unique `j : (ZMod n)ˣ`, and then `f (χ(g)) = χ(g ^ j)` whenever `g ^ n = 1`. -/
-theorem algEquiv_character_eq_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+theorem map_character_eq_character_pow_of_isPrimitiveRoot (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
     f (X.character g) = X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) :=
   FDRep.map_character_eq_character_pow X (NeZero.ne n) hg f.toAlgHom.toRingHom
@@ -145,7 +147,7 @@ automorphism of `ℂ`. -/
 theorem isConjRoot_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
     (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
     IsConjRoot ℚ (X.character g) (X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val))) := by
-  rw [← FDRep.algEquiv_character_eq_character_pow X hζ hg f]
+  rw [← FDRep.map_character_eq_character_pow_of_isPrimitiveRoot X hζ hg f]
   exact isConjRoot_of_algEquiv _ f
 
 /-- **A rational character value is fixed by the power maps that automorphisms of `ℂ` realize**: if
@@ -155,7 +157,7 @@ theorem character_pow_eq_character_of_mem_range (X : FDRep ℂ G) {n : ℕ} [NeZ
     (hχ : X.character g ∈ (algebraMap ℚ ℂ).range) :
     X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) = X.character g := by
   obtain ⟨q, hq⟩ := hχ
-  rw [← FDRep.algEquiv_character_eq_character_pow X hζ hg f, ← hq, AlgEquiv.commutes]
+  rw [← FDRep.map_character_eq_character_pow_of_isPrimitiveRoot X hζ hg f, ← hq, AlgEquiv.commutes]
 
 end FDRep
 

--- a/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Galois.lean
@@ -1,0 +1,195 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.ClassFunction
+public import TauCeti.RepresentationTheory.CharacterTable.Values
+public import Mathlib.FieldTheory.Minpoly.IsConjRoot
+public import Mathlib.NumberTheory.Cyclotomic.CyclotomicCharacter
+
+/-!
+# The Galois action on character values
+
+A character value `χ(g)` at an element with `g ^ n = 1` is a sum of `n`-th roots of unity, the
+eigenvalues of `ρ g`, weighted by the dimensions of the eigenspaces. A ring endomorphism `σ` of the
+coefficient field fixes those dimensions, which enter as natural numbers, so it acts on `χ(g)` only
+through its action on the roots of unity. The roots of unity form a cyclic group, so `σ` acts on
+them as a power map `μ ↦ μ ^ j`, and then `σ (χ(g)) = ∑ dim(V_μ) · μ ^ j = χ(g ^ j)`: **the Galois
+action on character values is by power maps of the group element**.
+
+This file proves that identity, first for an arbitrary ring endomorphism of an algebraically closed
+field and then, over `ℂ`, in the form the character-theory roadmap asks for, with the exponent `j`
+supplied by Mathlib's cyclotomic character. Two packagings of that exponent are given, because
+Mathlib supplies two: `IsPrimitiveRoot.autToPow` reads it off a chosen primitive root of unity and
+an algebra automorphism, while `modularCyclotomicCharacter` reads it off a ring automorphism with
+no base ring in sight. Over `ℂ` the two settings agree: every ring homomorphism `ℂ →+* ℂ` is
+automatically `ℚ`-linear, so `ℂ ≃ₐ[ℚ] ℂ` is the group of field automorphisms of `ℂ`.
+
+Complex conjugation is the instance `j = n - 1` of all this, and gives back
+`TauCeti.Representation.conj_char_eq_char_inv`, `conj (χ g) = χ g⁻¹`.
+
+Two consequences are recorded: `χ(g)` and `χ(g ^ j)` are conjugate algebraic numbers over `ℚ`
+(they are `IsConjRoot ℚ`), and a character value that is rational is unchanged by the power maps
+that automorphisms of `ℂ` realize.
+
+Only the direction "an automorphism determines the power map" is proved here. The converse
+direction, that every `j` coprime to the exponent is realized by some `σ : ℂ →+* ℂ`, needs a
+cyclotomic Galois automorphism to be extended along a transcendence basis of `ℂ`, and is not proved
+here; the identity above is the load-bearing half, and it is the half the Dixon-Schneider lift
+consumes once such a `σ` is in hand.
+
+## Main statements
+
+* `TauCeti.Representation.map_character_eq_character_pow`: if `σ` raises every `n`-th root of unity
+  to the `j`-th power and `g ^ n = 1`, then `σ (χ(g)) = χ(g ^ j)`. The variant
+  `TauCeti.Representation.map_character_eq_character_pow_of_isPrimitiveRoot` witnesses the power on
+  a single primitive root of unity, and `TauCeti.Representation.map_comp_character` states the
+  identity as an equality of functions on the group.
+* `TauCeti.Representation.character_comp_pow_mem_classFunction`: the twisted function
+  `g ↦ χ(g ^ j)` is again a class function, so the Galois twist stays in `ClassFunction k G`.
+* `TauCeti.FDRep.algEquiv_character_eq_character_pow`: over `ℂ`, a field automorphism `f` of `ℂ`
+  sends `χ(g)` to `χ(g ^ j)`, with `j` the cyclotomic exponent `IsPrimitiveRoot.autToPow` attaches
+  to `f`.
+* `TauCeti.FDRep.ringEquiv_character_eq_character_pow`: the same statement with the exponent read
+  off `modularCyclotomicCharacter` instead.
+* `TauCeti.FDRep.isConjRoot_character_pow`: `χ(g)` and `χ(g ^ j)` are conjugate over `ℚ`.
+* `TauCeti.FDRep.character_pow_eq_character_of_mem_range`: a rational character value is unchanged
+  by the power maps that automorphisms of `ℂ` realize.
+
+## References
+
+* [Character Theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 4, "The Galois action".
+* I. M. Isaacs, *Character Theory of Finite Groups* (1976), Lemma 9.16.
+* J.-P. Serre, *Linear Representations of Finite Groups* (1977), Section 12.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open Module Polynomial
+
+universe u v w
+
+section RootsOfUnity
+
+variable {R : Type u} [CommRing R] [IsDomain R]
+
+/-- A ring homomorphism that raises one primitive `n`-th root of unity to the `j`-th power raises
+every `n`-th root of unity to the `j`-th power, since the `n`-th roots of unity are exactly the
+powers of a primitive one. -/
+theorem IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrimitiveRoot ζ n)
+    (σ : R →+* R) (hσ : σ ζ = ζ ^ j) {μ : R} (hμ : μ ^ n = 1) : σ μ = μ ^ j := by
+  obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one hμ
+  rw [map_pow, hσ, ← pow_mul, ← pow_mul, Nat.mul_comm]
+
+end RootsOfUnity
+
+namespace Representation
+
+variable {k : Type u} {G : Type v} {V : Type w} [Field k] [IsAlgClosed k] [Monoid G]
+  [AddCommGroup V] [Module k V] [FiniteDimensional k V]
+
+/-- **The Galois action on character values is by power maps.** If `g ^ n = 1` and the ring
+endomorphism `σ` of the coefficient field raises every `n`-th root of unity to the `j`-th power,
+then `σ (χ(g)) = χ(g ^ j)`: the eigenvalues of `ρ g` are `n`-th roots of unity, and `σ` fixes the
+dimensions of the eigenspaces they are weighted by. -/
+theorem map_character_eq_character_pow (ρ : Representation k G V) {g : G} {n j : ℕ}
+    (hn : (n : k) ≠ 0) (hg : g ^ n = 1) (σ : k →+* k) (hσ : ∀ μ : k, μ ^ n = 1 → σ μ = μ ^ j) :
+    σ (ρ.character g) = ρ.character (g ^ j) := by
+  simp only [Representation.character, map_pow]
+  exact End.map_trace_eq_trace_pow hn (by rw [← map_pow, hg, map_one]) σ hσ
+
+/-- **The Galois action on character values is by power maps**, in the form where the power `j` is
+witnessed on a single primitive `n`-th root of unity: if `σ ζ = ζ ^ j` for a primitive `n`-th root
+of unity `ζ` and `g ^ n = 1`, then `σ (χ(g)) = χ(g ^ j)`. -/
+theorem map_character_eq_character_pow_of_isPrimitiveRoot (ρ : Representation k G V) {g : G}
+    {n j : ℕ} [NeZero n] {ζ : k} (hζ : IsPrimitiveRoot ζ n) (hn : (n : k) ≠ 0) (hg : g ^ n = 1)
+    (σ : k →+* k) (hσ : σ ζ = ζ ^ j) :
+    σ (ρ.character g) = ρ.character (g ^ j) :=
+  Representation.map_character_eq_character_pow ρ hn hg σ
+    fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ σ hσ hμ
+
+/-- **The Galois twist of a character is its twist by a power map**, as functions on a group of
+exponent dividing `n`: `σ ∘ χ = χ ∘ (· ^ j)`. -/
+theorem map_comp_character (ρ : Representation k G V) {n j : ℕ} (hn : (n : k) ≠ 0)
+    (hG : ∀ g : G, g ^ n = 1) (σ : k →+* k) (hσ : ∀ μ : k, μ ^ n = 1 → σ μ = μ ^ j) :
+    σ ∘ ρ.character = fun g => ρ.character (g ^ j) :=
+  funext fun g => Representation.map_character_eq_character_pow ρ hn (hG g) σ hσ
+
+end Representation
+
+section ClassFunction
+
+variable {k : Type u} {G : Type v} {V : Type w} [Field k] [Group G] [AddCommGroup V] [Module k V]
+
+/-- **The power-map twist of a character is again a class function**, because a power of a
+conjugate is the conjugate of that power. Together with
+`TauCeti.Representation.map_comp_character` this places the Galois twist `σ ∘ χ` of a character in
+`ClassFunction k G`, where the character itself lives. -/
+theorem Representation.character_comp_pow_mem_classFunction (ρ : Representation k G V) (j : ℕ) :
+    (fun g => ρ.character (g ^ j)) ∈ ClassFunction k G :=
+  ClassFunction.mem_iff.mpr fun g h => by
+    show ρ.character ((h * g * h⁻¹) ^ j) = ρ.character (g ^ j)
+    rw [conj_pow, _root_.Representation.char_conj]
+
+end ClassFunction
+
+namespace FDRep
+
+variable {G : Type v} [Monoid G]
+
+/-- **The Galois action on complex character values is by power maps.** If `g ^ n = 1` and the ring
+endomorphism `σ` of `ℂ` raises every `n`-th root of unity to the `j`-th power, then
+`σ (χ(g)) = χ(g ^ j)`. -/
+theorem map_character_eq_character_pow (X : FDRep ℂ G) {g : G} {n j : ℕ} (hn : n ≠ 0)
+    (hg : g ^ n = 1) (σ : ℂ →+* ℂ) (hσ : ∀ μ : ℂ, μ ^ n = 1 → σ μ = μ ^ j) :
+    σ (X.character g) = X.character (g ^ j) :=
+  Representation.map_character_eq_character_pow X.ρ (Nat.cast_ne_zero.2 hn) hg σ hσ
+
+/-- **The Galois action on complex character values is by power maps**, with the power supplied by
+the cyclotomic character `IsPrimitiveRoot.autToPow`: a field automorphism `f` of `ℂ`, which is the
+same thing as a `ℚ`-algebra automorphism, acts on the roots of unity of order dividing `n` as
+`ζ ↦ ζ ^ j` for a unique `j : (ZMod n)ˣ`, and then `f (χ(g)) = χ(g ^ j)` whenever `g ^ n = 1`. -/
+theorem algEquiv_character_eq_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
+    f (X.character g) = X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) :=
+  FDRep.map_character_eq_character_pow X (NeZero.ne n) hg f.toAlgHom.toRingHom
+    fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ _ (hζ.autToPow_spec ℚ f).symm hμ
+
+/-- **The Galois action on complex character values is by power maps**, with the power supplied by
+`modularCyclotomicCharacter`, which reads the action of a ring automorphism of `ℂ` on the `n`-th
+roots of unity directly, with no base ring. -/
+theorem ringEquiv_character_eq_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (σ : ℂ ≃+* ℂ) :
+    σ (X.character g) =
+      X.character (g ^ ((modularCyclotomicCharacter ℂ hζ.card_rootsOfUnity σ : ZMod n).val)) := by
+  have hζ' := modularCyclotomicCharacter.spec ℂ hζ.card_rootsOfUnity σ hζ.toRootsOfUnity.2
+  rw [hζ.val_toRootsOfUnity_coe] at hζ'
+  exact FDRep.map_character_eq_character_pow X (NeZero.ne n) hg σ.toRingHom
+    fun _ hμ => IsPrimitiveRoot.map_eq_pow hζ _ hζ' hμ
+
+/-- **A character value and its power-map twist are conjugate algebraic numbers**: `χ(g)` and
+`χ(g ^ j)` have the same minimal polynomial over `ℚ`, being images of one another under a field
+automorphism of `ℂ`. -/
+theorem isConjRoot_character_pow (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ) :
+    IsConjRoot ℚ (X.character g) (X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val))) := by
+  rw [← FDRep.algEquiv_character_eq_character_pow X hζ hg f]
+  exact isConjRoot_of_algEquiv _ f
+
+/-- **A rational character value is fixed by the power maps that automorphisms of `ℂ` realize**: if
+`χ(g)` is rational then `χ(g ^ j) = χ(g)` for every `j` coming from a field automorphism of `ℂ`. -/
+theorem character_pow_eq_character_of_mem_range (X : FDRep ℂ G) {n : ℕ} [NeZero n] {ζ : ℂ}
+    (hζ : IsPrimitiveRoot ζ n) {g : G} (hg : g ^ n = 1) (f : ℂ ≃ₐ[ℚ] ℂ)
+    (hχ : X.character g ∈ (algebraMap ℚ ℂ).range) :
+    X.character (g ^ ((hζ.autToPow ℚ f : ZMod n).val)) = X.character g := by
+  obtain ⟨q, hq⟩ := hχ
+  rw [← FDRep.algEquiv_character_eq_character_pow X hζ hg f, ← hq, AlgEquiv.commutes]
+
+end FDRep
+
+end TauCeti

--- a/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
+++ b/TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean
@@ -1,0 +1,39 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.RingTheory.RootsOfUnity.PrimitiveRoots
+
+/-!
+# How a ring endomorphism acts on the roots of unity
+
+In a domain the `n`-th roots of unity are exactly the powers of a primitive one, so a ring
+endomorphism is pinned down on all of them by its value on a single primitive `n`-th root: if it
+raises that root to the `j`-th power, it raises every `n`-th root of unity to the `j`-th power.
+
+## Main results
+
+* `TauCeti.IsPrimitiveRoot.map_eq_pow`: a ring endomorphism sending a primitive `n`-th root of
+  unity `ζ` to `ζ ^ j` sends every `n`-th root of unity `μ` to `μ ^ j`.
+-/
+
+public section
+
+namespace TauCeti
+
+universe u
+
+variable {R : Type u} [CommRing R] [IsDomain R]
+
+/-- A ring homomorphism that raises one primitive `n`-th root of unity to the `j`-th power raises
+every `n`-th root of unity to the `j`-th power, since the `n`-th roots of unity are exactly the
+powers of a primitive one. -/
+theorem IsPrimitiveRoot.map_eq_pow {n j : ℕ} [NeZero n] {ζ : R} (hζ : IsPrimitiveRoot ζ n)
+    (σ : R →+* R) (hσ : σ ζ = ζ ^ j) {μ : R} (hμ : μ ^ n = 1) : σ μ = μ ^ j := by
+  obtain ⟨i, -, rfl⟩ := hζ.eq_pow_of_pow_eq_one hμ
+  rw [map_pow, hσ, ← pow_mul, ← pow_mul, Nat.mul_comm]
+
+end TauCeti


### PR DESCRIPTION
This PR proves that the Galois action on the values of a character of a finite-dimensional
representation is by power maps of the group element: if a ring endomorphism `σ` of the coefficient
field raises every `n`-th root of unity to the `j`-th power and `g ^ n = 1`, then
`σ (χ(g)) = χ(g ^ j)`. The proof runs through the eigenvalue expansion of the trace, so the new
endomorphism-level lemma `TauCeti.End.map_trace_eq_trace_pow` sits directly under the existing
`trace_pow_eq_sum_eigenvalue_pow`, and the existing complex-conjugation lemma
`conj_trace_eq_trace_pow_sub_one` becomes its `j = n - 1` instance, shortening that proof.

The target is the "The Galois action" bullet of Layer 4 of the character-theory roadmap,
`RepresentationTheory/CharacterTheory/README.md`, which states that `Gal(ℚ(ζ_e)/ℚ) ≃ (ZMod e)ˣ`
acts on character values by `(σ_k · χ)(g) = χ(g^k)` and marks it mandatory for the Layer 6
Dixon-Schneider lift. Over `ℂ` the exponent comes from Mathlib's cyclotomic
character `IsPrimitiveRoot.autToPow`. Two consequences are recorded, that `χ(g)` and `χ(g ^ j)` are
conjugate algebraic numbers over `ℚ` (`IsConjRoot ℚ`) and that a rational character value is
unchanged by the realized power maps. The twist itself is bundled, as the linear map
`TauCeti.ClassFunction.powMap j : ClassFunction k G →ₗ[k] ClassFunction k G` sending `f` to
`g ↦ f (g ^ j)`, so the Galois twist of a character is an operation on `ClassFunction k G`; the
generic roots-of-unity step, that a ring endomorphism raising one primitive `n`-th root of unity to
the `j`-th power raises all of them, lives in its own module
`TauCeti/RingTheory/RootsOfUnity/PrimitiveRoots.lean`.

Only the direction "an automorphism determines the power map" is proved. What remains of this
Layer 4 bullet is the converse existential, `Suggested.lean`'s `character_galois_pow`: that every
`k` coprime to the exponent is realized by some `σ : ℂ →+* ℂ`. That needs a cyclotomic Galois
automorphism to be extended along a transcendence basis of `ℂ`, which is a separate piece of field
theory rather than character theory; the identity proved here is the half that the Dixon-Schneider
lift consumes once such a `σ` is in hand. After that existential, Layer 4 is complete and Layer 5's
specification and checker are the next step.

No material is derived from the supplementary source snapshot, and no Mathlib infrastructure is
vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"galois-action-on-character-values"}-->

🤖 Prepared with Claude Code

