### PR TITLE
feat(EllipticCurve): integral points from a squarefree leading coefficient

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -17,7 +17,7 @@ that do not mention torsion.
 The first is the rational-root step. If the `x`-coordinate of a `K`-point is a root of some
 `f ∈ R[X]`, the rational root theorem bounds its denominator: `den x ∣ f.leadingCoeff`. On its own
 that is far from integrality — but the denominator of a point is *powerful*
-(`sq_dvd_den_of_prime_dvd`), so any prime dividing it divides it twice, hence divides
+(`sq_dvd_den_of_prime_of_dvd`), so any prime dividing it divides it twice, hence divides
 `f.leadingCoeff` twice. If that leading coefficient is squarefree, no prime can divide the
 denominator at all, so `den x` is a unit and `x` is integral.
 
@@ -93,7 +93,7 @@ variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] {x y : K}
 `f ∈ R[X]` and `f.leadingCoeff` is squarefree, then `x` is integral.
 
 The rational root theorem gives `den x ∣ f.leadingCoeff`; powerfulness of the denominator
-(`sq_dvd_den_of_prime_dvd`) upgrades any prime factor `q` of `den x` to `q * q ∣ f.leadingCoeff`,
+(`sq_dvd_den_of_prime_of_dvd`) upgrades any prime factor `q` of `den x` to `q * q ∣ f.leadingCoeff`,
 which squarefreeness forbids. -/
 theorem isInteger_of_is_root_of_squarefree_leadingCoeff
     (h : (W.baseChange K).toAffine.Equation x y) {f : R[X]} (hroot : aeval x f = 0)
@@ -104,7 +104,7 @@ theorem isInteger_of_is_root_of_squarefree_leadingCoeff
     (mem_nonZeroDivisors_iff_ne_zero.mp (den R x).2)
   have hq : Prime q := UniqueFactorizationMonoid.irreducible_iff_prime.mp hq_irr
   have hden : q * q ∣ (den R x : R) := by
-    rw [← pow_two]; exact sq_dvd_den_of_prime_dvd W h hq hq_dvd
+    rw [← pow_two]; exact sq_dvd_den_of_prime_of_dvd W h hq hq_dvd
   exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
 
 /-- **On the curve over a fraction field, an integral `x`-coordinate forces an integral

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -5,7 +5,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.RingTheory.Polynomial.IsIntegral
-public import Mathlib.RingTheory.Polynomial.RationalRoot
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
 
 /-!
@@ -29,9 +28,10 @@ arbitrary `R`-algebra, with the fraction-field version as a corollary.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.isInteger_of_is_root_of_squarefree_leadingCoeff`: the `x`-coordinate of
-  a point is integral if it is a root of a polynomial over `R` with squarefree leading coefficient.
-* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral`: over **any** `R`-algebra, a
+* `TauCeti.WeierstrassCurve.isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff`: the
+  `x`-coordinate of a point is integral if it is a root of a polynomial over `R` with squarefree
+  leading coefficient.
+* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral_x`: over **any** `R`-algebra, a
   point whose `x`-coordinate is integral over `R` has `y`-coordinate integral over `R`.
 * `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its fraction-field corollary,
   the shape the Nagell–Lutz argument consumes.
@@ -67,7 +67,7 @@ variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 On the curve, `y` is a root of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)`,
 whose coefficients are polynomial in `x` and so are integral whenever `x` is. No domain,
 fraction-field or factorisation hypothesis is needed, and `x` need not come from `R` itself. -/
-theorem isIntegral_y_of_equation_of_isIntegral {A : Type*} [CommRing A] [Algebra R A] {x y : A}
+theorem isIntegral_y_of_equation_of_isIntegral_x {A : Type*} [CommRing A] [Algebra R A] {x y : A}
     (h : (W.baseChange A).toAffine.Equation x y) (hx : IsIntegral R x) : IsIntegral R y := by
   nontriviality A
   rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
@@ -98,8 +98,11 @@ theorem isIntegral_y_of_equation_of_isIntegral {A : Type*} [CommRing A] [Algebra
 
 section FractionField
 
-variable [IsDomain R] [UniqueFactorizationMonoid R]
 variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] {x y : K}
+
+section UniqueFactorization
+
+variable [IsDomain R] [UniqueFactorizationMonoid R]
 
 /-- **The rational-root integrality step.** If the `x`-coordinate of a point of `W` is a root of
 `f ∈ R[X]` and `f.leadingCoeff` is squarefree, then `x` is integral.
@@ -107,7 +110,7 @@ variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] {x y : K}
 The rational root theorem gives `den x ∣ f.leadingCoeff`; powerfulness of the denominator
 (`sq_dvd_den_of_prime_of_dvd`) upgrades any prime factor `q` of `den x` to `q * q ∣ f.leadingCoeff`,
 which squarefreeness forbids. -/
-theorem isInteger_of_is_root_of_squarefree_leadingCoeff
+theorem isInteger_x_of_equation_of_is_root_of_squarefree_leadingCoeff
     (h : (W.baseChange K).toAffine.Equation x y) {f : R[X]} (hroot : aeval x f = 0)
     (hsf : Squarefree f.leadingCoeff) : IsLocalization.IsInteger R x := by
   refine isInteger_of_isUnit_den ?_
@@ -119,14 +122,22 @@ theorem isInteger_of_is_root_of_squarefree_leadingCoeff
     rw [← pow_two]; exact sq_dvd_den_of_prime_of_dvd W h hq hq_dvd
   exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
 
+end UniqueFactorization
+
+section IntegrallyClosed
+
+variable [IsIntegrallyClosed R]
+
 /-- **On the curve over a fraction field, an integral `x`-coordinate forces an integral
-`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral`,
+`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral_x`,
 which is the shape the Nagell–Lutz argument consumes. -/
 theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
     (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
   obtain ⟨x₀, hx₀⟩ := hx
   exact RingHom.mem_rangeS.mpr (IsIntegrallyClosed.isIntegral_iff.mp
-    (isIntegral_y_of_equation_of_isIntegral W h (hx₀ ▸ isIntegral_algebraMap)))
+    (isIntegral_y_of_equation_of_isIntegral_x W h (hx₀ ▸ isIntegral_algebraMap)))
+
+end IntegrallyClosed
 
 end FractionField
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
+public import Mathlib.RingTheory.Polynomial.IsIntegral
 public import Mathlib.RingTheory.Polynomial.RationalRoot
 public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
 
@@ -30,8 +31,8 @@ arbitrary `R`-algebra, with the fraction-field version as a corollary.
 
 * `TauCeti.WeierstrassCurve.isInteger_of_is_root_of_squarefree_leadingCoeff`: the `x`-coordinate of
   a point is integral if it is a root of a polynomial over `R` with squarefree leading coefficient.
-* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_mem_range`: over **any** `R`-algebra, a
-  point whose `x`-coordinate comes from `R` has `y`-coordinate integral over `R`.
+* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_isIntegral`: over **any** `R`-algebra, a
+  point whose `x`-coordinate is integral over `R` has `y`-coordinate integral over `R`.
 * `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its fraction-field corollary,
   the shape the Nagell–Lutz argument consumes.
 
@@ -63,26 +64,37 @@ variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
 /-- **An integral `x`-coordinate forces an integral `y`-coordinate**, over any `R`-algebra.
 
-On the curve, `y` is a root of the monic quadratic `Y² + (a₁x₀ + a₃)Y − (x₀³ + a₂x₀² + a₄x₀ + a₆)`
-over `R`, so `y` is integral over `R`. No domain, fraction-field or factorisation hypothesis is
-needed — only that the `x`-coordinate comes from `R`.
-
-(The variant assuming merely `IsIntegral R x` also holds, by running this argument over
-`Algebra.adjoin R {x}` and applying `isIntegral_trans`; it is not needed by the Nagell–Lutz route,
-where the `x`-coordinate is genuinely an element of `R`.) -/
-theorem isIntegral_y_of_equation_of_mem_range {A : Type*} [CommRing A] [Algebra R A] {x y : A}
-    (h : (W.baseChange A).toAffine.Equation x y) {x₀ : R} (hx₀ : algebraMap R A x₀ = x) :
-    IsIntegral R y := by
-  refine ⟨X ^ 2 + (C (W.a₁ * x₀ + W.a₃) * X + C (-(x₀ ^ 3 + W.a₂ * x₀ ^ 2 + W.a₄ * x₀ + W.a₆))),
-    monic_X_pow_add (by compute_degree!), ?_⟩
+On the curve, `y` is a root of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)`,
+whose coefficients are polynomial in `x` and so are integral whenever `x` is. No domain,
+fraction-field or factorisation hypothesis is needed, and `x` need not come from `R` itself. -/
+theorem isIntegral_y_of_equation_of_isIntegral {A : Type*} [CommRing A] [Algebra R A] {x y : A}
+    (h : (W.baseChange A).toAffine.Equation x y) (hx : IsIntegral R x) : IsIntegral R y := by
+  nontriviality A
   rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
   simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
     _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
     _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
-  simp only [eval₂_add, eval₂_mul, eval₂_pow, eval₂_X, eval₂_C, eval₂_neg, map_add, map_mul,
-    map_pow, map_neg]
-  rw [← hx₀] at h
-  linear_combination h
+  set b : A := algebraMap R A W.a₁ * x + algebraMap R A W.a₃ with hb
+  set c : A := -(x ^ 3 + algebraMap R A W.a₂ * x ^ 2 + algebraMap R A W.a₄ * x
+    + algebraMap R A W.a₆) with hc
+  have hbI : IsIntegral R b := (isIntegral_algebraMap.mul hx).add isIntegral_algebraMap
+  have hcI : IsIntegral R c :=
+    (((hx.pow 3).add (isIntegral_algebraMap.mul (hx.pow 2))).add
+      (isIntegral_algebraMap.mul hx)).add isIntegral_algebraMap |>.neg
+  have hdeg : (X ^ 2 + (C b * X + C c) : A[X]).natDegree = 2 := by compute_degree!
+  refine IsIntegral.of_aeval_monic_of_isIntegral_coeff
+    (p := X ^ 2 + (C b * X + C c)) (monic_X_pow_add (by compute_degree!)) (by omega) ?_ ?_
+  · have heval : Polynomial.eval y (X ^ 2 + (C b * X + C c) : A[X]) = 0 := by
+      simp only [eval_add, eval_pow, eval_X, eval_mul, eval_C, hb, hc]
+      linear_combination h
+    rw [heval]
+    exact isIntegral_zero
+  · intro i
+    match i with
+    | 0 => simpa using hcI
+    | 1 => simpa using hbI
+    | 2 => simpa using (isIntegral_one : IsIntegral R (1 : A))
+    | (n + 3) => simpa using (isIntegral_zero : IsIntegral R (0 : A))
 
 section FractionField
 
@@ -108,13 +120,13 @@ theorem isInteger_of_is_root_of_squarefree_leadingCoeff
   exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
 
 /-- **On the curve over a fraction field, an integral `x`-coordinate forces an integral
-`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_mem_range`,
+`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_isIntegral`,
 which is the shape the Nagell–Lutz argument consumes. -/
 theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
     (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
   obtain ⟨x₀, hx₀⟩ := hx
   exact RingHom.mem_rangeS.mpr (IsIntegrallyClosed.isIntegral_iff.mp
-    (isIntegral_y_of_equation_of_mem_range W h hx₀))
+    (isIntegral_y_of_equation_of_isIntegral W h (hx₀ ▸ isIntegral_algebraMap)))
 
 end FractionField
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -21,16 +21,19 @@ that is far from integrality — but the denominator of a point is *powerful*
 `f.leadingCoeff` twice. If that leading coefficient is squarefree, no prime can divide the
 denominator at all, so `den x` is a unit and `x` is integral.
 
-The second is a one-line consequence of the curve equation: once `x` is integral, `y` is a root of
-the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`, so `y` is integral too.
+The second is a consequence of the curve equation alone: once `x` comes from `R`, `y` is a root of
+the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`, so `y` is integral over
+`R`. That step needs no domain, fraction-field or factorisation hypothesis, so it is stated over an
+arbitrary `R`-algebra, with the fraction-field version as a corollary.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.isInteger_of_aeval_eq_zero_of_squarefree_leadingCoeff`: the
-  `x`-coordinate of a point is integral if it is a root of a polynomial over `R` with squarefree
-  leading coefficient.
-* `TauCeti.WeierstrassCurve.isInteger_of_equation_of_isInteger`: on the curve, an integral
-  `x`-coordinate forces an integral `y`-coordinate.
+* `TauCeti.WeierstrassCurve.isInteger_of_is_root_of_squarefree_leadingCoeff`: the `x`-coordinate of
+  a point is integral if it is a root of a polynomial over `R` with squarefree leading coefficient.
+* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_mem_range`: over **any** `R`-algebra, a
+  point whose `x`-coordinate comes from `R` has `y`-coordinate integral over `R`.
+* `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x`: its fraction-field corollary,
+  the shape the Nagell–Lutz argument consumes.
 
 Both are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In the
 Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is the
@@ -44,7 +47,8 @@ This advances the Nagell–Lutz integrality milestone of
 Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
 that roadmap at `dev/modular-curves @ 9fec8eba7652`:
 `LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean`, declarations
-`isInteger_of_root_squarefree_leading_coeff` and `y_isInteger_of_x_isInteger_on_curve`.
+`isInteger_of_root_squarefree_leading_coeff` and `y_isInteger_of_x_isInteger_on_curve`. The latter
+is generalised here from the fraction field to an arbitrary `R`-algebra.
 -/
 
 public section
@@ -55,9 +59,35 @@ namespace TauCeti
 
 namespace WeierstrassCurve
 
-variable {R : Type*} [CommRing R] [IsDomain R] [UniqueFactorizationMonoid R]
-variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
-variable (W : _root_.WeierstrassCurve R) {x y : K}
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
+
+/-- **An integral `x`-coordinate forces an integral `y`-coordinate**, over any `R`-algebra.
+
+On the curve, `y` is a root of the monic quadratic `Y² + (a₁x₀ + a₃)Y − (x₀³ + a₂x₀² + a₄x₀ + a₆)`
+over `R`, so `y` is integral over `R`. No domain, fraction-field or factorisation hypothesis is
+needed — only that the `x`-coordinate comes from `R`.
+
+(The variant assuming merely `IsIntegral R x` also holds, by running this argument over
+`Algebra.adjoin R {x}` and applying `isIntegral_trans`; it is not needed by the Nagell–Lutz route,
+where the `x`-coordinate is genuinely an element of `R`.) -/
+theorem isIntegral_y_of_equation_of_mem_range {A : Type*} [CommRing A] [Algebra R A] {x y : A}
+    (h : (W.baseChange A).toAffine.Equation x y) {x₀ : R} (hx₀ : algebraMap R A x₀ = x) :
+    IsIntegral R y := by
+  refine ⟨X ^ 2 + (C (W.a₁ * x₀ + W.a₃) * X + C (-(x₀ ^ 3 + W.a₂ * x₀ ^ 2 + W.a₄ * x₀ + W.a₆))),
+    monic_X_pow_add (by compute_degree!), ?_⟩
+  rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
+  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
+    _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
+    _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
+  simp only [eval₂_add, eval₂_mul, eval₂_pow, eval₂_X, eval₂_C, eval₂_neg, map_add, map_mul,
+    map_pow, map_neg]
+  rw [← hx₀] at h
+  linear_combination h
+
+section FractionField
+
+variable [IsDomain R] [UniqueFactorizationMonoid R]
+variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K] {x y : K}
 
 /-- **The rational-root integrality step.** If the `x`-coordinate of a point of `W` is a root of
 `f ∈ R[X]` and `f.leadingCoeff` is squarefree, then `x` is integral.
@@ -65,7 +95,7 @@ variable (W : _root_.WeierstrassCurve R) {x y : K}
 The rational root theorem gives `den x ∣ f.leadingCoeff`; powerfulness of the denominator
 (`sq_dvd_den_of_prime_dvd`) upgrades any prime factor `q` of `den x` to `q * q ∣ f.leadingCoeff`,
 which squarefreeness forbids. -/
-theorem isInteger_of_aeval_eq_zero_of_squarefree_leadingCoeff
+theorem isInteger_of_is_root_of_squarefree_leadingCoeff
     (h : (W.baseChange K).toAffine.Equation x y) {f : R[X]} (hroot : aeval x f = 0)
     (hsf : Squarefree f.leadingCoeff) : IsLocalization.IsInteger R x := by
   refine isInteger_of_isUnit_den ?_
@@ -77,22 +107,16 @@ theorem isInteger_of_aeval_eq_zero_of_squarefree_leadingCoeff
     rw [← pow_two]; exact sq_dvd_den_of_prime_dvd W h hq hq_dvd
   exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
 
-/-- **An integral `x`-coordinate forces an integral `y`-coordinate.** On the curve, `y` is a root
-of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`. -/
-theorem isInteger_of_equation_of_isInteger (h : (W.baseChange K).toAffine.Equation x y)
+/-- **On the curve over a fraction field, an integral `x`-coordinate forces an integral
+`y`-coordinate.** The `IsLocalization.IsInteger` form of `isIntegral_y_of_equation_of_mem_range`,
+which is the shape the Nagell–Lutz argument consumes. -/
+theorem isInteger_y_of_equation_of_isInteger_x (h : (W.baseChange K).toAffine.Equation x y)
     (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
   obtain ⟨x₀, hx₀⟩ := hx
-  set c₁ : R := W.a₁ * x₀ + W.a₃ with hc₁
-  set c₀ : R := -(x₀ ^ 3 + W.a₂ * x₀ ^ 2 + W.a₄ * x₀ + W.a₆) with hc₀
-  refine isInteger_of_is_root_of_monic (p := X ^ 2 + (C c₁ * X + C c₀))
-    (monic_X_pow_add (by compute_degree!)) ?_
-  rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
-  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
-    _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
-    _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
-  simp only [map_add, map_mul, map_pow, aeval_X, aeval_C, hc₁, hc₀, map_neg]
-  rw [← hx₀] at h
-  linear_combination h
+  exact RingHom.mem_rangeS.mpr (IsIntegrallyClosed.isIntegral_iff.mp
+    (isIntegral_y_of_equation_of_mem_range W h hx₀))
+
+end FractionField
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean
@@ -1,0 +1,99 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.Polynomial.RationalRoot
+public import TauCeti.AlgebraicGeometry.EllipticCurve.Denominator
+
+/-!
+# Integrality of points on a Weierstrass curve over a unique factorization domain
+
+Let `R` be a unique factorization domain with fraction field `K` and let `W : WeierstrassCurve R`
+have coefficients in `R`. This file gives the two integrality steps of the Nagell–Lutz argument
+that do not mention torsion.
+
+The first is the rational-root step. If the `x`-coordinate of a `K`-point is a root of some
+`f ∈ R[X]`, the rational root theorem bounds its denominator: `den x ∣ f.leadingCoeff`. On its own
+that is far from integrality — but the denominator of a point is *powerful*
+(`sq_dvd_den_of_prime_dvd`), so any prime dividing it divides it twice, hence divides
+`f.leadingCoeff` twice. If that leading coefficient is squarefree, no prime can divide the
+denominator at all, so `den x` is a unit and `x` is integral.
+
+The second is a one-line consequence of the curve equation: once `x` is integral, `y` is a root of
+the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`, so `y` is integral too.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.isInteger_of_aeval_eq_zero_of_squarefree_leadingCoeff`: the
+  `x`-coordinate of a point is integral if it is a root of a polynomial over `R` with squarefree
+  leading coefficient.
+* `TauCeti.WeierstrassCurve.isInteger_of_equation_of_isInteger`: on the curve, an integral
+  `x`-coordinate forces an integral `y`-coordinate.
+
+Both are stated for an arbitrary point: no torsion, ellipticity or minimality hypothesis. In the
+Nagell–Lutz argument the polynomial `f` is a division polynomial, whose leading coefficient is the
+order of the torsion point.
+
+This advances the Nagell–Lutz integrality milestone of
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz".
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+that roadmap at `dev/modular-curves @ 9fec8eba7652`:
+`LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean`, declarations
+`isInteger_of_root_squarefree_leading_coeff` and `y_isInteger_of_x_isInteger_on_curve`.
+-/
+
+public section
+
+open Polynomial IsFractionRing
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] [IsDomain R] [UniqueFactorizationMonoid R]
+variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+variable (W : _root_.WeierstrassCurve R) {x y : K}
+
+/-- **The rational-root integrality step.** If the `x`-coordinate of a point of `W` is a root of
+`f ∈ R[X]` and `f.leadingCoeff` is squarefree, then `x` is integral.
+
+The rational root theorem gives `den x ∣ f.leadingCoeff`; powerfulness of the denominator
+(`sq_dvd_den_of_prime_dvd`) upgrades any prime factor `q` of `den x` to `q * q ∣ f.leadingCoeff`,
+which squarefreeness forbids. -/
+theorem isInteger_of_aeval_eq_zero_of_squarefree_leadingCoeff
+    (h : (W.baseChange K).toAffine.Equation x y) {f : R[X]} (hroot : aeval x f = 0)
+    (hsf : Squarefree f.leadingCoeff) : IsLocalization.IsInteger R x := by
+  refine isInteger_of_isUnit_den ?_
+  by_contra hnu
+  obtain ⟨q, hq_irr, hq_dvd⟩ := WfDvdMonoid.exists_irreducible_factor hnu
+    (mem_nonZeroDivisors_iff_ne_zero.mp (den R x).2)
+  have hq : Prime q := UniqueFactorizationMonoid.irreducible_iff_prime.mp hq_irr
+  have hden : q * q ∣ (den R x : R) := by
+    rw [← pow_two]; exact sq_dvd_den_of_prime_dvd W h hq hq_dvd
+  exact hq.not_isUnit (hsf q (hden.trans (den_dvd_of_is_root hroot)))
+
+/-- **An integral `x`-coordinate forces an integral `y`-coordinate.** On the curve, `y` is a root
+of the monic quadratic `Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`. -/
+theorem isInteger_of_equation_of_isInteger (h : (W.baseChange K).toAffine.Equation x y)
+    (hx : IsLocalization.IsInteger R x) : IsLocalization.IsInteger R y := by
+  obtain ⟨x₀, hx₀⟩ := hx
+  set c₁ : R := W.a₁ * x₀ + W.a₃ with hc₁
+  set c₀ : R := -(x₀ ^ 3 + W.a₂ * x₀ ^ 2 + W.a₄ * x₀ + W.a₆) with hc₀
+  refine isInteger_of_is_root_of_monic (p := X ^ 2 + (C c₁ * X + C c₀))
+    (monic_X_pow_add (by compute_degree!)) ?_
+  rw [_root_.WeierstrassCurve.Affine.equation_iff] at h
+  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_a₁,
+    _root_.WeierstrassCurve.map_a₂, _root_.WeierstrassCurve.map_a₃,
+    _root_.WeierstrassCurve.map_a₄, _root_.WeierstrassCurve.map_a₆] at h
+  simp only [map_add, map_mul, map_pow, aeval_X, aeval_C, hc₁, hc₀, map_neg]
+  rw [← hx₀] at h
+  linear_combination h
+
+end WeierstrassCurve
+
+end TauCeti


### PR DESCRIPTION
The two integrality steps of the Nagell–Lutz argument that do not mention torsion, for a Weierstrass
curve `W` with coefficients in a unique factorization domain `R` with fraction field `K`.

* `TauCeti.WeierstrassCurve.isInteger_of_is_root_of_squarefree_leadingCoeff` — if the
  `x`-coordinate of a `K`-point is a root of some `f ∈ R[X]` whose leading coefficient is
  squarefree, then `x` is integral.
* `TauCeti.WeierstrassCurve.isIntegral_y_of_equation_of_mem_range` — over **any** `R`-algebra, a
  point whose `x`-coordinate comes from `R` has `y`-coordinate integral over `R`. No domain,
  fraction-field or factorisation hypothesis.
* `TauCeti.WeierstrassCurve.isInteger_y_of_equation_of_isInteger_x` — its fraction-field
  corollary, the shape the Nagell–Lutz argument consumes.

The first is the rational-root step, and it is where the denominator theory pays off. Mathlib's
`den_dvd_of_is_root` gives only `den x ∣ f.leadingCoeff`, which is far from integrality on its own.
But the denominator of a point is *powerful* — `sq_dvd_den_of_prime_of_dvd` — so any prime `q` dividing
it divides it twice, hence `q * q ∣ f.leadingCoeff`, which a squarefree leading coefficient forbids.
So `den x` has no prime factors at all, is a unit, and `x` is integral. The second is a one-line
consequence of the curve equation: `y` is a root of the monic quadratic
`Y² + (a₁x + a₃)Y − (x³ + a₂x² + a₄x + a₆)` over `R`.

In the Nagell–Lutz argument `f` is a division polynomial, whose leading coefficient is the order of
the torsion point — which is why "squarefree leading coefficient" is the hypothesis that later
specialises to "`p` is an unramified prime". Both statements here are for an *arbitrary* point: no
torsion, ellipticity or minimality hypothesis.

### Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item "The torsion subgroup and Nagell–Lutz",
whose targets are `lutz_nagell` and `lutz_nagell_integrality_general` and whose stated route is
"division polynomials". This is the rational-root step of that route.

### No longer stacked

This PR was stacked on #2246 (`EllipticCurve/Denominator.lean`), which supplies the
powerful-denominator input. **#2246 has since merged**, so this branch has been rebased onto main
and the diff is now a single new file. Two consequences of that merge are folded in here: the
prerequisite's commits are gone from the diff, and the call site follows the rename its `naming`
rubric asked for (`sq_dvd_den_of_prime_dvd` → `sq_dvd_den_of_prime_of_dvd`), without which this
branch no longer built against main.

The dependency on it is exactly one `refine` — see the proof of
`isInteger_of_is_root_of_squarefree_leadingCoeff`.

### Provenance

Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`),
`LutzNagell/LutzNagellTheorem/PIDPrimeOrder.lean`: `isInteger_of_root_squarefree_leading_coeff`
(:88) and `y_isInteger_of_x_isInteger_on_curve` (:42).

Divergences from the source: the curve hypothesis is Mathlib's
`(W.baseChange K).toAffine.Equation x y` rather than a hand-written equation; the denominator input
is used in its positive form (`q ∣ den → q ^ 2 ∣ den`) instead of the source's `→ False` form, which
shortens the argument to four lines; and the monic quadratic is built with Mathlib's
`monic_X_pow_add` plus `compute_degree` rather than a hand-rolled `Monic.add_of_left` chain. The
source file's other theorems depend on its vendored division-polynomial copies and on
`ZSMul.lean`, so they are not in this PR.

A pre-review pass on this branch reported two findings, both applied before marking ready: the
`y`-integrality step was stated at the fraction-field/UFD level when the argument needs neither, so
it is now over an arbitrary `R`-algebra with the fraction-field version as a corollary; and the
names now follow Mathlib's rational-root terminology (`den_dvd_of_is_root`) and say which
coordinate is concluded from which.

New file `TauCeti/AlgebraicGeometry/EllipticCurve/Integrality.lean`, 119 lines; longest proof 13
lines; no existing file touched.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md#layer-6-nagell-lutz-rational-root-integrality"}-->
