### PR TITLE
feat: prove the tangent adjoint action is smooth

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -63,6 +63,12 @@ theorem conjDiffeomorph_apply (g x : G) :
   ConjAct.toConjAct_smul g x
 
 @[simp]
+theorem conjDiffeomorph_coe (g : G) :
+    (conjDiffeomorph (I := I) (n := n) g : G → G) = fun x ↦ g * x * g⁻¹ := by
+  funext x
+  exact conjDiffeomorph_apply g x
+
+@[simp]
 theorem conjDiffeomorph_symm_apply (g x : G) :
     (conjDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
   ConjAct.toConjAct_inv_smul g x

--- a/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Conjugation.lean
@@ -63,12 +63,6 @@ theorem conjDiffeomorph_apply (g x : G) :
   ConjAct.toConjAct_smul g x
 
 @[simp]
-theorem conjDiffeomorph_coe (g : G) :
-    (conjDiffeomorph (I := I) (n := n) g : G → G) = fun x ↦ g * x * g⁻¹ := by
-  funext x
-  exact conjDiffeomorph_apply g x
-
-@[simp]
 theorem conjDiffeomorph_symm_apply (g x : G) :
     (conjDiffeomorph (I := I) (n := n) g).symm x = g⁻¹ * x * g :=
   ConjAct.toConjAct_inv_smul g x

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -10,22 +10,28 @@ public import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
 /-!
 # Smoothness of the tangent adjoint action
 
-The differential of conjugation depends smoothly on both the conjugating group element and the
-tangent vector. Mathlib's smoothness theorem for manifold derivatives expresses the derivative in a
-moving chart frame. Since conjugation fixes the identity, this file cancels the resulting fixed
-tangent trivialization to recover the unframed tangent adjoint action.
+The differential of conjugation depends smoothly on the conjugating group element. Mathlib's
+smoothness theorem for manifold derivatives expresses the derivative in a moving chart frame. Since
+conjugation fixes the identity, this file cancels the resulting fixed tangent trivialization to
+recover the unframed tangent adjoint operator and its jointly smooth evaluation action.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
-## Main result
+## Main results
 
+* `TauCeti.Lie.contMDiff_adjointContinuousLinearMap`: the adjoint operator depends smoothly on the
+  group element.
 * `TauCeti.Lie.contMDiff_tangentAd_apply`: the joint action `(g, X) ↦ tangentAd g X` is smooth.
 
 ## References
 
 * [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
   Deliverable A, Layer 1, "The group adjoint".
+* Sébastien Gouëzel and Floris van Doorn's
+  `Mathlib.Geometry.Manifold.ContMDiffMFDeriv`, especially `ContMDiffAt.mfderiv`, supplies
+  smoothness of the conjugation differential in a fixed frame. The frame cancellation follows the
+  argument for `Pretrivialization.continuousLinearMap` in `Mathlib.Topology.VectorBundle.Hom`.
 -/
 
 public section
@@ -40,87 +46,85 @@ open scoped ContDiff Manifold
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+  [CompleteSpace E] [LieGroup I ∞ G]
 
-omit [FiniteDimensional ℝ E] in
+omit [CompleteSpace E] in
 private theorem cancel_inCoordinates_at (x : G)
-    (ϕ : TangentSpace I x →L[ℝ] TangentSpace I x) (v : TangentSpace I x) :
+    (ϕ : TangentSpace I x →L[ℝ] TangentSpace I x) :
     let e := trivializationAt E (TangentSpace I) x
-    e.symmL ℝ x
-      (ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
-        x x x x ϕ (e.continuousLinearMapAt ℝ x v)) = ϕ v := by
-  dsimp only
-  rw [ContinuousLinearMap.inCoordinates, ContinuousLinearMap.comp_apply,
-    ContinuousLinearMap.comp_apply,
-    Bundle.Trivialization.symmL_continuousLinearMapAt,
-    Bundle.Trivialization.symmL_continuousLinearMapAt] <;>
+    (e.symmL ℝ x).comp
+      ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
+        x x x x ϕ).comp (e.continuousLinearMapAt ℝ x)) = ϕ := by
+  apply ContinuousLinearMap.ext
+  intro v
+  have hcancel (w : TangentSpace I x) :
+      (trivializationAt E (TangentSpace I) x).symmL ℝ x
+        ((trivializationAt E (TangentSpace I) x).continuousLinearMapAt ℝ x w) = w := by
+    rw [Bundle.Trivialization.symmL_continuousLinearMapAt]
     exact FiberBundle.mem_baseSet_trivializationAt' x
+  simp only [ContinuousLinearMap.inCoordinates, ContinuousLinearMap.comp_apply]
+  rw [hcancel, hcancel]
 
-omit [FiniteDimensional ℝ E] in
-private theorem contMDiff_mfderiv_conj_apply :
-    ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
-      (fun p : G × E ↦ @id E
-        (mfderiv I I (conjDiffeomorph (I := I) (n := 3) p.1) 1
-          (show TangentSpace I (1 : G) from p.2))) := by
-  intro p
+omit [CompleteSpace E] in
+/-- The continuous linear operator underlying the tangent adjoint action depends smoothly on the
+group element. -/
+theorem contMDiff_adjointContinuousLinearMap :
+    ContMDiff I 𝓘(ℝ, E →L[ℝ] E) ∞
+      (fun g : G ↦ show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) := by
+  intro g
   let e := trivializationAt E (TangentSpace I) (1 : G)
   let A : TangentSpace I (1 : G) →L[ℝ] E := e.continuousLinearMapAt ℝ 1
   let B : E →L[ℝ] TangentSpace I (1 : G) := e.symmL ℝ 1
   let Amodel : E →L[ℝ] E := A
   let Bmodel : E →L[ℝ] E := B
-  have he : (1 : G) ∈ e.baseSet := FiberBundle.mem_baseSet_trivializationAt' 1
   let f : G → G → G := fun g x ↦ g * x * g⁻¹
   let c : G → G := fun _ ↦ 1
-  have hf : CMDiffAt ∞ (Function.uncurry f) (p.1, c p.1) := by
-    exact (contMDiff_fst.mul contMDiff_snd).mul contMDiff_fst.inv |>.contMDiffAt
-  have hA : CMDiffAt ∞ (fun x : G × E ↦ Amodel x.2) p :=
-    Amodel.contMDiffAt.comp p contMDiffAt_snd
-  have h := hf.mfderiv_apply (m := ∞) f c Prod.fst (fun x : G × E ↦ Amodel x.2)
-    contMDiffAt_const contMDiffAt_fst hA (by simp)
+  have hf : CMDiffAt ∞ (Function.uncurry f) (g, c g) := by
+    have h := contMDiff_smul (I := I) (I' := I) (n := ∞)
+      (G := ConjAct G) (M := G) (ConjAct.toConjAct g, c g)
+    change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g) at h
+    change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g)
+    exact h
+  have h := hf.mfderiv (m := ∞) f c contMDiffAt_const (by simp)
   have hfc : (fun x ↦ f x (c x)) = c := by
     funext x
     simp [f, c]
   rw [hfc] at h
-  have h' := Bmodel.contMDiffAt.comp p h
+  have hA : CMDiffAt ∞ (fun _ : G ↦ Amodel) g := contMDiffAt_const
+  have hB : CMDiffAt ∞ (fun _ : G ↦ Bmodel) g := contMDiffAt_const
+  have h' := hB.clm_comp (h.clm_comp hA)
   convert h' using 1
   funext x
-  let v : TangentSpace I (1 : G) := x.2
-  change @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := 3) x.1) 1) v) =
-    @id E (B ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
-      (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x.1) 1)) (A v)))
-  have hcancel :
-      B ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
-        (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x.1) 1)) (A v)) =
-          (mfderiv I I (f x.1) 1) v := by
-    dsimp only [A, B, e]
-    exact cancel_inCoordinates_at (I := I) (G := G) (x := 1)
-      (ϕ := mfderiv I I (f x.1) 1) (v := v)
-  rw [hcancel]
-  have hfun : (conjDiffeomorph (I := I) (n := 3) x.1 : G → G) = f x.1 := by
-    funext y
-    exact conjDiffeomorph_apply (I := I) (n := 3) x.1 y
+  -- Unfold the fixed source and target fibers hidden by `inTangentCoordinates`.
+  change (adjointContinuousLinearMap (I := I) x : E →L[ℝ] E) =
+    Bmodel.comp
+      ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
+        (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x) 1)).comp Amodel)
+  have hadj : (adjointContinuousLinearMap (I := I) x : E →L[ℝ] E) =
+      mfderiv I I (conjDiffeomorph (I := I) (n := 1) x) 1 := by
+    apply ContinuousLinearMap.ext
+    intro v
+    exact adjointContinuousLinearMap_apply (I := I) x v
+  rw [hadj]
+  have hfun : (conjDiffeomorph (I := I) (n := 1) x : G → G) = f x := by
+    simpa only [f] using conjDiffeomorph_coe (I := I) (n := 1) x
   rw [mfderiv_congr hfun]
-  rfl
+  symm
+  dsimp only [Amodel, Bmodel, A, B, e]
+  exact cancel_inCoordinates_at (I := I) (G := G) (x := 1)
+    (ϕ := mfderiv I I (f x) 1)
 
-/-- The tangent adjoint action is jointly smooth in the group element and tangent vector.
-
-The explicit `id` fixes the codomain as the model space `E`; `GroupLieAlgebra I G` is definitionally
-that space, but manifold typeclass search deliberately does not rely on this reduction. -/
+/-- The tangent adjoint action is jointly smooth in the group element and tangent vector. -/
 theorem contMDiff_tangentAd_apply :
     ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
-      (fun p : G × E ↦ @id E
-        (tangentAd (I := I) p.1 (show GroupLieAlgebra I G from p.2))) := by
-  apply contMDiff_mfderiv_conj_apply (I := I) (G := G) |>.congr
-  intro p
-  let v : GroupLieAlgebra I G := p.2
-  change @id E (tangentAd (I := I) p.1 v) =
-    @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := 3) p.1) 1) v)
-  rw [tangentAd_apply, adjointContinuousLinearMap_apply]
-  have hconj :
-      (conjDiffeomorph (I := I) (n := 1) p.1 : G → G) =
-        (conjDiffeomorph (I := I) (n := 3) p.1 : G → G) := by
-    funext x
-    simp only [conjDiffeomorph_apply]
-  exact congrArg (fun L : E →L[ℝ] E ↦ @id E (L v)) (mfderiv_congr hconj)
+      (fun p : G × E ↦
+        show E from tangentAd (I := I) p.1 (p.2 : GroupLieAlgebra I G)) := by
+  rw [show (fun p : G × E ↦
+      show E from tangentAd (I := I) p.1 (p.2 : GroupLieAlgebra I G)) =
+      fun p ↦ (show E →L[ℝ] E from adjointContinuousLinearMap (I := I) p.1) p.2 by
+    funext p
+    exact tangentAd_apply (I := I) p.1 p.2]
+  exact ((contMDiff_adjointContinuousLinearMap (I := I) (G := G)).comp contMDiff_fst).clm_apply
+    contMDiff_snd
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -60,7 +60,7 @@ omit [FiniteDimensional ℝ E] in
 private theorem contMDiff_mfderiv_conj_apply :
     ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
       (fun p : G × E ↦ @id E
-        (mfderiv I I (conjDiffeomorph (I := I) (n := ∞) p.1) 1
+        (mfderiv I I (conjDiffeomorph (I := I) (n := 3) p.1) 1
           (show TangentSpace I (1 : G) from p.2))) := by
   intro p
   let e := trivializationAt E (TangentSpace I) (1 : G)
@@ -85,7 +85,7 @@ private theorem contMDiff_mfderiv_conj_apply :
   convert h' using 1
   funext x
   let v : TangentSpace I (1 : G) := x.2
-  change @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := ∞) x.1) 1) v) =
+  change @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := 3) x.1) 1) v) =
     @id E (B ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
       (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x.1) 1)) (A v)))
   have hcancel :
@@ -96,9 +96,9 @@ private theorem contMDiff_mfderiv_conj_apply :
     exact cancel_inCoordinates_at (I := I) (G := G) (x := 1)
       (ϕ := mfderiv I I (f x.1) 1) (v := v)
   rw [hcancel]
-  have hfun : (conjDiffeomorph (I := I) (n := ∞) x.1 : G → G) = f x.1 := by
+  have hfun : (conjDiffeomorph (I := I) (n := 3) x.1 : G → G) = f x.1 := by
     funext y
-    exact conjDiffeomorph_apply (I := I) (n := ∞) x.1 y
+    exact conjDiffeomorph_apply (I := I) (n := 3) x.1 y
   rw [mfderiv_congr hfun]
   rfl
 
@@ -114,7 +114,7 @@ theorem contMDiff_tangentAd_apply :
   intro p
   let v : GroupLieAlgebra I G := p.2
   change @id E (tangentAd (I := I) p.1 v) =
-    @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := ∞) p.1) 1) v)
+    @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := 3) p.1) 1) v)
   rw [tangentAd_apply, adjointContinuousLinearMap_apply]
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Adjoint.Basic
+public import Mathlib.Geometry.Manifold.ContMDiffMFDeriv
+
+/-!
+# Smoothness of the tangent adjoint action
+
+The differential of conjugation depends smoothly on both the conjugating group element and the
+tangent vector. Mathlib's smoothness theorem for manifold derivatives expresses the derivative in a
+moving chart frame. Since conjugation fixes the identity, this file cancels the resulting fixed
+tangent trivialization to recover the unframed tangent adjoint action.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main result
+
+* `TauCeti.Lie.contMDiff_tangentAd_apply`: the joint action `(g, X) ↦ tangentAd g X` is smooth.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open Manifold
+open scoped ContDiff Manifold
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
+
+omit [FiniteDimensional ℝ E] in
+private theorem cancel_inCoordinates_at (x : G)
+    (ϕ : TangentSpace I x →L[ℝ] TangentSpace I x) (v : TangentSpace I x) :
+    let e := trivializationAt E (TangentSpace I) x
+    e.symmL ℝ x
+      (ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
+        x x x x ϕ (e.continuousLinearMapAt ℝ x v)) = ϕ v := by
+  dsimp only
+  rw [ContinuousLinearMap.inCoordinates, ContinuousLinearMap.comp_apply,
+    ContinuousLinearMap.comp_apply,
+    Bundle.Trivialization.symmL_continuousLinearMapAt,
+    Bundle.Trivialization.symmL_continuousLinearMapAt] <;>
+    exact FiberBundle.mem_baseSet_trivializationAt' x
+
+omit [FiniteDimensional ℝ E] in
+private theorem contMDiff_mfderiv_conj_apply :
+    ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
+      (fun p : G × E ↦ @id E
+        (mfderiv I I (conjDiffeomorph (I := I) (n := ∞) p.1) 1
+          (show TangentSpace I (1 : G) from p.2))) := by
+  intro p
+  let e := trivializationAt E (TangentSpace I) (1 : G)
+  let A : TangentSpace I (1 : G) →L[ℝ] E := e.continuousLinearMapAt ℝ 1
+  let B : E →L[ℝ] TangentSpace I (1 : G) := e.symmL ℝ 1
+  let Amodel : E →L[ℝ] E := A
+  let Bmodel : E →L[ℝ] E := B
+  have he : (1 : G) ∈ e.baseSet := FiberBundle.mem_baseSet_trivializationAt' 1
+  let f : G → G → G := fun g x ↦ g * x * g⁻¹
+  let c : G → G := fun _ ↦ 1
+  have hf : CMDiffAt ∞ (Function.uncurry f) (p.1, c p.1) := by
+    exact (contMDiff_fst.mul contMDiff_snd).mul contMDiff_fst.inv |>.contMDiffAt
+  have hA : CMDiffAt ∞ (fun x : G × E ↦ Amodel x.2) p :=
+    Amodel.contMDiffAt.comp p contMDiffAt_snd
+  have h := hf.mfderiv_apply (m := ∞) f c Prod.fst (fun x : G × E ↦ Amodel x.2)
+    contMDiffAt_const contMDiffAt_fst hA (by simp)
+  have hfc : (fun x ↦ f x (c x)) = c := by
+    funext x
+    simp [f, c]
+  rw [hfc] at h
+  have h' := Bmodel.contMDiffAt.comp p h
+  convert h' using 1
+  funext x
+  let v : TangentSpace I (1 : G) := x.2
+  change @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := ∞) x.1) 1) v) =
+    @id E (B ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
+      (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x.1) 1)) (A v)))
+  have hcancel :
+      B ((ContinuousLinearMap.inCoordinates E (TangentSpace I) E (TangentSpace I)
+        (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x.1) 1)) (A v)) =
+          (mfderiv I I (f x.1) 1) v := by
+    dsimp only [A, B, e]
+    exact cancel_inCoordinates_at (I := I) (G := G) (x := 1)
+      (ϕ := mfderiv I I (f x.1) 1) (v := v)
+  rw [hcancel]
+  have hfun : (conjDiffeomorph (I := I) (n := ∞) x.1 : G → G) = f x.1 := by
+    funext y
+    exact conjDiffeomorph_apply (I := I) (n := ∞) x.1 y
+  rw [mfderiv_congr hfun]
+  rfl
+
+/-- The tangent adjoint action is jointly smooth in the group element and tangent vector.
+
+The explicit `id` fixes the codomain as the model space `E`; `GroupLieAlgebra I G` is definitionally
+that space, but manifold typeclass search deliberately does not rely on this reduction. -/
+theorem contMDiff_tangentAd_apply :
+    ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
+      (fun p : G × E ↦ @id E
+        (tangentAd (I := I) p.1 (show GroupLieAlgebra I G from p.2))) := by
+  apply contMDiff_mfderiv_conj_apply (I := I) (G := G) |>.congr
+  intro p
+  let v : GroupLieAlgebra I G := p.2
+  change @id E (tangentAd (I := I) p.1 v) =
+    @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := ∞) p.1) 1) v)
+  rw [tangentAd_apply, adjointContinuousLinearMap_apply]
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -49,7 +49,8 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   [CompleteSpace E] [LieGroup I ∞ G]
 
 omit [CompleteSpace E] in
-private theorem cancel_inCoordinates_at (x : G)
+private theorem cancel_inCoordinates_at {M : Type*} [TopologicalSpace M] [ChartedSpace H M]
+    [IsManifold I 1 M] (x : M)
     (ϕ : TangentSpace I x →L[ℝ] TangentSpace I x) :
     let e := trivializationAt E (TangentSpace I) x
     (e.symmL ℝ x).comp
@@ -70,6 +71,8 @@ omit [CompleteSpace E] in
 group element. -/
 theorem contMDiff_adjointContinuousLinearMap :
     ContMDiff I 𝓘(ℝ, E →L[ℝ] E) ∞
+      -- `GroupLieAlgebra I G` definitionally reduces to the tangent model `E`; the ascription
+      -- exposes that model to the normed-space smoothness API.
       (fun g : G ↦ show E →L[ℝ] E from adjointContinuousLinearMap (I := I) g) := by
   intro g
   let e := trivializationAt E (TangentSpace I) (1 : G)
@@ -77,7 +80,7 @@ theorem contMDiff_adjointContinuousLinearMap :
   let B : E →L[ℝ] TangentSpace I (1 : G) := e.symmL ℝ 1
   let Amodel : E →L[ℝ] E := A
   let Bmodel : E →L[ℝ] E := B
-  let f : G → G → G := fun g x ↦ g * x * g⁻¹
+  let f : G → G → G := fun g ↦ conjDiffeomorph (I := I) (n := 1) g
   let c : G → G := fun _ ↦ 1
   have hf : CMDiffAt ∞ (Function.uncurry f) (g, c g) := by
     have h := contMDiff_smul (I := I) (I' := I) (n := ∞)
@@ -86,7 +89,9 @@ theorem contMDiff_adjointContinuousLinearMap :
     -- its scalar action is definitionally conjugation. Since `contMDiff_smul` exposes the domain
     -- as `ConjAct G × G`, crossing that wrapper requires this definitional reduction.
     change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g) at h
-    change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g)
+    rw [show Function.uncurry f = fun p : G × G ↦ p.1 * p.2 * p.1⁻¹ by
+      funext p
+      exact conjDiffeomorph_apply p.1 p.2]
     exact h
   have h := hf.mfderiv (m := ∞) f c contMDiffAt_const (by simp)
   have hfc : (fun x ↦ f x (c x)) = c := by
@@ -105,17 +110,16 @@ theorem contMDiff_adjointContinuousLinearMap :
         (1 : G) (1 : G) (1 : G) (1 : G) (mfderiv I I (f x) 1)).comp Amodel)
   have hadj : (adjointContinuousLinearMap (I := I) x : E →L[ℝ] E) =
       mfderiv I I (conjDiffeomorph (I := I) (n := 1) x) 1 := by
+    -- The public definitions from `Basic` are opaque here, so use its exported pointwise
+    -- comparison theorem and extensionality to compare the operators.
     apply ContinuousLinearMap.ext
     intro v
     exact adjointContinuousLinearMap_apply (I := I) x v
   rw [hadj]
-  have hfun : (conjDiffeomorph (I := I) (n := 1) x : G → G) = f x := by
-    funext y
-    exact conjDiffeomorph_apply x y
-  rw [mfderiv_congr hfun]
+  dsimp only [f]
   symm
   dsimp only [Amodel, Bmodel, A, B, e]
-  exact cancel_inCoordinates_at (I := I) (G := G) (x := 1)
+  exact cancel_inCoordinates_at (I := I) (M := G) (x := 1)
     (ϕ := mfderiv I I (f x) 1)
 
 /-- The tangent adjoint action is jointly smooth in the group element and tangent vector. -/
@@ -123,6 +127,8 @@ theorem contMDiff_tangentAd_apply :
     ContMDiff (I.prod 𝓘(ℝ, E)) 𝓘(ℝ, E) ∞
       (fun p : G × E ↦
         show E from tangentAd (I := I) p.1 (p.2 : GroupLieAlgebra I G)) := by
+  -- `GroupLieAlgebra I G` is definitionally the model `E`; these ascriptions expose the model on
+  -- both sides so the continuous-linear-map application theorem can be used.
   rw [show (fun p : G × E ↦
       show E from tangentAd (I := I) p.1 (p.2 : GroupLieAlgebra I G)) =
       fun p ↦ (show E →L[ℝ] E from adjointContinuousLinearMap (I := I) p.1) p.2 by

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -82,6 +82,9 @@ theorem contMDiff_adjointContinuousLinearMap :
   have hf : CMDiffAt ∞ (Function.uncurry f) (g, c g) := by
     have h := contMDiff_smul (I := I) (I' := I) (n := ∞)
       (G := ConjAct G) (M := G) (ConjAct.toConjAct g, c g)
+    -- `ConjAct G` is a type synonym carrying definitionally the topology and charts of `G`, and
+    -- its scalar action is definitionally conjugation. Since `contMDiff_smul` exposes the domain
+    -- as `ConjAct G × G`, crossing that wrapper requires this definitional reduction.
     change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g) at h
     change CMDiffAt ∞ (fun p : G × G ↦ p.1 * p.2 * p.1⁻¹) (g, c g)
     exact h
@@ -107,7 +110,8 @@ theorem contMDiff_adjointContinuousLinearMap :
     exact adjointContinuousLinearMap_apply (I := I) x v
   rw [hadj]
   have hfun : (conjDiffeomorph (I := I) (n := 1) x : G → G) = f x := by
-    simpa only [f] using conjDiffeomorph_coe (I := I) (n := 1) x
+    funext y
+    exact conjDiffeomorph_apply x y
   rw [mfderiv_congr hfun]
   symm
   dsimp only [Amodel, Bmodel, A, B, e]

--- a/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Smooth.lean
@@ -116,5 +116,11 @@ theorem contMDiff_tangentAd_apply :
   change @id E (tangentAd (I := I) p.1 v) =
     @id E ((mfderiv I I (conjDiffeomorph (I := I) (n := 3) p.1) 1) v)
   rw [tangentAd_apply, adjointContinuousLinearMap_apply]
+  have hconj :
+      (conjDiffeomorph (I := I) (n := 1) p.1 : G → G) =
+        (conjDiffeomorph (I := I) (n := 3) p.1 : G → G) := by
+    funext x
+    simp only [conjDiffeomorph_apply]
+  exact congrArg (fun L : E →L[ℝ] E ↦ @id E (L v)) (mfderiv_congr hconj)
 
 end TauCeti.Lie


### PR DESCRIPTION
## Goal

Advance Deliverable A, Layer 1 by proving that the tangent-space adjoint action varies smoothly in both the group element and the Lie-algebra vector. This supplies the analytic input needed to package `Ad` as the roadmap's smooth representation.

## Why this works

Mathlib's parameterized manifold-derivative theorem gives smooth dependence of the differential of conjugation in a moving chart frame. Because every conjugation map fixes the identity, the source and target tangent fibers are fixed; composing with the tangent-bundle trivialization and its inverse cancels that frame and recovers the unframed differential defining `tangentAd`. The final comparison explicitly identifies the conjugation diffeomorphisms at the regularities used by the foundational adjoint API and by the smoothness proof, so the result is stated directly against the canonical `tangentAd` rather than a parallel construction.

The exact roadmap target is [`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 1, "The group adjoint"](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad).

## Validation

`lake build TauCeti.Geometry.Lie.Adjoint.Smooth`

Roadmap: RepresentationTheory
