### PR TITLE
feat: extract the displacement bound against a density length

### DIFF
--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Shift
+public import Mathlib.MeasureTheory.Integral.IntervalIntegral.DistLEIntegral
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
 
 /-!
@@ -39,6 +40,12 @@ the comparison `TauCeti.densityLength_le_densityLength`, without which two compa
 need not have comparable integrals. The pointwise hypotheses are asked at the *interior*
 parameters only, the two endpoints forming a null set.
 
+The one estimate that leaves the pair `(ρ, γ)` is `TauCeti.norm_sub_le_densityLength`, and it too
+is a statement about the parameter side: a function of the parameter whose speed is dominated by
+the density-weighted speed of `γ` is displaced, over the parameter interval, by no more than the
+length of `γ` over it. It runs in a second normed space of its own, unrelated to `F`, the
+hypothesis again comparing only real-valued speeds.
+
 The integral is taken over the **unordered** interval `uIcc a b`, as in Mathlib's
 `Manifold.pathELength`. This is what makes the length independent of the orientation of the
 parameter interval (`TauCeti.densityLength_symm`) and nonnegative for a nonnegative density
@@ -62,7 +69,9 @@ be routed through a Riemannian structure, the statements below are the ones to r
 
 The substitution rules are Mathlib's change of variables for a monotone or antitone substitution
 (`intervalIntegral.integral_deriv_smul_comp_of_deriv_nonneg` and its `nonpos` counterpart) read
-through the chain rule; the affine rule is `intervalIntegral.integral_comp_mul_add`.
+through the chain rule; the affine rule is `intervalIntegral.integral_comp_mul_add`; and the
+displacement bound is Mathlib's `norm_sub_le_integral_of_norm_deriv_le_of_le`, freed from the
+ordering of the parameter interval.
 
 ## Main definitions
 
@@ -78,6 +87,9 @@ through the chain rule; the affine rule is `intervalIntegral.integral_comp_mul_a
 * `TauCeti.densityLength_congr_of_eqOn` and `TauCeti.densityLength_le_densityLength` — two paths
   whose density-weighted speeds agree inside the parameter interval have equal lengths, and two
   whose integrable speeds compare there have comparable lengths.
+* `TauCeti.norm_sub_le_densityLength` — **displacement is at most the length**: a function of the
+  parameter whose speed is dominated by the density-weighted speed of the path moves, across the
+  parameter interval, by no more than the length of the path over it.
 * `TauCeti.densityLength_congr` — the length depends on the path only through its restriction to
   the interior of the parameter interval.
 * `TauCeti.densityLength_add` — additivity along the parameter interval.
@@ -216,6 +228,45 @@ theorem densityLength_le_densityLength {G : Type*} [NormedAddCommGroup G] [Norme
   rw [densityLength_eq_setIntegral_uIoo, densityLength_eq_setIntegral_uIoo]
   exact setIntegral_mono_on ((intervalIntegrable_iff.mp hδint).mono_set hsub)
     ((intervalIntegrable_iff.mp hγint).mono_set hsub) measurableSet_Ioo h
+
+/-- The displacement bound over an ordered parameter interval; the general case follows by
+symmetry. -/
+private theorem norm_sub_le_densityLength_of_le {G : Type*} [NormedAddCommGroup G]
+    [NormedSpace ℝ G] {u : ℝ → G} (hab : a ≤ b) (hu : ContinuousOn u (Icc a b))
+    (hdiff : DifferentiableOn ℝ u (Ioo a b))
+    (hbound : ∀ t ∈ Ioo a b, ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
+    (hint : IntervalIntegrable (fun t => ρ (γ t) * ‖deriv γ t‖) volume a b) :
+    ‖u b - u a‖ ≤ densityLength ρ γ a b := by
+  rw [densityLength_eq_intervalIntegral ρ γ hab]
+  exact norm_sub_le_integral_of_norm_deriv_le_of_le hab hu hdiff (.of_forall hbound) hint
+
+/-- **Displacement is at most the length.** If a function `u` of the parameter is continuous on the
+parameter interval, differentiable inside it, and its speed there is at most the density-weighted
+speed of `γ`, then `u` moves across the interval by at most the `ρ`-length of `γ` over it,
+whichever way round the endpoints are.
+
+This is how a length bounds a distance. Taking for `u` a quantity that the length is to dominate —
+`Real.artanh ‖γ‖` for the Poincaré density on the disc, say, or a linear functional applied to `γ`
+itself — reduces the bound to the *pointwise* comparison `hbound` between two speeds, exactly as
+`TauCeti.densityLength_le_densityLength` reduces a comparison of two lengths to one. Nothing
+relates `u` to `γ` beyond that comparison, not even the space it runs in: `u` takes values in a
+normed space of its own, and the density-weighted speed of `γ` enters only as a real-valued upper
+estimate on `‖deriv u‖`. Integrability of that estimate is needed for the same reason as there,
+and both hypotheses are asked at the *interior* parameters only, the two endpoints forming a null
+set; a `u` with an explicit derivative is read through `HasDerivAt.deriv`. -/
+theorem norm_sub_le_densityLength {G : Type*} [NormedAddCommGroup G] [NormedSpace ℝ G]
+    {u : ℝ → G} (hu : ContinuousOn u (uIcc a b)) (hdiff : DifferentiableOn ℝ u (uIoo a b))
+    (hbound : ∀ t ∈ uIoo a b, ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
+    (hint : IntervalIntegrable (fun t => ρ (γ t) * ‖deriv γ t‖) volume a b) :
+    ‖u b - u a‖ ≤ densityLength ρ γ a b := by
+  rcases le_total a b with hab | hab
+  · rw [uIcc_of_le hab] at hu
+    rw [uIoo_of_le hab] at hdiff hbound
+    exact norm_sub_le_densityLength_of_le hab hu hdiff hbound hint
+  · rw [uIcc_comm, uIcc_of_le hab] at hu
+    rw [uIoo_comm, uIoo_of_le hab] at hdiff hbound
+    rw [← densityLength_symm ρ γ a b, ← norm_neg, neg_sub]
+    exact norm_sub_le_densityLength_of_le hab hu hdiff hbound hint.symm
 
 /-- The congruence over an ordered parameter interval; the general case follows by symmetry. -/
 private theorem densityLength_congr_of_le (hab : a ≤ b) (hδ : EqOn δ γ (Ioo a b)) :

--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -38,7 +38,8 @@ the density for `TauCeti.densityLength_nonneg`, differentiability of the path fo
 substitution rules, which differentiate the composite, and integrability of the two integrands for
 the comparison `TauCeti.densityLength_le_densityLength`, without which two comparable integrands
 need not have comparable integrals. The pointwise hypotheses are asked at the *interior*
-parameters only, the two endpoints forming a null set.
+parameters only, the two endpoints forming a null set, and the displacement bound asks its
+comparison there only almost everywhere.
 
 The one estimate that leaves the pair `(ρ, γ)` is `TauCeti.norm_sub_le_densityLength`, and it too
 is a statement about the parameter side: a function of the parameter whose speed is dominated by
@@ -234,31 +235,34 @@ symmetry. -/
 private theorem norm_sub_le_densityLength_of_le {G : Type*} [NormedAddCommGroup G]
     [NormedSpace ℝ G] {u : ℝ → G} (hab : a ≤ b) (hu : ContinuousOn u (Icc a b))
     (hdiff : DifferentiableOn ℝ u (Ioo a b))
-    (hbound : ∀ t ∈ Ioo a b, ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
+    (hbound : ∀ᵐ t, t ∈ Ioo a b → ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
     (hint : IntervalIntegrable (fun t => ρ (γ t) * ‖deriv γ t‖) volume a b) :
     ‖u b - u a‖ ≤ densityLength ρ γ a b := by
   rw [densityLength_eq_intervalIntegral ρ γ hab]
-  exact norm_sub_le_integral_of_norm_deriv_le_of_le hab hu hdiff (.of_forall hbound) hint
+  exact norm_sub_le_integral_of_norm_deriv_le_of_le hab hu hdiff hbound hint
 
 /-- **Displacement is at most the length.** If a function `u` of the parameter is continuous on the
-parameter interval, differentiable inside it, and its speed there is at most the density-weighted
-speed of `γ`, then `u` moves across the interval by at most the `ρ`-length of `γ` over it,
-whichever way round the endpoints are.
+parameter interval, differentiable inside it, and its speed there is almost everywhere at most the
+density-weighted speed of `γ`, then `u` moves across the interval by at most the `ρ`-length of `γ`
+over it, whichever way round the endpoints are.
 
 This is how a length bounds a distance. Taking for `u` a quantity that the length is to dominate —
 for the Poincaré density on the disc, `Real.artanh ∘ (fun t => (v * γ t).re)` for a unit vector
 `v`, a linear functional of `γ` read through `Real.artanh` rather than `Real.artanh ‖γ‖`, which
-is not differentiable where the path crosses the origin — reduces the bound to the *pointwise*
-comparison `hbound` between two speeds, exactly as
+is not differentiable where the path crosses the origin — reduces the bound to the comparison
+`hbound` between two speeds, exactly as
 `TauCeti.densityLength_le_densityLength` reduces a comparison of two lengths to one. Nothing
 relates `u` to `γ` beyond that comparison, not even the space it runs in: `u` takes values in a
 normed space of its own, and the density-weighted speed of `γ` enters only as a real-valued upper
 estimate on `‖deriv u‖`. Integrability of that estimate is needed for the same reason as there,
 and both hypotheses are asked at the *interior* parameters only, the two endpoints forming a null
-set; a `u` with an explicit derivative is read through `HasDerivAt.deriv`. -/
+set — the comparison, as in Mathlib's `norm_sub_le_integral_of_norm_deriv_le_of_le`, only almost
+everywhere there, a bound holding at every interior parameter being read through
+`Filter.Eventually.of_forall`; a `u` with an explicit derivative is read through
+`HasDerivAt.deriv`. -/
 theorem norm_sub_le_densityLength {G : Type*} [NormedAddCommGroup G] [NormedSpace ℝ G]
     {u : ℝ → G} (hu : ContinuousOn u (uIcc a b)) (hdiff : DifferentiableOn ℝ u (uIoo a b))
-    (hbound : ∀ t ∈ uIoo a b, ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
+    (hbound : ∀ᵐ t, t ∈ uIoo a b → ‖deriv u t‖ ≤ ρ (γ t) * ‖deriv γ t‖)
     (hint : IntervalIntegrable (fun t => ρ (γ t) * ‖deriv γ t‖) volume a b) :
     ‖u b - u a‖ ≤ densityLength ρ γ a b := by
   rcases le_total a b with hab | hab

--- a/TauCeti/Analysis/Calculus/DensityLength.lean
+++ b/TauCeti/Analysis/Calculus/DensityLength.lean
@@ -5,8 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Analysis.Calculus.Deriv.Shift
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.DistLEIntegral
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.IntegrationByParts
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.DistLEIntegral
 
 /-!
 # The length of a path measured against a density
@@ -246,8 +246,10 @@ speed of `γ`, then `u` moves across the interval by at most the `ρ`-length of 
 whichever way round the endpoints are.
 
 This is how a length bounds a distance. Taking for `u` a quantity that the length is to dominate —
-`Real.artanh ‖γ‖` for the Poincaré density on the disc, say, or a linear functional applied to `γ`
-itself — reduces the bound to the *pointwise* comparison `hbound` between two speeds, exactly as
+for the Poincaré density on the disc, `Real.artanh ∘ (fun t => (v * γ t).re)` for a unit vector
+`v`, a linear functional of `γ` read through `Real.artanh` rather than `Real.artanh ‖γ‖`, which
+is not differentiable where the path crosses the origin — reduces the bound to the *pointwise*
+comparison `hbound` between two speeds, exactly as
 `TauCeti.densityLength_le_densityLength` reduces a comparison of two lengths to one. Nothing
 relates `u` to `γ` beyond that comparison, not even the space it runs in: `u` takes values in a
 normed space of its own, and the density-weighted speed of `γ` enters only as a real-valued upper

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -10,7 +10,6 @@ public import TauCeti.Analysis.Complex.Conformal.Moebius
 public import TauCeti.Analysis.Complex.Conformal.SchwarzPick.AutomorphismIsometry
 public import TauCeti.Analysis.Complex.Conformal.SchwarzPick.Derivative
 public import TauCeti.Analysis.SpecialFunctions.Artanh
-public import Mathlib.MeasureTheory.Integral.IntervalIntegral.DistLEIntegral
 import Mathlib.Analysis.Calculus.Deriv.Star
 import Mathlib.Analysis.Complex.CauchyIntegral
 
@@ -74,11 +73,13 @@ runs from `0` to `‖γ b‖` and satisfies `|ψ| ≤ ‖γ‖` and `|ψ ′| �
 
 `(Real.artanh ∘ ψ) ′ = ψ ′ / (1 - ψ ^ 2) ≤ ‖γ ′‖ / (1 - ‖γ‖ ^ 2)`,
 
-the first inequality being `1 - ‖γ‖ ^ 2 ≤ 1 - ψ ^ 2` in the denominator. So Mathlib's
-displacement bound `norm_sub_le_integral_of_norm_deriv_le_of_le` applies to `Real.artanh ∘ ψ`,
-whose displacement is `Real.artanh ‖γ b‖ = hyperbolicDist (γ a) (γ b)`. Projecting on a *linear*
-functional rather than on the norm is what keeps the comparison function differentiable where the
-path crosses the origin.
+the first inequality being `1 - ‖γ‖ ^ 2 ≤ 1 - ψ ^ 2` in the denominator. That is precisely the
+hypothesis of the displacement bound `TauCeti.norm_sub_le_densityLength` — a function of the
+parameter whose speed is dominated by the density-weighted speed of `γ` moves by at most the
+length of `γ` — read at the Poincaré density and at `Real.artanh ∘ ψ`, whose displacement is
+`Real.artanh ‖γ b‖ = hyperbolicDist (γ a) (γ b)`. Projecting on a *linear* functional rather than
+on the norm is what keeps the comparison function differentiable where the path crosses the
+origin.
 
 *The bound is attained.* By the same invariance it suffices to exhibit a shortest path from the
 origin, and the Euclidean radius `t ↦ u * t` is one: its hyperbolic length over `[0, r]` is
@@ -142,7 +143,8 @@ that API at that point.
   `TauCeti.intervalIntegrable_norm_deriv_div_one_sub_norm_sq` — for a `C¹` path in the disc the
   density-weighted speed is interval integrable, against an explicit derivative and against
   `deriv` respectively. The latter is the integrability hypothesis of
-  `TauCeti.hyperbolicLength_add`, and what the Schwarz--Pick estimate below spends.
+  `TauCeti.hyperbolicLength_add`, and what the Schwarz--Pick estimate and the lower bound below
+  spend.
 * `TauCeti.hyperbolicLength_comp_of_deriv_nonneg` and
   `TauCeti.hyperbolicLength_comp_of_deriv_nonpos` — **hyperbolic length is a reparametrisation
   invariant**: precomposing a path with a differentiable monotone, respectively antitone, map of
@@ -505,19 +507,23 @@ theorem hyperbolicLength_comp_eq_of_leftInvOn {f g : ℂ → ℂ}
 /-- The lower bound for a path issued from the origin, where the hyperbolic distance to the
 endpoint is `Real.artanh` of its Euclidean norm. Comparing with the real function
 `t ↦ (v * γ t).re` for a suitable unit vector `v` — rather than with `t ↦ ‖γ t‖`, which need not
-be differentiable — turns the estimate into Mathlib's displacement bound
-`norm_sub_le_integral_of_norm_deriv_le_of_le` applied to `Real.artanh ∘ ψ`. -/
-private theorem artanh_norm_le_integral (hab : a ≤ b) (hγ : ContinuousOn γ (Icc a b))
+be differentiable — turns the estimate into the displacement bound
+`TauCeti.norm_sub_le_densityLength` applied to `Real.artanh ∘ ψ` against the Poincaré density. -/
+private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : ContinuousOn γ (Icc a b))
     (hderiv : ∀ t ∈ Ioo a b, HasDerivAt γ (γ' t) t) (hγ' : ContinuousOn γ' (Icc a b))
     (hmem : ∀ t ∈ Icc a b, ‖γ t‖ < 1) (h0 : γ a = 0) :
-    Real.artanh ‖γ b‖ ≤ ∫ t in a..b, ‖γ' t‖ / (1 - ‖γ t‖ ^ 2) := by
+    Real.artanh ‖γ b‖ ≤ hyperbolicLength γ a b := by
   have hpos : ∀ t ∈ Icc a b, (0 : ℝ) < 1 - ‖γ t‖ ^ 2 := fun t ht => by
     nlinarith [norm_nonneg (γ t), hmem t ht]
   have hγu : ContinuousOn γ (uIcc a b) := by rwa [uIcc_of_le hab]
   have hγ'u : ContinuousOn γ' (uIcc a b) := by rwa [uIcc_of_le hab]
   have hmemu : ∀ t ∈ uIcc a b, ‖γ t‖ < 1 := by rwa [uIcc_of_le hab]
-  have hint2 : IntervalIntegrable (fun t => ‖γ' t‖ / (1 - ‖γ t‖ ^ 2)) MeasureTheory.volume a b :=
-    intervalIntegrable_norm_div_one_sub_norm_sq hγu hγ'u hmemu
+  have hderivu : ∀ t ∈ uIoo a b, HasDerivAt γ (γ' t) t := by rwa [uIoo_of_le hab]
+  -- the density-weighted speed in the shape `TauCeti.densityLength` integrates it
+  have hint2 : IntervalIntegrable (fun t => (1 - ‖γ t‖ ^ 2)⁻¹ * ‖deriv γ t‖)
+      MeasureTheory.volume a b := by
+    simpa only [div_eq_inv_mul] using
+      intervalIntegrable_norm_deriv_div_one_sub_norm_sq hγu hγ'u hderivu hmemu
   obtain ⟨v, hvnorm, hvb⟩ := Complex.exists_norm_eq_mul_self (γ b)
   set ψ : ℝ → ℝ := fun t => (v * γ t).re with hψdef
   have hψa : ψ a = 0 := by simp [hψdef, h0]
@@ -535,25 +541,31 @@ private theorem artanh_norm_le_integral (hab : a ≤ b) (hγ : ContinuousOn γ (
     have := hψmem t ht
     nlinarith [this.1, this.2]
   -- `Real.artanh ∘ ψ` runs from `0` to `Real.artanh ‖γ b‖` with speed at most the
-  -- density-weighted speed of `γ`, so Mathlib's displacement bound applies to it.
-  have hcont : ContinuousOn (fun t => Real.artanh (ψ t)) (Icc a b) :=
-    Real.continuousOn_artanh.comp hψcont fun t ht => hψmem t ht
-  have hdiff : DifferentiableOn ℝ (fun t => Real.artanh (ψ t)) (Ioo a b) := fun t ht =>
-    ((hψderiv t ht).artanh
+  -- density-weighted speed of `γ`, so the displacement bound applies to it.
+  have hcont : ContinuousOn (fun t => Real.artanh (ψ t)) (uIcc a b) := by
+    rw [uIcc_of_le hab]
+    exact Real.continuousOn_artanh.comp hψcont fun t ht => hψmem t ht
+  have hdiff : DifferentiableOn ℝ (fun t => Real.artanh (ψ t)) (uIoo a b) := by
+    rw [uIoo_of_le hab]
+    exact fun t ht => ((hψderiv t ht).artanh
       (hψmem t (Ioo_subset_Icc_self ht))).differentiableAt.differentiableWithinAt
-  have hbound : ∀ᵐ t, t ∈ Ioo a b →
-      ‖deriv (fun s => Real.artanh (ψ s)) t‖ ≤ ‖γ' t‖ / (1 - ‖γ t‖ ^ 2) :=
-    .of_forall fun t ht => by
-      have htI : t ∈ Icc a b := Ioo_subset_Icc_self ht
-      have hnum : |(v * γ' t).re| ≤ ‖γ' t‖ :=
-        (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul])
-      have hPQ : 1 - ‖γ t‖ ^ 2 ≤ 1 - ψ t ^ 2 := by
-        nlinarith [hψbound t, abs_nonneg (ψ t), sq_abs (ψ t), norm_nonneg (γ t)]
-      rw [((hψderiv t ht).artanh (hψmem t htI)).deriv, Real.norm_eq_abs, abs_mul, abs_inv,
-        abs_of_pos (hPpos t htI), inv_mul_eq_div]
-      gcongr
-      exact hpos t htI
-  have key := norm_sub_le_integral_of_norm_deriv_le_of_le hab hcont hdiff hbound hint2
+  have hbound : ∀ t ∈ uIoo a b,
+      ‖deriv (fun s => Real.artanh (ψ s)) t‖ ≤ (1 - ‖γ t‖ ^ 2)⁻¹ * ‖deriv γ t‖ := by
+    rw [uIoo_of_le hab]
+    intro t ht
+    have htI : t ∈ Icc a b := Ioo_subset_Icc_self ht
+    have hnum : |(v * γ' t).re| ≤ ‖γ' t‖ :=
+      (Complex.abs_re_le_norm _).trans_eq (by rw [norm_mul, hvnorm, one_mul])
+    have hPQ : 1 - ‖γ t‖ ^ 2 ≤ 1 - ψ t ^ 2 := by
+      nlinarith [hψbound t, abs_nonneg (ψ t), sq_abs (ψ t), norm_nonneg (γ t)]
+    rw [(hderiv t ht).deriv, ← div_eq_inv_mul,
+      ((hψderiv t ht).artanh (hψmem t htI)).deriv, Real.norm_eq_abs, abs_mul, abs_inv,
+      abs_of_pos (hPpos t htI), inv_mul_eq_div]
+    gcongr
+    exact hpos t htI
+  rw [hyperbolicLength]
+  have key := norm_sub_le_densityLength (ρ := fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) (γ := γ)
+    hcont hdiff hbound hint2
   simp only [hψa, hψb, Real.artanh_zero, sub_zero, Real.norm_eq_abs] at key
   exact (le_abs_self _).trans key
 
@@ -590,9 +602,8 @@ private theorem hyperbolicDist_le_hyperbolicLength_of_le (hab : a ≤ b)
   have hmemu : ∀ t ∈ uIoo a b, ‖γ t‖ < 1 := by
     rw [uIoo_of_le hab]
     exact fun t ht => hmem t (Ioo_subset_Icc_self ht)
-  have key := artanh_norm_le_integral hab hσcont hσderiv hσ'cont hσmem hσa
-  rw [← hyperbolicLength_eq_integral hab hσderiv,
-    hyperbolicLength_unitDiscMoebiusFormula_comp hc hderivu hmemu] at key
+  have key := artanh_norm_le_hyperbolicLength hab hσcont hσderiv hσ'cont hσmem hσa
+  rw [hyperbolicLength_unitDiscMoebiusFormula_comp hc hderivu hmemu] at key
   refine le_trans (le_of_eq ?_) key
   rw [hyperbolicDist_comm, hyperbolicDist_def, pseudoHyperbolicExpr_def]
 

--- a/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Hyperbolic/Length.lean
@@ -565,7 +565,7 @@ private theorem artanh_norm_le_hyperbolicLength (hab : a ≤ b) (hγ : Continuou
     exact hpos t htI
   rw [hyperbolicLength]
   have key := norm_sub_le_densityLength (ρ := fun z : ℂ => (1 - ‖z‖ ^ 2)⁻¹) (γ := γ)
-    hcont hdiff hbound hint2
+    hcont hdiff (.of_forall hbound) hint2
   simp only [hψa, hψb, Real.artanh_zero, sub_zero, Real.norm_eq_abs] at key
   exact (le_abs_self _).trans key
 


### PR DESCRIPTION
This PR extracts, from the Poincaré-length material, the density-independent estimate that a
length bounds a distance, and states it where the rest of the parameter-side calculus already
lives. `TauCeti.norm_sub_le_densityLength` says that if a function `u` of the parameter is
continuous on the parameter interval, differentiable inside it, and its speed there is at most the
density-weighted speed `ρ (γ t) * ‖deriv γ t‖` of a path `γ`, then `‖u b - u a‖ ≤
densityLength ρ γ a b` — whichever way round the endpoints are. Nothing relates `u` to `γ` beyond
that pointwise comparison, not even the space it runs in: `u` takes values in a real normed space
of its own and the density-weighted speed enters only as a real-valued upper estimate, exactly as
in the existing comparison `TauCeti.densityLength_le_densityLength`, whose inequality between two
lengths this complements with an inequality between a displacement and one length.

The statement was, until now, inlined in the proof of the private
`TauCeti.artanh_norm_le_integral` of `Conformal/Hyperbolic/Length.lean`, where the lower bound
`hyperbolicDist (γ a) (γ b) ≤ hyperbolicLength γ a b` is obtained by applying Mathlib's
displacement bound to `Real.artanh ∘ ψ` for a linear comparison function `ψ`. That private lemma is
reproved here through the extracted statement and renamed
`TauCeti.artanh_norm_le_hyperbolicLength`, its conclusion now reading against `hyperbolicLength`
rather than against the unfolded interval integral, which lets the caller drop a rewrite; nothing
public in `Length.lean` changes shape, and `TauCeti.hyperbolicDist_le_hyperbolicLength` and
`TauCeti.isLeast_hyperbolicLength` are untouched. This continues the extraction begun in #2205,
which pulled `TauCeti.densityLength` and the parameter-side calculus out of `hyperbolicLength`,
and #2215, which pulled out the comparison of two density lengths; the displacement bound is the
last piece of that calculus that was still stated only in Poincaré terms.

The mathematics is Mathlib's: the ordered case is
`norm_sub_le_integral_of_norm_deriv_le_of_le` (Yury Kudryashov,
`Mathlib/MeasureTheory/Integral/IntervalIntegral/DistLEIntegral.lean`) read through
`TauCeti.densityLength_eq_intervalIntegral`, and what is added here is the orientation-free form
over `uIcc`/`uIoo`, which is the shape every other lemma in the file is stated in and the shape
its consumers use. No new declaration is added to `Conformal/Hyperbolic/Length.lean`; the direct
import of `DistLEIntegral` there is dropped, nothing in that file using it any more, and in
`TauCeti/Analysis/Calculus/DensityLength.lean` it is a plain, non-`public` import, read only by
the proof of the private ordered case — `TauCeti.norm_sub_le_densityLength` is the public
interface to the result.

This is refactoring of code that already exists, so it claims no new roadmap target; the roadmap
chiefly motivating the code it improves is the L2 Schwarz-lemma-extensions layer of
`TauCetiRoadmap/ConformalMapping/README.md` ("**L2 — Schwarz lemma extensions.** *Schwarz–Pick*
…, the **hyperbolic / Poincaré metric** on `𝔻` …"), whose Poincaré-metric target
`TauCeti.isLeast_hyperbolicLength` is the theorem whose proof this cleans up.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"norm-sub-le-densitylength"}-->

🤖 Prepared with Claude Code

