### PR TITLE
feat(ModularForms): restriction to the imaginary axis

### DIFF
--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -20,8 +20,9 @@ restriction,
 
 The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
 that the restriction is real-valued, real and positive, or real and eventually positive along
-`atTop`. `RealOnImagAxis` is closed under all the pointwise algebraic operations; the two
-positivity predicates are closed under the operations that preserve strict positivity —
+`atTop`. `RealOnImagAxis` is closed under constants, negation, addition, subtraction,
+multiplication, multiplication by a real scalar, and natural powers; the two positivity
+predicates are closed under the operations that preserve strict positivity —
 positive constants, addition, multiplication, multiplication by a positive real scalar, and
 natural powers — but not under negation or subtraction. The closure lemmas are tagged
 `@[fun_prop]`, except `PosOnImagAxis.const` and `EventuallyPosOnImagAxis.const`, whose
@@ -40,7 +41,8 @@ constant is not determined by the goal.
 * `UpperHalfPlane.resToImagAxis_zero`, `_add`, `_neg`, `_sub`, `_mul`, `_smul`: the
   restriction commutes with the pointwise operations, unconditionally.
 * `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
-  `t > 0` when `F` is differentiable as a map of manifolds at the corresponding point.
+  `t > 0` when `F ∘ ofComplex` is, and `differentiableAt_resToImagAxis_of_mDiffAt`: the same
+  from manifold differentiability at the corresponding point.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/Modularforms/ResToImagAxis.lean`, Chris Birkbeck,

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -124,10 +124,12 @@ theorem resToImagAxis_smul (c : ℂ) (F : ℍ → ℂ) :
 @[simp]
 theorem resToImagAxis_real_smul (c : ℝ) (F : ℍ → ℂ) :
     resToImagAxis (c • F) = c • resToImagAxis F := by
-  funext t
-  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+  simpa [Complex.real_smul] using resToImagAxis_smul (c : ℂ) F
 
-/-- Powers need `0 < t`: at `t ≤ 0` the restriction of `F ^ 0 = 1` is `0`, not `1`. -/
+/-- Powers need `0 < t`: at `t ≤ 0` the restriction of `F ^ 0 = 1` is `0`, not `1`.
+
+Not `@[simp]`: `resToImagAxis_of_pos` together with `Pi.pow_apply` already reduces the
+left-hand side, so the attribute would be a duplicate (the `simpNF` linter rejects it). -/
 theorem resToImagAxis_pow (F : ℍ → ℂ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
     resToImagAxis (F ^ n) t = resToImagAxis F t ^ n := by
   simp [resToImagAxis_of_pos _ ht]

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -12,17 +12,17 @@ public import Mathlib.Geometry.Manifold.Notation
 # Restriction of a function on the upper half-plane to the imaginary axis
 
 The Mellin transform computing the completed L-function of a modular form integrates the
-form along the positive imaginary axis: Mathlib's `ModularForm.Λ_eq_mellin` reads
-`Λ f = mellin (fun t ↦ f (ofComplex (I * t)))`. This file names that restriction,
+form along the positive imaginary axis: Mathlib's `CuspForm.Λ_eq_mellin` reads
+`Λ hk f = mellin (fun t ↦ f (ofComplex (I * t)))` for a cusp form. This file names that
+restriction,
 `resToImagAxis F t = F (i t)` for `t > 0` (and `0` otherwise, since `i t ∈ ℍ` fails for
 `t ≤ 0`), for an arbitrary `F : ℍ → ℂ`.
 
 The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
 that the restriction is real-valued, real and positive, or real and eventually positive along
-`atTop`. Each is closed under the pointwise algebraic operations. The closure lemmas under
-`+`, `*`, `•` and `^` are tagged `@[fun_prop]`; the constant lemmas of `PosOnImagAxis` and
-`EventuallyPosOnImagAxis` are not, since they take a positivity hypothesis on the constant
-that has to be supplied by hand.
+`atTop`. Each is closed under the pointwise algebraic operations, and the closure lemmas are
+tagged `@[fun_prop]` — except `PosOnImagAxis.const` and `EventuallyPosOnImagAxis.const`,
+whose constant is not determined by the goal.
 
 ## Main definitions
 
@@ -33,7 +33,9 @@ that has to be supplied by hand.
 ## Main results
 
 * `UpperHalfPlane.resToImagAxis_of_pos`, `resToImagAxis_of_nonpos`: the characteristic
-  equations of the restriction, which every proof below rewrites with.
+  equations of the restriction.
+* `UpperHalfPlane.resToImagAxis_add`, `_neg`, `_sub`, `_mul`, `_smul`: the restriction
+  commutes with the pointwise operations, unconditionally.
 * `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
   `t > 0` when `F` is differentiable as a map of manifolds at the corresponding point.
 
@@ -70,6 +72,47 @@ theorem resToImagAxis_of_pos (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t) :
 theorem resToImagAxis_of_nonpos (F : ℍ → ℂ) {t : ℝ} (ht : t ≤ 0) :
     resToImagAxis F t = 0 := dif_neg (not_lt.mpr ht)
 
+/-! ### The restriction commutes with the pointwise operations
+
+Each identity is unconditional in `t`: off the positive axis both sides are `0`.
+-/
+
+@[simp]
+theorem resToImagAxis_neg (F : ℍ → ℂ) : resToImagAxis (-F) = -resToImagAxis F := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+@[simp]
+theorem resToImagAxis_add (F G : ℍ → ℂ) :
+    resToImagAxis (F + G) = resToImagAxis F + resToImagAxis G := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+@[simp]
+theorem resToImagAxis_sub (F G : ℍ → ℂ) :
+    resToImagAxis (F - G) = resToImagAxis F - resToImagAxis G := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+@[simp]
+theorem resToImagAxis_mul (F G : ℍ → ℂ) :
+    resToImagAxis (F * G) = resToImagAxis F * resToImagAxis G := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+@[simp]
+theorem resToImagAxis_smul (c : ℝ) (F : ℍ → ℂ) :
+    resToImagAxis (c • F) = c • resToImagAxis F := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+/-- Powers need `0 < t`: at `t ≤ 0` the restriction of `F ^ 0 = 1` is `0`, not `1`. -/
+theorem resToImagAxis_pow (F : ℍ → ℂ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
+    resToImagAxis (F ^ n) t = resToImagAxis F t ^ n := by
+  simp [resToImagAxis_of_pos _ ht]
+
+/-! ### Real-valuedness, positivity, and eventual positivity -/
+
 /-- `F` is real-valued on the positive imaginary axis. -/
 @[fun_prop]
 def RealOnImagAxis (F : ℍ → ℂ) : Prop :=
@@ -87,21 +130,25 @@ def EventuallyPosOnImagAxis (F : ℍ → ℂ) : Prop :=
 
 /-! ### Differentiability -/
 
-/-- The restriction is real-differentiable at `t > 0` whenever `F` is differentiable as a map
-of manifolds at the corresponding point: the restriction is the composite of `F` with
-`t ↦ i t`, so only differentiability there is used. -/
-@[fun_prop]
+/-- The restriction is real-differentiable at `t > 0` whenever `F ∘ ofComplex` is: the
+restriction is its composite with `t ↦ i t`, so only real differentiability at the
+corresponding point is used — holomorphy is not needed. -/
 theorem differentiableAt_resToImagAxis (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t)
-    (hF : MDiffAt F ⟨Complex.I * t, by simpa using ht⟩) :
+    (hF : DifferentiableAt ℝ (fun z : ℂ ↦ F (ofComplex z)) (Complex.I * t)) :
     DifferentiableAt ℝ (resToImagAxis F) t := by
-  rw [mdifferentiableAt_iff] at hF
   have h_diff : DifferentiableAt ℝ (fun t : ℝ ↦ F (ofComplex (Complex.I * t))) t := by
-    convert hF.restrictScalars ℝ |>.comp t
-      (DifferentiableAt.const_mul ofRealCLM.differentiableAt _) using 1
-    all_goals try rfl
+    have hmul : DifferentiableAt ℝ (fun s : ℝ ↦ Complex.I * s) t := by fun_prop
+    simpa only [Function.comp_def] using hF.comp t hmul
   refine h_diff.congr_of_eventuallyEq ?_
   filter_upwards [lt_mem_nhds ht] with s hs
   rw [resToImagAxis_of_pos F hs, ofComplex_apply_of_im_pos (by simp [hs])]
+
+/-- The manifold-differentiable case, which is how modular forms supply the hypothesis. -/
+@[fun_prop]
+theorem differentiableAt_resToImagAxis_of_mDiffAt (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t)
+    (hF : MDiffAt F ⟨Complex.I * t, by simpa using ht⟩) :
+    DifferentiableAt ℝ (resToImagAxis F) t :=
+  differentiableAt_resToImagAxis F ht ((mdifferentiableAt_iff.mp hF).restrictScalars ℝ)
 
 /-! ### Real-valuedness is preserved by the algebraic operations -/
 
@@ -110,8 +157,7 @@ namespace RealOnImagAxis
 /-- A real constant is real-valued on the imaginary axis. -/
 @[fun_prop]
 theorem const (c : ℝ) : RealOnImagAxis (fun _ ↦ (c : ℂ)) := fun t ht ↦ by
-  rw [resToImagAxis_of_pos _ ht]
-  simp
+  simp [resToImagAxis_of_pos _ ht]
 
 /-- The zero function is real-valued on the imaginary axis. -/
 @[fun_prop]
@@ -124,18 +170,13 @@ theorem one : RealOnImagAxis (fun _ ↦ 1) := by simpa using const 1
 /-- Negation preserves real-valuedness on the imaginary axis. -/
 @[fun_prop]
 theorem neg {F : ℍ → ℂ} (hF : RealOnImagAxis F) : RealOnImagAxis (-F) := fun t ht ↦ by
-  have hf := hF t ht
-  rw [resToImagAxis_of_pos _ ht] at hf ⊢
-  simp [hf]
+  simp [hF t ht]
 
 /-- Addition preserves real-valuedness on the imaginary axis. -/
 @[fun_prop]
 theorem add {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
     RealOnImagAxis (F + G) := fun t ht ↦ by
-  have hf := hF t ht
-  have hg := hG t ht
-  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-  simp [hf, hg]
+  simp [hF t ht, hG t ht]
 
 /-- Subtraction preserves real-valuedness on the imaginary axis. -/
 @[fun_prop]
@@ -146,18 +187,12 @@ theorem sub {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) 
 @[fun_prop]
 theorem mul {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
     RealOnImagAxis (F * G) := fun t ht ↦ by
-  have hf := hF t ht
-  have hg := hG t ht
-  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-  simp [Complex.mul_im, hf, hg]
+  simp [Complex.mul_im, hF t ht, hG t ht]
 
 /-- Real scalar multiplication preserves real-valuedness on the imaginary axis. -/
 @[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
-  fun t ht ↦ by
-  have hf := hF t ht
-  rw [resToImagAxis_of_pos _ ht] at hf ⊢
-  simp [Complex.real_smul, Complex.mul_im, hf]
+theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
+  fun t ht ↦ by simp [Complex.real_smul, Complex.mul_im, hF t ht]
 
 /-- Natural powers preserve real-valuedness on the imaginary axis. -/
 @[fun_prop]
@@ -174,7 +209,7 @@ namespace PosOnImagAxis
 
 /-- A positive real constant is positive on the imaginary axis. -/
 theorem const {c : ℝ} (hc : 0 < c) : PosOnImagAxis (fun _ ↦ (c : ℂ)) :=
-  ⟨RealOnImagAxis.const c, fun t ht ↦ by rw [resToImagAxis_of_pos _ ht]; simpa using hc⟩
+  ⟨RealOnImagAxis.const c, fun t ht ↦ by simpa [resToImagAxis_of_pos _ ht] using hc⟩
 
 /-- The constant function `1` is positive on the imaginary axis. -/
 @[fun_prop]
@@ -184,11 +219,7 @@ theorem one : PosOnImagAxis (fun _ ↦ 1) := by simpa using const one_pos
 @[fun_prop]
 theorem add {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
     PosOnImagAxis (F + G) :=
-  ⟨hF.1.add hG.1, fun t ht ↦ by
-    have hf := hF.2 t ht
-    have hg := hG.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-    simpa using add_pos hf hg⟩
+  ⟨hF.1.add hG.1, fun t ht ↦ by simpa using add_pos (hF.2 t ht) (hG.2 t ht)⟩
 
 /-- Multiplication preserves positivity on the imaginary axis: the two restrictions are real
 there, so the real part of the product is the product of the real parts. -/
@@ -196,21 +227,14 @@ there, so the real part of the product is the product of the real parts. -/
 theorem mul {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
     PosOnImagAxis (F * G) :=
   ⟨hF.1.mul hG.1, fun t ht ↦ by
-    have hfi := hF.1 t ht
-    have hgi := hG.1 t ht
-    have hfr := hF.2 t ht
-    have hgr := hG.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hfi hgi hfr hgr ⊢
-    simpa [Complex.mul_re, hfi, hgi] using mul_pos hfr hgr⟩
+    simpa [Complex.mul_re, hF.1 t ht, hG.1 t ht] using mul_pos (hF.2 t ht) (hG.2 t ht)⟩
 
 /-- Positive scalar multiplication preserves positivity on the imaginary axis. -/
 @[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
+theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
     PosOnImagAxis (c • F) :=
-  ⟨hF.1.smul, fun t ht ↦ by
-    have hf := hF.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hf ⊢
-    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
+  ⟨hF.1.const_smul, fun t ht ↦ by
+    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc (hF.2 t ht)⟩
 
 /-- Natural powers preserve positivity on the imaginary axis. -/
 @[fun_prop]
@@ -227,24 +251,24 @@ namespace EventuallyPosOnImagAxis
 
 /-- Positivity everywhere implies positivity far out. -/
 @[fun_prop]
-theorem of_pos {F : ℍ → ℂ} (hF : PosOnImagAxis F) : EventuallyPosOnImagAxis F :=
+theorem _root_.UpperHalfPlane.PosOnImagAxis.eventuallyPos {F : ℍ → ℂ}
+    (hF : PosOnImagAxis F) : EventuallyPosOnImagAxis F :=
   ⟨hF.1, by filter_upwards [eventually_gt_atTop (0 : ℝ)] with t ht using hF.2 t ht⟩
 
 /-- The constant function `1` is eventually positive on the imaginary axis. -/
 @[fun_prop]
-theorem one : EventuallyPosOnImagAxis (fun _ ↦ 1) := of_pos PosOnImagAxis.one
+theorem one : EventuallyPosOnImagAxis (fun _ ↦ 1) := PosOnImagAxis.one.eventuallyPos
 
 /-- A positive real constant is eventually positive on the imaginary axis. -/
 theorem const {c : ℝ} (hc : 0 < c) : EventuallyPosOnImagAxis (fun _ ↦ (c : ℂ)) :=
-  of_pos (PosOnImagAxis.const hc)
+  (PosOnImagAxis.const hc).eventuallyPos
 
 /-- Addition preserves eventual positivity on the imaginary axis. -/
 @[fun_prop]
 theorem add {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
     EventuallyPosOnImagAxis (F + G) :=
   ⟨hF.1.add hG.1, by
-    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
-    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+    filter_upwards [hF.2, hG.2] with t hf hg
     simpa using add_pos hf hg⟩
 
 /-- Multiplication preserves eventual positivity on the imaginary axis. -/
@@ -253,18 +277,14 @@ theorem mul {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : Eventuall
     EventuallyPosOnImagAxis (F * G) :=
   ⟨hF.1.mul hG.1, by
     filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
-    have hfi := hF.1 t ht
-    have hgi := hG.1 t ht
-    rw [resToImagAxis_of_pos _ ht] at hfi hgi hf hg ⊢
-    simpa [Complex.mul_re, hfi, hgi] using mul_pos hf hg⟩
+    simpa [Complex.mul_re, hF.1 t ht, hG.1 t ht] using mul_pos hf hg⟩
 
 /-- Positive scalar multiplication preserves eventual positivity on the imaginary axis. -/
 @[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) (hc : 0 < c) :
+theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) (hc : 0 < c) :
     EventuallyPosOnImagAxis (c • F) :=
-  ⟨hF.1.smul, by
-    filter_upwards [hF.2, eventually_gt_atTop (0 : ℝ)] with t hf ht
-    rw [resToImagAxis_of_pos _ ht] at hf ⊢
+  ⟨hF.1.const_smul, by
+    filter_upwards [hF.2] with t hf
     simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
 
 /-- Natural powers preserve eventual positivity on the imaginary axis. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -120,9 +120,9 @@ theorem resToImagAxis_smul (c : ℂ) (F : ℍ → ℂ) :
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
-/-- The real-scalar form of `resToImagAxis_smul`. Private: it is a thin specialization with
-no consumers outside this file, but the three `const_smul` closure lemmas below would
-otherwise repeat its two-line proof. -/
+/-- The real-scalar form of `resToImagAxis_smul`: the complex-scalar law does not fire on
+`(c : ℝ) • F`. Private, since its three consumers — `RealOnImagAxis.const_smul`,
+`PosOnImagAxis.const_smul` and `EventuallyPosOnImagAxis.const_smul` — are all in this file. -/
 @[simp]
 private theorem resToImagAxis_real_smul (c : ℝ) (F : ℍ → ℂ) :
     resToImagAxis (c • F) = c • resToImagAxis F := by
@@ -209,7 +209,9 @@ theorem mul {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) 
 /-- Real scalar multiplication preserves real-valuedness on the imaginary axis. -/
 @[fun_prop]
 theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
-  fun t ht ↦ by simp [Complex.real_smul, Complex.mul_im, hF t ht]
+  fun t ht ↦ by
+  rw [resToImagAxis_real_smul]
+  simp [Complex.real_smul, Complex.mul_im, hF t ht]
 
 /-- Natural powers preserve real-valuedness on the imaginary axis. -/
 @[fun_prop]
@@ -251,6 +253,7 @@ theorem mul {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
 theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
     PosOnImagAxis (c • F) :=
   ⟨hF.1.const_smul, fun t ht ↦ by
+    rw [resToImagAxis_real_smul]
     simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc (hF.2 t ht)⟩
 
 /-- Natural powers preserve positivity on the imaginary axis. -/
@@ -302,6 +305,7 @@ theorem const_smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) 
     EventuallyPosOnImagAxis (c • F) :=
   ⟨hF.1.const_smul, by
     filter_upwards [hF.2] with t hf
+    rw [resToImagAxis_real_smul]
     simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
 
 /-- Natural powers preserve eventual positivity on the imaginary axis. -/

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -1,0 +1,280 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
+public import Mathlib.Geometry.Manifold.Notation
+
+/-!
+# Restriction of a function on the upper half-plane to the imaginary axis
+
+The Mellin transform computing the completed L-function of a modular form integrates the
+form along the positive imaginary axis: Mathlib's `ModularForm.Λ_eq_mellin` reads
+`Λ f = mellin (fun t ↦ f (ofComplex (I * t)))`. This file names that restriction,
+`resToImagAxis F t = F (i t)` for `t > 0` (and `0` otherwise, since `i t ∈ ℍ` fails for
+`t ≤ 0`), for an arbitrary `F : ℍ → ℂ`.
+
+The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
+that the restriction is real-valued, real and positive, or real and eventually positive along
+`atTop`. Each is closed under the pointwise algebraic operations. The closure lemmas under
+`+`, `*`, `•` and `^` are tagged `@[fun_prop]`; the constant lemmas of `PosOnImagAxis` and
+`EventuallyPosOnImagAxis` are not, since they take a positivity hypothesis on the constant
+that has to be supplied by hand.
+
+## Main definitions
+
+* `UpperHalfPlane.resToImagAxis`: the restriction `t ↦ F (i t)`, extended by `0` on `t ≤ 0`.
+* `UpperHalfPlane.RealOnImagAxis`, `PosOnImagAxis`, `EventuallyPosOnImagAxis`: the restriction
+  is real-valued, positive, or eventually positive along `atTop`.
+
+## Main results
+
+* `UpperHalfPlane.resToImagAxis_of_pos`, `resToImagAxis_of_nonpos`: the characteristic
+  equations of the restriction, which every proof below rewrites with.
+* `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
+  `t > 0` when `F` is differentiable as a map of manifolds at the corresponding point.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/Modularforms/ResToImagAxis.lean`, Chris Birkbeck,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the
+`Function.resToImagAxis` dot-notation alias dropped in favour of the single definition, the
+repeated unfolding replaced by `resToImagAxis_of_pos`, and eventual positivity phrased with
+the `atTop` filter. The slash-action behaviour of the restriction, the one modular-forms
+statement of the source file, lives in
+`TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean`.
+-/
+
+public section
+
+open Complex Filter Topology
+
+open scoped Manifold
+
+namespace UpperHalfPlane
+
+/-- The restriction of `F : ℍ → ℂ` to the positive imaginary axis, `t ↦ F (i t)`. Since
+`i t` lies in `ℍ` only for `t > 0`, the restriction is extended by `0` on `t ≤ 0`. -/
+noncomputable def resToImagAxis (F : ℍ → ℂ) : ℝ → ℂ :=
+  fun t ↦ if ht : 0 < t then F ⟨Complex.I * t, by simpa using ht⟩ else 0
+
+/-- The characteristic equation of `resToImagAxis` on its domain of interest. -/
+@[simp]
+theorem resToImagAxis_of_pos (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t) :
+    resToImagAxis F t = F ⟨Complex.I * t, by simpa using ht⟩ := dif_pos ht
+
+/-- Off the positive axis the restriction is `0` by convention. -/
+@[simp]
+theorem resToImagAxis_of_nonpos (F : ℍ → ℂ) {t : ℝ} (ht : t ≤ 0) :
+    resToImagAxis F t = 0 := dif_neg (not_lt.mpr ht)
+
+/-- `F` is real-valued on the positive imaginary axis. -/
+@[fun_prop]
+def RealOnImagAxis (F : ℍ → ℂ) : Prop :=
+  ∀ t : ℝ, 0 < t → (resToImagAxis F t).im = 0
+
+/-- `F` is real and strictly positive on the positive imaginary axis. -/
+@[fun_prop]
+def PosOnImagAxis (F : ℍ → ℂ) : Prop :=
+  RealOnImagAxis F ∧ ∀ t : ℝ, 0 < t → 0 < (resToImagAxis F t).re
+
+/-- `F` is real on the positive imaginary axis and strictly positive far out along it. -/
+@[fun_prop]
+def EventuallyPosOnImagAxis (F : ℍ → ℂ) : Prop :=
+  RealOnImagAxis F ∧ ∀ᶠ t : ℝ in atTop, 0 < (resToImagAxis F t).re
+
+/-! ### Differentiability and the behaviour under `S` -/
+
+/-- The restriction is real-differentiable at `t > 0` whenever `F` is differentiable as a map
+of manifolds at the corresponding point: the restriction is the composite of `F` with
+`t ↦ i t`, so only differentiability there is used. -/
+@[fun_prop]
+theorem differentiableAt_resToImagAxis (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t)
+    (hF : MDiffAt F ⟨Complex.I * t, by simpa using ht⟩) :
+    DifferentiableAt ℝ (resToImagAxis F) t := by
+  rw [mdifferentiableAt_iff] at hF
+  have h_diff : DifferentiableAt ℝ (fun t : ℝ ↦ F (ofComplex (Complex.I * t))) t := by
+    convert hF.restrictScalars ℝ |>.comp t
+      (DifferentiableAt.const_mul ofRealCLM.differentiableAt _) using 1
+    all_goals try rfl
+  refine h_diff.congr_of_eventuallyEq ?_
+  filter_upwards [lt_mem_nhds ht] with s hs
+  rw [resToImagAxis_of_pos F hs, ofComplex_apply_of_im_pos (by simp [hs])]
+
+/-! ### Real-valuedness is preserved by the algebraic operations -/
+
+namespace RealOnImagAxis
+
+/-- A real constant is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem const (c : ℝ) : RealOnImagAxis (fun _ ↦ (c : ℂ)) := fun t ht ↦ by
+  rw [resToImagAxis_of_pos _ ht]
+  simp
+
+/-- The zero function is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem zero : RealOnImagAxis (fun _ ↦ 0) := by simpa using const 0
+
+/-- The constant function `1` is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem one : RealOnImagAxis (fun _ ↦ 1) := by simpa using const 1
+
+/-- Negation preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem neg {F : ℍ → ℂ} (hF : RealOnImagAxis F) : RealOnImagAxis (-F) := fun t ht ↦ by
+  have hf := hF t ht
+  rw [resToImagAxis_of_pos _ ht] at hf ⊢
+  simp [hf]
+
+/-- Addition preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F + G) := fun t ht ↦ by
+  have hf := hF t ht
+  have hg := hG t ht
+  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+  simp [hf, hg]
+
+/-- Subtraction preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem sub {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F - G) := by simpa [sub_eq_add_neg] using hF.add hG.neg
+
+/-- Multiplication preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F * G) := fun t ht ↦ by
+  have hf := hF t ht
+  have hg := hG t ht
+  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+  simp [Complex.mul_im, hf, hg]
+
+/-- Real scalar multiplication preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
+  fun t ht ↦ by
+  have hf := hF t ht
+  rw [resToImagAxis_of_pos _ ht] at hf ⊢
+  simp [Complex.real_smul, Complex.mul_im, hf]
+
+/-- Natural powers preserve real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : RealOnImagAxis F) (n : ℕ) : RealOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end RealOnImagAxis
+
+/-! ### Positivity is preserved by the algebraic operations -/
+
+namespace PosOnImagAxis
+
+/-- A positive real constant is positive on the imaginary axis. -/
+theorem const {c : ℝ} (hc : 0 < c) : PosOnImagAxis (fun _ ↦ (c : ℂ)) :=
+  ⟨RealOnImagAxis.const c, fun t ht ↦ by rw [resToImagAxis_of_pos _ ht]; simpa using hc⟩
+
+/-- The constant function `1` is positive on the imaginary axis. -/
+@[fun_prop]
+theorem one : PosOnImagAxis (fun _ ↦ 1) := by simpa using const one_pos
+
+/-- Addition preserves positivity on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
+    PosOnImagAxis (F + G) :=
+  ⟨hF.1.add hG.1, fun t ht ↦ by
+    have hf := hF.2 t ht
+    have hg := hG.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+    simpa using add_pos hf hg⟩
+
+/-- Multiplication preserves positivity on the imaginary axis: the two restrictions are real
+there, so the real part of the product is the product of the real parts. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
+    PosOnImagAxis (F * G) :=
+  ⟨hF.1.mul hG.1, fun t ht ↦ by
+    have hfi := hF.1 t ht
+    have hgi := hG.1 t ht
+    have hfr := hF.2 t ht
+    have hgr := hG.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hfi hgi hfr hgr ⊢
+    simpa [Complex.mul_re, hfi, hgi] using mul_pos hfr hgr⟩
+
+/-- Positive scalar multiplication preserves positivity on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
+    PosOnImagAxis (c • F) :=
+  ⟨hF.1.smul, fun t ht ↦ by
+    have hf := hF.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hf ⊢
+    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
+
+/-- Natural powers preserve positivity on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : PosOnImagAxis F) (n : ℕ) : PosOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end PosOnImagAxis
+
+/-! ### Eventual positivity is preserved by the algebraic operations -/
+
+namespace EventuallyPosOnImagAxis
+
+/-- Positivity everywhere implies positivity far out. -/
+@[fun_prop]
+theorem of_pos {F : ℍ → ℂ} (hF : PosOnImagAxis F) : EventuallyPosOnImagAxis F :=
+  ⟨hF.1, by filter_upwards [eventually_gt_atTop (0 : ℝ)] with t ht using hF.2 t ht⟩
+
+/-- The constant function `1` is eventually positive on the imaginary axis. -/
+@[fun_prop]
+theorem one : EventuallyPosOnImagAxis (fun _ ↦ 1) := of_pos PosOnImagAxis.one
+
+/-- A positive real constant is eventually positive on the imaginary axis. -/
+theorem const {c : ℝ} (hc : 0 < c) : EventuallyPosOnImagAxis (fun _ ↦ (c : ℂ)) :=
+  of_pos (PosOnImagAxis.const hc)
+
+/-- Addition preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
+    EventuallyPosOnImagAxis (F + G) :=
+  ⟨hF.1.add hG.1, by
+    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
+    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+    simpa using add_pos hf hg⟩
+
+/-- Multiplication preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
+    EventuallyPosOnImagAxis (F * G) :=
+  ⟨hF.1.mul hG.1, by
+    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
+    have hfi := hF.1 t ht
+    have hgi := hG.1 t ht
+    rw [resToImagAxis_of_pos _ ht] at hfi hgi hf hg ⊢
+    simpa [Complex.mul_re, hfi, hgi] using mul_pos hf hg⟩
+
+/-- Positive scalar multiplication preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) (hc : 0 < c) :
+    EventuallyPosOnImagAxis (c • F) :=
+  ⟨hF.1.smul, by
+    filter_upwards [hF.2, eventually_gt_atTop (0 : ℝ)] with t hf ht
+    rw [resToImagAxis_of_pos _ ht] at hf ⊢
+    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
+
+/-- Natural powers preserve eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (n : ℕ) :
+    EventuallyPosOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end EventuallyPosOnImagAxis
+
+end UpperHalfPlane

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -20,9 +20,12 @@ restriction,
 
 The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
 that the restriction is real-valued, real and positive, or real and eventually positive along
-`atTop`. Each is closed under the pointwise algebraic operations, and the closure lemmas are
-tagged `@[fun_prop]` — except `PosOnImagAxis.const` and `EventuallyPosOnImagAxis.const`,
-whose constant is not determined by the goal.
+`atTop`. `RealOnImagAxis` is closed under all the pointwise algebraic operations; the two
+positivity predicates are closed under the operations that preserve strict positivity —
+positive constants, addition, multiplication, multiplication by a positive real scalar, and
+natural powers — but not under negation or subtraction. The closure lemmas are tagged
+`@[fun_prop]`, except `PosOnImagAxis.const` and `EventuallyPosOnImagAxis.const`, whose
+constant is not determined by the goal.
 
 ## Main definitions
 
@@ -77,31 +80,49 @@ theorem resToImagAxis_of_nonpos (F : ℍ → ℂ) {t : ℝ} (ht : t ≤ 0) :
 Each identity is unconditional in `t`: off the positive axis both sides are `0`.
 -/
 
+/-- The restriction of `0` is `0`. -/
+@[simp]
+theorem resToImagAxis_zero : resToImagAxis 0 = 0 := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+/-- The restriction commutes with negation. -/
 @[simp]
 theorem resToImagAxis_neg (F : ℍ → ℂ) : resToImagAxis (-F) = -resToImagAxis F := by
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
+/-- The restriction commutes with addition. -/
 @[simp]
 theorem resToImagAxis_add (F G : ℍ → ℂ) :
     resToImagAxis (F + G) = resToImagAxis F + resToImagAxis G := by
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
+/-- The restriction commutes with subtraction. -/
 @[simp]
 theorem resToImagAxis_sub (F G : ℍ → ℂ) :
     resToImagAxis (F - G) = resToImagAxis F - resToImagAxis G := by
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
+/-- The restriction commutes with pointwise multiplication. -/
 @[simp]
 theorem resToImagAxis_mul (F G : ℍ → ℂ) :
     resToImagAxis (F * G) = resToImagAxis F * resToImagAxis G := by
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
+/-- The restriction commutes with scalar multiplication. -/
 @[simp]
-theorem resToImagAxis_smul (c : ℝ) (F : ℍ → ℂ) :
+theorem resToImagAxis_smul (c : ℂ) (F : ℍ → ℂ) :
+    resToImagAxis (c • F) = c • resToImagAxis F := by
+  funext t
+  rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
+
+/-- The real-scalar form of `resToImagAxis_smul`, which the positivity predicates use. -/
+@[simp]
+theorem resToImagAxis_real_smul (c : ℝ) (F : ℍ → ℂ) :
     resToImagAxis (c • F) = c • resToImagAxis F := by
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -37,8 +37,8 @@ constant is not determined by the goal.
 
 * `UpperHalfPlane.resToImagAxis_of_pos`, `resToImagAxis_of_nonpos`: the characteristic
   equations of the restriction.
-* `UpperHalfPlane.resToImagAxis_add`, `_neg`, `_sub`, `_mul`, `_smul`: the restriction
-  commutes with the pointwise operations, unconditionally.
+* `UpperHalfPlane.resToImagAxis_zero`, `_add`, `_neg`, `_sub`, `_mul`, `_smul`: the
+  restriction commutes with the pointwise operations, unconditionally.
 * `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
   `t > 0` when `F` is differentiable as a map of manifolds at the corresponding point.
 
@@ -120,19 +120,13 @@ theorem resToImagAxis_smul (c : ℂ) (F : ℍ → ℂ) :
   funext t
   rcases le_or_gt t 0 with ht | ht <;> simp [resToImagAxis_of_pos, resToImagAxis_of_nonpos, ht]
 
-/-- The real-scalar form of `resToImagAxis_smul`, which the positivity predicates use. -/
+/-- The real-scalar form of `resToImagAxis_smul`. Private: it is a thin specialization with
+no consumers outside this file, but the three `const_smul` closure lemmas below would
+otherwise repeat its two-line proof. -/
 @[simp]
-theorem resToImagAxis_real_smul (c : ℝ) (F : ℍ → ℂ) :
+private theorem resToImagAxis_real_smul (c : ℝ) (F : ℍ → ℂ) :
     resToImagAxis (c • F) = c • resToImagAxis F := by
   simpa [Complex.real_smul] using resToImagAxis_smul (c : ℂ) F
-
-/-- Powers need `0 < t`: at `t ≤ 0` the restriction of `F ^ 0 = 1` is `0`, not `1`.
-
-Not `@[simp]`: `resToImagAxis_of_pos` together with `Pi.pow_apply` already reduces the
-left-hand side, so the attribute would be a duplicate (the `simpNF` linter rejects it). -/
-theorem resToImagAxis_pow (F : ℍ → ℂ) (n : ℕ) {t : ℝ} (ht : 0 < t) :
-    resToImagAxis (F ^ n) t = resToImagAxis F t ^ n := by
-  simp [resToImagAxis_of_pos _ ht]
 
 /-! ### Real-valuedness, positivity, and eventual positivity -/
 

--- a/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
+++ b/TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean
@@ -85,7 +85,7 @@ def PosOnImagAxis (F : ℍ → ℂ) : Prop :=
 def EventuallyPosOnImagAxis (F : ℍ → ℂ) : Prop :=
   RealOnImagAxis F ∧ ∀ᶠ t : ℝ in atTop, 0 < (resToImagAxis F t).re
 
-/-! ### Differentiability and the behaviour under `S` -/
+/-! ### Differentiability -/
 
 /-- The restriction is real-differentiable at `t > 0` whenever `F` is differentiable as a map
 of manifolds at the corresponding point: the restriction is the composite of `F` with

--- a/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
+++ b/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
@@ -46,10 +46,12 @@ theorem resToImagAxis_slash_S (F : ℍ → ℂ) (k : ℤ) {t : ℝ} (ht : 0 < t)
   have h : mk _ (⟨Complex.I * t, by simpa using ht⟩ : ℍ).im_inv_neg_coe_pos =
       (⟨Complex.I * (1 / t : ℝ), by simpa using ht'⟩ : ℍ) :=
     UpperHalfPlane.ext (by
+      -- `(-(i t))⁻¹ = i / t`, since `i * i = -1`
+      have ht0 : (t : ℂ) ≠ 0 := by exact_mod_cast ht.ne'
+      have hI : Complex.I * Complex.I = -1 := Complex.I_mul_I
       push_cast
       field_simp
-      rw [Complex.I_sq]
-      ring)
+      linear_combination -hI)
   rw [resToImagAxis_of_pos _ ht, SlashInvariantForm.slash_S_apply, h,
     resToImagAxis_of_pos F ht']
   simp only [mul_zpow]

--- a/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
+++ b/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
@@ -1,0 +1,298 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
+public import Mathlib.Geometry.Manifold.Notation
+public import Mathlib.NumberTheory.ModularForms.Identities
+
+/-!
+# Restriction of a function on the upper half-plane to the imaginary axis
+
+The Mellin transform computing the completed L-function of a modular form integrates the
+form along the positive imaginary axis: Mathlib's `ModularForm.Λ_eq_mellin` reads
+`Λ f = mellin (fun t ↦ f (ofComplex (I * t)))`. This file names that restriction,
+`resToImagAxis F t = F (i t)` for `t > 0` (and `0` otherwise, since `i t ∈ ℍ` fails for
+`t ≤ 0`), and develops the properties of it that the L-function estimates consume.
+
+The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
+that the restriction is real-valued, real and positive, or real and eventually positive along
+`atTop`. Each is closed under the pointwise algebraic operations, and the closure lemmas are
+tagged `@[fun_prop]`, so `fun_prop` discharges these side conditions for a concrete
+expression built from constants by `+`, `*`, `•` and `^`.
+
+## Main definitions
+
+* `UpperHalfPlane.resToImagAxis`: the restriction `t ↦ F (i t)`, extended by `0` on `t ≤ 0`.
+* `UpperHalfPlane.RealOnImagAxis`, `PosOnImagAxis`, `EventuallyPosOnImagAxis`: the restriction
+  is real-valued, positive, or eventually positive along `atTop`.
+
+## Main results
+
+* `UpperHalfPlane.resToImagAxis_of_pos`: the characteristic equation of the restriction, which
+  every proof below rewrites with.
+* `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
+  every `t > 0` when `F` is differentiable as a map of manifolds.
+* `UpperHalfPlane.resToImagAxis_slash_S`: the restriction of `F ∣[k] S` at `t` is
+  `i ^ (-k) t ^ (-k)` times the restriction of `F` at `1 / t` — the involution `t ↦ 1 / t`
+  underlying the functional equation.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/Modularforms/ResToImagAxis.lean`, Chris Birkbeck,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the
+`Function.resToImagAxis` dot-notation alias dropped in favour of the single definition, the
+repeated unfolding replaced by `resToImagAxis_of_pos`, and eventual positivity phrased with
+the `atTop` filter.
+-/
+
+public section
+
+open Complex Filter Topology ModularGroup
+
+open scoped Manifold ModularForm MatrixGroups
+
+namespace UpperHalfPlane
+
+/-- The restriction of `F : ℍ → ℂ` to the positive imaginary axis, `t ↦ F (i t)`. Since
+`i t` lies in `ℍ` only for `t > 0`, the restriction is extended by `0` on `t ≤ 0`. -/
+noncomputable def resToImagAxis (F : ℍ → ℂ) : ℝ → ℂ :=
+  fun t ↦ if ht : 0 < t then F ⟨Complex.I * t, by simpa using ht⟩ else 0
+
+/-- The characteristic equation of `resToImagAxis` on its domain of interest. -/
+@[simp]
+theorem resToImagAxis_of_pos (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t) :
+    resToImagAxis F t = F ⟨Complex.I * t, by simpa using ht⟩ := dif_pos ht
+
+/-- Off the positive axis the restriction is `0` by convention. -/
+theorem resToImagAxis_of_nonpos (F : ℍ → ℂ) {t : ℝ} (ht : t ≤ 0) :
+    resToImagAxis F t = 0 := dif_neg (not_lt.mpr ht)
+
+/-- `F` is real-valued on the positive imaginary axis. -/
+@[fun_prop]
+def RealOnImagAxis (F : ℍ → ℂ) : Prop :=
+  ∀ t : ℝ, 0 < t → (resToImagAxis F t).im = 0
+
+/-- `F` is real and strictly positive on the positive imaginary axis. -/
+@[fun_prop]
+def PosOnImagAxis (F : ℍ → ℂ) : Prop :=
+  RealOnImagAxis F ∧ ∀ t : ℝ, 0 < t → 0 < (resToImagAxis F t).re
+
+/-- `F` is real on the positive imaginary axis and strictly positive far out along it. -/
+@[fun_prop]
+def EventuallyPosOnImagAxis (F : ℍ → ℂ) : Prop :=
+  RealOnImagAxis F ∧ ∀ᶠ t : ℝ in atTop, 0 < (resToImagAxis F t).re
+
+/-! ### Differentiability and the behaviour under `S` -/
+
+/-- The restriction is real-differentiable at every `t > 0` whenever `F` is differentiable as
+a map of manifolds: the restriction is the composite of `F` with `t ↦ i t`. -/
+@[fun_prop]
+theorem differentiableAt_resToImagAxis (F : ℍ → ℂ) (hF : MDiff F) {t : ℝ} (ht : 0 < t) :
+    DifferentiableAt ℝ (resToImagAxis F) t := by
+  have hmdiff := hF ⟨Complex.I * t, by simpa using ht⟩
+  rw [mdifferentiableAt_iff] at hmdiff
+  have h_diff : DifferentiableAt ℝ (fun t : ℝ ↦ F (ofComplex (Complex.I * t))) t := by
+    convert hmdiff.restrictScalars ℝ |>.comp t
+      (DifferentiableAt.const_mul ofRealCLM.differentiableAt _) using 1
+    all_goals try rfl
+  refine h_diff.congr_of_eventuallyEq ?_
+  filter_upwards [lt_mem_nhds ht] with s hs
+  rw [resToImagAxis_of_pos F hs, ofComplex_apply_of_im_pos (by simp [hs])]
+
+/-- **The `S`-involution on the imaginary axis**: slashing by `S` turns `t` into `1 / t`,
+`(F ∣[k] S) (i t) = i ^ (-k) t ^ (-k) F (i / t)`. This is the reflection underlying the
+functional equation of the L-function. -/
+theorem resToImagAxis_slash_S (F : ℍ → ℂ) (k : ℤ) {t : ℝ} (ht : 0 < t) :
+    resToImagAxis (F ∣[k] S) t =
+      Complex.I ^ (-k) * (t : ℂ) ^ (-k) * resToImagAxis F (1 / t) := by
+  have ht' : (0 : ℝ) < 1 / t := by positivity
+  have h : mk _ (⟨Complex.I * t, by simpa using ht⟩ : ℍ).im_inv_neg_coe_pos =
+      (⟨Complex.I * (1 / t : ℝ), by simpa using ht'⟩ : ℍ) :=
+    UpperHalfPlane.ext (by
+      push_cast
+      field_simp
+      rw [Complex.I_sq]
+      ring)
+  rw [resToImagAxis_of_pos _ ht, SlashInvariantForm.slash_S_apply, h,
+    resToImagAxis_of_pos F ht']
+  simp only [mul_zpow]
+  ring
+
+/-! ### Real-valuedness is preserved by the algebraic operations -/
+
+namespace RealOnImagAxis
+
+/-- A real constant is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem const (c : ℝ) : RealOnImagAxis (fun _ ↦ (c : ℂ)) := fun t ht ↦ by
+  rw [resToImagAxis_of_pos _ ht]
+  simp
+
+/-- The zero function is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem zero : RealOnImagAxis (fun _ ↦ 0) := by simpa using const 0
+
+/-- The constant function `1` is real-valued on the imaginary axis. -/
+@[fun_prop]
+theorem one : RealOnImagAxis (fun _ ↦ 1) := by simpa using const 1
+
+/-- Negation preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem neg {F : ℍ → ℂ} (hF : RealOnImagAxis F) : RealOnImagAxis (-F) := fun t ht ↦ by
+  have hf := hF t ht
+  rw [resToImagAxis_of_pos _ ht] at hf ⊢
+  simp [hf]
+
+/-- Addition preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F + G) := fun t ht ↦ by
+  have hf := hF t ht
+  have hg := hG t ht
+  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+  simp [hf, hg]
+
+/-- Subtraction preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem sub {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F - G) := by simpa [sub_eq_add_neg] using hF.add hG.neg
+
+/-- Multiplication preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
+    RealOnImagAxis (F * G) := fun t ht ↦ by
+  have hf := hF t ht
+  have hg := hG t ht
+  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+  simp [Complex.mul_im, hf, hg]
+
+/-- Real scalar multiplication preserves real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
+  fun t ht ↦ by
+  have hf := hF t ht
+  rw [resToImagAxis_of_pos _ ht] at hf ⊢
+  simp [Complex.real_smul, Complex.mul_im, hf]
+
+/-- Natural powers preserve real-valuedness on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : RealOnImagAxis F) (n : ℕ) : RealOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end RealOnImagAxis
+
+/-! ### Positivity is preserved by the algebraic operations -/
+
+namespace PosOnImagAxis
+
+/-- A positive real constant is positive on the imaginary axis. -/
+theorem const {c : ℝ} (hc : 0 < c) : PosOnImagAxis (fun _ ↦ (c : ℂ)) :=
+  ⟨RealOnImagAxis.const c, fun t ht ↦ by rw [resToImagAxis_of_pos _ ht]; simpa using hc⟩
+
+/-- The constant function `1` is positive on the imaginary axis. -/
+@[fun_prop]
+theorem one : PosOnImagAxis (fun _ ↦ 1) := by simpa using const one_pos
+
+/-- Addition preserves positivity on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
+    PosOnImagAxis (F + G) :=
+  ⟨hF.1.add hG.1, fun t ht ↦ by
+    have hf := hF.2 t ht
+    have hg := hG.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+    simpa using add_pos hf hg⟩
+
+/-- Multiplication preserves positivity on the imaginary axis: the two restrictions are real
+there, so the real part of the product is the product of the real parts. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
+    PosOnImagAxis (F * G) :=
+  ⟨hF.1.mul hG.1, fun t ht ↦ by
+    have hfi := hF.1 t ht
+    have hgi := hG.1 t ht
+    have hfr := hF.2 t ht
+    have hgr := hG.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hfi hgi hfr hgr ⊢
+    simpa [Complex.mul_re, hfi, hgi] using mul_pos hfr hgr⟩
+
+/-- Positive scalar multiplication preserves positivity on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
+    PosOnImagAxis (c • F) :=
+  ⟨hF.1.smul, fun t ht ↦ by
+    have hf := hF.2 t ht
+    rw [resToImagAxis_of_pos _ ht] at hf ⊢
+    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
+
+/-- Natural powers preserve positivity on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : PosOnImagAxis F) (n : ℕ) : PosOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end PosOnImagAxis
+
+/-! ### Eventual positivity is preserved by the algebraic operations -/
+
+namespace EventuallyPosOnImagAxis
+
+/-- Positivity everywhere implies positivity far out. -/
+@[fun_prop]
+theorem of_pos {F : ℍ → ℂ} (hF : PosOnImagAxis F) : EventuallyPosOnImagAxis F :=
+  ⟨hF.1, by filter_upwards [eventually_gt_atTop (0 : ℝ)] with t ht using hF.2 t ht⟩
+
+/-- The constant function `1` is eventually positive on the imaginary axis. -/
+@[fun_prop]
+theorem one : EventuallyPosOnImagAxis (fun _ ↦ 1) := of_pos PosOnImagAxis.one
+
+/-- A positive real constant is eventually positive on the imaginary axis. -/
+theorem const {c : ℝ} (hc : 0 < c) : EventuallyPosOnImagAxis (fun _ ↦ (c : ℂ)) :=
+  of_pos (PosOnImagAxis.const hc)
+
+/-- Addition preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem add {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
+    EventuallyPosOnImagAxis (F + G) :=
+  ⟨hF.1.add hG.1, by
+    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
+    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
+    simpa using add_pos hf hg⟩
+
+/-- Multiplication preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem mul {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
+    EventuallyPosOnImagAxis (F * G) :=
+  ⟨hF.1.mul hG.1, by
+    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
+    have hfi := hF.1 t ht
+    have hgi := hG.1 t ht
+    rw [resToImagAxis_of_pos _ ht] at hfi hgi hf hg ⊢
+    simpa [Complex.mul_re, hfi, hgi] using mul_pos hf hg⟩
+
+/-- Positive scalar multiplication preserves eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) (hc : 0 < c) :
+    EventuallyPosOnImagAxis (c • F) :=
+  ⟨hF.1.smul, by
+    filter_upwards [hF.2, eventually_gt_atTop (0 : ℝ)] with t hf ht
+    rw [resToImagAxis_of_pos _ ht] at hf ⊢
+    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
+
+/-- Natural powers preserve eventual positivity on the imaginary axis. -/
+@[fun_prop]
+theorem pow {F : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (n : ℕ) :
+    EventuallyPosOnImagAxis (F ^ n) := by
+  induction n with
+  | zero => simpa [Pi.one_def] using one
+  | succ n hn => simpa [pow_succ] using hn.mul hF
+
+end EventuallyPosOnImagAxis
+
+end UpperHalfPlane

--- a/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
+++ b/TauCeti/NumberTheory/ModularForms/ResToImagAxis.lean
@@ -5,102 +5,36 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import Mathlib.Analysis.Complex.UpperHalfPlane.Manifold
-public import Mathlib.Geometry.Manifold.Notation
 public import Mathlib.NumberTheory.ModularForms.Identities
+public import TauCeti.Analysis.Complex.UpperHalfPlane.ResToImagAxis
 
 /-!
-# Restriction of a function on the upper half-plane to the imaginary axis
+# The slash action on the imaginary axis
 
-The Mellin transform computing the completed L-function of a modular form integrates the
-form along the positive imaginary axis: Mathlib's `ModularForm.Λ_eq_mellin` reads
-`Λ f = mellin (fun t ↦ f (ofComplex (I * t)))`. This file names that restriction,
-`resToImagAxis F t = F (i t)` for `t > 0` (and `0` otherwise, since `i t ∈ ℍ` fails for
-`t ≤ 0`), and develops the properties of it that the L-function estimates consume.
-
-The three predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis` record
-that the restriction is real-valued, real and positive, or real and eventually positive along
-`atTop`. Each is closed under the pointwise algebraic operations, and the closure lemmas are
-tagged `@[fun_prop]`, so `fun_prop` discharges these side conditions for a concrete
-expression built from constants by `+`, `*`, `•` and `^`.
-
-## Main definitions
-
-* `UpperHalfPlane.resToImagAxis`: the restriction `t ↦ F (i t)`, extended by `0` on `t ≤ 0`.
-* `UpperHalfPlane.RealOnImagAxis`, `PosOnImagAxis`, `EventuallyPosOnImagAxis`: the restriction
-  is real-valued, positive, or eventually positive along `atTop`.
+The restriction `UpperHalfPlane.resToImagAxis` of a function on `ℍ` to the positive imaginary
+axis intertwines the weight-`k` slash action of `S = ![![0, -1], ![1, 0]]` with the involution
+`t ↦ 1 / t` of the axis. This is the reflection underlying the functional equation of the
+L-function of a modular form.
 
 ## Main results
 
-* `UpperHalfPlane.resToImagAxis_of_pos`: the characteristic equation of the restriction, which
-  every proof below rewrites with.
-* `UpperHalfPlane.differentiableAt_resToImagAxis`: the restriction is real-differentiable at
-  every `t > 0` when `F` is differentiable as a map of manifolds.
 * `UpperHalfPlane.resToImagAxis_slash_S`: the restriction of `F ∣[k] S` at `t` is
-  `i ^ (-k) t ^ (-k)` times the restriction of `F` at `1 / t` — the involution `t ↦ 1 / t`
-  underlying the functional equation.
+  `i ^ (-k) t ^ (-k)` times the restriction of `F` at `1 / t`.
 
 Ported from the AINTLIB `LeanModularForms` project
 (`LeanModularForms/Modularforms/ResToImagAxis.lean`, Chris Birkbeck,
-<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>), with the
-`Function.resToImagAxis` dot-notation alias dropped in favour of the single definition, the
-repeated unfolding replaced by `resToImagAxis_of_pos`, and eventual positivity phrased with
-the `atTop` filter.
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>); the generic
+material about the restriction is in
+`TauCeti/Analysis/Complex/UpperHalfPlane/ResToImagAxis.lean`.
 -/
 
 public section
 
-open Complex Filter Topology ModularGroup
+open Complex ModularGroup
 
-open scoped Manifold ModularForm MatrixGroups
+open scoped ModularForm MatrixGroups
 
 namespace UpperHalfPlane
-
-/-- The restriction of `F : ℍ → ℂ` to the positive imaginary axis, `t ↦ F (i t)`. Since
-`i t` lies in `ℍ` only for `t > 0`, the restriction is extended by `0` on `t ≤ 0`. -/
-noncomputable def resToImagAxis (F : ℍ → ℂ) : ℝ → ℂ :=
-  fun t ↦ if ht : 0 < t then F ⟨Complex.I * t, by simpa using ht⟩ else 0
-
-/-- The characteristic equation of `resToImagAxis` on its domain of interest. -/
-@[simp]
-theorem resToImagAxis_of_pos (F : ℍ → ℂ) {t : ℝ} (ht : 0 < t) :
-    resToImagAxis F t = F ⟨Complex.I * t, by simpa using ht⟩ := dif_pos ht
-
-/-- Off the positive axis the restriction is `0` by convention. -/
-theorem resToImagAxis_of_nonpos (F : ℍ → ℂ) {t : ℝ} (ht : t ≤ 0) :
-    resToImagAxis F t = 0 := dif_neg (not_lt.mpr ht)
-
-/-- `F` is real-valued on the positive imaginary axis. -/
-@[fun_prop]
-def RealOnImagAxis (F : ℍ → ℂ) : Prop :=
-  ∀ t : ℝ, 0 < t → (resToImagAxis F t).im = 0
-
-/-- `F` is real and strictly positive on the positive imaginary axis. -/
-@[fun_prop]
-def PosOnImagAxis (F : ℍ → ℂ) : Prop :=
-  RealOnImagAxis F ∧ ∀ t : ℝ, 0 < t → 0 < (resToImagAxis F t).re
-
-/-- `F` is real on the positive imaginary axis and strictly positive far out along it. -/
-@[fun_prop]
-def EventuallyPosOnImagAxis (F : ℍ → ℂ) : Prop :=
-  RealOnImagAxis F ∧ ∀ᶠ t : ℝ in atTop, 0 < (resToImagAxis F t).re
-
-/-! ### Differentiability and the behaviour under `S` -/
-
-/-- The restriction is real-differentiable at every `t > 0` whenever `F` is differentiable as
-a map of manifolds: the restriction is the composite of `F` with `t ↦ i t`. -/
-@[fun_prop]
-theorem differentiableAt_resToImagAxis (F : ℍ → ℂ) (hF : MDiff F) {t : ℝ} (ht : 0 < t) :
-    DifferentiableAt ℝ (resToImagAxis F) t := by
-  have hmdiff := hF ⟨Complex.I * t, by simpa using ht⟩
-  rw [mdifferentiableAt_iff] at hmdiff
-  have h_diff : DifferentiableAt ℝ (fun t : ℝ ↦ F (ofComplex (Complex.I * t))) t := by
-    convert hmdiff.restrictScalars ℝ |>.comp t
-      (DifferentiableAt.const_mul ofRealCLM.differentiableAt _) using 1
-    all_goals try rfl
-  refine h_diff.congr_of_eventuallyEq ?_
-  filter_upwards [lt_mem_nhds ht] with s hs
-  rw [resToImagAxis_of_pos F hs, ofComplex_apply_of_im_pos (by simp [hs])]
 
 /-- **The `S`-involution on the imaginary axis**: slashing by `S` turns `t` into `1 / t`,
 `(F ∣[k] S) (i t) = i ^ (-k) t ^ (-k) F (i / t)`. This is the reflection underlying the
@@ -120,179 +54,5 @@ theorem resToImagAxis_slash_S (F : ℍ → ℂ) (k : ℤ) {t : ℝ} (ht : 0 < t)
     resToImagAxis_of_pos F ht']
   simp only [mul_zpow]
   ring
-
-/-! ### Real-valuedness is preserved by the algebraic operations -/
-
-namespace RealOnImagAxis
-
-/-- A real constant is real-valued on the imaginary axis. -/
-@[fun_prop]
-theorem const (c : ℝ) : RealOnImagAxis (fun _ ↦ (c : ℂ)) := fun t ht ↦ by
-  rw [resToImagAxis_of_pos _ ht]
-  simp
-
-/-- The zero function is real-valued on the imaginary axis. -/
-@[fun_prop]
-theorem zero : RealOnImagAxis (fun _ ↦ 0) := by simpa using const 0
-
-/-- The constant function `1` is real-valued on the imaginary axis. -/
-@[fun_prop]
-theorem one : RealOnImagAxis (fun _ ↦ 1) := by simpa using const 1
-
-/-- Negation preserves real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem neg {F : ℍ → ℂ} (hF : RealOnImagAxis F) : RealOnImagAxis (-F) := fun t ht ↦ by
-  have hf := hF t ht
-  rw [resToImagAxis_of_pos _ ht] at hf ⊢
-  simp [hf]
-
-/-- Addition preserves real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem add {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
-    RealOnImagAxis (F + G) := fun t ht ↦ by
-  have hf := hF t ht
-  have hg := hG t ht
-  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-  simp [hf, hg]
-
-/-- Subtraction preserves real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem sub {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
-    RealOnImagAxis (F - G) := by simpa [sub_eq_add_neg] using hF.add hG.neg
-
-/-- Multiplication preserves real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem mul {F G : ℍ → ℂ} (hF : RealOnImagAxis F) (hG : RealOnImagAxis G) :
-    RealOnImagAxis (F * G) := fun t ht ↦ by
-  have hf := hF t ht
-  have hg := hG t ht
-  rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-  simp [Complex.mul_im, hf, hg]
-
-/-- Real scalar multiplication preserves real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : RealOnImagAxis F) : RealOnImagAxis (c • F) :=
-  fun t ht ↦ by
-  have hf := hF t ht
-  rw [resToImagAxis_of_pos _ ht] at hf ⊢
-  simp [Complex.real_smul, Complex.mul_im, hf]
-
-/-- Natural powers preserve real-valuedness on the imaginary axis. -/
-@[fun_prop]
-theorem pow {F : ℍ → ℂ} (hF : RealOnImagAxis F) (n : ℕ) : RealOnImagAxis (F ^ n) := by
-  induction n with
-  | zero => simpa [Pi.one_def] using one
-  | succ n hn => simpa [pow_succ] using hn.mul hF
-
-end RealOnImagAxis
-
-/-! ### Positivity is preserved by the algebraic operations -/
-
-namespace PosOnImagAxis
-
-/-- A positive real constant is positive on the imaginary axis. -/
-theorem const {c : ℝ} (hc : 0 < c) : PosOnImagAxis (fun _ ↦ (c : ℂ)) :=
-  ⟨RealOnImagAxis.const c, fun t ht ↦ by rw [resToImagAxis_of_pos _ ht]; simpa using hc⟩
-
-/-- The constant function `1` is positive on the imaginary axis. -/
-@[fun_prop]
-theorem one : PosOnImagAxis (fun _ ↦ 1) := by simpa using const one_pos
-
-/-- Addition preserves positivity on the imaginary axis. -/
-@[fun_prop]
-theorem add {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
-    PosOnImagAxis (F + G) :=
-  ⟨hF.1.add hG.1, fun t ht ↦ by
-    have hf := hF.2 t ht
-    have hg := hG.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-    simpa using add_pos hf hg⟩
-
-/-- Multiplication preserves positivity on the imaginary axis: the two restrictions are real
-there, so the real part of the product is the product of the real parts. -/
-@[fun_prop]
-theorem mul {F G : ℍ → ℂ} (hF : PosOnImagAxis F) (hG : PosOnImagAxis G) :
-    PosOnImagAxis (F * G) :=
-  ⟨hF.1.mul hG.1, fun t ht ↦ by
-    have hfi := hF.1 t ht
-    have hgi := hG.1 t ht
-    have hfr := hF.2 t ht
-    have hgr := hG.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hfi hgi hfr hgr ⊢
-    simpa [Complex.mul_re, hfi, hgi] using mul_pos hfr hgr⟩
-
-/-- Positive scalar multiplication preserves positivity on the imaginary axis. -/
-@[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : PosOnImagAxis F) (hc : 0 < c) :
-    PosOnImagAxis (c • F) :=
-  ⟨hF.1.smul, fun t ht ↦ by
-    have hf := hF.2 t ht
-    rw [resToImagAxis_of_pos _ ht] at hf ⊢
-    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
-
-/-- Natural powers preserve positivity on the imaginary axis. -/
-@[fun_prop]
-theorem pow {F : ℍ → ℂ} (hF : PosOnImagAxis F) (n : ℕ) : PosOnImagAxis (F ^ n) := by
-  induction n with
-  | zero => simpa [Pi.one_def] using one
-  | succ n hn => simpa [pow_succ] using hn.mul hF
-
-end PosOnImagAxis
-
-/-! ### Eventual positivity is preserved by the algebraic operations -/
-
-namespace EventuallyPosOnImagAxis
-
-/-- Positivity everywhere implies positivity far out. -/
-@[fun_prop]
-theorem of_pos {F : ℍ → ℂ} (hF : PosOnImagAxis F) : EventuallyPosOnImagAxis F :=
-  ⟨hF.1, by filter_upwards [eventually_gt_atTop (0 : ℝ)] with t ht using hF.2 t ht⟩
-
-/-- The constant function `1` is eventually positive on the imaginary axis. -/
-@[fun_prop]
-theorem one : EventuallyPosOnImagAxis (fun _ ↦ 1) := of_pos PosOnImagAxis.one
-
-/-- A positive real constant is eventually positive on the imaginary axis. -/
-theorem const {c : ℝ} (hc : 0 < c) : EventuallyPosOnImagAxis (fun _ ↦ (c : ℂ)) :=
-  of_pos (PosOnImagAxis.const hc)
-
-/-- Addition preserves eventual positivity on the imaginary axis. -/
-@[fun_prop]
-theorem add {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
-    EventuallyPosOnImagAxis (F + G) :=
-  ⟨hF.1.add hG.1, by
-    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
-    rw [resToImagAxis_of_pos _ ht] at hf hg ⊢
-    simpa using add_pos hf hg⟩
-
-/-- Multiplication preserves eventual positivity on the imaginary axis. -/
-@[fun_prop]
-theorem mul {F G : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (hG : EventuallyPosOnImagAxis G) :
-    EventuallyPosOnImagAxis (F * G) :=
-  ⟨hF.1.mul hG.1, by
-    filter_upwards [hF.2, hG.2, eventually_gt_atTop (0 : ℝ)] with t hf hg ht
-    have hfi := hF.1 t ht
-    have hgi := hG.1 t ht
-    rw [resToImagAxis_of_pos _ ht] at hfi hgi hf hg ⊢
-    simpa [Complex.mul_re, hfi, hgi] using mul_pos hf hg⟩
-
-/-- Positive scalar multiplication preserves eventual positivity on the imaginary axis. -/
-@[fun_prop]
-theorem smul {F : ℍ → ℂ} {c : ℝ} (hF : EventuallyPosOnImagAxis F) (hc : 0 < c) :
-    EventuallyPosOnImagAxis (c • F) :=
-  ⟨hF.1.smul, by
-    filter_upwards [hF.2, eventually_gt_atTop (0 : ℝ)] with t hf ht
-    rw [resToImagAxis_of_pos _ ht] at hf ⊢
-    simpa [Complex.real_smul, Complex.mul_re] using mul_pos hc hf⟩
-
-/-- Natural powers preserve eventual positivity on the imaginary axis. -/
-@[fun_prop]
-theorem pow {F : ℍ → ℂ} (hF : EventuallyPosOnImagAxis F) (n : ℕ) :
-    EventuallyPosOnImagAxis (F ^ n) := by
-  induction n with
-  | zero => simpa [Pi.one_def] using one
-  | succ n hn => simpa [pow_succ] using hn.mul hF
-
-end EventuallyPosOnImagAxis
 
 end UpperHalfPlane


### PR DESCRIPTION
The Mellin transform computing the completed L-function of a modular form integrates the
form along the positive imaginary axis — Mathlib's `ModularForm.Λ_eq_mellin` reads
`Λ f = mellin (fun t ↦ f (ofComplex (I * t)))`. This names that restriction,
`resToImagAxis F t = F (i t)` for `t > 0` (and `0` otherwise, since `i t ∈ ℍ` fails for
`t ≤ 0`), and develops the properties of it that the L-function estimates consume:

* `resToImagAxis_of_pos`, the characteristic equation;
* `differentiableAt_resToImagAxis`: real-differentiability at every `t > 0` for a
  manifold-differentiable `F`;
* `resToImagAxis_slash_S`: slashing by `S` sends `t` to `1 / t`, the reflection underlying
  the functional equation;
* the predicates `RealOnImagAxis`, `PosOnImagAxis` and `EventuallyPosOnImagAxis`, each closed
  under the pointwise algebraic operations, with the closure lemmas tagged `@[fun_prop]` so
  the side conditions discharge automatically for concrete expressions.

Ported from the AINTLIB `LeanModularForms` project
(`LeanModularForms/Modularforms/ResToImagAxis.lean`). Three deliberate changes from the
source:

* the `Function.resToImagAxis` dot-notation alias (and its two `rfl` `simp` lemmas) is
  dropped — it was a second name for the same definition;
* the unfolding `simp only [Function.resToImagAxis, ResToImagAxis, ht, ↓reduceDIte]`, which
  the source repeats in every proof, is replaced by the single characteristic lemma
  `resToImagAxis_of_pos`;
* eventual positivity is phrased with the `atTop` filter rather than an explicit threshold,
  which lets the `add`/`mul`/`smul` proofs use `filter_upwards` instead of hand-rolled `max`
  bookkeeping.

The source's two AINTLIB dependencies are not needed: `ResToImagAxis` used exactly one
declaration from them, `modular_slash_S_apply`, which is now Mathlib's
`SlashInvariantForm.slash_S_apply`.

Roadmap: ModularForms

Layer 7 (L-functions): the Mellin-transform route to the L-function of a modular form and
its functional equation, for which the restriction to the imaginary axis is the integrand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gn84x8BuMAmGnzTCuvo5D5