### PR TITLE
refactor(CentralSimple): decompose the Skolem-Noether proof

### DIFF
--- a/TauCeti/Algebra/CentralSimple/Bimodule.lean
+++ b/TauCeti/Algebra/CentralSimple/Bimodule.lean
@@ -50,9 +50,12 @@ value `u` at `1`, and that value intertwines `f` and `g`:
 * `TauCeti.Bimodule.exists_symm_apply_one_mul_eq_one`: when `of g 1` is hit, `u` has a right
   inverse.
 
-The Skolem-Noether argument in `TauCeti/Algebra/CentralSimple/SkolemNoether.lean` runs on all of
-them; the centralizer theorem in `TauCeti/Algebra/CentralSimple/Centralizer.lean` uses
-`apply_of` and `symm_apply_one_mul_eq_mul_symm_apply_one` at `f = g = B.val`.
+The two consumers take different halves. The Skolem-Noether argument in
+`TauCeti/Algebra/CentralSimple/SkolemNoether.lean` uses the right-inverse lemma
+`exists_symm_apply_one_mul_eq_one` and the intertwining lemma
+`symm_apply_one_mul_eq_mul_symm_apply_one`; the centralizer theorem in
+`TauCeti/Algebra/CentralSimple/Centralizer.lean` uses `apply_of` and the same intertwining lemma, at
+`f = g = B.val`.
 
 ## Implementation notes
 

--- a/TauCeti/Algebra/CentralSimple/Bimodule.lean
+++ b/TauCeti/Algebra/CentralSimple/Bimodule.lean
@@ -46,7 +46,7 @@ value `u` at `1`, and that value intertwines `f` and `g`:
 
 * `TauCeti.Bimodule.symm_apply_eq_symm_apply_one_mul`: the transported map is `a ↦ u * a`.
 * `TauCeti.Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one`: `u * f b = g b * u`.
-* `TauCeti.Bimodule.exists_symm_apply_one_mul_eq_one`: for a surjective map, `u` has a right
+* `TauCeti.Bimodule.exists_symm_apply_one_mul_eq_one`: when `of g 1` is hit, `u` has a right
   inverse.
 
 These are what the Skolem-Noether argument in
@@ -157,6 +157,7 @@ variable {f g : B →ₐ[K] A}
 
 /-- Transported along `Bimodule.of`, a `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g` sends
 `a` to its value at `1`, multiplied by `a`. -/
+@[grind =]
 theorem symm_apply_eq_symm_apply_one_mul (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
     (of g).symm (φ (of f a))
       = (of g).symm (φ (of f 1)) * a := by
@@ -168,6 +169,7 @@ theorem symm_apply_eq_symm_apply_one_mul (φ : Bimodule f →ₗ[B ⊗[K] Aᵐ�
 
 /-- The transported value at `1` intertwines `f` and `g`: writing `u` for it, `u * f b = g b * u`
 for every `b : B`. -/
+@[grind =]
 theorem symm_apply_one_mul_eq_mul_symm_apply_one
     (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
     (of g).symm (φ (of f 1)) * f b
@@ -186,11 +188,12 @@ theorem symm_apply_one_mul_eq_mul_symm_apply_one
     _ = (of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • of g u) := by rw [hu']
     _ = g b * u := by rw [smul_of]; simp
 
-/-- For a surjective `φ`, the transported value at `1` has a right inverse in `A`. -/
+/-- Whenever `of g 1` is in the range of `φ`, the transported value at `1` has a right inverse
+in `A`. Surjectivity of `φ` is more than is needed: only this one value must be hit. -/
 theorem exists_symm_apply_one_mul_eq_one (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g)
-    (hφ : Function.Surjective φ) :
+    (h1 : of g 1 ∈ LinearMap.range φ) :
     ∃ v : A, (of g).symm (φ (of f 1)) * v = 1 := by
-  obtain ⟨y, hy⟩ := hφ (of g 1)
+  obtain ⟨y, hy⟩ := h1
   refine ⟨(of f).symm y, ?_⟩
   have h := symm_apply_eq_symm_apply_one_mul φ ((of f).symm y)
   rw [LinearEquiv.apply_symm_apply, hy] at h

--- a/TauCeti/Algebra/CentralSimple/Bimodule.lean
+++ b/TauCeti/Algebra/CentralSimple/Bimodule.lean
@@ -45,12 +45,14 @@ A `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g`, transported a
 value `u` at `1`, and that value intertwines `f` and `g`:
 
 * `TauCeti.Bimodule.symm_apply_eq_symm_apply_one_mul`: the transported map is `a ↦ u * a`.
+* `TauCeti.Bimodule.apply_of`: the untransported form, `φ (of f a) = of g (u * a)`.
 * `TauCeti.Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one`: `u * f b = g b * u`.
 * `TauCeti.Bimodule.exists_symm_apply_one_mul_eq_one`: when `of g 1` is hit, `u` has a right
   inverse.
 
-These are what the Skolem-Noether argument in
-`TauCeti/Algebra/CentralSimple/SkolemNoether.lean` runs on.
+The Skolem-Noether argument in `TauCeti/Algebra/CentralSimple/SkolemNoether.lean` runs on all of
+them; the centralizer theorem in `TauCeti/Algebra/CentralSimple/Centralizer.lean` uses
+`apply_of` and `symm_apply_one_mul_eq_mul_symm_apply_one` at `f = g = B.val`.
 
 ## Implementation notes
 
@@ -166,6 +168,14 @@ theorem symm_apply_eq_symm_apply_one_mul (φ : Bimodule f →ₗ[B ⊗[K] Aᵐ�
     rw [smul_of]; simp
   rw [ha, map_smul, symm_smul]
   simp
+
+/-- The untransported form of `symm_apply_eq_symm_apply_one_mul`: `φ` sends `of f a` to
+`of g (u * a)`, where `u` is its transported value at `1`. This is the `of`-side companion, in the
+same way that `smul_of` is the companion of `symm_smul`. -/
+@[grind =]
+theorem apply_of (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
+    φ (of f a) = of g ((of g).symm (φ (of f 1)) * a) :=
+  (of g).symm.injective (by simpa using symm_apply_eq_symm_apply_one_mul φ a)
 
 /-- The transported value at `1` intertwines `f` and `g`: writing `u` for it, `u * f b = g b * u`
 for every `b : B`. -/

--- a/TauCeti/Algebra/CentralSimple/Bimodule.lean
+++ b/TauCeti/Algebra/CentralSimple/Bimodule.lean
@@ -41,6 +41,17 @@ instance.
   is Mathlib's `AlgHom.mulLeftRight` restricted along `f` on the left factor, so for
   `f = AlgHom.id K A` it is `AlgHom.mulLeftRight K A` itself.
 
+A `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g`, transported along `of`, is determined by its
+value `u` at `1`, and that value intertwines `f` and `g`:
+
+* `TauCeti.Bimodule.symm_apply_eq_symm_apply_one_mul`: the transported map is `a ↦ u * a`.
+* `TauCeti.Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one`: `u * f b = g b * u`.
+* `TauCeti.Bimodule.exists_symm_apply_one_mul_eq_one`: for a surjective map, `u` has a right
+  inverse.
+
+These are what the Skolem-Noether argument in
+`TauCeti/Algebra/CentralSimple/SkolemNoether.lean` runs on.
+
 ## Implementation notes
 
 `TauCeti.Bimodule.smul_of` and `TauCeti.Bimodule.symm_smul` are the working interface: they compute
@@ -139,6 +150,53 @@ is `x ↦ f b * x * a`. -/
 theorem symm_smul (b : B) (a : Aᵐᵒᵖ) (y : Bimodule f) :
     (of f).symm ((b ⊗ₜ a : B ⊗[K] Aᵐᵒᵖ) • y) = f b * (of f).symm y * a.unop :=
   toEnd_tmul_apply f b a ((of f).symm y)
+
+section Map
+
+variable {f g : B →ₐ[K] A}
+
+/-- Transported along `Bimodule.of`, a `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g` sends
+`a` to its value at `1`, multiplied by `a`. -/
+theorem symm_apply_eq_symm_apply_one_mul (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
+    (of g).symm (φ (of f a))
+      = (of g).symm (φ (of f 1)) * a := by
+  -- Linearity for the right action of `A` fixes `φ` everywhere from its value at `1`.
+  have ha : of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • of f 1 := by
+    rw [smul_of]; simp
+  rw [ha, map_smul, symm_smul]
+  simp
+
+/-- The transported value at `1` intertwines `f` and `g`: writing `u` for it, `u * f b = g b * u`
+for every `b : B`. -/
+theorem symm_apply_one_mul_eq_mul_symm_apply_one
+    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
+    (of g).symm (φ (of f 1)) * f b
+      = g b * (of g).symm (φ (of f 1)) := by
+  -- Linearity for the left action of `B`, read through `symm_apply_eq_symm_apply_one_mul`.
+  set u : A := (of g).symm (φ (of f 1)) with hu
+  have hu' : φ (of f 1) = of g u := by rw [hu]; simp
+  have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • of f 1 = of f (f b) := by
+    rw [smul_of]; simp
+  calc u * f b = (of g).symm (φ (of f (f b))) :=
+        (symm_apply_eq_symm_apply_one_mul φ (f b)).symm
+    _ = (of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • of f 1)) := by
+          rw [h1]
+    _ = (of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (of f 1)) := by
+          rw [map_smul]
+    _ = (of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • of g u) := by rw [hu']
+    _ = g b * u := by rw [smul_of]; simp
+
+/-- For a surjective `φ`, the transported value at `1` has a right inverse in `A`. -/
+theorem exists_symm_apply_one_mul_eq_one (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g)
+    (hφ : Function.Surjective φ) :
+    ∃ v : A, (of g).symm (φ (of f 1)) * v = 1 := by
+  obtain ⟨y, hy⟩ := hφ (of g 1)
+  refine ⟨(of f).symm y, ?_⟩
+  have h := symm_apply_eq_symm_apply_one_mul φ ((of f).symm y)
+  rw [LinearEquiv.apply_symm_apply, hy] at h
+  simpa using h.symm
+
+end Map
 
 end Bimodule
 

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -213,7 +213,6 @@ private theorem centralizerAlgHom_bijective : Function.Bijective (centralizerAlg
     simpa using h
   · -- Surjectivity: `φ` is left multiplication by `c = φ 1`, which centralizes `B`.
     set c : A := (Bimodule.of B.val).symm (φ (Bimodule.of B.val 1)) with hc
-    have hφ1 : φ (Bimodule.of B.val 1) = Bimodule.of B.val c := by rw [hc]; simp
     -- `φ` is multiplication by `c`: this is the shared bimodule-map API at `f = g = B.val`.
     have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := fun x =>
       (Bimodule.of B.val).symm.injective (by

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -214,9 +214,8 @@ private theorem centralizerAlgHom_bijective : Function.Bijective (centralizerAlg
   · -- Surjectivity: `φ` is left multiplication by `c = φ 1`, which centralizes `B`.
     set c : A := (Bimodule.of B.val).symm (φ (Bimodule.of B.val 1)) with hc
     -- `φ` is multiplication by `c`: this is the shared bimodule-map API at `f = g = B.val`.
-    have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := fun x =>
-      (Bimodule.of B.val).symm.injective (by
-        simpa [hc] using Bimodule.symm_apply_eq_symm_apply_one_mul (φ := φ) x)
+    have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := fun x => by
+      simpa [hc] using Bimodule.apply_of (φ := φ) x
     -- Linearity for the left action of `B` says exactly that `c` centralizes `B`.
     have hcomm : ∀ b ∈ (B : Set A), b * c = c * b := fun b hb => by
       simpa [hc] using

--- a/TauCeti/Algebra/CentralSimple/Centralizer.lean
+++ b/TauCeti/Algebra/CentralSimple/Centralizer.lean
@@ -214,23 +214,14 @@ private theorem centralizerAlgHom_bijective : Function.Bijective (centralizerAlg
   · -- Surjectivity: `φ` is left multiplication by `c = φ 1`, which centralizes `B`.
     set c : A := (Bimodule.of B.val).symm (φ (Bimodule.of B.val 1)) with hc
     have hφ1 : φ (Bimodule.of B.val 1) = Bimodule.of B.val c := by rw [hc]; simp
-    -- Every element of `A` is `1` moved by the right action, so `φ` is multiplication by `c`.
-    have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := by
-      intro x
-      have hx : Bimodule.of B.val x
-          = ((1 : ↥B) ⊗ₜ MulOpposite.op x : ↥B ⊗[K] Aᵐᵒᵖ) • Bimodule.of B.val 1 := by
-        rw [Bimodule.smul_of]; simp
-      rw [hx, map_smul, hφ1, Bimodule.smul_of]
-      simp
+    -- `φ` is multiplication by `c`: this is the shared bimodule-map API at `f = g = B.val`.
+    have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := fun x =>
+      (Bimodule.of B.val).symm.injective (by
+        simpa [hc] using Bimodule.symm_apply_eq_symm_apply_one_mul (φ := φ) x)
     -- Linearity for the left action of `B` says exactly that `c` centralizes `B`.
-    have hcomm : ∀ b ∈ (B : Set A), b * c = c * b := by
-      intro b hb
-      have hb' : Bimodule.of B.val b
-          = ((⟨b, hb⟩ : ↥B) ⊗ₜ (1 : Aᵐᵒᵖ) : ↥B ⊗[K] Aᵐᵒᵖ) • Bimodule.of B.val 1 := by
-        rw [Bimodule.smul_of]; simp
-      have h := key b
-      rw [hb', map_smul, hφ1, Bimodule.smul_of] at h
-      simpa using ((Bimodule.of B.val).injective h.symm).symm
+    have hcomm : ∀ b ∈ (B : Set A), b * c = c * b := fun b hb => by
+      simpa [hc] using
+        (Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one (φ := φ) ⟨b, hb⟩).symm
     refine ⟨⟨c, (Subalgebra.mem_centralizer_iff K).2 hcomm⟩, ?_⟩
     ext y
     obtain ⟨x, rfl⟩ := (Bimodule.of B.val).surjective y

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -96,6 +96,46 @@ section SkolemNoether
 
 variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Algebra K B]
 
+/-- A `B ⊗[K] Aᵐᵒᵖ`-linear isomorphism `Bimodule f ≃ₗ Bimodule g`, transported to `A`, is left
+multiplication by the image of `1`: linearity for the right action of `A` fixes it on all of `A`. -/
+private theorem symm_apply_of_eq_mul (f g : B →ₐ[K] A)
+    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
+    (Bimodule.of g).symm (φ (Bimodule.of f a))
+      = (Bimodule.of g).symm (φ (Bimodule.of f 1)) * a := by
+  have ha : Bimodule.of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 := by
+    rw [Bimodule.smul_of]; simp
+  rw [ha, map_smul, Bimodule.symm_smul]
+  simp
+
+/-- Linearity of `φ` for the left action of `B` turns the element of `TauCeti.symm_apply_of_eq_mul`
+into a conjugator: it intertwines `f` and `g`. -/
+private theorem symm_apply_of_one_mul_eq_mul (f g : B →ₐ[K] A)
+    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
+    (Bimodule.of g).symm (φ (Bimodule.of f 1)) * f b
+      = g b * (Bimodule.of g).symm (φ (Bimodule.of f 1)) := by
+  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
+  have hu' : φ (Bimodule.of f 1) = Bimodule.of g u := by rw [hu]; simp
+  have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 = Bimodule.of f (f b) := by
+    rw [Bimodule.smul_of]; simp
+  calc u * f b = (Bimodule.of g).symm (φ (Bimodule.of f (f b))) :=
+        (symm_apply_of_eq_mul K f g φ (f b)).symm
+    _ = (Bimodule.of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1)) := by
+          rw [h1]
+    _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (Bimodule.of f 1)) := by
+          rw [map_smul]
+    _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
+    _ = g b * u := by rw [Bimodule.smul_of]; simp
+
+/-- Surjectivity of `φ` supplies a right inverse for the conjugator. -/
+private theorem exists_symm_apply_of_one_mul_eq_one (f g : B →ₐ[K] A)
+    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) :
+    ∃ v : A, (Bimodule.of g).symm (φ (Bimodule.of f 1)) * v = 1 := by
+  obtain ⟨y, hy⟩ := φ.surjective (Bimodule.of g 1)
+  refine ⟨(Bimodule.of f).symm y, ?_⟩
+  have h := symm_apply_of_eq_mul K f g φ ((Bimodule.of f).symm y)
+  rw [LinearEquiv.apply_symm_apply, hy] at h
+  simpa using h.symm
+
 /-- **The Skolem-Noether theorem.** Two `K`-algebra homomorphisms `f g : B →ₐ[K] A` from a
 finite-dimensional **central simple** `K`-algebra `B` to a finite-dimensional **simple** `K`-algebra
 `A` are conjugate: there is a unit `u` of `A` with `g x = u * f x * u⁻¹` for all `x : B`.
@@ -113,49 +153,19 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) :=
     ((Bimodule.of f).symm.trans (Bimodule.of g)).finrank_eq
   obtain ⟨φ⟩ := IsSimpleRing.nonempty_linearEquiv_of_finrank_eq (R := B ⊗[K] Aᵐᵒᵖ) K hrank
-  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
-  -- Linearity of `φ` for the right action of `A` makes it left multiplication by `u`.
-  have key : ∀ a : A, (Bimodule.of g).symm (φ (Bimodule.of f a)) = u * a := by
-    intro a
-    have ha : Bimodule.of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 := by
-      rw [Bimodule.smul_of]; simp
-    rw [ha, map_smul, Bimodule.symm_smul]
-    simp [hu]
-  have hu' : φ (Bimodule.of f 1) = Bimodule.of g u := by
-    have h1 := key 1
-    rw [mul_one] at h1
-    rw [← h1]
-    simp
-  -- Surjectivity of `φ` gives a right inverse of `u`.
-  obtain ⟨y, hy⟩ := φ.surjective (Bimodule.of g 1)
-  set v : A := (Bimodule.of f).symm y with hv
-  have huv : u * v = 1 := by
-    have h := key v
-    rw [hv, LinearEquiv.apply_symm_apply, hy] at h
-    simpa using h.symm
+  obtain ⟨v, huv⟩ := exists_symm_apply_of_one_mul_eq_one K f g φ
   -- `A` is finite-dimensional over a field, hence Artinian, hence Dedekind-finite
   -- (`IsArtinianRing.of_finite` is a theorem, not an instance, so it is supplied by hand).
-  -- A right inverse therefore already presents `u` as a unit.
+  -- A right inverse therefore already presents the conjugator as a unit.
   have : IsArtinianRing A := IsArtinianRing.of_finite K A
-  -- Linearity of `φ` for the left action of `B` is the conjugation relation.
-  have hb : ∀ b : B, u * f b = g b * u := by
-    intro b
-    have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 = Bimodule.of f (f b) := by
-      rw [Bimodule.smul_of]; simp
-    calc u * f b = (Bimodule.of g).symm (φ (Bimodule.of f (f b))) := (key (f b)).symm
-      _ = (Bimodule.of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1)) := by
-            rw [h1]
-      _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (Bimodule.of f 1)) := by
-            rw [map_smul]
-      _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
-      _ = g b * u := by rw [Bimodule.smul_of]; simp
+  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
   -- Name the two coercions of the constructed unit through the stable `Units` API rather than
   -- relying on `Units.mkOfMulEqOne` reducing definitionally.
   have hUval : ((Units.mkOfMulEqOne u v huv : Aˣ) : A) = u := Units.val_mkOfMulEqOne huv
   have hUinv : (↑(Units.mkOfMulEqOne u v huv)⁻¹ : A) = v :=
     Units.inv_eq_of_mul_eq_one_right (by rw [hUval]; exact huv)
   refine ⟨Units.mkOfMulEqOne u v huv, fun x ↦ ?_⟩
-  rw [hUval, hUinv, hb x, mul_assoc, huv, mul_one]
+  rw [hUval, hUinv, hu, symm_apply_of_one_mul_eq_mul K f g φ x, mul_assoc, ← hu, huv, mul_one]
 
 /-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a
 finite-dimensional central simple `K`-algebra `A` is conjugation by a unit of `A`. -/

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -113,7 +113,7 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) :=
     ((Bimodule.of f).symm.trans (Bimodule.of g)).finrank_eq
   obtain ⟨φ⟩ := IsSimpleRing.nonempty_linearEquiv_of_finrank_eq (R := B ⊗[K] Aᵐᵒᵖ) K hrank
-  -- The three steps below need only linearity and surjectivity, so use `φ` as a linear map.
+  -- The two steps below need only linearity and that `of g 1` is hit, so use `φ` as a linear map.
   set ψ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g := φ.toLinearMap with hψ
   have hψsurj : Function.Surjective ψ := by rw [hψ]; simpa using φ.surjective
   obtain ⟨v, huv⟩ := Bimodule.exists_symm_apply_one_mul_eq_one ψ (hψsurj _)
@@ -127,9 +127,11 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   have hUval : ((Units.mkOfMulEqOne u v huv : Aˣ) : A) = u := Units.val_mkOfMulEqOne huv
   have hUinv : (↑(Units.mkOfMulEqOne u v huv)⁻¹ : A) = v :=
     Units.inv_eq_of_mul_eq_one_right (by rw [hUval]; exact huv)
+  -- Name the conjugation relation at the abstraction boundary, so `u` never has to be unfolded.
+  have hb : ∀ b : B, u * f b = g b * u :=
+    Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one ψ
   refine ⟨Units.mkOfMulEqOne u v huv, fun x ↦ ?_⟩
-  rw [hUval, hUinv, hu, Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one ψ x, mul_assoc, ← hu, huv,
-    mul_one]
+  rw [hUval, hUinv, hb x, mul_assoc, huv, mul_one]
 
 /-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a
 finite-dimensional central simple `K`-algebra `A` is conjugation by a unit of `A`. -/

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -116,7 +116,7 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   -- The three steps below need only linearity and surjectivity, so use `φ` as a linear map.
   set ψ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g := φ.toLinearMap with hψ
   have hψsurj : Function.Surjective ψ := by rw [hψ]; simpa using φ.surjective
-  obtain ⟨v, huv⟩ := Bimodule.exists_symm_apply_one_mul_eq_one ψ hψsurj
+  obtain ⟨v, huv⟩ := Bimodule.exists_symm_apply_one_mul_eq_one ψ (hψsurj _)
   -- `A` is finite-dimensional over a field, hence Artinian, hence Dedekind-finite
   -- (`IsArtinianRing.of_finite` is a theorem, not an instance, so it is supplied by hand).
   -- A right inverse therefore already presents the conjugator as a unit.

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -92,55 +92,6 @@ namespace TauCeti
 
 open scoped TensorProduct
 
-section BimoduleMap
-
-variable (K : Type*) {A B : Type*} [CommSemiring K] [Semiring A] [Algebra K A] [Semiring B]
-  [Algebra K B]
-
-/-- Transported along `Bimodule.of`, a `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g` sends
-`a` to its value at `1`, multiplied by `a`. -/
-private theorem symm_apply_eq_symm_apply_one_mul (f g : B →ₐ[K] A)
-    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
-    (Bimodule.of g).symm (φ (Bimodule.of f a))
-      = (Bimodule.of g).symm (φ (Bimodule.of f 1)) * a := by
-  -- Linearity for the right action of `A` fixes `φ` everywhere from its value at `1`.
-  have ha : Bimodule.of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 := by
-    rw [Bimodule.smul_of]; simp
-  rw [ha, map_smul, Bimodule.symm_smul]
-  simp
-
-/-- The transported value at `1` intertwines `f` and `g`: writing `u` for it, `u * f b = g b * u`
-for every `b : B`. -/
-private theorem symm_apply_one_mul_eq_mul_symm_apply_one (f g : B →ₐ[K] A)
-    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
-    (Bimodule.of g).symm (φ (Bimodule.of f 1)) * f b
-      = g b * (Bimodule.of g).symm (φ (Bimodule.of f 1)) := by
-  -- Linearity for the left action of `B`, read through `symm_apply_eq_symm_apply_one_mul`.
-  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
-  have hu' : φ (Bimodule.of f 1) = Bimodule.of g u := by rw [hu]; simp
-  have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 = Bimodule.of f (f b) := by
-    rw [Bimodule.smul_of]; simp
-  calc u * f b = (Bimodule.of g).symm (φ (Bimodule.of f (f b))) :=
-        (symm_apply_eq_symm_apply_one_mul K f g φ (f b)).symm
-    _ = (Bimodule.of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1)) := by
-          rw [h1]
-    _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (Bimodule.of f 1)) := by
-          rw [map_smul]
-    _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
-    _ = g b * u := by rw [Bimodule.smul_of]; simp
-
-/-- For a surjective `φ`, the transported value at `1` has a right inverse in `A`. -/
-private theorem exists_symm_apply_one_mul_eq_one (f g : B →ₐ[K] A)
-    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (hφ : Function.Surjective φ) :
-    ∃ v : A, (Bimodule.of g).symm (φ (Bimodule.of f 1)) * v = 1 := by
-  obtain ⟨y, hy⟩ := hφ (Bimodule.of g 1)
-  refine ⟨(Bimodule.of f).symm y, ?_⟩
-  have h := symm_apply_eq_symm_apply_one_mul K f g φ ((Bimodule.of f).symm y)
-  rw [LinearEquiv.apply_symm_apply, hy] at h
-  simpa using h.symm
-
-end BimoduleMap
-
 section SkolemNoether
 
 variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Algebra K B]
@@ -165,7 +116,7 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   -- The three steps below need only linearity and surjectivity, so use `φ` as a linear map.
   set ψ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g := φ.toLinearMap with hψ
   have hψsurj : Function.Surjective ψ := by rw [hψ]; simpa using φ.surjective
-  obtain ⟨v, huv⟩ := exists_symm_apply_one_mul_eq_one K f g ψ hψsurj
+  obtain ⟨v, huv⟩ := Bimodule.exists_symm_apply_one_mul_eq_one ψ hψsurj
   -- `A` is finite-dimensional over a field, hence Artinian, hence Dedekind-finite
   -- (`IsArtinianRing.of_finite` is a theorem, not an instance, so it is supplied by hand).
   -- A right inverse therefore already presents the conjugator as a unit.
@@ -177,7 +128,7 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   have hUinv : (↑(Units.mkOfMulEqOne u v huv)⁻¹ : A) = v :=
     Units.inv_eq_of_mul_eq_one_right (by rw [hUval]; exact huv)
   refine ⟨Units.mkOfMulEqOne u v huv, fun x ↦ ?_⟩
-  rw [hUval, hUinv, hu, symm_apply_one_mul_eq_mul_symm_apply_one K f g ψ x, mul_assoc, ← hu, huv,
+  rw [hUval, hUinv, hu, Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one ψ x, mul_assoc, ← hu, huv,
     mul_one]
 
 /-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a

--- a/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
+++ b/TauCeti/Algebra/CentralSimple/SkolemNoether.lean
@@ -92,33 +92,36 @@ namespace TauCeti
 
 open scoped TensorProduct
 
-section SkolemNoether
+section BimoduleMap
 
-variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Algebra K B]
+variable (K : Type*) {A B : Type*} [CommSemiring K] [Semiring A] [Algebra K A] [Semiring B]
+  [Algebra K B]
 
-/-- A `B ⊗[K] Aᵐᵒᵖ`-linear isomorphism `Bimodule f ≃ₗ Bimodule g`, transported to `A`, is left
-multiplication by the image of `1`: linearity for the right action of `A` fixes it on all of `A`. -/
-private theorem symm_apply_of_eq_mul (f g : B →ₐ[K] A)
-    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
+/-- Transported along `Bimodule.of`, a `B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g` sends
+`a` to its value at `1`, multiplied by `a`. -/
+private theorem symm_apply_eq_symm_apply_one_mul (f g : B →ₐ[K] A)
+    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (a : A) :
     (Bimodule.of g).symm (φ (Bimodule.of f a))
       = (Bimodule.of g).symm (φ (Bimodule.of f 1)) * a := by
+  -- Linearity for the right action of `A` fixes `φ` everywhere from its value at `1`.
   have ha : Bimodule.of f a = (1 ⊗ₜ MulOpposite.op a : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 := by
     rw [Bimodule.smul_of]; simp
   rw [ha, map_smul, Bimodule.symm_smul]
   simp
 
-/-- Linearity of `φ` for the left action of `B` turns the element of `TauCeti.symm_apply_of_eq_mul`
-into a conjugator: it intertwines `f` and `g`. -/
-private theorem symm_apply_of_one_mul_eq_mul (f g : B →ₐ[K] A)
-    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
+/-- The transported value at `1` intertwines `f` and `g`: writing `u` for it, `u * f b = g b * u`
+for every `b : B`. -/
+private theorem symm_apply_one_mul_eq_mul_symm_apply_one (f g : B →ₐ[K] A)
+    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (b : B) :
     (Bimodule.of g).symm (φ (Bimodule.of f 1)) * f b
       = g b * (Bimodule.of g).symm (φ (Bimodule.of f 1)) := by
+  -- Linearity for the left action of `B`, read through `symm_apply_eq_symm_apply_one_mul`.
   set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
   have hu' : φ (Bimodule.of f 1) = Bimodule.of g u := by rw [hu]; simp
   have h1 : (b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1 = Bimodule.of f (f b) := by
     rw [Bimodule.smul_of]; simp
   calc u * f b = (Bimodule.of g).symm (φ (Bimodule.of f (f b))) :=
-        (symm_apply_of_eq_mul K f g φ (f b)).symm
+        (symm_apply_eq_symm_apply_one_mul K f g φ (f b)).symm
     _ = (Bimodule.of g).symm (φ ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of f 1)) := by
           rw [h1]
     _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • φ (Bimodule.of f 1)) := by
@@ -126,15 +129,21 @@ private theorem symm_apply_of_one_mul_eq_mul (f g : B →ₐ[K] A)
     _ = (Bimodule.of g).symm ((b ⊗ₜ (1 : Aᵐᵒᵖ) : B ⊗[K] Aᵐᵒᵖ) • Bimodule.of g u) := by rw [hu']
     _ = g b * u := by rw [Bimodule.smul_of]; simp
 
-/-- Surjectivity of `φ` supplies a right inverse for the conjugator. -/
-private theorem exists_symm_apply_of_one_mul_eq_one (f g : B →ₐ[K] A)
-    (φ : Bimodule f ≃ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) :
+/-- For a surjective `φ`, the transported value at `1` has a right inverse in `A`. -/
+private theorem exists_symm_apply_one_mul_eq_one (f g : B →ₐ[K] A)
+    (φ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g) (hφ : Function.Surjective φ) :
     ∃ v : A, (Bimodule.of g).symm (φ (Bimodule.of f 1)) * v = 1 := by
-  obtain ⟨y, hy⟩ := φ.surjective (Bimodule.of g 1)
+  obtain ⟨y, hy⟩ := hφ (Bimodule.of g 1)
   refine ⟨(Bimodule.of f).symm y, ?_⟩
-  have h := symm_apply_of_eq_mul K f g φ ((Bimodule.of f).symm y)
+  have h := symm_apply_eq_symm_apply_one_mul K f g φ ((Bimodule.of f).symm y)
   rw [LinearEquiv.apply_symm_apply, hy] at h
   simpa using h.symm
+
+end BimoduleMap
+
+section SkolemNoether
+
+variable (K : Type*) {A B : Type*} [Field K] [Ring A] [Algebra K A] [Ring B] [Algebra K B]
 
 /-- **The Skolem-Noether theorem.** Two `K`-algebra homomorphisms `f g : B →ₐ[K] A` from a
 finite-dimensional **central simple** `K`-algebra `B` to a finite-dimensional **simple** `K`-algebra
@@ -153,19 +162,23 @@ theorem skolemNoether [IsSimpleRing A] [FiniteDimensional K A]
   have hrank : Module.finrank K (Bimodule f) = Module.finrank K (Bimodule g) :=
     ((Bimodule.of f).symm.trans (Bimodule.of g)).finrank_eq
   obtain ⟨φ⟩ := IsSimpleRing.nonempty_linearEquiv_of_finrank_eq (R := B ⊗[K] Aᵐᵒᵖ) K hrank
-  obtain ⟨v, huv⟩ := exists_symm_apply_of_one_mul_eq_one K f g φ
+  -- The three steps below need only linearity and surjectivity, so use `φ` as a linear map.
+  set ψ : Bimodule f →ₗ[B ⊗[K] Aᵐᵒᵖ] Bimodule g := φ.toLinearMap with hψ
+  have hψsurj : Function.Surjective ψ := by rw [hψ]; simpa using φ.surjective
+  obtain ⟨v, huv⟩ := exists_symm_apply_one_mul_eq_one K f g ψ hψsurj
   -- `A` is finite-dimensional over a field, hence Artinian, hence Dedekind-finite
   -- (`IsArtinianRing.of_finite` is a theorem, not an instance, so it is supplied by hand).
   -- A right inverse therefore already presents the conjugator as a unit.
   have : IsArtinianRing A := IsArtinianRing.of_finite K A
-  set u : A := (Bimodule.of g).symm (φ (Bimodule.of f 1)) with hu
+  set u : A := (Bimodule.of g).symm (ψ (Bimodule.of f 1)) with hu
   -- Name the two coercions of the constructed unit through the stable `Units` API rather than
   -- relying on `Units.mkOfMulEqOne` reducing definitionally.
   have hUval : ((Units.mkOfMulEqOne u v huv : Aˣ) : A) = u := Units.val_mkOfMulEqOne huv
   have hUinv : (↑(Units.mkOfMulEqOne u v huv)⁻¹ : A) = v :=
     Units.inv_eq_of_mul_eq_one_right (by rw [hUval]; exact huv)
   refine ⟨Units.mkOfMulEqOne u v huv, fun x ↦ ?_⟩
-  rw [hUval, hUinv, hu, symm_apply_of_one_mul_eq_mul K f g φ x, mul_assoc, ← hu, huv, mul_one]
+  rw [hUval, hUinv, hu, symm_apply_one_mul_eq_mul_symm_apply_one K f g ψ x, mul_assoc, ← hu, huv,
+    mul_one]
 
 /-- **Every automorphism of a central simple algebra is inner.** A `K`-algebra automorphism of a
 finite-dimensional central simple `K`-algebra `A` is conjugation by a unit of `A`. -/


### PR DESCRIPTION
`skolemNoether` carried a 51-line proof that derived, inline, the three facts about a
`B ⊗[K] Aᵐᵒᵖ`-linear map `Bimodule f →ₗ Bimodule g` that the argument actually runs on. Those facts
are about the bimodule interface, not about Skolem–Noether, and the centralizer theorem needs two
of them too — it was re-deriving them independently.

## Where the helpers live

They are **public**, in `TauCeti/Algebra/CentralSimple/Bimodule.lean` under `namespace Bimodule`,
`section Map`, beside the existing action lemmas `smul_of` / `symm_smul`. Writing `u` for
`(of g).symm (φ (of f 1))`, the transported value at `1`:

* `symm_apply_eq_symm_apply_one_mul` — `(of g).symm (φ (of f a)) = u * a`. Linearity for the right
  action of `A` fixes `φ` everywhere from its value at `1`.
* `apply_of` — the untransported companion, `φ (of f a) = of g (u * a)`. The file already ships
  both sides of this pair for the action (`smul_of` vs `symm_smul`), so both sides are the
  established interface here.
* `symm_apply_one_mul_eq_mul_symm_apply_one` — `u * f b = g b * u`, from linearity for the left
  action of `B`.
* `exists_symm_apply_one_mul_eq_one` — when `of g 1` is in the range of `φ`, `u` has a right
  inverse. Range membership is all that is used; surjectivity is more than needed.

## Two consumers

`SkolemNoether.lean`'s proof goes from 51 lines to 21, and `Centralizer.lean`'s
`centralizerAlgHom_bijective` now gets `key` and `hcomm` from `apply_of` and
`symm_apply_one_mul_eq_mul_symm_apply_one` at `f = g = B.val`, instead of re-deriving both:

```lean
have key : ∀ x : A, φ (Bimodule.of B.val x) = Bimodule.of B.val (c * x) := fun x => by
  simpa [hc] using Bimodule.apply_of (φ := φ) x
have hcomm : ∀ b ∈ (B : Set A), b * c = c * b := fun b hb => by
  simpa [hc] using
    (Bimodule.symm_apply_one_mul_eq_mul_symm_apply_one (φ := φ) ⟨b, hb⟩).symm
```

That second consumer is why the lemmas are public rather than private to `SkolemNoether.lean`, and
the module docstring names both.

## Annotations

Both normal-form equations carry `@[grind =]`. `@[simp]` is not available on
`symm_apply_eq_symm_apply_one_mul` or on `apply_of`: each RHS re-contains its own LHS at `a = 1`,
so simp loops through `mul_one`. That is demonstrated with compiler output in the `api-design`
thread, and the current `api-design` finding agrees ("not `@[simp]`: the RHS re-contains
`φ (of f 1)`, so simp would loop through `mul_one`").

## Scope

Four public lemmas added to `Bimodule.lean` under an existing namespace, its module docstring
updated to name both consumers, and the two consuming proofs rerouted. No statement of any
pre-existing declaration changes.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations.

Roadmap: RepresentationTheory
