### PR TITLE
refactor(HeckeRing): expose pointwise evaluation of the coset module

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -446,10 +446,10 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
         rw [smul_apply, smul_apply, sum_apply, sum_apply, sum_def, sum_def,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
             (fun E _ hE ↦ by
-              simp [apply_eq_zero_of_notMem_support _ hE, zero_apply]),
+              simp [notMem_support_iff.mp hE, zero_apply]),
           Finset.sum_subset (support_structureConstants_subset R D₂.rep D₃.rep)
             (fun F _ hF ↦ by
-              simp [apply_eq_zero_of_notMem_support _ hF, zero_apply])]
+              simp [notMem_support_iff.mp hF, zero_apply])]
         simp only [smul_apply, structureConstants_apply]
         have hL : ∀ E : HeckeCoset Δ H₁ H₃,
             ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) : R) *

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -443,7 +443,7 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
           sum_smul_index_T R b₂ _ _ fun F ↦ by simp,
           sum_smul_index_T R b₃ _ _ fun F ↦ by simp]
         ext D
-        rw [smul_apply, smul_apply, sum_apply_eval, sum_apply_eval, sum_eq_sum, sum_eq_sum,
+        rw [smul_apply, smul_apply, sum_apply, sum_apply, sum_def, sum_def,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
             (fun E _ hE ↦ by
               simp [apply_eq_zero_of_notMem_support _ hE, zero_apply]),

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -390,31 +390,6 @@ private lemma sum_smul_index_T {N : Type*} [AddCommMonoid N] (a : R)
     (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
   Finsupp.sum_smul_index h0
 
-/-- `Finsupp.smul_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
-private lemma smul_apply_T (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
-    (a • f) D = a * f D :=
-  rfl
-
-/-- Unfolding `Finsupp.sum` with the wrapper-type coercion. -/
-private lemma sum_eq_sum_T {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) :=
-  rfl
-
-/-- `Finsupp.notMem_support_iff`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
-private lemma apply_eq_zero_of_notMem_support_T (f : HeckeCosetModule Δ H₁ H₂ R)
-    (D : HeckeCoset Δ H₁ H₂) (h : D ∉ f.support) : f D = 0 :=
-  Finsupp.notMem_support_iff.mp h
-
-/-- `Finsupp.zero_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
-private lemma zero_apply_T (D : HeckeCoset Δ H₁ H₂) : (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 :=
-  rfl
-
-/-- `Finsupp.sum_apply`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
-private lemma sum_apply_T {H₁ H₂ H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
-    (f.sum F) D = f.sum fun E c ↦ F E c D :=
-  Finsupp.sum_apply
-
 /-- The convolution product commutes with scalar multiplication on the left factor. (Note
 that the corresponding statement for the right factor fails over a noncommutative `R`.) -/
 lemma smul_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (a : R)
@@ -468,14 +443,14 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
           sum_smul_index_T R b₂ _ _ fun F ↦ by simp,
           sum_smul_index_T R b₃ _ _ fun F ↦ by simp]
         ext D
-        rw [smul_apply_T, smul_apply_T, sum_apply_T, sum_apply_T, sum_eq_sum_T, sum_eq_sum_T,
+        rw [smul_apply, smul_apply, sum_apply_eval, sum_apply_eval, sum_eq_sum, sum_eq_sum,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
             (fun E _ hE ↦ by
-              simp [apply_eq_zero_of_notMem_support_T _ _ _ hE, zero_apply_T]),
+              simp [apply_eq_zero_of_notMem_support _ hE, zero_apply]),
           Finset.sum_subset (support_structureConstants_subset R D₂.rep D₃.rep)
             (fun F _ hF ↦ by
-              simp [apply_eq_zero_of_notMem_support_T _ _ _ hF, zero_apply_T])]
-        simp only [smul_apply_T, structureConstants_apply]
+              simp [apply_eq_zero_of_notMem_support _ hF, zero_apply])]
+        simp only [smul_apply, structureConstants_apply]
         have hL : ∀ E : HeckeCoset Δ H₁ H₃,
             ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) : R) *
               (b₃ * (multiplicity H₁ H₃ H₄ (E.rep : G) (D₃.rep : G) (D.rep : G) : R))) =

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -440,10 +440,10 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
         rw [smul_apply, smul_apply, sum_apply, sum_apply, sum_def, sum_def,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
             (fun E _ hE ↦ by
-              simp at hE; simp [hE]),
+              simp [notMem_support_iff.mp hE, zero_apply]),
           Finset.sum_subset (support_structureConstants_subset R D₂.rep D₃.rep)
             (fun F _ hF ↦ by
-              simp at hF; simp [hF])]
+              simp [notMem_support_iff.mp hF, zero_apply])]
         simp only [smul_apply, structureConstants_apply]
         have hL : ∀ E : HeckeCoset Δ H₁ H₃,
             ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) : R) *

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -440,10 +440,10 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
         rw [smul_apply, smul_apply, sum_apply, sum_apply, sum_def, sum_def,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)
             (fun E _ hE ↦ by
-              simp [notMem_support_iff.mp hE, zero_apply]),
+              simp at hE; simp [hE]),
           Finset.sum_subset (support_structureConstants_subset R D₂.rep D₃.rep)
             (fun F _ hF ↦ by
-              simp [notMem_support_iff.mp hF, zero_apply])]
+              simp at hF; simp [hF])]
         simp only [smul_apply, structureConstants_apply]
         have hL : ∀ E : HeckeCoset Δ H₁ H₃,
             ((multiplicity H₁ H₂ H₃ (D₁.rep : G) (D₂.rep : G) (E.rep : G) : R) *

--- a/TauCeti/NumberTheory/HeckeRing/Associativity.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Associativity.lean
@@ -384,18 +384,12 @@ open DoubleCoset
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H₁ H₂ H₃ H₄ : Subgroup G}
   (R : Type*) [Semiring R]
 
-/-- `Finsupp.sum_smul_index`, restated for the wrapper type `HeckeCosetModule Δ H₁ H₂ R`. -/
-private lemma sum_smul_index_T {N : Type*} [AddCommMonoid N] (a : R)
-    (f : HeckeCosetModule Δ H₁ H₂ R) (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
-    (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
-  Finsupp.sum_smul_index h0
-
 /-- The convolution product commutes with scalar multiplication on the left factor. (Note
 that the corresponding statement for the right factor fails over a noncommutative `R`.) -/
 lemma smul_mul [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃] (a : R)
     (f : HeckeCosetModule Δ H₁ H₂ R) (g : HeckeCosetModule Δ H₂ H₃ R) :
     mul R (a • f) g = a • mul R f g := by
-  rw [mul_eq_sum, mul_eq_sum, sum_smul_index_T R a f _ fun D₁ ↦ by
+  rw [mul_eq_sum, mul_eq_sum, sum_smul_index a f _ fun D₁ ↦ by
     simp only [zero_smul]; exact Finsupp.sum_fun_zero (f := g)]
   refine Eq.trans ?_ Finsupp.smul_sum.symm
   refine Finsupp.sum_congr fun D₁ c ↦ Eq.trans ?_ Finsupp.smul_sum.symm
@@ -440,8 +434,8 @@ theorem mul_assoc [IsHeckeTriple Δ H₁ H₂] [IsHeckeTriple Δ H₂ H₃]
       | hsingle D₃ b₃ =>
         rw [mul_single_single R D₁ D₂ b₁ b₂, smul_mul, smul_mul, mul_single,
           mul_single_single R D₂ D₃ b₂ b₃, single_mul,
-          sum_smul_index_T R b₂ _ _ fun F ↦ by simp,
-          sum_smul_index_T R b₃ _ _ fun F ↦ by simp]
+          sum_smul_index b₂ _ _ fun F ↦ by simp,
+          sum_smul_index b₃ _ _ fun F ↦ by simp]
         ext D
         rw [smul_apply, smul_apply, sum_apply, sum_apply, sum_def, sum_def,
           Finset.sum_subset (support_structureConstants_subset R D₁.rep D₂.rep)

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -42,7 +42,7 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
 * Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
-  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+  `mem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
   `HeckeCosetModule` is a `def` over `Finsupp` carrying transported instances, so Mathlib's
   `Finsupp` evaluation lemmas hold *definitionally* — they can be applied in term mode — but
   `rw`, `simp` and `grind` match syntactically and so cannot see through the wrapper. These
@@ -339,11 +339,6 @@ variable {R : Type*} [Zero R]
 @[simp, grind =] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R}
     {D : HeckeCoset Δ H₁ H₂} : D ∈ f.support ↔ f D ≠ 0 :=
   Finsupp.mem_support_iff
-
-/-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
-@[grind =] lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
-    D ∉ f.support ↔ f D = 0 :=
-  Finsupp.notMem_support_iff
 
 /-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
 lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -334,14 +334,17 @@ lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset �
     D ∉ f.support ↔ f D = 0 :=
   Finsupp.notMem_support_iff
 
-/-- The elimination direction of `notMem_support_iff`. -/
-lemma apply_eq_zero_of_notMem_support (f : HeckeCosetModule Δ H₁ H₂ R)
-    {D : HeckeCoset Δ H₁ H₂} (h : D ∉ f.support) : f D = 0 :=
-  notMem_support_iff.mp h
-
 /-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
 lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
     (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) := (rfl)
+
+/-- `Finsupp.sum_apply`, at the wrapper type: evaluation commutes with a `Finsupp.sum`. The
+target coefficients are independent of the source's. -/
+@[simp] lemma sum_apply {S : Type*} [AddCommMonoid S] {H₃ H₄ : Subgroup G}
+    (f : HeckeCosetModule Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ S) (D : HeckeCoset Δ H₃ H₄) :
+    (f.sum F) D = f.sum fun E c ↦ F E c D :=
+  Finsupp.sum_apply
 
 end EvalSupport
 
@@ -356,12 +359,6 @@ variable {R : Type*} [AddCommMonoid R]
 /-- `Finsupp.add_apply`, at the wrapper type. -/
 @[simp] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
     (f + g) D = f D + g D := (rfl)
-
-/-- `Finsupp.sum_apply`, at the wrapper type: evaluation commutes with a `Finsupp.sum`. -/
-@[simp] lemma sum_apply {H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
-    (f.sum F) D = f.sum fun E c ↦ F E c D :=
-  Finsupp.sum_apply
 
 end EvalAdd
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -331,7 +331,8 @@ variable {R : Type*} [Zero R]
 
 /-- `Finsupp.mem_support_iff`, at the wrapper type.
 
-Deliberately carries no `@[simp]`/`@[grind =]`: `HeckeCosetModule` defines no `support` of its
+Deliberately unattributed, for the same reason as `add_apply` below; it carries no
+`@[simp]`/`@[grind =]`. `HeckeCosetModule` defines no `support` of its
 own, so the left-hand side `D ∈ f.support` elaborates to `Finsupp.support f` and would share a
 discrimination key with Mathlib's `@[simp, grind =] Finsupp.mem_support_iff`, whose right-hand
 side differs only by the wrapper coercion — making the normal form order-dependent. It is
@@ -367,9 +368,13 @@ variable {R : Type*} [AddCommMonoid R]
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
 
-/-- `Finsupp.add_apply`, at the wrapper type. Carries no `@[simp]` for the same
-normal-form reason as `mem_support_iff`: the wrapper's `+` is `Finsupp`'s, so Mathlib's
-`Finsupp.add_apply` already matches the same term. -/
+/-- `Finsupp.add_apply`, at the wrapper type, as a named lemma to cite.
+
+Deliberately unattributed. Unlike the `Finsupp.sum`-shaped lemmas above — where the wrapper
+genuinely blocks matching, which is why this section exists — `+` on the wrapper is the
+`Finsupp` addition itself, so a `@[simp]`/`@[grind =]` here would compete with Mathlib's own
+`Finsupp.add_apply` on the same left-hand side while carrying a right-hand side that differs
+only by the wrapper coercion, leaving the normal form order-dependent. -/
 lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
     (f + g) D = f D + g D := (rfl)
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -315,11 +315,39 @@ end SingleModule
 
 `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's `Finsupp` evaluation lemmas hold
 definitionally but neither `rw` nor `simp` can match them through the wrapper. These are the
-wrapper-level restatements; without them every consumer re-derives its own private copies. -/
+wrapper-level restatements; without them every consumer re-derives its own private copies.
+Each is stated at the coefficient assumptions its underlying operation actually needs: the
+`FunLike` coercion and `Finsupp.support` need only `[Zero R]`, while the wrapper's `0`, `+`
+and `•` come from its `AddCommMonoid` and `Module` instances. -/
 
-section Eval
+section EvalSupport
 
-variable {R : Type*} [Semiring R]
+variable {R : Type*} [Zero R]
+
+/-- `Finsupp.mem_support_iff`, at the wrapper type. -/
+@[simp] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+    D ∈ f.support ↔ f D ≠ 0 :=
+  Finsupp.mem_support_iff
+
+/-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
+lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+    D ∉ f.support ↔ f D = 0 :=
+  Finsupp.notMem_support_iff
+
+/-- The elimination direction of `notMem_support_iff`. -/
+lemma apply_eq_zero_of_notMem_support (f : HeckeCosetModule Δ H₁ H₂ R)
+    {D : HeckeCoset Δ H₁ H₂} (h : D ∉ f.support) : f D = 0 :=
+  notMem_support_iff.mp h
+
+/-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
+lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) := (rfl)
+
+end EvalSupport
+
+section EvalAdd
+
+variable {R : Type*} [AddCommMonoid R]
 
 /-- `Finsupp.zero_apply`, at the wrapper type. -/
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
@@ -329,25 +357,22 @@ variable {R : Type*} [Semiring R]
 @[simp] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
     (f + g) D = f D + g D := (rfl)
 
-/-- `Finsupp.smul_apply`, at the wrapper type. -/
-@[simp] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
-    (a • f) D = a * f D := (rfl)
-
-/-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
-lemma apply_eq_zero_of_notMem_support (f : HeckeCosetModule Δ H₁ H₂ R)
-    {D : HeckeCoset Δ H₁ H₂} (h : D ∉ f.support) : f D = 0 :=
-  Finsupp.notMem_support_iff.mp h
-
-/-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
-lemma sum_eq_sum {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
-    (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) := (rfl)
-
 /-- `Finsupp.sum_apply`, at the wrapper type: evaluation commutes with a `Finsupp.sum`. -/
-lemma sum_apply_eval {H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
+@[simp] lemma sum_apply {H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
     (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
     (f.sum F) D = f.sum fun E c ↦ F E c D :=
   Finsupp.sum_apply
 
-end Eval
+end EvalAdd
+
+section EvalSMul
+
+variable {R : Type*} [Semiring R]
+
+/-- `Finsupp.smul_apply`, at the wrapper type. -/
+@[simp] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (a • f) D = a * f D := (rfl)
+
+end EvalSMul
 
 end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -41,6 +41,11 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
+* Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
+  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+  `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's evaluation lemmas hold
+  definitionally but cannot be matched through the wrapper by `rw`, `simp` or `grind`;
+  these are the wrapper-level restatements.
 * `HeckeCoset.degree`: the number of left cosets in the decomposition of a double coset,
   with `degree_eq_relIndex` and `degree_mk` presenting it as a relative index,
   `degree_eq_natCard_decompQuotient` as the (hypothesis-free) count of that quotient, and
@@ -325,7 +330,7 @@ section EvalSupport
 variable {R : Type*} [Zero R]
 
 /-- `Finsupp.mem_support_iff`, at the wrapper type. -/
-@[simp] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+@[simp, grind =] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∈ f.support ↔ f D ≠ 0 :=
   Finsupp.mem_support_iff
 
@@ -357,7 +362,7 @@ variable {R : Type*} [AddCommMonoid R]
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
 
 /-- `Finsupp.add_apply`, at the wrapper type. -/
-@[simp] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+@[simp, grind =] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
     (f + g) D = f D + g D := (rfl)
 
 end EvalAdd
@@ -367,8 +372,14 @@ section EvalSMul
 variable {R : Type*} [Semiring R]
 
 /-- `Finsupp.smul_apply`, at the wrapper type. -/
-@[simp] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
-    (a • f) D = a * f D := (rfl)
+@[simp, grind =] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R)
+    (D : HeckeCoset Δ H₁ H₂) : (a • f) D = a * f D := (rfl)
+
+/-- `Finsupp.sum_smul_index`, at the wrapper type: a scalar pushes into a `Finsupp.sum`. -/
+lemma sum_smul_index {N : Type*} [AddCommMonoid N] (a : R)
+    (f : HeckeCosetModule Δ H₁ H₂ R) (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
+    (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
+  Finsupp.sum_smul_index h0
 
 end EvalSMul
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -42,7 +42,7 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
 * Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
-  `mem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
   `HeckeCosetModule` is a `def` over `Finsupp` carrying transported instances, so Mathlib's
   `Finsupp` evaluation lemmas hold *definitionally* — they can be applied in term mode — but
   `rw`, `simp` and `grind` match syntactically and so cannot see through the wrapper. These
@@ -339,6 +339,13 @@ variable {R : Type*} [Zero R]
 @[simp, grind =] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R}
     {D : HeckeCoset Δ H₁ H₂} : D ∈ f.support ↔ f D ≠ 0 :=
   Finsupp.mem_support_iff
+
+/-- `Finsupp.notMem_support_iff`, at the wrapper type: the elimination form of
+`mem_support_iff`. Deliberately unannotated — `mem_support_iff` is the `@[simp]` normal form,
+and `simp` discharges this direction from it. -/
+lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+    D ∉ f.support ↔ f D = 0 :=
+  Finsupp.notMem_support_iff
 
 /-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
 lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -311,4 +311,43 @@ lemma smul_single_one (D : HeckeCoset Δ H₁ H₂) (b : R) : b • single R D 1
 
 end SingleModule
 
+/-! ### Pointwise evaluation
+
+`HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's `Finsupp` evaluation lemmas hold
+definitionally but neither `rw` nor `simp` can match them through the wrapper. These are the
+wrapper-level restatements; without them every consumer re-derives its own private copies. -/
+
+section Eval
+
+variable {R : Type*} [Semiring R]
+
+/-- `Finsupp.zero_apply`, at the wrapper type. -/
+@[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
+    (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
+
+/-- `Finsupp.add_apply`, at the wrapper type. -/
+@[simp] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (f + g) D = f D + g D := (rfl)
+
+/-- `Finsupp.smul_apply`, at the wrapper type. -/
+@[simp] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (a • f) D = a * f D := (rfl)
+
+/-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
+lemma apply_eq_zero_of_notMem_support (f : HeckeCosetModule Δ H₁ H₂ R)
+    {D : HeckeCoset Δ H₁ H₂} (h : D ∉ f.support) : f D = 0 :=
+  Finsupp.notMem_support_iff.mp h
+
+/-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
+lemma sum_eq_sum {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) := (rfl)
+
+/-- `Finsupp.sum_apply`, at the wrapper type: evaluation commutes with a `Finsupp.sum`. -/
+lemma sum_apply_eval {H₃ H₄ : Subgroup G} (f : HeckeCosetModule Δ H₁ H₂ R)
+    (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ R) (D : HeckeCoset Δ H₃ H₄) :
+    (f.sum F) D = f.sum fun E c ↦ F E c D :=
+  Finsupp.sum_apply
+
+end Eval
+
 end HeckeCosetModule

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -330,7 +330,7 @@ section EvalSupport
 variable {R : Type*} [Zero R]
 
 /-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
-lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+@[grind =] lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∉ f.support ↔ f D = 0 :=
   Finsupp.notMem_support_iff
 
@@ -340,7 +340,7 @@ lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R
 
 /-- `Finsupp.sum_apply`, at the wrapper type: evaluation commutes with a `Finsupp.sum`. The
 target coefficients are independent of the source's. -/
-@[simp] lemma sum_apply {S : Type*} [AddCommMonoid S] {H₃ H₄ : Subgroup G}
+@[simp, grind =] lemma sum_apply {S : Type*} [AddCommMonoid S] {H₃ H₄ : Subgroup G}
     (f : HeckeCosetModule Δ H₁ H₂ R)
     (F : HeckeCoset Δ H₁ H₂ → R → HeckeCosetModule Δ H₃ H₄ S) (D : HeckeCoset Δ H₃ H₄) :
     (f.sum F) D = f.sum fun E c ↦ F E c D :=
@@ -367,7 +367,7 @@ variable {R : Type*} [Semiring R]
     (D : HeckeCoset Δ H₁ H₂) : (a • f) D = a * f D := (rfl)
 
 /-- `Finsupp.sum_smul_index`, at the wrapper type: a scalar pushes into a `Finsupp.sum`. -/
-lemma sum_smul_index {N : Type*} [AddCommMonoid N] (a : R)
+@[grind =] lemma sum_smul_index {N : Type*} [AddCommMonoid N] (a : R)
     (f : HeckeCosetModule Δ H₁ H₂ R) (F : HeckeCoset Δ H₁ H₂ → R → N) (h0 : ∀ D, F D 0 = 0) :
     (a • f).sum F = f.sum fun D c ↦ F D (a * c) :=
   Finsupp.sum_smul_index h0

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -41,17 +41,17 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
-* Pointwise evaluation of the coset module: `zero_apply`, `smul_apply`,
-  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`. `HeckeCosetModule` is a
-  `def` over `Finsupp` carrying transported instances, so Mathlib's `Finsupp` evaluation
-  lemmas hold *definitionally* — they can be applied in term mode — but `rw`, `simp` and
-  `grind` match syntactically and so cannot see through the wrapper. These restatements are
-  what makes those facts usable tactically.
+* Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
+  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+  `HeckeCosetModule` is a `def` over `Finsupp` carrying transported instances, so Mathlib's
+  `Finsupp` evaluation lemmas hold *definitionally* — they can be applied in term mode — but
+  `rw`, `simp` and `grind` match syntactically and so cannot see through the wrapper. These
+  restatements are what makes those facts usable tactically.
 
-  No restatement is provided for `+` or `support`: nothing in the repository currently needs
-  to rewrite with `Finsupp.add_apply` or `Finsupp.mem_support_iff` at this type. That is a
-  statement about present consumers, not about the wrapper being transparent for them — if a
-  proof needs one, it should land together with that proof rather than standing unused.
+  In particular these do not compete with their `Finsupp` originals: at this type
+  `simp [Finsupp.mem_support_iff]` reports the argument as unused and `simp [Finsupp.add_apply]`
+  makes no progress, because neither left-hand side matches through the wrapper. The wrapper
+  restatement is the only form `simp` can apply.
 * `HeckeCoset.degree`: the number of left cosets in the decomposition of a double coset,
   with `degree_eq_relIndex` and `degree_mk` presenting it as a relative index,
   `degree_eq_natCard_decompQuotient` as the (hypothesis-free) count of that quotient, and
@@ -335,6 +335,11 @@ section EvalSupport
 
 variable {R : Type*} [Zero R]
 
+/-- `Finsupp.mem_support_iff`, at the wrapper type. -/
+@[simp, grind =] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R}
+    {D : HeckeCoset Δ H₁ H₂} : D ∈ f.support ↔ f D ≠ 0 :=
+  Finsupp.mem_support_iff
+
 /-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
 @[grind =] lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∉ f.support ↔ f D = 0 :=
@@ -361,6 +366,11 @@ variable {R : Type*} [AddCommMonoid R]
 /-- `Finsupp.zero_apply`, at the wrapper type. -/
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
+
+/-- `Finsupp.add_apply`, at the wrapper type. -/
+@[simp, grind =] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (f + g) D = f D + g D :=
+  Finsupp.add_apply f g D
 
 end EvalZero
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -41,8 +41,10 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
-* Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
-  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+* Pointwise evaluation of the coset module: `zero_apply`, `smul_apply`,
+  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`. These are the cases the
+  wrapper genuinely hides; `+` and `support` are `Finsupp`'s own, so Mathlib's
+  `Finsupp.add_apply` and `Finsupp.mem_support_iff` already apply at this type.
   `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's evaluation lemmas hold
   definitionally but cannot be matched through the wrapper by `rw`, `simp` or `grind`;
   these are the wrapper-level restatements.
@@ -329,18 +331,6 @@ section EvalSupport
 
 variable {R : Type*} [Zero R]
 
-/-- `Finsupp.mem_support_iff`, at the wrapper type.
-
-Deliberately unattributed, for the same reason as `add_apply` below; it carries no
-`@[simp]`/`@[grind =]`. `HeckeCosetModule` defines no `support` of its
-own, so the left-hand side `D ∈ f.support` elaborates to `Finsupp.support f` and would share a
-discrimination key with Mathlib's `@[simp, grind =] Finsupp.mem_support_iff`, whose right-hand
-side differs only by the wrapper coercion — making the normal form order-dependent. It is
-provided as a named lemma so consumers can cite it explicitly. -/
-lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
-    D ∈ f.support ↔ f D ≠ 0 :=
-  Finsupp.mem_support_iff
-
 /-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
 @[grind =] lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∉ f.support ↔ f D = 0 :=
@@ -367,16 +357,6 @@ variable {R : Type*} [AddCommMonoid R]
 /-- `Finsupp.zero_apply`, at the wrapper type. -/
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
-
-/-- `Finsupp.add_apply`, at the wrapper type, as a named lemma to cite.
-
-Deliberately unattributed. Unlike the `Finsupp.sum`-shaped lemmas above — where the wrapper
-genuinely blocks matching, which is why this section exists — `+` on the wrapper is the
-`Finsupp` addition itself, so a `@[simp]`/`@[grind =]` here would compete with Mathlib's own
-`Finsupp.add_apply` on the same left-hand side while carrying a right-hand side that differs
-only by the wrapper coercion, leaving the normal form order-dependent. -/
-lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
-    (f + g) D = f D + g D := (rfl)
 
 end EvalZero
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -348,6 +348,8 @@ lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset �
   Finsupp.notMem_support_iff
 
 /-- `Finsupp.sum` unfolded to a `Finset.sum`, at the wrapper type. -/
+-- `rfl` rather than a cited lemma: `Finsupp.sum` is a plain `def` for exactly this
+-- `Finset.sum`, and Mathlib exposes no unfolding lemma to name here.
 lemma sum_def {N : Type*} [AddCommMonoid N] (f : HeckeCosetModule Δ H₁ H₂ R)
     (F : HeckeCoset Δ H₁ H₂ → R → N) : f.sum F = ∑ D ∈ f.support, F D (f D) := (rfl)
 
@@ -365,9 +367,12 @@ section EvalZero
 
 variable {R : Type*} [AddCommMonoid R]
 
-/-- `Finsupp.zero_apply`, at the wrapper type. -/
+/-- `Finsupp.zero_apply`, at the wrapper type. Not `@[grind =]`: unlike Mathlib's
+`Finsupp.zero_apply`, where `M` is recoverable from `(0 : α →₀ M)`, the wrapper's coercion
+leaves `R` and its `AddCommMonoid` uninstantiable, and `grind` rejects the pattern. -/
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
-    (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
+    (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 :=
+  Finsupp.zero_apply
 
 /-- `Finsupp.add_apply`, at the wrapper type. -/
 @[simp, grind =] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
@@ -382,7 +387,8 @@ variable {R : Type*} [Semiring R]
 
 /-- `Finsupp.smul_apply`, at the wrapper type. -/
 @[simp, grind =] lemma smul_apply (a : R) (f : HeckeCosetModule Δ H₁ H₂ R)
-    (D : HeckeCoset Δ H₁ H₂) : (a • f) D = a * f D := (rfl)
+    (D : HeckeCoset Δ H₁ H₂) : (a • f) D = a * f D :=
+  (Finsupp.smul_apply a f D).trans (smul_eq_mul _ _)
 
 /-- `Finsupp.sum_smul_index`, at the wrapper type: a scalar pushes into a `Finsupp.sum`. -/
 @[grind =] lemma sum_smul_index {N : Type*} [AddCommMonoid N] (a : R)

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -41,8 +41,8 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
-* Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
-  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+* Pointwise evaluation of the coset module: `zero_apply`, `smul_apply`,
+  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
   `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's evaluation lemmas hold
   definitionally but cannot be matched through the wrapper by `rw`, `simp` or `grind`;
   these are the wrapper-level restatements.
@@ -329,11 +329,6 @@ section EvalSupport
 
 variable {R : Type*} [Zero R]
 
-/-- `Finsupp.mem_support_iff`, at the wrapper type. -/
-@[simp, grind =] lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
-    D ∈ f.support ↔ f D ≠ 0 :=
-  Finsupp.mem_support_iff
-
 /-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
 lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∉ f.support ↔ f D = 0 :=
@@ -353,7 +348,7 @@ target coefficients are independent of the source's. -/
 
 end EvalSupport
 
-section EvalAdd
+section EvalZero
 
 variable {R : Type*} [AddCommMonoid R]
 
@@ -361,11 +356,7 @@ variable {R : Type*} [AddCommMonoid R]
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
 
-/-- `Finsupp.add_apply`, at the wrapper type. -/
-@[simp, grind =] lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
-    (f + g) D = f D + g D := (rfl)
-
-end EvalAdd
+end EvalZero
 
 section EvalSMul
 

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -42,12 +42,16 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
 * Pointwise evaluation of the coset module: `zero_apply`, `smul_apply`,
-  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`. These are the cases the
-  wrapper genuinely hides; `+` and `support` are `Finsupp`'s own, so Mathlib's
-  `Finsupp.add_apply` and `Finsupp.mem_support_iff` already apply at this type.
-  `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's evaluation lemmas hold
-  definitionally but cannot be matched through the wrapper by `rw`, `simp` or `grind`;
-  these are the wrapper-level restatements.
+  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`. `HeckeCosetModule` is a
+  `def` over `Finsupp` carrying transported instances, so Mathlib's `Finsupp` evaluation
+  lemmas hold *definitionally* — they can be applied in term mode — but `rw`, `simp` and
+  `grind` match syntactically and so cannot see through the wrapper. These restatements are
+  what makes those facts usable tactically.
+
+  No restatement is provided for `+` or `support`: nothing in the repository currently needs
+  to rewrite with `Finsupp.add_apply` or `Finsupp.mem_support_iff` at this type. That is a
+  statement about present consumers, not about the wrapper being transparent for them — if a
+  proof needs one, it should land together with that proof rather than standing unused.
 * `HeckeCoset.degree`: the number of left cosets in the decomposition of a double coset,
   with `degree_eq_relIndex` and `degree_mk` presenting it as a relative index,
   `degree_eq_natCard_decompQuotient` as the (hypothesis-free) count of that quotient, and

--- a/TauCeti/NumberTheory/HeckeRing/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/Basic.lean
@@ -41,8 +41,8 @@ merges. The degree section is instead ported from the AINTLIB `LeanModularForms`
 * `HeckeCosetModule.single`: the basis element `b • [D]` of the Hecke coset module, with
   `single_apply`, `sum_single_index`, `smul_single_one`, `single_add`, `induction_linear`,
   and the `Module R` instance `HeckeCosetModule.instModule`.
-* Pointwise evaluation of the coset module: `zero_apply`, `smul_apply`,
-  `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
+* Pointwise evaluation of the coset module: `zero_apply`, `add_apply`, `smul_apply`,
+  `mem_support_iff`, `notMem_support_iff`, `sum_def`, `sum_apply` and `sum_smul_index`.
   `HeckeCosetModule` is a `def` over `Finsupp`, so Mathlib's evaluation lemmas hold
   definitionally but cannot be matched through the wrapper by `rw`, `simp` or `grind`;
   these are the wrapper-level restatements.
@@ -329,6 +329,17 @@ section EvalSupport
 
 variable {R : Type*} [Zero R]
 
+/-- `Finsupp.mem_support_iff`, at the wrapper type.
+
+Deliberately carries no `@[simp]`/`@[grind =]`: `HeckeCosetModule` defines no `support` of its
+own, so the left-hand side `D ∈ f.support` elaborates to `Finsupp.support f` and would share a
+discrimination key with Mathlib's `@[simp, grind =] Finsupp.mem_support_iff`, whose right-hand
+side differs only by the wrapper coercion — making the normal form order-dependent. It is
+provided as a named lemma so consumers can cite it explicitly. -/
+lemma mem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
+    D ∈ f.support ↔ f D ≠ 0 :=
+  Finsupp.mem_support_iff
+
 /-- `Finsupp.notMem_support_iff`, at the wrapper type. -/
 @[grind =] lemma notMem_support_iff {f : HeckeCosetModule Δ H₁ H₂ R} {D : HeckeCoset Δ H₁ H₂} :
     D ∉ f.support ↔ f D = 0 :=
@@ -355,6 +366,12 @@ variable {R : Type*} [AddCommMonoid R]
 /-- `Finsupp.zero_apply`, at the wrapper type. -/
 @[simp] lemma zero_apply (D : HeckeCoset Δ H₁ H₂) :
     (0 : HeckeCosetModule Δ H₁ H₂ R) D = 0 := (rfl)
+
+/-- `Finsupp.add_apply`, at the wrapper type. Carries no `@[simp]` for the same
+normal-form reason as `mem_support_iff`: the wrapper's `+` is `Finsupp`'s, so Mathlib's
+`Finsupp.add_apply` already matches the same term. -/
+lemma add_apply (f g : HeckeCosetModule Δ H₁ H₂ R) (D : HeckeCoset Δ H₁ H₂) :
+    (f + g) D = f D + g D := (rfl)
 
 end EvalZero
 


### PR DESCRIPTION
`HeckeCosetModule Δ H₁ H₂ R` is a `def` over `HeckeCoset Δ H₁ H₂ →₀ R`, not an `abbrev`.
Mathlib's `Finsupp` evaluation lemmas therefore hold **definitionally** at the wrapper type,
but neither `rw`, `simp` nor `grind` can match them through the definition — a
`rw [Finsupp.smul_apply]` on a `HeckeCosetModule` goal fails even when the goal is
syntactically identical to the lemma.

The consequence is that every consumer needing pointwise evaluation re-derives its own private
copies. `Associativity.lean` alone carried six:

* `smul_apply_T`, `sum_apply_T`, `sum_eq_sum_T`, `zero_apply_T`,
  `apply_eq_zero_of_notMem_support_T`, `sum_smul_index_T`

and further private restatements of the same facts exist elsewhere in the development. Each is
a one-line `rfl` or a direct `Finsupp` citation; the duplication is purely an artefact of the
lemmas not being reachable.

## What this does

Adds one public set beside `single_apply` in `HeckeRing/Basic.lean`:

* `zero_apply`, `add_apply`, `smul_apply` — `rfl` lemmas
* `mem_support_iff`, `notMem_support_iff` — support membership both ways
* `sum_def` — `Finsupp.sum` as an explicit `Finset.sum` over the support
* `sum_apply` — evaluation commutes with a `Finsupp.sum`
* `sum_smul_index` — a scalar pushes into a `Finsupp.sum`

and deletes all six private restatements from `Associativity.lean`, whose use sites now cite
the public names.

Each lemma is stated at the coefficient assumptions its underlying operation actually needs:
`[Zero R]` for the support lemmas, `sum_def` and `sum_apply` — the `FunLike` coercion and
`Finsupp.support` need no more — `[AddCommMonoid R]` for `zero_apply`/`add_apply`, and
`[Semiring R]` for the scalar lemmas. `sum_apply` additionally takes an independent target
coefficient type `[AddCommMonoid S]`. `mem_support_iff`, `add_apply` and `smul_apply` are
`@[simp, grind =]`; `zero_apply` is `@[simp]` only, since its left-hand side is the constant
`0` and `grind` has no pattern to key on.

`notMem_support_iff` is deliberately left unannotated, exactly as `Finsupp.notMem_support_iff`
is in Mathlib (`Data/Finsupp/Defs.lean:156` annotates `mem_support_iff`; `:164` leaves this one
bare): once `mem_support_iff` is a simp lemma, `D ∉ f.support ↔ f D = 0` is provable `by simp`
outright, so annotating it would add a simpNF-redundant lemma.

No mathematical content changes — the deleted lemmas and their replacements are the same
statements with the same proofs.

## Verification

That the wrapper genuinely blocks Mathlib's lemmas is measured, not assumed. Importing only
`Mathlib.NumberTheory.HeckeRing.Defs`, so no TauCeti declaration can interfere:

* `by simp` on `D ∈ f.support ↔ f D ≠ 0` — *unsolved goals*, the goal returned untouched
* `by simp` on `(f + g) D = f D + g D` — *`simp` made no progress*
* `by rw [Finsupp.add_apply]` — *did not find an occurrence of the pattern `(?g₁ + ?g₂) ?a`*

while both statements close in term mode from the corresponding `Finsupp` lemmas. The cause is
that `HeckeCosetModule`'s `FunLike` and `AddCommMonoid` instances are its own `inferInstanceAs`
copies (Mathlib `NumberTheory/HeckeRing/Defs.lean:201,204`). With this PR all three close, and
so does `by grind`.

Full tree build (6686 jobs), `lake exe axioms`, `lake exe module-system` and
`scripts/lint-env.sh` green; no new lint violations.

Roadmap: ModularForms

This is an API fix to already-merged code rather than new mathematics, but the diff touches
only `TauCeti/NumberTheory/HeckeRing/`, which the ModularForms roadmap owns (Layer 2, Hecke
theory), and it is motivated by that lane: the missing lemmas were about to force a seventh
private copy in the `GLn/PolynomialRing` port.
