### PR TITLE
feat(ModularForms): the residue sum along the boundary contour

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -50,7 +50,7 @@ variable {H : ℝ} {w : ℂ}
 
 /-- Off-curve avoidance for interior points: each piece is separated from `w` in one
 coordinate, the arc by the norm. -/
-private lemma fdBoundary_ne_of_interior (hre : |w.re| < 1 / 2) (hnorm : 1 < ‖w‖)
+theorem fdBoundary_ne_of_interior (hre : |w.re| < 1 / 2) (hnorm : 1 < ‖w‖)
     (him : w.im < H) : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w := by
   obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hre
   intro t ht h_eq

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Interior.lean
@@ -50,8 +50,8 @@ variable {H : ℝ} {w : ℂ}
 
 /-- Off-curve avoidance for interior points: each piece is separated from `w` in one
 coordinate, the arc by the norm. -/
-theorem fdBoundary_ne_of_interior (hre : |w.re| < 1 / 2) (hnorm : 1 < ‖w‖)
-    (him : w.im < H) : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w := by
+theorem fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt (hre : |w.re| < 1 / 2)
+    (hnorm : 1 < ‖w‖) (him : w.im < H) : ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ w := by
   obtain ⟨hx₁, hx₂⟩ := abs_lt.mp hre
   intro t ht h_eq
   rcases le_or_gt t 1 with h1 | h1
@@ -88,7 +88,7 @@ private theorem windingNumber_fdBoundary_eq_neg_one_of_one_lt_im (hx : |w.re| < 
     nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
   have hnorm : 1 < ‖w‖ :=
     hy1.trans_le ((le_abs_self _).trans (Complex.abs_im_le_norm w))
-  have hw := fdBoundary_ne_of_interior hx hnorm hyH
+  have hw := fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt hx hnorm hyH
   -- the four endpoint differences, their coordinates, and their nonvanishing
   have hz₀ : (1 / 2 + H * Complex.I - w).re = 1 / 2 - w.re ∧
       (1 / 2 + H * Complex.I - w).im = H - w.im := by constructor <;> simp
@@ -237,7 +237,7 @@ theorem windingNumber_fdBoundary_eq_neg_one_of_interior (hH : 1 < H) {w : ℂ}
     rintro z hz ⟨t, ht, h_eq⟩
     rw [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht
     obtain ⟨hz_re, hz_norm, hz_im⟩ := interior_avoiding_facts hH hnorm hre him hpos hz
-    exact fdBoundary_ne_of_interior hz_re hz_norm hz_im t ht h_eq
+    exact fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt hz_re hz_norm hz_im t ht h_eq
   rw [(isPiecewiseC1On_fdBoundary H).windingNumber_eq_of_mem_connectedComponentIn
       (fdBoundary_closed H).symm
       (hconn.subset_connectedComponentIn (Or.inr htop_mem_box) hdisj

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
@@ -51,9 +51,7 @@ variable {H : ℝ}
 lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
     (ht : t ∈ Icc (0 : ℝ) 5) :
     fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
   refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
     one_le_norm_fdBoundary hH ht⟩
@@ -70,11 +68,10 @@ theorem hasCauchyPV_fdBoundary_residue_sum (hH : 1 < H) {f : ℂ → ℂ} {S : F
     (hS : ∀ s ∈ S, 1 < ‖s‖ ∧ |s.re| < 1 / 2 ∧ 0 < s.im ∧ s.im < H) :
     HasCauchyPV (fdBoundary H) 0 5 f
       (-(2 * (Real.pi : ℂ) * Complex.I) * ∑ s ∈ S, residue f s) := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
-    rw [div_le_one (by norm_num)]
-    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   have hne : ∀ s ∈ S, ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ s := fun s hs =>
-    fdBoundary_ne_of_interior (hS s hs).2.1 (hS s hs).1 (hS s hs).2.2.2
+    fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt (hS s hs).2.1 (hS s hs).1
+      (hS s hs).2.2.2
   have key := decomp.hasCauchyPV_residue_sum hU
     (isPwC1ImmersionOn_fdBoundary (ne_of_gt (lt_of_le_of_lt h32 hH)))
     (by norm_num : (0 : ℝ) ≤ 5) (fdBoundary_closed H).symm

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
@@ -1,0 +1,102 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.Modular
+public import TauCeti.Analysis.Contour.Residue.Assembly
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+
+import TauCeti.Analysis.Contour.NullHomologous
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Immersion
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Interior
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Winding
+
+/-!
+# The residue sum along the boundary contour
+
+The Hungerbühler–Wasem residue sum, instantiated on the boundary contour of the truncated
+fundamental domain: for a function with a polar-part decomposition whose poles all lie in
+the open truncated domain, the principal value of the contour integral is `-2πi` times the
+sum of the residues — the contour winds `-1` about every interior point, and the corner
+conditions of the general theorem hold vacuously because the contour avoids the poles.
+
+This is the contour side of the valence formula: applied to the logarithmic derivative of
+a modular form, the residues become the orders of its zeros.
+
+## Main declarations
+
+* `TauCeti.ModularForm.hasCauchyPV_fdBoundary_residue_sum`.
+
+## References
+
+The truncated-contour strategy follows the fundamental-domain boundary development of
+AINTLIB's `LeanModularForms` (`ForMathlib/FDBoundary.lean`, `FDBoundaryH.lean`,
+`FDBoundaryPath.lean`); the residue machinery is Tau Ceti's Hungerbühler–Wasem
+development.
+-/
+
+public section
+
+open Set TauCeti.Contour UpperHalfPlane
+
+namespace TauCeti
+
+namespace ModularForm
+
+variable {H : ℝ}
+
+/-- The boundary contour lies in the closed truncated fundamental domain. -/
+lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
+    (ht : t ∈ Icc (0 : ℝ) 5) :
+    fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
+  refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
+    one_le_norm_fdBoundary hH ht⟩
+  have := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht
+  nlinarith [Real.sqrt_nonneg 3]
+
+/-- **The residue sum along the boundary contour.** For a function with a polar-part
+decomposition on an open set containing the closed truncated fundamental domain, all of
+whose poles lie in the open truncated domain, the principal value of the contour integral
+is `-2πi` times the sum of the residues: the contour winds `-1` about every pole. -/
+theorem hasCauchyPV_fdBoundary_residue_sum (hH : 1 < H) {f : ℂ → ℂ} {S : Finset ℂ}
+    {U : Set ℂ} (decomp : PolarPartDecomposition f S U) (hU : IsOpen U)
+    (hUdom : UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H ⊆ U)
+    (hS : ∀ s ∈ S, 1 < ‖s‖ ∧ |s.re| < 1 / 2 ∧ 0 < s.im ∧ s.im < H) :
+    HasCauchyPV (fdBoundary H) 0 5 f
+      (-(2 * (Real.pi : ℂ) * Complex.I) * ∑ s ∈ S, residue f s) := by
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := by
+    rw [div_le_one (by norm_num)]
+    nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
+  have hne : ∀ s ∈ S, ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ s := fun s hs =>
+    fdBoundary_ne_of_interior (hS s hs).2.1 (hS s hs).1 (hS s hs).2.2.2
+  have key := decomp.hasCauchyPV_residue_sum hU
+    (isPwC1ImmersionOn_fdBoundary (ne_of_gt (lt_of_le_of_lt h32 hH)))
+    (by norm_num : (0 : ℝ) ≤ 5) (fdBoundary_closed H).symm
+    (fun t ht => hUdom (fdBoundary_mem_coe_truncatedFundamentalDomain hH.le
+      (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht)))
+    ((isNullHomologous_fdBoundary hH.le).mono hUdom)
+    (fun s t ht heq => absurd heq (hne s s.2 t ht))
+    (fun s k _ _ t ht heq => absurd heq (hne s s.2 t ht))
+    (fun s k _ _ t ht heq => absurd heq (hne s s.2 t ht))
+  have hsum : ∑ s ∈ S, windingNumber (fdBoundary H) 0 5 s * residue f s =
+      -∑ s ∈ S, residue f s := by
+    rw [← Finset.sum_neg_distrib]
+    refine Finset.sum_congr rfl fun s hs => ?_
+    rw [windingNumber_fdBoundary_eq_neg_one_of_interior hH (hS s hs).1 (hS s hs).2.1
+      (hS s hs).2.2.1 (hS s hs).2.2.2]
+    ring
+  rw [hsum] at key
+  convert key using 1
+  ring
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/ResidueSum.lean
@@ -47,16 +47,9 @@ namespace ModularForm
 
 variable {H : ℝ}
 
-/-- The boundary contour lies in the closed truncated fundamental domain. -/
-lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
-    (ht : t ∈ Icc (0 : ℝ) 5) :
-    fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
-  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
-  refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
-    one_le_norm_fdBoundary hH ht⟩
-  have := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht
-  nlinarith [Real.sqrt_nonneg 3]
+/-- The truncation height dominates the corner row. -/
+private lemma sqrt_three_div_two_lt_of_one_lt (hH : 1 < H) : Real.sqrt 3 / 2 < H := by
+  nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 
 /-- **The residue sum along the boundary contour.** For a function with a polar-part
 decomposition on an open set containing the closed truncated fundamental domain, all of
@@ -68,12 +61,11 @@ theorem hasCauchyPV_fdBoundary_residue_sum (hH : 1 < H) {f : ℂ → ℂ} {S : F
     (hS : ∀ s ∈ S, 1 < ‖s‖ ∧ |s.re| < 1 / 2 ∧ 0 < s.im ∧ s.im < H) :
     HasCauchyPV (fdBoundary H) 0 5 f
       (-(2 * (Real.pi : ℂ) * Complex.I) * ∑ s ∈ S, residue f s) := by
-  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
   have hne : ∀ s ∈ S, ∀ t ∈ Icc (0 : ℝ) 5, fdBoundary H t ≠ s := fun s hs =>
     fdBoundary_ne_of_abs_re_lt_half_of_one_lt_norm_of_im_lt (hS s hs).2.1 (hS s hs).1
       (hS s hs).2.2.2
   have key := decomp.hasCauchyPV_residue_sum hU
-    (isPwC1ImmersionOn_fdBoundary (ne_of_gt (lt_of_le_of_lt h32 hH)))
+    (isPwC1ImmersionOn_fdBoundary (ne_of_gt (sqrt_three_div_two_lt_of_one_lt hH)))
     (by norm_num : (0 : ℝ) ≤ 5) (fdBoundary_closed H).symm
     (fun t ht => hUdom (fdBoundary_mem_coe_truncatedFundamentalDomain hH.le
       (by rwa [uIcc_of_le (by norm_num : (0 : ℝ) ≤ 5)] at ht)))

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -50,7 +50,7 @@ namespace ModularForm
 variable {H t : ℝ}
 
 /-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
-private lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
+lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
   rw [div_le_one (by norm_num)]
   nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/Winding.lean
@@ -50,7 +50,7 @@ namespace ModularForm
 variable {H t : ℝ}
 
 /-- The corner height `√3/2` lies below `1`, the height of the arc's apex. -/
-lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
+private lemma sqrt_three_div_two_le_one : Real.sqrt 3 / 2 ≤ 1 := by
   rw [div_le_one (by norm_num)]
   nlinarith [Real.sq_sqrt (by norm_num : (3 : ℝ) ≥ 0), Real.sqrt_nonneg 3]
 
@@ -357,6 +357,17 @@ theorem isNullHomologous_fdBoundary (hH : 1 ≤ H) :
       norm_num at h ⊢
       linarith
   · exact windingNumber_fdBoundary_eq_zero_of_norm_lt_one hH hnorm
+
+/-- The boundary contour lies in the closed truncated fundamental domain. -/
+lemma fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H) {t : ℝ}
+    (ht : t ∈ Icc (0 : ℝ) 5) :
+    fdBoundary H t ∈ UpperHalfPlane.coe '' ModularGroup.truncatedFundamentalDomain H := by
+  have h32 : Real.sqrt 3 / 2 ≤ 1 := sqrt_three_div_two_le_one
+  rw [ModularGroup.coe_truncatedFundamentalDomain, Set.mem_ofPred_eq]
+  refine ⟨?_, im_fdBoundary_le hH ht, abs_re_fdBoundary_le_half ht.2,
+    one_le_norm_fdBoundary hH ht⟩
+  have := sqrt_three_div_two_le_im_fdBoundary (h32.trans hH) ht
+  nlinarith [Real.sqrt_nonneg 3]
 
 end ModularForm
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The Hungerbühler–Wasem residue sum instantiated on the boundary contour of the truncated
fundamental domain: for a function with a polar-part decomposition whose poles all lie
strictly inside the truncated domain, the Cauchy principal value along the contour is
`-2πi` times the residue sum.

- `fdBoundary_mem_coe_truncatedFundamentalDomain (hH : 1 ≤ H)` — the contour lies in the
  closed truncated domain (the four coordinate bounds)
- `hasCauchyPV_fdBoundary_residue_sum (hH : 1 < H) (decomp : PolarPartDecomposition f S U)
  (hU : IsOpen U) (hUdom : coe '' truncatedFundamentalDomain H ⊆ U)
  (hS : poles strictly interior) : HasCauchyPV (fdBoundary H) 0 5 f (-(2πi) * Σ residues)`
  — via `PolarPartDecomposition.hasCauchyPV_residue_sum` with the merged winding
  determination: the interior winding number is `-1` (#2067), the contour is a
  piecewise-`C¹` immersion (#2040), null-homologous in the domain (#2020), and the
  corner conditions hold vacuously because the contour avoids the poles (the interior
  avoidance lemma, publicized here from #2067's file as this PR's cross-module consumer).

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): applied to
`f := logDeriv (F ∘ ofComplex)` of a nonzero level-one form with
`PolarPartDecomposition.ofMeromorphic` at its zeros, the residue sum is the order sum —
the divisor side of the valence formula. The integral-evaluation side (#2117, #2118,
#2128, #2130, #2134) computes the same principal value as `2πi·(ord_∞ + k/12 - …)`,
and equating the two is the valence contour identity.

Roadmap: ModularForms
