### PR TITLE
feat: James's submodule theorem and the irreducibility of the Specht module

### DIFF
--- a/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/Module.lean
@@ -39,7 +39,9 @@ distinct and the coefficient of `{t}` itself is `1`.
 
 The identification of `S^μ` with the left ideal `ℚ[Sₙ] c_t` of
 `TauCeti/RepresentationTheory/Symmetric/Specht/Ideal/Basic.lean` is a separate milestone and is not
-proved here; so are James's submodule theorem and irreducibility.
+proved here.  Neither is James's submodule theorem, which rests on the nonvanishing recorded below
+and lives in `TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean` together with
+the irreducibility it yields.
 
 ## Main definitions
 
@@ -148,6 +150,13 @@ noncomputable def polytabloid (t : YoungTableau μ) :
     (permutationModule (shapePartition μ)).V :=
   (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
     (MonoidAlgebra.single (tabloid t) 1)
+
+/-- The polytabloid is the column antisymmetrizer applied to the tabloid. -/
+theorem polytabloid_def (t : YoungTableau μ) :
+    polytabloid t =
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+        (MonoidAlgebra.single (tabloid t) 1) :=
+  (rfl)
 
 /-- The polytabloid is the signed sum of the tabloids obtained from `{t}` by the column group. -/
 theorem polytabloid_eq_sum (t : YoungTableau μ) :

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -85,20 +85,6 @@ variable {μ : YoungDiagram}
 noncomputable local instance (t : YoungTableau μ) : DecidablePred (· ∈ colSubgroup t) :=
   Classical.decPred _
 
-/-! ### The column antisymmetrizer as an operator -/
-
-/-- The column antisymmetrizer of `t` acts on any representation as the signed sum of the
-permutations in the column group of `t`. -/
-theorem asAlgebraHom_columnAntisymmetrizer_apply {V : Type*} [AddCommGroup V] [Module ℚ V]
-    (ρ : Representation ℚ (Equiv.Perm (Fin μ.card)) V) (t : YoungTableau μ) (v : V) :
-    ρ.asAlgebraHom (columnAntisymmetrizer t) v =
-      ∑ q : colSubgroup t,
-        ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) • ρ q v := by
-  rw [columnAntisymmetrizer_def, map_sum, LinearMap.sum_apply]
-  refine Finset.sum_congr rfl fun q _ => ?_
-  rw [map_smul, MonoidAlgebra.of_apply, Representation.asAlgebraHom_single_one,
-    LinearMap.smul_apply]
-
 /-! ### James's lemma: the column antisymmetrizer of a tabloid -/
 
 /-- **James's Lemma 4.6.**  The column antisymmetrizer of `t` sends a `μ`-tabloid to a rational

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -99,15 +99,6 @@ theorem asAlgebraHom_columnAntisymmetrizer_apply {V : Type*} [AddCommGroup V] [M
   rw [map_smul, MonoidAlgebra.of_apply, Representation.asAlgebraHom_single_one,
     LinearMap.smul_apply]
 
-/-- A subrepresentation is stable under the column antisymmetrizer, being stable under each
-permutation of the column group. -/
-theorem asAlgebraHom_columnAntisymmetrizer_mem {V : Type*} [AddCommGroup V] [Module ℚ V]
-    {ρ : Representation ℚ (Equiv.Perm (Fin μ.card)) V} (t : YoungTableau μ)
-    {U : Subrepresentation ρ} {v : V} (hv : v ∈ U.toSubmodule) :
-    ρ.asAlgebraHom (columnAntisymmetrizer t) v ∈ U.toSubmodule := by
-  rw [asAlgebraHom_columnAntisymmetrizer_apply]
-  exact Submodule.sum_mem _ fun q _ => Submodule.smul_mem _ _ (U.apply_mem_toSubmodule _ hv)
-
 /-! ### James's lemma: the column antisymmetrizer of a tabloid -/
 
 /-- **James's Lemma 4.6.**  The column antisymmetrizer of `t` sends a `μ`-tabloid to a rational
@@ -119,7 +110,7 @@ shared labels fixes the tabloid while `b_t` sees its sign, and otherwise `σ⁻�
 row and column groups of `t`, of which the row part fixes `{t}`. -/
 theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
     (T : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) :
-    ∃ κ : ℚ,
+    ∃ κ : ℚ, (κ = 0 ∨ κ = 1 ∨ κ = -1) ∧
       (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
           (MonoidAlgebra.single T 1) = κ • polytabloid t := by
   obtain ⟨s, rfl⟩ := tabloid_surjective T
@@ -127,7 +118,7 @@ theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
   by_cases h : RowMeetsColumnTwice (relabel σ t) t
   · -- the transposition of the two shared labels fixes the tabloid and negates `b_t`
     obtain ⟨x, y, hxy, hrow, hcol⟩ := (rowMeetsColumnTwice_def _ _).mp h
-    refine ⟨0, ?_⟩
+    refine ⟨0, Or.inl rfl, ?_⟩
     rw [zero_smul]
     have hfix : (permutationModule (shapePartition μ)).ρ (Equiv.swap x y)
         (MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ)) =
@@ -157,7 +148,9 @@ theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
     rw [rowMeetsColumnTwice_relabel_left_iff] at h
     obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
     have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
-    refine ⟨((Equiv.Perm.sign q : ℤ) : ℚ), ?_⟩
+    have hsign : ((Equiv.Perm.sign q : ℤ) : ℚ) = 1 ∨ ((Equiv.Perm.sign q : ℤ) : ℚ) = -1 := by
+      rcases Int.units_eq_one_or (Equiv.Perm.sign q) with hq | hq <;> simp [hq]
+    refine ⟨((Equiv.Perm.sign q : ℤ) : ℚ), Or.inr hsign, ?_⟩
     have htab : MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ) =
         (permutationModule (shapePartition μ)).ρ q⁻¹
           (MonoidAlgebra.single (tabloid t) 1) := by
@@ -184,7 +177,7 @@ theorem exists_eq_smul_polytabloid (t : YoungTableau μ)
     induction hv using Submodule.span_induction with
     | mem w hw =>
       obtain ⟨T, rfl⟩ := hw
-      obtain ⟨κ, hκ⟩ := exists_eq_smul_polytabloid_single t T
+      obtain ⟨κ, -, hκ⟩ := exists_eq_smul_polytabloid_single t T
       rw [MonoidAlgebra.basis_apply, hκ]
       exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
     | zero => rw [map_zero]; exact Submodule.zero_mem _
@@ -241,7 +234,8 @@ theorem spechtSubrepresentation_le_or_le_orthogonal (μ : YoungDiagram)
     -- the polytabloid itself lies in `U`, after rescaling
     have hmem : polytabloid t ∈ U.toSubmodule := by
       have hsmul : κ • polytabloid t ∈ U.toSubmodule :=
-        hκ ▸ asAlgebraHom_columnAntisymmetrizer_mem t hvU
+        hκ ▸ Representation.asAlgebraHom_mem_of_forall_mem _ U.toSubmodule
+          (fun g _ hv => U.apply_mem_toSubmodule g hv) v hvU (columnAntisymmetrizer t)
       have := U.toSubmodule.smul_mem κ⁻¹ hsmul
       rwa [smul_smul, inv_mul_cancel₀ hκ0, one_smul] at this
     -- and `U` then contains the whole orbit of the polytabloid, which spans `S^μ`

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -1,0 +1,299 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.RepresentationTheory.Induction.Restriction
+public import TauCeti.RepresentationTheory.Irreducible
+public import TauCeti.RepresentationTheory.Symmetric.Factorization
+public import TauCeti.RepresentationTheory.Symmetric.Specht.Module
+
+/-!
+# James's submodule theorem, and the irreducibility of the Specht module
+
+Every subrepresentation `U` of the Young permutation module `M^μ` is comparable with the Specht
+module `S^μ` in a very strong sense: either `S^μ ≤ U`, or `U` is orthogonal to `S^μ` for the
+tabloid form.  This dichotomy is **James's submodule theorem**, and it is proved here
+(`TauCeti.spechtSubrepresentation_le_or_le_orthogonal`).  Since the tabloid form is positive
+definite, the two alternatives overlap only on the zero subrepresentation, so the theorem
+immediately makes `S^μ` an atom of the lattice of subrepresentations of `M^μ`, hence irreducible.
+
+The engine is the behaviour of the column antisymmetrizer `b_t` on a single tabloid, which is
+James's Lemma 4.6: `b_t · {s}` is either `0` or `± e_t`
+(`TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`).  Writing `{s} = σ · {t}`, the two cases
+are exactly the two cases of the row/column criterion of
+`TauCeti.RepresentationTheory.Symmetric.Vanishing`, read with the roles of the two tableaux
+exchanged.
+
+* If a row of `relabel σ t` meets a column of `t` in two distinct labels `x ≠ y`, then the
+  transposition of `x` and `y` lies in the column group of `t` while fixing the tabloid `{s}`, so
+  pushing it across turns `b_t · {s}` into its own negative and kills it.
+* Otherwise the row-column factorization of
+  `TauCeti.RepresentationTheory.Symmetric.Factorization` writes `σ⁻¹ = p q` with `p` in the row
+  group and `q` in the column group of `t`.  The row group is the stabilizer of `{t}`, so
+  `{s} = q⁻¹ · {t}`, and `b_t` absorbs `q⁻¹` through its sign: `b_t · {s} = sign q • e_t`.
+
+By linearity the same holds for an arbitrary vector of `M^μ`
+(`TauCeti.YoungTableau.exists_eq_smul_polytabloid`), and that is the dichotomy.  Given a
+subrepresentation `U`, either some `b_t` fails to annihilate some vector of `U` -- and then `e_t`
+itself lies in `U`, and with it the span of its orbit, which is all of `S^μ` -- or every `b_t`
+annihilates every vector of `U`, and then `U` is orthogonal to every polytabloid, because `b_t` is
+self-adjoint for the tabloid form
+(`TauCeti.YoungTableau.tabloidForm_asAlgebraHom_columnAntisymmetrizer`) and `e_t = b_t · {t}`.
+
+The dimension of `S^μ`, the standard basis of polytabloids indexing it, and the statement that
+the `S^μ` exhaust the irreducibles of `Sₙ` and are pairwise non-isomorphic are separate targets and
+are not proved here.  Neither is the comparison of `S^μ` with the left ideal `ℚ[Sₙ] c_t`, which is
+irreducible by
+`TauCeti.YoungTableau.isIrreducible_spechtIdealRep` through an argument that shares the row-column
+factorization but not the tabloid form.
+
+## Main results
+
+* `TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`: the column antisymmetrizer sends a
+  tabloid to a multiple of the polytabloid (James's Lemma 4.6), and
+  `TauCeti.YoungTableau.exists_eq_smul_polytabloid` extends this to all of `M^μ`.
+* `TauCeti.YoungTableau.tabloidForm_asAlgebraHom_columnAntisymmetrizer`: the column
+  antisymmetrizer is self-adjoint for the tabloid form.
+* `TauCeti.spechtSubrepresentation_le_or_le_orthogonal`: **James's submodule theorem**.
+* `TauCeti.isAtom_spechtSubrepresentation` and `TauCeti.isIrreducible_spechtSubrepresentation`:
+  the Specht module is a minimal subrepresentation of `M^μ`, hence irreducible, with
+  `TauCeti.isIrreducible_spechtModule` the partition-indexed form.
+
+## References
+
+* [G. D. James, *The Representation Theory of the Symmetric Groups*][james1978], Chapter 4:
+  Lemma 4.6, the submodule theorem 4.8, and Corollary 4.9.
+* B. E. Sagan, *The Symmetric Group*, 2nd ed. (2001), Section 2.4.
+* [Schur--Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md),
+  Layer 3, "The submodule theorem (James)", and Layer 4, "Irreducibility".
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped BigOperators
+
+namespace YoungTableau
+
+variable {μ : YoungDiagram}
+
+/-- Classical decidability of membership in the column group, used to form its finite sum, as in
+`TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean`. -/
+noncomputable local instance (t : YoungTableau μ) : DecidablePred (· ∈ colSubgroup t) :=
+  Classical.decPred _
+
+/-! ### The column antisymmetrizer as an operator -/
+
+/-- The column antisymmetrizer of `t` acts on any representation as the signed sum of the
+permutations in the column group of `t`. -/
+theorem asAlgebraHom_columnAntisymmetrizer_apply {V : Type*} [AddCommGroup V] [Module ℚ V]
+    (ρ : Representation ℚ (Equiv.Perm (Fin μ.card)) V) (t : YoungTableau μ) (v : V) :
+    ρ.asAlgebraHom (columnAntisymmetrizer t) v =
+      ∑ q : colSubgroup t,
+        ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) • ρ q v := by
+  rw [columnAntisymmetrizer_def, map_sum, LinearMap.sum_apply]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  rw [map_smul, MonoidAlgebra.of_apply, Representation.asAlgebraHom_single_one,
+    LinearMap.smul_apply]
+
+/-- A subrepresentation is stable under the column antisymmetrizer, being stable under each
+permutation of the column group. -/
+theorem asAlgebraHom_columnAntisymmetrizer_mem {V : Type*} [AddCommGroup V] [Module ℚ V]
+    {ρ : Representation ℚ (Equiv.Perm (Fin μ.card)) V} (t : YoungTableau μ)
+    {U : Subrepresentation ρ} {v : V} (hv : v ∈ U.toSubmodule) :
+    ρ.asAlgebraHom (columnAntisymmetrizer t) v ∈ U.toSubmodule := by
+  rw [asAlgebraHom_columnAntisymmetrizer_apply]
+  exact Submodule.sum_mem _ fun q _ => Submodule.smul_mem _ _ (U.apply_mem_toSubmodule _ hv)
+
+/-! ### James's lemma: the column antisymmetrizer of a tabloid -/
+
+/-- **James's Lemma 4.6.**  The column antisymmetrizer of `t` sends a `μ`-tabloid to a rational
+multiple of the polytabloid `e_t`; the multiple is `0` or a sign.
+
+The tabloid is `σ · {t}` for some `σ`, and the two cases are the two cases of the row/column
+criterion: if a row of `relabel σ t` meets a column of `t` twice the transposition of the two
+shared labels fixes the tabloid while `b_t` sees its sign, and otherwise `σ⁻¹` factors through the
+row and column groups of `t`, of which the row part fixes `{t}`. -/
+theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
+    (T : Equiv.Perm (Fin μ.card) ⧸ youngSubgroup (shapePartition μ)) :
+    ∃ κ : ℚ,
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+          (MonoidAlgebra.single T 1) = κ • polytabloid t := by
+  obtain ⟨s, rfl⟩ := tabloid_surjective T
+  obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
+  by_cases h : RowMeetsColumnTwice (relabel σ t) t
+  · -- the transposition of the two shared labels fixes the tabloid and negates `b_t`
+    obtain ⟨x, y, hxy, hrow, hcol⟩ := (rowMeetsColumnTwice_def _ _).mp h
+    refine ⟨0, ?_⟩
+    rw [zero_smul]
+    have hfix : (permutationModule (shapePartition μ)).ρ (Equiv.swap x y)
+        (MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ)) =
+        MonoidAlgebra.single (tabloid (relabel σ t)) 1 := by
+      rw [Representation.ofMulAction_single,
+        smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow)]
+    have hneg : columnAntisymmetrizer t * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) =
+        -columnAntisymmetrizer t := by
+      rw [mul_columnAntisymmetrizer_right t ⟨Equiv.swap x y, swap_mem_colSubgroup hcol⟩,
+        Equiv.Perm.sign_swap hxy]
+      simp
+    have key : (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+          (MonoidAlgebra.single (tabloid (relabel σ t)) 1) =
+        -((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+          (MonoidAlgebra.single (tabloid (relabel σ t)) 1)) := by
+      conv_lhs => rw [← hfix]
+      rw [← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
+        ← Module.End.mul_apply, ← map_mul, hneg, map_neg, LinearMap.neg_apply]
+    have h2 : (2 : ℚ) •
+        (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+          (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
+      rw [two_smul]
+      nth_rewrite 2 [key]
+      exact add_neg_cancel _
+    exact (smul_eq_zero.mp h2).resolve_left (by norm_num)
+  · -- `σ⁻¹ = p q`, the row part fixes `{t}`, and `b_t` absorbs the column part by its sign
+    rw [rowMeetsColumnTwice_relabel_left_iff] at h
+    obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
+    have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
+    refine ⟨((Equiv.Perm.sign q : ℤ) : ℚ), ?_⟩
+    have htab : MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ) =
+        (permutationModule (shapePartition μ)).ρ q⁻¹
+          (MonoidAlgebra.single (tabloid t) 1) := by
+      rw [Representation.ofMulAction_single, tabloid_relabel, hσ, mul_smul,
+        smul_tabloid_eq_self_iff.mpr (inv_mem (SetLike.mem_coe.mp hp))]
+    rw [htab, ← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
+      ← Module.End.mul_apply, ← map_mul,
+      mul_columnAntisymmetrizer_right t ⟨q⁻¹, inv_mem (SetLike.mem_coe.mp hq)⟩,
+      Equiv.Perm.sign_inv, map_smul, LinearMap.smul_apply, ← polytabloid_def]
+
+/-- **The column antisymmetrizer collapses `M^μ` onto the line spanned by the polytabloid.**  This
+is the linear extension of `TauCeti.YoungTableau.exists_eq_smul_polytabloid_single` from the
+tabloid basis to the whole Young permutation module. -/
+theorem exists_eq_smul_polytabloid (t : YoungTableau μ)
+    (v : (permutationModule (shapePartition μ)).V) :
+    ∃ κ : ℚ,
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t) v =
+        κ • polytabloid t := by
+  have hv : v ∈ Submodule.span ℚ (Set.range (permutationModuleBasis (shapePartition μ))) := by
+    rw [Module.Basis.span_eq]
+    exact Submodule.mem_top
+  have hspan : (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t) v ∈
+      Submodule.span ℚ {polytabloid t} := by
+    induction hv using Submodule.span_induction with
+    | mem w hw =>
+      obtain ⟨T, rfl⟩ := hw
+      obtain ⟨κ, hκ⟩ := exists_eq_smul_polytabloid_single t T
+      rw [MonoidAlgebra.basis_apply, hκ]
+      exact Submodule.smul_mem _ _ (Submodule.mem_span_singleton_self _)
+    | zero => rw [map_zero]; exact Submodule.zero_mem _
+    | add x y _ _ hx hy => rw [map_add]; exact Submodule.add_mem _ hx hy
+    | smul r x _ hx => rw [map_smul]; exact Submodule.smul_mem _ _ hx
+  obtain ⟨κ, hκ⟩ := Submodule.mem_span_singleton.mp hspan
+  exact ⟨κ, hκ.symm⟩
+
+/-! ### Self-adjointness of the column antisymmetrizer -/
+
+/-- **The column antisymmetrizer is self-adjoint for the tabloid form.**  The symmetric group acts
+on `M^μ` by isometries, so moving a permutation across the form inverts it, and inversion is a
+sign-preserving involution of the column group. -/
+theorem tabloidForm_asAlgebraHom_columnAntisymmetrizer (t : YoungTableau μ)
+    (v w : (permutationModule (shapePartition μ)).V) :
+    tabloidForm (shapePartition μ)
+        ((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t) v) w =
+      tabloidForm (shapePartition μ) v
+        ((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t) w) := by
+  rw [asAlgebraHom_columnAntisymmetrizer_apply, asAlgebraHom_columnAntisymmetrizer_apply,
+    map_sum, LinearMap.sum_apply, map_sum]
+  refine Fintype.sum_equiv (Equiv.inv (colSubgroup t)) _ _ fun q => ?_
+  rw [map_smul, LinearMap.smul_apply, map_smul]
+  simp only [Equiv.inv_apply, InvMemClass.coe_inv, Equiv.Perm.sign_inv, smul_eq_mul]
+  rw [permutationForm_ofMulAction_left]
+
+end YoungTableau
+
+/-! ### The submodule theorem -/
+
+open YoungTableau
+
+/-- **James's submodule theorem.**  A subrepresentation `U` of the Young permutation module `M^μ`
+either contains the Specht module `S^μ` or is orthogonal to it for the tabloid form.
+
+The dichotomy is whether some column antisymmetrizer `b_t` fails to annihilate some vector of `U`.
+If it does fail, the value is a nonzero multiple of the polytabloid `e_t` and lies in `U`, so `U`
+contains the orbit of `e_t`, which spans `S^μ`.  If every `b_t` annihilates every vector of `U`,
+then self-adjointness of `b_t` moves it off each polytabloid `e_t = b_t · {t}` and onto the vector
+of `U`, where it vanishes. -/
+theorem spechtSubrepresentation_le_or_le_orthogonal (μ : YoungDiagram)
+    (U : Subrepresentation (permutationModule (shapePartition μ)).ρ) :
+    spechtSubrepresentation μ ≤ U ∨
+      U ≤ orthogonalSubrepresentation (spechtSubrepresentation μ) := by
+  by_cases hex : ∃ (t : YoungTableau μ) (v : (permutationModule (shapePartition μ)).V),
+      v ∈ U.toSubmodule ∧
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t) v ≠ 0
+  · obtain ⟨t, v, hvU, hne⟩ := hex
+    refine Or.inl ?_
+    obtain ⟨κ, hκ⟩ := exists_eq_smul_polytabloid t v
+    have hκ0 : κ ≠ 0 := by
+      rintro rfl
+      exact hne (by rw [hκ, zero_smul])
+    -- the polytabloid itself lies in `U`, after rescaling
+    have hmem : polytabloid t ∈ U.toSubmodule := by
+      have hsmul : κ • polytabloid t ∈ U.toSubmodule :=
+        hκ ▸ asAlgebraHom_columnAntisymmetrizer_mem t hvU
+      have := U.toSubmodule.smul_mem κ⁻¹ hsmul
+      rwa [smul_smul, inv_mul_cancel₀ hκ0, one_smul] at this
+    -- and `U` then contains the whole orbit of the polytabloid, which spans `S^μ`
+    rw [← Subrepresentation.toSubmodule_le_toSubmodule, spechtSubrepresentation_eq_span_orbit t]
+    refine Submodule.span_le.mpr ?_
+    rintro _ ⟨σ, rfl⟩
+    exact U.apply_mem_toSubmodule σ hmem
+  · push Not at hex
+    refine Or.inr ?_
+    rw [← Subrepresentation.toSubmodule_le_toSubmodule,
+      toSubmodule_orthogonalSubrepresentation]
+    intro v hv
+    rw [LinearMap.BilinForm.mem_orthogonal_iff]
+    intro w hw
+    rw [spechtSubrepresentation_toSubmodule] at hw
+    induction hw using Submodule.span_induction with
+    | mem x hx =>
+      obtain ⟨t, rfl⟩ := hx
+      rw [polytabloid_def, tabloidForm_asAlgebraHom_columnAntisymmetrizer, hex t v hv,
+        map_zero]
+    | zero => rw [map_zero, LinearMap.zero_apply]
+    | add x y _ _ hx hy => rw [map_add, LinearMap.add_apply, hx, hy, add_zero]
+    | smul r x _ hx => rw [map_smul, LinearMap.smul_apply, hx, smul_zero]
+
+/-! ### Irreducibility -/
+
+/-- **The Specht module is a minimal subrepresentation of `M^μ`.**  A nonzero subrepresentation
+strictly inside `S^μ` would, by the submodule theorem, be orthogonal to `S^μ` while lying in it,
+and the tabloid form is positive definite. -/
+theorem isAtom_spechtSubrepresentation (μ : YoungDiagram) :
+    IsAtom (spechtSubrepresentation μ) := by
+  refine ⟨spechtSubrepresentation_ne_bot μ, fun U hU => ?_⟩
+  rcases spechtSubrepresentation_le_or_le_orthogonal μ U with hle | hle
+  · exact absurd (le_antisymm hU.le hle) hU.ne
+  · exact le_bot_iff.mp
+      ((isCompl_orthogonalSubrepresentation_permutationModule (shapePartition μ)
+        (spechtSubrepresentation μ)).disjoint hU.le hle)
+
+/-- **The Specht module is irreducible.**  This is James's Corollary 4.9 over a field of
+characteristic zero, in the concrete presentation of `S^μ` as the span of the polytabloids inside
+the Young permutation module. -/
+theorem isIrreducible_spechtSubrepresentation (μ : YoungDiagram) :
+    (spechtSubrepresentation μ).toRepresentation.IsIrreducible :=
+  Representation.isIrreducible_toRepresentation_of_isAtom (isAtom_spechtSubrepresentation μ)
+
+/-- **The Specht module of a partition is irreducible**, in the partition-indexed packaging
+`TauCeti.spechtModule`.  Transporting along the relabelling `Fin n ≃ Fin (diagramOf μ).card` is an
+isomorphism of groups, and restriction along an isomorphism preserves irreducibility. -/
+instance isIrreducible_spechtModule {n : ℕ} (μ : n.Partition) :
+    _root_.Representation.IsIrreducible (spechtModule μ).ρ :=
+  (isIrreducible_comp_equiv_iff (finCongr (card_diagramOf μ).symm).permCongrHom
+    (spechtSubrepresentation (diagramOf μ)).toRepresentation).mpr
+    (isIrreducible_spechtSubrepresentation (diagramOf μ))
+
+end TauCeti

--- a/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Symmetrizer.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Algebra.MonoidAlgebra.Basic
 public import Mathlib.Algebra.Group.Subgroup.Finite
 public import Mathlib.GroupTheory.Perm.Sign
+public import Mathlib.RepresentationTheory.Basic
 public import TauCeti.RepresentationTheory.Symmetric.RowColumnSubgroup
 
 /-!
@@ -23,6 +24,8 @@ These are the elementary inputs to the essential-idempotence theorem for `c_t` a
 construction of Specht modules.  The two extreme shapes are also evaluated here: a trivial row or
 column group collapses the corresponding factor to `1`, so on a shape with at most one row the
 whole group fixes `c_t`, and on a shape with at most one column it scales `c_t` by the sign.
+Finally, `b_t` acting on an arbitrary representation is unfolded into the signed sum over the
+column group, which is how every downstream computation with the operator `b_t` begins.
 
 The symmetrizers are built over `ℚ`, which is what the essential-idempotence theorem and the
 Specht-module constructions downstream of this file work over.  The coefficients of `c_t` are in
@@ -328,6 +331,20 @@ theorem single_mul_youngSymmetrizer_of_colSubgroup_eq_top (t : YoungTableau μ)
       ((Equiv.Perm.sign g : ℤ) : ℚ) • youngSymmetrizer t := by
   rw [youngSymmetrizer_eq_columnAntisymmetrizer t (rowSubgroup_eq_bot_of_colSubgroup_eq_top t h)]
   exact mul_columnAntisymmetrizer_left t ⟨g, by rw [h]; exact Subgroup.mem_top g⟩
+
+/-! ### The column antisymmetrizer as an operator -/
+
+/-- The column antisymmetrizer of `t` acts on any representation as the signed sum of the
+permutations in the column group of `t`. -/
+theorem asAlgebraHom_columnAntisymmetrizer_apply {V : Type*} [AddCommGroup V] [Module ℚ V]
+    (ρ : Representation ℚ (Equiv.Perm (Fin μ.card)) V) (t : YoungTableau μ) (v : V) :
+    ρ.asAlgebraHom (columnAntisymmetrizer t) v =
+      ∑ q : colSubgroup t,
+        ((Equiv.Perm.sign (q : Equiv.Perm (Fin μ.card)) : ℤ) : ℚ) • ρ q v := by
+  rw [columnAntisymmetrizer_def, map_sum, LinearMap.sum_apply]
+  refine Finset.sum_congr rfl fun q _ => ?_
+  rw [map_smul, MonoidAlgebra.of_apply, Representation.asAlgebraHom_single_one,
+    LinearMap.smul_apply]
 
 section Transport
 

--- a/TauCeti/RepresentationTheory/Symmetric/Vanishing.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Vanishing.lean
@@ -40,6 +40,10 @@ and no row of `t` meets a column of `relabel σ t` twice
 permutations whose sandwich is visibly nonzero, and it certifies that the permutations it does
 fire on lie outside the product set `Row(t) · Col(t)`.
 
+A relabelling can be moved from one argument of the criterion to the other by inverting it
+(`YoungTableau.rowMeetsColumnTwice_relabel_left_iff`), which is what lets the criterion be applied
+when it is the tableau whose *rows* are read that has been relabelled.
+
 Neither half is vacuous: `YoungTableau.exists_rowMeetsColumnTwice_relabel` produces a permutation
 the criterion fires on whenever `t` has a row and a column each containing two distinct labels, so
 `YoungTableau.exists_rowSymmetrizer_mul_single_mul_columnAntisymmetrizer_eq_zero` exhibits a
@@ -91,6 +95,23 @@ theorem rowMeetsColumnTwice_relabel_iff (t : YoungTableau μ) (σ : Equiv.Perm (
       ∃ x y, x ≠ y ∧ rowIndex t x = rowIndex t y ∧
         colIndex t (σ⁻¹ x) = colIndex t (σ⁻¹ y) := by
   simp only [rowMeetsColumnTwice_def, colIndex_relabel]
+
+/-- Relabelling moves across the criterion by inverting: a row of `relabel σ t` meets a column of
+`s` twice exactly when a row of `t` meets a column of `relabel σ⁻¹ s` twice.  Both sides say that
+two distinct labels share a row of `t` after applying `σ⁻¹` and share a column of `s`, read from
+the two ends.
+
+Not a `simp` lemma: neither side is simpler than the other, and pushing the relabelling to the
+right would fight `rowMeetsColumnTwice_relabel_iff`. -/
+theorem rowMeetsColumnTwice_relabel_left_iff (t s : YoungTableau μ)
+    (σ : Equiv.Perm (Fin μ.card)) :
+    RowMeetsColumnTwice (relabel σ t) s ↔ RowMeetsColumnTwice t (relabel σ⁻¹ s) := by
+  simp only [rowMeetsColumnTwice_def, rowIndex_relabel, colIndex_relabel, inv_inv]
+  constructor
+  · rintro ⟨x, y, hxy, hrow, hcol⟩
+    exact ⟨σ⁻¹ x, σ⁻¹ y, fun h => hxy (σ⁻¹.injective h), hrow, by simpa using hcol⟩
+  · rintro ⟨x, y, hxy, hrow, hcol⟩
+    exact ⟨σ x, σ y, fun h => hxy (σ.injective h), by simpa using hrow, hcol⟩
 
 /-- No row of a tableau meets one of its own columns twice: a label is determined by its row
 together with its column. -/


### PR DESCRIPTION
This PR proves **James's submodule theorem** for the Young permutation module and deduces that the Specht module is irreducible. For a Young diagram `μ`, every subrepresentation `U` of `M^μ` satisfies `S^μ ≤ U` or `U ≤ (S^μ)^⊥`, where the orthogonal complement is taken for the tabloid form. Since that form is positive definite, the two alternatives meet only at zero, so `S^μ` is an atom of the lattice of subrepresentations of `M^μ` and therefore irreducible — over `ℚ`, in the concrete presentation of `S^μ` as the span of the polytabloids.

The engine is James's Lemma 4.6, `TauCeti.YoungTableau.exists_eq_smul_polytabloid_single`: the column antisymmetrizer `b_t` sends any `μ`-tabloid to `0` or to `± e_t`. Writing the tabloid as `σ · {t}`, the two cases are exactly the two cases of the row/column criterion already in the repository. If a row of `relabel σ t` meets a column of `t` in two distinct labels, the transposition of those labels lies in the column group of `t` while fixing the tabloid, so pushing it across turns `b_t · {s}` into its own negative. Otherwise the row-column factorization of `TauCeti.RepresentationTheory.Symmetric.Factorization` writes `σ⁻¹ = p q` with `p` in the row group and `q` in the column group; the row group is the stabilizer of `{t}`, so `{s} = q⁻¹ · {t}` and `b_t` absorbs `q⁻¹` through its sign. Linearity extends this to all of `M^μ`, and the dichotomy is then whether some `b_t` fails to annihilate some vector of `U`: if it does, `e_t` lies in `U` and with it the span of its orbit, which is all of `S^μ`; if it does not, self-adjointness of `b_t` for the tabloid form moves it off each `e_t = b_t · {t}` and onto the vector of `U`, where it vanishes.

Reading the criterion with the roles of the two tableaux exchanged needs one new lemma about the existing predicate, `RowMeetsColumnTwice (relabel σ t) s ↔ RowMeetsColumnTwice t (relabel σ⁻¹ s)`, which is added to `Vanishing.lean` beside the definition it is about. `Specht/Module.lean` gains the `polytabloid_def` unfolding lemma its own file was using definitionally, and its module docstring now points at where the submodule theorem lives instead of only saying it is missing.

Milestone: the [Schur-Weyl roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SchurWeyl/README.md), Layer 3's "**The submodule theorem (James)**" — "For any submodule `U ≤ M^λ`, either `S^λ ≤ U` or `U ≤ (S^λ)^⊥` (the orthogonal under the tabloid bilinear form). This is the engine of irreducibility" — together with the first bullet of Layer 4, "Over `ℚ` (characteristic `0`), each `spechtModule μ` is irreducible". What remains on that path is the rest of Layer 4: the isomorphism `S^μ ≅ ℚ[Sₙ] c_t` with the already-irreducible Specht ideal, absolute irreducibility `End_{ℚ[Sₙ]} S^λ ≅ ℚ`, and the distinctness and completeness of the family.

Nothing is vendored from Mathlib and nothing is taken from any external source; the new material is built on the row-column factorization, the tabloid form, and the polytabloids already in this repository.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"james-submodule-theorem"}-->

🤖 Prepared with Claude Code
