### PR TITLE
feat(HeckeRing): the GL(2) degree map and multiplication table

### DIFF
--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -1,0 +1,148 @@
+/-
+Copyright (c) 2026 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Degree
+public import TauCeti.NumberTheory.HeckeRing.GL2.Basic
+public import TauCeti.NumberTheory.HeckeRing.GL2.DiagonalCosetDegree
+public import TauCeti.NumberTheory.HeckeRing.GLn.Degree
+public import Mathlib.NumberTheory.ArithmeticFunction.Misc
+
+/-!
+# Degrees of the `GL₂` Hecke operators
+
+Shimura's Theorem 3.24, identities (6) and (7): the double coset of `diag(pⁱ, pⁱ⁺ᵏ)` has
+degree `pᵏ⁻¹(p + 1)` for `k > 0`, and the degrees of the summed operators `T(m)` assemble
+into the divisor-sum function, `deg T(m) = σ₁(m)`.
+
+The prime-power case is a two-step induction on `k`. Expanding `T(pᵏ)` into its diagonal
+terms `T(pⁱ, pᵏ⁻ⁱ)`, raising `k` by two shifts the indexing by one place and leaves every
+term's degree unchanged, so only the new leading term `T(1, pᵏ⁺²)` contributes and
+`deg T(pᵏ⁺²) = deg T(pᵏ) + pᵏ⁺¹(p + 1)`. Multiplicativity of `T` in coprime arguments then
+upgrades the prime-power formula to every `m`.
+
+## Main results
+
+* `HeckeRing.GL2.degree_diagCoset_ppow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`.
+* `HeckeRing.GL2.deg_heckeT_prime_pow`: `deg T(pᵏ) = 1 + p + ⋯ + pᵏ`.
+* `HeckeRing.GL2.deg_heckeT`: `deg T(m) = σ₁(m)`.
+
+Ported from the AINTLIB `LeanModularForms` project
+(`LeanModularForms/HeckeRIngs/GL2/Degree.lean`, Chris Birkbeck,
+<https://github.com/CBirkbeck/AINTLIB/tree/main/projects/LeanModularForms>).
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Theorem 3.24.
+-/
+
+public section
+
+open Matrix HeckeRing HeckeRing.GLn LeftCosetModule
+
+open scoped ArithmeticFunction.sigma
+
+namespace HeckeRing.GL2
+
+variable (p : ℕ)
+
+/-- **The prime-power coset degree** (Shimura, Theorem 3.24(6)):
+`deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`. -/
+theorem degree_diagCoset_ppow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
+    (diagCoset ![p ^ i, p ^ (i + k)]).degree = p ^ (k - 1) * (p + 1) :=
+  degree_diagCoset_of_ratio_eq_prime_pow p hp _
+    (isDvdChain_iff.mpr fun j₁ j₂ h ↦ by
+      fin_cases j₁ <;> fin_cases j₂ <;>
+        simp_all [Nat.pow_dvd_pow p (Nat.le_add_right i k)])
+    k hk (by simp [Nat.pow_div (Nat.le_add_right i k) hp.pos])
+
+/-- The degree of a nonzero diagonal operator is the degree of its double coset. -/
+private lemma deg_heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (hdvd : a ∣ d) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag a d) = ((diagCoset ![a, d]).degree : ℤ) := by
+  rw [heckeTDiag_of_pos ha hd hdvd, diagElem_def, deg_single, nsmul_eq_mul, mul_one]
+
+/-- A term of the `T(pᵏ)` expansion strictly below the middle has degree
+`p^(k - 2i - 1)(p + 1)`. -/
+private lemma deg_ppow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) =
+      ((p ^ (k - 2 * i - 1) * (p + 1) : ℕ) : ℤ) := by
+  rw [show k - i = i + (k - 2 * i) by omega,
+    deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos _)
+      (Nat.pow_dvd_pow p (Nat.le_add_right i _)),
+    degree_diagCoset_ppow p hp i (k - 2 * i) (by omega)]
+
+/-- The middle term of the `T(pᵏ)` expansion, where the two exponents agree, has degree
+one. -/
+private lemma deg_ppow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) = 1 := by
+  rw [show k - i = i by omega, deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
+    show ![p ^ i, p ^ i] = (fun _ : Fin 2 ↦ p ^ i) from funext fun j ↦ by fin_cases j <;> rfl,
+    degree_diagCoset_const 2 _, Nat.cast_one]
+
+/-- Raising the exponent by two shifts the expansion of `T(pᵏ)` by one place without
+changing any term's degree. -/
+private lemma deg_ppow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
+      deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) := by
+  rcases lt_or_ge (2 * i) k with h2i | h2i
+  · rw [deg_ppow_term_lt p hp (i + 1) (k + 2) (by omega),
+      deg_ppow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
+  · rw [deg_ppow_term_eq p hp (i + 1) (k + 2) (by omega),
+      deg_ppow_term_eq p hp i k (by omega)]
+
+/-- The inductive step of `deg_heckeT_prime_pow`, from `k` to `k + 2`. -/
+private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
+    (ih : deg (posDetInt 2) (SLnZ 2) ℤ (heckeT ⟨p ^ k, pow_pos hp.pos k⟩) =
+      ∑ j ∈ Finset.range (k + 1), (p : ℤ) ^ j) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeT ⟨p ^ (k + 2), pow_pos hp.pos (k + 2)⟩) =
+      ∑ j ∈ Finset.range (k + 2 + 1), (p : ℤ) ^ j := by
+  rw [heckeT_ppow_expansion p hp (k + 2), map_sum, Nat.add_div_right k two_pos,
+    Finset.sum_range_succ']
+  have h_tail : ∑ i ∈ Finset.range (k / 2 + 1),
+      deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
+      ∑ i ∈ Finset.range (k / 2 + 1),
+        deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) :=
+    Finset.sum_congr rfl fun i hi ↦ deg_ppow_shift p hp i k (Finset.mem_range.mp hi)
+  rw [heckeT_ppow_expansion p hp k, map_sum] at ih
+  rw [h_tail, ih, show deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ 0) (p ^ (k + 2 - 0))) =
+      ((p ^ (k + 1) * (p + 1) : ℕ) : ℤ) by
+    simpa [show k + 2 - 2 * 0 - 1 = k + 1 by omega] using
+      deg_ppow_term_lt p hp 0 (k + 2) (by omega)]
+  conv_rhs => rw [Finset.sum_range_succ, Finset.sum_range_succ]
+  push_cast
+  ring
+
+/-- **The prime-power degree** (Shimura, Theorem 3.24(7) at a prime power):
+`deg T(pᵏ) = 1 + p + ⋯ + pᵏ`. -/
+theorem deg_heckeT_prime_pow (hp : p.Prime) (k : ℕ) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeT ⟨p ^ k, pow_pos hp.pos k⟩) =
+      ∑ j ∈ Finset.range (k + 1), (p : ℤ) ^ j := by
+  induction k using Nat.twoStepInduction with
+  | zero => simp
+  | one =>
+    rw [heckeT_ppow_expansion p hp 1, map_sum]
+    simpa using deg_ppow_term_lt p hp 0 1 (by omega)
+  | more k ih _ => exact deg_heckeT_prime_pow_step p hp k ih
+
+/-- **The degree of `T(m)`** (Shimura, Theorem 3.24(7)): `deg T(m) = σ₁(m)`. -/
+theorem deg_heckeT (m : ℕ+) :
+    deg (posDetInt 2) (SLnZ 2) ℤ (heckeT m) = (σ 1) (m : ℕ) := by
+  obtain ⟨n, hn⟩ := m
+  induction n using Nat.recOnPosPrimePosCoprime with
+  | prime_pow p k hp hk =>
+    rw [deg_heckeT_prime_pow p hp k]
+    exact_mod_cast (ArithmeticFunction.sigma_one_apply_prime_pow hp).symm
+  | zero => exact absurd hn (lt_irrefl 0)
+  | one => simp
+  | coprime p q hp hq hcop ihp ihq =>
+    have hp_pos : 0 < p := zero_lt_one.trans hp
+    have hq_pos : 0 < q := zero_lt_one.trans hq
+    rw [show heckeT ⟨p * q, hn⟩ = heckeT ⟨p, hp_pos⟩ * heckeT ⟨q, hq_pos⟩ from
+      (heckeT_mul_coprime ⟨p, hp_pos⟩ ⟨q, hq_pos⟩ hcop).symm, map_mul, ihp hp_pos, ihq hq_pos]
+    exact_mod_cast (ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime hcop).symm
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -26,7 +26,7 @@ upgrades the prime-power formula to every `m`.
 
 ## Main results
 
-* `HeckeRing.GL2.degree_diagCoset_primePow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`.
+* `HeckeRing.GL2.degree_diagCoset_prime_pow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`.
 * `HeckeRing.GL2.deg_heckeT_prime_pow`: `deg T(pᵏ) = 1 + p + ⋯ + pᵏ`.
 * `HeckeRing.GL2.deg_heckeT`: `deg T(m) = σ₁(m)`.
 
@@ -52,7 +52,7 @@ variable (p : ℕ)
 
 /-- **The prime-power coset degree** (Shimura, Theorem 3.24(6)):
 `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`. -/
-theorem degree_diagCoset_primePow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
+theorem degree_diagCoset_prime_pow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
     (diagCoset ![p ^ i, p ^ (i + k)]).degree = p ^ (k - 1) * (p + 1) :=
   degree_diagCoset_of_ratio_eq_prime_pow p hp _
     (isDvdChain_iff.mpr fun j₁ j₂ h ↦ by
@@ -67,17 +67,17 @@ private lemma deg_heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (hdvd 
 
 /-- A term of the `T(pᵏ)` expansion strictly below the middle has degree
 `p^(k - 2i - 1)(p + 1)`. -/
-private lemma deg_primePow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
+private lemma deg_prime_pow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) =
       ((p ^ (k - 2 * i - 1) * (p + 1) : ℕ) : ℤ) := by
   rw [show k - i = i + (k - 2 * i) by omega,
     deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos _)
       (Nat.pow_dvd_pow p (Nat.le_add_right i _)),
-    degree_diagCoset_primePow p hp i (k - 2 * i) (by omega)]
+    degree_diagCoset_prime_pow p hp i (k - 2 * i) (by omega)]
 
 /-- The middle term of the `T(pᵏ)` expansion, where the two exponents agree, has degree
 one. -/
-private lemma deg_primePow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
+private lemma deg_prime_pow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) = 1 := by
   rw [show k - i = i by omega, deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
     show ![p ^ i, p ^ i] = (fun _ : Fin 2 ↦ p ^ i) from funext fun j ↦ by fin_cases j <;> rfl,
@@ -85,14 +85,14 @@ private lemma deg_primePow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) 
 
 /-- Raising the exponent by two shifts the expansion of `T(pᵏ)` by one place without
 changing any term's degree. -/
-private lemma deg_primePow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1) :
+private lemma deg_prime_pow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
       deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) := by
   rcases lt_or_ge (2 * i) k with h2i | h2i
-  · rw [deg_primePow_term_lt p hp (i + 1) (k + 2) (by omega),
-      deg_primePow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
-  · rw [deg_primePow_term_eq p hp (i + 1) (k + 2) (by omega),
-      deg_primePow_term_eq p hp i k (by omega)]
+  · rw [deg_prime_pow_term_lt p hp (i + 1) (k + 2) (by omega),
+      deg_prime_pow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
+  · rw [deg_prime_pow_term_eq p hp (i + 1) (k + 2) (by omega),
+      deg_prime_pow_term_eq p hp i k (by omega)]
 
 /-- The inductive step of `deg_heckeT_prime_pow`, from `k` to `k + 2`. -/
 private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
@@ -100,18 +100,18 @@ private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
       ∑ j ∈ Finset.range (k + 1), (p : ℤ) ^ j) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeT ⟨p ^ (k + 2), pow_pos hp.pos (k + 2)⟩) =
       ∑ j ∈ Finset.range (k + 2 + 1), (p : ℤ) ^ j := by
-  rw [heckeT_primePow_expansion p hp (k + 2), map_sum, Nat.add_div_right k two_pos,
+  rw [heckeT_prime_pow_expansion p hp (k + 2), map_sum, Nat.add_div_right k two_pos,
     Finset.sum_range_succ']
   have h_tail : ∑ i ∈ Finset.range (k / 2 + 1),
       deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
       ∑ i ∈ Finset.range (k / 2 + 1),
         deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) :=
-    Finset.sum_congr rfl fun i hi ↦ deg_primePow_shift p hp i k (Finset.mem_range.mp hi)
-  rw [heckeT_primePow_expansion p hp k, map_sum] at ih
+    Finset.sum_congr rfl fun i hi ↦ deg_prime_pow_shift p hp i k (Finset.mem_range.mp hi)
+  rw [heckeT_prime_pow_expansion p hp k, map_sum] at ih
   rw [h_tail, ih, show deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ 0) (p ^ (k + 2 - 0))) =
       ((p ^ (k + 1) * (p + 1) : ℕ) : ℤ) by
     simpa [show k + 2 - 2 * 0 - 1 = k + 1 by omega] using
-      deg_primePow_term_lt p hp 0 (k + 2) (by omega)]
+      deg_prime_pow_term_lt p hp 0 (k + 2) (by omega)]
   conv_rhs => rw [Finset.sum_range_succ, Finset.sum_range_succ]
   push_cast
   ring
@@ -124,8 +124,8 @@ theorem deg_heckeT_prime_pow (hp : p.Prime) (k : ℕ) :
   induction k using Nat.twoStepInduction with
   | zero => simp
   | one =>
-    rw [heckeT_primePow_expansion p hp 1, map_sum]
-    simpa using deg_primePow_term_lt p hp 0 1 (by omega)
+    rw [heckeT_prime_pow_expansion p hp 1, map_sum]
+    simpa using deg_prime_pow_term_lt p hp 0 1 (by omega)
   | more k ih _ => exact deg_heckeT_prime_pow_step p hp k ih
 
 /-- **The degree of `T(m)`** (Shimura, Theorem 3.24(7)): `deg T(m) = σ₁(m)`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -26,7 +26,7 @@ upgrades the prime-power formula to every `m`.
 
 ## Main results
 
-* `HeckeRing.GL2.degree_diagCoset_ppow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`.
+* `HeckeRing.GL2.degree_diagCoset_primePow`: `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`.
 * `HeckeRing.GL2.deg_heckeT_prime_pow`: `deg T(pᵏ) = 1 + p + ⋯ + pᵏ`.
 * `HeckeRing.GL2.deg_heckeT`: `deg T(m) = σ₁(m)`.
 
@@ -52,7 +52,7 @@ variable (p : ℕ)
 
 /-- **The prime-power coset degree** (Shimura, Theorem 3.24(6)):
 `deg T(pⁱ, pⁱ⁺ᵏ) = pᵏ⁻¹(p + 1)` for `k > 0`. -/
-theorem degree_diagCoset_ppow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
+theorem degree_diagCoset_primePow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
     (diagCoset ![p ^ i, p ^ (i + k)]).degree = p ^ (k - 1) * (p + 1) :=
   degree_diagCoset_of_ratio_eq_prime_pow p hp _
     (isDvdChain_iff.mpr fun j₁ j₂ h ↦ by
@@ -67,17 +67,17 @@ private lemma deg_heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (hdvd 
 
 /-- A term of the `T(pᵏ)` expansion strictly below the middle has degree
 `p^(k - 2i - 1)(p + 1)`. -/
-private lemma deg_ppow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
+private lemma deg_primePow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) =
       ((p ^ (k - 2 * i - 1) * (p + 1) : ℕ) : ℤ) := by
   rw [show k - i = i + (k - 2 * i) by omega,
     deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos _)
       (Nat.pow_dvd_pow p (Nat.le_add_right i _)),
-    degree_diagCoset_ppow p hp i (k - 2 * i) (by omega)]
+    degree_diagCoset_primePow p hp i (k - 2 * i) (by omega)]
 
 /-- The middle term of the `T(pᵏ)` expansion, where the two exponents agree, has degree
 one. -/
-private lemma deg_ppow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
+private lemma deg_primePow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) = 1 := by
   rw [show k - i = i by omega, deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
     show ![p ^ i, p ^ i] = (fun _ : Fin 2 ↦ p ^ i) from funext fun j ↦ by fin_cases j <;> rfl,
@@ -85,14 +85,14 @@ private lemma deg_ppow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
 
 /-- Raising the exponent by two shifts the expansion of `T(pᵏ)` by one place without
 changing any term's degree. -/
-private lemma deg_ppow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1) :
+private lemma deg_primePow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
       deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) := by
   rcases lt_or_ge (2 * i) k with h2i | h2i
-  · rw [deg_ppow_term_lt p hp (i + 1) (k + 2) (by omega),
-      deg_ppow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
-  · rw [deg_ppow_term_eq p hp (i + 1) (k + 2) (by omega),
-      deg_ppow_term_eq p hp i k (by omega)]
+  · rw [deg_primePow_term_lt p hp (i + 1) (k + 2) (by omega),
+      deg_primePow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
+  · rw [deg_primePow_term_eq p hp (i + 1) (k + 2) (by omega),
+      deg_primePow_term_eq p hp i k (by omega)]
 
 /-- The inductive step of `deg_heckeT_prime_pow`, from `k` to `k + 2`. -/
 private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
@@ -100,18 +100,18 @@ private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
       ∑ j ∈ Finset.range (k + 1), (p : ℤ) ^ j) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeT ⟨p ^ (k + 2), pow_pos hp.pos (k + 2)⟩) =
       ∑ j ∈ Finset.range (k + 2 + 1), (p : ℤ) ^ j := by
-  rw [heckeT_ppow_expansion p hp (k + 2), map_sum, Nat.add_div_right k two_pos,
+  rw [heckeT_primePow_expansion p hp (k + 2), map_sum, Nat.add_div_right k two_pos,
     Finset.sum_range_succ']
   have h_tail : ∑ i ∈ Finset.range (k / 2 + 1),
       deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
       ∑ i ∈ Finset.range (k / 2 + 1),
         deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) :=
-    Finset.sum_congr rfl fun i hi ↦ deg_ppow_shift p hp i k (Finset.mem_range.mp hi)
-  rw [heckeT_ppow_expansion p hp k, map_sum] at ih
+    Finset.sum_congr rfl fun i hi ↦ deg_primePow_shift p hp i k (Finset.mem_range.mp hi)
+  rw [heckeT_primePow_expansion p hp k, map_sum] at ih
   rw [h_tail, ih, show deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ 0) (p ^ (k + 2 - 0))) =
       ((p ^ (k + 1) * (p + 1) : ℕ) : ℤ) by
     simpa [show k + 2 - 2 * 0 - 1 = k + 1 by omega] using
-      deg_ppow_term_lt p hp 0 (k + 2) (by omega)]
+      deg_primePow_term_lt p hp 0 (k + 2) (by omega)]
   conv_rhs => rw [Finset.sum_range_succ, Finset.sum_range_succ]
   push_cast
   ring
@@ -124,8 +124,8 @@ theorem deg_heckeT_prime_pow (hp : p.Prime) (k : ℕ) :
   induction k using Nat.twoStepInduction with
   | zero => simp
   | one =>
-    rw [heckeT_ppow_expansion p hp 1, map_sum]
-    simpa using deg_ppow_term_lt p hp 0 1 (by omega)
+    rw [heckeT_primePow_expansion p hp 1, map_sum]
+    simpa using deg_primePow_term_lt p hp 0 1 (by omega)
   | more k ih _ => exact deg_heckeT_prime_pow_step p hp k ih
 
 /-- **The degree of `T(m)`** (Shimura, Theorem 3.24(7)): `deg T(m) = σ₁(m)`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -63,7 +63,7 @@ theorem degree_diagCoset_prime_pow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
 /-- The degree of a nonzero diagonal operator is the degree of its double coset. -/
 private lemma deg_heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (hdvd : a ∣ d) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag a d) = ((diagCoset ![a, d]).degree : ℤ) := by
-  rw [heckeTDiag_of_pos ha hd hdvd, diagElem_def, deg_single, nsmul_eq_mul, mul_one]
+  rw [heckeTDiag_eq_diagElem ha hd hdvd, diagElem_def, deg_single, nsmul_eq_mul, mul_one]
 
 /-- A term of the `T(pᵏ)` expansion strictly below the middle has degree
 `p^(k - 2i - 1)(p + 1)`. -/

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -70,6 +70,9 @@ private lemma deg_heckeTDiag_eq_diagCoset_degree {a d : ℕ} (ha : 0 < a) (hd : 
 private lemma deg_prime_pow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) =
       ((p ^ (k - 2 * i - 1) * (p + 1) : ℕ) : ℤ) := by
+  -- `degree_diagCoset_prime_pow` is stated at `![p ^ i, p ^ (i + k')]`. Truncated ℕ-subtraction
+  -- hides that shape inside `k - i`, and `rw` matches syntactically, so re-index the exponent
+  -- with `omega` before the degree lemmas can fire.
   rw [show k - i = i + (k - 2 * i) by omega,
     deg_heckeTDiag_eq_diagCoset_degree (pow_pos hp.pos i) (pow_pos hp.pos _)
       (Nat.pow_dvd_pow p (Nat.le_add_right i _)),
@@ -79,6 +82,9 @@ private lemma deg_prime_pow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k)
 one. -/
 private lemma deg_prime_pow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) = 1 := by
+  -- Two shape mismatches `rw` cannot bridge on its own: truncated ℕ-subtraction hides `k - i = i`,
+  -- and `degree_diagCoset_const` is stated for a constant *function*, which `![x, x]` is only
+  -- extensionally — hence the `funext`.
   rw [show k - i = i by omega,
     deg_heckeTDiag_eq_diagCoset_degree (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
     show ![p ^ i, p ^ i] = (fun _ : Fin 2 ↦ p ^ i) from funext fun j ↦ by fin_cases j <;> rfl,
@@ -90,7 +96,9 @@ private lemma deg_prime_pow_shift (hp : p.Prime) (i k : ℕ) (hi : i < k / 2 + 1
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ (i + 1)) (p ^ (k + 2 - (i + 1)))) =
       deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) := by
   rcases lt_or_ge (2 * i) k with h2i | h2i
-  · rw [deg_prime_pow_term_lt p hp (i + 1) (k + 2) (by omega),
+  · -- Both sides are now `p ^ _ * (p + 1)` and differ only in how truncated ℕ-subtraction
+    -- writes the exponent, which `omega` reconciles.
+    rw [deg_prime_pow_term_lt p hp (i + 1) (k + 2) (by omega),
       deg_prime_pow_term_lt p hp i k h2i, show k + 2 - 2 * (i + 1) - 1 = k - 2 * i - 1 by omega]
   · rw [deg_prime_pow_term_eq p hp (i + 1) (k + 2) (by omega),
       deg_prime_pow_term_eq p hp i k (by omega)]
@@ -109,6 +117,8 @@ private lemma deg_heckeT_prime_pow_step (hp : p.Prime) (k : ℕ)
         deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) :=
     Finset.sum_congr rfl fun i hi ↦ deg_prime_pow_shift p hp i k (Finset.mem_range.mp hi)
   rw [heckeT_prime_pow_expansion p hp k, map_sum] at ih
+  -- `Finset.sum_range_succ'` peels off the `i = 0` term, which `deg_prime_pow_term_lt` returns
+  -- with the exponent written as `k + 2 - 2 * 0 - 1`; `omega` normalises that to `k + 1`.
   rw [h_tail, ih, show deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ 0) (p ^ (k + 2 - 0))) =
       ((p ^ (k + 1) * (p + 1) : ℕ) : ℤ) by
     simpa [show k + 2 - 2 * 0 - 1 = k + 1 by omega] using

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -142,7 +142,7 @@ theorem deg_heckeT (m : ℕ+) :
     have hp_pos : 0 < p := zero_lt_one.trans hp
     have hq_pos : 0 < q := zero_lt_one.trans hq
     rw [show heckeT ⟨p * q, hn⟩ = heckeT ⟨p, hp_pos⟩ * heckeT ⟨q, hq_pos⟩ from
-      (heckeT_mul_coprime ⟨p, hp_pos⟩ ⟨q, hq_pos⟩ hcop).symm, map_mul, ihp hp_pos, ihq hq_pos]
+      (heckeT_mul_of_coprime ⟨p, hp_pos⟩ ⟨q, hq_pos⟩ hcop).symm, map_mul, ihp hp_pos, ihq hq_pos]
     exact_mod_cast (ArithmeticFunction.isMultiplicative_sigma.map_mul_of_coprime hcop).symm
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -61,7 +61,8 @@ theorem degree_diagCoset_prime_pow (hp : p.Prime) (i k : ℕ) (hk : 0 < k) :
     k hk (by simp [Nat.pow_div (Nat.le_add_right i k) hp.pos])
 
 /-- The degree of a nonzero diagonal operator is the degree of its double coset. -/
-private lemma deg_heckeTDiag_of_pos {a d : ℕ} (ha : 0 < a) (hd : 0 < d) (hdvd : a ∣ d) :
+private lemma deg_heckeTDiag_eq_diagCoset_degree {a d : ℕ} (ha : 0 < a) (hd : 0 < d)
+    (hdvd : a ∣ d) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag a d) = ((diagCoset ![a, d]).degree : ℤ) := by
   rw [heckeTDiag_eq_diagElem ha hd hdvd, diagElem_def, deg_single, nsmul_eq_mul, mul_one]
 
@@ -71,7 +72,7 @@ private lemma deg_prime_pow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k)
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) =
       ((p ^ (k - 2 * i - 1) * (p + 1) : ℕ) : ℤ) := by
   rw [show k - i = i + (k - 2 * i) by omega,
-    deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos _)
+    deg_heckeTDiag_eq_diagCoset_degree (pow_pos hp.pos i) (pow_pos hp.pos _)
       (Nat.pow_dvd_pow p (Nat.le_add_right i _)),
     degree_diagCoset_prime_pow p hp i (k - 2 * i) (by omega)]
 
@@ -79,7 +80,8 @@ private lemma deg_prime_pow_term_lt (hp : p.Prime) (i k : ℕ) (h2i : 2 * i < k)
 one. -/
 private lemma deg_prime_pow_term_eq (hp : p.Prime) (i k : ℕ) (h2i : 2 * i = k) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeTDiag (p ^ i) (p ^ (k - i))) = 1 := by
-  rw [show k - i = i by omega, deg_heckeTDiag_of_pos (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
+  rw [show k - i = i by omega,
+    deg_heckeTDiag_eq_diagCoset_degree (pow_pos hp.pos i) (pow_pos hp.pos i) dvd_rfl,
     show ![p ^ i, p ^ i] = (fun _ : Fin 2 ↦ p ^ i) from funext fun j ↦ by fin_cases j <;> rfl,
     degree_diagCoset_const 2 _, Nat.cast_one]
 

--- a/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/Degree.lean
@@ -8,7 +8,6 @@ module
 public import TauCeti.NumberTheory.HeckeRing.Degree
 public import TauCeti.NumberTheory.HeckeRing.GL2.Basic
 public import TauCeti.NumberTheory.HeckeRing.GL2.DiagonalCosetDegree
-public import TauCeti.NumberTheory.HeckeRing.GLn.Degree
 public import Mathlib.NumberTheory.ArithmeticFunction.Misc
 
 /-!
@@ -131,6 +130,9 @@ theorem deg_heckeT_prime_pow (hp : p.Prime) (k : ℕ) :
   | more k ih _ => exact deg_heckeT_prime_pow_step p hp k ih
 
 /-- **The degree of `T(m)`** (Shimura, Theorem 3.24(7)): `deg T(m) = σ₁(m)`. -/
+-- `@[simp]` on the unconditional formula only: `deg_heckeT_prime_pow` is the instance
+-- `m = ⟨p ^ k, _⟩` of this one, so annotating both would leave the specialized form unreachable.
+@[simp]
 theorem deg_heckeT (m : ℕ+) :
     deg (posDetInt 2) (SLnZ 2) ℤ (heckeT m) = (σ 1) (m : ℕ) := by
   obtain ⟨n, hn⟩ := m

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -87,14 +87,14 @@ Every double coset in the support of the product `T(1,p) · T(1,pᵏ)` is `T(1, 
 `T(p, pᵏ)`: the determinant balances to `p^(k+1)`, and the first invariant factor divides
 `p` because the conjugated middle matrix stays integral. -/
 
-/-- `mapGL_coe_matrix` at the `.val` coercion. It states the same fact, but with the
-`GL`-unit coercion already reduced to a plain matrix; the simp set below needs that form,
-and `mapGL_coe_matrix` alone leaves a `mod_cast` obligation it cannot discharge. -/
-private lemma mapGL_val (S : SpecialLinearGroup (Fin 2) ℤ) :
-    ((mapGL ℚ S : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      S.val.map (algebraMap ℤ ℚ) :=
-  mapGL_coe_matrix S
+/-- The **matrix** determinant of a mapped `SL₂` element is `1`.
 
+Not a restatement of Mathlib's `det_mapGL`, which is about the **unit** determinant
+`(mapGL S g).det : Sˣ`; the goals here are about `(↑(mapGL ℚ S)).det : ℚ`, the determinant of
+the underlying matrix. Bridging the two with
+`Matrix.GeneralLinearGroup.val_det_apply` (in either direction) does not close them, and four
+of the call sites use this in term position (`exact … SL_i₀`), where no `simp`-set substitution
+applies. Its sibling `mapGL_val` *was* a redundant restatement and has been removed. -/
 private lemma mapGL_val_det (S : SpecialLinearGroup (Fin 2) ℤ) :
     (mapGL ℚ S).val.det = 1 := by
   rw [mapGL_coe_matrix]
@@ -189,8 +189,9 @@ private lemma mulSupport_pp_dvd_p_aux (p : ℕ) (hp : p.Prime)
     ext i j
     have h := congr_arg (fun g : GL (Fin 2) ℚ ↦ (↑g : Matrix (Fin 2) (Fin 2) ℚ) i j) h_gl
     simp only [natDiagGL_coe 2 _ ha_pos, natDiagGL_coe 2 _ h1p, natDiagGL_coe 2 _ h1pk,
-      Matrix.diagonal_apply, Units.val_mul, mapGL_val, Matrix.mul_apply,
-      Matrix.map_apply, algebraMap_int_eq, Int.coe_castRingHom] at h
+      Matrix.diagonal_apply, Units.val_mul, mapGL_coe_matrix, Matrix.mul_apply,
+      map_apply_coe, RingHom.mapMatrix_apply, Matrix.map_apply, algebraMap_int_eq,
+      Int.coe_castRingHom] at h
     simp only [Matrix.diagonal_apply, Matrix.mul_apply]
     exact_mod_cast h
   exact first_invariant_dvd_p_of_product p S_mid a hdiv L' R' k h_int

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -1,0 +1,598 @@
+/-
+Copyright (c) 2024 Chris Birkbeck. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Chris Birkbeck
+-/
+module
+
+public import TauCeti.NumberTheory.HeckeRing.Degree
+public import TauCeti.NumberTheory.HeckeRing.GL2.Basic
+public import TauCeti.NumberTheory.HeckeRing.GL2.DiagonalCosetDegree
+
+/-!
+# The `GL₂` multiplication table: telescoping identities
+
+The first multiplication identity of Shimura's Theorem 3.24 for the `GL₂` Hecke ring:
+`T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`, by telescoping the divisor-pair
+expansion of `T(pᵏ)` against the index shift `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))`.
+
+Ported from the AINTLIB `LeanModularForms` project
+([`LeanModularForms/HeckeRIngs/GL2/MultiplicationTable.lean`](https://github.com/CBirkbeck/AINTLIB),
+Chris Birkbeck), first section.
+
+## Main results
+
+* `HeckeRing.GL2.heckeTDiag_one_ppow_eq`: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))`.
+
+## References
+
+* [G. Shimura, *Introduction to the arithmetic theory of automorphic functions*][shimura1971],
+  Theorem 3.24.
+-/
+
+public section
+
+open Matrix HeckeRing DoubleCoset Finset HeckeRing.GLn Matrix.SpecialLinearGroup
+
+namespace HeckeRing.GL2
+
+variable (p : ℕ) (hp : p.Prime)
+
+include hp in
+/-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`. -/
+lemma heckeTScalar_mul_heckeTDiag_ppow (j d : ℕ) (hjd : j ≤ d) :
+    heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
+      heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
+  rw [heckeTDiag_of_pos (pow_pos hp.pos j) (pow_pos hp.pos d) (Nat.pow_dvd_pow p hjd),
+    heckeTDiag_of_pos (pow_pos hp.pos (j + 1)) (pow_pos hp.pos (d + 1))
+      (Nat.pow_dvd_pow p (by omega)),
+    HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
+      (transposeAntiInvolution_onHeckeCoset_eq_self 2),
+    heckeTScalar_of_pos hp.pos,
+    diagElem_mul_const 2 ![p ^ j, p ^ d]
+      (fun i ↦ by fin_cases i <;> exact pow_pos hp.pos _) p hp.pos]
+  exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply, pow_succ])
+
+include hp in
+/-- **Shimura, Theorem 3.24(2)**: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`:
+the divisor-pair expansion of `T(pᵏ)` telescopes against the index shift. -/
+theorem heckeTDiag_one_ppow_eq (k : ℕ) (hk : 2 ≤ k) :
+    heckeTDiag 1 (p ^ k) = heckeT ⟨p ^ k, pow_pos hp.pos k⟩ -
+      heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ := by
+  suffices h : heckeTDiag 1 (p ^ k) +
+      heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ =
+      heckeT ⟨p ^ k, pow_pos hp.pos k⟩ from eq_sub_iff_add_eq.mpr h
+  rw [heckeT_ppow_expansion p hp k, heckeT_ppow_expansion p hp (k - 2), Finset.mul_sum]
+  have shift : ∀ j ∈ Finset.range ((k - 2) / 2 + 1),
+      heckeTScalar p * heckeTDiag (p ^ j) (p ^ (k - 2 - j)) =
+      heckeTDiag (p ^ (j + 1)) (p ^ (k - (j + 1))) := fun j hj ↦ by
+    rw [Finset.mem_range] at hj
+    have harith : k - 2 - j + 1 = k - (j + 1) := by omega
+    rw [heckeTScalar_mul_heckeTDiag_ppow p hp j (k - 2 - j) (by omega), harith]
+  rw [Finset.sum_congr rfl shift,
+    show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
+    Finset.sum_range_succ']
+  simp only [pow_zero, Nat.sub_zero]
+  abel
+
+section SupportAnalysis
+
+/-! ## Support analysis for `T(1,p) · T(1,pᵏ)`
+
+Every double coset in the support of the product `T(1,p) · T(1,pᵏ)` is `T(1, p^(k+1))` or
+`T(p, pᵏ)`: the determinant balances to `p^(k+1)`, and the first invariant factor divides
+`p` because the conjugated middle matrix stays integral. -/
+
+private lemma mapGL_val_det (S : SpecialLinearGroup (Fin 2) ℤ) :
+    (mapGL ℚ S).val.det = 1 := by
+  rw [mapGL_coe_matrix]
+  exact_mod_cast (SpecialLinearGroup.map (algebraMap ℤ ℚ) S).prop
+
+private lemma mapGL_val (S : SpecialLinearGroup (Fin 2) ℤ) :
+    ((mapGL ℚ S : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      S.val.map (algebraMap ℤ ℚ) := by
+  rw [mapGL_coe_matrix]
+  rfl
+
+private lemma matrix_isolate_middle (L_ℤ M R_ℤ D : Matrix (Fin 2) (Fin 2) ℤ)
+    (hLadj : L_ℤ.adjugate * L_ℤ = 1) (hRadj : R_ℤ * R_ℤ.adjugate = 1)
+    (heq_LMR : L_ℤ * M * R_ℤ = D) : M = L_ℤ.adjugate * D * R_ℤ.adjugate := by
+  have hassoc : L_ℤ.adjugate * (L_ℤ * M * R_ℤ) * R_ℤ.adjugate =
+      L_ℤ.adjugate * L_ℤ * M * (R_ℤ * R_ℤ.adjugate) := by
+    simp [mul_assoc]
+  rw [← heq_LMR, hassoc, hLadj, hRadj, one_mul, mul_one]
+
+private lemma first_invariant_dvd_p_of_product (p : ℕ) (S : SpecialLinearGroup (Fin 2) ℤ)
+    (a : Fin 2 → ℕ) (hdiv : IsDvdChain a) (L R : SpecialLinearGroup (Fin 2) ℤ) (k : ℕ)
+    (heq : (L : Matrix (Fin 2) (Fin 2) ℤ) * Matrix.diagonal (![1, p] : Fin 2 → ℤ) *
+      (S : Matrix (Fin 2) (Fin 2) ℤ) * Matrix.diagonal (![1, p ^ k] : Fin 2 → ℤ) *
+      (R : Matrix (Fin 2) (Fin 2) ℤ) = Matrix.diagonal (fun i ↦ (a i : ℤ))) : a 0 ∣ p := by
+  set dp := Matrix.diagonal (![1, p] : Fin 2 → ℤ)
+  set dpk := Matrix.diagonal (![1, p ^ k] : Fin 2 → ℤ)
+  set S_ℤ := (S : Matrix (Fin 2) (Fin 2) ℤ)
+  set M := dp * S_ℤ * dpk
+  set L_ℤ := (L : Matrix (Fin 2) (Fin 2) ℤ)
+  set R_ℤ := (R : Matrix (Fin 2) (Fin 2) ℤ)
+  have hLadj : L_ℤ.adjugate * L_ℤ = 1 := by rw [Matrix.adjugate_mul, L.prop, one_smul]
+  have hRadj : R_ℤ * R_ℤ.adjugate = 1 := by rw [Matrix.mul_adjugate, R.prop, one_smul]
+  have hM_eq : M = L_ℤ.adjugate * Matrix.diagonal (fun i ↦ (a i : ℤ)) * R_ℤ.adjugate :=
+    matrix_isolate_middle L_ℤ M R_ℤ _ hLadj hRadj (by
+      have hre : L_ℤ * M * R_ℤ = L_ℤ * dp * S_ℤ * dpk * R_ℤ := by
+        ext i j
+        simp only [M, S_ℤ, Matrix.mul_apply, Fin.sum_univ_two]
+        ring
+      rw [hre]
+      exact heq)
+  have h_dvd_entry : ∀ i j : Fin 2, (a 0 : ℤ) ∣ M i j := by
+    intro i j
+    rw [hM_eq]
+    simp only [Matrix.mul_apply, Matrix.diagonal_apply, Fin.sum_univ_two,
+      mul_ite, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
+    apply dvd_add
+    · exact dvd_mul_of_dvd_left (dvd_mul_of_dvd_right (dvd_refl _) _) _
+    · exact dvd_mul_of_dvd_left (dvd_mul_of_dvd_right
+        (show (a 0 : ℤ) ∣ (a 1 : ℤ) from
+          Int.natCast_dvd_natCast.mpr (isDvdChain_iff.mp hdiv (Fin.zero_le 1))) _) _
+  have h_M00 : M 0 0 = S_ℤ 0 0 := by
+    simp [M, S_ℤ, dp, dpk, Matrix.mul_apply, Fin.sum_univ_two]
+  have h_M10 : M 1 0 = (p : ℤ) * S_ℤ 1 0 := by
+    simp [M, S_ℤ, dp, dpk, Matrix.mul_apply, Fin.sum_univ_two, mul_comm]
+  have h_cop : IsCoprime (S_ℤ 0 0) (S_ℤ 1 0) := S.isCoprime_col 0
+  have h1 : (a 0 : ℤ) ∣ S_ℤ 0 0 := h_M00 ▸ h_dvd_entry 0 0
+  have h2 : (a 0 : ℤ) ∣ (p : ℤ) * S_ℤ 1 0 := h_M10 ▸ h_dvd_entry 1 0
+  have h_cop_a : IsCoprime ((a 0 : ℤ)) (S_ℤ 1 0) := by
+    obtain ⟨u, v, huv⟩ := h_cop
+    obtain ⟨t, ht⟩ := h1
+    refine ⟨u * t, v, ?_⟩
+    have hshuffle : u * t * (a 0 : ℤ) = u * ((a 0 : ℤ) * t) := by ring
+    rw [hshuffle, ← ht]
+    exact huv
+  exact_mod_cast h_cop_a.dvd_of_dvd_mul_right h2
+
+/-- Determinant balance: if a `T(1,p) · T(1,pᵏ)`-shaped product lies in the double coset
+of `diag a`, then `a 0 * a 1 = p ^ (k + 1)`. -/
+private lemma mulSupport_pp_det_eq (p : ℕ) (k : ℕ) (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i)
+    (g₁ g₂ g₃ g₄ : GL (Fin 2) ℚ) (h1 : g₁.val.det = 1) (h2 : g₂.val.det = (p : ℚ))
+    (h3 : g₃.val.det = 1) (h4 : g₄.val.det = (p : ℚ) ^ k)
+    (SL_La SL_Ra : SpecialLinearGroup (Fin 2) ℤ)
+    (h_eq : g₁ * g₂ * (g₃ * g₄) =
+      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra) :
+    a 0 * a 1 = p ^ (k + 1) := by
+  have h_lhs : (g₁ * g₂ * (g₃ * g₄)).val.det = (p : ℚ) ^ (k + 1) := by
+    simp only [Units.val_mul, Matrix.det_mul, h1, h2, h3, h4]
+    ring
+  have h_rhs : (g₁ * g₂ * (g₃ * g₄)).val.det = (a 0 : ℚ) * (a 1 : ℚ) := by
+    rw [h_eq, Units.val_mul, Units.val_mul, Matrix.det_mul, Matrix.det_mul]
+    simp only [mapGL_val_det, natDiagGL_det 2 a ha_pos, Fin.prod_univ_two, one_mul, mul_one]
+  exact_mod_cast h_rhs.symm.trans h_lhs
+
+private lemma mulSupport_pp_dvd_p_aux (p : ℕ) (hp : p.Prime)
+    (S_mid L' R' : SpecialLinearGroup (Fin 2) ℤ)
+    (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (k : ℕ)
+    (h_gl : mapGL ℚ L' * natDiagGL 2 (![1, p]) * mapGL ℚ S_mid *
+      natDiagGL 2 (![1, p ^ k]) * mapGL ℚ R' = natDiagGL 2 a) : a 0 ∣ p := by
+  have h1p : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := by
+    intro i
+    fin_cases i <;> simp [hp.pos]
+  have h1pk : ∀ i : Fin 2, 0 < (![1, p ^ k] : Fin 2 → ℕ) i := by
+    intro i
+    fin_cases i <;> simp [pow_pos hp.pos k]
+  have h_int : (L' : Matrix (Fin 2) (Fin 2) ℤ) * Matrix.diagonal (![1, p] : Fin 2 → ℤ) *
+      (S_mid : Matrix (Fin 2) (Fin 2) ℤ) * Matrix.diagonal (![1, p ^ k] : Fin 2 → ℤ) *
+      (R' : Matrix (Fin 2) (Fin 2) ℤ) = Matrix.diagonal (fun i ↦ (a i : ℤ)) := by
+    ext i j
+    have h := congr_arg (fun g : GL (Fin 2) ℚ ↦ (↑g : Matrix (Fin 2) (Fin 2) ℚ) i j) h_gl
+    simp only [natDiagGL_coe 2 _ ha_pos, natDiagGL_coe 2 _ h1p, natDiagGL_coe 2 _ h1pk,
+      Matrix.diagonal_apply, Units.val_mul, mapGL_val, Matrix.mul_apply,
+      Matrix.map_apply, algebraMap_int_eq, Int.coe_castRingHom] at h
+    simp only [Matrix.diagonal_apply, Matrix.mul_apply]
+    exact_mod_cast h
+  exact first_invariant_dvd_p_of_product p S_mid a hdiv L' R' k h_int
+
+/-- Divisibility constraint: if a `T(1,p) · T(1,pᵏ)`-shaped product lies in the double
+coset of `diag a`, the first invariant `a 0` divides `p`. -/
+private lemma mulSupport_pp_dvd_p (p : ℕ) (hp : p.Prime) (k : ℕ) (a : Fin 2 → ℕ)
+    (ha_pos : ∀ i, 0 < a i) (hdiv : IsDvdChain a) (D1c D2c i₀_gl j₀_gl : GL (Fin 2) ℚ)
+    (SL_L₁ SL_R₁ SL_L₂ SL_R₂ SL_La SL_Ra SL_i₀ SL_j₀ : SpecialLinearGroup (Fin 2) ℤ)
+    (hD1_eq : D1c = mapGL ℚ SL_L₁ * natDiagGL 2 (![1, p]) * mapGL ℚ SL_R₁)
+    (hD2_eq : D2c = mapGL ℚ SL_L₂ * natDiagGL 2 (![1, p ^ k]) * mapGL ℚ SL_R₂)
+    (hi₀ : i₀_gl = mapGL ℚ SL_i₀) (hj₀ : j₀_gl = mapGL ℚ SL_j₀)
+    (h_prod_eq_a : i₀_gl * D1c * (j₀_gl * D2c) =
+      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra) : a 0 ∣ p := by
+  apply mulSupport_pp_dvd_p_aux p hp (SL_R₁ * SL_j₀ * SL_L₂) (SL_La⁻¹ * SL_i₀ * SL_L₁)
+    (SL_R₂ * SL_Ra⁻¹) a ha_pos hdiv k
+  have hprod : mapGL ℚ SL_i₀ * (mapGL ℚ SL_L₁ * natDiagGL 2 (![1, p]) * mapGL ℚ SL_R₁) *
+      (mapGL ℚ SL_j₀ * (mapGL ℚ SL_L₂ * natDiagGL 2 (![1, p ^ k]) * mapGL ℚ SL_R₂)) =
+      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
+    rwa [← hi₀, ← hj₀, ← hD1_eq, ← hD2_eq]
+  have hiso := congr_arg (· * (mapGL ℚ SL_Ra)⁻¹)
+    (congr_arg ((mapGL ℚ SL_La)⁻¹ * ·) hprod)
+  simp only [mul_assoc, inv_mul_cancel_left] at hiso
+  simp only [map_mul, map_inv]
+  convert hiso using 1
+  group
+
+/-- The two-way case split: determinant balance and the invariant-divisibility force any
+support coset of `T(1,p) · T(1,pᵏ)` to be `T(1, p^(k+1))` or `T(p, pᵏ)`. -/
+private lemma mulSupport_pp_case_split (p : ℕ) (hp : p.Prime) (k : ℕ) (a : Fin 2 → ℕ)
+    (h_det_prod : a 0 * a 1 = p ^ (k + 1)) (h_dvd_p : a 0 ∣ p) :
+    diagCoset a = diagCoset (![1, p ^ (k + 1)]) ∨ diagCoset a = diagCoset (![p, p ^ k]) := by
+  rcases hp.eq_one_or_self_of_dvd (a 0) h_dvd_p with ha0_1 | ha0_p
+  · left
+    congr 1
+    ext i
+    fin_cases i
+    · exact ha0_1
+    · rw [ha0_1, one_mul] at h_det_prod
+      simpa using h_det_prod
+  · right
+    congr 1
+    ext i
+    fin_cases i
+    · exact ha0_p
+    · change a 1 = p ^ k
+      have h1 : p * a 1 = p ^ (k + 1) := by rwa [ha0_p] at h_det_prod
+      refine Nat.eq_of_mul_eq_mul_left hp.pos ?_
+      rw [h1, pow_succ]
+      ring
+
+end SupportAnalysis
+
+section DegreeCount
+
+variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
+
+/-- The wrapper's addition evaluates pointwise. Mathlib's `Finsupp.add_apply` does not
+apply through the sealed `HeckeCosetModule` coercion, but the fact is definitional. -/
+private lemma coe_add_apply (f g : HeckeCosetModule Δ H H ℤ) (B : HeckeCoset Δ H H) :
+    (f + g) B = f B + g B := (rfl)
+
+/-- The wrapper's scalar multiplication evaluates pointwise, definitionally. -/
+private lemma coe_smul_apply (c : ℤ) (f : HeckeCosetModule Δ H H ℤ) (B : HeckeCoset Δ H H) :
+    (c • f) B = c * f B := (rfl)
+
+private lemma single_one_mul_single_one (D₁ D₂ : HeckeCoset Δ H H) :
+    HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1 =
+      HeckeCosetModule.structureConstants ℤ H H H D₁.rep D₂.rep := by
+  rw [HeckeCosetModule.single_mul_single]
+  exact (one_smul ℤ _).trans (one_smul ℤ _)
+
+/-- Counting degrees through the degree homomorphism: when the product of two double cosets
+is supported on exactly two cosets, the multiplicity-weighted degrees of the two outputs
+add up to the product of the input degrees. -/
+private lemma multiplicity_degree_sum_eq (D₁ D₂ Dout₁ Dout₂ : HeckeCoset Δ H H)
+    (hne : Dout₁ ≠ Dout₂)
+    (hzero : ∀ A : HeckeCoset Δ H H, A ≠ Dout₁ → A ≠ Dout₂ →
+      multiplicity H H H (D₁.rep : G) (D₂.rep : G) (A.rep : G) = 0) :
+    multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₁.rep : G) * Dout₁.degree +
+      multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₂.rep : G) * Dout₂.degree =
+      D₁.degree * D₂.degree := by
+  classical
+  have hSC2 : HeckeCosetModule.structureConstants ℤ H H H D₁.rep D₂.rep =
+      HeckeCosetModule.single ℤ Dout₁
+        (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₁.rep : G) : ℤ) +
+      HeckeCosetModule.single ℤ Dout₂
+        (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₂.rep : G) : ℤ) := by
+    ext A
+    rw [HeckeCosetModule.structureConstants_apply, coe_add_apply,
+      HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+    by_cases h1 : Dout₁ = A
+    · rw [if_pos h1, if_neg (h1 ▸ fun h ↦ hne h.symm), add_zero, ← h1]
+    · rw [if_neg h1]
+      by_cases h2 : Dout₂ = A
+      · rw [if_pos h2, zero_add, ← h2]
+      · rw [if_neg h2, add_zero,
+          hzero A (fun h ↦ h1 h.symm) (fun h ↦ h2 h.symm), Nat.cast_zero]
+  have h1 : LeftCosetModule.deg Δ H ℤ
+      (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
+      (D₁.degree : ℤ) * D₂.degree := by
+    rw [map_mul, LeftCosetModule.deg_single, LeftCosetModule.deg_single]
+    simp
+  have h2 : LeftCosetModule.deg Δ H ℤ
+      (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
+      (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₁.rep : G) : ℤ) * Dout₁.degree +
+      (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₂.rep : G) : ℤ) * Dout₂.degree := by
+    rw [single_one_mul_single_one, hSC2, map_add, LeftCosetModule.deg_single,
+      LeftCosetModule.deg_single]
+    simp [mul_comm]
+  exact_mod_cast (h1.symm.trans h2).symm
+
+end DegreeCount
+
+section SupportSubset
+
+include hp in
+/-- The support of `T(1,p) · T(1,pᵏ)` is contained in `{T(1,p^(k+1)), T(p,pᵏ)}`. -/
+private lemma mulSupport_pp_subset (k : ℕ)
+    (A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2))
+    (hA : multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) ≠ 0) :
+    A = diagCoset ![1, p ^ (k + 1)] ∨ A = diagCoset ![p, p ^ k] := by
+  classical
+  have h1p_pos : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := fun i ↦ by
+    fin_cases i <;> simp [hp.pos]
+  have h1pk_pos : ∀ i : Fin 2, 0 < (![1, p ^ k] : Fin 2 → ℕ) i := fun i ↦ by
+    fin_cases i <;> simp [pow_pos hp.pos k]
+  obtain ⟨a, ha_pos, hdiv, hA_eq⟩ := exists_diagonal_representative A
+  have hmem := (HeckeCoset.mem_image_mulMap_iff (diagCoset ![1, p]).rep
+    (diagCoset ![1, p ^ k]).rep A).mpr hA
+  simp only [Finset.mem_image, Finset.mem_univ, true_and] at hmem
+  obtain ⟨q, hq⟩ := hmem
+  have h_prod_mem : ((q.1.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
+      ((q.2.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))) ∈
+      doubleCoset (natDiagGL 2 a) (SLnZ 2) (SLnZ 2) := by
+    have hself : ((q.1.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
+        ((q.2.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))) ∈
+        (HeckeCoset.mulMap (SLnZ 2) (SLnZ 2) (SLnZ 2)
+          (diagCoset ![1, p]).rep (diagCoset ![1, p ^ k]).rep q).toSet := by
+      rw [HeckeCoset.mulMap_eq_mk, HeckeCoset.toSet_mk]
+      exact mem_doubleCoset_self _ _ _
+    rwa [hq, hA_eq, diagCoset_toSet] at hself
+  rw [mem_doubleCoset] at h_prod_mem
+  obtain ⟨La, hLa, Ra, hRa, h_prod_eq⟩ := h_prod_mem
+  obtain ⟨SL_La, hSL_La⟩ := (mem_SLnZ_iff 2).mp hLa
+  obtain ⟨SL_Ra, hSL_Ra⟩ := (mem_SLnZ_iff 2).mp hRa
+  obtain ⟨SL_i₀, hSL_i₀⟩ := (mem_SLnZ_iff 2).mp q.1.out.2
+  obtain ⟨SL_j₀, hSL_j₀⟩ := (mem_SLnZ_iff 2).mp q.2.out.2
+  obtain ⟨L₁, hL₁, R₁, hR₁, hD1⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p])
+  obtain ⟨SL_L₁, hSL_L₁⟩ := (mem_SLnZ_iff 2).mp hL₁
+  obtain ⟨SL_R₁, hSL_R₁⟩ := (mem_SLnZ_iff 2).mp hR₁
+  obtain ⟨L₂, hL₂, R₂, hR₂, hD2⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p ^ k])
+  obtain ⟨SL_L₂, hSL_L₂⟩ := (mem_SLnZ_iff 2).mp hL₂
+  obtain ⟨SL_R₂, hSL_R₂⟩ := (mem_SLnZ_iff 2).mp hR₂
+  have h_prod_eq' : (q.1.out : GL (Fin 2) ℚ) *
+      ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) *
+      ((q.2.out : GL (Fin 2) ℚ) * ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) =
+      mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
+    rw [hSL_La, hSL_Ra]
+    exact h_prod_eq
+  have h_det := mulSupport_pp_det_eq p k a ha_pos (q.1.out : GL (Fin 2) ℚ)
+    ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
+    ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
+    (by rw [← hSL_i₀]; exact mapGL_val_det SL_i₀)
+    (by rw [hD1, ← hSL_L₁, ← hSL_R₁, Units.val_mul, Units.val_mul, Matrix.det_mul,
+          Matrix.det_mul, mapGL_val_det, mapGL_val_det, natDiagGL_det 2 _ h1p_pos]
+        simp [Fin.prod_univ_two])
+    (by rw [← hSL_j₀]; exact mapGL_val_det SL_j₀)
+    (by rw [hD2, ← hSL_L₂, ← hSL_R₂, Units.val_mul, Units.val_mul, Matrix.det_mul,
+          Matrix.det_mul, mapGL_val_det, mapGL_val_det, natDiagGL_det 2 _ h1pk_pos]
+        simp [Fin.prod_univ_two])
+    SL_La SL_Ra h_prod_eq'
+  have h_dvd := mulSupport_pp_dvd_p p hp k a ha_pos hdiv
+    ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
+    (q.1.out : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
+    SL_L₁ SL_R₁ SL_L₂ SL_R₂ SL_La SL_Ra SL_i₀ SL_j₀
+    (by rw [hD1, hSL_L₁, hSL_R₁]) (by rw [hD2, hSL_L₂, hSL_R₂])
+    hSL_i₀.symm hSL_j₀.symm h_prod_eq'
+  rw [hA_eq]
+  exact mulSupport_pp_case_split p hp k a h_det h_dvd
+
+include hp in
+/-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1`. -/
+private lemma degree_diagCoset_one_ppow (j : ℕ) (hj : 0 < j) :
+    (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) :=
+  degree_diagCoset_of_ratio_eq_prime_pow p hp _
+    (isDvdChain_iff.mpr fun i j' hij ↦ by
+      fin_cases i <;> fin_cases j' <;> first | exact absurd hij (by decide) | simp)
+    j hj (by simp)
+
+include hp in
+/-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2`. -/
+private lemma degree_diagCoset_p_ppow (k : ℕ) (hk2 : 2 ≤ k) :
+    (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) := by
+  have h := degree_diagCoset_of_ratio_eq_prime_pow p hp (![p, p ^ k] : Fin 2 → ℕ)
+    (isDvdChain_iff.mpr fun i j' hij ↦ by
+      fin_cases i <;> fin_cases j' <;>
+        first
+        | exact absurd hij (by decide)
+        | simp [dvd_pow_self p (show k ≠ 0 by omega)])
+    (k - 1) (by omega)
+    (by change p ^ k / p = p ^ (k - 1)
+        have hsplit : p ^ k = p ^ (k - 1) * p := by
+          rw [← pow_succ]
+          congr 1
+          omega
+        rw [hsplit, Nat.mul_div_cancel _ hp.pos])
+  rwa [show k - 1 - 1 = k - 2 by omega] at h
+
+omit hp in
+/-- The degree of the scalar coset `T(p, p)` is `1`. -/
+private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).degree = 1 := by
+  have hconst : (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p := by
+    funext i
+    fin_cases i <;> simp
+  rw [hconst]
+  exact degree_diagCoset_const 2 p
+
+include hp in
+/-- The two support cosets are distinct: their invariant factors differ at the top. -/
+private lemma diagCoset_one_ppow_succ_ne (k : ℕ) (hk : 0 < k) :
+    diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) ≠ diagCoset (![p, p ^ k] : Fin 2 → ℕ) := by
+  intro heq
+  have ha := eq_of_diagCoset_eq
+    (fun i : Fin 2 ↦ by fin_cases i <;> simp [pow_pos hp.pos])
+    (fun i : Fin 2 ↦ by fin_cases i <;> simp [hp.pos, pow_pos hp.pos])
+    (isDvdChain_iff.mpr fun i j' hij ↦ by
+      fin_cases i <;> fin_cases j' <;> first | exact absurd hij (by decide) | simp)
+    (isDvdChain_iff.mpr fun i j' hij ↦ by
+      fin_cases i <;> fin_cases j' <;>
+        first
+        | exact absurd hij (by decide)
+        | simp [dvd_pow_self p (show k ≠ 0 by omega)])
+    heq
+  exact hp.one_lt.ne' (by simpa using (congr_fun ha 0).symm)
+
+/-- Arithmetic core, `k ≥ 2`: the degree balance forces `m₁ = 1` and `m₂ = P`. -/
+private lemma m1_eq_one_and_m2_eq_of_two_le (P m1 m2 : ℤ) (k : ℕ) (hk2 : 2 ≤ k)
+    (hP : 2 ≤ P) (hm1 : 1 ≤ m1) (hm2 : 0 ≤ m2)
+    (h_deg : m1 * (P ^ k * (P + 1)) + m2 * (P ^ (k - 2) * (P + 1)) =
+      (P + 1) * (P ^ (k - 1) * (P + 1))) :
+    m1 = 1 ∧ m2 = P := by
+  have hpk : P ^ k = P ^ (k - 2) * P ^ 2 := by
+    rw [← pow_add]
+    congr 1
+    omega
+  have hpk1 : P ^ (k - 1) = P ^ (k - 2) * P := by
+    rw [show k - 1 = (k - 2) + 1 by omega, pow_succ]
+  have h_eq : m1 * P ^ 2 + m2 = P * (P + 1) := by
+    have h := h_deg
+    rw [hpk, hpk1] at h
+    have key : P ^ (k - 2) * (P + 1) ≠ 0 := by positivity
+    have hcancel := mul_right_cancel₀ key (show
+      (m1 * P ^ 2 + m2) * (P ^ (k - 2) * (P + 1)) =
+      (P * (P + 1)) * (P ^ (k - 2) * (P + 1)) by nlinarith)
+    linarith
+  have h_m1_eq : m1 = 1 := by
+    have h_le : m1 * P ^ 2 ≤ P ^ 2 + P := by linarith
+    nlinarith [show P ^ 2 ≥ 4 by nlinarith]
+  exact ⟨h_m1_eq, by rw [h_m1_eq] at h_eq; linarith⟩
+
+/-- Arithmetic core, `k = 1`: the degree balance forces `m₁ = 1` and `m₂ = P + 1`. -/
+private lemma m1_eq_one_and_m2_eq_of_eq_one (P m1 m2 : ℤ) (hP : 2 ≤ P)
+    (hm1 : 1 ≤ m1) (hm2 : 0 ≤ m2)
+    (h_deg : m1 * (P ^ 1 * (P + 1)) + m2 * 1 = (P + 1) * (P + 1)) :
+    m1 = 1 ∧ m2 = P + 1 := by
+  have h_m1_eq : m1 = 1 := by nlinarith [mul_self_nonneg (P - 1)]
+  exact ⟨h_m1_eq, by rw [h_m1_eq] at h_deg; nlinarith⟩
+
+include hp in
+/-- The diagonal elements multiply as expected: `diag(1, p) · diag(1, pᵏ) = diag(1, p^(k+1))`. -/
+private lemma natDiagGL_one_p_mul_one_ppow (k : ℕ) :
+    natDiagGL 2 (![1, p]) * natDiagGL 2 (![1, p ^ k]) = natDiagGL 2 (![1, p ^ (k + 1)]) := by
+  rw [natDiagGL_mul 2 _ _ (fun i ↦ by fin_cases i <;> simp [hp.pos])
+    (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos k])]
+  exact congrArg (natDiagGL 2) (funext fun i ↦ by
+    fin_cases i <;> simp [Pi.mul_apply, pow_succ'])
+
+include hp in
+/-- `T(1, p^(k+1))` genuinely occurs in `T(1,p) · T(1,pᵏ)`: its representative is the product
+of the two representatives, up to `SL₂(ℤ)` factors on either side. -/
+private lemma multiplicity_one_ppow_succ_pos (k : ℕ) :
+    0 < multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ (k + 1)]).rep : GL (Fin 2) ℚ)) := by
+  refine Nat.pos_of_ne_zero (multiplicity_ne_zero_iff.mpr ?_)
+  obtain ⟨L₁, hL₁, R₁, hR₁, hD1⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p])
+  obtain ⟨L₂, hL₂, R₂, hR₂, hD2⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p ^ k])
+  obtain ⟨L, hL, R, hR, hD⟩ := exists_rep_diagCoset_eq_mul_natDiagGL_mul (![1, p ^ (k + 1)])
+  rw [mem_doubleCoset]
+  refine ⟨L * L₁⁻¹ * ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) * (R₁⁻¹ * L₂⁻¹),
+    mem_doubleCoset.mpr ⟨L * L₁⁻¹,
+      (SLnZ 2).mul_mem hL ((SLnZ 2).inv_mem hL₁),
+      R₁⁻¹ * L₂⁻¹,
+      (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₁) ((SLnZ 2).inv_mem hL₂), rfl⟩,
+    R₂⁻¹ * R, (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₂) hR, ?_⟩
+  rw [hD, hD1, hD2, ← natDiagGL_one_p_mul_one_ppow p hp k]
+  group
+
+include hp in
+/-- The multiplicities in `T(1,p) · T(1,pᵏ)`: the coset `T(1, p^(k+1))` appears once, and
+`T(p, pᵏ)` appears `p + 1` times for `k = 1` and `p` times for `k ≥ 2`. -/
+private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
+    multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ (k + 1)]).rep : GL (Fin 2) ℚ)) = 1 ∧
+    multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+      (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+      (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) =
+      if k = 1 then p + 1 else p := by
+  classical
+  set m1 := multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+    (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+    (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+    (((diagCoset ![1, p ^ (k + 1)]).rep : GL (Fin 2) ℚ)) with hm1_def
+  set m2 := multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+    (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+    (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
+    (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) with hm2_def
+  have h_ne := diagCoset_one_ppow_succ_ne p hp k hk
+  have h_zero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
+      A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
+      multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) = 0 := by
+    intro A h1 h2
+    by_contra h0
+    exact ((mulSupport_pp_subset p hp k A h0).elim h1 h2)
+  have h_deg := multiplicity_degree_sum_eq (diagCoset ![1, p]) (diagCoset ![1, p ^ k])
+    (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k]) h_ne h_zero
+  rw [← hm1_def, ← hm2_def] at h_deg
+  rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p ^ 0 * (p + 1) by
+      simpa using degree_diagCoset_one_ppow p hp 1 one_pos,
+    degree_diagCoset_one_ppow p hp k hk,
+    show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
+      simpa using degree_diagCoset_one_ppow p hp (k + 1) (by omega)] at h_deg
+  have hm1_pos : 0 < m1 := multiplicity_one_ppow_succ_pos p hp k
+  have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
+  by_cases hk1 : k = 1
+  · subst hk1
+    rw [degree_diagCoset_p_p p] at h_deg
+    have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ 1 * ((p : ℤ) + 1)) + (m2 : ℤ) * 1 =
+        ((p : ℤ) + 1) * ((p : ℤ) + 1) := by
+      have := h_deg
+      push_cast at this ⊢
+      norm_num at this ⊢
+      linarith
+    obtain ⟨h1, h2⟩ := m1_eq_one_and_m2_eq_of_eq_one (p : ℤ) (m1 : ℤ) (m2 : ℤ) hp2
+      (by exact_mod_cast hm1_pos) (by positivity) h_degZ
+    simp only [ite_true]
+    exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
+  · have hk2 : 2 ≤ k := by omega
+    rw [degree_diagCoset_p_ppow p hp k hk2] at h_deg
+    have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
+        (m2 : ℤ) * ((p : ℤ) ^ (k - 2) * ((p : ℤ) + 1)) =
+        ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
+      have := h_deg
+      zify at this
+      ring_nf at this ⊢
+      linarith
+    obtain ⟨h1, h2⟩ := m1_eq_one_and_m2_eq_of_two_le (p : ℤ) (m1 : ℤ) (m2 : ℤ) k hk2 hp2
+      (by exact_mod_cast hm1_pos) (by positivity) h_degZ
+    simp only [hk1, ite_false]
+    exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
+
+include hp in
+/-- **Shimura, Theorem 3.24(5)**: `T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, where
+the multiplicity `m` is `p + 1` for `k = 1` and `p` for `k ≥ 2`. -/
+theorem heckeT_prime_mul_heckeTDiag (k : ℕ) (hk : 0 < k) :
+    heckeT ⟨p, hp.pos⟩ * heckeTDiag 1 (p ^ k) =
+      heckeTDiag 1 (p ^ (k + 1)) +
+        (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by
+  classical
+  obtain ⟨hm1, hm2⟩ := multiplicity_values p hp k hk
+  have hne := diagCoset_one_ppow_succ_ne p hp k hk
+  have hzero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
+      A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
+      multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
+        (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) = 0 := by
+    intro A h1 h2
+    by_contra h0
+    exact ((mulSupport_pp_subset p hp k A h0).elim h1 h2)
+  rw [heckeT_prime p hp,
+    heckeTDiag_of_pos one_pos hp.pos (one_dvd _),
+    heckeTDiag_of_pos one_pos (pow_pos hp.pos k) (one_dvd _),
+    heckeTDiag_of_pos one_pos (pow_pos hp.pos (k + 1)) (one_dvd _),
+    heckeTDiag_of_pos hp.pos (pow_pos hp.pos k) (dvd_pow_self p (by omega))]
+  simp only [diagElem_def]
+  rw [single_one_mul_single_one]
+  ext A
+  rw [HeckeCosetModule.structureConstants_apply, coe_add_apply, coe_smul_apply,
+    HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+  by_cases h1 : diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) = A
+  · have h12 : diagCoset (![p, p ^ k] : Fin 2 → ℕ) ≠ A := fun h ↦ hne (h1.trans h.symm)
+    rw [if_pos h1, if_neg h12, mul_zero, add_zero, ← h1, hm1, Nat.cast_one]
+  · rw [if_neg h1]
+    by_cases h2 : diagCoset (![p, p ^ k] : Fin 2 → ℕ) = A
+    · rw [if_pos h2, mul_one, zero_add, ← h2, hm2]
+      split_ifs <;> push_cast <;> ring
+    · rw [if_neg h2, mul_zero, add_zero,
+        hzero A (fun h ↦ h1 h.symm) (fun h ↦ h2 h.symm), Nat.cast_zero]
+
+end SupportSubset
+
+end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -43,19 +43,22 @@ namespace HeckeRing.GL2
 
 variable (p : ℕ) (hp : p.Prime)
 
-include hp in
-/-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`. -/
-lemma heckeTScalar_mul_heckeTDiag_prime_pow (j d : ℕ) (hjd : j ≤ d) :
+/-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`.
+
+Needs only `0 < p`, not primality: the argument is the scalar-multiplication rule for diagonal
+Hecke elements, which never inspects the factorization of `p`. -/
+@[simp]
+lemma heckeTScalar_mul_heckeTDiag_prime_pow (hp0 : 0 < p) (j d : ℕ) (hjd : j ≤ d) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
-  rw [heckeTDiag_of_pos (pow_pos hp.pos j) (pow_pos hp.pos d) (Nat.pow_dvd_pow p hjd),
-    heckeTDiag_of_pos (pow_pos hp.pos (j + 1)) (pow_pos hp.pos (d + 1))
+  rw [heckeTDiag_of_pos (pow_pos hp0 j) (pow_pos hp0 d) (Nat.pow_dvd_pow p hjd),
+    heckeTDiag_of_pos (pow_pos hp0 (j + 1)) (pow_pos hp0 (d + 1))
       (Nat.pow_dvd_pow p (by omega)),
     HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
       (transposeAntiInvolution_onHeckeCoset_eq_self 2),
-    heckeTScalar_of_pos hp.pos,
+    heckeTScalar_of_pos hp0,
     diagElem_mul_const 2 ![p ^ j, p ^ d]
-      (fun i ↦ by fin_cases i <;> exact pow_pos hp.pos _) p hp.pos]
+      (fun i ↦ by fin_cases i <;> exact pow_pos hp0 _) p hp0]
   exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply, pow_succ])
 
 include hp in
@@ -73,7 +76,7 @@ theorem heckeTDiag_one_prime_pow_eq (k : ℕ) (hk : 2 ≤ k) :
       heckeTDiag (p ^ (j + 1)) (p ^ (k - (j + 1))) := fun j hj ↦ by
     rw [Finset.mem_range] at hj
     have harith : k - 2 - j + 1 = k - (j + 1) := by omega
-    rw [heckeTScalar_mul_heckeTDiag_prime_pow p hp j (k - 2 - j) (by omega), harith]
+    rw [heckeTScalar_mul_heckeTDiag_prime_pow p hp.pos j (k - 2 - j) (by omega), harith]
   rw [Finset.sum_congr rfl shift,
     show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
     Finset.sum_range_succ']

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.NumberTheory.HeckeRing.Degree
 public import TauCeti.NumberTheory.HeckeRing.GL2.Basic
 public import TauCeti.NumberTheory.HeckeRing.GL2.DiagonalCosetDegree
+public import TauCeti.NumberTheory.HeckeRing.GL2.Degree
 
 /-!
 # The `GL₂` multiplication table: telescoping identities
@@ -384,37 +385,21 @@ private lemma mulSupport_pp_subset (k : ℕ)
   exact mulSupport_pp_case_split p hp k a h_det h_dvd
 
 include hp in
-/-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1`. -/
+/-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1` — the `i = 0` case of
+`degree_diagCoset_prime_pow`. -/
 private lemma degree_diagCoset_one_prime_pow (j : ℕ) (hj : 0 < j) :
-    (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) :=
-  degree_diagCoset_of_ratio_eq_prime_pow p hp _
-    (isDvdChain_iff.mpr fun i j' hij ↦ by
-      fin_cases i <;> fin_cases j' <;> first | exact absurd hij (by decide) | simp)
-    j hj (by simp)
+    (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) := by
+  simpa using degree_diagCoset_prime_pow p hp 0 j hj
 
 include hp in
-/-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2`. -/
+/-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2` — the `i = 1` case of
+`degree_diagCoset_prime_pow`. -/
 private lemma degree_diagCoset_p_prime_pow (k : ℕ) (hk2 : 2 ≤ k) :
     (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) := by
-  have h := degree_diagCoset_of_ratio_eq_prime_pow p hp (![p, p ^ k] : Fin 2 → ℕ)
-    (isDvdChain_iff.mpr fun i j' hij ↦ by
-      fin_cases i <;> fin_cases j' <;>
-        first
-        | exact absurd hij (by decide)
-        | simp [dvd_pow_self p (show k ≠ 0 by omega)])
-    (k - 1) (by omega)
-    -- the ratio is stated as a `Nat` division; `change` puts it in the closed form
-    -- the arithmetic lemma below proves, which `rw` cannot reach through `/`
-    (by change p ^ k / p = p ^ (k - 1)
-        have hsplit : p ^ k = p ^ (k - 1) * p := by
-          rw [← pow_succ]
-          congr 1
-          omega
-        rw [hsplit, Nat.mul_div_cancel _ hp.pos])
-  rwa [show k - 1 - 1 = k - 2 by omega] at h
+  have h := degree_diagCoset_prime_pow p hp 1 (k - 1) (by omega)
+  rw [show 1 + (k - 1) = k by omega, pow_one] at h
+  rw [h, show k - 1 - 1 = k - 2 by omega]
 
-omit hp in
-/-- The degree of the scalar coset `T(p, p)` is `1`. -/
 private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).degree = 1 := by
   have hconst : (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p := by
     funext i

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -26,7 +26,7 @@ Chris Birkbeck), first section.
 
 ## Main results
 
-* `HeckeRing.GL2.heckeTDiag_one_primePow_eq`: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))`.
+* `HeckeRing.GL2.heckeTDiag_one_prime_pow_eq`: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))`.
 
 ## References
 
@@ -44,7 +44,7 @@ variable (p : ℕ) (hp : p.Prime)
 
 include hp in
 /-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`. -/
-lemma heckeTScalar_mul_heckeTDiag_primePow (j d : ℕ) (hjd : j ≤ d) :
+lemma heckeTScalar_mul_heckeTDiag_prime_pow (j d : ℕ) (hjd : j ≤ d) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
   rw [heckeTDiag_of_pos (pow_pos hp.pos j) (pow_pos hp.pos d) (Nat.pow_dvd_pow p hjd),
@@ -60,19 +60,19 @@ lemma heckeTScalar_mul_heckeTDiag_primePow (j d : ℕ) (hjd : j ≤ d) :
 include hp in
 /-- **Shimura, Theorem 3.24(2)**: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`:
 the divisor-pair expansion of `T(pᵏ)` telescopes against the index shift. -/
-theorem heckeTDiag_one_primePow_eq (k : ℕ) (hk : 2 ≤ k) :
+theorem heckeTDiag_one_prime_pow_eq (k : ℕ) (hk : 2 ≤ k) :
     heckeTDiag 1 (p ^ k) = heckeT ⟨p ^ k, pow_pos hp.pos k⟩ -
       heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ := by
   suffices h : heckeTDiag 1 (p ^ k) +
       heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ =
       heckeT ⟨p ^ k, pow_pos hp.pos k⟩ from eq_sub_iff_add_eq.mpr h
-  rw [heckeT_primePow_expansion p hp k, heckeT_primePow_expansion p hp (k - 2), Finset.mul_sum]
+  rw [heckeT_prime_pow_expansion p hp k, heckeT_prime_pow_expansion p hp (k - 2), Finset.mul_sum]
   have shift : ∀ j ∈ Finset.range ((k - 2) / 2 + 1),
       heckeTScalar p * heckeTDiag (p ^ j) (p ^ (k - 2 - j)) =
       heckeTDiag (p ^ (j + 1)) (p ^ (k - (j + 1))) := fun j hj ↦ by
     rw [Finset.mem_range] at hj
     have harith : k - 2 - j + 1 = k - (j + 1) := by omega
-    rw [heckeTScalar_mul_heckeTDiag_primePow p hp j (k - 2 - j) (by omega), harith]
+    rw [heckeTScalar_mul_heckeTDiag_prime_pow p hp j (k - 2 - j) (by omega), harith]
   rw [Finset.sum_congr rfl shift,
     show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
     Finset.sum_range_succ']
@@ -378,7 +378,7 @@ private lemma mulSupport_pp_subset (k : ℕ)
 
 include hp in
 /-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1`. -/
-private lemma degree_diagCoset_one_primePow (j : ℕ) (hj : 0 < j) :
+private lemma degree_diagCoset_one_prime_pow (j : ℕ) (hj : 0 < j) :
     (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) :=
   degree_diagCoset_of_ratio_eq_prime_pow p hp _
     (isDvdChain_iff.mpr fun i j' hij ↦ by
@@ -387,7 +387,7 @@ private lemma degree_diagCoset_one_primePow (j : ℕ) (hj : 0 < j) :
 
 include hp in
 /-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2`. -/
-private lemma degree_diagCoset_p_primePow (k : ℕ) (hk2 : 2 ≤ k) :
+private lemma degree_diagCoset_p_prime_pow (k : ℕ) (hk2 : 2 ≤ k) :
     (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) := by
   have h := degree_diagCoset_of_ratio_eq_prime_pow p hp (![p, p ^ k] : Fin 2 → ℕ)
     (isDvdChain_iff.mpr fun i j' hij ↦ by
@@ -417,7 +417,7 @@ private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).d
 
 include hp in
 /-- The two support cosets are distinct: their invariant factors differ at the top. -/
-private lemma diagCoset_one_primePow_succ_ne (k : ℕ) (hk : 0 < k) :
+private lemma diagCoset_one_prime_pow_succ_ne (k : ℕ) (hk : 0 < k) :
     diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) ≠ diagCoset (![p, p ^ k] : Fin 2 → ℕ) := by
   intro heq
   have ha := eq_of_diagCoset_eq
@@ -468,7 +468,7 @@ private lemma m1_eq_one_and_m2_eq_of_eq_one (P m1 m2 : ℤ) (hP : 2 ≤ P)
 
 include hp in
 /-- The diagonal elements multiply as expected: `diag(1, p) · diag(1, pᵏ) = diag(1, p^(k+1))`. -/
-private lemma natDiagGL_one_p_mul_one_primePow (k : ℕ) :
+private lemma natDiagGL_one_p_mul_one_prime_pow (k : ℕ) :
     natDiagGL 2 (![1, p]) * natDiagGL 2 (![1, p ^ k]) = natDiagGL 2 (![1, p ^ (k + 1)]) := by
   rw [natDiagGL_mul 2 _ _ (fun i ↦ by fin_cases i <;> simp [hp.pos])
     (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos k])]
@@ -478,7 +478,7 @@ private lemma natDiagGL_one_p_mul_one_primePow (k : ℕ) :
 include hp in
 /-- `T(1, p^(k+1))` genuinely occurs in `T(1,p) · T(1,pᵏ)`: its representative is the product
 of the two representatives, up to `SL₂(ℤ)` factors on either side. -/
-private lemma multiplicity_one_primePow_succ_pos (k : ℕ) :
+private lemma multiplicity_one_prime_pow_succ_pos (k : ℕ) :
     0 < multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
       (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
       (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
@@ -494,7 +494,7 @@ private lemma multiplicity_one_primePow_succ_pos (k : ℕ) :
       R₁⁻¹ * L₂⁻¹,
       (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₁) ((SLnZ 2).inv_mem hL₂), rfl⟩,
     R₂⁻¹ * R, (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₂) hR, ?_⟩
-  rw [hD, hD1, hD2, ← natDiagGL_one_p_mul_one_primePow p hp k]
+  rw [hD, hD1, hD2, ← natDiagGL_one_p_mul_one_prime_pow p hp k]
   group
 
 include hp in
@@ -519,7 +519,7 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) with hm2_def
-  have h_ne := diagCoset_one_primePow_succ_ne p hp k hk
+  have h_ne := diagCoset_one_prime_pow_succ_ne p hp k hk
   have h_zero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
       A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
       multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
@@ -532,11 +532,11 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k]) h_ne h_zero
   rw [← hm1_def, ← hm2_def] at h_deg
   rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p ^ 0 * (p + 1) by
-      simpa using degree_diagCoset_one_primePow p hp 1 one_pos,
-    degree_diagCoset_one_primePow p hp k hk,
+      simpa using degree_diagCoset_one_prime_pow p hp 1 one_pos,
+    degree_diagCoset_one_prime_pow p hp k hk,
     show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
-      simpa using degree_diagCoset_one_primePow p hp (k + 1) (by omega)] at h_deg
-  have hm1_pos : 0 < m1 := multiplicity_one_primePow_succ_pos p hp k
+      simpa using degree_diagCoset_one_prime_pow p hp (k + 1) (by omega)] at h_deg
+  have hm1_pos : 0 < m1 := multiplicity_one_prime_pow_succ_pos p hp k
   have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
   by_cases hk1 : k = 1
   · subst hk1
@@ -552,7 +552,7 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     simp only [ite_true]
     exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
   · have hk2 : 2 ≤ k := by omega
-    rw [degree_diagCoset_p_primePow p hp k hk2] at h_deg
+    rw [degree_diagCoset_p_prime_pow p hp k hk2] at h_deg
     have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
         (m2 : ℤ) * ((p : ℤ) ^ (k - 2) * ((p : ℤ) + 1)) =
         ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
@@ -574,7 +574,7 @@ theorem heckeT_prime_mul_heckeTDiag (k : ℕ) (hk : 0 < k) :
         (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by
   classical
   obtain ⟨hm1, hm2⟩ := multiplicity_values p hp k hk
-  have hne := diagCoset_one_primePow_succ_ne p hp k hk
+  have hne := diagCoset_one_prime_pow_succ_ne p hp k hk
   have hzero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
       A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
       multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -16,6 +16,10 @@ The first multiplication identity of Shimura's Theorem 3.24 for the `GL₂` Heck
 `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`, by telescoping the divisor-pair
 expansion of `T(pᵏ)` against the index shift `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))`.
 
+The file also proves `heckeT_prime_mul_heckeTDiag`, Shimura's Theorem 3.24(5):
+`T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, with multiplicity `m = p + 1` at
+`k = 1` and `m = p` for `k ≥ 2`.
+
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/MultiplicationTable.lean`](https://github.com/CBirkbeck/AINTLIB),
 Chris Birkbeck), first section.
@@ -83,16 +87,18 @@ Every double coset in the support of the product `T(1,p) · T(1,pᵏ)` is `T(1, 
 `T(p, pᵏ)`: the determinant balances to `p^(k+1)`, and the first invariant factor divides
 `p` because the conjugated middle matrix stays integral. -/
 
+/-- `mapGL_coe_matrix` at the `.val` coercion. It states the same fact, but with the
+`GL`-unit coercion already reduced to a plain matrix; the simp set below needs that form,
+and `mapGL_coe_matrix` alone leaves a `mod_cast` obligation it cannot discharge. -/
+private lemma mapGL_val (S : SpecialLinearGroup (Fin 2) ℤ) :
+    ((mapGL ℚ S : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
+      S.val.map (algebraMap ℤ ℚ) :=
+  mapGL_coe_matrix S
+
 private lemma mapGL_val_det (S : SpecialLinearGroup (Fin 2) ℤ) :
     (mapGL ℚ S).val.det = 1 := by
   rw [mapGL_coe_matrix]
   exact_mod_cast (SpecialLinearGroup.map (algebraMap ℤ ℚ) S).prop
-
-private lemma mapGL_val (S : SpecialLinearGroup (Fin 2) ℤ) :
-    ((mapGL ℚ S : GL (Fin 2) ℚ) : Matrix (Fin 2) (Fin 2) ℚ) =
-      S.val.map (algebraMap ℤ ℚ) := by
-  rw [mapGL_coe_matrix]
-  rfl
 
 private lemma matrix_isolate_middle (L_ℤ M R_ℤ D : Matrix (Fin 2) (Fin 2) ℤ)
     (hLadj : L_ℤ.adjugate * L_ℤ = 1) (hRadj : R_ℤ * R_ℤ.adjugate = 1)
@@ -230,6 +236,8 @@ private lemma mulSupport_pp_case_split (p : ℕ) (hp : p.Prime) (k : ℕ) (a : F
     ext i
     fin_cases i
     · exact ha0_p
+    -- `a 1` and the goal's coordinate projection are the same term up to defeq;
+    -- no rewrite exposes it, so state the coordinate directly
     · change a 1 = p ^ k
       have h1 : p * a 1 = p ^ (k + 1) := by rwa [ha0_p] at h_det_prod
       refine Nat.eq_of_mul_eq_mul_left hp.pos ?_
@@ -388,6 +396,8 @@ private lemma degree_diagCoset_p_ppow (k : ℕ) (hk2 : 2 ≤ k) :
         | exact absurd hij (by decide)
         | simp [dvd_pow_self p (show k ≠ 0 by omega)])
     (k - 1) (by omega)
+    -- the ratio is stated as a `Nat` division; `change` puts it in the closed form
+    -- the arithmetic lemma below proves, which `rw` cannot reach through `/`
     (by change p ^ k / p = p ^ (k - 1)
         have hsplit : p ^ k = p ^ (k - 1) * p := by
           rw [← pow_succ]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -26,7 +26,7 @@ Chris Birkbeck), first section.
 
 ## Main results
 
-* `HeckeRing.GL2.heckeTDiag_one_ppow_eq`: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))`.
+* `HeckeRing.GL2.heckeTDiag_one_primePow_eq`: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))`.
 
 ## References
 
@@ -44,7 +44,7 @@ variable (p : ℕ) (hp : p.Prime)
 
 include hp in
 /-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`. -/
-lemma heckeTScalar_mul_heckeTDiag_ppow (j d : ℕ) (hjd : j ≤ d) :
+lemma heckeTScalar_mul_heckeTDiag_primePow (j d : ℕ) (hjd : j ≤ d) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
   rw [heckeTDiag_of_pos (pow_pos hp.pos j) (pow_pos hp.pos d) (Nat.pow_dvd_pow p hjd),
@@ -60,19 +60,19 @@ lemma heckeTScalar_mul_heckeTDiag_ppow (j d : ℕ) (hjd : j ≤ d) :
 include hp in
 /-- **Shimura, Theorem 3.24(2)**: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`:
 the divisor-pair expansion of `T(pᵏ)` telescopes against the index shift. -/
-theorem heckeTDiag_one_ppow_eq (k : ℕ) (hk : 2 ≤ k) :
+theorem heckeTDiag_one_primePow_eq (k : ℕ) (hk : 2 ≤ k) :
     heckeTDiag 1 (p ^ k) = heckeT ⟨p ^ k, pow_pos hp.pos k⟩ -
       heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ := by
   suffices h : heckeTDiag 1 (p ^ k) +
       heckeTScalar p * heckeT ⟨p ^ (k - 2), pow_pos hp.pos (k - 2)⟩ =
       heckeT ⟨p ^ k, pow_pos hp.pos k⟩ from eq_sub_iff_add_eq.mpr h
-  rw [heckeT_ppow_expansion p hp k, heckeT_ppow_expansion p hp (k - 2), Finset.mul_sum]
+  rw [heckeT_primePow_expansion p hp k, heckeT_primePow_expansion p hp (k - 2), Finset.mul_sum]
   have shift : ∀ j ∈ Finset.range ((k - 2) / 2 + 1),
       heckeTScalar p * heckeTDiag (p ^ j) (p ^ (k - 2 - j)) =
       heckeTDiag (p ^ (j + 1)) (p ^ (k - (j + 1))) := fun j hj ↦ by
     rw [Finset.mem_range] at hj
     have harith : k - 2 - j + 1 = k - (j + 1) := by omega
-    rw [heckeTScalar_mul_heckeTDiag_ppow p hp j (k - 2 - j) (by omega), harith]
+    rw [heckeTScalar_mul_heckeTDiag_primePow p hp j (k - 2 - j) (by omega), harith]
   rw [Finset.sum_congr rfl shift,
     show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
     Finset.sum_range_succ']
@@ -378,7 +378,7 @@ private lemma mulSupport_pp_subset (k : ℕ)
 
 include hp in
 /-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1`. -/
-private lemma degree_diagCoset_one_ppow (j : ℕ) (hj : 0 < j) :
+private lemma degree_diagCoset_one_primePow (j : ℕ) (hj : 0 < j) :
     (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) :=
   degree_diagCoset_of_ratio_eq_prime_pow p hp _
     (isDvdChain_iff.mpr fun i j' hij ↦ by
@@ -387,7 +387,7 @@ private lemma degree_diagCoset_one_ppow (j : ℕ) (hj : 0 < j) :
 
 include hp in
 /-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2`. -/
-private lemma degree_diagCoset_p_ppow (k : ℕ) (hk2 : 2 ≤ k) :
+private lemma degree_diagCoset_p_primePow (k : ℕ) (hk2 : 2 ≤ k) :
     (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) := by
   have h := degree_diagCoset_of_ratio_eq_prime_pow p hp (![p, p ^ k] : Fin 2 → ℕ)
     (isDvdChain_iff.mpr fun i j' hij ↦ by
@@ -417,7 +417,7 @@ private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).d
 
 include hp in
 /-- The two support cosets are distinct: their invariant factors differ at the top. -/
-private lemma diagCoset_one_ppow_succ_ne (k : ℕ) (hk : 0 < k) :
+private lemma diagCoset_one_primePow_succ_ne (k : ℕ) (hk : 0 < k) :
     diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) ≠ diagCoset (![p, p ^ k] : Fin 2 → ℕ) := by
   intro heq
   have ha := eq_of_diagCoset_eq
@@ -468,7 +468,7 @@ private lemma m1_eq_one_and_m2_eq_of_eq_one (P m1 m2 : ℤ) (hP : 2 ≤ P)
 
 include hp in
 /-- The diagonal elements multiply as expected: `diag(1, p) · diag(1, pᵏ) = diag(1, p^(k+1))`. -/
-private lemma natDiagGL_one_p_mul_one_ppow (k : ℕ) :
+private lemma natDiagGL_one_p_mul_one_primePow (k : ℕ) :
     natDiagGL 2 (![1, p]) * natDiagGL 2 (![1, p ^ k]) = natDiagGL 2 (![1, p ^ (k + 1)]) := by
   rw [natDiagGL_mul 2 _ _ (fun i ↦ by fin_cases i <;> simp [hp.pos])
     (fun i ↦ by fin_cases i <;> simp [pow_pos hp.pos k])]
@@ -478,7 +478,7 @@ private lemma natDiagGL_one_p_mul_one_ppow (k : ℕ) :
 include hp in
 /-- `T(1, p^(k+1))` genuinely occurs in `T(1,p) · T(1,pᵏ)`: its representative is the product
 of the two representatives, up to `SL₂(ℤ)` factors on either side. -/
-private lemma multiplicity_one_ppow_succ_pos (k : ℕ) :
+private lemma multiplicity_one_primePow_succ_pos (k : ℕ) :
     0 < multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
       (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
       (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
@@ -494,7 +494,7 @@ private lemma multiplicity_one_ppow_succ_pos (k : ℕ) :
       R₁⁻¹ * L₂⁻¹,
       (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₁) ((SLnZ 2).inv_mem hL₂), rfl⟩,
     R₂⁻¹ * R, (SLnZ 2).mul_mem ((SLnZ 2).inv_mem hR₂) hR, ?_⟩
-  rw [hD, hD1, hD2, ← natDiagGL_one_p_mul_one_ppow p hp k]
+  rw [hD, hD1, hD2, ← natDiagGL_one_p_mul_one_primePow p hp k]
   group
 
 include hp in
@@ -519,7 +519,7 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     (((diagCoset ![1, p]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ))
     (((diagCoset ![p, p ^ k]).rep : GL (Fin 2) ℚ)) with hm2_def
-  have h_ne := diagCoset_one_ppow_succ_ne p hp k hk
+  have h_ne := diagCoset_one_primePow_succ_ne p hp k hk
   have h_zero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
       A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
       multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)
@@ -532,11 +532,11 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k]) h_ne h_zero
   rw [← hm1_def, ← hm2_def] at h_deg
   rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p ^ 0 * (p + 1) by
-      simpa using degree_diagCoset_one_ppow p hp 1 one_pos,
-    degree_diagCoset_one_ppow p hp k hk,
+      simpa using degree_diagCoset_one_primePow p hp 1 one_pos,
+    degree_diagCoset_one_primePow p hp k hk,
     show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
-      simpa using degree_diagCoset_one_ppow p hp (k + 1) (by omega)] at h_deg
-  have hm1_pos : 0 < m1 := multiplicity_one_ppow_succ_pos p hp k
+      simpa using degree_diagCoset_one_primePow p hp (k + 1) (by omega)] at h_deg
+  have hm1_pos : 0 < m1 := multiplicity_one_primePow_succ_pos p hp k
   have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
   by_cases hk1 : k = 1
   · subst hk1
@@ -552,7 +552,7 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     simp only [ite_true]
     exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
   · have hk2 : 2 ≤ k := by omega
-    rw [degree_diagCoset_p_ppow p hp k hk2] at h_deg
+    rw [degree_diagCoset_p_primePow p hp k hk2] at h_deg
     have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
         (m2 : ℤ) * ((p : ℤ) ^ (k - 2) * ((p : ℤ) + 1)) =
         ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
@@ -574,7 +574,7 @@ theorem heckeT_prime_mul_heckeTDiag (k : ℕ) (hk : 0 < k) :
         (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by
   classical
   obtain ⟨hm1, hm2⟩ := multiplicity_values p hp k hk
-  have hne := diagCoset_one_ppow_succ_ne p hp k hk
+  have hne := diagCoset_one_primePow_succ_ne p hp k hk
   have hzero : ∀ A : HeckeCoset (posDetInt 2) (SLnZ 2) (SLnZ 2),
       A ≠ diagCoset ![1, p ^ (k + 1)] → A ≠ diagCoset ![p, p ^ k] →
       multiplicity (SLnZ 2) (SLnZ 2) (SLnZ 2)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -88,18 +88,20 @@ Every double coset in the support of the product `T(1,p) · T(1,pᵏ)` is `T(1, 
 `T(p, pᵏ)`: the determinant balances to `p^(k+1)`, and the first invariant factor divides
 `p` because the conjugated middle matrix stays integral. -/
 
-/-- The **matrix** determinant of a mapped `SL₂` element is `1`.
+/-- The **matrix** determinant of a mapped `SL₂` element is `1`, as a one-line citation of
+Mathlib's `Matrix.SpecialLinearGroup.det_mapGL`.
 
-Not a restatement of Mathlib's `det_mapGL`, which is about the **unit** determinant
-`(mapGL S g).det : Sˣ`; the goals here are about `(↑(mapGL ℚ S)).det : ℚ`, the determinant of
-the underlying matrix. Bridging the two with
-`Matrix.GeneralLinearGroup.val_det_apply` (in either direction) does not close them, and four
-of the call sites use this in term position (`exact … SL_i₀`), where no `simp`-set substitution
-applies. Its sibling `mapGL_val` *was* a redundant restatement and has been removed. -/
+`det_mapGL` is about the *unit* determinant `(mapGL S g).det : Sˣ`, while every goal here is
+about `(↑(mapGL ℚ S)).det : ℚ`. Pushing the former through `Units.val` and simplifying with
+`GeneralLinearGroup.val_det_apply` bridges the two, which is exactly this proof — so this is a
+coercion-shape restatement, not an independent derivation.
+
+It is kept rather than inlined only because one use is inside a `simp only` set, where a
+tactic block cannot go. -/
 private lemma mapGL_val_det (S : SpecialLinearGroup (Fin 2) ℤ) :
     (mapGL ℚ S).val.det = 1 := by
-  rw [mapGL_coe_matrix]
-  exact_mod_cast (SpecialLinearGroup.map (algebraMap ℤ ℚ) S).prop
+  simpa only [Matrix.GeneralLinearGroup.val_det_apply, Units.val_one] using
+    congrArg Units.val (Matrix.SpecialLinearGroup.det_mapGL (S := ℚ) S)
 
 private lemma matrix_isolate_middle (L_ℤ M R_ℤ D : Matrix (Fin 2) (Fin 2) ℤ)
     (hLadj : L_ℤ.adjugate * L_ℤ = 1) (hRadj : R_ℤ * R_ℤ.adjugate = 1)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -18,7 +18,8 @@ expansion of `T(pᵏ)` against the index shift `T(p,p) · T(pʲ, p^d) = T(p^(j+1
 
 The file also proves `heckeT_prime_mul_heckeTDiag`, Shimura's Theorem 3.24(5):
 `T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, with multiplicity `m = p + 1` at
-`k = 1` and `m = p` for `k ≥ 2`.
+`k = 1` and `m = p` otherwise. No positivity hypothesis on `k` is needed: at `k = 0` the
+identity reads `T(p) = T(1, p)`, since `T(1,1) = 1` and `T(p,1) = 0` for prime `p`.
 
 Ported from the AINTLIB `LeanModularForms` project
 ([`LeanModularForms/HeckeRIngs/GL2/MultiplicationTable.lean`](https://github.com/CBirkbeck/AINTLIB),
@@ -569,10 +570,15 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
 include hp in
 /-- **Shimura, Theorem 3.24(5)**: `T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, where
 the multiplicity `m` is `p + 1` for `k = 1` and `p` for `k ≥ 2`. -/
-theorem heckeT_prime_mul_heckeTDiag (k : ℕ) (hk : 0 < k) :
+theorem heckeT_prime_mul_heckeTDiag (k : ℕ) :
     heckeT ⟨p, hp.pos⟩ * heckeTDiag 1 (p ^ k) =
       heckeTDiag 1 (p ^ (k + 1)) +
         (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by
+  rcases Nat.eq_zero_or_pos k with rfl | hk
+  · -- `T(p) · T(1,1) = T(p) = T(1,p)`, and `T(p,1) = 0` because `p ∤ 1`
+    have hp1 : heckeTDiag p 1 = 0 :=
+      heckeTDiag_eq_zero fun h ↦ hp.ne_one (Nat.dvd_one.mp h.2.2)
+    simp [heckeT_prime p hp, hp1]
   classical
   obtain ⟨hm1, hm2⟩ := multiplicity_values p hp k hk
   have hne := diagCoset_one_prime_pow_succ_ne p hp k hk

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -164,7 +164,7 @@ private lemma first_invariant_dvd_p_of_product (p : ℕ) (S : SpecialLinearGroup
 
 /-- Determinant balance: if a `T(1,p) · T(1,pᵏ)`-shaped product lies in the double coset
 of `diag a`, then `a 0 * a 1 = p ^ (k + 1)`. -/
-private lemma mulSupport_pp_det_eq (p : ℕ) (k : ℕ) (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i)
+private lemma diag_entries_mul_eq_pow_succ (p : ℕ) (k : ℕ) (a : Fin 2 → ℕ) (ha_pos : ∀ i, 0 < a i)
     (g₁ g₂ g₃ g₄ : GL (Fin 2) ℚ) (h1 : g₁.val.det = 1) (h2 : g₂.val.det = (p : ℚ))
     (h3 : g₃.val.det = 1) (h4 : g₄.val.det = (p : ℚ) ^ k)
     (SL_La SL_Ra : SpecialLinearGroup (Fin 2) ℤ)
@@ -363,7 +363,7 @@ private lemma mulSupport_pp_subset (k : ℕ)
       mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
     rw [hSL_La, hSL_Ra]
     exact h_prod_eq
-  have h_det := mulSupport_pp_det_eq p k a ha_pos (q.1.out : GL (Fin 2) ℚ)
+  have h_det := diag_entries_mul_eq_pow_succ p k a ha_pos (q.1.out : GL (Fin 2) ℚ)
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
     ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
     (by rw [← hSL_i₀]; exact mapGL_val_det SL_i₀)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -41,13 +41,10 @@ namespace HeckeRing.GL2
 
 variable (p : ℕ) (hp : p.Prime)
 
-/-- Scaling a diagonal Hecke element: `T(c,c) · T(a,d) = T(c·a, c·d)` whenever `a ∣ d` and all
-three are positive.
-
-Primality plays no role, and neither does the shape of `a` and `d`: the argument is the
-scalar-multiplication rule for diagonal Hecke elements, which never inspects a factorization. -/
-lemma heckeTScalar_mul_heckeTDiag {c a d : ℕ} (hc : 0 < c) (ha : 0 < a) (hd : 0 < d)
-    (had : a ∣ d) :
+/-- Scaling a diagonal Hecke element in the good range: `T(c,c) · T(a,d) = T(c·a, c·d)` when
+`a ∣ d` and all three are positive. -/
+private lemma heckeTScalar_mul_heckeTDiag_of_pos {c a d : ℕ} (hc : 0 < c) (ha : 0 < a)
+    (hd : 0 < d) (had : a ∣ d) :
     heckeTScalar c * heckeTDiag a d = heckeTDiag (c * a) (c * d) := by
   rw [heckeTDiag_eq_diagElem ha hd had,
     heckeTDiag_eq_diagElem (Nat.mul_pos hc ha) (Nat.mul_pos hc hd) (mul_dvd_mul_left c had),
@@ -57,15 +54,39 @@ lemma heckeTScalar_mul_heckeTDiag {c a d : ℕ} (hc : 0 < c) (ha : 0 < a) (hd : 
     diagElem_mul_const 2 ![a, d] (fun i ↦ by fin_cases i <;> assumption) c hc]
   exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply, Nat.mul_comm])
 
-/-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`.
+/-- Scaling a diagonal Hecke element: `T(c,c) · T(a,d) = T(c·a, c·d)`, with **no hypotheses**.
 
-The prime-power case of `heckeTScalar_mul_heckeTDiag`; it needs only `0 < p`, not primality. -/
+`heckeTDiag` is zero-extended off the divisor-pair range, and that extension is compatible with
+scaling: outside the range both sides vanish, since `0 < c·a` forces `0 < a`, and for `0 < c` the
+divisibility `c·a ∣ c·d` is equivalent to `a ∣ d`. Primality plays no role, and neither does the
+shape of `a` and `d`. -/
+lemma heckeTScalar_mul_heckeTDiag (c a d : ℕ) :
+    heckeTScalar c * heckeTDiag a d = heckeTDiag (c * a) (c * d) := by
+  rcases Nat.eq_zero_or_pos c with rfl | hc
+  · simp [heckeTScalar_def, heckeTDiag_def]
+  by_cases hcond : 0 < a ∧ 0 < d ∧ a ∣ d
+  · exact heckeTScalar_mul_heckeTDiag_of_pos hc hcond.1 hcond.2.1 hcond.2.2
+  · have hzero : heckeTDiag a d = 0 := by rw [heckeTDiag_def]; exact if_neg hcond
+    have hzero' : heckeTDiag (c * a) (c * d) = 0 := by
+      rw [heckeTDiag_def]
+      refine if_neg fun h ↦ hcond ⟨?_, ?_, ?_⟩
+      · rcases Nat.eq_zero_or_pos a with rfl | ha
+        · simp at h
+        · exact ha
+      · rcases Nat.eq_zero_or_pos d with rfl | hd
+        · simp at h
+        · exact hd
+      · exact (Nat.mul_dvd_mul_iff_left hc).mp h.2.2
+    rw [hzero, hzero', mul_zero]
+
+/-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))`, for arbitrary `p`, `j`, `d`.
+
+The prime-power case of `heckeTScalar_mul_heckeTDiag`; like it, unconditional. -/
 @[simp]
-lemma heckeTScalar_mul_heckeTDiag_prime_pow (hp0 : 0 < p) (j d : ℕ) (hjd : j ≤ d) :
+lemma heckeTScalar_mul_heckeTDiag_prime_pow (j d : ℕ) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
-  rw [heckeTScalar_mul_heckeTDiag hp0 (pow_pos hp0 j) (pow_pos hp0 d)
-    (Nat.pow_dvd_pow p hjd), ← pow_succ' p j, ← pow_succ' p d]
+  rw [heckeTScalar_mul_heckeTDiag, ← pow_succ' p j, ← pow_succ' p d]
 
 include hp in
 /-- **Shimura, Theorem 3.24(2)**: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`:
@@ -82,7 +103,7 @@ theorem heckeTDiag_one_prime_pow_eq (k : ℕ) (hk : 2 ≤ k) :
       heckeTDiag (p ^ (j + 1)) (p ^ (k - (j + 1))) := fun j hj ↦ by
     rw [Finset.mem_range] at hj
     have harith : k - 2 - j + 1 = k - (j + 1) := by omega
-    rw [heckeTScalar_mul_heckeTDiag_prime_pow p hp.pos j (k - 2 - j) (by omega), harith]
+    rw [heckeTScalar_mul_heckeTDiag_prime_pow p j (k - 2 - j), harith]
   rw [Finset.sum_congr rfl shift,
     show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
     Finset.sum_range_succ']
@@ -606,5 +627,22 @@ theorem heckeT_prime_mul_heckeTDiag_one_prime_pow (k : ℕ) :
         hzero A (fun h ↦ h1 h.symm) (fun h ↦ h2 h.symm), Nat.cast_zero]
 
 end SupportSubset
+
+include hp in
+/-- The characteristic product rule in simp normal form:
+`T(1, p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`.
+
+`heckeT_prime_mul_heckeTDiag_one_prime_pow` states the same identity with `T(p)` on the left,
+but `@[simp] heckeT_prime` rewrites that `T(p)` to `T(1, p)` first, so the rule can never fire
+during simplification. This restatement is the form simp actually meets, and carries the
+attribute. -/
+@[simp]
+theorem heckeTDiag_one_prime_mul_heckeTDiag_one_prime_pow (k : ℕ) :
+    heckeTDiag 1 p * heckeTDiag 1 (p ^ k) =
+      heckeTDiag 1 (p ^ (k + 1)) +
+        (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by
+  rw [← heckeT_prime p hp]
+  exact heckeT_prime_mul_heckeTDiag_one_prime_pow p hp k
+
 
 end HeckeRing.GL2

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -258,12 +258,12 @@ section DegreeCount
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
 
-/-- The wrapper's addition evaluates pointwise. Mathlib's `Finsupp.add_apply` does not
-apply through the sealed `HeckeCosetModule` coercion, but the fact is definitional. -/
-private lemma coe_add_apply (f g : HeckeCosetModule Δ H H ℤ) (B : HeckeCoset Δ H H) :
-    (f + g) B = f B + g B := (rfl)
+/-- The wrapper's scalar multiplication evaluates pointwise, definitionally.
 
-/-- The wrapper's scalar multiplication evaluates pointwise, definitionally. -/
+NOT redundant with the public `HeckeCosetModule.smul_apply`, despite the identical statement:
+here the `ℤ`-action on `HeckeCosetModule Δ H H ℤ` arrives through a different instance path
+than the transported `Module R`, so the public lemma is defeq but does not match syntactically
+and `simp` reports it as unused. `(rfl)` bridges the two. -/
 private lemma coe_smul_apply (c : ℤ) (f : HeckeCosetModule Δ H H ℤ) (B : HeckeCoset Δ H H) :
     (c • f) B = c * f B := (rfl)
 
@@ -290,7 +290,7 @@ private lemma multiplicity_degree_sum_eq (D₁ D₂ Dout₁ Dout₂ : HeckeCoset
       HeckeCosetModule.single ℤ Dout₂
         (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₂.rep : G) : ℤ) := by
     ext A
-    rw [HeckeCosetModule.structureConstants_apply, coe_add_apply,
+    rw [HeckeCosetModule.structureConstants_apply, HeckeCosetModule.add_apply,
       HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
     by_cases h1 : Dout₁ = A
     · rw [if_pos h1, if_neg (h1 ▸ fun h ↦ hne h.symm), add_zero, ← h1]
@@ -588,7 +588,7 @@ theorem heckeT_prime_mul_heckeTDiag (k : ℕ) :
   simp only [diagElem_def]
   rw [single_one_mul_single_one]
   ext A
-  rw [HeckeCosetModule.structureConstants_apply, coe_add_apply, coe_smul_apply,
+  rw [HeckeCosetModule.structureConstants_apply, HeckeCosetModule.add_apply, coe_smul_apply,
     HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
   by_cases h1 : diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) = A
   · have h12 : diagCoset (![p, p ^ k] : Fin 2 → ℕ) ≠ A := fun h ↦ hne (h1.trans h.symm)

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -60,6 +60,7 @@ private lemma heckeTScalar_mul_heckeTDiag_of_pos {c a d : ℕ} (hc : 0 < c) (ha 
 scaling: outside the range both sides vanish, since `0 < c·a` forces `0 < a`, and for `0 < c` the
 divisibility `c·a ∣ c·d` is equivalent to `a ∣ d`. Primality plays no role, and neither does the
 shape of `a` and `d`. -/
+@[simp]
 lemma heckeTScalar_mul_heckeTDiag (c a d : ℕ) :
     heckeTScalar c * heckeTDiag a d = heckeTDiag (c * a) (c * d) := by
   rcases Nat.eq_zero_or_pos c with rfl | hc
@@ -81,8 +82,12 @@ lemma heckeTScalar_mul_heckeTDiag (c a d : ℕ) :
 
 /-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))`, for arbitrary `p`, `j`, `d`.
 
-The prime-power case of `heckeTScalar_mul_heckeTDiag`; like it, unconditional. -/
-@[simp]
+The prime-power case of `heckeTScalar_mul_heckeTDiag`; like it, unconditional.
+
+Deliberately *not* `@[simp]`: the general rule carries the attribute, and it already rewrites
+this left-hand side (to `T(p·pʲ, p·p^d)`), so annotating the specialisation too would leave its
+left-hand side outside simp normal form — `simpNF` rejects exactly that. Callers wanting the
+`p^(j+1)` form rewrite with this lemma by name. -/
 lemma heckeTScalar_mul_heckeTDiag_prime_pow (j d : ℕ) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
@@ -104,6 +109,9 @@ theorem heckeTDiag_one_prime_pow_eq (k : ℕ) (hk : 2 ≤ k) :
     rw [Finset.mem_range] at hj
     have harith : k - 2 - j + 1 = k - (j + 1) := by omega
     rw [heckeTScalar_mul_heckeTDiag_prime_pow p j (k - 2 - j), harith]
+  -- The two ranges are equal but not syntactically so — `(k - 2) / 2 + 1` and `k / 2` involve
+  -- truncated subtraction and division, which only `omega` sees through, so `rw` needs the
+  -- equality supplied explicitly before `sum_range_succ'` can peel off the first term.
   rw [Finset.sum_congr rfl shift,
     show Finset.range ((k - 2) / 2 + 1) = Finset.range (k / 2) from by congr 1; omega,
     Finset.sum_range_succ']
@@ -117,21 +125,6 @@ section SupportAnalysis
 Every double coset in the support of the product `T(1,p) · T(1,pᵏ)` is `T(1, p^(k+1))` or
 `T(p, pᵏ)`: the determinant balances to `p^(k+1)`, and the first invariant factor divides
 `p` because the conjugated middle matrix stays integral. -/
-
-/-- The **matrix** determinant of a mapped `SL₂` element is `1`, as a one-line citation of
-Mathlib's `Matrix.SpecialLinearGroup.det_mapGL`.
-
-`det_mapGL` is about the *unit* determinant `(mapGL S g).det : Sˣ`, while every goal here is
-about `(↑(mapGL ℚ S)).det : ℚ`. Pushing the former through `Units.val` and simplifying with
-`GeneralLinearGroup.val_det_apply` bridges the two, which is exactly this proof — so this is a
-coercion-shape restatement, not an independent derivation.
-
-It is kept rather than inlined only because one use is inside a `simp only` set, where a
-tactic block cannot go. -/
-private lemma mapGL_val_det (S : SpecialLinearGroup (Fin 2) ℤ) :
-    (mapGL ℚ S).val.det = 1 := by
-  simpa only [Matrix.GeneralLinearGroup.val_det_apply, Units.val_one] using
-    congrArg Units.val (Matrix.SpecialLinearGroup.det_mapGL (S := ℚ) S)
 
 private lemma matrix_isolate_middle (L_ℤ M R_ℤ D : Matrix (Fin 2) (Fin 2) ℤ)
     (hLadj : L_ℤ.adjugate * L_ℤ = 1) (hRadj : R_ℤ * R_ℤ.adjugate = 1)
@@ -169,6 +162,8 @@ private lemma first_invariant_dvd_p_of_product (p : ℕ) (S : SpecialLinearGroup
       mul_ite, mul_zero, Finset.sum_ite_eq', Finset.mem_univ, ite_true]
     apply dvd_add
     · exact dvd_mul_of_dvd_left (dvd_mul_of_dvd_right (dvd_refl _) _) _
+    -- The chain hypothesis is about ℕ-divisibility, but this goal is over ℤ; the `show` names
+    -- the cast form so `Int.natCast_dvd_natCast` has something to transport it into.
     · exact dvd_mul_of_dvd_left (dvd_mul_of_dvd_right
         (show (a 0 : ℤ) ∣ (a 1 : ℤ) from
           Int.natCast_dvd_natCast.mpr (isDvdChain_iff.mp hdiv (Fin.zero_le 1))) _) _
@@ -202,7 +197,10 @@ private lemma diag_entries_mul_eq_pow_succ (p : ℕ) (k : ℕ) (a : Fin 2 → �
     ring
   have h_rhs : (g₁ * g₂ * (g₃ * g₄)).val.det = (a 0 : ℚ) * (a 1 : ℚ) := by
     rw [h_eq, Units.val_mul, Units.val_mul, Matrix.det_mul, Matrix.det_mul]
-    simp only [mapGL_val_det, natDiagGL_det 2 a ha_pos, Fin.prod_univ_two, one_mul, mul_one]
+    -- `det_mapGL` is about the *unit* determinant, so `← val_det_apply` moves the matrix
+    -- determinant into that form before it can fire.
+    simp only [← Matrix.GeneralLinearGroup.val_det_apply, Matrix.SpecialLinearGroup.det_mapGL,
+      Units.val_one, natDiagGL_det 2 a ha_pos, Fin.prod_univ_two, one_mul, mul_one]
   exact_mod_cast h_rhs.symm.trans h_lhs
 
 private lemma mulSupport_pp_dvd_p_aux (p : ℕ) (hp : p.Prime)
@@ -284,12 +282,6 @@ section DegreeCount
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
 
-private lemma single_one_mul_single_one (D₁ D₂ : HeckeCoset Δ H H) :
-    HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1 =
-      HeckeCosetModule.structureConstants ℤ H H H D₁.rep D₂.rep := by
-  rw [HeckeCosetModule.single_mul_single]
-  exact (one_smul ℤ _).trans (one_smul ℤ _)
-
 /-- Counting degrees through the degree homomorphism: when the product of two double cosets
 is supported on exactly two cosets, the multiplicity-weighted degrees of the two outputs
 add up to the product of the input degrees. -/
@@ -325,8 +317,14 @@ private lemma multiplicity_degree_sum_eq (D₁ D₂ Dout₁ Dout₂ : HeckeCoset
       (HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1) =
       (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₁.rep : G) : ℤ) * Dout₁.degree +
       (multiplicity H H H (D₁.rep : G) (D₂.rep : G) (Dout₂.rep : G) : ℤ) * Dout₂.degree := by
-    rw [single_one_mul_single_one, hSC2, map_add, LeftCosetModule.deg_single,
-      LeftCosetModule.deg_single]
+    -- `single_mul_single` yields `1 • 1 • …` on the `Module ℤ` instance transported to
+    -- `HeckeCosetModule`, which is not the instance `one_smul` picks for `ℤ`, so neither `rw`
+    -- nor `simp` matches it. Stating the product `•`-free lets unification supply the instance.
+    have hmul : HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1 =
+        HeckeCosetModule.structureConstants ℤ H H H D₁.rep D₂.rep := by
+      rw [HeckeCosetModule.single_mul_single]
+      exact (one_smul ℤ _).trans (one_smul ℤ _)
+    rw [hmul, hSC2, map_add, LeftCosetModule.deg_single, LeftCosetModule.deg_single]
     simp [mul_comm]
   exact_mod_cast (h1.symm.trans h2).symm
 
@@ -343,11 +341,20 @@ private lemma mulSupport_pp_subset (k : ℕ)
       (((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)) ((A.rep : GL (Fin 2) ℚ)) ≠ 0) :
     A = diagCoset ![1, p ^ (k + 1)] ∨ A = diagCoset ![p, p ^ k] := by
   classical
+  -- Mathlib's `det_mapGL` is about the *unit* determinant `(mapGL ℚ S).det : ℚˣ`, while every
+  -- goal below is about the matrix determinant `(↑(mapGL ℚ S)).det : ℚ`. This is the bridge
+  -- between the two, used four times in the determinant bookkeeping of stage 4.
+  have hdet : ∀ S : SpecialLinearGroup (Fin 2) ℤ, (mapGL ℚ S).val.det = 1 := fun S ↦ by
+    simpa only [Matrix.GeneralLinearGroup.val_det_apply, Units.val_one] using
+      congrArg Units.val (Matrix.SpecialLinearGroup.det_mapGL (S := ℚ) S)
+  -- Stage 1: positivity of the two input diagonals, and a diagonal representative `a` for `A`.
   have h1p_pos : ∀ i : Fin 2, 0 < (![1, p] : Fin 2 → ℕ) i := fun i ↦ by
     fin_cases i <;> simp [hp.pos]
   have h1pk_pos : ∀ i : Fin 2, 0 < (![1, p ^ k] : Fin 2 → ℕ) i := fun i ↦ by
     fin_cases i <;> simp [pow_pos hp.pos k]
   obtain ⟨a, ha_pos, hdiv, hA_eq⟩ := exists_diagonal_representative A
+  -- Stage 2: `A` occurs in the product, so some pair `q` of coset representatives multiplies
+  -- into the double coset of `natDiagGL 2 a`; unpack that into an explicit `La · D · Ra`.
   have hmem := (HeckeCoset.mem_image_mulMap_iff (diagCoset ![1, p]).rep
     (diagCoset ![1, p ^ k]).rep A).mpr hA
   simp only [Finset.mem_image, Finset.mem_univ, true_and] at hmem
@@ -364,6 +371,8 @@ private lemma mulSupport_pp_subset (k : ℕ)
     rwa [hq, hA_eq, diagCoset_toSet] at hself
   rw [mem_doubleCoset] at h_prod_mem
   obtain ⟨La, hLa, Ra, hRa, h_prod_eq⟩ := h_prod_mem
+  -- Stage 3: every `SLnZ 2` element appearing above is `mapGL ℚ` of an honest integral `SL₂`
+  -- matrix; name those lifts, and likewise for the two input cosets' own decompositions.
   obtain ⟨SL_La, hSL_La⟩ := (mem_SLnZ_iff 2).mp hLa
   obtain ⟨SL_Ra, hSL_Ra⟩ := (mem_SLnZ_iff 2).mp hRa
   obtain ⟨SL_i₀, hSL_i₀⟩ := (mem_SLnZ_iff 2).mp q.1.out.2
@@ -380,18 +389,22 @@ private lemma mulSupport_pp_subset (k : ℕ)
       mapGL ℚ SL_La * natDiagGL 2 a * mapGL ℚ SL_Ra := by
     rw [hSL_La, hSL_Ra]
     exact h_prod_eq
+  -- Stage 4: determinants. Both sides of the product have determinant `p^(k+1)`, which pins
+  -- `a 0 * a 1`; the four `hdet` uses discharge the `SL₂` factors' determinants.
   have h_det := diag_entries_mul_eq_pow_succ p k a ha_pos (q.1.out : GL (Fin 2) ℚ)
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
     ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
-    (by rw [← hSL_i₀]; exact mapGL_val_det SL_i₀)
+    (by rw [← hSL_i₀]; exact hdet SL_i₀)
     (by rw [hD1, ← hSL_L₁, ← hSL_R₁, Units.val_mul, Units.val_mul, Matrix.det_mul,
-          Matrix.det_mul, mapGL_val_det, mapGL_val_det, natDiagGL_det 2 _ h1p_pos]
+          Matrix.det_mul, hdet, hdet, natDiagGL_det 2 _ h1p_pos]
         simp [Fin.prod_univ_two])
-    (by rw [← hSL_j₀]; exact mapGL_val_det SL_j₀)
+    (by rw [← hSL_j₀]; exact hdet SL_j₀)
     (by rw [hD2, ← hSL_L₂, ← hSL_R₂, Units.val_mul, Units.val_mul, Matrix.det_mul,
-          Matrix.det_mul, mapGL_val_det, mapGL_val_det, natDiagGL_det 2 _ h1pk_pos]
+          Matrix.det_mul, hdet, hdet, natDiagGL_det 2 _ h1pk_pos]
         simp [Fin.prod_univ_two])
     SL_La SL_Ra h_prod_eq'
+  -- Stage 5: the first invariant factor divides `p`, because conjugating the middle matrix
+  -- keeps it integral. With `a 0 * a 1 = p^(k+1)` that leaves only the two claimed cosets.
   have h_dvd := mulSupport_pp_dvd_p p hp k a ha_pos hdiv
     ((diagCoset ![1, p]).rep : GL (Fin 2) ℚ) ((diagCoset ![1, p ^ k]).rep : GL (Fin 2) ℚ)
     (q.1.out : GL (Fin 2) ℚ) (q.2.out : GL (Fin 2) ℚ)
@@ -400,22 +413,6 @@ private lemma mulSupport_pp_subset (k : ℕ)
     hSL_i₀.symm hSL_j₀.symm h_prod_eq'
   rw [hA_eq]
   exact mulSupport_pp_case_split p hp k a h_det h_dvd
-
-include hp in
-/-- The degree of `T(1, pʲ)` is `p^(j-1)(p+1)` for `j ≥ 1` — the `i = 0` case of
-`degree_diagCoset_prime_pow`. -/
-private lemma degree_diagCoset_one_prime_pow (j : ℕ) (hj : 0 < j) :
-    (diagCoset (![1, p ^ j] : Fin 2 → ℕ)).degree = p ^ (j - 1) * (p + 1) := by
-  simpa using degree_diagCoset_prime_pow p hp 0 j hj
-
-include hp in
-/-- The degree of `T(p, pᵏ)` is `p^(k-2)(p+1)` for `k ≥ 2` — the `i = 1` case of
-`degree_diagCoset_prime_pow`. -/
-private lemma degree_diagCoset_p_prime_pow (k : ℕ) (hk2 : 2 ≤ k) :
-    (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) := by
-  have h := degree_diagCoset_prime_pow p hp 1 (k - 1) (by omega)
-  rw [show 1 + (k - 1) = k by omega, pow_one] at h
-  rw [h, show k - 1 - 1 = k - 2 by omega]
 
 private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).degree = 1 := by
   have hconst : (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p := by
@@ -540,11 +537,14 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
   have h_deg := multiplicity_degree_sum_eq (diagCoset ![1, p]) (diagCoset ![1, p ^ k])
     (diagCoset ![1, p ^ (k + 1)]) (diagCoset ![p, p ^ k]) h_ne h_zero
   rw [← hm1_def, ← hm2_def] at h_deg
+  -- All three degrees are the `i = 0` case of `degree_diagCoset_prime_pow`; `simpa` absorbs
+  -- the `p ^ 0 = 1` and `0 + j = j` normalisations.
   rw [show (diagCoset (![1, p] : Fin 2 → ℕ)).degree = p ^ 0 * (p + 1) by
-      simpa using degree_diagCoset_one_prime_pow p hp 1 one_pos,
-    degree_diagCoset_one_prime_pow p hp k hk,
+      simpa using degree_diagCoset_prime_pow p hp 0 1 one_pos,
+    show (diagCoset (![1, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 1) * (p + 1) by
+      simpa using degree_diagCoset_prime_pow p hp 0 k hk,
     show (diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ)).degree = p ^ k * (p + 1) by
-      simpa using degree_diagCoset_one_prime_pow p hp (k + 1) (by omega)] at h_deg
+      simpa using degree_diagCoset_prime_pow p hp 0 (k + 1) (by omega)] at h_deg
   have hm1_pos : 0 < m1 := multiplicity_one_prime_pow_succ_pos p hp k
   have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
   by_cases hk1 : k = 1
@@ -561,7 +561,11 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
     simp only [ite_true]
     exact ⟨by exact_mod_cast h1, by exact_mod_cast h2⟩
   · have hk2 : 2 ≤ k := by omega
-    rw [degree_diagCoset_p_prime_pow p hp k hk2] at h_deg
+    -- The `i = 1` case of `degree_diagCoset_prime_pow`, re-indexed from `1 + (k - 1)` to `k`.
+    rw [show (diagCoset (![p, p ^ k] : Fin 2 → ℕ)).degree = p ^ (k - 2) * (p + 1) by
+        have h := degree_diagCoset_prime_pow p hp 1 (k - 1) (by omega)
+        rw [show 1 + (k - 1) = k by omega, pow_one] at h
+        rw [h, show k - 1 - 1 = k - 2 by omega]] at h_deg
     have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ k * ((p : ℤ) + 1)) +
         (m2 : ℤ) * ((p : ℤ) ^ (k - 2) * ((p : ℤ) + 1)) =
         ((p : ℤ) + 1) * ((p : ℤ) ^ (k - 1) * ((p : ℤ) + 1)) := by
@@ -602,8 +606,16 @@ theorem heckeT_prime_mul_heckeTDiag_one_prime_pow (k : ℕ) :
     heckeTDiag_eq_diagElem one_pos (pow_pos hp.pos k) (one_dvd _),
     heckeTDiag_eq_diagElem one_pos (pow_pos hp.pos (k + 1)) (one_dvd _),
     heckeTDiag_eq_diagElem hp.pos (pow_pos hp.pos k) (dvd_pow_self p (by omega))]
-  simp only [diagElem_def]
-  rw [single_one_mul_single_one]
+  -- As in `multiplicity_degree_sum_eq`, the `1 • 1 •` that `single_mul_single` produces sits on
+  -- the transported `Module ℤ` instance, which `one_smul` does not match by `rw`/`simp`; a
+  -- `•`-free restatement lets unification supply it.
+  have hmul : HeckeCosetModule.single ℤ (diagCoset (![1, p] : Fin 2 → ℕ)) 1 *
+      HeckeCosetModule.single ℤ (diagCoset (![1, p ^ k] : Fin 2 → ℕ)) 1 =
+      HeckeCosetModule.structureConstants ℤ (SLnZ 2) (SLnZ 2) (SLnZ 2)
+        (diagCoset (![1, p] : Fin 2 → ℕ)).rep (diagCoset (![1, p ^ k] : Fin 2 → ℕ)).rep := by
+    rw [HeckeCosetModule.single_mul_single]
+    exact (one_smul ℤ _).trans (one_smul ℤ _)
+  rw [diagElem_def, diagElem_def, diagElem_def, diagElem_def, hmul]
   ext A
   rw [HeckeCosetModule.structureConstants_apply, HeckeCosetModule.add_apply]
   -- The `ℤ`-action here reaches `HeckeCosetModule` by a different instance path than the

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -14,7 +14,7 @@ The first multiplication identity of Shimura's Theorem 3.24 for the `GL₂` Heck
 `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`, by telescoping the divisor-pair
 expansion of `T(pᵏ)` against the index shift `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))`.
 
-The file also proves `heckeT_prime_mul_heckeTDiag`, Shimura's Theorem 3.24(5):
+The file also proves `heckeT_prime_mul_heckeTDiag_one_prime_pow`, Shimura's Theorem 3.24(5):
 `T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, with multiplicity `m = p + 1` at
 `k = 1` and `m = p` otherwise. No positivity hypothesis on `k` is needed: at `k = 0` the
 identity reads `T(p) = T(1, p)`, since `T(1,1) = 1` and `T(p,1) = 0` for prime `p`.
@@ -556,7 +556,7 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
 include hp in
 /-- **Shimura, Theorem 3.24(5)**: `T(p) · T(1, pᵏ) = T(1, p^(k+1)) + m · T(p, pᵏ)`, where
 the multiplicity `m` is `p + 1` for `k = 1` and `p` for `k ≥ 2`. -/
-theorem heckeT_prime_mul_heckeTDiag (k : ℕ) :
+theorem heckeT_prime_mul_heckeTDiag_one_prime_pow (k : ℕ) :
     heckeT ⟨p, hp.pos⟩ * heckeTDiag 1 (p ^ k) =
       heckeTDiag 1 (p ^ (k + 1)) +
         (if k = 1 then ((p : ℤ) + 1) else (p : ℤ)) • heckeTDiag p (p ^ k) := by

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -414,13 +414,6 @@ private lemma mulSupport_pp_subset (k : ℕ)
   rw [hA_eq]
   exact mulSupport_pp_case_split p hp k a h_det h_dvd
 
-private lemma degree_diagCoset_p_p : (diagCoset (![p, p ^ 1] : Fin 2 → ℕ)).degree = 1 := by
-  have hconst : (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p := by
-    funext i
-    fin_cases i <;> simp
-  rw [hconst]
-  exact degree_diagCoset_const 2 p
-
 include hp in
 /-- The two support cosets are distinct: their invariant factors differ at the top. -/
 private lemma diagCoset_one_prime_pow_succ_ne (k : ℕ) (hk : 0 < k) :
@@ -549,7 +542,9 @@ private lemma multiplicity_values (k : ℕ) (hk : 0 < k) :
   have hp2 : (2 : ℤ) ≤ (p : ℤ) := by exact_mod_cast hp.two_le
   by_cases hk1 : k = 1
   · subst hk1
-    rw [degree_diagCoset_p_p p] at h_deg
+    -- `![p, p ^ 1]` is the constant vector, so the generic `degree_diagCoset_const` applies.
+    rw [show (![p, p ^ 1] : Fin 2 → ℕ) = fun _ ↦ p from by funext i; fin_cases i <;> simp,
+      degree_diagCoset_const 2 p] at h_deg
     have h_degZ : (m1 : ℤ) * ((p : ℤ) ^ 1 * ((p : ℤ) + 1)) + (m2 : ℤ) * 1 =
         ((p : ℤ) + 1) * ((p : ℤ) + 1) := by
       have := h_deg

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -5,9 +5,6 @@ Authors: Chris Birkbeck
 -/
 module
 
-public import TauCeti.NumberTheory.HeckeRing.Degree
-public import TauCeti.NumberTheory.HeckeRing.GL2.Basic
-public import TauCeti.NumberTheory.HeckeRing.GL2.DiagonalCosetDegree
 public import TauCeti.NumberTheory.HeckeRing.GL2.Degree
 
 /-!
@@ -44,23 +41,31 @@ namespace HeckeRing.GL2
 
 variable (p : ℕ) (hp : p.Prime)
 
+/-- Scaling a diagonal Hecke element: `T(c,c) · T(a,d) = T(c·a, c·d)` whenever `a ∣ d` and all
+three are positive.
+
+Primality plays no role, and neither does the shape of `a` and `d`: the argument is the
+scalar-multiplication rule for diagonal Hecke elements, which never inspects a factorization. -/
+lemma heckeTScalar_mul_heckeTDiag {c a d : ℕ} (hc : 0 < c) (ha : 0 < a) (hd : 0 < d)
+    (had : a ∣ d) :
+    heckeTScalar c * heckeTDiag a d = heckeTDiag (c * a) (c * d) := by
+  rw [heckeTDiag_eq_diagElem ha hd had,
+    heckeTDiag_eq_diagElem (Nat.mul_pos hc ha) (Nat.mul_pos hc hd) (mul_dvd_mul_left c had),
+    HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
+      (transposeAntiInvolution_onHeckeCoset_eq_self 2),
+    heckeTScalar_of_pos hc,
+    diagElem_mul_const 2 ![a, d] (fun i ↦ by fin_cases i <;> assumption) c hc]
+  exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply, Nat.mul_comm])
+
 /-- The index shift: `T(p,p) · T(pʲ, p^d) = T(p^(j+1), p^(d+1))` for `j ≤ d`.
 
-Needs only `0 < p`, not primality: the argument is the scalar-multiplication rule for diagonal
-Hecke elements, which never inspects the factorization of `p`. -/
+The prime-power case of `heckeTScalar_mul_heckeTDiag`; it needs only `0 < p`, not primality. -/
 @[simp]
 lemma heckeTScalar_mul_heckeTDiag_prime_pow (hp0 : 0 < p) (j d : ℕ) (hjd : j ≤ d) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
-  rw [heckeTDiag_eq_diagElem (pow_pos hp0 j) (pow_pos hp0 d) (Nat.pow_dvd_pow p hjd),
-    heckeTDiag_eq_diagElem (pow_pos hp0 (j + 1)) (pow_pos hp0 (d + 1))
-      (Nat.pow_dvd_pow p (by omega)),
-    HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
-      (transposeAntiInvolution_onHeckeCoset_eq_self 2),
-    heckeTScalar_of_pos hp0,
-    diagElem_mul_const 2 ![p ^ j, p ^ d]
-      (fun i ↦ by fin_cases i <;> exact pow_pos hp0 _) p hp0]
-  exact congrArg diagElem (funext fun i ↦ by fin_cases i <;> simp [Pi.mul_apply, pow_succ])
+  rw [heckeTScalar_mul_heckeTDiag hp0 (pow_pos hp0 j) (pow_pos hp0 d)
+    (Nat.pow_dvd_pow p hjd), ← pow_succ' p j, ← pow_succ' p d]
 
 include hp in
 /-- **Shimura, Theorem 3.24(2)**: `T(1, pᵏ) = T(pᵏ) − T(p,p) · T(p^(k−2))` for `k ≥ 2`:
@@ -257,15 +262,6 @@ end SupportAnalysis
 section DegreeCount
 
 variable {G : Type*} [Group G] {Δ : Submonoid G} {H : Subgroup G} [IsHeckeTriple Δ H H]
-
-/-- The wrapper's scalar multiplication evaluates pointwise, definitionally.
-
-NOT redundant with the public `HeckeCosetModule.smul_apply`, despite the identical statement:
-here the `ℤ`-action on `HeckeCosetModule Δ H H ℤ` arrives through a different instance path
-than the transported `Module R`, so the public lemma is defeq but does not match syntactically
-and `simp` reports it as unused. `(rfl)` bridges the two. -/
-private lemma coe_smul_apply (c : ℤ) (f : HeckeCosetModule Δ H H ℤ) (B : HeckeCoset Δ H H) :
-    (c • f) B = c * f B := (rfl)
 
 private lemma single_one_mul_single_one (D₁ D₂ : HeckeCoset Δ H H) :
     HeckeCosetModule.single ℤ D₁ 1 * HeckeCosetModule.single ℤ D₂ 1 =
@@ -588,8 +584,17 @@ theorem heckeT_prime_mul_heckeTDiag (k : ℕ) :
   simp only [diagElem_def]
   rw [single_one_mul_single_one]
   ext A
-  rw [HeckeCosetModule.structureConstants_apply, HeckeCosetModule.add_apply, coe_smul_apply,
-    HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
+  rw [HeckeCosetModule.structureConstants_apply, HeckeCosetModule.add_apply]
+  -- The `ℤ`-action here reaches `HeckeCosetModule` by a different instance path than the
+  -- transported `Module R` that `HeckeCosetModule.smul_apply` is stated for, so `rw` and
+  -- `simp only` both fail to match it. Naming the instance in a `have` applies the public
+  -- lemma anyway, which is why no private restatement is needed.
+  have hsmul : ((if k = 1 then (p : ℤ) + 1 else (p : ℤ)) •
+      HeckeCosetModule.single ℤ (diagCoset (![p, p ^ k] : Fin 2 → ℕ)) 1) A
+      = (if k = 1 then (p : ℤ) + 1 else (p : ℤ)) *
+        HeckeCosetModule.single ℤ (diagCoset (![p, p ^ k] : Fin 2 → ℕ)) 1 A :=
+    HeckeCosetModule.smul_apply _ _ _
+  rw [hsmul, HeckeCosetModule.single_apply, HeckeCosetModule.single_apply]
   by_cases h1 : diagCoset (![1, p ^ (k + 1)] : Fin 2 → ℕ) = A
   · have h12 : diagCoset (![p, p ^ k] : Fin 2 → ℕ) ≠ A := fun h ↦ hne (h1.trans h.symm)
     rw [if_pos h1, if_neg h12, mul_zero, add_zero, ← h1, hm1, Nat.cast_one]

--- a/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
+++ b/TauCeti/NumberTheory/HeckeRing/GL2/MultiplicationTable.lean
@@ -52,8 +52,8 @@ Hecke elements, which never inspects the factorization of `p`. -/
 lemma heckeTScalar_mul_heckeTDiag_prime_pow (hp0 : 0 < p) (j d : ℕ) (hjd : j ≤ d) :
     heckeTScalar p * heckeTDiag (p ^ j) (p ^ d) =
       heckeTDiag (p ^ (j + 1)) (p ^ (d + 1)) := by
-  rw [heckeTDiag_of_pos (pow_pos hp0 j) (pow_pos hp0 d) (Nat.pow_dvd_pow p hjd),
-    heckeTDiag_of_pos (pow_pos hp0 (j + 1)) (pow_pos hp0 (d + 1))
+  rw [heckeTDiag_eq_diagElem (pow_pos hp0 j) (pow_pos hp0 d) (Nat.pow_dvd_pow p hjd),
+    heckeTDiag_eq_diagElem (pow_pos hp0 (j + 1)) (pow_pos hp0 (d + 1))
       (Nat.pow_dvd_pow p (by omega)),
     HeckeCosetModule.mul_comm_of_antiInvolution ℤ (transposeAntiInvolution 2)
       (transposeAntiInvolution_onHeckeCoset_eq_self 2),
@@ -581,10 +581,10 @@ theorem heckeT_prime_mul_heckeTDiag (k : ℕ) :
     by_contra h0
     exact ((mulSupport_pp_subset p hp k A h0).elim h1 h2)
   rw [heckeT_prime p hp,
-    heckeTDiag_of_pos one_pos hp.pos (one_dvd _),
-    heckeTDiag_of_pos one_pos (pow_pos hp.pos k) (one_dvd _),
-    heckeTDiag_of_pos one_pos (pow_pos hp.pos (k + 1)) (one_dvd _),
-    heckeTDiag_of_pos hp.pos (pow_pos hp.pos k) (dvd_pow_self p (by omega))]
+    heckeTDiag_eq_diagElem one_pos hp.pos (one_dvd _),
+    heckeTDiag_eq_diagElem one_pos (pow_pos hp.pos k) (one_dvd _),
+    heckeTDiag_eq_diagElem one_pos (pow_pos hp.pos (k + 1)) (one_dvd _),
+    heckeTDiag_eq_diagElem hp.pos (pow_pos hp.pos k) (dvd_pow_self p (by omega))]
   simp only [diagElem_def]
   rw [single_one_mul_single_one]
   ext A


### PR DESCRIPTION
**Stacked on #2276 → #2274 → #2204.** Draft until those land; the content specific to this
PR is `GL2/Degree.lean` and `GL2/MultiplicationTable.lean`.

* `GL2/Degree.lean` — `deg T(n) = σ₁(n)`: the degree of the classical Hecke operator is
  the sum of divisors of `n`.
* `GL2/MultiplicationTable.lean` — the multiplication table of the `GL(2)` Hecke ring:
  `heckeT_prime_mul_heckeTDiag` (`T(p) · T(1, p^k) = T(1, p^{k+1}) + m · T(p, p^k)` with
  `m = p + 1` at `k = 1` and `p` beyond, Shimura Thm 3.24(5)), the scalar-times-diagonal
  row, and the prime-power products feeding the `T(p^k)` recurrence.

Note on commutativity: the Hecke ring carries no `CommRing` instance, so `mul_comm` does
not apply directly. This uses `HeckeCosetModule.mul_comm_of_antiInvolution` with the
transpose anti-involution — the same idiom `GLn/ScalarMul.lean` uses in main.

Ported from Chris Birkbeck's AINTLIB `LeanModularForms`.

## Roadmap

`TauCetiRoadmap/ModularForms/README.md`, **Layer 2: Hecke operators and the Hecke algebra**:

* **Layer 2(a)** — "The Hecke ring, stated at `GL_n`" — covers the degree map, which that item
  names via `GLn/Degree.lean` alongside the diagonal-coset parametrization. `GL2/Degree.lean`
  here is the `n = 2` specialization, `deg T(m) = σ₁(m)`.
* **Layer 2(b)** — "The action on forms" — names this PR's other file outright: it asks for
  "`Tₘ Tₙ = Tₘₙ` for `(m,n)=1` and the prime-power recurrence (`MultiplicationTable.lean`)".
  That is exactly the multiplication table proved here (Shimura 3.24).

Roadmap: ModularForms

