### PR TITLE
feat: recognize closed image crosscuts as Jordan curves

### DIFF
--- a/TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean
+++ b/TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean
@@ -1,0 +1,98 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Analysis.Complex.Conformal.Crosscut.Path
+public import TauCeti.Topology.JordanCurve.Basic
+import TauCeti.Topology.JordanCurve.Path
+
+/-!
+# The coincident-end case of an image crosscut
+
+A genuine circular crosscut of a disc is carried by a conformal map to a simple open arc in the
+image domain. When its image has finite length,
+`TauCeti.exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn` packages the closure of
+that arc as the range of a path. The path's interior is injective, its interior values lie in the
+image domain, and its two endpoints lie on the image boundary, so the only repetition it may have
+is a common value of those endpoints.
+
+This file settles that exceptional case. If the closed image crosscut meets the boundary of the
+image domain in a subsingleton, both path endpoints must be that same boundary point. The path is
+therefore closed, and `TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` identifies its range —
+the closure of the image crosscut — as a Jordan curve.
+
+The subsingleton hypothesis is deliberately literal. The endpoint theorem in
+`Conformal/Crosscut/BoundaryEnds.lean` shows that the boundary intersection is a pair `{u, v}`, but
+does not prove the two points distinct; asserting distinctness here would assume the planar
+separation argument that remains to be formalized. Instead this theorem gives the exact conclusion
+in the coincident-end branch, with no weakened or surrogate separation claim.
+
+## Main result
+
+* `TauCeti.isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton` — if a finite-length
+  image crosscut has at most one boundary end, its closure is a Jordan curve.
+
+## Roadmap role
+
+This advances layer **L5** of `TauCetiRoadmap/ConformalMapping/README.md`, the Jordan-domain case of
+the Carathéodory boundary correspondence. The existing length-area machinery produces arbitrarily
+short image crosscuts and the existing path theorem supplies their simple parametrisations. The
+remaining step after this file is the planar separation argument: treat the Jordan curve produced
+here when the ends coincide, and join the crosscut to one of the two boundary arcs when they are
+distinct, in order to bound the whole boundary of the cut-off image piece.
+
+## References
+
+* C. Carathéodory, *Über die gegenseitige Beziehung der Ränder bei der konformen Abbildung*,
+  Math. Ann. **73** (1913).
+* Ch. Pommerenke, *Boundary Behaviour of Conformal Maps*, §2.2–2.3.
+* P. L. Duren, *Univalent Functions*, Ch. 3.
+-/
+
+public section
+
+namespace TauCeti
+
+open Complex Metric Set
+
+variable {f : ℂ → ℂ} {c ζ : ℂ} {r ρ : ℝ}
+
+/-- **A finite-length image crosscut with a single boundary end closes to a Jordan curve.**
+Let `f` be holomorphic and injective on `ball c r`, and let `ball c r ∩ sphere ζ ρ` be a genuine
+circular crosscut whose image has finite length. If the intersection
+
+`frontier (f '' ball c r) ∩ closure (f '' (ball c r ∩ sphere ζ ρ))`
+
+is a subsingleton, then the closure of the image crosscut is a Jordan curve.
+
+The hypothesis says only that the two endpoint limits supplied by the finite-length theorem agree.
+It makes no assertion about the rest of the image boundary or about which planar region the closed
+curve encloses. -/
+theorem isJordanCurve_closure_image_ball_inter_sphere_of_subsingleton
+    (hζ : dist ζ c = r) (hρ : 0 < ρ) (hρr : ρ < 2 * r)
+    (hf : DifferentiableOn ℂ f (ball c r)) (hinj : InjOn f (ball c r))
+    (hfin : circleImageLength f (ball c r) ζ ρ ≠ ⊤)
+    (hends : (frontier (f '' ball c r) ∩
+      closure (f '' (ball c r ∩ sphere ζ ρ))).Subsingleton) :
+    IsJordanCurve (closure (f '' (ball c r ∩ sphere ζ ρ))) := by
+  obtain ⟨u, v, γ, hγrange, -, -, hu, hv, hγsimple, -⟩ :=
+    exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn hζ hρ hρr hf hinj hfin
+  have hu' : u ∈ frontier (f '' ball c r) ∩
+      closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+    refine ⟨hu, ?_⟩
+    rw [← hγrange]
+    exact ⟨0, γ.source⟩
+  have hv' : v ∈ frontier (f '' ball c r) ∩
+      closure (f '' (ball c r ∩ sphere ζ ρ)) := by
+    refine ⟨hv, ?_⟩
+    rw [← hγrange]
+    exact ⟨1, γ.target⟩
+  have huv : u = v := hends hu' hv'
+  subst v
+  rw [← hγrange]
+  exact isJordanCurve_range_of_eq_or_eq_endpoints γ hγsimple
+
+end TauCeti

--- a/TauCeti/Topology/JordanCurve.lean
+++ b/TauCeti/Topology/JordanCurve.lean
@@ -6,6 +6,7 @@ Authors: The Tau Ceti contributors
 module
 
 public import TauCeti.Topology.JordanCurve.Basic
+public import TauCeti.Topology.JordanCurve.Path
 public import TauCeti.Topology.JordanCurve.Separation
 public import TauCeti.Topology.JordanCurve.SmallArc
 
@@ -13,9 +14,11 @@ public import TauCeti.Topology.JordanCurve.SmallArc
 # Jordan curves
 
 This module re-exports the Jordan-curve API: the predicate `TauCeti.IsJordanCurve` together with
-its transfer lemmas (`TauCeti.Topology.JordanCurve.Basic`), the cutting of a Jordan curve at
-one or two of its points (`TauCeti.Topology.JordanCurve.Separation`), and the fact that two nearby
-points cut off an arc of small diameter (`TauCeti.Topology.JordanCurve.SmallArc`). It declares
+its transfer lemmas (`TauCeti.Topology.JordanCurve.Basic`), the criterion recognizing the range of
+a simple closed path as a Jordan curve (`TauCeti.Topology.JordanCurve.Path`), the cutting of a
+Jordan curve at one or two of its points (`TauCeti.Topology.JordanCurve.Separation`), and the fact
+that two nearby points cut off an arc of small diameter
+(`TauCeti.Topology.JordanCurve.SmallArc`). It declares
 nothing of its own, and keeps the import path `TauCeti.Topology.JordanCurve` — which named the
 basic theory before it moved into the directory — working.
 -/

--- a/TauCeti/Topology/JordanCurve/Path.lean
+++ b/TauCeti/Topology/JordanCurve/Path.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: The Tau Ceti contributors
+-/
+module
+
+public import TauCeti.Topology.JordanCurve.Basic
+import Mathlib.Topology.Instances.AddCircle.Real
+
+/-!
+# Jordan curves traced by paths
+
+A path whose two endpoints agree is a parametrised closed curve, but its range need not be a
+Jordan curve: the path may pause, retrace an arc, or cross itself. This file supplies the exact
+criterion needed to exclude those degeneracies. If a closed path has no repeated values except
+for its two endpoint parameters, its range is a Jordan curve
+(`TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints`).
+
+The proof uses the quotient model of the circle already in Mathlib. The extension of a path
+`γ : Path x x` to `ℝ` has equal values at `0` and `1`, so
+`AddCircle.liftIco 1 0 γ.extend` factors it through the additive circle `ℝ / ℤ`. The hypothesis on
+repetitions says precisely that this factor is injective. Its range is the range of `γ`; compactness
+of the additive circle then upgrades the resulting continuous bijection onto the range to a
+homeomorphism, and `AddCircle.homeomorphCircle` identifies its source with `Circle`.
+
+The condition is stated directly rather than bundled as a new notion of simple closed path. This
+is the only operation needed here, and keeping it as a theorem hypothesis avoids introducing a
+second simplicity vocabulary alongside Mathlib's path API.
+
+## Main result
+
+* `TauCeti.isJordanCurve_range_of_eq_or_eq_endpoints` — the range of a closed path whose only
+  possible repetition is its pair of endpoints is a Jordan curve.
+
+## Roadmap role
+
+This is the topological gluing step used by layer **L5** of
+`TauCetiRoadmap/ConformalMapping/README.md`, the Carathéodory boundary correspondence. A
+finite-length image crosscut is already packaged as a path with exactly this simplicity property in
+`TauCeti/Analysis/Complex/Conformal/Crosscut/Path.lean`; when its two boundary ends coincide, the
+result below identifies the closure of that crosscut as a Jordan curve. The conformal specialization
+is in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean`.
+-/
+
+public section
+
+namespace TauCeti
+
+open Set
+
+variable {X : Type*} [TopologicalSpace X] [T2Space X] {x : X}
+
+/-- **The range of a simple closed path is a Jordan curve.** Let `γ : Path x x` be a closed path.
+If equality `γ s = γ t` forces either `s = t` or the unordered pair of parameters to be `{0, 1}`,
+then `range γ` is homeomorphic to the circle.
+
+The disjunction records both orientations of the exceptional endpoint pair explicitly. No local
+injectivity, embedding, or ambient separation hypothesis is needed. -/
+theorem isJordanCurve_range_of_eq_or_eq_endpoints (γ : Path x x)
+    (hγ : ∀ ⦃s t : unitInterval⦄, γ s = γ t →
+      s = t ∨ (s = 0 ∧ t = 1) ∨ (s = 1 ∧ t = 0)) :
+    IsJordanCurve (range γ) := by
+  -- Factor the extended path through `[0, 1]` with its endpoints identified.
+  let g : AddCircle (1 : ℝ) → X := AddCircle.liftIco 1 0 γ.extend
+  have hg0 : γ.extend 0 = γ.extend 1 := by rw [γ.extend_zero, γ.extend_one]
+  have hgc : Continuous g :=
+    AddCircle.liftIco_zero_continuous hg0 γ.continuous_extend.continuousOn
+  have hgcoe {t : ℝ} (ht : t ∈ Ico (0 : ℝ) 1) :
+      g (t : AddCircle (1 : ℝ)) = γ ⟨t, ht.1, ht.2.le⟩ := by
+    rw [show g (t : AddCircle (1 : ℝ)) = γ.extend t from
+      AddCircle.liftIco_zero_coe_apply ht]
+    exact γ.extend_extends' ⟨t, ht.1, ht.2.le⟩
+  -- Representatives in `[0, 1)` cannot form the exceptional endpoint pair, so the factor is
+  -- injective on the quotient.
+  have hgi : Function.Injective g := by
+    intro q q' hqq'
+    obtain ⟨s, hs, rfl⟩ := AddCircle.eq_coe_Ico q
+    obtain ⟨t, ht, rfl⟩ := AddCircle.eq_coe_Ico q'
+    rw [hgcoe hs, hgcoe ht] at hqq'
+    rcases hγ hqq' with hst | hends | hends
+    · exact congrArg (fun u : unitInterval => ((u : ℝ) : AddCircle (1 : ℝ))) hst
+    · exact absurd (congrArg ((↑) : unitInterval → ℝ) hends.2) ht.2.ne
+    · exact absurd (congrArg ((↑) : unitInterval → ℝ) hends.1) hs.2.ne
+  -- The quotient factor traces exactly the original path range; the endpoint `1` is represented
+  -- by `0` in the additive circle.
+  have hgrange : range g = range γ := by
+    apply Subset.antisymm
+    · rintro y ⟨q, rfl⟩
+      obtain ⟨t, ht, rfl⟩ := AddCircle.eq_coe_Ico q
+      exact ⟨⟨t, ht.1, ht.2.le⟩, (hgcoe ht).symm⟩
+    · rintro y ⟨t, rfl⟩
+      by_cases ht : (t : ℝ) < 1
+      · exact ⟨((t : ℝ) : AddCircle (1 : ℝ)), hgcoe ⟨t.2.1, ht⟩⟩
+      · have ht1 : t = 1 := Subtype.ext (le_antisymm t.2.2 (not_lt.mp ht))
+        refine ⟨(0 : AddCircle (1 : ℝ)), ?_⟩
+        subst t
+        exact (hgcoe (t := 0) (by simp)).trans (γ.source.trans γ.target.symm)
+  -- Restrict the codomain to the range and use compact-to-Hausdorff to upgrade the continuous
+  -- bijection to a homeomorphism.
+  let g' : AddCircle (1 : ℝ) → range γ := fun q =>
+    ⟨g q, hgrange.le (mem_range_self q)⟩
+  have hgi' : Function.Injective g' := fun _ _ h => hgi (congrArg Subtype.val h)
+  have hgs' : Function.Surjective g' := by
+    rintro ⟨y, t, rfl⟩
+    obtain ⟨q, hq⟩ : ∃ q, g q = γ t := hgrange.ge (mem_range_self t)
+    exact ⟨q, Subtype.ext hq⟩
+  let e : AddCircle (1 : ℝ) ≃ range γ := Equiv.ofBijective g' ⟨hgi', hgs'⟩
+  have he : (e : AddCircle (1 : ℝ) → range γ) = g' := by
+    unfold e
+    exact Equiv.coe_ofBijective g' ⟨hgi', hgs'⟩
+  have hec : Continuous e := by
+    rw [he]
+    exact hgc.subtype_mk fun q => hgrange.le (mem_range_self q)
+  let h : AddCircle (1 : ℝ) ≃ₜ range γ := Continuous.homeoOfEquivCompactToT2 hec
+  exact isJordanCurve_iff.mpr ⟨h.symm.trans (AddCircle.homeomorphCircle one_ne_zero)⟩
+
+end TauCeti

--- a/TauCeti/Topology/JordanCurve/Path.lean
+++ b/TauCeti/Topology/JordanCurve/Path.lean
@@ -20,9 +20,11 @@ for its two endpoint parameters, its range is a Jordan curve
 The proof uses the quotient model of the circle already in Mathlib. The extension of a path
 `γ : Path x x` to `ℝ` has equal values at `0` and `1`, so
 `AddCircle.liftIco 1 0 γ.extend` factors it through the additive circle `ℝ / ℤ`. The hypothesis on
-repetitions says precisely that this factor is injective. Its range is the range of `γ`; compactness
-of the additive circle then upgrades the resulting continuous bijection onto the range to a
-homeomorphism, and `AddCircle.homeomorphCircle` identifies its source with `Circle`.
+repetitions says precisely that this factor is injective, and its range is the range of `γ`. The
+additive circle is itself a Jordan curve, `AddCircle.homeomorphCircle` identifying it with
+`Circle`, so `TauCeti.IsJordanCurve.image` carries that along the factor: the compactness argument
+upgrading a continuous injection to a homeomorphism onto its image is already packaged there and is
+not repeated here.
 
 The condition is stated directly rather than bundled as a new notion of simple closed path. This
 is the only operation needed here, and keeping it as a theorem hypothesis avoids introducing a
@@ -56,7 +58,8 @@ If equality `γ s = γ t` forces either `s = t` or the unordered pair of paramet
 then `range γ` is homeomorphic to the circle.
 
 The disjunction records both orientations of the exceptional endpoint pair explicitly. No local
-injectivity, embedding, or ambient separation hypothesis is needed. -/
+injectivity or embedding hypothesis is needed, and no separation assumption on the ambient space
+beyond the Hausdorffness that `TauCeti.IsJordanCurve.image` asks for. -/
 theorem isJordanCurve_range_of_eq_or_eq_endpoints (γ : Path x x)
     (hγ : ∀ ⦃s t : unitInterval⦄, γ s = γ t →
       s = t ∨ (s = 0 ∧ t = 1) ∨ (s = 1 ∧ t = 0)) :
@@ -66,11 +69,11 @@ theorem isJordanCurve_range_of_eq_or_eq_endpoints (γ : Path x x)
   have hg0 : γ.extend 0 = γ.extend 1 := by rw [γ.extend_zero, γ.extend_one]
   have hgc : Continuous g :=
     AddCircle.liftIco_zero_continuous hg0 γ.continuous_extend.continuousOn
+  -- At the class of a representative in `[0, 1)` the lift is the extended path, which on `[0, 1]`
+  -- is the path itself.
   have hgcoe {t : ℝ} (ht : t ∈ Ico (0 : ℝ) 1) :
-      g (t : AddCircle (1 : ℝ)) = γ ⟨t, ht.1, ht.2.le⟩ := by
-    rw [show g (t : AddCircle (1 : ℝ)) = γ.extend t from
-      AddCircle.liftIco_zero_coe_apply ht]
-    exact γ.extend_extends' ⟨t, ht.1, ht.2.le⟩
+      g (t : AddCircle (1 : ℝ)) = γ ⟨t, ht.1, ht.2.le⟩ :=
+    (AddCircle.liftIco_zero_coe_apply ht).trans (γ.extend_extends' ⟨t, ht.1, ht.2.le⟩)
   -- Representatives in `[0, 1)` cannot form the exceptional endpoint pair, so the factor is
   -- injective on the quotient.
   have hgi : Function.Injective g := by
@@ -96,23 +99,11 @@ theorem isJordanCurve_range_of_eq_or_eq_endpoints (γ : Path x x)
         refine ⟨(0 : AddCircle (1 : ℝ)), ?_⟩
         subst t
         exact (hgcoe (t := 0) (by simp)).trans (γ.source.trans γ.target.symm)
-  -- Restrict the codomain to the range and use compact-to-Hausdorff to upgrade the continuous
-  -- bijection to a homeomorphism.
-  let g' : AddCircle (1 : ℝ) → range γ := fun q =>
-    ⟨g q, hgrange.le (mem_range_self q)⟩
-  have hgi' : Function.Injective g' := fun _ _ h => hgi (congrArg Subtype.val h)
-  have hgs' : Function.Surjective g' := by
-    rintro ⟨y, t, rfl⟩
-    obtain ⟨q, hq⟩ : ∃ q, g q = γ t := hgrange.ge (mem_range_self t)
-    exact ⟨q, Subtype.ext hq⟩
-  let e : AddCircle (1 : ℝ) ≃ range γ := Equiv.ofBijective g' ⟨hgi', hgs'⟩
-  have he : (e : AddCircle (1 : ℝ) → range γ) = g' := by
-    unfold e
-    exact Equiv.coe_ofBijective g' ⟨hgi', hgs'⟩
-  have hec : Continuous e := by
-    rw [he]
-    exact hgc.subtype_mk fun q => hgrange.le (mem_range_self q)
-  let h : AddCircle (1 : ℝ) ≃ₜ range γ := Continuous.homeoOfEquivCompactToT2 hec
-  exact isJordanCurve_iff.mpr ⟨h.symm.trans (AddCircle.homeomorphCircle one_ne_zero)⟩
+  -- The additive circle is a Jordan curve, and `g` carries it onto the range of `γ`.
+  have huniv : IsJordanCurve (univ : Set (AddCircle (1 : ℝ))) :=
+    isJordanCurve_iff.mpr
+      ⟨(Homeomorph.Set.univ (AddCircle (1 : ℝ))).trans (AddCircle.homeomorphCircle one_ne_zero)⟩
+  have himage := huniv.image hgc.continuousOn hgi.injOn
+  rwa [image_univ, hgrange] at himage
 
 end TauCeti


### PR DESCRIPTION
This PR recognizes the range of a closed path with no repetitions except its endpoint pair as a Jordan curve, and applies that criterion to the coincident-end branch of a finite-length conformal image crosscut.

The exact roadmap target is `TauCetiRoadmap/ConformalMapping/README.md`, layer **L5 — Carathéodory boundary correspondence**, whose Jordan-domain milestone requires the Riemann map to extend to a homeomorphism of closures. The existing crosscut path theorem produces a path whose interior is injective and whose only possible repetition is its two boundary endpoints; this PR factors any such closed path through `AddCircle (1 : ℝ)`, proves the factor injective, and upgrades it to a homeomorphism from the circle onto the path range. The conformal specialization then proves that if the closed image crosscut meets the image boundary in a subsingleton, its two path endpoints coincide and its closure is a Jordan curve.

This is the next connective step after `TauCeti.exists_path_range_eq_closure_image_ball_inter_sphere_of_injOn`: it resolves the endpoint-coincidence branch without assuming endpoint distinctness or weakening the separation problem. What remains after this PR is the planar separation argument, using this Jordan curve in the coincident-end case and a crosscut joined to a boundary arc in the distinct-end case, to bound the whole boundary of the cut-off image piece and feed the existing continuous-extension criterion.

The general result lives in `TauCeti/Topology/JordanCurve/Path.lean`; the roadmap-facing application lives in `TauCeti/Analysis/Complex/Conformal/Crosscut/Jordan.lean`. No Mathlib source is vendored. The proof consumes Mathlib's `AddCircle.liftIco_zero_continuous` and `AddCircle.homeomorphCircle`, following Mathlib's endpoint-identification model of the additive circle, and delegates the compactness upgrade of the continuous injection to the existing `TauCeti.IsJordanCurve.image`; the conformal argument consumes Tau Ceti's existing finite-length image-crosscut path theorem unchanged. The conformal geometry follows Carathéodory's 1913 paper, Pommerenke §2.2–2.3, and Duren Ch. 3, cited in the module docstring.

Roadmap: ConformalMapping

<!--tauceti-target:v1 {"focus":"ConformalMapping","id":"closed-simple-path-jordan-curve"}-->

🤖 Prepared with Codex

