### PR TITLE
fix: reject bumps to mathlib commits with no cache

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -342,7 +342,25 @@ jobs:
       # policy; only the PR's TauCeti/ code stays untrusted and runs solely under landrun below.
       - name: Fetch Mathlib with the (bump-validated) config (network, no token; no PR code)
         if: ${{ env.INFRA != '1' }}
-        run: ( cd base && lake exe cache get ) && mkdir -p base/.lake/tmp
+        run: ( cd base && lake exe cache get 2>&1 | tee ../cache-get.log ) && mkdir -p base/.lake/tmp
+
+      # Backstop to bump-guard's step 2b, measuring the thing itself rather than a proxy.
+      # `lake exe cache get` exits 0 on a PARTIAL hit: it prints one warning and the build
+      # then quietly recompiles every module whose oleans never arrived. That is invisible
+      # in a green build and costs about an hour on every downstream build until the pin
+      # moves again, so catch it here (roughly 90 seconds in) rather than after the build.
+      #
+      # Only a bump is judged. A normal PR builds against the base pin, which it did not
+      # choose and cannot fix; failing those would take every PR in the repo down for as
+      # long as a bad pin sat on main, which is precisely backwards.
+      - name: Require a complete Mathlib cache for a bump
+        if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
+        run: |
+          if grep -qF 'some files were not found in the cache' cache-get.log; then
+            echo "::error::the bump target's Mathlib cache is incomplete, so this pin would make every downstream build recompile the missing modules; bump to a commit upstream CI built"
+            exit 1
+          fi
+          echo "Mathlib cache is complete at the bump target."
 
       # Enable Lake's built-in artifact cache for the build below ONLY when the public read
       # endpoints are configured (repo variables). Until then this is a no-op: LAKE_*

--- a/scripts/check-bump.sh
+++ b/scripts/check-bump.sh
@@ -18,6 +18,8 @@
 #      inputRev's history* — a genuine forward move on the nominated branch (via
 #      the GitHub compare API; the SHA requirement makes the compared revs
 #      immutable, so what we validate is exactly what Lake will resolve and build).
+#      Its new rev is also one upstream CI actually built, so its oleans are in the
+#      cache (see step 2b).
 #   3. The PR manifest's package set, MINUS mathlib, is EXACTLY mathlib's own
 #      lake-manifest at the new rev, field-for-field (type/url/rev/inputRev) — no
 #      package added, removed, renamed, retyped (e.g. a `path` dep), duplicated, or
@@ -136,6 +138,26 @@ else
     *) fail "mathlib new rev $ML_REV_P is not on branch '$NOMINATED_BRANCH' (compare status: ${st_branch:-unknown})" ;;
   esac
   echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$NOMINATED_BRANCH'."
+
+  # --- 2b. the new rev is one upstream CI actually built (so its cache exists) --
+  # Being on master is not enough. Mathlib lands in batches: bors tests a batch and
+  # fast-forwards master over all of its commits, but only the commit it tested gets
+  # built, and only a built commit has its oleans uploaded to the cache. A batch's
+  # intermediate commits are perfectly good ancestors carrying no cache at all, so
+  # pinning to one silently costs every downstream build a full recompile of whatever
+  # that commit invalidated: a rename in a core algebra file is ~1400 modules and about
+  # an hour, on every CI run and every pr-build, until the pin moves again.
+  #
+  # bors stamps exactly the commits it tested, and a batch intermediate carries no
+  # commit status at all, which makes this a clean and cheap test. Requiring it is
+  # conservative in the right direction: a commit whose CI has not finished yet also
+  # has no cache yet, and waiting for the next candidate is what we want.
+  bors_state="$(gh api "repos/$ML_SLUG/commits/$ML_REV_P/status" \
+    --jq 'first(.statuses[] | select(.context == "bors") | .state) // ""' 2>/dev/null)" \
+    || fail "commit status API failed for $ML_SLUG $ML_REV_P"
+  [ "$bors_state" = "success" ] \
+    || fail "mathlib rev $ML_REV_P has no successful 'bors' status (got '${bors_state:-none}'), so upstream CI never built it and its oleans are not in the cache; bump to the tested commit of that batch instead"
+  echo "bump-guard: mathlib $ML_REV_P was built upstream (bors: success), so its cache exists."
 fi
 
 # --- 3. the rest of the manifest is EXACTLY mathlib's own manifest at the new rev


### PR DESCRIPTION
This PR stops the bump machinery from pinning Mathlib at a commit whose oleans were never uploaded to the cache, and fails fast if one slips through anyway.

Being on `master` is not sufficient for a pin. Mathlib lands in batches: bors tests a batch and fast-forwards `master` over all of its commits, but only the commit it tested is built, and only a built commit has its oleans in the cache. A batch's intermediate commits are ordinary ancestors carrying no cache at all. `lake exe cache get` then returns a partial hit, exits 0, prints a single warning, and the build quietly recompiles everything the commit invalidated.

That is what #2201 did. It pinned `c0032752`, the first commit of a three-commit rename batch (`Prime.not_unit` to `Prime.not_isUnit`, mathlib4#42385, #42388, #42390), whose tested commit is `d586c71e`. Because the rename touches a core algebra file, 2523 files covering 1415 modules were absent from the cache, and every build since fetched 6158 of 8681 files and rebuilt the rest. CI on `main` went from a steady 27 minutes to 86-90 minutes, and merge-queue throughput fell with it. #2230 moves the pin to the tested commit.

`check-bump.sh` gains step 2b: the new rev must carry a successful `bors` commit status. bors stamps exactly the commits it tested, and a batch intermediate carries no commit status at all, so the test is cheap and unambiguous. It is conservative in the useful direction, since a commit whose CI has not finished also has no cache yet. Replaying #2201 against the guard now fails with the reason named; replaying #2230 passes.

`pr-build.yml` gains a backstop that measures the outcome rather than a proxy, failing a bump about 90 seconds in when `lake exe cache get` reports missing files. It judges bumps only. A normal PR builds against a base pin it did not choose and cannot fix, so failing those would take every PR down for as long as a bad pin sat on `main`.

Backtesting the guard over the last fifteen pins accepts eleven and rejects four, so untested commits are picked reasonably often. The other three cost little, because the penalty scales with how much the commit invalidates and those had low fanout; the guard removes a risk whose severity varies rather than a constant tax.

🤖 Prepared with Claude Code
