### PR TITLE
feat(EllipticCurve): Galois descent for changes of variables and for affine points

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
@@ -12,13 +12,13 @@ public import TauCeti.FieldTheory.Galois.Basic
 
 Let `L/K` be a separable quadratic extension. Data attached to a Weierstrass curve over `L` and
 fixed by the nontrivial `σ ∈ Gal(L/K)` descends to `K`, because an element of `L` fixed by `σ` is
-already in `K` (`Algebra.IsQuadraticExtension.mem_range_algebraMap_of_apply_eq`). Two instances
-are proved here:
+already in `K` (`Algebra.IsQuadraticExtension.mem_range_algebraMap_of_apply_eq`). Two descent
+results are proved here:
 
-* `WeierstrassCurve.exists_baseChange_eq_of_map_eq`: an admissible change of variables over `L`
-  fixed by `σ` is the base change of one over `K`;
-* `WeierstrassCurve.exists_baseChange_point_eq_of_map_eq`: an affine point of `W` over `L` fixed
-  by `σ` is the base change of a point over `K`.
+* `WeierstrassCurve.VariableChange.exists_baseChange_eq_of_map_eq`: an admissible change of
+  variables over `L` fixed by `σ` is the base change of one over `K`;
+* `WeierstrassCurve.Affine.Point.exists_baseChange_eq_of_map_eq`: an affine point of `W` over
+  `L` fixed by `σ` is the base change of a point over `K`.
 
 Both are stated with `σ` an explicit nontrivial automorphism rather than a quantifier over
 `Gal(L/K)`: for a quadratic extension the two are equivalent, and the consumers have a
@@ -48,6 +48,8 @@ open scoped WeierstrassCurve.Affine
 variable {K : Type*} [Field K] (L : Type*) [Field L] [Algebra K L]
 variable [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
 
+namespace VariableChange
+
 /-- **Galois descent for changes of variables.** A change of variables over `L` fixed by the
 nontrivial `σ ∈ Gal(L/K)` has all its coefficients in `K`, so it is the base change of a change
 of variables over `K`. -/
@@ -72,10 +74,14 @@ lemma exists_baseChange_eq_of_map_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {C : 
   refine ⟨⟨Units.mk0 uK huK', rK, sK, tK⟩, VariableChange.ext (Units.ext ?_) hrK hsK htK⟩
   simpa [VariableChange.baseChange, VariableChange.map] using huK
 
+end VariableChange
+
+namespace Affine.Point
+
 /-- **Galois descent for points.** A point of `W(L)` fixed by the nontrivial `σ ∈ Gal(L/K)`
 (hence, as `[L : K] = 2`, by all of `Gal(L/K)`) is the base change of a point of `W(K)`: its
 coordinates, being fixed by `σ`, lie in `K`. -/
-theorem exists_baseChange_point_eq_of_map_eq [DecidableEq K] [DecidableEq L]
+theorem exists_baseChange_eq_of_map_eq [DecidableEq K] [DecidableEq L]
     {W : WeierstrassCurve K} {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {R : (W⁄L).Point}
     (hR : Affine.Point.map σ.toAlgHom R = R) :
     ∃ Q : (W⁄K).Point, Affine.Point.baseChange K L Q = R := by
@@ -87,6 +93,8 @@ theorem exists_baseChange_point_eq_of_map_eq [DecidableEq K] [DecidableEq L]
     obtain ⟨y₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hy
     exact ⟨.some x₀ y₀ ((Affine.baseChange_nonsingular W
       (f := Algebra.ofId K L) (FaithfulSMul.algebraMap_injective K L) x₀ y₀).mp h), rfl⟩
+
+end Affine.Point
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
@@ -1,0 +1,93 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+public import TauCeti.FieldTheory.Galois.Basic
+
+/-!
+# Galois descent for Weierstrass curve data
+
+Let `L/K` be a separable quadratic extension. Data attached to a Weierstrass curve over `L` and
+fixed by the nontrivial `σ ∈ Gal(L/K)` descends to `K`, because an element of `L` fixed by `σ` is
+already in `K` (`Algebra.IsQuadraticExtension.mem_range_algebraMap_of_apply_eq`). Two instances
+are proved here:
+
+* `WeierstrassCurve.exists_baseChange_eq_of_map_eq`: an admissible change of variables over `L`
+  fixed by `σ` is the base change of one over `K`;
+* `WeierstrassCurve.exists_baseChange_point_eq_of_map_eq`: an affine point of `W` over `L` fixed
+  by `σ` is the base change of a point over `K`.
+
+Both are stated with `σ` an explicit nontrivial automorphism rather than a quantifier over
+`Gal(L/K)`: for a quadratic extension the two are equivalent, and the consumers have a
+distinguished `σ` in hand.
+
+These are the descent steps of the quadratic-twist layer of
+`TauCetiRoadmap/EllipticCurves/README.md` (§Layer 5): the twist point isomorphism and the
+classification of twists both descend `L`-data fixed by the Galois action to `K`-data.
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
+`FLT/Mathlib/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean` at the roadmap's pin
+`bc2fe8ff7396`, FLT PR #1088, Apache 2.0). That file's own header reads
+`Authors: Kevin Buzzard, Michael Stoll, Claude`; following this repository's convention for
+adapted material, the upstream authorship is credited here rather than in the copyright header.
+Ported against Mathlib's own `VariableChange.baseChange` and `Affine.Point.baseChange` rather
+than the source's complements to them.
+-/
+
+public section
+
+open Algebra.IsQuadraticExtension
+
+namespace WeierstrassCurve
+
+open scoped WeierstrassCurve.Affine
+
+variable {K : Type*} [Field K] (L : Type*) [Field L] [Algebra K L]
+variable [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
+
+/-- **Galois descent for changes of variables.** A change of variables over `L` fixed by the
+nontrivial `σ ∈ Gal(L/K)` has all its coefficients in `K`, so it is the base change of a change
+of variables over `K`. -/
+lemma exists_baseChange_eq_of_map_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {C : VariableChange L}
+    (hCinv : C.map σ.toAlgHom.toRingHom = C) : ∃ CK : VariableChange K, CK.baseChange L = C := by
+  have hap : ⇑σ.toAlgHom.toRingHom = ⇑σ := rfl
+  have mem : ∀ x : L, σ x = x → x ∈ Set.range (algebraMap K L) :=
+    fun x hx ↦ mem_range_algebraMap_of_apply_eq K L hσ hx
+  have hu : σ (C.u : L) = (C.u : L) := by
+    simpa [VariableChange.map, Units.coe_map, hap] using congrArg (fun D ↦ (D.u : L)) hCinv
+  have hr : σ C.r = C.r := by
+    simpa [VariableChange.map, hap] using congrArg VariableChange.r hCinv
+  have hs : σ C.s = C.s := by
+    simpa [VariableChange.map, hap] using congrArg VariableChange.s hCinv
+  have ht : σ C.t = C.t := by
+    simpa [VariableChange.map, hap] using congrArg VariableChange.t hCinv
+  obtain ⟨uK, huK⟩ := mem _ hu
+  obtain ⟨rK, hrK⟩ := mem _ hr
+  obtain ⟨sK, hsK⟩ := mem _ hs
+  obtain ⟨tK, htK⟩ := mem _ ht
+  have huK' : uK ≠ 0 := by rintro rfl; rw [map_zero] at huK; exact C.u.ne_zero huK.symm
+  refine ⟨⟨Units.mk0 uK huK', rK, sK, tK⟩, VariableChange.ext (Units.ext ?_) hrK hsK htK⟩
+  simpa [VariableChange.baseChange, VariableChange.map] using huK
+
+/-- **Galois descent for points.** A point of `W(L)` fixed by the nontrivial `σ ∈ Gal(L/K)`
+(hence, as `[L : K] = 2`, by all of `Gal(L/K)`) is the base change of a point of `W(K)`: its
+coordinates, being fixed by `σ`, lie in `K`. -/
+theorem exists_baseChange_point_eq_of_map_eq [DecidableEq K] [DecidableEq L]
+    {W : WeierstrassCurve K} {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {R : (W⁄L).Point}
+    (hR : Affine.Point.map σ.toAlgHom R = R) :
+    ∃ Q : (W⁄K).Point, Affine.Point.baseChange K L Q = R := by
+  rcases R with _ | ⟨x, y, h⟩
+  · exact ⟨0, rfl⟩
+  · rw [Affine.Point.map_some] at hR
+    injection hR with hx hy
+    obtain ⟨x₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hx
+    obtain ⟨y₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hy
+    exact ⟨.some x₀ y₀ ((Affine.baseChange_nonsingular W
+      (f := Algebra.ofId K L) (FaithfulSMul.algebraMap_injective K L) x₀ y₀).mp h), rfl⟩
+
+end WeierstrassCurve
+
+end

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
@@ -55,24 +55,23 @@ nontrivial `σ ∈ Gal(L/K)` has all its coefficients in `K`, so it is the base 
 of variables over `K`. -/
 lemma exists_baseChange_eq_of_map_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {C : VariableChange L}
     (hCinv : C.map σ.toAlgHom.toRingHom = C) : ∃ CK : VariableChange K, CK.baseChange L = C := by
-  have hap : ⇑σ.toAlgHom.toRingHom = ⇑σ := AlgEquiv.coe_toAlgHom σ
   have mem : ∀ x : L, σ x = x → x ∈ Set.range (algebraMap K L) :=
     fun x hx ↦ mem_range_algebraMap_of_apply_eq K L hσ hx
   have hu : σ (C.u : L) = (C.u : L) := by
-    simpa [VariableChange.map, Units.coe_map, hap] using congrArg (fun D ↦ (D.u : L)) hCinv
+    simpa [Units.coe_map] using congrArg (fun D ↦ (D.u : L)) hCinv
   have hr : σ C.r = C.r := by
-    simpa [VariableChange.map, hap] using congrArg VariableChange.r hCinv
+    simpa using congrArg VariableChange.r hCinv
   have hs : σ C.s = C.s := by
-    simpa [VariableChange.map, hap] using congrArg VariableChange.s hCinv
+    simpa using congrArg VariableChange.s hCinv
   have ht : σ C.t = C.t := by
-    simpa [VariableChange.map, hap] using congrArg VariableChange.t hCinv
+    simpa using congrArg VariableChange.t hCinv
   obtain ⟨uK, huK⟩ := mem _ hu
   obtain ⟨rK, hrK⟩ := mem _ hr
   obtain ⟨sK, hsK⟩ := mem _ hs
   obtain ⟨tK, htK⟩ := mem _ ht
   have huK' : uK ≠ 0 := by rintro rfl; rw [map_zero] at huK; exact C.u.ne_zero huK.symm
   refine ⟨⟨Units.mk0 uK huK', rK, sK, tK⟩, VariableChange.ext (Units.ext ?_) hrK hsK htK⟩
-  simpa [VariableChange.baseChange, VariableChange.map] using huK
+  simpa [VariableChange.baseChange] using huK
 
 end VariableChange
 
@@ -91,6 +90,8 @@ theorem exists_baseChange_eq_of_map_eq [DecidableEq K] [DecidableEq L]
     injection hR with hx hy
     obtain ⟨x₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hx
     obtain ⟨y₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hy
+    -- `Algebra.ofId K L` and `algebraMap K L` are the same map; make the bridge explicit.
+    simp only [← Algebra.ofId_apply] at h ⊢
     exact ⟨.some x₀ y₀ ((Affine.baseChange_nonsingular W
       (f := Algebra.ofId K L) (FaithfulSMul.algebraMap_injective K L) x₀ y₀).mp h),
       Affine.Point.map_some _ _⟩

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean
@@ -55,7 +55,7 @@ nontrivial `σ ∈ Gal(L/K)` has all its coefficients in `K`, so it is the base 
 of variables over `K`. -/
 lemma exists_baseChange_eq_of_map_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {C : VariableChange L}
     (hCinv : C.map σ.toAlgHom.toRingHom = C) : ∃ CK : VariableChange K, CK.baseChange L = C := by
-  have hap : ⇑σ.toAlgHom.toRingHom = ⇑σ := rfl
+  have hap : ⇑σ.toAlgHom.toRingHom = ⇑σ := AlgEquiv.coe_toAlgHom σ
   have mem : ∀ x : L, σ x = x → x ∈ Set.range (algebraMap K L) :=
     fun x hx ↦ mem_range_algebraMap_of_apply_eq K L hσ hx
   have hu : σ (C.u : L) = (C.u : L) := by
@@ -86,13 +86,14 @@ theorem exists_baseChange_eq_of_map_eq [DecidableEq K] [DecidableEq L]
     (hR : Affine.Point.map σ.toAlgHom R = R) :
     ∃ Q : (W⁄K).Point, Affine.Point.baseChange K L Q = R := by
   rcases R with _ | ⟨x, y, h⟩
-  · exact ⟨0, rfl⟩
+  · exact ⟨0, Affine.Point.map_zero _⟩
   · rw [Affine.Point.map_some] at hR
     injection hR with hx hy
     obtain ⟨x₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hx
     obtain ⟨y₀, rfl⟩ := mem_range_algebraMap_of_apply_eq K L hσ hy
     exact ⟨.some x₀ y₀ ((Affine.baseChange_nonsingular W
-      (f := Algebra.ofId K L) (FaithfulSMul.algebraMap_injective K L) x₀ y₀).mp h), rfl⟩
+      (f := Algebra.ofId K L) (FaithfulSMul.algebraMap_injective K L) x₀ y₀).mp h),
+      Affine.Point.map_some _ _⟩
 
 end Affine.Point
 

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -1,0 +1,65 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.FieldTheory.Galois.Basic
+
+/-!
+# The Galois theory of separable quadratic extensions
+
+Material complementing `Mathlib/FieldTheory/Galois/Basic.lean` for a separable quadratic
+extension `L/K`: it has exactly two automorphisms, so the identity and any one nontrivial
+automorphism exhaust `Gal(L/K)`, and an element fixed by a nontrivial automorphism lies in the
+base field.
+
+Mathlib already supplies the surrounding structure: `Algebra.IsQuadraticExtension` makes `L/K`
+finite and normal (`Algebra.IsQuadraticExtension.normal`), hence Galois with separability
+(`Algebra.IsQuadraticExtension.isGalois`); `IsGalois.card_aut_eq_finrank` counts the
+automorphisms and `IsGalois.mem_range_algebraMap_iff_fixed` characterises the base field.
+
+These are the descent inputs for the quadratic-twist layer of
+`TauCetiRoadmap/EllipticCurves/README.md` (§Layer 5), consumed by
+`TauCeti/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean`.
+
+Adapted from the FLT project (`ImperialCollegeLondon/FLT`,
+`FLT/Mathlib/FieldTheory/Galois/Basic.lean` at the roadmap's pin `bc2fe8ff7396`, FLT PR #1088,
+Apache 2.0). That file's own header reads `Authors: Kevin Buzzard, Claude`; following this
+repository's convention for adapted material, the upstream authorship is credited here rather
+than in the copyright header. Only the three results the descent file consumes are ported; the
+rest of the source file is deferred to the Tau Ceti PRs that consume it.
+-/
+
+public section
+
+variable (K L : Type*) [Field K] [Field L] [Algebra K L]
+variable [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
+
+namespace Algebra.IsQuadraticExtension
+
+/-- A separable quadratic extension has exactly two automorphisms. -/
+theorem card_algEquiv : Nat.card (L ≃ₐ[K] L) = 2 := by
+  rw [IsGalois.card_aut_eq_finrank]
+  exact finrank_eq_two K L
+
+/-- The only automorphisms of a separable quadratic extension are the identity and any given
+nontrivial automorphism. -/
+theorem algEquiv_eq_one_or_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (φ : L ≃ₐ[K] L) : φ = 1 ∨ φ = σ := by
+  rcases eq_or_ne φ 1 with h1 | h1
+  · exact .inl h1
+  · exact .inr (((Nat.card_eq_two_iff' 1).mp (card_algEquiv K L)).unique h1 hσ)
+
+/-- An element fixed by a nontrivial automorphism — hence, `Gal(L/K)` having order two, by all of
+`Gal(L/K)` — lies in the base field. -/
+theorem mem_range_algebraMap_of_apply_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) {x : L} (hx : σ x = x) :
+    x ∈ Set.range (algebraMap K L) := by
+  rw [IsGalois.mem_range_algebraMap_iff_fixed]
+  intro φ
+  rcases algEquiv_eq_one_or_eq K L hσ φ with rfl | rfl
+  · exact AlgEquiv.one_apply x
+  · exact hx
+
+end Algebra.IsQuadraticExtension
+
+end

--- a/TauCeti/FieldTheory/Galois/Basic.lean
+++ b/TauCeti/FieldTheory/Galois/Basic.lean
@@ -39,7 +39,7 @@ variable [Algebra.IsQuadraticExtension K L] [Algebra.IsSeparable K L]
 namespace Algebra.IsQuadraticExtension
 
 /-- A separable quadratic extension has exactly two automorphisms. -/
-theorem card_algEquiv : Nat.card (L ≃ₐ[K] L) = 2 := by
+theorem card_algEquiv_eq_two : Nat.card (L ≃ₐ[K] L) = 2 := by
   rw [IsGalois.card_aut_eq_finrank]
   exact finrank_eq_two K L
 
@@ -48,7 +48,7 @@ nontrivial automorphism. -/
 theorem algEquiv_eq_one_or_eq {σ : L ≃ₐ[K] L} (hσ : σ ≠ 1) (φ : L ≃ₐ[K] L) : φ = 1 ∨ φ = σ := by
   rcases eq_or_ne φ 1 with h1 | h1
   · exact .inl h1
-  · exact .inr (((Nat.card_eq_two_iff' 1).mp (card_algEquiv K L)).unique h1 hσ)
+  · exact .inr (((Nat.card_eq_two_iff' 1).mp (card_algEquiv_eq_two K L)).unique h1 hσ)
 
 /-- An element fixed by a nontrivial automorphism — hence, `Gal(L/K)` having order two, by all of
 `Gal(L/K)` — lies in the base field. -/


### PR DESCRIPTION
For a separable quadratic extension `L/K`, data attached to a Weierstrass curve over `L` and fixed by the nontrivial `σ ∈ Gal(L/K)` descends to `K`. Two instances: `WeierstrassCurve.exists_baseChange_eq_of_map_eq`, an admissible change of variables over `L` fixed by `σ` is the base change of one over `K`; and `WeierstrassCurve.exists_baseChange_point_eq_of_map_eq`, an affine point of `W` over `L` fixed by `σ` is the base change of a point over `K`. Both rest on the fact that an element of `L` fixed by a nontrivial automorphism lies in `K`, which holds because a separable quadratic extension has exactly two automorphisms.

That Galois input goes in `TauCeti/FieldTheory/Galois/Basic.lean`, complementing the Mathlib module of the same name: `Algebra.IsQuadraticExtension.card_algEquiv`, `.algEquiv_eq_one_or_eq`, and `.mem_range_algebraMap_of_apply_eq`. Only these three are ported — the rest of the source file (the trace/norm-via-σ lemmas and the quadratic character) is deferred to the PRs that consume it, matching the deferred-with-consumers policy of the other elliptic ports.

Mathlib supplies everything else: `Algebra.IsQuadraticExtension` and its `normal`/`isGalois` instances, `IsGalois.card_aut_eq_finrank`, `IsGalois.mem_range_algebraMap_iff_fixed`, `VariableChange.map`/`VariableChange.baseChange`, and `Affine.Point.map`/`Affine.Point.baseChange`/`Affine.baseChange_nonsingular`. The port is written against those rather than against the source's own complements to them, which is why this PR is independent of the other in-flight elliptic PRs (#2247, #2248, #2254) and does not import them.

This advances `TauCetiRoadmap/EllipticCurves` §Layer 5 (twists): the twist point isomorphism `quadraticTwistPointEquiv` and the classification of twists both work by descending `L`-data fixed by the Galois action to `K`-data, and these are exactly those two descent steps.

Adapted from the FLT project (`ImperialCollegeLondon/FLT` at the roadmap's pin `bc2fe8ff7396`, FLT PR #1088, Apache 2.0): `FLT/Mathlib/AlgebraicGeometry/EllipticCurve/GaloisDescent.lean`, whose header reads `Authors: Kevin Buzzard, Michael Stoll, Claude`, and `FLT/Mathlib/FieldTheory/Galois/Basic.lean`, whose header reads `Authors: Kevin Buzzard, Claude`. Neither file has been touched in FLT since `bc2fe8ff7396`, so the pin and the working clone (`d18b563029f3`, a later Mathlib bump) agree on them verbatim. Following this repository's convention for adapted material, upstream authorship is credited in each module docstring. Changes in porting: Tau Ceti headers, definition bodies left unexposed, and the retargeting onto Mathlib's own base-change API described above.

Roadmap: EllipticCurves

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"galoisdescent"}-->

🤖 Prepared with Claude Code (Claude Opus 5)


One note for reviewers, contesting a generality finding. The dry-run asked to drop `[DecidableEq K] [DecidableEq L]` from `Affine.Point.exists_baseChange_eq_of_map_eq` and "add `classical` inside the proof to supply the instances required by the affine-point API". That is not possible here: the instances are required by the **statement**, not the proof. `Affine.Point.baseChange K L Q` and `(W⁄L).Point` both mention Mathlib's affine point group, whose `AddCommGroup` instance and `Point.map`/`Point.baseChange` are declared under `variable [DecidableEq F] [DecidableEq K] [DecidableEq L]` (`Mathlib/AlgebraicGeometry/EllipticCurve/Affine/Point.lean:656`). Removing them from the signature and adding `classical` to the proof gives, verbatim:

```
error: GaloisDescent.lean:86:10: failed to synthesize instance of type class DecidableEq L
error: GaloisDescent.lean:87:23: failed to synthesize instance of type class DecidableEq K
```

— at the hypothesis and the conclusion, before the tactic block is ever entered. Every Mathlib lemma about this API carries the same assumptions for the same reason, so the signature here matches its model rather than overstating hypotheses. `VariableChange.exists_baseChange_eq_of_map_eq`, which does not mention the point group, correctly carries neither.
