### PR TITLE
refactor(DedekindDomain): extract the inductive step of the transversal family

### DIFF
--- a/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
+++ b/TauCeti/NumberTheory/DedekindDomain/Transversal.lean
@@ -172,6 +172,48 @@ private lemma mem_sdiff_pair_of_invariant {σ : R ≃+* R}
     (f := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ) hqdef (hinvol x hxS)
     (hinvol p hpS) (Finset.mem_sdiff.mp hx).2
 
+/-- The inductive step. Given a conjugate pair `p`, `σ p` inside `S` and a transversal family for
+`S` with that pair removed, multiplying the family through by `p` and by `σ p` separately doubles
+it and gives a transversal family for `S`. -/
+private theorem exists_transversal_family_of_sdiff_pair (σ : R ≃+* R)
+    {S : Finset (IsDedekindDomain.HeightOneSpectrum R)}
+    {p : IsDedekindDomain.HeightOneSpectrum R} (hpS : p ∈ S)
+    (hqS : IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p ∈ S)
+    (hpq : IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p ≠ p)
+    (hinvol : IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ
+      (IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p) = p) {G' : Finset (Ideal R)}
+    (hcard' : 2 ^ ((S \ {p, IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p}).card / 2)
+      ≤ G'.card)
+    (hprod' : ∀ A ∈ G', A * Ideal.map σ A =
+      ∏ x ∈ S \ {p, IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p}, x.asIdeal) :
+    ∃ G : Finset (Ideal R), 2 ^ (S.card / 2) ≤ G.card ∧
+      ∀ A ∈ G, A * Ideal.map σ A = ∏ x ∈ S, x.asIdeal := by
+  set q := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p with hqdef
+  have hpair : ({p, q} : Finset (IsDedekindDomain.HeightOneSpectrum R)) ⊆ S :=
+    Finset.insert_subset_iff.mpr ⟨hpS, Finset.singleton_subset_iff.mpr hqS⟩
+  have hqIdeal : q.asIdeal = Ideal.map σ p.asIdeal := by
+    rw [hqdef]; exact asIdeal_equivOfRingEquiv σ p
+  -- The product over `S` factors through the conjugate pair we removed.
+  have hprodS : ∏ x ∈ S, x.asIdeal
+      = (∏ x ∈ S \ {p, q}, x.asIdeal) * p.asIdeal * q.asIdeal := by
+    rw [← Finset.prod_sdiff hpair, Finset.prod_pair hpq.symm, mul_assoc]
+  have hcardS : (S \ {p, q}).card = S.card - 2 := by
+    have h := Finset.card_sdiff_add_card_eq_card hpair
+    rw [Finset.card_pair hpq.symm] at h
+    omega
+  have hpS' : p ∉ S \ {p, q} := fun h => (Finset.mem_sdiff.mp h).2 (Finset.mem_insert_self _ _)
+  refine ⟨(G'.image (· * p.asIdeal)) ∪ (G'.image (· * q.asIdeal)), ?_, ?_⟩
+  · -- The two images are disjoint, so the union doubles the family.
+    have hdisj : Disjoint (G'.image (· * p.asIdeal)) (G'.image (· * q.asIdeal)) :=
+      disjoint_image_mul_asIdeal hpq (fun A hA hpA =>
+        isPrime_not_dvd_prod p hpS' (hprod' A hA ▸ dvd_mul_of_dvd_left hpA (Ideal.map σ A)))
+    exact two_pow_le_card_union_image_mul hdisj hcard' (by omega)
+  · have hmapq : Ideal.map σ q.asIdeal = p.asIdeal := by
+      rw [← asIdeal_equivOfRingEquiv σ q]
+      exact congr_arg IsDedekindDomain.HeightOneSpectrum.asIdeal hinvol
+    exact fun A hA =>
+      mul_map_eq_prod_of_mem_image_union (σ := (σ : R →+* R)) hqIdeal hmapq hprodS hprod' hA
+
 /-- **Conjugate-transversal ideal family.** For a fixed-point-free involution `σ` of a finite set
 `S` of height-one primes of a Dedekind domain, there are at least `2 ^ (S.card / 2)` ideals `A`
 with `A * σ A = ∏ p ∈ S, p.asIdeal`. -/
@@ -190,41 +232,14 @@ theorem exists_transversal_family (σ : R ≃+* R) (S : Finset (IsDedekindDomain
   obtain ⟨p, hpS⟩ := hS
   set q := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p with hqdef
   have hqS : q ∈ S := hinv p hpS
-  have hpq : q ≠ p := hfree p hpS
-  have hqIdeal : q.asIdeal = Ideal.map σ p.asIdeal := by
-    rw [hqdef]; exact asIdeal_equivOfRingEquiv σ p
-  have hpair : ({p, q} : Finset (IsDedekindDomain.HeightOneSpectrum R)) ⊆ S := by
-    intro x hx; rcases Finset.mem_insert.mp hx with rfl | hx
-    · exact hpS
-    · rw [Finset.mem_singleton.mp hx]; exact hqS
-  set S' := S \ {p, q} with hS'def
-  have hS'sub : S' ⊂ S := by
-    refine Finset.sdiff_ssubset hpair ?_
-    exact ⟨p, Finset.mem_insert_self _ _⟩
-  -- The subset `S'` still satisfies all the hypotheses.
-  have hmem' : ∀ {x}, x ∈ S' → x ∈ S := fun hx => (Finset.mem_sdiff.mp hx).1
-  obtain ⟨G', hcard', hprod'⟩ := ih S' hS'sub
-    (mem_sdiff_pair_of_invariant hqdef hinv hinvol hpS)
+  have hS'sub : S \ {p, q} ⊂ S :=
+    Finset.sdiff_ssubset (Finset.insert_subset_iff.mpr ⟨hpS, Finset.singleton_subset_iff.mpr hqS⟩)
+      ⟨p, Finset.mem_insert_self _ _⟩
+  -- The subset `S \ {p, q}` still satisfies all the hypotheses.
+  have hmem' : ∀ {x}, x ∈ S \ {p, q} → x ∈ S := fun hx => (Finset.mem_sdiff.mp hx).1
+  obtain ⟨G', hcard', hprod'⟩ := ih _ hS'sub (mem_sdiff_pair_of_invariant hqdef hinv hinvol hpS)
     (fun x hx => hinvol x (hmem' hx)) (fun x hx => hfree x (hmem' hx))
-  -- The product over `S` factors through the conjugate pair we removed.
-  have hprodS :
-      ∏ x ∈ S, x.asIdeal = (∏ x ∈ S', x.asIdeal) * p.asIdeal * q.asIdeal := by
-    rw [hS'def, ← Finset.prod_sdiff hpair, Finset.prod_pair hpq.symm, mul_assoc]
-  have hcardS : S'.card = S.card - 2 := by
-    have h := Finset.card_sdiff_add_card_eq_card hpair
-    rw [Finset.card_pair hpq.symm] at h
-    rw [hS'def]; omega
-  have hpS' : p ∉ S' := fun h => (Finset.mem_sdiff.mp h).2 (Finset.mem_insert_self _ _)
-  refine ⟨(G'.image (· * p.asIdeal)) ∪ (G'.image (· * q.asIdeal)), ?_, ?_⟩
-  · -- The two images are disjoint, so the union doubles the family.
-    have hdisj : Disjoint (G'.image (· * p.asIdeal)) (G'.image (· * q.asIdeal)) :=
-      disjoint_image_mul_asIdeal hpq (fun A hA hpA =>
-        isPrime_not_dvd_prod p hpS' (hprod' A hA ▸ dvd_mul_of_dvd_left hpA (Ideal.map σ A)))
-    exact two_pow_le_card_union_image_mul hdisj hcard' (by omega)
-  · have hmapq : Ideal.map σ q.asIdeal = p.asIdeal := by
-      rw [← asIdeal_equivOfRingEquiv σ q]
-      exact congr_arg IsDedekindDomain.HeightOneSpectrum.asIdeal (hinvol p hpS)
-    exact fun A hA =>
-      mul_map_eq_prod_of_mem_image_union (σ := (σ : R →+* R)) hqIdeal hmapq hprodS hprod' hA
+  exact exists_transversal_family_of_sdiff_pair σ hpS hqS (hfree p hpS) (hinvol p hpS)
+    hcard' hprod'
 
 end TauCeti.DedekindDomain


### PR DESCRIPTION
`exists_transversal_family` ran to 45 lines because its induction did two jobs at once: choosing
the conjugate pair `{p, σ p}` to strip and recursing on the rest, and then building the doubled
family for `S` out of the family for `S \ {p, σ p}`. Only the first is really the induction; the
second is a self-contained construction that never mentions recursion.

## The helper

`exists_transversal_family_of_sdiff_pair` takes the conjugate pair and a transversal family `G'`
for `S \ {p, σ p}`, and returns one for `S`. Its content is the three bookkeeping facts the doubling
needs — that the product over `S` factors as `(∏ S \ {p, σ p}) * p * σ p`, that the cardinality drops
by exactly two, and that `p` is no longer in the smaller set — plus the two goals: the images
`G' * p` and `G' * σ p` are disjoint (so the union doubles), and every element of the union has the
right product.

It takes `hinvol` only at `p` (`σ (σ p) = p`) rather than the ambient `∀ p ∈ S` form, and takes
`hpq`/`hqS` as plain facts rather than the `hfree`/`hinv` families, so it says nothing about `σ`
being an involution of `S` — only about the one pair it strips.

## What is left

```lean
obtain ⟨p, hpS⟩ := hS
set q := IsDedekindDomain.HeightOneSpectrum.equivOfRingEquiv σ p with hqdef
have hqS : q ∈ S := hinv p hpS
have hS'sub : S \ {p, q} ⊂ S := ...
have hmem' : ∀ {x}, x ∈ S \ {p, q} → x ∈ S := fun hx => (Finset.mem_sdiff.mp hx).1
obtain ⟨G', hcard', hprod'⟩ := ih _ hS'sub (mem_sdiff_pair_of_invariant hqdef hinv hinvol hpS)
  (fun x hx => hinvol x (hmem' hx)) (fun x hx => hfree x (hmem' hx))
exact exists_transversal_family_of_sdiff_pair σ hpS hqS (hfree p hpS) (hinvol p hpS) hcard' hprod'
```

Along the way the `{p, q} ⊆ S` step goes through Mathlib's `Finset.insert_subset_iff` rather than
the original `intro x hx; rcases Finset.mem_insert.mp hx with rfl | hx` — same fact, three lines
shorter, and it no longer needs `Finset.mem_singleton`.

## Scope

The statement and docstring of `exists_transversal_family` are unchanged, and the helper is
`private`; the entire diff is proof-internal.

## Verification

Full tree build, `lake exe axioms`, `lake exe module-system` and `scripts/lint-env.sh` all green;
no new lint violations. Proof body 45 → 18 lines, with the helper at 26.

Roadmap: Multiquadratic
