### PR TITLE
refactor(L2): decompose the finite-measure vanishing-integral proof

### DIFF
--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -288,55 +288,65 @@ theorem setIntegral_pi_eq_zero_of_forall_inner {h : Lp 𝕜 2 (Measure.pi μ)}
     _ = inner 𝕜 (L2piMul F) h := (L2.inner_def _ _).symm
     _ = 0 := hz F
 
+omit [Fintype ι] in
+/-- The product boxes built from the spanning sets of the factors exhaust the whole product space:
+a point lies in the box of index `Finset.univ.sup m`, where `m i` is an index for its `i`-th
+coordinate. Only finiteness of `ι` is needed, to bound those indices. -/
+private theorem iUnion_univ_pi_spanningSets [Finite ι] :
+    ⋃ n, (Set.univ.pi fun i => spanningSets (μ i) n) = Set.univ := by
+  refine Set.eq_univ_of_forall fun x => ?_
+  have hx : ∀ i, ∃ m, x i ∈ spanningSets (μ i) m := fun i =>
+    Set.mem_iUnion.1 (by rw [iUnion_spanningSets]; trivial)
+  choose m hm using hx
+  have : Fintype ι := Fintype.ofFinite ι
+  exact Set.mem_iUnion.2 ⟨Finset.univ.sup m, fun i _ =>
+    monotone_spanningSets (μ i) (Finset.le_sup (Finset.mem_univ i)) (hm i)⟩
+
+/-- The integral of `h` vanishes on the part of any measurable set inside a product box.
+
+Inside the box the measure is finite, so the boxes generate the σ-algebra as a π-system on which
+`h` already integrates to zero, and Dynkin's lemma propagates that to every measurable set. -/
+private theorem setIntegral_inter_univ_pi_spanningSets_eq_zero {h : Lp 𝕜 2 (Measure.pi μ)}
+    (hz : ∀ F : ∀ i, Lp 𝕜 2 (μ i), inner 𝕜 (L2piMul F) h = 0) {u : Set (∀ i, α i)}
+    (hu : MeasurableSet u) (n : ℕ) :
+    ∫ x in u ∩ (Set.univ.pi fun i => spanningSets (μ i) n), h x ∂(Measure.pi μ) = 0 := by
+  classical
+  have hboxfin : Measure.pi μ (Set.univ.pi fun i => spanningSets (μ i) n) < ⊤ := by
+    rw [Measure.pi_pi]
+    exact ENNReal.prod_lt_top fun i _ => measure_spanningSets_lt_top (μ i) n
+  have huniv : ∫ x, h x ∂((Measure.pi μ).restrict
+      (Set.univ.pi fun i => spanningSets (μ i) n)) = 0 :=
+    setIntegral_pi_eq_zero_of_forall_inner hz _ (fun i => measurableSet_spanningSets (μ i) n)
+      (fun i => (measure_spanningSets_lt_top (μ i) n).ne)
+  have hS : ∀ t ∈ (Set.pi Set.univ '' Set.pi Set.univ fun i => {v : Set (α i) | MeasurableSet v}),
+      ∫ x in t, h x ∂((Measure.pi μ).restrict
+        (Set.univ.pi fun i => spanningSets (μ i) n)) = 0 := by
+    rintro _ ⟨t, ht, rfl⟩
+    rw [Measure.restrict_restrict
+      (MeasurableSet.univ_pi fun i => ht i (Set.mem_univ i)), ← Set.pi_inter_distrib]
+    exact setIntegral_pi_eq_zero_of_forall_inner hz _
+      (fun i => (ht i (Set.mem_univ i)).inter (measurableSet_spanningSets (μ i) n))
+      (fun i => (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
+        (measure_spanningSets_lt_top (μ i) n)).ne)
+  have hdyn := setIntegral_eq_zero_of_isPiSystem generateFrom_pi.symm isPiSystem_pi
+    (integrableOn_Lp_of_measure_ne_top h one_le_two hboxfin.ne) huniv hS u hu
+  rwa [Measure.restrict_restrict hu] at hdyn
+
 /-- A vector orthogonal to every elementary tensor has vanishing integral over every measurable set
 of finite measure. -/
 theorem setIntegral_eq_zero_of_forall_inner_pi {h : Lp 𝕜 2 (Measure.pi μ)}
     (hz : ∀ F : ∀ i, Lp 𝕜 2 (μ i), inner 𝕜 (L2piMul F) h = 0)
     (u : Set (∀ i, α i)) (hu : MeasurableSet u) (hfin : Measure.pi μ u < ⊤) :
     ∫ x in u, h x ∂(Measure.pi μ) = 0 := by
-  classical
-  have hboxm : ∀ n, MeasurableSet (Set.univ.pi fun i => spanningSets (μ i) n) := fun n =>
-    MeasurableSet.univ_pi fun i => measurableSet_spanningSets (μ i) n
-  have hboxfin : ∀ n, Measure.pi μ (Set.univ.pi fun i => spanningSets (μ i) n) < ⊤ := by
-    intro n
-    rw [Measure.pi_pi]
-    exact ENNReal.prod_lt_top fun i _ => measure_spanningSets_lt_top (μ i) n
-  have hb : ∀ n, ∫ x in u ∩ (Set.univ.pi fun i => spanningSets (μ i) n),
-      h x ∂(Measure.pi μ) = 0 := by
-    intro n
-    have huniv : ∫ x, h x ∂((Measure.pi μ).restrict
-        (Set.univ.pi fun i => spanningSets (μ i) n)) = 0 :=
-      setIntegral_pi_eq_zero_of_forall_inner hz _ (fun i => measurableSet_spanningSets (μ i) n)
-        (fun i => (measure_spanningSets_lt_top (μ i) n).ne)
-    have hS : ∀ t ∈ (Set.pi Set.univ '' Set.pi Set.univ fun i => {v : Set (α i) | MeasurableSet v}),
-        ∫ x in t, h x ∂((Measure.pi μ).restrict
-          (Set.univ.pi fun i => spanningSets (μ i) n)) = 0 := by
-      rintro _ ⟨t, ht, rfl⟩
-      rw [Measure.restrict_restrict
-        (MeasurableSet.univ_pi fun i => ht i (Set.mem_univ i)), ← Set.pi_inter_distrib]
-      exact setIntegral_pi_eq_zero_of_forall_inner hz _
-        (fun i => (ht i (Set.mem_univ i)).inter (measurableSet_spanningSets (μ i) n))
-        (fun i => (lt_of_le_of_lt (measure_mono Set.inter_subset_right)
-          (measure_spanningSets_lt_top (μ i) n)).ne)
-    have hdyn := setIntegral_eq_zero_of_isPiSystem generateFrom_pi.symm isPiSystem_pi
-      (integrableOn_Lp_of_measure_ne_top h one_le_two (hboxfin n).ne) huniv hS u hu
-    rwa [Measure.restrict_restrict hu] at hdyn
   have hmono : Monotone fun n => u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) := fun m n hmn =>
     Set.inter_subset_inter_right _ (Set.pi_mono fun i _ => monotone_spanningSets (μ i) hmn)
   have hcover : ⋃ n, u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) = u := by
-    rw [← Set.inter_iUnion]
-    have hcov : ⋃ n, (Set.univ.pi fun i => spanningSets (μ i) n) = Set.univ := by
-      refine Set.eq_univ_of_forall fun x => ?_
-      have hx : ∀ i, ∃ m, x i ∈ spanningSets (μ i) m := fun i =>
-        Set.mem_iUnion.1 (by rw [iUnion_spanningSets]; trivial)
-      choose m hm using hx
-      exact Set.mem_iUnion.2 ⟨Finset.univ.sup m, fun i _ =>
-        monotone_spanningSets (μ i) (Finset.le_sup (Finset.mem_univ i)) (hm i)⟩
-    rw [hcov, Set.inter_univ]
-  have htend := tendsto_setIntegral_of_monotone (fun n => hu.inter (hboxm n)) hmono
+    rw [← Set.inter_iUnion, iUnion_univ_pi_spanningSets, Set.inter_univ]
+  have htend := tendsto_setIntegral_of_monotone
+    (fun n => hu.inter (MeasurableSet.univ_pi fun i => measurableSet_spanningSets (μ i) n)) hmono
     (by rw [hcover]; exact integrableOn_Lp_of_measure_ne_top h one_le_two hfin.ne)
   rw [hcover] at htend
-  simp only [hb] at htend
+  simp only [setIntegral_inter_univ_pi_spanningSets_eq_zero hz hu] at htend
   exact tendsto_nhds_unique htend tendsto_const_nhds
 
 /-- **Completeness of the tensor family.** The tensors built from coordinatewise Hilbert bases have

--- a/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
+++ b/TauCeti/Analysis/InnerProductSpace/L2/Pi.lean
@@ -288,24 +288,8 @@ theorem setIntegral_pi_eq_zero_of_forall_inner {h : Lp 𝕜 2 (Measure.pi μ)}
     _ = inner 𝕜 (L2piMul F) h := (L2.inner_def _ _).symm
     _ = 0 := hz F
 
-omit [Fintype ι] in
-/-- The product boxes built from the spanning sets of the factors exhaust the whole product space:
-a point lies in the box of index `Finset.univ.sup m`, where `m i` is an index for its `i`-th
-coordinate. Only finiteness of `ι` is needed, to bound those indices. -/
-private theorem iUnion_univ_pi_spanningSets [Finite ι] :
-    ⋃ n, (Set.univ.pi fun i => spanningSets (μ i) n) = Set.univ := by
-  refine Set.eq_univ_of_forall fun x => ?_
-  have hx : ∀ i, ∃ m, x i ∈ spanningSets (μ i) m := fun i =>
-    Set.mem_iUnion.1 (by rw [iUnion_spanningSets]; trivial)
-  choose m hm using hx
-  have : Fintype ι := Fintype.ofFinite ι
-  exact Set.mem_iUnion.2 ⟨Finset.univ.sup m, fun i _ =>
-    monotone_spanningSets (μ i) (Finset.le_sup (Finset.mem_univ i)) (hm i)⟩
-
-/-- The integral of `h` vanishes on the part of any measurable set inside a product box.
-
-Inside the box the measure is finite, so the boxes generate the σ-algebra as a π-system on which
-`h` already integrates to zero, and Dynkin's lemma propagates that to every measurable set. -/
+/-- Orthogonality to every elementary tensor makes the integral of `h` vanish on the intersection
+of any measurable set with a product box of spanning sets. -/
 private theorem setIntegral_inter_univ_pi_spanningSets_eq_zero {h : Lp 𝕜 2 (Measure.pi μ)}
     (hz : ∀ F : ∀ i, Lp 𝕜 2 (μ i), inner 𝕜 (L2piMul F) h = 0) {u : Set (∀ i, α i)}
     (hu : MeasurableSet u) (n : ℕ) :
@@ -341,7 +325,9 @@ theorem setIntegral_eq_zero_of_forall_inner_pi {h : Lp 𝕜 2 (Measure.pi μ)}
   have hmono : Monotone fun n => u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) := fun m n hmn =>
     Set.inter_subset_inter_right _ (Set.pi_mono fun i _ => monotone_spanningSets (μ i) hmn)
   have hcover : ⋃ n, u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) = u := by
-    rw [← Set.inter_iUnion, iUnion_univ_pi_spanningSets, Set.inter_univ]
+    rw [← Set.inter_iUnion,
+      Set.iUnion_univ_pi_of_monotone fun i => monotone_spanningSets (μ i)]
+    simp [iUnion_spanningSets, Set.pi_univ]
   have htend := tendsto_setIntegral_of_monotone
     (fun n => hu.inter (MeasurableSet.univ_pi fun i => measurableSet_spanningSets (μ i) n)) hmono
     (by rw [hcover]; exact integrableOn_Lp_of_measure_ne_top h one_le_two hfin.ne)


### PR DESCRIPTION
`setIntegral_eq_zero_of_forall_inner_pi` ran to 45 lines because it did the whole exhaustion
inline. The argument has two independent halves — kill the integral inside one product box, and
show the boxes cover — with the actual theorem being just the monotone limit of the two. Only the
first is TauCeti's own work; the second is Mathlib's.

## The helper

`setIntegral_inter_univ_pi_spanningSets_eq_zero` — inside a box, `Measure.pi μ` is finite, the
boxes form a π-system generating the σ-algebra on which `h` already integrates to zero (by the
existing `setIntegral_pi_eq_zero_of_forall_inner`), and `setIntegral_eq_zero_of_isPiSystem`
propagates that to every measurable set. This is the whole Dynkin step, and it is the only place
`Measure.restrict_restrict` and the finiteness of the box are used.

## The covering half is Mathlib's

`Set.iUnion_univ_pi_of_monotone` (`Data/Set/Finite/Lattice.lean`) pushes the union through a finite
product of monotone families, so `⋃ n, Set.univ.pi fun i => spanningSets (μ i) n` becomes
`Set.univ.pi fun i => ⋃ n, spanningSets (μ i) n`, which `iUnion_spanningSets` and `Set.pi_univ`
finish. The call site is three lines and adds no declaration.

## What is left

```lean
have hmono : Monotone fun n => u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) := fun m n hmn =>
  Set.inter_subset_inter_right _ (Set.pi_mono fun i _ => monotone_spanningSets (μ i) hmn)
have hcover : ⋃ n, u ∩ (Set.univ.pi fun i => spanningSets (μ i) n) = u := by
  rw [← Set.inter_iUnion,
    Set.iUnion_univ_pi_of_monotone fun i => monotone_spanningSets (μ i)]
  simp [iUnion_spanningSets, Set.pi_univ]
have htend := tendsto_setIntegral_of_monotone ... hmono ...
rw [hcover] at htend
simp only [setIntegral_inter_univ_pi_spanningSets_eq_zero hz hu] at htend
exact tendsto_nhds_unique htend tendsto_const_nhds
```

## Scope

The statement and docstring of the public theorem are unchanged, and the helper is `private`; the
entire diff is proof-internal, and it adds no import.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 45 → 13 lines, with one helper at 22.

Roadmap: OrthogonalL2Bases
