### PR TITLE
fix: propagate cache-fetch failures and tie the bump guard to the publishing build

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -342,7 +342,16 @@ jobs:
       # policy; only the PR's TauCeti/ code stays untrusted and runs solely under landrun below.
       - name: Fetch Mathlib with the (bump-validated) config (network, no token; no PR code)
         if: ${{ env.INFRA != '1' }}
-        run: ( cd base && lake exe cache get 2>&1 | tee ../cache-get.log ) && mkdir -p base/.lake/tmp
+        # `set -o pipefail` is not optional here. A `run:` step with no explicit `shell:`
+        # gets the runner default `bash -e {0}`, which does NOT set pipefail, so piping
+        # into `tee` would report the pipeline's status as tee's and swallow a failing
+        # `cache get` on every PR, not just a bump. Naming the shell also sets pipefail;
+        # both are here so neither the tee nor the guard below depends on runner defaults.
+        shell: bash
+        run: |
+          set -o pipefail
+          ( cd base && lake exe cache get ) 2>&1 | tee "$GITHUB_WORKSPACE/cache-get.log"
+          mkdir -p base/.lake/tmp
 
       # Backstop to bump-guard's step 2b, measuring the thing itself rather than a proxy.
       # `lake exe cache get` exits 0 on a PARTIAL hit: it prints one warning and the build
@@ -355,9 +364,19 @@ jobs:
       # long as a bad pin sat on main, which is precisely backwards.
       - name: Require a complete Mathlib cache for a bump
         if: ${{ env.INFRA != '1' && env.BUMP == '1' }}
+        shell: bash
         run: |
-          if grep -qF 'some files were not found in the cache' cache-get.log; then
-            echo "::error::the bump target's Mathlib cache is incomplete, so this pin would make every downstream build recompile the missing modules; bump to a commit upstream CI built"
+          set -euo pipefail
+          log="$GITHUB_WORKSPACE/cache-get.log"
+          # Fail closed. An absent or unreadable log is not evidence of a complete cache,
+          # and `grep` on a missing file exits 2, which as an `if` condition would read the
+          # same as "phrase not found" and wave the bump through.
+          if [ ! -r "$log" ]; then
+            echo "::error::$log is missing or unreadable, so cache completeness cannot be established for this bump"
+            exit 1
+          fi
+          if grep -qF 'some files were not found in the cache' "$log"; then
+            echo "::error::the bump target's Mathlib cache is incomplete, so this pin would make every downstream build recompile the missing modules; bump to a commit whose master-push build published its cache"
             exit 1
           fi
           echo "Mathlib cache is complete at the bump target."

--- a/scripts/check-bump.sh
+++ b/scripts/check-bump.sh
@@ -18,7 +18,7 @@
 #      inputRev's history* — a genuine forward move on the nominated branch (via
 #      the GitHub compare API; the SHA requirement makes the compared revs
 #      immutable, so what we validate is exactly what Lake will resolve and build).
-#      Its new rev is also one upstream CI actually built, so its oleans are in the
+#      Its new rev is also one whose master-push build completed, so its oleans are in the
 #      cache (see step 2b).
 #   3. The PR manifest's package set, MINUS mathlib, is EXACTLY mathlib's own
 #      lake-manifest at the new rev, field-for-field (type/url/rev/inputRev) — no
@@ -139,25 +139,29 @@ else
   esac
   echo "bump-guard: mathlib $ML_REV_B -> $ML_REV_P is a forward move on '$NOMINATED_BRANCH'."
 
-  # --- 2b. the new rev is one upstream CI actually built (so its cache exists) --
+  # --- 2b. the new rev is one whose cache was actually published ---------------
   # Being on master is not enough. Mathlib lands in batches: bors tests a batch and
-  # fast-forwards master over all of its commits, but only the commit it tested gets
-  # built, and only a built commit has its oleans uploaded to the cache. A batch's
-  # intermediate commits are perfectly good ancestors carrying no cache at all, so
-  # pinning to one silently costs every downstream build a full recompile of whatever
-  # that commit invalidated: a rename in a core algebra file is ~1400 modules and about
-  # an hour, on every CI run and every pr-build, until the pin moves again.
+  # fast-forwards master over all of its commits, but only the resulting master tip is
+  # built by the push-triggered CI run, and that run is the only one that publishes to
+  # the `mathlib4-master` cache container (mathlib's build.yml gates `publish_cache` on
+  # `event_name == 'push' && ref == 'refs/heads/master'`). A batch's intermediate commits
+  # are ordinary ancestors whose oleans were never uploaded, so pinning to one costs every
+  # downstream build a full recompile of whatever that commit invalidated: a rename in a
+  # core algebra file is ~1400 modules and about an hour, on every CI run and every
+  # pr-build, until the pin moves again.
   #
-  # bors stamps exactly the commits it tested, and a batch intermediate carries no
-  # commit status at all, which makes this a clean and cheap test. Requiring it is
-  # conservative in the right direction: a commit whose CI has not finished yet also
-  # has no cache yet, and waiting for the next candidate is what we want.
-  bors_state="$(gh api "repos/$ML_SLUG/commits/$ML_REV_P/status" \
-    --jq 'first(.statuses[] | select(.context == "bors") | .state) // ""' 2>/dev/null)" \
-    || fail "commit status API failed for $ML_SLUG $ML_REV_P"
-  [ "$bors_state" = "success" ] \
-    || fail "mathlib rev $ML_REV_P has no successful 'bors' status (got '${bors_state:-none}'), so upstream CI never built it and its oleans are not in the cache; bump to the tested commit of that batch instead"
-  echo "bump-guard: mathlib $ML_REV_P was built upstream (bors: success), so its cache exists."
+  # We require that publishing run to have COMPLETED successfully on this exact rev. That
+  # is both narrower and better timed than asking bors: bors reports success on the batch
+  # commit before the master build has uploaded anything, so a very fresh tip can carry a
+  # green bors status while its cache is still hours away. Coupling to upstream's workflow
+  # file name is deliberate. If it is renamed this check fails closed and the bump routes
+  # to a human, which is the safe direction for a trust anchor.
+  pub="$(gh api "repos/$ML_SLUG/actions/workflows/build.yml/runs?head_sha=$ML_REV_P&event=push&per_page=20" \
+    --jq '[.workflow_runs[] | select(.head_branch == "master" and .status == "completed" and .conclusion == "success")] | length' 2>&1)" \
+    || fail "workflow-runs API failed for $ML_SLUG $ML_REV_P: $pub"
+  [ "${pub:-0}" -gt 0 ] 2>/dev/null \
+    || fail "mathlib rev $ML_REV_P has no completed, successful master-push build, so its oleans were never published to the cache; bump to the built tip of that batch, or wait for its build to finish"
+  echo "bump-guard: mathlib $ML_REV_P has a successful master-push build, so its cache is published."
 fi
 
 # --- 3. the rest of the manifest is EXACTLY mathlib's own manifest at the new rev


### PR DESCRIPTION
This PR repairs three failure modes in the cache guard added by #2231.

The `tee` added to the `lake exe cache get` step silently disarmed that step's failure reporting for every PR, not only for bumps. A `run:` step with no explicit `shell:` gets the runner default `bash -e {0}`, which does not set `pipefail`, so the pipeline reports `tee`'s exit status and a failing `cache get` passes. The step now names `bash` and sets `pipefail` explicitly, so neither it nor the guard depends on runner defaults.

The completeness check now fails closed. It previously ran `grep` against a bare relative path with no check that the file existed, and `grep` on a missing file exits 2, which as an `if` condition is indistinguishable from "phrase not found" and would have waved the bump through. The log is now written to and read from `$GITHUB_WORKSPACE`, and an absent or unreadable log is an error rather than a pass.

`check-bump.sh` step 2b now requires a completed, successful master-push build on the target rev instead of a successful `bors` status. Mathlib's `build.yml` gates `publish_cache` on `event_name == 'push' && ref == 'refs/heads/master'`, so that run, not the bors staging build, is what populates the `mathlib4-master` container. The distinction also fixes a timing hole: bors reports success on a batch commit before the master build has uploaded anything, so a very fresh tip could carry a green bors status while its cache was still hours away. Coupling to upstream's workflow file name is deliberate, since a rename makes this check fail closed and routes the bump to a human.

Both predicates agree on all fifteen of the most recent pins, so the stricter one introduces no new rejections. Replaying #2201 still fails with the reason named, and replaying #2230 still passes.

🤖 Prepared with Claude Code
