### PR TITLE
feat: the elementary symmetric chart on Sym^n is a homeomorphism

### DIFF
--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -91,29 +91,6 @@ theorem continuous_coeff_prod_X_sub_C (s : Finset ι) (k : ℕ) :
 
 end Continuity
 
-/-! ### The chart read on ordered tuples
-
-These two lemmas are pure algebra; they live here because this is the first file in which both
-`TauCeti.Sym.ofFn` and `TauCeti.Sym.toMonic` are in scope. -/
-
-section Algebra
-
-variable {R K : Type*} [CommRing R] [Nontrivial R] [Field K] [IsAlgClosed K] {n : ℕ}
-
-/-- The monic polynomial of the unordered tuple underlying `f : Fin n → R` is the product of the
-corresponding linear factors. -/
-theorem toMonic_ofFn (f : Fin n → R) : (toMonic (ofFn f) : R[X]) = ∏ i, (X - C (f i)) := by
-  rw [coe_toMonic, coe_ofFn]
-  simp [← List.prod_ofFn, List.map_ofFn, Function.comp_def]
-
-/-- The chart of an unordered tuple presented by `f : Fin n → K` reads off the coefficients of the
-product of the linear factors of `f`. -/
-theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
-    coeffEquiv K n (ofFn f) i = (∏ j, (X - C (f j))).coeff i := by
-  rw [coeffEquiv_apply_eq_coeff, toMonic_ofFn]
-
-end Algebra
-
 section Chart
 
 variable {K : Type*} [NormedField K] [IsAlgClosed K] {n : ℕ}

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -61,21 +61,21 @@ namespace Sym
 
 section Continuity
 
-variable {ι K : Type*} [NormedField K]
+variable {ι R : Type*} [CommRing R] [TopologicalSpace R] [IsTopologicalRing R]
 
 /-- The coefficients of `∏ i ∈ s, (X - C (f i))` depend continuously on the tuple `f` of roots.
 
 This is the elementary half of the chart: each coefficient is, up to sign, an elementary symmetric
-function of the roots. -/
+function of the roots, so continuity of the ring operations is all that is used. -/
 theorem continuous_coeff_prod_X_sub_C (s : Finset ι) (k : ℕ) :
-    Continuous fun f : ι → K => (∏ i ∈ s, (X - C (f i))).coeff k := by
+    Continuous fun f : ι → R => (∏ i ∈ s, (X - C (f i))).coeff k := by
   classical
   induction s using Finset.induction_on generalizing k with
   | empty => simpa using continuous_const
   | @insert a s ha ih =>
     cases k with
     | zero =>
-      have hpt : (fun f : ι → K => (∏ i ∈ insert a s, (X - C (f i))).coeff 0) =
+      have hpt : (fun f : ι → R => (∏ i ∈ insert a s, (X - C (f i))).coeff 0) =
           fun f => -f a * (∏ i ∈ s, (X - C (f i))).coeff 0 := by
         funext f
         rw [Finset.prod_insert ha, mul_coeff_zero]
@@ -83,7 +83,7 @@ theorem continuous_coeff_prod_X_sub_C (s : Finset ι) (k : ℕ) :
       rw [hpt]
       exact (continuous_apply a).neg.mul (ih 0)
     | succ k =>
-      have hpt : (fun f : ι → K => (∏ i ∈ insert a s, (X - C (f i))).coeff (k + 1)) =
+      have hpt : (fun f : ι → R => (∏ i ∈ insert a s, (X - C (f i))).coeff (k + 1)) =
           fun f => (∏ i ∈ s, (X - C (f i))).coeff k
             - f a * (∏ i ∈ s, (X - C (f i))).coeff (k + 1) := by
         funext f
@@ -93,23 +93,32 @@ theorem continuous_coeff_prod_X_sub_C (s : Finset ι) (k : ℕ) :
 
 end Continuity
 
-section Chart
+/-! ### The chart read on ordered tuples
 
-variable {K : Type*} [NormedField K] {n : ℕ}
+These two lemmas are pure algebra; they live here because this is the first file in which both
+`TauCeti.Sym.ofFn` and `TauCeti.Sym.toMonic` are in scope. -/
 
-/-- The monic polynomial of the unordered tuple underlying `f : Fin n → K` is the product of the
+section Algebra
+
+variable {R K : Type*} [CommRing R] [Nontrivial R] [Field K] [IsAlgClosed K] {n : ℕ}
+
+/-- The monic polynomial of the unordered tuple underlying `f : Fin n → R` is the product of the
 corresponding linear factors. -/
-theorem toMonic_ofFn (f : Fin n → K) : (toMonic (ofFn f) : K[X]) = ∏ i, (X - C (f i)) := by
+theorem toMonic_ofFn (f : Fin n → R) : (toMonic (ofFn f) : R[X]) = ∏ i, (X - C (f i)) := by
   rw [coe_toMonic, coe_ofFn]
   simp [← List.prod_ofFn, List.map_ofFn, Function.comp_def]
-
-variable [IsAlgClosed K]
 
 /-- The chart of an unordered tuple presented by `f : Fin n → K` reads off the coefficients of the
 product of the linear factors of `f`. -/
 theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
     coeffEquiv K n (ofFn f) i = (∏ j, (X - C (f j))).coeff i := by
   rw [coeffEquiv_apply_eq_coeff, toMonic_ofFn]
+
+end Algebra
+
+section Chart
+
+variable {K : Type*} [NormedField K] [IsAlgClosed K] {n : ℕ}
 
 /-- The coefficient map `(Fin n → K) → (Fin n → K)`, the elementary symmetric chart read on ordered
 tuples, is continuous. -/
@@ -128,16 +137,16 @@ theorem norm_le_norm_coeffEquiv_ofFn_add_one (f : Fin n → K) :
   have hnonneg : (0 : ℝ) ≤ ‖coeffEquiv K n (ofFn f)‖ + 1 := by positivity
   refine (pi_norm_le_iff_of_nonneg hnonneg).2 fun j => ?_
   have hmonic : (toMonic (ofFn f) : K[X]).Monic := monic_toMonic _
-  have hroot : (toMonic (ofFn f) : K[X]).IsRoot (f j) := mem_iff_isRoot.1 (mem_ofFn.2 ⟨j, rfl⟩)
+  have hroot : (toMonic (ofFn f) : K[X]).IsRoot (f j) :=
+    mem_iff_isRoot.1 (_root_.Sym.mem_coe.2 (mem_ofFn.2 ⟨j, rfl⟩))
   have hcauchy := hroot.norm_lt_cauchyBound hmonic.ne_zero
   have hbound : cauchyBound (toMonic (ofFn f) : K[X]) ≤ ‖coeffEquiv K n (ofFn f)‖₊ + 1 := by
     have hsup : ((Finset.range n).sup fun i => ‖(toMonic (ofFn f) : K[X]).coeff i‖₊)
         ≤ ‖coeffEquiv K n (ofFn f)‖₊ := by
       refine Finset.sup_le fun i hi => ?_
       rw [Finset.mem_range] at hi
-      rw [show (toMonic (ofFn f) : K[X]).coeff i = coeffEquiv K n (ofFn f) ⟨i, hi⟩ from
-        (coeffEquiv_apply_eq_coeff _ ⟨i, hi⟩).symm]
-      exact nnnorm_le_pi_nnnorm _ _
+      have hcoord := nnnorm_le_pi_nnnorm (coeffEquiv K n (ofFn f)) ⟨i, hi⟩
+      rwa [coeffEquiv_apply_eq_coeff] at hcoord
     rw [cauchyBound, hmonic.leadingCoeff, nnnorm_one, div_one, natDegree_toMonic]
     exact add_le_add hsup le_rfl
   have : ‖f j‖₊ < ‖coeffEquiv K n (ofFn f)‖₊ + 1 := hcauchy.trans_le hbound
@@ -161,8 +170,8 @@ theorem isClosedMap_coeffEquiv : IsClosedMap (coeffEquiv K n) := by
   intro C hC
   have himage : coeffEquiv K n '' C =
       (fun f : Fin n → K => coeffEquiv K n (ofFn f)) '' (ofFn ⁻¹' C) := by
-    rw [show (fun f : Fin n → K => coeffEquiv K n (ofFn f)) = coeffEquiv K n ∘ ofFn from rfl,
-      Set.image_comp, Set.image_preimage_eq _ ofFn_surjective]
+    rw [← Set.image_image (coeffEquiv K n) ofFn (ofFn ⁻¹' C),
+      Set.image_preimage_eq _ ofFn_surjective]
   rw [himage]
   exact isProperMap_coeffEquiv_comp_ofFn.isClosedMap _ (hC.preimage continuous_ofFn)
 
@@ -175,24 +184,20 @@ continuously and with continuous inverse, by the lower coefficients of its monic
 Continuity of the inverse is the classical continuity of the roots of a monic polynomial in its
 coefficients; it comes from `TauCeti.Sym.isProperMap_coeffEquiv_comp_ofFn`, and hence from Cauchy's
 bound. -/
-@[expose]
-noncomputable def coeffHomeomorph : Sym K n ≃ₜ (Fin n → K) where
-  toEquiv := coeffEquiv K n
-  continuous_toFun := continuous_iff_comp_ofFn.2 continuous_coeffEquiv_comp_ofFn
-  continuous_invFun := continuous_iff_isClosed.2 fun C hC => by
-    rw [Equiv.invFun_as_coe, ← Equiv.image_eq_preimage_symm]
-    exact isClosedMap_coeffEquiv C hC
+noncomputable def coeffHomeomorph : Sym K n ≃ₜ (Fin n → K) :=
+  (coeffEquiv K n).toHomeomorphOfContinuousClosed
+    (continuous_iff_comp_ofFn.2 continuous_coeffEquiv_comp_ofFn) isClosedMap_coeffEquiv
 
 /-- The chart homeomorphism is the chart equivalence. -/
 @[simp]
-theorem coeffHomeomorph_apply (s : Sym K n) : coeffHomeomorph K n s = coeffEquiv K n s :=
-  rfl
+theorem coeffHomeomorph_apply (s : Sym K n) : coeffHomeomorph K n s = coeffEquiv K n s := by
+  simp [coeffHomeomorph]
 
 /-- The inverse chart homeomorphism is the inverse chart equivalence. -/
 @[simp]
 theorem coeffHomeomorph_symm_apply (f : Fin n → K) :
-    ((coeffHomeomorph K n).symm f : Sym K n) = (coeffEquiv K n).symm f :=
-  rfl
+    ((coeffHomeomorph K n).symm f : Sym K n) = (coeffEquiv K n).symm f := by
+  simp [coeffHomeomorph]
 
 variable {K n}
 

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -38,8 +38,6 @@ Both halves are elementary, but neither is formal:
 * `TauCeti.Sym.isProperMap_coeffEquiv_comp_ofFn`: consequently the coefficient map
   `(Fin n → K) → (Fin n → K)` is proper.
 * `TauCeti.Sym.coeffHomeomorph`: the **elementary symmetric chart** `Sym K n ≃ₜ (Fin n → K)`.
-* `TauCeti.Sym.isClosedMap_ofFn` and `TauCeti.Sym.instT2Space`: the quotient map is closed and the
-  symmetric power is Hausdorff.
 
 Lane F4.1 of the analytic Heegaard Floer roadmap opens with "`Sym^g(Σ)` geometry: smooth complex
 structure (elementary symmetric functions)", after Ozsváth--Szabó
@@ -198,22 +196,6 @@ theorem coeffHomeomorph_apply (s : Sym K n) : coeffHomeomorph K n s = coeffEquiv
 theorem coeffHomeomorph_symm_apply (f : Fin n → K) :
     ((coeffHomeomorph K n).symm f : Sym K n) = (coeffEquiv K n).symm f := by
   simp [coeffHomeomorph]
-
-variable {K n}
-
-/-- The quotient map from ordered to unordered tuples is closed. -/
-theorem isClosedMap_ofFn : IsClosedMap (ofFn : (Fin n → K) → Sym K n) := by
-  have : (ofFn : (Fin n → K) → Sym K n) =
-      (coeffHomeomorph K n).symm ∘ fun f => coeffEquiv K n (ofFn f) := by
-    funext f
-    simp
-  rw [this]
-  exact (coeffHomeomorph K n).symm.isClosedMap.comp isProperMap_coeffEquiv_comp_ofFn.isClosedMap
-
-/-- The symmetric power of a proper algebraically closed normed field is Hausdorff, being
-homeomorphic to affine space. -/
-instance instT2Space : T2Space (Sym K n) :=
-  (coeffHomeomorph K n).isEmbedding.t2Space
 
 end Chart
 

--- a/TauCeti/Analysis/Polynomial/SymmetricPower.lean
+++ b/TauCeti/Analysis/Polynomial/SymmetricPower.lean
@@ -1,0 +1,217 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Analysis.Normed.Group.Bounded
+public import Mathlib.Analysis.Polynomial.CauchyBound
+public import Mathlib.Topology.Algebra.Polynomial
+public import TauCeti.RingTheory.Polynomial.SymmetricPower
+public import TauCeti.Topology.Sym
+
+/-!
+# The elementary symmetric chart is a homeomorphism
+
+`TauCeti.Sym.coeffEquiv` presents the `n`-th symmetric power of an algebraically closed field `K`
+as the affine space `Fin n → K`, by sending an unordered `n`-tuple to the lower coefficients of the
+monic polynomial having it as its root multiset. That equivalence is pure algebra. This file proves
+that, when `K` is a proper normed field — `ℂ` being the case of interest — it is a
+**homeomorphism** for the quotient topology of `TauCeti.Sym.instTopologicalSpace`.
+
+Both halves are elementary, but neither is formal:
+
+* the coefficients are polynomial in the roots, so the chart is continuous;
+* the roots are *not* a polynomial function of the coefficients, and continuity of the inverse is
+  the classical statement that the roots of a monic polynomial depend continuously on its
+  coefficients. It is obtained here from **Cauchy's bound** `Polynomial.cauchyBound`: a root of a
+  monic polynomial is bounded by its coefficients, so the coefficient map is proper, hence closed,
+  and a closed continuous bijection is a homeomorphism.
+
+## Main declarations
+
+* `TauCeti.Sym.continuous_coeffEquiv_comp_ofFn`: the coefficients depend continuously on an
+  ordered tuple of roots.
+* `TauCeti.Sym.norm_le_norm_coeffEquiv_ofFn_add_one`: Cauchy's bound on the symmetric power, that
+  an ordered tuple is bounded by one more than the norm of its coefficient tuple.
+* `TauCeti.Sym.isProperMap_coeffEquiv_comp_ofFn`: consequently the coefficient map
+  `(Fin n → K) → (Fin n → K)` is proper.
+* `TauCeti.Sym.coeffHomeomorph`: the **elementary symmetric chart** `Sym K n ≃ₜ (Fin n → K)`.
+* `TauCeti.Sym.isClosedMap_ofFn` and `TauCeti.Sym.instT2Space`: the quotient map is closed and the
+  symmetric power is Hausdorff.
+
+Lane F4.1 of the analytic Heegaard Floer roadmap opens with "`Sym^g(Σ)` geometry: smooth complex
+structure (elementary symmetric functions)", after Ozsváth--Szabó
+([arXiv:math/0101206](https://arxiv.org/abs/math/0101206), §2.1): a holomorphic coordinate on the
+surface identifies a neighbourhood in `Sym^g(Σ)` with an open subset of `Sym^g(ℂ)`, and the chart
+below is what makes that a chart on a topological manifold. The complex structure itself, and the
+totally real tori `T_α`, `T_β`, are separate later steps.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Polynomial
+
+namespace Sym
+
+/-! ### Continuity of the coefficients -/
+
+section Continuity
+
+variable {ι K : Type*} [NormedField K]
+
+/-- The coefficients of `∏ i ∈ s, (X - C (f i))` depend continuously on the tuple `f` of roots.
+
+This is the elementary half of the chart: each coefficient is, up to sign, an elementary symmetric
+function of the roots. -/
+theorem continuous_coeff_prod_X_sub_C (s : Finset ι) (k : ℕ) :
+    Continuous fun f : ι → K => (∏ i ∈ s, (X - C (f i))).coeff k := by
+  classical
+  induction s using Finset.induction_on generalizing k with
+  | empty => simpa using continuous_const
+  | @insert a s ha ih =>
+    cases k with
+    | zero =>
+      have hpt : (fun f : ι → K => (∏ i ∈ insert a s, (X - C (f i))).coeff 0) =
+          fun f => -f a * (∏ i ∈ s, (X - C (f i))).coeff 0 := by
+        funext f
+        rw [Finset.prod_insert ha, mul_coeff_zero]
+        simp
+      rw [hpt]
+      exact (continuous_apply a).neg.mul (ih 0)
+    | succ k =>
+      have hpt : (fun f : ι → K => (∏ i ∈ insert a s, (X - C (f i))).coeff (k + 1)) =
+          fun f => (∏ i ∈ s, (X - C (f i))).coeff k
+            - f a * (∏ i ∈ s, (X - C (f i))).coeff (k + 1) := by
+        funext f
+        rw [Finset.prod_insert ha, sub_mul, coeff_sub, coeff_X_mul, coeff_C_mul]
+      rw [hpt]
+      exact (ih k).sub ((continuous_apply a).mul (ih (k + 1)))
+
+end Continuity
+
+section Chart
+
+variable {K : Type*} [NormedField K] {n : ℕ}
+
+/-- The monic polynomial of the unordered tuple underlying `f : Fin n → K` is the product of the
+corresponding linear factors. -/
+theorem toMonic_ofFn (f : Fin n → K) : (toMonic (ofFn f) : K[X]) = ∏ i, (X - C (f i)) := by
+  rw [coe_toMonic, coe_ofFn]
+  simp [← List.prod_ofFn, List.map_ofFn, Function.comp_def]
+
+variable [IsAlgClosed K]
+
+/-- The chart of an unordered tuple presented by `f : Fin n → K` reads off the coefficients of the
+product of the linear factors of `f`. -/
+theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
+    coeffEquiv K n (ofFn f) i = (∏ j, (X - C (f j))).coeff i := by
+  rw [coeffEquiv_apply_eq_coeff, toMonic_ofFn]
+
+/-- The coefficient map `(Fin n → K) → (Fin n → K)`, the elementary symmetric chart read on ordered
+tuples, is continuous. -/
+@[continuity, fun_prop]
+theorem continuous_coeffEquiv_comp_ofFn :
+    Continuous fun f : Fin n → K => coeffEquiv K n (ofFn f) := by
+  refine continuous_pi fun i => ?_
+  simp only [coeffEquiv_ofFn_apply]
+  exact continuous_coeff_prod_X_sub_C Finset.univ i
+
+/-- **Cauchy's bound** on the symmetric power: the points of an unordered tuple are bounded by one
+more than the sup-norm of its elementary symmetric chart, because each of them is a root of the
+monic polynomial those coordinates present. -/
+theorem norm_le_norm_coeffEquiv_ofFn_add_one (f : Fin n → K) :
+    ‖f‖ ≤ ‖coeffEquiv K n (ofFn f)‖ + 1 := by
+  have hnonneg : (0 : ℝ) ≤ ‖coeffEquiv K n (ofFn f)‖ + 1 := by positivity
+  refine (pi_norm_le_iff_of_nonneg hnonneg).2 fun j => ?_
+  have hmonic : (toMonic (ofFn f) : K[X]).Monic := monic_toMonic _
+  have hroot : (toMonic (ofFn f) : K[X]).IsRoot (f j) := mem_iff_isRoot.1 (mem_ofFn.2 ⟨j, rfl⟩)
+  have hcauchy := hroot.norm_lt_cauchyBound hmonic.ne_zero
+  have hbound : cauchyBound (toMonic (ofFn f) : K[X]) ≤ ‖coeffEquiv K n (ofFn f)‖₊ + 1 := by
+    have hsup : ((Finset.range n).sup fun i => ‖(toMonic (ofFn f) : K[X]).coeff i‖₊)
+        ≤ ‖coeffEquiv K n (ofFn f)‖₊ := by
+      refine Finset.sup_le fun i hi => ?_
+      rw [Finset.mem_range] at hi
+      rw [show (toMonic (ofFn f) : K[X]).coeff i = coeffEquiv K n (ofFn f) ⟨i, hi⟩ from
+        (coeffEquiv_apply_eq_coeff _ ⟨i, hi⟩).symm]
+      exact nnnorm_le_pi_nnnorm _ _
+    rw [cauchyBound, hmonic.leadingCoeff, nnnorm_one, div_one, natDegree_toMonic]
+    exact add_le_add hsup le_rfl
+  have : ‖f j‖₊ < ‖coeffEquiv K n (ofFn f)‖₊ + 1 := hcauchy.trans_le hbound
+  simpa using (NNReal.coe_lt_coe.2 this).le
+
+variable [ProperSpace K]
+
+/-- The coefficient map is proper: bounded coefficients force bounded roots, by Cauchy's bound. -/
+theorem isProperMap_coeffEquiv_comp_ofFn :
+    IsProperMap fun f : Fin n → K => coeffEquiv K n (ofFn f) := by
+  rw [isProperMap_iff_tendsto_cocompact]
+  refine ⟨continuous_coeffEquiv_comp_ofFn, ?_⟩
+  rw [← Metric.cobounded_eq_cocompact, ← tendsto_norm_atTop_iff_cobounded]
+  refine tendsto_atTop_mono (fun f => ?_)
+    (tendsto_atTop_add_const_right _ (-1) tendsto_norm_cobounded_atTop)
+  have := norm_le_norm_coeffEquiv_ofFn_add_one f
+  linarith
+
+/-- The elementary symmetric chart is a closed map. -/
+theorem isClosedMap_coeffEquiv : IsClosedMap (coeffEquiv K n) := by
+  intro C hC
+  have himage : coeffEquiv K n '' C =
+      (fun f : Fin n → K => coeffEquiv K n (ofFn f)) '' (ofFn ⁻¹' C) := by
+    rw [show (fun f : Fin n → K => coeffEquiv K n (ofFn f)) = coeffEquiv K n ∘ ofFn from rfl,
+      Set.image_comp, Set.image_preimage_eq _ ofFn_surjective]
+  rw [himage]
+  exact isProperMap_coeffEquiv_comp_ofFn.isClosedMap _ (hC.preimage continuous_ofFn)
+
+variable (K n)
+
+/-- The **elementary symmetric chart** on the `n`-th symmetric power of a proper algebraically
+closed normed field is a homeomorphism onto affine `n`-space: an unordered `n`-tuple is determined,
+continuously and with continuous inverse, by the lower coefficients of its monic polynomial.
+
+Continuity of the inverse is the classical continuity of the roots of a monic polynomial in its
+coefficients; it comes from `TauCeti.Sym.isProperMap_coeffEquiv_comp_ofFn`, and hence from Cauchy's
+bound. -/
+@[expose]
+noncomputable def coeffHomeomorph : Sym K n ≃ₜ (Fin n → K) where
+  toEquiv := coeffEquiv K n
+  continuous_toFun := continuous_iff_comp_ofFn.2 continuous_coeffEquiv_comp_ofFn
+  continuous_invFun := continuous_iff_isClosed.2 fun C hC => by
+    rw [Equiv.invFun_as_coe, ← Equiv.image_eq_preimage_symm]
+    exact isClosedMap_coeffEquiv C hC
+
+/-- The chart homeomorphism is the chart equivalence. -/
+@[simp]
+theorem coeffHomeomorph_apply (s : Sym K n) : coeffHomeomorph K n s = coeffEquiv K n s :=
+  rfl
+
+/-- The inverse chart homeomorphism is the inverse chart equivalence. -/
+@[simp]
+theorem coeffHomeomorph_symm_apply (f : Fin n → K) :
+    ((coeffHomeomorph K n).symm f : Sym K n) = (coeffEquiv K n).symm f :=
+  rfl
+
+variable {K n}
+
+/-- The quotient map from ordered to unordered tuples is closed. -/
+theorem isClosedMap_ofFn : IsClosedMap (ofFn : (Fin n → K) → Sym K n) := by
+  have : (ofFn : (Fin n → K) → Sym K n) =
+      (coeffHomeomorph K n).symm ∘ fun f => coeffEquiv K n (ofFn f) := by
+    funext f
+    simp
+  rw [this]
+  exact (coeffHomeomorph K n).symm.isClosedMap.comp isProperMap_coeffEquiv_comp_ofFn.isClosedMap
+
+/-- The symmetric power of a proper algebraically closed normed field is Hausdorff, being
+homeomorphic to affine space. -/
+instance instT2Space : T2Space (Sym K n) :=
+  (coeffHomeomorph K n).isEmbedding.t2Space
+
+end Chart
+
+end Sym
+
+end TauCeti

--- a/TauCeti/Data/Sym/Basic.lean
+++ b/TauCeti/Data/Sym/Basic.lean
@@ -4,12 +4,28 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.Data.Fin.Tuple.Basic
 public import Mathlib.Data.Sym.Basic
+import Mathlib.Data.Fintype.EquivFin
+import Mathlib.Data.List.FinRange
 
 /-!
 # Basic lemmas for symmetric powers
 
-This file records small API extensions for Mathlib's symmetric powers.
+This file records small API extensions for Mathlib's symmetric powers, and the map
+`TauCeti.Sym.ofFn` reading an ordered `n`-tuple `f : Fin n → α` as an unordered one.
+
+`ofFn` presents `Sym α n` as a quotient of `Fin n → α`: it is surjective, and its fibres are the
+orbits of the permutation action, by `TauCeti.Sym.ofFn_eq_ofFn_iff`. Nothing here is topological;
+`TauCeti/Topology/Sym.lean` uses this to give `Sym α n` the quotient topology coinduced along
+`ofFn`.
+
+## Main declarations
+
+* `TauCeti.Sym.ofFn`: the ordered tuple `f : Fin n → α` read as a point of `Sym α n`, and
+  `TauCeti.Sym.ofFn_surjective`, that every unordered tuple arises this way.
+* `TauCeti.Sym.ofFn_eq_ofFn_iff`: two ordered tuples have the same underlying unordered tuple
+  exactly when one is a reindexing of the other by a permutation.
 -/
 
 public section
@@ -26,3 +42,75 @@ theorem map_append (f : X → Y) (s : Sym X d) (t : Sym X e) :
   Subtype.ext <| by simp [Multiset.map_add]
 
 end Sym
+
+namespace TauCeti
+
+namespace Sym
+
+variable {α : Type*} {n : ℕ}
+
+/-! ### Ordered tuples as unordered ones -/
+
+/-- The ordered `n`-tuple `f : Fin n → α` read as an unordered `n`-tuple.
+
+This is Mathlib's quotient map `Sym.ofVector` precomposed with `List.Vector.ofFn`; the `Fin n → α`
+form is the one that carries a product topology, so it is the map that `Sym α n` carries the
+quotient topology along in `TauCeti/Topology/Sym.lean`. -/
+def ofFn (f : Fin n → α) : Sym α n :=
+  Sym.ofVector (List.Vector.ofFn f)
+
+/-- The multiset underlying `ofFn f` is the list of values of `f`. -/
+@[simp]
+theorem coe_ofFn (f : Fin n → α) : (ofFn f : Multiset α) = ↑(List.ofFn f) :=
+  congrArg _ (List.Vector.toList_ofFn f)
+
+/-- The points of `ofFn f` are exactly the values of `f`. -/
+@[simp]
+theorem mem_ofFn {a : α} {f : Fin n → α} : a ∈ ofFn f ↔ ∃ i, f i = a := by
+  rw [← _root_.Sym.mem_coe, coe_ofFn]
+  simp
+
+/-- Every unordered `n`-tuple is the image of an ordered one: `ofFn` is the quotient map
+presenting `Sym α n` as a quotient of `Fin n → α`. -/
+theorem ofFn_surjective : Function.Surjective (ofFn : (Fin n → α) → Sym α n) := by
+  rintro ⟨s, hs⟩
+  obtain ⟨l, rfl⟩ : ∃ l : List α, (l : Multiset α) = s := ⟨s.toList, s.coe_toList⟩
+  have hlen : l.length = n := by simpa using hs
+  subst hlen
+  exact ⟨l.get, Subtype.ext (by simp)⟩
+
+/-- Prepending a point to an ordered tuple adjoins it to the unordered one. -/
+@[simp]
+theorem ofFn_cons (a : α) (f : Fin n → α) : ofFn (Fin.cons a f) = a ::ₛ ofFn f :=
+  Subtype.ext <| by simp [Sym.coe_cons, List.ofFn_succ]
+
+/-! ### The fibres of the quotient map -/
+
+/-- Reindexing an ordered tuple by a permutation leaves the underlying unordered tuple unchanged. -/
+theorem ofFn_comp_perm (σ : Equiv.Perm (Fin n)) (f : Fin n → α) : ofFn (f ∘ σ) = ofFn f :=
+  Sym.coe_injective <| by simpa using Multiset.coe_eq_coe.2 (σ.ofFn_comp_perm f)
+
+/-- Two ordered tuples have the same underlying unordered tuple exactly when one is a reindexing
+of the other: the fibres of `ofFn` are the orbits of the permutation action. -/
+theorem ofFn_eq_ofFn_iff {f g : Fin n → α} :
+    ofFn f = ofFn g ↔ ∃ σ : Equiv.Perm (Fin n), f ∘ σ = g := by
+  classical
+  refine ⟨fun h => ?_, ?_⟩
+  · -- the two tuples take each value the same number of times, so their fibres are equinumerous
+    have key : ∀ (u : Fin n → α) (c : α),
+        Fintype.card {i // u i = c} = Multiset.count c (↑(List.ofFn u) : Multiset α) := by
+      intro u c
+      have hmap : (↑(List.ofFn u) : Multiset α) = Multiset.map u Finset.univ.val := by
+        rw [List.ofFn_eq_map]; rfl
+      rw [Fintype.card_subtype, hmap, Multiset.count_map, ← Finset.filter_val, Finset.card_def]
+      simp [eq_comm]
+    have hcard : ∀ c : α, Fintype.card {i // g i = c} = Fintype.card {i // f i = c} := fun c => by
+      rw [key, key, ← coe_ofFn, ← coe_ofFn, h]
+    exact ⟨Equiv.ofFiberEquiv fun c => Fintype.equivOfCardEq (hcard c),
+      funext fun i => Equiv.ofFiberEquiv_map _ i⟩
+  · rintro ⟨σ, rfl⟩
+    exact (ofFn_comp_perm σ f).symm
+
+end Sym
+
+end TauCeti

--- a/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
+++ b/TauCeti/RingTheory/Polynomial/SymmetricPower.lean
@@ -5,10 +5,10 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.Data.Sym.Basic
 public import Mathlib.RingTheory.Polynomial.Basic
 public import Mathlib.RingTheory.Polynomial.Vieta
 public import Mathlib.FieldTheory.IsAlgClosed.Basic
+public import TauCeti.Data.Sym.Basic
 import Mathlib.Data.Fin.VecNotation
 
 /-!
@@ -48,6 +48,9 @@ are separate later steps.
   functions and `TauCeti.Sym.coeffEquiv_symm_apply` describing the inverse as a root-taking map.
 * `TauCeti.Sym.coeffEquiv_one_apply` and `TauCeti.Sym.coeffEquiv_two_apply`: the chart in degrees
   one and two, pinning down the sign convention.
+* `TauCeti.Sym.toMonic_ofFn` and `TauCeti.Sym.coeffEquiv_ofFn_apply`: read on an ordered tuple
+  `f : Fin n → R` through `TauCeti.Sym.ofFn`, the monic polynomial is the product
+  `∏ i, (X - C (f i))` of linear factors and the chart reads off its coefficients.
 
 Lane F4.1 of the analytic Heegaard Floer roadmap opens with "`Sym^g(Σ)` geometry: smooth complex
 structure (elementary symmetric functions), the totally real tori `T_α`, `T_β`, …", after
@@ -126,6 +129,12 @@ theorem toMonic_append (s : Sym R n) (t : Sym R m) :
     (toMonic (s.append t) : R[X]) = (toMonic s : R[X]) * (toMonic t : R[X]) := by
   simp only [coe_toMonic, Sym.coe_append]
   exact ofMultiset.map_add_eq_mul _ _
+
+/-- The monic polynomial of the unordered tuple underlying an ordered one `f : Fin n → R` is the
+product of the corresponding linear factors. -/
+theorem toMonic_ofFn (f : Fin n → R) : (toMonic (ofFn f) : R[X]) = ∏ i, (X - C (f i)) := by
+  rw [coe_toMonic, coe_ofFn]
+  simp [← List.prod_ofFn, List.map_ofFn, Function.comp_def]
 
 /-- The monic polynomial of a constant tuple is a pure power of a linear factor. -/
 @[simp]
@@ -276,6 +285,12 @@ tuple, in decreasing order and with alternating signs. -/
 theorem coeffEquiv_apply (s : Sym K n) (i : Fin n) :
     coeffEquiv K n s i = (-1) ^ (n - (i : ℕ)) * (s : Multiset K).esymm (n - (i : ℕ)) := by
   rw [coeffEquiv_apply_eq_coeff, coeff_toMonic s i.2.le]
+
+/-- The chart of an unordered tuple presented by an ordered one `f : Fin n → K` reads off the
+coefficients of the product of the linear factors of `f`. -/
+theorem coeffEquiv_ofFn_apply (f : Fin n → K) (i : Fin n) :
+    coeffEquiv K n (ofFn f) i = (∏ j, (X - C (f j))).coeff i := by
+  rw [coeffEquiv_apply_eq_coeff, toMonic_ofFn]
 
 /-- The inverse chart sends a coefficient tuple to the root multiset of the monic polynomial it
 determines. -/

--- a/TauCeti/Topology/Sym.lean
+++ b/TauCeti/Topology/Sym.lean
@@ -18,8 +18,8 @@ this file gives it the corresponding quotient topology, together with the API th
 topology is used through: the quotient map is continuous, and a map out of `Sym α n` is continuous
 exactly when its composition with the quotient map is.
 
-The quotient map is `TauCeti.Sym.ofFn`, which reads an ordered tuple as an unordered one. Mathlib
-already has the analogous map `Sym.ofVector` out of `List.Vector α n`; the `Fin n → α` form is the
+The quotient map is `TauCeti.Sym.ofFn`, which reads an ordered tuple as an unordered one. It is
+Mathlib's quotient map `Sym.ofVector` composed with `List.Vector.ofFn`; the `Fin n → α` form is the
 one that carries a product topology, so it is what the quotient topology is defined against.
 
 ## Main declarations
@@ -51,18 +51,20 @@ variable {α β : Type*} {n : ℕ}
 
 /-- The ordered `n`-tuple `f : Fin n → α` read as an unordered `n`-tuple.
 
-This is the map that `Sym α n` carries the quotient topology along. -/
-@[expose]
+This is Mathlib's quotient map `Sym.ofVector` precomposed with `List.Vector.ofFn`; it is the map
+that `Sym α n` carries the quotient topology along. -/
 def ofFn (f : Fin n → α) : Sym α n :=
-  ⟨↑(List.ofFn f), by simp⟩
+  Sym.ofVector (List.Vector.ofFn f)
 
 /-- The multiset underlying `ofFn f` is the list of values of `f`. -/
 @[simp]
 theorem coe_ofFn (f : Fin n → α) : (ofFn f : Multiset α) = ↑(List.ofFn f) :=
-  rfl
+  congrArg _ (List.Vector.toList_ofFn f)
 
 /-- The points of `ofFn f` are exactly the values of `f`. -/
-theorem mem_ofFn {a : α} {f : Fin n → α} : a ∈ (ofFn f : Multiset α) ↔ ∃ i, f i = a := by
+@[simp]
+theorem mem_ofFn {a : α} {f : Fin n → α} : a ∈ ofFn f ↔ ∃ i, f i = a := by
+  rw [← _root_.Sym.mem_coe, coe_ofFn]
   simp
 
 /-- Every unordered `n`-tuple is the image of an ordered one: `ofFn` is the quotient map

--- a/TauCeti/Topology/Sym.lean
+++ b/TauCeti/Topology/Sym.lean
@@ -8,6 +8,7 @@ module
 public import Mathlib.Data.Sym.Basic
 public import Mathlib.Topology.Compactness.Compact
 public import Mathlib.Topology.Constructions
+public import Mathlib.Topology.Separation.Hausdorff
 
 /-!
 # The symmetric power of a topological space
@@ -26,10 +27,15 @@ one that carries a product topology, so it is what the quotient topology is defi
 
 * `TauCeti.Sym.ofFn`: the ordered tuple `f : Fin n → α` read as a point of `Sym α n`, and
   `TauCeti.Sym.ofFn_surjective`, that every unordered tuple arises this way.
+* `TauCeti.Sym.ofFn_eq_ofFn_iff`: two ordered tuples have the same underlying unordered tuple
+  exactly when one is a reindexing of the other by a permutation.
 * `TauCeti.Sym.instTopologicalSpace`: the quotient topology on `Sym α n`, coinduced along `ofFn`.
 * `TauCeti.Sym.isQuotientMap_ofFn`, `TauCeti.Sym.continuous_ofFn` and
   `TauCeti.Sym.continuous_iff_comp_ofFn`: the resulting quotient-map API.
-* `TauCeti.Sym.instCompactSpace`: the symmetric power of a compact space is compact.
+* `TauCeti.Sym.isOpenMap_ofFn` and `TauCeti.Sym.isClosedMap_ofFn`: the quotient map is open and
+  closed, the permutation group being finite.
+* `TauCeti.Sym.instCompactSpace` and `TauCeti.Sym.instT2Space`: the symmetric power of a compact
+  space is compact, and that of a Hausdorff space is Hausdorff.
 
 Lane F4.1 of the analytic Heegaard Floer roadmap needs `Sym^g(Σ)` as a space before it can be
 given a complex structure; this file supplies the underlying topology, and
@@ -81,6 +87,45 @@ theorem ofFn_surjective : Function.Surjective (ofFn : (Fin n → α) → Sym α 
 theorem ofFn_cons (a : α) (f : Fin n → α) : ofFn (Fin.cons a f) = a ::ₛ ofFn f :=
   Subtype.ext <| by simp [Sym.coe_cons, List.ofFn_succ]
 
+/-! ### The fibres of the quotient map -/
+
+/-- Reindexing an ordered tuple by a permutation leaves the underlying unordered tuple unchanged. -/
+theorem ofFn_comp_perm (σ : Equiv.Perm (Fin n)) (f : Fin n → α) : ofFn (f ∘ σ) = ofFn f :=
+  Sym.coe_injective <| by simpa using Multiset.coe_eq_coe.2 (σ.ofFn_comp_perm f)
+
+/-- Two ordered tuples have the same underlying unordered tuple exactly when one is a reindexing
+of the other: the fibres of `ofFn` are the orbits of the permutation action. -/
+theorem ofFn_eq_ofFn_iff {f g : Fin n → α} :
+    ofFn f = ofFn g ↔ ∃ σ : Equiv.Perm (Fin n), f ∘ σ = g := by
+  classical
+  refine ⟨fun h => ?_, ?_⟩
+  · -- the two tuples take each value the same number of times, so their fibres are equinumerous
+    have key : ∀ (u : Fin n → α) (c : α),
+        Fintype.card {i // u i = c} = Multiset.count c (↑(List.ofFn u) : Multiset α) := by
+      intro u c
+      have hmap : (↑(List.ofFn u) : Multiset α) = Multiset.map u Finset.univ.val := by
+        rw [List.ofFn_eq_map]; rfl
+      rw [Fintype.card_subtype, hmap, Multiset.count_map, ← Finset.filter_val, Finset.card_def]
+      simp [eq_comm]
+    have hcard : ∀ c : α, Fintype.card {i // g i = c} = Fintype.card {i // f i = c} := fun c => by
+      rw [key, key, ← coe_ofFn, ← coe_ofFn, h]
+    exact ⟨Equiv.ofFiberEquiv fun c => Fintype.equivOfCardEq (hcard c),
+      funext fun i => Equiv.ofFiberEquiv_map _ i⟩
+  · rintro ⟨σ, rfl⟩
+    exact (ofFn_comp_perm σ f).symm
+
+/-- The saturation of a set of ordered tuples under `ofFn` is the union of its reindexings. -/
+theorem preimage_image_ofFn (s : Set (Fin n → α)) :
+    ofFn ⁻¹' (ofFn '' s) = ⋃ σ : Equiv.Perm (Fin n), (· ∘ σ) ⁻¹' s := by
+  ext g
+  simp only [Set.mem_preimage, Set.mem_image, Set.mem_iUnion]
+  constructor
+  · rintro ⟨f, hf, hfg⟩
+    obtain ⟨σ, rfl⟩ := ofFn_eq_ofFn_iff.1 hfg
+    exact ⟨σ.symm, by simpa [Function.comp_assoc] using hf⟩
+  · rintro ⟨σ, hσ⟩
+    exact ⟨g ∘ σ, hσ, ofFn_comp_perm σ g⟩
+
 /-! ### The quotient topology -/
 
 variable [TopologicalSpace α] [TopologicalSpace β]
@@ -105,12 +150,38 @@ tuples is; this is the universal property of the quotient topology. -/
 theorem continuous_iff_comp_ofFn {g : Sym α n → β} : Continuous g ↔ Continuous (g ∘ ofFn) :=
   isQuotientMap_ofFn.continuous_iff
 
+/-- The quotient map onto the symmetric power is open: the saturation of an open set is the union
+of its reindexings, each of them open. -/
+theorem isOpenMap_ofFn : IsOpenMap (ofFn : (Fin n → α) → Sym α n) := fun s hs => by
+  rw [← isQuotientMap_ofFn.isCoinducing.isOpen_preimage, preimage_image_ofFn]
+  exact isOpen_iUnion fun σ => hs.preimage (Pi.continuous_precomp σ)
+
+/-- The quotient map onto the symmetric power is closed: the saturation of a closed set is the
+union of its reindexings, a *finite* union of closed sets. -/
+theorem isClosedMap_ofFn : IsClosedMap (ofFn : (Fin n → α) → Sym α n) := fun s hs => by
+  rw [← isQuotientMap_ofFn.isCoinducing.isClosed_preimage, preimage_image_ofFn]
+  exact isClosed_iUnion_of_finite fun σ => hs.preimage (Pi.continuous_precomp σ)
+
 /-- The symmetric power of a compact space is compact, being a continuous image of a finite power
 of that space. -/
 instance instCompactSpace [CompactSpace α] : CompactSpace (Sym α n) :=
   ⟨by
     rw [← Set.image_univ_of_surjective (ofFn_surjective (α := α) (n := n))]
     exact isCompact_univ.image continuous_ofFn⟩
+
+/-- The symmetric power of a Hausdorff space is Hausdorff: `ofFn` is an open quotient map, and the
+relation it induces is the finite union, over permutations, of the graphs of the reindexing maps,
+hence closed. -/
+instance instT2Space [T2Space α] : T2Space (Sym α n) := by
+  rw [t2Space_iff_of_isOpenQuotientMap
+    (.of_isOpenMap_isQuotientMap isOpenMap_ofFn isQuotientMap_ofFn)]
+  have hrel : {q : (Fin n → α) × (Fin n → α) | ofFn q.1 = ofFn q.2} =
+      ⋃ σ : Equiv.Perm (Fin n), {q : (Fin n → α) × (Fin n → α) | q.1 ∘ σ = q.2} := by
+    ext q
+    simpa using ofFn_eq_ofFn_iff
+  rw [hrel]
+  exact isClosed_iUnion_of_finite fun σ =>
+    isClosed_eq ((Pi.continuous_precomp σ).comp continuous_fst) continuous_snd
 
 end Sym
 

--- a/TauCeti/Topology/Sym.lean
+++ b/TauCeti/Topology/Sym.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Data.Sym.Basic
+public import Mathlib.Topology.Compactness.Compact
+public import Mathlib.Topology.Constructions
+
+/-!
+# The symmetric power of a topological space
+
+The `n`-th symmetric power `Sym α n` of a type is the type of unordered `n`-tuples of points of
+`α`. It is the quotient of the space `Fin n → α` of ordered tuples by the permutation action, and
+this file gives it the corresponding quotient topology, together with the API that a quotient
+topology is used through: the quotient map is continuous, and a map out of `Sym α n` is continuous
+exactly when its composition with the quotient map is.
+
+The quotient map is `TauCeti.Sym.ofFn`, which reads an ordered tuple as an unordered one. Mathlib
+already has the analogous map `Sym.ofVector` out of `List.Vector α n`; the `Fin n → α` form is the
+one that carries a product topology, so it is what the quotient topology is defined against.
+
+## Main declarations
+
+* `TauCeti.Sym.ofFn`: the ordered tuple `f : Fin n → α` read as a point of `Sym α n`, and
+  `TauCeti.Sym.ofFn_surjective`, that every unordered tuple arises this way.
+* `TauCeti.Sym.instTopologicalSpace`: the quotient topology on `Sym α n`, coinduced along `ofFn`.
+* `TauCeti.Sym.isQuotientMap_ofFn`, `TauCeti.Sym.continuous_ofFn` and
+  `TauCeti.Sym.continuous_iff_comp_ofFn`: the resulting quotient-map API.
+* `TauCeti.Sym.instCompactSpace`: the symmetric power of a compact space is compact.
+
+Lane F4.1 of the analytic Heegaard Floer roadmap needs `Sym^g(Σ)` as a space before it can be
+given a complex structure; this file supplies the underlying topology, and
+`TauCeti/Analysis/Polynomial/SymmetricPower.lean` identifies it, over an algebraically closed
+normed field, with affine space through the elementary symmetric functions.
+-/
+
+public section
+
+open Topology
+
+namespace TauCeti
+
+namespace Sym
+
+variable {α β : Type*} {n : ℕ}
+
+/-! ### Ordered tuples as unordered ones -/
+
+/-- The ordered `n`-tuple `f : Fin n → α` read as an unordered `n`-tuple.
+
+This is the map that `Sym α n` carries the quotient topology along. -/
+@[expose]
+def ofFn (f : Fin n → α) : Sym α n :=
+  ⟨↑(List.ofFn f), by simp⟩
+
+/-- The multiset underlying `ofFn f` is the list of values of `f`. -/
+@[simp]
+theorem coe_ofFn (f : Fin n → α) : (ofFn f : Multiset α) = ↑(List.ofFn f) :=
+  rfl
+
+/-- The points of `ofFn f` are exactly the values of `f`. -/
+theorem mem_ofFn {a : α} {f : Fin n → α} : a ∈ (ofFn f : Multiset α) ↔ ∃ i, f i = a := by
+  simp
+
+/-- Every unordered `n`-tuple is the image of an ordered one: `ofFn` is the quotient map
+presenting `Sym α n` as a quotient of `Fin n → α`. -/
+theorem ofFn_surjective : Function.Surjective (ofFn : (Fin n → α) → Sym α n) := by
+  rintro ⟨s, hs⟩
+  obtain ⟨l, rfl⟩ : ∃ l : List α, (l : Multiset α) = s := ⟨s.toList, s.coe_toList⟩
+  have hlen : l.length = n := by simpa using hs
+  subst hlen
+  exact ⟨l.get, Subtype.ext (by simp)⟩
+
+/-- Prepending a point to an ordered tuple adjoins it to the unordered one. -/
+@[simp]
+theorem ofFn_cons (a : α) (f : Fin n → α) : ofFn (Fin.cons a f) = a ::ₛ ofFn f :=
+  Subtype.ext <| by simp [Sym.coe_cons, List.ofFn_succ]
+
+/-! ### The quotient topology -/
+
+variable [TopologicalSpace α] [TopologicalSpace β]
+
+/-- The `n`-th symmetric power of a topological space carries the quotient topology of the
+permutation action on ordered `n`-tuples, presented as the topology coinduced along
+`TauCeti.Sym.ofFn`. -/
+instance instTopologicalSpace : TopologicalSpace (Sym α n) :=
+  .coinduced ofFn inferInstance
+
+/-- The quotient map onto the symmetric power is continuous. -/
+@[continuity, fun_prop]
+theorem continuous_ofFn : Continuous (ofFn : (Fin n → α) → Sym α n) :=
+  continuous_coinduced_rng
+
+/-- `ofFn` presents `Sym α n` as a topological quotient of `Fin n → α`. -/
+theorem isQuotientMap_ofFn : IsQuotientMap (ofFn : (Fin n → α) → Sym α n) :=
+  ⟨⟨rfl⟩, ofFn_surjective⟩
+
+/-- A map out of a symmetric power is continuous exactly when the associated map on ordered
+tuples is; this is the universal property of the quotient topology. -/
+theorem continuous_iff_comp_ofFn {g : Sym α n → β} : Continuous g ↔ Continuous (g ∘ ofFn) :=
+  isQuotientMap_ofFn.continuous_iff
+
+/-- The symmetric power of a compact space is compact, being a continuous image of a finite power
+of that space. -/
+instance instCompactSpace [CompactSpace α] : CompactSpace (Sym α n) :=
+  ⟨by
+    rw [← Set.image_univ_of_surjective (ofFn_surjective (α := α) (n := n))]
+    exact isCompact_univ.image continuous_ofFn⟩
+
+end Sym
+
+end TauCeti

--- a/TauCeti/Topology/Sym.lean
+++ b/TauCeti/Topology/Sym.lean
@@ -5,10 +5,10 @@ Authors: Claude
 -/
 module
 
-public import Mathlib.Data.Sym.Basic
 public import Mathlib.Topology.Compactness.Compact
 public import Mathlib.Topology.Constructions
 public import Mathlib.Topology.Separation.Hausdorff
+public import TauCeti.Data.Sym.Basic
 
 /-!
 # The symmetric power of a topological space
@@ -19,16 +19,16 @@ this file gives it the corresponding quotient topology, together with the API th
 topology is used through: the quotient map is continuous, and a map out of `Sym α n` is continuous
 exactly when its composition with the quotient map is.
 
-The quotient map is `TauCeti.Sym.ofFn`, which reads an ordered tuple as an unordered one. It is
-Mathlib's quotient map `Sym.ofVector` composed with `List.Vector.ofFn`; the `Fin n → α` form is the
-one that carries a product topology, so it is what the quotient topology is defined against.
+The quotient map is `TauCeti.Sym.ofFn` of `TauCeti/Data/Sym/Basic.lean`, which reads an ordered
+tuple as an unordered one; the `Fin n → α` form is the one that carries a product topology, so it
+is what the quotient topology is defined against. Its surjectivity and the description
+`TauCeti.Sym.ofFn_eq_ofFn_iff` of its fibres as the orbits of the permutation action are the two
+facts about it used below.
 
 ## Main declarations
 
-* `TauCeti.Sym.ofFn`: the ordered tuple `f : Fin n → α` read as a point of `Sym α n`, and
-  `TauCeti.Sym.ofFn_surjective`, that every unordered tuple arises this way.
-* `TauCeti.Sym.ofFn_eq_ofFn_iff`: two ordered tuples have the same underlying unordered tuple
-  exactly when one is a reindexing of the other by a permutation.
+* `TauCeti.Sym.preimage_image_ofFn`: the saturation of a set of ordered tuples under `ofFn` is the
+  union of its reindexings.
 * `TauCeti.Sym.instTopologicalSpace`: the quotient topology on `Sym α n`, coinduced along `ofFn`.
 * `TauCeti.Sym.isQuotientMap_ofFn`, `TauCeti.Sym.continuous_ofFn` and
   `TauCeti.Sym.continuous_iff_comp_ofFn`: the resulting quotient-map API.
@@ -53,66 +53,7 @@ namespace Sym
 
 variable {α β : Type*} {n : ℕ}
 
-/-! ### Ordered tuples as unordered ones -/
-
-/-- The ordered `n`-tuple `f : Fin n → α` read as an unordered `n`-tuple.
-
-This is Mathlib's quotient map `Sym.ofVector` precomposed with `List.Vector.ofFn`; it is the map
-that `Sym α n` carries the quotient topology along. -/
-def ofFn (f : Fin n → α) : Sym α n :=
-  Sym.ofVector (List.Vector.ofFn f)
-
-/-- The multiset underlying `ofFn f` is the list of values of `f`. -/
-@[simp]
-theorem coe_ofFn (f : Fin n → α) : (ofFn f : Multiset α) = ↑(List.ofFn f) :=
-  congrArg _ (List.Vector.toList_ofFn f)
-
-/-- The points of `ofFn f` are exactly the values of `f`. -/
-@[simp]
-theorem mem_ofFn {a : α} {f : Fin n → α} : a ∈ ofFn f ↔ ∃ i, f i = a := by
-  rw [← _root_.Sym.mem_coe, coe_ofFn]
-  simp
-
-/-- Every unordered `n`-tuple is the image of an ordered one: `ofFn` is the quotient map
-presenting `Sym α n` as a quotient of `Fin n → α`. -/
-theorem ofFn_surjective : Function.Surjective (ofFn : (Fin n → α) → Sym α n) := by
-  rintro ⟨s, hs⟩
-  obtain ⟨l, rfl⟩ : ∃ l : List α, (l : Multiset α) = s := ⟨s.toList, s.coe_toList⟩
-  have hlen : l.length = n := by simpa using hs
-  subst hlen
-  exact ⟨l.get, Subtype.ext (by simp)⟩
-
-/-- Prepending a point to an ordered tuple adjoins it to the unordered one. -/
-@[simp]
-theorem ofFn_cons (a : α) (f : Fin n → α) : ofFn (Fin.cons a f) = a ::ₛ ofFn f :=
-  Subtype.ext <| by simp [Sym.coe_cons, List.ofFn_succ]
-
 /-! ### The fibres of the quotient map -/
-
-/-- Reindexing an ordered tuple by a permutation leaves the underlying unordered tuple unchanged. -/
-theorem ofFn_comp_perm (σ : Equiv.Perm (Fin n)) (f : Fin n → α) : ofFn (f ∘ σ) = ofFn f :=
-  Sym.coe_injective <| by simpa using Multiset.coe_eq_coe.2 (σ.ofFn_comp_perm f)
-
-/-- Two ordered tuples have the same underlying unordered tuple exactly when one is a reindexing
-of the other: the fibres of `ofFn` are the orbits of the permutation action. -/
-theorem ofFn_eq_ofFn_iff {f g : Fin n → α} :
-    ofFn f = ofFn g ↔ ∃ σ : Equiv.Perm (Fin n), f ∘ σ = g := by
-  classical
-  refine ⟨fun h => ?_, ?_⟩
-  · -- the two tuples take each value the same number of times, so their fibres are equinumerous
-    have key : ∀ (u : Fin n → α) (c : α),
-        Fintype.card {i // u i = c} = Multiset.count c (↑(List.ofFn u) : Multiset α) := by
-      intro u c
-      have hmap : (↑(List.ofFn u) : Multiset α) = Multiset.map u Finset.univ.val := by
-        rw [List.ofFn_eq_map]; rfl
-      rw [Fintype.card_subtype, hmap, Multiset.count_map, ← Finset.filter_val, Finset.card_def]
-      simp [eq_comm]
-    have hcard : ∀ c : α, Fintype.card {i // g i = c} = Fintype.card {i // f i = c} := fun c => by
-      rw [key, key, ← coe_ofFn, ← coe_ofFn, h]
-    exact ⟨Equiv.ofFiberEquiv fun c => Fintype.equivOfCardEq (hcard c),
-      funext fun i => Equiv.ofFiberEquiv_map _ i⟩
-  · rintro ⟨σ, rfl⟩
-    exact (ofFn_comp_perm σ f).symm
 
 /-- The saturation of a set of ordered tuples under `ofFn` is the union of its reindexings. -/
 theorem preimage_image_ofFn (s : Set (Fin n → α)) :


### PR DESCRIPTION
This PR topologizes the symmetric power and proves that the elementary symmetric chart on it is a homeomorphism. `Sym α n` is given the quotient topology coinduced along `TauCeti.Sym.ofFn`, the map reading an ordered tuple `Fin n → α` as an unordered one, with the quotient-map API that goes with it; then, over an algebraically closed proper normed field `K` (the case of interest being `ℂ`), the pure-algebra chart `TauCeti.Sym.coeffEquiv` of `TauCeti/RingTheory/Polynomial/SymmetricPower.lean` is upgraded to `TauCeti.Sym.coeffHomeomorph : Sym K n ≃ₜ (Fin n → K)`. The forward direction is that the coefficients of `∏ i, (X - C (f i))` are polynomial in the roots; the inverse direction is the classical continuity of the roots of a monic polynomial in its coefficients, obtained from Mathlib's Cauchy bound `Polynomial.IsRoot.norm_lt_cauchyBound`: the coefficient map `(Fin n → K) → (Fin n → K)` is proper, hence closed, and a continuous closed bijection is a homeomorphism.

This serves Lane F4.1 of the HeegaardFloer roadmap, whose opening milestone is "`Sym^g(Σ)` geometry: smooth complex structure (elementary symmetric functions), the totally real tori `T_α`, `T_β`, …" after Ozsváth–Szabó (arXiv:math/0101206, §2.1). The roadmap's own status note names this step explicitly — "`Sym^g(Σ)` needs its complex structure: promoting `Sym.monicEquiv` from a bijection to a homeomorphism, and then to a chart, is a concrete and independent task that does not wait on the analytic tower" — and it is exactly the promotion done here. What remains for that milestone after this PR is the complex structure itself (holomorphic transition functions for the chart on a Riemann surface, making `Sym^g(Σ)` a complex manifold), and then `T_α`, `T_β`, `π₂`, and the basepoint divisor.

Two files are added, ~330 lines:

- `TauCeti/Topology/Sym.lean` — `TauCeti.Sym.ofFn` and its surjectivity, the description `ofFn_eq_ofFn_iff` of its fibres as the orbits of the permutation action, the quotient topology instance on `Sym α n`, `isQuotientMap_ofFn`, `continuous_ofFn`, `continuous_iff_comp_ofFn`, the facts that `ofFn` is an open and a closed map, and compactness and Hausdorffness of the symmetric power of a compact, resp. Hausdorff, space.
- `TauCeti/Analysis/Polynomial/SymmetricPower.lean` — continuity of the coefficients of `∏ i ∈ s, (X - C (f i))` in the roots, `toMonic_ofFn`, Cauchy's bound in the form `norm_le_norm_coeffEquiv_ofFn_add_one`, properness and closedness of the coefficient map, and the homeomorphism `coeffHomeomorph`.

No Mathlib infrastructure is vendored: Cauchy's bound (`Polynomial.cauchyBound`, `Polynomial.IsRoot.norm_lt_cauchyBound`), the proper-map package (`isProperMap_iff_tendsto_cocompact`, `IsProperMap.isClosedMap`), Vieta's formulas and `Polynomial.ofMultiset` are all consumed from Mathlib, and the algebraic chart is the existing `TauCeti.Sym.coeffEquiv`. The permutation description of the fibres of `ofFn` is proved in the topology file, so the openness, closedness and Hausdorffness statements are the general ones and do not go through the chart.

Roadmap: HeegaardFloer

<!--tauceti-target:v1 {"focus":"HeegaardFloer","id":"sym-coeffhomeomorph"}-->

🤖 Prepared with Claude Code

