### PR TITLE
feat(EllipticCurve): the denominator of a point's x-coordinate is powerful

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -14,9 +14,13 @@ Let `R` be a unique factorization domain with fraction field `K` and let `W : We
 have coefficients in `R`. Writing a `K`-point of `W` as a pair of reduced fractions
 `x = num x / den x` and `y = num y / den y` (Mathlib's `IsFractionRing.num` and
 `IsFractionRing.den`), the Weierstrass equation forces the denominator of the `x`-coordinate to
-be **powerful**: a prime dividing it divides it at least twice. Equivalently, `den x` is never a
+be **powerful**: a prime dividing it divides it at least twice. In particular `den x` is never a
 prime element — the form in which the Nagell–Lutz integrality argument uses it, where the rational
 root theorem has already bounded `den x` by a prime.
+
+This is weaker than the classical statement for a short model `y² = x³ + Ax + B` over `ℤ`, that
+`den x = d²` and `den y = d³` for some `d` — that needs the `q`-adic valuations to be *even*, not
+merely at least `2`, and goes through the formal group rather than the elementary descent below.
 
 The reason is a three-step descent. Clearing denominators in the Weierstrass equation gives an
 identity in `R`; if a prime `q` divides `den x` exactly once, then reducing that identity modulo
@@ -33,6 +37,14 @@ successive powers of `q` forces `q` to divide `den y` three times over, and fina
 This is the denominator input to the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
 No torsion hypothesis is needed here: the statements hold for every point.
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+that roadmap at `dev/modular-curves @ 9fec8eba7652`: the descent follows
+`LutzNagell/LutzNagellTheorem/PIDDenominators.lean`
+(`den_no_simple_prime_factor_of_on_curve`, `den_not_prime_of_on_curve`) and its positive restatement
+`den_powerful_of_on_curve` in `LutzNagell/LutzNagellTheorem/PIDMain.lean`.
 -/
 
 public section

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -31,7 +31,7 @@ of `y`.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_dvd`: a prime dividing the denominator of the
+* `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_of_dvd`: a prime dividing the denominator of the
   `x`-coordinate of a point divides it at least twice.
 * `TauCeti.WeierstrassCurve.not_prime_den`: the denominator of the `x`-coordinate of a point is
   not a prime element.
@@ -124,7 +124,7 @@ private lemma num_den_equation (h : (W.baseChange K).toAffine.Equation x y) :
 
 If `(x, y)` is a point of `W` over the fraction field `K` of a unique factorization domain `R`,
 then a prime of `R` dividing the denominator of `x` divides it at least twice. -/
-theorem sq_dvd_den_of_prime_dvd (h : (W.baseChange K).toAffine.Equation x y) (hq : Prime q)
+theorem sq_dvd_den_of_prime_of_dvd (h : (W.baseChange K).toAffine.Equation x y) (hq : Prime q)
     (hqd : q ∣ (den R x : R)) : q ^ 2 ∣ (den R x : R) := by
   by_contra hq2
   obtain ⟨u, hu⟩ := hqd
@@ -143,13 +143,13 @@ theorem sq_dvd_den_of_prime_dvd (h : (W.baseChange K).toAffine.Equation x y) (hq
 
 /-- **The denominator of the `x`-coordinate of a point is not prime.**
 
-The Nagell–Lutz form of `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_dvd`: a prime element is
+The Nagell–Lutz form of `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_of_dvd`: a prime element is
 not divisible by its own square, so it cannot be the denominator of the `x`-coordinate of a
 point. -/
 theorem not_prime_den (h : (W.baseChange K).toAffine.Equation x y) :
     ¬Prime (den R x : R) := fun hp ↦
   hp.not_isUnit <| hp.irreducible.squarefree _ <| by
-    simpa [sq] using sq_dvd_den_of_prime_dvd W h hp dvd_rfl
+    simpa [sq] using sq_dvd_den_of_prime_of_dvd W h hp dvd_rfl
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic
+public import Mathlib.RingTheory.Localization.NumDen
+
+/-!
+# Denominators of points on a Weierstrass curve over a unique factorization domain
+
+Let `R` be a unique factorization domain with fraction field `K` and let `W : WeierstrassCurve R`
+have coefficients in `R`. Writing a `K`-point of `W` as a pair of reduced fractions
+`x = num x / den x` and `y = num y / den y` (Mathlib's `IsFractionRing.num` and
+`IsFractionRing.den`), the Weierstrass equation forces the denominator of the `x`-coordinate to
+be **powerful**: a prime dividing it divides it at least twice. Equivalently, `den x` is never a
+prime element — the form in which the Nagell–Lutz integrality argument uses it, where the rational
+root theorem has already bounded `den x` by a prime.
+
+The reason is a three-step descent. Clearing denominators in the Weierstrass equation gives an
+identity in `R`; if a prime `q` divides `den x` exactly once, then reducing that identity modulo
+successive powers of `q` forces `q` to divide `den y` three times over, and finally to divide
+`num y` as well — contradicting the reducedness of `y`.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_dvd`: a prime dividing the denominator of the
+  `x`-coordinate of a point divides it at least twice.
+* `TauCeti.WeierstrassCurve.not_prime_den`: the denominator of the `x`-coordinate of a point is
+  not a prime element.
+
+This is the denominator input to the Nagell–Lutz integrality milestone of
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
+No torsion hypothesis is needed here: the statements hold for every point.
+-/
+
+public section
+
+open IsFractionRing
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+section Descent
+
+variable {R : Type*} [CommRing R] [NoZeroDivisors R]
+
+/-- The descent behind the powerful-denominator theorem, over a commutative ring without zero
+divisors — no fraction field, no curve.
+
+The hypothesis is the Weierstrass equation of `(γ / (q * u), e)` with denominators cleared, the
+cubic in the numerator of the `x`-coordinate split as `α ^ 3 + q * c`. Dividing the identity by
+`q ^ 2` and then by `q` in turn shows that `q` divides `e` three times over and divides `γ`, so
+`γ / e` is not in lowest terms. -/
+private lemma not_isRelPrime_of_cleared_equation {q u γ e α c A B : R} (hq : Prime q)
+    (hu : ¬q ∣ u) (hα : ¬q ∣ α) (h : γ ^ 2 * (q * u) ^ 3 + A * (q * u) ^ 2 * e
+      + B * (q * u) ^ 3 * e = e ^ 2 * (α ^ 3 + q * c)) : ¬IsRelPrime γ e := by
+  have hS : ¬q ∣ α ^ 3 + q * c := fun hd ↦
+    hα <| hq.dvd_of_dvd_pow <| (dvd_add_left (dvd_mul_right q c)).mp hd
+  -- Every term on the left is divisible by `q`, hence so is `e`.
+  have hdvd : q ∣ e ^ 2 * (α ^ 3 + q * c) := h ▸
+    ⟨γ ^ 2 * (q ^ 2 * u ^ 3) + A * (q * u ^ 2) * e + B * (q ^ 2 * u ^ 3) * e, by ring⟩
+  obtain ⟨e₁, he₁⟩ : q ∣ e := hq.dvd_of_dvd_pow ((hq.dvd_or_dvd hdvd).resolve_right hS)
+  -- Divide the identity by `q ^ 2`; the left-hand side is still divisible by `q`.
+  have h₂ : q * (γ ^ 2 * u ^ 3 + A * u ^ 2 * e₁ + B * q * u ^ 3 * e₁) =
+      e₁ ^ 2 * (α ^ 3 + q * c) := by
+    rw [he₁] at h
+    exact mul_left_cancel₀ (pow_ne_zero 2 hq.ne_zero) (by linear_combination h)
+  obtain ⟨e₂, he₂⟩ : q ∣ e₁ :=
+    hq.dvd_of_dvd_pow <| (hq.dvd_or_dvd ⟨_, h₂.symm⟩).resolve_right hS
+  -- Divide once more; now `q` divides `γ ^ 2 * u ^ 3`, and `q ∤ u`, so `q` divides `γ`.
+  have h₃ : γ ^ 2 * u ^ 3 + q * (A * u ^ 2 * e₂ + B * q * u ^ 3 * e₂) =
+      q * (e₂ ^ 2 * (α ^ 3 + q * c)) := by
+    rw [he₂] at h₂
+    exact mul_left_cancel₀ hq.ne_zero (by linear_combination h₂)
+  have hγ : q ∣ γ := hq.dvd_of_dvd_pow <| (hq.dvd_or_dvd (a := γ ^ 2) (b := u ^ 3)
+    ⟨e₂ ^ 2 * (α ^ 3 + q * c) - (A * u ^ 2 * e₂ + B * q * u ^ 3 * e₂),
+      by linear_combination h₃⟩).resolve_right fun hd ↦ hu (hq.dvd_of_dvd_pow hd)
+  exact fun hrel ↦ hq.not_isUnit (hrel hγ ⟨q * e₂, by rw [he₁, he₂]⟩)
+
+end Descent
+
+variable {R : Type*} [CommRing R] [IsDomain R] [UniqueFactorizationMonoid R]
+variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+variable (W : _root_.WeierstrassCurve R) {x y : K} {q : R}
+
+/-- The Weierstrass equation with the denominators of the two coordinates cleared: an identity
+in `R` between the numerators and denominators of a `K`-point. -/
+private lemma num_den_equation (h : (W.baseChange K).toAffine.Equation x y) :
+    num R y ^ 2 * (den R x : R) ^ 3 + W.a₁ * num R x * num R y * (den R x : R) ^ 2 * (den R y : R)
+        + W.a₃ * num R y * (den R x : R) ^ 3 * (den R y : R) =
+      (den R y : R) ^ 2 * (num R x ^ 3 + W.a₂ * num R x ^ 2 * (den R x : R)
+        + W.a₄ * num R x * (den R x : R) ^ 2 + W.a₆ * (den R x : R) ^ 3) := by
+  have hd : (algebraMap R K (den R x : R)) ≠ 0 :=
+    IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors (den R x).2
+  have he : (algebraMap R K (den R y : R)) ≠ 0 :=
+    IsFractionRing.to_map_ne_zero_of_mem_nonZeroDivisors (den R y).2
+  apply IsFractionRing.injective R K
+  rw [_root_.WeierstrassCurve.Affine.equation_iff, ← mk'_num_den' R x, ← mk'_num_den' R y] at h
+  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
+    _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
+    _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
+  push_cast
+  field_simp at h ⊢
+  linear_combination h
+
+/-- **The denominator of the `x`-coordinate of a point is powerful.**
+
+If `(x, y)` is a point of `W` over the fraction field `K` of a unique factorization domain `R`,
+then a prime of `R` dividing the denominator of `x` divides it at least twice. -/
+theorem sq_dvd_den_of_prime_dvd (h : (W.baseChange K).toAffine.Equation x y) (hq : Prime q)
+    (hqd : q ∣ (den R x : R)) : q ^ 2 ∣ (den R x : R) := by
+  by_contra hq2
+  obtain ⟨u, hu⟩ := hqd
+  have key := num_den_equation W h
+  rw [hu] at key
+  set α := num R x
+  set γ := num R y
+  set e := (den R y : R)
+  have hu' : ¬q ∣ u := fun ⟨v, hv⟩ ↦ hq2 ⟨v, by rw [hu, hv]; ring⟩
+  have hα : ¬q ∣ α := fun hd ↦ hq.not_isUnit (num_den_reduced R x hd ⟨u, hu⟩)
+  have hcl : γ ^ 2 * (q * u) ^ 3 + W.a₁ * α * γ * (q * u) ^ 2 * e
+      + W.a₃ * γ * (q * u) ^ 3 * e = e ^ 2 * (α ^ 3 +
+        q * (W.a₂ * α ^ 2 * u + W.a₄ * α * u ^ 2 * q + W.a₆ * u ^ 3 * q ^ 2)) := by
+    linear_combination key
+  exact not_isRelPrime_of_cleared_equation hq hu' hα hcl (num_den_reduced R y)
+
+/-- **The denominator of the `x`-coordinate of a point is not prime.**
+
+The Nagell–Lutz form of `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_dvd`: a prime element is
+not divisible by its own square, so it cannot be the denominator of the `x`-coordinate of a
+point. -/
+theorem not_prime_den (h : (W.baseChange K).toAffine.Equation x y) :
+    ¬Prime (den R x : R) := fun hp ↦
+  hp.not_isUnit <| hp.irreducible.squarefree _ <| by
+    simpa [sq] using sq_dvd_den_of_prime_dvd W h hp dvd_rfl
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -19,13 +19,15 @@ prime element — the form in which the Nagell–Lutz integrality argument uses 
 root theorem has already bounded `den x` by a prime.
 
 This is weaker than the classical statement for a short model `y² = x³ + Ax + B` over `ℤ`, that
-`den x = d²` and `den y = d³` for some `d` — that needs the `q`-adic valuations to be *even*, not
-merely at least `2`, and goes through the formal group rather than the elementary descent below.
+`den x = d²` and `den y = d³` for some `d`: that needs each `q`-adic valuation of `den x` to be
+*even*, not merely at least `2`. For a short model that parity follows from comparing valuations
+across `y² = x³ + Ax + B`; no such argument is carried out here, and the statement below is the
+weaker one the Nagell–Lutz route consumes.
 
-The reason is a three-step descent. Clearing denominators in the Weierstrass equation gives an
-identity in `R`; if a prime `q` divides `den x` exactly once, then reducing that identity modulo
-successive powers of `q` forces `q` to divide `den y` three times over, and finally to divide
-`num y` as well — contradicting the reducedness of `y`.
+The proof is a descent in three steps. Clearing denominators in the Weierstrass equation gives an
+identity in `R`; if a prime `q` divides `den x` exactly once, then dividing that identity by
+successive powers of `q` forces `q ^ 2 ∣ den y` and then `q ∣ num y` — contradicting the reducedness
+of `y`.
 
 ## Main results
 
@@ -64,8 +66,8 @@ divisors — no fraction field, no curve.
 
 The hypothesis is the Weierstrass equation of `(γ / (q * u), e)` with denominators cleared, the
 cubic in the numerator of the `x`-coordinate split as `α ^ 3 + q * c`. Dividing the identity by
-`q ^ 2` and then by `q` in turn shows that `q` divides `e` three times over and divides `γ`, so
-`γ / e` is not in lowest terms. -/
+`q ^ 2` and then by `q` in turn shows `q ^ 2 ∣ e` and then `q ∣ γ`, so `γ / e` is not in lowest
+terms. -/
 private lemma not_isRelPrime_of_cleared_equation {q u γ e α c A B : R} (hq : Prime q)
     (hu : ¬q ∣ u) (hα : ¬q ∣ α) (h : γ ^ 2 * (q * u) ^ 3 + A * (q * u) ^ 2 * e
       + B * (q * u) ^ 3 * e = e ^ 2 * (α ^ 3 + q * c)) : ¬IsRelPrime γ e := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean
@@ -64,8 +64,8 @@ variable {R : Type*} [CommRing R] [NoZeroDivisors R]
 /-- The descent behind the powerful-denominator theorem, over a commutative ring without zero
 divisors — no fraction field, no curve.
 
-The hypothesis is the Weierstrass equation of `(γ / (q * u), e)` with denominators cleared, the
-cubic in the numerator of the `x`-coordinate split as `α ^ 3 + q * c`. Dividing the identity by
+The hypothesis is the Weierstrass equation of the point `(α / (q * u), γ / e)` with denominators
+cleared, the cubic in the numerator of the `x`-coordinate split as `α ^ 3 + q * c`. Dividing by
 `q ^ 2` and then by `q` in turn shows `q ^ 2 ∣ e` and then `q ∣ γ`, so `γ / e` is not in lowest
 terms. -/
 private lemma not_isRelPrime_of_cleared_equation {q u γ e α c A B : R} (hq : Prime q)


### PR DESCRIPTION
For a Weierstrass curve `W` with coefficients in a unique factorization domain `R` with fraction
field `K`, this proves that the denominator of the `x`-coordinate of any `K`-point of `W` is
**powerful**: a prime of `R` dividing it divides it at least twice. The corollary is that this
denominator is never a prime element.

* `TauCeti.WeierstrassCurve.sq_dvd_den_of_prime_dvd`
* `TauCeti.WeierstrassCurve.not_prime_den`

Both hold for *every* point — no torsion, ellipticity, or minimality hypothesis. Coordinates are
Mathlib's reduced fractions `IsFractionRing.num`/`IsFractionRing.den`, and the point hypothesis is
Mathlib's `(W.baseChange K).toAffine.Equation x y`. The proof clears denominators in the
Weierstrass equation and runs a three-step `q`-adic descent on the resulting identity in `R`; that
descent is isolated as a private lemma over a commutative ring without zero divisors, mentioning
neither a curve nor a fraction field.

This advances `TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item "The torsion subgroup and
Nagell–Lutz", whose targets are `lutz_nagell` and `lutz_nagell_integrality_general`. It is the
denominator input that route consumes: the rational root theorem bounds `den x` by a prime, and
`not_prime_den` is what rules that prime out and yields `den x = 1`.

The layer's parenthetical that the "formal-group integrality refinement … is a named later milestone
consuming Layer 4's filtration" describes *deriving* powerfulness from the reduction filtration. The
provenance the roadmap pins proves it elementarily instead — its `den_powerful_of_on_curve` is a thin
wrapper around a UFD-level lemma, carrying the in-source note "Only needs `R` to be a UFD (not a
PID)". This PR is that elementary proof, and its imports are `Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Basic`
and `Mathlib.RingTheory.Localization.NumDen` and nothing else, so it cannot consume Layers 0–5 even
in principle.

Provenance: ported from the AINTLIB `NagellLutz` project (`CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`),
`LutzNagell/LutzNagellTheorem/{PIDDenominators,PIDMain}.lean` — `den_no_simple_prime_factor_of_on_curve`,
`den_not_prime_of_on_curve`, `den_powerful_of_on_curve`. Restated against Mathlib's `baseChange` and
`Affine.Equation` in place of a hand-written equation, with the positive `q ∣ den → q ^ 2 ∣ den`
conclusion replacing a `→ False` form, and the descent extracted as a curve-free lemma. The source
project's vendored copies of Mathlib's `EllipticDivisibilitySequence.lean` and
`DivisionPolynomial.lean` are not used and not carried over; `not_prime_den` routes through Mathlib's
`Irreducible.squarefree`.

New file `TauCeti/AlgebraicGeometry/EllipticCurve/Denominator.lean`, 143 lines, no other file touched.
Longest proof 25 lines.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md#layer-6-nagell-lutz-denominator-powerful"}-->
