### PR TITLE
refactor(Young): decompose the row-column counting lemma

### DIFF
--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -172,9 +172,7 @@ theorem card_filter_rowIndex_eq (t : YoungTableau μ) (i : ℕ) :
 
 /-! ## The counting lemma -/
 
-/-- **Row `i` meets the first `k` columns in exactly `min (μ.rowLen i) k` labels.** The labels of
-row `i` are indexed by their columns, which run over `Finset.range (μ.rowLen i)`, so those below `k`
-number `min (μ.rowLen i) k`. -/
+/-- **Row `i` meets the first `k` columns in exactly `min (μ.rowLen i) k` labels.** -/
 private theorem card_filter_colIndex_lt_and_rowIndex_eq (t : YoungTableau μ) (i k : ℕ) :
     (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).card
       = min (μ.rowLen i) k := by
@@ -200,11 +198,11 @@ private theorem card_filter_colIndex_lt_and_rowIndex_eq (t : YoungTableau μ) (i
     simp
   rw [← Finset.card_image_of_injOn hinj, himg, hrange, Finset.card_range]
 
-/-- **Along an injective row-column pairing, row `i` meets the first `k` columns of the `u`-image in
-at most `min (μ.rowLen i) k` labels.** The bound by `μ.rowLen i` is the size of the row; the bound
-by `k` holds because injectivity makes the `u`-columns of row `i` distinct. -/
+/-- **Row `i` meets the first `k` columns of the `u`-image in at most `min (μ.rowLen i) k`
+labels**, when the row of a label together with the column of its `u`-image determines the label.
+Only injectivity of that pairing is used, so `u` need not be a permutation. -/
 private theorem card_filter_colIndex_comp_lt_and_rowIndex_eq_le (t : YoungTableau μ)
-    {u : Equiv.Perm (Fin μ.card)}
+    {u : Fin μ.card → Fin μ.card}
     (hu : Function.Injective fun x => (rowIndex t x, colIndex t (u x))) (i k : ℕ) :
     (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
       ≤ min (μ.rowLen i) k := by
@@ -229,9 +227,7 @@ private theorem card_filter_colIndex_comp_lt_and_rowIndex_eq_le (t : YoungTablea
       _ = k := Finset.card_range k
 
 /-- **Summed over the rows, the labels whose `u`-image lies in the first `k` columns number
-`∑ᵢ min (μ.rowLen i) k`.** Both sides count the same labels: `u` is a permutation, so it does not
-change how many labels land in the first `k` columns, and without `u` each row contributes exactly
-`min (μ.rowLen i) k` of them. No injectivity hypothesis is needed. -/
+`∑ᵢ min (μ.rowLen i) k`.** No injectivity hypothesis is needed. -/
 private theorem sum_card_filter_colIndex_comp_lt_and_rowIndex_eq (t : YoungTableau μ)
     (u : Equiv.Perm (Fin μ.card)) (k : ℕ) :
     ∑ i ∈ Finset.image (rowIndex t) Finset.univ,

--- a/TauCeti/Combinatorics/Young/Tableau.lean
+++ b/TauCeti/Combinatorics/Young/Tableau.lean
@@ -172,6 +172,91 @@ theorem card_filter_rowIndex_eq (t : YoungTableau μ) (i : ℕ) :
 
 /-! ## The counting lemma -/
 
+/-- **Row `i` meets the first `k` columns in exactly `min (μ.rowLen i) k` labels.** The labels of
+row `i` are indexed by their columns, which run over `Finset.range (μ.rowLen i)`, so those below `k`
+number `min (μ.rowLen i) k`. -/
+private theorem card_filter_colIndex_lt_and_rowIndex_eq (t : YoungTableau μ) (i k : ℕ) :
+    (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).card
+      = min (μ.rowLen i) k := by
+  have hinj : Set.InjOn (colIndex t)
+      ↑(Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i) := by
+    intro a ha b hb hab
+    simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at ha hb
+    exact rowIndex_colIndex_injective t (Prod.ext (ha.2.trans hb.2.symm) hab)
+  have himg : (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).image
+      (colIndex t) = (Finset.range (μ.rowLen i)).filter fun j => j < k := by
+    ext j
+    simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_range]
+    constructor
+    · rintro ⟨y, ⟨hy1, hy2⟩, rfl⟩
+      exact ⟨hy2 ▸ colIndex_lt_rowLen t y, hy1⟩
+    · rintro ⟨hj1, hj2⟩
+      obtain ⟨y, hy1, hy2⟩ :=
+        exists_rowIndex_colIndex t (YoungDiagram.mem_iff_lt_rowLen.mpr hj1)
+      exact ⟨y, ⟨hy2 ▸ hj2, hy1⟩, hy2⟩
+  have hrange : ((Finset.range (μ.rowLen i)).filter fun j => j < k)
+      = Finset.range (min (μ.rowLen i) k) := by
+    ext j
+    simp
+  rw [← Finset.card_image_of_injOn hinj, himg, hrange, Finset.card_range]
+
+/-- **Along an injective row-column pairing, row `i` meets the first `k` columns of the `u`-image in
+at most `min (μ.rowLen i) k` labels.** The bound by `μ.rowLen i` is the size of the row; the bound
+by `k` holds because injectivity makes the `u`-columns of row `i` distinct. -/
+private theorem card_filter_colIndex_comp_lt_and_rowIndex_eq_le (t : YoungTableau μ)
+    {u : Equiv.Perm (Fin μ.card)}
+    (hu : Function.Injective fun x => (rowIndex t x, colIndex t (u x))) (i k : ℕ) :
+    (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
+      ≤ min (μ.rowLen i) k := by
+  refine le_min ?_ ?_
+  · rw [← card_filter_rowIndex_eq t i]
+    refine Finset.card_le_card fun y hy => ?_
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy ⊢
+    exact hy.2
+  · have hinj : Set.InjOn (fun y => colIndex t (u y))
+        ↑(Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i) := by
+      intro a ha b hb hab
+      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at ha hb
+      exact hu (Prod.ext (ha.2.trans hb.2.symm) hab)
+    calc (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
+        = ((Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).image
+            fun y => colIndex t (u y)).card := (Finset.card_image_of_injOn hinj).symm
+      _ ≤ (Finset.range k).card := by
+            refine Finset.card_le_card fun j hj => ?_
+            simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and] at hj
+            obtain ⟨y, ⟨hy1, _⟩, rfl⟩ := hj
+            exact Finset.mem_range.mpr hy1
+      _ = k := Finset.card_range k
+
+/-- **Summed over the rows, the labels whose `u`-image lies in the first `k` columns number
+`∑ᵢ min (μ.rowLen i) k`.** Both sides count the same labels: `u` is a permutation, so it does not
+change how many labels land in the first `k` columns, and without `u` each row contributes exactly
+`min (μ.rowLen i) k` of them. No injectivity hypothesis is needed. -/
+private theorem sum_card_filter_colIndex_comp_lt_and_rowIndex_eq (t : YoungTableau μ)
+    (u : Equiv.Perm (Fin μ.card)) (k : ℕ) :
+    ∑ i ∈ Finset.image (rowIndex t) Finset.univ,
+        (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
+      = ∑ i ∈ Finset.image (rowIndex t) Finset.univ, min (μ.rowLen i) k := by
+  have hmemS : ∀ y : Fin μ.card, rowIndex t y ∈ Finset.image (rowIndex t) Finset.univ :=
+    fun y => Finset.mem_image_of_mem _ (Finset.mem_univ y)
+  have h1 : (Finset.univ.filter fun y => colIndex t (u y) < k).card
+      = ∑ i ∈ Finset.image (rowIndex t) Finset.univ,
+          (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card := by
+    rw [Finset.card_eq_sum_card_fiberwise (f := rowIndex t)
+      (t := Finset.image (rowIndex t) Finset.univ) fun y _ => hmemS y]
+    exact Finset.sum_congr rfl fun i _ => by rw [Finset.filter_filter]
+  have h2 : (Finset.univ.filter fun y => colIndex t y < k).card
+      = ∑ i ∈ Finset.image (rowIndex t) Finset.univ,
+          (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).card := by
+    rw [Finset.card_eq_sum_card_fiberwise (f := rowIndex t)
+      (t := Finset.image (rowIndex t) Finset.univ) fun y _ => hmemS y]
+    exact Finset.sum_congr rfl fun i _ => by rw [Finset.filter_filter]
+  have h3 : (Finset.univ.filter fun y => colIndex t (u y) < k).card
+      = (Finset.univ.filter fun y => colIndex t y < k).card :=
+    Finset.card_equiv u fun i => by simp
+  rw [← h1, h3, h2]
+  exact Finset.sum_congr rfl fun i _ => card_filter_colIndex_lt_and_rowIndex_eq t i k
+
 /-- **The counting lemma for rows and columns along a permutation.**  If the row of a label
 together with the column of its `u`-image determine the label, then that pair is again a cell of
 `μ`.
@@ -183,82 +268,13 @@ first `k` columns number `∑ᵢ min (μ.rowLen i) k`, while row `i` can contrib
 theorem colIndex_lt_rowLen_of_injective (t : YoungTableau μ) (u : Equiv.Perm (Fin μ.card))
     (hu : Function.Injective fun x => (rowIndex t x, colIndex t (u x))) (x : Fin μ.card) :
     colIndex t (u x) < μ.rowLen (rowIndex t x) := by
-  -- the rows of `μ` that actually carry labels
-  set S : Finset ℕ := Finset.image (rowIndex t) Finset.univ with hS
-  have hmemS : ∀ y : Fin μ.card, rowIndex t y ∈ S := fun y =>
-    Finset.mem_image_of_mem _ (Finset.mem_univ y)
-  -- row `i` contributes exactly `min (μ.rowLen i) k` labels to the first `k` columns
-  have hexact : ∀ i k : ℕ,
-      (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).card
-        = min (μ.rowLen i) k := by
-    intro i k
-    have hinj : Set.InjOn (colIndex t)
-        ↑(Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i) := by
-      intro a ha b hb hab
-      simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at ha hb
-      exact rowIndex_colIndex_injective t (Prod.ext (ha.2.trans hb.2.symm) hab)
-    have himg : (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).image
-        (colIndex t) = (Finset.range (μ.rowLen i)).filter fun j => j < k := by
-      ext j
-      simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_range]
-      constructor
-      · rintro ⟨y, ⟨hy1, hy2⟩, rfl⟩
-        exact ⟨hy2 ▸ colIndex_lt_rowLen t y, hy1⟩
-      · rintro ⟨hj1, hj2⟩
-        obtain ⟨y, hy1, hy2⟩ :=
-          exists_rowIndex_colIndex t (YoungDiagram.mem_iff_lt_rowLen.mpr hj1)
-        exact ⟨y, ⟨hy2 ▸ hj2, hy1⟩, hy2⟩
-    have hrange : ((Finset.range (μ.rowLen i)).filter fun j => j < k)
-        = Finset.range (min (μ.rowLen i) k) := by
-      ext j
-      simp
-    rw [← Finset.card_image_of_injOn hinj, himg, hrange, Finset.card_range]
-  -- row `i` contributes at most `min (μ.rowLen i) k` labels along `u`
-  have hle : ∀ i k : ℕ,
-      (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
-        ≤ min (μ.rowLen i) k := by
-    intro i k
-    refine le_min ?_ ?_
-    · rw [← card_filter_rowIndex_eq t i]
-      refine Finset.card_le_card fun y hy => ?_
-      simp only [Finset.mem_filter, Finset.mem_univ, true_and] at hy ⊢
-      exact hy.2
-    · have hinj : Set.InjOn (fun y => colIndex t (u y))
-          ↑(Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i) := by
-        intro a ha b hb hab
-        simp only [Finset.mem_coe, Finset.mem_filter, Finset.mem_univ, true_and] at ha hb
-        exact hu (Prod.ext (ha.2.trans hb.2.symm) hab)
-      calc (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
-          = ((Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).image
-              fun y => colIndex t (u y)).card := (Finset.card_image_of_injOn hinj).symm
-        _ ≤ (Finset.range k).card := by
-              refine Finset.card_le_card fun j hj => ?_
-              simp only [Finset.mem_image, Finset.mem_filter, Finset.mem_univ, true_and] at hj
-              obtain ⟨y, ⟨hy1, _⟩, rfl⟩ := hj
-              exact Finset.mem_range.mpr hy1
-        _ = k := Finset.card_range k
-  -- the two counts agree, so the upper bounds are equalities
-  have hsum : ∀ k : ℕ,
-      ∑ i ∈ S, (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card
-        = ∑ i ∈ S, min (μ.rowLen i) k := by
-    intro k
-    have h1 : (Finset.univ.filter fun y => colIndex t (u y) < k).card
-        = ∑ i ∈ S,
-            (Finset.univ.filter fun y => colIndex t (u y) < k ∧ rowIndex t y = i).card := by
-      rw [Finset.card_eq_sum_card_fiberwise (f := rowIndex t) (t := S) fun y _ => hmemS y]
-      exact Finset.sum_congr rfl fun i _ => by rw [Finset.filter_filter]
-    have h2 : (Finset.univ.filter fun y => colIndex t y < k).card
-        = ∑ i ∈ S, (Finset.univ.filter fun y => colIndex t y < k ∧ rowIndex t y = i).card := by
-      rw [Finset.card_eq_sum_card_fiberwise (f := rowIndex t) (t := S) fun y _ => hmemS y]
-      exact Finset.sum_congr rfl fun i _ => by rw [Finset.filter_filter]
-    have h3 : (Finset.univ.filter fun y => colIndex t (u y) < k).card
-        = (Finset.univ.filter fun y => colIndex t y < k).card :=
-      Finset.card_equiv u fun i => by simp
-    rw [← h1, h3, h2]
-    exact Finset.sum_congr rfl fun i _ => hexact i k
-  have hfull := fun k =>
-    (Finset.sum_eq_sum_iff_of_le fun i _ => hle i k).mp (hsum k) (rowIndex t x) (hmemS x)
-  have hi := hfull (μ.rowLen (rowIndex t x))
+  have hmemS : ∀ y : Fin μ.card, rowIndex t y ∈ Finset.image (rowIndex t) Finset.univ :=
+    fun y => Finset.mem_image_of_mem _ (Finset.mem_univ y)
+  -- The row-wise upper bounds add up to the total, so each is an equality.
+  have hi := (Finset.sum_eq_sum_iff_of_le fun i _ =>
+      card_filter_colIndex_comp_lt_and_rowIndex_eq_le t hu i (μ.rowLen (rowIndex t x))).mp
+    (sum_card_filter_colIndex_comp_lt_and_rowIndex_eq t u (μ.rowLen (rowIndex t x)))
+    (rowIndex t x) (hmemS x)
   rw [min_self] at hi
   -- a subset of the row with the same cardinality is the whole row
   have hsub : (Finset.univ.filter fun y =>


### PR DESCRIPTION
`colIndex_lt_rowLen_of_injective` (`Combinatorics/Young/Tableau.lean`) had a **93-line** body —
the largest uncontended proof in the library. Its three counting steps, already separate `have`s,
are now private lemmas stated above it.

Main proof: **93 → 24 lines**. Nothing in `Combinatorics/Young/` now exceeds 24.

| helper | proves |
|---|---|
| `card_filter_colIndex_lt_and_rowIndex_eq` | row `i` meets the first `k` columns in exactly `min (μ.rowLen i) k` labels |
| `card_filter_colIndex_comp_lt_and_rowIndex_eq_le` | row `i` meets the first `k` columns of the `u`-image in at most that many, when the row and `u`-column of a label determine it |
| `sum_card_filter_colIndex_comp_lt_and_rowIndex_eq` | summed over the rows, those counts total `∑ᵢ min (μ.rowLen i) k` |

The main proof is then exactly the argument its docstring already described: upper bounds that add
up to the total are equalities, and the case `k = μ.rowLen i` is the statement.

Splitting them makes two hypothesis boundaries visible that the monolithic proof hid.

- **Only the middle lemma uses injectivity.** The exact row count and the summed identity hold for
  any tableau and any permutation, so neither takes `hu`.
- **Only the summed identity uses bijectivity.** The middle lemma applies `u` purely as a
  function, so it takes `{u : Fin μ.card → Fin μ.card}`; `Equiv.Perm` survives just where the
  counting argument actually transports along the permutation.

The three are private, matching their single consumer, and sit alongside the file's existing
`rowIndex`/`colIndex` helper layer.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean, against the current mathlib pin.

Roadmap: RepresentationTheory