### PR TITLE
feat: add scheme sheaf cohomology

### DIFF
--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -74,6 +74,7 @@ lemma cohomologyMap_id_apply (M : X.Modules) (i : ℕ) (x : cohomology M i) :
   exact CategoryTheory.Sheaf.H.map_id_apply x
 
 /-- The map induced by a composite is the composite of the induced cohomology maps. -/
+@[simp]
 lemma cohomologyMap_comp_apply {M N P : X.Modules} (f : M ⟶ N) (g : N ⟶ P)
     (i : ℕ) (x : cohomology M i) :
     cohomologyMap (f ≫ g) i x = cohomologyMap g i (cohomologyMap f i x) := by

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -18,7 +18,7 @@ abelian sheaf of an `𝒪_X`-module and packages the result in the scheme-module
 
 For a scheme `X` and `M : X.Modules`, the main declarations are:
 
-* `Scheme.Modules.cohomology M i`, the group `Hⁱ(X, M)`;
+* `Scheme.Modules.Cohomology M i`, the group `Hⁱ(X, M)`;
 * `Scheme.Modules.functorH X i`, functoriality in the coefficient sheaf;
 * `Scheme.Modules.cohomologyEquivOfIso e i`, invariance under an isomorphism of coefficient
   sheaves;
@@ -55,7 +55,7 @@ variable {X : Scheme.{u}}
 
 This is sheaf cohomology on the small Zariski site of `X`, obtained by forgetting the
 `𝒪_X`-module structure and applying Mathlib's `CategoryTheory.Sheaf.H`. -/
-abbrev cohomology (M : X.Modules) (i : ℕ) : Type u :=
+abbrev Cohomology (M : X.Modules) (i : ℕ) : Type u :=
   CategoryTheory.Sheaf.H.{u}
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) i
 
@@ -73,14 +73,14 @@ instance (X : Scheme.{u}) (i : ℕ) : (functorH X i).Additive :=
 
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
 def cohomologyEquivOfIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
-    cohomology M i ≃+ cohomology N i :=
+    Cohomology M i ≃+ Cohomology N i :=
   ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv
 
 /-- The forward map of `cohomologyEquivOfIso` is the cohomology map induced by the forward
 morphism. -/
 @[simp]
 lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
-    (x : cohomology M i) :
+    (x : Cohomology M i) :
     cohomologyEquivOfIso e i x = ((functorH X i).map e.hom).hom x := by
   rw [← Functor.mapIso_hom]
   exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
@@ -89,7 +89,7 @@ lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
 morphism. -/
 @[simp]
 lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
-    (x : cohomology N i) :
+    (x : Cohomology N i) :
     (cohomologyEquivOfIso e i).symm x = ((functorH X i).map e.inv).hom x := by
   rw [← Functor.mapIso_inv]
   exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
@@ -102,14 +102,14 @@ equivalence, and of its inverse, with `((functorH X 0).map f).hom` and `f.app �
 `CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and
 `(SheafOfModules.toSheaf X.ringCatSheaf).map f`. -/
 def cohomologyZeroEquiv (M : X.Modules) :
-    cohomology M 0 ≃+ Γ(M, ⊤) :=
+    Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
 
 /-- The degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
 @[simp]
 lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
-    (x : cohomology M 0) :
+    (x : Cohomology M 0) :
     f.app ⊤ (cohomologyZeroEquiv M x) =
       cohomologyZeroEquiv N (((functorH X 0).map f).hom x) := by
   exact CategoryTheory.Sheaf.H.equiv₀_naturality

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -19,11 +19,9 @@ abelian sheaf of an `𝒪_X`-module and packages the result in the scheme-module
 For a scheme `X` and `M : X.Modules`, the main declarations are:
 
 * `Scheme.Modules.Cohomology M i`, the group `Hⁱ(X, M)`;
-* `Scheme.Modules.functorH X i`, functoriality in the coefficient sheaf;
-* `Scheme.Modules.cohomologyEquivOfIso e i`, invariance under an isomorphism of coefficient
-  sheaves;
+* `Scheme.Modules.cohomologyFunctor X i`, functoriality in the coefficient sheaf;
 * `Scheme.Modules.cohomologyZeroEquiv`, the canonical equivalence
-  `H⁰(X, M) ≃+ Γ(X, M)` with global sections.
+  `H⁰(X, M) ≃+ Γ(M, ⊤)` with global sections.
 
 The construction is stated for every sheaf of modules, which is the natural generality of sheaf
 cohomology. In particular it applies to finitely presented sheaves through their underlying
@@ -60,67 +58,43 @@ abbrev Cohomology (M : X.Modules) (i : ℕ) : Type u :=
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) i
 
 /-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
-abbrev functorH (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
+abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i
 
 /-- Degreewise cohomology is additive. This is Mathlib's instance for a composite of additive
 functors; it has to be restated because inference does not see through the `X.Modules` type
 synonym. -/
-instance (X : Scheme.{u}) (i : ℕ) : (functorH X i).Additive :=
+instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
-/-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
-def cohomologyEquivOfIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
-    Cohomology M i ≃+ Cohomology N i :=
-  ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv
-
-/-- The forward map of `cohomologyEquivOfIso` is the cohomology map induced by the forward
-morphism. -/
-@[simp]
-lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
-    (x : Cohomology M i) :
-    cohomologyEquivOfIso e i x = ((functorH X i).map e.hom).hom x := by
-  rw [← Functor.mapIso_hom]
-  exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
-
-/-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
-morphism. -/
-@[simp]
-lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
-    (x : Cohomology N i) :
-    (cohomologyEquivOfIso e i).symm x = ((functorH X i).map e.inv).hom x := by
-  rw [← Functor.mapIso_inv]
-  exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
-
 /-- Zeroth cohomology is canonically equivalent to the group of global sections.
 
-The equivalence is natural in the coefficient sheaf: for `f : M ⟶ N`, the commutation of this
-equivalence, and of its inverse, with `((functorH X 0).map f).hom` and `f.app ⊤` is Mathlib's
-`CategoryTheory.Sheaf.H.equiv₀_naturality`, respectively
-`CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and
-`(SheafOfModules.toSheaf X.ringCatSheaf).map f`. -/
+The equivalence is natural in the coefficient sheaf; see `cohomologyZeroEquiv_naturality` and
+`cohomologyZeroEquiv_symm_naturality`. -/
 def cohomologyZeroEquiv (M : X.Modules) :
     Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
 
 /-- The degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
-@[simp]
 lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
     (x : Cohomology M 0) :
     f.app ⊤ (cohomologyZeroEquiv M x) =
-      cohomologyZeroEquiv N (((functorH X 0).map f).hom x) := by
+      cohomologyZeroEquiv N (((cohomologyFunctor X 0).map f).hom x) := by
+  -- The scheme-level section map and cohomology-functor map are definitionally the maps of the
+  -- underlying abelian sheaves.
   exact CategoryTheory.Sheaf.H.equiv₀_naturality
     isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
 
 /-- The inverse degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
-@[simp]
 lemma cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
     (x : Γ(M, ⊤)) :
-    ((functorH X 0).map f).hom ((cohomologyZeroEquiv M).symm x) =
+    ((cohomologyFunctor X 0).map f).hom ((cohomologyZeroEquiv M).symm x) =
       (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
+  -- The scheme-level section map and cohomology-functor map are definitionally the maps of the
+  -- underlying abelian sheaves.
   exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
     isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -139,7 +139,13 @@ lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
   rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_inv]
   exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
-/-- Zeroth cohomology is canonically equivalent to the group of global sections. -/
+/-- Zeroth cohomology is canonically equivalent to the group of global sections.
+
+The equivalence is natural in the coefficient sheaf: for `f : M ⟶ N`, the commutation of this
+equivalence, and of its inverse, with `cohomologyMap f 0` and `f.app ⊤` is Mathlib's
+`CategoryTheory.Sheaf.H.equiv₀_naturality`, respectively
+`CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and
+`(SheafOfModules.toSheaf X.ringCatSheaf).map f`. -/
 def cohomologyZeroEquiv (M : X.Modules) :
     cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -19,8 +19,6 @@ abelian sheaf of an `𝒪_X`-module and packages the result in the scheme-module
 For a scheme `X` and `M : X.Modules`, the main declarations are:
 
 * `Scheme.Modules.cohomology M i`, the group `Hⁱ(X, M)`;
-* `Scheme.Modules.cohomologyMap f i`, the map on cohomology induced by a morphism of
-  `𝒪_X`-modules;
 * `Scheme.Modules.functorH X i`, functoriality in the coefficient sheaf;
 * `Scheme.Modules.cohomologyEquivOfIso e i`, invariance under an isomorphism of coefficient
   sheaves;
@@ -33,8 +31,8 @@ objects, and hence supplies the `Hⁱ(X, ℱ)` used for coherent sheaves in
 `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B. Finite-dimensionality for proper schemes,
 vanishing on curves, and the comparison with Čech cohomology remain later Layer B work.
 
-No formalization is vendored. The definitions reuse Mathlib's `Sheaf.H`, `Sheaf.H.map`,
-`Sheaf.functorH`, and `Sheaf.H.equiv₀`.
+No formalization is vendored. The definitions reuse Mathlib's `Sheaf.H`, `Sheaf.functorH`,
+and `Sheaf.H.equiv₀`.
 -/
 
 public section
@@ -61,12 +59,6 @@ abbrev cohomology (M : X.Modules) (i : ℕ) : Type u :=
   CategoryTheory.Sheaf.H.{u}
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) i
 
-/-- A morphism of sheaves of modules induces an additive map on cohomology. -/
-def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
-    cohomology M i →+ cohomology N i :=
-  CategoryTheory.Sheaf.H.map
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i
-
 /-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
 abbrev functorH (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
@@ -79,43 +71,6 @@ instance (X : Scheme.{u}) (i : ℕ) : (functorH X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
-/-- Internally identify the standalone cohomology map with the map of the cohomology functor. -/
-private lemma functorH_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
-    ((functorH X i).map f).hom = cohomologyMap f i :=
-  rfl
-
-/-- The identity morphism induces the identity map on cohomology. -/
-@[simp]
-lemma cohomologyMap_id (M : X.Modules) (i : ℕ) :
-    cohomologyMap (𝟙 M) i = AddMonoidHom.id (cohomology M i) := by
-  rw [← functorH_map_hom, (functorH X i).map_id]
-  rfl
-
-/-- The map induced by a composite is the composite of the induced cohomology maps. -/
-@[simp]
-lemma cohomologyMap_comp {M N P : X.Modules} (f : M ⟶ N) (g : N ⟶ P) (i : ℕ) :
-    cohomologyMap (f ≫ g) i = (cohomologyMap g i).comp (cohomologyMap f i) := by
-  ext x
-  exact CategoryTheory.Sheaf.H.map_comp_apply
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
-
-/-- Cohomology maps preserve addition of morphisms in the coefficient sheaf. -/
-@[simp]
-lemma cohomologyMap_add {M N : X.Modules} (f g : M ⟶ N) (i : ℕ) :
-    cohomologyMap (f + g) i = cohomologyMap f i + cohomologyMap g i := by
-  ext x
-  exact CategoryTheory.Sheaf.H.map_add_apply
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
-
-/-- The zero morphism induces the zero map on cohomology. -/
-@[simp]
-lemma cohomologyMap_zero (M N : X.Modules) (i : ℕ) :
-    cohomologyMap (0 : M ⟶ N) i = 0 := by
-  rw [← functorH_map_hom, (functorH X i).map_zero]
-  rfl
-
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
 def cohomologyEquivOfIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
     cohomology M i ≃+ cohomology N i :=
@@ -126,8 +81,8 @@ morphism. -/
 @[simp]
 lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology M i) :
-    cohomologyEquivOfIso e i x = cohomologyMap e.hom i x := by
-  rw [← functorH_map_hom, ← Functor.mapIso_hom]
+    cohomologyEquivOfIso e i x = ((functorH X i).map e.hom).hom x := by
+  rw [← Functor.mapIso_hom]
   exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
 
 /-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
@@ -135,14 +90,14 @@ morphism. -/
 @[simp]
 lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology N i) :
-    (cohomologyEquivOfIso e i).symm x = cohomologyMap e.inv i x := by
-  rw [← functorH_map_hom, ← Functor.mapIso_inv]
+    (cohomologyEquivOfIso e i).symm x = ((functorH X i).map e.inv).hom x := by
+  rw [← Functor.mapIso_inv]
   exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections.
 
 The equivalence is natural in the coefficient sheaf: for `f : M ⟶ N`, the commutation of this
-equivalence, and of its inverse, with `cohomologyMap f 0` and `f.app ⊤` is Mathlib's
+equivalence, and of its inverse, with `((functorH X 0).map f).hom` and `f.app ⊤` is Mathlib's
 `CategoryTheory.Sheaf.H.equiv₀_naturality`, respectively
 `CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and
 `(SheafOfModules.toSheaf X.ringCatSheaf).map f`. -/
@@ -156,7 +111,7 @@ def cohomologyZeroEquiv (M : X.Modules) :
 lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
     (x : cohomology M 0) :
     f.app ⊤ (cohomologyZeroEquiv M x) =
-      cohomologyZeroEquiv N (cohomologyMap f 0 x) := by
+      cohomologyZeroEquiv N (((functorH X 0).map f).hom x) := by
   exact CategoryTheory.Sheaf.H.equiv₀_naturality
     isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
 
@@ -164,7 +119,7 @@ lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
 @[simp]
 lemma cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
     (x : Γ(M, ⊤)) :
-    cohomologyMap f 0 ((cohomologyZeroEquiv M).symm x) =
+    ((functorH X 0).map f).hom ((cohomologyZeroEquiv M).symm x) =
       (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
   exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
     isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -4,7 +4,6 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import Mathlib.Algebra.Category.Grp.AB
 public import Mathlib.AlgebraicGeometry.Modules.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
 public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
@@ -68,18 +67,10 @@ def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
   CategoryTheory.Sheaf.H.map
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i
 
-/-- Applying the cohomology map is applying Mathlib's map on the underlying abelian sheaves. -/
-lemma cohomologyMap_apply {M N : X.Modules} (f : M ⟶ N) (i : ℕ)
-    (x : cohomology M i) :
-    cohomologyMap f i x = CategoryTheory.Sheaf.H.map
-      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i x :=
-  (rfl)
-
 /-- The identity morphism induces the identity on cohomology. -/
 @[simp]
 lemma cohomologyMap_id_apply (M : X.Modules) (i : ℕ) (x : cohomology M i) :
     cohomologyMap (𝟙 M) i x = x := by
-  rw [cohomologyMap_apply]
   exact CategoryTheory.Sheaf.H.map_id_apply x
 
 /-- The map induced by a composite is the composite of the induced cohomology maps. -/
@@ -111,17 +102,13 @@ instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
-/-- The morphism of the cohomology functor is `cohomologyMap`. -/
-@[simp]
-lemma cohomologyFunctor_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
-    ((cohomologyFunctor X i).map f).hom = cohomologyMap f i :=
-  (rfl)
-
 /-- The zero morphism induces the zero map on cohomology. -/
 @[simp]
 lemma cohomologyMap_zero_apply (M N : X.Modules) (i : ℕ) (x : cohomology M i) :
     cohomologyMap (0 : M ⟶ N) i x = 0 := by
-  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_zero]
+  rw [show cohomologyMap (0 : M ⟶ N) i =
+    ((cohomologyFunctor X i).map (0 : M ⟶ N)).hom from rfl,
+    (cohomologyFunctor X i).map_zero]
   rfl
 
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
@@ -135,7 +122,8 @@ morphism. -/
 lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology M i) :
     cohomologyEquivOfIso e i x = cohomologyMap e.hom i x := by
-  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_hom]
+  rw [show cohomologyMap e.hom i = ((cohomologyFunctor X i).map e.hom).hom from rfl,
+    ← Functor.mapIso_hom]
   exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
 
 /-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
@@ -144,7 +132,8 @@ morphism. -/
 lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology N i) :
     (cohomologyEquivOfIso e i).symm x = cohomologyMap e.inv i x := by
-  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_inv]
+  rw [show cohomologyMap e.inv i = ((cohomologyFunctor X i).map e.inv).hom from rfl,
+    ← Functor.mapIso_inv]
   exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections. -/

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -6,9 +6,9 @@ module
 
 public import Mathlib.Algebra.Category.Grp.AB
 public import Mathlib.AlgebraicGeometry.Modules.Sheaf
-public import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
 public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
+public import Mathlib.Topology.Sheaves.Abelian
 
 /-!
 # Cohomology of sheaves of modules on a scheme
@@ -53,15 +53,6 @@ noncomputable section
 namespace Scheme.Modules
 
 variable {X : Scheme.{u}}
-
-/-- Abelian sheaves on the small Zariski site form a Grothendieck abelian category. This
-instance selects the `u`-small `Ext` groups used by `cohomology`. -/
-instance (X : Scheme.{u}) :
-    IsGrothendieckAbelian.{u}
-      (Sheaf (Opens.grothendieckTopology X) AddCommGrpCat.{u}) := by
-  have : EssentiallySmall.{u} X.Opens := inferInstance
-  exact Sheaf.isGrothendieckAbelian_of_essentiallySmall
-    (Opens.grothendieckTopology X) AddCommGrpCat.{u}
 
 /-- The `i`th cohomology group `Hⁱ(X, M)` of a sheaf of modules on a scheme.
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -62,9 +62,7 @@ abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCa
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i
 
-/-- Degreewise cohomology is additive. This is Mathlib's instance for a composite of additive
-functors; it has to be restated because inference does not see through the `X.Modules` type
-synonym. -/
+/-- Degreewise scheme-module cohomology preserves addition and zero morphisms. -/
 instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -4,8 +4,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 -/
 module
 
-public import TauCeti.AlgebraicGeometry.FinitelyPresentedSheaf.Basic
 public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.AlgebraicGeometry.Modules.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
 public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
 public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
@@ -23,13 +23,14 @@ For a scheme `X` and `M : X.Modules`, the main declarations are:
 * `Scheme.Modules.cohomologyMap f i`, the map on cohomology induced by a morphism of
   `𝒪_X`-modules;
 * `Scheme.Modules.cohomologyFunctor X i`, functoriality in the coefficient sheaf;
-* `Scheme.Modules.cohomologyIso e i`, invariance under an isomorphism of coefficient sheaves;
+* `Scheme.Modules.cohomologyEquivOfIso e i`, invariance under an isomorphism of coefficient
+  sheaves;
 * `Scheme.Modules.cohomologyZeroEquiv`, the canonical equivalence
   `H⁰(X, M) ≃+ Γ(X, M)` with global sections.
 
 The construction is stated for every sheaf of modules, which is the natural generality of sheaf
-cohomology. In particular it applies to `FinitelyPresentedSheaf X` through its underlying object,
-and hence supplies the `Hⁱ(X, ℱ)` used for coherent sheaves in
+cohomology. In particular it applies to finitely presented sheaves through their underlying
+objects, and hence supplies the `Hⁱ(X, ℱ)` used for coherent sheaves in
 `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B. Finite-dimensionality for proper schemes,
 vanishing on curves, and the comparison with Čech cohomology remain later Layer B work.
 
@@ -107,25 +108,17 @@ lemma cohomologyMap_add_apply {M N : X.Modules} (f g : M ⟶ N) (i : ℕ)
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
 
-/-- The zero morphism induces the zero map on cohomology. -/
-@[simp]
-lemma cohomologyMap_zero_apply (M N : X.Modules) (i : ℕ) (x : cohomology M i) :
-    cohomologyMap (0 : M ⟶ N) i x = 0 := by
-  have h := cohomologyMap_add_apply (0 : M ⟶ N) (0 : M ⟶ N) i x
-  simp only [zero_add] at h
-  apply add_left_cancel (a := cohomologyMap (0 : M ⟶ N) i x)
-  simpa only [add_zero] using h.symm
-
 /-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
 abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i
 
-instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive where
-  map_add := by
-    intro M N f g
-    ext x
-    exact cohomologyMap_add_apply f g i x
+/-- Degreewise cohomology is additive. This is Mathlib's instance for a composite of additive
+functors; it has to be restated because inference does not see through the `X.Modules` type
+synonym. -/
+instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
+  inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
+    CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
 /-- The morphism of the cohomology functor is `cohomologyMap`. -/
 @[simp]
@@ -133,24 +126,35 @@ lemma cohomologyFunctor_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
     ((cohomologyFunctor X i).map f).hom = cohomologyMap f i :=
   (rfl)
 
+/-- The zero morphism induces the zero map on cohomology. -/
+@[simp]
+lemma cohomologyMap_zero_apply (M N : X.Modules) (i : ℕ) (x : cohomology M i) :
+    cohomologyMap (0 : M ⟶ N) i x = 0 := by
+  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_zero]
+  rfl
+
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
-def cohomologyIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
+def cohomologyEquivOfIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
     cohomology M i ≃+ cohomology N i :=
   ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv
 
-/-- The forward map of `cohomologyIso` is the cohomology map induced by the forward morphism. -/
+/-- The forward map of `cohomologyEquivOfIso` is the cohomology map induced by the forward
+morphism. -/
 @[simp]
-lemma cohomologyIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
+lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology M i) :
-    cohomologyIso e i x = cohomologyMap e.hom i x :=
-  (rfl)
+    cohomologyEquivOfIso e i x = cohomologyMap e.hom i x := by
+  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_hom]
+  exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
 
-/-- The inverse of `cohomologyIso` is the cohomology map induced by the inverse morphism. -/
+/-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
+morphism. -/
 @[simp]
-lemma cohomologyIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
+lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology N i) :
-    (cohomologyIso e i).symm x = cohomologyMap e.inv i x :=
-  (rfl)
+    (cohomologyEquivOfIso e i).symm x = cohomologyMap e.inv i x := by
+  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_inv]
+  exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections. -/
 def cohomologyZeroEquiv (M : X.Modules) :

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -71,32 +71,13 @@ instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections.
 
-The equivalence is natural in the coefficient sheaf; see `cohomologyZeroEquiv_naturality` and
-`cohomologyZeroEquiv_symm_naturality`. -/
+Naturality in the coefficient sheaf follows from `CategoryTheory.Sheaf.H.equiv₀_naturality`
+and `CategoryTheory.Sheaf.H.equiv₀_symm_naturality`, applied to `isTerminalTop` and the
+underlying sheaf morphism. -/
 def cohomologyZeroEquiv (M : X.Modules) :
     Cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
-
-/-- The degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
-lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
-    (x : Cohomology M 0) :
-    f.app ⊤ (cohomologyZeroEquiv M x) =
-      cohomologyZeroEquiv N (((cohomologyFunctor X 0).map f).hom x) := by
-  -- The scheme-level section map and cohomology-functor map are definitionally the maps of the
-  -- underlying abelian sheaves.
-  exact CategoryTheory.Sheaf.H.equiv₀_naturality
-    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
-
-/-- The inverse degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
-lemma cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
-    (x : Γ(M, ⊤)) :
-    ((cohomologyFunctor X 0).map f).hom ((cohomologyZeroEquiv M).symm x) =
-      (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
-  -- The scheme-level section map and cohomology-functor map are definitionally the maps of the
-  -- underlying abelian sheaves.
-  exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
-    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
 
 end Scheme.Modules
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import TauCeti.AlgebraicGeometry.FinitelyPresentedSheaf.Basic
+public import Mathlib.Algebra.Category.Grp.AB
+public import Mathlib.CategoryTheory.Abelian.GrothendieckAxioms.Sheaf
+public import Mathlib.CategoryTheory.Abelian.GrothendieckCategory.HasExt
+public import Mathlib.CategoryTheory.Sites.SheafCohomology.Basic
+
+/-!
+# Cohomology of sheaves of modules on a scheme
+
+Mathlib defines the cohomology `CategoryTheory.Sheaf.H` of an abelian sheaf on a site as an
+`Ext` group from the constant sheaf `ℤ`. This file applies that construction to the underlying
+abelian sheaf of an `𝒪_X`-module and packages the result in the scheme-module API.
+
+For a scheme `X` and `M : X.Modules`, the main declarations are:
+
+* `Scheme.Modules.cohomology M i`, the group `Hⁱ(X, M)`;
+* `Scheme.Modules.cohomologyMap f i`, the map on cohomology induced by a morphism of
+  `𝒪_X`-modules;
+* `Scheme.Modules.cohomologyFunctor X i`, functoriality in the coefficient sheaf;
+* `Scheme.Modules.cohomologyIso e i`, invariance under an isomorphism of coefficient sheaves;
+* `Scheme.Modules.cohomologyZeroEquiv`, the canonical equivalence
+  `H⁰(X, M) ≃+ Γ(X, M)` with global sections.
+
+The construction is stated for every sheaf of modules, which is the natural generality of sheaf
+cohomology. In particular it applies to `FinitelyPresentedSheaf X` through its underlying object,
+and hence supplies the `Hⁱ(X, ℱ)` used for coherent sheaves in
+`TauCetiRoadmap/JacobianChallenge/README.md`, Layer B. Finite-dimensionality for proper schemes,
+vanishing on curves, and the comparison with Čech cohomology remain later Layer B work.
+
+No formalization is vendored. The definitions reuse Mathlib's `Sheaf.H`, `Sheaf.H.map`,
+`Sheaf.functorH`, and `Sheaf.H.equiv₀`.
+-/
+
+public section
+
+open CategoryTheory Limits AlgebraicGeometry
+
+namespace TauCeti
+
+namespace AlgebraicGeometry
+
+universe u
+
+noncomputable section
+
+namespace Scheme.Modules
+
+variable {X : Scheme.{u}}
+
+/-- Abelian sheaves on the small Zariski site form a Grothendieck abelian category. This
+instance selects the `u`-small `Ext` groups used by `cohomology`. -/
+instance (X : Scheme.{u}) :
+    IsGrothendieckAbelian.{u}
+      (Sheaf (Opens.grothendieckTopology X) AddCommGrpCat.{u}) := by
+  have : EssentiallySmall.{u} X.Opens := inferInstance
+  exact Sheaf.isGrothendieckAbelian_of_essentiallySmall
+    (Opens.grothendieckTopology X) AddCommGrpCat.{u}
+
+/-- The `i`th cohomology group `Hⁱ(X, M)` of a sheaf of modules on a scheme.
+
+This is sheaf cohomology on the small Zariski site of `X`, obtained by forgetting the
+`𝒪_X`-module structure and applying Mathlib's `CategoryTheory.Sheaf.H`. -/
+abbrev cohomology (M : X.Modules) (i : ℕ) : Type u :=
+  CategoryTheory.Sheaf.H.{u}
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) i
+
+/-- A morphism of sheaves of modules induces an additive map on cohomology. -/
+def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
+    cohomology M i →+ cohomology N i :=
+  CategoryTheory.Sheaf.H.map
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i
+
+/-- Applying the cohomology map is applying Mathlib's map on the underlying abelian sheaves. -/
+lemma cohomologyMap_apply {M N : X.Modules} (f : M ⟶ N) (i : ℕ)
+    (x : cohomology M i) :
+    cohomologyMap f i x = CategoryTheory.Sheaf.H.map
+      ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i x :=
+  (rfl)
+
+/-- The identity morphism induces the identity on cohomology. -/
+@[simp]
+lemma cohomologyMap_id_apply (M : X.Modules) (i : ℕ) (x : cohomology M i) :
+    cohomologyMap (𝟙 M) i x = x := by
+  rw [cohomologyMap_apply]
+  exact CategoryTheory.Sheaf.H.map_id_apply x
+
+/-- The map induced by a composite is the composite of the induced cohomology maps. -/
+lemma cohomologyMap_comp_apply {M N P : X.Modules} (f : M ⟶ N) (g : N ⟶ P)
+    (i : ℕ) (x : cohomology M i) :
+    cohomologyMap (f ≫ g) i x = cohomologyMap g i (cohomologyMap f i x) := by
+  exact CategoryTheory.Sheaf.H.map_comp_apply
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
+
+/-- Cohomology maps preserve addition of morphisms in the coefficient sheaf. -/
+@[simp]
+lemma cohomologyMap_add_apply {M N : X.Modules} (f g : M ⟶ N) (i : ℕ)
+    (x : cohomology M i) :
+    cohomologyMap (f + g) i x = cohomologyMap f i x + cohomologyMap g i x := by
+  exact CategoryTheory.Sheaf.H.map_add_apply
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
+
+/-- The zero morphism induces the zero map on cohomology. -/
+@[simp]
+lemma cohomologyMap_zero_apply (M N : X.Modules) (i : ℕ) (x : cohomology M i) :
+    cohomologyMap (0 : M ⟶ N) i x = 0 := by
+  have h := cohomologyMap_add_apply (0 : M ⟶ N) (0 : M ⟶ N) i x
+  simp only [zero_add] at h
+  apply add_left_cancel (a := cohomologyMap (0 : M ⟶ N) i x)
+  simpa only [add_zero] using h.symm
+
+/-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
+abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
+  _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
+    CategoryTheory.Sheaf.functorH.{u} _ i
+
+instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive where
+  map_add := by
+    intro M N f g
+    ext x
+    exact cohomologyMap_add_apply f g i x
+
+/-- The morphism of the cohomology functor is `cohomologyMap`. -/
+@[simp]
+lemma cohomologyFunctor_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
+    ((cohomologyFunctor X i).map f).hom = cohomologyMap f i :=
+  (rfl)
+
+/-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
+def cohomologyIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
+    cohomology M i ≃+ cohomology N i :=
+  ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv
+
+/-- The forward map of `cohomologyIso` is the cohomology map induced by the forward morphism. -/
+@[simp]
+lemma cohomologyIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
+    (x : cohomology M i) :
+    cohomologyIso e i x = cohomologyMap e.hom i x :=
+  (rfl)
+
+/-- The inverse of `cohomologyIso` is the cohomology map induced by the inverse morphism. -/
+@[simp]
+lemma cohomologyIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
+    (x : cohomology N i) :
+    (cohomologyIso e i).symm x = cohomologyMap e.inv i x :=
+  (rfl)
+
+/-- Zeroth cohomology is canonically equivalent to the group of global sections. -/
+def cohomologyZeroEquiv (M : X.Modules) :
+    cohomology M 0 ≃+ Γ(M, ⊤) :=
+  CategoryTheory.Sheaf.H.equiv₀
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
+
+/-- The degree-zero equivalence is natural in the coefficient sheaf. -/
+theorem cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
+    (x : cohomology M 0) :
+    f.app ⊤ (cohomologyZeroEquiv M x) =
+      cohomologyZeroEquiv N (cohomologyMap f 0 x) := by
+  exact CategoryTheory.Sheaf.H.equiv₀_naturality
+    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
+
+/-- Naturality of the inverse degree-zero equivalence. -/
+theorem cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
+    (x : Γ(M, ⊤)) :
+    cohomologyMap f 0 ((cohomologyZeroEquiv M).symm x) =
+      (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
+  exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
+    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
+
+end Scheme.Modules
+
+end
+
+end AlgebraicGeometry
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -151,6 +151,24 @@ def cohomologyZeroEquiv (M : X.Modules) :
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
 
+/-- The degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
+@[simp]
+lemma cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
+    (x : cohomology M 0) :
+    f.app ⊤ (cohomologyZeroEquiv M x) =
+      cohomologyZeroEquiv N (cohomologyMap f 0 x) := by
+  exact CategoryTheory.Sheaf.H.equiv₀_naturality
+    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
+
+/-- The inverse degree-zero cohomology equivalence commutes with maps of coefficient sheaves. -/
+@[simp]
+lemma cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
+    (x : Γ(M, ⊤)) :
+    cohomologyMap f 0 ((cohomologyZeroEquiv M).symm x) =
+      (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
+  exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
+    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
+
 end Scheme.Modules
 
 end

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -67,30 +67,6 @@ def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
   CategoryTheory.Sheaf.H.map
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i
 
-/-- The identity morphism induces the identity on cohomology. -/
-@[simp]
-lemma cohomologyMap_id_apply (M : X.Modules) (i : ℕ) (x : cohomology M i) :
-    cohomologyMap (𝟙 M) i x = x := by
-  exact CategoryTheory.Sheaf.H.map_id_apply x
-
-/-- The map induced by a composite is the composite of the induced cohomology maps. -/
-@[simp]
-lemma cohomologyMap_comp_apply {M N P : X.Modules} (f : M ⟶ N) (g : N ⟶ P)
-    (i : ℕ) (x : cohomology M i) :
-    cohomologyMap (f ≫ g) i x = cohomologyMap g i (cohomologyMap f i x) := by
-  exact CategoryTheory.Sheaf.H.map_comp_apply
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
-
-/-- Cohomology maps preserve addition of morphisms in the coefficient sheaf. -/
-@[simp]
-lemma cohomologyMap_add_apply {M N : X.Modules} (f g : M ⟶ N) (i : ℕ)
-    (x : cohomology M i) :
-    cohomologyMap (f + g) i x = cohomologyMap f i x + cohomologyMap g i x := by
-  exact CategoryTheory.Sheaf.H.map_add_apply
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
-    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
-
 /-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
 abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
@@ -103,13 +79,41 @@ instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
+/-- Internally identify the standalone cohomology map with the map of the cohomology functor. -/
+private lemma cohomologyFunctor_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
+    ((cohomologyFunctor X i).map f).hom = cohomologyMap f i :=
+  rfl
+
+/-- The identity morphism induces the identity map on cohomology. -/
+@[simp]
+lemma cohomologyMap_id (M : X.Modules) (i : ℕ) :
+    cohomologyMap (𝟙 M) i = AddMonoidHom.id (cohomology M i) := by
+  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_id]
+  rfl
+
+/-- The map induced by a composite is the composite of the induced cohomology maps. -/
+@[simp]
+lemma cohomologyMap_comp {M N P : X.Modules} (f : M ⟶ N) (g : N ⟶ P) (i : ℕ) :
+    cohomologyMap (f ≫ g) i = (cohomologyMap g i).comp (cohomologyMap f i) := by
+  ext x
+  exact CategoryTheory.Sheaf.H.map_comp_apply
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
+
+/-- Cohomology maps preserve addition of morphisms in the coefficient sheaf. -/
+@[simp]
+lemma cohomologyMap_add {M N : X.Modules} (f g : M ⟶ N) (i : ℕ) :
+    cohomologyMap (f + g) i = cohomologyMap f i + cohomologyMap g i := by
+  ext x
+  exact CategoryTheory.Sheaf.H.map_add_apply
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f)
+    ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map g) x
+
 /-- The zero morphism induces the zero map on cohomology. -/
 @[simp]
-lemma cohomologyMap_zero_apply (M N : X.Modules) (i : ℕ) (x : cohomology M i) :
-    cohomologyMap (0 : M ⟶ N) i x = 0 := by
-  rw [show cohomologyMap (0 : M ⟶ N) i =
-    ((cohomologyFunctor X i).map (0 : M ⟶ N)).hom from rfl,
-    (cohomologyFunctor X i).map_zero]
+lemma cohomologyMap_zero (M N : X.Modules) (i : ℕ) :
+    cohomologyMap (0 : M ⟶ N) i = 0 := by
+  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_zero]
   rfl
 
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
@@ -123,8 +127,7 @@ morphism. -/
 lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology M i) :
     cohomologyEquivOfIso e i x = cohomologyMap e.hom i x := by
-  rw [show cohomologyMap e.hom i = ((cohomologyFunctor X i).map e.hom).hom from rfl,
-    ← Functor.mapIso_hom]
+  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_hom]
   exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
 
 /-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
@@ -133,8 +136,7 @@ morphism. -/
 lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology N i) :
     (cohomologyEquivOfIso e i).symm x = cohomologyMap e.inv i x := by
-  rw [show cohomologyMap e.inv i = ((cohomologyFunctor X i).map e.inv).hom from rfl,
-    ← Functor.mapIso_inv]
+  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_inv]
   exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections. -/
@@ -142,22 +144,6 @@ def cohomologyZeroEquiv (M : X.Modules) :
     cohomology M 0 ≃+ Γ(M, ⊤) :=
   CategoryTheory.Sheaf.H.equiv₀
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).obj M) isTerminalTop
-
-/-- The degree-zero equivalence is natural in the coefficient sheaf. -/
-theorem cohomologyZeroEquiv_naturality {M N : X.Modules} (f : M ⟶ N)
-    (x : cohomology M 0) :
-    f.app ⊤ (cohomologyZeroEquiv M x) =
-      cohomologyZeroEquiv N (cohomologyMap f 0 x) := by
-  exact CategoryTheory.Sheaf.H.equiv₀_naturality
-    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
-
-/-- Naturality of the inverse degree-zero equivalence. -/
-theorem cohomologyZeroEquiv_symm_naturality {M N : X.Modules} (f : M ⟶ N)
-    (x : Γ(M, ⊤)) :
-    cohomologyMap f 0 ((cohomologyZeroEquiv M).symm x) =
-      (cohomologyZeroEquiv N).symm (f.app ⊤ x) := by
-  exact CategoryTheory.Sheaf.H.equiv₀_symm_naturality
-    isTerminalTop ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) x
 
 end Scheme.Modules
 

--- a/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
+++ b/TauCeti/AlgebraicGeometry/Cohomology/Basic.lean
@@ -21,7 +21,7 @@ For a scheme `X` and `M : X.Modules`, the main declarations are:
 * `Scheme.Modules.cohomology M i`, the group `Hⁱ(X, M)`;
 * `Scheme.Modules.cohomologyMap f i`, the map on cohomology induced by a morphism of
   `𝒪_X`-modules;
-* `Scheme.Modules.cohomologyFunctor X i`, functoriality in the coefficient sheaf;
+* `Scheme.Modules.functorH X i`, functoriality in the coefficient sheaf;
 * `Scheme.Modules.cohomologyEquivOfIso e i`, invariance under an isomorphism of coefficient
   sheaves;
 * `Scheme.Modules.cohomologyZeroEquiv`, the canonical equivalence
@@ -68,27 +68,27 @@ def cohomologyMap {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
     ((_root_.SheafOfModules.toSheaf X.ringCatSheaf).map f) i
 
 /-- Degree-`i` cohomology as an additive functor from sheaves of modules to abelian groups. -/
-abbrev cohomologyFunctor (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
+abbrev functorH (X : Scheme.{u}) (i : ℕ) : X.Modules ⥤ AddCommGrpCat.{u} :=
   _root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i
 
 /-- Degreewise cohomology is additive. This is Mathlib's instance for a composite of additive
 functors; it has to be restated because inference does not see through the `X.Modules` type
 synonym. -/
-instance (X : Scheme.{u}) (i : ℕ) : (cohomologyFunctor X i).Additive :=
+instance (X : Scheme.{u}) (i : ℕ) : (functorH X i).Additive :=
   inferInstanceAs ((_root_.SheafOfModules.toSheaf X.ringCatSheaf ⋙
     CategoryTheory.Sheaf.functorH.{u} _ i).Additive)
 
 /-- Internally identify the standalone cohomology map with the map of the cohomology functor. -/
-private lemma cohomologyFunctor_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
-    ((cohomologyFunctor X i).map f).hom = cohomologyMap f i :=
+private lemma functorH_map_hom {M N : X.Modules} (f : M ⟶ N) (i : ℕ) :
+    ((functorH X i).map f).hom = cohomologyMap f i :=
   rfl
 
 /-- The identity morphism induces the identity map on cohomology. -/
 @[simp]
 lemma cohomologyMap_id (M : X.Modules) (i : ℕ) :
     cohomologyMap (𝟙 M) i = AddMonoidHom.id (cohomology M i) := by
-  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_id]
+  rw [← functorH_map_hom, (functorH X i).map_id]
   rfl
 
 /-- The map induced by a composite is the composite of the induced cohomology maps. -/
@@ -113,13 +113,13 @@ lemma cohomologyMap_add {M N : X.Modules} (f g : M ⟶ N) (i : ℕ) :
 @[simp]
 lemma cohomologyMap_zero (M N : X.Modules) (i : ℕ) :
     cohomologyMap (0 : M ⟶ N) i = 0 := by
-  rw [← cohomologyFunctor_map_hom, (cohomologyFunctor X i).map_zero]
+  rw [← functorH_map_hom, (functorH X i).map_zero]
   rfl
 
 /-- Isomorphic sheaves of modules have canonically additively equivalent cohomology groups. -/
 def cohomologyEquivOfIso {M N : X.Modules} (e : M ≅ N) (i : ℕ) :
     cohomology M i ≃+ cohomology N i :=
-  ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv
+  ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv
 
 /-- The forward map of `cohomologyEquivOfIso` is the cohomology map induced by the forward
 morphism. -/
@@ -127,8 +127,8 @@ morphism. -/
 lemma cohomologyEquivOfIso_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology M i) :
     cohomologyEquivOfIso e i x = cohomologyMap e.hom i x := by
-  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_hom]
-  exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
+  rw [← functorH_map_hom, ← Functor.mapIso_hom]
+  exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_apply x
 
 /-- The inverse of `cohomologyEquivOfIso` is the cohomology map induced by the inverse
 morphism. -/
@@ -136,8 +136,8 @@ morphism. -/
 lemma cohomologyEquivOfIso_symm_apply {M N : X.Modules} (e : M ≅ N) (i : ℕ)
     (x : cohomology N i) :
     (cohomologyEquivOfIso e i).symm x = cohomologyMap e.inv i x := by
-  rw [← cohomologyFunctor_map_hom, ← Functor.mapIso_inv]
-  exact ((cohomologyFunctor X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
+  rw [← functorH_map_hom, ← Functor.mapIso_inv]
+  exact ((functorH X i).mapIso e).addCommGroupIsoToAddEquiv_symm_apply x
 
 /-- Zeroth cohomology is canonically equivalent to the group of global sections.
 


### PR DESCRIPTION
This PR introduces the scheme-level `Hⁱ(X, M)` interface for sheaves of modules: it defines cohomology on the small Zariski site, packages degreewise cohomology as an additive functor, and identifies `H⁰(X, M)` with `Γ(M, ⊤)` using Mathlib's canonical equivalence. Its existing forward and inverse naturality lemmas apply through the underlying sheaf morphism.

The exact roadmap target is `TauCetiRoadmap/JacobianChallenge/README.md`, Layer B, milestone “Coherent sheaves and cohomology `Hⁱ(X, ℱ)`.” The merged coherent-sheaf PR #2029 supplies the finitely presented coefficient objects; this PR supplies the cohomology groups those objects need, at the natural generality of arbitrary `𝒪_X`-modules. After this PR, the milestone still needs affine acyclicity, the Čech/derived comparison, finite-dimensionality for proper schemes over a field, and vanishing above the dimension before genus, Riemann–Roch, and Serre duality can be built.

No Mathlib infrastructure is vendored. The construction reuses Mathlib's `SheafOfModules.toSheaf`, `Sheaf.H`, `Sheaf.functorH`, and `Sheaf.H.equiv₀`. The only local instance restates additivity for the composite scheme-module cohomology functor, because inference does not see it through the `X.Modules` type synonym; the Grothendieck-category and `HasExt` infrastructure comes from Mathlib.

The new module is `TauCeti/AlgebraicGeometry/Cohomology/Basic.lean` (88 lines). No existing file or module path changes.

Roadmap: JacobianChallenge

<!--tauceti-target:v1 {"focus":"JacobianChallenge","id":"scheme-sheaf-cohomology"}-->

🤖 Prepared with Codex
