### PR TITLE
feat: the de Finetti affine correspondence

### DIFF
--- a/TauCeti/MeasureTheory/Measure/GiryMonad.lean
+++ b/TauCeti/MeasureTheory/Measure/GiryMonad.lean
@@ -23,11 +23,6 @@ although all of their ingredients — `Measure.bind_bind`, `Measure.bind_dirac_e
 They are the shape mixture arguments want: `bind` is how a random measure is integrated against
 its mixing law, so pushing a mixture forward along a coordinate map (a marginal), or rewriting a
 mixture over a pushforward mixing law, are both routine steps.
-
-The file also records `bind_add`, additivity of `Measure.bind` in the mixing measure. Mathlib has
-the `ℝ≥0∞`-homogeneity `Measure.bind_smul` and the `Measure.sum`-indexed `Measure.bind_sum`, but
-not the binary sum; together with `Measure.bind_smul` it makes `bind` an affine operation on
-mixing measures.
 -/
 
 public section
@@ -64,20 +59,6 @@ theorem bind_map {μ : Measure S} {f : S → γ} (hf : AEMeasurable f μ)
     {g : γ → Measure δ} (hg : AEMeasurable g (μ.map f)) : (μ.map f).bind g = μ.bind (g ∘ f) := by
   unfold Measure.bind
   rw [AEMeasurable.map_map_of_aemeasurable hg hf]
-
-/-- **`Measure.bind` is additive in the mixing measure.** Mixing against the sum of two measures
-is the sum of the two mixtures.
-
-Together with Mathlib's `Measure.bind_smul` this says that a fixed measurable kernel acts affinely
-on mixing measures. Mathlib has the `Measure.sum`-indexed `Measure.bind_sum`, of which this is the
-binary case. -/
-theorem bind_add (μ ν : Measure S) {g : S → Measure γ} (hg : Measurable g) :
-    (μ + ν).bind g = μ.bind g + ν.bind g := by
-  unfold Measure.bind
-  rw [Measure.map_add _ _ hg]
-  ext s hs
-  rw [Measure.join_apply hs, Measure.add_apply, Measure.join_apply hs, Measure.join_apply hs,
-    lintegral_add_measure]
 
 end MeasureTheory
 

--- a/TauCeti/MeasureTheory/Measure/GiryMonad.lean
+++ b/TauCeti/MeasureTheory/Measure/GiryMonad.lean
@@ -23,6 +23,11 @@ although all of their ingredients — `Measure.bind_bind`, `Measure.bind_dirac_e
 They are the shape mixture arguments want: `bind` is how a random measure is integrated against
 its mixing law, so pushing a mixture forward along a coordinate map (a marginal), or rewriting a
 mixture over a pushforward mixing law, are both routine steps.
+
+The file also records `bind_add`, additivity of `Measure.bind` in the mixing measure. Mathlib has
+the `ℝ≥0∞`-homogeneity `Measure.bind_smul` and the `Measure.sum`-indexed `Measure.bind_sum`, but
+not the binary sum; together with `Measure.bind_smul` it makes `bind` an affine operation on
+mixing measures.
 -/
 
 public section
@@ -59,6 +64,20 @@ theorem bind_map {μ : Measure S} {f : S → γ} (hf : AEMeasurable f μ)
     {g : γ → Measure δ} (hg : AEMeasurable g (μ.map f)) : (μ.map f).bind g = μ.bind (g ∘ f) := by
   unfold Measure.bind
   rw [AEMeasurable.map_map_of_aemeasurable hg hf]
+
+/-- **`Measure.bind` is additive in the mixing measure.** Mixing against the sum of two measures
+is the sum of the two mixtures.
+
+Together with Mathlib's `Measure.bind_smul` this says that a fixed measurable kernel acts affinely
+on mixing measures. Mathlib has the `Measure.sum`-indexed `Measure.bind_sum`, of which this is the
+binary case. -/
+theorem bind_add (μ ν : Measure S) {g : S → Measure γ} (hg : Measurable g) :
+    (μ + ν).bind g = μ.bind g + ν.bind g := by
+  unfold Measure.bind
+  rw [Measure.map_add _ _ hg]
+  ext s hs
+  rw [Measure.join_apply hs, Measure.add_apply, Measure.join_apply hs, Measure.join_apply hs,
+    lintegral_add_measure]
 
 end MeasureTheory
 

--- a/TauCeti/Probability/DeFinetti.lean
+++ b/TauCeti/Probability/DeFinetti.lean
@@ -9,12 +9,14 @@ public import TauCeti.Probability.DeFinetti.Representation
 public import TauCeti.Probability.DeFinetti.CountableIndex
 public import TauCeti.Probability.Exchangeability.ConditionallyIID.Unique
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Extreme
+public import TauCeti.Probability.DeFinetti.Correspondence
 
 /-!
 # De Finetti's theorem
 
 The completed representation API: the summit theorems, their equivalence forms, the unique mixture
-representation, both uniqueness statements, and the countable-index extension.
+representation, both uniqueness statements, the countable-index extension, and the correspondence
+between mixing laws and exchangeable path laws.
 
 This module declares nothing of its own; it is a curated re-export, and it builds on
 `TauCeti.Probability.Exchangeability` rather than duplicating it.
@@ -28,7 +30,10 @@ This module declares nothing of its own; it is a curated re-export, and it build
 * `mixedIID_mixingLaw_unique` — uniqueness of the mixing *law*;
 * `conditionallyIID_ae_unique` — a.e. uniqueness of the directing *measure*;
 * `conditionallyIID_of_exchangeableFamily` — the countable-index extension;
-* `exchangeable_extreme_iff_iid` — the extreme exchangeable laws are exactly the i.i.d. laws.
+* `exchangeable_extreme_iff_iid` — the extreme exchangeable laws are exactly the i.i.d. laws;
+* `deFinettiBarycenter` and `deFinettiEquiv` — the affine correspondence carrying a mixing law to
+  its exchangeable path law, with `deFinettiBarycenter_mem_extremePoints_iff` identifying the
+  point masses with the extreme laws.
 
 The two uniqueness statements are genuinely different, and the difference is the point of the
 conditional predicate: only the law `μ.map ν` is pinned down by the mixture identity, whereas a

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -10,9 +10,8 @@ public import TauCeti.MeasureTheory.Measure.ProductKernel
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Basic
 -- Public: `ExchangeableLaw.existsUnique_mixingLaw` is the path-law form of `deFinetti_mixture`.
 public import TauCeti.Probability.DeFinetti.Representation
--- Non-public: used only inside proofs — additivity of `bind`, the canonical conditionally i.i.d.
--- construction that realizes a barycenter as a path law, and the process/path-law bridge.
-import TauCeti.MeasureTheory.Measure.GiryMonad
+-- Non-public: used only inside proofs — injectivity of the mixture, the canonical conditionally
+-- i.i.d. construction that realizes a barycenter as a path law, and the process/path-law bridge.
 import TauCeti.MeasureTheory.Measure.MixtureInjective
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
 import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
@@ -28,11 +27,12 @@ barycenter**
 deFinettiBarycenter π = ∫ P^{⊗ℕ} dπ(P)
 ```
 
-is the law on `ℕ → α` of a sequence drawn i.i.d. from a `π`-random probability measure. It is the
-`Measure.bind` of `π` against the countable-power kernel `P ↦ P^{⊗ℕ}`, equivalently the barycenter
-(`Measure.join`) of the law of `P^{⊗ℕ}` under `π`; that second reading is the one that makes the
-representation an *ergodic decomposition*, since every `P^{⊗ℕ}` is an extreme exchangeable law
-(`infinitePi_mem_extremePoints_exchangeable`).
+is the `Measure.bind` of `π` against the countable-power kernel `P ↦ P^{⊗ℕ}`, equivalently the
+barycenter (`Measure.join`) of the pushforward of `π` along `P ↦ P^{⊗ℕ}`; that second reading is
+the one that makes the representation an *ergodic decomposition*, since every `P^{⊗ℕ}` is an
+extreme exchangeable law (`infinitePi_mem_extremePoints_exchangeable`). The definition accepts an
+arbitrary measure `π`; when `π` is a probability measure the barycenter is the law on `ℕ → α` of a
+sequence drawn i.i.d. from a `π`-random probability measure.
 
 The map is affine in the mixing law — `deFinettiBarycenter_add` and Mathlib's `Measure.bind_smul`
 — sends probability measures to exchangeable probability measures, and, by de Finetti's theorem,
@@ -79,11 +79,9 @@ namespace Probability
 
 variable {α : Type*} [MeasurableSpace α]
 
-/-- The **de Finetti barycenter** of a mixing law `π` on `ProbabilityMeasure α`: the law on
-`ℕ → α` of a sequence drawn i.i.d. from a `π`-random probability measure,
-`∫ P^{⊗ℕ} dπ(P)`. -/
--- `@[expose]` is forced by the exported `rfl`-unfold `deFinettiBarycenter_def` below.
-@[expose]
+/-- The **de Finetti barycenter** of a mixing law `π` on `ProbabilityMeasure α`: the measure
+`∫ P^{⊗ℕ} dπ(P)` on `ℕ → α` mixing the countable powers against `π`. For `π` a probability
+measure this is the law of a sequence drawn i.i.d. from a `π`-random probability measure. -/
 def deFinettiBarycenter (π : Measure (ProbabilityMeasure α)) : Measure (ℕ → α) :=
   π.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)
 
@@ -92,15 +90,17 @@ form in which the surrounding development states the mixture representation, so 
 to `deFinetti_mixture`, `mixedIID_mixingLaw_unique` and `Measure.ext_of_bind_infinitePi_eq`. -/
 theorem deFinettiBarycenter_def (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter π = π.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
-  rfl
+  (rfl)
 
-/-- The barycenter as the `Measure.join` of the law of `P^{⊗ℕ}` under the mixing law: the mixture
-representation read as a barycenter of path laws rather than of state laws. -/
+/-- The barycenter as the `Measure.join` of the pushforward of the mixing measure along
+`P ↦ P^{⊗ℕ}`: the mixture representation read as a barycenter of measures on `ℕ → α` rather than
+of measures on `α`. For `π` a probability measure this pushforward is the law of `P^{⊗ℕ}` under a
+`π`-random `P`. -/
 theorem deFinettiBarycenter_eq_join_map (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter π =
       (π.map fun P : ProbabilityMeasure α =>
         Measure.infinitePi fun _ : ℕ => (P : Measure α)).join :=
-  rfl
+  (rfl)
 
 /-- Evaluation of a barycenter on a measurable set: the `π`-average of the countable-power
 masses. -/
@@ -125,17 +125,21 @@ instance isProbabilityMeasure_deFinettiBarycenter (π : Measure (ProbabilityMeas
 
 /-- **The barycenter is additive in the mixing law.** -/
 theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) :
-    deFinettiBarycenter (π₁ + π₂) = deFinettiBarycenter π₁ + deFinettiBarycenter π₂ :=
-  TauCeti.MeasureTheory.bind_add π₁ π₂ TauCeti.MeasureTheory.measurable_infinitePi_const
+    deFinettiBarycenter (π₁ + π₂) = deFinettiBarycenter π₁ + deFinettiBarycenter π₂ := by
+  simp only [deFinettiBarycenter_def]
+  rw [← Measure.sum_cond π₁ π₂,
+    Measure.bind_sum _ _ TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable,
+    Measure.sum_bool]
+  rfl
 
 /-- **The barycenter is homogeneous in the mixing law.** -/
 theorem deFinettiBarycenter_smul (c : ℝ≥0∞) (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (c • π) = c • deFinettiBarycenter π :=
   Measure.bind_smul c π _
 
-/-- **The barycenter map is affine.** A convex combination of mixing laws has the corresponding
-convex combination of their barycenters as its own barycenter; taking `a + b = 1` and `π₁`, `π₂`
-probability measures reads this as: mixing the mixing laws mixes the path laws. -/
+/-- **The barycenter map is affine.** A weighted sum of mixing measures has the corresponding
+weighted sum of their barycenters as its own barycenter. For `a + b = 1` and `π₁`, `π₂` probability
+measures this is the convex-combination form: mixing the mixing laws mixes the path laws. -/
 theorem deFinettiBarycenter_smul_add_smul (a b : ℝ≥0∞) (π₁ π₂ : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (a • π₁ + b • π₂) =
       a • deFinettiBarycenter π₁ + b • deFinettiBarycenter π₂ := by

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -50,7 +50,8 @@ throughout the de Finetti development (`deFinetti_mixture`, `mixedIID_mixingLaw_
 
 * `deFinettiBarycenter` — the mixture of countable powers along a mixing law.
 * `deFinettiBarycenter_dirac` — a point mass mixes to a single i.i.d. law.
-* `deFinettiBarycenter_add`, `deFinettiBarycenter_smul_add_smul` — affinity in the mixing law.
+* `deFinettiBarycenter_zero`, `deFinettiBarycenter_add`, `deFinettiBarycenter_smul`,
+  `deFinettiBarycenter_smul_add_smul` — affinity in the mixing law.
 * `exchangeableLaw_deFinettiBarycenter` — every barycenter of a mixing probability law is an
   exchangeable path law.
 * `ExchangeableLaw.existsUnique_mixingLaw` — conversely, an exchangeable probability law on
@@ -123,7 +124,13 @@ instance isProbabilityMeasure_deFinettiBarycenter (π : Measure (ProbabilityMeas
   isProbabilityMeasure_bind TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable
     (.of_forall fun _ => inferInstance)
 
+/-- **The zero mixing law has the zero barycenter.** -/
+@[simp]
+theorem deFinettiBarycenter_zero : deFinettiBarycenter (0 : Measure (ProbabilityMeasure α)) = 0 :=
+  Measure.bind_zero_left _
+
 /-- **The barycenter is additive in the mixing law.** -/
+@[simp]
 theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (π₁ + π₂) = deFinettiBarycenter π₁ + deFinettiBarycenter π₂ := by
   simp only [deFinettiBarycenter_def]
@@ -133,6 +140,7 @@ theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) 
   rfl
 
 /-- **The barycenter is homogeneous in the mixing law.** -/
+@[simp]
 theorem deFinettiBarycenter_smul (c : ℝ≥0∞) (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (c • π) = c • deFinettiBarycenter π :=
   Measure.bind_smul c π _

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -10,9 +10,8 @@ public import TauCeti.MeasureTheory.Measure.ProductKernel
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Basic
 -- Public: `ExchangeableLaw.existsUnique_mixingLaw` is the path-law form of `deFinetti_mixture`.
 public import TauCeti.Probability.DeFinetti.Representation
--- Non-public: used only inside proofs — injectivity of the mixture, the canonical conditionally
--- i.i.d. construction that realizes a barycenter as a path law, and the process/path-law bridge.
-import TauCeti.MeasureTheory.Measure.MixtureInjective
+-- Non-public: used only inside proofs — the canonical conditionally i.i.d. construction that
+-- realizes a barycenter as a path law, and the process/path-law bridge.
 import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
 import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
 
@@ -180,12 +179,6 @@ theorem ExchangeableLaw.existsUnique_mixingLaw [StandardBorelSpace α] {ρ : Mea
     (exchangeable_iff_exchangeableLaw_pathLaw fun n => (hcoord n).aemeasurable).2
       (by simpa [pathLaw_def] using hρ)
   simpa [hpath, deFinettiBarycenter_def] using deFinetti_mixture hexch hcoord
-
-/-- **A barycenter determines its mixing law.** Two finite mixing laws with the same de Finetti
-barycenter are equal. This is `Measure.ext_of_bind_infinitePi_eq` read through the barycenter. -/
-theorem eq_of_deFinettiBarycenter_eq {π₁ π₂ : Measure (ProbabilityMeasure α)} [IsFiniteMeasure π₁]
-    (h : deFinettiBarycenter π₁ = deFinettiBarycenter π₂) : π₁ = π₂ :=
-  TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq h
 
 end Probability
 

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -1,0 +1,188 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+-- Public: the barycenter is a `Measure.bind` against the measurable countable-power kernel, and
+-- its values are exchangeable path laws.
+public import TauCeti.MeasureTheory.Measure.ProductKernel
+public import TauCeti.Probability.Exchangeability.PathSpace.Law.Basic
+-- Public: `ExchangeableLaw.existsUnique_mixingLaw` is the path-law form of `deFinetti_mixture`.
+public import TauCeti.Probability.DeFinetti.Representation
+-- Non-public: used only inside proofs — additivity of `bind`, the canonical conditionally i.i.d.
+-- construction that realizes a barycenter as a path law, and the process/path-law bridge.
+import TauCeti.MeasureTheory.Measure.GiryMonad
+import TauCeti.MeasureTheory.Measure.MixtureInjective
+import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
+import TauCeti.Probability.Exchangeability.PathSpace.Law.Bridge
+
+/-!
+# The de Finetti barycenter of a mixing law
+
+De Finetti's representation is a map in one direction and a theorem in the other. This file builds
+the map. For a measure `π` on `ProbabilityMeasure α` — a *mixing law* — the **de Finetti
+barycenter**
+
+```text
+deFinettiBarycenter π = ∫ P^{⊗ℕ} dπ(P)
+```
+
+is the law on `ℕ → α` of a sequence drawn i.i.d. from a `π`-random probability measure. It is the
+`Measure.bind` of `π` against the countable-power kernel `P ↦ P^{⊗ℕ}`, equivalently the barycenter
+(`Measure.join`) of the law of `P^{⊗ℕ}` under `π`; that second reading is the one that makes the
+representation an *ergodic decomposition*, since every `P^{⊗ℕ}` is an extreme exchangeable law
+(`infinitePi_mem_extremePoints_exchangeable`).
+
+The map is affine in the mixing law — `deFinettiBarycenter_add` and Mathlib's `Measure.bind_smul`
+— sends probability measures to exchangeable probability measures, and, by de Finetti's theorem,
+hits every exchangeable probability law exactly once
+(`ExchangeableLaw.existsUnique_mixingLaw`). The packaging of that bijection as an equivalence, and
+its restriction to point masses, is in `TauCeti.Probability.DeFinetti.Correspondence`.
+
+This is the object the Layer 8 bullet of `TauCetiRoadmap/Exchangeability/README.md` — "package
+`p ↦ p^{⊗ℕ}` and the de Finetti barycenter as an affine correspondence between mixing laws and
+exchangeable path laws" — asks for. The expression `π.bind (P ↦ P^{⊗ℕ})` already occurs unnamed
+throughout the de Finetti development (`deFinetti_mixture`, `mixedIID_mixingLaw_unique`,
+`Measure.ext_of_bind_infinitePi_eq`); naming it is what lets the correspondence be stated.
+
+## Main results
+
+* `deFinettiBarycenter` — the mixture of countable powers along a mixing law.
+* `deFinettiBarycenter_dirac` — a point mass mixes to a single i.i.d. law.
+* `deFinettiBarycenter_add`, `deFinettiBarycenter_smul_add_smul` — affinity in the mixing law.
+* `exchangeableLaw_deFinettiBarycenter` — every barycenter of a mixing probability law is an
+  exchangeable path law.
+* `ExchangeableLaw.existsUnique_mixingLaw` — conversely, an exchangeable probability law on
+  `ℕ → α` is the barycenter of exactly one mixing law, for `α` standard Borel.
+
+## References
+
+* Olav Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005,
+  Chapter 1, Theorem 1.1.
+
+No material is adapted from `cameronfreer/exchangeability`, which carries the mixture
+representation only as an unnamed `bind` expression and does not package the correspondence.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- The **de Finetti barycenter** of a mixing law `π` on `ProbabilityMeasure α`: the law on
+`ℕ → α` of a sequence drawn i.i.d. from a `π`-random probability measure,
+`∫ P^{⊗ℕ} dπ(P)`. -/
+-- `@[expose]` is forced by the exported `rfl`-unfold `deFinettiBarycenter_def` below.
+@[expose]
+def deFinettiBarycenter (π : Measure (ProbabilityMeasure α)) : Measure (ℕ → α) :=
+  π.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)
+
+/-- The barycenter unfolded as a `Measure.bind` against the countable-power kernel. This is the
+form in which the surrounding development states the mixture representation, so it is the bridge
+to `deFinetti_mixture`, `mixedIID_mixingLaw_unique` and `Measure.ext_of_bind_infinitePi_eq`. -/
+theorem deFinettiBarycenter_def (π : Measure (ProbabilityMeasure α)) :
+    deFinettiBarycenter π = π.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
+  rfl
+
+/-- The barycenter as the `Measure.join` of the law of `P^{⊗ℕ}` under the mixing law: the mixture
+representation read as a barycenter of path laws rather than of state laws. -/
+theorem deFinettiBarycenter_eq_join_map (π : Measure (ProbabilityMeasure α)) :
+    deFinettiBarycenter π =
+      (π.map fun P : ProbabilityMeasure α =>
+        Measure.infinitePi fun _ : ℕ => (P : Measure α)).join :=
+  rfl
+
+/-- Evaluation of a barycenter on a measurable set: the `π`-average of the countable-power
+masses. -/
+theorem deFinettiBarycenter_apply (π : Measure (ProbabilityMeasure α)) {s : Set (ℕ → α)}
+    (hs : MeasurableSet s) :
+    deFinettiBarycenter π s =
+      ∫⁻ P, (Measure.infinitePi fun _ : ℕ => (P : Measure α)) s ∂π :=
+  Measure.bind_apply hs TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable
+
+/-- A point mass mixing law has the corresponding i.i.d. law as its barycenter. -/
+@[simp]
+theorem deFinettiBarycenter_dirac (P : ProbabilityMeasure α) :
+    deFinettiBarycenter (Measure.dirac P) = Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
+  Measure.dirac_bind TauCeti.MeasureTheory.measurable_infinitePi_const P
+
+/-- The barycenter of a probability mixing law is a probability measure: every countable power of
+a probability measure is one, so the mixture keeps the total mass of `π`. -/
+instance isProbabilityMeasure_deFinettiBarycenter (π : Measure (ProbabilityMeasure α))
+    [IsProbabilityMeasure π] : IsProbabilityMeasure (deFinettiBarycenter π) :=
+  isProbabilityMeasure_bind TauCeti.MeasureTheory.measurable_infinitePi_const.aemeasurable
+    (.of_forall fun _ => inferInstance)
+
+/-- **The barycenter is additive in the mixing law.** -/
+theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) :
+    deFinettiBarycenter (π₁ + π₂) = deFinettiBarycenter π₁ + deFinettiBarycenter π₂ :=
+  TauCeti.MeasureTheory.bind_add π₁ π₂ TauCeti.MeasureTheory.measurable_infinitePi_const
+
+/-- **The barycenter is homogeneous in the mixing law.** -/
+theorem deFinettiBarycenter_smul (c : ℝ≥0∞) (π : Measure (ProbabilityMeasure α)) :
+    deFinettiBarycenter (c • π) = c • deFinettiBarycenter π :=
+  Measure.bind_smul c π _
+
+/-- **The barycenter map is affine.** A convex combination of mixing laws has the corresponding
+convex combination of their barycenters as its own barycenter; taking `a + b = 1` and `π₁`, `π₂`
+probability measures reads this as: mixing the mixing laws mixes the path laws. -/
+theorem deFinettiBarycenter_smul_add_smul (a b : ℝ≥0∞) (π₁ π₂ : Measure (ProbabilityMeasure α)) :
+    deFinettiBarycenter (a • π₁ + b • π₂) =
+      a • deFinettiBarycenter π₁ + b • deFinettiBarycenter π₂ := by
+  rw [deFinettiBarycenter_add, deFinettiBarycenter_smul, deFinettiBarycenter_smul]
+
+/-- **A barycenter is an exchangeable path law.** Drawing `P` from `π` and then an i.i.d.
+`P`-sequence produces a law invariant under every permutation of the time coordinate.
+
+The witness is the canonical conditionally i.i.d. construction `iidMixtureLaw π id`, whose
+coordinate process is exchangeable and whose path law is this barycenter. -/
+theorem exchangeableLaw_deFinettiBarycenter {π : Measure (ProbabilityMeasure α)}
+    [IsProbabilityMeasure π] : ExchangeableLaw (deFinettiBarycenter π) := by
+  have := isProbabilityMeasure_iidMixtureLaw (π := π) (P := id) measurable_id
+  have hX := exchangeable_iidMixtureLaw (π := π) (P := id) measurable_id
+  have hcoord : ∀ n, AEMeasurable
+      (fun ω : ProbabilityMeasure α × (ℕ → α) => ω.2 n) (iidMixtureLaw π id) :=
+    fun n => ((measurable_pi_apply n).comp measurable_snd).aemeasurable
+  have hlaw := (exchangeable_iff_exchangeableLaw_pathLaw
+    (X := fun n (ω : ProbabilityMeasure α × (ℕ → α)) => ω.2 n) hcoord).mp hX
+  rw [pathLaw_iidMixtureLaw (π := π) (P := id) measurable_id] at hlaw
+  simpa [deFinettiBarycenter_def] using hlaw
+
+/-- **The mixing law of an exchangeable path law.** Over a standard Borel state space, an
+exchangeable probability measure on `ℕ → α` is the de Finetti barycenter of exactly one mixing
+law.
+
+This is the path-law form of `deFinetti_mixture`, obtained by taking the coordinate process of
+`ρ` itself: existence is de Finetti's theorem and uniqueness is injectivity of the mixture. The
+state space needs no nonemptiness hypothesis, since a probability measure on `ℕ → α` already
+exhibits a point of `α`. -/
+theorem ExchangeableLaw.existsUnique_mixingLaw [StandardBorelSpace α] {ρ : Measure (ℕ → α)}
+    [IsProbabilityMeasure ρ] (hρ : ExchangeableLaw ρ) :
+    ∃! π : ProbabilityMeasure (ProbabilityMeasure α), ρ = deFinettiBarycenter π := by
+  have : Nonempty α := (nonempty_of_isProbabilityMeasure ρ).map fun x => x 0
+  have hcoord : ∀ n, Measurable fun x : ℕ → α => x n := fun n => measurable_pi_apply n
+  have hpath : pathLaw ρ (fun n (x : ℕ → α) => x n) = ρ := by simp [pathLaw_def]
+  have hexch : Exchangeable ρ (fun n (x : ℕ → α) => x n) :=
+    (exchangeable_iff_exchangeableLaw_pathLaw fun n => (hcoord n).aemeasurable).2
+      (by simpa [pathLaw_def] using hρ)
+  simpa [hpath, deFinettiBarycenter_def] using deFinetti_mixture hexch hcoord
+
+/-- **A barycenter determines its mixing law.** Two finite mixing laws with the same de Finetti
+barycenter are equal. This is `Measure.ext_of_bind_infinitePi_eq` read through the barycenter. -/
+theorem eq_of_deFinettiBarycenter_eq {π₁ π₂ : Measure (ProbabilityMeasure α)} [IsFiniteMeasure π₁]
+    (h : deFinettiBarycenter π₁ = deFinettiBarycenter π₂) : π₁ = π₂ :=
+  TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq h
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/DeFinetti/Barycenter.lean
+++ b/TauCeti/Probability/DeFinetti/Barycenter.lean
@@ -50,8 +50,8 @@ throughout the de Finetti development (`deFinetti_mixture`, `mixedIID_mixingLaw_
 
 * `deFinettiBarycenter` — the mixture of countable powers along a mixing law.
 * `deFinettiBarycenter_dirac` — a point mass mixes to a single i.i.d. law.
-* `deFinettiBarycenter_zero`, `deFinettiBarycenter_add`, `deFinettiBarycenter_smul`,
-  `deFinettiBarycenter_smul_add_smul` — affinity in the mixing law.
+* `deFinettiBarycenter_zero`, `deFinettiBarycenter_add`, `deFinettiBarycenter_smul` — affinity in
+  the mixing law.
 * `exchangeableLaw_deFinettiBarycenter` — every barycenter of a mixing probability law is an
   exchangeable path law.
 * `ExchangeableLaw.existsUnique_mixingLaw` — conversely, an exchangeable probability law on
@@ -144,14 +144,6 @@ theorem deFinettiBarycenter_add (π₁ π₂ : Measure (ProbabilityMeasure α)) 
 theorem deFinettiBarycenter_smul (c : ℝ≥0∞) (π : Measure (ProbabilityMeasure α)) :
     deFinettiBarycenter (c • π) = c • deFinettiBarycenter π :=
   Measure.bind_smul c π _
-
-/-- **The barycenter map is affine.** A weighted sum of mixing measures has the corresponding
-weighted sum of their barycenters as its own barycenter. For `a + b = 1` and `π₁`, `π₂` probability
-measures this is the convex-combination form: mixing the mixing laws mixes the path laws. -/
-theorem deFinettiBarycenter_smul_add_smul (a b : ℝ≥0∞) (π₁ π₂ : Measure (ProbabilityMeasure α)) :
-    deFinettiBarycenter (a • π₁ + b • π₂) =
-      a • deFinettiBarycenter π₁ + b • deFinettiBarycenter π₂ := by
-  rw [deFinettiBarycenter_add, deFinettiBarycenter_smul, deFinettiBarycenter_smul]
 
 /-- **A barycenter is an exchangeable path law.** Drawing `P` from `π` and then an i.i.d.
 `P`-sequence produces a law invariant under every permutation of the time coordinate.

--- a/TauCeti/Probability/DeFinetti/Correspondence.lean
+++ b/TauCeti/Probability/DeFinetti/Correspondence.lean
@@ -78,8 +78,6 @@ The forward map is `deFinettiBarycenter`; the inverse sends an exchangeable law 
 Injectivity is uniqueness of the mixing law and surjectivity is de Finetti's theorem, so the
 equivalence is exactly the content of `ExchangeableLaw.existsUnique_mixingLaw` in bijective
 form. -/
--- `@[expose]` is forced by the exported `rfl`-unfold `deFinettiEquiv_apply_coe` below.
-@[expose]
 def deFinettiEquiv [StandardBorelSpace α] :
     ProbabilityMeasure (ProbabilityMeasure α) ≃
       {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw (ρ : Measure (ℕ → α))} :=
@@ -100,7 +98,7 @@ theorem deFinettiEquiv_apply_coe [StandardBorelSpace α]
     (π : ProbabilityMeasure (ProbabilityMeasure α)) :
     ((deFinettiEquiv π : ProbabilityMeasure (ℕ → α)) : Measure (ℕ → α)) =
       deFinettiBarycenter (π : Measure (ProbabilityMeasure α)) :=
-  rfl
+  (rfl)
 
 /-- The inverse of the correspondence really is the mixing law: the barycenter of the mixing law
 of an exchangeable law recovers that law. -/

--- a/TauCeti/Probability/DeFinetti/Correspondence.lean
+++ b/TauCeti/Probability/DeFinetti/Correspondence.lean
@@ -26,11 +26,12 @@ Injectivity is `Measure.ext_of_bind_infinitePi_eq`, surjectivity is
 `deFinettiEquiv.symm` is therefore a genuine construction: it reads the mixing law off an
 exchangeable law.
 
-The correspondence is affine, `deFinettiBarycenter_smul_add_smul` giving the mixture identity on
-the barycenter side; and it takes the point masses of `ProbabilityMeasure α` exactly to the
-extreme exchangeable laws (`deFinettiBarycenter_mem_extremePoints_iff`,
-`deFinettiEquiv_dirac`). Reading `deFinettiBarycenter` as `deFinettiBarycenter_eq_join_map` does,
-this is the canonical decomposition of an exchangeable law over the extreme — equivalently the
+The correspondence is affine, `deFinettiBarycenter_add` and `deFinettiBarycenter_smul` giving
+the mixture identity on the barycenter side; and it takes the point masses of
+`ProbabilityMeasure α` exactly to the extreme exchangeable laws
+(`deFinettiBarycenter_mem_extremePoints_iff`, `deFinettiEquiv_dirac`). Reading
+`deFinettiBarycenter` as `deFinettiBarycenter_eq_join_map` does, this is the canonical
+decomposition of an exchangeable law over the extreme — equivalently the
 i.i.d. — exchangeable laws: the mixing law is unique, and the path laws it averages are extreme.
 
 This settles the first two sentences of the Layer 8 bullet "the affine and ergodic decomposition

--- a/TauCeti/Probability/DeFinetti/Correspondence.lean
+++ b/TauCeti/Probability/DeFinetti/Correspondence.lean
@@ -1,0 +1,153 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Probability.DeFinetti.Barycenter
+-- Public: the correspondence's point masses are characterized by extremality.
+public import TauCeti.Probability.Exchangeability.PathSpace.Law.Extreme
+
+/-!
+# The de Finetti correspondence
+
+De Finetti's theorem says that the barycenter map `π ↦ ∫ P^{⊗ℕ} dπ(P)` is a bijection from mixing
+laws onto exchangeable path laws. This file packages that bijection as an equivalence
+
+```text
+deFinettiEquiv :
+  ProbabilityMeasure (ProbabilityMeasure α) ≃ {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw ρ}
+```
+
+for a standard Borel state space `α`, and identifies its point masses.
+
+Injectivity is `Measure.ext_of_bind_infinitePi_eq`, surjectivity is
+`ExchangeableLaw.existsUnique_mixingLaw` — de Finetti's theorem in path-law form. The inverse
+`deFinettiEquiv.symm` is therefore a genuine construction: it reads the mixing law off an
+exchangeable law.
+
+The correspondence is affine, `deFinettiBarycenter_smul_add_smul` giving the mixture identity on
+the barycenter side; and it takes the point masses of `ProbabilityMeasure α` exactly to the
+extreme exchangeable laws (`deFinettiBarycenter_mem_extremePoints_iff`,
+`deFinettiEquiv_dirac`). Reading `deFinettiBarycenter` as `deFinettiBarycenter_eq_join_map` does,
+this is the canonical decomposition of an exchangeable law over the extreme — equivalently the
+i.i.d. — exchangeable laws: the mixing law is unique, and the path laws it averages are extreme.
+
+This settles the first two sentences of the Layer 8 bullet "the affine and ergodic decomposition
+of exchangeable laws" in `TauCetiRoadmap/Exchangeability/README.md`. Identifying the components
+with the ergodic components of the finitely supported permutation action, which that bullet
+sequences after the `ErgodicSMul` interface of Layer 6, is not done here.
+
+## Main results
+
+* `deFinettiEquiv` — mixing laws correspond bijectively to exchangeable path laws.
+* `deFinettiEquiv_dirac` — a point mass corresponds to an i.i.d. law.
+* `deFinettiBarycenter_mem_extremePoints_iff` — a barycenter is an extreme exchangeable law
+  exactly when its mixing law is a point mass.
+
+## References
+
+* Olav Kallenberg, *Probabilistic Symmetries and Invariance Principles*, Springer, 2005,
+  Chapter 1, Theorem 1.1.
+* David Aldous, *Exchangeability and related topics*, École d'Été de Probabilités de Saint-Flour
+  XIII, 1983, §3, for the affine and extreme-point reading of the representation.
+
+No material is adapted from `cameronfreer/exchangeability`, which does not package the
+representation as a correspondence.
+-/
+
+public section
+
+noncomputable section
+
+open MeasureTheory Set
+
+open scoped ENNReal
+
+namespace TauCeti
+
+namespace Probability
+
+variable {α : Type*} [MeasurableSpace α]
+
+/-- **The de Finetti correspondence.** Over a standard Borel state space, the de Finetti
+barycenter is a bijection from mixing laws — probability measures on `ProbabilityMeasure α` — onto
+exchangeable probability measures on `ℕ → α`.
+
+The forward map is `deFinettiBarycenter`; the inverse sends an exchangeable law to its mixing law.
+Injectivity is uniqueness of the mixing law and surjectivity is de Finetti's theorem, so the
+equivalence is exactly the content of `ExchangeableLaw.existsUnique_mixingLaw` in bijective
+form. -/
+-- `@[expose]` is forced by the exported `rfl`-unfold `deFinettiEquiv_apply_coe` below.
+@[expose]
+def deFinettiEquiv [StandardBorelSpace α] :
+    ProbabilityMeasure (ProbabilityMeasure α) ≃
+      {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw (ρ : Measure (ℕ → α))} :=
+  Equiv.ofBijective
+    (fun π : ProbabilityMeasure (ProbabilityMeasure α) =>
+      ⟨⟨deFinettiBarycenter π.toMeasure, inferInstance⟩, exchangeableLaw_deFinettiBarycenter⟩)
+    ⟨fun π₁ π₂ h => by
+      have h' : deFinettiBarycenter π₁.toMeasure = deFinettiBarycenter π₂.toMeasure :=
+        congrArg (fun r : {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw ρ.toMeasure} =>
+          ProbabilityMeasure.toMeasure r.1) h
+      exact ProbabilityMeasure.toMeasure_injective (eq_of_deFinettiBarycenter_eq h'),
+      fun ρ => by
+        obtain ⟨π, hπ, -⟩ := ρ.2.existsUnique_mixingLaw
+        exact ⟨π, Subtype.ext (ProbabilityMeasure.toMeasure_injective hπ.symm)⟩⟩
+
+@[simp]
+theorem deFinettiEquiv_apply_coe [StandardBorelSpace α]
+    (π : ProbabilityMeasure (ProbabilityMeasure α)) :
+    ((deFinettiEquiv π : ProbabilityMeasure (ℕ → α)) : Measure (ℕ → α)) =
+      deFinettiBarycenter (π : Measure (ProbabilityMeasure α)) :=
+  rfl
+
+/-- The inverse of the correspondence really is the mixing law: the barycenter of the mixing law
+of an exchangeable law recovers that law. -/
+@[simp]
+theorem deFinettiBarycenter_deFinettiEquiv_symm [StandardBorelSpace α]
+    (ρ : {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw (ρ : Measure (ℕ → α))}) :
+    deFinettiBarycenter ((deFinettiEquiv.symm ρ : ProbabilityMeasure (ProbabilityMeasure α)) :
+        Measure (ProbabilityMeasure α)) = (ρ : ProbabilityMeasure (ℕ → α)) := by
+  rw [← deFinettiEquiv_apply_coe, deFinettiEquiv.apply_symm_apply]
+
+/-- The mixing law is characterized by its barycenter: a mixing law whose barycenter is `ρ` is
+*the* mixing law of `ρ`. -/
+theorem deFinettiEquiv_symm_eq [StandardBorelSpace α]
+    {ρ : {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw (ρ : Measure (ℕ → α))}}
+    {π : ProbabilityMeasure (ProbabilityMeasure α)}
+    (h : ((ρ : ProbabilityMeasure (ℕ → α)) : Measure (ℕ → α)) =
+      deFinettiBarycenter (π : Measure (ProbabilityMeasure α))) :
+    deFinettiEquiv.symm ρ = π :=
+  deFinettiEquiv.symm_apply_eq.2 (Subtype.ext (Subtype.ext h))
+
+/-- **Point masses correspond to i.i.d. laws.** A mixing law concentrated at `P` corresponds to
+the i.i.d. law `P^{⊗ℕ}`. -/
+@[simp]
+theorem deFinettiEquiv_dirac [StandardBorelSpace α] (P : ProbabilityMeasure α) :
+    ((deFinettiEquiv ⟨Measure.dirac P, inferInstance⟩ : ProbabilityMeasure (ℕ → α)) :
+        Measure (ℕ → α)) = Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
+  deFinettiBarycenter_dirac P
+
+/-- **The extreme fibres of the correspondence are exactly the point masses.** The de Finetti
+barycenter of a mixing law is an extreme exchangeable probability law if and only if that mixing
+law is a Dirac mass.
+
+Combined with `deFinettiBarycenter_eq_join_map`, this is the canonical decomposition an
+exchangeable law admits: it is the barycenter of a unique law on path laws, and that law is
+carried by the extreme — equivalently i.i.d. — exchangeable laws
+(`infinitePi_mem_extremePoints_exchangeable`), degenerating exactly on the extreme points
+themselves. -/
+theorem deFinettiBarycenter_mem_extremePoints_iff [StandardBorelSpace α]
+    {π : Measure (ProbabilityMeasure α)} [IsProbabilityMeasure π] :
+    deFinettiBarycenter π ∈ extremePoints ℝ≥0∞
+        {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν} ↔
+      ∃ P : ProbabilityMeasure α, π = Measure.dirac P := by
+  rw [exchangeable_extreme_iff_iid]
+  refine ⟨fun ⟨P, hP⟩ => ⟨P, eq_of_deFinettiBarycenter_eq ?_⟩, fun ⟨P, hP⟩ => ⟨P, ?_⟩⟩
+  · rw [hP, deFinettiBarycenter_dirac]
+  · rw [hP, deFinettiBarycenter_dirac]
+
+end Probability
+
+end TauCeti

--- a/TauCeti/Probability/DeFinetti/Correspondence.lean
+++ b/TauCeti/Probability/DeFinetti/Correspondence.lean
@@ -7,6 +7,9 @@ module
 public import TauCeti.Probability.DeFinetti.Barycenter
 -- Public: the correspondence's point masses are characterized by extremality.
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Extreme
+-- Non-public: used only inside proofs — injectivity of the mixture is what makes the
+-- correspondence injective.
+import TauCeti.MeasureTheory.Measure.MixtureInjective
 
 /-!
 # The de Finetti correspondence
@@ -89,7 +92,9 @@ def deFinettiEquiv [StandardBorelSpace α] :
       have h' : deFinettiBarycenter π₁.toMeasure = deFinettiBarycenter π₂.toMeasure :=
         congrArg (fun r : {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw ρ.toMeasure} =>
           ProbabilityMeasure.toMeasure r.1) h
-      exact ProbabilityMeasure.toMeasure_injective (eq_of_deFinettiBarycenter_eq h'),
+      simp only [deFinettiBarycenter_def] at h'
+      exact ProbabilityMeasure.toMeasure_injective
+        (TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq h'),
       fun ρ => by
         obtain ⟨π, hπ, -⟩ := ρ.2.existsUnique_mixingLaw
         exact ⟨π, Subtype.ext (ProbabilityMeasure.toMeasure_injective hπ.symm)⟩⟩
@@ -143,8 +148,9 @@ theorem deFinettiBarycenter_mem_extremePoints_iff [StandardBorelSpace α]
         {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν} ↔
       ∃ P : ProbabilityMeasure α, π = Measure.dirac P := by
   rw [exchangeable_extreme_iff_iid]
-  refine ⟨fun ⟨P, hP⟩ => ⟨P, eq_of_deFinettiBarycenter_eq ?_⟩, fun ⟨P, hP⟩ => ⟨P, ?_⟩⟩
-  · rw [hP, deFinettiBarycenter_dirac]
+  refine ⟨fun ⟨P, hP⟩ => ⟨P, TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq ?_⟩,
+    fun ⟨P, hP⟩ => ⟨P, ?_⟩⟩
+  · simp only [← deFinettiBarycenter_def, hP, deFinettiBarycenter_dirac]
   · rw [hP, deFinettiBarycenter_dirac]
 
 end Probability

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -133,7 +133,8 @@ private theorem cond_eq_of_extreme_iidMixture [StandardBorelSpace α]
   -- affinity of the barycenter turns the splitting of `p` into a splitting of `ρ`
   have hmix_split : deFinettiBarycenter p =
       p s • deFinettiBarycenter (p[|s]) + p sᶜ • deFinettiBarycenter (p[|sᶜ]) := by
-    rw [← deFinettiBarycenter_smul_add_smul, ← hp_split]
+    conv_lhs => rw [hp_split]
+    simp only [deFinettiBarycenter_add, deFinettiBarycenter_smul]
   have hopen : ρ ∈
       openSegment ℝ≥0∞ (deFinettiBarycenter (p[|s])) (deFinettiBarycenter (p[|sᶜ])) :=
     ⟨p s, p sᶜ, pos_iff_ne_zero.2 hs0, pos_iff_ne_zero.2 hsc0,

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -17,6 +17,8 @@ import TauCeti.Probability.Exchangeability.PathSpace.InvariantTail
 import TauCeti.Probability.Exchangeability.PathSpace.Exchangeable.ToContractable
 -- Non-public: a zero-one law on `ProbabilityMeasure α` is Dirac.
 import TauCeti.MeasureTheory.Measure.ProbabilityMeasureExt
+-- Non-public: mixture injectivity identifies the conditioned mixing law with `π`.
+import TauCeti.MeasureTheory.Measure.MixtureInjective
 import Mathlib.Probability.Independence.InfinitePi
 
 /-!
@@ -140,7 +142,9 @@ private theorem cond_eq_of_extreme_iidMixture [StandardBorelSpace α]
     ⟨p s, p sᶜ, pos_iff_ne_zero.2 hs0, pos_iff_ne_zero.2 hsc0,
       prob_add_prob_compl hs, hmix_split.symm.trans hrepr.symm⟩
   have hμs : deFinettiBarycenter (p[|s]) = ρ := hρ.2 hs_mem hsc_mem hopen
-  exact eq_of_deFinettiBarycenter_eq (hμs.trans hrepr)
+  have hbary : deFinettiBarycenter (p[|s]) = deFinettiBarycenter p := hμs.trans hrepr
+  simp only [deFinettiBarycenter_def] at hbary
+  exact TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq hbary
 
 /-- **An extreme exchangeable law is i.i.d.** De Finetti writes the law as a mixture over
 `ProbabilityMeasure α`; extremality forces the mixing measure to be a zero-one law, hence a Dirac

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -191,8 +191,8 @@ theorem infinitePi_mem_extremePoints_exchangeable (P : ProbabilityMeasure α) :
     rintro ν ⟨hν, hνprob⟩
     let : IsProbabilityMeasure ν := hνprob
     exact ⟨hν.contractableLaw.measurePreserving_shift, hνprob⟩
-  have hρPexch : ExchangeableLaw ρP := by
-    rw [show ρP = deFinettiBarycenter (Measure.dirac P) from (deFinettiBarycenter_dirac P).symm]
+  have hρPexch : ExchangeableLaw (Measure.infinitePi fun _ : ℕ => (P : Measure α)) := by
+    rw [← deFinettiBarycenter_dirac P]
     exact exchangeableLaw_deFinettiBarycenter
   exact inter_extremePoints_subset_extremePoints_of_subset hsubset
     ⟨⟨hρPexch, inferInstance⟩, hshiftExtreme⟩

--- a/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
+++ b/TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean
@@ -4,7 +4,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.Probability.DeFinetti.Representation
+-- Public: the de Finetti barycenter, whose mixing law is what extremality pins down; it
+-- re-exports the mixture representation `deFinetti_mixture` this file consumes.
+public import TauCeti.Probability.DeFinetti.Barycenter
 public import TauCeti.Probability.Exchangeability.PathSpace.Law.Basic
 public import Mathlib.Dynamics.Ergodic.Extreme
 -- Non-public: the zero-one input for the i.i.d. direction and the comparison between invariant
@@ -13,11 +15,8 @@ import TauCeti.Probability.Exchangeability.PathSpace.HewittSavage
 import TauCeti.Probability.Exchangeability.PathSpace.InvariantTail
 -- Non-public: exchangeable path laws are shift-preserving.
 import TauCeti.Probability.Exchangeability.PathSpace.Exchangeable.ToContractable
-import TauCeti.Probability.Exchangeability.ConditionallyIID.Construct
 -- Non-public: a zero-one law on `ProbabilityMeasure α` is Dirac.
 import TauCeti.MeasureTheory.Measure.ProbabilityMeasureExt
--- Non-public: uniqueness of the mixing law from its mixture of infinite powers.
-import TauCeti.MeasureTheory.Measure.MixtureInjective
 import Mathlib.Probability.Independence.InfinitePi
 
 /-!
@@ -81,20 +80,6 @@ namespace Probability
 
 variable {α : Type*} [MeasurableSpace α]
 
-private theorem exchangeableLaw_bind_infinitePi
-    {π : Measure (ProbabilityMeasure α)} [IsProbabilityMeasure π] :
-    ExchangeableLaw
-      (π.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) := by
-  have := isProbabilityMeasure_iidMixtureLaw (π := π) (P := id) measurable_id
-  have hX := exchangeable_iidMixtureLaw (π := π) (P := id) measurable_id
-  have hcoord : ∀ n, AEMeasurable
-      (fun ω : ProbabilityMeasure α × (ℕ → α) => ω.2 n) (iidMixtureLaw π id) :=
-    fun n => ((measurable_pi_apply n).comp measurable_snd).aemeasurable
-  have hlaw := (exchangeable_iff_exchangeableLaw_pathLaw
-    (X := fun n (ω : ProbabilityMeasure α × (ℕ → α)) => ω.2 n) hcoord).mp hX
-  rw [pathLaw_iidMixtureLaw (π := π) (P := id) measurable_id] at hlaw
-  simpa using hlaw
-
 /-- An i.i.d. infinite product law is ergodic for the one-sided shift.
 
 The shift-invariant σ-algebra is contained in the exchangeable σ-algebra, and the coordinate
@@ -130,54 +115,31 @@ private theorem cond_eq_of_extreme_iidMixture [StandardBorelSpace α]
     {ρ : Measure (ℕ → α)} [IsProbabilityMeasure ρ]
     (hρ : ρ ∈ extremePoints ℝ≥0∞
       {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν})
-    (hrepr : ρ = p.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α))
+    (hrepr : ρ = deFinettiBarycenter p)
     {s : Set (ProbabilityMeasure α)} (hs : MeasurableSet s) (hs0 : p s ≠ 0)
     (hsc0 : p sᶜ ≠ 0) : p[|s] = p := by
-  let ps : Measure (ProbabilityMeasure α) := p[|s]
-  let psc : Measure (ProbabilityMeasure α) := p[|sᶜ]
-  have : IsProbabilityMeasure ps := cond_isProbabilityMeasure hs0
-  have : IsProbabilityMeasure psc := cond_isProbabilityMeasure hsc0
-  let μs : Measure (ℕ → α) :=
-    ps.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)
-  let μsc : Measure (ℕ → α) :=
-    psc.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)
-  have hpow : Measurable fun P : ProbabilityMeasure α =>
-      Measure.infinitePi fun _ : ℕ => (P : Measure α) :=
-    TauCeti.MeasureTheory.measurable_infinitePi_const
-  have : IsProbabilityMeasure μs := isProbabilityMeasure_bind hpow.aemeasurable
-    (ae_of_all _ fun _ => inferInstance)
-  have : IsProbabilityMeasure μsc := isProbabilityMeasure_bind hpow.aemeasurable
-    (ae_of_all _ fun _ => inferInstance)
-  have hs_mem : μs ∈
+  have : IsProbabilityMeasure (p[|s]) := cond_isProbabilityMeasure hs0
+  have : IsProbabilityMeasure (p[|sᶜ]) := cond_isProbabilityMeasure hsc0
+  have hs_mem : deFinettiBarycenter (p[|s]) ∈
       {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν} :=
-    ⟨exchangeableLaw_bind_infinitePi, inferInstance⟩
-  have hsc_mem : μsc ∈
+    ⟨exchangeableLaw_deFinettiBarycenter, inferInstance⟩
+  have hsc_mem : deFinettiBarycenter (p[|sᶜ]) ∈
       {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν} :=
-    ⟨exchangeableLaw_bind_infinitePi, inferInstance⟩
-  have hp_split : p = p s • ps + p sᶜ • psc := by
+    ⟨exchangeableLaw_deFinettiBarycenter, inferInstance⟩
+  have hp_split : p = p s • p[|s] + p sᶜ • p[|sᶜ] := by
     ext t ht
     simp only [Measure.add_apply, Measure.smul_apply, smul_eq_mul]
     simpa [mul_comm] using (cond_add_cond_compl_eq (μ := p) (t := t) hs).symm
-  have hmix_split :
-      p.bind (fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) =
-        p s • μs + p sᶜ • μsc := by
-    calc
-      p.bind (fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) =
-          (p s • ps + p sᶜ • psc).bind
-            (fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) :=
-        congrArg
-          (fun q : Measure (ProbabilityMeasure α) =>
-            q.bind fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) hp_split
-      _ = p s • μs + p sᶜ • μsc := by
-        have h := Measure.bind_sum
-          (fun b : Bool => if b then p s • ps else p sᶜ • psc)
-          (fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α)) hpow.aemeasurable
-        simpa [Measure.sum_bool, Measure.bind_smul, μs, μsc] using h
-  have hopen : ρ ∈ openSegment ℝ≥0∞ μs μsc :=
+  -- affinity of the barycenter turns the splitting of `p` into a splitting of `ρ`
+  have hmix_split : deFinettiBarycenter p =
+      p s • deFinettiBarycenter (p[|s]) + p sᶜ • deFinettiBarycenter (p[|sᶜ]) := by
+    rw [← deFinettiBarycenter_smul_add_smul, ← hp_split]
+  have hopen : ρ ∈
+      openSegment ℝ≥0∞ (deFinettiBarycenter (p[|s])) (deFinettiBarycenter (p[|sᶜ])) :=
     ⟨p s, p sᶜ, pos_iff_ne_zero.2 hs0, pos_iff_ne_zero.2 hsc0,
       prob_add_prob_compl hs, hmix_split.symm.trans hrepr.symm⟩
-  have hμs : μs = ρ := hρ.2 hs_mem hsc_mem hopen
-  exact TauCeti.MeasureTheory.Measure.ext_of_bind_infinitePi_eq (hμs.trans hrepr)
+  have hμs : deFinettiBarycenter (p[|s]) = ρ := hρ.2 hs_mem hsc_mem hopen
+  exact eq_of_deFinettiBarycenter_eq (hμs.trans hrepr)
 
 /-- **An extreme exchangeable law is i.i.d.** De Finetti writes the law as a mixture over
 `ProbabilityMeasure α`; extremality forces the mixing measure to be a zero-one law, hence a Dirac
@@ -188,17 +150,10 @@ private theorem exists_eq_infinitePi_of_mem_extremePoints [StandardBorelSpace α
       {ν : Measure (ℕ → α) | ExchangeableLaw ν ∧ IsProbabilityMeasure ν}) :
     ∃ P : ProbabilityMeasure α,
       ρ = Measure.infinitePi fun _ : ℕ => (P : Measure α) := by
-  let : Nonempty α := (nonempty_of_isProbabilityMeasure ρ).map fun x => x 0
-  have hcoord : ∀ n, Measurable (fun x : ℕ → α => x n) := fun n => measurable_pi_apply n
-  have hX : Exchangeable ρ (fun n x => x n) :=
-    (exchangeable_iff_exchangeableLaw_pathLaw fun n => (hcoord n).aemeasurable).2 (by
-      simpa [pathLaw_def] using hρ.1.1)
-  obtain ⟨π, hrepr, -⟩ := deFinetti_mixture hX hcoord
-  have hrepr' : ρ = (π : Measure (ProbabilityMeasure α)).bind
-      fun P => Measure.infinitePi fun _ : ℕ => (P : Measure α) := by
-    simpa [pathLaw_def] using hrepr
+  obtain ⟨π, hrepr, -⟩ := hρ.1.1.existsUnique_mixingLaw
   let p : Measure (ProbabilityMeasure α) := π
   have : IsProbabilityMeasure p := π.2
+  have hrepr' : ρ = deFinettiBarycenter p := hrepr
   have hp_zeroOne : IsZeroOneMeasure p := {
     zero_one₀ := fun s hs => by
       by_cases hs0 : p s = 0
@@ -207,8 +162,7 @@ private theorem exists_eq_infinitePi_of_mem_extremePoints [StandardBorelSpace α
       · exact Or.inr hs1
       exfalso
       have hsc0 : p sᶜ ≠ 0 := fun h => hs1 ((prob_compl_eq_zero_iff hs).mp h)
-      have hps : p[|s] = p := cond_eq_of_extreme_iidMixture hρ (by simpa [p] using hrepr')
-        hs hs0 hsc0
+      have hps : p[|s] = p := cond_eq_of_extreme_iidMixture hρ hrepr' hs hs0 hsc0
       apply hs1
       rw [← hps]
       exact cond_apply_self hs0 (measure_ne_top p s)
@@ -216,12 +170,7 @@ private theorem exists_eq_infinitePi_of_mem_extremePoints [StandardBorelSpace α
   let : IsZeroOneMeasure p := hp_zeroOne
   obtain ⟨P, hp⟩ :=
     TauCeti.MeasureTheory.IsZeroOneMeasure.exists_eq_dirac_probabilityMeasure (π := p)
-  refine ⟨P, ?_⟩
-  calc
-    ρ = p.bind (fun Q => Measure.infinitePi fun _ : ℕ => (Q : Measure α)) := by
-      simpa [p] using hrepr'
-    _ = Measure.infinitePi fun _ : ℕ => (P : Measure α) := by
-      rw [hp, Measure.dirac_bind TauCeti.MeasureTheory.measurable_infinitePi_const]
+  exact ⟨P, by rw [hrepr', hp, deFinettiBarycenter_dirac]⟩
 
 /-- **An i.i.d. law is an extreme exchangeable law.** The infinite product is ergodic for the
 shift, hence extreme among the shift-invariant laws; exchangeable laws are shift-invariant, so
@@ -243,11 +192,8 @@ theorem infinitePi_mem_extremePoints_exchangeable (P : ProbabilityMeasure α) :
     let : IsProbabilityMeasure ν := hνprob
     exact ⟨hν.contractableLaw.measurePreserving_shift, hνprob⟩
   have hρPexch : ExchangeableLaw ρP := by
-    have hdirac : ρP = (Measure.dirac P).bind
-        (fun Q => Measure.infinitePi fun _ : ℕ => (Q : Measure α)) := by
-      rw [Measure.dirac_bind TauCeti.MeasureTheory.measurable_infinitePi_const]
-    rw [hdirac]
-    exact exchangeableLaw_bind_infinitePi
+    rw [show ρP = deFinettiBarycenter (Measure.dirac P) from (deFinettiBarycenter_dirac P).symm]
+    exact exchangeableLaw_deFinettiBarycenter
   exact inter_extremePoints_subset_extremePoints_of_subset hsubset
     ⟨⟨hρPexch, inferInstance⟩, hshiftExtreme⟩
 


### PR DESCRIPTION
This PR names the de Finetti barycenter of a mixing law and packages de Finetti's representation as the affine correspondence it is: for a measure `π` on `ProbabilityMeasure α`, `deFinettiBarycenter π = ∫ P^{⊗ℕ} dπ(P)` is the law on `ℕ → α` of a sequence drawn i.i.d. from a `π`-random probability measure. The map is affine in the mixing law (`deFinettiBarycenter_add`, `deFinettiBarycenter_smul`), sends probability measures to exchangeable path laws (`exchangeableLaw_deFinettiBarycenter`), and — over a standard Borel state space — hits every exchangeable probability law exactly once (`ExchangeableLaw.existsUnique_mixingLaw`, the path-law form of `deFinetti_mixture`). That bijection is packaged as `deFinettiEquiv : ProbabilityMeasure (ProbabilityMeasure α) ≃ {ρ : ProbabilityMeasure (ℕ → α) // ExchangeableLaw ρ}`, whose inverse reads the mixing law off an exchangeable law. Finally `deFinettiBarycenter_mem_extremePoints_iff` shows a barycenter is an extreme exchangeable law exactly when its mixing law is a Dirac mass, so — reading the barycenter as `Measure.join` of the law of `P^{⊗ℕ}` (`deFinettiBarycenter_eq_join_map`) — the unique mixing law gives the canonical decomposition of an exchangeable law over the extreme, equivalently i.i.d., components.

The milestone is Layer 8 of `TauCetiRoadmap/Exchangeability/README.md`, "generalized exchangeability and representation theorems", specifically its bullet "the affine and ergodic decomposition of exchangeable laws: package `p ↦ p^{⊗ℕ}` and the de Finetti barycenter as an affine correspondence between mixing laws and exchangeable path laws. The unique mixing law then gives the canonical decomposition supported on product — equivalently extreme — laws." That roadmap's `STATUS.md` frontier names the same gap: "What remains for ergodic decomposition is the affine decomposition API and, separately, its interpretation through the finitely supported permutation `ErgodicSMul` action." This PR supplies the affine decomposition API; what remains on that bullet is the second half, identifying these components with the ergodic components for the finitely supported permutation action, which the roadmap sequences after the Layer 6 `ErgodicSMul` interface (not yet landed, and in flight elsewhere). The other Layer 8 entries — finite de Finetti bounds, Markov exchangeability, Aldous–Hoover — are untouched and out of scope here.

Files: `TauCeti/Probability/DeFinetti/Barycenter.lean` (new, 188 lines) carries the definition, its evaluation and `Dirac` computation, the affinity lemmas, exchangeability of a barycenter, mixing-law existence and uniqueness, and injectivity; `TauCeti/Probability/DeFinetti/Correspondence.lean` (new, 153 lines) carries `deFinettiEquiv`, its simp lemmas, and the extreme-point characterization.

One existing module is updated rather than duplicated. `TauCeti/Probability/Exchangeability/PathSpace/Law/Extreme.lean` drops its private `exchangeableLaw_bind_infinitePi` in favour of the new public `exchangeableLaw_deFinettiBarycenter`, replaces its inline path-law mixture derivation by `ExchangeableLaw.existsUnique_mixingLaw`, and replaces the `Measure.bind_sum`/`Measure.sum_bool` splitting of a conditioned mixing law by the affinity lemmas `deFinettiBarycenter_add` and `deFinettiBarycenter_smul`; that file loses about 60 lines and two imports with no change to any of its statements.

No Mathlib source is vendored. No material is adapted from `cameronfreer/exchangeability`, which carries the mixture representation only as an unnamed `bind` expression and does not package the correspondence.

Roadmap: Exchangeability

<!--tauceti-target:v1 {"focus":"Exchangeability","id":"de-finetti-affine-correspondence"}-->

🤖 Prepared with Claude Code

