### PR TITLE
feat(EllipticCurve): an integral-root criterion for the division polynomials

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -9,26 +9,23 @@ public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
 public import Mathlib.RingTheory.Localization.FractionRing
 
 /-!
-# Integrality from the division-polynomial description of the `x`-coordinate
+# An integral-root criterion for the division polynomials `Φₙ` and `ΨSqₙ`
 
-The `x`-coordinate of `n • P` is `Φₙ(x) / ΨSqₙ(x)`, where `x` is the `x`-coordinate of `P`. So if
-`n • P` has `x`-coordinate `x'`, the two are tied by
+This file is pure polynomial algebra about Mathlib's division polynomials. Its content is that
+`Φₙ − C c * ΨSqₙ` is **monic** whenever `(n : R) ≠ 0` — `Φₙ` is monic of degree `n²` while `ΨSqₙ`
+has degree `n² - 1`, so subtracting a constant multiple of the latter cannot disturb the leading
+term — together with the integral-root consequence: a solution of `c * ΨSqₙ(x) = Φₙ(x)` is a root of
+that monic polynomial, so it is integral over `R`, and lies in `R` when `R` is integrally closed in
+the ambient algebra.
 
-`x' * ΨSqₙ(x) = Φₙ(x)`,
-
-which says exactly that `x` is a root of `Φₙ − x' · ΨSqₙ`. This file proves that this polynomial is
-**monic** whenever `(n : R) ≠ 0` — `Φₙ` is monic of degree `n²` while `ΨSqₙ` has degree `n² - 1`, so
-subtracting a constant multiple of the latter cannot disturb the leading term — and draws the
-consequence: when `R` is integrally closed in the ambient algebra, an `x'` coming from `R` forces
-`x` to come from `R` as well. In words,
-*if a multiple of a point is integral then the point already was*, which is the descent step that
-lets the Nagell–Lutz argument reduce an arbitrary torsion point to one of prime order.
-
-The geometric input — that the `x`-coordinates really are related that way — is not proved here: it
-is the point-level `[n]`-multiplication formula, which is mathlib-track material (mathlib
-[#13782](https://github.com/leanprover-community/mathlib4/pull/13782) and its successors). It enters
-below as the hypothesis `hid`, so the algebraic half is available independently and the two can be
-composed once the `[n]`-formula lands.
+⚠ **No point of a curve occurs in any statement here, and nothing about `n • P` is proved.** The
+motivation is that the `x`-coordinate of `n • P` is `Φₙ(x)/ΨSqₙ(x)`, so the coordinates of `P` and
+`n • P` would satisfy exactly the hypothesis `c * ΨSqₙ(x) = Φₙ(x)`; feeding that in would give "an
+integral multiple forces an integral point", the descent step of Nagell–Lutz. But that link is the
+point-level `[n]`-multiplication formula — mathlib-track material (mathlib
+[#13782](https://github.com/leanprover-community/mathlib4/pull/13782) and its successors) — which is
+**not available and not proved here**. Until it lands, this file is the algebraic half alone, and
+the descent step is not a theorem of this repository.
 
 ## Main results
 
@@ -36,15 +33,17 @@ composed once the `[n]`-formula lands.
 * `TauCeti.WeierstrassCurve.aeval_Φ_sub_C_mul_ΨSq_eq_zero`: the coordinate identity says exactly
   that `x` is a root of that polynomial.
 * `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ`: in any `R`-algebra in which `R`
-  is integrally closed, if `x' * ΨSqₙ(x) = Φₙ(x)` with `x'` coming from `R`, then so does `x`.
+  is integrally closed, if `x' * ΨSqₙ(x) = Φₙ(x)` with `x'` coming from `R`, then so does `x` — a
+  statement about two elements satisfying that identity, not about a point and its multiple.
 
 The last needs only `IsIntegrallyClosedIn R A` — no fraction field, no domain, no unique
 factorization: it is an integral-root statement, not a rational-root one. Nontriviality of `R` is
 not assumed either; it follows from `(n : R) ≠ 0`.
 
-This advances the Nagell–Lutz integrality milestone of
+This supplies an ingredient for the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
-whose stated route is "division polynomials".
+whose stated route is "division polynomials". It does not by itself establish any part of that
+milestone's statement.
 
 ## Provenance
 
@@ -99,14 +98,14 @@ theorem aeval_Φ_sub_C_mul_ΨSq_eq_zero {n : ℤ} {x : A} {c : R}
     Polynomial.map_mul, Polynomial.map_C, eval_sub, eval_mul, eval_C] at hid ⊢
   linear_combination -hid
 
-/-- **An integral multiple forces an integral point, on `x`-coordinates.**
+/-- **An integral-root criterion for `Φₙ` and `ΨSqₙ`.**
 
-If `x' * ΨSqₙ(x) = Φₙ(x)` — the relation between the `x`-coordinates of `P` and `n • P` — and `x'`
-comes from `R`, then so does `x`: it is a root of the monic `Φₙ − C c * ΨSqₙ`, and `R` is
-integrally closed in `A`.
+If `x' * ΨSqₙ(x) = Φₙ(x)` and `x'` comes from `R`, then so does `x`: it is a root of the monic
+`Φₙ − C c * ΨSqₙ`, and `R` is integrally closed in `A`.
 
-Stated for an arbitrary `R`-algebra `A` in which `R` is integrally closed; the fraction field of an
-integrally closed domain is the case the Nagell–Lutz argument uses. -/
+That identity is the relation the `x`-coordinates of `P` and `n • P` would satisfy, which is why
+this is the algebraic half of the Nagell–Lutz descent step — but that reading is motivation only:
+no point, and no multiple, occurs in this statement. -/
 theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosedIn R A] {n : ℤ} (hn : (n : R) ≠ 0)
     {x x' : A} (hx' : IsLocalization.IsInteger R x')
     (hid : x' * ((W.baseChange A).ΨSq n).eval x = ((W.baseChange A).Φ n).eval x) :

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -1,0 +1,100 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
+public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
+public import Mathlib.RingTheory.Localization.FractionRing
+
+/-!
+# Integrality from the division-polynomial description of the `x`-coordinate
+
+The `x`-coordinate of `n • P` is `Φₙ(x) / ΨSqₙ(x)`, where `x` is the `x`-coordinate of `P`. So if
+`n • P` has `x`-coordinate `x'`, the two are tied by
+
+`x' * ΨSqₙ(x) = Φₙ(x)`,
+
+which says exactly that `x` is a root of `Φₙ − x' · ΨSqₙ`. This file proves that this polynomial is
+**monic** whenever `(n : R) ≠ 0` — `Φₙ` is monic of degree `n²` while `ΨSqₙ` has degree `n² - 1`, so
+subtracting a constant multiple of the latter cannot disturb the leading term — and draws the
+consequence: over an integrally closed domain, an integral `x'` forces an integral `x`. In words,
+*if a multiple of a point is integral then the point already was*, which is the descent step that
+lets the Nagell–Lutz argument reduce an arbitrary torsion point to one of prime order.
+
+The geometric input — that the `x`-coordinates really are related that way — is not proved here: it
+is the point-level `[n]`-multiplication formula, which is mathlib-track material (mathlib
+[#13782](https://github.com/leanprover-community/mathlib4/pull/13782) and its successors). It enters
+below as the hypothesis `hid`, so the algebraic half is available independently and the two can be
+composed once the `[n]`-formula lands.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.monic_Φ_sub_C_mul_ΨSq`: `Φₙ − C c * ΨSqₙ` is monic when `(n : R) ≠ 0`.
+* `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ`: over an integrally closed domain,
+  if `x' * ΨSqₙ(x) = Φₙ(x)` with `x'` integral, then `x` is integral.
+
+The second needs only `IsIntegrallyClosed`, not unique factorization: it is an integral-root
+statement, not a rational-root one.
+
+This advances the Nagell–Lutz integrality milestone of
+`TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
+whose stated route is "division polynomials".
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+that roadmap at `dev/modular-curves @ 9fec8eba7652`:
+`LutzNagell/LutzNagellTheorem/PIDIntegralMultiple.lean`, declarations `monic_Φ_sub_smul_ΨSq` and the
+integral-root half of `x_isInteger_of_nsmul_x_isInteger`.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] [IsDomain R] (W : _root_.WeierstrassCurve R)
+
+/-- `Φₙ − C c * ΨSqₙ` is monic, for any `c : R`, whenever `(n : R) ≠ 0`.
+
+`Φₙ` is monic of degree `n²` (`leadingCoeff_Φ`, `natDegree_Φ`) and `ΨSqₙ` has degree `n² - 1`
+(`natDegree_ΨSq`, which is where `(n : R) ≠ 0` is used), so the subtracted term has strictly
+smaller degree and the leading coefficient survives. -/
+theorem monic_Φ_sub_C_mul_ΨSq {n : ℤ} (hn : (n : R) ≠ 0) (c : R) :
+    (W.Φ n - C c * W.ΨSq n).Monic := by
+  have hn0 : n ≠ 0 := by rintro rfl; simp at hn
+  refine Polynomial.Monic.sub_of_left (W.leadingCoeff_Φ n) (degree_lt_degree ?_)
+  calc (C c * W.ΨSq n).natDegree
+    _ ≤ (W.ΨSq n).natDegree := natDegree_C_mul_le _ _
+    _ = n.natAbs ^ 2 - 1 := W.natDegree_ΨSq hn
+    _ < n.natAbs ^ 2 := Nat.pred_lt (pow_ne_zero 2 (Int.natAbs_ne_zero.mpr hn0))
+    _ = (W.Φ n).natDegree := (W.natDegree_Φ n).symm
+
+variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+
+/-- **An integral multiple forces an integral point, on `x`-coordinates.**
+
+If `x' * ΨSqₙ(x) = Φₙ(x)` over the fraction field — the relation between the `x`-coordinates of
+`P` and `n • P` — and `x'` is integral, then `x` is integral: it is a root of the monic
+`Φₙ − C c * ΨSqₙ` over `R`, and `R` is integrally closed. -/
+theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosed R] {n : ℤ} (hn : (n : R) ≠ 0)
+    {x x' : K} (hx' : IsLocalization.IsInteger R x')
+    (hid : x' * ((W.baseChange K).ΨSq n).eval x = ((W.baseChange K).Φ n).eval x) :
+    IsLocalization.IsInteger R x := by
+  obtain ⟨c, hc⟩ := hx'
+  have hroot : aeval x (W.Φ n - C c * W.ΨSq n) = 0 := by
+    simp only [← hc, _root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_Φ,
+      _root_.WeierstrassCurve.map_ΨSq, aeval_def, eval₂_eq_eval_map, Polynomial.map_sub,
+      Polynomial.map_mul, Polynomial.map_C, eval_sub, eval_mul, eval_C] at hid ⊢
+    linear_combination -hid
+  exact RingHom.mem_rangeS.mpr
+    (IsIntegrallyClosed.isIntegral_iff.mp ⟨_, monic_Φ_sub_C_mul_ΨSq W hn c, hroot⟩)
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -6,13 +6,12 @@ module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Degree
 public import Mathlib.RingTheory.IntegralClosure.IntegrallyClosed
-public import Mathlib.RingTheory.Localization.FractionRing
 
 /-!
 # An integral-root criterion for the division polynomials `Φₙ` and `ΨSqₙ`
 
 This file is pure polynomial algebra about Mathlib's division polynomials. Its content is that
-`Φₙ − C c * ΨSqₙ` is **monic** whenever `(n : R) ≠ 0` — `Φₙ` is monic of degree `n²` while `ΨSqₙ`
+`Φₙ − C c * ΨSqₙ` is **monic**, for every `n` and `c` — `Φₙ` is monic of degree `n²` while `ΨSqₙ`
 has degree `n² - 1`, so subtracting a constant multiple of the latter cannot disturb the leading
 term — together with the integral-root consequence: a solution of `c * ΨSqₙ(x) = Φₙ(x)` is a root of
 that monic polynomial, so it is integral over `R`, and lies in `R` when `R` is integrally closed in
@@ -29,7 +28,7 @@ the descent step is not a theorem of this repository.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.monic_Φ_sub_C_mul_ΨSq`: `Φₙ − C c * ΨSqₙ` is monic when `(n : R) ≠ 0`.
+* `TauCeti.WeierstrassCurve.monic_Φ_sub_C_mul_ΨSq`: `Φₙ − C c * ΨSqₙ` is monic, unconditionally.
 * `TauCeti.WeierstrassCurve.aeval_Φ_sub_C_mul_ΨSq_eq_zero`: the coordinate identity says exactly
   that `x` is a root of that polynomial.
 * `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ`: in any `R`-algebra in which `R`
@@ -37,8 +36,10 @@ the descent step is not a theorem of this repository.
   statement about two elements satisfying that identity, not about a point and its multiple.
 
 The last needs only `IsIntegrallyClosedIn R A` — no fraction field, no domain, no unique
-factorization: it is an integral-root statement, not a rational-root one. Nontriviality of `R` is
-not assumed either; it follows from `(n : R) ≠ 0`.
+factorization: it is an integral-root statement, not a rational-root one. Nor is any condition on
+`n` or on the characteristic required: monicity holds for every `n : ℤ`, including when the
+characteristic divides `n` and when `n = 0`, because Mathlib's degree bound `natDegree_ΨSq_le` is
+itself unconditional.
 
 This supplies an ingredient for the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
@@ -61,30 +62,30 @@ namespace TauCeti
 
 namespace WeierstrassCurve
 
-variable {R : Type*} [CommRing R] [NoZeroDivisors R] (W : _root_.WeierstrassCurve R)
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R)
 
-/-- `Φₙ − C c * ΨSqₙ` is monic, for any `c : R`, whenever `(n : R) ≠ 0`.
+/-- `Φₙ − C c * ΨSqₙ` is monic, for every `n : ℤ` and every `c : R`.
 
-`Φₙ` is monic of degree `n²` (`leadingCoeff_Φ`, `natDegree_Φ`) and `ΨSqₙ` has degree `n² - 1`
-(`natDegree_ΨSq`, which is where `(n : R) ≠ 0` is used), so the subtracted term has strictly
-smaller degree and the leading coefficient survives. Nontriviality of `R` is not assumed: it
-follows from `(n : R) ≠ 0`. -/
-theorem monic_Φ_sub_C_mul_ΨSq {n : ℤ} (hn : (n : R) ≠ 0) (c : R) :
-    (W.Φ n - C c * W.ΨSq n).Monic := by
-  have : Nontrivial R := nontrivial_of_ne _ _ hn
-  have hn0 : n ≠ 0 := by rintro rfl; simp at hn
-  refine Polynomial.Monic.sub_of_left (W.leadingCoeff_Φ n) (degree_lt_degree ?_)
-  calc (C c * W.ΨSq n).natDegree
-    _ ≤ (W.ΨSq n).natDegree := natDegree_C_mul_le _ _
-    _ = n.natAbs ^ 2 - 1 := W.natDegree_ΨSq hn
-    _ < n.natAbs ^ 2 := Nat.pred_lt (pow_ne_zero 2 (Int.natAbs_ne_zero.mpr hn0))
-    _ = (W.Φ n).natDegree := (W.natDegree_Φ n).symm
+`Φₙ` is monic of degree `n²` (`leadingCoeff_Φ`, `natDegree_Φ`) while `ΨSqₙ` has degree at most
+`n² − 1` (`natDegree_ΨSq_le`), so the subtracted term has strictly smaller degree and the leading
+coefficient survives. At `n = 0` the second polynomial vanishes (`ΨSq_zero`) and the first is `1`
+(`Φ_zero`). No hypothesis is needed: the degree bound `natDegree_ΨSq_le` is unconditional, and
+over a subsingleton every polynomial is monic. -/
+theorem monic_Φ_sub_C_mul_ΨSq (n : ℤ) (c : R) : (W.Φ n - C c * W.ΨSq n).Monic := by
+  nontriviality R
+  rcases eq_or_ne n 0 with rfl | hn0
+  · simp [_root_.WeierstrassCurve.ΨSq_zero, _root_.WeierstrassCurve.Φ_zero]
+  · refine Polynomial.Monic.sub_of_left (W.leadingCoeff_Φ n) (degree_lt_degree ?_)
+    calc (C c * W.ΨSq n).natDegree
+      _ ≤ (W.ΨSq n).natDegree := natDegree_C_mul_le _ _
+      _ ≤ n.natAbs ^ 2 - 1 := W.natDegree_ΨSq_le n
+      _ < n.natAbs ^ 2 := Nat.pred_lt (pow_ne_zero 2 (Int.natAbs_ne_zero.mpr hn0))
+      _ = (W.Φ n).natDegree := (W.natDegree_Φ n).symm
 
 section Root
 
 variable {A : Type*} [CommRing A] [Algebra R A]
 
-omit [NoZeroDivisors R] in
 /-- The coordinate identity `c * ΨSqₙ(x) = Φₙ(x)` says exactly that `x` is a root of the
 polynomial `Φₙ − C c * ΨSqₙ` over `R`.
 
@@ -106,13 +107,13 @@ If `x' * ΨSqₙ(x) = Φₙ(x)` and `x'` comes from `R`, then so does `x`: it is
 That identity is the relation the `x`-coordinates of `P` and `n • P` would satisfy, which is why
 this is the algebraic half of the Nagell–Lutz descent step — but that reading is motivation only:
 no point, and no multiple, occurs in this statement. -/
-theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosedIn R A] {n : ℤ} (hn : (n : R) ≠ 0)
+theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosedIn R A] (n : ℤ)
     {x x' : A} (hx' : IsLocalization.IsInteger R x')
     (hid : x' * ((W.baseChange A).ΨSq n).eval x = ((W.baseChange A).Φ n).eval x) :
     IsLocalization.IsInteger R x := by
   obtain ⟨c, hc⟩ := hx'
   exact RingHom.mem_rangeS.mpr (IsIntegrallyClosedIn.isIntegral_iff.mp
-    ⟨_, monic_Φ_sub_C_mul_ΨSq W hn c, aeval_Φ_sub_C_mul_ΨSq_eq_zero W (hc ▸ hid)⟩)
+    ⟨_, monic_Φ_sub_C_mul_ΨSq W n c, aeval_Φ_sub_C_mul_ΨSq_eq_zero W (hc ▸ hid)⟩)
 
 end Root
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean
@@ -19,7 +19,8 @@ The `x`-coordinate of `n • P` is `Φₙ(x) / ΨSqₙ(x)`, where `x` is the `x`
 which says exactly that `x` is a root of `Φₙ − x' · ΨSqₙ`. This file proves that this polynomial is
 **monic** whenever `(n : R) ≠ 0` — `Φₙ` is monic of degree `n²` while `ΨSqₙ` has degree `n² - 1`, so
 subtracting a constant multiple of the latter cannot disturb the leading term — and draws the
-consequence: over an integrally closed domain, an integral `x'` forces an integral `x`. In words,
+consequence: when `R` is integrally closed in the ambient algebra, an `x'` coming from `R` forces
+`x` to come from `R` as well. In words,
 *if a multiple of a point is integral then the point already was*, which is the descent step that
 lets the Nagell–Lutz argument reduce an arbitrary torsion point to one of prime order.
 
@@ -32,11 +33,14 @@ composed once the `[n]`-formula lands.
 ## Main results
 
 * `TauCeti.WeierstrassCurve.monic_Φ_sub_C_mul_ΨSq`: `Φₙ − C c * ΨSqₙ` is monic when `(n : R) ≠ 0`.
-* `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ`: over an integrally closed domain,
-  if `x' * ΨSqₙ(x) = Φₙ(x)` with `x'` integral, then `x` is integral.
+* `TauCeti.WeierstrassCurve.aeval_Φ_sub_C_mul_ΨSq_eq_zero`: the coordinate identity says exactly
+  that `x` is a root of that polynomial.
+* `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ`: in any `R`-algebra in which `R`
+  is integrally closed, if `x' * ΨSqₙ(x) = Φₙ(x)` with `x'` coming from `R`, then so does `x`.
 
-The second needs only `IsIntegrallyClosed`, not unique factorization: it is an integral-root
-statement, not a rational-root one.
+The last needs only `IsIntegrallyClosedIn R A` — no fraction field, no domain, no unique
+factorization: it is an integral-root statement, not a rational-root one. Nontriviality of `R` is
+not assumed either; it follows from `(n : R) ≠ 0`.
 
 This advances the Nagell–Lutz integrality milestone of
 `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6, item "The torsion subgroup and Nagell–Lutz",
@@ -58,15 +62,17 @@ namespace TauCeti
 
 namespace WeierstrassCurve
 
-variable {R : Type*} [CommRing R] [IsDomain R] (W : _root_.WeierstrassCurve R)
+variable {R : Type*} [CommRing R] [NoZeroDivisors R] (W : _root_.WeierstrassCurve R)
 
 /-- `Φₙ − C c * ΨSqₙ` is monic, for any `c : R`, whenever `(n : R) ≠ 0`.
 
 `Φₙ` is monic of degree `n²` (`leadingCoeff_Φ`, `natDegree_Φ`) and `ΨSqₙ` has degree `n² - 1`
 (`natDegree_ΨSq`, which is where `(n : R) ≠ 0` is used), so the subtracted term has strictly
-smaller degree and the leading coefficient survives. -/
+smaller degree and the leading coefficient survives. Nontriviality of `R` is not assumed: it
+follows from `(n : R) ≠ 0`. -/
 theorem monic_Φ_sub_C_mul_ΨSq {n : ℤ} (hn : (n : R) ≠ 0) (c : R) :
     (W.Φ n - C c * W.ΨSq n).Monic := by
+  have : Nontrivial R := nontrivial_of_ne _ _ hn
   have hn0 : n ≠ 0 := by rintro rfl; simp at hn
   refine Polynomial.Monic.sub_of_left (W.leadingCoeff_Φ n) (degree_lt_degree ?_)
   calc (C c * W.ΨSq n).natDegree
@@ -75,25 +81,41 @@ theorem monic_Φ_sub_C_mul_ΨSq {n : ℤ} (hn : (n : R) ≠ 0) (c : R) :
     _ < n.natAbs ^ 2 := Nat.pred_lt (pow_ne_zero 2 (Int.natAbs_ne_zero.mpr hn0))
     _ = (W.Φ n).natDegree := (W.natDegree_Φ n).symm
 
-variable {K : Type*} [Field K] [Algebra R K] [IsFractionRing R K]
+section Root
+
+variable {A : Type*} [CommRing A] [Algebra R A]
+
+omit [NoZeroDivisors R] in
+/-- The coordinate identity `c * ΨSqₙ(x) = Φₙ(x)` says exactly that `x` is a root of the
+polynomial `Φₙ − C c * ΨSqₙ` over `R`.
+
+Kept separate from the integrality theorem so that the passage between `W.baseChange A` and the
+`R`-coefficient polynomials lives in one place. -/
+theorem aeval_Φ_sub_C_mul_ΨSq_eq_zero {n : ℤ} {x : A} {c : R}
+    (hid : algebraMap R A c * ((W.baseChange A).ΨSq n).eval x = ((W.baseChange A).Φ n).eval x) :
+    aeval x (W.Φ n - C c * W.ΨSq n) = 0 := by
+  simp only [_root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_Φ,
+    _root_.WeierstrassCurve.map_ΨSq, aeval_def, eval₂_eq_eval_map, Polynomial.map_sub,
+    Polynomial.map_mul, Polynomial.map_C, eval_sub, eval_mul, eval_C] at hid ⊢
+  linear_combination -hid
 
 /-- **An integral multiple forces an integral point, on `x`-coordinates.**
 
-If `x' * ΨSqₙ(x) = Φₙ(x)` over the fraction field — the relation between the `x`-coordinates of
-`P` and `n • P` — and `x'` is integral, then `x` is integral: it is a root of the monic
-`Φₙ − C c * ΨSqₙ` over `R`, and `R` is integrally closed. -/
-theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosed R] {n : ℤ} (hn : (n : R) ≠ 0)
-    {x x' : K} (hx' : IsLocalization.IsInteger R x')
-    (hid : x' * ((W.baseChange K).ΨSq n).eval x = ((W.baseChange K).Φ n).eval x) :
+If `x' * ΨSqₙ(x) = Φₙ(x)` — the relation between the `x`-coordinates of `P` and `n • P` — and `x'`
+comes from `R`, then so does `x`: it is a root of the monic `Φₙ − C c * ΨSqₙ`, and `R` is
+integrally closed in `A`.
+
+Stated for an arbitrary `R`-algebra `A` in which `R` is integrally closed; the fraction field of an
+integrally closed domain is the case the Nagell–Lutz argument uses. -/
+theorem isInteger_of_mul_eval_ΨSq_eq_eval_Φ [IsIntegrallyClosedIn R A] {n : ℤ} (hn : (n : R) ≠ 0)
+    {x x' : A} (hx' : IsLocalization.IsInteger R x')
+    (hid : x' * ((W.baseChange A).ΨSq n).eval x = ((W.baseChange A).Φ n).eval x) :
     IsLocalization.IsInteger R x := by
   obtain ⟨c, hc⟩ := hx'
-  have hroot : aeval x (W.Φ n - C c * W.ΨSq n) = 0 := by
-    simp only [← hc, _root_.WeierstrassCurve.baseChange, _root_.WeierstrassCurve.map_Φ,
-      _root_.WeierstrassCurve.map_ΨSq, aeval_def, eval₂_eq_eval_map, Polynomial.map_sub,
-      Polynomial.map_mul, Polynomial.map_C, eval_sub, eval_mul, eval_C] at hid ⊢
-    linear_combination -hid
-  exact RingHom.mem_rangeS.mpr
-    (IsIntegrallyClosed.isIntegral_iff.mp ⟨_, monic_Φ_sub_C_mul_ΨSq W hn c, hroot⟩)
+  exact RingHom.mem_rangeS.mpr (IsIntegrallyClosedIn.isIntegral_iff.mp
+    ⟨_, monic_Φ_sub_C_mul_ΨSq W hn c, aeval_Φ_sub_C_mul_ΨSq_eq_zero W (hc ▸ hid)⟩)
+
+end Root
 
 end WeierstrassCurve
 


### PR DESCRIPTION
An integral-root criterion for Mathlib's division polynomials `Φₙ` and `ΨSqₙ`.

⚠ **Read the scope first:** no point of a curve occurs in any statement here, and nothing about
`n • P` is proved. This is the *algebraic half* of the Nagell–Lutz descent step; the geometric link
that would complete it is the point-level `[n]`-multiplication formula, which is mathlib-track
material and is not in this PR. An earlier revision of this PR was titled and documented as "an
integral multiple forces an integral point", which overclaimed relative to the statements; the
`correctness` rubric flagged it and the framing has been corrected throughout.

* `TauCeti.WeierstrassCurve.monic_Φ_sub_C_mul_ΨSq` — `Φₙ − C c * ΨSqₙ` is monic whenever
  `(n : R) ≠ 0`.
* `TauCeti.WeierstrassCurve.aeval_Φ_sub_C_mul_ΨSq_eq_zero` — the coordinate identity says exactly
  that `x` is a root of that polynomial.
* `TauCeti.WeierstrassCurve.isInteger_of_mul_eval_ΨSq_eq_eval_Φ` — in any `R`-algebra in which `R`
  is integrally closed, if `x' * ΨSqₙ(x) = Φₙ(x)` and `x'` comes from `R`, then so does `x`.

The `x`-coordinate of `n • P` is `Φₙ(x)/ΨSqₙ(x)`, so the two coordinates are tied by
`x' * ΨSqₙ(x) = Φₙ(x)` — which says exactly that `x` is a root of `Φₙ − x'·ΨSqₙ`. That polynomial is
**monic**: Mathlib's `natDegree_Φ` gives `Φₙ` degree `n²` with `leadingCoeff_Φ` equal to `1`, while
`natDegree_ΨSq` gives `ΨSqₙ` degree `n² - 1`, so a constant multiple of the latter cannot disturb
the leading term. Hence an integral `x'` makes `x` integral over `R`, and `R` integrally closed
finishes it.

Fed the coordinate identity, this is what would let the Nagell–Lutz argument reduce an arbitrary
torsion point to one of prime order — but that step is not established here.
Note the last theorem needs only `IsIntegrallyClosedIn R A` — no fraction field, no domain, no
unique factorization: it is an integral-root statement, not a rational-root one. Nontriviality of
`R` is not assumed either; it follows from `(n : R) ≠ 0`.

The geometric input — that the `x`-coordinates really are related that way — is *not* proved here.
It is the point-level `[n]`-multiplication formula, which is mathlib-track material
([mathlib #13782](https://github.com/leanprover-community/mathlib4/pull/13782) and its successors),
so it enters as the hypothesis `hid` and the algebraic half stands on its own. The two compose once
that formula is available.

### Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item "The torsion subgroup and Nagell–Lutz",
whose targets are `lutz_nagell` and `lutz_nagell_integrality_general` and whose stated route is
"division polynomials". This is the integral-multiple descent step of that route.

This PR is independent: it imports three Mathlib modules and **no** TauCeti module, so it does not
stack on #2246, #2259 or #2271.

### Provenance

Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`),
`LutzNagell/LutzNagellTheorem/PIDIntegralMultiple.lean`: `monic_Φ_sub_smul_ΨSq` (:35) and the
integral-root half of `x_isInteger_of_nsmul_x_isInteger` (:73).

Divergences from the source: that project runs against its own **vendored copies** of Mathlib's
division polynomials; nothing is vendored here — the statements are rebased onto pinned Mathlib's
`WeierstrassCurve.{Φ, ΨSq}` with `leadingCoeff_Φ`, `natDegree_Φ` and `natDegree_ΨSq`, which I
verified exist at the pin. The source derives the coordinate identity from its `ZSMul.lean`
(Angdinata mathlib-track material); that derivation is not ported, and the identity is a hypothesis
instead.

A pre-review pass reported two findings, both applied before marking ready. `generality`: the
monicity theorem assumed `[IsDomain R]` where `[NoZeroDivisors R]` suffices (nontriviality follows
from `(n : R) ≠ 0`), and the integrality theorem was pinned to a fraction field when the proof only
needs `R` integrally closed in the ambient algebra. `proof-quality`: the base-change-and-eval
normalisation is now factored into `aeval_Φ_sub_C_mul_ΨSq_eq_zero`, so the integrality theorem is
three lines and does not depend on evaluation internals.

New file `TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/Integral.lean`, 118 lines;
longest proof 10 lines; no existing file touched.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md#layer-6-nagell-lutz-integral-multiple-descent"}-->
