### PR TITLE
feat(EllipticCurve): the affine points over a finite ring form a finite type

### DIFF
--- a/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FinitePoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FinitePoint.lean
@@ -13,17 +13,14 @@ public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
 anything: `Nat.card` reads `0` on an infinite type, so a statement like the Hasse bound is only the
 honest count when accompanied by finiteness.
 
-The proof is the obvious one — a point is either the point at infinity or a pair `(x, y)` of ring
-elements, and `Nonsingular` is a proposition, so `Point` injects into `Option (R × R)`.
-
 ## Main results
 
 * `TauCeti.WeierstrassCurve.Affine.finite_point`: `W.Point` is finite whenever the base is.
 
 Stated over an arbitrary finite commutative ring and an arbitrary affine Weierstrass curve: neither
-a field nor `IsElliptic` is needed, since the argument never leaves the underlying inductive type.
-The roadmap seeds this over a finite field with `[W.IsElliptic]`; that form is discharged by
-`inferInstance` from the instance below, which I checked before writing this.
+a field nor `IsElliptic` is needed. The roadmap seeds this over a finite field with
+`[W.IsElliptic]`; that form is discharged by `inferInstance` from the instance below, which I
+checked before writing this.
 
 It is an `instance`, so `Nat.card`/`Finset` arguments about `E(𝔽_q)` pick it up without being
 handed a proof. It is named — contrary to the usual preference for anonymous instances — because
@@ -51,16 +48,14 @@ namespace Affine
 
 variable {R : Type*} [CommRing R] [Finite R] (W : _root_.WeierstrassCurve.Affine R)
 
-/-- **The affine points of a Weierstrass curve over a finite ring form a finite type.**
-
-A point is the point at infinity or a pair of ring elements together with a proof of
-`Nonsingular`, which is a proposition; so `Point` injects into `Option (R × R)`. -/
+/-- **The affine points of a Weierstrass curve over a finite ring form a finite type.** -/
 instance finite_point : Finite W.Point :=
-  Finite.of_injective
-    (fun P => match P with
-      | .zero => none
-      | .some x y _ => some (x, y))
-    (by rintro (_ | ⟨x₁, y₁, h₁⟩) (_ | ⟨x₂, y₂, h₂⟩) hP <;> simp_all)
+  -- transport along Mathlib's decomposition of `Point` as the point at infinity together with the
+  -- pairs satisfying `Nonsingular`; `WithZero` carries no `Finite` instance of its own, so it is
+  -- taken from the `Option` it unfolds to
+  have : Finite (WithZero {xy : R × R // W.Nonsingular xy.1 xy.2}) :=
+    inferInstanceAs (Finite (Option _))
+  .of_equiv _ W.nonsingularPointEquiv.symm
 
 end Affine
 

--- a/TauCeti/AlgebraicGeometry/EllipticCurve/FinitePoint.lean
+++ b/TauCeti/AlgebraicGeometry/EllipticCurve/FinitePoint.lean
@@ -1,0 +1,69 @@
+/-
+Copyright (c) 2026 The Tau Ceti contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+-/
+module
+
+public import Mathlib.AlgebraicGeometry.EllipticCurve.Affine.Point
+
+/-!
+# The affine points of a Weierstrass curve over a finite ring form a finite type
+
+`E(𝔽_q)` is finite. Mathlib does not have this, and it is needed before the count `#E(𝔽_q)` means
+anything: `Nat.card` reads `0` on an infinite type, so a statement like the Hasse bound is only the
+honest count when accompanied by finiteness.
+
+The proof is the obvious one — a point is either the point at infinity or a pair `(x, y)` of ring
+elements, and `Nonsingular` is a proposition, so `Point` injects into `Option (R × R)`.
+
+## Main results
+
+* `TauCeti.WeierstrassCurve.Affine.finite_point`: `W.Point` is finite whenever the base is.
+
+Stated over an arbitrary finite commutative ring and an arbitrary affine Weierstrass curve: neither
+a field nor `IsElliptic` is needed, since the argument never leaves the underlying inductive type.
+The roadmap seeds this over a finite field with `[W.IsElliptic]`; that form is discharged by
+`inferInstance` from the instance below, which I checked before writing this.
+
+It is an `instance`, so `Nat.card`/`Finset` arguments about `E(𝔽_q)` pick it up without being
+handed a proof. It is named — contrary to the usual preference for anonymous instances — because
+the name is the roadmap's identifier for this milestone.
+
+This is the finiteness milestone of `TauCetiRoadmap/EllipticCurves/README.md`, Layer 3
+("elliptic curves over finite fields — the Hasse bound"), seeded in that roadmap's
+`Suggested.lean` as `finite_point`, where it is called "a prerequisite Mathlib lacks" and the
+"required companion" of the Hasse bound.
+
+## Provenance
+
+Not ported: this is a direct proof. The AINTLIB `HasseWeil` project (the roadmap's pinned Hasse
+provenance) assumes `[Fintype W.toAffine.Point]` as a hypothesis rather than proving it, and the
+roadmap records that `finite_point` is "NOT proven upstream".
+-/
+
+public section
+
+namespace TauCeti
+
+namespace WeierstrassCurve
+
+namespace Affine
+
+variable {R : Type*} [CommRing R] [Finite R] (W : _root_.WeierstrassCurve.Affine R)
+
+/-- **The affine points of a Weierstrass curve over a finite ring form a finite type.**
+
+A point is the point at infinity or a pair of ring elements together with a proof of
+`Nonsingular`, which is a proposition; so `Point` injects into `Option (R × R)`. -/
+instance finite_point : Finite W.Point :=
+  Finite.of_injective
+    (fun P => match P with
+      | .zero => none
+      | .some x y _ => some (x, y))
+    (by rintro (_ | ⟨x₁, y₁, h₁⟩) (_ | ⟨x₂, y₂, h₂⟩) hP <;> simp_all)
+
+end Affine
+
+end WeierstrassCurve
+
+end TauCeti


### PR DESCRIPTION
`E(𝔽_q)` is finite.

* `TauCeti.WeierstrassCurve.Affine.finite_point` — `W.Point` is a `Finite` type whenever the base
  ring is.

This is a **seeded roadmap milestone**, not an auxiliary lemma: `TauCetiRoadmap/EllipticCurves/Suggested.lean`
pins it as `finite_point`, calling it "a prerequisite Mathlib lacks (needed even for the count to
make sense)" and, in the `hasse_bound` docstring, "a **required companion**, not a nicety:
`Nat.card` of an infinite type is `0`, which would make this inequality false rather than vacuous".

The proof transports along Mathlib's `nonsingularPointEquiv`, which already decomposes `Point` as
the point at infinity together with the pairs satisfying `Nonsingular`. (`WithZero` carries no
`Finite` instance of its own, so that one step is taken from the `Option` it unfolds to.)

**Generality.** The roadmap seeds this over a finite *field* with `[W.IsElliptic]`, for a
`WeierstrassCurve K`. Neither hypothesis is used — the argument never leaves the underlying
inductive type — so it is stated for an arbitrary finite commutative ring and an arbitrary
`WeierstrassCurve.Affine R`. I checked before writing the docstring that the seeded form

```lean
example {K : Type*} [Field K] [Finite K] (W : WeierstrassCurve K) [W.IsElliptic] :
    Finite W.toAffine.Point := inferInstance
```

is discharged by `inferInstance` from the instance added here.

**Why an `instance` rather than a `theorem`.** `Nat.card` and `Finset` arguments about `E(𝔽_q)`
should pick finiteness up from typeclass search rather than being handed a proof; the Hasse bound
is stated with `Nat.card`, so this is how it will be consumed. It is given a name — against the
usual preference for anonymous instances — because the name is the roadmap's identifier for the
milestone.

### Roadmap

Roadmap: EllipticCurves

`TauCetiRoadmap/EllipticCurves/README.md`, **Layer 3** ("elliptic curves over finite fields — the
Hasse bound"), first bullet: "**Finiteness.** `E(𝔽_q)` is finite (seeded as `Finite
(W.toAffine.Point)` over a finite field)". Layer 3 is the layer the roadmap's §Ordering names as
"the earliest PR".

This PR is independent: it imports one Mathlib module and **no** TauCeti module.

### Provenance

**Nothing is ported here — this is a direct proof.** The roadmap's pinned Hasse provenance, the
AINTLIB `HasseWeil` project (`github.com/CBirkbeck/AINTLIB`, Apache-2.0, `dev/hasse-weil @
513e83879e2f`), does not prove finiteness: it assumes `[Fintype W.toAffine.Point]` as a hypothesis
on the capstone, and the roadmap's own audit records that `finite_point` is "NOT proven upstream
(assumed `[Fintype]`)". So this closes a gap rather than migrating code.

A pre-review pass reported three findings, all applied before marking ready. `reuse`: the first
draft built the injection into `Option (R × R)` by hand, duplicating `nonsingularPointEquiv`; it
now uses that equivalence. `placement`: moved under the existing `EllipticCurve/Affine/` directory,
since this is affine-point API. `documentation`: the proof sketch is out of both docstrings and
into a comment on the proof.

New file `TauCeti/AlgebraicGeometry/EllipticCurve/Affine/FinitePoint.lean`, 64 lines; the proof is
3 lines; no existing file touched.

<!--tauceti-target:v1 {"focus":"EllipticCurves","id":"EllipticCurves/Suggested.lean#finite_point"}-->
