### PR TITLE
feat(Analysis): the boundary-tolerant logarithmic FTC

### DIFF
--- a/TauCeti/Analysis/Complex/UpperLogContinuity.lean
+++ b/TauCeti/Analysis/Complex/UpperLogContinuity.lean
@@ -18,8 +18,8 @@ touch the slit-plane boundary.
 
 ## Main declarations
 
-* `TauCeti.Complex.continuousOn_arg_im_nonneg`.
-* `TauCeti.Complex.continuousOn_log_im_nonneg`.
+* `TauCeti.continuousOn_arg_im_nonneg`.
+* `TauCeti.continuousOn_log_im_nonneg`.
 
 ## References
 
@@ -32,7 +32,7 @@ public section
 
 open Complex
 
-namespace TauCeti.Complex
+namespace TauCeti
 
 /-- The principal argument is continuous on the punctured closed upper half-plane: the
 approach is confined to nonnegative imaginary parts, where `arg` is the `arccos` of the
@@ -60,6 +60,6 @@ theorem continuousOn_log_im_nonneg :
   · exact (continuous_ofReal.continuousAt.comp_continuousWithinAt
       (continuousOn_arg_im_nonneg z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
 
-end TauCeti.Complex
+end TauCeti
 
 end

--- a/TauCeti/Analysis/Complex/UpperLogContinuity.lean
+++ b/TauCeti/Analysis/Complex/UpperLogContinuity.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.SpecialFunctions.Complex.Log
+
+/-!
+# Continuity of `arg` and `log` on the closed upper half-plane
+
+The principal argument and logarithm are continuous on the punctured closed upper
+half-plane `{z | 0 ≤ im z ∧ z ≠ 0}`. This strengthens Mathlib's continuity on the open
+slit plane: the negative real axis is allowed because the approach is confined to
+nonnegative imaginary parts, where `arg` agrees with the continuous `arccos` formula.
+It is the boundary-tolerant ingredient for logarithmic primitives along contours that
+touch the slit-plane boundary.
+
+## Main declarations
+
+* `TauCeti.Complex.continuousOn_arg_of_im_nonneg`.
+* `TauCeti.Complex.continuousOn_log_of_im_nonneg`.
+
+## References
+
+* [AINTLIB `LeanModularForms`](https://github.com/CBirkbeck/AINTLIB) — the valence-formula
+  development (`ForMathlib/ValenceFormula/WindingWeights/Common.lean`) this file ports
+  onto the current Mathlib pin.
+-/
+
+public section
+
+open Complex
+
+namespace TauCeti.Complex
+
+/-- The principal argument is continuous on the punctured closed upper half-plane: the
+approach is confined to nonnegative imaginary parts, where `arg` is the `arccos` of the
+normalized real part. -/
+theorem continuousOn_arg_of_im_nonneg :
+    ContinuousOn Complex.arg {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
+  rintro z ⟨hz_im, hz_ne⟩
+  exact ContinuousWithinAt.congr
+    ((continuous_re.continuousWithinAt.div continuous_norm.continuousWithinAt
+      (norm_ne_zero_iff.mpr hz_ne)).arccos)
+    (fun w ⟨hw_im, hw_ne⟩ ↦ Complex.arg_of_im_nonneg_of_ne_zero hw_im hw_ne)
+    (Complex.arg_of_im_nonneg_of_ne_zero hz_im hz_ne)
+
+/-- The principal logarithm is continuous on the punctured closed upper half-plane. -/
+theorem continuousOn_log_of_im_nonneg :
+    ContinuousOn Complex.log {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
+  rintro z ⟨hz_im, hz_ne⟩
+  rw [show Complex.log =
+      (fun w ↦ ↑(Real.log ‖w‖) + ↑(Complex.arg w) * Complex.I) from funext fun _ ↦ rfl]
+  refine ContinuousWithinAt.add ?_ ?_
+  · exact (continuous_ofReal.continuousAt.comp
+      ((Real.continuousAt_log (norm_ne_zero_iff.mpr hz_ne)).comp
+        continuous_norm.continuousAt)).continuousWithinAt
+  · exact (continuous_ofReal.continuousAt.comp_continuousWithinAt
+      (continuousOn_arg_of_im_nonneg z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
+
+end TauCeti.Complex
+
+end

--- a/TauCeti/Analysis/Complex/UpperLogContinuity.lean
+++ b/TauCeti/Analysis/Complex/UpperLogContinuity.lean
@@ -18,8 +18,8 @@ touch the slit-plane boundary.
 
 ## Main declarations
 
-* `TauCeti.Complex.continuousOn_arg_of_im_nonneg`.
-* `TauCeti.Complex.continuousOn_log_of_im_nonneg`.
+* `TauCeti.Complex.continuousOn_arg_im_nonneg`.
+* `TauCeti.Complex.continuousOn_log_im_nonneg`.
 
 ## References
 
@@ -37,7 +37,7 @@ namespace TauCeti.Complex
 /-- The principal argument is continuous on the punctured closed upper half-plane: the
 approach is confined to nonnegative imaginary parts, where `arg` is the `arccos` of the
 normalized real part. -/
-theorem continuousOn_arg_of_im_nonneg :
+theorem continuousOn_arg_im_nonneg :
     ContinuousOn Complex.arg {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
   rintro z ⟨hz_im, hz_ne⟩
   exact ContinuousWithinAt.congr
@@ -47,17 +47,18 @@ theorem continuousOn_arg_of_im_nonneg :
     (Complex.arg_of_im_nonneg_of_ne_zero hz_im hz_ne)
 
 /-- The principal logarithm is continuous on the punctured closed upper half-plane. -/
-theorem continuousOn_log_of_im_nonneg :
+theorem continuousOn_log_im_nonneg :
     ContinuousOn Complex.log {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
+  have hlog : Complex.log = fun w ↦ ↑(Real.log ‖w‖) + ↑(Complex.arg w) * Complex.I :=
+    funext fun w ↦ Complex.ext (by simp [Complex.log_re]) (by simp [Complex.log_im])
+  rw [hlog]
   rintro z ⟨hz_im, hz_ne⟩
-  rw [show Complex.log =
-      (fun w ↦ ↑(Real.log ‖w‖) + ↑(Complex.arg w) * Complex.I) from funext fun _ ↦ rfl]
   refine ContinuousWithinAt.add ?_ ?_
   · exact (continuous_ofReal.continuousAt.comp
       ((Real.continuousAt_log (norm_ne_zero_iff.mpr hz_ne)).comp
         continuous_norm.continuousAt)).continuousWithinAt
   · exact (continuous_ofReal.continuousAt.comp_continuousWithinAt
-      (continuousOn_arg_of_im_nonneg z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
+      (continuousOn_arg_im_nonneg z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
 
 end TauCeti.Complex
 

--- a/TauCeti/Analysis/Complex/UpperLogContinuity.lean
+++ b/TauCeti/Analysis/Complex/UpperLogContinuity.lean
@@ -18,8 +18,8 @@ touch the slit-plane boundary.
 
 ## Main declarations
 
-* `TauCeti.continuousOn_arg_im_nonneg`.
-* `TauCeti.continuousOn_log_im_nonneg`.
+* `TauCeti.continuousOn_arg_im_nonneg_ne_zero`.
+* `TauCeti.continuousOn_log_im_nonneg_ne_zero`.
 
 ## References
 
@@ -37,7 +37,8 @@ namespace TauCeti
 /-- The principal argument is continuous on the punctured closed upper half-plane: the
 approach is confined to nonnegative imaginary parts, where `arg` is the `arccos` of the
 normalized real part. -/
-theorem continuousOn_arg_im_nonneg :
+@[fun_prop]
+theorem continuousOn_arg_im_nonneg_ne_zero :
     ContinuousOn Complex.arg {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
   rintro z ⟨hz_im, hz_ne⟩
   exact ContinuousWithinAt.congr
@@ -47,7 +48,8 @@ theorem continuousOn_arg_im_nonneg :
     (Complex.arg_of_im_nonneg_of_ne_zero hz_im hz_ne)
 
 /-- The principal logarithm is continuous on the punctured closed upper half-plane. -/
-theorem continuousOn_log_im_nonneg :
+@[fun_prop]
+theorem continuousOn_log_im_nonneg_ne_zero :
     ContinuousOn Complex.log {z : ℂ | 0 ≤ z.im ∧ z ≠ 0} := by
   have hlog : Complex.log = fun w ↦ ↑(Real.log ‖w‖) + ↑(Complex.arg w) * Complex.I :=
     funext fun w ↦ Complex.ext (by simp [Complex.log_re]) (by simp [Complex.log_im])
@@ -58,7 +60,7 @@ theorem continuousOn_log_im_nonneg :
       ((Real.continuousAt_log (norm_ne_zero_iff.mpr hz_ne)).comp
         continuous_norm.continuousAt)).continuousWithinAt
   · exact (continuous_ofReal.continuousAt.comp_continuousWithinAt
-      (continuousOn_arg_im_nonneg z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
+      (continuousOn_arg_im_nonneg_ne_zero z ⟨hz_im, hz_ne⟩)).mul continuousWithinAt_const
 
 end TauCeti
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -324,6 +324,36 @@ theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : �
     _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
     _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
 
+
+/-- **The comparison logarithmic FTC on the slit plane**: for a comparison function `h`
+slit-plane-valued on the closed interval, the logarithmic integral of `g` evaluates to
+the difference of endpoint logarithms. -/
+theorem integral_deriv_div_eq_log_of_slitPlane {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
+    Complex.slitPlane_ne_zero (hh_slit t ht)
+  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) := fun t ht ↦
+    (continuousAt_clog (hh_slit t ht)).comp_continuousWithinAt (hh_cont t ht)
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ⟨ht.1.le, ht.2.le⟩)) hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
+
 end BoundaryTolerant
 
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -9,7 +9,10 @@ public import Mathlib.Analysis.Calculus.FDeriv.Analytic
 public import Mathlib.Analysis.Calculus.LogDeriv
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.Analysis.Complex.UpperLogContinuity
 public import TauCeti.Analysis.Contour.Curve.Integrability
+
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
@@ -229,5 +232,99 @@ theorem windingNumber_comp_eq_integral_logDeriv {γ : ℝ → ℂ} {h : ℂ → 
   rw [windingNumber_eq_integral_of_avoidance hcont
       (fun t ht => hne t ht) (hint.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae))]
   exact congrArg _ (intervalIntegral.integral_congr_ae hae).symm
+
+section BoundaryTolerant
+
+open MeasureTheory
+
+/-- Transport of the logarithmic integrand across an interior agreement: if `g = h` with
+equal derivatives on the open interval, the integrands agree almost everywhere on the
+interval and integrability transports. -/
+private lemma aeEq_and_intervalIntegrable_of_eqOn_Ioo {g h : ℝ → ℂ} {a b : ℝ}
+    (hab : a ≤ b) (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b) :
+    (∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t) ∧
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b := by
+  have hb_ae : ({b} : Set ℝ)ᶜ ∈ ae volume := by
+    simp [MeasureTheory.mem_ae_iff]
+  have h_congr : ∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t := by
+    filter_upwards [hb_ae] with t ht_ne_b ht_mem
+    rw [Set.uIoc_of_le hab] at ht_mem
+    obtain ⟨hval, hderiv⟩ := heq t
+      ⟨ht_mem.1, lt_of_le_of_ne ht_mem.2 fun h ↦ ht_ne_b (Set.mem_singleton_iff.mpr h)⟩
+    rw [hval, hderiv]
+  refine ⟨h_congr, hint_h.congr_ae ?_⟩
+  exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
+    (h_congr.mono fun t ht hm ↦ (ht hm).symm)
+
+/-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
+confined to the closed upper half-plane, nonvanishing, and slit-plane-valued on the
+interior, the logarithmic integral of `g` evaluates to the difference of logarithms —
+even when the endpoint values sit on the slit-plane boundary. -/
+theorem integral_deriv_div_eq_log_of_im_nonneg {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_im_nn : ∀ t ∈ Set.Icc a b, 0 ≤ (h t).im)
+    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (hh_slit : ∀ t ∈ Set.Ioo a b, h t ∈ Complex.slitPlane)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
+    TauCeti.continuousOn_log_im_nonneg.comp hh_cont
+      fun t ht ↦ ⟨hh_im_nn t ht, hh_ne t ht⟩
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht)) hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
+
+/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
+confined to the closed lower half-plane with strictly negative interior imaginary part,
+the logarithmic integral evaluates against the negated arguments. -/
+theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
+    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (hh_im_neg : ∀ t ∈ Set.Ioo a b, (h t).im < 0)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t =
+      Complex.log (-(g b)) - Complex.log (-(g a)) := by
+  have hnh_log_cont : ContinuousOn (fun t ↦ Complex.log (-(h t))) (Set.Icc a b) :=
+    TauCeti.continuousOn_log_im_nonneg.comp hh_cont.neg fun t ht ↦
+      ⟨by simpa using hh_im_np t ht, neg_ne_zero.mpr (hh_ne t ht)⟩
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hnh_log_cont
+    (fun t ht ↦ by
+      have hslit : -(h t) ∈ Complex.slitPlane := Complex.mem_slitPlane_iff.mpr
+        (Or.inr (by simpa using ne_of_lt (hh_im_neg t ht)))
+      have := (hh_diff t ht).hasDerivAt.neg.clog_real hslit
+      exact (show -deriv h t / -h t = deriv h t / h t by rw [neg_div_neg_eq]) ▸ this)
+    hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
+    _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
+
+end BoundaryTolerant
+
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -273,7 +273,7 @@ theorem integral_deriv_div_eq_log_of_im_nonneg {g h : ℝ → ℂ} {a b : ℝ} (
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
   have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
-    TauCeti.continuousOn_log_im_nonneg.comp hh_cont
+    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont
       fun t ht ↦ ⟨hh_im_nn t ht, hh_ne t ht⟩
   have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
     ((hh_deriv_cont.div hh_cont hh_ne).mono
@@ -304,7 +304,7 @@ theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : �
     ∫ t in a..b, deriv g t / g t =
       Complex.log (-(g b)) - Complex.log (-(g a)) := by
   have hnh_log_cont : ContinuousOn (fun t ↦ Complex.log (-(h t))) (Set.Icc a b) :=
-    TauCeti.continuousOn_log_im_nonneg.comp hh_cont.neg fun t ht ↦
+    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont.neg fun t ht ↦
       ⟨by simpa using hh_im_np t ht, neg_ne_zero.mpr (hh_ne t ht)⟩
   have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
     ((hh_deriv_cont.div hh_cont hh_ne).mono


### PR DESCRIPTION
<!--tauceti-target:v1 {"area":"ModularForms","target":"valence-formula","layer":"L1"}-->

The boundary-tolerant logarithmic fundamental theorem of calculus, with its continuity
prerequisite:

**`TauCeti/Analysis/Complex/UpperLogContinuity.lean`** — the principal argument and
logarithm are continuous on the punctured **closed** upper half-plane
`{z | 0 ≤ im z ∧ z ≠ 0}`:

- `TauCeti.continuousOn_arg_im_nonneg_ne_zero`
- `TauCeti.continuousOn_log_im_nonneg_ne_zero`

**`TauCeti/Analysis/Contour/LogDerivFTC.lean` (§BoundaryTolerant)** — three
comparison-form logarithmic FTCs for `∫ g'/g` against a smooth comparison `h` agreeing
with `g` on the open interval:

- `integral_deriv_div_eq_log_of_slitPlane` (slit-plane confinement),
- `integral_deriv_div_eq_log_of_im_nonneg` (closed **upper** half-plane confinement —
  endpoint values may sit on the negative-real boundary),
- `integral_deriv_div_eq_log_neg_of_im_nonpos` (closed lower half-plane, against negated
  arguments).

The upper and lower forms consume the closed-half-plane continuity verbatim; slit-plane
continuity is insufficient because the valence contour crosses the branch cut of
`log(γ(t) - i)` at the left vertical's height-1 crossing and touches it at
`γ(t) - (ρ+1) = -1`. These are the fundamental theorems behind the Hungerbühler–Wasem
winding weights of the on-contour elliptic points (ModularForms roadmap, Layer 1), whose
telescope evaluations apply them piecewise along the fundamental-domain boundary.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)
