### PR TITLE
feat(ModularForms): the Petersson inner product at level N

### DIFF
--- a/TauCeti/GroupTheory/Index.lean
+++ b/TauCeti/GroupTheory/Index.lean
@@ -10,7 +10,9 @@ public import Mathlib.GroupTheory.Index
 # Consequences of the index formula
 
 The preimage `H.comap f` of a finite-index subgroup along a group homomorphism again has finite
-index: its index is the relative index of `H` in the range of `f`, which is finite.
+index: its index is the relative index of `H` in the range of `f`, which is finite. Adjoining
+the centre to a finite-index subgroup also keeps the index finite, since it only enlarges the
+subgroup.
 
 Because the order of a subgroup divides the order of the group -- with the index as cofactor --
 invertibility of the order of a finite group in a semiring passes to every subgroup.
@@ -25,6 +27,26 @@ namespace Subgroup
 instance instFiniteIndexComap {G G' : Type*} [Group G] [Group G'] (H : Subgroup G) [H.FiniteIndex]
     (f : G' →* G) : (H.comap f).FiniteIndex :=
   ⟨by rw [index_comap]; exact FiniteIndex.index_ne_zero⟩
+
+/-- `Γ` with the centre of the ambient group adjoined. For `Γ ≤ SL(2, ℤ)` the centre is
+`{±I}`, which acts trivially on `ℍ`; it is the cosets of `Γ·{±I}` — not those of `Γ` itself —
+that name the distinct translates of `𝒟` tiling a `Γ` fundamental domain, since `q` and `-q`
+would otherwise be counted as two cosets carrying the same translate. The two subgroups agree
+exactly when `-I ∈ Γ`. -/
+def withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Subgroup G :=
+  Γ ⊔ Subgroup.center G
+
+/-- Unfolding: `Γ.withCenter` is the supremum of `Γ` with the centre. -/
+theorem withCenter_def {G : Type*} [Group G] (Γ : Subgroup G) :
+    Γ.withCenter = Γ ⊔ Subgroup.center G := (rfl)
+
+/-- `Γ` sits inside `Γ` with the centre adjoined. -/
+lemma le_withCenter {G : Type*} [Group G] (Γ : Subgroup G) : Γ ≤ Γ.withCenter :=
+  le_sup_left
+
+instance instFiniteIndexWithCenter {G : Type*} [Group G] (Γ : Subgroup G)
+    [Γ.FiniteIndex] : Γ.withCenter.FiniteIndex :=
+  Subgroup.finiteIndex_of_le Γ.le_withCenter
 
 end Subgroup
 

--- a/TauCeti/NumberTheory/ModularForms/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Basic.lean
@@ -40,6 +40,8 @@ AINTLIB `LeanModularForms` project
 
 ## Main results
 
+* `SlashInvariantFormClass.SL_slash_eq`: a form invariant under the image of `Γ ≤ SL(2, ℤ)`
+  is fixed by the slash action of every element of `Γ`.
 * `Subgroup.IsArithmetic.isCusp_of_isCusp`: any two arithmetic groups have the same cusps.
 * `ModularForm.mem_range_ofLeₗ_iff`, `CuspForm.mem_range_ofLeₗ_iff`: for `Γ' ≤ Γ` with every
   cusp of `Γ` a cusp of `Γ'`, a form for `Γ'` extends to `Γ` exactly when it is `Γ`-slash
@@ -88,6 +90,15 @@ theorem _root_.ModularForm.slash_neg_one (k : ℤ) (f : ℍ → ℂ) :
   funext z
   rw [ModularForm.slash_apply]
   simp [UpperHalfPlane.σ, hzpow, hdet, mul_comm]
+
+/-- A form invariant under the image in `GL(2, ℝ)` of a subgroup `Γ ≤ SL(2, ℤ)` is fixed by
+the weight-`k` slash action of every element of `Γ` — the invariance condition read back at
+the `SL₂(ℤ)` level, where congruence subgroups are given. -/
+theorem _root_.SlashInvariantFormClass.SL_slash_eq {F : Type*} [FunLike F ℍ ℂ] {k : ℤ}
+    {Γ : Subgroup SL(2, ℤ)} [SlashInvariantFormClass F (Γ.map (mapGL ℝ)) k] (f : F)
+    (γ : SL(2, ℤ)) (hγ : γ ∈ Γ) : ⇑f ∣[k] γ = ⇑f := by
+  rw [ModularForm.SL_slash]
+  exact SlashInvariantFormClass.slash_action_eq f _ ⟨γ, hγ, rfl⟩
 
 /-! ### Changing the invariance group
 

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Basic.lean
@@ -37,6 +37,10 @@ Mathlib's invariant measure `volume : Measure ℍ` (`dx dy / y²`,
 * `UpperHalfPlane.peterssonInner_conj_symm`: Hermitian symmetry.
 * `UpperHalfPlane.integrableOn_petersson_fd_left`: integrability of the Petersson integrand of a
   cusp form against a modular form over the standard fundamental domain.
+* `UpperHalfPlane.integrableOn_petersson_slash`: the same for forms slashed by `SL₂(ℤ)`.
+* `UpperHalfPlane.peterssonInner_self_eq_ofReal`, `peterssonInner_self_re_nonneg`: the
+  self-pairing of any function is the real integral of `‖h τ‖² (Im τ)^k`, hence nonnegative
+  over any domain.
 * `UpperHalfPlane.eq_zero_on_fd_of_peterssonInner_self_eq_zero`: definiteness on the
   fundamental domain, for any continuous function with integrable self-integrand.
 
@@ -64,8 +68,9 @@ public section
 noncomputable section
 
 open MeasureTheory Measure UpperHalfPlane ModularGroup Complex Set ENNReal
+open Matrix.SpecialLinearGroup
 
-open scoped ComplexConjugate MatrixGroups NNReal Pointwise
+open scoped ComplexConjugate MatrixGroups ModularForm NNReal Pointwise
 
 namespace UpperHalfPlane
 
@@ -149,6 +154,53 @@ theorem integrableOn_petersson_fd_right {F F' : Type*} [FunLike F ℍ ℂ] [FunL
       (ModularFormClass.continuous f')).aestronglyMeasurable.restrict) C
     (ae_of_all _ fun τ ↦ hC τ)
 
+/-- The Petersson self-integrand of any function is a nonnegative real:
+`petersson k h h τ = ‖h τ‖² (Im τ)^k`. -/
+@[simp]
+theorem petersson_self_eq_ofReal (k : ℤ) (h : ℍ → ℂ) (τ : ℍ) :
+    petersson k h h τ = ((normSq (h τ) * τ.im ^ k : ℝ) : ℂ) := by
+  simp only [petersson, ← Complex.normSq_eq_conj_mul_self]
+  push_cast
+  ring
+
+/-- The Petersson self-pairing of any function over any domain is the real integral of
+`‖h τ‖² (Im τ)^k`. -/
+theorem peterssonInner_self_eq_ofReal (k : ℤ) (D : Set ℍ) (h : ℍ → ℂ) :
+    peterssonInner k D h h = ((∫ τ in D, normSq (h τ) * τ.im ^ k : ℝ) : ℂ) := by
+  rw [peterssonInner_def]
+  simp_rw [petersson_self_eq_ofReal]
+  exact integral_ofReal
+
+/-- The Petersson self-pairing over a measurable domain is nonnegative, for any function:
+the integrand `‖h τ‖² (Im τ)^k` is. -/
+theorem peterssonInner_self_re_nonneg (k : ℤ) (D : Set ℍ)
+    (h : ℍ → ℂ) : 0 ≤ (peterssonInner k D h h).re := by
+  rw [peterssonInner_self_eq_ofReal, Complex.ofReal_re]
+  exact setIntegral_nonneg_of_ae_restrict <| ae_of_all _ fun τ ↦
+    mul_nonneg (normSq_nonneg _) (zpow_nonneg (UpperHalfPlane.im_pos τ).le _)
+
+/-- The Petersson integrand of slashed forms is integrable over `𝒟`: slashing by an element
+of `SL₂(ℤ)` moves the integrand along the action, where the cusp-form bound still applies. -/
+theorem integrableOn_petersson_slash {F F' : Type*} [FunLike F ℍ ℂ] [FunLike F' ℍ ℂ]
+    (k : ℤ) (Γ : Subgroup (GL (Fin 2) ℝ)) [Γ.IsArithmetic]
+    [CuspFormClass F Γ k] [ModularFormClass F' Γ k]
+    (f : F) (f' : F') (δ : SL(2, ℤ)) :
+    IntegrableOn (fun τ ↦ petersson k (⇑f ∣[k] δ) (⇑f' ∣[k] δ) τ) fd (volume : Measure ℍ) := by
+  obtain ⟨C, hC⟩ := CuspFormClass.petersson_bounded_left k Γ f f'
+  have hslash : (fun τ ↦ petersson k (⇑f ∣[k] δ) (⇑f' ∣[k] δ) τ) =
+      fun τ ↦ petersson k (⇑f) (⇑f') (δ • τ) :=
+    funext fun τ ↦ petersson_slash_SL k _ _ δ τ
+  rw [hslash]
+  -- the `SL(2, ℤ)` action on `ℍ` is the `GL(2, ℝ)` action along `mapGL`, where the
+  -- continuity instance lives
+  have hsmul : Continuous fun τ : ℍ ↦ δ • τ := by
+    simp only [MulAction.compHom_smul_def]
+    exact continuous_const_smul (mapGL ℝ δ)
+  exact IntegrableOn.of_bound ModularGroup.volume_fd_lt_top
+    ((petersson_continuous k (ModularFormClass.continuous f)
+      (ModularFormClass.continuous f')).comp hsmul |>.aestronglyMeasurable.restrict)
+    C (ae_of_all _ fun τ ↦ hC (δ • τ))
+
 /-- Additivity in the second argument. -/
 theorem peterssonInner_add_right (k : ℤ) (D : Set ℍ) (f g₁ g₂ : ℍ → ℂ)
     (hg₁ : IntegrableOn (fun τ ↦ petersson k f g₁ τ) D (volume : Measure ℍ))
@@ -191,11 +243,6 @@ theorem peterssonInner_smul_left (k : ℤ) (D : Set ℍ) (c : ℂ) (f g : ℍ �
     simp only [petersson, Pi.smul_apply, smul_eq_mul, map_mul]
     ring)
 
-private lemma petersson_self_re_eq (z : ℂ) (y : ℝ) (k : ℤ) :
-    (starRingEnd ℂ z * z * (↑y : ℂ) ^ k).re = Complex.normSq z * y ^ k := by
-  rw [← Complex.normSq_eq_conj_mul_self, ← Complex.ofReal_zpow, ← Complex.ofReal_mul,
-    Complex.ofReal_re]
-
 /-- **Definiteness of the Petersson pairing on the fundamental domain**: a continuous
 function whose Petersson self-integrand is integrable on `𝒟` and whose self-pairing over
 `𝒟` vanishes is zero everywhere on `𝒟`.
@@ -211,9 +258,8 @@ theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {k : ℤ} {f : ℍ → ℂ}
     · exact integral_re hint
     · simp only [peterssonInner] at hpet; rw [hpet]; simp
   have hg_nonneg : ∀ z, 0 ≤ g z := fun z ↦ by
-    simp only [g, petersson]
-    exact (petersson_self_re_eq (f z) z.im k).symm ▸
-      mul_nonneg (Complex.normSq_nonneg _) (zpow_nonneg z.im_pos.le _)
+    simp only [g, petersson_self_eq_ofReal, Complex.ofReal_re]
+    exact mul_nonneg (Complex.normSq_nonneg _) (zpow_nonneg z.im_pos.le _)
   have hg_ae : g =ᶠ[ae ((volume : Measure ℍ).restrict fd)] 0 := by
     rwa [← integral_eq_zero_iff_of_nonneg_ae (ae_of_all _ hg_nonneg) hint.re]
   have hg_cont : Continuous g :=
@@ -221,8 +267,7 @@ theorem eq_zero_on_fd_of_peterssonInner_self_eq_zero {k : ℤ} {f : ℍ → ℂ}
   have hgτ : g τ = 0 :=
     Measure.eqOn_of_ae_eq hg_ae hg_cont.continuousOn continuousOn_const
       (by rw [← fdo_eq_interior_fd, ← fd_eq_closure_fdo]) hτ
-  simp only [g, petersson] at hgτ
-  rw [petersson_self_re_eq] at hgτ
+  simp only [g, petersson_self_eq_ofReal, Complex.ofReal_re] at hgτ
   exact Complex.normSq_eq_zero.mp ((mul_eq_zero.mp hgτ).elim id
     (fun h ↦ absurd h (ne_of_gt (zpow_pos τ.im_pos k))))
 
@@ -267,16 +312,8 @@ theorem peterssonInnerFd_self_im (f : CuspForm Γ k) : (peterssonInnerFd f f).im
 `|f τ|² (Im τ)ᵏ ≥ 0` over the fundamental domain. -/
 theorem peterssonInnerFd_self_re_nonneg (f : CuspForm Γ k) :
     0 ≤ (peterssonInnerFd f f).re := by
-  rw [peterssonInnerFd_def, UpperHalfPlane.peterssonInner_def]
-  have hpt : ∀ τ : ℍ, UpperHalfPlane.petersson k (⇑f) (⇑f) τ =
-      ((‖f τ‖ ^ 2 * τ.im ^ k : ℝ) : ℂ) := fun τ ↦ by
-    simp [UpperHalfPlane.petersson, Complex.conj_mul', Complex.ofReal_mul,
-      Complex.ofReal_zpow]
-  simp only [hpt, integral_complex_ofReal, Complex.ofReal_re]
-  refine MeasureTheory.setIntegral_nonneg ModularGroup.isClosed_fd.measurableSet
-    fun τ _ ↦ ?_
-  have him : (0 : ℝ) < τ.im := τ.im_pos
-  positivity
+  rw [peterssonInnerFd_def]
+  exact UpperHalfPlane.peterssonInner_self_re_nonneg k _ _
 
 /-- The pairing vanishes when its right argument is zero. -/
 @[simp]

--- a/TauCeti/NumberTheory/ModularForms/Petersson/Basic.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/Basic.lean
@@ -171,7 +171,7 @@ theorem peterssonInner_self_eq_ofReal (k : ℤ) (D : Set ℍ) (h : ℍ → ℂ) 
   simp_rw [petersson_self_eq_ofReal]
   exact integral_ofReal
 
-/-- The Petersson self-pairing over a measurable domain is nonnegative, for any function:
+/-- The Petersson self-pairing over any domain is nonnegative, for any function:
 the integrand `‖h τ‖² (Im τ)^k` is. -/
 theorem peterssonInner_self_re_nonneg (k : ℤ) (D : Set ℍ)
     (h : ℍ → ℂ) : 0 ≤ (peterssonInner k D h h).re := by

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -71,15 +71,19 @@ open Matrix.SpecialLinearGroup
 
 open scoped MatrixGroups ModularForm ComplexConjugate
 
+namespace Subgroup
+
+/-- The coset space of `Γ.withCenter` is finite when `Γ` has finite index; this is what makes
+the defining sum of `CuspForm.peterssonInnerCosets` a finite one. -/
+noncomputable instance fintypeQuotientWithCenter {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex] :
+    Fintype (SL(2, ℤ) ⧸ Γ.withCenter) :=
+  Subgroup.fintypeQuotientOfFiniteIndex
+
+end Subgroup
+
 namespace CuspForm
 
 variable {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex] {k : ℤ}
-
-/-- The effective coset space is finite, which is what makes the defining sum below a finite
-one. -/
-noncomputable instance instFintypeQuotientWithCenter :
-    Fintype (SL(2, ℤ) ⧸ Γ.withCenter) :=
-  Subgroup.fintypeQuotientOfFiniteIndex
 
 /-- The **Petersson inner product** on `S_k(Γ)` for a finite-index `Γ ≤ SL₂(ℤ)`: the sum,
 over the cosets of `Γ·{±I}` in `SL₂(ℤ)`, of the level-one pairing of the correspondingly

--- a/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
+++ b/TauCeti/NumberTheory/ModularForms/Petersson/FiniteIndex.lean
@@ -1,0 +1,314 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.ModularForms.Basic
+public import TauCeti.NumberTheory.ModularForms.Petersson.Basic
+public import TauCeti.GroupTheory.Index
+public import TauCeti.LinearAlgebra.Matrix.SpecialLinearGroup.Basic
+
+/-!
+# The Petersson inner product for a finite-index subgroup
+
+The Petersson pairing of `Mathlib.NumberTheory.ModularForms.Petersson` is integrated over
+the standard fundamental domain `𝒟` of `SL₂(ℤ)`, which is too small for forms on a proper
+subgroup `Γ ≤ SL₂(ℤ)`: a fundamental domain for `Γ` is tiled by `[SL₂(ℤ) : Γ·{±I}]` translates of
+`𝒟`. This file defines the pairing on `S_k(Γ)` as the corresponding sum over cosets,
+
+`⟪f, g⟫ = ∑_{[δ] ∈ SL₂(ℤ)/Γ·{±I}} ∫_𝒟 conj((f ∣[k] δ⁻¹)(τ)) (g ∣[k] δ⁻¹)(τ) (Im τ)^k dμ`,
+
+and establishes that it is a positive-definite Hermitian form: conjugate-symmetric, additive
+and complex-linear in the second argument, conjugate-linear in the first, and vanishing on
+the diagonal only at `0`.
+
+The sum runs over the cosets of `Γ·{±I}`, not of `Γ`: since `-I` acts trivially on `ℍ`, the
+cosets of `q` and `-q` carry the same translate of `𝒟`, so indexing by `Γ` alone would count
+every translate twice whenever `-I ∉ Γ`. The summand does not depend on the chosen
+representative: the `Γ` part of the subgroup fixes a `Γ`-invariant form, and `-I` scales it by
+the real sign `(-1)^k`, which the conjugate-linear pairing cancels against itself.
+
+Finite index is what makes the sum finite, and it is also exactly what makes the image of `Γ`
+in `GL(2, ℝ)` arithmetic, which the definiteness argument needs. Taking `Γ = Γ₁(N)` gives the
+classical level-`N` Petersson product.
+
+The pairing is deliberately left un-normalized by the volume of the fundamental domain: a
+positive-definite Hermitian form is all that the adjoint theory downstream needs.
+
+## Main definitions
+
+* `CuspForm.peterssonInnerCosets`: the Petersson inner product on `S_k(Γ)`.
+
+## Main results
+
+* `Subgroup.mem_withCenter_iff`: an element of `Γ·{±I}` is `±` one of `Γ`.
+* `CuspForm.peterssonInner_slash_of_mem_withCenter`: the summand is independent of the coset
+  representative, which is what makes the sum well defined.
+* `CuspForm.peterssonInnerCosets_conj_symm`: Hermitian symmetry.
+* `CuspForm.peterssonInnerCosets_add_left`/`_right`, `_smul_right`, `_smul_left`:
+  sesquilinearity.
+* `CuspForm.peterssonInnerCosets_definite`: positive definiteness.
+* `CuspForm.peterssonInnerCosetsCore`: the pairing bundled as an `InnerProductSpace.Core`.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/Modularforms/PeterssonLevelN.lean`, Chris Birkbeck,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the
+bespoke hyperbolic measure replaced by the `volume` of `ℍ` used throughout TauCeti, and
+stated for an arbitrary finite-index subgroup rather than only `Γ₁(N)`.
+
+## References
+
+* [F. Diamond and J. Shurman, *A first course in modular forms*][diamondshurman2005],
+  Section 5.4.
+-/
+
+public section
+
+open MeasureTheory UpperHalfPlane ModularGroup Complex
+open Matrix.SpecialLinearGroup
+
+open scoped MatrixGroups ModularForm ComplexConjugate
+
+namespace CuspForm
+
+variable {Γ : Subgroup SL(2, ℤ)} [Γ.FiniteIndex] {k : ℤ}
+
+/-- The effective coset space is finite, which is what makes the defining sum below a finite
+one. -/
+noncomputable instance instFintypeQuotientWithCenter :
+    Fintype (SL(2, ℤ) ⧸ Γ.withCenter) :=
+  Subgroup.fintypeQuotientOfFiniteIndex
+
+/-- The **Petersson inner product** on `S_k(Γ)` for a finite-index `Γ ≤ SL₂(ℤ)`: the sum,
+over the cosets of `Γ·{±I}` in `SL₂(ℤ)`, of the level-one pairing of the correspondingly
+slashed forms. The subgroup is `Γ.withCenter`, not `Γ`, because `-I` acts trivially on `ℍ`.
+For `Γ = Γ₁(N)` this is the classical level-`N` Petersson product. -/
+noncomputable def peterssonInnerCosets
+    (f g : CuspForm (Γ.map (mapGL ℝ)) k) : ℂ :=
+  ∑ q : SL(2, ℤ) ⧸ Γ.withCenter,
+    UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] (q.out)⁻¹) (⇑g ∣[k] (q.out)⁻¹)
+
+/-- Unfolding: the pairing is the coset sum of level-one pairings. -/
+theorem peterssonInnerCosets_def (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f g = ∑ q : SL(2, ℤ) ⧸ Γ.withCenter,
+      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] (q.out)⁻¹) (⇑g ∣[k] (q.out)⁻¹) := (rfl)
+
+/-- Hermitian symmetry of the coset pairing. -/
+@[simp]
+theorem peterssonInnerCosets_conj_symm (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    conj (peterssonInnerCosets g f) = peterssonInnerCosets f g := by
+  simp only [peterssonInnerCosets, map_sum, peterssonInner_conj_symm]
+
+/-- The coset pairing vanishes when its second argument does. -/
+@[simp]
+theorem peterssonInnerCosets_zero_right (f : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f 0 = 0 := by
+  simp [peterssonInnerCosets]
+
+/-- The coset pairing vanishes when its first argument does. -/
+@[simp]
+theorem peterssonInnerCosets_zero_left (g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets 0 g = 0 := by
+  simp [peterssonInnerCosets]
+
+omit [Γ.FiniteIndex] in
+private theorem out_one_mem_WithCenter :
+    ((QuotientGroup.mk 1 : SL(2, ℤ) ⧸ Γ.withCenter)).out ∈ Γ.withCenter := by
+  have h : (QuotientGroup.mk
+      ((QuotientGroup.mk 1 : SL(2, ℤ) ⧸ Γ.withCenter)).out : SL(2, ℤ) ⧸ Γ.withCenter) =
+      QuotientGroup.mk 1 := Quotient.out_eq _
+  simpa using (Γ.withCenter).inv_mem (QuotientGroup.eq.mp h)
+
+omit [Γ.FiniteIndex] in
+/-- Membership in `Γ·{±I}`: its elements are exactly `±` the elements of `Γ`. The adjoined
+centre of `SL₂(ℤ)` is `{±I}`, so the supremum only adds the negatives. -/
+@[simp]
+theorem _root_.Subgroup.mem_withCenter_iff {γ : SL(2, ℤ)} :
+    γ ∈ Γ.withCenter ↔ ∃ γ' ∈ Γ, γ = γ' ∨ γ = -γ' := by
+  refine ⟨fun hγ ↦ ?_, ?_⟩
+  · rw [Subgroup.withCenter_def, ← SetLike.mem_coe, Subgroup.mul_normal] at hγ
+    obtain ⟨a, ha, b, hb, rfl⟩ := hγ
+    obtain ⟨r, hr, hscal⟩ := Matrix.SpecialLinearGroup.mem_center_iff.mp hb
+    have hb1 : b = 1 ∨ b = -1 := by
+      have : r = 1 ∨ r = -1 :=
+        Int.isUnit_iff.mp (IsUnit.of_mul_eq_one r (by simpa [pow_two] using hr))
+      rcases this with rfl | rfl
+      · exact Or.inl (Subtype.ext (by simpa using hscal.symm))
+      · exact Or.inr (Subtype.ext (by simpa using hscal.symm))
+    refine ⟨a, ha, ?_⟩
+    rcases hb1 with rfl | rfl
+    · exact Or.inl (by simp)
+    · exact Or.inr (by simp)
+  · rintro ⟨γ', hγ', rfl | rfl⟩
+    · exact Γ.le_withCenter hγ'
+    · have hcenter : (-1 : SL(2, ℤ)) ∈ Subgroup.center SL(2, ℤ) :=
+        Subgroup.mem_center_iff.mpr fun g ↦ by rw [neg_one_mul, mul_neg_one]
+      exact Subgroup.withCenter_def Γ ▸ mul_neg_one γ' ▸ Subgroup.mul_mem_sup hγ' hcenter
+
+omit [Γ.FiniteIndex] in
+/-- **The summand does not depend on the coset representative**: the level-one-domain pairing
+is unchanged by slashing with `Γ·{±I}`. The `Γ` part fixes a `Γ`-invariant form, and `-I`
+scales it by the real sign `(-1)^k`, which the conjugate-linear pairing cancels against
+itself. This is what lets the defining sum be reindexed over the coset space. -/
+theorem peterssonInner_slash_of_mem_withCenter
+    (f g : CuspForm (Γ.map (mapGL ℝ)) k) {γ : SL(2, ℤ)} (hγ : γ ∈ Γ.withCenter) :
+    UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] γ) (⇑g ∣[k] γ) = peterssonInnerFd f g := by
+  obtain ⟨γ', hγ', hcase⟩ := Subgroup.mem_withCenter_iff.mp hγ
+  rcases hcase with rfl | rfl
+  · rw [SlashInvariantFormClass.SL_slash_eq f _ hγ',
+      SlashInvariantFormClass.SL_slash_eq g _ hγ', peterssonInnerFd_def]
+  · -- the `SL(2, ℤ)` slash action goes through `mapGL ℝ`, which sends `-I` to `-I`
+    have hcoe : ((-1 : SL(2, ℤ)) : GL (Fin 2) ℝ) = -1 := mapGL_neg_one
+    have hneg : ∀ h : ℍ → ℂ, h ∣[k] (-γ') = (-1 : ℂ) ^ k • (h ∣[k] γ') := fun h ↦ by
+      rw [← mul_neg_one γ', SlashAction.slash_mul, ModularForm.SL_slash (γ := (-1 : SL(2, ℤ))),
+        hcoe, ModularForm.slash_neg_one]
+    rw [hneg, hneg, SlashInvariantFormClass.SL_slash_eq f _ hγ',
+      SlashInvariantFormClass.SL_slash_eq g _ hγ',
+      peterssonInner_smul_right, peterssonInner_smul_left, peterssonInnerFd_def]
+    have hreal : (starRingEnd ℂ) ((-1 : ℂ) ^ k) = (-1 : ℂ) ^ k := by simp
+    have hsq : ((-1 : ℂ) ^ k) * ((-1 : ℂ) ^ k) = 1 := by
+      rw [← zpow_add₀ (by norm_num : (-1 : ℂ) ≠ 0), ← two_mul, zpow_mul]
+      norm_num
+    rw [hreal, ← mul_assoc, hsq, one_mul]
+
+omit [Γ.FiniteIndex] in
+/-- Each summand of the self-pairing is a non-negative real: the integrand is
+`‖(f ∣[k] q.out⁻¹)(τ)‖² (Im τ)^k`. -/
+private theorem peterssonInnerCosets_summand_nonneg
+    (f : CuspForm (Γ.map (mapGL ℝ)) k) (q : SL(2, ℤ) ⧸ Γ.withCenter) :
+    ∃ r : ℝ, 0 ≤ r ∧
+      UpperHalfPlane.peterssonInner k fd (⇑f ∣[k] (q.out)⁻¹) (⇑f ∣[k] (q.out)⁻¹) = (r : ℂ) := by
+  set h := ⇑f ∣[k] (q.out)⁻¹ with hh
+  refine ⟨∫ τ in fd, normSq (h τ) * τ.im ^ k, ?_,
+    UpperHalfPlane.peterssonInner_self_eq_ofReal k fd h⟩
+  have hnn := UpperHalfPlane.peterssonInner_self_re_nonneg k fd h
+  rwa [UpperHalfPlane.peterssonInner_self_eq_ofReal, Complex.ofReal_re] at hnn
+
+/-- **Positive definiteness** of the Petersson inner product: every summand of the
+self-pairing is non-negative, so the whole sum vanishes only if the identity-coset summand
+does, and that summand is the level-one pairing. -/
+theorem peterssonInnerCosets_definite (f : CuspForm (Γ.map (mapGL ℝ)) k)
+    (hpet : peterssonInnerCosets f f = 0) : f = 0 := by
+  apply peterssonInnerFd_definite f
+  rw [← peterssonInner_slash_of_mem_withCenter f f
+    ((Γ.withCenter).inv_mem out_one_mem_WithCenter)]
+  choose r hr_nonneg hr_eq using peterssonInnerCosets_summand_nonneg f
+  have hsum : ((∑ q, r q : ℝ) : ℂ) = 0 := by
+    rw [Complex.ofReal_sum]
+    simp_rw [← hr_eq]
+    exact hpet
+  rw [hr_eq (QuotientGroup.mk 1), (Finset.sum_eq_zero_iff_of_nonneg fun q _ ↦ hr_nonneg q).mp
+    (Complex.ofReal_eq_zero.mp hsum) (QuotientGroup.mk 1) (Finset.mem_univ _), Complex.ofReal_zero]
+
+/-- Negation in the second argument. -/
+@[simp]
+theorem peterssonInnerCosets_neg_right (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f (-g) = -peterssonInnerCosets f g := by
+  simp only [peterssonInnerCosets, FunLike.coe_neg, SlashAction.neg_slash,
+    peterssonInner_neg_right, Finset.sum_neg_distrib]
+
+/-- Negation in the first argument. -/
+@[simp]
+theorem peterssonInnerCosets_neg_left (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets (-f) g = -peterssonInnerCosets f g := by
+  simp only [peterssonInnerCosets, FunLike.coe_neg, SlashAction.neg_slash,
+    peterssonInner_neg_left, Finset.sum_neg_distrib]
+
+/-- Additivity in the second argument. -/
+@[simp]
+theorem peterssonInnerCosets_add_right (f g₁ g₂ : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f (g₁ + g₂) =
+      peterssonInnerCosets f g₁ + peterssonInnerCosets f g₂ := by
+  simp only [peterssonInnerCosets, ← Finset.sum_add_distrib]
+  refine Finset.sum_congr rfl fun q _ ↦ ?_
+  rw [FunLike.coe_add, SlashAction.add_slash]
+  exact peterssonInner_add_right k fd _ _ _
+    (integrableOn_petersson_slash k _ f g₁ (q.out)⁻¹)
+    (integrableOn_petersson_slash k _ f g₂ (q.out)⁻¹)
+
+/-- Complex-linearity in the second argument. -/
+@[simp]
+theorem peterssonInnerCosets_smul_right (c : ℂ)
+    (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f (c • g) = c * peterssonInnerCosets f g := by
+  simp only [peterssonInnerCosets, Finset.mul_sum]
+  refine Finset.sum_congr rfl fun q _ ↦ ?_
+  rw [FunLike.coe_smul, ModularForm.SL_smul_slash]
+  exact peterssonInner_smul_right k _ c _ _
+
+/-- Conjugate-linearity in the first argument. -/
+@[simp]
+theorem peterssonInnerCosets_smul_left (c : ℂ)
+    (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets (c • f) g = conj c * peterssonInnerCosets f g :=
+  calc peterssonInnerCosets (c • f) g
+      = conj (peterssonInnerCosets g (c • f)) := (peterssonInnerCosets_conj_symm _ _).symm
+    _ = conj (c * peterssonInnerCosets g f) := by rw [peterssonInnerCosets_smul_right]
+    _ = conj c * conj (peterssonInnerCosets g f) := map_mul _ _ _
+    _ = conj c * peterssonInnerCosets f g := by rw [peterssonInnerCosets_conj_symm]
+
+/-- Additivity in the first argument. -/
+@[simp]
+theorem peterssonInnerCosets_add_left (f₁ f₂ g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets (f₁ + f₂) g =
+      peterssonInnerCosets f₁ g + peterssonInnerCosets f₂ g :=
+  calc peterssonInnerCosets (f₁ + f₂) g
+      = conj (peterssonInnerCosets g (f₁ + f₂)) := (peterssonInnerCosets_conj_symm _ _).symm
+    _ = conj (peterssonInnerCosets g f₁ + peterssonInnerCosets g f₂) := by
+        rw [peterssonInnerCosets_add_right]
+    _ = conj (peterssonInnerCosets g f₁) + conj (peterssonInnerCosets g f₂) := map_add _ _ _
+    _ = peterssonInnerCosets f₁ g + peterssonInnerCosets f₂ g := by
+        rw [peterssonInnerCosets_conj_symm, peterssonInnerCosets_conj_symm]
+
+/-- The self-pairing is nonnegative: each coset summand is a nonnegative real. -/
+theorem peterssonInnerCosets_self_re_nonneg (f : CuspForm (Γ.map (mapGL ℝ)) k) :
+    0 ≤ (peterssonInnerCosets f f).re := by
+  rw [peterssonInnerCosets_def, Complex.re_sum]
+  refine Finset.sum_nonneg fun q _ ↦ ?_
+  obtain ⟨r, hr, heq⟩ := peterssonInnerCosets_summand_nonneg f q
+  rw [heq, Complex.ofReal_re]
+  exact hr
+
+/-- The self-pairing is real: its imaginary part vanishes, by Hermitian symmetry. -/
+@[simp]
+theorem peterssonInnerCosets_self_im (f : CuspForm (Γ.map (mapGL ℝ)) k) :
+    (peterssonInnerCosets f f).im = 0 :=
+  Complex.conj_eq_iff_im.mp (peterssonInnerCosets_conj_symm f f)
+
+/-- The self-pairing vanishes exactly on the zero form. -/
+@[simp]
+theorem peterssonInnerCosets_self_eq_zero (f : CuspForm (Γ.map (mapGL ℝ)) k) :
+    peterssonInnerCosets f f = 0 ↔ f = 0 :=
+  ⟨peterssonInnerCosets_definite f, fun h ↦ by rw [h]; exact peterssonInnerCosets_zero_left 0⟩
+
+/-- The Petersson pairing bundled as an `InnerProductSpace.Core` on `S_k(Γ)`: the Hermitian
+interface behind Mathlib's inner-product, norm, orthogonality and adjoint APIs, which the
+adjoint theory consumes. Evaluation is `peterssonInnerCosetsCore_inner`.
+
+Unlike the level-one `peterssonInnerCore`, this one does integrate over a fundamental domain
+for the group in question, so it is the genuine Petersson product of `Γ`. It is still a
+plain `def` rather than an instance, following the same convention: consumers name it
+explicitly, and no `InnerProductSpace` instance is derived from it. The
+`@[instance_reducible]` attribute is required by Lean's class-definition reducibility linter
+for any `def` of class type. -/
+@[instance_reducible]
+noncomputable def peterssonInnerCosetsCore :
+    InnerProductSpace.Core ℂ (CuspForm (Γ.map (mapGL ℝ)) k) where
+  inner := peterssonInnerCosets
+  conj_inner_symm := peterssonInnerCosets_conj_symm
+  re_inner_nonneg := peterssonInnerCosets_self_re_nonneg
+  add_left := peterssonInnerCosets_add_left
+  smul_left f g c := peterssonInnerCosets_smul_left c f g
+  definite := peterssonInnerCosets_definite
+
+/-- Evaluation of the bundled core: its inner product is `peterssonInnerCosets`. -/
+@[simp]
+theorem peterssonInnerCosetsCore_inner
+    (f g : CuspForm (Γ.map (mapGL ℝ)) k) :
+    (peterssonInnerCosetsCore :
+        InnerProductSpace.Core ℂ (CuspForm (Γ.map (mapGL ℝ)) k)).inner f g =
+      peterssonInnerCosets f g := (rfl)
+
+end CuspForm


### PR DESCRIPTION
Mathlib's Petersson pairing is integrated over the standard fundamental domain `𝒟` of `SL₂(ℤ)`, which is too small for forms of level `N`: a fundamental domain for `Γ₁(N)` is tiled by `[SL₂(ℤ) : Γ₁(N)]` translates of `𝒟`. This defines the level-`N` pairing on `S_k(Γ₁(N))` as the corresponding sum over cosets,

`⟪f, g⟫_N = ∑_{[δ] ∈ SL₂(ℤ)/Γ₁(N)} ∫_𝒟 conj((f ∣[k] δ⁻¹)(τ)) · (g ∣[k] δ⁻¹)(τ) · (Im τ)^k dμ`,

and establishes that it is a positive-definite Hermitian form.

* `CuspForm.peterssonInnerGamma1`: the definition, with `Γ₁(N)` of finite index supplying the `Fintype` on the coset space that makes the sum finite.
* `CuspForm.peterssonInnerGamma1_conj_symm`, `_add_left`/`_right`, `_smul_right`, `_conj_smul_left`, `_neg_left`/`_right`, `_zero_left`/`_right`: sesquilinearity.
* `CuspForm.peterssonInnerGamma1_definite`: positive definiteness. Every summand of the self-pairing is a non-negative real (`peterssonInnerGamma1_summand_nonneg`, the integrand being `‖f(τ)‖²(Im τ)^k`), so the sum vanishes only if each summand does; the identity-coset summand is the level-one pairing `peterssonInnerFd`, where definiteness is already known.
* `CuspForm.integrableOn_petersson_slash`: the Petersson integrand of slashed forms is integrable over `𝒟`, which is what additivity needs. Stated for an arbitrary arithmetic `Γ` and any cusp-form/modular-form classes, not just for `Γ₁(N)`.
* `CuspForm.slash_Gamma1_eq`: the slash action of `Γ₁(N)` fixes a form of level `N` — why the summand does not depend on the coset representative.

Ported from the AINTLIB `LeanModularForms` project (`LeanModularForms/Modularforms/PeterssonLevelN.lean`, Chris Birkbeck). Two deviations from the source, both to match what is already here: AINTLIB integrates against a bespoke `hyperbolicMeasure`, whereas TauCeti's `peterssonInner` uses the `volume` of `ℍ`; and the fundamental domain's measurability comes from Mathlib's `ModularGroup.isClosed_fd` rather than being rederived. That file's measure-theoretic half is already in TauCeti as `MeasureTheory/Group/FundamentalDomain.lean`, and its PSL fundamental-domain half is left for a separate PR.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/TauCetiRoadmap/ModularForms/README.md), Layer 3 ("the Petersson inner product, adjoints, oldforms and newforms"), whose first item is the level-`N` pairing on `S_k(Γ)` and which names AINTLIB's `petN` (`Modularforms/PeterssonLevelN.lean`) as its provenance. The adjoint relation `Tₙ* = ⟨n⟩⁻¹Tₙ` and the old/new decomposition are stated against exactly this pairing.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
