### PR TITLE
fix: bump mathlib to a rev with a complete cache

### DIFF
--- a/lake-manifest.json
+++ b/lake-manifest.json
@@ -5,7 +5,7 @@
    "type": "git",
    "subDir": null,
    "scope": "",
-   "rev": "c0032752b47af314b015a7b411123fa4ac99bbaf",
+   "rev": "d586c71e87ddf1c4fef06a739cdd3b733fd8b64d",
    "name": "mathlib",
    "manifestFile": "lake-manifest.json",
    "inputRev": "master",


### PR DESCRIPTION
This PR moves the Mathlib pin two commits forward, from `c0032752` to `d586c71e`, so that CI restores Mathlib's oleans from the cache instead of rebuilding them.

`c0032752` is the first commit of a three-commit rename batch (`Prime.not_unit` to `Prime.not_isUnit`, mathlib4#42385, #42388, #42390). Mathlib CI never built that intermediate commit, so no oleans were ever uploaded for it, and because the rename touches a core algebra file the miss cascades to 1415 downstream modules. Every build since the pin landed has fetched 6158 of 8681 files from the cache, failed to find the remaining 2523 in either bucket, and rebuilt them from source. CI on `main` went from a steady 27 minutes to 86-90 minutes, and merge-queue throughput fell with it.

`d586c71e` is the final commit of the same batch, has green Mathlib CI and therefore a complete cache, and carries an identical dependency closure, so this is a one-line change to `lake-manifest.json`. It is still on `v4.33.0-rc1`, so `lean-toolchain` does not move; everything on Mathlib master after 2026-08-03T14:29 is on `v4.33.0-rc2`, which would drag the toolchain along.

🤖 Prepared with Claude Code
