### PR TITLE
feat: rings of integral elements and Huber pairs

### DIFF
--- a/TauCeti/RingTheory/Huber/Bounded.lean
+++ b/TauCeti/RingTheory/Huber/Bounded.lean
@@ -144,6 +144,14 @@ theorem IsBounded.mul {S T : Set M} (hS : IsBounded S) (hT : IsBounded T) : IsBo
   obtain ⟨V, hV, hSV⟩ := hS W hW
   exact ⟨V, hV, by simpa [← mul_assoc] using (Set.mul_subset_mul_right hSV).trans hTW⟩
 
+/-- Every subset of a discrete ring is bounded: `{0}` is already a neighbourhood of zero. -/
+theorem isBounded_of_discreteTopology [DiscreteTopology M] (S : Set M) : IsBounded S := by
+  rw [isBounded_iff]
+  intro U hU
+  refine ⟨{0}, by simp, ?_⟩
+  rintro _ ⟨_, rfl, s, -, rfl⟩
+  simpa using mem_of_mem_nhds hU
+
 section ContinuousMul
 
 variable [ContinuousMul M]

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -32,11 +32,22 @@ explicit.
   every ring of integral elements.
 * `TauCeti.Huber.Pair.discrete`: a discrete ring is a Huber pair with `A⁺ = A`, so the
   definitions above are not vacuous.
-* `TauCeti.Huber.Pair.Hom.id`, `TauCeti.Huber.Pair.Hom.comp`: morphisms of Huber pairs compose.
+* `TauCeti.Huber.Pair.Hom.id`, `TauCeti.Huber.Pair.Hom.comp`: morphisms of Huber pairs compose,
+  associatively and unitally (`TauCeti.Huber.Pair.Hom.comp_assoc`,
+  `TauCeti.Huber.Pair.Hom.id_comp`, `TauCeti.Huber.Pair.Hom.comp_id`).
+
+## Provenance
+
+The shape of these declarations follows the roadmap's own prototype in
+`TauCetiRoadmap/AdicSpaces/Suggested.lean`, which fixes the design choice that the plus ring is
+explicit data rather than a typeclass, and the selection of results follows AINTLIB's
+`AffinoidRings.lean`; neither's proofs were used.
 
 ## References
 
-* [Wedhorn, *Adic Spaces*][wedhorn_adic], Definition 7.1 and Remark 7.2.
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Definition 7.14 and Remark 7.15.
+* [AINTLIB](https://github.com/CBirkbeck/AINTLIB), branch `dev/adic-spaces`,
+  `projects/AdicSpaces/Adic spaces/AffinoidRings.lean`.
 -/
 
 @[expose] public section
@@ -58,19 +69,25 @@ structure IsRingOfIntegralElements [NonarchimedeanRing A] (Aplus : Subring A) : 
   le_powerBoundedSubring : Aplus ≤ powerBoundedSubring A
 
 omit [IsTopologicalRing A] in
-/-- Wedhorn: an open integrally closed subring contains every topologically nilpotent element,
-so `A°° ⊆ A⁺` for every ring of integral elements.
+/-- Wedhorn: an open integrally closed subring contains every topologically nilpotent element.
 
-The powers of a topologically nilpotent `a` eventually land in `A⁺`, which is a neighbourhood of
-zero; from `aⁿ ∈ A⁺` with `n` positive, `a` is integral over `A⁺` and integral closedness
-finishes. -/
-theorem IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent [NonarchimedeanRing A]
-    {Aplus : Subring A} (h : IsRingOfIntegralElements Aplus) {a : A}
+The powers of a topologically nilpotent `a` eventually land in the subring, which is a
+neighbourhood of zero; from `aⁿ` in it with `n` positive, `a` is integral over it and integral
+closedness finishes. Neither power-boundedness nor a nonarchimedean topology plays any part, so
+this is stated for an arbitrary open integrally closed subring. -/
+theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosed {Aplus : Subring A}
+    (hopen : IsOpen (Aplus : Set A)) (hclosed : ∀ x : A, IsIntegral Aplus x → x ∈ Aplus) {a : A}
     (ha : IsTopologicallyNilpotent a) : a ∈ Aplus := by
   obtain ⟨n, hmem, hn⟩ :=
-    ((ha.eventually_mem (h.isOpen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
-  exact h.isIntegrallyClosed a
-    (IsIntegral.of_pow hn (isIntegral_algebraMap (x := (⟨a ^ n, hmem⟩ : Aplus))))
+    ((ha.eventually_mem (hopen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
+  exact hclosed a (IsIntegral.of_pow hn (isIntegral_algebraMap (x := (⟨a ^ n, hmem⟩ : Aplus))))
+
+omit [IsTopologicalRing A] in
+/-- `A°° ⊆ A⁺` for every ring of integral elements. -/
+theorem IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent [NonarchimedeanRing A]
+    {Aplus : Subring A} (h : IsRingOfIntegralElements Aplus) {a : A}
+    (ha : IsTopologicallyNilpotent a) : a ∈ Aplus :=
+  mem_of_isTopologicallyNilpotent_of_isIntegrallyClosed h.isOpen h.isIntegrallyClosed ha
 
 variable (A) in
 /-- A *Huber pair* `(A, A⁺)`: a Huber ring together with a ring of integral elements. Only the
@@ -115,6 +132,25 @@ theorem Hom.toRingHom_id (S : Pair A) : (Hom.id S).toRingHom = RingHom.id A := r
 @[simp]
 theorem Hom.toRingHom_comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
     (g.comp f).toRingHom = g.toRingHom.comp f.toRingHom := rfl
+
+@[ext]
+theorem Hom.ext {S : Pair A} {T : Pair B} {f g : Hom S T}
+    (h : f.toRingHom = g.toRingHom) : f = g := by
+  cases f; cases g; congr
+
+/-- Composition of morphisms of Huber pairs is associative. -/
+theorem Hom.comp_assoc {D : Type*} [CommRing D] [TopologicalSpace D] [IsTopologicalRing D]
+    [IsHuberRing D] {S : Pair A} {T : Pair B} {U : Pair C} {V : Pair D}
+    (h : Hom U V) (g : Hom T U) (f : Hom S T) : (h.comp g).comp f = h.comp (g.comp f) := by
+  ext; rfl
+
+@[simp]
+theorem Hom.id_comp {S : Pair A} {T : Pair B} (f : Hom S T) : (Hom.id T).comp f = f := by
+  ext; rfl
+
+@[simp]
+theorem Hom.comp_id {S : Pair A} {T : Pair B} (f : Hom S T) : f.comp (Hom.id S) = f := by
+  ext; rfl
 
 variable (A) in
 /-- A discrete ring is a Huber pair with `A⁺ = A`: every element is power-bounded, the whole

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -1,0 +1,132 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
+public import TauCeti.RingTheory.Huber.Basic
+
+/-!
+# Huber pairs
+
+A *ring of integral elements* of a Huber ring `A` is an open subring `A⁺` which is integrally
+closed in `A` and consists of power-bounded elements, and a *Huber pair* `(A, A⁺)` is a Huber
+ring together with such a subring. Huber pairs are the affine objects of the theory: the adic
+spectrum of the next layer is built from one.
+
+A Huber ring has many rings of integral elements, so `A⁺` is carried as data rather than
+selected by a typeclass; this is the roadmap's standing convention that the plus ring is
+explicit.
+
+## Main definitions
+
+* `TauCeti.Huber.IsRingOfIntegralElements`: `A⁺` is open, integrally closed in `A`, and
+  contained in `A°`.
+* `TauCeti.Huber.Pair`: a Huber pair, that is, a choice of `A⁺`.
+* `TauCeti.Huber.Pair.Hom`: a continuous ring homomorphism carrying `A⁺` into `B⁺`.
+
+## Main results
+
+* `TauCeti.Huber.IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent`: `A°° ⊆ A⁺` for
+  every ring of integral elements.
+* `TauCeti.Huber.Pair.discrete`: a discrete ring is a Huber pair with `A⁺ = A`, so the
+  definitions above are not vacuous.
+* `TauCeti.Huber.Pair.Hom.id`, `TauCeti.Huber.Pair.Hom.comp`: morphisms of Huber pairs compose.
+
+## References
+
+* [Wedhorn, *Adic Spaces*][wedhorn_adic], Definition 7.1 and Remark 7.2.
+-/
+
+@[expose] public section
+
+open Filter Topology
+
+namespace TauCeti.Huber
+
+variable {A : Type*} [CommRing A] [TopologicalSpace A] [IsTopologicalRing A]
+
+/-- A subring `A⁺` of a nonarchimedean ring is a *ring of integral elements* if it is open,
+integrally closed in `A`, and contained in the power-bounded subring `A°`. -/
+structure IsRingOfIntegralElements [NonarchimedeanRing A] (Aplus : Subring A) : Prop where
+  /-- `A⁺` is open in `A`. -/
+  isOpen : IsOpen (Aplus : Set A)
+  /-- `A⁺` is integrally closed in `A`. -/
+  isIntegrallyClosed : ∀ x : A, IsIntegral Aplus x → x ∈ Aplus
+  /-- Every element of `A⁺` is power-bounded. -/
+  le_powerBoundedSubring : Aplus ≤ powerBoundedSubring A
+
+omit [IsTopologicalRing A] in
+/-- Wedhorn: an open integrally closed subring contains every topologically nilpotent element,
+so `A°° ⊆ A⁺` for every ring of integral elements.
+
+The powers of a topologically nilpotent `a` eventually land in `A⁺`, which is a neighbourhood of
+zero; from `aⁿ ∈ A⁺` with `n` positive, `a` is integral over `A⁺` and integral closedness
+finishes. -/
+theorem IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent [NonarchimedeanRing A]
+    {Aplus : Subring A} (h : IsRingOfIntegralElements Aplus) {a : A}
+    (ha : IsTopologicallyNilpotent a) : a ∈ Aplus := by
+  obtain ⟨n, hmem, hn⟩ :=
+    ((ha.eventually_mem (h.isOpen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
+  exact h.isIntegrallyClosed a
+    (IsIntegral.of_pow hn (isIntegral_algebraMap (x := (⟨a ^ n, hmem⟩ : Aplus))))
+
+variable (A) in
+/-- A *Huber pair* `(A, A⁺)`: a Huber ring together with a ring of integral elements. Only the
+noncanonical subring `A⁺` is stored; the Huber structure on `A` is a parameter. -/
+structure Pair [IsHuberRing A] where
+  /-- The ring of integral elements `A⁺`. -/
+  plus : Subring A
+  /-- `A⁺` really is a ring of integral elements. -/
+  isRingOfIntegralElements : IsRingOfIntegralElements plus
+
+namespace Pair
+
+variable {B : Type*} [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
+
+/-- A morphism of Huber pairs is a continuous ring homomorphism carrying `A⁺` into `B⁺`. -/
+structure Hom [IsHuberRing A] [IsHuberRing B] (S : Pair A) (T : Pair B) where
+  /-- The underlying ring homomorphism. -/
+  toRingHom : A →+* B
+  /-- The underlying ring homomorphism is continuous. -/
+  continuous_toRingHom : Continuous toRingHom
+  /-- The underlying ring homomorphism carries `A⁺` into `B⁺`. -/
+  map_mem_plus : ∀ a ∈ S.plus, toRingHom a ∈ T.plus
+
+variable {C : Type*} [CommRing C] [TopologicalSpace C] [IsTopologicalRing C]
+variable [IsHuberRing A] [IsHuberRing B] [IsHuberRing C]
+
+/-- The identity morphism of a Huber pair. -/
+def Hom.id (S : Pair A) : Hom S S where
+  toRingHom := RingHom.id A
+  continuous_toRingHom := continuous_id
+  map_mem_plus _ ha := ha
+
+/-- Morphisms of Huber pairs compose. -/
+def Hom.comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) : Hom S U where
+  toRingHom := g.toRingHom.comp f.toRingHom
+  continuous_toRingHom := g.continuous_toRingHom.comp f.continuous_toRingHom
+  map_mem_plus _ ha := g.map_mem_plus _ (f.map_mem_plus _ ha)
+
+@[simp]
+theorem Hom.toRingHom_id (S : Pair A) : (Hom.id S).toRingHom = RingHom.id A := rfl
+
+@[simp]
+theorem Hom.toRingHom_comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
+    (g.comp f).toRingHom = g.toRingHom.comp f.toRingHom := rfl
+
+variable (A) in
+/-- A discrete ring is a Huber pair with `A⁺ = A`: every element is power-bounded, the whole
+ring is open, and `⊤` is trivially integrally closed. This is the witness that the definitions
+above are satisfiable. -/
+def discrete [DiscreteTopology A] : Pair A where
+  plus := ⊤
+  isRingOfIntegralElements :=
+    { isOpen := by simp
+      isIntegrallyClosed := fun _ _ ↦ trivial
+      le_powerBoundedSubring := by simp }
+
+end Pair
+
+end TauCeti.Huber

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -50,7 +50,7 @@ explicit data rather than a typeclass, and the selection of results follows AINT
   `projects/AdicSpaces/Adic spaces/AffinoidRings.lean`.
 -/
 
-@[expose] public section
+public section
 
 open Filter Topology
 
@@ -114,14 +114,17 @@ structure Hom [IsHuberRing A] [IsHuberRing B] (S : Pair A) (T : Pair B) where
 variable {C : Type*} [CommRing C] [TopologicalSpace C] [IsTopologicalRing C]
 variable [IsHuberRing A] [IsHuberRing B] [IsHuberRing C]
 
-/-- The identity morphism of a Huber pair. -/
-def Hom.id (S : Pair A) : Hom S S where
+/-- The identity morphism of a Huber pair. Exposed so that `Hom.toRingHom_id` can state its
+underlying ring homomorphism. -/
+@[expose] def Hom.id (S : Pair A) : Hom S S where
   toRingHom := RingHom.id A
   continuous_toRingHom := continuous_id
   map_mem_plus _ ha := ha
 
-/-- Morphisms of Huber pairs compose. -/
-def Hom.comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) : Hom S U where
+/-- Morphisms of Huber pairs compose. Exposed so that `Hom.toRingHom_comp` can state the
+underlying ring homomorphism. -/
+@[expose] def Hom.comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
+    Hom S U where
   toRingHom := g.toRingHom.comp f.toRingHom
   continuous_toRingHom := g.continuous_toRingHom.comp f.continuous_toRingHom
   map_mem_plus _ ha := g.map_mem_plus _ (f.map_mem_plus _ ha)

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.RingTheory.IntegralClosure.IsIntegral.Basic
+public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
 public import TauCeti.RingTheory.Huber.Basic
 
 /-!
@@ -21,8 +21,8 @@ explicit.
 
 ## Main definitions
 
-* `TauCeti.Huber.IsRingOfIntegralElements`: `A⁺` is open, integrally closed in `A`, and
-  contained in `A°`.
+* `TauCeti.Huber.IsRingOfIntegralElements`: `A⁺` is open, integrally closed in `A` in the
+  sense of Mathlib's `IsIntegrallyClosedIn`, and contained in `A°`.
 * `TauCeti.Huber.Pair`: a Huber pair, that is, a choice of `A⁺`.
 * `TauCeti.Huber.Pair.Hom`: a continuous ring homomorphism carrying `A⁺` into `B⁺`.
 
@@ -64,7 +64,7 @@ structure IsRingOfIntegralElements [NonarchimedeanRing A] (Aplus : Subring A) : 
   /-- `A⁺` is open in `A`. -/
   isOpen : IsOpen (Aplus : Set A)
   /-- `A⁺` is integrally closed in `A`. -/
-  isIntegrallyClosed : ∀ x : A, IsIntegral Aplus x → x ∈ Aplus
+  isIntegrallyClosedIn : IsIntegrallyClosedIn Aplus A
   /-- Every element of `A⁺` is power-bounded. -/
   le_powerBoundedSubring : Aplus ≤ powerBoundedSubring A
 
@@ -75,19 +75,25 @@ The powers of a topologically nilpotent `a` eventually land in the subring, whic
 neighbourhood of zero; from `aⁿ` in it with `n` positive, `a` is integral over it and integral
 closedness finishes. Neither power-boundedness nor a nonarchimedean topology plays any part, so
 this is stated for an arbitrary open integrally closed subring. -/
-theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosed {Aplus : Subring A}
-    (hopen : IsOpen (Aplus : Set A)) (hclosed : ∀ x : A, IsIntegral Aplus x → x ∈ Aplus) {a : A}
+theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosedIn {Aplus : Subring A}
+    (hopen : IsOpen (Aplus : Set A)) [IsIntegrallyClosedIn Aplus A] {a : A}
     (ha : IsTopologicallyNilpotent a) : a ∈ Aplus := by
   obtain ⟨n, hmem, hn⟩ :=
     ((ha.eventually_mem (hopen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
-  exact hclosed a (IsIntegral.of_pow hn (isIntegral_algebraMap (x := (⟨a ^ n, hmem⟩ : Aplus))))
+  have hpow : IsIntegral Aplus (a ^ n) :=
+    isIntegral_algebraMap (R := Aplus) (x := (⟨a ^ n, hmem⟩ : Aplus))
+  obtain ⟨y, hy⟩ :=
+    (IsIntegralClosure.isIntegral_iff (R := Aplus) (A := Aplus) (B := A)).mp
+      (IsIntegral.of_pow hn hpow)
+  exact hy ▸ y.2
 
 omit [IsTopologicalRing A] in
 /-- `A°° ⊆ A⁺` for every ring of integral elements. -/
 theorem IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent [NonarchimedeanRing A]
     {Aplus : Subring A} (h : IsRingOfIntegralElements Aplus) {a : A}
     (ha : IsTopologicallyNilpotent a) : a ∈ Aplus :=
-  mem_of_isTopologicallyNilpotent_of_isIntegrallyClosed h.isOpen h.isIntegrallyClosed ha
+  have := h.isIntegrallyClosedIn
+  mem_of_isTopologicallyNilpotent_of_isIntegrallyClosedIn h.isOpen ha
 
 variable (A) in
 /-- A *Huber pair* `(A, A⁺)`: a Huber ring together with a ring of integral elements. Only the
@@ -163,7 +169,8 @@ def discrete [DiscreteTopology A] : Pair A where
   plus := ⊤
   isRingOfIntegralElements :=
     { isOpen := by simp
-      isIntegrallyClosed := fun _ _ ↦ trivial
+      isIntegrallyClosedIn :=
+        isIntegrallyClosedIn_iff.mpr ⟨Subtype.val_injective, fun _ ↦ ⟨⟨_, trivial⟩, rfl⟩⟩
       le_powerBoundedSubring := by simp }
 
 end Pair

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -71,10 +71,8 @@ structure IsRingOfIntegralElements [NonarchimedeanRing A] (Aplus : Subring A) : 
 omit [IsTopologicalRing A] in
 /-- Wedhorn: an open integrally closed subring contains every topologically nilpotent element.
 
-The powers of a topologically nilpotent `a` eventually land in the subring, which is a
-neighbourhood of zero; from `aⁿ` in it with `n` positive, `a` is integral over it and integral
-closedness finishes. Neither power-boundedness nor a nonarchimedean topology plays any part, so
-this is stated for an arbitrary open integrally closed subring. -/
+Neither power-boundedness nor a nonarchimedean topology plays any part, so this is stated for an
+arbitrary open subring integrally closed in `A`, not just for a ring of integral elements. -/
 theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosedIn {Aplus : Subring A}
     (hopen : IsOpen (Aplus : Set A)) [IsIntegrallyClosedIn Aplus A] {a : A}
     (ha : IsTopologicallyNilpotent a) : a ∈ Aplus := by
@@ -82,10 +80,7 @@ theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosedIn {Aplus : Subring
     ((ha.eventually_mem (hopen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
   have hpow : IsIntegral Aplus (a ^ n) :=
     isIntegral_algebraMap (R := Aplus) (x := (⟨a ^ n, hmem⟩ : Aplus))
-  obtain ⟨y, hy⟩ :=
-    (IsIntegralClosure.isIntegral_iff (R := Aplus) (A := Aplus) (B := A)).mp
-      (IsIntegral.of_pow hn hpow)
-  exact hy ▸ y.2
+  exact Subring.isIntegrallyClosedIn_iff.mp ‹_› (hpow.of_pow hn)
 
 omit [IsTopologicalRing A] in
 /-- `A°° ⊆ A⁺` for every ring of integral elements. -/
@@ -106,6 +101,12 @@ structure Pair [IsHuberRing A] where
 
 namespace Pair
 
+/-- Two Huber pairs on the same Huber ring agree as soon as their rings of integral elements
+do: `A⁺` is the only data a Huber pair carries. -/
+@[ext]
+theorem ext [IsHuberRing A] {S T : Pair A} (h : S.plus = T.plus) : S = T := by
+  cases S; cases T; congr
+
 variable {B : Type*} [CommRing B] [TopologicalSpace B] [IsTopologicalRing B]
 
 /-- A morphism of Huber pairs is a continuous ring homomorphism carrying `A⁺` into `B⁺`. -/
@@ -120,27 +121,25 @@ structure Hom [IsHuberRing A] [IsHuberRing B] (S : Pair A) (T : Pair B) where
 variable {C : Type*} [CommRing C] [TopologicalSpace C] [IsTopologicalRing C]
 variable [IsHuberRing A] [IsHuberRing B] [IsHuberRing C]
 
-/-- The identity morphism of a Huber pair. Exposed so that `Hom.toRingHom_id` can state its
-underlying ring homomorphism. -/
-@[expose] def Hom.id (S : Pair A) : Hom S S where
+/-- The identity morphism of a Huber pair. -/
+def Hom.id (S : Pair A) : Hom S S where
   toRingHom := RingHom.id A
   continuous_toRingHom := continuous_id
   map_mem_plus _ ha := ha
 
-/-- Morphisms of Huber pairs compose. Exposed so that `Hom.toRingHom_comp` can state the
-underlying ring homomorphism. -/
-@[expose] def Hom.comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
+/-- Morphisms of Huber pairs compose. -/
+def Hom.comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
     Hom S U where
   toRingHom := g.toRingHom.comp f.toRingHom
   continuous_toRingHom := g.continuous_toRingHom.comp f.continuous_toRingHom
   map_mem_plus _ ha := g.map_mem_plus _ (f.map_mem_plus _ ha)
 
 @[simp]
-theorem Hom.toRingHom_id (S : Pair A) : (Hom.id S).toRingHom = RingHom.id A := rfl
+theorem Hom.toRingHom_id (S : Pair A) : (Hom.id S).toRingHom = RingHom.id A := (rfl)
 
 @[simp]
 theorem Hom.toRingHom_comp {S : Pair A} {T : Pair B} {U : Pair C} (g : Hom T U) (f : Hom S T) :
-    (g.comp f).toRingHom = g.toRingHom.comp f.toRingHom := rfl
+    (g.comp f).toRingHom = g.toRingHom.comp f.toRingHom := (rfl)
 
 @[ext]
 theorem Hom.ext {S : Pair A} {T : Pair B} {f g : Hom S T}
@@ -151,15 +150,17 @@ theorem Hom.ext {S : Pair A} {T : Pair B} {f g : Hom S T}
 theorem Hom.comp_assoc {D : Type*} [CommRing D] [TopologicalSpace D] [IsTopologicalRing D]
     [IsHuberRing D] {S : Pair A} {T : Pair B} {U : Pair C} {V : Pair D}
     (h : Hom U V) (g : Hom T U) (f : Hom S T) : (h.comp g).comp f = h.comp (g.comp f) := by
-  ext; rfl
+  ext; simp
 
+/-- The identity morphism is a left unit for composition of morphisms of Huber pairs. -/
 @[simp]
 theorem Hom.id_comp {S : Pair A} {T : Pair B} (f : Hom S T) : (Hom.id T).comp f = f := by
-  ext; rfl
+  ext; simp
 
+/-- The identity morphism is a right unit for composition of morphisms of Huber pairs. -/
 @[simp]
 theorem Hom.comp_id {S : Pair A} {T : Pair B} (f : Hom S T) : f.comp (Hom.id S) = f := by
-  ext; rfl
+  ext; simp
 
 variable (A) in
 /-- A discrete ring is a Huber pair with `A⁺ = A`: every element is power-bounded, the whole
@@ -169,9 +170,12 @@ def discrete [DiscreteTopology A] : Pair A where
   plus := ⊤
   isRingOfIntegralElements :=
     { isOpen := by simp
-      isIntegrallyClosedIn :=
-        isIntegrallyClosedIn_iff.mpr ⟨Subtype.val_injective, fun _ ↦ ⟨⟨_, trivial⟩, rfl⟩⟩
+      isIntegrallyClosedIn := Subring.isIntegrallyClosedIn_iff.mpr fun _ _ ↦ trivial
       le_powerBoundedSubring := by simp }
+
+/-- The ring of integral elements of the discrete Huber pair is the whole ring. -/
+@[simp]
+theorem discrete_plus [DiscreteTopology A] : (discrete A).plus = ⊤ := (rfl)
 
 end Pair
 

--- a/TauCeti/RingTheory/Huber/Pair.lean
+++ b/TauCeti/RingTheory/Huber/Pair.lean
@@ -80,7 +80,8 @@ theorem mem_of_isTopologicallyNilpotent_of_isIntegrallyClosedIn {Aplus : Subring
     ((ha.eventually_mem (hopen.mem_nhds Aplus.zero_mem)).and (eventually_gt_atTop 0)).exists
   have hpow : IsIntegral Aplus (a ^ n) :=
     isIntegral_algebraMap (R := Aplus) (x := (⟨a ^ n, hmem⟩ : Aplus))
-  exact Subring.isIntegrallyClosedIn_iff.mp ‹_› (hpow.of_pow hn)
+  obtain ⟨y, hy⟩ := IsIntegrallyClosedIn.exists_algebraMap_eq_of_isIntegral_pow hn hpow
+  exact hy ▸ y.2
 
 omit [IsTopologicalRing A] in
 /-- `A°° ⊆ A⁺` for every ring of integral elements. -/

--- a/TauCeti/RingTheory/Huber/PowerBounded.lean
+++ b/TauCeti/RingTheory/Huber/PowerBounded.lean
@@ -338,6 +338,11 @@ theorem coe_topologicallyNilpotentIdeal :
   Set.ext fun a ↦ ⟨by rintro ⟨b, hb, rfl⟩; exact hb,
     fun ha ↦ ⟨⟨a, IsPowerBounded.of_isTopologicallyNilpotent ha⟩, ha, rfl⟩⟩
 
+/-- In a discrete ring every element is power-bounded, so `A° = A`. -/
+@[simp]
+theorem powerBoundedSubring_eq_top [DiscreteTopology A] : powerBoundedSubring A = ⊤ :=
+  eq_top_iff.mpr fun _ _ ↦ isPowerBounded_iff.mpr (isBounded_of_discreteTopology _)
+
 end Nonarchimedean
 
 section Transport


### PR DESCRIPTION
The rest of Layer 0.2 of the adic-spaces roadmap that the affine theory needs: rings of integral elements and Huber pairs, in a new `TauCeti/RingTheory/Huber/Pair.lean`.

`IsRingOfIntegralElements A⁺` says `A⁺` is open, integrally closed in `A`, and contained in `A°`; `Pair A` is a Huber ring together with such a subring, and `Pair.Hom` is a continuous ring homomorphism carrying `A⁺` into `B⁺`, with `Hom.id` and `Hom.comp`. `A⁺` is data rather than a typeclass selection, per the roadmap's standing convention that the plus ring is explicit — a Huber ring has many rings of integral elements and Layer 2 chooses among them.

The substantive result is `IsRingOfIntegralElements.mem_of_isTopologicallyNilpotent`: every ring of integral elements contains `A°°`, which is the roadmap's "every open integrally closed subring contains `A°°`". The proof uses all three fields — the powers of a topologically nilpotent `a` eventually land in `A⁺` because `A⁺` is a neighbourhood of zero, and `aⁿ ∈ A⁺` for positive `n` makes `a` integral over `A⁺`, so integral closedness puts `a` in `A⁺`.

`Pair.discrete` is the satisfiability witness: a discrete ring is a Huber pair with `A⁺ = A`. It needs two small prerequisites in their canonical homes rather than here — `isBounded_of_discreteTopology` in `Bounded.lean` (every subset of a discrete ring is bounded, since `{0}` is already a neighbourhood of zero) and `powerBoundedSubring_eq_top` in `PowerBounded.lean` (hence `A° = A`). They are three lines each and exist only to support the witness; putting them in `Pair.lean` would be the wrong home.

What this PR deliberately does **not** do: take `A⁺ = A°` as the witness. That needs `A°` to be integrally closed — Wedhorn Proposition 5.30(4) — which is a substantial separate argument (it goes through 5.30(2), that the subring generated by finitely many power-bounded elements is bounded). That is the remaining Layer-0.2 item and follows as its own PR, along with Wedhorn Lemma 6.2 and Lemma 6.6.

Advances `AdicSpaces/README.md` § "Layer 0.2 Huber rings and Tate rings", specifically the bullet "every open integrally closed subring contains `A°°`" and the closing sentence "A ring of integral elements is an open integrally closed subring `A⁺ ⊆ A°`. Define Huber pairs and continuous morphisms of pairs." The structure shape follows `AdicSpaces/Suggested.lean`'s `IsRingOfIntegralElements`/`Pair` prototype. Layer 0.2's own prerequisites are #2263 (Layer 0.1) and #2267 (the Huber/Tate definitions); this branch is stacked on both. A search of the pinned Mathlib for `Huber`, `PairOfDefinition`, `IsTateRing` and `ringOfDefinition` returns nothing, so none of this duplicates existing material; `IsIntegral` and `IsIntegral.of_pow` are reused rather than reproved.

Roadmap: AdicSpaces

<!--tauceti-target:v1 {"focus":"AdicSpaces","id":"layer-0.2-huber-pairs"}-->

🤖 Prepared with Claude Code
