### PR TITLE
feat(ModularForms): the q-circle integral of the cusp function's logDeriv

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
@@ -10,6 +10,7 @@ public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
 public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
 
+import TauCeti.Analysis.Complex.IsolatedZero
 import TauCeti.Analysis.Contour.Argument.Principle
 
 /-!
@@ -28,6 +29,8 @@ value is `2πi` times the order at the cusp.
   `q`-circle, with `fdBoundaryQRadius_def`, `_pos`, and `_lt_one`.
 * `TauCeti.ModularForm.qParam_fdBoundary_segment5`: the ceiling parametrizes the
   `q`-circle.
+* `TauCeti.ModularForm.circleIntegral_logDeriv_cuspFunction`: the `q`-circle integral of
+  the cusp function's logarithmic derivative is `2πi` times the cusp order.
 
 ## References
 
@@ -89,10 +92,10 @@ theorem qParam_fdBoundary_segment5 (H t : ℝ) :
 
 /-- The `q`-circle integral of the logarithmic derivative of the cusp function is `2πi`
 times the `q`-expansion order at the cusp: the cusp function is analytic on the closed
-`q`-disc and vanishes there only at the origin, so the argument principle localizes to
-the central zero, whose multiplicity is the cusp order. The order is finite because a
-cusp function vanishing identically near `0` would also vanish somewhere on the
-punctured disc. -/
+`q`-disc and vanishes there at most at the origin, so the argument principle localizes
+the order contribution to the origin — the cusp order, which is `0` when the cusp
+function does not vanish there. The order is finite because a cusp function vanishing
+identically near `0` would also vanish somewhere on the punctured disc. -/
 theorem circleIntegral_logDeriv_cuspFunction {g : UpperHalfPlane → ℂ} {H : ℝ}
     (hga : ∀ q ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H),
       AnalyticAt ℂ (UpperHalfPlane.cuspFunction 1 g) q)
@@ -103,17 +106,9 @@ theorem circleIntegral_logDeriv_cuspFunction {g : UpperHalfPlane → ℂ} {H : �
   have hR := fdBoundaryQRadius_pos H
   have h0 : (0 : ℂ) ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H) :=
     Metric.mem_closedBall_self hR.le
-  have hfin : analyticOrderAt (UpperHalfPlane.cuspFunction 1 g) 0 ≠ ⊤ := by
-    intro htop
-    obtain ⟨ε, hε, hev⟩ := Metric.eventually_nhds_iff.mp (analyticOrderAt_eq_top.mp htop)
-    have hq0 : 0 < min (ε / 2) (fdBoundaryQRadius H) := lt_min (by linarith) hR
-    refine hgz ((min (ε / 2) (fdBoundaryQRadius H) : ℝ) : ℂ) ?_ ?_ (hev ?_)
-    · rw [Metric.mem_closedBall, dist_zero_right, Complex.norm_real,
-        Real.norm_of_nonneg hq0.le]
-      exact min_le_right _ _
-    · exact Complex.ofReal_ne_zero.mpr hq0.ne'
-    · rw [dist_zero_right, Complex.norm_real, Real.norm_of_nonneg hq0.le]
-      exact lt_of_le_of_lt (min_le_left _ _) (by linarith)
+  have hfin : analyticOrderAt (UpperHalfPlane.cuspFunction 1 g) 0 ≠ ⊤ :=
+    TauCeti.analyticOrderAt_ne_top_of_forall_ne_zero hR
+      (fun z hz hz0 => hgz z (Metric.ball_subset_closedBall hz) hz0)
   have hmer : MeromorphicOn (UpperHalfPlane.cuspFunction 1 g)
       (Metric.closedBall 0 (fdBoundaryQRadius H)) := fun q hq => (hga q hq).meromorphicAt
   have honly : ∀ z ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H),

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CuspCircle.lean
@@ -5,7 +5,12 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Complex.Periodic
+public import Mathlib.MeasureTheory.Integral.CircleIntegral
+public import Mathlib.NumberTheory.ModularForms.QExpansion
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Basic
+public import TauCeti.NumberTheory.ModularForms.Order.AtCusp
+
+import TauCeti.Analysis.Contour.Argument.Principle
 
 /-!
 # The ceiling of the boundary contour maps to a `q`-circle
@@ -80,6 +85,53 @@ theorem qParam_fdBoundary_segment5 (H t : ℝ) :
     linear_combination (2 * (Real.pi : ℂ) * H) * Complex.I_sq
   rw [hz, Periodic.qParam, fdBoundaryQRadius_def, circleMap_zero, hexp, Complex.exp_add,
     Complex.ofReal_exp]
+
+
+/-- The `q`-circle integral of the logarithmic derivative of the cusp function is `2πi`
+times the `q`-expansion order at the cusp: the cusp function is analytic on the closed
+`q`-disc and vanishes there only at the origin, so the argument principle localizes to
+the central zero, whose multiplicity is the cusp order. The order is finite because a
+cusp function vanishing identically near `0` would also vanish somewhere on the
+punctured disc. -/
+theorem circleIntegral_logDeriv_cuspFunction {g : UpperHalfPlane → ℂ} {H : ℝ}
+    (hga : ∀ q ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H),
+      AnalyticAt ℂ (UpperHalfPlane.cuspFunction 1 g) q)
+    (hgz : ∀ q ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H), q ≠ 0 →
+      UpperHalfPlane.cuspFunction 1 g q ≠ 0) :
+    circleIntegral (logDeriv (UpperHalfPlane.cuspFunction 1 g)) 0 (fdBoundaryQRadius H) =
+      2 * Real.pi * Complex.I * qExpansionOrderAtCusp 1 g := by
+  have hR := fdBoundaryQRadius_pos H
+  have h0 : (0 : ℂ) ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H) :=
+    Metric.mem_closedBall_self hR.le
+  have hfin : analyticOrderAt (UpperHalfPlane.cuspFunction 1 g) 0 ≠ ⊤ := by
+    intro htop
+    obtain ⟨ε, hε, hev⟩ := Metric.eventually_nhds_iff.mp (analyticOrderAt_eq_top.mp htop)
+    have hq0 : 0 < min (ε / 2) (fdBoundaryQRadius H) := lt_min (by linarith) hR
+    refine hgz ((min (ε / 2) (fdBoundaryQRadius H) : ℝ) : ℂ) ?_ ?_ (hev ?_)
+    · rw [Metric.mem_closedBall, dist_zero_right, Complex.norm_real,
+        Real.norm_of_nonneg hq0.le]
+      exact min_le_right _ _
+    · exact Complex.ofReal_ne_zero.mpr hq0.ne'
+    · rw [dist_zero_right, Complex.norm_real, Real.norm_of_nonneg hq0.le]
+      exact lt_of_le_of_lt (min_le_left _ _) (by linarith)
+  have hmer : MeromorphicOn (UpperHalfPlane.cuspFunction 1 g)
+      (Metric.closedBall 0 (fdBoundaryQRadius H)) := fun q hq => (hga q hq).meromorphicAt
+  have honly : ∀ z ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H),
+      meromorphicOrderAt (UpperHalfPlane.cuspFunction 1 g) z ≠ 0 → z = 0 := by
+    intro z hz hord
+    by_contra hz0
+    refine hord ?_
+    rw [(hga z hz).meromorphicOrderAt_eq,
+      (hga z hz).analyticOrderAt_eq_zero.mpr (hgz z hz hz0)]
+    rfl
+  have hn : meromorphicOrderAt (UpperHalfPlane.cuspFunction 1 g) 0 =
+      ((qExpansionOrderAtCusp 1 g : ℤ) : WithTop ℤ) := by
+    rw [(hga 0 h0).meromorphicOrderAt_eq,
+      qExpansionOrderAtCusp_eq_analyticOrderAt (hga 0 h0)]
+    lift analyticOrderAt (UpperHalfPlane.cuspFunction 1 g) 0 to ℕ using hfin with n hnn
+    simp
+  have key := Contour.argumentPrinciple_local hR hmer honly hn
+  rw [key]
 
 end ModularForm
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The `q`-circle integral of the logarithmic derivative of a cusp function is `2πi` times
the `q`-expansion order at the cusp:

- `circleIntegral_logDeriv_cuspFunction {g : ℍ → ℂ} {H : ℝ}
  (hga : AnalyticAt … on the closed q-disc) (hgz : nonvanishing off the origin) :
  circleIntegral (logDeriv (cuspFunction 1 g)) 0 (fdBoundaryQRadius H) =
  2πi * qExpansionOrderAtCusp 1 g`

The argument principle (`Contour.argumentPrinciple_local`) localizes to the central zero;
the order dictionary is `qExpansionOrderAtCusp_eq_analyticOrderAt` +
`AnalyticAt.meromorphicOrderAt_eq`. The order-finiteness is **derived, not assumed**: a
cusp function vanishing identically near `0` would also vanish somewhere on the punctured
disc, contradicting the nonvanishing hypothesis. No height hypothesis: the q-radius is
positive for every `H`.

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): third step of
the ceiling/cusp sub-chain (#2128 parametrized the ceiling as this q-circle, #2130 turned
the ceiling integrand into `logDeriv (cuspFunction)` via the chain rule; this PR
evaluates the resulting circle integral as the `ord_∞` term). What remains of the
sub-chain is the change-of-variables bridge equating the ceiling interval integral with
this circle integral.

Roadmap: ModularForms
