### PR TITLE
feat: construct the tangent-space adjoint action

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -49,7 +49,7 @@ local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :
 @[expose]
 def adjointContinuousLinearMap (g : G) :
     GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
-  mfderiv I I (conjugationDiffeomorph (I := I) g) 1
+  mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) 1
 
 @[simp]
 theorem adjointContinuousLinearMap_one :
@@ -68,128 +68,130 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
   unfold adjointContinuousLinearMap
   change @Eq (E →L[ℝ] E) _ _
   have hfun :
-      conjugationDiffeomorph (I := I) (g * h) =
-        (conjugationDiffeomorph (I := I) g) ∘
-          (conjugationDiffeomorph (I := I) h) := by
+      conjugationDiffeomorph (I := I) (n := ∞) (g * h) =
+        (conjugationDiffeomorph (I := I) (n := ∞) g) ∘
+          (conjugationDiffeomorph (I := I) (n := ∞) h) := by
     funext x
     simp only [conjugationDiffeomorph_apply, Function.comp_apply]
     group
   rw [mfderiv_congr (I := I) (I' := I) hfun]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _)
-    (((conjugationDiffeomorph (I := I) h).mdifferentiable (by simp)) _)]
+    (((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
+    (((conjugationDiffeomorph (I := I) (n := ∞) h).mdifferentiable (by simp)) _)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) g)
-    (x := conjugationDiffeomorph (I := I) h 1) (x' := 1)
-    (conjugationDiffeomorph_one (I := I) h)]
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
+    (x := conjugationDiffeomorph (I := I) (n := ∞) h 1) (x' := 1)
+    (by simp)]
   with_unfolding_all rfl
 
 theorem inverse_mfderiv_conjugation (g x : G) :
-    (mfderiv I I (conjugationDiffeomorph (I := I) g) x).inverse =
-      mfderiv I I (conjugationDiffeomorph (I := I) g⁻¹)
-        (conjugationDiffeomorph (I := I) g x) := by
-  have hdiff (a : G) : MDifferentiableAt I I (conjugationDiffeomorph (I := I) a) x :=
-    ((conjugationDiffeomorph (I := I) a).mdifferentiable (by simp)) x
+    (mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) x).inverse =
+      mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
+        (conjugationDiffeomorph (I := I) (n := ∞) g x) := by
+  have hdiff (a : G) : MDifferentiableAt I I (conjugationDiffeomorph (I := I) (n := ∞) a) x :=
+    ((conjugationDiffeomorph (I := I) (n := ∞) a).mdifferentiable (by simp)) x
   have A : mfderiv I I
-      ((conjugationDiffeomorph (I := I) g⁻¹) ∘
-        (conjugationDiffeomorph (I := I) g)) x =
+      ((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
+        (conjugationDiffeomorph (I := I) (n := ∞) g)) x =
         ContinuousLinearMap.id ℝ (TangentSpace I x) := by
     have h :
-        (conjugationDiffeomorph (I := I) g⁻¹) ∘
-          (conjugationDiffeomorph (I := I) g) = id := by
+        (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
+          (conjugationDiffeomorph (I := I) (n := ∞) g) = id := by
       funext y
       simp [Function.comp_apply, mul_assoc]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) g⁻¹).mdifferentiable (by simp)) _)
+    (((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)
     (hdiff g)] at A
   have A' : mfderiv I I
-      ((conjugationDiffeomorph (I := I) g) ∘
-        (conjugationDiffeomorph (I := I) g⁻¹))
-        (conjugationDiffeomorph (I := I) g x) =
-        ContinuousLinearMap.id ℝ (TangentSpace I (conjugationDiffeomorph (I := I) g x)) := by
+      ((conjugationDiffeomorph (I := I) (n := ∞) g) ∘
+        (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹))
+        (conjugationDiffeomorph (I := I) (n := ∞) g x) =
+        ContinuousLinearMap.id ℝ
+          (TangentSpace I (conjugationDiffeomorph (I := I) (n := ∞) g x)) := by
     have h :
-        (conjugationDiffeomorph (I := I) g) ∘
-          (conjugationDiffeomorph (I := I) g⁻¹) = id := by
+        (conjugationDiffeomorph (I := I) (n := ∞) g) ∘
+          (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) = id := by
       funext y
       simp [Function.comp_apply, mul_assoc]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _)
-    (((conjugationDiffeomorph (I := I) g⁻¹).mdifferentiable (by simp)) _)] at A'
+    (((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
+    (((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)] at A'
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) g)
-    (x := conjugationDiffeomorph (I := I) g⁻¹ (conjugationDiffeomorph (I := I) g x))
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
+    (x := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹
+      (conjugationDiffeomorph (I := I) (n := ∞) g x))
     (x' := x) (by simp only [conjugationDiffeomorph_apply]; group)] at A'
   exact ContinuousLinearMap.inverse_eq A' A
 
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
-    mfderiv I I (conjugationDiffeomorph (I := I) g) x
+    mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) x
         (mulInvariantVectorField X x) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
-        (conjugationDiffeomorph (I := I) g x) := by
+        (conjugationDiffeomorph (I := I) (n := ∞) g x) := by
   simp only [mulInvariantVectorField]
   have hfun :
-      (conjugationDiffeomorph (I := I) g) ∘ (fun y : G ↦ x * y) =
-        (fun y : G ↦ conjugationDiffeomorph (I := I) g x * y) ∘
-          (conjugationDiffeomorph (I := I) g) := by
+      (conjugationDiffeomorph (I := I) (n := ∞) g) ∘ (fun y : G ↦ x * y) =
+        (fun y : G ↦ conjugationDiffeomorph (I := I) (n := ∞) g x * y) ∘
+          (conjugationDiffeomorph (I := I) (n := ∞) g) := by
     funext y
     simp [Function.comp_apply, mul_assoc]
   have h := congrArg (fun f : G → G ↦ mfderiv I I f 1 X) hfun
   rw [mfderiv_comp_apply (I := I) (I' := I) (I'' := I),
     mfderiv_comp_apply (I := I) (I' := I) (I'' := I)] at h
-  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjugationDiffeomorph (I := I) g)
+  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjugationDiffeomorph (I := I) (n := ∞) g)
       (x := x * 1) (x' := x) (by simp)] at h
     rw [mfderiv_congr_point (I := I) (I' := I)
-      (f := fun y : G ↦ conjugationDiffeomorph (I := I) g x * y)
-      (x := conjugationDiffeomorph (I := I) g 1) (x' := 1)
-      (conjugationDiffeomorph_one (I := I) g)] at h
+      (f := fun y : G ↦ conjugationDiffeomorph (I := I) (n := ∞) g x * y)
+      (x := conjugationDiffeomorph (I := I) (n := ∞) g 1) (x' := 1)
+      (by simp)] at h
     change @Eq E _ _
     exact h
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
-  · exact ((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _
-  · exact ((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _
+  · exact ((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
+  · exact ((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
 
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
-    VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹)
+    VectorField.mpullback I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
         (mulInvariantVectorField X) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
   funext x
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) g⁻¹⁻¹)
-    (f' := conjugationDiffeomorph (I := I) g) (by simp)]
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
+    (f' := conjugationDiffeomorph (I := I) (n := ∞) g) (by simp)]
   have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
-    (conjugationDiffeomorph (I := I) g⁻¹ x) X
+    (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ x) X
   change @Eq E _ _
   change @Eq E _ _ at hpush
-  have hpoint : conjugationDiffeomorph (I := I) g
-      (conjugationDiffeomorph (I := I) g⁻¹ x) = x := by
+  have hpoint : conjugationDiffeomorph (I := I) (n := ∞) g
+      (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ x) = x := by
     simp only [conjugationDiffeomorph_apply]
     group
   rw [hpoint] at hpush
   exact hpush
 
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
-    VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹) V 1 =
+    VectorField.mpullback I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) g⁻¹⁻¹)
-    (f' := conjugationDiffeomorph (I := I) g) (by simp)]
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
+    (f' := conjugationDiffeomorph (I := I) (n := ∞) g) (by simp)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) g)
-    (x := conjugationDiffeomorph (I := I) g⁻¹ 1) (x' := 1)
-    (conjugationDiffeomorph_one (I := I) g⁻¹)]
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
+    (x := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ 1) (x' := 1)
+    (by simp)]
   change @Eq E _ _
   rw [adjointContinuousLinearMap]
   congr 1
-  exact congrArg (fun y : G ↦ (V y : E)) (conjugationDiffeomorph_one (I := I) g⁻¹)
+  exact congrArg (fun y : G ↦ (V y : E)) (by simp)
 
 theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
     (X Y : GroupLieAlgebra I G) :
@@ -198,11 +200,11 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
         adjointContinuousLinearMap (I := I) g Y⁆ := by
   have h := VectorField.mpullback_mlieBracket
     (I := I) (I' := I) (n := ∞)
-    (f := conjugationDiffeomorph (I := I) g⁻¹)
+    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
     (V := mulInvariantVectorField X) (W := mulInvariantVectorField Y) (x₀ := (1 : G))
     (mdifferentiableAt_mulInvariantVectorField X)
     (mdifferentiableAt_mulInvariantVectorField Y)
-    (conjugationDiffeomorph (I := I) g⁻¹).contMDiffAt
+    (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).contMDiffAt
       (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   rw [mpullback_conjugation_mulInvariantVectorField,
     mpullback_conjugation_mulInvariantVectorField] at h

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -131,6 +131,8 @@ private theorem conjDiffeomorph_inv (g : G) :
   have h := map_inv (conj (I := I) (n := 1)) g
   simpa only [conj_apply, TauCeti.Diffeomorph.inv_def] using h
 
+/-- The inverse of the derivative of conjugation by `g` is the derivative of conjugation by
+`g⁻¹` at the conjugated point. -/
 theorem inverse_mfderiv_conjugation (g x : G) :
     (mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) x).inverse =
       mfderiv I I (conjDiffeomorph (I := I) (n := 1) g⁻¹)
@@ -150,6 +152,8 @@ theorem inverse_mfderiv_conjugation (g x : G) :
   change mfderiv I I hΦ.localInverse (Φ x) = mfderiv I I Φ.symm (Φ x)
   exact Filter.EventuallyEq.mfderiv_eq (I := I) (I' := I) heq
 
+/-- The derivative of conjugation by `g` transports a left-invariant vector field to the field
+whose value at the identity is the adjoint image. -/
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
     mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) x
@@ -196,6 +200,8 @@ theorem mpullback_conjugation (g x : G) (V : ∀ y : G, TangentSpace I y) :
     (f' := conjDiffeomorph (I := I) (n := 1) g) (by simp)]
   rfl
 
+/-- Pullback by conjugation by `g⁻¹` sends the left-invariant field of `X` to the
+left-invariant field of the adjoint image of `X`. -/
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
     VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 1) g⁻¹)
@@ -212,6 +218,7 @@ theorem mpullback_conjugation_mulInvariantVectorField (g : G)
   rw [hpoint] at hpush
   exact hpush
 
+/-- At the identity, pullback by conjugation by `g⁻¹` is the adjoint differential of `g`. -/
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
     VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 1) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
@@ -297,6 +304,7 @@ theorem tangentAd_mul [CompleteSpace E] (g h : G) :
     (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
     (adjointContinuousLinearMap_mul (I := I) g h)
 
+/-- The tangent adjoint automorphism of `g⁻¹` is the inverse of that of `g`. -/
 @[simp]
 theorem tangentAd_inv [CompleteSpace E] (g : G) :
     tangentAd (I := I) g⁻¹ = (tangentAd (I := I) g).symm := by

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -22,12 +22,12 @@ This advances Deliverable A, Layer 1 of
 ## Main definitions
 
 * `TauCeti.Lie.adjointContinuousLinearMap`: the differential of conjugation at the identity.
-* `TauCeti.Lie.Ad`: the resulting Lie algebra automorphism.
+* `TauCeti.Lie.tangentAd`: the resulting tangent Lie algebra automorphism.
 
 ## Main results
 
 * `TauCeti.Lie.adjointContinuousLinearMap_lie`: the differential preserves the Lie bracket.
-* `TauCeti.Lie.Ad_mul`: the adjoint automorphism respects group multiplication.
+* `TauCeti.Lie.tangentAd_mul`: the tangent adjoint automorphism respects group multiplication.
 -/
 
 public section
@@ -223,7 +223,7 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
 
 /-- The group adjoint automorphism: the differential at the identity of conjugation by `g`. -/
 @[expose]
-def Ad [CompleteSpace E] (g : G) :
+def tangentAd [CompleteSpace E] (g : G) :
     GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G where
   toFun := adjointContinuousLinearMap (I := I) g
   invFun := adjointContinuousLinearMap (I := I) g⁻¹
@@ -242,26 +242,27 @@ def Ad [CompleteSpace E] (g : G) :
     exact adjointContinuousLinearMap_lie (I := I) g X Y
 
 @[simp]
-theorem Ad_apply [CompleteSpace E] (g : G) (X : GroupLieAlgebra I G) :
-    Ad (I := I) g X = adjointContinuousLinearMap (I := I) g X :=
+theorem tangentAd_apply [CompleteSpace E] (g : G) (X : GroupLieAlgebra I G) :
+    tangentAd (I := I) g X = adjointContinuousLinearMap (I := I) g X :=
   rfl
 
 @[simp]
-theorem Ad_one [CompleteSpace E] :
-    Ad (I := I) (1 : G) = LieEquiv.refl := by
+theorem tangentAd_one [CompleteSpace E] :
+    tangentAd (I := I) (1 : G) = LieEquiv.refl := by
   ext X
-  simp [Ad_apply]
+  simp [tangentAd_apply]
 
-theorem Ad_mul [CompleteSpace E] (g h : G) :
-    Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
+theorem tangentAd_mul [CompleteSpace E] (g h : G) :
+    tangentAd (I := I) (g * h) =
+      (tangentAd (I := I) h).trans (tangentAd (I := I) g) := by
   ext X
-  simpa [Ad_apply] using congrArg
+  simpa [tangentAd_apply] using congrArg
     (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
     (adjointContinuousLinearMap_mul (I := I) g h)
 
 @[simp]
-theorem Ad_inv [CompleteSpace E] (g : G) :
-    Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
+theorem tangentAd_inv [CompleteSpace E] (g : G) :
+    tangentAd (I := I) g⁻¹ = (tangentAd (I := I) g).symm := by
   ext X
   rfl
 

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -11,7 +11,23 @@ public import TauCeti.Geometry.Lie.Adjoint.Conjugation
 /-!
 # The adjoint action of a Lie group
 
-The group adjoint action is the differential at the identity of conjugation.
+The group adjoint action is the differential at the identity of conjugation.  We first prove that
+this differential transports left-invariant vector fields.  Naturality of the manifold Lie
+bracket then shows that it is a Lie algebra automorphism, and the composition law for conjugation
+gives the representation law.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main definitions
+
+* `TauCeti.Lie.adjointContinuousLinearMap`: the differential of conjugation at the identity.
+* `TauCeti.Lie.Ad`: the resulting Lie algebra automorphism.
+
+## Main results
+
+* `TauCeti.Lie.adjointContinuousLinearMap_lie`: the differential preserves the Lie bracket.
+* `TauCeti.Lie.Ad_mul`: the adjoint automorphism respects group multiplication.
 -/
 
 public section

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import Mathlib.Geometry.Manifold.LocalDiffeomorph
 public import TauCeti.Geometry.Lie.Basic
 public import TauCeti.Geometry.Lie.Adjoint.Conjugation
 
@@ -50,195 +51,190 @@ open scoped Manifold ContDiff
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [LieGroup I ∞ G]
+  [LieGroup I 3 G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
+
+/-- The continuous linear equivalence given by the differential of conjugation at the identity. -/
+def adjointContinuousLinearEquiv (g : G) :
+    GroupLieAlgebra I G ≃L[ℝ] GroupLieAlgebra I G :=
+  (conjDiffeomorph (I := I) (n := 3) g).mfderivToContinuousLinearEquiv (by simp) 1
+
+@[simp]
+theorem adjointContinuousLinearEquiv_coe (g : G) :
+    (adjointContinuousLinearEquiv (I := I) g :
+      GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G) =
+        mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) 1 := by
+  exact Diffeomorph.mfderivToContinuousLinearEquiv_coe _ _
 
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
 def adjointContinuousLinearMap (g : G) :
     GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
-  mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) 1
+  adjointContinuousLinearEquiv (I := I) g
 
 @[simp]
 theorem adjointContinuousLinearMap_apply (g : G) (X : GroupLieAlgebra I G) :
     adjointContinuousLinearMap (I := I) g X =
-      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) 1 X :=
-  (rfl)
+      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) 1 X := by
+  congr 1
+  exact adjointContinuousLinearEquiv_coe (I := I) g
 
 @[simp]
 theorem adjointContinuousLinearMap_one :
     adjointContinuousLinearMap (I := I) (1 : G) =
       ContinuousLinearMap.id ℝ (GroupLieAlgebra I G) := by
+  rw [adjointContinuousLinearMap]
+  rw [adjointContinuousLinearEquiv_coe]
+  -- `GroupLieAlgebra I G` is the tangent model space `E`; expose it for `mfderiv_id`.
   change @Eq (E →L[ℝ] E) _ _
   rw [← mfderiv_id]
   apply mfderiv_congr
   have h := congrArg
-    (fun f : TauCeti.Diff I G ∞ ↦ (f : G → G))
-    (map_one (conj (I := I) (n := ∞)))
+    (fun f : TauCeti.Diff I G 3 ↦ (f : G → G))
+    (map_one (conj (I := I) (n := 3)))
   simpa only [conj_apply, TauCeti.Diffeomorph.coe_one] using h
 
+@[simp]
 theorem adjointContinuousLinearMap_mul (g h : G) :
     adjointContinuousLinearMap (I := I) (g * h) =
       (adjointContinuousLinearMap (I := I) g).comp
         (adjointContinuousLinearMap (I := I) h) := by
-  unfold adjointContinuousLinearMap
+  simp only [adjointContinuousLinearMap, adjointContinuousLinearEquiv_coe]
+  -- The tangent fibers in this model-with-corners presentation share the model space `E`.
   change @Eq (E →L[ℝ] E) _ _
   have hfun :
-      conjDiffeomorph (I := I) (n := ∞) (g * h) =
-        (conjDiffeomorph (I := I) (n := ∞) g) ∘
-          (conjDiffeomorph (I := I) (n := ∞) h) := by
+      conjDiffeomorph (I := I) (n := 3) (g * h) =
+        (conjDiffeomorph (I := I) (n := 3) g) ∘
+          (conjDiffeomorph (I := I) (n := 3) h) := by
     have hmap := congrArg
-      (fun f : TauCeti.Diff I G ∞ ↦ (f : G → G))
-      (map_mul (conj (I := I) (n := ∞)) g h)
+      (fun f : TauCeti.Diff I G 3 ↦ (f : G → G))
+      (map_mul (conj (I := I) (n := 3)) g h)
     simpa only [conj_apply, TauCeti.Diffeomorph.coe_mul] using hmap
   rw [mfderiv_congr (I := I) (I' := I) hfun]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
-    (((conjDiffeomorph (I := I) (n := ∞) h).mdifferentiable (by simp)) _)]
+    (((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _)
+    (((conjDiffeomorph (I := I) (n := 3) h).mdifferentiable (by simp)) _)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g)
-    (x := conjDiffeomorph (I := I) (n := ∞) h 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := 3) g)
+    (x := conjDiffeomorph (I := I) (n := 3) h 1) (x' := 1)
     (by simp)]
-  with_unfolding_all rfl
+  rfl
 
 @[simp]
 private theorem conjDiffeomorph_inv (g : G) :
-    conjDiffeomorph (I := I) (n := ∞) g⁻¹ =
-      (conjDiffeomorph (I := I) (n := ∞) g).symm := by
-  have h := map_inv (conj (I := I) (n := ∞)) g
+    conjDiffeomorph (I := I) (n := 3) g⁻¹ =
+      (conjDiffeomorph (I := I) (n := 3) g).symm := by
+  have h := map_inv (conj (I := I) (n := 3)) g
   simpa only [conj_apply, TauCeti.Diffeomorph.inv_def] using h
 
 theorem inverse_mfderiv_conjugation (g x : G) :
-    (mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) x).inverse =
-      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹)
-        (conjDiffeomorph (I := I) (n := ∞) g x) := by
-  have hdiff (a : G) : MDifferentiableAt I I (conjDiffeomorph (I := I) (n := ∞) a) x :=
-    ((conjDiffeomorph (I := I) (n := ∞) a).mdifferentiable (by simp)) x
-  have A : mfderiv I I
-      ((conjDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
-        (conjDiffeomorph (I := I) (n := ∞) g)) x =
-        ContinuousLinearMap.id ℝ (TangentSpace I x) := by
-    have h :
-        (conjDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
-          (conjDiffeomorph (I := I) (n := ∞) g) = id := by
-      funext y
-      simp only [Function.comp_apply, conjDiffeomorph_inv, id_eq,
-        Diffeomorph.symm_apply_apply]
-    rw [h, mfderiv_id]
-  rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)
-    (hdiff g)] at A
-  have A' : mfderiv I I
-      ((conjDiffeomorph (I := I) (n := ∞) g) ∘
-        (conjDiffeomorph (I := I) (n := ∞) g⁻¹))
-        (conjDiffeomorph (I := I) (n := ∞) g x) =
-        ContinuousLinearMap.id ℝ
-          (TangentSpace I (conjDiffeomorph (I := I) (n := ∞) g x)) := by
-    have h :
-        (conjDiffeomorph (I := I) (n := ∞) g) ∘
-          (conjDiffeomorph (I := I) (n := ∞) g⁻¹) = id := by
-      funext y
-      simp only [Function.comp_apply, conjDiffeomorph_inv, id_eq,
-        Diffeomorph.apply_symm_apply]
-    rw [h, mfderiv_id]
-  rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
-    (((conjDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)] at A'
-  rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g)
-    (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹
-      (conjDiffeomorph (I := I) (n := ∞) g x))
-    (x' := x) (by
-      rw [conjDiffeomorph_inv]
-      exact (conjDiffeomorph (I := I) (n := ∞) g).symm_apply_apply x)] at A'
-  exact ContinuousLinearMap.inverse_eq A' A
+    (mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) x).inverse =
+      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g⁻¹)
+        (conjDiffeomorph (I := I) (n := 3) g x) := by
+  rw [conjDiffeomorph_inv]
+  let Φ := conjDiffeomorph (I := I) (n := 3) g
+  let hΦ := Φ.isLocalDiffeomorph x
+  change (mfderiv I I Φ x).inverse = mfderiv I I Φ.symm (Φ x)
+  rw [← hΦ.mfderivToContinuousLinearEquiv_coe (by simp)]
+  rw [ContinuousLinearMap.inverse_equiv]
+  have heq : hΦ.localInverse =ᶠ[nhds (Φ x)] ⇑Φ.symm := by
+    filter_upwards [hΦ.localInverse_eventuallyEq_right] with y hy
+    apply Φ.injective
+    simpa using hy
+  -- The inverse field of Mathlib's packaged differential equivalence is the chosen local inverse.
+  change mfderiv I I hΦ.localInverse (Φ x) = mfderiv I I Φ.symm (Φ x)
+  exact Filter.EventuallyEq.mfderiv_eq (I := I) (I' := I) heq
 
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
-    mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) x
+    mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) x
         (mulInvariantVectorField X x) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
-        (conjDiffeomorph (I := I) (n := ∞) g x) := by
+        (conjDiffeomorph (I := I) (n := 3) g x) := by
   simp only [mulInvariantVectorField]
+  have hreg : minSmoothness ℝ 3 ≠ 0 :=
+    (lt_of_lt_of_le (by simp) le_minSmoothness).ne'
   have hfun :
-      (conjDiffeomorph (I := I) (n := ∞) g) ∘ (fun y : G ↦ x * y) =
-        (fun y : G ↦ conjDiffeomorph (I := I) (n := ∞) g x * y) ∘
-          (conjDiffeomorph (I := I) (n := ∞) g) := by
+      (conjDiffeomorph (I := I) (n := 3) g) ∘ (fun y : G ↦ x * y) =
+        (fun y : G ↦ conjDiffeomorph (I := I) (n := 3) g x * y) ∘
+          (conjDiffeomorph (I := I) (n := 3) g) := by
     funext y
     simp [Function.comp_apply, mul_assoc]
   have h := congrArg (fun f : G → G ↦ mfderiv I I f 1 X) hfun
   rw [mfderiv_comp_apply (I := I) (I' := I) (I'' := I),
     mfderiv_comp_apply (I := I) (I' := I) (I'' := I)] at h
-  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjDiffeomorph (I := I) (n := ∞) g)
+  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjDiffeomorph (I := I) (n := 3) g)
       (x := x * 1) (x' := x) (by simp)] at h
     rw [mfderiv_congr_point (I := I) (I' := I)
-      (f := fun y : G ↦ conjDiffeomorph (I := I) (n := ∞) g x * y)
-      (x := conjDiffeomorph (I := I) (n := ∞) g 1) (x' := 1)
+      (f := fun y : G ↦ conjDiffeomorph (I := I) (n := 3) g x * y)
+      (x := conjDiffeomorph (I := I) (n := 3) g 1) (x' := 1)
       (by simp)] at h
+    -- For this model-with-corners presentation, each tangent fiber is implemented by `E`.
     change @Eq E _ _
+    rw [adjointContinuousLinearMap_apply]
     exact h
-  · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
-  · exact ((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
-  · exact ((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
-  · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
+  · exact contMDiffAt_mul_left.mdifferentiableAt hreg
+  · exact ((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _
+  · exact ((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _
+  · exact contMDiffAt_mul_left.mdifferentiableAt hreg
 
 /-- Pullback through inverse conjugation is the derivative of forward conjugation. -/
 theorem mpullback_conjugation (g x : G) (V : ∀ y : G, TangentSpace I y) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹) V x =
-      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g)
-        (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x)
-        (V (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x)) := by
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹) V x =
+      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g)
+        (conjDiffeomorph (I := I) (n := 3) g⁻¹ x)
+        (V (conjDiffeomorph (I := I) (n := 3) g⁻¹ x)) := by
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
-    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
-  with_unfolding_all rfl
+    (f := conjDiffeomorph (I := I) (n := 3) g⁻¹⁻¹)
+    (f' := conjDiffeomorph (I := I) (n := 3) g) (by simp)]
+  rfl
 
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹)
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹)
         (mulInvariantVectorField X) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
   funext x
   rw [mpullback_conjugation]
   have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
-    (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) X
-  change @Eq E _ _
-  change @Eq E _ _ at hpush
-  have hpoint : conjDiffeomorph (I := I) (n := ∞) g
-      (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) = x := by
+    (conjDiffeomorph (I := I) (n := 3) g⁻¹ x) X
+  have hpoint : conjDiffeomorph (I := I) (n := 3) g
+      (conjDiffeomorph (I := I) (n := 3) g⁻¹ x) = x := by
     rw [conjDiffeomorph_inv]
-    exact (conjDiffeomorph (I := I) (n := ∞) g).apply_symm_apply x
+    exact (conjDiffeomorph (I := I) (n := 3) g).apply_symm_apply x
   rw [hpoint] at hpush
   exact hpush
 
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹) V 1 =
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
   rw [mpullback_conjugation]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g)
-    (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹ 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := 3) g)
+    (x := conjDiffeomorph (I := I) (n := 3) g⁻¹ 1) (x' := 1)
     (by simp)]
-  change @Eq E _ _
-  rw [adjointContinuousLinearMap]
-  congr 1
-  exact congrArg (fun y : G ↦ (V y : E)) (by simp)
+  rw [adjointContinuousLinearMap_apply]
+  have hpoint : conjDiffeomorph (I := I) (n := 3) g⁻¹ 1 = 1 := by
+    simp only [conjDiffeomorph_apply, mul_one, inv_inv, inv_mul_cancel]
+  exact congrArg (fun y : G ↦ mfderiv I I
+    (conjDiffeomorph (I := I) (n := 3) g) 1 (V y)) hpoint
 
+/-- The differential of conjugation preserves the manifold Lie bracket. -/
 theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
     (X Y : GroupLieAlgebra I G) :
     adjointContinuousLinearMap (I := I) g ⁅X, Y⁆ =
       ⁅adjointContinuousLinearMap (I := I) g X,
         adjointContinuousLinearMap (I := I) g Y⁆ := by
   have h := VectorField.mpullback_mlieBracket
-    (I := I) (I' := I) (n := ∞)
-    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹)
+    (I := I) (I' := I) (n := 3)
+    (f := conjDiffeomorph (I := I) (n := 3) g⁻¹)
     (V := mulInvariantVectorField X) (W := mulInvariantVectorField Y) (x₀ := (1 : G))
     (mdifferentiableAt_mulInvariantVectorField X)
     (mdifferentiableAt_mulInvariantVectorField Y)
-    (conjDiffeomorph (I := I) (n := ∞) g⁻¹).contMDiffAt
-      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
+    (conjDiffeomorph (I := I) (n := 3) g⁻¹).contMDiffAt
+      (by norm_num)
   rw [mpullback_conjugation_mulInvariantVectorField,
     mpullback_conjugation_mulInvariantVectorField] at h
   rw [mpullback_conjugation_one] at h
@@ -247,18 +243,12 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
 /-- The group adjoint automorphism: the differential at the identity of conjugation by `g`. -/
 def tangentAd [CompleteSpace E] (g : G) :
     GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G where
-  toFun := adjointContinuousLinearMap (I := I) g
-  invFun := adjointContinuousLinearMap (I := I) g⁻¹
-  left_inv X := by
-    have h := congrArg (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
-      (adjointContinuousLinearMap_mul (I := I) g⁻¹ g)
-    simpa using h.symm
-  right_inv X := by
-    have h := congrArg (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
-      (adjointContinuousLinearMap_mul (I := I) g g⁻¹)
-    simpa using h.symm
-  map_add' := map_add _
-  map_smul' := map_smul _
+  toFun := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv
+  invFun := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv.symm
+  left_inv := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv.left_inv
+  right_inv := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv.right_inv
+  map_add' := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv.map_add
+  map_smul' := (adjointContinuousLinearEquiv (I := I) g).toLinearEquiv.map_smul
   map_lie' := by
     intro X Y
     exact adjointContinuousLinearMap_lie (I := I) g X Y
@@ -274,6 +264,8 @@ theorem tangentAd_one [CompleteSpace E] :
   ext X
   simp [tangentAd_apply]
 
+/-- The tangent adjoint action sends a product to the composite of the two adjoint maps. -/
+@[simp]
 theorem tangentAd_mul [CompleteSpace E] (g h : G) :
     tangentAd (I := I) (g * h) =
       (tangentAd (I := I) h).trans (tangentAd (I := I) g) := by
@@ -287,6 +279,13 @@ theorem tangentAd_mul [CompleteSpace E] (g h : G) :
 theorem tangentAd_inv [CompleteSpace E] (g : G) :
     tangentAd (I := I) g⁻¹ = (tangentAd (I := I) g).symm := by
   ext X
-  rfl
+  apply (tangentAd (I := I) g).injective
+  change tangentAd (I := I) g (tangentAd (I := I) g⁻¹ X) =
+    tangentAd (I := I) g ((tangentAd (I := I) g).symm X)
+  rw [LieEquiv.apply_symm_apply]
+  have h := congrArg
+    (fun e : GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G ↦ e X)
+    (tangentAd_mul (I := I) g g⁻¹)
+  simpa using h.symm
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -63,7 +63,6 @@ def adjointContinuousLinearMap (g : G) :
     GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
   mfderiv I I (conjugationDiffeomorph (I := I) g) 1
 
-set_option backward.isDefEq.respectTransparency false in
 @[simp]
 theorem adjointContinuousLinearMap_one :
     adjointContinuousLinearMap (I := I) (1 : G) =
@@ -74,7 +73,6 @@ theorem adjointContinuousLinearMap_one :
   funext x
   simp
 
-set_option backward.isDefEq.respectTransparency false in
 theorem adjointContinuousLinearMap_mul (g h : G) :
     adjointContinuousLinearMap (I := I) (g * h) =
       (adjointContinuousLinearMap (I := I) g).comp
@@ -96,8 +94,8 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
     (f := conjugationDiffeomorph (I := I) g)
     (x := conjugationDiffeomorph (I := I) h 1) (x' := 1)
     (conjugationDiffeomorph_one (I := I) h)]
+  with_unfolding_all rfl
 
-set_option backward.isDefEq.respectTransparency false in
 theorem inverse_mfderiv_conjugation (g x : G) :
     (mfderiv I I (conjugationDiffeomorph (I := I) g) x).inverse =
       mfderiv I I (conjugationDiffeomorph (I := I) g⁻¹)
@@ -137,7 +135,6 @@ theorem inverse_mfderiv_conjugation (g x : G) :
     (x' := x) (by simp only [conjugationDiffeomorph_apply]; group)] at A'
   exact ContinuousLinearMap.inverse_eq A' A
 
-set_option backward.isDefEq.respectTransparency false in
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
     mfderiv I I (conjugationDiffeomorph (I := I) g) x
@@ -167,7 +164,6 @@ theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
   · exact ((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
 
-set_option backward.isDefEq.respectTransparency false in
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
     VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹)
@@ -183,17 +179,13 @@ theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (conjugationDiffeomorph (I := I) g⁻¹ x) X
   change @Eq E _ _
   change @Eq E _ _ at hpush
-  calc
-    _ = (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
-          (conjugationDiffeomorph (I := I) g
-            (conjugationDiffeomorph (I := I) g⁻¹ x)) : E) := hpush
-    _ = (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) x : E) :=
-      congrArg (fun y : G ↦
-      (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) y : E)) (by
-        simp only [conjugationDiffeomorph_apply]
-        group)
+  have hpoint : conjugationDiffeomorph (I := I) g
+      (conjugationDiffeomorph (I := I) g⁻¹ x) = x := by
+    simp only [conjugationDiffeomorph_apply]
+    group
+  rw [hpoint] at hpush
+  exact hpush
 
-set_option backward.isDefEq.respectTransparency false in
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
     VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
@@ -211,7 +203,6 @@ theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
   congr 1
   exact congrArg (fun y : G ↦ (V y : E)) (conjugationDiffeomorph_one (I := I) g⁻¹)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
     (X Y : GroupLieAlgebra I G) :
     adjointContinuousLinearMap (I := I) g ⁅X, Y⁆ =

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -54,12 +54,12 @@ local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
 def adjointContinuousLinearMap (g : G) :
     GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
-  mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) 1
+  mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) 1
 
 @[simp]
 theorem adjointContinuousLinearMap_apply (g : G) (X : GroupLieAlgebra I G) :
     adjointContinuousLinearMap (I := I) g X =
-      mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) 1 X :=
+      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) 1 X :=
   (rfl)
 
 @[simp]
@@ -79,125 +79,125 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
   unfold adjointContinuousLinearMap
   change @Eq (E →L[ℝ] E) _ _
   have hfun :
-      conjugationDiffeomorph (I := I) (n := ∞) (g * h) =
-        (conjugationDiffeomorph (I := I) (n := ∞) g) ∘
-          (conjugationDiffeomorph (I := I) (n := ∞) h) := by
+      conjDiffeomorph (I := I) (n := ∞) (g * h) =
+        (conjDiffeomorph (I := I) (n := ∞) g) ∘
+          (conjDiffeomorph (I := I) (n := ∞) h) := by
     funext x
-    simp only [conjugationDiffeomorph_apply, Function.comp_apply]
+    simp only [conjDiffeomorph_apply, Function.comp_apply]
     group
   rw [mfderiv_congr (I := I) (I' := I) hfun]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
-    (((conjugationDiffeomorph (I := I) (n := ∞) h).mdifferentiable (by simp)) _)]
+    (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
+    (((conjDiffeomorph (I := I) (n := ∞) h).mdifferentiable (by simp)) _)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
-    (x := conjugationDiffeomorph (I := I) (n := ∞) h 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := ∞) g)
+    (x := conjDiffeomorph (I := I) (n := ∞) h 1) (x' := 1)
     (by simp)]
   with_unfolding_all rfl
 
 theorem inverse_mfderiv_conjugation (g x : G) :
-    (mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) x).inverse =
-      mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
-        (conjugationDiffeomorph (I := I) (n := ∞) g x) := by
-  have hdiff (a : G) : MDifferentiableAt I I (conjugationDiffeomorph (I := I) (n := ∞) a) x :=
-    ((conjugationDiffeomorph (I := I) (n := ∞) a).mdifferentiable (by simp)) x
+    (mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) x).inverse =
+      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹)
+        (conjDiffeomorph (I := I) (n := ∞) g x) := by
+  have hdiff (a : G) : MDifferentiableAt I I (conjDiffeomorph (I := I) (n := ∞) a) x :=
+    ((conjDiffeomorph (I := I) (n := ∞) a).mdifferentiable (by simp)) x
   have A : mfderiv I I
-      ((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
-        (conjugationDiffeomorph (I := I) (n := ∞) g)) x =
+      ((conjDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
+        (conjDiffeomorph (I := I) (n := ∞) g)) x =
         ContinuousLinearMap.id ℝ (TangentSpace I x) := by
     have h :
-        (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
-          (conjugationDiffeomorph (I := I) (n := ∞) g) = id := by
+        (conjDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
+          (conjDiffeomorph (I := I) (n := ∞) g) = id := by
       funext y
       simp [Function.comp_apply, mul_assoc]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)
+    (((conjDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)
     (hdiff g)] at A
   have A' : mfderiv I I
-      ((conjugationDiffeomorph (I := I) (n := ∞) g) ∘
-        (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹))
-        (conjugationDiffeomorph (I := I) (n := ∞) g x) =
+      ((conjDiffeomorph (I := I) (n := ∞) g) ∘
+        (conjDiffeomorph (I := I) (n := ∞) g⁻¹))
+        (conjDiffeomorph (I := I) (n := ∞) g x) =
         ContinuousLinearMap.id ℝ
-          (TangentSpace I (conjugationDiffeomorph (I := I) (n := ∞) g x)) := by
+          (TangentSpace I (conjDiffeomorph (I := I) (n := ∞) g x)) := by
     have h :
-        (conjugationDiffeomorph (I := I) (n := ∞) g) ∘
-          (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) = id := by
+        (conjDiffeomorph (I := I) (n := ∞) g) ∘
+          (conjDiffeomorph (I := I) (n := ∞) g⁻¹) = id := by
       funext y
       simp [Function.comp_apply, mul_assoc]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
-    (((conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)] at A'
+    (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
+    (((conjDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)] at A'
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
-    (x := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹
-      (conjugationDiffeomorph (I := I) (n := ∞) g x))
-    (x' := x) (by simp only [conjugationDiffeomorph_apply]; group)] at A'
+    (f := conjDiffeomorph (I := I) (n := ∞) g)
+    (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹
+      (conjDiffeomorph (I := I) (n := ∞) g x))
+    (x' := x) (by simp only [conjDiffeomorph_apply]; group)] at A'
   exact ContinuousLinearMap.inverse_eq A' A
 
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
-    mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) x
+    mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) x
         (mulInvariantVectorField X x) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
-        (conjugationDiffeomorph (I := I) (n := ∞) g x) := by
+        (conjDiffeomorph (I := I) (n := ∞) g x) := by
   simp only [mulInvariantVectorField]
   have hfun :
-      (conjugationDiffeomorph (I := I) (n := ∞) g) ∘ (fun y : G ↦ x * y) =
-        (fun y : G ↦ conjugationDiffeomorph (I := I) (n := ∞) g x * y) ∘
-          (conjugationDiffeomorph (I := I) (n := ∞) g) := by
+      (conjDiffeomorph (I := I) (n := ∞) g) ∘ (fun y : G ↦ x * y) =
+        (fun y : G ↦ conjDiffeomorph (I := I) (n := ∞) g x * y) ∘
+          (conjDiffeomorph (I := I) (n := ∞) g) := by
     funext y
     simp [Function.comp_apply, mul_assoc]
   have h := congrArg (fun f : G → G ↦ mfderiv I I f 1 X) hfun
   rw [mfderiv_comp_apply (I := I) (I' := I) (I'' := I),
     mfderiv_comp_apply (I := I) (I' := I) (I'' := I)] at h
-  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjugationDiffeomorph (I := I) (n := ∞) g)
+  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjDiffeomorph (I := I) (n := ∞) g)
       (x := x * 1) (x' := x) (by simp)] at h
     rw [mfderiv_congr_point (I := I) (I' := I)
-      (f := fun y : G ↦ conjugationDiffeomorph (I := I) (n := ∞) g x * y)
-      (x := conjugationDiffeomorph (I := I) (n := ∞) g 1) (x' := 1)
+      (f := fun y : G ↦ conjDiffeomorph (I := I) (n := ∞) g x * y)
+      (x := conjDiffeomorph (I := I) (n := ∞) g 1) (x' := 1)
       (by simp)] at h
     change @Eq E _ _
     exact h
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
-  · exact ((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
-  · exact ((conjugationDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
+  · exact ((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
+  · exact ((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
 
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
-    VectorField.mpullback I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹)
         (mulInvariantVectorField X) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
   funext x
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
-    (f' := conjugationDiffeomorph (I := I) (n := ∞) g) (by simp)]
+    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
+    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
   have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
-    (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ x) X
+    (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) X
   change @Eq E _ _
   change @Eq E _ _ at hpush
-  have hpoint : conjugationDiffeomorph (I := I) (n := ∞) g
-      (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ x) = x := by
-    simp only [conjugationDiffeomorph_apply]
+  have hpoint : conjDiffeomorph (I := I) (n := ∞) g
+      (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) = x := by
+    simp only [conjDiffeomorph_apply]
     group
   rw [hpoint] at hpush
   exact hpush
 
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
-    VectorField.mpullback I I (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹) V 1 =
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
-    (f' := conjugationDiffeomorph (I := I) (n := ∞) g) (by simp)]
+    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
+    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g)
-    (x := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹ 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := ∞) g)
+    (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹ 1) (x' := 1)
     (by simp)]
   change @Eq E _ _
   rw [adjointContinuousLinearMap]
@@ -211,11 +211,11 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
         adjointContinuousLinearMap (I := I) g Y⁆ := by
   have h := VectorField.mpullback_mlieBracket
     (I := I) (I' := I) (n := ∞)
-    (f := conjugationDiffeomorph (I := I) (n := ∞) g⁻¹)
+    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹)
     (V := mulInvariantVectorField X) (W := mulInvariantVectorField Y) (x₀ := (1 : G))
     (mdifferentiableAt_mulInvariantVectorField X)
     (mdifferentiableAt_mulInvariantVectorField Y)
-    (conjugationDiffeomorph (I := I) (n := ∞) g⁻¹).contMDiffAt
+    (conjDiffeomorph (I := I) (n := ∞) g⁻¹).contMDiffAt
       (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
   rw [mpullback_conjugation_mulInvariantVectorField,
     mpullback_conjugation_mulInvariantVectorField] at h

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -51,20 +51,24 @@ open scoped Manifold ContDiff
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [LieGroup I 3 G]
 
-attribute [local instance] LieGroup.minSmoothnessThree
+section Differential
+
+variable [LieGroup I 1 G]
+
+local instance lieGroupMinSmoothnessOne : LieGroup I (minSmoothness ℝ 1) G := by
+  simpa using (inferInstance : LieGroup I 1 G)
 
 /-- The continuous linear equivalence given by the differential of conjugation at the identity. -/
 def adjointContinuousLinearEquiv (g : G) :
     GroupLieAlgebra I G ≃L[ℝ] GroupLieAlgebra I G :=
-  (conjDiffeomorph (I := I) (n := 3) g).mfderivToContinuousLinearEquiv (by simp) 1
+  (conjDiffeomorph (I := I) (n := 1) g).mfderivToContinuousLinearEquiv (by simp) 1
 
 @[simp]
 theorem adjointContinuousLinearEquiv_coe (g : G) :
     (adjointContinuousLinearEquiv (I := I) g :
       GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G) =
-        mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) 1 := by
+        mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) 1 := by
   exact Diffeomorph.mfderivToContinuousLinearEquiv_coe _ _
 
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
@@ -75,7 +79,7 @@ def adjointContinuousLinearMap (g : G) :
 @[simp]
 theorem adjointContinuousLinearMap_apply (g : G) (X : GroupLieAlgebra I G) :
     adjointContinuousLinearMap (I := I) g X =
-      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) 1 X := by
+      mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) 1 X := by
   congr 1
   exact adjointContinuousLinearEquiv_coe (I := I) g
 
@@ -90,8 +94,8 @@ theorem adjointContinuousLinearMap_one :
   rw [← mfderiv_id]
   apply mfderiv_congr
   have h := congrArg
-    (fun f : TauCeti.Diff I G 3 ↦ (f : G → G))
-    (map_one (conj (I := I) (n := 3)))
+    (fun f : TauCeti.Diff I G 1 ↦ (f : G → G))
+    (map_one (conj (I := I) (n := 1)))
   simpa only [conj_apply, TauCeti.Diffeomorph.coe_one] using h
 
 @[simp]
@@ -103,37 +107,38 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
   -- The tangent fibers in this model-with-corners presentation share the model space `E`.
   change @Eq (E →L[ℝ] E) _ _
   have hfun :
-      conjDiffeomorph (I := I) (n := 3) (g * h) =
-        (conjDiffeomorph (I := I) (n := 3) g) ∘
-          (conjDiffeomorph (I := I) (n := 3) h) := by
+      conjDiffeomorph (I := I) (n := 1) (g * h) =
+        (conjDiffeomorph (I := I) (n := 1) g) ∘
+          (conjDiffeomorph (I := I) (n := 1) h) := by
     have hmap := congrArg
-      (fun f : TauCeti.Diff I G 3 ↦ (f : G → G))
-      (map_mul (conj (I := I) (n := 3)) g h)
+      (fun f : TauCeti.Diff I G 1 ↦ (f : G → G))
+      (map_mul (conj (I := I) (n := 1)) g h)
     simpa only [conj_apply, TauCeti.Diffeomorph.coe_mul] using hmap
   rw [mfderiv_congr (I := I) (I' := I) hfun]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
-    (((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _)
-    (((conjDiffeomorph (I := I) (n := 3) h).mdifferentiable (by simp)) _)]
+    (((conjDiffeomorph (I := I) (n := 1) g).mdifferentiable (by simp)) _)
+    (((conjDiffeomorph (I := I) (n := 1) h).mdifferentiable (by simp)) _)]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := 3) g)
-    (x := conjDiffeomorph (I := I) (n := 3) h 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := 1) g)
+    (x := conjDiffeomorph (I := I) (n := 1) h 1) (x' := 1)
     (by simp)]
   rfl
 
 @[simp]
 private theorem conjDiffeomorph_inv (g : G) :
-    conjDiffeomorph (I := I) (n := 3) g⁻¹ =
-      (conjDiffeomorph (I := I) (n := 3) g).symm := by
-  have h := map_inv (conj (I := I) (n := 3)) g
+    conjDiffeomorph (I := I) (n := 1) g⁻¹ =
+      (conjDiffeomorph (I := I) (n := 1) g).symm := by
+  have h := map_inv (conj (I := I) (n := 1)) g
   simpa only [conj_apply, TauCeti.Diffeomorph.inv_def] using h
 
 theorem inverse_mfderiv_conjugation (g x : G) :
-    (mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) x).inverse =
-      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g⁻¹)
-        (conjDiffeomorph (I := I) (n := 3) g x) := by
+    (mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) x).inverse =
+      mfderiv I I (conjDiffeomorph (I := I) (n := 1) g⁻¹)
+        (conjDiffeomorph (I := I) (n := 1) g x) := by
   rw [conjDiffeomorph_inv]
-  let Φ := conjDiffeomorph (I := I) (n := 3) g
+  let Φ := conjDiffeomorph (I := I) (n := 1) g
   let hΦ := Φ.isLocalDiffeomorph x
+  -- Unfold the local names so Mathlib's differential-equivalence API sees the same diffeomorphism.
   change (mfderiv I I Φ x).inverse = mfderiv I I Φ.symm (Φ x)
   rw [← hΦ.mfderivToContinuousLinearEquiv_coe (by simp)]
   rw [ContinuousLinearMap.inverse_equiv]
@@ -147,79 +152,90 @@ theorem inverse_mfderiv_conjugation (g x : G) :
 
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
     (X : GroupLieAlgebra I G) :
-    mfderiv I I (conjDiffeomorph (I := I) (n := 3) g) x
+    mfderiv I I (conjDiffeomorph (I := I) (n := 1) g) x
         (mulInvariantVectorField X x) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
-        (conjDiffeomorph (I := I) (n := 3) g x) := by
+        (conjDiffeomorph (I := I) (n := 1) g x) := by
   simp only [mulInvariantVectorField]
-  have hreg : minSmoothness ℝ 3 ≠ 0 :=
+  have hreg : minSmoothness ℝ 1 ≠ 0 :=
     (lt_of_lt_of_le (by simp) le_minSmoothness).ne'
   have hfun :
-      (conjDiffeomorph (I := I) (n := 3) g) ∘ (fun y : G ↦ x * y) =
-        (fun y : G ↦ conjDiffeomorph (I := I) (n := 3) g x * y) ∘
-          (conjDiffeomorph (I := I) (n := 3) g) := by
+      (conjDiffeomorph (I := I) (n := 1) g) ∘ (fun y : G ↦ x * y) =
+        (fun y : G ↦ conjDiffeomorph (I := I) (n := 1) g x * y) ∘
+          (conjDiffeomorph (I := I) (n := 1) g) := by
     funext y
     simp [Function.comp_apply, mul_assoc]
   have h := congrArg (fun f : G → G ↦ mfderiv I I f 1 X) hfun
   rw [mfderiv_comp_apply (I := I) (I' := I) (I'' := I),
     mfderiv_comp_apply (I := I) (I' := I) (I'' := I)] at h
-  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjDiffeomorph (I := I) (n := 3) g)
+  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjDiffeomorph (I := I) (n := 1) g)
       (x := x * 1) (x' := x) (by simp)] at h
     rw [mfderiv_congr_point (I := I) (I' := I)
-      (f := fun y : G ↦ conjDiffeomorph (I := I) (n := 3) g x * y)
-      (x := conjDiffeomorph (I := I) (n := 3) g 1) (x' := 1)
+      (f := fun y : G ↦ conjDiffeomorph (I := I) (n := 1) g x * y)
+      (x := conjDiffeomorph (I := I) (n := 1) g 1) (x' := 1)
       (by simp)] at h
     -- For this model-with-corners presentation, each tangent fiber is implemented by `E`.
     change @Eq E _ _
     rw [adjointContinuousLinearMap_apply]
     exact h
   · exact contMDiffAt_mul_left.mdifferentiableAt hreg
-  · exact ((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _
-  · exact ((conjDiffeomorph (I := I) (n := 3) g).mdifferentiable (by simp)) _
+  · exact ((conjDiffeomorph (I := I) (n := 1) g).mdifferentiable (by simp)) _
+  · exact ((conjDiffeomorph (I := I) (n := 1) g).mdifferentiable (by simp)) _
   · exact contMDiffAt_mul_left.mdifferentiableAt hreg
 
 /-- Pullback through inverse conjugation is the derivative of forward conjugation. -/
 theorem mpullback_conjugation (g x : G) (V : ∀ y : G, TangentSpace I y) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹) V x =
-      mfderiv I I (conjDiffeomorph (I := I) (n := 3) g)
-        (conjDiffeomorph (I := I) (n := 3) g⁻¹ x)
-        (V (conjDiffeomorph (I := I) (n := 3) g⁻¹ x)) := by
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 1) g⁻¹) V x =
+      mfderiv I I (conjDiffeomorph (I := I) (n := 1) g)
+        (conjDiffeomorph (I := I) (n := 1) g⁻¹ x)
+        (V (conjDiffeomorph (I := I) (n := 1) g⁻¹ x)) := by
   simp only [VectorField.mpullback]
   rw [inverse_mfderiv_conjugation]
   rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := 3) g⁻¹⁻¹)
-    (f' := conjDiffeomorph (I := I) (n := 3) g) (by simp)]
+    (f := conjDiffeomorph (I := I) (n := 1) g⁻¹⁻¹)
+    (f' := conjDiffeomorph (I := I) (n := 1) g) (by simp)]
   rfl
 
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹)
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 1) g⁻¹)
         (mulInvariantVectorField X) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
   funext x
   rw [mpullback_conjugation]
   have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
-    (conjDiffeomorph (I := I) (n := 3) g⁻¹ x) X
-  have hpoint : conjDiffeomorph (I := I) (n := 3) g
-      (conjDiffeomorph (I := I) (n := 3) g⁻¹ x) = x := by
+    (conjDiffeomorph (I := I) (n := 1) g⁻¹ x) X
+  have hpoint : conjDiffeomorph (I := I) (n := 1) g
+      (conjDiffeomorph (I := I) (n := 1) g⁻¹ x) = x := by
     rw [conjDiffeomorph_inv]
-    exact (conjDiffeomorph (I := I) (n := 3) g).apply_symm_apply x
+    exact (conjDiffeomorph (I := I) (n := 1) g).apply_symm_apply x
   rw [hpoint] at hpush
   exact hpush
 
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
-    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 3) g⁻¹) V 1 =
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := 1) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
   rw [mpullback_conjugation]
   rw [mfderiv_congr_point (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := 3) g)
-    (x := conjDiffeomorph (I := I) (n := 3) g⁻¹ 1) (x' := 1)
+    (f := conjDiffeomorph (I := I) (n := 1) g)
+    (x := conjDiffeomorph (I := I) (n := 1) g⁻¹ 1) (x' := 1)
     (by simp)]
   rw [adjointContinuousLinearMap_apply]
-  have hpoint : conjDiffeomorph (I := I) (n := 3) g⁻¹ 1 = 1 := by
+  have hpoint : conjDiffeomorph (I := I) (n := 1) g⁻¹ 1 = 1 := by
     simp only [conjDiffeomorph_apply, mul_one, inv_inv, inv_mul_cancel]
   exact congrArg (fun y : G ↦ mfderiv I I
-    (conjDiffeomorph (I := I) (n := 3) g) 1 (V y)) hpoint
+    (conjDiffeomorph (I := I) (n := 1) g) 1 (V y)) hpoint
+
+end Differential
+
+section Bracket
+
+variable [LieGroup I 3 G]
+
+attribute [local instance] LieGroup.minSmoothnessThree
+
+local instance lieGroupOne : LieGroup I 1 G :=
+  LieGroup.of_le (I := I) (G := G) (m := 1) (n := 3) (by norm_num)
 
 /-- The differential of conjugation preserves the manifold Lie bracket. -/
 theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
@@ -235,6 +251,12 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
     (mdifferentiableAt_mulInvariantVectorField Y)
     (conjDiffeomorph (I := I) (n := 3) g⁻¹).contMDiffAt
       (by norm_num)
+  have hconj :
+      (conjDiffeomorph (I := I) (n := 3) g⁻¹ : G → G) =
+        (conjDiffeomorph (I := I) (n := 1) g⁻¹ : G → G) := by
+    funext x
+    simp only [conjDiffeomorph_apply]
+  rw [hconj] at h
   rw [mpullback_conjugation_mulInvariantVectorField,
     mpullback_conjugation_mulInvariantVectorField] at h
   rw [mpullback_conjugation_one] at h
@@ -280,6 +302,7 @@ theorem tangentAd_inv [CompleteSpace E] (g : G) :
     tangentAd (I := I) g⁻¹ = (tangentAd (I := I) g).symm := by
   ext X
   apply (tangentAd (I := I) g).injective
+  -- Expose the coercions and symmetry of `LieEquiv` so injectivity can use the product law.
   change tangentAd (I := I) g (tangentAd (I := I) g⁻¹ X) =
     tangentAd (I := I) g ((tangentAd (I := I) g).symm X)
   rw [LieEquiv.apply_symm_apply]
@@ -287,5 +310,7 @@ theorem tangentAd_inv [CompleteSpace E] (g : G) :
     (fun e : GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G ↦ e X)
     (tangentAd_mul (I := I) g g⁻¹)
   simpa using h.symm
+
+end Bracket
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -1,0 +1,261 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import Mathlib.Geometry.Manifold.LocalDiffeomorph
+public import TauCeti.Geometry.Lie.Adjoint.Conjugation
+
+/-!
+# The adjoint action of a Lie group
+
+The group adjoint action is the differential at the identity of conjugation.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open scoped Manifold ContDiff
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [LieGroup I ∞ G]
+
+local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
+  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
+    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+
+/-- The differential at the identity of conjugation by `g`, as a continuous linear
+equivalence of the tangent Lie algebra.  The fixed-point identity
+`conjugationDiffeomorph_one` identifies the target fiber of the differential with the tangent
+space at the identity. -/
+@[expose]
+def adjointContinuousLinearEquiv (g : G) :
+    GroupLieAlgebra I G ≃L[ℝ] GroupLieAlgebra I G :=
+  conjugationDiffeomorph_one (I := I) g ▸
+    (conjugationDiffeomorph (I := I) g).mfderivToContinuousLinearEquiv (by simp) (1 : G)
+
+/-- The continuous linear map underlying the differential of conjugation at the identity. -/
+@[expose]
+def adjointContinuousLinearMap (g : G) :
+    GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
+  mfderiv I I (conjugationDiffeomorph (I := I) g) 1
+
+set_option backward.isDefEq.respectTransparency false in
+@[simp]
+theorem adjointContinuousLinearMap_one :
+    adjointContinuousLinearMap (I := I) (1 : G) =
+      ContinuousLinearMap.id ℝ (GroupLieAlgebra I G) := by
+  change @Eq (E →L[ℝ] E) _ _
+  rw [← mfderiv_id]
+  apply mfderiv_congr
+  funext x
+  simp
+
+set_option backward.isDefEq.respectTransparency false in
+theorem adjointContinuousLinearMap_mul (g h : G) :
+    adjointContinuousLinearMap (I := I) (g * h) =
+      (adjointContinuousLinearMap (I := I) g).comp
+        (adjointContinuousLinearMap (I := I) h) := by
+  unfold adjointContinuousLinearMap
+  change @Eq (E →L[ℝ] E) _ _
+  have hfun :
+      conjugationDiffeomorph (I := I) (g * h) =
+        (conjugationDiffeomorph (I := I) g) ∘
+          (conjugationDiffeomorph (I := I) h) := by
+    funext x
+    simp only [conjugationDiffeomorph_apply, Function.comp_apply]
+    group
+  rw [mfderiv_congr (I := I) (I' := I) hfun]
+  rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
+    (((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _)
+    (((conjugationDiffeomorph (I := I) h).mdifferentiable (by simp)) _)]
+  rw [mfderiv_congr_point (I := I) (I' := I)
+    (f := conjugationDiffeomorph (I := I) g)
+    (x := conjugationDiffeomorph (I := I) h 1) (x' := 1)
+    (conjugationDiffeomorph_one (I := I) h)]
+
+set_option backward.isDefEq.respectTransparency false in
+theorem inverse_mfderiv_conjugation (g x : G) :
+    (mfderiv I I (conjugationDiffeomorph (I := I) g) x).inverse =
+      mfderiv I I (conjugationDiffeomorph (I := I) g⁻¹)
+        (conjugationDiffeomorph (I := I) g x) := by
+  have hdiff (a : G) : MDifferentiableAt I I (conjugationDiffeomorph (I := I) a) x :=
+    ((conjugationDiffeomorph (I := I) a).mdifferentiable (by simp)) x
+  have A : mfderiv I I
+      ((conjugationDiffeomorph (I := I) g⁻¹) ∘
+        (conjugationDiffeomorph (I := I) g)) x =
+        ContinuousLinearMap.id ℝ (TangentSpace I x) := by
+    have h :
+        (conjugationDiffeomorph (I := I) g⁻¹) ∘
+          (conjugationDiffeomorph (I := I) g) = id := by
+      funext y
+      simp [Function.comp_apply, mul_assoc]
+    rw [h, mfderiv_id]
+  rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
+    (((conjugationDiffeomorph (I := I) g⁻¹).mdifferentiable (by simp)) _)
+    (hdiff g)] at A
+  have A' : mfderiv I I
+      ((conjugationDiffeomorph (I := I) g) ∘
+        (conjugationDiffeomorph (I := I) g⁻¹))
+        (conjugationDiffeomorph (I := I) g x) =
+        ContinuousLinearMap.id ℝ (TangentSpace I (conjugationDiffeomorph (I := I) g x)) := by
+    have h :
+        (conjugationDiffeomorph (I := I) g) ∘
+          (conjugationDiffeomorph (I := I) g⁻¹) = id := by
+      funext y
+      simp [Function.comp_apply, mul_assoc]
+    rw [h, mfderiv_id]
+  rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
+    (((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _)
+    (((conjugationDiffeomorph (I := I) g⁻¹).mdifferentiable (by simp)) _)] at A'
+  rw [mfderiv_congr_point (I := I) (I' := I)
+    (f := conjugationDiffeomorph (I := I) g)
+    (x := conjugationDiffeomorph (I := I) g⁻¹ (conjugationDiffeomorph (I := I) g x))
+    (x' := x) (by simp only [conjugationDiffeomorph_apply]; group)] at A'
+  exact ContinuousLinearMap.inverse_eq A' A
+
+set_option backward.isDefEq.respectTransparency false in
+theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
+    (X : GroupLieAlgebra I G) :
+    mfderiv I I (conjugationDiffeomorph (I := I) g) x
+        (mulInvariantVectorField X x) =
+      mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
+        (conjugationDiffeomorph (I := I) g x) := by
+  simp only [mulInvariantVectorField]
+  have hfun :
+      (conjugationDiffeomorph (I := I) g) ∘ (fun y : G ↦ x * y) =
+        (fun y : G ↦ conjugationDiffeomorph (I := I) g x * y) ∘
+          (conjugationDiffeomorph (I := I) g) := by
+    funext y
+    simp [Function.comp_apply, mul_assoc]
+  have h := congrArg (fun f : G → G ↦ mfderiv I I f 1 X) hfun
+  rw [mfderiv_comp_apply (I := I) (I' := I) (I'' := I),
+    mfderiv_comp_apply (I := I) (I' := I) (I'' := I)] at h
+  · rw [mfderiv_congr_point (I := I) (I' := I) (f := conjugationDiffeomorph (I := I) g)
+      (x := x * 1) (x' := x) (by simp)] at h
+    rw [mfderiv_congr_point (I := I) (I' := I)
+      (f := fun y : G ↦ conjugationDiffeomorph (I := I) g x * y)
+      (x := conjugationDiffeomorph (I := I) g 1) (x' := 1)
+      (conjugationDiffeomorph_one (I := I) g)] at h
+    change @Eq E _ _
+    exact h
+  · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
+  · exact ((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _
+  · exact ((conjugationDiffeomorph (I := I) g).mdifferentiable (by simp)) _
+  · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
+
+set_option backward.isDefEq.respectTransparency false in
+theorem mpullback_conjugation_mulInvariantVectorField (g : G)
+    (X : GroupLieAlgebra I G) :
+    VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹)
+        (mulInvariantVectorField X) =
+      mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
+  funext x
+  simp only [VectorField.mpullback]
+  rw [inverse_mfderiv_conjugation]
+  rw [mfderiv_congr (I := I) (I' := I)
+    (f := conjugationDiffeomorph (I := I) g⁻¹⁻¹)
+    (f' := conjugationDiffeomorph (I := I) g) (by simp)]
+  have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
+    (conjugationDiffeomorph (I := I) g⁻¹ x) X
+  change @Eq E _ _
+  change @Eq E _ _ at hpush
+  calc
+    _ = (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X)
+          (conjugationDiffeomorph (I := I) g
+            (conjugationDiffeomorph (I := I) g⁻¹ x)) : E) := hpush
+    _ = (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) x : E) :=
+      congrArg (fun y : G ↦
+      (mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) y : E)) (by
+        simp only [conjugationDiffeomorph_apply]
+        group)
+
+set_option backward.isDefEq.respectTransparency false in
+theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
+    VectorField.mpullback I I (conjugationDiffeomorph (I := I) g⁻¹) V 1 =
+      adjointContinuousLinearMap (I := I) g (V 1) := by
+  simp only [VectorField.mpullback]
+  rw [inverse_mfderiv_conjugation]
+  rw [mfderiv_congr (I := I) (I' := I)
+    (f := conjugationDiffeomorph (I := I) g⁻¹⁻¹)
+    (f' := conjugationDiffeomorph (I := I) g) (by simp)]
+  rw [mfderiv_congr_point (I := I) (I' := I)
+    (f := conjugationDiffeomorph (I := I) g)
+    (x := conjugationDiffeomorph (I := I) g⁻¹ 1) (x' := 1)
+    (conjugationDiffeomorph_one (I := I) g⁻¹)]
+  change @Eq E _ _
+  rw [adjointContinuousLinearMap]
+  congr 1
+  exact congrArg (fun y : G ↦ (V y : E)) (conjugationDiffeomorph_one (I := I) g⁻¹)
+
+set_option backward.isDefEq.respectTransparency false in
+theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
+    (X Y : GroupLieAlgebra I G) :
+    adjointContinuousLinearMap (I := I) g ⁅X, Y⁆ =
+      ⁅adjointContinuousLinearMap (I := I) g X,
+        adjointContinuousLinearMap (I := I) g Y⁆ := by
+  have h := VectorField.mpullback_mlieBracket
+    (I := I) (I' := I) (n := ∞)
+    (f := conjugationDiffeomorph (I := I) g⁻¹)
+    (V := mulInvariantVectorField X) (W := mulInvariantVectorField Y) (x₀ := (1 : G))
+    (mdifferentiableAt_mulInvariantVectorField X)
+    (mdifferentiableAt_mulInvariantVectorField Y)
+    (conjugationDiffeomorph (I := I) g⁻¹).contMDiffAt
+      (by simpa using (inferInstance : ENat.LEInfty (2 : ℕ∞ω)).out)
+  rw [mpullback_conjugation_mulInvariantVectorField,
+    mpullback_conjugation_mulInvariantVectorField] at h
+  rw [mpullback_conjugation_one] at h
+  exact h
+
+/-- The group adjoint automorphism: the differential at the identity of conjugation by `g`. -/
+@[expose]
+def Ad [CompleteSpace E] (g : G) :
+    GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G where
+  toFun := adjointContinuousLinearMap (I := I) g
+  invFun := adjointContinuousLinearMap (I := I) g⁻¹
+  left_inv X := by
+    have h := congrArg (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
+      (adjointContinuousLinearMap_mul (I := I) g⁻¹ g)
+    simpa using h.symm
+  right_inv X := by
+    have h := congrArg (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
+      (adjointContinuousLinearMap_mul (I := I) g g⁻¹)
+    simpa using h.symm
+  map_add' := map_add _
+  map_smul' := map_smul _
+  map_lie' := by
+    intro X Y
+    exact adjointContinuousLinearMap_lie (I := I) g X Y
+
+@[simp]
+theorem Ad_apply [CompleteSpace E] (g : G) (X : GroupLieAlgebra I G) :
+    Ad (I := I) g X = adjointContinuousLinearMap (I := I) g X :=
+  rfl
+
+@[simp]
+theorem Ad_one [CompleteSpace E] :
+    Ad (I := I) (1 : G) = LieEquiv.refl := by
+  ext X
+  simp [Ad_apply]
+
+theorem Ad_mul [CompleteSpace E] (g h : G) :
+    Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
+  ext X
+  simpa [Ad_apply] using congrArg
+    (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
+    (adjointContinuousLinearMap_mul (I := I) g h)
+
+@[simp]
+theorem Ad_inv [CompleteSpace E] (g : G) :
+    Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
+  ext X
+  rfl
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.GroupLieAlgebra
+public import TauCeti.Geometry.Lie.Basic
 public import TauCeti.Geometry.Lie.Adjoint.Conjugation
 
 /-!
@@ -32,6 +33,10 @@ This advances Deliverable A, Layer 1 of
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 1, "The group adjoint".
+* Sébastien Gouëzel's `Mathlib.Geometry.Manifold.GroupLieAlgebra`, especially
+  `inverse_mfderiv_mul_left`, `mpullback_mulInvariantVectorField`, and
+  `mulInvariantVector_mlieBracket`; the corresponding conjugation arguments below adapt the
+  derivative-inverse and pullback/bracket proof patterns developed there.
 -/
 
 public section
@@ -47,9 +52,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [LieGroup I ∞ G]
 
-local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
-  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
-    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+attribute [local instance] LieGroup.minSmoothnessThree
 
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
 def adjointContinuousLinearMap (g : G) :
@@ -69,8 +72,10 @@ theorem adjointContinuousLinearMap_one :
   change @Eq (E →L[ℝ] E) _ _
   rw [← mfderiv_id]
   apply mfderiv_congr
-  funext x
-  simp
+  have h := congrArg
+    (fun f : TauCeti.Diff I G ∞ ↦ (f : G → G))
+    (map_one (conj (I := I) (n := ∞)))
+  simpa only [conj_apply, TauCeti.Diffeomorph.coe_one] using h
 
 theorem adjointContinuousLinearMap_mul (g h : G) :
     adjointContinuousLinearMap (I := I) (g * h) =
@@ -82,9 +87,10 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
       conjDiffeomorph (I := I) (n := ∞) (g * h) =
         (conjDiffeomorph (I := I) (n := ∞) g) ∘
           (conjDiffeomorph (I := I) (n := ∞) h) := by
-    funext x
-    simp only [conjDiffeomorph_apply, Function.comp_apply]
-    group
+    have hmap := congrArg
+      (fun f : TauCeti.Diff I G ∞ ↦ (f : G → G))
+      (map_mul (conj (I := I) (n := ∞)) g h)
+    simpa only [conj_apply, TauCeti.Diffeomorph.coe_mul] using hmap
   rw [mfderiv_congr (I := I) (I' := I) hfun]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
     (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
@@ -94,6 +100,13 @@ theorem adjointContinuousLinearMap_mul (g h : G) :
     (x := conjDiffeomorph (I := I) (n := ∞) h 1) (x' := 1)
     (by simp)]
   with_unfolding_all rfl
+
+@[simp]
+private theorem conjDiffeomorph_inv (g : G) :
+    conjDiffeomorph (I := I) (n := ∞) g⁻¹ =
+      (conjDiffeomorph (I := I) (n := ∞) g).symm := by
+  have h := map_inv (conj (I := I) (n := ∞)) g
+  simpa only [conj_apply, TauCeti.Diffeomorph.inv_def] using h
 
 theorem inverse_mfderiv_conjugation (g x : G) :
     (mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g) x).inverse =
@@ -109,7 +122,8 @@ theorem inverse_mfderiv_conjugation (g x : G) :
         (conjDiffeomorph (I := I) (n := ∞) g⁻¹) ∘
           (conjDiffeomorph (I := I) (n := ∞) g) = id := by
       funext y
-      simp [Function.comp_apply, mul_assoc]
+      simp only [Function.comp_apply, conjDiffeomorph_inv, id_eq,
+        Diffeomorph.symm_apply_apply]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
     (((conjDiffeomorph (I := I) (n := ∞) g⁻¹).mdifferentiable (by simp)) _)
@@ -124,7 +138,8 @@ theorem inverse_mfderiv_conjugation (g x : G) :
         (conjDiffeomorph (I := I) (n := ∞) g) ∘
           (conjDiffeomorph (I := I) (n := ∞) g⁻¹) = id := by
       funext y
-      simp [Function.comp_apply, mul_assoc]
+      simp only [Function.comp_apply, conjDiffeomorph_inv, id_eq,
+        Diffeomorph.apply_symm_apply]
     rw [h, mfderiv_id]
   rw [mfderiv_comp (I := I) (I' := I) (I'' := I) _
     (((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _)
@@ -133,7 +148,9 @@ theorem inverse_mfderiv_conjugation (g x : G) :
     (f := conjDiffeomorph (I := I) (n := ∞) g)
     (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹
       (conjDiffeomorph (I := I) (n := ∞) g x))
-    (x' := x) (by simp only [conjDiffeomorph_apply]; group)] at A'
+    (x' := x) (by
+      rw [conjDiffeomorph_inv]
+      exact (conjDiffeomorph (I := I) (n := ∞) g).symm_apply_apply x)] at A'
   exact ContinuousLinearMap.inverse_eq A' A
 
 theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
@@ -165,36 +182,41 @@ theorem mfderiv_conjugation_mulInvariantVectorField (g x : G)
   · exact ((conjDiffeomorph (I := I) (n := ∞) g).mdifferentiable (by simp)) _
   · exact contMDiffAt_mul_left.mdifferentiableAt one_ne_zero
 
+/-- Pullback through inverse conjugation is the derivative of forward conjugation. -/
+theorem mpullback_conjugation (g x : G) (V : ∀ y : G, TangentSpace I y) :
+    VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹) V x =
+      mfderiv I I (conjDiffeomorph (I := I) (n := ∞) g)
+        (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x)
+        (V (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x)) := by
+  simp only [VectorField.mpullback]
+  rw [inverse_mfderiv_conjugation]
+  rw [mfderiv_congr (I := I) (I' := I)
+    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
+    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
+  with_unfolding_all rfl
+
 theorem mpullback_conjugation_mulInvariantVectorField (g : G)
     (X : GroupLieAlgebra I G) :
     VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹)
         (mulInvariantVectorField X) =
       mulInvariantVectorField (adjointContinuousLinearMap (I := I) g X) := by
   funext x
-  simp only [VectorField.mpullback]
-  rw [inverse_mfderiv_conjugation]
-  rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
-    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
+  rw [mpullback_conjugation]
   have hpush := mfderiv_conjugation_mulInvariantVectorField (I := I) g
     (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) X
   change @Eq E _ _
   change @Eq E _ _ at hpush
   have hpoint : conjDiffeomorph (I := I) (n := ∞) g
       (conjDiffeomorph (I := I) (n := ∞) g⁻¹ x) = x := by
-    simp only [conjDiffeomorph_apply]
-    group
+    rw [conjDiffeomorph_inv]
+    exact (conjDiffeomorph (I := I) (n := ∞) g).apply_symm_apply x
   rw [hpoint] at hpush
   exact hpush
 
 theorem mpullback_conjugation_one (g : G) (V : ∀ x : G, TangentSpace I x) :
     VectorField.mpullback I I (conjDiffeomorph (I := I) (n := ∞) g⁻¹) V 1 =
       adjointContinuousLinearMap (I := I) g (V 1) := by
-  simp only [VectorField.mpullback]
-  rw [inverse_mfderiv_conjugation]
-  rw [mfderiv_congr (I := I) (I' := I)
-    (f := conjDiffeomorph (I := I) (n := ∞) g⁻¹⁻¹)
-    (f' := conjDiffeomorph (I := I) (n := ∞) g) (by simp)]
+  rw [mpullback_conjugation]
   rw [mfderiv_congr_point (I := I) (I' := I)
     (f := conjDiffeomorph (I := I) (n := ∞) g)
     (x := conjDiffeomorph (I := I) (n := ∞) g⁻¹ 1) (x' := 1)

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -287,6 +287,7 @@ theorem tangentAd_apply [CompleteSpace E] (g : G) (X : GroupLieAlgebra I G) :
     tangentAd (I := I) g X = adjointContinuousLinearMap (I := I) g X :=
   (rfl)
 
+/-- The tangent adjoint automorphism at the identity is the identity Lie equivalence. -/
 @[simp]
 theorem tangentAd_one [CompleteSpace E] :
     tangentAd (I := I) (1 : G) = LieEquiv.refl := by

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.GroupLieAlgebra
-public import Mathlib.Geometry.Manifold.LocalDiffeomorph
 public import TauCeti.Geometry.Lie.Adjoint.Conjugation
 
 /-!
@@ -21,7 +20,6 @@ This advances Deliverable A, Layer 1 of
 
 ## Main definitions
 
-* `TauCeti.Lie.adjointContinuousLinearMap`: the differential of conjugation at the identity.
 * `TauCeti.Lie.tangentAd`: the resulting tangent Lie algebra automorphism.
 
 ## Main results
@@ -46,16 +44,6 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
   LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
     (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
-
-/-- The differential at the identity of conjugation by `g`, as a continuous linear
-equivalence of the tangent Lie algebra.  The fixed-point identity
-`conjugationDiffeomorph_one` identifies the target fiber of the differential with the tangent
-space at the identity. -/
-@[expose]
-def adjointContinuousLinearEquiv (g : G) :
-    GroupLieAlgebra I G ≃L[ℝ] GroupLieAlgebra I G :=
-  conjugationDiffeomorph_one (I := I) g ▸
-    (conjugationDiffeomorph (I := I) g).mfderivToContinuousLinearEquiv (by simp) (1 : G)
 
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
 @[expose]

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -46,10 +46,15 @@ local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :
     (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
 
 /-- The continuous linear map underlying the differential of conjugation at the identity. -/
-@[expose]
 def adjointContinuousLinearMap (g : G) :
     GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G :=
   mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) 1
+
+@[simp]
+theorem adjointContinuousLinearMap_apply (g : G) (X : GroupLieAlgebra I G) :
+    adjointContinuousLinearMap (I := I) g X =
+      mfderiv I I (conjugationDiffeomorph (I := I) (n := ∞) g) 1 X :=
+  (rfl)
 
 @[simp]
 theorem adjointContinuousLinearMap_one :
@@ -212,7 +217,6 @@ theorem adjointContinuousLinearMap_lie [CompleteSpace E] (g : G)
   exact h
 
 /-- The group adjoint automorphism: the differential at the identity of conjugation by `g`. -/
-@[expose]
 def tangentAd [CompleteSpace E] (g : G) :
     GroupLieAlgebra I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G where
   toFun := adjointContinuousLinearMap (I := I) g
@@ -234,7 +238,7 @@ def tangentAd [CompleteSpace E] (g : G) :
 @[simp]
 theorem tangentAd_apply [CompleteSpace E] (g : G) (X : GroupLieAlgebra I G) :
     tangentAd (I := I) g X = adjointContinuousLinearMap (I := I) g X :=
-  rfl
+  (rfl)
 
 @[simp]
 theorem tangentAd_one [CompleteSpace E] :
@@ -246,7 +250,8 @@ theorem tangentAd_mul [CompleteSpace E] (g h : G) :
     tangentAd (I := I) (g * h) =
       (tangentAd (I := I) h).trans (tangentAd (I := I) g) := by
   ext X
-  simpa [tangentAd_apply] using congrArg
+  rw [tangentAd_apply, LieEquiv.trans_apply, tangentAd_apply, tangentAd_apply]
+  exact congrArg
     (fun f : GroupLieAlgebra I G →L[ℝ] GroupLieAlgebra I G ↦ f X)
     (adjointContinuousLinearMap_mul (I := I) g h)
 

--- a/TauCeti/Geometry/Lie/Adjoint/Basic.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Basic.lean
@@ -8,12 +8,13 @@ public import Mathlib.Geometry.Manifold.GroupLieAlgebra
 public import TauCeti.Geometry.Lie.Adjoint.Conjugation
 
 /-!
-# The adjoint action of a Lie group
+# The tangent-space adjoint action of a Lie group
 
-The group adjoint action is the differential at the identity of conjugation.  We first prove that
-this differential transports left-invariant vector fields.  Naturality of the manifold Lie
+The tangent-space adjoint action is the differential at the identity of conjugation. We first prove
+that this differential transports left-invariant vector fields. Naturality of the manifold Lie
 bracket then shows that it is a Lie algebra automorphism, and the composition law for conjugation
-gives the representation law.
+gives the representation law. A subsequent file transports this construction to the roadmap-facing
+Lie algebra of left-invariant derivations.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
@@ -26,6 +27,11 @@ This advances Deliverable A, Layer 1 of
 
 * `TauCeti.Lie.adjointContinuousLinearMap_lie`: the differential preserves the Lie bracket.
 * `TauCeti.Lie.tangentAd_mul`: the tangent adjoint automorphism respects group multiplication.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
 -/
 
 public section


### PR DESCRIPTION
Roadmap: RepresentationTheory

## Goal

Construct the tangent-space form of the Lie-group adjoint action, providing the geometric core needed to package the roadmap-facing adjoint representation on left-invariant derivations. This advances [Deliverable A, Layer 1, “The group adjoint”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad).

## Why this is sufficient

Conjugation already supplies a smooth diffeomorphism of the group. Differentiating it at the identity gives the underlying continuous linear map; transporting left-invariant vector fields through conjugation and applying naturality of the manifold Lie bracket proves that map preserves the bracket. The conjugation composition law then proves multiplicativity, while conjugation by the inverse supplies the inverse linear map. Together these facts package each differential as a Lie-algebra automorphism `tangentAd g` with the representation laws at `1`, products, and inverses.

## Verification

- `lake build TauCeti.Geometry.Lie.Adjoint.Basic`
- `lake build`
- `bash scripts/lint-env.sh TauCeti/Geometry/Lie/Adjoint/Basic.lean`