### PR TITLE
feat(Analysis): the boundary-tolerant logarithmic FTC

### DIFF
--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -54,14 +54,16 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
   analytic and nonzero; the regularity input shared by the results below and by the argument
   principle.
-* `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg`,
-  `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos`,
-  and `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane` —
+* `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg` and
+  `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos` —
   the boundary-tolerant comparison FTCs: the logarithmic integral of `g` is integrable and
   evaluates to an endpoint-log difference through a comparison `h` that agrees with `g` on the
   open interval, is differentiable there off a countable set with integrable logarithmic
-  integrand, and is confined to a closed half-plane or the slit plane — so endpoint values may
-  sit on the negative-real boundary.
+  integrand, and is confined to a closed half-plane — so endpoint values may sit on the
+  negative-real boundary. A comparison confined to the slit plane on the whole closed interval
+  needs no dedicated form: `integral_deriv_div_eq_log_sub_log` applies to it directly, and
+  `IntervalIntegrable.congr_uIoo` with `intervalIntegral.integral_congr_uIoo` transport its
+  conclusion across the interior agreement.
 * `TauCeti.Contour.integral_deriv_div_eq_log_sub_log` — the slit-plane logarithmic-derivative FTC in
   general `f' / f` form.
 * `TauCeti.Contour.integral_deriv_div_sub_eq_log` — its contour specialization to
@@ -342,23 +344,6 @@ theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_non
     (fun t ht ↦ by simp only [Pi.neg_apply, heq ht])
     (by simp only [Pi.neg_apply, heq_a]) (by simp only [Pi.neg_apply, heq_b])
   rwa [hderiv_neg g] at hkey
-
-/-- **The comparison logarithmic FTC on the slit plane**: the boundary-tolerant comparison
-form whose branch continuity comes from slit-plane confinement on the whole closed interval,
-transported to `g` across the interior agreement. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane {P : Set ℝ}
-    (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
-    (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
-    (hh_slit : ∀ t ∈ Set.uIcc a b, h t ∈ Complex.slitPlane)
-    (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
-    (heq_a : g a = h a) (heq_b : g b = h b) :
-    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) :=
-  comparison_core hP (hh_cont.clog hh_slit)
-    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real
-      (hh_slit t (by rw [← Set.Icc_min_max]; exact Set.Ioo_subset_Icc_self ht.1)))
-    hh_int heq heq_a heq_b
 
 end BoundaryTolerant
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -9,7 +9,7 @@ public import Mathlib.Analysis.Calculus.FDeriv.Analytic
 public import Mathlib.Analysis.Calculus.LogDeriv
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
-public import TauCeti.Analysis.Complex.UpperLogContinuity
+import TauCeti.Analysis.Complex.UpperLogContinuity
 public import TauCeti.Analysis.Contour.Curve.Integrability
 
 import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
@@ -54,6 +54,11 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
   analytic and nonzero; the regularity input shared by the results below and by the argument
   principle.
+* `TauCeti.Contour.intervalIntegrable_and_integral_deriv_div_eq_log_of_slitPlane`,
+  `…_eq_log_of_im_nonneg`, `…_eq_log_neg_of_im_nonpos` — the boundary-tolerant comparison
+  FTCs: the logarithmic integral of `g` evaluated through a smooth comparison `h` that
+  agrees with `g` on the open interval, confined to the slit plane or to a closed
+  half-plane, so endpoint values may sit on the negative-real boundary.
 * `TauCeti.Contour.integral_deriv_div_eq_log_sub_log` — the slit-plane logarithmic-derivative FTC in
   general `f' / f` form.
 * `TauCeti.Contour.integral_deriv_div_sub_eq_log` — its contour specialization to
@@ -237,39 +242,27 @@ section BoundaryTolerant
 
 open MeasureTheory
 
-/-- Transport of the logarithmic integrand across an interior agreement: if `g = h` with
-equal derivatives on the open interval, the integrands agree almost everywhere on the
-interval and integrability transports. -/
-private lemma aeEq_and_intervalIntegrable_of_eqOn_Ioo {g h : ℝ → ℂ} {a b : ℝ}
-    (hab : a ≤ b) (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
-    (hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b) :
-    (∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t) ∧
-    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b := by
-  have hb_ae : ({b} : Set ℝ)ᶜ ∈ ae volume := by
-    simp [MeasureTheory.mem_ae_iff]
-  have h_congr : ∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t := by
-    filter_upwards [hb_ae] with t ht_ne_b ht_mem
-    rw [Set.uIoc_of_le hab] at ht_mem
-    obtain ⟨hval, hderiv⟩ := heq t
-      ⟨ht_mem.1, lt_of_le_of_ne ht_mem.2 fun h ↦ ht_ne_b (Set.mem_singleton_iff.mpr h)⟩
-    rw [hval, hderiv]
-  refine ⟨h_congr, hint_h.congr_ae ?_⟩
-  exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
-    (h_congr.mono fun t ht hm ↦ (ht hm).symm)
+variable {g h : ℝ → ℂ} {a b : ℝ}
+
+/-- Interior agreement transports the logarithmic integrand to the open interval. -/
+private lemma eqOn_uIoo_deriv_div (hab : a ≤ b) (heq : Set.EqOn g h (Set.Ioo a b)) :
+    Set.EqOn (fun t ↦ deriv g t / g t) (fun t ↦ deriv h t / h t) (Set.uIoo a b) := by
+  intro t ht
+  rw [Set.uIoo_of_le hab] at ht
+  simp only [heq ht, heq.deriv isOpen_Ioo ht]
 
 /-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
 confined to the closed upper half-plane, nonvanishing, and slit-plane-valued on the
-interior, the logarithmic integral of `g` evaluates to the difference of logarithms —
-even when the endpoint values sit on the slit-plane boundary. -/
-theorem integral_deriv_div_eq_log_of_im_nonneg {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+interior, the logarithmic integral of `g` is integrable and evaluates to the difference
+of logarithms — even when the endpoint values sit on the slit-plane boundary. -/
+theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_im_nn : ∀ t ∈ Set.Icc a b, 0 ≤ (h t).im)
     (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
     (hh_slit : ∀ t ∈ Set.Ioo a b, h t ∈ Complex.slitPlane)
-    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
-    (heq_a : g a = h a) (heq_b : g b = h b) :
+    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
   have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
@@ -278,28 +271,28 @@ theorem integral_deriv_div_eq_log_of_im_nonneg {g h : ℝ → ℂ} {a b : ℝ} (
   have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
     ((hh_deriv_cont.div hh_cont hh_ne).mono
       (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
-  obtain ⟨h_congr, hint_g⟩ :=
-    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
+    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
   have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
     (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht)) hint_h
   refine ⟨hint_g, ?_⟩
   calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+      = ∫ t in a..b, deriv h t / h t :=
+        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
     _ = Complex.log (h b) - Complex.log (h a) := h_ftc
     _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 
 /-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
 confined to the closed lower half-plane with strictly negative interior imaginary part,
 the logarithmic integral evaluates against the negated arguments. -/
-theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
     (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
     (hh_im_neg : ∀ t ∈ Set.Ioo a b, (h t).im < 0)
-    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
-    (heq_a : g a = h a) (heq_b : g b = h b) :
+    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t =
       Complex.log (-(g b)) - Complex.log (-(g a)) := by
@@ -309,48 +302,50 @@ theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : �
   have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
     ((hh_deriv_cont.div hh_cont hh_ne).mono
       (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
-  obtain ⟨h_congr, hint_g⟩ :=
-    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
+    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
   have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hnh_log_cont
     (fun t ht ↦ by
       have hslit : -(h t) ∈ Complex.slitPlane := Complex.mem_slitPlane_iff.mpr
         (Or.inr (by simpa using ne_of_lt (hh_im_neg t ht)))
-      have := (hh_diff t ht).hasDerivAt.neg.clog_real hslit
-      exact (show -deriv h t / -h t = deriv h t / h t by rw [neg_div_neg_eq]) ▸ this)
+      exact neg_div_neg_eq (deriv h t) (h t) ▸
+        (hh_diff t ht).hasDerivAt.neg.clog_real hslit)
     hint_h
   refine ⟨hint_g, ?_⟩
   calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+      = ∫ t in a..b, deriv h t / h t :=
+        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
     _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
     _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
 
-
-/-- **The comparison logarithmic FTC on the slit plane**: for a comparison function `h`
-slit-plane-valued on the closed interval, the logarithmic integral of `g` evaluates to
-the difference of endpoint logarithms. -/
-theorem integral_deriv_div_eq_log_of_slitPlane {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+/-- **The comparison logarithmic FTC on the slit plane**: the slit-plane FTC
+`TauCeti.Contour.integral_deriv_div_eq_log_sub_log`, applied to the comparison `h` and
+transported to `g` across the interior agreement. -/
+theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_slitPlane (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
-    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
-    (heq_a : g a = h a) (heq_b : g b = h b) :
+    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
   have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
     Complex.slitPlane_ne_zero (hh_slit t ht)
-  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) := fun t ht ↦
-    (continuousAt_clog (hh_slit t ht)).comp_continuousWithinAt (hh_cont t ht)
+  have hIcc : Set.uIcc a b = Set.Icc a b := Set.uIcc_of_le hab
   have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
-    ((hh_deriv_cont.div hh_cont hh_ne).mono
-      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
-  obtain ⟨h_congr, hint_g⟩ :=
-    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
-  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
-    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ⟨ht.1.le, ht.2.le⟩)) hint_h
+    ((hh_deriv_cont.div hh_cont hh_ne).mono (hIcc ▸ Set.Subset.rfl)).intervalIntegrable
+  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
+    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
+  have h_ftc : ∫ t in a..b, deriv h t / h t = Complex.log (h b) - Complex.log (h a) :=
+    integral_deriv_div_eq_log_sub_log Set.countable_empty (hIcc ▸ hh_cont)
+      (fun t ht ↦ (hh_diff t (by
+        rw [min_eq_left hab, max_eq_right hab] at ht
+        exact ht.1)).hasDerivAt)
+      (fun t ht ↦ hh_slit t (hIcc ▸ ht)) hint_h
   refine ⟨hint_g, ?_⟩
   calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+      = ∫ t in a..b, deriv h t / h t :=
+        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
     _ = Complex.log (h b) - Complex.log (h a) := h_ftc
     _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -56,10 +56,12 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg`
   and `intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_sub_log_neg_of_im_nonpos` —
   the boundary-tolerant comparison FTCs: the logarithmic integral of `g` is integrable and
-  evaluates to an endpoint-log difference through a comparison `h` that agrees with `g` on the
-  open interval, is differentiable there off a countable set with integrable logarithmic
-  integrand, and is confined to a closed half-plane — so endpoint values may sit on the
-  negative-real boundary. A comparison confined to the slit plane on the whole closed interval
+  evaluates to an endpoint-log difference through a comparison `h` that is continuous on the
+  closed interval, differentiable on the open one off a countable set, has integrable logarithmic
+  integrand, is confined to a closed half-plane, is nonvanishing at the two endpoints and
+  slit-plane-valued strictly between them, and agrees with `g` both on the open interval and at
+  each endpoint — so endpoint values may sit on the negative-real boundary. A comparison confined
+  to the slit plane on the whole closed interval
   needs no dedicated form: `integral_deriv_div_eq_log_sub_log` applies to it directly, and
   `IntervalIntegrable.congr_uIoo` with `intervalIntegral.integral_congr_uIoo` transport its
   conclusion across the interior agreement.
@@ -295,11 +297,14 @@ private lemma ne_zero_on_uIcc (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
   exact Complex.slitPlane_ne_zero (hh_slit t ⟨hlt1, hlt2⟩)
 
 /-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
-confined to the closed upper half-plane, nonvanishing at the endpoints, slit-plane-valued
-strictly between them, differentiable there off a countable set, and with integrable
-logarithmic integrand, the logarithmic integral of `g` is integrable and evaluates to the
-difference of endpoint logarithms — even when the endpoint values sit on the slit-plane
-boundary. -/
+continuous on the closed interval, confined to the closed upper half-plane, nonvanishing at the
+endpoints, slit-plane-valued strictly between them, differentiable there off a countable set, and
+with integrable logarithmic integrand, and for a `g` agreeing with `h` on the open interval and
+at both endpoints, the logarithmic integral of `g` is integrable and evaluates to the difference
+of its endpoint logarithms — even when the endpoint values sit on the slit-plane boundary.
+
+The conclusion is about `g`, which is otherwise unconstrained: it is the agreement with `h`, at
+the endpoints as well as inside, that carries the regularity across. -/
 theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg {P : Set ℝ}
     (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
     (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
@@ -317,10 +322,12 @@ theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im
     (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht.1))
     hh_int heq heq_a heq_b
 
-/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function confined
-to the closed lower half-plane, nonvanishing at the endpoints, whose negation is
-slit-plane-valued strictly between them, the logarithmic integral of `g` is integrable and
-evaluates to the difference of endpoint logarithms of the negations. -/
+/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function `h`
+continuous on the closed interval, differentiable on the open one off a countable set, with
+integrable logarithmic integrand, confined to the closed lower half-plane, nonvanishing at the
+endpoints and whose negation is slit-plane-valued strictly between them, and for a `g` agreeing
+with `h` on the open interval and at both endpoints, the logarithmic integral of `g` is
+integrable and evaluates to the difference of the endpoint logarithms of the negations. -/
 theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_sub_log_neg_of_im_nonpos
     {P : Set ℝ} (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
     (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -54,8 +54,8 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
   analytic and nonzero; the regularity input shared by the results below and by the argument
   principle.
-* `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg` and
-  `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos` —
+* `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg`
+  and `intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_sub_log_neg_of_im_nonpos` —
   the boundary-tolerant comparison FTCs: the logarithmic integral of `g` is integrable and
   evaluates to an endpoint-log difference through a comparison `h` that agrees with `g` on the
   open interval, is differentiable there off a countable set with integrable logarithmic
@@ -301,7 +301,7 @@ strictly between them, differentiable there off a countable set, and with integr
 logarithmic integrand, the logarithmic integral of `g` is integrable and evaluates to the
 difference of endpoint logarithms — even when the endpoint values sit on the slit-plane
 boundary. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg {P : Set ℝ}
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg {P : Set ℝ}
     (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
     (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
     (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
@@ -322,8 +322,8 @@ theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg 
 to the closed lower half-plane, nonvanishing at the endpoints, whose negation is
 slit-plane-valued strictly between them, the logarithmic integral of `g` is integrable and
 evaluates to the difference of endpoint logarithms of the negations. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos {P : Set ℝ}
-    (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_sub_log_neg_of_im_nonpos
+    {P : Set ℝ} (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
     (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
     (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
     (hh_im_np : ∀ t ∈ Set.uIcc a b, (h t).im ≤ 0)
@@ -335,7 +335,7 @@ theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_non
     ∫ t in a..b, deriv g t / g t = Complex.log (-(g b)) - Complex.log (-(g a)) := by
   have hderiv_neg : ∀ k : ℝ → ℂ, (fun t ↦ deriv (-k) t / (-k) t) = fun t ↦ deriv k t / k t :=
     fun k ↦ funext fun t ↦ by rw [deriv.neg, Pi.neg_apply, neg_div_neg_eq]
-  have hkey := intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg
+  have hkey := intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_sub_log_of_im_nonneg
     (g := -g) (h := -h) hP hh_cont.neg (fun t ht ↦ (hh_diff t ht).neg)
     (by rw [hderiv_neg h]; exact hh_int)
     (fun t ht ↦ by simpa using hh_im_np t ht)

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -9,7 +9,10 @@ public import Mathlib.Analysis.Calculus.FDeriv.Analytic
 public import Mathlib.Analysis.Calculus.LogDeriv
 public import Mathlib.Analysis.SpecialFunctions.Complex.Log
 public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
+public import TauCeti.Analysis.Complex.UpperLogContinuity
 public import TauCeti.Analysis.Contour.Curve.Integrability
+
+import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem
@@ -229,5 +232,129 @@ theorem windingNumber_comp_eq_integral_logDeriv {γ : ℝ → ℂ} {h : ℂ → 
   rw [windingNumber_eq_integral_of_avoidance hcont
       (fun t ht => hne t ht) (hint.congr_ae ((ae_restrict_iff' measurableSet_uIoc).mpr hae))]
   exact congrArg _ (intervalIntegral.integral_congr_ae hae).symm
+
+section BoundaryTolerant
+
+open MeasureTheory
+
+/-- Transport of the logarithmic integrand across an interior agreement: if `g = h` with
+equal derivatives on the open interval, the integrands agree almost everywhere on the
+interval and integrability transports. -/
+private lemma aeEq_and_intervalIntegrable_of_eqOn_Ioo {g h : ℝ → ℂ} {a b : ℝ}
+    (hab : a ≤ b) (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b) :
+    (∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t) ∧
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b := by
+  have hb_ae : ({b} : Set ℝ)ᶜ ∈ ae volume := by
+    simp [MeasureTheory.mem_ae_iff]
+  have h_congr : ∀ᵐ t ∂volume, t ∈ Set.uIoc a b → deriv g t / g t = deriv h t / h t := by
+    filter_upwards [hb_ae] with t ht_ne_b ht_mem
+    rw [Set.uIoc_of_le hab] at ht_mem
+    obtain ⟨hval, hderiv⟩ := heq t
+      ⟨ht_mem.1, lt_of_le_of_ne ht_mem.2 fun h ↦ ht_ne_b (Set.mem_singleton_iff.mpr h)⟩
+    rw [hval, hderiv]
+  refine ⟨h_congr, hint_h.congr_ae ?_⟩
+  exact (MeasureTheory.ae_restrict_iff' measurableSet_uIoc).mpr
+    (h_congr.mono fun t ht hm ↦ (ht hm).symm)
+
+/-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
+confined to the closed upper half-plane, nonvanishing, and slit-plane-valued on the
+interior, the logarithmic integral of `g` evaluates to the difference of logarithms —
+even when the endpoint values sit on the slit-plane boundary. -/
+theorem integral_deriv_div_eq_log_of_im_nonneg {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_im_nn : ∀ t ∈ Set.Icc a b, 0 ≤ (h t).im)
+    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (hh_slit : ∀ t ∈ Set.Ioo a b, h t ∈ Complex.slitPlane)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
+    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont
+      fun t ht ↦ ⟨hh_im_nn t ht, hh_ne t ht⟩
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht)) hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
+
+/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
+confined to the closed lower half-plane with strictly negative interior imaginary part,
+the logarithmic integral evaluates against the negated arguments. -/
+theorem integral_deriv_div_eq_log_neg_of_im_nonpos {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
+    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (hh_im_neg : ∀ t ∈ Set.Ioo a b, (h t).im < 0)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t =
+      Complex.log (-(g b)) - Complex.log (-(g a)) := by
+  have hnh_log_cont : ContinuousOn (fun t ↦ Complex.log (-(h t))) (Set.Icc a b) :=
+    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont.neg fun t ht ↦
+      ⟨by simpa using hh_im_np t ht, neg_ne_zero.mpr (hh_ne t ht)⟩
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hnh_log_cont
+    (fun t ht ↦ by
+      have hslit : -(h t) ∈ Complex.slitPlane := Complex.mem_slitPlane_iff.mpr
+        (Or.inr (by simpa using ne_of_lt (hh_im_neg t ht)))
+      have := (hh_diff t ht).hasDerivAt.neg.clog_real hslit
+      exact (show -deriv h t / -h t = deriv h t / h t by rw [neg_div_neg_eq]) ▸ this)
+    hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
+    _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
+
+
+/-- **The comparison logarithmic FTC on the slit plane**: for a comparison function `h`
+slit-plane-valued on the closed interval, the logarithmic integral of `g` evaluates to
+the difference of endpoint logarithms. -/
+theorem integral_deriv_div_eq_log_of_slitPlane {g h : ℝ → ℂ} {a b : ℝ} (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
+    (heq : ∀ t ∈ Set.Ioo a b, g t = h t ∧ deriv g t = deriv h t)
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
+    Complex.slitPlane_ne_zero (hh_slit t ht)
+  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) := fun t ht ↦
+    (continuousAt_clog (hh_slit t ht)).comp_continuousWithinAt (hh_cont t ht)
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono
+      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
+  obtain ⟨h_congr, hint_g⟩ :=
+    aeEq_and_intervalIntegrable_of_eqOn_Ioo hab heq hint_h
+  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ⟨ht.1.le, ht.2.le⟩)) hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t := intervalIntegral.integral_congr_ae h_congr
+    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
+
+end BoundaryTolerant
+
 
 end TauCeti.Contour

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -260,11 +260,18 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg (hab : a �
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_im_nn : ∀ t ∈ Set.Icc a b, 0 ≤ (h t).im)
-    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
     (hh_slit : ∀ t ∈ Set.Ioo a b, h t ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := by
+    intro t ht
+    rcases eq_or_lt_of_le ht.1 with rfl | hlt
+    · exact ha_ne
+    · rcases eq_or_lt_of_le ht.2 with rfl | hlt2
+      · exact hb_ne
+      · exact Complex.slitPlane_ne_zero (hh_slit t ⟨hlt, hlt2⟩)
   have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
     TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont
       fun t ht ↦ ⟨hh_im_nn t ht, hh_ne t ht⟩
@@ -283,37 +290,32 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg (hab : a �
     _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 
 /-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
-confined to the closed lower half-plane with strictly negative interior imaginary part,
-the logarithmic integral evaluates against the negated arguments. -/
+confined to the closed lower half-plane whose negation is slit-plane-valued on the
+interior, the logarithmic integral evaluates against the negated arguments. This is the
+upper form applied to the negated pair. -/
 theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
-    (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
+    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
     (hh_slit_neg : ∀ t ∈ Set.Ioo a b, -(h t) ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t =
       Complex.log (-(g b)) - Complex.log (-(g a)) := by
-  have hnh_log_cont : ContinuousOn (fun t ↦ Complex.log (-(h t))) (Set.Icc a b) :=
-    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont.neg fun t ht ↦
-      ⟨by simpa using hh_im_np t ht, neg_ne_zero.mpr (hh_ne t ht)⟩
-  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
-    ((hh_deriv_cont.div hh_cont hh_ne).mono
-      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
-  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
-    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
-  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hnh_log_cont
-    (fun t ht ↦ neg_div_neg_eq (deriv h t) (h t) ▸
-      (hh_diff t ht).hasDerivAt.neg.clog_real (hh_slit_neg t ht))
-    hint_h
-  refine ⟨hint_g, ?_⟩
-  calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t :=
-        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
-    _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
-    _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
+  have hderiv_neg : (fun t ↦ deriv (-g) t / (-g) t) = fun t ↦ deriv g t / g t :=
+    funext fun t ↦ by rw [deriv.neg, Pi.neg_apply, neg_div_neg_eq]
+  have hkey := intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg
+    (g := -g) (h := -h) hab hh_cont.neg
+    (fun t ht ↦ (hh_diff t ht).neg)
+    (by rw [deriv.neg']; exact hh_deriv_cont.neg)
+    (fun t ht ↦ by simpa using hh_im_np t ht)
+    (neg_ne_zero.mpr ha_ne) (neg_ne_zero.mpr hb_ne)
+    (fun t ht ↦ by simpa using hh_slit_neg t ht)
+    (fun t ht ↦ by simp only [Pi.neg_apply, heq ht]) (by simp only [Pi.neg_apply, heq_a])
+    (by simp only [Pi.neg_apply, heq_b])
+  rwa [hderiv_neg] at hkey
 
 end BoundaryTolerant
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -54,11 +54,14 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
   analytic and nonzero; the regularity input shared by the results below and by the argument
   principle.
-* `TauCeti.Contour.intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg` and
-  `…_eq_log_neg_of_im_nonpos` — the boundary-tolerant comparison FTCs: the logarithmic
-  integral of `g` evaluated through a smooth comparison `h` that agrees with `g` on the
-  open interval, confined to a closed half-plane, so endpoint values may sit on the
-  negative-real boundary.
+* `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg`,
+  `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos`,
+  and `TauCeti.Contour.intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane` —
+  the boundary-tolerant comparison FTCs: the logarithmic integral of `g` is integrable and
+  evaluates to an endpoint-log difference through a comparison `h` that agrees with `g` on the
+  open interval, is differentiable there off a countable set with integrable logarithmic
+  integrand, and is confined to a closed half-plane or the slit plane — so endpoint values may
+  sit on the negative-real boundary.
 * `TauCeti.Contour.integral_deriv_div_eq_log_sub_log` — the slit-plane logarithmic-derivative FTC in
   general `f' / f` form.
 * `TauCeti.Contour.integral_deriv_div_sub_eq_log` — its contour specialization to
@@ -249,185 +252,113 @@ open MeasureTheory
 variable {g h : ℝ → ℂ} {a b : ℝ}
 
 /-- Interior agreement transports the logarithmic integrand to the open interval. -/
-private lemma eqOn_uIoo_deriv_div (hab : a ≤ b) (heq : Set.EqOn g h (Set.Ioo a b)) :
+private lemma eqOn_uIoo_deriv_div (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b))) :
     Set.EqOn (fun t ↦ deriv g t / g t) (fun t ↦ deriv h t / h t) (Set.uIoo a b) := by
   intro t ht
-  rw [Set.uIoo_of_le hab] at ht
+  rw [← Set.Ioo_min_max] at ht
   simp only [heq ht, heq.deriv isOpen_Ioo ht]
 
-/-- The ordered core of the upper form. -/
-private lemma im_nonneg_core (hab : a ≤ b)
-    (hh_cont : ContinuousOn h (Set.Icc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
-    (hh_im_nn : ∀ t ∈ Set.Icc a b, 0 ≤ (h t).im)
-    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
-    (hh_slit : ∀ t ∈ Set.Ioo a b, h t ∈ Complex.slitPlane)
-    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
+/-- The shared comparison core: once the branch `Complex.log ∘ h` of the comparison function
+is continuous up to the endpoints and differentiates to the logarithmic integrand off a
+countable set, the logarithmic FTC transports to `g` across the interior agreement. -/
+private lemma comparison_core {P : Set ℝ} (hP : P.Countable)
+    (hlog_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.uIcc a b))
+    (hlog_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P,
+      HasDerivAt (fun t ↦ Complex.log (h t)) (deriv h t / h t) t)
+    (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
+    (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
+    (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
-  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := by
-    intro t ht
-    rcases eq_or_lt_of_le ht.1 with rfl | hlt
-    · exact ha_ne
-    · rcases eq_or_lt_of_le ht.2 with rfl | hlt2
-      · exact hb_ne
-      · exact Complex.slitPlane_ne_zero (hh_slit t ⟨hlt, hlt2⟩)
-  have hh_log_cont : ContinuousOn (fun t ↦ Complex.log (h t)) (Set.Icc a b) :=
-    TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont
-      fun t ht ↦ ⟨hh_im_nn t ht, hh_ne t ht⟩
-  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
-    ((hh_deriv_cont.div hh_cont hh_ne).mono
-      (Set.uIcc_of_le hab ▸ Set.Subset.rfl)).intervalIntegrable
-  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
-    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
-  have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hh_log_cont
-    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht)) hint_h
-  refine ⟨hint_g, ?_⟩
+  refine ⟨hh_int.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div heq ht).symm, ?_⟩
   calc ∫ t in a..b, deriv g t / g t
       = ∫ t in a..b, deriv h t / h t :=
-        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
-    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div heq)
+    _ = Complex.log (h b) - Complex.log (h a) :=
+        integral_eq_of_hasDerivAt_off_countable _ _ hP hlog_cont hlog_diff hh_int
     _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 
-/-- The ordered core of the lower form. -/
-private lemma im_nonpos_core (hab : a ≤ b)
-    (hh_cont : ContinuousOn h (Set.Icc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
-    (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
-    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
-    (hh_slit_neg : ∀ t ∈ Set.Ioo a b, -(h t) ∈ Complex.slitPlane)
-    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
-    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t =
-      Complex.log (-(g b)) - Complex.log (-(g a)) := by
-  have hderiv_neg : (fun t ↦ deriv (-g) t / (-g) t) = fun t ↦ deriv g t / g t :=
-    funext fun t ↦ by rw [deriv.neg, Pi.neg_apply, neg_div_neg_eq]
-  have hkey := im_nonneg_core
-    (g := -g) (h := -h) hab hh_cont.neg
-    (fun t ht ↦ (hh_diff t ht).neg)
-    (by rw [deriv.neg']; exact hh_deriv_cont.neg)
-    (fun t ht ↦ by simpa using hh_im_np t ht)
-    (neg_ne_zero.mpr ha_ne) (neg_ne_zero.mpr hb_ne)
-    (fun t ht ↦ by simpa using hh_slit_neg t ht)
-    (fun t ht ↦ by simp only [Pi.neg_apply, heq ht]) (by simp only [Pi.neg_apply, heq_a])
-    (by simp only [Pi.neg_apply, heq_b])
-  rwa [hderiv_neg] at hkey
-
-
-/-- The ordered core of the slit-plane form. -/
-private lemma slitPlane_core (hab : a ≤ b)
-    (hh_cont : ContinuousOn h (Set.Icc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
-    (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
-    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
-    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
-  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
-    Complex.slitPlane_ne_zero (hh_slit t ht)
-  have hIcc : Set.uIcc a b = Set.Icc a b := Set.uIcc_of_le hab
-  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
-    ((hh_deriv_cont.div hh_cont hh_ne).mono (hIcc ▸ Set.Subset.rfl)).intervalIntegrable
-  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
-    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
-  have h_ftc : ∫ t in a..b, deriv h t / h t = Complex.log (h b) - Complex.log (h a) :=
-    integral_deriv_div_eq_log_sub_log Set.countable_empty (hIcc ▸ hh_cont)
-      (fun t ht ↦ (hh_diff t (by
-        rw [min_eq_left hab, max_eq_right hab] at ht
-        exact ht.1)).hasDerivAt)
-      (fun t ht ↦ hh_slit t (hIcc ▸ ht)) hint_h
-  refine ⟨hint_g, ?_⟩
-  calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t :=
-        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
-    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
-    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
-
-
+/-- Endpoint nonvanishing and interior slit-plane confinement keep the comparison function
+zero-free on the whole closed interval. -/
+private lemma ne_zero_on_uIcc (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
+    (hh_slit : ∀ t ∈ Set.Ioo (min a b) (max a b), h t ∈ Complex.slitPlane) :
+    ∀ t ∈ Set.uIcc a b, h t ≠ 0 := by
+  intro t ht
+  rw [← Set.Icc_min_max] at ht
+  rcases eq_or_lt_of_le ht.1 with heq1 | hlt1
+  · rcases min_choice a b with hm | hm <;> rw [← heq1, hm]
+    exacts [ha_ne, hb_ne]
+  rcases eq_or_lt_of_le ht.2 with heq2 | hlt2
+  · rcases max_choice a b with hm | hm <;> rw [heq2, hm]
+    exacts [ha_ne, hb_ne]
+  exact Complex.slitPlane_ne_zero (hh_slit t ⟨hlt1, hlt2⟩)
 
 /-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
-confined to the closed upper half-plane, nonvanishing at the endpoints, and
-slit-plane-valued strictly between them, the logarithmic integral of `g` is integrable
-and evaluates to the difference of endpoint logarithms — even when the endpoint values
-sit on the slit-plane boundary. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg
-    (hh_cont : ContinuousOn h (Set.uIcc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+confined to the closed upper half-plane, nonvanishing at the endpoints, slit-plane-valued
+strictly between them, differentiable there off a countable set, and with integrable
+logarithmic integrand, the logarithmic integral of `g` is integrable and evaluates to the
+difference of endpoint logarithms — even when the endpoint values sit on the slit-plane
+boundary. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg {P : Set ℝ}
+    (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
+    (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
     (hh_im_nn : ∀ t ∈ Set.uIcc a b, 0 ≤ (h t).im)
     (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
     (hh_slit : ∀ t ∈ Set.Ioo (min a b) (max a b), h t ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
     (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
-  rcases le_total a b with hab | hba
-  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_im_nn
-    rw [min_eq_left hab, max_eq_right hab] at hh_diff hh_slit heq
-    exact im_nonneg_core hab hh_cont hh_diff hh_deriv_cont hh_im_nn ha_ne hb_ne hh_slit
-      heq heq_a heq_b
-  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_im_nn
-    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff hh_slit heq
-    obtain ⟨hi, he⟩ := im_nonneg_core hba hh_cont hh_diff hh_deriv_cont hh_im_nn
-      hb_ne ha_ne hh_slit heq heq_b heq_a
-    refine ⟨hi.symm, ?_⟩
-    rw [intervalIntegral.integral_symm, he]
-    ring
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) :=
+  comparison_core hP
+    (TauCeti.continuousOn_log_im_nonneg_ne_zero.comp hh_cont fun t ht ↦
+      ⟨hh_im_nn t ht, ne_zero_on_uIcc ha_ne hb_ne hh_slit t ht⟩)
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real (hh_slit t ht.1))
+    hh_int heq heq_a heq_b
 
-/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
-confined to the closed lower half-plane, nonvanishing at the endpoints, whose negation
-is slit-plane-valued strictly between them, the logarithmic integral of `g` is
-integrable and evaluates to the difference of endpoint logarithms of the negations. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos
-    (hh_cont : ContinuousOn h (Set.uIcc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function confined
+to the closed lower half-plane, nonvanishing at the endpoints, whose negation is
+slit-plane-valued strictly between them, the logarithmic integral of `g` is integrable and
+evaluates to the difference of endpoint logarithms of the negations. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos {P : Set ℝ}
+    (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
+    (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
     (hh_im_np : ∀ t ∈ Set.uIcc a b, (h t).im ≤ 0)
     (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
     (hh_slit_neg : ∀ t ∈ Set.Ioo (min a b) (max a b), -(h t) ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
     (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t =
-      Complex.log (-(g b)) - Complex.log (-(g a)) := by
-  rcases le_total a b with hab | hba
-  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_im_np
-    rw [min_eq_left hab, max_eq_right hab] at hh_diff hh_slit_neg heq
-    exact im_nonpos_core hab hh_cont hh_diff hh_deriv_cont hh_im_np ha_ne hb_ne
-      hh_slit_neg heq heq_a heq_b
-  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_im_np
-    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff hh_slit_neg heq
-    obtain ⟨hi, he⟩ := im_nonpos_core hba hh_cont hh_diff hh_deriv_cont hh_im_np
-      hb_ne ha_ne hh_slit_neg heq heq_b heq_a
-    refine ⟨hi.symm, ?_⟩
-    rw [intervalIntegral.integral_symm, he]
-    ring
+    ∫ t in a..b, deriv g t / g t = Complex.log (-(g b)) - Complex.log (-(g a)) := by
+  have hderiv_neg : ∀ k : ℝ → ℂ, (fun t ↦ deriv (-k) t / (-k) t) = fun t ↦ deriv k t / k t :=
+    fun k ↦ funext fun t ↦ by rw [deriv.neg, Pi.neg_apply, neg_div_neg_eq]
+  have hkey := intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg
+    (g := -g) (h := -h) hP hh_cont.neg (fun t ht ↦ (hh_diff t ht).neg)
+    (by rw [hderiv_neg h]; exact hh_int)
+    (fun t ht ↦ by simpa using hh_im_np t ht)
+    (neg_ne_zero.mpr ha_ne) (neg_ne_zero.mpr hb_ne)
+    (fun t ht ↦ by simpa using hh_slit_neg t ht)
+    (fun t ht ↦ by simp only [Pi.neg_apply, heq ht])
+    (by simp only [Pi.neg_apply, heq_a]) (by simp only [Pi.neg_apply, heq_b])
+  rwa [hderiv_neg g] at hkey
 
-/-- **The comparison logarithmic FTC on the slit plane**: the slit-plane FTC
-`TauCeti.Contour.integral_deriv_div_eq_log_sub_log`, applied to a smooth comparison `h`
-and transported to `g` across the interior agreement. -/
-theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane
-    (hh_cont : ContinuousOn h (Set.uIcc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+/-- **The comparison logarithmic FTC on the slit plane**: the boundary-tolerant comparison
+form whose branch continuity comes from slit-plane confinement on the whole closed interval,
+transported to `g` across the interior agreement. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane {P : Set ℝ}
+    (hP : P.Countable) (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b) \ P, DifferentiableAt ℝ h t)
+    (hh_int : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b)
     (hh_slit : ∀ t ∈ Set.uIcc a b, h t ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
     (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
-  rcases le_total a b with hab | hba
-  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_slit
-    rw [min_eq_left hab, max_eq_right hab] at hh_diff heq
-    exact slitPlane_core hab hh_cont hh_diff hh_deriv_cont hh_slit heq heq_a heq_b
-  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_slit
-    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff heq
-    obtain ⟨hi, he⟩ := slitPlane_core hba hh_cont hh_diff hh_deriv_cont hh_slit
-      heq heq_b heq_a
-    refine ⟨hi.symm, ?_⟩
-    rw [intervalIntegral.integral_symm, he]
-    ring
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) :=
+  comparison_core hP (hh_cont.clog hh_slit)
+    (fun t ht ↦ (hh_diff t ht).hasDerivAt.clog_real
+      (hh_slit t (by rw [← Set.Icc_min_max]; exact Set.Ioo_subset_Icc_self ht.1)))
+    hh_int heq heq_a heq_b
 
 end BoundaryTolerant
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -77,6 +77,10 @@ argument principle above all — into a statement about how often an image curve
 
 Adapted from `segment_log_FTC` in `WindingInteger.lean` of the AINTLIB `LeanModularForms`
 development, split from the argument-lift PR (#759) as an independent contour prerequisite.
+The boundary-tolerant comparison forms port the corner FTC pieces of AINTLIB's
+valence-formula winding-weight development
+(`ForMathlib/ValenceFormula/WindingWeights/I.lean`, `Rho.lean`, `RhoPlusOne.lean`)
+onto the current Mathlib pin.
 -/
 
 public section
@@ -251,11 +255,8 @@ private lemma eqOn_uIoo_deriv_div (hab : a ≤ b) (heq : Set.EqOn g h (Set.Ioo a
   rw [Set.uIoo_of_le hab] at ht
   simp only [heq ht, heq.deriv isOpen_Ioo ht]
 
-/-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
-confined to the closed upper half-plane, nonvanishing, and slit-plane-valued on the
-interior, the logarithmic integral of `g` is integrable and evaluates to the difference
-of logarithms — even when the endpoint values sit on the slit-plane boundary. -/
-theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg (hab : a ≤ b)
+/-- The ordered core of the upper form. -/
+private lemma im_nonneg_core (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
@@ -289,11 +290,8 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg (hab : a �
     _ = Complex.log (h b) - Complex.log (h a) := h_ftc
     _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 
-/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
-confined to the closed lower half-plane whose negation is slit-plane-valued on the
-interior, the logarithmic integral evaluates against the negated arguments. This is the
-upper form applied to the negated pair. -/
-theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab : a ≤ b)
+/-- The ordered core of the lower form. -/
+private lemma im_nonpos_core (hab : a ≤ b)
     (hh_cont : ContinuousOn h (Set.Icc a b))
     (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
@@ -306,7 +304,7 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab :
       Complex.log (-(g b)) - Complex.log (-(g a)) := by
   have hderiv_neg : (fun t ↦ deriv (-g) t / (-g) t) = fun t ↦ deriv g t / g t :=
     funext fun t ↦ by rw [deriv.neg, Pi.neg_apply, neg_div_neg_eq]
-  have hkey := intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg
+  have hkey := im_nonneg_core
     (g := -g) (h := -h) hab hh_cont.neg
     (fun t ht ↦ (hh_diff t ht).neg)
     (by rw [deriv.neg']; exact hh_deriv_cont.neg)
@@ -316,6 +314,120 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab :
     (fun t ht ↦ by simp only [Pi.neg_apply, heq ht]) (by simp only [Pi.neg_apply, heq_a])
     (by simp only [Pi.neg_apply, heq_b])
   rwa [hderiv_neg] at hkey
+
+
+/-- The ordered core of the slit-plane form. -/
+private lemma slitPlane_core (hab : a ≤ b)
+    (hh_cont : ContinuousOn h (Set.Icc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
+    (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
+    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
+    Complex.slitPlane_ne_zero (hh_slit t ht)
+  have hIcc : Set.uIcc a b = Set.Icc a b := Set.uIcc_of_le hab
+  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
+    ((hh_deriv_cont.div hh_cont hh_ne).mono (hIcc ▸ Set.Subset.rfl)).intervalIntegrable
+  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
+    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
+  have h_ftc : ∫ t in a..b, deriv h t / h t = Complex.log (h b) - Complex.log (h a) :=
+    integral_deriv_div_eq_log_sub_log Set.countable_empty (hIcc ▸ hh_cont)
+      (fun t ht ↦ (hh_diff t (by
+        rw [min_eq_left hab, max_eq_right hab] at ht
+        exact ht.1)).hasDerivAt)
+      (fun t ht ↦ hh_slit t (hIcc ▸ ht)) hint_h
+  refine ⟨hint_g, ?_⟩
+  calc ∫ t in a..b, deriv g t / g t
+      = ∫ t in a..b, deriv h t / h t :=
+        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
+    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
+    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
+
+
+
+/-- **The boundary-tolerant logarithmic FTC, upper form**: for a comparison function `h`
+confined to the closed upper half-plane, nonvanishing at the endpoints, and
+slit-plane-valued strictly between them, the logarithmic integral of `g` is integrable
+and evaluates to the difference of endpoint logarithms — even when the endpoint values
+sit on the slit-plane boundary. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg
+    (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+    (hh_im_nn : ∀ t ∈ Set.uIcc a b, 0 ≤ (h t).im)
+    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
+    (hh_slit : ∀ t ∈ Set.Ioo (min a b) (max a b), h t ∈ Complex.slitPlane)
+    (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  rcases le_total a b with hab | hba
+  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_im_nn
+    rw [min_eq_left hab, max_eq_right hab] at hh_diff hh_slit heq
+    exact im_nonneg_core hab hh_cont hh_diff hh_deriv_cont hh_im_nn ha_ne hb_ne hh_slit
+      heq heq_a heq_b
+  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_im_nn
+    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff hh_slit heq
+    obtain ⟨hi, he⟩ := im_nonneg_core hba hh_cont hh_diff hh_deriv_cont hh_im_nn
+      hb_ne ha_ne hh_slit heq heq_b heq_a
+    refine ⟨hi.symm, ?_⟩
+    rw [intervalIntegral.integral_symm, he]
+    ring
+
+/-- **The boundary-tolerant logarithmic FTC, lower form**: for a comparison function
+confined to the closed lower half-plane, nonvanishing at the endpoints, whose negation
+is slit-plane-valued strictly between them, the logarithmic integral of `g` is
+integrable and evaluates to the difference of endpoint logarithms of the negations. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos
+    (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+    (hh_im_np : ∀ t ∈ Set.uIcc a b, (h t).im ≤ 0)
+    (ha_ne : h a ≠ 0) (hb_ne : h b ≠ 0)
+    (hh_slit_neg : ∀ t ∈ Set.Ioo (min a b) (max a b), -(h t) ∈ Complex.slitPlane)
+    (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t =
+      Complex.log (-(g b)) - Complex.log (-(g a)) := by
+  rcases le_total a b with hab | hba
+  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_im_np
+    rw [min_eq_left hab, max_eq_right hab] at hh_diff hh_slit_neg heq
+    exact im_nonpos_core hab hh_cont hh_diff hh_deriv_cont hh_im_np ha_ne hb_ne
+      hh_slit_neg heq heq_a heq_b
+  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_im_np
+    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff hh_slit_neg heq
+    obtain ⟨hi, he⟩ := im_nonpos_core hba hh_cont hh_diff hh_deriv_cont hh_im_np
+      hb_ne ha_ne hh_slit_neg heq heq_b heq_a
+    refine ⟨hi.symm, ?_⟩
+    rw [intervalIntegral.integral_symm, he]
+    ring
+
+/-- **The comparison logarithmic FTC on the slit plane**: the slit-plane FTC
+`TauCeti.Contour.integral_deriv_div_eq_log_sub_log`, applied to a smooth comparison `h`
+and transported to `g` across the interior agreement. -/
+theorem intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_slitPlane
+    (hh_cont : ContinuousOn h (Set.uIcc a b))
+    (hh_diff : ∀ t ∈ Set.Ioo (min a b) (max a b), DifferentiableAt ℝ h t)
+    (hh_deriv_cont : ContinuousOn (deriv h) (Set.uIcc a b))
+    (hh_slit : ∀ t ∈ Set.uIcc a b, h t ∈ Complex.slitPlane)
+    (heq : Set.EqOn g h (Set.Ioo (min a b) (max a b)))
+    (heq_a : g a = h a) (heq_b : g b = h b) :
+    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
+    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
+  rcases le_total a b with hab | hba
+  · rw [Set.uIcc_of_le hab] at hh_cont hh_deriv_cont hh_slit
+    rw [min_eq_left hab, max_eq_right hab] at hh_diff heq
+    exact slitPlane_core hab hh_cont hh_diff hh_deriv_cont hh_slit heq heq_a heq_b
+  · rw [Set.uIcc_comm, Set.uIcc_of_le hba] at hh_cont hh_deriv_cont hh_slit
+    rw [min_comm, min_eq_left hba, max_comm, max_eq_right hba] at hh_diff heq
+    obtain ⟨hi, he⟩ := slitPlane_core hba hh_cont hh_diff hh_deriv_cont hh_slit
+      heq heq_b heq_a
+    refine ⟨hi.symm, ?_⟩
+    rw [intervalIntegral.integral_symm, he]
+    ring
 
 end BoundaryTolerant
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -54,11 +54,11 @@ argument principle above all — into a statement about how often an image curve
 * `TauCeti.Contour.analyticAt_logDeriv_of_analyticAt` — `logDeriv f` is analytic wherever `f` is
   analytic and nonzero; the regularity input shared by the results below and by the argument
   principle.
-* `TauCeti.Contour.intervalIntegrable_and_integral_deriv_div_eq_log_of_slitPlane`,
-  `…_eq_log_of_im_nonneg`, `…_eq_log_neg_of_im_nonpos` — the boundary-tolerant comparison
-  FTCs: the logarithmic integral of `g` evaluated through a smooth comparison `h` that
-  agrees with `g` on the open interval, confined to the slit plane or to a closed
-  half-plane, so endpoint values may sit on the negative-real boundary.
+* `TauCeti.Contour.intervalIntegrable_and_integral_deriv_div_eq_log_of_im_nonneg` and
+  `…_eq_log_neg_of_im_nonpos` — the boundary-tolerant comparison FTCs: the logarithmic
+  integral of `g` evaluated through a smooth comparison `h` that agrees with `g` on the
+  open interval, confined to a closed half-plane, so endpoint values may sit on the
+  negative-real boundary.
 * `TauCeti.Contour.integral_deriv_div_eq_log_sub_log` — the slit-plane logarithmic-derivative FTC in
   general `f' / f` form.
 * `TauCeti.Contour.integral_deriv_div_sub_eq_log` — its contour specialization to
@@ -291,7 +291,7 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab :
     (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
     (hh_im_np : ∀ t ∈ Set.Icc a b, (h t).im ≤ 0)
     (hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0)
-    (hh_im_neg : ∀ t ∈ Set.Ioo a b, (h t).im < 0)
+    (hh_slit_neg : ∀ t ∈ Set.Ioo a b, -(h t) ∈ Complex.slitPlane)
     (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
     IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
     ∫ t in a..b, deriv g t / g t =
@@ -305,11 +305,8 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab :
   have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
     hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
   have h_ftc := intervalIntegral.integral_eq_sub_of_hasDerivAt_of_le hab hnh_log_cont
-    (fun t ht ↦ by
-      have hslit : -(h t) ∈ Complex.slitPlane := Complex.mem_slitPlane_iff.mpr
-        (Or.inr (by simpa using ne_of_lt (hh_im_neg t ht)))
-      exact neg_div_neg_eq (deriv h t) (h t) ▸
-        (hh_diff t ht).hasDerivAt.neg.clog_real hslit)
+    (fun t ht ↦ neg_div_neg_eq (deriv h t) (h t) ▸
+      (hh_diff t ht).hasDerivAt.neg.clog_real (hh_slit_neg t ht))
     hint_h
   refine ⟨hint_g, ?_⟩
   calc ∫ t in a..b, deriv g t / g t
@@ -317,37 +314,6 @@ theorem intervalIntegrable_and_integral_deriv_div_eq_log_neg_of_im_nonpos (hab :
         intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
     _ = Complex.log (-(h b)) - Complex.log (-(h a)) := h_ftc
     _ = Complex.log (-(g b)) - Complex.log (-(g a)) := by rw [heq_a, heq_b]
-
-/-- **The comparison logarithmic FTC on the slit plane**: the slit-plane FTC
-`TauCeti.Contour.integral_deriv_div_eq_log_sub_log`, applied to the comparison `h` and
-transported to `g` across the interior agreement. -/
-theorem intervalIntegrable_and_integral_deriv_div_eq_log_of_slitPlane (hab : a ≤ b)
-    (hh_cont : ContinuousOn h (Set.Icc a b))
-    (hh_diff : ∀ t ∈ Set.Ioo a b, DifferentiableAt ℝ h t)
-    (hh_deriv_cont : ContinuousOn (deriv h) (Set.Icc a b))
-    (hh_slit : ∀ t ∈ Set.Icc a b, h t ∈ Complex.slitPlane)
-    (heq : Set.EqOn g h (Set.Ioo a b)) (heq_a : g a = h a) (heq_b : g b = h b) :
-    IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b ∧
-    ∫ t in a..b, deriv g t / g t = Complex.log (g b) - Complex.log (g a) := by
-  have hh_ne : ∀ t ∈ Set.Icc a b, h t ≠ 0 := fun t ht ↦
-    Complex.slitPlane_ne_zero (hh_slit t ht)
-  have hIcc : Set.uIcc a b = Set.Icc a b := Set.uIcc_of_le hab
-  have hint_h : IntervalIntegrable (fun t ↦ deriv h t / h t) volume a b :=
-    ((hh_deriv_cont.div hh_cont hh_ne).mono (hIcc ▸ Set.Subset.rfl)).intervalIntegrable
-  have hint_g : IntervalIntegrable (fun t ↦ deriv g t / g t) volume a b :=
-    hint_h.congr_uIoo fun t ht ↦ (eqOn_uIoo_deriv_div hab heq ht).symm
-  have h_ftc : ∫ t in a..b, deriv h t / h t = Complex.log (h b) - Complex.log (h a) :=
-    integral_deriv_div_eq_log_sub_log Set.countable_empty (hIcc ▸ hh_cont)
-      (fun t ht ↦ (hh_diff t (by
-        rw [min_eq_left hab, max_eq_right hab] at ht
-        exact ht.1)).hasDerivAt)
-      (fun t ht ↦ hh_slit t (hIcc ▸ ht)) hint_h
-  refine ⟨hint_g, ?_⟩
-  calc ∫ t in a..b, deriv g t / g t
-      = ∫ t in a..b, deriv h t / h t :=
-        intervalIntegral.integral_congr_uIoo (eqOn_uIoo_deriv_div hab heq)
-    _ = Complex.log (h b) - Complex.log (h a) := h_ftc
-    _ = Complex.log (g b) - Complex.log (g a) := by rw [heq_a, heq_b]
 
 end BoundaryTolerant
 

--- a/TauCeti/Analysis/Contour/LogDerivFTC.lean
+++ b/TauCeti/Analysis/Contour/LogDerivFTC.lean
@@ -12,7 +12,6 @@ public import Mathlib.MeasureTheory.Integral.IntervalIntegral.Basic
 import TauCeti.Analysis.Complex.UpperLogContinuity
 public import TauCeti.Analysis.Contour.Curve.Integrability
 
-import Mathlib.MeasureTheory.Integral.IntervalIntegral.FundThmCalculus
 public import TauCeti.Analysis.Contour.Winding.Number.Basic
 import Mathlib.Analysis.SpecialFunctions.Complex.LogDeriv
 import Mathlib.MeasureTheory.Integral.DivergenceTheorem


### PR DESCRIPTION
<!--tauceti-target:v1 {"focus":"ModularForms","id":"valence-formula/boundary-tolerant-ftc"}-->

> **PR chain notice (agent coordination):** part of the level-one valence-formula chain
> (ModularForms roadmap, Layer 1). #2195 merged its continuity prerequisite; this PR is
> the consumer that was prepared with it — the telescope slices at the elliptic points
> follow.

Two boundary-tolerant comparison-form logarithmic fundamental theorems for `∫ g'/g`
against a comparison `h` agreeing with `g` on the open interval — differentiable there
off a countable set, with integrable logarithmic integrand
(`TauCeti/Analysis/Contour/LogDerivFTC.lean`, §BoundaryTolerant):

- `intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_of_im_nonneg` — closed
  **upper** half-plane confinement, via the merged `continuousOn_log_im_nonneg_ne_zero`:
  endpoint values may sit on the negative-real boundary;
- `intervalIntegrable_deriv_div_and_integral_deriv_div_eq_log_neg_of_im_nonpos` — closed
  lower half-plane, derived from the upper form at the negated pair.

A comparison confined to the slit plane on the whole closed interval needs no dedicated
form — the existing `integral_deriv_div_eq_log_sub_log` applies to it directly and the
interior-congruence lemmas transport its conclusion — so no slit sibling is added.

Slit-plane continuity is insufficient for the valence contour: it crosses the branch
cut of `log(γ(t) - i)` at the left vertical's height-1 crossing and touches it at
`γ(t) - (ρ + 1) = -1`. These are the fundamental theorems behind the winding weights
`-1/2, -1/6, -1/6` at the on-contour elliptic points.

Roadmap: ModularForms

🤖 Generated with [Claude Code](https://claude.com/claude-code)