### PR TITLE
refactor(SmithNormalForm): decompose the positive-determinant diagonalization

### DIFF
--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -172,16 +172,17 @@ private theorem isUnit_det_of_columns (b : Module.Basis (Fin n) ℤ (Fin n → �
     simp only [Matrix.of_apply]
     rw [e.toMatrix_apply, he, Pi.basisFun_repr]
   rw [hb]
-  simpa [Module.Basis.det_apply] using e.isUnit_det b
+  have := e.invertibleToMatrix b
+  exact Matrix.isUnit_det_of_invertible _
 
 /-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
 `A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`
 back along it is the family `r`. -/
-private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ) (hdet_ne : A.det ≠ 0)
+private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ)
+    (hinj : Function.Injective A.mulVecLin)
     {ab' : Module.Basis (Fin n) ℤ ↥(LinearMap.range A.mulVecLin)} {r : Fin n → Fin n → ℤ}
     (hr : ∀ i, A.mulVecLin (r i) = ↑(ab' i)) :
     IsUnit (Matrix.of (fun k j ↦ r j k) : Matrix (Fin n) (Fin n) ℤ).det := by
-  have hinj := mulVecLin_injective_of_det_ne_zero A hdet_ne
   set r_basis : Module.Basis (Fin n) ℤ (Fin n → ℤ) :=
     ab'.map (LinearEquiv.ofInjective A.mulVecLin hinj).symm with hr_basis
   have hrb : ⇑r_basis = r := funext fun i ↦ hinj (by
@@ -226,7 +227,8 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
     mul_of_columns_eq_of_mulVec A hkey
   have hP_unit : IsUnit P_mat.det := isUnit_det_of_columns b'
-  have hQ_unit : IsUnit Q_mat.det := isUnit_det_of_mulVec_columns A hdet_ne hr
+  have hQ_unit : IsUnit Q_mat.det :=
+    isUnit_det_of_mulVec_columns A (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr
   have h_diag_eq : P_mat⁻¹ * A * Q_mat = Matrix.diagonal a := by
     rw [Matrix.mul_assoc, hmat_eq, ← Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hP_unit,
       Matrix.one_mul]

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -177,7 +177,9 @@ private theorem isUnit_det_of_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fi
   rw [← hrb]
   set e := Pi.basisFun ℤ (Fin n) with he
   have hb : (Matrix.of (fun k j ↦ r_basis j k) : Matrix (Fin n) (Fin n) ℤ)
-      = e.toMatrix r_basis := rfl
+      = e.toMatrix r_basis := by
+    rw [he]
+    exact (congrFun Module.Basis.coePiBasisFun.toMatrix_eq_transpose _).symm
   rw [hb]
   simpa [Module.Basis.det_apply] using e.isUnit_det r_basis
 
@@ -217,7 +219,9 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
     mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul A hkey
   have hP_unit : IsUnit P_mat.det := by
     set e := Pi.basisFun ℤ (Fin n) with he
-    have hb : P_mat = e.toMatrix b' := rfl
+    have hb : P_mat = e.toMatrix b' := by
+      rw [he]
+      exact (congrFun Module.Basis.coePiBasisFun.toMatrix_eq_transpose _).symm
     rw [hb]
     simpa [Module.Basis.det_apply] using e.isUnit_det b'
   have hQ_unit : IsUnit Q_mat.det :=

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -171,8 +171,7 @@ private theorem isUnit_det_of_columns (b : Module.Basis (Fin n) ℤ (Fin n → �
     simp only [Matrix.of_apply]
     rw [e.toMatrix_apply, he, Pi.basisFun_repr]
   rw [hb]
-  have := e.invertibleToMatrix b
-  exact Matrix.isUnit_det_of_invertible _
+  simpa [Module.Basis.det_apply] using e.isUnit_det b
 
 /-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
 `A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -161,6 +161,49 @@ private lemma exists_SL_diagonal_of_unit_diagonalization (A P Q : Matrix (Fin n)
       nlinarith
   exact ⟨d, hd_pos, sign_correct_unit_transform A d L_mat Q hL_eq hLQ_one⟩
 
+/-- **The matrix whose columns are the vectors of a basis of `ℤⁿ` has unit determinant.** It is the
+change-of-basis matrix from the standard basis, whose determinant is a unit by
+`Module.Basis.isUnit_det`. -/
+private theorem isUnit_det_of_columns (b : Module.Basis (Fin n) ℤ (Fin n → ℤ)) :
+    IsUnit (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ).det := by
+  set e := Pi.basisFun ℤ (Fin n) with he
+  have hb : (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ) = e.toMatrix b := by
+    ext k j
+    simp only [Matrix.of_apply]
+    rw [e.toMatrix_apply, he, Pi.basisFun_repr]
+  rw [hb]
+  simpa [Module.Basis.det_apply] using e.isUnit_det b
+
+/-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
+`A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`
+back along it is the family `r`. -/
+private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ) (hdet_ne : A.det ≠ 0)
+    {ab' : Module.Basis (Fin n) ℤ ↥(LinearMap.range A.mulVecLin)} {r : Fin n → Fin n → ℤ}
+    (hr : ∀ i, A.mulVecLin (r i) = ↑(ab' i)) :
+    IsUnit (Matrix.of (fun k j ↦ r j k) : Matrix (Fin n) (Fin n) ℤ).det := by
+  have hinj := mulVecLin_injective_of_det_ne_zero A hdet_ne
+  set r_basis : Module.Basis (Fin n) ℤ (Fin n → ℤ) :=
+    ab'.map (LinearEquiv.ofInjective A.mulVecLin hinj).symm with hr_basis
+  have hrb : ⇑r_basis = r := funext fun i ↦ hinj (by
+    rw [hr i, hr_basis, Module.Basis.map_apply]
+    exact congrArg Subtype.val
+      ((LinearEquiv.ofInjective A.mulVecLin hinj).apply_symm_apply (ab' i)))
+  rw [← hrb]
+  exact isUnit_det_of_columns r_basis
+
+/-- **The column matrices of `r` and `b'` intertwine `A` with the diagonal of `a`**, given that `A`
+carries each `r j` to `a j • b' j`. -/
+private theorem mul_of_columns_eq_of_mulVec (A : Matrix (Fin n) (Fin n) ℤ) {a : Fin n → ℤ}
+    {b' r : Fin n → Fin n → ℤ} (hkey : ∀ j, A *ᵥ r j = a j • b' j) :
+    A * Matrix.of (fun k j ↦ r j k) =
+      (Matrix.of fun k j ↦ b' j k) * Matrix.diagonal a := by
+  ext k j
+  simp only [Matrix.mul_apply, Matrix.of_apply, Matrix.diagonal_apply]
+  -- fold the entry sum into a matrix-vector product to apply `hkey`
+  conv_lhs => rw [show ∑ l, A k l * r j l = (A *ᵥ r j) k by simp [mulVec, dotProduct]]
+  rw [hkey j]; simp only [Pi.smul_apply, smul_eq_mul]
+  simp [Finset.sum_ite_eq', Finset.mem_univ, mul_comm]
+
 /-- Every integer matrix with positive determinant is `SL_n(ℤ)`-equivalent to a positive
 diagonal. -/
 private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hdet : 0 < A.det) :
@@ -178,37 +221,12 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   choose r hr using fun i ↦ LinearMap.mem_range.mp (ab' i).2
   have hkey : ∀ j, A *ᵥ r j = a j • b' j := fun j ↦ by
     rw [← Matrix.mulVecLin_apply, hr j, hsnf j]
-  set e := Pi.basisFun ℤ (Fin n)
   set P_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ b' j k) with hP_def
   set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k) with hQ_def
-  have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a := by
-    ext k j; simp only [Matrix.mul_apply, hQ_def, hP_def, Matrix.of_apply, Matrix.diagonal_apply]
-    -- fold the entry sum into a matrix-vector product to apply `hkey`
-    conv_lhs => rw [show ∑ l, A k l * r j l = (A *ᵥ r j) k by simp [mulVec, dotProduct]]
-    rw [hkey j]; simp only [Pi.smul_apply, smul_eq_mul]
-    simp [Finset.sum_ite_eq', Finset.mem_univ, mul_comm]
-  have hP_eq : P_mat = e.toMatrix b' := by
-    ext k j
-    rw [hP_def]
-    simp only [Matrix.of_apply]
-    rw [e.toMatrix_apply, Pi.basisFun_repr]
-  have hP_unit : IsUnit P_mat.det := by
-    rw [hP_eq]; simpa [Module.Basis.det_apply] using e.isUnit_det b'
-  have hQ_eq : Q_mat = e.toMatrix r := by
-    ext k j
-    rw [hQ_def]
-    simp only [Matrix.of_apply]
-    rw [e.toMatrix_apply, Pi.basisFun_repr]
-  have hQ_unit : IsUnit Q_mat.det := by
-    have hinj := mulVecLin_injective_of_det_ne_zero A hdet_ne
-    set r_basis : Module.Basis (Fin n) ℤ (Fin n → ℤ) :=
-      ab'.map (LinearEquiv.ofInjective A.mulVecLin hinj).symm with hr_basis
-    have hrb : ⇑r_basis = r := funext fun i ↦ hinj (by
-      rw [hr i, hr_basis, Module.Basis.map_apply]
-      exact congrArg Subtype.val
-        ((LinearEquiv.ofInjective A.mulVecLin hinj).apply_symm_apply (ab' i)))
-    rw [hQ_eq, ← hrb]
-    simpa [Module.Basis.det_apply] using e.isUnit_det r_basis
+  have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
+    mul_of_columns_eq_of_mulVec A hkey
+  have hP_unit : IsUnit P_mat.det := isUnit_det_of_columns b'
+  have hQ_unit : IsUnit Q_mat.det := isUnit_det_of_mulVec_columns A hdet_ne hr
   have h_diag_eq : P_mat⁻¹ * A * Q_mat = Matrix.diagonal a := by
     rw [Matrix.mul_assoc, hmat_eq, ← Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hP_unit,
       Matrix.one_mul]

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -163,20 +163,17 @@ private lemma exists_SL_diagonal_of_unit_diagonalization (A P Q : Matrix (Fin n)
 
 /-- **The matrix whose columns are the vectors of a basis of `ℤⁿ` has unit determinant.** It is the
 change-of-basis matrix from the standard basis, and such a matrix is invertible. -/
-private theorem isUnit_det_of_columns (b : Module.Basis (Fin n) ℤ (Fin n → ℤ)) :
+private theorem isUnit_det_of_basis_cols (b : Module.Basis (Fin n) ℤ (Fin n → ℤ)) :
     IsUnit (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ).det := by
   set e := Pi.basisFun ℤ (Fin n) with he
-  have hb : (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ) = e.toMatrix b := by
-    ext k j
-    simp only [Matrix.of_apply]
-    rw [e.toMatrix_apply, he, Pi.basisFun_repr]
+  have hb : (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ) = e.toMatrix b := rfl
   rw [hb]
   simpa [Module.Basis.det_apply] using e.isUnit_det b
 
 /-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
 `A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`
 back along it is the family `r`. -/
-private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ)
+private theorem isUnit_det_of_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fin n) ℤ)
     (hinj : Function.Injective A.mulVecLin)
     {ab' : Module.Basis (Fin n) ℤ ↥(LinearMap.range A.mulVecLin)} {r : Fin n → Fin n → ℤ}
     (hr : ∀ i, A.mulVecLin (r i) = ↑(ab' i)) :
@@ -185,10 +182,9 @@ private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ)
     ab'.map (LinearEquiv.ofInjective A.mulVecLin hinj).symm with hr_basis
   have hrb : ⇑r_basis = r := funext fun i ↦ hinj (by
     rw [hr i, hr_basis, Module.Basis.map_apply]
-    exact congrArg Subtype.val
-      ((LinearEquiv.ofInjective A.mulVecLin hinj).apply_symm_apply (ab' i)))
+    simp)
   rw [← hrb]
-  exact isUnit_det_of_columns r_basis
+  exact isUnit_det_of_basis_cols r_basis
 
 /-- **The column matrices of `r` and `b'` intertwine `A` with the diagonal of `a`**, given that `A`
 carries each `r j` to `a j • b' j`. -/
@@ -198,11 +194,10 @@ private theorem mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul
     A * Matrix.of (fun k j ↦ r j k) =
       (Matrix.of fun k j ↦ b' j k) * Matrix.diagonal a := by
   ext k j
-  simp only [Matrix.mul_apply, Matrix.of_apply, Matrix.diagonal_apply]
-  -- fold the entry sum into a matrix-vector product to apply `hkey`
-  conv_lhs => rw [show ∑ l, A k l * r j l = (A *ᵥ r j) k by simp [mulVec, dotProduct]]
-  rw [hkey j]; simp only [Pi.smul_apply, smul_eq_mul]
-  simp [Finset.sum_ite_eq', Finset.mem_univ, mul_comm]
+  rw [Matrix.mul_diagonal, Matrix.mul_apply]
+  simp only [Matrix.of_apply]
+  rw [← A.mulVec_apply_eq_sum (r j) k, hkey j]
+  simp [mul_comm]
 
 /-- Every integer matrix with positive determinant is `SL_n(ℤ)`-equivalent to a positive
 diagonal. -/
@@ -221,13 +216,14 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   choose r hr using fun i ↦ LinearMap.mem_range.mp (ab' i).2
   have hkey : ∀ j, A *ᵥ r j = a j • b' j := fun j ↦ by
     rw [← Matrix.mulVecLin_apply, hr j, hsnf j]
-  set P_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ b' j k) with hP_def
-  set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k) with hQ_def
+  set P_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ b' j k)
+  set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k)
   have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
     mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul A hkey
-  have hP_unit : IsUnit P_mat.det := isUnit_det_of_columns b'
+  have hP_unit : IsUnit P_mat.det := isUnit_det_of_basis_cols b'
   have hQ_unit : IsUnit Q_mat.det :=
-    isUnit_det_of_mulVec_columns A (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr
+    isUnit_det_of_cols_of_mulVecLin_eq_basis A
+      (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr
   have h_diag_eq : P_mat⁻¹ * A * Q_mat = Matrix.diagonal a := by
     rw [Matrix.mul_assoc, hmat_eq, ← Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hP_unit,
       Matrix.one_mul]

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -194,8 +194,9 @@ private theorem isUnit_det_of_mulVec_columns (A : Matrix (Fin n) (Fin n) ℤ)
 
 /-- **The column matrices of `r` and `b'` intertwine `A` with the diagonal of `a`**, given that `A`
 carries each `r j` to `a j • b' j`. -/
-private theorem mul_of_columns_eq_of_mulVec (A : Matrix (Fin n) (Fin n) ℤ) {a : Fin n → ℤ}
-    {b' r : Fin n → Fin n → ℤ} (hkey : ∀ j, A *ᵥ r j = a j • b' j) :
+private theorem mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul
+    (A : Matrix (Fin n) (Fin n) ℤ) {a : Fin n → ℤ} {b' r : Fin n → Fin n → ℤ}
+    (hkey : ∀ j, A *ᵥ r j = a j • b' j) :
     A * Matrix.of (fun k j ↦ r j k) =
       (Matrix.of fun k j ↦ b' j k) * Matrix.diagonal a := by
   ext k j
@@ -225,7 +226,7 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   set P_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ b' j k) with hP_def
   set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k) with hQ_def
   have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
-    mul_of_columns_eq_of_mulVec A hkey
+    mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul A hkey
   have hP_unit : IsUnit P_mat.det := isUnit_det_of_columns b'
   have hQ_unit : IsUnit Q_mat.det :=
     isUnit_det_of_mulVec_columns A (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -161,15 +161,6 @@ private lemma exists_SL_diagonal_of_unit_diagonalization (A P Q : Matrix (Fin n)
       nlinarith
   exact ⟨d, hd_pos, sign_correct_unit_transform A d L_mat Q hL_eq hLQ_one⟩
 
-/-- **The matrix whose columns are the vectors of a basis of `ℤⁿ` has unit determinant.** It is the
-change-of-basis matrix from the standard basis, and such a matrix is invertible. -/
-private theorem isUnit_det_of_basis_cols (b : Module.Basis (Fin n) ℤ (Fin n → ℤ)) :
-    IsUnit (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ).det := by
-  set e := Pi.basisFun ℤ (Fin n) with he
-  have hb : (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ) = e.toMatrix b := rfl
-  rw [hb]
-  simpa [Module.Basis.det_apply] using e.isUnit_det b
-
 /-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
 `A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`
 back along it is the family `r`. -/
@@ -184,7 +175,11 @@ private theorem isUnit_det_of_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fi
     rw [hr i, hr_basis, Module.Basis.map_apply]
     simp)
   rw [← hrb]
-  exact isUnit_det_of_basis_cols r_basis
+  set e := Pi.basisFun ℤ (Fin n) with he
+  have hb : (Matrix.of (fun k j ↦ r_basis j k) : Matrix (Fin n) (Fin n) ℤ)
+      = e.toMatrix r_basis := rfl
+  rw [hb]
+  simpa [Module.Basis.det_apply] using e.isUnit_det r_basis
 
 /-- **The column matrices of `r` and `b'` intertwine `A` with the diagonal of `a`**, given that `A`
 carries each `r j` to `a j • b' j`. -/
@@ -220,7 +215,11 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k)
   have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
     mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul A hkey
-  have hP_unit : IsUnit P_mat.det := isUnit_det_of_basis_cols b'
+  have hP_unit : IsUnit P_mat.det := by
+    set e := Pi.basisFun ℤ (Fin n) with he
+    have hb : P_mat = e.toMatrix b' := rfl
+    rw [hb]
+    simpa [Module.Basis.det_apply] using e.isUnit_det b'
   have hQ_unit : IsUnit Q_mat.det :=
     isUnit_det_of_cols_of_mulVecLin_eq_basis A
       (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -164,7 +164,7 @@ private lemma exists_SL_diagonal_of_unit_diagonalization (A P Q : Matrix (Fin n)
 /-- **Preimages of a basis of the range under an injective `A` have unit determinant as columns.**
 `A.mulVecLin` restricts to a linear equivalence onto its range, and transporting the basis `ab'`
 back along it is the family `r`. -/
-private theorem isUnit_det_of_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fin n) ℤ)
+private theorem isUnit_det_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fin n) ℤ)
     (hinj : Function.Injective A.mulVecLin)
     {ab' : Module.Basis (Fin n) ℤ ↥(LinearMap.range A.mulVecLin)} {r : Fin n → Fin n → ℤ}
     (hr : ∀ i, A.mulVecLin (r i) = ↑(ab' i)) :
@@ -185,7 +185,7 @@ private theorem isUnit_det_of_cols_of_mulVecLin_eq_basis (A : Matrix (Fin n) (Fi
 
 /-- **The column matrices of `r` and `b'` intertwine `A` with the diagonal of `a`**, given that `A`
 carries each `r j` to `a j • b' j`. -/
-private theorem mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul
+private theorem mul_cols_eq_cols_mul_diagonal_of_mulVec_eq_smul
     (A : Matrix (Fin n) (Fin n) ℤ) {a : Fin n → ℤ} {b' r : Fin n → Fin n → ℤ}
     (hkey : ∀ j, A *ᵥ r j = a j • b' j) :
     A * Matrix.of (fun k j ↦ r j k) =
@@ -216,7 +216,7 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
   set P_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ b' j k)
   set Q_mat : Matrix (Fin n) (Fin n) ℤ := Matrix.of (fun k j ↦ r j k)
   have hmat_eq : A * Q_mat = P_mat * Matrix.diagonal a :=
-    mul_columns_eq_columns_mul_diagonal_of_mulVec_eq_smul A hkey
+    mul_cols_eq_cols_mul_diagonal_of_mulVec_eq_smul A hkey
   have hP_unit : IsUnit P_mat.det := by
     set e := Pi.basisFun ℤ (Fin n) with he
     have hb : P_mat = e.toMatrix b' := by
@@ -225,7 +225,7 @@ private theorem exists_diagonal_of_det_pos (A : Matrix (Fin n) (Fin n) ℤ) (hde
     rw [hb]
     simpa [Module.Basis.det_apply] using e.isUnit_det b'
   have hQ_unit : IsUnit Q_mat.det :=
-    isUnit_det_of_cols_of_mulVecLin_eq_basis A
+    isUnit_det_cols_of_mulVecLin_eq_basis A
       (mulVecLin_injective_of_det_ne_zero A hdet_ne) hr
   have h_diag_eq : P_mat⁻¹ * A * Q_mat = Matrix.diagonal a := by
     rw [Matrix.mul_assoc, hmat_eq, ← Matrix.mul_assoc, Matrix.nonsing_inv_mul _ hP_unit,

--- a/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
+++ b/TauCeti/LinearAlgebra/Matrix/SmithNormalForm.lean
@@ -162,8 +162,7 @@ private lemma exists_SL_diagonal_of_unit_diagonalization (A P Q : Matrix (Fin n)
   exact ⟨d, hd_pos, sign_correct_unit_transform A d L_mat Q hL_eq hLQ_one⟩
 
 /-- **The matrix whose columns are the vectors of a basis of `ℤⁿ` has unit determinant.** It is the
-change-of-basis matrix from the standard basis, whose determinant is a unit by
-`Module.Basis.isUnit_det`. -/
+change-of-basis matrix from the standard basis, and such a matrix is invertible. -/
 private theorem isUnit_det_of_columns (b : Module.Basis (Fin n) ℤ (Fin n → ℤ)) :
     IsUnit (Matrix.of (fun k j ↦ b j k) : Matrix (Fin n) (Fin n) ℤ).det := by
   set e := Pi.basisFun ℤ (Fin n) with he


### PR DESCRIPTION
`exists_diagonal_of_det_pos` (`LinearAlgebra/Matrix/SmithNormalForm.lean`) had a **48-line** body.
Two steps are now private lemmas stated above it.

Main proof: **48 → 29 lines**. The helpers are 12 and 6.

| helper | proves |
|---|---|
| `isUnit_det_cols_of_mulVecLin_eq_basis` | preimages of a basis of the range under an injective `A.mulVecLin` have unit determinant as columns |
| `mul_cols_eq_cols_mul_diagonal_of_mulVec_eq_smul` | the column matrices of `r` and `b'` intertwine `A` with the diagonal of `a` |

Both go through named Mathlib lemmas rather than unfolding or `rfl`: the column matrix is
identified with `(Pi.basisFun ℤ (Fin n)).toMatrix b` by
`Module.Basis.coePiBasisFun.toMatrix_eq_transpose`, its determinant is a unit by
`Module.Basis.det_apply` with `Module.Basis.isUnit_det`, and the intertwining computation is
`Matrix.mul_diagonal` with `Matrix.mulVec_apply_eq_sum`.

Hypotheses are at their weakest: `isUnit_det_cols_of_mulVecLin_eq_basis` takes
`Function.Injective A.mulVecLin` rather than `A.det ≠ 0` (the call site supplies
`mulVecLin_injective_of_det_ne_zero`), and `mul_cols_eq_cols_mul_diagonal_of_mulVec_eq_smul` is
stated for plain families `b' r : Fin n → Fin n → ℤ` rather than for bases.

### On the basis-column determinant argument

An earlier revision factored this into a third helper shared by the two places that need it. The
`reuse` rubric blocked that as a restatement of `Module.Basis.isUnit_det`, so it is gone and the
argument sits at both use sites.

For the record, the suggested one-line replacement does not compile:
`simpa [Module.Basis.det_apply] using (Pi.basisFun ℤ (Fin n)).isUnit_det b` fails because `simp`
normalises `(Pi.basisFun ℤ (Fin n)).det` to `detRowAlternating` before `Module.Basis.det_apply` can
fire. Binding the basis with `set` keeps it folded, but then the two sides disagree on the `Monoid`
instance. The form that works states and rewrites the definitional identification first.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean, against the current mathlib pin.

Roadmap: none