### PR TITLE
feat: identify the tangent and derivation Lie brackets

### DIFF
--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -4,31 +4,29 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import TauCeti.Geometry.Manifold.VectorField.LieBracket
 public import TauCeti.Geometry.Lie.Tangent.LeftInvariantDerivation
 
 /-!
 # The Lie equivalence between derivations and the identity tangent space
 
-The manifold Lie bracket computes the commutator of directional derivatives. Consequently, the
-canonical linear equivalence between left-invariant derivations and the tangent space at the
-identity is an equivalence of Lie algebras. This supplies the bracket-compatible dictionary needed
-to transport the tangent adjoint action to Mathlib's roadmap-facing Lie algebra
-`LeftInvariantDerivation I G`.
+For a finite-dimensional smooth real Lie group whose identity is an interior point, the canonical
+linear equivalence between left-invariant derivations and the tangent space at the identity is an
+equivalence of Lie algebras. This supplies the bracket-compatible dictionary needed to transport the
+tangent adjoint action to Mathlib's roadmap-facing Lie algebra `LeftInvariantDerivation I G`.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
 ## Main results
 
-* `mvfderiv_mlieBracket`: a scalar differential sends the manifold bracket to the commutator of
-  directional derivatives.
 * `tangentToLeftInvariantDerivation_lie`: the invariant derivation construction preserves brackets.
 * `leftInvariantDerivationLieEquivGroupLieAlgebra`: the canonical derivation–tangent Lie
   equivalence.
 
 ## References
 
+* `Mathlib/Geometry/Manifold/GroupLieAlgebra.lean`, whose compatibility TODO this file discharges.
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 1, "The group adjoint".
 -/
@@ -37,142 +35,23 @@ public section
 
 noncomputable section
 
-open Bundle Filter Manifold VectorField
-open scoped ContDiff Manifold Topology
+open Manifold VectorField
+open scoped ContDiff Manifold
 
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [CompleteSpace E] [LieGroup I ∞ G]
 
+-- The manifold bracket API needs three derivatives; this instance is the corresponding downgrade of
+-- the ambient smooth Lie-group structure.
 local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
   LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
     (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
 
-/-- Applying a scalar function's differential to the manifold Lie bracket of two differentiable
-vector fields gives the commutator of their directional derivatives. -/
-theorem mvfderiv_mlieBracket {f : G → ℝ} {V W : ∀ x : G, TangentSpace I x} {x : G}
-    (hf : CMDiffAt 2 f x)
-    (hV : MDiffAt (fun y ↦ (V y : TangentBundle I G)) x)
-    (hW : MDiffAt (fun y ↦ (W y : TangentBundle I G)) x)
-    (hVf : MDiffAt (fun y ↦ mvfderiv I f y (V y)) x)
-    (hWf : MDiffAt (fun y ↦ mvfderiv I f y (W y)) x) :
-    mvfderiv I f x (mlieBracket I V W x) =
-      mvfderiv I (fun y ↦ mvfderiv I f y (W y)) x (V x) -
-        mvfderiv I (fun y ↦ mvfderiv I f y (V y)) x (W x) := by
-  rw [← mlieBracketWithin_univ, mlieBracketWithin_apply]
-  have hinv :
-      (mfderiv% (extChartAt I x) x).inverse =
-        mfderiv[Set.range I] (extChartAt I x).symm (extChartAt I x x) := by
-    exact ContinuousLinearMap.inverse_eq
-      (mfderiv_extChartAt_comp_mfderivWithin_extChartAt_symm'
-        (mem_extChartAt_source x))
-      (mfderivWithin_extChartAt_symm_comp_mfderiv_extChartAt'
-        (mem_extChartAt_source x))
-  rw [hinv]
-  change (mfderiv% f x) _ = _
-  have hf' : MDiffAt f x := hf.mdifferentiableAt (by norm_num)
-  have hchain := mfderiv_comp_mfderivWithin_of_eq
-    (I := 𝓘(ℝ, E)) (I' := I) (I'' := 𝓘(ℝ, ℝ))
-    (f := (extChartAt I x).symm) (g := f) (s := Set.range I)
-    hf' (mdifferentiableWithinAt_extChartAt_symm (mem_extChartAt_target x))
-    (by apply I.uniqueMDiffOn; exact Set.mem_range_self (f := I) _)
-    (extChartAt_to_inv x)
-  change @Eq (E →L[ℝ] ℝ) _ _ at hchain
-  let Z : E := lieBracketWithin ℝ
-    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
-    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
-    ((extChartAt I x).symm ⁻¹' Set.univ ∩ Set.range I) (extChartAt I x x)
-  have hchain_apply := congrArg (fun L : E →L[ℝ] ℝ ↦ L Z) hchain
-  change _ = (mfderiv% f x) ((mfderiv[Set.range I]
-    (extChartAt I x).symm (extChartAt I x x)) Z) at hchain_apply
-  change (mfderiv% f x) ((mfderiv[Set.range I]
-    (extChartAt I x).symm (extChartAt I x x)) Z) = _
-  rw [← hchain_apply]
-  simp only [mfderivWithin_eq_fderivWithin]
-  have hfcoord : ContDiffWithinAt ℝ 2 (f ∘ (extChartAt I x).symm)
-      (Set.range I) (extChartAt I x x) := by
-    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := 2) x
-    have hcomp := ContMDiffWithinAt.comp_of_eq
-      (show ContMDiffWithinAt I 𝓘(ℝ, ℝ) 2 f Set.univ x from hf)
-      hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
-    exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
-  have hVcoord : DifferentiableWithinAt ℝ
-      (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
-      (Set.range I) (extChartAt I x x) := by
-    have hV' : MDiffAt[Set.univ] (fun y ↦ (V y : TangentBundle I G)) x :=
-      hV.mdifferentiableWithinAt
-    simpa using hV'.differentiableWithinAt_mpullbackWithin_vectorField
-  have hWcoord : DifferentiableWithinAt ℝ
-      (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
-      (Set.range I) (extChartAt I x x) := by
-    have hW' : MDiffAt[Set.univ] (fun y ↦ (W y : TangentBundle I G)) x :=
-      hW.mdifferentiableWithinAt
-    simpa using hW'.differentiableWithinAt_mpullbackWithin_vectorField
-  have hdirection (p : G → ℝ) (U : ∀ y : G, TangentSpace I y) {z : E}
-      (hz : z ∈ (extChartAt I x).target)
-      (hpz : MDiffAt p ((extChartAt I x).symm z)) :
-      (fderivWithin ℝ (p ∘ (extChartAt I x).symm) (Set.range I) z)
-          (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm U (Set.range I) z) =
-        mvfderiv I p ((extChartAt I x).symm z) (U ((extChartAt I x).symm z)) := by
-    rw [← mfderivWithin_eq_fderivWithin]
-    change (mfderiv[Set.range I] (p ∘ (extChartAt I x).symm) z)
-      ((mfderiv[Set.range I] (extChartAt I x).symm z).inverse
-        (U ((extChartAt I x).symm z))) =
-      (mfderiv% p ((extChartAt I x).symm z)) (U ((extChartAt I x).symm z))
-    rw [mfderiv_comp_mfderivWithin
-      (I := 𝓘(ℝ, E)) (I' := I) (I'' := 𝓘(ℝ, ℝ))
-      (f := (extChartAt I x).symm) (g := p) (s := Set.range I) z hpz
-      (mdifferentiableWithinAt_extChartAt_symm hz)
-      (show UniqueMDiffAt[Set.range I] z by
-        rw [uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
-        exact I.uniqueDiffOn.uniqueDiffWithinAt (extChartAt_target_subset_range x hz))]
-    rw [ContinuousLinearMap.comp_apply]
-    exact congrArg (mfderiv% p ((extChartAt I x).symm z))
-      ((isInvertible_mfderivWithin_extChartAt_symm hz).self_apply_inverse _)
-  have hf_eventually : ∀ᶠ y in 𝓝 x, MDiffAt f y := by
-    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf]
-      with y hy
-    exact hy.mdifferentiableAt (by norm_num)
-  have hsymm_tendsto : Tendsto (extChartAt I x).symm
-      (𝓝[Set.range I] (extChartAt I x x)) (𝓝 x) := by
-    simpa only [extChartAt_to_inv] using
-      (contMDiffWithinAt_extChartAt_symm_range_self
-        (I := I) (n := 2) x).continuousWithinAt.tendsto
-  have htarget : ∀ᶠ z in 𝓝[Set.range I] (extChartAt I x x),
-      z ∈ (extChartAt I x).target :=
-    extChartAt_target_mem_nhdsWithin x
-  have hcoord_eventually (U : ∀ y : G, TangentSpace I y) :
-      (fun z ↦ (fderivWithin ℝ (f ∘ (extChartAt I x).symm) (Set.range I) z)
-        (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm U (Set.range I) z)) =ᶠ[
-        𝓝[Set.range I] (extChartAt I x x)]
-      (fun y ↦ mvfderiv I f y (U y)) ∘ (extChartAt I x).symm := by
-    filter_upwards [htarget, hsymm_tendsto hf_eventually] with z hz hfz
-    exact hdirection f U hz hfz
-  have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
-    simpa only [extChartAt_to_inv] using hf'
-  have hcoordW := (hcoord_eventually W).fderivWithin_eq (𝕜 := ℝ)
-    (by simpa only [Function.comp_apply, extChartAt_to_inv] using
-      hdirection f W (mem_extChartAt_target x) hf_chart)
-  have hcoordV := (hcoord_eventually V).fderivWithin_eq (𝕜 := ℝ)
-    (by simpa only [Function.comp_apply, extChartAt_to_inv] using
-      hdirection f V (mem_extChartAt_target x) hf_chart)
-  have houterW := hdirection (fun y ↦ mvfderiv I f y (W y)) V
-    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hWf)
-  have houterV := hdirection (fun y ↦ mvfderiv I f y (V y)) W
-    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hVf)
-  rw [extChartAt_to_inv] at houterW houterV
-  rw [show Z = lieBracketWithin ℝ
-    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
-    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
-    (Set.range I) (extChartAt I x x) by
-      simp only [Z, Set.preimage_univ, Set.univ_inter]]
-  rw [fderivWithin_apply_lieBracket hfcoord (by norm_num) I.uniqueDiffOn
-    (I.range_subset_closure_interior (Set.mem_range_self (f := I) _))
-    (Set.mem_range_self (f := I) _) hWcoord hVcoord]
-  rw [hcoordW, hcoordV]
-  exact congrArg₂ (· - ·) houterW houterV
-
+/-- The map sending a tangent vector at the identity to its left-invariant derivation preserves the
+Lie bracket. -/
+@[simp]
 theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
     tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ =
       ⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
@@ -182,11 +61,9 @@ theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
   let F : C^∞⟮I, G; ℝ⟯ := f
   change (tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ F) 1 =
     (⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
-      tangentToLeftInvariantDerivation (I := I) (G := G) w⁆
-        F) 1
+      tangentToLeftInvariantDerivation (I := I) (G := G) w⁆ F) 1
   rw [LeftInvariantDerivation.commutator_apply]
-  simp only [tangentToLeftInvariantDerivation_apply,
-    ContMDiffMap.coe_sub, Pi.sub_apply]
+  simp only [tangentToLeftInvariantDerivation_apply, ContMDiffMap.coe_sub, Pi.sub_apply]
   rw [mulInvariantVectorField_one, GroupLieAlgebra.bracket_def]
   have hvfun : (⇑((tangentToLeftInvariantDerivation v) F) : G → ℝ) =
       fun y ↦ mvfderiv I F y (mulInvariantVectorField v y) := by
@@ -208,6 +85,7 @@ theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
       (V := mulInvariantVectorField v)
       (W := mulInvariantVectorField w)
       (x := (1 : G))
+      (by norm_num)
       (F.contMDiff.contMDiffAt.of_le (show
         ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
           WithTop.coe_le_coe.mpr le_top))
@@ -221,30 +99,28 @@ theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
         (by simp)).mdifferentiableAt
   exact hbridge.trans (congrArg₂ (· - ·) hwapply.symm hvapply.symm)
 
+private noncomputable def tangentToLeftInvariantDerivationLieHom
+    : GroupLieAlgebra I G →ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
+  { toLinearMap := tangentToLeftInvariantDerivation (I := I) (G := G)
+    map_lie' := by
+      intro v w
+      exact tangentToLeftInvariantDerivation_lie (I := I) (G := G) v w }
+
 /-- The tangent Lie algebra at the identity is canonically Lie-equivalent to the algebra of
 left-invariant derivations. -/
 private noncomputable def groupLieAlgebraLieEquivLeftInvariantDerivation
     [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
-    GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G where
-  toLieHom :=
-    { (leftInvariantDerivationEquivGroupLieAlgebra
-        (I := I) (G := G) h₁).symm.toLinearMap with
-      map_lie' := by
-        intro v w
-        calc
-          _ = tangentToLeftInvariantDerivation ⁅v, w⁆ :=
-            leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ ⁅v, w⁆
-          _ = ⁅tangentToLeftInvariantDerivation v,
-              tangentToLeftInvariantDerivation w⁆ :=
-            tangentToLeftInvariantDerivation_lie v w
-          _ = _ := congrArg₂ (fun X Y ↦ ⁅X, Y⁆)
-            (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ v).symm
-            (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ w).symm }
-  invFun := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
-  left_inv := (leftInvariantDerivationEquivGroupLieAlgebra
-    (I := I) (G := G) h₁).apply_symm_apply
-  right_inv := (leftInvariantDerivationEquivGroupLieAlgebra
-    (I := I) (G := G) h₁).symm_apply_apply
+    GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
+  LieEquiv.ofBijective (tangentToLeftInvariantDerivationLieHom (I := I) (G := G))
+    (by
+      let e := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
+      have hfun :
+          (tangentToLeftInvariantDerivationLieHom (I := I) (G := G) :
+            GroupLieAlgebra I G → LeftInvariantDerivation I G) = e.symm := by
+        funext v
+        exact leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ v |>.symm
+      rw [hfun]
+      exact e.symm.bijective)
 
 /-- Evaluation at the identity identifies left-invariant derivations with the tangent Lie algebra as
 Lie algebras. -/
@@ -253,10 +129,33 @@ noncomputable def leftInvariantDerivationLieEquivGroupLieAlgebra
     LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G :=
   (groupLieAlgebraLieEquivLeftInvariantDerivation (I := I) (G := G) h₁).symm
 
+/-- The inverse Lie equivalence sends a tangent vector to its left-invariant derivation. -/
+@[simp]
+theorem leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
+    (v : GroupLieAlgebra I G) :
+    (leftInvariantDerivationLieEquivGroupLieAlgebra h₁).symm v =
+      tangentToLeftInvariantDerivation v := by
+  simp [leftInvariantDerivationLieEquivGroupLieAlgebra,
+    groupLieAlgebraLieEquivLeftInvariantDerivation,
+    tangentToLeftInvariantDerivationLieHom]
+  rfl
+
+/-- The Lie equivalence acts as the underlying linear equivalence given by evaluation at the
+identity. -/
 @[simp]
 theorem leftInvariantDerivationLieEquivGroupLieAlgebra_apply
     [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
     (D : LeftInvariantDerivation I G) :
     leftInvariantDerivationLieEquivGroupLieAlgebra h₁ D =
-      leftInvariantDerivationEquivGroupLieAlgebra h₁ D :=
-  (rfl)
+      leftInvariantDerivationEquivGroupLieAlgebra h₁ D := by
+  let e := leftInvariantDerivationLieEquivGroupLieAlgebra h₁
+  let e₀ := leftInvariantDerivationEquivGroupLieAlgebra h₁
+  have hright : e.symm (e₀ D) = D := by
+    calc
+      e.symm (e₀ D) = tangentToLeftInvariantDerivation (e₀ D) :=
+        leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply h₁ (e₀ D)
+      _ = e₀.symm (e₀ D) :=
+        (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ (e₀ D)).symm
+      _ = D := e₀.symm_apply_apply D
+  exact e.symm.injective ((e.symm_apply_apply D).trans hright.symm)

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -41,7 +41,10 @@ open scoped ContDiff Manifold
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [CompleteSpace E] [LieGroup I ∞ G]
+  [LieGroup I ∞ G]
+
+local instance finiteDimensionalCompleteSpaceLieEquiv [FiniteDimensional ℝ E] : CompleteSpace E :=
+  FiniteDimensional.complete ℝ E
 
 -- The manifold bracket API needs three derivatives; this instance is the corresponding downgrade of
 -- the ambient smooth Lie-group structure.
@@ -52,16 +55,25 @@ local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :
 /-- The map sending a tangent vector at the identity to its left-invariant derivation preserves the
 Lie bracket. -/
 @[simp]
-theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
+theorem tangentToLeftInvariantDerivation_lie [CompleteSpace E]
+    (v w : GroupLieAlgebra I G) :
     tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ =
       ⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
         tangentToLeftInvariantDerivation (I := I) (G := G) w⁆ := by
   apply LeftInvariantDerivation.evalAt_one_injective
   ext f
   let F : C^∞⟮I, G; ℝ⟯ := f
-  change (tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ F) 1 =
-    (⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
-      tangentToLeftInvariantDerivation (I := I) (G := G) w⁆ F) 1
+  -- Point-derivation extensionality presents `f` as a pointed smooth map, while a global
+  -- derivation acts on its canonical global extension `F`.
+  have hleft :
+      (LeftInvariantDerivation.evalAt (I := I) (1 : G)
+        (tangentToLeftInvariantDerivation ⁅v, w⁆)) f =
+        (tangentToLeftInvariantDerivation ⁅v, w⁆ F) 1 := rfl
+  have hright :
+      (LeftInvariantDerivation.evalAt (I := I) (1 : G)
+        ⁅tangentToLeftInvariantDerivation v, tangentToLeftInvariantDerivation w⁆) f =
+        (⁅tangentToLeftInvariantDerivation v, tangentToLeftInvariantDerivation w⁆ F) 1 := rfl
+  rw [hleft, hright]
   rw [LeftInvariantDerivation.commutator_apply]
   simp only [tangentToLeftInvariantDerivation_apply, ContMDiffMap.coe_sub, Pi.sub_apply]
   rw [mulInvariantVectorField_one, GroupLieAlgebra.bracket_def]
@@ -85,61 +97,32 @@ theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
       (V := mulInvariantVectorField v)
       (W := mulInvariantVectorField w)
       (x := (1 : G))
-      (by norm_num)
-      (F.contMDiff.contMDiffAt.of_le (show
-        ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
-          WithTop.coe_le_coe.mpr le_top))
+      F.contMDiff.contMDiffAt
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
       ((contMDiff_mulInvariantVectorField_infty v).mdifferentiable
         (by simp)).mdifferentiableAt
       ((contMDiff_mulInvariantVectorField_infty w).mdifferentiable
         (by simp)).mdifferentiableAt
-      ((contMDiff_mvfderiv_mulInvariantVectorField v F).mdifferentiable
-        (by simp)).mdifferentiableAt
-      ((contMDiff_mvfderiv_mulInvariantVectorField w F).mdifferentiable
-        (by simp)).mdifferentiableAt
   exact hbridge.trans (congrArg₂ (· - ·) hwapply.symm hvapply.symm)
-
-private noncomputable def tangentToLeftInvariantDerivationLieHom
-    : GroupLieAlgebra I G →ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
-  { toLinearMap := tangentToLeftInvariantDerivation (I := I) (G := G)
-    map_lie' := by
-      intro v w
-      exact tangentToLeftInvariantDerivation_lie (I := I) (G := G) v w }
-
-/-- The tangent Lie algebra at the identity is canonically Lie-equivalent to the algebra of
-left-invariant derivations. -/
-private noncomputable def groupLieAlgebraLieEquivLeftInvariantDerivation
-    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
-    GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
-  LieEquiv.ofBijective (tangentToLeftInvariantDerivationLieHom (I := I) (G := G))
-    (by
-      let e := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
-      have hfun :
-          (tangentToLeftInvariantDerivationLieHom (I := I) (G := G) :
-            GroupLieAlgebra I G → LeftInvariantDerivation I G) = e.symm := by
-        funext v
-        exact leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ v |>.symm
-      rw [hfun]
-      exact e.symm.bijective)
 
 /-- Evaluation at the identity identifies left-invariant derivations with the tangent Lie algebra as
 Lie algebras. -/
 noncomputable def leftInvariantDerivationLieEquivGroupLieAlgebra
     [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
     LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G :=
-  (groupLieAlgebraLieEquivLeftInvariantDerivation (I := I) (G := G) h₁).symm
-
-/-- The inverse Lie equivalence sends a tangent vector to its left-invariant derivation. -/
-@[simp]
-theorem leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply
-    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
-    (v : GroupLieAlgebra I G) :
-    (leftInvariantDerivationLieEquivGroupLieAlgebra h₁).symm v =
-      tangentToLeftInvariantDerivation v := by
-  simp [leftInvariantDerivationLieEquivGroupLieAlgebra,
-    groupLieAlgebraLieEquivLeftInvariantDerivation,
-    tangentToLeftInvariantDerivationLieHom]
-  rfl
+  { leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁ with
+    map_lie' := by
+      intro D D'
+      let e₀ := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
+      -- Expose the underlying canonical linear equivalence supplied to this structure literal.
+      change e₀ ⁅D, D'⁆ = ⁅e₀ D, e₀ D'⁆
+      apply e₀.symm.injective
+      rw [e₀.symm_apply_apply]
+      rw [leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁]
+      rw [tangentToLeftInvariantDerivation_lie]
+      rw [← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁,
+        ← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁]
+      rw [e₀.symm_apply_apply, e₀.symm_apply_apply] }
 
 /-- The Lie equivalence acts as the underlying linear equivalence given by evaluation at the
 identity. -/
@@ -149,13 +132,38 @@ theorem leftInvariantDerivationLieEquivGroupLieAlgebra_apply
     (D : LeftInvariantDerivation I G) :
     leftInvariantDerivationLieEquivGroupLieAlgebra h₁ D =
       leftInvariantDerivationEquivGroupLieAlgebra h₁ D := by
+  rfl
+
+/-- The inverse Lie equivalence sends a tangent vector to its left-invariant derivation. -/
+@[simp]
+theorem leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
+    (v : GroupLieAlgebra I G) :
+    (leftInvariantDerivationLieEquivGroupLieAlgebra h₁).symm v =
+      tangentToLeftInvariantDerivation v := by
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra h₁
   let e₀ := leftInvariantDerivationEquivGroupLieAlgebra h₁
-  have hright : e.symm (e₀ D) = D := by
-    calc
-      e.symm (e₀ D) = tangentToLeftInvariantDerivation (e₀ D) :=
-        leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply h₁ (e₀ D)
-      _ = e₀.symm (e₀ D) :=
-        (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ (e₀ D)).symm
-      _ = D := e₀.symm_apply_apply D
-  exact e.symm.injective ((e.symm_apply_apply D).trans hright.symm)
+  apply e.symm_apply_eq.mpr
+  rw [leftInvariantDerivationLieEquivGroupLieAlgebra_apply]
+  symm
+  calc
+    e₀ (tangentToLeftInvariantDerivation v) = e₀ (e₀.symm v) := by
+      rw [leftInvariantDerivationEquivGroupLieAlgebra_symm_apply]
+    _ = v := e₀.apply_symm_apply v
+
+/-- Evaluation at the identity preserves the Lie bracket. -/
+@[simp]
+theorem leftInvariantDerivationEquivGroupLieAlgebra_lie
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
+    (D D' : LeftInvariantDerivation I G) :
+    pointDerivationEquivTangentSpace (I := I) 1 h₁
+        (LeftInvariantDerivation.evalAt 1 ⁅D, D'⁆) =
+      ⁅pointDerivationEquivTangentSpace (I := I) 1 h₁
+          (LeftInvariantDerivation.evalAt 1 D),
+        pointDerivationEquivTangentSpace (I := I) 1 h₁
+          (LeftInvariantDerivation.evalAt 1 D')⁆ := by
+  rw [← leftInvariantDerivationEquivGroupLieAlgebra_apply,
+    ← leftInvariantDerivationEquivGroupLieAlgebra_apply,
+    ← leftInvariantDerivationEquivGroupLieAlgebra_apply]
+  simpa only [leftInvariantDerivationLieEquivGroupLieAlgebra_apply] using
+    (leftInvariantDerivationLieEquivGroupLieAlgebra h₁).map_lie D D'

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -109,13 +109,13 @@ noncomputable def leftInvariantDerivationLieEquivGroupLieAlgebra
       let e₀ := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
       -- Expose the underlying canonical linear equivalence supplied to this structure literal.
       change e₀ ⁅D, D'⁆ = ⁅e₀ D, e₀ D'⁆
+      have hinv (X : LeftInvariantDerivation I G) :
+          tangentToLeftInvariantDerivation (e₀ X) = X := by
+        rw [← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁,
+          e₀.symm_apply_apply]
       apply e₀.symm.injective
-      rw [e₀.symm_apply_apply]
-      rw [leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁]
-      rw [tangentToLeftInvariantDerivation_lie]
-      rw [← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁,
-        ← leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁]
-      rw [e₀.symm_apply_apply, e₀.symm_apply_apply] }
+      rw [e₀.symm_apply_apply, leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁]
+      simp only [tangentToLeftInvariantDerivation_lie, hinv] }
 
 /-- The Lie equivalence acts as the underlying linear equivalence given by evaluation at the
 identity. -/

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -43,9 +43,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [LieGroup I ∞ G]
 
-local instance finiteDimensionalCompleteSpaceLieEquiv [FiniteDimensional ℝ E] : CompleteSpace E :=
-  FiniteDimensional.complete ℝ E
-
 -- The manifold bracket API needs three derivatives; this instance is the corresponding downgrade of
 -- the ambient smooth Lie-group structure.
 local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
@@ -63,17 +60,13 @@ theorem tangentToLeftInvariantDerivation_lie [CompleteSpace E]
   apply LeftInvariantDerivation.evalAt_one_injective
   ext f
   let F : C^∞⟮I, G; ℝ⟯ := f
-  -- Point-derivation extensionality presents `f` as a pointed smooth map, while a global
-  -- derivation acts on its canonical global extension `F`.
-  have hleft :
-      (LeftInvariantDerivation.evalAt (I := I) (1 : G)
-        (tangentToLeftInvariantDerivation ⁅v, w⁆)) f =
-        (tangentToLeftInvariantDerivation ⁅v, w⁆ F) 1 := rfl
-  have hright :
-      (LeftInvariantDerivation.evalAt (I := I) (1 : G)
-        ⁅tangentToLeftInvariantDerivation v, tangentToLeftInvariantDerivation w⁆) f =
-        (⁅tangentToLeftInvariantDerivation v, tangentToLeftInvariantDerivation w⁆ F) 1 := rfl
-  rw [hleft, hright]
+  -- `PointedContMDiffMap` is Mathlib's type synonym for the same smooth map with a different scalar
+  -- action; expose its canonical global-map view before using the evaluation API.
+  change (LeftInvariantDerivation.evalAt (I := I) (1 : G)
+      (tangentToLeftInvariantDerivation ⁅v, w⁆)) F =
+    (LeftInvariantDerivation.evalAt (I := I) (1 : G)
+      ⁅tangentToLeftInvariantDerivation v, tangentToLeftInvariantDerivation w⁆) F
+  rw [LeftInvariantDerivation.evalAt_apply, LeftInvariantDerivation.evalAt_apply]
   rw [LeftInvariantDerivation.commutator_apply]
   simp only [tangentToLeftInvariantDerivation_apply, ContMDiffMap.coe_sub, Pi.sub_apply]
   rw [mulInvariantVectorField_one, GroupLieAlgebra.bracket_def]

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -1,0 +1,262 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import TauCeti.Geometry.Lie.Tangent.LeftInvariantDerivation
+
+/-!
+# The Lie equivalence between derivations and the identity tangent space
+
+The manifold Lie bracket computes the commutator of directional derivatives. Consequently, the
+canonical linear equivalence between left-invariant derivations and the tangent space at the
+identity is an equivalence of Lie algebras. This supplies the bracket-compatible dictionary needed
+to transport the tangent adjoint action to Mathlib's roadmap-facing Lie algebra
+`LeftInvariantDerivation I G`.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main results
+
+* `mvfderiv_mlieBracket`: a scalar differential sends the manifold bracket to the commutator of
+  directional derivatives.
+* `tangentToLeftInvariantDerivation_lie`: the invariant derivation construction preserves brackets.
+* `leftInvariantDerivationLieEquivGroupLieAlgebra`: the canonical derivation–tangent Lie
+  equivalence.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
+-/
+
+public section
+
+noncomputable section
+
+open Bundle Filter Manifold VectorField
+open scoped ContDiff Manifold Topology
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [CompleteSpace E] [LieGroup I ∞ G]
+
+local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
+  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
+    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+
+/-- Applying a scalar function's differential to the manifold Lie bracket of two differentiable
+vector fields gives the commutator of their directional derivatives. -/
+theorem mvfderiv_mlieBracket {f : G → ℝ} {V W : ∀ x : G, TangentSpace I x} {x : G}
+    (hf : CMDiffAt 2 f x)
+    (hV : MDiffAt (fun y ↦ (V y : TangentBundle I G)) x)
+    (hW : MDiffAt (fun y ↦ (W y : TangentBundle I G)) x)
+    (hVf : MDiffAt (fun y ↦ mvfderiv I f y (V y)) x)
+    (hWf : MDiffAt (fun y ↦ mvfderiv I f y (W y)) x) :
+    mvfderiv I f x (mlieBracket I V W x) =
+      mvfderiv I (fun y ↦ mvfderiv I f y (W y)) x (V x) -
+        mvfderiv I (fun y ↦ mvfderiv I f y (V y)) x (W x) := by
+  rw [← mlieBracketWithin_univ, mlieBracketWithin_apply]
+  have hinv :
+      (mfderiv% (extChartAt I x) x).inverse =
+        mfderiv[Set.range I] (extChartAt I x).symm (extChartAt I x x) := by
+    exact ContinuousLinearMap.inverse_eq
+      (mfderiv_extChartAt_comp_mfderivWithin_extChartAt_symm'
+        (mem_extChartAt_source x))
+      (mfderivWithin_extChartAt_symm_comp_mfderiv_extChartAt'
+        (mem_extChartAt_source x))
+  rw [hinv]
+  change (mfderiv% f x) _ = _
+  have hf' : MDiffAt f x := hf.mdifferentiableAt (by norm_num)
+  have hchain := mfderiv_comp_mfderivWithin_of_eq
+    (I := 𝓘(ℝ, E)) (I' := I) (I'' := 𝓘(ℝ, ℝ))
+    (f := (extChartAt I x).symm) (g := f) (s := Set.range I)
+    hf' (mdifferentiableWithinAt_extChartAt_symm (mem_extChartAt_target x))
+    (by apply I.uniqueMDiffOn; exact Set.mem_range_self (f := I) _)
+    (extChartAt_to_inv x)
+  change @Eq (E →L[ℝ] ℝ) _ _ at hchain
+  let Z : E := lieBracketWithin ℝ
+    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
+    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
+    ((extChartAt I x).symm ⁻¹' Set.univ ∩ Set.range I) (extChartAt I x x)
+  have hchain_apply := congrArg (fun L : E →L[ℝ] ℝ ↦ L Z) hchain
+  change _ = (mfderiv% f x) ((mfderiv[Set.range I]
+    (extChartAt I x).symm (extChartAt I x x)) Z) at hchain_apply
+  change (mfderiv% f x) ((mfderiv[Set.range I]
+    (extChartAt I x).symm (extChartAt I x x)) Z) = _
+  rw [← hchain_apply]
+  simp only [mfderivWithin_eq_fderivWithin]
+  have hfcoord : ContDiffWithinAt ℝ 2 (f ∘ (extChartAt I x).symm)
+      (Set.range I) (extChartAt I x x) := by
+    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := 2) x
+    have hcomp := ContMDiffWithinAt.comp_of_eq
+      (show ContMDiffWithinAt I 𝓘(ℝ, ℝ) 2 f Set.univ x from hf)
+      hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
+    exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
+  have hVcoord : DifferentiableWithinAt ℝ
+      (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    have hV' : MDiffAt[Set.univ] (fun y ↦ (V y : TangentBundle I G)) x :=
+      hV.mdifferentiableWithinAt
+    simpa using hV'.differentiableWithinAt_mpullbackWithin_vectorField
+  have hWcoord : DifferentiableWithinAt ℝ
+      (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    have hW' : MDiffAt[Set.univ] (fun y ↦ (W y : TangentBundle I G)) x :=
+      hW.mdifferentiableWithinAt
+    simpa using hW'.differentiableWithinAt_mpullbackWithin_vectorField
+  have hdirection (p : G → ℝ) (U : ∀ y : G, TangentSpace I y) {z : E}
+      (hz : z ∈ (extChartAt I x).target)
+      (hpz : MDiffAt p ((extChartAt I x).symm z)) :
+      (fderivWithin ℝ (p ∘ (extChartAt I x).symm) (Set.range I) z)
+          (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm U (Set.range I) z) =
+        mvfderiv I p ((extChartAt I x).symm z) (U ((extChartAt I x).symm z)) := by
+    rw [← mfderivWithin_eq_fderivWithin]
+    change (mfderiv[Set.range I] (p ∘ (extChartAt I x).symm) z)
+      ((mfderiv[Set.range I] (extChartAt I x).symm z).inverse
+        (U ((extChartAt I x).symm z))) =
+      (mfderiv% p ((extChartAt I x).symm z)) (U ((extChartAt I x).symm z))
+    rw [mfderiv_comp_mfderivWithin
+      (I := 𝓘(ℝ, E)) (I' := I) (I'' := 𝓘(ℝ, ℝ))
+      (f := (extChartAt I x).symm) (g := p) (s := Set.range I) z hpz
+      (mdifferentiableWithinAt_extChartAt_symm hz)
+      (show UniqueMDiffAt[Set.range I] z by
+        rw [uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
+        exact I.uniqueDiffOn.uniqueDiffWithinAt (extChartAt_target_subset_range x hz))]
+    rw [ContinuousLinearMap.comp_apply]
+    exact congrArg (mfderiv% p ((extChartAt I x).symm z))
+      ((isInvertible_mfderivWithin_extChartAt_symm hz).self_apply_inverse _)
+  have hf_eventually : ∀ᶠ y in 𝓝 x, MDiffAt f y := by
+    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf]
+      with y hy
+    exact hy.mdifferentiableAt (by norm_num)
+  have hsymm_tendsto : Tendsto (extChartAt I x).symm
+      (𝓝[Set.range I] (extChartAt I x x)) (𝓝 x) := by
+    simpa only [extChartAt_to_inv] using
+      (contMDiffWithinAt_extChartAt_symm_range_self
+        (I := I) (n := 2) x).continuousWithinAt.tendsto
+  have htarget : ∀ᶠ z in 𝓝[Set.range I] (extChartAt I x x),
+      z ∈ (extChartAt I x).target :=
+    extChartAt_target_mem_nhdsWithin x
+  have hcoord_eventually (U : ∀ y : G, TangentSpace I y) :
+      (fun z ↦ (fderivWithin ℝ (f ∘ (extChartAt I x).symm) (Set.range I) z)
+        (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm U (Set.range I) z)) =ᶠ[
+        𝓝[Set.range I] (extChartAt I x x)]
+      (fun y ↦ mvfderiv I f y (U y)) ∘ (extChartAt I x).symm := by
+    filter_upwards [htarget, hsymm_tendsto hf_eventually] with z hz hfz
+    exact hdirection f U hz hfz
+  have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
+    simpa only [extChartAt_to_inv] using hf'
+  have hcoordW := (hcoord_eventually W).fderivWithin_eq (𝕜 := ℝ)
+    (by simpa only [Function.comp_apply, extChartAt_to_inv] using
+      hdirection f W (mem_extChartAt_target x) hf_chart)
+  have hcoordV := (hcoord_eventually V).fderivWithin_eq (𝕜 := ℝ)
+    (by simpa only [Function.comp_apply, extChartAt_to_inv] using
+      hdirection f V (mem_extChartAt_target x) hf_chart)
+  have houterW := hdirection (fun y ↦ mvfderiv I f y (W y)) V
+    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hWf)
+  have houterV := hdirection (fun y ↦ mvfderiv I f y (V y)) W
+    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hVf)
+  rw [extChartAt_to_inv] at houterW houterV
+  rw [show Z = lieBracketWithin ℝ
+    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm V (Set.range I))
+    (mpullbackWithin 𝓘(ℝ, E) I (extChartAt I x).symm W (Set.range I))
+    (Set.range I) (extChartAt I x x) by
+      simp only [Z, Set.preimage_univ, Set.univ_inter]]
+  rw [fderivWithin_apply_lieBracket hfcoord (by norm_num) I.uniqueDiffOn
+    (I.range_subset_closure_interior (Set.mem_range_self (f := I) _))
+    (Set.mem_range_self (f := I) _) hWcoord hVcoord]
+  rw [hcoordW, hcoordV]
+  exact congrArg₂ (· - ·) houterW houterV
+
+theorem tangentToLeftInvariantDerivation_lie (v w : GroupLieAlgebra I G) :
+    tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ =
+      ⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
+        tangentToLeftInvariantDerivation (I := I) (G := G) w⁆ := by
+  apply LeftInvariantDerivation.evalAt_one_injective
+  ext f
+  let F : C^∞⟮I, G; ℝ⟯ := f
+  change (tangentToLeftInvariantDerivation (I := I) (G := G) ⁅v, w⁆ F) 1 =
+    (⁅tangentToLeftInvariantDerivation (I := I) (G := G) v,
+      tangentToLeftInvariantDerivation (I := I) (G := G) w⁆
+        F) 1
+  rw [LeftInvariantDerivation.commutator_apply]
+  simp only [tangentToLeftInvariantDerivation_apply,
+    ContMDiffMap.coe_sub, Pi.sub_apply]
+  rw [mulInvariantVectorField_one, GroupLieAlgebra.bracket_def]
+  have hvfun : (⇑((tangentToLeftInvariantDerivation v) F) : G → ℝ) =
+      fun y ↦ mvfderiv I F y (mulInvariantVectorField v y) := by
+    funext y
+    exact tangentToLeftInvariantDerivation_apply v F y
+  have hwfun : (⇑((tangentToLeftInvariantDerivation w) F) : G → ℝ) =
+      fun y ↦ mvfderiv I F y (mulInvariantVectorField w y) := by
+    funext y
+    exact tangentToLeftInvariantDerivation_apply w F y
+  have hvapply := congrArg
+    (fun L : E →L[ℝ] ℝ ↦ L (mulInvariantVectorField w (1 : G)))
+    (mfderiv_congr (I := I) (I' := 𝓘(ℝ, ℝ)) (x := (1 : G)) hvfun)
+  have hwapply := congrArg
+    (fun L : E →L[ℝ] ℝ ↦ L (mulInvariantVectorField v (1 : G)))
+    (mfderiv_congr (I := I) (I' := 𝓘(ℝ, ℝ)) (x := (1 : G)) hwfun)
+  have hbridge :=
+    mvfderiv_mlieBracket
+      (f := (F : G → ℝ))
+      (V := mulInvariantVectorField v)
+      (W := mulInvariantVectorField w)
+      (x := (1 : G))
+      (F.contMDiff.contMDiffAt.of_le (show
+        ((2 : ℕ∞) : ℕ∞ω) ≤ ((⊤ : ℕ∞) : ℕ∞ω) from
+          WithTop.coe_le_coe.mpr le_top))
+      ((contMDiff_mulInvariantVectorField_infty v).mdifferentiable
+        (by simp)).mdifferentiableAt
+      ((contMDiff_mulInvariantVectorField_infty w).mdifferentiable
+        (by simp)).mdifferentiableAt
+      ((contMDiff_mvfderiv_mulInvariantVectorField v F).mdifferentiable
+        (by simp)).mdifferentiableAt
+      ((contMDiff_mvfderiv_mulInvariantVectorField w F).mdifferentiable
+        (by simp)).mdifferentiableAt
+  exact hbridge.trans (congrArg₂ (· - ·) hwapply.symm hvapply.symm)
+
+/-- The tangent Lie algebra at the identity is canonically Lie-equivalent to the algebra of
+left-invariant derivations. -/
+private noncomputable def groupLieAlgebraLieEquivLeftInvariantDerivation
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
+    GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G where
+  toLieHom :=
+    { (leftInvariantDerivationEquivGroupLieAlgebra
+        (I := I) (G := G) h₁).symm.toLinearMap with
+      map_lie' := by
+        intro v w
+        calc
+          _ = tangentToLeftInvariantDerivation ⁅v, w⁆ :=
+            leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ ⁅v, w⁆
+          _ = ⁅tangentToLeftInvariantDerivation v,
+              tangentToLeftInvariantDerivation w⁆ :=
+            tangentToLeftInvariantDerivation_lie v w
+          _ = _ := congrArg₂ (fun X Y ↦ ⁅X, Y⁆)
+            (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ v).symm
+            (leftInvariantDerivationEquivGroupLieAlgebra_symm_apply h₁ w).symm }
+  invFun := leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁
+  left_inv := (leftInvariantDerivationEquivGroupLieAlgebra
+    (I := I) (G := G) h₁).apply_symm_apply
+  right_inv := (leftInvariantDerivationEquivGroupLieAlgebra
+    (I := I) (G := G) h₁).symm_apply_apply
+
+/-- Evaluation at the identity identifies left-invariant derivations with the tangent Lie algebra as
+Lie algebras. -/
+noncomputable def leftInvariantDerivationLieEquivGroupLieAlgebra
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
+    LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G :=
+  (groupLieAlgebraLieEquivLeftInvariantDerivation (I := I) (G := G) h₁).symm
+
+@[simp]
+theorem leftInvariantDerivationLieEquivGroupLieAlgebra_apply
+    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
+    (D : LeftInvariantDerivation I G) :
+    leftInvariantDerivationLieEquivGroupLieAlgebra h₁ D =
+      leftInvariantDerivationEquivGroupLieAlgebra h₁ D :=
+  (rfl)

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -171,7 +171,12 @@ private theorem mdifferentiableAt_mvfderiv_apply
       (tangentMap I 𝓘(𝕜, F) f (U x : TangentBundle I M)) :=
     (contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
       (n := 1)).mdifferentiable (by norm_num) |>.mdifferentiableAt
-  exact (hsnd.comp x htangent).congr_of_eventuallyEq (by rfl)
+  apply (hsnd.comp x htangent).congr_of_eventuallyEq
+  filter_upwards with y
+  rw [Function.comp_apply, tangentMap_snd, mvfderiv, ContinuousLinearMap.comp_apply]
+  -- `fromTangentSpace` is Mathlib's explicit interface for the definitional identification of the
+  -- tangent space of a normed space with that normed space.
+  rfl
 
 /-- Let `f` have enough derivatives for symmetry of its second derivative at `x`, and let `V` and
 `W` be differentiable vector fields there. Then the differential of `f` on the manifold bracket is

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -1,0 +1,191 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.VectorField.LieBracket
+
+/-!
+# Directional derivatives and the manifold Lie bracket
+
+This file transports Mathlib's normed-space identity `fderivWithin_apply_lieBracket` through a
+manifold chart. It identifies the differential of a scalar function on the manifold Lie bracket with
+the commutator of its directional derivatives.
+
+The chart argument follows the pullback idiom used for the manifold bracket in
+`Mathlib/Geometry/Manifold/VectorField/LieBracket.lean`. The resulting lemma is a general manifold
+prerequisite for Deliverable A, Layer 1 of the Lie-groups roadmap.
+
+## Main result
+
+* `mvfderiv_mlieBracket`: a scalar differential sends the manifold bracket to the commutator of
+  directional derivatives.
+
+## References
+
+* `Mathlib/Analysis/Calculus/VectorField.lean`, theorem `fderivWithin_apply_lieBracket`.
+* `Mathlib/Geometry/Manifold/VectorField/LieBracket.lean`, for the chart-transport construction.
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1.
+-/
+
+public section
+
+noncomputable section
+
+open Bundle Filter Manifold VectorField
+open scoped ContDiff Manifold Topology
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+
+omit [CompleteSpace E] in
+private theorem fderivWithin_chart_apply_mpullbackWithin
+    {p : M → 𝕜} {U : ∀ y : M, TangentSpace I y} {x : M} {z : E}
+    (hz : z ∈ (extChartAt I x).target)
+    (hpz : MDiffAt p ((extChartAt I x).symm z)) :
+    (fderivWithin 𝕜 (p ∘ (extChartAt I x).symm) (Set.range I) z)
+        (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I) z) =
+      mvfderiv I p ((extChartAt I x).symm z) (U ((extChartAt I x).symm z)) := by
+  rw [← mfderivWithin_eq_fderivWithin]
+  -- `TangentSpace I _` is definitionally the model space `E`; no public rewrite lemma exposes the
+  -- coordinate composition in the form needed by the chain rule.
+  change (mfderiv[Set.range I] (p ∘ (extChartAt I x).symm) z)
+    ((mfderiv[Set.range I] (extChartAt I x).symm z).inverse
+      (U ((extChartAt I x).symm z))) =
+    (mfderiv% p ((extChartAt I x).symm z)) (U ((extChartAt I x).symm z))
+  rw [mfderiv_comp_mfderivWithin
+    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, 𝕜))
+    (f := (extChartAt I x).symm) (g := p) (s := Set.range I) z hpz
+    (mdifferentiableWithinAt_extChartAt_symm hz)
+    (show UniqueMDiffAt[Set.range I] z by
+      rw [uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
+      exact I.uniqueDiffOn.uniqueDiffWithinAt (extChartAt_target_subset_range x hz))]
+  rw [ContinuousLinearMap.comp_apply]
+  exact congrArg (mfderiv% p ((extChartAt I x).symm z))
+    ((isInvertible_mfderivWithin_extChartAt_symm hz).self_apply_inverse _)
+
+omit [CompleteSpace E] in
+private theorem eventuallyEq_chart_directionalDerivative
+    {f : M → 𝕜} {U : ∀ y : M, TangentSpace I y} {x : M}
+    (hf : CMDiffAt 2 f x) :
+    (fun z ↦ (fderivWithin 𝕜 (f ∘ (extChartAt I x).symm) (Set.range I) z)
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I) z)) =ᶠ[
+      𝓝[Set.range I] (extChartAt I x x)]
+    (fun y ↦ mvfderiv I f y (U y)) ∘ (extChartAt I x).symm := by
+  have hf_eventually : ∀ᶠ y in 𝓝 x, MDiffAt f y := by
+    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf]
+      with y hy
+    exact hy.mdifferentiableAt (by norm_num)
+  have hsymm_tendsto : Tendsto (extChartAt I x).symm
+      (𝓝[Set.range I] (extChartAt I x x)) (𝓝 x) := by
+    simpa only [extChartAt_to_inv] using
+      (contMDiffWithinAt_extChartAt_symm_range_self
+        (I := I) (n := 2) x).continuousWithinAt.tendsto
+  have htarget : ∀ᶠ z in 𝓝[Set.range I] (extChartAt I x x),
+      z ∈ (extChartAt I x).target :=
+    extChartAt_target_mem_nhdsWithin x
+  filter_upwards [htarget, hsymm_tendsto hf_eventually] with z hz hfz
+  exact fderivWithin_chart_apply_mpullbackWithin hz hfz
+
+/-- Over a field whose minimum smoothness for second derivatives is at most two, let `f` be twice
+differentiable at `x`, and let `V` and `W` be differentiable vector fields there. If the directional
+derivatives of `f` along `V` and `W` are differentiable at `x`, then the differential of `f` on the
+manifold bracket is their commutator. This is the manifold counterpart of Mathlib's
+`fderivWithin_apply_lieBracket`. -/
+theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x} {x : M}
+    (hmin : minSmoothness 𝕜 2 ≤ 2)
+    (hf : CMDiffAt 2 f x)
+    (hV : MDiffAt (fun y ↦ (V y : TangentBundle I M)) x)
+    (hW : MDiffAt (fun y ↦ (W y : TangentBundle I M)) x)
+    (hVf : MDiffAt (fun y ↦ mvfderiv I f y (V y)) x)
+    (hWf : MDiffAt (fun y ↦ mvfderiv I f y (W y)) x) :
+    mvfderiv I f x (mlieBracket I V W x) =
+      mvfderiv I (fun y ↦ mvfderiv I f y (W y)) x (V x) -
+        mvfderiv I (fun y ↦ mvfderiv I f y (V y)) x (W x) := by
+  -- Express the manifold bracket and the outer differential in the chart at `x`.
+  rw [← mlieBracketWithin_univ, mlieBracketWithin_apply]
+  have hinv :
+      (mfderiv% (extChartAt I x) x).inverse =
+        mfderiv[Set.range I] (extChartAt I x).symm (extChartAt I x x) := by
+    exact ContinuousLinearMap.inverse_eq
+      (mfderiv_extChartAt_comp_mfderivWithin_extChartAt_symm'
+        (mem_extChartAt_source x))
+      (mfderivWithin_extChartAt_symm_comp_mfderiv_extChartAt'
+        (mem_extChartAt_source x))
+  rw [hinv]
+  -- Normalize the same definitional tangent-space representation before applying the chart chain
+  -- rule. The following `change`s only expose applications of that single linear-map identity.
+  change (mfderiv% f x) _ = _
+  have hf' : MDiffAt f x := hf.mdifferentiableAt (by norm_num)
+  have hchain := mfderiv_comp_mfderivWithin_of_eq
+    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, 𝕜))
+    (f := (extChartAt I x).symm) (g := f) (s := Set.range I)
+    hf' (mdifferentiableWithinAt_extChartAt_symm (mem_extChartAt_target x))
+    (by apply I.uniqueMDiffOn; exact Set.mem_range_self (f := I) _)
+    (extChartAt_to_inv x)
+  change @Eq (E →L[𝕜] 𝕜) _ _ at hchain
+  let Z : E := lieBracketWithin 𝕜
+    (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
+    (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
+    ((extChartAt I x).symm ⁻¹' Set.univ ∩ Set.range I) (extChartAt I x x)
+  have hchain_apply := congrArg (fun L : E →L[𝕜] 𝕜 ↦ L Z) hchain
+  change _ = (mfderiv% f x) ((mfderiv[Set.range I]
+    (extChartAt I x).symm (extChartAt I x x)) Z) at hchain_apply
+  change (mfderiv% f x) ((mfderiv[Set.range I]
+    (extChartAt I x).symm (extChartAt I x x)) Z) = _
+  rw [← hchain_apply]
+  simp only [mfderivWithin_eq_fderivWithin]
+  -- Pull the vector fields back and invoke the normed-space bracket identity.
+  have hfcoord : ContDiffWithinAt 𝕜 2 (f ∘ (extChartAt I x).symm)
+      (Set.range I) (extChartAt I x x) := by
+    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := 2) x
+    have hcomp := ContMDiffWithinAt.comp_of_eq
+      (show ContMDiffWithinAt I 𝓘(𝕜, 𝕜) 2 f Set.univ x from hf)
+      hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
+    exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
+  have hVcoord : DifferentiableWithinAt 𝕜
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    have hV' : MDiffAt[Set.univ] (fun y ↦ (V y : TangentBundle I M)) x :=
+      hV.mdifferentiableWithinAt
+    simpa using hV'.differentiableWithinAt_mpullbackWithin_vectorField
+  have hWcoord : DifferentiableWithinAt 𝕜
+      (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
+      (Set.range I) (extChartAt I x x) := by
+    have hW' : MDiffAt[Set.univ] (fun y ↦ (W y : TangentBundle I M)) x :=
+      hW.mdifferentiableWithinAt
+    simpa using hW'.differentiableWithinAt_mpullbackWithin_vectorField
+  -- Identify chart directional derivatives with their manifold counterparts.
+  have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
+    simpa only [extChartAt_to_inv] using hf'
+  have hcoordW := (eventuallyEq_chart_directionalDerivative (I := I) (U := W) hf).fderivWithin_eq
+    (𝕜 := 𝕜) (by
+      simpa only [Function.comp_apply, extChartAt_to_inv] using
+        fderivWithin_chart_apply_mpullbackWithin
+          (I := I) (U := W) (mem_extChartAt_target x) hf_chart)
+  have hcoordV := (eventuallyEq_chart_directionalDerivative (I := I) (U := V) hf).fderivWithin_eq
+    (𝕜 := 𝕜) (by
+      simpa only [Function.comp_apply, extChartAt_to_inv] using
+        fderivWithin_chart_apply_mpullbackWithin
+          (I := I) (U := V) (mem_extChartAt_target x) hf_chart)
+  have houterW := fderivWithin_chart_apply_mpullbackWithin
+    (I := I) (p := fun y ↦ mvfderiv I f y (W y)) (U := V)
+    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hWf)
+  have houterV := fderivWithin_chart_apply_mpullbackWithin
+    (I := I) (p := fun y ↦ mvfderiv I f y (V y)) (U := W)
+    (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hVf)
+  rw [extChartAt_to_inv] at houterW houterV
+  rw [show Z = lieBracketWithin 𝕜
+    (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
+    (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
+    (Set.range I) (extChartAt I x x) by
+      simp only [Z, Set.preimage_univ, Set.univ_inter]]
+  rw [fderivWithin_apply_lieBracket hfcoord hmin I.uniqueDiffOn
+    (I.range_subset_closure_interior (Set.mem_range_self (f := I) _))
+    (Set.mem_range_self (f := I) _) hWcoord hVcoord]
+  rw [hcoordW, hcoordV]
+  exact congrArg₂ (· - ·) houterW houterV

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -59,13 +59,13 @@ private theorem fderivWithin_chart_apply_mpullbackWithin
     ((mfderiv[Set.range I] (extChartAt I x).symm z).inverse
       (U ((extChartAt I x).symm z))) =
     (mfderiv% p ((extChartAt I x).symm z)) (U ((extChartAt I x).symm z))
+  have hunique : UniqueMDiffAt[Set.range I] z := by
+    rw [uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
+    exact I.uniqueDiffOn.uniqueDiffWithinAt (extChartAt_target_subset_range x hz)
   rw [mfderiv_comp_mfderivWithin
     (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, F))
     (f := (extChartAt I x).symm) (g := p) (s := Set.range I) z hpz
-    (mdifferentiableWithinAt_extChartAt_symm hz)
-    (show UniqueMDiffAt[Set.range I] z by
-      rw [uniqueMDiffWithinAt_iff_uniqueDiffWithinAt]
-      exact I.uniqueDiffOn.uniqueDiffWithinAt (extChartAt_target_subset_range x hz))]
+    (mdifferentiableWithinAt_extChartAt_symm hz) hunique]
   rw [ContinuousLinearMap.comp_apply]
   exact congrArg (mfderiv% p ((extChartAt I x).symm z))
     ((isInvertible_mfderivWithin_extChartAt_symm hz).self_apply_inverse _)
@@ -228,11 +228,12 @@ theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {
   have hfcoord : ContDiffWithinAt 𝕜 (minSmoothness 𝕜 2)
       (f ∘ (extChartAt I x).symm)
       (Set.range I) (extChartAt I x x) := by
+    have hfWithin : ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x :=
+      hf.of_le hn
     have hsymm := contMDiffWithinAt_extChartAt_symm_range_self
       (I := I) (n := minSmoothness 𝕜 2) x
     have hcomp := ContMDiffWithinAt.comp_of_eq
-      (show ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x from
-        hf.of_le hn)
+      hfWithin
       hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
     exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
   have hVcoord : DifferentiableWithinAt 𝕜
@@ -271,11 +272,12 @@ theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {
     (I := I) (p := fun y ↦ mvfderiv I f y (V y)) (U := W)
     (mem_extChartAt_target x) (by simpa only [extChartAt_to_inv] using hVf)
   rw [extChartAt_to_inv] at houterW houterV
-  rw [show Z = lieBracketWithin 𝕜
+  have hZ : Z = lieBracketWithin 𝕜
     (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
     (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
-    (Set.range I) (extChartAt I x x) by
-      simp only [Z, Set.preimage_univ, Set.univ_inter]]
+    (Set.range I) (extChartAt I x x) := by
+    simp only [Z, Set.preimage_univ, Set.univ_inter]
+  rw [hZ]
   rw [fderivWithin_apply_lieBracket hfcoord le_rfl I.uniqueDiffOn
     (I.range_subset_closure_interior (Set.mem_range_self (f := I) _))
     (Set.mem_range_self (f := I) _) hWcoord hVcoord]

--- a/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
+++ b/TauCeti/Geometry/Manifold/VectorField/LieBracket.lean
@@ -10,8 +10,8 @@ public import Mathlib.Geometry.Manifold.VectorField.LieBracket
 # Directional derivatives and the manifold Lie bracket
 
 This file transports Mathlib's normed-space identity `fderivWithin_apply_lieBracket` through a
-manifold chart. It identifies the differential of a scalar function on the manifold Lie bracket with
-the commutator of its directional derivatives.
+manifold chart. It identifies the differential of a vector-valued function on the manifold Lie
+bracket with the commutator of its directional derivatives.
 
 The chart argument follows the pullback idiom used for the manifold bracket in
 `Mathlib/Geometry/Manifold/VectorField/LieBracket.lean`. The resulting lemma is a general manifold
@@ -19,7 +19,7 @@ prerequisite for Deliverable A, Layer 1 of the Lie-groups roadmap.
 
 ## Main result
 
-* `mvfderiv_mlieBracket`: a scalar differential sends the manifold bracket to the commutator of
+* `mvfderiv_mlieBracket`: a differential sends the manifold bracket to the commutator of
   directional derivatives.
 
 ## References
@@ -37,14 +37,16 @@ noncomputable section
 open Bundle Filter Manifold VectorField
 open scoped ContDiff Manifold Topology
 
-variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] {n : ℕ∞ω}
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E] [CompleteSpace E]
+  {F : Type*} [NormedAddCommGroup F] [NormedSpace 𝕜 F]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
-  {M : Type*} [TopologicalSpace M] [ChartedSpace H M] [IsManifold I 2 M]
+  {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+  [IsManifold I (minSmoothness 𝕜 2) M]
 
 omit [CompleteSpace E] in
 private theorem fderivWithin_chart_apply_mpullbackWithin
-    {p : M → 𝕜} {U : ∀ y : M, TangentSpace I y} {x : M} {z : E}
+    {p : M → F} {U : ∀ y : M, TangentSpace I y} {x : M} {z : E}
     (hz : z ∈ (extChartAt I x).target)
     (hpz : MDiffAt p ((extChartAt I x).symm z)) :
     (fderivWithin 𝕜 (p ∘ (extChartAt I x).symm) (Set.range I) z)
@@ -58,7 +60,7 @@ private theorem fderivWithin_chart_apply_mpullbackWithin
       (U ((extChartAt I x).symm z))) =
     (mfderiv% p ((extChartAt I x).symm z)) (U ((extChartAt I x).symm z))
   rw [mfderiv_comp_mfderivWithin
-    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, 𝕜))
+    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, F))
     (f := (extChartAt I x).symm) (g := p) (s := Set.range I) z hpz
     (mdifferentiableWithinAt_extChartAt_symm hz)
     (show UniqueMDiffAt[Set.range I] z by
@@ -70,39 +72,115 @@ private theorem fderivWithin_chart_apply_mpullbackWithin
 
 omit [CompleteSpace E] in
 private theorem eventuallyEq_chart_directionalDerivative
-    {f : M → 𝕜} {U : ∀ y : M, TangentSpace I y} {x : M}
-    (hf : CMDiffAt 2 f x) :
+    {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M}
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
     (fun z ↦ (fderivWithin 𝕜 (f ∘ (extChartAt I x).symm) (Set.range I) z)
       (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm U (Set.range I) z)) =ᶠ[
       𝓝[Set.range I] (extChartAt I x x)]
     (fun y ↦ mvfderiv I f y (U y)) ∘ (extChartAt I x).symm := by
   have hf_eventually : ∀ᶠ y in 𝓝 x, MDiffAt f y := by
-    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf]
+    have h2n : (2 : ℕ∞ω) ≤ n :=
+      (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
+    have hf₂ : CMDiffAt 2 f x := hf.of_le h2n
+    filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1 hf₂]
       with y hy
     exact hy.mdifferentiableAt (by norm_num)
   have hsymm_tendsto : Tendsto (extChartAt I x).symm
       (𝓝[Set.range I] (extChartAt I x x)) (𝓝 x) := by
     simpa only [extChartAt_to_inv] using
       (contMDiffWithinAt_extChartAt_symm_range_self
-        (I := I) (n := 2) x).continuousWithinAt.tendsto
+        (I := I) (n := minSmoothness 𝕜 2) x).continuousWithinAt.tendsto
   have htarget : ∀ᶠ z in 𝓝[Set.range I] (extChartAt I x x),
       z ∈ (extChartAt I x).target :=
     extChartAt_target_mem_nhdsWithin x
   filter_upwards [htarget, hsymm_tendsto hf_eventually] with z hz hfz
   exact fderivWithin_chart_apply_mpullbackWithin hz hfz
 
-/-- Over a field whose minimum smoothness for second derivatives is at most two, let `f` be twice
-differentiable at `x`, and let `V` and `W` be differentiable vector fields there. If the directional
-derivatives of `f` along `V` and `W` are differentiable at `x`, then the differential of `f` on the
-manifold bracket is their commutator. This is the manifold counterpart of Mathlib's
+omit [CompleteSpace E] in
+private theorem mdifferentiableAt_tangentMapWithin_apply
+    {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M} {t : Set M}
+    (ht_open : IsOpen t) (hft : ContMDiffOn I 𝓘(𝕜, F) 2 f t)
+    (hxt : x ∈ t) (hU : MDiffAt (fun y ↦ (U y : TangentBundle I M)) x) :
+    MDiffAt (fun y ↦ tangentMapWithin I 𝓘(𝕜, F) f t
+      (U y : TangentBundle I M)) x := by
+  let u : M → TangentBundle I M := fun y ↦ (U y : TangentBundle I M)
+  have hu_mem : u x ∈ π E (TangentSpace I) ⁻¹' t := hxt
+  have htangent := hft.contMDiffOn_tangentMapWithin
+    (I := I) (I' := 𝓘(𝕜, F)) (m := 1) (by norm_num) ht_open.uniqueMDiffOn
+  have hpre : π E (TangentSpace I) ⁻¹' t ∈ 𝓝 (u x) :=
+    (FiberBundle.continuous_proj E (TangentSpace I)).continuousAt
+      (ht_open.mem_nhds hxt)
+  have htangentAt : MDiffAt (tangentMapWithin I 𝓘(𝕜, F) f t) (u x) := by
+    rw [← mdifferentiableWithinAt_univ]
+    exact ((htangent (u x) hu_mem).mdifferentiableWithinAt (by norm_num)).mono_of_mem_nhdsWithin
+      (by simpa only [nhdsWithin_univ] using hpre)
+  exact htangentAt.comp x hU
+
+omit [CompleteSpace E] in
+private theorem exists_open_contMDiffOn_two
+    {f : M → F} {x : M} (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
+    ∃ t : Set M, IsOpen t ∧ t ∈ 𝓝 x ∧ ContMDiffOn I 𝓘(𝕜, F) 2 f t := by
+  have h2n : (2 : ℕ∞ω) ≤ n :=
+    (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
+  rcases (contMDiffAt_iff_contMDiffOn_nhds (n := 2) (by norm_num)).1 (hf.of_le h2n) with
+    ⟨s, hs, hfs⟩
+  exact ⟨interior s, isOpen_interior,
+    isOpen_interior.mem_nhds (mem_interior_iff_mem_nhds.mpr hs), hfs.mono interior_subset⟩
+
+omit [CompleteSpace E] in
+private theorem eventually_mdifferentiableAt_of_contMDiffAt
+    {f : M → F} {x : M} (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
+    ∀ᶠ y in 𝓝 x, MDiffAt f y := by
+  have h2n : (2 : ℕ∞ω) ≤ n :=
+    (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
+  filter_upwards [(contMDiffAt_iff_contMDiffAt_nhds (n := 2) (by norm_num)).1
+    (hf.of_le h2n)] with y hy
+  exact hy.mdifferentiableAt (by norm_num)
+
+omit [CompleteSpace E] in
+private theorem eventuallyEq_tangentMapWithin_apply
+    {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M} {t : Set M}
+    (ht_open : IsOpen t) (ht : t ∈ 𝓝 x)
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n) :
+    (fun y ↦ tangentMapWithin I 𝓘(𝕜, F) f t (U y : TangentBundle I M)) =ᶠ[𝓝 x]
+      fun y ↦ tangentMap I 𝓘(𝕜, F) f (U y : TangentBundle I M) := by
+  filter_upwards [ht, eventually_mdifferentiableAt_of_contMDiffAt hf hn] with y hyt hfy
+  exact tangentMapWithin_eq_tangentMap (ht_open.uniqueMDiffWithinAt hyt) hfy
+
+omit [CompleteSpace E] in
+private theorem mdifferentiableAt_tangentMap_apply
+    {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M}
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n)
+    (hU : MDiffAt (fun y ↦ (U y : TangentBundle I M)) x) :
+    MDiffAt (fun y ↦ tangentMap I 𝓘(𝕜, F) f
+      (U y : TangentBundle I M)) x := by
+  rcases exists_open_contMDiffOn_two hf hn with ⟨t, ht_open, ht, hft⟩
+  have hx : x ∈ t := mem_of_mem_nhds ht
+  have htangentAt := mdifferentiableAt_tangentMapWithin_apply ht_open hft hx hU
+  exact htangentAt.congr_of_eventuallyEq
+    (eventuallyEq_tangentMapWithin_apply (U := U) ht_open ht hf hn).symm
+
+omit [CompleteSpace E] in
+private theorem mdifferentiableAt_mvfderiv_apply
+    {f : M → F} {U : ∀ y : M, TangentSpace I y} {x : M}
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n)
+    (hU : MDiffAt (fun y ↦ (U y : TangentBundle I M)) x) :
+    MDiffAt (fun y ↦ mvfderiv I f y (U y)) x := by
+  have htangent := mdifferentiableAt_tangentMap_apply hf hn hU
+  have hsnd : MDiffAt (fun p : TangentBundle 𝓘(𝕜, F) F ↦ @id F p.2)
+      (tangentMap I 𝓘(𝕜, F) f (U x : TangentBundle I M)) :=
+    (contMDiff_snd_tangentBundle_modelSpace F 𝓘(𝕜, F)
+      (n := 1)).mdifferentiable (by norm_num) |>.mdifferentiableAt
+  exact (hsnd.comp x htangent).congr_of_eventuallyEq (by rfl)
+
+/-- Let `f` have enough derivatives for symmetry of its second derivative at `x`, and let `V` and
+`W` be differentiable vector fields there. Then the differential of `f` on the manifold bracket is
+the commutator of its directional derivatives. This is the manifold counterpart of Mathlib's
 `fderivWithin_apply_lieBracket`. -/
-theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x} {x : M}
-    (hmin : minSmoothness 𝕜 2 ≤ 2)
-    (hf : CMDiffAt 2 f x)
+theorem mvfderiv_mlieBracket {f : M → F} {V W : ∀ x : M, TangentSpace I x} {x : M}
+    (hf : CMDiffAt n f x) (hn : minSmoothness 𝕜 2 ≤ n)
     (hV : MDiffAt (fun y ↦ (V y : TangentBundle I M)) x)
-    (hW : MDiffAt (fun y ↦ (W y : TangentBundle I M)) x)
-    (hVf : MDiffAt (fun y ↦ mvfderiv I f y (V y)) x)
-    (hWf : MDiffAt (fun y ↦ mvfderiv I f y (W y)) x) :
+    (hW : MDiffAt (fun y ↦ (W y : TangentBundle I M)) x) :
     mvfderiv I f x (mlieBracket I V W x) =
       mvfderiv I (fun y ↦ mvfderiv I f y (W y)) x (V x) -
         mvfderiv I (fun y ↦ mvfderiv I f y (V y)) x (W x) := by
@@ -120,19 +198,21 @@ theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x
   -- Normalize the same definitional tangent-space representation before applying the chart chain
   -- rule. The following `change`s only expose applications of that single linear-map identity.
   change (mfderiv% f x) _ = _
-  have hf' : MDiffAt f x := hf.mdifferentiableAt (by norm_num)
+  have h2n : (2 : ℕ∞ω) ≤ n :=
+    (le_minSmoothness (𝕜 := 𝕜) (n := (2 : ℕ∞ω))).trans hn
+  have hf' : MDiffAt f x := (hf.of_le h2n).mdifferentiableAt (by norm_num)
   have hchain := mfderiv_comp_mfderivWithin_of_eq
-    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, 𝕜))
+    (I := 𝓘(𝕜, E)) (I' := I) (I'' := 𝓘(𝕜, F))
     (f := (extChartAt I x).symm) (g := f) (s := Set.range I)
     hf' (mdifferentiableWithinAt_extChartAt_symm (mem_extChartAt_target x))
     (by apply I.uniqueMDiffOn; exact Set.mem_range_self (f := I) _)
     (extChartAt_to_inv x)
-  change @Eq (E →L[𝕜] 𝕜) _ _ at hchain
+  change @Eq (E →L[𝕜] F) _ _ at hchain
   let Z : E := lieBracketWithin 𝕜
     (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm V (Set.range I))
     (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
     ((extChartAt I x).symm ⁻¹' Set.univ ∩ Set.range I) (extChartAt I x x)
-  have hchain_apply := congrArg (fun L : E →L[𝕜] 𝕜 ↦ L Z) hchain
+  have hchain_apply := congrArg (fun L : E →L[𝕜] F ↦ L Z) hchain
   change _ = (mfderiv% f x) ((mfderiv[Set.range I]
     (extChartAt I x).symm (extChartAt I x x)) Z) at hchain_apply
   change (mfderiv% f x) ((mfderiv[Set.range I]
@@ -140,11 +220,14 @@ theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x
   rw [← hchain_apply]
   simp only [mfderivWithin_eq_fderivWithin]
   -- Pull the vector fields back and invoke the normed-space bracket identity.
-  have hfcoord : ContDiffWithinAt 𝕜 2 (f ∘ (extChartAt I x).symm)
+  have hfcoord : ContDiffWithinAt 𝕜 (minSmoothness 𝕜 2)
+      (f ∘ (extChartAt I x).symm)
       (Set.range I) (extChartAt I x x) := by
-    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self (I := I) (n := 2) x
+    have hsymm := contMDiffWithinAt_extChartAt_symm_range_self
+      (I := I) (n := minSmoothness 𝕜 2) x
     have hcomp := ContMDiffWithinAt.comp_of_eq
-      (show ContMDiffWithinAt I 𝓘(𝕜, 𝕜) 2 f Set.univ x from hf)
+      (show ContMDiffWithinAt I 𝓘(𝕜, F) (minSmoothness 𝕜 2) f Set.univ x from
+        hf.of_le hn)
       hsymm (Set.mapsTo_univ _ _) (extChartAt_to_inv x)
     exact contMDiffWithinAt_iff_contDiffWithinAt.mp hcomp
   have hVcoord : DifferentiableWithinAt 𝕜
@@ -162,12 +245,16 @@ theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x
   -- Identify chart directional derivatives with their manifold counterparts.
   have hf_chart : MDiffAt f ((extChartAt I x).symm (extChartAt I x x)) := by
     simpa only [extChartAt_to_inv] using hf'
-  have hcoordW := (eventuallyEq_chart_directionalDerivative (I := I) (U := W) hf).fderivWithin_eq
+  have hVf := mdifferentiableAt_mvfderiv_apply hf hn hV
+  have hWf := mdifferentiableAt_mvfderiv_apply hf hn hW
+  have hcoordW := (eventuallyEq_chart_directionalDerivative
+    (I := I) (U := W) hf hn).fderivWithin_eq
     (𝕜 := 𝕜) (by
       simpa only [Function.comp_apply, extChartAt_to_inv] using
         fderivWithin_chart_apply_mpullbackWithin
           (I := I) (U := W) (mem_extChartAt_target x) hf_chart)
-  have hcoordV := (eventuallyEq_chart_directionalDerivative (I := I) (U := V) hf).fderivWithin_eq
+  have hcoordV := (eventuallyEq_chart_directionalDerivative
+    (I := I) (U := V) hf hn).fderivWithin_eq
     (𝕜 := 𝕜) (by
       simpa only [Function.comp_apply, extChartAt_to_inv] using
         fderivWithin_chart_apply_mpullbackWithin
@@ -184,7 +271,7 @@ theorem mvfderiv_mlieBracket {f : M → 𝕜} {V W : ∀ x : M, TangentSpace I x
     (mpullbackWithin 𝓘(𝕜, E) I (extChartAt I x).symm W (Set.range I))
     (Set.range I) (extChartAt I x x) by
       simp only [Z, Set.preimage_univ, Set.univ_inter]]
-  rw [fderivWithin_apply_lieBracket hfcoord hmin I.uniqueDiffOn
+  rw [fderivWithin_apply_lieBracket hfcoord le_rfl I.uniqueDiffOn
     (I.range_subset_closure_interior (Set.mem_range_self (f := I) _))
     (Set.mem_range_self (f := I) _) hWcoord hVcoord]
   rw [hcoordW, hcoordV]


### PR DESCRIPTION
## Goal

Upgrade the canonical linear equivalence between `LeftInvariantDerivation I G` and the tangent Lie algebra at the identity to an equivalence of Lie algebras. This is the bracket-compatible dictionary needed to transport the tangent adjoint construction to the roadmap's prescribed Lie algebra.

## Why this establishes the goal

The two brackets are presented differently: Mathlib defines the tangent bracket through the manifold bracket of invariant vector fields, while the derivation bracket is their commutator on smooth scalar functions. The new vector-valued bridge proves directly in manifold coordinates that applying a differential to `mlieBracket` gives exactly that commutator of directional derivatives. Specializing it to Mathlib's invariant vector fields proves that `tangentToLeftInvariantDerivation` preserves brackets. Combining this bracket law with the already-merged bijective linear equivalence yields the canonical `LieEquiv`, without introducing a second Lie algebra or changing either existing bracket.

This resolves the compatibility explicitly left as a TODO in Mathlib's `Geometry.Manifold.GroupLieAlgebra` and supplies a direct prerequisite for Deliverable A, Layer 1, “The group adjoint” in the [Lie groups roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md). It is part of [the active Layer 1 intention](https://github.com/TauCetiProject/TauCetiRoadmap/issues/162).

## Verification

- `lake build TauCeti.Geometry.Lie.Tangent.LieEquiv`
- `lake build`
- `bash scripts/lint-env.sh`
- forbidden-declaration scan for `sorry`, `admit`, `native_decide`, and `set_option`

Roadmap: RepresentationTheory