### PR TITLE
refactor: centralize the rational algebra instance

### DIFF
--- a/TauCeti/Analysis/Normed/Algebra/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/Basic.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.Normed.Module.Basic
+
+/-!
+# Basic facts about normed algebras
+
+This file provides small pieces of generic normed-algebra infrastructure used across Tau Ceti.
+-/
+
+public section
+
+namespace TauCeti
+
+variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R]
+
+/-- A real normed algebra regarded as a rational normed algebra. -/
+noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ R :=
+  .restrictScalars ℚ ℝ R
+
+end TauCeti

--- a/TauCeti/Analysis/Normed/Algebra/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/Basic.lean
@@ -16,7 +16,7 @@ public section
 
 namespace TauCeti
 
-variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R]
+variable {R : Type*} [SeminormedRing R] [NormedAlgebra ℝ R]
 
 /-- A real normed algebra regarded as a rational normed algebra. -/
 noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ R :=

--- a/TauCeti/Analysis/SpecialFunctions/Exponential.lean
+++ b/TauCeti/Analysis/SpecialFunctions/Exponential.lean
@@ -8,6 +8,7 @@ public import Mathlib.Analysis.SpecialFunctions.Exponential
 import Mathlib.Analysis.Calculus.Deriv.Mul
 import Mathlib.Analysis.Calculus.Deriv.Shift
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
+import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
 # Duhamel's formula for the Banach-algebra exponential
@@ -35,9 +36,7 @@ noncomputable section
 
 variable {A : Type*} [NormedRing A] [NormedAlgebra ℝ A] [CompleteSpace A]
 
-/-- The rational normed algebra structure obtained by restricting the real scalars. -/
-noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ A :=
-  .restrictScalars ℚ ℝ A
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 private theorem hasDerivAt_duhamelPath (x h : A) (t : ℝ) :
     HasDerivAt

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Analysis.Normed.Algebra.Exponential
 public import Mathlib.Analysis.Normed.Operator.Mul
 public import Mathlib.Algebra.Lie.OfAssociative
+public import TauCeti.Geometry.Lie.Exponential.Units.Basic
 
 /-!
 # Exponentiating the commutator operator
@@ -51,9 +52,7 @@ open NormedSpace
 
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-/-- The rational scalar restriction used by Mathlib's exponential API in this module. -/
-private noncomputable local instance normedAlgebraRat : NormedAlgebra ℚ R :=
-  .restrictScalars ℚ ℝ R
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 omit [CompleteSpace R] in
 private theorem mulLeft_toLinearMap (x : R) :

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.Analysis.Normed.Algebra.Exponential
 public import Mathlib.Analysis.Normed.Operator.Mul
 public import Mathlib.Algebra.Lie.OfAssociative
-public import TauCeti.Geometry.Lie.Exponential.Units.Basic
+public import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
 # Exponentiating the commutator operator

--- a/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/OperatorExponential.lean
@@ -7,7 +7,7 @@ module
 public import Mathlib.Analysis.Normed.Algebra.Exponential
 public import Mathlib.Analysis.Normed.Operator.Mul
 public import Mathlib.Algebra.Lie.OfAssociative
-public import TauCeti.Analysis.Normed.Algebra.Basic
+import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
 # Exponentiating the commutator operator

--- a/TauCeti/Geometry/Lie/Exponential/OneParameter.lean
+++ b/TauCeti/Geometry/Lie/Exponential/OneParameter.lean
@@ -41,7 +41,7 @@ open scoped ContDiff Manifold
 
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-attribute [local instance] normedAlgebraRatOfReal
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 /-- The algebra-valued exponential curve `t ↦ exp (t • x)` is real analytic. -/
 @[fun_prop]

--- a/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
@@ -91,7 +91,7 @@ section Real
 
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-attribute [local instance] normedAlgebraRatOfReal
+attribute [local instance] TauCeti.normedAlgebraRatOfReal
 
 /-- The one-parameter subgroup law lifted from the algebra to its group of units. -/
 @[simp]

--- a/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
+++ b/TauCeti/Geometry/Lie/Exponential/Units/Basic.lean
@@ -7,6 +7,7 @@ module
 public import Mathlib.Analysis.SpecialFunctions.Exponential
 public import Mathlib.Topology.Algebra.ContinuousMonoidHom
 public import Mathlib.Topology.ContinuousMap.Units
+public import TauCeti.Analysis.Normed.Algebra.Basic
 
 /-!
 # Banach-algebra exponentials as units
@@ -90,9 +91,7 @@ section Real
 
 variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
 
-/-- A real normed algebra regarded as a rational normed algebra within this module. -/
-noncomputable local instance normedAlgebraRatOfReal : NormedAlgebra ℚ R :=
-  .restrictScalars ℚ ℝ R
+attribute [local instance] normedAlgebraRatOfReal
 
 /-- The one-parameter subgroup law lifted from the algebra to its group of units. -/
 @[simp]


### PR DESCRIPTION
## Goal

Centralize the rational scalar-restriction instance used by the Banach-algebra exponential modules, then remove the duplicate instances from all three consumers.

## Why this is equivalent

`TauCeti.normedAlgebraRatOfReal` has the same type and implementation as the deleted file-local instances: it equips a normed real algebra with the rational scalar restriction required by Mathlib's exponential API. The helper now lives in the generic `TauCeti.Analysis.Normed.Algebra.Basic` module, and `Analysis.SpecialFunctions.Exponential`, `Geometry.Lie.Exponential.Units.Basic`, and `Geometry.Lie.Adjoint.OperatorExponential` each opt into it locally. The refactor changes no theorem statement or mathematical behavior and avoids exposing the units-exponential API through an unrelated public import. This addresses the unresolved reuse finding on #2173 after that PR entered the merge queue before the cleanup landed.

## Validation

- `lake build TauCeti.Analysis.Normed.Algebra.Basic TauCeti.Analysis.SpecialFunctions.Exponential TauCeti.Geometry.Lie.Exponential.Units.Basic TauCeti.Geometry.Lie.Adjoint.OperatorExponential`
- `lake build`
- `bash scripts/lint-env.sh`
- `git diff --check`

Roadmap: LieGroups
