### PR TITLE
feat(ModularForms): the arc integral collapses to the weight term

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -70,7 +70,7 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
 /-- The reflected-half integrability: interval integrability of the arc contour
 integrand on `[2, 3]` follows from integrability on `[1, 2]` through the pairing, which
 writes the second half as a reflected constant-minus-first-half integrand. -/
-theorem intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc_snd
+theorem intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_segment3
     [SlashInvariantFormClass F Γ k] (f : F) (hS : ModularGroup.S ∈ Γ) {H : ℝ}
     (hd : ∀ t ∈ Ioo (1 : ℝ) 2, DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
     (hne : ∀ t ∈ Ioo (1 : ℝ) 2, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
@@ -128,7 +128,7 @@ theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
       (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 :=
     ((intervalIntegrable_logDeriv_fdBoundary_arc H ⟨le_rfl, by norm_num⟩
       ⟨by norm_num, by norm_num⟩).const_mul _).neg
-  have hint' := intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc_snd
+  have hint' := intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_segment3
     f hS hd hne hint
   rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
   have h23 : (∫ t in (2 : ℝ)..3,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -64,13 +64,16 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
   ring
 
 
-/-- The arc integral of the logarithmic-derivative contour integrand collapses to the
-weight term: under the substitution `t ↦ 4 - t` the two halves of the arc pair through
-the `S`-transformation, leaving `-k` times the arc integral of `γ' / γ`. -/
-theorem intervalIntegral_logDeriv_fdBoundary_arc [SlashInvariantFormClass F Γ k] (f : F)
+/-- The arc contour integral of a slash-invariant form's logarithmic derivative is
+`-(k * (π/6 * I))` — the arc's `-k/12` contribution to the `(2πi)⁻¹`-normalized valence
+contour. The two halves of the arc pair through the `S`-transformation under the
+substitution `t ↦ 4 - t`, leaving `-k` times the constant arc integral of the contour's
+own logarithmic derivative. -/
+theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
+    [SlashInvariantFormClass F Γ k] (f : F)
     (hS : ModularGroup.S ∈ Γ) {H : ℝ}
-    (hd : ∀ t ∈ Icc (1 : ℝ) 3, DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
-    (hne : ∀ t ∈ Icc (1 : ℝ) 3, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
+    (hd : ∀ t ∈ Ioo (1 : ℝ) 2, DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
+    (hne : ∀ t ∈ Ioo (1 : ℝ) 2, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
     (hint : IntervalIntegrable
       (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
       volume 1 2)
@@ -96,7 +99,7 @@ theorem intervalIntegral_logDeriv_fdBoundary_arc [SlashInvariantFormClass F Γ k
     intro u hu
     have hu13 : u ∈ Ioo (1 : ℝ) 3 := ⟨hu.1, by linarith [hu.2]⟩
     have hp := logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg f hS hu13
-      (hd u ⟨hu13.1.le, hu13.2.le⟩) (hne u ⟨hu13.1.le, hu13.2.le⟩)
+      (hd u hu) (hne u hu)
     linear_combination hp
   have hconst : IntervalIntegrable
       (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 := by

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -67,6 +67,38 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
   ring
 
 
+/-- The reflected-half integrability: interval integrability of the arc contour
+integrand on `[2, 3]` follows from integrability on `[1, 2]` through the pairing, which
+writes the second half as a reflected constant-minus-first-half integrand. -/
+theorem intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc_snd
+    [SlashInvariantFormClass F Γ k] (f : F) (hS : ModularGroup.S ∈ Γ) {H : ℝ}
+    (hd : ∀ t ∈ Ioo (1 : ℝ) 2, DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
+    (hne : ∀ t ∈ Ioo (1 : ℝ) 2, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
+    (hint : IntervalIntegrable
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
+      volume 1 2) :
+    IntervalIntegrable
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
+      volume 2 3 := by
+  have hconst : IntervalIntegrable
+      (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 :=
+    ((intervalIntegrable_logDeriv_fdBoundary_arc H ⟨le_rfl, by norm_num⟩
+      ⟨by norm_num, by norm_num⟩).const_mul _).neg
+  have hI := ((hconst.sub hint).comp_sub_left 4).symm
+  have h42 : (4 : ℝ) - 2 = 2 := by norm_num
+  have h41 : (4 : ℝ) - 1 = 3 := by norm_num
+  rw [h42, h41] at hI
+  refine hI.congr_uIoo ?_
+  rw [Set.uIoo_of_le (by norm_num : (2 : ℝ) ≤ 3)]
+  intro x hx
+  have hu : 4 - x ∈ Ioo (1 : ℝ) 2 := ⟨by linarith [hx.2], by linarith [hx.1]⟩
+  have hp := logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg f hS
+    ⟨hu.1, by linarith [hu.2]⟩ (hd _ hu) (hne _ hu)
+  have hxx : (4 : ℝ) - (4 - x) = x := by ring
+  rw [hxx] at hp
+  simp only [smul_eq_mul] at hp ⊢
+  linear_combination -hp
+
 /-- The arc contour integral of a slash-invariant form's logarithmic derivative is
 `-(k * (π/6 * I))` — the arc's `-k/12` contribution to the `(2πi)⁻¹`-normalized valence
 contour. The two halves of the arc pair through the `S`-transformation under the
@@ -93,34 +125,21 @@ theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
       (hd u hu) (hne u hu)
     linear_combination hp
   have hconst : IntervalIntegrable
-      (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 := by
-    refine (intervalIntegrable_const
-      (c := -(↑k * (((Real.pi / 6 : ℝ) : ℂ) * Complex.I)))).congr_uIoo ?_
-    rw [Set.uIoo_of_le (by norm_num : (1 : ℝ) ≤ 2)]
-    intro u hu
-    simp only [logDeriv_fdBoundary_arc ⟨hu.1, by linarith [hu.2]⟩]
-  have hint' : IntervalIntegrable
-      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
-      volume 2 3 := by
-    have hI := ((hconst.sub hint).comp_sub_left 4).symm
-    norm_num at hI
-    refine hI.congr_uIoo ?_
-    rw [Set.uIoo_of_le (by norm_num : (2 : ℝ) ≤ 3)]
-    intro x hx
-    have hu : 4 - x ∈ Ioo (1 : ℝ) 2 := ⟨by linarith [hx.2], by linarith [hx.1]⟩
-    have hp := hpair (4 - x) hu
-    have hxx : (4 : ℝ) - (4 - x) = x := by ring
-    rw [hxx] at hp
-    simpa using hp.symm
+      (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 :=
+    ((intervalIntegrable_logDeriv_fdBoundary_arc H ⟨le_rfl, by norm_num⟩
+      ⟨by norm_num, by norm_num⟩).const_mul _).neg
+  have hint' := intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc_snd
+    f hS hd hne hint
   rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
   have h23 : (∫ t in (2 : ℝ)..3,
       deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) =
       ∫ u in (1 : ℝ)..2,
         deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) := by
-    have h := intervalIntegral.integral_comp_sub_left (a := 1) (b := 2)
-      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) 4
-    norm_num at h
-    exact h.symm
+    have h42 : (4 : ℝ) - 2 = 2 := by norm_num
+    have h41 : (4 : ℝ) - 1 = 3 := by norm_num
+    have h := intervalIntegral_comp_fdBoundary_four_sub H
+      (logDeriv (⇑f ∘ ofComplex)) (a := 1) (b := 2)
+    rwa [h42, h41] at h
   rw [h23, intervalIntegral.integral_congr_Ioo_of_le (by norm_num) hpair,
     intervalIntegral.integral_sub hconst hint, intervalIntegral.integral_neg,
     intervalIntegral.integral_const_mul,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -109,7 +109,8 @@ theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
     intro x hx
     have hu : 4 - x ∈ Ioo (1 : ℝ) 2 := ⟨by linarith [hx.2], by linarith [hx.1]⟩
     have hp := hpair (4 - x) hu
-    rw [show (4 : ℝ) - (4 - x) = x by ring] at hp
+    have hxx : (4 : ℝ) - (4 - x) = x := by ring
+    rw [hxx] at hp
     simpa using hp.symm
   rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
   have h23 : (∫ t in (2 : ℝ)..3,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -63,6 +63,55 @@ theorem logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg
   field_simp
   ring
 
+
+/-- The arc integral of the logarithmic-derivative contour integrand collapses to the
+weight term: under the substitution `t ↦ 4 - t` the two halves of the arc pair through
+the `S`-transformation, leaving `-k` times the arc integral of `γ' / γ`. -/
+theorem intervalIntegral_logDeriv_fdBoundary_arc [SlashInvariantFormClass F Γ k] (f : F)
+    (hS : ModularGroup.S ∈ Γ) {H : ℝ}
+    (hd : ∀ t ∈ Icc (1 : ℝ) 3, DifferentiableAt ℂ (⇑f ∘ ofComplex) (fdBoundary H t))
+    (hne : ∀ t ∈ Icc (1 : ℝ) 3, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
+    (hint : IntervalIntegrable
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
+      volume 1 2)
+    (hint' : IntervalIntegrable
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
+      volume 2 3) :
+    ∫ t in (1 : ℝ)..3,
+        deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t) =
+      -(k * ((Real.pi / 6 : ℝ) * Complex.I)) := by
+  rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
+  have h23 : (∫ t in (2 : ℝ)..3,
+      deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) =
+      ∫ u in (1 : ℝ)..2,
+        deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) := by
+    have h := intervalIntegral.integral_comp_sub_left (a := 1) (b := 2)
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) 4
+    norm_num at h
+    exact h.symm
+  have hpair : ∀ u ∈ Ioo (1 : ℝ) 2,
+      deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) =
+        -(↑k * logDeriv (fdBoundary H) u) -
+          deriv (fdBoundary H) u • logDeriv (⇑f ∘ ofComplex) (fdBoundary H u) := by
+    intro u hu
+    have hu13 : u ∈ Ioo (1 : ℝ) 3 := ⟨hu.1, by linarith [hu.2]⟩
+    have hp := logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg f hS hu13
+      (hd u ⟨hu13.1.le, hu13.2.le⟩) (hne u ⟨hu13.1.le, hu13.2.le⟩)
+    linear_combination hp
+  have hconst : IntervalIntegrable
+      (fun u : ℝ ↦ -(↑k * logDeriv (fdBoundary H) u)) volume 1 2 := by
+    refine (intervalIntegrable_const
+      (c := -(↑k * (((Real.pi / 6 : ℝ) : ℂ) * Complex.I)))).congr_uIoo ?_
+    rw [Set.uIoo_of_le (by norm_num : (1 : ℝ) ≤ 2)]
+    intro u hu
+    simp only [logDeriv_fdBoundary_arc ⟨hu.1, by linarith [hu.2]⟩]
+  rw [h23, intervalIntegral.integral_congr_Ioo_of_le (by norm_num) hpair,
+    intervalIntegral.integral_sub hconst hint, intervalIntegral.integral_neg,
+    intervalIntegral.integral_const_mul,
+    integral_logDeriv_fdBoundary_arc H (by norm_num) (by norm_num)]
+  push_cast
+  ring
+
 end ModularForm
 
 end TauCeti

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ArcPairing.lean
@@ -25,6 +25,9 @@ the term that lands as `k/12` on the divisor side of the valence formula.
 
 * `TauCeti.ModularForm.logDeriv_comp_ofComplex_fdBoundary_arc_add_four_sub_eq_neg`: the
   direct and reflected arc contour integrands sum to the negated weight term.
+* `TauCeti.ModularForm.intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc`:
+  the arc contour integral of the form's logarithmic derivative evaluates to
+  `-(k * (π/6 * I))`, the arc's `-k/12` contribution to the normalized valence contour.
 
 ## References
 
@@ -76,22 +79,10 @@ theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
     (hne : ∀ t ∈ Ioo (1 : ℝ) 2, (⇑f ∘ ofComplex) (fdBoundary H t) ≠ 0)
     (hint : IntervalIntegrable
       (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
-      volume 1 2)
-    (hint' : IntervalIntegrable
-      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
-      volume 2 3) :
+      volume 1 2) :
     ∫ t in (1 : ℝ)..3,
         deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t) =
       -(k * ((Real.pi / 6 : ℝ) * Complex.I)) := by
-  rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
-  have h23 : (∫ t in (2 : ℝ)..3,
-      deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) =
-      ∫ u in (1 : ℝ)..2,
-        deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) := by
-    have h := intervalIntegral.integral_comp_sub_left (a := 1) (b := 2)
-      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) 4
-    norm_num at h
-    exact h.symm
   have hpair : ∀ u ∈ Ioo (1 : ℝ) 2,
       deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) =
         -(↑k * logDeriv (fdBoundary H) u) -
@@ -108,6 +99,27 @@ theorem intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
     rw [Set.uIoo_of_le (by norm_num : (1 : ℝ) ≤ 2)]
     intro u hu
     simp only [logDeriv_fdBoundary_arc ⟨hu.1, by linarith [hu.2]⟩]
+  have hint' : IntervalIntegrable
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t))
+      volume 2 3 := by
+    have hI := ((hconst.sub hint).comp_sub_left 4).symm
+    norm_num at hI
+    refine hI.congr_uIoo ?_
+    rw [Set.uIoo_of_le (by norm_num : (2 : ℝ) ≤ 3)]
+    intro x hx
+    have hu : 4 - x ∈ Ioo (1 : ℝ) 2 := ⟨by linarith [hx.2], by linarith [hx.1]⟩
+    have hp := hpair (4 - x) hu
+    rw [show (4 : ℝ) - (4 - x) = x by ring] at hp
+    simpa using hp.symm
+  rw [← intervalIntegral.integral_add_adjacent_intervals hint hint']
+  have h23 : (∫ t in (2 : ℝ)..3,
+      deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) =
+      ∫ u in (1 : ℝ)..2,
+        deriv (fdBoundary H) (4 - u) • logDeriv (⇑f ∘ ofComplex) (fdBoundary H (4 - u)) := by
+    have h := intervalIntegral.integral_comp_sub_left (a := 1) (b := 2)
+      (fun t ↦ deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t)) 4
+    norm_num at h
+    exact h.symm
   rw [h23, intervalIntegral.integral_congr_Ioo_of_le (by norm_num) hpair,
     intervalIntegral.integral_sub hconst hint, intervalIntegral.integral_neg,
     intervalIntegral.integral_const_mul,

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -279,6 +279,25 @@ theorem integral_logDeriv_fdBoundary_arc (H : ℝ) {a b : ℝ} (ha : a ∈ Set.I
   push_cast
   ring
 
+
+/-- The contour's logarithmic derivative is interval-integrable on arc subintervals: it
+is the constant `π/6 · i` on the open arc. -/
+theorem intervalIntegrable_logDeriv_fdBoundary_arc (H : ℝ) {a b : ℝ}
+    (ha : a ∈ Set.Icc (1 : ℝ) 3) (hb : b ∈ Set.Icc (1 : ℝ) 3) :
+    IntervalIntegrable (logDeriv (fdBoundary H)) MeasureTheory.volume a b := by
+  refine (intervalIntegrable_const
+    (c := ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)).congr_uIoo fun t ht ↦ ?_
+  exact (logDeriv_fdBoundary_arc ⟨lt_of_le_of_lt (le_inf ha.1 hb.1) ht.1,
+    lt_of_lt_of_le ht.2 (sup_le ha.2 hb.2)⟩).symm
+
+/-- Substituting the reflection `t ↦ 4 - t` in a boundary contour integral. -/
+theorem intervalIntegral_comp_fdBoundary_four_sub {E : Type*} [NormedAddCommGroup E]
+    [NormedSpace ℂ E] (H : ℝ) (φ : ℂ → E) {a b : ℝ} :
+    ∫ t in (4 - b : ℝ)..(4 - a), deriv (fdBoundary H) t • φ (fdBoundary H t) =
+      ∫ u in a..b, deriv (fdBoundary H) (4 - u) • φ (fdBoundary H (4 - u)) :=
+  (intervalIntegral.integral_comp_sub_left
+    (fun t ↦ deriv (fdBoundary H) t • φ (fdBoundary H t)) 4).symm
+
 end Reflection
 
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Deriv.lean
@@ -285,10 +285,9 @@ is the constant `π/6 · i` on the open arc. -/
 theorem intervalIntegrable_logDeriv_fdBoundary_arc (H : ℝ) {a b : ℝ}
     (ha : a ∈ Set.Icc (1 : ℝ) 3) (hb : b ∈ Set.Icc (1 : ℝ) 3) :
     IntervalIntegrable (logDeriv (fdBoundary H)) MeasureTheory.volume a b := by
-  refine (intervalIntegrable_const
-    (c := ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)).congr_uIoo fun t ht ↦ ?_
-  exact (logDeriv_fdBoundary_arc ⟨lt_of_le_of_lt (le_inf ha.1 hb.1) ht.1,
-    lt_of_lt_of_le ht.2 (sup_le ha.2 hb.2)⟩).symm
+  exact (intervalIntegrable_const
+    (c := ((Real.pi / 6 : ℝ) : ℂ) * Complex.I)).congr_uIoo fun t ht ↦
+    (logDeriv_fdBoundary_arc (Set.uIoo_subset_Ioo ha hb ht)).symm
 
 /-- Substituting the reflection `t ↦ 4 - t` in a boundary contour integral. -/
 theorem intervalIntegral_comp_fdBoundary_four_sub {E : Type*} [NormedAddCommGroup E]

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/VerticalCancel.lean
@@ -51,10 +51,10 @@ theorem intervalIntegral_fdBoundary_segment4_eq_neg_segment1 {E : Type*}
       -∫ t in (0 : ℝ)..1, deriv (fdBoundary H) t • φ (fdBoundary H t) := by
   have hsub : (∫ t in (3 : ℝ)..4, deriv (fdBoundary H) t • φ (fdBoundary H t)) =
       ∫ u in (0 : ℝ)..1, deriv (fdBoundary H) (4 - u) • φ (fdBoundary H (4 - u)) := by
-    have h := intervalIntegral.integral_comp_sub_left (a := 0) (b := 1)
-      (fun t ↦ deriv (fdBoundary H) t • φ (fdBoundary H t)) 4
-    norm_num at h
-    exact h.symm
+    have h41 : (4 : ℝ) - 1 = 3 := by norm_num
+    have h40 : (4 : ℝ) - 0 = 4 := by norm_num
+    have h := intervalIntegral_comp_fdBoundary_four_sub H φ (a := 0) (b := 1)
+    rwa [h41, h40] at h
   rw [hsub, ← intervalIntegral.integral_neg]
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun u hu ↦ ?_
   rw [fdBoundary_four_sub_vertical H ⟨hu.1.le, hu.2.le⟩,


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The arc contour integral of a slash-invariant form's logarithmic derivative evaluates to
the weight term — the arc's `-k/12` contribution to the `(2πi)⁻¹`-normalized valence
contour:

- `intervalIntegral_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc
  [SlashInvariantFormClass F Γ k] (hS : ModularGroup.S ∈ Γ)
  (hd hne : pointwise on Ioo 1 2)
  (hint : IntervalIntegrable … volume 1 2) :
  ∫ t in 1..3, deriv (fdBoundary H) t • logDeriv (⇑f ∘ ofComplex) (fdBoundary H t) =
  -(k * (π/6 * I))`

The single integrability hypothesis is on `[1, 2]` only: integrability of the reflected
half on `[2, 3]` is derived through the pairing as the named
`intervalIntegrable_deriv_smul_logDeriv_comp_ofComplex_fdBoundary_arc_snd`, reusable by
contour-splitting callers. Supporting API extracted to `Deriv.lean`:
`intervalIntegrable_logDeriv_fdBoundary_arc` (the arc's logarithmic speed is integrable
on arc subintervals) and `intervalIntegral_comp_fdBoundary_four_sub` (the reflection
substitution, now shared with `VerticalCancel.lean`).

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): together with
the vertical cancellation (#2117) and the ceiling/cusp sub-chain (#2128, #2130, #2144),
it completes the integral-evaluation side of the valence contour.

Roadmap: ModularForms
