### PR TITLE
feat: a finite-type Cartan matrix carries no triangle

### DIFF
--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
@@ -558,8 +558,10 @@ theorem not_isFiniteType_affineD₄ :
 matrix; it is symmetrizable, by `d = (1, 2, 1)`; its Cartan products `2`, `1`, `2` all lie in the
 rank-two range; and it is nonsingular, with determinant `-6`. So neither the combinatorial axioms,
 nor `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`, nor `TauCeti.IsFiniteType.det_ne_zero`
-excludes it, and the star bound never applies, its non-adjacency hypothesis being what a triangle
-fails. It is `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` that rules it out. -/
+excludes it. Neither does the star bound: no two of the three indices are non-adjacent, so the only
+neighbour sets meeting its pairwise non-adjacency hypothesis are the empty and the singleton ones,
+whose Cartan products sum to at most `2` and so stay clear of the bound. It is
+`TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` that rules it out. -/
 theorem not_isFiniteType_doubleEdgeTriangle :
     ¬ IsFiniteType (!![2, -2, -1; -1, 2, -1; -1, -2, 2] : Matrix (Fin 3) (Fin 3) ℤ) := by
   intro h

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
@@ -46,25 +46,38 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 * `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`: the rank-two bound. For `i ≠ j` the Cartan
   product `A i j * A j i` lies in `{0, 1, 2, 3}`, so every edge of the diagram is single, double or
   triple.
-* `TauCeti.IsFiniteType.card_le_three_of_pairwise_apply_eq_zero`: the degree bound for a
-  non-adjacent star. No index has four pairwise non-adjacent neighbours; the affine type `D̃₄` is
-  ruled out in `TauCeti.not_isFiniteType_affineD₄`.
 * `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le` and
   `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three`: of two edges at an index whose
   far ends are non-adjacent at most one is multiple, and an index carrying a triple edge is joined
   to no further index non-adjacent to the far end of that edge.
-* `TauCeti.IsFiniteType.apply_mul_apply_eq_one_of_three_le_card`: three pairwise non-adjacent
-  neighbours of an index are each joined to it by a single edge.
 
 Each of these consequences selects its neighbours through a pairwise non-adjacency hypothesis,
-which is what the star bound asks for. Turning them into the unconditional graph statements the
-classification runs on - degree at most three, at most one multiple edge at a vertex, an isolated
-triple edge, a simply laced branch vertex - needs in addition that distinct neighbours of an index
-are never adjacent, that is, that a finite-type diagram carries no triangle. That exclusion is not
-proved here.
+which is what the star bound asks for. The second positive-definiteness estimate of the file
+removes that hypothesis for good.
+
+* `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero`: **a finite-type diagram carries no
+  triangle**. Two distinct neighbours of an index are never adjacent to one another. The test
+  vector is supported on the three indices of the putative triangle, its coordinate at each of them
+  being the weight of the opposite edge; the rank-two bound then makes the symmetrized form
+  nonpositive there. `TauCeti.IsFiniteType.pairwise_apply_eq_zero` is the same statement for a whole
+  neighbourhood, in the shape the star bound consumes.
+
+With it the conditional consequences above become the graph statements the classification runs on.
+
+* `TauCeti.IsFiniteType.card_le_three` and `TauCeti.IsFiniteType.card_filter_le_three`: **the
+  degree bound**. No index has four neighbours; the affine type `D̃₄` is ruled out in
+  `TauCeti.not_isFiniteType_affineD₄`.
+* `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le_of_ne`: **at most one edge at an index is
+  multiple**.
+* `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three_of_ne`: **a triple edge is
+  isolated**, so it is a connected component of the diagram; this is why `G₂` has rank `2`.
+* `TauCeti.IsFiniteType.apply_mul_apply_eq_one_of_three_le_card`: **a branch vertex is simply
+  laced**. Three neighbours of an index are each joined to it by a single edge.
 * `TauCeti.IsFiniteType.det_ne_zero`: a finite-type matrix is nonsingular. Since the extended
-  Dynkin diagrams have singular Cartan matrices, this is the second elimination tool; the affine
-  type `Ã₂` is ruled out in `TauCeti.not_isFiniteType_affineA₂`.
+  Dynkin diagrams have singular Cartan matrices, this is the third elimination tool; the affine
+  type `Ã₂` is ruled out in `TauCeti.not_isFiniteType_affineA₂`. It does not subsume the
+  no-triangle theorem: `TauCeti.not_isFiniteType_doubleEdgeTriangle` exhibits a nonsingular
+  triangle.
 * `TauCeti.isFiniteType_cartanMatrix`: **the Cartan matrix of a base of a finite crystallographic
   root system is of finite type**, and `TauCeti.HasCartanType.isFiniteType`: so is the standard
   Cartan matrix of any Dynkin type realized by such a base.
@@ -267,6 +280,143 @@ theorem apply_mul_apply_mem_of_ne (h : IsFiniteType A) {i j : B} (hij : i ≠ j)
   simp only [Set.mem_insert_iff, Set.mem_singleton_iff]
   omega
 
+/-- **Three Cartan products in the rank-two range satisfy `(α + β + γ) ^ 2 ≤ 9αβγ`.** This is the
+arithmetic behind the exclusion of triangles. The three edges of a triangle carry Cartan products
+between `1` and `3`, and the inequality then says that the test vector built from those three
+products does not see a positive value of the symmetrized form. Equality holds exactly at
+`α = β = γ = 1`, the simply laced triangle, which is the affine diagram `Ã₂`. -/
+private theorem sq_add_le_nine_mul {α β γ : ℤ} (hα : 1 ≤ α) (hα' : α ≤ 3) (hβ : 1 ≤ β)
+    (hβ' : β ≤ 3) (hγ : 1 ≤ γ) (hγ' : γ ≤ 3) :
+    (α + β + γ) ^ 2 ≤ 9 * (α * β * γ) := by
+  interval_cases α <;> interval_cases β <;> interval_cases γ <;> norm_num
+
+/-- **The endgame of the triangle exclusion.** If `m` is positive with `m² = P²αβγ` and the three
+Cartan products satisfy the bound of `TauCeti.IsFiniteType.sq_add_le_nine_mul`, then `3m` is not
+below `P(α + β + γ)`: squaring the strict inequality would make `9P²αβγ` smaller than itself.
+
+At the call site `P` is the product of the three symmetrizer values, `α`, `β`, `γ` are the Cartan
+products along the three edges of the triangle, and `m` is the product of the three edge weights of
+the symmetrization, up to sign; the value of the symmetrized form at the test vector is
+`2P(α + β + γ) - 6m`, so positive definiteness is exactly the inequality refuted here. -/
+private theorem not_three_mul_lt {P m α β γ : ℚ} (hP : 0 < P) (hm : 0 < m)
+    (hm2 : m ^ 2 = P ^ 2 * (α * β * γ)) (hb : (α + β + γ) ^ 2 ≤ 9 * (α * β * γ)) :
+    ¬ 3 * m < P * (α + β + γ) := fun hlt ↦ by
+  nlinarith [mul_le_mul_of_nonneg_left hb (mul_pos hP hP).le, sq_nonneg (P * (α + β + γ) - 3 * m)]
+
+/-- **The three-index core of the no-triangle theorem.** A finite-type matrix on three indices has
+a missing edge: if the first index is joined to the other two, those two are not joined to each
+other.
+
+The proof is the second, and last, positive-definiteness estimate of this file, and it is a
+different one from the star bound: the test vector is supported on *all three* indices, and at each
+of them its coordinate is the weight, in the symmetrization, of the *opposite* edge. Writing
+`a`, `b`, `c` for the three edge weights - each negative, since the off-diagonal entries are - the
+symmetrized form evaluates at that vector to `2(d₀c² + d₁b² + d₂a²) + 6abc`, and the identity
+`a² = d₀d₁·(A₀₁A₁₀)` turns this into `2P(α + β + γ) - 6m` in the notation of
+`TauCeti.IsFiniteType.not_three_mul_lt`. -/
+private theorem apply_eq_zero_of_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h : IsFiniteType T)
+    (h01 : T 0 1 ≠ 0) (h02 : T 0 2 ≠ 0) :
+    T 1 2 = 0 := by
+  by_contra h12
+  obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
+  -- The symmetrizer intertwines the two entries of a transposed pair.
+  have hsymm : ∀ p q : Fin 3, d q * ((T q p : ℤ) : ℚ) = d p * ((T p q : ℤ) : ℚ) := fun p q ↦ by
+    simpa using hpd.isHermitian.apply p q
+  -- Each of the three edges is present, so each edge weight of the symmetrization is negative.
+  have hT01 : T 0 1 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h01
+  have hT02 : T 0 2 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h02
+  have hT12 : T 1 2 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h12
+  have ha : d 0 * ((T 0 1 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 0) (by exact_mod_cast hT01)
+  have hb : d 0 * ((T 0 2 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 0) (by exact_mod_cast hT02)
+  have hc : d 1 * ((T 1 2 : ℤ) : ℚ) < 0 := mul_neg_of_pos_of_neg (hd 1) (by exact_mod_cast hT12)
+  -- The test vector: at each index, the weight of the opposite edge.
+  have hq := hpd.dotProduct_mulVec_pos
+    (x := ![-(d 1 * ((T 1 2 : ℤ) : ℚ)), -(d 0 * ((T 0 2 : ℤ) : ℚ)), -(d 0 * ((T 0 1 : ℤ) : ℚ))])
+    (fun hcon ↦ by
+      have h0 := congrFun hcon 0
+      simp only [Matrix.cons_val_zero, Pi.zero_apply, neg_eq_zero] at h0
+      linarith)
+  rw [star_trivial, Matrix.dot_mulVec_eq_sum_sum] at hq
+  simp only [Fin.sum_univ_three, Matrix.of_apply, Matrix.cons_val_zero, Matrix.cons_val_one,
+    Matrix.head_cons, Matrix.cons_val_two, Matrix.tail_cons] at hq
+  rw [h.apply_self 0, h.apply_self 1, h.apply_self 2, hsymm 0 1, hsymm 0 2, hsymm 1 2] at hq
+  push_cast at hq
+  -- The square of an edge weight is the Cartan product of that edge, scaled by two symmetrizers.
+  have ea : (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2
+      = d 0 * d 1 * (((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) := by
+    linear_combination (-(d 0 * ((T 0 1 : ℤ) : ℚ))) * hsymm 0 1
+  have eb : (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2
+      = d 0 * d 2 * (((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ)) := by
+    linear_combination (-(d 0 * ((T 0 2 : ℤ) : ℚ))) * hsymm 0 2
+  have ec : (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2
+      = d 1 * d 2 * (((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ)) := by
+    linear_combination (-(d 1 * ((T 1 2 : ℤ) : ℚ))) * hsymm 1 2
+  -- Package the three edges as the data the arithmetic endgame consumes.
+  refine not_three_mul_lt (P := d 0 * d 1 * d 2)
+    (m := -(d 0 * ((T 0 1 : ℤ) : ℚ) * (d 0 * ((T 0 2 : ℤ) : ℚ)) * (d 1 * ((T 1 2 : ℤ) : ℚ))))
+    (α := ((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) (β := ((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ))
+    (γ := ((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ))
+    (mul_pos (mul_pos (hd 0) (hd 1)) (hd 2))
+    (neg_pos.mpr (mul_neg_of_pos_of_neg (mul_pos_of_neg_of_neg ha hb) hc)) ?_ ?_ ?_
+  · -- `m² = P²αβγ`, by multiplying the three edge identities.
+    have : (-(d 0 * ((T 0 1 : ℤ) : ℚ) * (d 0 * ((T 0 2 : ℤ) : ℚ)) * (d 1 * ((T 1 2 : ℤ) : ℚ)))) ^ 2
+        = (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2 * (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2 *
+          (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2 := by ring
+    rw [this, ea, eb, ec]
+    ring
+  · -- The rank-two bound on each of the three edges feeds the arithmetic inequality.
+    have hα := h.one_le_apply_mul_apply h01
+    have hβ := h.one_le_apply_mul_apply h02
+    have hγ := h.one_le_apply_mul_apply h12
+    have hα' := h.apply_mul_apply_mem_of_ne (i := 0) (j := 1) (by decide)
+    have hβ' := h.apply_mul_apply_mem_of_ne (i := 0) (j := 2) (by decide)
+    have hγ' := h.apply_mul_apply_mem_of_ne (i := 1) (j := 2) (by decide)
+    simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hα' hβ' hγ'
+    have := sq_add_le_nine_mul hα (by omega) hβ (by omega) hγ (by omega)
+    exact_mod_cast this
+  · -- Positive definiteness at the test vector, rewritten through the three edge identities: each
+    -- diagonal contribution is twice `P` times the Cartan product of the opposite edge.
+    have ea' : 2 * d 2 * (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2
+        = 2 * (d 0 * d 1 * d 2) * (((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) := by rw [ea]; ring
+    have eb' : 2 * d 1 * (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2
+        = 2 * (d 0 * d 1 * d 2) * (((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ)) := by rw [eb]; ring
+    have ec' : 2 * d 0 * (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2
+        = 2 * (d 0 * d 1 * d 2) * (((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ)) := by rw [ec]; ring
+    linarith [hq, ea', eb', ec']
+
+/-- **A finite-type diagram carries no triangle.** Two distinct neighbours of an index are never
+adjacent to one another, so the neighbourhood of an index is pairwise non-adjacent and the star
+bound applies to it with no side condition.
+
+This is what turns the conditional consequences of the star bound into graph statements: the degree
+bound `TauCeti.IsFiniteType.card_le_three`, the fact that at most one edge at an index is multiple,
+and the isolation of a triple edge. -/
+theorem apply_eq_zero_of_apply_ne_zero (h : IsFiniteType A) {i j k : B} (hij : i ≠ j) (hik : i ≠ k)
+    (hjk : j ≠ k) (hj : A i j ≠ 0) (hk : A i k ≠ 0) :
+    A j k = 0 := by
+  -- Restrict to the principal submatrix on the three indices and apply the three-index core.
+  have he : Function.Injective ![i, j, k] := by
+    intro p q hpq
+    fin_cases p <;> fin_cases q <;> simp_all
+  have h' := h.submatrix he
+  have e01 : (A.submatrix ![i, j, k] ![i, j, k]) 0 1 = A i j := by simp
+  have e02 : (A.submatrix ![i, j, k] ![i, j, k]) 0 2 = A i k := by simp
+  have e12 : (A.submatrix ![i, j, k] ![i, j, k]) 1 2 = A j k := by simp
+  have := apply_eq_zero_of_fin_three h' (e01 ▸ hj) (e02 ▸ hk)
+  rwa [e12] at this
+
+/-- **The neighbourhood of an index is pairwise non-adjacent.** This is the no-triangle theorem in
+the form the star bound consumes: a set of neighbours of `i`, none of them `i` itself, satisfies the
+pairwise hypothesis of `TauCeti.IsFiniteType.sum_apply_mul_apply_lt_four` for free. -/
+theorem pairwise_apply_eq_zero (h : IsFiniteType A) {i : B} {s : Finset B} (his : i ∉ s)
+    (hadj : ∀ j ∈ s, A i j ≠ 0) :
+    (s : Set B).Pairwise fun j k ↦ A j k = 0 := by
+  intro j hj k hk hjk
+  simp only [Finset.mem_coe] at hj hk
+  refine h.apply_eq_zero_of_apply_ne_zero ?_ ?_ hjk (hadj j hj) (hadj k hk)
+  · rintro rfl; exact his hj
+  · rintro rfl; exact his hk
+
 /-- **The two-index case of the star bound.** Two non-adjacent indices `j` and `k`, both distinct
 from `i`, carry Cartan products with `i` summing to less than `4`; neither is required to be a
 neighbour of `i`, an absent edge contributing `0`. Here `j ≠ k` need not be assumed: it follows
@@ -301,6 +451,20 @@ theorem apply_mul_apply_le_one_of_two_le (h : IsFiniteType A) {i j k : B} (h0 : 
   have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik h0
   omega
 
+/-- **At most one edge at an index is multiple.** An index carrying a multiple edge is joined to
+every other index by at most a single edge. This is the unconditional form of
+`TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le`: the non-adjacency of the two far ends,
+which that statement assumes, is supplied by the no-triangle theorem. -/
+theorem apply_mul_apply_le_one_of_two_le_of_ne (h : IsFiniteType A) {i j k : B} (hij : i ≠ j)
+    (hik : i ≠ k) (hjk : j ≠ k) (hj : 2 ≤ A i j * A j i) :
+    A i k * A k i ≤ 1 := by
+  -- Either `k` is not a neighbour of `i` at all, or the triangle `i, j, k` is forbidden.
+  rcases eq_or_ne (A i k) 0 with h0 | h0
+  · simp [h0]
+  have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
+  exact h.apply_mul_apply_le_one_of_two_le
+    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0) hj
+
 /-- **A triple edge is isolated among the neighbours non-adjacent to its far end.** An index joined
 to `j` by a triple edge is joined to no further index non-adjacent to `j`. This is the local step
 behind `G₂` being the only finite-type diagram carrying a triple edge. -/
@@ -321,30 +485,48 @@ theorem apply_eq_zero_of_apply_mul_apply_eq_three (h : IsFiniteType A) {i j k : 
   have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik h0
   omega
 
-/-- **An index of a finite-type matrix has at most three pairwise non-adjacent neighbours**, so a
-finite-type diagram branches into at most three pairwise unjoined arms. The unconditional degree
-bound asks in addition that distinct neighbours of an index are non-adjacent, which is not proved
-here. -/
-theorem card_le_three_of_pairwise_apply_eq_zero (h : IsFiniteType A) {i : B} {s : Finset B}
-    (his : i ∉ s) (hadj : ∀ j ∈ s, A i j ≠ 0)
-    (hs : (s : Set B).Pairwise fun j k ↦ A j k = 0) :
+/-- **A triple edge is isolated.** An index carrying a triple edge is joined to no other index at
+all. This is the unconditional form of
+`TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three`, and applied at both ends of the
+edge it says that a triple edge is a connected component: it is why `G₂` has rank `2`. -/
+theorem apply_eq_zero_of_apply_mul_apply_eq_three_of_ne (h : IsFiniteType A) {i j k : B}
+    (hij : i ≠ j) (hik : i ≠ k) (hjk : j ≠ k) (hj : A i j * A j i = 3) :
+    A i k = 0 := by
+  -- Were `k` a neighbour of `i` too, the triangle `i, j, k` would be forbidden.
+  by_contra h0
+  have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
+  exact h0 (h.apply_eq_zero_of_apply_mul_apply_eq_three
+    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0) hj)
+
+/-- **The degree bound: an index of a finite-type matrix has at most three neighbours**, so a
+finite-type diagram branches into at most three arms. By the no-triangle theorem the neighbours are
+automatically pairwise non-adjacent, so the star bound applies to them directly. -/
+theorem card_le_three (h : IsFiniteType A) {i : B} {s : Finset B} (his : i ∉ s)
+    (hadj : ∀ j ∈ s, A i j ≠ 0) :
     s.card ≤ 3 := by
   have hone : ∀ j ∈ s, (1 : ℤ) ≤ A i j * A j i := fun j hj ↦
     h.one_le_apply_mul_apply (hadj j hj)
   have hcard : (s.card : ℤ) ≤ ∑ j ∈ s, A i j * A j i := by
     calc (s.card : ℤ) = ∑ _j ∈ s, (1 : ℤ) := by simp
       _ ≤ _ := Finset.sum_le_sum hone
-  have := h.sum_apply_mul_apply_lt_four his hs
+  have := h.sum_apply_mul_apply_lt_four his (h.pairwise_apply_eq_zero his hadj)
   omega
 
-/-- **A three-armed non-adjacent star of a finite-type matrix is simply laced.** An index with
-three pairwise non-adjacent neighbours meets each of them along a single edge, since three Cartan
-products of value at least `1` already exhaust the star bound. -/
+/-- **The degree bound, for the neighbourhood itself.** The indices joined to `i`, other than `i`,
+number at most three. -/
+theorem card_filter_le_three [DecidableEq B] (h : IsFiniteType A) (i : B) :
+    (Finset.univ.filter fun j ↦ j ≠ i ∧ A i j ≠ 0).card ≤ 3 :=
+  h.card_le_three (by simp) fun j hj ↦ (Finset.mem_filter.mp hj).2.2
+
+/-- **A three-armed star of a finite-type matrix is simply laced.** An index with three neighbours
+meets each of them along a single edge, since three Cartan products of value at least `1` already
+exhaust the star bound. Together with `TauCeti.IsFiniteType.card_le_three` this says that a branch
+vertex of a finite-type diagram carries exactly three simple edges. -/
 theorem apply_mul_apply_eq_one_of_three_le_card (h : IsFiniteType A) {i : B} {s : Finset B}
-    (his : i ∉ s) (hadj : ∀ j ∈ s, A i j ≠ 0)
-    (hs : (s : Set B).Pairwise fun j k ↦ A j k = 0) (hcard : 3 ≤ s.card) {j : B} (hj : j ∈ s) :
+    (his : i ∉ s) (hadj : ∀ j ∈ s, A i j ≠ 0) (hcard : 3 ≤ s.card) {j : B} (hj : j ∈ s) :
     A i j * A j i = 1 := by
   classical
+  have hs : (s : Set B).Pairwise fun j k ↦ A j k = 0 := h.pairwise_apply_eq_zero his hadj
   have hone : ∀ k ∈ s, (1 : ℤ) ≤ A i k * A k i := fun k hk ↦
     h.one_le_apply_mul_apply (hadj k hk)
   have hsplit : ∑ k ∈ s, A i k * A k i
@@ -390,8 +572,7 @@ theorem not_isFiniteType_affineA₂ :
 
 /-- **The Cartan matrix of the affine diagram `D̃₄` is not of finite type.** The four-armed star is
 the smallest diagram excluded by the degree bound; unlike `Ã₂` it needs no determinant, since
-`TauCeti.IsFiniteType.card_le_three_of_pairwise_apply_eq_zero` applies to the central index
-directly. -/
+`TauCeti.IsFiniteType.card_le_three` applies to the central index directly. -/
 theorem not_isFiniteType_affineD₄ :
     ¬ IsFiniteType (!![2, -1, -1, -1, -1;
                       -1, 2, 0, 0, 0;
@@ -399,14 +580,22 @@ theorem not_isFiniteType_affineD₄ :
                       -1, 0, 0, 2, 0;
                       -1, 0, 0, 0, 2] : Matrix (Fin 5) (Fin 5) ℤ) := by
   intro h
-  have hcard := h.card_le_three_of_pairwise_apply_eq_zero (i := 0) (s := {1, 2, 3, 4})
-    (by decide) (by decide) (by
-      intro p hp q hq hpq
-      simp only [Finset.coe_insert, Finset.coe_singleton, Set.mem_insert_iff,
-        Set.mem_singleton_iff] at hp hq
-      rcases hp with rfl | rfl | rfl | rfl <;> rcases hq with rfl | rfl | rfl | rfl <;>
-        revert hpq <;> decide)
+  have hcard := h.card_le_three (i := 0) (s := {1, 2, 3, 4}) (by decide) (by decide)
   revert hcard
+  decide
+
+/-- **A triangle carrying double edges is not of finite type.** This matrix is a generalized Cartan
+matrix; it is symmetrizable, by `d = (1, 2, 1)`; its Cartan products `2`, `1`, `2` all lie in the
+rank-two range; and it is nonsingular, with determinant `-6`. So neither the combinatorial axioms,
+nor `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`, nor `TauCeti.IsFiniteType.det_ne_zero`
+excludes it, and the star bound never applies, its non-adjacency hypothesis being what a triangle
+fails. It is `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` that rules it out. -/
+theorem not_isFiniteType_doubleEdgeTriangle :
+    ¬ IsFiniteType (!![2, -2, -1; -1, 2, -1; -1, -2, 2] : Matrix (Fin 3) (Fin 3) ℤ) := by
+  intro h
+  have h12 := h.apply_eq_zero_of_apply_ne_zero (i := 0) (j := 1) (k := 2)
+    (by decide) (by decide) (by decide) (by decide) (by decide)
+  revert h12
   decide
 
 section RootPairing

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
@@ -417,15 +417,28 @@ theorem pairwise_apply_eq_zero (h : IsFiniteType A) {i : B} {s : Finset B} (his 
   · rintro rfl; exact his hj
   · rintro rfl; exact his hk
 
-/-- **The two-index case of the star bound.** Two non-adjacent indices `j` and `k`, both distinct
-from `i`, carry Cartan products with `i` summing to less than `4`; neither is required to be a
-neighbour of `i`, an absent edge contributing `0`. Here `j ≠ k` need not be assumed: it follows
-from `A j k = 0`, since the diagonal entries are `2`. -/
+/-- **The two-index case of the star bound.** Three pairwise distinct indices `i`, `j`, `k` are such
+that the Cartan products of `i` with `j` and with `k` sum to less than `4`; neither `j` nor `k` is
+required to be a neighbour of `i`, an absent edge contributing `0`. No non-adjacency of `j` and `k`
+is assumed: if both are neighbours of `i` the no-triangle theorem supplies it, and otherwise the
+rank-two bound alone already caps the sum at `3`. -/
 theorem apply_mul_apply_add_apply_mul_apply_lt_four (h : IsFiniteType A) {i j k : B} (hij : i ≠ j)
-    (hik : i ≠ k) (h0 : A j k = 0) :
+    (hik : i ≠ k) (hjk : j ≠ k) :
     A i j * A j i + A i k * A k i < 4 := by
   classical
-  have hjk : j ≠ k := fun hc ↦ by rw [hc, h.apply_self k] at h0; omega
+  -- If either of `j`, `k` misses `i`, the rank-two bound on the other edge is already enough.
+  have hmemj := h.apply_mul_apply_mem_of_ne hij
+  have hmemk := h.apply_mul_apply_mem_of_ne hik
+  simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hmemj hmemk
+  rcases eq_or_ne (A i j) 0 with hzj | hnej
+  · simp only [hzj, zero_mul, zero_add]
+    omega
+  rcases eq_or_ne (A i k) 0 with hzk | hnek
+  · simp only [hzk, zero_mul, add_zero]
+    omega
+  -- Otherwise `j` and `k` are both neighbours of `i`, so the no-triangle theorem separates them and
+  -- the star bound applies to the star `{j, k}`.
+  have h0 : A j k = 0 := h.apply_eq_zero_of_apply_ne_zero hij hik hjk hnej hnek
   have hkj : A k j = 0 := h.apply_eq_zero_symm h0
   have hi : i ∉ ({j, k} : Finset B) := by simp [hij, hik]
   have hp : ((({j, k} : Finset B) : Set B)).Pairwise fun p q ↦ A p q = 0 := by
@@ -442,13 +455,8 @@ assumed: the no-triangle theorem supplies it. -/
 theorem apply_mul_apply_le_one_of_two_le (h : IsFiniteType A) {i j k : B} (hij : i ≠ j)
     (hik : i ≠ k) (hjk : j ≠ k) (hj : 2 ≤ A i j * A j i) :
     A i k * A k i ≤ 1 := by
-  -- Either `k` is not a neighbour of `i` at all, or the triangle `i, j, k` is forbidden and the
-  -- two-index case of the star bound applies.
-  rcases eq_or_ne (A i k) 0 with h0 | h0
-  · simp [h0]
-  have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
-  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik
-    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0)
+  -- The two-index case of the star bound leaves less than `2` for the edge to `k`.
+  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik hjk
   omega
 
 /-- **A triple edge is isolated.** An index joined to `j` by a triple edge is joined to no index
@@ -462,12 +470,10 @@ theorem apply_eq_zero_of_apply_mul_apply_eq_three (h : IsFiniteType A) {i j k : 
     rintro rfl
     rw [h.apply_self] at hj
     omega
-  -- Were `k` a neighbour of `i` too, the triangle `i, j, k` would be forbidden.
+  -- A triple edge already exhausts the two-index case of the star bound, leaving no room for `k`.
   by_contra h0
-  have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
   have h1 := h.one_le_apply_mul_apply h0
-  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik
-    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0)
+  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik hjk
   omega
 
 /-- **The degree bound: an index of a finite-type matrix has at most three neighbours**, so a

--- a/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
+++ b/TauCeti/LinearAlgebra/RootSystem/FiniteType.lean
@@ -40,37 +40,28 @@ denominators. The symmetrization itself is not redone here: Mathlib packages it 
 * `TauCeti.IsFiniteType.submatrix`: principal submatrices of a finite-type matrix are of finite
   type. This is what lets a forbidden subdiagram rule out a diagram containing it.
 * `TauCeti.IsFiniteType.sum_apply_mul_apply_lt_four`: the star bound. The Cartan products joining
-  an index to pairwise non-adjacent neighbours sum to less than `4`. This is the one
-  positive-definiteness estimate behind the local shape of a finite-type diagram, and the results
-  below are its corollaries.
+  an index to pairwise non-adjacent neighbours sum to less than `4`. This is the first of the two
+  positive-definiteness estimates behind the local shape of a finite-type diagram.
 * `TauCeti.IsFiniteType.apply_mul_apply_mem_of_ne`: the rank-two bound. For `i ≠ j` the Cartan
   product `A i j * A j i` lies in `{0, 1, 2, 3}`, so every edge of the diagram is single, double or
   triple.
-* `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le` and
-  `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three`: of two edges at an index whose
-  far ends are non-adjacent at most one is multiple, and an index carrying a triple edge is joined
-  to no further index non-adjacent to the far end of that edge.
-
-Each of these consequences selects its neighbours through a pairwise non-adjacency hypothesis,
-which is what the star bound asks for. The second positive-definiteness estimate of the file
-removes that hypothesis for good.
-
 * `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero`: **a finite-type diagram carries no
-  triangle**. Two distinct neighbours of an index are never adjacent to one another. The test
-  vector is supported on the three indices of the putative triangle, its coordinate at each of them
-  being the weight of the opposite edge; the rank-two bound then makes the symmetrized form
-  nonpositive there. `TauCeti.IsFiniteType.pairwise_apply_eq_zero` is the same statement for a whole
-  neighbourhood, in the shape the star bound consumes.
+  triangle**. Two distinct neighbours of an index are never adjacent to one another. This is the
+  second estimate: the test vector is supported on the three indices of the putative triangle, its
+  coordinate at each of them being the weight of the opposite edge, and the rank-two bound then
+  makes the symmetrized form nonpositive there. `TauCeti.IsFiniteType.pairwise_apply_eq_zero` is the
+  same statement for a whole neighbourhood, in the shape the star bound consumes.
 
-With it the conditional consequences above become the graph statements the classification runs on.
+The star bound selects its neighbours through a pairwise non-adjacency hypothesis; with the triangle
+excluded that hypothesis comes for free, and the consequences below are the unconditional graph
+statements the classification runs on.
 
-* `TauCeti.IsFiniteType.card_le_three` and `TauCeti.IsFiniteType.card_filter_le_three`: **the
-  degree bound**. No index has four neighbours; the affine type `D̃₄` is ruled out in
-  `TauCeti.not_isFiniteType_affineD₄`.
-* `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le_of_ne`: **at most one edge at an index is
+* `TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero`: **the degree bound**. No index has
+  four neighbours; the affine type `D̃₄` is ruled out in `TauCeti.not_isFiniteType_affineD₄`.
+* `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le`: **at most one edge at an index is
   multiple**.
-* `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three_of_ne`: **a triple edge is
-  isolated**, so it is a connected component of the diagram; this is why `G₂` has rank `2`.
+* `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three`: **a triple edge is isolated**,
+  so it is a connected component of the diagram; this is why `G₂` has rank `2`.
 * `TauCeti.IsFiniteType.apply_mul_apply_eq_one_of_three_le_card`: **a branch vertex is simply
   laced**. Three neighbours of an index are each joined to it by a single edge.
 * `TauCeti.IsFiniteType.det_ne_zero`: a finite-type matrix is nonsingular. Since the extended
@@ -145,6 +136,24 @@ lemma apply_eq_zero_iff (h : IsFiniteType A) {i j : B} : A i j = 0 ↔ A j i = 0
 /-- The symmetrizer of a finite-type matrix, together with its defining properties. -/
 lemma exists_symmetrizer (h : IsFiniteType A) :
     ∃ d : B → ℚ, (∀ i, 0 < d i) ∧ (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef := h.2.2.2
+
+omit [Fintype B] in
+/-- **The symmetrizer intertwines the two entries of a transposed pair.** The symmetrization is
+symmetric, being positive definite, and this is what that says entrywise. -/
+private theorem symmetrization_apply_comm {d : B → ℚ}
+    (hpd : (Matrix.of fun i j ↦ d i * (A i j : ℚ)).PosDef) (p q : B) :
+    d q * (A q p : ℚ) = d p * (A p q : ℚ) := by
+  simpa using hpd.isHermitian.apply p q
+
+omit [Fintype B] in
+/-- **The square of an edge weight of the symmetrization is a scaled Cartan product.** The weight
+`dₚAₚq` squares to `dₚdq · AₚqAqₚ`, the two symmetrizer values times the Cartan product of the
+edge. This is what lets the triangle estimate be run over `ℚ`: the square roots of the geometric
+argument never appear. -/
+private theorem sq_symmetrization_apply {d : B → ℚ} {p q : B}
+    (hsymm : d q * (A q p : ℚ) = d p * (A p q : ℚ)) :
+    (d p * (A p q : ℚ)) ^ 2 = d p * d q * ((A p q : ℚ) * (A q p : ℚ)) := by
+  linear_combination (-(d p * (A p q : ℚ))) * hsymm
 
 /-- **A principal submatrix of a finite-type matrix is of finite type.** This is the form in which
 a forbidden subdiagram excludes every diagram containing it. -/
@@ -236,17 +245,16 @@ private theorem dotProduct_mulVec_symmetrization_eq_of_pairwise_apply_eq_zero
 pairwise non-adjacent, then the Cartan products of `i` with the indices of `s` sum to less than
 `4`.
 
-This is the single positive-definiteness estimate behind the local shape of a finite-type diagram:
-inside a pairwise non-adjacent star at `i` there are at most three neighbours, at most one of the
-edges to them is multiple, and a triple edge among them stands alone. -/
+This is the first of the two positive-definiteness estimates behind the local shape of a finite-type
+diagram: inside a pairwise non-adjacent star at `i` there are at most three neighbours, at most one
+of the edges to them is multiple, and a triple edge among them stands alone. The second,
+`TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero`, removes the pairwise hypothesis. -/
 theorem sum_apply_mul_apply_lt_four (h : IsFiniteType A) {i : B} {s : Finset B} (his : i ∉ s)
     (hs : (s : Set B).Pairwise fun j k ↦ A j k = 0) :
     ∑ j ∈ s, A i j * A j i < 4 := by
   classical
   obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
-  -- The symmetrizer intertwines the two entries of a transposed pair.
-  have hsymm : ∀ p q : B, d q * (A q p : ℚ) = d p * (A p q : ℚ) := fun p q ↦ by
-    simpa using hpd.isHermitian.apply p q
+  have hsymm := symmetrization_apply_comm hpd
   -- The test vector: `1` at `i`, the value minimizing the `k`-th coordinate of the form at each
   -- `k ∈ s`, and `0` elsewhere.
   set x : B → ℚ := fun k ↦ if k = i then 1 else
@@ -285,13 +293,13 @@ arithmetic behind the exclusion of triangles. The three edges of a triangle carr
 between `1` and `3`, and the inequality then says that the test vector built from those three
 products does not see a positive value of the symmetrized form. Equality holds exactly at
 `α = β = γ = 1`, the simply laced triangle, which is the affine diagram `Ã₂`. -/
-private theorem sq_add_le_nine_mul {α β γ : ℤ} (hα : 1 ≤ α) (hα' : α ≤ 3) (hβ : 1 ≤ β)
+private theorem add_sq_le_nine_mul {α β γ : ℤ} (hα : 1 ≤ α) (hα' : α ≤ 3) (hβ : 1 ≤ β)
     (hβ' : β ≤ 3) (hγ : 1 ≤ γ) (hγ' : γ ≤ 3) :
     (α + β + γ) ^ 2 ≤ 9 * (α * β * γ) := by
   interval_cases α <;> interval_cases β <;> interval_cases γ <;> norm_num
 
 /-- **The endgame of the triangle exclusion.** If `m` is positive with `m² = P²αβγ` and the three
-Cartan products satisfy the bound of `TauCeti.IsFiniteType.sq_add_le_nine_mul`, then `3m` is not
+Cartan products satisfy the bound of `TauCeti.IsFiniteType.add_sq_le_nine_mul`, then `3m` is not
 below `P(α + β + γ)`: squaring the strict inequality would make `9P²αβγ` smaller than itself.
 
 At the call site `P` is the product of the three symmetrizer values, `α`, `β`, `γ` are the Cartan
@@ -314,14 +322,12 @@ of them its coordinate is the weight, in the symmetrization, of the *opposite* e
 symmetrized form evaluates at that vector to `2(d₀c² + d₁b² + d₂a²) + 6abc`, and the identity
 `a² = d₀d₁·(A₀₁A₁₀)` turns this into `2P(α + β + γ) - 6m` in the notation of
 `TauCeti.IsFiniteType.not_three_mul_lt`. -/
-private theorem apply_eq_zero_of_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h : IsFiniteType T)
+private theorem apply_eq_zero_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h : IsFiniteType T)
     (h01 : T 0 1 ≠ 0) (h02 : T 0 2 ≠ 0) :
     T 1 2 = 0 := by
   by_contra h12
   obtain ⟨d, hd, hpd⟩ := h.exists_symmetrizer
-  -- The symmetrizer intertwines the two entries of a transposed pair.
-  have hsymm : ∀ p q : Fin 3, d q * ((T q p : ℤ) : ℚ) = d p * ((T p q : ℤ) : ℚ) := fun p q ↦ by
-    simpa using hpd.isHermitian.apply p q
+  have hsymm := symmetrization_apply_comm hpd
   -- Each of the three edges is present, so each edge weight of the symmetrization is negative.
   have hT01 : T 0 1 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h01
   have hT02 : T 0 2 < 0 := lt_of_le_of_ne (h.apply_le_zero_of_ne (by decide)) h02
@@ -342,15 +348,9 @@ private theorem apply_eq_zero_of_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h :
   rw [h.apply_self 0, h.apply_self 1, h.apply_self 2, hsymm 0 1, hsymm 0 2, hsymm 1 2] at hq
   push_cast at hq
   -- The square of an edge weight is the Cartan product of that edge, scaled by two symmetrizers.
-  have ea : (d 0 * ((T 0 1 : ℤ) : ℚ)) ^ 2
-      = d 0 * d 1 * (((T 0 1 : ℤ) : ℚ) * ((T 1 0 : ℤ) : ℚ)) := by
-    linear_combination (-(d 0 * ((T 0 1 : ℤ) : ℚ))) * hsymm 0 1
-  have eb : (d 0 * ((T 0 2 : ℤ) : ℚ)) ^ 2
-      = d 0 * d 2 * (((T 0 2 : ℤ) : ℚ) * ((T 2 0 : ℤ) : ℚ)) := by
-    linear_combination (-(d 0 * ((T 0 2 : ℤ) : ℚ))) * hsymm 0 2
-  have ec : (d 1 * ((T 1 2 : ℤ) : ℚ)) ^ 2
-      = d 1 * d 2 * (((T 1 2 : ℤ) : ℚ) * ((T 2 1 : ℤ) : ℚ)) := by
-    linear_combination (-(d 1 * ((T 1 2 : ℤ) : ℚ))) * hsymm 1 2
+  have ea := sq_symmetrization_apply (hsymm 0 1)
+  have eb := sq_symmetrization_apply (hsymm 0 2)
+  have ec := sq_symmetrization_apply (hsymm 1 2)
   -- Package the three edges as the data the arithmetic endgame consumes.
   refine not_three_mul_lt (P := d 0 * d 1 * d 2)
     (m := -(d 0 * ((T 0 1 : ℤ) : ℚ) * (d 0 * ((T 0 2 : ℤ) : ℚ)) * (d 1 * ((T 1 2 : ℤ) : ℚ))))
@@ -372,7 +372,7 @@ private theorem apply_eq_zero_of_fin_three {T : Matrix (Fin 3) (Fin 3) ℤ} (h :
     have hβ' := h.apply_mul_apply_mem_of_ne (i := 0) (j := 2) (by decide)
     have hγ' := h.apply_mul_apply_mem_of_ne (i := 1) (j := 2) (by decide)
     simp only [Set.mem_insert_iff, Set.mem_singleton_iff] at hα' hβ' hγ'
-    have := sq_add_le_nine_mul hα (by omega) hβ (by omega) hγ (by omega)
+    have := add_sq_le_nine_mul hα (by omega) hβ (by omega) hγ (by omega)
     exact_mod_cast this
   · -- Positive definiteness at the test vector, rewritten through the three edge identities: each
     -- diagonal contribution is twice `P` times the Cartan product of the opposite edge.
@@ -389,8 +389,8 @@ adjacent to one another, so the neighbourhood of an index is pairwise non-adjace
 bound applies to it with no side condition.
 
 This is what turns the conditional consequences of the star bound into graph statements: the degree
-bound `TauCeti.IsFiniteType.card_le_three`, the fact that at most one edge at an index is multiple,
-and the isolation of a triple edge. -/
+bound `TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero`, the fact that at most one edge
+at an index is multiple, and the isolation of a triple edge. -/
 theorem apply_eq_zero_of_apply_ne_zero (h : IsFiniteType A) {i j k : B} (hij : i ≠ j) (hik : i ≠ k)
     (hjk : j ≠ k) (hj : A i j ≠ 0) (hk : A i k ≠ 0) :
     A j k = 0 := by
@@ -402,7 +402,7 @@ theorem apply_eq_zero_of_apply_ne_zero (h : IsFiniteType A) {i j k : B} (hij : i
   have e01 : (A.submatrix ![i, j, k] ![i, j, k]) 0 1 = A i j := by simp
   have e02 : (A.submatrix ![i, j, k] ![i, j, k]) 0 2 = A i k := by simp
   have e12 : (A.submatrix ![i, j, k] ![i, j, k]) 1 2 = A j k := by simp
-  have := apply_eq_zero_of_fin_three h' (e01 ▸ hj) (e02 ▸ hk)
+  have := apply_eq_zero_fin_three h' (e01 ▸ hj) (e02 ▸ hk)
   rwa [e12] at this
 
 /-- **The neighbourhood of an index is pairwise non-adjacent.** This is the no-triangle theorem in
@@ -436,73 +436,45 @@ theorem apply_mul_apply_add_apply_mul_apply_lt_four (h : IsFiniteType A) {i j k 
   have hlt := h.sum_apply_mul_apply_lt_four hi hp
   rwa [Finset.sum_insert (by simpa using hjk), Finset.sum_singleton] at hlt
 
-/-- **At most one edge of a non-adjacent pair at an index is multiple.** If the edge from `i` to
-`j` is multiple, then `i` is joined to every index non-adjacent to `j` by at most a single edge. -/
-theorem apply_mul_apply_le_one_of_two_le (h : IsFiniteType A) {i j k : B} (h0 : A j k = 0)
-    (hj : 2 ≤ A i j * A j i) :
-    A i k * A k i ≤ 1 := by
-  -- A multiple edge at `i` makes `i ≠ j`, and were `i` equal to `k` that edge would be absent.
-  rcases eq_or_ne i j with rfl | hij
-  · simp [h0]
-  have hik : i ≠ k := by
-    rintro rfl
-    rw [h.apply_eq_zero_symm h0] at hj
-    simp at hj
-  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik h0
-  omega
-
-/-- **At most one edge at an index is multiple.** An index carrying a multiple edge is joined to
-every other index by at most a single edge. This is the unconditional form of
-`TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le`: the non-adjacency of the two far ends,
-which that statement assumes, is supplied by the no-triangle theorem. -/
-theorem apply_mul_apply_le_one_of_two_le_of_ne (h : IsFiniteType A) {i j k : B} (hij : i ≠ j)
+/-- **At most one edge at an index is multiple.** An index carrying a multiple edge to `j` is
+joined to every index other than `j` by at most a single edge. No non-adjacency of the far ends is
+assumed: the no-triangle theorem supplies it. -/
+theorem apply_mul_apply_le_one_of_two_le (h : IsFiniteType A) {i j k : B} (hij : i ≠ j)
     (hik : i ≠ k) (hjk : j ≠ k) (hj : 2 ≤ A i j * A j i) :
     A i k * A k i ≤ 1 := by
-  -- Either `k` is not a neighbour of `i` at all, or the triangle `i, j, k` is forbidden.
+  -- Either `k` is not a neighbour of `i` at all, or the triangle `i, j, k` is forbidden and the
+  -- two-index case of the star bound applies.
   rcases eq_or_ne (A i k) 0 with h0 | h0
   · simp [h0]
   have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
-  exact h.apply_mul_apply_le_one_of_two_le
-    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0) hj
+  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik
+    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0)
+  omega
 
-/-- **A triple edge is isolated among the neighbours non-adjacent to its far end.** An index joined
-to `j` by a triple edge is joined to no further index non-adjacent to `j`. This is the local step
-behind `G₂` being the only finite-type diagram carrying a triple edge. -/
-theorem apply_eq_zero_of_apply_mul_apply_eq_three (h : IsFiniteType A) {i j k : B} (h0 : A j k = 0)
-    (hj : A i j * A j i = 3) :
+/-- **A triple edge is isolated.** An index joined to `j` by a triple edge is joined to no index
+other than `j` at all; applied at both ends of the edge this says that a triple edge is a connected
+component of the diagram, which is why `G₂` has rank `2`. Here `i ≠ j` need not be assumed: it
+follows from the Cartan product being `3` rather than the diagonal value `4`. -/
+theorem apply_eq_zero_of_apply_mul_apply_eq_three (h : IsFiniteType A) {i j k : B} (hik : i ≠ k)
+    (hjk : j ≠ k) (hj : A i j * A j i = 3) :
     A i k = 0 := by
-  -- A Cartan product of `3` is neither the diagonal value `4` nor the absent edge from `k` to `j`.
   have hij : i ≠ j := by
     rintro rfl
     rw [h.apply_self] at hj
     omega
-  have hik : i ≠ k := by
-    rintro rfl
-    rw [h.apply_eq_zero_symm h0] at hj
-    simp at hj
-  by_contra hne
-  have h1 := h.one_le_apply_mul_apply hne
-  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik h0
-  omega
-
-/-- **A triple edge is isolated.** An index carrying a triple edge is joined to no other index at
-all. This is the unconditional form of
-`TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three`, and applied at both ends of the
-edge it says that a triple edge is a connected component: it is why `G₂` has rank `2`. -/
-theorem apply_eq_zero_of_apply_mul_apply_eq_three_of_ne (h : IsFiniteType A) {i j k : B}
-    (hij : i ≠ j) (hik : i ≠ k) (hjk : j ≠ k) (hj : A i j * A j i = 3) :
-    A i k = 0 := by
   -- Were `k` a neighbour of `i` too, the triangle `i, j, k` would be forbidden.
   by_contra h0
   have hne : A i j ≠ 0 := fun hc ↦ by simp [hc] at hj
-  exact h0 (h.apply_eq_zero_of_apply_mul_apply_eq_three
-    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0) hj)
+  have h1 := h.one_le_apply_mul_apply h0
+  have := h.apply_mul_apply_add_apply_mul_apply_lt_four hij hik
+    (h.apply_eq_zero_of_apply_ne_zero hij hik hjk hne h0)
+  omega
 
 /-- **The degree bound: an index of a finite-type matrix has at most three neighbours**, so a
 finite-type diagram branches into at most three arms. By the no-triangle theorem the neighbours are
 automatically pairwise non-adjacent, so the star bound applies to them directly. -/
-theorem card_le_three (h : IsFiniteType A) {i : B} {s : Finset B} (his : i ∉ s)
-    (hadj : ∀ j ∈ s, A i j ≠ 0) :
+theorem card_le_three_of_forall_apply_ne_zero (h : IsFiniteType A) {i : B} {s : Finset B}
+    (his : i ∉ s) (hadj : ∀ j ∈ s, A i j ≠ 0) :
     s.card ≤ 3 := by
   have hone : ∀ j ∈ s, (1 : ℤ) ≤ A i j * A j i := fun j hj ↦
     h.one_le_apply_mul_apply (hadj j hj)
@@ -512,16 +484,10 @@ theorem card_le_three (h : IsFiniteType A) {i : B} {s : Finset B} (his : i ∉ s
   have := h.sum_apply_mul_apply_lt_four his (h.pairwise_apply_eq_zero his hadj)
   omega
 
-/-- **The degree bound, for the neighbourhood itself.** The indices joined to `i`, other than `i`,
-number at most three. -/
-theorem card_filter_le_three [DecidableEq B] (h : IsFiniteType A) (i : B) :
-    (Finset.univ.filter fun j ↦ j ≠ i ∧ A i j ≠ 0).card ≤ 3 :=
-  h.card_le_three (by simp) fun j hj ↦ (Finset.mem_filter.mp hj).2.2
-
 /-- **A three-armed star of a finite-type matrix is simply laced.** An index with three neighbours
 meets each of them along a single edge, since three Cartan products of value at least `1` already
-exhaust the star bound. Together with `TauCeti.IsFiniteType.card_le_three` this says that a branch
-vertex of a finite-type diagram carries exactly three simple edges. -/
+exhaust the star bound. Together with `TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero`
+this says that a branch vertex of a finite-type diagram carries exactly three simple edges. -/
 theorem apply_mul_apply_eq_one_of_three_le_card (h : IsFiniteType A) {i : B} {s : Finset B}
     (his : i ∉ s) (hadj : ∀ j ∈ s, A i j ≠ 0) (hcard : 3 ≤ s.card) {j : B} (hj : j ∈ s) :
     A i j * A j i = 1 := by
@@ -561,8 +527,10 @@ end IsFiniteType
 
 /-- **The Cartan matrix of the affine diagram `Ã₂` is not of finite type.** The three-cycle is a
 genuine generalized Cartan matrix, symmetric with every Cartan product equal to `1`, so neither the
-combinatorial axioms nor the rank-two bound exclude it; it is positive *semi*definite, and it is
-`TauCeti.IsFiniteType.det_ne_zero` that rules it out. -/
+combinatorial axioms nor the rank-two bound exclude it; it is positive *semi*definite. The proof
+below rules it out by `TauCeti.IsFiniteType.det_ne_zero`, which is merely the tool it uses: being a
+triangle, `Ã₂` is excluded by `TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` as well, and it
+is exactly the equality case of that estimate. -/
 theorem not_isFiniteType_affineA₂ :
     ¬ IsFiniteType (!![2, -1, -1; -1, 2, -1; -1, -1, 2] : Matrix (Fin 3) (Fin 3) ℤ) := by
   intro h
@@ -572,7 +540,8 @@ theorem not_isFiniteType_affineA₂ :
 
 /-- **The Cartan matrix of the affine diagram `D̃₄` is not of finite type.** The four-armed star is
 the smallest diagram excluded by the degree bound; unlike `Ã₂` it needs no determinant, since
-`TauCeti.IsFiniteType.card_le_three` applies to the central index directly. -/
+`TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero` applies to the central index
+directly. -/
 theorem not_isFiniteType_affineD₄ :
     ¬ IsFiniteType (!![2, -1, -1, -1, -1;
                       -1, 2, 0, 0, 0;
@@ -580,7 +549,8 @@ theorem not_isFiniteType_affineD₄ :
                       -1, 0, 0, 2, 0;
                       -1, 0, 0, 0, 2] : Matrix (Fin 5) (Fin 5) ℤ) := by
   intro h
-  have hcard := h.card_le_three (i := 0) (s := {1, 2, 3, 4}) (by decide) (by decide)
+  have hcard := h.card_le_three_of_forall_apply_ne_zero (i := 0) (s := {1, 2, 3, 4})
+    (by decide) (by decide)
   revert hcard
   decide
 


### PR DESCRIPTION
This PR proves that a finite-type Cartan matrix carries no triangle: two distinct neighbours of an index are never adjacent to one another. `TauCeti/LinearAlgebra/RootSystem/FiniteType.lean` already had the star bound and its consequences, but every one of them selected its neighbours through a pairwise non-adjacency hypothesis, and the file said so explicitly — "Turning them into the unconditional graph statements the classification runs on ... needs in addition that distinct neighbours of an index are never adjacent, that is, that a finite-type diagram carries no triangle. That exclusion is not proved here." This PR supplies that exclusion and discharges the hypothesis everywhere it was carried.

The target is `TauCetiRoadmap/RepresentationTheory/RootSystems/README.md`, Layer 5 (Dynkin diagrams and the Cartan-Killing classification), the bullet "The classification of finite-type Cartan matrices", which names as its combinatorial core "the positive-definiteness bound on subdiagrams (no vertex of degree `> 3`, at most one multiple edge, the chain/fork length constraints)". Those first two bounds are what land here, unconditionally, as prerequisites of that roadmap's `existsUnique_dynkinType`.

The proof is the second positive-definiteness estimate of the file, and a different one from the star bound. Where the star bound tests a vector supported on an index and a non-adjacent star around it, choosing each outer coordinate to minimise its own contribution, a triangle admits no such coordinatewise choice; instead the test vector is supported on all three indices of the triangle, and its coordinate at each of them is the weight, in the symmetrization, of the *opposite* edge. Writing `a`, `b`, `c` for the three edge weights — each negative, since the off-diagonal entries are — the symmetrized form evaluates there to `2(d₀c² + d₁b² + d₂a²) + 6abc`, and the identity `a² = d₀d₁·(A₀₁A₁₀)` rewrites this as `2P(α + β + γ) - 6m`, with `P` the product of the three symmetrizer values, `α`, `β`, `γ` the three Cartan products and `m = -abc > 0`. Squaring `3m < P(α + β + γ)` against `m² = P²αβγ` reduces positive definiteness to `9αβγ < (α + β + γ)²`, which the rank-two bound `α, β, γ ∈ {1, 2, 3}` refutes by a finite check. Nothing here leaves `ℚ`: the symmetrizer is rational, the test vector is built from rational edge weights rather than from the square roots the geometric argument would use, and the one place a square root would appear is squared away. Equality holds exactly at `α = β = γ = 1`, the affine diagram `Ã₂`.

`TauCeti.IsFiniteType.apply_eq_zero_of_apply_ne_zero` is the pointwise statement, `TauCeti.IsFiniteType.pairwise_apply_eq_zero` the same fact for a whole neighbourhood, in the shape the star bound consumes. With them every consequence of the star bound in the file is strengthened in place, by deleting the non-adjacency hypothesis it used to select its indices through. `TauCeti.IsFiniteType.card_le_three_of_forall_apply_ne_zero` (renamed from `card_le_three_of_pairwise_apply_eq_zero`, since the hypothesis it was named for is gone) and `TauCeti.IsFiniteType.apply_mul_apply_eq_one_of_three_le_card` lose their pairwise hypothesis, so the degree bound and the simply laced branch vertex now hold for any set of neighbours. `TauCeti.IsFiniteType.apply_mul_apply_add_apply_mul_apply_lt_four`, `TauCeti.IsFiniteType.apply_mul_apply_le_one_of_two_le` and `TauCeti.IsFiniteType.apply_eq_zero_of_apply_mul_apply_eq_three` trade the hypothesis `A j k = 0` for the bare `j ≠ k`, which is the unconditional form of, respectively, the two-index star bound, the fact that at most one edge at an index is multiple, and the fact that a triple edge is a connected component of the diagram. No statement in the file is left carrying a non-adjacency side condition.

`TauCeti.not_isFiniteType_doubleEdgeTriangle` records that the new tool is not subsumed by the old ones. That matrix is a generalized Cartan matrix, is symmetrizable by `d = (1, 2, 1)`, has all its Cartan products in the rank-two range, and is nonsingular with determinant `-6`, so neither the combinatorial axioms, nor the rank-two bound, nor `det_ne_zero` reaches it, and the star bound never applies; only the no-triangle theorem excludes it. The existing `not_isFiniteType_affineD₄` loses the pairwise side condition it used to discharge by `decide`.

No new module: the whole development belongs to the file whose stated gap it closes, and the module docstring is updated to match. No Mathlib infrastructure was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"finite-type-diagram-carries-no-triangle"}-->

🤖 Prepared with Claude Code

