### PR TITLE
feat: the Dixon-Schneider specification of a character table

### DIFF
--- a/TauCeti/Algebra/Group/ConjFinite.lean
+++ b/TauCeti/Algebra/Group/ConjFinite.lean
@@ -1,0 +1,56 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.Group.ConjFinite
+
+/-!
+# Sizes of conjugacy classes
+
+Two elementary facts about the carrier of a conjugacy class: the class of the identity is the
+singleton `{1}`, and every class of a finite group is nonempty.
+
+## Main results
+
+* `TauCeti.ConjClasses.carrier_mk_one`: the class of `1` is `{1}`, with its counting form
+  `TauCeti.ConjClasses.card_carrier_mk_one`.
+* `TauCeti.ConjClasses.card_carrier_pos`: a conjugacy class of a finite group has positive size.
+-/
+
+public section
+
+namespace TauCeti
+
+namespace ConjClasses
+
+variable {G : Type*} [Group G]
+
+/-- **The conjugacy class of the identity is the singleton `{1}`**: an element conjugate to `1` is
+`1`. -/
+@[simp]
+theorem carrier_mk_one : (_root_.ConjClasses.mk (1 : G)).carrier = {1} := by
+  ext g
+  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq, _root_.ConjClasses.mk_eq_mk_iff_isConj,
+    isConj_one_left, Set.mem_singleton_iff]
+
+/-- **The identity conjugacy class has exactly one element.** This is the weight that normalizes the
+identity column of a character table.
+
+This is not a `@[simp]` lemma: `Nat.card` of a coerced set is not in simp normal form, `Set.ncard`
+being what `Nat.card_coe_set_eq` rewrites it to. -/
+theorem card_carrier_mk_one : Nat.card (_root_.ConjClasses.mk (1 : G)).carrier = 1 := by
+  rw [carrier_mk_one]
+  simp
+
+/-- **A conjugacy class of a finite group has positive size**: it contains any of its
+representatives. -/
+theorem card_carrier_pos [Finite G] (C : _root_.ConjClasses G) : 0 < Nat.card C.carrier := by
+  obtain ⟨g, rfl⟩ := C.exists_rep
+  have : Nonempty (_root_.ConjClasses.mk g).carrier := ⟨⟨g, _root_.ConjClasses.mem_carrier_mk⟩⟩
+  exact Nat.card_pos
+
+end ConjClasses
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Group.ConjFinite
+public import TauCeti.Algebra.Group.ConjFinite
 public import Mathlib.Algebra.Algebra.Subalgebra.Basic
 public import Mathlib.Algebra.MonoidAlgebra.Basic
 
@@ -14,11 +14,6 @@ public import Mathlib.Algebra.MonoidAlgebra.Basic
 This file defines the element of a group algebra obtained by summing the members of a conjugacy
 class.  It proves that every class sum is central, the first input to the class-algebra side of
 finite-group character theory.
-
-It also records the two elementary facts about the sizes of conjugacy classes that the class-sum
-bookkeeping needs: the class of the identity is the singleton `{1}`
-(`TauCeti.ConjClasses.carrier_mk_one`), and every class of a finite group has positive size
-(`TauCeti.ConjClasses.card_carrier_pos`).
 -/
 
 public section
@@ -97,36 +92,6 @@ theorem classSum_commutes {k : Type*} [Semiring k] (C : ConjClasses G) (g : G) :
   simp [mul_assoc]
 
 end
-
-namespace ConjClasses
-
-omit [Fintype G] [DecidableEq G] in
-/-- **The conjugacy class of the identity is the singleton `{1}`**: an element conjugate to `1` is
-`1`. -/
-theorem carrier_mk_one : (_root_.ConjClasses.mk (1 : G)).carrier = {1} := by
-  ext g
-  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq, _root_.ConjClasses.mk_eq_mk_iff_isConj,
-    isConj_one_left, Set.mem_singleton_iff]
-
-omit [Fintype G] [DecidableEq G] in
-/-- **The identity conjugacy class has exactly one element.** This is the weight that normalizes the
-identity column of a character table.
-
-This is not a `@[simp]` lemma: `Nat.card` of a coerced set is not in simp normal form, `Set.ncard`
-being what `Nat.card_coe_set_eq` rewrites it to. -/
-theorem card_carrier_mk_one : Nat.card (_root_.ConjClasses.mk (1 : G)).carrier = 1 := by
-  rw [carrier_mk_one]
-  simp
-
-omit [Fintype G] [DecidableEq G] in
-/-- **A conjugacy class of a finite group has positive size**: it contains any of its
-representatives. -/
-theorem card_carrier_pos [Finite G] (C : _root_.ConjClasses G) : 0 < Nat.card C.carrier := by
-  obtain ⟨g, rfl⟩ := C.exists_rep
-  have : Nonempty (_root_.ConjClasses.mk g).carrier := ⟨⟨g, _root_.ConjClasses.mem_carrier_mk⟩⟩
-  exact Nat.card_pos
-
-end ConjClasses
 
 /-- The class sum of the conjugacy class of `1` is the unit of the group algebra: that class is the
 singleton `{1}` (`TauCeti.ConjClasses.carrier_mk_one`). -/

--- a/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean
@@ -14,6 +14,11 @@ public import Mathlib.Algebra.MonoidAlgebra.Basic
 This file defines the element of a group algebra obtained by summing the members of a conjugacy
 class.  It proves that every class sum is central, the first input to the class-algebra side of
 finite-group character theory.
+
+It also records the two elementary facts about the sizes of conjugacy classes that the class-sum
+bookkeeping needs: the class of the identity is the singleton `{1}`
+(`TauCeti.ConjClasses.carrier_mk_one`), and every class of a finite group has positive size
+(`TauCeti.ConjClasses.card_carrier_pos`).
 -/
 
 public section
@@ -93,8 +98,38 @@ theorem classSum_commutes {k : Type*} [Semiring k] (C : ConjClasses G) (g : G) :
 
 end
 
+namespace ConjClasses
+
+omit [Fintype G] [DecidableEq G] in
+/-- **The conjugacy class of the identity is the singleton `{1}`**: an element conjugate to `1` is
+`1`. -/
+theorem carrier_mk_one : (_root_.ConjClasses.mk (1 : G)).carrier = {1} := by
+  ext g
+  rw [_root_.ConjClasses.mem_carrier_iff_mk_eq, _root_.ConjClasses.mk_eq_mk_iff_isConj,
+    isConj_one_left, Set.mem_singleton_iff]
+
+omit [Fintype G] [DecidableEq G] in
+/-- **The identity conjugacy class has exactly one element.** This is the weight that normalizes the
+identity column of a character table.
+
+This is not a `@[simp]` lemma: `Nat.card` of a coerced set is not in simp normal form, `Set.ncard`
+being what `Nat.card_coe_set_eq` rewrites it to. -/
+theorem card_carrier_mk_one : Nat.card (_root_.ConjClasses.mk (1 : G)).carrier = 1 := by
+  rw [carrier_mk_one]
+  simp
+
+omit [Fintype G] [DecidableEq G] in
+/-- **A conjugacy class of a finite group has positive size**: it contains any of its
+representatives. -/
+theorem card_carrier_pos [Finite G] (C : _root_.ConjClasses G) : 0 < Nat.card C.carrier := by
+  obtain ⟨g, rfl⟩ := C.exists_rep
+  have : Nonempty (_root_.ConjClasses.mk g).carrier := ⟨⟨g, _root_.ConjClasses.mem_carrier_mk⟩⟩
+  exact Nat.card_pos
+
+end ConjClasses
+
 /-- The class sum of the conjugacy class of `1` is the unit of the group algebra: that class is the
-singleton `{1}`. -/
+singleton `{1}` (`TauCeti.ConjClasses.carrier_mk_one`). -/
 @[simp]
 theorem classSum_mk_one (k : Type*) [Semiring k] :
     classSum k (ConjClasses.mk (1 : G)) = 1 := by

--- a/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
@@ -45,7 +45,7 @@ orthonormality forbids repetitions, so the matching is a permutation.
 * `TauCeti.characterTable_unique_rows`: **labeled uniqueness**, a matrix satisfying the
   specification is the character table up to a permutation of rows. With
   `TauCeti.IsCharacterTableSpec.submatrix`, that a row permutation preserves the specification, this
-  becomes the characterization `TauCeti.isCharacterTableSpec_iff_exists_equiv` of the matrices
+  becomes the characterization `TauCeti.isCharacterTableSpec_iff_exists_perm` of the matrices
   satisfying it, and `TauCeti.IsCharacterTableSpec.exists_perm_eq`: any two of them differ by a
   permutation of rows.
 * `TauCeti.IsCharacterTableSpec.exists_eq_characterTable`: the row-by-row form of uniqueness, that
@@ -59,8 +59,9 @@ the Hermitian one, which is the form the algorithm checks. The normalized row
 `TauCeti.centralCharacterRow_characterTable` (the normalized rows of the character table are the
 rows of the central character table) is available wherever the two tables are.
 
-The group is left implicit in `TauCeti.IsCharacterTableSpec`, being determined by the type of the
-matrix.
+The group is an explicit argument of `TauCeti.IsCharacterTableSpec`, as the roadmap pins it: the
+specification is read as a statement about `G`, and `IsCharacterTableSpec G M` says what it says
+without having to recover `G` from the type of `M`.
 
 Three of the four conditions do the work in `TauCeti.characterTable_unique_rows`: the positivity
 and integrality of the degrees, row orthonormality, and the eigenrow condition. The divisibility
@@ -164,7 +165,7 @@ labeled by the conjugacy classes of `G` satisfies it when
 These are conditions on the structure constants of the class algebra and on the entries of `M`
 alone, mentioning no representation, and they determine `M` up to a permutation of its rows
 (`TauCeti.characterTable_unique_rows`). -/
-structure IsCharacterTableSpec
+structure IsCharacterTableSpec (G : Type v) [Group G] [Fintype G] [DecidableEq G]
     (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ) : Prop where
   /-- The identity column consists of positive integers dividing the order of `G`. -/
   exists_degree : ∀ i, ∃ d : ℕ, 0 < d ∧ M i (ConjClasses.mk 1) = (d : ℂ) ∧ d ∣ Nat.card G
@@ -181,7 +182,7 @@ which are positive and divide `|G|` and whose squares sum to `|G|`; the rows are
 first orthogonality relation; and the normalized rows are the rows of the central character table,
 which are eigenrows because a central character is an algebra homomorphism out of the centre. -/
 theorem isCharacterTableSpec_characterTable (G : Type v) [Group G] [Fintype G] [DecidableEq G] :
-    IsCharacterTableSpec (characterTable ℂ G) where
+    IsCharacterTableSpec G (characterTable ℂ G) where
   exists_degree i :=
     ⟨characterDegree ℂ i, characterDegree_pos ℂ i, characterTable_one i,
       characterDegree_dvd_card ℂ i⟩
@@ -199,7 +200,7 @@ theorem isCharacterTableSpec_characterTable (G : Type v) [Group G] [Fintype G] [
 
 namespace IsCharacterTableSpec
 
-variable (hM : IsCharacterTableSpec M) (i : Fin (Nat.card (ConjClasses G)))
+variable (hM : IsCharacterTableSpec G M) (i : Fin (Nat.card (ConjClasses G)))
 include hM
 
 /-- The identity column of a matrix satisfying the specification has no zero entry. -/
@@ -268,7 +269,7 @@ theorem exists_eq_characterTable : ∃ j, ∀ C, M i C = characterTable ℂ G j 
 
 /-- Permuting the rows of a matrix satisfying the specification gives a matrix satisfying it. -/
 theorem submatrix (σ : Equiv.Perm (Fin (Nat.card (ConjClasses G)))) :
-    IsCharacterTableSpec (M.submatrix σ id) where
+    IsCharacterTableSpec G (M.submatrix σ id) where
   exists_degree i := hM.exists_degree (σ i)
   sum_degree_sq := by
     rw [← hM.sum_degree_sq]
@@ -290,7 +291,7 @@ its rows, and of its rows only.
 Each row is a row of the character table (`TauCeti.IsCharacterTableSpec.exists_eq_characterTable`),
 and the assignment is injective because two equal rows would pair to `1` rather than to `0`; an
 injective self-map of a finite type is a permutation. -/
-theorem characterTable_unique_rows (hM : IsCharacterTableSpec M) :
+theorem characterTable_unique_rows (hM : IsCharacterTableSpec G M) :
     ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))),
       M = (characterTable ℂ G).submatrix σ id := by
   choose τ hτ using hM.exists_eq_characterTable
@@ -308,8 +309,8 @@ theorem characterTable_unique_rows (hM : IsCharacterTableSpec M) :
 
 /-- **The matrices satisfying the specification are exactly the row permutations of the character
 table**: the specification recognizes the character table, and nothing else. -/
-theorem isCharacterTableSpec_iff_exists_equiv :
-    IsCharacterTableSpec M ↔ ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))),
+theorem isCharacterTableSpec_iff_exists_perm :
+    IsCharacterTableSpec G M ↔ ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))),
       M = (characterTable ℂ G).submatrix σ id :=
   ⟨characterTable_unique_rows, by
     rintro ⟨σ, rfl⟩
@@ -320,10 +321,10 @@ character table up to such a permutation, so a solver that returns a matrix pass
 returned the same table as any other. -/
 theorem IsCharacterTableSpec.exists_perm_eq
     {N : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ}
-    (hM : IsCharacterTableSpec M) (hN : IsCharacterTableSpec N) :
+    (hM : IsCharacterTableSpec G M) (hN : IsCharacterTableSpec G N) :
     ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))), M = N.submatrix σ id := by
-  obtain ⟨σ, rfl⟩ := isCharacterTableSpec_iff_exists_equiv.mp hM
-  obtain ⟨τ, rfl⟩ := isCharacterTableSpec_iff_exists_equiv.mp hN
+  obtain ⟨σ, rfl⟩ := isCharacterTableSpec_iff_exists_perm.mp hM
+  obtain ⟨τ, rfl⟩ := isCharacterTableSpec_iff_exists_perm.mp hN
   exact ⟨τ⁻¹ * σ, by ext i C; simp⟩
 
 end Spec

--- a/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
@@ -57,7 +57,10 @@ The specification is stated over `ℂ`, where the roadmap pins it: its orthonorm
 the Hermitian one, which is the form the algorithm checks. The normalized row
 `TauCeti.centralCharacterRow` needs no such restriction and is defined over any field, so that
 `TauCeti.centralCharacterRow_characterTable` (the normalized rows of the character table are the
-rows of the central character table) is available wherever the two tables are.
+rows of the central character table) is available wherever the two tables are. Normalizing reads
+only the row it is given, so it is also defined for a matrix with any row index type, and only
+`TauCeti.centralCharacterRow_characterTable` and the specification itself ask for the character
+table's.
 
 The group is an explicit argument of `TauCeti.IsCharacterTableSpec`, as the roadmap pins it: the
 specification is read as a statement about `G`, and `IsCharacterTableSpec G M` says what it says
@@ -89,9 +92,8 @@ universe u v
 
 section Row
 
-variable {k : Type u} {G : Type v} [Field k] [Group G]
-  {M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k}
-  {i : Fin (Nat.card (ConjClasses G))}
+variable {ι : Type*} {k : Type u} {G : Type v} [Field k] [Group G]
+  {M : Matrix ι (ConjClasses G) k} {i : ι}
 
 /-- **The normalized row** `ω_i(K_C) = |C| · M i C / M i 1` of a candidate character table `M`.
 
@@ -99,18 +101,15 @@ For the character table itself this is the corresponding row of the central char
 (`TauCeti.centralCharacterRow_characterTable`), which is why the specification of a character table
 asks for its normalized rows, rather than its rows, to be eigenrows of the class-multiplication
 matrices. -/
-noncomputable def centralCharacterRow
-    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
-    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) : k :=
+noncomputable def centralCharacterRow (M : Matrix ι (ConjClasses G) k) (i : ι) (C : ConjClasses G) :
+    k :=
   (Nat.card C.carrier : k) * M i C / M i (ConjClasses.mk 1)
 
 /-- The normalized row, unfolded. The definition is not `@[expose]`d, so this is how it unfolds
 outside this file; it is deliberately not `@[simp]`, because the specification and its consequences
 are stated about `TauCeti.centralCharacterRow` as a whole, and unfolding it would take them out of
 the shape in which the eigenrow API applies. -/
-theorem centralCharacterRow_apply
-    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
-    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) :
+theorem centralCharacterRow_apply (M : Matrix ι (ConjClasses G) k) (i : ι) (C : ConjClasses G) :
     centralCharacterRow M i C = (Nat.card C.carrier : k) * M i C / M i (ConjClasses.mk 1) :=
   (rfl)
 
@@ -127,12 +126,12 @@ theorem centralCharacterRow_mul (hM : M i (ConjClasses.mk 1) ≠ 0) (C : ConjCla
     centralCharacterRow M i C * M i (ConjClasses.mk 1) = (Nat.card C.carrier : k) * M i C := by
   rw [centralCharacterRow_apply, div_mul_cancel₀ _ hM]
 
-/-- Permuting the rows of a matrix permutes its normalized rows. -/
+/-- Reindexing the rows of a matrix reindexes its normalized rows; in particular a permutation of
+the rows permutes them. -/
 @[simp]
-theorem centralCharacterRow_submatrix
-    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
-    (σ : Equiv.Perm (Fin (Nat.card (ConjClasses G)))) (i : Fin (Nat.card (ConjClasses G))) :
-    centralCharacterRow (M.submatrix σ id) i = centralCharacterRow M (σ i) := by
+theorem centralCharacterRow_submatrix {ι' : Type*} (M : Matrix ι (ConjClasses G) k) (e : ι' → ι)
+    (i : ι') :
+    centralCharacterRow (M.submatrix e id) i = centralCharacterRow M (e i) := by
   funext C
   rw [centralCharacterRow_apply, centralCharacterRow_apply, Matrix.submatrix_apply,
     Matrix.submatrix_apply, id_eq, id_eq]
@@ -142,7 +141,8 @@ variable [Fintype G] [DecidableEq G] [IsAlgClosed k] [Invertible (Nat.card G : k
 /-- **The normalized rows of the character table are the rows of the central character table.**
 Both say `ω_i(K_C) = |C| · χᵢ(g_C) / χᵢ(1)`; the hypothesis is that the degree `χᵢ(1)` does not
 vanish in `k`, which holds automatically in characteristic zero. -/
-theorem centralCharacterRow_characterTable (hdeg : (characterDegree k i : k) ≠ 0) :
+theorem centralCharacterRow_characterTable {i : Fin (Nat.card (ConjClasses G))}
+    (hdeg : (characterDegree k i : k) ≠ 0) :
     centralCharacterRow (characterTable k G) i = centralCharacterTable k G i := by
   funext C
   rw [centralCharacterRow_apply, characterTable_one, centralCharacterTable_eq_div i hdeg C]

--- a/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
@@ -115,6 +115,7 @@ theorem centralCharacterRow_apply
 
 /-- The normalized row is normalized: it takes the value `1` on the class of the identity, whose
 size is `1`. -/
+@[simp]
 theorem centralCharacterRow_mk_one (hM : M i (ConjClasses.mk 1) ≠ 0) :
     centralCharacterRow M i (ConjClasses.mk (1 : G)) = 1 := by
   rw [centralCharacterRow_apply, ConjClasses.card_carrier_mk_one, Nat.cast_one, one_mul,
@@ -126,6 +127,7 @@ theorem centralCharacterRow_mul (hM : M i (ConjClasses.mk 1) ≠ 0) (C : ConjCla
   rw [centralCharacterRow_apply, div_mul_cancel₀ _ hM]
 
 /-- Permuting the rows of a matrix permutes its normalized rows. -/
+@[simp]
 theorem centralCharacterRow_submatrix
     (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
     (σ : Equiv.Perm (Fin (Nat.card (ConjClasses G)))) (i : Fin (Nat.card (ConjClasses G))) :

--- a/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Specification.lean
@@ -1,0 +1,329 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.CharacterTable.Eigenrow
+
+/-!
+# The specification a character table satisfies, and the labeled uniqueness it forces
+
+Let `G` be a finite group. Its complex character table `TauCeti.characterTable ℂ G` is a square
+matrix whose rows are indexed by an arbitrary enumeration of the irreducible characters and whose
+columns are labeled by the conjugacy classes themselves. This file writes down a property
+`TauCeti.IsCharacterTableSpec` of an *arbitrary* such matrix, proves that the character table has
+it, and proves that it pins the character table down: **any matrix with this property is the
+character table up to a permutation of its rows**.
+
+The property is the checker of the Burnside--Dixon--Schneider algorithm. Its three ingredients are
+the data that algorithm produces and can verify without knowing any representation theory:
+
+* the identity column consists of positive integers dividing `|G|` whose squares sum to `|G|`;
+* the rows are orthonormal for the class-size weighted Hermitian pairing;
+* each **normalized row** `ω_i(K_C) = |C| · M i C / M i 1` (`TauCeti.centralCharacterRow`) is a
+  common left eigenrow of the class-multiplication matrices, the eigenvalue at `C` being its own
+  value there.
+
+Uniqueness is the reason this is worth having: an algorithm that returns *a* matrix passing the
+checker has returned *the* character table. The proof matches each normalized row with a row of the
+central character table `Ω` (`TauCeti.isClassEigenrow_iff_exists_centralCharacterTable_eq`, which
+identifies the normalized common left eigenrows with the central characters of the irreducibles),
+recovers the degree of that irreducible from the self-pairing of the row, and reads the ordinary row
+off `Ω` by `TauCeti.characterTable_eq_div`. Distinct rows of the matrix stay distinct because
+orthonormality forbids repetitions, so the matching is a permutation.
+
+## Main definitions
+
+* `TauCeti.centralCharacterRow`: the normalized row `ω_i` of a candidate character table.
+* `TauCeti.IsCharacterTableSpec`: the specification itself.
+
+## Main results
+
+* `TauCeti.isCharacterTableSpec_characterTable`: **the character table satisfies the
+  specification**.
+* `TauCeti.characterTable_unique_rows`: **labeled uniqueness**, a matrix satisfying the
+  specification is the character table up to a permutation of rows. With
+  `TauCeti.IsCharacterTableSpec.submatrix`, that a row permutation preserves the specification, this
+  becomes the characterization `TauCeti.isCharacterTableSpec_iff_exists_equiv` of the matrices
+  satisfying it, and `TauCeti.IsCharacterTableSpec.exists_perm_eq`: any two of them differ by a
+  permutation of rows.
+* `TauCeti.IsCharacterTableSpec.exists_eq_characterTable`: the row-by-row form of uniqueness, that
+  every row is a row of the character table.
+
+## Implementation notes
+
+The specification is stated over `ℂ`, where the roadmap pins it: its orthonormality condition is
+the Hermitian one, which is the form the algorithm checks. The normalized row
+`TauCeti.centralCharacterRow` needs no such restriction and is defined over any field, so that
+`TauCeti.centralCharacterRow_characterTable` (the normalized rows of the character table are the
+rows of the central character table) is available wherever the two tables are.
+
+The group is left implicit in `TauCeti.IsCharacterTableSpec`, being determined by the type of the
+matrix.
+
+Three of the four conditions do the work in `TauCeti.characterTable_unique_rows`: the positivity
+and integrality of the degrees, row orthonormality, and the eigenrow condition. The divisibility
+`dᵢ ∣ |G|` and the identity `∑ dᵢ² = |G|` are part of the checker as the roadmap pins it, being
+what the algorithm tests after the eigenvector search and before lifting; they are recorded here
+because the character table satisfies them, not because uniqueness needs them.
+
+## References
+
+This is the specification and the labeled uniqueness of Layer 5 of the
+[character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md)
+(`IsCharacterTableSpec`, `isCharacterTableSpec_characterTable` and `characterTable_unique_rows` in
+that roadmap's `Suggested.lean`). See J. D. Dixon, *High speed computation of group characters*,
+Numer. Math. 10 (1967) 446-450, and I. M. Isaacs, *Character Theory of Finite Groups* (1976),
+Chapter 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Matrix
+
+universe u v
+
+section Row
+
+variable {k : Type u} {G : Type v} [Field k] [Group G]
+  {M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k}
+  {i : Fin (Nat.card (ConjClasses G))}
+
+/-- **The normalized row** `ω_i(K_C) = |C| · M i C / M i 1` of a candidate character table `M`.
+
+For the character table itself this is the corresponding row of the central character table
+(`TauCeti.centralCharacterRow_characterTable`), which is why the specification of a character table
+asks for its normalized rows, rather than its rows, to be eigenrows of the class-multiplication
+matrices. -/
+noncomputable def centralCharacterRow
+    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
+    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) : k :=
+  (Nat.card C.carrier : k) * M i C / M i (ConjClasses.mk 1)
+
+/-- The normalized row, unfolded. The definition is not `@[expose]`d, so this is how it unfolds
+outside this file; it is deliberately not `@[simp]`, because the specification and its consequences
+are stated about `TauCeti.centralCharacterRow` as a whole, and unfolding it would take them out of
+the shape in which the eigenrow API applies. -/
+theorem centralCharacterRow_apply
+    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
+    (i : Fin (Nat.card (ConjClasses G))) (C : ConjClasses G) :
+    centralCharacterRow M i C = (Nat.card C.carrier : k) * M i C / M i (ConjClasses.mk 1) :=
+  (rfl)
+
+/-- The normalized row is normalized: it takes the value `1` on the class of the identity, whose
+size is `1`. -/
+theorem centralCharacterRow_mk_one (hM : M i (ConjClasses.mk 1) ≠ 0) :
+    centralCharacterRow M i (ConjClasses.mk (1 : G)) = 1 := by
+  rw [centralCharacterRow_apply, ConjClasses.card_carrier_mk_one, Nat.cast_one, one_mul,
+    div_self hM]
+
+/-- Normalizing a row, in the division-free form: `ω_i(K_C) · M i 1 = |C| · M i C`. -/
+theorem centralCharacterRow_mul (hM : M i (ConjClasses.mk 1) ≠ 0) (C : ConjClasses G) :
+    centralCharacterRow M i C * M i (ConjClasses.mk 1) = (Nat.card C.carrier : k) * M i C := by
+  rw [centralCharacterRow_apply, div_mul_cancel₀ _ hM]
+
+/-- Permuting the rows of a matrix permutes its normalized rows. -/
+theorem centralCharacterRow_submatrix
+    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) k)
+    (σ : Equiv.Perm (Fin (Nat.card (ConjClasses G)))) (i : Fin (Nat.card (ConjClasses G))) :
+    centralCharacterRow (M.submatrix σ id) i = centralCharacterRow M (σ i) := by
+  funext C
+  rw [centralCharacterRow_apply, centralCharacterRow_apply, Matrix.submatrix_apply,
+    Matrix.submatrix_apply, id_eq, id_eq]
+
+variable [Fintype G] [DecidableEq G] [IsAlgClosed k] [Invertible (Nat.card G : k)]
+
+/-- **The normalized rows of the character table are the rows of the central character table.**
+Both say `ω_i(K_C) = |C| · χᵢ(g_C) / χᵢ(1)`; the hypothesis is that the degree `χᵢ(1)` does not
+vanish in `k`, which holds automatically in characteristic zero. -/
+theorem centralCharacterRow_characterTable (hdeg : (characterDegree k i : k) ≠ 0) :
+    centralCharacterRow (characterTable k G) i = centralCharacterTable k G i := by
+  funext C
+  rw [centralCharacterRow_apply, characterTable_one, centralCharacterTable_eq_div i hdeg C]
+
+end Row
+
+section Spec
+
+variable {G : Type v} [Group G] [Fintype G] [DecidableEq G]
+  {M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ}
+
+/-- **The specification of a complex character table.** A square matrix `M` whose columns are
+labeled by the conjugacy classes of `G` satisfies it when
+
+* its identity column consists of positive integers dividing `|G|`, whose squares sum to `|G|`;
+* its rows are orthonormal for the class-size weighted Hermitian pairing on class functions;
+* each of its normalized rows `TauCeti.centralCharacterRow` is a common left eigenrow of the
+  class-multiplication matrices of `G` (`TauCeti.IsClassEigenrow`).
+
+These are conditions on the structure constants of the class algebra and on the entries of `M`
+alone, mentioning no representation, and they determine `M` up to a permutation of its rows
+(`TauCeti.characterTable_unique_rows`). -/
+structure IsCharacterTableSpec
+    (M : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ) : Prop where
+  /-- The identity column consists of positive integers dividing the order of `G`. -/
+  exists_degree : ∀ i, ∃ d : ℕ, 0 < d ∧ M i (ConjClasses.mk 1) = (d : ℂ) ∧ d ∣ Nat.card G
+  /-- The squares of the identity column sum to the order of `G`. -/
+  sum_degree_sq : ∑ i, M i (ConjClasses.mk 1) ^ 2 = (Nat.card G : ℂ)
+  /-- The rows are orthonormal for the class-size weighted Hermitian pairing. -/
+  row_orthonormal : ∀ i j, (Nat.card G : ℂ)⁻¹ * ∑ C : ConjClasses G,
+      (Nat.card C.carrier : ℂ) * M i C * (starRingEnd ℂ) (M j C) = if i = j then 1 else 0
+  /-- Each normalized row is a common left eigenrow of the class-multiplication matrices. -/
+  row_eigen : ∀ i, IsClassEigenrow (centralCharacterRow M i)
+
+/-- **The character table satisfies its specification.** The identity column lists the degrees,
+which are positive and divide `|G|` and whose squares sum to `|G|`; the rows are orthonormal by the
+first orthogonality relation; and the normalized rows are the rows of the central character table,
+which are eigenrows because a central character is an algebra homomorphism out of the centre. -/
+theorem isCharacterTableSpec_characterTable (G : Type v) [Group G] [Fintype G] [DecidableEq G] :
+    IsCharacterTableSpec (characterTable ℂ G) where
+  exists_degree i :=
+    ⟨characterDegree ℂ i, characterDegree_pos ℂ i, characterTable_one i,
+      characterDegree_dvd_card ℂ i⟩
+  sum_degree_sq := by
+    simp only [characterTable_one]
+    exact_mod_cast congrArg (Nat.cast (R := ℂ))
+      (sum_characterDegree_sq_eq_card (k := ℂ) (G := G))
+  row_orthonormal i j :=
+    (card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj i j).trans
+      (if_congr Iff.rfl rfl rfl)
+  row_eigen i := by
+    rw [centralCharacterRow_characterTable
+      (Nat.cast_ne_zero.mpr (characterDegree_pos ℂ i).ne')]
+    exact isClassEigenrow_centralCharacterTable i
+
+namespace IsCharacterTableSpec
+
+variable (hM : IsCharacterTableSpec M) (i : Fin (Nat.card (ConjClasses G)))
+include hM
+
+/-- The identity column of a matrix satisfying the specification has no zero entry. -/
+theorem apply_mk_one_ne_zero : M i (ConjClasses.mk 1) ≠ 0 := by
+  obtain ⟨d, hd, hMd, -⟩ := hM.exists_degree i
+  rw [hMd]
+  exact_mod_cast hd.ne'
+
+/-- **Every row of a matrix satisfying the specification is a row of the character table.**
+
+Its normalized row is a normalized common left eigenrow of the class-multiplication matrices, hence
+the central character of some irreducible; the self-pairing of the row then forces the degree of
+that irreducible to be the identity entry of the row, and the two rows agree class by class. -/
+theorem exists_eq_characterTable : ∃ j, ∀ C, M i C = characterTable ℂ G j C := by
+  obtain ⟨d, hdpos, hMd, -⟩ := hM.exists_degree i
+  obtain ⟨j, hj⟩ := (isClassEigenrow_iff_exists_centralCharacterTable_eq
+    (centralCharacterRow_mk_one (hM.apply_mk_one_ne_zero i))).mp (hM.row_eigen i)
+  have hcard : ∀ C : ConjClasses G, (Nat.card (ConjClasses.carrier C) : ℂ) ≠ 0 := fun C =>
+    Nat.cast_ne_zero.mpr (ConjClasses.card_carrier_pos C).ne'
+  have he : (characterDegree ℂ j : ℂ) ≠ 0 :=
+    Nat.cast_ne_zero.mpr (characterDegree_pos ℂ j).ne'
+  -- The two rows are proportional, with the degrees as the constants of proportionality.
+  have key : ∀ C, (characterDegree ℂ j : ℂ) * M i C = (d : ℂ) * characterTable ℂ G j C := by
+    intro C
+    have h₁ := centralCharacterRow_mul (hM.apply_mk_one_ne_zero i) C
+    have h₂ := centralCharacterTable_mul_characterDegree (k := ℂ) j C
+    rw [hMd] at h₁
+    rw [hj] at h₂
+    refine mul_left_cancel₀ (hcard C) ?_
+    calc (Nat.card C.carrier : ℂ) * ((characterDegree ℂ j : ℂ) * M i C)
+        = (characterDegree ℂ j : ℂ) * ((Nat.card C.carrier : ℂ) * M i C) := by ring
+      _ = (characterDegree ℂ j : ℂ) * (centralCharacterRow M i C * (d : ℂ)) := by rw [h₁]
+      _ = (d : ℂ) * (centralCharacterRow M i C * (characterDegree ℂ j : ℂ)) := by ring
+      _ = (d : ℂ) * ((Nat.card C.carrier : ℂ) * characterTable ℂ G j C) := by rw [h₂]
+      _ = (Nat.card C.carrier : ℂ) * ((d : ℂ) * characterTable ℂ G j C) := by ring
+  -- Both rows have self-pairing `1`, so the two constants of proportionality have equal squares.
+  have hG : (Nat.card G : ℂ) ≠ 0 := Nat.cast_ne_zero.mpr Nat.card_pos.ne'
+  have hsum : (characterDegree ℂ j : ℂ) ^ 2 * ∑ C : ConjClasses G,
+        (Nat.card C.carrier : ℂ) * M i C * (starRingEnd ℂ) (M i C) =
+      (d : ℂ) ^ 2 * ∑ C : ConjClasses G, (Nat.card C.carrier : ℂ) *
+        characterTable ℂ G j C * (starRingEnd ℂ) (characterTable ℂ G j C) := by
+    rw [Finset.mul_sum, Finset.mul_sum]
+    refine Finset.sum_congr rfl fun C _ => ?_
+    have hconj : (characterDegree ℂ j : ℂ) * (starRingEnd ℂ) (M i C) =
+        (d : ℂ) * (starRingEnd ℂ) (characterTable ℂ G j C) := by
+      simpa using congrArg (starRingEnd ℂ) (key C)
+    calc (characterDegree ℂ j : ℂ) ^ 2 *
+          ((Nat.card C.carrier : ℂ) * M i C * (starRingEnd ℂ) (M i C))
+        = (Nat.card C.carrier : ℂ) * ((characterDegree ℂ j : ℂ) * M i C) *
+            ((characterDegree ℂ j : ℂ) * (starRingEnd ℂ) (M i C)) := by ring
+      _ = (Nat.card C.carrier : ℂ) * ((d : ℂ) * characterTable ℂ G j C) *
+            ((d : ℂ) * (starRingEnd ℂ) (characterTable ℂ G j C)) := by rw [key C, hconj]
+      _ = (d : ℂ) ^ 2 * ((Nat.card C.carrier : ℂ) * characterTable ℂ G j C *
+            (starRingEnd ℂ) (characterTable ℂ G j C)) := by ring
+  have hMii := hM.row_orthonormal i i
+  rw [if_pos rfl] at hMii
+  have hTjj := card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj j j
+  rw [if_pos rfl] at hTjj
+  rw [((inv_mul_eq_one₀ hG).mp hMii).symm, ((inv_mul_eq_one₀ hG).mp hTjj).symm] at hsum
+  have hsq : characterDegree ℂ j ^ 2 = d ^ 2 := by
+    have := mul_right_cancel₀ hG hsum
+    exact_mod_cast this
+  have hdeg : (d : ℂ) = (characterDegree ℂ j : ℂ) := by
+    exact_mod_cast ((Nat.pow_left_inj two_ne_zero).mp hsq).symm
+  exact ⟨j, fun C => mul_left_cancel₀ he (by rw [key C, hdeg])⟩
+
+/-- Permuting the rows of a matrix satisfying the specification gives a matrix satisfying it. -/
+theorem submatrix (σ : Equiv.Perm (Fin (Nat.card (ConjClasses G)))) :
+    IsCharacterTableSpec (M.submatrix σ id) where
+  exists_degree i := hM.exists_degree (σ i)
+  sum_degree_sq := by
+    rw [← hM.sum_degree_sq]
+    exact Fintype.sum_equiv σ _ _ fun i => rfl
+  row_orthonormal i j := by
+    simp only [Matrix.submatrix_apply, id_eq]
+    rw [hM.row_orthonormal (σ i) (σ j)]
+    exact if_congr σ.apply_eq_iff_eq rfl rfl
+  row_eigen i := by
+    rw [centralCharacterRow_submatrix]
+    exact hM.row_eigen (σ i)
+
+end IsCharacterTableSpec
+
+/-- **Labeled uniqueness of the character table.** With the columns labeled by the conjugacy
+classes of `G`, a matrix satisfying the specification is the character table up to a permutation of
+its rows, and of its rows only.
+
+Each row is a row of the character table (`TauCeti.IsCharacterTableSpec.exists_eq_characterTable`),
+and the assignment is injective because two equal rows would pair to `1` rather than to `0`; an
+injective self-map of a finite type is a permutation. -/
+theorem characterTable_unique_rows (hM : IsCharacterTableSpec M) :
+    ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))),
+      M = (characterTable ℂ G).submatrix σ id := by
+  choose τ hτ using hM.exists_eq_characterTable
+  have hinj : Function.Injective τ := by
+    intro i j hij
+    by_contra hne
+    have hrow : M j = M i := funext fun C => by rw [hτ j C, hτ i C, hij]
+    have h₀ := hM.row_orthonormal i j
+    rw [if_neg hne, hrow] at h₀
+    have h₁ := hM.row_orthonormal i i
+    rw [if_pos rfl] at h₁
+    exact one_ne_zero (h₁.symm.trans h₀)
+  exact ⟨Equiv.ofBijective τ (Finite.injective_iff_bijective.mp hinj),
+    Matrix.ext fun i C => hτ i C⟩
+
+/-- **The matrices satisfying the specification are exactly the row permutations of the character
+table**: the specification recognizes the character table, and nothing else. -/
+theorem isCharacterTableSpec_iff_exists_equiv :
+    IsCharacterTableSpec M ↔ ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))),
+      M = (characterTable ℂ G).submatrix σ id :=
+  ⟨characterTable_unique_rows, by
+    rintro ⟨σ, rfl⟩
+    exact (isCharacterTableSpec_characterTable G).submatrix σ⟩
+
+/-- **Any two matrices satisfying the specification differ by a permutation of rows.** Both are the
+character table up to such a permutation, so a solver that returns a matrix passing the checker has
+returned the same table as any other. -/
+theorem IsCharacterTableSpec.exists_perm_eq
+    {N : Matrix (Fin (Nat.card (ConjClasses G))) (ConjClasses G) ℂ}
+    (hM : IsCharacterTableSpec M) (hN : IsCharacterTableSpec N) :
+    ∃ σ : Equiv.Perm (Fin (Nat.card (ConjClasses G))), M = N.submatrix σ id := by
+  obtain ⟨σ, rfl⟩ := isCharacterTableSpec_iff_exists_equiv.mp hM
+  obtain ⟨τ, rfl⟩ := isCharacterTableSpec_iff_exists_equiv.mp hN
+  exact ⟨τ⁻¹ * σ, by ext i C; simp⟩
+
+end Spec
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/CharacterTable/Table.lean
+++ b/TauCeti/RepresentationTheory/CharacterTable/Table.lean
@@ -420,17 +420,21 @@ theorem card_inv_mul_sum_characterTable_mul_conj [Fintype G]
   simp only [conj_characterTable_apply]
   exact card_inv_mul_sum_characterTable_mul_characterTable_inv i j
 
-open scoped Classical in
 /-- **First (row) orthogonality over `ℂ`, summed one column at a time**: the Hermitian pairing of
 two rows of the complex character table, collected over the conjugacy classes with the class sizes
 as weights. This is the shape in which the roadmap's specification of a character table asks for row
 orthonormality; `TauCeti.card_inv_mul_sum_characterTable_mul_conj` is the same statement summed over
-the group. -/
-theorem card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj [Fintype G]
+the group.
+
+The enumeration of the conjugacy classes is an explicit `Fintype` argument rather than a classical
+one, so that the statement is about whichever enumeration the caller has in hand; a caller with
+`[DecidableEq G]` has one, and a classical instance would not be defeq to it. -/
+theorem card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj [Fintype (ConjClasses G)]
     (i j : Fin (Nat.card (ConjClasses G))) :
     (Nat.card G : ℂ)⁻¹ * ∑ C : ConjClasses G, (Nat.card C.carrier : ℂ) *
         characterTable ℂ G i C * (starRingEnd ℂ) (characterTable ℂ G j C) =
       if i = j then 1 else 0 := by
+  let _ : Fintype G := Fintype.ofFinite G
   rw [← card_inv_mul_sum_characterTable_mul_conj i j]
   congr 1
   have hsum := ClassFunction.sum_eq_sum_conjClasses (ClassFunction.ofConjClasses


### PR DESCRIPTION
This PR adds `TauCeti.IsCharacterTableSpec`, the property of a square complex matrix with columns labeled by the conjugacy classes of a finite group `G` that the Burnside-Dixon-Schneider checker tests, and proves the two theorems that make it a specification rather than a definition: `TauCeti.isCharacterTableSpec_characterTable`, that `TauCeti.characterTable ℂ G` satisfies it, and `TauCeti.characterTable_unique_rows`, labeled uniqueness, that any matrix satisfying it equals the character table after a permutation of its rows. The four conditions are the ones the roadmap pins: the identity column consists of positive integers dividing `|G|`, their squares sum to `|G|`, the rows are orthonormal for the class-size weighted Hermitian pairing, and each normalized row `ω_i(K_C) = |C| · M i C / M i 1` (the new `TauCeti.centralCharacterRow`) is a common left eigenrow of the class-multiplication matrices. None of them mentions a representation, so passing the checker is something a computation on structure constants can establish, and uniqueness is what turns "the algorithm produced a table" into "the algorithm produced the table".

The milestone is Layer 5 of `TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md`, deliverable B, whose closing bullet is "the specification and the checker": `IsCharacterTableSpec`, `isCharacterTableSpec_characterTable` and `characterTable_unique_rows` are pinned under those names in that roadmap's `Suggested.lean`. Its earlier bullets are already in the repository: the coordinate identity and the class-multiplication matrices in the pinned `ᵥ*` convention, and `TauCeti.isClassEigenrow_iff_exists_centralCharacterTable_eq`, which identifies the normalized common left eigenrows with the central characters of the irreducibles (TauCeti#2104). With this PR the layer is complete except for the quotient form of degree recovery, in flight as TauCeti#2145; what remains for the roadmap is deliverable C, the executable algorithm, whose summit `characterTable_eq` is stated against exactly the `IsCharacterTableSpec` this PR defines.

The uniqueness argument matches each normalized row with a row of the central character table `Ω`, then recovers the degree of the matching irreducible from the row's own self-pairing: writing `M i C = dᵢ · ω_i(C) / |C|` and `χⱼ(g_C) = dⱼ · ω_i(C) / |C|` for the same normalized row, orthonormality of each gives `dᵢ² = dⱼ²` against the common weighted sum, and both degrees are positive naturals. So the whole row, not just its normalization, is determined, and distinct rows stay distinct because two equal rows would pair to `1` where orthonormality demands `0`. This is deliberately not a use of TauCeti#2145: that PR recovers the degree of an actual irreducible character from its central character, a statement about representations, whereas here the same identity has to be applied to a hypothetical row of an abstract matrix, where the only available input is the specification's own orthonormality condition. Nothing about orthogonality, Wedderburn or the eigenrow correspondence is reproved; `TauCeti.characterTable_eq_div`, `TauCeti.centralCharacterTable_mul_characterDegree` and the first orthogonality relation on the table are all consumed as they stand.

Two smaller changes support it. `TauCeti/RepresentationTheory/CharacterTable/ClassSum/Basic.lean` gains the two facts about class sizes the normalization needs: the identity class is the singleton `{1}` (`TauCeti.ConjClasses.carrier_mk_one`, with the counting form `card_carrier_mk_one`), which is the fact that file's `classSum_mk_one` already asserts in prose, and `TauCeti.ConjClasses.card_carrier_pos`, that a class of a finite group is nonempty. Mathlib has neither. In `TauCeti/RepresentationTheory/CharacterTable/Table.lean`, `card_inv_mul_sum_card_conjClass_mul_characterTable_mul_conj` takes the enumeration of the conjugacy classes as an explicit `[Fintype (ConjClasses G)]` argument instead of an `open scoped Classical` one: a caller with `[DecidableEq G]`, which everything about class-multiplication matrices has, sums over the instance that hypothesis gives, and a classical instance is not definitionally equal to it, so in its old form the lemma was unusable exactly where the specification needs it.

New file: `TauCeti/RepresentationTheory/CharacterTable/Specification.lean` (329 lines). No material is derived from the supplementary source snapshot, and no Mathlib infrastructure is vendored: `Matrix.submatrix`, `Equiv.ofBijective`, `Finite.injective_iff_bijective`, `inv_mul_eq_one₀` and `Nat.pow_left_inj` are all consumed from the pinned Mathlib.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"ischaractertablespec"}-->

🤖 Prepared with Claude Code
