### PR TITLE
feat(ModularForms): the ceiling contour integral is a q-circle integral

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
@@ -1,0 +1,106 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.MeasureTheory.Integral.CircleIntegral
+public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.CuspCircle
+
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
+import TauCeti.Analysis.Calculus.PeriodicDeriv
+import TauCeti.Analysis.Complex.Periodic
+import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.Deriv
+
+/-!
+# The ceiling contour integral is a `q`-circle integral
+
+The change of variables for the cusp term of the valence contour: along the truncation
+ceiling the contour derivative is `1`, the `q`-parameter maps the ceiling onto the
+`q`-circle of radius `e^{-2πH}`, and the logarithmic derivative of a width-`1` periodic
+function factors through its cusp function — so the ceiling contour integral of the
+logarithmic derivative equals the `q`-circle integral of the cusp function's logarithmic
+derivative.
+
+## Main declarations
+
+* `TauCeti.ModularForm.intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development (`ForMathlib/ValenceFormula/PVChain/Seg5CuspIntegral.lean`) this file ports
+  onto the current Mathlib pin.
+-/
+
+public section
+
+open Complex Function intervalIntegral MeasureTheory Set
+
+open scoped Real
+
+namespace TauCeti
+
+namespace ModularForm
+
+/-- The ceiling contour integral of the logarithmic derivative of a width-`1` periodic
+function on the upper half-plane is the `q`-circle integral of its cusp function's
+logarithmic derivative: the contour derivative is `1` on the ceiling, the `q`-parameter
+carries the ceiling onto the `q`-circle, and the logarithmic derivative factors through
+the cusp function. -/
+theorem intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction
+    {g : UpperHalfPlane → ℂ} {H : ℝ}
+    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) :
+    ∫ t in (4 : ℝ)..5,
+        deriv (fdBoundary H) t • logDeriv (g ∘ UpperHalfPlane.ofComplex) (fdBoundary H t) =
+      circleIntegral (logDeriv (UpperHalfPlane.cuspFunction 1 g)) 0 (fdBoundaryQRadius H) := by
+  set R := fdBoundaryQRadius H with hR
+  set Lc := logDeriv (UpperHalfPlane.cuspFunction 1 g) with hLc
+  have hcusp : UpperHalfPlane.cuspFunction 1 g =
+      Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex) := rfl
+  -- the circle integrand is `2π`-periodic
+  have hcper : Function.Periodic
+      (fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ)) (2 * π) := fun θ ↦ by
+    simp only []
+    rw [TauCeti.Function.Periodic.deriv (periodic_circleMap 0 R) θ,
+      periodic_circleMap 0 R θ]
+  -- shift the circle integral to `[-π, π]`
+  have h2π : -π + 2 * π = π := by ring
+  have h0π : (0 : ℝ) + 2 * π = 2 * π := by ring
+  have hshift : circleIntegral Lc 0 R = ∫ θ in (-π)..π,
+      deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ) := by
+    rw [circleIntegral, ← h0π, ← Function.Periodic.intervalIntegral_add_eq hcper (-π) 0,
+      h2π]
+  -- substitute the affine angle map `θ = 2π·t + -(9π)`
+  have h := intervalIntegral.integral_comp_mul_add
+    (f := fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ))
+    (by positivity : (2 * π : ℝ) ≠ 0) (-(9 * π)) (a := 4) (b := 5)
+  have h4 : 2 * π * 4 + -(9 * π) = -π := by ring
+  have h5 : 2 * π * 5 + -(9 * π) = π := by ring
+  rw [h4, h5] at h
+  have hcov : (∫ θ in (-π)..π, deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ)) =
+      (2 * π) • ∫ t in (4 : ℝ)..5,
+        deriv (circleMap 0 R) (2 * π * t + -(9 * π)) •
+          Lc (circleMap 0 R (2 * π * t + -(9 * π))) := by
+    rw [h, smul_smul, mul_inv_cancel₀ (by positivity : (2 * π : ℝ) ≠ 0), one_smul]
+  -- identify the substituted integrand with the contour integrand on the open ceiling
+  rw [hshift, hcov, ← intervalIntegral.integral_smul]
+  refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun t ht ↦ ?_
+  have hgt : (4 : ℝ) < t := ht.1
+  have hchain := TauCeti.Periodic.logDeriv_eq_logDeriv_cuspFunction_mul_deriv_qParam
+    (one_ne_zero) hper (fdBoundary_segment5 H t)
+  have hangle : 2 * Real.pi * (t - 9 / 2) = 2 * π * t + -(9 * π) := by ring
+  have hqe : Function.Periodic.qParam 1 (fdBoundary_segment5 H t) =
+      circleMap 0 R (2 * π * t + -(9 * π)) := by
+    rw [qParam_fdBoundary_segment5 H t, hangle, hR]
+  rw [deriv_fdBoundary_of_gt_four hgt, one_smul, fdBoundary_of_gt_four hgt, hchain,
+    TauCeti.Periodic.deriv_qParam, hqe, hLc, hcusp, deriv_circleMap, smul_eq_mul,
+    Complex.real_smul]
+  push_cast
+  ring
+
+end ModularForm
+
+end TauCeti
+
+end

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
@@ -43,6 +43,37 @@ namespace TauCeti
 
 namespace ModularForm
 
+/-- The pointwise ceiling-integrand identification on the open ceiling: the chain rule
+substitutes the cusp function along the `q`-parameter, and the affine angle map matches
+the circle parametrization with Jacobian `2π`. -/
+private lemma ceiling_integrand_eq {g : UpperHalfPlane → ℂ} {H : ℝ}
+    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) {t : ℝ} (hgt : 4 < t) :
+    deriv (fdBoundary H) t • logDeriv (g ∘ UpperHalfPlane.ofComplex) (fdBoundary H t) =
+      (2 * π) • (deriv (circleMap 0 (fdBoundaryQRadius H)) (2 * π * t + -(9 * π)) •
+        logDeriv (Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex))
+          (circleMap 0 (fdBoundaryQRadius H) (2 * π * t + -(9 * π)))) := by
+  have hangle : 2 * Real.pi * (t - 9 / 2) = 2 * π * t + -(9 * π) := by ring
+  have hqe : Function.Periodic.qParam 1 (fdBoundary_segment5 H t) =
+      circleMap 0 (fdBoundaryQRadius H) (2 * π * t + -(9 * π)) := by
+    rw [qParam_fdBoundary_segment5 H t, hangle]
+  calc deriv (fdBoundary H) t • logDeriv (g ∘ UpperHalfPlane.ofComplex) (fdBoundary H t)
+      = logDeriv (g ∘ UpperHalfPlane.ofComplex) (fdBoundary_segment5 H t) := by
+        rw [deriv_fdBoundary_of_gt_four hgt, one_smul, fdBoundary_of_gt_four hgt]
+    _ = logDeriv (Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex))
+          (Function.Periodic.qParam 1 (fdBoundary_segment5 H t)) *
+          deriv (Function.Periodic.qParam 1) (fdBoundary_segment5 H t) :=
+        TauCeti.Periodic.logDeriv_eq_logDeriv_cuspFunction_mul_deriv_qParam one_ne_zero
+          hper (fdBoundary_segment5 H t)
+    _ = logDeriv (Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex))
+          (circleMap 0 (fdBoundaryQRadius H) (2 * π * t + -(9 * π))) *
+          (circleMap 0 (fdBoundaryQRadius H) (2 * π * t + -(9 * π)) *
+            (2 * ↑π * Complex.I / (1 : ℝ))) := by
+        rw [TauCeti.Periodic.deriv_qParam, hqe]
+    _ = _ := by
+        rw [deriv_circleMap, smul_eq_mul, Complex.real_smul]
+        push_cast
+        ring
+
 /-- The ceiling contour integral of the logarithmic derivative of a width-`1` periodic
 function on the upper half-plane is the `q`-circle integral of its cusp function's
 logarithmic derivative: the contour derivative is `1` on the ceiling, the `q`-parameter
@@ -87,18 +118,8 @@ theorem intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunc
   -- identify the substituted integrand with the contour integrand on the open ceiling
   rw [hshift, hcov, ← intervalIntegral.integral_smul]
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun t ht ↦ ?_
-  have hgt : (4 : ℝ) < t := ht.1
-  have hchain := TauCeti.Periodic.logDeriv_eq_logDeriv_cuspFunction_mul_deriv_qParam
-    (one_ne_zero) hper (fdBoundary_segment5 H t)
-  have hangle : 2 * Real.pi * (t - 9 / 2) = 2 * π * t + -(9 * π) := by ring
-  have hqe : Function.Periodic.qParam 1 (fdBoundary_segment5 H t) =
-      circleMap 0 R (2 * π * t + -(9 * π)) := by
-    rw [qParam_fdBoundary_segment5 H t, hangle, hR]
-  rw [deriv_fdBoundary_of_gt_four hgt, one_smul, fdBoundary_of_gt_four hgt, hchain,
-    TauCeti.Periodic.deriv_qParam, hqe, hLc, hcusp, deriv_circleMap, smul_eq_mul,
-    Complex.real_smul]
-  push_cast
-  ring
+  rw [hLc, hcusp, hR]
+  exact ceiling_integrand_eq hper ht.1
 
 end ModularForm
 

--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.MeasureTheory.Integral.CircleIntegral
 public import TauCeti.NumberTheory.ModularForms.LevelOne.FundamentalDomainBoundary.CuspCircle
 
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.Periodic
@@ -24,7 +23,8 @@ derivative.
 
 ## Main declarations
 
-* `TauCeti.ModularForm.intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction`.
+* `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunction`
+  (the ceiling bridge).
 
 ## References
 
@@ -48,7 +48,7 @@ function on the upper half-plane is the `q`-circle integral of its cusp function
 logarithmic derivative: the contour derivative is `1` on the ceiling, the `q`-parameter
 carries the ceiling onto the `q`-circle, and the logarithmic derivative factors through
 the cusp function. -/
-theorem intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction
+theorem intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunction
     {g : UpperHalfPlane → ℂ} {H : ℝ}
     (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1) :
     ∫ t in (4 : ℝ)..5,
@@ -57,7 +57,8 @@ theorem intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction
   set R := fdBoundaryQRadius H with hR
   set Lc := logDeriv (UpperHalfPlane.cuspFunction 1 g) with hLc
   have hcusp : UpperHalfPlane.cuspFunction 1 g =
-      Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex) := rfl
+      Function.Periodic.cuspFunction 1 (g ∘ UpperHalfPlane.ofComplex) := by
+    simp [UpperHalfPlane.cuspFunction]
   -- the circle integrand is `2π`-periodic
   have hcper : Function.Periodic
       (fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ)) (2 * π) := fun θ ↦ by
@@ -72,17 +73,17 @@ theorem intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction
     rw [circleIntegral, ← h0π, ← Function.Periodic.intervalIntegral_add_eq hcper (-π) 0,
       h2π]
   -- substitute the affine angle map `θ = 2π·t + -(9π)`
-  have h := intervalIntegral.integral_comp_mul_add
-    (f := fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ))
-    (by positivity : (2 * π : ℝ) ≠ 0) (-(9 * π)) (a := 4) (b := 5)
   have h4 : 2 * π * 4 + -(9 * π) = -π := by ring
   have h5 : 2 * π * 5 + -(9 * π) = π := by ring
-  rw [h4, h5] at h
   have hcov : (∫ θ in (-π)..π, deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ)) =
       (2 * π) • ∫ t in (4 : ℝ)..5,
         deriv (circleMap 0 R) (2 * π * t + -(9 * π)) •
           Lc (circleMap 0 R (2 * π * t + -(9 * π))) := by
-    rw [h, smul_smul, mul_inv_cancel₀ (by positivity : (2 * π : ℝ) ≠ 0), one_smul]
+    have h := intervalIntegral.smul_integral_comp_mul_add
+      (f := fun θ ↦ deriv (circleMap 0 R) θ • Lc (circleMap 0 R θ))
+      (2 * π) (-(9 * π)) (a := 4) (b := 5)
+    rw [h4, h5] at h
+    exact h.symm
   -- identify the substituted integrand with the contour integrand on the open ceiling
   rw [hshift, hcov, ← intervalIntegral.integral_smul]
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun t ht ↦ ?_


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The change of variables for the cusp term of the valence contour:

- `intervalIntegral_ceiling_eq_circleIntegral_logDeriv_cuspFunction
  (hper : Function.Periodic (g ∘ ofComplex) 1) :
  ∫ t in 4..5, deriv (fdBoundary H) t • logDeriv (g ∘ ofComplex) (fdBoundary H t) =
  circleIntegral (logDeriv (cuspFunction 1 g)) 0 (fdBoundaryQRadius H)`

Along the ceiling the contour derivative is `1`, the `q`-parameter carries the ceiling
onto the `q`-circle (#2128), and the logarithmic derivative factors through the cusp
function by the junk-compatible chain rule (#2130) — so only periodicity is assumed.
The proof shifts the circle integral to the principal period `[-π, π]` (the circle
integrand is `2π`-periodic via `Periodic.deriv` from #2107) and substitutes the affine
angle map.

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): composed with
the `q`-circle evaluation (#2144), the ceiling contour integral of a level-one form's
logarithmic derivative is `2πi · qExpansionOrderAtCusp` — the `ord_∞` term. This is the
last change-of-variables lemma of the integral-evaluation side (verticals #2117, arc
#2134, ceiling here).

Roadmap: ModularForms
