### PR TITLE
refactor(SU2): decompose the torus-conjugacy proof

### DIFF
--- a/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
+++ b/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
@@ -76,10 +76,10 @@ private theorem isDiag_star_left_conjugate_of_eq_smul_one_add_smul {R n : Type*}
   rw [hexpand]
   exact (Matrix.isDiag_one.smul _).add (hdiagH.smul _)
 
-/-- **A special unitary matrix is a scalar plus a multiple of its Hermitian part.** Writing
-`H = I • (g - star g)`, the identity `g = (tr g / 2) • 1 + (-I / 2) • H` holds because
-`g + star g` is the scalar `tr g`. -/
-private theorem coe_eq_smul_one_add_smul_hermitianPart (g : SU2) :
+/-- **A special unitary matrix is a scalar plus a multiple of `I • (g - star g)`.** The identity
+`g = (tr g / 2) • 1 + (-I / 2) • (I • (g - star g))` holds because `g + star g` is the scalar
+`tr g`. -/
+private theorem coe_eq_smul_one_add_smul_I_smul_sub_star (g : SU2) :
     (g : Matrix (Fin 2) (Fin 2) ℂ)
       = (Matrix.trace (g : Matrix (Fin 2) (Fin 2) ℂ) / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ)
         + (-Complex.I / 2) •
@@ -99,7 +99,7 @@ private theorem coe_eq_smul_one_add_smul_hermitianPart (g : SU2) :
 /-- **A unitary that diagonalises `g` rescales to a special unitary one.** Multiplying a unitary by
 a unit-modulus scalar leaves the conjugate `star u * g * u` unchanged, and some such multiple is
 special unitary, so `g` is conjugate into the torus inside `SU(2)`. -/
-private theorem exists_mem_torus_of_isDiag_star_conj (g : SU2)
+private theorem exists_conj_mem_torus_of_isDiag_star_left_conjugate (g : SU2)
     {U : Matrix.unitaryGroup (Fin 2) ℂ}
     (hdiagG : (star (U : Matrix (Fin 2) (Fin 2) ℂ) * (g : Matrix (Fin 2) (Fin 2) ℂ)
       * (U : Matrix (Fin 2) (Fin 2) ℂ)).IsDiag) :
@@ -138,9 +138,9 @@ theorem exists_conj_mem_torus (g : SU2) : ∃ u : SU2, u * g * u⁻¹ ∈ torus 
     rw [h]
     exact Matrix.isDiag_diagonal _
   -- `G` is a scalar plus a multiple of `H`, so that unitary diagonalises `G` too.
-  exact exists_mem_torus_of_isDiag_star_conj g
+  exact exists_conj_mem_torus_of_isDiag_star_left_conjugate g
     (isDiag_star_left_conjugate_of_eq_smul_one_add_smul
-      (coe_eq_smul_one_add_smul_hermitianPart g) (Matrix.UnitaryGroup.star_mul_self U) hdiagH)
+      (coe_eq_smul_one_add_smul_I_smul_sub_star g) (Matrix.UnitaryGroup.star_mul_self U) hdiagH)
 
 /-- Every element of `SU(2)` is conjugate to the torus element `diag (e^{iθ}, e^{-iθ})` for some
 angle `θ`. -/

--- a/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
+++ b/TauCeti/RepresentationTheory/SU2/TorusConjugacy.lean
@@ -76,6 +76,50 @@ private theorem isDiag_star_left_conjugate_of_eq_smul_one_add_smul {R n : Type*}
   rw [hexpand]
   exact (Matrix.isDiag_one.smul _).add (hdiagH.smul _)
 
+/-- **A special unitary matrix is a scalar plus a multiple of its Hermitian part.** Writing
+`H = I • (g - star g)`, the identity `g = (tr g / 2) • 1 + (-I / 2) • H` holds because
+`g + star g` is the scalar `tr g`. -/
+private theorem coe_eq_smul_one_add_smul_hermitianPart (g : SU2) :
+    (g : Matrix (Fin 2) (Fin 2) ℂ)
+      = (Matrix.trace (g : Matrix (Fin 2) (Fin 2) ℂ) / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ)
+        + (-Complex.I / 2) •
+          (Complex.I • ((g : Matrix (Fin 2) (Fin 2) ℂ) - star (g : Matrix (Fin 2) (Fin 2) ℂ))) := by
+  have hscalar : (Matrix.trace (g : Matrix (Fin 2) (Fin 2) ℂ) / 2) •
+      (1 : Matrix (Fin 2) (Fin 2) ℂ)
+      = (2⁻¹ : ℂ) • ((g : Matrix (Fin 2) (Fin 2) ℂ) + star (g : Matrix (Fin 2) (Fin 2) ℂ)) := by
+    rw [coe_add_star g, smul_smul]
+    congr 1
+    ring
+  have hI : (-Complex.I / 2) * Complex.I = 2⁻¹ := by
+    rw [div_mul_eq_mul_div, neg_mul, Complex.I_mul_I]
+    norm_num
+  rw [smul_smul, hI, hscalar]
+  module
+
+/-- **A unitary that diagonalises `g` rescales to a special unitary one.** Multiplying a unitary by
+a unit-modulus scalar leaves the conjugate `star u * g * u` unchanged, and some such multiple is
+special unitary, so `g` is conjugate into the torus inside `SU(2)`. -/
+private theorem exists_mem_torus_of_isDiag_star_conj (g : SU2)
+    {U : Matrix.unitaryGroup (Fin 2) ℂ}
+    (hdiagG : (star (U : Matrix (Fin 2) (Fin 2) ℂ) * (g : Matrix (Fin 2) (Fin 2) ℂ)
+      * (U : Matrix (Fin 2) (Fin 2) ℂ)).IsDiag) :
+    ∃ u : SU2, u * g * u⁻¹ ∈ torus := by
+  obtain ⟨c, hc⟩ := Matrix.exists_circle_smul_mem_specialUnitaryGroup U
+  obtain ⟨u, hu⟩ : ∃ u : SU2,
+    (u : Matrix (Fin 2) (Fin 2) ℂ) = (c : ℂ) • (U : Matrix (Fin 2) (Fin 2) ℂ) := ⟨⟨_, hc⟩, rfl⟩
+  refine ⟨u⁻¹, mem_torus_iff.mpr ?_⟩
+  -- Inversion in `SU(2)` is `star`, which commutes with the coercion to matrices.
+  have hcoe : ((u⁻¹ * g * (u⁻¹)⁻¹ : SU2) : Matrix (Fin 2) (Fin 2) ℂ)
+      = star (u : Matrix (Fin 2) (Fin 2) ℂ) * (g : Matrix (Fin 2) (Fin 2) ℂ)
+        * (u : Matrix (Fin 2) (Fin 2) ℂ) := by
+    rw [inv_inv, Submonoid.coe_mul, Submonoid.coe_mul, ← Matrix.star_eq_inv,
+      Matrix.specialUnitaryGroup.coe_star]
+  have hcmul : (c : ℂ) * star (c : ℂ) = 1 := by
+    rw [Complex.star_def, Complex.mul_conj, Circle.normSq_coe, Complex.ofReal_one]
+  rw [hcoe, hu]
+  simp only [star_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul, hcmul, one_smul]
+  exact hdiagG
+
 /-- **Torus conjugacy for `SU(2)`**: every element of `SU(2)` is conjugate into the maximal torus.
 Equivalently, every special unitary `2 × 2` matrix is diagonalised by a special unitary matrix. -/
 theorem exists_conj_mem_torus (g : SU2) : ∃ u : SU2, u * g * u⁻¹ ∈ torus := by
@@ -85,19 +129,6 @@ theorem exists_conj_mem_torus (g : SU2) : ∃ u : SU2, u * g * u⁻¹ ∈ torus 
   have hHerm : H.IsHermitian := by
     rw [Matrix.isHermitian_iff_isSelfAdjoint, isSelfAdjoint_iff, hHdef, star_smul, star_sub,
       star_star, Complex.star_def, Complex.conj_I, neg_smul, ← smul_neg, neg_sub]
-  -- `G` is a scalar matrix plus a multiple of `H`, so anything diagonalising `H` diagonalises `G`.
-  have hdecomp : G = (Matrix.trace G / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ)
-      + (-Complex.I / 2) • H := by
-    have hscalar : (Matrix.trace G / 2) • (1 : Matrix (Fin 2) (Fin 2) ℂ)
-        = (2⁻¹ : ℂ) • (G + star G) := by
-      rw [coe_add_star g, smul_smul]
-      congr 1
-      ring
-    have hI : (-Complex.I / 2) * Complex.I = 2⁻¹ := by
-      rw [div_mul_eq_mul_div, neg_mul, Complex.I_mul_I]
-      norm_num
-    rw [hHdef, smul_smul, hI, hscalar]
-    module
   -- Mathlib's spectral theorem diagonalises `H` by a unitary matrix.
   obtain ⟨U, hdiagH⟩ : ∃ U : Matrix.unitaryGroup (Fin 2) ℂ,
       (star (U : Matrix (Fin 2) (Fin 2) ℂ) * H * (U : Matrix (Fin 2) (Fin 2) ℂ)).IsDiag := by
@@ -106,27 +137,10 @@ theorem exists_conj_mem_torus (g : SU2) : ∃ u : SU2, u * g * u⁻¹ ∈ torus 
     rw [Unitary.conjStarAlgAut_star_apply] at h
     rw [h]
     exact Matrix.isDiag_diagonal _
-  have hUU : star (U : Matrix (Fin 2) (Fin 2) ℂ) * (U : Matrix (Fin 2) (Fin 2) ℂ) = 1 :=
-    Matrix.UnitaryGroup.star_mul_self U
-  -- Conjugating by any unitary that diagonalises `H` diagonalises `G`.
-  have hdiagG :
-      (star (U : Matrix (Fin 2) (Fin 2) ℂ) * G * (U : Matrix (Fin 2) (Fin 2) ℂ)).IsDiag :=
-    isDiag_star_left_conjugate_of_eq_smul_one_add_smul hdecomp hUU hdiagH
-  -- Rescale `U` into `SU(2)`; the rescaling does not change the conjugation.
-  obtain ⟨c, hc⟩ := Matrix.exists_circle_smul_mem_specialUnitaryGroup U
-  obtain ⟨u, hu⟩ : ∃ u : SU2,
-      (u : Matrix (Fin 2) (Fin 2) ℂ) = (c : ℂ) • (U : Matrix (Fin 2) (Fin 2) ℂ) := ⟨⟨_, hc⟩, rfl⟩
-  refine ⟨u⁻¹, mem_torus_iff.mpr ?_⟩
-  -- Inversion in `SU(2)` is `star`, which commutes with the coercion to matrices.
-  have hcoe : ((u⁻¹ * g * (u⁻¹)⁻¹ : SU2) : Matrix (Fin 2) (Fin 2) ℂ)
-      = star (u : Matrix (Fin 2) (Fin 2) ℂ) * G * (u : Matrix (Fin 2) (Fin 2) ℂ) := by
-    rw [inv_inv, Submonoid.coe_mul, Submonoid.coe_mul, ← Matrix.star_eq_inv,
-      Matrix.specialUnitaryGroup.coe_star]
-  have hcmul : (c : ℂ) * star (c : ℂ) = 1 := by
-    rw [Complex.star_def, Complex.mul_conj, Circle.normSq_coe, Complex.ofReal_one]
-  rw [hcoe, hu]
-  simp only [star_smul, Matrix.smul_mul, Matrix.mul_smul, smul_smul, hcmul, one_smul]
-  exact hdiagG
+  -- `G` is a scalar plus a multiple of `H`, so that unitary diagonalises `G` too.
+  exact exists_mem_torus_of_isDiag_star_conj g
+    (isDiag_star_left_conjugate_of_eq_smul_one_add_smul
+      (coe_eq_smul_one_add_smul_hermitianPart g) (Matrix.UnitaryGroup.star_mul_self U) hdiagH)
 
 /-- Every element of `SU(2)` is conjugate to the torus element `diag (e^{iθ}, e^{-iθ})` for some
 angle `θ`. -/


### PR DESCRIPTION
`exists_conj_mem_torus` (`RepresentationTheory/SU2/TorusConjugacy.lean`) had a **49-line** body.
Its two algebraic steps are now private lemmas stated above it, leaving the spectral argument in
the parent.

Main proof: **49 → 19 lines**. The helpers are 12 and 16.

| helper | proves |
|---|---|
| `coe_eq_smul_one_add_smul_I_smul_sub_star` | a special unitary matrix is a scalar plus a multiple of `I • (g - star g)`: `g = (tr g / 2) • 1 + (-I / 2) • (I • (g - star g))`, because `g + star g` is the scalar `tr g` |
| `exists_conj_mem_torus_of_isDiag_star_left_conjugate` | a unitary that diagonalises `g` rescales to a *special* unitary one — multiplying by a unit-modulus scalar leaves `star u * g * u` unchanged — so `g` is conjugate into the torus inside `SU(2)` |

The parent now reads as the mathematical outline it always was: `H = I • (g - star g)` is Hermitian,
Mathlib's spectral theorem diagonalises it by a unitary, and the two lemmas carry that back to `g`.

The second helper's name matches the adjacent `isDiag_star_left_conjugate_of_eq_smul_one_add_smul`
in the same file.

Gates run locally: `lake build`, `lake exe axioms`, `lake exe module-system`, `scripts/lint-env.sh`
— all clean, against the current mathlib pin.

Roadmap: RepresentationTheory