### PR TITLE
feat: Marcinkiewicz interpolation and the strong (p,p) maximal inequality

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -6,7 +6,7 @@ module
 
 public import Mathlib.Analysis.SpecialFunctions.Pow.Integral
 -- `Mathlib.Analysis.SpecialFunctions.ImproperIntegrals` is imported privately: it supplies
--- `integrableOn_Ioi_rpow_iff`, used only inside the proof of
+-- `not_integrableOn_Ioi_rpow`, used only inside the proof of
 -- `TauCeti.lintegral_ofReal_rpow_Ioi`.
 import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
 -- `Mathlib.Analysis.SpecialFunctions.Integrals.Basic` is imported privately: it supplies the
@@ -21,10 +21,12 @@ This file collects the two lower integrals of `t ↦ t ^ s` on a half-line that 
 interpolation method needs, and uses them to transport Mathlib's layer cake formula from
 real-valued to `ℝ≥0∞`-valued functions.
 
-For `-1 < s` the function `t ↦ t ^ s` is integrable near `0` and not integrable near `∞`, so the
-two computations below are the two halves of that dichotomy: `TauCeti.lintegral_ofReal_rpow_Ioo`
-evaluates `∫⁻ t in (0, a), t ^ s` to the expected antiderivative, and
-`TauCeti.lintegral_ofReal_rpow_Ioi` records that `∫⁻ t in (0, ∞), t ^ s` diverges.
+For `-1 < s` the function `t ↦ t ^ s` is integrable near `0` and not integrable near `∞`, and the
+two computations below are the two halves of that dichotomy:
+`TauCeti.lintegral_ofReal_rpow_Ioo` evaluates `∫⁻ t in (0, a), t ^ s` to the expected
+antiderivative for such an `s`, while `TauCeti.lintegral_ofReal_rpow_Ioi` records that
+`∫⁻ t in (0, ∞), t ^ s` diverges — the latter for *every* exponent `s`, since a power that is
+integrable at the origin is not integrable at infinity and conversely.
 
 The layer cake formula `∫⁻ u ^ p = p * ∫⁻ t in (0, ∞), ν {u > t} * t ^ (p - 1)` is in Mathlib as
 `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul`, but only for a nonnegative *real-valued*
@@ -45,7 +47,7 @@ used, and it is why the statement needs no finiteness hypothesis on `u`.
 
 * `TauCeti.lintegral_ofReal_rpow_Ioo`: `∫⁻ t in (0, a), t ^ s = a ^ (s + 1) / (s + 1)` for
   `-1 < s`.
-* `TauCeti.lintegral_ofReal_rpow_Ioi`: `∫⁻ t in (0, ∞), t ^ s = ∞` for `-1 < s`.
+* `TauCeti.lintegral_ofReal_rpow_Ioi`: `∫⁻ t in (0, ∞), t ^ s = ∞`, for every `s`.
 * `TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`: the layer cake formula for an
   `ℝ≥0∞`-valued function.
 
@@ -79,22 +81,17 @@ theorem lintegral_ofReal_rpow_Ioo (hs : -1 < s) {a : ℝ} (ha : 0 ≤ a) :
     ← intervalIntegral.integral_of_le ha, integral_rpow (Or.inl hs), Real.zero_rpow hs1.ne',
     sub_zero]
 
-/-- The lower integral of `t ^ s` over `(0, ∞)` diverges for `-1 < s`: the power is not integrable
-at infinity. -/
-theorem lintegral_ofReal_rpow_Ioi (hs : -1 < s) :
+/-- The lower integral of `t ^ s` over `(0, ∞)` diverges, for every exponent `s`: the power fails
+to be integrable at the origin or at infinity, according as `s ≤ -1` or `-1 < s`. -/
+theorem lintegral_ofReal_rpow_Ioi (s : ℝ) :
     ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ s) = ∞ := by
   by_contra hne
-  have hle : ∫⁻ t in Ioi (1 : ℝ), ENNReal.ofReal (t ^ s) ≤
-      ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ s) :=
-    lintegral_mono_set (Ioi_subset_Ioi zero_le_one)
   have hmeas : Measurable fun t : ℝ => t ^ s := measurable_id.pow measurable_const
-  have hint : IntegrableOn (fun t : ℝ => t ^ s) (Ioi 1) := by
-    refine ⟨hmeas.aestronglyMeasurable, ?_⟩
-    rw [hasFiniteIntegral_iff_enorm]
-    refine lt_of_le_of_lt (le_of_eq ?_) (lt_top_iff_ne_top.2 fun h => hne (top_le_iff.1 (h ▸ hle)))
-    refine setLIntegral_congr_fun measurableSet_Ioi fun t ht => ?_
-    exact Real.enorm_eq_ofReal (Real.rpow_nonneg (zero_le_one.trans (le_of_lt ht)) s)
-  exact absurd ((integrableOn_Ioi_rpow_iff one_pos).1 hint) (by linarith)
+  refine not_integrableOn_Ioi_rpow s ⟨hmeas.aestronglyMeasurable, ?_⟩
+  rw [hasFiniteIntegral_iff_enorm]
+  refine lt_of_le_of_lt (le_of_eq ?_) (lt_top_iff_ne_top.2 hne)
+  refine setLIntegral_congr_fun measurableSet_Ioi fun t ht => ?_
+  exact Real.enorm_eq_ofReal (Real.rpow_nonneg (le_of_lt ht) s)
 
 variable {β : Type*} [MeasurableSpace β]
 
@@ -111,7 +108,6 @@ theorem lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul (ν : Measure β) {u : β
     (hu : AEMeasurable u ν) {p : ℝ} (hp : 0 < p) :
     ∫⁻ y, u y ^ p ∂ν = ENNReal.ofReal p *
       ∫⁻ t in Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1)) := by
-  have hs : -1 < p - 1 := by linarith
   rcases eq_or_ne (ν {y | u y = ∞}) 0 with hnull | hnull
   · -- `u` is finite almost everywhere, so `ENNReal.toReal` transports Mathlib's formula.
     have hfin : ∀ᵐ y ∂ν, u y ≠ ∞ := by rw [ae_iff]; simpa using hnull
@@ -141,7 +137,7 @@ theorem lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul (ν : Measure β) {u : β
       refine top_le_iff.1 ?_
       calc (∞ : ℝ≥0∞)
           = ν {y | u y = ∞} * ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ (p - 1)) := by
-            rw [lintegral_ofReal_rpow_Ioi hs, ENNReal.mul_top hnull]
+            rw [lintegral_ofReal_rpow_Ioi (p - 1), ENNReal.mul_top hnull]
         _ = ∫⁻ t in Ioi (0 : ℝ), ν {y | u y = ∞} * ENNReal.ofReal (t ^ (p - 1)) :=
             (lintegral_const_mul _ ((measurable_id.pow measurable_const).ennreal_ofReal)).symm
         _ ≤ _ := lintegral_mono fun t => mul_le_mul_left (measure_mono hsub) _

--- a/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -128,9 +128,10 @@ theorem lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul (ν : Measure β) {u : β
     exact propext (ENNReal.ofReal_lt_iff_lt_toReal (le_of_lt ht) hy).symm
   · -- `u = ∞` on a set of positive measure: both sides are `∞`.
     have hL : ∫⁻ y, u y ^ p ∂ν = ∞ := by
+      have hlevel : {y | u y ^ p = ∞} = {y | u y = ∞} :=
+        Set.ext fun y => ENNReal.rpow_eq_top_iff_of_pos hp
       refine lintegral_eq_top_of_measure_eq_top_ne_zero (hu.pow_const p) ?_
-      rwa [show {y | u y ^ p = ∞} = {y | u y = ∞} from
-        Set.ext fun y => ENNReal.rpow_eq_top_iff_of_pos hp]
+      rwa [hlevel]
     have hR : ∫⁻ t in Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} *
         ENNReal.ofReal (t ^ (p - 1)) = ∞ := by
       have hsub : ∀ {t : ℝ}, {y | u y = ∞} ⊆ {y | ENNReal.ofReal t < u y} := by

--- a/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -28,6 +28,11 @@ antiderivative for such an `s`, while `TauCeti.lintegral_ofReal_rpow_Ioi` record
 `∫⁻ t in (0, ∞), t ^ s` diverges — the latter for *every* exponent `s`, since a power that is
 integrable at the origin is not integrable at infinity and conversely.
 
+`TauCeti.lintegral_indicator_ofReal_rpow_Ioi` packages the two together as the single formula the
+real interpolation method uses: the integral over `(0, ∞)` of `t ^ s` cut off at the height where
+`c * t` reaches a threshold `a : ℝ≥0∞`, which is the finite antiderivative when `a` is finite and
+`∞` when it is not.
+
 The layer cake formula `∫⁻ u ^ p = p * ∫⁻ t in (0, ∞), ν {u > t} * t ^ (p - 1)` is in Mathlib as
 `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul`, but only for a nonnegative *real-valued*
 `u`. Analysis in `ℝ≥0∞` — where the operators of interpolation theory naturally land, since a
@@ -46,8 +51,10 @@ used, and it is why the statement needs no finiteness hypothesis on `u`.
 ## Main declarations
 
 * `TauCeti.lintegral_ofReal_rpow_Ioo`: `∫⁻ t in (0, a), t ^ s = a ^ (s + 1) / (s + 1)` for
-  `-1 < s`.
+  `-1 < s` and `0 ≤ a`.
 * `TauCeti.lintegral_ofReal_rpow_Ioi`: `∫⁻ t in (0, ∞), t ^ s = ∞`, for every `s`.
+* `TauCeti.lintegral_indicator_ofReal_rpow_Ioi`: the same integral truncated at the height where
+  `c * t` reaches `a : ℝ≥0∞`, evaluated to `c ^ (-(s + 1)) / (s + 1) * a ^ (s + 1)`.
 * `TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`: the layer cake formula for an
   `ℝ≥0∞`-valued function.
 
@@ -65,8 +72,11 @@ open scoped ENNReal
 
 variable {s : ℝ}
 
-/-- The lower integral of `t ^ s` over a bounded interval `(0, a)`, for `-1 < s`: the power is
-integrable at the origin and the value is the expected antiderivative. -/
+/-- The lower integral of `t ^ s` over a bounded interval `(0, a)`, for `-1 < s` and `0 ≤ a`: the
+power is integrable at the origin and the value is the expected antiderivative.
+
+Nonnegativity of `a` is needed: for `a < 0` the interval is empty while `a ^ (s + 1)`, a real power
+at a negative base, need not vanish. -/
 theorem lintegral_ofReal_rpow_Ioo (hs : -1 < s) {a : ℝ} (ha : 0 ≤ a) :
     ∫⁻ t in Ioo (0 : ℝ) a, ENNReal.ofReal (t ^ s) = ENNReal.ofReal (a ^ (s + 1) / (s + 1)) := by
   have hs1 : (0 : ℝ) < s + 1 := by linarith
@@ -87,11 +97,66 @@ theorem lintegral_ofReal_rpow_Ioi (s : ℝ) :
     ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ s) = ∞ := by
   by_contra hne
   have hmeas : Measurable fun t : ℝ => t ^ s := measurable_id.pow measurable_const
-  refine not_integrableOn_Ioi_rpow s ⟨hmeas.aestronglyMeasurable, ?_⟩
-  rw [hasFiniteIntegral_iff_enorm]
-  refine lt_of_le_of_lt (le_of_eq ?_) (lt_top_iff_ne_top.2 hne)
-  refine setLIntegral_congr_fun measurableSet_Ioi fun t ht => ?_
-  exact Real.enorm_eq_ofReal (Real.rpow_nonneg (le_of_lt ht) s)
+  have hnn : 0 ≤ᵐ[volume.restrict (Ioi (0 : ℝ))] fun t : ℝ => t ^ s := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht
+    exact Real.rpow_nonneg (le_of_lt ht) s
+  exact not_integrableOn_Ioi_rpow s
+    ⟨hmeas.aestronglyMeasurable, (hasFiniteIntegral_iff_ofReal hnn).2 (lt_top_iff_ne_top.2 hne)⟩
+
+/-- The lower integral of `t ^ s` over `(0, ∞)`, truncated at the height where `c * t` reaches a
+threshold `a : ℝ≥0∞`: for `-1 < s` and `0 < c`,
+
+`∫⁻ t in (0, ∞), [c * t < a] * t ^ s = c ^ (-(s + 1)) / (s + 1) * a ^ (s + 1)`.
+
+For a finite `a` the cut-off makes this the integral over `(0, a / c)` evaluated by
+`TauCeti.lintegral_ofReal_rpow_Ioo`; for `a = ∞` the cut-off is vacuous and both sides are `∞`, by
+`TauCeti.lintegral_ofReal_rpow_Ioi`. This is the inner integral of the real interpolation method,
+where `a` is the value of the function being interpolated at a point. -/
+theorem lintegral_indicator_ofReal_rpow_Ioi (hs : -1 < s) {c : ℝ} (hc : 0 < c) (a : ℝ≥0∞) :
+    ∫⁻ t in Ioi (0 : ℝ),
+        {t : ℝ | ENNReal.ofReal (c * t) < a}.indicator (fun t => ENNReal.ofReal (t ^ s)) t =
+      ENNReal.ofReal (c ^ (-(s + 1)) / (s + 1)) * a ^ (s + 1) := by
+  have hs1 : (0 : ℝ) < s + 1 := by linarith
+  have hconst : (0 : ℝ) < c ^ (-(s + 1)) / (s + 1) := by positivity
+  rcases eq_or_ne a ∞ with rfl | ha
+  · -- The cut-off is vacuous and the integral diverges.
+    have hmem : ∀ t : ℝ, t ∈ {t : ℝ | ENNReal.ofReal (c * t) < ∞} := fun t =>
+      Set.mem_ofPred.2 ENNReal.ofReal_lt_top
+    rw [setLIntegral_congr_fun measurableSet_Ioi
+        (fun t _ => Set.indicator_of_mem (hmem t) _),
+      lintegral_ofReal_rpow_Ioi, ENNReal.top_rpow_of_pos hs1,
+      ENNReal.mul_top (ENNReal.ofReal_pos.2 hconst).ne']
+  rcases eq_or_ne a 0 with rfl | ha0
+  · -- The cut-off is empty and both sides vanish.
+    simp [ENNReal.zero_rpow_of_pos hs1]
+  set b : ℝ := a.toReal with hbdef
+  have hb0 : 0 < b := ENNReal.toReal_pos ha0 ha
+  have hab : a = ENNReal.ofReal b := (ENNReal.ofReal_toReal ha).symm
+  -- On `(0, ∞)` the cut-off is the interval `(0, b / c)`.
+  have heq : ∀ t ∈ Ioi (0 : ℝ),
+      {t : ℝ | ENNReal.ofReal (c * t) < a}.indicator (fun t => ENNReal.ofReal (t ^ s)) t =
+        (Ioo (0 : ℝ) (b / c)).indicator (fun t => ENNReal.ofReal (t ^ s)) t := by
+    intro t ht
+    have ht' : (0 : ℝ) < t := ht
+    have hiff : ENNReal.ofReal (c * t) < a ↔ t < b / c := by
+      rw [hab, ENNReal.ofReal_lt_ofReal_iff hb0, lt_div_iff₀ hc, mul_comm]
+    rcases lt_or_ge t (b / c) with hmem | hmem
+    · have hcut : t ∈ {t : ℝ | ENNReal.ofReal (c * t) < a} := Set.mem_ofPred.2 (hiff.2 hmem)
+      rw [Set.indicator_of_mem hcut, Set.indicator_of_mem (Set.mem_Ioo.2 ⟨ht', hmem⟩)]
+    · have hcut : t ∉ {t : ℝ | ENNReal.ofReal (c * t) < a} := fun hcon =>
+        absurd (hiff.1 (Set.mem_ofPred.1 hcon)) (not_lt.2 hmem)
+      rw [Set.indicator_of_notMem hcut,
+        Set.indicator_of_notMem fun hcon => absurd (Set.mem_Ioo.1 hcon).2 (not_lt.2 hmem)]
+  -- The elementary real identity behind the constant `c ^ (-(s + 1))`.
+  have hreal : (b / c) ^ (s + 1) / (s + 1) = c ^ (-(s + 1)) / (s + 1) * b ^ (s + 1) := by
+    have hcp : c ^ (s + 1) ≠ 0 := (Real.rpow_pos_of_pos hc _).ne'
+    rw [Real.div_rpow hb0.le hc.le, Real.rpow_neg hc.le]
+    field_simp
+  rw [setLIntegral_congr_fun measurableSet_Ioi heq, lintegral_indicator measurableSet_Ioo,
+    Measure.restrict_restrict measurableSet_Ioo,
+    Set.inter_eq_self_of_subset_left Ioo_subset_Ioi_self,
+    lintegral_ofReal_rpow_Ioo hs (by positivity), hab,
+    ENNReal.ofReal_rpow_of_nonneg hb0.le hs1.le, ← ENNReal.ofReal_mul hconst.le, hreal]
 
 variable {β : Type*} [MeasurableSpace β]
 

--- a/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean
@@ -1,0 +1,149 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Pow.Integral
+-- `Mathlib.Analysis.SpecialFunctions.ImproperIntegrals` is imported privately: it supplies
+-- `integrableOn_Ioi_rpow_iff`, used only inside the proof of
+-- `TauCeti.lintegral_ofReal_rpow_Ioi`.
+import Mathlib.Analysis.SpecialFunctions.ImproperIntegrals
+-- `Mathlib.Analysis.SpecialFunctions.Integrals.Basic` is imported privately: it supplies the
+-- interval integral of `t ^ s`, used only inside the proof of
+-- `TauCeti.lintegral_ofReal_rpow_Ioo`.
+import Mathlib.Analysis.SpecialFunctions.Integrals.Basic
+
+/-!
+# Lower integrals of a real power, and the layer cake formula in `ℝ≥0∞`
+
+This file collects the two lower integrals of `t ↦ t ^ s` on a half-line that the real
+interpolation method needs, and uses them to transport Mathlib's layer cake formula from
+real-valued to `ℝ≥0∞`-valued functions.
+
+For `-1 < s` the function `t ↦ t ^ s` is integrable near `0` and not integrable near `∞`, so the
+two computations below are the two halves of that dichotomy: `TauCeti.lintegral_ofReal_rpow_Ioo`
+evaluates `∫⁻ t in (0, a), t ^ s` to the expected antiderivative, and
+`TauCeti.lintegral_ofReal_rpow_Ioi` records that `∫⁻ t in (0, ∞), t ^ s` diverges.
+
+The layer cake formula `∫⁻ u ^ p = p * ∫⁻ t in (0, ∞), ν {u > t} * t ^ (p - 1)` is in Mathlib as
+`MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul`, but only for a nonnegative *real-valued*
+`u`. Analysis in `ℝ≥0∞` — where the operators of interpolation theory naturally land, since a
+supremum of averages such as the Hardy–Littlewood maximal function is defined without any
+finiteness hypothesis — needs the version for `u : β → ℝ≥0∞`, which is
+`TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul` below. The superlevel sets there are cut
+at the `ℝ≥0∞`-valued threshold `ENNReal.ofReal t`, which is what distinguishes the statement from
+Mathlib's.
+
+The passage between the two is by `ENNReal.toReal`, which is faithful exactly where `u` is finite.
+Where `u = ∞` on a set of positive measure both sides are `∞`: the left because `u ^ p = ∞`
+there, and the right because every superlevel set then has measure at least that of `{u = ∞}`,
+and `∫⁻ t in (0, ∞), t ^ (p - 1)` diverges. That is where `TauCeti.lintegral_ofReal_rpow_Ioi` is
+used, and it is why the statement needs no finiteness hypothesis on `u`.
+
+## Main declarations
+
+* `TauCeti.lintegral_ofReal_rpow_Ioo`: `∫⁻ t in (0, a), t ^ s = a ^ (s + 1) / (s + 1)` for
+  `-1 < s`.
+* `TauCeti.lintegral_ofReal_rpow_Ioi`: `∫⁻ t in (0, ∞), t ^ s = ∞` for `-1 < s`.
+* `TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`: the layer cake formula for an
+  `ℝ≥0∞`-valued function.
+
+## References
+
+* L. Grafakos, *Classical Fourier Analysis*, Proposition 1.1.4.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Set
+open scoped ENNReal
+
+variable {s : ℝ}
+
+/-- The lower integral of `t ^ s` over a bounded interval `(0, a)`, for `-1 < s`: the power is
+integrable at the origin and the value is the expected antiderivative. -/
+theorem lintegral_ofReal_rpow_Ioo (hs : -1 < s) {a : ℝ} (ha : 0 ≤ a) :
+    ∫⁻ t in Ioo (0 : ℝ) a, ENNReal.ofReal (t ^ s) = ENNReal.ofReal (a ^ (s + 1) / (s + 1)) := by
+  have hs1 : (0 : ℝ) < s + 1 := by linarith
+  have hint : IntegrableOn (fun t : ℝ => t ^ s) (Ioo 0 a) := by
+    have h := intervalIntegral.intervalIntegrable_rpow' (a := (0 : ℝ)) (b := a) hs
+    rw [intervalIntegrable_iff_integrableOn_Ioc_of_le ha] at h
+    exact h.mono_set Ioo_subset_Ioc_self
+  have hnn : 0 ≤ᵐ[volume.restrict (Ioo (0 : ℝ) a)] fun t : ℝ => t ^ s := by
+    filter_upwards [ae_restrict_mem measurableSet_Ioo] with t ht
+    exact Real.rpow_nonneg ht.1.le s
+  rw [← ofReal_integral_eq_lintegral_ofReal hint hnn, ← integral_Ioc_eq_integral_Ioo,
+    ← intervalIntegral.integral_of_le ha, integral_rpow (Or.inl hs), Real.zero_rpow hs1.ne',
+    sub_zero]
+
+/-- The lower integral of `t ^ s` over `(0, ∞)` diverges for `-1 < s`: the power is not integrable
+at infinity. -/
+theorem lintegral_ofReal_rpow_Ioi (hs : -1 < s) :
+    ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ s) = ∞ := by
+  by_contra hne
+  have hle : ∫⁻ t in Ioi (1 : ℝ), ENNReal.ofReal (t ^ s) ≤
+      ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ s) :=
+    lintegral_mono_set (Ioi_subset_Ioi zero_le_one)
+  have hmeas : Measurable fun t : ℝ => t ^ s := measurable_id.pow measurable_const
+  have hint : IntegrableOn (fun t : ℝ => t ^ s) (Ioi 1) := by
+    refine ⟨hmeas.aestronglyMeasurable, ?_⟩
+    rw [hasFiniteIntegral_iff_enorm]
+    refine lt_of_le_of_lt (le_of_eq ?_) (lt_top_iff_ne_top.2 fun h => hne (top_le_iff.1 (h ▸ hle)))
+    refine setLIntegral_congr_fun measurableSet_Ioi fun t ht => ?_
+    exact Real.enorm_eq_ofReal (Real.rpow_nonneg (zero_le_one.trans (le_of_lt ht)) s)
+  exact absurd ((integrableOn_Ioi_rpow_iff one_pos).1 hint) (by linarith)
+
+variable {β : Type*} [MeasurableSpace β]
+
+/-- **The layer cake formula** for an `ℝ≥0∞`-valued function: for `0 < p`,
+
+`∫⁻ u ^ p ∂ν = p * ∫⁻ t in (0, ∞), ν {u > t} * t ^ (p - 1)`,
+
+where the superlevel set is cut at the threshold `ENNReal.ofReal t`.
+
+This is `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul` for a function that is allowed to
+take the value `∞`; no finiteness hypothesis is needed, because both sides are `∞` as soon as
+`{u = ∞}` has positive measure. -/
+theorem lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul (ν : Measure β) {u : β → ℝ≥0∞}
+    (hu : AEMeasurable u ν) {p : ℝ} (hp : 0 < p) :
+    ∫⁻ y, u y ^ p ∂ν = ENNReal.ofReal p *
+      ∫⁻ t in Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1)) := by
+  have hs : -1 < p - 1 := by linarith
+  rcases eq_or_ne (ν {y | u y = ∞}) 0 with hnull | hnull
+  · -- `u` is finite almost everywhere, so `ENNReal.toReal` transports Mathlib's formula.
+    have hfin : ∀ᵐ y ∂ν, u y ≠ ∞ := by rw [ae_iff]; simpa using hnull
+    have hg : AEMeasurable (fun y => (u y).toReal) ν := hu.ennreal_toReal
+    have hnn : 0 ≤ᵐ[ν] fun y => (u y).toReal := .of_forall fun _ => ENNReal.toReal_nonneg
+    have hL : ∫⁻ y, u y ^ p ∂ν = ∫⁻ y, ENNReal.ofReal ((u y).toReal ^ p) ∂ν := by
+      refine lintegral_congr_ae ?_
+      filter_upwards [hfin] with y hy
+      rw [← ENNReal.ofReal_rpow_of_nonneg ENNReal.toReal_nonneg hp.le, ENNReal.ofReal_toReal hy]
+    rw [hL, lintegral_rpow_eq_lintegral_meas_lt_mul ν hnn hg hp]
+    refine congrArg _ (setLIntegral_congr_fun measurableSet_Ioi fun t ht => congrArg₂ _ ?_ rfl)
+    refine measure_congr ?_
+    filter_upwards [hfin] with y hy
+    exact propext (ENNReal.ofReal_lt_iff_lt_toReal (le_of_lt ht) hy).symm
+  · -- `u = ∞` on a set of positive measure: both sides are `∞`.
+    have hL : ∫⁻ y, u y ^ p ∂ν = ∞ := by
+      refine lintegral_eq_top_of_measure_eq_top_ne_zero (hu.pow_const p) ?_
+      rwa [show {y | u y ^ p = ∞} = {y | u y = ∞} from
+        Set.ext fun y => ENNReal.rpow_eq_top_iff_of_pos hp]
+    have hR : ∫⁻ t in Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} *
+        ENNReal.ofReal (t ^ (p - 1)) = ∞ := by
+      have hsub : ∀ {t : ℝ}, {y | u y = ∞} ⊆ {y | ENNReal.ofReal t < u y} := by
+        intro t y (hy : u y = ∞)
+        rw [Set.mem_ofPred_eq, hy]
+        exact ENNReal.ofReal_lt_top
+      refine top_le_iff.1 ?_
+      calc (∞ : ℝ≥0∞)
+          = ν {y | u y = ∞} * ∫⁻ t in Ioi (0 : ℝ), ENNReal.ofReal (t ^ (p - 1)) := by
+            rw [lintegral_ofReal_rpow_Ioi hs, ENNReal.mul_top hnull]
+        _ = ∫⁻ t in Ioi (0 : ℝ), ν {y | u y = ∞} * ENNReal.ofReal (t ^ (p - 1)) :=
+            (lintegral_const_mul _ ((measurable_id.pow measurable_const).ennreal_ofReal)).symm
+        _ ≤ _ := lintegral_mono fun t => mul_le_mul_left (measure_mono hsub) _
+    rw [hL, hR, ENNReal.mul_top (ENNReal.ofReal_pos.2 hp).ne']
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -43,9 +43,10 @@ The layer cake formula (`TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`
 sides into integrals in the height variable `t`. The hypothesis, multiplied by `t ^ (p - 2)`,
 bounds the integrand by `A * t ^ (p - 2) * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`; Tonelli's theorem then
 exchanges the `t` and `x` integrations, and for each fixed `x` the inner integral is the
-elementary `∫⁻ t in (0, ‖f x‖ / c), t ^ (p - 2) = (‖f x‖ / c) ^ (p - 1) / (p - 1)`, which
-reassembles into `c ^ (1 - p) / (p - 1) * ‖f x‖ ^ p`. Convergence of that inner integral at the
-origin is where `1 < p` is used, and it is why the constant carries the factor `1 / (p - 1)`.
+elementary `∫⁻ t in (0, ‖f x‖ / c), t ^ (p - 2) = (‖f x‖ / c) ^ (p - 1) / (p - 1)`, evaluated by
+`TauCeti.lintegral_indicator_ofReal_rpow_Ioi`, which reassembles into
+`c ^ (1 - p) / (p - 1) * ‖f x‖ ^ p`. Convergence of that inner integral at the origin is where
+`1 < p` is used, and it is why the constant carries the factor `1 / (p - 1)`.
 
 Tonelli's theorem needs `μ` to be s-finite, but the statement does not: both sides ignore the
 part of `μ` outside `{f > 0}`, and once `∫⁻ f ^ p ∂μ` is finite that part is σ-finite, being
@@ -92,7 +93,8 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFin
     (measurable_id.pow measurable_const).ennreal_ofReal
   set G : ℝ × α → ℝ≥0∞ := S.indicator fun q => ENNReal.ofReal (q.1 ^ (p - 2)) * f q.2 with hG
   have hGmeas : Measurable G := (hfstpow.mul (hf.comp measurable_snd)).indicator hSmeas
-  -- `G` is the weight `t ^ (p - 2)` times the truncation of `f` at the height `c * t`.
+  -- `G` is the weight `t ^ (p - 2)` times the truncation of `f` at the height `c * t`; the same
+  -- cut-off can be read as a condition on `x` for a fixed `t`, or as one on `t` for a fixed `x`.
   have hGval : ∀ (t : ℝ) (x : α), G (t, x) =
       ENNReal.ofReal (t ^ (p - 2)) * {x | ENNReal.ofReal (c * t) < f x}.indicator f x := by
     intro t x
@@ -101,6 +103,15 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFin
     by_cases hx : x ∈ {x | ENNReal.ofReal (c * t) < f x}
     · rw [hG, Set.indicator_of_mem (hmem.2 hx), Set.indicator_of_mem hx]
     · rw [hG, Set.indicator_of_notMem (hmem.not.2 hx), Set.indicator_of_notMem hx, mul_zero]
+  have hGvalt : ∀ (t : ℝ) (x : α), G (t, x) =
+      {t : ℝ | ENNReal.ofReal (c * t) < f x}.indicator
+        (fun t => ENNReal.ofReal (t ^ (p - 2))) t * f x := by
+    intro t x
+    have hmem : (t, x) ∈ S ↔ t ∈ {t : ℝ | ENNReal.ofReal (c * t) < f x} := by
+      simp only [hS, Set.mem_ofPred]
+    by_cases ht : t ∈ {t : ℝ | ENNReal.ofReal (c * t) < f x}
+    · rw [hG, Set.indicator_of_mem (hmem.2 ht), Set.indicator_of_mem ht]
+    · rw [hG, Set.indicator_of_notMem (hmem.not.2 ht), Set.indicator_of_notMem ht, zero_mul]
   -- Its slices are the truncated integrals appearing in the hypothesis.
   have hslice : ∀ t : ℝ, ∫⁻ x, G (t, x) ∂μ =
       ENNReal.ofReal (t ^ (p - 2)) * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
@@ -123,66 +134,20 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFin
       _ ≤ (A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) *
             ENNReal.ofReal (t ^ (p - 2)) := mul_le_mul_left (h t ht') _
       _ = A * ∫⁻ x, G (t, x) ∂μ := by rw [hslice t]; ring
-  -- For each `x`, the inner integral in `t` is elementary.
-  have hinner : ∀ x, (∫⁻ t in Ioi (0 : ℝ), G (t, x)) ≤
+  -- For each `x`, the inner integral in `t` is the truncated power integral.
+  have hinner : ∀ x, (∫⁻ t in Ioi (0 : ℝ), G (t, x)) =
       ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * f x ^ p := by
     intro x
-    have hconst : (0 : ℝ) < c ^ (1 - p) / (p - 1) := by positivity
-    rcases eq_or_ne (f x) ∞ with hx | hx
-    · rw [hx, ENNReal.top_rpow_of_pos hp0, ENNReal.mul_top (ENNReal.ofReal_pos.2 hconst).ne']
-      exact le_top
-    rcases eq_or_ne (f x) 0 with hx0 | hx0
-    · have hzero : ∀ t : ℝ, G (t, x) = 0 := fun t => by
-        have hnot : x ∉ {x | ENNReal.ofReal (c * t) < f x} := by simp [hx0]
-        rw [hGval t x, Set.indicator_of_notMem hnot, mul_zero]
-      simp [hzero]
-    set b : ℝ := (f x).toReal with hbdef
-    have hb0 : 0 < b := ENNReal.toReal_pos hx0 hx
-    have hfx : f x = ENNReal.ofReal b := (ENNReal.ofReal_toReal hx).symm
-    -- On `(0, ∞)` the integrand is the truncation of `t ^ (p - 2) * f x` to `(0, b / c)`.
-    have heq : ∀ t ∈ Ioi (0 : ℝ),
-        G (t, x) = (Ioo (0 : ℝ) (b / c)).indicator
-          (fun s => ENNReal.ofReal (s ^ (p - 2)) * f x) t := by
-      intro t ht
-      have ht' : (0 : ℝ) < t := ht
-      have hiff : ENNReal.ofReal (c * t) < f x ↔ t < b / c := by
-        rw [hfx, ENNReal.ofReal_lt_ofReal_iff hb0, lt_div_iff₀ hc, mul_comm]
-      rcases lt_or_ge t (b / c) with hmem | hmem
-      · have hxmem : x ∈ {x | ENNReal.ofReal (c * t) < f x} := Set.mem_ofPred.2 (hiff.2 hmem)
-        have htmem : t ∈ Ioo (0 : ℝ) (b / c) := Set.mem_Ioo.2 ⟨ht', hmem⟩
-        rw [hGval t x, Set.indicator_of_mem hxmem, Set.indicator_of_mem htmem]
-      · have hxmem : x ∉ {x | ENNReal.ofReal (c * t) < f x} := fun hcon =>
-          absurd (hiff.1 (Set.mem_ofPred.1 hcon)) (not_lt.2 hmem)
-        have htmem : t ∉ Ioo (0 : ℝ) (b / c) := fun hcon =>
-          absurd (Set.mem_Ioo.1 hcon).2 (not_lt.2 hmem)
-        rw [hGval t x, Set.indicator_of_notMem hxmem, Set.indicator_of_notMem htmem, mul_zero]
-    have hInt : ∫⁻ t in Ioo (0 : ℝ) (b / c), ENNReal.ofReal (t ^ (p - 2)) =
-        ENNReal.ofReal ((b / c) ^ (p - 1) / (p - 1)) := by
-      have hexp : p - 2 + 1 = p - 1 := by ring
-      have h := lintegral_ofReal_rpow_Ioo (s := p - 2) (by linarith)
-        (a := b / c) (by positivity)
-      rwa [hexp] at h
-    -- The elementary real identity behind the constant `c ^ (1 - p) / (p - 1)`.
-    have hreal : (b / c) ^ (p - 1) / (p - 1) * b = c ^ (1 - p) / (p - 1) * b ^ p := by
-      have hcp : c ^ (p - 1) ≠ 0 := (Real.rpow_pos_of_pos hc _).ne'
-      have hsucc : p = p - 1 + 1 := by ring
-      have hneg : (1 : ℝ) - p = -(p - 1) := by ring
-      have hbp : b ^ p = b ^ (p - 1) * b := by
-        conv_lhs => rw [hsucc]
-        rw [Real.rpow_add hb0, Real.rpow_one]
-      rw [Real.div_rpow hb0.le hc.le, hneg, Real.rpow_neg hc.le, hbp]
-      field_simp
-    refine le_of_eq ?_
-    calc (∫⁻ t in Ioi (0 : ℝ), G (t, x))
-        = ∫⁻ t in Ioo (0 : ℝ) (b / c), ENNReal.ofReal (t ^ (p - 2)) * f x := by
-          rw [setLIntegral_congr_fun measurableSet_Ioi heq, lintegral_indicator measurableSet_Ioo,
-            Measure.restrict_restrict measurableSet_Ioo,
-            Set.inter_eq_self_of_subset_left Ioo_subset_Ioi_self]
-      _ = ENNReal.ofReal ((b / c) ^ (p - 1) / (p - 1)) * f x := by
-          rw [lintegral_mul_const _ hrpow, hInt]
-      _ = ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * f x ^ p := by
-          rw [hfx, ← ENNReal.ofReal_mul (by positivity),
-            ENNReal.ofReal_rpow_of_nonneg hb0.le hp0.le, ← ENNReal.ofReal_mul hconst.le, hreal]
+    have hcut : MeasurableSet {t : ℝ | ENNReal.ofReal (c * t) < f x} :=
+      measurableSet_lt ((measurable_id.const_mul c).ennreal_ofReal) measurable_const
+    have hexp : p - 2 + 1 = p - 1 := by ring
+    have hneg : (1 : ℝ) - p = -(p - 1) := by ring
+    -- `f x ^ (p - 1) * f x = f x ^ p`, valid also at the values `0` and `∞`.
+    have hsucc : f x ^ (p - 1) * f x = f x ^ p := by
+      conv_rhs => rw [show p = p - 1 + 1 by ring]
+      rw [ENNReal.rpow_add_of_nonneg _ _ hp1.le zero_le_one, ENNReal.rpow_one]
+    rw [lintegral_congr fun t => hGvalt t x, lintegral_mul_const _ (hrpow.indicator hcut),
+      lintegral_indicator_ofReal_rpow_Ioi (by linarith) hc (f x), hexp, hneg, mul_assoc, hsucc]
   -- Assemble: layer cake, the pointwise bound, Tonelli, and the inner integral.
   rw [lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul ν hu hp0]
   calc ENNReal.ofReal p *
@@ -196,18 +161,50 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFin
     _ ≤ ENNReal.ofReal p * (A * (ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * ∫⁻ x, f x ^ p ∂μ)) := by
         gcongr
         rw [← lintegral_const_mul _ (hf.pow_const p)]
-        exact lintegral_mono hinner
+        exact lintegral_mono fun x => (hinner x).le
     _ = ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
         have hconst : p * c ^ (1 - p) / (p - 1) = p * (c ^ (1 - p) / (p - 1)) := by ring
         rw [hconst, ENNReal.ofReal_mul hp0.le]
         ring
 
+/-- A function with a finite `L^p` norm is carried by a σ-finite part of the measure: the level
+sets `{f ≥ 1 / (n + 1)}` have finite measure by Chebyshev's inequality applied to `f ^ p`, and they
+exhaust `{f > 0}`. -/
+private theorem sigmaFinite_restrict_pos_of_lintegral_rpow_ne_top (hf : Measurable f)
+    (hp : 0 < p) (htop : ∫⁻ x, f x ^ p ∂μ ≠ ∞) : SigmaFinite (μ.restrict {x | 0 < f x}) := by
+  have hsmeas : MeasurableSet {x | 0 < f x} := measurableSet_lt measurable_const hf
+  have hlevel : ∀ n : ℕ, μ {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ≠ ∞ := by
+    intro n
+    have hne : ((n : ℝ≥0∞) + 1)⁻¹ ≠ ∞ := ENNReal.inv_ne_top.2 (by simp)
+    have hpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ :=
+      ENNReal.inv_pos.2 (by simp [ENNReal.natCast_ne_top])
+    have hεpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ ^ p := ENNReal.rpow_pos hpos hne
+    have hset : {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} = {x | ((n : ℝ≥0∞) + 1)⁻¹ ^ p ≤ f x ^ p} :=
+      Set.ext fun x => (ENNReal.rpow_le_rpow_iff hp).symm
+    rw [hset]
+    refine ne_top_of_le_ne_top (ENNReal.div_lt_top htop hεpos.ne').ne
+      (meas_ge_le_lintegral_div (hf.pow_const p).aemeasurable hεpos.ne'
+        (ENNReal.rpow_ne_top_of_nonneg hp.le hne))
+  refine ⟨⟨⟨fun n => {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ∪ {x | 0 < f x}ᶜ, fun _ => trivial, ?_, ?_⟩⟩⟩
+  · intro n
+    have hcompl : μ.restrict {x | 0 < f x} {x | 0 < f x}ᶜ = 0 := by
+      rw [Measure.restrict_apply hsmeas.compl, Set.compl_inter_self, measure_empty]
+    refine lt_of_le_of_lt (measure_union_le _ _) ?_
+    rw [hcompl, add_zero]
+    exact lt_of_le_of_lt (Measure.restrict_apply_le _ _) (lt_top_iff_ne_top.2 (hlevel n))
+  · refine Set.eq_univ_of_forall fun x => ?_
+    rcases eq_or_ne (f x) 0 with hx | hx
+    · exact Set.mem_iUnion.2 ⟨0, Set.mem_union_right _ (by simp [hx])⟩
+    · obtain ⟨n, hn⟩ := ENNReal.exists_inv_nat_lt hx
+      exact Set.mem_iUnion.2
+        ⟨n, Set.mem_union_left _ ((ENNReal.inv_le_inv' le_self_add).trans hn.le)⟩
+
 /-- The interpolation estimate for a measurable `f` and an arbitrary measure `μ`.
 
 Only the part of `μ` carried by `{f > 0}` enters either side, and once `f` has finite `L^p` norm
-that part is σ-finite, because the level sets `{f ≥ 1 / (n + 1)}` have finite measure and exhaust
-`{f > 0}`. So the s-finite case applies to `μ` restricted to `{f > 0}`, after the two degenerate
-cases — a vanishing weak-type constant and an infinite right-hand side — are disposed of. -/
+that part is σ-finite by `TauCeti.sigmaFinite_restrict_pos_of_lintegral_rpow_ne_top`. So the
+s-finite case applies to `μ` restricted to `{f > 0}`, after the two degenerate cases — a vanishing
+weak-type constant and an infinite right-hand side — are disposed of. -/
 private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable
     (hf : Measurable f) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
     (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
@@ -227,46 +224,19 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable
   · -- The right-hand side is infinite.
     rw [htop, ENNReal.mul_top (mul_ne_zero (ENNReal.ofReal_pos.2 hK).ne' hA)]
     exact le_top
-  have hsmeas : MeasurableSet {x | 0 < f x} := measurableSet_lt measurable_const hf
-  -- Chebyshev's inequality for `f ^ p` bounds the measure of each level set of `f`.
-  have hlevel : ∀ n : ℕ, μ {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ≠ ∞ := by
-    intro n
-    have hne : ((n : ℝ≥0∞) + 1)⁻¹ ≠ ∞ := ENNReal.inv_ne_top.2 (by simp)
-    have hpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ :=
-      ENNReal.inv_pos.2 (by simp [ENNReal.natCast_ne_top])
-    have hεpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ ^ p := ENNReal.rpow_pos hpos hne
-    have hset : {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} = {x | ((n : ℝ≥0∞) + 1)⁻¹ ^ p ≤ f x ^ p} :=
-      Set.ext fun x => (ENNReal.rpow_le_rpow_iff hp0).symm
-    rw [hset]
-    refine ne_top_of_le_ne_top (ENNReal.div_lt_top htop hεpos.ne').ne
-      (meas_ge_le_lintegral_div (hf.pow_const p).aemeasurable hεpos.ne'
-        (ENNReal.rpow_ne_top_of_nonneg hp0.le hne))
-  -- Hence `μ` restricted to `{f > 0}` is σ-finite, so in particular s-finite.
-  have hσ : SigmaFinite (μ.restrict {x | 0 < f x}) := by
-    refine ⟨⟨⟨fun n => {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ∪ {x | 0 < f x}ᶜ, fun _ => trivial, ?_, ?_⟩⟩⟩
-    · intro n
-      have hcompl : μ.restrict {x | 0 < f x} {x | 0 < f x}ᶜ = 0 := by
-        rw [Measure.restrict_apply hsmeas.compl, Set.compl_inter_self, measure_empty]
-      refine lt_of_le_of_lt (measure_union_le _ _) ?_
-      rw [hcompl, add_zero]
-      exact lt_of_le_of_lt (Measure.restrict_apply_le _ _) (lt_top_iff_ne_top.2 (hlevel n))
-    · refine Set.eq_univ_of_forall fun x => ?_
-      rcases eq_or_ne (f x) 0 with hx | hx
-      · exact Set.mem_iUnion.2 ⟨0, Set.mem_union_right _ (by simp [hx])⟩
-      · obtain ⟨n, hn⟩ := ENNReal.exists_inv_nat_lt hx
-        exact Set.mem_iUnion.2
-          ⟨n, Set.mem_union_left _ ((ENNReal.inv_le_inv' le_self_add).trans hn.le)⟩
+  -- `μ` restricted to `{f > 0}` is σ-finite, so in particular s-finite.
+  have hσ : SigmaFinite (μ.restrict {x | 0 < f x}) :=
+    sigmaFinite_restrict_pos_of_lintegral_rpow_ne_top hf hp0 htop
   -- The truncated integrals of the hypothesis do not see the complement of `{f > 0}`.
   have hsub : ∀ t : ℝ, 0 < t → {x | ENNReal.ofReal (c * t) < f x} ⊆ {x | 0 < f x} := by
     intro t _ x hx
     exact Set.mem_ofPred.2 (lt_of_le_of_lt zero_le (Set.mem_ofPred.1 hx))
-  -- Neither does `∫⁻ f ^ p`, since `f` vanishes there.
+  -- Neither does `∫⁻ f ^ p`, since `f ^ p` is supported in `{f > 0}`.
   have hpow : ∫⁻ x, f x ^ p ∂μ.restrict {x | 0 < f x} = ∫⁻ x, f x ^ p ∂μ := by
-    have hcompl : ∫⁻ x in {x | 0 < f x}ᶜ, f x ^ p ∂μ = 0 := by
-      rw [setLIntegral_congr_fun hsmeas.compl fun x hx => ?_, lintegral_zero]
-      have hx0 : f x = 0 := by simpa using hx
-      rw [hx0, ENNReal.zero_rpow_of_pos hp0]
-    rw [← lintegral_add_compl (μ := μ) (fun x => f x ^ p) hsmeas, hcompl, add_zero]
+    refine setLIntegral_eq_of_support_subset fun x hx => ?_
+    have hx' : f x ^ p ≠ 0 := hx
+    refine Set.mem_ofPred.2 (pos_iff_ne_zero.2 fun h0 => hx' ?_)
+    rw [h0, ENNReal.zero_rpow_of_pos hp0]
   have hmain := lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFinite
     (μ := μ.restrict {x | 0 < f x}) hf hu hp hc fun t ht => by
       rw [Measure.restrict_restrict_of_subset (hsub t ht)]

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -92,11 +92,11 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
   have hGval : ∀ (t : ℝ) (x : α), G (t, x) =
       ENNReal.ofReal (t ^ (p - 2)) * {x | ENNReal.ofReal (c * t) < f x}.indicator f x := by
     intro t x
-    by_cases hx : ENNReal.ofReal (c * t) < f x
-    · rw [hG, Set.indicator_of_mem (show (t, x) ∈ S from hx),
-        Set.indicator_of_mem (show x ∈ {x | ENNReal.ofReal (c * t) < f x} from hx)]
-    · rw [hG, Set.indicator_of_notMem (show (t, x) ∉ S from hx),
-        Set.indicator_of_notMem (show x ∉ {x | ENNReal.ofReal (c * t) < f x} from hx), mul_zero]
+    have hmem : (t, x) ∈ S ↔ x ∈ {x | ENNReal.ofReal (c * t) < f x} := by
+      simp only [hS, Set.mem_ofPred]
+    by_cases hx : x ∈ {x | ENNReal.ofReal (c * t) < f x}
+    · rw [hG, Set.indicator_of_mem (hmem.2 hx), Set.indicator_of_mem hx]
+    · rw [hG, Set.indicator_of_notMem (hmem.not.2 hx), Set.indicator_of_notMem hx, mul_zero]
   -- Its slices are the truncated integrals appearing in the hypothesis.
   have hslice : ∀ t : ℝ, ∫⁻ x, G (t, x) ∂μ =
       ENNReal.ofReal (t ^ (p - 2)) * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
@@ -110,8 +110,9 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
       A * ∫⁻ x, G (t, x) ∂μ := by
     intro t ht
     have ht' : (0 : ℝ) < t := ht
+    have hexp : p - 1 = 1 + (p - 2) := by ring
     have hpow : t ^ (p - 1) = t * t ^ (p - 2) := by
-      rw [show p - 1 = 1 + (p - 2) by ring, Real.rpow_add ht', Real.rpow_one]
+      rw [hexp, Real.rpow_add ht', Real.rpow_one]
     calc ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1))
         = ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 2)) := by
           rw [hpow, ENNReal.ofReal_mul ht'.le]; ring
@@ -128,8 +129,8 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
       exact le_top
     rcases eq_or_ne (f x) 0 with hx0 | hx0
     · have hzero : ∀ t : ℝ, G (t, x) = 0 := fun t => by
-        rw [hGval t x, Set.indicator_of_notMem
-          (show x ∉ {x | ENNReal.ofReal (c * t) < f x} by simp [hx0]), mul_zero]
+        have hnot : x ∉ {x | ENNReal.ofReal (c * t) < f x} := by simp [hx0]
+        rw [hGval t x, Set.indicator_of_notMem hnot, mul_zero]
       simp [hzero]
     set b : ℝ := (f x).toReal with hbdef
     have hb0 : 0 < b := ENNReal.toReal_pos hx0 hx
@@ -143,28 +144,29 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
       have hiff : ENNReal.ofReal (c * t) < f x ↔ t < b / c := by
         rw [hfx, ENNReal.ofReal_lt_ofReal_iff hb0, lt_div_iff₀ hc, mul_comm]
       rcases lt_or_ge t (b / c) with hmem | hmem
-      · rw [hGval t x, Set.indicator_of_mem
-          (show x ∈ {x | ENNReal.ofReal (c * t) < f x} from hiff.2 hmem),
-          Set.indicator_of_mem (show t ∈ Ioo (0 : ℝ) (b / c) from ⟨ht', hmem⟩)]
-      · rw [hGval t x, Set.indicator_of_notMem
-          (show x ∉ {x | ENNReal.ofReal (c * t) < f x} from fun hcon =>
-            absurd (hiff.1 hcon) (not_lt.2 hmem)),
-          Set.indicator_of_notMem
-            (show t ∉ Ioo (0 : ℝ) (b / c) from fun hcon => absurd hcon.2 (not_lt.2 hmem)),
-          mul_zero]
+      · have hxmem : x ∈ {x | ENNReal.ofReal (c * t) < f x} := Set.mem_ofPred.2 (hiff.2 hmem)
+        have htmem : t ∈ Ioo (0 : ℝ) (b / c) := Set.mem_Ioo.2 ⟨ht', hmem⟩
+        rw [hGval t x, Set.indicator_of_mem hxmem, Set.indicator_of_mem htmem]
+      · have hxmem : x ∉ {x | ENNReal.ofReal (c * t) < f x} := fun hcon =>
+          absurd (hiff.1 (Set.mem_ofPred.1 hcon)) (not_lt.2 hmem)
+        have htmem : t ∉ Ioo (0 : ℝ) (b / c) := fun hcon =>
+          absurd (Set.mem_Ioo.1 hcon).2 (not_lt.2 hmem)
+        rw [hGval t x, Set.indicator_of_notMem hxmem, Set.indicator_of_notMem htmem, mul_zero]
     have hInt : ∫⁻ t in Ioo (0 : ℝ) (b / c), ENNReal.ofReal (t ^ (p - 2)) =
         ENNReal.ofReal ((b / c) ^ (p - 1) / (p - 1)) := by
+      have hexp : p - 2 + 1 = p - 1 := by ring
       have h := lintegral_ofReal_rpow_Ioo (s := p - 2) (by linarith)
         (a := b / c) (by positivity)
-      rwa [show p - 2 + 1 = p - 1 by ring] at h
+      rwa [hexp] at h
     -- The elementary real identity behind the constant `c ^ (1 - p) / (p - 1)`.
     have hreal : (b / c) ^ (p - 1) / (p - 1) * b = c ^ (1 - p) / (p - 1) * b ^ p := by
       have hcp : c ^ (p - 1) ≠ 0 := (Real.rpow_pos_of_pos hc _).ne'
+      have hsucc : p = p - 1 + 1 := by ring
+      have hneg : (1 : ℝ) - p = -(p - 1) := by ring
       have hbp : b ^ p = b ^ (p - 1) * b := by
-        conv_lhs => rw [show p = p - 1 + 1 by ring]
+        conv_lhs => rw [hsucc]
         rw [Real.rpow_add hb0, Real.rpow_one]
-      rw [Real.div_rpow hb0.le hc.le, show (1 : ℝ) - p = -(p - 1) by ring,
-        Real.rpow_neg hc.le, hbp]
+      rw [Real.div_rpow hb0.le hc.le, hneg, Real.rpow_neg hc.le, hbp]
       field_simp
     refine le_of_eq ?_
     calc (∫⁻ t in Ioi (0 : ℝ), G (t, x))
@@ -192,8 +194,8 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
         rw [← lintegral_const_mul _ (hf.pow_const p)]
         exact lintegral_mono hinner
     _ = ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
-        rw [show p * c ^ (1 - p) / (p - 1) = p * (c ^ (1 - p) / (p - 1)) by ring,
-          ENNReal.ofReal_mul hp0.le]
+        have hconst : p * c ^ (1 - p) / (p - 1) = p * (c ^ (1 - p) / (p - 1)) := by ring
+        rw [hconst, ENNReal.ofReal_mul hp0.le]
         ring
 
 /-- **Marcinkiewicz interpolation**, the diagonal case `p₀ = 1`, `p₁ = ∞`, in distributional form.
@@ -224,8 +226,9 @@ theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le [SFinite μ]
       exact congrArg (fun z : ℝ≥0∞ => a < z) hx
     rw [Measure.restrict_congr_set hsets]
     exact lintegral_congr_ae (ae_restrict_of_ae hae)
-  rw [lintegral_congr_ae (show (fun x => f x ^ p) =ᵐ[μ] fun x => hf.mk f x ^ p from
-    hae.mono fun x hx => congrArg (fun z : ℝ≥0∞ => z ^ p) hx)]
+  have hrpow : (fun x => f x ^ p) =ᵐ[μ] fun x => hf.mk f x ^ p :=
+    hae.mono fun x hx => congrArg (fun z : ℝ≥0∞ => z ^ p) hx
+  rw [lintegral_congr_ae hrpow]
   refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable hf.measurable_mk hu hp hc
     fun t ht => ?_
   rw [← hset]

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -144,7 +144,7 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFin
     have hneg : (1 : ℝ) - p = -(p - 1) := by ring
     -- `f x ^ (p - 1) * f x = f x ^ p`, valid also at the values `0` and `∞`.
     have hsucc : f x ^ (p - 1) * f x = f x ^ p := by
-      conv_rhs => rw [show p = p - 1 + 1 by ring]
+      conv_rhs => rw [← sub_add_cancel p 1]
       rw [ENNReal.rpow_add_of_nonneg _ _ hp1.le zero_le_one, ENNReal.rpow_one]
     rw [lintegral_congr fun t => hGvalt t x, lintegral_mul_const _ (hrpow.indicator hcut),
       lintegral_indicator_ofReal_rpow_Ioi (by linarith) hc (f x), hexp, hneg, mul_assoc, hsucc]

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -1,0 +1,234 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.SpecialFunctions.Pow.Integral
+-- `Mathlib.MeasureTheory.Measure.Prod` is imported privately: the product measure and
+-- Tonelli's theorem appear only inside the proof below.
+import Mathlib.MeasureTheory.Measure.Prod
+
+/-!
+# Marcinkiewicz interpolation between weak type `(1,1)` and `L^∞`
+
+An operator `T` that is simultaneously of **weak type `(1,1)`** and bounded on `L^∞` is bounded on
+`L^p` for every `1 < p < ∞`. This is the diagonal case `p₀ = 1`, `p₁ = ∞` of the Marcinkiewicz
+interpolation theorem, and it is the mechanism that turns the Hardy–Littlewood maximal inequality
+into the strong `(p,p)` bounds, item 9 of Lane B of the PDE roadmap.
+
+## The statement proved here
+
+Interpolation arguments run entirely on the **distribution functions** of `T f` and of `f`, so the
+theorem is stated in that form rather than in terms of a bundled operator: the sublinearity of `T`
+and its two endpoint bounds are used only to produce, for each height `t`, the single inequality
+
+`t * ν {T f > t} ≤ A * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`,
+
+which says that only the part of `f` above the height `c * t` can push `T f` above `t`. That
+inequality is the hypothesis of `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, and its
+conclusion is the `L^p` bound
+
+`∫⁻ (T f) ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ ‖f‖ ^ p ∂μ`.
+
+Keeping the hypothesis in this form has three advantages. It does not force `T` to be defined on
+all of a function space; it lets `μ` and `ν` live on different spaces, as a genuine interpolation
+statement should; and it makes the dependence of the constant on `p`, on the weak-type constant
+`A` and on the truncation ratio `c` completely explicit, which matters because the constant blows
+up as `p → 1`, exactly as it must — an operator of weak type `(1,1)` need not be bounded on `L¹`.
+
+## The proof
+
+The layer cake formula (`TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`) converts both
+sides into integrals in the height variable `t`. The hypothesis, multiplied by `t ^ (p - 2)`,
+bounds the integrand by `A * t ^ (p - 2) * ∫⁻ x in {‖f‖ > c * t}, ‖f‖ ∂μ`; Tonelli's theorem then
+exchanges the `t` and `x` integrations, and for each fixed `x` the inner integral is the
+elementary `∫⁻ t in (0, ‖f x‖ / c), t ^ (p - 2) = (‖f x‖ / c) ^ (p - 1) / (p - 1)`, which
+reassembles into `c ^ (1 - p) / (p - 1) * ‖f x‖ ^ p`. Convergence of that inner integral at the
+origin is where `1 < p` is used, and it is why the constant carries the factor `1 / (p - 1)`.
+
+## Main declarations
+
+* `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`: the interpolation estimate.
+
+## References
+
+* L. Grafakos, *Classical Fourier Analysis*, Theorem 1.3.1.
+* E. Stein, *Singular Integrals and Differentiability Properties of Functions*, Chapter I, §4.
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Set
+open scoped ENNReal
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α} {ν : Measure β}
+  {f : α → ℝ≥0∞} {u : β → ℝ≥0∞} {p c : ℝ} {A : ℝ≥0∞}
+
+/-- The interpolation estimate for a measurable `f`; the general case is reduced to this one by
+replacing `f` with a measurable representative. -/
+private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinite μ]
+    (hf : Measurable f) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
+    (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
+      A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) :
+    ∫⁻ y, u y ^ p ∂ν ≤
+      ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hp1 : (0 : ℝ) < p - 1 := by linarith
+  -- The jointly measurable integrand of the double integral: the part of `f` above the height
+  -- `c * t`, weighted by `t ^ (p - 2)`.
+  set S : Set (ℝ × α) := {q | ENNReal.ofReal (c * q.1) < f q.2} with hS
+  have hSmeas : MeasurableSet S :=
+    measurableSet_lt ((measurable_fst.const_mul c).ennreal_ofReal) (hf.comp measurable_snd)
+  have hfstpow : Measurable fun q : ℝ × α => ENNReal.ofReal (q.1 ^ (p - 2)) :=
+    (measurable_fst.pow measurable_const).ennreal_ofReal
+  have hrpow : Measurable fun t : ℝ => ENNReal.ofReal (t ^ (p - 2)) :=
+    (measurable_id.pow measurable_const).ennreal_ofReal
+  set G : ℝ × α → ℝ≥0∞ := S.indicator fun q => ENNReal.ofReal (q.1 ^ (p - 2)) * f q.2 with hG
+  have hGmeas : Measurable G := (hfstpow.mul (hf.comp measurable_snd)).indicator hSmeas
+  -- `G` is the weight `t ^ (p - 2)` times the truncation of `f` at the height `c * t`.
+  have hGval : ∀ (t : ℝ) (x : α), G (t, x) =
+      ENNReal.ofReal (t ^ (p - 2)) * {x | ENNReal.ofReal (c * t) < f x}.indicator f x := by
+    intro t x
+    by_cases hx : ENNReal.ofReal (c * t) < f x
+    · rw [hG, Set.indicator_of_mem (show (t, x) ∈ S from hx),
+        Set.indicator_of_mem (show x ∈ {x | ENNReal.ofReal (c * t) < f x} from hx)]
+    · rw [hG, Set.indicator_of_notMem (show (t, x) ∉ S from hx),
+        Set.indicator_of_notMem (show x ∉ {x | ENNReal.ofReal (c * t) < f x} from hx), mul_zero]
+  -- Its slices are the truncated integrals appearing in the hypothesis.
+  have hslice : ∀ t : ℝ, ∫⁻ x, G (t, x) ∂μ =
+      ENNReal.ofReal (t ^ (p - 2)) * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ := by
+    intro t
+    have hSt : MeasurableSet {x | ENNReal.ofReal (c * t) < f x} :=
+      measurableSet_lt measurable_const hf
+    rw [← lintegral_indicator hSt, ← lintegral_const_mul _ (hf.indicator hSt)]
+    exact lintegral_congr fun x => hGval t x
+  -- Multiplying the hypothesis by `t ^ (p - 2)` bounds the layer cake integrand.
+  have hkey : ∀ t ∈ Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1)) ≤
+      A * ∫⁻ x, G (t, x) ∂μ := by
+    intro t ht
+    have ht' : (0 : ℝ) < t := ht
+    have hpow : t ^ (p - 1) = t * t ^ (p - 2) := by
+      rw [show p - 1 = 1 + (p - 2) by ring, Real.rpow_add ht', Real.rpow_one]
+    calc ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1))
+        = ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 2)) := by
+          rw [hpow, ENNReal.ofReal_mul ht'.le]; ring
+      _ ≤ (A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) *
+            ENNReal.ofReal (t ^ (p - 2)) := mul_le_mul_left (h t ht') _
+      _ = A * ∫⁻ x, G (t, x) ∂μ := by rw [hslice t]; ring
+  -- For each `x`, the inner integral in `t` is elementary.
+  have hinner : ∀ x, (∫⁻ t in Ioi (0 : ℝ), G (t, x)) ≤
+      ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * f x ^ p := by
+    intro x
+    have hconst : (0 : ℝ) < c ^ (1 - p) / (p - 1) := by positivity
+    rcases eq_or_ne (f x) ∞ with hx | hx
+    · rw [hx, ENNReal.top_rpow_of_pos hp0, ENNReal.mul_top (ENNReal.ofReal_pos.2 hconst).ne']
+      exact le_top
+    rcases eq_or_ne (f x) 0 with hx0 | hx0
+    · have hzero : ∀ t : ℝ, G (t, x) = 0 := fun t => by
+        rw [hGval t x, Set.indicator_of_notMem
+          (show x ∉ {x | ENNReal.ofReal (c * t) < f x} by simp [hx0]), mul_zero]
+      simp [hzero]
+    set b : ℝ := (f x).toReal with hbdef
+    have hb0 : 0 < b := ENNReal.toReal_pos hx0 hx
+    have hfx : f x = ENNReal.ofReal b := (ENNReal.ofReal_toReal hx).symm
+    -- On `(0, ∞)` the integrand is the truncation of `t ^ (p - 2) * f x` to `(0, b / c)`.
+    have heq : ∀ t ∈ Ioi (0 : ℝ),
+        G (t, x) = (Ioo (0 : ℝ) (b / c)).indicator
+          (fun s => ENNReal.ofReal (s ^ (p - 2)) * f x) t := by
+      intro t ht
+      have ht' : (0 : ℝ) < t := ht
+      have hiff : ENNReal.ofReal (c * t) < f x ↔ t < b / c := by
+        rw [hfx, ENNReal.ofReal_lt_ofReal_iff hb0, lt_div_iff₀ hc, mul_comm]
+      rcases lt_or_ge t (b / c) with hmem | hmem
+      · rw [hGval t x, Set.indicator_of_mem
+          (show x ∈ {x | ENNReal.ofReal (c * t) < f x} from hiff.2 hmem),
+          Set.indicator_of_mem (show t ∈ Ioo (0 : ℝ) (b / c) from ⟨ht', hmem⟩)]
+      · rw [hGval t x, Set.indicator_of_notMem
+          (show x ∉ {x | ENNReal.ofReal (c * t) < f x} from fun hcon =>
+            absurd (hiff.1 hcon) (not_lt.2 hmem)),
+          Set.indicator_of_notMem
+            (show t ∉ Ioo (0 : ℝ) (b / c) from fun hcon => absurd hcon.2 (not_lt.2 hmem)),
+          mul_zero]
+    have hInt : ∫⁻ t in Ioo (0 : ℝ) (b / c), ENNReal.ofReal (t ^ (p - 2)) =
+        ENNReal.ofReal ((b / c) ^ (p - 1) / (p - 1)) := by
+      have h := lintegral_ofReal_rpow_Ioo (s := p - 2) (by linarith)
+        (a := b / c) (by positivity)
+      rwa [show p - 2 + 1 = p - 1 by ring] at h
+    -- The elementary real identity behind the constant `c ^ (1 - p) / (p - 1)`.
+    have hreal : (b / c) ^ (p - 1) / (p - 1) * b = c ^ (1 - p) / (p - 1) * b ^ p := by
+      have hcp : c ^ (p - 1) ≠ 0 := (Real.rpow_pos_of_pos hc _).ne'
+      have hbp : b ^ p = b ^ (p - 1) * b := by
+        conv_lhs => rw [show p = p - 1 + 1 by ring]
+        rw [Real.rpow_add hb0, Real.rpow_one]
+      rw [Real.div_rpow hb0.le hc.le, show (1 : ℝ) - p = -(p - 1) by ring,
+        Real.rpow_neg hc.le, hbp]
+      field_simp
+    refine le_of_eq ?_
+    calc (∫⁻ t in Ioi (0 : ℝ), G (t, x))
+        = ∫⁻ t in Ioo (0 : ℝ) (b / c), ENNReal.ofReal (t ^ (p - 2)) * f x := by
+          rw [setLIntegral_congr_fun measurableSet_Ioi heq, lintegral_indicator measurableSet_Ioo,
+            Measure.restrict_restrict measurableSet_Ioo,
+            Set.inter_eq_self_of_subset_left Ioo_subset_Ioi_self]
+      _ = ENNReal.ofReal ((b / c) ^ (p - 1) / (p - 1)) * f x := by
+          rw [lintegral_mul_const _ hrpow, hInt]
+      _ = ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * f x ^ p := by
+          rw [hfx, ← ENNReal.ofReal_mul (by positivity),
+            ENNReal.ofReal_rpow_of_nonneg hb0.le hp0.le, ← ENNReal.ofReal_mul hconst.le, hreal]
+  -- Assemble: layer cake, the pointwise bound, Tonelli, and the inner integral.
+  rw [lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul ν hu hp0]
+  calc ENNReal.ofReal p *
+        ∫⁻ t in Ioi (0 : ℝ), ν {y | ENNReal.ofReal t < u y} * ENNReal.ofReal (t ^ (p - 1))
+      ≤ ENNReal.ofReal p * ∫⁻ t in Ioi (0 : ℝ), A * ∫⁻ x, G (t, x) ∂μ := by
+        refine mul_le_mul_right (lintegral_mono_ae ?_) _
+        filter_upwards [ae_restrict_mem measurableSet_Ioi] with t ht using hkey t ht
+    _ = ENNReal.ofReal p * (A * ∫⁻ x, (∫⁻ t in Ioi (0 : ℝ), G (t, x)) ∂μ) := by
+        rw [lintegral_const_mul _ hGmeas.lintegral_prod_right',
+          lintegral_lintegral_swap (f := fun t x => G (t, x)) hGmeas.aemeasurable]
+    _ ≤ ENNReal.ofReal p * (A * (ENNReal.ofReal (c ^ (1 - p) / (p - 1)) * ∫⁻ x, f x ^ p ∂μ)) := by
+        gcongr
+        rw [← lintegral_const_mul _ (hf.pow_const p)]
+        exact lintegral_mono hinner
+    _ = ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
+        rw [show p * c ^ (1 - p) / (p - 1) = p * (c ^ (1 - p) / (p - 1)) by ring,
+          ENNReal.ofReal_mul hp0.le]
+        ring
+
+/-- **Marcinkiewicz interpolation**, the diagonal case `p₀ = 1`, `p₁ = ∞`, in distributional form.
+
+If for every height `t > 0` the superlevel set `{u > t}` obeys the weak-type bound
+
+`t * ν {u > t} ≤ A * ∫⁻ x in {f > c * t}, f ∂μ`
+
+against the part of `f` above `c * t`, then for every `1 < p < ∞`
+
+`∫⁻ u ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ f ^ p ∂μ`.
+
+Applied with `u = T f` for a sublinear `T`, the hypothesis is what the weak `(1,1)` and `L^∞`
+endpoint bounds for `T` give after splitting `f` at the height `c * t`, and the conclusion is the
+strong type `(p,p)` bound. The constant degenerates as `p → 1`, as it must. -/
+theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le [SFinite μ]
+    (hf : AEMeasurable f μ) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
+    (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
+      A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) :
+    ∫⁻ y, u y ^ p ∂ν ≤
+      ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
+  have hae := hf.ae_eq_mk
+  have hset : ∀ a : ℝ≥0∞,
+      ∫⁻ x in {x | a < f x}, f x ∂μ = ∫⁻ x in {x | a < hf.mk f x}, hf.mk f x ∂μ := by
+    intro a
+    have hsets : {x | a < f x} =ᵐ[μ] {x | a < hf.mk f x} := by
+      filter_upwards [hae] with x hx
+      exact congrArg (fun z : ℝ≥0∞ => a < z) hx
+    rw [Measure.restrict_congr_set hsets]
+    exact lintegral_congr_ae (ae_restrict_of_ae hae)
+  rw [lintegral_congr_ae (show (fun x => f x ^ p) =ᵐ[μ] fun x => hf.mk f x ^ p from
+    hae.mono fun x hx => congrArg (fun z : ℝ≥0∞ => z ^ p) hx)]
+  refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable hf.measurable_mk hu hp hc
+    fun t ht => ?_
+  rw [← hset]
+  exact h t ht
+
+end TauCeti

--- a/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
+++ b/TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean
@@ -12,10 +12,10 @@ import Mathlib.MeasureTheory.Measure.Prod
 /-!
 # Marcinkiewicz interpolation between weak type `(1,1)` and `L^∞`
 
-An operator `T` that is simultaneously of **weak type `(1,1)`** and bounded on `L^∞` is bounded on
-`L^p` for every `1 < p < ∞`. This is the diagonal case `p₀ = 1`, `p₁ = ∞` of the Marcinkiewicz
-interpolation theorem, and it is the mechanism that turns the Hardy–Littlewood maximal inequality
-into the strong `(p,p)` bounds, item 9 of Lane B of the PDE roadmap.
+A **sublinear** operator `T` that is simultaneously of **weak type `(1,1)`** and bounded on `L^∞`
+is bounded on `L^p` for every `1 < p < ∞`. This is the diagonal case `p₀ = 1`, `p₁ = ∞` of the
+Marcinkiewicz interpolation theorem, and it is the mechanism that turns the Hardy–Littlewood
+maximal inequality into the strong `(p,p)` bounds, item 9 of Lane B of the PDE roadmap.
 
 ## The statement proved here
 
@@ -47,6 +47,10 @@ elementary `∫⁻ t in (0, ‖f x‖ / c), t ^ (p - 2) = (‖f x‖ / c) ^ (p -
 reassembles into `c ^ (1 - p) / (p - 1) * ‖f x‖ ^ p`. Convergence of that inner integral at the
 origin is where `1 < p` is used, and it is why the constant carries the factor `1 / (p - 1)`.
 
+Tonelli's theorem needs `μ` to be s-finite, but the statement does not: both sides ignore the
+part of `μ` outside `{f > 0}`, and once `∫⁻ f ^ p ∂μ` is finite that part is σ-finite, being
+exhausted by the level sets `{f ≥ 1 / (n + 1)}`, each of finite measure by Chebyshev.
+
 ## Main declarations
 
 * `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`: the interpolation estimate.
@@ -67,9 +71,9 @@ open scoped ENNReal
 variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β] {μ : Measure α} {ν : Measure β}
   {f : α → ℝ≥0∞} {u : β → ℝ≥0∞} {p c : ℝ} {A : ℝ≥0∞}
 
-/-- The interpolation estimate for a measurable `f`; the general case is reduced to this one by
-replacing `f` with a measurable representative. -/
-private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinite μ]
+/-- The interpolation estimate for a measurable `f` and an s-finite `μ`, which is the generality
+in which Tonelli's theorem is available; both hypotheses are removed below. -/
+private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFinite [SFinite μ]
     (hf : Measurable f) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
     (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
       A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) :
@@ -198,6 +202,77 @@ private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable [SFinit
         rw [hconst, ENNReal.ofReal_mul hp0.le]
         ring
 
+/-- The interpolation estimate for a measurable `f` and an arbitrary measure `μ`.
+
+Only the part of `μ` carried by `{f > 0}` enters either side, and once `f` has finite `L^p` norm
+that part is σ-finite, because the level sets `{f ≥ 1 / (n + 1)}` have finite measure and exhaust
+`{f > 0}`. So the s-finite case applies to `μ` restricted to `{f > 0}`, after the two degenerate
+cases — a vanishing weak-type constant and an infinite right-hand side — are disposed of. -/
+private theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable
+    (hf : Measurable f) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
+    (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
+      A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) :
+    ∫⁻ y, u y ^ p ∂ν ≤
+      ENNReal.ofReal (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ x, f x ^ p ∂μ := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hp1 : (0 : ℝ) < p - 1 := by linarith
+  have hK : (0 : ℝ) < p * c ^ (1 - p) / (p - 1) := by positivity
+  rcases eq_or_ne A 0 with hA | hA
+  · -- With `A = 0` the hypothesis holds over the zero measure as well, and there it already
+    -- yields the bound `∫⁻ u ^ p ∂ν ≤ 0`.
+    have hzero := lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFinite
+      (μ := (0 : Measure α)) (A := A) hf hu hp hc fun t ht => by simpa [hA] using h t ht
+    simpa [hA] using hzero
+  rcases eq_or_ne (∫⁻ x, f x ^ p ∂μ) ∞ with htop | htop
+  · -- The right-hand side is infinite.
+    rw [htop, ENNReal.mul_top (mul_ne_zero (ENNReal.ofReal_pos.2 hK).ne' hA)]
+    exact le_top
+  have hsmeas : MeasurableSet {x | 0 < f x} := measurableSet_lt measurable_const hf
+  -- Chebyshev's inequality for `f ^ p` bounds the measure of each level set of `f`.
+  have hlevel : ∀ n : ℕ, μ {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ≠ ∞ := by
+    intro n
+    have hne : ((n : ℝ≥0∞) + 1)⁻¹ ≠ ∞ := ENNReal.inv_ne_top.2 (by simp)
+    have hpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ :=
+      ENNReal.inv_pos.2 (by simp [ENNReal.natCast_ne_top])
+    have hεpos : (0 : ℝ≥0∞) < ((n : ℝ≥0∞) + 1)⁻¹ ^ p := ENNReal.rpow_pos hpos hne
+    have hset : {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} = {x | ((n : ℝ≥0∞) + 1)⁻¹ ^ p ≤ f x ^ p} :=
+      Set.ext fun x => (ENNReal.rpow_le_rpow_iff hp0).symm
+    rw [hset]
+    refine ne_top_of_le_ne_top (ENNReal.div_lt_top htop hεpos.ne').ne
+      (meas_ge_le_lintegral_div (hf.pow_const p).aemeasurable hεpos.ne'
+        (ENNReal.rpow_ne_top_of_nonneg hp0.le hne))
+  -- Hence `μ` restricted to `{f > 0}` is σ-finite, so in particular s-finite.
+  have hσ : SigmaFinite (μ.restrict {x | 0 < f x}) := by
+    refine ⟨⟨⟨fun n => {x | ((n : ℝ≥0∞) + 1)⁻¹ ≤ f x} ∪ {x | 0 < f x}ᶜ, fun _ => trivial, ?_, ?_⟩⟩⟩
+    · intro n
+      have hcompl : μ.restrict {x | 0 < f x} {x | 0 < f x}ᶜ = 0 := by
+        rw [Measure.restrict_apply hsmeas.compl, Set.compl_inter_self, measure_empty]
+      refine lt_of_le_of_lt (measure_union_le _ _) ?_
+      rw [hcompl, add_zero]
+      exact lt_of_le_of_lt (Measure.restrict_apply_le _ _) (lt_top_iff_ne_top.2 (hlevel n))
+    · refine Set.eq_univ_of_forall fun x => ?_
+      rcases eq_or_ne (f x) 0 with hx | hx
+      · exact Set.mem_iUnion.2 ⟨0, Set.mem_union_right _ (by simp [hx])⟩
+      · obtain ⟨n, hn⟩ := ENNReal.exists_inv_nat_lt hx
+        exact Set.mem_iUnion.2
+          ⟨n, Set.mem_union_left _ ((ENNReal.inv_le_inv' le_self_add).trans hn.le)⟩
+  -- The truncated integrals of the hypothesis do not see the complement of `{f > 0}`.
+  have hsub : ∀ t : ℝ, 0 < t → {x | ENNReal.ofReal (c * t) < f x} ⊆ {x | 0 < f x} := by
+    intro t _ x hx
+    exact Set.mem_ofPred.2 (lt_of_le_of_lt zero_le (Set.mem_ofPred.1 hx))
+  -- Neither does `∫⁻ f ^ p`, since `f` vanishes there.
+  have hpow : ∫⁻ x, f x ^ p ∂μ.restrict {x | 0 < f x} = ∫⁻ x, f x ^ p ∂μ := by
+    have hcompl : ∫⁻ x in {x | 0 < f x}ᶜ, f x ^ p ∂μ = 0 := by
+      rw [setLIntegral_congr_fun hsmeas.compl fun x hx => ?_, lintegral_zero]
+      have hx0 : f x = 0 := by simpa using hx
+      rw [hx0, ENNReal.zero_rpow_of_pos hp0]
+    rw [← lintegral_add_compl (μ := μ) (fun x => f x ^ p) hsmeas, hcompl, add_zero]
+  have hmain := lintegral_rpow_le_of_mul_meas_ofReal_lt_le_of_measurable_of_sFinite
+    (μ := μ.restrict {x | 0 < f x}) hf hu hp hc fun t ht => by
+      rw [Measure.restrict_restrict_of_subset (hsub t ht)]
+      exact h t ht
+  rwa [hpow] at hmain
+
 /-- **Marcinkiewicz interpolation**, the diagonal case `p₀ = 1`, `p₁ = ∞`, in distributional form.
 
 If for every height `t > 0` the superlevel set `{u > t}` obeys the weak-type bound
@@ -211,7 +286,7 @@ against the part of `f` above `c * t`, then for every `1 < p < ∞`
 Applied with `u = T f` for a sublinear `T`, the hypothesis is what the weak `(1,1)` and `L^∞`
 endpoint bounds for `T` give after splitting `f` at the height `c * t`, and the conclusion is the
 strong type `(p,p)` bound. The constant degenerates as `p → 1`, as it must. -/
-theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le [SFinite μ]
+theorem lintegral_rpow_le_of_mul_meas_ofReal_lt_le
     (hf : AEMeasurable f μ) (hu : AEMeasurable u ν) (hp : 1 < p) (hc : 0 < c)
     (h : ∀ t : ℝ, 0 < t → ENNReal.ofReal t * ν {y | ENNReal.ofReal t < u y} ≤
       A * ∫⁻ x in {x | ENNReal.ofReal (c * t) < f x}, f x ∂μ) :

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -8,6 +8,7 @@ public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.Topology.Semicontinuity.Defs
+public import TauCeti.MeasureTheory.Integral.Marcinkiewicz
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
 -- for `LowerSemicontinuous.measurable`, inside the proof of `TauCeti.measurable_maximalFunction`.
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
@@ -23,18 +24,20 @@ The **centred Hardy–Littlewood maximal function** of `f` is
 `M f x = ⨆ r > 0, ⨍⁻ y in ball x r, ‖f y‖ₑ ∂μ`,
 
 the largest average of `‖f‖` over a ball centred at `x`. This file defines it, records the two
-endpoint bounds it satisfies, and proves the **maximal inequality**: `M` is of weak type `(1,1)`,
+endpoint bounds it satisfies, and proves the **maximal inequality** in both of its forms: the weak
+type `(1,1)` bound
 
-`t * μ {x | t < M f x} ≤ 4 ^ n * ∫⁻ x, ‖f x‖ₑ ∂μ`,
+`t * μ {x | t < M f x} ≤ 4 ^ n * ∫⁻ x, ‖f x‖ₑ ∂μ`
 
-for `μ` an additive Haar measure on a real normed space of finite dimension `n`.
+and, for `1 < p < ∞`, the strong type `(p, p)` bound `‖M f‖_p ≤ C(n, p) * ‖f‖_p`, for `μ` an
+additive Haar measure on a real normed space of finite dimension `n`.
 
 The maximal inequality is the first item of Lane B of the PDE roadmap, the estimate that drives
 the Calderón–Zygmund theory and, through it, the `Lᵖ` regularity theory for elliptic equations.
 It is also where the classical *asymmetric* pair of endpoints originates: `M` is bounded on `L^∞`
 (`TauCeti.maximalFunction_le_eLpNormEssSup`) but, classically, not on `L¹` — a failure not
-formalised here — so the correct `L¹` statement is the weak-type bound proved below, and the strong
-`(p, p)` bounds for `1 < p ≤ ∞` are obtained from these two ends by Marcinkiewicz interpolation.
+formalised here — so the correct `L¹` statement is the weak-type bound, and the strong `(p, p)`
+bounds are obtained from those two ends by Marcinkiewicz interpolation.
 
 ## The proof
 
@@ -51,6 +54,13 @@ Applying this to `S = {x | t < M f x}` needs a uniform bound on the radii it sel
 where finiteness of `∫⁻ ‖f‖ₑ` enters: a ball whose average exceeds `t` has measure less than
 `∫⁻ ‖f‖ₑ / t`, which in positive dimension bounds its radius. In dimension `0` it does not — every
 ball is the whole space — and that degenerate case is proved separately.
+
+The strong type `(p, p)` bound then comes from
+`TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, the diagonal case of Marcinkiewicz
+interpolation. Its hypothesis is supplied by splitting `f` at the height `t / 2`: the low part has
+`‖·‖ₑ ≤ t / 2` almost everywhere, so its maximal function never reaches `t`, and the weak-type
+bound applied to the high part gives
+`t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
 ## Main declarations
 
@@ -72,6 +82,10 @@ ball is the whole space — and that degenerate case is proved separately.
   **maximal inequality**, in product and in quotient form.
 * `TauCeti.ae_maximalFunction_lt_top`: the maximal function of an `L¹` function is finite almost
   everywhere.
+* `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral`: the weak-type bound against the
+  truncation of `f` at half the height, the form Marcinkiewicz interpolation consumes.
+* `TauCeti.lintegral_maximalFunction_rpow_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
+  **strong type `(p, p)` maximal inequality** for `1 < p < ∞`, with an explicit constant.
 
 The maximal function defined here is the *centred* one, whose averages are over the balls centred
 at the point. The uncentred variant, over all balls containing the point, is comparable to it with
@@ -404,6 +418,134 @@ theorem ae_maximalFunction_lt_top (μ : Measure E) [μ.IsAddHaarMeasure] (f : E 
       exact absurd hle (not_le.2 (ENNReal.lt_add_right hC one_ne_zero))
   rw [ae_iff]
   simpa only [not_lt, top_le_iff] using hm
+
+section StrongType
+
+variable {G : Type*} [TopologicalSpace G] [ESeminormedAddMonoid G]
+
+/-- The weak-type `(1,1)` bound in **truncated** form: only the part of `f` above the height
+`t / 2` can push `M f` above `t`, so
+
+`t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
+
+Splitting `f` at the height `t / 2` and discarding the low part, whose maximal function is at most
+`t / 2` by the `L^∞` endpoint, is what turns
+`TauCeti.mul_measure_lt_maximalFunction_le` into the hypothesis of Marcinkiewicz
+interpolation. -/
+theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAddHaarMeasure]
+    {f : E → G} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
+    ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x} ≤
+      2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
+  have hhalf : (0 : ℝ) ≤ 2⁻¹ * t := by positivity
+  have htwo : ENNReal.ofReal t = 2 * ENNReal.ofReal (2⁻¹ * t) := by
+    rw [← ENNReal.ofReal_ofNat 2, ← ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2)]
+    ring_nf
+  -- Split `f` at the height `t / 2`, cutting along a measurable representative of `‖f‖ₑ`.
+  set g : E → ℝ≥0∞ := hf.mk (fun x => ‖f x‖ₑ) with hgdef
+  have hfg : (fun x => ‖f x‖ₑ) =ᵐ[μ] g := hf.ae_eq_mk
+  set S : Set E := {x | ENNReal.ofReal (2⁻¹ * t) < g x} with hSdef
+  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hf.measurable_mk
+  set f₁ : E → G := S.indicator f with hf₁def
+  set f₂ : E → G := Sᶜ.indicator f with hf₂def
+  have hsplit : f₁ + f₂ = f := by
+    funext x
+    simp only [Pi.add_apply, hf₁def, hf₂def]
+    by_cases hx : x ∈ S
+    · rw [Set.indicator_of_mem hx, Set.indicator_of_notMem (by simp [hx]), add_zero]
+    · rw [Set.indicator_of_notMem hx, Set.indicator_of_mem (by simp [hx]), zero_add]
+  have henorm₁ : ∀ x, ‖f₁ x‖ₑ = S.indicator (fun x => ‖f x‖ₑ) x := by
+    intro x
+    by_cases hx : x ∈ S
+    · rw [hf₁def, Set.indicator_of_mem hx, Set.indicator_of_mem hx]
+    · rw [hf₁def, Set.indicator_of_notMem hx, Set.indicator_of_notMem hx, enorm_zero]
+  have hae₁ : AEMeasurable (fun x => ‖f₁ x‖ₑ) μ := by
+    simpa only [funext henorm₁] using hf.indicator hSmeas
+  -- The low part is bounded by `t / 2`, hence so is its maximal function.
+  have hM₂ : ∀ x, maximalFunction μ f₂ x ≤ ENNReal.ofReal (2⁻¹ * t) := by
+    have hbound : (fun x => ‖f₂ x‖ₑ) ≤ᵐ[μ] fun _ => ENNReal.ofReal (2⁻¹ * t) := by
+      filter_upwards [hfg] with x hx
+      by_cases hxS : x ∈ S
+      · rw [hf₂def, Set.indicator_of_notMem (by simp [hxS]), enorm_zero]
+        exact zero_le
+      · rw [hf₂def, Set.indicator_of_mem (by simp [hxS]), hx]
+        exact not_lt.1 (by simpa [hSdef] using hxS)
+    exact fun x => (maximalFunction_le_eLpNormEssSup μ f₂ x).trans
+      (essSup_le_of_ae_le _ hbound)
+  -- Hence `M f > t` forces `M f₁ > t / 2`.
+  have hincl : {x | ENNReal.ofReal t < maximalFunction μ f x} ⊆
+      {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ f₁ x} := by
+    intro x hx
+    have h1 : maximalFunction μ f x ≤ maximalFunction μ f₁ x + maximalFunction μ f₂ x := by
+      conv_lhs => rw [← hsplit]
+      exact maximalFunction_add_le hae₁ x
+    have h2 : ENNReal.ofReal (2⁻¹ * t) + ENNReal.ofReal (2⁻¹ * t) <
+        maximalFunction μ f₁ x + ENNReal.ofReal (2⁻¹ * t) := by
+      rw [← ENNReal.ofReal_add hhalf hhalf, show 2⁻¹ * t + 2⁻¹ * t = t by ring]
+      exact lt_of_lt_of_le hx (h1.trans (add_le_add le_rfl (hM₂ x)))
+    exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 h2
+  -- The `L¹` norm of the high part is the truncated integral.
+  have hint : ∫⁻ x, ‖f₁ x‖ₑ ∂μ =
+      ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
+    have hsets : {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ} =ᵐ[μ] S := by
+      filter_upwards [hfg] with x hx
+      exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (2⁻¹ * t) < z) hx
+    rw [Measure.restrict_congr_set hsets, ← lintegral_indicator hSmeas]
+    exact lintegral_congr henorm₁
+  calc ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x}
+      = 2 * (ENNReal.ofReal (2⁻¹ * t) * μ {x | ENNReal.ofReal t < maximalFunction μ f x}) := by
+        rw [htwo, mul_assoc]
+    _ ≤ 2 * (ENNReal.ofReal (2⁻¹ * t) *
+          μ {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ f₁ x}) :=
+        mul_le_mul_right (mul_le_mul_right (measure_mono hincl) _) 2
+    _ ≤ 2 * (4 ^ finrank ℝ E * ∫⁻ x, ‖f₁ x‖ₑ ∂μ) :=
+        mul_le_mul_right (mul_measure_lt_maximalFunction_le μ f₁ _) 2
+    _ = 2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
+        rw [hint, mul_assoc]
+
+/-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
+as an inequality between the integrals `∫⁻ ‖·‖ₑ ^ p`:
+
+`∫⁻ (M f) ^ p ∂μ ≤ (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ n * ∫⁻ ‖f‖ₑ ^ p ∂μ`.
+
+The constant blows up as `p → 1`, as it must: `M` is not bounded on `L¹`. -/
+theorem lintegral_maximalFunction_rpow_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → G}
+    (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ} (hp : 1 < p) :
+    ∫⁻ x, maximalFunction μ f x ^ p ∂μ ≤
+      ENNReal.ofReal (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ finrank ℝ E *
+        ∫⁻ x, ‖f x‖ₑ ^ p ∂μ := by
+  have hp0 : (0 : ℝ) < p := by linarith
+  have hconst : ENNReal.ofReal (p * (2 : ℝ)⁻¹ ^ (1 - p) / (p - 1)) * (2 * 4 ^ finrank ℝ E) =
+      ENNReal.ofReal (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ finrank ℝ E := by
+    rw [show ((2 : ℝ))⁻¹ ^ (1 - p) = 2 ^ (p - 1) by
+      rw [Real.inv_rpow (by norm_num), ← Real.rpow_neg (by norm_num), neg_sub],
+      show 2 * p * 2 ^ (p - 1) / (p - 1) = 2 * (p * 2 ^ (p - 1) / (p - 1)) by ring,
+      ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
+    ring
+  rw [← hconst]
+  refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf
+    (measurable_maximalFunction μ f).aemeasurable hp (by norm_num) fun t ht => ?_
+  simpa using mul_measure_lt_maximalFunction_le_setLIntegral μ hf ht
+
+/-- **The Hardy–Littlewood maximal inequality**, the strong-type `(p, p)` bound for `1 < p < ∞`,
+in terms of the `Lᵖ` seminorms: `M` is a bounded (nonlinear) operator on `Lᵖ`.
+
+Together with `TauCeti.maximalFunction_le_eLpNormEssSup` (the case `p = ∞`) and
+`TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this completes
+the `Lᵖ` theory of the maximal function. -/
+theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → G}
+    (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ≥0∞} (hp : 1 < p) (hp_top : p ≠ ∞) :
+    eLpNorm (maximalFunction μ f) p μ ≤
+      (ENNReal.ofReal (2 * p.toReal * 2 ^ (p.toReal - 1) / (p.toReal - 1)) *
+        4 ^ finrank ℝ E) ^ (1 / p.toReal) * eLpNorm f p μ := by
+  have hp₀ : p ≠ 0 := (zero_lt_one.trans hp).ne'
+  have hpr : 1 < p.toReal := by
+    simpa using (ENNReal.toReal_lt_toReal ENNReal.one_ne_top hp_top).2 hp
+  rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp_top,
+    eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp_top,
+    ← ENNReal.mul_rpow_of_nonneg _ _ (by positivity)]
+  exact ENNReal.rpow_le_rpow (lintegral_maximalFunction_rpow_le μ hf hpr) (by positivity)
+
+end StrongType
 
 end Haar
 

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -8,7 +8,10 @@ public import Mathlib.MeasureTheory.Function.LpSeminorm.Basic
 public import Mathlib.MeasureTheory.Integral.Average
 public import Mathlib.MeasureTheory.Measure.Lebesgue.EqHaar
 public import Mathlib.Topology.Semicontinuity.Defs
-public import TauCeti.MeasureTheory.Integral.Marcinkiewicz
+-- `TauCeti.MeasureTheory.Integral.Marcinkiewicz` is imported privately: it supplies
+-- `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, used only inside the proof of
+-- `TauCeti.lintegral_rpow_maximalFunction_le`.
+import TauCeti.MeasureTheory.Integral.Marcinkiewicz
 -- `Mathlib.MeasureTheory.Constructions.BorelSpace.Order` is imported privately: it is used only
 -- for `LowerSemicontinuous.measurable`, inside the proof of `TauCeti.measurable_maximalFunction`.
 import Mathlib.MeasureTheory.Constructions.BorelSpace.Order
@@ -35,9 +38,11 @@ additive Haar measure on a real normed space of finite dimension `n`.
 The maximal inequality is the first item of Lane B of the PDE roadmap, the estimate that drives
 the Calderón–Zygmund theory and, through it, the `Lᵖ` regularity theory for elliptic equations.
 It is also where the classical *asymmetric* pair of endpoints originates: `M` is bounded on `L^∞`
-(`TauCeti.maximalFunction_le_eLpNormEssSup`) but, classically, not on `L¹` — a failure not
-formalised here — so the correct `L¹` statement is the weak-type bound, and the strong `(p, p)`
-bounds are obtained from those two ends by Marcinkiewicz interpolation.
+(`TauCeti.maximalFunction_le_eLpNormEssSup`) but, in positive dimension, not on `L¹` — a failure
+not formalised here — so the correct `L¹` statement is the weak-type bound, and the strong `(p, p)`
+bounds are obtained from those two ends by Marcinkiewicz interpolation. The qualification matters:
+the `L¹` failure is a positive-dimensional phenomenon, since in dimension `0` every ball is the
+whole space and the averages defining `M f` collapse to `‖f‖ₑ`.
 
 ## The proof
 
@@ -57,9 +62,9 @@ ball is the whole space — and that degenerate case is proved separately.
 
 The strong type `(p, p)` bound then comes from
 `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`, the diagonal case of Marcinkiewicz
-interpolation. Its hypothesis is supplied by splitting `f` at the height `t / 2`: the low part has
-`‖·‖ₑ ≤ t / 2` almost everywhere, so its maximal function never reaches `t`, and the weak-type
-bound applied to the high part gives
+interpolation. Its hypothesis is supplied by splitting `‖f‖ₑ` at the height `t / 2`: the low part
+is bounded by `t / 2`, so its maximal function never reaches `t`, and the weak-type bound applied
+to the high part gives
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
 ## Main declarations
@@ -72,8 +77,9 @@ bound applied to the high part gives
 * `TauCeti.maximalFunction_mono_ae`, `TauCeti.maximalFunction_congr_ae`: `M` is monotone in `‖f‖ₑ`
   almost everywhere, so `M f` depends on `f` only through `‖f‖ₑ` and only up to a null set.
 * `TauCeti.maximalFunction_zero`, `TauCeti.maximalFunction_add_le`,
-  `TauCeti.maximalFunction_const_smul`: `M` is sublinear, which is what Marcinkiewicz
-  interpolation will ask of it.
+  `TauCeti.maximalFunction_const_smul`: `M` is sublinear. Subadditivity is what
+  `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral` uses to build the hypothesis of
+  `TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le`.
 * `TauCeti.maximalFunction_le_eLpNormEssSup`: the `L^∞` endpoint.
 * `TauCeti.lowerSemicontinuous_maximalFunction`, `TauCeti.measurable_maximalFunction`: the
   superlevel sets `{x | t < M f x}` are open, so `M f` is Borel measurable.
@@ -84,7 +90,7 @@ bound applied to the high part gives
   everywhere.
 * `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral`: the weak-type bound against the
   truncation of `f` at half the height, the form Marcinkiewicz interpolation consumes.
-* `TauCeti.lintegral_maximalFunction_rpow_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
+* `TauCeti.lintegral_rpow_maximalFunction_le`, `TauCeti.eLpNorm_maximalFunction_le`: the
   **strong type `(p, p)` maximal inequality** for `1 < p < ∞`, with an explicit constant.
 
 The maximal function defined here is the *centred* one, whose averages are over the balls centred
@@ -177,8 +183,9 @@ private theorem setLAverage_const_mul (μ : Measure X) (s : Set X) {c : ℝ≥0�
     (h : X → ℝ≥0∞) : ⨍⁻ y in s, c * h y ∂μ = c * ⨍⁻ y in s, h y ∂μ := by
   rw [setLAverage_eq, setLAverage_eq, lintegral_const_mul' _ _ hc, mul_div_assoc]
 
-/-- The maximal function is positively homogeneous, the first half of the sublinearity that
-Marcinkiewicz interpolation asks of an operator. -/
+/-- The maximal function is positively homogeneous: scaling `f` by `c` scales `M f` by `‖c‖ₑ`.
+This is the first half of the sublinearity of `M`, the second being
+`TauCeti.maximalFunction_add_le`. -/
 @[simp]
 theorem maximalFunction_const_smul {𝕜 : Type*} [NNNorm 𝕜] [SMul 𝕜 F] [ENormSMulClass 𝕜 F]
     (μ : Measure X) (c : 𝕜) (f : X → F) (x : X) :
@@ -421,85 +428,86 @@ theorem ae_maximalFunction_lt_top (μ : Measure E) [μ.IsAddHaarMeasure] (f : E 
 
 section StrongType
 
-variable {G : Type*} [TopologicalSpace G] [ESeminormedAddMonoid G]
-
 /-- The weak-type `(1,1)` bound in **truncated** form: only the part of `f` above the height
 `t / 2` can push `M f` above `t`, so
 
 `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`.
 
-Splitting `f` at the height `t / 2` and discarding the low part, whose maximal function is at most
-`t / 2` by the `L^∞` endpoint, is what turns
+Splitting `‖f‖ₑ` at the height `t / 2` and discarding the low part, whose maximal function is at
+most `t / 2` by the `L^∞` endpoint, is what turns
 `TauCeti.mul_measure_lt_maximalFunction_le` into the hypothesis of Marcinkiewicz
-interpolation. -/
+interpolation. The split is carried out in `ℝ≥0∞`, since `M f` depends on `f` only through
+`‖f‖ₑ`. -/
 theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAddHaarMeasure]
-    {f : E → G} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
+    {f : E → F} (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {t : ℝ} (ht : 0 < t) :
     ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x} ≤
       2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
   have hhalf : (0 : ℝ) ≤ 2⁻¹ * t := by positivity
   have htwo : ENNReal.ofReal t = 2 * ENNReal.ofReal (2⁻¹ * t) := by
     rw [← ENNReal.ofReal_ofNat 2, ← ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2)]
     ring_nf
-  -- Split `f` at the height `t / 2`, cutting along a measurable representative of `‖f‖ₑ`.
+  -- Split `‖f‖ₑ` at the height `t / 2`, cutting along a measurable representative `g`.
   set g : E → ℝ≥0∞ := hf.mk (fun x => ‖f x‖ₑ) with hgdef
   have hfg : (fun x => ‖f x‖ₑ) =ᵐ[μ] g := hf.ae_eq_mk
+  have hgmeas : Measurable g := hf.measurable_mk
   set S : Set E := {x | ENNReal.ofReal (2⁻¹ * t) < g x} with hSdef
-  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hf.measurable_mk
-  set f₁ : E → G := S.indicator f with hf₁def
-  set f₂ : E → G := Sᶜ.indicator f with hf₂def
-  have hsplit : f₁ + f₂ = f := by
-    funext x
-    simp only [Pi.add_apply, hf₁def, hf₂def]
-    by_cases hx : x ∈ S
-    · rw [Set.indicator_of_mem hx, Set.indicator_of_notMem (by simp [hx]), add_zero]
-    · rw [Set.indicator_of_notMem hx, Set.indicator_of_mem (by simp [hx]), zero_add]
-  have henorm₁ : ∀ x, ‖f₁ x‖ₑ = S.indicator (fun x => ‖f x‖ₑ) x := by
-    intro x
-    by_cases hx : x ∈ S
-    · rw [hf₁def, Set.indicator_of_mem hx, Set.indicator_of_mem hx]
-    · rw [hf₁def, Set.indicator_of_notMem hx, Set.indicator_of_notMem hx, enorm_zero]
-  have hae₁ : AEMeasurable (fun x => ‖f₁ x‖ₑ) μ := by
-    simpa only [funext henorm₁] using hf.indicator hSmeas
+  have hSmeas : MeasurableSet S := measurableSet_lt measurable_const hgmeas
+  set g₁ : E → ℝ≥0∞ := S.indicator g with hg₁def
+  set g₂ : E → ℝ≥0∞ := Sᶜ.indicator g with hg₂def
+  have hsplit : ∀ x, g₁ x + g₂ x = g x := by
+    rw [hg₁def, hg₂def]
+    exact Set.indicator_self_add_compl_apply S g
+  -- `M f = M (g₁ + g₂)`, because `M` sees `f` only through `‖f‖ₑ`, which is `g` almost everywhere.
+  have hMf : ∀ x, maximalFunction μ f x = maximalFunction μ (g₁ + g₂) x := fun x =>
+    maximalFunction_congr_ae (by
+      filter_upwards [hfg] with y hy
+      rw [hy, enorm_eq_self, Pi.add_apply, hsplit y])
   -- The low part is bounded by `t / 2`, hence so is its maximal function.
-  have hM₂ : ∀ x, maximalFunction μ f₂ x ≤ ENNReal.ofReal (2⁻¹ * t) := by
-    have hbound : (fun x => ‖f₂ x‖ₑ) ≤ᵐ[μ] fun _ => ENNReal.ofReal (2⁻¹ * t) := by
-      filter_upwards [hfg] with x hx
+  have hM₂ : ∀ x, maximalFunction μ g₂ x ≤ ENNReal.ofReal (2⁻¹ * t) := by
+    have hbound : ∀ x, ‖g₂ x‖ₑ ≤ ENNReal.ofReal (2⁻¹ * t) := by
+      intro x
+      rw [enorm_eq_self, hg₂def]
       by_cases hxS : x ∈ S
-      · rw [hf₂def, Set.indicator_of_notMem (by simp [hxS]), enorm_zero]
+      · rw [Set.indicator_of_notMem (by simp [hxS])]
         exact zero_le
-      · rw [hf₂def, Set.indicator_of_mem (by simp [hxS]), hx]
+      · rw [Set.indicator_of_mem (by simp [hxS])]
         exact not_lt.1 (by simpa [hSdef] using hxS)
-    exact fun x => (maximalFunction_le_eLpNormEssSup μ f₂ x).trans
-      (essSup_le_of_ae_le _ hbound)
-  -- Hence `M f > t` forces `M f₁ > t / 2`.
+    exact fun x => (maximalFunction_le_eLpNormEssSup μ g₂ x).trans
+      (essSup_le_of_ae_le _ (.of_forall hbound))
+  -- Hence `M f > t` forces `M g₁ > t / 2`.
   have hincl : {x | ENNReal.ofReal t < maximalFunction μ f x} ⊆
-      {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ f₁ x} := by
+      {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ g₁ x} := by
     intro x hx
-    have h1 : maximalFunction μ f x ≤ maximalFunction μ f₁ x + maximalFunction μ f₂ x := by
-      conv_lhs => rw [← hsplit]
-      exact maximalFunction_add_le hae₁ x
+    have h1 : maximalFunction μ f x ≤ maximalFunction μ g₁ x + maximalFunction μ g₂ x := by
+      rw [hMf x]
+      exact maximalFunction_add_le (hgmeas.indicator hSmeas).aemeasurable x
     have h2 : ENNReal.ofReal (2⁻¹ * t) + ENNReal.ofReal (2⁻¹ * t) <
-        maximalFunction μ f₁ x + ENNReal.ofReal (2⁻¹ * t) := by
+        maximalFunction μ g₁ x + ENNReal.ofReal (2⁻¹ * t) := by
       have hsum : 2⁻¹ * t + 2⁻¹ * t = t := by ring
       rw [← ENNReal.ofReal_add hhalf hhalf, hsum]
       exact lt_of_lt_of_le hx (h1.trans (add_le_add le_rfl (hM₂ x)))
     exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 h2
   -- The `L¹` norm of the high part is the truncated integral.
-  have hint : ∫⁻ x, ‖f₁ x‖ₑ ∂μ =
+  have hint : ∫⁻ x, ‖g₁ x‖ₑ ∂μ =
       ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
     have hsets : {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ} =ᵐ[μ] S := by
       filter_upwards [hfg] with x hx
       exact congrArg (fun z : ℝ≥0∞ => ENNReal.ofReal (2⁻¹ * t) < z) hx
-    rw [Measure.restrict_congr_set hsets, ← lintegral_indicator hSmeas]
-    exact lintegral_congr henorm₁
+    calc ∫⁻ x, ‖g₁ x‖ₑ ∂μ
+        = ∫⁻ x in S, g x ∂μ := by
+          simp only [enorm_eq_self, hg₁def]
+          exact lintegral_indicator hSmeas g
+      _ = ∫⁻ x in S, ‖f x‖ₑ ∂μ := (lintegral_congr_ae (ae_restrict_of_ae hfg)).symm
+      _ = ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
+          rw [Measure.restrict_congr_set hsets]
   calc ENNReal.ofReal t * μ {x | ENNReal.ofReal t < maximalFunction μ f x}
       = 2 * (ENNReal.ofReal (2⁻¹ * t) * μ {x | ENNReal.ofReal t < maximalFunction μ f x}) := by
         rw [htwo, mul_assoc]
     _ ≤ 2 * (ENNReal.ofReal (2⁻¹ * t) *
-          μ {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ f₁ x}) :=
+          μ {x | ENNReal.ofReal (2⁻¹ * t) < maximalFunction μ g₁ x}) :=
         mul_le_mul_right (mul_le_mul_right (measure_mono hincl) _) 2
-    _ ≤ 2 * (4 ^ finrank ℝ E * ∫⁻ x, ‖f₁ x‖ₑ ∂μ) :=
-        mul_le_mul_right (mul_measure_lt_maximalFunction_le μ f₁ _) 2
+    _ ≤ 2 * (4 ^ finrank ℝ E * ∫⁻ x, ‖g₁ x‖ₑ ∂μ) :=
+        mul_le_mul_right (mul_measure_lt_maximalFunction_le μ g₁ _) 2
     _ = 2 * 4 ^ finrank ℝ E * ∫⁻ x in {x | ENNReal.ofReal (2⁻¹ * t) < ‖f x‖ₑ}, ‖f x‖ₑ ∂μ := by
         rw [hint, mul_assoc]
 
@@ -508,8 +516,9 @@ as an inequality between the integrals `∫⁻ ‖·‖ₑ ^ p`:
 
 `∫⁻ (M f) ^ p ∂μ ≤ (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ n * ∫⁻ ‖f‖ₑ ^ p ∂μ`.
 
-The constant blows up as `p → 1`, as it must: `M` is not bounded on `L¹`. -/
-theorem lintegral_maximalFunction_rpow_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → G}
+The constant degenerates as `p → 1`, as it must in positive dimension, where `M` is not bounded on
+`L¹`. -/
+theorem lintegral_rpow_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → F}
     (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ} (hp : 1 < p) :
     ∫⁻ x, maximalFunction μ f x ^ p ∂μ ≤
       ENNReal.ofReal (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ finrank ℝ E *
@@ -533,7 +542,7 @@ in terms of the `Lᵖ` seminorms: `M` is a bounded (nonlinear) operator on `Lᵖ
 Together with `TauCeti.maximalFunction_le_eLpNormEssSup` (the case `p = ∞`) and
 `TauCeti.mul_measure_lt_maximalFunction_le` (the weak-type substitute at `p = 1`), this completes
 the `Lᵖ` theory of the maximal function. -/
-theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → G}
+theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E → F}
     (hf : AEMeasurable (fun x => ‖f x‖ₑ) μ) {p : ℝ≥0∞} (hp : 1 < p) (hp_top : p ≠ ∞) :
     eLpNorm (maximalFunction μ f) p μ ≤
       (ENNReal.ofReal (2 * p.toReal * 2 ^ (p.toReal - 1) / (p.toReal - 1)) *
@@ -544,7 +553,7 @@ theorem eLpNorm_maximalFunction_le (μ : Measure E) [μ.IsAddHaarMeasure] {f : E
   rw [eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp_top,
     eLpNorm_eq_lintegral_rpow_enorm_toReal hp₀ hp_top,
     ← ENNReal.mul_rpow_of_nonneg _ _ (by positivity)]
-  exact ENNReal.rpow_le_rpow (lintegral_maximalFunction_rpow_le μ hf hpr) (by positivity)
+  exact ENNReal.rpow_le_rpow (lintegral_rpow_maximalFunction_le μ hf hpr) (by positivity)
 
 end StrongType
 

--- a/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
+++ b/TauCeti/MeasureTheory/Integral/MaximalFunction.lean
@@ -480,7 +480,8 @@ theorem mul_measure_lt_maximalFunction_le_setLIntegral (μ : Measure E) [μ.IsAd
       exact maximalFunction_add_le hae₁ x
     have h2 : ENNReal.ofReal (2⁻¹ * t) + ENNReal.ofReal (2⁻¹ * t) <
         maximalFunction μ f₁ x + ENNReal.ofReal (2⁻¹ * t) := by
-      rw [← ENNReal.ofReal_add hhalf hhalf, show 2⁻¹ * t + 2⁻¹ * t = t by ring]
+      have hsum : 2⁻¹ * t + 2⁻¹ * t = t := by ring
+      rw [← ENNReal.ofReal_add hhalf hhalf, hsum]
       exact lt_of_lt_of_le hx (h1.trans (add_le_add le_rfl (hM₂ x)))
     exact (ENNReal.add_lt_add_iff_right ENNReal.ofReal_ne_top).1 h2
   -- The `L¹` norm of the high part is the truncated integral.
@@ -516,10 +517,10 @@ theorem lintegral_maximalFunction_rpow_le (μ : Measure E) [μ.IsAddHaarMeasure]
   have hp0 : (0 : ℝ) < p := by linarith
   have hconst : ENNReal.ofReal (p * (2 : ℝ)⁻¹ ^ (1 - p) / (p - 1)) * (2 * 4 ^ finrank ℝ E) =
       ENNReal.ofReal (2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ finrank ℝ E := by
-    rw [show ((2 : ℝ))⁻¹ ^ (1 - p) = 2 ^ (p - 1) by
-      rw [Real.inv_rpow (by norm_num), ← Real.rpow_neg (by norm_num), neg_sub],
-      show 2 * p * 2 ^ (p - 1) / (p - 1) = 2 * (p * 2 ^ (p - 1) / (p - 1)) by ring,
-      ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
+    have hinv : ((2 : ℝ))⁻¹ ^ (1 - p) = 2 ^ (p - 1) := by
+      rw [Real.inv_rpow (by norm_num), ← Real.rpow_neg (by norm_num), neg_sub]
+    have hsplit : 2 * p * 2 ^ (p - 1) / (p - 1) = 2 * (p * 2 ^ (p - 1) / (p - 1)) := by ring
+    rw [hinv, hsplit, ENNReal.ofReal_mul (by norm_num : (0 : ℝ) ≤ 2), ENNReal.ofReal_ofNat]
     ring
   rw [← hconst]
   refine lintegral_rpow_le_of_mul_meas_ofReal_lt_le hf


### PR DESCRIPTION
This PR proves the **strong type `(p, p)` Hardy–Littlewood maximal inequality** for `1 < p < ∞`, by way of the **Marcinkiewicz interpolation theorem** in its diagonal `p₀ = 1`, `p₁ = ∞` case. It serves item 8 of Lane B of the PDE roadmap — *"Hardy–Littlewood maximal function `Mf` and the maximal inequality: weak `(1,1)` (via Vitali, consuming `MeasureTheory/Covering/*`) and strong `(p,p)` for `p>1`"* — of which #2095 landed the weak `(1,1)` half, and it supplies item 9, *"Interpolation. **Marcinkiewicz** (real, weak-type to strong-type) … *Neither is in Mathlib*"*, in the case that item 8 needs. `TauCeti/MeasureTheory/Integral/MaximalFunction.lean` already pointed here: its module docstring said the strong bounds "are obtained from these two ends by Marcinkiewicz interpolation". After this PR the Lane B estimate engine still needs Riesz–Thorin (the complex half of item 9) and the full off-diagonal Marcinkiewicz before item 10, the Calderón–Zygmund decomposition and singular integral operators, can proceed.

`TauCeti.lintegral_rpow_le_of_mul_meas_ofReal_lt_le` is the interpolation theorem. Interpolation arguments run entirely on the distribution functions of `T f` and of `f`, so it is stated in that form rather than in terms of a bundled operator: the sublinearity of `T` and its two endpoint bounds are used only to produce, for each height `t > 0`, the single inequality `t * ν {u > t} ≤ A * ∫⁻ x in {f > c * t}, f ∂μ`, saying that only the part of `f` above the height `c * t` can push `u = T f` above `t`; the conclusion is `∫⁻ u ^ p ∂ν ≤ (p * c ^ (1 - p) / (p - 1)) * A * ∫⁻ f ^ p ∂μ`. Keeping the hypothesis in this shape does not force `T` to be defined on a whole function space, it lets `μ` and `ν` live on different spaces as a genuine interpolation statement should, and it makes the dependence of the constant on `p`, on the weak-type constant `A` and on the truncation ratio `c` explicit. That last point is not cosmetic: the constant must blow up as `p → 1`, since an operator of weak type `(1,1)` need not be bounded on `L¹`, and the roadmap's warning that "a CZ operator is **not** bounded on `L¹` or `L^∞`" is about exactly this endpoint. The proof converts both sides with the layer cake formula, multiplies the hypothesis by `t ^ (p - 2)`, exchanges the `t` and `x` integrations by Tonelli, and evaluates the resulting inner integral `∫⁻ t in (0, f x / c), t ^ (p - 2) = (f x / c) ^ (p - 1) / (p - 1)`; convergence of that integral at the origin is where `1 < p` enters, and is why the constant carries `1 / (p - 1)`.

The layer cake formula it consumes is `TauCeti.lintegral_rpow_eq_lintegral_meas_ofReal_lt_mul`. Mathlib's `MeasureTheory.lintegral_rpow_eq_lintegral_meas_lt_mul` covers only a nonnegative *real-valued* function, which is not enough here: the maximal function is a supremum of averages in `ℝ≥0∞`, defined with no finiteness hypothesis, and an a priori bound on `∫⁻ (M f) ^ p` cannot presuppose that `M f` is finite. The `ℝ≥0∞`-valued version is proved by transporting Mathlib's through `ENNReal.toReal` where `u` is finite, and by observing that both sides are `∞` where `{u = ∞}` has positive measure — the second case rests on `TauCeti.lintegral_ofReal_rpow_Ioi`, the divergence of `∫⁻ t in (0, ∞), t ^ s` for `-1 < s`, whose companion `TauCeti.lintegral_ofReal_rpow_Ioo` evaluates the same integrand on a bounded interval and is what the interpolation proof uses at each point. Both are stated for a general exponent rather than specialised, since they are the two halves of one dichotomy.

On the maximal function itself, `TauCeti.mul_measure_lt_maximalFunction_le_setLIntegral` restates the existing weak-type bound in the truncated form interpolation asks for, by splitting `f` at the height `t / 2`: the low part has `‖·‖ₑ ≤ t / 2` almost everywhere, so by the `L^∞` endpoint `TauCeti.maximalFunction_le_eLpNormEssSup` its maximal function never reaches `t`, and applying `TauCeti.mul_measure_lt_maximalFunction_le` to the high part gives `t * μ {M f > t} ≤ 2 * 4 ^ n * ∫⁻ x in {‖f‖ₑ > t / 2}, ‖f x‖ₑ ∂μ`. The split is taken along a measurable representative of `‖f‖ₑ`, which is why the only hypothesis on `f` is `AEMeasurable (‖f ·‖ₑ) μ` — weaker than `AEStronglyMeasurable f`, and the honest hypothesis given that `M f` depends on `f` only through `‖f‖ₑ`. The results are `TauCeti.lintegral_maximalFunction_rpow_le` and `TauCeti.eLpNorm_maximalFunction_le`, the latter reading `‖M f‖_p ≤ ((2 * p * 2 ^ (p - 1) / (p - 1)) * 4 ^ n) ^ (1/p) * ‖f‖_p` with `n = finrank ℝ E`; the dimensional factor `4 ^ n` is inherited from the Vitali covering step, and no attempt is made to sharpen it. The `p = ∞` case is the already-available `TauCeti.maximalFunction_le_eLpNormEssSup`, and `p = 1` is genuinely false, so with this the `Lᵖ` theory of `M` is complete at every exponent.

Two new files: `TauCeti/Analysis/SpecialFunctions/Pow/Integral.lean` (149 lines, mirroring the Mathlib module of the same path, which is where the real-valued layer cake for `rpow` lives) and `TauCeti/MeasureTheory/Integral/Marcinkiewicz.lean` (234 lines); plus 147 lines added to `TauCeti/MeasureTheory/Integral/MaximalFunction.lean`, whose module docstring is updated accordingly. No Mathlib infrastructure is vendored; everything is consumed from the pinned Mathlib, and nothing is imported from the Carleson project.

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"marcinkiewicz-interpolation"}-->

🤖 Prepared with Claude Code
