### PR TITLE
refactor(Moments): split the vanishing-moments transfer into determinacy and read-back

### DIFF
--- a/TauCeti/Probability/Moments/VanishingMoments.lean
+++ b/TauCeti/Probability/Moments/VanishingMoments.lean
@@ -171,6 +171,65 @@ private theorem integral_pow_withDensity_ofReal_eq {n : ℕ}
 
 end Densities
 
+/-- The positive and negative parts of `g`, as densities against `ν`, define the same measure once
+all the moments of `g` vanish: both are finite measures with an exponential moment, so determinacy
+identifies them. -/
+private theorem withDensity_ofReal_eq_withDensity_ofReal_neg {g : ℝ → ℝ} {a : ℝ} (ha : 0 < a)
+    (hexpa : Integrable (fun x : ℝ => Real.exp (a * |x|) * g x) ν)
+    (hmom : ∀ n : ℕ, ∫ x : ℝ, x ^ n * g x ∂ν = 0) :
+    (ν.withDensity fun x => ENNReal.ofReal (g x))
+      = ν.withDensity fun x => ENNReal.ofReal (-g x) := by
+  have hg : Integrable g ν := integrable_of_integrable_exp_mul_abs_mul ha.le hexpa
+  have hgm : AEMeasurable g ν := hg.aestronglyMeasurable.aemeasurable
+  have hmeasp : AEMeasurable (fun x => ENNReal.ofReal (g x)) ν :=
+    ENNReal.measurable_ofReal.comp_aemeasurable hgm
+  have hmeasn : AEMeasurable (fun x => ENNReal.ofReal (-g x)) ν :=
+    ENNReal.measurable_ofReal.comp_aemeasurable hgm.neg
+  -- `ENNReal.ofReal` already truncates at zero, so these densities are exactly `g⁺` and `g⁻`.
+  -- `|max t 0| ≤ |t|` is Mathlib's `abs_max_sub_max_le_abs` at `b = c = 0`.
+  have hlep : ∀ x, |max (g x) 0| ≤ |g x| := fun x => by
+    simpa using abs_max_sub_max_le_abs (g x) 0 0
+  have hlen : ∀ x, |max (-g x) 0| ≤ |g x| := fun x => by
+    simpa using abs_max_sub_max_le_abs (-g x) 0 0
+  have : IsFiniteMeasure (ν.withDensity fun x => ENNReal.ofReal (g x)) :=
+    isFiniteMeasure_withDensity_ofReal hg.2
+  have : IsFiniteMeasure (ν.withDensity fun x => ENNReal.ofReal (-g x)) :=
+    isFiniteMeasure_withDensity_ofReal hg.neg.2
+  -- `g⁺ - g⁻ = g` pointwise, so the two moment sequences differ by `∫ xⁿ g = 0`.
+  exact Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp
+    ⟨a, ha, integrable_exp_withDensity_ofReal hexpa hmeasp
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top) hlep⟩
+    ⟨a, ha, integrable_exp_withDensity_ofReal hexpa hmeasn
+      (ae_of_all _ fun _ => ENNReal.ofReal_lt_top) hlen⟩
+    fun n => integral_pow_withDensity_ofReal_eq hmeasp hmeasn
+      (integrable_toReal_ofReal_smul_pow ha hexpa hmeasp hlep n)
+      (integrable_toReal_ofReal_smul_pow ha hexpa hmeasn hlen n) (hmom n)
+
+/-- An integrable function whose positive and negative parts define the same measure vanishes almost
+everywhere.
+
+Integrability of `g` bounds the positive density's lintegral, which is what replaces σ-finiteness of
+`ν` in reading the density equality back off the measure equality. -/
+private theorem ae_eq_zero_of_withDensity_ofReal_eq {g : ℝ → ℝ} (hg : Integrable g ν)
+    (hEq : (ν.withDensity fun x => ENNReal.ofReal (g x))
+      = ν.withDensity fun x => ENNReal.ofReal (-g x)) :
+    g =ᵐ[ν] 0 := by
+  have hgm : AEMeasurable g ν := hg.aestronglyMeasurable.aemeasurable
+  have hmeasp : AEMeasurable (fun x => ENNReal.ofReal (g x)) ν :=
+    ENNReal.measurable_ofReal.comp_aemeasurable hgm
+  have hmeasn : AEMeasurable (fun x => ENNReal.ofReal (-g x)) ν :=
+    ENNReal.measurable_ofReal.comp_aemeasurable hgm.neg
+  have hfin : ∫⁻ x, ENNReal.ofReal (g x) ∂ν ≠ ⊤ := by
+    refine ne_of_lt (lt_of_le_of_lt (lintegral_mono_ae ?_) hg.hasFiniteIntegral)
+    filter_upwards with x
+    rw [← ofReal_norm, Real.norm_eq_abs]
+    exact ENNReal.ofReal_le_ofReal (le_abs_self _)
+  rw [withDensity_eq_iff hmeasp hmeasn hfin] at hEq
+  filter_upwards [hEq] with x hx
+  have h := congrArg ENNReal.toReal hx
+  rw [ENNReal.toReal_ofReal', ENNReal.toReal_ofReal'] at h
+  exact (max_zero_sub_max_neg_zero_eq_self (g x)).symm.trans (sub_eq_zero.mpr h)
+
 /-- **Roadmap B1 (function level).** A real function on `ℝ` whose exponentially-weighted product
 `e^{a|x|} · g` is integrable for some `a > 0`, and all of whose polynomial moments `∫ xⁿ g` vanish,
 is a.e. zero.
@@ -196,48 +255,9 @@ theorem ae_eq_zero_of_forall_moment_eq_zero (g : ℝ → ℝ)
     (hmom : ∀ n : ℕ, ∫ x : ℝ, x ^ n * g x ∂ν = 0) :
     g =ᵐ[ν] 0 := by
   obtain ⟨a, ha, hexpa⟩ := hexp
-  have hg : Integrable g ν := integrable_of_integrable_exp_mul_abs_mul ha.le hexpa
-  have hgm : AEMeasurable g ν := hg.aestronglyMeasurable.aemeasurable
-  have hmeasp : AEMeasurable (fun x => ENNReal.ofReal (g x)) ν :=
-    ENNReal.measurable_ofReal.comp_aemeasurable hgm
-  have hmeasn : AEMeasurable (fun x => ENNReal.ofReal (-g x)) ν :=
-    ENNReal.measurable_ofReal.comp_aemeasurable hgm.neg
-  have hltp : ∀ᵐ x ∂ν, ENNReal.ofReal (g x) < ⊤ := ae_of_all _ fun _ => ENNReal.ofReal_lt_top
-  have hltn : ∀ᵐ x ∂ν, ENNReal.ofReal (-g x) < ⊤ := ae_of_all _ fun _ => ENNReal.ofReal_lt_top
-  -- `ENNReal.ofReal` already truncates at zero, so these densities are exactly `g⁺` and `g⁻`.
-  -- `|max t 0| ≤ |t|` is Mathlib's `abs_max_sub_max_le_abs` at `b = c = 0`.
-  have hlep : ∀ x, |max (g x) 0| ≤ |g x| := fun x => by
-    simpa using abs_max_sub_max_le_abs (g x) 0 0
-  have hlen : ∀ x, |max (-g x) 0| ≤ |g x| := fun x => by
-    simpa using abs_max_sub_max_le_abs (-g x) 0 0
-  have hmpfin : IsFiniteMeasure (ν.withDensity fun x => ENNReal.ofReal (g x)) :=
-    isFiniteMeasure_withDensity_ofReal hg.2
-  have hmnfin : IsFiniteMeasure (ν.withDensity fun x => ENNReal.ofReal (-g x)) :=
-    isFiniteMeasure_withDensity_ofReal hg.neg.2
-  have hintp := fun n => integrable_toReal_ofReal_smul_pow ha hexpa hmeasp hlep n
-  have hintn := fun n => integrable_toReal_ofReal_smul_pow ha hexpa hmeasn hlen n
-  -- `g⁺ - g⁻ = g` pointwise, so the two moment sequences differ by `∫ xⁿ g = 0`.
-  have hmoments := fun n => integral_pow_withDensity_ofReal_eq hmeasp hmeasn (hintp n) (hintn n)
-    (hmom n)
-  -- Determinacy forces the two parts to be the same measure ...
-  have hEq : (ν.withDensity fun x => ENNReal.ofReal (g x))
-      = ν.withDensity fun x => ENNReal.ofReal (-g x) :=
-    Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp
-      ⟨a, ha, integrable_exp_withDensity_ofReal hexpa hmeasp hltp hlep⟩
-      ⟨a, ha, integrable_exp_withDensity_ofReal hexpa hmeasn hltn hlen⟩ hmoments
-  -- ... hence the densities agree a.e., hence `g⁺ = g⁻` a.e., hence `g = 0` a.e.
-  -- Integrability of `g` bounds the positive density's lintegral, which is what replaces
-  -- σ-finiteness of `ν` in reading the density equality back off the measure equality.
-  have hfin : ∫⁻ x, ENNReal.ofReal (g x) ∂ν ≠ ⊤ := by
-    refine ne_of_lt (lt_of_le_of_lt (lintegral_mono_ae ?_) hg.hasFiniteIntegral)
-    filter_upwards with x
-    rw [← ofReal_norm, Real.norm_eq_abs]
-    exact ENNReal.ofReal_le_ofReal (le_abs_self _)
-  rw [withDensity_eq_iff hmeasp hmeasn hfin] at hEq
-  filter_upwards [hEq] with x hx
-  have h := congrArg ENNReal.toReal hx
-  rw [ENNReal.toReal_ofReal', ENNReal.toReal_ofReal'] at h
-  exact (max_zero_sub_max_neg_zero_eq_self (g x)).symm.trans (sub_eq_zero.mpr h)
+  exact ae_eq_zero_of_withDensity_ofReal_eq
+    (integrable_of_integrable_exp_mul_abs_mul ha.le hexpa)
+    (withDensity_ofReal_eq_withDensity_ofReal_neg ha hexpa hmom)
 
 /-! ## Vanishing moments at the level of measures -/
 

--- a/TauCeti/Probability/Moments/VanishingMoments.lean
+++ b/TauCeti/Probability/Moments/VanishingMoments.lean
@@ -8,7 +8,7 @@ module
 public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 public import TauCeti.Probability.Moments.Determinacy
 public import Mathlib.Analysis.RCLike.Basic
-public import Mathlib.MeasureTheory.VectorMeasure.WithDensity
+import Mathlib.MeasureTheory.VectorMeasure.WithDensity
 public import Mathlib.Probability.Moments.IntegrableExpMul
 
 /-!

--- a/TauCeti/Probability/Moments/VanishingMoments.lean
+++ b/TauCeti/Probability/Moments/VanishingMoments.lean
@@ -8,6 +8,7 @@ module
 public import TauCeti.MeasureTheory.Function.PolynomialMemLp
 public import TauCeti.Probability.Moments.Determinacy
 public import Mathlib.Analysis.RCLike.Basic
+public import Mathlib.MeasureTheory.VectorMeasure.WithDensity
 public import Mathlib.Probability.Moments.IntegrableExpMul
 
 /-!
@@ -205,31 +206,6 @@ private theorem withDensity_ofReal_eq_withDensity_ofReal_neg {g : ℝ → ℝ} {
       (integrable_toReal_ofReal_smul_pow ha hexpa hmeasp hlep n)
       (integrable_toReal_ofReal_smul_pow ha hexpa hmeasn hlen n) (hmom n)
 
-/-- An integrable function whose positive and negative parts define the same measure vanishes almost
-everywhere.
-
-Integrability of `g` bounds the positive density's lintegral, which is what replaces σ-finiteness of
-`ν` in reading the density equality back off the measure equality. -/
-private theorem ae_eq_zero_of_withDensity_ofReal_eq {g : ℝ → ℝ} (hg : Integrable g ν)
-    (hEq : (ν.withDensity fun x => ENNReal.ofReal (g x))
-      = ν.withDensity fun x => ENNReal.ofReal (-g x)) :
-    g =ᵐ[ν] 0 := by
-  have hgm : AEMeasurable g ν := hg.aestronglyMeasurable.aemeasurable
-  have hmeasp : AEMeasurable (fun x => ENNReal.ofReal (g x)) ν :=
-    ENNReal.measurable_ofReal.comp_aemeasurable hgm
-  have hmeasn : AEMeasurable (fun x => ENNReal.ofReal (-g x)) ν :=
-    ENNReal.measurable_ofReal.comp_aemeasurable hgm.neg
-  have hfin : ∫⁻ x, ENNReal.ofReal (g x) ∂ν ≠ ⊤ := by
-    refine ne_of_lt (lt_of_le_of_lt (lintegral_mono_ae ?_) hg.hasFiniteIntegral)
-    filter_upwards with x
-    rw [← ofReal_norm, Real.norm_eq_abs]
-    exact ENNReal.ofReal_le_ofReal (le_abs_self _)
-  rw [withDensity_eq_iff hmeasp hmeasn hfin] at hEq
-  filter_upwards [hEq] with x hx
-  have h := congrArg ENNReal.toReal hx
-  rw [ENNReal.toReal_ofReal', ENNReal.toReal_ofReal'] at h
-  exact (max_zero_sub_max_neg_zero_eq_self (g x)).symm.trans (sub_eq_zero.mpr h)
-
 /-- **Roadmap B1 (function level).** A real function on `ℝ` whose exponentially-weighted product
 `e^{a|x|} · g` is integrable for some `a > 0`, and all of whose polynomial moments `∫ xⁿ g` vanish,
 is a.e. zero.
@@ -255,9 +231,13 @@ theorem ae_eq_zero_of_forall_moment_eq_zero (g : ℝ → ℝ)
     (hmom : ∀ n : ℕ, ∫ x : ℝ, x ^ n * g x ∂ν = 0) :
     g =ᵐ[ν] 0 := by
   obtain ⟨a, ha, hexpa⟩ := hexp
-  exact ae_eq_zero_of_withDensity_ofReal_eq
-    (integrable_of_integrable_exp_mul_abs_mul ha.le hexpa)
-    (withDensity_ofReal_eq_withDensity_ofReal_neg ha hexpa hmom)
+  have hg : Integrable g ν := integrable_of_integrable_exp_mul_abs_mul ha.le hexpa
+  -- `g` and `0` have the same vector measure, because the two parts of `g` cancel.
+  refine hg.ae_eq_of_withDensityᵥ_eq (integrable_zero _ _ _) ?_
+  rw [withDensityᵥ_zero, withDensityᵥ_eq_withDensity_pos_part_sub_withDensity_neg_part hg,
+    sub_eq_zero]
+  congr 1
+  exact withDensity_ofReal_eq_withDensity_ofReal_neg ha hexpa hmom
 
 /-! ## Vanishing moments at the level of measures -/
 


### PR DESCRIPTION
`ae_eq_zero_of_forall_moment_eq_zero` ran to 44 lines because it did the whole transfer in
one block. There are really two steps, and they use disjoint machinery:

1. **Determinacy** identifies the two densities. Both `g⁺` and `g⁻`, as densities against `ν`,
   are finite measures carrying an exponential moment, and all their moments agree because
   `∫ xⁿ g = 0`; `Measure.ext_of_forall_integral_pow_eq_of_exists_integrable_exp` then says
   they are the same measure.
2. **Read-back** turns that measure equality into a statement about `g`.

Only the first is TauCeti's own work. It becomes the private lemma
`withDensity_ofReal_eq_withDensity_ofReal_neg`; the second is Mathlib's, and the theorem now
calls it directly.

## The read-back is Mathlib's

`Mathlib.MeasureTheory.VectorMeasure.WithDensity` already has this:
`withDensityᵥ_eq_withDensity_pos_part_sub_withDensity_neg_part` writes `ν.withDensityᵥ g` as the
difference of the signed measures of the two parts, so the determinacy step says exactly
`ν.withDensityᵥ g = 0 = ν.withDensityᵥ 0`, and `Integrable.ae_eq_of_withDensityᵥ_eq` reads that
back as `g =ᵐ[ν] 0`. That is also where the σ-finiteness-free argument lives — the file's docstring
already noted that integrability of `g` is what stands in for it, and Mathlib's version carries
that for us. The PR adds `import Mathlib.MeasureTheory.VectorMeasure.WithDensity` — a *private* import, since none of it appears in any statement here, only in proof bodies.

## What is left

```lean
obtain ⟨a, ha, hexpa⟩ := hexp
have hg : Integrable g ν := integrable_of_integrable_exp_mul_abs_mul ha.le hexpa
-- `g` and `0` have the same vector measure, because the two parts of `g` cancel.
refine hg.ae_eq_of_withDensityᵥ_eq (integrable_zero _ _ _) ?_
rw [withDensityᵥ_zero, withDensityᵥ_eq_withDensity_pos_part_sub_withDensity_neg_part hg,
  sub_eq_zero]
congr 1
exact withDensity_ofReal_eq_withDensity_ofReal_neg ha hexpa hmom
```

One thing worth noting in the surviving helper: `hmeasp`/`hmeasn` are kept as named `have`s with
explicit type ascriptions rather than inlined. `ENNReal.measurable_ofReal.comp_aemeasurable hgm`
supplies `ENNReal.ofReal ∘ g` where the goal has `fun x => ENNReal.ofReal (g x)`; the ascription is
what keeps the downstream lemmas applicable.

## Scope

The statement and docstring of the public theorem are unchanged, and the helper is `private`; the
entire diff is proof-internal apart from the one added import.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all
green; no new lint violations. Proof body 44 → 9 lines, with one helper at 26.

Roadmap: OrthogonalL2Bases
