### PR TITLE
refactor: reuse the Lie group smoothness downgrade in the bracket bridge

### DIFF
--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -43,11 +43,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [LieGroup I ∞ G]
 
--- The manifold bracket API needs three derivatives; this instance is the corresponding downgrade of
--- the ambient smooth Lie-group structure.
-local instance lieGroupMinSmoothnessThree : LieGroup I (minSmoothness ℝ 3) G :=
-  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
-    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+attribute [local instance] LieGroup.minSmoothnessThree
 
 /-- The map sending a tangent vector at the identity to its left-invariant derivation preserves the
 Lie bracket. -/


### PR DESCRIPTION
## Goal

Reuse the shared `LieGroup.minSmoothnessThree` instance in the tangent/derivation Lie bracket bridge.

## Why

PR #2170 centralized this regularity downgrade, but PR #2154 entered the merge queue concurrently and landed with one additional local copy. This follow-up removes that race residue so the bracket bridge uses the canonical helper too. No declaration or theorem statement changes.

## Verification

- `lake build TauCeti.Geometry.Lie.Tangent.LieEquiv`
- `lake build`
- `bash scripts/lint-env.sh`
- `git diff --check`

Roadmap: LieGroups