### PR TITLE
feat: segment membership criteria with an endpoint at the origin

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
@@ -5,8 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Analysis.Complex.Conformal.Poincare.Geodesic
-public import Mathlib.Analysis.Convex.Segment
-import Mathlib.Analysis.Normed.Module.Ray
+public import TauCeti.Analysis.Convex.Segment
 
 /-!
 # Betweenness in the Poincaré disc: the hyperbolic geodesic is unique
@@ -34,6 +33,12 @@ nonnegativity of `ρ` forces — is exactly the statement that `m` lies on the E
 towards `w`. The mirror equality case, for the origin sitting in the *middle* rather than at an
 end, is proved the same way and identifies `(z * conj w).re = -(‖z‖ * ‖w‖)` with
 `0 ∈ segment ℝ z w`.
+
+Both of those last identifications are Euclidean, not hyperbolic, and hold in any real inner
+product space: `(z * conj w).re` is the real inner product of `ℂ` (`Complex.inner`), and the
+criteria are `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` and
+`TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` of
+`TauCeti/Analysis/Convex/Segment.lean`, consumed here through that one translation.
 
 Three geometric consequences follow, in increasing strength:
 
@@ -74,7 +79,8 @@ at the origin: it is the origin statement applied to
 This advances the conformal-mapping roadmap's L2 target "the hyperbolic / Poincaré metric on `𝔻`"
 (see `ConformalMapping/README.md`), completing the geodesic description that
 `Poincare/Geodesic.lean` began. It reuses Tau Ceti's pseudo-hyperbolic, hyperbolic-distance and
-disc-automorphism API throughout, and Mathlib's `segment` and `SameRay` for the Euclidean side.
+disc-automorphism API throughout, and `TauCeti/Analysis/Convex/Segment.lean` — itself built on
+Mathlib's `segment` and `SameRay` — for the Euclidean side.
 As with the rest of the L0--L3 conformal-mapping material it is coordinated with the upstream
 Mathlib Riemann-mapping effort leanprover-community/mathlib4#33505 and the preceding
 human-curated work in `Analysis/Complex/RiemannMapping.lean` and
@@ -88,11 +94,22 @@ public section
 
 namespace TauCeti
 
-open _root_.Complex Metric Set
+open _root_.Complex Metric RealInnerProductSpace Set
 
 variable {m w z : ℂ}
 
-/-! ### Euclidean segments through the origin, in terms of `(z * conj w).re` -/
+/-! ### Euclidean segments through the origin, in terms of `(z * conj w).re`
+
+The two criteria of this section are the statements of `TauCeti/Analysis/Convex/Segment.lean` —
+which hold in any real inner product space — transcribed into the Hermitian language `ℂ` supplies
+for its own inner product. They stay private: the exported statements of this file are the
+hyperbolic ones below. -/
+
+/-- The real part of the Hermitian product of two complex numbers is their real inner product: `ℂ`
+carries the real inner product `⟪w, z⟫ = (z * conj w).re` (`Complex.inner`), which is symmetric.
+This is the only translation the Euclidean criteria need in order to apply here. -/
+private lemma re_mul_conj_eq_real_inner (z w : ℂ) : (z * (starRingEnd ℂ) w).re = ⟪z, w⟫ := by
+  rw [← _root_.Complex.inner w z, real_inner_comm]
 
 /-- A point of the Euclidean segment from `0` to `w` is a real multiple `t • w` with `t ∈ [0, 1]`,
 and conversely. A repackaging of Mathlib's `segment_eq_image_lineMap` at the left endpoint `0`, in
@@ -104,127 +121,24 @@ private lemma mem_segment_zero_left_iff :
   exact exists_congr fun _ => and_congr_right fun _ => eq_comm
 
 /-- **Membership in the Euclidean radius, read off the Hermitian product.** A point `m` lies on the
-segment from `0` to `w` exactly when `m` and `w` point in the same direction — equality in
-`Complex.abs_re_le_norm` for `m * conj w` — and `m` is no further from the origin than `w` is.
+segment from `0` to `w` exactly when `m` and `w` point in the same direction — equality in the
+Cauchy--Schwarz inequality, `Complex.abs_re_le_norm` for `m * conj w` — and `m` is no further from
+the origin than `w` is.
 
 Both conditions are needed: `2 * w` points in the direction of `w` without lying on the segment.
 
-"Pointing in the same direction" is Mathlib's `SameRay ℝ`, and `sameRay_iff_norm_add` would give
-that reading of the first conjunct — but only in a `StrictConvexSpace ℝ E`, an instance the pinned
-Mathlib does not provide for `ℂ`. The two-line normSq computation below is used instead. Both this
-lemma and its mirror are kept private: they are statements about complex numbers rather than about
-the hyperbolic metric, and only the hyperbolic consequences are exported. -/
+This is `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` read through `Complex.inner`. -/
 private lemma mem_segment_zero_left_iff_re_mul_conj :
     m ∈ segment ℝ 0 w ↔ (m * (starRingEnd ℂ) w).re = ‖m‖ * ‖w‖ ∧ ‖m‖ ≤ ‖w‖ := by
-  constructor
-  · rw [mem_segment_zero_left_iff]
-    rintro ⟨t, ⟨ht0, ht1⟩, rfl⟩
-    have hnorm : ‖(t : ℂ) * w‖ = t * ‖w‖ := by
-      rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_nonneg ht0]
-    have hre : ((t : ℂ) * w * (starRingEnd ℂ) w).re = t * ‖w‖ ^ 2 := by
-      rw [mul_assoc, Complex.mul_conj, Complex.re_ofReal_mul, Complex.ofReal_re,
-        Complex.normSq_eq_norm_sq]
-    refine ⟨by rw [hnorm, hre]; ring, ?_⟩
-    rw [hnorm]
-    nlinarith [norm_nonneg w]
-  · rintro ⟨h, hle⟩
-    rcases eq_or_ne w 0 with rfl | hw
-    · have hm : m = 0 := by
-        rw [← norm_eq_zero]
-        exact le_antisymm (by simpa using hle) (norm_nonneg m)
-      exact hm ▸ left_mem_segment ℝ (0 : ℂ) 0
-    · have hwpos : 0 < ‖w‖ := norm_pos_iff.mpr hw
-      refine mem_segment_zero_left_iff.mpr
-        ⟨‖m‖ / ‖w‖, ⟨by positivity, (div_le_one hwpos).mpr hle⟩, ?_⟩
-      have hnorm : ‖((‖m‖ / ‖w‖ : ℝ) : ℂ) * w‖ = ‖m‖ / ‖w‖ * ‖w‖ := by
-        rw [norm_mul, Complex.norm_real, Real.norm_eq_abs, abs_of_nonneg (by positivity)]
-      -- Conjugation fixes the real scalar, so it can be pulled out in front of `m * conj w`,
-      -- which is the shape the hypothesis `h` is about.
-      have hpull : m * (starRingEnd ℂ) (((‖m‖ / ‖w‖ : ℝ) : ℂ) * w)
-          = ((‖m‖ / ‖w‖ : ℝ) : ℂ) * (m * (starRingEnd ℂ) w) := by
-        rw [map_mul, Complex.conj_ofReal]; ring
-      have hre : (m * (starRingEnd ℂ) (((‖m‖ / ‖w‖ : ℝ) : ℂ) * w)).re
-          = ‖m‖ / ‖w‖ * (‖m‖ * ‖w‖) := by
-        rw [hpull, Complex.re_ofReal_mul, h]
-      have hzero : ‖m - ((‖m‖ / ‖w‖ : ℝ) : ℂ) * w‖ ^ 2 = 0 := by
-        have h3 := Complex.normSq_sub m (((‖m‖ / ‖w‖ : ℝ) : ℂ) * w)
-        rw [Complex.normSq_eq_norm_sq, Complex.normSq_eq_norm_sq,
-          Complex.normSq_eq_norm_sq] at h3
-        rw [h3, hnorm, hre]
-        field_simp
-        ring
-      exact sub_eq_zero.mp (norm_eq_zero.mp (sq_eq_zero_iff.mp hzero))
-
--- Forward direction. Write `0 = a • z + b • w` with `a + b = 1`. If `a = 0` the point `w` is the
--- origin and both sides vanish; otherwise multiply by `conj w`, which turns each side into a real
--- scalar times a single complex number, and cancel `a`.
-private lemma re_mul_conj_of_zero_mem_segment (h : (0 : ℂ) ∈ segment ℝ z w) :
-    (z * (starRingEnd ℂ) w).re = -(‖z‖ * ‖w‖) := by
-  obtain ⟨a, b, ha, hb, hab, h⟩ := h
-  rcases eq_or_lt_of_le ha with rfl | hapos
-  · have hb1 : b = 1 := by linarith
-    rw [hb1, one_smul, zero_smul, zero_add] at h
-    simp [h]
-  · have h' : (a : ℂ) * z = -((b : ℂ) * w) := by
-      rw [eq_neg_iff_add_eq_zero, ← Complex.real_smul, ← Complex.real_smul]
-      exact h
-    have hnormeq : a * ‖z‖ = b * ‖w‖ := by
-      have hn := congrArg norm h'
-      rwa [norm_mul, norm_neg, norm_mul, Complex.norm_real, Complex.norm_real,
-        Real.norm_eq_abs, Real.norm_eq_abs, abs_of_nonneg ha, abs_of_nonneg hb] at hn
-    -- Multiplying `h'` by `conj w` makes each side a real scalar times a single complex number:
-    -- `z * conj w` on the left, `w * conj w = ‖w‖ ^ 2` on the right.
-    have hright : -((b : ℂ) * w) * (starRingEnd ℂ) w
-        = -((b : ℂ) * (w * (starRingEnd ℂ) w)) := by ring
-    have hre : a * (z * (starRingEnd ℂ) w).re = -(b * ‖w‖ ^ 2) := by
-      have hc := congrArg (fun x : ℂ => (x * (starRingEnd ℂ) w).re) h'
-      rwa [mul_assoc, hright, Complex.re_ofReal_mul, Complex.neg_re, Complex.re_ofReal_mul,
-        Complex.mul_conj, Complex.ofReal_re, Complex.normSq_eq_norm_sq] at hc
-    refine mul_left_cancel₀ hapos.ne' ?_
-    linear_combination hre + ‖w‖ * hnormeq
-
--- Reverse direction. The degenerate cases `z = 0` and `w = 0` are endpoints of the segment; when
--- both are nonzero, `‖w‖ • z + ‖z‖ • w` has vanishing norm by `normSq_add`, which places the
--- origin at the barycentre with weights proportional to the two norms.
-private lemma zero_mem_segment_of_re_mul_conj (h : (z * (starRingEnd ℂ) w).re = -(‖z‖ * ‖w‖)) :
-    (0 : ℂ) ∈ segment ℝ z w := by
-  rcases eq_or_ne z 0 with rfl | hz
-  · exact ⟨1, 0, zero_le_one, le_refl 0, by ring, by simp⟩
-  rcases eq_or_ne w 0 with rfl | hw
-  · exact ⟨0, 1, le_refl 0, zero_le_one, by ring, by simp⟩
-  have hzpos : 0 < ‖z‖ := norm_pos_iff.mpr hz
-  have hwpos : 0 < ‖w‖ := norm_pos_iff.mpr hw
-  have hsum : 0 < ‖z‖ + ‖w‖ := by linarith
-  refine ⟨‖w‖ / (‖z‖ + ‖w‖), ‖z‖ / (‖z‖ + ‖w‖), by positivity, by positivity,
-    by field_simp; ring, ?_⟩
-  -- Conjugation fixes the two real scalars, so the cross term of `normSq_add` is a real
-  -- multiple of `z * conj w`, which is the shape the hypothesis `h` is about.
-  have hcross : (‖w‖ : ℂ) * z * (starRingEnd ℂ) ((‖z‖ : ℂ) * w)
-      = ((‖w‖ * ‖z‖ : ℝ) : ℂ) * (z * (starRingEnd ℂ) w) := by
-    rw [map_mul, Complex.conj_ofReal]; push_cast; ring
-  have hzero : ‖(‖w‖ : ℂ) * z + (‖z‖ : ℂ) * w‖ ^ 2 = 0 := by
-    have h3 := Complex.normSq_add ((‖w‖ : ℂ) * z) ((‖z‖ : ℂ) * w)
-    rw [Complex.normSq_eq_norm_sq, Complex.normSq_eq_norm_sq,
-      Complex.normSq_eq_norm_sq] at h3
-    rw [h3, norm_mul, norm_mul, Complex.norm_real, Complex.norm_real, Real.norm_eq_abs,
-      Real.norm_eq_abs, abs_of_nonneg hwpos.le, abs_of_nonneg hzpos.le, hcross,
-      Complex.re_ofReal_mul, h]
-    ring
-  have hcancel : (‖w‖ : ℂ) * z + (‖z‖ : ℂ) * w = 0 :=
-    norm_eq_zero.mp (sq_eq_zero_iff.mp hzero)
-  rw [Complex.real_smul, Complex.real_smul]
-  push_cast
-  have hsumC : ((‖z‖ : ℂ) + (‖w‖ : ℂ)) ≠ 0 := by
-    simpa using Complex.ofReal_ne_zero.mpr hsum.ne'
-  field_simp
-  linear_combination hcancel
+  rw [re_mul_conj_eq_real_inner, mem_segment_zero_left_iff_real_inner_eq_norm_mul]
 
 /-- **The origin lies between two points exactly when their Hermitian product is negative real.**
 This is the mirror of `TauCeti.mem_segment_zero_left_iff_re_mul_conj`, for the origin at the
-middle of a Euclidean segment rather than at one of its ends. -/
+middle of a Euclidean segment rather than at one of its ends: it is
+`TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` read through `Complex.inner`. -/
 private lemma zero_mem_segment_iff_re_mul_conj :
-    (0 : ℂ) ∈ segment ℝ z w ↔ (z * (starRingEnd ℂ) w).re = -(‖z‖ * ‖w‖) :=
-  ⟨re_mul_conj_of_zero_mem_segment, zero_mem_segment_of_re_mul_conj⟩
+    (0 : ℂ) ∈ segment ℝ z w ↔ (z * (starRingEnd ℂ) w).re = -(‖z‖ * ‖w‖) := by
+  rw [re_mul_conj_eq_real_inner, zero_mem_segment_iff_real_inner_eq_neg_norm_mul]
 
 /-! ### Hyperbolic betweenness -/
 
@@ -301,17 +215,6 @@ theorem hyperbolicDist_add_zero_eq_iff_of_norm_lt_one (hz : ‖z‖ < 1) (hw : �
     ← pseudoHyperbolicExpr_eq_add_div_one_add_mul_iff_of_norm_lt_one hz hw]
   exact eq_comm
 
-/-- Two points of a Euclidean segment issued from the origin at the same distance from the origin
-coincide: they are nonnegative multiples of the same vector, hence `SameRay ℝ`, and
-`SameRay.eq_of_norm_eq` separates such points by their norm. -/
-private lemma eq_of_mem_segment_zero_of_norm_eq {m₁ m₂ : ℂ} (h₁ : m₁ ∈ segment ℝ 0 w)
-    (h₂ : m₂ ∈ segment ℝ 0 w) (h : ‖m₁‖ = ‖m₂‖) : m₁ = m₂ := by
-  obtain ⟨t₁, ⟨ht₁0, -⟩, rfl⟩ := mem_segment_zero_left_iff.mp h₁
-  obtain ⟨t₂, ⟨ht₂0, -⟩, rfl⟩ := mem_segment_zero_left_iff.mp h₂
-  refine SameRay.eq_of_norm_eq ?_ h
-  rw [← Complex.real_smul, ← Complex.real_smul]
-  exact (SameRay.rfl.nonneg_smul_left ht₁0).nonneg_smul_right ht₂0
-
 namespace PoincareDisc
 
 /-! ### Uniqueness of geodesics -/
@@ -341,7 +244,7 @@ theorem eq_of_dist_add_dist_eq {z w m₁ m₂ : PoincareDisc}
   have hnorm := Real.artanh_injOn ⟨by linarith [norm_nonneg (toUnitDisc (g m₁) : ℂ)], hmem m₁⟩
     ⟨by linarith [norm_nonneg (toUnitDisc (g m₂) : ℂ)], hmem m₂⟩ h
   exact g.injective (toUnitDisc.injective
-    (Complex.UnitDisc.coe_injective (eq_of_mem_segment_zero_of_norm_eq hs₁ hs₂ hnorm)))
+    (Complex.UnitDisc.coe_injective (eq_of_mem_segment_zero_left_of_norm_eq hs₁ hs₂ hnorm)))
 
 /-- **Menger convexity, with uniqueness.** For `0 ≤ r ≤ dist z w` there is exactly one point at
 distance `r` from `z` and `dist z w - r` from `w`. The existence half is

--- a/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean
@@ -36,7 +36,7 @@ end, is proved the same way and identifies `(z * conj w).re = -(‖z‖ * ‖w�
 
 Both of those last identifications are Euclidean, not hyperbolic, and hold in any real inner
 product space: `(z * conj w).re` is the real inner product of `ℂ` (`Complex.inner`), and the
-criteria are `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` and
+criteria are `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le` and
 `TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` of
 `TauCeti/Analysis/Convex/Segment.lean`, consumed here through that one translation.
 
@@ -127,10 +127,11 @@ the origin than `w` is.
 
 Both conditions are needed: `2 * w` points in the direction of `w` without lying on the segment.
 
-This is `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` read through `Complex.inner`. -/
+This is `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le` read through
+`Complex.inner`. -/
 private lemma mem_segment_zero_left_iff_re_mul_conj :
     m ∈ segment ℝ 0 w ↔ (m * (starRingEnd ℂ) w).re = ‖m‖ * ‖w‖ ∧ ‖m‖ ≤ ‖w‖ := by
-  rw [re_mul_conj_eq_real_inner, mem_segment_zero_left_iff_real_inner_eq_norm_mul]
+  rw [re_mul_conj_eq_real_inner, mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le]
 
 /-- **The origin lies between two points exactly when their Hermitian product is negative real.**
 This is the mirror of `TauCeti.mem_segment_zero_left_iff_re_mul_conj`, for the origin at the

--- a/TauCeti/Analysis/Convex/Segment.lean
+++ b/TauCeti/Analysis/Convex/Segment.lean
@@ -1,0 +1,157 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Convex.Segment
+public import Mathlib.Analysis.InnerProductSpace.Basic
+public import Mathlib.Analysis.Normed.Module.Ray
+
+/-!
+# Membership in a segment with an endpoint at the origin
+
+Mathlib describes membership in a segment through the ray predicate `SameRay` by
+`mem_segment_iff_sameRay`: `x ∈ [y -[𝕜] z] ↔ SameRay 𝕜 (x - y) (z - x)`. That form is symmetric in
+the two endpoints, and the differences `x - y`, `z - x` are exactly what a *metric* consumer does
+not want: such a consumer holds a point `m` and an endpoint `w`, and asks whether `m` lies on the
+segment `[0, w]` in terms of the two data it can measure — the direction of `m` against `w`, and
+the two norms. This file supplies that reading, together with its mirror in which the origin sits
+in the *middle* of the segment rather than at an end, and the inner-product form of both.
+
+Each criterion is stated at the generality its proof uses. The origin-in-the-middle one needs no
+norm at all, and is stated for a module over a linearly ordered field; the origin-at-an-end one
+compares two norms, and is stated for a real normed space; the inner-product forms replace
+`SameRay` by the equality case of the Cauchy--Schwarz inequality, and are stated for a real inner
+product space.
+
+The bridge between the ray forms and the inner-product forms is
+`TauCeti.sameRay_iff_real_inner_eq_norm_mul`: two vectors of a real inner product space lie on a
+common ray exactly when Cauchy--Schwarz is an equality for them. Mathlib has both halves of it —
+`inner_eq_norm_mul_iff_real : ⟪x, y⟫_ℝ = ‖x‖ * ‖y‖ ↔ ‖y‖ • x = ‖x‖ • y` and
+`sameRay_iff_norm_smul_eq : SameRay ℝ x y ↔ ‖x‖ • y = ‖y‖ • x` — but not the composite, which is
+what makes the geometric content visible. No strict convexity is involved: the alternative route
+through `sameRay_iff_norm_add` would need a `StrictConvexSpace ℝ E` instance, whereas
+`sameRay_iff_norm_smul_eq` and `inner_eq_norm_mul_iff_real` hold in any normed, respectively inner
+product, space.
+
+## Main results
+
+* `TauCeti.zero_mem_segment_iff_sameRay_neg` — `0 ∈ [x -[𝕜] y] ↔ SameRay 𝕜 x (-y)`.
+* `TauCeti.mem_segment_zero_left_iff_sameRay` —
+  `m ∈ [0 -[ℝ] w] ↔ SameRay ℝ m w ∧ ‖m‖ ≤ ‖w‖`. Both conjuncts are needed.
+* `TauCeti.eq_of_mem_segment_zero_left_of_norm_eq` — the norm separates the points of `[0, w]`.
+* `TauCeti.sameRay_iff_real_inner_eq_norm_mul` — the ray predicate as the equality case of
+  Cauchy--Schwarz.
+* `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` and
+  `TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` — the two criteria in a real inner
+  product space.
+
+The consumer is `TauCeti/Analysis/Complex/Conformal/Poincare/Betweenness.lean`, which identifies
+the hyperbolic segments of the Poincaré disc issuing from, or straddling, the origin with the
+Euclidean ones; `ℂ` is a real inner product space with `⟪w, z⟫_ℝ = (z * conj w).re`
+(`Complex.inner`), so the two inner-product criteria are what that file needs. It proved them
+itself, by hand, in the complex-number-specific `Complex.normSq` language and only for `ℂ`, its
+own docstrings recording that they are "statements about complex numbers rather than about the
+hyperbolic metric". Nothing in them is about complex numbers either, which is why they live here.
+This supports the hyperbolic-metric layer L2 of the conformal-mapping roadmap
+(`TauCetiRoadmap/ConformalMapping/README.md`) without adding to it.
+-/
+
+public section
+
+namespace TauCeti
+
+open RealInnerProductSpace Set
+open scoped Convex
+
+/-! ### Segments and rays -/
+
+section Module
+
+variable {𝕜 E : Type*} [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E]
+  [Module 𝕜 E] {x y : E}
+
+/-- **The origin lies between two points exactly when they point in opposite directions.** This is
+`mem_segment_iff_sameRay` evaluated at the point `0`, with the resulting `SameRay 𝕜 (-x) y`
+rewritten by `sameRay_neg_swap`.
+
+No nondegeneracy is needed: if `x = 0` then `0` is an endpoint of the segment and `SameRay 𝕜 0 (-y)`
+holds, and symmetrically for `y`. -/
+theorem zero_mem_segment_iff_sameRay_neg : (0 : E) ∈ [x -[𝕜] y] ↔ SameRay 𝕜 x (-y) := by
+  rw [mem_segment_iff_sameRay, zero_sub, sub_zero, sameRay_neg_swap]
+
+end Module
+
+section Normed
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] {m w : E}
+
+/-- **Membership in the segment from the origin, read off the direction and the two norms.** A
+point `m` lies on `[0, w]` exactly when it points along `w` and is no further from the origin than
+`w` is.
+
+Both conjuncts are needed: for `w ≠ 0` the point `(2 : ℝ) • w` satisfies the first without
+satisfying the second. -/
+theorem mem_segment_zero_left_iff_sameRay :
+    m ∈ [(0 : E) -[ℝ] w] ↔ SameRay ℝ m w ∧ ‖m‖ ≤ ‖w‖ := by
+  rw [segment_eq_image' ℝ (0 : E) w]
+  simp only [mem_image, mem_Icc, zero_add, sub_zero]
+  constructor
+  · rintro ⟨t, ⟨ht₀, ht₁⟩, rfl⟩
+    refine ⟨SameRay.sameRay_nonneg_smul_left w ht₀, ?_⟩
+    rw [norm_smul, Real.norm_of_nonneg ht₀]
+    nlinarith [norm_nonneg w]
+  · rintro ⟨hray, hle⟩
+    rcases eq_or_ne w 0 with rfl | hw
+    · refine ⟨0, ⟨le_rfl, zero_le_one⟩, ?_⟩
+      simpa using (norm_le_zero_iff.mp (by simpa using hle)).symm
+    -- With `w ≠ 0` the ray condition `‖m‖ • w = ‖w‖ • m` solves for `m` as `(‖m‖ / ‖w‖) • w`,
+    -- and the norm comparison places that scalar in `[0, 1]`.
+    · have hwpos : 0 < ‖w‖ := norm_pos_iff.mpr hw
+      refine ⟨‖m‖ / ‖w‖, ⟨by positivity, (div_le_one hwpos).mpr hle⟩, ?_⟩
+      rw [div_eq_inv_mul, mul_smul, hray.norm_smul_eq, inv_smul_smul₀ hwpos.ne']
+
+/-- **Two points of a segment from the origin with the same norm coincide.** The segment `[0, w]`
+carries no two distinct points at the same distance from `0`: it is contained in a ray, on which
+the norm is injective (`norm_injOn_ray_right`). -/
+theorem eq_of_mem_segment_zero_left_of_norm_eq {m₁ m₂ : E} (h₁ : m₁ ∈ [(0 : E) -[ℝ] w])
+    (h₂ : m₂ ∈ [(0 : E) -[ℝ] w]) (h : ‖m₁‖ = ‖m₂‖) : m₁ = m₂ := by
+  rcases eq_or_ne w 0 with rfl | hw
+  · rw [segment_same, mem_singleton_iff] at h₁ h₂
+    rw [h₁, h₂]
+  · exact norm_injOn_ray_right hw (mem_segment_zero_left_iff_sameRay.mp h₁).1
+      (mem_segment_zero_left_iff_sameRay.mp h₂).1 h
+
+end Normed
+
+/-! ### The inner-product forms -/
+
+section InnerProduct
+
+variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] {x y : F}
+
+/-- **Two vectors lie on a common ray exactly when Cauchy–Schwarz is an equality for them.** Both
+sides are Mathlib's, in the shapes `sameRay_iff_norm_smul_eq` and `inner_eq_norm_mul_iff_real`
+give them; only the composite is new. -/
+theorem sameRay_iff_real_inner_eq_norm_mul : SameRay ℝ x y ↔ ⟪x, y⟫ = ‖x‖ * ‖y‖ := by
+  rw [sameRay_iff_norm_smul_eq, inner_eq_norm_mul_iff_real, eq_comm]
+
+/-- **Membership in the segment from the origin, read off the inner product.** The inner-product
+form of `TauCeti.mem_segment_zero_left_iff_sameRay`. -/
+theorem mem_segment_zero_left_iff_real_inner_eq_norm_mul :
+    x ∈ [(0 : F) -[ℝ] y] ↔ ⟪x, y⟫ = ‖x‖ * ‖y‖ ∧ ‖x‖ ≤ ‖y‖ := by
+  rw [mem_segment_zero_left_iff_sameRay, sameRay_iff_real_inner_eq_norm_mul]
+
+/-- **The origin lies between two vectors exactly when their inner product is minimal.** The
+inner-product form of `TauCeti.zero_mem_segment_iff_sameRay_neg`: Cauchy–Schwarz is an equality at
+the other end of its range, `⟪x, y⟫_ℝ = -(‖x‖ * ‖y‖)`. -/
+theorem zero_mem_segment_iff_real_inner_eq_neg_norm_mul :
+    (0 : F) ∈ [x -[ℝ] y] ↔ ⟪x, y⟫ = -(‖x‖ * ‖y‖) := by
+  rw [zero_mem_segment_iff_sameRay_neg, sameRay_iff_real_inner_eq_norm_mul, inner_neg_right,
+    norm_neg, neg_eq_iff_eq_neg]
+
+end InnerProduct
+
+end TauCeti

--- a/TauCeti/Analysis/Convex/Segment.lean
+++ b/TauCeti/Analysis/Convex/Segment.lean
@@ -20,30 +20,23 @@ segment `[0, w]` in terms of the two data it can measure — the direction of `m
 the two norms. This file supplies that reading, together with its mirror in which the origin sits
 in the *middle* of the segment rather than at an end, and the inner-product form of both.
 
-Each criterion is stated at the generality its proof uses. The origin-in-the-middle one needs no
-norm at all, and is stated for a module over a linearly ordered field; the origin-at-an-end one
-compares two norms, and is stated for a real normed space; the inner-product forms replace
-`SameRay` by the equality case of the Cauchy--Schwarz inequality, and are stated for a real inner
-product space.
+Each criterion is stated at the generality its proof uses. The origin-at-an-end one compares two
+norms, and is stated for a real normed space; the inner-product forms replace `SameRay` by the
+equality case of the Cauchy--Schwarz inequality, and are stated for a real inner product space.
 
-The bridge between the ray forms and the inner-product forms is
-`TauCeti.sameRay_iff_real_inner_eq_norm_mul`: two vectors of a real inner product space lie on a
-common ray exactly when Cauchy--Schwarz is an equality for them. Mathlib has both halves of it —
-`inner_eq_norm_mul_iff_real : ⟪x, y⟫_ℝ = ‖x‖ * ‖y‖ ↔ ‖y‖ • x = ‖x‖ • y` and
-`sameRay_iff_norm_smul_eq : SameRay ℝ x y ↔ ‖x‖ • y = ‖y‖ • x` — but not the composite, which is
-what makes the geometric content visible. No strict convexity is involved: the alternative route
-through `sameRay_iff_norm_add` would need a `StrictConvexSpace ℝ E` instance, whereas
-`sameRay_iff_norm_smul_eq` and `inner_eq_norm_mul_iff_real` hold in any normed, respectively inner
-product, space.
+The bridge between the ray form and the inner-product forms is Mathlib's pair
+`sameRay_iff_norm_smul_eq : SameRay ℝ x y ↔ ‖x‖ • y = ‖y‖ • x` and
+`inner_eq_norm_mul_iff_real : ⟪x, y⟫_ℝ = ‖x‖ * ‖y‖ ↔ ‖y‖ • x = ‖x‖ • y`, used directly: together
+they say that two vectors lie on a common ray exactly when Cauchy--Schwarz is an equality for them.
+No strict convexity is involved: the alternative route through `sameRay_iff_norm_add` would need a
+`StrictConvexSpace ℝ E` instance, whereas `sameRay_iff_norm_smul_eq` and
+`inner_eq_norm_mul_iff_real` hold in any normed, respectively inner product, space.
 
 ## Main results
 
-* `TauCeti.zero_mem_segment_iff_sameRay_neg` — `0 ∈ [x -[𝕜] y] ↔ SameRay 𝕜 x (-y)`.
 * `TauCeti.mem_segment_zero_left_iff_sameRay` —
   `m ∈ [0 -[ℝ] w] ↔ SameRay ℝ m w ∧ ‖m‖ ≤ ‖w‖`. Both conjuncts are needed.
 * `TauCeti.eq_of_mem_segment_zero_left_of_norm_eq` — the norm separates the points of `[0, w]`.
-* `TauCeti.sameRay_iff_real_inner_eq_norm_mul` — the ray predicate as the equality case of
-  Cauchy--Schwarz.
 * `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` and
   `TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` — the two criteria in a real inner
   product space.
@@ -67,22 +60,6 @@ open RealInnerProductSpace Set
 open scoped Convex
 
 /-! ### Segments and rays -/
-
-section Module
-
-variable {𝕜 E : Type*} [Field 𝕜] [LinearOrder 𝕜] [IsStrictOrderedRing 𝕜] [AddCommGroup E]
-  [Module 𝕜 E] {x y : E}
-
-/-- **The origin lies between two points exactly when they point in opposite directions.** This is
-`mem_segment_iff_sameRay` evaluated at the point `0`, with the resulting `SameRay 𝕜 (-x) y`
-rewritten by `sameRay_neg_swap`.
-
-No nondegeneracy is needed: if `x = 0` then `0` is an endpoint of the segment and `SameRay 𝕜 0 (-y)`
-holds, and symmetrically for `y`. -/
-theorem zero_mem_segment_iff_sameRay_neg : (0 : E) ∈ [x -[𝕜] y] ↔ SameRay 𝕜 x (-y) := by
-  rw [mem_segment_iff_sameRay, zero_sub, sub_zero, sameRay_neg_swap]
-
-end Module
 
 section Normed
 
@@ -132,25 +109,27 @@ section InnerProduct
 
 variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] {x y : F}
 
-/-- **Two vectors lie on a common ray exactly when Cauchy–Schwarz is an equality for them.** Both
-sides are Mathlib's, in the shapes `sameRay_iff_norm_smul_eq` and `inner_eq_norm_mul_iff_real`
-give them; only the composite is new. -/
-theorem sameRay_iff_real_inner_eq_norm_mul : SameRay ℝ x y ↔ ⟪x, y⟫ = ‖x‖ * ‖y‖ := by
-  rw [sameRay_iff_norm_smul_eq, inner_eq_norm_mul_iff_real, eq_comm]
-
 /-- **Membership in the segment from the origin, read off the inner product.** The inner-product
-form of `TauCeti.mem_segment_zero_left_iff_sameRay`. -/
+form of `TauCeti.mem_segment_zero_left_iff_sameRay`: by `sameRay_iff_norm_smul_eq` and
+`inner_eq_norm_mul_iff_real`, two vectors lie on a common ray exactly when Cauchy–Schwarz is an
+equality for them. -/
 theorem mem_segment_zero_left_iff_real_inner_eq_norm_mul :
     x ∈ [(0 : F) -[ℝ] y] ↔ ⟪x, y⟫ = ‖x‖ * ‖y‖ ∧ ‖x‖ ≤ ‖y‖ := by
-  rw [mem_segment_zero_left_iff_sameRay, sameRay_iff_real_inner_eq_norm_mul]
+  rw [mem_segment_zero_left_iff_sameRay, sameRay_iff_norm_smul_eq, inner_eq_norm_mul_iff_real,
+    eq_comm]
 
-/-- **The origin lies between two vectors exactly when their inner product is minimal.** The
-inner-product form of `TauCeti.zero_mem_segment_iff_sameRay_neg`: Cauchy–Schwarz is an equality at
-the other end of its range, `⟪x, y⟫_ℝ = -(‖x‖ * ‖y‖)`. -/
+/-- **The origin lies between two vectors exactly when their inner product is minimal.** The mirror
+of `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul`, with the origin in the middle of the
+segment rather than at an end: `mem_segment_iff_sameRay` at the point `0` says that `x` and `-y`
+lie on a common ray, so Cauchy–Schwarz is an equality at the other end of its range,
+`⟪x, y⟫_ℝ = -(‖x‖ * ‖y‖)`.
+
+No nondegeneracy is needed: if `x = 0` then `0` is an endpoint of the segment and both sides hold,
+and symmetrically for `y`. -/
 theorem zero_mem_segment_iff_real_inner_eq_neg_norm_mul :
     (0 : F) ∈ [x -[ℝ] y] ↔ ⟪x, y⟫ = -(‖x‖ * ‖y‖) := by
-  rw [zero_mem_segment_iff_sameRay_neg, sameRay_iff_real_inner_eq_norm_mul, inner_neg_right,
-    norm_neg, neg_eq_iff_eq_neg]
+  rw [mem_segment_iff_sameRay, zero_sub, sub_zero, sameRay_neg_swap, sameRay_iff_norm_smul_eq,
+    eq_comm, ← inner_eq_norm_mul_iff_real, inner_neg_right, norm_neg, neg_eq_iff_eq_neg]
 
 end InnerProduct
 

--- a/TauCeti/Analysis/Convex/Segment.lean
+++ b/TauCeti/Analysis/Convex/Segment.lean
@@ -34,10 +34,10 @@ No strict convexity is involved: the alternative route through `sameRay_iff_norm
 
 ## Main results
 
-* `TauCeti.mem_segment_zero_left_iff_sameRay` —
+* `TauCeti.mem_segment_zero_left_iff_sameRay_and_norm_le` —
   `m ∈ [0 -[ℝ] w] ↔ SameRay ℝ m w ∧ ‖m‖ ≤ ‖w‖`. Both conjuncts are needed.
 * `TauCeti.eq_of_mem_segment_zero_left_of_norm_eq` — the norm separates the points of `[0, w]`.
-* `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul` and
+* `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le` and
   `TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul` — the two criteria in a real inner
   product space.
 
@@ -71,7 +71,7 @@ point `m` lies on `[0, w]` exactly when it points along `w` and is no further fr
 
 Both conjuncts are needed: for `w ≠ 0` the point `(2 : ℝ) • w` satisfies the first without
 satisfying the second. -/
-theorem mem_segment_zero_left_iff_sameRay :
+theorem mem_segment_zero_left_iff_sameRay_and_norm_le :
     m ∈ [(0 : E) -[ℝ] w] ↔ SameRay ℝ m w ∧ ‖m‖ ≤ ‖w‖ := by
   rw [segment_eq_image' ℝ (0 : E) w]
   simp only [mem_image, mem_Icc, zero_add, sub_zero]
@@ -98,8 +98,8 @@ theorem eq_of_mem_segment_zero_left_of_norm_eq {m₁ m₂ : E} (h₁ : m₁ ∈ 
   rcases eq_or_ne w 0 with rfl | hw
   · rw [segment_same, mem_singleton_iff] at h₁ h₂
     rw [h₁, h₂]
-  · exact norm_injOn_ray_right hw (mem_segment_zero_left_iff_sameRay.mp h₁).1
-      (mem_segment_zero_left_iff_sameRay.mp h₂).1 h
+  · exact norm_injOn_ray_right hw (mem_segment_zero_left_iff_sameRay_and_norm_le.mp h₁).1
+      (mem_segment_zero_left_iff_sameRay_and_norm_le.mp h₂).1 h
 
 end Normed
 
@@ -110,18 +110,18 @@ section InnerProduct
 variable {F : Type*} [NormedAddCommGroup F] [InnerProductSpace ℝ F] {x y : F}
 
 /-- **Membership in the segment from the origin, read off the inner product.** The inner-product
-form of `TauCeti.mem_segment_zero_left_iff_sameRay`: by `sameRay_iff_norm_smul_eq` and
+form of `TauCeti.mem_segment_zero_left_iff_sameRay_and_norm_le`: by `sameRay_iff_norm_smul_eq` and
 `inner_eq_norm_mul_iff_real`, two vectors lie on a common ray exactly when Cauchy–Schwarz is an
 equality for them. -/
-theorem mem_segment_zero_left_iff_real_inner_eq_norm_mul :
+theorem mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le :
     x ∈ [(0 : F) -[ℝ] y] ↔ ⟪x, y⟫ = ‖x‖ * ‖y‖ ∧ ‖x‖ ≤ ‖y‖ := by
-  rw [mem_segment_zero_left_iff_sameRay, sameRay_iff_norm_smul_eq, inner_eq_norm_mul_iff_real,
-    eq_comm]
+  rw [mem_segment_zero_left_iff_sameRay_and_norm_le, sameRay_iff_norm_smul_eq,
+    inner_eq_norm_mul_iff_real, eq_comm]
 
 /-- **The origin lies between two vectors exactly when their inner product is minimal.** The mirror
-of `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul`, with the origin in the middle of the
-segment rather than at an end: `mem_segment_iff_sameRay` at the point `0` says that `x` and `-y`
-lie on a common ray, so Cauchy–Schwarz is an equality at the other end of its range,
+of `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le`, with the origin in the
+middle of the segment rather than at an end: `mem_segment_iff_sameRay` at the point `0` says that
+`x` and `-y` lie on a common ray, so Cauchy–Schwarz is an equality at the other end of its range,
 `⟪x, y⟫_ℝ = -(‖x‖ * ‖y‖)`.
 
 No nondegeneracy is needed: if `x = 0` then `0` is an endpoint of the segment and both sides hold,


### PR DESCRIPTION
This PR extracts the two Euclidean segment criteria that `Conformal/Poincare/Betweenness.lean` proved privately — "a point lies on the segment from the origin to `w`" and "the origin lies between two points" — and states them where they belong, at the generality their proofs actually use. That file's own docstrings record the misplacement: the lemmas are, in their words, "statements about complex numbers rather than about the hyperbolic metric", and in fact nothing in them is about complex numbers either. The new `TauCeti/Analysis/Convex/Segment.lean` states the origin-at-an-end criterion for a real normed space, and the inner-product forms of both criteria for a real inner product space; `Betweenness.lean` now consumes the two inner-product forms through the single translation `(z * conj w).re = ⟪z, w⟫_ℝ`, which is Mathlib's `Complex.inner` together with symmetry of the real inner product.

The four results added are `TauCeti.mem_segment_zero_left_iff_sameRay_and_norm_le`, `TauCeti.eq_of_mem_segment_zero_left_of_norm_eq`, `TauCeti.mem_segment_zero_left_iff_real_inner_eq_norm_mul_and_norm_le` and `TauCeti.zero_mem_segment_iff_real_inner_eq_neg_norm_mul`. Mathlib supplies the pieces but not these statements: `mem_segment_iff_sameRay` reads segment membership as `SameRay 𝕜 (x - y) (z - x)`, which is symmetric in the endpoints and phrased in differences, whereas a metric consumer holds a point and an endpoint and can only measure their direction and their norms. The bridge from the ray form to the inner-product forms is Mathlib's pair `sameRay_iff_norm_smul_eq` and `inner_eq_norm_mul_iff_real`, used directly. On the way this removes an incorrect claim from the old docstring, which asserted that the ray reading was unavailable for want of a `StrictConvexSpace ℝ ℂ` instance; the inner-product route needs no strict convexity at all.

The five private lemmas of `Betweenness.lean` and their `Complex.normSq` / `nlinarith` computations go away with them, so the refactor is a net deletion of hand-rolled algebra: 136 lines added in the new file against 129 removed. No statement of `Betweenness.lean` changes, and no declaration is renamed apart from the extracted ones, which were private.

This is improving code that already exists — relocating misplaced declarations, modestly generalising them to the setting their proofs use, and adopting Mathlib's `SameRay` idiom in place of a bespoke computation — and adds no new mathematics to the roadmap. The material it supports is the hyperbolic-metric layer **L2** of `TauCetiRoadmap/ConformalMapping/README.md` ("**L2 — Schwarz lemma extensions.** *Schwarz–Pick* …, the **hyperbolic / Poincaré metric** on `𝔻`, and the disc automorphism group"), whose uniqueness-of-geodesics file is the sole consumer. No Mathlib source was vendored.

`lake build` and `lake exe axioms` are green: `Build completed successfully (6621 jobs).` and `axioms: audited 25076 TauCeti declaration(s); all within the allowlist [propext, Classical.choice, Quot.sound].`

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"mem-segment-zero-left-iff-sameray"}-->

🤖 Prepared with Claude Code

