### PR TITLE
feat: the additive law of the inverse hyperbolic tangent

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Triangle.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Triangle.lean
@@ -6,7 +6,7 @@ module
 
 public import TauCeti.Analysis.Complex.Conformal.Hyperbolic.Distance
 public import TauCeti.Analysis.Complex.Conformal.Moebius
-public import Mathlib.Analysis.Complex.Trigonometric
+public import TauCeti.Analysis.SpecialFunctions.Artanh
 
 /-!
 # The triangle inequality for the hyperbolic distance on the unit disc
@@ -36,15 +36,13 @@ hence the hyperbolic geodesics, in `Conformal/Poincare/Betweenness.lean`.
 
 Passing to the hyperbolic distance `hyperbolicDist = artanh ∘ pseudoHyperbolicExpr` uses the
 addition formula for the inverse hyperbolic tangent,
-`Real.artanh a + Real.artanh b = Real.artanh ((a + b) / (1 + a * b))` (`artanh_add`, proved
-here from `Real.sinh_add` / `Real.cosh_add` and the closed forms `Real.sinh_artanh` /
-`Real.cosh_artanh`), together with the isometry invariance of `hyperbolicDist` under the disc
-Moebius factors (`hyperbolicDist_unitDiscMoebius`): the general triangle inequality is reduced
-to the origin case by sending the middle point to `0`.
+`Real.artanh a + Real.artanh b = Real.artanh ((a + b) / (1 + a * b))` (`Real.artanh_add`, proved
+in `TauCeti/Analysis/SpecialFunctions/Artanh.lean`), together with the isometry invariance of
+`hyperbolicDist` under the disc Moebius factors (`hyperbolicDist_unitDiscMoebius`): the general
+triangle inequality is reduced to the origin case by sending the middle point to `0`.
 
 Main results:
 
-* `artanh_add` — the addition formula for `Real.artanh` on `Ioo (-1) 1`;
 * `pseudoHyperbolicExpr_le_add_div_one_add_mul_of_norm_lt_one` — the strong pseudo-hyperbolic
   triangle inequality against the origin, and
   `pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff_of_norm_lt_one` — its equality case;
@@ -82,7 +80,7 @@ last group of results above therefore removes it, and does so without repeating 
 argument: since `hyperbolicDist = artanh ∘ pseudoHyperbolicExpr` and `artanh` is a strictly
 monotone bijection `(-1, 1) ≃ ℝ`, an inequality between pseudo-hyperbolic expressions is
 *equivalent* to the corresponding inequality between hyperbolic distances, and the addition
-formula `artanh_add` is exactly the dictionary translating the additive law
+formula `Real.artanh_add` is exactly the dictionary translating the additive law
 `d(z, u) + d(u, w)` into the Moebius law `(a + b) / (1 + a b)`. So the general forms are read
 off `hyperbolicDist_triangle` — which is where the transport already happened — and their
 equality cases off the injectivity of `artanh`.
@@ -100,30 +98,6 @@ namespace TauCeti
 
 open _root_.Complex Metric Set
 open scoped ComplexConjugate
-
-/-- **Addition formula for the inverse hyperbolic tangent.** For `a, b ∈ (-1, 1)`,
-`artanh a + artanh b = artanh ((a + b) / (1 + a * b))`. This is the additive law by which the
-hyperbolic distance turns the pseudo-hyperbolic expression into a genuine metric. -/
-lemma artanh_add {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b ∈ Ioo (-1 : ℝ) 1) :
-    Real.artanh a + Real.artanh b = Real.artanh ((a + b) / (1 + a * b)) := by
-  have ha1 := ha.1
-  have ha2 := ha.2
-  have hb1 := hb.1
-  have hb2 := hb.2
-  have h1pa : 0 < 1 + a := by linarith
-  have h1ma : 0 < 1 - a := by linarith
-  have h1pb : 0 < 1 + b := by linarith
-  have h1mb : 0 < 1 - b := by linarith
-  have hab : 0 < 1 + a * b := by nlinarith
-  have hsa : Real.sqrt (1 - a ^ 2) ≠ 0 :=
-    Real.sqrt_ne_zero'.mpr (by nlinarith [mul_pos h1pa h1ma])
-  have hsb : Real.sqrt (1 - b ^ 2) ≠ 0 :=
-    Real.sqrt_ne_zero'.mpr (by nlinarith [mul_pos h1pb h1mb])
-  have key : Real.tanh (Real.artanh a + Real.artanh b) = (a + b) / (1 + a * b) := by
-    rw [Real.tanh_eq_sinh_div_cosh, Real.sinh_add, Real.cosh_add, Real.sinh_artanh ha,
-      Real.cosh_artanh ha, Real.sinh_artanh hb, Real.cosh_artanh hb]
-    field_simp
-  rw [← key, Real.artanh_tanh]
 
 /-- **Poincaré defect identity.** The factorisation behind the strong pseudo-hyperbolic triangle
 inequality against the origin: the difference of the squared cross-multiplied sides of
@@ -321,7 +295,7 @@ theorem hyperbolicDist_triangle_zero {z w : ℂ}
     hyperbolicDist_zero_right w]
   have hzIoo : ‖z‖ ∈ Ioo (-1 : ℝ) 1 := ⟨by have := norm_nonneg z; linarith, hzn⟩
   have hwIoo : ‖w‖ ∈ Ioo (-1 : ℝ) 1 := ⟨by have := norm_nonneg w; linarith, hwn⟩
-  rw [artanh_add hzIoo hwIoo]
+  rw [Real.artanh_add hzIoo hwIoo]
   refine Real.artanh_le_artanh (by linarith) ?_ ?_
   · rw [div_lt_one (by positivity)]
     nlinarith [mul_pos (sub_pos.mpr hzn) (sub_pos.mpr hwn)]
@@ -360,15 +334,6 @@ theorem hyperbolicDist_triangle {z w u : ℂ}
 
 /-! ### The pseudo-hyperbolic inequalities at an arbitrary middle point -/
 
-/-- The Moebius sum `(a + b) / (1 + a b)` of two elements of `[0, 1)` again lies in
-`Ioo (-1) 1`, so `artanh_add` may be applied to it. -/
-private lemma mem_Ioo_add_div_one_add_mul {a b : ℝ} (ha₀ : 0 ≤ a) (hb₀ : 0 ≤ b)
-    (ha₁ : a < 1) (hb₁ : b < 1) : (a + b) / (1 + a * b) ∈ Ioo (-1 : ℝ) 1 := by
-  have hmul : (0 : ℝ) ≤ a * b := mul_nonneg ha₀ hb₀
-  have hden : (0 : ℝ) < 1 + a * b := by linarith
-  have hnn : (0 : ℝ) ≤ (a + b) / (1 + a * b) := div_nonneg (by linarith) hden.le
-  exact ⟨by linarith, by rw [div_lt_one hden]; nlinarith⟩
-
 /-- **The strong pseudo-hyperbolic triangle inequality.** For three points of the open unit disc,
 `ρ(z, w) ≤ (ρ(z, u) + ρ(u, w)) / (1 + ρ(z, u) ρ(u, w))`, where `ρ = pseudoHyperbolicExpr`. This is
 `TauCeti.pseudoHyperbolicExpr_le_add_div_one_add_mul_of_norm_lt_one` with the middle point freed
@@ -391,10 +356,8 @@ theorem pseudoHyperbolicExpr_le_add_div_one_add_mul {z w u : ℂ}
     hyperbolicDist_triangle (by simpa [mem_ball_zero_iff] using hz)
       (by simpa [mem_ball_zero_iff] using hw) (by simpa [mem_ball_zero_iff] using hu)
   rw [hyperbolicDist_def z w, hyperbolicDist_def z u, hyperbolicDist_def u w,
-    artanh_add hzu huw] at hd
-  exact (Real.artanh_le_artanh_iff hzw
-    (mem_Ioo_add_div_one_add_mul (pseudoHyperbolicExpr_nonneg z u)
-      (pseudoHyperbolicExpr_nonneg u w) hzu.2 huw.2)).mp hd
+    Real.artanh_add hzu huw] at hd
+  exact (Real.artanh_le_artanh_iff hzw (Real.add_div_one_add_mul_mem_Ioo hzu huw)).mp hd
 
 /-- **The strong pseudo-hyperbolic triangle inequality (bundled unit-disc form).** The
 hypothesis-free form of `TauCeti.pseudoHyperbolicExpr_le_add_div_one_add_mul` for points of
@@ -419,10 +382,9 @@ theorem pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff {z w u : ℂ}
   have huw := pseudoHyperbolicExpr_mem_Ioo_of_norm_lt_one hu hw
   have hzw := pseudoHyperbolicExpr_mem_Ioo_of_norm_lt_one hz hw
   rw [hyperbolicDist_def z w, hyperbolicDist_def z u, hyperbolicDist_def u w,
-    artanh_add hzu huw]
-  refine ⟨fun h => by rw [h], fun h => Real.artanh_injOn hzw
-    (mem_Ioo_add_div_one_add_mul (pseudoHyperbolicExpr_nonneg z u)
-      (pseudoHyperbolicExpr_nonneg u w) hzu.2 huw.2) h⟩
+    Real.artanh_add hzu huw]
+  refine ⟨fun h => by rw [h],
+    fun h => Real.artanh_injOn hzw (Real.add_div_one_add_mul_mem_Ioo hzu huw) h⟩
 
 /-- **Equality in the strong pseudo-hyperbolic triangle inequality (bundled unit-disc form).**
 The hypothesis-free form of `TauCeti.pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff` for points

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
@@ -234,7 +234,7 @@ hyperbolically between the origin and `w` — exactly when it lies on the Euclid
 to `w`.
 
 The implication `←` is `TauCeti.hyperbolicDist_zero_add_hyperbolicDist_ofReal_mul`. For `→`, the
-addition formula `TauCeti.artanh_add` and the injectivity of `Real.artanh` on `Ioo (-1) 1` turn the
+addition formula `Real.artanh_add` and the injectivity of `Real.artanh` on `Ioo (-1) 1` turn the
 hypothesis into `(‖m‖ + ρ) / (1 + ‖m‖ ρ) = ‖w‖`, hence into `ρ (1 - ‖m‖ ‖w‖) = ‖w‖ - ‖m‖`, where
 `ρ = pseudoHyperbolicExpr m w`; that is the equality case
 `TauCeti.pseudoHyperbolicExpr_eq_abs_sub_div_one_sub_mul_iff_of_norm_lt_one` of the reverse
@@ -251,17 +251,9 @@ theorem hyperbolicDist_zero_add_eq_iff_of_norm_lt_one (hm : ‖m‖ < 1) (hw : �
     have hwIoo : ‖w‖ ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [norm_nonneg w], hw⟩
     have hρIoo : pseudoHyperbolicExpr m w ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith, hρ1⟩
     have hquotIoo : (‖m‖ + pseudoHyperbolicExpr m w) / (1 + ‖m‖ * pseudoHyperbolicExpr m w)
-        ∈ Ioo (-1 : ℝ) 1 := by
-      have hposden : (0 : ℝ) < 1 + ‖m‖ * pseudoHyperbolicExpr m w := by
-        nlinarith [norm_nonneg m]
-      have hquot0 : (0 : ℝ) ≤ (‖m‖ + pseudoHyperbolicExpr m w)
-          / (1 + ‖m‖ * pseudoHyperbolicExpr m w) :=
-        div_nonneg (by linarith [norm_nonneg m]) hposden.le
-      refine ⟨by linarith, ?_⟩
-      rw [div_lt_one hposden]
-      nlinarith [mul_pos (sub_pos.mpr hm) (sub_pos.mpr hρ1)]
+        ∈ Ioo (-1 : ℝ) 1 := Real.add_div_one_add_mul_mem_Ioo hmIoo hρIoo
     rw [hyperbolicDist_comm 0 m, hyperbolicDist_zero_right, hyperbolicDist_def,
-      hyperbolicDist_comm 0 w, hyperbolicDist_zero_right, artanh_add hmIoo hρIoo] at h
+      hyperbolicDist_comm 0 w, hyperbolicDist_zero_right, Real.artanh_add hmIoo hρIoo] at h
     have heq := Real.artanh_injOn hquotIoo hwIoo h
     rw [div_eq_iff (by nlinarith [norm_nonneg m] : (1 : ℝ) + ‖m‖ * pseudoHyperbolicExpr m w ≠ 0)]
       at heq
@@ -284,19 +276,15 @@ equality case `TauCeti.pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff_of_norm_l
 @[simp]
 theorem hyperbolicDist_add_zero_eq_iff_of_norm_lt_one (hz : ‖z‖ < 1) (hw : ‖w‖ < 1) :
     hyperbolicDist z 0 + hyperbolicDist 0 w = hyperbolicDist z w ↔ (0 : ℂ) ∈ segment ℝ z w := by
-  have hAB : (0 : ℝ) < 1 + ‖z‖ * ‖w‖ := by positivity
   have hρ0 : 0 ≤ pseudoHyperbolicExpr z w := pseudoHyperbolicExpr_nonneg z w
   have hρ1 : pseudoHyperbolicExpr z w < 1 := pseudoHyperbolicExpr_lt_one_of_norm_lt_one hz hw
   have hzIoo : ‖z‖ ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [norm_nonneg z], hz⟩
   have hwIoo : ‖w‖ ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [norm_nonneg w], hw⟩
   have hρIoo : pseudoHyperbolicExpr z w ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith, hρ1⟩
-  have hquotIoo : (‖z‖ + ‖w‖) / (1 + ‖z‖ * ‖w‖) ∈ Ioo (-1 : ℝ) 1 := by
-    have hquot0 : (0 : ℝ) ≤ (‖z‖ + ‖w‖) / (1 + ‖z‖ * ‖w‖) := by positivity
-    refine ⟨by linarith, ?_⟩
-    rw [div_lt_one hAB]
-    nlinarith [mul_pos (sub_pos.mpr hz) (sub_pos.mpr hw)]
+  have hquotIoo : (‖z‖ + ‖w‖) / (1 + ‖z‖ * ‖w‖) ∈ Ioo (-1 : ℝ) 1 :=
+    Real.add_div_one_add_mul_mem_Ioo hzIoo hwIoo
   rw [hyperbolicDist_zero_right, hyperbolicDist_comm 0 w, hyperbolicDist_zero_right,
-    hyperbolicDist_def, artanh_add hzIoo hwIoo, Real.artanh_injOn.eq_iff hquotIoo hρIoo,
+    hyperbolicDist_def, Real.artanh_add hzIoo hwIoo, Real.artanh_injOn.eq_iff hquotIoo hρIoo,
     zero_mem_segment_iff_re_mul_conj,
     ← pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff_of_norm_lt_one hz hw]
   exact eq_comm

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Geodesic.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Geodesic.lean
@@ -22,9 +22,9 @@ tangents of the signed radii:
 `hyperbolicDist (u * a) (u * b) = |artanh a - artanh b|`
 (`TauCeti.hyperbolicDist_mul_ofReal_of_norm_eq_one`). Indeed the Moebius denominator
 `1 - conj (u * b) * (u * a)` collapses to the real number `1 - a * b`, so the pseudo-hyperbolic
-expression is `|a - b| / |1 - a * b|`, and the subtraction formula for `Real.artanh` — the
-mirror image of the addition formula `TauCeti.artanh_add` proved for the triangle inequality —
-turns that into `|artanh a - artanh b|`. Reparametrising the diameter by `a = Real.tanh t` makes
+expression is `|a - b| / |1 - a * b|`, and the subtraction formula `Real.artanh_sub` of
+`TauCeti/Analysis/SpecialFunctions/Artanh.lean`, together with `Real.artanh_abs`, turns that
+into `|artanh a - artanh b|`. Reparametrising the diameter by `a = Real.tanh t` makes
 it a unit-speed line: `TauCeti.PoincareDisc.radialGeodesic u` is an isometric embedding of `ℝ`.
 
 Every point of the disc lies on such a line through the origin, and the disc automorphisms act
@@ -85,41 +85,6 @@ namespace TauCeti
 
 open _root_.Complex Metric Set
 
-/-! ### Inverse hyperbolic tangent helpers -/
-
-/-- `Real.artanh` is odd on `(-1, 1)`.
-
-Mathlib's `Analysis/SpecialFunctions/Artanh.lean` records the monotonicity, sign and inversion
-properties of `Real.artanh` but not this one (the name `Real.artanh_neg` is taken there by the
-sign lemma). This is a local proof helper for the geodesic computation, kept private so that a
-general real-analysis fact is not exported from a file about the Poincaré disc. -/
-private lemma artanh_neg_eq {x : ℝ} (hx : x ∈ Ioo (-1 : ℝ) 1) :
-    Real.artanh (-x) = -Real.artanh x := by
-  have h1 : (0 : ℝ) < 1 + x := by linarith [hx.1]
-  have h2 : (0 : ℝ) < 1 - x := by linarith [hx.2]
-  rw [Real.artanh_eq_half_log ⟨by linarith [hx.2], by linarith [hx.1]⟩,
-    Real.artanh_eq_half_log (Ioo_subset_Icc_self hx), ← sub_eq_add_neg, sub_neg_eq_add,
-    ← inv_div (1 + x) (1 - x), Real.log_inv]
-  ring
-
-/-- The absolute value passes through `Real.artanh` on `(-1, 1)`. -/
-private lemma artanh_abs {x : ℝ} (hx : x ∈ Ioo (-1 : ℝ) 1) :
-    Real.artanh |x| = |Real.artanh x| := by
-  rcases le_or_gt 0 x with hx0 | hx0
-  · rw [abs_of_nonneg hx0, abs_of_nonneg (Real.artanh_nonneg hx0)]
-  · rw [abs_of_neg hx0, artanh_neg_eq hx, abs_of_nonpos (Real.artanh_nonpos hx0.le)]
-
-/-- **Subtraction formula for the inverse hyperbolic tangent.** For `a, b ∈ (-1, 1)`,
-`artanh a - artanh b = artanh ((a - b) / (1 - a * b))`. This is the addition formula
-`TauCeti.artanh_add`, which underlies the hyperbolic triangle inequality, with `b` negated. -/
-private lemma artanh_sub {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b ∈ Ioo (-1 : ℝ) 1) :
-    Real.artanh a - Real.artanh b = Real.artanh ((a - b) / (1 - a * b)) := by
-  have hb' : -b ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [hb.2], by linarith [hb.1]⟩
-  have h := artanh_add ha hb'
-  rw [artanh_neg_eq hb] at h
-  rw [sub_eq_add_neg a b, sub_eq_add_neg 1 (a * b), ← mul_neg, ← h]
-  ring
-
 /-! ### The hyperbolic distance along a Euclidean diameter -/
 
 /-- The pseudo-hyperbolic expression of two points `u * a`, `u * b` of the same real line
@@ -148,17 +113,8 @@ theorem hyperbolicDist_mul_ofReal_of_norm_eq_one {u : ℂ} (hu : ‖u‖ = 1) {a
     hyperbolicDist (u * a) (u * b) = |Real.artanh a - Real.artanh b| := by
   have ha' := abs_lt.1 ha
   have hb' := abs_lt.1 hb
-  have hab : (0 : ℝ) < 1 - a * b := by nlinarith [ha'.1, ha'.2, hb'.1, hb'.2]
-  have hquot : (a - b) / (1 - a * b) ∈ Ioo (-1 : ℝ) 1 := by
-    refine mem_Ioo.2 (abs_lt.1 ?_)
-    rw [abs_div, abs_of_pos hab, div_lt_one hab, abs_lt]
-    have h₁ : (0 : ℝ) < (1 + a) * (1 - b) :=
-      mul_pos (by linarith [ha'.1]) (by linarith [hb'.2])
-    have h₂ : (0 : ℝ) < (1 - a) * (1 + b) :=
-      mul_pos (by linarith [ha'.2]) (by linarith [hb'.1])
-    constructor <;> nlinarith [h₁, h₂]
   rw [hyperbolicDist_def, pseudoHyperbolicExpr_mul_ofReal_of_norm_eq_one hu a b,
-    ← abs_div, artanh_abs hquot, ← artanh_sub ⟨ha'.1, ha'.2⟩ ⟨hb'.1, hb'.2⟩]
+    ← abs_div, Real.artanh_abs, ← Real.artanh_sub ⟨ha'.1, ha'.2⟩ ⟨hb'.1, hb'.2⟩]
 
 /-- Reparametrising a Euclidean diameter by `Real.tanh` makes it unit speed: the hyperbolic
 distance between `u * Real.tanh s` and `u * Real.tanh t` is `|s - t|`. -/

--- a/TauCeti/Analysis/SpecialFunctions/Artanh.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Artanh.lean
@@ -38,7 +38,7 @@ follows from the inversion `Real.tanh_artanh` together with the addition formula
   be applied again to their own right-hand sides.
 * `Real.artanh_neg_eq_neg_artanh` and `Real.artanh_abs` — `artanh (-x) = -artanh x` and
   `artanh |x| = |artanh x|`, both for *every* real `x`, the values outside `(-1, 1)` being
-  handled by `Real.artanh_eq_zero_of_one_le_abs`.
+  handled by Mathlib's `Real.artanh_eq_zero_iff`.
 
 ### The calculus
 
@@ -79,22 +79,13 @@ open scoped Topology
 
 /-! ### The additive law -/
 
-/-- `Real.artanh` vanishes outside the interval `(-1, 1)` on which it inverts `Real.tanh`: this
-is the junk value forced by the defining formula `artanh x = log √((1 + x) / (1 - x))`, whose
-argument is there nonpositive — or, at `x = 1`, the value `2 / 0 = 0` of Lean's division
-convention — so that both `√` and `log` return `0`.
-
-This is `Real.artanh_eq_zero_iff` in the form the two unconditional identities below spend it. -/
-theorem _root_.Real.artanh_eq_zero_of_one_le_abs {x : ℝ} (hx : 1 ≤ |x|) : Real.artanh x = 0 := by
-  rcases le_abs.mp hx with h | h
-  · exact Real.artanh_eq_zero_iff.mpr (Or.inr (Or.inr h))
-  · exact Real.artanh_eq_zero_iff.mpr (Or.inl (by linarith))
-
 /-- **`Real.artanh` is odd**, at every real number: `artanh (-x) = -artanh x`.
 
 No hypothesis is needed. On `(-1, 1)` this is the logarithmic formula
 `Real.artanh_eq_half_log` read through `Real.log_inv`, and outside it both sides vanish by
-`Real.artanh_eq_zero_of_one_le_abs`.
+`Real.artanh_eq_zero_iff` — the junk value forced by the defining formula
+`artanh x = log √((1 + x) / (1 - x))`, whose argument is there nonpositive, or, at `x = 1`, the
+value `2 / 0 = 0` of Lean's division convention.
 
 The name `Real.artanh_neg`, which the Mathlib convention for oddness would suggest (compare
 `Real.arsinh_neg`, `Real.arctan_neg`), is taken in Mathlib by the sign lemma
@@ -110,8 +101,11 @@ theorem _root_.Real.artanh_neg_eq_neg_artanh (x : ℝ) : Real.artanh (-x) = -Rea
       Real.artanh_eq_half_log (Ioo_subset_Icc_self hx'), ← sub_eq_add_neg, sub_neg_eq_add,
       ← inv_div (1 + x) (1 - x), Real.log_inv]
     ring
-  · rw [Real.artanh_eq_zero_of_one_le_abs hx,
-      Real.artanh_eq_zero_of_one_le_abs (by rwa [abs_neg]), neg_zero]
+  · have hzero : ∀ y : ℝ, 1 ≤ |y| → Real.artanh y = 0 := fun y hy => by
+      rcases le_abs.mp hy with h | h
+      · exact Real.artanh_eq_zero_iff.mpr (Or.inr (Or.inr h))
+      · exact Real.artanh_eq_zero_iff.mpr (Or.inl (by linarith))
+    rw [hzero x hx, hzero (-x) (by rwa [abs_neg]), neg_zero]
 
 /-- **The absolute value passes through `Real.artanh`**, at every real number:
 `artanh |x| = |artanh x|`. Both sides are `artanh` of the larger of `x` and `-x`, by oddness and

--- a/TauCeti/Analysis/SpecialFunctions/Artanh.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Artanh.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Artanh
 public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+public import TauCeti.Analysis.SpecialFunctions.Hyperbolic
 
 /-!
 # The algebra and the calculus of the inverse hyperbolic tangent
@@ -22,19 +23,19 @@ This file supplies both. The analytic half follows from the logarithmic formula
 the open interval `(-1, 1)`; since that interval is open, the formula may be differentiated at
 each of its points and the result transported back to `Real.artanh` itself. The algebraic half
 follows from the inversion `Real.tanh_artanh` together with the addition formula for
-`Real.tanh`, which the pinned Mathlib does not state either and which is proved here.
+`Real.tanh`, which the pinned Mathlib does not state either and which is proved in
+`TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean`.
 
 ## Main declarations
 
 ### The additive law
 
-* `Real.tanh_add` — `tanh (a + b) = (tanh a + tanh b) / (1 + tanh a * tanh b)`, the addition
-  formula for `Real.tanh`, from which the `Real.artanh` one is read off by inversion.
 * `Real.artanh_add` and `Real.artanh_sub` — `artanh a ± artanh b = artanh ((a ± b) / (1 ± a * b))`
   for `a` and `b` in `(-1, 1)`: `Real.artanh` is an isomorphism from the Möbius addition of
   `(-1, 1)` onto `(ℝ, +)`.
-* `Real.add_div_one_add_mul_mem_Ioo` — that Möbius addition is closed on `(-1, 1)`, which is
-  what lets the addition formula be applied again to its own right-hand side.
+* `Real.add_div_one_add_mul_mem_Ioo` and `Real.sub_div_one_sub_mul_mem_Ioo` — that Möbius
+  addition and Möbius subtraction are closed on `(-1, 1)`, which is what lets the two formulae
+  be applied again to their own right-hand sides.
 * `Real.artanh_neg_eq_neg_artanh` and `Real.artanh_abs` — `artanh (-x) = -artanh x` and
   `artanh |x| = |artanh x|`, both for *every* real `x`, the values outside `(-1, 1)` being
   handled by `Real.artanh_eq_zero_of_one_le_abs`.
@@ -66,10 +67,6 @@ while its infinitesimal form — proved in
 `Real.artanh` at the origin transported along that expression. Nothing here is
 complex-analytic, so it is all stated for `Real.artanh` alone, at the natural generality of a
 real special function, rather than being buried in the disc files.
-
-`Real.tanh_add` is stated here, rather than in a file of its own, because `Real.artanh` is
-where it is consumed: the pinned Mathlib has no hyperbolic addition formulae beyond
-`Real.sinh_add` and `Real.cosh_add`, and Tau Ceti has no other hyperbolic-function file.
 -/
 
 public section
@@ -81,33 +78,6 @@ open Set
 open scoped Topology
 
 /-! ### The additive law -/
-
-/-- **Addition formula for the hyperbolic tangent.** `Real.tanh (a + b)` is the Möbius sum
-`(tanh a + tanh b) / (1 + tanh a * tanh b)`.
-
-The pinned Mathlib has `Real.sinh_add` and `Real.cosh_add` but no addition formula for
-`Real.tanh`. This one is their quotient, both sides of which carry the same factor: by those two
-formulae `tanh a + tanh b = sinh (a + b) / (cosh a * cosh b)` and
-`1 + tanh a * tanh b = cosh (a + b) / (cosh a * cosh b)`, and the right-hand denominator is
-positive, so dividing cancels `cosh a * cosh b` and leaves `tanh (a + b)`. -/
-theorem _root_.Real.tanh_add (a b : ℝ) :
-    Real.tanh (a + b) = (Real.tanh a + Real.tanh b) / (1 + Real.tanh a * Real.tanh b) := by
-  have ha : Real.cosh a ≠ 0 := (Real.cosh_pos a).ne'
-  have hb : Real.cosh b ≠ 0 := (Real.cosh_pos b).ne'
-  have hc : Real.cosh (a + b) ≠ 0 := (Real.cosh_pos _).ne'
-  have hnum : Real.tanh a + Real.tanh b
-      = Real.sinh (a + b) / (Real.cosh a * Real.cosh b) := by
-    rw [Real.sinh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
-    field_simp
-  have hden : 1 + Real.tanh a * Real.tanh b
-      = Real.cosh (a + b) / (Real.cosh a * Real.cosh b) := by
-    rw [Real.cosh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
-    field_simp
-  have hne : 1 + Real.tanh a * Real.tanh b ≠ 0 := by
-    rw [hden]
-    exact div_ne_zero hc (mul_ne_zero ha hb)
-  rw [eq_div_iff hne, hnum, hden, Real.tanh_eq_sinh_div_cosh (a + b)]
-  field_simp
 
 /-- `Real.artanh` vanishes outside the interval `(-1, 1)` on which it inverts `Real.tanh`: this
 is the junk value forced by the defining formula `artanh x = log √((1 + x) / (1 - x))`, whose
@@ -195,6 +165,19 @@ theorem _root_.Real.artanh_sub {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b
   rw [Real.artanh_neg_eq_neg_artanh] at h
   rw [sub_eq_add_neg a b, sub_eq_add_neg 1 (a * b), ← mul_neg, ← h]
   ring
+
+/-- **Möbius subtraction preserves the interval `(-1, 1)`**: for `a, b ∈ (-1, 1)` the Möbius
+difference `(a - b) / (1 - a * b)` again lies in `(-1, 1)`.
+
+This is the closure statement that `Real.artanh_sub` needs, exactly as
+`Real.add_div_one_add_mul_mem_Ioo` is the one that `Real.artanh_add` needs: without it a
+consumer of the subtraction formula could not feed its right-hand side back into the
+interval-only `Real.artanh` API. It is the addition statement at `-b`. -/
+theorem _root_.Real.sub_div_one_sub_mul_mem_Ioo {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1)
+    (hb : b ∈ Ioo (-1 : ℝ) 1) : (a - b) / (1 - a * b) ∈ Ioo (-1 : ℝ) 1 := by
+  have hb' : -b ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [hb.2], by linarith [hb.1]⟩
+  have h := Real.add_div_one_add_mul_mem_Ioo ha hb'
+  rwa [mul_neg, ← sub_eq_add_neg, ← sub_eq_add_neg] at h
 
 /-! ### Differentiability -/
 

--- a/TauCeti/Analysis/SpecialFunctions/Artanh.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Artanh.lean
@@ -9,19 +9,37 @@ public import Mathlib.Analysis.SpecialFunctions.Log.Deriv
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 
 /-!
-# The calculus of the inverse hyperbolic tangent
+# The algebra and the calculus of the inverse hyperbolic tangent
 
 Mathlib's `Analysis/SpecialFunctions/Artanh.lean` introduces `Real.artanh` and proves that it
 inverts `Real.tanh` on `(-1, 1)`, that it is strictly monotone there, and the closed forms
-`Real.sinh_artanh`, `Real.cosh_artanh`. It records no analytic property whatsoever: neither
-continuity nor differentiability of `Real.artanh` appears anywhere in the pinned Mathlib.
+`Real.sinh_artanh`, `Real.cosh_artanh`. It records neither the *additive law* of `Real.artanh`
+nor any of its analytic properties: no addition formula, no oddness, and no continuity or
+differentiability statement appears anywhere in the pinned Mathlib.
 
-This file supplies that missing calculus. Everything follows from the logarithmic formula
+This file supplies both. The analytic half follows from the logarithmic formula
 `Real.artanh_eq_half_log`, `artanh x = (1 / 2) * log ((1 + x) / (1 - x))`, which is valid on
 the open interval `(-1, 1)`; since that interval is open, the formula may be differentiated at
-each of its points and the result transported back to `Real.artanh` itself.
+each of its points and the result transported back to `Real.artanh` itself. The algebraic half
+follows from the inversion `Real.tanh_artanh` together with the addition formula for
+`Real.tanh`, which the pinned Mathlib does not state either and which is proved here.
 
 ## Main declarations
+
+### The additive law
+
+* `Real.tanh_add` — `tanh (a + b) = (tanh a + tanh b) / (1 + tanh a * tanh b)`, the addition
+  formula for `Real.tanh`, from which the `Real.artanh` one is read off by inversion.
+* `Real.artanh_add` and `Real.artanh_sub` — `artanh a ± artanh b = artanh ((a ± b) / (1 ± a * b))`
+  for `a` and `b` in `(-1, 1)`: `Real.artanh` is an isomorphism from the Möbius addition of
+  `(-1, 1)` onto `(ℝ, +)`.
+* `Real.add_div_one_add_mul_mem_Ioo` — that Möbius addition is closed on `(-1, 1)`, which is
+  what lets the addition formula be applied again to its own right-hand side.
+* `Real.artanh_neg_eq_neg_artanh` and `Real.artanh_abs` — `artanh (-x) = -artanh x` and
+  `artanh |x| = |artanh x|`, both for *every* real `x`, the values outside `(-1, 1)` being
+  handled by `Real.artanh_eq_zero_of_one_le_abs`.
+
+### The calculus
 
 * `Real.hasDerivAt_artanh` — `Real.artanh` has derivative `(1 - x ^ 2)⁻¹` at each `x` of
   `(-1, 1)`, with `Real.deriv_artanh`, `Real.differentiableAt_artanh`,
@@ -38,11 +56,20 @@ each of its points and the result transported back to `Real.artanh` itself.
 
 The motivation is the conformal-mapping roadmap (`TauCetiRoadmap/ConformalMapping/README.md`),
 whose layer L2 asks for the hyperbolic (Poincaré) metric on the unit disc. Tau Ceti's
-`TauCeti.hyperbolicDist` is `Real.artanh` of the pseudo-hyperbolic expression, so its
-infinitesimal form — proved in `TauCeti/Analysis/Complex/Conformal/Hyperbolic/Density.lean` —
-is exactly the derivative of `Real.artanh` at the origin transported along that expression.
-Nothing here is complex-analytic, so it is stated for `Real.artanh` alone, at the natural
-generality of a real special function, rather than being buried in the disc files.
+`TauCeti.hyperbolicDist` is `Real.artanh` of the pseudo-hyperbolic expression, so the additive
+law below is what makes it satisfy the triangle inequality
+(`TauCeti.hyperbolicDist_triangle`, in `Conformal/Hyperbolic/Triangle.lean`) and what measures
+hyperbolic arclength along a Euclidean diameter
+(`TauCeti.hyperbolicDist_mul_ofReal_of_norm_eq_one`, in `Conformal/Poincare/Geodesic.lean`),
+while its infinitesimal form — proved in
+`TauCeti/Analysis/Complex/Conformal/Hyperbolic/Density.lean` — is the derivative of
+`Real.artanh` at the origin transported along that expression. Nothing here is
+complex-analytic, so it is all stated for `Real.artanh` alone, at the natural generality of a
+real special function, rather than being buried in the disc files.
+
+`Real.tanh_add` is stated here, rather than in a file of its own, because `Real.artanh` is
+where it is consumed: the pinned Mathlib has no hyperbolic addition formulae beyond
+`Real.sinh_add` and `Real.cosh_add`, and Tau Ceti has no other hyperbolic-function file.
 -/
 
 public section
@@ -52,6 +79,122 @@ namespace TauCeti
 open Set
 
 open scoped Topology
+
+/-! ### The additive law -/
+
+/-- **Addition formula for the hyperbolic tangent.** `Real.tanh (a + b)` is the Möbius sum
+`(tanh a + tanh b) / (1 + tanh a * tanh b)`.
+
+The pinned Mathlib has `Real.sinh_add` and `Real.cosh_add` but no addition formula for
+`Real.tanh`. This one is their quotient, both sides of which carry the same factor: by those two
+formulae `tanh a + tanh b = sinh (a + b) / (cosh a * cosh b)` and
+`1 + tanh a * tanh b = cosh (a + b) / (cosh a * cosh b)`, and the right-hand denominator is
+positive, so dividing cancels `cosh a * cosh b` and leaves `tanh (a + b)`. -/
+theorem _root_.Real.tanh_add (a b : ℝ) :
+    Real.tanh (a + b) = (Real.tanh a + Real.tanh b) / (1 + Real.tanh a * Real.tanh b) := by
+  have ha : Real.cosh a ≠ 0 := (Real.cosh_pos a).ne'
+  have hb : Real.cosh b ≠ 0 := (Real.cosh_pos b).ne'
+  have hc : Real.cosh (a + b) ≠ 0 := (Real.cosh_pos _).ne'
+  have hnum : Real.tanh a + Real.tanh b
+      = Real.sinh (a + b) / (Real.cosh a * Real.cosh b) := by
+    rw [Real.sinh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
+    field_simp
+  have hden : 1 + Real.tanh a * Real.tanh b
+      = Real.cosh (a + b) / (Real.cosh a * Real.cosh b) := by
+    rw [Real.cosh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
+    field_simp
+  have hne : 1 + Real.tanh a * Real.tanh b ≠ 0 := by
+    rw [hden]
+    exact div_ne_zero hc (mul_ne_zero ha hb)
+  rw [eq_div_iff hne, hnum, hden, Real.tanh_eq_sinh_div_cosh (a + b)]
+  field_simp
+
+/-- `Real.artanh` vanishes outside the interval `(-1, 1)` on which it inverts `Real.tanh`: this
+is the junk value forced by the defining formula `artanh x = log √((1 + x) / (1 - x))`, whose
+argument is there nonpositive — or, at `x = 1`, the value `2 / 0 = 0` of Lean's division
+convention — so that both `√` and `log` return `0`.
+
+This is `Real.artanh_eq_zero_iff` in the form the two unconditional identities below spend it. -/
+theorem _root_.Real.artanh_eq_zero_of_one_le_abs {x : ℝ} (hx : 1 ≤ |x|) : Real.artanh x = 0 := by
+  rcases le_abs.mp hx with h | h
+  · exact Real.artanh_eq_zero_iff.mpr (Or.inr (Or.inr h))
+  · exact Real.artanh_eq_zero_iff.mpr (Or.inl (by linarith))
+
+/-- **`Real.artanh` is odd**, at every real number: `artanh (-x) = -artanh x`.
+
+No hypothesis is needed. On `(-1, 1)` this is the logarithmic formula
+`Real.artanh_eq_half_log` read through `Real.log_inv`, and outside it both sides vanish by
+`Real.artanh_eq_zero_of_one_le_abs`.
+
+The name `Real.artanh_neg`, which the Mathlib convention for oddness would suggest (compare
+`Real.arsinh_neg`, `Real.arctan_neg`), is taken in Mathlib by the sign lemma
+`artanh x < 0`; the `_eq_` form follows the precedent of `Real.log_neg_eq_log`, whose name is
+displaced by `Real.log_neg` for the same reason. -/
+@[simp]
+theorem _root_.Real.artanh_neg_eq_neg_artanh (x : ℝ) : Real.artanh (-x) = -Real.artanh x := by
+  rcases lt_or_ge |x| 1 with hx | hx
+  · have hx' : x ∈ Ioo (-1 : ℝ) 1 := mem_Ioo.mpr (abs_lt.mp hx)
+    have h1 : (0 : ℝ) < 1 + x := by linarith [hx'.1]
+    have h2 : (0 : ℝ) < 1 - x := by linarith [hx'.2]
+    rw [Real.artanh_eq_half_log ⟨by linarith, by linarith⟩,
+      Real.artanh_eq_half_log (Ioo_subset_Icc_self hx'), ← sub_eq_add_neg, sub_neg_eq_add,
+      ← inv_div (1 + x) (1 - x), Real.log_inv]
+    ring
+  · rw [Real.artanh_eq_zero_of_one_le_abs hx,
+      Real.artanh_eq_zero_of_one_le_abs (by rwa [abs_neg]), neg_zero]
+
+/-- **The absolute value passes through `Real.artanh`**, at every real number:
+`artanh |x| = |artanh x|`. Both sides are `artanh` of the larger of `x` and `-x`, by oddness and
+the sign lemmas `Real.artanh_nonneg`, `Real.artanh_nonpos`.
+
+Not a `simp` lemma: neither side is a normal form for the other, and rewriting in either
+direction merely moves the absolute value across `Real.artanh`. -/
+theorem _root_.Real.artanh_abs (x : ℝ) : Real.artanh |x| = |Real.artanh x| := by
+  rcases le_or_gt 0 x with hx | hx
+  · rw [abs_of_nonneg hx, abs_of_nonneg (Real.artanh_nonneg hx)]
+  · rw [abs_of_neg hx, Real.artanh_neg_eq_neg_artanh,
+      abs_of_nonpos (Real.artanh_nonpos hx.le)]
+
+/-- The `Real.tanh` of a sum of two inverse hyperbolic tangents is the Möbius sum of their
+arguments. This is `Real.tanh_add` with `Real.tanh_artanh` substituted twice, and is the single
+computation behind both the addition formula and the closure of Möbius addition below; kept
+private, as each of those two is the form a consumer wants. -/
+private lemma tanh_artanh_add {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b ∈ Ioo (-1 : ℝ) 1) :
+    Real.tanh (Real.artanh a + Real.artanh b) = (a + b) / (1 + a * b) := by
+  rw [Real.tanh_add, Real.tanh_artanh ha, Real.tanh_artanh hb]
+
+/-- **Addition formula for the inverse hyperbolic tangent.** For `a, b ∈ (-1, 1)`,
+`artanh a + artanh b = artanh ((a + b) / (1 + a * b))`: `Real.artanh` carries the Möbius
+addition of `(-1, 1)` — the one-dimensional relativistic velocity addition — to the addition of
+`ℝ`.
+
+Both hypotheses are needed: outside `(-1, 1)` the left-hand side is a junk value while the
+right-hand side need not be. The proof applies `Real.artanh_tanh` to the sum, whose `Real.tanh`
+is computed by `Real.tanh_add`. -/
+theorem _root_.Real.artanh_add {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b ∈ Ioo (-1 : ℝ) 1) :
+    Real.artanh a + Real.artanh b = Real.artanh ((a + b) / (1 + a * b)) := by
+  rw [← tanh_artanh_add ha hb, Real.artanh_tanh]
+
+/-- **Möbius addition preserves the interval `(-1, 1)`**: for `a, b ∈ (-1, 1)` the Möbius sum
+`(a + b) / (1 + a * b)` again lies in `(-1, 1)`, so that `Real.artanh_add` may be applied to it.
+
+Elementary as the statement is, it is `Real.tanh_add` read backwards: the Möbius sum is
+`tanh (artanh a + artanh b)`, and `Real.tanh` takes its values in `(-1, 1)`. -/
+theorem _root_.Real.add_div_one_add_mul_mem_Ioo {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1)
+    (hb : b ∈ Ioo (-1 : ℝ) 1) : (a + b) / (1 + a * b) ∈ Ioo (-1 : ℝ) 1 := by
+  rw [← tanh_artanh_add ha hb]
+  exact mem_Ioo.mpr ⟨Real.neg_one_lt_tanh _, Real.tanh_lt_one _⟩
+
+/-- **Subtraction formula for the inverse hyperbolic tangent.** For `a, b ∈ (-1, 1)`,
+`artanh a - artanh b = artanh ((a - b) / (1 - a * b))`: the addition formula
+`Real.artanh_add` with `b` negated, `Real.artanh` being odd. -/
+theorem _root_.Real.artanh_sub {a b : ℝ} (ha : a ∈ Ioo (-1 : ℝ) 1) (hb : b ∈ Ioo (-1 : ℝ) 1) :
+    Real.artanh a - Real.artanh b = Real.artanh ((a - b) / (1 - a * b)) := by
+  have hb' : -b ∈ Ioo (-1 : ℝ) 1 := ⟨by linarith [hb.2], by linarith [hb.1]⟩
+  have h := Real.artanh_add ha hb'
+  rw [Real.artanh_neg_eq_neg_artanh] at h
+  rw [sub_eq_add_neg a b, sub_eq_add_neg 1 (a * b), ← mul_neg, ← h]
+  ring
 
 /-! ### Differentiability -/
 

--- a/TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Complex.Trigonometric
+
+/-!
+# The addition formula for the hyperbolic tangent
+
+Mathlib's `Analysis/Complex/Trigonometric.lean` defines `Real.sinh`, `Real.cosh` and `Real.tanh`
+and proves the two addition formulae `Real.sinh_add` and `Real.cosh_add`, but records none for
+`Real.tanh`. This file supplies it.
+
+## Main declarations
+
+* `Real.tanh_add` — `tanh (a + b) = (tanh a + tanh b) / (1 + tanh a * tanh b)`: the hyperbolic
+  tangent of a sum is the Möbius sum of the hyperbolic tangents.
+
+The formula is the quotient of the other two, both sides carrying the factor
+`cosh a * cosh b`, which is nonzero because `Real.cosh` is positive.
+
+Where it is used: `TauCeti/Analysis/SpecialFunctions/Artanh.lean` inverts it into the additive
+law of `Real.artanh`, which carries the Möbius addition of `(-1, 1)` to the addition of `ℝ`;
+that law is in turn what makes the hyperbolic distance of the complex unit disc a metric, the
+subject of layer L2 of the conformal-mapping roadmap
+(`TauCetiRoadmap/ConformalMapping/README.md`).
+-/
+
+public section
+
+namespace TauCeti
+
+/-- **Addition formula for the hyperbolic tangent.** `Real.tanh (a + b)` is the Möbius sum
+`(tanh a + tanh b) / (1 + tanh a * tanh b)`.
+
+The pinned Mathlib has `Real.sinh_add` and `Real.cosh_add` but no addition formula for
+`Real.tanh`. This one is their quotient, both sides of which carry the same factor: by those two
+formulae `tanh a + tanh b = sinh (a + b) / (cosh a * cosh b)` and
+`1 + tanh a * tanh b = cosh (a + b) / (cosh a * cosh b)`, and the right-hand denominator is
+positive, so dividing cancels `cosh a * cosh b` and leaves `tanh (a + b)`. -/
+theorem _root_.Real.tanh_add (a b : ℝ) :
+    Real.tanh (a + b) = (Real.tanh a + Real.tanh b) / (1 + Real.tanh a * Real.tanh b) := by
+  have ha : Real.cosh a ≠ 0 := (Real.cosh_pos a).ne'
+  have hb : Real.cosh b ≠ 0 := (Real.cosh_pos b).ne'
+  have hc : Real.cosh (a + b) ≠ 0 := (Real.cosh_pos _).ne'
+  have hnum : Real.tanh a + Real.tanh b
+      = Real.sinh (a + b) / (Real.cosh a * Real.cosh b) := by
+    rw [Real.sinh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
+    field_simp
+  have hden : 1 + Real.tanh a * Real.tanh b
+      = Real.cosh (a + b) / (Real.cosh a * Real.cosh b) := by
+    rw [Real.cosh_add, Real.tanh_eq_sinh_div_cosh, Real.tanh_eq_sinh_div_cosh]
+    field_simp
+  have hne : 1 + Real.tanh a * Real.tanh b ≠ 0 := by
+    rw [hden]
+    exact div_ne_zero hc (mul_ne_zero ha hb)
+  rw [eq_div_iff hne, hnum, hden, Real.tanh_eq_sinh_div_cosh (a + b)]
+  field_simp
+
+end TauCeti


### PR DESCRIPTION
This PR collects the algebra of `Real.artanh` into `TauCeti/Analysis/SpecialFunctions/Artanh.lean`, which already holds its calculus, and completes it into the additive law that the Poincaré metric of layer **L2** runs on. Until now that algebra was scattered: `TauCeti.artanh_add` lived in `Conformal/Hyperbolic/Triangle.lean`, while oddness, the passage of `|·|`, and the subtraction formula were three `private` helpers of `Conformal/Poincare/Geodesic.lean`, each carrying an apologetic docstring about a general real-analysis fact being trapped in a file about the disc. All four move to the special-functions file under `Real.*` names, and nothing about `Real.artanh` is left stated twice.

Added along the way, and consumed here: `Real.tanh_add`, the addition formula for `Real.tanh`, which the pinned Mathlib does not have (only `Real.sinh_add` and `Real.cosh_add`) and which the previous proof of `artanh_add` re-derived inline from those two, complete with `Real.sqrt_ne_zero'` side conditions. It mentions no `Real.artanh`, so on the round-1 `placement` finding it lives one file earlier, in the new `TauCeti/Analysis/SpecialFunctions/Hyperbolic.lean`, which `Artanh.lean` imports. With it named, `Real.artanh_add` is `Real.artanh_tanh` applied to the sum in two lines, and `Real.artanh_sub` follows from oddness. Also added: `Real.add_div_one_add_mul_mem_Ioo`, that Möbius addition is closed on `(-1, 1)`. That fact existed on `main` as the private nonnegative-argument lemma `mem_Ioo_add_div_one_add_mul` of `Hyperbolic/Triangle.lean`, and separately as three inline `nlinarith` blocks in `Triangle.lean` and `Poincare/Betweenness.lean`; the version here allows signed arguments and is proved by reading `Real.tanh_add` backwards — the Möbius sum is `tanh (artanh a + artanh b)`, and `Real.tanh` lands in `(-1, 1)` — so all four sites now cite one lemma. Its subtraction-side companion `Real.sub_div_one_sub_mul_mem_Ioo`, added on the round-1 `api-design` finding, is that statement at `-b`, and is what lets a consumer of the newly public `Real.artanh_sub` feed the Möbius difference back into the interval-only `Real.artanh` API.

Two of the moved statements are modestly generalised. `Real.artanh_neg_eq_neg_artanh` and `Real.artanh_abs` are stated for *every* real number rather than on `(-1, 1)`: outside the interval both sides vanish, which the oddness proof reads off Mathlib's `Real.artanh_eq_zero_iff` directly. That is not decoration — the hypothesis-free form is what lets `TauCeti.hyperbolicDist_mul_ofReal_of_norm_eq_one` drop the ten-line derivation that the Möbius difference `(a - b) / (1 - a * b)` lies in `(-1, 1)`, a goal it previously had to discharge only in order to apply the interval-bound version. The name `Real.artanh_neg` that the Mathlib convention for oddness would want (compare `Real.arsinh_neg`, `Real.arctan_neg`) is taken upstream by the sign lemma `artanh x < 0`, so the `_eq_` form follows the precedent of `Real.log_neg_eq_log`, displaced by `Real.log_neg` for exactly the same reason.

Roadmap fit is the a-priori clause of `rubrics/scope.md`: up to relocation, renaming, re-proving and modest generalisation, every statement here already exists on `main`, so no fresh roadmap claim is owed. The material's target, for attribution, is the L2 milestone "the hyperbolic / Poincaré metric on `𝔻`" of `TauCetiRoadmap/ConformalMapping/README.md` (the "Layers" section, L2), which `TauCeti.hyperbolicDist = Real.artanh ∘ pseudoHyperbolicExpr` implements: the additive law is what makes that a metric (`TauCeti.hyperbolicDist_triangle`) and what measures hyperbolic arclength along a Euclidean diameter. Nothing here is complex-analytic, so the roadmap's scalar-`ℂ` generality bar is untouched — the conformal statements it governs all keep their shape and their `ℂ` target, and only their real-variable inputs moved. `TauCeti.artanh_add` and the private `mem_Ioo_add_div_one_add_mul` are deleted rather than aliased, and their six call sites updated in this PR, per `rubrics/api-design.md`'s requirement that no name survive solely for compatibility. `Hyperbolic/Triangle.lean` also loses `public import Mathlib.Analysis.Complex.Trigonometric`, which the departed proof was the only user of, and gains the `TauCeti` `Artanh` import in its place.

No Mathlib material is vendored and no source is followed: the addition formulae are the standard textbook identities, taken from the shape the existing Tau Ceti proofs already had.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"real-artanh-add"}-->

🤖 Prepared with Claude Code


