### PR TITLE
refactor(Isotopy): decompose the concatenation embedding proof

### DIFF
--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -293,6 +293,64 @@ private theorem trans_halfRight (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) 
     apply Subtype.ext
     simp only [coe_halfRight]; ring
 
+/-- One half of a concatenation. Where the cylinder is parametrised by the embedding `e`, the
+concatenated total map `T` is `e × id` composed with the factor's total map, so it is inducing
+there. This is used at `e = half` with the first isotopy and at `e = halfRight` with the second. -/
+private theorem isInducing_domRestrict_of_isEmbedding_prodMap (H : Isotopy f₀ f₁) {e : I → I}
+    (he : IsEmbedding e) {T : I × X → I × Y} {D : Set (I × Y)}
+    (hrange : Set.range (Prod.map e (id : X → X)) = T ⁻¹' D)
+    (hTe : T ∘ (Prod.map e (id : X → X)) = (Prod.map e (id : Y → Y)) ∘ H.totalMap) :
+    IsInducing ((T ⁻¹' D).domRestrict T) :=
+  isInducing_restrict_of_embedding (he.prodMap IsEmbedding.id) hrange
+    (hTe ▸ (he.prodMap IsEmbedding.id).isInducing.comp H.isEmbedding_total.isInducing)
+
+/-- The total map of a concatenation is inducing: it is inducing on each closed half of the
+cylinder, where it is a reparametrisation of a factor's total map, and the two halves cover. -/
+private theorem isInducing_totalMap_trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
+    IsInducing fun p : I × X => (p.1, (F.toHomotopy.trans G.toHomotopy) p) := by
+  set T : I × X → I × Y := fun p => (p.1, (F.toHomotopy.trans G.toHomotopy) p) with hT
+  have hfst : Continuous fun q : I × Y => (q.1 : ℝ) := by fun_prop
+  set D₁ : Set (I × Y) := {q | (q.1 : ℝ) ≤ 1 / 2} with hD₁def
+  set D₂ : Set (I × Y) := {q | 1 / 2 ≤ (q.1 : ℝ)} with hD₂def
+  have hcov : D₁ ∪ D₂ = Set.univ := by
+    ext q
+    simp only [hD₁def, hD₂def, Set.mem_union, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
+    exact le_total _ _
+  have hrange₁ : Set.range (Prod.map half (id : X → X)) = T ⁻¹' D₁ := by
+    rw [Set.range_prodMap, Set.range_id, range_half]; ext ⟨t, x⟩; simp [hT, hD₁def]
+  have hTe₁ : T ∘ (Prod.map half (id : X → X))
+      = (Prod.map half (id : Y → Y)) ∘ F.totalMap := by
+    funext p; obtain ⟨s, x⟩ := p
+    simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
+    rw [trans_half]
+  have hrange₂ : Set.range (Prod.map halfRight (id : X → X)) = T ⁻¹' D₂ := by
+    rw [Set.range_prodMap, Set.range_id, range_halfRight]; ext ⟨t, x⟩; simp [hT, hD₂def]
+  have hTe₂ : T ∘ (Prod.map halfRight (id : X → X))
+      = (Prod.map halfRight (id : Y → Y)) ∘ G.totalMap := by
+    funext p; obtain ⟨s, x⟩ := p
+    simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
+    rw [trans_halfRight]
+  exact isInducing_of_isClosed_cover (by fun_prop) (isClosed_le hfst continuous_const)
+    (isClosed_le continuous_const hfst) hcov
+    (isInducing_domRestrict_of_isEmbedding_prodMap F isEmbedding_half hrange₁ hTe₁)
+    (isInducing_domRestrict_of_isEmbedding_prodMap G isEmbedding_halfRight hrange₂ hTe₂)
+
+/-- The total map of a concatenation is injective: on each half it agrees with the corresponding
+factor's total map, which is injective, and the time coordinate is preserved. -/
+private theorem injective_totalMap_trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
+    Function.Injective fun p : I × X => (p.1, (F.toHomotopy.trans G.toHomotopy) p) := by
+  rintro ⟨t, x⟩ ⟨t', x'⟩ hpp
+  have ht : t = t' := congrArg Prod.fst hpp
+  subst ht
+  have hH : (F.toHomotopy.trans G.toHomotopy) (t, x)
+      = (F.toHomotopy.trans G.toHomotopy) (t, x') := congrArg Prod.snd hpp
+  by_cases h : (t : ℝ) ≤ 1 / 2
+  · rw [trans_toHomotopy_apply_of_le _ _ _ h, trans_toHomotopy_apply_of_le _ _ _ h] at hH
+    exact Prod.ext rfl ((F.isEmbedding_apply _).injective hH)
+  · rw [trans_toHomotopy_apply_of_not_le _ _ _ h,
+      trans_toHomotopy_apply_of_not_le _ _ _ h] at hH
+    exact Prod.ext rfl ((G.isEmbedding_apply _).injective hH)
+
 /-- Concatenate two isotopies: the result follows `F` on `[0, 1 / 2]` and `G` on `[1 / 2, 1]`,
 with the time parameter rescaled linearly. The concatenated total map is an embedding because it
 is one on each closed half (where it is `F`'s or `G`'s total embedding, reparametrised), and these
@@ -300,50 +358,7 @@ glue along the closed cover `{(t, y) | t ≤ 1 / 2}`, `{(t, y) | 1 / 2 ≤ t}` o
 noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
     Isotopy f₀ f₂ where
   toHomotopy := F.toHomotopy.trans G.toHomotopy
-  isEmbedding_total' := by
-    set T : I × X → I × Y := fun p => (p.1, (F.toHomotopy.trans G.toHomotopy) p) with hT
-    have hTcont : Continuous T := by fun_prop
-    refine ⟨?_, ?_⟩
-    · have hfst : Continuous fun q : I × Y => (q.1 : ℝ) := by fun_prop
-      set D₁ : Set (I × Y) := {q | (q.1 : ℝ) ≤ 1 / 2} with hD₁def
-      set D₂ : Set (I × Y) := {q | 1 / 2 ≤ (q.1 : ℝ)} with hD₂def
-      have hcov : D₁ ∪ D₂ = Set.univ := by
-        ext q
-        simp only [hD₁def, hD₂def, Set.mem_union, Set.mem_ofPred_eq, Set.mem_univ, iff_true]
-        exact le_total _ _
-      have hrange₁ : Set.range (Prod.map half (id : X → X)) = T ⁻¹' D₁ := by
-        rw [Set.range_prodMap, Set.range_id, range_half]; ext ⟨t, x⟩; simp [hT, hD₁def]
-      have hTe₁ : T ∘ (Prod.map half (id : X → X))
-          = (Prod.map half (id : Y → Y)) ∘ F.totalMap := by
-        funext p; obtain ⟨s, x⟩ := p
-        simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
-        rw [trans_half]
-      have hi₁ := isInducing_restrict_of_embedding (isEmbedding_half.prodMap IsEmbedding.id)
-        hrange₁ (hTe₁ ▸ (isEmbedding_half.prodMap IsEmbedding.id).isInducing.comp
-          F.isEmbedding_total.isInducing)
-      have hrange₂ : Set.range (Prod.map halfRight (id : X → X)) = T ⁻¹' D₂ := by
-        rw [Set.range_prodMap, Set.range_id, range_halfRight]; ext ⟨t, x⟩; simp [hT, hD₂def]
-      have hTe₂ : T ∘ (Prod.map halfRight (id : X → X))
-          = (Prod.map halfRight (id : Y → Y)) ∘ G.totalMap := by
-        funext p; obtain ⟨s, x⟩ := p
-        simp only [Function.comp_apply, Prod.map_apply, id_eq, hT, totalMap_apply]
-        rw [trans_halfRight]
-      have hi₂ := isInducing_restrict_of_embedding (isEmbedding_halfRight.prodMap IsEmbedding.id)
-        hrange₂ (hTe₂ ▸ (isEmbedding_halfRight.prodMap IsEmbedding.id).isInducing.comp
-          G.isEmbedding_total.isInducing)
-      exact isInducing_of_isClosed_cover hTcont (isClosed_le hfst continuous_const)
-        (isClosed_le continuous_const hfst) hcov hi₁ hi₂
-    · rintro ⟨t, x⟩ ⟨t', x'⟩ hpp
-      have ht : t = t' := congrArg Prod.fst hpp
-      subst ht
-      have hH : (F.toHomotopy.trans G.toHomotopy) (t, x)
-          = (F.toHomotopy.trans G.toHomotopy) (t, x') := congrArg Prod.snd hpp
-      by_cases h : (t : ℝ) ≤ 1 / 2
-      · rw [trans_toHomotopy_apply_of_le _ _ _ h, trans_toHomotopy_apply_of_le _ _ _ h] at hH
-        exact Prod.ext rfl ((F.isEmbedding_apply _).injective hH)
-      · rw [trans_toHomotopy_apply_of_not_le _ _ _ h,
-          trans_toHomotopy_apply_of_not_le _ _ _ h] at hH
-        exact Prod.ext rfl ((G.isEmbedding_apply _).injective hH)
+  isEmbedding_total' := ⟨isInducing_totalMap_trans F G, injective_totalMap_trans F G⟩
 
 /-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
 and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/

--- a/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
+++ b/TauCeti/Topology/Homotopy/Isotopy/Basic.lean
@@ -337,7 +337,7 @@ private theorem isInducing_totalMap_trans {f₂ : C(X, Y)} (F : Isotopy f₀ f�
 
 /-- The total map of a concatenation is injective: on each half it agrees with the corresponding
 factor's total map, which is injective, and the time coordinate is preserved. -/
-private theorem injective_totalMap_trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
+private theorem totalMap_trans_injective {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
     Function.Injective fun p : I × X => (p.1, (F.toHomotopy.trans G.toHomotopy) p) := by
   rintro ⟨t, x⟩ ⟨t', x'⟩ hpp
   have ht : t = t' := congrArg Prod.fst hpp
@@ -358,7 +358,7 @@ glue along the closed cover `{(t, y) | t ≤ 1 / 2}`, `{(t, y) | 1 / 2 ≤ t}` o
 noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) :
     Isotopy f₀ f₂ where
   toHomotopy := F.toHomotopy.trans G.toHomotopy
-  isEmbedding_total' := ⟨isInducing_totalMap_trans F G, injective_totalMap_trans F G⟩
+  isEmbedding_total' := ⟨isInducing_totalMap_trans F G, totalMap_trans_injective F G⟩
 
 /-- The value of a concatenated isotopy is given by the first isotopy on `[0, 1 / 2]`
 and by the second isotopy on `[1 / 2, 1]`, with the time parameter rescaled linearly. -/


### PR DESCRIPTION
The `isEmbedding_total'` field of `Isotopy.trans` carried a 45-line proof that did three things
inline: the inducing half of `IsEmbedding`, the injective half, and — inside the inducing half —
the same three-step argument run twice, once for each half of the cylinder.

## The helpers

* `isInducing_domRestrict_of_isEmbedding_prodMap` — the repeated step. Where the cylinder is
  parametrised by an embedding `e`, the concatenated total map `T` is `e × id` composed with the
  relevant factor's total map, so `isInducing_restrict_of_embedding` applies. Stated once for a
  general `e` and a general factor; used at `e = half` with `F` and at `e = halfRight` with `G`,
  which is exactly the pair of six-line blocks the original repeated.
* `isInducing_totalMap_trans` — the inducing half: the two closed halves `{q | q.1 ≤ 1/2}` and
  `{q | 1/2 ≤ q.1}` cover, the map is inducing on each by the lemma above, and
  `isInducing_of_isClosed_cover` glues.
* `totalMap_trans_injective` — the injective half: the time coordinate is preserved, and on each
  half the map agrees with a factor's, which is injective.

## What is left

```lean
noncomputable def trans {f₂ : C(X, Y)} (F : Isotopy f₀ f₁) (G : Isotopy f₁ f₂) : Isotopy f₀ f₂ where
  toHomotopy := F.toHomotopy.trans G.toHomotopy
  isEmbedding_total' := ⟨isInducing_totalMap_trans F G, totalMap_trans_injective F G⟩
```

which is what the docstring above it has always said the proof was.

## Scope

The statement and docstring of `Isotopy.trans` are unchanged, and all three helpers are `private`;
the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Field proof 45 → 1 line, with helpers at 5, 27 and 12.

Roadmap: GeometricTopology
