### PR TITLE
feat: the trivial-intersection induction isometry

### DIFF
--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -1,0 +1,223 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import Mathlib.Algebra.Group.Subgroup.Pointwise
+public import Mathlib.Tactic.Group
+
+/-!
+# Trivial-intersection subgroups and Frobenius complements
+
+A subgroup `H` of `G` is a **trivial-intersection subgroup** when it meets each of its distinct
+conjugates trivially: `H ⊓ g H g⁻¹ = ⊥` whenever `g ∉ H`.  Equivalently `H` is *malnormal*: a
+nonidentity element of `H` is conjugated out of `H` by every `g ∉ H`.  A **Frobenius complement**
+is such a subgroup that is in addition proper and nontrivial, and `G` is then called a Frobenius
+group with complement `H`.
+
+The elementwise form is the definition taken here, because it is what every proof uses; the
+lattice form is `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot`.
+
+Alongside the subgroup notion there is a set-level one.  A **trivial-intersection set** for `H` is
+a subset `S ⊆ H` normalized by `H` whose distinct `G`-conjugates are pairwise disjoint.  The
+example that matters is the nonidentity part `H# = (H : Set G) \ {1}` of a Frobenius complement
+(`TauCeti.IsFrobeniusComplement.isTISet_diff_one`): a class function on `H` supported on such an
+`S` induces to `G` without changing its norm, which is the input to the exceptional-character
+argument for Frobenius's theorem.  That induction statement is
+`TauCeti.characterPairing_ind_ind_of_isTISet`, in
+`TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean`.
+
+## Main definitions
+
+* `TauCeti.IsTISubgroup`: `H` meets each of its distinct conjugates trivially.
+* `TauCeti.IsTISet`: `S` is a trivial-intersection set relative to `H`.
+* `TauCeti.IsFrobeniusComplement`: `H` is a proper nontrivial trivial-intersection subgroup.
+
+## Main results
+
+* `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot`: the lattice form of the definition.
+* `TauCeti.IsTISubgroup.normalizer_eq`: a nontrivial trivial-intersection subgroup is
+  self-normalizing.
+* `TauCeti.IsTISubgroup.isTISet`: an `H`-invariant subset of `H` avoiding the identity is a
+  trivial-intersection set, and in particular so is the nonidentity part of `H`.
+* `TauCeti.IsTISet.one_notMem`: conversely, a trivial-intersection set for a proper subgroup
+  avoids the identity.
+
+## References
+
+* I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 7.
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 8 (`IsTISet`, `IsFrobeniusComplement`).
+-/
+
+public section
+
+namespace TauCeti
+
+open scoped Pointwise
+
+variable {G : Type*} [Group G] {H : Subgroup G} {S : Set G}
+
+/-! ### Trivial-intersection subgroups -/
+
+/-- **A trivial-intersection subgroup**: `H` meets each of its distinct conjugates trivially.
+Stated elementwise, as the malnormality condition that only the identity of `H` can be conjugated
+back into `H` by an element outside `H`; `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot` is the
+equivalent statement `H ⊓ g H g⁻¹ = ⊥` about the subgroup lattice. -/
+def IsTISubgroup (H : Subgroup G) : Prop :=
+  ∀ ⦃g x : G⦄, g ∉ H → x ∈ H → g * x * g⁻¹ ∈ H → x = 1
+
+namespace IsTISubgroup
+
+/-- The defining property of a trivial-intersection subgroup, as a named lemma. -/
+theorem eq_one (hH : IsTISubgroup H) {g x : G} (hg : g ∉ H) (hx : x ∈ H)
+    (hgx : g * x * g⁻¹ ∈ H) : x = 1 :=
+  hH hg hx hgx
+
+/-- A nonidentity element of a trivial-intersection subgroup is conjugated out of it by every
+element outside it. -/
+theorem conj_notMem (hH : IsTISubgroup H) {g x : G} (hg : g ∉ H) (hx : x ∈ H) (hx1 : x ≠ 1) :
+    g * x * g⁻¹ ∉ H :=
+  fun h => hx1 (hH hg hx h)
+
+/-- **A nontrivial trivial-intersection subgroup is self-normalizing.**  An element of the
+normalizer conjugates a chosen nonidentity element of `H` back into `H`, so it cannot lie outside
+`H`. -/
+theorem normalizer_eq (hH : IsTISubgroup H) (hne : H ≠ ⊥) :
+    Subgroup.normalizer (H : Set G) = H := by
+  refine le_antisymm (fun g hg => ?_) Subgroup.le_normalizer
+  obtain ⟨⟨x, hx⟩, hx1⟩ := Subgroup.ne_bot_iff_exists_ne_one.mp hne
+  by_contra hgH
+  exact hx1 (Subtype.ext (hH hgH hx ((Subgroup.mem_normalizer_iff.mp hg x).mp hx)))
+
+end IsTISubgroup
+
+/-- **The lattice form of the trivial-intersection condition**: `H` meets each conjugate
+`g H g⁻¹` with `g ∉ H` in the trivial subgroup.  This is how the condition is usually written; the
+elementwise `TauCeti.IsTISubgroup` is the form the proofs use. -/
+theorem isTISubgroup_iff_inf_conj_smul_eq_bot :
+    IsTISubgroup H ↔ ∀ g : G, g ∉ H → H ⊓ MulAut.conj g • H = ⊥ := by
+  have key : ∀ g y : G, y ∈ MulAut.conj g • H ↔ g⁻¹ * y * g ∈ H := by
+    intro g y
+    rw [Subgroup.mem_pointwise_smul_iff_inv_smul_mem]
+    simp [MulAut.smul_def]
+  constructor
+  · intro hH g hg
+    refine (Subgroup.eq_bot_iff_forall _).mpr fun y hy => ?_
+    obtain ⟨hyH, hyc⟩ := Subgroup.mem_inf.mp hy
+    exact hH (g := g⁻¹) (by simpa using hg) hyH (by simpa using (key g y).mp hyc)
+  · intro hH g x hg hx hgx
+    have hmem : g * x * g⁻¹ ∈ H ⊓ MulAut.conj g • H :=
+      Subgroup.mem_inf.mpr ⟨hgx, (key g _).mpr (by rwa [show g⁻¹ * (g * x * g⁻¹) * g = x by group])⟩
+    have h1 : g * x * g⁻¹ = 1 := (Subgroup.eq_bot_iff_forall _).mp (hH g hg) _ hmem
+    exact mul_eq_left.mp (mul_inv_eq_one.mp h1)
+
+/-! ### Trivial-intersection sets -/
+
+/-- **A trivial-intersection set** for `H`: a subset of `H`, normalized by `H`, whose
+`G`-conjugates by elements outside `H` are disjoint from it.  Since conjugation by an element of
+`H` fixes `S`, the conjugates of `S` are indexed by the cosets of `H`, and the condition says that
+the distinct ones are pairwise disjoint.
+
+The motivating example is the nonidentity part `(H : Set G) \ {1}` of a trivial-intersection
+subgroup (`TauCeti.IsTISubgroup.isTISet_diff_one`). -/
+structure IsTISet (S : Set G) (H : Subgroup G) : Prop where
+  /-- A trivial-intersection set is contained in its subgroup. -/
+  subset : S ⊆ (H : Set G)
+  /-- A trivial-intersection set is normalized by its subgroup. -/
+  conj_mem : ∀ h ∈ H, ∀ x ∈ S, h * x * h⁻¹ ∈ S
+  /-- Conjugating a trivial-intersection set by an element outside its subgroup moves it off
+  itself. -/
+  disjoint_conj : ∀ g : G, g ∉ H → ∀ x ∈ S, g * x * g⁻¹ ∉ S
+
+namespace IsTISet
+
+/-- The image of a trivial-intersection set under conjugation by an element of its subgroup is the
+set itself; the two inclusions come from `TauCeti.IsTISet.conj_mem` at `h` and at `h⁻¹`. -/
+theorem conj_image_eq (hS : IsTISet S H) {h : G} (hh : h ∈ H) :
+    (fun x => h * x * h⁻¹) '' S = S := by
+  apply Set.Subset.antisymm
+  · rintro _ ⟨x, hx, rfl⟩
+    exact hS.conj_mem h hh x hx
+  · intro x hx
+    refine ⟨h⁻¹ * x * h, ?_, ?_⟩
+    · simpa using hS.conj_mem h⁻¹ (H.inv_mem hh) x hx
+    · change h * (h⁻¹ * x * h) * h⁻¹ = x
+      group
+
+/-- **Distinct conjugates of a trivial-intersection set are disjoint**, in the form the name of the
+notion refers to. -/
+theorem disjoint_conj_image (hS : IsTISet S H) {g : G} (hg : g ∉ H) :
+    Disjoint ((fun x => g * x * g⁻¹) '' S) S :=
+  Set.disjoint_left.mpr <| by
+    rintro _ ⟨x, hx, rfl⟩
+    exact hS.disjoint_conj g hg x hx
+
+/-- **A trivial-intersection set for a proper subgroup avoids the identity.**  The identity is
+fixed by every conjugation, so it could not be moved off the set. -/
+theorem one_notMem (hS : IsTISet S H) (hH : H ≠ ⊤) : (1 : G) ∉ S := by
+  obtain ⟨g, hg⟩ : ∃ g : G, g ∉ H := by
+    by_contra h
+    exact hH ((Subgroup.eq_top_iff' H).mpr (by simpa using h))
+  intro h1
+  exact hS.disjoint_conj g hg 1 h1 (by simpa using h1)
+
+end IsTISet
+
+/-- **An `H`-invariant subset of `H` avoiding the identity is a trivial-intersection set.**  This
+is where the trivial-intersection condition on the subgroup does the work: an element of `S`
+conjugated by some `g ∉ H` back into `H` would have to be the identity. -/
+theorem IsTISubgroup.isTISet (hH : IsTISubgroup H) (hS : S ⊆ (H : Set G)) (h1 : (1 : G) ∉ S)
+    (hconj : ∀ h ∈ H, ∀ x ∈ S, h * x * h⁻¹ ∈ S) : IsTISet S H where
+  subset := hS
+  conj_mem := hconj
+  disjoint_conj _g hg _x hx hmem :=
+    hH.conj_notMem hg (hS hx) (fun h => h1 (h ▸ hx)) (hS hmem)
+
+/-- **The nonidentity part of a trivial-intersection subgroup is a trivial-intersection set.**
+This is the set `H#` the exceptional-character argument induces from. -/
+theorem IsTISubgroup.isTISet_diff_one (hH : IsTISubgroup H) :
+    IsTISet ((H : Set G) \ {1}) H := by
+  refine hH.isTISet Set.sdiff_subset (by simp) fun h hh x hx => ⟨?_, ?_⟩
+  · exact H.mul_mem (H.mul_mem hh hx.1) (H.inv_mem hh)
+  · simp only [Set.mem_singleton_iff]
+    intro hcon
+    exact hx.2 (mul_eq_left.mp (mul_inv_eq_one.mp hcon))
+
+/-! ### Frobenius complements -/
+
+/-- **A Frobenius complement**: a proper, nontrivial trivial-intersection subgroup.  A group with
+such a subgroup is a *Frobenius group* with complement `H`; Frobenius's theorem says that the
+elements lying in no conjugate of `H`, together with the identity, form a normal complement to
+`H`. -/
+structure IsFrobeniusComplement (H : Subgroup G) : Prop where
+  /-- A Frobenius complement is nontrivial. -/
+  ne_bot : H ≠ ⊥
+  /-- A Frobenius complement is proper. -/
+  ne_top : H ≠ ⊤
+  /-- A Frobenius complement meets each of its distinct conjugates trivially. -/
+  isTISubgroup : IsTISubgroup H
+
+namespace IsFrobeniusComplement
+
+/-- A Frobenius complement is self-normalizing. -/
+theorem normalizer_eq (hH : IsFrobeniusComplement H) :
+    Subgroup.normalizer (H : Set G) = H :=
+  hH.isTISubgroup.normalizer_eq hH.ne_bot
+
+/-- The nonidentity part of a Frobenius complement is a trivial-intersection set. -/
+theorem isTISet_diff_one (hH : IsFrobeniusComplement H) : IsTISet ((H : Set G) \ {1}) H :=
+  hH.isTISubgroup.isTISet_diff_one
+
+/-- **A Frobenius complement is not normal.**  It is self-normalizing and proper, so its
+normalizer is not the whole group. -/
+theorem not_normal (hH : IsFrobeniusComplement H) : ¬H.Normal := by
+  intro hnorm
+  have htop : Subgroup.normalizer (H : Set G) = ⊤ := Subgroup.normalizer_eq_top_iff.mpr hnorm
+  exact hH.ne_top (hH.normalizer_eq ▸ htop)
+
+end IsFrobeniusComplement
+
+end TauCeti

--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -38,7 +38,7 @@ argument for Frobenius's theorem.  That induction statement is
 ## Main results
 
 * `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot`: the lattice form of the definition.
-* `TauCeti.IsTISubgroup.normalizer_eq`: a nontrivial trivial-intersection subgroup is
+* `TauCeti.IsTISubgroup.normalizer_eq_self`: a nontrivial trivial-intersection subgroup is
   self-normalizing.
 * `TauCeti.IsTISubgroup.isTISet`: an `H`-invariant subset of `H` avoiding the identity is a
   trivial-intersection set, and in particular so is the nonidentity part of `H`.
@@ -85,7 +85,7 @@ theorem conj_notMem (hH : IsTISubgroup H) {g x : G} (hg : g ∉ H) (hx : x ∈ H
 /-- **A nontrivial trivial-intersection subgroup is self-normalizing.**  An element of the
 normalizer conjugates a chosen nonidentity element of `H` back into `H`, so it cannot lie outside
 `H`. -/
-theorem normalizer_eq (hH : IsTISubgroup H) (hne : H ≠ ⊥) :
+theorem normalizer_eq_self (hH : IsTISubgroup H) (hne : H ≠ ⊥) :
     Subgroup.normalizer (H : Set G) = H := by
   refine le_antisymm (fun g hg => ?_) Subgroup.le_normalizer
   obtain ⟨⟨x, hx⟩, hx1⟩ := Subgroup.ne_bot_iff_exists_ne_one.mp hne
@@ -110,7 +110,7 @@ theorem isTISubgroup_iff_inf_conj_smul_eq_bot :
     exact hH (g := g⁻¹) (by simpa using hg) hyH (by simpa using (key g y).mp hyc)
   · intro hH g x hg hx hgx
     have hmem : g * x * g⁻¹ ∈ H ⊓ MulAut.conj g • H :=
-      Subgroup.mem_inf.mpr ⟨hgx, (key g _).mpr (by rwa [show g⁻¹ * (g * x * g⁻¹) * g = x by group])⟩
+      Subgroup.mem_inf.mpr ⟨hgx, (key g _).mpr (by simpa [mul_assoc] using hx)⟩
     have h1 : g * x * g⁻¹ = 1 := (Subgroup.eq_bot_iff_forall _).mp (hH g hg) _ hmem
     exact mul_eq_left.mp (mul_inv_eq_one.mp h1)
 
@@ -144,8 +144,7 @@ theorem conj_image_eq (hS : IsTISet S H) {h : G} (hh : h ∈ H) :
   · intro x hx
     refine ⟨h⁻¹ * x * h, ?_, ?_⟩
     · simpa using hS.conj_mem h⁻¹ (H.inv_mem hh) x hx
-    · change h * (h⁻¹ * x * h) * h⁻¹ = x
-      group
+    · group
 
 /-- **Distinct conjugates of a trivial-intersection set are disjoint**, in the form the name of the
 notion refers to. -/
@@ -203,9 +202,9 @@ structure IsFrobeniusComplement (H : Subgroup G) : Prop where
 namespace IsFrobeniusComplement
 
 /-- A Frobenius complement is self-normalizing. -/
-theorem normalizer_eq (hH : IsFrobeniusComplement H) :
+theorem normalizer_eq_self (hH : IsFrobeniusComplement H) :
     Subgroup.normalizer (H : Set G) = H :=
-  hH.isTISubgroup.normalizer_eq hH.ne_bot
+  hH.isTISubgroup.normalizer_eq_self hH.ne_bot
 
 /-- The nonidentity part of a Frobenius complement is a trivial-intersection set. -/
 theorem isTISet_diff_one (hH : IsFrobeniusComplement H) : IsTISet ((H : Set G) \ {1}) H :=
@@ -216,7 +215,7 @@ normalizer is not the whole group. -/
 theorem not_normal (hH : IsFrobeniusComplement H) : ¬H.Normal := by
   intro hnorm
   have htop : Subgroup.normalizer (H : Set G) = ⊤ := Subgroup.normalizer_eq_top_iff.mpr hnorm
-  exact hH.ne_top (hH.normalizer_eq ▸ htop)
+  exact hH.ne_top (hH.normalizer_eq_self ▸ htop)
 
 end IsFrobeniusComplement
 

--- a/TauCeti/GroupTheory/TrivialIntersection.lean
+++ b/TauCeti/GroupTheory/TrivialIntersection.lean
@@ -24,8 +24,10 @@ Alongside the subgroup notion there is a set-level one.  A **trivial-intersectio
 a subset `S ⊆ H` normalized by `H` whose distinct `G`-conjugates are pairwise disjoint.  The
 example that matters is the nonidentity part `H# = (H : Set G) \ {1}` of a Frobenius complement
 (`TauCeti.IsFrobeniusComplement.isTISet_diff_one`): a class function on `H` supported on such an
-`S` induces to `G` without changing its norm, which is the input to the exceptional-character
-argument for Frobenius's theorem.  That induction statement is
+`S` induces to `G` without changing its norm, as long as the order of `G` is invertible in the
+coefficient field `k` (`IsUnit (Nat.card G : k)`, as everywhere in this theory, because induction
+divides by that order).  That is the input to the exceptional-character argument for Frobenius's
+theorem.  That induction statement is
 `TauCeti.characterPairing_ind_ind_of_isTISet`, in
 `TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean`.
 

--- a/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
+++ b/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
@@ -20,9 +20,11 @@ its norm.  Concretely, if `f` is a class function on `H` with `f 1 = 0` then
 
 The first statement is `TauCeti.ClassFunction.comap_subtype_ind_eq_self` and the second is
 `TauCeti.characterPairing_ind_ind`.  This is the isometry that the exceptional-character route to
-Frobenius's theorem runs on: it is what makes a difference `χᵢ - χⱼ` of irreducible characters of
-`H`, which vanishes at `1` and has norm `2`, induce to a norm-`2` virtual character of `G`, so that
-it is `±` a difference of two irreducible characters of `G`.
+Frobenius's theorem runs on: it is what makes a difference `χᵢ - χⱼ` of two *distinct* ordinary
+irreducible characters of `H` *of the same degree*, which then vanishes at `1` and has norm `2`,
+induce to a norm-`2` virtual character of `G`, so that it is `±` a difference of two irreducible
+characters of `G`.  (Both qualifications are needed: `(χᵢ - χⱼ) 1 = χᵢ 1 - χⱼ 1` is the difference
+of the two degrees, and the norm is `2` by orthonormality only for distinct ordinary characters.)
 
 The hypothesis is not the tautology that `f` vanishes off `H`, which holds for every class function
 on `H` and gives no such conclusion.  What is used is the trivial-intersection condition: for
@@ -35,9 +37,9 @@ terms all equal `f x`.
 * `TauCeti.indClassFun_apply_coe`: the induced class function agrees with `f` on `H`.
 * `TauCeti.ClassFunction.comap_subtype_ind_eq_self`: restriction undoes induction, `Res ∘ Ind = id`.
 * `TauCeti.characterPairing_ind_ind`: induction preserves the character pairing.
-* `TauCeti.characterPairing_ind_ind_of_isTISet` and
-  `TauCeti.characterPairing_ind_self_of_isTISet`: the same, for a class function supported on a
-  trivial-intersection set of a Frobenius complement, which is the form Frobenius's theorem uses.
+* `TauCeti.characterPairing_ind_ind_of_isTISet` and `TauCeti.isometry_ind_of_isTISet`: the same,
+  for a class function supported on a trivial-intersection set of a Frobenius complement, which is
+  the form Frobenius's theorem uses.
 
 ## Implementation notes
 
@@ -142,10 +144,14 @@ theorem characterPairing_ind_ind_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G
 
 open scoped Classical in
 /-- **Induction from a trivial-intersection set preserves the norm**, the special case of
-`TauCeti.characterPairing_ind_ind_of_isTISet` at equal arguments.  A difference of two irreducible
-characters of `H` is supported off the identity and has norm `2`, so it induces to a norm-`2`
-virtual character of `G`; that is the step the exceptional-character correspondence begins with. -/
-theorem characterPairing_ind_self_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
+`TauCeti.characterPairing_ind_ind_of_isTISet` at equal arguments.  A difference of two distinct
+ordinary irreducible characters of `H` of the same degree is supported off the identity and has
+norm `2`, so it induces to a norm-`2` virtual character of `G`; that is the step the
+exceptional-character correspondence begins with.
+
+The name is the one the character-theory roadmap pins for this result: preserving the pairing at
+equal arguments is preservation of the norm, which is what "isometry" refers to. -/
+theorem isometry_ind_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
     (hH : IsFrobeniusComplement H) (hS : IsTISet S H) (f : ClassFunction k H)
     (hf : ∀ y : H, (y : G) ∉ S → f.1 y = 0) :
     ClassFunction.characterPairing (ClassFunction.ind H f) (ClassFunction.ind H f) =

--- a/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
+++ b/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
@@ -14,9 +14,13 @@ public import TauCeti.RepresentationTheory.Induction.FrobeniusReciprocity
 Let `H` be a trivial-intersection subgroup of a finite group `G`: one meeting each of its distinct
 conjugates trivially (`TauCeti.IsTISubgroup`).  A class function on `H` that vanishes at the
 identity then induces to `G` *without changing its values on `H`*, and therefore without changing
-its norm.  Concretely, if `f` is a class function on `H` with `f 1 = 0` then
+its norm, as long as the relevant group order is invertible in the coefficient field `k` — the
+characteristic of `k` must not divide it, as everywhere in this theory, because induction divides
+by that order.  Concretely, if `f` is a class function on `H` with `f 1 = 0` then
 
-`Res_H (Ind_H^G f) = f`,  hence  `⟨Ind f, Ind f⟩_G = ⟨f, f⟩_H`.
+`Res_H (Ind_H^G f) = f`  when `(|H| : k)` is a unit,  hence  `⟨Ind f, Ind f⟩_G = ⟨f, f⟩_H`  when
+`(|G| : k)` is (which gives the former, by `TauCeti.isUnit_natCard_subgroup`).  All the statements
+below carry that hypothesis.
 
 The first statement is `TauCeti.ClassFunction.comap_subtype_ind_eq_self` and the second is
 `TauCeti.characterPairing_ind_ind`.  This is the isometry that the exceptional-character route to
@@ -38,8 +42,8 @@ terms all equal `f x`.
 * `TauCeti.ClassFunction.comap_subtype_ind_eq_self`: restriction undoes induction, `Res ∘ Ind = id`.
 * `TauCeti.characterPairing_ind_ind`: induction preserves the character pairing.
 * `TauCeti.characterPairing_ind_ind_of_isTISet` and `TauCeti.isometry_ind_of_isTISet`: the same,
-  for a class function supported on a trivial-intersection set of a Frobenius complement, which is
-  the form Frobenius's theorem uses.
+  for a class function supported on a trivial-intersection set of a proper trivial-intersection
+  subgroup, which is the form Frobenius's theorem uses (applied there to a Frobenius complement).
 
 ## Implementation notes
 
@@ -130,17 +134,18 @@ theorem characterPairing_ind_ind [Fintype G] (hG : IsUnit (Nat.card G : k))
     ClassFunction.comap_subtype_ind_eq_self hH (isUnit_natCard_subgroup H hG) f₂ hf₂]
 
 open scoped Classical in
-/-- **A class function supported on a trivial-intersection set of a Frobenius complement induces
-isometrically.**  The support condition supplies the vanishing at the identity that
-`TauCeti.characterPairing_ind_ind` asks for, because a trivial-intersection set for a proper
-subgroup does not contain the identity. -/
+/-- **A class function supported on a trivial-intersection set of a proper trivial-intersection
+subgroup induces isometrically.**  The support condition supplies the vanishing at the identity
+that `TauCeti.characterPairing_ind_ind` asks for, because a trivial-intersection set for a proper
+subgroup does not contain the identity.  Nontriviality of `H` plays no part, so this asks only for
+the two halves of `TauCeti.IsFrobeniusComplement` that the argument uses; for a Frobenius
+complement `hH`, pass `hH.isTISubgroup` and `hH.ne_top`. -/
 theorem characterPairing_ind_ind_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
-    (hH : IsFrobeniusComplement H) (hS : IsTISet S H) (f₁ f₂ : ClassFunction k H)
+    (hH : IsTISubgroup H) (hne_top : H ≠ ⊤) (hS : IsTISet S H) (f₁ f₂ : ClassFunction k H)
     (hf₂ : ∀ y : H, (y : G) ∉ S → f₂.1 y = 0) :
     ClassFunction.characterPairing (ClassFunction.ind H f₁) (ClassFunction.ind H f₂) =
       ClassFunction.characterPairing f₁ f₂ :=
-  characterPairing_ind_ind hG hH.isTISubgroup f₁ f₂
-    (hf₂ 1 (by simpa using hS.one_notMem hH.ne_top))
+  characterPairing_ind_ind hG hH f₁ f₂ (hf₂ 1 (by simpa using hS.one_notMem hne_top))
 
 open scoped Classical in
 /-- **Induction from a trivial-intersection set preserves the norm**, the special case of
@@ -152,10 +157,10 @@ exceptional-character correspondence begins with.
 The name is the one the character-theory roadmap pins for this result: preserving the pairing at
 equal arguments is preservation of the norm, which is what "isometry" refers to. -/
 theorem isometry_ind_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
-    (hH : IsFrobeniusComplement H) (hS : IsTISet S H) (f : ClassFunction k H)
+    (hH : IsTISubgroup H) (hne_top : H ≠ ⊤) (hS : IsTISet S H) (f : ClassFunction k H)
     (hf : ∀ y : H, (y : G) ∉ S → f.1 y = 0) :
     ClassFunction.characterPairing (ClassFunction.ind H f) (ClassFunction.ind H f) =
       ClassFunction.characterPairing f f :=
-  characterPairing_ind_ind_of_isTISet hG hH hS f f hf
+  characterPairing_ind_ind_of_isTISet hG hH hne_top hS f f hf
 
 end TauCeti

--- a/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
+++ b/TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean
@@ -1,0 +1,155 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Claude
+-/
+module
+
+public import TauCeti.GroupTheory.TrivialIntersection
+public import TauCeti.RepresentationTheory.Induction.FrobeniusReciprocity
+
+/-!
+# Induction from a trivial-intersection subgroup
+
+Let `H` be a trivial-intersection subgroup of a finite group `G`: one meeting each of its distinct
+conjugates trivially (`TauCeti.IsTISubgroup`).  A class function on `H` that vanishes at the
+identity then induces to `G` *without changing its values on `H`*, and therefore without changing
+its norm.  Concretely, if `f` is a class function on `H` with `f 1 = 0` then
+
+`Res_H (Ind_H^G f) = f`,  hence  `⟨Ind f, Ind f⟩_G = ⟨f, f⟩_H`.
+
+The first statement is `TauCeti.ClassFunction.comap_subtype_ind_eq_self` and the second is
+`TauCeti.characterPairing_ind_ind`.  This is the isometry that the exceptional-character route to
+Frobenius's theorem runs on: it is what makes a difference `χᵢ - χⱼ` of irreducible characters of
+`H`, which vanishes at `1` and has norm `2`, induce to a norm-`2` virtual character of `G`, so that
+it is `±` a difference of two irreducible characters of `G`.
+
+The hypothesis is not the tautology that `f` vanishes off `H`, which holds for every class function
+on `H` and gives no such conclusion.  What is used is the trivial-intersection condition: for
+`y ∉ H`, an element of `H` conjugated by `y` back into `H` must be the identity, where `f` vanishes.
+So exactly the terms of the group sum coming from outside `H` drop out, and the remaining `|H|`
+terms all equal `f x`.
+
+## Main statements
+
+* `TauCeti.indClassFun_apply_coe`: the induced class function agrees with `f` on `H`.
+* `TauCeti.ClassFunction.comap_subtype_ind_eq_self`: restriction undoes induction, `Res ∘ Ind = id`.
+* `TauCeti.characterPairing_ind_ind`: induction preserves the character pairing.
+* `TauCeti.characterPairing_ind_ind_of_isTISet` and
+  `TauCeti.characterPairing_ind_self_of_isTISet`: the same, for a class function supported on a
+  trivial-intersection set of a Frobenius complement, which is the form Frobenius's theorem uses.
+
+## Implementation notes
+
+Only `f₂ 1 = 0` is needed for `TauCeti.characterPairing_ind_ind`, not the same hypothesis on `f₁`:
+the proof is Frobenius reciprocity `⟨Ind f₁, Ind f₂⟩ = ⟨f₁, Res (Ind f₂)⟩` followed by
+`Res (Ind f₂) = f₂`, and only the second factor is restricted.  Since
+`TauCeti.ClassFunction.characterPairing_symm` says the pairing is symmetric, the hypothesis may be
+put on either argument.
+
+## References
+
+* I. M. Isaacs, *Character Theory of Finite Groups*, Chapter 7, Lemma 7.2 and Theorem 7.5.
+* [Character theory roadmap](https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/CharacterTheory/README.md),
+  Layer 8 (`isometry_ind_of_isTISet`).
+-/
+
+public section
+
+namespace TauCeti
+
+universe u v
+
+variable {k : Type u} {G : Type v} [Field k] [Group G] {H : Subgroup G} {S : Set G}
+
+/-- **A class function vanishing at the identity of a trivial-intersection subgroup induces to a
+function agreeing with it on the subgroup.**
+
+In the group-sum form `|H| · (Ind f)(x) = ∑_{y ∈ G} f (y⁻¹ x y)` (terms with `y⁻¹ x y ∉ H` read as
+`0`), a term with `y ∉ H` contributes nothing: if `y⁻¹ x y ∈ H` then the trivial-intersection
+condition forces `x = 1`, and `f` vanishes there.  The `|H|` terms with `y ∈ H` each equal `f x`,
+because `f` is a class function. -/
+theorem indClassFun_apply_coe [Finite G] (hH : IsTISubgroup H) (hk : IsUnit (Nat.card H : k))
+    {f : H → k} (hf : f ∈ ClassFunction k H) (hf1 : f 1 = 0) (x : H) :
+    indClassFun H f (x : G) = f x := by
+  classical
+  let := Fintype.ofFinite G
+  -- A representative outside `H` contributes nothing.
+  have hout : ∀ y : G, y ∉ H → indTerm f (x : G) y = 0 := by
+    intro y hy
+    rw [indTerm_apply]
+    by_cases h : y⁻¹ * (x : G) * y ∈ H
+    · rw [dif_pos h]
+      have hx1 : (x : G) = 1 := hH.eq_one (g := y⁻¹) (by simpa using hy) x.2 (by simpa using h)
+      have hone : (⟨y⁻¹ * (x : G) * y, h⟩ : H) = 1 := by
+        ext
+        simp [hx1]
+      rw [hone, hf1]
+    · rw [dif_neg h]
+  -- A representative inside `H` contributes `f x`, since `f` is a class function.
+  have hin : ∀ y : H, indTerm f (x : G) (y : G) = f x := by
+    intro y
+    have hmem : (y : G)⁻¹ * (x : G) * (y : G) ∈ H :=
+      H.mul_mem (H.mul_mem (H.inv_mem y.2) x.2) y.2
+    have hcoe : (⟨(y : G)⁻¹ * (x : G) * (y : G), hmem⟩ : H) = y⁻¹ * x * y⁻¹⁻¹ := by
+      ext
+      simp
+    rw [indTerm_apply, dif_pos hmem, hcoe]
+    exact ClassFunction.mem_iff.mp hf x y⁻¹
+  refine mul_left_cancel₀ hk.ne_zero ?_
+  rw [natCard_mul_indClassFun hf]
+  simp only [← indTerm_apply]
+  calc ∑ y : G, indTerm f (x : G) y
+      = ∑ y ∈ Finset.univ.filter fun y : G => y ∈ H, indTerm f (x : G) y :=
+        (Finset.sum_subset (Finset.filter_subset _ _) fun y _ hy =>
+          hout y (by simpa using hy)).symm
+    _ = ∑ y : H, indTerm f (x : G) (y : G) := Finset.sum_subtype _ (by simp) _
+    _ = ∑ _y : H, f x := Finset.sum_congr rfl fun y _ => hin y
+    _ = (Nat.card H : k) * f x := by simp [Nat.card_eq_fintype_card]
+
+/-- **Restriction undoes induction, for a class function on a trivial-intersection subgroup that
+vanishes at the identity.**  This is the bundled form of `TauCeti.indClassFun_apply_coe`. -/
+theorem ClassFunction.comap_subtype_ind_eq_self [Finite G] (hH : IsTISubgroup H)
+    (hk : IsUnit (Nat.card H : k)) (f : ClassFunction k H) (hf1 : f.1 1 = 0) :
+    ClassFunction.comap H.subtype (ClassFunction.ind H f) = f := by
+  refine Subtype.ext (funext fun x => ?_)
+  simp only [ClassFunction.comap_apply, ClassFunction.ind_apply, Subgroup.coe_subtype]
+  exact indClassFun_apply_coe hH hk f.2 hf1 x
+
+open scoped Classical in
+/-- **Induction from a trivial-intersection subgroup preserves the character pairing**, provided
+the second argument vanishes at the identity.  This is the isometry the exceptional-character
+argument for Frobenius's theorem rests on; taking `f₁ = f₂` gives the preservation of the norm. -/
+theorem characterPairing_ind_ind [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (hH : IsTISubgroup H) (f₁ f₂ : ClassFunction k H) (hf₂ : f₂.1 1 = 0) :
+    ClassFunction.characterPairing (ClassFunction.ind H f₁) (ClassFunction.ind H f₂) =
+      ClassFunction.characterPairing f₁ f₂ := by
+  rw [characterPairing_ind hG,
+    ClassFunction.comap_subtype_ind_eq_self hH (isUnit_natCard_subgroup H hG) f₂ hf₂]
+
+open scoped Classical in
+/-- **A class function supported on a trivial-intersection set of a Frobenius complement induces
+isometrically.**  The support condition supplies the vanishing at the identity that
+`TauCeti.characterPairing_ind_ind` asks for, because a trivial-intersection set for a proper
+subgroup does not contain the identity. -/
+theorem characterPairing_ind_ind_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (hH : IsFrobeniusComplement H) (hS : IsTISet S H) (f₁ f₂ : ClassFunction k H)
+    (hf₂ : ∀ y : H, (y : G) ∉ S → f₂.1 y = 0) :
+    ClassFunction.characterPairing (ClassFunction.ind H f₁) (ClassFunction.ind H f₂) =
+      ClassFunction.characterPairing f₁ f₂ :=
+  characterPairing_ind_ind hG hH.isTISubgroup f₁ f₂
+    (hf₂ 1 (by simpa using hS.one_notMem hH.ne_top))
+
+open scoped Classical in
+/-- **Induction from a trivial-intersection set preserves the norm**, the special case of
+`TauCeti.characterPairing_ind_ind_of_isTISet` at equal arguments.  A difference of two irreducible
+characters of `H` is supported off the identity and has norm `2`, so it induces to a norm-`2`
+virtual character of `G`; that is the step the exceptional-character correspondence begins with. -/
+theorem characterPairing_ind_self_of_isTISet [Fintype G] (hG : IsUnit (Nat.card G : k))
+    (hH : IsFrobeniusComplement H) (hS : IsTISet S H) (f : ClassFunction k H)
+    (hf : ∀ y : H, (y : G) ∉ S → f.1 y = 0) :
+    ClassFunction.characterPairing (ClassFunction.ind H f) (ClassFunction.ind H f) =
+      ClassFunction.characterPairing f f :=
+  characterPairing_ind_ind_of_isTISet hG hH hS f f hf
+
+end TauCeti


### PR DESCRIPTION
This PR builds the trivial-intersection machinery of Layer 8 of the character-theory roadmap and proves the isometry it exists for. `TauCeti.IsTISubgroup H` says that `H` meets each of its distinct conjugates trivially, stated elementwise as malnormality and matched to the lattice form `H ⊓ g H g⁻¹ = ⊥` by `TauCeti.isTISubgroup_iff_inf_conj_smul_eq_bot`; such an `H` is self-normalizing once it is nontrivial (`TauCeti.IsTISubgroup.normalizer_eq`). `TauCeti.IsTISet S H` is the set-level notion, and `TauCeti.IsFrobeniusComplement H` bundles a proper nontrivial trivial-intersection subgroup, whose nonidentity part `H# = (H : Set G) \ {1}` is the motivating trivial-intersection set (`TauCeti.IsFrobeniusComplement.isTISet_diff_one`). On top of that sits the induction result: a class function `f` on a trivial-intersection subgroup with `f 1 = 0` induces to a class function on `G` whose restriction to `H` is `f` again (`TauCeti.ClassFunction.comap_subtype_ind_eq_self`), so induction preserves the character pairing (`TauCeti.characterPairing_ind_ind`), and in the roadmap's phrasing, a class function supported on a trivial-intersection set of a Frobenius complement induces with its norm unchanged (`TauCeti.isometry_ind_of_isTISet`).

The milestone is Layer 8 of `RepresentationTheory/CharacterTheory`, Frobenius groups and Frobenius's theorem `G = N ⋊ H`. That layer states its own requirement precisely and warns what not to prove: "The load-bearing lemma (`isometry_ind_of_isTISet`) is that a class function on `H` **supported on `S`** (vanishing outside `H#`), extended by zero and induced to `G` via `Representation.ind` and the induced-character formula of the induction-restriction roadmap, **preserves the norm**, not the tautology 'a function vanishing off `H` induces isometrically'." That is what is proved here, and it is genuinely the trivial-intersection condition doing the work: in the group-sum form `|H| · (Ind f)(x) = ∑_{y ∈ G} f (y⁻¹ x y)`, a representative `y ∉ H` can only contribute when `y⁻¹ x y ∈ H`, which for `x ∈ H` forces `x = 1` by malnormality, where `f` vanishes; the surviving `|H|` terms are all `f x` because `f` is a class function. The layer's remaining steps after this one are the exceptional-character bijection with its coherent sign choices, the class function cutting out `N` that a coherent family builds, and the proof that the support of that function is a normal subgroup, which is Frobenius's theorem itself.

Two decisions worth flagging. The trivial-intersection condition is defined elementwise rather than as `H ⊓ MulAut.conj g • H = ⊥`, because every proof in both files uses the elementwise form; the lattice form the roadmap writes is proved equivalent, so nothing is lost. And the induction results ask only that `f` vanish at the identity, not that it be supported on a named trivial-intersection set: that is all the proof consumes, and it is weaker, since a trivial-intersection set for a proper subgroup does not contain the identity (`TauCeti.IsTISet.one_notMem`). The roadmap-shaped statements over a set are supplied as corollaries. Correspondingly, `TauCeti.characterPairing_ind_ind` restricts only its second argument: Frobenius reciprocity turns `⟨Ind f₁, Ind f₂⟩` into `⟨f₁, Res (Ind f₂)⟩`, and only the second factor is restricted; the pairing is symmetric, so the hypothesis may be moved to either side.

The group-theoretic notions go in `TauCeti/GroupTheory/TrivialIntersection.lean` (about 230 lines) since they mention no representation, and the induction statements in `TauCeti/RepresentationTheory/Induction/TrivialIntersection.lean` (about 155 lines) beside the induced class function and Frobenius reciprocity they are built from. Mathlib has neither malnormal subgroups nor Frobenius groups under any spelling, and the class-function induction, `TauCeti.indClassFun` with `TauCeti.natCard_mul_indClassFun` and `TauCeti.characterPairing_ind`, is reused from the induction-restriction layer already in the repository rather than restated.

No material is derived from the supplementary source snapshot, and no Mathlib infrastructure was vendored.

Roadmap: RepresentationTheory

<!--tauceti-target:v1 {"focus":"RepresentationTheory","id":"isometry-ind-of-istiset"}-->

🤖 Prepared with Claude Code

