### PR TITLE
feat: count the ramified primes of a quadratic field

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
@@ -1,0 +1,76 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Relative.Degree
+public import TauCeti.NumberTheory.Multiquadratic.Quadratic.Ramification
+
+/-!
+# The candidate genus field has degree `2 ^ t`
+
+For a squarefree integer `d`, the degree of `candidateGenusField hd` over `ℚ` was computed in
+`CandidateGenusField/Degree.lean` as `2 ^ (genusPrimeDiscriminants hd).card`, and its degree over
+the embedded copy of `ℚ(√d)` in `CandidateGenusField/Relative/Degree.lean` as `2 ^ (t - 1)` for the
+same `t`. Those exponents count a *chosen* prime-discriminant factorization of
+`fundamentalDiscriminant d`. This file replaces them by the intrinsic invariant of `K = ℚ(√d)` that
+genus theory names: the number `t` of rational primes ramifying in `K`.
+
+That identification is `TauCeti.Multiquadratic.ncard_ramifiedPrimes_eq_card`, so all that happens
+here is the substitution. Its point is that the exponents no longer depend on the choice made by
+`genusPrimeDiscriminants`, and that the relative degree now reads as the classical `2 ^ (t - 1)` —
+the field-theoretic half of the genus-theory `2`-rank formula, whose remaining half is the
+isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` (not yet available).
+
+The `2 ^ (t - 1)` count for the genus field is classical; see D. A. Cox, *Primes of the Form
+x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
+
+## Main results
+
+* `TauCeti.Multiquadratic.finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes`.
+* `TauCeti.Multiquadratic.finrank_candidateGenusField_over_base_eq_two_pow_ncard_ramifiedPrimes`.
+-/
+
+public section
+
+open Polynomial
+open scoped NumberField
+open TauCeti.NumberField (ramifiedPrimes)
+
+namespace TauCeti.Multiquadratic
+
+variable {K : Type*} [Field K] [NumberField K] {θ : 𝓞 K} {d : ℤ}
+
+/-- **The chosen prime-discriminant factorization has as many members as `ℚ(√d)` has ramified
+primes.** -/
+theorem card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hd : Squarefree d) :
+    (genusPrimeDiscriminants hd).card = (ramifiedPrimes K).ncard :=
+  have ⟨hs, heven, hprod⟩ := genusPrimeDiscriminants_spec hd
+  (ncard_ramifiedPrimes_eq_card hmin hgen hd hs heven hprod).symm
+
+/-- **The candidate genus field of `ℚ(√d)` has degree `2 ^ t` over `ℚ`**, where `t` is the number of
+rational primes ramifying in `ℚ(√d)`. -/
+theorem finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hd : Squarefree d) :
+    Module.finrank ℚ (candidateGenusField hd) = 2 ^ (ramifiedPrimes K).ncard := by
+  rw [finrank_candidateGenusField hd,
+    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes hmin hgen hd]
+
+/-- **The candidate genus field of `ℚ(√d)` has degree `2 ^ (t - 1)` over `ℚ(√d)`**, where `t` is the
+number of rational primes ramifying in `ℚ(√d)`. This is the field-theoretic side of the genus-theory
+`2`-rank formula: once `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` is available, it says that the elementary-`2`
+quotient of the class group has rank `t - 1`. -/
+theorem finrank_candidateGenusField_over_base_eq_two_pow_ncard_ramifiedPrimes
+    (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
+    (hd : Squarefree d) :
+    Module.finrank (candidateGenusFieldBase hd) (candidateGenusField hd) =
+      2 ^ ((ramifiedPrimes K).ncard - 1) := by
+  rw [finrank_candidateGenusField_over_candidateGenusFieldBase hd
+      (TauCeti.NumberField.not_isSquare_radicand hmin),
+    card_genusPrimeDiscriminants_eq_ncard_ramifiedPrimes hmin hgen hd]
+
+end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
@@ -28,8 +28,10 @@ x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes`.
-* `TauCeti.Multiquadratic.finrank_candidateGenusField_over_base_eq_two_pow_ncard_ramifiedPrimes`.
+In the namespace `TauCeti.Multiquadratic`:
+
+* `finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes`.
+* `finrank_candidateGenusField_over_candidateGenusFieldBase_eq_two_pow_ncard_ramifiedPrimes`.
 -/
 
 public section
@@ -64,7 +66,7 @@ theorem finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes
 number of rational primes ramifying in `ℚ(√d)`. This is the field-theoretic side of the genus-theory
 `2`-rank formula: once `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` is available, it says that the elementary-`2`
 quotient of the class group has rank `t - 1`. -/
-theorem finrank_candidateGenusField_over_base_eq_two_pow_ncard_ramifiedPrimes
+theorem finrank_candidateGenusField_over_candidateGenusFieldBase_eq_two_pow_ncard_ramifiedPrimes
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
     (hd : Squarefree d) :
     Module.finrank (candidateGenusFieldBase hd) (candidateGenusField hd) =

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean
@@ -21,7 +21,10 @@ That identification is `TauCeti.Multiquadratic.ncard_ramifiedPrimes_eq_card`, so
 here is the substitution. Its point is that the exponents no longer depend on the choice made by
 `genusPrimeDiscriminants`, and that the relative degree now reads as the classical `2 ^ (t - 1)` —
 the field-theoretic half of the genus-theory `2`-rank formula, whose remaining half is the
-isomorphism `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` (not yet available).
+isomorphism `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²` with the *narrow* class group (not yet available). The
+narrow class group is the right object here because `candidateGenusField` is unramified only at the
+finite places; for imaginary `d` it agrees with `Cl(K)`, while for real `d` the ordinary quotient
+can be smaller.
 
 The `2 ^ (t - 1)` count for the genus field is classical; see D. A. Cox, *Primes of the Form
 x² + ny²*, and F. Lemmermeyer, *Reciprocity Laws*.
@@ -64,8 +67,8 @@ theorem finrank_candidateGenusField_eq_two_pow_ncard_ramifiedPrimes
 
 /-- **The candidate genus field of `ℚ(√d)` has degree `2 ^ (t - 1)` over `ℚ(√d)`**, where `t` is the
 number of rational primes ramifying in `ℚ(√d)`. This is the field-theoretic side of the genus-theory
-`2`-rank formula: once `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` is available, it says that the elementary-`2`
-quotient of the class group has rank `t - 1`. -/
+`2`-rank formula: once `Gal(K_gen/K) ≅ Cl⁺(K)/Cl⁺(K)²` is available, it says that the elementary-`2`
+quotient of the *narrow* class group has rank `t - 1`. -/
 theorem finrank_candidateGenusField_over_candidateGenusFieldBase_eq_two_pow_ncard_ramifiedPrimes
     (hmin : minpoly ℤ θ = X ^ 2 - C d) (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤)
     (hd : Squarefree d) :

--- a/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/OfSquarefree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/FundamentalDiscriminant/OfSquarefree.lean
@@ -36,6 +36,8 @@ law in `Quadratic/Ramification.lean`: a prime coprime to `2` divides it exactly 
   `p ∣ fundamentalDiscriminant d ↔ p ∣ d` (the ramified odd primes are the divisors of `d`).
 * `TauCeti.Multiquadratic.two_not_dvd_fundamentalDiscriminant_iff_mod_four_eq_one`:
   `2 ∤ fundamentalDiscriminant d ↔ d ≡ 1 (mod 4)` (`2` is unramified exactly then).
+* `TauCeti.Multiquadratic.fundamentalDiscriminant_primeDiscriminantRadicand`: a prime discriminant
+  is the fundamental discriminant of its own radicand.
 -/
 
 public section
@@ -112,5 +114,17 @@ left-hand side is not a simp normal form (it is applied explicitly instead). -/
 theorem two_not_dvd_fundamentalDiscriminant_iff_mod_four_eq_one (d : ℤ) :
     ¬ (2 : ℤ) ∣ fundamentalDiscriminant d ↔ d % 4 = 1 := by
   rw [fundamentalDiscriminant_def]; split_ifs with h <;> omega
+
+/-- **A prime discriminant is the fundamental discriminant of its own radicand.** For an odd prime
+discriminant this is the congruence `p* ≡ 1 (mod 4)`; for `-4`, `8`, `-8` it is the factor `4`
+removed by `primeDiscriminantRadicand`. So `ℚ(√(radicand D))` is the quadratic field of
+discriminant `D`. -/
+theorem fundamentalDiscriminant_primeDiscriminantRadicand {D : ℤ} (hD : IsPrimeDiscriminant D) :
+    fundamentalDiscriminant (primeDiscriminantRadicand D) = D := by
+  rcases isPrimeDiscriminant_iff.mp hD with hev | ⟨p, _hp, hodd, rfl⟩
+  · rw [primeDiscriminantRadicand_of_isEvenPrimeDiscriminant hev]
+    rcases hev with rfl | rfl | rfl <;> norm_num [fundamentalDiscriminant_def]
+  · rw [primeDiscriminantRadicand_oddPrimeDiscriminant hodd,
+      fundamentalDiscriminant_of_mod_four_eq_one (oddPrimeDiscriminant_mod_four_eq_one hodd)]
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
@@ -35,6 +35,9 @@ discriminant `D ∈ {-4, 8, -8}`, the radicand is `D / 4`, so the three even cas
   squarefree.
 * `TauCeti.Multiquadratic.not_isSquare_primeDiscriminantRadicand_rat`: the associated rational
   radicand is not a square.
+* `TauCeti.Multiquadratic.primeDiscriminantPrime`: the single rational prime lying under a prime
+  discriminant, with `TauCeti.Multiquadratic.natCast_dvd_primeDiscriminant_iff` saying that it is
+  the only prime divisor.
 -/
 
 public section
@@ -359,5 +362,104 @@ theorem injective_primeDiscriminantRadicand_comp_iff {ι : Type*} {D : ι → �
   simpa only [Function.comp_def] using
     (Set.InjOn.injective_iff {D : ℤ | IsPrimeDiscriminant D} injOn_primeDiscriminantRadicand
       (by rintro _ ⟨i, rfl⟩; exact hD i))
+
+/-! ### The prime under a prime discriminant
+
+A prime discriminant is, up to sign, a power of a single rational prime: `p` for the odd prime
+discriminant `p*`, and `2` for each of `-4`, `8`, `-8`. That prime is the one ramifying in the
+quadratic field the discriminant belongs to, so the map below is what turns a prime-discriminant
+factorization of a fundamental discriminant into the list of ramified primes. -/
+
+/-- The rational prime lying under a prime discriminant: `p` for the odd prime discriminant `p*`,
+and `2` for the even prime discriminants `-4`, `8`, `-8`. -/
+@[expose] def primeDiscriminantPrime (D : ℤ) : ℕ :=
+  if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs
+
+/-- The defining `if` expression for `primeDiscriminantPrime`. -/
+theorem primeDiscriminantPrime_def (D : ℤ) :
+    primeDiscriminantPrime D = if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs :=
+  rfl
+
+/-- The prime under an even prime discriminant is `2`. -/
+@[simp]
+theorem primeDiscriminantPrime_of_isEvenPrimeDiscriminant {D : ℤ}
+    (hD : IsEvenPrimeDiscriminant D) : primeDiscriminantPrime D = 2 := by
+  rcases hD with rfl | rfl | rfl <;> simp [primeDiscriminantPrime]
+
+/-- The prime under the odd prime discriminant `p*` is `p`. -/
+@[simp]
+theorem primeDiscriminantPrime_oddPrimeDiscriminant {p : ℕ} (hodd : Odd p) :
+    primeDiscriminantPrime (oddPrimeDiscriminant p) = p := by
+  have hnot : ¬ (oddPrimeDiscriminant p = -4 ∨
+      oddPrimeDiscriminant p = 8 ∨ oddPrimeDiscriminant p = -8) := by
+    simpa [IsEvenPrimeDiscriminant] using not_isEvenPrimeDiscriminant_oddPrimeDiscriminant hodd
+  simp [primeDiscriminantPrime, hnot]
+
+/-- The prime under a prime discriminant is a natural prime. -/
+theorem prime_primeDiscriminantPrime {D : ℤ} (hD : IsPrimeDiscriminant D) :
+    (primeDiscriminantPrime D).Prime := by
+  rcases hD with hev | ⟨p, hp, hodd, rfl⟩
+  · rw [primeDiscriminantPrime_of_isEvenPrimeDiscriminant hev]
+    exact Nat.prime_two
+  · rwa [primeDiscriminantPrime_oddPrimeDiscriminant hodd]
+
+/-- The prime under a prime discriminant divides it. -/
+theorem primeDiscriminantPrime_dvd {D : ℤ} (hD : IsPrimeDiscriminant D) :
+    (primeDiscriminantPrime D : ℤ) ∣ D := by
+  rcases hD with hev | ⟨p, _hp, hodd, rfl⟩
+  · rw [primeDiscriminantPrime_of_isEvenPrimeDiscriminant hev]
+    simpa using two_dvd_evenPrimeDiscriminant hev
+  · simp [primeDiscriminantPrime_oddPrimeDiscriminant hodd]
+
+/-- A natural prime dividing a power of `2` is `2`. -/
+private theorem eq_two_of_prime_dvd_two_pow {p k : ℕ} (hp : p.Prime) (h : p ∣ 2 ^ k) : p = 2 :=
+  (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow h)
+
+/-- **A prime discriminant has exactly one prime divisor.** A natural prime divides a prime
+discriminant precisely when it is the prime under it. This is what makes the prime-discriminant
+factorization of a fundamental discriminant a list of ramified primes without repetition. -/
+theorem natCast_dvd_primeDiscriminant_iff {D : ℤ} (hD : IsPrimeDiscriminant D) {p : ℕ}
+    (hp : p.Prime) : (p : ℤ) ∣ D ↔ p = primeDiscriminantPrime D := by
+  refine ⟨fun hdvd => ?_, fun h => h ▸ primeDiscriminantPrime_dvd hD⟩
+  rcases hD with hev | ⟨r, hr, hodd, rfl⟩
+  · rw [primeDiscriminantPrime_of_isEvenPrimeDiscriminant hev]
+    have hd8 : D ∣ (8 : ℤ) := by
+      rcases hev with rfl | rfl | rfl
+      · exact ⟨-2, by norm_num⟩
+      · exact ⟨1, by norm_num⟩
+      · exact ⟨-1, by norm_num⟩
+    have hdvd8 : (p : ℤ) ∣ ((2 ^ 3 : ℕ) : ℤ) := by
+      simpa using hdvd.trans hd8
+    exact eq_two_of_prime_dvd_two_pow hp (Int.natCast_dvd_natCast.mp hdvd8)
+  · rw [primeDiscriminantPrime_oddPrimeDiscriminant hodd]
+    rw [dvd_oddPrimeDiscriminant_iff] at hdvd
+    exact (Nat.prime_dvd_prime_iff_eq hp hr).mp (Int.natCast_dvd_natCast.mp hdvd)
+
+/-- **The prime under a prime discriminant determines it**, provided the two discriminants are not
+two distinct even prime discriminants (all three of which lie over `2`). -/
+theorem eq_of_primeDiscriminantPrime_eq {D E : ℤ} (hD : IsPrimeDiscriminant D)
+    (hE : IsPrimeDiscriminant E)
+    (heven : IsEvenPrimeDiscriminant D → IsEvenPrimeDiscriminant E → D = E)
+    (h : primeDiscriminantPrime D = primeDiscriminantPrime E) : D = E := by
+  rcases hD with hevD | ⟨p, _hp, hpodd, rfl⟩ <;> rcases hE with hevE | ⟨r, _hr, hrodd, rfl⟩
+  · exact heven hevD hevE
+  · rw [primeDiscriminantPrime_of_isEvenPrimeDiscriminant hevD,
+      primeDiscriminantPrime_oddPrimeDiscriminant hrodd] at h
+    rcases hrodd with ⟨k, hk⟩
+    omega
+  · rw [primeDiscriminantPrime_oddPrimeDiscriminant hpodd,
+      primeDiscriminantPrime_of_isEvenPrimeDiscriminant hevE] at h
+    rcases hpodd with ⟨k, hk⟩
+    omega
+  · rw [primeDiscriminantPrime_oddPrimeDiscriminant hpodd,
+      primeDiscriminantPrime_oddPrimeDiscriminant hrodd] at h
+    rw [h]
+
+/-- `primeDiscriminantPrime` is injective on a set of prime discriminants containing at most one
+even prime discriminant. -/
+theorem injOn_primeDiscriminantPrime {s : Set ℤ} (hs : ∀ D ∈ s, IsPrimeDiscriminant D)
+    (heven : ∀ D ∈ s, ∀ E ∈ s, IsEvenPrimeDiscriminant D → IsEvenPrimeDiscriminant E → D = E) :
+    Set.InjOn primeDiscriminantPrime s :=
+  fun D hD E hE h => eq_of_primeDiscriminantPrime_eq (hs D hD) (hs E hE) (heven D hD E hE) h
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
@@ -372,13 +372,15 @@ factorization of a fundamental discriminant into the list of ramified primes. -/
 
 /-- The rational prime lying under a prime discriminant: `p` for the odd prime discriminant `p*`,
 and `2` for the even prime discriminants `-4`, `8`, `-8`. -/
-@[expose] def primeDiscriminantPrime (D : ℤ) : ℕ :=
+def primeDiscriminantPrime (D : ℤ) : ℕ :=
   if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs
 
-/-- The defining `if` expression for `primeDiscriminantPrime`. -/
+/-- The defining `if` expression for `primeDiscriminantPrime`. The body of
+`primeDiscriminantPrime` is not `@[expose]`d, so downstream files rewrite with this lemma — or with
+the evaluation lemmas below — rather than unfolding the definition. -/
 theorem primeDiscriminantPrime_def (D : ℤ) :
-    primeDiscriminantPrime D = if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs :=
-  rfl
+    primeDiscriminantPrime D = if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs := by
+  rw [primeDiscriminantPrime]
 
 /-- The prime under an even prime discriminant is `2`. -/
 @[simp]
@@ -411,10 +413,6 @@ theorem primeDiscriminantPrime_dvd {D : ℤ} (hD : IsPrimeDiscriminant D) :
     simpa using two_dvd_evenPrimeDiscriminant hev
   · simp [primeDiscriminantPrime_oddPrimeDiscriminant hodd]
 
-/-- A natural prime dividing a power of `2` is `2`. -/
-private theorem eq_two_of_prime_dvd_two_pow {p k : ℕ} (hp : p.Prime) (h : p ∣ 2 ^ k) : p = 2 :=
-  (Nat.prime_dvd_prime_iff_eq hp Nat.prime_two).mp (hp.dvd_of_dvd_pow h)
-
 /-- **A prime discriminant has exactly one prime divisor.** A natural prime divides a prime
 discriminant precisely when it is the prime under it. This is what makes the prime-discriminant
 factorization of a fundamental discriminant a list of ramified primes without repetition. -/
@@ -430,7 +428,7 @@ theorem natCast_dvd_primeDiscriminant_iff {D : ℤ} (hD : IsPrimeDiscriminant D)
       · exact ⟨-1, by norm_num⟩
     have hdvd8 : (p : ℤ) ∣ ((2 ^ 3 : ℕ) : ℤ) := by
       simpa using hdvd.trans hd8
-    exact eq_two_of_prime_dvd_two_pow hp (Int.natCast_dvd_natCast.mp hdvd8)
+    exact Nat.prime_eq_prime_of_dvd_pow hp Nat.prime_two (Int.natCast_dvd_natCast.mp hdvd8)
   · rw [primeDiscriminantPrime_oddPrimeDiscriminant hodd]
     rw [dvd_oddPrimeDiscriminant_iff] at hdvd
     exact (Nat.prime_dvd_prime_iff_eq hp hr).mp (Int.natCast_dvd_natCast.mp hdvd)

--- a/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Prime/Discriminants.lean
@@ -370,8 +370,13 @@ discriminant `p*`, and `2` for each of `-4`, `8`, `-8`. That prime is the one ra
 quadratic field the discriminant belongs to, so the map below is what turns a prime-discriminant
 factorization of a fundamental discriminant into the list of ramified primes. -/
 
-/-- The rational prime lying under a prime discriminant: `p` for the odd prime discriminant `p*`,
-and `2` for the even prime discriminants `-4`, `8`, `-8`. -/
+/-- The rational prime lying under a prime discriminant `D`, when `IsPrimeDiscriminant D`: `p` for
+the odd prime discriminant `p*`, and `2` for the even prime discriminants `-4`, `8`, `-8`. That the
+value really is prime under that hypothesis is `prime_primeDiscriminantPrime`.
+
+The definition is total: on an integer that is not a prime discriminant it returns the junk value
+`D.natAbs` (unless `D` is one of `-4`, `8`, `-8`), which need not be prime — for instance
+`primeDiscriminantPrime 9 = 9`. -/
 def primeDiscriminantPrime (D : ℤ) : ℕ :=
   if D = -4 ∨ D = 8 ∨ D = -8 then 2 else D.natAbs
 

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
@@ -7,7 +7,6 @@ module
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.Discriminant
 public import TauCeti.NumberTheory.Multiquadratic.FundamentalDiscriminant.Factorization
 public import TauCeti.NumberTheory.NumberField.RamifiedPrimes
-public import Mathlib.NumberTheory.NumberField.Discriminant.Different
 import Mathlib.Algebra.BigOperators.Associated
 
 /-!

--- a/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/Quadratic/Ramification.lean
@@ -5,7 +5,10 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.Quadratic.Discriminant
+public import TauCeti.NumberTheory.Multiquadratic.FundamentalDiscriminant.Factorization
+public import TauCeti.NumberTheory.NumberField.RamifiedPrimes
 public import Mathlib.NumberTheory.NumberField.Discriminant.Different
+import Mathlib.Algebra.BigOperators.Associated
 
 /-!
 # Ramification of primes in a quadratic field
@@ -22,17 +25,33 @@ This is the finite-prime half of the Layer-1 ramified-prime behaviour of the mul
 roadmap. It combines Mathlib's `NumberField.not_dvd_discr_iff_isUnramifiedIn` with the quadratic
 discriminant computation `TauCeti.Multiquadratic.discr_eq_fundamentalDiscriminant`.
 
+The second half of the file counts the ramified primes. Writing `fundamentalDiscriminant d` as a
+product of prime discriminants (`IsFundamentalDiscriminant.exists_finset_primeDiscriminant`), each
+factor contributes exactly one ramified prime — the prime `primeDiscriminantPrime` lying under it —
+and distinct factors contribute distinct primes. So the number `t` of ramified primes of `ℚ(√d)` is
+the number of prime discriminants in that factorization: the `t` of the genus-theory `2`-rank
+formula and of the degree `2 ^ t` of the candidate genus field. The one-factor case is recorded
+separately: a single prime ramifies in the quadratic field of a prime discriminant, which is what
+the name "prime discriminant" refers to.
+
 ## Main results
 
 * `TauCeti.Multiquadratic.isUnramifiedIn_iff_not_dvd_fundamentalDiscriminant`.
 * `TauCeti.Multiquadratic.isUnramifiedIn_iff_not_dvd_of_not_dvd_two`: odd primes.
 * `TauCeti.Multiquadratic.isUnramifiedIn_two_iff_mod_four_eq_one`: the prime `2`.
+* `TauCeti.Multiquadratic.ramifiedPrimes_eq_singleton`: exactly one prime ramifies in the quadratic
+  field of a prime discriminant.
+* `TauCeti.Multiquadratic.ramifiedPrimes_eq_image`: the ramified primes of `ℚ(√d)` are the primes
+  under the prime discriminants dividing its discriminant.
+* `TauCeti.Multiquadratic.ncard_ramifiedPrimes_eq_card`: hence there are as many ramified primes as
+  prime-discriminant factors.
 -/
 
 public section
 
 open Polynomial
 open scoped NumberField
+open TauCeti.NumberField (ramifiedPrimes)
 
 namespace TauCeti.Multiquadratic
 
@@ -62,5 +81,88 @@ theorem isUnramifiedIn_two_iff_mod_four_eq_one (hmin : minpoly ℤ θ = X ^ 2 - 
     Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(2 : ℤ)}) ↔ d % 4 = 1 := by
   rw [isUnramifiedIn_iff_not_dvd_fundamentalDiscriminant hmin hgen hsf Int.prime_two,
     two_not_dvd_fundamentalDiscriminant_iff_mod_four_eq_one]
+
+/-! ### Counting the ramified primes -/
+
+/-- **The ramified primes of `ℚ(√d)`.** A natural prime lies in `ramifiedPrimes K` exactly when it
+divides `fundamentalDiscriminant d`. -/
+theorem mem_ramifiedPrimes_iff_dvd_fundamentalDiscriminant (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) {p : ℕ} (hp : p.Prime) :
+    p ∈ ramifiedPrimes K ↔ (p : ℤ) ∣ fundamentalDiscriminant d := by
+  rw [TauCeti.NumberField.mem_ramifiedPrimes_iff_dvd_discr hp,
+    discr_eq_fundamentalDiscriminant hmin hgen hsf]
+
+/-- **Exactly one rational prime ramifies in the quadratic field of a prime discriminant.** If `D`
+is a prime discriminant and `K = ℚ(√(primeDiscriminantRadicand D))`, then the ramified primes of `K`
+are the single prime `primeDiscriminantPrime D` lying under `D`. This is the defining property of a
+prime discriminant, and the base case of the count below. -/
+theorem ramifiedPrimes_eq_singleton {D : ℤ} (hD : IsPrimeDiscriminant D)
+    (hmin : minpoly ℤ θ = X ^ 2 - C (primeDiscriminantRadicand D))
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) :
+    ramifiedPrimes K = {primeDiscriminantPrime D} := by
+  have key : ∀ p : ℕ, p.Prime → (p ∈ ramifiedPrimes K ↔ p = primeDiscriminantPrime D) := by
+    intro p hp
+    rw [mem_ramifiedPrimes_iff_dvd_fundamentalDiscriminant hmin hgen
+        (squarefree_primeDiscriminantRadicand hD) hp,
+      fundamentalDiscriminant_primeDiscriminantRadicand hD,
+      natCast_dvd_primeDiscriminant_iff hD hp]
+  ext p
+  rw [Set.mem_singleton_iff]
+  exact ⟨fun hp => (key p (TauCeti.NumberField.prime_of_mem_ramifiedPrimes hp)).mp hp,
+    fun hp => (key p (hp ▸ prime_primeDiscriminantPrime hD)).mpr hp⟩
+
+variable {s : Finset ℤ}
+
+/-- **The ramified primes of `ℚ(√d)` are the primes under the prime discriminants dividing its
+discriminant.** If `s` is a finite set of prime discriminants with product
+`fundamentalDiscriminant d`, then the ramified primes of `K = ℚ(√d)` are exactly the primes
+`primeDiscriminantPrime P` for `P ∈ s`: a prime divides the product iff it divides some factor, and
+a prime discriminant has just one prime divisor. -/
+theorem ramifiedPrimes_eq_image (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d)
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P) (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) :
+    ramifiedPrimes K = ↑(s.image primeDiscriminantPrime) := by
+  classical
+  have hmem : ∀ p : ℕ, p.Prime →
+      (p ∈ ramifiedPrimes K ↔ ∃ P ∈ s, p = primeDiscriminantPrime P) := by
+    intro p hp
+    rw [mem_ramifiedPrimes_iff_dvd_fundamentalDiscriminant hmin hgen hsf hp, ← hprod,
+      (Nat.prime_iff_prime_int.mp hp).dvd_finsetProd_iff]
+    exact exists_congr fun P => and_congr_right fun hP =>
+      natCast_dvd_primeDiscriminant_iff (hs P hP) hp
+  ext p
+  simp only [Finset.coe_image, Set.mem_image, Finset.mem_coe]
+  constructor
+  · intro hp
+    obtain ⟨P, hP, hpP⟩ := (hmem p (TauCeti.NumberField.prime_of_mem_ramifiedPrimes hp)).mp hp
+    exact ⟨P, hP, hpP.symm⟩
+  · rintro ⟨P, hP, rfl⟩
+    exact (hmem _ (prime_primeDiscriminantPrime (hs P hP))).mpr ⟨P, hP, rfl⟩
+
+/-- **The number of ramified primes of `ℚ(√d)` is the number of prime discriminants dividing its
+discriminant.** This is the `t` of genus theory: the exponent in the degree `2 ^ t` of the candidate
+genus field, and the `t` of the `2`-rank formula `t - 1`. Distinct prime-discriminant factors give
+distinct ramified primes because only the three even prime discriminants share a prime, and `s`
+contains at most one of them. -/
+theorem ncard_ramifiedPrimes_eq_card (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d)
+    (hs : ∀ P ∈ s, IsPrimeDiscriminant P)
+    (heven : ∀ P ∈ s, ∀ Q ∈ s, IsEvenPrimeDiscriminant P → IsEvenPrimeDiscriminant Q → P = Q)
+    (hprod : ∏ P ∈ s, P = fundamentalDiscriminant d) :
+    (ramifiedPrimes K).ncard = s.card := by
+  classical
+  rw [ramifiedPrimes_eq_image hmin hgen hsf hs hprod, Set.ncard_coe_finset,
+    Finset.card_image_of_injOn (injOn_primeDiscriminantPrime hs heven)]
+
+/-- **The ramified primes of `ℚ(√d)`, counted by a prime-discriminant factorization of the
+discriminant.** Packages `ncard_ramifiedPrimes_eq_card` with the existence of the factorization, so
+a caller need only supply `d` squarefree together with a quadratic presentation of `K`. -/
+theorem exists_finset_primeDiscriminant_ncard_ramifiedPrimes (hmin : minpoly ℤ θ = X ^ 2 - C d)
+    (hgen : Algebra.adjoin ℚ {(θ : K)} = ⊤) (hsf : Squarefree d) :
+    ∃ s : Finset ℤ, (∀ P ∈ s, IsPrimeDiscriminant P) ∧
+      ∏ P ∈ s, P = fundamentalDiscriminant d ∧ (ramifiedPrimes K).ncard = s.card := by
+  obtain ⟨s, hs, heven, hprod⟩ :=
+    (isFundamentalDiscriminant_fundamentalDiscriminant hsf).exists_finset_primeDiscriminant
+  exact ⟨s, hs, hprod, ncard_ramifiedPrimes_eq_card hmin hgen hsf hs heven hprod⟩
 
 end TauCeti.Multiquadratic

--- a/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
+++ b/TauCeti/NumberTheory/NumberField/Quadratic/Basic.lean
@@ -24,6 +24,7 @@ the ring-of-integers/discriminant computation (`Quadratic/RingOfIntegers.lean`).
 * `TauCeti.NumberField.finrank_rat_eq_two`: `K` has degree `2` over `ℚ`.
 * `TauCeti.NumberField.coe_gen_sq`: the generator squares to the radicand, `θ² = d` in `K`.
 * `TauCeti.NumberField.gen_notMem_range`: the generator is not rational, `θ ∉ ℚ`.
+* `TauCeti.NumberField.not_isSquare_radicand`: the radicand is not a rational square.
 * `TauCeti.NumberField.trace_gen_eq_zero`: the trace of the generator is `0`.
 * `TauCeti.NumberField.discr_one_gen`: the discriminant of `{1, θ}` over `ℚ` is `4d`.
 * `TauCeti.NumberField.discr_one_halfGen`: the discriminant of `{1, (1+θ)/2}` over `ℚ` is `d`.
@@ -82,6 +83,21 @@ theorem gen_notMem_range (hmin : minpoly ℤ θ = X ^ 2 - C d) :
     simpa [natDegree_X_sub_C] using Polynomial.natDegree_le_of_dvd hdvd (X_sub_C_ne_zero q)
   rw [hq, minpoly_rat_quadratic hmin, natDegree_X_pow_sub_C] at h1
   norm_num at h1
+
+/-- **The radicand of a quadratic presentation is not a rational square.** Were `d = q²`, the
+factorization `(θ - q)(θ + q) = θ² - d = 0` would force `θ = ±q ∈ ℚ`. -/
+theorem not_isSquare_radicand (hmin : minpoly ℤ θ = X ^ 2 - C d) :
+    ¬ IsSquare (((d : ℤ) : ℚ)) := by
+  rintro ⟨q, hq⟩
+  have hθ : (θ : K) ^ 2 = algebraMap ℚ K ((d : ℤ) : ℚ) := by
+    rw [coe_gen_sq hmin, IsScalarTower.algebraMap_apply ℤ ℚ K]; norm_num
+  have hq' : algebraMap ℚ K ((d : ℤ) : ℚ) = algebraMap ℚ K q * algebraMap ℚ K q := by
+    rw [← map_mul, ← hq]
+  have hfac : ((θ : K) - algebraMap ℚ K q) * ((θ : K) + algebraMap ℚ K q) = 0 := by
+    linear_combination hθ + hq'
+  rcases mul_eq_zero.mp hfac with h | h
+  · exact gen_notMem_range hmin ⟨q, by linear_combination -h⟩
+  · exact gen_notMem_range hmin ⟨-q, by rw [map_neg]; linear_combination -h⟩
 
 /-- The trace of the generator vanishes: `Tr(θ) = 0`. -/
 theorem trace_gen_eq_zero (hmin : minpoly ℤ θ = X ^ 2 - C d) :

--- a/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
@@ -41,8 +41,8 @@ namespace TauCeti.NumberField
 variable (K : Type*) [Field K]
 
 /-- **The ramified rational primes of a number field.** The set of natural primes `p` such that
-`p` — as the ideal `span {p}` of `ℤ` — ramifies in the ring of integers of `K`. Its cardinality is
-the `t` of genus theory. -/
+`p` — as the ideal `span {p}` of `ℤ` — ramifies in the ring of integers of `K`. For a quadratic
+field `K`, its cardinality is the `t` of genus theory. -/
 def ramifiedPrimes : Set ℕ :=
   {p | p.Prime ∧ ¬ Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(p : ℤ)})}
 

--- a/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
@@ -1,0 +1,86 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.NumberTheory.NumberField.Discriminant.Different
+public import Mathlib.NumberTheory.NumberField.ExistsRamified
+
+/-!
+# The ramified rational primes of a number field
+
+The genus theory of a quadratic field is governed by the number `t` of rational primes that ramify
+in it: the genus field has degree `2 ^ t` over `ℚ` and the `2`-rank of the narrow class group is
+`t - 1`. This file names that set of primes and records its basic properties.
+
+Mathlib phrases ramification of a rational prime `p` in a number field `K` as
+`Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(p : ℤ)})`, and characterises it by divisibility of the
+discriminant (`NumberField.not_dvd_discr_iff_isUnramifiedIn`). We package the negation as a set of
+natural primes, which is the form in which `t` is counted.
+
+## Main definitions
+
+* `TauCeti.NumberField.ramifiedPrimes`: the set of natural primes ramifying in `K`.
+
+## Main results
+
+* `TauCeti.NumberField.mem_ramifiedPrimes_iff_dvd_discr`: a prime ramifies iff it divides the
+  discriminant.
+* `TauCeti.NumberField.finite_ramifiedPrimes`: only finitely many primes ramify.
+* `TauCeti.NumberField.ramifiedPrimes_nonempty`: some prime ramifies, unless `K = ℚ`
+  (Minkowski, via `NumberField.exists_not_isUnramifiedIn`).
+-/
+
+public section
+
+open scoped NumberField
+
+namespace TauCeti.NumberField
+
+variable (K : Type*) [Field K]
+
+/-- **The ramified rational primes of a number field.** The set of natural primes `p` such that
+`p` — as the ideal `span {p}` of `ℤ` — ramifies in the ring of integers of `K`. Its cardinality is
+the `t` of genus theory. -/
+def ramifiedPrimes : Set ℕ :=
+  {p | p.Prime ∧ ¬ Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(p : ℤ)})}
+
+variable {K}
+
+/-- The defining condition for membership in `ramifiedPrimes`. -/
+theorem mem_ramifiedPrimes_iff {p : ℕ} :
+    p ∈ ramifiedPrimes K ↔
+      p.Prime ∧ ¬ Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(p : ℤ)}) :=
+  Iff.rfl
+
+/-- A ramified prime is prime. -/
+theorem prime_of_mem_ramifiedPrimes {p : ℕ} (hp : p ∈ ramifiedPrimes K) : p.Prime :=
+  hp.1
+
+variable [NumberField K]
+
+/-- **Ramification is divisibility of the discriminant.** A natural prime `p` ramifies in `K` iff
+`p` divides `NumberField.discr K`. This is `NumberField.not_dvd_discr_iff_isUnramifiedIn` in the
+`ramifiedPrimes` packaging. -/
+theorem mem_ramifiedPrimes_iff_dvd_discr {p : ℕ} (hp : p.Prime) :
+    p ∈ ramifiedPrimes K ↔ (p : ℤ) ∣ NumberField.discr K := by
+  rw [mem_ramifiedPrimes_iff, and_iff_right hp,
+    ← NumberField.not_dvd_discr_iff_isUnramifiedIn K (𝓞 K) (Nat.prime_iff_prime_int.mp hp),
+    not_not]
+
+/-- **Only finitely many primes ramify**, since they all divide the nonzero integer
+`NumberField.discr K`. -/
+theorem finite_ramifiedPrimes : (ramifiedPrimes K).Finite := by
+  have hne : (NumberField.discr K).natAbs ≠ 0 :=
+    Int.natAbs_ne_zero.mpr (NumberField.discr_ne_zero K)
+  refine Set.Finite.subset (NumberField.discr K).natAbs.divisors.finite_toSet fun p hp => ?_
+  exact Finset.mem_coe.mpr (Nat.mem_divisors.mpr
+    ⟨Int.natCast_dvd.mp ((mem_ramifiedPrimes_iff_dvd_discr hp.1).mp hp), hne⟩)
+
+/-- **Some prime ramifies in a number field other than `ℚ`.** This is Minkowski's bound in the form
+`NumberField.exists_not_isUnramifiedIn`. -/
+theorem ramifiedPrimes_nonempty (h : Module.finrank ℚ K ≠ 1) : (ramifiedPrimes K).Nonempty :=
+  NumberField.exists_not_isUnramifiedIn (𝒪 := 𝓞 K) h
+
+end TauCeti.NumberField

--- a/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
+++ b/TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean
@@ -49,6 +49,7 @@ def ramifiedPrimes : Set ℕ :=
 variable {K}
 
 /-- The defining condition for membership in `ramifiedPrimes`. -/
+@[simp]
 theorem mem_ramifiedPrimes_iff {p : ℕ} :
     p ∈ ramifiedPrimes K ↔
       p.Prime ∧ ¬ Algebra.IsUnramifiedIn (𝓞 K) (Ideal.span {(p : ℤ)}) :=
@@ -80,7 +81,8 @@ theorem finite_ramifiedPrimes : (ramifiedPrimes K).Finite := by
 
 /-- **Some prime ramifies in a number field other than `ℚ`.** This is Minkowski's bound in the form
 `NumberField.exists_not_isUnramifiedIn`. -/
-theorem ramifiedPrimes_nonempty (h : Module.finrank ℚ K ≠ 1) : (ramifiedPrimes K).Nonempty :=
-  NumberField.exists_not_isUnramifiedIn (𝒪 := 𝓞 K) h
+theorem ramifiedPrimes_nonempty (h : Module.finrank ℚ K ≠ 1) : (ramifiedPrimes K).Nonempty := by
+  simpa only [Set.nonempty_def, mem_ramifiedPrimes_iff] using
+    NumberField.exists_not_isUnramifiedIn (𝒪 := 𝓞 K) h
 
 end TauCeti.NumberField


### PR DESCRIPTION
This PR counts the rational primes that ramify in a quadratic field, supplying the `t` that the Multiquadratic roadmap's Layer-3 milestone — the genus field and its `2`-rank formula — is stated in terms of. `TauCeti.NumberField.ramifiedPrimes` names the set of natural primes ramifying in a number field (with the discriminant criterion, finiteness, and nonemptiness away from `ℚ`); `TauCeti.Multiquadratic.primeDiscriminantPrime` names the single rational prime lying under a prime discriminant, and `natCast_dvd_primeDiscriminant_iff` proves it is the only prime divisor; `fundamentalDiscriminant_primeDiscriminantRadicand` shows a prime discriminant is the discriminant of its own quadratic field, whence `ramifiedPrimes_eq_singleton`: exactly one prime ramifies in `ℚ(√(radicand D))`. The main theorem `ramifiedPrimes_eq_image` then identifies the ramified primes of `ℚ(√d)` with the primes under the prime discriminants dividing `fundamentalDiscriminant d`, and `ncard_ramifiedPrimes_eq_card` counts them: `t` equals the number of prime-discriminant factors, distinct factors giving distinct primes because at most one of them is even. Finally the two known degrees of the candidate genus field are restated in this intrinsic invariant — `[K_gen : ℚ] = 2 ^ t` and `[K_gen : ℚ(√d)] = 2 ^ (t - 1)` — so they no longer depend on the arbitrary factorization chosen by `genusPrimeDiscriminants`.

The milestone served is Layer 3, "the genus field and the 2-rank theorem": the roadmap states the summit as `2-rank = t - 1` with `t` the number of ramified primes, and until now `t` did not exist in the repository — the candidate genus field's degrees were expressed through a chosen prime-discriminant factorization instead. `[K_gen : ℚ(√d)] = 2 ^ (t - 1)` is now the exact field-theoretic half of that formula; what remains for the milestone is the arithmetic half, `Gal(K_gen/K) ≅ Cl(K)/Cl(K)²` (and, for real `d`, the narrow genus field), plus the intrinsic characterisation of the genus field as the maximal everywhere-unramified extension abelian over `ℚ`, for which these ramified-prime facts are the finite-place input. On the worked examples the count is the roadmap's: `t = 2` for `ℚ(√-5)` (discriminant `-20 = (-4)·5`) and `t = 3` for `ℚ(√-21)` (discriminant `-84 = (-4)·(-3)·(-7)`).

Files: `TauCeti/NumberTheory/NumberField/RamifiedPrimes.lean` (new, 86 lines) and `TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/RamifiedPrimes.lean` (new, 76 lines), plus additions to `Prime/Discriminants.lean` (102), `Quadratic/Ramification.lean` (102), `FundamentalDiscriminant/OfSquarefree.lean` (14) and `NumberField/Quadratic/Basic.lean` (16). No Mathlib infrastructure was vendored; the work consumes `NumberField.not_dvd_discr_iff_isUnramifiedIn`, `NumberField.exists_not_isUnramifiedIn` and `Prime.dvd_finsetProd_iff` from the pinned Mathlib.

Roadmap: Multiquadratic

<!--tauceti-target:v1 {"focus":"Multiquadratic","id":"ncard-ramifiedprimes-eq-card"}-->

🤖 Prepared with Claude Code
