### PR TITLE
feat: extract the length of a path measured against a density

### DIFF
--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -4,9 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Analysis.Calculus.Deriv.CompMul
 public import Mathlib.Analysis.Calculus.Deriv.Shift
-public import Mathlib.Analysis.Calculus.Deriv.MeanValue
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 
 /-!
@@ -28,14 +26,16 @@ are.
 
 Everything proved below is a statement about the *parameter* side of the integral: how the length
 responds to reversing, splitting or substituting in the parameter interval, and to changing the
-path off that interval. None of it looks at the density, which is carried along as an arbitrary
-function of the point; and none of it looks at the codomain beyond its norm, so `F` is an
-arbitrary real normed space and `γ` an arbitrary map — not necessarily continuous, let alone
-differentiable, `deriv` reading its junk value where the path is not differentiable
-(`TauCeti.densityLength_eq_integral` is the reformulation for a path with a known derivative).
-The hypotheses appear only where the mathematics needs them: nonnegativity of the density for
-`TauCeti.densityLength_nonneg`, differentiability of the path for the two substitution rules,
-which differentiate the composite.
+path off that interval. The reparametrisation and interval-calculus results carry the density
+along unchanged, as an arbitrary function of the point, and only `TauCeti.densityLength_nonneg`
+inspects it at all, asking it to be nonnegative along the path; and none of it looks at the
+codomain beyond its norm, so `F` is an arbitrary real normed space and `γ` an arbitrary map — not
+necessarily continuous, let alone differentiable, `deriv` reading its junk value where the path is
+not differentiable (`TauCeti.densityLength_eq_integral` is the reformulation for a path with a
+known derivative). The hypotheses appear only where the mathematics needs them: nonnegativity of
+the density for `TauCeti.densityLength_nonneg`, differentiability of the path for the two
+substitution rules, which differentiate the composite. Each is asked at the *interior* parameters
+only, the two endpoints forming a null set.
 
 The integral is taken over the **unordered** interval `uIcc a b`, as in Mathlib's
 `Manifold.pathELength`. This is what makes the length independent of the orientation of the
@@ -74,7 +74,7 @@ through the chain rule; the affine rule is `intervalIntegral.integral_comp_mul_a
   derivative being needed only at the interior parameters.
 * `TauCeti.densityLength_nonneg` — a nonnegative density gives a nonnegative length.
 * `TauCeti.densityLength_congr` — the length depends on the path only through its restriction to
-  the parameter interval.
+  the interior of the parameter interval.
 * `TauCeti.densityLength_add` — additivity along the parameter interval.
 * `TauCeti.densityLength_comp_mul_add`, `TauCeti.densityLength_comp_of_deriv_nonneg`,
   `TauCeti.densityLength_comp_of_deriv_nonpos` — invariance under affine, monotone and antitone
@@ -134,14 +134,20 @@ theorem densityLength_const (ρ : F → ℝ) (c : F) (a b : ℝ) :
   rw [densityLength_def]
   simp
 
-/-- **Two paths with the same density-weighted speed over the parameter interval have the same
+/-- The length as an integral over the *open* parameter interval, the two endpoints forming a null
+set. This is what lets every hypothesis below be asked at the interior parameters only. -/
+private theorem densityLength_eq_setIntegral_uIoo (ρ : F → ℝ) (γ : ℝ → F) (a b : ℝ) :
+    densityLength ρ γ a b = ∫ t in uIoo a b, ρ (γ t) * ‖deriv γ t‖ := by
+  rw [densityLength_def, ← Icc_min_max, ← restrict_Ioo_eq_restrict_Icc, Ioo_min_max]
+
+/-- **Two paths with the same density-weighted speed inside the parameter interval have the same
 length.** This is the shape in which a symmetry of the pair `(ρ, γ)` — an isometry of the ambient
 space preserving the density, say — is fed to the length. -/
 theorem densityLength_congr_of_eqOn
-    (h : EqOn (fun t => ρ' (δ t) * ‖deriv δ t‖) (fun t => ρ (γ t) * ‖deriv γ t‖) (uIcc a b)) :
+    (h : EqOn (fun t => ρ' (δ t) * ‖deriv δ t‖) (fun t => ρ (γ t) * ‖deriv γ t‖) (uIoo a b)) :
     densityLength ρ' δ a b = densityLength ρ γ a b := by
-  rw [densityLength_def, densityLength_def]
-  exact setIntegral_congr_fun measurableSet_uIcc h
+  rw [densityLength_eq_setIntegral_uIoo, densityLength_eq_setIntegral_uIoo]
+  exact setIntegral_congr_fun measurableSet_Ioo h
 
 /-- The length over an ordered parameter interval as an interval integral of any function
 agreeing with the density-weighted speed at the interior parameters, the two endpoints forming a
@@ -165,30 +171,29 @@ theorem densityLength_eq_integral (hab : a ≤ b) (hderiv : ∀ t ∈ Ioo a b, H
     densityLength ρ γ a b = ∫ t in a..b, ρ (γ t) * ‖γ' t‖ :=
   densityLength_eq_intervalIntegral_of_eqOn hab fun t ht => by simp only [(hderiv t ht).deriv]
 
-/-- A path along which the density is nonnegative has nonnegative length, whichever way round its
-endpoints are. -/
-theorem densityLength_nonneg (hρ : ∀ t ∈ uIcc a b, 0 ≤ ρ (γ t)) : 0 ≤ densityLength ρ γ a b := by
-  rw [densityLength_def]
-  exact setIntegral_nonneg measurableSet_uIcc fun t ht => mul_nonneg (hρ t ht) (norm_nonneg _)
+/-- A path along which the density is nonnegative inside the parameter interval has nonnegative
+length, whichever way round its endpoints are. -/
+theorem densityLength_nonneg (hρ : ∀ t ∈ uIoo a b, 0 ≤ ρ (γ t)) : 0 ≤ densityLength ρ γ a b := by
+  rw [densityLength_eq_setIntegral_uIoo]
+  exact setIntegral_nonneg measurableSet_Ioo fun t ht => mul_nonneg (hρ t ht) (norm_nonneg _)
 
 /-- The congruence over an ordered parameter interval; the general case follows by symmetry. -/
-private theorem densityLength_congr_of_le (hab : a ≤ b) (hδ : EqOn δ γ (Icc a b)) :
+private theorem densityLength_congr_of_le (hab : a ≤ b) (hδ : EqOn δ γ (Ioo a b)) :
     densityLength ρ δ a b = densityLength ρ γ a b := by
   rw [densityLength_eq_intervalIntegral ρ γ hab]
   refine densityLength_eq_intervalIntegral_of_eqOn hab fun t ht => ?_
-  have hnhds : δ =ᶠ[nhds t] γ :=
-    Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) (hδ.mono Ioo_subset_Icc_self)
-  simp only [hnhds.deriv_eq, hδ (Ioo_subset_Icc_self ht)]
+  have hnhds : δ =ᶠ[nhds t] γ := Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) hδ
+  simp only [hnhds.deriv_eq, hδ ht]
 
-/-- **The length of a path depends only on its parameter interval.** Two paths that agree on the
-interval with endpoints `a` and `b` have the same length over it: at an interior parameter they
+/-- **The length of a path depends only on its parameter interval.** Two paths that agree inside
+the interval with endpoints `a` and `b` have the same length over it: at an interior parameter they
 have the same germ, hence the same derivative, and the two endpoints form a null set. -/
-theorem densityLength_congr (hδ : EqOn δ γ (uIcc a b)) :
+theorem densityLength_congr (hδ : EqOn δ γ (uIoo a b)) :
     densityLength ρ δ a b = densityLength ρ γ a b := by
   rcases le_total a b with hab | hab
-  · rw [uIcc_of_le hab] at hδ
+  · rw [uIoo_of_le hab] at hδ
     exact densityLength_congr_of_le hab hδ
-  · rw [uIcc_comm, uIcc_of_le hab] at hδ
+  · rw [uIoo_comm, uIoo_of_le hab] at hδ
     rw [densityLength_symm ρ δ b a, densityLength_symm ρ γ b a]
     exact densityLength_congr_of_le hab hδ
 

--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -1,0 +1,352 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Calculus.Deriv.CompMul
+public import Mathlib.Analysis.Calculus.Deriv.Shift
+public import Mathlib.Analysis.Calculus.Deriv.MeanValue
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+
+/-!
+# The length of a path measured against a density
+
+A **density** on a real normed space `F` is a function `ρ : F → ℝ`, thought of as a variable
+conversion factor between the ambient norm and the length one wishes to measure. The length of a
+path `γ : ℝ → F` over the parameter interval with endpoints `a` and `b` measured against `ρ` is
+
+`TauCeti.densityLength ρ γ a b = ∫ t in uIcc a b, ρ (γ t) * ‖deriv γ t‖`,
+
+the Euclidean speed `‖deriv γ t‖` weighted by the density at the point the path is passing
+through. Taking `ρ = 1` gives the ordinary length of a `C¹` path; taking `ρ z = (1 - ‖z‖ ^ 2)⁻¹`
+on the complex unit disc gives the hyperbolic length of
+`TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean`, which is where this file's consumers
+are.
+
+## Why the definition is at this level
+
+Everything proved below is a statement about the *parameter* side of the integral: how the length
+responds to reversing, splitting or substituting in the parameter interval, and to changing the
+path off that interval. None of it looks at the density, which is carried along as an arbitrary
+function of the point; and none of it looks at the codomain beyond its norm, so `F` is an
+arbitrary real normed space and `γ` an arbitrary map — not necessarily continuous, let alone
+differentiable, `deriv` reading its junk value where the path is not differentiable
+(`TauCeti.densityLength_eq_integral` is the reformulation for a path with a known derivative).
+The hypotheses appear only where the mathematics needs them: nonnegativity of the density for
+`TauCeti.densityLength_nonneg`, differentiability of the path for the two substitution rules,
+which differentiate the composite.
+
+The integral is taken over the **unordered** interval `uIcc a b`, as in Mathlib's
+`Manifold.pathELength`. This is what makes the length independent of the orientation of the
+parameter interval (`TauCeti.densityLength_symm`) and nonnegative for a nonnegative density
+whichever way round the endpoints are (`TauCeti.densityLength_nonneg`), and it is why the
+substitution rules below hold for antitone substitutions
+(`TauCeti.densityLength_comp_of_deriv_nonpos`) as they stand for monotone ones, with no sign
+correction.
+
+## Relation to Mathlib
+
+Mathlib's `Mathlib/Geometry/Manifold/Riemannian/PathELength.lean` defines `Manifold.pathELength`,
+the `ℝ≥0∞`-valued length of a path in a charted space each of whose tangent spaces carries an
+`ENorm`, and `Manifold.riemannianEDist`, the infimum of such lengths. The two notions are
+different in both directions: `pathELength` measures with a norm on each tangent space, which
+subsumes a scalar density only after the ambient space is given a manifold structure and its
+tangent spaces the corresponding `ENorm`s, and it is `ℝ≥0∞`-valued, whereas a density-weighted
+length of a `C¹` path is an ordinary real number and is compared with real-valued distances
+downstream. `densityLength` is therefore the elementary interval integral rather than a
+`pathELength` specialisation, and the two share no lemma. Should the density-weighted case later
+be routed through a Riemannian structure, the statements below are the ones to refactor.
+
+The substitution rules are Mathlib's change of variables for a monotone or antitone substitution
+(`intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg` and its `nonpos` counterpart) read
+through the chain rule; the affine rule is `intervalIntegral.integral_comp_mul_add`.
+
+## Main definitions
+
+* `TauCeti.densityLength` — the `ρ`-weighted length of a path over a parameter interval.
+
+## Main results
+
+* `TauCeti.densityLength_symm`, `TauCeti.densityLength_self`, `TauCeti.densityLength_const` —
+  the length is unoriented, degenerate intervals and constant paths contributing nothing.
+* `TauCeti.densityLength_eq_integral` — the length computed from an explicit derivative, the
+  derivative being needed only at the interior parameters.
+* `TauCeti.densityLength_nonneg` — a nonnegative density gives a nonnegative length.
+* `TauCeti.densityLength_congr` — the length depends on the path only through its restriction to
+  the parameter interval.
+* `TauCeti.densityLength_add` — additivity along the parameter interval.
+* `TauCeti.densityLength_comp_mul_add`, `TauCeti.densityLength_comp_of_deriv_nonneg`,
+  `TauCeti.densityLength_comp_of_deriv_nonpos` — invariance under affine, monotone and antitone
+  reparametrisation: the length is a property of the path, not of its parametrisation.
+
+## References
+
+* L. V. Ahlfors, *Conformal Invariants*, Ch. 1 (lengths measured against a conformal density).
+-/
+
+public section
+
+namespace TauCeti
+
+open MeasureTheory Set
+
+variable {F : Type*} [NormedAddCommGroup F] [NormedSpace ℝ F]
+  {ρ ρ' : F → ℝ} {γ δ : ℝ → F} {γ' : ℝ → F} {a b : ℝ}
+
+/-- The **length of the path `γ` measured against the density `ρ`**, over the parameter interval
+with endpoints `a` and `b`: the Euclidean speed `‖deriv γ t‖` integrated over the unordered
+interval `uIcc a b` against the weight `ρ (γ t)`.
+
+Taking the integral over the unordered interval makes the length independent of the orientation
+of the parameter interval (`TauCeti.densityLength_symm`); together with
+`TauCeti.densityLength_comp_of_deriv_nonneg` and `TauCeti.densityLength_comp_of_deriv_nonpos` this
+makes it a reparametrisation invariant of the path.
+
+The definition asks nothing of `γ` or of `ρ`; only the derivative at the interior parameters
+enters (`TauCeti.densityLength_eq_integral`), the two endpoints forming a null set. It is the
+intended notion of length when `γ` is a `C¹` path and `ρ` is a positive continuous density, which
+is what the comparisons with a distance downstream assume; the evaluations of the length itself
+need no such hypothesis. -/
+noncomputable def densityLength (ρ : F → ℝ) (γ : ℝ → F) (a b : ℝ) : ℝ :=
+  ∫ t in uIcc a b, ρ (γ t) * ‖deriv γ t‖
+
+/-- The defining formula for the density-weighted length of a path. -/
+theorem densityLength_def (ρ : F → ℝ) (γ : ℝ → F) (a b : ℝ) :
+    densityLength ρ γ a b = ∫ t in uIcc a b, ρ (γ t) * ‖deriv γ t‖ := by
+  rw [densityLength]
+
+/-- A degenerate parameter interval carries no length. -/
+@[simp]
+theorem densityLength_self (ρ : F → ℝ) (γ : ℝ → F) (a : ℝ) : densityLength ρ γ a a = 0 := by
+  rw [densityLength_def, uIcc_self]
+  simp
+
+/-- The length does not depend on the orientation of the parameter interval. -/
+theorem densityLength_symm (ρ : F → ℝ) (γ : ℝ → F) (a b : ℝ) :
+    densityLength ρ γ b a = densityLength ρ γ a b := by
+  rw [densityLength_def, densityLength_def, uIcc_comm]
+
+/-- A constant path has zero length. -/
+@[simp]
+theorem densityLength_const (ρ : F → ℝ) (c : F) (a b : ℝ) :
+    densityLength ρ (fun _ => c) a b = 0 := by
+  rw [densityLength_def]
+  simp
+
+/-- **Two paths with the same density-weighted speed over the parameter interval have the same
+length.** This is the shape in which a symmetry of the pair `(ρ, γ)` — an isometry of the ambient
+space preserving the density, say — is fed to the length. -/
+theorem densityLength_congr_of_eqOn
+    (h : EqOn (fun t => ρ' (δ t) * ‖deriv δ t‖) (fun t => ρ (γ t) * ‖deriv γ t‖) (uIcc a b)) :
+    densityLength ρ' δ a b = densityLength ρ γ a b := by
+  rw [densityLength_def, densityLength_def]
+  exact setIntegral_congr_fun measurableSet_uIcc h
+
+/-- The length over an ordered parameter interval as an interval integral of any function
+agreeing with the density-weighted speed at the interior parameters, the two endpoints forming a
+null set. -/
+private theorem densityLength_eq_intervalIntegral_of_eqOn {f : ℝ → ℝ} (hab : a ≤ b)
+    (hf : EqOn (fun t => ρ (γ t) * ‖deriv γ t‖) f (Ioo a b)) :
+    densityLength ρ γ a b = ∫ t in a..b, f t := by
+  rw [densityLength_def, uIcc_of_le hab, ← restrict_Ioo_eq_restrict_Icc,
+    setIntegral_congr_fun measurableSet_Ioo hf, restrict_Ioo_eq_restrict_Icc,
+    integral_Icc_eq_integral_Ioc, intervalIntegral.integral_of_le hab]
+
+/-- The length over an ordered parameter interval as an interval integral of the density-weighted
+speed. -/
+theorem densityLength_eq_intervalIntegral (ρ : F → ℝ) (γ : ℝ → F) (hab : a ≤ b) :
+    densityLength ρ γ a b = ∫ t in a..b, ρ (γ t) * ‖deriv γ t‖ :=
+  densityLength_eq_intervalIntegral_of_eqOn hab fun _ _ => rfl
+
+/-- The length computed from an explicit derivative rather than from `deriv`. The derivative is
+only asked for at the interior parameters, the two endpoints forming a null set. -/
+theorem densityLength_eq_integral (hab : a ≤ b) (hderiv : ∀ t ∈ Ioo a b, HasDerivAt γ (γ' t) t) :
+    densityLength ρ γ a b = ∫ t in a..b, ρ (γ t) * ‖γ' t‖ :=
+  densityLength_eq_intervalIntegral_of_eqOn hab fun t ht => by simp only [(hderiv t ht).deriv]
+
+/-- A path along which the density is nonnegative has nonnegative length, whichever way round its
+endpoints are. -/
+theorem densityLength_nonneg (hρ : ∀ t ∈ uIcc a b, 0 ≤ ρ (γ t)) : 0 ≤ densityLength ρ γ a b := by
+  rw [densityLength_def]
+  exact setIntegral_nonneg measurableSet_uIcc fun t ht => mul_nonneg (hρ t ht) (norm_nonneg _)
+
+/-- The congruence over an ordered parameter interval; the general case follows by symmetry. -/
+private theorem densityLength_congr_of_le (hab : a ≤ b) (hδ : EqOn δ γ (Icc a b)) :
+    densityLength ρ δ a b = densityLength ρ γ a b := by
+  rw [densityLength_eq_intervalIntegral ρ γ hab]
+  refine densityLength_eq_intervalIntegral_of_eqOn hab fun t ht => ?_
+  have hnhds : δ =ᶠ[nhds t] γ :=
+    Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) (hδ.mono Ioo_subset_Icc_self)
+  simp only [hnhds.deriv_eq, hδ (Ioo_subset_Icc_self ht)]
+
+/-- **The length of a path depends only on its parameter interval.** Two paths that agree on the
+interval with endpoints `a` and `b` have the same length over it: at an interior parameter they
+have the same germ, hence the same derivative, and the two endpoints form a null set. -/
+theorem densityLength_congr (hδ : EqOn δ γ (uIcc a b)) :
+    densityLength ρ δ a b = densityLength ρ γ a b := by
+  rcases le_total a b with hab | hab
+  · rw [uIcc_of_le hab] at hδ
+    exact densityLength_congr_of_le hab hδ
+  · rw [uIcc_comm, uIcc_of_le hab] at hδ
+    rw [densityLength_symm ρ δ b a, densityLength_symm ρ γ b a]
+    exact densityLength_congr_of_le hab hδ
+
+/-- **The length is additive along the parameter interval**: the lengths of the two halves of a
+path add up to the length of the whole, as soon as the density-weighted speed is integrable over
+the whole. For a `C¹` path and a continuous density that hypothesis holds by continuity. -/
+theorem densityLength_add {a b c : ℝ} (hab : a ≤ b) (hbc : b ≤ c)
+    (hint : IntervalIntegrable (fun t => ρ (γ t) * ‖deriv γ t‖) volume a c) :
+    densityLength ρ γ a b + densityLength ρ γ b c = densityLength ρ γ a c := by
+  have hac : a ≤ c := hab.trans hbc
+  rw [densityLength_eq_intervalIntegral ρ γ hab, densityLength_eq_intervalIntegral ρ γ hbc,
+    densityLength_eq_intervalIntegral ρ γ hac]
+  refine intervalIntegral.integral_add_adjacent_intervals (hint.mono_set ?_) (hint.mono_set ?_)
+  · rw [uIcc_of_le hab, uIcc_of_le hac]
+    exact Icc_subset_Icc le_rfl hbc
+  · rw [uIcc_of_le hbc, uIcc_of_le hac]
+    exact Icc_subset_Icc hab le_rfl
+
+/-- The affine reparametrisation invariance over an ordered parameter interval; the general case
+follows by symmetry. -/
+private theorem densityLength_comp_mul_add_of_le (ρ : F → ℝ) (γ : ℝ → F) {s : ℝ} (hs : s ≠ 0)
+    (d : ℝ) (hab : a ≤ b) :
+    densityLength ρ (fun t => γ (s * t + d)) a b = densityLength ρ γ (s * a + d) (s * b + d) := by
+  have hderiv : ∀ t : ℝ, deriv (fun u : ℝ => γ (s * u + d)) t = s • deriv γ (s * t + d) := by
+    intro t
+    have h := deriv_comp_mul_left s (fun u : ℝ => γ (u + d)) t
+    rw [deriv_comp_add_const] at h
+    simpa using h
+  have hLHS : densityLength ρ (fun t => γ (s * t + d)) a b
+      = |s| * ∫ t in a..b, ρ (γ (s * t + d)) * ‖deriv γ (s * t + d)‖ := by
+    rw [densityLength_eq_intervalIntegral _ _ hab, ← intervalIntegral.integral_const_mul]
+    refine intervalIntegral.integral_congr fun t _ => ?_
+    rw [hderiv t, norm_smul, Real.norm_eq_abs]
+    ring
+  rw [hLHS, intervalIntegral.integral_comp_mul_add
+    (fun u => ρ (γ u) * ‖deriv γ u‖) hs d, smul_eq_mul]
+  rcases hs.lt_or_gt with hneg | hpos
+  · have hle : s * b + d ≤ s * a + d := by nlinarith
+    rw [densityLength_symm, densityLength_eq_intervalIntegral _ _ hle,
+      intervalIntegral.integral_symm (s * a + d) (s * b + d), abs_of_neg hneg]
+    field_simp
+  · have hle : s * a + d ≤ s * b + d := by nlinarith
+    rw [densityLength_eq_intervalIntegral _ _ hle, abs_of_pos hpos]
+    field_simp
+
+/-- **The length is invariant under affine reparametrisation.** Replacing the parameter `t` by
+`s * t + d` for `s ≠ 0`, an orientation-preserving reparametrisation for `0 < s` and an
+orientation-reversing one for `s < 0`, transports the parameter interval and leaves the length
+unchanged. Being a change of variables in the parameter alone, it asks nothing of the path, unlike
+the reparametrisations by a general monotone or antitone map below
+(`TauCeti.densityLength_comp_of_deriv_nonneg`, `TauCeti.densityLength_comp_of_deriv_nonpos`),
+which need the path to be differentiable to differentiate the composite. -/
+theorem densityLength_comp_mul_add (ρ : F → ℝ) (γ : ℝ → F) {s : ℝ} (hs : s ≠ 0) (d a b : ℝ) :
+    densityLength ρ (fun t => γ (s * t + d)) a b = densityLength ρ γ (s * a + d) (s * b + d) := by
+  rcases le_total a b with hab | hab
+  · exact densityLength_comp_mul_add_of_le ρ γ hs d hab
+  · rw [densityLength_symm ρ (fun t => γ (s * t + d)) b a,
+      densityLength_symm ρ γ (s * b + d) (s * a + d)]
+    exact densityLength_comp_mul_add_of_le ρ γ hs d hab
+
+/-- The monotone reparametrisation invariance over an ordered parameter interval; the general case
+follows by symmetry. -/
+private theorem densityLength_comp_of_deriv_nonneg_of_le {φ φ' : ℝ → ℝ} (hab : a ≤ b)
+    (hφ : ContinuousOn φ (Icc a b)) (hderiv : ∀ t ∈ Ioo a b, HasDerivAt φ (φ' t) t)
+    (hsign : ∀ t ∈ Ioo a b, 0 ≤ φ' t) (hγ : ∀ t ∈ Ioo a b, DifferentiableAt ℝ γ (φ t)) :
+    densityLength ρ (γ ∘ φ) a b = densityLength ρ γ (φ a) (φ b) := by
+  have hIoo : Ioo (min a b) (max a b) = Ioo a b := by rw [min_eq_left hab, max_eq_right hab]
+  -- inside the parameter interval the density-weighted speed of `γ ∘ φ` is `φ'` times that of
+  -- `γ` read at `φ`, written as a composition to meet the change of variables below
+  have hEq : EqOn (fun t => ρ ((γ ∘ φ) t) * ‖deriv (γ ∘ φ) t‖)
+      (fun t => φ' t • ((fun u => ρ (γ u) * ‖deriv γ u‖) ∘ φ) t) (Ioo a b) := by
+    intro t ht
+    have hchain : deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
+      ((hγ t ht).hasDerivAt.scomp t (hderiv t ht)).deriv
+    simp only [Function.comp_apply, hchain, norm_smul, Real.norm_eq_abs,
+      abs_of_nonneg (hsign t ht), smul_eq_mul]
+    ring
+  have hmono : MonotoneOn φ (Icc a b) := by
+    refine monotoneOn_of_deriv_nonneg (convex_Icc a b) hφ (fun t ht => ?_) fun t ht => ?_
+    · rw [interior_Icc] at ht
+      exact (hderiv t ht).differentiableAt.differentiableWithinAt
+    · rw [interior_Icc] at ht
+      rw [(hderiv t ht).deriv]
+      exact hsign t ht
+  have hφab : φ a ≤ φ b := hmono (left_mem_Icc.2 hab) (right_mem_Icc.2 hab) hab
+  rw [densityLength_eq_intervalIntegral_of_eqOn hab hEq,
+    intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg (by rwa [uIcc_of_le hab])
+      (by rwa [hIoo]) (by rwa [hIoo]),
+    ← densityLength_eq_intervalIntegral ρ γ hφab]
+
+/-- **The length is invariant under monotone reparametrisation.** Precomposing a path with a map
+`φ` that is continuous on the parameter interval and has a nonnegative derivative inside it — so
+that `φ` is monotone there — reparametrises the path and transports the parameter interval,
+leaving the length unchanged. The path is asked to be differentiable at the reparametrised
+parameters, which is what makes the composite differentiable; no regularity beyond that is needed,
+because Mathlib's change of variables for a monotone substitution
+(`intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg`) asks nothing of the integrand. -/
+theorem densityLength_comp_of_deriv_nonneg {φ φ' : ℝ → ℝ} (hφ : ContinuousOn φ (uIcc a b))
+    (hderiv : ∀ t ∈ uIoo a b, HasDerivAt φ (φ' t) t) (hsign : ∀ t ∈ uIoo a b, 0 ≤ φ' t)
+    (hγ : ∀ t ∈ uIoo a b, DifferentiableAt ℝ γ (φ t)) :
+    densityLength ρ (γ ∘ φ) a b = densityLength ρ γ (φ a) (φ b) := by
+  rcases le_total a b with hab | hab
+  · rw [uIcc_of_le hab] at hφ
+    rw [uIoo_of_le hab] at hderiv hsign hγ
+    exact densityLength_comp_of_deriv_nonneg_of_le hab hφ hderiv hsign hγ
+  · rw [uIcc_comm, uIcc_of_le hab] at hφ
+    rw [uIoo_comm, uIoo_of_le hab] at hderiv hsign hγ
+    rw [densityLength_symm ρ (γ ∘ φ) b a, densityLength_symm ρ γ (φ b) (φ a)]
+    exact densityLength_comp_of_deriv_nonneg_of_le hab hφ hderiv hsign hγ
+
+/-- The antitone reparametrisation invariance over an ordered parameter interval; the general case
+follows by symmetry. -/
+private theorem densityLength_comp_of_deriv_nonpos_of_le {φ φ' : ℝ → ℝ} (hab : a ≤ b)
+    (hφ : ContinuousOn φ (Icc a b)) (hderiv : ∀ t ∈ Ioo a b, HasDerivAt φ (φ' t) t)
+    (hsign : ∀ t ∈ Ioo a b, φ' t ≤ 0) (hγ : ∀ t ∈ Ioo a b, DifferentiableAt ℝ γ (φ t)) :
+    densityLength ρ (γ ∘ φ) a b = densityLength ρ γ (φ a) (φ b) := by
+  have hIoo : Ioo (min a b) (max a b) = Ioo a b := by rw [min_eq_left hab, max_eq_right hab]
+  -- as in the monotone case, save that `φ'` is now nonpositive, so that the speed of `γ ∘ φ`
+  -- is *minus* `φ'` times the speed of `γ` read at `φ`
+  have hEq : EqOn (fun t => ρ ((γ ∘ φ) t) * ‖deriv (γ ∘ φ) t‖)
+      (fun t => -(φ' t • ((fun u => ρ (γ u) * ‖deriv γ u‖) ∘ φ) t)) (Ioo a b) := by
+    intro t ht
+    have hchain : deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
+      ((hγ t ht).hasDerivAt.scomp t (hderiv t ht)).deriv
+    simp only [Function.comp_apply, hchain, norm_smul, Real.norm_eq_abs,
+      abs_of_nonpos (hsign t ht), smul_eq_mul]
+    ring
+  have hanti : AntitoneOn φ (Icc a b) := by
+    refine antitoneOn_of_deriv_nonpos (convex_Icc a b) hφ (fun t ht => ?_) fun t ht => ?_
+    · rw [interior_Icc] at ht
+      exact (hderiv t ht).differentiableAt.differentiableWithinAt
+    · rw [interior_Icc] at ht
+      rw [(hderiv t ht).deriv]
+      exact hsign t ht
+  have hφab : φ b ≤ φ a := hanti (left_mem_Icc.2 hab) (right_mem_Icc.2 hab) hab
+  rw [densityLength_eq_intervalIntegral_of_eqOn hab hEq, intervalIntegral.integral_neg,
+    intervalIntegral.integral_deriv_smul_comp_of_deriv_nonpos (by rwa [uIcc_of_le hab])
+      (by rwa [hIoo]) (by rwa [hIoo]),
+    ← intervalIntegral.integral_symm, densityLength_symm ρ γ (φ b) (φ a),
+    ← densityLength_eq_intervalIntegral ρ γ hφab]
+
+/-- **The length is invariant under antitone reparametrisation.** The orientation-reversing
+counterpart of `TauCeti.densityLength_comp_of_deriv_nonneg`: precomposing a path with a map `φ`
+that is continuous on the parameter interval and has a nonpositive derivative inside it — so that
+`φ` is antitone there — leaves the length unchanged, the parameter interval being transported with
+its orientation reversed. Together the two lemmas say that the length is a property of a path
+rather than of its parametrisation. -/
+theorem densityLength_comp_of_deriv_nonpos {φ φ' : ℝ → ℝ} (hφ : ContinuousOn φ (uIcc a b))
+    (hderiv : ∀ t ∈ uIoo a b, HasDerivAt φ (φ' t) t) (hsign : ∀ t ∈ uIoo a b, φ' t ≤ 0)
+    (hγ : ∀ t ∈ uIoo a b, DifferentiableAt ℝ γ (φ t)) :
+    densityLength ρ (γ ∘ φ) a b = densityLength ρ γ (φ a) (φ b) := by
+  rcases le_total a b with hab | hab
+  · rw [uIcc_of_le hab] at hφ
+    rw [uIoo_of_le hab] at hderiv hsign hγ
+    exact densityLength_comp_of_deriv_nonpos_of_le hab hφ hderiv hsign hγ
+  · rw [uIcc_comm, uIcc_of_le hab] at hφ
+    rw [uIoo_comm, uIoo_of_le hab] at hderiv hsign hγ
+    rw [densityLength_symm ρ (γ ∘ φ) b a, densityLength_symm ρ γ (φ b) (φ a)]
+    exact densityLength_comp_of_deriv_nonpos_of_le hab hφ hderiv hsign hγ
+
+end TauCeti

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -240,8 +240,9 @@ theorem hyperbolicLength_eq_integral (hab : a ≤ b)
     densityLength_eq_integral (ρ := fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) hab hderiv
 
 /-- A path running through the open unit disc has nonnegative hyperbolic length, whichever way
-round its endpoints are: the Poincaré density is positive there. -/
-theorem hyperbolicLength_nonneg (hmem : ∀ t ∈ uIcc a b, ‖γ t‖ < 1) :
+round its endpoints are: the Poincaré density is positive there. Only the interior parameters are
+asked about, the two endpoints forming a null set. -/
+theorem hyperbolicLength_nonneg (hmem : ∀ t ∈ uIoo a b, ‖γ t‖ < 1) :
     0 ≤ hyperbolicLength γ a b :=
   densityLength_nonneg fun t ht =>
     inv_nonneg.2 (by nlinarith [norm_nonneg (γ t), hmem t ht])
@@ -259,10 +260,10 @@ private theorem intervalIntegrable_norm_div_one_sub_norm_sq (hab : a ≤ b)
   exact hpos.ne'
 
 /-- **The hyperbolic length of a path depends only on its parameter interval.** Two paths that
-agree on the interval with endpoints `a` and `b` have the same hyperbolic length over it: at an
+agree inside the interval with endpoints `a` and `b` have the same hyperbolic length over it: at an
 interior parameter they have the same germ, hence the same derivative, and the two endpoints form
 a null set. -/
-theorem hyperbolicLength_congr {δ : ℝ → ℂ} (hδ : EqOn δ γ (uIcc a b)) :
+theorem hyperbolicLength_congr {δ : ℝ → ℂ} (hδ : EqOn δ γ (uIoo a b)) :
     hyperbolicLength δ a b = hyperbolicLength γ a b :=
   densityLength_congr hδ
 
@@ -482,7 +483,8 @@ theorem hyperbolicLength_comp_eq_of_leftInvOn {f g : ℂ → ℂ}
     ((hf.analyticOnNhd isOpen_ball).deriv.continuousOn).comp hγ hball
   have key := hyperbolicLength_comp_le hg hgmaps (hf.continuousOn.comp hγ hball) hcomp
     (hγ'.mul hdf) hfmem
-  rwa [hyperbolicLength_congr (δ := g ∘ (f ∘ γ)) fun t ht => hgf (hball ht)] at key
+  rwa [hyperbolicLength_congr (δ := g ∘ (f ∘ γ)) fun t ht =>
+    hgf (hball (uIoo_subset_uIcc_self ht))] at key
 
 /-! ## The distance is a lower bound for the length -/
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -4,13 +4,13 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import TauCeti.Analysis.Calculus.DensityLength
 public import TauCeti.Analysis.Complex.Conformal.Hyperbolic.ClosedForm
 public import TauCeti.Analysis.Complex.Conformal.Moebius
 public import TauCeti.Analysis.Complex.Conformal.SchwarzPick.AutomorphismIsometry
 public import TauCeti.Analysis.Complex.Conformal.SchwarzPick.Derivative
 public import TauCeti.Analysis.SpecialFunctions.Artanh
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.DistLEIntegral
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 import Mathlib.Analysis.Calculus.Deriv.Star
 import Mathlib.Analysis.Complex.CauchyIntegral
 
@@ -32,7 +32,14 @@ The definition is the obvious one: for a path `γ : ℝ → ℂ` in the disc,
 
 the Euclidean speed integrated against the Poincaré density over the *unordered* parameter
 interval, as for Mathlib's `Manifold.pathELength`: the length of a path does not depend on the
-orientation of its parameter interval, and is nonnegative. The theorem is that
+orientation of its parameter interval, and is nonnegative. That is the length of `γ` measured
+against the density `(1 - ‖z‖ ^ 2)⁻¹` in the sense of `TauCeti.densityLength` of
+`TauCeti/Analysis/Calculus/DensityLength.lean`, and `hyperbolicLength` is *defined* as that
+instance: everything about the *parameter* side of the integral — that the length is unoriented
+and additive, that it depends on the path only through its restriction to the parameter interval,
+and that it is unchanged by an affine, monotone or antitone reparametrisation — is proved there,
+for an arbitrary density on an arbitrary real normed space, and is only read off here. What this
+file adds is what the Poincaré density itself contributes. The theorem is that
 `hyperbolicDist z w` is the **least** such length over `C¹` paths from `z` to `w`
 (`TauCeti.isLeast_hyperbolicLength`): no path is shorter
 (`TauCeti.hyperbolicDist_le_hyperbolicLength`), and one path realises the value
@@ -107,16 +114,12 @@ the Poincaré disc as `Conformal/Poincare/Isometry/Classification.lean` exhibits
 
 ## Relation to Mathlib's `Manifold.pathELength`
 
-Mathlib's `Mathlib/Geometry/Manifold/Riemannian/PathELength.lean` defines `Manifold.pathELength`
-and `Manifold.riemannianEDist`, the infimum of path lengths, for a charted space each of whose
-tangent spaces carries an `ENorm`. Routing this file through it would first require equipping the
-open unit disc with a manifold structure and its tangent spaces with the Poincaré `ENorm`, none of
-which exists in this tree; and it would state the result in `ℝ≥0∞`, whereas `hyperbolicDist` and
-the entire disc development are real-valued. `hyperbolicLength` is therefore the elementary
-integral over the parameter interval rather than a `pathELength` specialisation. Should the
-Poincaré disc later be given a Riemannian structure, `TauCeti.isLeast_hyperbolicLength` is
-precisely the input needed to identify `hyperbolicDist` with `Manifold.riemannianEDist`, and this
-file should be refactored onto that API at that point.
+Why `TauCeti.densityLength`, and not Mathlib's `ℝ≥0∞`-valued `Manifold.pathELength` of
+`Mathlib/Geometry/Manifold/Riemannian/PathELength.lean`, is the notion being instantiated is
+argued in `TauCeti/Analysis/Calculus/DensityLength.lean`. Should the Poincaré disc later be given
+a Riemannian structure, `TauCeti.isLeast_hyperbolicLength` is precisely the input needed to
+identify `hyperbolicDist` with `Manifold.riemannianEDist`, and this file should be refactored onto
+that API at that point.
 
 ## Main declarations
 
@@ -133,6 +136,12 @@ file should be refactored onto that API at that point.
   `TauCeti.hyperbolicLength_comp_mul_add`.
 * `TauCeti.hyperbolicLength_congr` — the hyperbolic length of a path depends only on its values
   along its own parameter interval.
+
+  These last three groups are the Poincaré readings of the density-independent statements
+  `TauCeti.densityLength_symm`, `TauCeti.densityLength_nonneg`, `TauCeti.densityLength_const`,
+  `TauCeti.densityLength_add`, `TauCeti.densityLength_comp_of_deriv_nonneg`,
+  `TauCeti.densityLength_comp_of_deriv_nonpos`, `TauCeti.densityLength_comp_mul_add` and
+  `TauCeti.densityLength_congr`, and are proved by naming them.
 * `TauCeti.hyperbolicLength_unitDiscMoebiusFormula_comp` — hyperbolic length is a Moebius
   invariant, the integrated form of the infinitesimal isometry
   `TauCeti.norm_deriv_div_one_sub_norm_sq_unitDiscMoebiusFormula_of_norm_lt_one`;
@@ -179,8 +188,10 @@ variable {γ γ' : ℝ → ℂ} {a b : ℝ} {c z w : ℂ}
 /-! ## The hyperbolic length of a path -/
 
 /-- The **hyperbolic length** of the path `γ` over the parameter interval with endpoints `a` and
-`b`: the Euclidean speed `‖deriv γ t‖` integrated over the unordered interval `uIcc a b` against
-the Poincaré density `(1 - ‖γ t‖ ^ 2)⁻¹` of `Conformal/Hyperbolic/Density.lean`.
+`b`: its length measured against the Poincaré density `(1 - ‖z‖ ^ 2)⁻¹` of
+`Conformal/Hyperbolic/Density.lean`, in the sense of `TauCeti.densityLength`. Unfolded, it is the
+Euclidean speed `‖deriv γ t‖` integrated over the unordered interval `uIcc a b` against that
+density (`TauCeti.hyperbolicLength_def`).
 
 Taking the integral over the unordered interval, as Mathlib's `Manifold.pathELength` does, makes
 the length independent of the orientation of the parameter interval
@@ -196,57 +207,44 @@ when `γ` is a `C¹` path with values in the open unit disc, which is what the c
 `TauCeti.hyperbolicDist` below assumes; the evaluations of the length itself need no such
 hypothesis. -/
 noncomputable def hyperbolicLength (γ : ℝ → ℂ) (a b : ℝ) : ℝ :=
-  ∫ t in uIcc a b, ‖deriv γ t‖ / (1 - ‖γ t‖ ^ 2)
+  densityLength (fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) γ a b
 
 /-- The defining formula for the hyperbolic length of a path. -/
 theorem hyperbolicLength_def (γ : ℝ → ℂ) (a b : ℝ) :
     hyperbolicLength γ a b = ∫ t in uIcc a b, ‖deriv γ t‖ / (1 - ‖γ t‖ ^ 2) := by
-  rw [hyperbolicLength]
+  simp only [hyperbolicLength, densityLength_def, div_eq_inv_mul]
 
 /-- A degenerate parameter interval carries no hyperbolic length. -/
 @[simp]
-theorem hyperbolicLength_self (γ : ℝ → ℂ) (a : ℝ) : hyperbolicLength γ a a = 0 := by
-  rw [hyperbolicLength_def, uIcc_self]
-  simp
+theorem hyperbolicLength_self (γ : ℝ → ℂ) (a : ℝ) : hyperbolicLength γ a a = 0 :=
+  densityLength_self _ γ a
 
 /-- Hyperbolic length does not depend on the orientation of the parameter interval. -/
 theorem hyperbolicLength_symm (γ : ℝ → ℂ) (a b : ℝ) :
-    hyperbolicLength γ b a = hyperbolicLength γ a b := by
-  rw [hyperbolicLength_def, hyperbolicLength_def, uIcc_comm]
+    hyperbolicLength γ b a = hyperbolicLength γ a b :=
+  densityLength_symm _ γ a b
 
 /-- A constant path has zero hyperbolic length. -/
 @[simp]
 theorem hyperbolicLength_const (c : ℂ) (a b : ℝ) :
-    hyperbolicLength (fun _ => c) a b = 0 := by
-  rw [hyperbolicLength_def]
-  simp
-
-/-- The hyperbolic length over an ordered parameter interval as an interval integral of any
-function agreeing with the density-weighted speed at the interior parameters, the two endpoints
-forming a null set. -/
-private theorem hyperbolicLength_eq_intervalIntegral_of_eqOn {f : ℝ → ℝ} (hab : a ≤ b)
-    (hf : EqOn (fun t => ‖deriv γ t‖ / (1 - ‖γ t‖ ^ 2)) f (Ioo a b)) :
-    hyperbolicLength γ a b = ∫ t in a..b, f t := by
-  rw [hyperbolicLength_def, uIcc_of_le hab,
-    ← MeasureTheory.restrict_Ioo_eq_restrict_Icc,
-    MeasureTheory.setIntegral_congr_fun measurableSet_Ioo hf,
-    MeasureTheory.restrict_Ioo_eq_restrict_Icc,
-    MeasureTheory.integral_Icc_eq_integral_Ioc, intervalIntegral.integral_of_le hab]
+    hyperbolicLength (fun _ => c) a b = 0 :=
+  densityLength_const _ c a b
 
 /-- The hyperbolic length computed from an explicit derivative rather than from `deriv`. The
 derivative is only asked for at the interior parameters, the two endpoints forming a null set. -/
 theorem hyperbolicLength_eq_integral (hab : a ≤ b)
     (hderiv : ∀ t ∈ Ioo a b, HasDerivAt γ (γ' t) t) :
-    hyperbolicLength γ a b = ∫ t in a..b, ‖γ' t‖ / (1 - ‖γ t‖ ^ 2) :=
-  hyperbolicLength_eq_intervalIntegral_of_eqOn hab fun t ht => by simp only [(hderiv t ht).deriv]
+    hyperbolicLength γ a b = ∫ t in a..b, ‖γ' t‖ / (1 - ‖γ t‖ ^ 2) := by
+  rw [hyperbolicLength]
+  simpa only [div_eq_inv_mul] using
+    densityLength_eq_integral (ρ := fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) hab hderiv
 
 /-- A path running through the open unit disc has nonnegative hyperbolic length, whichever way
-round its endpoints are. -/
+round its endpoints are: the Poincaré density is positive there. -/
 theorem hyperbolicLength_nonneg (hmem : ∀ t ∈ uIcc a b, ‖γ t‖ < 1) :
-    0 ≤ hyperbolicLength γ a b := by
-  rw [hyperbolicLength_def]
-  exact MeasureTheory.setIntegral_nonneg measurableSet_uIcc fun t ht =>
-    div_nonneg (norm_nonneg _) (by nlinarith [norm_nonneg (γ t), hmem t ht])
+    0 ≤ hyperbolicLength γ a b :=
+  densityLength_nonneg fun t ht =>
+    inv_nonneg.2 (by nlinarith [norm_nonneg (γ t), hmem t ht])
 
 /-- For a `C¹` path in the disc the density-weighted speed is interval integrable: it is
 continuous, its denominator staying away from zero because the path stays in the open disc. -/
@@ -260,33 +258,13 @@ private theorem intervalIntegrable_norm_div_one_sub_norm_sq (hab : a ≤ b)
   have hpos : (0 : ℝ) < 1 - ‖γ t‖ ^ 2 := by nlinarith [norm_nonneg (γ t), hmem t ht]
   exact hpos.ne'
 
-/-- The hyperbolic length over an ordered parameter interval as an interval integral of the
-density-weighted speed. -/
-private theorem hyperbolicLength_eq_intervalIntegral (γ : ℝ → ℂ) (hab : a ≤ b) :
-    hyperbolicLength γ a b = ∫ t in a..b, ‖deriv γ t‖ / (1 - ‖γ t‖ ^ 2) :=
-  hyperbolicLength_eq_intervalIntegral_of_eqOn hab fun _ _ => rfl
-
-/-- The congruence over an ordered parameter interval; the general case follows by symmetry. -/
-private theorem hyperbolicLength_congr_of_le {δ : ℝ → ℂ} (hab : a ≤ b)
-    (hδ : EqOn δ γ (Icc a b)) : hyperbolicLength δ a b = hyperbolicLength γ a b := by
-  rw [hyperbolicLength_eq_intervalIntegral γ hab]
-  refine hyperbolicLength_eq_intervalIntegral_of_eqOn hab fun t ht => ?_
-  have hnhds : δ =ᶠ[nhds t] γ :=
-    Filter.eventuallyEq_of_mem (isOpen_Ioo.mem_nhds ht) (hδ.mono Ioo_subset_Icc_self)
-  simp only [hnhds.deriv_eq, hδ (Ioo_subset_Icc_self ht)]
-
 /-- **The hyperbolic length of a path depends only on its parameter interval.** Two paths that
 agree on the interval with endpoints `a` and `b` have the same hyperbolic length over it: at an
 interior parameter they have the same germ, hence the same derivative, and the two endpoints form
 a null set. -/
 theorem hyperbolicLength_congr {δ : ℝ → ℂ} (hδ : EqOn δ γ (uIcc a b)) :
-    hyperbolicLength δ a b = hyperbolicLength γ a b := by
-  rcases le_total a b with hab | hab
-  · rw [uIcc_of_le hab] at hδ
-    exact hyperbolicLength_congr_of_le hab hδ
-  · rw [uIcc_comm, uIcc_of_le hab] at hδ
-    rw [hyperbolicLength_symm δ b a, hyperbolicLength_symm γ b a]
-    exact hyperbolicLength_congr_of_le hab hδ
+    hyperbolicLength δ a b = hyperbolicLength γ a b :=
+  densityLength_congr hδ
 
 /-- **Hyperbolic length is additive along the parameter interval**: the lengths of the two halves
 of a path add up to the length of the whole, as soon as the density-weighted speed is integrable
@@ -294,42 +272,8 @@ over the whole. For a `C¹` path in the disc that hypothesis holds by continuity
 theorem hyperbolicLength_add {a b c : ℝ} (hab : a ≤ b) (hbc : b ≤ c)
     (hint : IntervalIntegrable (fun t => ‖deriv γ t‖ / (1 - ‖γ t‖ ^ 2))
       MeasureTheory.volume a c) :
-    hyperbolicLength γ a b + hyperbolicLength γ b c = hyperbolicLength γ a c := by
-  have hac : a ≤ c := hab.trans hbc
-  rw [hyperbolicLength_eq_intervalIntegral γ hab, hyperbolicLength_eq_intervalIntegral γ hbc,
-    hyperbolicLength_eq_intervalIntegral γ hac]
-  refine intervalIntegral.integral_add_adjacent_intervals (hint.mono_set ?_) (hint.mono_set ?_)
-  · rw [uIcc_of_le hab, uIcc_of_le hac]
-    exact Icc_subset_Icc le_rfl hbc
-  · rw [uIcc_of_le hbc, uIcc_of_le hac]
-    exact Icc_subset_Icc hab le_rfl
-
-/-- The affine reparametrisation invariance over an ordered parameter interval; the general case
-follows by symmetry. -/
-private theorem hyperbolicLength_comp_mul_add_of_le (γ : ℝ → ℂ) {s : ℝ} (hs : s ≠ 0) (d : ℝ)
-    (hab : a ≤ b) :
-    hyperbolicLength (fun t => γ (s * t + d)) a b
-      = hyperbolicLength γ (s * a + d) (s * b + d) := by
-  have hderiv : ∀ t : ℝ, deriv (fun u : ℝ => γ (s * u + d)) t = s • deriv γ (s * t + d) := by
-    intro t
-    have h := deriv_comp_mul_left s (fun u : ℝ => γ (u + d)) t
-    rw [deriv_comp_add_const] at h
-    simpa using h
-  have hLHS : hyperbolicLength (fun t => γ (s * t + d)) a b
-      = |s| * ∫ t in a..b, ‖deriv γ (s * t + d)‖ / (1 - ‖γ (s * t + d)‖ ^ 2) := by
-    rw [hyperbolicLength_eq_intervalIntegral _ hab, ← intervalIntegral.integral_const_mul]
-    refine intervalIntegral.integral_congr fun t _ => ?_
-    rw [hderiv t, norm_smul, Real.norm_eq_abs, mul_div_assoc]
-  rw [hLHS, intervalIntegral.integral_comp_mul_add
-    (fun u => ‖deriv γ u‖ / (1 - ‖γ u‖ ^ 2)) hs d, smul_eq_mul]
-  rcases hs.lt_or_gt with hneg | hpos
-  · have hle : s * b + d ≤ s * a + d := by nlinarith
-    rw [hyperbolicLength_symm, hyperbolicLength_eq_intervalIntegral _ hle,
-      intervalIntegral.integral_symm (s * a + d) (s * b + d), abs_of_neg hneg]
-    field_simp
-  · have hle : s * a + d ≤ s * b + d := by nlinarith
-    rw [hyperbolicLength_eq_intervalIntegral _ hle, abs_of_pos hpos]
-    field_simp
+    hyperbolicLength γ a b + hyperbolicLength γ b c = hyperbolicLength γ a c :=
+  densityLength_add hab hbc (by simpa only [div_eq_inv_mul] using hint)
 
 /-- **Hyperbolic length is invariant under affine reparametrisation.** Replacing the parameter `t`
 by `s * t + d` for `s ≠ 0`, an orientation-preserving reparametrisation for `0 < s` and an
@@ -337,100 +281,21 @@ orientation-reversing one for `s < 0`, transports the parameter interval and lea
 unchanged: two affinely reparametrised copies of one path have the same hyperbolic length. For
 instance `s = r`, `d = 0` reads the path of
 `TauCeti.exists_hyperbolicLength_eq_hyperbolicDist`, defined on `[0, r]`, on the parameter
-interval `[0, 1]` without changing its length. Being a change of variables in the parameter alone,
-it asks nothing of the path, unlike the reparametrisations by a general monotone or antitone map
-below (`TauCeti.hyperbolicLength_comp_of_deriv_nonneg`,
-`TauCeti.hyperbolicLength_comp_of_deriv_nonpos`), which need the path to be differentiable to
-differentiate the composite. -/
+interval `[0, 1]` without changing its length. -/
 theorem hyperbolicLength_comp_mul_add (γ : ℝ → ℂ) {s : ℝ} (hs : s ≠ 0) (d a b : ℝ) :
     hyperbolicLength (fun t => γ (s * t + d)) a b
-      = hyperbolicLength γ (s * a + d) (s * b + d) := by
-  rcases le_total a b with hab | hab
-  · exact hyperbolicLength_comp_mul_add_of_le γ hs d hab
-  · rw [hyperbolicLength_symm (fun t => γ (s * t + d)) b a,
-      hyperbolicLength_symm γ (s * b + d) (s * a + d)]
-    exact hyperbolicLength_comp_mul_add_of_le γ hs d hab
-
-/-- The monotone reparametrisation invariance over an ordered parameter interval; the general case
-follows by symmetry. -/
-private theorem hyperbolicLength_comp_of_deriv_nonneg_of_le {φ φ' : ℝ → ℝ} (hab : a ≤ b)
-    (hφ : ContinuousOn φ (Icc a b)) (hderiv : ∀ t ∈ Ioo a b, HasDerivAt φ (φ' t) t)
-    (hsign : ∀ t ∈ Ioo a b, 0 ≤ φ' t) (hγ : ∀ t ∈ Ioo a b, DifferentiableAt ℝ γ (φ t)) :
-    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) := by
-  have hIoo : Ioo (min a b) (max a b) = Ioo a b := by rw [min_eq_left hab, max_eq_right hab]
-  -- inside the parameter interval the density-weighted speed of `γ ∘ φ` is `φ'` times that of
-  -- `γ` read at `φ`, written as a composition to meet the change of variables below
-  have hEq : EqOn (fun t => ‖deriv (γ ∘ φ) t‖ / (1 - ‖(γ ∘ φ) t‖ ^ 2))
-      (fun t => φ' t • ((fun u => ‖deriv γ u‖ / (1 - ‖γ u‖ ^ 2)) ∘ φ) t) (Ioo a b) := by
-    intro t ht
-    have hchain : deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
-      ((hγ t ht).hasDerivAt.scomp t (hderiv t ht)).deriv
-    simp only [Function.comp_apply, hchain, norm_smul, Real.norm_eq_abs,
-      abs_of_nonneg (hsign t ht), smul_eq_mul]
-    ring
-  have hmono : MonotoneOn φ (Icc a b) := by
-    refine monotoneOn_of_deriv_nonneg (convex_Icc a b) hφ (fun t ht => ?_) fun t ht => ?_
-    · rw [interior_Icc] at ht
-      exact (hderiv t ht).differentiableAt.differentiableWithinAt
-    · rw [interior_Icc] at ht
-      rw [(hderiv t ht).deriv]
-      exact hsign t ht
-  have hφab : φ a ≤ φ b := hmono (left_mem_Icc.2 hab) (right_mem_Icc.2 hab) hab
-  rw [hyperbolicLength_eq_intervalIntegral_of_eqOn hab hEq,
-    intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg (by rwa [uIcc_of_le hab])
-      (by rwa [hIoo]) (by rwa [hIoo]),
-    ← hyperbolicLength_eq_intervalIntegral γ hφab]
+      = hyperbolicLength γ (s * a + d) (s * b + d) :=
+  densityLength_comp_mul_add _ γ hs d a b
 
 /-- **Hyperbolic length is invariant under monotone reparametrisation.** Precomposing a path with
 a map `φ` that is continuous on the parameter interval and has a nonnegative derivative inside it —
 so that `φ` is monotone there — reparametrises the path and transports the parameter interval,
-leaving the length unchanged. The path is asked to be differentiable at the reparametrised
-parameters, which is what makes the composite differentiable; no regularity beyond that is needed,
-because Mathlib's change of variables for a monotone substitution
-(`intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg`) asks nothing of the integrand. -/
+leaving the length unchanged. -/
 theorem hyperbolicLength_comp_of_deriv_nonneg {φ φ' : ℝ → ℝ} (hφ : ContinuousOn φ (uIcc a b))
     (hderiv : ∀ t ∈ uIoo a b, HasDerivAt φ (φ' t) t) (hsign : ∀ t ∈ uIoo a b, 0 ≤ φ' t)
     (hγ : ∀ t ∈ uIoo a b, DifferentiableAt ℝ γ (φ t)) :
-    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) := by
-  rcases le_total a b with hab | hab
-  · rw [uIcc_of_le hab] at hφ
-    rw [uIoo_of_le hab] at hderiv hsign hγ
-    exact hyperbolicLength_comp_of_deriv_nonneg_of_le hab hφ hderiv hsign hγ
-  · rw [uIcc_comm, uIcc_of_le hab] at hφ
-    rw [uIoo_comm, uIoo_of_le hab] at hderiv hsign hγ
-    rw [hyperbolicLength_symm (γ ∘ φ) b a, hyperbolicLength_symm γ (φ b) (φ a)]
-    exact hyperbolicLength_comp_of_deriv_nonneg_of_le hab hφ hderiv hsign hγ
-
-/-- The antitone reparametrisation invariance over an ordered parameter interval; the general case
-follows by symmetry. -/
-private theorem hyperbolicLength_comp_of_deriv_nonpos_of_le {φ φ' : ℝ → ℝ} (hab : a ≤ b)
-    (hφ : ContinuousOn φ (Icc a b)) (hderiv : ∀ t ∈ Ioo a b, HasDerivAt φ (φ' t) t)
-    (hsign : ∀ t ∈ Ioo a b, φ' t ≤ 0) (hγ : ∀ t ∈ Ioo a b, DifferentiableAt ℝ γ (φ t)) :
-    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) := by
-  have hIoo : Ioo (min a b) (max a b) = Ioo a b := by rw [min_eq_left hab, max_eq_right hab]
-  -- as in the monotone case, save that `φ'` is now nonpositive, so that the speed of `γ ∘ φ`
-  -- is *minus* `φ'` times the speed of `γ` read at `φ`
-  have hEq : EqOn (fun t => ‖deriv (γ ∘ φ) t‖ / (1 - ‖(γ ∘ φ) t‖ ^ 2))
-      (fun t => -(φ' t • ((fun u => ‖deriv γ u‖ / (1 - ‖γ u‖ ^ 2)) ∘ φ) t)) (Ioo a b) := by
-    intro t ht
-    have hchain : deriv (γ ∘ φ) t = φ' t • deriv γ (φ t) :=
-      ((hγ t ht).hasDerivAt.scomp t (hderiv t ht)).deriv
-    simp only [Function.comp_apply, hchain, norm_smul, Real.norm_eq_abs,
-      abs_of_nonpos (hsign t ht), smul_eq_mul]
-    ring
-  have hanti : AntitoneOn φ (Icc a b) := by
-    refine antitoneOn_of_deriv_nonpos (convex_Icc a b) hφ (fun t ht => ?_) fun t ht => ?_
-    · rw [interior_Icc] at ht
-      exact (hderiv t ht).differentiableAt.differentiableWithinAt
-    · rw [interior_Icc] at ht
-      rw [(hderiv t ht).deriv]
-      exact hsign t ht
-  have hφab : φ b ≤ φ a := hanti (left_mem_Icc.2 hab) (right_mem_Icc.2 hab) hab
-  rw [hyperbolicLength_eq_intervalIntegral_of_eqOn hab hEq, intervalIntegral.integral_neg,
-    intervalIntegral.integral_deriv_smul_comp_of_deriv_nonpos (by rwa [uIcc_of_le hab])
-      (by rwa [hIoo]) (by rwa [hIoo]),
-    ← intervalIntegral.integral_symm, hyperbolicLength_symm γ (φ b) (φ a),
-    ← hyperbolicLength_eq_intervalIntegral γ hφab]
+    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) :=
+  densityLength_comp_of_deriv_nonneg hφ hderiv hsign hγ
 
 /-- **Hyperbolic length is invariant under antitone reparametrisation.** The orientation-reversing
 counterpart of `TauCeti.hyperbolicLength_comp_of_deriv_nonneg`: precomposing a path with a map `φ`
@@ -441,15 +306,8 @@ path rather than of its parametrisation. -/
 theorem hyperbolicLength_comp_of_deriv_nonpos {φ φ' : ℝ → ℝ} (hφ : ContinuousOn φ (uIcc a b))
     (hderiv : ∀ t ∈ uIoo a b, HasDerivAt φ (φ' t) t) (hsign : ∀ t ∈ uIoo a b, φ' t ≤ 0)
     (hγ : ∀ t ∈ uIoo a b, DifferentiableAt ℝ γ (φ t)) :
-    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) := by
-  rcases le_total a b with hab | hab
-  · rw [uIcc_of_le hab] at hφ
-    rw [uIoo_of_le hab] at hderiv hsign hγ
-    exact hyperbolicLength_comp_of_deriv_nonpos_of_le hab hφ hderiv hsign hγ
-  · rw [uIcc_comm, uIcc_of_le hab] at hφ
-    rw [uIoo_comm, uIoo_of_le hab] at hderiv hsign hγ
-    rw [hyperbolicLength_symm (γ ∘ φ) b a, hyperbolicLength_symm γ (φ b) (φ a)]
-    exact hyperbolicLength_comp_of_deriv_nonpos_of_le hab hφ hderiv hsign hγ
+    hyperbolicLength (γ ∘ φ) a b = hyperbolicLength γ (φ a) (φ b) :=
+  densityLength_comp_of_deriv_nonpos hφ hderiv hsign hγ
 
 /-- **The hyperbolic length of a Euclidean radius.** For a unit vector `u` and `0 ≤ r < 1`, the
 path `t ↦ u * t` has hyperbolic length `Real.artanh r` over `[0, r]`, which by
@@ -477,8 +335,8 @@ junk value of `deriv`. -/
 @[simp]
 theorem hyperbolicLength_const_mul {u : ℂ} (hu : ‖u‖ = 1) :
     hyperbolicLength (fun t => u * γ t) a b = hyperbolicLength γ a b := by
-  rw [hyperbolicLength_def, hyperbolicLength_def]
-  refine MeasureTheory.setIntegral_congr_fun measurableSet_uIcc fun t _ => ?_
+  simp only [hyperbolicLength]
+  refine densityLength_congr_of_eqOn fun t _ => ?_
   simp only [deriv_const_mul_field, norm_mul, hu, one_mul]
 
 /-- **Hyperbolic length is a conjugation invariant.** Reflecting a path in the real axis leaves its
@@ -493,8 +351,8 @@ conjugates. -/
 @[simp]
 theorem hyperbolicLength_conj (γ : ℝ → ℂ) (a b : ℝ) :
     hyperbolicLength (fun t => (starRingEnd ℂ) (γ t)) a b = hyperbolicLength γ a b := by
-  rw [hyperbolicLength_def, hyperbolicLength_def]
-  refine MeasureTheory.setIntegral_congr_fun measurableSet_uIcc fun t _ => ?_
+  simp only [hyperbolicLength]
+  refine densityLength_congr_of_eqOn fun t _ => ?_
   simp only [← Complex.star_def, deriv.star, norm_star]
 
 /-- The Moebius invariance of hyperbolic length over an ordered parameter interval; the general


### PR DESCRIPTION
This PR extracts the density-independent half of `TauCeti.hyperbolicLength` into a general notion and re-derives the hyperbolic statements from it. `TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean` defines the hyperbolic length of a path in the unit disc as the Euclidean speed integrated against the Poincaré density over the unordered parameter interval, and then proves its parameter-side calculus: that the length is unoriented, that a degenerate interval and a constant path contribute nothing, that it is additive along the parameter interval, that it depends on the path only through its restriction to that interval, that it is computable from an explicit derivative, and that it is unchanged by an affine, monotone or antitone reparametrisation. Not one of those proofs looks at the Poincaré density, and none looks at the complex plane beyond its norm. The new file `TauCeti/Analysis/Calculus/DensityLength.lean` states them once, for `TauCeti.densityLength ρ γ a b = ∫ t in uIcc a b, ρ (γ t) * ‖deriv γ t‖`, the length of a path `γ : ℝ → F` in an arbitrary real normed space measured against an arbitrary scalar density `ρ : F → ℝ`; `TauCeti.hyperbolicLength` is then *defined* as that instance at `ρ z = (1 - ‖z‖ ^ 2)⁻¹`, and each of the nine hyperbolic statements above keeps its name, signature and docstring and is proved by naming its general counterpart. The two invariances of the hyperbolic length under a rotation and under conjugation, which were separate `setIntegral_congr_fun` computations, become instances of the general `TauCeti.densityLength_congr_of_eqOn`. No file outside these two changes: `hyperbolicLength` had no consumers elsewhere in the tree, and the migration is confined to the file that owns it, which loses 199 lines and gains 57.

The generality is the natural one rather than a speculative one: the hypotheses appear exactly where the mathematics needs them — nonnegativity of the density only for `TauCeti.densityLength_nonneg`, differentiability of the path only for the two substitution rules, which differentiate the composite — and the definition asks nothing of `γ` or `ρ`, `deriv` reading its junk value where the path is not differentiable, as the hyperbolic version already did. The substitution rules are Mathlib's change of variables for a monotone or antitone substitution (`intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg` and its `nonpos` counterpart) read through the chain rule, and the affine rule is `intervalIntegral.integral_comp_mul_add`; the proofs are the merged ones, transported. Mathlib's `Manifold.pathELength` is not the notion being instantiated and the new file says why: it measures with an `ENorm` on each tangent space of a charted space and is `ℝ≥0∞`-valued, so consuming it would need the disc equipped with a manifold structure and the whole real-valued disc development restated, an argument the merged `Hyperbolic/Length.lean` already made and which this PR moves to the general file and points at from the hyperbolic one.

Roadmap: ConformalMapping

This is a refactor of already-merged material — the mathematics of all nine general statements is on `main` in `TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean`, up to the generalisation of the density and the relocation — so it carries no fresh roadmap claim. The roadmap chiefly motivating the material it reworks is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L2 — Schwarz lemma extensions**, whose target "the **hyperbolic / Poincaré metric** on `𝔻`" the hyperbolic length was built for: `TauCeti.isLeast_hyperbolicLength` identifies `hyperbolicDist` with the length metric of that density, and its parameter-side calculus is what that identification spends.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"densitylength"}-->

🤖 Prepared with Claude Code
