### PR TITLE
feat(HewittSavage): the zero-one law for an i.i.d. product law

### DIFF
--- a/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/HewittSavage.lean
@@ -13,6 +13,7 @@ public import Mathlib.MeasureTheory.Constructions.Cylinders
 import Mathlib.MeasureTheory.Measure.MeasuredSets
 import Mathlib.MeasureTheory.Constructions.ProjectiveFamilyContent
 import Mathlib.Probability.Independence.ZeroOne
+import Mathlib.Probability.Independence.InfinitePi
 
 /-!
 # The Hewitt–Savage zero-one law
@@ -387,6 +388,28 @@ theorem hewittSavage_trivial_of_iIndep {μ : Measure Ω} {X : ℕ → Ω → α}
   exact measure_eq_zero_or_one_of_exchangeableSigma hexch
     (fun {_F _G} hFG {_S} hS {_T} hT =>
       measure_pathLaw_inter_cylinder_of_disjoint hX h_indep hFG hS hT) hs
+
+/-- **The zero-one law for an i.i.d. product law.** Every exchangeable event has probability `0` or
+`1` under `P^{⊗ℕ}`.
+
+This is `hewittSavage_trivial_of_iIndep` read for the product law itself rather than for a process
+carried by some other measure: under `P^{⊗ℕ}` the coordinates are independent and identically
+distributed, and the path law of the coordinate process is the product law back again. -/
+theorem exchangeableSigma_trivial_of_infinitePi (P : ProbabilityMeasure α) {s : Set (ℕ → α)}
+    (hs : MeasurableSet[exchangeableSigma α] s) :
+    (Measure.infinitePi fun _ : ℕ => (P : Measure α)) s = 0 ∨
+      (Measure.infinitePi fun _ : ℕ => (P : Measure α)) s = 1 := by
+  let ρ := Measure.infinitePi fun _ : ℕ => (P : Measure α)
+  have hindep : ProbabilityTheory.iIndepFun (fun n (x : ℕ → α) => x n) ρ :=
+    ProbabilityTheory.iIndepFun_infinitePi (P := fun _ : ℕ => (P : Measure α))
+      (X := fun _ x => x) fun _ => measurable_id
+  have hident : ∀ n, ProbabilityTheory.IdentDistrib
+      (fun x : ℕ → α => x n) (fun x => x 0) ρ ρ := fun n =>
+    ⟨(measurable_pi_apply n).aemeasurable, (measurable_pi_apply 0).aemeasurable, by
+      simp [ρ, Measure.infinitePi_map_eval]⟩
+  have hpath : pathLaw ρ (fun n (x : ℕ → α) => x n) = ρ := by simp [pathLaw_def]
+  have hzeroOne := hewittSavage_trivial_of_iIndep hindep hident hs
+  rwa [hpath] at hzeroOne
 
 end HewittSavage
 

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -118,10 +118,8 @@ theorem ergodic_shift_infinitePi_const (P : ProbabilityMeasure α) :
   refine { hexchLaw.contractableLaw.measurePreserving_shift with aeconst_set := ?_ }
   intro s hs hs_shift
   have hs_inv : MeasurableSet[MeasurableSpace.invariants (shift α)] s := ⟨hs, hs_shift⟩
-  have hs_exch : MeasurableSet[exchangeableSigma α] s :=
-    invariants_shift_le_exchangeableSigma (α := α) s hs_inv
-  have hzeroOne := hewittSavage_trivial_of_iIndep hindep hident hs_exch
-  rw [hpath] at hzeroOne
+  have hzeroOne := exchangeableSigma_trivial_of_infinitePi P
+    (invariants_shift_le_exchangeableSigma (α := α) s hs_inv)
   refine eventuallyConst_set.2 ?_
   rcases hzeroOne with hzero | hone
   · exact Or.inr (ae_iff.mpr (by simpa using hzero))


### PR DESCRIPTION
```lean
theorem exchangeableSigma_trivial_of_infinitePi (P : ProbabilityMeasure α) {s : Set (ℕ → α)}
    (hs : MeasurableSet[exchangeableSigma α] s) :
    (Measure.infinitePi fun _ : ℕ => (P : Measure α)) s = 0 ∨
      (Measure.infinitePi fun _ : ℕ => (P : Measure α)) s = 1
```

`hewittSavage_trivial_of_iIndep` is stated for a process `X` carried by some other measure `μ`.
This reads it for the product law itself: under `P^{⊗ℕ}` the coordinates are independent
(`iIndepFun_infinitePi`) and identically distributed (`Measure.infinitePi_map_eval`), and the path
law of the coordinate process is the product law back again, so the zero-one law applies directly
to `P^{⊗ℕ}`.

`ergodic_shift_infinitePi_const` in `PathSpace/Law/Extreme.lean` was already running this argument
inline, restricted to shift-invariant events via `invariants_shift_le_exchangeableSigma`. It now
calls the general lemma instead, dropping the duplicated `iIndepFun` / `IdentDistrib` / `pathLaw`
bookkeeping — a net simplification there.

Roadmap: Exchangeability

Advances `TauCetiRoadmap/Exchangeability/README.md`, **Layer 6**, the
`exchangeableSigma_trivial_iff_iid` target: this is the product-to-zero-one direction, which the
roadmap identifies as the easy half ("The product-to-zero–one direction is Hewitt–Savage"). The
converse — that triviality of `exchangeableSigma` forces the mixing law to be Dirac — is the
substantive half and is deliberately left to a follow-up; the roadmap notes explicitly that
`mixedIID_mixingLaw_unique` alone does not give it.

Intention: TauCetiProject/TauCetiRoadmap#160 (claimed).

🤖 Directed by Cameron Freer, drafted by Opus 5, reviewed by GPT 5.6 Sol