### PR TITLE
feat(HeckeRing): degrees of the diagonal double cosets

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
@@ -34,6 +34,11 @@ representatives with permuted diagonals.
 The rank-general constant case `deg T(c, ..., c) = 1` is in
 `TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean`.
 
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GLn/Degree.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck), split out of the rank-general material of that file, since
+the Γ₀-index computation is specific to rank two.
+
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],

--- a/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+
+/-!
+# The degree of a rank-two diagonal double coset
+
+The degree of a double coset is the relative index of the conjugated copy of `SL₂(ℤ)`. For a
+diagonal representative `a = (a₀, a₁)` with `a₀ ∣ a₁`, conjugating `SL₂(ℤ)` by `natDiagGL 2 a`
+carves out exactly `Γ₀(N)` for the ratio `N = a₁ / a₀`, so
+
+`deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`,
+
+and specializing to `N = pᵏ` with the index computed in
+`TauCeti.NumberTheory.ModularForms.CongruenceSubgroups` gives Shimura's `pᵏ⁻¹(p + 1)`.
+
+Note that the degree is not the number of diagonal representatives: for `a = (1, p)` that
+count is `p`, while the true degree is `p + 1` — the double coset also contains
+representatives with permuted diagonals.
+
+## Main results
+
+* `degree_diagCoset_eq_Gamma0_index`: `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]` for a divisibility
+  chain `a` whose ratio `N = a₁ / a₀` is positive.
+* `degree_diagCoset_of_ratio_eq_prime_pow`: `deg T(a₀, a₁) = pᵏ⁻¹(p + 1)` for a divisibility
+  chain `a` whose ratio is `pᵏ`, with `p` prime and `k ≥ 1`.
+
+The rank-general constant case `deg T(c, ..., c) = 1` is in
+`TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Propositions 3.14, 3.18 and Theorem 3.24.
+-/
+
+public section
+
+open HeckeRing HeckeRing.GLn Finset CongruenceSubgroup Matrix.SpecialLinearGroup Matrix
+open scoped Pointwise MatrixGroups
+
+namespace HeckeRing.GL2
+
+private lemma a1_eq_a0_mul_ratio {N : ℕ} {a : Fin 2 → ℕ}
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
+    (a 1 : ℚ) = (a 0 : ℚ) * (N : ℚ) := by
+  have h1 := Nat.div_mul_cancel h_dvd_a
+  rw [h_ratio] at h1
+  push_cast [← h1]; ring
+
+private lemma conj_natDiagGL_mem_of_dvd (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+    (hσ : (N : ℤ) ∣ σ.1 1 0) :
+    (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2 := by
+  obtain ⟨c, hc⟩ := hσ
+  let τ_mat : Matrix (Fin 2) (Fin 2) ℤ :=
+    !![σ.1 0 0, (N : ℤ) * σ.1 0 1; c, σ.1 1 1]
+  have h_det : τ_mat.det = 1 := by
+    simp only [τ_mat, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one]
+    have hσ_det := σ.prop; simp only [Matrix.det_fin_two] at hσ_det
+    rw [hc] at hσ_det; linarith
+  let τ : SL(2, ℤ) := ⟨τ_mat, h_det⟩
+  refine (mem_SLnZ_iff 2).mpr ⟨τ, ?_⟩
+  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
+  have hcQ : (σ.1 1 0 : ℚ) = (N : ℚ) * (c : ℚ) := by exact_mod_cast hc
+  suffices h : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a by
+    have h' := congr_arg ((natDiagGL 2 a)⁻¹ * ·) h
+    simp only [← mul_assoc, inv_mul_cancel, one_mul] at h'; exact h'
+  apply Units.ext
+  have hval : ∀ μ : SL(2, ℤ), (↑(mapGL ℚ μ) : Matrix _ _ ℚ) = μ.val.map (Int.cast) :=
+    fun μ ↦ by simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
+  simp only [Units.val_mul, hval]
+  ext i j
+  simp only [natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
+    Matrix.map_apply]
+  fin_cases i <;> fin_cases j <;>
+    simp only [τ, τ_mat, Matrix.of_apply, Matrix.cons_val', Fin.isValue] <;>
+    push_cast <;> (try rw [hcQ]) <;> (try rw [ha1]) <;> ring
+
+private lemma dvd_of_conj_natDiagGL_mem (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+    (hmem : (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2) :
+    (N : ℤ) ∣ σ.1 1 0 := by
+  obtain ⟨τ, hτ⟩ := (mem_SLnZ_iff 2).mp hmem
+  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
+  have ha0_ne : (a 0 : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha 0).ne'
+  have h_mul : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a := by
+    have := congr_arg (natDiagGL 2 a * ·) hτ
+    simp only [← mul_assoc, mul_inv_cancel, one_mul] at this; exact this
+  have h_entry : (a 1 : ℚ) * (τ.1 1 0 : ℚ) = (σ.1 1 0 : ℚ) * (a 0 : ℚ) := by
+    have h10 := Units.ext_iff.mp h_mul
+    have := congr_arg (fun M ↦ M 1 0) h10
+    simpa only [Units.val_mul, mapGL_coe_matrix, map_apply_coe, RingHom.mapMatrix_apply,
+      natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.map_apply, algebraMap_int_eq, eq_intCast] using this
+  have h_σ₁₀ : (σ.1 1 0 : ℚ) = (N : ℚ) * (τ.1 1 0 : ℚ) := by
+    rw [ha1] at h_entry; field_simp at h_entry ⊢; linarith
+  exact ⟨τ.1 1 0, by exact_mod_cast h_σ₁₀⟩
+
+private lemma natDiagGL_conj_relIndex_eq_Gamma0_index (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
+    (ConjAct.toConjAct (natDiagGL 2 a) • SLnZ 2).relIndex (SLnZ 2) =
+    (Gamma0 N).index := by
+  set H := SLnZ 2
+  set α := natDiagGL 2 a
+  set f := (mapGL ℚ : SL(2, ℤ) →* GL (Fin 2) ℚ)
+  have h_inj : Function.Injective f := mapGL_injective
+  have h_H_eq : H = Subgroup.map f ⊤ := by
+    ext g
+    simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
+    exact (mem_SLnZ_iff 2).trans (by simp [f])
+  have h_gamma0_iff : ∀ σ : SL(2, ℤ),
+      σ ∈ Gamma0 N ↔ α⁻¹ * f σ * α ∈ H := by
+    intro σ
+    rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
+    exact ⟨conj_natDiagGL_mem_of_dvd N a ha h_ratio h_dvd_a σ,
+           dvd_of_conj_natDiagGL_mem N a ha h_ratio h_dvd_a σ⟩
+  have h_inf_eq : (ConjAct.toConjAct α • H) ⊓ H = Subgroup.map f (Gamma0 N) := by
+    ext g; simp only [Subgroup.mem_inf, Subgroup.mem_map]
+    constructor
+    · rintro ⟨h_smul, h_mem⟩
+      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
+        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv] at h_smul
+      obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp h_mem
+      exact ⟨σ, (h_gamma0_iff σ).mpr h_smul, rfl⟩
+    · rintro ⟨σ, hσ, rfl⟩
+      refine ⟨?_, coe_mem_SLnZ 2 σ⟩
+      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
+        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv]
+      exact (h_gamma0_iff σ).mp hσ
+  calc (ConjAct.toConjAct α • H).relIndex H
+      = ((ConjAct.toConjAct α • H) ⊓ H).relIndex H :=
+        (Subgroup.inf_relIndex_right _ _).symm
+    _ = (Subgroup.map f (Gamma0 N)).relIndex (Subgroup.map f ⊤) := by
+        rw [h_inf_eq, h_H_eq]
+    _ = (Gamma0 N).relIndex ⊤ :=
+        Subgroup.relIndex_map_map_of_injective _ _ h_inj
+    _ = (Gamma0 N).index := (Gamma0 N).relIndex_top_right
+
+/-- **The degree of a rank-two diagonal double coset is an index of `Γ₀`**: if `a` is a
+divisibility chain whose entries are in ratio `N > 0`, then
+`deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`. Conjugating `SL₂(ℤ)` by the diagonal matrix `a` carves out
+exactly `Γ₀(N)`, so the relative index computing the degree is the index of `Γ₀(N)`. -/
+theorem degree_diagCoset_eq_Gamma0_index (N : ℕ) (hN : 0 < N) (a : Fin 2 → ℕ)
+    (hdiv : IsDvdChain a) (h_ratio : a 1 / a 0 = N) :
+    (diagCoset a).degree = (Gamma0 N).index := by
+  -- positivity is forced by the ratio: in `ℕ`, a vanishing numerator or denominator would
+  -- make `a 1 / a 0` zero, but `N` is not
+  have ha : ∀ i, 0 < a i := by
+    have h0 : 0 < a 0 := by
+      rcases Nat.eq_zero_or_pos (a 0) with h | h
+      · rw [h, Nat.div_zero] at h_ratio; omega
+      · exact h
+    have h1 : 0 < a 1 := by
+      rcases Nat.eq_zero_or_pos (a 1) with h | h
+      · rw [h, Nat.zero_div] at h_ratio; omega
+      · exact h
+    intro i
+    fin_cases i <;> assumption
+  -- `degree_mk` already computes the degree from an explicit representative, so only the
+  -- relative index at `natDiagGL` is left to identify
+  rw [diagCoset_def, HeckeCoset.degree_mk,
+    natDiagGL_conj_relIndex_eq_Gamma0_index N a ha h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1))]
+
+/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p` and
+`k ≥ 1`, a divisibility chain `a` of ratio `a₁ / a₀ = pᵏ` has `deg T(a₀, a₁) = pᵏ⁻¹ (p + 1)`.
+The archetype is `a = (pⁱ, pⁱ⁺ᵏ)`. -/
+theorem degree_diagCoset_of_ratio_eq_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
+    (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
+    (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
+  rw [degree_diagCoset_eq_Gamma0_index (p ^ k) (pow_pos hp.pos k) a hdiv h_ratio,
+    Gamma0_prime_power_index p hp k hk]
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean
@@ -12,13 +12,16 @@ public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 # The degree of a rank-two diagonal double coset
 
 The degree of a double coset is the relative index of the conjugated copy of `SL₂(ℤ)`. For a
-diagonal representative `a = (a₀, a₁)` with `a₀ ∣ a₁`, conjugating `SL₂(ℤ)` by `natDiagGL 2 a`
-carves out exactly `Γ₀(N)` for the ratio `N = a₁ / a₀`, so
+diagonal representative `a = (a₀, a₁)` with `a₀ ∣ a₁` whose ratio `N = a₁ / a₀` is positive,
+conjugating `SL₂(ℤ)` by `natDiagGL 2 a` carves out exactly `Γ₀(N)`, so
 
 `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`,
 
 and specializing to `N = pᵏ` with the index computed in
 `TauCeti.NumberTheory.ModularForms.CongruenceSubgroups` gives Shimura's `pᵏ⁻¹(p + 1)`.
+
+Positivity of the ratio is needed: it forces both entries positive, and so rules out the
+tuples on which `natDiagGL` takes its junk value `1` (for `a = (0, 0)` the ratio is `0`).
 
 Note that the degree is not the number of diagonal representatives: for `a = (1, p)` that
 count is `p`, while the true degree is `p + 1` — the double coset also contains

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -14,7 +14,8 @@ public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 The degree of a diagonal double coset `T(a₁, ..., aₙ)`, in the two cases the Hecke-ring
 calculations need. The scalar case `deg T(c, ..., c) = 1` holds at every positive rank, because a
-scalar matrix is central. The prime-power case `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k ≥ 1`
+scalar matrix is central. The prime-power case `deg T(a₀, a₁) = pᵏ⁻¹(p + 1)` for a divisibility
+chain of ratio `a₁ / a₀ = pᵏ` with `k ≥ 1`
 is specific to rank two: the degree of a double coset is the relative index of the
 conjugated copy of `SL₂(ℤ)`, which for a diagonal representative is exactly the index
 `[SL₂(ℤ) : Γ₀(pᵏ)]` computed in `TauCeti.NumberTheory.ModularForms.CongruenceSubgroups`.
@@ -32,9 +33,10 @@ contains representatives with permuted diagonals.
 
 ## Main results
 
-* `degree_diagCoset_eq_Gamma0_index`: `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]` for the ratio
-  `N = a₁ / a₀`, whenever that ratio is positive.
-* `degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p`, `k ≥ 1`.
+* `degree_diagCoset_eq_Gamma0_index`: `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]` for a divisibility
+  chain `a` whose ratio `N = a₁ / a₀` is positive.
+* `degree_diagCoset_prime_pow`: `deg T(a₀, a₁) = pᵏ⁻¹(p + 1)` for a divisibility chain `a`
+  whose ratio is `pᵏ`, with `p` prime and `k ≥ 1`.
 * `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank and for every
   constant tuple.
 
@@ -150,10 +152,10 @@ private lemma conjDiag_relIndex_eq_Gamma0_index (N : ℕ) (a : Fin 2 → ℕ) (h
         Subgroup.relIndex_map_map_of_injective _ _ h_inj
     _ = (Gamma0 N).index := (Gamma0 N).relIndex_top_right
 
-/-- **The degree of a rank-two diagonal double coset is an index of `Γ₀`**: if the two entries
-of `a` are in ratio `N > 0`, then `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`. Conjugating `SL₂(ℤ)` by
-the diagonal matrix `a` carves out exactly `Γ₀(N)`, so the relative index computing the degree
-is the index of `Γ₀(N)`. -/
+/-- **The degree of a rank-two diagonal double coset is an index of `Γ₀`**: if `a` is a
+divisibility chain whose entries are in ratio `N > 0`, then
+`deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`. Conjugating `SL₂(ℤ)` by the diagonal matrix `a` carves out
+exactly `Γ₀(N)`, so the relative index computing the degree is the index of `Γ₀(N)`. -/
 theorem degree_diagCoset_eq_Gamma0_index (N : ℕ) (hN : 0 < N) (a : Fin 2 → ℕ)
     (hdiv : IsDvdChain a) (h_ratio : a 1 / a 0 = N) :
     (diagCoset a).degree = (Gamma0 N).index := by
@@ -175,8 +177,9 @@ theorem degree_diagCoset_eq_Gamma0_index (N : ℕ) (hN : 0 < N) (a : Fin 2 → �
   rw [diagCoset_def, HeckeCoset.degree_mk,
     conjDiag_relIndex_eq_Gamma0_index N a ha h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1))]
 
-/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p`,
-`deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹ (p + 1)` for `k ≥ 1`. -/
+/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p` and
+`k ≥ 1`, a divisibility chain `a` of ratio `a₁ / a₀ = pᵏ` has `deg T(a₀, a₁) = pᵏ⁻¹ (p + 1)`.
+The archetype is `a = (pⁱ, pⁱ⁺ᵏ)`. -/
 theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
     (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
     (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
@@ -217,8 +220,7 @@ theorem degree_diagCoset_scalar (a : Fin n → ℕ) (h_const : ∀ i, a i = a 0)
   have hnorm : natDiagGL n a ∈ Subgroup.normalizer (SLnZ n) := by
     rw [Subgroup.mem_normalizer_iff]
     intro x
-    rw [show natDiagGL n a * x * (natDiagGL n a)⁻¹ = x by
-      rw [natDiagGL_comm_of_const n a ha h_const x, mul_assoc, mul_inv_cancel, mul_one]]
+    rw [natDiagGL_comm_of_const n a ha h_const x, mul_assoc, mul_inv_cancel, mul_one]
   rw [Subgroup.conjAct_pointwise_smul_eq_self hnorm, Subgroup.relIndex_self]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -7,8 +7,7 @@ module
 
 public import TauCeti.NumberTheory.HeckeRing.Degree
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
-
-import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
 # Degrees of the diagonal double cosets
@@ -33,6 +32,8 @@ contains representatives with permuted diagonals.
 
 ## Main results
 
+* `degree_diagCoset_eq_Gamma0_index`: `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]` for the ratio
+  `N = a₁ / a₀`, whenever that ratio is positive.
 * `degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p`, `k ≥ 1`.
 * `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank and for every
   constant tuple.
@@ -52,20 +53,20 @@ namespace HeckeRing.GLn
 
 variable (n : ℕ) [NeZero n]
 
-private lemma a1_eq_a0_mul_pk {p : ℕ} {a : Fin 2 → ℕ} {k : ℕ}
-    (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) :
-    (a 1 : ℚ) = (a 0 : ℚ) * (↑(p ^ k) : ℚ) := by
+private lemma a1_eq_a0_mul_ratio {N : ℕ} {a : Fin 2 → ℕ}
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
+    (a 1 : ℚ) = (a 0 : ℚ) * (N : ℚ) := by
   have h1 := Nat.div_mul_cancel h_dvd_a
   rw [h_ratio] at h1
   push_cast [← h1]; ring
 
-private lemma conj_natDiagGL_mem_of_Gamma0 (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
-    (hσ : (↑(p ^ k) : ℤ) ∣ σ.1 1 0) :
+private lemma conj_natDiagGL_mem_of_Gamma0 (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+    (hσ : (N : ℤ) ∣ σ.1 1 0) :
     (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2 := by
   obtain ⟨c, hc⟩ := hσ
   let τ_mat : Matrix (Fin 2) (Fin 2) ℤ :=
-    !![σ.1 0 0, ↑(p ^ k) * σ.1 0 1; c, σ.1 1 1]
+    !![σ.1 0 0, (N : ℤ) * σ.1 0 1; c, σ.1 1 1]
   have h_det : τ_mat.det = 1 := by
     simp only [τ_mat, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val',
       Matrix.cons_val_zero, Matrix.cons_val_one]
@@ -73,9 +74,8 @@ private lemma conj_natDiagGL_mem_of_Gamma0 (p : ℕ) (a : Fin 2 → ℕ) (ha : �
     rw [hc] at hσ_det; linarith
   let τ : SL(2, ℤ) := ⟨τ_mat, h_det⟩
   refine (mem_SLnZ_iff 2).mpr ⟨τ, ?_⟩
-  have ha1 := a1_eq_a0_mul_pk h_ratio h_dvd_a
-  have hcQ : (σ.1 1 0 : ℚ) = (↑(p ^ k) : ℚ) * (c : ℚ) := by exact_mod_cast hc
-  push_cast at ha1 hcQ
+  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
+  have hcQ : (σ.1 1 0 : ℚ) = (N : ℚ) * (c : ℚ) := by exact_mod_cast hc
   suffices h : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a by
     have h' := congr_arg ((natDiagGL 2 a)⁻¹ * ·) h
     simp only [← mul_assoc, inv_mul_cancel, one_mul] at h'; exact h'
@@ -90,12 +90,12 @@ private lemma conj_natDiagGL_mem_of_Gamma0 (p : ℕ) (a : Fin 2 → ℕ) (ha : �
     simp only [τ, τ_mat, Matrix.of_apply, Matrix.cons_val', Fin.isValue] <;>
     push_cast <;> (try rw [hcQ]) <;> (try rw [ha1]) <;> ring
 
-private lemma Gamma0_of_conj_natDiagGL_mem (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+private lemma Gamma0_of_conj_natDiagGL_mem (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
     (hmem : (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2) :
-    (↑(p ^ k) : ℤ) ∣ σ.1 1 0 := by
+    (N : ℤ) ∣ σ.1 1 0 := by
   obtain ⟨τ, hτ⟩ := (mem_SLnZ_iff 2).mp hmem
-  have ha1 := a1_eq_a0_mul_pk h_ratio h_dvd_a
+  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
   have ha0_ne : (a 0 : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha 0).ne'
   have h_mul : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a := by
     have := congr_arg (natDiagGL 2 a * ·) hτ
@@ -106,14 +106,14 @@ private lemma Gamma0_of_conj_natDiagGL_mem (p : ℕ) (a : Fin 2 → ℕ) (ha : �
     simpa only [Units.val_mul, mapGL_coe_matrix, map_apply_coe, RingHom.mapMatrix_apply,
       natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
       Matrix.map_apply, algebraMap_int_eq, eq_intCast] using this
-  have h_σ₁₀ : (σ.1 1 0 : ℚ) = ↑(p ^ k) * (τ.1 1 0 : ℚ) := by
+  have h_σ₁₀ : (σ.1 1 0 : ℚ) = (N : ℚ) * (τ.1 1 0 : ℚ) := by
     rw [ha1] at h_entry; field_simp at h_entry ⊢; linarith
   exact ⟨τ.1 1 0, by exact_mod_cast h_σ₁₀⟩
 
-private lemma conjDiag_relIndex_eq_Gamma0_index (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) :
+private lemma conjDiag_relIndex_eq_Gamma0_index (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
     (ConjAct.toConjAct (natDiagGL 2 a) • SLnZ 2).relIndex (SLnZ 2) =
-    (Gamma0 (p ^ k)).index := by
+    (Gamma0 N).index := by
   set H := SLnZ 2
   set α := natDiagGL 2 a
   set f := (mapGL ℚ : SL(2, ℤ) →* GL (Fin 2) ℚ)
@@ -123,12 +123,12 @@ private lemma conjDiag_relIndex_eq_Gamma0_index (p : ℕ) (a : Fin 2 → ℕ) (h
     simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
     exact (mem_SLnZ_iff 2).trans (by simp [f])
   have h_gamma0_iff : ∀ σ : SL(2, ℤ),
-      σ ∈ Gamma0 (p ^ k) ↔ α⁻¹ * f σ * α ∈ H := by
+      σ ∈ Gamma0 N ↔ α⁻¹ * f σ * α ∈ H := by
     intro σ
     rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
-    exact ⟨conj_natDiagGL_mem_of_Gamma0 p a ha k h_ratio h_dvd_a σ,
-           Gamma0_of_conj_natDiagGL_mem p a ha k h_ratio h_dvd_a σ⟩
-  have h_inf_eq : (ConjAct.toConjAct α • H) ⊓ H = Subgroup.map f (Gamma0 (p ^ k)) := by
+    exact ⟨conj_natDiagGL_mem_of_Gamma0 N a ha h_ratio h_dvd_a σ,
+           Gamma0_of_conj_natDiagGL_mem N a ha h_ratio h_dvd_a σ⟩
+  have h_inf_eq : (ConjAct.toConjAct α • H) ⊓ H = Subgroup.map f (Gamma0 N) := by
     ext g; simp only [Subgroup.mem_inf, Subgroup.mem_map]
     constructor
     · rintro ⟨h_smul, h_mem⟩
@@ -144,20 +144,21 @@ private lemma conjDiag_relIndex_eq_Gamma0_index (p : ℕ) (a : Fin 2 → ℕ) (h
   calc (ConjAct.toConjAct α • H).relIndex H
       = ((ConjAct.toConjAct α • H) ⊓ H).relIndex H :=
         (Subgroup.inf_relIndex_right _ _).symm
-    _ = (Subgroup.map f (Gamma0 (p ^ k))).relIndex (Subgroup.map f ⊤) := by
+    _ = (Subgroup.map f (Gamma0 N)).relIndex (Subgroup.map f ⊤) := by
         rw [h_inf_eq, h_H_eq]
-    _ = (Gamma0 (p ^ k)).relIndex ⊤ :=
+    _ = (Gamma0 N).relIndex ⊤ :=
         Subgroup.relIndex_map_map_of_injective _ _ h_inj
-    _ = (Gamma0 (p ^ k)).index := (Gamma0 (p ^ k)).relIndex_top_right
+    _ = (Gamma0 N).index := (Gamma0 N).relIndex_top_right
 
-/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p`,
-`deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹ (p + 1)` for `k ≥ 1`. -/
-theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
-    (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
-    (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
+/-- **The degree of a rank-two diagonal double coset is an index of `Γ₀`**: if the two entries
+of `a` are in ratio `N > 0`, then `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`. Conjugating `SL₂(ℤ)` by
+the diagonal matrix `a` carves out exactly `Γ₀(N)`, so the relative index computing the degree
+is the index of `Γ₀(N)`. -/
+theorem degree_diagCoset_eq_Gamma0_index (N : ℕ) (hN : 0 < N) (a : Fin 2 → ℕ)
+    (hdiv : IsDvdChain a) (h_ratio : a 1 / a 0 = N) :
+    (diagCoset a).degree = (Gamma0 N).index := by
   -- positivity is forced by the ratio: in `ℕ`, a vanishing numerator or denominator would
-  -- make `a 1 / a 0` zero, but `p ^ k` is not
-  have hpk : 0 < p ^ k := pow_pos hp.pos k
+  -- make `a 1 / a 0` zero, but `N` is not
   have ha : ∀ i, 0 < a i := by
     have h0 : 0 < a 0 := by
       rcases Nat.eq_zero_or_pos (a 0) with h | h
@@ -172,10 +173,16 @@ theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → �
   -- `degree_mk` already computes the degree from an explicit representative, so only the
   -- relative index at `natDiagGL` is left to identify
   rw [diagCoset_def, HeckeCoset.degree_mk,
-    conjDiag_relIndex_eq_Gamma0_index p a ha k h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1)),
+    conjDiag_relIndex_eq_Gamma0_index N a ha h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1))]
+
+/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p`,
+`deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹ (p + 1)` for `k ≥ 1`. -/
+theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
+    (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
+    (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
+  rw [degree_diagCoset_eq_Gamma0_index (p ^ k) (pow_pos hp.pos k) a hdiv h_ratio,
     Gamma0_prime_power_index p hp k hk]
 
-/-- A constant `natDiagGL` is Mathlib's scalar matrix, so it is central. -/
 private lemma natDiagGL_const_eq_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
     (h_const : ∀ i, a i = a 0) :
     natDiagGL n a =

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -23,6 +23,11 @@ is in `TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean`.
   unconditionally, since a non-positive entry sends `natDiagGL` to its junk value `1`, whose
   double coset is the identity.
 
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GLn/Degree.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck), keeping only the rank-general constant case; the rank-two
+computation is split into `GL2/DiagonalCosetDegree.lean`.
+
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -14,15 +14,16 @@ import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 # Degrees of the diagonal double cosets
 
 The degree of a diagonal double coset `T(a₁, ..., aₙ)`, in the two cases the Hecke-ring
-calculations need. The scalar case `deg T(c, ..., c) = 1` holds at every rank, because a
+calculations need. The scalar case `deg T(c, ..., c) = 1` holds at every positive rank, because a
 scalar matrix is central. The prime-power case `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k ≥ 1`
 is specific to rank two: the degree of a double coset is the relative index of the
 conjugated copy of `SL₂(ℤ)`, which for a diagonal representative is exactly the index
 `[SL₂(ℤ) : Γ₀(pᵏ)]` computed in `TauCeti.NumberTheory.ModularForms.CongruenceSubgroups`.
 
-Both live here, below `GLn.CoprimeMul` and the `GL2` files that consume them, rather than
-under `GL2`: the rank-two formula is a shared prerequisite of `GL2.MultiplicationTable` and
-`GL2.Degree` alike, and the scalar formula is rank-general.
+Both live here rather than under `GL2` because the rank-two formula is a shared prerequisite
+of the planned `GL2.MultiplicationTable` and `GL2.Degree` developments alike and must sit
+below both, while the scalar formula is rank-general. Those consumers are not yet in the
+repository; this file is the prerequisite that unblocks them.
 
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GLn/Degree.lean`](https://github.com/CBirkbeck/AINTLIB),
@@ -33,7 +34,7 @@ contains representatives with permuted diagonals.
 ## Main results
 
 * `degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p`, `k ≥ 1`.
-* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every rank.
+* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank.
 
 ## References
 
@@ -154,30 +155,10 @@ theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → �
     (ha : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k)
     (h_ratio : a 1 / a 0 = p ^ k) :
     (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
-  set H := SLnZ 2
-  set α := (natDiagGL 2 a : GL (Fin 2) ℚ) with hα_def
-  set D := diagCoset a with hD_def
-  set δ := (HeckeCoset.rep D : GL (Fin 2) ℚ)
-  have h_dvd_a : a 0 ∣ a 1 := isDvdChain_iff.mp hdiv (Fin.zero_le 1)
-  have h_in_set : δ ∈ HeckeCoset.toSet D := HeckeCoset.rep_mem D
-  have h_D_set : HeckeCoset.toSet D = DoubleCoset.doubleCoset α ↑H ↑H := by
-    rw [hD_def]; exact diagCoset_toSet a
-  rw [h_D_set, DoubleCoset.mem_doubleCoset] at h_in_set
-  obtain ⟨σ₁, hσ₁, σ₂, hσ₂, hδ_eq⟩ := h_in_set
-  have h_smul_σ₁ : ConjAct.toConjAct σ₁ • H = H :=
-    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hσ₁)
-  have h_δ_smul : ConjAct.toConjAct δ • H =
-      ConjAct.toConjAct σ₁ • (ConjAct.toConjAct α • H) := by
-    rw [hδ_eq, map_mul, map_mul, ← smul_smul, ← smul_smul,
-      Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hσ₂)]
-  have h_S1 : (ConjAct.toConjAct α • H).relIndex H =
-      (ConjAct.toConjAct δ • H).relIndex H := by
-    rw [h_δ_smul]
-    have := Subgroup.relIndex_pointwise_smul
-      (ConjAct.toConjAct σ₁) (ConjAct.toConjAct α • H) H
-    rw [h_smul_σ₁] at this; exact this.symm
-  rw [HeckeCoset.degree_eq_relIndex, ← h_S1,
-    conjDiag_relIndex_eq_Gamma0_index p a ha k h_ratio h_dvd_a,
+  -- `degree_mk` already computes the degree from an explicit representative, so only the
+  -- relative index at `natDiagGL` is left to identify
+  rw [diagCoset_def, HeckeCoset.degree_mk,
+    conjDiag_relIndex_eq_Gamma0_index p a ha k h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1)),
     Gamma0_prime_power_index p hp k hk]
 
 private lemma natDiagGL_comm_of_const (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
@@ -196,34 +177,18 @@ private lemma natDiagGL_comm_of_const (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
 
 /-- **The scalar degree**: a scalar diagonal matrix is central, so its double coset is a
 single coset and `deg T(c, ..., c) = 1`. -/
+@[simp]
 theorem degree_diagCoset_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
     (h_const : ∀ i, a i = a 0) : (diagCoset a).degree = 1 := by
-  set H := SLnZ n
-  set D := diagCoset a with hD_def
-  set δ := HeckeCoset.rep D
-  suffices hsmul : ConjAct.toConjAct (δ : GL (Fin n) ℚ) • H = H by
-    rw [HeckeCoset.degree_eq_relIndex]
-    rw [show ConjAct.toConjAct ((HeckeCoset.rep D : _) : GL (Fin n) ℚ) • H = H from hsmul,
-      Subgroup.relIndex_self]
-  have hδ_mem : (δ : GL (Fin n) ℚ) ∈ HeckeCoset.toSet D := HeckeCoset.rep_mem D
-  rw [show HeckeCoset.toSet D =
-      DoubleCoset.doubleCoset (natDiagGL n a) ↑H ↑H from by
-    rw [hD_def]; exact diagCoset_toSet a, DoubleCoset.mem_doubleCoset] at hδ_mem
-  obtain ⟨h₁, hh₁, h₂, hh₂, hδ_eq⟩ := hδ_mem
-  have h_comm : natDiagGL n a * h₂ = h₂ * natDiagGL n a :=
-    natDiagGL_comm_of_const n a ha h_const h₂
-  have hδ_simp : (δ : GL (Fin n) ℚ) = (h₁ * h₂) * natDiagGL n a := by
-    rw [hδ_eq, mul_assoc, h_comm, ← mul_assoc]
-  have h_diag_conj : ∀ (g : GL (Fin n) ℚ),
-      (natDiagGL n a)⁻¹ * g * natDiagGL n a = g := by
-    intro g; rw [mul_assoc, ← natDiagGL_comm_of_const n a ha h_const g, ← mul_assoc,
+  rw [diagCoset_def, HeckeCoset.degree_mk]
+  have h_diag_conj : ∀ g : GL (Fin n) ℚ,
+      (natDiagGL n a)⁻¹ * g * natDiagGL n a = g := fun g ↦ by
+    rw [mul_assoc, ← natDiagGL_comm_of_const n a ha h_const g, ← mul_assoc,
       inv_mul_cancel, one_mul]
-  rw [hδ_simp, map_mul, ← smul_smul]
-  have h_smul_diag : ConjAct.toConjAct (natDiagGL n a) • H = H := by
+  have h_smul_diag : ConjAct.toConjAct (natDiagGL n a) • SLnZ n = SLnZ n := by
     ext x
     simp only [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
       map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, h_diag_conj]
-  rw [h_smul_diag]
-  exact Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer (H.mul_mem hh₁ hh₂))
+  rw [h_smul_diag, Subgroup.relIndex_self]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -34,7 +34,8 @@ contains representatives with permuted diagonals.
 ## Main results
 
 * `degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p`, `k ≥ 1`.
-* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank.
+* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank and for every
+  constant tuple.
 
 ## References
 
@@ -161,25 +162,36 @@ theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → �
     conjDiag_relIndex_eq_Gamma0_index p a ha k h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1)),
     Gamma0_prime_power_index p hp k hk]
 
+/-- A constant `natDiagGL` is Mathlib's scalar matrix, so it is central. -/
+private lemma natDiagGL_const_eq_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
+    (h_const : ∀ i, a i = a 0) :
+    natDiagGL n a =
+      Matrix.GeneralLinearGroup.scalar (Fin n)
+        (Units.mk0 (a 0 : ℚ) (by exact_mod_cast (ha 0).ne')) := by
+  apply Units.ext
+  ext i j
+  simp only [natDiagGL_coe n a ha, Matrix.GeneralLinearGroup.coe_scalar, Matrix.scalar_apply,
+    Matrix.diagonal_apply, Units.val_mk0]
+  split_ifs with h
+  · subst h; simp [h_const]
+  · rfl
+
 private lemma natDiagGL_comm_of_const (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
     (h_const : ∀ i, a i = a 0) (g : GL (Fin n) ℚ) :
     natDiagGL n a * g = g * natDiagGL n a := by
-  apply Units.ext
-  simp only [Units.val_mul, natDiagGL_coe n a ha]
-  have h_diag : Matrix.diagonal (fun i ↦ (a i : ℚ)) =
-      (a 0 : ℚ) • (1 : Matrix (Fin n) (Fin n) ℚ) := by
-    ext i j
-    simp only [Matrix.diagonal_apply, Matrix.smul_apply, Matrix.one_apply, smul_eq_mul]
-    split_ifs with h
-    · subst h; simp [h_const]
-    · simp
-  rw [h_diag, smul_mul_assoc, mul_smul_comm, one_mul, mul_one]
+  rw [natDiagGL_const_eq_scalar n a ha h_const]
+  exact Matrix.GeneralLinearGroup.scalar_commute _ _
 
 /-- **The scalar degree**: a scalar diagonal matrix is central, so its double coset is a
 single coset and `deg T(c, ..., c) = 1`. -/
 @[simp]
-theorem degree_diagCoset_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
-    (h_const : ∀ i, a i = a 0) : (diagCoset a).degree = 1 := by
+theorem degree_diagCoset_scalar (a : Fin n → ℕ) (h_const : ∀ i, a i = a 0) :
+    (diagCoset a).degree = 1 := by
+  by_cases ha : ∀ i, 0 < a i
+  swap
+  · -- the junk value of `natDiagGL` is `1`, whose double coset is the identity
+    rw [diagCoset_of_not_pos ha]
+    exact HeckeCoset.degree_one
   rw [diagCoset_def, HeckeCoset.degree_mk]
   have h_diag_conj : ∀ g : GL (Fin n) ℚ,
       (natDiagGL n a)⁻¹ * g * natDiagGL n a = g := fun g ↦ by

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -5,222 +5,73 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.Degree
 public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
-public import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
 
 /-!
-# Degrees of the diagonal double cosets
+# The degree of a constant diagonal double coset
 
-The degree of a diagonal double coset `T(a₁, ..., aₙ)`, in the two cases the Hecke-ring
-calculations need. The scalar case `deg T(c, ..., c) = 1` holds at every positive rank, because a
-scalar matrix is central. The prime-power case `deg T(a₀, a₁) = pᵏ⁻¹(p + 1)` for a divisibility
-chain of ratio `a₁ / a₀ = pᵏ` with `k ≥ 1`
-is specific to rank two: the degree of a double coset is the relative index of the
-conjugated copy of `SL₂(ℤ)`, which for a diagonal representative is exactly the index
-`[SL₂(ℤ) : Γ₀(pᵏ)]` computed in `TauCeti.NumberTheory.ModularForms.CongruenceSubgroups`.
+A constant tuple `a = (c, ..., c)` has `natDiagGL n a` a scalar matrix, which is central in
+`GL_n(ℚ)` and so normalizes `SL_n(ℤ)`; the double coset `T(c, ..., c)` is therefore a single
+coset and `deg T(c, ..., c) = 1`, at every rank.
 
-Both live here rather than under `GL2` because the rank-two formula is a shared prerequisite
-of the planned `GL2.MultiplicationTable` and `GL2.Degree` developments alike and must sit
-below both, while the scalar formula is rank-general. Those consumers are not yet in the
-repository; this file is the prerequisite that unblocks them.
-
-Ported from the AINTLIB `LeanModularForms` project
-([`LeanModularForms/HeckeRIngs/GLn/Degree.lean`](https://github.com/CBirkbeck/AINTLIB),
-Chris Birkbeck).  Note the degree of `T(a₁,...,aₙ)` is **not** `∏_{i<j}(aⱼ/aᵢ)`: for
-`a = (1, p)` that count is `p`, while the true degree is `p + 1` — the double coset also
-contains representatives with permuted diagonals.
+The rank-two computation `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(a₁ / a₀)]`, which is not rank-general,
+is in `TauCeti/NumberTheory/HeckeRing/GL2/DiagonalCosetDegree.lean`.
 
 ## Main results
 
-* `degree_diagCoset_eq_Gamma0_index`: `deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]` for a divisibility
-  chain `a` whose ratio `N = a₁ / a₀` is positive.
-* `degree_diagCoset_prime_pow`: `deg T(a₀, a₁) = pᵏ⁻¹(p + 1)` for a divisibility chain `a`
-  whose ratio is `pᵏ`, with `p` prime and `k ≥ 1`.
-* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every positive rank and for every
-  constant tuple.
+* `degree_diagCoset_const`: `deg T(c, ..., c) = 1`, at every rank and for every `c : ℕ` —
+  unconditionally, since a non-positive entry sends `natDiagGL` to its junk value `1`, whose
+  double coset is the identity.
 
 ## References
 
 * [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
-  Propositions 3.14, 3.18 and Theorem 3.24.
+  Proposition 3.14.
 -/
 
 public section
 
-open HeckeRing Finset CongruenceSubgroup Matrix.SpecialLinearGroup Matrix
+open HeckeRing Matrix.SpecialLinearGroup Matrix
 open scoped Pointwise MatrixGroups
 
 namespace HeckeRing.GLn
 
-variable (n : ℕ) [NeZero n]
+variable (n : ℕ)
 
-private lemma a1_eq_a0_mul_ratio {N : ℕ} {a : Fin 2 → ℕ}
-    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
-    (a 1 : ℚ) = (a 0 : ℚ) * (N : ℚ) := by
-  have h1 := Nat.div_mul_cancel h_dvd_a
-  rw [h_ratio] at h1
-  push_cast [← h1]; ring
-
-private lemma conj_natDiagGL_mem_of_Gamma0 (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
-    (hσ : (N : ℤ) ∣ σ.1 1 0) :
-    (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2 := by
-  obtain ⟨c, hc⟩ := hσ
-  let τ_mat : Matrix (Fin 2) (Fin 2) ℤ :=
-    !![σ.1 0 0, (N : ℤ) * σ.1 0 1; c, σ.1 1 1]
-  have h_det : τ_mat.det = 1 := by
-    simp only [τ_mat, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val',
-      Matrix.cons_val_zero, Matrix.cons_val_one]
-    have hσ_det := σ.prop; simp only [Matrix.det_fin_two] at hσ_det
-    rw [hc] at hσ_det; linarith
-  let τ : SL(2, ℤ) := ⟨τ_mat, h_det⟩
-  refine (mem_SLnZ_iff 2).mpr ⟨τ, ?_⟩
-  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
-  have hcQ : (σ.1 1 0 : ℚ) = (N : ℚ) * (c : ℚ) := by exact_mod_cast hc
-  suffices h : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a by
-    have h' := congr_arg ((natDiagGL 2 a)⁻¹ * ·) h
-    simp only [← mul_assoc, inv_mul_cancel, one_mul] at h'; exact h'
-  apply Units.ext
-  have hval : ∀ μ : SL(2, ℤ), (↑(mapGL ℚ μ) : Matrix _ _ ℚ) = μ.val.map (Int.cast) :=
-    fun μ ↦ by simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
-  simp only [Units.val_mul, hval]
-  ext i j
-  simp only [natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
-    Matrix.map_apply]
-  fin_cases i <;> fin_cases j <;>
-    simp only [τ, τ_mat, Matrix.of_apply, Matrix.cons_val', Fin.isValue] <;>
-    push_cast <;> (try rw [hcQ]) <;> (try rw [ha1]) <;> ring
-
-private lemma Gamma0_of_conj_natDiagGL_mem (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
-    (hmem : (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2) :
-    (N : ℤ) ∣ σ.1 1 0 := by
-  obtain ⟨τ, hτ⟩ := (mem_SLnZ_iff 2).mp hmem
-  have ha1 := a1_eq_a0_mul_ratio h_ratio h_dvd_a
-  have ha0_ne : (a 0 : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha 0).ne'
-  have h_mul : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a := by
-    have := congr_arg (natDiagGL 2 a * ·) hτ
-    simp only [← mul_assoc, mul_inv_cancel, one_mul] at this; exact this
-  have h_entry : (a 1 : ℚ) * (τ.1 1 0 : ℚ) = (σ.1 1 0 : ℚ) * (a 0 : ℚ) := by
-    have h10 := Units.ext_iff.mp h_mul
-    have := congr_arg (fun M ↦ M 1 0) h10
-    simpa only [Units.val_mul, mapGL_coe_matrix, map_apply_coe, RingHom.mapMatrix_apply,
-      natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
-      Matrix.map_apply, algebraMap_int_eq, eq_intCast] using this
-  have h_σ₁₀ : (σ.1 1 0 : ℚ) = (N : ℚ) * (τ.1 1 0 : ℚ) := by
-    rw [ha1] at h_entry; field_simp at h_entry ⊢; linarith
-  exact ⟨τ.1 1 0, by exact_mod_cast h_σ₁₀⟩
-
-private lemma conjDiag_relIndex_eq_Gamma0_index (N : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
-    (h_ratio : a 1 / a 0 = N) (h_dvd_a : a 0 ∣ a 1) :
-    (ConjAct.toConjAct (natDiagGL 2 a) • SLnZ 2).relIndex (SLnZ 2) =
-    (Gamma0 N).index := by
-  set H := SLnZ 2
-  set α := natDiagGL 2 a
-  set f := (mapGL ℚ : SL(2, ℤ) →* GL (Fin 2) ℚ)
-  have h_inj : Function.Injective f := mapGL_injective
-  have h_H_eq : H = Subgroup.map f ⊤ := by
-    ext g
-    simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
-    exact (mem_SLnZ_iff 2).trans (by simp [f])
-  have h_gamma0_iff : ∀ σ : SL(2, ℤ),
-      σ ∈ Gamma0 N ↔ α⁻¹ * f σ * α ∈ H := by
-    intro σ
-    rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
-    exact ⟨conj_natDiagGL_mem_of_Gamma0 N a ha h_ratio h_dvd_a σ,
-           Gamma0_of_conj_natDiagGL_mem N a ha h_ratio h_dvd_a σ⟩
-  have h_inf_eq : (ConjAct.toConjAct α • H) ⊓ H = Subgroup.map f (Gamma0 N) := by
-    ext g; simp only [Subgroup.mem_inf, Subgroup.mem_map]
-    constructor
-    · rintro ⟨h_smul, h_mem⟩
-      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
-        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv] at h_smul
-      obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp h_mem
-      exact ⟨σ, (h_gamma0_iff σ).mpr h_smul, rfl⟩
-    · rintro ⟨σ, hσ, rfl⟩
-      refine ⟨?_, coe_mem_SLnZ 2 σ⟩
-      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
-        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv]
-      exact (h_gamma0_iff σ).mp hσ
-  calc (ConjAct.toConjAct α • H).relIndex H
-      = ((ConjAct.toConjAct α • H) ⊓ H).relIndex H :=
-        (Subgroup.inf_relIndex_right _ _).symm
-    _ = (Subgroup.map f (Gamma0 N)).relIndex (Subgroup.map f ⊤) := by
-        rw [h_inf_eq, h_H_eq]
-    _ = (Gamma0 N).relIndex ⊤ :=
-        Subgroup.relIndex_map_map_of_injective _ _ h_inj
-    _ = (Gamma0 N).index := (Gamma0 N).relIndex_top_right
-
-/-- **The degree of a rank-two diagonal double coset is an index of `Γ₀`**: if `a` is a
-divisibility chain whose entries are in ratio `N > 0`, then
-`deg T(a₀, a₁) = [SL₂(ℤ) : Γ₀(N)]`. Conjugating `SL₂(ℤ)` by the diagonal matrix `a` carves out
-exactly `Γ₀(N)`, so the relative index computing the degree is the index of `Γ₀(N)`. -/
-theorem degree_diagCoset_eq_Gamma0_index (N : ℕ) (hN : 0 < N) (a : Fin 2 → ℕ)
-    (hdiv : IsDvdChain a) (h_ratio : a 1 / a 0 = N) :
-    (diagCoset a).degree = (Gamma0 N).index := by
-  -- positivity is forced by the ratio: in `ℕ`, a vanishing numerator or denominator would
-  -- make `a 1 / a 0` zero, but `N` is not
-  have ha : ∀ i, 0 < a i := by
-    have h0 : 0 < a 0 := by
-      rcases Nat.eq_zero_or_pos (a 0) with h | h
-      · rw [h, Nat.div_zero] at h_ratio; omega
-      · exact h
-    have h1 : 0 < a 1 := by
-      rcases Nat.eq_zero_or_pos (a 1) with h | h
-      · rw [h, Nat.zero_div] at h_ratio; omega
-      · exact h
-    intro i
-    fin_cases i <;> assumption
-  -- `degree_mk` already computes the degree from an explicit representative, so only the
-  -- relative index at `natDiagGL` is left to identify
-  rw [diagCoset_def, HeckeCoset.degree_mk,
-    conjDiag_relIndex_eq_Gamma0_index N a ha h_ratio (isDvdChain_iff.mp hdiv (Fin.zero_le 1))]
-
-/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p` and
-`k ≥ 1`, a divisibility chain `a` of ratio `a₁ / a₀ = pᵏ` has `deg T(a₀, a₁) = pᵏ⁻¹ (p + 1)`.
-The archetype is `a = (pⁱ, pⁱ⁺ᵏ)`. -/
-theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
-    (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
-    (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
-  rw [degree_diagCoset_eq_Gamma0_index (p ^ k) (pow_pos hp.pos k) a hdiv h_ratio,
-    Gamma0_prime_power_index p hp k hk]
-
-private lemma natDiagGL_const_eq_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
-    (h_const : ∀ i, a i = a 0) :
-    natDiagGL n a =
+private lemma natDiagGL_const_eq_scalar {c : ℕ} (hc : 0 < c) :
+    natDiagGL n (fun _ ↦ c) =
       Matrix.GeneralLinearGroup.scalar (Fin n)
-        (Units.mk0 (a 0 : ℚ) (by exact_mod_cast (ha 0).ne')) := by
+        (Units.mk0 (c : ℚ) (by exact_mod_cast hc.ne')) := by
   apply Units.ext
   ext i j
-  simp only [natDiagGL_coe n a ha, Matrix.GeneralLinearGroup.coe_scalar, Matrix.scalar_apply,
-    Matrix.diagonal_apply, Units.val_mk0]
-  split_ifs with h
-  · subst h; simp [h_const]
-  · rfl
+  simp only [natDiagGL_coe n _ fun _ ↦ hc, Matrix.GeneralLinearGroup.coe_scalar,
+    Matrix.scalar_apply, Matrix.diagonal_apply, Units.val_mk0]
 
-private lemma natDiagGL_comm_of_const (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
-    (h_const : ∀ i, a i = a 0) (g : GL (Fin n) ℚ) :
-    natDiagGL n a * g = g * natDiagGL n a := by
-  rw [natDiagGL_const_eq_scalar n a ha h_const]
-  exact Matrix.GeneralLinearGroup.scalar_commute _ _
+/-- A constant diagonal matrix is a scalar, hence commutes with everything — unconditionally
+in the constant, since `c = 0` sends `natDiagGL` to its junk value `1`. -/
+private lemma natDiagGL_const_comm (c : ℕ) (g : GL (Fin n) ℚ) :
+    natDiagGL n (fun _ ↦ c) * g = g * natDiagGL n (fun _ ↦ c) := by
+  rcases Nat.eq_zero_or_pos n with rfl | hn
+  -- at rank zero `GL (Fin 0) ℚ` is trivial
+  · exact Subsingleton.elim _ _
+  rcases Nat.eq_zero_or_pos c with rfl | hc
+  · rw [natDiagGL_of_not_pos n (not_forall.mpr ⟨⟨0, hn⟩, by simp⟩), one_mul, mul_one]
+  · rw [natDiagGL_const_eq_scalar n hc]
+    exact Matrix.GeneralLinearGroup.scalar_commute _ _
 
-/-- **The scalar degree**: a scalar diagonal matrix is central, so its double coset is a
-single coset and `deg T(c, ..., c) = 1`. -/
+/-- **The constant degree**: a constant diagonal matrix is scalar, hence central, so its
+double coset is a single coset and `deg T(c, ..., c) = 1`.
+
+The statement is unconditional in `c`: for `c = 0` the value comes from `natDiagGL`'s junk
+branch, which is `1`, whose double coset is the identity — not from centrality. -/
 @[simp]
-theorem degree_diagCoset_scalar (a : Fin n → ℕ) (h_const : ∀ i, a i = a 0) :
-    (diagCoset a).degree = 1 := by
-  by_cases ha : ∀ i, 0 < a i
-  swap
-  · -- the junk value of `natDiagGL` is `1`, whose double coset is the identity
-    rw [diagCoset_of_not_pos ha]
-    exact HeckeCoset.degree_one
+theorem degree_diagCoset_const (c : ℕ) : (diagCoset (fun _ : Fin n ↦ c)).degree = 1 := by
   rw [diagCoset_def, HeckeCoset.degree_mk]
   -- a central element normalizes every subgroup, so Mathlib's lemma applies
-  have hnorm : natDiagGL n a ∈ Subgroup.normalizer (SLnZ n) := by
+  have hnorm : natDiagGL n (fun _ ↦ c) ∈ Subgroup.normalizer (SLnZ n) := by
     rw [Subgroup.mem_normalizer_iff]
     intro x
-    rw [natDiagGL_comm_of_const n a ha h_const x, mul_assoc, mul_inv_cancel, mul_one]
+    rw [natDiagGL_const_comm n c x, mul_assoc, mul_inv_cancel, mul_one]
   rw [Subgroup.conjAct_pointwise_smul_eq_self hnorm, Subgroup.relIndex_self]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -153,9 +153,22 @@ private lemma conjDiag_relIndex_eq_Gamma0_index (p : ℕ) (a : Fin 2 → ℕ) (h
 /-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p`,
 `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹ (p + 1)` for `k ≥ 1`. -/
 theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
-    (ha : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k)
-    (h_ratio : a 1 / a 0 = p ^ k) :
+    (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k) (h_ratio : a 1 / a 0 = p ^ k) :
     (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
+  -- positivity is forced by the ratio: in `ℕ`, a vanishing numerator or denominator would
+  -- make `a 1 / a 0` zero, but `p ^ k` is not
+  have hpk : 0 < p ^ k := pow_pos hp.pos k
+  have ha : ∀ i, 0 < a i := by
+    have h0 : 0 < a 0 := by
+      rcases Nat.eq_zero_or_pos (a 0) with h | h
+      · rw [h, Nat.div_zero] at h_ratio; omega
+      · exact h
+    have h1 : 0 < a 1 := by
+      rcases Nat.eq_zero_or_pos (a 1) with h | h
+      · rw [h, Nat.zero_div] at h_ratio; omega
+      · exact h
+    intro i
+    fin_cases i <;> assumption
   -- `degree_mk` already computes the degree from an explicit representative, so only the
   -- relative index at `natDiagGL` is left to identify
   rw [diagCoset_def, HeckeCoset.degree_mk,
@@ -193,14 +206,12 @@ theorem degree_diagCoset_scalar (a : Fin n → ℕ) (h_const : ∀ i, a i = a 0)
     rw [diagCoset_of_not_pos ha]
     exact HeckeCoset.degree_one
   rw [diagCoset_def, HeckeCoset.degree_mk]
-  have h_diag_conj : ∀ g : GL (Fin n) ℚ,
-      (natDiagGL n a)⁻¹ * g * natDiagGL n a = g := fun g ↦ by
-    rw [mul_assoc, ← natDiagGL_comm_of_const n a ha h_const g, ← mul_assoc,
-      inv_mul_cancel, one_mul]
-  have h_smul_diag : ConjAct.toConjAct (natDiagGL n a) • SLnZ n = SLnZ n := by
-    ext x
-    simp only [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
-      map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, h_diag_conj]
-  rw [h_smul_diag, Subgroup.relIndex_self]
+  -- a central element normalizes every subgroup, so Mathlib's lemma applies
+  have hnorm : natDiagGL n a ∈ Subgroup.normalizer (SLnZ n) := by
+    rw [Subgroup.mem_normalizer_iff]
+    intro x
+    rw [show natDiagGL n a * x * (natDiagGL n a)⁻¹ = x by
+      rw [natDiagGL_comm_of_const n a ha h_const x, mul_assoc, mul_inv_cancel, mul_one]]
+  rw [Subgroup.conjAct_pointwise_smul_eq_self hnorm, Subgroup.relIndex_self]
 
 end HeckeRing.GLn

--- a/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GLn/Degree.lean
@@ -1,0 +1,229 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Degree
+public import TauCeti.NumberTheory.HeckeRing.GLn.DiagonalCosets
+
+import TauCeti.NumberTheory.ModularForms.CongruenceSubgroups
+
+/-!
+# Degrees of the diagonal double cosets
+
+The degree of a diagonal double coset `T(a₁, ..., aₙ)`, in the two cases the Hecke-ring
+calculations need. The scalar case `deg T(c, ..., c) = 1` holds at every rank, because a
+scalar matrix is central. The prime-power case `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k ≥ 1`
+is specific to rank two: the degree of a double coset is the relative index of the
+conjugated copy of `SL₂(ℤ)`, which for a diagonal representative is exactly the index
+`[SL₂(ℤ) : Γ₀(pᵏ)]` computed in `TauCeti.NumberTheory.ModularForms.CongruenceSubgroups`.
+
+Both live here, below `GLn.CoprimeMul` and the `GL2` files that consume them, rather than
+under `GL2`: the rank-two formula is a shared prerequisite of `GL2.MultiplicationTable` and
+`GL2.Degree` alike, and the scalar formula is rank-general.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GLn/Degree.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck).  Note the degree of `T(a₁,...,aₙ)` is **not** `∏_{i<j}(aⱼ/aᵢ)`: for
+`a = (1, p)` that count is `p`, while the true degree is `p + 1` — the double coset also
+contains representatives with permuted diagonals.
+
+## Main results
+
+* `degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p`, `k ≥ 1`.
+* `degree_diagCoset_scalar`: `deg T(c, ..., c) = 1`, at every rank.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Propositions 3.14, 3.18 and Theorem 3.24.
+-/
+
+public section
+
+open HeckeRing Finset CongruenceSubgroup Matrix.SpecialLinearGroup Matrix
+open scoped Pointwise MatrixGroups
+
+namespace HeckeRing.GLn
+
+variable (n : ℕ) [NeZero n]
+
+private lemma a1_eq_a0_mul_pk {p : ℕ} {a : Fin 2 → ℕ} {k : ℕ}
+    (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) :
+    (a 1 : ℚ) = (a 0 : ℚ) * (↑(p ^ k) : ℚ) := by
+  have h1 := Nat.div_mul_cancel h_dvd_a
+  rw [h_ratio] at h1
+  push_cast [← h1]; ring
+
+private lemma conj_natDiagGL_mem_of_Gamma0 (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+    (hσ : (↑(p ^ k) : ℤ) ∣ σ.1 1 0) :
+    (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2 := by
+  obtain ⟨c, hc⟩ := hσ
+  let τ_mat : Matrix (Fin 2) (Fin 2) ℤ :=
+    !![σ.1 0 0, ↑(p ^ k) * σ.1 0 1; c, σ.1 1 1]
+  have h_det : τ_mat.det = 1 := by
+    simp only [τ_mat, Matrix.det_fin_two, Matrix.of_apply, Matrix.cons_val',
+      Matrix.cons_val_zero, Matrix.cons_val_one]
+    have hσ_det := σ.prop; simp only [Matrix.det_fin_two] at hσ_det
+    rw [hc] at hσ_det; linarith
+  let τ : SL(2, ℤ) := ⟨τ_mat, h_det⟩
+  refine (mem_SLnZ_iff 2).mpr ⟨τ, ?_⟩
+  have ha1 := a1_eq_a0_mul_pk h_ratio h_dvd_a
+  have hcQ : (σ.1 1 0 : ℚ) = (↑(p ^ k) : ℚ) * (c : ℚ) := by exact_mod_cast hc
+  push_cast at ha1 hcQ
+  suffices h : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a by
+    have h' := congr_arg ((natDiagGL 2 a)⁻¹ * ·) h
+    simp only [← mul_assoc, inv_mul_cancel, one_mul] at h'; exact h'
+  apply Units.ext
+  have hval : ∀ μ : SL(2, ℤ), (↑(mapGL ℚ μ) : Matrix _ _ ℚ) = μ.val.map (Int.cast) :=
+    fun μ ↦ by simp [mapGL_coe_matrix, algebraMap_int_eq, RingHom.mapMatrix_apply]
+  simp only [Units.val_mul, hval]
+  ext i j
+  simp only [natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
+    Matrix.map_apply]
+  fin_cases i <;> fin_cases j <;>
+    simp only [τ, τ_mat, Matrix.of_apply, Matrix.cons_val', Fin.isValue] <;>
+    push_cast <;> (try rw [hcQ]) <;> (try rw [ha1]) <;> ring
+
+private lemma Gamma0_of_conj_natDiagGL_mem (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) (σ : SL(2, ℤ))
+    (hmem : (natDiagGL 2 a)⁻¹ * (σ : GL (Fin 2) ℚ) * natDiagGL 2 a ∈ SLnZ 2) :
+    (↑(p ^ k) : ℤ) ∣ σ.1 1 0 := by
+  obtain ⟨τ, hτ⟩ := (mem_SLnZ_iff 2).mp hmem
+  have ha1 := a1_eq_a0_mul_pk h_ratio h_dvd_a
+  have ha0_ne : (a 0 : ℚ) ≠ 0 := Nat.cast_ne_zero.mpr (ha 0).ne'
+  have h_mul : natDiagGL 2 a * (τ : GL (Fin 2) ℚ) = (σ : GL (Fin 2) ℚ) * natDiagGL 2 a := by
+    have := congr_arg (natDiagGL 2 a * ·) hτ
+    simp only [← mul_assoc, mul_inv_cancel, one_mul] at this; exact this
+  have h_entry : (a 1 : ℚ) * (τ.1 1 0 : ℚ) = (σ.1 1 0 : ℚ) * (a 0 : ℚ) := by
+    have h10 := Units.ext_iff.mp h_mul
+    have := congr_arg (fun M ↦ M 1 0) h10
+    simpa only [Units.val_mul, mapGL_coe_matrix, map_apply_coe, RingHom.mapMatrix_apply,
+      natDiagGL_coe 2 a ha, Matrix.diagonal_mul, Matrix.mul_diagonal,
+      Matrix.map_apply, algebraMap_int_eq, eq_intCast] using this
+  have h_σ₁₀ : (σ.1 1 0 : ℚ) = ↑(p ^ k) * (τ.1 1 0 : ℚ) := by
+    rw [ha1] at h_entry; field_simp at h_entry ⊢; linarith
+  exact ⟨τ.1 1 0, by exact_mod_cast h_σ₁₀⟩
+
+private lemma conjDiag_relIndex_eq_Gamma0_index (p : ℕ) (a : Fin 2 → ℕ) (ha : ∀ i, 0 < a i)
+    (k : ℕ) (h_ratio : a 1 / a 0 = p ^ k) (h_dvd_a : a 0 ∣ a 1) :
+    (ConjAct.toConjAct (natDiagGL 2 a) • SLnZ 2).relIndex (SLnZ 2) =
+    (Gamma0 (p ^ k)).index := by
+  set H := SLnZ 2
+  set α := natDiagGL 2 a
+  set f := (mapGL ℚ : SL(2, ℤ) →* GL (Fin 2) ℚ)
+  have h_inj : Function.Injective f := mapGL_injective
+  have h_H_eq : H = Subgroup.map f ⊤ := by
+    ext g
+    simp only [Subgroup.mem_map, Subgroup.mem_top, true_and]
+    exact (mem_SLnZ_iff 2).trans (by simp [f])
+  have h_gamma0_iff : ∀ σ : SL(2, ℤ),
+      σ ∈ Gamma0 (p ^ k) ↔ α⁻¹ * f σ * α ∈ H := by
+    intro σ
+    rw [Gamma0_mem, ZMod.intCast_zmod_eq_zero_iff_dvd]
+    exact ⟨conj_natDiagGL_mem_of_Gamma0 p a ha k h_ratio h_dvd_a σ,
+           Gamma0_of_conj_natDiagGL_mem p a ha k h_ratio h_dvd_a σ⟩
+  have h_inf_eq : (ConjAct.toConjAct α • H) ⊓ H = Subgroup.map f (Gamma0 (p ^ k)) := by
+    ext g; simp only [Subgroup.mem_inf, Subgroup.mem_map]
+    constructor
+    · rintro ⟨h_smul, h_mem⟩
+      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
+        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv] at h_smul
+      obtain ⟨σ, rfl⟩ := (mem_SLnZ_iff 2).mp h_mem
+      exact ⟨σ, (h_gamma0_iff σ).mpr h_smul, rfl⟩
+    · rintro ⟨σ, hσ, rfl⟩
+      refine ⟨?_, coe_mem_SLnZ 2 σ⟩
+      rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
+        ConjAct.ofConjAct_inv, ConjAct.ofConjAct_toConjAct, inv_inv]
+      exact (h_gamma0_iff σ).mp hσ
+  calc (ConjAct.toConjAct α • H).relIndex H
+      = ((ConjAct.toConjAct α • H) ⊓ H).relIndex H :=
+        (Subgroup.inf_relIndex_right _ _).symm
+    _ = (Subgroup.map f (Gamma0 (p ^ k))).relIndex (Subgroup.map f ⊤) := by
+        rw [h_inf_eq, h_H_eq]
+    _ = (Gamma0 (p ^ k)).relIndex ⊤ :=
+        Subgroup.relIndex_map_map_of_injective _ _ h_inj
+    _ = (Gamma0 (p ^ k)).index := (Gamma0 (p ^ k)).relIndex_top_right
+
+/-- **The prime-power degree** (Shimura, Theorem 3.24, degree count): for prime `p`,
+`deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹ (p + 1)` for `k ≥ 1`. -/
+theorem degree_diagCoset_prime_pow (p : ℕ) (hp : Nat.Prime p) (a : Fin 2 → ℕ)
+    (ha : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (k : ℕ) (hk : 0 < k)
+    (h_ratio : a 1 / a 0 = p ^ k) :
+    (diagCoset a).degree = p ^ (k - 1) * (p + 1) := by
+  set H := SLnZ 2
+  set α := (natDiagGL 2 a : GL (Fin 2) ℚ) with hα_def
+  set D := diagCoset a with hD_def
+  set δ := (HeckeCoset.rep D : GL (Fin 2) ℚ)
+  have h_dvd_a : a 0 ∣ a 1 := isDvdChain_iff.mp hdiv (Fin.zero_le 1)
+  have h_in_set : δ ∈ HeckeCoset.toSet D := HeckeCoset.rep_mem D
+  have h_D_set : HeckeCoset.toSet D = DoubleCoset.doubleCoset α ↑H ↑H := by
+    rw [hD_def]; exact diagCoset_toSet a
+  rw [h_D_set, DoubleCoset.mem_doubleCoset] at h_in_set
+  obtain ⟨σ₁, hσ₁, σ₂, hσ₂, hδ_eq⟩ := h_in_set
+  have h_smul_σ₁ : ConjAct.toConjAct σ₁ • H = H :=
+    Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hσ₁)
+  have h_δ_smul : ConjAct.toConjAct δ • H =
+      ConjAct.toConjAct σ₁ • (ConjAct.toConjAct α • H) := by
+    rw [hδ_eq, map_mul, map_mul, ← smul_smul, ← smul_smul,
+      Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer hσ₂)]
+  have h_S1 : (ConjAct.toConjAct α • H).relIndex H =
+      (ConjAct.toConjAct δ • H).relIndex H := by
+    rw [h_δ_smul]
+    have := Subgroup.relIndex_pointwise_smul
+      (ConjAct.toConjAct σ₁) (ConjAct.toConjAct α • H) H
+    rw [h_smul_σ₁] at this; exact this.symm
+  rw [HeckeCoset.degree_eq_relIndex, ← h_S1,
+    conjDiag_relIndex_eq_Gamma0_index p a ha k h_ratio h_dvd_a,
+    Gamma0_prime_power_index p hp k hk]
+
+private lemma natDiagGL_comm_of_const (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
+    (h_const : ∀ i, a i = a 0) (g : GL (Fin n) ℚ) :
+    natDiagGL n a * g = g * natDiagGL n a := by
+  apply Units.ext
+  simp only [Units.val_mul, natDiagGL_coe n a ha]
+  have h_diag : Matrix.diagonal (fun i ↦ (a i : ℚ)) =
+      (a 0 : ℚ) • (1 : Matrix (Fin n) (Fin n) ℚ) := by
+    ext i j
+    simp only [Matrix.diagonal_apply, Matrix.smul_apply, Matrix.one_apply, smul_eq_mul]
+    split_ifs with h
+    · subst h; simp [h_const]
+    · simp
+  rw [h_diag, smul_mul_assoc, mul_smul_comm, one_mul, mul_one]
+
+/-- **The scalar degree**: a scalar diagonal matrix is central, so its double coset is a
+single coset and `deg T(c, ..., c) = 1`. -/
+theorem degree_diagCoset_scalar (a : Fin n → ℕ) (ha : ∀ i, 0 < a i)
+    (h_const : ∀ i, a i = a 0) : (diagCoset a).degree = 1 := by
+  set H := SLnZ n
+  set D := diagCoset a with hD_def
+  set δ := HeckeCoset.rep D
+  suffices hsmul : ConjAct.toConjAct (δ : GL (Fin n) ℚ) • H = H by
+    rw [HeckeCoset.degree_eq_relIndex]
+    rw [show ConjAct.toConjAct ((HeckeCoset.rep D : _) : GL (Fin n) ℚ) • H = H from hsmul,
+      Subgroup.relIndex_self]
+  have hδ_mem : (δ : GL (Fin n) ℚ) ∈ HeckeCoset.toSet D := HeckeCoset.rep_mem D
+  rw [show HeckeCoset.toSet D =
+      DoubleCoset.doubleCoset (natDiagGL n a) ↑H ↑H from by
+    rw [hD_def]; exact diagCoset_toSet a, DoubleCoset.mem_doubleCoset] at hδ_mem
+  obtain ⟨h₁, hh₁, h₂, hh₂, hδ_eq⟩ := hδ_mem
+  have h_comm : natDiagGL n a * h₂ = h₂ * natDiagGL n a :=
+    natDiagGL_comm_of_const n a ha h_const h₂
+  have hδ_simp : (δ : GL (Fin n) ℚ) = (h₁ * h₂) * natDiagGL n a := by
+    rw [hδ_eq, mul_assoc, h_comm, ← mul_assoc]
+  have h_diag_conj : ∀ (g : GL (Fin n) ℚ),
+      (natDiagGL n a)⁻¹ * g * natDiagGL n a = g := by
+    intro g; rw [mul_assoc, ← natDiagGL_comm_of_const n a ha h_const g, ← mul_assoc,
+      inv_mul_cancel, one_mul]
+  rw [hδ_simp, map_mul, ← smul_smul]
+  have h_smul_diag : ConjAct.toConjAct (natDiagGL n a) • H = H := by
+    ext x
+    simp only [Subgroup.mem_pointwise_smul_iff_inv_smul_mem, ConjAct.smul_def,
+      map_inv, ConjAct.ofConjAct_toConjAct, inv_inv, h_diag_conj]
+  rw [h_smul_diag]
+  exact Subgroup.conjAct_pointwise_smul_eq_self (Subgroup.le_normalizer (H.mul_mem hh₁ hh₂))
+
+end HeckeRing.GLn


### PR DESCRIPTION
The degree of a diagonal double coset `T(a₁, …, aₙ)`, in the two cases the Hecke-ring calculations need.

* `HeckeRing.GLn.degree_diagCoset_scalar`: `deg T(c, …, c) = 1`, **at every rank** — a scalar matrix is central, so it commutes past both sides of the double coset and the conjugated copy of `SL_n(ℤ)` is `SL_n(ℤ)` itself.
* `HeckeRing.GLn.degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for prime `p` and `k ≥ 1`. This one is genuinely rank-two: the degree is the relative index of the conjugated copy of `SL₂(ℤ)`, which for a diagonal representative is exactly `[SL₂(ℤ) : Γ₀(pᵏ)]`, already computed in `ModularForms/CongruenceSubgroups.lean` (#2052).

Both live under `GLn` rather than `GL2` because the rank-two formula is a shared prerequisite of `GL2.MultiplicationTable` and `GL2.Degree` alike, and must sit below both; the scalar formula is rank-general. The module docstring says so, so the placement is not accidental.

Worth recording, since it is an easy thing to assume: the degree of `T(a₁, …, aₙ)` is **not** `∏_{i<j}(aⱼ/aᵢ)`. For `a = (1, p)` that count gives `p`, while the true degree is `p + 1` — the double coset also contains representatives with permuted diagonals.

Ported from the AINTLIB `LeanModularForms` project (`LeanModularForms/HeckeRIngs/GLn/Degree.lean`, Chris Birkbeck). Two deviations from the source: the scalar case is stated at arbitrary rank rather than for `Fin 2` (its proof never used the rank), and the conjugation-fixes-a-subgroup step calls Mathlib's `Subgroup.conjAct_pointwise_smul_eq_self` directly instead of through a local wrapper.

Builds on #2084 (the abstract degree homomorphism), now in `main`.

**Roadmap target.** [`TauCetiRoadmap/ModularForms/README.md`](https://github.com/FormalFrontier/TauCetiRoadmap/blob/main/TauCetiRoadmap/ModularForms/README.md), Layer 2: the concrete `GL_n` Hecke-ring theory underlying the `T_p` operators. These degree formulas are what turn the abstract degree homomorphism into the classical `deg T(m) = σ₁(m)`.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5
