### PR TITLE
fix: retry the artifact-cache fetch more, and treat a hash mismatch as unclean

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -478,12 +478,27 @@ jobs:
             fi
             return 0
           }
-          FAIL_RE='failed to download|output lookup failed|curl exited with code'
+          # `downloaded artifact hash mismatch` must be here. Lake handles a mismatch by deleting
+          # the artifact and setting `didError`, but the stale `didError` read below means the
+          # process can still exit 0, and the deletion leaves an input-to-output mapping whose
+          # artifact is gone. The offline build cannot refetch it, so that entry becomes a build
+          # failure rather than a rebuild. Treat it as unclean so the cache is refetched or dropped.
+          FAIL_RE='failed to download|output lookup failed|curl exited with code|downloaded artifact hash mismatch'
           # A revision with no cached build at all is deterministic: retrying cannot change it,
           # and there is nothing partial to discard.
           MISS_RE='no outputs found'
+          # Six attempts, not three. Losing every attempt discards the whole cache and forces a
+          # ~22 minute full rebuild, which was happening on 4 of 18 sampled builds (the other 14
+          # took 2-3 minutes). The cause is lean4#14698: one unreadable artifact throws out of
+          # `computeFileHash`, which has no try/catch, so a single ENOENT aborts the entire fetch
+          # and discards every artifact already downloaded. Which artifact trips it varies between
+          # attempts, so re-fetching genuinely tends to succeed; at the observed per-attempt
+          # failure rate six attempts take whole-cache loss from roughly 22% to roughly 5%.
+          # Reduce this again once the fix (lean4#14651) reaches a released toolchain: it is on
+          # master only, and v4.33.0-rc2 was branched before it landed.
+          ATTEMPTS=6
           clean=0
-          for attempt in 1 2 3; do
+          for attempt in $(seq 1 $ATTEMPTS); do
             LOG="$RUNNER_TEMP/cache-get-$attempt.log"
             rc=0
             ( cd base && LAKE_CONFIG="$CFG" lake cache get --service tauceti-public \
@@ -493,16 +508,15 @@ jobs:
             if grep -qE "$MISS_RE" "$LOG"; then break; fi
             # `[ ... ] && sleep` would abort the step under `bash -e` on the last attempt,
             # when the test is false and the whole list returns nonzero. Use a plain `if`.
-            # The backoff is deliberately long: Lake already gives each artifact transfer
-            # `--retry 3`, so spacing the outer attempts keeps us from adding request rate to
-            # an endpoint that is throttling us.
-            if [ "$attempt" != 3 ]; then
-              echo "::notice::lake cache get attempt $attempt did not complete cleanly; discarding the partial cache and retrying"
+            if [ "$attempt" != "$ATTEMPTS" ]; then
+              echo "::notice::lake cache get attempt $attempt of $ATTEMPTS did not complete cleanly; discarding the partial cache and retrying"
               # Sleep BEFORE discarding. A failed `lake cache get` returns as soon as one transfer
               # errors, while its sibling curl/leantar processes are still writing into the cache
-              # dir; discarding at that instant races them. The backoff also serves its original
-              # purpose of not adding request rate to an endpoint that is throttling us.
-              sleep $(( attempt * 30 ))
+              # dir; discarding at that instant races them. This is no longer a throttling backoff:
+              # the read endpoint serves these artifacts byte-identically under 48-way concurrency,
+              # so the failures are the Lake bug above rather than rate limiting, and a short fixed
+              # pause is enough to let the stragglers finish.
+              sleep 10
               # Must precede the retry: see the step comment above. Without this, attempt N+1
               # skips every artifact this attempt already wrote, including the broken ones, and
               # a clean exit from it says nothing about the entries that made this attempt fail.


### PR DESCRIPTION
This PR widens the `lake cache get` retry loop from three attempts to six, and counts a downloaded-artifact hash mismatch as an unclean attempt.

Losing every attempt discards the whole artifact cache and forces a full recompile of TauCeti, which is about 22 minutes of work against the 2 to 3 minutes a cached PR build takes. Sampling eighteen successful `pr-build` runs from 2026-08-06, before the Mathlib pin regression distorted the numbers, gives a clean split: fourteen at 2 to 3 minutes and four at 24 to 25 minutes. So roughly a fifth of PR builds were paying an order-of-magnitude penalty.

The underlying cause is lean4#14698. In `monitorTransfer`, each artifact is verified with `computeFileHash`, which is `IO Hash` and has no `try`/`catch` around it, so one unreadable file throws out of the whole fetch and discards every artifact already downloaded. Which artifact trips it varies between attempts, and the read endpoint is not implicated: the specific artifacts that failed in CI download byte-identically over 48 concurrent requests. Retrying is therefore genuinely likely to succeed, and at the observed per-attempt failure rate six attempts take whole-cache loss from roughly 22% to roughly 5%. The fix, lean4#14651, is on Lean master only; v4.33.0-rc2 was branched before it landed, so no released toolchain carries it yet. Reduce the attempt count again once one does.

The backoff drops from 30 and 60 seconds to a flat 10. Its stated purpose was to avoid adding request rate to an endpoint that might be throttling us, and that is now ruled out by the concurrency measurement above. The sleep remains because a failed fetch returns while its sibling transfers are still writing into the cache directory, and discarding at that instant races them.

`FAIL_RE` gains `downloaded artifact hash mismatch`. Lake handles a mismatch by deleting the artifact and setting `didError`, but the stale `didError` read means the process can still exit 0, so such an attempt was being judged clean. The deletion leaves an input-to-output mapping whose artifact is gone, and because the sandboxed build runs offline it cannot refetch it, so that entry becomes a build failure rather than a rebuild. On a real failing log the old pattern matched none of the actual error lines and the new one matches both.

🤖 Prepared with Claude Code
