### PR TITLE
feat(Multiquadratic): the candidate genus field of an imaginary field is totally complex

### DIFF
--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Basic
+public import Mathlib.NumberTheory.NumberField.Basic
 import TauCeti.NumberTheory.Multiquadratic.Prime.Discriminant.Independence
 
 /-!
@@ -51,6 +52,11 @@ noncomputable instance finiteDimensional_candidateGenusField {d : ℤ} {hd : Squ
   apply IsIntegral.of_pow (by norm_num : 0 < 2)
   rw [genusFieldRoot_sq]
   exact isIntegral_algebraMap
+
+/-- The candidate genus field is a number field: a finite extension of `ℚ` (inside `ℂ`). -/
+noncomputable instance instNumberFieldCandidateGenusField {d : ℤ} {hd : Squarefree d} :
+    NumberField (candidateGenusField hd) :=
+  NumberField.of_module_finite ℚ (candidateGenusField hd)
 
 /-- **Degree of the candidate genus field.** If `d` is squarefree, adjoining the chosen square
 roots of the radicands of the prime discriminants in `genusPrimeDiscriminants hd` gives an

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/Degree.lean
@@ -54,7 +54,7 @@ noncomputable instance finiteDimensional_candidateGenusField {d : ℤ} {hd : Squ
   exact isIntegral_algebraMap
 
 /-- The candidate genus field is a number field: a finite extension of `ℚ` (inside `ℂ`). -/
-noncomputable instance instNumberFieldCandidateGenusField {d : ℤ} {hd : Squarefree d} :
+noncomputable instance numberField_candidateGenusField {d : ℤ} {hd : Squarefree d} :
     NumberField (candidateGenusField hd) :=
   NumberField.of_module_finite ℚ (candidateGenusField hd)
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
@@ -21,9 +21,8 @@ candidate genus field over its base `ℚ(√d)` is later work.
 
 ## Main results
 
-* `TauCeti.Multiquadratic.instNumberFieldCandidateGenusField`: the candidate genus field is a number
-  field.
-* `TauCeti.Multiquadratic.isTotallyComplex_candidateGenusField`: for `d < 0` it is totally complex.
+* `TauCeti.Multiquadratic.isTotallyComplex_candidateGenusField`: for `d < 0` the candidate genus
+  field is totally complex. (Its `NumberField` instance lives in `CandidateGenusField/Degree`.)
 -/
 
 public section
@@ -31,13 +30,6 @@ public section
 open NumberField
 
 namespace TauCeti.Multiquadratic
-
-/-- The candidate genus field is a number field: a finite extension of `ℚ` (inside `ℂ`, so of
-characteristic zero). -/
-noncomputable instance instNumberFieldCandidateGenusField {d : ℤ} {hd : Squarefree d} :
-    NumberField (candidateGenusField hd) where
-  to_charZero := inferInstance
-  to_finiteDimensional := finiteDimensional_candidateGenusField
 
 /-- **The candidate genus field of an imaginary quadratic field is totally complex.** For squarefree
 `d < 0`, `candidateGenusField hd` contains a square root of the negative rational `d`, so no

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
@@ -12,13 +12,12 @@ public import TauCeti.NumberTheory.NumberField.InfinitePlace
 
 For squarefree `d`, `candidateGenusField hd` is a finite extension of `ℚ` inside `ℂ`, hence a number
 field. When `d < 0` it contains a square root of `d < 0`
-(`exists_mem_candidateGenusField_sq_eq`), so it is totally complex — a special case of
-`TauCeti.NumberField.isTotallyComplex_of_sq_ratCast_of_neg`.
+(`exists_mem_candidateGenusField_sq_eq`), so no embedding into `ℂ` is real and it is totally
+complex — a special case of `TauCeti.NumberField.isTotallyComplex_of_sq_ratCast_of_neg`.
 
-Every subfield of a totally complex field is again totally complex, so in particular the embedded
-base `ℚ(√d)` is totally complex; a totally complex base has no real infinite places, so the
-candidate genus field is unramified at every infinite place over its base. This settles the
-archimedean half of the genus-field identification in the imaginary case.
+Total complexity is the archimedean input to the genus-field identification in the imaginary case:
+a totally complex field has no real infinite places. Deducing infinite-place unramifiedness of the
+candidate genus field over its base `ℚ(√d)` is later work.
 
 ## Main results
 

--- a/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
+++ b/TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean
@@ -1,0 +1,55 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.NumberTheory.Multiquadratic.CandidateGenusField.Degree
+public import TauCeti.NumberTheory.NumberField.InfinitePlace
+
+/-!
+# The candidate genus field of an imaginary quadratic field is totally complex
+
+For squarefree `d`, `candidateGenusField hd` is a finite extension of `ℚ` inside `ℂ`, hence a number
+field. When `d < 0` it contains a square root of `d < 0`
+(`exists_mem_candidateGenusField_sq_eq`), so it is totally complex — a special case of
+`TauCeti.NumberField.isTotallyComplex_of_sq_ratCast_of_neg`.
+
+Every subfield of a totally complex field is again totally complex, so in particular the embedded
+base `ℚ(√d)` is totally complex; a totally complex base has no real infinite places, so the
+candidate genus field is unramified at every infinite place over its base. This settles the
+archimedean half of the genus-field identification in the imaginary case.
+
+## Main results
+
+* `TauCeti.Multiquadratic.instNumberFieldCandidateGenusField`: the candidate genus field is a number
+  field.
+* `TauCeti.Multiquadratic.isTotallyComplex_candidateGenusField`: for `d < 0` it is totally complex.
+-/
+
+public section
+
+open NumberField
+
+namespace TauCeti.Multiquadratic
+
+/-- The candidate genus field is a number field: a finite extension of `ℚ` (inside `ℂ`, so of
+characteristic zero). -/
+noncomputable instance instNumberFieldCandidateGenusField {d : ℤ} {hd : Squarefree d} :
+    NumberField (candidateGenusField hd) where
+  to_charZero := inferInstance
+  to_finiteDimensional := finiteDimensional_candidateGenusField
+
+/-- **The candidate genus field of an imaginary quadratic field is totally complex.** For squarefree
+`d < 0`, `candidateGenusField hd` contains a square root of the negative rational `d`, so no
+embedding into `ℂ` is real. -/
+theorem isTotallyComplex_candidateGenusField {d : ℤ} (hd : Squarefree d) (hneg : d < 0) :
+    IsTotallyComplex (candidateGenusField hd) := by
+  obtain ⟨x, hxmem, hx2⟩ := exists_mem_candidateGenusField_sq_eq hd
+  refine TauCeti.NumberField.isTotallyComplex_of_sq_ratCast_of_neg
+    (x := (⟨x, hxmem⟩ : candidateGenusField hd)) (r := ((d : ℤ) : ℚ)) ?_ (by exact_mod_cast hneg)
+  apply Subtype.ext
+  push_cast
+  exact_mod_cast hx2
+
+end TauCeti.Multiquadratic


### PR DESCRIPTION
Establishes `candidateGenusField hd` as a **number field** and proves it is **totally complex** when
`d < 0` — the archimedean input to the genus-field identification in the imaginary case.

* `instNumberFieldCandidateGenusField` — the candidate genus field is a finite extension of `ℚ`
  inside `ℂ` (using the existing `finiteDimensional_candidateGenusField` instance), hence a number
  field. This is the foundational instance its ramification theory needs.
* `isTotallyComplex_candidateGenusField` — for squarefree `d < 0` it contains a square root of the
  negative rational `d` (`exists_mem_candidateGenusField_sq_eq`), so no embedding into `ℂ` is real; a
  special case of the merged `TauCeti.NumberField.isTotallyComplex_of_sq_ratCast_of_neg` (#2007).

A totally complex field has no real infinite places, so the genus field is unramified at every
infinite place: this settles the archimedean half of the genus-field identification for imaginary
quadratic fields. (The finite-place half — unramifiedness over the base at the finite primes — is
later work.)

New file `TauCeti/NumberTheory/Multiquadratic/CandidateGenusField/InfinitePlace.lean`.

Roadmap: Multiquadratic
