### PR TITLE
refactor(Sobolev): decompose the slab Poincaré proof into line lemmas

### DIFF
--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -251,17 +251,18 @@ private theorem hasDerivAt_comp_slabChart (y : Fin n → ℝ) {t : ℝ}
 
 omit [CompleteSpace F] in
 /-- The one-dimensional estimate on a single line of the slab: the `r`-th power integral of `u`
-along the line is at most `(b - a) ^ r` times that of the full derivative. Only differentiability
-of `u` and continuity of its derivative *along that line* are needed. -/
+along the line is at most `(b - a) ^ r` times that of the full derivative. Everything is asked of
+the restricted line only: differentiability of `u` along it, continuity of the *directional*
+derivative along it, and the support of the restriction. -/
 private theorem lintegral_enorm_rpow_comp_slabChart_le {y : Fin n → ℝ}
     (hu : ∀ t : ℝ, DifferentiableAt ℝ u (slabChart i (t, y)))
-    (hfc : Continuous fun t : ℝ => fderiv ℝ u (slabChart i (t, y))) (hab : a ≤ b)
-    (hsupp : ∀ x ∈ Function.support u, x i ∈ Icc a b) {r : ℝ} (hr : 1 ≤ r) :
+    (hfc : Continuous fun t : ℝ => fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1))
+    (hab : a ≤ b) (hsupp : Function.support (fun t : ℝ => u (slabChart i (t, y))) ⊆ Icc a b)
+    {r : ℝ} (hr : 1 ≤ r) :
     ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r
       ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := by
   refine le_trans (lintegral_enorm_rpow_le_of_support_subset_Icc hab
-    (fun t => hasDerivAt_comp_slabChart y (hu t)) (hfc.clm_apply continuous_const)
-    (fun t ht => by simpa using hsupp _ (Function.mem_support.2 ht)) hr) ?_
+    (fun t => hasDerivAt_comp_slabChart y (hu t)) hfc hsupp hr) ?_
   gcongr with t
   rw [← ofReal_norm, ← ofReal_norm]
   refine ENNReal.ofReal_le_ofReal ?_
@@ -294,7 +295,9 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (hu : ContDiff ℝ 1 u)
       ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := fun y =>
     lintegral_enorm_rpow_comp_slabChart_le
       (fun _ => (hu.differentiable one_ne_zero).differentiableAt)
-      (hfc.comp (by simp only [slabChart_eq_add_smul_single]; fun_prop)) hab hsupp hr
+      (((hfc.comp (by simp only [slabChart_eq_add_smul_single]; fun_prop)).clm_apply
+        continuous_const)) hab
+      (fun t ht => by simpa using hsupp _ (Function.mem_support.2 ht)) hr
   calc ∫⁻ x, ‖u x‖ₑ ^ r
       = ∫⁻ y, ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r := lintegral_eq_lintegral_slabChart hmu
     _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -235,6 +235,38 @@ private theorem lintegral_eq_lintegral_slabChart {w : EuclideanSpace ℝ (Fin (n
     (hw.comp (measurePreserving_slabChart (i := i)).measurable).aemeasurable
 
 omit [CompleteSpace F] in
+/-- Along the line `t ↦ slabChart i (t, y)`, the function `u` has derivative the directional
+derivative of `u` in the `i`-th coordinate direction. -/
+private theorem hasDerivAt_comp_slabChart (hu : ContDiff ℝ 1 u) (y : Fin n → ℝ) (t : ℝ) :
+    HasDerivAt (fun s => u (slabChart i (s, y)))
+      (fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1)) t := by
+  have hl : HasDerivAt (fun s : ℝ => slabChart i (s, y)) (EuclideanSpace.single i 1) t := by
+    simp only [slabChart_eq_add_smul_single]
+    have hid : HasDerivAt (fun s : ℝ => s) 1 t := hasDerivAt_id t
+    simpa using _root_.HasDerivAt.const_add (WithLp.toLp 2 (i.insertNth (0 : ℝ) y))
+      (_root_.HasDerivAt.smul_const hid (EuclideanSpace.single i (1 : ℝ)))
+  exact (hu.differentiable one_ne_zero).differentiableAt.hasFDerivAt.comp_hasDerivAt t hl
+
+omit [CompleteSpace F] in
+/-- The one-dimensional estimate on a single line of the slab: the `r`-th power integral of `u`
+along the line is at most `(b - a) ^ r` times that of the full derivative. -/
+private theorem lintegral_enorm_rpow_comp_slabChart_le (hu : ContDiff ℝ 1 u) (hab : a ≤ b)
+    (hsupp : ∀ x ∈ Function.support u, x i ∈ Icc a b) {r : ℝ} (hr : 1 ≤ r) (y : Fin n → ℝ) :
+    ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r
+      ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := by
+  have hfc : Continuous (fderiv ℝ u) := hu.continuous_fderiv one_ne_zero
+  have hlinecont : Continuous fun t : ℝ => slabChart i (t, y) := by
+    simp only [slabChart_eq_add_smul_single]
+    fun_prop
+  refine le_trans (lintegral_enorm_rpow_le_of_support_subset_Icc hab
+    (hasDerivAt_comp_slabChart hu y) ((hfc.comp hlinecont).clm_apply continuous_const)
+    (fun t ht => by simpa using hsupp _ (Function.mem_support.2 ht)) hr) ?_
+  gcongr with t
+  rw [← ofReal_norm, ← ofReal_norm]
+  refine ENNReal.ofReal_le_ofReal ?_
+  simpa using (fderiv ℝ u (slabChart i (t, y))).le_opNorm (EuclideanSpace.single i 1)
+
+omit [CompleteSpace F] in
 /-- **The Poincaré inequality on a slab.** A `C¹` function on `ℝ^{n+1}` that vanishes outside
 the slab `{x | x i ∈ Set.Icc a b}` satisfies `‖u‖_p ≤ (b - a) ‖Du‖_p` for every `1 ≤ p < ∞`.
 
@@ -253,45 +285,14 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (hu : ContDiff ℝ 1 u)
   refine eLpNorm_le_eLpNorm_of_lintegral_rpow_le (sub_nonneg.2 hab)
     (zero_lt_one.trans_le hp).ne' hp' ?_
   set r := p.toReal
-  -- Restricted to a line in the `i`-th coordinate direction, `u` is a `C¹` function of one
-  -- variable supported in `Set.Icc a b`.
-  have hlinecont : ∀ y : Fin n → ℝ, Continuous fun t : ℝ => slabChart i (t, y) := by
-    intro y
-    simp only [slabChart_eq_add_smul_single]
-    fun_prop
-  have hderiv : ∀ (y : Fin n → ℝ) (t : ℝ),
-      HasDerivAt (fun s => u (slabChart i (s, y)))
-        (fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1)) t := by
-    intro y t
-    have hl : HasDerivAt (fun s : ℝ => slabChart i (s, y)) (EuclideanSpace.single i 1) t := by
-      simp only [slabChart_eq_add_smul_single]
-      have hid : HasDerivAt (fun s : ℝ => s) 1 t := hasDerivAt_id t
-      simpa using _root_.HasDerivAt.const_add (WithLp.toLp 2 (i.insertNth (0 : ℝ) y))
-        (_root_.HasDerivAt.smul_const hid (EuclideanSpace.single i (1 : ℝ)))
-    exact (hu.differentiable one_ne_zero).differentiableAt.hasFDerivAt.comp_hasDerivAt t hl
-  have hcont : ∀ y : Fin n → ℝ,
-      Continuous fun t => fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1) :=
-    fun y => (hfc.comp (hlinecont y)).clm_apply continuous_const
-  have hsuppline : ∀ y : Fin n → ℝ,
-      Function.support (fun t => u (slabChart i (t, y))) ⊆ Icc a b := by
-    intro y t ht
-    simpa using hsupp _ (Function.mem_support.2 ht)
   have hmu : Measurable fun x : EuclideanSpace ℝ (Fin (n + 1)) => ‖u x‖ₑ ^ r :=
     (ENNReal.continuous_rpow_const.comp hu.continuous.enorm).measurable
   have hmf : Measurable fun x : EuclideanSpace ℝ (Fin (n + 1)) => ‖fderiv ℝ u x‖ₑ ^ r :=
     (ENNReal.continuous_rpow_const.comp hfc.enorm).measurable
   calc ∫⁻ x, ‖u x‖ₑ ^ r
       = ∫⁻ y, ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r := lintegral_eq_lintegral_slabChart hmu
-    _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) *
-          ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1)‖ₑ ^ r :=
-        lintegral_mono fun y => lintegral_enorm_rpow_le_of_support_subset_Icc hab (hderiv y)
-          (hcont y) (hsuppline y) hr
-    _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := by
-        refine lintegral_mono fun y => ?_
-        gcongr with t
-        rw [← ofReal_norm, ← ofReal_norm]
-        refine ENNReal.ofReal_le_ofReal ?_
-        simpa using (fderiv ℝ u (slabChart i (t, y))).le_opNorm (EuclideanSpace.single i 1)
+    _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
+        lintegral_mono (lintegral_enorm_rpow_comp_slabChart_le hu hab hsupp hr)
     _ = ENNReal.ofReal ((b - a) ^ r) *
           ∫⁻ y, ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
         lintegral_const_mul' _ _ (by finiteness)

--- a/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
+++ b/TauCeti/Analysis/Sobolev/Poincare/Slab.lean
@@ -236,8 +236,10 @@ private theorem lintegral_eq_lintegral_slabChart {w : EuclideanSpace ℝ (Fin (n
 
 omit [CompleteSpace F] in
 /-- Along the line `t ↦ slabChart i (t, y)`, the function `u` has derivative the directional
-derivative of `u` in the `i`-th coordinate direction. -/
-private theorem hasDerivAt_comp_slabChart (hu : ContDiff ℝ 1 u) (y : Fin n → ℝ) (t : ℝ) :
+derivative of `u` in the `i`-th coordinate direction. Only differentiability at the single point
+of the line is needed. -/
+private theorem hasDerivAt_comp_slabChart (y : Fin n → ℝ) {t : ℝ}
+    (hu : DifferentiableAt ℝ u (slabChart i (t, y))) :
     HasDerivAt (fun s => u (slabChart i (s, y)))
       (fderiv ℝ u (slabChart i (t, y)) (EuclideanSpace.single i 1)) t := by
   have hl : HasDerivAt (fun s : ℝ => slabChart i (s, y)) (EuclideanSpace.single i 1) t := by
@@ -245,21 +247,20 @@ private theorem hasDerivAt_comp_slabChart (hu : ContDiff ℝ 1 u) (y : Fin n →
     have hid : HasDerivAt (fun s : ℝ => s) 1 t := hasDerivAt_id t
     simpa using _root_.HasDerivAt.const_add (WithLp.toLp 2 (i.insertNth (0 : ℝ) y))
       (_root_.HasDerivAt.smul_const hid (EuclideanSpace.single i (1 : ℝ)))
-  exact (hu.differentiable one_ne_zero).differentiableAt.hasFDerivAt.comp_hasDerivAt t hl
+  exact hu.hasFDerivAt.comp_hasDerivAt t hl
 
 omit [CompleteSpace F] in
 /-- The one-dimensional estimate on a single line of the slab: the `r`-th power integral of `u`
-along the line is at most `(b - a) ^ r` times that of the full derivative. -/
-private theorem lintegral_enorm_rpow_comp_slabChart_le (hu : ContDiff ℝ 1 u) (hab : a ≤ b)
-    (hsupp : ∀ x ∈ Function.support u, x i ∈ Icc a b) {r : ℝ} (hr : 1 ≤ r) (y : Fin n → ℝ) :
+along the line is at most `(b - a) ^ r` times that of the full derivative. Only differentiability
+of `u` and continuity of its derivative *along that line* are needed. -/
+private theorem lintegral_enorm_rpow_comp_slabChart_le {y : Fin n → ℝ}
+    (hu : ∀ t : ℝ, DifferentiableAt ℝ u (slabChart i (t, y)))
+    (hfc : Continuous fun t : ℝ => fderiv ℝ u (slabChart i (t, y))) (hab : a ≤ b)
+    (hsupp : ∀ x ∈ Function.support u, x i ∈ Icc a b) {r : ℝ} (hr : 1 ≤ r) :
     ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r
       ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := by
-  have hfc : Continuous (fderiv ℝ u) := hu.continuous_fderiv one_ne_zero
-  have hlinecont : Continuous fun t : ℝ => slabChart i (t, y) := by
-    simp only [slabChart_eq_add_smul_single]
-    fun_prop
   refine le_trans (lintegral_enorm_rpow_le_of_support_subset_Icc hab
-    (hasDerivAt_comp_slabChart hu y) ((hfc.comp hlinecont).clm_apply continuous_const)
+    (fun t => hasDerivAt_comp_slabChart y (hu t)) (hfc.clm_apply continuous_const)
     (fun t ht => by simpa using hsupp _ (Function.mem_support.2 ht)) hr) ?_
   gcongr with t
   rw [← ofReal_norm, ← ofReal_norm]
@@ -289,10 +290,15 @@ theorem eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab (hu : ContDiff ℝ 1 u)
     (ENNReal.continuous_rpow_const.comp hu.continuous.enorm).measurable
   have hmf : Measurable fun x : EuclideanSpace ℝ (Fin (n + 1)) => ‖fderiv ℝ u x‖ₑ ^ r :=
     (ENNReal.continuous_rpow_const.comp hfc.enorm).measurable
+  have hline : ∀ y : Fin n → ℝ, ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r
+      ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r := fun y =>
+    lintegral_enorm_rpow_comp_slabChart_le
+      (fun _ => (hu.differentiable one_ne_zero).differentiableAt)
+      (hfc.comp (by simp only [slabChart_eq_add_smul_single]; fun_prop)) hab hsupp hr
   calc ∫⁻ x, ‖u x‖ₑ ^ r
       = ∫⁻ y, ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r := lintegral_eq_lintegral_slabChart hmu
     _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
-        lintegral_mono (lintegral_enorm_rpow_comp_slabChart_le hu hab hsupp hr)
+        lintegral_mono hline
     _ = ENNReal.ofReal ((b - a) ^ r) *
           ∫⁻ y, ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
         lintegral_const_mul' _ _ (by finiteness)


### PR DESCRIPTION
`eLpNorm_le_eLpNorm_fderiv_of_support_subset_slab` ran to 52 lines because it did three
separate things inline: it differentiated `u` along a line of the slab, it ran the
one-dimensional estimate on that line, and it sandwiched the result between two Fubini
rewrites. Only the third is really about the slab; the first two are facts about a single
line, and this states them as such.

## The helpers

* `hasDerivAt_comp_slabChart` — along `t ↦ slabChart i (t, y)`, `u` has derivative
  `fderiv ℝ u · (EuclideanSpace.single i 1)`. This is the chain rule against the affine
  parametrisation of the line: it needs nothing about the support, and nothing about `u`
  beyond `DifferentiableAt` at the single point it differentiates at.
* `lintegral_enorm_rpow_comp_slabChart_le` — the one-dimensional estimate on one line:
  `∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r ≤ ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r`.
  It applies `lintegral_enorm_rpow_le_of_support_subset_Icc` to the line and then passes
  from the directional derivative to the full derivative by `le_opNorm`, which is the only
  place the operator norm is used. Its hypotheses are differentiability of `u` along its own
  line and continuity of the derivative restricted to that line — not the caller's global
  `ContDiff`.

Both take `r` as a real parameter rather than `p.toReal`, so neither mentions `p` or
`eLpNorm`; the exponent bookkeeping stays in the caller.

## What is left

The main proof is now the Fubini sandwich it always was:

```lean
calc ∫⁻ x, ‖u x‖ₑ ^ r
    = ∫⁻ y, ∫⁻ t, ‖u (slabChart i (t, y))‖ₑ ^ r := lintegral_eq_lintegral_slabChart hmu
  _ ≤ ∫⁻ y, ENNReal.ofReal ((b - a) ^ r) * ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
      lintegral_mono hline
  _ = ENNReal.ofReal ((b - a) ^ r) *
        ∫⁻ y, ∫⁻ t, ‖fderiv ℝ u (slabChart i (t, y))‖ₑ ^ r :=
      lintegral_const_mul' _ _ (by finiteness)
  _ = ENNReal.ofReal ((b - a) ^ r) * ∫⁻ x, ‖fderiv ℝ u x‖ₑ ^ r := by
      rw [lintegral_eq_lintegral_slabChart hmf]
```

## Scope

The statement and docstring of the public theorem are unchanged, and both helpers are
`private`; the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all
green; no new lint violations. Proof body 52 → 26 lines, with helpers at 9 and 10.

Roadmap: PDE
