### PR TITLE
feat(HeckeRing): the GL(2) diagonal Hecke basis and T(n)

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -29,12 +29,12 @@ Chris Birkbeck).
 
 ## Main results
 
-* `HeckeRing.GL2.heckeTDiag_one_one`: `T(1, 1) = 1`.
+* `HeckeRing.GL2.heckeTDiag_one_one`: `T(1, 1) = 1`, with `heckeTScalar_one` its scalar form.
 * `HeckeRing.GL2.heckeT_one`: `T(1) = 1`.
 * `HeckeRing.GL2.heckeT_prime`: `T(p) = T(1, p)` for prime `p`.
 * `HeckeRing.GL2.heckeTDiag_mul_of_coprime`: `T(a,da) · T(b,db) = T(ab, da·db)` for
   coprime determinants — coprimality alone, the zero-extension covering the rest.
-* `HeckeRing.GL2.heckeT_mul_coprime`: `T(m) · T(n) = T(mn)` for coprime `m`, `n`.
+* `HeckeRing.GL2.heckeT_mul_of_coprime`: `T(m) · T(n) = T(mn)` for coprime `m`, `n`.
 
 ## References
 
@@ -57,12 +57,11 @@ noncomputable def heckeTDiag (a d : ℕ) : IntegralHeckeRing 2 :=
 lemma heckeTDiag_def (a d : ℕ) :
     heckeTDiag a d = if 0 < a ∧ 0 < d ∧ a ∣ d then diagElem ![a, d] else 0 := (rfl)
 
-/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold.
-
-Deliberately not `@[simp]`: it rewrites *past* `heckeTDiag_one_one`. With this tagged,
-`heckeTDiag 1 1` normalises to `diagElem ![1, 1]` rather than to `1`, and it stops there —
-`diagElem_one` is stated for `fun _ ↦ 1`, which `![1, 1]` does not match syntactically. The
-identity normal form `T(1, 1) = 1` is the more useful one, so this stays a cited lemma. -/
+/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold. -/
+-- Deliberately not `@[simp]`: it rewrites *past* `heckeTDiag_one_one`. With this tagged,
+-- `heckeTDiag 1 1` normalises to `diagElem ![1, 1]` rather than to `1`, and it stops there —
+-- `diagElem_one` is stated for `fun _ ↦ 1`, which `![1, 1]` does not match syntactically. The
+-- identity normal form `T(1, 1) = 1` is the more useful one, so this stays a cited lemma.
 lemma heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (h : a ∣ d) :
     heckeTDiag a d = diagElem ![a, d] :=
   if_pos ⟨ha, hd, h⟩
@@ -76,12 +75,11 @@ lemma heckeTDiag_eq_zero {a d : ℕ} (h : ¬(0 < a ∧ 0 < d ∧ a ∣ d)) : hec
 noncomputable def heckeTScalar (c : ℕ) : IntegralHeckeRing 2 :=
   heckeTDiag c c
 
-/-- The defining equation of `heckeTScalar`.
-
-Deliberately not `@[simp]`: unfolding `heckeTScalar c` to `heckeTDiag c c` would leave the
-left-hand side of `heckeTScalar_of_pos` in non-normal form, which `simpNF` rejects. Only one of
-the two can carry the attribute, and `heckeTScalar_of_pos` is the one that reduces to a
-diagonal element. -/
+/-- The defining equation of `heckeTScalar`. -/
+-- Deliberately not `@[simp]`: unfolding `heckeTScalar c` to `heckeTDiag c c` would leave the
+-- left-hand side of `heckeTScalar_of_pos` in non-normal form, which `simpNF` rejects. Only one
+-- of the two can carry the attribute, and `heckeTScalar_of_pos` is the one that reduces to a
+-- diagonal element.
 lemma heckeTScalar_def (c : ℕ) : heckeTScalar c = heckeTDiag c c := (rfl)
 
 /-- `T(0, 0) = 0`: the scalar operator of `0` is zero, since the divisor-pair conditions fail.
@@ -93,13 +91,12 @@ lemma heckeTScalar_zero : heckeTScalar 0 = 0 := by
   rw [heckeTScalar_def]
   exact heckeTDiag_eq_zero (by simp)
 
-/-- The scalar operator of a positive `c` is the constant diagonal element.
-
-Deliberately not `@[simp]`, although an earlier api-design round asked for it. Tagging this
-unfolds every `heckeTScalar p` to `diagElem (fun _ ↦ p)`, which leaves the left-hand side of
-`heckeTScalar_mul_heckeTDiag_prime_pow` non-normal — `simpNF` rejects that, and the index shift
-is the rule worth keeping: it collapses `T(p,p) · T(pʲ, p^d)` to a single `heckeTDiag`, the
-normal form the GL₂ multiplication table works in. This stays an explicit citation. -/
+/-- The scalar operator of a positive `c` is the constant diagonal element. -/
+-- Deliberately not `@[simp]`, although an earlier api-design round asked for it. Tagging this
+-- unfolds every `heckeTScalar p` to `diagElem (fun _ ↦ p)`, which leaves the left-hand side of
+-- `heckeTScalar_mul_heckeTDiag_prime_pow` non-normal — `simpNF` rejects that, and the index
+-- shift is the rule worth keeping: it collapses `T(p,p) · T(pʲ, p^d)` to a single
+-- `heckeTDiag`, the normal form the GL₂ multiplication table works in.
 lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
     heckeTScalar c = diagElem (fun _ : Fin 2 ↦ c) := by
   rw [heckeTScalar, heckeTDiag_of_pos hc hc dvd_rfl]
@@ -110,6 +107,13 @@ lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
   rw [heckeTDiag_of_pos one_pos one_pos dvd_rfl,
     show ![1, 1] = (fun _ : Fin 2 ↦ 1) from funext fun i ↦ by fin_cases i <;> rfl]
   exact diagElem_one
+
+/-- `T(1, 1) = 1` in scalar form: the scalar operator of `1` is the identity. Together with
+`heckeTScalar_zero` and `heckeTScalar_of_pos` this closes the `ℕ`-valued interface at its
+canonical input. -/
+@[simp] lemma heckeTScalar_one : heckeTScalar 1 = 1 := by
+  rw [heckeTScalar_def]
+  exact heckeTDiag_one_one
 
 /-- Shimura's summed Hecke operator: `T(m) = ∑_{a ∣ m} T(a, m / a)`. -/
 noncomputable def heckeT (m : ℕ+) : IntegralHeckeRing 2 :=
@@ -209,7 +213,7 @@ lemma heckeTDiag_mul_of_coprime (a b da db : ℕ)
 open scoped Pointwise in
 /-- **Shimura, Theorem 3.24(3a)** — coprime multiplicativity: `T(m) · T(n) = T(mn)` when
 `m` and `n` are coprime. -/
-theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ)) :
+theorem heckeT_mul_of_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ)) :
     heckeT m * heckeT n = heckeT (m * n) := by
   simp only [heckeT_def, PNat.mul_coe]
   -- `Finset` pointwise multiplication is by definition the image of the product set,

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -1,0 +1,227 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.GLn.PrimeDecomposition
+
+import Mathlib.Data.Finset.NatDivisors
+
+/-!
+# The `GL₂` Hecke operators `T(a, d)` and `T(m)`
+
+The specialization of the `GL_n` Hecke ring to `n = 2`: the basis operators `T(a, d)` for
+divisor pairs `a ∣ d`, the scalar operators `T(c, c)`, and Shimura's summed operator
+`T(m) = ∑_{a ∣ m} T(a, m / a)`.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/Basic.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck).
+
+## Main definitions
+
+* `HeckeRing.GL2.heckeTDiag`: `T(a, d)`, zero unless `0 < a`, `0 < d`, `a ∣ d`.
+* `HeckeRing.GL2.heckeTScalar`: the scalar operator `T(c, c)`.
+* `HeckeRing.GL2.heckeT`: Shimura's `T(m) = ∑_{a ∣ m} T(a, m / a)`.
+
+## Main results
+
+* `HeckeRing.GL2.heckeTDiag_one_one`: `T(1, 1) = 1`.
+* `HeckeRing.GL2.heckeT_one`: `T(1) = 1`.
+* `HeckeRing.GL2.heckeT_prime`: `T(p) = T(1, p)` for prime `p`.
+* `HeckeRing.GL2.heckeTDiag_mul_of_coprime`: `T(a,da) · T(b,db) = T(ab, da·db)` for
+  coprime determinants.
+* `HeckeRing.GL2.heckeT_mul_coprime`: `T(m) · T(n) = T(mn)` for coprime `m`, `n`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Theorem 3.24.
+-/
+
+public section
+
+open Matrix HeckeRing DoubleCoset Finset HeckeRing.GLn
+
+namespace HeckeRing.GL2
+
+/-- `T(a, d)`: the diagonal Hecke basis element of the pair `(a, d)`, zero unless
+`0 < a`, `0 < d` and `a ∣ d`. -/
+noncomputable def heckeTDiag (a d : ℕ) : IntegralHeckeRing 2 :=
+  if 0 < a ∧ 0 < d ∧ a ∣ d then diagElem ![a, d] else 0
+
+/-- Defining equation for the sealed `heckeTDiag`. -/
+lemma heckeTDiag_def (a d : ℕ) :
+    heckeTDiag a d = if 0 < a ∧ 0 < d ∧ a ∣ d then diagElem ![a, d] else 0 := (rfl)
+
+/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold. -/
+lemma heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (h : a ∣ d) :
+    heckeTDiag a d = diagElem ![a, d] :=
+  if_pos ⟨ha, hd, h⟩
+
+/-- `T(a, d)` is zero when the divisor-pair conditions fail. -/
+lemma heckeTDiag_eq_zero {a d : ℕ} (h : ¬(0 < a ∧ 0 < d ∧ a ∣ d)) : heckeTDiag a d = 0 :=
+  if_neg h
+
+/-- `T(c, c)`: the scalar Hecke operator. -/
+noncomputable def heckeTScalar (c : ℕ) : IntegralHeckeRing 2 :=
+  heckeTDiag c c
+
+/-- The defining equation of `heckeTScalar`. -/
+lemma heckeTScalar_def (c : ℕ) : heckeTScalar c = heckeTDiag c c := (rfl)
+
+/-- The scalar operator of a positive `c` is the constant diagonal element. -/
+lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
+    heckeTScalar c = diagElem (fun _ : Fin 2 ↦ c) := by
+  rw [heckeTScalar, heckeTDiag_of_pos hc hc dvd_rfl]
+  exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> rfl)
+
+/-- `T(1, 1)` is the identity. -/
+@[simp] lemma heckeTDiag_one_one : heckeTDiag 1 1 = 1 := by
+  rw [heckeTDiag_of_pos one_pos one_pos dvd_rfl,
+    show ![1, 1] = (fun _ : Fin 2 ↦ 1) from funext fun i ↦ by fin_cases i <;> rfl]
+  exact diagElem_one
+
+/-- Shimura's summed Hecke operator: `T(m) = ∑_{a ∣ m} T(a, m / a)`. -/
+noncomputable def heckeT (m : ℕ+) : IntegralHeckeRing 2 :=
+  ∑ a ∈ (m : ℕ).divisors, heckeTDiag a ((m : ℕ) / a)
+
+/-- The defining equation of `heckeT`. -/
+lemma heckeT_def (m : ℕ+) :
+    heckeT m = ∑ a ∈ (m : ℕ).divisors, heckeTDiag a ((m : ℕ) / a) := (rfl)
+
+/-- `T(1) = 1`: the only divisor pair of `1` is `(1,1)`. -/
+@[simp] lemma heckeT_one : heckeT 1 = 1 := by
+  rw [heckeT_def]
+  simp only [PNat.one_coe, Nat.divisors_one, Finset.sum_singleton, Nat.div_self one_pos]
+  exact heckeTDiag_one_one
+
+/-- For a prime `p`, the summed operator collapses: `T(p) = T(1, p)`. -/
+lemma heckeT_prime (p : ℕ) (hp : p.Prime) : heckeT ⟨p, hp.pos⟩ = heckeTDiag 1 p := by
+  -- `heckeT` is sealed (`public section`, no `@[expose]`), so `rw`/`simp` cannot unfold it;
+  -- `change` states the defeq divisor-pair sum directly
+  change ∑ a ∈ p.divisors, heckeTDiag a (p / a) = _
+  rw [hp.sum_divisors, Nat.div_self hp.pos, Nat.div_one,
+    heckeTDiag_eq_zero (fun ⟨_, _, hdvd⟩ ↦ hp.ne_one (Nat.dvd_one.mp hdvd)), zero_add]
+
+section Structural
+
+variable (p : ℕ)
+
+/-- Powers of the scalar operator: `T(p,p) ^ i = T(pⁱ,...,pⁱ)`. -/
+lemma heckeTScalar_pow (hp : 0 < p) (i : ℕ) :
+    heckeTScalar p ^ i = diagElem (fun _ : Fin 2 ↦ p ^ i) := by
+  induction i with
+  | zero =>
+    rw [pow_zero]
+    exact ((congrArg diagElem (funext fun _ ↦ by simp)).trans diagElem_one).symm
+  | succ i ih =>
+    rw [pow_succ', ih, heckeTScalar_of_pos hp,
+      diagElem_const_mul 2 p hp (fun _ ↦ p ^ i) (fun _ ↦ pow_pos hp i)]
+    exact congrArg diagElem (funext fun _ ↦ by simp [Pi.mul_apply, pow_succ, mul_comm])
+
+/-- Expansion of `T(pᵏ)`: only the divisor pairs `(pⁱ, p^(k-i))` with `i ≤ k - i`
+contribute. -/
+lemma heckeT_ppow_expansion (hp : p.Prime) (k : ℕ) :
+    heckeT ⟨p ^ k, pow_pos hp.pos k⟩ =
+      ∑ i ∈ Finset.range (k / 2 + 1), heckeTDiag (p ^ i) (p ^ (k - i)) := by
+  -- `heckeT` is sealed (`public section`, no `@[expose]`), so `rw`/`simp` cannot unfold it;
+  -- `change` states the defeq divisor-pair sum directly
+  change ∑ a ∈ (p ^ k).divisors, heckeTDiag a (p ^ k / a) = _
+  rw [Nat.sum_divisors_prime_pow hp, Finset.sum_congr rfl
+    (g := fun j ↦ heckeTDiag (p ^ j) (p ^ (k - j))) fun j hj ↦ by
+      rw [Nat.pow_div (Nat.lt_succ_iff.mp (Finset.mem_range.mp hj)) hp.pos]]
+  refine (Finset.sum_subset (Finset.range_mono (by omega)) fun j hj hnj ↦ ?_).symm
+  simp only [Finset.mem_range] at hj hnj
+  exact heckeTDiag_eq_zero fun ⟨_, _, hdvd⟩ ↦ absurd (Nat.le_of_dvd (pow_pos hp.pos _) hdvd)
+    (not_le_of_gt (Nat.pow_lt_pow_right hp.one_lt (by omega)))
+
+/-- **Coprime multiplicativity** (Shimura, Proposition 3.16 in the `GL₂` notation):
+`T(a, da) · T(b, db) = T(ab, da·db)` when the determinants `a·da` and `b·db` are coprime. -/
+lemma heckeTDiag_mul_of_coprime (a b da db : ℕ) (hda : 0 < da)
+    (hdb : 0 < db) (hdva : a ∣ da) (hdvb : b ∣ db)
+    (hcop : Nat.Coprime (a * da) (b * db)) :
+    heckeTDiag a da * heckeTDiag b db = heckeTDiag (a * b) (da * db) := by
+  -- positivity of the left entries is forced: a divisor of a positive number is positive
+  have ha : 0 < a := Nat.pos_of_dvd_of_pos hdva hda
+  have hb : 0 < b := Nat.pos_of_dvd_of_pos hdvb hdb
+  rw [heckeTDiag_of_pos ha hda hdva, heckeTDiag_of_pos hb hdb hdvb,
+    heckeTDiag_of_pos (Nat.mul_pos ha hb) (Nat.mul_pos hda hdb) (Nat.mul_dvd_mul hdva hdvb)]
+  have hprod : diagElem ((![a, da] : Fin 2 → ℕ) * ![b, db]) =
+      diagElem (![a * b, da * db] : Fin 2 → ℕ) :=
+    congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply])
+  rw [← hprod]
+  exact diagElem_mul_of_coprime 2 ![a, da] ![b, db]
+    (fun i ↦ by fin_cases i <;> simp [ha, hda])
+    (fun i ↦ by fin_cases i <;> simp [hb, hdb])
+    (by simpa [Fin.prod_univ_two] using hcop)
+
+private lemma heckeTDiag_mul_eq_zero_left {a da : ℕ} (h : ¬(0 < a ∧ 0 < da ∧ a ∣ da))
+    (x : IntegralHeckeRing 2) : heckeTDiag a da * x = 0 := by
+  rw [heckeTDiag_eq_zero h, zero_mul]
+
+private lemma heckeTDiag_mul_eq_zero_right {b db : ℕ} (h : ¬(0 < b ∧ 0 < db ∧ b ∣ db))
+    (x : IntegralHeckeRing 2) : x * heckeTDiag b db = 0 := by
+  rw [heckeTDiag_eq_zero h, mul_zero]
+
+/-- Multiplying divisor pairs is injective on the divisors of coprime numbers. -/
+private lemma mul_injOn_coprime_divisors (m n : ℕ) (hcop : Nat.Coprime m n) :
+    Set.InjOn (fun q : ℕ × ℕ ↦ q.1 * q.2) (↑(m.divisors ×ˢ n.divisors)) := by
+  rintro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
+  simp only [Finset.mem_coe, Finset.mem_product, Nat.mem_divisors] at h₁ h₂
+  simp only at heq
+  have haeq : a₁ = a₂ := Nat.dvd_antisymm
+    (((hcop.coprime_dvd_left h₁.1.1).coprime_dvd_right h₂.2.1).dvd_of_dvd_mul_right
+      (heq ▸ dvd_mul_right a₁ b₁))
+    (((hcop.coprime_dvd_left h₂.1.1).coprime_dvd_right h₁.2.1).dvd_of_dvd_mul_right
+      (heq ▸ dvd_mul_right a₂ b₂))
+  have ha_pos : 0 < a₁ := Nat.pos_of_ne_zero fun h ↦ by simp [h] at h₁
+  exact Prod.ext haeq (Nat.eq_of_mul_eq_mul_left ha_pos (haeq ▸ heq))
+
+open scoped Pointwise in
+/-- **Shimura, Theorem 3.24(3a)** — coprime multiplicativity: `T(m) · T(n) = T(mn)` when
+`m` and `n` are coprime. -/
+theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ)) :
+    heckeT m * heckeT n = heckeT (m * n) := by
+  simp only [heckeT_def, PNat.mul_coe]
+  -- `Finset` pointwise multiplication is by definition the image of the product set,
+  -- so the divisor-set product can be reindexed as a sum over pairs
+  rw [Finset.sum_mul_sum, Nat.divisors_mul,
+    show ((m : ℕ).divisors * (n : ℕ).divisors) =
+      ((m : ℕ).divisors ×ˢ (n : ℕ).divisors).image (fun q ↦ q.1 * q.2) from rfl,
+    Finset.sum_image (mul_injOn_coprime_divisors _ _ hcop), ← Finset.sum_product']
+  refine Finset.sum_congr rfl fun q hq ↦ ?_
+  obtain ⟨a, b⟩ := q
+  simp only [Finset.mem_product, Nat.mem_divisors] at hq
+  have ha_pos : 0 < a := Nat.pos_of_ne_zero fun h ↦ by simp [h] at hq
+  have hb_pos : 0 < b := Nat.pos_of_ne_zero fun h ↦ by simp [h] at hq
+  rw [(Nat.div_mul_div_comm hq.1.1 hq.2.1).symm]
+  by_cases hca : a ∣ (m : ℕ) / a
+  · by_cases hcb : b ∣ (n : ℕ) / b
+    · refine heckeTDiag_mul_of_coprime a b _ _
+        (Nat.div_pos (Nat.le_of_dvd (by omega) hq.1.1) ha_pos)
+        (Nat.div_pos (Nat.le_of_dvd (by omega) hq.2.1) hb_pos) hca hcb ?_
+      rwa [Nat.mul_div_cancel' hq.1.1, Nat.mul_div_cancel' hq.2.1]
+    · rw [heckeTDiag_mul_eq_zero_right (by push Not; intro _ _; exact hcb)
+        (heckeTDiag a ((m : ℕ) / a))]
+      symm
+      refine heckeTDiag_eq_zero ?_
+      push Not
+      intro _ _ hdvd
+      exact absurd (((hcop.symm.coprime_dvd_left hq.2.1).coprime_dvd_right
+        (Nat.div_dvd_of_dvd hq.1.1)).dvd_of_dvd_mul_left
+        (dvd_trans (dvd_mul_left b a) hdvd)) hcb
+  · rw [heckeTDiag_mul_eq_zero_left (by push Not; intro _ _; exact hca)]
+    symm
+    refine heckeTDiag_eq_zero ?_
+    push Not
+    intro _ _ hdvd
+    exact absurd (((hcop.coprime_dvd_left hq.1.1).coprime_dvd_right
+      (Nat.div_dvd_of_dvd hq.2.1)).dvd_of_dvd_mul_right
+      (dvd_trans (dvd_mul_right a b) hdvd)) hca
+
+end Structural
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -126,7 +126,7 @@ lemma heckeTScalar_pow (hp : 0 < p) (i : ℕ) :
 
 /-- Expansion of `T(pᵏ)`: only the divisor pairs `(pⁱ, p^(k-i))` with `i ≤ k - i`
 contribute. -/
-lemma heckeT_primePow_expansion (hp : p.Prime) (k : ℕ) :
+lemma heckeT_prime_pow_expansion (hp : p.Prime) (k : ℕ) :
     heckeT ⟨p ^ k, pow_pos hp.pos k⟩ =
       ∑ i ∈ Finset.range (k / 2 + 1), heckeTDiag (p ^ i) (p ^ (k - i)) := by
   -- `heckeT` is sealed (`public section`, no `@[expose]`), so `rw`/`simp` cannot unfold it;

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -33,7 +33,8 @@ Chris Birkbeck).
 * `HeckeRing.GL2.heckeT_one`: `T(1) = 1`.
 * `HeckeRing.GL2.heckeT_prime`: `T(p) = T(1, p)` for prime `p`.
 * `HeckeRing.GL2.heckeTDiag_mul_of_coprime`: `T(a,da) · T(b,db) = T(ab, da·db)` for
-  coprime determinants.
+  coprime determinants, both operators being basis elements (`0 < da`, `0 < db`, `a ∣ da`,
+  `b ∣ db`).
 * `HeckeRing.GL2.heckeT_mul_coprime`: `T(m) · T(n) = T(mn)` for coprime `m`, `n`.
 
 ## References
@@ -140,7 +141,11 @@ lemma heckeT_primePow_expansion (hp : p.Prime) (k : ℕ) :
     (not_le_of_gt (Nat.pow_lt_pow_right hp.one_lt (by omega)))
 
 /-- **Coprime multiplicativity** (Shimura, Proposition 3.16 in the `GL₂` notation):
-`T(a, da) · T(b, db) = T(ab, da·db)` when the determinants `a·da` and `b·db` are coprime. -/
+`T(a, da) · T(b, db) = T(ab, da·db)` when the determinants `a·da` and `b·db` are coprime.
+
+Coprimality is not the only hypothesis: both operators must be genuine basis elements, so
+`da` and `db` are positive and `a ∣ da`, `b ∣ db`. Positivity of `a` and `b` is *not* assumed
+— it follows, a divisor of a positive number being positive. -/
 lemma heckeTDiag_mul_of_coprime (a b da db : ℕ) (hda : 0 < da)
     (hdb : 0 < db) (hdva : a ∣ da) (hdvb : b ∣ db)
     (hcop : Nat.Coprime (a * da) (b * db)) :

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -158,28 +158,6 @@ lemma heckeTDiag_mul_of_coprime (a b da db : ℕ) (hda : 0 < da)
     (fun i ↦ by fin_cases i <;> simp [hb, hdb])
     (by simpa [Fin.prod_univ_two] using hcop)
 
-private lemma heckeTDiag_mul_eq_zero_left {a da : ℕ} (h : ¬(0 < a ∧ 0 < da ∧ a ∣ da))
-    (x : IntegralHeckeRing 2) : heckeTDiag a da * x = 0 := by
-  rw [heckeTDiag_eq_zero h, zero_mul]
-
-private lemma heckeTDiag_mul_eq_zero_right {b db : ℕ} (h : ¬(0 < b ∧ 0 < db ∧ b ∣ db))
-    (x : IntegralHeckeRing 2) : x * heckeTDiag b db = 0 := by
-  rw [heckeTDiag_eq_zero h, mul_zero]
-
-/-- Multiplying divisor pairs is injective on the divisors of coprime numbers. -/
-private lemma mul_injOn_coprime_divisors (m n : ℕ) (hcop : Nat.Coprime m n) :
-    Set.InjOn (fun q : ℕ × ℕ ↦ q.1 * q.2) (↑(m.divisors ×ˢ n.divisors)) := by
-  rintro ⟨a₁, b₁⟩ h₁ ⟨a₂, b₂⟩ h₂ heq
-  simp only [Finset.mem_coe, Finset.mem_product, Nat.mem_divisors] at h₁ h₂
-  simp only at heq
-  have haeq : a₁ = a₂ := Nat.dvd_antisymm
-    (((hcop.coprime_dvd_left h₁.1.1).coprime_dvd_right h₂.2.1).dvd_of_dvd_mul_right
-      (heq ▸ dvd_mul_right a₁ b₁))
-    (((hcop.coprime_dvd_left h₂.1.1).coprime_dvd_right h₁.2.1).dvd_of_dvd_mul_right
-      (heq ▸ dvd_mul_right a₂ b₂))
-  have ha_pos : 0 < a₁ := Nat.pos_of_ne_zero fun h ↦ by simp [h] at h₁
-  exact Prod.ext haeq (Nat.eq_of_mul_eq_mul_left ha_pos (haeq ▸ heq))
-
 open scoped Pointwise in
 /-- **Shimura, Theorem 3.24(3a)** — coprime multiplicativity: `T(m) · T(n) = T(mn)` when
 `m` and `n` are coprime. -/
@@ -191,7 +169,7 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
   rw [Finset.sum_mul_sum, Nat.divisors_mul,
     show ((m : ℕ).divisors * (n : ℕ).divisors) =
       ((m : ℕ).divisors ×ˢ (n : ℕ).divisors).image (fun q ↦ q.1 * q.2) from rfl,
-    Finset.sum_image (mul_injOn_coprime_divisors _ _ hcop), ← Finset.sum_product']
+    Finset.sum_image hcop.mul_injOn_divisors, ← Finset.sum_product']
   refine Finset.sum_congr rfl fun q hq ↦ ?_
   obtain ⟨a, b⟩ := q
   simp only [Finset.mem_product, Nat.mem_divisors] at hq
@@ -204,7 +182,7 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
         (Nat.div_pos (Nat.le_of_dvd (by omega) hq.1.1) ha_pos)
         (Nat.div_pos (Nat.le_of_dvd (by omega) hq.2.1) hb_pos) hca hcb ?_
       rwa [Nat.mul_div_cancel' hq.1.1, Nat.mul_div_cancel' hq.2.1]
-    · rw [heckeTDiag_mul_eq_zero_right (by push Not; intro _ _; exact hcb)
+    · rw [heckeTDiag_eq_zero (by push Not; intro _ _; exact hcb), mul_zero
         (heckeTDiag a ((m : ℕ) / a))]
       symm
       refine heckeTDiag_eq_zero ?_
@@ -213,7 +191,7 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
       exact absurd (((hcop.symm.coprime_dvd_left hq.2.1).coprime_dvd_right
         (Nat.div_dvd_of_dvd hq.1.1)).dvd_of_dvd_mul_left
         (dvd_trans (dvd_mul_left b a) hdvd)) hcb
-  · rw [heckeTDiag_mul_eq_zero_left (by push Not; intro _ _; exact hca)]
+  · rw [heckeTDiag_eq_zero (by push Not; intro _ _; exact hca), zero_mul]
     symm
     refine heckeTDiag_eq_zero ?_
     push Not

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -84,6 +84,15 @@ the two can carry the attribute, and `heckeTScalar_of_pos` is the one that reduc
 diagonal element. -/
 lemma heckeTScalar_def (c : ℕ) : heckeTScalar c = heckeTDiag c c := (rfl)
 
+/-- `T(0, 0) = 0`: the scalar operator of `0` is zero, since the divisor-pair conditions fail.
+
+Together with `heckeTScalar_of_pos` this covers the whole `ℕ`-valued interface, so consumers
+never need to unfold through `heckeTScalar_def`. -/
+@[simp]
+lemma heckeTScalar_zero : heckeTScalar 0 = 0 := by
+  rw [heckeTScalar_def]
+  exact heckeTDiag_eq_zero (by simp)
+
 /-- The scalar operator of a positive `c` is the constant diagonal element.
 
 Deliberately not `@[simp]`, although an earlier api-design round asked for it. Tagging this

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -5,7 +5,7 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.GLn.PrimeDecomposition
+public import TauCeti.NumberTheory.HeckeRing.GLn.CoprimeMul
 public import TauCeti.NumberTheory.HeckeRing.GLn.ScalarMul
 
 import Mathlib.Data.Finset.NatDivisors

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -84,8 +84,13 @@ the two can carry the attribute, and `heckeTScalar_of_pos` is the one that reduc
 diagonal element. -/
 lemma heckeTScalar_def (c : ℕ) : heckeTScalar c = heckeTDiag c c := (rfl)
 
-/-- The scalar operator of a positive `c` is the constant diagonal element. -/
-@[simp]
+/-- The scalar operator of a positive `c` is the constant diagonal element.
+
+Deliberately not `@[simp]`, although an earlier api-design round asked for it. Tagging this
+unfolds every `heckeTScalar p` to `diagElem (fun _ ↦ p)`, which leaves the left-hand side of
+`heckeTScalar_mul_heckeTDiag_prime_pow` non-normal — `simpNF` rejects that, and the index shift
+is the rule worth keeping: it collapses `T(p,p) · T(pʲ, p^d)` to a single `heckeTDiag`, the
+normal form the GL₂ multiplication table works in. This stays an explicit citation. -/
 lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
     heckeTScalar c = diagElem (fun _ : Fin 2 ↦ c) := by
   rw [heckeTScalar, heckeTDiag_of_pos hc hc dvd_rfl]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -125,7 +125,7 @@ lemma heckeTScalar_pow (hp : 0 < p) (i : ℕ) :
 
 /-- Expansion of `T(pᵏ)`: only the divisor pairs `(pⁱ, p^(k-i))` with `i ≤ k - i`
 contribute. -/
-lemma heckeT_ppow_expansion (hp : p.Prime) (k : ℕ) :
+lemma heckeT_primePow_expansion (hp : p.Prime) (k : ℕ) :
     heckeT ⟨p ^ k, pow_pos hp.pos k⟩ =
       ∑ i ∈ Finset.range (k / 2 + 1), heckeTDiag (p ^ i) (p ^ (k - i)) := by
   -- `heckeT` is sealed (`public section`, no `@[expose]`), so `rw`/`simp` cannot unfold it;

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -33,8 +33,7 @@ Chris Birkbeck).
 * `HeckeRing.GL2.heckeT_one`: `T(1) = 1`.
 * `HeckeRing.GL2.heckeT_prime`: `T(p) = T(1, p)` for prime `p`.
 * `HeckeRing.GL2.heckeTDiag_mul_of_coprime`: `T(a,da) · T(b,db) = T(ab, da·db)` for
-  coprime determinants, both operators being basis elements (`0 < da`, `0 < db`, `a ∣ da`,
-  `b ∣ db`).
+  coprime determinants — coprimality alone, the zero-extension covering the rest.
 * `HeckeRing.GL2.heckeT_mul_coprime`: `T(m) · T(n) = T(mn)` for coprime `m`, `n`.
 
 ## References
@@ -156,15 +155,33 @@ lemma heckeT_prime_pow_expansion (hp : p.Prime) (k : ℕ) :
 /-- **Coprime multiplicativity** (Shimura, Proposition 3.16 in the `GL₂` notation):
 `T(a, da) · T(b, db) = T(ab, da·db)` when the determinants `a·da` and `b·db` are coprime.
 
-Coprimality is not the only hypothesis: both operators must be genuine basis elements, so
-`da` and `db` are positive and `a ∣ da`, `b ∣ db`. Positivity of `a` and `b` is *not* assumed
-— it follows, a divisor of a positive number being positive. -/
-lemma heckeTDiag_mul_of_coprime (a b da db : ℕ) (hda : 0 < da)
-    (hdb : 0 < db) (hdva : a ∣ da) (hdvb : b ∣ db)
+Coprimality is the *only* hypothesis. No positivity or divisor-pair condition is needed,
+because `heckeTDiag` is zero-extended and coprimality propagates that zero: if `T(a, da)`
+fails to be a basis element then so does `T(ab, da·db)`, since `a` is coprime to `db`, so
+`a ∣ ab ∣ da·db` would force `a ∣ da`. Both sides are then `0`. -/
+lemma heckeTDiag_mul_of_coprime (a b da db : ℕ)
     (hcop : Nat.Coprime (a * da) (b * db)) :
     heckeTDiag a da * heckeTDiag b db = heckeTDiag (a * b) (da * db) := by
-  -- positivity of the left entries is forced: a divisor of a positive number is positive
-  have ha : 0 < a := Nat.pos_of_dvd_of_pos hdva hda
+  -- Coprimality alone suffices: if either factor fails to be a basis element it is zero, and
+  -- coprimality then forces the product to be zero too (see `hzero`).
+  have hzero : ∀ x y u v : ℕ, Nat.Coprime (x * u) (y * v) →
+      ¬(0 < x ∧ 0 < u ∧ x ∣ u) → ¬(0 < x * y ∧ 0 < u * v ∧ x * y ∣ u * v) := by
+    rintro x y u v hc hbad ⟨hxy, huv, hdvd⟩
+    refine hbad ⟨Nat.pos_of_ne_zero fun h ↦ by simp [h] at hxy,
+      Nat.pos_of_ne_zero fun h ↦ by simp [h] at huv, ?_⟩
+    -- `x` is coprime to `v`, and `x ∣ x * y ∣ u * v`, so `x ∣ u`
+    exact (Nat.Coprime.dvd_of_dvd_mul_right
+      ((hc.coprime_dvd_left (dvd_mul_right x u)).coprime_dvd_right (dvd_mul_left v y))
+      ((dvd_mul_right x y).trans hdvd))
+  by_cases h1 : 0 < a ∧ 0 < da ∧ a ∣ da
+  swap
+  · rw [heckeTDiag_eq_zero h1, zero_mul, heckeTDiag_eq_zero (hzero a b da db hcop h1)]
+  by_cases h2 : 0 < b ∧ 0 < db ∧ b ∣ db
+  swap
+  · rw [heckeTDiag_eq_zero h2, mul_zero,
+      heckeTDiag_eq_zero (by simpa [Nat.mul_comm] using hzero b a db da hcop.symm h2)]
+  obtain ⟨ha, hda, hdva⟩ := h1
+  obtain ⟨hb, hdb, hdvb⟩ := h2
   have hb : 0 < b := Nat.pos_of_dvd_of_pos hdvb hdb
   rw [heckeTDiag_of_pos ha hda hdva, heckeTDiag_of_pos hb hdb hdvb,
     heckeTDiag_of_pos (Nat.mul_pos ha hb) (Nat.mul_pos hda hdb) (Nat.mul_dvd_mul hdva hdvb)]
@@ -192,33 +209,9 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
   refine Finset.sum_congr rfl fun q hq ↦ ?_
   obtain ⟨a, b⟩ := q
   simp only [Finset.mem_product, Nat.mem_divisors] at hq
-  have ha_pos : 0 < a := Nat.pos_of_ne_zero fun h ↦ by simp [h] at hq
-  have hb_pos : 0 < b := Nat.pos_of_ne_zero fun h ↦ by simp [h] at hq
   rw [(Nat.div_mul_div_comm hq.1.1 hq.2.1).symm]
-  by_cases hca : a ∣ (m : ℕ) / a
-  · by_cases hcb : b ∣ (n : ℕ) / b
-    · refine heckeTDiag_mul_of_coprime a b _ _
-        (Nat.div_pos (Nat.le_of_dvd (by omega) hq.1.1) ha_pos)
-        (Nat.div_pos (Nat.le_of_dvd (by omega) hq.2.1) hb_pos) hca hcb ?_
-      rwa [Nat.mul_div_cancel' hq.1.1, Nat.mul_div_cancel' hq.2.1]
-    · rw [show heckeTDiag b ((n : ℕ) / b) = 0 from
-        heckeTDiag_eq_zero (by push Not; intro _ _; exact hcb), mul_zero]
-      symm
-      refine heckeTDiag_eq_zero ?_
-      push Not
-      intro _ _ hdvd
-      exact absurd (((hcop.symm.coprime_dvd_left hq.2.1).coprime_dvd_right
-        (Nat.div_dvd_of_dvd hq.1.1)).dvd_of_dvd_mul_left
-        (dvd_trans (dvd_mul_left b a) hdvd)) hcb
-  · rw [show heckeTDiag a ((m : ℕ) / a) = 0 from
-      heckeTDiag_eq_zero (by push Not; intro _ _; exact hca), zero_mul]
-    symm
-    refine heckeTDiag_eq_zero ?_
-    push Not
-    intro _ _ hdvd
-    exact absurd (((hcop.coprime_dvd_left hq.1.1).coprime_dvd_right
-      (Nat.div_dvd_of_dvd hq.2.1)).dvd_of_dvd_mul_right
-      (dvd_trans (dvd_mul_right a b) hdvd)) hca
+  refine heckeTDiag_mul_of_coprime a b _ _ ?_
+  rwa [Nat.mul_div_cancel' hq.1.1, Nat.mul_div_cancel' hq.2.1]
 
 end Structural
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -6,6 +6,7 @@ Authors: Chris Birkbeck
 module
 
 public import TauCeti.NumberTheory.HeckeRing.GLn.PrimeDecomposition
+public import TauCeti.NumberTheory.HeckeRing.GLn.ScalarMul
 
 import Mathlib.Data.Finset.NatDivisors
 
@@ -182,8 +183,8 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
         (Nat.div_pos (Nat.le_of_dvd (by omega) hq.1.1) ha_pos)
         (Nat.div_pos (Nat.le_of_dvd (by omega) hq.2.1) hb_pos) hca hcb ?_
       rwa [Nat.mul_div_cancel' hq.1.1, Nat.mul_div_cancel' hq.2.1]
-    · rw [heckeTDiag_eq_zero (by push Not; intro _ _; exact hcb), mul_zero
-        (heckeTDiag a ((m : ℕ) / a))]
+    · rw [show heckeTDiag b ((n : ℕ) / b) = 0 from
+        heckeTDiag_eq_zero (by push Not; intro _ _; exact hcb), mul_zero]
       symm
       refine heckeTDiag_eq_zero ?_
       push Not
@@ -191,7 +192,8 @@ theorem heckeT_mul_coprime (m n : ℕ+) (hcop : Nat.Coprime (m : ℕ) (n : ℕ))
       exact absurd (((hcop.symm.coprime_dvd_left hq.2.1).coprime_dvd_right
         (Nat.div_dvd_of_dvd hq.1.1)).dvd_of_dvd_mul_left
         (dvd_trans (dvd_mul_left b a) hdvd)) hcb
-  · rw [heckeTDiag_eq_zero (by push Not; intro _ _; exact hca), zero_mul]
+  · rw [show heckeTDiag a ((m : ℕ) / a) = 0 from
+      heckeTDiag_eq_zero (by push Not; intro _ _; exact hca), zero_mul]
     symm
     refine heckeTDiag_eq_zero ?_
     push Not

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -204,8 +204,6 @@ lemma heckeTDiag_mul_of_coprime (a b da db : ℕ)
     congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply])
   rw [← hprod]
   exact diagElem_mul_of_coprime 2 ![a, da] ![b, db]
-    (fun i ↦ by fin_cases i <;> simp [ha, hda])
-    (fun i ↦ by fin_cases i <;> simp [hb, hdb])
     (by simpa [Fin.prod_univ_two] using hcop)
 
 open scoped Pointwise in

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -58,12 +58,18 @@ noncomputable def heckeTDiag (a d : ℕ) : IntegralHeckeRing 2 :=
 lemma heckeTDiag_def (a d : ℕ) :
     heckeTDiag a d = if 0 < a ∧ 0 < d ∧ a ∣ d then diagElem ![a, d] else 0 := (rfl)
 
-/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold. -/
+/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold.
+
+Deliberately not `@[simp]`: it rewrites *past* `heckeTDiag_one_one`. With this tagged,
+`heckeTDiag 1 1` normalises to `diagElem ![1, 1]` rather than to `1`, and it stops there —
+`diagElem_one` is stated for `fun _ ↦ 1`, which `![1, 1]` does not match syntactically. The
+identity normal form `T(1, 1) = 1` is the more useful one, so this stays a cited lemma. -/
 lemma heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (h : a ∣ d) :
     heckeTDiag a d = diagElem ![a, d] :=
   if_pos ⟨ha, hd, h⟩
 
 /-- `T(a, d)` is zero when the divisor-pair conditions fail. -/
+@[simp]
 lemma heckeTDiag_eq_zero {a d : ℕ} (h : ¬(0 < a ∧ 0 < d ∧ a ∣ d)) : heckeTDiag a d = 0 :=
   if_neg h
 
@@ -71,10 +77,16 @@ lemma heckeTDiag_eq_zero {a d : ℕ} (h : ¬(0 < a ∧ 0 < d ∧ a ∣ d)) : hec
 noncomputable def heckeTScalar (c : ℕ) : IntegralHeckeRing 2 :=
   heckeTDiag c c
 
-/-- The defining equation of `heckeTScalar`. -/
+/-- The defining equation of `heckeTScalar`.
+
+Deliberately not `@[simp]`: unfolding `heckeTScalar c` to `heckeTDiag c c` would leave the
+left-hand side of `heckeTScalar_of_pos` in non-normal form, which `simpNF` rejects. Only one of
+the two can carry the attribute, and `heckeTScalar_of_pos` is the one that reduces to a
+diagonal element. -/
 lemma heckeTScalar_def (c : ℕ) : heckeTScalar c = heckeTDiag c c := (rfl)
 
 /-- The scalar operator of a positive `c` is the constant diagonal element. -/
+@[simp]
 lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
     heckeTScalar c = diagElem (fun _ : Fin 2 ↦ c) := by
   rw [heckeTScalar, heckeTDiag_of_pos hc hc dvd_rfl]
@@ -101,6 +113,7 @@ lemma heckeT_def (m : ℕ+) :
   exact heckeTDiag_one_one
 
 /-- For a prime `p`, the summed operator collapses: `T(p) = T(1, p)`. -/
+@[simp]
 lemma heckeT_prime (p : ℕ) (hp : p.Prime) : heckeT ⟨p, hp.pos⟩ = heckeTDiag 1 p := by
   -- `heckeT` is sealed (`public section`, no `@[expose]`), so `rw`/`simp` cannot unfold it;
   -- `change` states the defeq divisor-pair sum directly

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Basic.lean
@@ -57,12 +57,17 @@ noncomputable def heckeTDiag (a d : ℕ) : IntegralHeckeRing 2 :=
 lemma heckeTDiag_def (a d : ℕ) :
     heckeTDiag a d = if 0 < a ∧ 0 < d ∧ a ∣ d then diagElem ![a, d] else 0 := (rfl)
 
-/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold. -/
+/-- `T(a, d)` is the diagonal Hecke element when the divisor-pair conditions hold.
+
+All three hypotheses are needed. `0 < d` does not follow from `0 < a` and `a ∣ d`: in `ℕ`
+every number divides `0`, so `a = 1, d = 0` satisfies both while `0 < d` fails — and that is
+exactly the tuple on which `natDiagGL` takes its junk value, which the `0 < d` branch of
+`heckeTDiag` exists to exclude. -/
 -- Deliberately not `@[simp]`: it rewrites *past* `heckeTDiag_one_one`. With this tagged,
 -- `heckeTDiag 1 1` normalises to `diagElem ![1, 1]` rather than to `1`, and it stops there —
 -- `diagElem_one` is stated for `fun _ ↦ 1`, which `![1, 1]` does not match syntactically. The
 -- identity normal form `T(1, 1) = 1` is the more useful one, so this stays a cited lemma.
-lemma heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (h : a ∣ d) :
+lemma heckeTDiag_eq_diagElem {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (h : a ∣ d) :
     heckeTDiag a d = diagElem ![a, d] :=
   if_pos ⟨ha, hd, h⟩
 
@@ -99,12 +104,12 @@ lemma heckeTScalar_zero : heckeTScalar 0 = 0 := by
 -- `heckeTDiag`, the normal form the GL₂ multiplication table works in.
 lemma heckeTScalar_of_pos {c : ℕ} (hc : 0 < c) :
     heckeTScalar c = diagElem (fun _ : Fin 2 ↦ c) := by
-  rw [heckeTScalar, heckeTDiag_of_pos hc hc dvd_rfl]
+  rw [heckeTScalar, heckeTDiag_eq_diagElem hc hc dvd_rfl]
   exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> rfl)
 
 /-- `T(1, 1)` is the identity. -/
 @[simp] lemma heckeTDiag_one_one : heckeTDiag 1 1 = 1 := by
-  rw [heckeTDiag_of_pos one_pos one_pos dvd_rfl,
+  rw [heckeTDiag_eq_diagElem one_pos one_pos dvd_rfl,
     show ![1, 1] = (fun _ : Fin 2 ↦ 1) from funext fun i ↦ by fin_cases i <;> rfl]
   exact diagElem_one
 
@@ -201,8 +206,8 @@ lemma heckeTDiag_mul_of_coprime (a b da db : ℕ)
   obtain ⟨ha, hda, hdva⟩ := h1
   obtain ⟨hb, hdb, hdvb⟩ := h2
   have hb : 0 < b := Nat.pos_of_dvd_of_pos hdvb hdb
-  rw [heckeTDiag_of_pos ha hda hdva, heckeTDiag_of_pos hb hdb hdvb,
-    heckeTDiag_of_pos (Nat.mul_pos ha hb) (Nat.mul_pos hda hdb) (Nat.mul_dvd_mul hdva hdvb)]
+  rw [heckeTDiag_eq_diagElem ha hda hdva, heckeTDiag_eq_diagElem hb hdb hdvb,
+    heckeTDiag_eq_diagElem (Nat.mul_pos ha hb) (Nat.mul_pos hda hdb) (Nat.mul_dvd_mul hdva hdvb)]
   have hprod : diagElem ((![a, da] : Fin 2 → ℕ) * ![b, db]) =
       diagElem (![a * b, da * db] : Fin 2 → ℕ) :=
     congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply])


### PR DESCRIPTION
#2204 and #2274 have both merged, so this diff is now this PR's own content only:
`GL2/Basic.lean` (+234, one file).

Specialises the `GL_n` diagonal machinery to `n = 2`. Every double coset of
`SL(2, ℤ) \ Δ / SL(2, ℤ)` is `T(a, d)` with `a ∣ d`, so:

* `heckeTDiag a d` — the basis element of a divisor pair, zero unless `0 < a`, `0 < d`
  and `a ∣ d`;
* `heckeT n` — the classical `T(n) = ∑_{ad = n, a ∣ d} T(a, d)`, summed over divisors.

Both are sealed by the module system, so each ships its defining equation
(`heckeTDiag_def`, `heckeT_def`) for downstream unfolding; the two `change` steps in the
proofs are annotated with why `rw`/`simp` cannot reach the goal through the seal.

Prerequisite for the `GL_2` multiplication table, the `T(p^k)` recurrence, and the
polynomial-ring presentation.

Ported from Chris Birkbeck's AINTLIB `LeanModularForms`, `HeckeRIngs/GL2/Basic.lean`.

## Roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2: Hecke operators and the Hecke algebra**,
item (a). That item states the concrete theory at general `n` and names the elementary-divisor
parametrization of double cosets by diagonal representatives with coprime factorization —
citing `GLn/DiagonalCosets.lean`, `GLn/PrimeDecomposition.lean` and `GLn/CoprimeMul.lean` — as
the route to "the `p`-local ring `R_p` with **Shimura's Theorem 3.20**".

This PR is the `GL₂` specialization of that machinery: `heckeTDiag`/`heckeTScalar` name the
diagonal and scalar operators for `n = 2`, `heckeT` is Shimura's summed operator
`T(m) = ∑_{a ∣ m} T(a, m/a)`, and `heckeTDiag_mul_of_coprime` / `heckeT_mul_of_coprime` are the
`GL₂` readings of the coprime-factorization milestone (Shimura Theorem 3.24). Layer 2(a) keeps
the congruence level at `n = 2`, so this specialization is where that thread continues; it is
also the layer `GLn/PolynomialRing.lean` consumes for the `n = 2` case of 3.20.

Roadmap: ModularForms


