### PR TITLE
feat: the quadratic elements of a Clifford algebra as a Lie subalgebra

### DIFF
--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -41,8 +41,8 @@ Layer 9 CAR worked instance.
 * `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
   `TauCeti.CliffordAlgebra.cliffordBivector_mem_filtration_two`: it is even and has filtration
   degree at most two.
-* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_range_le`: the exterior-square map lands in
-  any submodule containing the Clifford bivectors.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_range_le_of_cliffordBivector_mem`: the
+  exterior-square map lands in any submodule containing the Clifford bivectors.
 
 ## References
 
@@ -144,7 +144,8 @@ theorem cliffordBivector_mem_filtration_two (a b : M) :
 
 /-- The image of the exterior-square Clifford bivector map lands in any submodule containing every
 Clifford bivector: the decomposable bivectors generate `⋀[R]^2 M`. -/
-theorem cliffordBivectorExterior_range_le (P : Submodule R (CliffordAlgebra Q))
+theorem cliffordBivectorExterior_range_le_of_cliffordBivector_mem
+    (P : Submodule R (CliffordAlgebra Q))
     (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
     LinearMap.range (cliffordBivectorExterior Q) ≤ P := by
   rw [LinearMap.range_eq_map, Submodule.map_le_iff_le_comap,
@@ -163,12 +164,14 @@ theorem cliffordBivectorExterior_range_le (P : Submodule R (CliffordAlgebra Q))
 /-- The exterior-square Clifford bivector map takes values in the even component. -/
 theorem cliffordBivectorExterior_range_le_evenOdd_zero :
     LinearMap.range (cliffordBivectorExterior Q) ≤ evenOdd Q 0 :=
-  cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_evenOdd_zero Q)
+  cliffordBivectorExterior_range_le_of_cliffordBivector_mem Q _
+    (cliffordBivector_mem_evenOdd_zero Q)
 
 /-- The exterior-square Clifford bivector map takes values in filtration degree at most two. -/
 theorem cliffordBivectorExterior_range_le_filtration_two :
     LinearMap.range (cliffordBivectorExterior Q) ≤ filtration Q 2 :=
-  cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_filtration_two Q)
+  cliffordBivectorExterior_range_le_of_cliffordBivector_mem Q _
+    (cliffordBivector_mem_filtration_two Q)
 
 /-- The action-normalization identity for the half-normalized Clifford bivector. -/
 theorem cliffordBivector_lie_ι (a b x : M) :

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean
@@ -41,6 +41,8 @@ Layer 9 CAR worked instance.
 * `TauCeti.CliffordAlgebra.cliffordBivector_mem_evenOdd_zero` and
   `TauCeti.CliffordAlgebra.cliffordBivector_mem_filtration_two`: it is even and has filtration
   degree at most two.
+* `TauCeti.CliffordAlgebra.cliffordBivectorExterior_range_le`: the exterior-square map lands in
+  any submodule containing the Clifford bivectors.
 
 ## References
 
@@ -140,7 +142,9 @@ theorem cliffordBivector_mem_filtration_two (a b : M) :
   exact Submodule.smul_mem _ _ <|
     Submodule.sub_mem _ (ι_mul_ι_mem_filtration_two Q a b) (ι_mul_ι_mem_filtration_two Q b a)
 
-private theorem cliffordBivectorExterior_range_le (P : Submodule R (CliffordAlgebra Q))
+/-- The image of the exterior-square Clifford bivector map lands in any submodule containing every
+Clifford bivector: the decomposable bivectors generate `⋀[R]^2 M`. -/
+theorem cliffordBivectorExterior_range_le (P : Submodule R (CliffordAlgebra Q))
     (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
     LinearMap.range (cliffordBivectorExterior Q) ≤ P := by
   rw [LinearMap.range_eq_map, Submodule.map_le_iff_le_comap,

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
@@ -196,6 +196,7 @@ theorem quadraticLieSubalgebra_toSubmodule_eq_range :
 /-- **Membership in the quadratic elements**: an element of the Clifford algebra is quadratic
 exactly when it is in the image of `⋀[R]^2 M` under
 `TauCeti.CliffordAlgebra.cliffordBivectorExterior`. -/
+@[simp]
 theorem mem_quadraticLieSubalgebra_iff {x : CliffordAlgebra Q} :
     x ∈ quadraticLieSubalgebra Q ↔ x ∈ LinearMap.range (cliffordBivectorExterior Q) := by
   rw [← LieSubalgebra.mem_toSubmodule, quadraticLieSubalgebra_toSubmodule_eq_range]

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
@@ -1,0 +1,214 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+import Mathlib.Tactic.NoncommRing
+public import Mathlib.Algebra.Lie.OfAssociative
+public import Mathlib.Algebra.Lie.Subalgebra
+public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
+public import TauCeti.LinearAlgebra.CliffordAlgebra.Bivector
+
+/-!
+# The quadratic elements of a Clifford algebra as a Lie subalgebra
+
+A Clifford algebra is an associative algebra, so its commutator makes it a Lie algebra. Inside it
+the **quadratic elements** — the span of the half-normalized commutators
+`TauCeti.CliffordAlgebra.cliffordBivector Q a b` of two generators — are closed under the bracket,
+and this file equips them with the resulting `LieSubalgebra` structure.
+
+Closure is a two-line consequence of the action-normalization identity
+`TauCeti.CliffordAlgebra.cliffordBivector_lie_ι`, which says that a Clifford bivector brackets a
+generator to the infinitesimal rotation `x ↦ polar Q b x • a - polar Q a x • b`. Because bracketing
+with a fixed element is a derivation for the associative product, the bracket of two Clifford
+bivectors is obtained by rotating each of the two generators of the second one in turn, so it is
+again a sum of two Clifford bivectors
+(`TauCeti.CliffordAlgebra.lie_cliffordBivector_cliffordBivector`).
+
+Nothing here needs the quadratic form to be nondegenerate, the module to be finite-dimensional, or
+the base to be a field: the statements hold over any commutative ring in which `2` is invertible.
+The identification of this subalgebra with `𝔰𝔬(V, Q)` — Mathlib's
+`skewAdjointLieSubalgebra (QuadraticMap.polarBilin Q)` — does need those hypotheses, and is not
+proved here; the bridging fact this file does supply is that a quadratic element brackets every
+generator back into the generators
+(`TauCeti.CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`), which is what makes
+that comparison map exist at all.
+
+Following Mathlib's `Mathlib/Algebra/Lie/SkewAdjoint.lean`, the Lie ring structure on an
+associative ring is a *local* instance (`LieRing.ofAssociativeRing`): it cannot be global, since it
+would clash with the module bracket when a ring is regarded as a module over itself. A downstream
+file that states results about `quadraticLieSubalgebra` therefore has to put the same attribute in
+scope.
+
+## Main definitions
+
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra`: the quadratic elements of `CliffordAlgebra Q`,
+  as a Lie subalgebra under the commutator bracket.
+
+## Main results
+
+* `TauCeti.CliffordAlgebra.lie_cliffordBivector_cliffordBivector`: the bracket of two Clifford
+  bivectors, as a sum of two Clifford bivectors.
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_le`: the universal property of the
+  underlying submodule, from which the containments below are read off.
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_evenOdd_zero`,
+  `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_even` and
+  `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_filtration_two`: the quadratic elements are
+  even and have filtration degree at most two.
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_eq_range`: they are exactly the image
+  of `⋀[R]^2 M` under `TauCeti.CliffordAlgebra.cliffordBivectorExterior`.
+* `TauCeti.CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`: bracketing with a
+  quadratic element preserves the generators.
+
+## References
+
+* [Clifford algebras, Pin and Spin, and spin representations roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md),
+  Layer 9, "the abstract quadratic realization".
+-/
+
+public section
+
+open CliffordAlgebra
+
+universe u v
+
+namespace TauCeti
+
+namespace CliffordAlgebra
+
+attribute [local instance 100] LieRing.ofAssociativeRing
+
+section CommRing
+
+variable {R : Type u} {M : Type v} [CommRing R] [AddCommGroup M] [Module R M]
+  (Q : QuadraticForm R M) [Invertible (2 : R)]
+
+omit [Invertible (2 : R)] in
+/-- Bracketing with a fixed element of an associative ring is a derivation. -/
+private theorem lie_mul (x y z : CliffordAlgebra Q) :
+    ⁅x, y * z⁆ = ⁅x, y⁆ * z + y * ⁅x, z⁆ := by
+  simp only [Ring.lie_def]
+  noncomm_ring
+
+/-- **The bracket of two Clifford bivectors.** Bracketing with `cliffordBivector Q a b` is a
+derivation which rotates a generator by `x ↦ polar Q b x • a - polar Q a x • b`, so it takes the
+Clifford bivector of `(c, d)` to the sum of the Clifford bivectors of the two rotated pairs. This
+is the closure property that makes the quadratic elements a Lie subalgebra. -/
+theorem lie_cliffordBivector_cliffordBivector (a b c d : M) :
+    ⁅cliffordBivector Q a b, cliffordBivector Q c d⁆ =
+      cliffordBivector Q
+          (QuadraticMap.polar Q b c • a - QuadraticMap.polar Q a c • b) d +
+        cliffordBivector Q c
+          (QuadraticMap.polar Q b d • a - QuadraticMap.polar Q a d • b) := by
+  rw [cliffordBivector_def Q c d, lie_smul, lie_sub, lie_mul, lie_mul, cliffordBivector_lie_ι,
+    cliffordBivector_lie_ι, cliffordBivector_def Q _ d, cliffordBivector_def Q c _, ← smul_add]
+  congr 1
+  abel
+
+/-- The set of Clifford bivectors of `Q`, indexed by pairs of vectors. -/
+private def bivectorSet : Set (CliffordAlgebra Q) :=
+  Set.range fun p : M × M => cliffordBivector Q p.1 p.2
+
+private theorem cliffordBivector_mem_span (a b : M) :
+    cliffordBivector Q a b ∈ Submodule.span R (bivectorSet Q) :=
+  Submodule.subset_span ⟨(a, b), rfl⟩
+
+private theorem lie_cliffordBivector_mem_span (a b : M) {y : CliffordAlgebra Q}
+    (hy : y ∈ Submodule.span R (bivectorSet Q)) :
+    ⁅cliffordBivector Q a b, y⁆ ∈ Submodule.span R (bivectorSet Q) := by
+  induction hy using Submodule.span_induction with
+  | mem z hz =>
+    obtain ⟨p, rfl⟩ := hz
+    rw [lie_cliffordBivector_cliffordBivector]
+    exact add_mem (cliffordBivector_mem_span Q _ _) (cliffordBivector_mem_span Q _ _)
+  | zero => rw [lie_zero]; exact Submodule.zero_mem _
+  | add _ _ _ _ hy hz => rw [lie_add]; exact Submodule.add_mem _ hy hz
+  | smul r _ _ hy => rw [lie_smul]; exact Submodule.smul_mem _ r hy
+
+private theorem lie_mem_span {x y : CliffordAlgebra Q}
+    (hx : x ∈ Submodule.span R (bivectorSet Q)) (hy : y ∈ Submodule.span R (bivectorSet Q)) :
+    ⁅x, y⁆ ∈ Submodule.span R (bivectorSet Q) := by
+  induction hx using Submodule.span_induction with
+  | mem z hz =>
+    obtain ⟨p, rfl⟩ := hz
+    exact lie_cliffordBivector_mem_span Q _ _ hy
+  | zero => rw [zero_lie]; exact Submodule.zero_mem _
+  | add _ _ _ _ hz hw => rw [add_lie]; exact Submodule.add_mem _ hz hw
+  | smul r _ _ hz => rw [smul_lie]; exact Submodule.smul_mem _ r hz
+
+/-- **The quadratic elements of a Clifford algebra**, as a Lie subalgebra of `CliffordAlgebra Q`
+under the commutator bracket: the `R`-span of the Clifford bivectors
+`TauCeti.CliffordAlgebra.cliffordBivector Q a b`.
+
+Unlike a transported bracket on `⋀[R]^2 M`, this is a subobject of the Clifford algebra itself, so
+it needs no scoped instances beyond the local `LieRing.ofAssociativeRing` on an associative ring. -/
+noncomputable def quadraticLieSubalgebra : LieSubalgebra R (CliffordAlgebra Q) :=
+  { Submodule.span R (bivectorSet Q) with lie_mem' := lie_mem_span Q }
+
+/-- The definitional pin: the quadratic elements are the span of the Clifford bivectors. -/
+theorem quadraticLieSubalgebra_toSubmodule :
+    (quadraticLieSubalgebra Q).toSubmodule =
+      Submodule.span R (Set.range fun p : M × M => cliffordBivector Q p.1 p.2) := (rfl)
+
+/-- Every Clifford bivector is a quadratic element. -/
+theorem cliffordBivector_mem_quadraticLieSubalgebra (a b : M) :
+    cliffordBivector Q a b ∈ quadraticLieSubalgebra Q :=
+  cliffordBivector_mem_span Q a b
+
+/-- **The universal property of the quadratic elements**: any submodule containing every Clifford
+bivector contains them all. Every containment below is an instance of this. -/
+theorem quadraticLieSubalgebra_toSubmodule_le {P : Submodule R (CliffordAlgebra Q)}
+    (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
+    (quadraticLieSubalgebra Q).toSubmodule ≤ P := by
+  refine Submodule.span_le.2 ?_
+  rintro _ ⟨p, rfl⟩
+  exact hP _ _
+
+/-- The quadratic elements are even. -/
+theorem quadraticLieSubalgebra_le_evenOdd_zero :
+    (quadraticLieSubalgebra Q).toSubmodule ≤ evenOdd Q 0 :=
+  quadraticLieSubalgebra_toSubmodule_le Q (cliffordBivector_mem_evenOdd_zero Q)
+
+/-- The quadratic elements lie in the even subalgebra. -/
+theorem quadraticLieSubalgebra_le_even :
+    (quadraticLieSubalgebra Q).toSubmodule ≤ Subalgebra.toSubmodule (even Q) := by
+  rw [CliffordAlgebra.even_toSubmodule]
+  exact quadraticLieSubalgebra_le_evenOdd_zero Q
+
+/-- The quadratic elements have filtration degree at most two. -/
+theorem quadraticLieSubalgebra_le_filtration_two :
+    (quadraticLieSubalgebra Q).toSubmodule ≤ filtration Q 2 :=
+  quadraticLieSubalgebra_toSubmodule_le Q (cliffordBivector_mem_filtration_two Q)
+
+/-- **The quadratic elements are the image of the second exterior power.** This is the sense in
+which the Lie subalgebra realizes `⋀[R]^2 M` inside the Clifford algebra; the map itself is
+`TauCeti.CliffordAlgebra.cliffordBivectorExterior`. -/
+theorem quadraticLieSubalgebra_toSubmodule_eq_range :
+    (quadraticLieSubalgebra Q).toSubmodule = LinearMap.range (cliffordBivectorExterior Q) :=
+  le_antisymm
+    (quadraticLieSubalgebra_toSubmodule_le Q fun a b =>
+      ⟨exteriorPower.ιMulti R 2 ![a, b], cliffordBivectorExterior_apply_ιMulti Q a b⟩)
+    (cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_quadraticLieSubalgebra Q))
+
+/-- **Quadratic elements preserve the generators.** Bracketing with a quadratic element sends
+`ι Q m` back into the image of `ι Q`; on the span of the generators it is therefore an
+endomorphism, which is what the comparison with the skew-adjoint endomorphisms of
+`QuadraticMap.polarBilin Q` is built from. -/
+theorem lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra {x : CliffordAlgebra Q}
+    (hx : x ∈ quadraticLieSubalgebra Q) (m : M) : ⁅x, ι Q m⁆ ∈ LinearMap.range (ι Q) := by
+  have key : (quadraticLieSubalgebra Q).toSubmodule ≤
+      { carrier := {y : CliffordAlgebra Q | ∀ m : M, ⁅y, ι Q m⁆ ∈ LinearMap.range (ι Q)}
+        add_mem' := fun hy hz m => by rw [add_lie]; exact Submodule.add_mem _ (hy m) (hz m)
+        zero_mem' := fun m => by rw [zero_lie]; exact Submodule.zero_mem _
+        smul_mem' := fun r _ hy m => by
+          rw [smul_lie]; exact Submodule.smul_mem _ r (hy m) } :=
+    quadraticLieSubalgebra_toSubmodule_le Q fun a b m =>
+      ⟨_, (cliffordBivector_lie_ι Q a b m).symm⟩
+  exact key hx m
+
+end CommRing
+
+end CliffordAlgebra
+
+end TauCeti

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
@@ -91,6 +91,15 @@ private theorem lie_mul (x y z : CliffordAlgebra Q) :
   simp only [Ring.lie_def]
   noncomm_ring
 
+/-- Bracketing with an element that moves each of the two generators of a Clifford bivector to
+another generator takes that bivector to the sum of the two bivectors obtained by moving one
+generator at a time — the derivation property, written on the half-normalized commutator. -/
+private theorem lie_cliffordBivector_of_lie_ι {x : CliffordAlgebra Q} {c d c' d' : M}
+    (hc : ⁅x, ι Q c⁆ = ι Q c') (hd : ⁅x, ι Q d⁆ = ι Q d') :
+    ⁅x, cliffordBivector Q c d⁆ = cliffordBivector Q c' d + cliffordBivector Q c d' := by
+  simp only [cliffordBivector_def, lie_smul, lie_sub, lie_mul, hc, hd]
+  module
+
 /-- **The bracket of two Clifford bivectors.** Bracketing with `cliffordBivector Q a b` is a
 derivation which rotates a generator by `x ↦ polar Q b x • a - polar Q a x • b`, so it takes the
 Clifford bivector of `(c, d)` to the sum of the Clifford bivectors of the two rotated pairs. This
@@ -100,11 +109,8 @@ theorem lie_cliffordBivector_cliffordBivector (a b c d : M) :
       cliffordBivector Q
           (QuadraticMap.polar Q b c • a - QuadraticMap.polar Q a c • b) d +
         cliffordBivector Q c
-          (QuadraticMap.polar Q b d • a - QuadraticMap.polar Q a d • b) := by
-  rw [cliffordBivector_def Q c d, lie_smul, lie_sub, lie_mul, lie_mul, cliffordBivector_lie_ι,
-    cliffordBivector_lie_ι, cliffordBivector_def Q _ d, cliffordBivector_def Q c _, ← smul_add]
-  congr 1
-  abel
+          (QuadraticMap.polar Q b d • a - QuadraticMap.polar Q a d • b) :=
+  lie_cliffordBivector_of_lie_ι Q (cliffordBivector_lie_ι Q a b c) (cliffordBivector_lie_ι Q a b d)
 
 /-- The set of Clifford bivectors of `Q`, indexed by pairs of vectors. -/
 private def bivectorSet : Set (CliffordAlgebra Q) :=

--- a/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
+++ b/TauCeti/LinearAlgebra/CliffordAlgebra/QuadraticLieSubalgebra.lean
@@ -6,7 +6,6 @@ module
 
 import Mathlib.Tactic.NoncommRing
 public import Mathlib.Algebra.Lie.OfAssociative
-public import Mathlib.Algebra.Lie.Subalgebra
 public import Mathlib.LinearAlgebra.CliffordAlgebra.Even
 public import TauCeti.LinearAlgebra.CliffordAlgebra.Bivector
 
@@ -50,14 +49,15 @@ scope.
 
 * `TauCeti.CliffordAlgebra.lie_cliffordBivector_cliffordBivector`: the bracket of two Clifford
   bivectors, as a sum of two Clifford bivectors.
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_le`: the universal property of the
-  underlying submodule, from which the containments below are read off.
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem`: the
+  universal property of the underlying submodule, from which the containments below are read off.
 * `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_evenOdd_zero`,
   `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_even` and
   `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_le_filtration_two`: the quadratic elements are
   even and have filtration degree at most two.
-* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_eq_range`: they are exactly the image
-  of `⋀[R]^2 M` under `TauCeti.CliffordAlgebra.cliffordBivectorExterior`.
+* `TauCeti.CliffordAlgebra.quadraticLieSubalgebra_toSubmodule_eq_range` and
+  `TauCeti.CliffordAlgebra.mem_quadraticLieSubalgebra_iff`: they are exactly the image of
+  `⋀[R]^2 M` under `TauCeti.CliffordAlgebra.cliffordBivectorExterior`.
 * `TauCeti.CliffordAlgebra.lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra`: bracketing with a
   quadratic element preserves the generators.
 
@@ -114,28 +114,21 @@ private theorem cliffordBivector_mem_span (a b : M) :
     cliffordBivector Q a b ∈ Submodule.span R (bivectorSet Q) :=
   Submodule.subset_span ⟨(a, b), rfl⟩
 
-private theorem lie_cliffordBivector_mem_span (a b : M) {y : CliffordAlgebra Q}
-    (hy : y ∈ Submodule.span R (bivectorSet Q)) :
-    ⁅cliffordBivector Q a b, y⁆ ∈ Submodule.span R (bivectorSet Q) := by
-  induction hy using Submodule.span_induction with
-  | mem z hz =>
-    obtain ⟨p, rfl⟩ := hz
-    rw [lie_cliffordBivector_cliffordBivector]
-    exact add_mem (cliffordBivector_mem_span Q _ _) (cliffordBivector_mem_span Q _ _)
-  | zero => rw [lie_zero]; exact Submodule.zero_mem _
-  | add _ _ _ _ hy hz => rw [lie_add]; exact Submodule.add_mem _ hy hz
-  | smul r _ _ hy => rw [lie_smul]; exact Submodule.smul_mem _ r hy
-
 private theorem lie_mem_span {x y : CliffordAlgebra Q}
     (hx : x ∈ Submodule.span R (bivectorSet Q)) (hy : y ∈ Submodule.span R (bivectorSet Q)) :
     ⁅x, y⁆ ∈ Submodule.span R (bivectorSet Q) := by
-  induction hx using Submodule.span_induction with
-  | mem z hz =>
+  induction hx, hy using Submodule.span_induction₂ with
+  | mem_mem _ _ hz hw =>
     obtain ⟨p, rfl⟩ := hz
-    exact lie_cliffordBivector_mem_span Q _ _ hy
-  | zero => rw [zero_lie]; exact Submodule.zero_mem _
-  | add _ _ _ _ hz hw => rw [add_lie]; exact Submodule.add_mem _ hz hw
-  | smul r _ _ hz => rw [smul_lie]; exact Submodule.smul_mem _ r hz
+    obtain ⟨q, rfl⟩ := hw
+    rw [lie_cliffordBivector_cliffordBivector]
+    exact add_mem (cliffordBivector_mem_span Q _ _) (cliffordBivector_mem_span Q _ _)
+  | zero_left => rw [zero_lie]; exact Submodule.zero_mem _
+  | zero_right => rw [lie_zero]; exact Submodule.zero_mem _
+  | add_left _ _ _ _ _ _ h₁ h₂ => rw [add_lie]; exact Submodule.add_mem _ h₁ h₂
+  | add_right _ _ _ _ _ _ h₁ h₂ => rw [lie_add]; exact Submodule.add_mem _ h₁ h₂
+  | smul_left r _ _ _ _ h => rw [smul_lie]; exact Submodule.smul_mem _ r h
+  | smul_right r _ _ _ _ h => rw [lie_smul]; exact Submodule.smul_mem _ r h
 
 /-- **The quadratic elements of a Clifford algebra**, as a Lie subalgebra of `CliffordAlgebra Q`
 under the commutator bracket: the `R`-span of the Clifford bivectors
@@ -158,8 +151,8 @@ theorem cliffordBivector_mem_quadraticLieSubalgebra (a b : M) :
 
 /-- **The universal property of the quadratic elements**: any submodule containing every Clifford
 bivector contains them all. Every containment below is an instance of this. -/
-theorem quadraticLieSubalgebra_toSubmodule_le {P : Submodule R (CliffordAlgebra Q)}
-    (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
+theorem quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem
+    {P : Submodule R (CliffordAlgebra Q)} (hP : ∀ a b : M, cliffordBivector Q a b ∈ P) :
     (quadraticLieSubalgebra Q).toSubmodule ≤ P := by
   refine Submodule.span_le.2 ?_
   rintro _ ⟨p, rfl⟩
@@ -168,7 +161,8 @@ theorem quadraticLieSubalgebra_toSubmodule_le {P : Submodule R (CliffordAlgebra 
 /-- The quadratic elements are even. -/
 theorem quadraticLieSubalgebra_le_evenOdd_zero :
     (quadraticLieSubalgebra Q).toSubmodule ≤ evenOdd Q 0 :=
-  quadraticLieSubalgebra_toSubmodule_le Q (cliffordBivector_mem_evenOdd_zero Q)
+  quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem Q
+    (cliffordBivector_mem_evenOdd_zero Q)
 
 /-- The quadratic elements lie in the even subalgebra. -/
 theorem quadraticLieSubalgebra_le_even :
@@ -179,7 +173,8 @@ theorem quadraticLieSubalgebra_le_even :
 /-- The quadratic elements have filtration degree at most two. -/
 theorem quadraticLieSubalgebra_le_filtration_two :
     (quadraticLieSubalgebra Q).toSubmodule ≤ filtration Q 2 :=
-  quadraticLieSubalgebra_toSubmodule_le Q (cliffordBivector_mem_filtration_two Q)
+  quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem Q
+    (cliffordBivector_mem_filtration_two Q)
 
 /-- **The quadratic elements are the image of the second exterior power.** This is the sense in
 which the Lie subalgebra realizes `⋀[R]^2 M` inside the Clifford algebra; the map itself is
@@ -187,9 +182,17 @@ which the Lie subalgebra realizes `⋀[R]^2 M` inside the Clifford algebra; the 
 theorem quadraticLieSubalgebra_toSubmodule_eq_range :
     (quadraticLieSubalgebra Q).toSubmodule = LinearMap.range (cliffordBivectorExterior Q) :=
   le_antisymm
-    (quadraticLieSubalgebra_toSubmodule_le Q fun a b =>
+    (quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem Q fun a b =>
       ⟨exteriorPower.ιMulti R 2 ![a, b], cliffordBivectorExterior_apply_ιMulti Q a b⟩)
-    (cliffordBivectorExterior_range_le Q _ (cliffordBivector_mem_quadraticLieSubalgebra Q))
+    (cliffordBivectorExterior_range_le_of_cliffordBivector_mem Q _
+      (cliffordBivector_mem_quadraticLieSubalgebra Q))
+
+/-- **Membership in the quadratic elements**: an element of the Clifford algebra is quadratic
+exactly when it is in the image of `⋀[R]^2 M` under
+`TauCeti.CliffordAlgebra.cliffordBivectorExterior`. -/
+theorem mem_quadraticLieSubalgebra_iff {x : CliffordAlgebra Q} :
+    x ∈ quadraticLieSubalgebra Q ↔ x ∈ LinearMap.range (cliffordBivectorExterior Q) := by
+  rw [← LieSubalgebra.mem_toSubmodule, quadraticLieSubalgebra_toSubmodule_eq_range]
 
 /-- **Quadratic elements preserve the generators.** Bracketing with a quadratic element sends
 `ι Q m` back into the image of `ι Q`; on the span of the generators it is therefore an
@@ -203,7 +206,7 @@ theorem lie_ι_mem_range_ι_of_mem_quadraticLieSubalgebra {x : CliffordAlgebra Q
         zero_mem' := fun m => by rw [zero_lie]; exact Submodule.zero_mem _
         smul_mem' := fun r _ hy m => by
           rw [smul_lie]; exact Submodule.smul_mem _ r (hy m) } :=
-    quadraticLieSubalgebra_toSubmodule_le Q fun a b m =>
+    quadraticLieSubalgebra_toSubmodule_le_of_cliffordBivector_mem Q fun a b m =>
       ⟨_, (cliffordBivector_lie_ι Q a b m).symm⟩
   exact key hx m
 


### PR DESCRIPTION
This PR realizes the quadratic elements of a Clifford algebra as a Lie subalgebra under the commutator bracket. `TauCeti.CliffordAlgebra.cliffordBivector Q a b` is the half-normalized commutator of two generators, already in the repository, and its defining property `cliffordBivector_lie_ι` says that bracketing with it rotates a generator by `x ↦ polar Q b x • a - polar Q a x • b`. Since bracketing with a fixed element is a derivation for the associative product, applying that rotation to each of the two generators of a second Clifford bivector computes the bracket of the two as a sum of two Clifford bivectors, so their span is closed under the bracket. The new module packages that closure as `TauCeti.CliffordAlgebra.quadraticLieSubalgebra`, together with the universal property of its underlying submodule, the containments in `even Q`, in `evenOdd Q 0` and in `filtration Q 2`, the identification with the image of `⋀[R]^2 M` under `cliffordBivectorExterior`, and the fact that bracketing with a quadratic element carries the generators back into the generators — the bridging fact that makes the later comparison with the skew-adjoint endomorphisms of `QuadraticMap.polarBilin Q` expressible. Everything is stated over an arbitrary commutative ring with `2` invertible; nondegeneracy, finite-dimensionality, and a field base are needed only for that comparison, which is a separate target and is not proved here.

The roadmap target is `TauCetiRoadmap/RepresentationTheory/SpinRepresentations/README.md`, Layer 9 ("Lie algebras acting through the Clifford algebra, and Kostant's isotypy corollary"), first bullet, "the abstract quadratic realization": "the quadratic elements as a `LieSubalgebra` of `Cliff(V, Q)` (contained in `even Q` and in `filtration Q 2`)". The pinned signature is `quadraticLieSubalgebra` in that roadmap's `Suggested.lean`, and it is matched: `(Q : QuadraticForm R M) [Invertible (2 : R)] : LieSubalgebra R (CliffordAlgebra Q)`. The two other named items of the same bullet, `soEquivQuadratic` and `soEquivQuadratic_lie_ι`, are deliberately left for a follow-up.

Following Mathlib's `Mathlib/Algebra/Lie/SkewAdjoint.lean`, which this file mirrors in shape, the Lie ring structure on an associative ring is put in scope as a local instance (`LieRing.ofAssociativeRing`); it cannot be a global instance, because it would clash with the module bracket when a ring is viewed as a module over itself. No Mathlib source was vendored. One existing declaration changes: `TauCeti.CliffordAlgebra.cliffordBivectorExterior_range_le` in `TauCeti/LinearAlgebra/CliffordAlgebra/Bivector.lean` loses its `private` marker and gains a docstring, so that the exterior-power identification reuses it rather than repeating its proof.

`lake build`, `lake exe axioms` (all within `[propext, Classical.choice, Quot.sound]`), `lake exe module-system`, and `scripts/lint-env.sh` all pass locally.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"quadraticliesubalgebra"}-->

🤖 Prepared with Claude Code
