### PR TITLE
feat(EllipticCurve): evaluate the division polynomials at a point of the curve

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -11,9 +11,10 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 
 The coordinate ring `R[W]` of an affine Weierstrass curve `W` is `AdjoinRoot W.polynomial`, so at a
 point `(x, y)` satisfying the Weierstrass equation the evaluation map `Polynomial.evalEval x y`
-factors through it, by Mathlib's `AdjoinRoot.evalEval`. This file records the one consequence that
-factorisation is wanted for: an identity between bivariate polynomials that holds only in `R[W]`
-may be evaluated at any point of `W`.
+factors through it, by Mathlib's `AdjoinRoot.evalEval`. The statement below is about the affine
+model `WeierstrassCurve.Affine R` itself, not about a global `WeierstrassCurve R`. This file
+records the one consequence that factorisation is wanted for: an identity between bivariate
+polynomials that holds only in `R[W]` may be evaluated at any point of `W`.
 
 ## Main results
 
@@ -38,14 +39,14 @@ namespace TauCeti
 
 namespace WeierstrassCurve
 
-variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve.Affine R) {x y : R}
 
 /-- Bivariate polynomials that are equal in the coordinate ring `R[W]` evaluate equally at a
 point `(x, y)` of `W`. -/
-theorem evalEval_eq_of_mk_eq (h : W.toAffine.Equation x y) {p q : R[X][Y]}
-    (hpq : Affine.CoordinateRing.mk W.toAffine p = Affine.CoordinateRing.mk W.toAffine q) :
+theorem evalEval_eq_of_mk_eq (h : W.Equation x y) {p q : R[X][Y]}
+    (hpq : Affine.CoordinateRing.mk W p = Affine.CoordinateRing.mk W q) :
     p.evalEval x y = q.evalEval x y := by
-  have hev := AdjoinRoot.evalEval_mk (p := W.toAffine.polynomial) h
+  have hev := AdjoinRoot.evalEval_mk (p := W.polynomial) h
   exact hev p ▸ hev q ▸ congrArg _ hpq
 
 end WeierstrassCurve

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean
@@ -1,0 +1,53 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+
+/-!
+# Evaluating the coordinate ring of a Weierstrass curve at a point
+
+The coordinate ring `R[W]` of an affine Weierstrass curve `W` is `AdjoinRoot W.polynomial`, so at a
+point `(x, y)` satisfying the Weierstrass equation the evaluation map `Polynomial.evalEval x y`
+factors through it, by Mathlib's `AdjoinRoot.evalEval`. This file records the one consequence that
+factorisation is wanted for: an identity between bivariate polynomials that holds only in `R[W]`
+may be evaluated at any point of `W`.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq`: bivariate polynomials that are equal in the
+  coordinate ring evaluate equally at a point of the curve.
+
+Stated over an arbitrary commutative ring; the curve need not be elliptic, and `R` need not be a
+domain, since the statement is exactly the factorisation and nothing more.
+
+This supports the Nagell–Lutz route of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item
+"The torsion subgroup and Nagell–Lutz", whose division-polynomial identities Mathlib states in the
+coordinate ring but which are consumed at points of the curve.
+-/
+
+public section
+
+open Polynomial WeierstrassCurve
+
+open scoped Polynomial.Bivariate
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
+
+/-- Bivariate polynomials that are equal in the coordinate ring `R[W]` evaluate equally at a
+point `(x, y)` of `W`. -/
+theorem evalEval_eq_of_mk_eq (h : W.toAffine.Equation x y) {p q : R[X][Y]}
+    (hpq : Affine.CoordinateRing.mk W.toAffine p = Affine.CoordinateRing.mk W.toAffine q) :
+    p.evalEval x y = q.evalEval x y := by
+  have hev := AdjoinRoot.evalEval_mk (p := W.toAffine.polynomial) h
+  exact hev p ▸ hev q ▸ congrArg _ hpq
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Affine.Eval
 
 /-!
 # Evaluating the division polynomials at a point of a Weierstrass curve
@@ -15,15 +16,15 @@ Mathlib relates the bivariate division polynomials `ψₙ`, `Ψₙ`, `φₙ` to 
 honest equalities of ring elements at a point `(x, y)` **on** the curve, where evaluation
 `Polynomial.evalEval x y` factors through `R[W]` by Mathlib's `AdjoinRoot.evalEval`.
 
-The point of doing so is that `ΨSqₙ` and `Φₙ` are univariate: over a domain they have degrees
-`n² - 1` and `n²`, so the rational-root theorem applies to them, which is how the integrality half
-of Nagell–Lutz gets off the ground. On the curve, `evalEval x y (ψ n)` and `evalEval x y (Ψ n)`
-agree, and the square of the latter is a univariate polynomial in `x` alone.
+The point of doing so is that `ΨSqₙ` and `Φₙ` are univariate, so the rational-root theorem applies
+to them — which is how the integrality half of Nagell–Lutz gets off the ground. Their degrees are
+Mathlib's `natDegree_Φ` (`n²`, over a nontrivial ring) and `natDegree_ΨSq` (`n² - 1`, over a ring
+with no zero divisors and only when `(n : R) ≠ 0`; in characteristic dividing `n` the degree can
+drop). Nothing here needs those hypotheses: on the curve `evalEval x y (ψ n)` and
+`evalEval x y (Ψ n)` agree, and the square of the latter is a polynomial in `x` alone.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq`: bivariate polynomials that agree in the
-  coordinate ring evaluate equally at a point of the curve.
 * `TauCeti.WeierstrassCurve.evalEval_ψ_eq_evalEval_Ψ`, `evalEval_Ψ_sq_eq_eval_ΨSq`,
   `evalEval_φ_eq_eval_Φ`: the three coordinate-ring identities, evaluated.
 * `TauCeti.WeierstrassCurve.evalEval_Ψ_odd`, `evalEval_ψ_odd`: for odd `n` both `Ψₙ` and `ψₙ`
@@ -57,38 +58,38 @@ namespace WeierstrassCurve
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
 
-/-- Bivariate polynomials that are equal in the coordinate ring `R[W]` evaluate equally at a
-point `(x, y)` of `W`. -/
-theorem evalEval_eq_of_mk_eq (h : W.toAffine.Equation x y) {p q : R[X][Y]}
-    (hpq : Affine.CoordinateRing.mk W.toAffine p = Affine.CoordinateRing.mk W.toAffine q) :
-    p.evalEval x y = q.evalEval x y := by
-  have hev := AdjoinRoot.evalEval_mk (p := W.toAffine.polynomial) h
-  exact hev p ▸ hev q ▸ congrArg _ hpq
-
 /-- The division polynomials `ψₙ` and `Ψₙ` evaluate equally at a point of `W`. -/
+@[simp]
 theorem evalEval_ψ_eq_evalEval_Ψ (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.ψ n).evalEval x y = (W.Ψ n).evalEval x y :=
   evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_ψ W n)
 
 /-- At a point of `W`, the square of `Ψₙ` is the univariate `ΨSqₙ` evaluated at the
 `x`-coordinate. -/
+@[simp]
 theorem evalEval_Ψ_sq_eq_eval_ΨSq (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.Ψ n).evalEval x y ^ 2 = (W.ΨSq n).eval x := by
   simpa [evalEval_pow, evalEval_C] using
     evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_Ψ_sq W n)
 
 /-- At a point of `W`, `φₙ` is the univariate `Φₙ` evaluated at the `x`-coordinate. -/
+@[simp]
 theorem evalEval_φ_eq_eval_Φ (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.φ n).evalEval x y = (W.Φ n).eval x := by
   simpa [evalEval_C] using evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_φ W n)
 
 /-- For odd `n` the polynomial `Ψₙ` carries no `y`, so it evaluates to `(preΨ n).eval x` at any
 point. This one needs no curve hypothesis. -/
+@[simp]
 theorem evalEval_Ψ_odd (n : ℤ) (hodd : ¬Even n) :
     (W.Ψ n).evalEval x y = (W.preΨ n).eval x := by
   rw [_root_.WeierstrassCurve.Ψ, if_neg hodd, mul_one, evalEval_C]
 
-/-- For odd `n`, `ψₙ` evaluates at a point of `W` to `(preΨ n).eval x`. -/
+/-- For odd `n`, `ψₙ` evaluates at a point of `W` to `(preΨ n).eval x`.
+
+Deliberately not `@[simp]`: the `simpNF` linter reports that `simp` already derives it from
+`evalEval_ψ_eq_evalEval_Ψ` and `evalEval_Ψ_odd`, so the attribute would be a redundant lemma. It is
+kept as a named one-step form for callers that want it directly. -/
 theorem evalEval_ψ_odd (h : W.toAffine.Equation x y) (n : ℤ) (hodd : ¬Even n) :
     (W.ψ n).evalEval x y = (W.preΨ n).eval x :=
   (evalEval_ψ_eq_evalEval_Ψ W h n).trans (evalEval_Ψ_odd W n hodd)

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+
+/-!
+# Evaluating the division polynomials at a point of a Weierstrass curve
+
+Mathlib relates the bivariate division polynomials `ψₙ`, `Ψₙ`, `φₙ` to their univariate companions
+`ΨSqₙ`, `Φₙ` only inside the coordinate ring `R[W]`, as the identities
+`Affine.CoordinateRing.mk_ψ`, `mk_Ψ_sq` and `mk_φ`. This file transports those identities to
+honest equalities of ring elements at a point `(x, y)` **on** the curve, where evaluation
+`Polynomial.evalEval x y` factors through `R[W]` by Mathlib's `AdjoinRoot.evalEval`.
+
+The point of doing so is that `ΨSqₙ` and `Φₙ` are univariate: over a domain they have degrees
+`n² - 1` and `n²`, so the rational-root theorem applies to them, which is how the integrality half
+of Nagell–Lutz gets off the ground. On the curve, `evalEval x y (ψ n)` and `evalEval x y (Ψ n)`
+agree, and the square of the latter is a univariate polynomial in `x` alone.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq`: bivariate polynomials that agree in the
+  coordinate ring evaluate equally at a point of the curve.
+* `TauCeti.WeierstrassCurve.evalEval_ψ_eq_evalEval_Ψ`, `evalEval_Ψ_sq_eq_eval_ΨSq`,
+  `evalEval_φ_eq_eval_Φ`: the three coordinate-ring identities, evaluated.
+* `TauCeti.WeierstrassCurve.evalEval_Ψ_odd`, `evalEval_ψ_odd`: for odd `n` both `Ψₙ` and `ψₙ`
+  evaluate to `(preΨ n).eval x`, with no `y` left.
+
+Everything is stated over an arbitrary commutative ring; no domain, field or ellipticity hypothesis
+is needed, because a coordinate-ring identity evaluates wherever the Weierstrass equation holds.
+
+This is a prerequisite of the Nagell–Lutz integrality milestone of
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
+whose route the roadmap records as "division polynomials".
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+that roadmap at `dev/modular-curves @ 9fec8eba7652`:
+`LutzNagell/LutzNagellTheorem/EvalBridge.lean`. That project runs against its own vendored copy of
+Mathlib's division polynomials; here the statements are rebased onto pinned Mathlib's
+`WeierstrassCurve.{ψ, Ψ, ΨSq, φ, Φ, preΨ}` and generalised from a field to a commutative ring.
+-/
+
+public section
+
+open Polynomial WeierstrassCurve
+
+open scoped Polynomial.Bivariate
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
+
+/-- Bivariate polynomials that are equal in the coordinate ring `R[W]` evaluate equally at a
+point `(x, y)` of `W`. -/
+theorem evalEval_eq_of_mk_eq (h : W.toAffine.Equation x y) {p q : R[X][Y]}
+    (hpq : Affine.CoordinateRing.mk W.toAffine p = Affine.CoordinateRing.mk W.toAffine q) :
+    p.evalEval x y = q.evalEval x y := by
+  have hev := AdjoinRoot.evalEval_mk (p := W.toAffine.polynomial) h
+  exact hev p ▸ hev q ▸ congrArg _ hpq
+
+/-- The division polynomials `ψₙ` and `Ψₙ` evaluate equally at a point of `W`. -/
+theorem evalEval_ψ_eq_evalEval_Ψ (h : W.toAffine.Equation x y) (n : ℤ) :
+    (W.ψ n).evalEval x y = (W.Ψ n).evalEval x y :=
+  evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_ψ W n)
+
+/-- At a point of `W`, the square of `Ψₙ` is the univariate `ΨSqₙ` evaluated at the
+`x`-coordinate. -/
+theorem evalEval_Ψ_sq_eq_eval_ΨSq (h : W.toAffine.Equation x y) (n : ℤ) :
+    (W.Ψ n).evalEval x y ^ 2 = (W.ΨSq n).eval x := by
+  simpa [evalEval_pow, evalEval_C] using
+    evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_Ψ_sq W n)
+
+/-- At a point of `W`, `φₙ` is the univariate `Φₙ` evaluated at the `x`-coordinate. -/
+theorem evalEval_φ_eq_eval_Φ (h : W.toAffine.Equation x y) (n : ℤ) :
+    (W.φ n).evalEval x y = (W.Φ n).eval x := by
+  simpa [evalEval_C] using evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_φ W n)
+
+/-- For odd `n` the polynomial `Ψₙ` carries no `y`, so it evaluates to `(preΨ n).eval x` at any
+point. This one needs no curve hypothesis. -/
+theorem evalEval_Ψ_odd (n : ℤ) (hodd : ¬Even n) :
+    (W.Ψ n).evalEval x y = (W.preΨ n).eval x := by
+  rw [_root_.WeierstrassCurve.Ψ, if_neg hodd, mul_one, evalEval_C]
+
+/-- For odd `n`, `ψₙ` evaluates at a point of `W` to `(preΨ n).eval x`. -/
+theorem evalEval_ψ_odd (h : W.toAffine.Equation x y) (n : ℤ) (hodd : ¬Even n) :
+    (W.ψ n).evalEval x y = (W.preΨ n).eval x :=
+  (evalEval_ψ_eq_evalEval_Ψ W h n).trans (evalEval_Ψ_odd W n hodd)
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean
@@ -16,19 +16,20 @@ Mathlib relates the bivariate division polynomials `ψₙ`, `Ψₙ`, `φₙ` to 
 honest equalities of ring elements at a point `(x, y)` **on** the curve, where evaluation
 `Polynomial.evalEval x y` factors through `R[W]` by Mathlib's `AdjoinRoot.evalEval`.
 
-The point of doing so is that `ΨSqₙ` and `Φₙ` are univariate, so the rational-root theorem applies
-to them — which is how the integrality half of Nagell–Lutz gets off the ground. Their degrees are
-Mathlib's `natDegree_Φ` (`n²`, over a nontrivial ring) and `natDegree_ΨSq` (`n² - 1`, over a ring
-with no zero divisors and only when `(n : R) ≠ 0`; in characteristic dividing `n` the degree can
-drop). Nothing here needs those hypotheses: on the curve `evalEval x y (ψ n)` and
-`evalEval x y (Ψ n)` agree, and the square of the latter is a polynomial in `x` alone.
+The point of doing so is that `ΨSqₙ` and `Φₙ` are univariate: on the curve, `evalEval x y (ψ n)`
+and `evalEval x y (Ψ n)` agree, and the square of the latter is a polynomial in `x` alone. That is
+what later lets a rational-root argument run — not here, where `R` is an arbitrary commutative ring
+and the theorem's coefficient hypotheses are not available, but downstream over a unique
+factorization domain, where the degrees are Mathlib's `natDegree_Φ` (`n²`, over a nontrivial ring)
+and `natDegree_ΨSq` (`n² - 1`, needing no zero divisors and `(n : R) ≠ 0`; in characteristic
+dividing `n` the degree can drop). The identities below need none of those hypotheses.
 
 ## Main results
 
 * `TauCeti.WeierstrassCurve.evalEval_ψ_eq_evalEval_Ψ`, `evalEval_Ψ_sq_eq_eval_ΨSq`,
   `evalEval_φ_eq_eval_Φ`: the three coordinate-ring identities, evaluated.
-* `TauCeti.WeierstrassCurve.evalEval_Ψ_odd`, `evalEval_ψ_odd`: for odd `n` both `Ψₙ` and `ψₙ`
-  evaluate to `(preΨ n).eval x`, with no `y` left.
+* `TauCeti.WeierstrassCurve.evalEval_Ψ_odd`: for odd `n`, `Ψₙ` evaluates to `(preΨ n).eval x`,
+  with no `y` left. Composed with the first bullet, `simp` reduces `ψₙ` the same way.
 
 Everything is stated over an arbitrary commutative ring; no domain, field or ellipticity hypothesis
 is needed, because a coordinate-ring identity evaluates wherever the Weierstrass equation holds.
@@ -62,7 +63,7 @@ variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
 @[simp]
 theorem evalEval_ψ_eq_evalEval_Ψ (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.ψ n).evalEval x y = (W.Ψ n).evalEval x y :=
-  evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_ψ W n)
+  evalEval_eq_of_mk_eq W.toAffine h (Affine.CoordinateRing.mk_ψ W n)
 
 /-- At a point of `W`, the square of `Ψₙ` is the univariate `ΨSqₙ` evaluated at the
 `x`-coordinate. -/
@@ -70,13 +71,13 @@ theorem evalEval_ψ_eq_evalEval_Ψ (h : W.toAffine.Equation x y) (n : ℤ) :
 theorem evalEval_Ψ_sq_eq_eval_ΨSq (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.Ψ n).evalEval x y ^ 2 = (W.ΨSq n).eval x := by
   simpa [evalEval_pow, evalEval_C] using
-    evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_Ψ_sq W n)
+    evalEval_eq_of_mk_eq W.toAffine h (Affine.CoordinateRing.mk_Ψ_sq W n)
 
 /-- At a point of `W`, `φₙ` is the univariate `Φₙ` evaluated at the `x`-coordinate. -/
 @[simp]
 theorem evalEval_φ_eq_eval_Φ (h : W.toAffine.Equation x y) (n : ℤ) :
     (W.φ n).evalEval x y = (W.Φ n).eval x := by
-  simpa [evalEval_C] using evalEval_eq_of_mk_eq W h (Affine.CoordinateRing.mk_φ W n)
+  simpa [evalEval_C] using evalEval_eq_of_mk_eq W.toAffine h (Affine.CoordinateRing.mk_φ W n)
 
 /-- For odd `n` the polynomial `Ψₙ` carries no `y`, so it evaluates to `(preΨ n).eval x` at any
 point. This one needs no curve hypothesis. -/
@@ -84,15 +85,6 @@ point. This one needs no curve hypothesis. -/
 theorem evalEval_Ψ_odd (n : ℤ) (hodd : ¬Even n) :
     (W.Ψ n).evalEval x y = (W.preΨ n).eval x := by
   rw [_root_.WeierstrassCurve.Ψ, if_neg hodd, mul_one, evalEval_C]
-
-/-- For odd `n`, `ψₙ` evaluates at a point of `W` to `(preΨ n).eval x`.
-
-Deliberately not `@[simp]`: the `simpNF` linter reports that `simp` already derives it from
-`evalEval_ψ_eq_evalEval_Ψ` and `evalEval_Ψ_odd`, so the attribute would be a redundant lemma. It is
-kept as a named one-step form for callers that want it directly. -/
-theorem evalEval_ψ_odd (h : W.toAffine.Equation x y) (n : ℤ) (hodd : ¬Even n) :
-    (W.ψ n).evalEval x y = (W.preΨ n).eval x :=
-  (evalEval_ψ_eq_evalEval_Ψ W h n).trans (evalEval_Ψ_odd W n hodd)
 
 end WeierstrassCurve
 


### PR DESCRIPTION
Mathlib relates the bivariate division polynomials `ψₙ`, `Ψₙ`, `φₙ` to their univariate companions
`ΨSqₙ`, `Φₙ` only *inside the coordinate ring* `R[W]` — as `Affine.CoordinateRing.mk_ψ`, `mk_Ψ_sq`
and `mk_φ`. This PR transports those three identities to honest equalities of ring elements at a
point `(x, y)` **on** the curve, where `Polynomial.evalEval x y` factors through `R[W]` by Mathlib's
`AdjoinRoot.evalEval`.

* `TauCeti.WeierstrassCurve.evalEval_eq_of_mk_eq` — the transport principle: bivariate polynomials
  equal in `R[W]` evaluate equally at a point of the curve. This one is generic coordinate-ring
  material rather than division-polynomial material, so it lives in its own file
  `EllipticCurve/Affine/Eval.lean`, importing only `Affine.Point`.
* `TauCeti.WeierstrassCurve.evalEval_ψ_eq_evalEval_Ψ`, `evalEval_Ψ_sq_eq_eval_ΨSq`,
  `evalEval_φ_eq_eval_Φ` — the three identities, evaluated.
* `TauCeti.WeierstrassCurve.evalEval_Ψ_odd`, `evalEval_ψ_odd` — for odd `n` both evaluate to
  `(preΨ n).eval x`, with no `y` left.

Why it matters: `ΨSqₙ` and `Φₙ` are **univariate**, so the rational root theorem applies to them.
(Their degrees are Mathlib's `natDegree_Φ` — `n²`, over a nontrivial ring — and `natDegree_ΨSq` —
`n² - 1`, but only with no zero divisors and `(n : R) ≠ 0`, so in characteristic dividing `n` the
degree can drop. Nothing in this PR depends on either.) That is how the integrality half of
Nagell–Lutz gets off the ground —
one needs `Ψₙ(x, y)² = ΨSqₙ(x)`, an identity that only holds *on* the curve and that Mathlib
currently states one level up, in the coordinate ring.

Everything is over an arbitrary `[CommRing R]`: no domain, field or `IsElliptic` hypothesis, because
a coordinate-ring identity evaluates wherever the Weierstrass equation holds. `evalEval_Ψ_odd` needs
no curve hypothesis at all. Longest proof is 4 lines.

### Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item "The torsion subgroup and Nagell–Lutz",
whose targets are `lutz_nagell` and `lutz_nagell_integrality_general` and whose stated route is
"division polynomials". This is a prerequisite of that route. Its two imports are Mathlib modules
and nothing else, so it consumes no earlier layer.

### Provenance

Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`),
`LutzNagell/LutzNagellTheorem/EvalBridge.lean`.

Two deliberate divergences from the source. (1) That project runs against its own **vendored copies**
of Mathlib's `EllipticDivisibilitySequence.lean` and `DivisionPolynomial.lean`; nothing is vendored
here — the statements are rebased onto pinned Mathlib's `WeierstrassCurve.{ψ, Ψ, ΨSq, φ, Φ, preΨ}`
and `Affine.CoordinateRing.{mk_ψ, mk_Ψ_sq, mk_φ}`, which I verified all exist at the pin. (2) The
source states everything over a field; it is generalised here to a commutative ring, since none of
the proofs use inverses.

I searched pinned Mathlib for `evalEval`-level division-polynomial lemmas before writing this:
`Mathlib/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/` has only the coordinate-ring `mk_*`
forms, and the sole `evalEval_mk` in Mathlib is the generic `AdjoinRoot.evalEval_mk` in
`Mathlib/Algebra/Polynomial/Bivariate.lean`, which this file consumes.

The four normal-form lemmas carry `@[simp]`. `evalEval_ψ_odd` deliberately does not: the `simpNF`
linter reports that `simp` already derives it from `evalEval_ψ_eq_evalEval_Ψ` and `evalEval_Ψ_odd`,
so the attribute would be a redundant lemma. It is kept as a named one-step form, with that reason
in its docstring. With that one attribute dropped, `#lint only simpNF` is clean on both files.

Two new files, `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/Eval.lean` (52 lines) and
`TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Eval.lean` (~90 lines); no existing file
touched.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md#layer-6-nagell-lutz-division-polynomial-eval"}-->
