### PR TITLE
feat(HeckeRing): the Hecke ring over ring coefficients is a ring

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -32,7 +32,8 @@ stack merges.
 * `DoubleCoset.multiplicity_doubleCoset_congr`: `m(g, h; d)` depends on `d` only through the
   double coset `Γ₁dΓ₃`.
 * `HeckeCosetModule.mul_assoc`: associativity of the convolution product at mixed levels.
-* the `Semiring (𝕋 Δ H R)` instance.
+* the `Semiring (𝕋 Δ H R)` instance, and the `Ring (𝕋 Δ H R)` instance over a ring of
+  coefficients.
 -/
 
 public section
@@ -501,5 +502,12 @@ noncomputable instance instSemiringHeckeRing {H : Subgroup G} [IsHeckeTriple Δ 
     Semiring (𝕋 Δ H R) :=
   { (inferInstance : NonAssocSemiring (𝕋 Δ H R)) with
     mul_assoc := fun f g h ↦ HeckeCosetModule.mul_assoc R f g h }
+
+/-- The Hecke ring over a ring of coefficients is a ring: the coefficientwise additive
+inverse of the underlying finitely supported functions. -/
+noncomputable instance instRingHeckeRing {H : Subgroup G} [IsHeckeTriple Δ H H]
+    {R' : Type*} [Ring R'] : Ring (𝕋 Δ H R') :=
+  { (inferInstance : Semiring (𝕋 Δ H R')),
+    (inferInstance : AddCommGroup (𝕋 Δ H R')) with }
 
 end HeckeCosetModule


### PR DESCRIPTION
`𝕋 Δ H R` already carries a `Semiring` instance (`instSemiringHeckeRing`) and, as a
module of finitely supported functions, an `AddCommGroup` whenever the coefficients
have one. This assembles the two into the `Ring (𝕋 Δ H R')` instance for a ring `R'`
of coefficients, so that subtraction in the Hecke ring interacts with the convolution
product through the ordinary ring API (`mul_sub`, `sub_mul`, …).

No new mathematics: both parents are already in `main`, and the instance adds only the
distributivity of the product over differences that they jointly determine.

It is a prerequisite of the `T(p^r)` recursion in the GL₂ Hecke ring, whose statement
is the telescoping difference `T(p) · T(p^r) − p·T(p,p) · T(p^(r-1))`; without a `Ring`
instance that expression does not even typecheck against the product.

Roadmap: ModularForms

Layer 2 (Hecke operators on modular forms): the `T(p^r)` recurrence and the resulting
multiplicativity of the Hecke algebra, ported from the AINTLIB `LeanModularForms`
project.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5