### PR TITLE
feat: extract the path traced by a function on an open interval

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -48,8 +48,9 @@ point, in producing the two endpoint limits.
 This construction does not need injectivity. When `f` is injective on the disc, a companion
 theorem also places the endpoints on the image frontier and shows that only the two endpoints can
 be identified. Interior injectivity uses only the injectivity of `f`, Mathlib's
-`Complex.injOn_circleMap_of_abs_sub_le`, and the fact that `b - a < 2π`, fed to the
-reparametrisation lemmas `TauCeti.injOn_Ioo_of_eq_lineMap`, `TauCeti.mapsTo_Ioo_of_eq_lineMap` and
+`Complex.injOn_circleMap_of_abs_sub_le`, the fact that `b - a < 2π`, and the injectivity of
+`AffineMap.lineMap a b`; the last step, that a curve injective on the interior and avoiding both
+endpoint values there can repeat only between its endpoints, is
 `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` of the same file.
 
 ## Main result
@@ -267,24 +268,30 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn
       γ t = f (circleMap ζ ρ (AffineMap.lineMap a b (t : ℝ))) := by
     simpa only [a, b, φ] using hγformula
   -- The angular composite is injective, `circleMap` being injective on an arc shorter than a full
-  -- turn; the reparametrisation lemmas then carry that to the path.
+  -- turn; the affine parametrisation then carries that to the path.
   have hginj : InjOn (fun θ => f (circleMap ζ ρ θ)) (Ioo a b) := fun x hx y hy hxy =>
     injOn_circleMap_of_abs_sub_le (c := ζ) hρ.ne'
       (by rw [abs_sub_comm, abs_of_pos (sub_pos.mpr hab)]; exact hab2π.le)
       (by rw [uIoc_of_le hab.le]; exact ⟨hx.1, hx.2.le⟩)
       (by rw [uIoc_of_le hab.le]; exact ⟨hy.1, hy.2.le⟩)
       (hinj (hmaps hx) (hmaps hy) hxy)
-  have hγinj : InjOn γ (Ioo (0 : unitInterval) 1) :=
-    injOn_Ioo_of_eq_lineMap (g := fun θ => f (circleMap ζ ρ θ)) hab hginj hγformula'
+  have hline : ∀ t ∈ Ioo (0 : unitInterval) 1,
+      AffineMap.lineMap a b (t : ℝ) ∈ Ioo a b := fun t ht => by
+    rw [← openSegment_eq_Ioo hab]
+    exact lineMap_mem_openSegment ℝ a b (by simpa using ht)
+  have hγinj : InjOn γ (Ioo (0 : unitInterval) 1) := fun x hx y hy hxy => by
+    rw [hγformula' x hx, hγformula' y hy] at hxy
+    exact Subtype.ext (AffineMap.lineMap_injective ℝ hab.ne
+      (hginj (hline x hx) (hline y hy) hxy))
   have hγzero : γ 0 ∈ frontier (f '' ball c r) := by
     simpa only [Path.source] using hufrontier
   have hγone : γ 1 ∈ frontier (f '' ball c r) := by
     simpa only [Path.target] using hvfrontier
   have himageOpen : IsOpen (f '' ball c r) :=
     isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
-  have hγmem : ∀ t ∈ Ioo (0 : unitInterval) 1, γ t ∈ f '' ball c r :=
-    mapsTo_Ioo_of_eq_lineMap (g := fun θ => f (circleMap ζ ρ θ)) hab
-      (fun θ hθ => ⟨circleMap ζ ρ θ, hmaps hθ, rfl⟩) hγformula'
+  have hγmem : ∀ t ∈ Ioo (0 : unitInterval) 1, γ t ∈ f '' ball c r := fun t ht => by
+    rw [hγformula' t ht]
+    exact ⟨circleMap ζ ρ _, hmaps (hline t ht), rfl⟩
   have hγsimple := eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo
     (himageOpen.frontier_eq ▸ hγzero).2 (himageOpen.frontier_eq ▸ hγone).2 hγmem hγinj
   exact ⟨u, v, γ, hγrange, hu, hv, hufrontier, hvfrontier, hγsimple, hγformula⟩

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -10,7 +10,7 @@ public import Mathlib.Topology.Path
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.EndpointLimit
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 import TauCeti.Analysis.Complex.Conformal.ClusterSet
-import TauCeti.Topology.Path.ExtendFrom
+import TauCeti.Topology.Path.ExtendIoo
 
 /-!
 # A finite-length image crosscut as a path
@@ -37,7 +37,7 @@ Write
 The open interval `Ioo a b` parametrises `ball c r ∩ sphere ζ ρ`. At every point of its frontier,
 the endpoint-limit theorem gives a limit of `f` along the crosscut. Composing with `circleMap`
 turns those into limits of the angular composite `g = f ∘ circleMap ζ ρ` at `a` and at `b`, which
-is exactly the data `TauCeti.Path.ofContinuousOnIoo` of `TauCeti/Topology/Path/ExtendFrom.lean`
+is exactly the data `TauCeti.Path.ofContinuousOnIoo` of `TauCeti/Topology/Path/ExtendIoo.lean`
 consumes: a function continuous on an open interval with a limit at each end traces a path between
 those two limits, whose range is the closure of the curve
 (`TauCeti.Path.range_ofContinuousOnIoo`) and which follows `g` along
@@ -64,10 +64,10 @@ reparametrisation lemmas `TauCeti.injOn_Ioo_of_eq_lineMap`, `TauCeti.mapsTo_Ioo_
 Layer L5 is absent from
 [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
 human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself. Mathlib
-supplies `Path`, the `extendFrom` extension across an interval — packaged as a path in
-`TauCeti/Topology/Path/ExtendFrom.lean` — and the injectivity of `circleMap` on an interval shorter
-than a full turn; it has no boundary-crosscut or endpoint-limit result. No Mathlib source is
-vendored.
+supplies `Path` and the injectivity of `circleMap` on an interval shorter than a full turn; the
+extension of a curve across the two ends of an open interval is packaged as a path in
+`TauCeti/Topology/Path/ExtendIoo.lean`. Mathlib has no boundary-crosscut or endpoint-limit result.
+No Mathlib source is vendored.
 
 ## References
 

--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean
@@ -5,10 +5,12 @@ Authors: The Tau Ceti contributors
 -/
 module
 
-public import Mathlib.Analysis.Convex.PathConnected
+public import Mathlib.LinearAlgebra.AffineSpace.AffineMap
+public import Mathlib.Topology.Path
 public import TauCeti.Analysis.Complex.Conformal.Crosscut.EndpointLimit
 import TauCeti.Analysis.Complex.Conformal.Crosscut.Endpoints
 import TauCeti.Analysis.Complex.Conformal.ClusterSet
+import TauCeti.Topology.Path.ExtendFrom
 
 /-!
 # A finite-length image crosscut as a path
@@ -34,18 +36,21 @@ Write
 
 The open interval `Ioo a b` parametrises `ball c r ∩ sphere ζ ρ`. At every point of its frontier,
 the endpoint-limit theorem gives a limit of `f` along the crosscut. Composing with `circleMap`
-turns those into limits of the angular composite at `a` and at `b`, which is what
-`continuousOn_Icc_extendFrom_Ioo` asks for: `extendFrom (Ioo a b)` is then continuous on `Icc a b`
-and agrees with the composite on `Ioo a b`. Pushing Mathlib's straight-line path `Path.segment a b`
-forward along that extension with `Path.map'` gives the path, parametrised by
-`AffineMap.lineMap a b : [0, 1] → [a, b]`.
+turns those into limits of the angular composite `g = f ∘ circleMap ζ ρ` at `a` and at `b`, which
+is exactly the data `TauCeti.Path.ofContinuousOnIoo` of `TauCeti/Topology/Path/ExtendFrom.lean`
+consumes: a function continuous on an open interval with a limit at each end traces a path between
+those two limits, whose range is the closure of the curve
+(`TauCeti.Path.range_ofContinuousOnIoo`) and which follows `g` along
+`AffineMap.lineMap a b : [0, 1] → [a, b]` in the interior
+(`TauCeti.Path.ofContinuousOnIoo_apply_of_mem_Ioo`). All the holomorphy is spent before that
+point, in producing the two endpoint limits.
 
-The range statement follows from compactness: the image of `Icc a b`, the closure of `Ioo a b`,
-is the closure of the image of `Ioo a b`. This construction does not need injectivity. When `f`
-is injective on the disc, a companion theorem also places the endpoints on the image frontier and
-shows that only the two endpoints can be identified. Interior injectivity uses only the
-injectivity of `f`, Mathlib's `Complex.injOn_circleMap_of_abs_sub_le`, and the fact that
-`b - a < 2π`.
+This construction does not need injectivity. When `f` is injective on the disc, a companion
+theorem also places the endpoints on the image frontier and shows that only the two endpoints can
+be identified. Interior injectivity uses only the injectivity of `f`, Mathlib's
+`Complex.injOn_circleMap_of_abs_sub_le`, and the fact that `b - a < 2π`, fed to the
+reparametrisation lemmas `TauCeti.injOn_Ioo_of_eq_lineMap`, `TauCeti.mapsTo_Ioo_of_eq_lineMap` and
+`TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` of the same file.
 
 ## Main result
 
@@ -59,9 +64,10 @@ injectivity of `f`, Mathlib's `Complex.injOn_circleMap_of_abs_sub_le`, and the f
 Layer L5 is absent from
 [mathlib4#33505](https://github.com/leanprover-community/mathlib4/pull/33505), the in-progress
 human-curated Riemann-mapping-theorem effort, which stops at the mapping theorem itself. Mathlib
-supplies `Path`, affine segments, the `extendFrom` extension across an interval, and the injectivity
-of `circleMap` on an interval shorter than a full turn; it has no boundary-crosscut or
-endpoint-limit result. No Mathlib source is vendored.
+supplies `Path`, the `extendFrom` extension across an interval — packaged as a path in
+`TauCeti/Topology/Path/ExtendFrom.lean` — and the injectivity of `circleMap` on an interval shorter
+than a full turn; it has no boundary-crosscut or endpoint-limit result. No Mathlib source is
+vendored.
 
 ## References
 
@@ -77,40 +83,6 @@ open Bornology Complex Filter Metric Set Topology
 open scoped Real
 
 variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
-
-/-- The affine parametrisation from the unit interval to `Icc a b` sends its interior into
-`Ioo a b`. -/
-private theorem lineMap_mem_Ioo {a b : ℝ} (hab : a < b) {t : unitInterval}
-    (ht : t ∈ Ioo (0 : unitInterval) 1) : AffineMap.lineMap a b (t : ℝ) ∈ Ioo a b := by
-  rw [← openSegment_eq_Ioo hab]
-  exact lineMap_mem_openSegment ℝ a b (by simpa using ht)
-
-/-- A point of the unit interval is an endpoint or lies in its interior. -/
-private theorem unitInterval_eq_zero_or_eq_one_or_mem_Ioo (t : unitInterval) :
-    t = 0 ∨ t = 1 ∨ t ∈ Ioo (0 : unitInterval) 1 := by
-  by_cases h0 : t = 0
-  · exact Or.inl h0
-  by_cases h1 : t = 1
-  · exact Or.inr (Or.inl h1)
-  exact Or.inr (Or.inr ⟨lt_of_le_of_ne t.2.1 (fun h => h0 h.symm),
-    lt_of_le_of_ne t.2.2 h1⟩)
-
-/-- **The angular parametrisation of a finite-length image crosscut extends continuously to the
-closed arc.** The composite `θ ↦ f (circleMap ζ ρ θ)` is continuous on `Ioo a b` and has a limit at
-each endpoint, so `extendFrom` extends it to `closure (Ioo a b)`. -/
-private theorem exists_continuousOn_closure_eqOn_comp_circleMap {a b : ℝ} (hab : a < b)
-    (hgcont : ContinuousOn (fun θ => f (circleMap ζ ρ θ)) (Ioo a b))
-    (hglim : ∀ θ ∈ frontier (Ioo a b), ∃ v,
-      Tendsto (fun θ => f (circleMap ζ ρ θ)) (𝓝[Ioo a b] θ) (𝓝 v)) :
-    ∃ F : ℝ → ℂ, ContinuousOn F (closure (Ioo a b)) ∧
-      EqOn F (fun θ => f (circleMap ζ ρ θ)) (Ioo a b) := by
-  obtain ⟨la, hla⟩ := hglim a (by simp [frontier_Ioo hab])
-  obtain ⟨lb, hlb⟩ := hglim b (by simp [frontier_Ioo hab])
-  rw [nhdsWithin_Ioo_eq_nhdsGT hab] at hla
-  rw [nhdsWithin_Ioo_eq_nhdsLT hab] at hlb
-  exact ⟨extendFrom (Ioo a b) fun θ => f (circleMap ζ ρ θ),
-    closure_Ioo hab.ne ▸ continuousOn_Icc_extendFrom_Ioo hgcont hla hlb,
-    extendFrom_extends hgcont⟩
 
 /-- **At any angle landing on the closed crosscut, the limit is reached along both approaches.**
 The limit of `f` along the crosscut at `circleMap ζ ρ θ` is also the limit of the angular
@@ -172,68 +144,26 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere (hζ : dist ζ c = 
     simpa only [a, b, φ] using ball_inter_sphere_eq_circleMap_image_Ioo hζ hρ hρr
   have hclosedCrosscut : closedBall c r ∩ sphere ζ ρ = circleMap ζ ρ '' Icc a b := by
     simpa only [a, b, φ] using closedBall_inter_sphere_eq_circleMap_image_Icc hζ hρ hρr
-  have hglim : ∀ θ ∈ frontier (Ioo a b), ∃ v,
-      Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ θ)) (𝓝 v) ∧
-        Tendsto g (𝓝[Ioo a b] θ) (𝓝 v) := fun θ hθ =>
-    exists_tendsto_nhdsWithin_and_tendsto_comp_circleMap hζ hρ hρr hf hfin hcrosscut
-      (hclosedCrosscut.ge ⟨θ, closure_Ioo hab.ne ▸ frontier_subset_closure hθ, rfl⟩)
   have hmaps : MapsTo (circleMap ζ ρ) (Ioo a b) (ball c r) := fun θ hθ =>
     (hcrosscut.ge ⟨θ, hθ, rfl⟩).1
   have hgcont : ContinuousOn g (Ioo a b) := fun θ hθ => by
     simpa only [Function.comp_def] using (hf.continuousOn _ (hmaps hθ)).comp
       (continuous_circleMap ζ ρ).continuousAt.continuousWithinAt hmaps
-  obtain ⟨F, hFc, hFg⟩ :=
-    exists_continuousOn_closure_eqOn_comp_circleMap hab hgcont
-      fun θ hθ => (hglim θ hθ).imp fun _ h => h.2
-  have hcl : closure (Ioo a b) = Icc a b := closure_Ioo hab.ne
-  have hFends : ∀ θ ∈ frontier (Ioo a b),
-      Tendsto f (𝓝[ball c r ∩ sphere ζ ρ] (circleMap ζ ρ θ)) (𝓝 (F θ)) := by
-    intro θ hθ
-    obtain ⟨v, hv, hvangle⟩ := hglim θ hθ
-    have hθcl : θ ∈ closure (Ioo a b) := frontier_subset_closure hθ
-    rwa [tendsto_nhds_unique' (mem_closure_iff_nhdsWithin_neBot.mp hθcl)
-      (((hFc θ hθcl).mono subset_closure).congr'
-        (hFg.eventuallyEq_of_mem self_mem_nhdsWithin)) hvangle]
-  -- Traverse `Icc a b` by `Path.segment a b`, then push it forward along `F` with `Path.map'`.
-  have hFcseg : ContinuousOn F (range (Path.segment a b)) := by
-    rw [Path.range_segment, segment_eq_Icc hab.le, ← hcl]; exact hFc
-  -- Mathlib has `Path.map_coe` for `Path.map` but no `map'_coe`, so unfold pointwise.
-  have hcoe : ⇑((Path.segment a b).map' hFcseg) = F ∘ ⇑(Path.segment a b) := by ext t; rfl
-  have hγformula : ∀ t ∈ Ioo (0 : unitInterval) 1, ((Path.segment a b).map' hFcseg) t
-      = f (circleMap ζ ρ (AffineMap.lineMap a b (t : ℝ))) := fun t ht => by
-    rw [hcoe, Function.comp_apply, Path.segment_apply]
-    exact hFg (lineMap_mem_Ioo hab ht)
-  have hFimage : F '' Icc a b = closure (g '' Ioo a b) := by
-    rw [← hcl, image_closure_of_isCompact (hcl ▸ isCompact_Icc) hFc, hFg.image_eq]
-  refine ⟨F a, F b, (Path.segment a b).map' hFcseg, ?_, ?_, ?_, ?_⟩
-  · rw [hcoe, range_comp, Path.range_segment, segment_eq_Icc hab.le, hFimage, hcrosscut,
-      image_image]
-  · simpa only [a, b, φ] using hFends a (by simp [frontier_Ioo hab])
-  · simpa only [a, b, φ] using hFends b (by simp [frontier_Ioo hab])
-  · simpa only [a, b, φ] using hγformula
-
-/-- **A path given by `g ∘ circleMap` along an affine reparametrisation is injective.** If the arc
-`Ioo a b` spans at most a full turn and `g` is injective on a set the arc maps into, then the path
-is injective on the open interval.
-
-Injectivity of `circleMap` on the arc is what `b - a ≤ 2 * π` buys; `g` supplies the rest. Nothing
-is assumed of the codomain, and `g` need only be injective on the set the arc lands in. -/
-private theorem injOn_Ioo_of_eq_circleMap_lineMap {X : Type*} {S : Set ℂ} {g : ℂ → X}
-    {γ : unitInterval → X} {a b : ℝ} (hab : a < b) (hab2π : b - a ≤ 2 * π) (hρ : ρ ≠ 0)
-    (hinj : InjOn g S) (hmaps : MapsTo (circleMap ζ ρ) (Ioo a b) S)
-    (hγformula : ∀ t ∈ Ioo (0 : unitInterval) 1,
-      γ t = g (circleMap ζ ρ (AffineMap.lineMap a b (t : ℝ)))) :
-    InjOn γ (Ioo (0 : unitInterval) 1) := by
-  intro x hx y hy hxy
-  have hxIoo := lineMap_mem_Ioo hab hx
-  have hyIoo := lineMap_mem_Ioo hab hy
-  rw [hγformula x hx, hγformula y hy] at hxy
-  have hcircle := hinj (hmaps hxIoo) (hmaps hyIoo) hxy
-  have hangle := injOn_circleMap_of_abs_sub_le (c := ζ) hρ
-    (by rw [abs_sub_comm, abs_of_pos (sub_pos.mpr hab)]; exact hab2π)
-    (by rw [uIoc_of_le hab.le]; exact ⟨hxIoo.1, hxIoo.2.le⟩)
-    (by rw [uIoc_of_le hab.le]; exact ⟨hyIoo.1, hyIoo.2.le⟩) hcircle
-  exact Subtype.ext ((AffineMap.lineMap_injective ℝ hab.ne) hangle)
+  -- The endpoint-limit theorem at the two ends of the arc, read both along the crosscut and along
+  -- the angle: the latter is what `TauCeti.Path.ofContinuousOnIoo` consumes.
+  obtain ⟨u, hu, huangle⟩ :=
+    exists_tendsto_nhdsWithin_and_tendsto_comp_circleMap hζ hρ hρr hf hfin hcrosscut
+      (hclosedCrosscut.ge ⟨a, left_mem_Icc.mpr hab.le, rfl⟩)
+  obtain ⟨v, hv, hvangle⟩ :=
+    exists_tendsto_nhdsWithin_and_tendsto_comp_circleMap hζ hρ hρr hf hfin hcrosscut
+      (hclosedCrosscut.ge ⟨b, right_mem_Icc.mpr hab.le, rfl⟩)
+  rw [nhdsWithin_Ioo_eq_nhdsGT hab] at huangle
+  rw [nhdsWithin_Ioo_eq_nhdsLT hab] at hvangle
+  refine ⟨u, v, Path.ofContinuousOnIoo hab hgcont huangle hvangle, ?_, ?_, ?_, ?_⟩
+  · rw [Path.range_ofContinuousOnIoo, hcrosscut, image_image]
+  · simpa only [a, φ] using hu
+  · simpa only [b, φ] using hv
+  · exact fun t ht => Path.ofContinuousOnIoo_apply_of_mem_Ioo hab hgcont huangle hvangle ht
 
 /-- **An endpoint limit of a circular image crosscut lies on the frontier of the image.** For `f`
 differentiable and injective on `ball c r`, a limit of `f` along the crosscut at either endpoint of
@@ -273,33 +203,6 @@ private theorem mem_frontier_image_ball_of_tendsto_arc_endpoint
     exact mem_singleton w
   exact (clusterSetOn_inter_sphere_subset_frontier_inter_closure_image (U := ball c r) (ζ := ζ)
     (ρ := ρ) isOpen_ball hf hinj hefrontier hwcluster).1
-
-/-- **A path repeats only at its endpoints when its interior avoids both endpoint values.**
-If `γ` maps the open interval into `S`, neither endpoint value lies in `S`, and `γ` is injective on
-the open interval, then any repeated value is a common value of the two endpoints.
-
-Purely a statement about function values: neither `γ` nor `S` carries any topology, and a `Path`
-specializes automatically through its coercion. The frontier/open-set form is derived at the call
-site. -/
-private theorem eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo {X : Type*}
-    {γ : unitInterval → X} {S : Set X}
-    (hzero : γ 0 ∉ S) (hone : γ 1 ∉ S)
-    (hmem : ∀ t ∈ Ioo (0 : unitInterval) 1, γ t ∈ S)
-    (hinj : InjOn γ (Ioo (0 : unitInterval) 1)) ⦃x y : unitInterval⦄ (hxy : γ x = γ y) :
-    x = y ∨ (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 0) := by
-  rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo x with rfl | rfl | hx
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
-    · exact Or.inl rfl
-    · exact Or.inr (Or.inl ⟨rfl, rfl⟩)
-    · exact absurd (by rw [hxy]; exact hmem y hy) hzero
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
-    · exact Or.inr (Or.inr ⟨rfl, rfl⟩)
-    · exact Or.inl rfl
-    · exact absurd (by rw [hxy]; exact hmem y hy) hone
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
-    · exact absurd (by rw [← hxy]; exact hmem x hx) hzero
-    · exact absurd (by rw [← hxy]; exact hmem x hx) hone
-    · exact Or.inl (hinj hx hy hxy)
 
 /-- **An injective finite-length circular image crosscut has no repetitions except possibly at its
 endpoints.** Under the hypotheses of
@@ -363,19 +266,25 @@ theorem exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn
   have hγformula' : ∀ t ∈ Ioo (0 : unitInterval) 1,
       γ t = f (circleMap ζ ρ (AffineMap.lineMap a b (t : ℝ))) := by
     simpa only [a, b, φ] using hγformula
+  -- The angular composite is injective, `circleMap` being injective on an arc shorter than a full
+  -- turn; the reparametrisation lemmas then carry that to the path.
+  have hginj : InjOn (fun θ => f (circleMap ζ ρ θ)) (Ioo a b) := fun x hx y hy hxy =>
+    injOn_circleMap_of_abs_sub_le (c := ζ) hρ.ne'
+      (by rw [abs_sub_comm, abs_of_pos (sub_pos.mpr hab)]; exact hab2π.le)
+      (by rw [uIoc_of_le hab.le]; exact ⟨hx.1, hx.2.le⟩)
+      (by rw [uIoc_of_le hab.le]; exact ⟨hy.1, hy.2.le⟩)
+      (hinj (hmaps hx) (hmaps hy) hxy)
   have hγinj : InjOn γ (Ioo (0 : unitInterval) 1) :=
-    injOn_Ioo_of_eq_circleMap_lineMap hab hab2π.le hρ.ne' hinj hmaps hγformula'
+    injOn_Ioo_of_eq_lineMap (g := fun θ => f (circleMap ζ ρ θ)) hab hginj hγformula'
   have hγzero : γ 0 ∈ frontier (f '' ball c r) := by
     simpa only [Path.source] using hufrontier
   have hγone : γ 1 ∈ frontier (f '' ball c r) := by
     simpa only [Path.target] using hvfrontier
   have himageOpen : IsOpen (f '' ball c r) :=
     isOpen_image_of_differentiableOn_of_injOn isOpen_ball hf hinj
-  have hγmem : ∀ t ∈ Ioo (0 : unitInterval) 1, γ t ∈ f '' ball c r := by
-    intro t ht
-    rw [hγformula' t ht]
-    exact ⟨circleMap ζ ρ (AffineMap.lineMap a b (t : ℝ)),
-      hmaps (lineMap_mem_Ioo hab ht), rfl⟩
+  have hγmem : ∀ t ∈ Ioo (0 : unitInterval) 1, γ t ∈ f '' ball c r :=
+    mapsTo_Ioo_of_eq_lineMap (g := fun θ => f (circleMap ζ ρ θ)) hab
+      (fun θ hθ => ⟨circleMap ζ ρ θ, hmaps hθ, rfl⟩) hγformula'
   have hγsimple := eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo
     (himageOpen.frontier_eq ▸ hγzero).2 (himageOpen.frontier_eq ▸ hγone).2 hγmem hγinj
   exact ⟨u, v, γ, hγrange, hu, hv, hufrontier, hvfrontier, hγsimple, hγformula⟩

--- a/TauCeti/Topology/Path/ExtendFrom.lean
+++ b/TauCeti/Topology/Path/ExtendFrom.lean
@@ -58,8 +58,8 @@ path from an existential and knows only the formula.
 * `TauCeti.Path.range_ofContinuousOnIoo` — its range is `closure (g '' Ioo a b)`.
 * `TauCeti.mapsTo_Ioo_of_eq_lineMap`, `TauCeti.injOn_Ioo_of_eq_lineMap` and
   `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — the reparametrisation-only lemmas
-  above, together with `TauCeti.unitInterval_eq_zero_or_eq_one_or_mem_Ioo`, the trichotomy on which
-  the last of them runs.
+  above; the last of them runs on Mathlib's trichotomy
+  `Set.eq_endpoints_or_mem_Ioo_of_mem_Icc`, read on the unit interval.
 
 ## Generality
 
@@ -94,16 +94,6 @@ private theorem lineMap_mem_Ioo (hab : a < b) {t : I}
   rw [← openSegment_eq_Ioo hab]
   exact lineMap_mem_openSegment ℝ a b (by simpa using ht)
 
-/-- A point of the unit interval is an endpoint or lies in its interior. -/
-theorem unitInterval_eq_zero_or_eq_one_or_mem_Ioo (t : I) :
-    t = 0 ∨ t = 1 ∨ t ∈ Ioo (0 : I) 1 := by
-  by_cases h0 : t = 0
-  · exact Or.inl h0
-  by_cases h1 : t = 1
-  · exact Or.inr (Or.inl h1)
-  exact Or.inr (Or.inr ⟨lt_of_le_of_ne t.2.1 (fun h => h0 h.symm),
-    lt_of_le_of_ne t.2.2 h1⟩)
-
 /-- **The interior of an affinely reparametrised curve stays where the curve does.** If `γ` follows
 `g` along `AffineMap.lineMap a b` on the interior of the unit interval and `g` maps `Ioo a b` into
 `S`, then `γ` maps that interior into `S`. -/
@@ -135,16 +125,16 @@ theorem eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo {S : Set X}
     (hmem : ∀ t ∈ Ioo (0 : I) 1, γ t ∈ S)
     (hinj : InjOn γ (Ioo (0 : I) 1)) ⦃x y : I⦄ (hxy : γ x = γ y) :
     x = y ∨ (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 0) := by
-  rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo x with rfl | rfl | hx
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+  rcases eq_endpoints_or_mem_Ioo_of_mem_Icc (a := (0 : I)) (b := 1) x.2 with rfl | rfl | hx
+  · rcases eq_endpoints_or_mem_Ioo_of_mem_Icc (a := (0 : I)) (b := 1) y.2 with rfl | rfl | hy
     · exact Or.inl rfl
     · exact Or.inr (Or.inl ⟨rfl, rfl⟩)
     · exact absurd (by rw [hxy]; exact hmem y hy) hzero
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+  · rcases eq_endpoints_or_mem_Ioo_of_mem_Icc (a := (0 : I)) (b := 1) y.2 with rfl | rfl | hy
     · exact Or.inr (Or.inr ⟨rfl, rfl⟩)
     · exact Or.inl rfl
     · exact absurd (by rw [hxy]; exact hmem y hy) hone
-  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+  · rcases eq_endpoints_or_mem_Ioo_of_mem_Icc (a := (0 : I)) (b := 1) y.2 with rfl | rfl | hy
     · exact absurd (by rw [← hxy]; exact hmem x hx) hzero
     · exact absurd (by rw [← hxy]; exact hmem x hx) hone
     · exact Or.inl (hinj hx hy hxy)

--- a/TauCeti/Topology/Path/ExtendFrom.lean
+++ b/TauCeti/Topology/Path/ExtendFrom.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import Mathlib.Analysis.Convex.Segment
+public import Mathlib.Topology.Order.ExtendFrom
+public import Mathlib.Topology.Path
+import Mathlib.Topology.Order.Compact
+import Mathlib.Topology.Separation.Hausdorff
+
+/-!
+# The path traced by a function on an open interval
+
+A curve is often produced not as a `Path` but as a function `g : ℝ → X` defined on an *open*
+interval `Ioo a b`, continuous there, and converging at each of the two ends. This file turns such
+a function into an honest `Path` between its two limits, `TauCeti.Path.ofContinuousOnIoo`, and
+records the three facts a consumer of that path needs: what its values are on the interior of the
+unit interval, what its range is, and when it repeats a value.
+
+The construction is Mathlib's `extendFrom` composed with the affine reparametrisation
+`AffineMap.lineMap a b : [0, 1] → [a, b]`. Mathlib's `continuousOn_Icc_extendFrom_Ioo` says that
+`extendFrom (Ioo a b) g` is continuous on the *closed* interval as soon as `g` is continuous on the
+open one and has a limit at each end, and `eq_lim_at_left_extendFrom_Ioo` /
+`eq_lim_at_right_extendFrom_Ioo` identify its two endpoint values with those limits; the
+reparametrisation carries all of that to the unit interval. Nothing else is needed: the two
+endpoint limits are exactly the data that a `Path` between them requires.
+
+The range is `closure (g '' Ioo a b)` rather than `g '' Ioo a b`: the path traverses the closed
+interval, and the image of a compact set under a map continuous on it is the closure of the image
+of the dense open part. So the closure of a curve given on an open interval is automatically
+path-connected, with the curve itself as the interior of the traversal — which is what makes this
+construction useful, since the endpoints are in general *not* values of `g`.
+
+## Simplicity
+
+Whether the path is simple is not a matter of the extension but of `g` and of the endpoints, and
+is treated here in the reparametrisation-only form, with no topology on `X` at all:
+
+* `TauCeti.injOn_Ioo_of_eq_lineMap` — the path is injective on the interior of the unit interval
+  as soon as `g` is injective on `Ioo a b`, because `AffineMap.lineMap a b` is;
+* `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — if in addition the interior stays
+  inside a set that neither endpoint value belongs to, the only repetition left is between the two
+  endpoints. That is the statement "the path is a simple arc, except that it may be a loop".
+
+Both are stated for a bare function `unitInterval → X` satisfying the parametrisation formula,
+rather than for `TauCeti.Path.ofContinuousOnIoo` itself, because a consumer typically receives its
+path from an existential and knows only the formula.
+
+## Main declarations
+
+* `TauCeti.Path.ofContinuousOnIoo` — the path traced by a function continuous on `Ioo a b` with a
+  limit at each end, from the limit at `a` to the limit at `b`.
+* `TauCeti.Path.ofContinuousOnIoo_apply` and
+  `TauCeti.Path.ofContinuousOnIoo_apply_of_mem_Ioo` — its values, in general and on the interior.
+* `TauCeti.Path.range_ofContinuousOnIoo` — its range is `closure (g '' Ioo a b)`.
+* `TauCeti.mapsTo_Ioo_of_eq_lineMap`, `TauCeti.injOn_Ioo_of_eq_lineMap` and
+  `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — the reparametrisation-only lemmas
+  above, together with `TauCeti.unitInterval_eq_zero_or_eq_one_or_mem_Ioo`, the trichotomy on which
+  the last of them runs.
+
+## Generality
+
+The construction asks `X` to be regular (for `continuousOn_Icc_extendFrom_Ioo`) and Hausdorff (for
+`extendFrom` to pin the endpoint values down and for the range computation), which is what Mathlib
+asks of the ingredients; a metric space, the case every consumer here instantiates, satisfies both.
+The simplicity lemmas assume nothing about `X`. The interval is a real one, as `AffineMap.lineMap`
+and `unitInterval` are.
+-/
+
+public section
+
+namespace TauCeti
+
+open Filter Set Topology
+open scoped unitInterval
+
+section Reparametrisation
+
+variable {X : Type*} {a b : ℝ} {g : ℝ → X} {γ : I → X}
+
+/-- The affine parametrisation from the unit interval to `Icc a b` sends the whole unit interval
+into `Icc a b`. -/
+private theorem lineMap_mem_Icc (hab : a ≤ b) (t : I) :
+    AffineMap.lineMap a b (t : ℝ) ∈ Icc a b :=
+  segment_eq_Icc hab ▸ lineMap_mem_segment ℝ a b t.2
+
+/-- The affine parametrisation from the unit interval to `Icc a b` sends its interior into
+`Ioo a b`. -/
+private theorem lineMap_mem_Ioo (hab : a < b) {t : I}
+    (ht : t ∈ Ioo (0 : I) 1) : AffineMap.lineMap a b (t : ℝ) ∈ Ioo a b := by
+  rw [← openSegment_eq_Ioo hab]
+  exact lineMap_mem_openSegment ℝ a b (by simpa using ht)
+
+/-- A point of the unit interval is an endpoint or lies in its interior. -/
+theorem unitInterval_eq_zero_or_eq_one_or_mem_Ioo (t : I) :
+    t = 0 ∨ t = 1 ∨ t ∈ Ioo (0 : I) 1 := by
+  by_cases h0 : t = 0
+  · exact Or.inl h0
+  by_cases h1 : t = 1
+  · exact Or.inr (Or.inl h1)
+  exact Or.inr (Or.inr ⟨lt_of_le_of_ne t.2.1 (fun h => h0 h.symm),
+    lt_of_le_of_ne t.2.2 h1⟩)
+
+/-- **The interior of an affinely reparametrised curve stays where the curve does.** If `γ` follows
+`g` along `AffineMap.lineMap a b` on the interior of the unit interval and `g` maps `Ioo a b` into
+`S`, then `γ` maps that interior into `S`. -/
+theorem mapsTo_Ioo_of_eq_lineMap {S : Set X} (hab : a < b) (hmaps : MapsTo g (Ioo a b) S)
+    (hγ : ∀ t ∈ Ioo (0 : I) 1, γ t = g (AffineMap.lineMap a b (t : ℝ))) :
+    MapsTo γ (Ioo (0 : I) 1) S := fun _t ht =>
+  (hγ _ ht) ▸ hmaps (lineMap_mem_Ioo hab ht)
+
+/-- **An affinely reparametrised curve is injective on the interior of the unit interval whenever
+the curve is injective on the open interval.** Only injectivity of `AffineMap.lineMap a b` is spent,
+so nothing is assumed of `X`. -/
+theorem injOn_Ioo_of_eq_lineMap (hab : a < b) (hinj : InjOn g (Ioo a b))
+    (hγ : ∀ t ∈ Ioo (0 : I) 1, γ t = g (AffineMap.lineMap a b (t : ℝ))) :
+    InjOn γ (Ioo (0 : I) 1) := by
+  intro x hx y hy hxy
+  rw [hγ x hx, hγ y hy] at hxy
+  exact Subtype.ext ((AffineMap.lineMap_injective ℝ hab.ne)
+    (hinj (lineMap_mem_Ioo hab hx) (lineMap_mem_Ioo hab hy) hxy))
+
+/-- **A path repeats only at its endpoints when its interior avoids both endpoint values.**
+If `γ` maps the open interval into `S`, neither endpoint value lies in `S`, and `γ` is injective on
+the open interval, then any repeated value is a common value of the two endpoints.
+
+Purely a statement about function values: neither `γ` nor `S` carries any topology, and a `Path`
+specializes automatically through its coercion. The frontier/open-set form is derived at the call
+site. -/
+theorem eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo {S : Set X}
+    (hzero : γ 0 ∉ S) (hone : γ 1 ∉ S)
+    (hmem : ∀ t ∈ Ioo (0 : I) 1, γ t ∈ S)
+    (hinj : InjOn γ (Ioo (0 : I) 1)) ⦃x y : I⦄ (hxy : γ x = γ y) :
+    x = y ∨ (x = 0 ∧ y = 1) ∨ (x = 1 ∧ y = 0) := by
+  rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo x with rfl | rfl | hx
+  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+    · exact Or.inl rfl
+    · exact Or.inr (Or.inl ⟨rfl, rfl⟩)
+    · exact absurd (by rw [hxy]; exact hmem y hy) hzero
+  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+    · exact Or.inr (Or.inr ⟨rfl, rfl⟩)
+    · exact Or.inl rfl
+    · exact absurd (by rw [hxy]; exact hmem y hy) hone
+  · rcases unitInterval_eq_zero_or_eq_one_or_mem_Ioo y with rfl | rfl | hy
+    · exact absurd (by rw [← hxy]; exact hmem x hx) hzero
+    · exact absurd (by rw [← hxy]; exact hmem x hx) hone
+    · exact Or.inl (hinj hx hy hxy)
+
+end Reparametrisation
+
+namespace Path
+
+variable {X : Type*} [TopologicalSpace X] [RegularSpace X] [T2Space X]
+  {a b : ℝ} {u v : X} {g : ℝ → X}
+
+/-- **The path traced by a function on an open interval.** If `g` is continuous on `Ioo a b`, tends
+to `u` at `a` from the right and to `v` at `b` from the left, then `g` traverses a path from `u` to
+`v`: the continuous extension `extendFrom (Ioo a b) g` of `g` to `Icc a b`, read along the affine
+parametrisation `AffineMap.lineMap a b` of `Icc a b` by the unit interval.
+
+Its values on the interior of the unit interval are those of `g`
+(`TauCeti.Path.ofContinuousOnIoo_apply_of_mem_Ioo`) and its range is `closure (g '' Ioo a b)`
+(`TauCeti.Path.range_ofContinuousOnIoo`); the endpoints `u` and `v` need not themselves be values
+of `g`.
+
+The definition is not exposed; `TauCeti.Path.ofContinuousOnIoo_apply` characterizes it. -/
+noncomputable def ofContinuousOnIoo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
+    (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) : Path u v where
+  toFun t := extendFrom (Ioo a b) g (AffineMap.lineMap a b (t : ℝ))
+  continuous_toFun :=
+    (continuousOn_Icc_extendFrom_Ioo hg hu hv).comp_continuous
+      (by simp only [AffineMap.lineMap_apply_ring]; fun_prop)
+      fun t => lineMap_mem_Icc hab.le t
+  source' := by
+    simpa only [Set.Icc.coe_zero, AffineMap.lineMap_apply_zero] using
+      eq_lim_at_left_extendFrom_Ioo hab hu
+  target' := by
+    simpa only [Set.Icc.coe_one, AffineMap.lineMap_apply_one] using
+      eq_lim_at_right_extendFrom_Ioo hab hv
+
+/-- The path traced by `g` is the continuous extension of `g` read along the affine parametrisation
+of `Icc a b` by the unit interval. -/
+theorem ofContinuousOnIoo_apply (hab : a < b) (hg : ContinuousOn g (Ioo a b))
+    (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) (t : I) :
+    ofContinuousOnIoo hab hg hu hv t = extendFrom (Ioo a b) g (AffineMap.lineMap a b (t : ℝ)) :=
+  (rfl)
+
+/-- **On the interior of the unit interval the path traced by `g` is `g` itself**, along the affine
+parametrisation. The endpoints are excluded because there `g` need not be defined at all; that is
+what makes the construction more than a reparametrisation. -/
+theorem ofContinuousOnIoo_apply_of_mem_Ioo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
+    (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) {t : I}
+    (ht : t ∈ Ioo (0 : I) 1) :
+    ofContinuousOnIoo hab hg hu hv t = g (AffineMap.lineMap a b (t : ℝ)) :=
+  extendFrom_extends hg _ (lineMap_mem_Ioo hab ht)
+
+/-- **The range of the path traced by `g` is the closure of the curve.** The path traverses the
+closed interval `Icc a b`, which is the closure of `Ioo a b` and compact, so its image under a map
+continuous there is the closure of the image of `Ioo a b`. In particular the closure of a curve
+defined on an open interval and converging at both ends is path-connected. -/
+theorem range_ofContinuousOnIoo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
+    (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) :
+    range (ofContinuousOnIoo hab hg hu hv) = closure (g '' Ioo a b) := by
+  have hcl : closure (Ioo a b) = Icc a b := closure_Ioo hab.ne
+  have hparam : range (fun t : I => AffineMap.lineMap a b (t : ℝ)) = Icc a b := by
+    rw [show (fun t : I => AffineMap.lineMap a b (t : ℝ))
+        = AffineMap.lineMap a b ∘ (Subtype.val : I → ℝ) from rfl, range_comp,
+      Subtype.range_coe_subtype, ofPred_mem_eq, ← segment_eq_image_lineMap ℝ a b,
+      segment_eq_Icc hab.le]
+  have hcont : ContinuousOn (extendFrom (Ioo a b) g) (closure (Ioo a b)) :=
+    hcl ▸ continuousOn_Icc_extendFrom_Ioo hg hu hv
+  have heq : EqOn (extendFrom (Ioo a b) g) g (Ioo a b) := fun x hx => extendFrom_extends hg x hx
+  rw [show (⇑(ofContinuousOnIoo hab hg hu hv)) =
+      extendFrom (Ioo a b) g ∘ fun t : I => AffineMap.lineMap a b (t : ℝ) from rfl,
+    range_comp, hparam, ← hcl, image_closure_of_isCompact (hcl ▸ isCompact_Icc) hcont,
+    heq.image_eq]
+
+end Path
+
+end TauCeti

--- a/TauCeti/Topology/Path/ExtendIoo.lean
+++ b/TauCeti/Topology/Path/ExtendIoo.lean
@@ -18,8 +18,7 @@ import Mathlib.Topology.Separation.Hausdorff
 A curve is often produced not as a `Path` but as a function `g : ℝ → X` defined on an *open*
 interval `Ioo a b`, continuous there, and converging at each of the two ends. This file turns such
 a function into an honest `Path` between its two limits, `TauCeti.Path.ofContinuousOnIoo`, and
-records the three facts a consumer of that path needs: what its values are on the interior of the
-unit interval, what its range is, and when it repeats a value.
+records what its values are on the interior of the unit interval and what its range is.
 
 The construction is the extension `TauCeti.extendIoo a b u v g` of `g` across the two ends of the
 interval by the prescribed values `u` and `v`, composed with the affine reparametrisation
@@ -39,38 +38,39 @@ construction useful, since the endpoints are in general *not* values of `g`.
 ## Simplicity
 
 Whether the path is simple is not a matter of the extension but of `g` and of the endpoints, and
-is treated here in the reparametrisation-only form, with no topology on `X` at all:
+the one step of that argument which is not a plain composition is recorded here, in the
+reparametrisation-only form and with no topology on `X` at all:
+`TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` says that if a curve on the unit interval
+is injective on the interior, and that interior stays inside a set to which neither endpoint value
+belongs, then the only repetition left is between the two endpoints. That is the statement "the
+path is a simple arc, except that it may be a loop".
 
-* `TauCeti.injOn_Ioo_of_eq_lineMap` — the path is injective on the interior of the unit interval
-  as soon as `g` is injective on `Ioo a b`, because `AffineMap.lineMap a b` is;
-* `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — if in addition the interior stays
-  inside a set that neither endpoint value belongs to, the only repetition left is between the two
-  endpoints. That is the statement "the path is a simple arc, except that it may be a loop".
-
-Both are stated for a bare function `unitInterval → X` satisfying the parametrisation formula,
-rather than for `TauCeti.Path.ofContinuousOnIoo` itself, because a consumer typically receives its
-path from an existential and knows only the formula.
+It is stated for a bare function `unitInterval → X` satisfying the parametrisation formula, rather
+than for `TauCeti.Path.ofContinuousOnIoo` itself, because a consumer typically receives its path
+from an existential and knows only the formula. Injectivity on the interior is left to the call
+site, being the injectivity of `g` composed with that of `AffineMap.lineMap a b`.
 
 ## Main declarations
 
 * `TauCeti.extendIoo` — a function on `Ioo a b`, extended across both ends by prescribed values,
-  and `TauCeti.continuousOn_Icc_extendIoo`, its continuity on `Icc a b`.
+  with `TauCeti.extendIoo_apply_of_mem_Ioo`, `TauCeti.extendIoo_apply_of_le_left` and
+  `TauCeti.extendIoo_apply_of_right_le` computing it everywhere, and
+  `TauCeti.continuousOn_Icc_extendIoo`, its continuity on `Icc a b`.
 * `TauCeti.Path.ofContinuousOnIoo` — the path traced by a function continuous on `Ioo a b` with a
   limit at each end, from the limit at `a` to the limit at `b`.
 * `TauCeti.Path.ofContinuousOnIoo_apply` and
   `TauCeti.Path.ofContinuousOnIoo_apply_of_mem_Ioo` — its values, in general and on the interior.
 * `TauCeti.Path.range_ofContinuousOnIoo` — its range is `closure (g '' Ioo a b)`.
-* `TauCeti.mapsTo_Ioo_of_eq_lineMap`, `TauCeti.injOn_Ioo_of_eq_lineMap` and
-  `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — the reparametrisation-only lemmas
-  above; the last of them runs on Mathlib's trichotomy
-  `Set.eq_endpoints_or_mem_Ioo_of_mem_Icc`, read on the unit interval.
+* `TauCeti.eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo` — the simplicity lemma above; it runs on
+  Mathlib's trichotomy `Set.eq_endpoints_or_mem_Ioo_of_mem_Icc`, read on the unit interval.
 
 ## Generality
 
-The path and its values ask nothing of `X` beyond a topology; only the range computation is
-Hausdorff, the image of a compact set having to be closed there. The simplicity lemmas assume
-nothing about `X` at all. The interval is a real one, as `AffineMap.lineMap` and `unitInterval`
-are.
+The extension and its continuity are stated over an arbitrary linearly ordered domain with an
+order-closed topology; only the path is real, `AffineMap.lineMap` and `unitInterval` being so. The
+path and its values ask nothing of `X` beyond a topology; only the range computation is Hausdorff,
+the image of a compact set having to be closed there. The simplicity lemma assumes nothing about
+`X` at all.
 -/
 
 public section
@@ -82,7 +82,7 @@ open scoped unitInterval
 
 section Reparametrisation
 
-variable {X : Type*} {a b : ℝ} {g : ℝ → X} {γ : I → X}
+variable {X : Type*} {a b : ℝ} {γ : I → X}
 
 /-- The affine parametrisation from the unit interval to `Icc a b` sends the whole unit interval
 into `Icc a b`. -/
@@ -96,25 +96,6 @@ private theorem lineMap_mem_Ioo (hab : a < b) {t : I}
     (ht : t ∈ Ioo (0 : I) 1) : AffineMap.lineMap a b (t : ℝ) ∈ Ioo a b := by
   rw [← openSegment_eq_Ioo hab]
   exact lineMap_mem_openSegment ℝ a b (by simpa using ht)
-
-/-- **The interior of an affinely reparametrised curve stays where the curve does.** If `γ` follows
-`g` along `AffineMap.lineMap a b` on the interior of the unit interval and `g` maps `Ioo a b` into
-`S`, then `γ` maps that interior into `S`. -/
-theorem mapsTo_Ioo_of_eq_lineMap {S : Set X} (hab : a < b) (hmaps : MapsTo g (Ioo a b) S)
-    (hγ : ∀ t ∈ Ioo (0 : I) 1, γ t = g (AffineMap.lineMap a b (t : ℝ))) :
-    MapsTo γ (Ioo (0 : I) 1) S := fun _t ht =>
-  (hγ _ ht) ▸ hmaps (lineMap_mem_Ioo hab ht)
-
-/-- **An affinely reparametrised curve is injective on the interior of the unit interval whenever
-the curve is injective on the open interval.** Only injectivity of `AffineMap.lineMap a b` is spent,
-so nothing is assumed of `X`. -/
-theorem injOn_Ioo_of_eq_lineMap (hab : a < b) (hinj : InjOn g (Ioo a b))
-    (hγ : ∀ t ∈ Ioo (0 : I) 1, γ t = g (AffineMap.lineMap a b (t : ℝ))) :
-    InjOn γ (Ioo (0 : I) 1) := by
-  intro x hx y hy hxy
-  rw [hγ x hx, hγ y hy] at hxy
-  exact Subtype.ext ((AffineMap.lineMap_injective ℝ hab.ne)
-    (hinj (lineMap_mem_Ioo hab hx) (lineMap_mem_Ioo hab hy) hxy))
 
 /-- **A path repeats only at its endpoints when its interior avoids both endpoint values.**
 If `γ` maps the open interval into `S`, neither endpoint value lies in `S`, and `γ` is injective on
@@ -146,59 +127,66 @@ end Reparametrisation
 
 section Extend
 
-variable {X : Type*} {a b x : ℝ} {u v : X} {g : ℝ → X}
+variable {X α : Type*} [LinearOrder α] {a b x : α} {u v : X} {g : α → X}
 
 /-- **A function on an open interval, extended across both of its ends by prescribed values.**
-`TauCeti.extendIoo a b u v g` agrees with `g` on `Ioo a b`, takes the value `u` at `a` and the
-value `v` at `b`. Outside `Icc a b` its values are irrelevant, and are chosen so that the
-definition carries no side condition.
+`TauCeti.extendIoo a b u v g` agrees with `g` on `Ioo a b` and takes the value `u` on `Iic a`; when
+`a < b` it takes the value `v` on `Ici b`, so that in particular it is `u` at `a` and `v` at `b`.
+The two outer branches run over the whole of `Iic a` and `Ici b`, rather than over the endpoints
+alone, so that the definition computes everywhere and carries no side condition. The
+nondegeneracy `a < b` is not part of the definition, and is needed for the right-hand branch only:
+if instead `b ≤ a`, the interval is empty and the extension is `u` on `Iic a` and `v` on `Ioi a`,
+so that `b` itself is sent to `u`.
 
 Mathlib's `extendFrom` instead *recovers* the end values as limits, which is why its continuity
 theorem `continuousOn_Icc_extendFrom_Ioo` asks for a regular codomain and its identification
 theorem `eq_lim_at_left_extendFrom_Ioo` for a Hausdorff one. Here the end values are given, and
 `TauCeti.continuousOn_Icc_extendIoo` needs neither. -/
-noncomputable def extendIoo (a b : ℝ) (u v : X) (g : ℝ → X) : ℝ → X :=
+noncomputable def extendIoo (a b : α) (u v : X) (g : α → X) : α → X :=
   fun x => if x ≤ a then u else if b ≤ x then v else g x
 
 /-- Inside the open interval the extension is the function itself. -/
 @[simp]
-theorem extendIoo_of_mem_Ioo (hx : x ∈ Ioo a b) : extendIoo a b u v g x = g x := by
+theorem extendIoo_apply_of_mem_Ioo (hx : x ∈ Ioo a b) : extendIoo a b u v g x = g x := by
   simp [extendIoo, hx.1.not_ge, hx.2.not_ge]
 
-/-- At the left end the extension takes the prescribed value `u`. -/
+/-- At and below the left end the extension takes the prescribed value `u`. -/
 @[simp]
-theorem extendIoo_left : extendIoo a b u v g a = u := by simp [extendIoo]
+theorem extendIoo_apply_of_le_left (hx : x ≤ a) : extendIoo a b u v g x = u := by
+  simp [extendIoo, hx]
 
-/-- At the right end the extension takes the prescribed value `v`. -/
+/-- At and above the right end the extension takes the prescribed value `v`, the interval being
+nondegenerate. -/
 @[simp]
-theorem extendIoo_right (hab : a < b) : extendIoo a b u v g b = v := by
-  simp [extendIoo, hab.not_ge]
+theorem extendIoo_apply_of_right_le (hab : a < b) (hx : b ≤ x) : extendIoo a b u v g x = v := by
+  simp [extendIoo, (hab.trans_le hx).not_ge, hx]
 
 /-- **A function continuous on an open interval and converging at both ends extends continuously
 to the closed interval.** The extension is `TauCeti.extendIoo` by the two limits; being handed
 them, the proof glues at the two ends and asks nothing of `X` beyond a topology. -/
-theorem continuousOn_Icc_extendIoo [TopologicalSpace X] (hab : a < b)
+theorem continuousOn_Icc_extendIoo [TopologicalSpace α] [OrderClosedTopology α]
+    [TopologicalSpace X] (hab : a < b)
     (hg : ContinuousOn g (Ioo a b)) (hu : Tendsto g (𝓝[>] a) (𝓝 u))
     (hv : Tendsto g (𝓝[<] b) (𝓝 v)) : ContinuousOn (extendIoo a b u v g) (Icc a b) := by
   have hleft : ContinuousWithinAt (extendIoo a b u v g) (Icc a b) a := by
     refine ContinuousWithinAt.mono ?_ Icc_subset_Ici_self
     rw [← Ioi_insert, continuousWithinAt_insert_self]
     have heq : g =ᶠ[𝓝[>] a] extendIoo a b u v g := by
-      filter_upwards [Ioo_mem_nhdsGT hab] with y hy using (extendIoo_of_mem_Ioo hy).symm
-    simpa only [ContinuousWithinAt, extendIoo_left] using hu.congr' heq
+      filter_upwards [Ioo_mem_nhdsGT hab] with y hy using (extendIoo_apply_of_mem_Ioo hy).symm
+    simpa only [ContinuousWithinAt, extendIoo_apply_of_le_left le_rfl] using hu.congr' heq
   have hright : ContinuousWithinAt (extendIoo a b u v g) (Icc a b) b := by
     refine ContinuousWithinAt.mono ?_ Icc_subset_Iic_self
     rw [← Iio_insert, continuousWithinAt_insert_self]
     have heq : g =ᶠ[𝓝[<] b] extendIoo a b u v g := by
-      filter_upwards [Ioo_mem_nhdsLT hab] with y hy using (extendIoo_of_mem_Ioo hy).symm
-    simpa only [ContinuousWithinAt, extendIoo_right hab] using hv.congr' heq
+      filter_upwards [Ioo_mem_nhdsLT hab] with y hy using (extendIoo_apply_of_mem_Ioo hy).symm
+    simpa only [ContinuousWithinAt, extendIoo_apply_of_right_le hab le_rfl] using hv.congr' heq
   intro x hx
   rcases eq_endpoints_or_mem_Ioo_of_mem_Icc hx with rfl | rfl | hx
   · exact hleft
   · exact hright
   · have hmem : Ioo a b ∈ 𝓝 x := isOpen_Ioo.mem_nhds hx
     refine ContinuousAt.continuousWithinAt ((hg.continuousAt hmem).congr ?_)
-    filter_upwards [hmem] with y hy using (extendIoo_of_mem_Ioo hy).symm
+    filter_upwards [hmem] with y hy using (extendIoo_apply_of_mem_Ioo hy).symm
 
 end Extend
 
@@ -244,8 +232,8 @@ reparametrisation. -/
 theorem ofContinuousOnIoo_apply_of_mem_Ioo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
     (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) {t : I}
     (ht : t ∈ Ioo (0 : I) 1) :
-    ofContinuousOnIoo hab hg hu hv t = g (AffineMap.lineMap a b (t : ℝ)) :=
-  extendIoo_of_mem_Ioo (lineMap_mem_Ioo hab ht)
+    ofContinuousOnIoo hab hg hu hv t = g (AffineMap.lineMap a b (t : ℝ)) := by
+  rw [ofContinuousOnIoo_apply, extendIoo_apply_of_mem_Ioo (lineMap_mem_Ioo hab ht)]
 
 /-- **The range of the path traced by `g` is the closure of the curve.** The path traverses the
 closed interval `Icc a b`, which is the closure of `Ioo a b` and compact, so its image under a map
@@ -259,7 +247,7 @@ theorem range_ofContinuousOnIoo [T2Space X] (hab : a < b) (hg : ContinuousOn g (
     rw [← image_eq_range, ← segment_eq_image_lineMap, segment_eq_Icc hab.le]
   have hcont : ContinuousOn (extendIoo a b u v g) (closure (Ioo a b)) :=
     hcl ▸ continuousOn_Icc_extendIoo hab hg hu hv
-  have heq : EqOn (extendIoo a b u v g) g (Ioo a b) := fun _ hx => extendIoo_of_mem_Ioo hx
+  have heq : EqOn (extendIoo a b u v g) g (Ioo a b) := fun _ hx => extendIoo_apply_of_mem_Ioo hx
   have hfun : ⇑(ofContinuousOnIoo hab hg hu hv)
       = extendIoo a b u v g ∘ fun t : I => AffineMap.lineMap a b (t : ℝ) :=
     funext (ofContinuousOnIoo_apply hab hg hu hv)

--- a/TauCeti/Topology/Path/ExtendIoo.lean
+++ b/TauCeti/Topology/Path/ExtendIoo.lean
@@ -6,9 +6,10 @@ Authors: The Tau Ceti contributors
 module
 
 public import Mathlib.Analysis.Convex.Segment
-public import Mathlib.Topology.Order.ExtendFrom
+public import Mathlib.Topology.Order.OrderClosed
 public import Mathlib.Topology.Path
 import Mathlib.Topology.Order.Compact
+import Mathlib.Topology.Order.DenselyOrdered
 import Mathlib.Topology.Separation.Hausdorff
 
 /-!
@@ -20,13 +21,14 @@ a function into an honest `Path` between its two limits, `TauCeti.Path.ofContinu
 records the three facts a consumer of that path needs: what its values are on the interior of the
 unit interval, what its range is, and when it repeats a value.
 
-The construction is Mathlib's `extendFrom` composed with the affine reparametrisation
-`AffineMap.lineMap a b : [0, 1] → [a, b]`. Mathlib's `continuousOn_Icc_extendFrom_Ioo` says that
-`extendFrom (Ioo a b) g` is continuous on the *closed* interval as soon as `g` is continuous on the
-open one and has a limit at each end, and `eq_lim_at_left_extendFrom_Ioo` /
-`eq_lim_at_right_extendFrom_Ioo` identify its two endpoint values with those limits; the
-reparametrisation carries all of that to the unit interval. Nothing else is needed: the two
-endpoint limits are exactly the data that a `Path` between them requires.
+The construction is the extension `TauCeti.extendIoo a b u v g` of `g` across the two ends of the
+interval by the prescribed values `u` and `v`, composed with the affine reparametrisation
+`AffineMap.lineMap a b : [0, 1] → [a, b]`. Because those two values are *given* rather than
+recovered as limits, the continuity of the extension on `Icc a b`
+(`TauCeti.continuousOn_Icc_extendIoo`) needs no separation assumption on `X`, unlike Mathlib's
+`continuousOn_Icc_extendFrom_Ioo` for `extendFrom`, which must locate the limits and so asks for a
+regular codomain, and `eq_lim_at_left_extendFrom_Ioo`, which asks for a Hausdorff one. Nothing else
+is needed: the two endpoint limits are exactly the data that a `Path` between them requires.
 
 The range is `closure (g '' Ioo a b)` rather than `g '' Ioo a b`: the path traverses the closed
 interval, and the image of a compact set under a map continuous on it is the closure of the image
@@ -51,6 +53,8 @@ path from an existential and knows only the formula.
 
 ## Main declarations
 
+* `TauCeti.extendIoo` — a function on `Ioo a b`, extended across both ends by prescribed values,
+  and `TauCeti.continuousOn_Icc_extendIoo`, its continuity on `Icc a b`.
 * `TauCeti.Path.ofContinuousOnIoo` — the path traced by a function continuous on `Ioo a b` with a
   limit at each end, from the limit at `a` to the limit at `b`.
 * `TauCeti.Path.ofContinuousOnIoo_apply` and
@@ -63,11 +67,10 @@ path from an existential and knows only the formula.
 
 ## Generality
 
-The construction asks `X` to be regular (for `continuousOn_Icc_extendFrom_Ioo`) and Hausdorff (for
-`extendFrom` to pin the endpoint values down and for the range computation), which is what Mathlib
-asks of the ingredients; a metric space, the case every consumer here instantiates, satisfies both.
-The simplicity lemmas assume nothing about `X`. The interval is a real one, as `AffineMap.lineMap`
-and `unitInterval` are.
+The path and its values ask nothing of `X` beyond a topology; only the range computation is
+Hausdorff, the image of a compact set having to be closed there. The simplicity lemmas assume
+nothing about `X` at all. The interval is a real one, as `AffineMap.lineMap` and `unitInterval`
+are.
 -/
 
 public section
@@ -141,71 +144,126 @@ theorem eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo {S : Set X}
 
 end Reparametrisation
 
+section Extend
+
+variable {X : Type*} {a b x : ℝ} {u v : X} {g : ℝ → X}
+
+/-- **A function on an open interval, extended across both of its ends by prescribed values.**
+`TauCeti.extendIoo a b u v g` agrees with `g` on `Ioo a b`, takes the value `u` at `a` and the
+value `v` at `b`. Outside `Icc a b` its values are irrelevant, and are chosen so that the
+definition carries no side condition.
+
+Mathlib's `extendFrom` instead *recovers* the end values as limits, which is why its continuity
+theorem `continuousOn_Icc_extendFrom_Ioo` asks for a regular codomain and its identification
+theorem `eq_lim_at_left_extendFrom_Ioo` for a Hausdorff one. Here the end values are given, and
+`TauCeti.continuousOn_Icc_extendIoo` needs neither. -/
+noncomputable def extendIoo (a b : ℝ) (u v : X) (g : ℝ → X) : ℝ → X :=
+  fun x => if x ≤ a then u else if b ≤ x then v else g x
+
+/-- Inside the open interval the extension is the function itself. -/
+@[simp]
+theorem extendIoo_of_mem_Ioo (hx : x ∈ Ioo a b) : extendIoo a b u v g x = g x := by
+  simp [extendIoo, hx.1.not_ge, hx.2.not_ge]
+
+/-- At the left end the extension takes the prescribed value `u`. -/
+@[simp]
+theorem extendIoo_left : extendIoo a b u v g a = u := by simp [extendIoo]
+
+/-- At the right end the extension takes the prescribed value `v`. -/
+@[simp]
+theorem extendIoo_right (hab : a < b) : extendIoo a b u v g b = v := by
+  simp [extendIoo, hab.not_ge]
+
+/-- **A function continuous on an open interval and converging at both ends extends continuously
+to the closed interval.** The extension is `TauCeti.extendIoo` by the two limits; being handed
+them, the proof glues at the two ends and asks nothing of `X` beyond a topology. -/
+theorem continuousOn_Icc_extendIoo [TopologicalSpace X] (hab : a < b)
+    (hg : ContinuousOn g (Ioo a b)) (hu : Tendsto g (𝓝[>] a) (𝓝 u))
+    (hv : Tendsto g (𝓝[<] b) (𝓝 v)) : ContinuousOn (extendIoo a b u v g) (Icc a b) := by
+  have hleft : ContinuousWithinAt (extendIoo a b u v g) (Icc a b) a := by
+    refine ContinuousWithinAt.mono ?_ Icc_subset_Ici_self
+    rw [← Ioi_insert, continuousWithinAt_insert_self]
+    have heq : g =ᶠ[𝓝[>] a] extendIoo a b u v g := by
+      filter_upwards [Ioo_mem_nhdsGT hab] with y hy using (extendIoo_of_mem_Ioo hy).symm
+    simpa only [ContinuousWithinAt, extendIoo_left] using hu.congr' heq
+  have hright : ContinuousWithinAt (extendIoo a b u v g) (Icc a b) b := by
+    refine ContinuousWithinAt.mono ?_ Icc_subset_Iic_self
+    rw [← Iio_insert, continuousWithinAt_insert_self]
+    have heq : g =ᶠ[𝓝[<] b] extendIoo a b u v g := by
+      filter_upwards [Ioo_mem_nhdsLT hab] with y hy using (extendIoo_of_mem_Ioo hy).symm
+    simpa only [ContinuousWithinAt, extendIoo_right hab] using hv.congr' heq
+  intro x hx
+  rcases eq_endpoints_or_mem_Ioo_of_mem_Icc hx with rfl | rfl | hx
+  · exact hleft
+  · exact hright
+  · have hmem : Ioo a b ∈ 𝓝 x := isOpen_Ioo.mem_nhds hx
+    refine ContinuousAt.continuousWithinAt ((hg.continuousAt hmem).congr ?_)
+    filter_upwards [hmem] with y hy using (extendIoo_of_mem_Ioo hy).symm
+
+end Extend
+
 namespace Path
 
-variable {X : Type*} [TopologicalSpace X] [RegularSpace X] [T2Space X]
-  {a b : ℝ} {u v : X} {g : ℝ → X}
+variable {X : Type*} [TopologicalSpace X] {a b : ℝ} {u v : X} {g : ℝ → X}
 
 /-- **The path traced by a function on an open interval.** If `g` is continuous on `Ioo a b`, tends
 to `u` at `a` from the right and to `v` at `b` from the left, then `g` traverses a path from `u` to
-`v`: the continuous extension `extendFrom (Ioo a b) g` of `g` to `Icc a b`, read along the affine
+`v`: the extension `TauCeti.extendIoo a b u v g` of `g` across the two ends, read along the affine
 parametrisation `AffineMap.lineMap a b` of `Icc a b` by the unit interval.
 
 Its values on the interior of the unit interval are those of `g`
 (`TauCeti.Path.ofContinuousOnIoo_apply_of_mem_Ioo`) and its range is `closure (g '' Ioo a b)`
 (`TauCeti.Path.range_ofContinuousOnIoo`); the endpoints `u` and `v` need not themselves be values
-of `g`.
-
-The definition is not exposed; `TauCeti.Path.ofContinuousOnIoo_apply` characterizes it. -/
+of `g`. Compute with it through `TauCeti.Path.ofContinuousOnIoo_apply` rather than through the
+definition. -/
 noncomputable def ofContinuousOnIoo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
     (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) : Path u v where
-  toFun t := extendFrom (Ioo a b) g (AffineMap.lineMap a b (t : ℝ))
+  toFun t := extendIoo a b u v g (AffineMap.lineMap a b (t : ℝ))
   continuous_toFun :=
-    (continuousOn_Icc_extendFrom_Ioo hg hu hv).comp_continuous
+    (continuousOn_Icc_extendIoo hab hg hu hv).comp_continuous
       (by simp only [AffineMap.lineMap_apply_ring]; fun_prop)
       fun t => lineMap_mem_Icc hab.le t
-  source' := by
-    simpa only [Set.Icc.coe_zero, AffineMap.lineMap_apply_zero] using
-      eq_lim_at_left_extendFrom_Ioo hab hu
-  target' := by
-    simpa only [Set.Icc.coe_one, AffineMap.lineMap_apply_one] using
-      eq_lim_at_right_extendFrom_Ioo hab hv
+  source' := by simp
+  target' := by simp [hab]
 
-/-- The path traced by `g` is the continuous extension of `g` read along the affine parametrisation
-of `Icc a b` by the unit interval. -/
+/-- The path traced by `g` is the extension of `g` across the two ends of `Ioo a b`, read along the
+affine parametrisation of `Icc a b` by the unit interval. -/
+@[grind =]
 theorem ofContinuousOnIoo_apply (hab : a < b) (hg : ContinuousOn g (Ioo a b))
     (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) (t : I) :
-    ofContinuousOnIoo hab hg hu hv t = extendFrom (Ioo a b) g (AffineMap.lineMap a b (t : ℝ)) :=
+    ofContinuousOnIoo hab hg hu hv t = extendIoo a b u v g (AffineMap.lineMap a b (t : ℝ)) :=
+  -- Parenthesised: the bare-`rfl` elaborator additionally demands that `ofContinuousOnIoo` be
+  -- `@[expose]`d, which it cannot be while its proof fields use private lemmas of this file.
   (rfl)
 
 /-- **On the interior of the unit interval the path traced by `g` is `g` itself**, along the affine
-parametrisation. The endpoints are excluded because there `g` need not be defined at all; that is
-what makes the construction more than a reparametrisation. -/
+parametrisation. The endpoints are excluded because there the values of `g` are unconstrained: they
+need not be the limits `u` and `v`, which is what makes the construction more than a
+reparametrisation. -/
+@[simp]
 theorem ofContinuousOnIoo_apply_of_mem_Ioo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
     (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) {t : I}
     (ht : t ∈ Ioo (0 : I) 1) :
     ofContinuousOnIoo hab hg hu hv t = g (AffineMap.lineMap a b (t : ℝ)) :=
-  extendFrom_extends hg _ (lineMap_mem_Ioo hab ht)
+  extendIoo_of_mem_Ioo (lineMap_mem_Ioo hab ht)
 
 /-- **The range of the path traced by `g` is the closure of the curve.** The path traverses the
 closed interval `Icc a b`, which is the closure of `Ioo a b` and compact, so its image under a map
 continuous there is the closure of the image of `Ioo a b`. In particular the closure of a curve
 defined on an open interval and converging at both ends is path-connected. -/
-theorem range_ofContinuousOnIoo (hab : a < b) (hg : ContinuousOn g (Ioo a b))
+theorem range_ofContinuousOnIoo [T2Space X] (hab : a < b) (hg : ContinuousOn g (Ioo a b))
     (hu : Tendsto g (𝓝[>] a) (𝓝 u)) (hv : Tendsto g (𝓝[<] b) (𝓝 v)) :
     range (ofContinuousOnIoo hab hg hu hv) = closure (g '' Ioo a b) := by
   have hcl : closure (Ioo a b) = Icc a b := closure_Ioo hab.ne
   have hparam : range (fun t : I => AffineMap.lineMap a b (t : ℝ)) = Icc a b := by
-    rw [show (fun t : I => AffineMap.lineMap a b (t : ℝ))
-        = AffineMap.lineMap a b ∘ (Subtype.val : I → ℝ) from rfl, range_comp,
-      Subtype.range_coe_subtype, ofPred_mem_eq, ← segment_eq_image_lineMap ℝ a b,
-      segment_eq_Icc hab.le]
-  have hcont : ContinuousOn (extendFrom (Ioo a b) g) (closure (Ioo a b)) :=
-    hcl ▸ continuousOn_Icc_extendFrom_Ioo hg hu hv
-  have heq : EqOn (extendFrom (Ioo a b) g) g (Ioo a b) := fun x hx => extendFrom_extends hg x hx
-  rw [show (⇑(ofContinuousOnIoo hab hg hu hv)) =
-      extendFrom (Ioo a b) g ∘ fun t : I => AffineMap.lineMap a b (t : ℝ) from rfl,
-    range_comp, hparam, ← hcl, image_closure_of_isCompact (hcl ▸ isCompact_Icc) hcont,
+    rw [← image_eq_range, ← segment_eq_image_lineMap, segment_eq_Icc hab.le]
+  have hcont : ContinuousOn (extendIoo a b u v g) (closure (Ioo a b)) :=
+    hcl ▸ continuousOn_Icc_extendIoo hab hg hu hv
+  have heq : EqOn (extendIoo a b u v g) g (Ioo a b) := fun _ hx => extendIoo_of_mem_Ioo hx
+  have hfun : ⇑(ofContinuousOnIoo hab hg hu hv)
+      = extendIoo a b u v g ∘ fun t : I => AffineMap.lineMap a b (t : ℝ) :=
+    funext (ofContinuousOnIoo_apply hab hg hu hv)
+  rw [hfun, range_comp, hparam, ← hcl, image_closure_of_isCompact (hcl ▸ isCompact_Icc) hcont,
     heq.image_eq]
 
 end Path

--- a/TauCeti/Topology/Path/ExtendIoo.lean
+++ b/TauCeti/Topology/Path/ExtendIoo.lean
@@ -45,16 +45,18 @@ is injective on the interior, and that interior stays inside a set to which neit
 belongs, then the only repetition left is between the two endpoints. That is the statement "the
 path is a simple arc, except that it may be a loop".
 
-It is stated for a bare function `unitInterval → X` satisfying the parametrisation formula, rather
-than for `TauCeti.Path.ofContinuousOnIoo` itself, because a consumer typically receives its path
-from an existential and knows only the formula. Injectivity on the interior is left to the call
-site, being the injectivity of `g` composed with that of `AffineMap.lineMap a b`.
+It is stated for a bare function `unitInterval → X`, with no hypothesis relating it to `g` or to
+the extension, rather than for `TauCeti.Path.ofContinuousOnIoo` itself: a consumer typically
+receives its path from an existential and knows only a parametrisation formula for it, which it
+uses to establish the membership and injectivity hypotheses; a `Path` specializes through its
+coercion. Injectivity on the interior is likewise left to the call site, being the injectivity of
+`g` composed with that of `AffineMap.lineMap a b`.
 
 ## Main declarations
 
 * `TauCeti.extendIoo` — a function on `Ioo a b`, extended across both ends by prescribed values,
   with `TauCeti.extendIoo_apply_of_mem_Ioo`, `TauCeti.extendIoo_apply_of_le_left` and
-  `TauCeti.extendIoo_apply_of_right_le` computing it everywhere, and
+  `TauCeti.extendIoo_apply_of_left_lt_of_right_le` computing it at every point, and
   `TauCeti.continuousOn_Icc_extendIoo`, its continuity on `Icc a b`.
 * `TauCeti.Path.ofContinuousOnIoo` — the path traced by a function continuous on `Ioo a b` with a
   limit at each end, from the limit at `a` to the limit at `b`.
@@ -136,7 +138,10 @@ The two outer branches run over the whole of `Iic a` and `Ici b`, rather than ov
 alone, so that the definition computes everywhere and carries no side condition. The
 nondegeneracy `a < b` is not part of the definition, and is needed for the right-hand branch only:
 if instead `b ≤ a`, the interval is empty and the extension is `u` on `Iic a` and `v` on `Ioi a`,
-so that `b` itself is sent to `u`.
+so that `b` itself is sent to `u`. The value is therefore computed at every point of `α`,
+degenerate intervals included, by `TauCeti.extendIoo_apply_of_mem_Ioo`,
+`TauCeti.extendIoo_apply_of_le_left` and `TauCeti.extendIoo_apply_of_left_lt_of_right_le`, whose
+hypotheses are exactly the three branch conditions.
 
 Mathlib's `extendFrom` instead *recovers* the end values as limits, which is why its continuity
 theorem `continuousOn_Icc_extendFrom_Ioo` asks for a regular codomain and its identification
@@ -155,11 +160,14 @@ theorem extendIoo_apply_of_mem_Ioo (hx : x ∈ Ioo a b) : extendIoo a b u v g x 
 theorem extendIoo_apply_of_le_left (hx : x ≤ a) : extendIoo a b u v g x = u := by
   simp [extendIoo, hx]
 
-/-- At and above the right end the extension takes the prescribed value `v`, the interval being
-nondegenerate. -/
+/-- Above the left end and at or above the right end the extension takes the prescribed value `v`.
+These are exactly the conditions of the second branch, so together with
+`TauCeti.extendIoo_apply_of_mem_Ioo` and `TauCeti.extendIoo_apply_of_le_left` this computes the
+extension at every point, degenerate intervals included. -/
 @[simp]
-theorem extendIoo_apply_of_right_le (hab : a < b) (hx : b ≤ x) : extendIoo a b u v g x = v := by
-  simp [extendIoo, (hab.trans_le hx).not_ge, hx]
+theorem extendIoo_apply_of_left_lt_of_right_le (hax : a < x) (hx : b ≤ x) :
+    extendIoo a b u v g x = v := by
+  simp [extendIoo, hax.not_ge, hx]
 
 /-- **A function continuous on an open interval and converging at both ends extends continuously
 to the closed interval.** The extension is `TauCeti.extendIoo` by the two limits; being handed
@@ -179,7 +187,8 @@ theorem continuousOn_Icc_extendIoo [TopologicalSpace α] [OrderClosedTopology α
     rw [← Iio_insert, continuousWithinAt_insert_self]
     have heq : g =ᶠ[𝓝[<] b] extendIoo a b u v g := by
       filter_upwards [Ioo_mem_nhdsLT hab] with y hy using (extendIoo_apply_of_mem_Ioo hy).symm
-    simpa only [ContinuousWithinAt, extendIoo_apply_of_right_le hab le_rfl] using hv.congr' heq
+    simpa only [ContinuousWithinAt, extendIoo_apply_of_left_lt_of_right_le hab le_rfl] using
+      hv.congr' heq
   intro x hx
   rcases eq_endpoints_or_mem_Ioo_of_mem_Icc hx with rfl | rfl | hx
   · exact hleft


### PR DESCRIPTION
This PR extracts the complex-analysis-free half of `TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean` into a new general module, `TauCeti/Topology/Path/ExtendIoo.lean`. That file built its image-crosscut path by hand — a continuous extension to close up the arc, `Path.segment` pushed forward with `Path.map'` to traverse it, and the affine reparametrisation `AffineMap.lineMap a b : [0, 1] → [a, b]`, the endpoint identification and the simple-arc criterion all inlined as private lemmas of a complex-analysis file. None of that mentions holomorphy, or `ℂ`, or even a metric.

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"path-ofcontinuousonioo"}-->

The new module names the construction: `TauCeti.Path.ofContinuousOnIoo` turns a function `g : ℝ → X` continuous on `Ioo a b` and converging at each end into an honest `Path` between its two limits, with the characteristic API a consumer needs — `ofContinuousOnIoo_apply`, `ofContinuousOnIoo_apply_of_mem_Ioo` (in the interior the path is `g` itself, along `AffineMap.lineMap a b`), and `range_ofContinuousOnIoo` (the range is `closure (g '' Ioo a b)`, so the closure of a curve given on an open interval and converging at both ends is path-connected, the endpoints in general not being values of `g`). Whether such a path is simple is a matter of `g` and of the endpoints rather than of the extension, so the one step of that argument which is not a plain composition is kept in the reparametrisation-only form, with no topology on `X` at all: `eq_or_eq_endpoints_of_notMem_of_forall_mem_Ioo`, which runs on Mathlib's trichotomy `Set.eq_endpoints_or_mem_Ioo_of_mem_Icc` read on the unit interval, and which keeps the name and the statement it had as a private lemma. Injectivity on the interior and the containment of the interior are left to the call site, being `Set.InjOn`/`Set.MapsTo` composed with `AffineMap.lineMap_injective` and `lineMap_mem_openSegment`. The two `Crosscut/Path.lean` helpers that were specialized to `circleMap` — `exists_continuousOn_closure_eqOn_comp_circleMap` and `injOn_Ioo_of_eq_circleMap_lineMap` — disappear.

The extension itself is `TauCeti.extendIoo a b u v g`, which agrees with `g` on `Ioo a b`, takes the *prescribed* value `u` on `Iic a` and, when `a < b`, the value `v` on `Ici b` — computed at every point by `extendIoo_apply_of_mem_Ioo`, `extendIoo_apply_of_le_left` and
`extendIoo_apply_of_left_lt_of_right_le` (whose hypotheses are exactly the three branch conditions,
so degenerate intervals are covered too) — together with `TauCeti.continuousOn_Icc_extendIoo`, its continuity on `Icc a b`. The extension and its continuity are stated over an arbitrary `[LinearOrder α]` with `[OrderClosedTopology α]`; only the path is real, `AffineMap.lineMap` and `unitInterval` being so. Mathlib's `extendFrom` would instead recover the two end values as limits, which is why `continuousOn_Icc_extendFrom_Ioo` asks for a regular codomain and `eq_lim_at_left_extendFrom_Ioo` for a Hausdorff one; since `ofContinuousOnIoo` is handed both limits, nothing has to be recovered, and the path and its value lemmas ask nothing of `X` beyond a topology. Only `range_ofContinuousOnIoo`, where the image of a compact set must be closed, keeps `[T2Space X]`.

`Crosscut/Path.lean` keeps both public theorems verbatim and loses 136 lines: it now spends its holomorphy exactly where holomorphy is needed, on producing the two endpoint limits of the image crosscut from `TauCeti.exists_tendsto_nhdsWithin_ball_inter_sphere`, and hands them to the general construction. The bookkeeping that took the extension to a `Path` and back — the uniqueness argument identifying the two endpoint values with the endpoint limits, the `Path.segment`/`Path.map'` coercion unfolding, and the compactness computation of the range — is gone from it entirely, since `ofContinuousOnIoo` is stated in terms of the limits themselves.

This is a refactor of already-merged material, so it makes no fresh roadmap claim; the material it reworks serves layer **L5** (Carathéodory boundary correspondence) of `TauCetiRoadmap/ConformalMapping/README.md`, whose narrative names the Jordan-domain case of the boundary correspondence as its milestone, and the extracted construction is the topological input by which a finite-length image crosscut becomes a parametrised curve there. Nothing new mathematically is added: every statement below the extraction already existed on `main`, up to the removal of the `circleMap` specialization, the generalisation of the codomain from `ℂ` to a topological space, and of the extension's domain from `ℝ` to a linearly ordered space. No Mathlib source is vendored; the construction consumes `Path`, `Set.image_eq_range` and `segment_eq_image_lineMap`, and the order-topology gluing API (`Ioo_mem_nhdsGT`, `continuousWithinAt_insert_self`).

Roadmap: ConformalMapping

`lake build`, `lake exe axioms` (27362 declarations audited, allowlist only) and `scripts/lint-env.sh` are green.

🤖 Prepared with Claude Code


