### PR TITLE
refactor(KrullSchmidt): decompose Azumaya's exchange lemma

### DIFF
--- a/TauCeti/LinearAlgebra/Projection.lean
+++ b/TauCeti/LinearAlgebra/Projection.lean
@@ -28,6 +28,7 @@ single projection is that over a finite index type the projections sum to the id
 
 * `TauCeti.isCompl_biSup_ne`: a summand of an internal direct sum decomposition is complementary to
   the supremum of the other summands.
+* `TauCeti.internalProjection_surjective`: the projection onto `Q i` is surjective.
 * `TauCeti.ker_internalProjection`: the kernel of the projection onto `Q i` is the supremum of the
   other summands.
 * `TauCeti.sum_coe_internalProjection`: over a finite index type the projections onto the summands
@@ -86,6 +87,11 @@ This is the form `simp` can use: the summand index `i` is read off the type of `
 theorem internalProjection_apply_of_ne (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {i j : ι}
     (hij : i ≠ j) (x : Q i) : internalProjection hQi hQt j (x : M) = 0 :=
   internalProjection_apply_eq_zero_of_mem_of_ne hQi hQt hij x.2
+
+/-- The projection onto `Q i` is surjective, being the identity on `Q i`. -/
+theorem internalProjection_surjective (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) (i : ι) :
+    Function.Surjective (internalProjection hQi hQt i) :=
+  Submodule.projectionOnto_surjective _
 
 /-- The kernel of the projection onto `Q i` is the supremum of the other summands. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Projection.lean
+++ b/TauCeti/LinearAlgebra/Projection.lean
@@ -88,10 +88,15 @@ theorem internalProjection_apply_of_ne (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = �
     (hij : i ≠ j) (x : Q i) : internalProjection hQi hQt j (x : M) = 0 :=
   internalProjection_apply_eq_zero_of_mem_of_ne hQi hQt hij x.2
 
-/-- The projection onto `Q i` is surjective, being the identity on `Q i`. -/
+/-- The projection onto `Q i` is surjective, being the identity on `Q i`.
+
+The `simp only [internalProjection]` is the point of the lemma: it performs the unfolding to
+`Submodule.projectionOnto` here, in the module that defines `internalProjection` and can therefore
+see its body, so that consumers never have to. -/
 theorem internalProjection_surjective (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) (i : ι) :
-    Function.Surjective (internalProjection hQi hQt i) :=
-  Submodule.projectionOnto_surjective _
+    Function.Surjective (internalProjection hQi hQt i) := by
+  simpa only [internalProjection] using
+    Submodule.projectionOnto_surjective (isCompl_biSup_ne hQi hQt i)
 
 /-- The kernel of the projection onto `Q i` is the supremum of the other summands. -/
 @[simp]

--- a/TauCeti/LinearAlgebra/Projection.lean
+++ b/TauCeti/LinearAlgebra/Projection.lean
@@ -88,15 +88,10 @@ theorem internalProjection_apply_of_ne (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = �
     (hij : i ≠ j) (x : Q i) : internalProjection hQi hQt j (x : M) = 0 :=
   internalProjection_apply_eq_zero_of_mem_of_ne hQi hQt hij x.2
 
-/-- The projection onto `Q i` is surjective, being the identity on `Q i`.
-
-The `simp only [internalProjection]` is the point of the lemma: it performs the unfolding to
-`Submodule.projectionOnto` here, in the module that defines `internalProjection` and can therefore
-see its body, so that consumers never have to. -/
+/-- The projection onto `Q i` is surjective, being the identity on `Q i`. -/
 theorem internalProjection_surjective (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) (i : ι) :
-    Function.Surjective (internalProjection hQi hQt i) := by
-  simpa only [internalProjection] using
-    Submodule.projectionOnto_surjective (isCompl_biSup_ne hQi hQt i)
+    Function.Surjective (internalProjection hQi hQt i) :=
+  Submodule.projectionOnto_surjective (isCompl_biSup_ne hQi hQt i)
 
 /-- The kernel of the projection onto `Q i` is the supremum of the other summands. -/
 @[simp]

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -75,7 +75,8 @@ private theorem sum_projectionOnto_comp_internalProjection_eq_one {ι : Type w} 
     rw [sum_coe_internalProjection hQi hQt, Submodule.projectionOnto_apply_left]
   rw [map_sum] at hx
   rw [LinearMap.sum_apply]
-  exact hx
+  simpa only [LinearMap.comp_apply, LinearMap.domRestrict_apply, Submodule.subtype_apply,
+    Module.End.one_apply] using hx
 
 /-- **Azumaya's exchange lemma.** Let `M` be the internal direct sum of a finite family `Q` of
 indecomposable submodules, and let `N` be a direct summand of `M` whose endomorphism ring is local

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -77,44 +77,6 @@ private theorem sum_projectionOnto_comp_internalProjection_eq_one {ι : Type w} 
   rw [LinearMap.sum_apply]
   exact hx
 
-/-- Half of the exchange. If the projection onto `Q i₀` is injective on a submodule `N`, then `N`
-meets the remaining summands trivially, since those are exactly what that projection kills. -/
-private theorem disjoint_biSup_ne_of_injective {ι : Type w} {Q : ι → Submodule A M}
-    (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N : Submodule A M} {i₀ : ι}
-    (hinj : Function.Injective (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :
-    Disjoint N (⨆ j, ⨆ (_ : j ≠ i₀), Q j) := by
-  rw [Submodule.disjoint_def]
-  intro x hxN hxT
-  have hzero : (internalProjection hQi hQt i₀ ∘ₗ N.subtype) ⟨x, hxN⟩ = 0 := by
-    rw [LinearMap.comp_apply, Submodule.subtype_apply, ← LinearMap.mem_ker,
-      ker_internalProjection]
-    exact hxT
-  simpa using congrArg Subtype.val (hinj (hzero.trans (map_zero _).symm))
-
-/-- The other half of the exchange. If the projection onto `Q i₀` maps a submodule `N` onto all of
-`Q i₀`, then `N` and the remaining summands span, since every element of `M` differs from its
-`i₀`-component by an element of those summands. -/
-private theorem codisjoint_biSup_ne_of_surjective {ι : Type w} {Q : ι → Submodule A M}
-    (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N : Submodule A M} {i₀ : ι}
-    (hsurj : Function.Surjective (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :
-    Codisjoint N (⨆ j, ⨆ (_ : j ≠ i₀), Q j) := by
-  have hrest : ∀ x : M, x - ((internalProjection hQi hQt i₀ x : M)) ∈ ⨆ j, ⨆ (_ : j ≠ i₀), Q j :=
-    fun x ↦ by
-      rw [← ker_internalProjection hQi hQt i₀, LinearMap.mem_ker, map_sub,
-        internalProjection_apply, sub_self]
-  rw [codisjoint_iff, eq_top_iff]
-  intro m _
-  obtain ⟨n, hn⟩ := hsurj (internalProjection hQi hQt i₀ m)
-  have hcomp : ((internalProjection hQi hQt i₀ (n : M) : M)) =
-      ((internalProjection hQi hQt i₀ m : M)) := by
-    rw [← hn, LinearMap.comp_apply, Submodule.subtype_apply]
-  have hmem : ((internalProjection hQi hQt i₀ m : M)) ∈ N ⊔ ⨆ j, ⨆ (_ : j ≠ i₀), Q j := by
-    rw [← hcomp, ← sub_sub_cancel (n : M) ((internalProjection hQi hQt i₀ (n : M) : M))]
-    exact Submodule.sub_mem _ (Submodule.mem_sup_left n.2)
-      (Submodule.mem_sup_right (hrest (n : M)))
-  rw [← sub_add_cancel m ((internalProjection hQi hQt i₀ m : M))]
-  exact Submodule.add_mem _ (Submodule.mem_sup_right (hrest m)) hmem
-
 /-- **Azumaya's exchange lemma.** Let `M` be the internal direct sum of a finite family `Q` of
 indecomposable submodules, and let `N` be a direct summand of `M` whose endomorphism ring is local
 (so in particular `N` is nonzero). Then `N` is isomorphic to one of the `Q i₀`, and can be exchanged
@@ -138,7 +100,15 @@ theorem exists_linearEquiv_and_isCompl_biSup_ne
   have hbij : Function.Bijective (internalProjection hQi hQt i₀ ∘ₗ N.subtype) :=
     (hQind i₀).bijective_of_bijective_comp (g := N.projectionOnto S hNS ∘ₗ (Q i₀).subtype)
       ((Module.End.isUnit_iff _).mp hunit)
-  exact ⟨i₀, ⟨LinearEquiv.ofBijective _ hbij⟩, disjoint_biSup_ne_of_injective hQi hQt hbij.1,
-    codisjoint_biSup_ne_of_surjective hQi hQt hbij.2⟩
+  -- The projection onto `Q i₀` is surjective, being the identity there.
+  have hsurj : Function.Surjective (internalProjection hQi hQt i₀) :=
+    fun x ↦ ⟨(x : M), internalProjection_apply hQi hQt x⟩
+  -- The exchange is the kernel characterisation of injectivity and surjectivity on `N`,
+  -- since the remaining summands are exactly the kernel of the `i₀`-projection.
+  refine ⟨i₀, ⟨LinearEquiv.ofBijective _ hbij⟩, ?_, ?_⟩
+  · rw [← ker_internalProjection hQi hQt i₀]
+    exact LinearMap.injective_domRestrict_iff.mp hbij.1
+  · rw [← ker_internalProjection hQi hQt i₀]
+    exact (LinearMap.surjective_domRestrict_iff hsurj).mp hbij.2
 
 end TauCeti

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -62,6 +62,59 @@ universe u v w
 
 variable {A : Type u} {M : Type v} [Ring A] [AddCommGroup M] [Module A M]
 
+/-- The components of the identity of `N` along the decomposition `Q`: projecting `N` into the
+summand `Q i` and back onto `N` along its complement `S` gives a family of endomorphisms of `N`
+summing to the identity, because the projections onto the summands sum to the identity of `M`. -/
+private theorem sum_projectionOnto_comp_internalProjection_eq_one {ι : Type w} [Fintype ι]
+    {Q : ι → Submodule A M} (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N S : Submodule A M}
+    (hNS : IsCompl N S) :
+    ∑ i, ((N.projectionOnto S hNS ∘ₗ (Q i).subtype) ∘ₗ
+      (internalProjection hQi hQt i ∘ₗ N.subtype)) = 1 := by
+  refine LinearMap.ext fun x ↦ ?_
+  have hx : N.projectionOnto S hNS (∑ i, ((internalProjection hQi hQt i (x : M) : M))) = x := by
+    rw [sum_coe_internalProjection hQi hQt, Submodule.projectionOnto_apply_left]
+  rw [map_sum] at hx
+  rw [LinearMap.sum_apply]
+  exact hx
+
+/-- Half of the exchange. If the projection onto `Q i₀` is injective on a submodule `N`, then `N`
+meets the remaining summands trivially, since those are exactly what that projection kills. -/
+private theorem disjoint_biSup_ne_of_injective {ι : Type w} {Q : ι → Submodule A M}
+    (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N : Submodule A M} {i₀ : ι}
+    (hinj : Function.Injective (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :
+    Disjoint N (⨆ j, ⨆ (_ : j ≠ i₀), Q j) := by
+  rw [Submodule.disjoint_def]
+  intro x hxN hxT
+  have hzero : (internalProjection hQi hQt i₀ ∘ₗ N.subtype) ⟨x, hxN⟩ = 0 := by
+    rw [LinearMap.comp_apply, Submodule.subtype_apply, ← LinearMap.mem_ker,
+      ker_internalProjection]
+    exact hxT
+  simpa using congrArg Subtype.val (hinj (hzero.trans (map_zero _).symm))
+
+/-- The other half of the exchange. If the projection onto `Q i₀` maps a submodule `N` onto all of
+`Q i₀`, then `N` and the remaining summands span, since every element of `M` differs from its
+`i₀`-component by an element of those summands. -/
+private theorem codisjoint_biSup_ne_of_surjective {ι : Type w} {Q : ι → Submodule A M}
+    (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N : Submodule A M} {i₀ : ι}
+    (hsurj : Function.Surjective (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :
+    Codisjoint N (⨆ j, ⨆ (_ : j ≠ i₀), Q j) := by
+  have hrest : ∀ x : M, x - ((internalProjection hQi hQt i₀ x : M)) ∈ ⨆ j, ⨆ (_ : j ≠ i₀), Q j :=
+    fun x ↦ by
+      rw [← ker_internalProjection hQi hQt i₀, LinearMap.mem_ker, map_sub,
+        internalProjection_apply, sub_self]
+  rw [codisjoint_iff, eq_top_iff]
+  intro m _
+  obtain ⟨n, hn⟩ := hsurj (internalProjection hQi hQt i₀ m)
+  have hcomp : ((internalProjection hQi hQt i₀ (n : M) : M)) =
+      ((internalProjection hQi hQt i₀ m : M)) := by
+    rw [← hn, LinearMap.comp_apply, Submodule.subtype_apply]
+  have hmem : ((internalProjection hQi hQt i₀ m : M)) ∈ N ⊔ ⨆ j, ⨆ (_ : j ≠ i₀), Q j := by
+    rw [← hcomp, ← sub_sub_cancel (n : M) ((internalProjection hQi hQt i₀ (n : M) : M))]
+    exact Submodule.sub_mem _ (Submodule.mem_sup_left n.2)
+      (Submodule.mem_sup_right (hrest (n : M)))
+  rw [← sub_add_cancel m ((internalProjection hQi hQt i₀ m : M))]
+  exact Submodule.add_mem _ (Submodule.mem_sup_right (hrest m)) hmem
+
 /-- **Azumaya's exchange lemma.** Let `M` be the internal direct sum of a finite family `Q` of
 indecomposable submodules, and let `N` be a direct summand of `M` whose endomorphism ring is local
 (so in particular `N` is nonzero). Then `N` is isomorphic to one of the `Q i₀`, and can be exchanged
@@ -76,51 +129,16 @@ theorem exists_linearEquiv_and_isCompl_biSup_ne
     ∃ i₀ : ι, Nonempty (N ≃ₗ[A] Q i₀) ∧ IsCompl N (⨆ j, ⨆ (_ : j ≠ i₀), Q j) := by
   have _ : Fintype ι := Fintype.ofFinite ι
   have _ : Nontrivial N := nontrivial_of_isLocalRing_end (A := A)
-  set p : M →ₗ[A] N := N.projectionOnto S hNS with hp
-  set f : ι → Module.End A N :=
-    fun i ↦ (p ∘ₗ (Q i).subtype) ∘ₗ (internalProjection hQi hQt i ∘ₗ N.subtype) with hf
-  -- The components of the identity of `N` along the decomposition `Q`.
-  have hsum : ∑ i, f i = 1 := by
-    refine LinearMap.ext fun x ↦ ?_
-    have hx : p (∑ i, ((internalProjection hQi hQt i (x : M) : M))) = x := by
-      rw [sum_coe_internalProjection hQi hQt, hp, Submodule.projectionOnto_apply_left]
-    rw [map_sum] at hx
-    rw [LinearMap.sum_apply]
-    exact hx
   -- Locality of `Module.End A N` picks out an index whose component is invertible.
-  obtain ⟨i₀, -, hunit⟩ : ∃ i₀ ∈ Finset.univ, IsUnit (f i₀) :=
-    IsLocalRing.exists_of_isUnit_sum (by rw [hsum]; exact isUnit_one)
-  set α : N →ₗ[A] Q i₀ := internalProjection hQi hQt i₀ ∘ₗ N.subtype with hα
-  have hbij : Function.Bijective α :=
-    (hQind i₀).bijective_of_bijective_comp (g := p ∘ₗ (Q i₀).subtype)
+  obtain ⟨i₀, -, hunit⟩ : ∃ i₀ ∈ Finset.univ, IsUnit ((N.projectionOnto S hNS ∘ₗ (Q i₀).subtype)
+      ∘ₗ (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :=
+    IsLocalRing.exists_of_isUnit_sum
+      (by rw [sum_projectionOnto_comp_internalProjection_eq_one]; exact isUnit_one)
+  -- A split injection into the indecomposable `Q i₀` is already an isomorphism.
+  have hbij : Function.Bijective (internalProjection hQi hQt i₀ ∘ₗ N.subtype) :=
+    (hQind i₀).bijective_of_bijective_comp (g := N.projectionOnto S hNS ∘ₗ (Q i₀).subtype)
       ((Module.End.isUnit_iff _).mp hunit)
-  refine ⟨i₀, ⟨LinearEquiv.ofBijective α hbij⟩, ?_⟩
-  set T : Submodule A M := ⨆ j, ⨆ (_ : j ≠ i₀), Q j with hT
-  -- `T` is exactly what the `i₀`-projection kills.
-  have hTker : T = LinearMap.ker (internalProjection hQi hQt i₀) := by
-    rw [hT, ker_internalProjection]
-  -- Each element of `M` differs from its `i₀`-component by an element of `T`.
-  have hrest : ∀ x : M, x - ((internalProjection hQi hQt i₀ x : M)) ∈ T := fun x ↦ by
-    rw [hTker, LinearMap.mem_ker, map_sub, internalProjection_apply, sub_self]
-  constructor
-  · rw [Submodule.disjoint_def]
-    intro x hxN hxT
-    have hzero : α ⟨x, hxN⟩ = 0 := by
-      rw [hα, LinearMap.comp_apply, Submodule.subtype_apply, ← LinearMap.mem_ker, ← hTker]
-      exact hxT
-    have hx0 := hbij.1 (hzero.trans (map_zero α).symm)
-    simpa using congrArg Subtype.val hx0
-  · rw [codisjoint_iff, eq_top_iff]
-    intro m _
-    obtain ⟨n, hn⟩ := hbij.2 (internalProjection hQi hQt i₀ m)
-    have hcomp : ((internalProjection hQi hQt i₀ (n : M) : M)) =
-        ((internalProjection hQi hQt i₀ m : M)) := by
-      rw [← hn, hα, LinearMap.comp_apply, Submodule.subtype_apply]
-    have hmem : ((internalProjection hQi hQt i₀ m : M)) ∈ N ⊔ T := by
-      rw [← hcomp, ← sub_sub_cancel (n : M) ((internalProjection hQi hQt i₀ (n : M) : M))]
-      exact Submodule.sub_mem _ (Submodule.mem_sup_left n.2)
-        (Submodule.mem_sup_right (hrest (n : M)))
-    rw [← sub_add_cancel m ((internalProjection hQi hQt i₀ m : M))]
-    exact Submodule.add_mem _ (Submodule.mem_sup_right (hrest m)) hmem
+  exact ⟨i₀, ⟨LinearEquiv.ofBijective _ hbij⟩, disjoint_biSup_ne_of_injective hQi hQt hbij.1,
+    codisjoint_biSup_ne_of_surjective hQi hQt hbij.2⟩
 
 end TauCeti

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -16,8 +16,8 @@ suppose `N` is an indecomposable direct summand of `M`. Then `N` is isomorphic t
 summands `Q i₀`, and it may be *exchanged* for it: `M` is also the direct sum of `N` and the
 remaining summands `⨆ j ≠ i₀, Q j`.
 
-The argument is the classical one. Writing `p` for the projection of `M` onto `N`, the
-endomorphisms of `N` obtained by projecting `N` into `Q i` and back sum to the identity, because the
+The argument is the classical one. The endomorphisms of `N` obtained by projecting `N` into `Q i`
+and back sum to the identity, because the
 projections `TauCeti.internalProjection` onto the summands do
 (`TauCeti.sum_coe_internalProjection`). The hypothesis is that `Module.End A N` is local, and in a
 local ring a finite sum can only be a unit if one of its terms is

--- a/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
+++ b/TauCeti/RingTheory/KrullSchmidt/Exchange.lean
@@ -69,7 +69,7 @@ private theorem sum_projectionOnto_comp_internalProjection_eq_one {ι : Type w} 
     {Q : ι → Submodule A M} (hQi : iSupIndep Q) (hQt : ⨆ i, Q i = ⊤) {N S : Submodule A M}
     (hNS : IsCompl N S) :
     ∑ i, ((N.projectionOnto S hNS ∘ₗ (Q i).subtype) ∘ₗ
-      (internalProjection hQi hQt i ∘ₗ N.subtype)) = 1 := by
+      (internalProjection hQi hQt i).domRestrict N) = 1 := by
   refine LinearMap.ext fun x ↦ ?_
   have hx : N.projectionOnto S hNS (∑ i, ((internalProjection hQi hQt i (x : M) : M))) = x := by
     rw [sum_coe_internalProjection hQi hQt, Submodule.projectionOnto_apply_left]
@@ -93,22 +93,20 @@ theorem exists_linearEquiv_and_isCompl_biSup_ne
   have _ : Nontrivial N := nontrivial_of_isLocalRing_end (A := A)
   -- Locality of `Module.End A N` picks out an index whose component is invertible.
   obtain ⟨i₀, -, hunit⟩ : ∃ i₀ ∈ Finset.univ, IsUnit ((N.projectionOnto S hNS ∘ₗ (Q i₀).subtype)
-      ∘ₗ (internalProjection hQi hQt i₀ ∘ₗ N.subtype)) :=
+      ∘ₗ (internalProjection hQi hQt i₀).domRestrict N) :=
     IsLocalRing.exists_of_isUnit_sum
       (by rw [sum_projectionOnto_comp_internalProjection_eq_one]; exact isUnit_one)
   -- A split injection into the indecomposable `Q i₀` is already an isomorphism.
-  have hbij : Function.Bijective (internalProjection hQi hQt i₀ ∘ₗ N.subtype) :=
+  have hbij : Function.Bijective ((internalProjection hQi hQt i₀).domRestrict N) :=
     (hQind i₀).bijective_of_bijective_comp (g := N.projectionOnto S hNS ∘ₗ (Q i₀).subtype)
       ((Module.End.isUnit_iff _).mp hunit)
-  -- The projection onto `Q i₀` is surjective, being the identity there.
-  have hsurj : Function.Surjective (internalProjection hQi hQt i₀) :=
-    fun x ↦ ⟨(x : M), internalProjection_apply hQi hQt x⟩
   -- The exchange is the kernel characterisation of injectivity and surjectivity on `N`,
   -- since the remaining summands are exactly the kernel of the `i₀`-projection.
   refine ⟨i₀, ⟨LinearEquiv.ofBijective _ hbij⟩, ?_, ?_⟩
   · rw [← ker_internalProjection hQi hQt i₀]
     exact LinearMap.injective_domRestrict_iff.mp hbij.1
   · rw [← ker_internalProjection hQi hQt i₀]
-    exact (LinearMap.surjective_domRestrict_iff hsurj).mp hbij.2
+    exact (LinearMap.surjective_domRestrict_iff
+      (internalProjection_surjective hQi hQt i₀)).mp hbij.2
 
 end TauCeti


### PR DESCRIPTION
`exists_linearEquiv_and_isCompl_biSup_ne` — Azumaya's exchange lemma — carried a 49-line proof
running two independent arguments end to end: selecting the index `i₀` whose component of the
identity is invertible, and then deriving the exchange from the resulting isomorphism. This cuts
it to 20 lines reading as an outline of the classical argument.

Most of the length turned out to be a re-derivation of Mathlib. `LinearMap.injective_domRestrict_iff`
(`Algebra/Module/Submodule/Ker.lean:202`) and `LinearMap.surjective_domRestrict_iff`
(`LinearAlgebra/Span/Basic.lean:612`) already characterise injectivity and surjectivity of
`f.domRestrict S` as `Disjoint S f.ker` and `Codisjoint S f.ker`. Since `ker_internalProjection`
identifies that kernel with `⨆ j ≠ i₀, Q j`, each half of the exchange is two lines:

```lean
refine ⟨i₀, ⟨LinearEquiv.ofBijective _ hbij⟩, ?_, ?_⟩
· rw [← ker_internalProjection hQi hQt i₀]
  exact LinearMap.injective_domRestrict_iff.mp hbij.1
· rw [← ker_internalProjection hQi hQt i₀]
  exact (LinearMap.surjective_domRestrict_iff
    (internalProjection_surjective hQi hQt i₀)).mp hbij.2
```

Twenty-eight lines of hand-rolled kernel and span manipulation go away, including a
`sub_add_cancel`/`sub_sub_cancel` dance that existed only to show every element differs from its
`i₀`-component by an element of the other summands.

The restricted map is spelled `(internalProjection hQi hQt i).domRestrict N` throughout — in the
helper statement, the `obtain` ascription and `hbij` — rather than `∘ₗ N.subtype`, so both Mathlib
lemmas match syntactically instead of through an unstated unfolding of `LinearMap.domRestrict`.

## Declarations

* `TauCeti/LinearAlgebra/Projection.lean` gains `internalProjection_surjective`, proved by
  `Submodule.projectionOnto_surjective`. That is the file's stated job — its module docstring says
  the pointwise behaviour and kernel of `internalProjection` "are Mathlib's lemmas about
  `Submodule.projectionOnto`, restated for the specialization" — and naming the fact keeps the
  citation off a goal that would otherwise need the `internalProjection = projectionOnto _ _`
  unfolding. Added to that file's Main results.
* `sum_projectionOnto_comp_internalProjection_eq_one` (private, in `Exchange.lean`) — projecting
  `N` into each summand `Q i` and back along `S` gives endomorphisms of `N` summing to the
  identity, the input `IsLocalRing.exists_of_isUnit_sum` consumes. Mathlib has no counterpart. It
  needs `[Fintype ι]`; nothing else in the proof does.

## Scope

The statement and docstring of the exchange lemma are unchanged; that part of the diff is
proof-internal. The only added public declaration is the one-line surjectivity restatement above.

## Verification

Full tree build (6704 jobs), `lake exe axioms`, `lake exe module-system` and
`scripts/lint-env.sh` all green; no new lint violations. Proof body 49 → 20 lines;
`Exchange.lean` is 112 lines against 125 on `main`, so the refactor is a net reduction rather
than a reshuffle.

Roadmap: RepresentationTheory
