### PR TITLE
feat(EllipticCurve): the sharp discriminant divisibility for a1 = a3 = 0

### DIFF
--- a/TauCeti/Algebra/CubicDiscriminant.lean
+++ b/TauCeti/Algebra/CubicDiscriminant.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.Algebra.CubicDiscriminant
+
+/-!
+# Divisors of a monic cubic and of its discriminant
+
+Two divisibility transfers for the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` over a commutative
+ring. A common divisor of `f(x)` and of the quartic `3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`
+divides `f'(x)²`; and a common divisor of `f(x)` and `f'(x)²` divides `Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
+
+Both are certified by explicit polynomial identities in `x`, so no hypothesis beyond the two
+divisibilities is needed — no domain, no ellipticity, nothing about the ring beyond commutativity.
+
+Composing them is the algebraic half of the sharp discriminant bound in Nagell–Lutz: a divisor of
+the cubic which also divides that quartic divides the cubic's discriminant.
+
+## Main results
+
+* `TauCeti.Cubic.dvd_derivative_sq`
+* `TauCeti.Cubic.dvd_discr`
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+the roadmap at `dev/modular-curves @ 9fec8eba7652`,
+`LutzNagell/LutzNagellTheorem/GeneralDiscriminant.lean`, where the two identities appear inline
+inside the discriminant argument rather than as separate lemmas.
+-/
+
+public section
+
+namespace TauCeti.Cubic
+
+variable {R : Type*} [CommRing R] {d a₂ a₄ a₆ x : R}
+
+/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and the quartic
+`3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`, then it divides `f'(x)²`.
+
+The two are related by `f'(x)² + (that quartic) = (12x + 4a₂) · f(x)`, an identity in `x`. -/
+theorem dvd_derivative_sq (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+    (hq : d ∣ 3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) :
+    d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
+  have hid : (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 =
+      (12 * x + 4 * a₂) * (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆) -
+        (3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) := by
+    ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) hq
+
+/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and `f'(x)²`, then it divides
+the cubic's discriminant.
+
+`Cubic.discr ⟨1, a₂, a₄, a₆⟩` is an explicit combination of `f(x)` and `f'(x)²`, an identity in
+`x`. -/
+theorem dvd_discr (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+    (hderiv : d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2) :
+    d ∣ (_root_.Cubic.mk 1 a₂ a₄ a₆).discr := by
+  have hid : (_root_.Cubic.mk 1 a₂ a₄ a₆).discr =
+      (27 * x ^ 3 + 27 * a₂ * x ^ 2 + 27 * a₄ * x - 4 * a₂ ^ 3 + 18 * a₂ * a₄ - 27 * a₆) *
+          (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+        - (3 * x ^ 2 + 2 * a₂ * x - a₂ ^ 2 + 4 * a₄) * (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
+    simp only [_root_.Cubic.discr]; ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) (Dvd.dvd.mul_left hderiv _)
+
+end TauCeti.Cubic

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -109,6 +109,7 @@ variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
 
 /-- For a model with `a₁ = a₃ = 0`, the univariate `Ψ₃` is the quartic
 `3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`. -/
+@[simp]
 theorem eval_Ψ₃_of_a₁_eq_zero_of_a₃_eq_zero (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0) :
     (W.Ψ₃).eval x = 3 * x ^ 4 + 4 * W.a₂ * x ^ 3 + 6 * W.a₄ * x ^ 2 + 12 * W.a₆ * x +
       (4 * W.a₂ * W.a₆ - W.a₄ ^ 2) := by

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -19,18 +19,28 @@ so the cubic discriminant is the invariant with the factors of `16` divided out.
 the classical statement of Nagell–Lutz for a short model, where `a₂ = 0` too and the conclusion
 reads `y² ∣ 4a₄³ + 27a₆²` up to sign.
 
-The proof is two ring identities over the cubic. Writing `f(x) = x³ + a₂x² + a₄x + a₆`, the
-derivative square `f'(x)² = (3x² + 2a₂x + a₄)²` differs from `Ψ₃(x)` by a multiple of `f(x) = y²`;
-and `Cubic.discr` is an explicit combination of `y²` and `f'(x)²`. So `y² ∣ Ψ₃(x)` propagates to
-`y² ∣ f'(x)²` and then to the discriminant.
+The proof is two ring identities, and neither mentions a curve. Writing
+`f(x) = x³ + a₂x² + a₄x + a₆`, the first is
+
+`f'(x)² + Q(x) = (12x + 4a₂) · f(x)`,   `Q(x) = 3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`,
+
+so anything dividing `f(x)` and `Q(x)` divides `f'(x)²`; the second expresses
+`Cubic.discr ⟨1, a₂, a₄, a₆⟩` as a combination of `f(x)` and `f'(x)²`. Both are stated for an
+arbitrary divisor `d`, in a namespace about cubics rather than curves. `Ψ₃` enters only at the end:
+for `a₁ = a₃ = 0` it evaluates to exactly that `Q(x)`, and the curve equation makes `y²` a divisor
+of `f(x)`.
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.sq_dvd_derivative_sq`: `y² ∣ (3x² + 2a₂x + a₄)²`.
-* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr_of_sq_dvd_derivative_sq`: the discriminant step on
-  its own — no `a₁ = a₃ = 0`, no `Ψ₃`, just the curve equation and that divisibility.
-* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`, the two
+* `TauCeti.Cubic.dvd_derivative_sq`: a divisor of `f(x)` and of `Q(x)` divides `f'(x)²`.
+* `TauCeti.Cubic.dvd_discr`: a divisor of `f(x)` and of `f'(x)²` divides
+  `Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
+* `TauCeti.WeierstrassCurve.eval_Ψ₃_of_a₁_eq_zero_of_a₃_eq_zero`: for `a₁ = a₃ = 0`, `Ψ₃` is `Q`.
+* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`, the three
   composed.
+
+The first two are about coefficients `a₂ a₄ a₆ : R` and an arbitrary divisor `d`, with no
+Weierstrass curve and no `y²` in sight; only the last is curve-specific.
 
 Both are over an arbitrary commutative ring, for an arbitrary point of the curve — no domain,
 torsion, integrality or ellipticity hypothesis. The input `y² ∣ Ψ₃(x)` is what a torsion point
@@ -57,40 +67,55 @@ open Polynomial
 
 namespace TauCeti
 
+namespace Cubic
+
+variable {R : Type*} [CommRing R] {d a₂ a₄ a₆ x : R}
+
+/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and the quartic
+`3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`, then it divides `f'(x)²`.
+
+The two are related by `f'(x)² + (that quartic) = (12x + 4a₂) · f(x)`, an identity in `x`. -/
+theorem dvd_derivative_sq (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+    (hq : d ∣ 3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) :
+    d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
+  have hid : (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 =
+      (12 * x + 4 * a₂) * (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆) -
+        (3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) := by
+    ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) hq
+
+/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and `f'(x)²`, then it divides
+the cubic's discriminant.
+
+`Cubic.discr ⟨1, a₂, a₄, a₆⟩` is an explicit combination of `f(x)` and `f'(x)²`, an identity in
+`x`. -/
+theorem dvd_discr (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+    (hderiv : d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2) :
+    d ∣ (_root_.Cubic.mk 1 a₂ a₄ a₆).discr := by
+  have hid : (_root_.Cubic.mk 1 a₂ a₄ a₆).discr =
+      (27 * x ^ 3 + 27 * a₂ * x ^ 2 + 27 * a₄ * x - 4 * a₂ ^ 3 + 18 * a₂ * a₄ - 27 * a₆) *
+          (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
+        - (3 * x ^ 2 + 2 * a₂ * x - a₂ ^ 2 + 4 * a₄) * (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
+    simp only [_root_.Cubic.discr]; ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) (Dvd.dvd.mul_left hderiv _)
+
+end Cubic
+
 namespace WeierstrassCurve
+
+open Polynomial
 
 variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
 
-/-- For a model with `a₁ = a₃ = 0`, the square of the derivative of the defining cubic differs from
-`Ψ₃(x)` by a multiple of `y²`, so `y² ∣ Ψ₃(x)` forces `y² ∣ (3x² + 2a₂x + a₄)²`. -/
-theorem sq_dvd_derivative_sq (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
-    (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
-    (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) : y ^ 2 ∣ (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
-  have hid : (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 =
-      (12 * x + 4 * W.a₂) * y ^ 2 - (W.Ψ₃).eval x := by
-    simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.b₂,
-      _root_.WeierstrassCurve.b₄, _root_.WeierstrassCurve.b₆, _root_.WeierstrassCurve.b₈,
-      ha₁, ha₃, eval_add, eval_mul, eval_pow, eval_C, eval_X, eval_ofNat]
-    rw [hcurve]; ring
-  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _) hΨ₃
-
-/-- The discriminant of `x³ + a₂x² + a₄x + a₆` is a combination of `y²` and the square of the
-cubic's derivative, so `y²` divides it as soon as it divides that square.
-
-This step needs neither `a₁ = a₃ = 0` nor anything about `Ψ₃`: only the curve equation and the
-divisibility of the derivative square. -/
-theorem sq_dvd_cubic_discr_of_sq_dvd_derivative_sq
-    (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
-    (hderiv : y ^ 2 ∣ (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2) :
-    y ^ 2 ∣ (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr := by
-  have hid : (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr =
-      (27 * x ^ 3 + 27 * W.a₂ * x ^ 2 + 27 * W.a₄ * x - 4 * W.a₂ ^ 3 + 18 * W.a₂ * W.a₄
-          - 27 * W.a₆) * y ^ 2
-        - (3 * x ^ 2 + 2 * W.a₂ * x - W.a₂ ^ 2 + 4 * W.a₄) *
-          (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
-    simp only [Cubic.discr]
-    rw [hcurve]; ring
-  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _) (Dvd.dvd.mul_left hderiv _)
+/-- For a model with `a₁ = a₃ = 0`, the univariate `Ψ₃` is the quartic
+`3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`. -/
+theorem eval_Ψ₃_of_a₁_eq_zero_of_a₃_eq_zero (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0) :
+    (W.Ψ₃).eval x = 3 * x ^ 4 + 4 * W.a₂ * x ^ 3 + 6 * W.a₄ * x ^ 2 + 12 * W.a₆ * x +
+      (4 * W.a₂ * W.a₆ - W.a₄ ^ 2) := by
+  simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.b₂, _root_.WeierstrassCurve.b₄,
+    _root_.WeierstrassCurve.b₆, _root_.WeierstrassCurve.b₈, ha₁, ha₃, eval_add, eval_mul,
+    eval_pow, eval_C, eval_X, eval_ofNat]
+  ring
 
 /-- **The sharp discriminant divisibility.**
 
@@ -100,9 +125,10 @@ this is the classical `y² ∣ 4a₄³ + 27a₆²` up to sign. -/
 theorem sq_dvd_cubic_discr (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
     (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
     (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) :
-    y ^ 2 ∣ (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr :=
-  sq_dvd_cubic_discr_of_sq_dvd_derivative_sq W hcurve
-    (sq_dvd_derivative_sq W ha₁ ha₃ hcurve hΨ₃)
+    y ^ 2 ∣ (_root_.Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr :=
+  have hf : y ^ 2 ∣ x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆ := hcurve ▸ dvd_rfl
+  Cubic.dvd_discr hf
+    (Cubic.dvd_derivative_sq hf (eval_Ψ₃_of_a₁_eq_zero_of_a₃_eq_zero W ha₁ ha₃ ▸ hΨ₃))
 
 end WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+
+/-!
+# The sharp discriminant divisibility for a model with `a₁ = a₃ = 0`
+
+For a Weierstrass model with `a₁ = a₃ = 0` — so the equation is the cubic
+`y² = x³ + a₂x² + a₄x + a₆` — a point whose `y²` divides `Ψ₃(x)` has `y²` dividing the
+**discriminant of that cubic**, Mathlib's `Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
+
+This is sharper than dividing `Δ`. Mathlib's `twoTorsionPolynomial_discr` records
+`Cubic.discr ⟨4, b₂, 2b₄, b₆⟩ = 16Δ`, and for these models `Δ = −16 · Cubic.discr ⟨1, a₂, a₄, a₆⟩`,
+so the cubic discriminant is the invariant with the factors of `16` divided out. It is the `Δ` of
+the classical statement of Nagell–Lutz for a short model, where `a₂ = 0` too and the conclusion
+reads `y² ∣ 4a₄³ + 27a₆²` up to sign.
+
+The proof is two ring identities over the cubic. Writing `f(x) = x³ + a₂x² + a₄x + a₆`, the
+derivative square `f'(x)² = (3x² + 2a₂x + a₄)²` differs from `Ψ₃(x)` by a multiple of `f(x) = y²`;
+and `Cubic.discr` is an explicit combination of `y²` and `f'(x)²`. So `y² ∣ Ψ₃(x)` propagates to
+`y² ∣ f'(x)²` and then to the discriminant.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.sq_dvd_deriv_sq`: `y² ∣ (3x² + 2a₂x + a₄)²`.
+* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
+
+Both are over an arbitrary commutative ring, for an arbitrary point of the curve — no domain,
+torsion, integrality or ellipticity hypothesis. The input `y² ∣ Ψ₃(x)` is what a torsion point
+supplies through the coordinate formula for `2 • P`; that derivation is not part of this file.
+
+This advances the Nagell–Lutz milestone of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6,
+item "The torsion subgroup and Nagell–Lutz", whose short-model target `lutz_nagell` asks for
+`y = 0 ∨ y² ∣ Δ`; this is the sharp form of that second conjunct.
+
+## Provenance
+
+Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0), pinned by
+that roadmap at `dev/modular-curves @ 9fec8eba7652`:
+`LutzNagell/LutzNagellTheorem/PIDMain.lean`, the algebraic core of
+`lutz_nagell_cubicDisc_discriminant` (:438). The source states the conclusion as the raw polynomial
+`4a₄³ + 27a₆² + 4a₂³a₆ − a₂²a₄² − 18a₂a₄a₆` and reaches it inside a torsion argument; here it is
+the negative of Mathlib's `Cubic.discr`, and the torsion-dependent part — which needs the
+point-level `[n]`-multiplication material — is left out, with `y² ∣ Ψ₃(x)` as a hypothesis instead.
+-/
+
+public section
+
+open Polynomial
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
+
+/-- For a model with `a₁ = a₃ = 0`, the square of the derivative of the defining cubic differs from
+`Ψ₃(x)` by a multiple of `y²`, so `y² ∣ Ψ₃(x)` forces `y² ∣ (3x² + 2a₂x + a₄)²`. -/
+theorem sq_dvd_deriv_sq (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
+    (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
+    (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) : y ^ 2 ∣ (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
+  have hid : (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 =
+      (12 * x + 4 * W.a₂) * y ^ 2 - (W.Ψ₃).eval x := by
+    simp only [_root_.WeierstrassCurve.Ψ₃, _root_.WeierstrassCurve.b₂,
+      _root_.WeierstrassCurve.b₄, _root_.WeierstrassCurve.b₆, _root_.WeierstrassCurve.b₈,
+      ha₁, ha₃, eval_add, eval_mul, eval_pow, eval_C, eval_X, eval_ofNat]
+    rw [hcurve]; ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _) hΨ₃
+
+/-- **The sharp discriminant divisibility.**
+
+For a model with `a₁ = a₃ = 0`, a point whose `y²` divides `Ψ₃(x)` has `y²` dividing the
+discriminant of the defining cubic `x³ + a₂x² + a₄x + a₆`. For a short model (`a₂ = 0` as well)
+this is the classical `y² ∣ 4a₄³ + 27a₆²` up to sign. -/
+theorem sq_dvd_cubic_discr (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
+    (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
+    (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) :
+    y ^ 2 ∣ (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr := by
+  have hid : (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr =
+      (27 * x ^ 3 + 27 * W.a₂ * x ^ 2 + 27 * W.a₄ * x - 4 * W.a₂ ^ 3 + 18 * W.a₂ * W.a₄
+          - 27 * W.a₆) * y ^ 2
+        - (3 * x ^ 2 + 2 * W.a₂ * x - W.a₂ ^ 2 + 4 * W.a₄) *
+          (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
+    simp only [Cubic.discr]
+    rw [hcurve]; ring
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _)
+    (Dvd.dvd.mul_left (sq_dvd_deriv_sq W ha₁ ha₃ hcurve hΨ₃) _)
+
+end WeierstrassCurve
+
+end TauCeti

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -5,6 +5,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 module
 
 public import Mathlib.AlgebraicGeometry.EllipticCurve.DivisionPolynomial.Basic
+public import TauCeti.Algebra.CubicDiscriminant
 
 /-!
 # The sharp discriminant divisibility for a model with `a₁ = a₃ = 0`
@@ -26,29 +27,30 @@ The proof is two ring identities, and neither mentions a curve. Writing
 
 so anything dividing `f(x)` and `Q(x)` divides `f'(x)²`; the second expresses
 `Cubic.discr ⟨1, a₂, a₄, a₆⟩` as a combination of `f(x)` and `f'(x)²`. Both are stated for an
-arbitrary divisor `d`, in a namespace about cubics rather than curves. `Ψ₃` enters only at the end:
-for `a₁ = a₃ = 0` it evaluates to exactly that `Q(x)`, and the curve equation makes `y²` a divisor
-of `f(x)`.
+arbitrary divisor `d`. Both are pure cubic algebra and live in `TauCeti.Algebra.CubicDiscriminant`
+(`TauCeti.Cubic.dvd_derivative_sq` and `TauCeti.Cubic.dvd_discr`), which this file imports. `Ψ₃`
+enters only here: for `a₁ = a₃ = 0` it evaluates to exactly that `Q(x)`, and the curve equation
+makes `y²` a divisor of `f(x)`.
 
 ## Main results
 
-* `TauCeti.Cubic.dvd_derivative_sq`: a divisor of `f(x)` and of `Q(x)` divides `f'(x)²`.
-* `TauCeti.Cubic.dvd_discr`: a divisor of `f(x)` and of `f'(x)²` divides
-  `Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
 * `TauCeti.WeierstrassCurve.eval_Ψ₃_of_a₁_eq_zero_of_a₃_eq_zero`: for `a₁ = a₃ = 0`, `Ψ₃` is `Q`.
 * `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`, the three
   composed.
 
-The first two are about coefficients `a₂ a₄ a₆ : R` and an arbitrary divisor `d`, with no
-Weierstrass curve and no `y²` in sight; only the last is curve-specific.
-
 Both are over an arbitrary commutative ring, for an arbitrary point of the curve — no domain,
-torsion, integrality or ellipticity hypothesis. The input `y² ∣ Ψ₃(x)` is what a torsion point
-supplies through the coordinate formula for `2 • P`; that derivation is not part of this file.
+torsion, integrality or ellipticity hypothesis.
 
-This advances the Nagell–Lutz milestone of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 6,
-item "The torsion subgroup and Nagell–Lutz", whose short-model target `lutz_nagell` asks for
-`y = 0 ∨ y² ∣ Δ`; this is the sharp form of that second conjunct.
+⚠ The input `y² ∣ Ψ₃(x)` is a hypothesis, and it is **not** something torsion alone provides. Over
+an arbitrary commutative ring finite order says nothing about divisibility; the divisibility is
+extracted in the integral Nagell–Lutz setting, from the coordinate formula for `2 • P` together
+with the integrality of the coordinates. Both of those are point-level results that this file does
+not contain. Read the hypothesis as the shape a later torsion argument is expected to supply, not
+as a consequence of torsion.
+
+This is an ingredient for the Nagell–Lutz milestone of `TauCetiRoadmap/EllipticCurves/README.md`,
+Layer 6, item "The torsion subgroup and Nagell–Lutz", whose short-model target `lutz_nagell` asks
+for `y = 0 ∨ y² ∣ Δ`; it is the sharp algebraic form of that second conjunct's divisibility step.
 
 ## Provenance
 
@@ -66,40 +68,6 @@ public section
 open Polynomial
 
 namespace TauCeti
-
-namespace Cubic
-
-variable {R : Type*} [CommRing R] {d a₂ a₄ a₆ x : R}
-
-/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and the quartic
-`3x⁴ + 4a₂x³ + 6a₄x² + 12a₆x + (4a₂a₆ − a₄²)`, then it divides `f'(x)²`.
-
-The two are related by `f'(x)² + (that quartic) = (12x + 4a₂) · f(x)`, an identity in `x`. -/
-theorem dvd_derivative_sq (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
-    (hq : d ∣ 3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) :
-    d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
-  have hid : (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 =
-      (12 * x + 4 * a₂) * (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆) -
-        (3 * x ^ 4 + 4 * a₂ * x ^ 3 + 6 * a₄ * x ^ 2 + 12 * a₆ * x + (4 * a₂ * a₆ - a₄ ^ 2)) := by
-    ring
-  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) hq
-
-/-- If `d` divides both the monic cubic `f(x) = x³ + a₂x² + a₄x + a₆` and `f'(x)²`, then it divides
-the cubic's discriminant.
-
-`Cubic.discr ⟨1, a₂, a₄, a₆⟩` is an explicit combination of `f(x)` and `f'(x)²`, an identity in
-`x`. -/
-theorem dvd_discr (hf : d ∣ x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
-    (hderiv : d ∣ (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2) :
-    d ∣ (_root_.Cubic.mk 1 a₂ a₄ a₆).discr := by
-  have hid : (_root_.Cubic.mk 1 a₂ a₄ a₆).discr =
-      (27 * x ^ 3 + 27 * a₂ * x ^ 2 + 27 * a₄ * x - 4 * a₂ ^ 3 + 18 * a₂ * a₄ - 27 * a₆) *
-          (x ^ 3 + a₂ * x ^ 2 + a₄ * x + a₆)
-        - (3 * x ^ 2 + 2 * a₂ * x - a₂ ^ 2 + 4 * a₄) * (3 * x ^ 2 + 2 * a₂ * x + a₄) ^ 2 := by
-    simp only [_root_.Cubic.discr]; ring
-  exact hid ▸ dvd_sub (Dvd.dvd.mul_left hf _) (Dvd.dvd.mul_left hderiv _)
-
-end Cubic
 
 namespace WeierstrassCurve
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean
@@ -14,7 +14,7 @@ For a Weierstrass model with `a₁ = a₃ = 0` — so the equation is the cubic
 **discriminant of that cubic**, Mathlib's `Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
 
 This is sharper than dividing `Δ`. Mathlib's `twoTorsionPolynomial_discr` records
-`Cubic.discr ⟨4, b₂, 2b₄, b₆⟩ = 16Δ`, and for these models `Δ = −16 · Cubic.discr ⟨1, a₂, a₄, a₆⟩`,
+`Cubic.discr ⟨4, b₂, 2b₄, b₆⟩ = 16Δ`, and for these models `Δ = 16 · Cubic.discr ⟨1, a₂, a₄, a₆⟩`,
 so the cubic discriminant is the invariant with the factors of `16` divided out. It is the `Δ` of
 the classical statement of Nagell–Lutz for a short model, where `a₂ = 0` too and the conclusion
 reads `y² ∣ 4a₄³ + 27a₆²` up to sign.
@@ -26,8 +26,11 @@ and `Cubic.discr` is an explicit combination of `y²` and `f'(x)²`. So `y² ∣
 
 ## Main results
 
-* `TauCeti.WeierstrassCurve.sq_dvd_deriv_sq`: `y² ∣ (3x² + 2a₂x + a₄)²`.
-* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`.
+* `TauCeti.WeierstrassCurve.sq_dvd_derivative_sq`: `y² ∣ (3x² + 2a₂x + a₄)²`.
+* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr_of_sq_dvd_derivative_sq`: the discriminant step on
+  its own — no `a₁ = a₃ = 0`, no `Ψ₃`, just the curve equation and that divisibility.
+* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr`: `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`, the two
+  composed.
 
 Both are over an arbitrary commutative ring, for an arbitrary point of the curve — no domain,
 torsion, integrality or ellipticity hypothesis. The input `y² ∣ Ψ₃(x)` is what a torsion point
@@ -60,7 +63,7 @@ variable {R : Type*} [CommRing R] (W : _root_.WeierstrassCurve R) {x y : R}
 
 /-- For a model with `a₁ = a₃ = 0`, the square of the derivative of the defining cubic differs from
 `Ψ₃(x)` by a multiple of `y²`, so `y² ∣ Ψ₃(x)` forces `y² ∣ (3x² + 2a₂x + a₄)²`. -/
-theorem sq_dvd_deriv_sq (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
+theorem sq_dvd_derivative_sq (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
     (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
     (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) : y ^ 2 ∣ (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
   have hid : (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 =
@@ -71,14 +74,14 @@ theorem sq_dvd_deriv_sq (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
     rw [hcurve]; ring
   exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _) hΨ₃
 
-/-- **The sharp discriminant divisibility.**
+/-- The discriminant of `x³ + a₂x² + a₄x + a₆` is a combination of `y²` and the square of the
+cubic's derivative, so `y²` divides it as soon as it divides that square.
 
-For a model with `a₁ = a₃ = 0`, a point whose `y²` divides `Ψ₃(x)` has `y²` dividing the
-discriminant of the defining cubic `x³ + a₂x² + a₄x + a₆`. For a short model (`a₂ = 0` as well)
-this is the classical `y² ∣ 4a₄³ + 27a₆²` up to sign. -/
-theorem sq_dvd_cubic_discr (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
+This step needs neither `a₁ = a₃ = 0` nor anything about `Ψ₃`: only the curve equation and the
+divisibility of the derivative square. -/
+theorem sq_dvd_cubic_discr_of_sq_dvd_derivative_sq
     (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
-    (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) :
+    (hderiv : y ^ 2 ∣ (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2) :
     y ^ 2 ∣ (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr := by
   have hid : (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr =
       (27 * x ^ 3 + 27 * W.a₂ * x ^ 2 + 27 * W.a₄ * x - 4 * W.a₂ ^ 3 + 18 * W.a₂ * W.a₄
@@ -87,8 +90,19 @@ theorem sq_dvd_cubic_discr (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
           (3 * x ^ 2 + 2 * W.a₂ * x + W.a₄) ^ 2 := by
     simp only [Cubic.discr]
     rw [hcurve]; ring
-  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _)
-    (Dvd.dvd.mul_left (sq_dvd_deriv_sq W ha₁ ha₃ hcurve hΨ₃) _)
+  exact hid ▸ dvd_sub (Dvd.dvd.mul_left dvd_rfl _) (Dvd.dvd.mul_left hderiv _)
+
+/-- **The sharp discriminant divisibility.**
+
+For a model with `a₁ = a₃ = 0`, a point whose `y²` divides `Ψ₃(x)` has `y²` dividing the
+discriminant of the defining cubic `x³ + a₂x² + a₄x + a₆`. For a short model (`a₂ = 0` as well)
+this is the classical `y² ∣ 4a₄³ + 27a₆²` up to sign. -/
+theorem sq_dvd_cubic_discr (ha₁ : W.a₁ = 0) (ha₃ : W.a₃ = 0)
+    (hcurve : y ^ 2 = x ^ 3 + W.a₂ * x ^ 2 + W.a₄ * x + W.a₆)
+    (hΨ₃ : y ^ 2 ∣ (W.Ψ₃).eval x) :
+    y ^ 2 ∣ (Cubic.mk 1 W.a₂ W.a₄ W.a₆).discr :=
+  sq_dvd_cubic_discr_of_sq_dvd_derivative_sq W hcurve
+    (sq_dvd_derivative_sq W ha₁ ha₃ hcurve hΨ₃)
 
 end WeierstrassCurve
 


### PR DESCRIPTION
The **sharp** form of the discriminant half of Nagell–Lutz, for a model with `a₁ = a₃ = 0` — so the
equation is the cubic `y² = x³ + a₂x² + a₄x + a₆`.

* `TauCeti.WeierstrassCurve.sq_dvd_derivative_sq` — `y² ∣ (3x² + 2a₂x + a₄)²`.
* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr_of_sq_dvd_derivative_sq` — the discriminant step on
  its own: only the curve equation and that divisibility, no `a₁ = a₃ = 0` and no `Ψ₃`.
* `TauCeti.WeierstrassCurve.sq_dvd_cubic_discr` — `y² ∣ Cubic.discr ⟨1, a₂, a₄, a₆⟩`, the two
  composed.

⚠ **Scope:** the input `y² ∣ Ψ₃(x)` is a hypothesis. It is what a torsion point supplies through
the coordinate formula for `2 • P`, but that derivation needs the point-level `[n]`-material and is
not proved here — so no torsion statement, and no part of `lutz_nagell` itself, is established by
this PR.

Why "sharp": Mathlib's `twoTorsionPolynomial_discr` records `Cubic.discr ⟨4, b₂, 2b₄, b₆⟩ = 16Δ`,
and for these models `Δ = 16 · Cubic.discr ⟨1, a₂, a₄, a₆⟩`. So dividing the *cubic* discriminant
is the statement with the factors of `16` divided out — strictly stronger than dividing `Δ`, and it
is the `Δ` of the classical statement of Nagell–Lutz, which for a short model (`a₂ = 0` as well)
reads `y² ∣ 4a₄³ + 27a₆²` up to sign.

The proof is two ring identities over the cubic. Writing `f(x) = x³ + a₂x² + a₄x + a₆`: the
derivative square `f'(x)² = (3x² + 2a₂x + a₄)²` differs from `Ψ₃(x)` by a multiple of
`f(x) = y²`, and `Cubic.discr` is an explicit combination of `y²` and `f'(x)²`. So `y² ∣ Ψ₃(x)`
propagates first to `y² ∣ f'(x)²` and then to the discriminant.

Everything is over an arbitrary commutative ring, for an arbitrary point — no domain, torsion,
integrality or `IsElliptic` hypothesis. The input `y² ∣ Ψ₃(x)` is what a torsion point supplies
through the coordinate formula for `2 • P`; that derivation needs the point-level `[n]`-material and
is not in this PR.

### Relation to #2287

#2287 proves the same shape for a **general** model, in the form `ψ₂(x, y) = 0 ∨ ψ₂(x, y)² ∣ 4Δ`.
This PR is the specialisation to `a₁ = a₃ = 0` with the factors of `4` and `16` removed, which is
what makes it the classical statement. The two are independent files with no import between them —
this one takes `y² ∣ Ψ₃(x)` directly rather than routing through `ψ₂`, since with `a₁ = a₃ = 0` the
relation `ψ₂(x, y) = 2y` would only reintroduce the factor of `4` that the sharp form removes.

### Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 6**, item "The torsion subgroup and Nagell–Lutz".
The short-model target `lutz_nagell` asks for `x, y ∈ ℤ` and `y = 0 ∨ y² ∣ Δ`; this is the sharp
form of that second conjunct.

This PR is independent: it imports one Mathlib module and **no** TauCeti module.

### Provenance

Ported from the AINTLIB `NagellLutz` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, pinned by
the roadmap at `dev/modular-curves @ 9fec8eba7652`),
`LutzNagell/LutzNagellTheorem/PIDMain.lean`: the algebraic core of
`lutz_nagell_cubicDisc_discriminant` (:438).

Divergences from the source: it states the conclusion as the raw polynomial
`4a₄³ + 27a₆² + 4a₂³a₆ − a₂²a₄² − 18a₂a₄a₆`, where here it is (the negative of) Mathlib's
`Cubic.discr`, so the result lands in the library's own vocabulary; and the source reaches it inside
a torsion argument resting on its `ZSMul.lean` (Angdinata mathlib-track material), whereas here the
torsion-dependent part is left out and `y² ∣ Ψ₃(x)` is a hypothesis. Nothing is vendored.

A pre-review pass reported three findings, all applied before marking ready. `documentation`
caught a real error: I had written `Δ = −16 · Cubic.discr`, where the `b`-invariants give
`Δ = +16 · Cubic.discr` — verified symbolically before correcting. `generality`: the discriminant
step needs only the curve equation and divisibility of the derivative square, so it is now the
standalone `sq_dvd_cubic_discr_of_sq_dvd_derivative_sq` with the `Ψ₃` version as its corollary.
`naming`: `deriv` → `derivative`, per Mathlib's polynomial API.

New file `TauCeti/AlgebraicGeometry/EllipticCurve/DivisionPolynomial/CubicDiscriminant.lean`,
~110 lines; longest proof 10 lines; no existing file touched.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/README.md#layer-6-nagell-lutz-sharp-cubic-discriminant"}-->
