### PR TITLE
feat: package the Banach algebra dexp factor

### DIFF
--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -5,7 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import TauCeti.Geometry.Lie.Adjoint.OperatorExponential
-public import TauCeti.Analysis.Normed.Algebra.OneSubExpNegDivSelf
+public import TauCeti.Analysis.Normed.Algebra.OneSubExpNegDivSelf.Basic
 
 /-!
 # The Banach-algebra dexp factor

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -48,17 +48,23 @@ noncomputable def banachDexpFactor (x : R) : R →L[ℝ] R :=
   oneSubExpNegDivSelf ℝ (continuousCommutator x)
 
 omit [CompleteSpace R] in
+/-- The Banach dexp factor is the regularized quotient evaluated at the commutator operator. -/
+theorem banachDexpFactor_eq_oneSubExpNegDivSelf (x : R) :
+    banachDexpFactor x = oneSubExpNegDivSelf ℝ (continuousCommutator x) := by
+  rw [banachDexpFactor]
+
+omit [CompleteSpace R] in
 /-- At zero, the Banach-algebra dexp factor is the identity operator. -/
 @[simp]
 theorem banachDexpFactor_zero : banachDexpFactor (0 : R) = 1 := by
-  rw [banachDexpFactor, map_zero, oneSubExpNegDivSelf_zero]
+  rw [banachDexpFactor_eq_oneSubExpNegDivSelf, map_zero, oneSubExpNegDivSelf_zero]
 
 /-- Multiplication by the commutator operator cancels the regularized denominator. -/
 @[simp]
 theorem continuousCommutator_mul_banachDexpFactor (x : R) :
     continuousCommutator x * banachDexpFactor x =
       1 - exp (-continuousCommutator x) := by
-  rw [banachDexpFactor, mul_oneSubExpNegDivSelf]
+  rw [banachDexpFactor_eq_oneSubExpNegDivSelf, mul_oneSubExpNegDivSelf]
 
 /-- Multiplication by the commutator operator on the right also cancels the regularized
 denominator. -/
@@ -66,13 +72,13 @@ denominator. -/
 theorem banachDexpFactor_mul_continuousCommutator (x : R) :
     banachDexpFactor x * continuousCommutator x =
       1 - exp (-continuousCommutator x) := by
-  rw [banachDexpFactor, oneSubExpNegDivSelf_mul]
+  rw [banachDexpFactor_eq_oneSubExpNegDivSelf, oneSubExpNegDivSelf_mul]
 
 omit [CompleteSpace R] in
 /-- The commutator operator commutes with its Banach dexp factor. -/
 theorem commute_continuousCommutator_banachDexpFactor (x : R) :
     Commute (continuousCommutator x) (banachDexpFactor x) := by
-  rw [banachDexpFactor]
+  rw [banachDexpFactor_eq_oneSubExpNegDivSelf]
   exact commute_oneSubExpNegDivSelf (continuousCommutator x)
 
 /-- The operator quotient identity evaluated on an algebra element, with the operator exponential

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Geometry.Lie.Adjoint.OperatorExponential
+public import TauCeti.Analysis.Normed.Algebra.OneSubExpNegDivSelf
+
+/-!
+# The Banach-algebra dexp factor
+
+This file evaluates the regularized exponential quotient at the bounded commutator operator. The
+result is the Banach-algebra realization of `(1 - exp (-ad x)) / ad x`, the right-trivialized
+factor in the differential of a Lie-group exponential.
+
+## Main definitions
+
+* `TauCeti.Lie.banachDexpFactor`: the regularized quotient at the bounded commutator.
+
+## Main results
+
+* `TauCeti.Lie.continuousCommutator_mul_banachDexpFactor`: the operator quotient identity.
+* `TauCeti.Lie.continuousCommutator_banachDexpFactor_apply`: its concrete conjugation form.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The conjugation formulas".
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti.Lie
+
+open NormedSpace
+
+variable {R : Type*} [NormedRing R] [NormedAlgebra ℝ R] [CompleteSpace R]
+
+/-- The Banach-algebra realization of the regularized operator quotient
+`(1 - exp (-ad x)) / ad x`. -/
+noncomputable def banachDexpFactor (x : R) : R →L[ℝ] R :=
+  oneSubExpNegDivSelf ℝ (continuousCommutator x)
+
+omit [CompleteSpace R] in
+/-- The Banach dexp factor is the regularized quotient evaluated at the commutator operator. -/
+theorem banachDexpFactor_eq_oneSubExpNegDivSelf (x : R) :
+    banachDexpFactor x = oneSubExpNegDivSelf ℝ (continuousCommutator x) := by
+  rw [banachDexpFactor]
+
+omit [CompleteSpace R] in
+/-- At zero, the Banach-algebra dexp factor is the identity operator. -/
+@[simp]
+theorem banachDexpFactor_zero : banachDexpFactor (0 : R) = 1 := by
+  rw [banachDexpFactor, show continuousCommutator (0 : R) = 0 by
+    ext y
+    simp, oneSubExpNegDivSelf_zero]
+
+/-- Multiplication by the commutator operator cancels the regularized denominator. -/
+theorem continuousCommutator_mul_banachDexpFactor (x : R) :
+    continuousCommutator x * banachDexpFactor x =
+      1 - exp (-continuousCommutator x) := by
+  exact mul_oneSubExpNegDivSelf (𝕂 := ℝ) (continuousCommutator x)
+
+/-- The operator quotient identity evaluated on an algebra element, with the operator exponential
+rewritten as concrete conjugation. -/
+theorem continuousCommutator_banachDexpFactor_apply (x y : R) :
+    continuousCommutator x (banachDexpFactor x y) =
+      y - exp (-x) * y * exp x := by
+  have hneg : -continuousCommutator x = continuousCommutator (-x) := by
+    ext z
+    simp only [neg_apply, continuousCommutator_apply]
+    noncomm_ring
+  have h := congrArg (fun f : R →L[ℝ] R ↦ f y)
+    (continuousCommutator_mul_banachDexpFactor x)
+  simpa only [mul_apply_eq_comp, one_apply_eq_self, sub_apply, hneg,
+    exp_continuousCommutator_apply, neg_neg] using h
+
+end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -98,11 +98,8 @@ exponential rewritten as concrete conjugation. -/
 theorem banachDexpFactor_continuousCommutator_apply (x y : R) :
     banachDexpFactor x (continuousCommutator x y) =
       y - exp (-x) * y * exp x := by
-  have hneg : -continuousCommutator x = continuousCommutator (-x) :=
-    (map_neg continuousCommutator x).symm
-  have h := congrArg (fun f : R →L[ℝ] R ↦ f y)
-    (banachDexpFactor_mul_continuousCommutator x)
-  simpa only [mul_apply_eq_comp, one_apply_eq_self, sub_apply, hneg,
-    exp_continuousCommutator_apply, neg_neg] using h
+  rw [← mul_apply_eq_comp,
+    ← (commute_continuousCommutator_banachDexpFactor x).eq, mul_apply_eq_comp]
+  exact continuousCommutator_banachDexpFactor_apply x y
 
 end TauCeti.Lie

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -11,7 +11,7 @@ public import TauCeti.Analysis.Normed.Algebra.OneSubExpNegDivSelf
 # The Banach-algebra dexp factor
 
 This file evaluates the regularized exponential quotient at the bounded commutator operator. The
-result is the Banach-algebra realization of `(1 - exp (-ad x)) / ad x`, the right-trivialized
+result is the Banach-algebra realization of `(1 - exp (-ad x)) / ad x`, the left-trivialized
 factor in the differential of a Lie-group exponential.
 
 ## Main definitions

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -54,9 +54,10 @@ omit [CompleteSpace R] in
 /-- At zero, the Banach-algebra dexp factor is the identity operator. -/
 @[simp]
 theorem banachDexpFactor_zero : banachDexpFactor (0 : R) = 1 := by
-  rw [banachDexpFactor, show continuousCommutator (0 : R) = 0 by
+  have hzero : continuousCommutator (0 : R) = 0 := by
     ext y
-    simp, oneSubExpNegDivSelf_zero]
+    simp
+  rw [banachDexpFactor, hzero, oneSubExpNegDivSelf_zero]
 
 /-- Multiplication by the commutator operator cancels the regularized denominator. -/
 theorem continuousCommutator_mul_banachDexpFactor (x : R) :

--- a/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
+++ b/TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
@@ -21,7 +21,10 @@ factor in the differential of a Lie-group exponential.
 ## Main results
 
 * `TauCeti.Lie.continuousCommutator_mul_banachDexpFactor`: the operator quotient identity.
+* `TauCeti.Lie.banachDexpFactor_mul_continuousCommutator`: the symmetric quotient identity.
+* `TauCeti.Lie.commute_continuousCommutator_banachDexpFactor`: the factor commutes with `ad x`.
 * `TauCeti.Lie.continuousCommutator_banachDexpFactor_apply`: its concrete conjugation form.
+* `TauCeti.Lie.banachDexpFactor_continuousCommutator_apply`: the symmetric pointwise form.
 
 ## References
 
@@ -45,37 +48,54 @@ noncomputable def banachDexpFactor (x : R) : R →L[ℝ] R :=
   oneSubExpNegDivSelf ℝ (continuousCommutator x)
 
 omit [CompleteSpace R] in
-/-- The Banach dexp factor is the regularized quotient evaluated at the commutator operator. -/
-theorem banachDexpFactor_eq_oneSubExpNegDivSelf (x : R) :
-    banachDexpFactor x = oneSubExpNegDivSelf ℝ (continuousCommutator x) := by
-  rw [banachDexpFactor]
-
-omit [CompleteSpace R] in
 /-- At zero, the Banach-algebra dexp factor is the identity operator. -/
 @[simp]
 theorem banachDexpFactor_zero : banachDexpFactor (0 : R) = 1 := by
-  have hzero : continuousCommutator (0 : R) = 0 := by
-    ext y
-    simp
-  rw [banachDexpFactor, hzero, oneSubExpNegDivSelf_zero]
+  rw [banachDexpFactor, map_zero, oneSubExpNegDivSelf_zero]
 
 /-- Multiplication by the commutator operator cancels the regularized denominator. -/
+@[simp]
 theorem continuousCommutator_mul_banachDexpFactor (x : R) :
     continuousCommutator x * banachDexpFactor x =
       1 - exp (-continuousCommutator x) := by
-  exact mul_oneSubExpNegDivSelf (𝕂 := ℝ) (continuousCommutator x)
+  rw [banachDexpFactor, mul_oneSubExpNegDivSelf]
+
+/-- Multiplication by the commutator operator on the right also cancels the regularized
+denominator. -/
+@[simp]
+theorem banachDexpFactor_mul_continuousCommutator (x : R) :
+    banachDexpFactor x * continuousCommutator x =
+      1 - exp (-continuousCommutator x) := by
+  rw [banachDexpFactor, oneSubExpNegDivSelf_mul]
+
+omit [CompleteSpace R] in
+/-- The commutator operator commutes with its Banach dexp factor. -/
+theorem commute_continuousCommutator_banachDexpFactor (x : R) :
+    Commute (continuousCommutator x) (banachDexpFactor x) := by
+  rw [banachDexpFactor]
+  exact commute_oneSubExpNegDivSelf (continuousCommutator x)
 
 /-- The operator quotient identity evaluated on an algebra element, with the operator exponential
 rewritten as concrete conjugation. -/
 theorem continuousCommutator_banachDexpFactor_apply (x y : R) :
     continuousCommutator x (banachDexpFactor x y) =
       y - exp (-x) * y * exp x := by
-  have hneg : -continuousCommutator x = continuousCommutator (-x) := by
-    ext z
-    simp only [neg_apply, continuousCommutator_apply]
-    noncomm_ring
+  have hneg : -continuousCommutator x = continuousCommutator (-x) :=
+    (map_neg continuousCommutator x).symm
   have h := congrArg (fun f : R →L[ℝ] R ↦ f y)
     (continuousCommutator_mul_banachDexpFactor x)
+  simpa only [mul_apply_eq_comp, one_apply_eq_self, sub_apply, hneg,
+    exp_continuousCommutator_apply, neg_neg] using h
+
+/-- The symmetric operator quotient identity evaluated on an algebra element, with the operator
+exponential rewritten as concrete conjugation. -/
+theorem banachDexpFactor_continuousCommutator_apply (x y : R) :
+    banachDexpFactor x (continuousCommutator x y) =
+      y - exp (-x) * y * exp x := by
+  have hneg : -continuousCommutator x = continuousCommutator (-x) :=
+    (map_neg continuousCommutator x).symm
+  have h := congrArg (fun f : R →L[ℝ] R ↦ f y)
+    (banachDexpFactor_mul_continuousCommutator x)
   simpa only [mul_apply_eq_comp, one_apply_eq_self, sub_apply, hneg,
     exp_continuousCommutator_apply, neg_neg] using h
 


### PR DESCRIPTION
## Goal

Package the Layer 1 regularized dexp factor in a Banach algebra by evaluating the merged filled exponential quotient at the bounded commutator operator.

## Why this works

For an algebra element x, continuousCommutator x is the bounded realization of ad x, and oneSubExpNegDivSelf is the everywhere-defined realization of (1 - exp (-a)) / a. Their composition gives the required factor without an invertibility hypothesis. The lifted quotient API proves left and right cancellation and commutation with ad x. Evaluating either cancellation and applying the merged commutator-exponential theorem yields the two concrete conjugation identities by exp (-x) and exp x. This is the Banach shadow needed by the abstract left-trivialized derivative formula while reusing both canonical prerequisites.

The exact roadmap target is TauCetiRoadmap/RepresentationTheory/LieGroups/README.md, Deliverable A, Layer 1, The conjugation formulas: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad.

## Validation

- lake env lean TauCeti/Geometry/Lie/Adjoint/BanachDexp.lean
- lake build
- bash scripts/lint-env.sh
- git diff --check

Roadmap: RepresentationTheory