### PR TITLE
feat: preserve the filled exponential quotient under algebra maps

### DIFF
--- a/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
@@ -153,17 +153,3 @@ theorem map_oneSubExpNegDivSelf {F : Type*} [FunLike F A B] [RingHomClass F A B]
   simp
 
 end Map
-
-section ContinuousAlgHom
-
-variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
-  [ContinuousSMul ℚ 𝕂] [NormedRing A] [NormedAlgebra 𝕂 A] [CompleteSpace A]
-  [NormedRing B] [NormedAlgebra 𝕂 B]
-
-/-- Continuous algebra homomorphisms preserve `oneSubExpNegDivSelf` over their scalar field. -/
-@[simp]
-theorem ContinuousAlgHom.map_oneSubExpNegDivSelf (f : A →A[𝕂] B) (a : A) :
-    f (oneSubExpNegDivSelf 𝕂 a) = oneSubExpNegDivSelf 𝕂 (f a) :=
-  _root_.map_oneSubExpNegDivSelf f f.continuous a
-
-end ContinuousAlgHom

--- a/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
@@ -21,6 +21,7 @@ map.
 * `commute_oneSubExpNegDivSelf`: the series commutes with its argument.
 * `mul_oneSubExpNegDivSelf`: multiplying the series by `a` gives `1 - exp (-a)`.
 * `oneSubExpNegDivSelf_mul`: the corresponding right-multiplication identity.
+* `map_oneSubExpNegDivSelf`: continuous ring homomorphisms preserve the series.
 
 ## References
 
@@ -135,19 +136,20 @@ end Normed
 
 section Map
 
-variable {A B : Type*} [NormedRing A] [NormedAlgebra ℚ A] [CompleteSpace A]
-  [Ring B] [Algebra ℚ B] [TopologicalSpace B] [IsTopologicalRing B] [T2Space B]
+variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+  [ContinuousSMul ℚ 𝕂] [NormedRing A] [NormedAlgebra 𝕂 A] [CompleteSpace A]
+  [Ring B] [Algebra 𝕂 B] [TopologicalSpace B] [IsTopologicalRing B] [T2Space B]
 
 /-- Any continuous ring homomorphism commutes with `oneSubExpNegDivSelf`. -/
 theorem map_oneSubExpNegDivSelf {F : Type*} [FunLike F A B] [RingHomClass F A B]
     (f : F) (hf : Continuous f) (a : A) :
-    f (oneSubExpNegDivSelf ℚ a) = oneSubExpNegDivSelf ℚ (f a) := by
+    f (oneSubExpNegDivSelf 𝕂 a) = oneSubExpNegDivSelf 𝕂 (f a) := by
   rw [oneSubExpNegDivSelf_eq_tsum, oneSubExpNegDivSelf_eq_tsum]
-  refine ((summable_oneSubExpNegDivSelf (𝕂 := ℚ) a).hasSum.map f hf).tsum_eq.symm.trans ?_
+  refine ((summable_oneSubExpNegDivSelf (𝕂 := 𝕂) a).hasSum.map f hf).tsum_eq.symm.trans ?_
   dsimp only [Function.comp_def]
   apply tsum_congr
   intro n
-  rw [map_inv_natCast_smul f ℚ ℚ]
+  rw [map_inv_natCast_smul f 𝕂 𝕂]
   simp
 
 end Map
@@ -159,14 +161,9 @@ variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
   [NormedRing B] [NormedAlgebra 𝕂 B]
 
 /-- Continuous algebra homomorphisms preserve `oneSubExpNegDivSelf` over their scalar field. -/
+@[simp]
 theorem ContinuousAlgHom.map_oneSubExpNegDivSelf (f : A →A[𝕂] B) (a : A) :
-    f (oneSubExpNegDivSelf 𝕂 a) = oneSubExpNegDivSelf 𝕂 (f a) := by
-  rw [oneSubExpNegDivSelf_eq_tsum, oneSubExpNegDivSelf_eq_tsum]
-  have hsum := (summable_oneSubExpNegDivSelf (𝕂 := 𝕂) a).hasSum.map f f.continuous
-  refine hsum.tsum_eq.symm.trans ?_
-  dsimp only [Function.comp_apply]
-  apply tsum_congr
-  intro n
-  rw [map_smul, map_pow, map_neg]
+    f (oneSubExpNegDivSelf 𝕂 a) = oneSubExpNegDivSelf 𝕂 (f a) :=
+  _root_.map_oneSubExpNegDivSelf f f.continuous a
 
 end ContinuousAlgHom

--- a/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
+++ b/TauCeti/Analysis/Normed/Algebra/OneSubExpNegDivSelf/Basic.lean
@@ -151,3 +151,22 @@ theorem map_oneSubExpNegDivSelf {F : Type*} [FunLike F A B] [RingHomClass F A B]
   simp
 
 end Map
+
+section ContinuousAlgHom
+
+variable {𝕂 A B : Type*} [NontriviallyNormedField 𝕂] [CharZero 𝕂]
+  [ContinuousSMul ℚ 𝕂] [NormedRing A] [NormedAlgebra 𝕂 A] [CompleteSpace A]
+  [NormedRing B] [NormedAlgebra 𝕂 B]
+
+/-- Continuous algebra homomorphisms preserve `oneSubExpNegDivSelf` over their scalar field. -/
+theorem ContinuousAlgHom.map_oneSubExpNegDivSelf (f : A →A[𝕂] B) (a : A) :
+    f (oneSubExpNegDivSelf 𝕂 a) = oneSubExpNegDivSelf 𝕂 (f a) := by
+  rw [oneSubExpNegDivSelf_eq_tsum, oneSubExpNegDivSelf_eq_tsum]
+  have hsum := (summable_oneSubExpNegDivSelf (𝕂 := 𝕂) a).hasSum.map f f.continuous
+  refine hsum.tsum_eq.symm.trans ?_
+  dsimp only [Function.comp_apply]
+  apply tsum_congr
+  intro n
+  rw [map_smul, map_pow, map_neg]
+
+end ContinuousAlgHom


### PR DESCRIPTION
## Goal

Make the filled exponential quotient natural under continuous algebra homomorphisms over its scalar field, so the Layer 1 differential-of-exponential construction can be transported through continuous algebra equivalences.

## Why this works

The quotient is defined by an everywhere-summable power series. Continuity lets the algebra homomorphism map the series sum, while preservation of scalar multiplication, powers, and negation identifies every mapped term with the corresponding term at the mapped argument. This proves the naturality statement without invertibility assumptions and reuses the existing summability theorem.

This supplies an analytic prerequisite for `TauCetiRoadmap/RepresentationTheory/LieGroups/README.md`, Deliverable A, Layer 1, “The conjugation formulas”: https://github.com/TauCetiProject/TauCetiRoadmap/blob/main/TauCetiRoadmap/RepresentationTheory/LieGroups/README.md#layer-1-the-adjoint-representations-ad-and-ad.

Intention: https://github.com/TauCetiProject/TauCetiRoadmap/issues/162

## Validation

- `lake build TauCeti.Analysis.Normed.Algebra.OneSubExpNegDivSelf.Basic`
- `lake build`
- `bash scripts/lint-env.sh`
- `git diff --check`

Roadmap: RepresentationTheory