### PR TITLE
feat: transport the adjoint action to derivations

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -15,9 +15,11 @@ The tangent adjoint action is transported across the canonical Lie equivalence b
 space at the identity and left-invariant derivations. The result is the roadmap-facing group adjoint
 `Ad` on Mathlib's Lie algebra `LeftInvariantDerivation I G`.
 
-The Hausdorff hypothesis is inherited from the canonical derivation–tangent equivalence: its proof
-uses global smooth functions to identify point derivations with tangent vectors. No boundaryless
-manifold assumption is needed, because a Lie group's identity is automatically an interior point.
+The canonical derivation–tangent equivalence uses Hausdorffness to identify point derivations with
+tangent vectors through global smooth functions. This imposes no extra public hypothesis on `Ad`
+or its group laws: a charted space over the normed model is `T1`, and a `T1` topological group is
+Hausdorff. No boundaryless manifold assumption is needed, because a Lie group's identity is
+automatically an interior point.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
@@ -49,13 +51,22 @@ open scoped Manifold ContDiff
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
+
+omit [FiniteDimensional ℝ E] in
+private theorem t2Space_of_lieGroup
+    (I : ModelWithCorners ℝ E H) (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
+    [Group G] [LieGroup I ∞ G] : T2Space G := by
+  let _ : T1Space G := I.t1Space G
+  let _ : IsTopologicalGroup G := topologicalGroup_of_lieGroup I ∞
+  exact IsTopologicalGroup.t2Space_iff_one_closed.mpr isClosed_singleton
 
 /-- The group adjoint on left-invariant derivations, obtained by transporting the differential of
 conjugation across evaluation at the identity. -/
 def Ad (g : G) : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
+  let _ : T2Space G := t2Space_of_lieGroup I G
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra
     (I := I) (G := G) (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
   (e.trans (tangentAd (I := I) g)).trans e.symm
@@ -63,7 +74,7 @@ def Ad (g : G) : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDeriva
 /-- Applying the derivation adjoint is applying the tangent adjoint through the canonical Lie
 equivalence. -/
 @[simp]
-theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
+theorem Ad_apply [T2Space G] (g : G) (D : LeftInvariantDerivation I G) :
     Ad (I := I) g D =
       (leftInvariantDerivationLieEquivGroupLieAlgebra
           (I := I) (G := G)
@@ -77,6 +88,7 @@ theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
 /-- The identity element acts trivially on left-invariant derivations. -/
 @[simp]
 theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
+  let _ : T2Space G := t2Space_of_lieGroup I G
   apply LieEquiv.ext
   intro D
   rw [Ad_apply, tangentAd_one, LieEquiv.refl_apply]
@@ -87,6 +99,7 @@ theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
 /-- A product acts by the composite of the two derivation adjoint automorphisms. -/
 theorem Ad_mul (g h : G) :
     Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
+  let _ : T2Space G := t2Space_of_lieGroup I G
   apply LieEquiv.ext
   intro D
   rw [Ad_apply, tangentAd_mul, LieEquiv.trans_apply, LieEquiv.trans_apply,

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -44,9 +44,7 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
   [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
 
-local instance lieGroupMinSmoothnessThreeDerivation : LieGroup I (minSmoothness ℝ 3) G :=
-  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
-    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+attribute [local instance] LieGroup.minSmoothnessThree
 
 /-- The group adjoint on left-invariant derivations, obtained by transporting the differential of
 conjugation across evaluation at the identity. -/

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -55,26 +55,16 @@ variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 
-omit [FiniteDimensional ℝ E] in
-private theorem t2Space_of_lieGroup
-    (I : ModelWithCorners ℝ E H) (G : Type*) [TopologicalSpace G] [ChartedSpace H G]
-    [Group G] [LieGroup I ∞ G] : T2Space G := by
-  let _ : T1Space G := I.t1Space G
-  let _ : IsTopologicalGroup G := topologicalGroup_of_lieGroup I ∞
-  exact IsTopologicalGroup.t2Space_iff_one_closed.mpr isClosed_singleton
-
 /-- The group adjoint on left-invariant derivations, obtained by transporting the differential of
 conjugation across evaluation at the identity. -/
 def Ad (g : G) : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
-  let _ : T2Space G := t2Space_of_lieGroup I G
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra
     (I := I) (G := G) (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
   (e.trans (tangentAd (I := I) g)).trans e.symm
 
 /-- Applying the derivation adjoint is applying the tangent adjoint through the canonical Lie
 equivalence. -/
-@[simp]
-theorem Ad_apply [T2Space G] (g : G) (D : LeftInvariantDerivation I G) :
+theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
     Ad (I := I) g D =
       (leftInvariantDerivationLieEquivGroupLieAlgebra
           (I := I) (G := G)
@@ -85,10 +75,23 @@ theorem Ad_apply [T2Space G] (g : G) (D : LeftInvariantDerivation I G) :
             (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) D)) :=
   (rfl)
 
+/-- Evaluation at the identity intertwines the derivation and tangent adjoint actions. -/
+@[simp]
+theorem leftInvariantDerivationLieEquivGroupLieAlgebra_Ad
+    (g : G) (D : LeftInvariantDerivation I G) :
+    leftInvariantDerivationLieEquivGroupLieAlgebra
+        (I := I) (G := G)
+        (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+        (Ad (I := I) g D) =
+      tangentAd (I := I) g
+        (leftInvariantDerivationLieEquivGroupLieAlgebra
+          (I := I) (G := G)
+          (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) D) := by
+  rw [Ad_apply, LieEquiv.apply_symm_apply]
+
 /-- The identity element acts trivially on left-invariant derivations. -/
 @[simp]
 theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
-  let _ : T2Space G := t2Space_of_lieGroup I G
   apply LieEquiv.ext
   intro D
   rw [Ad_apply, tangentAd_one, LieEquiv.refl_apply]
@@ -97,9 +100,9 @@ theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
     (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))).symm_apply_apply D
 
 /-- A product acts by the composite of the two derivation adjoint automorphisms. -/
+@[simp]
 theorem Ad_mul (g h : G) :
     Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
-  let _ : T2Space G := t2Space_of_lieGroup I G
   apply LieEquiv.ext
   intro D
   rw [Ad_apply, tangentAd_mul, LieEquiv.trans_apply, LieEquiv.trans_apply,
@@ -108,15 +111,11 @@ theorem Ad_mul (g h : G) :
 /-- The adjoint of an inverse is the inverse adjoint automorphism. -/
 @[simp]
 theorem Ad_inv (g : G) : Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
-  apply LieEquiv.ext
-  intro D
-  apply (Ad (I := I) g).injective
-  change Ad (I := I) g (Ad (I := I) g⁻¹ D) =
-    Ad (I := I) g ((Ad (I := I) g).symm D)
-  rw [LieEquiv.apply_symm_apply]
-  have h := congrArg
-    (fun e : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G ↦ e D)
-    (Ad_mul (I := I) g g⁻¹)
-  simpa only [mul_inv_cancel, Ad_one, LieEquiv.refl_apply, LieEquiv.trans_apply] using h.symm
+  let e := leftInvariantDerivationLieEquivGroupLieAlgebra
+    (I := I) (G := G) (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+  change (e.trans (tangentAd (I := I) g⁻¹)).trans e.symm =
+    ((e.trans (tangentAd (I := I) g)).trans e.symm).symm
+  rw [tangentAd_inv]
+  rfl
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -1,0 +1,96 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Adjoint.Basic
+public import TauCeti.Geometry.Lie.Tangent.LieEquiv
+
+/-!
+# The adjoint action on left-invariant derivations
+
+The tangent adjoint action is transported across the canonical Lie equivalence between the tangent
+space at the identity and left-invariant derivations. The result is the roadmap-facing group adjoint
+`Ad` on Mathlib's Lie algebra `LeftInvariantDerivation I G`.
+
+This advances Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main definitions
+
+* `TauCeti.Lie.Ad`: the group adjoint as an automorphism of left-invariant derivations.
+
+## Main results
+
+* `TauCeti.Lie.Ad_mul`: the group adjoint respects multiplication.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open scoped Manifold ContDiff
+
+variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+
+local instance lieGroupMinSmoothnessThreeDerivation : LieGroup I (minSmoothness ℝ 3) G :=
+  LieGroup.of_le (I := I) (G := G) (m := minSmoothness ℝ 3) (n := ∞)
+    (by simpa using (inferInstance : ENat.LEInfty (3 : ℕ∞ω)).out)
+
+/-- The group adjoint on left-invariant derivations, obtained by transporting the differential of
+conjugation across evaluation at the identity. -/
+def Ad (g : G) : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
+  let e := leftInvariantDerivationLieEquivGroupLieAlgebra
+    (I := I) (G := G) BoundarylessManifold.isInteriorPoint
+  (e.trans (tangentAd (I := I) g)).trans e.symm
+
+@[simp]
+theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
+    Ad (I := I) g D =
+      (leftInvariantDerivationLieEquivGroupLieAlgebra
+          (I := I) (G := G) BoundarylessManifold.isInteriorPoint).symm
+        (tangentAd (I := I) g
+          (leftInvariantDerivationLieEquivGroupLieAlgebra
+            (I := I) (G := G) BoundarylessManifold.isInteriorPoint D)) :=
+  (rfl)
+
+@[simp]
+theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
+  apply LieEquiv.ext
+  intro D
+  rw [Ad_apply, tangentAd_one, LieEquiv.refl_apply]
+  exact (leftInvariantDerivationLieEquivGroupLieAlgebra
+    (I := I) (G := G) BoundarylessManifold.isInteriorPoint).symm_apply_apply D
+
+theorem Ad_mul (g h : G) :
+    Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
+  apply LieEquiv.ext
+  intro D
+  rw [Ad_apply, tangentAd_mul, LieEquiv.trans_apply, LieEquiv.trans_apply,
+    Ad_apply, Ad_apply, LieEquiv.apply_symm_apply]
+
+@[simp]
+theorem Ad_inv (g : G) : Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
+  apply LieEquiv.ext
+  intro D
+  apply (Ad (I := I) g).injective
+  change Ad (I := I) g (Ad (I := I) g⁻¹ D) =
+    Ad (I := I) g ((Ad (I := I) g).symm D)
+  rw [LieEquiv.apply_symm_apply]
+  have h := congrArg
+    (fun e : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G ↦ e D)
+    (Ad_mul (I := I) g g⁻¹)
+  simpa only [mul_inv_cancel, Ad_one, LieEquiv.refl_apply, LieEquiv.trans_apply] using h.symm
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Geometry.Lie.Adjoint.Basic
+public import TauCeti.Geometry.Lie.Interior
 public import TauCeti.Geometry.Lie.Tangent.LieEquiv
 
 /-!
@@ -13,6 +14,10 @@ public import TauCeti.Geometry.Lie.Tangent.LieEquiv
 The tangent adjoint action is transported across the canonical Lie equivalence between the tangent
 space at the identity and left-invariant derivations. The result is the roadmap-facing group adjoint
 `Ad` on Mathlib's Lie algebra `LeftInvariantDerivation I G`.
+
+The Hausdorff hypothesis is inherited from the canonical derivation–tangent equivalence: its proof
+uses global smooth functions to identify point derivations with tangent vectors. No boundaryless
+manifold assumption is needed, because a Lie group's identity is automatically an interior point.
 
 This advances Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
@@ -23,7 +28,9 @@ This advances Deliverable A, Layer 1 of
 
 ## Main results
 
+* `TauCeti.Lie.Ad_one`: the identity acts trivially.
 * `TauCeti.Lie.Ad_mul`: the group adjoint respects multiplication.
+* `TauCeti.Lie.Ad_inv`: inversion corresponds to the inverse automorphism.
 
 ## References
 
@@ -42,7 +49,7 @@ open scoped Manifold ContDiff
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners ℝ E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
-  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G] [BoundarylessManifold I G]
+  [FiniteDimensional ℝ E] [LieGroup I ∞ G] [T2Space G]
 
 attribute [local instance] LieGroup.minSmoothnessThree
 
@@ -50,27 +57,34 @@ attribute [local instance] LieGroup.minSmoothnessThree
 conjugation across evaluation at the identity. -/
 def Ad (g : G) : LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ LeftInvariantDerivation I G :=
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra
-    (I := I) (G := G) BoundarylessManifold.isInteriorPoint
+    (I := I) (G := G) (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
   (e.trans (tangentAd (I := I) g)).trans e.symm
 
+/-- Applying the derivation adjoint is applying the tangent adjoint through the canonical Lie
+equivalence. -/
 @[simp]
 theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
     Ad (I := I) g D =
       (leftInvariantDerivationLieEquivGroupLieAlgebra
-          (I := I) (G := G) BoundarylessManifold.isInteriorPoint).symm
+          (I := I) (G := G)
+          (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))).symm
         (tangentAd (I := I) g
           (leftInvariantDerivationLieEquivGroupLieAlgebra
-            (I := I) (G := G) BoundarylessManifold.isInteriorPoint D)) :=
+            (I := I) (G := G)
+            (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G)) D)) :=
   (rfl)
 
+/-- The identity element acts trivially on left-invariant derivations. -/
 @[simp]
 theorem Ad_one : Ad (I := I) (1 : G) = LieEquiv.refl := by
   apply LieEquiv.ext
   intro D
   rw [Ad_apply, tangentAd_one, LieEquiv.refl_apply]
   exact (leftInvariantDerivationLieEquivGroupLieAlgebra
-    (I := I) (G := G) BoundarylessManifold.isInteriorPoint).symm_apply_apply D
+    (I := I) (G := G)
+    (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))).symm_apply_apply D
 
+/-- A product acts by the composite of the two derivation adjoint automorphisms. -/
 theorem Ad_mul (g h : G) :
     Ad (I := I) (g * h) = (Ad (I := I) h).trans (Ad (I := I) g) := by
   apply LieEquiv.ext
@@ -78,6 +92,7 @@ theorem Ad_mul (g h : G) :
   rw [Ad_apply, tangentAd_mul, LieEquiv.trans_apply, LieEquiv.trans_apply,
     Ad_apply, Ad_apply, LieEquiv.apply_symm_apply]
 
+/-- The adjoint of an inverse is the inverse adjoint automorphism. -/
 @[simp]
 theorem Ad_inv (g : G) : Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
   apply LieEquiv.ext

--- a/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/Derivation.lean
@@ -76,7 +76,7 @@ theorem Ad_apply (g : G) (D : LeftInvariantDerivation I G) :
   (rfl)
 
 /-- Evaluation at the identity intertwines the derivation and tangent adjoint actions. -/
-@[simp]
+@[simp high]
 theorem leftInvariantDerivationLieEquivGroupLieAlgebra_Ad
     (g : G) (D : LeftInvariantDerivation I G) :
     leftInvariantDerivationLieEquivGroupLieAlgebra
@@ -113,6 +113,8 @@ theorem Ad_mul (g h : G) :
 theorem Ad_inv (g : G) : Ad (I := I) g⁻¹ = (Ad (I := I) g).symm := by
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra
     (I := I) (G := G) (ContMDiffMul.isInteriorPoint (I := I) (n := ∞) (by simp) (1 : G))
+  -- Expose the transported action so `tangentAd_inv` rewrites its middle equivalence; the inverse
+  -- of the resulting composite is then definitionally the composite on the right.
   change (e.trans (tangentAd (I := I) g⁻¹)).trans e.symm =
     ((e.trans (tangentAd (I := I) g)).trans e.symm).symm
   rw [tangentAd_inv]

--- a/TauCeti/Geometry/Lie/Basic.lean
+++ b/TauCeti/Geometry/Lie/Basic.lean
@@ -14,18 +14,26 @@ This file records lightweight consequences of the Lie-group regularity hierarchy
 
 ## Main results
 
+* `t2Space_of_lieGroup`: a Lie group modeled on a normed space is Hausdorff.
 * `LieGroup.minSmoothnessThree`: a `C³` Lie group over an RCL-like field has the regularity
   required by Mathlib's tangent Lie algebra.
 -/
 
 public section
 
-open scoped Manifold
+open scoped ContDiff Manifold
 
 variable {𝕜 : Type*} [NontriviallyNormedField 𝕜] [IsRCLikeNormedField 𝕜]
   {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+omit [IsRCLikeNormedField 𝕜] in
+/-- A Lie group modeled on a normed space is Hausdorff. -/
+theorem t2Space_of_lieGroup {n : ℕ∞ω} [LieGroup I n G] : T2Space G := by
+  let _ : T1Space G := I.t1Space G
+  let _ : IsTopologicalGroup G := topologicalGroup_of_lieGroup I n
+  exact IsTopologicalGroup.t2Space_iff_one_closed.mpr isClosed_singleton
 
 /-- A `C³` Lie group over an RCL-like field has the regularity required by Mathlib's tangent Lie
 algebra. This theorem is deliberately not a global instance, so the downgrade applies only in files

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -97,8 +97,9 @@ theorem tangentToLeftInvariantDerivation_lie [CompleteSpace E]
 /-- Evaluation at the identity identifies left-invariant derivations with the tangent Lie algebra as
 Lie algebras. -/
 noncomputable def leftInvariantDerivationLieEquivGroupLieAlgebra
-    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G)) :
+    [FiniteDimensional ℝ E] (h₁ : I.IsInteriorPoint (1 : G)) :
     LeftInvariantDerivation I G ≃ₗ⁅ℝ⁆ GroupLieAlgebra I G :=
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   { leftInvariantDerivationEquivGroupLieAlgebra (I := I) (G := G) h₁ with
     map_lie' := by
       intro D D'
@@ -121,6 +122,9 @@ theorem leftInvariantDerivationLieEquivGroupLieAlgebra_apply
     (D : LeftInvariantDerivation I G) :
     leftInvariantDerivationLieEquivGroupLieAlgebra h₁ D =
       leftInvariantDerivationEquivGroupLieAlgebra h₁ D := by
+  have hT2 : (inferInstance : T2Space G) =
+      t2Space_of_lieGroup (I := I) (n := ∞) := Subsingleton.elim _ _
+  cases hT2
   rfl
 
 /-- The inverse Lie equivalence sends a tangent vector to its left-invariant derivation. -/

--- a/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
+++ b/TauCeti/Geometry/Lie/Tangent/LieEquiv.lean
@@ -130,10 +130,11 @@ theorem leftInvariantDerivationLieEquivGroupLieAlgebra_apply
 /-- The inverse Lie equivalence sends a tangent vector to its left-invariant derivation. -/
 @[simp]
 theorem leftInvariantDerivationLieEquivGroupLieAlgebra_symm_apply
-    [FiniteDimensional ℝ E] [T2Space G] (h₁ : I.IsInteriorPoint (1 : G))
+    [FiniteDimensional ℝ E] (h₁ : I.IsInteriorPoint (1 : G))
     (v : GroupLieAlgebra I G) :
     (leftInvariantDerivationLieEquivGroupLieAlgebra h₁).symm v =
       tangentToLeftInvariantDerivation v := by
+  let _ : T2Space G := t2Space_of_lieGroup (I := I) (n := ∞)
   let e := leftInvariantDerivationLieEquivGroupLieAlgebra h₁
   let e₀ := leftInvariantDerivationEquivGroupLieAlgebra h₁
   apply e.symm_apply_eq.mpr


### PR DESCRIPTION
## Goal

Expose the group adjoint on Tau Ceti's canonical Lie algebra, `LeftInvariantDerivation I G`, so the tangent-space construction merged in #2166 becomes the roadmap-facing `Ad` and can support the smooth-representation and infinitesimal-adjoint milestones.

## Why this works

The merged `tangentAd` is already the differential of conjugation at the identity and preserves the tangent Lie bracket. The canonical Lie equivalence between left-invariant derivations and the tangent space at `1` therefore transports it without introducing a second adjoint action. Conjugating `tangentAd` by that equivalence preserves its Lie-automorphism structure, while the identity, multiplication, and inverse laws follow from the corresponding tangent laws.

PR #2261 proved every point of a positive-regularity group manifold with `C^n` multiplication is interior, so this construction no longer assumes `BoundarylessManifold`. The existing derivation–tangent equivalence uses Hausdorffness, but `Ad` derives it internally: the model with corners makes the charted space `T1`, and a `T1` topological group is Hausdorff. Thus the roadmap-facing adjoint and its group laws require only the intended finite-dimensional Lie-group hypotheses.

The exact roadmap target is [`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 1, "The group adjoint"](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad).

## Validation

`lake build TauCeti.Geometry.Lie.Adjoint.Derivation`

Roadmap: RepresentationTheory