### PR TITLE
refactor(Sl2): decompose the invariant-vector induction

### DIFF
--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -150,21 +150,17 @@ private theorem exists_notMem_forall_lie_mem_of_le {d : ℕ}
       ∀ [FiniteDimensional K M'] (N' : LieSubmodule K L M'), finrank K M' ≤ d → N' ≠ ⊤ →
         (∀ (x : L) (m : M'), ⁅x, m⁆ ∈ N') → ∃ v : M', v ∉ N' ∧ ∀ x : L, ⁅x, v⁆ = 0)
     {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
-    [FiniteDimensional K M] {N W : LieSubmodule K L M} (hquot : finrank K (M ⧸ W) ≤ d)
+    {N W : LieSubmodule K L M} [FiniteDimensional K (M ⧸ W)] (hquot : finrank K (M ⧸ W) ≤ d)
     (hN : N ≠ ⊤) (htriv : ∀ (x : L) (m : M), ⁅x, m⁆ ∈ N) (hWle : W ≤ N) :
     ∃ v₀ : M, v₀ ∉ N ∧ ∀ x : L, ⁅x, v₀⁆ ∈ W := by
   have hNq : N.map (LieSubmodule.Quotient.mk' W) ≠ ⊤ := by
     intro hcon
-    refine hN (eq_top_iff.2 fun m _ ↦ ?_)
-    have hm : LieSubmodule.Quotient.mk' W m ∈ N.map (LieSubmodule.Quotient.mk' W) := by
-      rw [hcon]; exact LieSubmodule.mem_top _
-    obtain ⟨n, hn, hnm⟩ := hm
-    have hdiff : m - n ∈ W := by
-      have hz : (Submodule.Quotient.mk m : M ⧸ (W : Submodule K M))
-          = Submodule.Quotient.mk n := hnm.symm
-      exact (Submodule.Quotient.eq _).1 hz
-    have := N.add_mem hn (hWle hdiff)
-    simpa using this
+    refine hN ((LieSubmodule.toSubmodule_inj _ _).1 ?_)
+    have hmap : Submodule.map (W : Submodule K M).mkQ (N : Submodule K M) = ⊤ := by
+      have := congrArg LieSubmodule.toSubmodule hcon
+      rwa [LieSubmodule.toSubmodule_map, LieSubmodule.top_toSubmodule] at this
+    have hWN := (Submodule.map_mkQ_eq_top _ _).1 hmap
+    rwa [sup_eq_right.2 ((LieSubmodule.toSubmodule_le_toSubmodule _ _).2 hWle)] at hWN
   obtain ⟨w, hwmem, hwinv⟩ := ih (N.map (LieSubmodule.Quotient.mk' W)) hquot hNq
     (by
       intro x q
@@ -203,10 +199,8 @@ private theorem exists_invariant_notMem_of_forall_lie_mem {d : ℕ}
   have hv₀P : v₀ ∈ P :=
     (hPmem _).2 (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v₀))
   have hPrank : finrank K P ≤ d := by
-    have hne : v₀ ≠ 0 := fun hc ↦ hv₀N (hc ▸ N.zero_mem)
-    have hsup := Submodule.finrank_sup_add_finrank_inf_eq
-      (W : Submodule K M) (Submodule.span K {v₀})
-    rw [finrank_span_singleton hne] at hsup
+    have hsup := Submodule.finrank_sup_span_singleton
+      (p := (W : Submodule K M)) (v := v₀) (fun hc ↦ hv₀N (hWle hc))
     have hP : finrank K (((W : Submodule K M) ⊔ Submodule.span K {v₀} :
         Submodule K M) : Type _) = finrank K P := rfl
     have hw : finrank K ((W : Submodule K M) : Type _) = finrank K W := rfl

--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -78,8 +78,8 @@ omit [CharZero K] [IsAlgClosed K] in
 irreducible.** The hypothesis quantifies over Lie submodules of `M` lying below `N`, whereas
 irreducibility speaks of Lie submodules of `N` itself; `LieSubmodule.map_incl_lt_iff_lt_top`
 transports between the two. -/
-private theorem isIrreducible_of_forall_ne_bot_of_le {M : Type v} [AddCommGroup M] [Module K M]
-    [LieRingModule L M] [LieModule K L M] {N : LieSubmodule K L M} (hNbot : N ≠ ⊥)
+private theorem isIrreducible_of_forall_not_le_of_ne_bot_of_ne {M : Type v} [AddCommGroup M]
+    [Module K M] [LieRingModule L M] [LieModule K L M] {N : LieSubmodule K L M} (hNbot : N ≠ ⊥)
     (hred : ∀ W : LieSubmodule K L M, W ≠ ⊥ → W ≠ N → ¬ W ≤ N) :
     LieModule.IsIrreducible K L N := by
   have : Nontrivial N := (LieSubmodule.nontrivial_iff_ne_bot K L _).2 hNbot
@@ -278,7 +278,7 @@ private theorem exists_invariant_notMem_aux (htop : t.toLieSubalgebra K = ⊤) (
     · -- `N` is irreducible: the Casimir operator supplies the invariant vector.
       push Not at hred
       exact exists_invariant_notMem_of_isIrreducible htop hN htriv hact
-        (isIrreducible_of_forall_ne_bot_of_le hNbot hred)
+        (isIrreducible_of_forall_not_le_of_ne_bot_of_ne hNbot hred)
 
 variable {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
 

--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -181,7 +181,7 @@ private theorem exists_invariant_notMem_of_forall_lie_mem {d : ℕ}
       ∀ [FiniteDimensional K M'] (N' : LieSubmodule K L M'), finrank K M' ≤ d → N' ≠ ⊤ →
         (∀ (x : L) (m : M'), ⁅x, m⁆ ∈ N') → ∃ v : M', v ∉ N' ∧ ∀ x : L, ⁅x, v⁆ = 0)
     {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
-    [FiniteDimensional K M] {N W : LieSubmodule K L M} {v₀ : M} (hWrank : finrank K W + 1 ≤ d)
+    {N W : LieSubmodule K L M} [FiniteDimensional K W] {v₀ : M} (hWrank : finrank K W + 1 ≤ d)
     (hWle : W ≤ N) (hv₀N : v₀ ∉ N) (hv₀W : ∀ x : L, ⁅x, v₀⁆ ∈ W) :
     ∃ v : M, v ∉ N ∧ ∀ x : L, ⁅x, v⁆ = 0 := by
   have hlie : ∀ (x : L) (m : M),
@@ -199,12 +199,16 @@ private theorem exists_invariant_notMem_of_forall_lie_mem {d : ℕ}
   have hv₀P : v₀ ∈ P :=
     (hPmem _).2 (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v₀))
   have hPrank : finrank K P ≤ d := by
-    have hsup := Submodule.finrank_sup_span_singleton
-      (p := (W : Submodule K M)) (v := v₀) (fun hc ↦ hv₀N (hWle hc))
+    have hne : v₀ ≠ 0 := fun hc ↦ hv₀N (hc ▸ N.zero_mem)
+    have hle := Submodule.finrank_add_le_finrank_add_finrank
+      (W : Submodule K M) (Submodule.span K {v₀})
+    rw [finrank_span_singleton hne] at hle
     have hP : finrank K (((W : Submodule K M) ⊔ Submodule.span K {v₀} :
         Submodule K M) : Type _) = finrank K P := rfl
     have hw : finrank K ((W : Submodule K M) : Type _) = finrank K W := rfl
     omega
+  have : FiniteDimensional K P :=
+    Submodule.finiteDimensional_sup (W : Submodule K M) (Submodule.span K {v₀})
   have hWcomap : W.comap P.incl ≠ ⊤ := by
     rw [Ne, LieSubmodule.comap_incl_eq_top]
     exact fun hc ↦ hv₀N (hWle (hc hv₀P))

--- a/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
+++ b/TauCeti/Algebra/Lie/Sl2/CompleteReducibility.lean
@@ -73,6 +73,165 @@ variable {K : Type*} [Field K] [CharZero K] [IsAlgClosed K]
 variable {L : Type*} [LieRing L] [LieAlgebra K L]
 variable {h e f : L} {t : IsSl2Triple h e f}
 
+omit [CharZero K] [IsAlgClosed K] in
+/-- **A Lie submodule admitting no proper nonzero Lie submodule of the ambient module is
+irreducible.** The hypothesis quantifies over Lie submodules of `M` lying below `N`, whereas
+irreducibility speaks of Lie submodules of `N` itself; `LieSubmodule.map_incl_lt_iff_lt_top`
+transports between the two. -/
+private theorem isIrreducible_of_forall_ne_bot_of_le {M : Type v} [AddCommGroup M] [Module K M]
+    [LieRingModule L M] [LieModule K L M] {N : LieSubmodule K L M} (hNbot : N ≠ ⊥)
+    (hred : ∀ W : LieSubmodule K L M, W ≠ ⊥ → W ≠ N → ¬ W ≤ N) :
+    LieModule.IsIrreducible K L N := by
+  have : Nontrivial N := (LieSubmodule.nontrivial_iff_ne_bot K L _).2 hNbot
+  refine LieModule.IsIrreducible.mk fun N' hN' ↦ ?_
+  by_contra hne
+  have hlt : N'.map N.incl < N :=
+    LieSubmodule.map_incl_lt_iff_lt_top.2 (lt_top_iff_ne_top.2 hne)
+  have hbot : N'.map N.incl = ⊥ := by
+    by_contra hb
+    exact hred _ hb (ne_of_lt hlt) (le_of_lt hlt)
+  refine hN' ((LieSubmodule.eq_bot_iff _).2 fun z hz ↦ ?_)
+  have hmem : (z : M) ∈ N'.map N.incl := ⟨z, hz, rfl⟩
+  rw [hbot] at hmem
+  exact Subtype.ext (by simpa using hmem)
+
+/-- **The Casimir operator supplies an invariant vector outside an irreducible submodule.** If `L`
+carries `M` into an irreducible proper `N` and acts nontrivially somewhere on `M`, then `L` acts
+nontrivially on `N`, so the Casimir operator is injective on `N`. Its range lies in `N`, so it is
+not surjective on `M`, hence — `M` being finite-dimensional — not injective, and any nonzero kernel
+vector is invariant and outside `N`. -/
+private theorem exists_invariant_notMem_of_isIrreducible (htop : t.toLieSubalgebra K = ⊤)
+    {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+    [FiniteDimensional K M] {N : LieSubmodule K L M} (hN : N ≠ ⊤)
+    (htriv : ∀ (x : L) (m : M), ⁅x, m⁆ ∈ N) (hact : ∃ (x : L) (m : M), ⁅x, m⁆ ≠ 0)
+    (hirr : LieModule.IsIrreducible K L N) : ∃ v : M, v ∉ N ∧ ∀ x : L, ⁅x, v⁆ = 0 := by
+  have hactN : ∃ (x : L) (z : N), ⁅x, z⁆ ≠ 0 := by
+    by_contra hcon
+    push Not at hcon
+    obtain ⟨x, m, hm⟩ := hact
+    refine hm (lie_eq_zero_of_lie_lie_eq_zero htop (fun y z w ↦ ?_) x m)
+    have hval := congrArg (Subtype.val : N → M) (hcon y ⟨⁅z, w⁆, htriv z w⟩)
+    rw [LieSubmodule.coe_bracket] at hval
+    simpa using hval
+  have hinjN := sl2Casimir_injective (M := N) (t := t) htop hactN
+  have hinj : ∀ w : M, w ∈ N → sl2Casimir K h e f M w = 0 → w = 0 := by
+    intro w hw hw0
+    have hz : (⟨w, hw⟩ : N) = 0 := by
+      refine hinjN (Subtype.ext ?_)
+      rw [coe_sl2Casimir_lieSubmodule]
+      simpa using hw0
+    exact congrArg Subtype.val hz
+  have hrange : ∀ m : M, sl2Casimir K h e f M m ∈ N := by
+    intro m
+    rw [sl2Casimir_apply]
+    exact N.add_mem (N.add_mem (N.lie_mem (htriv f m)) (N.lie_mem (htriv e m)))
+      (N.smul_mem _ (N.lie_mem (htriv h m)))
+  have hnotinj : ¬ Function.Injective (sl2Casimir K h e f M) := by
+    intro hi
+    refine hN ((LieSubmodule.toSubmodule_inj _ _).1 ?_)
+    rw [LieSubmodule.top_toSubmodule, eq_top_iff]
+    intro m _
+    obtain ⟨w, rfl⟩ := LinearMap.injective_iff_surjective.1 hi m
+    exact hrange w
+  obtain ⟨v, hvmem, hv0⟩ := (Submodule.ne_bot_iff _).1
+    (fun hc ↦ hnotinj (LinearMap.ker_eq_bot.1 hc))
+  have hv : sl2Casimir K h e f M v = 0 := hvmem
+  refine ⟨v, fun hc ↦ hv0 (hinj v hc hv), fun x ↦ ?_⟩
+  refine hinj _ (htriv x v) ?_
+  rw [← lie_sl2Casimir t (htop ▸ LieSubalgebra.mem_top x) v, hv, lie_zero]
+
+omit [CharZero K] [IsAlgClosed K] in
+/-- **In `M ⧸ W` the inductive hypothesis produces a vector outside `N` whose brackets land in
+`W`.** This is the first half of the reducible step: the quotient by a nonzero `W ≤ N` is smaller,
+so the induction applies to it, and pulling the resulting vector back along `W`-cosets turns
+invariance in the quotient into `⁅L, v₀⁆ ⊆ W` upstairs. -/
+private theorem exists_notMem_forall_lie_mem_of_le {d : ℕ}
+    (ih : ∀ {M' : Type v} [AddCommGroup M'] [Module K M'] [LieRingModule L M'] [LieModule K L M'],
+      ∀ [FiniteDimensional K M'] (N' : LieSubmodule K L M'), finrank K M' ≤ d → N' ≠ ⊤ →
+        (∀ (x : L) (m : M'), ⁅x, m⁆ ∈ N') → ∃ v : M', v ∉ N' ∧ ∀ x : L, ⁅x, v⁆ = 0)
+    {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+    [FiniteDimensional K M] {N W : LieSubmodule K L M} (hquot : finrank K (M ⧸ W) ≤ d)
+    (hN : N ≠ ⊤) (htriv : ∀ (x : L) (m : M), ⁅x, m⁆ ∈ N) (hWle : W ≤ N) :
+    ∃ v₀ : M, v₀ ∉ N ∧ ∀ x : L, ⁅x, v₀⁆ ∈ W := by
+  have hNq : N.map (LieSubmodule.Quotient.mk' W) ≠ ⊤ := by
+    intro hcon
+    refine hN (eq_top_iff.2 fun m _ ↦ ?_)
+    have hm : LieSubmodule.Quotient.mk' W m ∈ N.map (LieSubmodule.Quotient.mk' W) := by
+      rw [hcon]; exact LieSubmodule.mem_top _
+    obtain ⟨n, hn, hnm⟩ := hm
+    have hdiff : m - n ∈ W := by
+      have hz : (Submodule.Quotient.mk m : M ⧸ (W : Submodule K M))
+          = Submodule.Quotient.mk n := hnm.symm
+      exact (Submodule.Quotient.eq _).1 hz
+    have := N.add_mem hn (hWle hdiff)
+    simpa using this
+  obtain ⟨w, hwmem, hwinv⟩ := ih (N.map (LieSubmodule.Quotient.mk' W)) hquot hNq
+    (by
+      intro x q
+      induction q using Quotient.inductionOn' with
+      | h m => exact ⟨⁅x, m⁆, htriv x m, rfl⟩)
+  obtain ⟨v₀, rfl⟩ := LieSubmodule.Quotient.surjective_mk' W w
+  refine ⟨v₀, fun hc ↦ hwmem ⟨v₀, hc, rfl⟩, fun x ↦ ?_⟩
+  rw [← LieSubmodule.Quotient.mk_eq_zero]
+  simpa using hwinv x
+
+omit [CharZero K] [IsAlgClosed K] in
+/-- **A vector outside `N` whose brackets land in `W` upgrades to a genuinely invariant one.** This
+is the second half of the reducible step. The span `W + K v₀` is carried into `W` by `L`, so it is a
+Lie submodule; it has dimension at most `finrank W + 1`, so the induction applies to it with `W`
+pulled back inside, and the vector it returns is invariant in `M` and still outside `N`. -/
+private theorem exists_invariant_notMem_of_forall_lie_mem {d : ℕ}
+    (ih : ∀ {M' : Type v} [AddCommGroup M'] [Module K M'] [LieRingModule L M'] [LieModule K L M'],
+      ∀ [FiniteDimensional K M'] (N' : LieSubmodule K L M'), finrank K M' ≤ d → N' ≠ ⊤ →
+        (∀ (x : L) (m : M'), ⁅x, m⁆ ∈ N') → ∃ v : M', v ∉ N' ∧ ∀ x : L, ⁅x, v⁆ = 0)
+    {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
+    [FiniteDimensional K M] {N W : LieSubmodule K L M} {v₀ : M} (hWrank : finrank K W + 1 ≤ d)
+    (hWle : W ≤ N) (hv₀N : v₀ ∉ N) (hv₀W : ∀ x : L, ⁅x, v₀⁆ ∈ W) :
+    ∃ v : M, v ∉ N ∧ ∀ x : L, ⁅x, v⁆ = 0 := by
+  have hlie : ∀ (x : L) (m : M),
+      m ∈ (W : Submodule K M) ⊔ Submodule.span K {v₀} → ⁅x, m⁆ ∈ W := by
+    intro x m hm
+    obtain ⟨y, hy, z, hz, rfl⟩ := Submodule.mem_sup.1 hm
+    obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.1 hz
+    rw [lie_add, lie_smul]
+    exact W.add_mem (W.lie_mem hy) (W.smul_mem c (hv₀W x))
+  let P : LieSubmodule K L M :=
+    { __ := (W : Submodule K M) ⊔ Submodule.span K {v₀}
+      lie_mem := fun {x m} hm ↦ Submodule.mem_sup_left (hlie x m hm) }
+  have hPmem : ∀ m : M, m ∈ P ↔ m ∈ (W : Submodule K M) ⊔ Submodule.span K {v₀} :=
+    fun _ ↦ Iff.rfl
+  have hv₀P : v₀ ∈ P :=
+    (hPmem _).2 (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v₀))
+  have hPrank : finrank K P ≤ d := by
+    have hne : v₀ ≠ 0 := fun hc ↦ hv₀N (hc ▸ N.zero_mem)
+    have hsup := Submodule.finrank_sup_add_finrank_inf_eq
+      (W : Submodule K M) (Submodule.span K {v₀})
+    rw [finrank_span_singleton hne] at hsup
+    have hP : finrank K (((W : Submodule K M) ⊔ Submodule.span K {v₀} :
+        Submodule K M) : Type _) = finrank K P := rfl
+    have hw : finrank K ((W : Submodule K M) : Type _) = finrank K W := rfl
+    omega
+  have hWcomap : W.comap P.incl ≠ ⊤ := by
+    rw [Ne, LieSubmodule.comap_incl_eq_top]
+    exact fun hc ↦ hv₀N (hWle (hc hv₀P))
+  obtain ⟨p, hpmem, hpinv⟩ := ih (W.comap P.incl) hPrank hWcomap
+    (fun x q ↦ hlie x (q : M) ((hPmem _).1 q.2))
+  refine ⟨(p : M), ?_, fun x ↦ ?_⟩
+  · intro hcon
+    obtain ⟨y, hy, z, hz, hyz⟩ := Submodule.mem_sup.1 ((hPmem _).1 p.2)
+    obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.1 hz
+    rcases eq_or_ne c 0 with rfl | hc0
+    · exact hpmem (by simpa [← hyz] using hy)
+    · refine hv₀N ?_
+      have hcv : c • v₀ ∈ N := by
+        have hsub : c • v₀ = (p : M) - y := by rw [← hyz]; abel
+        rw [hsub]
+        exact N.sub_mem hcon (hWle hy)
+      simpa [hc0] using N.smul_mem c⁻¹ hcv
+  · have hp := hpinv x
+    rw [← LieSubmodule.coe_bracket, hp]
+    rfl
+
 /-- The inductive form of `TauCeti.exists_invariant_notMem`, with the dimension of the ambient
 module bounded by an explicit `d`, since the induction changes the module. -/
 private theorem exists_invariant_notMem_aux (htop : t.toLieSubalgebra K = ⊤) (d : ℕ) :
@@ -116,121 +275,12 @@ private theorem exists_invariant_notMem_aux (htop : t.toLieSubalgebra K = ⊤) (
         have hq : finrank K (M ⧸ (W : Submodule K M)) = finrank K (M ⧸ W) := rfl
         have hw : finrank K ((W : Submodule K M) : Type _) = finrank K W := rfl
         omega
-      have hNq : N.map (LieSubmodule.Quotient.mk' W) ≠ ⊤ := by
-        intro hcon
-        refine hN (eq_top_iff.2 fun m _ ↦ ?_)
-        have hm : LieSubmodule.Quotient.mk' W m ∈ N.map (LieSubmodule.Quotient.mk' W) := by
-          rw [hcon]; exact LieSubmodule.mem_top _
-        obtain ⟨n, hn, hnm⟩ := hm
-        have hdiff : m - n ∈ W := by
-          have hz : (Submodule.Quotient.mk m : M ⧸ (W : Submodule K M))
-              = Submodule.Quotient.mk n := hnm.symm
-          exact (Submodule.Quotient.eq _).1 hz
-        have := N.add_mem hn (hWle hdiff)
-        simpa using this
-      obtain ⟨w, hwmem, hwinv⟩ := ih (N.map (LieSubmodule.Quotient.mk' W)) hquot hNq
-        (by
-          intro x q
-          induction q using Quotient.inductionOn' with
-          | h m => exact ⟨⁅x, m⁆, htriv x m, rfl⟩)
-      obtain ⟨v₀, rfl⟩ := LieSubmodule.Quotient.surjective_mk' W w
-      have hv₀N : v₀ ∉ N := fun hc ↦ hwmem ⟨v₀, hc, rfl⟩
-      have hv₀W : ∀ x : L, ⁅x, v₀⁆ ∈ W := by
-        intro x
-        rw [← LieSubmodule.Quotient.mk_eq_zero]
-        simpa using hwinv x
-      have hlie : ∀ (x : L) (m : M),
-          m ∈ (W : Submodule K M) ⊔ Submodule.span K {v₀} → ⁅x, m⁆ ∈ W := by
-        intro x m hm
-        obtain ⟨y, hy, z, hz, rfl⟩ := Submodule.mem_sup.1 hm
-        obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.1 hz
-        rw [lie_add, lie_smul]
-        exact W.add_mem (W.lie_mem hy) (W.smul_mem c (hv₀W x))
-      let P : LieSubmodule K L M :=
-        { __ := (W : Submodule K M) ⊔ Submodule.span K {v₀}
-          lie_mem := fun {x m} hm ↦ Submodule.mem_sup_left (hlie x m hm) }
-      have hPmem : ∀ m : M, m ∈ P ↔ m ∈ (W : Submodule K M) ⊔ Submodule.span K {v₀} :=
-        fun _ ↦ Iff.rfl
-      have hv₀P : v₀ ∈ P :=
-        (hPmem _).2 (Submodule.mem_sup_right (Submodule.mem_span_singleton_self v₀))
-      have hPrank : finrank K P ≤ d := by
-        have hne : v₀ ≠ 0 := fun hc ↦ hv₀N (hc ▸ N.zero_mem)
-        have hsup := Submodule.finrank_sup_add_finrank_inf_eq
-          (W : Submodule K M) (Submodule.span K {v₀})
-        rw [finrank_span_singleton hne] at hsup
-        have hP : finrank K (((W : Submodule K M) ⊔ Submodule.span K {v₀} :
-            Submodule K M) : Type _) = finrank K P := rfl
-        have hw : finrank K ((W : Submodule K M) : Type _) = finrank K W := rfl
-        omega
-      have hWcomap : W.comap P.incl ≠ ⊤ := by
-        rw [Ne, LieSubmodule.comap_incl_eq_top]
-        exact fun hc ↦ hv₀N (hWle (hc hv₀P))
-      obtain ⟨p, hpmem, hpinv⟩ := ih (W.comap P.incl) hPrank hWcomap
-        (fun x q ↦ hlie x (q : M) ((hPmem _).1 q.2))
-      refine ⟨(p : M), ?_, fun x ↦ ?_⟩
-      · intro hcon
-        obtain ⟨y, hy, z, hz, hyz⟩ := Submodule.mem_sup.1 ((hPmem _).1 p.2)
-        obtain ⟨c, rfl⟩ := Submodule.mem_span_singleton.1 hz
-        rcases eq_or_ne c 0 with rfl | hc0
-        · exact hpmem (by simpa [← hyz] using hy)
-        · refine hv₀N ?_
-          have hcv : c • v₀ ∈ N := by
-            have hsub : c • v₀ = (p : M) - y := by rw [← hyz]; abel
-            rw [hsub]
-            exact N.sub_mem hcon (hWle hy)
-          simpa [hc0] using N.smul_mem c⁻¹ hcv
-      · have hp := hpinv x
-        rw [← LieSubmodule.coe_bracket, hp]
-        rfl
+      obtain ⟨v₀, hv₀N, hv₀W⟩ := exists_notMem_forall_lie_mem_of_le ih hquot hN htriv hWle
+      exact exists_invariant_notMem_of_forall_lie_mem ih (by omega) hWle hv₀N hv₀W
     · -- `N` is irreducible: the Casimir operator supplies the invariant vector.
       push Not at hred
-      have hNtriv : Nontrivial N := (LieSubmodule.nontrivial_iff_ne_bot K L _).2 hNbot
-      have hirr : LieModule.IsIrreducible K L N := by
-        refine LieModule.IsIrreducible.mk fun N' hN' ↦ ?_
-        by_contra hne
-        have hlt : N'.map N.incl < N :=
-          LieSubmodule.map_incl_lt_iff_lt_top.2 (lt_top_iff_ne_top.2 hne)
-        have hbot : N'.map N.incl = ⊥ := by
-          by_contra hb
-          exact hred _ hb (ne_of_lt hlt) (le_of_lt hlt)
-        refine hN' ((LieSubmodule.eq_bot_iff _).2 fun z hz ↦ ?_)
-        have hmem : (z : M) ∈ N'.map N.incl := ⟨z, hz, rfl⟩
-        rw [hbot] at hmem
-        exact Subtype.ext (by simpa using hmem)
-      have hactN : ∃ (x : L) (z : N), ⁅x, z⁆ ≠ 0 := by
-        by_contra hcon
-        push Not at hcon
-        obtain ⟨x, m, hm⟩ := hact
-        refine hm (lie_eq_zero_of_lie_lie_eq_zero htop (fun y z w ↦ ?_) x m)
-        have hval := congrArg (Subtype.val : N → M) (hcon y ⟨⁅z, w⁆, htriv z w⟩)
-        rw [LieSubmodule.coe_bracket] at hval
-        simpa using hval
-      have hinjN := sl2Casimir_injective (M := N) (t := t) htop hactN
-      have hinj : ∀ w : M, w ∈ N → sl2Casimir K h e f M w = 0 → w = 0 := by
-        intro w hw hw0
-        have hz : (⟨w, hw⟩ : N) = 0 := by
-          refine hinjN (Subtype.ext ?_)
-          rw [coe_sl2Casimir_lieSubmodule]
-          simpa using hw0
-        exact congrArg Subtype.val hz
-      have hrange : ∀ m : M, sl2Casimir K h e f M m ∈ N := by
-        intro m
-        rw [sl2Casimir_apply]
-        exact N.add_mem (N.add_mem (N.lie_mem (htriv f m)) (N.lie_mem (htriv e m)))
-          (N.smul_mem _ (N.lie_mem (htriv h m)))
-      have hnotinj : ¬ Function.Injective (sl2Casimir K h e f M) := by
-        intro hi
-        refine hN ((LieSubmodule.toSubmodule_inj _ _).1 ?_)
-        rw [LieSubmodule.top_toSubmodule, eq_top_iff]
-        intro m _
-        obtain ⟨w, rfl⟩ := LinearMap.injective_iff_surjective.1 hi m
-        exact hrange w
-      obtain ⟨v, hvmem, hv0⟩ := (Submodule.ne_bot_iff _).1
-        (fun hc ↦ hnotinj (LinearMap.ker_eq_bot.1 hc))
-      have hv : sl2Casimir K h e f M v = 0 := hvmem
-      refine ⟨v, fun hc ↦ hv0 (hinj v hc hv), fun x ↦ ?_⟩
-      refine hinj _ (htriv x v) ?_
-      rw [← lie_sl2Casimir t (htop ▸ LieSubalgebra.mem_top x) v, hv, lie_zero]
+      exact exists_invariant_notMem_of_isIrreducible htop hN htriv hact
+        (isIrreducible_of_forall_ne_bot_of_le hNbot hred)
 
 variable {M : Type v} [AddCommGroup M] [Module K M] [LieRingModule L M] [LieModule K L M]
 


### PR DESCRIPTION
`exists_invariant_notMem_aux` (`Algebra/Lie/Sl2/CompleteReducibility.lean`) had a **153-line**
body, the longest uncontended proof in the library. Its three phases are now private helpers
stated above it, each taking only what its own proof uses rather than the parent's context.

Main proof: **153 → 44 lines**. One file, no public declaration changed.

| helper | proves |
|---|---|
| `isIrreducible_of_forall_ne_bot_of_le` | a Lie submodule admitting no proper nonzero Lie submodule of `M` below it is irreducible |
| `exists_invariant_notMem_of_isIrreducible` | the Casimir step: for irreducible proper `N`, the Casimir operator is injective on `N` with range in `N`, so it has a nonzero kernel vector, which is invariant and outside `N` |
| `exists_notMem_forall_lie_mem_of_le` | first half of the reducible step: the inductive hypothesis in `M ⧸ W` yields `v₀ ∉ N` with `⁅L, v₀⁆ ⊆ W` |
| `exists_invariant_notMem_of_forall_lie_mem` | second half: the inductive hypothesis in `W + K v₀` upgrades `v₀` to a genuinely invariant vector |

Every new helper is at most 46 lines.

The two halves of the reducible step take the inductive hypothesis as an ordinary argument, so
the induction stays in the parent and the helpers are ordinary lemmas rather than a
mutually-recursive rewrite.

Hypotheses are at their weakest usable form rather than the parent's:

- three of the four helpers use neither `CharZero K` nor `IsAlgClosed K` — only the Casimir step
  needs the field hypotheses — so they carry `omit`;
- neither half of the reducible step needs ambient finite-dimensionality:
  `exists_notMem_forall_lie_mem_of_le` takes `[FiniteDimensional K (M ⧸ W)]` and
  `exists_invariant_notMem_of_forall_lie_mem` takes `[FiniteDimensional K W]`;
- the rank side-conditions go in as `finrank K (M ⧸ W) ≤ d` and `finrank K W + 1 ≤ d`, not as the
  ambient bound together with the facts those are derived from;
- the first half needs `W ≤ N` but not `W ≠ N`, and neither half needs `htop`, which is already
  baked into the inductive hypothesis.

Everything the extraction needs comes from Mathlib: `Submodule.map_mkQ_eq_top` with
`LieSubmodule.toSubmodule_map` for the quotient-image step, and
`Submodule.finrank_add_le_finrank_add_finrank` with `finrank_span_singleton` for the rank of
`W ⊔ K v₀` — the latter pair requiring only the two summands to be finite-dimensional, which is
what lets the ambient instance go.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean, against the current mathlib pin.

Roadmap: RepresentationTheory