### PR TITLE
feat: prove the exact Duhamel formula for the Banach exponential

### DIFF
--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.SpecialFunctions.Exponential
-public import Mathlib.Analysis.Calculus.Deriv.Mul
-public import Mathlib.Analysis.Calculus.Deriv.Shift
+import Mathlib.Analysis.Calculus.Deriv.Mul
+import Mathlib.Analysis.Calculus.Deriv.Shift
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 
 /-!

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -18,13 +18,16 @@ every increment.
 
 ## Main result
 
+* `intervalIntegrable_exp_add_sub_exp`: the Duhamel integrand is interval integrable.
 * `exp_add_sub_exp_eq_integral`: `exp (x + h) - exp x` is the integral of
   `exp ((1 - t) (x + h)) * h * exp (t x)` over the unit interval.
 
 ## References
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
-  Deliverable A, Layer 1, "Differential of the exponential".
+  Deliverable A, Layer 1, "The conjugation formulas".
+* R. M. Wilcox, *Exponential Operators and Parameter Differentiation in Quantum Physics*, Journal
+  of Mathematical Physics 8 (1967), 962–982.
 -/
 
 public section
@@ -33,13 +36,16 @@ open NormedSpace MeasureTheory
 
 noncomputable section
 
+namespace TauCeti
+
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
 
-/-- The rational normed algebra structure obtained by restricting the real scalars. -/
-noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ A :=
+/-- `NormedSpace.exp_continuous` requires a rational normed algebra structure; obtain it by
+restricting the real scalars. -/
+private noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ A :=
   .restrictScalars ℚ ℝ A
 
-private theorem hasDerivAt_duhamelPath (x h : A) (t : ℝ) :
+private theorem hasDerivAt_exp_smul_mul_exp_smul (x h : A) (t : ℝ) :
     HasDerivAt
       (fun s : ℝ ↦ exp ((1 - s) • (x + h)) * exp (s • x))
       (-(exp ((1 - t) • (x + h)) * h * exp (t • x))) t := by
@@ -51,10 +57,13 @@ private theorem hasDerivAt_duhamelPath (x h : A) (t : ℝ) :
       (fun s : ℝ ↦ exp (s • x))
       (x * exp (t • x)) t :=
     hasDerivAt_exp_smul_const' x t
-  convert hleft.mul hright using 1
-  · ext s
-    rfl
-  · noncomm_ring
+  exact (hleft.fun_mul hright).congr_deriv (by noncomm_ring)
+
+/-- The integrand in Duhamel's finite-increment formula is interval integrable. -/
+theorem intervalIntegrable_exp_add_sub_exp (x h : A) :
+    IntervalIntegrable
+      (fun t : ℝ ↦ exp ((1 - t) • (x + h)) * h * exp (t • x)) volume 0 1 :=
+  Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
 
 /-- Duhamel's exact finite-increment formula for the exponential in a possibly noncommutative real
 Banach algebra. -/
@@ -65,12 +74,14 @@ theorem exp_add_sub_exp_eq_integral (x h : A) :
   let F' : ℝ → A := fun t ↦ -(exp ((1 - t) • (x + h)) * h * exp (t • x))
   have hderiv : ∀ t ∈ Set.uIcc (0 : ℝ) 1, HasDerivAt F (F' t) t := by
     intro t _ht
-    exact hasDerivAt_duhamelPath x h t
+    exact hasDerivAt_exp_smul_mul_exp_smul x h t
   have hint : IntervalIntegrable F' volume (0 : ℝ) 1 := by
-    exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
+    exact (intervalIntegrable_exp_add_sub_exp x h).neg
   have hFTC := intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint
   dsimp only [F, F'] at hFTC
   simp only [one_smul, sub_self, sub_zero, zero_smul, exp_zero, mul_one, one_mul,
     intervalIntegral.integral_neg] at hFTC
   have hneg := congrArg Neg.neg hFTC
   simpa only [neg_neg, neg_sub] using hneg.symm
+
+end TauCeti

--- a/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
@@ -1,0 +1,78 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Exponential
+public import Mathlib.Analysis.Calculus.Deriv.Mul
+public import Mathlib.Analysis.Calculus.Deriv.Shift
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+
+/-!
+# Duhamel's formula for the Banach-algebra exponential
+
+This file expresses a finite increment of the exponential in a possibly noncommutative real
+Banach algebra as an integral. Unlike a first-order derivative formula, the identity is exact for
+every increment.
+
+## Main result
+
+* `exp_add_sub_exp_eq_integral`: `exp (x + h) - exp x` is the integral of
+  `exp ((1 - t) (x + h)) * h * exp (t x)` over the unit interval.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "Differential of the exponential".
+-/
+
+public section
+
+open NormedSpace MeasureTheory
+
+noncomputable section
+
+variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
+
+noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ A :=
+  .restrictScalars ℚ ℝ A
+
+private theorem hasDerivAt_duhamelPath (x h : A) (t : ℝ) :
+    HasDerivAt
+      (fun s : ℝ ↦ exp ((1 - s) • (x + h)) * exp (s • x))
+      (-(exp ((1 - t) • (x + h)) * h * exp (t • x))) t := by
+  have hleft : HasDerivAt
+      (fun s : ℝ ↦ exp ((1 - s) • (x + h)))
+      (-(exp ((1 - t) • (x + h)) * (x + h))) t := by
+    exact (hasDerivAt_exp_smul_const (x + h) (1 - t)).comp_const_sub 1 t
+  have hright : HasDerivAt
+      (fun s : ℝ ↦ exp (s • x))
+      (exp (t • x) * x) t :=
+    hasDerivAt_exp_smul_const x t
+  convert hleft.mul hright using 1
+  · ext s
+    rfl
+  · have hcommRight : exp (t • x) * x = x * exp (t • x) :=
+      ((Commute.refl x).smul_left t).exp_left.eq
+    rw [hcommRight]
+    noncomm_ring
+
+/-- Duhamel's exact finite-increment formula for the exponential in a possibly noncommutative real
+Banach algebra. -/
+theorem exp_add_sub_exp_eq_integral (x h : A) :
+    exp (x + h) - exp x =
+      ∫ t in (0 : ℝ)..1, exp ((1 - t) • (x + h)) * h * exp (t • x) := by
+  let F : ℝ → A := fun t ↦ exp ((1 - t) • (x + h)) * exp (t • x)
+  let F' : ℝ → A := fun t ↦ -(exp ((1 - t) • (x + h)) * h * exp (t • x))
+  have hderiv : ∀ t ∈ Set.uIcc (0 : ℝ) 1, HasDerivAt F (F' t) t := by
+    intro t _ht
+    exact hasDerivAt_duhamelPath x h t
+  have hint : IntervalIntegrable F' volume (0 : ℝ) 1 := by
+    exact Continuous.intervalIntegrable (μ := volume) (by fun_prop) 0 1
+  have hFTC := intervalIntegral.integral_eq_sub_of_hasDerivAt hderiv hint
+  dsimp only [F, F'] at hFTC
+  simp only [one_smul, sub_self, sub_zero, zero_smul, exp_zero, mul_one, one_mul,
+    intervalIntegral.integral_neg] at hFTC
+  have hneg := congrArg Neg.neg hFTC
+  simpa only [neg_neg, neg_sub] using hneg.symm

--- a/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
@@ -35,6 +35,7 @@ noncomputable section
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
 
+/-- The rational normed algebra structure obtained by restricting the real scalars. -/
 noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ A :=
   .restrictScalars ℚ ℝ A
 

--- a/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Duhamel.lean
@@ -49,15 +49,12 @@ private theorem hasDerivAt_duhamelPath (x h : A) (t : ℝ) :
     exact (hasDerivAt_exp_smul_const (x + h) (1 - t)).comp_const_sub 1 t
   have hright : HasDerivAt
       (fun s : ℝ ↦ exp (s • x))
-      (exp (t • x) * x) t :=
-    hasDerivAt_exp_smul_const x t
+      (x * exp (t • x)) t :=
+    hasDerivAt_exp_smul_const' x t
   convert hleft.mul hright using 1
   · ext s
     rfl
-  · have hcommRight : exp (t • x) * x = x * exp (t • x) :=
-      ((Commute.refl x).smul_left t).exp_left.eq
-    rw [hcommRight]
-    noncomm_ring
+  · noncomm_ring
 
 /-- Duhamel's exact finite-increment formula for the exponential in a possibly noncommutative real
 Banach algebra. -/


### PR DESCRIPTION
## Summary

- prove an exact finite-increment formula for the exponential in a noncommutative real Banach algebra
- expose interval integrability of its Duhamel integrand for downstream differentiation and bounds
- keep the result independent of the later derivative-series and adjoint infrastructure

## Why

This finite-increment identity is needed to identify the derivative of the Banach-algebra exponential with the regularized adjoint factor. It advances TauCetiRoadmap/RepresentationTheory/LieGroups/README.md, Deliverable A, Layer 1, target “The conjugation formulas”, specifically the derivative-of-lieExp formula.

## Proof

1. Differentiate the path t ↦ exp ((1 - t) • (x + h)) * exp (t • x).
2. Reduce its derivative to the negative Duhamel integrand.
3. Apply the interval fundamental theorem of calculus and simplify the endpoints.

## Validation

- lake build TauCeti.Analysis.SpecialFunctions.Exponential
- lake build (6,680 jobs)
- bash scripts/lint-env.sh

Roadmap: RepresentationTheory