### PR TITLE
feat: prove group manifold points are interior

### DIFF
--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -5,21 +5,23 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.Geometry.Manifold.Algebra.LieGroup
-public import Mathlib.Geometry.Manifold.Algebra.SMul
+import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
 
 /-!
 # Interior points of Lie groups
 
-Every point of a positive-smoothness Lie group manifold is an interior point. It suffices to find
-one interior point in a chart and transport it to the identity by smooth left multiplication.
+Every point of a positive-smoothness group manifold with smooth multiplication is an interior
+point. It suffices to find one interior point in a chart and transport it to the desired point by
+smooth left multiplication.
 
 This supplies a prerequisite for Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
 ## Main results
 
-* `LieGroup.isInteriorPoint_one`: the identity of a Lie group is an interior point.
+* `ContMDiffMul.isInteriorPoint`: every point of a group manifold with smooth multiplication is an
+  interior point.
 
 ## References
 
@@ -36,9 +38,10 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
 
-/-- The identity of a positive-smoothness Lie group manifold is an interior point. -/
-theorem LieGroup.isInteriorPoint_one {n : WithTop ℕ∞} [LieGroup I n G] (hn : n ≠ 0) :
-    I.IsInteriorPoint (1 : G) := by
+/-- Every point of a positive-smoothness group manifold with smooth multiplication is an interior
+point. -/
+theorem ContMDiffMul.isInteriorPoint {n : WithTop ℕ∞} [ContMDiffMul I n G] (hn : n ≠ 0)
+    (g : G) : I.IsInteriorPoint g := by
   obtain ⟨y, hy⟩ := interior_extChartAt_target_nonempty I (1 : G)
   let x := (extChartAt I (1 : G)).symm y
   have hy_target : y ∈ (extChartAt I (1 : G)).target := interior_subset hy
@@ -47,8 +50,9 @@ theorem LieGroup.isInteriorPoint_one {n : WithTop ℕ∞} [LieGroup I n G] (hn :
     exact (extChartAt I (1 : G)).map_target hy_target
   have hx : I.IsInteriorPoint x := by
     rw [I.isInteriorPoint_iff_of_mem_atlas hn (chart_mem_atlas H (1 : G)) hx_source]
+    -- `extChartAt` is definitionally the extension of `chartAt` used by the preceding theorem.
     change extChartAt I (1 : G) x ∈ interior (extChartAt I (1 : G)).target
     rwa [(extChartAt I (1 : G)).right_inv hy_target]
   have htranslate :=
-    ((Diffeomorph.smul I I n x⁻¹).isLocalDiffeomorph x).isInteriorPoint_iff hn |>.mp hx
+    ((Diffeomorph.smul I I n (g * x⁻¹)).isLocalDiffeomorph x).isInteriorPoint_iff hn |>.mp hx
   simpa [x] using htranslate

--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -4,24 +4,24 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import Mathlib.Geometry.Manifold.Algebra.Monoid
 import Mathlib.Geometry.Manifold.Algebra.SMul
 public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
 
 /-!
-# Interior points of Lie groups
+# Interior points of group manifolds
 
-Every point of a positive-smoothness group manifold with smooth multiplication is an interior
-point. It suffices to find one interior point in a chart and transport it to the desired point by
-smooth left multiplication.
+Every point of a group manifold whose multiplication is `C^n`, for `n ≠ 0`, is an interior point;
+smooth inversion is not required. It suffices to find one interior point in a chart and transport
+it to the desired point by `C^n` left multiplication.
 
 This supplies a prerequisite for Deliverable A, Layer 1 of
 `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
 
 ## Main results
 
-* `ContMDiffMul.isInteriorPoint`: every point of a group manifold with smooth multiplication is an
-  interior point.
+* `ContMDiffMul.isInteriorPoint`: every point of a group manifold with `C^n` multiplication, for
+  `n ≠ 0`, is an interior point.
 
 ## References
 
@@ -38,8 +38,7 @@ variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
   {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
   {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
 
-/-- Every point of a positive-smoothness group manifold with smooth multiplication is an interior
-point. -/
+/-- Every point of a group manifold with `C^n` multiplication, for `n ≠ 0`, is an interior point. -/
 theorem ContMDiffMul.isInteriorPoint {n : WithTop ℕ∞} [ContMDiffMul I n G] (hn : n ≠ 0)
     (g : G) : I.IsInteriorPoint g := by
   obtain ⟨y, hy⟩ := interior_extChartAt_target_nonempty I (1 : G)

--- a/TauCeti/Geometry/Lie/Interior.lean
+++ b/TauCeti/Geometry/Lie/Interior.lean
@@ -1,0 +1,54 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Geometry.Manifold.Algebra.LieGroup
+public import Mathlib.Geometry.Manifold.Algebra.SMul
+public import Mathlib.Geometry.Manifold.IsManifold.InteriorBoundary
+
+/-!
+# Interior points of Lie groups
+
+Every point of a positive-smoothness Lie group manifold is an interior point. It suffices to find
+one interior point in a chart and transport it to the identity by smooth left multiplication.
+
+This supplies a prerequisite for Deliverable A, Layer 1 of
+`TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`.
+
+## Main results
+
+* `LieGroup.isInteriorPoint_one`: the identity of a Lie group is an interior point.
+
+## References
+
+* [Lie groups and the Lie algebra correspondence roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md),
+  Deliverable A, Layer 1, "The group adjoint".
+-/
+
+public section
+
+open ModelWithCorners
+
+variable {𝕜 : Type*} [NontriviallyNormedField 𝕜]
+  {E : Type*} [NormedAddCommGroup E] [NormedSpace 𝕜 E]
+  {H : Type*} [TopologicalSpace H] {I : ModelWithCorners 𝕜 E H}
+  {G : Type*} [TopologicalSpace G] [ChartedSpace H G] [Group G]
+
+/-- The identity of a positive-smoothness Lie group manifold is an interior point. -/
+theorem LieGroup.isInteriorPoint_one {n : WithTop ℕ∞} [LieGroup I n G] (hn : n ≠ 0) :
+    I.IsInteriorPoint (1 : G) := by
+  obtain ⟨y, hy⟩ := interior_extChartAt_target_nonempty I (1 : G)
+  let x := (extChartAt I (1 : G)).symm y
+  have hy_target : y ∈ (extChartAt I (1 : G)).target := interior_subset hy
+  have hx_source : x ∈ (chartAt H (1 : G)).source := by
+    rw [← extChartAt_source I (1 : G)]
+    exact (extChartAt I (1 : G)).map_target hy_target
+  have hx : I.IsInteriorPoint x := by
+    rw [I.isInteriorPoint_iff_of_mem_atlas hn (chart_mem_atlas H (1 : G)) hx_source]
+    change extChartAt I (1 : G) x ∈ interior (extChartAt I (1 : G)).target
+    rwa [(extChartAt I (1 : G)).right_inv hy_target]
+  have htranslate :=
+    ((Diffeomorph.smul I I n x⁻¹).isLocalDiffeomorph x).isInteriorPoint_iff hn |>.mp hx
+  simpa [x] using htranslate


### PR DESCRIPTION
## Goal

Supply the missing manifold prerequisite for Deliverable A, Layer 1 by proving that every point of a positive-smoothness group manifold with smooth multiplication is interior, without assuming smooth inversion or the whole manifold is boundaryless.

## Why this works

A chart around the identity has a nonempty interior in its target, so its inverse produces some interior point of the group manifold. Smooth left multiplication is a local diffeomorphism; translating by `g * x⁻¹` sends the chosen interior point `x` to any requested point `g`.

The exact roadmap target is [TauCetiRoadmap/RepresentationTheory/LieGroups/README.md, Deliverable A, Layer 1, "The group adjoint"](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad). This theorem removes the stronger `BoundarylessManifold` assumption from the roadmap-facing `Ad` construction.

## Validation

`lake build TauCeti.Geometry.Lie.Interior`

Roadmap: RepresentationTheory