### PR TITLE
feat: exponentiate the Banach algebra commutator

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -1,0 +1,144 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Algebra.Exponential
+public import Mathlib.Analysis.Normed.Operator.Mul
+public import Mathlib.Algebra.Lie.OfAssociative
+public import TauCeti.Geometry.Lie.Exponential.Units.Basic
+
+/-!
+# Exponentiating the commutator operator
+
+In a real Banach algebra, exponentiating the continuous commutator operator
+`y ↦ x * y - y * x` gives conjugation by `exp x`. This is the Banach-algebra shadow of the Lie-group
+identity `Ad (lieExp X) = exp (ad X)`.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main definitions
+
+* `TauCeti.Lie.continuousCommutator`: the continuous commutator operator associated to an algebra
+  element.
+
+## Main results
+
+* `TauCeti.Lie.exp_continuousCommutator_apply`: its operator exponential acts by conjugation.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The conjugation formulas".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open NormedSpace
+
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
+
+variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
+
+private def mulLeft (x : R) : R →L[ℝ] R :=
+  ContinuousLinearMap.mul ℝ R x
+
+private def mulRight (x : R) : R →L[ℝ] R :=
+  (ContinuousLinearMap.mul ℝ R).flip x
+
+omit [CompleteSpace R] in
+private theorem mulLeft_apply (x y : R) : mulLeft x y = x * y :=
+  rfl
+
+omit [CompleteSpace R] in
+private theorem mulRight_apply (x y : R) : mulRight x y = y * x :=
+  rfl
+
+omit [CompleteSpace R] in
+private theorem mulLeft_pow_apply (x y : R) (n : ℕ) :
+    (mulLeft x ^ n) y = x ^ n * y := by
+  induction n generalizing y with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, pow_succ]
+      simp only [mul_apply_eq_comp, mulLeft_apply, ih,
+        mul_assoc]
+
+omit [CompleteSpace R] in
+private theorem mulRight_pow_apply (x y : R) (n : ℕ) :
+    (mulRight x ^ n) y = y * x ^ n := by
+  induction n generalizing y with
+  | zero => simp
+  | succ n ih =>
+      rw [pow_succ, pow_succ']
+      simp only [mul_apply_eq_comp, mulRight_apply, ih,
+        mul_assoc]
+
+private theorem exp_mulLeft_apply (x y : R) :
+    exp (mulLeft x) y = exp x * y := by
+  have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
+    (exp_series_hasSum_exp' (𝕂 := ℝ) (mulLeft x))
+  have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_right y
+  apply HasSum.unique (hop.congr fun n => ?_) halg
+  simp only [map_smul, ContinuousLinearMap.apply_apply, mulLeft_pow_apply]
+  simp only [smul_mul_assoc]
+
+private theorem exp_mulRight_apply (x y : R) :
+    exp (mulRight x) y = y * exp x := by
+  have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
+    (exp_series_hasSum_exp' (𝕂 := ℝ) (mulRight x))
+  have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_left y
+  apply HasSum.unique (hop.congr fun n => ?_) halg
+  simp only [map_smul, ContinuousLinearMap.apply_apply, mulRight_pow_apply]
+  simp only [mul_smul_comm]
+
+/-- The continuous endomorphism `y ↦ x * y - y * x`. -/
+def continuousCommutator (x : R) : R →L[ℝ] R :=
+  mulLeft x - mulRight x
+
+omit [CompleteSpace R] in
+@[simp]
+theorem continuousCommutator_apply (x y : R) :
+    continuousCommutator x y = x * y - y * x := by
+  rw [continuousCommutator]
+  rfl
+
+/-- Exponentiating the continuous commutator operator gives conjugation by the algebra
+exponential. -/
+theorem exp_continuousCommutator_apply (x y : R) :
+    exp (continuousCommutator x) y = exp x * y * exp (-x) := by
+  have hcomm : Commute (mulLeft x) (-mulRight x) := by
+    rw [Commute]
+    ext z
+    simp only [mul_apply_eq_comp, neg_apply, mulLeft_apply,
+      mulRight_apply]
+    simp [mul_assoc]
+  rw [continuousCommutator, sub_eq_add_neg, exp_add_of_commute hcomm]
+  change exp (mulLeft x) (exp (-mulRight x) y) = _
+  have hneg : -mulRight x = mulRight (-x) := by
+    ext z
+    simp [mulRight_apply]
+  rw [hneg, exp_mulRight_apply, exp_mulLeft_apply, mul_assoc]
+
+section AlgebraicAdjoint
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+omit [CompleteSpace R] in
+/-- The continuous commutator is the bounded realization of Mathlib's algebraic adjoint map. -/
+theorem continuousCommutator_toLinearMap (x : R) :
+    (continuousCommutator x).toLinearMap = LieAlgebra.ad ℝ R x := by
+  ext y
+  change continuousCommutator x y = LieAlgebra.ad ℝ R x y
+  rw [continuousCommutator_apply, LieAlgebra.ad_apply,
+    LieRing.of_associative_ring_bracket]
+
+end AlgebraicAdjoint
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -71,17 +71,15 @@ omit [CompleteSpace R] in
 private theorem mulLeft_pow_apply (x y : R) (n : ℕ) :
     ((ContinuousLinearMap.mul ℝ R x) ^ n) y = x ^ n * y := by
   -- Transport Mathlib's linear-map power identity through the explicit bundling boundary.
-  change (((ContinuousLinearMap.mul ℝ R x) ^ n).toLinearMap) y = x ^ n * y
-  rw [ContinuousLinearMap.toLinearMap_pow, mulLeft_toLinearMap, LinearMap.pow_mulLeft,
-    LinearMap.mulLeft_apply]
+  rw [← ContinuousLinearMap.coe_coe, ContinuousLinearMap.toLinearMap_pow,
+    mulLeft_toLinearMap, LinearMap.pow_mulLeft, LinearMap.mulLeft_apply]
 
 omit [CompleteSpace R] in
 private theorem mulRight_pow_apply (x y : R) (n : ℕ) :
     (((ContinuousLinearMap.mul ℝ R).flip x) ^ n) y = y * x ^ n := by
   -- Transport Mathlib's linear-map power identity through the explicit bundling boundary.
-  change ((((ContinuousLinearMap.mul ℝ R).flip x) ^ n).toLinearMap) y = y * x ^ n
-  rw [ContinuousLinearMap.toLinearMap_pow, mulRight_toLinearMap, LinearMap.pow_mulRight,
-    LinearMap.mulRight_apply]
+  rw [← ContinuousLinearMap.coe_coe, ContinuousLinearMap.toLinearMap_pow,
+    mulRight_toLinearMap, LinearMap.pow_mulRight, LinearMap.mulRight_apply]
 
 /-- Exponentiating the bounded left-multiplication operator gives left multiplication by the
 algebra exponential. -/
@@ -91,7 +89,7 @@ theorem exp_mulLeft_apply (x y : R) :
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
     (exp_series_hasSum_exp' (𝕂 := ℝ) (ContinuousLinearMap.mul ℝ R x))
   have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_right y
-  apply HasSum.unique (hop.congr fun n => ?_) halg
+  apply HasSum.unique (hop.congr_fun fun n => ?_) halg
   simp only [map_smul, ContinuousLinearMap.apply_apply, mulLeft_pow_apply]
   simp only [smul_mul_assoc]
 
@@ -103,7 +101,7 @@ theorem exp_mulRight_apply (x y : R) :
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
     (exp_series_hasSum_exp' (𝕂 := ℝ) ((ContinuousLinearMap.mul ℝ R).flip x))
   have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_left y
-  apply HasSum.unique (hop.congr fun n => ?_) halg
+  apply HasSum.unique (hop.congr_fun fun n => ?_) halg
   simp only [map_smul, ContinuousLinearMap.apply_apply, mulRight_pow_apply]
   simp only [mul_smul_comm]
 

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -7,14 +7,14 @@ module
 public import Mathlib.Analysis.Normed.Algebra.Exponential
 public import Mathlib.Analysis.Normed.Operator.Mul
 public import Mathlib.Algebra.Lie.OfAssociative
-public import TauCeti.Geometry.Lie.Exponential.Units.Basic
 
 /-!
 # Exponentiating the commutator operator
 
 In a real Banach algebra, exponentiating the continuous commutator operator
 `y ↦ x * y - y * x` gives conjugation by `exp x`. This is the Banach-algebra shadow of the Lie-group
-identity `Ad (lieExp X) = exp (ad X)`.
+identity `Ad (lieExp X) = exp (ad X)`. The final result identifies the underlying linear map of the
+bounded commutator with Mathlib's `LieAlgebra.ad` for the associative-ring Lie bracket.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
@@ -26,7 +26,12 @@ This advances Deliverable A, Layer 1 of
 
 ## Main results
 
+* `TauCeti.Lie.exp_mulLeft_apply`: exponentiating left multiplication acts by `exp x` on the left.
+* `TauCeti.Lie.exp_mulRight_apply`: the analogous right-multiplication identity.
 * `TauCeti.Lie.exp_continuousCommutator_apply`: its operator exponential acts by conjugation.
+* `TauCeti.Lie.exp_continuousCommutator`: the corresponding equality of bounded operators.
+* `TauCeti.Lie.continuousCommutator_toLinearMap`: its underlying linear map is Mathlib's
+  `LieAlgebra.ad`.
 
 ## References
 
@@ -42,102 +47,98 @@ namespace TauCeti.Lie
 
 open NormedSpace
 
-attribute [local instance] TauCeti.normedAlgebraRatOfReal
-
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-private def mulLeft (x : R) : R →L[ℝ] R :=
-  ContinuousLinearMap.mul ℝ R x
-
-private def mulRight (x : R) : R →L[ℝ] R :=
-  (ContinuousLinearMap.mul ℝ R).flip x
-
-omit [CompleteSpace R] in
-private theorem mulLeft_apply (x y : R) : mulLeft x y = x * y :=
-  rfl
-
-omit [CompleteSpace R] in
-private theorem mulRight_apply (x y : R) : mulRight x y = y * x :=
-  rfl
+/-- The rational scalar restriction used by Mathlib's exponential API in this module. -/
+noncomputable local instance normedAlgebraRat : NormedAlgebra ℚ R :=
+  .restrictScalars ℚ ℝ R
 
 omit [CompleteSpace R] in
 private theorem mulLeft_pow_apply (x y : R) (n : ℕ) :
-    (mulLeft x ^ n) y = x ^ n * y := by
-  induction n generalizing y with
-  | zero => simp
-  | succ n ih =>
-      rw [pow_succ, pow_succ]
-      simp only [mul_apply_eq_comp, mulLeft_apply, ih,
-        mul_assoc]
+    ((ContinuousLinearMap.mul ℝ R x) ^ n) y = x ^ n * y := by
+  -- Transport Mathlib's linear-map power identity through the underlying linear map.
+  change (((ContinuousLinearMap.mul ℝ R x) ^ n).toLinearMap) y = x ^ n * y
+  rw [ContinuousLinearMap.toLinearMap_pow]
+  exact LinearMap.congr_fun (LinearMap.pow_mulLeft ℝ R x n) y
 
 omit [CompleteSpace R] in
 private theorem mulRight_pow_apply (x y : R) (n : ℕ) :
-    (mulRight x ^ n) y = y * x ^ n := by
-  induction n generalizing y with
-  | zero => simp
-  | succ n ih =>
-      rw [pow_succ, pow_succ']
-      simp only [mul_apply_eq_comp, mulRight_apply, ih,
-        mul_assoc]
+    (((ContinuousLinearMap.mul ℝ R).flip x) ^ n) y = y * x ^ n := by
+  -- Transport Mathlib's linear-map power identity through the underlying linear map.
+  change ((((ContinuousLinearMap.mul ℝ R).flip x) ^ n).toLinearMap) y = y * x ^ n
+  rw [ContinuousLinearMap.toLinearMap_pow]
+  exact LinearMap.congr_fun (LinearMap.pow_mulRight ℝ R x n) y
 
-private theorem exp_mulLeft_apply (x y : R) :
-    exp (mulLeft x) y = exp x * y := by
+/-- Exponentiating the bounded left-multiplication operator gives left multiplication by the
+algebra exponential. -/
+theorem exp_mulLeft_apply (x y : R) :
+    exp (ContinuousLinearMap.mul ℝ R x) y = exp x * y := by
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
-    (exp_series_hasSum_exp' (𝕂 := ℝ) (mulLeft x))
+    (exp_series_hasSum_exp' (𝕂 := ℝ) (ContinuousLinearMap.mul ℝ R x))
   have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_right y
   apply HasSum.unique (hop.congr fun n => ?_) halg
   simp only [map_smul, ContinuousLinearMap.apply_apply, mulLeft_pow_apply]
   simp only [smul_mul_assoc]
 
-private theorem exp_mulRight_apply (x y : R) :
-    exp (mulRight x) y = y * exp x := by
+/-- Exponentiating the bounded right-multiplication operator gives right multiplication by the
+algebra exponential. -/
+theorem exp_mulRight_apply (x y : R) :
+    exp ((ContinuousLinearMap.mul ℝ R).flip x) y = y * exp x := by
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
-    (exp_series_hasSum_exp' (𝕂 := ℝ) (mulRight x))
+    (exp_series_hasSum_exp' (𝕂 := ℝ) ((ContinuousLinearMap.mul ℝ R).flip x))
   have halg := (exp_series_hasSum_exp' (𝕂 := ℝ) x).mul_left y
   apply HasSum.unique (hop.congr fun n => ?_) halg
   simp only [map_smul, ContinuousLinearMap.apply_apply, mulRight_pow_apply]
   simp only [mul_smul_comm]
 
-/-- The continuous endomorphism `y ↦ x * y - y * x`. -/
-def continuousCommutator (x : R) : R →L[ℝ] R :=
-  mulLeft x - mulRight x
+/-- The continuous-linear family of endomorphisms `y ↦ x * y - y * x`. -/
+def continuousCommutator : R →L[ℝ] R →L[ℝ] R :=
+  ContinuousLinearMap.mul ℝ R - (ContinuousLinearMap.mul ℝ R).flip
 
 omit [CompleteSpace R] in
 @[simp]
 theorem continuousCommutator_apply (x y : R) :
     continuousCommutator x y = x * y - y * x := by
-  rw [continuousCommutator]
-  rfl
+  simp [continuousCommutator]
 
 /-- Exponentiating the continuous commutator operator gives conjugation by the algebra
 exponential. -/
+@[simp]
 theorem exp_continuousCommutator_apply (x y : R) :
     exp (continuousCommutator x) y = exp x * y * exp (-x) := by
-  have hcomm : Commute (mulLeft x) (-mulRight x) := by
-    rw [Commute]
-    ext z
-    simp only [mul_apply_eq_comp, neg_apply, mulLeft_apply,
-      mulRight_apply]
-    simp [mul_assoc]
-  rw [continuousCommutator, sub_eq_add_neg, exp_add_of_commute hcomm]
-  change exp (mulLeft x) (exp (-mulRight x) y) = _
-  have hneg : -mulRight x = mulRight (-x) := by
-    ext z
-    simp [mulRight_apply]
+  let L := ContinuousLinearMap.mul ℝ R x
+  let R' := (ContinuousLinearMap.mul ℝ R).flip x
+  have hcomm : Commute L R' := by
+    apply ContinuousLinearMap.ext
+    intro z
+    exact LinearMap.congr_fun (LinearMap.commute_mulLeft_right x x).eq z
+  have hcommutator : continuousCommutator x = L - R' := rfl
+  rw [hcommutator, sub_eq_add_neg, exp_add_of_commute hcomm.neg_right,
+    mul_apply_eq_comp]
+  have hneg : -R' = (ContinuousLinearMap.mul ℝ R).flip (-x) := by
+    simpa only [R'] using (map_neg (ContinuousLinearMap.mul ℝ R).flip x).symm
   rw [hneg, exp_mulRight_apply, exp_mulLeft_apply, mul_assoc]
+
+/-- Exponentiating the continuous commutator gives the bounded conjugation operator. -/
+theorem exp_continuousCommutator (x : R) :
+    exp (continuousCommutator x) =
+      ContinuousLinearMap.mulLeftRight ℝ R (exp x) (exp (-x)) := by
+  ext y
+  simp
 
 section AlgebraicAdjoint
 
 attribute [local instance 100] LieRing.ofAssociativeRing
 
 omit [CompleteSpace R] in
-/-- The continuous commutator is the bounded realization of Mathlib's algebraic adjoint map. -/
+/-- The continuous commutator is the bounded realization of Mathlib's algebraic adjoint map for
+the ring-commutator bracket supplied by `LieRing.ofAssociativeRing`. Callers who restate the
+right-hand side should enable that instance locally. -/
 theorem continuousCommutator_toLinearMap (x : R) :
     (continuousCommutator x).toLinearMap = LieAlgebra.ad ℝ R x := by
+  rw [LieAlgebra.ad_eq_lmul_left_sub_lmul_right]
   ext y
-  change continuousCommutator x y = LieAlgebra.ad ℝ R x y
-  rw [continuousCommutator_apply, LieAlgebra.ad_apply,
-    LieRing.of_associative_ring_bracket]
+  simp [continuousCommutator]
 
 end AlgebraicAdjoint
 

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -28,6 +28,8 @@ This advances Deliverable A, Layer 1 of
 
 * `TauCeti.Lie.exp_mulLeft_apply`: exponentiating left multiplication acts by `exp x` on the left.
 * `TauCeti.Lie.exp_mulRight_apply`: the analogous right-multiplication identity.
+* `TauCeti.Lie.exp_mulLeft` and `TauCeti.Lie.exp_mulRight`: the corresponding bounded-operator
+  identities.
 * `TauCeti.Lie.exp_continuousCommutator_apply`: its operator exponential acts by conjugation.
 * `TauCeti.Lie.exp_continuousCommutator`: the corresponding equality of bounded operators.
 * `TauCeti.Lie.continuousCommutator_toLinearMap`: its underlying linear map is Mathlib's
@@ -50,27 +52,40 @@ open NormedSpace
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
 /-- The rational scalar restriction used by Mathlib's exponential API in this module. -/
-noncomputable local instance normedAlgebraRat : NormedAlgebra ℚ R :=
+private noncomputable local instance normedAlgebraRat : NormedAlgebra ℚ R :=
   .restrictScalars ℚ ℝ R
+
+omit [CompleteSpace R] in
+private theorem mulLeft_toLinearMap (x : R) :
+    (ContinuousLinearMap.mul ℝ R x).toLinearMap = LinearMap.mulLeft ℝ x := by
+  ext y
+  simp
+
+omit [CompleteSpace R] in
+private theorem mulRight_toLinearMap (x : R) :
+    ((ContinuousLinearMap.mul ℝ R).flip x).toLinearMap = LinearMap.mulRight ℝ x := by
+  ext y
+  simp
 
 omit [CompleteSpace R] in
 private theorem mulLeft_pow_apply (x y : R) (n : ℕ) :
     ((ContinuousLinearMap.mul ℝ R x) ^ n) y = x ^ n * y := by
-  -- Transport Mathlib's linear-map power identity through the underlying linear map.
+  -- Transport Mathlib's linear-map power identity through the explicit bundling boundary.
   change (((ContinuousLinearMap.mul ℝ R x) ^ n).toLinearMap) y = x ^ n * y
-  rw [ContinuousLinearMap.toLinearMap_pow]
-  exact LinearMap.congr_fun (LinearMap.pow_mulLeft ℝ R x n) y
+  rw [ContinuousLinearMap.toLinearMap_pow, mulLeft_toLinearMap, LinearMap.pow_mulLeft,
+    LinearMap.mulLeft_apply]
 
 omit [CompleteSpace R] in
 private theorem mulRight_pow_apply (x y : R) (n : ℕ) :
     (((ContinuousLinearMap.mul ℝ R).flip x) ^ n) y = y * x ^ n := by
-  -- Transport Mathlib's linear-map power identity through the underlying linear map.
+  -- Transport Mathlib's linear-map power identity through the explicit bundling boundary.
   change ((((ContinuousLinearMap.mul ℝ R).flip x) ^ n).toLinearMap) y = y * x ^ n
-  rw [ContinuousLinearMap.toLinearMap_pow]
-  exact LinearMap.congr_fun (LinearMap.pow_mulRight ℝ R x n) y
+  rw [ContinuousLinearMap.toLinearMap_pow, mulRight_toLinearMap, LinearMap.pow_mulRight,
+    LinearMap.mulRight_apply]
 
 /-- Exponentiating the bounded left-multiplication operator gives left multiplication by the
 algebra exponential. -/
+@[simp]
 theorem exp_mulLeft_apply (x y : R) :
     exp (ContinuousLinearMap.mul ℝ R x) y = exp x * y := by
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
@@ -82,6 +97,7 @@ theorem exp_mulLeft_apply (x y : R) :
 
 /-- Exponentiating the bounded right-multiplication operator gives right multiplication by the
 algebra exponential. -/
+@[simp]
 theorem exp_mulRight_apply (x y : R) :
     exp ((ContinuousLinearMap.mul ℝ R).flip x) y = y * exp x := by
   have hop := (ContinuousLinearMap.apply ℝ R y).hasSum
@@ -90,6 +106,21 @@ theorem exp_mulRight_apply (x y : R) :
   apply HasSum.unique (hop.congr fun n => ?_) halg
   simp only [map_smul, ContinuousLinearMap.apply_apply, mulRight_pow_apply]
   simp only [mul_smul_comm]
+
+/-- Exponentiating the bounded left-multiplication operator gives the operator of left
+multiplication by the algebra exponential. -/
+theorem exp_mulLeft (x : R) :
+    exp (ContinuousLinearMap.mul ℝ R x) = ContinuousLinearMap.mul ℝ R (exp x) := by
+  ext y
+  simp
+
+/-- Exponentiating the bounded right-multiplication operator gives the operator of right
+multiplication by the algebra exponential. -/
+theorem exp_mulRight (x : R) :
+    exp ((ContinuousLinearMap.mul ℝ R).flip x) =
+      (ContinuousLinearMap.mul ℝ R).flip (exp x) := by
+  ext y
+  simp
 
 /-- The continuous-linear family of endomorphisms `y ↦ x * y - y * x`. -/
 def continuousCommutator : R →L[ℝ] R →L[ℝ] R :=
@@ -109,10 +140,11 @@ theorem exp_continuousCommutator_apply (x y : R) :
   let L := ContinuousLinearMap.mul ℝ R x
   let R' := (ContinuousLinearMap.mul ℝ R).flip x
   have hcomm : Commute L R' := by
-    apply ContinuousLinearMap.ext
-    intro z
-    exact LinearMap.congr_fun (LinearMap.commute_mulLeft_right x x).eq z
-  have hcommutator : continuousCommutator x = L - R' := rfl
+    ext z
+    simp only [L, R', mul_apply_eq_comp, ContinuousLinearMap.mul_apply',
+      ContinuousLinearMap.flip_apply, mul_assoc]
+  have hcommutator : continuousCommutator x = L - R' := by
+    rw [continuousCommutator, sub_apply]
   rw [hcommutator, sub_eq_add_neg, exp_add_of_commute hcomm.neg_right,
     mul_apply_eq_comp]
   have hneg : -R' = (ContinuousLinearMap.mul ℝ R).flip (-x) := by


### PR DESCRIPTION
## Goal

Establish the Banach-algebra model of the Layer 1 identity `Ad (lieExp X) = exp (ad X)`: exponentiating the bounded commutator operator must act by conjugation with the algebra exponential.

## Why the construction proves the identity

Left and right multiplication are bounded operators whose powers act by multiplication with the corresponding algebra powers, so their operator exponentials act by multiplication with `exp x`. These two operators commute, and the commutator operator is their difference. The exponential addition law therefore factors its operator exponential into left multiplication by `exp x` and right multiplication by `exp (-x)`, yielding conjugation on every argument.

Identifying the underlying linear map with Mathlib’s `LieAlgebra.ad` connects this analytic result to the roadmap-facing Lie-algebra notation without introducing a duplicate algebraic adjoint.

This advances [RepresentationTheory/LieGroups, Deliverable A, Layer 1, “The conjugation formulas”](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md).

## Validation

- `lake env lean TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean`
- `lake build TauCeti.Geometry.Lie.Adjoint.OperatorExponential`
- `lake build` (6,680 jobs)
- `scripts/lint-env.sh` (2,057 declarations documented; no new violations)
- `git diff --check`

Roadmap: RepresentationTheory
