### PR TITLE
feat(ModularForms): the ceiling contour integral evaluates to the cusp order

### DIFF
--- a/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
+++ b/TauCeti/NumberTheory/ModularForms/LevelOne/FundamentalDomainBoundary/CeilingBridge.lean
@@ -25,6 +25,8 @@ derivative.
 
 * `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunction`
   (the ceiling bridge).
+* `TauCeti.ModularForm.intervalIntegral_fdBoundary_segment5_eq_qExpansionOrderAtCusp`:
+  the evaluated form — the ceiling contributes `2πi` times the cusp order.
 
 ## References
 
@@ -120,6 +122,24 @@ theorem intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunc
   refine intervalIntegral.integral_congr_Ioo_of_le (by norm_num) fun t ht ↦ ?_
   rw [hLc, hcusp, hR]
   exact ceiling_integrand_eq hper ht.1
+
+
+/-- **The ceiling contour integral evaluates to the cusp order**: for a width-`1`
+periodic function whose cusp function is analytic on the closed `q`-disc and vanishes
+there at most at the origin, the ceiling contour integral of the logarithmic derivative
+is `2πi` times the `q`-expansion order at the cusp. -/
+theorem intervalIntegral_fdBoundary_segment5_eq_qExpansionOrderAtCusp
+    {g : UpperHalfPlane → ℂ} {H : ℝ}
+    (hper : Function.Periodic (g ∘ UpperHalfPlane.ofComplex) 1)
+    (hga : ∀ q ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H),
+      AnalyticAt ℂ (UpperHalfPlane.cuspFunction 1 g) q)
+    (hgz : ∀ q ∈ Metric.closedBall (0 : ℂ) (fdBoundaryQRadius H), q ≠ 0 →
+      UpperHalfPlane.cuspFunction 1 g q ≠ 0) :
+    ∫ t in (4 : ℝ)..5,
+        deriv (fdBoundary H) t • logDeriv (g ∘ UpperHalfPlane.ofComplex) (fdBoundary H t) =
+      2 * Real.pi * Complex.I * qExpansionOrderAtCusp 1 g :=
+  (intervalIntegral_fdBoundary_segment5_eq_circleIntegral_logDeriv_cuspFunction hper).trans
+    (circleIntegral_logDeriv_cuspFunction hga hgz)
 
 end ModularForm
 


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

Composing the ceiling bridge (#2149) with the `q`-circle evaluation (#2144):

- `intervalIntegral_fdBoundary_segment5_eq_qExpansionOrderAtCusp (hper) (hga) (hgz) :
  ∫ t in 4..5, deriv (fdBoundary H) t • logDeriv (g ∘ ofComplex) (fdBoundary H t) =
  2πi * qExpansionOrderAtCusp 1 g`

— a one-step `.trans` corollary giving the ceiling's evaluated contribution: `2πi` times
the cusp order, under periodicity plus the analyticity/nonvanishing of the cusp function
on the closed `q`-disc.

Roadmap: this advances the **ModularForms** roadmap's Layer 1 (the valence formula,
`TauCetiRoadmap/ModularForms/README.md` § "Layer 1: the valence formula"): the localized
`ord_∞` term in the form the boundary assembly consumes, so the assembly can sum the four
boundary pieces without seeing the intermediate `q`-circle.

Roadmap: ModularForms
