### PR TITLE
refactor(Specht): extract the two cases of James's lemma

### DIFF
--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -120,17 +120,19 @@ private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero (s t : YoungTa
     exact add_neg_cancel _
   exact (smul_eq_zero.mp h2).resolve_left (by norm_num)
 
-/-- When no row of `relabel σ t` meets a column of `t` twice, the column antisymmetrizer of `t`
-sends the tabloid of `relabel σ t` to a signed multiple of the polytabloid `e_t`, the sign being
-that of some permutation. -/
-private theorem exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul (t : YoungTableau μ)
-    {σ : Equiv.Perm (Fin μ.card)} (h : ¬ RowMeetsColumnTwice (relabel σ t) t) :
+/-- When no row of `s` meets a column of `t` twice, the column antisymmetrizer of `t` sends the
+tabloid of `s` to a signed multiple of the polytabloid `e_t`, the sign being that of some
+permutation. -/
+private theorem exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul
+    (s t : YoungTableau μ) (h : ¬ RowMeetsColumnTwice s t) :
     ∃ q : Equiv.Perm (Fin μ.card),
       (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-        (MonoidAlgebra.single (tabloid (relabel σ t)) 1)
+        (MonoidAlgebra.single (tabloid s) 1)
           = ((Equiv.Perm.sign q : ℤ) : ℚ) • polytabloid t := by
-  -- `σ⁻¹` factors as a row permutation times a column permutation; the row part fixes `{t}`,
-  -- and `b_t` absorbs the column part `q⁻¹` by its sign.
+  -- Writing `s = relabel σ t`, the permutation `σ⁻¹` factors as a row permutation times a
+  -- column permutation; the row part fixes `{t}`, and `b_t` absorbs the column part `q⁻¹` by
+  -- its sign.
+  obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
   rw [rowMeetsColumnTwice_relabel_left_iff] at h
   obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
   have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
@@ -158,11 +160,10 @@ theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
       (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
           (MonoidAlgebra.single T 1) = κ • polytabloid t := by
   obtain ⟨s, rfl⟩ := tabloid_surjective T
-  obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
-  by_cases h : RowMeetsColumnTwice (relabel σ t) t
+  by_cases h : RowMeetsColumnTwice s t
   · exact ⟨0, Or.inl rfl, by
-      rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero _ t h⟩
-  · obtain ⟨q, hq⟩ := exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul t h
+      rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero s t h⟩
+  · obtain ⟨q, hq⟩ := exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul s t h
     exact ⟨_, Or.inr (by rcases Int.units_eq_one_or (Equiv.Perm.sign q) with h | h <;> simp [h]),
       hq⟩
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -87,17 +87,17 @@ noncomputable local instance (t : YoungTableau μ) : DecidablePred (· ∈ colSu
 
 /-! ### James's lemma: the column antisymmetrizer of a tabloid -/
 
-/-- **The vanishing case of James's lemma.** If a row of `relabel σ t` meets a column of `t` twice,
-the transposition of the two shared labels fixes the tabloid while `b_t` sees its sign, so the
-image is its own negative and hence zero. -/
-private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero (t : YoungTableau μ)
-    {σ : Equiv.Perm (Fin μ.card)} (h : RowMeetsColumnTwice (relabel σ t) t) :
+/-- The column antisymmetrizer of `t` annihilates the tabloid of `s` when some row of `s` meets
+some column of `t` twice. -/
+private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero (s t : YoungTableau μ)
+    (h : RowMeetsColumnTwice s t) :
     (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-      (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
+      (MonoidAlgebra.single (tabloid s) 1) = 0 := by
+  -- The transposition of the two shared labels fixes the tabloid but negates `b_t`, so the
+  -- image is its own negative; over `ℚ` that forces it to vanish.
   obtain ⟨x, y, hxy, hrow, hcol⟩ := (rowMeetsColumnTwice_def _ _).mp h
   have hfix : (permutationModule (shapePartition μ)).ρ (Equiv.swap x y)
-      (MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ)) =
-      MonoidAlgebra.single (tabloid (relabel σ t)) 1 := by
+      (MonoidAlgebra.single (tabloid s) (1 : ℚ)) = MonoidAlgebra.single (tabloid s) 1 := by
     rw [Representation.ofMulAction_single,
       smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow)]
   have hneg : columnAntisymmetrizer t * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) =
@@ -106,29 +106,31 @@ private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero (t : YoungTabl
       Equiv.Perm.sign_swap hxy]
     simp
   have key : (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-        (MonoidAlgebra.single (tabloid (relabel σ t)) 1) =
+        (MonoidAlgebra.single (tabloid s) 1) =
       -((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-        (MonoidAlgebra.single (tabloid (relabel σ t)) 1)) := by
+        (MonoidAlgebra.single (tabloid s) 1)) := by
     conv_lhs => rw [← hfix]
     rw [← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
       ← Module.End.mul_apply, ← map_mul, hneg, map_neg, LinearMap.neg_apply]
   have h2 : (2 : ℚ) •
       (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-        (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
+        (MonoidAlgebra.single (tabloid s) 1) = 0 := by
     rw [two_smul]
     nth_rewrite 2 [key]
     exact add_neg_cancel _
   exact (smul_eq_zero.mp h2).resolve_left (by norm_num)
 
-/-- **The sign case of James's lemma.** If no row of `relabel σ t` meets a column of `t` twice,
-then `σ⁻¹` factors through the row and column groups of `t`; the row part fixes `{t}` and `b_t`
-absorbs the column part by its sign. -/
-private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul (t : YoungTableau μ)
+/-- When no row of `relabel σ t` meets a column of `t` twice, the column antisymmetrizer of `t`
+sends the tabloid of `relabel σ t` to a signed multiple of the polytabloid `e_t`, the sign being
+that of some permutation. -/
+private theorem exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul (t : YoungTableau μ)
     {σ : Equiv.Perm (Fin μ.card)} (h : ¬ RowMeetsColumnTwice (relabel σ t) t) :
     ∃ q : Equiv.Perm (Fin μ.card),
       (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
         (MonoidAlgebra.single (tabloid (relabel σ t)) 1)
           = ((Equiv.Perm.sign q : ℤ) : ℚ) • polytabloid t := by
+  -- `σ⁻¹` factors as a row permutation times a column permutation; the row part fixes `{t}`,
+  -- and `b_t` absorbs the column part `q⁻¹` by its sign.
   rw [rowMeetsColumnTwice_relabel_left_iff] at h
   obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
   have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
@@ -159,8 +161,8 @@ theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
   obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
   by_cases h : RowMeetsColumnTwice (relabel σ t) t
   · exact ⟨0, Or.inl rfl, by
-      rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero t h⟩
-  · obtain ⟨q, hq⟩ := asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul t h
+      rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero _ t h⟩
+  · obtain ⟨q, hq⟩ := exists_asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul t h
     exact ⟨_, Or.inr (by rcases Int.units_eq_one_or (Equiv.Perm.sign q) with h | h <;> simp [h]),
       hq⟩
 

--- a/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
+++ b/TauCeti/RepresentationTheory/Symmetric/Specht/SubmoduleTheorem.lean
@@ -87,6 +87,62 @@ noncomputable local instance (t : YoungTableau μ) : DecidablePred (· ∈ colSu
 
 /-! ### James's lemma: the column antisymmetrizer of a tabloid -/
 
+/-- **The vanishing case of James's lemma.** If a row of `relabel σ t` meets a column of `t` twice,
+the transposition of the two shared labels fixes the tabloid while `b_t` sees its sign, so the
+image is its own negative and hence zero. -/
+private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_zero (t : YoungTableau μ)
+    {σ : Equiv.Perm (Fin μ.card)} (h : RowMeetsColumnTwice (relabel σ t) t) :
+    (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+      (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
+  obtain ⟨x, y, hxy, hrow, hcol⟩ := (rowMeetsColumnTwice_def _ _).mp h
+  have hfix : (permutationModule (shapePartition μ)).ρ (Equiv.swap x y)
+      (MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ)) =
+      MonoidAlgebra.single (tabloid (relabel σ t)) 1 := by
+    rw [Representation.ofMulAction_single,
+      smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow)]
+  have hneg : columnAntisymmetrizer t * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) =
+      -columnAntisymmetrizer t := by
+    rw [mul_columnAntisymmetrizer_right t ⟨Equiv.swap x y, swap_mem_colSubgroup hcol⟩,
+      Equiv.Perm.sign_swap hxy]
+    simp
+  have key : (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+        (MonoidAlgebra.single (tabloid (relabel σ t)) 1) =
+      -((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+        (MonoidAlgebra.single (tabloid (relabel σ t)) 1)) := by
+    conv_lhs => rw [← hfix]
+    rw [← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
+      ← Module.End.mul_apply, ← map_mul, hneg, map_neg, LinearMap.neg_apply]
+  have h2 : (2 : ℚ) •
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+        (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
+    rw [two_smul]
+    nth_rewrite 2 [key]
+    exact add_neg_cancel _
+  exact (smul_eq_zero.mp h2).resolve_left (by norm_num)
+
+/-- **The sign case of James's lemma.** If no row of `relabel σ t` meets a column of `t` twice,
+then `σ⁻¹` factors through the row and column groups of `t`; the row part fixes `{t}` and `b_t`
+absorbs the column part by its sign. -/
+private theorem asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul (t : YoungTableau μ)
+    {σ : Equiv.Perm (Fin μ.card)} (h : ¬ RowMeetsColumnTwice (relabel σ t) t) :
+    ∃ q : Equiv.Perm (Fin μ.card),
+      (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
+        (MonoidAlgebra.single (tabloid (relabel σ t)) 1)
+          = ((Equiv.Perm.sign q : ℤ) : ℚ) • polytabloid t := by
+  rw [rowMeetsColumnTwice_relabel_left_iff] at h
+  obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
+  have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
+  refine ⟨q, ?_⟩
+  have htab : MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ) =
+      (permutationModule (shapePartition μ)).ρ q⁻¹
+        (MonoidAlgebra.single (tabloid t) 1) := by
+    rw [Representation.ofMulAction_single, tabloid_relabel, hσ, mul_smul,
+      smul_tabloid_eq_self_iff.mpr (inv_mem (SetLike.mem_coe.mp hp))]
+  rw [htab, ← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
+    ← Module.End.mul_apply, ← map_mul,
+    mul_columnAntisymmetrizer_right t ⟨q⁻¹, inv_mem (SetLike.mem_coe.mp hq)⟩,
+    Equiv.Perm.sign_inv, map_smul, LinearMap.smul_apply, ← polytabloid_def]
+
 /-- **James's Lemma 4.6.**  The column antisymmetrizer of `t` sends a `μ`-tabloid to a rational
 multiple of the polytabloid `e_t`; the multiple is `0` or a sign.
 
@@ -102,50 +158,11 @@ theorem exists_eq_smul_polytabloid_single (t : YoungTableau μ)
   obtain ⟨s, rfl⟩ := tabloid_surjective T
   obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
   by_cases h : RowMeetsColumnTwice (relabel σ t) t
-  · -- the transposition of the two shared labels fixes the tabloid and negates `b_t`
-    obtain ⟨x, y, hxy, hrow, hcol⟩ := (rowMeetsColumnTwice_def _ _).mp h
-    refine ⟨0, Or.inl rfl, ?_⟩
-    rw [zero_smul]
-    have hfix : (permutationModule (shapePartition μ)).ρ (Equiv.swap x y)
-        (MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ)) =
-        MonoidAlgebra.single (tabloid (relabel σ t)) 1 := by
-      rw [Representation.ofMulAction_single,
-        smul_tabloid_eq_self_iff.mpr (swap_mem_rowSubgroup hrow)]
-    have hneg : columnAntisymmetrizer t * MonoidAlgebra.single (Equiv.swap x y) (1 : ℚ) =
-        -columnAntisymmetrizer t := by
-      rw [mul_columnAntisymmetrizer_right t ⟨Equiv.swap x y, swap_mem_colSubgroup hcol⟩,
-        Equiv.Perm.sign_swap hxy]
-      simp
-    have key : (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-          (MonoidAlgebra.single (tabloid (relabel σ t)) 1) =
-        -((permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-          (MonoidAlgebra.single (tabloid (relabel σ t)) 1)) := by
-      conv_lhs => rw [← hfix]
-      rw [← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
-        ← Module.End.mul_apply, ← map_mul, hneg, map_neg, LinearMap.neg_apply]
-    have h2 : (2 : ℚ) •
-        (permutationModule (shapePartition μ)).ρ.asAlgebraHom (columnAntisymmetrizer t)
-          (MonoidAlgebra.single (tabloid (relabel σ t)) 1) = 0 := by
-      rw [two_smul]
-      nth_rewrite 2 [key]
-      exact add_neg_cancel _
-    exact (smul_eq_zero.mp h2).resolve_left (by norm_num)
-  · -- `σ⁻¹ = p q`, the row part fixes `{t}`, and `b_t` absorbs the column part by its sign
-    rw [rowMeetsColumnTwice_relabel_left_iff] at h
-    obtain ⟨p, hp, q, hq, hpq⟩ := Set.mem_mul.mp (mem_mul_of_not_rowMeetsColumnTwice h)
-    have hσ : σ = q⁻¹ * p⁻¹ := by rw [← mul_inv_rev, hpq, inv_inv]
-    have hsign : ((Equiv.Perm.sign q : ℤ) : ℚ) = 1 ∨ ((Equiv.Perm.sign q : ℤ) : ℚ) = -1 := by
-      rcases Int.units_eq_one_or (Equiv.Perm.sign q) with hq | hq <;> simp [hq]
-    refine ⟨((Equiv.Perm.sign q : ℤ) : ℚ), Or.inr hsign, ?_⟩
-    have htab : MonoidAlgebra.single (tabloid (relabel σ t)) (1 : ℚ) =
-        (permutationModule (shapePartition μ)).ρ q⁻¹
-          (MonoidAlgebra.single (tabloid t) 1) := by
-      rw [Representation.ofMulAction_single, tabloid_relabel, hσ, mul_smul,
-        smul_tabloid_eq_self_iff.mpr (inv_mem (SetLike.mem_coe.mp hp))]
-    rw [htab, ← Representation.asAlgebraHom_single_one (permutationModule (shapePartition μ)).ρ,
-      ← Module.End.mul_apply, ← map_mul,
-      mul_columnAntisymmetrizer_right t ⟨q⁻¹, inv_mem (SetLike.mem_coe.mp hq)⟩,
-      Equiv.Perm.sign_inv, map_smul, LinearMap.smul_apply, ← polytabloid_def]
+  · exact ⟨0, Or.inl rfl, by
+      rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero t h⟩
+  · obtain ⟨q, hq⟩ := asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul t h
+    exact ⟨_, Or.inr (by rcases Int.units_eq_one_or (Equiv.Perm.sign q) with h | h <;> simp [h]),
+      hq⟩
 
 /-- **The column antisymmetrizer collapses `M^μ` onto the line spanned by the polytabloid.**  This
 is the linear extension of `TauCeti.YoungTableau.exists_eq_smul_polytabloid_single` from the


### PR DESCRIPTION
`exists_eq_smul_polytabloid_single` — James's Lemma 4.6 — ran both branches of its `by_cases`
inline, at 28 and 16 lines. This extracts each as a private helper named for the case it handles,
leaving the main proof a 9-line statement of the dichotomy:

```lean
obtain ⟨s, rfl⟩ := tabloid_surjective T
obtain ⟨σ, rfl⟩ := exists_relabel_eq t s
by_cases h : RowMeetsColumnTwice (relabel σ t) t
· exact ⟨0, Or.inl rfl, by
    rw [zero_smul]; exact asAlgebraHom_columnAntisymmetrizer_single_eq_zero t h⟩
· obtain ⟨q, hq⟩ := asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul t h
  exact ⟨_, Or.inr (by rcases Int.units_eq_one_or (Equiv.Perm.sign q) with h | h <;> simp [h]),
    hq⟩
```

## The helpers

* `asAlgebraHom_columnAntisymmetrizer_single_eq_zero` — the vanishing case. A row of
  `relabel σ t` meeting a column of `t` twice gives a transposition that fixes the tabloid while
  `b_t` sees its sign, so the image is its own negative and hence zero.
* `asAlgebraHom_columnAntisymmetrizer_single_eq_sign_smul` — the sign case. `σ⁻¹` factors through
  the row and column groups of `t`; the row part fixes `{t}` and `b_t` absorbs the column part by
  its sign.

## Interface choice

The sign helper returns the witnessing permutation `q` and the equation
`… = ((sign q : ℤ) : ℚ) • polytabloid t`, rather than the disjunction `κ = 0 ∨ κ = 1 ∨ κ = -1`.
The `Int.units_eq_one_or` step that converts a sign into that disjunction then stays in the
caller, where the disjunction is actually wanted. This keeps the helper a statement about the
antisymmetrizer rather than about the shape of the coefficient, and it is why the second branch
above is two lines rather than one.

Both helpers take `σ` implicitly and assume only their case hypothesis; neither sees `T`, the
tabloid surjectivity, or the other branch.

## Not a re-derivation

The vanishing case ends with `x = -x ⟹ x = 0`. Checked before keeping it: Mathlib has no form
that applies here — `CharZero.eq_neg_self_iff` is stated for rings, and the abstract module
version needs a `Module.IsTorsionFree` instance that is not available at this type — so the
`two_smul` / `smul_eq_zero` route stays.

## Scope

The statement and docstring of the public theorem are unchanged; the only added declarations are
two `private theorem`s in the same file.

## Verification

Full tree build (6704 jobs), `lake exe axioms`, `lake exe module-system` and
`scripts/lint-env.sh` all green; no new lint violations. Proof body 48 → 9 lines, with helpers at
26 and 14.

Roadmap: RepresentationTheory
