### PR TITLE
feat: add the higher-dimensional Newtonian kernel

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/NormPow.lean
+++ b/TauCeti/Analysis/InnerProductSpace/NormPow.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Analysis.InnerProductSpace.NormPow
+public import TauCeti.Analysis.InnerProductSpace.Laplacian.Basic
+
+/-!
+# Real powers of the norm away from the origin
+
+Mathlib computes the derivative of `x ↦ ‖x‖ ^ p` on the whole inner-product space when
+`1 < p`.  Negative powers, which occur in the Newtonian kernel, are smooth only away from the
+origin.  This file supplies the corresponding local derivative, Hessian, and Laplacian formulas
+under the explicit hypothesis `x ≠ 0`.
+
+The first derivative proof adapts Mathlib's `hasFDerivAt_norm_rpow`, retaining its norm-square
+chain-rule argument while replacing the global exponent hypothesis with the local condition
+`x ≠ 0`.
+
+## Main declarations
+
+* `hasFDerivAt_norm_rpow_of_ne`: the derivative of an arbitrary real power away from zero.
+* `iteratedFDeriv_two_norm_rpow_apply`: the Hessian of an arbitrary real power away from zero.
+* `laplacian_norm_rpow_of_ne`: the radial Laplacian formula
+  `Δ ‖x‖^p = p (p + dim E - 2) ‖x‖^(p-2)` away from zero.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open Filter InnerProductSpace Laplacian Topology
+open scoped RealInnerProductSpace
+
+variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
+
+/-- Away from the origin, the derivative of `x ↦ ‖x‖ ^ p` is
+`p ‖x‖ ^ (p - 2) ⟨x, ·⟩`.  Unlike Mathlib's `hasFDerivAt_norm_rpow`, this local form
+allows every real exponent. -/
+theorem hasFDerivAt_norm_rpow_of_ne (p : ℝ) {x : E} (hx : x ≠ 0) :
+    HasFDerivAt (fun y : E ↦ ‖y‖ ^ p) ((p * ‖x‖ ^ (p - 2)) • innerSL ℝ x) x := by
+  apply HasStrictFDerivAt.hasFDerivAt
+  convert (hasStrictFDerivAt_norm_sq x).rpow_const (p := p / 2) (by simp [hx]) using 0
+  simp_rw [← Real.rpow_natCast_mul (norm_nonneg _), ← Nat.cast_smul_eq_nsmul ℝ, smul_smul]
+  ring_nf
+
+/-- The Fréchet derivative of an arbitrary real power of the norm away from the origin. -/
+theorem fderiv_norm_rpow_of_ne (p : ℝ) {x : E} (hx : x ≠ 0) :
+    fderiv ℝ (fun y : E ↦ ‖y‖ ^ p) x = (p * ‖x‖ ^ (p - 2)) • innerSL ℝ x :=
+  (hasFDerivAt_norm_rpow_of_ne p hx).fderiv
+
+/-- The Hessian of `x ↦ ‖x‖ ^ p` away from the origin, evaluated on two directions. -/
+theorem iteratedFDeriv_two_norm_rpow_apply (p : ℝ) {x : E} (hx : x ≠ 0) (v w : E) :
+    iteratedFDeriv ℝ 2 (fun y : E ↦ ‖y‖ ^ p) x ![v, w] =
+      p * (p - 2) * ‖x‖ ^ (p - 4) * ⟪x, v⟫_ℝ * ⟪x, w⟫_ℝ +
+        p * ‖x‖ ^ (p - 2) * ⟪v, w⟫_ℝ := by
+  have hne : ∀ᶠ y in nhds x, y ≠ 0 := eventually_ne_nhds hx
+  have hfd : fderiv ℝ (fun y : E ↦ ‖y‖ ^ p) =ᶠ[nhds x]
+      fun y ↦ (p * ‖y‖ ^ (p - 2)) • innerSL ℝ y := by
+    filter_upwards [hne] with y hy
+    exact fderiv_norm_rpow_of_ne p hy
+  have hc : DifferentiableAt ℝ (fun y : E ↦ p * ‖y‖ ^ (p - 2)) x :=
+    (hasFDerivAt_norm_rpow_of_ne (p - 2) hx).const_mul p |>.differentiableAt
+  have hi : DifferentiableAt ℝ (innerSL ℝ : E → E →L[ℝ] ℝ) x :=
+    (innerSL ℝ).differentiableAt
+  rw [iteratedFDeriv_two_apply, hfd.fderiv_eq, fderiv_fun_smul hc hi]
+  rw [((hasFDerivAt_norm_rpow_of_ne (p - 2) hx).const_mul p).fderiv]
+  rw [(innerSL ℝ : E →L[ℝ] E →L[ℝ] ℝ).fderiv]
+  have hinner : (innerSL ℝ : E →L[ℝ] E →L[ℝ] ℝ) v w = ⟪v, w⟫_ℝ := rfl
+  simp only [Fin.isValue, Matrix.cons_val_zero, add_apply, smul_apply,
+    ContinuousLinearMap.smulRight_apply, coe_innerSL_apply, smul_eq_mul,
+    Matrix.cons_val_one, Matrix.cons_val_fin_one]
+  rw [hinner]
+  ring_nf
+
+variable [FiniteDimensional ℝ E]
+
+/-- The Laplacian of a real power of the norm away from the origin is
+`p (p + dim E - 2) ‖x‖ ^ (p - 2)`. -/
+theorem laplacian_norm_rpow_of_ne (p : ℝ) {x : E} (hx : x ≠ 0) :
+    Δ (fun y : E ↦ ‖y‖ ^ p) x =
+      p * (p + Module.finrank ℝ E - 2) * ‖x‖ ^ (p - 2) := by
+  rw [congrFun (laplacian_eq_iteratedFDeriv_orthonormalBasis
+    (fun y : E ↦ ‖y‖ ^ p) (stdOrthonormalBasis ℝ E)) x]
+  simp_rw [iteratedFDeriv_two_norm_rpow_apply p hx]
+  rw [Finset.sum_add_distrib]
+  have hfirst :
+      ∑ i, p * (p - 2) * ‖x‖ ^ (p - 4) * ⟪x, stdOrthonormalBasis ℝ E i⟫_ℝ *
+          ⟪x, stdOrthonormalBasis ℝ E i⟫_ℝ =
+        p * (p - 2) * ‖x‖ ^ (p - 4) * ‖x‖ ^ 2 := by
+    rw [← (stdOrthonormalBasis ℝ E).sum_sq_inner_left x, Finset.mul_sum]
+    apply Finset.sum_congr rfl
+    intro i _
+    ring
+  rw [hfirst]
+  simp_rw [real_inner_self_eq_norm_sq,
+    (stdOrthonormalBasis ℝ E).orthonormal.norm_eq_one, one_pow]
+  simp only [mul_one, Finset.sum_const, Finset.card_univ, Fintype.card_fin, nsmul_eq_mul]
+  have hnorm : 0 < ‖x‖ := norm_pos_iff.mpr hx
+  have hrpow : ‖x‖ ^ (p - 4) * ‖x‖ ^ 2 = ‖x‖ ^ (p - 2) := by
+    calc
+      ‖x‖ ^ (p - 4) * ‖x‖ ^ 2 = ‖x‖ ^ (p - 4) * ‖x‖ ^ (2 : ℝ) := by
+        rw [Real.rpow_two]
+      _ = ‖x‖ ^ ((p - 4) + 2) := (Real.rpow_add hnorm _ _).symm
+      _ = ‖x‖ ^ (p - 2) := by ring_nf
+  rw [mul_assoc (p * (p - 2)), hrpow]
+  ring
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/InnerProductSpace/NormPow.lean
+++ b/TauCeti/Analysis/InnerProductSpace/NormPow.lean
@@ -70,7 +70,9 @@ theorem iteratedFDeriv_two_norm_rpow_apply (p : ℝ) {x : E} (hx : x ≠ 0) (v w
   rw [iteratedFDeriv_two_apply, hfd.fderiv_eq, fderiv_fun_smul hc hi]
   rw [((hasFDerivAt_norm_rpow_of_ne (p - 2) hx).const_mul p).fderiv]
   rw [(innerSL ℝ : E →L[ℝ] E →L[ℝ] ℝ).fderiv]
-  have hinner : (innerSL ℝ : E →L[ℝ] E →L[ℝ] ℝ) v w = ⟪v, w⟫_ℝ := rfl
+  -- `innerSL ℝ` is bundled as a conjugate-linear map, so this evaluation is not syntactically
+  -- an instance of `innerSL_apply_apply`; it is stated separately rather than proved by `rfl`.
+  have hinner : (innerSL ℝ : E →L[ℝ] E →L[ℝ] ℝ) v w = ⟪v, w⟫_ℝ := innerSL_apply_apply (𝕜 := ℝ) v w
   simp only [Fin.isValue, Matrix.cons_val_zero, add_apply, smul_apply,
     ContinuousLinearMap.smulRight_apply, coe_innerSL_apply, smul_eq_mul,
     Matrix.cons_val_one, Matrix.cons_val_fin_one]

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -66,11 +66,13 @@ theorem newtonianKernel_def (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) :
 
 /-- The totalized Newtonian kernel takes the value zero at its pole. -/
 @[simp]
-theorem newtonianKernel_zero (n : ℕ) (hn : 3 ≤ n) :
+theorem newtonianKernel_zero (n : ℕ) :
     newtonianKernel n 0 = 0 := by
-  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
-  have hexp : 2 - (n : ℝ) ≠ 0 := by linarith
-  simp [newtonianKernel, Real.zero_rpow hexp]
+  rcases eq_or_ne n 2 with rfl | hn
+  · norm_num [newtonianKernel]
+  · have hexp : 2 - (n : ℝ) ≠ 0 := by
+      exact sub_ne_zero.mpr (by exact_mod_cast hn.symm)
+    simp [newtonianKernel, Real.zero_rpow hexp]
 
 /-- The Newtonian kernel is radial, hence invariant under orthogonal transformations. -/
 @[simp]
@@ -79,6 +81,12 @@ theorem newtonianKernel_map_linearIsometryEquiv (n : ℕ)
     (x : EuclideanSpace ℝ (Fin n)) :
     newtonianKernel n (e x) = newtonianKernel n x := by
   simp [newtonianKernel]
+
+/-- The Newtonian kernel is symmetric under exchanging a point and its pole. -/
+@[simp]
+theorem newtonianKernel_sub_comm (n : ℕ) (x a : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n (x - a) = newtonianKernel n (a - x) := by
+  simp [newtonianKernel, norm_sub_rev]
 
 /-- Positive dilation scales the Newtonian kernel with homogeneity `2 - n`. -/
 theorem newtonianKernel_smul (n : ℕ) {r : ℝ} (hr : 0 < r)
@@ -107,7 +115,7 @@ theorem newtonianKernel_pos (n : ℕ) (hn : 3 ≤ n)
     (Real.rpow_pos_of_pos (norm_pos_iff.mpr hx) _)
 
 /-- The Fréchet derivative of the Newtonian kernel away from its pole. -/
-theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : n ≠ 2)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
     HasFDerivAt (newtonianKernel n)
       ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
@@ -120,9 +128,12 @@ theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
   refine ((hasFDerivAt_norm_rpow_of_ne (2 - (n : ℝ)) hx).const_mul
     (((n : ℝ) * ((n : ℝ) - 2) *
       volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹)).congr_fderiv ?_
-  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
-  have hn0 : (n : ℝ) ≠ 0 := by positivity
-  have hn2 : (n : ℝ) - 2 ≠ 0 := ne_of_gt (by linarith)
+  have hn0 : (n : ℝ) ≠ 0 := by
+    cases n with
+    | zero => exact (hx (Subsingleton.elim x 0)).elim
+    | succ n => positivity
+  have hn2 : (n : ℝ) - 2 ≠ 0 := by
+    exact sub_ne_zero.mpr (by exact_mod_cast hn)
   have hvol := (volume_real_unitBall_pos n).ne'
   have hexp : (2 - (n : ℝ)) - 2 = -(n : ℝ) := by ring
   rw [hexp]
@@ -132,7 +143,7 @@ theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
   ring
 
 /-- The Fréchet derivative of the Newtonian kernel as a continuous linear functional. -/
-theorem fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+theorem fderiv_newtonianKernel (n : ℕ) (hn : n ≠ 2)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
     fderiv ℝ (newtonianKernel n) x =
       (-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
@@ -140,7 +151,7 @@ theorem fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
   (hasFDerivAt_newtonianKernel n hn hx).fderiv
 
 /-- The derivative of the Newtonian kernel evaluated in a direction. -/
-theorem fderiv_newtonianKernel_apply (n : ℕ) (hn : 3 ≤ n)
+theorem fderiv_newtonianKernel_apply (n : ℕ) (hn : n ≠ 2)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) (v : EuclideanSpace ℝ (Fin n)) :
     fderiv ℝ (newtonianKernel n) x v =
       -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
@@ -151,16 +162,19 @@ theorem fderiv_newtonianKernel_apply (n : ℕ) (hn : 3 ≤ n)
 
 /-- The operator norm of the derivative of the Newtonian kernel decays like `‖x‖ ^ (1 - n)`. -/
 @[simp]
-theorem norm_fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+theorem norm_fderiv_newtonianKernel (n : ℕ) (hn : n ≠ 2)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
     ‖fderiv ℝ (newtonianKernel n) x‖ =
       ((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
         ‖x‖ ^ (1 - (n : ℝ)) := by
-  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
-  have hnpos : (0 : ℝ) < n := by positivity
+  have hn0 : n ≠ 0 := by
+    intro hn
+    subst n
+    exact hx (Subsingleton.elim x 0)
+  have hnpos : (0 : ℝ) < n := by exact_mod_cast Nat.pos_of_ne_zero hn0
   have hnorm : 0 < ‖x‖ := norm_pos_iff.mpr hx
   have hsplit : ‖x‖ ^ (1 - (n : ℝ)) = ‖x‖ ^ (-(n : ℝ)) * ‖x‖ := by
-    rw [show (1 : ℝ) - (n : ℝ) = -(n : ℝ) + 1 by ring, Real.rpow_add hnorm, Real.rpow_one]
+    rw [sub_eq_add_neg, add_comm, Real.rpow_add hnorm, Real.rpow_one]
   rw [fderiv_newtonianKernel n hn hx, norm_smul, innerSL_apply_norm, Real.norm_eq_abs,
     abs_mul, abs_neg, abs_inv, abs_of_pos (mul_pos hnpos (volume_real_unitBall_pos n)),
     abs_of_pos (Real.rpow_pos_of_pos hnorm _), hsplit]
@@ -231,7 +245,7 @@ theorem contDiffAt_newtonianKernel_sub (n : ℕ)
   (harmonicAt_newtonianKernel_sub n hxa).1
 
 /-- A Newtonian kernel with pole at `a` has the translated Fréchet derivative. -/
-theorem hasFDerivAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem hasFDerivAt_newtonianKernel_sub (n : ℕ) (hn : n ≠ 2)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
     HasFDerivAt (fun y ↦ newtonianKernel n (y - a))
       ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
@@ -240,7 +254,7 @@ theorem hasFDerivAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
   exact hasFDerivAt_newtonianKernel n hn (sub_ne_zero.mpr hxa)
 
 /-- The Fréchet derivative of a Newtonian kernel with pole at `a`. -/
-theorem fderiv_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem fderiv_newtonianKernel_sub (n : ℕ) (hn : n ≠ 2)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
     fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x =
       (-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
@@ -248,7 +262,7 @@ theorem fderiv_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
   (hasFDerivAt_newtonianKernel_sub n hn hxa).fderiv
 
 /-- The derivative of the Newtonian kernel with a translated pole. -/
-theorem fderiv_newtonianKernel_sub_apply (n : ℕ) (hn : 3 ≤ n)
+theorem fderiv_newtonianKernel_sub_apply (n : ℕ) (hn : n ≠ 2)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) (v : EuclideanSpace ℝ (Fin n)) :
     fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x v =
       -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
@@ -259,7 +273,7 @@ theorem fderiv_newtonianKernel_sub_apply (n : ℕ) (hn : 3 ≤ n)
 
 /-- The operator norm of the derivative of a Newtonian kernel with pole at `a`. -/
 @[simp]
-theorem norm_fderiv_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem norm_fderiv_newtonianKernel_sub (n : ℕ) (hn : n ≠ 2)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
     ‖fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x‖ =
       ((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -47,22 +47,14 @@ open scoped RealInnerProductSpace
 
 /-- The Newtonian kernel for the negative Laplacian on `ℝⁿ`.
 
-The normalization is the fundamental solution exactly in dimension `n ≥ 3`, which is therefore
-hypothesized on the results that need it rather than carried in the definition.  At the pole,
-Lean's convention for a negative real power of zero makes this total function take the value
-zero. -/
+For `3 ≤ n`, this normalization is the fundamental solution, and the exponent `2 - n` is
+negative.  Lean's convention for a negative real power of zero makes the kernel take the value
+zero at the pole in these dimensions.  Results that need the higher-dimensional regime state it
+as a hypothesis rather than carrying it in the definition. -/
 def newtonianKernel (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) : ℝ :=
   ((n : ℝ) * ((n : ℝ) - 2) *
       volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
     ‖x‖ ^ (2 - (n : ℝ))
-
-/-- The defining formula for the Newtonian kernel. -/
-theorem newtonianKernel_def (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) :
-    newtonianKernel n x =
-      ((n : ℝ) * ((n : ℝ) - 2) *
-        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
-      ‖x‖ ^ (2 - (n : ℝ)) := by
-  rw [newtonianKernel]
 
 /-- The totalized Newtonian kernel takes the value zero at its pole. -/
 @[simp]
@@ -87,12 +79,12 @@ theorem newtonianKernel_sub_comm (n : ℕ) (x a : EuclideanSpace ℝ (Fin n)) :
     newtonianKernel n (x - a) = newtonianKernel n (a - x) := by
   simp [newtonianKernel, norm_sub_rev]
 
-/-- Positive dilation scales the Newtonian kernel with homogeneity `2 - n`. -/
-theorem newtonianKernel_smul (n : ℕ) {r : ℝ} (hr : 0 < r)
+/-- Real dilation scales the Newtonian kernel with radial homogeneity `2 - n`. -/
+theorem newtonianKernel_smul (n : ℕ) (r : ℝ)
     (x : EuclideanSpace ℝ (Fin n)) :
-    newtonianKernel n (r • x) = r ^ (2 - (n : ℝ)) * newtonianKernel n x := by
-  rw [newtonianKernel_def, newtonianKernel_def, norm_smul, Real.norm_of_nonneg hr.le,
-    Real.mul_rpow hr.le (norm_nonneg x)]
+    newtonianKernel n (r • x) = ‖r‖ ^ (2 - (n : ℝ)) * newtonianKernel n x := by
+  rw [newtonianKernel, newtonianKernel, norm_smul,
+    Real.mul_rpow (norm_nonneg r) (norm_nonneg x)]
   ring
 
 private theorem volume_real_unitBall_pos (n : ℕ) :
@@ -108,7 +100,7 @@ theorem newtonianKernel_pos (n : ℕ) (hn : 3 ≤ n)
   have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
   have hnpos : (0 : ℝ) < n := by positivity
   have hnsub : (0 : ℝ) < (n : ℝ) - 2 := by linarith
-  rw [newtonianKernel_def]
+  rw [newtonianKernel]
   exact mul_pos (inv_pos.mpr (mul_pos (mul_pos hnpos hnsub)
       (volume_real_unitBall_pos n)))
     (Real.rpow_pos_of_pos (norm_pos_iff.mpr hx) _)
@@ -188,7 +180,7 @@ theorem contDiffAt_newtonianKernel (n : ℕ)
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
     funext y
-    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
+    simp only [newtonianKernel, Pi.smul_apply, smul_eq_mul]
   rw [hfun]
   have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
       ‖y‖ ^ (2 - (n : ℝ))) x :=
@@ -206,7 +198,7 @@ theorem laplacian_newtonianKernel (n : ℕ)
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
     funext y
-    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
+    simp only [newtonianKernel, Pi.smul_apply, smul_eq_mul]
   have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
       ‖y‖ ^ (2 - (n : ℝ))) x :=
     (contDiffAt_norm ℝ hx).rpow_const_of_ne (norm_ne_zero_iff.mpr hx)
@@ -302,7 +294,7 @@ theorem newtonianKernel_three (x : EuclideanSpace ℝ (Fin 3)) :
     rw [Measure.real_def, EuclideanSpace.volume_ball_fin_three]
     simp only [one_pow, ENNReal.ofReal_one, one_mul]
     exact ENNReal.toReal_ofReal (by positivity)
-  rw [newtonianKernel_def, hvol]
+  rw [newtonianKernel, hvol]
   norm_num [Real.rpow_neg_one]
   field_simp [Real.pi_ne_zero]
 

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -29,6 +29,7 @@ from the derivative proved here.
 
 * `TauCeti.newtonianKernel`: the normalized kernel in dimension `n ≥ 3`.
 * `TauCeti.hasFDerivAt_newtonianKernel`: its derivative away from the origin.
+* `TauCeti.norm_fderiv_newtonianKernel`: the `‖x‖ ^ (1 - n)` operator norm of that derivative.
 * `TauCeti.laplacian_newtonianKernel`: the pointwise equation `Δ Gₙ = 0` away from the origin.
 * `TauCeti.harmonicAt_newtonianKernel_sub`: harmonicity of the kernel with a translated pole.
 * `TauCeti.newtonianKernel_three`: the familiar three-dimensional formula.
@@ -44,19 +45,20 @@ open Filter InnerProductSpace Laplacian MeasureTheory Metric Topology
 
 open scoped RealInnerProductSpace
 
-/-- The Newtonian kernel for the negative Laplacian on `ℝⁿ`, in dimension `n ≥ 3`.
+/-- The Newtonian kernel for the negative Laplacian on `ℝⁿ`.
 
-The proof argument records the range where the power-law formula is the fundamental solution;
-it does not occur in the value.  At the pole, Lean's convention for a negative real power of zero
-makes this total function take the value zero. -/
-def newtonianKernel (n : ℕ) (_hn : 3 ≤ n) (x : EuclideanSpace ℝ (Fin n)) : ℝ :=
+The normalization is the fundamental solution exactly in dimension `n ≥ 3`, which is therefore
+hypothesized on the results that need it rather than carried in the definition.  At the pole,
+Lean's convention for a negative real power of zero makes this total function take the value
+zero. -/
+def newtonianKernel (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) : ℝ :=
   ((n : ℝ) * ((n : ℝ) - 2) *
       volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
     ‖x‖ ^ (2 - (n : ℝ))
 
 /-- The defining formula for the Newtonian kernel. -/
-theorem newtonianKernel_def (n : ℕ) (hn : 3 ≤ n) (x : EuclideanSpace ℝ (Fin n)) :
-    newtonianKernel n hn x =
+theorem newtonianKernel_def (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n x =
       ((n : ℝ) * ((n : ℝ) - 2) *
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
       ‖x‖ ^ (2 - (n : ℝ)) := by
@@ -65,28 +67,28 @@ theorem newtonianKernel_def (n : ℕ) (hn : 3 ≤ n) (x : EuclideanSpace ℝ (Fi
 /-- The totalized Newtonian kernel takes the value zero at its pole. -/
 @[simp]
 theorem newtonianKernel_zero (n : ℕ) (hn : 3 ≤ n) :
-    newtonianKernel n hn 0 = 0 := by
+    newtonianKernel n 0 = 0 := by
   have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
   have hexp : 2 - (n : ℝ) ≠ 0 := by linarith
   simp [newtonianKernel, Real.zero_rpow hexp]
 
 /-- The Newtonian kernel is radial, hence invariant under orthogonal transformations. -/
 @[simp]
-theorem newtonianKernel_map_linearIsometryEquiv (n : ℕ) (hn : 3 ≤ n)
+theorem newtonianKernel_map_linearIsometryEquiv (n : ℕ)
     (e : EuclideanSpace ℝ (Fin n) ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin n))
     (x : EuclideanSpace ℝ (Fin n)) :
-    newtonianKernel n hn (e x) = newtonianKernel n hn x := by
+    newtonianKernel n (e x) = newtonianKernel n x := by
   simp [newtonianKernel]
 
 /-- Positive dilation scales the Newtonian kernel with homogeneity `2 - n`. -/
-theorem newtonianKernel_smul (n : ℕ) (hn : 3 ≤ n) {r : ℝ} (hr : 0 < r)
+theorem newtonianKernel_smul (n : ℕ) {r : ℝ} (hr : 0 < r)
     (x : EuclideanSpace ℝ (Fin n)) :
-    newtonianKernel n hn (r • x) = r ^ (2 - (n : ℝ)) * newtonianKernel n hn x := by
+    newtonianKernel n (r • x) = r ^ (2 - (n : ℝ)) * newtonianKernel n x := by
   rw [newtonianKernel_def, newtonianKernel_def, norm_smul, Real.norm_of_nonneg hr.le,
     Real.mul_rpow hr.le (norm_nonneg x)]
   ring
 
-private theorem volume_real_unitBall_pos (n : ℕ) (_hn : 3 ≤ n) :
+private theorem volume_real_unitBall_pos (n : ℕ) :
     0 < volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1) := by
   exact ENNReal.toReal_pos
     (measure_ball_pos volume (0 : EuclideanSpace ℝ (Fin n)) zero_lt_one).ne'
@@ -95,22 +97,22 @@ private theorem volume_real_unitBall_pos (n : ℕ) (_hn : 3 ≤ n) :
 /-- Away from the pole, the normalized Newtonian kernel is strictly positive. -/
 theorem newtonianKernel_pos (n : ℕ) (hn : 3 ≤ n)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    0 < newtonianKernel n hn x := by
+    0 < newtonianKernel n x := by
   have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
   have hnpos : (0 : ℝ) < n := by positivity
   have hnsub : (0 : ℝ) < (n : ℝ) - 2 := by linarith
   rw [newtonianKernel_def]
   exact mul_pos (inv_pos.mpr (mul_pos (mul_pos hnpos hnsub)
-      (volume_real_unitBall_pos n hn)))
+      (volume_real_unitBall_pos n)))
     (Real.rpow_pos_of_pos (norm_pos_iff.mpr hx) _)
 
 /-- The Fréchet derivative of the Newtonian kernel away from its pole. -/
 theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    HasFDerivAt (newtonianKernel n hn)
+    HasFDerivAt (newtonianKernel n)
       ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
         ‖x‖ ^ (-(n : ℝ))) • innerSL ℝ x) x := by
-  have hfun : newtonianKernel n hn = fun y ↦
+  have hfun : newtonianKernel n = fun y ↦
       ((n : ℝ) * ((n : ℝ) - 2) *
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
       ‖y‖ ^ (2 - (n : ℝ)) := by rfl
@@ -121,7 +123,7 @@ theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
   have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
   have hn0 : (n : ℝ) ≠ 0 := by positivity
   have hn2 : (n : ℝ) - 2 ≠ 0 := ne_of_gt (by linarith)
-  have hvol := (volume_real_unitBall_pos n hn).ne'
+  have hvol := (volume_real_unitBall_pos n).ne'
   have hexp : (2 - (n : ℝ)) - 2 = -(n : ℝ) := by ring
   rw [hexp]
   ext v
@@ -132,7 +134,7 @@ theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
 /-- The Fréchet derivative of the Newtonian kernel as a continuous linear functional. -/
 theorem fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    fderiv ℝ (newtonianKernel n hn) x =
+    fderiv ℝ (newtonianKernel n) x =
       (-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
         ‖x‖ ^ (-(n : ℝ))) • innerSL ℝ x :=
   (hasFDerivAt_newtonianKernel n hn hx).fderiv
@@ -140,18 +142,35 @@ theorem fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
 /-- The derivative of the Newtonian kernel evaluated in a direction. -/
 theorem fderiv_newtonianKernel_apply (n : ℕ) (hn : 3 ≤ n)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) (v : EuclideanSpace ℝ (Fin n)) :
-    fderiv ℝ (newtonianKernel n hn) x v =
+    fderiv ℝ (newtonianKernel n) x v =
       -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
         ‖x‖ ^ (-(n : ℝ)) * ⟪x, v⟫_ℝ) := by
   rw [fderiv_newtonianKernel n hn hx]
   simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
   ring
 
-/-- Away from its pole, the Newtonian kernel is twice continuously differentiable. -/
-theorem contDiffAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+/-- The operator norm of the derivative of the Newtonian kernel decays like `‖x‖ ^ (1 - n)`. -/
+@[simp]
+theorem norm_fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    ContDiffAt ℝ 2 (newtonianKernel n hn) x := by
-  have hfun : newtonianKernel n hn =
+    ‖fderiv ℝ (newtonianKernel n) x‖ =
+      ((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+        ‖x‖ ^ (1 - (n : ℝ)) := by
+  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < n := by positivity
+  have hnorm : 0 < ‖x‖ := norm_pos_iff.mpr hx
+  have hsplit : ‖x‖ ^ (1 - (n : ℝ)) = ‖x‖ ^ (-(n : ℝ)) * ‖x‖ := by
+    rw [show (1 : ℝ) - (n : ℝ) = -(n : ℝ) + 1 by ring, Real.rpow_add hnorm, Real.rpow_one]
+  rw [fderiv_newtonianKernel n hn hx, norm_smul, innerSL_apply_norm, Real.norm_eq_abs,
+    abs_mul, abs_neg, abs_inv, abs_of_pos (mul_pos hnpos (volume_real_unitBall_pos n)),
+    abs_of_pos (Real.rpow_pos_of_pos hnorm _), hsplit]
+  ring
+
+/-- Away from its pole, the Newtonian kernel is twice continuously differentiable. -/
+theorem contDiffAt_newtonianKernel (n : ℕ)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    ContDiffAt ℝ 2 (newtonianKernel n) x := by
+  have hfun : newtonianKernel n =
       ((n : ℝ) * ((n : ℝ) - 2) *
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
@@ -166,10 +185,10 @@ theorem contDiffAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
 
 /-- The Newtonian kernel solves the homogeneous Laplace equation pointwise away from its pole. -/
 @[simp]
-theorem laplacian_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+theorem laplacian_newtonianKernel (n : ℕ)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    Δ (newtonianKernel n hn) x = 0 := by
-  have hfun : newtonianKernel n hn =
+    Δ (newtonianKernel n) x = 0 := by
+  have hfun : newtonianKernel n =
       ((n : ℝ) * ((n : ℝ) - 2) *
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
@@ -184,63 +203,87 @@ theorem laplacian_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
   ring
 
 /-- The Newtonian kernel is harmonic at every point away from its pole at the origin. -/
-theorem harmonicAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+theorem harmonicAt_newtonianKernel (n : ℕ)
     {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
-    HarmonicAt (newtonianKernel n hn) x := by
-  refine ⟨contDiffAt_newtonianKernel n hn hx, ?_⟩
+    HarmonicAt (newtonianKernel n) x := by
+  refine ⟨contDiffAt_newtonianKernel n hx, ?_⟩
   filter_upwards [eventually_ne_nhds hx] with y hy
-  exact laplacian_newtonianKernel n hn hy
+  exact laplacian_newtonianKernel n hy
 
 /-- The Newtonian kernel is harmonic on the punctured Euclidean space. -/
-theorem harmonicOnNhd_newtonianKernel (n : ℕ) (hn : 3 ≤ n) :
-    HarmonicOnNhd (newtonianKernel n hn) ({0}ᶜ : Set (EuclideanSpace ℝ (Fin n))) := by
+theorem harmonicOnNhd_newtonianKernel (n : ℕ) :
+    HarmonicOnNhd (newtonianKernel n) ({0}ᶜ : Set (EuclideanSpace ℝ (Fin n))) := by
   intro x hx
-  exact harmonicAt_newtonianKernel n hn (Set.mem_compl_singleton_iff.mp hx)
+  exact harmonicAt_newtonianKernel n (Set.mem_compl_singleton_iff.mp hx)
 
 /-- A Newtonian kernel with pole at `a` is harmonic away from that pole. -/
-theorem harmonicAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem harmonicAt_newtonianKernel_sub (n : ℕ)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
-    HarmonicAt (fun y ↦ newtonianKernel n hn (y - a)) x := by
+    HarmonicAt (fun y ↦ newtonianKernel n (y - a)) x := by
   simpa [sub_eq_add_neg] using
-    (harmonicAt_comp_add_right_iff (f := newtonianKernel n hn) (x := x) (a := -a)).2
-      (harmonicAt_newtonianKernel n hn (sub_ne_zero.mpr hxa))
+    (harmonicAt_comp_add_right_iff (f := newtonianKernel n) (x := x) (a := -a)).2
+      (harmonicAt_newtonianKernel n (sub_ne_zero.mpr hxa))
+
+/-- A Newtonian kernel with pole at `a` is twice continuously differentiable away from `a`. -/
+theorem contDiffAt_newtonianKernel_sub (n : ℕ)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    ContDiffAt ℝ 2 (fun y ↦ newtonianKernel n (y - a)) x :=
+  (harmonicAt_newtonianKernel_sub n hxa).1
 
 /-- A Newtonian kernel with pole at `a` has the translated Fréchet derivative. -/
 theorem hasFDerivAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
-    HasFDerivAt (fun y ↦ newtonianKernel n hn (y - a))
+    HasFDerivAt (fun y ↦ newtonianKernel n (y - a))
       ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
         ‖x - a‖ ^ (-(n : ℝ))) • innerSL ℝ (x - a)) x := by
   rw [hasFDerivAt_comp_sub]
   exact hasFDerivAt_newtonianKernel n hn (sub_ne_zero.mpr hxa)
 
+/-- The Fréchet derivative of a Newtonian kernel with pole at `a`. -/
+theorem fderiv_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x =
+      (-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
+        ‖x - a‖ ^ (-(n : ℝ))) • innerSL ℝ (x - a) :=
+  (hasFDerivAt_newtonianKernel_sub n hn hxa).fderiv
+
 /-- The derivative of the Newtonian kernel with a translated pole. -/
 theorem fderiv_newtonianKernel_sub_apply (n : ℕ) (hn : 3 ≤ n)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) (v : EuclideanSpace ℝ (Fin n)) :
-    fderiv ℝ (fun y ↦ newtonianKernel n hn (y - a)) x v =
+    fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x v =
       -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
         ‖x - a‖ ^ (-(n : ℝ)) * ⟪x - a, v⟫_ℝ) := by
-  rw [(hasFDerivAt_newtonianKernel_sub n hn hxa).fderiv]
+  rw [fderiv_newtonianKernel_sub n hn hxa]
   simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
   ring
 
+/-- The operator norm of the derivative of a Newtonian kernel with pole at `a`. -/
+@[simp]
+theorem norm_fderiv_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    ‖fderiv ℝ (fun y ↦ newtonianKernel n (y - a)) x‖ =
+      ((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+        ‖x - a‖ ^ (1 - (n : ℝ)) := by
+  rw [fderiv_comp_sub]
+  exact norm_fderiv_newtonianKernel n hn (sub_ne_zero.mpr hxa)
+
 /-- A translated Newtonian kernel solves the homogeneous Laplace equation away from its pole. -/
 @[simp]
-theorem laplacian_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem laplacian_newtonianKernel_sub (n : ℕ)
     {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
-    Δ (fun y ↦ newtonianKernel n hn (y - a)) x = 0 :=
-  (harmonicAt_newtonianKernel_sub n hn hxa).2.self_of_nhds
+    Δ (fun y ↦ newtonianKernel n (y - a)) x = 0 :=
+  (harmonicAt_newtonianKernel_sub n hxa).2.self_of_nhds
 
 /-- A Newtonian kernel with pole at `a` is harmonic on the complement of the pole. -/
-theorem harmonicOnNhd_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+theorem harmonicOnNhd_newtonianKernel_sub (n : ℕ)
     (a : EuclideanSpace ℝ (Fin n)) :
-    HarmonicOnNhd (fun x ↦ newtonianKernel n hn (x - a)) ({a}ᶜ : Set _) := by
+    HarmonicOnNhd (fun x ↦ newtonianKernel n (x - a)) ({a}ᶜ : Set _) := by
   intro x hx
-  exact harmonicAt_newtonianKernel_sub n hn (Set.mem_compl_singleton_iff.mp hx)
+  exact harmonicAt_newtonianKernel_sub n (Set.mem_compl_singleton_iff.mp hx)
 
 /-- In dimension three the Newtonian kernel is the classical function `1 / (4π‖x‖)`. -/
 theorem newtonianKernel_three (x : EuclideanSpace ℝ (Fin 3)) :
-    newtonianKernel 3 (by omega) x = (4 * Real.pi * ‖x‖)⁻¹ := by
+    newtonianKernel 3 x = (4 * Real.pi * ‖x‖)⁻¹ := by
   have hvol : volume.real (ball (0 : EuclideanSpace ℝ (Fin 3)) 1) =
       Real.pi * 4 / 3 := by
     rw [Measure.real_def, EuclideanSpace.volume_ball_fin_three]

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -83,7 +83,6 @@ theorem newtonianKernel_map_linearIsometryEquiv (n : ℕ)
   simp [newtonianKernel]
 
 /-- The Newtonian kernel is symmetric under exchanging a point and its pole. -/
-@[simp]
 theorem newtonianKernel_sub_comm (n : ℕ) (x a : EuclideanSpace ℝ (Fin n)) :
     newtonianKernel n (x - a) = newtonianKernel n (a - x) := by
   simp [newtonianKernel, norm_sub_rev]

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.Analysis.InnerProductSpace.Harmonic.Isometry
+public import TauCeti.Analysis.InnerProductSpace.NormPow
+public import Mathlib.MeasureTheory.Measure.Lebesgue.VolumeOfBalls
+
+/-!
+# The Newtonian kernel in dimension at least three
+
+For `3 ≤ n`, this file defines the Newtonian kernel for the negative Laplacian on
+`EuclideanSpace ℝ (Fin n)`:
+
+`Gₙ(x) = (n (n - 2) ωₙ)⁻¹ ‖x‖²⁻ⁿ`,
+
+where `ωₙ` is the volume of the Euclidean unit ball.  It proves the full Fréchet derivative
+formula and the pointwise equation `Δ Gₙ = 0` away from the pole, together with translated
+versions for a pole at an arbitrary point.  The dimension-three specialization recovers the
+classical kernel `1 / (4π‖x‖)`.
+
+The normalization and formulas follow Evans, *Partial Differential Equations*, Section 2.2.
+The remaining distributional identity `-Δ Gₙ = δ₀` will use the sphere-flux calculation built
+from the derivative proved here.
+
+## Main declarations
+
+* `TauCeti.newtonianKernel`: the normalized kernel in dimension `n ≥ 3`.
+* `TauCeti.hasFDerivAt_newtonianKernel`: its derivative away from the origin.
+* `TauCeti.laplacian_newtonianKernel`: the pointwise equation `Δ Gₙ = 0` away from the origin.
+* `TauCeti.harmonicAt_newtonianKernel_sub`: harmonicity of the kernel with a translated pole.
+* `TauCeti.newtonianKernel_three`: the familiar three-dimensional formula.
+-/
+
+public section
+
+noncomputable section
+
+namespace TauCeti
+
+open Filter InnerProductSpace Laplacian MeasureTheory Metric Topology
+
+open scoped RealInnerProductSpace
+
+/-- The Newtonian kernel for the negative Laplacian on `ℝⁿ`, in dimension `n ≥ 3`.
+
+The proof argument records the range where the power-law formula is the fundamental solution;
+it does not occur in the value.  At the pole, Lean's convention for a negative real power of zero
+makes this total function take the value zero. -/
+def newtonianKernel (n : ℕ) (_hn : 3 ≤ n) (x : EuclideanSpace ℝ (Fin n)) : ℝ :=
+  ((n : ℝ) * ((n : ℝ) - 2) *
+      volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+    ‖x‖ ^ (2 - (n : ℝ))
+
+/-- The defining formula for the Newtonian kernel. -/
+theorem newtonianKernel_def (n : ℕ) (hn : 3 ≤ n) (x : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n hn x =
+      ((n : ℝ) * ((n : ℝ) - 2) *
+        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+      ‖x‖ ^ (2 - (n : ℝ)) := by
+  rw [newtonianKernel]
+
+/-- The totalized Newtonian kernel takes the value zero at its pole. -/
+@[simp]
+theorem newtonianKernel_zero (n : ℕ) (hn : 3 ≤ n) :
+    newtonianKernel n hn 0 = 0 := by
+  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
+  have hexp : 2 - (n : ℝ) ≠ 0 := by linarith
+  simp [newtonianKernel, Real.zero_rpow hexp]
+
+/-- The Newtonian kernel is radial, hence invariant under orthogonal transformations. -/
+@[simp]
+theorem newtonianKernel_map_linearIsometryEquiv (n : ℕ) (hn : 3 ≤ n)
+    (e : EuclideanSpace ℝ (Fin n) ≃ₗᵢ[ℝ] EuclideanSpace ℝ (Fin n))
+    (x : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n hn (e x) = newtonianKernel n hn x := by
+  simp [newtonianKernel]
+
+/-- Positive dilation scales the Newtonian kernel with homogeneity `2 - n`. -/
+theorem newtonianKernel_smul (n : ℕ) (hn : 3 ≤ n) {r : ℝ} (hr : 0 < r)
+    (x : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n hn (r • x) = r ^ (2 - (n : ℝ)) * newtonianKernel n hn x := by
+  rw [newtonianKernel_def, newtonianKernel_def, norm_smul, Real.norm_of_nonneg hr.le,
+    Real.mul_rpow hr.le (norm_nonneg x)]
+  ring
+
+private theorem volume_real_unitBall_pos (n : ℕ) (_hn : 3 ≤ n) :
+    0 < volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1) := by
+  exact ENNReal.toReal_pos
+    (measure_ball_pos volume (0 : EuclideanSpace ℝ (Fin n)) zero_lt_one).ne'
+    measure_ball_ne_top
+
+/-- Away from the pole, the normalized Newtonian kernel is strictly positive. -/
+theorem newtonianKernel_pos (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    0 < newtonianKernel n hn x := by
+  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
+  have hnpos : (0 : ℝ) < n := by positivity
+  have hnsub : (0 : ℝ) < (n : ℝ) - 2 := by linarith
+  rw [newtonianKernel_def]
+  exact mul_pos (inv_pos.mpr (mul_pos (mul_pos hnpos hnsub)
+      (volume_real_unitBall_pos n hn)))
+    (Real.rpow_pos_of_pos (norm_pos_iff.mpr hx) _)
+
+/-- The Fréchet derivative of the Newtonian kernel away from its pole. -/
+theorem hasFDerivAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    HasFDerivAt (newtonianKernel n hn)
+      ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
+        ‖x‖ ^ (-(n : ℝ))) • innerSL ℝ x) x := by
+  have hfun : newtonianKernel n hn = fun y ↦
+      ((n : ℝ) * ((n : ℝ) - 2) *
+        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+      ‖y‖ ^ (2 - (n : ℝ)) := by rfl
+  rw [hfun]
+  refine ((hasFDerivAt_norm_rpow_of_ne (2 - (n : ℝ)) hx).const_mul
+    (((n : ℝ) * ((n : ℝ) - 2) *
+      volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹)).congr_fderiv ?_
+  have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
+  have hn0 : (n : ℝ) ≠ 0 := by positivity
+  have hn2 : (n : ℝ) - 2 ≠ 0 := ne_of_gt (by linarith)
+  have hvol := (volume_real_unitBall_pos n hn).ne'
+  have hexp : (2 - (n : ℝ)) - 2 = -(n : ℝ) := by ring
+  rw [hexp]
+  ext v
+  simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
+  field_simp
+  ring
+
+/-- The Fréchet derivative of the Newtonian kernel as a continuous linear functional. -/
+theorem fderiv_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    fderiv ℝ (newtonianKernel n hn) x =
+      (-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
+        ‖x‖ ^ (-(n : ℝ))) • innerSL ℝ x :=
+  (hasFDerivAt_newtonianKernel n hn hx).fderiv
+
+/-- The derivative of the Newtonian kernel evaluated in a direction. -/
+theorem fderiv_newtonianKernel_apply (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) (v : EuclideanSpace ℝ (Fin n)) :
+    fderiv ℝ (newtonianKernel n hn) x v =
+      -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+        ‖x‖ ^ (-(n : ℝ)) * ⟪x, v⟫_ℝ) := by
+  rw [fderiv_newtonianKernel n hn hx]
+  simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
+  ring
+
+/-- Away from its pole, the Newtonian kernel is twice continuously differentiable. -/
+theorem contDiffAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    ContDiffAt ℝ 2 (newtonianKernel n hn) x := by
+  have hfun : newtonianKernel n hn =
+      ((n : ℝ) * ((n : ℝ) - 2) *
+        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
+        fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
+    funext y
+    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
+  rw [hfun]
+  have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
+      ‖y‖ ^ (2 - (n : ℝ))) x :=
+    (contDiffAt_norm ℝ hx).rpow_const_of_ne (norm_ne_zero_iff.mpr hx)
+  exact hpow.const_smul (((n : ℝ) * ((n : ℝ) - 2) *
+    volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹)
+
+/-- The Newtonian kernel solves the homogeneous Laplace equation pointwise away from its pole. -/
+@[simp]
+theorem laplacian_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    Δ (newtonianKernel n hn) x = 0 := by
+  have hfun : newtonianKernel n hn =
+      ((n : ℝ) * ((n : ℝ) - 2) *
+        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
+        fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
+    funext y
+    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
+  have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
+      ‖y‖ ^ (2 - (n : ℝ))) x :=
+    (contDiffAt_norm ℝ hx).rpow_const_of_ne (norm_ne_zero_iff.mpr hx)
+  rw [hfun, laplacian_smul _ hpow]
+  rw [laplacian_norm_rpow_of_ne (2 - (n : ℝ)) hx]
+  simp only [finrank_euclideanSpace, Fintype.card_fin, smul_eq_mul]
+  ring
+
+/-- The Newtonian kernel is harmonic at every point away from its pole at the origin. -/
+theorem harmonicAt_newtonianKernel (n : ℕ) (hn : 3 ≤ n)
+    {x : EuclideanSpace ℝ (Fin n)} (hx : x ≠ 0) :
+    HarmonicAt (newtonianKernel n hn) x := by
+  refine ⟨contDiffAt_newtonianKernel n hn hx, ?_⟩
+  filter_upwards [eventually_ne_nhds hx] with y hy
+  exact laplacian_newtonianKernel n hn hy
+
+/-- The Newtonian kernel is harmonic on the punctured Euclidean space. -/
+theorem harmonicOnNhd_newtonianKernel (n : ℕ) (hn : 3 ≤ n) :
+    HarmonicOnNhd (newtonianKernel n hn) ({0}ᶜ : Set (EuclideanSpace ℝ (Fin n))) := by
+  intro x hx
+  exact harmonicAt_newtonianKernel n hn (Set.mem_compl_singleton_iff.mp hx)
+
+/-- A Newtonian kernel with pole at `a` is harmonic away from that pole. -/
+theorem harmonicAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    HarmonicAt (fun y ↦ newtonianKernel n hn (y - a)) x := by
+  simpa [sub_eq_add_neg] using
+    (harmonicAt_comp_add_right_iff (f := newtonianKernel n hn) (x := x) (a := -a)).2
+      (harmonicAt_newtonianKernel n hn (sub_ne_zero.mpr hxa))
+
+/-- A Newtonian kernel with pole at `a` has the translated Fréchet derivative. -/
+theorem hasFDerivAt_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    HasFDerivAt (fun y ↦ newtonianKernel n hn (y - a))
+      ((-(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹) *
+        ‖x - a‖ ^ (-(n : ℝ))) • innerSL ℝ (x - a)) x := by
+  rw [hasFDerivAt_comp_sub]
+  exact hasFDerivAt_newtonianKernel n hn (sub_ne_zero.mpr hxa)
+
+/-- The derivative of the Newtonian kernel with a translated pole. -/
+theorem fderiv_newtonianKernel_sub_apply (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) (v : EuclideanSpace ℝ (Fin n)) :
+    fderiv ℝ (fun y ↦ newtonianKernel n hn (y - a)) x v =
+      -(((n : ℝ) * volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+        ‖x - a‖ ^ (-(n : ℝ)) * ⟪x - a, v⟫_ℝ) := by
+  rw [(hasFDerivAt_newtonianKernel_sub n hn hxa).fderiv]
+  simp only [smul_apply, smul_eq_mul, innerSL_apply_apply]
+  ring
+
+/-- A translated Newtonian kernel solves the homogeneous Laplace equation away from its pole. -/
+@[simp]
+theorem laplacian_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    {x a : EuclideanSpace ℝ (Fin n)} (hxa : x ≠ a) :
+    Δ (fun y ↦ newtonianKernel n hn (y - a)) x = 0 :=
+  (harmonicAt_newtonianKernel_sub n hn hxa).2.self_of_nhds
+
+/-- A Newtonian kernel with pole at `a` is harmonic on the complement of the pole. -/
+theorem harmonicOnNhd_newtonianKernel_sub (n : ℕ) (hn : 3 ≤ n)
+    (a : EuclideanSpace ℝ (Fin n)) :
+    HarmonicOnNhd (fun x ↦ newtonianKernel n hn (x - a)) ({a}ᶜ : Set _) := by
+  intro x hx
+  exact harmonicAt_newtonianKernel_sub n hn (Set.mem_compl_singleton_iff.mp hx)
+
+/-- In dimension three the Newtonian kernel is the classical function `1 / (4π‖x‖)`. -/
+theorem newtonianKernel_three (x : EuclideanSpace ℝ (Fin 3)) :
+    newtonianKernel 3 (by omega) x = (4 * Real.pi * ‖x‖)⁻¹ := by
+  have hvol : volume.real (ball (0 : EuclideanSpace ℝ (Fin 3)) 1) =
+      Real.pi * 4 / 3 := by
+    rw [Measure.real_def, EuclideanSpace.volume_ball_fin_three]
+    simp only [one_pow, ENNReal.ofReal_one, one_mul]
+    exact ENNReal.toReal_ofReal (by positivity)
+  rw [newtonianKernel_def, hvol]
+  norm_num [Real.rpow_neg_one]
+  field_simp [Real.pi_ne_zero]
+
+end TauCeti
+
+end

--- a/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
+++ b/TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean
@@ -56,6 +56,15 @@ def newtonianKernel (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) : ℝ :=
       volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
     ‖x‖ ^ (2 - (n : ℝ))
 
+/-- The defining formula for the Newtonian kernel.  The body of `TauCeti.newtonianKernel` is not
+`@[expose]`d, so this is the form in which other modules reach the definition. -/
+theorem newtonianKernel_def (n : ℕ) (x : EuclideanSpace ℝ (Fin n)) :
+    newtonianKernel n x =
+      ((n : ℝ) * ((n : ℝ) - 2) *
+        volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ *
+      ‖x‖ ^ (2 - (n : ℝ)) := by
+  rw [newtonianKernel]
+
 /-- The totalized Newtonian kernel takes the value zero at its pole. -/
 @[simp]
 theorem newtonianKernel_zero (n : ℕ) :
@@ -83,7 +92,7 @@ theorem newtonianKernel_sub_comm (n : ℕ) (x a : EuclideanSpace ℝ (Fin n)) :
 theorem newtonianKernel_smul (n : ℕ) (r : ℝ)
     (x : EuclideanSpace ℝ (Fin n)) :
     newtonianKernel n (r • x) = ‖r‖ ^ (2 - (n : ℝ)) * newtonianKernel n x := by
-  rw [newtonianKernel, newtonianKernel, norm_smul,
+  rw [newtonianKernel_def, newtonianKernel_def, norm_smul,
     Real.mul_rpow (norm_nonneg r) (norm_nonneg x)]
   ring
 
@@ -100,7 +109,7 @@ theorem newtonianKernel_pos (n : ℕ) (hn : 3 ≤ n)
   have hnℝ : (3 : ℝ) ≤ n := by exact_mod_cast hn
   have hnpos : (0 : ℝ) < n := by positivity
   have hnsub : (0 : ℝ) < (n : ℝ) - 2 := by linarith
-  rw [newtonianKernel]
+  rw [newtonianKernel_def]
   exact mul_pos (inv_pos.mpr (mul_pos (mul_pos hnpos hnsub)
       (volume_real_unitBall_pos n)))
     (Real.rpow_pos_of_pos (norm_pos_iff.mpr hx) _)
@@ -180,7 +189,7 @@ theorem contDiffAt_newtonianKernel (n : ℕ)
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
     funext y
-    simp only [newtonianKernel, Pi.smul_apply, smul_eq_mul]
+    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
   rw [hfun]
   have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
       ‖y‖ ^ (2 - (n : ℝ))) x :=
@@ -198,7 +207,7 @@ theorem laplacian_newtonianKernel (n : ℕ)
         volume.real (ball (0 : EuclideanSpace ℝ (Fin n)) 1))⁻¹ •
         fun y : EuclideanSpace ℝ (Fin n) ↦ ‖y‖ ^ (2 - (n : ℝ)) := by
     funext y
-    simp only [newtonianKernel, Pi.smul_apply, smul_eq_mul]
+    simp only [newtonianKernel_def, Pi.smul_apply, smul_eq_mul]
   have hpow : ContDiffAt ℝ 2 (fun y : EuclideanSpace ℝ (Fin n) ↦
       ‖y‖ ^ (2 - (n : ℝ))) x :=
     (contDiffAt_norm ℝ hx).rpow_const_of_ne (norm_ne_zero_iff.mpr hx)
@@ -294,7 +303,7 @@ theorem newtonianKernel_three (x : EuclideanSpace ℝ (Fin 3)) :
     rw [Measure.real_def, EuclideanSpace.volume_ball_fin_three]
     simp only [one_pow, ENNReal.ofReal_one, one_mul]
     exact ENNReal.toReal_ofReal (by positivity)
-  rw [newtonianKernel, hvol]
+  rw [newtonianKernel_def, hvol]
   norm_num [Real.rpow_neg_one]
   field_simp [Real.pi_ne_zero]
 


### PR DESCRIPTION
This PR adds the normalized Newtonian kernel on `EuclideanSpace ℝ (Fin n)` for `3 ≤ n` and proves its pointwise PDE package: positivity away from the pole, orthogonal invariance, homogeneity, the full Fréchet derivative `−(nωₙ)⁻¹‖x‖⁻ⁿ⟨x,·⟩`, twice continuous differentiability, and harmonicity away from the pole, including translated-pole forms. The dimension-three check identifies the normalization with the classical formula `1 / (4π‖x‖)`.

This advances `PDE/README.md`, Lane C, item 15, the milestone **fundamental solution / Newtonian potential of `Δ` on `ℝⁿ`**. The repository already contains the planar logarithmic kernel, its gradient, and its circle flux; the power-law kernel in dimensions at least three is the next missing case of the roadmap's explicitly higher-dimensional target and supplies the kernel and gradient that the sphere-flux and Newtonian-potential constructions consume. After this PR, item 15 still needs the higher-dimensional sphere-flux and distributional identity `-ΔGₙ = δ₀`, then the Newtonian potential, Green functions, Poisson kernels, and Perron's method.

`TauCeti/Analysis/InnerProductSpace/NormPow.lean` supplies the direct reusable prerequisite: for arbitrary real `p`, away from the origin it proves the derivative, Hessian, and radial identity `Δ‖x‖ᵖ = p(p + dim E - 2)‖x‖ᵖ⁻²`. Its first derivative proof adapts the norm-square chain-rule argument of pinned Mathlib's `hasFDerivAt_norm_rpow`, weakening the global hypothesis `1 < p` to the local hypothesis `x ≠ 0`; no Mathlib module or other external formalization is vendored. The Newtonian normalization and gradient follow Evans, *Partial Differential Equations*, Section 2.2, as credited in the module docstring.

The two new files are `TauCeti/Analysis/InnerProductSpace/NormPow.lean` (115 lines) and `TauCeti/Analysis/PDE/FundamentalSolution/Euclidean.lean` (255 lines).

Roadmap: PDE

<!--tauceti-target:v1 {"focus":"PDE","id":"newtonian-kernel-dimension-at-least-three"}-->

🤖 Prepared with Codex
