### PR TITLE
feat(EllipticCurve): the quadratic twist of a Weierstrass curve and its invariants

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -25,8 +25,10 @@ commutative ring in which the relevant parameter is a unit.
   an explicit Weierstrass model over any commutative ring.
 * `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
   `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
-* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: the
-  twist of an elliptic curve is elliptic when `t² - 4n` is a unit, with equal `j`.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf_of_isUnit` and its field specialisation
+  `WeierstrassCurve.isElliptic_quadraticTwistOf`, and `WeierstrassCurve.j_quadraticTwistOf`: the
+  twist of an elliptic curve is elliptic when `t² - 4n` is a unit — over a field, when it is
+  nonzero — with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is isomorphic to the
   original curve, and changing the generator moves the twist by a change of variables.
@@ -71,8 +73,8 @@ turns this relation into the Weierstrass model below of the twist:
 `y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
 
 Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
-elliptic when `D` is a unit (`isElliptic_quadraticTwistOf`) — over a field, when `D ≠ 0` — with
-the same `j`-invariant (`j_quadraticTwistOf`).
+elliptic when `D` is a unit (`isElliptic_quadraticTwistOf_of_isUnit`) — over a field, when
+`D ≠ 0` (`isElliptic_quadraticTwistOf`) — with the same `j`-invariant (`j_quadraticTwistOf`).
 
 Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
 `E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
@@ -168,10 +170,10 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
       map_pow, map_ofNat]
 
 /-- The quadratic twist of an elliptic curve is elliptic when the discriminant `D = t² - 4n` of
-the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a field this hypothesis is `D ≠ 0`
-(`isUnit_iff_ne_zero`), the form in which the source states it; over a general commutative ring
-`D ≠ 0` is not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`). -/
-theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
+the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a general commutative ring `D ≠ 0` is
+not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`); over a field
+the two coincide, which is `isElliptic_quadraticTwistOf`. -/
+theorem isElliptic_quadraticTwistOf_of_isUnit [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
     (E.quadraticTwistOf t n).IsElliptic := by
   rw [isElliptic_iff, Δ_quadraticTwistOf]
   exact (hD.pow 6).mul E.isUnit_Δ
@@ -213,6 +215,19 @@ theorem exists_smul_quadraticTwistOf_eq {a : A} (b : A) (ha : IsUnit a) :
   ext <;> simp only [quadraticTwistOf, inv_inv, ← hv] <;> grobner
 
 end QuadraticTwistOfRing
+
+section Field
+
+variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
+
+/-- Over a field, the quadratic twist of an elliptic curve is elliptic when the discriminant
+`D = t² - 4n` of the twisting parameters is nonzero. This is the form the roadmap and the source
+state; `isElliptic_quadraticTwistOf_of_isUnit` is the ring-level strengthening it specialises. -/
+theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
+    (E.quadraticTwistOf t n).IsElliptic :=
+  E.isElliptic_quadraticTwistOf_of_isUnit t n (isUnit_iff_ne_zero.mpr hD)
+
+end Field
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -63,7 +63,10 @@ variable {A : Type*} [CommRing A] (E : WeierstrassCurve A)
 /-- The quadratic twist of a Weierstrass curve `E` over `K` by parameters `t`, `n`, to be
 thought of as the trace and norm of a generator `θ` of a separable quadratic extension `L/K`
 (so that `θ² = tθ - n`, and `D := t² - 4n` is the discriminant of the minimal polynomial of
-`θ`, nonzero exactly when `θ` is separable).
+`θ`). The parameters are arbitrary elements of any commutative ring `A`; the reading of `(t, n)`
+as the trace and norm of a generator of a separable quadratic extension, with `D ≠ 0` the
+separability criterion, is the field case. Over a general commutative ring the condition that
+makes the twist behave — and the hypothesis the results below take — is that `D` be a *unit*.
 
 The construction: writing the equation of `E` as `y² + A(x)y = f(x)` with `A(x) = a₁x + a₃`,
 the functions `x` and `Y := (t - 2θ)y - θ·A(x)` on `E` are invariant under the Galois action
@@ -224,8 +227,7 @@ theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : IsUnit (t ^ 2 - 4
     ∃ C : VariableChange A, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
   -- the split case at roots `t² - 2n` and `2n`: their difference is `-(t² - 4n)`, and their
   -- sum and product are the composite parameters of `quadraticTwistOf_quadraticTwistOf`.
-  have hrs : IsUnit (2 * n - (t ^ 2 - 2 * n)) := by
-    rw [show 2 * n - (t ^ 2 - 2 * n) = -(t ^ 2 - 4 * n) by ring, IsUnit.neg_iff]; exact hD
+  have hrs : IsUnit (2 * n - (t ^ 2 - 2 * n)) := by convert hD.neg using 1; ring
   obtain ⟨C, hC⟩ := E.exists_smul_eq_quadraticTwistOf_add_mul (t ^ 2 - 2 * n) (2 * n) hrs
   rw [quadraticTwistOf_quadraticTwistOf]
   exact ⟨C, by convert hC using 2 <;> ring⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -22,9 +22,9 @@ another generator, moves the twist by an explicit change of variables over the b
 
 * `WeierstrassCurve.quadraticTwistOf`: the quadratic twist of a Weierstrass curve by `(t, n)`,
   an explicit Weierstrass model over any commutative ring.
-* `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
-  `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
-* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: over a
+* `WeierstrassCurve.quadraticTwistOf_Δ`, `WeierstrassCurve.quadraticTwistOf_c₄`,
+  `WeierstrassCurve.quadraticTwistOf_c₆`: the invariants of the twist.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.quadraticTwistOf_j`: over a
   field, the twist of an elliptic curve is elliptic when `t² - 4n ≠ 0`, with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is `K`-isomorphic to the
@@ -44,7 +44,7 @@ Apache 2.0, by Kevin Buzzard and Claude; merged there through FLT PR #1088).
 * [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.§10, X.§2 and X.§5
 -/
 
-@[expose] public section
+public section
 
 namespace WeierstrassCurve
 
@@ -65,9 +65,9 @@ turns this relation into the Weierstrass model below of the twist:
 
 `y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
 
-Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
+Its discriminant is `D⁶·Δ(E)` (`quadraticTwistOf_Δ`), so the twist of an elliptic curve is
 elliptic when `D ≠ 0` (`isElliptic_quadraticTwistOf`), with the same `j`-invariant
-(`j_quadraticTwistOf`).
+(`quadraticTwistOf_j`).
 
 Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
 `E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
@@ -84,31 +84,57 @@ def quadraticTwistOf (t n : A) : WeierstrassCurve A where
 
 variable (t n : A)
 
+/-- The coefficient `a₁` of the quadratic twist. -/
+@[simp] theorem quadraticTwistOf_a₁ : (E.quadraticTwistOf t n).a₁ = t * E.a₁ := by
+  simp only [quadraticTwistOf]
+
+/-- The coefficient `a₂` of the quadratic twist. -/
+@[simp] theorem quadraticTwistOf_a₂ :
+    (E.quadraticTwistOf t n).a₂ = (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2 := by
+  simp only [quadraticTwistOf]
+
+/-- The coefficient `a₃` of the quadratic twist. -/
+@[simp] theorem quadraticTwistOf_a₃ :
+    (E.quadraticTwistOf t n).a₃ = (t ^ 2 - 4 * n) * t * E.a₃ := by
+  simp only [quadraticTwistOf]
+
+/-- The coefficient `a₄` of the quadratic twist. -/
+@[simp] theorem quadraticTwistOf_a₄ :
+    (E.quadraticTwistOf t n).a₄
+      = (t ^ 2 - 4 * n) ^ 2 * E.a₄ - 2 * (t ^ 2 - 4 * n) * n * E.a₁ * E.a₃ := by
+  simp only [quadraticTwistOf]
+
+/-- The coefficient `a₆` of the quadratic twist. -/
+@[simp] theorem quadraticTwistOf_a₆ :
+    (E.quadraticTwistOf t n).a₆
+      = (t ^ 2 - 4 * n) ^ 3 * E.a₆ - (t ^ 2 - 4 * n) ^ 2 * n * E.a₃ ^ 2 := by
+  simp only [quadraticTwistOf]
+
 /-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. -/
-theorem c₄_quadraticTwistOf : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
+theorem quadraticTwistOf_c₄ : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
   simp only [quadraticTwistOf, c₄, b₂, b₄]
   ring
 
 /-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. -/
-theorem Δ_quadraticTwistOf : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
+theorem quadraticTwistOf_Δ : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
   simp only [quadraticTwistOf, Δ, b₂, b₄, b₆, b₈]
   ring
 
 /-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. -/
-theorem c₆_quadraticTwistOf : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
+theorem quadraticTwistOf_c₆ : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
   simp only [quadraticTwistOf, c₆, b₂, b₄, b₆]
   ring
 
 /-- The invariant `b₂` of the quadratic twist: `b₂ ↦ Db₂` with `D = t² - 4n`. -/
-theorem b₂_quadraticTwistOf : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
+theorem quadraticTwistOf_b₂ : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
   simp only [quadraticTwistOf, b₂]; ring
 
 /-- The invariant `b₄` of the quadratic twist: `b₄ ↦ D²b₄` with `D = t² - 4n`. -/
-theorem b₄_quadraticTwistOf : (E.quadraticTwistOf t n).b₄ = (t ^ 2 - 4 * n) ^ 2 * E.b₄ := by
+theorem quadraticTwistOf_b₄ : (E.quadraticTwistOf t n).b₄ = (t ^ 2 - 4 * n) ^ 2 * E.b₄ := by
   simp only [quadraticTwistOf, b₄]; ring
 
 /-- The invariant `b₆` of the quadratic twist: `b₆ ↦ D³b₆` with `D = t² - 4n`. -/
-theorem b₆_quadraticTwistOf : (E.quadraticTwistOf t n).b₆ = (t ^ 2 - 4 * n) ^ 3 * E.b₆ := by
+theorem quadraticTwistOf_b₆ : (E.quadraticTwistOf t n).b₆ = (t ^ 2 - 4 * n) ^ 3 * E.b₆ := by
   simp only [quadraticTwistOf, b₆]; ring
 
 /-- The quadratic twist commutes with a ring homomorphism `f` (in particular with base change):
@@ -128,8 +154,8 @@ theorem kappa_quadraticTwistOf :
       + (E.quadraticTwistOf t n).a₂ * (E.quadraticTwistOf t n).c₄
       = (t ^ 2 - 4 * n) ^ 3 * (54 * E.b₆ - 3 * E.b₂ * E.b₄ + E.a₂ * E.c₄)
         - (t ^ 2 - 4 * n) ^ 2 * n * E.a₁ ^ 2 * E.c₄ := by
-  rw [b₆_quadraticTwistOf, b₂_quadraticTwistOf, b₄_quadraticTwistOf, c₄_quadraticTwistOf,
-    show (E.quadraticTwistOf t n).a₂ = (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2 from rfl]
+  rw [quadraticTwistOf_b₆, quadraticTwistOf_b₂, quadraticTwistOf_b₄, quadraticTwistOf_c₄,
+    quadraticTwistOf_a₂]
   ring
 
 end QuadraticTwistOfRing
@@ -142,16 +168,16 @@ variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
 discriminant `D = t² - 4n` of the twisting parameters is nonzero: `Δ ↦ D⁶Δ`. -/
 theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
     (E.quadraticTwistOf t n).IsElliptic := by
-  rw [isElliptic_iff, Δ_quadraticTwistOf]
+  rw [isElliptic_iff, quadraticTwistOf_Δ]
   exact (isUnit_iff_ne_zero.mpr (pow_ne_zero 6 hD)).mul E.isUnit_Δ
 
 /-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
-theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+theorem quadraticTwistOf_j [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
     (E.quadraticTwistOf t n).j = E.j := by
   have hD : t ^ 2 - 4 * n ≠ 0 := fun h0 ↦ (E.quadraticTwistOf t n).isUnit_Δ.ne_zero
-    (by rw [Δ_quadraticTwistOf, h0]; ring)
+    (by rw [quadraticTwistOf_Δ, h0]; ring)
   have hΔ : E.Δ ≠ 0 := E.isUnit_Δ.ne_zero
-  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', Δ_quadraticTwistOf, c₄_quadraticTwistOf]
+  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', quadraticTwistOf_Δ, quadraticTwistOf_c₄]
   field_simp
 
 /-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -14,9 +14,10 @@ be thought of as the trace and norm of a generator `θ` of a separable quadratic
 `L/K`, with `D := t² - 4n` the discriminant of its minimal polynomial — together with the
 behaviour of the standard invariants under twisting, uniformly in the characteristic: over any
 commutative ring `b₂, b₄, b₆` scale by `D, D², D³`, `c₄, c₆` by `D², D³`, and `Δ` by `D⁶`, so
-over a field the twist of an elliptic curve is elliptic when `D ≠ 0`, with the same
-`j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the trace and norm of
-another generator, moves the twist by an explicit change of variables over the base field.
+the twist of an elliptic curve is elliptic exactly when `D` is a unit (over a field, when
+`D ≠ 0`), with the same `j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the
+trace and norm of another generator, moves the twist by an explicit change of variables over the
+base field.
 
 ## Main definitions
 
@@ -24,8 +25,8 @@ another generator, moves the twist by an explicit change of variables over the b
   an explicit Weierstrass model over any commutative ring.
 * `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
   `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
-* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: over a
-  field, the twist of an elliptic curve is elliptic when `t² - 4n ≠ 0`, with equal `j`.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: the
+  twist of an elliptic curve is elliptic when `t² - 4n` is a unit, with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is `K`-isomorphic to the
   original curve, and changing the generator moves the twist by a change of variables.
@@ -70,8 +71,8 @@ turns this relation into the Weierstrass model below of the twist:
 `y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
 
 Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
-elliptic when `D ≠ 0` (`isElliptic_quadraticTwistOf`), with the same `j`-invariant
-(`j_quadraticTwistOf`).
+elliptic when `D` is a unit (`isElliptic_quadraticTwistOf`) — over a field, when `D ≠ 0` — with
+the same `j`-invariant (`j_quadraticTwistOf`).
 
 Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
 `E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
@@ -114,6 +115,14 @@ variable (t n : A)
       = (t ^ 2 - 4 * n) ^ 3 * E.a₆ - (t ^ 2 - 4 * n) ^ 2 * n * E.a₃ ^ 2 := by
   simp only [quadraticTwistOf]
 
+/-- Twisting by `(t, n) = (1, 0)` — the split quadratic `x² - x`, with `D = 1` — returns the
+curve itself. -/
+@[simp] theorem quadraticTwistOf_one_zero : E.quadraticTwistOf 1 0 = E := by
+  ext <;>
+    simp only [a₁_quadraticTwistOf, a₂_quadraticTwistOf, a₃_quadraticTwistOf,
+      a₄_quadraticTwistOf, a₆_quadraticTwistOf] <;>
+    ring
+
 /-- The invariant `b₂` of the quadratic twist: `b₂ ↦ Db₂` with `D = t² - 4n`. -/
 @[simp] theorem b₂_quadraticTwistOf : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
   simp only [quadraticTwistOf, b₂]; ring
@@ -151,77 +160,40 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
 
 /-- The quadratic twist commutes with a ring homomorphism `f` (in particular with base change):
 `(E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n)`. -/
-@[simp] theorem quadraticTwistOf_map {B : Type*} [CommRing B] (f : A →+* B) :
+@[simp] theorem map_quadraticTwistOf {B : Type*} [CommRing B] (f : A →+* B) :
     (E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n) := by
   ext <;>
     simp only [quadraticTwistOf, map_a₁, map_a₂,
       map_a₃, map_a₄, map_a₆, map_mul, map_sub,
       map_pow, map_ofNat]
 
-/-- The constant term `54 b₆ - 3 b₂ b₄ + a₂ c₄` of the quadratic twist by `(t, n)`, in terms of
-that of `E`: it becomes `D³ · (54 b₆ - 3 b₂ b₄ + a₂ c₄) - D² n a₁² c₄` where `D = t² - 4n`.
-
-This is the constant term of the polynomial `c₄T² + a₁c₄T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)` whose
-splitting characterises split multiplicative reduction (Mathlib's
-`WeierstrassCurve.HasSplitMultiplicativeReduction`), and which arises from the second-order
-Taylor expansion of the equation at the node. It is consumed by the twist-to-split-reduction
-theorem, a later milestone of the same roadmap layer. -/
-theorem nodeConst_quadraticTwistOf :
-    54 * (E.quadraticTwistOf t n).b₆
-      - 3 * (E.quadraticTwistOf t n).b₂ * (E.quadraticTwistOf t n).b₄
-      + (E.quadraticTwistOf t n).a₂ * (E.quadraticTwistOf t n).c₄
-      = (t ^ 2 - 4 * n) ^ 3 * (54 * E.b₆ - 3 * E.b₂ * E.b₄ + E.a₂ * E.c₄)
-        - (t ^ 2 - 4 * n) ^ 2 * n * E.a₁ ^ 2 * E.c₄ := by
-  rw [b₆_quadraticTwistOf, b₂_quadraticTwistOf, b₄_quadraticTwistOf, c₄_quadraticTwistOf,
-    a₂_quadraticTwistOf]
-  ring
-
-/-- The quadratic twist of an elliptic curve is elliptic when the discriminant `D = t² - 4n` of
-the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a field this hypothesis is `D ≠ 0`
-(`isUnit_iff_ne_zero`), the form in which the source states it; over a general commutative ring
-`D ≠ 0` is not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`). -/
-theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
-    (E.quadraticTwistOf t n).IsElliptic := by
-  rw [isElliptic_iff, Δ_quadraticTwistOf]
-  exact (hD.pow 6).mul E.isUnit_Δ
-
-/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. Both `j`s are `Δ'⁻¹c₄³`, and the
-twist scales `Δ` by `D⁶` and `c₄` by `D²`, so the two `D`-powers cancel against each other. -/
-theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
-    (E.quadraticTwistOf t n).j = E.j := by
-  have hΔ : E.Δ * ((E.Δ'⁻¹ : Aˣ) : A) = 1 := by
-    rw [← coe_Δ']
-    exact E.Δ'.mul_inv
-  rw [j, j, Units.inv_mul_eq_iff_eq_mul, c₄_quadraticTwistOf, coe_Δ', Δ_quadraticTwistOf]
-  linear_combination (-((t ^ 2 - 4 * n) ^ 6 * E.c₄ ^ 3)) * hΔ
-
-end QuadraticTwistOfRing
-
-section QuadraticTwistOf
-
-variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
-
-/-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:
-explicitly, the double twist is obtained from `E` by the change of variables
-`(x, y) ↦ (D²x, D³y - 2nD²(a₁x + a₃))`, where `D = t² - 4n`. -/
-theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : t ^ 2 - 4 * n ≠ 0) :
-    ∃ C : VariableChange K, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
-  refine ⟨⟨(Units.mk0 _ hD)⁻¹, 0, 2 * n / (t ^ 2 - 4 * n) * E.a₁,
-    2 * n / (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+/-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve: explicitly, the
+double twist is obtained from `E` by the change of variables
+`(x, y) ↦ (D²x, D³y - 2nD²(a₁x + a₃))`, where `D = t² - 4n`. Over a field the hypothesis is
+`D ≠ 0` (`isUnit_iff_ne_zero`). -/
+theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : IsUnit (t ^ 2 - 4 * n)) :
+    ∃ C : VariableChange A, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
+  obtain ⟨u, hu⟩ := hD
+  have hi : (↑u⁻¹ : A) * (u : A) = 1 := u.inv_mul
+  refine ⟨⟨u⁻¹, 0, 2 * n * (↑u⁻¹ : A) * E.a₁, 2 * n * (↑u⁻¹ : A) * E.a₃⟩, ?_⟩
   rw [variableChange_def]
-  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field
+  ext <;> simp only [quadraticTwistOf, inv_inv, ← hu] <;> grobner
 
 /-- Changing the parameters `(t, n)` — the trace and norm of a generator `θ` of a quadratic
 extension — into the trace and norm `(at + 2b, b² + abt + a²n)` of another generator `aθ + b`
-changes the quadratic twist by an explicit change of variables over `K`. -/
-theorem exists_smul_quadraticTwistOf_eq {a : K} (b : K) (ha : a ≠ 0) :
-    ∃ C : VariableChange K, C • E.quadraticTwistOf t n
+changes the quadratic twist by an explicit change of variables. Over a field the hypothesis is
+`a ≠ 0` (`isUnit_iff_ne_zero`). -/
+theorem exists_smul_quadraticTwistOf_eq {a : A} (b : A) (ha : IsUnit a) :
+    ∃ C : VariableChange A, C • E.quadraticTwistOf t n
       = E.quadraticTwistOf (a * t + 2 * b) (b ^ 2 + a * b * t + a ^ 2 * n) := by
-  refine ⟨⟨(Units.mk0 a ha)⁻¹, 0, a⁻¹ * b * E.a₁, a⁻¹ * b * (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+  obtain ⟨v, hv⟩ := ha
+  have hi : (↑v⁻¹ : A) * (v : A) = 1 := v.inv_mul
+  refine ⟨⟨v⁻¹, 0, (↑v⁻¹ : A) * b * E.a₁,
+    (↑v⁻¹ : A) * b * (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
   rw [variableChange_def]
-  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field
+  ext <;> simp only [quadraticTwistOf, inv_inv, ← hv] <;> grobner
 
-end QuadraticTwistOf
+end QuadraticTwistOfRing
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -1,0 +1,181 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.VariableChange
+
+/-!
+# The quadratic twist of a Weierstrass curve: definition and invariants
+
+The quadratic twist `E.quadraticTwistOf t n` of a Weierstrass curve by parameters `(t, n)` — to
+be thought of as the trace and norm of a generator `θ` of a separable quadratic extension
+`L/K`, with `D := t² - 4n` the discriminant of its minimal polynomial — together with the
+behaviour of the standard invariants under twisting, uniformly in the characteristic: over any
+commutative ring `b₂, b₄, b₆` scale by `D, D², D³`, `c₄, c₆` by `D², D³`, and `Δ` by `D⁶`, so
+over a field the twist of an elliptic curve is elliptic exactly when `D ≠ 0`, with the same
+`j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the trace and norm of
+another generator, moves the twist by an explicit change of variables over the base field.
+
+## Main definitions
+
+* `WeierstrassCurve.quadraticTwistOf`: the quadratic twist of a Weierstrass curve by `(t, n)`,
+  an explicit Weierstrass model over any commutative ring.
+* `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
+  `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: over a
+  field, the twist of an elliptic curve is elliptic when `t² - 4n ≠ 0`, with equal `j`.
+* `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
+  `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is `K`-isomorphic to the
+  original curve, and changing the generator moves the twist by a change of variables.
+
+These are the `quadraticTwistOf` seeds of `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5
+(twists), pinned in that roadmap's `Suggested.lean`; the extension twist `quadraticTwist E L`
+by a separable quadratic extension, the point isomorphism, and the split-multiplicative-
+reduction theorem are later milestones of the same layer and build on this file.
+
+Adapted from the FLT project's quadratic-twist development (`ImperialCollegeLondon/FLT`,
+`FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean` at `d18b563029f3`,
+Apache 2.0, by Kevin Buzzard and Claude; merged there through FLT PR #1088).
+
+## References
+
+* [J. Silverman, *The Arithmetic of Elliptic Curves*][silverman2009], III.§10, X.§2 and X.§5
+-/
+
+@[expose] public section
+
+namespace WeierstrassCurve
+
+section QuadraticTwistOfRing
+
+variable {A : Type*} [CommRing A] (E : WeierstrassCurve A)
+
+/-- The quadratic twist of a Weierstrass curve `E` over `K` by parameters `t`, `n`, to be
+thought of as the trace and norm of a generator `θ` of a separable quadratic extension `L/K`
+(so that `θ² = tθ - n`, and `D := t² - 4n` is the discriminant of the minimal polynomial of
+`θ`, nonzero exactly when `θ` is separable).
+
+The construction: writing the equation of `E` as `y² + A(x)y = f(x)` with `A(x) = a₁x + a₃`,
+the functions `x` and `Y := (t - 2θ)y - θ·A(x)` on `E` are invariant under the Galois action
+twisted by the quadratic character of `L/K`, and satisfy
+`Y² + t·A(x)·Y = D·(y² + A(x)y) - n·A(x)²`; clearing denominators via `(x, Y) ↦ (Dx, DY)`
+turns this relation into the Weierstrass model below of the twist:
+
+`y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
+
+Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
+elliptic when `D ≠ 0` (`isElliptic_quadraticTwistOf`), with the same `j`-invariant
+(`j_quadraticTwistOf`).
+
+Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
+`E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
+classical twist by `4d ≡ d mod (K^×)²`. If `char K = 2` we may take `θ` with `θ² + θ = d`
+(Artin–Schreier), so `t = 1`, `n = -d`, `D = 1`; for ordinary `E : y² + xy = x³ + a₂x² + a₆`
+the model is the classical twist `y² + xy = x³ + (a₂ + d)x² + a₆`, and for supersingular
+`E : y² + a₃y = x³ + a₄x + a₆` it is `y² + a₃y = x³ + a₄x + (a₆ + da₃²)`. -/
+def quadraticTwistOf (t n : A) : WeierstrassCurve A where
+  a₁ := t * E.a₁
+  a₂ := (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2
+  a₃ := (t ^ 2 - 4 * n) * t * E.a₃
+  a₄ := (t ^ 2 - 4 * n) ^ 2 * E.a₄ - 2 * (t ^ 2 - 4 * n) * n * E.a₁ * E.a₃
+  a₆ := (t ^ 2 - 4 * n) ^ 3 * E.a₆ - (t ^ 2 - 4 * n) ^ 2 * n * E.a₃ ^ 2
+
+variable (t n : A)
+
+/-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. -/
+theorem c₄_quadraticTwistOf : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
+  simp only [quadraticTwistOf, c₄, b₂, b₄]
+  ring
+
+/-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. -/
+theorem Δ_quadraticTwistOf : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
+  simp only [quadraticTwistOf, Δ, b₂, b₄, b₆, b₈]
+  ring
+
+/-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. -/
+theorem c₆_quadraticTwistOf : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
+  simp only [quadraticTwistOf, c₆, b₂, b₄, b₆]
+  ring
+
+/-- The invariant `b₂` of the quadratic twist: `b₂ ↦ Db₂` with `D = t² - 4n`. -/
+theorem b₂_quadraticTwistOf : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
+  simp only [quadraticTwistOf, b₂]; ring
+
+/-- The invariant `b₄` of the quadratic twist: `b₄ ↦ D²b₄` with `D = t² - 4n`. -/
+theorem b₄_quadraticTwistOf : (E.quadraticTwistOf t n).b₄ = (t ^ 2 - 4 * n) ^ 2 * E.b₄ := by
+  simp only [quadraticTwistOf, b₄]; ring
+
+/-- The invariant `b₆` of the quadratic twist: `b₆ ↦ D³b₆` with `D = t² - 4n`. -/
+theorem b₆_quadraticTwistOf : (E.quadraticTwistOf t n).b₆ = (t ^ 2 - 4 * n) ^ 3 * E.b₆ := by
+  simp only [quadraticTwistOf, b₆]; ring
+
+/-- The quadratic twist commutes with a ring homomorphism `f` (in particular with base change):
+`(E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n)`. -/
+theorem quadraticTwistOf_map {B : Type*} [CommRing B] (f : A →+* B) :
+    (E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n) := by
+  ext <;>
+    simp only [quadraticTwistOf, map_a₁, map_a₂,
+      map_a₃, map_a₄, map_a₆, map_mul, map_sub,
+      map_pow, map_ofNat]
+
+/-- The node-polynomial constant `κ = 54 b₆ - 3 b₂ b₄ + a₂ c₄` of the quadratic twist by `(t, n)`
+in terms of that of `E`: `κ_W = D³ κ - D² n a₁² c₄` where `D = t² - 4n`. -/
+theorem kappa_quadraticTwistOf :
+    54 * (E.quadraticTwistOf t n).b₆
+      - 3 * (E.quadraticTwistOf t n).b₂ * (E.quadraticTwistOf t n).b₄
+      + (E.quadraticTwistOf t n).a₂ * (E.quadraticTwistOf t n).c₄
+      = (t ^ 2 - 4 * n) ^ 3 * (54 * E.b₆ - 3 * E.b₂ * E.b₄ + E.a₂ * E.c₄)
+        - (t ^ 2 - 4 * n) ^ 2 * n * E.a₁ ^ 2 * E.c₄ := by
+  rw [b₆_quadraticTwistOf, b₂_quadraticTwistOf, b₄_quadraticTwistOf, c₄_quadraticTwistOf,
+    show (E.quadraticTwistOf t n).a₂ = (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2 from rfl]
+  ring
+
+end QuadraticTwistOfRing
+
+section QuadraticTwistOf
+
+variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
+
+/-- Over a field, the quadratic twist of an elliptic curve is elliptic exactly when the
+discriminant `D = t² - 4n` of the twisting parameters is nonzero: `Δ ↦ D⁶Δ`. -/
+theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
+    (E.quadraticTwistOf t n).IsElliptic := by
+  rw [isElliptic_iff, Δ_quadraticTwistOf]
+  exact (isUnit_iff_ne_zero.mpr (pow_ne_zero 6 hD)).mul E.isUnit_Δ
+
+/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
+theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+    (E.quadraticTwistOf t n).j = E.j := by
+  have hD : t ^ 2 - 4 * n ≠ 0 := fun h0 ↦ (E.quadraticTwistOf t n).isUnit_Δ.ne_zero
+    (by rw [Δ_quadraticTwistOf, h0]; ring)
+  have hΔ : E.Δ ≠ 0 := E.isUnit_Δ.ne_zero
+  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', Δ_quadraticTwistOf, c₄_quadraticTwistOf]
+  field_simp
+
+/-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:
+explicitly, the double twist is obtained from `E` by the change of variables
+`(x, y) ↦ (D²x, D³y + 2nD²(a₁x + a₃))`, where `D = t² - 4n`. -/
+theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : t ^ 2 - 4 * n ≠ 0) :
+    ∃ C : VariableChange K, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
+  refine ⟨⟨(Units.mk0 _ hD)⁻¹, 0, 2 * n / (t ^ 2 - 4 * n) * E.a₁,
+    2 * n / (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+  rw [variableChange_def]
+  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field
+
+/-- Changing the parameters `(t, n)` — the trace and norm of a generator `θ` of a quadratic
+extension — into the trace and norm `(at + 2b, b² + abt + a²n)` of another generator `aθ + b`
+changes the quadratic twist by an explicit change of variables over `K`. -/
+theorem exists_smul_quadraticTwistOf_eq {a : K} (b : K) (ha : a ≠ 0) :
+    ∃ C : VariableChange K, C • E.quadraticTwistOf t n
+      = E.quadraticTwistOf (a * t + 2 * b) (b ^ 2 + a * b * t + a ^ 2 * n) := by
+  refine ⟨⟨(Units.mk0 a ha)⁻¹, 0, a⁻¹ * b * E.a₁, a⁻¹ * b * (t ^ 2 - 4 * n) * E.a₃⟩, ?_⟩
+  rw [variableChange_def]
+  ext <;> simp only [quadraticTwistOf, inv_inv, Units.val_mk0] <;> field
+
+end QuadraticTwistOf
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -174,11 +174,11 @@ curve itself. -/
 `D = t² - 4n` of the twisting parameters is a unit. Over a general commutative ring `D ≠ 0` is
 not the right criterion (take `A = ℤ`, `D = 2`); over a field the two coincide, which is
 `isElliptic_quadraticTwistOf`. -/
-theorem isElliptic_quadraticTwistOf_iff [E.IsElliptic] :
-    (E.quadraticTwistOf t n).IsElliptic ↔ IsUnit (t ^ 2 - 4 * n) := by
-  rw [isElliptic_iff, Δ_quadraticTwistOf]
-  exact ⟨fun h ↦ (isUnit_pow_iff (by norm_num)).mp (isUnit_of_mul_isUnit_left h),
-    fun hD ↦ (hD.pow 6).mul E.isUnit_Δ⟩
+theorem isElliptic_quadraticTwistOf_iff :
+    (E.quadraticTwistOf t n).IsElliptic ↔ IsUnit (t ^ 2 - 4 * n) ∧ E.IsElliptic := by
+  rw [isElliptic_iff, isElliptic_iff, Δ_quadraticTwistOf]
+  refine ⟨fun h ↦ ⟨(isUnit_pow_iff (by norm_num)).mp (isUnit_of_mul_isUnit_left h),
+    isUnit_of_mul_isUnit_right h⟩, fun ⟨hD, hΔ⟩ ↦ (hD.pow 6).mul hΔ⟩
 
 /-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
 theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
@@ -190,7 +190,9 @@ theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsEllipt
   linear_combination (-((t ^ 2 - 4 * n) ^ 6 * E.c₄ ^ 3)) * hΔ
 
 /-- Twisting twice by the same parameters is twisting once by their composite: the quadratic
-`x² - t²x + (2t²n - 4n²)` is the norm form of the composite extension. No hypothesis. -/
+`x² - t²x + (2t²n - 4n²)` is *split*, with roots `t² - 2n` and `2n` — it represents the trivial
+twist, which is why the double twist is isomorphic to `E` whenever `t² - 4n` is a unit. No
+hypothesis. -/
 theorem quadraticTwistOf_quadraticTwistOf :
     (E.quadraticTwistOf t n).quadraticTwistOf t n
       = E.quadraticTwistOf (t ^ 2) (2 * t ^ 2 * n - 4 * n ^ 2) := by
@@ -243,7 +245,7 @@ variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
 state; `isElliptic_quadraticTwistOf_iff` is the ring-level equivalence it specialises. -/
 theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
     (E.quadraticTwistOf t n).IsElliptic :=
-  (E.isElliptic_quadraticTwistOf_iff t n).mpr (isUnit_iff_ne_zero.mpr hD)
+  (E.isElliptic_quadraticTwistOf_iff t n).mpr ⟨isUnit_iff_ne_zero.mpr hD, ‹E.IsElliptic›⟩
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -14,7 +14,7 @@ be thought of as the trace and norm of a generator `θ` of a separable quadratic
 `L/K`, with `D := t² - 4n` the discriminant of its minimal polynomial — together with the
 behaviour of the standard invariants under twisting, uniformly in the characteristic: over any
 commutative ring `b₂, b₄, b₆` scale by `D, D², D³`, `c₄, c₆` by `D², D³`, and `Δ` by `D⁶`, so
-over a field the twist of an elliptic curve is elliptic exactly when `D ≠ 0`, with the same
+over a field the twist of an elliptic curve is elliptic when `D ≠ 0`, with the same
 `j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the trace and norm of
 another generator, moves the twist by an explicit change of variables over the base field.
 
@@ -22,9 +22,9 @@ another generator, moves the twist by an explicit change of variables over the b
 
 * `WeierstrassCurve.quadraticTwistOf`: the quadratic twist of a Weierstrass curve by `(t, n)`,
   an explicit Weierstrass model over any commutative ring.
-* `WeierstrassCurve.quadraticTwistOf_Δ`, `WeierstrassCurve.quadraticTwistOf_c₄`,
-  `WeierstrassCurve.quadraticTwistOf_c₆`: the invariants of the twist.
-* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.quadraticTwistOf_j`: over a
+* `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
+  `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
+* `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: over a
   field, the twist of an elliptic curve is elliptic when `t² - 4n ≠ 0`, with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is `K`-isomorphic to the
@@ -36,8 +36,12 @@ by a separable quadratic extension, the point isomorphism, and the split-multipl
 reduction theorem are later milestones of the same layer and build on this file.
 
 Adapted from the FLT project's quadratic-twist development (`ImperialCollegeLondon/FLT`,
-`FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean` at `d18b563029f3`,
-Apache 2.0, by Kevin Buzzard and Claude; merged there through FLT PR #1088).
+`FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean` at the roadmap's pin
+`bc2fe8ff7396`, FLT PR #1088, Apache 2.0). That file's own header reads
+`Authors: Kevin Buzzard, Claude`, and it has not been touched in FLT since `bc2fe8ff7396`, so
+the pin and the working clone (`d18b563029f3`, a later Mathlib bump) agree on it verbatim.
+Following this repository's convention for adapted material, the upstream authorship is
+credited here rather than in the copyright header.
 
 ## References
 
@@ -65,9 +69,9 @@ turns this relation into the Weierstrass model below of the twist:
 
 `y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
 
-Its discriminant is `D⁶·Δ(E)` (`quadraticTwistOf_Δ`), so the twist of an elliptic curve is
+Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
 elliptic when `D ≠ 0` (`isElliptic_quadraticTwistOf`), with the same `j`-invariant
-(`quadraticTwistOf_j`).
+(`j_quadraticTwistOf`).
 
 Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
 `E : y² = x³ + a₂x² + a₄x + a₆` the model is `y² = x³ + 4da₂x² + 16d²a₄x + 64d³a₆`, the
@@ -85,61 +89,69 @@ def quadraticTwistOf (t n : A) : WeierstrassCurve A where
 variable (t n : A)
 
 /-- The coefficient `a₁` of the quadratic twist. -/
-@[simp] theorem quadraticTwistOf_a₁ : (E.quadraticTwistOf t n).a₁ = t * E.a₁ := by
+@[simp] theorem a₁_quadraticTwistOf : (E.quadraticTwistOf t n).a₁ = t * E.a₁ := by
   simp only [quadraticTwistOf]
 
 /-- The coefficient `a₂` of the quadratic twist. -/
-@[simp] theorem quadraticTwistOf_a₂ :
+@[simp] theorem a₂_quadraticTwistOf :
     (E.quadraticTwistOf t n).a₂ = (t ^ 2 - 4 * n) * E.a₂ - n * E.a₁ ^ 2 := by
   simp only [quadraticTwistOf]
 
 /-- The coefficient `a₃` of the quadratic twist. -/
-@[simp] theorem quadraticTwistOf_a₃ :
+@[simp] theorem a₃_quadraticTwistOf :
     (E.quadraticTwistOf t n).a₃ = (t ^ 2 - 4 * n) * t * E.a₃ := by
   simp only [quadraticTwistOf]
 
 /-- The coefficient `a₄` of the quadratic twist. -/
-@[simp] theorem quadraticTwistOf_a₄ :
+@[simp] theorem a₄_quadraticTwistOf :
     (E.quadraticTwistOf t n).a₄
       = (t ^ 2 - 4 * n) ^ 2 * E.a₄ - 2 * (t ^ 2 - 4 * n) * n * E.a₁ * E.a₃ := by
   simp only [quadraticTwistOf]
 
 /-- The coefficient `a₆` of the quadratic twist. -/
-@[simp] theorem quadraticTwistOf_a₆ :
+@[simp] theorem a₆_quadraticTwistOf :
     (E.quadraticTwistOf t n).a₆
       = (t ^ 2 - 4 * n) ^ 3 * E.a₆ - (t ^ 2 - 4 * n) ^ 2 * n * E.a₃ ^ 2 := by
   simp only [quadraticTwistOf]
 
-/-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_c₄ : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
-  simp only [quadraticTwistOf, c₄, b₂, b₄]
-  ring
-
-/-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_Δ : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
-  simp only [quadraticTwistOf, Δ, b₂, b₄, b₆, b₈]
-  ring
-
-/-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_c₆ : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
-  simp only [quadraticTwistOf, c₆, b₂, b₄, b₆]
-  ring
-
 /-- The invariant `b₂` of the quadratic twist: `b₂ ↦ Db₂` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_b₂ : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
+@[simp] theorem b₂_quadraticTwistOf : (E.quadraticTwistOf t n).b₂ = (t ^ 2 - 4 * n) * E.b₂ := by
   simp only [quadraticTwistOf, b₂]; ring
 
 /-- The invariant `b₄` of the quadratic twist: `b₄ ↦ D²b₄` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_b₄ : (E.quadraticTwistOf t n).b₄ = (t ^ 2 - 4 * n) ^ 2 * E.b₄ := by
+@[simp] theorem b₄_quadraticTwistOf : (E.quadraticTwistOf t n).b₄ = (t ^ 2 - 4 * n) ^ 2 * E.b₄ := by
   simp only [quadraticTwistOf, b₄]; ring
 
 /-- The invariant `b₆` of the quadratic twist: `b₆ ↦ D³b₆` with `D = t² - 4n`. -/
-theorem quadraticTwistOf_b₆ : (E.quadraticTwistOf t n).b₆ = (t ^ 2 - 4 * n) ^ 3 * E.b₆ := by
+@[simp] theorem b₆_quadraticTwistOf : (E.quadraticTwistOf t n).b₆ = (t ^ 2 - 4 * n) ^ 3 * E.b₆ := by
   simp only [quadraticTwistOf, b₆]; ring
+
+/-- The invariant `b₈` of the quadratic twist: `b₈ ↦ D⁴b₈` with `D = t² - 4n`. -/
+@[simp] theorem b₈_quadraticTwistOf : (E.quadraticTwistOf t n).b₈ = (t ^ 2 - 4 * n) ^ 4 * E.b₈ := by
+  simp only [quadraticTwistOf, b₈]; ring
+
+/-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. Immediate from
+the `b₂` and `b₄` laws, since `c₄ = b₂² - 24b₄`. -/
+@[simp] theorem c₄_quadraticTwistOf : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
+  simp only [c₄, b₂_quadraticTwistOf, b₄_quadraticTwistOf]
+  ring
+
+/-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. Immediate from
+the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆`. -/
+@[simp] theorem c₆_quadraticTwistOf : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
+  simp only [c₆, b₂_quadraticTwistOf, b₄_quadraticTwistOf, b₆_quadraticTwistOf]
+  ring
+
+/-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. Immediate from the
+`b`-laws, since `Δ = -b₂²b₈ - 8b₄³ - 27b₆² + 9b₂b₄b₆`. -/
+@[simp] theorem Δ_quadraticTwistOf : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
+  simp only [Δ, b₂_quadraticTwistOf, b₄_quadraticTwistOf, b₆_quadraticTwistOf,
+    b₈_quadraticTwistOf]
+  ring
 
 /-- The quadratic twist commutes with a ring homomorphism `f` (in particular with base change):
 `(E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n)`. -/
-theorem quadraticTwistOf_map {B : Type*} [CommRing B] (f : A →+* B) :
+@[simp] theorem quadraticTwistOf_map {B : Type*} [CommRing B] (f : A →+* B) :
     (E.quadraticTwistOf t n).map f = (E.map f).quadraticTwistOf (f t) (f n) := by
   ext <;>
     simp only [quadraticTwistOf, map_a₁, map_a₂,
@@ -154,8 +166,8 @@ theorem kappa_quadraticTwistOf :
       + (E.quadraticTwistOf t n).a₂ * (E.quadraticTwistOf t n).c₄
       = (t ^ 2 - 4 * n) ^ 3 * (54 * E.b₆ - 3 * E.b₂ * E.b₄ + E.a₂ * E.c₄)
         - (t ^ 2 - 4 * n) ^ 2 * n * E.a₁ ^ 2 * E.c₄ := by
-  rw [quadraticTwistOf_b₆, quadraticTwistOf_b₂, quadraticTwistOf_b₄, quadraticTwistOf_c₄,
-    quadraticTwistOf_a₂]
+  rw [b₆_quadraticTwistOf, b₂_quadraticTwistOf, b₄_quadraticTwistOf, c₄_quadraticTwistOf,
+    a₂_quadraticTwistOf]
   ring
 
 end QuadraticTwistOfRing
@@ -164,25 +176,25 @@ section QuadraticTwistOf
 
 variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
 
-/-- Over a field, the quadratic twist of an elliptic curve is elliptic exactly when the
-discriminant `D = t² - 4n` of the twisting parameters is nonzero: `Δ ↦ D⁶Δ`. -/
+/-- Over a field, the quadratic twist of an elliptic curve is elliptic when the discriminant
+`D = t² - 4n` of the twisting parameters is nonzero, since `Δ ↦ D⁶Δ`. -/
 theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
     (E.quadraticTwistOf t n).IsElliptic := by
-  rw [isElliptic_iff, quadraticTwistOf_Δ]
+  rw [isElliptic_iff, Δ_quadraticTwistOf]
   exact (isUnit_iff_ne_zero.mpr (pow_ne_zero 6 hD)).mul E.isUnit_Δ
 
 /-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
-theorem quadraticTwistOf_j [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
     (E.quadraticTwistOf t n).j = E.j := by
   have hD : t ^ 2 - 4 * n ≠ 0 := fun h0 ↦ (E.quadraticTwistOf t n).isUnit_Δ.ne_zero
-    (by rw [quadraticTwistOf_Δ, h0]; ring)
+    (by rw [Δ_quadraticTwistOf, h0]; ring)
   have hΔ : E.Δ ≠ 0 := E.isUnit_Δ.ne_zero
-  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', quadraticTwistOf_Δ, quadraticTwistOf_c₄]
+  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', Δ_quadraticTwistOf, c₄_quadraticTwistOf]
   field_simp
 
 /-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:
 explicitly, the double twist is obtained from `E` by the change of variables
-`(x, y) ↦ (D²x, D³y + 2nD²(a₁x + a₃))`, where `D = t² - 4n`. -/
+`(x, y) ↦ (D²x, D³y - 2nD²(a₁x + a₃))`, where `D = t² - 4n`. -/
 theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : t ^ 2 - 4 * n ≠ 0) :
     ∃ C : VariableChange K, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
   refine ⟨⟨(Units.mk0 _ hD)⁻¹, 0, 2 * n / (t ^ 2 - 4 * n) * E.a₁,

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -142,20 +142,17 @@ curve itself. -/
 @[simp] theorem b₈_quadraticTwistOf : (E.quadraticTwistOf t n).b₈ = (t ^ 2 - 4 * n) ^ 4 * E.b₈ := by
   simp only [quadraticTwistOf, b₈]; ring
 
-/-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. Immediate from
-the `b₂` and `b₄` laws, since `c₄ = b₂² - 24b₄`. -/
+/-- The invariant `c₄` of the quadratic twist: `c₄ ↦ D²c₄` with `D = t² - 4n`. -/
 @[simp] theorem c₄_quadraticTwistOf : (E.quadraticTwistOf t n).c₄ = (t ^ 2 - 4 * n) ^ 2 * E.c₄ := by
   simp only [c₄, b₂_quadraticTwistOf, b₄_quadraticTwistOf]
   ring
 
-/-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. Immediate from
-the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆`. -/
+/-- The invariant `c₆` of the quadratic twist: `c₆ ↦ D³c₆` with `D = t² - 4n`. -/
 @[simp] theorem c₆_quadraticTwistOf : (E.quadraticTwistOf t n).c₆ = (t ^ 2 - 4 * n) ^ 3 * E.c₆ := by
   simp only [c₆, b₂_quadraticTwistOf, b₄_quadraticTwistOf, b₆_quadraticTwistOf]
   ring
 
-/-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. Immediate from the
-`b`-laws, since `Δ = -b₂²b₈ - 8b₄³ - 27b₆² + 9b₂b₄b₆`. -/
+/-- The discriminant of the quadratic twist: `Δ ↦ D⁶Δ` with `D = t² - 4n`. -/
 @[simp] theorem Δ_quadraticTwistOf : (E.quadraticTwistOf t n).Δ = (t ^ 2 - 4 * n) ^ 6 * E.Δ := by
   simp only [Δ, b₂_quadraticTwistOf, b₄_quadraticTwistOf, b₆_quadraticTwistOf,
     b₈_quadraticTwistOf]
@@ -171,17 +168,16 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
       map_pow, map_ofNat]
 
 /-- The quadratic twist of an elliptic curve is elliptic exactly when the discriminant
-`D = t² - 4n` of the twisting parameters is a unit, since `Δ ↦ D⁶Δ` and `D⁶ · unit` is a unit
-precisely when `D` is. Over a general commutative ring `D ≠ 0` is not the right criterion (take
-`A = ℤ`, `D = 2`); over a field the two coincide, which is `isElliptic_quadraticTwistOf`. -/
+`D = t² - 4n` of the twisting parameters is a unit. Over a general commutative ring `D ≠ 0` is
+not the right criterion (take `A = ℤ`, `D = 2`); over a field the two coincide, which is
+`isElliptic_quadraticTwistOf`. -/
 theorem isElliptic_quadraticTwistOf_iff [E.IsElliptic] :
     (E.quadraticTwistOf t n).IsElliptic ↔ IsUnit (t ^ 2 - 4 * n) := by
   rw [isElliptic_iff, Δ_quadraticTwistOf]
   exact ⟨fun h ↦ (isUnit_pow_iff (by norm_num)).mp (isUnit_of_mul_isUnit_left h),
     fun hD ↦ (hD.pow 6).mul E.isUnit_Δ⟩
 
-/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. Both `j`s are `Δ'⁻¹c₄³`, and the
-twist scales `Δ` by `D⁶` and `c₄` by `D²`, so the two `D`-powers cancel against each other. -/
+/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
 theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
     (E.quadraticTwistOf t n).j = E.j := by
   have hΔ : E.Δ * ((E.Δ'⁻¹ : Aˣ) : A) = 1 := by
@@ -216,22 +212,23 @@ by its trace and norm `(r + s, rs)` is a change of variables away from `E`, prov
 difference of the roots is a unit (that difference squared is the discriminant). -/
 theorem exists_smul_eq_quadraticTwistOf_add_mul (r s : A) (h : IsUnit (s - r)) :
     ∃ C : VariableChange A, C • E = E.quadraticTwistOf (r + s) (r * s) := by
+  -- twisting by `(1, 0)` is the identity, and the generator change `a = s - r`, `b = r` sends
+  -- its parameters to `(r + s, rs)`; the two agree after polynomial normalisation.
   obtain ⟨C, hC⟩ := E.exists_smul_quadraticTwistOf_eq 1 0 (a := s - r) r h
-  refine ⟨C, ?_⟩
-  rwa [quadraticTwistOf_one_zero, show (s - r) * 1 + 2 * r = r + s by ring,
-    show r ^ 2 + (s - r) * r * 1 + (s - r) ^ 2 * 0 = r * s by ring] at hC
+  rw [quadraticTwistOf_one_zero] at hC
+  exact ⟨C, by convert hC using 2 <;> ring⟩
 
-/-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve. This is the split
-case `exists_smul_eq_quadraticTwistOf_add_mul` at roots `r = t² - 2n` and `s = 2n`, whose sum
-and product are the composite parameters of `quadraticTwistOf_quadraticTwistOf` and whose
-difference is `-(t² - 4n)`. -/
+/-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve, provided the
+discriminant `D = t² - 4n` is a unit. -/
 theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : IsUnit (t ^ 2 - 4 * n)) :
     ∃ C : VariableChange A, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
-  obtain ⟨C, hC⟩ := E.exists_smul_eq_quadraticTwistOf_add_mul (t ^ 2 - 2 * n) (2 * n)
-    (by rwa [show 2 * n - (t ^ 2 - 2 * n) = -(t ^ 2 - 4 * n) by ring, IsUnit.neg_iff])
-  rw [show t ^ 2 - 2 * n + 2 * n = t ^ 2 by ring,
-    show (t ^ 2 - 2 * n) * (2 * n) = 2 * t ^ 2 * n - 4 * n ^ 2 by ring] at hC
-  exact ⟨C, by rw [quadraticTwistOf_quadraticTwistOf]; exact hC⟩
+  -- the split case at roots `t² - 2n` and `2n`: their difference is `-(t² - 4n)`, and their
+  -- sum and product are the composite parameters of `quadraticTwistOf_quadraticTwistOf`.
+  have hrs : IsUnit (2 * n - (t ^ 2 - 2 * n)) := by
+    rw [show 2 * n - (t ^ 2 - 2 * n) = -(t ^ 2 - 4 * n) by ring, IsUnit.neg_iff]; exact hD
+  obtain ⟨C, hC⟩ := E.exists_smul_eq_quadraticTwistOf_add_mul (t ^ 2 - 2 * n) (2 * n) hrs
+  rw [quadraticTwistOf_quadraticTwistOf]
+  exact ⟨C, by convert hC using 2 <;> ring⟩
 
 end QuadraticTwistOfRing
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -14,10 +14,11 @@ be thought of as the trace and norm of a generator `θ` of a separable quadratic
 `L/K`, with `D := t² - 4n` the discriminant of its minimal polynomial — together with the
 behaviour of the standard invariants under twisting, uniformly in the characteristic: over any
 commutative ring `b₂, b₄, b₆` scale by `D, D², D³`, `c₄, c₆` by `D², D³`, and `Δ` by `D⁶`, so
-the twist of an elliptic curve is elliptic when `D` is a unit — over a field, when `D ≠ 0` —
-with the same `j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the trace and
-norm of another generator, moves the twist by an explicit change of variables, again over any
-commutative ring in which the relevant parameter is a unit.
+the twist of an elliptic curve is elliptic exactly when `D` is a unit — over a field, when
+`D ≠ 0` —
+with the same `j`-invariant. Twisting by a split quadratic, twisting twice by `(t, n)`, or
+changing `(t, n)` to the trace and norm of another generator, all move the twist by an explicit
+change of variables, again over any commutative ring in which the relevant parameter is a unit.
 
 ## Main definitions
 
@@ -25,10 +26,10 @@ commutative ring in which the relevant parameter is a unit.
   an explicit Weierstrass model over any commutative ring.
 * `WeierstrassCurve.Δ_quadraticTwistOf`, `WeierstrassCurve.c₄_quadraticTwistOf`,
   `WeierstrassCurve.c₆_quadraticTwistOf`: the invariants of the twist.
-* `WeierstrassCurve.isElliptic_quadraticTwistOf_of_isUnit` and its field specialisation
+* `WeierstrassCurve.isElliptic_quadraticTwistOf_iff` and its field specialisation
   `WeierstrassCurve.isElliptic_quadraticTwistOf`, and `WeierstrassCurve.j_quadraticTwistOf`: the
-  twist of an elliptic curve is elliptic when `t² - 4n` is a unit — over a field, when it is
-  nonzero — with equal `j`.
+  twist of an elliptic curve is elliptic exactly when `t² - 4n` is a unit — over a field, when
+  it is nonzero — with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
   `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is isomorphic to the
   original curve, and changing the generator moves the twist by a change of variables.
@@ -73,7 +74,7 @@ turns this relation into the Weierstrass model below of the twist:
 `y² + ta₁·xy + Dta₃·y = x³ + (Da₂ - na₁²)·x² + (D²a₄ - 2Dna₁a₃)·x + (D³a₆ - D²na₃²)`.
 
 Its discriminant is `D⁶·Δ(E)` (`Δ_quadraticTwistOf`), so the twist of an elliptic curve is
-elliptic when `D` is a unit (`isElliptic_quadraticTwistOf_of_isUnit`) — over a field, when
+elliptic exactly when `D` is a unit (`isElliptic_quadraticTwistOf_iff`) — over a field, when
 `D ≠ 0` (`isElliptic_quadraticTwistOf`) — with the same `j`-invariant (`j_quadraticTwistOf`).
 
 Sanity checks. If `char K ≠ 2` we may take `θ = √d`, so `t = 0`, `n = -d`, `D = 4d`; for
@@ -169,14 +170,15 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
       map_a₃, map_a₄, map_a₆, map_mul, map_sub,
       map_pow, map_ofNat]
 
-/-- The quadratic twist of an elliptic curve is elliptic when the discriminant `D = t² - 4n` of
-the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a general commutative ring `D ≠ 0` is
-not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`); over a field
-the two coincide, which is `isElliptic_quadraticTwistOf`. -/
-theorem isElliptic_quadraticTwistOf_of_isUnit [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
-    (E.quadraticTwistOf t n).IsElliptic := by
+/-- The quadratic twist of an elliptic curve is elliptic exactly when the discriminant
+`D = t² - 4n` of the twisting parameters is a unit, since `Δ ↦ D⁶Δ` and `D⁶ · unit` is a unit
+precisely when `D` is. Over a general commutative ring `D ≠ 0` is not the right criterion (take
+`A = ℤ`, `D = 2`); over a field the two coincide, which is `isElliptic_quadraticTwistOf`. -/
+theorem isElliptic_quadraticTwistOf_iff [E.IsElliptic] :
+    (E.quadraticTwistOf t n).IsElliptic ↔ IsUnit (t ^ 2 - 4 * n) := by
   rw [isElliptic_iff, Δ_quadraticTwistOf]
-  exact (hD.pow 6).mul E.isUnit_Δ
+  exact ⟨fun h ↦ (isUnit_pow_iff (by norm_num)).mp (isUnit_of_mul_isUnit_left h),
+    fun hD ↦ (hD.pow 6).mul E.isUnit_Δ⟩
 
 /-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. Both `j`s are `Δ'⁻¹c₄³`, and the
 twist scales `Δ` by `D⁶` and `c₄` by `D²`, so the two `D`-powers cancel against each other. -/
@@ -188,17 +190,12 @@ theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsEllipt
   rw [j, j, Units.inv_mul_eq_iff_eq_mul, c₄_quadraticTwistOf, coe_Δ', Δ_quadraticTwistOf]
   linear_combination (-((t ^ 2 - 4 * n) ^ 6 * E.c₄ ^ 3)) * hΔ
 
-/-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve: explicitly, the
-double twist is obtained from `E` by the change of variables
-`(x, y) ↦ (D²x, D³y - 2nD²(a₁x + a₃))`, where `D = t² - 4n`. Over a field the hypothesis is
-`D ≠ 0` (`isUnit_iff_ne_zero`). -/
-theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : IsUnit (t ^ 2 - 4 * n)) :
-    ∃ C : VariableChange A, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
-  obtain ⟨u, hu⟩ := hD
-  have hi : (↑u⁻¹ : A) * (u : A) = 1 := u.inv_mul
-  refine ⟨⟨u⁻¹, 0, 2 * n * (↑u⁻¹ : A) * E.a₁, 2 * n * (↑u⁻¹ : A) * E.a₃⟩, ?_⟩
-  rw [variableChange_def]
-  ext <;> simp only [quadraticTwistOf, inv_inv, ← hu] <;> grobner
+/-- Twisting twice by the same parameters is twisting once by their composite: the quadratic
+`x² - t²x + (2t²n - 4n²)` is the norm form of the composite extension. No hypothesis. -/
+theorem quadraticTwistOf_quadraticTwistOf :
+    (E.quadraticTwistOf t n).quadraticTwistOf t n
+      = E.quadraticTwistOf (t ^ 2) (2 * t ^ 2 * n - 4 * n ^ 2) := by
+  ext <;> simp only [quadraticTwistOf] <;> ring
 
 /-- Changing the parameters `(t, n)` — the trace and norm of a generator `θ` of a quadratic
 extension — into the trace and norm `(at + 2b, b² + abt + a²n)` of another generator `aθ + b`
@@ -214,6 +211,28 @@ theorem exists_smul_quadraticTwistOf_eq {a : A} (b : A) (ha : IsUnit a) :
   rw [variableChange_def]
   ext <;> simp only [quadraticTwistOf, inv_inv, ← hv] <;> grobner
 
+/-- Twisting by a **split** quadratic `(x - r)(x - s)` is trivial up to isomorphism: the twist
+by its trace and norm `(r + s, rs)` is a change of variables away from `E`, provided the
+difference of the roots is a unit (that difference squared is the discriminant). -/
+theorem exists_smul_eq_quadraticTwistOf_add_mul (r s : A) (h : IsUnit (s - r)) :
+    ∃ C : VariableChange A, C • E = E.quadraticTwistOf (r + s) (r * s) := by
+  obtain ⟨C, hC⟩ := E.exists_smul_quadraticTwistOf_eq 1 0 (a := s - r) r h
+  refine ⟨C, ?_⟩
+  rwa [quadraticTwistOf_one_zero, show (s - r) * 1 + 2 * r = r + s by ring,
+    show r ^ 2 + (s - r) * r * 1 + (s - r) ^ 2 * 0 = r * s by ring] at hC
+
+/-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve. This is the split
+case `exists_smul_eq_quadraticTwistOf_add_mul` at roots `r = t² - 2n` and `s = 2n`, whose sum
+and product are the composite parameters of `quadraticTwistOf_quadraticTwistOf` and whose
+difference is `-(t² - 4n)`. -/
+theorem exists_smul_eq_quadraticTwistOf_quadraticTwistOf (hD : IsUnit (t ^ 2 - 4 * n)) :
+    ∃ C : VariableChange A, C • E = (E.quadraticTwistOf t n).quadraticTwistOf t n := by
+  obtain ⟨C, hC⟩ := E.exists_smul_eq_quadraticTwistOf_add_mul (t ^ 2 - 2 * n) (2 * n)
+    (by rwa [show 2 * n - (t ^ 2 - 2 * n) = -(t ^ 2 - 4 * n) by ring, IsUnit.neg_iff])
+  rw [show t ^ 2 - 2 * n + 2 * n = t ^ 2 by ring,
+    show (t ^ 2 - 2 * n) * (2 * n) = 2 * t ^ 2 * n - 4 * n ^ 2 by ring] at hC
+  exact ⟨C, by rw [quadraticTwistOf_quadraticTwistOf]; exact hC⟩
+
 end QuadraticTwistOfRing
 
 section Field
@@ -222,10 +241,10 @@ variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
 
 /-- Over a field, the quadratic twist of an elliptic curve is elliptic when the discriminant
 `D = t² - 4n` of the twisting parameters is nonzero. This is the form the roadmap and the source
-state; `isElliptic_quadraticTwistOf_of_isUnit` is the ring-level strengthening it specialises. -/
+state; `isElliptic_quadraticTwistOf_iff` is the ring-level equivalence it specialises. -/
 theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
     (E.quadraticTwistOf t n).IsElliptic :=
-  E.isElliptic_quadraticTwistOf_of_isUnit t n (isUnit_iff_ne_zero.mpr hD)
+  (E.isElliptic_quadraticTwistOf_iff t n).mpr (isUnit_iff_ne_zero.mpr hD)
 
 end Field
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -14,10 +14,10 @@ be thought of as the trace and norm of a generator `θ` of a separable quadratic
 `L/K`, with `D := t² - 4n` the discriminant of its minimal polynomial — together with the
 behaviour of the standard invariants under twisting, uniformly in the characteristic: over any
 commutative ring `b₂, b₄, b₆` scale by `D, D², D³`, `c₄, c₆` by `D², D³`, and `Δ` by `D⁶`, so
-the twist of an elliptic curve is elliptic exactly when `D` is a unit (over a field, when
-`D ≠ 0`), with the same `j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the
-trace and norm of another generator, moves the twist by an explicit change of variables over the
-base field.
+the twist of an elliptic curve is elliptic when `D` is a unit — over a field, when `D ≠ 0` —
+with the same `j`-invariant. Twisting twice by `(t, n)`, or changing `(t, n)` to the trace and
+norm of another generator, moves the twist by an explicit change of variables, again over any
+commutative ring in which the relevant parameter is a unit.
 
 ## Main definitions
 
@@ -28,7 +28,7 @@ base field.
 * `WeierstrassCurve.isElliptic_quadraticTwistOf`, `WeierstrassCurve.j_quadraticTwistOf`: the
   twist of an elliptic curve is elliptic when `t² - 4n` is a unit, with equal `j`.
 * `WeierstrassCurve.exists_smul_eq_quadraticTwistOf_quadraticTwistOf`,
-  `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is `K`-isomorphic to the
+  `WeierstrassCurve.exists_smul_quadraticTwistOf_eq`: the double twist is isomorphic to the
   original curve, and changing the generator moves the twist by a change of variables.
 
 These are the `quadraticTwistOf` seeds of `TauCetiRoadmap/EllipticCurves/README.md` §Layer 5
@@ -166,6 +166,25 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
     simp only [quadraticTwistOf, map_a₁, map_a₂,
       map_a₃, map_a₄, map_a₆, map_mul, map_sub,
       map_pow, map_ofNat]
+
+/-- The quadratic twist of an elliptic curve is elliptic when the discriminant `D = t² - 4n` of
+the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a field this hypothesis is `D ≠ 0`
+(`isUnit_iff_ne_zero`), the form in which the source states it; over a general commutative ring
+`D ≠ 0` is not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`). -/
+theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
+    (E.quadraticTwistOf t n).IsElliptic := by
+  rw [isElliptic_iff, Δ_quadraticTwistOf]
+  exact (hD.pow 6).mul E.isUnit_Δ
+
+/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. Both `j`s are `Δ'⁻¹c₄³`, and the
+twist scales `Δ` by `D⁶` and `c₄` by `D²`, so the two `D`-powers cancel against each other. -/
+theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+    (E.quadraticTwistOf t n).j = E.j := by
+  have hΔ : E.Δ * ((E.Δ'⁻¹ : Aˣ) : A) = 1 := by
+    rw [← coe_Δ']
+    exact E.Δ'.mul_inv
+  rw [j, j, Units.inv_mul_eq_iff_eq_mul, c₄_quadraticTwistOf, coe_Δ', Δ_quadraticTwistOf]
+  linear_combination (-((t ^ 2 - 4 * n) ^ 6 * E.c₄ ^ 3)) * hΔ
 
 /-- Twisting twice by the same parameters `(t, n)` gives an isomorphic curve: explicitly, the
 double twist is obtained from `E` by the change of variables

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/QuadraticTwist.lean
@@ -158,9 +158,15 @@ the `b₂`, `b₄` and `b₆` laws, since `c₆ = -b₂³ + 36b₂b₄ - 216b₆
       map_a₃, map_a₄, map_a₆, map_mul, map_sub,
       map_pow, map_ofNat]
 
-/-- The node-polynomial constant `κ = 54 b₆ - 3 b₂ b₄ + a₂ c₄` of the quadratic twist by `(t, n)`
-in terms of that of `E`: `κ_W = D³ κ - D² n a₁² c₄` where `D = t² - 4n`. -/
-theorem kappa_quadraticTwistOf :
+/-- The constant term `54 b₆ - 3 b₂ b₄ + a₂ c₄` of the quadratic twist by `(t, n)`, in terms of
+that of `E`: it becomes `D³ · (54 b₆ - 3 b₂ b₄ + a₂ c₄) - D² n a₁² c₄` where `D = t² - 4n`.
+
+This is the constant term of the polynomial `c₄T² + a₁c₄T - (54 b₆ - 3 b₂ b₄ + a₂ c₄)` whose
+splitting characterises split multiplicative reduction (Mathlib's
+`WeierstrassCurve.HasSplitMultiplicativeReduction`), and which arises from the second-order
+Taylor expansion of the equation at the node. It is consumed by the twist-to-split-reduction
+theorem, a later milestone of the same roadmap layer. -/
+theorem nodeConst_quadraticTwistOf :
     54 * (E.quadraticTwistOf t n).b₆
       - 3 * (E.quadraticTwistOf t n).b₂ * (E.quadraticTwistOf t n).b₄
       + (E.quadraticTwistOf t n).a₂ * (E.quadraticTwistOf t n).c₄
@@ -170,27 +176,30 @@ theorem kappa_quadraticTwistOf :
     a₂_quadraticTwistOf]
   ring
 
+/-- The quadratic twist of an elliptic curve is elliptic when the discriminant `D = t² - 4n` of
+the twisting parameters is a unit, since `Δ ↦ D⁶Δ`. Over a field this hypothesis is `D ≠ 0`
+(`isUnit_iff_ne_zero`), the form in which the source states it; over a general commutative ring
+`D ≠ 0` is not enough, since `D⁶ · unit` is a unit only when `D` is (take `A = ℤ`, `D = 2`). -/
+theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : IsUnit (t ^ 2 - 4 * n)) :
+    (E.quadraticTwistOf t n).IsElliptic := by
+  rw [isElliptic_iff, Δ_quadraticTwistOf]
+  exact (hD.pow 6).mul E.isUnit_Δ
+
+/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. Both `j`s are `Δ'⁻¹c₄³`, and the
+twist scales `Δ` by `D⁶` and `c₄` by `D²`, so the two `D`-powers cancel against each other. -/
+theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
+    (E.quadraticTwistOf t n).j = E.j := by
+  have hΔ : E.Δ * ((E.Δ'⁻¹ : Aˣ) : A) = 1 := by
+    rw [← coe_Δ']
+    exact E.Δ'.mul_inv
+  rw [j, j, Units.inv_mul_eq_iff_eq_mul, c₄_quadraticTwistOf, coe_Δ', Δ_quadraticTwistOf]
+  linear_combination (-((t ^ 2 - 4 * n) ^ 6 * E.c₄ ^ 3)) * hΔ
+
 end QuadraticTwistOfRing
 
 section QuadraticTwistOf
 
 variable {K : Type*} [Field K] (E : WeierstrassCurve K) (t n : K)
-
-/-- Over a field, the quadratic twist of an elliptic curve is elliptic when the discriminant
-`D = t² - 4n` of the twisting parameters is nonzero, since `Δ ↦ D⁶Δ`. -/
-theorem isElliptic_quadraticTwistOf [E.IsElliptic] (hD : t ^ 2 - 4 * n ≠ 0) :
-    (E.quadraticTwistOf t n).IsElliptic := by
-  rw [isElliptic_iff, Δ_quadraticTwistOf]
-  exact (isUnit_iff_ne_zero.mpr (pow_ne_zero 6 hD)).mul E.isUnit_Δ
-
-/-- The `j`-invariant is a twist invariant: `j(E_{t,n}) = j(E)`. -/
-theorem j_quadraticTwistOf [E.IsElliptic] (h : (E.quadraticTwistOf t n).IsElliptic) :
-    (E.quadraticTwistOf t n).j = E.j := by
-  have hD : t ^ 2 - 4 * n ≠ 0 := fun h0 ↦ (E.quadraticTwistOf t n).isUnit_Δ.ne_zero
-    (by rw [Δ_quadraticTwistOf, h0]; ring)
-  have hΔ : E.Δ ≠ 0 := E.isUnit_Δ.ne_zero
-  simp only [j, Units.val_inv_eq_inv_val, coe_Δ', Δ_quadraticTwistOf, c₄_quadraticTwistOf]
-  field_simp
 
 /-- Twisting twice by the same parameters `(t, n)` gives a curve isomorphic to `E` over `K`:
 explicitly, the double twist is obtained from `E` by the change of variables


### PR DESCRIPTION
This PR defines the quadratic twist of a Weierstrass curve and proves its invariant theory, uniformly in the characteristic: `WeierstrassCurve.quadraticTwistOf E t n` is an explicit Weierstrass model of the twist by parameters `(t, n)` — the trace and norm of a generator of a separable quadratic extension, with `D = t² - 4n` — over any commutative ring, with the transformation laws `b₂ ↦ Db₂`, `b₄ ↦ D²b₄`, `b₆ ↦ D³b₆`, `c₄ ↦ D²c₄`, `c₆ ↦ D³c₆`, `Δ ↦ D⁶Δ`, the node-polynomial constant law, and compatibility with ring homomorphisms. Over a field this gives ellipticity of the twist exactly when `D ≠ 0` (`isElliptic_quadraticTwistOf`), invariance of `j` (`j_quadraticTwistOf`), and the two change-of-variables statements: the double twist is `K`-isomorphic to the original curve, and changing the generator of the extension moves the twist by an explicit change of variables.

This advances `TauCetiRoadmap/EllipticCurves` §Layer 5 (twists): `quadraticTwistOf`, `Δ_quadraticTwistOf`, `isElliptic_quadraticTwistOf`, and `j_quadraticTwistOf` are pinned verbatim as seeds in that roadmap's `Suggested.lean` ("The body is copied verbatim from FLT's `quadraticTwistOf` — pinned as a definition, not a `sorry`, so an implementation cannot drift to a different twist normalization"), and the roadmap's provenance section plans exactly this port ("a body of code to bring into Tau Ceti first"). Mathlib has no twists (`grep quadraticTwist` in `Mathlib/AlgebraicGeometry/EllipticCurve/` is empty at the pin). The remaining Layer-5 milestones — the extension twist `quadraticTwist E L`, the point isomorphism with its Galois anti-equivariance, the classification for `j ∉ {0, 1728}`, and split multiplicative reduction after a twist — build on this file and arrive in follow-up PRs (the automorphism-group prerequisite is #2248, the point-group transport #2247).

Adapted from the FLT project's quadratic-twist development (`ImperialCollegeLondon/FLT`, `FLT/KnownIn1980s/EllipticCurves/QuadraticTwists/QuadraticTwists.lean` at `d18b563029f3`, sections `QuadraticTwistOfRing` and `QuadraticTwistOf`, Apache 2.0, by Kevin Buzzard and Claude; merged there through FLT PR #1088). Changes in porting: Tau Ceti header, docstrings added to the invariant lemmas, and a module docstring scoped to this slice.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"quadratictwistof"}-->

🤖 Prepared with Claude Code (Claude Fable 5)
